### PR TITLE
core/stat: fix build with 32-bit

### DIFF
--- a/modules/core/src/stat.cpp
+++ b/modules/core/src/stat.cpp
@@ -225,7 +225,7 @@ template <>
 int countNonZero_ <uchar> (const uchar* src, int len)
 {
 	int i=0, nz = 0;
-	#if (defined CV_SSE4_2 && CV_SSE4_2)
+	#if (defined CV_SSE4_2 && CV_SSE4_2 && (_WIN64 || __amd64__))
 	if(USE_SSE4_2)//5x-6x
 	{
 		__m128i pattern = _mm_setzero_si128 ();


### PR DESCRIPTION
Optimization introduced in b782d8bb only works for 64-bit builds, but
ifdef failed to check for this.
