### PR TITLE
imgproc: add imadjust and stretchlim functions

### DIFF
--- a/modules/imgproc/include/opencv2/imgproc/imgproc.hpp
+++ b/modules/imgproc/include/opencv2/imgproc/imgproc.hpp
@@ -440,6 +440,16 @@ CV_EXPORTS_W void Canny( InputArray image, OutputArray edges,
                          double threshold1, double threshold2,
                          int apertureSize=3, bool L2gradient=false );
 
+//! finds upper and lower values to stretch the contrast of an image using a histogram
+CV_EXPORTS_W void stretchlim( const InputArray image, double* low_value,
+                                  double* high_value, double low_fract = 0.01,
+                                  double high_fract = 0.99);
+
+//! adjust image pixel values by linear mapping
+CV_EXPORTS_W void imadjust( const InputArray src, OutputArray dst,
+                            double low_in = 0, double high_in = 0,
+                            double low_out = 0, double high_out = 1 );
+
 //! computes minimum eigen value of 2x2 derivative covariation matrix at each pixel - the cornerness criteria
 CV_EXPORTS_W void cornerMinEigenVal( InputArray src, OutputArray dst,
                                    int blockSize, int ksize=3,

--- a/modules/imgproc/src/imadjust.cpp
+++ b/modules/imgproc/src/imadjust.cpp
@@ -1,0 +1,146 @@
+/*M///////////////////////////////////////////////////////////////////////////////////////
+//
+//  IMPORTANT: READ BEFORE DOWNLOADING, COPYING, INSTALLING OR USING.
+//
+//  By downloading, copying, installing or using the software you agree to this license.
+//  If you do not agree to this license, do not download, install,
+//  copy or use the software.
+//
+//
+//                        Intel License Agreement
+//                For Open Source Computer Vision Library
+//
+// Copyright (C) 2000, Intel Corporation, all rights reserved.
+// Third party copyrights are property of their respective owners.
+//
+// Redistribution and use in source and binary forms, with or without modification,
+// are permitted provided that the following conditions are met:
+//
+//   * Redistribution's of source code must retain the above copyright notice,
+//     this list of conditions and the following disclaimer.
+//
+//   * Redistribution's in binary form must reproduce the above copyright notice,
+//     this list of conditions and the following disclaimer in the documentation
+//     and/or other materials provided with the distribution.
+//
+//   * The name of Intel Corporation may not be used to endorse or promote products
+//     derived from this software without specific prior written permission.
+//
+// This software is provided by the copyright holders and contributors "as is" and
+// any express or implied warranties, including, but not limited to, the implied
+// warranties of merchantability and fitness for a particular purpose are disclaimed.
+// In no event shall the Intel Corporation or contributors be liable for any direct,
+// indirect, incidental, special, exemplary, or consequential damages
+// (including, but not limited to, procurement of substitute goods or services;
+// loss of use, data, or profits; or business interruption) however caused
+// and on any theory of liability, whether in contract, strict liability,
+// or tort (including negligence or otherwise) arising in any way out of
+// the use of this software, even if advised of the possibility of such damage.
+//
+//M*/
+
+#include "precomp.hpp"
+
+void stretchlimFromHist( const cv::MatND& hist, double* low_value,
+                     double* high_value, double low_fract, double high_fract,
+                     unsigned int histSum)
+{
+    CV_Assert( low_fract >= 0 && low_fract < 1.0 );
+    CV_Assert( low_fract < high_fract && high_fract <= 1.0);
+
+    unsigned int sum;
+    unsigned int low_count = low_fract * histSum;
+    sum = 0;
+    for( unsigned int i = 0; i < hist.rows; i++ ) {
+        if (sum >= low_count) {
+            *low_value = i;
+            break;
+        }
+
+        sum += ((float*)hist.data)[i];
+    }
+
+    unsigned int high_count = (1 - high_fract) * histSum;
+    sum = 0;
+    for( unsigned int i = hist.rows - 1; i >= 0; i-- ) {
+        if (sum >= high_count) {
+            *high_value = i;
+            break;
+        }
+
+        sum += ((float*)hist.data)[i];
+    }
+}
+
+//TODO: surely something like this already exists
+int bitsFromDepth( int depth )
+{
+    if (depth == CV_8U)
+        return 8;
+    else if (depth == CV_16U)
+        return 16;
+    else
+        return 0;
+}
+
+//TODO: handle RGB or force user to do a channel at a time?
+void cv::stretchlim( const InputArray _image, double* low_value,
+                     double* high_value, double low_fract, double high_fract )
+{
+    Mat image = _image.getMat();
+
+    CV_Assert( image.type() == CV_8UC1 || image.type() == CV_16UC1 );
+
+    if (low_fract == 0 && high_fract == 1.0) {
+        // no need to waste calculating histogram
+        *low_value = 0;
+        *high_value = 1;
+        return;
+    }
+
+    int nPixelValues = 1 << bitsFromDepth( image.depth() );
+    int channels[] = { 0 };
+    MatND hist;
+    int histSize[] = { nPixelValues };
+    float range[] = { 0, nPixelValues };
+    const float* ranges[] = { range };
+    calcHist( &image, 1, channels, Mat(), hist, 1, histSize, ranges );
+    
+    stretchlimFromHist( hist, low_value, high_value, low_fract, high_fract, image.rows * image.cols );
+
+    //TODO: scaling to 0..1 here, but should be in stretchlimFromHist?
+    unsigned int maxVal = (1 << bitsFromDepth( _image.depth() )) - 1;
+    *low_value /= maxVal;
+    *high_value /= maxVal;
+}
+
+//TODO: best to determine output depth from _dst or argument?
+void cv::imadjust( const InputArray _src, OutputArray _dst, double low_in,
+                   double high_in, double low_out, double high_out )
+{
+    CV_Assert( (low_in == 0 || high_in != low_in) && high_out != low_out );
+
+    //FIXME: use NaN or something else for default values?
+    if (low_in == 0 && high_in == 0)
+        stretchlim ( _src, &low_in, &high_in );
+
+    double alpha = (high_out - low_out) / (high_in - low_in);
+    double beta = high_out - high_in * alpha;
+
+    Mat src = _src.getMat();
+    int depth;
+    if (_dst.empty())
+        depth = _src.depth();
+    else
+        depth = _dst.depth();
+
+    //TODO: handle more than just 8U/16U
+    //adjust alpha/beta to handle to/from different depths
+    int max_in = (1 << bitsFromDepth( _src.depth() )) - 1;
+    int max_out = (1 << bitsFromDepth( _dst.depth() )) - 1;
+    // y = a*x*(outmax/inmax) + b*outmax
+    alpha *= max_out / max_in;
+    beta *= max_out;
+
+    src.convertTo( _dst, depth, alpha, beta );
+}

--- a/samples/cpp/imadjust.cpp
+++ b/samples/cpp/imadjust.cpp
@@ -1,0 +1,69 @@
+#include "opencv2/imgproc/imgproc.hpp"
+#include "opencv2/highgui/highgui.hpp"
+
+#include <stdio.h>
+
+using namespace cv;
+using namespace std;
+
+int lowFract = 1;
+int highFract = 99;
+
+Mat image, gray, adjusted;
+
+// define a trackbar callback
+static void onTrackbar(int, void*)
+{
+    try {
+        double lowIn, highIn;
+        stretchlim(gray, &lowIn, &highIn, lowFract/100.0, highFract/100.0);
+        imadjust(gray, adjusted, lowIn, highIn);
+    } catch (Exception& e) {
+    }
+    imshow("imadjust", adjusted);
+}
+
+static void help()
+{
+    printf("\nThis sample demonstrates Canny edge detection\n"
+           "Call:\n"
+           "    /.edge [image_name -- Default is fruits.jpg]\n\n");
+}
+
+const char* keys =
+{
+    "{1| |fruits.jpg|input image name}"
+};
+
+int main( int argc, const char** argv )
+{
+    help();
+
+    CommandLineParser parser(argc, argv, keys);
+    string filename = parser.get<string>("1");
+
+    image = imread(filename, 1);
+    if(image.empty())
+    {
+        printf("Cannot read image file: %s\n", filename.c_str());
+        help();
+        return -1;
+    }
+    adjusted.create(image.size(), CV_8U);
+    cvtColor(image, gray, CV_BGR2GRAY);
+
+    // Create a window
+    namedWindow("imadjust", 1);
+
+    // create a toolbar
+    createTrackbar("Low fraction", "imadjust", &lowFract, 100, onTrackbar);
+    createTrackbar("High fraction", "imadjust", &highFract, 100, onTrackbar);
+
+    // Show the image
+    onTrackbar(0, 0);
+
+    // Wait for a key stroke; the same function arranges events processing
+    waitKey(0);
+
+    return 0;
+}


### PR DESCRIPTION
This implementation is certainly not complete, but it at least works with 8UC1 and 16UC1 images, and includes a sample. Comments wanted especially on exported function signatures. I don't care about supporting RGB, but if that were to be added the signature would have to change or a second one would have to be added.
