### PR TITLE
fix a compile bug when applying norm() to a Matx

### DIFF
--- a/modules/core/include/opencv2/core/operations.hpp
+++ b/modules/core/include/opencv2/core/operations.hpp
@@ -1077,9 +1077,9 @@ double norm(const Matx<_Tp, m, n>& M)
 template<typename _Tp, int m, int n> static inline
 double norm(const Matx<_Tp, m, n>& M, int normType)
 {
-    return normType == NORM_INF ? (double)normInf<_Tp, DataType<_Tp>::work_type>(M.val, m*n) :
-        normType == NORM_L1 ? (double)normL1<_Tp, DataType<_Tp>::work_type>(M.val, m*n) :
-        std::sqrt((double)normL2Sqr<_Tp, DataType<_Tp>::work_type>(M.val, m*n));
+    return normType == NORM_INF ? (double)normInf<_Tp, typename DataType<_Tp>::work_type>(M.val, m*n) :
+        normType == NORM_L1 ? (double)normL1<_Tp, typename DataType<_Tp>::work_type>(M.val, m*n) :
+        std::sqrt((double)normL2Sqr<_Tp, typename DataType<_Tp>::work_type>(M.val, m*n));
 }
 
 


### PR DESCRIPTION
when applying norm() to a Matx, I got the following error (which the provided patch fixes) with gcc 4.7 on Ubuntu precise 64 bits:

/opt/ros/fuerte/include/opencv2/core/operations.hpp: In instantiation of ‘double cv::norm(const cv::Matx<_Tp, m, n>&, int) [with _Tp = double; int m = 3; int n = 3]’:
/home/vrabaud/workspace/libmv/src/libmv_opencv/src/fundamental.cpp:184:47:   required from here
/opt/ros/fuerte/include/opencv2/core/operations.hpp:1082:79: error: dependent-name ‘cv::DataType<_Tp>::work_type’ is parsed as a non-type, but instantiation yields a type
/opt/ros/fuerte/include/opencv2/core/operations.hpp:1082:79: note: say ‘typename cv::DataType<_Tp>::work_type’ if a type is meant
/opt/ros/fuerte/include/opencv2/core/operations.hpp:1082:79: error: dependent-name ‘cv::DataType<_Tp>::work_type’ is parsed as a non-type, but instantiation yields a type
/opt/ros/fuerte/include/opencv2/core/operations.hpp:1082:79: note: say ‘typename cv::DataType<_Tp>::work_type’ if a type is meant
/opt/ros/fuerte/include/opencv2/core/operations.hpp:1082:79: error: dependent-name ‘cv::DataType<_Tp>::work_type’ is parsed as a non-type, but instantiation yields a type
/opt/ros/fuerte/include/opencv2/core/operations.hpp:1082:79: note: say ‘typename cv::DataType<_Tp>::work_type’ if a type is meant
