### PR TITLE
Intel compiler fix

### DIFF
--- a/3rdparty/libjasper/CMakeLists.txt
+++ b/3rdparty/libjasper/CMakeLists.txt
@@ -19,9 +19,9 @@ file(GLOB lib_ext_hdrs jasper/*.h)
 
 add_library(${JASPER_LIBRARY} STATIC ${lib_srcs} ${lib_hdrs} ${lib_ext_hdrs})
 
-if(MSVC)
+if(WIN32 AND NOT MINGW)
   add_definitions(-DJAS_WIN_MSVC_BUILD)
-endif()
+endif(WIN32 AND NOT MINGW)
 
 ocv_warnings_disable(CMAKE_C_FLAGS -Wno-implicit-function-declaration -Wno-uninitialized -Wmissing-prototypes -Wmissing-declarations -Wunused -Wshadow -Wsign-compare)
 ocv_warnings_disable(CMAKE_C_FLAGS /wd4013 /wd4018 /wd4101 /wd4244 /wd4267 /wd4715) # vs2005

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -337,8 +337,11 @@ include(cmake/OpenCVCompilerOptions.cmake REQUIRED)
 # ----------------------------------------------------------------------------
 if(MSVC)
   include(cmake/OpenCVCRTLinkage.cmake REQUIRED)
-  add_definitions(-D_VARIADIC_MAX=10)
 endif(MSVC)
+
+if(WIN32 AND NOT MINGW)
+  add_definitions(-D_VARIADIC_MAX=10)
+endif(WIN32 AND NOT MINGW)
 
 
 # ----------------------------------------------------------------------------

--- a/modules/gpu/perf/perf_calib3d.cpp
+++ b/modules/gpu/perf/perf_calib3d.cpp
@@ -11,7 +11,7 @@ namespace {
 typedef pair<string, string> pair_string;
 DEF_PARAM_TEST_1(ImagePair, pair_string);
 
-PERF_TEST_P(ImagePair, Calib3D_StereoBM, Values(make_pair<string, string>("gpu/perf/aloe.jpg", "gpu/perf/aloeR.jpg")))
+PERF_TEST_P(ImagePair, Calib3D_StereoBM, Values(pair<string, string>("gpu/perf/aloe.jpg", "gpu/perf/aloeR.jpg")))
 {
     declare.time(5.0);
 
@@ -57,7 +57,7 @@ PERF_TEST_P(ImagePair, Calib3D_StereoBM, Values(make_pair<string, string>("gpu/p
 //////////////////////////////////////////////////////////////////////
 // StereoBeliefPropagation
 
-PERF_TEST_P(ImagePair, Calib3D_StereoBeliefPropagation, Values(make_pair<string, string>("gpu/stereobp/aloe-L.png", "gpu/stereobp/aloe-R.png")))
+PERF_TEST_P(ImagePair, Calib3D_StereoBeliefPropagation, Values(pair<string, string>("gpu/stereobp/aloe-L.png", "gpu/stereobp/aloe-R.png")))
 {
     declare.time(10.0);
 
@@ -93,7 +93,7 @@ PERF_TEST_P(ImagePair, Calib3D_StereoBeliefPropagation, Values(make_pair<string,
 //////////////////////////////////////////////////////////////////////
 // StereoConstantSpaceBP
 
-PERF_TEST_P(ImagePair, Calib3D_StereoConstantSpaceBP, Values(make_pair<string, string>("gpu/stereobm/aloe-L.png", "gpu/stereobm/aloe-R.png")))
+PERF_TEST_P(ImagePair, Calib3D_StereoConstantSpaceBP, Values(pair<string, string>("gpu/stereobm/aloe-L.png", "gpu/stereobm/aloe-R.png")))
 {
     declare.time(10.0);
 
@@ -129,7 +129,7 @@ PERF_TEST_P(ImagePair, Calib3D_StereoConstantSpaceBP, Values(make_pair<string, s
 //////////////////////////////////////////////////////////////////////
 // DisparityBilateralFilter
 
-PERF_TEST_P(ImagePair, Calib3D_DisparityBilateralFilter, Values(make_pair<string, string>("gpu/stereobm/aloe-L.png", "gpu/stereobm/aloe-disp.png")))
+PERF_TEST_P(ImagePair, Calib3D_DisparityBilateralFilter, Values(pair<string, string>("gpu/stereobm/aloe-L.png", "gpu/stereobm/aloe-disp.png")))
 {
     const cv::Mat img = readImage(GetParam().first, cv::IMREAD_GRAYSCALE);
     ASSERT_FALSE(img.empty());

--- a/modules/highgui/CMakeLists.txt
+++ b/modules/highgui/CMakeLists.txt
@@ -107,6 +107,7 @@ endif()
 
 if(WIN32)
   list(APPEND highgui_srcs src/cap_vfw.cpp src/cap_cmu.cpp src/cap_dshow.cpp)
+  list(APPEND HIGHGUI_LIBRARIES vfw32)
 endif(WIN32)
 
 if(HAVE_XINE)


### PR DESCRIPTION
Currently, OpenCV does not compile using the Windows version of Intel Compiler 12.1 and 13. The provided patch fixes this issue.
