### PR TITLE
Fixed #523

### DIFF
--- a/modules/objdetect/src/haar.cpp
+++ b/modules/objdetect/src/haar.cpp
@@ -1531,6 +1531,13 @@ cvHaarDetectObjectsForROC( const CvArr* _img,
                 continue;
             }
 
+            if ( winSize.width > maxSize.width || winSize.height > maxSize.height )
+            {
+                if( !findBiggestObject )
+                    break;
+                continue;
+            }
+
             cvSetImagesForHaarClassifierCascade( cascade, sum, sqsum, tilted, factor );
             cvZero( temp );
 


### PR DESCRIPTION
Hello, I fixed #523 http://code.opencv.org/issues/523 :  the problem where the MaxSize parameter in cvHaarDetectObjects does not work when the flag CV_HAAR_SCALE_IMAGE is not set. Please could you merge it.
Thanks,

thorikawa
Takahiro Horikawa horikawa.takahiro@gmail.com
