### PR TITLE
Update for SimpleFlow algorithm

### DIFF
--- a/modules/video/src/simpleflow.cpp
+++ b/modules/video/src/simpleflow.cpp
@@ -517,8 +517,8 @@ CV_EXPORTS_W void calcOpticalFlowSF(Mat& from,
                                flow,
                                averaging_radius, 
                                max_flow, 
-                               sigma_dist, 
-                               sigma_color);
+                               (float)sigma_dist, 
+                               (float)sigma_color);
 
   calcOpticalFlowSingleScaleSF(curr_to_extended,
                                curr_from_extended,
@@ -526,8 +526,8 @@ CV_EXPORTS_W void calcOpticalFlowSF(Mat& from,
                                flow_inv,
                                averaging_radius, 
                                max_flow, 
-                               sigma_dist, 
-                               sigma_color);
+                               (float)sigma_dist, 
+                               (float)sigma_color);
 
   removeOcclusions(flow, 
                    flow_inv,
@@ -586,9 +586,9 @@ CV_EXPORTS_W void calcOpticalFlowSF(Mat& from,
                               prev_from,
                               confidence,
                               flow, 
-                              (float)upscale_averaging_radius,
+                              upscale_averaging_radius,
                               (float)upscale_sigma_dist,
-                              upscale_sigma_color);
+                              (float)upscale_sigma_color);
 
     flow_inv = upscaleOpticalFlow(curr_rows,
                                   curr_cols,


### PR DESCRIPTION
Speedup of twice as fast.

Current results:

IMAGE NAMES          RMSE  
Dimetrodon           0.329428  
Grove2               0.550852  
Grove3               1.464699  
Hydrangea            0.523277  
RubberWhale          0.367246  
Urban2               2.717003  
Urban3               4.185070  
Venus                0.775422                                 

Time (for Urban3):
15.586034 sec
