### PR TITLE
Auto library linking pragma for VisualStudio.

### DIFF
--- a/modules/calib3d/include/opencv2/calib3d/calib3d.hpp
+++ b/modules/calib3d/include/opencv2/calib3d/calib3d.hpp
@@ -748,4 +748,10 @@ CV_EXPORTS_W  int estimateAffine3D(InputArray src, InputArray dst,
 
 #endif
 
+// Auto linking by "#pragma comment(lib)" syntax
+#include "opencv2/core/pragma_lib.hpp"
+#if PRAGMA_COMMENT_SUPPORT && OPENCV_AUTO_LINK
+#pragma OPENCV_COMMENT_LIB_FNAME("calib3d")
+#endif // PRAGMA_COMMENT_SUPPORT && OPENCV_AUTO_LINK
+
 #endif

--- a/modules/contrib/include/opencv2/contrib/contrib.hpp
+++ b/modules/contrib/include/opencv2/contrib/contrib.hpp
@@ -978,5 +978,10 @@ namespace cv
 
 #endif
 
-#endif
+// Auto linking by "#pragma comment(lib)" syntax
+#include "opencv2/core/pragma_lib.hpp"
+#if PRAGMA_COMMENT_SUPPORT && OPENCV_AUTO_LINK
+#pragma OPENCV_COMMENT_LIB_FNAME("contrib")
+#endif // PRAGMA_COMMENT_SUPPORT && OPENCV_AUTO_LINK
 
+#endif

--- a/modules/core/include/opencv2/core/core.hpp
+++ b/modules/core/include/opencv2/core/core.hpp
@@ -4612,4 +4612,10 @@ double CommandLineParser::analyzeValue<double>(const std::string& str, bool spac
 #include "opencv2/core/operations.hpp"
 #include "opencv2/core/mat.hpp"
 
+// Auto linking by "#pragma comment(lib)" syntax
+#include "opencv2/core/pragma_lib.hpp"
+#if PRAGMA_COMMENT_SUPPORT && OPENCV_AUTO_LINK
+#pragma OPENCV_COMMENT_LIB_FNAME("core")
+#endif // PRAGMA_COMMENT_SUPPORT && OPENCV_AUTO_LINK
+
 #endif /*__OPENCV_CORE_HPP__*/

--- a/modules/core/include/opencv2/core/pragma_lib.hpp
+++ b/modules/core/include/opencv2/core/pragma_lib.hpp
@@ -1,0 +1,182 @@
+/*! \file pragma_include.hpp
+    \brief #pragmas for auto library linking
+ */
+/*M///////////////////////////////////////////////////////////////////////////////////////
+//
+//  IMPORTANT: READ BEFORE DOWNLOADING, COPYING, INSTALLING OR USING.
+//
+//  By downloading, copying, installing or using the software you agree to this license.
+//  If you do not agree to this license, do not download, install,
+//  copy or use the software.
+//
+//
+//                           License Agreement
+//                For Open Source Computer Vision Library
+//
+// Copyright (C) 2000-2008, Intel Corporation, all rights reserved.
+// Copyright (C) 2009-2011, Willow Garage Inc., all rights reserved.
+// Third party copyrights are property of their respective owners.
+//
+// Redistribution and use in source and binary forms, with or without modification,
+// are permitted provided that the following conditions are met:
+//
+//   * Redistribution's of source code must retain the above copyright notice,
+//     this list of conditions and the following disclaimer.
+//
+//   * Redistribution's in binary form must reproduce the above copyright notice,
+//     this list of conditions and the following disclaimer in the documentation
+//     and/or other materials provided with the distribution.
+//
+//   * The name of the copyright holders may not be used to endorse or promote products
+//     derived from this software without specific prior written permission.
+//
+// This software is provided by the copyright holders and contributors "as is" and
+// any express or implied warranties, including, but not limited to, the implied
+// warranties of merchantability and fitness for a particular purpose are disclaimed.
+// In no event shall the Intel Corporation or contributors be liable for any direct,
+// indirect, incidental, special, exemplary, or consequential damages
+// (including, but not limited to, procurement of substitute goods or services;
+// loss of use, data, or profits; or business interruption) however caused
+// and on any theory of liability, whether in contract, strict liability,
+// or tort (including negligence or otherwise) arising in any way out of
+// the use of this software, even if advised of the possibility of such damage.
+//
+//M*/
+
+#ifndef __OPENCV_PRAGMA_LIB_HPP__
+#define __OPENCV_PRAGMA_LIB_HPP__ 1
+
+#if (defined(_MSC_VER) && !defined(PRAGMA_COMMENT_SUPPORT)) \
+  && !defined(CVAPI_EXPORTS)
+#define PRAGMA_COMMENT_SUPPORT 1
+#elif !defined(PRAGMA_COMMENT_SUPPORT)
+#define PRAGMA_COMMENT_SUPPORT 0
+#endif
+
+#ifndef CV_MAJOR_VERSION
+#pragma message("WARM: Any OpenCV header included before pragma_lib.hpp")
+#include "opencv2/core/version.hpp"
+#endif
+
+// version string which contains in library's file name such as "232"
+#define OPENCV_LIBVERSTR \
+  CVAUX_STR(CV_MAJOR_VERSION) \
+  CVAUX_STR(CV_MINOR_VERSION) \
+  CVAUX_STR(CV_SUBMINOR_VERSION)
+
+// generate #pragma arguments string
+#ifndef _DEBUG // Release
+#define OPENCV_COMMENT_LIB_FNAME(name) \
+comment(lib, "opencv_" name OPENCV_LIBVERSTR ".lib")
+#else          // Debug
+#define OPENCV_COMMENT_LIB_FNAME(name) \
+comment(lib, "opencv_" name OPENCV_LIBVERSTR "d.lib")
+#endif
+
+// defined macro search,
+// OPENCV_DEFINE_SEARCH(modulename) is only true
+// when header file of modulename is included.
+#define OPENCV_DEFINE_SEARCH(modulename) \
+  ( \
+  defined( __OPENCV_##modulename##_HPP__ )        || \
+  defined(  _OPENCV_##modulename##_HPP_ )         || \
+  defined( __OPENCV_##modulename##_H__ )          || \
+  defined( __OPENCV_##modulename##_##name##_C_H ) \
+  )
+
+#ifndef OPENCV_AUTO_LINK
+#define OPENCV_AUTO_LINK 1
+#endif
+
+#endif // #ifndef __OPENCV_PRAGMA_LIB_HPP__
+/*! \file pragma_include.hpp
+    \brief #pragmas for auto library linking
+ */
+/*M///////////////////////////////////////////////////////////////////////////////////////
+//
+//  IMPORTANT: READ BEFORE DOWNLOADING, COPYING, INSTALLING OR USING.
+//
+//  By downloading, copying, installing or using the software you agree to this license.
+//  If you do not agree to this license, do not download, install,
+//  copy or use the software.
+//
+//
+//                           License Agreement
+//                For Open Source Computer Vision Library
+//
+// Copyright (C) 2000-2008, Intel Corporation, all rights reserved.
+// Copyright (C) 2009-2011, Willow Garage Inc., all rights reserved.
+// Third party copyrights are property of their respective owners.
+//
+// Redistribution and use in source and binary forms, with or without modification,
+// are permitted provided that the following conditions are met:
+//
+//   * Redistribution's of source code must retain the above copyright notice,
+//     this list of conditions and the following disclaimer.
+//
+//   * Redistribution's in binary form must reproduce the above copyright notice,
+//     this list of conditions and the following disclaimer in the documentation
+//     and/or other materials provided with the distribution.
+//
+//   * The name of the copyright holders may not be used to endorse or promote products
+//     derived from this software without specific prior written permission.
+//
+// This software is provided by the copyright holders and contributors "as is" and
+// any express or implied warranties, including, but not limited to, the implied
+// warranties of merchantability and fitness for a particular purpose are disclaimed.
+// In no event shall the Intel Corporation or contributors be liable for any direct,
+// indirect, incidental, special, exemplary, or consequential damages
+// (including, but not limited to, procurement of substitute goods or services;
+// loss of use, data, or profits; or business interruption) however caused
+// and on any theory of liability, whether in contract, strict liability,
+// or tort (including negligence or otherwise) arising in any way out of
+// the use of this software, even if advised of the possibility of such damage.
+//
+//M*/
+
+#ifndef __OPENCV_PRAGMA_LIB_HPP__
+#define __OPENCV_PRAGMA_LIB_HPP__ 1
+
+#if (defined(_MSC_VER) && !defined(PRAGMA_COMMENT_SUPPORT)) \
+  && !defined(CVAPI_EXPORTS)
+#define PRAGMA_COMMENT_SUPPORT 1
+#elif !defined(PRAGMA_COMMENT_SUPPORT)
+#define PRAGMA_COMMENT_SUPPORT 0
+#endif
+
+#ifndef CV_MAJOR_VERSION
+#pragma message("WARM: Any OpenCV header included before pragma_lib.hpp")
+#include "opencv2/core/version.hpp"
+#endif
+
+// version string which contains in library's file name such as "232"
+#define OPENCV_LIBVERSTR \
+  CVAUX_STR(CV_MAJOR_VERSION) \
+  CVAUX_STR(CV_MINOR_VERSION) \
+  CVAUX_STR(CV_SUBMINOR_VERSION)
+
+// generate #pragma arguments string
+#ifndef _DEBUG // Release
+#define OPENCV_COMMENT_LIB_FNAME(name) \
+comment(lib, "opencv_" name OPENCV_LIBVERSTR ".lib")
+#else          // Debug
+#define OPENCV_COMMENT_LIB_FNAME(name) \
+comment(lib, "opencv_" name OPENCV_LIBVERSTR "d.lib")
+#endif
+
+// defined macro search,
+// OPENCV_DEFINE_SEARCH(modulename) is only true
+// when header file of modulename is included.
+#define OPENCV_DEFINE_SEARCH(modulename) \
+  ( \
+  defined( __OPENCV_##modulename##_HPP__ )        || \
+  defined(  _OPENCV_##modulename##_HPP_ )         || \
+  defined( __OPENCV_##modulename##_H__ )          || \
+  defined( __OPENCV_##modulename##_##name##_C_H ) \
+  )
+
+#ifndef OPENCV_AUTO_LINK
+#define OPENCV_AUTO_LINK 1
+#endif
+
+#endif // #ifndef __OPENCV_PRAGMA_LIB_HPP__

--- a/modules/features2d/include/opencv2/features2d/features2d.hpp
+++ b/modules/features2d/include/opencv2/features2d/features2d.hpp
@@ -1499,6 +1499,12 @@ protected:
 
 #endif /* __cplusplus */
 
+// Auto linking by "#pragma comment(lib)" syntax
+#include "opencv2/core/pragma_lib.hpp"
+#if PRAGMA_COMMENT_SUPPORT && OPENCV_AUTO_LINK
+#pragma OPENCV_COMMENT_LIB_FNAME("features2d")
+#endif // PRAGMA_COMMENT_SUPPORT && OPENCV_AUTO_LINK
+
 #endif
 
 /* End of file. */

--- a/modules/flann/include/opencv2/flann/flann.hpp
+++ b/modules/flann/include/opencv2/flann/flann.hpp
@@ -40,8 +40,8 @@
 //
 //M*/
 
-#ifndef _OPENCV_FLANN_HPP_
-#define _OPENCV_FLANN_HPP_
+#ifndef __OPENCV_FLANN_HPP__
+#define __OPENCV_FLANN_HPP__
 
 #ifdef __cplusplus
 
@@ -423,5 +423,11 @@ FLANN_DEPRECATED int hierarchicalClustering(const Mat& features, Mat& centers, c
 } } // namespace cv::flann
 
 #endif // __cplusplus
+
+// Auto linking by "#pragma comment(lib)" syntax
+#include "opencv2/core/pragma_lib.hpp"
+#if PRAGMA_COMMENT_SUPPORT && OPENCV_AUTO_LINK
+#pragma OPENCV_COMMENT_LIB_FNAME("flann")
+#endif // PRAGMA_COMMENT_SUPPORT && OPENCV_AUTO_LINK
 
 #endif

--- a/modules/gpu/include/opencv2/gpu/gpu.hpp
+++ b/modules/gpu/include/opencv2/gpu/gpu.hpp
@@ -1898,4 +1898,10 @@ CV_EXPORTS void createOpticalFlowNeedleMap(const GpuMat& u, const GpuMat& v, Gpu
 
 } // namespace cv
 
+// Auto linking by "#pragma comment(lib)" syntax
+#include "opencv2/core/pragma_lib.hpp"
+#if PRAGMA_COMMENT_SUPPORT && OPENCV_AUTO_LINK
+#pragma OPENCV_COMMENT_LIB_FNAME("gpu")
+#endif // PRAGMA_COMMENT_SUPPORT && OPENCV_AUTO_LINK
+
 #endif /* __OPENCV_GPU_HPP__ */

--- a/modules/highgui/include/opencv2/highgui/highgui.hpp
+++ b/modules/highgui/include/opencv2/highgui/highgui.hpp
@@ -248,4 +248,10 @@ protected:
 
 #endif
 
+// Auto linking by "#pragma comment(lib)" syntax
+#include "opencv2/core/pragma_lib.hpp"
+#if PRAGMA_COMMENT_SUPPORT && OPENCV_AUTO_LINK
+#pragma OPENCV_COMMENT_LIB_FNAME("highgui")
+#endif // PRAGMA_COMMENT_SUPPORT && OPENCV_AUTO_LINK
+
 #endif

--- a/modules/imgproc/include/opencv2/imgproc/imgproc.hpp
+++ b/modules/imgproc/include/opencv2/imgproc/imgproc.hpp
@@ -1226,6 +1226,12 @@ protected:
 
 #endif /* __cplusplus */
 
+// Auto linking by "#pragma comment(lib)" syntax
+#include "opencv2/core/pragma_lib.hpp"
+#if PRAGMA_COMMENT_SUPPORT && OPENCV_AUTO_LINK
+#pragma OPENCV_COMMENT_LIB_FNAME("imgproc")
+#endif // PRAGMA_COMMENT_SUPPORT && OPENCV_AUTO_LINK
+
 #endif
 
 /* End of file. */

--- a/modules/legacy/include/opencv2/legacy/legacy.hpp
+++ b/modules/legacy/include/opencv2/legacy/legacy.hpp
@@ -3432,6 +3432,12 @@ CVAPI(CvSeq*) cvSegmentFGMask( CvArr *fgmask, int poly1Hull0 CV_DEFAULT(1),
 }
 #endif
 
+// Auto linking by "#pragma comment(lib)" syntax
+#include "opencv2/core/pragma_lib.hpp"
+#if PRAGMA_COMMENT_SUPPORT && OPENCV_AUTO_LINK
+#pragma OPENCV_COMMENT_LIB_FNAME("legacy")
+#endif // PRAGMA_COMMENT_SUPPORT && OPENCV_AUTO_LINK
+
 #endif
 
 /* End of file. */

--- a/modules/ml/include/opencv2/ml/ml.hpp
+++ b/modules/ml/include/opencv2/ml/ml.hpp
@@ -2144,6 +2144,13 @@ CV_EXPORTS bool initModule_ml(void);
 }
 
 #endif // __cplusplus
+
+// Auto linking by "#pragma comment(lib)" syntax
+#include "opencv2/core/pragma_lib.hpp"
+#if PRAGMA_COMMENT_SUPPORT && OPENCV_AUTO_LINK
+#pragma OPENCV_COMMENT_LIB_FNAME("ml")
+#endif // PRAGMA_COMMENT_SUPPORT && OPENCV_AUTO_LINK
+
 #endif // __OPENCV_ML_HPP__
 
 /* End of file. */

--- a/modules/nonfree/include/opencv2/nonfree/nonfree.hpp
+++ b/modules/nonfree/include/opencv2/nonfree/nonfree.hpp
@@ -52,6 +52,12 @@ CV_EXPORTS_W bool initModule_nonfree();
     
 }
 
+// Auto linking by "#pragma comment(lib)" syntax
+#include "opencv2/core/pragma_lib.hpp"
+#if PRAGMA_COMMENT_SUPPORT && OPENCV_AUTO_LINK
+#pragma OPENCV_COMMENT_LIB_FNAME("nonfree")
+#endif // PRAGMA_COMMENT_SUPPORT && OPENCV_AUTO_LINK
+
 #endif
 
 /* End of file. */

--- a/modules/objdetect/include/opencv2/objdetect/objdetect.hpp
+++ b/modules/objdetect/include/opencv2/objdetect/objdetect.hpp
@@ -1024,4 +1024,10 @@ CV_EXPORTS Ptr<Detector> getDefaultLINEMOD();
 
 #endif
 
+// Auto linking by "#pragma comment(lib)" syntax
+#include "opencv2/core/pragma_lib.hpp"
+#if PRAGMA_COMMENT_SUPPORT && OPENCV_AUTO_LINK
+#pragma OPENCV_COMMENT_LIB_FNAME("objdetect")
+#endif // PRAGMA_COMMENT_SUPPORT && OPENCV_AUTO_LINK
+
 #endif

--- a/modules/photo/include/opencv2/photo/photo.hpp
+++ b/modules/photo/include/opencv2/photo/photo.hpp
@@ -71,4 +71,10 @@ CV_EXPORTS_W void inpaint( InputArray src, InputArray inpaintMask,
 
 #endif
 
+// Auto linking by "#pragma comment(lib)" syntax
+#include "opencv2/core/pragma_lib.hpp"
+#if PRAGMA_COMMENT_SUPPORT && OPENCV_AUTO_LINK
+#pragma OPENCV_COMMENT_LIB_FNAME("photo")
+#endif // PRAGMA_COMMENT_SUPPORT && OPENCV_AUTO_LINK
+
 #endif

--- a/modules/stitching/include/opencv2/stitching/stitcher.hpp
+++ b/modules/stitching/include/opencv2/stitching/stitcher.hpp
@@ -167,4 +167,10 @@ private:
 
 } // namespace cv
 
+// Auto linking by "#pragma comment(lib)" syntax
+#include "opencv2/core/pragma_lib.hpp"
+#if PRAGMA_COMMENT_SUPPORT && OPENCV_AUTO_LINK
+#pragma OPENCV_COMMENT_LIB_FNAME("stitching")
+#endif // PRAGMA_COMMENT_SUPPORT && OPENCV_AUTO_LINK
+
 #endif // __OPENCV_STITCHING_STITCHER_HPP__

--- a/modules/ts/include/opencv2/ts/ts.hpp
+++ b/modules/ts/include/opencv2/ts/ts.hpp
@@ -578,6 +578,13 @@ int main(int argc, char **argv) \
     return RUN_ALL_TESTS(); \
 }
 
+// Auto linking by "#pragma comment(lib)" syntax
+#include "opencv2/core/pragma_lib.hpp"
+#if PRAGMA_COMMENT_SUPPORT && OPENCV_AUTO_LINK
+#pragma OPENCV_COMMENT_LIB_FNAME("ts")
+#endif // PRAGMA_COMMENT_SUPPORT && OPENCV_AUTO_LINK
+
+
 #endif
 
 #include "ts_perf.hpp"

--- a/modules/video/include/opencv2/video/video.hpp
+++ b/modules/video/include/opencv2/video/video.hpp
@@ -55,4 +55,10 @@ CV_EXPORTS bool initModule_video(void);
 }
 #endif
 
+// Auto linking by "#pragma comment(lib)" syntax
+#include "opencv2/core/pragma_lib.hpp"
+#if PRAGMA_COMMENT_SUPPORT && OPENCV_AUTO_LINK
+#pragma OPENCV_COMMENT_LIB_FNAME("video")
+#endif // PRAGMA_COMMENT_SUPPORT && OPENCV_AUTO_LINK
+
 #endif //__OPENCV_VIDEO_HPP__

--- a/modules/videostab/include/opencv2/videostab/videostab.hpp
+++ b/modules/videostab/include/opencv2/videostab/videostab.hpp
@@ -45,4 +45,10 @@
 
 #include "opencv2/videostab/stabilizer.hpp"
 
+// Auto linking by "#pragma comment(lib)" syntax
+#include "opencv2/core/pragma_lib.hpp"
+#if PRAGMA_COMMENT_SUPPORT && OPENCV_AUTO_LINK
+#pragma OPENCV_COMMENT_LIB_FNAME("videostab")
+#endif // PRAGMA_COMMENT_SUPPORT && OPENCV_AUTO_LINK
+
 #endif


### PR DESCRIPTION
In Visual Studio, there are

```
#pragma comment(lib, "XXX")
```

syntax to specify a library file for Linker.
Writing a #pragma in your c/c++ source code or header file,
the linkage-editor recognize it and links the library file.
When users use the syntax, users no longer care about linker options such as

"add opencv_highgui242d.lib, opencv_core242d.lib .... ouch I forget imgproc.
 I also have to specify almost the same options in Release build Settings
 ............I think it is 100th settings in my life :-< ",

I hope that OpenCV use its useful syntax.

For same time back, Boost C++ library is using its technique, and
user who use the library in Visual Studio
can use the library without specifying library files manually.
Thanks to the pragma, we use Boost, there are no linker errors without side effects when.

It's like a .pc files of pkg-config in Unix/Linux environment.

I think there are no reason we don't use this syntax in Windows
because OpenCV on Linux/Mac now using similar technique which is called pkg-config.

Thanks.
