### PR TITLE
Add stream operators (Requested #2430)

### DIFF
--- a/modules/core/include/opencv2/core/operations.hpp
+++ b/modules/core/include/opencv2/core/operations.hpp
@@ -3797,6 +3797,43 @@ template<typename _Tp> inline std::ostream& operator<<(std::ostream& out, const 
     return out;
 }
 
+/** Writes a Matx to an output stream.
+ */
+template<typename _Tp, int m, int n> inline std::ostream& operator<<(std::ostream& out, const Matx<_Tp, m, n>& matx)
+{
+    out << cv::Mat(matx);
+    return out;
+}
+
+/** Writes a Vec to an output stream. Format example : [10, 20, 30]
+ */
+template<typename _Tp, int n> inline std::ostream& operator<<(std::ostream& out, const Vec<_Tp, n>& vec)
+{
+    out << "[";
+    for (int i = 0; i < n - 1; ++i) {
+        out << vec[i] << ", ";
+    }
+    out << vec[n-1] << "]";
+
+    return out;
+}
+
+/** Writes a Size_ to an output stream. Format example : [640 x 480]
+ */
+template<typename _Tp> inline std::ostream& operator<<(std::ostream& out, const Size_<_Tp>& size)
+{
+    out << "[" << size.width << " x " << size.height << "]";
+    return out;
+}
+
+/** Writes a Rect_ to an output stream. Format example : [640 x 480 from (10, 20)]
+ */
+template<typename _Tp> inline std::ostream& operator<<(std::ostream& out, const Rect_<_Tp>& rect)
+{
+    out << "[" << rect.width << " x " << rect.height << " from (" << rect.x << ", " << rect.y << ")]";
+    return out;
+}
+
 static inline Formatted format(const Mat& mtx, const char* fmt,
                                const vector<int>& params=vector<int>())
 {


### PR DESCRIPTION
Add output stream operators (<<) for Rect, Size, Matx, Vec.
I can't add operations for cv::KeyPoint.

Please reject if the format of Rect / Size is wrong.

http://code.opencv.org/issues/2430
