### PR TITLE
Changed link to Q&A forum in the docs

### DIFF
--- a/doc/_themes/blue/layout.html
+++ b/doc/_themes/blue/layout.html
@@ -188,7 +188,7 @@
                   {% if theme_lang == 'py' %}
                     <li>Try the <a href="cookbook.html">Cookbook</a>.</li>
                   {% endif %}
-                  <li>Ask a question in the <a href="http://tech.groups.yahoo.com/group/OpenCV/">user group/mailing list</a>.</li>
+                  <li>Ask a question on the <a href="http://answers.opencv.org">Q&A forum</a>.</li>
                   <li>If you think something is missing or wrong in the documentation,
                   please file a <a href="http://code.opencv.org">bug report</a>.</li>
               </ul>


### PR DESCRIPTION
docs.opencv.org are still referring to the old Yahoo group. I've replaced the link with answers.opencv.org.
