### PR TITLE
Restore core multiply/divide depth to CV_64F value.

### DIFF
--- a/modules/core/src/arithm.cpp
+++ b/modules/core/src/arithm.cpp
@@ -1281,7 +1281,7 @@ static void arithm_op(InputArray _src1, InputArray _src2, OutputArray _dst,
                 depth2 = CV_32F;
         }
         else
-            depth2 = src1.depth() < CV_32S || src1.depth() == CV_32F ? CV_32F : CV_64F;
+            depth2 = CV_64F;
     }
 
     int cn = src1.channels(), depth1 = src1.depth(), wtype;

--- a/modules/core/test/test_arithm.cpp
+++ b/modules/core/test/test_arithm.cpp
@@ -1522,4 +1522,12 @@ protected:
 
 TEST(Core_ArithmMask, uninitialized) { CV_ArithmMaskTest test; test.safe_run(); }
 
+TEST(Multiply, FloatingPointRounding)
+{
+    cv::Mat src(1, 1, CV_8UC1, cv::Scalar::all(110)), dst;
+    cv::Scalar s(147.286359696927, 1, 1 ,1);
 
+    cv::multiply(src, s, dst, 1, CV_16U);
+    // with CV_32F this produce result 16202
+    ASSERT_EQ(dst.at<ushort>(0,0), 16201);
+}


### PR DESCRIPTION
After setting depth to CV_32F for non double types this produces difference in results. I've attached test that reproduce this issue.The issue was found during analysis  broken GPU tests  for multiply/device functions.
