### PR TITLE
trying to fix test crashes and failures

### DIFF
--- a/modules/highgui/test/test_framecount.cpp
+++ b/modules/highgui/test/test_framecount.cpp
@@ -109,6 +109,6 @@ void CV_FramecountTest::run(int)
         }
     }
 }
-#if BUILD_WITH_VIDEO_INPUT_SUPPORT
+#if BUILD_WITH_VIDEO_INPUT_SUPPORT && defined HAVE_FFMPEG
 TEST(Highgui_Video, framecount) {CV_FramecountTest test; test.safe_run();}
 #endif

--- a/modules/highgui/test/test_positioning.cpp
+++ b/modules/highgui/test/test_positioning.cpp
@@ -217,7 +217,7 @@ void CV_VideoRandomPositioningTest::run(int)
     run_test(RANDOM);
 }
 
-#if BUILD_WITH_VIDEO_INPUT_SUPPORT
+#if BUILD_WITH_VIDEO_INPUT_SUPPORT && defined HAVE_FFMPEG
 TEST (Highgui_Video, seek_progressive) { CV_VideoProgressivePositioningTest test; test.safe_run(); }
 TEST (Highgui_Video, seek_random) { CV_VideoRandomPositioningTest test; test.safe_run(); }
 #endif

--- a/modules/highgui/test/test_video_pos.cpp
+++ b/modules/highgui/test/test_video_pos.cpp
@@ -173,6 +173,6 @@ public:
     Size framesize;
 };
 
-#if BUILD_WITH_VIDEO_INPUT_SUPPORT && BUILD_WITH_VIDEO_OUTPUT_SUPPORT
+#if BUILD_WITH_VIDEO_INPUT_SUPPORT && BUILD_WITH_VIDEO_OUTPUT_SUPPORT && defined HAVE_FFMPEG
 TEST(Highgui_Video, seek_random_synthetic) { CV_PositioningTest test; test.safe_run(); }
 #endif

--- a/modules/imgproc/src/imgwarp.cpp
+++ b/modules/imgproc/src/imgwarp.cpp
@@ -220,7 +220,7 @@ static const void* initInterTab2D( int method, bool fixpt )
     return fixpt ? (const void*)itab : (const void*)tab;
 }
 
-
+#if !defined WIN32 || !defined __GNUC__
 static bool initAllInterTab2D()
 {
     return  initInterTab2D( INTER_LINEAR, false ) &&
@@ -232,6 +232,7 @@ static bool initAllInterTab2D()
 }
 
 static volatile bool doInitAllInterTab2D = initAllInterTab2D();
+#endif
 
 template<typename ST, typename DT> struct Cast
 {


### PR DESCRIPTION
disabled several tests on Mac when no FFMPEG is used; disabled automatic table initialization in imgwarp in the case of MinGW
