### PR TITLE
openni documentation fixes

### DIFF
--- a/doc/user_guide/ug_highgui.rst
+++ b/doc/user_guide/ug_highgui.rst
@@ -41,15 +41,15 @@ VideoCapture can retrieve the following data:
 
 #.
     data given from depth generator:
-      * ``OPENNI_DEPTH_MAP``          - depth values in mm (CV_16UC1)
-      * ``OPENNI_POINT_CLOUD_MAP``    - XYZ in meters (CV_32FC3)
-      * ``OPENNI_DISPARITY_MAP``      - disparity in pixels (CV_8UC1)
-      * ``OPENNI_DISPARITY_MAP_32F``  - disparity in pixels (CV_32FC1)
-      * ``OPENNI_VALID_DEPTH_MASK``   - mask of valid pixels (not ocluded, not shaded etc.) (CV_8UC1)
+      * ``CV_CAP_OPENNI_DEPTH_MAP``          - depth values in mm (CV_16UC1)
+      * ``CV_CAP_OPENNI_POINT_CLOUD_MAP``    - XYZ in meters (CV_32FC3)
+      * ``CV_CAP_OPENNI_DISPARITY_MAP``      - disparity in pixels (CV_8UC1)
+      * ``CV_CAP_OPENNI_DISPARITY_MAP_32F``  - disparity in pixels (CV_32FC1)
+      * ``CV_CAP_OPENNI_VALID_DEPTH_MASK``   - mask of valid pixels (not ocluded, not shaded etc.) (CV_8UC1)
 #.
     data given from RGB image generator:
-      * ``OPENNI_BGR_IMAGE``          - color image (CV_8UC3)
-      * ``OPENNI_GRAY_IMAGE``         - gray image (CV_8UC1)
+      * ``CV_CAP_OPENNI_BGR_IMAGE``          - color image (CV_8UC3)
+      * ``CV_CAP_OPENNI_GRAY_IMAGE``         - gray image (CV_8UC1)
 
 In order to get depth map from depth sensor use ``VideoCapture::operator >>``, e. g. ::
 
@@ -69,12 +69,12 @@ For getting several data maps use ``VideoCapture::grab`` and ``VideoCapture::ret
     for(;;)
     {
         Mat depthMap;
-        Mat rgbImage
+        Mat bgrImage;
 
         capture.grab();
 
-        capture.retrieve( depthMap, OPENNI_DEPTH_MAP );
-        capture.retrieve( bgrImage, OPENNI_BGR_IMAGE );
+        capture.retrieve( depthMap, CV_CAP_OPENNI_DEPTH_MAP );
+        capture.retrieve( bgrImage, CV_CAP_OPENNI_BGR_IMAGE );
 
         if( waitKey( 30 ) >= 0 )
             break;

--- a/samples/cpp/openni_capture.cpp
+++ b/samples/cpp/openni_capture.cpp
@@ -12,14 +12,14 @@ static void help()
                         "The user gets some of the supported output images.\n"
             "\nAll supported output map types:\n"
             "1.) Data given from depth generator\n"
-            "   OPENNI_DEPTH_MAP            - depth values in mm (CV_16UC1)\n"
-            "   OPENNI_POINT_CLOUD_MAP      - XYZ in meters (CV_32FC3)\n"
-            "   OPENNI_DISPARITY_MAP        - disparity in pixels (CV_8UC1)\n"
-            "   OPENNI_DISPARITY_MAP_32F    - disparity in pixels (CV_32FC1)\n"
-            "   OPENNI_VALID_DEPTH_MASK     - mask of valid pixels (not ocluded, not shaded etc.) (CV_8UC1)\n"
+            "   CV_CAP_OPENNI_DEPTH_MAP            - depth values in mm (CV_16UC1)\n"
+            "   CV_CAP_OPENNI_POINT_CLOUD_MAP      - XYZ in meters (CV_32FC3)\n"
+            "   CV_CAP_OPENNI_DISPARITY_MAP        - disparity in pixels (CV_8UC1)\n"
+            "   CV_CAP_OPENNI_DISPARITY_MAP_32F    - disparity in pixels (CV_32FC1)\n"
+            "   CV_CAP_OPENNI_VALID_DEPTH_MASK     - mask of valid pixels (not ocluded, not shaded etc.) (CV_8UC1)\n"
             "2.) Data given from RGB image generator\n"
-            "   OPENNI_BGR_IMAGE            - color image (CV_8UC3)\n"
-            "   OPENNI_GRAY_IMAGE           - gray image (CV_8UC1)\n"
+            "   CV_CAP_OPENNI_BGR_IMAGE            - color image (CV_8UC3)\n"
+            "   CV_CAP_OPENNI_GRAY_IMAGE           - gray image (CV_8UC1)\n"
          << endl;
 }
 


### PR DESCRIPTION
fix comments to match CV_CAP_OPENNI_\* vs. wrong OPENNI_\* in sample @openni_sample.cpp@, as well as in highgui user guide documentation @ug_highgui.rst@
