### PR TITLE
fixed string->string conversion in CommandLineParser

### DIFF
--- a/modules/core/src/command_line_parser.cpp
+++ b/modules/core/src/command_line_parser.cpp
@@ -70,7 +70,7 @@ static void from_str(const string& str, int type, void* dst)
     else if( type == Param::REAL )
         ss >> *(double*)dst;
     else if( type == Param::STRING )
-        ss >> *(string*)dst;
+        *(string*)dst = str;
     else
         throw cv::Exception(CV_StsBadArg, "unknown/unsupported parameter type", "", __FILE__, __LINE__);
 


### PR DESCRIPTION
Current implementation of CommandLineParser doesn't support string parameters with spaces. 
For example,

```
.\sample "/home/user/Some Images/img.jpg"
```

``` C++
CommanLineParser cmd(argc, argv, "{%0 |  | }");
string param = cmd.get(0, false);
//assert(param == "/home/user/Some Images/img.jpg"); // it should be, but
assert(param == "/home/user/Some");
```

That happens, because `stringstream::operator>>` is used to convert from string to string. This operator reads a line up to the first whitespace character.
This fix changes string->string conversion to simple assignment.
