### PR TITLE
CvCaptureFile::grabFrame() always returns 1, regardless the end of video. Fixed.

### DIFF
--- a/modules/highgui/src/cap_qtkit.mm
+++ b/modules/highgui/src/cap_qtkit.mm
@@ -833,7 +833,15 @@ double CvCaptureFile::getProperty(int property_id){
             retval = currentFPS;
             break;
         case CV_CAP_PROP_FRAME_COUNT:
-            retval = movieDuration*movieFPS/1000;
+            {
+                NSArray *videoTracks = [mCaptureSession tracksOfMediaType:QTMediaTypeVideo];
+                if ([videoTracks count] > 0) {
+                    QTMedia *media = [[videoTracks objectAtIndex:0] media];
+                    retval = [[media attributeForKey:QTMediaSampleCountAttribute] longValue];
+                } else {
+                    retval = 0;
+                }
+            }
             break;
         case CV_CAP_PROP_FOURCC:
         default:


### PR DESCRIPTION
The function CvCaptureFile::grabFrame() in cap_qtkit.m alway returns true, which means if one relies on the returned value to step through frames of a quicktime video,  it'll be a dead loop.  This commit detects the end of a quicktime video properly and returns false when reaching the end.
