### PR TITLE
replase __APPLE__ marco with __clang__

### DIFF
--- a/modules/calib3d/perf/perf_precomp.hpp
+++ b/modules/calib3d/perf/perf_precomp.hpp
@@ -1,6 +1,6 @@
 #ifdef __GNUC__
 #  pragma GCC diagnostic ignored "-Wmissing-declarations"
-#  ifdef __APPLE__
+#  ifdef __clang__
 #    pragma GCC diagnostic ignored "-Wmissing-prototypes"
 #    pragma GCC diagnostic ignored "-Wextra"
 #  endif

--- a/modules/calib3d/test/test_precomp.hpp
+++ b/modules/calib3d/test/test_precomp.hpp
@@ -1,6 +1,6 @@
 #ifdef __GNUC__
 #  pragma GCC diagnostic ignored "-Wmissing-declarations"
-#  ifdef __APPLE__
+#  ifdef __clang__
 #    pragma GCC diagnostic ignored "-Wmissing-prototypes"
 #    pragma GCC diagnostic ignored "-Wextra"
 #  endif

--- a/modules/contrib/test/test_precomp.hpp
+++ b/modules/contrib/test/test_precomp.hpp
@@ -1,6 +1,6 @@
 #ifdef __GNUC__
 #  pragma GCC diagnostic ignored "-Wmissing-declarations"
-#  ifdef __APPLE__
+#  ifdef __clang__
 #    pragma GCC diagnostic ignored "-Wmissing-prototypes"
 #    pragma GCC diagnostic ignored "-Wextra"
 #  endif

--- a/modules/core/perf/perf_precomp.hpp
+++ b/modules/core/perf/perf_precomp.hpp
@@ -1,6 +1,6 @@
 #ifdef __GNUC__
 #  pragma GCC diagnostic ignored "-Wmissing-declarations"
-#  ifdef __APPLE__
+#  ifdef __clang__
 #    pragma GCC diagnostic ignored "-Wmissing-prototypes"
 #    pragma GCC diagnostic ignored "-Wextra"
 #  endif

--- a/modules/core/test/test_precomp.hpp
+++ b/modules/core/test/test_precomp.hpp
@@ -1,6 +1,6 @@
 #ifdef __GNUC__
 #  pragma GCC diagnostic ignored "-Wmissing-declarations"
-#  ifdef __APPLE__
+#  ifdef __clang__
 #    pragma GCC diagnostic ignored "-Wmissing-prototypes"
 #    pragma GCC diagnostic ignored "-Wextra"
 #  endif

--- a/modules/features2d/perf/perf_precomp.hpp
+++ b/modules/features2d/perf/perf_precomp.hpp
@@ -1,6 +1,6 @@
 #ifdef __GNUC__
 #  pragma GCC diagnostic ignored "-Wmissing-declarations"
-#  ifdef __APPLE__
+#  ifdef __clang__
 #    pragma GCC diagnostic ignored "-Wmissing-prototypes"
 #    pragma GCC diagnostic ignored "-Wextra"
 #  endif

--- a/modules/features2d/test/test_precomp.hpp
+++ b/modules/features2d/test/test_precomp.hpp
@@ -1,6 +1,6 @@
 #ifdef __GNUC__
 #  pragma GCC diagnostic ignored "-Wmissing-declarations"
-#  ifdef __APPLE__
+#  ifdef __clang__
 #    pragma GCC diagnostic ignored "-Wmissing-prototypes"
 #    pragma GCC diagnostic ignored "-Wextra"
 #  endif

--- a/modules/gpu/perf/perf_precomp.hpp
+++ b/modules/gpu/perf/perf_precomp.hpp
@@ -1,6 +1,6 @@
 #ifdef __GNUC__
 #  pragma GCC diagnostic ignored "-Wmissing-declarations"
-#  ifdef __APPLE__
+#  ifdef __clang__
 #    pragma GCC diagnostic ignored "-Wmissing-prototypes"
 #    pragma GCC diagnostic ignored "-Wextra"
 #  endif

--- a/modules/gpu/test/test_precomp.hpp
+++ b/modules/gpu/test/test_precomp.hpp
@@ -41,7 +41,7 @@
 
 #ifdef __GNUC__
 #  pragma GCC diagnostic ignored "-Wmissing-declarations"
-#  ifdef __APPLE__
+#  ifdef __clang__
 #    pragma GCC diagnostic ignored "-Wmissing-prototypes"
 #    pragma GCC diagnostic ignored "-Wextra"
 #  endif

--- a/modules/highgui/perf/perf_precomp.hpp
+++ b/modules/highgui/perf/perf_precomp.hpp
@@ -1,6 +1,6 @@
 #ifdef __GNUC__
 #  pragma GCC diagnostic ignored "-Wmissing-declarations"
-#  ifdef __APPLE__
+#  ifdef __clang__
 #    pragma GCC diagnostic ignored "-Wmissing-prototypes"
 #    pragma GCC diagnostic ignored "-Wextra"
 #  endif

--- a/modules/highgui/test/test_precomp.hpp
+++ b/modules/highgui/test/test_precomp.hpp
@@ -1,6 +1,6 @@
 #ifdef __GNUC__
 #  pragma GCC diagnostic ignored "-Wmissing-declarations"
-#  ifdef __APPLE__
+#  ifdef __clang__
 #    pragma GCC diagnostic ignored "-Wmissing-prototypes"
 #    pragma GCC diagnostic ignored "-Wextra"
 #  endif

--- a/modules/imgproc/perf/perf_precomp.hpp
+++ b/modules/imgproc/perf/perf_precomp.hpp
@@ -1,6 +1,6 @@
 #ifdef __GNUC__
 #  pragma GCC diagnostic ignored "-Wmissing-declarations"
-#  ifdef __APPLE__
+#  ifdef __clang__
 #    pragma GCC diagnostic ignored "-Wmissing-prototypes"
 #    pragma GCC diagnostic ignored "-Wextra"
 #  endif

--- a/modules/imgproc/test/test_precomp.hpp
+++ b/modules/imgproc/test/test_precomp.hpp
@@ -1,6 +1,6 @@
 #ifdef __GNUC__
 #  pragma GCC diagnostic ignored "-Wmissing-declarations"
-#  ifdef __APPLE__
+#  ifdef __clang__
 #    pragma GCC diagnostic ignored "-Wmissing-prototypes"
 #    pragma GCC diagnostic ignored "-Wextra"
 #  endif

--- a/modules/legacy/test/test_precomp.hpp
+++ b/modules/legacy/test/test_precomp.hpp
@@ -1,6 +1,6 @@
 #ifdef __GNUC__
 #  pragma GCC diagnostic ignored "-Wmissing-declarations"
-#  ifdef __APPLE__
+#  ifdef __clang__
 #    pragma GCC diagnostic ignored "-Wmissing-prototypes"
 #    pragma GCC diagnostic ignored "-Wextra"
 #  endif

--- a/modules/ml/test/test_precomp.hpp
+++ b/modules/ml/test/test_precomp.hpp
@@ -1,6 +1,6 @@
 #ifdef __GNUC__
 #  pragma GCC diagnostic ignored "-Wmissing-declarations"
-#  ifdef __APPLE__
+#  ifdef __clang__
 #    pragma GCC diagnostic ignored "-Wmissing-prototypes"
 #    pragma GCC diagnostic ignored "-Wextra"
 #  endif

--- a/modules/nonfree/perf/perf_precomp.hpp
+++ b/modules/nonfree/perf/perf_precomp.hpp
@@ -1,6 +1,6 @@
 #ifdef __GNUC__
 #  pragma GCC diagnostic ignored "-Wmissing-declarations"
-#  ifdef __APPLE__
+#  ifdef __clang__
 #    pragma GCC diagnostic ignored "-Wmissing-prototypes"
 #    pragma GCC diagnostic ignored "-Wextra"
 #  endif

--- a/modules/nonfree/test/test_precomp.hpp
+++ b/modules/nonfree/test/test_precomp.hpp
@@ -1,6 +1,6 @@
 #ifdef __GNUC__
 #  pragma GCC diagnostic ignored "-Wmissing-declarations"
-#  ifdef __APPLE__
+#  ifdef __clang__
 #    pragma GCC diagnostic ignored "-Wmissing-prototypes"
 #    pragma GCC diagnostic ignored "-Wextra"
 #  endif

--- a/modules/objdetect/perf/perf_precomp.hpp
+++ b/modules/objdetect/perf/perf_precomp.hpp
@@ -1,6 +1,6 @@
 #ifdef __GNUC__
 #  pragma GCC diagnostic ignored "-Wmissing-declarations"
-#  ifdef __APPLE__
+#  ifdef __clang__
 #    pragma GCC diagnostic ignored "-Wmissing-prototypes"
 #    pragma GCC diagnostic ignored "-Wextra"
 #  endif

--- a/modules/objdetect/test/test_precomp.hpp
+++ b/modules/objdetect/test/test_precomp.hpp
@@ -1,6 +1,6 @@
 #ifdef __GNUC__
 #  pragma GCC diagnostic ignored "-Wmissing-declarations"
-#  ifdef __APPLE__
+#  ifdef __clang__
 #    pragma GCC diagnostic ignored "-Wmissing-prototypes"
 #    pragma GCC diagnostic ignored "-Wextra"
 #  endif

--- a/modules/photo/perf/perf_precomp.hpp
+++ b/modules/photo/perf/perf_precomp.hpp
@@ -1,6 +1,6 @@
 #ifdef __GNUC__
 #  pragma GCC diagnostic ignored "-Wmissing-declarations"
-#  ifdef __APPLE__
+#  ifdef __clang__
 #    pragma GCC diagnostic ignored "-Wmissing-prototypes"
 #    pragma GCC diagnostic ignored "-Wextra"
 #  endif

--- a/modules/photo/test/test_precomp.hpp
+++ b/modules/photo/test/test_precomp.hpp
@@ -1,6 +1,6 @@
 #ifdef __GNUC__
 #  pragma GCC diagnostic ignored "-Wmissing-declarations"
-#  ifdef __APPLE__
+#  ifdef __clang__
 #    pragma GCC diagnostic ignored "-Wmissing-prototypes"
 #    pragma GCC diagnostic ignored "-Wextra"
 #  endif

--- a/modules/stitching/perf/perf_precomp.hpp
+++ b/modules/stitching/perf/perf_precomp.hpp
@@ -1,6 +1,6 @@
 #ifdef __GNUC__
 #  pragma GCC diagnostic ignored "-Wmissing-declarations"
-#  ifdef __APPLE__
+#  ifdef __clang__
 #    pragma GCC diagnostic ignored "-Wmissing-prototypes"
 #    pragma GCC diagnostic ignored "-Wextra"
 #  endif

--- a/modules/stitching/test/test_precomp.hpp
+++ b/modules/stitching/test/test_precomp.hpp
@@ -1,6 +1,6 @@
 #ifdef __GNUC__
 #  pragma GCC diagnostic ignored "-Wmissing-declarations"
-#  ifdef __APPLE__
+#  ifdef __clang__
 #    pragma GCC diagnostic ignored "-Wmissing-prototypes"
 #    pragma GCC diagnostic ignored "-Wextra"
 #  endif

--- a/modules/video/perf/perf_precomp.hpp
+++ b/modules/video/perf/perf_precomp.hpp
@@ -1,6 +1,6 @@
 #ifdef __GNUC__
 #  pragma GCC diagnostic ignored "-Wmissing-declarations"
-#  ifdef __APPLE__
+#  ifdef __clang__
 #    pragma GCC diagnostic ignored "-Wmissing-prototypes"
 #    pragma GCC diagnostic ignored "-Wextra"
 #  endif

--- a/modules/video/test/test_precomp.hpp
+++ b/modules/video/test/test_precomp.hpp
@@ -1,6 +1,6 @@
 #ifdef __GNUC__
 #  pragma GCC diagnostic ignored "-Wmissing-declarations"
-#  ifdef __APPLE__
+#  ifdef __clang__
 #    pragma GCC diagnostic ignored "-Wmissing-prototypes"
 #    pragma GCC diagnostic ignored "-Wextra"
 #  endif


### PR DESCRIPTION
Allow not only Mac users suppress clang warnings.  
