### PR TITLE
Fix build on Windows with OpenGl enabled

### DIFF
--- a/modules/core/src/opengl_interop.cpp
+++ b/modules/core/src/opengl_interop.cpp
@@ -45,6 +45,14 @@
 #include "opencv2/core/opengl_interop.hpp"
 #include "opencv2/core/gpumat.hpp"
 
+#if defined WIN32 || defined _WIN32 || defined WINCE
+#include <windows.h>
+#undef small
+#undef min
+#undef max
+#undef abs
+#endif
+
 #ifdef HAVE_OPENGL
     #ifdef __APPLE__
         #include <OpenGL/gl.h>


### PR DESCRIPTION
There was missing windows.h include in OpenGL interop code.
