### PR TITLE
added CV_OUT to StereoVar output paramiter

### DIFF
--- a/modules/contrib/include/opencv2/contrib/contrib.hpp
+++ b/modules/contrib/include/opencv2/contrib/contrib.hpp
@@ -583,7 +583,7 @@ namespace cv
         virtual ~StereoVar();
 
         //! the stereo correspondence operator that computes disparity map for the specified rectified stereo pair
-        CV_WRAP_AS(compute) virtual void operator()(const Mat& left, const Mat& right, Mat& disp);
+        CV_WRAP_AS(compute) virtual void operator()(const Mat& left, const Mat& right, CV_OUT Mat& disp);
 
         CV_PROP_RW int      levels;
         CV_PROP_RW double   pyrScale;


### PR DESCRIPTION
the fix repares the Python wrappers for the stereo correspondence algorithm. It does not affect C/C++ interface in any way and probably it should not affect Java interface. If yes, please, approve it to 2.4 branch
