### PR TITLE
fix a compile error in case of building without highgui

### DIFF
--- a/modules/objdetect/src/cascadedetect.cpp
+++ b/modules/objdetect/src/cascadedetect.cpp
@@ -47,6 +47,7 @@
 #include <string>
 
 
+#if defined (LOG_CASCADE_STATISTIC)
 struct Logger
 {
     enum { STADIES_NUM = 20 };
@@ -109,6 +110,7 @@ struct Logger
     }
 
 } logger;
+#endif
 
 
 namespace cv


### PR DESCRIPTION
Compiler swears on imwrite in objdetect.
