### PR TITLE
Increasing accuracy interval for image filters on Android (max_eps=1)

### DIFF
--- a/modules/imgproc/perf/perf_blur.cpp
+++ b/modules/imgproc/perf/perf_blur.cpp
@@ -63,11 +63,7 @@ PERF_TEST_P(Size_MatType_BorderType3x3, gaussianBlur3x3,
 
     TEST_CYCLE() GaussianBlur(src, dst, Size(3,3), 0, 0, btype);
 
-#if CV_SSE2
     SANITY_CHECK(dst, 1);
-#else
-    SANITY_CHECK(dst);
-#endif
 }
 
 PERF_TEST_P(Size_MatType_BorderType3x3, blur3x3,
@@ -89,7 +85,7 @@ PERF_TEST_P(Size_MatType_BorderType3x3, blur3x3,
 
     TEST_CYCLE() blur(src, dst, Size(3,3), Point(-1,-1), btype);
 
-    SANITY_CHECK(dst, 1e-3);
+    SANITY_CHECK(dst, 1);
 }
 
 PERF_TEST_P(Size_MatType_BorderType, blur16x16,
@@ -183,7 +179,7 @@ PERF_TEST_P(Size_MatType_BorderType, gaussianBlur5x5,
 
     TEST_CYCLE() GaussianBlur(src, dst, Size(5,5), 0, 0, btype);
 
-    SANITY_CHECK(dst);
+    SANITY_CHECK(dst, 1e-3);
 }
 
 PERF_TEST_P(Size_MatType_BorderType, blur5x5,
@@ -205,5 +201,5 @@ PERF_TEST_P(Size_MatType_BorderType, blur5x5,
 
     TEST_CYCLE() blur(src, dst, Size(5,5), Point(-1,-1), btype);
 
-    SANITY_CHECK(dst, 1e-3);
+    SANITY_CHECK(dst, 1);
 }

--- a/modules/imgproc/perf/perf_filter2d.cpp
+++ b/modules/imgproc/perf/perf_filter2d.cpp
@@ -39,7 +39,7 @@ PERF_TEST_P( TestFilter2d, Filter2d,
 
     TEST_CYCLE() filter2D(src, dst, CV_8UC4, kernel, Point(1, 1), 0., borderMode);
 
-    SANITY_CHECK(dst);
+    SANITY_CHECK(dst, 1);
 }
 
 PERF_TEST_P( Image_KernelSize, GaborFilter2d,


### PR DESCRIPTION
Fixing tests failure on some Android devices due to float point accuracy +/- 1
