### PR TITLE
Python: Enable opencv to act as an installable module

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ from distutils.command.install_lib import install_lib
 version = "2.4.9"
 
 
-OWN_PATH = os.path.dirname(__file__)
+OWN_PATH = os.path.dirname(os.path.realpath(__file__))
 
 
 class BuildOpenCV(build_ext):


### PR DESCRIPTION
- introduce a setup.py file to enable pip installs
- compile opencv statically into the loadable module
  so that each virtualenv can have its own
  opencv installation.

What works:
- pip install git+https://github.com/stylight/opencv#egg=opencv into a virtualenv
  this enables other modules to specify opencv as a dependency and get it resolved
  automatically (given the build dependencies are met)

Known Bugs:
- "pip uninstall opencv" fails to remove cv2.so
- uploading to pypi not tested and probably doesn't work yet.
- missing build dependencies are probably not handled gracefully.
