### PR TITLE
Update modules/ml/doc/gradient_boosted_trees.rst

### DIFF
--- a/modules/ml/doc/gradient_boosted_trees.rst
+++ b/modules/ml/doc/gradient_boosted_trees.rst
@@ -144,7 +144,7 @@ By default the following constructor is used:
 
 .. code-block:: cpp
 
-    CvGBTreesParams(CvGBTrees::SQUARED_LOSS, 200, 0.8f, 0.01f, 3, false)
+    CvGBTreesParams(CvGBTrees::SQUARED_LOSS, 200, 0.01f, 0.8f, 3, false)
         : CvDTreeParams( 3, 10, 0, false, 10, 0, false, false, 0 )
 
 CvGBTrees


### PR DESCRIPTION
Default shrinkage=0.01 and subsample_portion=0.8, but not vice versa
