### PR TITLE
Drop functions working with multibyte characters

### DIFF
--- a/modules/core/include/opencv2/core/core.hpp
+++ b/modules/core/include/opencv2/core/core.hpp
@@ -109,13 +109,6 @@ template<typename _Tp> class CV_EXPORTS MatIterator_;
 template<typename _Tp> class CV_EXPORTS MatConstIterator_;
 template<typename _Tp> class CV_EXPORTS MatCommaInitializer_;
 
-#if !defined(ANDROID) || (defined(_GLIBCXX_USE_WCHAR_T) && _GLIBCXX_USE_WCHAR_T)
-typedef std::basic_string<wchar_t> WString;
-
-CV_EXPORTS string fromUtf16(const WString& str);
-CV_EXPORTS WString toUtf16(const string& str);
-#endif
-
 CV_EXPORTS string format( const char* fmt, ... );
 CV_EXPORTS string tempfile( const char* suffix CV_DEFAULT(0));
 

--- a/modules/core/src/persistence.cpp
+++ b/modules/core/src/persistence.cpp
@@ -45,7 +45,6 @@
 #include <ctype.h>
 #include <deque>
 #include <iterator>
-#include <wchar.h>
 
 #define USE_ZLIB 1
 
@@ -154,35 +153,6 @@ cv::string cv::FileStorage::getDefaultObjectName(const string& _filename)
     if( strcmp( name, "_" ) == 0 )
         strcpy( name, stubname );
     return cv::string(name);
-}
-
-namespace cv
-{
-#if !defined(ANDROID) || (defined(_GLIBCXX_USE_WCHAR_T) && _GLIBCXX_USE_WCHAR_T)
-string fromUtf16(const WString& str)
-{
-    cv::AutoBuffer<char> _buf(str.size()*4 + 1);
-    char* buf = _buf;
-
-    size_t sz = wcstombs(buf, str.c_str(), str.size());
-    if( sz == (size_t)-1 )
-        return string();
-    buf[sz] = '\0';
-    return string(buf);
-}
-
-WString toUtf16(const string& str)
-{
-    cv::AutoBuffer<wchar_t> _buf(str.size() + 1);
-    wchar_t* buf = _buf;
-
-    size_t sz = mbstowcs(buf, str.c_str(), str.size());
-    if( sz == (size_t)-1 )
-        return WString();
-    buf[sz] = '\0';
-    return WString(buf);
-}
-#endif
 }
 
 typedef struct CvGenericHash


### PR DESCRIPTION
These functions are not used by the library itself, but often produce portability problems.
