### PR TITLE
highgui: fix segfault on CvCapture_GStreamer::open (bug #2608)

### DIFF
--- a/modules/highgui/src/cap_gstreamer.cpp
+++ b/modules/highgui/src/cap_gstreamer.cpp
@@ -399,12 +399,12 @@ bool CvCapture_GStreamer::open( int type, const char* filename )
 
     gst_app_sink_set_max_buffers (GST_APP_SINK(sink), 1);
     gst_app_sink_set_drop (GST_APP_SINK(sink), stream);
-
-    gst_app_sink_set_caps(GST_APP_SINK(sink), gst_caps_new_simple("video/x-raw-rgb",
-                                                                  "red_mask",   G_TYPE_INT, 0x0000FF,
-                                                                  "green_mask", G_TYPE_INT, 0x00FF00,
-                                                                  "blue_mask",  G_TYPE_INT, 0xFF0000,
-                                                                  NULL));
+    caps = gst_caps_new_simple("video/x-raw-rgb",
+                               "red_mask",   G_TYPE_INT, 0x0000FF,
+                               "green_mask", G_TYPE_INT, 0x00FF00,
+                               "blue_mask",  G_TYPE_INT, 0xFF0000,
+                               NULL);
+    gst_app_sink_set_caps(GST_APP_SINK(sink), caps);
     gst_caps_unref(caps);
 
     if(gst_element_set_state(GST_ELEMENT(pipeline), GST_STATE_READY) ==


### PR DESCRIPTION
This fixes bug #2608

When compiled with GStreamer, open (with a file name) segfaults.

Fix was suggested by Bostjan Vesnicer.
