### PR TITLE
Ptr<T>::operator==

### DIFF
--- a/modules/core/include/opencv2/core/core.hpp
+++ b/modules/core/include/opencv2/core/core.hpp
@@ -1284,6 +1284,8 @@ public:
     operator _Tp* ();
     operator const _Tp*() const;
 
+    bool operator==(const Ptr<_Tp>& ptr) const;
+
     _Tp* obj; //< the object pointer.
     int* refcount; //< the associated reference counter
 };

--- a/modules/core/include/opencv2/core/operations.hpp
+++ b/modules/core/include/opencv2/core/operations.hpp
@@ -2690,6 +2690,11 @@ template<typename _Tp> template<typename _Tp2> inline const Ptr<_Tp2> Ptr<_Tp>::
     return p;
 }
 
+template<typename _Tp> inline bool Ptr<_Tp>::operator==(const Ptr<_Tp>& _ptr) const
+{
+    return refcount == _ptr.refcount;
+}
+
 //// specializied implementations of Ptr::delete_obj() for classic OpenCV types
 
 template<> CV_EXPORTS void Ptr<CvMat>::delete_obj();

--- a/modules/features2d/perf/perf_fast.cpp
+++ b/modules/features2d/perf/perf_fast.cpp
@@ -31,7 +31,7 @@ PERF_TEST_P(fast, detect, testing::Combine(
     declare.in(frame);
 
     Ptr<FeatureDetector> fd = Algorithm::create<FeatureDetector>("Feature2D.FAST");
-    ASSERT_FALSE( fd == 0 );
+    ASSERT_FALSE( fd.empty() );
     fd->set("threshold", 20);
     fd->set("nonmaxSuppression", true);
     fd->set("type", type);

--- a/modules/features2d/src/matchers.cpp
+++ b/modules/features2d/src/matchers.cpp
@@ -531,7 +531,7 @@ void FlannBasedMatcher::train()
 
 void FlannBasedMatcher::read( const FileNode& fn)
 {
-     if (indexParams == 0)
+     if (indexParams.empty())
          indexParams = new flann::IndexParams();
 
      FileNode ip = fn["indexParams"];
@@ -570,7 +570,7 @@ void FlannBasedMatcher::read( const FileNode& fn)
         };
      }
 
-     if (searchParams == 0)
+     if (searchParams.empty())
          searchParams = new flann::SearchParams();
 
      FileNode sp = fn["searchParams"];

--- a/modules/stitching/src/matchers.cpp
+++ b/modules/stitching/src/matchers.cpp
@@ -350,7 +350,7 @@ void SurfFeaturesFinder::find(const Mat &image, ImageFeatures &features)
     Mat gray_image;
     CV_Assert(image.type() == CV_8UC3);
     cvtColor(image, gray_image, CV_BGR2GRAY);
-    if (surf == 0)
+    if (surf.empty())
     {
         detector_->detect(gray_image, features.keypoints);
         extractor_->compute(gray_image, features.keypoints, features.descriptors);

--- a/modules/video/test/test_backgroundsubtractor_gbh.cpp
+++ b/modules/video/test/test_backgroundsubtractor_gbh.cpp
@@ -41,7 +41,7 @@ void CV_BackgroundSubtractorTest::run(int)
             Algorithm::create<BackgroundSubtractorGMG>("BackgroundSubtractor.GMG");
     Mat fgmask;
 
-    if (fgbg == NULL)
+    if (fgbg.empty())
         CV_Error(CV_StsError,"Failed to create Algorithm\n");
 
     /**


### PR DESCRIPTION
This is necessary if user stores collection of Ptr<T>'s in std::vector and wants sometimes remove them by value.
