### PR TITLE
First experiments on exposing GPU api into Python

### DIFF
--- a/modules/core/include/opencv2/core/gpumat.hpp
+++ b/modules/core/include/opencv2/core/gpumat.hpp
@@ -146,11 +146,11 @@ namespace cv { namespace gpu
     //////////////////////////////// GpuMat ///////////////////////////////
 
     //! Smart pointer for GPU memory with reference counting. Its interface is mostly similar with cv::Mat.
-    class CV_EXPORTS GpuMat
+    class CV_EXPORTS_W GpuMat
     {
     public:
         //! default constructor
-        GpuMat();
+        CV_WRAP GpuMat();
 
         //! constructs GpuMatrix of the specified size and type (_type is CV_8UC1, CV_64FC3, CV_32SC(12) etc.)
         GpuMat(int rows, int cols, int type);
@@ -172,7 +172,7 @@ namespace cv { namespace gpu
         GpuMat(const GpuMat& m, Rect roi);
 
         //! builds GpuMat from Mat. Perfom blocking upload to device.
-        explicit GpuMat(const Mat& m);
+        CV_WRAP explicit GpuMat(const Mat& m);
 
         //! destructor - calls release()
         ~GpuMat();
@@ -181,10 +181,10 @@ namespace cv { namespace gpu
         GpuMat& operator = (const GpuMat& m);
 
         //! pefroms blocking upload data to GpuMat.
-        void upload(const Mat& m);
+        CV_WRAP void upload(const Mat& m);
 
         //! downloads data from device to host memory. Blocking calls.
-        void download(Mat& m) const;
+        CV_WRAP void download(CV_OUT Mat& m) const;
 
         //! returns a new GpuMatrix header for the specified row
         GpuMat row(int y) const;

--- a/modules/gpu/include/opencv2/gpu/gpu.hpp
+++ b/modules/gpu/include/opencv2/gpu/gpu.hpp
@@ -138,7 +138,7 @@ public:
 // Passed to each function that supports async kernel execution.
 // Reference counting is enabled
 
-class CV_EXPORTS Stream
+class CV_EXPORTS_W Stream
 {
 public:
     Stream();
@@ -759,10 +759,10 @@ CV_EXPORTS void matchTemplate(const GpuMat& image, const GpuMat& templ, GpuMat& 
 CV_EXPORTS void matchTemplate(const GpuMat& image, const GpuMat& templ, GpuMat& result, int method, MatchTemplateBuf &buf, Stream& stream = Stream::Null());
 
 //! smoothes the source image and downsamples it
-CV_EXPORTS void pyrDown(const GpuMat& src, GpuMat& dst, Stream& stream = Stream::Null());
+CV_EXPORTS_W void pyrDown(const gpu::GpuMat& src, CV_OUT gpu::GpuMat& dst, gpu::Stream& stream = gpu::Stream::Null());
 
 //! upsamples the source image and then smoothes it
-CV_EXPORTS void pyrUp(const GpuMat& src, GpuMat& dst, Stream& stream = Stream::Null());
+CV_EXPORTS_W void pyrUp(const gpu::GpuMat& src, CV_OUT gpu::GpuMat& dst, gpu::Stream& stream = gpu::Stream::Null());
 
 //! performs linear blending of two images
 //! to avoid accuracy errors sum of weigths shouldn't be very close to zero

--- a/modules/python/CMakeLists.txt
+++ b/modules/python/CMakeLists.txt
@@ -10,7 +10,7 @@ if(ANDROID OR IOS OR NOT PYTHONLIBS_FOUND OR NOT PYTHON_USE_NUMPY)
 endif()
 
 set(the_description "The python bindings")
-ocv_add_module(python BINDINGS opencv_core opencv_flann opencv_imgproc opencv_video opencv_ml opencv_features2d opencv_highgui opencv_calib3d opencv_photo opencv_objdetect opencv_contrib opencv_legacy OPTIONAL opencv_nonfree)
+ocv_add_module(python BINDINGS opencv_core opencv_flann opencv_imgproc opencv_video opencv_ml opencv_features2d opencv_highgui opencv_calib3d opencv_photo opencv_objdetect opencv_contrib opencv_legacy OPTIONAL opencv_nonfree opencv_gpu)
 
 add_definitions(-DPYTHON_USE_NUMPY=1)
 
@@ -40,6 +40,12 @@ if(HAVE_opencv_nonfree)
   list(APPEND opencv_hdrs     "${OPENCV_MODULE_opencv_nonfree_LOCATION}/include/opencv2/nonfree/features2d.hpp"
                               "${OPENCV_MODULE_opencv_nonfree_LOCATION}/include/opencv2/nonfree/nonfree.hpp")
 endif()
+
+if(HAVE_opencv_gpu)
+  list(APPEND opencv_hdrs     "${OPENCV_MODULE_opencv_gpu_LOCATION}/include/opencv2/gpu/gpu.hpp"
+                              "${OPENCV_MODULE_opencv_core_LOCATION}/include/opencv2/core/gpumat.hpp")
+endif()
+
 
 set(cv2_generated_hdrs
     "${CMAKE_CURRENT_BINARY_DIR}/pyopencv_generated_funcs.h"

--- a/modules/python/src2/cv2.cpp
+++ b/modules/python/src2/cv2.cpp
@@ -27,6 +27,11 @@
 #  include "opencv2/nonfree/nonfree.hpp"
 #endif
 
+#ifdef HAVE_OPENCV_GPU
+#  include "opencv2/gpu/gpu.hpp"
+#endif
+
+
 using cv::flann::IndexParams;
 using cv::flann::SearchParams;
 
@@ -133,6 +138,23 @@ typedef Ptr<flann::SearchParams> Ptr_flann_SearchParams;
 
 typedef Ptr<FaceRecognizer> Ptr_FaceRecognizer;
 typedef vector<Scalar> vector_Scalar;
+
+template<class T> 
+struct RefPtr : public Ptr<T>
+{
+    RefPtr() : Ptr(new T()) {}
+    RefPtr(T * _obj) : Ptr(_obj) {}
+    RefPtr(T & _obj) : Ptr(&_obj) {}
+
+    operator T& () {return **this;}
+    operator T const& () const {return **this;}
+};
+
+
+#ifdef HAVE_OPENCV_GPU
+    typedef RefPtr<gpu::GpuMat> gpu_GpuMat;
+    typedef RefPtr<gpu::Stream> gpu_Stream;
+#endif
 
 static PyObject* failmsgp(const char *fmt, ...)
 {

--- a/modules/python/src2/gen2.py
+++ b/modules/python/src2/gen2.py
@@ -363,7 +363,8 @@ class ArgInfo(object):
         self.py_outputarg = False
 
     def isbig(self):
-        return self.tp == "Mat" or self.tp == "vector_Mat"# or self.tp.startswith("vector")
+        big_names = ["Mat", "vector_Mat", "gpu_GpuMat"]
+        return self.tp in big_names # or self.tp.startswith("vector")
 
     def crepr(self):
         return "ArgInfo(\"%s\", %d)" % (self.name, self.outputarg)

--- a/modules/python/src2/hdr_parser.py
+++ b/modules/python/src2/hdr_parser.py
@@ -14,7 +14,9 @@ opencv_hdr_list = [
 "../../video/include/opencv2/video/background_segm.hpp",
 "../../objdetect/include/opencv2/objdetect/objdetect.hpp",
 "../../contrib/include/opencv2/contrib/contrib.hpp",
-"../../highgui/include/opencv2/highgui/highgui.hpp"
+"../../highgui/include/opencv2/highgui/highgui.hpp",
+"../../gpu/include/opencv2/gpu/gpu.hpp",
+"../../core/include/opencv2/core/gpumat.hpp",
 ]
 
 """
@@ -207,6 +209,8 @@ class CppHeaderParser(object):
         prev_val_delta = -1
         decl = []
         for pair in ll:
+            if pair.strip() == '': # handle final comma
+                break
             pv = pair.split("=")
             if len(pv) == 1:
                 prev_val_delta += 1
@@ -406,6 +410,8 @@ class CppHeaderParser(object):
         context = top[0]
         if decl_str.startswith("static") and (context == "class" or context == "struct"):
             decl_str = decl_str[len("static"):].lstrip()
+            static_method = True
+        if context == "namespace" and top[1] != 'cv':  # HACK
             static_method = True
 
         args_begin = decl_str.find("(")

--- a/samples/python2/gpu/test.py
+++ b/samples/python2/gpu/test.py
@@ -1,0 +1,38 @@
+'''
+Simple test for GPU module
+'''
+
+import numpy as np
+import cv2
+
+def clock():
+    return cv2.getTickCount() / cv2.getTickFrequency()
+
+
+img = cv2.imread('../data/aero1.jpg')
+
+
+iter_n = 100
+
+img2 = cv2.pyrUp(img)  # warm up
+t = clock()
+for i in xrange(iter_n):
+    cv2.pyrUp(img, img2)
+print 'CPU time: %.3f s' % (clock()-t)
+
+
+d_img = cv2.gpu_GpuMat(img)
+d_img2 = cv2.gpu_pyrUp(d_img) # warm up
+t = clock()
+for i in xrange(iter_n):
+    cv2.gpu_pyrUp(d_img, d_img2)
+d_img2.download() # sync
+print 'GPU time: %.3f s' % (clock()-t)
+
+diff = np.abs(img2 - d_img2.download())
+print "max |diff| ==", diff.max()  
+
+
+cv2.imshow('diff*100', diff*100)
+cv2.imshow('d_img2', d_img2.download())
+cv2.waitKey()


### PR DESCRIPTION
Here are some quick and humble attempts to expose OpenCV GPU features to python interface.
Currently exposed:
- GpuMat creation, upload and download
- pyrUp / pyrDown

See "samples/python2/gpu/test.py" for usage example.

Issues:
- probably should put gpu stuff into gpu submodule (instead of using prefix)
- 'gen2.py' incorreclty handles functions, residing in nested namespaces (it thinks of them as class methods). Temprorary fixed it but marking such fucntions as "static methods" (search for "HACK" in 'hdr_parser.py')
