### PR TITLE
Add missing _WIN32 check in core/operations.hpp. (Bugfix #2555)

### DIFF
--- a/modules/core/include/opencv2/core/operations.hpp
+++ b/modules/core/include/opencv2/core/operations.hpp
@@ -64,7 +64,7 @@
     #endif
   #elif __GNUC__*10 + __GNUC_MINOR__ >= 42
 
-    #if !defined WIN32 && (defined __i486__ || defined __i586__ || \
+    #if !(defined WIN32 || defined _WIN32) && (defined __i486__ || defined __i586__ || \
         defined __i686__ || defined __MMX__ || defined __SSE__  || defined __ppc__)
       #define CV_XADD __sync_fetch_and_add
     #else


### PR DESCRIPTION
Fix a compilation error with MinGW gcc 4.7 with enabled C++11 support (-std=c++11).
Issue number: #2555
