### PR TITLE
Use .yml.gz format to reduce space requirement from ~260Mb to ~17Mb

### DIFF
--- a/modules/ml/test/test_save_load.cpp
+++ b/modules/ml/test/test_save_load.cpp
@@ -64,11 +64,11 @@ int CV_SLMLTest::run_test_case( int testCaseIdx )
             if( code == cvtest::TS::OK )
             {
                 get_error( testCaseIdx, CV_TEST_ERROR, &test_resps1 );
-                fname1 = tempfile();
+                fname1 = tempfile(".yml.gz");
                 save( fname1.c_str() );
                 load( fname1.c_str() );
                 get_error( testCaseIdx, CV_TEST_ERROR, &test_resps2 );
-                fname2 = tempfile();
+                fname2 = tempfile(".yml.gz");
                 save( fname2.c_str() );
             }
             else


### PR DESCRIPTION
The size of temporary files is an issue on mobile platforms.
