### PR TITLE
Increase max RMSE error for tvl1 optical flow test

### DIFF
--- a/modules/video/test/test_tvl1optflow.cpp
+++ b/modules/video/test/test_tvl1optflow.cpp
@@ -140,7 +140,7 @@ namespace
 
 TEST(Video_calcOpticalFlowDual_TVL1, Regression)
 {
-    const double MAX_RMSE = 0.01;
+    const double MAX_RMSE = 0.02;
 
     const string frame1_path = TS::ptr()->get_data_path() + "optflow/RubberWhale1.png";
     const string frame2_path = TS::ptr()->get_data_path() + "optflow/RubberWhale2.png";


### PR DESCRIPTION
Current error on ARM is about 0.0187
