### PR TITLE
Smart operators for smart Ptr

### DIFF
--- a/modules/core/include/opencv2/core/core.hpp
+++ b/modules/core/include/opencv2/core/core.hpp
@@ -1277,11 +1277,12 @@ public:
     operator _Tp* ();
     operator const _Tp*() const;
 
-    bool operator==(const Ptr<_Tp>& ptr) const;
-
     _Tp* obj; //< the object pointer.
     int* refcount; //< the associated reference counter
 };
+
+template<class T, class U> bool operator==(Ptr<T> const & a, Ptr<U> const & b);
+template<class T, class U> bool operator!=(Ptr<T> const & a, Ptr<U> const & b);
 
 
 //////////////////////// Input/Output Array Arguments /////////////////////////////////

--- a/modules/core/include/opencv2/core/operations.hpp
+++ b/modules/core/include/opencv2/core/operations.hpp
@@ -2691,10 +2691,11 @@ template<typename _Tp> template<typename _Tp2> inline const Ptr<_Tp2> Ptr<_Tp>::
     return p;
 }
 
-template<typename _Tp> inline bool Ptr<_Tp>::operator==(const Ptr<_Tp>& _ptr) const
-{
-    return refcount == _ptr.refcount;
-}
+template<class _Tp, class _Tp2> inline bool operator==(const Ptr<_Tp>& a, const Ptr<_Tp2>& b) { return a.refcount == b.refcount; }
+template<class _Tp, class _Tp2> inline bool operator!=(const Ptr<_Tp>& a, const Ptr<_Tp2>& b) { return a.refcount != b.refcount; }
+
+
+
 
 //// specializied implementations of Ptr::delete_obj() for classic OpenCV types
 

--- a/modules/core/src/persistence.cpp
+++ b/modules/core/src/persistence.cpp
@@ -5519,7 +5519,7 @@ void read( const FileNode& node, SparseMat& mat, const SparseMat& default_mat )
         return;
     }
     Ptr<CvSparseMat> m = (CvSparseMat*)cvRead((CvFileStorage*)node.fs, (CvFileNode*)*node);
-    CV_Assert(CV_IS_SPARSE_MAT(m));
+    CV_Assert(CV_IS_SPARSE_MAT(m.obj));
     SparseMat(m).copyTo(mat);
 }
 

--- a/modules/features2d/src/matchers.cpp
+++ b/modules/features2d/src/matchers.cpp
@@ -616,7 +616,7 @@ void FlannBasedMatcher::write( FileStorage& fs) const
 {
      fs << "indexParams" << "[";
 
-     if (indexParams != 0)
+     if (indexParams)
      {
          std::vector<std::string> names;
          std::vector<int> types;
@@ -667,7 +667,7 @@ void FlannBasedMatcher::write( FileStorage& fs) const
 
      fs << "]" << "searchParams" << "[";
 
-     if (searchParams != 0)
+     if (searchParams)
      {
          std::vector<std::string> names;
          std::vector<int> types;


### PR DESCRIPTION
KK:

There are a couple of remarks regarding your pull request. It would be great if you could fix them in near future:
1. Symmetrical != operator is needed.
2. Comparison with 0 is broken, but it would be nice to have it.
3. It is possible that comparison of refcounts is not the best choice. In Boost it is implemented differently, you can contact Andrey K. for more details.

Answers:
1. Added
2. Disagree 
3. No difference
