### PR TITLE
OpenCV example-tutorial1 does not work on Android emulator (Bug #2656)

### DIFF
--- a/modules/java/generator/src/java/android+JavaCameraView.java
+++ b/modules/java/generator/src/java/android+JavaCameraView.java
@@ -124,7 +124,7 @@ public class JavaCameraView extends CameraBridgeViewBase implements PreviewCallb
                     params.setPreviewSize((int)frameSize.width, (int)frameSize.height);
 
                     List<String> FocusModes = params.getSupportedFocusModes();
-                    if (FocusModes.contains(Camera.Parameters.FOCUS_MODE_CONTINUOUS_VIDEO))
+                    if (FocusModes != null && FocusModes.contains(Camera.Parameters.FOCUS_MODE_CONTINUOUS_VIDEO))
                     {
                         params.setFocusMode(Camera.Parameters.FOCUS_MODE_CONTINUOUS_VIDEO);
                     }


### PR DESCRIPTION
Problems with Android 2.3.3 (API level 10) fixed;
Android 2.2 does not work due to unsupported camera frame format (known android-2.2 emulator issue).
