### PR TITLE
Explicitly use double precision sin & cos in hough implementation

### DIFF
--- a/modules/imgproc/src/hough.cpp
+++ b/modules/imgproc/src/hough.cpp
@@ -118,8 +118,8 @@ icvHoughLinesStandard( const CvMat* img, float rho, float theta,
     float ang = 0;
     for(int n = 0; n < numangle; ang += theta, n++ )
     {
-        tabSin[n] = (float)(sin(ang) * irho);
-        tabCos[n] = (float)(cos(ang) * irho);
+        tabSin[n] = (float)(sin((double)ang) * irho);
+        tabCos[n] = (float)(cos((double)ang) * irho);
     }
 
     // stage 1. fill accumulator


### PR DESCRIPTION
On some platforms sin and cos are calculated in single precision resulting in
diversity of results.
