### PR TITLE
Removed hack from HoughLines perf test, since I hope it is fixed by pr263

### DIFF
--- a/modules/imgproc/perf/perf_houghLines.cpp
+++ b/modules/imgproc/perf/perf_houghLines.cpp
@@ -36,18 +36,5 @@ PERF_TEST_P(Image_RhoStep_ThetaStep_Threshold, HoughLines,
 
     TEST_CYCLE() HoughLines(image, lines, rhoStep, thetaStep, threshold);
 
-#ifdef WIN32
-    //FIXME: ugly fix to make sanity check pass on Win32, must be investigated, issue #2617
-    if (lines.cols == 2015)
-    {
-        lines = lines(Rect(0, 0, lines.cols - 1, lines.rows));
-        SANITY_CHECK(lines, 800.0);
-    }
-    else
-    {
-        SANITY_CHECK(lines);
-    }
-#else
     SANITY_CHECK(lines);
-#endif
 }


### PR DESCRIPTION
I suppose that we can remove this hack after the #263. More details here: http://code.opencv.org/issues/2617.
