### PR TITLE
fixed CvBoost::predict()

### DIFF
--- a/modules/ml/src/boost.cpp
+++ b/modules/ml/src/boost.cpp
@@ -1598,7 +1598,6 @@ CvBoost::predict( const CvMat* _sample, const CvMat* _missing,
 {
     float value = -FLT_MAX;
 
-    CvMat sample, missing;
     CvSeqReader reader;
     double sum = 0;
     int wstep = 0;
@@ -1648,10 +1647,15 @@ CvBoost::predict( const CvMat* _sample, const CvMat* _missing,
     const int* cmap = data->cat_map->data.i;
     const int* cofs = data->cat_ofs->data.i;
 
+    cv::Mat sample = _sample;
+    cv::Mat missing;
+    if(!_missing)
+        missing = _missing;
+
     // if need, preprocess the input vector
     if( !raw_mode )
     {
-        int step, mstep = 0;
+        int sstep, mstep = 0;
         const float* src_sample;
         const uchar* src_mask = 0;
         float* dst_sample;
@@ -1660,12 +1664,14 @@ CvBoost::predict( const CvMat* _sample, const CvMat* _missing,
         const int* vidx_abs = active_vars_abs->data.i;
         bool have_mask = _missing != 0;
 
-        cv::AutoBuffer<float> buf(var_count + (var_count+3)/4);
-        dst_sample = &buf[0];
-        dst_mask = (uchar*)&buf[var_count];
+        sample = cv::Mat(1, var_count, CV_32FC1);
+        missing = cv::Mat(1, var_count, CV_8UC1);
+
+        dst_sample = sample.ptr<float>();
+        dst_mask = missing.ptr<uchar>();
 
         src_sample = _sample->data.fl;
-        step = CV_IS_MAT_CONT(_sample->type) ? 1 : _sample->step/sizeof(src_sample[0]);
+        sstep = CV_IS_MAT_CONT(_sample->type) ? 1 : _sample->step/sizeof(src_sample[0]);
 
         if( _missing )
         {
@@ -1676,7 +1682,7 @@ CvBoost::predict( const CvMat* _sample, const CvMat* _missing,
         for( i = 0; i < var_count; i++ )
         {
             int idx = vidx[i], idx_abs = vidx_abs[i];
-            float val = src_sample[idx_abs*step];
+            float val = src_sample[idx_abs*sstep];
             int ci = vtype[idx];
             uchar m = src_mask ? src_mask[idx_abs*mstep] : (uchar)0;
 
@@ -1713,15 +1719,9 @@ CvBoost::predict( const CvMat* _sample, const CvMat* _missing,
 
             dst_sample[i] = val;
             dst_mask[i] = m;
-        }
 
-        sample = cvMat( 1, var_count, CV_32F, dst_sample );
-        _sample = &sample;
-
-        if( have_mask )
-        {
-            missing = cvMat( 1, var_count, CV_8UC1, dst_mask );
-            _missing = &missing;
+            if( !have_mask )
+                missing.release();
         }
     }
     else
@@ -1733,9 +1733,9 @@ CvBoost::predict( const CvMat* _sample, const CvMat* _missing,
     cvStartReadSeq( weak, &reader );
     cvSetSeqReaderPos( &reader, slice.start_index );
 
-    sample_data = _sample->data.fl;
+    sample_data = sample.ptr<float>();
 
-    if( !have_active_cat_vars && !_missing && !weak_responses )
+    if( !have_active_cat_vars && missing.empty() && !weak_responses )
     {
         for( i = 0; i < weak_count; i++ )
         {
@@ -1760,7 +1760,7 @@ CvBoost::predict( const CvMat* _sample, const CvMat* _missing,
     else
     {
         const int* avars = active_vars->data.i;
-        const uchar* m = _missing ? _missing->data.ptr : 0;
+        const uchar* m = !missing.empty() ? missing.ptr<uchar>() : 0;
 
         // full-featured version
         for( i = 0; i < weak_count; i++ )


### PR DESCRIPTION
Sometimes sample_data became bad because the buffer with its values was deallocated early. The path fixes this.
