### PR TITLE
Fix incorrect Mat address reconstruction on 64-bit platforms

### DIFF
--- a/modules/java/generator/src/cpp/converters.cpp
+++ b/modules/java/generator/src/cpp/converters.cpp
@@ -219,7 +219,7 @@ void Mat_to_vector_Mat(cv::Mat& mat, std::vector<cv::Mat>& v_mat)
         for(int i=0; i<mat.rows; i++)
         {
             Vec<int, 2> a = mat.at< Vec<int, 2> >(i, 0);
-            long long addr = (((long long)a[0])<<32) | a[1];
+            long long addr = (((long long)a[0])<<32) | (a[1]&0xffffffff);
             Mat& m = *( (Mat*) addr );
             v_mat.push_back(m);
         }

--- a/modules/java/generator/src/java/utils+Converters.java
+++ b/modules/java/generator/src/java/utils+Converters.java
@@ -262,7 +262,7 @@ public class Converters {
         int[] buff = new int[count * 2];
         m.get(0, 0, buff);
         for (int i = 0; i < count; i++) {
-            long addr = (((long) buff[i * 2]) << 32) | ((long) buff[i * 2 + 1]);
+            long addr = (((long) buff[i * 2]) << 32) | (((long) buff[i * 2 + 1]) & 0xffffffffL);
             mats.add(new Mat(addr));
         }
     }


### PR DESCRIPTION
This fixes random failures in Java wrappers.
