### PR TITLE
fixing java test failure on some systems

### DIFF
--- a/modules/java/android_test/src/org/opencv/test/core/TermCriteriaTest.java
+++ b/modules/java/android_test/src/org/opencv/test/core/TermCriteriaTest.java
@@ -77,7 +77,8 @@ public class TermCriteriaTest extends OpenCVTestCase {
 
     public void testToString() {
         String actual = tc2.toString();
-        String expected = "{ type: 2, maxCount: 4, epsilon: " + EPS + "}";
+        double eps = EPS;
+        String expected = "{ type: 2, maxCount: 4, epsilon: " + eps + "}";
 
         assertEquals(expected, actual);
     }


### PR DESCRIPTION
on some systems Java produces different representation for `static final double` and `double`.
