### PR TITLE
Added ostream-like cv::putText helper function

### DIFF
--- a/modules/core/src/drawing.cpp
+++ b/modules/core/src/drawing.cpp
@@ -2025,6 +2025,22 @@ image_ostream::~image_ostream()
     nextLine();
 }
 
+image_ostream::image_ostream(const image_ostream& rhs)
+    : _img(rhs._img)
+    , _org(rhs._org)
+    , _fontFace(rhs._fontFace)
+    , _fontScale(rhs._fontScale)
+    , _color(rhs._color)
+    , _thickness(rhs._thickness)
+    , _lineType(rhs._lineType)
+    , _bottomLeftOrigin(rhs._bottomLeftOrigin)
+    , _offset(0)
+    , _str(rhs._str.str())
+{
+        
+}
+    
+
 void image_ostream::nextLine()
 {
     std::string line;
@@ -2038,8 +2054,6 @@ void image_ostream::nextLine()
 
         _offset += textSize.height + baseLine;
     } while (!_str.eof());
-
-    _str = std::stringstream();
 }
 
 }

--- a/samples/cpp/drawing.cpp
+++ b/samples/cpp/drawing.cpp
@@ -162,7 +162,7 @@ int main()
     for( i = 0; i < 255; i += 1 )
     {
         image2 = image - Scalar::all(i);
-        putText(image2, cv::Point(100,100), CV_FONT_HERSHEY_COMPLEX, 1, Scalar(i, i, 255)) 
+        putText(image2, cv::Point(100,100), CV_FONT_HERSHEY_COMPLEX, 1, Scalar(i, i, 255))
                 << "cv::putText() Demo!" << std::endl 
                 << "cv::putText(...) << \"Hello\\nWorld\";" << std::endl 
                 << "You can use std::endl" << std::endl 


### PR DESCRIPTION
This commit brings an ostream-like text rendering on the cv::Mat.
Unlike existing function, a new putText funtion allows to use operator << to print
text on cv::Mat and supports newline characters. You can see the
demonstration of the new cv::putText in drawing.cpp sample.

The proposed request allows to print text on the images in the following way:

```
putText(image2, cv::Point(100,100), CV_FONT_HERSHEY_COMPLEX, 1, Scalar(i, i, 255))
    << "cv::putText() Demo!" << std::endl 
    << "cv::putText(...) << \"Hello\\nWorld\";" << std::endl 
    << "You can use std::endl" << std::endl 
    << "or even\\n symbol\nto format text" << std::endl
    << "And we support formatters:\n"
    << "std::setprecision(5)" << std::setprecision(5) << CV_PI << std::endl
    << "std::scientific " << std::scientific << CV_PI << std::endl
    << "So you can use cv::putText like regular std::cout!";
```

The result of the rendering will be:
![putTextOstream](https://f.cloud.github.com/assets/532320/82343/09a86960-63a1-11e2-8665-eee31c1a2581.png)
