### PR TITLE
Fixed performance tests, eliminated some parameters to speed up tests

### DIFF
--- a/modules/core/perf/perf_addWeighted.cpp
+++ b/modules/core/perf/perf_addWeighted.cpp
@@ -6,7 +6,7 @@ using namespace perf;
 using std::tr1::make_tuple;
 using std::tr1::get;
 
-#define TYPICAL_MAT_TYPES_ADWEIGHTED  CV_8UC1, CV_8UC4, CV_8SC1, CV_16UC1, CV_16SC1, CV_32SC1, CV_32SC4
+#define TYPICAL_MAT_TYPES_ADWEIGHTED  CV_8UC1, CV_8UC4, CV_8SC1, CV_16UC1, CV_16SC1, CV_32SC1
 #define TYPICAL_MATS_ADWEIGHTED       testing::Combine(testing::Values(szVGA, sz720p, sz1080p), testing::Values(TYPICAL_MAT_TYPES_ADWEIGHTED))
 
 PERF_TEST_P(Size_MatType, addWeighted, TYPICAL_MATS_ADWEIGHTED)

--- a/modules/core/perf/perf_arithm.cpp
+++ b/modules/core/perf/perf_arithm.cpp
@@ -6,7 +6,7 @@ using namespace perf;
 using std::tr1::make_tuple;
 using std::tr1::get;
 
-#define TYPICAL_MAT_SIZES_CORE_ARITHM   TYPICAL_MAT_SIZES
+#define TYPICAL_MAT_SIZES_CORE_ARITHM   ::szVGA, ::sz720p, ::sz1080p
 #define TYPICAL_MAT_TYPES_CORE_ARITHM   CV_8UC1, CV_8SC1, CV_16SC1, CV_16SC2, CV_16SC3, CV_16SC4, CV_8UC4, CV_32SC1, CV_32FC1
 #define TYPICAL_MATS_CORE_ARITHM        testing::Combine( testing::Values( TYPICAL_MAT_SIZES_CORE_ARITHM ), testing::Values( TYPICAL_MAT_TYPES_CORE_ARITHM ) )
 

--- a/modules/core/perf/perf_bitwise.cpp
+++ b/modules/core/perf/perf_bitwise.cpp
@@ -19,7 +19,7 @@ PERF_TEST_P(Size_MatType, bitwise_not, TYPICAL_MATS_BITW_ARITHM)
     cv::Mat c = Mat(sz, type);
 
     declare.in(a, WARMUP_RNG).out(c);
-    declare.time(100);
+    declare.iterations(200);
 
     TEST_CYCLE() cv::bitwise_not(a, c);
 

--- a/modules/core/perf/perf_compare.cpp
+++ b/modules/core/perf/perf_compare.cpp
@@ -13,7 +13,7 @@ typedef perf::TestBaseWithParam<Size_MatType_CmpType_t> Size_MatType_CmpType;
 
 PERF_TEST_P( Size_MatType_CmpType, compare,
              testing::Combine(
-                 testing::Values(TYPICAL_MAT_SIZES),
+                 testing::Values(::perf::szVGA, ::perf::sz1080p),
                  testing::Values(CV_8UC1, CV_8UC4, CV_8SC1, CV_16UC1, CV_16SC1, CV_32SC1, CV_32FC1),
                  testing::ValuesIn(CmpType::all())
                  )

--- a/modules/core/perf/perf_convertTo.cpp
+++ b/modules/core/perf/perf_convertTo.cpp
@@ -29,6 +29,7 @@ PERF_TEST_P( Size_DepthSrc_DepthDst_Channels_alpha, convertTo,
     Mat src(sz, CV_MAKETYPE(depthSrc, channels));
     randu(src, 0, 255);
     Mat dst(sz, CV_MAKETYPE(depthDst, channels));
+    declare.iterations(500);
 
     TEST_CYCLE() src.convertTo(dst, depthDst, alpha);
 

--- a/modules/core/perf/perf_norm.cpp
+++ b/modules/core/perf/perf_norm.cpp
@@ -131,7 +131,7 @@ PERF_TEST_P(Size_MatType_NormType, normalize,
 
 PERF_TEST_P(Size_MatType_NormType, normalize_mask,
             testing::Combine(
-                testing::Values(TYPICAL_MAT_SIZES),
+                testing::Values(::perf::szVGA, ::perf::sz1080p),
                 testing::Values(TYPICAL_MAT_TYPES),
                 testing::Values((int)NORM_INF, (int)NORM_L1, (int)NORM_L2)
                 )
@@ -192,6 +192,7 @@ PERF_TEST_P( Size_MatType, normalize_minmax, TYPICAL_MATS )
     Mat dst(sz, matType);
 
     declare.in(src, WARMUP_RNG).out(dst);
+    declare.time(30);
 
     TEST_CYCLE() normalize(src, dst, 20., 100., NORM_MINMAX);
 

--- a/modules/imgproc/perf/perf_blur.cpp
+++ b/modules/imgproc/perf/perf_blur.cpp
@@ -90,7 +90,7 @@ PERF_TEST_P(Size_MatType_BorderType3x3, blur3x3,
 
 PERF_TEST_P(Size_MatType_BorderType, blur16x16,
             testing::Combine(
-                testing::Values(szODD, szQVGA, szVGA, sz720p),
+                testing::Values(szVGA, sz720p),
                 testing::Values(CV_8UC1, CV_8UC4, CV_16UC1, CV_16SC1, CV_32FC1),
                 testing::ValuesIn(BorderType::all())
                 )
@@ -184,7 +184,7 @@ PERF_TEST_P(Size_MatType_BorderType, gaussianBlur5x5,
 
 PERF_TEST_P(Size_MatType_BorderType, blur5x5,
             testing::Combine(
-                testing::Values(szODD, szQVGA, szVGA, sz720p),
+                testing::Values(szVGA, sz720p),
                 testing::Values(CV_8UC1, CV_8UC4, CV_16UC1, CV_16SC1, CV_32FC1, CV_32FC3),
                 testing::ValuesIn(BorderType::all())
                 )

--- a/modules/imgproc/perf/perf_filter2d.cpp
+++ b/modules/imgproc/perf/perf_filter2d.cpp
@@ -15,7 +15,7 @@ typedef TestBaseWithParam< tr1::tuple<String, int> > Image_KernelSize;
 
 PERF_TEST_P( TestFilter2d, Filter2d,
              Combine(
-                Values( Size(320, 240), szVGA, sz720p, sz1080p ),
+                Values( Size(320, 240), sz1080p ),
                 Values( 3, 5 ),
                 ValuesIn( BorderMode::all() )
              )

--- a/modules/imgproc/perf/perf_houghLines.cpp
+++ b/modules/imgproc/perf/perf_houghLines.cpp
@@ -32,7 +32,7 @@ PERF_TEST_P(Image_RhoStep_ThetaStep_Threshold, HoughLines,
     Canny(image, image, 0, 0);
 
     Mat lines;
-    declare.time(40);
+    declare.time(60);
 
     TEST_CYCLE() HoughLines(image, lines, rhoStep, thetaStep, threshold);
 

--- a/modules/imgproc/perf/perf_integral.cpp
+++ b/modules/imgproc/perf/perf_integral.cpp
@@ -33,9 +33,9 @@ PERF_TEST_P(Size_MatType_OutMatDepth, integral,
 
 PERF_TEST_P(Size_MatType_OutMatDepth, integral_sqsum,
             testing::Combine(
-                testing::Values(TYPICAL_MAT_SIZES),
+                testing::Values(::perf::szVGA, ::perf::sz1080p),
                 testing::Values(CV_8UC1, CV_8UC4),
-                testing::Values(CV_32S, CV_32F, CV_64F)
+                testing::Values(CV_32S, CV_32F)
                 )
             )
 {
@@ -58,9 +58,9 @@ PERF_TEST_P(Size_MatType_OutMatDepth, integral_sqsum,
 
 PERF_TEST_P( Size_MatType_OutMatDepth, integral_sqsum_tilted,
              testing::Combine(
-                 testing::Values( TYPICAL_MAT_SIZES ),
+                 testing::Values( ::perf::szVGA, ::perf::szODD , ::perf::sz1080p ),
                  testing::Values( CV_8UC1, CV_8UC4 ),
-                 testing::Values( CV_32S, CV_32F, CV_64F )
+                 testing::Values( CV_32S, CV_32F )
                  )
              )
 {

--- a/modules/imgproc/perf/perf_resize.cpp
+++ b/modules/imgproc/perf/perf_resize.cpp
@@ -97,7 +97,7 @@ typedef TestBaseWithParam<tr1::tuple<MatType, Size, double> > MatInfo_Size_Scale
 PERF_TEST_P(MatInfo_Size_Scale_Area, ResizeArea,
             testing::Combine(
                 testing::Values(CV_8UC1, CV_8UC4),
-                testing::Values(szVGA, szqHD, sz720p, sz1080p),
+                testing::Values(szVGA, szqHD, sz720p),
                 testing::Values(2.4, 3.4, 1.3)
                 )
             )

--- a/modules/imgproc/perf/perf_threshold.cpp
+++ b/modules/imgproc/perf/perf_threshold.cpp
@@ -31,7 +31,7 @@ PERF_TEST_P(Size_MatType_ThreshType, threshold,
     double maxval = theRNG().uniform(1, 254);
 
     declare.in(src, WARMUP_RNG).out(dst);
-    declare.time(100);
+    declare.iterations(500);
 
     TEST_CYCLE() threshold(src, dst, thresh, maxval, threshType);
 

--- a/modules/imgproc/perf/perf_warp.cpp
+++ b/modules/imgproc/perf/perf_warp.cpp
@@ -90,12 +90,7 @@ PERF_TEST_P( TestWarpPerspective, WarpPerspective,
 
 PERF_TEST_P( TestWarpPerspectiveNear_t, WarpPerspectiveNear,
              Combine(
-                 Values( Size(176,144), Size(320,240), Size(352,288), Size(480,480),
-                         Size(640,480), Size(704,576), Size(720,408), Size(720,480),
-                         Size(720,576), Size(768,432), Size(800,448), Size(960,720),
-                         Size(1024,768), Size(1280,720), Size(1280,960), Size(1360,720),
-                         Size(1600,1200), Size(1920,1080), Size(2048,1536), Size(2592,1920),
-                         Size(2592,1944), Size(3264,2448), Size(4096,3072), Size(4208,3120) ),
+                 Values( Size(640,480), Size(1920,1080), Size(2592,1944) ),
                  ValuesIn( InterType::all() ),
                  ValuesIn( BorderMode::all() ),
                  Values( CV_8UC1, CV_8UC4 )

--- a/modules/photo/perf/perf_inpaint.cpp
+++ b/modules/photo/perf/perf_inpaint.cpp
@@ -13,7 +13,7 @@ typedef perf::TestBaseWithParam<InpaintArea_InpaintingMethod_t> InpaintArea_Inpa
 
 PERF_TEST_P(InpaintArea_InpaintingMethod, inpaint,
             testing::Combine(
-                SZ_ALL_SMALL,
+                testing::Values(::perf::szSmall24, ::perf::szSmall32, ::perf::szSmall64),
                 testing::ValuesIn(InpaintingMethod::all())
                 )
             )

--- a/modules/stitching/perf/perf_stich.cpp
+++ b/modules/stitching/perf/perf_stich.cpp
@@ -154,7 +154,7 @@ PERF_TEST_P( match, bestOf2Nearest, TEST_DETECTORS)
 
 PERF_TEST_P( matchVector, bestOf2NearestVectorFeatures, testing::Combine(
                  TEST_DETECTORS,
-                 testing::Values(2, 4, 6, 8))
+                 testing::Values(2, 4, 8))
              )
 {
     Mat img1, img1_full = imread( getDataPath("stitching/b1.png") );

--- a/modules/video/perf/perf_optflowpyrlk.cpp
+++ b/modules/video/perf/perf_optflowpyrlk.cpp
@@ -33,7 +33,7 @@ PERF_TEST_P(Path_Idx_Cn_NPoints_WSize, OpticalFlowPyrLK_full, testing::Combine(
                 testing::Range(1, 3),
                 testing::Values(1, 3, 4),
                 testing::Values(make_tuple(9, 9), make_tuple(15, 15)),
-                testing::Values(7, 11, 25)
+                testing::Values(7, 11)
                 )
             )
 {
@@ -105,7 +105,7 @@ PERF_TEST_P(Path_Idx_Cn_NPoints_WSize_Deriv, OpticalFlowPyrLK_self, testing::Com
                 testing::Range(1, 3),
                 testing::Values(1, 3, 4),
                 testing::Values(make_tuple(9, 9), make_tuple(15, 15)),
-                testing::Values(7, 11, 25),
+                testing::Values(7, 11),
                 testing::Bool()
                 )
             )


### PR DESCRIPTION
Fixed performance test failures caused by instability. Sped up time-eating performance tests by excluding some parameters. Separated Bayer color conversions into individual test.
