### PR TITLE
Fixed visualization by choosing the color appropriate to the detection score.

### DIFF
--- a/samples/c/latentsvmdetect.cpp
+++ b/samples/c/latentsvmdetect.cpp
@@ -56,11 +56,12 @@ static void detect_and_draw_objects( IplImage* image, CvLatentSvmDetector* detec
     for( i = 0; i < detections->total; i++ )
     {
         CvObjectDetection detection = *(CvObjectDetection*)cvGetSeqElem( detections, i );
+		float score         = detection.score;
         CvRect bounding_box = detection.rect;
         cvRectangle( image, cvPoint(bounding_box.x, bounding_box.y),
                      cvPoint(bounding_box.x + bounding_box.width,
                             bounding_box.y + bounding_box.height),
-                     CV_RGB(255,0,0), 3 );
+                     CV_RGB(cvRound(255.0f*score),0,0), 3 );
     }
     cvReleaseMemStorage( &storage );
 }


### PR DESCRIPTION
Fixed visualization by choosing the color appropriate to the detection
score. Previously the sample program showed all detections with the same color
disregarding the confidence. This led to the impression that the object
detection did not work at all because there are many detections with low
confidences.
