### PR TITLE
Docs: Fix invalid conversion format in example (CV_BGR2GREY -> CV_BGR2GRAY)

### DIFF
--- a/doc/user_guide/ug_mat.rst
+++ b/doc/user_guide/ug_mat.rst
@@ -144,7 +144,7 @@ A call to ``waitKey()`` starts a message passing cycle that waits for a key stro
 
     Mat img = imread("image.jpg");
     Mat grey;
-    cvtColor(img, grey, CV_BGR2GREY);
+    cvtColor(img, grey, CV_BGR2GRAY);
 
     Mat sobelx;
     Sobel(grey, sobelx, CV_32F, 1, 0);


### PR DESCRIPTION
Fix Issue #2724
http://code.opencv.org/issues/2724
