### PR TITLE
Improve error reporting of JPEG image encoder

### DIFF
--- a/modules/highgui/src/grfmt_base.cpp
+++ b/modules/highgui/src/grfmt_base.cpp
@@ -123,6 +123,15 @@ ImageEncoder BaseImageEncoder::newEncoder() const
     return ImageEncoder();
 }
 
+void BaseImageEncoder::throwOnEror() const
+{
+    if(!m_last_error.empty())
+    {
+        std::string msg = "Raw image encoder error: " + m_last_error;
+        CV_Error( CV_BadImageSize, msg.c_str() );
+    }
+}
+
 }
 
 /* End of file. */

--- a/modules/highgui/src/grfmt_base.hpp
+++ b/modules/highgui/src/grfmt_base.hpp
@@ -100,12 +100,16 @@ public:
     virtual string getDescription() const;
     virtual ImageEncoder newEncoder() const;
 
+    virtual void throwOnEror() const;
+
 protected:
     string m_description;
 
     string m_filename;
     vector<uchar>* m_buf;
     bool m_buf_supported;
+
+    string m_last_error;
 };
 
 }

--- a/modules/highgui/src/grfmt_jpeg.cpp
+++ b/modules/highgui/src/grfmt_jpeg.cpp
@@ -537,8 +537,10 @@ ImageEncoder JpegEncoder::newEncoder() const
     return new JpegEncoder;
 }
 
-bool  JpegEncoder::write( const Mat& img, const vector<int>& params )
+bool JpegEncoder::write( const Mat& img, const vector<int>& params )
 {
+    m_last_error.clear();
+
     struct fileWrapper
     {
         FILE* f;
@@ -633,6 +635,14 @@ bool  JpegEncoder::write( const Mat& img, const vector<int>& params )
     }
 
 _exit_:
+
+    if(!result)
+    {
+        char jmsg_buf[JMSG_LENGTH_MAX];
+        jerr.pub.format_message((j_common_ptr)&cinfo, jmsg_buf);
+        m_last_error = jmsg_buf;
+    }
+
     jpeg_destroy_compress( &cinfo );
 
     return result;

--- a/modules/highgui/src/loadsave.cpp
+++ b/modules/highgui/src/loadsave.cpp
@@ -426,6 +426,7 @@ bool imencode( const string& ext, InputArray _image,
     if( encoder->setDestination(buf) )
     {
         code = encoder->write(image, params);
+        encoder->throwOnEror();
         CV_Assert( code );
     }
     else
@@ -433,8 +434,11 @@ bool imencode( const string& ext, InputArray _image,
         string filename = tempfile();
         code = encoder->setDestination(filename);
         CV_Assert( code );
+
         code = encoder->write(image, params);
+        encoder->throwOnEror();
         CV_Assert( code );
+
         FILE* f = fopen( filename.c_str(), "rb" );
         CV_Assert(f != 0);
         fseek( f, 0, SEEK_END );

--- a/modules/highgui/test/test_grfmt.cpp
+++ b/modules/highgui/test/test_grfmt.cpp
@@ -282,3 +282,12 @@ TEST(Highgui_ImreadVSCvtColor, regression)
 }
 #endif
 
+#ifdef HAVE_JPEG
+TEST(Highgui_Jpeg, encode_empty)
+{
+    cv::Mat img;
+    std::vector<uchar> jpegImg;
+
+    ASSERT_THROW(cv::imencode(".jpg", img, jpegImg), cv::Exception);
+}
+#endif


### PR DESCRIPTION
OpenCV issue #2604

After this patch applied an attempt to encode empty images produces exception
saying "Raw image encoder error: Empty JPEG image (DNL not supported)"
