### PR TITLE
Resolve warning in OpenCV Library project in Eclipse (Bug #2714)

### DIFF
--- a/modules/java/android_lib/.settings/org.eclipse.jdt.core.prefs
+++ b/modules/java/android_lib/.settings/org.eclipse.jdt.core.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+org.eclipse.jdt.core.compiler.problem.unusedPrivateMember=ignore


### PR DESCRIPTION
Warning in auto generated code was suppressed by project settings. Tested on both Eclipse brunches: 3.x and 4.x.
