### PR TITLE
Check pointers before using them in var init

### DIFF
--- a/modules/calib3d/src/posit.cpp
+++ b/modules/calib3d/src/posit.cpp
@@ -119,12 +119,6 @@ static  CvStatus  icvPOSIT( CvPOSITObject *pObject, CvPoint2D32f *imagePoints,
     float diff = (float)criteria.epsilon;
     float inv_focalLength = 1 / focalLength;
 
-    /* init variables */
-    int N = pObject->N;
-    float *objectVectors = pObject->obj_vecs;
-    float *invMatrix = pObject->inv_matr;
-    float *imgVectors = pObject->img_vecs;
-
     /* Check bad arguments */
     if( imagePoints == NULL )
         return CV_NULLPTR_ERR;
@@ -142,6 +136,12 @@ static  CvStatus  icvPOSIT( CvPOSITObject *pObject, CvPoint2D32f *imagePoints,
         return CV_BADFACTOR_ERR;
     if( (criteria.type & CV_TERMCRIT_ITER) && criteria.max_iter <= 0 )
         return CV_BADFACTOR_ERR;
+
+    /* init variables */
+    int N = pObject->N;
+    float *objectVectors = pObject->obj_vecs;
+    float *invMatrix = pObject->inv_matr;
+    float *imgVectors = pObject->img_vecs;
 
     while( !converged )
     {

--- a/modules/core/src/persistence.cpp
+++ b/modules/core/src/persistence.cpp
@@ -614,10 +614,11 @@ cvGetHashedKey( CvFileStorage* fs, const char* str, int len, int create_missing 
     CvStringHashNode* node = 0;
     unsigned hashval = 0;
     int i, tab_size;
-    CvStringHash* map = fs->str_hash;
 
     if( !fs )
         return 0;
+
+    CvStringHash* map = fs->str_hash;
 
     if( len < 0 )
     {


### PR DESCRIPTION
Pointer arguments are being used to initialize vars right before the pointers are checked for NULL.  Reorder code to avoid potential crashes.
