### PR TITLE
Solve conflict between tiff.h and opencv2/core/types_c.h

### DIFF
--- a/modules/highgui/test/test_grfmt.cpp
+++ b/modules/highgui/test/test_grfmt.cpp
@@ -294,7 +294,12 @@ TEST(Highgui_Jpeg, encode_empty)
 
 
 #ifdef HAVE_TIFF
+
+// these defines are used to resolve conflict between tiff.h and opencv2/core/types_c.h
+#define uint64 uint64_hack_
+#define int64 int64_hack_
 #include "tiff.h"
+
 TEST(Highgui_Tiff, decode_tile16384x16384)
 {
     // see issue #2161


### PR DESCRIPTION
Сonflict exists between some versions of libtiff and opencv headers
