### PR TITLE
improvements in SURF

### DIFF
--- a/modules/nonfree/test/test_features2d.cpp
+++ b/modules/nonfree/test/test_features2d.cpp
@@ -1114,6 +1114,10 @@ protected:
         Mat d1, d2;
         f->operator()(img1, Mat(), kpt1, d1);
         f->operator()(img1, Mat(), kpt2, d2);
+        for( size_t i = 0; i < kpt1.size(); i++ )
+            CV_Assert(kpt1[i].response > 0 );
+        for( size_t i = 0; i < kpt2.size(); i++ )
+            CV_Assert(kpt2[i].response > 0 );
 
         vector<DMatch> matches;
         BFMatcher(NORM_L2, true).match(d1, d2, matches);
@@ -1140,5 +1144,5 @@ protected:
 };
 
 TEST(Features2d_SIFTHomographyTest, regression) { CV_DetectPlanarTest test("SIFT", 80); test.safe_run(); }
-//TEST(Features2d_SURFHomographyTest, regression) { CV_DetectPlanarTest test("SURF", 80); test.safe_run(); }
+TEST(Features2d_SURFHomographyTest, regression) { CV_DetectPlanarTest test("SURF", 80); test.safe_run(); }
 

--- a/modules/nonfree/test/test_rotation_and_scale_invariance.cpp
+++ b/modules/nonfree/test/test_rotation_and_scale_invariance.cpp
@@ -616,7 +616,7 @@ protected:
 TEST(Features2d_RotationInvariance_Detector_SURF, regression)
 {
     DetectorRotationInvarianceTest test(Algorithm::create<FeatureDetector>("Feature2D.SURF"),
-                                        0.45f,
+                                        0.44f,
                                         0.76f);
     test.safe_run();
 }


### PR DESCRIPTION
changed default parameters of SURF, restored bi-linear interpolation in SURF descriptor extractor and switched off extended descriptors. Added test for SURF homography + check for non-zero (positive) responses.

It should address #1911, #2219, #2460.

opencv_extra, branch surf_fixes contains updated surf data
