### PR TITLE
class LevMarqSparse missing in the win/vs built binaries, missing  CV_EXPORTS

### DIFF
--- a/modules/contrib/include/opencv2/contrib/contrib.hpp
+++ b/modules/contrib/include/opencv2/contrib/contrib.hpp
@@ -435,7 +435,7 @@ namespace cv
 
     typedef bool (*BundleAdjustCallback)(int iteration, double norm_error, void* user_data);
 
-    class LevMarqSparse {
+    class CV_EXPORTS LevMarqSparse {
     public:
         LevMarqSparse();
         LevMarqSparse(int npoints, // number of points


### PR DESCRIPTION
class LevMarqSparse is not tagged CV_EXPORTS, 
so the contrib module,  built the on win using vs won't contain that symbol,
trying to create an instance of LevMarqSparse will lead to a 'undefined symbol' err, because it did not make it into the library.
