### PR TITLE
Use gtest assertions in cascade test

### DIFF
--- a/modules/objdetect/test/test_cascadeandhog.cpp
+++ b/modules/objdetect/test/test_cascadeandhog.cpp
@@ -363,22 +363,20 @@ int CV_DetectorTest::validate( int detectorIdx, vector<vector<Rect> >& objects )
         }
         noPair += (int)count_if( map.begin(), map.end(), isZero );
         totalNoPair += noPair;
-        if( noPair > cvRound(valRects.size()*eps.noPair)+1 )
+
+        EXPECT_LE(noPair, cvRound(valRects.size()*eps.noPair)+1)
+            << "detector " << detectorNames[detectorIdx] << " has overrated count of rectangles without pair on "
+            << imageFilenames[imageIdx] << " image";
+
+        if (::testing::Test::HasFailure())
             break;
     }
-    if( imageIdx < (int)imageFilenames.size() )
-    {
-        char msg[500];
-        sprintf( msg, "detector %s has overrated count of rectangles without pair on %s-image\n",
-            detectorNames[detectorIdx].c_str(), imageFilenames[imageIdx].c_str() );
-        ts->printf( cvtest::TS::LOG, msg );
+
+    EXPECT_LE(totalNoPair, cvRound(totalValRectCount*eps./*total*/noPair)+1)
+        << "detector " << detectorNames[detectorIdx] << " has overrated count of rectangles without pair on all images set";
+
+    if (::testing::Test::HasFailure())
         return cvtest::TS::FAIL_BAD_ACCURACY;
-    }
-    if ( totalNoPair > cvRound(totalValRectCount*eps./*total*/noPair)+1 )
-    {
-        ts->printf( cvtest::TS::LOG, "overrated count of rectangles without pair on all images set" );
-        return cvtest::TS::FAIL_BAD_ACCURACY;
-    }
 
     return cvtest::TS::OK;
 }


### PR DESCRIPTION
This simplifies test debugging a lot.

Also there is an associated patch for opencv_extra which is needed to make cascade test pass in all our Android configurations.
