### PR TITLE
Make Python module's cv.QueryFrame release the GIL

### DIFF
--- a/modules/python/src2/api
+++ b/modules/python/src2/api
@@ -1035,16 +1035,6 @@ HoughLines2 CvSeq*
   int threshold
   double param1 0
   double param2 0
-HoughCircles
-  CvArr image
-  CvMat circle_storage
-  int method
-  double dp
-  double min_dist
-  double param1 100
-  double param2 100
-  int min_radius 0
-  int max_radius 0
 DistTransform
   CvArr src
   CvArr dst
@@ -1765,6 +1755,16 @@ GetMinMaxHistValue min_value,max_value,min_idx,max_idx /doconly
   CvScalar max_value /O
   ints min_idx /O
   ints max_idx /O
+HoughCircles /doconly
+  CvArr image
+  CvMat circle_storage
+  int method
+  double dp
+  double min_dist
+  double param1 100
+  double param2 100
+  int min_radius 0
+  int max_radius 0
 InitLineIterator line_iterator /doconly
   CvArr image
   CvPoint pt1

--- a/modules/python/src2/cv2.cv.hpp
+++ b/modules/python/src2/cv2.cv.hpp
@@ -2610,6 +2610,38 @@ static PyObject *pycvQueryFrame(PyObject *self, PyObject *args)
   return FROM_ROIplImagePTR(r);
 }
 
+static PyObject *pycvHoughCircles(PyObject *self, PyObject *args, PyObject *kw)
+{
+  CvArr* image;
+  PyObject *pyobj_image = NULL;
+  CvMat* circle_storage;
+  PyObject *pyobj_circle_storage = NULL;
+  int method;
+  double dp;
+  double min_dist;
+  double param1 = 100;
+  double param2 = 100;
+  int min_radius = 0;
+  int max_radius = 0;
+
+  const char *keywords[] = { "image", "circle_storage", "method", "dp", "min_dist", "param1", "param2", "min_radius", "max_radius", NULL };
+  if (!PyArg_ParseTupleAndKeywords(args, kw, "OOidd|ddii", (char**)keywords, &pyobj_image, &pyobj_circle_storage, &method, &dp, &min_dist, &param1, &param2, &min_radius, &max_radius))
+    return NULL;
+  if (!convert_to_CvArr(pyobj_image, &image, "image")) return NULL;
+  if (!convert_to_CvMat(pyobj_circle_storage, &circle_storage, "circle_storage")) return NULL;
+  Py_INCREF(pyobj_image);
+  Py_INCREF(pyobj_circle_storage);
+
+  Py_BEGIN_ALLOW_THREADS
+  cvHoughCircles(image, circle_storage, method, dp, min_dist, param1, param2, min_radius, max_radius);
+  Py_END_ALLOW_THREADS
+
+  Py_DECREF(pyobj_circle_storage);
+  Py_DECREF(pyobj_image);
+
+  Py_RETURN_NONE;
+}
+
 static PyObject *pycvWaitKey(PyObject *self, PyObject *args, PyObject *kw)
 {
   int delay = 0;


### PR DESCRIPTION
Many functions in the Python module currently keep the GIL locked whilst operating, including QueryFrame which waits until the camera can take a picture.

I modified the opencv Python module to make sure that cv.QueryFrame releases the GIL so other threads can run while the camera is being queried.
