### PR TITLE
Issue in NativeCameraView and JavaCameraView fixed.

### DIFF
--- a/modules/java/generator/src/java/android+JavaCameraView.java
+++ b/modules/java/generator/src/java/android+JavaCameraView.java
@@ -198,7 +198,7 @@ public class JavaCameraView extends CameraBridgeViewBase implements PreviewCallb
          */
         /* First step - initialize camera connection */
         Log.d(TAG, "Connecting to camera");
-        if (!initializeCamera(getWidth(), getHeight()))
+        if (!initializeCamera(width, height))
             return false;
 
         /* now we can start update thread */

--- a/modules/java/generator/src/java/android+NativeCameraView.java
+++ b/modules/java/generator/src/java/android+NativeCameraView.java
@@ -37,7 +37,7 @@ public class NativeCameraView extends CameraBridgeViewBase {
          * 2. We need to start thread which will be getting frames
          */
         /* First step - initialize camera connection */
-        if (!initializeCamera(getWidth(), getHeight()))
+        if (!initializeCamera(width, height))
             return false;
 
         /* now we can start update thread */


### PR DESCRIPTION
In previous version getWidth() and getHeight() values were used instead method parameters.
