### PR TITLE
#2790 Added a test for cv::saturate_cast

### DIFF
--- a/modules/core/test/test_misc.cpp
+++ b/modules/core/test/test_misc.cpp
@@ -40,3 +40,11 @@ TEST(Core_OutputArraySreate, _1997)
 
     ASSERT_NO_THROW(local::create( mat(Rect(Point(), submatSize)), submatSize, mat.type() ));
 }
+
+TEST(Core_SaturateCast, NegativeNotClipped)
+{
+    double d = -1.0;
+    unsigned int val = cv::saturate_cast<unsigned int>(d);
+
+    ASSERT_EQ(0xffffffff, val);
+}


### PR DESCRIPTION
It documents that cv::saturate_cast shouldn't clip negative numbers while casting to uint. Don't know why, but want to have test for this behavior.
