### PR TITLE
Minor fix of reST documentation

### DIFF
--- a/modules/imgproc/doc/filtering.rst
+++ b/modules/imgproc/doc/filtering.rst
@@ -487,6 +487,8 @@ Blurs an image using the box filter.
 
     :param dst: output image of the same size and type as ``src``.
 
+    :param ddepth: the output image depth (-1 to use ``src.depth()``).
+
     :param ksize: blurring kernel size.
 
     :param anchor: anchor point; default value ``Point(-1,-1)`` means that the anchor is at the kernel center.


### PR DESCRIPTION
add description for `ddepth` parameter of `cv::boxFilter` function

fixes [bug #2709](http://code.opencv.org/issues/2709)
