### PR TITLE
Python wrapper "predict_all" in CvSVM class does not appear in the documentation

### DIFF
--- a/modules/ml/doc/support_vector_machines.rst
+++ b/modules/ml/doc/support_vector_machines.rst
@@ -232,6 +232,8 @@ Predicts the response for input sample(s).
 
 .. ocv:pyfunction:: cv2.SVM.predict(sample[, returnDFVal]) -> retval
 
+.. ocv:pyfunction:: cv2.SVM.predict_all(samples[, results]) -> results
+
     :param sample: Input sample for prediction.
 
     :param samples: Input samples for prediction.


### PR DESCRIPTION
The OpenCV source code defines a wrapper function for predict( cv::InputArray samples, cv::OutputArray results ) named as "predict_all". However, this function does not appear in the documentation: http://docs.opencv.org/2.4.4-beta/modules/ml/doc/support_vector_machines.html?highlight=svm#cvsvm-predict

I copied the pydocstring and added it to modules/ml/doc/support_vector_machines.rst
