### PR TITLE
allows building with -std=c++11 under G++

### DIFF
--- a/modules/softcascade/src/_random.hpp
+++ b/modules/softcascade/src/_random.hpp
@@ -67,7 +67,13 @@ namespace cv { namespace softcascade { namespace internal
 struct Random
 {
     typedef std::mt19937 engine;
+// True if we're using C++11.
+#if __cplusplus >= 201103L
+    // C++11 removes uniform_int.
+    typedef std::uniform_int_distribution<int> uniform;
+#else
     typedef std::uniform_int<int> uniform;
+#endif
 };
 }}}
 

--- a/modules/softcascade/src/integral_channel_builder.cpp
+++ b/modules/softcascade/src/integral_channel_builder.cpp
@@ -233,8 +233,22 @@ void ChannelFeaturePool::fill(int desired)
         int x = xRand(eng);
         int y = yRand(eng);
 
+#if __cplusplus >= 201103L
+        // The interface changed slightly going from uniform_int to
+        // uniform_int_distribution. See this page to understand
+        // the old behavior:
+        // http://www.boost.org/doc/libs/1_47_0/boost/random/uniform_int.hpp
+        int w = 1 + wRand(
+	  eng,
+          // This extra "- 1" appears to be necessary, based on the Boost docs.
+	  Random::uniform::param_type(0, (model.width  - x - 1) - 1));
+        int h = 1 + hRand(
+	  eng,
+	  Random::uniform::param_type(0, (model.height  - y - 1) - 1));
+#else
         int w = 1 + wRand(eng, model.width  - x - 1);
         int h = 1 + hRand(eng, model.height - y - 1);
+#endif
 
         CV_Assert(w > 0);
         CV_Assert(h > 0);


### PR DESCRIPTION
Fixes this bug: http://answers.opencv.org/question/7913/building-opencv-with-c11/
