### PR TITLE
Enable custom oclMat

### DIFF
--- a/modules/ocl/include/opencv2/ocl/matrix_operations.hpp
+++ b/modules/ocl/include/opencv2/ocl/matrix_operations.hpp
@@ -78,23 +78,36 @@ namespace cv
         ////////////////////////////////////////////////////////////////////////
         //////////////////////////////// oclMat ////////////////////////////////
         ////////////////////////////////////////////////////////////////////////
+ 
+       inline oclMat::oclMat(int _rw, int _mem) 
+            : flags(0), rows(0), cols(0), step(0), 
+              data(0), refcount(0), datastart(0), dataend(0), 
+              offset(0), wholerows(0), wholecols(0), rw_type(_rw), mem_type(_mem) 
+        {
+        }
 
-        inline oclMat::oclMat() : flags(0), rows(0), cols(0), step(0), data(0), refcount(0), datastart(0), dataend(0), offset(0), wholerows(0), wholecols(0) {}
-
-        inline oclMat::oclMat(int _rows, int _cols, int _type) : flags(0), rows(0), cols(0), step(0), data(0), refcount(0), datastart(0), dataend(0), offset(0), wholerows(0), wholecols(0)
+        inline oclMat::oclMat(int _rows, int _cols, int _type, int _rw, int _mem) 
+            : flags(0), rows(0), cols(0), step(0), 
+              data(0), refcount(0), datastart(0), dataend(0),
+              offset(0), wholerows(0), wholecols(0), rw_type(_rw), mem_type(_mem) 
         {
             if( _rows > 0 && _cols > 0 )
                 create( _rows, _cols, _type );
         }
 
-        inline oclMat::oclMat(Size _size, int _type) : flags(0), rows(0), cols(0), step(0), data(0), refcount(0), datastart(0), dataend(0), offset(0), wholerows(0), wholecols(0)
+        inline oclMat::oclMat(Size _size, int _type, int _rw, int _mem) 
+            : flags(0), rows(0), cols(0), step(0), 
+              data(0), refcount(0), datastart(0), dataend(0), 
+              offset(0), wholerows(0), wholecols(0), rw_type(_rw), mem_type(_mem)
         {
             if( _size.height > 0 && _size.width > 0 )
                 create( _size.height, _size.width, _type );
         }
 
-        inline oclMat::oclMat(int _rows, int _cols, int _type, const Scalar &_s)
-            : flags(0), rows(0), cols(0), step(0), data(0), refcount(0), datastart(0), dataend(0), offset(0), wholerows(0), wholecols(0)
+        inline oclMat::oclMat(int _rows, int _cols, int _type, const Scalar &_s, int _rw, int _mem)
+            : flags(0), rows(0), cols(0), step(0), 
+              data(0), refcount(0), datastart(0), dataend(0), 
+              offset(0), wholerows(0), wholecols(0), rw_type(_rw), mem_type(_mem)
         {
             if(_rows > 0 && _cols > 0)
             {
@@ -103,8 +116,10 @@ namespace cv
             }
         }
 
-        inline oclMat::oclMat(Size _size, int _type, const Scalar &_s)
-            : flags(0), rows(0), cols(0), step(0), data(0), refcount(0), datastart(0), dataend(0), offset(0), wholerows(0), wholecols(0)
+        inline oclMat::oclMat(Size _size, int _type, const Scalar &_s, int _rw, int _mem)
+            : flags(0), rows(0), cols(0), step(0), 
+              data(0), refcount(0), datastart(0), dataend(0), 
+              offset(0), wholerows(0), wholecols(0), rw_type(_rw), mem_type(_mem)
         {
             if( _size.height > 0 && _size.width > 0 )
             {
@@ -115,67 +130,40 @@ namespace cv
 
         inline oclMat::oclMat(const oclMat &m)
             : flags(m.flags), rows(m.rows), cols(m.cols), step(m.step), data(m.data),
-              refcount(m.refcount), datastart(m.datastart), dataend(m.dataend), clCxt(m.clCxt), offset(m.offset), wholerows(m.wholerows), wholecols(m.wholecols)
+              refcount(m.refcount), datastart(m.datastart), dataend(m.dataend), 
+              clCxt(m.clCxt), offset(m.offset), wholerows(m.wholerows), wholecols(m.wholecols),
+              rw_type(m.rw_type), mem_type(m.mem_type)
         {
             if( refcount )
                 CV_XADD(refcount, 1);
         }
 
-        inline oclMat::oclMat(int _rows, int _cols, int _type, void *_data, size_t _step)
+        inline oclMat::oclMat(int _rows, int _cols, int _type, void *_data, size_t _step, int _rw, int _mem)
             : flags(0), rows(0), cols(0), step(0), data(0), refcount(0),
-              datastart(0), dataend(0), offset(0), wholerows(0), wholecols(0)
+              datastart(0), dataend(0), offset(0), wholerows(0), wholecols(0),
+              rw_type(_rw), mem_type(_mem)  
         {
             cv::Mat m(_rows, _cols, _type, _data, _step);
             upload(m);
-            //size_t minstep = cols * elemSize();
-            //if( step == Mat::AUTO_STEP )
-            //{
-            //    step = minstep;
-            //    flags |= Mat::CONTINUOUS_FLAG;
-            //}
-            //else
-            //{
-            //    if( rows == 1 ) step = minstep;
-            //    CV_DbgAssert( step >= minstep );
-            //    flags |= step == minstep ? Mat::CONTINUOUS_FLAG : 0;
-            //}
-            //dataend += step * (rows - 1) + minstep;
         }
 
-        inline oclMat::oclMat(Size _size, int _type, void *_data, size_t _step)
+        inline oclMat::oclMat(Size _size, int _type, void *_data, size_t _step, int _rw, int _mem)
             : flags(0), rows(0), cols(0),
               step(0), data(0), refcount(0),
-              datastart(0), dataend(0), offset(0), wholerows(0), wholecols(0)
+              datastart(0), dataend(0), offset(0), wholerows(0), wholecols(0),
+              rw_type(_rw), mem_type(_mem)
         {
             cv::Mat m(_size, _type, _data, _step);
             upload(m);
-            //size_t minstep = cols * elemSize();
-            //if( step == Mat::AUTO_STEP )
-            //{
-            //    step = minstep;
-            //    flags |= Mat::CONTINUOUS_FLAG;
-            //}
-            //else
-            //{
-            //    if( rows == 1 ) step = minstep;
-            //    CV_DbgAssert( step >= minstep );
-            //    flags |= step == minstep ? Mat::CONTINUOUS_FLAG : 0;
-            //}
-            //dataend += step * (rows - 1) + minstep;
         }
 
 
-        inline oclMat::oclMat(const oclMat &m, const Range &rRange, const Range &cRange)
+        inline oclMat::oclMat(const oclMat &m, const Range &rRange, const Range &cRange) 
+            : flags(m.flags), step(m.step), data(m.data), refcount(m.refcount),
+              datastart(m.datastart), dataend(m.dataend), offset(m.offset),
+              wholerows(m.wholerows), wholecols(m.wholecols),
+              rw_type(m.rw_type), mem_type(m.mem_type)
         {
-            flags = m.flags;
-            step = m.step;
-            refcount = m.refcount;
-            data = m.data;
-            datastart = m.datastart;
-            dataend = m.dataend;
-            wholerows = m.wholerows;
-            wholecols = m.wholecols;
-            offset = m.offset;
             if( rRange == Range::all() )
                 rows = m.rows;
             else
@@ -207,7 +195,9 @@ namespace cv
         inline oclMat::oclMat(const oclMat &m, const Rect &roi)
             : flags(m.flags), rows(roi.height), cols(roi.width),
               step(m.step), data(m.data), refcount(m.refcount),
-              datastart(m.datastart), dataend(m.dataend), clCxt(m.clCxt), offset(m.offset), wholerows(m.wholerows), wholecols(m.wholecols)
+              datastart(m.datastart), dataend(m.dataend), clCxt(m.clCxt), 
+              offset(m.offset), wholerows(m.wholerows), wholecols(m.wholecols),
+              rw_type(m.rw_type), mem_type(m.mem_type)
         {
             flags &= roi.width < m.cols ? ~Mat::CONTINUOUS_FLAG : -1;
             offset += roi.y * step + roi.x * elemSize();
@@ -219,8 +209,10 @@ namespace cv
                 rows = cols = 0;
         }
 
-        inline oclMat::oclMat(const Mat &m)
-            : flags(0), rows(0), cols(0), step(0), data(0), refcount(0), datastart(0), dataend(0) , offset(0), wholerows(0), wholecols(0)
+        inline oclMat::oclMat(const Mat &m, int _rw, int _mem)
+            : flags(0), rows(0), cols(0), step(0), data(0), refcount(0), 
+              datastart(0), dataend(0) , offset(0), wholerows(0), wholecols(0),
+              rw_type(_rw), mem_type(_mem)
         {
             //clCxt = Context::getContext();
             upload(m);
@@ -250,6 +242,8 @@ namespace cv
                 wholerows = m.wholerows;
                 wholecols = m.wholecols;
                 refcount = m.refcount;
+                rw_type = m.rw_type;
+                mem_type = m.mem_type;
             }
             return *this;
         }
@@ -317,7 +311,7 @@ namespace cv
 
         inline oclMat oclMat::clone() const
         {
-            oclMat m;
+            oclMat m(rw_type, mem_type);
             copyTo(m);
             return m;
         }
@@ -358,6 +352,8 @@ namespace cv
             std::swap( clCxt,  b.clCxt );
             std::swap( wholerows, b.wholerows );
             std::swap( wholecols, b.wholecols );
+            std::swap( rw_type, b.rw_type);
+            std::swap( mem_type, b.mem_type);
         }
 
         inline void oclMat::locateROI( Size &wholeSize, Point &ofs ) const
@@ -486,7 +482,7 @@ namespace cv
 
         inline oclMat oclMat::t() const
         {
-            oclMat tmp;
+            oclMat tmp(rw_type, mem_type);
             transpose(*this, tmp);
             return tmp;
         }

--- a/modules/ocl/include/opencv2/ocl/ocl.hpp
+++ b/modules/ocl/include/opencv2/ocl/ocl.hpp
@@ -59,13 +59,29 @@ namespace cv
         using std::auto_ptr;
         enum
         {
-            CVCL_DEVICE_TYPE_DEFAULT     = (1 << 0),
-            CVCL_DEVICE_TYPE_CPU         = (1 << 1),
-            CVCL_DEVICE_TYPE_GPU         = (1 << 2),
-            CVCL_DEVICE_TYPE_ACCELERATOR = (1 << 3),
-            //CVCL_DEVICE_TYPE_CUSTOM      = (1 << 4)
-            CVCL_DEVICE_TYPE_ALL         = 0xFFFFFFFF
+            CVCL_DEVICE_TYPE_DEFAULT = 0,
+            CVCL_DEVICE_TYPE_CPU,
+            CVCL_DEVICE_TYPE_GPU,
+            CVCL_DEVICE_TYPE_ACCELERATOR,
+            CVCL_DEVICE_TYPE_ALL
         };
+
+        enum 
+        {
+            DEVICE_MEM_R_W = 0, 
+            DEVICE_MEM_R_ONLY, 
+            DEVICE_MEM_W_ONLY
+        };
+ 
+        enum 
+        { 
+            DEVICE_MEM_DEFAULT = 0, 
+            DEVICE_MEM_AHP,         //alloc host pointer
+            DEVICE_MEM_UHP,         //use host pointer
+            DEVICE_MEM_CHP,         //copy host pointer
+            DEVICE_MEM_PM           //persistent memory
+        };
+
         //this class contains ocl runtime information
         class CV_EXPORTS Info
         {
@@ -89,8 +105,17 @@ namespace cv
         CV_EXPORTS int getDevice(std::vector<Info> &oclinfo, int devicetype = CVCL_DEVICE_TYPE_GPU);
 
         //set device you want to use, optional function after getDevice be called
-        //the devnum is the index of the selected device in DeviceName vector of INfo
+        //the devnum is the index of the selected device in DeviceName vector of Info
         CV_EXPORTS void setDevice(Info &oclinfo, int devnum = 0);
+
+        //get the default device memory and read/write type
+        //return 1 if unified memory system supported, otherwise return 0
+        CV_EXPORTS int getDevMemType(int& rw_type, int& mem_type);
+
+        //set the default device memory and read/write type, 
+        //the newly generated oclMat will all use this type unless you specify them
+        //return -1 if the target type is unsupported, otherwise return 0
+        CV_EXPORTS int setDevMemType(int rw_type, int mem_type);
 
         //optional function, if you want save opencl binary kernel to the file, set its path
         CV_EXPORTS  void setBinpath(const char *path);
@@ -150,18 +175,37 @@ namespace cv
         public:
             //! default constructor
             oclMat();
+            oclMat(int rw_type, int mem_type);
+
             //! constructs oclMatrix of the specified size and type (_type is CV_8UC1, CV_64FC3, CV_32SC(12) etc.)
             oclMat(int rows, int cols, int type);
+            oclMat(int rows, int cols, int type, 
+                   int rw_type, int mem_type);
+
             oclMat(Size size, int type);
+            oclMat(Size size, int type, 
+                   int rw_type, int mem_type);
+
             //! constucts oclMatrix and fills it with the specified value _s.
             oclMat(int rows, int cols, int type, const Scalar &s);
+            oclMat(int rows, int cols, int type, const Scalar &s, 
+                   int rw_type, int mem_type);
+
             oclMat(Size size, int type, const Scalar &s);
+            oclMat(Size size, int type, const Scalar &s, 
+                   int rw_type, int mem_type);
+
             //! copy constructor
             oclMat(const oclMat &m);
 
             //! constructor for oclMatrix headers pointing to user-allocated data
             oclMat(int rows, int cols, int type, void *data, size_t step = Mat::AUTO_STEP);
+            oclMat(int rows, int cols, int type, void *data, size_t step,
+                   int rw_type, int mem_type);
+
             oclMat(Size size, int type, void *data, size_t step = Mat::AUTO_STEP);
+            oclMat(Size size, int type, void *data, size_t step, 
+                   int rw_type, int mem_type);
 
             //! creates a matrix header for a part of the bigger matrix
             oclMat(const oclMat &m, const Range &rowRange, const Range &colRange);
@@ -169,6 +213,8 @@ namespace cv
 
             //! builds oclMat from Mat. Perfom blocking upload to device.
             explicit oclMat (const Mat &m);
+            explicit oclMat (const Mat &m,
+                             int rw_type, int mem_type);
 
             //! destructor - calls release()
             ~oclMat();
@@ -319,6 +365,8 @@ namespace cv
             //add wholerows and wholecols for the whole matrix, datastart and dataend are no longer used
             int wholerows;
             int wholecols;
+            int rw_type;
+            int mem_type;
         };
 
 

--- a/modules/ocl/src/precomp.hpp
+++ b/modules/ocl/src/precomp.hpp
@@ -94,7 +94,7 @@ namespace cv
     {
         ///////////////////////////OpenCL call wrappers////////////////////////////
         void openCLMallocPitch(Context *clCxt, void **dev_ptr, size_t *pitch,
-                               size_t widthInBytes, size_t height);
+                               size_t widthInBytes, size_t height, int rw_type, int mem_type);
         void openCLMemcpy2D(Context *clCxt, void *dst, size_t dpitch,
                             const void *src, size_t spitch,
                             size_t width, size_t height, enum openCLMemcpyKind kind, int channels = -1);
@@ -143,6 +143,7 @@ namespace cv
             //extra options to recognize vendor specific fp64 extensions
             char extra_options[512];
             string Binpath;
+            int unified_memory; //1 means integrated GPU, otherwise this value is 0
         };
     }
 }


### PR DESCRIPTION
The added constructors enable user to specify custom R/W type or device memory type when creating oclMat. There's also interfaces for global settings to all R/W and device memory type for default constructors.
