### PR TITLE
Update cmake/templates/OpenCVConfig.cmake.in

### DIFF
--- a/cmake/templates/OpenCVConfig.cmake.in
+++ b/cmake/templates/OpenCVConfig.cmake.in
@@ -81,7 +81,6 @@ set(OpenCV_HAVE_ANDROID_CAMERA @HAVE_opencv_androidcamera@)
 
 # Provide the include directories to the caller
 set(OpenCV_INCLUDE_DIRS @OpenCV_INCLUDE_DIRS_CONFIGCMAKE@)
-include_directories(${OpenCV_INCLUDE_DIRS})
 
 # ======================================================
 # Link directories to add to the user project:


### PR DESCRIPTION
find_package(OpenCV) should not include_directories by default, that is not standard afaik. Plus that creates problems when creating the ROS package :)
