### PR TITLE
fix MSC warning w.r.t. unnecessary reinterpret_cast<>

### DIFF
--- a/modules/core/include/opencv2/core/operations.hpp
+++ b/modules/core/include/opencv2/core/operations.hpp
@@ -684,7 +684,7 @@ static inline
 Scalar operator * (const Matx<double, 4, 4>& a, const Scalar& b)
 {
     Matx<double, 4, 1> c(a, b, Matx_MatMulOp());
-    return reinterpret_cast<const Scalar&>(c);
+    return static_cast<const Scalar&>(c);
 }
 
 


### PR DESCRIPTION
Don't use reinterpret_cast<>s where static_cast<> suffices. This triggers warning C4946 in MS compilers (see http://msdn.microsoft.com/en-us/library/y775w13y.aspx).  I am not sure whether there are more occurences of this problem (maybe the warning only appears upon instantiation of the templates).

Background: This let our MeVisLab builds fail because we let warnings count as errors in some parts of our repository, and this is from an installed header file that is included in such a project.
