### PR TITLE
Bugfix reading/writing tiled tiff images

### DIFF
--- a/3rdparty/libtiff/tif_getimage.c
+++ b/3rdparty/libtiff/tif_getimage.c
@@ -2850,7 +2850,7 @@ TIFFReadRGBATile(TIFF* tif, uint32 col, uint32 row, uint32 * raster)
     }
 
     for( i_row = read_ysize; i_row < tile_ysize; i_row++ ) {
-        _TIFFmemset( raster + (tile_ysize - i_row - 1) * tile_xsize,
+        _TIFFmemset( raster + i_row * tile_xsize,
                      0, sizeof(uint32) * tile_xsize );
     }
 

--- a/modules/highgui/src/grfmt_tiff.cpp
+++ b/modules/highgui/src/grfmt_tiff.cpp
@@ -248,11 +248,11 @@ bool  TiffDecoder::readData( Mat& img )
 
                             for( i = 0; i < tile_height; i++ )
                                 if( color )
-                                    icvCvt_BGRA2BGR_8u_C4C3R( buffer + i*tile_width*4, 0,
+                                    icvCvt_BGRA2BGR_8u_C4C3R( buffer + i*tile_width0*4, 0,
                                                              data + x*3 + img.step*(tile_height - i - 1), 0,
                                                              cvSize(tile_width,1), 2 );
                                 else
-                                    icvCvt_BGRA2Gray_8u_C4C1R( buffer + i*tile_width*4, 0,
+                                    icvCvt_BGRA2Gray_8u_C4C1R( buffer + i*tile_width0*4, 0,
                                                               data + x + img.step*(tile_height - i - 1), 0,
                                                               cvSize(tile_width,1), 2 );
                             break;


### PR DESCRIPTION
We found a problem reading and writing tiled tiff images when the width or height is not multiple of the tile width / height.

I think both the problem and our solution are easy to spot from the source code, but if there is any doubt, feel free to contact me.

Thanks!
