### PR TITLE
SVD computation does not converge with float data types or may take a long time

### DIFF
--- a/modules/core/src/lapack.cpp
+++ b/modules/core/src/lapack.cpp
@@ -536,7 +536,7 @@ JacobiSVDImpl_(_Tp* At, size_t astep, _Tp* _W, _Tp* Vt, size_t vstep, int m, int
     VBLAS<_Tp> vblas;
     AutoBuffer<double> Wbuf(n);
     double* W = Wbuf;
-    _Tp eps = DBL_EPSILON*10;
+     _Tp eps = std::numeric_limits<_Tp>::epsilon()*10;
     int i, j, k, iter, max_iter = std::max(m, 30);
     _Tp c, s;
     double sd;


### PR DESCRIPTION
Precision for SVD was hardcoded for double computation. Trying to perform SVD with a matrix of floats causes it to take a long long time. Setting precision based on type (lower precision for floats) solves this issue. This is the way it was back in OpenCV 2.3.1 and for some reason had been changed in OpenCV 2.4 and broke some real time code that needed SVD computation using floats instead of doubles.
