### PR TITLE
Bugfix to potential inaccuracy in function:polyfit

### DIFF
--- a/modules/contrib/src/polyfit.cpp
+++ b/modules/contrib/src/polyfit.cpp
@@ -90,6 +90,6 @@ void cv::polyfit(const Mat& src_x, const Mat& src_y, Mat& dst, int order, bool o
     
     Mat W = temp3*srcY;
     if (!outDoublePrecision)
-	W.convertTo(W, CV_32F);
+        W.convertTo(W, CV_32F);
     W.copyTo(dst);
 }


### PR DESCRIPTION
1.Modify the default datatype(CV_32F) to CV_64F.
2.Re-write the generation of X matrix,reducing the times of multiplication.
3.Add a bool argument to control output datatype(float or double)
The problem has been reported at http://code.opencv.org/issues/2887
