### PR TITLE
Fixing segfault for near-zero-sized ellipses

### DIFF
--- a/modules/core/src/drawing.cpp
+++ b/modules/core/src/drawing.cpp
@@ -890,8 +890,10 @@ void ellipse2Poly( Point center, Size axes, int angle,
             pts.push_back(pt);
     }
 
-    if( pts.size() < 2 )
-        pts.push_back(pts[0]);
+    // If there are no points, it's a zero-size polygon
+    if( pts.size() < 2) {
+        pts.assign(2,center);
+    }
 }
 
 


### PR DESCRIPTION
Sometimes, `ellipse2Poly()` can be called with an ellipse of near-zero size. Currently, if this happens, no points are added to the polygon, and so the following line causes a segmentation fault:

``` c++
if( pts.size() < 2 )
    pts.push_back(pts[0]);
```

This patch replaces this unsafe code which makes any no-point or one-point polygon simply a zero-length line which goes from the center point to the center point. 
