### PR TITLE
Fixed compatibility issues with libavcodec > 53.25.0

### DIFF
--- a/modules/highgui/src/cap_ffmpeg_impl.hpp
+++ b/modules/highgui/src/cap_ffmpeg_impl.hpp
@@ -1021,7 +1021,11 @@ static const char * icvFFMPEGErrStr(int err)
 
 /* function internal to FFMPEG (libavformat/riff.c) to lookup codec id by fourcc tag*/
 extern "C" {
+#if LIBAVCODEC_BUILD >= CALC_FFMPEG_VERSION(54,25,0)
+    enum AVCodecID codec_get_bmp_id(unsigned int tag);
+#else
     enum CodecID codec_get_bmp_id(unsigned int tag);
+#endif
 }
 
 void CvVideoWriter_FFMPEG::init()
@@ -1073,7 +1077,11 @@ static AVFrame * icv_alloc_picture_FFMPEG(int pix_fmt, int width, int height, bo
 
 /* add a video output stream to the container */
 static AVStream *icv_add_video_stream_FFMPEG(AVFormatContext *oc,
+#if LIBAVCODEC_BUILD >= CALC_FFMPEG_VERSION(54,25,0)
+                                             AVCodecID codec_id,
+#else
                                              CodecID codec_id,
+#endif
                                              int w, int h, int bitrate,
                                              double fps, int pixel_format)
 {
@@ -1450,7 +1458,11 @@ void CvVideoWriter_FFMPEG::close()
 bool CvVideoWriter_FFMPEG::open( const char * filename, int fourcc,
                                  double fps, int width, int height, bool is_color )
 {
+#if LIBAVCODEC_BUILD >= CALC_FFMPEG_VERSION(54,25,0)
+    AVCodecID codec_id = AV_CODEC_ID_NONE;
+#else
     CodecID codec_id = CODEC_ID_NONE;
+#endif
     int err, codec_pix_fmt;
     double bitrate_scale = 1;
 
@@ -1761,7 +1773,11 @@ struct OutputMediaStream_FFMPEG
     void write(unsigned char* data, int size, int keyFrame);
 
     // add a video output stream to the container
+#if LIBAVCODEC_BUILD >= CALC_FFMPEG_VERSION(54,25,0)
+    static AVStream* addVideoStream(AVFormatContext *oc, AVCodecID codec_id, int w, int h, int bitrate, double fps, PixelFormat pixel_format);
+#else
     static AVStream* addVideoStream(AVFormatContext *oc, CodecID codec_id, int w, int h, int bitrate, double fps, PixelFormat pixel_format);
+#endif
 
     AVOutputFormat* fmt_;
     AVFormatContext* oc_;
@@ -1808,7 +1824,11 @@ void OutputMediaStream_FFMPEG::close()
     }
 }
 
+#if LIBAVCODEC_BUILD >= CALC_FFMPEG_VERSION(54,25,0)
+AVStream* OutputMediaStream_FFMPEG::addVideoStream(AVFormatContext *oc, AVCodecID codec_id, int w, int h, int bitrate, double fps, PixelFormat pixel_format)
+#else
 AVStream* OutputMediaStream_FFMPEG::addVideoStream(AVFormatContext *oc, CodecID codec_id, int w, int h, int bitrate, double fps, PixelFormat pixel_format)
+#endif
 {
     #if LIBAVFORMAT_BUILD >= CALC_FFMPEG_VERSION(53, 10, 0)
         AVStream* st = avformat_new_stream(oc, 0);
@@ -1928,7 +1948,11 @@ bool OutputMediaStream_FFMPEG::open(const char* fileName, int width, int height,
     if (!fmt_)
         return false;
 
+#if LIBAVCODEC_BUILD >= CALC_FFMPEG_VERSION(54,25,0)
+    AVCodecID codec_id = AV_CODEC_ID_H264;
+#else
     CodecID codec_id = CODEC_ID_H264;
+#endif
 
     // alloc memory for context
     #if LIBAVFORMAT_BUILD >= CALC_FFMPEG_VERSION(53, 2, 0)


### PR DESCRIPTION
Post libavcodec 53.25.0 the enum CodecID was changed to AVCodecID causing compilation errors saying CodecID was not previously declared.
