### PR TITLE
multiple definition of main() problem in 3rdparty/openexr/IlmImf/b44ExpLogTable.cpp

### DIFF
--- a/3rdparty/openexr/CMakeLists.txt
+++ b/3rdparty/openexr/CMakeLists.txt
@@ -28,6 +28,8 @@ file(GLOB lib_srcs Half/half.cpp Iex/*.cpp IlmThread/*.cpp Imath/*.cpp IlmImf/*.
 file(GLOB lib_hdrs Half/*.h Iex/Iex*.h IlmThread/IlmThread*.h Imath/Imath*.h IlmImf/*.h)
 list(APPEND lib_hdrs "${CMAKE_CURRENT_BINARY_DIR}/IlmBaseConfig.h" "${CMAKE_CURRENT_BINARY_DIR}/OpenEXRConfig.h")
 
+ocv_list_filterout(lib_srcs IlmImf/b44ExpLogTable.cpp)
+
 if(WIN32)
   ocv_list_filterout(lib_srcs Posix.*cpp)
 else()


### PR DESCRIPTION
exclude IlmImf/b44ExpLogTable.cpp from the build,

it's used originally to generate IlmImf/b44ExpLogTable.h, but it's not necessary for the library.(probably only here for documentation)

when included with static linking it introduces a problem with multiple definitions of main()
