### PR TITLE
Fix ant/Java detection in cmake scripts

### DIFF
--- a/cmake/OpenCVDetectApacheAnt.cmake
+++ b/cmake/OpenCVDetectApacheAnt.cmake
@@ -16,10 +16,16 @@ find_host_program(ANT_EXECUTABLE NAMES ${ANT_NAME})
 
 if(ANT_EXECUTABLE)
   execute_process(COMMAND ${ANT_EXECUTABLE} -version
+    RESULT_VARIABLE ANT_ERROR_LEVEL
     OUTPUT_VARIABLE ANT_VERSION_FULL
     OUTPUT_STRIP_TRAILING_WHITESPACE)
-  string(REGEX MATCH "[0-9]+.[0-9]+.[0-9]+" ANT_VERSION "${ANT_VERSION_FULL}")
-  set(ANT_VERSION "${ANT_VERSION}" CACHE INTERNAL "Detected ant vesion")
+  if (ANT_ERROR_LEVEL)
+    unset(ANT_EXECUTABLE)
+    unset(ANT_EXECUTABLE CACHE)
+  else()
+    string(REGEX MATCH "[0-9]+.[0-9]+.[0-9]+" ANT_VERSION "${ANT_VERSION_FULL}")
+    set(ANT_VERSION "${ANT_VERSION}" CACHE INTERNAL "Detected ant vesion")
 
-  message(STATUS "Found apache ant ${ANT_VERSION}: ${ANT_EXECUTABLE}")
+    message(STATUS "Found apache ant ${ANT_VERSION}: ${ANT_EXECUTABLE}")
+  endif()
 endif()


### PR DESCRIPTION
Mac OS X 10.7 and newer don't come with Java installed. They do
include some stub binaries, which ask the user if they want to
install Java when run.

OpenCV's cmake script just checks for the existence of an ant
binary and assumes that Java's available if ant is. As a result,
cmake will configure the build to use Java and it will fail once
it tries to compile the Java bindings.

This fixes the issue by checking for the exit status of
`ant -version` - it exits 0 if Java is installed, or 1
otherwise.
