### PR TITLE
added compute function to Feature2D (dirty workaround for #2699)

### DIFF
--- a/modules/features2d/include/opencv2/features2d.hpp
+++ b/modules/features2d/include/opencv2/features2d.hpp
@@ -263,6 +263,8 @@ public:
                                      OutputArray descriptors,
                                      bool useProvidedKeypoints=false ) const = 0;
 
+    CV_WRAP void compute( const Mat& image, CV_OUT CV_IN_OUT std::vector<KeyPoint>& keypoints, CV_OUT Mat& descriptors ) const;
+
     // Create feature detector and descriptor extractor by name.
     CV_WRAP static Ptr<Feature2D> create( const std::string& name );
 };

--- a/modules/features2d/src/descriptors.cpp
+++ b/modules/features2d/src/descriptors.cpp
@@ -104,6 +104,12 @@ Ptr<DescriptorExtractor> DescriptorExtractor::create(const std::string& descript
     return Algorithm::create<DescriptorExtractor>("Feature2D." + descriptorExtractorType);
 }
 
+
+CV_WRAP void Feature2D::compute( const Mat& image, CV_OUT CV_IN_OUT std::vector<KeyPoint>& keypoints, CV_OUT Mat& descriptors ) const
+{
+   DescriptorExtractor::compute(image, keypoints, descriptors);
+}
+
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
 /****************************************************************************************\


### PR DESCRIPTION
This is an ugly attempt to fix #2699. Currently it seems to be impossible to run any feature descriptor on user-provided keypoints from python.
Not sure if this solution should be merged in it's current form.
