### PR TITLE
Fix for encoding errors when building Java source

### DIFF
--- a/modules/java/build.xml.in
+++ b/modules/java/build.xml.in
@@ -8,6 +8,7 @@
     <!-- http://stackoverflow.com/questions/3584968/ant-how-to-compile-jar-that-includes-source-attachment -->
     <javac sourcepath="" srcdir="src" destdir="src" debug="on" includeantruntime="false" >
       <include name="**/*.java"/>
+      <compilerarg line="-encoding utf-8"/>
     </javac>
 
     <jar basedir="src" destfile="bin/@JAR_NAME@"/>


### PR DESCRIPTION
The generated OpenCV Java source can contain characters outside of ASCII on some systems – this patch allows the ant task to compile them.
(cherry picked from commit f3ee55e04222deea30ffe4e89456c220bc75ff1a)
