### PR TITLE
Use clflush replaces clfinish, add ocl::finish() for explicit finish call

### DIFF
--- a/modules/ocl/include/opencv2/ocl/ocl.hpp
+++ b/modules/ocl/include/opencv2/ocl/ocl.hpp
@@ -126,6 +126,9 @@ namespace cv
 
         CV_EXPORTS void* getoclCommandQueue();
 
+        //explicit call clFinish. The global command queue will be used.
+        CV_EXPORTS void finish();
+
         //this function enable ocl module to use customized cl_context and cl_command_queue
         //getDevice also need to be called before this function
         CV_EXPORTS void setDeviceEx(Info &oclinfo, void *ctx, void *qu, int devnum = 0);

--- a/modules/ocl/perf/precomp.hpp
+++ b/modules/ocl/perf/precomp.hpp
@@ -375,6 +375,7 @@ struct name##_test: Runnable { \
 	while (!TestSystem::instance().stop()) { \
 	TestSystem::instance().gpuOn()
 #define GPU_OFF \
+    ocl::finish(); \
 	TestSystem::instance().gpuOff(); \
 	} TestSystem::instance().gpuComplete()
 
@@ -388,4 +389,5 @@ struct name##_test: Runnable { \
 #define WARMUP_ON \
 	while (!TestSystem::instance().warmupStop()) {
 #define WARMUP_OFF \
+        ocl::finish(); \
 	} TestSystem::instance().warmupComplete()

--- a/modules/ocl/src/initialization.cpp
+++ b/modules/ocl/src/initialization.cpp
@@ -354,6 +354,11 @@ namespace cv
             return &(Context::getContext()->impl->clCmdQueue);
         }
 
+        void finish()
+        {
+            clFinish(Context::getContext()->impl->clCmdQueue);
+        }
+
         void queryDeviceInfo(DEVICE_INFO info_type, void* info)
         {
             static Info::Impl* impl = Context::getContext()->impl;
@@ -712,7 +717,7 @@ namespace cv
             clReleaseEvent(event);
 #endif
 
-            clFinish(clCxt->impl->clCmdQueue);
+            clFlush(clCxt->impl->clCmdQueue);
             openCLSafeCall(clReleaseKernel(kernel));
         }
 

--- a/modules/ocl/src/mcwutil.cpp
+++ b/modules/ocl/src/mcwutil.cpp
@@ -144,7 +144,7 @@ namespace cv
                 format.image_channel_data_type = CL_FLOAT;
                 break;
             default:
-                throw std::exception();
+                CV_Error(-1, "Image forma is not supported");
                 break;
             }
             switch(channels)
@@ -159,7 +159,7 @@ namespace cv
                 format.image_channel_order     = CL_RGBA;
                 break;
             default:
-                throw std::exception();
+                CV_Error(-1, "Image forma is not supported");
                 break;
             }
 #if CL_VERSION_1_2
@@ -197,7 +197,8 @@ namespace cv
                 const size_t regin[3] = {mat.cols * mat.elemSize(), mat.rows, 1};
                 clEnqueueCopyBufferRect((cl_command_queue)mat.clCxt->oclCommandQueue(), (cl_mem)mat.data, devData, origin, origin,
                     regin, mat.step, 0, mat.cols * mat.elemSize(), 0, 0, NULL, NULL);
-            }
+                clFlush((cl_command_queue)mat.clCxt->oclCommandQueue()); 
+           }
             else
             {
                 devData = (cl_mem)mat.data;
@@ -206,7 +207,7 @@ namespace cv
             clEnqueueCopyBufferToImage((cl_command_queue)mat.clCxt->oclCommandQueue(), devData, texture, 0, origin, region, 0, NULL, 0);
             if ((mat.cols * mat.elemSize() != mat.step))
             {
-                clFinish((cl_command_queue)mat.clCxt->oclCommandQueue());
+                clFlush((cl_command_queue)mat.clCxt->oclCommandQueue());
                 clReleaseMemObject(devData);
             }
 
@@ -231,7 +232,8 @@ namespace cv
             try
             {
                 cv::ocl::openCLGetKernelFromSource(clCxt, &_kernel_string, "test_func");
-                //_support = true;
+                finish();
+                _support = true;
             }
             catch (const cv::Exception& e)
             {


### PR DESCRIPTION
This will benefit performance of combo kernels functions.
