### PR TITLE
Fixed compilation warning for CUDA files

### DIFF
--- a/cmake/OpenCVDetectCUDA.cmake
+++ b/cmake/OpenCVDetectCUDA.cmake
@@ -142,11 +142,14 @@ if(CUDA_FOUND)
     foreach(var CMAKE_CXX_FLAGS CMAKE_CXX_FLAGS_RELEASE CMAKE_CXX_FLAGS_DEBUG)
       set(${var}_backup_in_cuda_compile_ "${${var}}")
 
-      # we reomove /EHa as it leasd warnings under windows
+      # we remove /EHa as it generates warnings under windows
       string(REPLACE "/EHa" "" ${var} "${${var}}")
 
       # we remove -ggdb3 flag as it leads to preprocessor errors when compiling CUDA files (CUDA 4.1)
       string(REPLACE "-ggdb3" "" ${var} "${${var}}")
+
+      # we remove -Wsign-promo as it generates warnings under linux
+      string(REPLACE "-Wsign-promo" "" ${var} "${${var}}")
     endforeach()
 
     if(BUILD_SHARED_LIBS)

--- a/modules/gpu/CMakeLists.txt
+++ b/modules/gpu/CMakeLists.txt
@@ -29,8 +29,6 @@ if(HAVE_CUDA)
   source_group("Src\\NVidia" FILES ${ncv_files})
   ocv_include_directories("src/nvidia" "src/nvidia/core" "src/nvidia/NPP_staging" ${CUDA_INCLUDE_DIRS})
   ocv_warnings_disable(CMAKE_CXX_FLAGS -Wundef -Wmissing-declarations -Wshadow -Wunused-parameter /wd4211 /wd4201 /wd4100 /wd4505 /wd4408)
-  string(REPLACE "-Wsign-promo" "" CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
-  #set (CUDA_NVCC_FLAGS ${CUDA_NVCC_FLAGS} "-Xcompiler;/EHsc-;")
 
   if(MSVC)
     if(NOT ENABLE_NOISY_WARNINGS)

--- a/modules/superres/CMakeLists.txt
+++ b/modules/superres/CMakeLists.txt
@@ -9,8 +9,6 @@ ocv_module_include_directories()
 ocv_warnings_disable(CMAKE_CXX_FLAGS -Wundef /wd4127)
 
 if(HAVE_CUDA)
-  string(REPLACE "-Wsign-promo" "" CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
-
   ocv_source_group("Src\\Cuda" GLOB "src/cuda/*.cu")
   ocv_include_directories("${OpenCV_SOURCE_DIR}/modules/gpu/include" ${CUDA_INCLUDE_DIRS})
 


### PR DESCRIPTION
`command line option '-Wsign-promo' is valid for C++/ObjC++ but not for C [enabled by default]`
