### PR TITLE
Bugfix: Avoid crash after un-plugging a webcam and then trying to re-scan the devices.

### DIFF
--- a/modules/highgui/src/cap_libv4l.cpp
+++ b/modules/highgui/src/cap_libv4l.cpp
@@ -1714,6 +1714,7 @@ static void icvCloseCAM_V4L( CvCaptureCAM_V4L* capture ){
 #endif
 
      free(capture->deviceName);
+     capture->deviceName = NULL;
      //v4l2_free_ranges(capture);
      //cvFree((void **)capture);
    }


### PR DESCRIPTION
Set ptr to NULL,
so static void icvCloseCAM_V4L( CvCaptureCAM_V4L\* capture ) can be called repeatedly.

This fixes a crash: After un-plugging a webcam and trying to re-scan the cameras there would be a crash due to icvCloseCAM_V4L() trying to free(capture->deviceName).
