### PR TITLE
attempt to fix stereobm failures on Mac and Linux

### DIFF
--- a/modules/calib3d/test/test_stereomatching.cpp
+++ b/modules/calib3d/test/test_stereomatching.cpp
@@ -459,14 +459,29 @@ void CV_StereoMatchingTest::run(int)
             continue;
         }
         int dispScaleFactor = datasetsParams[datasetName].dispScaleFactor;
-        trueLeftDisp.convertTo( trueLeftDisp, CV_32FC1, 1.f/dispScaleFactor );
+        Mat tmp;
+
+        trueLeftDisp.convertTo( tmp, CV_32FC1, 1.f/dispScaleFactor );
+        trueLeftDisp = tmp;
+        tmp.release();
+
         if( !trueRightDisp.empty() )
-            trueRightDisp.convertTo( trueRightDisp, CV_32FC1, 1.f/dispScaleFactor );
+        {
+            trueRightDisp.convertTo( tmp, CV_32FC1, 1.f/dispScaleFactor );
+            trueRightDisp = tmp;
+            tmp.release();
+        }
 
         Mat leftDisp, rightDisp;
         int ignBorder = max(runStereoMatchingAlgorithm(leftImg, rightImg, leftDisp, rightDisp, ci), EVAL_IGNORE_BORDER);
-        leftDisp.convertTo( leftDisp, CV_32FC1 );
-        rightDisp.convertTo( rightDisp, CV_32FC1 );
+
+        leftDisp.convertTo( tmp, CV_32FC1 );
+        leftDisp = tmp;
+        tmp.release();
+
+        rightDisp.convertTo( tmp, CV_32FC1 );
+        rightDisp = tmp;
+        tmp.release();
 
         int tempCode = processStereoMatchingResults( resFS, ci, isWrite,
                    leftImg, rightImg, trueLeftDisp, trueRightDisp, leftDisp, rightDisp, QualityEvalParams(ignBorder));


### PR DESCRIPTION
although the failure can not be reproduced on my MacOSX and virtual Ubuntu 12.04, I suspect that the in-place .convertTo() calls might be the reasons of the failure, given that some time ago we already had problems with in-place .convertTo().
