### PR TITLE
Remove the OpenCL Dir finding in CMake

### DIFF
--- a/cmake/OpenCVDetectOpenCL.cmake
+++ b/cmake/OpenCVDetectOpenCL.cmake
@@ -4,7 +4,7 @@ if(APPLE)
   set(OPENCL_INCLUDE_DIR "" CACHE STRING "OpenCL include directory")
   mark_as_advanced(OPENCL_INCLUDE_DIR OPENCL_LIBRARY)
 else(APPLE)
-  find_package(OpenCL QUIET)
+  #find_package(OpenCL QUIET)
 
   if (NOT OPENCL_FOUND)
     find_path(OPENCL_ROOT_DIR


### PR DESCRIPTION
OpenCV has its own CL finding sripts. This dependency helps nothing than confusing user that they haven't found OpenCL when they check the CMake results.
