### PR TITLE
Fix lossless WebP image file handling

### DIFF
--- a/modules/highgui/src/grfmt_webp.cpp
+++ b/modules/highgui/src/grfmt_webp.cpp
@@ -10,8 +10,7 @@
 //                           License Agreement
 //                For Open Source Computer Vision Library
 //
-// Copyright (C) 2000-2008, Intel Corporation, all rights reserved.
-// Copyright (C) 2009, Willow Garage Inc., all rights reserved.
+// Copyright (C) 2013, Prasanna Kumar T S M, all rights reserved.
 // Third party copyrights are property of their respective owners.
 //
 // Redistribution and use in source and binary forms, with or without modification,

--- a/modules/highgui/src/grfmt_webp.hpp
+++ b/modules/highgui/src/grfmt_webp.hpp
@@ -10,8 +10,7 @@
 //                           License Agreement
 //                For Open Source Computer Vision Library
 //
-// Copyright (C) 2000-2008, Intel Corporation, all rights reserved.
-// Copyright (C) 2009, Willow Garage Inc., all rights reserved.
+// Copyright (C) 2013, Prasanna Kumar T S M, all rights reserved.
 // Third party copyrights are property of their respective owners.
 //
 // Redistribution and use in source and binary forms, with or without modification,


### PR DESCRIPTION
Based on the discussion at https://groups.google.com/a/webmproject.org/forum/?fromgroups=#!searchin/webp-discuss/opencv/webp-discuss/_ocGETvcLVw/bhtZYjZTmXQJ the lossless WebP image format is not handled correctly. Fixing that now as per the suggestion mentioned there.
