### PR TITLE
Clarify floodfill documentation

### DIFF
--- a/modules/imgproc/doc/miscellaneous_transformations.rst
+++ b/modules/imgproc/doc/miscellaneous_transformations.rst
@@ -507,7 +507,7 @@ Fills a connected component with the given color.
 
             * **FLOODFILL_FIXED_RANGE** If set, the difference between the current pixel and seed pixel is considered. Otherwise, the difference between neighbor pixels is considered (that is, the range is floating).
 
-            * **FLOODFILL_MASK_ONLY**  If set, the function does not change the image ( ``newVal``  is ignored), but fills the mask.  The flag can be used for the second variant only.
+            * **FLOODFILL_MASK_ONLY**  If set, the function does not change the image ( ``newVal``  is ignored), but fills the mask with the value in bits 8-16 of ``flags`` (that is, the fill value is set to newValue by adding (newValue << 8) to the ``flags``).  The flag can be used for the second variant only.
 
 The functions ``floodFill`` fill a connected component starting from the seed point with the specified color. The connectivity is determined by the color/brightness closeness of the neighbor pixels. The pixel at
 :math:`(x,y)` is considered to belong to the repainted domain if:


### PR DESCRIPTION
The documentation for floodfill shows there is an option to modify just a mask, but does not indicate how to set the value to fill the mask with. The documentation makes it seem like the Scalar newVal is used in some cases, and not in others, but never explicitly indicates what is used in the "others" case.
The function actually decodes the value from bits 8-16 bits of the flags, so for instance if you wanted to set values in the mask to 255 then you'd set flags = (255 << 8).
Especially for programmers who aren't aware that << can be used with things other than insertion this is very confusing.

I clarified what value floodfill sets pixels in the mask to when FOODFILL_MASK_ONLY is set.
