### PR TITLE
Changed OnePassStabilizer and TwoPassStabilizer virtual function accessibility from private to protected

### DIFF
--- a/modules/videostab/include/opencv2/videostab/stabilizer.hpp
+++ b/modules/videostab/include/opencv2/videostab/stabilizer.hpp
@@ -144,7 +144,7 @@ public:
     virtual void reset();
     virtual Mat nextFrame() { return nextStabilizedFrame(); }
 
-private:
+protected:
     virtual void setUp(const Mat &firstFrame);
     virtual Mat estimateMotion();
     virtual Mat estimateStabilizationMotion();
@@ -170,7 +170,7 @@ public:
     virtual void reset();
     virtual Mat nextFrame();
 
-private:
+protected:
     void runPrePassIfNecessary();
 
     virtual void setUp(const Mat &firstFrame);


### PR DESCRIPTION
Changed accessibility of the virtual functions in OnePassStabilizer and TwoPassStabilizer that are derived from StabilizerBase from private to protected to enable stabilizer implementations that are derived from OnePassStabilizer and TwoPassStabilier to properly overwrite these functions
