### PR TITLE
JavaCameraView now handles a null attribute parameter.

### DIFF
--- a/modules/java/generator/src/java/android+CameraBridgeViewBase.java
+++ b/modules/java/generator/src/java/android+CameraBridgeViewBase.java
@@ -62,15 +62,17 @@ public abstract class CameraBridgeViewBase extends SurfaceView implements Surfac
     public CameraBridgeViewBase(Context context, AttributeSet attrs) {
         super(context, attrs);
 
-        int count = attrs.getAttributeCount();
-        Log.d(TAG, "Attr count: " + Integer.valueOf(count));
+        if (attrs != null){
+            int count = attrs.getAttributeCount();
+            Log.d(TAG, "Attr count: " + Integer.valueOf(count));
 
-        TypedArray styledAttrs = getContext().obtainStyledAttributes(attrs, R.styleable.CameraBridgeViewBase);
-        if (styledAttrs.getBoolean(R.styleable.CameraBridgeViewBase_show_fps, false))
-            enableFpsMeter();
+            TypedArray styledAttrs = getContext().obtainStyledAttributes(attrs, R.styleable.CameraBridgeViewBase);
+            if (styledAttrs.getBoolean(R.styleable.CameraBridgeViewBase_show_fps, false))
+                enableFpsMeter();
 
-        mCameraIndex = styledAttrs.getInt(R.styleable.CameraBridgeViewBase_camera_id, -1);
-
+            mCameraIndex = styledAttrs.getInt(R.styleable.CameraBridgeViewBase_camera_id, -1);
+        }
+        
         getHolder().addCallback(this);
         mMaxWidth = MAX_UNSPECIFIED;
         mMaxHeight = MAX_UNSPECIFIED;


### PR DESCRIPTION
This commit avoid a null pointer exception if the view attributes are null. 
Xml attributes exist if the view is created in with an Android Xml resource. Some developers needs to create a View directly on java and not in xml (which means that the AttributeSet param is null).

According to https://github.com/Itseez/opencv/pull/842, I have removed the tabs and converted them to spaces. Thank you for the advice about the other constructor.
