### PR TITLE
Changed convexHull's documentation to essentially invert the meaning of clockwise

### DIFF
--- a/modules/imgproc/doc/structural_analysis_and_shape_descriptors.rst
+++ b/modules/imgproc/doc/structural_analysis_and_shape_descriptors.rst
@@ -406,7 +406,7 @@ Finds the convex hull of a point set.
 
     :param hull_storage: Output memory storage in the old API (``cvConvexHull2`` returns a sequence containing the convex hull points or their indices).
 
-    :param clockwise: Orientation flag. If it is true, the output convex hull is oriented clockwise. Otherwise, it is oriented counter-clockwise. The usual screen coordinate system is assumed so that the origin is at the top-left corner, x axis is oriented to the right, and y axis is oriented downwards.
+    :param clockwise: Orientation flag. If it is true, the output convex hull is oriented clockwise. Otherwise, it is oriented counter-clockwise. The assumed coordinate system has its X axis pointing to the right, and its Y axis pointing upwards.
 
     :param orientation: Convex hull orientation parameter in the old API, ``CV_CLOCKWISE`` or ``CV_COUNTERCLOCKWISE``.
 


### PR DESCRIPTION
The orientation of `convexHull`'s result is currently the opposite of what the
documentation would suggest:

```
>>> import cv2, numpy as np
>>> points = np.array([[0,0],[0,1],[1,0]], dtype=np.int32)
>>> cv2.convexHull(points, clockwise=False)
array([[[1, 0]], [[0, 1]], [[0, 0]]], dtype=int32)
>>> cv2.convexHull(points, clockwise=True)
array([[[0, 0]], [[0, 1]], [[1, 0]]], dtype=int32)
```

Changing the function itself is probably not a good idea at this point, so
this fixes the documentation by flipping the coordinate system.

I also removed the mention of the origin, since it's irrelevant for this
function.
