### PR TITLE
Fix for spurious assert when comparing multi-channel histograms

### DIFF
--- a/modules/imgproc/src/histogram.cpp
+++ b/modules/imgproc/src/histogram.cpp
@@ -1980,7 +1980,7 @@ double cv::compareHist( InputArray _H1, InputArray _H2, int method )
     {
         const float* h1 = (const float*)it.planes[0].data;
         const float* h2 = (const float*)it.planes[1].data;
-        len = it.planes[0].rows*it.planes[0].cols;
+        len = it.planes[0].rows*it.planes[0].cols*H1.channels();
 
         if( method == CV_COMP_CHISQR )
         {


### PR DESCRIPTION
When comparing histograms that look like multi-channel images (e.g a 3D histogram, of 4x4x4 bins, might appear as a CV_32FC4 matrix), cv::compareHist would complain because it was expecting the matrix type() == CV_32F. Now we test for matrix depth() == CV_32F instead.

This appeared to be a particular problem when using the Python API - presumably a 3D `i x j x k` element `numpy.ndarray` was getting automagically converted to a 2D `i x j` image with `k` channels.
