### PR TITLE
Added setting feature of FPS in cap_libv4l

### DIFF
--- a/modules/highgui/src/cap_libv4l.cpp
+++ b/modules/highgui/src/cap_libv4l.cpp
@@ -1665,6 +1665,17 @@ static int icvSetPropertyCAM_V4L(CvCaptureCAM_V4L* capture, int property_id, dou
             width = height = 0;
         }
         break;
+    case CV_CAP_PROP_FPS:
+        struct v4l2_streamparm setfps;
+        memset (&setfps, 0, sizeof(struct v4l2_streamparm));
+        setfps.type = V4L2_BUF_TYPE_VIDEO_CAPTURE;
+        setfps.parm.capture.timeperframe.numerator = 1;
+        setfps.parm.capture.timeperframe.denominator = value;
+        if (xioctl (capture->deviceHandle, VIDIOC_S_PARM, &setfps) < 0){
+            fprintf(stderr, "HIGHGUI ERROR: V4L: Unable to set camera FPS\n");
+            retval=0;
+        }
+        break;
     default:
         retval = icvSetControl(capture, property_id, value);
     }


### PR DESCRIPTION
Some time ago I saw this post related with the setting feature of the FramePerSecond property in v4l2 cameras (http://answers.opencv.org/question/7353/how-do-i-adjust-fps-for-a-v4l2-camera/)

There were suggested to include this patch in the OpenCV open source project, but It wasn't done until now. Because of I need this piece of code for some personal projects, I took the patch written in the previous post and now I'm sending this pull request :)

I can confirm that this piece of code runs correctly with the following cameras:
- Logitech C525
- Logitech C920
- Logitech Webcam Pro 9000
