### PR TITLE
 add (optional) index argument to RetrieveFrame method

### DIFF
--- a/modules/python/src2/api
+++ b/modules/python/src2/api
@@ -1595,6 +1595,7 @@ GrabFrame int
   CvCapture* capture
 RetrieveFrame ROIplImage*
   CvCapture* capture
+  int index 0
 QueryFrame ROIplImage*
   CvCapture* capture
 GetCaptureProperty double


### PR DESCRIPTION
As requested in http://code.opencv.org/issues/1459, I hereby submit a pull request to expose the RetrieveFrame method to Python with the optional index argument to allow selection of different image sources from the same videosource.
