### PR TITLE
Fixed crash

### DIFF
--- a/samples/python2/facedetect.py
+++ b/samples/python2/facedetect.py
@@ -39,6 +39,7 @@ if __name__ == '__main__':
     nested = cv2.CascadeClassifier(nested_fn)
 
     cam = create_capture(video_src, fallback='synth:bg=../cpp/lena.jpg:noise=0.05')
+    cv2.namedWindow('facedetect', cv2.CV_WINDOW_AUTOSIZE)
 
     while True:
         ret, img = cam.read()


### PR DESCRIPTION
Without that line, the sample crashes on my system with the following error:

```
OpenCV Error: OpenGL API call (Can't load OpenGL extension [glGenerateMipmap]) in unknown function, file ..\..\..\opencv-2.4.5\modules\core\src\gl_core_3_1.cpp, line 141
Traceback (most recent call last):
  File "C:\facedetect.py", line 60, in <module>
    cv2.imshow('facedetect', vis)
cv2.error: ..\..\..\opencv-2.4.5\modules\core\src\gl_core_3_1.cpp:141: error: (-219) Can't load OpenGL extension [glGenerateMipmap]
```
