### PR TITLE
Fix ocl moudle build with latest Intel OpenCL SDK ver 3.0.

### DIFF
--- a/modules/ocl/src/mcwutil.cpp
+++ b/modules/ocl/src/mcwutil.cpp
@@ -43,6 +43,7 @@
 //
 //M*/
 
+#define CL_USE_DEPRECATED_OPENCL_1_1_APIS
 #include "precomp.hpp"
 
 using namespace std;


### PR DESCRIPTION
We found that cl.h file provided in latest Intel SDK muted deprecated interfaces.
