### PR TITLE
fixed a pca bug for fixed mean input

### DIFF
--- a/modules/core/src/matmul.cpp
+++ b/modules/core/src/matmul.cpp
@@ -2855,8 +2855,9 @@ PCA& PCA::operator()(InputArray _data, InputArray __mean, int flags, int maxComp
 
     if( _mean.data )
     {
-        CV_Assert( _mean.size() == mean_sz );
+        CV_Assert( _mean.size() == mean_sz );        
         _mean.convertTo(mean, ctype);
+        covar_flags |= CV_COVAR_USE_AVG; 
     }
 
     calcCovarMatrix( data, covar, mean, covar_flags, ctype );


### PR DESCRIPTION
Hi, 

I seems that PCA forgot a flag when a mean value is given. 
