### PR TITLE
Copy ocl::queryDeviceInfo interface from master to 2.4.

### DIFF
--- a/modules/ocl/include/opencv2/ocl/private/util.hpp
+++ b/modules/ocl/include/opencv2/ocl/private/util.hpp
@@ -128,11 +128,17 @@ namespace cv
         enum DEVICE_INFO
         {
             WAVEFRONT_SIZE,             //in AMD speak
-            WARP_SIZE = WAVEFRONT_SIZE, //in nvidia speak
             IS_CPU_DEVICE               //check if the device is CPU
         };
+        template<DEVICE_INFO _it, typename _ty>
+        _ty queryDeviceInfo(cl_kernel kernel = NULL);
         //info should have been pre-allocated
-        void CV_EXPORTS queryDeviceInfo(DEVICE_INFO info_type, void* info);
+        template<>
+        int CV_EXPORTS queryDeviceInfo<WAVEFRONT_SIZE, int>(cl_kernel kernel);
+        template<>
+        size_t CV_EXPORTS queryDeviceInfo<WAVEFRONT_SIZE, size_t>(cl_kernel kernel);
+        template<>
+        bool CV_EXPORTS queryDeviceInfo<IS_CPU_DEVICE, bool>(cl_kernel kernel);
 
     }//namespace ocl
 

--- a/modules/ocl/src/hog.cpp
+++ b/modules/ocl/src/hog.cpp
@@ -1578,8 +1578,7 @@ static void openCLExecuteKernel_hog(Context *clCxt , const char **source, string
                                     size_t globalThreads[3], size_t localThreads[3], 
                                     vector< pair<size_t, const void *> > &args)
 {
-    size_t wave_size = 0;
-    queryDeviceInfo(WAVEFRONT_SIZE, &wave_size);
+    size_t wave_size = queryDeviceInfo<WAVEFRONT_SIZE, size_t>();
     if (wave_size <= 16)
     {
         char build_options[64];

--- a/modules/ocl/src/pyrlk.cpp
+++ b/modules/ocl/src/pyrlk.cpp
@@ -187,8 +187,7 @@ static void lkSparse_run(oclMat &I, oclMat &J,
     args.push_back( make_pair( sizeof(cl_int), (void *)&iters ));
     args.push_back( make_pair( sizeof(cl_char), (void *)&calcErr ));
 
-    bool is_cpu;
-    queryDeviceInfo(IS_CPU_DEVICE, &is_cpu);
+    bool is_cpu = queryDeviceInfo<IS_CPU_DEVICE, bool>();
     if (is_cpu)
     {
         openCLExecuteKernel(clCxt, &pyrlk, kernelName, globalThreads, localThreads, args, I.oclchannels(), I.depth(), (char*)" -D CPU");


### PR DESCRIPTION
Affected functions surf.ocl, pyrlk.ocl and hog.ocl are updated with the change.
