### PR TITLE
fix a bug(DetectorType never change)

### DIFF
--- a/samples/android/face-detection/src/org/opencv/samples/facedetect/FdActivity.java
+++ b/samples/android/face-detection/src/org/opencv/samples/facedetect/FdActivity.java
@@ -215,9 +215,9 @@ public class FdActivity extends Activity implements CvCameraViewListener2 {
         else if (item == mItemFace20)
             setMinFaceSize(0.2f);
         else if (item == mItemType) {
-            mDetectorType = (mDetectorType + 1) % mDetectorName.length;
-            item.setTitle(mDetectorName[mDetectorType]);
-            setDetectorType(mDetectorType);
+            int tmpDetectorType = (mDetectorType + 1) % mDetectorName.length;
+            item.setTitle(mDetectorName[tmpDetectorType]);
+            setDetectorType(tmpDetectorType);
         }
         return true;
     }


### PR DESCRIPTION
changed line218 -> line220  
Presentation:
because line 220 give the global variable mDetectorType and in line 230 it will be compared with mDetectorType !!!  it will never be unequal ~
fix:
change mDetectorType(previous global var) to a new local var tmpDetectorType
