### PR TITLE
Add typedefs for the standard OpenCV native types.

### DIFF
--- a/modules/core/include/opencv2/core/cvdef.h
+++ b/modules/core/include/opencv2/core/cvdef.h
@@ -324,6 +324,39 @@ typedef signed char schar;
 #define CV_ELEM_SIZE(type) \
     (CV_MAT_CN(type) << ((((sizeof(size_t)/4+1)*16384|0x3a50) >> CV_MAT_DEPTH(type)*2) & 3))
 
+/* define the standard native types */
+typedef unsigned char  CvType8UC1;
+typedef signed char    CvType8SC1;
+typedef unsigned short CvType16UC1;
+typedef signed short   CvType16SC1;
+typedef int            CvType32SC1;
+typedef float     	   CvType32FC1;
+typedef double     	   CvType64FC1;
+
+typedef cv::Vec<CvType8UC1, 2>  CvType8UC2;
+typedef cv::Vec<CvType8SC1, 2>  CvType8SC2;
+typedef cv::Vec<CvType16UC1, 2> CvType16UC2;
+typedef cv::Vec<CvType16SC1, 2> CvType16SC2;
+typedef cv::Vec<CvType32SC1, 2> CvType32SC2;
+typedef cv::Vec<CvType32FC1, 2> CvType32FC2;
+typedef cv::Vec<CvType64FC1, 2> CvType64FC2;
+
+typedef cv::Vec<CvType8UC1, 3>  CvType8UC3;
+typedef cv::Vec<CvType8SC1, 3>  CvType8SC3;
+typedef cv::Vec<CvType16UC1, 3> CvType16UC3;
+typedef cv::Vec<CvType16SC1, 3> CvType16SC3;
+typedef cv::Vec<CvType32SC1, 3> CvType32SC3;
+typedef cv::Vec<CvType32FC1, 3> CvType32FC3;
+typedef cv::Vec<CvType64FC1, 3> CvType64FC3;
+
+typedef cv::Vec<CvType8UC1, 4>  CvType8UC4;
+typedef cv::Vec<CvType8SC1, 4>  CvType8SC4;
+typedef cv::Vec<CvType16UC1, 4> CvType16UC4;
+typedef cv::Vec<CvType16SC1, 4> CvType16SC4;
+typedef cv::Vec<CvType32SC1, 4> CvType32SC4;
+typedef cv::Vec<CvType32FC1, 4> CvType32FC4;
+typedef cv::Vec<CvType64FC1, 4> CvType64FC4;
+
 
 /****************************************************************************************\
 *                                      fast math                                         *


### PR DESCRIPTION
This commit adds typedefs for the standard types that are used by OpenCV.

The purpose of these type defs is to match the types used on matrix operations i.e. CV_8UC1 to simplify notation and help to avoid errors.

This allows programmers to specify:
cv::Mat m(cv::Size(100, 100), CV_8UC1);
m.at<CvType8UC1>(y, x);

// rather then
// Is this signed or unsigned (correct or wrong)? Implementation defined...
m.at<char>(y, x); 

Conversion can be managed as followed if needed (between native and soft types):
int type = cv::DataType<CvType8UC1>::type;

Happy to change the name structure of the typedef's if there is a structure that better matches your style guide, please let me know.
