### PR TITLE
Set Android Camera Index after the object has been initialized

### DIFF
--- a/modules/java/generator/src/java/android+CameraBridgeViewBase.java
+++ b/modules/java/generator/src/java/android+CameraBridgeViewBase.java
@@ -80,6 +80,14 @@ public abstract class CameraBridgeViewBase extends SurfaceView implements Surfac
         mMaxHeight = MAX_UNSPECIFIED;
         styledAttrs.recycle();
     }
+    
+    /**
+     * Sets the camera index
+     * @param camera index
+     */
+    public void setCameraIndex(int cameraIndex) {
+        this.mCameraIndex = cameraIndex;
+    }
 
     public interface CvCameraViewListener {
         /**


### PR DESCRIPTION
Commit Message: Simple set of the camera index to allow the user to change it after the object has been initialized.

This is just a simple feature that I have in my own code to allow me to set the camera index when the camera is initialized by a view instead of pure java. I have found it very useful for dynamically selecting what camera to use.
