### PR TITLE
Moved the CL_USE_DEPRECATED_OPENCL_1_1_APIS definition into precomp.hpp.

### DIFF
--- a/modules/ocl/src/mcwutil.cpp
+++ b/modules/ocl/src/mcwutil.cpp
@@ -43,7 +43,6 @@
 //
 //M*/
 
-#define CL_USE_DEPRECATED_OPENCL_1_1_APIS
 #include "precomp.hpp"
 
 using namespace std;

--- a/modules/ocl/src/precomp.hpp
+++ b/modules/ocl/src/precomp.hpp
@@ -78,6 +78,8 @@
 
 #if defined (HAVE_OPENCL)
 
+#define CL_USE_DEPRECATED_OPENCL_1_1_APIS
+
 #include "opencv2/ocl/private/util.hpp"
 #include "safe_call.hpp"
 


### PR DESCRIPTION
Defining it before including a precompiled header has no effect on the latter.
