### PR TITLE
Update ocl::surf_matcher sample.

### DIFF
--- a/samples/ocl/surf_matcher.cpp
+++ b/samples/ocl/surf_matcher.cpp
@@ -350,7 +350,7 @@ int main(int argc, char* argv[])
         else
         {
             bool result = false;
-            for(int i = 0; i < cpu_corner.size(); i++)
+            for(size_t i = 0; i < cpu_corner.size(); i++)
             {
                 if((std::abs(cpu_corner[i].x - gpu_corner[i].x) > 10)
                     ||(std::abs(cpu_corner[i].y - gpu_corner[i].y) > 10))


### PR DESCRIPTION
The new sample adjust some parameters thus it should always be able to
calculate valid homography matrix when input is box.png and
box_in_scene.png.
Pure cpp surf and bfmatcher implementation is also added to show the user
SURF_OCL and BFMatcher_OCL's accuracy and performance.
