### PR TITLE
Initialize OpenCL context at the end of getDevice call.

### DIFF
--- a/modules/ocl/src/initialization.cpp
+++ b/modules/ocl/src/initialization.cpp
@@ -333,6 +333,10 @@ namespace cv
                     oclinfo.push_back(ocltmpinfo);
                 }
             }
+            if(devcienums > 0)
+            {
+                setDevice(oclinfo[0]);
+            }
             return devcienums;
         }
 


### PR DESCRIPTION
Added for better compatibility with the current samples/test cases.
User now will be able to initialize OpenCL context explicitly with
ocl::getDevice api.
This may be obsoleted in future releases.
