### PR TITLE
setting 'char' to be signed by default

### DIFF
--- a/cmake/OpenCVCompilerOptions.cmake
+++ b/cmake/OpenCVCompilerOptions.cmake
@@ -47,7 +47,7 @@ macro(add_extra_compiler_option option)
   endif()
 endmacro()
 
-# some OpenCV tests fail when 'char' is 'unsigned' by default
+# OpenCV fails some tests when 'char' is 'unsigned' by default
 add_extra_compiler_option(-fsigned-char)
 
 if(MINGW)


### PR DESCRIPTION
some tests fail when it's wrong (e.g. native compilation on ARM Linux)
