### PR TITLE
Fixed GPU module compilation with CMake 2.8.11

### DIFF
--- a/modules/gpu/CMakeLists.txt
+++ b/modules/gpu/CMakeLists.txt
@@ -42,7 +42,7 @@ if(HAVE_CUDA)
 
   ocv_cuda_compile(cuda_objs ${lib_cuda} ${ncv_cuda})
 
-  set(cuda_link_libs ${CUDA_LIBRARIES} ${CUDA_npp_LIBRARY})
+  set(cuda_link_libs ${CUDA_LIBRARIES} ${CUDA_CUDA_LIBRARY} ${CUDA_npp_LIBRARY})
 
   if(WITH_NVCUVID)
     set(cuda_link_libs ${cuda_link_libs} ${CUDA_nvcuvid_LIBRARY})


### PR DESCRIPTION
CMake 2.8.11 removed linkage with CUDA driver library, but it's used by gpu video encoding/decoding.
