### PR TITLE
Fixed Bug #3069 (infinite loop in GPU LBP Cascade detectMultiScale)

### DIFF
--- a/modules/gpu/src/cascadeclassifier.cpp
+++ b/modules/gpu/src/cascadeclassifier.cpp
@@ -406,7 +406,7 @@ public:
         GpuMat dclassified(1, 1, CV_32S);
         cudaSafeCall( cudaMemcpy(dclassified.ptr(), &classified, sizeof(int), cudaMemcpyHostToDevice) );
 
-        PyrLavel level(0, 1.0f, image.size(), NxM, minObjectSize);
+        PyrLavel level(0, scaleFactor, image.size(), NxM, minObjectSize);
 
         while (level.isFeasible(maxObjectSize))
         {


### PR DESCRIPTION
Related bug : http://code.opencv.org/issues/3069

The second parameter in PyrLevel constructor is `_scale`, so I suppose we mast pass `scaleFactor` parameter. `1.0f` value leads to infinite loop.
