### PR TITLE
Don't resolve symlinks when looking for modules.

### DIFF
--- a/cmake/OpenCVModule.cmake
+++ b/cmake/OpenCVModule.cmake
@@ -303,7 +303,7 @@ macro(ocv_glob_modules)
   # collect modules
   set(OPENCV_INITIAL_PASS ON)
   foreach(__path ${ARGN})
-    ocv_get_real_path(__path "${__path}")
+    get_filename_component(__path "${__path}" ABSOLUTE)
 
     list(FIND __directories_observed "${__path}" __pathIdx)
     if(__pathIdx GREATER -1)
@@ -315,7 +315,7 @@ macro(ocv_glob_modules)
     if(__ocvmodules)
       list(SORT __ocvmodules)
       foreach(mod ${__ocvmodules})
-        ocv_get_real_path(__modpath "${__path}/${mod}")
+        get_filename_component(__modpath "${__path}/${mod}" ABSOLUTE)
         if(EXISTS "${__modpath}/CMakeLists.txt")
 
           list(FIND __directories_observed "${__modpath}" __pathIdx)

--- a/cmake/OpenCVUtils.cmake
+++ b/cmake/OpenCVUtils.cmake
@@ -411,16 +411,6 @@ macro(ocv_regex_escape var regex)
 endmacro()
 
 
-# get absolute path with symlinks resolved
-macro(ocv_get_real_path VAR PATHSTR)
-  if(CMAKE_VERSION VERSION_LESS 2.8)
-    get_filename_component(${VAR} "${PATHSTR}" ABSOLUTE)
-  else()
-    get_filename_component(${VAR} "${PATHSTR}" REALPATH)
-  endif()
-endmacro()
-
-
 # convert list of paths to full paths
 macro(ocv_convert_to_full_paths VAR)
   if(${VAR})


### PR DESCRIPTION
We don't really need it, it makes the code longer, and it can lead to
inconsistent paths when OpenCV is itself inside a symlink.
