### PR TITLE
Add a confidence measure for objects detected by detectMultiScale

### DIFF
--- a/modules/objdetect/doc/cascade_classification.rst
+++ b/modules/objdetect/doc/cascade_classification.rst
@@ -189,6 +189,7 @@ CascadeClassifier::detectMultiScale
 Detects objects of different sizes in the input image. The detected objects are returned as a list of rectangles.
 
 .. ocv:function:: void CascadeClassifier::detectMultiScale( const Mat& image, vector<Rect>& objects, double scaleFactor=1.1, int minNeighbors=3, int flags=0, Size minSize=Size(), Size maxSize=Size())
+.. ocv:function:: void CascadeClassifier::detectMultiScale( const Mat& image, vector<Rect>& objects, vector<int>& weights, double scaleFactor=1.1, int minNeighbors=3, int flags=0, Size minSize=Size(), Size maxSize=Size())
 
 .. ocv:pyfunction:: cv2.CascadeClassifier.detectMultiScale(image[, scaleFactor[, minNeighbors[, flags[, minSize[, maxSize]]]]]) -> objects
 .. ocv:pyfunction:: cv2.CascadeClassifier.detectMultiScale(image, rejectLevels, levelWeights[, scaleFactor[, minNeighbors[, flags[, minSize[, maxSize[, outputRejectLevels]]]]]]) -> objects
@@ -202,6 +203,8 @@ Detects objects of different sizes in the input image. The detected objects are 
     :param image: Matrix of the type   ``CV_8U``  containing an image where objects are detected.
 
     :param objects: Vector of rectangles where each rectangle contains the detected object.
+
+    :param weights: Vector of weights of the corresponding objects. Weight is the number of neighboring positively classified rectangles that were joined into one object.
 
     :param scaleFactor: Parameter specifying how much the image size is reduced at each image scale.
 

--- a/modules/objdetect/include/opencv2/objdetect/objdetect.hpp
+++ b/modules/objdetect/include/opencv2/objdetect/objdetect.hpp
@@ -384,13 +384,22 @@ public:
 
     CV_WRAP virtual void detectMultiScale( const Mat& image,
                                    CV_OUT vector<Rect>& objects,
+                                   vector<int>& weights,
+                                   double scaleFactor=1.1,
+                                   int minNeighbors=3, int flags=0,
+                                   Size minSize=Size(),
+                                   Size maxSize=Size() );
+
+    CV_WRAP virtual void detectMultiScale( const Mat& image,
+                                   CV_OUT vector<Rect>& objects,
                                    vector<int>& rejectLevels,
                                    vector<double>& levelWeights,
                                    double scaleFactor=1.1,
                                    int minNeighbors=3, int flags=0,
                                    Size minSize=Size(),
                                    Size maxSize=Size(),
-                                   bool outputRejectLevels=false );
+                                   bool outputRejectLevels=false,
+                                   bool outputWeights=false );
 
 
     bool isOldFormatCascade() const;


### PR DESCRIPTION
Add a variant of detectMultiScale that returns the number of neighbors joined into each object. See http://code.opencv.org/issues/3067.
