### PR TITLE
Add a new global function to control ocl binary storage

### DIFF
--- a/modules/ocl/include/opencv2/ocl/ocl.hpp
+++ b/modules/ocl/include/opencv2/ocl/ocl.hpp
@@ -118,9 +118,6 @@ namespace cv
         //the devnum is the index of the selected device in DeviceName vector of INfo
         CV_EXPORTS void setDevice(Info &oclinfo, int devnum = 0);
 
-        //optional function, if you want save opencl binary kernel to the file, set its path
-        CV_EXPORTS  void setBinpath(const char *path);
-
         //The two functions below enable other opencl program to use ocl module's cl_context and cl_command_queue
         //returns cl_context * 
         CV_EXPORTS void* getoclContext();
@@ -180,6 +177,23 @@ namespace cv
                                                         int channels, int depth, const char *build_options,
                                                         bool finish = true, bool measureKernelTime = false,
                                                         bool cleanUp = true);
+
+        //! Enable or disable OpenCL program binary caching onto local disk
+        // After a program (*.cl files in opencl/ folder) is built at runtime, we allow the compiled program to be 
+        // cached onto local disk automatically, which may accelerate subsequent runs.
+        // Caching mode is controlled by the following enum
+        // Note, the feature is by default enabled when OpenCV is built in release mode.
+        // enum BinaryDiskCacheMode
+        const int CACHE_NONE    = 0;
+        const int CACHE_DEBUG   = 0x1 << 0;
+        const int CACHE_RELEASE = 0x1 << 1;
+        const int CACHE_ALL     = CACHE_DEBUG | CACHE_RELEASE;
+        const int CACHE_UPDATE  = 0x1 << 2;  // if the binary cache file with the same name is already on the disk, it will be updated.
+
+        CV_EXPORTS void setBinaryDiskCache(int mode = CACHE_RELEASE, cv::String path = "./");
+
+        //! set where binary cache to be saved to 
+        CV_EXPORTS void setBinpath(const char *path);
 
         class CV_EXPORTS oclMatExpr;
         //////////////////////////////// oclMat ////////////////////////////////

--- a/modules/ocl/src/initialization.cpp
+++ b/modules/ocl/src/initialization.cpp
@@ -124,7 +124,8 @@ namespace cv
             cacheSize = 0;
         }
 
-
+        // not to be exported to dynamic lib
+        void setBinaryDiskCacheImpl(int mode, String path, Info::Impl * impl);
         struct Info::Impl
         {
             cl_platform_id oclplatform;
@@ -142,22 +143,12 @@ namespace cv
             char extra_options[512];
             int  double_support;
             int unified_memory; //1 means integrated GPU, otherwise this value is 0
+            bool enable_disk_cache; 
+            bool update_disk_cache;
             string binpath;
             int refcounter;
 
-            Impl()
-            {
-                refcounter = 1;
-                oclplatform = 0;
-                oclcontext = 0;
-                clCmdQueue = 0;
-                devnum = -1;
-                maxComputeUnits = 0;
-                maxWorkGroupSize = 0;
-                memset(extra_options, 0, 512);
-                double_support = 0;
-                unified_memory = 0;
-            }
+            Impl();
 
             void setDevice(void *ctx, void *q, int devnum);
 
@@ -181,6 +172,75 @@ namespace cv
             Impl& operator=(const Impl&);
             void releaseResources();
         };
+        
+        void setBinaryDiskCacheImpl(int mode, String path, Info::Impl * impl)
+        {
+            impl->update_disk_cache = (mode & CACHE_UPDATE) == CACHE_UPDATE;
+            impl->enable_disk_cache = 
+#if !defined(NDEBUG) || defined(_DEBUG) 
+                (mode & CACHE_DEBUG)   == CACHE_DEBUG;
+#else
+                (mode & CACHE_RELEASE) == CACHE_RELEASE;
+#endif
+            if(impl->enable_disk_cache && !path.empty())
+            {
+                impl->binpath = path;
+            }
+        }
+
+        Info::Impl::Impl()
+            :oclplatform(0),
+            oclcontext(0),
+            clCmdQueue(0),
+            devnum(-1),
+            maxWorkGroupSize(0),
+            maxDimensions(0),
+            maxComputeUnits(0),
+            double_support(0),
+            unified_memory(0),
+            enable_disk_cache(false),
+            update_disk_cache(false),
+            binpath("./"),
+            refcounter(1)
+        {
+            memset(extra_options, 0, 512);
+            setBinaryDiskCacheImpl(CACHE_RELEASE, String("./"), this);
+        }
+
+        // not to be exported to dynamic lib
+        void setBinaryDiskCacheImpl(int mode, String path, Info::Impl * impl)
+        {
+            impl->update_disk_cache = (mode & CACHE_UPDATE) == CACHE_UPDATE;
+            impl->enable_disk_cache = 
+#if !defined(NDEBUG) || defined(_DEBUG) 
+                (mode & CACHE_DEBUG)   == CACHE_DEBUG;
+#else
+                (mode & CACHE_RELEASE) == CACHE_RELEASE;
+#endif
+            if(impl->enable_disk_cache && !path.empty())
+            {
+                impl->binpath = path;
+            }
+        }
+
+        Info::Impl::Impl()
+            :oclplatform(0),
+            oclcontext(0),
+            clCmdQueue(0),
+            devnum(-1),
+            maxWorkGroupSize(0),
+            maxDimensions(0),
+            maxComputeUnits(0),
+            double_support(0),
+            unified_memory(0),
+            enable_disk_cache(false),
+            update_disk_cache(false),
+            binpath("./"),
+            refcounter(1)
+        {
+            memset(extra_options, 0, 512);
+            setBinaryDiskCacheImpl(CACHE_RELEASE, String("./"), this);
+        }
 
         void Info::Impl::releaseResources()
         {
@@ -494,6 +554,10 @@ namespace cv
             return openCLGetKernelFromSource(clCxt, source, kernelName, NULL);
         }
 
+        void setBinaryDiskCache(int mode, cv::String path)
+        {
+            setBinaryDiskCacheImpl(mode, path, Context::getContext()->impl);
+        }
 
         void setBinpath(const char *path)
         {
@@ -573,8 +637,8 @@ namespace cv
                     filename = clCxt->impl->binpath  + kernelName + "_" + clCxt->impl->devName[clCxt->impl->devnum] + ".clb";
                 }
 
-                FILE *fp = fopen(filename.c_str(), "rb");
-                if(fp == NULL || clCxt->impl->binpath.size() == 0)    //we should generate a binary file for the first time.
+                FILE *fp = clCxt->impl->enable_disk_cache ? fopen(filename.c_str(), "rb") : NULL;
+                if(fp == NULL || clCxt->impl->update_disk_cache)
                 {
                     if(fp != NULL)
                         fclose(fp);
@@ -583,7 +647,7 @@ namespace cv
                                   clCxt->impl->oclcontext, 1, source, NULL, &status);
                     openCLVerifyCall(status);
                     status = clBuildProgram(program, 1, &(clCxt->impl->devices[clCxt->impl->devnum]), all_build_options, NULL, NULL);
-                    if(status == CL_SUCCESS && clCxt->impl->binpath.size())
+                    if(status == CL_SUCCESS && clCxt->impl->enable_disk_cache)
                         savetofile(clCxt, program, filename.c_str());
                 }
                 else


### PR DESCRIPTION
Previously the feature is controlled by setBinpath implicitly.
We add the function to cope with setBinpath and setBinpath is only
useful when setBinaryDiskCache is set.
Refer to the header to see more info.
