### PR TITLE
Erase MatchPairsBody's copy constructor.

### DIFF
--- a/modules/stitching/src/matchers.cpp
+++ b/modules/stitching/src/matchers.cpp
@@ -68,10 +68,6 @@ struct DistIdxPair
 
 struct MatchPairsBody : ParallelLoopBody
 {
-    MatchPairsBody(const MatchPairsBody& other)
-            : matcher(other.matcher), features(other.features),
-              pairwise_matches(other.pairwise_matches), near_pairs(other.near_pairs) {}
-
     MatchPairsBody(FeaturesMatcher &_matcher, const vector<ImageFeatures> &_features,
                    vector<MatchesInfo> &_pairwise_matches, vector<pair<int,int> > &_near_pairs)
             : matcher(_matcher), features(_features),


### PR DESCRIPTION
It's the same as the implicitly defined one, and it causes a -Wextra warning
(not initializing the base class in a copy constructor).
