### PR TITLE
Add a confidence measure for objects detected by detectMultiScale (re-request)

### DIFF
--- a/modules/objdetect/doc/cascade_classification.rst
+++ b/modules/objdetect/doc/cascade_classification.rst
@@ -189,6 +189,7 @@ CascadeClassifier::detectMultiScale
 Detects objects of different sizes in the input image. The detected objects are returned as a list of rectangles.
 
 .. ocv:function:: void CascadeClassifier::detectMultiScale( const Mat& image, vector<Rect>& objects, double scaleFactor=1.1, int minNeighbors=3, int flags=0, Size minSize=Size(), Size maxSize=Size())
+.. ocv:function:: void CascadeClassifier::detectMultiScale( const Mat& image, vector<Rect>& objects, vector<int>& numDetections, double scaleFactor=1.1, int minNeighbors=3, int flags=0, Size minSize=Size(), Size maxSize=Size())
 
 .. ocv:pyfunction:: cv2.CascadeClassifier.detectMultiScale(image[, scaleFactor[, minNeighbors[, flags[, minSize[, maxSize]]]]]) -> objects
 .. ocv:pyfunction:: cv2.CascadeClassifier.detectMultiScale(image[, scaleFactor[, minNeighbors[, flags[, minSize[, maxSize[, outputRejectLevels]]]]]]) -> objects, rejectLevels, levelWeights
@@ -200,6 +201,8 @@ Detects objects of different sizes in the input image. The detected objects are 
     :param image: Matrix of the type   ``CV_8U``  containing an image where objects are detected.
 
     :param objects: Vector of rectangles where each rectangle contains the detected object, the rectangles may be partially outside the original image.
+
+    :param numDetections: Vector of detection numbers for the corresponding objects. An object's number of detections is the number of neighboring positively classified rectangles that were joined together to form the object.
 
     :param scaleFactor: Parameter specifying how much the image size is reduced at each image scale.
 

--- a/modules/objdetect/include/opencv2/objdetect.hpp
+++ b/modules/objdetect/include/opencv2/objdetect.hpp
@@ -151,6 +151,14 @@ public:
 
     CV_WRAP virtual void detectMultiScale( const Mat& image,
                                    CV_OUT std::vector<Rect>& objects,
+                                   CV_OUT std::vector<int>& numDetections,
+                                   double scaleFactor=1.1,
+                                   int minNeighbors=3, int flags=0,
+                                   Size minSize=Size(),
+                                   Size maxSize=Size() );
+
+    CV_WRAP virtual void detectMultiScale( const Mat& image,
+                                   CV_OUT std::vector<Rect>& objects,
                                    CV_OUT std::vector<int>& rejectLevels,
                                    CV_OUT std::vector<double>& levelWeights,
                                    double scaleFactor = 1.1,
@@ -168,7 +176,12 @@ public:
 protected:
     virtual bool detectSingleScale( const Mat& image, int stripCount, Size processingRectSize,
                                     int stripSize, int yStep, double factor, std::vector<Rect>& candidates,
-                                    std::vector<int>& rejectLevels, std::vector<double>& levelWeights, bool outputRejectLevels = false);
+                                    std::vector<int>& rejectLevels, std::vector<double>& levelWeights, bool outputRejectLevels = false );
+
+    virtual void detectMultiScaleNoGrouping( const Mat& image, std::vector<Rect>& candidates,
+                                             std::vector<int>& rejectLevels, std::vector<double>& levelWeights,
+                                             double scaleFactor, Size minObjectSize, Size maxObjectSize,
+                                             bool outputRejectLevels = false );
 
 protected:
     enum { BOOST = 0


### PR DESCRIPTION
See original pull request https://github.com/Itseez/opencv/pull/961.
The issue: http://code.opencv.org/issues/3067.
**Note:** this commit only touches the C++ interface (and its documentation), Python and Java interfaces should also be updated. Unfortunately, I'm not familiar with them neither as a user, nor as a developer.
