### PR TITLE
Fix for Bug #3085

### DIFF
--- a/modules/ml/src/ann_mlp.cpp
+++ b/modules/ml/src/ann_mlp.cpp
@@ -251,7 +251,7 @@ void CvANN_MLP::create( const CvMat* _layer_sizes, int _activ_func,
     buf_sz += (l_dst[0] + l_dst[l_count-1]*2)*2;
 
     CV_CALL( wbuf = cvCreateMat( 1, buf_sz, CV_64F ));
-    CV_CALL( weights = (double**)cvAlloc( (l_count+1)*sizeof(weights[0]) ));
+    CV_CALL( weights = (double**)cvAlloc( (l_count+2)*sizeof(weights[0]) ));
 
     weights[0] = wbuf->data.db;
     weights[1] = weights[0] + l_dst[0]*2;


### PR DESCRIPTION
In `CvANN_MLP::create()` function, code segment

``` C++
CV_CALL( weights = (double**)cvAlloc( (l_count+1)*sizeof(weights0) ));
weights[0] = wbuf->data.db;
weights[1] = weights[0] + l_dst[0]*2;
for( i = 1; i < l_count; i++ )
    weights[i+1] = weights[i] + (l_dst[i-1] + 1)*l_dst[i];
weights[l_count+1] = weights[l_count] + l_dst[l_count-1]*2;
```

In the first statement, the `weights` array is only allocated for `l_count+1` elements, but in the last statement, `weights[l_count+1]` element is accessed.
