### PR TITLE
Fixes bug #3071.

### DIFF
--- a/doc/tutorials/features2d/feature_flann_matcher/feature_flann_matcher.rst
+++ b/doc/tutorials/features2d/feature_flann_matcher/feature_flann_matcher.rst
@@ -85,7 +85,7 @@ This tutorial code's is shown lines below. You can also download it from `here <
      std::vector< DMatch > good_matches;
 
      for( int i = 0; i < descriptors_1.rows; i++ )
-     { if( matches[i].distance < 2*min_dist )
+     { if( matches[i].distance <= 2*min_dist )
        { good_matches.push_back( matches[i]); }
      }
 
@@ -127,6 +127,3 @@ Result
    .. image:: images/Feature_FlannMatcher_Keypoints_Result.jpg
       :align: center
       :height: 250pt
-
-
-

--- a/samples/cpp/tutorial_code/features2D/SURF_FlannMatcher.cpp
+++ b/samples/cpp/tutorial_code/features2D/SURF_FlannMatcher.cpp
@@ -70,7 +70,7 @@ int main( int argc, char** argv )
   std::vector< DMatch > good_matches;
 
   for( int i = 0; i < descriptors_1.rows; i++ )
-  { if( matches[i].distance < 2*min_dist )
+  { if( matches[i].distance <= 2*min_dist )
     { good_matches.push_back( matches[i]); }
   }
 


### PR DESCRIPTION
http://code.opencv.org/issues/3071

If we have perfect matches (min_dist == 0.0), then strict comparison
fails. Making it non-strict results in treating perfect matches as
good.
