### PR TITLE
Fix for bug #2985

### DIFF
--- a/cmake/OpenCVDetectOpenCL.cmake
+++ b/cmake/OpenCVDetectOpenCL.cmake
@@ -44,10 +44,16 @@ if(OPENCL_FOUND)
   set(OPENCL_INCLUDE_DIRS ${OPENCL_INCLUDE_DIR})
   set(OPENCL_LIBRARIES    ${OPENCL_LIBRARY})
 
-  if (X86_64)
+  if(WIN64)
     set(CLAMD_POSSIBLE_LIB_SUFFIXES lib64/import)
-  elseif (X86)
+  elseif(WIN32)
     set(CLAMD_POSSIBLE_LIB_SUFFIXES lib32/import)
+  endif()
+
+  if(X86_64 AND UNIX)
+    set(CLAMD_POSSIBLE_LIB_SUFFIXES lib64)
+  elseif(X86 AND UNIX)
+    set(CLAMD_POSSIBLE_LIB_SUFFIXES lib32)
   endif()
 
   if(WITH_OPENCLAMDFFT)
@@ -80,7 +86,7 @@ if(OPENCL_FOUND)
   if(WITH_OPENCLAMDBLAS)
     find_path(CLAMDBLAS_ROOT_DIR
               NAMES include/clAmdBlas.h
-              PATHS ENV CLAMDFFT_PATH ENV ProgramFiles
+              PATHS ENV CLAMDBLAS_PATH ENV ProgramFiles
               PATH_SUFFIXES clAmdBlas AMD/clAmdBlas
               DOC "AMD FFT root directory"
               NO_DEFAULT_PATH)


### PR DESCRIPTION
http://code.opencv.org/issues/2985

`OPENCLAMDBLAS` and `OPENCLAMDFFT` never detected under linux.
`lib64/import` and `lib32/import` is the path on Windows but not Linux.
For `CLAMDBLAS` library we should use `CLAMDBLAS_PATH` (not `CLAMDFFT_PATH`)
