### PR TITLE
(#1205) Added possibility to skip some param checks.

### DIFF
--- a/doc/ocv.py
+++ b/doc/ocv.py
@@ -1456,6 +1456,17 @@ class OCVCurrentNamespace(Directive):
                 env.temp_data['ocv:prefix'] = prefix
         return []
 
+class OCVIgnoreParams(Directive):
+    """This directive does nothing. It's a marker that tells our doc tester
+    that the listed arguments don't need to be documented.
+    """
+
+    has_content = False
+    required_arguments = 1
+    final_argument_whitespace = True
+
+    def run(self):
+        return []
 
 class OCVXRefRole(XRefRole):
 
@@ -1510,7 +1521,8 @@ class OCVDomain(Domain):
         'emember':      OCVEnumMemberObject,
         'type':         OCVTypeObject,
         'enum':         OCVEnumObject,
-        'namespace':    OCVCurrentNamespace
+        'namespace':    OCVCurrentNamespace,
+        'ignoreparams': OCVIgnoreParams,
     }
     roles = {
         'class':  OCVXRefRole(),

--- a/modules/core/doc/clustering.rst
+++ b/modules/core/doc/clustering.rst
@@ -39,11 +39,16 @@ Finds centers of clusters and groups input samples around the clusters.
 
     :param compactness: The returned value that is described below.
 
-.. :param termcrit: (documentation isn't required)
-.. :param _centers: (documentation isn't required)
-.. :param samples: (documentation isn't required)
-.. :param cluster_count: (documentation isn't required)
-.. :param labels: (documentation isn't required)
+    .. ocv:ignoreparams:: termcrit
+
+    .. ocv:ignoreparams:: _centers
+
+    .. ocv:ignoreparams:: samples
+
+    .. ocv:ignoreparams:: cluster_count
+
+    .. ocv:ignoreparams:: labels
+
 
 
 The function ``kmeans`` implements a k-means algorithm that finds the

--- a/modules/core/doc/drawing_functions.rst
+++ b/modules/core/doc/drawing_functions.rst
@@ -52,7 +52,8 @@ Draws a circle.
 
     :param shift: Number of fractional bits in the coordinates of the center and in the radius value.
 
-.. :param line_type: (documentation isn't required)
+    .. ocv:ignoreparams:: line_type
+
 The function ``circle`` draws a simple or filled circle with a given center and radius.
 
 clipLine
@@ -77,7 +78,8 @@ Clips the line against the image rectangle.
 
     :param pt2: Second line point.
 
-.. :param img_size: (documentation isn't required)
+    .. ocv:ignoreparams:: img_size
+
 
 The functions ``clipLine`` calculate a part of the line segment that is entirely within the specified rectangle.
 They return ``false`` if the line segment is completely outside the rectangle. Otherwise, they return ``true`` .
@@ -123,9 +125,12 @@ Draws a simple or thick elliptic arc or fills an ellipse sector.
 
     :param shift: Number of fractional bits in the coordinates of the center and values of axes.
 
-.. :param start_angle: (documentation isn't required)
-.. :param end_angle: (documentation isn't required)
-.. :param line_type: (documentation isn't required)
+    .. ocv:ignoreparams:: start_angle
+
+    .. ocv:ignoreparams:: end_angle
+
+    .. ocv:ignoreparams:: line_type
+
 
 The functions ``ellipse`` with less parameters draw an ellipse outline, a filled ellipse, an elliptic arc, or a filled ellipse sector.
 A piecewise-linear curve is used to approximate the elliptic arc boundary. If you need more control of the ellipse rendering, you can retrieve the curve using
@@ -188,7 +193,8 @@ Fills a convex polygon.
 
     :param shift: Number of fractional bits in the vertex coordinates.
 
-.. :param line_type: (documentation isn't required)
+    .. ocv:ignoreparams:: line_type
+
 
 The function ``fillConvexPoly`` draws a filled convex polygon.
 This function is much faster than the function ``fillPoly`` . It can fill not only convex polygons but any monotonic polygon without self-intersections,
@@ -224,8 +230,10 @@ Fills the area bounded by one or more polygons.
 
     :param offset: Optional offset of all points of the contours.
 
-.. :param line_type: (documentation isn't required)
-.. :param contours: (documentation isn't required)
+    .. ocv:ignoreparams:: line_type
+
+    .. ocv:ignoreparams:: contours
+
 
 The function ``fillPoly`` fills an area bounded by several polygonal contours. The function can fill complex areas, for example,
 areas with holes, contours with self-intersections (some of their parts), and so forth.
@@ -254,9 +262,12 @@ Calculates the width and height of a text string.
 
     :param baseLine: Output parameter - y-coordinate of the baseline relative to the bottom-most text point.
 
-.. :param baseline: (documentation isn't required)
-.. :param text_string: (documentation isn't required)
-.. :param text_size: (documentation isn't required)
+    .. ocv:ignoreparams:: baseline
+
+    .. ocv:ignoreparams:: text_string
+
+    .. ocv:ignoreparams:: text_size
+
 
 The function ``getTextSize`` calculates and returns the size of a box that contains the specified text.
 That is, the following code renders some text, the tight box surrounding it, and the baseline: ::
@@ -373,7 +384,8 @@ Draws a line segment connecting two points.
 
     :param shift: Number of fractional bits in the point coordinates.
 
-.. :param line_type: (documentation isn't required)
+    .. ocv:ignoreparams:: line_type
+
 
 The function ``line`` draws the line segment between ``pt1`` and ``pt2`` points in the image. The line is clipped by the image boundaries. For non-antialiased lines with integer coordinates, the 8-connected or 4-connected Bresenham algorithm is used. Thick lines are drawn with rounding endings.
 Antialiased lines are drawn using Gaussian filtering. To specify the line color, you may use the macro ``CV_RGB(r, g, b)`` .
@@ -461,7 +473,8 @@ Draws a simple, thick, or filled up-right rectangle.
 
     :param shift: Number of fractional bits in the point coordinates.
 
-.. :param line_type: (documentation isn't required)
+    .. ocv:ignoreparams:: line_type
+
 
 The function ``rectangle`` draws a rectangle outline or a filled rectangle whose two opposite corners are ``pt1`` and ``pt2``, or ``r.tl()`` and ``r.br()-Point(1,1)``.
 
@@ -499,9 +512,12 @@ Draws several polygonal curves.
 
     :param shift: Number of fractional bits in the vertex coordinates.
 
-.. :param line_type: (documentation isn't required)
-.. :param contours: (documentation isn't required)
-.. :param is_closed: (documentation isn't required)
+    .. ocv:ignoreparams:: line_type
+
+    .. ocv:ignoreparams:: contours
+
+    .. ocv:ignoreparams:: is_closed
+
 
 The function ``polylines`` draws one or more polygonal curves.
 

--- a/modules/core/doc/operations_on_arrays.rst
+++ b/modules/core/doc/operations_on_arrays.rst
@@ -436,7 +436,8 @@ Calculates the covariance matrix of a set of vectors.
 
             * **CV_COVAR_COLS** [Only useful in the second variant of the function] If the flag is specified, all the input vectors are stored as columns of the  ``samples``  matrix.  ``mean``  should be a single-column vector in this case.
 
-.. :param count: (documentation isn't required)
+    .. ocv:ignoreparams:: count
+
 
 The functions ``calcCovarMatrix`` calculate the covariance matrix and, optionally, the mean vector of the set of input vectors.
 
@@ -545,7 +546,8 @@ Performs the per-element comparison of two arrays or an array and scalar value.
             * **CMP_LE** ``src1`` is less than or equal to ``src2``.
             * **CMP_NE** ``src1`` is unequal to ``src2``.
 
-.. :param cmp_op: (documentation isn't required)
+    .. ocv:ignoreparams:: cmp_op
+
 
 The function compares:
 
@@ -878,7 +880,8 @@ Performs a forward or inverse Discrete Fourier transform of a 1D or 2D floating-
 
     :param nonzeroRows: when the parameter is not zero, the function assumes that only the first ``nonzeroRows`` rows of the input array (``DFT_INVERSE`` is not set) or only the first ``nonzeroRows`` of the output array (``DFT_INVERSE`` is set) contain non-zeros, thus, the function can handle the rest of the rows more efficiently and save some time; this technique is very useful for calculating array cross-correlation or convolution using DFT.
 
-.. :param nonzero_rows: (documentation isn't required)
+    .. ocv:ignoreparams:: nonzero_rows
+
 
 
 The function performs one of the following:
@@ -1428,8 +1431,10 @@ Checks if array elements lie between the elements of two other arrays.
 
     :param dst: output array of the same size as ``src`` and ``CV_8U`` type.
 
-.. :param lower: the same as lowerb (documentation isn't required)
-.. :param upper: the same as upperb (documentation isn't required)
+    .. ocv:ignoreparams:: lower
+
+    .. ocv:ignoreparams:: upper
+
 
 The function checks the range as follows:
 
@@ -1733,7 +1738,8 @@ Calculates a mean and standard deviation of array elements.
 
     :param mask: optional operation mask.
 
-.. :param std_dev: (documentation isn't required)
+    .. ocv:ignoreparams:: std_dev
+
 
 The function ``meanStdDev`` calculates the mean and the standard deviation ``M`` of array elements independently for each channel and returns it via the output parameters:
 
@@ -1774,10 +1780,14 @@ Creates one multichannel array out of several single-channel ones.
 
     :param dst: output array of the same size and the same depth as ``mv[0]``; The number of channels will be the total number of channels in the matrix array.
 
-.. :param src0: (documentation isn't required)
-.. :param src1: (documentation isn't required)
-.. :param src2: (documentation isn't required)
-.. :param src3: (documentation isn't required)
+    .. ocv:ignoreparams:: src0
+
+    .. ocv:ignoreparams:: src1
+
+    .. ocv:ignoreparams:: src2
+
+    .. ocv:ignoreparams:: src3
+
 
 The functions ``merge`` merge several arrays to make a single multi-channel array. That is, each element of the output array will be a concatenation of the elements of the input arrays, where elements of i-th input array are treated as ``mv[i].channels()``-element vectors.
 
@@ -1910,10 +1920,14 @@ Finds the global minimum and maximum in an array.
 
     :param mask: optional mask used to select a sub-array.
 
-.. :param min_val: (documentation isn't required)
-.. :param max_val: (documentation isn't required)
-.. :param min_loc: (documentation isn't required)
-.. :param max_loc: (documentation isn't required)
+    .. ocv:ignoreparams:: min_val
+
+    .. ocv:ignoreparams:: max_val
+
+    .. ocv:ignoreparams:: min_loc
+
+    .. ocv:ignoreparams:: max_loc
+
 
 The functions ``minMaxLoc`` find the minimum and maximum element values and their positions. The extremums are searched across the whole array or,
 if ``mask`` is not an empty array, in the specified array region.
@@ -1963,10 +1977,14 @@ Copies specified channels from input arrays to the specified channels of output 
 
     :param npairs: number of index pairs in ``fromTo``.
 
-.. :param src_count: (documentation isn't required)
-.. :param dst_count: (documentation isn't required)
-.. :param pair_count: (documentation isn't required)
-.. :param from_to: (documentation isn't required)
+    .. ocv:ignoreparams:: src_count
+
+    .. ocv:ignoreparams:: dst_count
+
+    .. ocv:ignoreparams:: pair_count
+
+    .. ocv:ignoreparams:: from_to
+
 
 The functions ``mixChannels`` provide an advanced mechanism for shuffling image channels.
 
@@ -2020,9 +2038,12 @@ Performs the per-element multiplication of two Fourier spectrums.
 
     :param conjB: optional flag that conjugates the second input array before the multiplication (true) or not (false).
 
-.. :param src1: (documentation isn't required)
-.. :param src2: (documentation isn't required)
-.. :param dst: (documentation isn't required)
+    .. ocv:ignoreparams:: src1
+
+    .. ocv:ignoreparams:: src2
+
+    .. ocv:ignoreparams:: dst
+
 
 The function ``mulSpectrums`` performs the per-element multiplication of the two CCS-packed or complex matrices that are results of a real or complex Fourier transform.
 
@@ -2154,9 +2175,12 @@ Calculates an absolute array norm, an absolute difference norm, or a relative di
 
     :param mask: optional operation mask; it must have the same size as ``src1`` and ``CV_8UC1`` type.
 
-.. :param arr1: (documentation isn't required)
-.. :param arr2: (documentation isn't required)
-.. :param norm_type: (documentation isn't required)
+    .. ocv:ignoreparams:: arr1
+
+    .. ocv:ignoreparams:: arr2
+
+    .. ocv:ignoreparams:: norm_type
+
 
 The functions ``norm`` calculate an absolute norm of ``src1`` (when there is no ``src2`` ):
 
@@ -2214,7 +2238,8 @@ Normalizes the norm or value range of an array.
 
     :param mask: optional operation mask.
 
-.. :param norm_type: (documentation isn't required)
+    .. ocv:ignoreparams:: norm_type
+
 
 The functions ``normalize`` scale and shift the input array elements so that
 
@@ -2414,7 +2439,8 @@ Performs the perspective matrix transformation of vectors.
 
     :param m: ``3x3`` or ``4x4`` floating-point transformation matrix.
 
-.. :param mat: (documentation isn't required)
+    .. ocv:ignoreparams:: mat
+
 
 The function ``perspectiveTransform`` transforms every element of ``src`` by treating it as a 2D or 3D vector, in the following way:
 
@@ -2494,7 +2520,8 @@ Calculates x and y coordinates of 2D vectors from their magnitude and angle.
 
     :param angleInDegrees: when true, the input angles are measured in degrees, otherwise, they are measured in radians.
 
-.. :param angle_in_degrees: (documentation isn't required)
+    .. ocv:ignoreparams:: angle_in_degrees
+
 
 The function ``polarToCart`` calculates the Cartesian coordinates of each 2D vector represented by the corresponding elements of ``magnitude`` and ``angle`` :
 
@@ -2813,7 +2840,8 @@ Reduces a matrix to a vector.
 
     :param dtype: when negative, the output vector will have the same type as the input matrix, otherwise, its type will be ``CV_MAKE_TYPE(CV_MAT_DEPTH(dtype), src.channels())``.
 
-.. :param op: (documentation isn't required)
+    .. ocv:ignoreparams:: op
+
 
 The function ``reduce`` reduces the matrix to a vector by treating the matrix rows/columns as a set of 1D vectors and performing the specified operation on the vectors until a single row/column is obtained. For example, the function can be used to compute horizontal and vertical projections of a raster image. In case of ``CV_REDUCE_SUM`` and ``CV_REDUCE_AVG`` , the output may have a larger element bit-depth to preserve accuracy. And multi-channel arrays are also supported in these two reduction modes.
 
@@ -3338,9 +3366,12 @@ Performs SVD of a matrix
 
     :param flags: operation flags - see :ocv:func:`SVD::SVD`.
 
-.. :param A: (documentation isn't required)
-.. :param W: (documentation isn't required)
-.. :param U: (documentation isn't required)
+    .. ocv:ignoreparams:: A
+
+    .. ocv:ignoreparams:: W
+
+    .. ocv:ignoreparams:: U
+
 
 The methods/functions perform SVD of matrix. Unlike ``SVD::SVD`` constructor and ``SVD::operator()``, they store the results to the user-provided matrices. ::
 
@@ -3392,10 +3423,14 @@ Performs a singular value back substitution.
 
     :param dst: found solution of the system.
 
-.. :param B: (documentation isn't required)
-.. :param W: (documentation isn't required)
-.. :param U: (documentation isn't required)
-.. :param X: (documentation isn't required)
+    .. ocv:ignoreparams:: B
+
+    .. ocv:ignoreparams:: W
+
+    .. ocv:ignoreparams:: U
+
+    .. ocv:ignoreparams:: X
+
 
 The method calculates a back substitution for the specified right-hand side:
 
@@ -3423,7 +3458,6 @@ Calculates the sum of array elements.
 
     :param arr: input array that must have from 1 to 4 channels.
 
-.. :param arr: (documentation isn't required)
 
 The functions ``sum`` calculate and return the sum of array elements, independently for each channel.
 

--- a/modules/core/doc/utility_and_system_functions_and_macros.rst
+++ b/modules/core/doc/utility_and_system_functions_and_macros.rst
@@ -99,7 +99,8 @@ Computes the cube root of an argument.
 
     :param val: A function argument.
 
-.. :param value: (documentation isn't required)
+    .. ocv:ignoreparams:: value
+
 
 The function ``cubeRoot`` computes :math:`\sqrt[3]{\texttt{val}}`. Negative arguments are handled correctly. NaN and Inf are not handled. The accuracy approaches the maximum possible accuracy for single-precision data.
 
@@ -175,7 +176,7 @@ Checks a condition at runtime and throws exception if it fails
 
 .. ocv:function:: CV_Assert(expr)
 
-.. :param: (documentation isn't required)
+    :ocv-param-ignore: (documentation isn't required)
 
 The macros ``CV_Assert`` (and ``CV_DbgAssert``) evaluate the specified expression. If it is 0, the macros raise an error (see :ocv:func:`error` ). The macro ``CV_Assert`` checks the condition in both Debug and Release configurations while ``CV_DbgAssert`` is only retained in the Debug configuration.
 
@@ -200,7 +201,8 @@ Signals an error and raises an exception.
 
     :param line: The line of the file, where the error has happened.
 
-.. :param args: ``printf`` -like formatted error message in parentheses.
+    .. ocv:ignoreparams:: args
+
 
 The function and the helper macros ``CV_Error`` and ``CV_Error_``: ::
 
@@ -260,7 +262,8 @@ Allocates an aligned memory buffer.
 
     :param bufSize: Allocated buffer size.
 
-.. :param size: (documentation isn't required)
+    .. ocv:ignoreparams:: size
+
 
 The function allocates the buffer of the specified size and returns it. When the buffer size is 16 bytes or more, the returned buffer is aligned to 16 bytes.
 

--- a/modules/core/doc/xml_yaml_persistence.rst
+++ b/modules/core/doc/xml_yaml_persistence.rst
@@ -183,9 +183,12 @@ Opens a file.
 
 See description of parameters in :ocv:func:`FileStorage::FileStorage`. The method calls :ocv:func:`FileStorage::release` before opening the file.
 
-.. :param filename: (documentation isn't required)
-.. :param flags: (documentation isn't required)
-.. :param encoding: (documentation isn't required)
+    .. ocv:ignoreparams:: filename
+
+    .. ocv:ignoreparams:: flags
+
+    .. ocv:ignoreparams:: encoding
+
 
 
 FileStorage::isOpened
@@ -665,7 +668,7 @@ Moves iterator to the next node.
 .. ocv:function:: FileNodeIterator FileNodeIterator::operator ++ (int)
 
 
-.. :param: (documentation isn't required)
+    :ocv-param-ignore: (documentation isn't required)
 
 
 FileNodeIterator::operator --
@@ -676,7 +679,7 @@ Moves iterator to the previous node.
 
 .. ocv:function:: FileNodeIterator FileNodeIterator::operator -- (int)
 
-.. :param: (documentation isn't required)
+    :ocv-param-ignore: (documentation isn't required)
 
 FileNodeIterator::operator +=
 -----------------------------

--- a/modules/highgui/doc/reading_and_writing_images_and_video.rst
+++ b/modules/highgui/doc/reading_and_writing_images_and_video.rst
@@ -495,8 +495,10 @@ VideoWriter constructors
 
     :param isColor: If it is not zero, the encoder will expect and encode color frames, otherwise it will work with grayscale frames (the flag is currently supported on Windows only).
 
-.. :param is_color: (documentation isn't required)
-.. :param frame_size: (documentation isn't required)
+    .. ocv:ignoreparams:: is_color
+
+    .. ocv:ignoreparams:: frame_size
+
 
 The constructors/functions initialize video writers. On Linux FFMPEG is used to write videos; on Windows FFMPEG or VFW is used; on MacOSX QTKit is used.
 
@@ -519,13 +521,18 @@ Initializes or reinitializes video writer.
 
 .. ocv:pyfunction:: cv2.VideoWriter.open(filename, fourcc, fps, frameSize[, isColor]) -> retval
 
+    .. ocv:ignoreparams:: filename
+
+    .. ocv:ignoreparams:: fourcc
+
+    .. ocv:ignoreparams:: fps
+
+    .. ocv:ignoreparams:: frameSize
+
+    .. ocv:ignoreparams:: isColor
+
 The method opens video writer. Parameters are the same as in the constructor :ocv:func:`VideoWriter::VideoWriter`.
 
-.. :param filename:  (documentation isn't required)
-.. :param fourcc:    (documentation isn't required)
-.. :param fps:       (documentation isn't required)
-.. :param frameSize: (documentation isn't required)
-.. :param isColor:   (documentation isn't required)
 
 VideoWriter::isOpened
 ---------------------

--- a/modules/imgproc/doc/feature_detection.rst
+++ b/modules/imgproc/doc/feature_detection.rst
@@ -29,7 +29,8 @@ Finds edges in an image using the [Canny86]_ algorithm.
 
     :param L2gradient: a flag, indicating whether a more accurate  :math:`L_2`  norm  :math:`=\sqrt{(dI/dx)^2 + (dI/dy)^2}`  should be used to calculate the image gradient magnitude ( ``L2gradient=true`` ), or whether the default  :math:`L_1`  norm  :math:`=|dI/dx|+|dI/dy|`  is enough ( ``L2gradient=false`` ).
 
-.. :param aperture_size: (documentation isn't required)
+    .. ocv:ignoreparams:: aperture_size
+
 
 The function finds edges in the input image ``image`` and marks them in the output map ``edges`` using the Canny algorithm. The smallest value between ``threshold1`` and ``threshold2`` is used for edge linking. The largest value is used to find initial segments of strong edges. See
 http://en.wikipedia.org/wiki/Canny_edge_detector
@@ -58,8 +59,10 @@ Calculates eigenvalues and eigenvectors of image blocks for corner detection.
 
     :param borderType: Pixel extrapolation method. See  :ocv:func:`borderInterpolate` .
 
-.. :param block_size: (documentation isn't required)
-.. :param aperture_size: (documentation isn't required)
+    .. ocv:ignoreparams:: block_size
+
+    .. ocv:ignoreparams:: aperture_size
+
 
 For every pixel
 :math:`p` , the function ``cornerEigenValsAndVecs`` considers a ``blockSize`` :math:`\times` ``blockSize`` neighborhood
@@ -116,7 +119,8 @@ Harris edge detector.
 
     :param borderType: Pixel extrapolation method. See  :ocv:func:`borderInterpolate` .
 
-.. :param aperture_size: (documentation isn't required)
+    .. ocv:ignoreparams:: aperture_size
+
 
 The function runs the Harris edge detector on the image. Similarly to
 :ocv:func:`cornerMinEigenVal` and
@@ -156,8 +160,10 @@ Calculates the minimal eigenvalue of gradient matrices for corner detection.
 
     :param borderType: Pixel extrapolation method. See  :ocv:func:`borderInterpolate` .
 
-.. :param block_size: (documentation isn't required)
-.. :param aperture_size: (documentation isn't required)
+    .. ocv:ignoreparams:: block_size
+
+    .. ocv:ignoreparams:: aperture_size
+
 
 The function is similar to
 :ocv:func:`cornerEigenValsAndVecs` but it calculates and stores only the minimal eigenvalue of the covariance matrix of derivatives, that is,
@@ -188,7 +194,8 @@ Refines the corner locations.
 
     :param criteria: Criteria for termination of the iterative process of corner refinement. That is, the process of corner position refinement stops either after ``criteria.maxCount`` iterations or when the corner position moves by less than ``criteria.epsilon`` on some iteration.
 
-.. :param zero_zone: (documentation isn't required)
+    .. ocv:ignoreparams:: zero_zone
+
 
 The function iterates to find the sub-pixel accurate location of corners or radial saddle points, as shown on the figure below.
 
@@ -264,9 +271,12 @@ Determines strong corners on an image.
 
     :param k: Free parameter of the Harris detector.
 
-.. :param quality_level: (documentation isn't required)
-.. :param min_distance: (documentation isn't required)
-.. :param block_size: (documentation isn't required)
+    .. ocv:ignoreparams:: quality_level
+
+    .. ocv:ignoreparams:: min_distance
+
+    .. ocv:ignoreparams:: block_size
+
 
 The function finds the most prominent corners in the image or in the specified image region, as described in [Shi94]_:
 

--- a/modules/imgproc/doc/filtering.rst
+++ b/modules/imgproc/doc/filtering.rst
@@ -1376,7 +1376,8 @@ Performs initial step of meanshift segmentation of an image.
 
     :param termcrit: Termination criteria: when to stop meanshift iterations.
 
-.. :param max_level: (documentation isn't required)
+    .. ocv:ignoreparams:: max_level
+
 
 The function implements the filtering stage of meanshift segmentation, that is, the output of the function is the filtered "posterized" image with color gradients and fine-grain texture flattened. At every pixel
 ``(X,Y)`` of the input image (or down-sized input image, see below) the function executes meanshift

--- a/modules/imgproc/doc/histograms.rst
+++ b/modules/imgproc/doc/histograms.rst
@@ -38,7 +38,8 @@ Calculates a histogram of a set of arrays.
 
     :param accumulate: Accumulation flag. If it is set, the histogram is not cleared in the beginning when it is allocated. This feature enables you to compute a single histogram from several sets of arrays, or to update the histogram in time.
 
-.. :param image: (documentation isn't required)
+    .. ocv:ignoreparams:: image
+
 
 The functions ``calcHist`` calculate the histogram of one or more
 arrays. The elements of a tuple used to increment
@@ -133,7 +134,8 @@ Calculates the back projection of a histogram.
 
     :param uniform: Flag indicating whether the histogram is uniform or not (see above).
 
-.. :param image: (documentation isn't required)
+    .. ocv:ignoreparams:: image
+
 
 The functions ``calcBackProject`` calculate the back project of the histogram. That is, similarly to ``calcHist`` , at each location ``(x, y)`` the function collects the values from the selected channels in the input images and finds the corresponding histogram bin. But instead of incrementing it, the function reads the bin value, scales it by ``scale`` , and stores in ``backProject(x,y)`` . In terms of statistics, the function computes probability of each element value in respect with the empirical probability distribution represented by the histogram. See how, for example, you can find and track a bright-colored object in a scene:
 
@@ -181,8 +183,10 @@ Compares two histograms.
             
             * **CV_COMP_HELLINGER**     Synonym for ``CV_COMP_BHATTACHARYYA``
 
-.. :param hist1: (documentation isn't required)
-.. :param hist2: (documentation isn't required)
+    .. ocv:ignoreparams:: hist1
+
+    .. ocv:ignoreparams:: hist2
+
 
 The functions ``compareHist`` compare two dense or two sparse histograms using the specified method:
 
@@ -259,9 +263,12 @@ Computes the "minimal work" distance between two weighted point configurations.
 
     :param userdata: Optional pointer directly passed to the custom distance function.
 
-.. :param distance_type: (documentation isn't required)
-.. :param lower_bound: (documentation isn't required)
-.. :param cost_matrix: (documentation isn't required)
+    .. ocv:ignoreparams:: distance_type
+
+    .. ocv:ignoreparams:: lower_bound
+
+    .. ocv:ignoreparams:: cost_matrix
+
 
 The function computes the earth mover distance and/or a lower boundary of the distance between the two weighted point configurations. One of the applications described in [RubnerSept98]_ is multi-dimensional histogram comparison for image retrieval. EMD is a transportation problem that is solved using some modification of a simplex algorithm, thus the complexity is exponential in the worst case, though, on average it is much faster. In the case of a real metric the lower boundary can be calculated even faster (using linear-time algorithm) and it can be used to determine roughly whether the two signatures are far enough so that they cannot relate to the same object.
 

--- a/modules/imgproc/doc/miscellaneous_transformations.rst
+++ b/modules/imgproc/doc/miscellaneous_transformations.rst
@@ -30,10 +30,14 @@ Applies an adaptive threshold to an array.
 
     :param C: Constant subtracted from the mean or weighted mean (see the details below). Normally, it is positive but may be zero or negative as well.
 
-.. :param max_value: (documentation isn't required)
-.. :param adaptive_method: (documentation isn't required)
-.. :param threshold_type: (documentation isn't required)
-.. :param block_size: (documentation isn't required)
+    .. ocv:ignoreparams:: max_value
+
+    .. ocv:ignoreparams:: adaptive_method
+
+    .. ocv:ignoreparams:: threshold_type
+
+    .. ocv:ignoreparams:: block_size
+
 
 The function transforms a grayscale image to a binary image according to the formulae:
 
@@ -439,8 +443,10 @@ Calculates the distance to the closest zero pixel for each pixel of the source i
 
     :param labelType: Type of the label array to build. If ``labelType==DIST_LABEL_CCOMP`` then each connected component of zeros in ``src`` (as well as all the non-zero pixels closest to the connected component) will be assigned the same label. If ``labelType==DIST_LABEL_PIXEL`` then each zero pixel (and all the non-zero pixels closest to it) gets its own label.
 
-.. :param distance_type: (documentation isn't required)
-.. :param mask_size: (documentation isn't required)
+    .. ocv:ignoreparams:: distance_type
+
+    .. ocv:ignoreparams:: mask_size
+
 
 The functions ``distanceTransform`` calculate the approximate or precise
 distance from every binary image pixel to the nearest zero pixel.
@@ -524,10 +530,14 @@ Fills a connected component with the given color.
 
             * **FLOODFILL_MASK_ONLY**  If set, the function does not change the image ( ``newVal``  is ignored), but fills the mask.  The flag can be used for the second variant only.
 
-.. :param seed_point: (documentation isn't required)
-.. :param new_val: (documentation isn't required)
-.. :param lo_diff: (documentation isn't required)
-.. :param up_diff: (documentation isn't required)
+    .. ocv:ignoreparams:: seed_point
+
+    .. ocv:ignoreparams:: new_val
+
+    .. ocv:ignoreparams:: lo_diff
+
+    .. ocv:ignoreparams:: up_diff
+
 
 The functions ``floodFill`` fill a connected component starting from the seed point with the specified color. The connectivity is determined by the color/brightness closeness of the neighbor pixels. The pixel at
 :math:`(x,y)` is considered to belong to the repainted domain if:
@@ -681,8 +691,10 @@ Applies a fixed-level threshold to each array element.
 
     :param type: thresholding type (see the details below).
 
-.. :param max_value: (documentation isn't required)
-.. :param threshold_type: (documentation isn't required)
+    .. ocv:ignoreparams:: max_value
+
+    .. ocv:ignoreparams:: threshold_type
+
 
 The function applies fixed-level thresholding
 to a single-channel array. The function is typically used to get a

--- a/modules/imgproc/doc/motion_analysis_and_object_tracking.rst
+++ b/modules/imgproc/doc/motion_analysis_and_object_tracking.rst
@@ -21,8 +21,10 @@ Adds an image to the accumulator.
 
     :param mask: Optional operation mask.
 
-.. :param image: (documentation isn't required)
-.. :param sum: (documentation isn't required)
+    .. ocv:ignoreparams:: image
+
+    .. ocv:ignoreparams:: sum
+
 
 The function adds ``src``  or some of its elements to ``dst`` :
 
@@ -60,8 +62,10 @@ Adds the square of a source image to the accumulator.
 
     :param mask: Optional operation mask.
 
-.. :param image: (documentation isn't required)
-.. :param sqsum: (documentation isn't required)
+    .. ocv:ignoreparams:: image
+
+    .. ocv:ignoreparams:: sqsum
+
 
 The function adds the input image ``src`` or its selected region, raised to a power of 2, to the accumulator ``dst`` :
 
@@ -99,9 +103,12 @@ Adds the per-element product of two input images to the accumulator.
 
     :param mask: Optional operation mask.
 
-.. :param image1: (documentation isn't required)
-.. :param image2: (documentation isn't required)
-.. :param acc: (documentation isn't required)
+    .. ocv:ignoreparams:: image1
+
+    .. ocv:ignoreparams:: image2
+
+    .. ocv:ignoreparams:: acc
+
 
 The function adds the product of two images or their selected regions to the accumulator ``dst`` :
 
@@ -138,8 +145,10 @@ Updates a running average.
 
     :param mask: Optional operation mask.
 
-.. :param image: (documentation isn't required)
-.. :param acc: (documentation isn't required)
+    .. ocv:ignoreparams:: image
+
+    .. ocv:ignoreparams:: acc
+
 
 The function calculates the weighted sum of the input image ``src`` and the accumulator ``dst`` so that ``dst`` becomes a running average of a frame sequence:
 


### PR DESCRIPTION
Since some parameters should not be documented explicitly
(e.g. when there is a description like "parameters the same as in the
constructor"), added possibility to skip the check concerning these
parameters in the rst_parser.py
