### PR TITLE
Replaced the semi-public CV_PARALLEL_FRAMEWORK macro with a function.

### DIFF
--- a/modules/core/include/opencv2/core/internal.hpp
+++ b/modules/core/include/opencv2/core/internal.hpp
@@ -50,7 +50,8 @@
 
 #include <vector>
 
-#include "cvconfig.h"
+#include "opencv2/core/core.hpp"
+#include "opencv2/core/types_c.h"
 
 #if defined WIN32 || defined _WIN32
 #  ifndef WIN32
@@ -186,30 +187,6 @@ CV_INLINE IppiSize ippiSize(int width, int height)
 #  include "opencv2/core/eigen.hpp"
 #endif
 
-#ifdef _OPENMP
-#  define HAVE_OPENMP
-#endif
-
-#ifdef __APPLE__
-#  define HAVE_GCD
-#endif
-
-#if defined _MSC_VER && _MSC_VER >= 1600
-#  define HAVE_CONCURRENCY
-#endif
-
-#if defined HAVE_TBB && TBB_VERSION_MAJOR*100 + TBB_VERSION_MINOR >= 202
-#  define CV_PARALLEL_FRAMEWORK "tbb"
-#elif defined HAVE_CSTRIPES
-#  define CV_PARALLEL_FRAMEWORK "cstripes"
-#elif defined HAVE_OPENMP
-#  define CV_PARALLEL_FRAMEWORK "openmp"
-#elif defined HAVE_GCD
-#  define CV_PARALLEL_FRAMEWORK "gcd"
-#elif defined HAVE_CONCURRENCY
-#  define CV_PARALLEL_FRAMEWORK "ms-concurrency"
-#endif
-
 #ifdef __cplusplus
 
 namespace cv
@@ -277,6 +254,10 @@ namespace cv
         body(range);
     }
 #endif
+
+    // Returns a static string if there is a parallel framework,
+    // NULL otherwise.
+    CV_EXPORTS const char* currentParallelFramework();
 } //namespace cv
 
 #define CV_INIT_ALGORITHM(classname, algname, memberinit) \

--- a/modules/core/src/parallel.cpp
+++ b/modules/core/src/parallel.cpp
@@ -61,6 +61,17 @@
     #endif
 #endif
 
+#ifdef _OPENMP
+    #define HAVE_OPENMP
+#endif
+
+#ifdef __APPLE__
+    #define HAVE_GCD
+#endif
+
+#if defined _MSC_VER && _MSC_VER >= 1600
+    #define HAVE_CONCURRENCY
+#endif
 
 /* IMPORTANT: always use the same order of defines
    1. HAVE_TBB         - 3rdparty library, should be explicitly enabled
@@ -97,6 +108,18 @@
     #elif defined HAVE_CONCURRENCY
         #include <ppl.h>
     #endif
+#endif
+
+#if defined HAVE_TBB && TBB_VERSION_MAJOR*100 + TBB_VERSION_MINOR >= 202
+#  define CV_PARALLEL_FRAMEWORK "tbb"
+#elif defined HAVE_CSTRIPES
+#  define CV_PARALLEL_FRAMEWORK "cstripes"
+#elif defined HAVE_OPENMP
+#  define CV_PARALLEL_FRAMEWORK "openmp"
+#elif defined HAVE_GCD
+#  define CV_PARALLEL_FRAMEWORK "gcd"
+#elif defined HAVE_CONCURRENCY
+#  define CV_PARALLEL_FRAMEWORK "ms-concurrency"
 #endif
 
 namespace cv
@@ -462,6 +485,14 @@ int cv::getNumberOfCPUs(void)
     return (int)numCPU;
 #else
     return 1;
+#endif
+}
+
+const char* cv::currentParallelFramework() {
+#ifdef CV_PARALLEL_FRAMEWORK
+    return CV_PARALLEL_FRAMEWORK;
+#else
+    return NULL;
 #endif
 }
 

--- a/modules/ts/src/precomp.hpp
+++ b/modules/ts/src/precomp.hpp
@@ -1,4 +1,3 @@
-#include "opencv2/core/core.hpp"
 #include "opencv2/core/core_c.h"
 #include "opencv2/core/internal.hpp"
 #include "opencv2/ts/ts.hpp"

--- a/modules/ts/src/ts_func.cpp
+++ b/modules/ts/src/ts_func.cpp
@@ -2963,13 +2963,12 @@ void printVersionInfo(bool useStdOut)
         if(useStdOut) std::cout << ver << std::endl;
     }
 
-#ifdef CV_PARALLEL_FRAMEWORK
-    ::testing::Test::RecordProperty("cv_parallel_framework", CV_PARALLEL_FRAMEWORK);
-    if (useStdOut)
-    {
-        std::cout << "Parallel framework: " << CV_PARALLEL_FRAMEWORK << std::endl;
+    const char* parallel_framework = currentParallelFramework();
+
+    if (parallel_framework) {
+        ::testing::Test::RecordProperty("cv_parallel_framework", parallel_framework);
+        if (useStdOut) std::cout << "Parallel framework: " << parallel_framework << std::endl;
     }
-#endif
 
     std::string cpu_features;
 


### PR DESCRIPTION
That way, core/internal.hpp doesn't have to depend on cvconfig.h, which we don't ship.
