### PR TITLE
fix gpu::DeviceInfo compilation under linux

### DIFF
--- a/modules/core/include/opencv2/core/gpu.hpp
+++ b/modules/core/include/opencv2/core/gpu.hpp
@@ -529,10 +529,10 @@ public:
     size_t totalConstMem() const;
 
     //! major compute capability
-    int major() const;
+    int majorVersion() const;
 
     //! minor compute capability
-    int minor() const;
+    int minorVersion() const;
 
     //! alignment requirement for textures
     size_t textureAlignment() const;

--- a/modules/core/include/opencv2/core/gpu.inl.hpp
+++ b/modules/core/include/opencv2/core/gpu.inl.hpp
@@ -619,7 +619,7 @@ size_t DeviceInfo::totalMemory() const
 inline
 bool DeviceInfo::supports(FeatureSet feature_set) const
 {
-    int version = major() * 10 + minor();
+    int version = majorVersion() * 10 + minorVersion();
     return version >= feature_set;
 }
 

--- a/modules/core/src/gpu_info.cpp
+++ b/modules/core/src/gpu_info.cpp
@@ -119,7 +119,7 @@ bool cv::gpu::deviceSupports(FeatureSet feature_set)
     else
     {
         DeviceInfo dev(devId);
-        version = dev.major() * 10 + dev.minor();
+        version = dev.majorVersion() * 10 + dev.minorVersion();
         if (devId < cache_size)
             versions[devId] = version;
     }
@@ -455,7 +455,7 @@ size_t cv::gpu::DeviceInfo::totalConstMem() const
 #endif
 }
 
-int cv::gpu::DeviceInfo::major() const
+int cv::gpu::DeviceInfo::majorVersion() const
 {
 #ifndef HAVE_CUDA
     throw_no_cuda();
@@ -465,7 +465,7 @@ int cv::gpu::DeviceInfo::major() const
 #endif
 }
 
-int cv::gpu::DeviceInfo::minor() const
+int cv::gpu::DeviceInfo::minorVersion() const
 {
 #ifndef HAVE_CUDA
     throw_no_cuda();
@@ -908,12 +908,12 @@ bool cv::gpu::DeviceInfo::isCompatible() const
     return false;
 #else
     // Check PTX compatibility
-    if (TargetArchs::hasEqualOrLessPtx(major(), minor()))
+    if (TargetArchs::hasEqualOrLessPtx(majorVersion(), minorVersion()))
         return true;
 
     // Check BIN compatibility
-    for (int i = minor(); i >= 0; --i)
-        if (TargetArchs::hasBin(major(), i))
+    for (int i = minorVersion(); i >= 0; --i)
+        if (TargetArchs::hasBin(majorVersion(), i))
             return true;
 
     return false;

--- a/modules/gpu/doc/initalization_and_information.rst
+++ b/modules/gpu/doc/initalization_and_information.rst
@@ -147,10 +147,10 @@ Class providing functionality for querying the specified GPU properties. ::
         size_t totalConstMem() const;
 
         //! major compute capability
-        int major() const;
+        int majorVersion() const;
 
         //! minor compute capability
-        int minor() const;
+        int minorVersion() const;
 
         //! alignment requirement for textures
         size_t textureAlignment() const;
@@ -313,19 +313,19 @@ Returns the device name.
 
 
 
-gpu::DeviceInfo::major
-----------------------
+gpu::DeviceInfo::majorVersion
+-----------------------------
 Returns the major compute capability version.
 
-.. ocv:function:: int gpu::DeviceInfo::major()
+.. ocv:function:: int gpu::DeviceInfo::majorVersion()
 
 
 
-gpu::DeviceInfo::minor
-----------------------
+gpu::DeviceInfo::minorVersion
+-----------------------------
 Returns the minor compute capability version.
 
-.. ocv:function:: int gpu::DeviceInfo::minor()
+.. ocv:function:: int gpu::DeviceInfo::minorVersion()
 
 
 

--- a/modules/gpufilters/src/filtering.cpp
+++ b/modules/gpufilters/src/filtering.cpp
@@ -409,7 +409,7 @@ namespace
         ensureSizeIsEnough(src.size(), bufType_, buf_);
 
         DeviceInfo devInfo;
-        const int cc = devInfo.major() * 10 + devInfo.minor();
+        const int cc = devInfo.majorVersion() * 10 + devInfo.minorVersion();
 
         cudaStream_t stream = StreamAccessor::getStream(_stream);
 

--- a/modules/gpuoptflow/test/test_optflow.cpp
+++ b/modules/gpuoptflow/test/test_optflow.cpp
@@ -80,7 +80,7 @@ GPU_TEST_P(BroxOpticalFlow, Regression)
     brox(loadMat(frame0), loadMat(frame1), u, v);
 
     std::string fname(cvtest::TS::ptr()->get_data_path());
-    if (devInfo.major() >= 2)
+    if (devInfo.majorVersion() >= 2)
         fname += "opticalflow/brox_optical_flow_cc20.bin";
     else
         fname += "opticalflow/brox_optical_flow.bin";

--- a/modules/ts/src/gpu_perf.cpp
+++ b/modules/ts/src/gpu_perf.cpp
@@ -288,7 +288,7 @@ namespace perf
 
             printf("[----------]\n"), fflush(stdout);
             printf("[ DEVICE   ] \t# %d %s.\n", i, info.name()), fflush(stdout);
-            printf("[          ] \tCompute capability: %d.%d\n", (int)info.major(), (int)info.minor()), fflush(stdout);
+            printf("[          ] \tCompute capability: %d.%d\n", (int)info.majorVersion(), (int)info.minorVersion()), fflush(stdout);
             printf("[          ] \tMulti Processor Count:  %d\n", info.multiProcessorCount()), fflush(stdout);
             printf("[          ] \tTotal memory: %d Mb\n", static_cast<int>(static_cast<int>(info.totalMemory() / 1024.0) / 1024.0)), fflush(stdout);
             printf("[          ] \tFree  memory: %d Mb\n", static_cast<int>(static_cast<int>(info.freeMemory()  / 1024.0) / 1024.0)), fflush(stdout);

--- a/samples/gpu/driver_api_multi.cpp
+++ b/samples/gpu/driver_api_multi.cpp
@@ -86,8 +86,8 @@ int main()
         if (!dev_info.isCompatible())
         {
             std::cout << "GPU module isn't built for GPU #" << i << " ("
-                 << dev_info.name() << ", CC " << dev_info.major()
-                 << dev_info.minor() << "\n";
+                 << dev_info.name() << ", CC " << dev_info.majorVersion()
+                 << dev_info.minorVersion() << "\n";
             return -1;
         }
     }

--- a/samples/gpu/driver_api_stereo_multi.cpp
+++ b/samples/gpu/driver_api_stereo_multi.cpp
@@ -116,8 +116,8 @@ int main(int argc, char** argv)
         if (!dev_info.isCompatible())
         {
             std::cout << "GPU module isn't built for GPU #" << i << " ("
-                 << dev_info.name() << ", CC " << dev_info.major()
-                 << dev_info.minor() << "\n";
+                 << dev_info.name() << ", CC " << dev_info.majorVersion()
+                 << dev_info.minorVersion() << "\n";
             return -1;
         }
     }

--- a/samples/gpu/multi.cpp
+++ b/samples/gpu/multi.cpp
@@ -62,8 +62,8 @@ int main()
         if (!dev_info.isCompatible())
         {
             std::cout << "GPU module isn't built for GPU #" << i << " ("
-                 << dev_info.name() << ", CC " << dev_info.major()
-                 << dev_info.minor() << "\n";
+                 << dev_info.name() << ", CC " << dev_info.majorVersion()
+                 << dev_info.minorVersion() << "\n";
             return -1;
         }
     }

--- a/samples/gpu/performance/performance.cpp
+++ b/samples/gpu/performance/performance.cpp
@@ -191,7 +191,7 @@ int main(int argc, const char* argv[])
     DeviceInfo dev_info(device);
     if (!dev_info.isCompatible())
     {
-        cerr << "GPU module isn't built for GPU #" << device << " " << dev_info.name() << ", CC " << dev_info.major() << '.' << dev_info.minor() << endl;
+        cerr << "GPU module isn't built for GPU #" << device << " " << dev_info.name() << ", CC " << dev_info.majorVersion() << '.' << dev_info.minorVersion() << endl;
         return -1;
     }
     setDevice(device);

--- a/samples/gpu/stereo_multi.cpp
+++ b/samples/gpu/stereo_multi.cpp
@@ -81,8 +81,8 @@ int main(int argc, char** argv)
         if (!dev_info.isCompatible())
         {
             std::cout << "GPU module isn't built for GPU #" << i << " ("
-                 << dev_info.name() << ", CC " << dev_info.major()
-                 << dev_info.minor() << "\n";
+                 << dev_info.name() << ", CC " << dev_info.majorVersion()
+                 << dev_info.minorVersion() << "\n";
             return -1;
         }
     }


### PR DESCRIPTION
glibc defines `major` and `minor` macros, which conflict with `gpu::DeviceInfo` methods with the same name.
