### PR TITLE
MinGW - Bugfix - C99 compliance (overide and replace the pull request #/1037)

### DIFF
--- a/cmake/OpenCVCompilerOptions.cmake
+++ b/cmake/OpenCVCompilerOptions.cmake
@@ -57,6 +57,9 @@ if(MINGW)
   if(NOT HAVE_CXX_MSTACKREALIGN)
     add_extra_compiler_option(-mpreferred-stack-boundary=2)
   endif()
+
+  # Use mingw's sprintf instead of windows's
+  add_definitions(-D__USE_MINGW_ANSI_STDIO=1) 
 endif()
 
 if(CMAKE_COMPILER_IS_GNUCXX)


### PR DESCRIPTION
Some functions provided by Microsoft does not work as described in C99 specifications. For example function 'vsnprintf' does not return number of characters that would have been printed but only '-1' if the format does not fit in the given field.
Mingw provides possibility to assume ANSI I/O standards are preferred over Microsoft's. This is enabled by
# define USE_MINGW_ANSI_STDIO 1

before including any system libraries. This way, without modifying the code, the call to "sprintf" (Microsoft's implementation) is replaced by a call to "mingw_sprintf" which is C99 compliant.
