### PR TITLE
Fix miscellaneous warnings from compiling with MinGW.

### DIFF
--- a/modules/ocl/perf/precomp.cpp
+++ b/modules/ocl/perf/precomp.cpp
@@ -42,7 +42,9 @@
 
 #include "precomp.hpp"
 #if GTEST_OS_WINDOWS
+#ifndef NOMINMAX
 #define NOMINMAX
+#endif
 # include <windows.h>
 #endif
 
@@ -278,7 +280,7 @@ enum GTestColor {
 };
 #if GTEST_OS_WINDOWS&&!GTEST_OS_WINDOWS_MOBILE
 // Returns the character attribute for the given color.
-WORD GetColorAttribute(GTestColor color) {
+static WORD GetColorAttribute(GTestColor color) {
     switch (color) {
     case COLOR_RED:    return FOREGROUND_RED;
     case COLOR_GREEN:  return FOREGROUND_GREEN;

--- a/modules/ocl/src/haar.cpp
+++ b/modules/ocl/src/haar.cpp
@@ -142,7 +142,7 @@ typedef struct
     int imgoff;
     float factor;
 } detect_piramid_info;
-#ifdef WIN32
+#ifdef _MSC_VER
 #define _ALIGNED_ON(_ALIGNMENT) __declspec(align(_ALIGNMENT))
 
 typedef _ALIGNED_ON(128) struct  GpuHidHaarTreeNode


### PR DESCRIPTION
These warnings: http://build.opencv.org/builders/win_x64%5Brelease%5D--%5Bsse_%3D_ON%5D--%5Btbb_%3D_OFF%5D--%5Bgpu_%3D_OFF%5D--%5Bcompiler_%3D_mingw%5D--%5Btests_%3D_ON%5D-/builds/1080/steps/compile%20release%2064%20mingw%20shared%20n/logs/stdio
