### PR TITLE
dc1394-2: support for operation mode 1394b added

### DIFF
--- a/modules/highgui/src/cap_dc1394_v2.cpp
+++ b/modules/highgui/src/cap_dc1394_v2.cpp
@@ -295,6 +295,11 @@ bool CvCaptureCAM_DC1394_v2_CPP::startCapture()
         return false;
     if (isoSpeed > 0)
     {
+        // if capable set operation mode to 1394b for iso speeds above 400
+        if (isoSpeed > 400 && dcCam->bmode_capable == DC1394_TRUE)
+        {
+            dc1394_video_set_operation_mode(dcCam, DC1394_OPERATION_MODE_1394B);
+        }
         code = dc1394_video_set_iso_speed(dcCam,
                                           isoSpeed <= 100 ? DC1394_ISO_SPEED_100 :
                                           isoSpeed <= 200 ? DC1394_ISO_SPEED_200 :


### PR DESCRIPTION
Adds support for the operation mode 1394b inside of the libdc1394-2 wrapper. 

It only tries to switch mode from the standard legacy into 1394b if
- iso-speed is above 400
- the camera reports to support mode 1394b and therefore should work fine with 1394a cameras

With this patch, the following problems are fixed:

Running a 1394b firewire camera with iso-speed above 400 (e.g. firewire800) at high resolutions (e.g. 1600x1200)  displays the following error messages from libdc1394-2 and crashes the software afterwards:

libdc1394 error: An ISO speed >400Mbps was requested while the camera is in LEGACY mode. Please set the operation mode to OPERATION_MODE_1394B before asking for 1394b ISO
libdc1394 warning: Forcefully killing servicing task...
libdc1394 error: Not enough iso bandwidth or channels are available to begin capture

Running the same camera in a low resolution (e.g. 800x600), might work but the first error message will still show up.

Tested with Point Grey Grasshopper, Grasshopper Express and FireflyMV cameras on Mac OS X and Windows (MinGW)
