### PR TITLE
allow QtKit capture in secondary threads

### DIFF
--- a/modules/highgui/src/cap_qtkit.mm
+++ b/modules/highgui/src/cap_qtkit.mm
@@ -277,11 +277,8 @@ bool CvCaptureCAM::grabFrame(double timeOut) {
     double sleepTime = 0.005;
     double total = 0;
 
-    NSDate *loopUntil = [NSDate dateWithTimeIntervalSinceNow:sleepTime];
-    while (![capture updateImage] && (total += sleepTime)<=timeOut &&
-           [[NSRunLoop currentRunLoop] runMode: NSDefaultRunLoopMode
-                                    beforeDate:loopUntil])
-        loopUntil = [NSDate dateWithTimeIntervalSinceNow:sleepTime];
+    while (![capture updateImage] && (total += sleepTime)<=timeOut)
+        usleep((int)(sleepTime*1000));
 
     [localpool drain];
 


### PR DESCRIPTION
[NSRunLoop currentRunLoop] is not the same as in the main thread.
see
https://developer.apple.com/library/mac/#documentation/Cocoa/Reference/F
oundation/Classes/nsrunloop_Class/Reference/Reference.html
"If no input sources or timers are attached to the run loop, this
method exits immediately"

The old code caused grabFrame() to return immediately if the capture
was not done in the main thread.
This code works correctly, even in secondary threads, provided that all
capture functions are called in the _same_ thread
