### PR TITLE
Fixed issue 3130 - Brisk call without descriptor generation

### DIFF
--- a/modules/features2d/src/brisk.cpp
+++ b/modules/features2d/src/brisk.cpp
@@ -525,7 +525,11 @@ BRISK::operator()( InputArray _image, InputArray _mask, vector<KeyPoint>& keypoi
   bool doOrientation=true;
   if (useProvidedKeypoints)
     doOrientation = false;
-  computeDescriptorsAndOrOrientation(_image, _mask, keypoints, _descriptors, true, doOrientation,
+
+  // If the user specified cv::noArray(), this will yield false. Otherwise it will return true.
+  bool doDescriptors = _descriptors.needed();
+
+  computeDescriptorsAndOrOrientation(_image, _mask, keypoints, _descriptors, doDescriptors, doOrientation,
                                        useProvidedKeypoints);
 }
 


### PR DESCRIPTION
Issue 3130 (http://code.opencv.org/issues/3130), where one argument of the BRISK-call was ignored. Previously it was not possible to use BRISK without creating descriptors.

Now it behaves like ORB (and how it is documented), and you can call BRISK to just generate feature points and no descriptors.
