### PR TITLE
fix opencv-XXX.pc.cmake.in and core/cvdef.h

### DIFF
--- a/cmake/templates/opencv-XXX.pc.cmake.in
+++ b/cmake/templates/opencv-XXX.pc.cmake.in
@@ -3,7 +3,7 @@
 prefix=@prefix@
 exec_prefix=@exec_prefix@
 libdir=@libdir@
-includedir_old=@includedir@/opencv -I@includedir@/opencv2
+includedir_old=@includedir@/opencv
 includedir_new=@includedir@
 
 Name: OpenCV


### PR DESCRIPTION
This pull request contains 2 minor changes:
1. using "static" to force inlineing of a function breaks builds with -Wall -Werror (specifically -Wunused-function). Better use
`__attribute__((always_inline))` when gcc is used
2. The .pc template only contains adds the "opencv" directory to the included paths. "opencv2" should also be included
