### PR TITLE
Fixed bugfix #3131: Added break directives to switch statement

### DIFF
--- a/modules/contrib/src/featuretracker.cpp
+++ b/modules/contrib/src/featuretracker.cpp
@@ -59,7 +59,7 @@ CvFeatureTracker::CvFeatureTracker(CvFeatureTrackerParams _params) :
         dd->set("nOctaveLayers", 5);
         dd->set("contrastThreshold", 0.04);
         dd->set("edgeThreshold", 10.7);
-		break;
+        break;
     case CvFeatureTrackerParams::SURF:
         dd = Algorithm::create<Feature2D>("Feature2D.SURF");
         if( dd.empty() )
@@ -67,10 +67,10 @@ CvFeatureTracker::CvFeatureTracker(CvFeatureTrackerParams _params) :
         dd->set("hessianThreshold", 400);
         dd->set("nOctaves", 3);
         dd->set("nOctaveLayers", 4);
-		break;
+        break;
     default:
         CV_Error(CV_StsBadArg, "Unknown feature type");
-		break;
+        break;
     }
 
     matcher = new BFMatcher(NORM_L2);


### PR DESCRIPTION
Added break directives to switch statement, so that the statement is actually correct as reported in the bug report.
