### PR TITLE
Fixed bug #3101, problem on ellipse2poly function

### DIFF
--- a/modules/core/src/drawing.cpp
+++ b/modules/core/src/drawing.cpp
@@ -886,9 +886,10 @@ void ellipse2Poly( Point center, Size axes, int angle,
         Point pt;
         pt.x = cvRound( cx + x * alpha - y * beta );
         pt.y = cvRound( cy + x * beta + y * alpha );
-        if( pt != prevPt )
+        if( pt != prevPt ){
             pts.push_back(pt);
             prevPt = pt;
+        }
     }
 
     if( pts.size() == 1 )


### PR DESCRIPTION
Added the fix of Guanta solving the following segmentation fault:

Before adding the points to draw to the output pts-vector it is resized to 0 (drawing.cpp, line 873). If now the ellipse to draw isn't valid, e.g. starting angle or ending angle are equal, then the loop won't be executed, no point will be added to the pts-vector and the line 894: pts.push_back(pts[0]); will result in a segfault.
