### PR TITLE
Added the solution mentioned in patch #3125

### DIFF
--- a/modules/core/include/opencv2/core/types_c.h
+++ b/modules/core/include/opencv2/core/types_c.h
@@ -137,9 +137,8 @@
 #ifndef CV_INLINE
 #  if defined __cplusplus
 #    define CV_INLINE inline
-#  elif (defined WIN32 || defined _WIN32 || defined WINCE) && !defined __GNUC__
+#  elif defined _MSC_VER
 #    define CV_INLINE __inline
-#  elif (defined WIN32 || defined WIN32 || defined WINCE) && (!defined GNUC && !defined _CVI)
 #  else
 #    define CV_INLINE static
 #  endif


### PR DESCRIPTION
As noted in http://code.opencv.org/issues/3125 --> added the line of code as I think it should be. More explanation in bug report zone. Please check this out.

I've been developing OpenCV applications using the LabWindows/CVI compiler & build environment. The process is straightforward, other than that the CVI compiler does not support the inline statement. I propose changing a pre-processor condition in type_c.h that will allow using said compiler:

elif (defined WIN32 || defined WIN32 || defined WINCE) && (!defined GNUC && !defined _CVI)
