### PR TITLE
Bugfix 1873 : returning image keypoint descriptors in bagofwords.cpp

### DIFF
--- a/modules/features2d/src/bagofwords.cpp
+++ b/modules/features2d/src/bagofwords.cpp
@@ -149,7 +149,7 @@ void BOWImgDescriptorExtractor::compute( const Mat& image, vector<KeyPoint>& key
     int clusterCount = descriptorSize(); // = vocabulary.rows
 
     // Compute descriptors for the image.
-    Mat descriptors = _descriptors ? *_descriptors : Mat();
+    Mat descriptors;
     dextractor->compute( image, keypoints, descriptors );
 
     // Match keypoint descriptors to cluster center (to vocabulary)
@@ -178,6 +178,11 @@ void BOWImgDescriptorExtractor::compute( const Mat& image, vector<KeyPoint>& key
 
     // Normalize image descriptor.
     imgDescriptor /= descriptors.rows;
+	
+    // Add the descriptors of image keypoints
+    if (_descriptors) {
+        *_descriptors = descriptors.clone(); 
+    }
 }
 
 int BOWImgDescriptorExtractor::descriptorSize() const


### PR DESCRIPTION
Fixed the bug mentioned in bug report 1873 + fix on line 152 : pure declaration
Issue : http://code.opencv.org/issues/1873 
