### PR TITLE
Change cvconfig visibility

### DIFF
--- a/modules/ts/CMakeLists.txt
+++ b/modules/ts/CMakeLists.txt
@@ -25,7 +25,7 @@ ocv_create_module()
 if(BUILD_SHARED_LIBS AND NOT MINGW)
   add_definitions(-DGTEST_CREATE_SHARED_LIBRARY=1)
 else()
-  add_definitions(-DGTEST_CREATE_SHARED_LIBRARY=0)
+  add_definitions(-DGTEST_LINKED_AS_SHARED_LIBRARY=1)
 endif()
 
 ocv_add_precompiled_headers(${the_module})

--- a/modules/ts/include/opencv2/ts.hpp
+++ b/modules/ts/include/opencv2/ts.hpp
@@ -4,12 +4,6 @@
 #include "opencv2/core/cvdef.h"
 #include <stdarg.h> // for va_list
 
-#ifndef GTEST_CREATE_SHARED_LIBRARY
-#ifdef BUILD_SHARED_LIBS
-#define GTEST_LINKED_AS_SHARED_LIBRARY 1
-#endif
-#endif
-
 #ifdef _MSC_VER
 #pragma warning( disable: 4127 )
 #endif

--- a/modules/ts/include/opencv2/ts/ts_perf.hpp
+++ b/modules/ts/include/opencv2/ts/ts_perf.hpp
@@ -1,12 +1,6 @@
 #ifndef __OPENCV_TS_PERF_HPP__
 #define __OPENCV_TS_PERF_HPP__
 
-#ifndef GTEST_CREATE_SHARED_LIBRARY
-#  ifdef BUILD_SHARED_LIBS
-#    define GTEST_LINKED_AS_SHARED_LIBRARY 1
-#  endif
-#endif
-
 #include "opencv2/core.hpp"
 #include "ts_gtest.h"
 

--- a/modules/ts/src/precomp.hpp
+++ b/modules/ts/src/precomp.hpp
@@ -2,7 +2,3 @@
 #include "opencv2/core/utility.hpp"
 #include "opencv2/core/private.hpp"
 #include "opencv2/ts.hpp"
-
-#ifdef GTEST_LINKED_AS_SHARED_LIBRARY
-#error ts module should not have GTEST_LINKED_AS_SHARED_LIBRARY defined
-#endif


### PR DESCRIPTION
From the discussion in the pull request [1112](https://github.com/Itseez/opencv/pull/1112), it was needed to remove references of cvconfig in public headers.
