### PR TITLE
Applied bugfix #3165 : Changed min_eps value

### DIFF
--- a/modules/imgproc/src/shapedescr.cpp
+++ b/modules/imgproc/src/shapedescr.cpp
@@ -804,7 +804,7 @@ cvFitEllipse2( const CvArr* array )
     CvPoint2D32f c = {0,0};
     double gfp[5], rp[5], t;
     CvMat A, b, x;
-    const double min_eps = 1e-6;
+    const double min_eps = 1e-8;
     int i, is_float;
     CvSeqReader reader;
 


### PR DESCRIPTION
Changed the parameter value of min_eps from 10^-6 to 10^-8 as suggested by the bugfix itself.
Link: http://code.opencv.org/issues/3165 
