### PR TITLE
Added paper reference to stardetector interface as mentioned in bug #3166

### DIFF
--- a/modules/features2d/doc/common_interfaces_of_feature_detectors.rst
+++ b/modules/features2d/doc/common_interfaces_of_feature_detectors.rst
@@ -220,7 +220,7 @@ StarFeatureDetector
 -------------------
 .. ocv:class:: StarFeatureDetector : public FeatureDetector
 
-The class implements the keypoint detector introduced by K. Konolige, synonym of ``StarDetector``.  ::
+The class implements the keypoint detector introduced by Agrawal, M., Konolige, K. and Blas, M.R. [Agrawal08], synonym of ``StarDetector``.  ::
 
     class StarFeatureDetector : public FeatureDetector
     {
@@ -233,6 +233,8 @@ The class implements the keypoint detector introduced by K. Konolige, synonym of
     protected:
         ...
     };
+	
+.. [Agrawal08] Agrawal, M., Konolige, K., & Blas, M. R. (2008). Censure: Center surround extremas for realtime feature detection and matching. In Computer Vision–ECCV 2008 (pp. 102-115). Springer Berlin Heidelberg.
 
 DenseFeatureDetector
 --------------------


### PR DESCRIPTION
As discussed in http://code.opencv.org/issues/3166

Added reference to original CENSURE paper, which is the basis of the stardetector.
