### PR TITLE
Fixed bug 3166 - added paper reference to stardetector code

### DIFF
--- a/modules/features2d/doc/common_interfaces_of_feature_detectors.rst
+++ b/modules/features2d/doc/common_interfaces_of_feature_detectors.rst
@@ -220,7 +220,7 @@ StarFeatureDetector
 -------------------
 .. ocv:class:: StarFeatureDetector : public FeatureDetector
 
-The class implements the keypoint detector introduced by [Agrawal08_], synonym of ``StarDetector``.  ::
+The class implements the keypoint detector introduced by [Agrawal08]_, synonym of ``StarDetector``.  ::
 
     class StarFeatureDetector : public FeatureDetector
     {


### PR DESCRIPTION
As discussed in http://code.opencv.org/issues/3166

Added reference to original CENSURE paper, which is the basis of the stardetector.
- Resubmit against branch 2.4 -
