### PR TITLE
fix cap_qtkit.mm for multithreaded applications (2nd try)

### DIFF
--- a/modules/highgui/src/cap_qtkit.mm
+++ b/modules/highgui/src/cap_qtkit.mm
@@ -333,7 +333,7 @@ int CvCaptureCAM::startCaptureDevice(int cameraNum) {
 
     if (cameraNum >= 0) {
         NSUInteger nCameras = [devices count];
-        if( cameraNum < 0 || cameraNum >= nCameras ) {
+        if( (NSUInteger)cameraNum >= nCameras ) {
             [localpool drain];
             return 0;
         }


### PR DESCRIPTION
This is my second try at this fix.
I don't know what failed in the previous patch, which used usleep(): did it block the GUI? Could you send me the bug reports for the previous patch?
I'm sorry, but I was only testing it using non-GUI applications.
This one should be nicer, since it uses NSRunLoop, as the original version, and manages to fix the "infinite framerate when running in a secondary thread" issue.
I also fixed various things, including a horrible bug where if you ask for the frame width or height you always get 0!

Please, Vadim, include me in your discussions if there is a problem with this one.

Fred
