### PR TITLE
Documentation fix for cv::compare (issue 3149)

### DIFF
--- a/modules/core/doc/operations_on_arrays.rst
+++ b/modules/core/doc/operations_on_arrays.rst
@@ -532,7 +532,7 @@ Performs the per-element comparison of two arrays or an array and scalar value.
 
     :param value: scalar value.
 
-    :param dst: output array that has the same size as the input arrays and type= ``CV_8UC1`` .
+    :param dst: output array that has the same size and type as the input arrays.
 
     :param cmpop: a flag, that specifies correspondence between the arrays:
 


### PR DESCRIPTION
Since commit d8417af0860 (July 2011) cv::compare produces an array with
the same size and type as the input arrays.

Signed-off-by: Michael Hanselmann public@hansmi.ch
