### PR TITLE
Added all *.cpp samples reference to the documentation

### DIFF
--- a/modules/calib3d/doc/camera_calibration_and_3d_reconstruction.rst
+++ b/modules/calib3d/doc/camera_calibration_and_3d_reconstruction.rst
@@ -105,7 +105,14 @@ The functions below use the above model to do the following:
 
  * Estimate the relative position and orientation of the stereo camera "heads" and compute the *rectification* transformation that makes the camera optical axes parallel.
 
+.. Sample code::
 
+   * : A calibration sample for 3 cameras in horizontal position can be found at opencv_source_code/samples/cpp/3calibration.cpp
+   * : A calibration sample based on a sequence of images can be found at opencv_source_code/samples/cpp/calibration.cpp
+   * : A calibration sample in order to do 3D reconstruction can be found at opencv_source_code/samples/cpp/build3dmodel.cpp
+   * : A calibration sample of an artificially generated camera and chessboard patterns can be found at opencv_source_code/samples/cpp/calibration_artificial.cpp
+   * : A calibration example on stereo calibration can be found at opencv_source_code/samples/cpp/stereo_calib.cpp
+   * : A calibration example on stereo matching can be found at opencv_source_code/samples/cpp/stereo_match.cpp
 
 calibrateCamera
 ---------------
@@ -766,6 +773,9 @@ Homography matrix is determined up to a scale. Thus, it is normalized so that
     :ocv:func:`warpPerspective`,
     :ocv:func:`perspectiveTransform`
 
+.. Sample code::
+
+   * : A example on calculating a homography for image matching can be found at opencv_source_code/samples/cpp/video_homography.cpp
 
 estimateAffine3D
 --------------------

--- a/modules/contrib/doc/facerec/facerec_api.rst
+++ b/modules/contrib/doc/facerec/facerec_api.rst
@@ -3,6 +3,10 @@ FaceRecognizer
 
 .. highlight:: cpp
 
+.. Sample code::
+
+   * : An example using the FaceRecognizer class can be found at opencv_source_code/samples/cpp/facerec_demo.cpp
+
 FaceRecognizer
 --------------
 

--- a/modules/contrib/doc/openfabmap.rst
+++ b/modules/contrib/doc/openfabmap.rst
@@ -9,6 +9,10 @@ FAB-MAP is an approach to appearance-based place recognition. FAB-MAP compares i
 
 openFABMAP requires training data (e.g. a collection of images from a similar but not identical environment) to construct a visual vocabulary for the visual bag-of-words model, along with a Chow-Liu tree representation of feature likelihood and for use in the Sampled new place method (see below).
 
+.. Sample code::
+
+   * : An example using the openFABMAP package can be found at opencv_source_code/samples/cpp/fabmap_sample.cpp
+
 of2::FabMap
 --------------------
 

--- a/modules/contrib/doc/retina/index.rst
+++ b/modules/contrib/doc/retina/index.rst
@@ -63,6 +63,11 @@ The retina can be settled up with various parameters, by default, the retina can
     void activateContoursProcessing (const bool activate);
   };
 
+.. Sample code::
+
+   * : An example on retina tone mapping can be found at opencv_source_code/samples/cpp/OpenEXRimages_HighDynamicRange_Retina_toneMapping.cpp
+   * : An example on retina tone mapping on video input can be found at opencv_source_code/samples/cpp/OpenEXRimages_HighDynamicRange_Retina_toneMapping.cpp
+   * : A complete example illustrating the retina interface can be found at opencv_source_code/samples/cpp/retinaDemo.cpp
 
 Description
 +++++++++++

--- a/modules/core/doc/basic_structures.rst
+++ b/modules/core/doc/basic_structures.rst
@@ -803,6 +803,9 @@ Finally, there are STL-style iterators that are smart enough to skip gaps betwee
 
 The matrix iterators are random-access iterators, so they can be passed to any STL algorithm, including ``std::sort()`` .
 
+.. Sample code::
+
+   * : An example demonstrating the serial out capabilities of cv::Mat can be found at opencv_source_code/samples/cpp/cout_mat.cpp
 
 .. _MatrixExpressions:
 

--- a/modules/core/doc/clustering.rst
+++ b/modules/core/doc/clustering.rst
@@ -66,6 +66,10 @@ Basically, you can use only the core of the function, set the number of
 attempts to 1, initialize labels each time using a custom algorithm, pass them with the
 ( ``flags`` = ``KMEANS_USE_INITIAL_LABELS`` ) flag, and then choose the best (most-compact) clustering.
 
+.. Sample code::
+
+   * : An example on K-means clustering can be found at opencv_source_code/samples/cpp/kmeans.cpp
+
 partition
 -------------
 Splits an element set into equivalency classes.

--- a/modules/core/doc/drawing_functions.rst
+++ b/modules/core/doc/drawing_functions.rst
@@ -26,6 +26,10 @@ If a drawn figure is partially or completely outside the image, the drawing func
 
 .. note:: The functions do not support alpha-transparency when the target image is 4-channel. In this case, the ``color[3]`` is simply copied to the repainted pixels. Thus, if you want to paint semi-transparent shapes, you can paint them in a separate buffer and then blend it with the main image.
 
+.. Sample code::
+
+   * : An example on using variate drawing functions like line, rectangle, ... can be found at opencv_source_code/samples/cpp/drawing.cpp
+
 circle
 ----------
 Draws a circle.

--- a/modules/core/doc/operations_on_arrays.rst
+++ b/modules/core/doc/operations_on_arrays.rst
@@ -997,6 +997,9 @@ All of the above improvements have been implemented in :ocv:func:`matchTemplate`
 
 .. seealso:: :ocv:func:`dct` , :ocv:func:`getOptimalDFTSize` , :ocv:func:`mulSpectrums`, :ocv:func:`filter2D` , :ocv:func:`matchTemplate` , :ocv:func:`flip` , :ocv:func:`cartToPolar` , :ocv:func:`magnitude` , :ocv:func:`phase`
 
+.. Sample code::
+
+   * : An example using the discrete fourier transform can be found at opencv_source_code/samples/cpp/dft.cpp
 
 
 divide
@@ -2262,7 +2265,9 @@ The sample below is the function that takes two matrices. The first function sto
     :ocv:func:`dft`,
     :ocv:func:`dct`
 
+.. Sample code::
 
+   * : An example using PCA for dimensionality reduction while maintaining an amount of variance can be found at opencv_source_code/samples/cpp/pca.cpp
 
 PCA::PCA
 --------

--- a/modules/core/doc/xml_yaml_persistence.rst
+++ b/modules/core/doc/xml_yaml_persistence.rst
@@ -91,6 +91,10 @@ Several things can be noted by looking at the sample code and the output:
  *
    In YAML (but not XML), mappings and sequences can be written in a compact Python-like inline form. In the sample above matrix elements, as well as each feature, including its lbp value, is stored in such inline form. To store a mapping/sequence in a compact form, put ":" after the opening character, e.g. use **"{:"** instead of **"{"** and **"[:"** instead of **"["**. When the data is written to XML, those extra ":" are ignored.
 
+.. Sample code::
+
+   * : A complete example using the FileStorage interface can be found at opencv_source_code/samples/cpp/filestorage.cpp
+
 
 Reading data from a file storage.
 ---------------------------------

--- a/modules/features2d/doc/common_interfaces_of_descriptor_extractors.rst
+++ b/modules/features2d/doc/common_interfaces_of_descriptor_extractors.rst
@@ -9,7 +9,10 @@ represented as vectors in a multidimensional space. All objects that implement t
 descriptor extractors inherit the
 :ocv:class:`DescriptorExtractor` interface.
 
+.. Sample code::
 
+   * : An example explaining keypoint extraction can be found at opencv_source_code/samples/cpp/descriptor_extractor_matcher.cpp
+   * : An example on descriptor evaluation can be found at opencv_source_code/samples/cpp/detector_descriptor_evaluation.cpp
 
 DescriptorExtractor
 -------------------
@@ -137,4 +140,6 @@ Strecha C., Fua P. *BRIEF: Binary Robust Independent Elementary Features* ,
         ...
     };
 
+.. Sample code:: 
 
+   * : A complete BRIEF extractor sample can be found at opencv_source_code/samples/cpp/brief_match_test.cpp

--- a/modules/features2d/doc/common_interfaces_of_descriptor_matchers.rst
+++ b/modules/features2d/doc/common_interfaces_of_descriptor_matchers.rst
@@ -9,6 +9,12 @@ that are represented as vectors in a multidimensional space. All objects that im
 descriptor matchers inherit the
 :ocv:class:`DescriptorMatcher` interface.
 
+.. Sample code::
+
+   * : An example explaining keypoint matching can be found at opencv_source_code/samples/cpp/descriptor_extractor_matcher.cpp
+   * : An example on descriptor matching evaluation can be found at opencv_source_code/samples/cpp/detector_descriptor_matcher_evaluation.cpp
+   * : An example on one to many image matching can be found at opencv_source_code/samples/cpp/matching_to_many_images.cpp
+
 DMatch
 ------
 .. ocv:struct:: DMatch

--- a/modules/features2d/doc/common_interfaces_of_feature_detectors.rst
+++ b/modules/features2d/doc/common_interfaces_of_feature_detectors.rst
@@ -8,6 +8,11 @@ between different algorithms solving the same problem. All objects that implemen
 inherit the
 :ocv:class:`FeatureDetector` interface.
 
+.. Sample code::
+
+   * : An example explaining keypoint detection can be found at opencv_source_code/samples/cpp/descriptor_extractor_matcher.cpp
+
+
 KeyPoint
 --------
 .. ocv:class:: KeyPoint

--- a/modules/features2d/doc/common_interfaces_of_generic_descriptor_matchers.rst
+++ b/modules/features2d/doc/common_interfaces_of_generic_descriptor_matchers.rst
@@ -11,7 +11,11 @@ Every descriptor with the
 :ocv:class:`VectorDescriptorMatcher` ).
 There are descriptors such as the One-way descriptor and Ferns that have the ``GenericDescriptorMatcher`` interface implemented but do not support ``DescriptorExtractor``.
 
+.. Sample code::
 
+   * : An example explaining keypoint description can be found at opencv_source_code/samples/cpp/descriptor_extractor_matcher.cpp
+   * : An example on descriptor matching evaluation can be found at opencv_source_code/samples/cpp/detector_descriptor_matcher_evaluation.cpp
+   * : An example on one to many image matching can be found at opencv_source_code/samples/cpp/matching_to_many_images.cpp
 
 GenericDescriptorMatcher
 ------------------------

--- a/modules/features2d/doc/feature_detection_and_description.rst
+++ b/modules/features2d/doc/feature_detection_and_description.rst
@@ -3,6 +3,10 @@ Feature Detection and Description
 
 .. highlight:: cpp
 
+.. Sample code::
+
+   * : An example explaining keypoint detection and description can be found at opencv_source_code/samples/cpp/descriptor_extractor_matcher.cpp
+
 FAST
 ----
 Detects corners using the FAST algorithm
@@ -157,6 +161,10 @@ FREAK
 Class implementing the FREAK (*Fast Retina Keypoint*) keypoint descriptor, described in [AOV12]_. The algorithm propose a novel keypoint descriptor inspired by the human visual system and more precisely the retina, coined Fast Retina Key- point (FREAK). A cascade of binary strings is computed by efficiently comparing image intensities over a retinal sampling pattern. FREAKs are in general faster to compute with lower memory load and also more robust than SIFT, SURF or BRISK. They are competitive alternatives to existing keypoints in particular for embedded applications.
 
 .. [AOV12] A. Alahi, R. Ortiz, and P. Vandergheynst. FREAK: Fast Retina Keypoint. In IEEE Conference on Computer Vision and Pattern Recognition, 2012. CVPR 2012 Open Source Award Winner.
+
+.. Sample code::
+
+   * : An example on how to use the FREAK descriptor can be found at opencv_source_code/samples/cpp/freak_demo.cpp
 
 FREAK::FREAK
 ------------

--- a/modules/features2d/doc/object_categorization.rst
+++ b/modules/features2d/doc/object_categorization.rst
@@ -5,6 +5,8 @@ Object Categorization
 
 This section describes approaches based on local 2D features and used to categorize objects.
 
+.. Sample code:: A complete Bag-Of-Words sample can be found at opencv_source_code/samples/cpp/bagofwords_classification.cpp
+
 BOWTrainer
 ----------
 .. ocv:class:: BOWTrainer

--- a/modules/gpu/doc/object_detection.rst
+++ b/modules/gpu/doc/object_detection.rst
@@ -62,7 +62,9 @@ The class implements Histogram of Oriented Gradients ([Dalal2005]_) object detec
 
 Interfaces of all methods are kept similar to the ``CPU HOG`` descriptor and detector analogues as much as possible.
 
+.. Sample code::
 
+   * : An example applying the HOG descriptor for people detection can be found at opencv_source_code/samples/cpp/peopledetect.cpp
 
 gpu::HOGDescriptor::HOGDescriptor
 -------------------------------------

--- a/modules/highgui/doc/reading_and_writing_images_and_video.rst
+++ b/modules/highgui/doc/reading_and_writing_images_and_video.rst
@@ -224,6 +224,10 @@ The class provides C++ API for capturing video from cameras or for reading video
 
 .. note:: In C API the black-box structure ``CvCapture`` is used instead of ``VideoCapture``.
 
+.. Sample code::
+
+   * : A basic sample on using the VideoCapture interface can be found at opencv_source_code/samples/cpp/starter_video.cpp
+   * : Another basic video processing sample can be found at opencv_source_code/samples/cpp/video_dmtx.cpp
 
 VideoCapture::VideoCapture
 ------------------------------

--- a/modules/highgui/doc/user_interface.rst
+++ b/modules/highgui/doc/user_interface.rst
@@ -33,6 +33,10 @@ The function ``createTrackbar`` creates a trackbar (a slider or range control) w
 
 Clicking the label of each trackbar enables editing the trackbar values manually.
 
+.. Sample code::
+
+   * : An example of using the trackbar functionality can be found at opencv_source_code/samples/cpp/connected_components.cpp
+
 getTrackbarPos
 ------------------
 Returns the trackbar position.

--- a/modules/imgproc/doc/feature_detection.rst
+++ b/modules/imgproc/doc/feature_detection.rst
@@ -32,7 +32,9 @@ Finds edges in an image using the [Canny86]_ algorithm.
 The function finds edges in the input image ``image`` and marks them in the output map ``edges`` using the Canny algorithm. The smallest value between ``threshold1`` and ``threshold2`` is used for edge linking. The largest value is used to find initial segments of strong edges. See
 http://en.wikipedia.org/wiki/Canny_edge_detector
 
+.. Sample code::
 
+   * : An example on using the canny edge detector can be found at opencv_source_code/samples/cpp/edge.cpp
 
 cornerEigenValsAndVecs
 ----------------------
@@ -356,6 +358,9 @@ Example: ::
     :ocv:func:`fitEllipse`,
     :ocv:func:`minEnclosingCircle`
 
+.. Sample code::
+
+   * : An example using the Hough circle detector can be found at opencv_source_code/samples/cpp/houghcircles.cpp
 
 HoughLines
 ----------
@@ -411,6 +416,10 @@ Finds lines in a binary image using the standard Hough transform.
 
 The function implements the standard or standard multi-scale Hough transform algorithm for line detection.  See http://homepages.inf.ed.ac.uk/rbf/HIPR2/hough.htm for a good explanation of Hough transform.
 See also the example in :ocv:func:`HoughLinesP` description.
+
+.. Sample code::
+
+   * : An example using the Hough line detector can be found at opencv_source_code/samples/cpp/houghlines.cpp
 
 HoughLinesP
 -----------

--- a/modules/imgproc/doc/filtering.rst
+++ b/modules/imgproc/doc/filtering.rst
@@ -868,6 +868,9 @@ The function supports the in-place mode. Dilation can be applied several ( ``ite
     :ocv:func:`morphologyEx`,
     :ocv:func:`createMorphologyFilter`
 
+.. Sample code::
+
+   * : An example using the morphological dilate operation can be found at opencv_source_code/samples/cpp/morphology2.cpp
 
 erode
 -----
@@ -908,7 +911,9 @@ The function supports the in-place mode. Erosion can be applied several ( ``iter
     :ocv:func:`morphologyEx`,
     :ocv:func:`createMorphologyFilter`
 
+.. Sample code::
 
+   * : An example using the morphological erode operation can be found at opencv_source_code/samples/cpp/morphology2.cpp
 
 filter2D
 --------
@@ -1245,6 +1250,9 @@ Any of the operations can be done in-place. In case of multi-channel images, eac
     :ocv:func:`erode`,
     :ocv:func:`createMorphologyFilter`
 
+.. Sample code::
+
+   * : An example using the morphologyEx function for the morphological opening and closing operations can be found at opencv_source_code/samples/cpp/morphology2.cpp
 
 Laplacian
 ---------
@@ -1290,7 +1298,9 @@ This is done when ``ksize > 1`` . When ``ksize == 1`` , the Laplacian is compute
     :ocv:func:`Sobel`,
     :ocv:func:`Scharr`
 
+.. Sample code::
 
+   * : An example using the Laplace transformation for edge detection can be found at opencv_source_code/samples/cpp/laplace.cpp
 
 pyrDown
 -------
@@ -1400,6 +1410,9 @@ After the iterations over, the color components of the initial pixel (that is, t
 
 When ``maxLevel > 0``, the gaussian pyramid of ``maxLevel+1`` levels is built, and the above procedure is run on the smallest layer first. After that, the results are propagated to the larger layer and the iterations are run again only on those pixels where the layer colors differ by more than ``sr`` from the lower-resolution layer of the pyramid. That makes boundaries of color regions sharper. Note that the results will be actually different from the ones obtained by running the meanshift procedure on the whole original image (i.e. when ``maxLevel==0``).
 
+.. Sample code::
+
+   * : An example using mean-shift image segmentation can be found at opencv_source_code/samples/cpp/meanshift_segmentation.cpp
 
 sepFilter2D
 -----------

--- a/modules/imgproc/doc/geometric_transformations.rst
+++ b/modules/imgproc/doc/geometric_transformations.rst
@@ -307,6 +307,9 @@ where
 
 The function emulates the human "foveal" vision and can be used for fast scale and rotation-invariant template matching, for object tracking and so forth. The function can not operate in-place.
 
+.. Sample code::
+
+   * : An example using the geometric logpolar operation in 4 applications can be found at opencv_source_code/samples/cpp/logpolar_bsm.cpp
 
 remap
 -----

--- a/modules/imgproc/doc/histograms.rst
+++ b/modules/imgproc/doc/histograms.rst
@@ -99,7 +99,9 @@ input arrays at the same location. The sample below shows how to compute a 2D Hu
         waitKey();
     }
 
+.. Sample code::
 
+   * : An example for creating histograms of an image can be found at opencv_source_code/samples/cpp/demhist.cpp
 
 
 calcBackProject

--- a/modules/imgproc/doc/miscellaneous_transformations.rst
+++ b/modules/imgproc/doc/miscellaneous_transformations.rst
@@ -481,6 +481,10 @@ In this mode, the complexity is still linear.
 That is, the function provides a very fast way to compute the Voronoi diagram for a binary image.
 Currently, the second variant can use only the approximate distance transform algorithm, i.e. ``maskSize=CV_DIST_MASK_PRECISE`` is not supported yet.
 
+.. Sample code::
+
+   * : An example on using the distance transform can be found at opencv_source_code/samples/cpp/distrans.cpp
+
 floodFill
 ---------
 Fills a connected component with the given color.
@@ -580,11 +584,13 @@ where
 *
     Color/brightness of the seed point in case of a fixed range.
 
-Use these functions to either mark a connected component with the specified color in-place, or build a mask and then extract the contour, or copy the region to another image, and so on. Various modes of the function are demonstrated in the ``floodfill.cpp`` sample.
+Use these functions to either mark a connected component with the specified color in-place, or build a mask and then extract the contour, or copy the region to another image, and so on.
 
 .. seealso:: :ocv:func:`findContours`
 
+.. Sample code::
 
+   * : An example using the FloodFill technique can be found at opencv_source_code/samples/cpp/ffilldemo.cpp
 
 integral
 --------
@@ -748,6 +754,10 @@ Visual demonstration and usage example of the function can be found in the OpenC
 
 .. seealso:: :ocv:func:`findContours`
 
+.. Sample code::
+
+   * : An example using the watershed algorithm can be found at opencv_source_code/samples/cpp/watershed.cpp
+
 grabCut
 -------
 Runs the GrabCut algorithm.
@@ -794,3 +804,7 @@ See the sample ``grabcut.cpp`` to learn how to use the function.
 .. [Meyer92] Meyer, F. *Color Image Segmentation*, ICIP92, 1992
 
 .. [Telea04] Alexandru Telea, *An Image Inpainting Technique Based on the Fast Marching Method*. Journal of Graphics, GPU, and Game Tools 9 1, pp 23-34 (2004)
+
+.. Sample code::
+
+   * : An example using the GrabCut algorithm can be found at opencv_source_code/samples/cpp/grabcut.cpp

--- a/modules/imgproc/doc/structural_analysis_and_shape_descriptors.rst
+++ b/modules/imgproc/doc/structural_analysis_and_shape_descriptors.rst
@@ -166,6 +166,12 @@ The function retrieves contours from the binary image using the algorithm
 
 .. note:: If you use the new Python interface then the ``CV_`` prefix has to be omitted in contour retrieval mode and contour approximation method parameters (for example, use ``cv2.RETR_LIST`` and ``cv2.CHAIN_APPROX_NONE`` parameters). If you use the old Python interface then these parameters have the ``CV_`` prefix (for example, use ``cv.CV_RETR_LIST`` and ``cv.CV_CHAIN_APPROX_NONE``).
 
+.. Sample code::
+
+   * : An example using the findContour functionality can be found at opencv_source_code/samples/cpp/contours2.cpp
+   * : An example using findContours to clean up a background segmentation result at opencv_source_code/samples/cpp/segment_objects.cpp
+
+
 drawContours
 ----------------
 Draws contours outlines or filled contours.
@@ -246,7 +252,10 @@ The function draws contour outlines in the image if
         waitKey(0);
     }
 
+.. Sample code::
 
+   * : An example using the drawContour functionality can be found at opencv_source_code/samples/cpp/contours2.cpp
+   * : An example using drawContours to clean up a background segmentation result at opencv_source_code/samples/cpp/segment_objects.cpp
 
 approxPolyDP
 ----------------
@@ -417,6 +426,10 @@ The functions find the convex hull of a 2D point set using the Sklansky's algori
 that has
 *O(N logN)* complexity in the current implementation. See the OpenCV sample ``convexhull.cpp`` that demonstrates the usage of different function variants.
 
+.. Sample code::
+
+   * : An example using the convexHull functionality can be found at opencv_source_code/samples/cpp/convexhull.cpp
+
 
 convexityDefects
 ----------------
@@ -472,6 +485,10 @@ Fits an ellipse around a set of 2D points.
         * Nx2 numpy array (Python interface)
 
 The function calculates the ellipse that fits (in a least-squares sense) a set of 2D points best of all. It returns the rotated rectangle in which the ellipse is inscribed. The algorithm [Fitzgibbon95]_ is used.
+
+.. Sample code::
+
+   * : An example using the fitEllipse technique can be found at opencv_source_code/samples/cpp/fitellipse.cpp
 
 fitLine
 -----------

--- a/modules/legacy/doc/expectation_maximization.rst
+++ b/modules/legacy/doc/expectation_maximization.rst
@@ -5,6 +5,10 @@ This section describes obsolete ``C`` interface of EM algorithm. Details of the 
 
 .. highlight:: cpp
 
+.. Sample code::
+
+   * : An example on using the Expectation Maximalization algorithm can be found at opencv_source_code/samples/cpp/em.cpp
+
 
 CvEMParams
 ----------

--- a/modules/legacy/doc/feature_detection_and_description.rst
+++ b/modules/legacy/doc/feature_detection_and_description.rst
@@ -99,7 +99,9 @@ Trains a randomized tree using an input set of keypoints.
 
     :param num_quant_bits: Number of bits used for quantization.
 
+.. Sample code::
 
+   * : An example on training a Random Tree Classifier for letter recognition can be found at opencv_source_code\samples\cpp\letter_recog.cpp
 
 RandomizedTree::read
 ------------------------

--- a/modules/nonfree/doc/feature_detection.rst
+++ b/modules/nonfree/doc/feature_detection.rst
@@ -75,6 +75,10 @@ SURF
 
 .. [Bay06] Bay, H. and Tuytelaars, T. and Van Gool, L. "SURF: Speeded Up Robust Features", 9th European Conference on Computer Vision, 2006
 
+.. Sample code::
+
+   * : An example using the SURF feature detector can be found at opencv_source_code/samples/cpp/generic_descriptor_match.cpp
+   * : Another example using the SURF feature detector, extractor and matcher can be found at opencv_source_code/samples/cpp/matcher_simple.cpp
 
 SURF::SURF
 ----------

--- a/modules/photo/doc/inpainting.rst
+++ b/modules/photo/doc/inpainting.rst
@@ -31,3 +31,7 @@ Restores the selected region in an image using the region neighborhood.
 The function reconstructs the selected image area from the pixel near the area boundary. The function may be used to remove dust and scratches from a scanned photo, or to remove undesirable objects from still images or video. See
 http://en.wikipedia.org/wiki/Inpainting
 for more details.
+
+.. Sample code::
+
+   * : An example using the inpainting technique can be found at opencv_source_code/samples/cpp/inpaint.cpp

--- a/modules/stitching/doc/high_level.rst
+++ b/modules/stitching/doc/high_level.rst
@@ -88,6 +88,11 @@ High level image stitcher. It's possible to use this class without being aware o
         /* hidden */
     };
 
+.. Sample code::
+
+   * : A basic example on image stitching can be found at opencv_source_code/samples/cpp/stitching.cpp
+   * : A detailed example on image stitching can be found at opencv_source_code/samples/cpp/stitching_detailed.cpp
+
 Stitcher::createDefault
 -----------------------
 Creates a stitcher with the default parameters.

--- a/modules/video/doc/motion_analysis_and_object_tracking.rst
+++ b/modules/video/doc/motion_analysis_and_object_tracking.rst
@@ -42,6 +42,10 @@ Calculates an optical flow for a sparse feature set using the iterative Lucas-Ka
 
 The function implements a sparse iterative version of the Lucas-Kanade optical flow in pyramids. See [Bouguet00]_. The function is parallelized with the TBB library.
 
+.. Sample code::
+
+   * : An example using the Lucas-Kanade optical flow algorithm can be found at opencv_source_code/samples/cpp/lkdemo.cpp
+
 buildOpticalFlowPyramid
 -----------------------
 Constructs the image pyramid which can be passed to :ocv:func:`calcOpticalFlowPyrLK`.
@@ -109,6 +113,9 @@ The function finds an optical flow for each ``prev`` pixel using the [Farneback2
 
     \texttt{prev} (y,x)  \sim \texttt{next} ( y + \texttt{flow} (y,x)[1],  x + \texttt{flow} (y,x)[0])
 
+.. Sample code::
+
+   * : An example using the optical flow algorithm described by Gunnar Farneback can be found at opencv_source_code/samples/cpp/fback.cpp
 
 estimateRigidTransform
 --------------------------
@@ -342,7 +349,9 @@ The function implements the iterative object search algorithm. It takes the inpu
 :ocv:func:`contourArea` ), and rendering the  remaining contours with
 :ocv:func:`drawContours` .
 
+.. Sample code::
 
+   * : A mean-shift tracking sample can be found at opencv_source_code/samples/cpp/camshiftdemo.cpp
 
 KalmanFilter
 ------------
@@ -353,7 +362,9 @@ KalmanFilter
 The class implements a standard Kalman filter
 http://en.wikipedia.org/wiki/Kalman_filter, [Welch95]_. However, you can modify ``transitionMatrix``, ``controlMatrix``, and ``measurementMatrix`` to get an extended Kalman filter functionality. See the OpenCV sample ``kalman.cpp`` .
 
+.. Sample code::
 
+   * : An example using the standard Kalman filter can be found at opencv_source_code/samples/cpp/kalman.cpp
 
 
 KalmanFilter::KalmanFilter
@@ -641,7 +652,9 @@ Calculate an optical flow using "SimpleFlow" algorithm.
 
 See [Tao2012]_. And site of project - http://graphics.berkeley.edu/papers/Tao-SAN-2012-05/.
 
+.. Sample code::
 
+   * : An example using the simpleFlow algorithm can be found at opencv_source_code/samples/cpp/simpleflow_demo.cpp
 
 createOptFlow_DualTVL1
 ----------------------


### PR DESCRIPTION
Added a link in documentation pointing to samples containing the functionality.
Did it only for the samples that have functionality in the 2.4 branch.

Suggestion was made in this feature request:
http://code.opencv.org/issues/3169 

If this works out and gets merged, will consider doing same for other sample folders also.
Also want to know if it is usefull to add C samples, since we want to demotivate people using the interface?
