### PR TITLE
expanded the CV_Assert in pyrdown_ to check for empty mats

### DIFF
--- a/modules/imgproc/src/pyramids.cpp
+++ b/modules/imgproc/src/pyramids.cpp
@@ -203,7 +203,8 @@ pyrDown_( const Mat& _src, Mat& _dst, int borderType )
     CastOp castOp;
     VecOp vecOp;
 
-    CV_Assert( std::abs(dsize.width*2 - ssize.width) <= 2 &&
+    CV_Assert( ssize.width > 0 && ssize.height > 0 && 
+               std::abs(dsize.width*2 - ssize.width) <= 2 &&
                std::abs(dsize.height*2 - ssize.height) <= 2 );
     int k, x, sy0 = -PD_SZ/2, sy = sy0, width0 = std::min((ssize.width-PD_SZ/2-1)/2 + 1, dsize.width);
 


### PR DESCRIPTION
this should fix [#3094](http://code.opencv.org/issues/3094)

tested with 2.9.0, and 2.4.2 and the endless loop happens a bit earlier as originally posted ( endless loop in borderInterpolate() )
