### PR TITLE
Sphinx

### DIFF
--- a/cmake/OpenCVDetectPython.cmake
+++ b/cmake/OpenCVDetectPython.cmake
@@ -108,7 +108,7 @@ if(PYTHON_EXECUTABLE)
                         OUTPUT_QUIET
                         ERROR_VARIABLE SPHINX_OUTPUT
                         OUTPUT_STRIP_TRAILING_WHITESPACE)
-        if(SPHINX_OUTPUT MATCHES ".*Sphinx v([0-9][^ \n]*)")
+        if(SPHINX_OUTPUT MATCHES "Sphinx v([0-9][^ \n]*)")
           set(SPHINX_VERSION "${CMAKE_MATCH_1}")
           set(HAVE_SPHINX 1)
           message(STATUS "Found Sphinx ${SPHINX_VERSION}: ${SPHINX_BUILD}")


### PR DESCRIPTION
On my MacOS the output of the sphinx-build binary is the following:

Error: Insufficient arguments.

Sphinx v1.2b1
Usage: /usr/local/bin/sphinx-build [options] sourcedir outdir [filenames...]

...

I have installed sphinx, but without this change HAVE_SPHINX==0 for me, so I can't build docs.
