### PR TITLE
NEON instruction set enabled for WIN32 on ARM by default.

### DIFF
--- a/modules/core/include/opencv2/core/internal.hpp
+++ b/modules/core/include/opencv2/core/internal.hpp
@@ -136,7 +136,13 @@ CV_INLINE IppiSize ippiSize(int width, int height)
 #  endif
 #endif
 
-#ifdef __ARM_NEON__
+
+#if (defined WIN32 || defined _WIN32) && defined(_M_ARM)
+# include <Intrin.h>
+# include "arm_neon.h"
+# define CV_NEON 1
+# define CPU_HAS_NEON_FEATURE (true)
+#elif defined(__ARM_NEON__)
 #  include <arm_neon.h>
 #  define CV_NEON 1
 #  define CPU_HAS_NEON_FEATURE (true)

--- a/modules/flann/include/opencv2/flann/dist.h
+++ b/modules/flann/include/opencv2/flann/dist.h
@@ -43,8 +43,12 @@ typedef unsigned __int64 uint64_t;
 
 #include "defines.h"
 
+#if (defined WIN32 || defined _WIN32) && defined(_M_ARM)
+# include <Intrin.h>
+#endif
+
 #ifdef __ARM_NEON__
-#include "arm_neon.h"
+# include "arm_neon.h"
 #endif
 
 namespace cvflann


### PR DESCRIPTION
It is done for Windows RT tablets.
