### PR TITLE
Solve the problem seen when using recent versions of CMake (such as 2.8....

### DIFF
--- a/cmake/OpenCVGenConfig.cmake
+++ b/cmake/OpenCVGenConfig.cmake
@@ -84,7 +84,7 @@ macro(ocv_generate_dependencies_map_configcmake suffix configuration)
 
     set(OPENCV_DEPENDENCIES_MAP_${suffix} "${OPENCV_DEPENDENCIES_MAP_${suffix}}set(OpenCV_${__ocv_lib}_LIBNAME_${suffix} \"${__libname}\")\n")
     set(OPENCV_DEPENDENCIES_MAP_${suffix} "${OPENCV_DEPENDENCIES_MAP_${suffix}}set(OpenCV_${__ocv_lib}_DEPS_${suffix} ${__mod_deps})\n")
-    set(OPENCV_DEPENDENCIES_MAP_${suffix} "${OPENCV_DEPENDENCIES_MAP_${suffix}}set(OpenCV_${__ocv_lib}_EXTRA_DEPS_${suffix} ${__ext_deps})\n")
+    set(OPENCV_DEPENDENCIES_MAP_${suffix} "${OPENCV_DEPENDENCIES_MAP_${suffix}}set(OpenCV_${__ocv_lib}_EXTRA_DEPS_${suffix} \"${__ext_deps}\")\n")
 
     list(APPEND OPENCV_PROCESSED_LIBS ${__ocv_lib})
     list(APPEND OPENCV_LIBS_TO_PROCESS ${${__ocv_lib}_MODULE_DEPS_${suffix}})


### PR DESCRIPTION
Solve the problem seen when using recent versions of CMake (such as 2.8.11): OpenCVConfig.cmake violates the policy CMP0004.

Symptoms:
CMake Error at CMakeLists.txt:10 (add_executable):
Target "my_app" links to item "C:/Program Files " which has leading
or trailing whitespace. This is now an error according to policy CMP0004.

This problem occurs when building on Windows when we depend on libraries located (for example) in "C:\Program Files (x86)..."
