### PR TITLE
Fix java test ellipse2poly

### DIFF
--- a/modules/java/android_test/src/org/opencv/test/core/CoreTest.java
+++ b/modules/java/android_test/src/org/opencv/test/core/CoreTest.java
@@ -491,20 +491,6 @@ public class CoreTest extends OpenCVTestCase {
 
         Point truth[] = {
                 new Point(5, 6),
-                new Point(5, 6),
-                new Point(5, 6),
-                new Point(5, 6),
-                new Point(5, 6),
-                new Point(5, 6),
-                new Point(5, 6),
-                new Point(5, 6),
-                new Point(4, 6),
-                new Point(4, 6),
-                new Point(4, 6),
-                new Point(4, 6),
-                new Point(4, 6),
-                new Point(4, 6),
-                new Point(4, 6),
                 new Point(4, 6)
         };
         assertArrayPointsEquals(truth, pts.toArray(), EPS);


### PR DESCRIPTION
It became broken after a fix in `cv::ellipse2Poly()` recently
