### PR TITLE
Make ts always static

### DIFF
--- a/modules/ts/CMakeLists.txt
+++ b/modules/ts/CMakeLists.txt
@@ -4,10 +4,7 @@ if(IOS)
   ocv_module_disable(ts)
 endif()
 
-if(MINGW)
-  set(OPENCV_MODULE_TYPE STATIC)
-endif()
-
+set(OPENCV_MODULE_TYPE STATIC)
 set(OPENCV_MODULE_IS_PART_OF_WORLD FALSE)
 
 if(HAVE_CUDA)
@@ -21,11 +18,5 @@ ocv_add_module(ts opencv_core opencv_features2d)
 ocv_glob_module_sources()
 ocv_module_include_directories()
 ocv_create_module()
-
-if(BUILD_SHARED_LIBS AND NOT MINGW)
-  add_definitions(-DGTEST_CREATE_SHARED_LIBRARY=1)
-else()
-  add_definitions(-DGTEST_CREATE_SHARED_LIBRARY=0)
-endif()
 
 ocv_add_precompiled_headers(${the_module})

--- a/modules/ts/include/opencv2/ts/ts.hpp
+++ b/modules/ts/include/opencv2/ts/ts.hpp
@@ -1,13 +1,6 @@
 #ifndef __OPENCV_GTESTCV_HPP__
 #define __OPENCV_GTESTCV_HPP__
 
-#include "cvconfig.h"
-#ifndef GTEST_CREATE_SHARED_LIBRARY
-#ifdef BUILD_SHARED_LIBS
-#define GTEST_LINKED_AS_SHARED_LIBRARY 1
-#endif
-#endif
-
 #include <stdarg.h> // for va_list
 
 #ifdef HAVE_WINRT


### PR DESCRIPTION
This allows us to forget about the `GTEST_(CREATE|LINKED_AS)_SHARED_LIBRARY` macros and to get rid of the dependency on cvconfig.h.
