### PR TITLE
CvCaptureCAM_DShow::open with an out of bound index inconsistant with V4L (Bug #3201)

### DIFF
--- a/modules/highgui/src/cap_dshow.cpp
+++ b/modules/highgui/src/cap_dshow.cpp
@@ -3170,7 +3170,7 @@ bool CvCaptureCAM_DShow::open( int _index )
     devices = VI.listDevices(true);
     if (devices == 0)
         return false;
-    if (_index < 0 || index > devices-1)
+    if (_index < 0 || _index > devices-1)
         return false;
     VI.setupDevice(_index);
     if( !VI.isDeviceSetup(_index) )


### PR DESCRIPTION
DShow wrapper now returns false if we try to open an incorrect input index
