### PR TITLE
Fix a bug of retinaParameters.

### DIFF
--- a/modules/contrib/src/retina.cpp
+++ b/modules/contrib/src/retina.cpp
@@ -357,6 +357,7 @@ void Retina::_init(const cv::Size inputSz, const bool colorMode, RETINA_COLORSAM
            delete _retinaFilter;
     _retinaFilter = new RetinaFilter(inputSz.height, inputSz.width, colorMode, colorSamplingMethod, useRetinaLogSampling, reductionFactor, samplingStrenght);
 
+    _retinaParameters.OPLandIplParvo.colorMode = colorMode;
     // prepare the default parameter XML file with default setup
         setup(_retinaParameters);
 


### PR DESCRIPTION
When colorMode is set to 0 via Retina::_init method, _retinaParameters's colorMode variable is not correctly assigned.
