### PR TITLE
Bugfix 3209: adding a minus to the anchor point in docs

### DIFF
--- a/modules/imgproc/doc/filtering.rst
+++ b/modules/imgproc/doc/filtering.rst
@@ -1446,7 +1446,7 @@ Applies a separable linear filter to an image.
 
     :param kernelY: Coefficients for filtering each column.
 
-    :param anchor: Anchor position within the kernel. The default value  :math:`(-1, 1)`  means that the anchor is at the kernel center.
+    :param anchor: Anchor position within the kernel. The default value  :math:`(-1,-1)`  means that the anchor is at the kernel center.
 
     :param delta: Value added to the filtered results before storing them.
 


### PR DESCRIPTION
As mentioned in bugfix #3209 : http://code.opencv.org/issues/3209

Fixed wrong documentation giving wrong anchor point.
