### PR TITLE
Fixing tutorials not including the nonfree module

### DIFF
--- a/doc/tutorials/features2d/feature_detection/feature_detection.rst
+++ b/doc/tutorials/features2d/feature_detection/feature_detection.rst
@@ -31,6 +31,7 @@ This tutorial code's is shown lines below. You can also download it from `here <
    #include "opencv2/core/core.hpp"
    #include "opencv2/features2d/features2d.hpp"
    #include "opencv2/highgui/highgui.hpp"
+   #include "opencv2/nonfree/nonfree.hpp"
 
    using namespace cv;
 

--- a/doc/tutorials/features2d/feature_flann_matcher/feature_flann_matcher.rst
+++ b/doc/tutorials/features2d/feature_flann_matcher/feature_flann_matcher.rst
@@ -28,6 +28,7 @@ This tutorial code's is shown lines below. You can also download it from `here <
    #include "opencv2/core/core.hpp"
    #include "opencv2/features2d/features2d.hpp"
    #include "opencv2/highgui/highgui.hpp"
+   #include "opencv2/nonfree/nonfree.hpp"
 
    using namespace cv;
 

--- a/doc/tutorials/features2d/feature_homography/feature_homography.rst
+++ b/doc/tutorials/features2d/feature_homography/feature_homography.rst
@@ -30,6 +30,7 @@ This tutorial code's is shown lines below. You can also download it from `here <
    #include "opencv2/features2d/features2d.hpp"
    #include "opencv2/highgui/highgui.hpp"
    #include "opencv2/calib3d/calib3d.hpp"
+   #include "opencv2/nonfree/nonfree.hpp"
 
    using namespace cv;
 


### PR DESCRIPTION
The tutorials at http://docs.opencv.org/doc/tutorials/features2d/ except for detection are missing the including of the nonfree module. Therefore the SurfFeatureDetector will not work.

Added the fix.
