### PR TITLE
CLAHE Python bindings

### DIFF
--- a/modules/imgproc/include/opencv2/imgproc/imgproc.hpp
+++ b/modules/imgproc/include/opencv2/imgproc/imgproc.hpp
@@ -759,20 +759,20 @@ CV_EXPORTS double compareHist( const SparseMat& H1, const SparseMat& H2, int met
 //! normalizes the grayscale image brightness and contrast by normalizing its histogram
 CV_EXPORTS_W void equalizeHist( InputArray src, OutputArray dst );
 
-class CV_EXPORTS CLAHE : public Algorithm
+class CV_EXPORTS_W CLAHE : public Algorithm
 {
 public:
-    virtual void apply(InputArray src, OutputArray dst) = 0;
+    CV_WRAP virtual void apply(InputArray src, OutputArray dst) = 0;
 
-    virtual void setClipLimit(double clipLimit) = 0;
-    virtual double getClipLimit() const = 0;
+    CV_WRAP virtual void setClipLimit(double clipLimit) = 0;
+    CV_WRAP virtual double getClipLimit() const = 0;
 
-    virtual void setTilesGridSize(Size tileGridSize) = 0;
-    virtual Size getTilesGridSize() const = 0;
+    CV_WRAP virtual void setTilesGridSize(Size tileGridSize) = 0;
+    CV_WRAP virtual Size getTilesGridSize() const = 0;
 
-    virtual void collectGarbage() = 0;
+    CV_WRAP virtual void collectGarbage() = 0;
 };
-CV_EXPORTS Ptr<CLAHE> createCLAHE(double clipLimit = 40.0, Size tileGridSize = Size(8, 8));
+CV_EXPORTS_W Ptr<CLAHE> createCLAHE(double clipLimit = 40.0, Size tileGridSize = Size(8, 8));
 
 CV_EXPORTS float EMD( InputArray signature1, InputArray signature2,
                       int distType, InputArray cost=noArray(),

--- a/modules/python/src2/cv2.cpp
+++ b/modules/python/src2/cv2.cpp
@@ -123,6 +123,7 @@ typedef Ptr<FeatureDetector> Ptr_FeatureDetector;
 typedef Ptr<DescriptorExtractor> Ptr_DescriptorExtractor;
 typedef Ptr<Feature2D> Ptr_Feature2D;
 typedef Ptr<DescriptorMatcher> Ptr_DescriptorMatcher;
+typedef Ptr<CLAHE> Ptr_CLAHE; 
 
 typedef SimpleBlobDetector::Params SimpleBlobDetector_Params;
 


### PR DESCRIPTION
Added Python bindings for CLAHE in imgproc module.

Usage :

```
In [3]: x = cv2.createCLAHE()
In [7]: img = cv2.imread('/home/abidrahmank/messi5.jpg',0)
In [8]: dst = x.apply(img)
```
