### PR TITLE
bug #3094: added CV_Assert to PyrDown_()

### DIFF
--- a/modules/imgproc/src/pyramids.cpp
+++ b/modules/imgproc/src/pyramids.cpp
@@ -191,6 +191,7 @@ pyrDown_( const Mat& _src, Mat& _dst, int borderType )
     typedef typename CastOp::type1 WT;
     typedef typename CastOp::rtype T;
 
+    CV_Assert( !_src.empty() );
     Size ssize = _src.size(), dsize = _dst.size();
     int cn = _src.channels();
     int bufstep = (int)alignSize(dsize.width*cn, 16);


### PR DESCRIPTION
added CV_Assert to PyrDown_ to check if source matrix is not empty
