### PR TITLE
fixed build problem with isnan on mac os x

### DIFF
--- a/modules/stitching/src/motion_estimators.cpp
+++ b/modules/stitching/src/motion_estimators.cpp
@@ -48,6 +48,7 @@
   #define isnan(x) _isnan(x)
 #else
   #include <math.h>
+  using namespace std;
 #endif
 
 using namespace cv;


### PR DESCRIPTION
compiler couldn't find the isnan function in the math library because is in another namespace. It suggested to use std::isnan but this wouldn't work for the case where we define isnan locally.
