### PR TITLE
In calcOpticalFlowSF, fix several uninitialized uses of matrices

### DIFF
--- a/modules/video/src/simpleflow.cpp
+++ b/modules/video/src/simpleflow.cpp
@@ -287,7 +287,7 @@ static Mat upscaleOpticalFlow(int new_rows,
 static Mat calcIrregularityMat(const Mat& flow, int radius) {
   const int rows = flow.rows;
   const int cols = flow.cols;
-  Mat irregularity(rows, cols, CV_32F);
+  Mat irregularity = Mat::zeros(rows, cols, CV_32F);
   for (int r = 0; r < rows; ++r) {
     const int start_row = max(0, r - radius);
     const int end_row = min(rows - 1, r + radius);
@@ -409,7 +409,7 @@ static void extrapolateFlow(Mat& flow,
                             const Mat& speed_up) {
   const int rows = flow.rows;
   const int cols = flow.cols;
-  Mat done(rows, cols, CV_8U);
+  Mat done = Mat::zeros(rows, cols, CV_8U);
   for (int r = 0; r < rows; ++r) {
     for (int c = 0; c < cols; ++c) {
       if (!done.at<uchar>(r, c) && speed_up.at<uchar>(r, c) > 1) {
@@ -504,8 +504,8 @@ CV_EXPORTS_W void calcOpticalFlowSF(Mat& from,
   Mat mask = Mat::ones(curr_from.size(), CV_8U);
   Mat mask_inv = Mat::ones(curr_from.size(), CV_8U);
 
-  Mat flow(curr_from.size(), CV_32FC2);
-  Mat flow_inv(curr_to.size(), CV_32FC2);
+  Mat flow = Mat::zeros(curr_from.size(), CV_32FC2);
+  Mat flow_inv = Mat::zeros(curr_to.size(), CV_32FC2);
 
   Mat confidence;
   Mat confidence_inv;


### PR DESCRIPTION
This should fix that pesky test failure that pops up from time to time.

I don't actually know if the default values should be zeros, but the tests pass, so...
