### PR TITLE
Filter bilateral

### DIFF
--- a/modules/imgproc/test/test_bilateral_filter.cpp
+++ b/modules/imgproc/test/test_bilateral_filter.cpp
@@ -251,7 +251,7 @@ namespace cvtest
 
     int CV_BilateralFilterTest::validate_test_results(int test_case_index)
     {
-        static const double eps = 1;
+        static const double eps = 4;
 
         Mat reference_dst, reference_src;
         if (_src.depth() == CV_32F)


### PR DESCRIPTION
IPP function is faster. Sometimes result is slightly different: for example, maximal L2 norm of error is 3.31662 for a 1020x965 image. It is neccessary to make changes in performance tests (in opencv_extra repository), I changed eps  for accuracy tests only.
