### PR TITLE
Typo in Java generator fixed.

### DIFF
--- a/modules/java/generator/gen_java.py
+++ b/modules/java/generator/gen_java.py
@@ -544,7 +544,7 @@ JNIEXPORT jstring JNICALL Java_org_opencv_highgui_VideoCapture_getSupportedPrevi
 {
     static const char method_name[] = "highgui::VideoCapture_getSupportedPreviewSizes_10()";
     try {
-        LOGD(%s, method_name);
+        LOGD("%s", method_name);
         VideoCapture* me = (VideoCapture*) self; //TODO: check for NULL
         union {double prop; const char* name;} u;
         u.prop = me->get(CV_CAP_PROP_SUPPORTED_PREVIEW_SIZES_STRING);


### PR DESCRIPTION
Typo breaks debug build for Android platform.
