### PR TITLE
Fix errors in usages of try_compile

### DIFF
--- a/cmake/OpenCVCRTLinkage.cmake
+++ b/cmake/OpenCVCRTLinkage.cmake
@@ -26,8 +26,8 @@ else()
   set(HAVE_MSVC2012 TRUE)
 endif()
 
-TRY_COMPILE(HAVE_WINRT_SDK
-  "${OPENCV_BINARY_DIR}/CMakeFiles/CMakeTmp"
+try_compile(HAVE_WINRT_SDK
+  "${OpenCV_BINARY_DIR}"
   "${OpenCV_SOURCE_DIR}/cmake/checks/winrttest.cpp")
 
 if (ENABLE_WINRT_MODE AND HAVE_WINRT_SDK AND HAVE_MSVC2012 AND HAVE_MSPDK)

--- a/cmake/OpenCVFindLibsGUI.cmake
+++ b/cmake/OpenCVFindLibsGUI.cmake
@@ -5,12 +5,11 @@
 #--- Win32 UI ---
 ocv_clear_vars(HAVE_WIN32UI)
 if(WITH_WIN32UI)
-  TRY_COMPILE(HAVE_WIN32UI
-    "${OPENCV_BINARY_DIR}/CMakeFiles/CMakeTmp"
+  try_compile(HAVE_WIN32UI
+    "${OpenCV_BINARY_DIR}"
     "${OpenCV_SOURCE_DIR}/cmake/checks/win32uitest.cpp"
-    CMAKE_FLAGS "\"user32.lib\" \"gdi32.lib\""
-    OUTPUT_VARIABLE OUTPUT)
-endif(WITH_WIN32UI)
+    CMAKE_FLAGS "-DLINK_LIBRARIES:STRING=user32;gdi32")
+endif()
 
 # --- QT4 ---
 ocv_clear_vars(HAVE_QT HAVE_QT5)

--- a/cmake/OpenCVFindLibsVideo.cmake
+++ b/cmake/OpenCVFindLibsVideo.cmake
@@ -3,13 +3,12 @@
 # ----------------------------------------------------------------------------
 
 ocv_clear_vars(HAVE_VFW)
-if (WITH_VFW)
-  TRY_COMPILE(HAVE_VFW
-    "${OPENCV_BINARY_DIR}/CMakeFiles/CMakeTmp"
+if(WITH_VFW)
+  try_compile(HAVE_VFW
+    "${OpenCV_BINARY_DIR}"
     "${OpenCV_SOURCE_DIR}/cmake/checks/vfwtest.cpp"
-    CMAKE_FLAGS "-DLINK_LIBRARIES:STRING=vfw32"
-    OUTPUT_VARIABLE OUTPUT)
- endif(WITH_VFW)
+    CMAKE_FLAGS "-DLINK_LIBRARIES:STRING=vfw32")
+endif(WITH_VFW)
 
 # --- GStreamer ---
 ocv_clear_vars(HAVE_GSTREAMER)

--- a/cmake/OpenCVUtils.cmake
+++ b/cmake/OpenCVUtils.cmake
@@ -77,7 +77,7 @@ MACRO(ocv_check_compiler_flag LANG FLAG RESULT)
     if(_fname)
       MESSAGE(STATUS "Performing Test ${RESULT}")
       TRY_COMPILE(${RESULT}
-        ${CMAKE_BINARY_DIR}
+        "${CMAKE_BINARY_DIR}"
         "${_fname}"
         COMPILE_DEFINITIONS "${FLAG}"
         OUTPUT_VARIABLE OUTPUT)


### PR DESCRIPTION
- There's no `OPENCV_BINARY_DIR` variable;
- No need to append CMakeFiles/CMakeTmp, as CMake does it for you;
- Output variables are unused;
- Wrong usage of `CMAKE_FLAGS`;
- Small quoting and style issues.
