### PR TITLE
let get_train_error() get called without a SegFault

### DIFF
--- a/modules/ml/src/rtrees.cpp
+++ b/modules/ml/src/rtrees.cpp
@@ -274,8 +274,10 @@ bool CvRTrees::train( const CvMat* _train_data, int _tflag,
         params.cv_folds, params.use_1se_rule, false, params.priors );
 
     data = new CvDTreeTrainData();
-    data->set_data( _train_data, _tflag, _responses, _var_idx,
-        _sample_idx, _var_type, _missing_mask, tree_params, true);
+    CvMat *_tdata = cvCloneMat(_train_data);
+
+    data->set_data( _tdata, _tflag, _responses, _var_idx,
+         _sample_idx, _var_type, _missing_mask, tree_params, true);
 
     int var_count = data->var_count;
     if( params.nactive_vars > var_count )


### PR DESCRIPTION
Hi, 

as already described in http://code.opencv.org/issues/2990#note-1 OpenCV fails when RTrees.get_train_error() is called. 

This partially fixes the issue but I still don't think it's the right way to solve it. 

------ edit
I'm sorry, actually this fix is based on version 2.4.5. but I overlooked the box where I coud set that. 
