### PR TITLE
bugfix for #3227

### DIFF
--- a/modules/core/src/matop.cpp
+++ b/modules/core/src/matop.cpp
@@ -1563,11 +1563,11 @@ void MatOp_Initializer::assign(const MatExpr& e, Mat& m, int _type) const
         m.create(e.a.dims, e.a.size, _type);
 
     if( e.flags == 'I' && e.a.dims <= 2 )
-        setIdentity(m, Scalar(e.alpha));
+        setIdentity(m, Scalar::all(e.alpha));
     else if( e.flags == '0' )
         m = Scalar();
     else if( e.flags == '1' )
-        m = Scalar(e.alpha);
+        m = Scalar::all(e.alpha);
     else
         CV_Error(CV_StsError, "Invalid matrix initializer type");
 }


### PR DESCRIPTION
[#3227](http://code.opencv.org/issues/3227)

changed Scalar(e.alpha) to Scalar::all(e.alpha) in MatOp_Initializer::assign(), so Mat::ones() and Mat::zeros() work as expected with multi-channel Mats
