### PR TITLE
Fix a potential bug of ParallelLoopBodyWrapper::operator(Range)

### DIFF
--- a/modules/core/src/parallel.cpp
+++ b/modules/core/src/parallel.cpp
@@ -144,9 +144,9 @@ namespace
         {
             cv::Range r;
             r.start = (int)(wholeRange.start +
-                            ((size_t)sr.start*(wholeRange.end - wholeRange.start) + nstripes/2)/nstripes);
+                            ((uint64)sr.start*(wholeRange.end - wholeRange.start) + nstripes/2)/nstripes);
             r.end = sr.end >= nstripes ? wholeRange.end : (int)(wholeRange.start +
-                            ((size_t)sr.end*(wholeRange.end - wholeRange.start) + nstripes/2)/nstripes);
+                            ((uint64)sr.end*(wholeRange.end - wholeRange.start) + nstripes/2)/nstripes);
             (*body)(r);
         }
         cv::Range stripeRange() const { return cv::Range(0, nstripes); }


### PR DESCRIPTION
On a 32-bit compiler the calculation may result in data (size_t) overflow when running some paralleled algorithms (which can safely run on a 64-bit compiler).
This bug is found when running OpenCV's Retina tutorial on 32bit VS2010.
