### PR TITLE
Changed the brief description of function Mat::colRange from "Create a m...

### DIFF
--- a/modules/core/doc/basic_structures.rst
+++ b/modules/core/doc/basic_structures.rst
@@ -1292,7 +1292,7 @@ The method makes a new header for the specified row span of the matrix. Similarl
 
 Mat::colRange
 -------------
-Creates a matrix header for the specified row span.
+Creates a matrix header for the specified column span.
 
 .. ocv:function:: Mat Mat::colRange(int startcol, int endcol) const
 


### PR DESCRIPTION
A very tiny bug in reference manual. The brief description of function Mat::colRange is changed from "Create a matrix header for the specified row span." to "Create a matrix header for the specified column span."
