### PR TITLE
Ml cpp wrappers fix

### DIFF
--- a/modules/ml/include/opencv2/ml/ml.hpp
+++ b/modules/ml/include/opencv2/ml/ml.hpp
@@ -936,6 +936,7 @@ protected:
     CvDTreeNode* root;
     CvMat* var_importance;
     CvDTreeTrainData* data;
+    CvMat train_data_hdr, responses_hdr;
 
 public:
     int pruned_tree_idx;
@@ -1047,6 +1048,7 @@ protected:
     // array of the trees of the forest
     CvForestTree** trees;
     CvDTreeTrainData* data;
+    CvMat train_data_hdr, responses_hdr;
     int ntrees;
     int nclasses;
     double oob_error;
@@ -1262,6 +1264,7 @@ protected:
     virtual void read_params( CvFileStorage* fs, CvFileNode* node );
 
     CvDTreeTrainData* data;
+    CvMat train_data_hdr, responses_hdr;
     CvBoostParams params;
     CvSeq* weak;
 

--- a/modules/ml/src/boost.cpp
+++ b/modules/ml/src/boost.cpp
@@ -2121,9 +2121,11 @@ CvBoost::train( const Mat& _train_data, int _tflag,
                const Mat& _missing_mask,
                CvBoostParams _params, bool _update )
 {
-    CvMat tdata = _train_data, responses = _responses, vidx = _var_idx,
-        sidx = _sample_idx, vtype = _var_type, mmask = _missing_mask;
-    return train(&tdata, _tflag, &responses, vidx.data.ptr ? &vidx : 0,
+    train_data_hdr = _train_data;
+    responses_hdr = _responses;
+    CvMat vidx = _var_idx, sidx = _sample_idx, vtype = _var_type, mmask = _missing_mask;
+
+    return train(&train_data_hdr, _tflag, &responses_hdr, vidx.data.ptr ? &vidx : 0,
           sidx.data.ptr ? &sidx : 0, vtype.data.ptr ? &vtype : 0,
           mmask.data.ptr ? &mmask : 0, _params, _update);
 }

--- a/modules/ml/src/ertrees.cpp
+++ b/modules/ml/src/ertrees.cpp
@@ -1839,9 +1839,11 @@ bool CvERTrees::train( const Mat& _train_data, int _tflag,
                       const Mat& _sample_idx, const Mat& _var_type,
                       const Mat& _missing_mask, CvRTParams params )
 {
-    CvMat tdata = _train_data, responses = _responses, vidx = _var_idx,
-    sidx = _sample_idx, vtype = _var_type, mmask = _missing_mask;
-    return train(&tdata, _tflag, &responses, vidx.data.ptr ? &vidx : 0,
+    train_data_hdr = _train_data;
+    responses_hdr = _responses;
+    CvMat vidx = _var_idx, sidx = _sample_idx, vtype = _var_type, mmask = _missing_mask;
+
+    return train(&train_data_hdr, _tflag, &responses_hdr, vidx.data.ptr ? &vidx : 0,
                  sidx.data.ptr ? &sidx : 0, vtype.data.ptr ? &vtype : 0,
                  mmask.data.ptr ? &mmask : 0, params);
 }

--- a/modules/ml/src/rtrees.cpp
+++ b/modules/ml/src/rtrees.cpp
@@ -839,9 +839,11 @@ bool CvRTrees::train( const Mat& _train_data, int _tflag,
                      const Mat& _sample_idx, const Mat& _var_type,
                      const Mat& _missing_mask, CvRTParams _params )
 {
-    CvMat tdata = _train_data, responses = _responses, vidx = _var_idx,
-    sidx = _sample_idx, vtype = _var_type, mmask = _missing_mask;
-    return train(&tdata, _tflag, &responses, vidx.data.ptr ? &vidx : 0,
+    train_data_hdr = _train_data;
+    responses_hdr = _responses;
+    CvMat vidx = _var_idx, sidx = _sample_idx, vtype = _var_type, mmask = _missing_mask;
+
+    return train(&train_data_hdr, _tflag, &responses_hdr, vidx.data.ptr ? &vidx : 0,
                  sidx.data.ptr ? &sidx : 0, vtype.data.ptr ? &vtype : 0,
                  mmask.data.ptr ? &mmask : 0, _params);
 }

--- a/modules/ml/src/tree.cpp
+++ b/modules/ml/src/tree.cpp
@@ -1583,9 +1583,11 @@ bool CvDTree::train( const Mat& _train_data, int _tflag,
                     const Mat& _sample_idx, const Mat& _var_type,
                     const Mat& _missing_mask, CvDTreeParams _params )
 {
-    CvMat tdata = _train_data, responses = _responses, vidx=_var_idx,
-        sidx=_sample_idx, vtype=_var_type, mmask=_missing_mask;
-    return train(&tdata, _tflag, &responses, vidx.data.ptr ? &vidx : 0, sidx.data.ptr ? &sidx : 0,
+    train_data_hdr = _train_data;
+    responses_hdr = _responses;
+    CvMat vidx=_var_idx, sidx=_sample_idx, vtype=_var_type, mmask=_missing_mask;
+
+    return train(&train_data_hdr, _tflag, &responses_hdr, vidx.data.ptr ? &vidx : 0, sidx.data.ptr ? &sidx : 0,
                  vtype.data.ptr ? &vtype : 0, mmask.data.ptr ? &mmask : 0, _params);
 }
 


### PR DESCRIPTION
There is the bug in MLL described in PR https://github.com/Itseez/opencv/pull/1325. But solution suggested in that PR has a drawback: doubling training data memory is unacceptably because real training data might be very large. This PR fixes the original problem without increasing memory.
