### PR TITLE
correct range computation in connectedcomponents stats

### DIFF
--- a/modules/imgproc/src/connectedcomponents.cpp
+++ b/modules/imgproc/src/connectedcomponents.cpp
@@ -92,20 +92,10 @@ namespace cv{
         }
         void operator()(int r, int c, int l){
             int *row = &statsv.at<int>(l, 0);
-            if(c > row[CC_STAT_WIDTH]){
-                row[CC_STAT_WIDTH] = c;
-            }else{
-                if(c < row[CC_STAT_LEFT]){
-                    row[CC_STAT_LEFT] = c;
-                }
-            }
-            if(r > row[CC_STAT_HEIGHT]){
-                row[CC_STAT_HEIGHT] = r;
-            }else{
-                if(r < row[CC_STAT_TOP]){
-                    row[CC_STAT_TOP] = r;
-                }
-            }
+            row[CC_STAT_LEFT] = MIN(row[CC_STAT_LEFT], c);
+            row[CC_STAT_WIDTH] = MAX(row[CC_STAT_WIDTH], c);
+            row[CC_STAT_TOP] = MIN(row[CC_STAT_TOP], r);
+            row[CC_STAT_HEIGHT] = MAX(row[CC_STAT_HEIGHT], r);
             row[CC_STAT_AREA]++;
             Point2ui64 &integral = integrals[l];
             integral.x += c;
@@ -114,9 +104,7 @@ namespace cv{
         void finish(){
             for(int l = 0; l < statsv.rows; ++l){
                 int *row = &statsv.at<int>(l, 0);
-                row[CC_STAT_LEFT] = std::min(row[CC_STAT_LEFT], row[CC_STAT_WIDTH]);
                 row[CC_STAT_WIDTH] = row[CC_STAT_WIDTH] - row[CC_STAT_LEFT] + 1;
-                row[CC_STAT_TOP] = std::min(row[CC_STAT_TOP], row[CC_STAT_HEIGHT]);
                 row[CC_STAT_HEIGHT] = row[CC_STAT_HEIGHT] - row[CC_STAT_TOP] + 1;
 
                 Point2ui64 &integral = integrals[l];


### PR DESCRIPTION
I originally tried doing a more efficient implementation but it was difficult to do correctly in this context and the version I had ended up incorrect.  Instead I'm using simpler version.
