### PR TITLE
AutoBuffer with initial zero size fixed.

### DIFF
--- a/modules/core/include/opencv2/core/utility.hpp
+++ b/modules/core/include/opencv2/core/utility.hpp
@@ -116,8 +116,8 @@ protected:
     _Tp* ptr;
     //! size of the real buffer
     size_t sz;
-    //! pre-allocated buffer
-    _Tp buf[fixed_size];
+    //! pre-allocated buffer. At least 1 element to confirm C++ standard reqirements
+    _Tp buf[(fixed_size > 0) ? fixed_size : 1];
 };
 
 //! Sets/resets the break-on-error mode.


### PR DESCRIPTION
Zero sized array are restricted by C++ standard.
