### PR TITLE
Fix featuretracker

### DIFF
--- a/modules/contrib/CMakeLists.txt
+++ b/modules/contrib/CMakeLists.txt
@@ -1,1 +1,1 @@
-ocv_define_module(contrib opencv_imgproc opencv_calib3d opencv_features2d opencv_ml opencv_video opencv_objdetect opencv_nonfree OPTIONAL opencv_highgui)
+ocv_define_module(contrib opencv_imgproc opencv_calib3d opencv_features2d opencv_ml opencv_video opencv_objdetect OPTIONAL opencv_highgui opencv_nonfree)

--- a/modules/contrib/src/featuretracker.cpp
+++ b/modules/contrib/src/featuretracker.cpp
@@ -45,6 +45,12 @@
 #include "opencv2/calib3d/calib3d.hpp"
 #include "opencv2/contrib/hybridtracker.hpp"
 
+#ifdef HAVE_OPENCV_NONFREE
+#include "opencv2/nonfree/nonfree.hpp"
+
+static bool makeUseOfNonfree = initModule_nonfree();
+#endif
+
 using namespace cv;
 
 CvFeatureTracker::CvFeatureTracker(CvFeatureTrackerParams _params) :


### PR DESCRIPTION
Added the fix to the cmakelist as mentioned in this Q&A forum topic.
However, the fix about the default case not having a break, has already been solved in the 2.4 branch.

Topic: http://answers.opencv.org/question/19531/featuretracker-opencv-has-been-compiled-without/ 

If this is not correct, feel free to close the pull request down.
