### PR TITLE
Fix for bug #3219 (undefined reference in GPU samples)

### DIFF
--- a/samples/gpu/CMakeLists.txt
+++ b/samples/gpu/CMakeLists.txt
@@ -40,6 +40,11 @@ if(BUILD_EXAMPLES AND OCV_DEPENDENCIES_FOUND)
     add_executable(${the_target} ${srcs})
 
     target_link_libraries(${the_target} ${OPENCV_LINKER_LIBS} ${OPENCV_GPU_SAMPLES_REQUIRED_DEPS})
+
+    if(HAVE_CUDA)
+      target_link_libraries(${the_target} ${CUDA_CUDA_LIBRARY})
+    endif()
+
     if(HAVE_opencv_nonfree)
       target_link_libraries(${the_target} opencv_nonfree)
     endif()


### PR DESCRIPTION
Original PR (https://github.com/Itseez/opencv/pull/1267) was merged into master branch, but the fix is also applicable to 2.4 branch.
