### PR TITLE
propid numbers

### DIFF
--- a/modules/highgui/doc/reading_and_writing_images_and_video.rst
+++ b/modules/highgui/doc/reading_and_writing_images_and_video.rst
@@ -360,43 +360,43 @@ Returns the specified ``VideoCapture`` property
 
     :param propId: Property identifier. It can be one of the following:
 
-        * **CV_CAP_PROP_POS_MSEC** Current position of the video file in milliseconds or video capture timestamp.
+        0. **CV_CAP_PROP_POS_MSEC** Current position of the video file in milliseconds or video capture timestamp.
 
-        * **CV_CAP_PROP_POS_FRAMES** 0-based index of the frame to be decoded/captured next.
+        1. **CV_CAP_PROP_POS_FRAMES** 0-based index of the frame to be decoded/captured next.
 
-        * **CV_CAP_PROP_POS_AVI_RATIO** Relative position of the video file: 0 - start of the film, 1 - end of the film.
+        2. **CV_CAP_PROP_POS_AVI_RATIO** Relative position of the video file: 0 - start of the film, 1 - end of the film.
 
-        * **CV_CAP_PROP_FRAME_WIDTH** Width of the frames in the video stream.
+        3. **CV_CAP_PROP_FRAME_WIDTH** Width of the frames in the video stream.
 
-        * **CV_CAP_PROP_FRAME_HEIGHT** Height of the frames in the video stream.
+        4. **CV_CAP_PROP_FRAME_HEIGHT** Height of the frames in the video stream.
 
-        * **CV_CAP_PROP_FPS** Frame rate.
+        5. **CV_CAP_PROP_FPS** Frame rate.
 
-        * **CV_CAP_PROP_FOURCC** 4-character code of codec.
+        6. **CV_CAP_PROP_FOURCC** 4-character code of codec.
 
-        * **CV_CAP_PROP_FRAME_COUNT** Number of frames in the video file.
+        7. **CV_CAP_PROP_FRAME_COUNT** Number of frames in the video file.
 
-        * **CV_CAP_PROP_FORMAT** Format of the Mat objects returned by ``retrieve()`` .
+        8. **CV_CAP_PROP_FORMAT** Format of the Mat objects returned by ``retrieve()`` .
 
-        * **CV_CAP_PROP_MODE** Backend-specific value indicating the current capture mode.
+        9. **CV_CAP_PROP_MODE** Backend-specific value indicating the current capture mode.
 
-        * **CV_CAP_PROP_BRIGHTNESS** Brightness of the image (only for cameras).
+        10. **CV_CAP_PROP_BRIGHTNESS** Brightness of the image (only for cameras).
 
-        * **CV_CAP_PROP_CONTRAST** Contrast of the image (only for cameras).
+        11. **CV_CAP_PROP_CONTRAST** Contrast of the image (only for cameras).
 
-        * **CV_CAP_PROP_SATURATION** Saturation of the image (only for cameras).
+        12. **CV_CAP_PROP_SATURATION** Saturation of the image (only for cameras).
 
-        * **CV_CAP_PROP_HUE** Hue of the image (only for cameras).
+        13. **CV_CAP_PROP_HUE** Hue of the image (only for cameras).
 
-        * **CV_CAP_PROP_GAIN** Gain of the image (only for cameras).
+        14. **CV_CAP_PROP_GAIN** Gain of the image (only for cameras).
 
-        * **CV_CAP_PROP_EXPOSURE** Exposure (only for cameras).
+        15. **CV_CAP_PROP_EXPOSURE** Exposure (only for cameras).
 
-        * **CV_CAP_PROP_CONVERT_RGB** Boolean flags indicating whether images should be converted to RGB.
+        16. **CV_CAP_PROP_CONVERT_RGB** Boolean flags indicating whether images should be converted to RGB.
 
-        * **CV_CAP_PROP_WHITE_BALANCE** Currently not supported
+        17. **CV_CAP_PROP_WHITE_BALANCE** Currently not supported
 
-        * **CV_CAP_PROP_RECTIFICATION** Rectification flag for stereo cameras (note: only supported by DC1394 v 2.x backend currently)
+        18. **CV_CAP_PROP_RECTIFICATION** Rectification flag for stereo cameras (note: only supported by DC1394 v 2.x backend currently)
 
 
 **Note**: When querying a property that is not supported by the backend used by the ``VideoCapture`` class, value 0 is returned.
@@ -413,43 +413,43 @@ Sets a property in the ``VideoCapture``.
 
     :param propId: Property identifier. It can be one of the following:
 
-        * **CV_CAP_PROP_POS_MSEC** Current position of the video file in milliseconds.
+        0. **CV_CAP_PROP_POS_MSEC** Current position of the video file in milliseconds.
 
-        * **CV_CAP_PROP_POS_FRAMES** 0-based index of the frame to be decoded/captured next.
+        1. **CV_CAP_PROP_POS_FRAMES** 0-based index of the frame to be decoded/captured next.
 
-        * **CV_CAP_PROP_POS_AVI_RATIO** Relative position of the video file: 0 - start of the film, 1 - end of the film.
+        2. **CV_CAP_PROP_POS_AVI_RATIO** Relative position of the video file: 0 - start of the film, 1 - end of the film.
 
-        * **CV_CAP_PROP_FRAME_WIDTH** Width of the frames in the video stream.
+        3. **CV_CAP_PROP_FRAME_WIDTH** Width of the frames in the video stream.
 
-        * **CV_CAP_PROP_FRAME_HEIGHT** Height of the frames in the video stream.
+        4. **CV_CAP_PROP_FRAME_HEIGHT** Height of the frames in the video stream.
 
-        * **CV_CAP_PROP_FPS** Frame rate.
+        5. **CV_CAP_PROP_FPS** Frame rate.
 
-        * **CV_CAP_PROP_FOURCC** 4-character code of codec.
+        6. **CV_CAP_PROP_FOURCC** 4-character code of codec.
 
-        * **CV_CAP_PROP_FRAME_COUNT** Number of frames in the video file.
+        7. **CV_CAP_PROP_FRAME_COUNT** Number of frames in the video file.
 
-        * **CV_CAP_PROP_FORMAT** Format of the Mat objects returned by ``retrieve()`` .
+        8. **CV_CAP_PROP_FORMAT** Format of the Mat objects returned by ``retrieve()`` .
 
-        * **CV_CAP_PROP_MODE** Backend-specific value indicating the current capture mode.
+        9. **CV_CAP_PROP_MODE** Backend-specific value indicating the current capture mode.
 
-        * **CV_CAP_PROP_BRIGHTNESS** Brightness of the image (only for cameras).
+        10. **CV_CAP_PROP_BRIGHTNESS** Brightness of the image (only for cameras).
 
-        * **CV_CAP_PROP_CONTRAST** Contrast of the image (only for cameras).
+        11. **CV_CAP_PROP_CONTRAST** Contrast of the image (only for cameras).
 
-        * **CV_CAP_PROP_SATURATION** Saturation of the image (only for cameras).
+        12. **CV_CAP_PROP_SATURATION** Saturation of the image (only for cameras).
 
-        * **CV_CAP_PROP_HUE** Hue of the image (only for cameras).
+        13. **CV_CAP_PROP_HUE** Hue of the image (only for cameras).
 
-        * **CV_CAP_PROP_GAIN** Gain of the image (only for cameras).
+        14. **CV_CAP_PROP_GAIN** Gain of the image (only for cameras).
 
-        * **CV_CAP_PROP_EXPOSURE** Exposure (only for cameras).
+        15. **CV_CAP_PROP_EXPOSURE** Exposure (only for cameras).
 
-        * **CV_CAP_PROP_CONVERT_RGB** Boolean flags indicating whether images should be converted to RGB.
+        16. **CV_CAP_PROP_CONVERT_RGB** Boolean flags indicating whether images should be converted to RGB.
 
-        * **CV_CAP_PROP_WHITE_BALANCE** Currently unsupported
+        17. **CV_CAP_PROP_WHITE_BALANCE** Currently unsupported
 
-        * **CV_CAP_PROP_RECTIFICATION** Rectification flag for stereo cameras (note: only supported by DC1394 v 2.x backend currently)
+        18. **CV_CAP_PROP_RECTIFICATION** Rectification flag for stereo cameras (note: only supported by DC1394 v 2.x backend currently)
 
     :param value: Value of the property.
 


### PR DESCRIPTION
Just converted bullets in VideoCapture.get() docs to corresponding index numbers. It helps those users who uses index numbers instead of the full flag name (like me).
