### PR TITLE
Fix a bug in FLANN resulting in uninitialized accesses

### DIFF
--- a/modules/flann/include/opencv2/flann/any.h
+++ b/modules/flann/include/opencv2/flann/any.h
@@ -255,8 +255,7 @@ public:
     const T& cast() const
     {
         if (policy->type() != typeid(T)) throw anyimpl::bad_any_cast();
-        void* obj = const_cast<void*>(object);
-        T* r = reinterpret_cast<T*>(policy->get_value(&obj));
+        T* r = reinterpret_cast<T*>(policy->get_value(const_cast<void **>(&object)));
         return *r;
     }
 


### PR DESCRIPTION
This might fix this intermittent error: http://build.opencv.org/builders/precommit_ubuntu_nosse/builds/2285.

The first commit is cherrypicked from mariusmuja/flann@b615f26.

Since it took me a while to understand what the bug is, and the original commit message is no help, here's a brief explanation. In the const version of `any::cast`, if `policy` is a `small_any_policy`, its `get_value` returns its input argument. So `r` becomes a pointer to `obj`, and the return value is a reference to a local variable, which is invalidated when the function exits.
