### PR TITLE
Bugfix for 3118

### DIFF
--- a/modules/features2d/src/draw.cpp
+++ b/modules/features2d/src/draw.cpp
@@ -200,12 +200,12 @@ void drawMatches( const Mat& img1, const std::vector<KeyPoint>& keypoints1,
     {
         if( matchesMask.empty() || matchesMask[m] )
         {
-            int i1 = matches1to2[m].queryIdx;
-            int i2 = matches1to2[m].trainIdx;
-            CV_Assert(i1 >= 0 && i1 < static_cast<int>(keypoints1.size()));
-            CV_Assert(i2 >= 0 && i2 < static_cast<int>(keypoints2.size()));
+            int i1_index = matches1to2[m].trainIdx;
+            int i2_index = matches1to2[m].queryIdx;
+            CV_Assert(i1_index >= 0 && i1_index < static_cast<int>(keypoints1.size()));
+            CV_Assert(i2_index >= 0 && i2_index < static_cast<int>(keypoints2.size()));
 
-            const KeyPoint &kp1 = keypoints1[i1], &kp2 = keypoints2[i2];
+            const KeyPoint &kp1 = keypoints1[i1_index], &kp2 = keypoints2[i2_index];
             _drawMatch( outImg, outImg1, outImg2, kp1, kp2, matchColor, flags );
         }
     }
@@ -229,8 +229,8 @@ void drawMatches( const Mat& img1, const std::vector<KeyPoint>& keypoints1,
     {
         for( size_t j = 0; j < matches1to2[i].size(); j++ )
         {
-            int i1 = matches1to2[i][j].queryIdx;
-            int i2 = matches1to2[i][j].trainIdx;
+            int i1 = matches1to2[i][j].trainIdx;
+            int i2 = matches1to2[i][j].queryIdx;
             if( matchesMask.empty() || matchesMask[i][j] )
             {
                 const KeyPoint &kp1 = keypoints1[i1], &kp2 = keypoints2[i2];


### PR DESCRIPTION
Regarding this issue: http://code.opencv.org/issues/3118

This is the original question that led to the issue: http://answers.opencv.org/question/12048/drawmatches-bug/

It's still not clear to me whether this is correct, as in the ocl and gpufeatures2d modules DMatch is always initialized with the query index before the training index, for example:

modules/gpufeatures2d/src/brute_force_matcher.cpp:            DMatch m(queryIdx, _trainIdx, _imgIdx, _distance);
