### PR TITLE
ocl::merge fix

### DIFF
--- a/modules/ocl/src/opencl/merge_mat.cl
+++ b/modules/ocl/src/opencl/merge_mat.cl
@@ -204,7 +204,7 @@ __kernel void merge_vector_C2_D4(__global int *mat_dst,  int dst_step,  int dst_
         int src0 = *((__global int *)((__global uchar *)mat_src0 + src0_index + (x << 2)));
         int src1 = *((__global int *)((__global uchar *)mat_src1 + src1_index + (x << 2)));
 
-        *((__global int2 *)((__global uchar *)mat_dst  + dst_index + (x << 4))) = (int2)(src0, src1);
+        *((__global int2 *)((__global uchar *)mat_dst  + dst_index + (x << 3))) = (int2)(src0, src1);
     }
 }
 __kernel void merge_vector_C2_D5(__global float *mat_dst,  int dst_step,  int dst_offset,
@@ -224,7 +224,7 @@ __kernel void merge_vector_C2_D5(__global float *mat_dst,  int dst_step,  int ds
         float src0 = *((__global float *)((__global uchar *)mat_src0 + src0_index + (x << 2)));
         float src1 = *((__global float *)((__global uchar *)mat_src1 + src1_index + (x << 2)));
 
-        *((__global float2 *)((__global uchar *)mat_dst  + dst_index + (x << 4))) = (float2)(src0, src1);
+        *((__global float2 *)((__global uchar *)mat_dst  + dst_index + (x << 3))) = (float2)(src0, src1);
     }
 }
 

--- a/modules/ocl/test/test_split_merge.cpp
+++ b/modules/ocl/test/test_split_merge.cpp
@@ -52,39 +52,27 @@ using namespace cvtest;
 using namespace testing;
 using namespace std;
 
-PARAM_TEST_CASE(MergeTestBase, MatType, int)
+#define MAX_CHANNELS 4
+
+PARAM_TEST_CASE(MergeTestBase, MatType, int, bool)
 {
     int type;
     int channels;
+    bool use_roi;
 
     //src mat
-    cv::Mat mat1;
-    cv::Mat mat2;
-    cv::Mat mat3;
-    cv::Mat mat4;
-
+    cv::Mat mat[MAX_CHANNELS];
     //dst mat
     cv::Mat dst;
 
     // set up roi
-    int roicols;
-    int roirows;
-    int src1x;
-    int src1y;
-    int src2x;
-    int src2y;
-    int src3x;
-    int src3y;
-    int src4x;
-    int src4y;
-    int dstx;
-    int dsty;
+    int roicols, roirows;
+    int srcx[MAX_CHANNELS];
+    int srcy[MAX_CHANNELS];
+    int dstx, dsty;
 
     //src mat with roi
-    cv::Mat mat1_roi;
-    cv::Mat mat2_roi;
-    cv::Mat mat3_roi;
-    cv::Mat mat4_roi;
+    cv::Mat mat_roi[MAX_CHANNELS];
 
     //dst mat with roi
     cv::Mat dst_roi;
@@ -93,78 +81,62 @@ PARAM_TEST_CASE(MergeTestBase, MatType, int)
     cv::ocl::oclMat gdst_whole;
 
     //ocl mat with roi
-    cv::ocl::oclMat gmat1;
-    cv::ocl::oclMat gmat2;
-    cv::ocl::oclMat gmat3;
-    cv::ocl::oclMat gmat4;
+    cv::ocl::oclMat gmat[MAX_CHANNELS];
     cv::ocl::oclMat gdst;
 
     virtual void SetUp()
     {
         type = GET_PARAM(0);
         channels = GET_PARAM(1);
+        use_roi = GET_PARAM(2);
 
         cv::RNG &rng = TS::ptr()->get_rng();
         cv::Size size(MWIDTH, MHEIGHT);
 
-        mat1 = randomMat(rng, size, CV_MAKETYPE(type, 1), 5, 16, false);
-        mat2 = randomMat(rng, size, CV_MAKETYPE(type, 1), 5, 16, false);
-        mat3 = randomMat(rng, size, CV_MAKETYPE(type, 1), 5, 16, false);
-        mat4 = randomMat(rng, size, CV_MAKETYPE(type, 1), 5, 16, false);
-        dst  = randomMat(rng, size, CV_MAKETYPE(type, channels), 5, 16, false);
-
+        for (int i = 0; i < channels; ++i)
+            mat[i] = randomMat(rng, size, CV_MAKETYPE(type, 1), 5, 16, false);
+        dst = randomMat(rng, size, CV_MAKETYPE(type, channels), 5, 16, false);
     }
 
     void random_roi()
     {
-#ifdef RANDOMROI
-        //randomize ROI
-        cv::RNG &rng = TS::ptr()->get_rng();
-        roicols = rng.uniform(1, mat1.cols);
-        roirows = rng.uniform(1, mat1.rows);
-        src1x   = rng.uniform(0, mat1.cols - roicols);
-        src1y   = rng.uniform(0, mat1.rows - roirows);
-        src2x   = rng.uniform(0, mat2.cols - roicols);
-        src2y   = rng.uniform(0, mat2.rows - roirows);
-        src3x   = rng.uniform(0, mat3.cols - roicols);
-        src3y   = rng.uniform(0, mat3.rows - roirows);
-        src4x   = rng.uniform(0, mat4.cols - roicols);
-        src4y   = rng.uniform(0, mat4.rows - roirows);
-        dstx    = rng.uniform(0, dst.cols  - roicols);
-        dsty    = rng.uniform(0, dst.rows  - roirows);
-#else
-        roicols = mat1.cols;
-        roirows = mat1.rows;
-        src1x   = 0;
-        src1y   = 0;
-        src2x   = 0;
-        src2y   = 0;
-        src3x   = 0;
-        src3y   = 0;
-        src4x   = 0;
-        src4y   = 0;
-        dstx    = 0;
-        dsty    = 0;
-#endif
+        if (use_roi)
+        {
+            //randomize ROI
+            cv::RNG &rng = TS::ptr()->get_rng();
+            roicols = rng.uniform(1, mat[0].cols);
+            roirows = rng.uniform(1, mat[0].rows);
 
+            for (int i = 0; i < channels; ++i)
+            {
+                srcx[i] = rng.uniform(0, mat[i].cols - roicols);
+                srcy[i] = rng.uniform(0, mat[i].rows - roirows);
+            }
 
-        mat1_roi = mat1(Rect(src1x, src1y, roicols, roirows));
-        mat2_roi = mat2(Rect(src2x, src2y, roicols, roirows));
-        mat3_roi = mat3(Rect(src3x, src3y, roicols, roirows));
-        mat4_roi = mat4(Rect(src4x, src4y, roicols, roirows));
+            dstx = rng.uniform(0, dst.cols  - roicols);
+            dsty = rng.uniform(0, dst.rows  - roirows);
+        }
+        else
+        {
+            roicols = mat[0].cols;
+            roirows = mat[0].rows;
+            for (int i = 0; i < channels; ++i)
+                srcx[i] = srcy[i] = 0;
 
+            dstx = dsty = 0;
+        }
+
+        for (int i = 0; i < channels; ++i)
+            mat_roi[i] = mat[i](Rect(srcx[i], srcy[i], roicols, roirows));
 
         dst_roi = dst(Rect(dstx, dsty, roicols, roirows));
 
         gdst_whole = dst;
         gdst = gdst_whole(Rect(dstx, dsty, roicols, roirows));
 
-        gmat1 = mat1_roi;
-        gmat2 = mat2_roi;
-        gmat3 = mat3_roi;
-        gmat4 = mat4_roi;
+        for (int i = 0; i < channels; ++i)
+            gmat[i] = mat_roi[i];
     }
-
 };
 
 struct Merge : MergeTestBase {};
@@ -175,159 +147,97 @@ TEST_P(Merge, Accuracy)
     {
         random_roi();
 
-        std::vector<cv::Mat> dev_src;
-        dev_src.push_back(mat1_roi);
-
-        if(channels >= 2)
-            dev_src.push_back(mat2_roi);
-
-        if(channels >= 3)
-            dev_src.push_back(mat3_roi);
-
-        if(channels >= 4)
-            dev_src.push_back(mat4_roi);
-
-        std::vector<cv::ocl::oclMat> dev_gsrc;
-        dev_gsrc.push_back(gmat1);
-
-        if(channels >= 2)
-            dev_gsrc.push_back(gmat2);
-
-        if(channels >= 3)
-            dev_gsrc.push_back(gmat3);
-
-        if(channels >= 4)
-            dev_gsrc.push_back(gmat4);
-
-        cv::merge(dev_src, dst_roi);
-        cv::ocl::merge(dev_gsrc, gdst);
+        cv::merge(mat_roi, channels, dst_roi);
+        cv::ocl::merge(gmat, channels, gdst);
 
         EXPECT_MAT_NEAR(dst, Mat(gdst_whole), 0.0);
     }
 }
 
-
-
-PARAM_TEST_CASE(SplitTestBase, MatType, int)
+PARAM_TEST_CASE(SplitTestBase, MatType, int, bool)
 {
     int type;
     int channels;
+    bool use_roi;
 
     //src mat
     cv::Mat mat;
 
     //dstmat
-    cv::Mat dst1;
-    cv::Mat dst2;
-    cv::Mat dst3;
-    cv::Mat dst4;
+    cv::Mat dst[MAX_CHANNELS];
 
     // set up roi
-    int roicols;
-    int roirows;
-    int srcx;
-    int srcy;
-    int dst1x;
-    int dst1y;
-    int dst2x;
-    int dst2y;
-    int dst3x;
-    int dst3y;
-    int dst4x;
-    int dst4y;
+    int roicols, roirows;
+    int srcx, srcy;
+    int dstx[MAX_CHANNELS];
+    int dsty[MAX_CHANNELS];
 
     //src mat with roi
     cv::Mat mat_roi;
 
     //dst mat with roi
-    cv::Mat dst1_roi;
-    cv::Mat dst2_roi;
-    cv::Mat dst3_roi;
-    cv::Mat dst4_roi;
+    cv::Mat dst_roi[MAX_CHANNELS];
 
     //ocl dst mat for testing
-    cv::ocl::oclMat gdst1_whole;
-    cv::ocl::oclMat gdst2_whole;
-    cv::ocl::oclMat gdst3_whole;
-    cv::ocl::oclMat gdst4_whole;
+    cv::ocl::oclMat gdst_whole[MAX_CHANNELS];
 
     //ocl mat with roi
     cv::ocl::oclMat gmat;
-    cv::ocl::oclMat gdst1;
-    cv::ocl::oclMat gdst2;
-    cv::ocl::oclMat gdst3;
-    cv::ocl::oclMat gdst4;
+    cv::ocl::oclMat gdst[MAX_CHANNELS];
 
     virtual void SetUp()
     {
         type = GET_PARAM(0);
         channels = GET_PARAM(1);
+        use_roi = GET_PARAM(2);
 
         cv::RNG &rng = TS::ptr()->get_rng();
         cv::Size size(MWIDTH, MHEIGHT);
 
         mat  = randomMat(rng, size, CV_MAKETYPE(type, channels), 5, 16, false);
-        dst1 = randomMat(rng, size, CV_MAKETYPE(type, 1), 5, 16, false);
-        dst2 = randomMat(rng, size, CV_MAKETYPE(type, 1), 5, 16, false);
-        dst3 = randomMat(rng, size, CV_MAKETYPE(type, 1), 5, 16, false);
-        dst4 = randomMat(rng, size, CV_MAKETYPE(type, 1), 5, 16, false);
-
-    }
+        for (int i = 0; i < channels; ++i)
+            dst[i] = randomMat(rng, size, CV_MAKETYPE(type, 1), 5, 16, false);    }
 
     void random_roi()
     {
-#ifdef RANDOMROI
-        //randomize ROI
-        cv::RNG &rng = TS::ptr()->get_rng();
-        roicols = rng.uniform(1, mat.cols);
-        roirows = rng.uniform(1, mat.rows);
-        srcx    = rng.uniform(0, mat.cols - roicols);
-        srcy    = rng.uniform(0, mat.rows - roirows);
-        dst1x   = rng.uniform(0, dst1.cols  - roicols);
-        dst1y   = rng.uniform(0, dst1.rows  - roirows);
-        dst2x   = rng.uniform(0, dst2.cols  - roicols);
-        dst2y   = rng.uniform(0, dst2.rows  - roirows);
-        dst3x   = rng.uniform(0, dst3.cols  - roicols);
-        dst3y   = rng.uniform(0, dst3.rows  - roirows);
-        dst4x   = rng.uniform(0, dst4.cols  - roicols);
-        dst4y   = rng.uniform(0, dst4.rows  - roirows);
-#else
-        roicols = mat.cols;
-        roirows = mat.rows;
-        srcx    = 0;
-        srcy    = 0;
-        dst1x   = 0;
-        dst1y   = 0;
-        dst2x   = 0;
-        dst2y   = 0;
-        dst3x   = 0;
-        dst3y   = 0;
-        dst4x   = 0;
-        dst4y   = 0;
-#endif
+        if (use_roi)
+        {
+            //randomize ROI
+            cv::RNG &rng = TS::ptr()->get_rng();
+            roicols = rng.uniform(1, mat.cols);
+            roirows = rng.uniform(1, mat.rows);
+            srcx    = rng.uniform(0, mat.cols - roicols);
+            srcy    = rng.uniform(0, mat.rows - roirows);
+
+            for (int i = 0; i < channels; ++i)
+            {
+                dstx[i] = rng.uniform(0, dst[i].cols  - roicols);
+                dsty[i] = rng.uniform(0, dst[i].rows  - roirows);
+            }
+        }
+        else
+        {
+            roicols = mat.cols;
+            roirows = mat.rows;
+            srcx = srcy = 0;
+
+            for (int i = 0; i < channels; ++i)
+                dstx[i] = dsty[i] = 0;
+        }
 
         mat_roi = mat(Rect(srcx, srcy, roicols, roirows));
 
-        dst1_roi = dst1(Rect(dst1x, dst1y, roicols, roirows));
-        dst2_roi = dst2(Rect(dst2x, dst2y, roicols, roirows));
-        dst3_roi = dst3(Rect(dst3x, dst3y, roicols, roirows));
-        dst4_roi = dst4(Rect(dst4x, dst4y, roicols, roirows));
+        for (int i = 0; i < channels; ++i)
+            dst_roi[i] = dst[i](Rect(dstx[i], dsty[i], roicols, roirows));
 
-        gdst1_whole = dst1;
-        gdst1 = gdst1_whole(Rect(dst1x, dst1y, roicols, roirows));
-
-        gdst2_whole = dst2;
-        gdst2 = gdst2_whole(Rect(dst2x, dst2y, roicols, roirows));
-
-        gdst3_whole = dst3;
-        gdst3 = gdst3_whole(Rect(dst3x, dst3y, roicols, roirows));
-
-        gdst4_whole = dst4;
-        gdst4 = gdst4_whole(Rect(dst4x, dst4y, roicols, roirows));
+        for (int i = 0; i < channels; ++i)
+        {
+            gdst_whole[i] = dst[i];
+            gdst[i] = gdst_whole[i](Rect(dstx[i], dsty[i], roicols, roirows));
+        }
 
         gmat = mat_roi;
     }
-
 };
 
 struct Split : SplitTestBase {};
@@ -338,33 +248,21 @@ TEST_P(Split, Accuracy)
     {
         random_roi();
 
-        cv::Mat         dev_dst[4]  = {dst1_roi, dst2_roi, dst3_roi, dst4_roi};
-        cv::ocl::oclMat dev_gdst[4] = {gdst1, gdst2, gdst3, gdst4};
+        cv::split(mat_roi, dst_roi);
+        cv::ocl::split(gmat, gdst);
 
-        cv::split(mat_roi, dev_dst);
-        cv::ocl::split(gmat, dev_gdst);
-
-        if(channels >= 1)
-            EXPECT_MAT_NEAR(dst1, Mat(gdst1_whole), 0.0);
-
-        if(channels >= 2)
-            EXPECT_MAT_NEAR(dst2, Mat(gdst2_whole), 0.0);
-
-        if(channels >= 3)
-            EXPECT_MAT_NEAR(dst3, Mat(gdst3_whole), 0.0);
-
-        if(channels >= 4)
-            EXPECT_MAT_NEAR(dst4, Mat(gdst4_whole), 0.0);
+        for (int i = 0; i < channels; ++i)
+            EXPECT_MAT_NEAR(dst[i], Mat(gdst_whole[i]), 0.0);
     }
 }
 
 
 INSTANTIATE_TEST_CASE_P(SplitMerge, Merge, Combine(
-                            Values(CV_8U, CV_32S, CV_32F), Values(1, 3, 4)));
+                            Values(CV_8U, CV_8S, CV_16U, CV_16S, CV_32S, CV_32F), Range(1, 5), Bool()));
 
 
 INSTANTIATE_TEST_CASE_P(SplitMerge, Split , Combine(
-                            Values(CV_8U, CV_32S, CV_32F), Values(1, 3, 4)));
+                            Values(CV_8U, CV_8S, CV_16U, CV_16S, CV_32S, CV_32F), Range(1, 5), Bool()));
 
 
 #endif // HAVE_OPENCL


### PR DESCRIPTION
rewrote split/merge tests to be more strict and complete and as a result - fixed error in opencl kernels merge_vector_C2_D4, merge_vector_C2_D5
