### PR TITLE
Fix mouse handling in python demos

### DIFF
--- a/samples/python2/common.py
+++ b/samples/python2/common.py
@@ -91,14 +91,15 @@ class Sketcher:
         pt = (x, y)
         if event == cv2.EVENT_LBUTTONDOWN:
             self.prev_pt = pt
+        elif event == cv2.EVENT_LBUTTONUP:
+            self.prev_pt = None
+
         if self.prev_pt and flags & cv2.EVENT_FLAG_LBUTTON:
             for dst, color in zip(self.dests, self.colors_func()):
                 cv2.line(dst, self.prev_pt, pt, color, 5)
             self.dirty = True
             self.prev_pt = pt
             self.show()
-        else:
-            self.prev_pt = None
 
 
 # palette data from matplotlib/_cm.py


### PR DESCRIPTION
The behavior seems to have changed, now mouse move events get set which broke the old code. This fixes it.
