### PR TITLE
Silence a few -Wcast-align warnings in the headers

### DIFF
--- a/modules/core/include/opencv2/core/core_c.h
+++ b/modules/core/include/opencv2/core/core_c.h
@@ -1129,7 +1129,7 @@ CVAPI(void)   cvSetRemove( CvSet* set_header, int index );
    NULL is returned */
 CV_INLINE CvSetElem* cvGetSetElem( const CvSet* set_header, int idx )
 {
-    CvSetElem* elem = (CvSetElem*)cvGetSeqElem( (CvSeq*)set_header, idx );
+    CvSetElem* elem = (CvSetElem*)(void *)cvGetSeqElem( (CvSeq*)set_header, idx );
     return elem && CV_IS_SET_ELEM( elem ) ? elem : 0;
 }
 

--- a/modules/core/include/opencv2/core/mat.hpp
+++ b/modules/core/include/opencv2/core/mat.hpp
@@ -2263,10 +2263,10 @@ template<typename _Tp> inline const _Tp& SparseMat::value(const Node* n) const
 { return *(const _Tp*)((const uchar*)n + hdr->valueOffset); }
 
 inline SparseMat::Node* SparseMat::node(size_t nidx)
-{ return (Node*)&hdr->pool[nidx]; }
+{ return (Node*)(void*)&hdr->pool[nidx]; }
 
 inline const SparseMat::Node* SparseMat::node(size_t nidx) const
-{ return (const Node*)&hdr->pool[nidx]; }
+{ return (const Node*)(void*)&hdr->pool[nidx]; }
 
 inline SparseMatIterator SparseMat::begin()
 { return SparseMatIterator(this); }
@@ -2327,7 +2327,7 @@ template<typename _Tp> inline const _Tp& SparseMatConstIterator::value() const
 inline const SparseMat::Node* SparseMatConstIterator::node() const
 {
     return ptr && m && m->hdr ?
-        (const SparseMat::Node*)(ptr - m->hdr->valueOffset) : 0;
+        (const SparseMat::Node*)(void*)(ptr - m->hdr->valueOffset) : 0;
 }
 
 inline SparseMatConstIterator SparseMatConstIterator::operator ++(int)

--- a/modules/core/include/opencv2/core/operations.hpp
+++ b/modules/core/include/opencv2/core/operations.hpp
@@ -3147,10 +3147,10 @@ inline FileNodeIterator FileNode::end() const
 }
 
 inline FileNode FileNodeIterator::operator *() const
-{ return FileNode(fs, (const CvFileNode*)reader.ptr); }
+{ return FileNode(fs, (const CvFileNode*)(void*)reader.ptr); }
 
 inline FileNode FileNodeIterator::operator ->() const
-{ return FileNode(fs, (const CvFileNode*)reader.ptr); }
+{ return FileNode(fs, (const CvFileNode*)(void*)reader.ptr); }
 
 template<typename _Tp> static inline FileNodeIterator& operator >> (FileNodeIterator& it, _Tp& value)
 { read( *it, value, _Tp()); return ++it; }

--- a/modules/core/include/opencv2/core/types_c.h
+++ b/modules/core/include/opencv2/core/types_c.h
@@ -766,11 +766,11 @@ CV_INLINE  double  cvmGet( const CvMat* mat, int row, int col )
             (unsigned)col < (unsigned)mat->cols );
 
     if( type == CV_32FC1 )
-        return ((float*)(mat->data.ptr + (size_t)mat->step*row))[col];
+        return ((float*)(void*)(mat->data.ptr + (size_t)mat->step*row))[col];
     else
     {
         assert( type == CV_64FC1 );
-        return ((double*)(mat->data.ptr + (size_t)mat->step*row))[col];
+        return ((double*)(void*)(mat->data.ptr + (size_t)mat->step*row))[col];
     }
 }
 
@@ -783,11 +783,11 @@ CV_INLINE  void  cvmSet( CvMat* mat, int row, int col, double value )
             (unsigned)col < (unsigned)mat->cols );
 
     if( type == CV_32FC1 )
-        ((float*)(mat->data.ptr + (size_t)mat->step*row))[col] = (float)value;
+        ((float*)(void*)(mat->data.ptr + (size_t)mat->step*row))[col] = (float)value;
     else
     {
         assert( type == CV_64FC1 );
-        ((double*)(mat->data.ptr + (size_t)mat->step*row))[col] = (double)value;
+        ((double*)(void*)(mat->data.ptr + (size_t)mat->step*row))[col] = (double)value;
     }
 }
 

--- a/modules/flann/include/opencv2/flann/lsh_table.h
+++ b/modules/flann/include/opencv2/flann/lsh_table.h
@@ -386,7 +386,7 @@ inline size_t LshTable<unsigned char>::getKey(const unsigned char* feature) cons
 {
     // no need to check if T is dividable by sizeof(size_t) like in the Hamming
     // distance computation as we have a mask
-    const size_t* feature_block_ptr = reinterpret_cast<const size_t*> (feature);
+    const size_t* feature_block_ptr = reinterpret_cast<const size_t*> ((const void*)feature);
 
     // Figure out the subsignature of the feature
     // Given the feature ABCDEF, and the mask 001011, the output will be


### PR DESCRIPTION
We don't use -Wcast-align ourselves, but the headers trigger warnings for those users who do, which is not nice.
