### PR TITLE
functions getDefaultClassifierNM1() and getDefaultClassifierNM2()

### DIFF
--- a/modules/objdetect/include/opencv2/objdetect/erfilter.hpp
+++ b/modules/objdetect/include/opencv2/objdetect/erfilter.hpp
@@ -164,8 +164,8 @@ public:
     local minimum is greater than minProbabilityDiff).
 
     \param  cb                Callback with the classifier.
-                              if omitted tries to load a default classifier from file trained_classifierNM1.xml
                               default classifier can be implicitly load with function loadClassifierNM1()
+                              from file in samples/cpp/trained_classifierNM1.xml
     \param  thresholdDelta    Threshold step in subsequent thresholds when extracting the component tree
     \param  minArea           The minimum area (% of image size) allowed for retreived ER's
     \param  minArea           The maximum area (% of image size) allowed for retreived ER's
@@ -173,7 +173,7 @@ public:
     \param  nonMaxSuppression Whenever non-maximum suppression is done over the branch probabilities
     \param  minProbability    The minimum probability difference between local maxima and local minima ERs
 */
-CV_EXPORTS Ptr<ERFilter> createERFilterNM1(const Ptr<ERFilter::Callback>& cb = Ptr<ERFilter::Callback>(),
+CV_EXPORTS Ptr<ERFilter> createERFilterNM1(const Ptr<ERFilter::Callback>& cb,
                                                   int thresholdDelta = 1, float minArea = 0.00025,
                                                   float maxArea = 0.13, float minProbability = 0.4,
                                                   bool nonMaxSuppression = true,
@@ -189,11 +189,11 @@ CV_EXPORTS Ptr<ERFilter> createERFilterNM1(const Ptr<ERFilter::Callback>& cb = P
     additional features: hole area ratio, convex hull ratio, and number of outer inflexion points.
 
     \param  cb             Callback with the classifier
-                           if omitted tries to load a default classifier from file trained_classifierNM2.xml
                            default classifier can be implicitly load with function loadClassifierNM2()
+                           from file in samples/cpp/trained_classifierNM2.xml
     \param  minProbability The minimum probability P(er|character) allowed for retreived ER's
 */
-CV_EXPORTS Ptr<ERFilter> createERFilterNM2(const Ptr<ERFilter::Callback>& cb = Ptr<ERFilter::Callback>(),
+CV_EXPORTS Ptr<ERFilter> createERFilterNM2(const Ptr<ERFilter::Callback>& cb,
                                                   float minProbability = 0.3);
 
 

--- a/modules/objdetect/src/erfilter.cpp
+++ b/modules/objdetect/src/erfilter.cpp
@@ -1056,8 +1056,8 @@ double ERClassifierNM2::eval(const ERStat& stat)
     local minimum is greater than minProbabilityDiff).
 
     \param  cb                Callback with the classifier.
-                              if omitted tries to load a default classifier from file trained_classifierNM1.xml
                               default classifier can be implicitly load with function loadClassifierNM1()
+                              from file in samples/cpp/trained_classifierNM1.xml
     \param  thresholdDelta    Threshold step in subsequent thresholds when extracting the component tree
     \param  minArea           The minimum area (% of image size) allowed for retreived ER's
     \param  minArea           The maximum area (% of image size) allowed for retreived ER's
@@ -1077,12 +1077,7 @@ Ptr<ERFilter> createERFilterNM1(const Ptr<ERFilter::Callback>& cb, int threshold
 
     Ptr<ERFilterNM> filter = makePtr<ERFilterNM>();
 
-    if (cb == NULL)
-        filter->setCallback(makePtr<ERClassifierNM1>("trained_classifierNM1.xml"));
-    else 
-        filter->setCallback(cb);
-    
-
+    filter->setCallback(cb);
 
     filter->setThresholdDelta(thresholdDelta);
     filter->setMinArea(minArea);
@@ -1103,8 +1098,8 @@ Ptr<ERFilter> createERFilterNM1(const Ptr<ERFilter::Callback>& cb, int threshold
     additional features: hole area ratio, convex hull ratio, and number of outer inflexion points.
 
     \param  cb             Callback with the classifier
-                           if omitted tries to load a default classifier from file trained_classifierNM2.xml
                            default classifier can be implicitly load with function loadClassifierNM1()
+                           from file in samples/cpp/trained_classifierNM2.xml
     \param  minProbability The minimum probability P(er|character) allowed for retreived ER's
 */
 Ptr<ERFilter> createERFilterNM2(const Ptr<ERFilter::Callback>& cb, float minProbability)
@@ -1114,10 +1109,7 @@ Ptr<ERFilter> createERFilterNM2(const Ptr<ERFilter::Callback>& cb, float minProb
 
     Ptr<ERFilterNM> filter = makePtr<ERFilterNM>();
 
-    if (cb == NULL)
-        filter->setCallback(makePtr<ERClassifierNM2>("trained_classifierNM2.xml"));
-    else
-        filter->setCallback(cb);
+    filter->setCallback(cb);
 
     filter->setMinProbability(minProbability);
     return (Ptr<ERFilter>)filter;

--- a/samples/cpp/erfilter.cpp
+++ b/samples/cpp/erfilter.cpp
@@ -58,7 +58,7 @@ int  main(int argc, const char * argv[])
     double t = (double)getTickCount();
 
     // Build ER tree and filter with the 1st stage default classifier
-    Ptr<ERFilter> er_filter1 = createERFilterNM1();
+    Ptr<ERFilter> er_filter1 = createERFilterNM1(loadClassifierNM1("trained_classifierNM1.xml"));
 
     er_filter1->run(grey, regions);
 
@@ -89,7 +89,7 @@ int  main(int argc, const char * argv[])
     t = (double)getTickCount();
 
     // Default second stage classifier
-    Ptr<ERFilter> er_filter2 = createERFilterNM2();
+    Ptr<ERFilter> er_filter2 = createERFilterNM2(loadClassifierNM2("trained_classifierNM2.xml"));
     er_filter2->run(grey, regions);
 
     t = (double)getTickCount() - t;


### PR DESCRIPTION
 allow to implicitly load the default classifiers when creating a ERFilter object
