### PR TITLE
Drop the HAVE_DC1394_095 configuration macro

### DIFF
--- a/cmake/templates/cvconfig.h.cmake
+++ b/cmake/templates/cvconfig.h.cmake
@@ -49,9 +49,6 @@
 /* IEEE1394 capturing support */
 #cmakedefine HAVE_DC1394
 
-/* libdc1394 0.9.4 or 0.9.5 */
-#cmakedefine HAVE_DC1394_095
-
 /* IEEE1394 capturing support - libdc1394 v2.x */
 #cmakedefine HAVE_DC1394_2
 

--- a/modules/highgui/src/cap_dc1394.cpp
+++ b/modules/highgui/src/cap_dc1394.cpp
@@ -296,11 +296,7 @@ static CvCaptureCAM_DC1394 * icvCaptureFromCAM_DC1394 (int index)
     if (pcap->format!=FORMAT_SCALABLE_IMAGE_SIZE) { // everything except Format 7
         if (dc1394_dma_setup_capture(pcap->handle, pcap->camera->node, index+1 /*channel*/,
                     pcap->format, pcap->mode, SPEED_400,
-                    pcap->frame_rate, NUM_BUFFERS,
-#ifdef HAVE_DC1394_095
-                    0 /*do_extra_buffering*/,
-#endif
-                    1 /*DROP_FRAMES*/,
+                    pcap->frame_rate, NUM_BUFFERS, 1 /*drop_frames*/,
                     pcap->device_name, pcap->camera) != DC1394_SUCCESS) {
             fprintf(stderr,"%s:%d: Failed to setup DMA capture with VIDEO1394\n",__FILE__,__LINE__);
             goto ERROR;
@@ -311,11 +307,7 @@ static CvCaptureCAM_DC1394 * icvCaptureFromCAM_DC1394 (int index)
                     pcap->mode, SPEED_400, QUERY_FROM_CAMERA,
                     (unsigned int)QUERY_FROM_CAMERA, (unsigned int)QUERY_FROM_CAMERA,
                     (unsigned int)QUERY_FROM_CAMERA, (unsigned int)QUERY_FROM_CAMERA,
-                    NUM_BUFFERS,
-#ifdef HAVE_DC1394_095
-                    0 /*do_extra_buffering*/,
-#endif
-                    1 /*DROP_FRAMES*/,
+                    NUM_BUFFERS, 1 /*drop_frames*/,
                     pcap->device_name, pcap->camera) != DC1394_SUCCESS) {
             fprintf(stderr,"%s:%d: Failed to setup DMA capture with VIDEO1394\n",__FILE__,__LINE__);
             goto ERROR;
@@ -661,11 +653,7 @@ icvSetModeCAM_DC1394( CvCaptureCAM_DC1394 * capture, int mode ){
     dc1394_dma_unlisten(capture->handle, capture->camera);
     if (dc1394_dma_setup_capture(capture->handle, capture->camera->node, capture->camera->channel /*channel*/,
                 format, mode, SPEED_400,
-                frame_rate, NUM_BUFFERS,
-#ifdef HAVE_DC1394_095
-                0 /*do_extra_buffering*/,
-#endif
-                1 /*DROP_FRAMES*/,
+                frame_rate, NUM_BUFFERS, 1 /*drop_frames*/,
                 capture->device_name, capture->camera) != DC1394_SUCCESS) {
         fprintf(stderr,"%s:%d: Failed to setup DMA capture with VIDEO1394\n",__FILE__,__LINE__);
         return 0;


### PR DESCRIPTION
We never set it, and libdc1394 0.9.5 is obsolete anyway - 1.0 came out in 2004.

Note that 1.0 doesn't have the `do_extra_buffering` parameter.
