### PR TITLE
Fix cv export templates

### DIFF
--- a/modules/core/include/opencv2/core/core.hpp
+++ b/modules/core/include/opencv2/core/core.hpp
@@ -78,11 +78,11 @@ using std::vector;
 using std::string;
 using std::ptrdiff_t;
 
-template<typename _Tp> class CV_EXPORTS Size_;
-template<typename _Tp> class CV_EXPORTS Point_;
-template<typename _Tp> class CV_EXPORTS Rect_;
-template<typename _Tp, int cn> class CV_EXPORTS Vec;
-template<typename _Tp, int m, int n> class CV_EXPORTS Matx;
+template<typename _Tp> class Size_;
+template<typename _Tp> class Point_;
+template<typename _Tp> class Rect_;
+template<typename _Tp, int cn> class Vec;
+template<typename _Tp, int m, int n> class Matx;
 
 typedef std::string String;
 
@@ -112,10 +112,10 @@ class CV_EXPORTS MatOp_Base;
 class CV_EXPORTS MatArg;
 class CV_EXPORTS MatConstIterator;
 
-template<typename _Tp> class CV_EXPORTS Mat_;
-template<typename _Tp> class CV_EXPORTS MatIterator_;
-template<typename _Tp> class CV_EXPORTS MatConstIterator_;
-template<typename _Tp> class CV_EXPORTS MatCommaInitializer_;
+template<typename _Tp> class Mat_;
+template<typename _Tp> class MatIterator_;
+template<typename _Tp> class MatConstIterator_;
+template<typename _Tp> class MatCommaInitializer_;
 
 #if !defined(ANDROID) || (defined(_GLIBCXX_USE_WCHAR_T) && _GLIBCXX_USE_WCHAR_T)
 typedef std::basic_string<wchar_t> WString;
@@ -363,7 +363,7 @@ CV_EXPORTS_W bool useOptimized();
 /*!
   The STL-compilant memory Allocator based on cv::fastMalloc() and cv::fastFree()
 */
-template<typename _Tp> class CV_EXPORTS Allocator
+template<typename _Tp> class Allocator
 {
 public:
     typedef _Tp value_type;
@@ -405,7 +405,7 @@ public:
   The class is specialized for each fundamental numerical data type supported by OpenCV.
   It provides DataDepth<T>::value constant.
 */
-template<typename _Tp> class CV_EXPORTS DataDepth {};
+template<typename _Tp> class DataDepth {};
 
 template<> class DataDepth<bool> { public: enum { value = CV_8U, fmt=(int)'u' }; };
 template<> class DataDepth<uchar> { public: enum { value = CV_8U, fmt=(int)'u' }; };
@@ -446,7 +446,7 @@ struct CV_EXPORTS Matx_MulOp {};
 struct CV_EXPORTS Matx_MatMulOp {};
 struct CV_EXPORTS Matx_TOp {};
 
-template<typename _Tp, int m, int n> class CV_EXPORTS Matx
+template<typename _Tp, int m, int n> class Matx
 {
 public:
     typedef _Tp value_type;
@@ -595,7 +595,7 @@ typedef Matx<double, 6, 6> Matx66d;
   In addition to the universal notation like Vec<float, 3>, you can use shorter aliases
   for the most popular specialized variants of Vec, e.g. Vec3f ~ Vec<float, 3>.
 */
-template<typename _Tp, int cn> class CV_EXPORTS Vec : public Matx<_Tp, cn, 1>
+template<typename _Tp, int cn> class Vec : public Matx<_Tp, cn, 1>
 {
 public:
     typedef _Tp value_type;
@@ -691,7 +691,7 @@ typedef Vec<double, 6> Vec6d;
   more convenient access to the real and imaginary parts using through the simple field access, as opposite
   to std::complex::real() and std::complex::imag().
 */
-template<typename _Tp> class CV_EXPORTS Complex
+template<typename _Tp> class Complex
 {
 public:
 
@@ -727,7 +727,7 @@ typedef Complex<double> Complexd;
   as a template parameter. There are a few shorter aliases available for user convenience.
   See cv::Point, cv::Point2i, cv::Point2f and cv::Point2d.
 */
-template<typename _Tp> class CV_EXPORTS Point_
+template<typename _Tp> class Point_
 {
 public:
     typedef _Tp value_type;
@@ -770,7 +770,7 @@ public:
 
   \see cv::Point3i, cv::Point3f and cv::Point3d
 */
-template<typename _Tp> class CV_EXPORTS Point3_
+template<typename _Tp> class Point3_
 {
 public:
     typedef _Tp value_type;
@@ -809,7 +809,7 @@ public:
   The class represents the size of a 2D rectangle, image size, matrix size etc.
   Normally, cv::Size ~ cv::Size_<int> is used.
 */
-template<typename _Tp> class CV_EXPORTS Size_
+template<typename _Tp> class Size_
 {
 public:
     typedef _Tp value_type;
@@ -844,7 +844,7 @@ public:
   The class represents a 2D rectangle with coordinates of the specified data type.
   Normally, cv::Rect ~ cv::Rect_<int> is used.
 */
-template<typename _Tp> class CV_EXPORTS Rect_
+template<typename _Tp> class Rect_
 {
 public:
     typedef _Tp value_type;
@@ -933,7 +933,7 @@ public:
    This is partially specialized cv::Vec class with the number of elements = 4, i.e. a short vector of four elements.
    Normally, cv::Scalar ~ cv::Scalar_<double> is used.
 */
-template<typename _Tp> class CV_EXPORTS Scalar_ : public Vec<_Tp, 4>
+template<typename _Tp> class Scalar_ : public Vec<_Tp, 4>
 {
 public:
     //! various constructors
@@ -1260,7 +1260,7 @@ public:
   \note{Another good property of the class is that the operations on the reference counter are atomic,
   i.e. it is safe to use the class in multi-threaded applications}
 */
-template<typename _Tp> class CV_EXPORTS Ptr
+template<typename _Tp> class Ptr
 {
 public:
     //! empty constructor
@@ -2748,7 +2748,7 @@ CV_EXPORTS_W Size getTextSize(const string& text, int fontFace,
        img(i,j)[2] ^= (uchar)(i ^ j); // img(y,x)[c] accesses c-th channel of the pixel (x,y)
  \endcode
 */
-template<typename _Tp> class CV_EXPORTS Mat_ : public Mat
+template<typename _Tp> class Mat_ : public Mat
 {
 public:
     typedef _Tp value_type;
@@ -2980,7 +2980,7 @@ public:
 
  */
 template<typename _Tp>
-class CV_EXPORTS MatConstIterator_ : public MatConstIterator
+class MatConstIterator_ : public MatConstIterator
 {
 public:
     typedef _Tp value_type;
@@ -3031,7 +3031,7 @@ public:
 
 */
 template<typename _Tp>
-class CV_EXPORTS MatIterator_ : public MatConstIterator_<_Tp>
+class MatIterator_ : public MatConstIterator_<_Tp>
 {
 public:
     typedef _Tp* pointer;
@@ -3072,7 +3072,7 @@ public:
     MatIterator_ operator ++(int);
 };
 
-template<typename _Tp> class CV_EXPORTS MatOp_Iter_;
+template<typename _Tp> class MatOp_Iter_;
 
 /*!
  Comma-separated Matrix Initializer
@@ -3087,7 +3087,7 @@ template<typename _Tp> class CV_EXPORTS MatOp_Iter_;
  Mat R = (Mat_<double>(2,2) << a, -b, b, a);
  \endcode
 */
-template<typename _Tp> class CV_EXPORTS MatCommaInitializer_
+template<typename _Tp> class MatCommaInitializer_
 {
 public:
     //! the constructor, created by "matrix << firstValue" operator, where matrix is cv::Mat
@@ -3102,7 +3102,7 @@ protected:
 };
 
 
-template<typename _Tp, int m, int n> class CV_EXPORTS MatxCommaInitializer
+template<typename _Tp, int m, int n> class MatxCommaInitializer
 {
 public:
     MatxCommaInitializer(Matx<_Tp, m, n>* _mtx);
@@ -3113,7 +3113,7 @@ public:
     int idx;
 };
 
-template<typename _Tp, int m> class CV_EXPORTS VecCommaInitializer : public MatxCommaInitializer<_Tp, m, 1>
+template<typename _Tp, int m> class VecCommaInitializer : public MatxCommaInitializer<_Tp, m, 1>
 {
 public:
     VecCommaInitializer(Vec<_Tp, m>* _vec);
@@ -3148,7 +3148,7 @@ public:
  }
  \endcode
 */
-template<typename _Tp, size_t fixed_size=4096/sizeof(_Tp)+8> class CV_EXPORTS AutoBuffer
+template<typename _Tp, size_t fixed_size=4096/sizeof(_Tp)+8> class AutoBuffer
 {
 public:
     typedef _Tp value_type;
@@ -3719,7 +3719,7 @@ public:
  m_.ref(2) += m_(3); // equivalent to m.ref<int>(2) += m.value<int>(3);
  \endcode
 */
-template<typename _Tp> class CV_EXPORTS SparseMat_ : public SparseMat
+template<typename _Tp> class SparseMat_ : public SparseMat
 {
 public:
     typedef SparseMatIterator_<_Tp> iterator;
@@ -3793,7 +3793,7 @@ public:
  This is the derived from SparseMatConstIterator class that
  introduces more convenient operator *() for accessing the current element.
 */
-template<typename _Tp> class CV_EXPORTS SparseMatConstIterator_ : public SparseMatConstIterator
+template<typename _Tp> class SparseMatConstIterator_ : public SparseMatConstIterator
 {
 public:
     typedef std::forward_iterator_tag iterator_category;
@@ -3823,7 +3823,7 @@ public:
  This is the derived from cv::SparseMatConstIterator_ class that
  introduces more convenient operator *() for accessing the current element.
 */
-template<typename _Tp> class CV_EXPORTS SparseMatIterator_ : public SparseMatConstIterator_<_Tp>
+template<typename _Tp> class SparseMatIterator_ : public SparseMatConstIterator_<_Tp>
 {
 public:
     typedef std::forward_iterator_tag iterator_category;
@@ -4255,7 +4255,7 @@ typedef Ptr<CvMemStorage> MemStorage;
     i.e. no constructors or destructors
     are called for the sequence elements.
 */
-template<typename _Tp> class CV_EXPORTS Seq
+template<typename _Tp> class Seq
 {
 public:
     typedef SeqIterator<_Tp> iterator;
@@ -4338,7 +4338,7 @@ public:
 /*!
  STL-style Sequence Iterator inherited from the CvSeqReader structure
 */
-template<typename _Tp> class CV_EXPORTS SeqIterator : public CvSeqReader
+template<typename _Tp> class SeqIterator : public CvSeqReader
 {
 public:
     //! the default constructor

--- a/modules/core/include/opencv2/core/operations.hpp
+++ b/modules/core/include/opencv2/core/operations.hpp
@@ -711,7 +711,7 @@ CV_EXPORTS bool Cholesky(float* A, size_t astep, int m, float* b, size_t bstep, 
 CV_EXPORTS bool Cholesky(double* A, size_t astep, int m, double* b, size_t bstep, int n);
 
 
-template<typename _Tp, int m> struct CV_EXPORTS Matx_DetOp
+template<typename _Tp, int m> struct Matx_DetOp
 {
     double operator ()(const Matx<_Tp, m, m>& a) const
     {
@@ -726,7 +726,7 @@ template<typename _Tp, int m> struct CV_EXPORTS Matx_DetOp
 };
 
 
-template<typename _Tp> struct CV_EXPORTS Matx_DetOp<_Tp, 1>
+template<typename _Tp> struct Matx_DetOp<_Tp, 1>
 {
     double operator ()(const Matx<_Tp, 1, 1>& a) const
     {
@@ -735,7 +735,7 @@ template<typename _Tp> struct CV_EXPORTS Matx_DetOp<_Tp, 1>
 };
 
 
-template<typename _Tp> struct CV_EXPORTS Matx_DetOp<_Tp, 2>
+template<typename _Tp> struct Matx_DetOp<_Tp, 2>
 {
     double operator ()(const Matx<_Tp, 2, 2>& a) const
     {
@@ -744,7 +744,7 @@ template<typename _Tp> struct CV_EXPORTS Matx_DetOp<_Tp, 2>
 };
 
 
-template<typename _Tp> struct CV_EXPORTS Matx_DetOp<_Tp, 3>
+template<typename _Tp> struct Matx_DetOp<_Tp, 3>
 {
     double operator ()(const Matx<_Tp, 3, 3>& a) const
     {
@@ -778,7 +778,7 @@ Matx<_Tp, n, m> Matx<_Tp, m, n>::t() const
 }
 
 
-template<typename _Tp, int m> struct CV_EXPORTS Matx_FastInvOp
+template<typename _Tp, int m> struct Matx_FastInvOp
 {
     bool operator()(const Matx<_Tp, m, m>& a, Matx<_Tp, m, m>& b, int method) const
     {
@@ -796,7 +796,7 @@ template<typename _Tp, int m> struct CV_EXPORTS Matx_FastInvOp
 };
 
 
-template<typename _Tp> struct CV_EXPORTS Matx_FastInvOp<_Tp, 2>
+template<typename _Tp> struct Matx_FastInvOp<_Tp, 2>
 {
     bool operator()(const Matx<_Tp, 2, 2>& a, Matx<_Tp, 2, 2>& b, int) const
     {
@@ -813,7 +813,7 @@ template<typename _Tp> struct CV_EXPORTS Matx_FastInvOp<_Tp, 2>
 };
 
 
-template<typename _Tp> struct CV_EXPORTS Matx_FastInvOp<_Tp, 3>
+template<typename _Tp> struct Matx_FastInvOp<_Tp, 3>
 {
     bool operator()(const Matx<_Tp, 3, 3>& a, Matx<_Tp, 3, 3>& b, int) const
     {
@@ -853,7 +853,7 @@ Matx<_Tp, n, m> Matx<_Tp, m, n>::inv(int method) const
 }
 
 
-template<typename _Tp, int m, int n> struct CV_EXPORTS Matx_FastSolveOp
+template<typename _Tp, int m, int n> struct Matx_FastSolveOp
 {
     bool operator()(const Matx<_Tp, m, m>& a, const Matx<_Tp, m, n>& b,
                     Matx<_Tp, m, n>& x, int method) const
@@ -868,7 +868,7 @@ template<typename _Tp, int m, int n> struct CV_EXPORTS Matx_FastSolveOp
 };
 
 
-template<typename _Tp> struct CV_EXPORTS Matx_FastSolveOp<_Tp, 2, 1>
+template<typename _Tp> struct Matx_FastSolveOp<_Tp, 2, 1>
 {
     bool operator()(const Matx<_Tp, 2, 2>& a, const Matx<_Tp, 2, 1>& b,
                     Matx<_Tp, 2, 1>& x, int) const
@@ -884,7 +884,7 @@ template<typename _Tp> struct CV_EXPORTS Matx_FastSolveOp<_Tp, 2, 1>
 };
 
 
-template<typename _Tp> struct CV_EXPORTS Matx_FastSolveOp<_Tp, 3, 1>
+template<typename _Tp> struct Matx_FastSolveOp<_Tp, 3, 1>
 {
     bool operator()(const Matx<_Tp, 3, 3>& a, const Matx<_Tp, 3, 1>& b,
                     Matx<_Tp, 3, 1>& x, int) const
@@ -2265,7 +2265,7 @@ inline Range::operator CvSlice() const
 //   1) it can be created on top of user-allocated data w/o copying it
 //   2) vector b = a means copying the header,
 //      not the underlying data (use clone() to make a deep copy)
-template <typename _Tp> class CV_EXPORTS Vector
+template <typename _Tp> class Vector
 {
 public:
     typedef _Tp value_type;
@@ -2274,7 +2274,7 @@ public:
     typedef _Tp& reference;
     typedef const _Tp& const_reference;
 
-    struct CV_EXPORTS Hdr
+    struct Hdr
     {
         Hdr() : data(0), datastart(0), refcount(0), size(0), capacity(0) {};
         _Tp* data;
@@ -2858,7 +2858,7 @@ inline void write(FileStorage& fs, const string& name, const Range& r )
     write(fs, r.end);
 }
 
-template<typename _Tp, int numflag> class CV_EXPORTS VecWriterProxy
+template<typename _Tp, int numflag> class VecWriterProxy
 {
 public:
     VecWriterProxy( FileStorage* _fs ) : fs(_fs) {}
@@ -2871,7 +2871,7 @@ public:
     FileStorage* fs;
 };
 
-template<typename _Tp> class CV_EXPORTS VecWriterProxy<_Tp,1>
+template<typename _Tp> class VecWriterProxy<_Tp,1>
 {
 public:
     VecWriterProxy( FileStorage* _fs ) : fs(_fs) {}
@@ -3086,7 +3086,7 @@ inline void FileNode::readRaw( const string& fmt, uchar* vec, size_t len ) const
     begin().readRaw( fmt, vec, len );
 }
 
-template<typename _Tp, int numflag> class CV_EXPORTS VecReaderProxy
+template<typename _Tp, int numflag> class VecReaderProxy
 {
 public:
     VecReaderProxy( FileNodeIterator* _it ) : it(_it) {}
@@ -3100,7 +3100,7 @@ public:
     FileNodeIterator* it;
 };
 
-template<typename _Tp> class CV_EXPORTS VecReaderProxy<_Tp,1>
+template<typename _Tp> class VecReaderProxy<_Tp,1>
 {
 public:
     VecReaderProxy( FileNodeIterator* _it ) : it(_it) {}
@@ -3414,19 +3414,19 @@ template<typename _Tp, class _LT> void sort( vector<_Tp>& vec, _LT LT=_LT() )
     }
 }
 
-template<typename _Tp> class CV_EXPORTS LessThan
+template<typename _Tp> class LessThan
 {
 public:
     bool operator()(const _Tp& a, const _Tp& b) const { return a < b; }
 };
 
-template<typename _Tp> class CV_EXPORTS GreaterEq
+template<typename _Tp> class GreaterEq
 {
 public:
     bool operator()(const _Tp& a, const _Tp& b) const { return a >= b; }
 };
 
-template<typename _Tp> class CV_EXPORTS LessThanIdx
+template<typename _Tp> class LessThanIdx
 {
 public:
     LessThanIdx( const _Tp* _arr ) : arr(_arr) {}
@@ -3434,7 +3434,7 @@ public:
     const _Tp* arr;
 };
 
-template<typename _Tp> class CV_EXPORTS GreaterEqIdx
+template<typename _Tp> class GreaterEqIdx
 {
 public:
     GreaterEqIdx( const _Tp* _arr ) : arr(_arr) {}
@@ -3763,7 +3763,7 @@ template<typename _Tp> inline bool operator != (const SeqIterator<_Tp>& a,
 }
 
 
-template<typename _ClsName> struct CV_EXPORTS RTTIImpl
+template<typename _ClsName> struct RTTIImpl
 {
 public:
     static int isInstance(const void* ptr)

--- a/modules/features2d/include/opencv2/features2d/features2d.hpp
+++ b/modules/features2d/include/opencv2/features2d/features2d.hpp
@@ -1017,7 +1017,7 @@ struct CV_EXPORTS Hamming
 
 typedef Hamming HammingLUT;
 
-template<int cellsize> struct CV_EXPORTS HammingMultilevel
+template<int cellsize> struct HammingMultilevel
 {
     enum { normType = NORM_HAMMING + (cellsize>1) };
     typedef unsigned char ValueType;


### PR DESCRIPTION
It is bad practice to write code like this:

```
template <typename T> class __declspec(dllexport) TemplatedClass
{
...
}
```

If we want to export something, then we should add explicit exporting of templated class specializations. For example:

```
template class __declspec(dllexport) TemplatedClass<float>;
```

This fix removes CV_EXPORT from templated classes only, no specializations are added. Any suggestions or bug reports are welcome.
