### PR TITLE
Expose CV_CPU_xx in cv2.cv for cv2.checkHardwareSupport

### DIFF
--- a/modules/python/src2/defs
+++ b/modules/python/src2/defs
@@ -358,3 +358,13 @@
 #define HG_AUTOSIZE CV_WINDOW_AUTOSIZE
 #define CV_CVTIMG_FLIP  1
 #define CV_CVTIMG_SWAP_RB 2
+#define CV_CPU_NONE    0
+#define CV_CPU_MMX     1
+#define CV_CPU_SSE     2
+#define CV_CPU_SSE2    3
+#define CV_CPU_SSE3    4
+#define CV_CPU_SSSE3   5
+#define CV_CPU_SSE4_1  6
+#define CV_CPU_SSE4_2  7
+#define CV_CPU_POPCNT  8
+#define CV_CPU_AVX    10


### PR DESCRIPTION
I could also add the CV_CPU_xx constants as public enum members in system.hpp and update the c++ checkHardwareSupport function if you think that is better
