### PR TITLE
Add checkippsupport

### DIFF
--- a/modules/core/include/opencv2/core/core.hpp
+++ b/modules/core/include/opencv2/core/core.hpp
@@ -288,6 +288,9 @@ CV_EXPORTS_W int64 getCPUTickCount();
 */
 CV_EXPORTS_W bool checkHardwareSupport(int feature);
 
+//! initilaizes and returns true if IPP was initialized correctly
+CV_EXPORTS_W bool checkIPPSupport();
+
 //! returns the number of CPUs (including hyper-threading)
 CV_EXPORTS_W int getNumberOfCPUs();
 

--- a/modules/core/src/system.cpp
+++ b/modules/core/src/system.cpp
@@ -247,6 +247,16 @@ struct IPPInitializer
 };
 
 IPPInitializer ippInitializer;
+
+bool checkIPPSupport(void)
+{
+    return ippInit() == ippStsNoErr;
+}
+#else
+bool checkIPPSupport(void)
+{
+    return false;
+}
 #endif
 
 volatile bool USE_SSE2 = featuresEnabled.have[CV_CPU_SSE2];


### PR DESCRIPTION
Adds a cv::checkIPPSupport() function whit inits IPP and returns true if everything is OK.

But system.cpp still calls ippStaticInit() which apparently is deprecated.

http://software.intel.com/en-us/articles/ipp-dispatcher-control-functions-ippinit-functions

So, perhaps I should convert the IPPInitializer variable to hold the return value of the now recommended ippInit() and expose that publicly instead.
