### PR TITLE
cmake: fixed incorrect usage of add_definitions() on Linux

### DIFF
--- a/cmake/OpenCVModule.cmake
+++ b/cmake/OpenCVModule.cmake
@@ -519,11 +519,7 @@ macro(ocv_create_module)
 
   if((NOT DEFINED OPENCV_MODULE_TYPE AND BUILD_SHARED_LIBS)
       OR (DEFINED OPENCV_MODULE_TYPE AND OPENCV_MODULE_TYPE STREQUAL SHARED))
-    if(MSVC)
-      set_target_properties(${the_module} PROPERTIES DEFINE_SYMBOL CVAPI_EXPORTS)
-    else()
-      add_definitions(-DCVAPI_EXPORTS)
-    endif()
+    set_target_properties(${the_module} PROPERTIES DEFINE_SYMBOL CVAPI_EXPORTS)
   endif()
 
   if(MSVC)


### PR DESCRIPTION
We should not add definition CVAPI_EXPORTS for tests/performance tests on Linux (non-MSVC).
Problem is:
- add_definitions() adds defines for all targets created in the current cmake directory (module, tests, perf tests).
