### PR TITLE
Fix bug #3277 (findCirclesGrid failures):

### DIFF
--- a/modules/calib3d/src/circlesgrid.cpp
+++ b/modules/calib3d/src/circlesgrid.cpp
@@ -836,6 +836,9 @@ Mat CirclesGridFinder::rectifyGrid(Size detectedGridSize, const std::vector<Poin
   Mat H = findHomography(Mat(centers), Mat(dstPoints), RANSAC);
   //Mat H = findHomography( Mat( corners ), Mat( dstPoints ) );
 
+  if (H.empty())
+      H = Mat::zeros(3, 3, CV_64FC1);
+
   std::vector<Point2f> srcKeypoints;
   for (size_t i = 0; i < keypoints.size(); i++)
   {


### PR DESCRIPTION
`findHomagraphy` can return empty `Mat` in master branch, so we need to check it before usage.

Related issue : http://code.opencv.org/issues/3277
