### PR TITLE
Add a workaround fix for MatrixOperations test if OpenCL device does not support double.

### DIFF
--- a/modules/ocl/test/test_matrix_operation.cpp
+++ b/modules/ocl/test/test_matrix_operation.cpp
@@ -131,6 +131,11 @@ typedef ConvertToTestBase ConvertTo;
 
 TEST_P(ConvertTo, Accuracy)
 {
+    if((src_depth == CV_64F || dst_depth == CV_64F) &&
+            !cv::ocl::Context::getContext()->supportsFeature(cv::ocl::Context::CL_DOUBLE))
+    {
+        return; // returns silently
+    }
     for (int j = 0; j < LOOP_TIMES; j++)
     {
         random_roi();
@@ -222,6 +227,11 @@ typedef CopyToTestBase CopyTo;
 
 TEST_P(CopyTo, Without_mask)
 {
+    if((src.depth() == CV_64F) &&
+            !cv::ocl::Context::getContext()->supportsFeature(cv::ocl::Context::CL_DOUBLE))
+    {
+        return; // returns silently
+    }
     for (int j = 0; j < LOOP_TIMES; j++)
     {
         random_roi();
@@ -235,6 +245,11 @@ TEST_P(CopyTo, Without_mask)
 
 TEST_P(CopyTo, With_mask)
 {
+    if(src.depth() == CV_64F &&
+        !cv::ocl::Context::getContext()->supportsFeature(cv::ocl::Context::CL_DOUBLE))
+    {
+        return; // returns silently
+    }
     for (int j = 0; j < LOOP_TIMES; j++)
     {
         random_roi();
@@ -326,6 +341,11 @@ typedef SetToTestBase SetTo;
 
 TEST_P(SetTo, Without_mask)
 {
+    if(depth == CV_64F &&
+            !cv::ocl::Context::getContext()->supportsFeature(cv::ocl::Context::CL_DOUBLE))
+    {
+        return; // returns silently
+    }
     for (int j = 0; j < LOOP_TIMES; j++)
     {
         random_roi();
@@ -339,6 +359,11 @@ TEST_P(SetTo, Without_mask)
 
 TEST_P(SetTo, With_mask)
 {
+    if(depth == CV_64F &&
+            !cv::ocl::Context::getContext()->supportsFeature(cv::ocl::Context::CL_DOUBLE))
+    {
+        return; // returns silently
+    }
     for (int j = 0; j < LOOP_TIMES; j++)
     {
         random_roi();
@@ -404,6 +429,11 @@ PARAM_TEST_CASE(convertC3C4, MatType, bool)
 
 TEST_P(convertC3C4, Accuracy)
 {
+    if(depth == CV_64F &&
+        !cv::ocl::Context::getContext()->supportsFeature(cv::ocl::Context::CL_DOUBLE))
+    {
+        return; // returns silently
+    }
     for (int j = 0; j < LOOP_TIMES; j++)
     {
         random_roi();


### PR DESCRIPTION
If device does not support double, returns immediately. 
