### PR TITLE
Replace obsolete Gtk symbols in highgui

### DIFF
--- a/modules/highgui/src/window_gtk.cpp
+++ b/modules/highgui/src/window_gtk.cpp
@@ -154,7 +154,7 @@ cvImageWidget_realize (GtkWidget *widget)
   g_return_if_fail (widget != NULL);
   g_return_if_fail (CV_IS_IMAGE_WIDGET (widget));
 
-  gtk_widget_set_realized(widget, true);
+  gtk_widget_set_realized(widget, TRUE);
 
   attributes.x = widget->allocation.x;
   attributes.y = widget->allocation.y;


### PR DESCRIPTION
This update replaces depreciated Gtk1.x symbols with Gtk2.x symbols in
preparation for adding Gtk3 support to highgui. These edits aim to be fully
compatible with Gtk2.x, allowing backward compatibility.
