### PR TITLE
add ocl::abs and ocl::max for CV_32FC1

### DIFF
--- a/modules/ocl/include/opencv2/ocl/ocl.hpp
+++ b/modules/ocl/include/opencv2/ocl/ocl.hpp
@@ -458,6 +458,9 @@ namespace cv
         // supports  CV_8UC1, 8UC4, 8SC4, 16UC2, 16SC2, 32SC1 and 32FC1.(the same as cuda)
         CV_EXPORTS void transpose(const oclMat &src, oclMat &dst);
 
+        //! computes element-wise absolute values (dst = abs(src))
+        // supports CV_32FC1 only
+        CV_EXPORTS void abs(const oclMat &src, oclMat &dst);
         //! computes element-wise absolute difference of two arrays (c = abs(a - b))
         // supports all types except CV_8SC1,CV_8SC2,CV8SC3 and CV_8SC4
         CV_EXPORTS void absdiff(const oclMat &a, const oclMat &b, oclMat &c);
@@ -490,9 +493,12 @@ namespace cv
         CV_EXPORTS Scalar absSum(const oclMat &m);
         CV_EXPORTS Scalar sqrSum(const oclMat &m);
 
+        //! computes maximum of src1 and src2 element-wise
+        // supports only CV_32FC1 type
+        CV_EXPORTS void max(const oclMat &src1, const oclMat &src2, oclMat &dst);
+
         //! finds global minimum and maximum array elements and returns their values
         // support all C1 types
-
         CV_EXPORTS void minMax(const oclMat &src, double *minVal, double *maxVal = 0, const oclMat &mask = oclMat());
         CV_EXPORTS void minMax_buf(const oclMat &src, double *minVal, double *maxVal, const oclMat &mask, oclMat& buf);
 

--- a/modules/ocl/src/opencl/arithm_abs.cl
+++ b/modules/ocl/src/opencl/arithm_abs.cl
@@ -1,0 +1,65 @@
+/*M///////////////////////////////////////////////////////////////////////////////////////
+//
+//  IMPORTANT: READ BEFORE DOWNLOADING, COPYING, INSTALLING OR USING.
+//
+//  By downloading, copying, installing or using the software you agree to this license.
+//  If you do not agree to this license, do not download, install,
+//  copy or use the software.
+//
+//
+//                           License Agreement
+//                For Open Source Computer Vision Library
+//
+// Third party copyrights are property of their respective owners.
+//
+// @Authors
+//    Sebastian Kramer, mail@kraymer.de
+//
+// Redistribution and use in source and binary forms, with or without modification,
+// are permitted provided that the following conditions are met:
+//
+//   * Redistribution's of source code must retain the above copyright notice,
+//     this list of conditions and the following disclaimer.
+//
+//   * Redistribution's in binary form must reproduce the above copyright notice,
+//     this list of conditions and the following disclaimer in the documentation
+//     and/or other oclMaterials provided with the distribution.
+//
+//   * The name of the copyright holders may not be used to endorse or promote products
+//     derived from this software without specific prior written permission.
+//
+// This software is provided by the copyright holders and contributors as is and
+// any express or implied warranties, including, but not limited to, the implied
+// warranties of merchantability and fitness for a particular purpose are disclaimed.
+// In no event shall the Intel Corporation or contributors be liable for any direct,
+// indirect, incidental, special, exemplary, or consequential damages
+// (including, but not limited to, procurement of substitute goods or services;
+// loss of use, data, or profits; or business interruption) however caused
+// and on any theory of liability, whether in contract, strict liability,
+// or tort (including negligence or otherwise) arising in any way out of
+// the use of this software, even if advised of the possibility of such damage.
+//
+//M*/
+
+// TODO: use vectors
+// TODO: use offset for ROI support (see absdiff)
+// TODO: support other image depths
+
+/**************************************abs******************************************/
+__kernel void arithm_abs_C1_D5 (__global const float *src, int src_step,
+                                __global       float *dst, int dst_step,
+                                int rows, int cols )
+{
+    const int2 g = (int2) ( get_global_id(0), get_global_id(1) );
+
+    const int src_step_float = src_step / sizeof(float);
+    const int dst_step_float = dst_step / sizeof(float);
+    
+    if ( g.x < cols && g.y < rows)
+    {
+        //if ( (x % 4) == 0 )  // in the future, use uchar4..
+        //uchar4 src_values = vload4( ..
+        
+        dst[ mad24( g.y, dst_step_float, g.x) ] = fabs( src[ mad24( g.y, src_step_float, g.x ) ] );
+    }
+}

--- a/modules/ocl/src/opencl/arithm_max.cl
+++ b/modules/ocl/src/opencl/arithm_max.cl
@@ -1,0 +1,70 @@
+/*M///////////////////////////////////////////////////////////////////////////////////////
+//
+//  IMPORTANT: READ BEFORE DOWNLOADING, COPYING, INSTALLING OR USING.
+//
+//  By downloading, copying, installing or using the software you agree to this license.
+//  If you do not agree to this license, do not download, install,
+//  copy or use the software.
+//
+//
+//                           License Agreement
+//                For Open Source Computer Vision Library
+//
+// Third party copyrights are property of their respective owners.
+//
+// @Authors
+//    Sebastian Kramer, mail@kraymer.de
+//
+// Redistribution and use in source and binary forms, with or without modification,
+// are permitted provided that the following conditions are met:
+//
+//   * Redistribution's of source code must retain the above copyright notice,
+//     this list of conditions and the following disclaimer.
+//
+//   * Redistribution's in binary form must reproduce the above copyright notice,
+//     this list of conditions and the following disclaimer in the documentation
+//     and/or other oclMaterials provided with the distribution.
+//
+//   * The name of the copyright holders may not be used to endorse or promote products
+//     derived from this software without specific prior written permission.
+//
+// This software is provided by the copyright holders and contributors as is and
+// any express or implied warranties, including, but not limited to, the implied
+// warranties of merchantability and fitness for a particular purpose are disclaimed.
+// In no event shall the Intel Corporation or contributors be liable for any direct,
+// indirect, incidental, special, exemplary, or consequential damages
+// (including, but not limited to, procurement of substitute goods or services;
+// loss of use, data, or profits; or business interruption) however caused
+// and on any theory of liability, whether in contract, strict liability,
+// or tort (including negligence or otherwise) arising in any way out of
+// the use of this software, even if advised of the possibility of such damage.
+//
+//M*/
+
+// TODO: use vectors
+// TODO: use offset for ROI support
+// TODO: support other image types and depths
+
+/**************************************abs******************************************/
+__kernel void arithm_max_C1_D5 (__global const float *src1, int src1_step,
+                                __global const float *src2, int src2_step,
+                                __global       float *dst,  int dst_step,
+                                int rows, int cols )
+{
+    const int2 g = (int2) ( get_global_id(0), get_global_id(1) );
+
+    const int src1_step_float = src1_step / sizeof(float);
+    const int src2_step_float = src2_step / sizeof(float);
+    const int  dst_step_float = dst_step / sizeof(float);
+    
+    if ( g.x < cols && g.y < rows)
+    {
+        //if ( (x % 4) == 0 )  // in the future, use uchar4..
+        //uchar4 src_values = vload4( ..
+        
+        dst[ mad24( g.y, dst_step_float, g.x) ]= max ( 
+                                                        src1[ mad24( g.y, src1_step_float, g.x ) ],
+                                                        src2[ mad24( g.y, src2_step_float, g.x ) ]
+                                                     );
+    }
+}


### PR DESCRIPTION
This is a first implementation of abs() and max() functionality. In the current state, it is rather restricted to the special case that I needed. However, it does work.
If it is acceptable as such, I'll try to add a test case. It should be rather straightforward to adapt it to other image types and depths. Finally, performance optimization (vectorization and others) could be another future task.
