### PR TITLE
Rewrite ocl::distanceToCenters. 

### DIFF
--- a/modules/ocl/doc/ml_machine_learning.rst
+++ b/modules/ocl/doc/ml_machine_learning.rst
@@ -86,3 +86,27 @@ Finds centers of clusters and groups input samples around the clusters.
             * **KMEANS_USE_INITIAL_LABELS** During the first (and possibly the only) attempt, use the user-supplied labels instead of computing them from the initial centers. For the second and further attempts, use the random or semi-random centers. Use one of  ``KMEANS_*_CENTERS``  flag to specify the exact method.
 
     :param centers: Output matrix of the cluster centers, one row per each cluster center.
+
+ocl::distanceToCenters
+----------------------
+For each samples in ``source``, find its closest neighour in ``centers``.
+
+.. ocv:function:: void ocl::distanceToCenters(oclMat &dists, oclMat &labels, const oclMat &src, const oclMat &centers, int distType = NORM_L2, const oclMat &indices = oclMat())
+
+    :param dists: The output distances calculated from each sample to the best matched center.
+
+    :param labels: The output index of best matched center for each row of sample.
+
+    :param src: Floating-point matrix of input samples. One row per sample.
+
+    :param centers: Floating-point matrix of center candidates. One row per center.
+
+    :param distType: Distance metric to calculate distances. Supports ``NORM_L1`` and ``NORM_L2``.
+
+    :param indices: Optional source indices. If not empty:
+
+            * only the indexed source samples will be processed
+            * outputs, i.e., ``dists`` and ``labels``, have the same size of indices
+            * outputs are in the same order of indices instead of the order of src
+
+The method is a utility function which maybe used for multiple clustering algorithms such as K-means.

--- a/modules/ocl/include/opencv2/ocl/ocl.hpp
+++ b/modules/ocl/include/opencv2/ocl/ocl.hpp
@@ -880,7 +880,10 @@ namespace cv
 
         //! Compute closest centers for each lines in source and lable it after center's index
         // supports CV_32FC1/CV_32FC2/CV_32FC4 data type
-        CV_EXPORTS void distanceToCenters(oclMat &dists, oclMat &labels, const oclMat &src, const oclMat &centers);
+        // supports NORM_L1 and NORM_L2 distType
+        // if indices is provided, only the indexed rows will be calculated and their results are in the same
+        // order of indices
+        CV_EXPORTS void distanceToCenters(oclMat &dists, oclMat &labels, const oclMat &src, const oclMat &centers, int distType = NORM_L2, const oclMat &indices = oclMat());
 
         //!Does k-means procedure on GPU
         // supports CV_32FC1/CV_32FC2/CV_32FC4 data type

--- a/modules/ocl/src/opencl/kmeans_kernel.cl
+++ b/modules/ocl/src/opencl/kmeans_kernel.cl
@@ -16,6 +16,7 @@
 //
 // @Authors
 //    Xiaopeng Fu, fuxiaopeng2222@163.com
+//    Peng Xiao, pengxiao@outlook.com
 //
 // Redistribution and use in source and binary forms, with or without modification,
 // are permitted provided that the following conditions are met:
@@ -43,42 +44,76 @@
 //
 //M*/
 
-__kernel void distanceToCenters(
-    int label_step, int K,
-    __global float *src,
-    __global int *labels, int dims, int rows,
-    __global float *centers,
-    __global float *dists)
+#ifdef L1_DIST
+#  define DISTANCE(A, B) fabs((A) - (B))
+#elif defined L2_DIST
+#  define DISTANCE(A, B) ((A) - (B)) * ((A) - (B))
+#else
+#  define DISTANCE(A, B) ((A) - (B)) * ((A) - (B))
+#endif
+
+inline float dist(__global const float * center, __global const float * src, int feature_cols)
 {
-    int gid = get_global_id(1);
-
-    float dist, euDist, min;
-    int minCentroid;
-
-    if(gid >= rows)
-        return;
-
-    for(int i = 0 ; i < K; i++)
+    float res = 0;
+    float4 tmp4;
+    int i;
+    for(i = 0; i < feature_cols / 4; i += 4, center += 4, src += 4)
     {
-        euDist = 0;
-        for(int j = 0; j < dims; j++)
-        {
-            dist = (src[j + gid * dims]
-                    - centers[j + i * dims]);
-            euDist += dist * dist;
-        }
+        tmp4 = vload4(0, center) - vload4(0, src);
+#ifdef L1_DIST
+        tmp4 = fabs(tmp4);
+#else
+        tmp4 *= tmp4;
+#endif
+        res += tmp4.x + tmp4.y + tmp4.z + tmp4.w;
+    }
 
-        if(i == 0)
+    for(; i < feature_cols; ++i, ++center, ++src)
+    {
+        res += DISTANCE(*src, *center);
+    }
+    return res;
+}
+
+// to be distinguished with distanceToCenters in kmeans_kernel.cl
+__kernel void distanceToCenters(
+    __global const float *src,
+    __global const float *centers,
+#ifdef USE_INDEX
+    __global const int   *indices,
+#endif
+    __global int   *labels,
+    __global float *dists,
+    int feature_cols,
+    int feature_step,
+    int label_step,
+    int input_size,
+    int K
+)
+{
+    int gid = get_global_id(0);
+    float euDist, minval;
+    int minCentroid;
+    if(gid >= input_size)
+    {
+        return;
+    }
+#ifdef USE_INDEX
+    src += indices[gid] * feature_step;
+#else
+    src += gid * feature_step;
+#endif
+    minval = dist(centers, src, feature_cols);
+    minCentroid = 0;
+    for(int i = 1 ; i < K; i++)
+    {
+        euDist = dist(centers + i * feature_step, src, feature_cols);
+        if(euDist < minval)
         {
-            min = euDist;
-            minCentroid = 0;
-        }
-        else if(euDist < min)
-        {
-            min = euDist;
+            minval = euDist;
             minCentroid = i;
         }
     }
-    dists[gid] = min;
-    labels[label_step * gid] = minCentroid;
+    labels[gid * label_step] = minCentroid;
+    dists[gid] = minval;
 }


### PR DESCRIPTION
It supports NORM_L1 distance types now and can use user provided indices of source input.
Also fixed a bug of kmeans where distance pointers should be float instead of double.
