### PR TITLE
Bugfix 3283: added boundingRect negative index note

### DIFF
--- a/modules/core/doc/drawing_functions.rst
+++ b/modules/core/doc/drawing_functions.rst
@@ -106,7 +106,7 @@ Draws a simple or thick elliptic arc or fills an ellipse sector.
 
     :param center: Center of the ellipse.
 
-    :param axes: Length of the ellipse axes.
+    :param axes: Half of the size of the ellipse main axes.
 
     :param angle: Ellipse rotation angle in degrees.
 
@@ -144,7 +144,7 @@ Approximates an elliptic arc with a polyline.
 
     :param center: Center of the arc.
 
-    :param axes: Half-sizes of the arc. See the  :ocv:func:`ellipse`  for details.
+    :param axes: Half of the size of the ellipse main axes. See the  :ocv:func:`ellipse`  for details.
 
     :param angle: Rotation angle of the ellipse in degrees. See the  :ocv:func:`ellipse`  for details.
 
@@ -158,7 +158,6 @@ Approximates an elliptic arc with a polyline.
 
 The function ``ellipse2Poly`` computes the vertices of a polyline that approximates the specified elliptic arc. It is used by
 :ocv:func:`ellipse` .
-
 
 
 fillConvexPoly

--- a/modules/imgproc/doc/structural_analysis_and_shape_descriptors.rst
+++ b/modules/imgproc/doc/structural_analysis_and_shape_descriptors.rst
@@ -358,8 +358,6 @@ Calculates the up-right bounding rectangle of a point set.
 The function calculates and returns the minimal up-right bounding rectangle for the specified point set.
 
 
-
-
 contourArea
 ---------------
 Calculates a contour area.
@@ -489,6 +487,7 @@ Fits an ellipse around a set of 2D points.
         * Nx2 numpy array (Python interface)
 
 The function calculates the ellipse that fits (in a least-squares sense) a set of 2D points best of all. It returns the rotated rectangle in which the ellipse is inscribed. The algorithm [Fitzgibbon95]_ is used.
+Developer should keep in mind that it is possible that the returned ellipse/rotatedRect data contains negative indices, due to the data points being close to the border of the containing Mat element.
 
 .. note::
 
@@ -614,7 +613,7 @@ Finds a rotated rectangle of the minimum area enclosing the input 2D point set.
         * Nx2 numpy array (Python interface)
 
 The function calculates and returns the minimum-area bounding rectangle (possibly rotated) for a specified point set. See the OpenCV sample ``minarea.cpp`` .
-
+Developer should keep in mind that the returned rotatedRect can contain negative indices when data is close the the containing Mat element boundary.
 
 
 minEnclosingCircle


### PR DESCRIPTION
Added note like mentioned in bugfix 3283 (http://code.opencv.org/issues/3283)
