### PR TITLE
Name FastFeatureDetector::Type to allow its use in makePtr

### DIFF
--- a/modules/features2d/include/opencv2/features2d.hpp
+++ b/modules/features2d/include/opencv2/features2d.hpp
@@ -517,7 +517,7 @@ CV_EXPORTS void FAST( InputArray image, CV_OUT std::vector<KeyPoint>& keypoints,
 class CV_EXPORTS_W FastFeatureDetector : public FeatureDetector
 {
 public:
-    enum
+    enum Type
     {
       TYPE_5_8 = 0, TYPE_7_12 = 1, TYPE_9_16 = 2
     };


### PR DESCRIPTION
It has actually worked before (likely because it's inside a class), but C++03 does disallow unnamed types as template arguments, and there's a report that at least in one version of GCC it's enforced: http://code.opencv.org/issues/3278.
