### PR TITLE
fixed cv::CommandLineParser when arg is like -+

### DIFF
--- a/modules/core/src/cmdparser.cpp
+++ b/modules/core/src/cmdparser.cpp
@@ -92,6 +92,22 @@ string del_space(string name)
 
 }//namespace
 
+static bool keyIsNumber(const std::string & option, size_t start)
+{
+    bool isNumber = true;
+    size_t end = option.find_first_of('=', start);
+    end = option.npos == end ? option.length() : end;
+
+    for ( ; start < end; ++start)
+        if (!isdigit(option[start]))
+        {
+            isNumber = false;
+            break;
+        }
+
+    return isNumber;
+}
+
 CommandLineParser::CommandLineParser(int argc, const char* const argv[], const char* keys)
 {
     std::string keys_buffer;
@@ -144,13 +160,13 @@ CommandLineParser::CommandLineParser(int argc, const char* const argv[], const c
         if (!argv[i])
             break;
         curName = argv[i];
-        if (curName.find('-') == 0 && ((curName[1] < '0') || (curName[1] > '9')))
-        {
-            while (curName.find('-') == 0)
-                curName.erase(curName.begin(), (curName.begin() + 1));
-        }
-            else
-                withNoKey = true;
+
+        size_t nondash = curName.find_first_not_of("-");
+        if (nondash == 0 || nondash == curName.npos || keyIsNumber(curName, nondash))
+            withNoKey = true;
+        else
+            curName.erase(0, nondash);
+
         if (curName.find('=') != curName.npos)
         {
             hasValueThroughEq = true;


### PR DESCRIPTION
example:  "./bin/opencv_perf_ocl perf_impl=plain - " - gives segmentation fault
