### PR TITLE
Added -l prefix to EXTRA_COMPONENTS when generating pkg-config file

### DIFF
--- a/cmake/OpenCVGenPkgconfig.cmake
+++ b/cmake/OpenCVGenPkgconfig.cmake
@@ -59,7 +59,7 @@ set(OpenCV_LIB_COMPONENTS ${OpenCV_LIB_COMPONENTS_})
 if(OpenCV_EXTRA_COMPONENTS)
   foreach(extra_component ${OpenCV_EXTRA_COMPONENTS})
 
-    if(extra_component MATCHES "^-[lL](.*)" OR extra_component MATCHES "[\\/]")
+    if(extra_component MATCHES "^-[lL]" OR extra_component MATCHES "[\\/]")
       set(maybe_l_prefix "")
     else()
       set(maybe_l_prefix "-l")


### PR DESCRIPTION
OpenCVGenPkgconfig.cmake was writing opencv.pc files that didn't compile when using pkg-config to build applications that link opencv on linux machines, as described in PR #1615.  But that PR change aimed at the four specific libraries that didn't get properly linked.  This PR addresses the problem during opencv.pc generation, where it's less likely to break other parts of the build process on other systems.
