### PR TITLE
refactored filters accuracy tests in the ocl module;

### DIFF
--- a/modules/ocl/doc/image_filtering.rst
+++ b/modules/ocl/doc/image_filtering.rst
@@ -666,3 +666,17 @@ Performs linear blending of two images.
     :param weights2: Weights for second image. Must have tha same size as ``img2`` . Supports only ``CV_32F`` type.
 
     :param result: Destination image.
+
+ocl::medianFilter
+--------------------
+Blurs an image using the median filter.
+
+.. ocv:function:: void ocl::medianFilter(const oclMat &src, oclMat &dst, int m)
+
+    :param src: input ```1-``` or ```4```-channel image; the image depth should be ```CV_8U```, ```CV_32F```.
+
+    :param dst: destination array of the same size and type as ```src```.
+
+    :param m: aperture linear size; it must be odd and greater than ```1```. Currently only ```3```, ```5``` are supported.
+
+The function smoothes an image using the median filter with the \texttt{m} \times \texttt{m} aperture. Each channel of a multi-channel image is processed independently. In-place operation is supported.

--- a/modules/ocl/include/opencv2/ocl/ocl.hpp
+++ b/modules/ocl/include/opencv2/ocl/ocl.hpp
@@ -839,11 +839,8 @@ namespace cv
         //! Applies a generic geometrical transformation to an image.
 
         // Supports INTER_NEAREST, INTER_LINEAR.
-
         // Map1 supports CV_16SC2, CV_32FC2  types.
-
         // Src supports CV_8UC1, CV_8UC2, CV_8UC4.
-
         CV_EXPORTS void remap(const oclMat &src, oclMat &dst, oclMat &map1, oclMat &map2, int interpolation, int bordertype, const Scalar &value = Scalar());
 
         //! copies 2D array to a larger destination array and pads borders with user-specifiable constant
@@ -851,7 +848,7 @@ namespace cv
         CV_EXPORTS void copyMakeBorder(const oclMat &src, oclMat &dst, int top, int bottom, int left, int right, int boardtype, const Scalar &value = Scalar());
 
         //! Smoothes image using median filter
-        // The source 1- or 4-channel image. When m is 3 or 5, the image depth should be CV 8U or CV 32F.
+        // The source 1- or 4-channel image. m should be 3 or 5, the image depth should be CV_8U or CV_32F.
         CV_EXPORTS void medianFilter(const oclMat &src, oclMat &dst, int m);
 
         //! warps the image using affine transformation

--- a/modules/ocl/src/imgproc.cpp
+++ b/modules/ocl/src/imgproc.cpp
@@ -408,20 +408,11 @@ namespace cv
         void medianFilter(const oclMat &src, oclMat &dst, int m)
         {
             CV_Assert( m % 2 == 1 && m > 1 );
-            CV_Assert( m <= 5 || src.depth() == CV_8U );
-            CV_Assert( src.cols <= dst.cols && src.rows <= dst.rows );
+            CV_Assert( (src.depth() == CV_8U || src.depth() == CV_32F) && (src.channels() == 1 || src.channels() == 4));
+            dst.create(src.size(), src.type());
 
-            if (src.data == dst.data)
-            {
-                oclMat src1;
-                src.copyTo(src1);
-                return medianFilter(src1, dst, m);
-            }
-
-            int srcStep = src.step1() / src.oclchannels();
-            int dstStep = dst.step1() / dst.oclchannels();
-            int srcOffset = src.offset / src.oclchannels() / src.elemSize1();
-            int dstOffset = dst.offset / dst.oclchannels() / dst.elemSize1();
+            int srcStep = src.step / src.elemSize(), dstStep = dst.step / dst.elemSize();
+            int srcOffset = src.offset /  src.elemSize(), dstOffset = dst.offset / dst.elemSize();
 
             Context *clCxt = src.clCxt;
 
@@ -1518,6 +1509,7 @@ namespace cv
             float *color_weight = &_color_weight[0];
             float *space_weight = &_space_weight[0];
             int *space_ofs = &_space_ofs[0];
+
             int dst_step_in_pixel = dst.step / dst.elemSize();
             int dst_offset_in_pixel = dst.offset / dst.elemSize();
             int temp_step_in_pixel = temp.step / temp.elemSize();
@@ -1548,7 +1540,7 @@ namespace cv
             if ((dst.type() == CV_8UC1) && ((dst.offset & 3) == 0) && ((dst.cols & 3) == 0))
             {
                 kernelName = "bilateral2";
-                globalThreads[0] = dst.cols / 4;
+                globalThreads[0] = dst.cols >> 2;
             }
 
             vector<pair<size_t , const void *> > args;
@@ -1566,15 +1558,17 @@ namespace cv
             args.push_back( make_pair( sizeof(cl_mem), (void *)&oclcolor_weight.data ));
             args.push_back( make_pair( sizeof(cl_mem), (void *)&oclspace_weight.data ));
             args.push_back( make_pair( sizeof(cl_mem), (void *)&oclspace_ofs.data ));
+
             openCLExecuteKernel(src.clCxt, &imgproc_bilateral, kernelName, globalThreads, localThreads, args, dst.oclchannels(), dst.depth());
         }
+
         void bilateralFilter(const oclMat &src, oclMat &dst, int radius, double sigmaclr, double sigmaspc, int borderType)
         {
             dst.create( src.size(), src.type() );
             if ( src.depth() == CV_8U )
                 oclbilateralFilter_8u( src, dst, radius, sigmaclr, sigmaspc, borderType );
             else
-                CV_Error( CV_StsUnsupportedFormat, "Bilateral filtering is only implemented for 8uimages" );
+                CV_Error( CV_StsUnsupportedFormat, "Bilateral filtering is only implemented for CV_8U images" );
         }
 
     }

--- a/modules/ocl/src/opencl/filtering_laplacian.cl
+++ b/modules/ocl/src/opencl/filtering_laplacian.cl
@@ -169,6 +169,7 @@ __kernel void filter2D(
     int globalRow = groupStartRow + localRow;
     const int src_offset = mad24(src_offset_y, src_step, src_offset_x);
     const int dst_offset = mad24(dst_offset_y, dst_step, dst_offset_x);
+
 #ifdef BORDER_CONSTANT
     for(int i = localRow; i < LOCAL_HEIGHT; i += get_local_size(1))
     {
@@ -208,6 +209,7 @@ __kernel void filter2D(
         }
     }
 #endif
+
     barrier(CLK_LOCAL_MEM_FENCE);
     if(globalRow < rows && globalCol < cols)
     {
@@ -231,6 +233,7 @@ __kernel void filter2D(
 //////////////////////////////////////////////////////////////////////////////////////////////////////
 /////////////////////////////Macro for define elements number per thread/////////////////////////////
 ////////////////////////////////////////////////////////////////////////////////////////////////////
+
 #define ANX                     1
 #define ANY                     1
 
@@ -249,6 +252,7 @@ __kernel void filter2D(
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 /////////////////////////////////////////8uC1////////////////////////////////////////////////////////
 ////////////////////////////////////////////////////////////////////////////////////////////////////
+
 __kernel void filter2D_3x3(
     __global T_IMG *src,
     __global T_IMG *dst,
@@ -359,6 +363,7 @@ __kernel void filter2D_3x3(
                 }
             }
         }
+
         if(dst_rows_index < dst_rows_end)
         {
             T_IMGx4 tmp_dst = CONVERT_TYPEx4(sum);

--- a/modules/ocl/src/opencl/filtering_morph.cl
+++ b/modules/ocl/src/opencl/filtering_morph.cl
@@ -45,6 +45,7 @@
 //BORDER_CONSTANT:      iiiiii|abcdefgh|iiiiiii
 #define ELEM(i,l_edge,r_edge,elem1,elem2) (i)<(l_edge) | (i) >= (r_edge) ? (elem1) : (elem2)
 #ifndef GENTYPE
+
 __kernel void morph_C1_D0(__global const uchar * restrict src,
                           __global uchar *dst,
                           int src_offset_x, int src_offset_y,
@@ -150,7 +151,9 @@ __kernel void morph_C1_D0(__global const uchar * restrict src,
         }
     }
 }
+
 #else
+
 __kernel void morph(__global const GENTYPE * restrict src,
                     __global GENTYPE *dst,
                     int src_offset_x, int src_offset_y,
@@ -221,4 +224,5 @@ __kernel void morph(__global const GENTYPE * restrict src,
         dst[out_addr] = res;
     }
 }
+
 #endif

--- a/modules/ocl/src/opencl/imgproc_bilateral.cl
+++ b/modules/ocl/src/opencl/imgproc_bilateral.cl
@@ -47,25 +47,27 @@ __kernel void bilateral_C1_D0(__global uchar *dst,
         __constant float *space_weight,
         __constant int *space_ofs)
 {
-    int gidx = get_global_id(0);
-    int gidy = get_global_id(1);
-    if((gidy<dst_rows) && (gidx<dst_cols))
+    int x = get_global_id(0);
+    int y = get_global_id(1);
+
+    if (y < dst_rows && x < dst_cols)
     {
-        int src_addr = mad24(gidy+radius,src_step,gidx+radius);
-        int dst_addr = mad24(gidy,dst_step,gidx+dst_offset);
+        int src_index = mad24(y + radius, src_step, x + radius);
+        int dst_index = mad24(y, dst_step, x + dst_offset);
         float sum = 0.f, wsum = 0.f;
 
-        int val0 = (int)src[src_addr];
+        int val0 = (int)src[src_index];
         for(int k = 0; k < maxk; k++ )
         {
-            int val = (int)src[src_addr + space_ofs[k]];
-            float w = space_weight[k]*color_weight[abs(val - val0)];
-            sum += (float)(val)*w;
+            int val = (int)src[src_index + space_ofs[k]];
+            float w = space_weight[k] * color_weight[abs(val - val0)];
+            sum += (float)(val) * w;
             wsum += w;
         }
-        dst[dst_addr] = convert_uchar_rtz(sum/wsum+0.5f);
+        dst[dst_index] = convert_uchar_rtz(sum / wsum + 0.5f);
     }
 }
+
 __kernel void bilateral2_C1_D0(__global uchar *dst,
         __global const uchar *src,
         const int dst_rows,
@@ -81,25 +83,28 @@ __kernel void bilateral2_C1_D0(__global uchar *dst,
         __constant float *space_weight,
         __constant int *space_ofs)
 {
-    int gidx = get_global_id(0)<<2;
-    int gidy = get_global_id(1);
-    if((gidy<dst_rows) && (gidx<dst_cols))
+    int x = get_global_id(0) << 2;
+    int y = get_global_id(1);
+
+    if (y < dst_rows && x < dst_cols)
     {
-        int src_addr = mad24(gidy+radius,src_step,gidx+radius);
-        int dst_addr = mad24(gidy,dst_step,gidx+dst_offset);
+        int src_index = mad24(y + radius, src_step, x + radius);
+        int dst_index = mad24(y, dst_step, x + dst_offset);
         float4 sum = (float4)(0.f), wsum = (float4)(0.f);
 
-        int4 val0 = convert_int4(vload4(0,src+src_addr));
+        int4 val0 = convert_int4(vload4(0,src + src_index));
         for(int k = 0; k < maxk; k++ )
         {
-            int4 val = convert_int4(vload4(0,src+src_addr + space_ofs[k]));
-            float4 w = (float4)(space_weight[k])*(float4)(color_weight[abs(val.x - val0.x)],color_weight[abs(val.y - val0.y)],color_weight[abs(val.z - val0.z)],color_weight[abs(val.w - val0.w)]);
-            sum += convert_float4(val)*w;
+            int4 val = convert_int4(vload4(0,src+src_index + space_ofs[k]));
+            float4 w = (float4)(space_weight[k]) * (float4)(color_weight[abs(val.x - val0.x)], color_weight[abs(val.y - val0.y)],
+                color_weight[abs(val.z - val0.z)], color_weight[abs(val.w - val0.w)]);
+            sum += convert_float4(val) * w;
             wsum += w;
         }
-        *(__global uchar4*)(dst+dst_addr) = convert_uchar4_rtz(sum/wsum+0.5f);
+        *(__global uchar4*)(dst+dst_index) = convert_uchar4_rtz(sum/wsum+0.5f);
     }
 }
+
 __kernel void bilateral_C4_D0(__global uchar4 *dst,
         __global const uchar4 *src,
         const int dst_rows,
@@ -115,24 +120,26 @@ __kernel void bilateral_C4_D0(__global uchar4 *dst,
         __constant float *space_weight,
         __constant int *space_ofs)
 {
-    int gidx = get_global_id(0);
-    int gidy = get_global_id(1);
-    if((gidy<dst_rows) && (gidx<dst_cols))
+    int x = get_global_id(0);
+    int y = get_global_id(1);
+
+    if (y < dst_rows && x < dst_cols)
     {
-        int src_addr = mad24(gidy+radius,src_step,gidx+radius);
-        int dst_addr = mad24(gidy,dst_step,gidx+dst_offset);
+        int src_index = mad24(y + radius, src_step, x + radius);
+        int dst_index = mad24(y, dst_step, x + dst_offset);
         float4 sum = (float4)0.f;
         float wsum = 0.f;
 
-        int4 val0 = convert_int4(src[src_addr]);
+        int4 val0 = convert_int4(src[src_index]);
         for(int k = 0; k < maxk; k++ )
         {
-            int4 val = convert_int4(src[src_addr + space_ofs[k]]);
-            float w = space_weight[k]*color_weight[abs(val.x - val0.x)+abs(val.y - val0.y)+abs(val.z - val0.z)];
-            sum += convert_float4(val)*(float4)w;
+            int4 val = convert_int4(src[src_index + space_ofs[k]]);
+            float w = space_weight[k] * color_weight[abs(val.x - val0.x) + abs(val.y - val0.y) + abs(val.z - val0.z)];
+            sum += convert_float4(val) * (float4)w;
             wsum += w;
         }
-        wsum=1.f/wsum;
-        dst[dst_addr] = convert_uchar4_rtz(sum*(float4)wsum+(float4)0.5f);
+
+        wsum = 1.f / wsum;
+        dst[dst_index] = convert_uchar4_rtz(sum * (float4)wsum + (float4)0.5f);
     }
 }

--- a/modules/ocl/test/test_filters.cpp
+++ b/modules/ocl/test/test_filters.cpp
@@ -52,424 +52,394 @@
 
 #ifdef HAVE_OPENCL
 
-using namespace cvtest;
 using namespace testing;
 using namespace std;
+using namespace cv;
 
-
-PARAM_TEST_CASE(FilterTestBase,
-                MatType,
-                cv::Size, // kernel size
-                cv::Size, // dx,dy
-                int       // border type, or iteration
-                )
+PARAM_TEST_CASE(FilterTestBase, MatType,
+                int, // kernel size
+                Size, // dx, dy
+                int, // border type, or iteration
+                bool) // roi or not
 {
-    //src mat
-    cv::Mat mat1;
-    cv::Mat dst;
+    int type, borderType;
+    int ksize;
+    bool useRoi;
 
-    // set up roi
-    int roicols;
-    int roirows;
-    int src1x;
-    int src1y;
-    int dstx;
-    int dsty;
+    Mat src, dst_whole, src_roi, dst_roi;
+    ocl::oclMat gsrc_whole, gsrc_roi, gdst_whole, gdst_roi;
 
-    //src mat with roi
-    cv::Mat mat1_roi;
-    cv::Mat dst_roi;
-
-    //ocl dst mat for testing
-    cv::ocl::oclMat gdst_whole;
-
-    //ocl mat with roi
-    cv::ocl::oclMat gmat1;
-    cv::ocl::oclMat gdst;
+    virtual void SetUp()
+    {
+        type = GET_PARAM(0);
+        ksize = GET_PARAM(1);
+        borderType = GET_PARAM(3);
+        useRoi = GET_PARAM(4);
+    }
 
     void random_roi()
     {
-#ifdef RANDOMROI
-        //randomize ROI
-        roicols = rng.uniform(2, mat1.cols);
-        roirows = rng.uniform(2, mat1.rows);
-        src1x   = rng.uniform(0, mat1.cols - roicols);
-        src1y   = rng.uniform(0, mat1.rows - roirows);
-        dstx    = rng.uniform(0, dst.cols  - roicols);
-        dsty    = rng.uniform(0, dst.rows  - roirows);
-#else
-        roicols = mat1.cols;
-        roirows = mat1.rows;
-        src1x = 0;
-        src1y = 0;
-        dstx = 0;
-        dsty = 0;
-#endif
+        Size roiSize = randomSize(1, MAX_VALUE);
+        Border srcBorder = randomBorder(0, useRoi ? MAX_VALUE : 0);
+        randomSubMat(src, src_roi, roiSize, srcBorder, type, 5, 256);
 
-        mat1_roi = mat1(Rect(src1x, src1y, roicols, roirows));
-        dst_roi  = dst(Rect(dstx, dsty, roicols, roirows));
+        Border dstBorder = randomBorder(0, useRoi ? MAX_VALUE : 0);
+        randomSubMat(dst_whole, dst_roi, roiSize, dstBorder, type, 5, 16);
 
-        gdst_whole = dst;
-        gdst = gdst_whole(Rect(dstx, dsty, roicols, roirows));
-
-        gmat1 = mat1_roi;
+        generateOclMat(gsrc_whole, gsrc_roi, src, roiSize, srcBorder);
+        generateOclMat(gdst_whole, gdst_roi, dst_whole, roiSize, dstBorder);
     }
 
-    void Init(int mat_type)
+    void Near(double threshold = 0.0)
     {
-        cv::Size size(MWIDTH, MHEIGHT);
-        mat1 = randomMat(size, mat_type, 5, 16);
-        dst  = randomMat(size, mat_type, 5, 16);
-    }
-
-    void Near(double threshold)
-    {
-        EXPECT_MAT_NEAR(dst, Mat(gdst_whole), threshold);
+        EXPECT_MAT_NEAR(dst_whole, Mat(gdst_whole), threshold);
+        EXPECT_MAT_NEAR(dst_roi, Mat(gdst_roi), threshold);
     }
 };
 
 /////////////////////////////////////////////////////////////////////////////////////////////////
 // blur
-struct Blur : FilterTestBase
-{
-    int type;
-    cv::Size ksize;
-    int bordertype;
 
-    virtual void SetUp()
-    {
-        type = GET_PARAM(0);
-        ksize = GET_PARAM(1);
-        bordertype = GET_PARAM(3);
-        Init(type);
-    }
-};
+typedef FilterTestBase Blur;
 
 OCL_TEST_P(Blur, Mat)
 {
-    for(int j = 0; j < LOOP_TIMES; j++)
+    Size kernelSize(ksize, ksize);
+
+    for (int j = 0; j < LOOP_TIMES; j++)
     {
         random_roi();
-        cv::blur(mat1_roi, dst_roi, ksize, Point(-1, -1), bordertype);
-        cv::ocl::blur(gmat1, gdst, ksize, Point(-1, -1), bordertype);
+
+        blur(src_roi, dst_roi, kernelSize, Point(-1, -1), borderType);
+        ocl::blur(gsrc_roi, gdst_roi, kernelSize, Point(-1, -1), borderType); // TODO anchor
+
         Near(1.0);
     }
 }
 
-
 /////////////////////////////////////////////////////////////////////////////////////////////////
-//Laplacian
-struct Laplacian : FilterTestBase
-{
-    int type;
-    cv::Size ksize;
+// Laplacian
 
-    virtual void SetUp()
-    {
-        type = GET_PARAM(0);
-        ksize = GET_PARAM(1);
-        Init(type);
-    }
-};
+typedef FilterTestBase LaplacianTest;
 
-OCL_TEST_P(Laplacian, Accuracy)
+OCL_TEST_P(LaplacianTest, Accuracy)
 {
-    for(int j = 0; j < LOOP_TIMES; j++)
+    for (int j = 0; j < LOOP_TIMES; j++)
     {
         random_roi();
-        cv::Laplacian(mat1_roi, dst_roi, -1, ksize.width, 1);
-        cv::ocl::Laplacian(gmat1, gdst, -1, ksize.width, 1);
+
+        Laplacian(src_roi, dst_roi, -1, ksize, 1);
+        ocl::Laplacian(gsrc_roi, gdst_roi, -1, ksize, 1); // TODO scale
+
         Near(1e-5);
     }
 }
 
-
-
 /////////////////////////////////////////////////////////////////////////////////////////////////
 // erode & dilate
-struct ErodeDilate : FilterTestBase
-{
-    int type;
-    int iterations;
 
-    //erode or dilate kernel
-    cv::Mat kernel;
+struct ErodeDilate :
+        public FilterTestBase
+{
+    int iterations;
 
     virtual void SetUp()
     {
         type = GET_PARAM(0);
         iterations = GET_PARAM(3);
-        Init(type);
-        kernel = randomMat(Size(3, 3), CV_8UC1, 0, 3);
+        useRoi = GET_PARAM(4);
     }
-
 };
 
-OCL_TEST_P(ErodeDilate, Mat)
+typedef ErodeDilate Erode;
+
+OCL_TEST_P(Erode, Mat)
 {
-    for(int j = 0; j < LOOP_TIMES; j++)
+    // erode or dilate kernel
+    Size kernelSize(ksize, ksize);
+    Mat kernel;
+
+    for (int j = 0; j < LOOP_TIMES; j++)
     {
+        kernel = randomMat(kernelSize, CV_8UC1, 0, 3);
+
         random_roi();
-        cv::erode(mat1_roi, dst_roi, kernel, Point(-1, -1), iterations);
-        cv::ocl::erode(gmat1, gdst, kernel, Point(-1, -1), iterations);
-        Near(1e-5);
-    }
-    for(int j = 0; j < LOOP_TIMES; j++)
-    {
-        random_roi();
-        cv::dilate(mat1_roi, dst_roi, kernel, Point(-1, -1), iterations);
-        cv::ocl::dilate(gmat1, gdst, kernel, Point(-1, -1), iterations);
+
+        cv::erode(src_roi, dst_roi, kernel, Point(-1, -1), iterations);
+        ocl::erode(gsrc_roi, gdst_roi, kernel, Point(-1, -1), iterations); // TODO iterations, borderType
+
         Near(1e-5);
     }
 }
 
+typedef ErodeDilate Dilate;
+
+OCL_TEST_P(Dilate, Mat)
+{
+    // erode or dilate kernel
+    Mat kernel;
+
+    for (int j = 0; j < LOOP_TIMES; j++)
+    {
+        kernel = randomMat(Size(3, 3), CV_8UC1, 0, 3);
+
+        random_roi();
+
+        cv::dilate(src_roi, dst_roi, kernel, Point(-1, -1), iterations);
+        ocl::dilate(gsrc_roi, gdst_roi, kernel, Point(-1, -1), iterations); // TODO iterations, borderType
+
+        Near(1e-5);
+    }
+}
 
 /////////////////////////////////////////////////////////////////////////////////////////////////
 // Sobel
-struct Sobel : FilterTestBase
+
+struct SobelTest :
+        public FilterTestBase
 {
-    int type;
-    int dx, dy, ksize, bordertype;
+    int dx, dy;
 
     virtual void SetUp()
     {
         type = GET_PARAM(0);
-        Size s = GET_PARAM(1);
-        ksize = s.width;
-        s = GET_PARAM(2);
-        dx = s.width;
-        dy = s.height;
-        bordertype = GET_PARAM(3);
-        Init(type);
+        ksize = GET_PARAM(1);
+        borderType = GET_PARAM(3);
+        useRoi = GET_PARAM(4);
+
+        Size d = GET_PARAM(2);
+        dx = d.width, dy = d.height;
     }
 };
 
-OCL_TEST_P(Sobel, Mat)
+OCL_TEST_P(SobelTest, Mat)
 {
-    for(int j = 0; j < LOOP_TIMES; j++)
+    for (int j = 0; j < LOOP_TIMES; j++)
     {
         random_roi();
-        cv::Sobel(mat1_roi, dst_roi, -1, dx, dy, ksize, /*scale*/0.00001,/*delta*/0, bordertype);
-        cv::ocl::Sobel(gmat1, gdst, -1, dx, dy, ksize,/*scale*/0.00001,/*delta*/0, bordertype);
+
+        Sobel(src_roi, dst_roi, -1, dx, dy, ksize, /* scale */ 0.00001, /* delta */0, borderType);
+        ocl::Sobel(gsrc_roi, gdst_roi, -1, dx, dy, ksize, /* scale */ 0.00001, /* delta */ 0, borderType);
+
         Near(1);
     }
 }
-
 
 /////////////////////////////////////////////////////////////////////////////////////////////////
 // Scharr
-struct Scharr : FilterTestBase
-{
-    int type;
-    int dx, dy, bordertype;
 
-    virtual void SetUp()
-    {
-        type = GET_PARAM(0);
-        Size s = GET_PARAM(2);
-        dx = s.width;
-        dy = s.height;
-        bordertype = GET_PARAM(3);
-        Init(type);
-    }
-};
+typedef SobelTest ScharrTest;
 
-OCL_TEST_P(Scharr, Mat)
+OCL_TEST_P(ScharrTest, Mat)
 {
-    for(int j = 0; j < LOOP_TIMES; j++)
+    for (int j = 0; j < LOOP_TIMES; j++)
     {
         random_roi();
-        cv::Scharr(mat1_roi, dst_roi, -1, dx, dy, /*scale*/1,/*delta*/0, bordertype);
-        cv::ocl::Scharr(gmat1, gdst, -1, dx, dy,/*scale*/1,/*delta*/0, bordertype);
+
+        Scharr(src_roi, dst_roi, -1, dx, dy, /* scale */ 1, /* delta */ 0, borderType);
+        ocl::Scharr(gsrc_roi, gdst_roi, -1, dx, dy, /* scale */ 1, /* delta */ 0, borderType);
+
         Near(1);
     }
-
 }
-
 
 /////////////////////////////////////////////////////////////////////////////////////////////////
 // GaussianBlur
-struct GaussianBlur : FilterTestBase
+
+struct GaussianBlurTest :
+        public FilterTestBase
 {
-    int type;
-    cv::Size ksize;
-    int bordertype;
     double sigma1, sigma2;
 
     virtual void SetUp()
     {
         type = GET_PARAM(0);
         ksize = GET_PARAM(1);
-        bordertype = GET_PARAM(3);
-        Init(type);
+        borderType = GET_PARAM(3);
+
         sigma1 = rng.uniform(0.1, 1.0);
         sigma2 = rng.uniform(0.1, 1.0);
     }
 };
 
-OCL_TEST_P(GaussianBlur, Mat)
+OCL_TEST_P(GaussianBlurTest, Mat)
 {
-    for(int j = 0; j < LOOP_TIMES; j++)
+    for (int j = 0; j < LOOP_TIMES; j++)
     {
         random_roi();
-        cv::GaussianBlur(mat1_roi, dst_roi, ksize, sigma1, sigma2, bordertype);
-        cv::ocl::GaussianBlur(gmat1, gdst, ksize, sigma1, sigma2, bordertype);
+
+        GaussianBlur(src_roi, dst_roi, Size(ksize, ksize), sigma1, sigma2, borderType);
+        ocl::GaussianBlur(gsrc_roi, gdst_roi, Size(ksize, ksize), sigma1, sigma2, borderType);
+
         Near(1);
     }
-
 }
-
-
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 // Filter2D
-struct Filter2D : FilterTestBase
-{
-    int type;
-    cv::Size ksize;
-    int bordertype;
-    Point anchor;
-    virtual void SetUp()
-    {
-        type = GET_PARAM(0);
-        ksize = GET_PARAM(1);
-        bordertype = GET_PARAM(3);
-        Init(type);
-        anchor = Point(-1,-1);
-    }
-};
+
+typedef FilterTestBase Filter2D;
 
 OCL_TEST_P(Filter2D, Mat)
 {
-    cv::Mat kernel = randomMat(cv::Size(ksize.width, ksize.height), CV_32FC1, 0.0, 1.0);
-    for(int j = 0; j < LOOP_TIMES; j++)
+    const Size kernelSize(ksize, ksize);
+    Mat kernel;
+
+    for (int j = 0; j < LOOP_TIMES; j++)
     {
+        kernel = randomMat(kernelSize, CV_32FC1, 0.0, 1.0);
+
         random_roi();
-        cv::filter2D(mat1_roi, dst_roi, -1, kernel, anchor, 0.0, bordertype);
-        cv::ocl::filter2D(gmat1, gdst, -1, kernel, anchor, bordertype);
+
+        cv::filter2D(src_roi, dst_roi, -1, kernel, Point(-1, -1), 0.0, borderType); // TODO anchor
+        ocl::filter2D(gsrc_roi, gdst_roi, -1, kernel, Point(-1, -1), borderType);
+
         Near(1);
     }
 }
+
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 // Bilateral
-struct Bilateral : FilterTestBase
-{
-    int type;
-    cv::Size ksize;
-    int bordertype;
-    double sigmacolor, sigmaspace;
 
-    virtual void SetUp()
-    {
-        type = GET_PARAM(0);
-        ksize = GET_PARAM(1);
-        bordertype = GET_PARAM(3);
-        Init(type);
-        sigmacolor = rng.uniform(20, 100);
-        sigmaspace = rng.uniform(10, 40);
-    }
-};
+typedef FilterTestBase Bilateral;
 
 OCL_TEST_P(Bilateral, Mat)
 {
-    for(int j = 0; j < LOOP_TIMES; j++)
+    for (int j = 0; j < LOOP_TIMES; j++)
     {
         random_roi();
-        cv::bilateralFilter(mat1_roi, dst_roi, ksize.width, sigmacolor, sigmaspace, bordertype);
-        cv::ocl::bilateralFilter(gmat1, gdst, ksize.width, sigmacolor, sigmaspace, bordertype);
+
+        double sigmacolor = rng.uniform(20, 100);
+        double sigmaspace = rng.uniform(10, 40);
+
+        cv::bilateralFilter(src_roi, dst_roi, ksize, sigmacolor, sigmaspace, borderType);
+        ocl::bilateralFilter(gsrc_roi, gdst_roi, ksize, sigmacolor, sigmaspace, borderType);
+
         Near(1);
     }
-
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 // AdaptiveBilateral
-struct AdaptiveBilateral : FilterTestBase
-{
-    int type;
-    cv::Size ksize;
-    int bordertype;
-    Point anchor;
-    virtual void SetUp()
-    {
-        type = GET_PARAM(0);
-        ksize = GET_PARAM(1);
-        bordertype = GET_PARAM(3);
-        Init(type);
-        anchor = Point(-1,-1);
-    }
-};
+
+typedef FilterTestBase AdaptiveBilateral;
 
 OCL_TEST_P(AdaptiveBilateral, Mat)
 {
-    for(int j = 0; j < LOOP_TIMES; j++)
+    const Size kernelSize(ksize, ksize);
+
+    for (int j = 0; j < LOOP_TIMES; j++)
     {
         random_roi();
-        cv::adaptiveBilateralFilter(mat1_roi, dst_roi, ksize, 5, anchor, bordertype);
-        cv::ocl::adaptiveBilateralFilter(gmat1, gdst, ksize, 5, anchor, bordertype);
+
+        adaptiveBilateralFilter(src_roi, dst_roi, kernelSize, 5, Point(-1, -1), borderType); // TODO anchor
+        ocl::adaptiveBilateralFilter(gsrc_roi, gdst_roi, kernelSize, 5, Point(-1, -1), borderType);
+
         Near(1);
     }
-
 }
 
+/////////////////////////////////////////////////////////////////////////////////////////////////////
+// MedianFilter
+
+typedef FilterTestBase MedianFilter;
+
+OCL_TEST_P(MedianFilter, Mat)
+{
+    for (int i = 0; i < LOOP_TIMES; ++i)
+    {
+        random_roi();
+
+        medianBlur(src_roi, dst_roi, ksize);
+        ocl::medianFilter(gsrc_roi, gdst_roi, ksize);
+
+        Near();
+    }
+}
+
+//////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
 INSTANTIATE_TEST_CASE_P(Filter, Blur, Combine(
-                        Values(CV_8UC1, CV_8UC3, CV_8UC4, CV_32FC1, CV_32FC4),
-                        Values(cv::Size(3, 3), cv::Size(5, 5), cv::Size(7, 7)),
-                        Values(Size(0, 0)), //not use
-                        Values((MatType)cv::BORDER_CONSTANT, (MatType)cv::BORDER_REPLICATE, (MatType)cv::BORDER_REFLECT, (MatType)cv::BORDER_REFLECT_101)));
+                            Values(CV_8UC1, CV_8UC3, CV_8UC4, CV_32FC1, CV_32FC4),
+                            Values(3, 5, 7),
+                            Values(Size(0, 0)), // not used
+                            Values((int)BORDER_CONSTANT, (int)BORDER_REPLICATE, (int)BORDER_REFLECT, (int)BORDER_REFLECT_101),
+                            Bool()));
 
+INSTANTIATE_TEST_CASE_P(Filter, LaplacianTest, Combine(
+                            Values(CV_8UC1, CV_8UC3, CV_8UC4, CV_32FC1, CV_32FC3, CV_32FC4),
+                            Values(1, 3),
+                            Values(Size(0, 0)), // not used
+                            Values(0), // not used
+                            Bool()));
 
-INSTANTIATE_TEST_CASE_P(Filter, Laplacian, Combine(
-                        Values(CV_8UC1, CV_8UC3, CV_8UC4, CV_32FC1, CV_32FC3, CV_32FC4),
-                        Values(Size(3, 3)),
-                        Values(Size(0, 0)), //not use
-                        Values(0)));        //not use
+INSTANTIATE_TEST_CASE_P(Filter, Erode, Combine(
+                            Values(CV_8UC1, CV_8UC3, CV_8UC4, CV_32FC1, CV_32FC3, CV_32FC4),
+                            Values(3, 5, 7),
+                            Values(Size(0, 0)), // not used
+                            testing::Range(1, 2),
+                            Bool()));
 
-INSTANTIATE_TEST_CASE_P(Filter, ErodeDilate, Combine(
-                        Values(CV_8UC1, CV_8UC4, CV_32FC1, CV_32FC4),
-                        Values(Size(0, 0)), //not use
-                        Values(Size(0, 0)), //not use
-                        Values(1)));
+INSTANTIATE_TEST_CASE_P(Filter, Dilate, Combine(
+                            Values(CV_8UC1, CV_8UC3, CV_8UC4, CV_32FC1, CV_32FC3, CV_32FC4),
+                            Values(3, 5, 7),
+                            Values(Size(0, 0)), // not used
+                            testing::Range(1, 2),
+                            Bool()));
 
+INSTANTIATE_TEST_CASE_P(Filter, SobelTest, Combine(
+                            Values(CV_8UC1, CV_8UC3, CV_8UC4, CV_32FC1, CV_32FC3, CV_32FC4),
+                            Values(3, 5),
+                            Values(Size(1, 0), Size(1, 1), Size(2, 0), Size(2, 1)),
+                            Values((int)BORDER_CONSTANT, (int)BORDER_REFLECT101,
+                                   (int)BORDER_REPLICATE, (int)BORDER_REFLECT),
+                            Bool()));
 
-INSTANTIATE_TEST_CASE_P(Filter, Sobel, Combine(
-                        Values(CV_8UC1, CV_8UC3, CV_8UC4, CV_32FC1, CV_32FC3, CV_32FC4),
-                        Values(Size(3, 3), Size(5, 5)),
-                        Values(Size(1, 0), Size(1, 1), Size(2, 0), Size(2, 1)),
-                        Values((MatType)cv::BORDER_CONSTANT, (MatType)cv::BORDER_REPLICATE)));
+INSTANTIATE_TEST_CASE_P(Filter, ScharrTest, Combine(
+                            Values(CV_8UC1, CV_8UC3, CV_8UC4, CV_32FC1, CV_32FC4),
+                            Values(0), // not used
+                            Values(Size(0, 1), Size(1, 0)),
+                            Values((int)BORDER_CONSTANT, (int)BORDER_REFLECT101,
+                                   (int)BORDER_REPLICATE, (int)BORDER_REFLECT),
+                            Bool()));
 
-
-INSTANTIATE_TEST_CASE_P(Filter, Scharr, Combine(
-                        Values(CV_8UC1, CV_8UC3, CV_8UC4, CV_32FC1, CV_32FC4),
-                        Values(Size(0, 0)), //not use
-                        Values(Size(0, 1), Size(1, 0)),
-                        Values((MatType)cv::BORDER_CONSTANT, (MatType)cv::BORDER_REPLICATE)));
-
-INSTANTIATE_TEST_CASE_P(Filter, GaussianBlur, Combine(
-                        Values(CV_8UC1, CV_8UC3, CV_8UC4, CV_32FC1, CV_32FC4),
-                        Values(Size(3, 3), Size(5, 5)),
-                        Values(Size(0, 0)), //not use
-                        Values((MatType)cv::BORDER_CONSTANT, (MatType)cv::BORDER_REPLICATE)));
-
-
+INSTANTIATE_TEST_CASE_P(Filter, GaussianBlurTest, Combine(
+                            Values(CV_8UC1, CV_8UC3, CV_8UC4, CV_32FC1, CV_32FC4),
+                            Values(3, 5),
+                            Values(Size(0, 0)), // not used
+                            Values((int)BORDER_CONSTANT, (int)BORDER_REFLECT101,
+                                   (int)BORDER_REPLICATE, (int)BORDER_REFLECT),
+                            Bool()));
 
 INSTANTIATE_TEST_CASE_P(Filter, Filter2D, testing::Combine(
-                        Values(CV_8UC1, CV_32FC1, CV_32FC4),
-                        Values(Size(3, 3), Size(15, 15), Size(25, 25)),
-                        Values(Size(0, 0)), //not use
-                        Values((MatType)cv::BORDER_CONSTANT, (MatType)cv::BORDER_REFLECT101, (MatType)cv::BORDER_REPLICATE, (MatType)cv::BORDER_REFLECT)));
+                            Values(CV_8UC1, CV_32FC1, CV_32FC4),
+                            Values(3, 15, 25),
+                            Values(Size(0, 0)), // not used
+                            Values((int)BORDER_CONSTANT, (int)BORDER_REFLECT101,
+                                   (int)BORDER_REPLICATE, (int)BORDER_REFLECT),
+                            Bool()));
 
 INSTANTIATE_TEST_CASE_P(Filter, Bilateral, Combine(
-                        Values(CV_8UC1, CV_8UC3),
-                        Values(Size(5, 5), Size(9, 9)),
-                        Values(Size(0, 0)), //not use
-                        Values((MatType)cv::BORDER_CONSTANT, (MatType)cv::BORDER_REPLICATE,
-                               (MatType)cv::BORDER_REFLECT, (MatType)cv::BORDER_WRAP, (MatType)cv::BORDER_REFLECT_101)));
+                            Values(CV_8UC1, CV_8UC3),
+                            Values(5, 9),
+                            Values(Size(0, 0)), // not used
+                            Values((int)BORDER_CONSTANT, (int)BORDER_REPLICATE,
+                                   (int)BORDER_REFLECT, (int)BORDER_WRAP, (int)BORDER_REFLECT_101),
+                            Values(false))); // TODO does not work with ROI
 
 INSTANTIATE_TEST_CASE_P(Filter, AdaptiveBilateral, Combine(
-                        Values(CV_8UC1, CV_8UC3),
-                        Values(Size(5, 5), Size(9, 9)),
-                        Values(Size(0, 0)), //not use
-                        Values((MatType)cv::BORDER_CONSTANT, (MatType)cv::BORDER_REPLICATE,
-                               (MatType)cv::BORDER_REFLECT,  (MatType)cv::BORDER_REFLECT_101)));
+                            Values(CV_8UC1, CV_8UC3),
+                            Values(5, 9),
+                            Values(Size(0, 0)), // not used
+                            Values((int)BORDER_CONSTANT, (int)BORDER_REPLICATE,
+                                   (int)BORDER_REFLECT, (int)BORDER_REFLECT_101),
+                            Bool()));
+
+INSTANTIATE_TEST_CASE_P(Filter, MedianFilter, Combine(
+                            Values((MatType)CV_8UC1, (MatType)CV_8UC4, (MatType)CV_32FC1, (MatType)CV_32FC4),
+                            Values(3, 5),
+                            Values(Size(0, 0)), // not used
+                            Values(0), // not used
+                            Bool()));
+
 #endif // HAVE_OPENCL

--- a/modules/ocl/test/test_imgproc.cpp
+++ b/modules/ocl/test/test_imgproc.cpp
@@ -55,9 +55,9 @@
 
 #ifdef HAVE_OPENCL
 
-using namespace cvtest;
-using namespace testing;
+using namespace cv;
 using namespace std;
+using namespace testing;
 
 MatType nulltype = -1;
 
@@ -77,7 +77,7 @@ typedef struct
     short y;
 } COOR;
 
-COOR do_meanShift(int x0, int y0, uchar *sptr, uchar *dptr, int sstep, cv::Size size, int sp, int sr, int maxIter, float eps, int *tab)
+COOR do_meanShift(int x0, int y0, uchar *sptr, uchar *dptr, int sstep, Size size, int sp, int sr, int maxIter, float eps, int *tab)
 {
 
     int isr2 = sr * sr;
@@ -219,7 +219,7 @@ COOR do_meanShift(int x0, int y0, uchar *sptr, uchar *dptr, int sstep, cv::Size 
     return coor;
 }
 
-void meanShiftFiltering_(const Mat &src_roi, Mat &dst_roi, int sp, int sr, cv::TermCriteria crit)
+void meanShiftFiltering_(const Mat &src_roi, Mat &dst_roi, int sp, int sr, TermCriteria crit)
 {
     if( src_roi.empty() )
         CV_Error( CV_StsBadArg, "The input image is empty" );
@@ -230,11 +230,11 @@ void meanShiftFiltering_(const Mat &src_roi, Mat &dst_roi, int sp, int sr, cv::T
     CV_Assert( (src_roi.cols == dst_roi.cols) && (src_roi.rows == dst_roi.rows) );
     CV_Assert( !(dst_roi.step & 0x3) );
 
-    if( !(crit.type & cv::TermCriteria::MAX_ITER) )
+    if( !(crit.type & TermCriteria::MAX_ITER) )
         crit.maxCount = 5;
     int maxIter = std::min(std::max(crit.maxCount, 1), 100);
     float eps;
-    if( !(crit.type & cv::TermCriteria::EPS) )
+    if( !(crit.type & TermCriteria::EPS) )
         eps = 1.f;
     eps = (float)std::max(crit.epsilon, 0.0);
 
@@ -245,7 +245,7 @@ void meanShiftFiltering_(const Mat &src_roi, Mat &dst_roi, int sp, int sr, cv::T
     uchar *dptr = dst_roi.data;
     int sstep = (int)src_roi.step;
     int dstep = (int)dst_roi.step;
-    cv::Size size = src_roi.size();
+    Size size = src_roi.size();
 
     for(int i = 0; i < size.height; i++, sptr += sstep - (size.width << 2),
             dptr += dstep - (size.width << 2))
@@ -257,7 +257,7 @@ void meanShiftFiltering_(const Mat &src_roi, Mat &dst_roi, int sp, int sr, cv::T
     }
 }
 
-void meanShiftProc_(const Mat &src_roi, Mat &dst_roi, Mat &dstCoor_roi, int sp, int sr, cv::TermCriteria crit)
+void meanShiftProc_(const Mat &src_roi, Mat &dst_roi, Mat &dstCoor_roi, int sp, int sr, TermCriteria crit)
 {
 
     if( src_roi.empty() )
@@ -268,11 +268,11 @@ void meanShiftProc_(const Mat &src_roi, Mat &dst_roi, Mat &dstCoor_roi, int sp, 
                (src_roi.cols == dstCoor_roi.cols) && (src_roi.rows == dstCoor_roi.rows));
     CV_Assert( !(dstCoor_roi.step & 0x3) );
 
-    if( !(crit.type & cv::TermCriteria::MAX_ITER) )
+    if( !(crit.type & TermCriteria::MAX_ITER) )
         crit.maxCount = 5;
     int maxIter = std::min(std::max(crit.maxCount, 1), 100);
     float eps;
-    if( !(crit.type & cv::TermCriteria::EPS) )
+    if( !(crit.type & TermCriteria::EPS) )
         eps = 1.f;
     eps = (float)std::max(crit.epsilon, 0.0);
 
@@ -285,7 +285,7 @@ void meanShiftProc_(const Mat &src_roi, Mat &dst_roi, Mat &dstCoor_roi, int sp, 
     int sstep = (int)src_roi.step;
     int dstep = (int)dst_roi.step;
     int dCoorstep = (int)dstCoor_roi.step >> 1;
-    cv::Size size = src_roi.size();
+    Size size = src_roi.size();
 
     for(int i = 0; i < size.height; i++, sptr += sstep - (size.width << 2),
             dptr += dstep - (size.width << 2), dCoorptr += dCoorstep - (size.width << 1))
@@ -301,7 +301,7 @@ void meanShiftProc_(const Mat &src_roi, Mat &dst_roi, Mat &dstCoor_roi, int sp, 
 PARAM_TEST_CASE(ImgprocTestBase, MatType, MatType, MatType, MatType, MatType, bool)
 {
     int type1, type2, type3, type4, type5;
-    cv::Scalar val;
+    Scalar val;
     // set up roi
     int roicols;
     int roirows;
@@ -317,32 +317,32 @@ PARAM_TEST_CASE(ImgprocTestBase, MatType, MatType, MatType, MatType, MatType, bo
     int masky;
 
     //mat
-    cv::Mat mat1;
-    cv::Mat mat2;
-    cv::Mat mask;
-    cv::Mat dst;
-    cv::Mat dst1; //bak, for two outputs
+    Mat mat1;
+    Mat mat2;
+    Mat mask;
+    Mat dst;
+    Mat dst1; //bak, for two outputs
 
     //mat with roi
-    cv::Mat mat1_roi;
-    cv::Mat mat2_roi;
-    cv::Mat mask_roi;
-    cv::Mat dst_roi;
-    cv::Mat dst1_roi; //bak
+    Mat mat1_roi;
+    Mat mat2_roi;
+    Mat mask_roi;
+    Mat dst_roi;
+    Mat dst1_roi; //bak
 
     //ocl mat
-    cv::ocl::oclMat clmat1;
-    cv::ocl::oclMat clmat2;
-    cv::ocl::oclMat clmask;
-    cv::ocl::oclMat cldst;
-    cv::ocl::oclMat cldst1; //bak
+    ocl::oclMat clmat1;
+    ocl::oclMat clmat2;
+    ocl::oclMat clmask;
+    ocl::oclMat cldst;
+    ocl::oclMat cldst1; //bak
 
     //ocl mat with roi
-    cv::ocl::oclMat clmat1_roi;
-    cv::ocl::oclMat clmat2_roi;
-    cv::ocl::oclMat clmask_roi;
-    cv::ocl::oclMat cldst_roi;
-    cv::ocl::oclMat cldst1_roi;
+    ocl::oclMat clmat1_roi;
+    ocl::oclMat clmat2_roi;
+    ocl::oclMat clmask_roi;
+    ocl::oclMat cldst_roi;
+    ocl::oclMat cldst1_roi;
 
     virtual void SetUp()
     {
@@ -351,7 +351,7 @@ PARAM_TEST_CASE(ImgprocTestBase, MatType, MatType, MatType, MatType, MatType, bo
         type3 = GET_PARAM(2);
         type4 = GET_PARAM(3);
         type5 = GET_PARAM(4);
-        cv::Size size(MWIDTH, MHEIGHT);
+        Size size(MWIDTH, MHEIGHT);
         double min = 1, max = 20;
 
         if(type1 != nulltype)
@@ -377,10 +377,10 @@ PARAM_TEST_CASE(ImgprocTestBase, MatType, MatType, MatType, MatType, MatType, bo
         if(type5 != nulltype)
         {
             mask = randomMat(size, CV_8UC1, 0, 2,  false);
-            cv::threshold(mask, mask, 0.5, 255., type5);
+            threshold(mask, mask, 0.5, 255., type5);
             clmask = mask;
         }
-        val = cv::Scalar(rng.uniform(-10.0, 10.0), rng.uniform(-10.0, 10.0), rng.uniform(-10.0, 10.0), rng.uniform(-10.0, 10.0));
+        val = Scalar(rng.uniform(-10.0, 10.0), rng.uniform(-10.0, 10.0), rng.uniform(-10.0, 10.0), rng.uniform(-10.0, 10.0));
     }
 
     void random_roi()
@@ -444,16 +444,16 @@ PARAM_TEST_CASE(ImgprocTestBase, MatType, MatType, MatType, MatType, MatType, bo
 
     void Near(double threshold)
     {
-        cv::Mat cpu_cldst;
+        Mat cpu_cldst;
         cldst.download(cpu_cldst);
         EXPECT_MAT_NEAR(dst, cpu_cldst, threshold);
     }
 };
 ////////////////////////////////equalizeHist//////////////////////////////////////////
 
-struct equalizeHist : ImgprocTestBase {};
+typedef ImgprocTestBase EqualizeHist;
 
-OCL_TEST_P(equalizeHist, Mat)
+OCL_TEST_P(EqualizeHist, Mat)
 {
     if (mat1.type() != CV_8UC1 || mat1.type() != dst.type())
     {
@@ -465,8 +465,8 @@ OCL_TEST_P(equalizeHist, Mat)
         for(int j = 0; j < LOOP_TIMES; j++)
         {
             random_roi();
-            cv::equalizeHist(mat1_roi, dst_roi);
-            cv::ocl::equalizeHist(clmat1_roi, cldst_roi);
+            equalizeHist(mat1_roi, dst_roi);
+            ocl::equalizeHist(clmat1_roi, cldst_roi);
             Near(1.1);
         }
     }
@@ -475,11 +475,11 @@ OCL_TEST_P(equalizeHist, Mat)
 
 ////////////////////////////////copyMakeBorder////////////////////////////////////////////
 
-struct CopyMakeBorder : ImgprocTestBase {};
+typedef ImgprocTestBase CopyMakeBorder;
 
 OCL_TEST_P(CopyMakeBorder, Mat)
 {
-    int bordertype[] = {cv::BORDER_CONSTANT, cv::BORDER_REPLICATE, cv::BORDER_REFLECT, cv::BORDER_WRAP, cv::BORDER_REFLECT_101};
+    int bordertype[] = {BORDER_CONSTANT, BORDER_REPLICATE, BORDER_REFLECT, BORDER_WRAP, BORDER_REFLECT_101};
     int top = rng.uniform(0, 10);
     int bottom = rng.uniform(0, 10);
     int left = rng.uniform(0, 10);
@@ -496,7 +496,7 @@ OCL_TEST_P(CopyMakeBorder, Mat)
             {
                 random_roi();
 #ifdef RANDOMROI
-                if(((bordertype[i] != cv::BORDER_CONSTANT) && (bordertype[i] != cv::BORDER_REPLICATE)) && (mat1_roi.cols <= left) || (mat1_roi.cols <= right) || (mat1_roi.rows <= top) || (mat1_roi.rows <= bottom))
+                if(((bordertype[i] != BORDER_CONSTANT) && (bordertype[i] != BORDER_REPLICATE)) && (mat1_roi.cols <= left) || (mat1_roi.cols <= right) || (mat1_roi.rows <= top) || (mat1_roi.rows <= bottom))
                 {
                     continue;
                 }
@@ -510,10 +510,10 @@ OCL_TEST_P(CopyMakeBorder, Mat)
                     continue;
                 }
 #endif
-                cv::copyMakeBorder(mat1_roi, dst_roi, top, bottom, left, right, bordertype[i] | cv::BORDER_ISOLATED, cv::Scalar(1.0));
-                cv::ocl::copyMakeBorder(clmat1_roi, cldst_roi, top, bottom, left, right,  bordertype[i] | cv::BORDER_ISOLATED, cv::Scalar(1.0));
+                cv::copyMakeBorder(mat1_roi, dst_roi, top, bottom, left, right, bordertype[i] | BORDER_ISOLATED, Scalar(1.0));
+                ocl::copyMakeBorder(clmat1_roi, cldst_roi, top, bottom, left, right,  bordertype[i] | BORDER_ISOLATED, Scalar(1.0));
 
-                cv::Mat cpu_cldst;
+                Mat cpu_cldst;
 #ifndef RANDOMROI
                 cldst_roi.download(cpu_cldst);
                 EXPECT_MAT_NEAR(dst_roi, cpu_cldst, 0.0);
@@ -530,20 +530,20 @@ OCL_TEST_P(CopyMakeBorder, Mat)
 
 ////////////////////////////////cornerMinEigenVal//////////////////////////////////////////
 
-struct cornerMinEigenVal : ImgprocTestBase {};
+struct CornerMinEigenVal : ImgprocTestBase {};
 
-OCL_TEST_P(cornerMinEigenVal, Mat)
+OCL_TEST_P(CornerMinEigenVal, Mat)
 {
     for(int j = 0; j < LOOP_TIMES; j++)
     {
 
         random_roi();
         int blockSize = 3, apertureSize = 3;//1 + 2 * (rand() % 4);
-        //int borderType = cv::BORDER_CONSTANT;
-        //int borderType = cv::BORDER_REPLICATE;
-        int borderType = cv::BORDER_REFLECT;
-        cv::cornerMinEigenVal(mat1_roi, dst_roi, blockSize, apertureSize, borderType);
-        cv::ocl::cornerMinEigenVal(clmat1_roi, cldst_roi, blockSize, apertureSize, borderType);
+        //int borderType = BORDER_CONSTANT;
+        //int borderType = BORDER_REPLICATE;
+        int borderType = BORDER_REFLECT;
+        cornerMinEigenVal(mat1_roi, dst_roi, blockSize, apertureSize, borderType);
+        ocl::cornerMinEigenVal(clmat1_roi, cldst_roi, blockSize, apertureSize, borderType);
         Near(1.);
     }
 }
@@ -552,9 +552,9 @@ OCL_TEST_P(cornerMinEigenVal, Mat)
 
 ////////////////////////////////cornerHarris//////////////////////////////////////////
 
-struct cornerHarris : ImgprocTestBase {};
+typedef ImgprocTestBase CornerHarris;
 
-OCL_TEST_P(cornerHarris, Mat)
+OCL_TEST_P(CornerHarris, Mat)
 {
     for(int j = 0; j < LOOP_TIMES; j++)
     {
@@ -562,11 +562,11 @@ OCL_TEST_P(cornerHarris, Mat)
         random_roi();
         int blockSize = 3, apertureSize = 3; //1 + 2 * (rand() % 4);
         double k = 2;
-        //int borderType = cv::BORDER_CONSTANT;
-        //int borderType = cv::BORDER_REPLICATE;
-        int borderType = cv::BORDER_REFLECT;
-        cv::cornerHarris(mat1_roi, dst_roi, blockSize, apertureSize, k, borderType);
-        cv::ocl::cornerHarris(clmat1_roi, cldst_roi, blockSize, apertureSize, k, borderType);
+        //int borderType = BORDER_CONSTANT;
+        //int borderType = BORDER_REPLICATE;
+        int borderType = BORDER_REFLECT;
+        cornerHarris(mat1_roi, dst_roi, blockSize, apertureSize, k, borderType);
+        ocl::cornerHarris(clmat1_roi, cldst_roi, blockSize, apertureSize, k, borderType);
         Near(1.);
     }
 }
@@ -574,31 +574,31 @@ OCL_TEST_P(cornerHarris, Mat)
 
 ////////////////////////////////integral/////////////////////////////////////////////////
 
-struct integral : ImgprocTestBase {};
+typedef ImgprocTestBase Integral;
 
-OCL_TEST_P(integral, Mat1)
+OCL_TEST_P(Integral, Mat1)
 {
     for(int j = 0; j < LOOP_TIMES; j++)
     {
         random_roi();
 
-        cv::ocl::integral(clmat1_roi, cldst_roi);
-        cv::integral(mat1_roi, dst_roi);
+        ocl::integral(clmat1_roi, cldst_roi);
+        integral(mat1_roi, dst_roi);
         Near(0);
     }
 }
 
-OCL_TEST_P(integral, Mat2)
+OCL_TEST_P(Integral, Mat2)
 {
     for(int j = 0; j < LOOP_TIMES; j++)
     {
         random_roi();
 
-        cv::ocl::integral(clmat1_roi, cldst_roi, cldst1_roi);
-        cv::integral(mat1_roi, dst_roi, dst1_roi);
+        ocl::integral(clmat1_roi, cldst_roi, cldst1_roi);
+        integral(mat1_roi, dst_roi, dst1_roi);
         Near(0);
 
-        cv::Mat cpu_cldst1;
+        Mat cpu_cldst1;
         cldst1.download(cpu_cldst1);
         EXPECT_MAT_NEAR(dst1, cpu_cldst1, 0.0);
     }
@@ -611,12 +611,12 @@ OCL_TEST_P(integral, Mat2)
 PARAM_TEST_CASE(WarpTestBase, MatType, int)
 {
     int type;
-    cv::Size size;
+    Size size;
     int interpolation;
 
     //src mat
-    cv::Mat mat1;
-    cv::Mat dst;
+    Mat mat1;
+    Mat dst;
 
     // set up roi
     int src_roicols;
@@ -630,21 +630,21 @@ PARAM_TEST_CASE(WarpTestBase, MatType, int)
 
 
     //src mat with roi
-    cv::Mat mat1_roi;
-    cv::Mat dst_roi;
+    Mat mat1_roi;
+    Mat dst_roi;
 
     //ocl dst mat for testing
-    cv::ocl::oclMat gdst_whole;
+    ocl::oclMat gdst_whole;
 
     //ocl mat with roi
-    cv::ocl::oclMat gmat1;
-    cv::ocl::oclMat gdst;
+    ocl::oclMat gmat1;
+    ocl::oclMat gdst;
 
     virtual void SetUp()
     {
         type = GET_PARAM(0);
         interpolation = GET_PARAM(1);
-        size = cv::Size(MWIDTH, MHEIGHT);
+        size = Size(MWIDTH, MHEIGHT);
 
         mat1 = randomMat(size, type, 5, 16, false);
         dst  = randomMat(size, type, 5, 16, false);
@@ -688,7 +688,7 @@ PARAM_TEST_CASE(WarpTestBase, MatType, int)
 
 /////warpAffine
 
-struct WarpAffine : WarpTestBase {};
+typedef WarpTestBase WarpAffine;
 
 OCL_TEST_P(WarpAffine, Mat)
 {
@@ -703,10 +703,10 @@ OCL_TEST_P(WarpAffine, Mat)
     {
         random_roi();
 
-        cv::warpAffine(mat1_roi, dst_roi, M, size, interpolation);
-        cv::ocl::warpAffine(gmat1, gdst, M, size, interpolation);
+        warpAffine(mat1_roi, dst_roi, M, size, interpolation);
+        ocl::warpAffine(gmat1, gdst, M, size, interpolation);
 
-        cv::Mat cpu_dst;
+        Mat cpu_dst;
         gdst_whole.download(cpu_dst);
         EXPECT_MAT_NEAR(dst, cpu_dst, 1.0);
     }
@@ -716,7 +716,7 @@ OCL_TEST_P(WarpAffine, Mat)
 
 // warpPerspective
 
-struct WarpPerspective : WarpTestBase {};
+typedef WarpTestBase WarpPerspective;
 
 OCL_TEST_P(WarpPerspective, Mat)
 {
@@ -732,10 +732,10 @@ OCL_TEST_P(WarpPerspective, Mat)
     {
         random_roi();
 
-        cv::warpPerspective(mat1_roi, dst_roi, M, size, interpolation);
-        cv::ocl::warpPerspective(gmat1, gdst, M, size, interpolation);
+        warpPerspective(mat1_roi, dst_roi, M, size, interpolation);
+        ocl::warpPerspective(gmat1, gdst, M, size, interpolation);
 
-        cv::Mat cpu_dst;
+        Mat cpu_dst;
         gdst_whole.download(cpu_dst);
         EXPECT_MAT_NEAR(dst, cpu_dst, 1.0);
     }
@@ -751,17 +751,17 @@ PARAM_TEST_CASE(Remap, MatType, MatType, MatType, int, int)
     int srcType;
     int map1Type;
     int map2Type;
-    cv::Scalar val;
+    Scalar val;
 
     int interpolation;
     int bordertype;
 
-    cv::Mat src;
-    cv::Mat dst;
-    cv::Mat map1;
-    cv::Mat map2;
+    Mat src;
+    Mat dst;
+    Mat map1;
+    Mat map2;
 
-    //std::vector<cv::ocl::Info> oclinfo;
+    //std::vector<ocl::Info> oclinfo;
 
     int src_roicols;
     int src_roirows;
@@ -780,19 +780,19 @@ PARAM_TEST_CASE(Remap, MatType, MatType, MatType, int, int)
     int map2x;
     int map2y;
 
-    cv::Mat src_roi;
-    cv::Mat dst_roi;
-    cv::Mat map1_roi;
-    cv::Mat map2_roi;
+    Mat src_roi;
+    Mat dst_roi;
+    Mat map1_roi;
+    Mat map2_roi;
 
     //ocl mat for testing
-    cv::ocl::oclMat gdst;
+    ocl::oclMat gdst;
 
     //ocl mat with roi
-    cv::ocl::oclMat gsrc_roi;
-    cv::ocl::oclMat gdst_roi;
-    cv::ocl::oclMat gmap1_roi;
-    cv::ocl::oclMat gmap2_roi;
+    ocl::oclMat gsrc_roi;
+    ocl::oclMat gdst_roi;
+    ocl::oclMat gmap1_roi;
+    ocl::oclMat gmap2_roi;
 
     virtual void SetUp()
     {
@@ -802,8 +802,8 @@ PARAM_TEST_CASE(Remap, MatType, MatType, MatType, int, int)
         interpolation = GET_PARAM(3);
         bordertype = GET_PARAM(4);
 
-        cv::Size srcSize = cv::Size(MWIDTH, MHEIGHT);
-        cv::Size map1Size = cv::Size(MWIDTH, MHEIGHT);
+        Size srcSize = Size(MWIDTH, MHEIGHT);
+        Size map1Size = Size(MWIDTH, MHEIGHT);
         double min = 5, max = 16;
 
         if(srcType != nulltype)
@@ -830,16 +830,16 @@ PARAM_TEST_CASE(Remap, MatType, MatType, MatType, int, int)
         switch (src.channels())
         {
         case 1:
-            val = cv::Scalar(rng.uniform(0.0, 10.0), 0, 0, 0);
+            val = Scalar(rng.uniform(0.0, 10.0), 0, 0, 0);
             break;
         case 2:
-            val = cv::Scalar(rng.uniform(0.0, 10.0), rng.uniform(0.0, 10.0), 0, 0);
+            val = Scalar(rng.uniform(0.0, 10.0), rng.uniform(0.0, 10.0), 0, 0);
             break;
         case 3:
-            val = cv::Scalar(rng.uniform(0.0, 10.0), rng.uniform(0.0, 10.0), rng.uniform(0.0, 10.0), 0);
+            val = Scalar(rng.uniform(0.0, 10.0), rng.uniform(0.0, 10.0), rng.uniform(0.0, 10.0), 0);
             break;
         case 4:
-            val = cv::Scalar(rng.uniform(0.0, 10.0), rng.uniform(0.0, 10.0), rng.uniform(0.0, 10.0), rng.uniform(0.0, 10.0));
+            val = Scalar(rng.uniform(0.0, 10.0), rng.uniform(0.0, 10.0), rng.uniform(0.0, 10.0), rng.uniform(0.0, 10.0));
             break;
         }
 
@@ -894,14 +894,14 @@ OCL_TEST_P(Remap, Mat)
         cout << "Don't support the dataType" << endl;
         return;
     }
-    int bordertype[] = {cv::BORDER_CONSTANT, cv::BORDER_REPLICATE/*,BORDER_REFLECT,BORDER_WRAP,BORDER_REFLECT_101*/};
+    int bordertype[] = {BORDER_CONSTANT, BORDER_REPLICATE/*,BORDER_REFLECT,BORDER_WRAP,BORDER_REFLECT_101*/};
 
     for(int j = 0; j < LOOP_TIMES; j++)
     {
         random_roi();
-        cv::remap(src_roi, dst_roi, map1_roi, map2_roi, interpolation, bordertype[0], val);
-        cv::ocl::remap(gsrc_roi, gdst_roi, gmap1_roi, gmap2_roi, interpolation, bordertype[0], val);
-        cv::Mat cpu_dst;
+        remap(src_roi, dst_roi, map1_roi, map2_roi, interpolation, bordertype[0], val);
+        ocl::remap(gsrc_roi, gdst_roi, gmap1_roi, gmap2_roi, interpolation, bordertype[0], val);
+        Mat cpu_dst;
         gdst.download(cpu_dst);
 
         if(interpolation == 0)
@@ -915,16 +915,16 @@ OCL_TEST_P(Remap, Mat)
 /////////////////////////////////////////////////////////////////////////////////////////////////
 // resize
 
-PARAM_TEST_CASE(Resize, MatType, cv::Size, double, double, int)
+PARAM_TEST_CASE(Resize, MatType, Size, double, double, int)
 {
     int type;
-    cv::Size dsize;
+    Size dsize;
     double fx, fy;
     int interpolation;
 
     //src mat
-    cv::Mat mat1;
-    cv::Mat dst;
+    Mat mat1;
+    Mat dst;
 
     // set up roi
     int src_roicols;
@@ -937,15 +937,15 @@ PARAM_TEST_CASE(Resize, MatType, cv::Size, double, double, int)
     int dsty;
 
     //src mat with roi
-    cv::Mat mat1_roi;
-    cv::Mat dst_roi;
+    Mat mat1_roi;
+    Mat dst_roi;
 
     //ocl dst mat for testing
-    cv::ocl::oclMat gdst_whole;
+    ocl::oclMat gdst_whole;
 
     //ocl mat with roi
-    cv::ocl::oclMat gmat1;
-    cv::ocl::oclMat gdst;
+    ocl::oclMat gmat1;
+    ocl::oclMat gdst;
 
     virtual void SetUp()
     {
@@ -955,15 +955,15 @@ PARAM_TEST_CASE(Resize, MatType, cv::Size, double, double, int)
         fy = GET_PARAM(3);
         interpolation = GET_PARAM(4);
 
-        cv::Size size(MWIDTH, MHEIGHT);
+        Size size(MWIDTH, MHEIGHT);
 
-        if(dsize == cv::Size() && !(fx > 0 && fy > 0))
+        if(dsize == Size() && !(fx > 0 && fy > 0))
         {
             cout << "invalid dsize and fx fy" << endl;
             return;
         }
 
-        if(dsize == cv::Size())
+        if(dsize == Size())
         {
             dsize.width = (int)(size.width * fx);
             dsize.height = (int)(size.height * fy);
@@ -1018,13 +1018,13 @@ OCL_TEST_P(Resize, Mat)
     {
         random_roi();
 
-        // cv::resize(mat1_roi, dst_roi, dsize, fx, fy, interpolation);
-        // cv::ocl::resize(gmat1, gdst, dsize, fx, fy, interpolation);
+        // resize(mat1_roi, dst_roi, dsize, fx, fy, interpolation);
+        // ocl::resize(gmat1, gdst, dsize, fx, fy, interpolation);
         if(dst_roicols < 1 || dst_roirows < 1) continue;
-        cv::resize(mat1_roi, dst_roi, dsize, fx, fy, interpolation);
-        cv::ocl::resize(gmat1, gdst, dsize, fx, fy, interpolation);
+        resize(mat1_roi, dst_roi, dsize, fx, fy, interpolation);
+        ocl::resize(gmat1, gdst, dsize, fx, fy, interpolation);
 
-        cv::Mat cpu_dst;
+        Mat cpu_dst;
         gdst_whole.download(cpu_dst);
         EXPECT_MAT_NEAR(dst, cpu_dst, 1.0);
     }
@@ -1041,8 +1041,8 @@ PARAM_TEST_CASE(Threshold, MatType, ThreshOp)
     int threshOp;
 
     //src mat
-    cv::Mat mat1;
-    cv::Mat dst;
+    Mat mat1;
+    Mat dst;
 
     // set up roi
     int roicols;
@@ -1053,22 +1053,22 @@ PARAM_TEST_CASE(Threshold, MatType, ThreshOp)
     int dsty;
 
     //src mat with roi
-    cv::Mat mat1_roi;
-    cv::Mat dst_roi;
+    Mat mat1_roi;
+    Mat dst_roi;
 
     //ocl dst mat for testing
-    cv::ocl::oclMat gdst_whole;
+    ocl::oclMat gdst_whole;
 
     //ocl mat with roi
-    cv::ocl::oclMat gmat1;
-    cv::ocl::oclMat gdst;
+    ocl::oclMat gmat1;
+    ocl::oclMat gdst;
 
     virtual void SetUp()
     {
         type = GET_PARAM(0);
         threshOp = GET_PARAM(1);
 
-        cv::Size size(MWIDTH, MHEIGHT);
+        Size size(MWIDTH, MHEIGHT);
 
         mat1 = randomMat(size, type, 5, 16, false);
         dst  = randomMat(size, type, 5, 16, false);
@@ -1113,25 +1113,25 @@ OCL_TEST_P(Threshold, Mat)
         double maxVal = randomDouble(20.0, 127.0);
         double thresh = randomDouble(0.0, maxVal);
 
-        cv::threshold(mat1_roi, dst_roi, thresh, maxVal, threshOp);
-        cv::ocl::threshold(gmat1, gdst, thresh, maxVal, threshOp);
+        threshold(mat1_roi, dst_roi, thresh, maxVal, threshOp);
+        ocl::threshold(gmat1, gdst, thresh, maxVal, threshOp);
 
-        cv::Mat cpu_dst;
+        Mat cpu_dst;
         gdst_whole.download(cpu_dst);
         EXPECT_MAT_NEAR(dst, cpu_dst, 1);
     }
 
 }
 
-PARAM_TEST_CASE(meanShiftTestBase, MatType, MatType, int, int, cv::TermCriteria)
+PARAM_TEST_CASE(MeanShiftTestBase, MatType, MatType, int, int, TermCriteria)
 {
     int type, typeCoor;
     int sp, sr;
-    cv::TermCriteria crit;
+    TermCriteria crit;
     //src mat
-    cv::Mat src;
-    cv::Mat dst;
-    cv::Mat dstCoor;
+    Mat src;
+    Mat dst;
+    Mat dstCoor;
 
     //set up roi
     int roicols;
@@ -1142,18 +1142,18 @@ PARAM_TEST_CASE(meanShiftTestBase, MatType, MatType, int, int, cv::TermCriteria)
     int dsty;
 
     //src mat with roi
-    cv::Mat src_roi;
-    cv::Mat dst_roi;
-    cv::Mat dstCoor_roi;
+    Mat src_roi;
+    Mat dst_roi;
+    Mat dstCoor_roi;
 
     //ocl dst mat
-    cv::ocl::oclMat gdst;
-    cv::ocl::oclMat gdstCoor;
+    ocl::oclMat gdst;
+    ocl::oclMat gdstCoor;
 
     //ocl mat with roi
-    cv::ocl::oclMat gsrc_roi;
-    cv::ocl::oclMat gdst_roi;
-    cv::ocl::oclMat gdstCoor_roi;
+    ocl::oclMat gsrc_roi;
+    ocl::oclMat gdst_roi;
+    ocl::oclMat gdstCoor_roi;
 
     virtual void SetUp()
     {
@@ -1164,7 +1164,7 @@ PARAM_TEST_CASE(meanShiftTestBase, MatType, MatType, int, int, cv::TermCriteria)
         crit     = GET_PARAM(4);
 
         // MWIDTH=256, MHEIGHT=256. defined in utility.hpp
-        cv::Size size = cv::Size(MWIDTH, MHEIGHT);
+        Size size = Size(MWIDTH, MHEIGHT);
 
         src = randomMat(size, type, 5, 16, false);
         dst = randomMat(size, type, 5, 16, false);
@@ -1204,20 +1204,21 @@ PARAM_TEST_CASE(meanShiftTestBase, MatType, MatType, int, int, cv::TermCriteria)
 };
 
 /////////////////////////meanShiftFiltering/////////////////////////////
-struct meanShiftFiltering : meanShiftTestBase {};
 
-OCL_TEST_P(meanShiftFiltering, Mat)
+typedef MeanShiftTestBase MeanShiftFiltering;
+
+OCL_TEST_P(MeanShiftFiltering, Mat)
 {
 
     for(int j = 0; j < LOOP_TIMES; j++)
     {
         random_roi();
 
-        cv::Mat cpu_gdst;
+        Mat cpu_gdst;
         gdst.download(cpu_gdst);
 
-        meanShiftFiltering_(src_roi, dst_roi, sp, sr, crit);
-        cv::ocl::meanShiftFiltering(gsrc_roi, gdst_roi, sp, sr, crit);
+        ::meanShiftFiltering_(src_roi, dst_roi, sp, sr, crit);
+        ocl::meanShiftFiltering(gsrc_roi, gdst_roi, sp, sr, crit);
 
         gdst.download(cpu_gdst);
         EXPECT_MAT_NEAR(dst, cpu_gdst, 0.0);
@@ -1225,20 +1226,21 @@ OCL_TEST_P(meanShiftFiltering, Mat)
 }
 
 ///////////////////////////meanShiftProc//////////////////////////////////
-struct meanShiftProc : meanShiftTestBase {};
 
-OCL_TEST_P(meanShiftProc, Mat)
+typedef MeanShiftTestBase MeanShiftProc;
+
+OCL_TEST_P(MeanShiftProc, Mat)
 {
 
     for(int j = 0; j < LOOP_TIMES; j++)
     {
         random_roi();
 
-        cv::Mat cpu_gdst;
-        cv::Mat cpu_gdstCoor;
+        Mat cpu_gdst;
+        Mat cpu_gdstCoor;
 
         meanShiftProc_(src_roi, dst_roi, dstCoor_roi, sp, sr, crit);
-        cv::ocl::meanShiftProc(gsrc_roi, gdst_roi, gdstCoor_roi, sp, sr, crit);
+        ocl::meanShiftProc(gsrc_roi, gdst_roi, gdstCoor_roi, sp, sr, crit);
 
         gdst.download(cpu_gdst);
         gdstCoor.download(cpu_gdstCoor);
@@ -1249,10 +1251,11 @@ OCL_TEST_P(meanShiftProc, Mat)
 
 ///////////////////////////////////////////////////////////////////////////////////////
 //hist
-void calcHistGold(const cv::Mat &src, cv::Mat &hist)
+
+void calcHistGold(const Mat &src, Mat &hist)
 {
     hist.create(1, 256, CV_32SC1);
-    hist.setTo(cv::Scalar::all(0));
+    hist.setTo(Scalar::all(0));
 
     int *hist_row = hist.ptr<int>();
     for (int y = 0; y < src.rows; ++y)
@@ -1264,30 +1267,30 @@ void calcHistGold(const cv::Mat &src, cv::Mat &hist)
     }
 }
 
-PARAM_TEST_CASE(histTestBase, MatType, MatType)
+PARAM_TEST_CASE(HistTestBase, MatType, MatType)
 {
     int type_src;
 
     //src mat
-    cv::Mat src;
-    cv::Mat dst_hist;
+    Mat src;
+    Mat dst_hist;
     //set up roi
     int roicols;
     int roirows;
     int srcx;
     int srcy;
     //src mat with roi
-    cv::Mat src_roi;
+    Mat src_roi;
     //ocl dst mat, dst_hist and gdst_hist don't have roi
-    cv::ocl::oclMat gdst_hist;
+    ocl::oclMat gdst_hist;
     //ocl mat with roi
-    cv::ocl::oclMat gsrc_roi;
+    ocl::oclMat gsrc_roi;
 
     virtual void SetUp()
     {
         type_src   = GET_PARAM(0);
 
-        cv::Size size = cv::Size(MWIDTH, MHEIGHT);
+        Size size = Size(MWIDTH, MHEIGHT);
 
         src = randomMat(size, type_src, 0, 256, false);
 
@@ -1312,69 +1315,73 @@ PARAM_TEST_CASE(histTestBase, MatType, MatType)
         gsrc_roi = src_roi;
     }
 };
-///////////////////////////calcHist///////////////////////////////////////
-struct calcHist : histTestBase {};
 
-OCL_TEST_P(calcHist, Mat)
+///////////////////////////calcHist///////////////////////////////////////
+
+typedef HistTestBase CalcHist;
+
+OCL_TEST_P(CalcHist, Mat)
 {
     for(int j = 0; j < LOOP_TIMES; j++)
     {
         random_roi();
 
-        cv::Mat cpu_hist;
+        Mat cpu_hist;
 
         calcHistGold(src_roi, dst_hist);
-        cv::ocl::calcHist(gsrc_roi, gdst_hist);
+        ocl::calcHist(gsrc_roi, gdst_hist);
 
         gdst_hist.download(cpu_hist);
         EXPECT_MAT_NEAR(dst_hist, cpu_hist, 0.0);
     }
 }
+
 ///////////////////////////////////////////////////////////////////////////////////////////////////////
 // CLAHE
 
-PARAM_TEST_CASE(CLAHE, cv::Size, double)
+PARAM_TEST_CASE(CLAHE_Test, Size, double)
 {
-    cv::Size gridSize;
+    Size gridSize;
     double clipLimit;
 
-    cv::Mat src;
-    cv::Mat dst_gold;
+    Mat src;
+    Mat dst_gold;
 
-    cv::ocl::oclMat g_src;
-    cv::ocl::oclMat g_dst;
+    ocl::oclMat g_src;
+    ocl::oclMat g_dst;
 
     virtual void SetUp()
     {
         gridSize = GET_PARAM(0);
         clipLimit = GET_PARAM(1);
 
-        src = randomMat(cv::Size(MWIDTH, MHEIGHT), CV_8UC1, 0, 256, false);
+        src = randomMat(Size(MWIDTH, MHEIGHT), CV_8UC1, 0, 256, false);
         g_src.upload(src);
     }
 };
 
-OCL_TEST_P(CLAHE, Accuracy)
+OCL_TEST_P(CLAHE_Test, Accuracy)
 {
-    cv::Ptr<cv::CLAHE> clahe = cv::ocl::createCLAHE(clipLimit, gridSize);
+    Ptr<CLAHE> clahe = ocl::createCLAHE(clipLimit, gridSize);
     clahe->apply(g_src, g_dst);
-    cv::Mat dst(g_dst);
+    Mat dst(g_dst);
 
-    cv::Ptr<cv::CLAHE> clahe_gold = cv::createCLAHE(clipLimit, gridSize);
+    Ptr<CLAHE> clahe_gold = createCLAHE(clipLimit, gridSize);
     clahe_gold->apply(src, dst_gold);
 
     EXPECT_MAT_NEAR(dst_gold, dst, 1.0);
 }
 
 ///////////////////////////Convolve//////////////////////////////////
+
 PARAM_TEST_CASE(ConvolveTestBase, MatType, bool)
 {
     int type;
     //src mat
-    cv::Mat mat1;
-    cv::Mat mat2;
-    cv::Mat dst;
-    cv::Mat dst1; //bak, for two outputs
+    Mat mat1;
+    Mat mat2;
+    Mat dst;
+    Mat dst1; //bak, for two outputs
     // set up roi
     int roicols;
     int roirows;
@@ -1385,23 +1392,23 @@ PARAM_TEST_CASE(ConvolveTestBase, MatType, bool)
     int dstx;
     int dsty;
     //src mat with roi
-    cv::Mat mat1_roi;
-    cv::Mat mat2_roi;
-    cv::Mat dst_roi;
-    cv::Mat dst1_roi; //bak
+    Mat mat1_roi;
+    Mat mat2_roi;
+    Mat dst_roi;
+    Mat dst1_roi; //bak
     //ocl dst mat for testing
-    cv::ocl::oclMat gdst_whole;
-    cv::ocl::oclMat gdst1_whole; //bak
+    ocl::oclMat gdst_whole;
+    ocl::oclMat gdst1_whole; //bak
     //ocl mat with roi
-    cv::ocl::oclMat gmat1;
-    cv::ocl::oclMat gmat2;
-    cv::ocl::oclMat gdst;
-    cv::ocl::oclMat gdst1;   //bak
+    ocl::oclMat gmat1;
+    ocl::oclMat gmat2;
+    ocl::oclMat gdst;
+    ocl::oclMat gdst1;   //bak
     virtual void SetUp()
     {
         type = GET_PARAM(0);
 
-        cv::Size size(MWIDTH, MHEIGHT);
+        Size size(MWIDTH, MHEIGHT);
 
         mat1 = randomMat(size, type, 5, 16, false);
         mat2 = randomMat(size, type, 5, 16, false);
@@ -1445,9 +1452,10 @@ PARAM_TEST_CASE(ConvolveTestBase, MatType, bool)
     }
 
 };
-struct Convolve : ConvolveTestBase {};
 
-void conv2( cv::Mat x, cv::Mat y, cv::Mat z)
+typedef ConvolveTestBase Convolve;
+
+void conv2( Mat x, Mat y, Mat z)
 {
     int N1 = x.rows;
     int M1 = x.cols;
@@ -1477,6 +1485,7 @@ void conv2( cv::Mat x, cv::Mat y, cv::Mat z)
             dstdata[i * (z.step >> 2) + j] = temp;
         }
 }
+
 OCL_TEST_P(Convolve, Mat)
 {
     if(mat1.type() != CV_32FC1)
@@ -1486,14 +1495,14 @@ OCL_TEST_P(Convolve, Mat)
     for(int j = 0; j < LOOP_TIMES; j++)
     {
         random_roi();
-        cv::ocl::oclMat temp1;
-        cv::Mat kernel_cpu = mat2(Rect(0, 0, 7, 7));
+        ocl::oclMat temp1;
+        Mat kernel_cpu = mat2(Rect(0, 0, 7, 7));
         temp1 = kernel_cpu;
 
         conv2(kernel_cpu, mat1_roi, dst_roi);
-        cv::ocl::convolve(gmat1, temp1, gdst);
+        ocl::convolve(gmat1, temp1, gdst);
 
-        cv::Mat cpu_dst;
+        Mat cpu_dst;
         gdst_whole.download(cpu_dst);
         EXPECT_MAT_NEAR(dst, cpu_dst, .1);
 
@@ -1501,10 +1510,11 @@ OCL_TEST_P(Convolve, Mat)
 }
 
 //////////////////////////////// ColumnSum //////////////////////////////////////
-PARAM_TEST_CASE(ColumnSum, cv::Size)
+
+PARAM_TEST_CASE(ColumnSum, Size)
 {
-    cv::Size size;
-    cv::Mat src;
+    Size size;
+    Mat src;
 
     virtual void SetUp()
     {
@@ -1514,13 +1524,13 @@ PARAM_TEST_CASE(ColumnSum, cv::Size)
 
 OCL_TEST_P(ColumnSum, Accuracy)
 {
-    cv::Mat src = randomMat(size, CV_32FC1, 0, 255);
-    cv::ocl::oclMat d_dst;
-    cv::ocl::oclMat d_src(src);
+    Mat src = randomMat(size, CV_32FC1, 0, 255);
+    ocl::oclMat d_dst;
+    ocl::oclMat d_src(src);
 
-    cv::ocl::columnSum(d_src, d_dst);
+    ocl::columnSum(d_src, d_dst);
 
-    cv::Mat dst(d_dst);
+    Mat dst(d_dst);
 
     for (int j = 0; j < src.cols; ++j)
     {
@@ -1539,9 +1549,10 @@ OCL_TEST_P(ColumnSum, Accuracy)
         }
     }
 }
+
 /////////////////////////////////////////////////////////////////////////////////////
 
-INSTANTIATE_TEST_CASE_P(ImgprocTestBase, equalizeHist, Combine(
+INSTANTIATE_TEST_CASE_P(ImgprocTestBase, EqualizeHist, Combine(
                             ONE_TYPE(CV_8UC1),
                             NULL_TYPE,
                             ONE_TYPE(CV_8UC1),
@@ -1558,7 +1569,7 @@ INSTANTIATE_TEST_CASE_P(ImgprocTestBase, CopyMakeBorder, Combine(
                             NULL_TYPE,
                             Values(false))); // Values(false) is the reserved parameter
 
-INSTANTIATE_TEST_CASE_P(ImgprocTestBase, cornerMinEigenVal, Combine(
+INSTANTIATE_TEST_CASE_P(ImgprocTestBase, CornerMinEigenVal, Combine(
                             Values(CV_8UC1, CV_32FC1),
                             NULL_TYPE,
                             ONE_TYPE(CV_32FC1),
@@ -1566,7 +1577,7 @@ INSTANTIATE_TEST_CASE_P(ImgprocTestBase, cornerMinEigenVal, Combine(
                             NULL_TYPE,
                             Values(false))); // Values(false) is the reserved parameter
 
-INSTANTIATE_TEST_CASE_P(ImgprocTestBase, cornerHarris, Combine(
+INSTANTIATE_TEST_CASE_P(ImgprocTestBase, CornerHarris, Combine(
                             Values(CV_8UC1, CV_32FC1),
                             NULL_TYPE,
                             ONE_TYPE(CV_32FC1),
@@ -1575,7 +1586,7 @@ INSTANTIATE_TEST_CASE_P(ImgprocTestBase, cornerHarris, Combine(
                             Values(false))); // Values(false) is the reserved parameter
 
 
-INSTANTIATE_TEST_CASE_P(ImgprocTestBase, integral, Combine(
+INSTANTIATE_TEST_CASE_P(ImgprocTestBase, Integral, Combine(
                             ONE_TYPE(CV_8UC1),
                             NULL_TYPE,
                             ONE_TYPE(CV_32SC1),
@@ -1585,60 +1596,60 @@ INSTANTIATE_TEST_CASE_P(ImgprocTestBase, integral, Combine(
 
 INSTANTIATE_TEST_CASE_P(Imgproc, WarpAffine, Combine(
                             Values(CV_8UC1, CV_8UC3, CV_8UC4, CV_32FC1, CV_32FC3, CV_32FC4),
-                            Values((MatType)cv::INTER_NEAREST, (MatType)cv::INTER_LINEAR,
-                                   (MatType)cv::INTER_CUBIC, (MatType)(cv::INTER_NEAREST | cv::WARP_INVERSE_MAP),
-                                   (MatType)(cv::INTER_LINEAR | cv::WARP_INVERSE_MAP), (MatType)(cv::INTER_CUBIC | cv::WARP_INVERSE_MAP))));
+                            Values((MatType)INTER_NEAREST, (MatType)INTER_LINEAR,
+                                   (MatType)INTER_CUBIC, (MatType)(INTER_NEAREST | WARP_INVERSE_MAP),
+                                   (MatType)(INTER_LINEAR | WARP_INVERSE_MAP), (MatType)(INTER_CUBIC | WARP_INVERSE_MAP))));
 
 
 INSTANTIATE_TEST_CASE_P(Imgproc, WarpPerspective, Combine
                         (Values(CV_8UC1, CV_8UC3, CV_8UC4, CV_32FC1, CV_32FC3, CV_32FC4),
-                         Values((MatType)cv::INTER_NEAREST, (MatType)cv::INTER_LINEAR,
-                                (MatType)cv::INTER_CUBIC, (MatType)(cv::INTER_NEAREST | cv::WARP_INVERSE_MAP),
-                                (MatType)(cv::INTER_LINEAR | cv::WARP_INVERSE_MAP), (MatType)(cv::INTER_CUBIC | cv::WARP_INVERSE_MAP))));
+                         Values((MatType)INTER_NEAREST, (MatType)INTER_LINEAR,
+                                (MatType)INTER_CUBIC, (MatType)(INTER_NEAREST | WARP_INVERSE_MAP),
+                                (MatType)(INTER_LINEAR | WARP_INVERSE_MAP), (MatType)(INTER_CUBIC | WARP_INVERSE_MAP))));
 
 
 INSTANTIATE_TEST_CASE_P(Imgproc, Resize, Combine(
-                            Values(CV_8UC1, CV_8UC3, CV_8UC4, CV_32FC1, CV_32FC3, CV_32FC4),  Values(cv::Size()),
-                            Values(0.5, 1.5, 2), Values(0.5, 1.5, 2), Values((MatType)cv::INTER_NEAREST, (MatType)cv::INTER_LINEAR)));
+                            Values(CV_8UC1, CV_8UC3, CV_8UC4, CV_32FC1, CV_32FC3, CV_32FC4),  Values(Size()),
+                            Values(0.5, 1.5, 2), Values(0.5, 1.5, 2), Values((MatType)INTER_NEAREST, (MatType)INTER_LINEAR)));
 
 
 INSTANTIATE_TEST_CASE_P(Imgproc, Threshold, Combine(
-                            Values(CV_8UC1, CV_32FC1), Values(ThreshOp(cv::THRESH_BINARY),
-                                    ThreshOp(cv::THRESH_BINARY_INV), ThreshOp(cv::THRESH_TRUNC),
-                                    ThreshOp(cv::THRESH_TOZERO), ThreshOp(cv::THRESH_TOZERO_INV))));
+                            Values(CV_8UC1, CV_32FC1), Values(ThreshOp(THRESH_BINARY),
+                                    ThreshOp(THRESH_BINARY_INV), ThreshOp(THRESH_TRUNC),
+                                    ThreshOp(THRESH_TOZERO), ThreshOp(THRESH_TOZERO_INV))));
 
 
-INSTANTIATE_TEST_CASE_P(Imgproc, meanShiftFiltering, Combine(
+INSTANTIATE_TEST_CASE_P(Imgproc, MeanShiftFiltering, Combine(
                             ONE_TYPE(CV_8UC4),
                             ONE_TYPE(CV_16SC2),
                             Values(5),
                             Values(6),
-                            Values(cv::TermCriteria(cv::TermCriteria::COUNT + cv::TermCriteria::EPS, 5, 1))
+                            Values(TermCriteria(TermCriteria::COUNT + TermCriteria::EPS, 5, 1))
                         ));
 
 
-INSTANTIATE_TEST_CASE_P(Imgproc, meanShiftProc, Combine(
+INSTANTIATE_TEST_CASE_P(Imgproc, MeanShiftProc, Combine(
                             ONE_TYPE(CV_8UC4),
                             ONE_TYPE(CV_16SC2),
                             Values(5),
                             Values(6),
-                            Values(cv::TermCriteria(cv::TermCriteria::COUNT + cv::TermCriteria::EPS, 5, 1))
+                            Values(TermCriteria(TermCriteria::COUNT + TermCriteria::EPS, 5, 1))
                         ));
 
 INSTANTIATE_TEST_CASE_P(Imgproc, Remap, Combine(
                             Values(CV_8UC1, CV_8UC3, CV_8UC4, CV_32FC1, CV_32FC3, CV_32FC4),
                             Values(CV_32FC1, CV_16SC2, CV_32FC2), Values(-1, CV_32FC1),
-                            Values((int)cv::INTER_NEAREST, (int)cv::INTER_LINEAR),
-                            Values((int)cv::BORDER_CONSTANT)));
+                            Values((int)INTER_NEAREST, (int)INTER_LINEAR),
+                            Values((int)BORDER_CONSTANT)));
 
 
-INSTANTIATE_TEST_CASE_P(histTestBase, calcHist, Combine(
+INSTANTIATE_TEST_CASE_P(histTestBase, CalcHist, Combine(
                             ONE_TYPE(CV_8UC1),
                             ONE_TYPE(CV_32SC1) //no use
                         ));
 
-INSTANTIATE_TEST_CASE_P(Imgproc, CLAHE, Combine(
-                        Values(cv::Size(4, 4), cv::Size(32, 8), cv::Size(8, 64)),
+INSTANTIATE_TEST_CASE_P(Imgproc, CLAHE_Test, Combine(
+                        Values(Size(4, 4), Size(32, 8), Size(8, 64)),
                         Values(0.0, 10.0, 62.0, 300.0)));
 
 INSTANTIATE_TEST_CASE_P(Imgproc, ColumnSum, DIFFERENT_SIZES);


### PR DESCRIPTION
- refactored accuracy tests in ocl/test/test_filters.cpp
- added an accuracy test for ocl::medianFilter
- fixed Filter2D in case of CV_32FC3
- removed needless piece of code from ocl::erode
- marked bottleneck in tests as // TODO ..
- fixed ocl::Laplacian (when used no default scale=1)
