### PR TITLE
Delete an import of junit.framework.Assert, which is deprecated in JUnit 4.x

### DIFF
--- a/modules/java/test/src/org/opencv/test/OpenCVTestRunner.java
+++ b/modules/java/test/src/org/opencv/test/OpenCVTestRunner.java
@@ -2,7 +2,6 @@ package org.opencv.test;
 
 import java.io.File;
 import java.io.IOException;
-import junit.framework.Assert;
 
 import org.opencv.core.Mat;
 


### PR DESCRIPTION
We don't use it, anyway.
