### PR TITLE
Fix running Java tests with run.py on everything other than Windows.

### DIFF
--- a/modules/java/test/CMakeLists.txt
+++ b/modules/java/test/CMakeLists.txt
@@ -10,6 +10,9 @@ set(opencv_test_java_bin_dir "${CMAKE_CURRENT_BINARY_DIR}/.build")
 set(android_source_dir "${CMAKE_CURRENT_SOURCE_DIR}/../android_test")
 set(java_source_dir ${CMAKE_CURRENT_SOURCE_DIR})
 
+# make sure the build directory exists
+file(MAKE_DIRECTORY "${opencv_test_java_bin_dir}")
+
 # get project sources
 file(GLOB_RECURSE opencv_test_java_files RELATIVE "${android_source_dir}" "${android_source_dir}/res/*" "${android_source_dir}/src/*.java")
 # These are the files that need to be updated for pure Java.
@@ -58,14 +61,6 @@ add_custom_command(OUTPUT "${opencv_test_java_bin_dir}/build.xml"
                    COMMENT "Copying build.xml"
                   )
 
-# Create a script for running the Java tests and place it in build/bin.
-#if(WIN32)
-  #file(WRITE "${CMAKE_BINARY_DIR}/bin/opencv_test_java.cmd"   "cd ${opencv_test_java_bin_dir}\nset PATH=${EXECUTABLE_OUTPUT_PATH}/Release;%PATH%\nant -DjavaLibraryPath=${EXECUTABLE_OUTPUT_PATH}/Release buildAndTest")
-  #file(WRITE "${CMAKE_BINARY_DIR}/bin/opencv_test_java_D.cmd" "cd ${opencv_test_java_bin_dir}\nset PATH=${EXECUTABLE_OUTPUT_PATH}/Debug;%PATH%\nant   -DjavaLibraryPath=${EXECUTABLE_OUTPUT_PATH}/Debug   buildAndTest")
-#else()
-  #file(WRITE "${CMAKE_BINARY_DIR}/bin/opencv_test_java.sh" "cd ${opencv_test_java_bin_dir};\nant -DjavaLibraryPath=${LIBRARY_OUTPUT_PATH} buildAndTest;\ncd -")
-#endif()
-
 add_custom_command(OUTPUT "${opencv_test_java_bin_dir}/build/jar/opencv-test.jar"
                    COMMAND "${ANT_EXECUTABLE}" build
                    WORKING_DIRECTORY "${opencv_test_java_bin_dir}"
@@ -73,8 +68,19 @@ add_custom_command(OUTPUT "${opencv_test_java_bin_dir}/build/jar/opencv-test.jar
                    COMMENT "Build Java tests"
                   )
 
-add_custom_target(${PROJECT_NAME} ALL SOURCES "${opencv_test_java_bin_dir}/build/jar/opencv-test.jar")
-add_dependencies(${PROJECT_NAME} ${the_module})
+# Not add_custom_command because generator expressions aren't supported in
+# OUTPUT file names, and we need to generate different files for different
+# configurations.
+add_custom_target(${PROJECT_NAME}_properties
+                  COMMAND "${CMAKE_COMMAND}" -E echo "opencv.lib.path = $<TARGET_FILE_DIR:${the_module}>"
+                    > "${opencv_test_java_bin_dir}/ant-$<CONFIGURATION>.properties"
+                  VERBATIM
+                 )
+
+add_custom_target(${PROJECT_NAME} ALL
+                  DEPENDS ${the_module} ${PROJECT_NAME}_properties
+                  SOURCES "${opencv_test_java_bin_dir}/build/jar/opencv-test.jar"
+                 )
 
 if(ENABLE_SOLUTION_FOLDERS)
   set_target_properties(${PROJECT_NAME} PROPERTIES FOLDER "tests accuracy")

--- a/modules/java/test/build.xml
+++ b/modules/java/test/build.xml
@@ -1,4 +1,6 @@
 <project>
+  <property file="ant-${opencv.build.type}.properties"/>
+
   <path id="master-classpath">
     <fileset dir="lib">
       <include name="*.jar"/>
@@ -34,8 +36,8 @@
   <target name="test">
     <mkdir dir="testResults"/>
     <junit printsummary="true" haltonfailure="false" haltonerror="false" showoutput="false" logfailedtests="true" maxmemory="256m">
-      <sysproperty key="java.library.path" path="${javaLibraryPath}"/>
-      <env key="PATH" path="${javaLibraryPath}"/>
+      <sysproperty key="java.library.path" path="${opencv.lib.path}"/>
+      <env key="PATH" path="${opencv.lib.path}"/>
       <classpath refid="master-classpath"/>
       <classpath>
         <pathelement location="build/classes"/>

--- a/modules/ts/misc/run.py
+++ b/modules/ts/misc/run.py
@@ -759,7 +759,10 @@ class TestSuite(object):
                 return hostlogpath
             return None
         elif path == "java":
-            cmd = [self.ant_executable, "-DjavaLibraryPath=" + self.tests_dir, "buildAndTest"]
+            cmd = [self.ant_executable,
+                   "-Dopencv.build.type="
+                     + (self.options.configuration if self.options.configuration else self.build_type),
+                   "buildAndTest"]
 
             print >> _stderr, "Run command:", " ".join(cmd)
             try:


### PR DESCRIPTION
Previously, run.py would assume that the opencv_java library is in the same directory as the tests, which is only true on Windows.

The library path depends on the build configuration, which may not be known until the actual build (e.g. with the Visual Studio generators), so it can't be stored in the CMake cache for run.py to read. I didn't want to hardcode into run.py where the library is on each platform, either. So that's why I used the current scheme with the properties file. It also makes running the tests without run.py a little easier.
