### PR TITLE
Fix imshow under Windows with OpenGL support

### DIFF
--- a/modules/highgui/src/window_w32.cpp
+++ b/modules/highgui/src/window_w32.cpp
@@ -1087,12 +1087,7 @@ cvShowImage( const char* name, const CvArr* arr )
     window = icvFindWindowByName(name);
     if(!window)
     {
-        #ifndef HAVE_OPENGL
-            cvNamedWindow(name, CV_WINDOW_AUTOSIZE);
-        #else
-            cvNamedWindow(name, CV_WINDOW_AUTOSIZE | CV_WINDOW_OPENGL);
-        #endif
-
+        cvNamedWindow(name, CV_WINDOW_AUTOSIZE);
         window = icvFindWindowByName(name);
     }
 


### PR DESCRIPTION
we doesn't create OpenGL windows by default
OpenGL window must be created by user via `namedWindow`
