### PR TITLE
cmake: cleanup OpenCVModules_TARGETS from cache

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -62,6 +62,8 @@ endif()
 
 include(cmake/OpenCVUtils.cmake)
 
+ocv_clear_vars(OpenCVModules_TARGETS)
+
 # ----------------------------------------------------------------------------
 # Break in case of popular CMake configuration mistakes
 # ----------------------------------------------------------------------------

--- a/cmake/OpenCVUtils.cmake
+++ b/cmake/OpenCVUtils.cmake
@@ -458,7 +458,6 @@ function(ocv_install_target)
 
   if(DEFINED __package)
     list(APPEND ${__package}_TARGETS ${__target})
-    list(REMOVE_DUPLICATES ${__package}_TARGETS)
     set(${__package}_TARGETS "${${__package}_TARGETS}" CACHE INTERNAL "List of ${__package} targets")
   endif()
 


### PR DESCRIPTION
This will allow to disable modules between cmake runs
