### PR TITLE
cmake: fix linker dependencies for opencv_java

### DIFF
--- a/cmake/OpenCVUtils.cmake
+++ b/cmake/OpenCVUtils.cmake
@@ -11,6 +11,18 @@ if(NOT COMMAND find_host_program)
   endmacro()
 endif()
 
+# assert macro
+# Note: it doesn't support lists in arguments
+# Usage samples:
+#   ocv_assert(MyLib_FOUND)
+#   ocv_assert(DEFINED MyLib_INCLUDE_DIRS)
+macro(ocv_assert)
+  if(NOT (${ARGN}))
+    string(REPLACE ";" " " __assert_msg "${ARGN}")
+    message(AUTHOR_WARNING "Assertion failed: ${__assert_msg}")
+  endif()
+endmacro()
+
 macro(ocv_check_environment_variables)
   foreach(_var ${ARGN})
     if(NOT DEFINED ${_var} AND DEFINED ENV{${_var}})

--- a/modules/java/CMakeLists.txt
+++ b/modules/java/CMakeLists.txt
@@ -274,7 +274,12 @@ add_library(${the_module} SHARED ${handwrittren_h_sources} ${handwrittren_cpp_so
                                 "${JAR_FILE}" "${JAR_FILE}.dephelper")
 if(BUILD_FAT_JAVA_LIB)
   set(__deps ${OPENCV_MODULE_${the_module}_DEPS} ${OPENCV_MODULES_BUILD})
-  list(REMOVE_ITEM __deps ${the_module} opencv_ts)
+  foreach(m ${OPENCV_MODULES_BUILD}) # filterout INTERNAL (like opencv_ts) and BINDINGS (like opencv_python) modules
+    ocv_assert(DEFINED OPENCV_MODULE_${m}_CLASS)
+    if(NOT OPENCV_MODULE_${m}_CLASS STREQUAL "PUBLIC")
+      list(REMOVE_ITEM __deps ${m})
+    endif()
+  endforeach()
   ocv_list_unique(__deps)
   set(__extradeps ${__deps})
   ocv_list_filterout(__extradeps "^opencv_")


### PR DESCRIPTION
We should not include other bindings in this list (like "opencv_python")
