### PR TITLE
ocl: workaround for msvc11 bug

### DIFF
--- a/cmake/checks/opencl.cpp
+++ b/cmake/checks/opencl.cpp
@@ -4,12 +4,21 @@
 #include <CL/cl.h>
 #endif
 
-int main(int argc, char** argv)
-{
+#ifndef _MSC_VER
 #ifdef CL_VERSION_1_2
 #error OpenCL is valid
 #else
 #error OpenCL check failed
 #endif
+#else
+#ifdef CL_VERSION_1_2
+#pragma message ("OpenCL is valid")
+#else
+#pragma message ("OpenCL check failed")
+#endif
+#endif
+
+int main(int /*argc*/, char** /*argv*/)
+{
     return 0;
 }


### PR DESCRIPTION
"#error" requires DOS line endings (or fails with fatal error C1004: unexpected end-of-file found)
See: http://connect.microsoft.com/VisualStudio/feedback/details/794991/c-error-directive-and-unix-line-endings-leads-to-an-unexpected-end-of-file
So replace them to #pragma message.
