### PR TITLE
cv::KalamFilter, updated predict()

### DIFF
--- a/modules/video/src/kalman.cpp
+++ b/modules/video/src/kalman.cpp
@@ -266,6 +266,7 @@ const Mat& KalmanFilter::predict(const Mat& control)
 
     // handle the case when there will be measurement before the next predict.
     statePre.copyTo(statePost);
+    errorCovPre.copyTo(errorCovPost);
 
     return statePre;
 }


### PR DESCRIPTION
Currently the predict function updates statePost, but not errorCovPost. As a result, the uncertainty does not grow if one keeps calling predict() without correct(). If this PR is accepted then this old ticket should be closed https://code.ros.org/trac/opencv/ticket/1380.
