### PR TITLE
Support Python 3 < version 3.3

### DIFF
--- a/modules/python/src2/pycompat.hpp
+++ b/modules/python/src2/pycompat.hpp
@@ -56,9 +56,16 @@
 // Python3 strings are unicode, these defines mimic the Python2 functionality.
 #define PyString_Check PyUnicode_Check
 #define PyString_FromString PyUnicode_FromString
-#define PyString_AsString PyUnicode_AsUTF8
 #define PyString_FromStringAndSize PyUnicode_FromStringAndSize
 #define PyString_Size PyUnicode_GET_SIZE
+
+// PyUnicode_AsUTF8 isn't available until Python 3.3
+#if (PY_VERSION_HEX < 0x03030000)
+#define PyString_AsString(x) PyBytes_AsString(PyUnicode_AsUTF8String(x))
+#else
+#define PyString_AsString PyUnicode_AsUTF8
+#endif
+
 #endif
 
 #endif // END HEADER GUARD


### PR DESCRIPTION
In pycompat.hpp, PyUnicode_AsUTF8() is used to replace
PyString_AsString(), which is not available in Python 3.  Unfortunately,
PyUnicode_AsUTF8() was only added in Python 3.3, and thus does not work
when building for Python 3.0, 3.1, or 3.2.

Add an additional check and #define to provide the PyString_AsString()
functionality in those versions of Python.  Doing so requires two
function calls, as there is no direct replacement.

This patch is based on a very similar patch for llvmpy:
https://github.com/llvmpy/llvmpy/commit/e4996f02d7573cec9033acb65176196a370710c8
