### PR TITLE
Fix incorrectly unprefixed constant names in the OpenNI tutorial

### DIFF
--- a/doc/user_guide/ug_highgui.rst
+++ b/doc/user_guide/ug_highgui.rst
@@ -41,15 +41,15 @@ VideoCapture can retrieve the following data:
 
 #.
     data given from depth generator:
-      * ``OPENNI_DEPTH_MAP``          - depth values in mm (CV_16UC1)
-      * ``OPENNI_POINT_CLOUD_MAP``    - XYZ in meters (CV_32FC3)
-      * ``OPENNI_DISPARITY_MAP``      - disparity in pixels (CV_8UC1)
-      * ``OPENNI_DISPARITY_MAP_32F``  - disparity in pixels (CV_32FC1)
-      * ``OPENNI_VALID_DEPTH_MASK``   - mask of valid pixels (not ocluded, not shaded etc.) (CV_8UC1)
+      * ``CV_CAP_OPENNI_DEPTH_MAP``          - depth values in mm (CV_16UC1)
+      * ``CV_CAP_OPENNI_POINT_CLOUD_MAP``    - XYZ in meters (CV_32FC3)
+      * ``CV_CAP_OPENNI_DISPARITY_MAP``      - disparity in pixels (CV_8UC1)
+      * ``CV_CAP_OPENNI_DISPARITY_MAP_32F``  - disparity in pixels (CV_32FC1)
+      * ``CV_CAP_OPENNI_VALID_DEPTH_MASK``   - mask of valid pixels (not ocluded, not shaded etc.) (CV_8UC1)
 #.
     data given from RGB image generator:
-      * ``OPENNI_BGR_IMAGE``          - color image (CV_8UC3)
-      * ``OPENNI_GRAY_IMAGE``         - gray image (CV_8UC1)
+      * ``CV_CAP_OPENNI_BGR_IMAGE``          - color image (CV_8UC3)
+      * ``CV_CAP_OPENNI_GRAY_IMAGE``         - gray image (CV_8UC1)
 
 In order to get depth map from depth sensor use ``VideoCapture::operator >>``, e. g. ::
 
@@ -73,8 +73,8 @@ For getting several data maps use ``VideoCapture::grab`` and ``VideoCapture::ret
 
         capture.grab();
 
-        capture.retrieve( depthMap, OPENNI_DEPTH_MAP );
-        capture.retrieve( bgrImage, OPENNI_BGR_IMAGE );
+        capture.retrieve( depthMap, CV_CAP_OPENNI_DEPTH_MAP );
+        capture.retrieve( bgrImage, CV_CAP_OPENNI_BGR_IMAGE );
 
         if( waitKey( 30 ) >= 0 )
             break;


### PR DESCRIPTION
Bug report: http://code.opencv.org/issues/3329.
