### PR TITLE
Eliminate PyString_AsString() calls

### DIFF
--- a/modules/python/src2/cv2.cpp
+++ b/modules/python/src2/cv2.cpp
@@ -613,10 +613,16 @@ bool pyopencv_to(PyObject* obj, String& value, const char* name)
     (void)name;
     if(!obj || obj == Py_None)
         return true;
-    char* str = PyString_AsString(obj);
-    if(!str)
+    PyObject *bytes = PyUnicode_AsUTF8String(obj);
+    if(!bytes)
         return false;
+    char* str = PyBytes_AsString(bytes);
+    if(!str) {
+        Py_DECREF(bytes);
+        return false;
+    }
     value = String(str);
+    Py_DECREF(bytes);
     return true;
 }
 
@@ -1048,11 +1054,28 @@ bool pyopencv_to(PyObject *o, cv::flann::IndexParams& p, const char *name)
             PyObject* item = PyList_GET_ITEM(values, i);
             if( !PyString_Check(key) )
                 break;
-            String k = PyString_AsString(key);
+            PyObject *bytes = PyUnicode_AsUTF8String(key);
+            if( !bytes )
+                break;
+            char *str = PyBytes_AsString(key);
+            if ( !str ) {
+                Py_DECREF(bytes);
+                break;
+            }
+            String k = str;
+            Py_DECREF(bytes);
             if( PyString_Check(item) )
             {
-                const char* value = PyString_AsString(item);
-                p.setString(k, value);
+                bytes = PyUnicode_AsUTF8String(key);
+                if( !bytes )
+                    break;
+                str = PyBytes_AsString(item);
+                if ( !str ) {
+                    Py_DECREF(bytes);
+                    break;
+                }
+                p.setString(k, str);
+                Py_DECREF(bytes);
             }
             else if( !!PyBool_Check(item) )
                 p.setBool(k, item == Py_True);
@@ -1213,7 +1236,16 @@ static PyObject *pycvCreateTrackbar(PyObject*, PyObject *args)
 static int convert_to_char(PyObject *o, char *dst, const char *name = "no_name")
 {
   if (PyString_Check(o) && PyString_Size(o) == 1) {
-    *dst = PyString_AsString(o)[0];
+    PyObject *bytes = PyUnicode_AsUTF8String(o);
+    if (!bytes)
+      return 0; // Exception already raised
+    char *str = PyBytes_AsString(bytes);
+    if (!str) {
+      Py_DECREF(bytes);
+      return 0; // Exception already raised
+    }
+    *dst = *str;
+    Py_DECREF(bytes);
     return 1;
   } else {
     (*dst) = 0;

--- a/modules/python/src2/pycompat.hpp
+++ b/modules/python/src2/pycompat.hpp
@@ -56,9 +56,15 @@
 // Python3 strings are unicode, these defines mimic the Python2 functionality.
 #define PyString_Check PyUnicode_Check
 #define PyString_FromString PyUnicode_FromString
-#define PyString_AsString PyUnicode_AsUTF8
+#define PyString_AsString PyUnicode_AsUTF8  // Only available in Python 3.3+
 #define PyString_FromStringAndSize PyUnicode_FromStringAndSize
 #define PyString_Size PyUnicode_GET_SIZE
+
+#else
+
+// Support use of PyBytes in Python 2
+#include <bytesobject.h>
+
 #endif
 
 #endif // END HEADER GUARD


### PR DESCRIPTION
For Python 3 compatibility, pycompat.hpp #defines PyString_AsString to
PyUnicode_AsUTF8.  Unfortunately, that function is not available until
Python 3.3, so older versions will not compile.

As an alternative to #1660, simply eliminate all uses of
PyString_AsString() in the Python module.  There are only four uses,
which can be replaced with Python 2/3 compatible PyUnicode to PyBytes
conversion, finally using PyBytes_AsString() to get the string.

This patch supports Python 2 and all versions of Python 3.  The downside
is that the number of conversions required is very ugly.  Additionally,
on Python 2, PyBytes_AsString is simply defined as PyString_AsString, so
the extra conversion to PyUnicode and back is completely useless.
