### PR TITLE
Removed incorrect release of obtained colorspace. This fixes bug #3318

### DIFF
--- a/doc/tutorials/ios/image_manipulation/image_manipulation.rst
+++ b/doc/tutorials/ios/image_manipulation/image_manipulation.rst
@@ -36,7 +36,7 @@ In *OpenCV* all the image processing operations are usually carried out on the *
 
      CGContextDrawImage(contextRef, CGRectMake(0, 0, cols, rows), image.CGImage);
      CGContextRelease(contextRef);
-     
+
      return cvMat;
    }
 


### PR DESCRIPTION
Making a CGRelease\* in Core Graphics is only allowed if you created or retained the object in question. This removes incorrect release of obtained colorspace.

And also cleaned up the documentation somewhat.

This fixes bug: http://code.opencv.org/issues/3318
