### PR TITLE
Removed incorrect release of obtained colorspace. This fixes bug #3318 (updated commit for 2.4 branch)

### DIFF
--- a/doc/tutorials/ios/image_manipulation/image_manipulation.rst
+++ b/doc/tutorials/ios/image_manipulation/image_manipulation.rst
@@ -12,7 +12,8 @@ In this tutorial we will learn how to do basic image processing using OpenCV in 
 *Introduction*
 ==============
 
-In *OpenCV* all the image processing operations are done on *Mat*. iOS uses UIImage object to display image. One of the thing is to convert UIImage object to Mat object. Below is the code to convert UIImage to Mat.
+In *OpenCV* all the image processing operations are usually carried out on the *Mat* structure. In iOS however, to render an image on screen it have to be an instance of the *UIImage* class. To convert an *OpenCV Mat* to an *UIImage* we use the *Core Graphics* framework available in iOS. Below is the code needed to covert back and forth between Mat's and UIImage's.
+
 
 .. code-block:: cpp
 
@@ -22,7 +23,7 @@ In *OpenCV* all the image processing operations are done on *Mat*. iOS uses UIIm
      CGFloat cols = image.size.width;
      CGFloat rows = image.size.height;
 
-     cv::Mat cvMat(rows, cols, CV_8UC4); // 8 bits per component, 4 channels
+     cv::Mat cvMat(rows, cols, CV_8UC4); // 8 bits per component, 4 channels (color channels + alpha)
 
      CGContextRef contextRef = CGBitmapContextCreate(cvMat.data,                 // Pointer to  data
                                                     cols,                       // Width of bitmap
@@ -35,7 +36,6 @@ In *OpenCV* all the image processing operations are done on *Mat*. iOS uses UIIm
 
      CGContextDrawImage(contextRef, CGRectMake(0, 0, cols, rows), image.CGImage);
      CGContextRelease(contextRef);
-     CGColorSpaceRelease(colorSpace);
 
      return cvMat;
    }
@@ -61,12 +61,11 @@ In *OpenCV* all the image processing operations are done on *Mat*. iOS uses UIIm
 
      CGContextDrawImage(contextRef, CGRectMake(0, 0, cols, rows), image.CGImage);
      CGContextRelease(contextRef);
-     CGColorSpaceRelease(colorSpace);
 
      return cvMat;
     }
 
-Once we obtain the Mat Object. We can do all our processing on Mat object, similar to cpp. For example if we want to convert image to gray, we can do it via below code.
+After the processing we need to convert it back to UIImage. The code below can handle both gray-scale and color image conversions (determined by the number of channels in the *if* statement).
 
 .. code-block:: cpp
 


### PR DESCRIPTION
Making a CGRelease\* in Core Graphics is only allowed if you created or retained the object in question. This removes incorrect release of obtained colorspace.

And also cleaned up the documentation somewhat.

This fixes bug: http://code.opencv.org/issues/3318

New commit for 2.4 as requested by @apavienko (https://github.com/Itseez/opencv/pull/1671)
