### PR TITLE
Fix a Wmissing-declarations warning when compiling with MinGW

### DIFF
--- a/modules/ocl/src/cl_context.cpp
+++ b/modules/ocl/src/cl_context.cpp
@@ -758,6 +758,9 @@ __Module::~__Module()
 #if defined(WIN32) && defined(CVAPI_EXPORTS)
 
 extern "C"
+BOOL WINAPI DllMain(HINSTANCE /*hInst*/, DWORD fdwReason, LPVOID lpReserved);
+
+extern "C"
 BOOL WINAPI DllMain(HINSTANCE /*hInst*/, DWORD fdwReason, LPVOID lpReserved)
 {
     if (fdwReason == DLL_PROCESS_DETACH)


### PR DESCRIPTION
Namely, this warning: http://build.opencv.org/builders/win_x64%5Brelease%5D--%5Bsse_%3D_ON%5D--%5Btbb_%3D_OFF%5D--%5Bgpu_%3D_OFF%5D--%5Bcompiler_%3D_mingw%5D--%5Btests_%3D_ON%5D-/builds/1199/steps/compile%20release%2064%20mingw%20shared%20n/logs/build%20summary%20%28e%3A%200%2C%20w%3A%201%29
