### PR TITLE
Added proper testing of the end of quicktime video files.

### DIFF
--- a/modules/highgui/src/cap_qtkit.mm
+++ b/modules/highgui/src/cap_qtkit.mm
@@ -672,7 +672,7 @@ CvCaptureFile::CvCaptureFile(const char* filename) {
         return;
     }
 
-    [mCaptureSession gotoEnd]; 
+    [mCaptureSession gotoEnd];
     endOfMovie = [mCaptureSession currentTime];
 
     [mCaptureSession gotoBeginning];
@@ -710,7 +710,7 @@ int CvCaptureFile::didStart() {
 bool CvCaptureFile::grabFrame() {
     NSAutoreleasePool* localpool = [[NSAutoreleasePool alloc] init];
     double t1 = getProperty(CV_CAP_PROP_POS_MSEC);
-    
+
     QTTime curTime;
     curTime = [mCaptureSession currentTime];
     bool isEnd=(QTTimeCompare(curTime,endOfMovie) == NSOrderedSame);


### PR DESCRIPTION
Before this patch, CvCaptureFile::grabFrame() always returns 1 regardless, which causes dead loop when one relies on the return value of VideoCapture::read(), as in the testing case listed below.

This problem is usually masked by the use of ffmpeg, which can open most quicktime files, but it'll show up on a Mac that doesn't have ffmpeg installed. 

``` c++
using namespace std;
using namespace cv;

int main(int argc, char **argv)
{
    if(argc != 2) {
        cerr << "Usage: " << argv[0] << " <video file>.\n";
        return 0;
    }

    cv::VideoCapture capture(argv[1]);
    if (!capture.isOpened())
        return 1;

    double rate= capture.get(CAP_PROP_FPS);
    cout << "rate: " << rate << "\n";

    bool stop(false);
    cv::Mat frame;

    namedWindow("Extracted Frame");

    int delay = 30;

    int fn=0;
    while (!stop) {

        if (!capture.read(frame))
            break;
        cv::imshow("Extracted Frame",frame);
        if (cv::waitKey(delay)>=0)
            stop= true;
        cout << fn++ << "\n";
    }

    return 0;
}
```
