### PR TITLE
VideoCapture: copy the captured frame, to avoid dangling Mats

### DIFF
--- a/modules/highgui/src/cap.cpp
+++ b/modules/highgui/src/cap.cpp
@@ -523,7 +523,7 @@ bool VideoCapture::retrieve(Mat& image, int channel)
         return false;
     }
     if(_img->origin == IPL_ORIGIN_TL)
-        image = Mat(_img);
+        Mat(_img).copyTo(image);
     else
     {
         Mat temp(_img);


### PR DESCRIPTION
Previously, `VideoCapture::retrieve` would return a `Mat` that referenced the internal `IplImage`. Since the latter is rewritten every time a frame is captured, it means that if the user captures two frames in a row, the first frame would reference nothing. Similar if a user captures a frame, then destroys the `VideoCapture` instance.

Note that the other branch of the `if` isn't affected, since `flip` allocates a new `Mat`.
