### PR TITLE
Fixed CMake warnings/bugs caused by #1670 and #1714

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,6 +39,10 @@ else()
   cmake_minimum_required(VERSION 2.6.3)
 endif()
 
+if(POLICY CMP0017)
+  cmake_policy(SET CMP0017 NEW)
+endif()
+
 if(POLICY CMP0022)
   cmake_policy(SET CMP0022 OLD)
 endif()

--- a/cmake/OpenCVDetectCUDA.cmake
+++ b/cmake/OpenCVDetectCUDA.cmake
@@ -15,11 +15,21 @@ endif()
 
 set(CMAKE_MODULE_PATH "${OpenCV_SOURCE_DIR}/cmake" ${CMAKE_MODULE_PATH})
 
+foreach(var INCLUDE LIBRARY PROGRAM)
+  set(__old_frpm_${var} "${CMAKE_FIND_ROOT_PATH_MODE_${var}}")
+endforeach()
+
 set(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)
 set(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY BOTH)
 set(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE NEVER)
 
 find_package(CUDA 4.2 QUIET)
+
+foreach(var INCLUDE LIBRARY PROGRAM)
+  set(CMAKE_FIND_ROOT_PATH_MODE_${var} "${__old_frpm_${var}}")
+endforeach()
+
+list(REMOVE_AT CMAKE_MODULE_PATH 0)
 
 if(CUDA_FOUND)
   set(HAVE_CUDA 1)


### PR DESCRIPTION
`include()` doesn't create a variable scope, so the settings of `CMAKE_MODULE_PATH` and `CMAKE_FIND_ROOT_PATH_MODE_*` were polluting everything included after `OpenCVDetectCUDA.cmake`.

Also, `FindCUDA` includes `FindPackageHandleStandardArgs`, which includes `CMakeParseArguments`, which causes warnings related to policy CMP0017. Setting it to `NEW` seems safe enough.
