### PR TITLE
fix crash when path has spaces

### DIFF
--- a/modules/java/CMakeLists.txt
+++ b/modules/java/CMakeLists.txt
@@ -137,6 +137,7 @@ add_custom_command(OUTPUT ${documented_java_files}
                    COMMAND ${PYTHON_EXECUTABLE} "${scripts_gen_javadoc}" --modules ${OPENCV_JAVA_MODULES_STR} "${CMAKE_CURRENT_SOURCE_DIR}/generator/src/java" "${CMAKE_CURRENT_BINARY_DIR}" 2> "${CMAKE_CURRENT_BINARY_DIR}/get_javadoc_errors.log"
                    WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
                    DEPENDS ${step2_depends}
+                   VERBATIM
                   )
 
 # step 3: copy files to destination


### PR DESCRIPTION
The paths are defined properly with an escape "\ " but you cannot have an escape and
quotes when piping (otherwise, escapes are understood as 2 characters).
So just remove the quotes.
