### PR TITLE
Update .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,9 @@
-*.pyc
-.DS_Store
-/modules/refman.rst
-tegra/
-*.user
-.sw[a-z]
-.*.swp
-tags
 *.autosave
+*.pyc
+*.user
+.*.swp
+.DS_Store
+.sw[a-z]
+/modules/refman.rst
+tags
+tegra/


### PR DESCRIPTION
- Stopped ignoring `OpenCV4Tegra/`, which is no longer relevant.
- Refined to ignore only the particular `refman.rst` that we generate.

Also sorted it, because i like sorting.
