### PR TITLE
Enable CV_Assert and such to print the function name with Visual C++

### DIFF
--- a/modules/contrib/src/detection_based_tracker.cpp
+++ b/modules/contrib/src/detection_based_tracker.cpp
@@ -169,7 +169,6 @@ bool DetectionBasedTracker::SeparateDetectionWork::run()
     return true;
 }
 
-#ifdef __GNUC__
 #define CATCH_ALL_AND_LOG(_block)                                                           \
 do {                                                                                        \
     try {                                                                                   \
@@ -177,29 +176,13 @@ do {                                                                            
         break;                                                                              \
     }                                                                                       \
     catch(cv::Exception& e) {                                                               \
-        LOGE0("\n %s: ERROR: OpenCV Exception caught: \n'%s'\n\n", __func__, e.what());     \
+        LOGE0("\n %s: ERROR: OpenCV Exception caught: \n'%s'\n\n", CV_Func, e.what());     \
     } catch(std::exception& e) {                                                            \
-        LOGE0("\n %s: ERROR: Exception caught: \n'%s'\n\n", __func__, e.what());            \
+        LOGE0("\n %s: ERROR: Exception caught: \n'%s'\n\n", CV_Func, e.what());            \
     } catch(...) {                                                                          \
-        LOGE0("\n %s: ERROR: UNKNOWN Exception caught\n\n", __func__);                      \
+        LOGE0("\n %s: ERROR: UNKNOWN Exception caught\n\n", CV_Func);                      \
     }                                                                                       \
 } while(0)
-#else
-#define CATCH_ALL_AND_LOG(_block)                                                           \
-do {                                                                                        \
-    try {                                                                                   \
-        _block;                                                                             \
-        break;                                                                              \
-    }                                                                                       \
-    catch(cv::Exception& e) {                                                               \
-        LOGE0("\n ERROR: OpenCV Exception caught: \n'%s'\n\n", e.what());                   \
-    } catch(std::exception& e) {                                                            \
-        LOGE0("\n ERROR: Exception caught: \n'%s'\n\n", e.what());                          \
-    } catch(...) {                                                                          \
-        LOGE0("\n ERROR: UNKNOWN Exception caught\n\n");                                    \
-    }                                                                                       \
-} while(0)
-#endif
 
 void* workcycleObjectDetectorFunction(void* p)
 {

--- a/modules/core/include/opencv2/core/core.hpp
+++ b/modules/core/include/opencv2/core/core.hpp
@@ -164,7 +164,7 @@ public:
 
     int code; ///< error code @see CVStatus
     string err; ///< error description
-    string func; ///< function name. Available only when the compiler supports __func__ macro
+    string func; ///< function name. Available only when the compiler supports getting it
     string file; ///< source file name where the error has occured
     int line; ///< line number in the source file where the error has occured
 };
@@ -209,15 +209,18 @@ typedef int (CV_CDECL *ErrorCallback)( int status, const char* func_name,
 CV_EXPORTS ErrorCallback redirectError( ErrorCallback errCallback,
                                         void* userdata=0, void** prevUserdata=0);
 
-#ifdef __GNUC__
-#define CV_Error( code, msg ) cv::error( cv::Exception(code, msg, __func__, __FILE__, __LINE__) )
-#define CV_Error_( code, args ) cv::error( cv::Exception(code, cv::format args, __func__, __FILE__, __LINE__) )
-#define CV_Assert( expr ) if(!!(expr)) ; else cv::error( cv::Exception(CV_StsAssert, #expr, __func__, __FILE__, __LINE__) )
+
+#if defined __GNUC__
+#define CV_Func __func__
+#elif defined _MSC_VER
+#define CV_Func __FUNCTION__
 #else
-#define CV_Error( code, msg ) cv::error( cv::Exception(code, msg, "", __FILE__, __LINE__) )
-#define CV_Error_( code, args ) cv::error( cv::Exception(code, cv::format args, "", __FILE__, __LINE__) )
-#define CV_Assert( expr ) if(!!(expr)) ; else cv::error( cv::Exception(CV_StsAssert, #expr, "", __FILE__, __LINE__) )
+#define CV_Func ""
 #endif
+
+#define CV_Error( code, msg ) cv::error( cv::Exception(code, msg, CV_Func, __FILE__, __LINE__) )
+#define CV_Error_( code, args ) cv::error( cv::Exception(code, cv::format args, CV_Func, __FILE__, __LINE__) )
+#define CV_Assert( expr ) if(!!(expr)) ; else cv::error( cv::Exception(CV_StsAssert, #expr, CV_Func, __FILE__, __LINE__) )
 
 #ifdef _DEBUG
 #define CV_DbgAssert(expr) CV_Assert(expr)

--- a/modules/core/include/opencv2/core/internal.hpp
+++ b/modules/core/include/opencv2/core/internal.hpp
@@ -774,11 +774,7 @@ namespace cv { namespace ogl {
 CV_EXPORTS bool checkError(const char* file, const int line, const char* func = "");
 }}
 
-#if defined(__GNUC__)
-    #define CV_CheckGlError() CV_DbgAssert( (cv::ogl::checkError(__FILE__, __LINE__, __func__)) )
-#else
-    #define CV_CheckGlError() CV_DbgAssert( (cv::ogl::checkError(__FILE__, __LINE__)) )
-#endif
+#define CV_CheckGlError() CV_DbgAssert( (cv::ogl::checkError(__FILE__, __LINE__, CV_Func)) )
 
 #endif //__cplusplus
 

--- a/modules/core/src/gpumat.cpp
+++ b/modules/core/src/gpumat.cpp
@@ -72,13 +72,8 @@ using namespace cv::gpu;
 
 namespace
 {
-#if defined(__GNUC__)
-    #define cudaSafeCall(expr)  ___cudaSafeCall(expr, __FILE__, __LINE__, __func__)
-    #define nppSafeCall(expr)  ___nppSafeCall(expr, __FILE__, __LINE__, __func__)
-#else /* defined(__CUDACC__) || defined(__MSVC__) */
-    #define cudaSafeCall(expr)  ___cudaSafeCall(expr, __FILE__, __LINE__)
-    #define nppSafeCall(expr)  ___nppSafeCall(expr, __FILE__, __LINE__)
-#endif
+#define cudaSafeCall(expr)  ___cudaSafeCall(expr, __FILE__, __LINE__, CV_Func)
+#define nppSafeCall(expr)  ___nppSafeCall(expr, __FILE__, __LINE__, CV_Func)
 
     inline void ___cudaSafeCall(cudaError_t err, const char *file, const int line, const char *func = "")
     {

--- a/modules/core/src/opengl_interop.cpp
+++ b/modules/core/src/opengl_interop.cpp
@@ -69,11 +69,7 @@ namespace
         #else
             void throw_nocuda() { CV_Error(CV_StsNotImplemented, "The called functionality is disabled for current build or platform"); }
 
-            #if defined(__GNUC__)
-                #define cudaSafeCall(expr)  ___cudaSafeCall(expr, __FILE__, __LINE__, __func__)
-            #else /* defined(__CUDACC__) || defined(__MSVC__) */
-                #define cudaSafeCall(expr)  ___cudaSafeCall(expr, __FILE__, __LINE__)
-            #endif
+            #define cudaSafeCall(expr)  ___cudaSafeCall(expr, __FILE__, __LINE__, CV_Func)
 
             void ___cudaSafeCall(cudaError_t err, const char* file, const int line, const char* func = "")
             {

--- a/modules/core/src/persistence.cpp
+++ b/modules/core/src/persistence.cpp
@@ -415,13 +415,8 @@ cvCreateMap( int flags, int header_size, int elem_size,
     return map;
 }
 
-#ifdef __GNUC__
 #define CV_PARSE_ERROR( errmsg )                                    \
-    icvParseError( fs, __func__, (errmsg), __FILE__, __LINE__ )
-#else
-#define CV_PARSE_ERROR( errmsg )                                    \
-    icvParseError( fs, "", (errmsg), __FILE__, __LINE__ )
-#endif
+    icvParseError( fs, CV_Func, (errmsg), __FILE__, __LINE__ )
 
 static void
 icvParseError( CvFileStorage* fs, const char* func_name,

--- a/modules/gpu/src/cuda/safe_call.hpp
+++ b/modules/gpu/src/cuda/safe_call.hpp
@@ -81,11 +81,7 @@ static inline void ___nppSafeCall(int err, const char *file, const int line, con
         cv::gpu::nppError(err, file, line, func);
 }
 
-#if defined(__GNUC__)
-    #define nppSafeCall(expr)  ___nppSafeCall(expr, __FILE__, __LINE__, __func__)
-#else
-    #define nppSafeCall(expr)  ___nppSafeCall(expr, __FILE__, __LINE__)
-#endif
+#define nppSafeCall(expr)  ___nppSafeCall(expr, __FILE__, __LINE__, CV_Func)
 
 // ncvSafeCall
 
@@ -95,11 +91,7 @@ static inline void ___ncvSafeCall(int err, const char *file, const int line, con
         cv::gpu::ncvError(err, file, line, func);
 }
 
-#if defined(__GNUC__)
-    #define ncvSafeCall(expr)  ___ncvSafeCall(expr, __FILE__, __LINE__, __func__)
-#else
-    #define ncvSafeCall(expr)  ___ncvSafeCall(expr, __FILE__, __LINE__)
-#endif
+#define ncvSafeCall(expr)  ___ncvSafeCall(expr, __FILE__, __LINE__, CV_Func)
 
 // cufftSafeCall
 
@@ -110,11 +102,7 @@ static inline void ___ncvSafeCall(int err, const char *file, const int line, con
             cv::gpu::cufftError(err, file, line, func);
     }
 
-    #if defined(__GNUC__)
-        #define cufftSafeCall(expr)  ___cufftSafeCall(expr, __FILE__, __LINE__, __func__)
-    #else
-        #define cufftSafeCall(expr)  ___cufftSafeCall(expr, __FILE__, __LINE__)
-    #endif
+#define cufftSafeCall(expr)  ___cufftSafeCall(expr, __FILE__, __LINE__, CV_Func)
 #endif
 
 // cublasSafeCall
@@ -126,11 +114,7 @@ static inline void ___ncvSafeCall(int err, const char *file, const int line, con
             cv::gpu::cublasError(err, file, line, func);
     }
 
-    #if defined(__GNUC__)
-        #define cublasSafeCall(expr)  ___cublasSafeCall(expr, __FILE__, __LINE__, __func__)
-    #else
-        #define cublasSafeCall(expr)  ___cublasSafeCall(expr, __FILE__, __LINE__)
-    #endif
+#define cublasSafeCall(expr)  ___cublasSafeCall(expr, __FILE__, __LINE__, CV_Func)
 #endif
 
 #endif /* __OPENCV_CUDA_SAFE_CALL_HPP__ */

--- a/modules/ocl/src/safe_call.hpp
+++ b/modules/ocl/src/safe_call.hpp
@@ -48,13 +48,8 @@
 
 #include "opencv2/ocl/cl_runtime/cl_runtime.hpp"
 
-#if defined(__GNUC__)
-#define openCLSafeCall(expr)  ___openCLSafeCall(expr, __FILE__, __LINE__, __func__)
-#define openCLVerifyCall(res) ___openCLSafeCall(res, __FILE__, __LINE__, __func__)
-#else /* defined(__OPENCLCC__) || defined(__MSVC__) */
-#define openCLSafeCall(expr)  ___openCLSafeCall(expr, __FILE__, __LINE__)
-#define openCLVerifyCall(res) ___openCLSafeCall(res, __FILE__, __LINE__)
-#endif
+#define openCLSafeCall(expr)  ___openCLSafeCall(expr, __FILE__, __LINE__, CV_Func)
+#define openCLVerifyCall(res) ___openCLSafeCall(res, __FILE__, __LINE__, CV_Func)
 
 
 namespace cv


### PR DESCRIPTION
Also, I made a separate macro for the current function name, which helps simplify a lot of code that uses it.
