### PR TITLE
Support PyString_AsString() in Python 3 < 3.3

### DIFF
--- a/modules/python/src2/pycompat.hpp
+++ b/modules/python/src2/pycompat.hpp
@@ -56,9 +56,15 @@
 // Python3 strings are unicode, these defines mimic the Python2 functionality.
 #define PyString_Check PyUnicode_Check
 #define PyString_FromString PyUnicode_FromString
-#define PyString_AsString PyUnicode_AsUTF8
 #define PyString_FromStringAndSize PyUnicode_FromStringAndSize
 #define PyString_Size PyUnicode_GET_SIZE
+
+// PyUnicode_AsUTF8 isn't available until Python 3.3
+#if (PY_VERSION_HEX < 0x03030000)
+#define PyString_AsString _PyUnicode_AsString
+#else
+#define PyString_AsString PyUnicode_AsUTF8
+#endif
 #endif
 
 #endif // END HEADER GUARD


### PR DESCRIPTION
In Python 3, version 3.3+, PyUnicode_AsUTF8() provides similar
functionality to Python 2's PyString_AsString().

In older versions of Python 3, there is no public function to provide
the same functionality.  However, the "internal" _PyUnicode_AsString()
does provide that functionality, so use it to replace
PyString_AsString().

With this patch, cv2 should compile for Python 3.[0-2].
