### PR TITLE
Removed "using namespace cv" from imagestorage.h

### DIFF
--- a/apps/traincascade/HOGfeatures.cpp
+++ b/apps/traincascade/HOGfeatures.cpp
@@ -5,6 +5,7 @@
 #include "cascadeclassifier.h"
 
 using namespace std;
+using namespace cv;
 
 CvHOGFeatureParams::CvHOGFeatureParams()
 {

--- a/apps/traincascade/HOGfeatures.h
+++ b/apps/traincascade/HOGfeatures.h
@@ -20,23 +20,23 @@ class CvHOGEvaluator : public CvFeatureEvaluator
 public:
     virtual ~CvHOGEvaluator() {}
     virtual void init(const CvFeatureParams *_featureParams,
-        int _maxSampleCount, Size _winSize );
-    virtual void setImage(const Mat& img, uchar clsLabel, int idx);
+        int _maxSampleCount, cv::Size _winSize );
+    virtual void setImage(const cv::Mat& img, uchar clsLabel, int idx);
     virtual float operator()(int varIdx, int sampleIdx) const;
-    virtual void writeFeatures( FileStorage &fs, const Mat& featureMap ) const;
+    virtual void writeFeatures( cv::FileStorage &fs, const cv::Mat& featureMap ) const;
 protected:
     virtual void generateFeatures();
-    virtual void integralHistogram(const Mat &img, std::vector<Mat> &histogram, Mat &norm, int nbins) const;
+    virtual void integralHistogram(const cv::Mat &img, std::vector<cv::Mat> &histogram, cv::Mat &norm, int nbins) const;
     class Feature
     {
     public:
         Feature();
         Feature( int offset, int x, int y, int cellW, int cellH );
-        float calc( const std::vector<Mat> &_hists, const Mat &_normSum, size_t y, int featComponent ) const;
-        void write( FileStorage &fs ) const;
-        void write( FileStorage &fs, int varIdx ) const;
+        float calc( const std::vector<cv::Mat> &_hists, const cv::Mat &_normSum, size_t y, int featComponent ) const;
+        void write( cv::FileStorage &fs ) const;
+        void write( cv::FileStorage &fs, int varIdx ) const;
 
-        Rect rect[N_CELLS]; //cells
+        cv::Rect rect[N_CELLS]; //cells
 
         struct
         {
@@ -45,8 +45,8 @@ protected:
     };
     std::vector<Feature> features;
 
-    Mat normSum; //for nomalization calculation (L1 or L2)
-    std::vector<Mat> hist;
+    cv::Mat normSum; //for nomalization calculation (L1 or L2)
+    std::vector<cv::Mat> hist;
 };
 
 inline float CvHOGEvaluator::operator()(int varIdx, int sampleIdx) const
@@ -57,7 +57,7 @@ inline float CvHOGEvaluator::operator()(int varIdx, int sampleIdx) const
     return features[featureIdx].calc( hist, normSum, sampleIdx, componentIdx);
 }
 
-inline float CvHOGEvaluator::Feature::calc( const std::vector<Mat>& _hists, const Mat& _normSum, size_t y, int featComponent ) const
+inline float CvHOGEvaluator::Feature::calc( const std::vector<cv::Mat>& _hists, const cv::Mat& _normSum, size_t y, int featComponent ) const
 {
     float normFactor;
     float res;

--- a/apps/traincascade/boost.cpp
+++ b/apps/traincascade/boost.cpp
@@ -48,6 +48,7 @@
 #endif
 
 using namespace std;
+using namespace cv;
 
 static inline double
 logRatio( double val )

--- a/apps/traincascade/boost.h
+++ b/apps/traincascade/boost.h
@@ -13,8 +13,8 @@ struct CvCascadeBoostParams : CvBoostParams
     CvCascadeBoostParams( int _boostType, float _minHitRate, float _maxFalseAlarm,
                           double _weightTrimRate, int _maxDepth, int _maxWeakCount );
     virtual ~CvCascadeBoostParams() {}
-    void write( FileStorage &fs ) const;
-    bool read( const FileNode &node );
+    void write( cv::FileStorage &fs ) const;
+    bool read( const cv::FileNode &node );
     virtual void printDefaults() const;
     virtual void printAttrs() const;
     virtual bool scanAttr( const std::string prmName, const std::string val);
@@ -45,7 +45,7 @@ struct CvCascadeBoostTrainData : CvDTreeTrainData
     virtual void free_train_data();
 
     const CvFeatureEvaluator* featureEvaluator;
-    Mat valCache; // precalculated feature values (CV_32FC1)
+    cv::Mat valCache; // precalculated feature values (CV_32FC1)
     CvMat _resp; // for casting
     int numPrecalcVal, numPrecalcIdx;
 };
@@ -54,9 +54,9 @@ class CvCascadeBoostTree : public CvBoostTree
 {
 public:
     virtual CvDTreeNode* predict( int sampleIdx ) const;
-    void write( FileStorage &fs, const Mat& featureMap );
-    void read( const FileNode &node, CvBoost* _ensemble, CvDTreeTrainData* _data );
-    void markFeaturesInMap( Mat& featureMap );
+    void write( cv::FileStorage &fs, const cv::Mat& featureMap );
+    void read( const cv::FileNode &node, CvBoost* _ensemble, CvDTreeTrainData* _data );
+    void markFeaturesInMap( cv::Mat& featureMap );
 protected:
     virtual void split_node_data( CvDTreeNode* n );
 };
@@ -70,10 +70,10 @@ public:
     virtual float predict( int sampleIdx, bool returnSum = false ) const;
 
     float getThreshold() const { return threshold; }
-    void write( FileStorage &fs, const Mat& featureMap ) const;
-    bool read( const FileNode &node, const CvFeatureEvaluator* _featureEvaluator,
+    void write( cv::FileStorage &fs, const cv::Mat& featureMap ) const;
+    bool read( const cv::FileNode &node, const CvFeatureEvaluator* _featureEvaluator,
                const CvCascadeBoostParams& _params );
-    void markUsedFeaturesInMap( Mat& featureMap );
+    void markUsedFeaturesInMap( cv::Mat& featureMap );
 protected:
     virtual bool set_params( const CvBoostParams& _params );
     virtual void update_weights( CvBoostTree* tree );

--- a/apps/traincascade/cascadeclassifier.cpp
+++ b/apps/traincascade/cascadeclassifier.cpp
@@ -4,6 +4,7 @@
 #include <queue>
 
 using namespace std;
+using namespace cv;
 
 static const char* stageTypes[] = { CC_BOOST };
 static const char* featureTypes[] = { CC_HAAR, CC_LBP, CC_HOG };

--- a/apps/traincascade/cascadeclassifier.h
+++ b/apps/traincascade/cascadeclassifier.h
@@ -72,8 +72,8 @@ public:
 
     CvCascadeParams();
     CvCascadeParams( int _stageType, int _featureType );
-    void write( FileStorage &fs ) const;
-    bool read( const FileNode &node );
+    void write( cv::FileStorage &fs ) const;
+    bool read( const cv::FileNode &node );
 
     void printDefaults() const;
     void printAttrs() const;
@@ -81,7 +81,7 @@ public:
 
     int stageType;
     int featureType;
-    Size winSize;
+    cv::Size winSize;
 };
 
 class CvCascadeClassifier
@@ -104,20 +104,20 @@ private:
     bool updateTrainingSet( double& acceptanceRatio );
     int fillPassedSamples( int first, int count, bool isPositive, int64& consumed );
 
-    void writeParams( FileStorage &fs ) const;
-    void writeStages( FileStorage &fs, const Mat& featureMap ) const;
-    void writeFeatures( FileStorage &fs, const Mat& featureMap ) const;
-    bool readParams( const FileNode &node );
-    bool readStages( const FileNode &node );
+    void writeParams( cv::FileStorage &fs ) const;
+    void writeStages( cv::FileStorage &fs, const cv::Mat& featureMap ) const;
+    void writeFeatures( cv::FileStorage &fs, const cv::Mat& featureMap ) const;
+    bool readParams( const cv::FileNode &node );
+    bool readStages( const cv::FileNode &node );
 
-    void getUsedFeaturesIdxMap( Mat& featureMap );
+    void getUsedFeaturesIdxMap( cv::Mat& featureMap );
 
     CvCascadeParams cascadeParams;
-    Ptr<CvFeatureParams> featureParams;
-    Ptr<CvCascadeBoostParams> stageParams;
+    cv::Ptr<CvFeatureParams> featureParams;
+    cv::Ptr<CvCascadeBoostParams> stageParams;
 
-    Ptr<CvFeatureEvaluator> featureEvaluator;
-    std::vector< Ptr<CvCascadeBoost> > stageClassifiers;
+    cv::Ptr<CvFeatureEvaluator> featureEvaluator;
+    std::vector< cv::Ptr<CvCascadeBoost> > stageClassifiers;
     CvCascadeImageReader imgReader;
     int numStages, curNumSamples;
     int numPos, numNeg;

--- a/apps/traincascade/features.cpp
+++ b/apps/traincascade/features.cpp
@@ -4,6 +4,7 @@
 #include "cascadeclassifier.h"
 
 using namespace std;
+using namespace cv;
 
 float calcNormFactor( const Mat& sum, const Mat& sqSum )
 {

--- a/apps/traincascade/haarfeatures.cpp
+++ b/apps/traincascade/haarfeatures.cpp
@@ -5,6 +5,7 @@
 #include "cascadeclassifier.h"
 
 using namespace std;
+using namespace cv;
 
 CvHaarFeatureParams::CvHaarFeatureParams() : mode(BASIC)
 {

--- a/apps/traincascade/haarfeatures.h
+++ b/apps/traincascade/haarfeatures.h
@@ -18,8 +18,8 @@ public:
     CvHaarFeatureParams( int _mode );
 
     virtual void init( const CvFeatureParams& fp );
-    virtual void write( FileStorage &fs ) const;
-    virtual bool read( const FileNode &node );
+    virtual void write( cv::FileStorage &fs ) const;
+    virtual bool read( const cv::FileNode &node );
 
     virtual void printDefaults() const;
     virtual void printAttrs() const;
@@ -32,11 +32,11 @@ class CvHaarEvaluator : public CvFeatureEvaluator
 {
 public:
     virtual void init(const CvFeatureParams *_featureParams,
-        int _maxSampleCount, Size _winSize );
-    virtual void setImage(const Mat& img, uchar clsLabel, int idx);
+        int _maxSampleCount, cv::Size _winSize );
+    virtual void setImage(const cv::Mat& img, uchar clsLabel, int idx);
     virtual float operator()(int featureIdx, int sampleIdx) const;
-    virtual void writeFeatures( FileStorage &fs, const Mat& featureMap ) const;
-    void writeFeature( FileStorage &fs, int fi ) const; // for old file fornat
+    virtual void writeFeatures( cv::FileStorage &fs, const cv::Mat& featureMap ) const;
+    void writeFeature( cv::FileStorage &fs, int fi ) const; // for old file fornat
 protected:
     virtual void generateFeatures();
 
@@ -48,13 +48,13 @@ protected:
             int x0, int y0, int w0, int h0, float wt0,
             int x1, int y1, int w1, int h1, float wt1,
             int x2 = 0, int y2 = 0, int w2 = 0, int h2 = 0, float wt2 = 0.0F );
-        float calc( const Mat &sum, const Mat &tilted, size_t y) const;
-        void write( FileStorage &fs ) const;
+        float calc( const cv::Mat &sum, const cv::Mat &tilted, size_t y) const;
+        void write( cv::FileStorage &fs ) const;
 
         bool  tilted;
         struct
         {
-            Rect r;
+            cv::Rect r;
             float weight;
         } rect[CV_HAAR_FEATURE_MAX];
 
@@ -65,9 +65,9 @@ protected:
     };
 
     std::vector<Feature> features;
-    Mat  sum;         /* sum images (each row represents image) */
-    Mat  tilted;      /* tilted sum images (each row represents image) */
-    Mat  normfactor;  /* normalization factor */
+    cv::Mat  sum;         /* sum images (each row represents image) */
+    cv::Mat  tilted;      /* tilted sum images (each row represents image) */
+    cv::Mat  normfactor;  /* normalization factor */
 };
 
 inline float CvHaarEvaluator::operator()(int featureIdx, int sampleIdx) const
@@ -76,7 +76,7 @@ inline float CvHaarEvaluator::operator()(int featureIdx, int sampleIdx) const
     return !nf ? 0.0f : (features[featureIdx].calc( sum, tilted, sampleIdx)/nf);
 }
 
-inline float CvHaarEvaluator::Feature::calc( const Mat &_sum, const Mat &_tilted, size_t y) const
+inline float CvHaarEvaluator::Feature::calc( const cv::Mat &_sum, const cv::Mat &_tilted, size_t y) const
 {
     const int* img = tilted ? _tilted.ptr<int>((int)y) : _sum.ptr<int>((int)y);
     float ret = rect[0].weight * (img[fastRect[0].p0] - img[fastRect[0].p1] - img[fastRect[0].p2] + img[fastRect[0].p3] ) +

--- a/apps/traincascade/imagestorage.cpp
+++ b/apps/traincascade/imagestorage.cpp
@@ -8,6 +8,7 @@
 #include <fstream>
 
 using namespace std;
+using namespace cv;
 
 bool CvCascadeImageReader::create( const string _posFilename, const string _negFilename, Size _winSize )
 {

--- a/apps/traincascade/imagestorage.h
+++ b/apps/traincascade/imagestorage.h
@@ -3,15 +3,13 @@
 
 #include "highgui.h"
 
-using namespace cv;
-
 class CvCascadeImageReader
 {
 public:
-    bool create( const std::string _posFilename, const std::string _negFilename, Size _winSize );
+    bool create( const std::string _posFilename, const std::string _negFilename, cv::Size _winSize );
     void restart() { posReader.restart(); }
-    bool getNeg(Mat &_img) { return negReader.get( _img ); }
-    bool getPos(Mat &_img) { return posReader.get( _img ); }
+    bool getNeg(cv::Mat &_img) { return negReader.get( _img ); }
+    bool getPos(cv::Mat &_img) { return posReader.get( _img ); }
 
 private:
     class PosReader
@@ -20,7 +18,7 @@ private:
         PosReader();
         virtual ~PosReader();
         bool create( const std::string _filename );
-        bool get( Mat &_img );
+        bool get( cv::Mat &_img );
         void restart();
 
         short* vec;
@@ -35,18 +33,18 @@ private:
     {
     public:
         NegReader();
-        bool create( const std::string _filename, Size _winSize );
-        bool get( Mat& _img );
+        bool create( const std::string _filename, cv::Size _winSize );
+        bool get( cv::Mat& _img );
         bool nextImg();
 
-        Mat     src, img;
+        cv::Mat     src, img;
         std::vector<std::string> imgFilenames;
-        Point   offset, point;
+        cv::Point   offset, point;
         float   scale;
         float   scaleFactor;
         float   stepFactor;
         size_t  last, round;
-        Size    winSize;
+        cv::Size    winSize;
     } negReader;
 };
 

--- a/apps/traincascade/lbpfeatures.cpp
+++ b/apps/traincascade/lbpfeatures.cpp
@@ -4,6 +4,8 @@
 #include "lbpfeatures.h"
 #include "cascadeclassifier.h"
 
+using namespace cv;
+
 CvLBPFeatureParams::CvLBPFeatureParams()
 {
     maxCatCount = 256;

--- a/apps/traincascade/lbpfeatures.h
+++ b/apps/traincascade/lbpfeatures.h
@@ -15,11 +15,11 @@ class CvLBPEvaluator : public CvFeatureEvaluator
 public:
     virtual ~CvLBPEvaluator() {}
     virtual void init(const CvFeatureParams *_featureParams,
-        int _maxSampleCount, Size _winSize );
-    virtual void setImage(const Mat& img, uchar clsLabel, int idx);
+        int _maxSampleCount, cv::Size _winSize );
+    virtual void setImage(const cv::Mat& img, uchar clsLabel, int idx);
     virtual float operator()(int featureIdx, int sampleIdx) const
     { return (float)features[featureIdx].calc( sum, sampleIdx); }
-    virtual void writeFeatures( FileStorage &fs, const Mat& featureMap ) const;
+    virtual void writeFeatures( cv::FileStorage &fs, const cv::Mat& featureMap ) const;
 protected:
     virtual void generateFeatures();
 
@@ -28,18 +28,18 @@ protected:
     public:
         Feature();
         Feature( int offset, int x, int y, int _block_w, int _block_h  );
-        uchar calc( const Mat& _sum, size_t y ) const;
-        void write( FileStorage &fs ) const;
+        uchar calc( const cv::Mat& _sum, size_t y ) const;
+        void write( cv::FileStorage &fs ) const;
 
-        Rect rect;
+        cv::Rect rect;
         int p[16];
     };
     std::vector<Feature> features;
 
-    Mat sum;
+    cv::Mat sum;
 };
 
-inline uchar CvLBPEvaluator::Feature::calc(const Mat &_sum, size_t y) const
+inline uchar CvLBPEvaluator::Feature::calc(const cv::Mat &_sum, size_t y) const
 {
     const int* psum = _sum.ptr<int>((int)y);
     int cval = psum[p[5]] - psum[p[6]] - psum[p[9]] + psum[p[10]];

--- a/apps/traincascade/traincascade.cpp
+++ b/apps/traincascade/traincascade.cpp
@@ -4,6 +4,7 @@
 #include "cascadeclassifier.h"
 
 using namespace std;
+using namespace cv;
 
 int main( int argc, char* argv[] )
 {

--- a/apps/traincascade/traincascade_features.h
+++ b/apps/traincascade/traincascade_features.h
@@ -30,13 +30,13 @@
     (p3) = (rect).x + (rect).width - (rect).height                        \
            + (step) * ((rect).y + (rect).width + (rect).height);
 
-float calcNormFactor( const Mat& sum, const Mat& sqSum );
+float calcNormFactor( const cv::Mat& sum, const cv::Mat& sqSum );
 
 template<class Feature>
-void _writeFeatures( const std::vector<Feature> features, FileStorage &fs, const Mat& featureMap )
+void _writeFeatures( const std::vector<Feature> features, cv::FileStorage &fs, const cv::Mat& featureMap )
 {
     fs << FEATURES << "[";
-    const Mat_<int>& featureMap_ = (const Mat_<int>&)featureMap;
+    const cv::Mat_<int>& featureMap_ = (const cv::Mat_<int>&)featureMap;
     for ( int fi = 0; fi < featureMap.cols; fi++ )
         if ( featureMap_(0, fi) >= 0 )
         {
@@ -53,8 +53,8 @@ public:
     CvParams();
     virtual ~CvParams() {}
     // from|to file
-    virtual void write( FileStorage &fs ) const = 0;
-    virtual bool read( const FileNode &node ) = 0;
+    virtual void write( cv::FileStorage &fs ) const = 0;
+    virtual bool read( const cv::FileNode &node ) = 0;
     // from|to screen
     virtual void printDefaults() const;
     virtual void printAttrs() const;
@@ -68,9 +68,9 @@ public:
     enum { HAAR = 0, LBP = 1, HOG = 2 };
     CvFeatureParams();
     virtual void init( const CvFeatureParams& fp );
-    virtual void write( FileStorage &fs ) const;
-    virtual bool read( const FileNode &node );
-    static Ptr<CvFeatureParams> create( int featureType );
+    virtual void write( cv::FileStorage &fs ) const;
+    virtual bool read( const cv::FileNode &node );
+    static cv::Ptr<CvFeatureParams> create( int featureType );
     int maxCatCount; // 0 in case of numerical features
     int featSize; // 1 in case of simple features (HAAR, LBP) and N_BINS(9)*N_CELLS(4) in case of Dalal's HOG features
 };
@@ -80,25 +80,25 @@ class CvFeatureEvaluator
 public:
     virtual ~CvFeatureEvaluator() {}
     virtual void init(const CvFeatureParams *_featureParams,
-                      int _maxSampleCount, Size _winSize );
-    virtual void setImage(const Mat& img, uchar clsLabel, int idx);
-    virtual void writeFeatures( FileStorage &fs, const Mat& featureMap ) const = 0;
+                      int _maxSampleCount, cv::Size _winSize );
+    virtual void setImage(const cv::Mat& img, uchar clsLabel, int idx);
+    virtual void writeFeatures( cv::FileStorage &fs, const cv::Mat& featureMap ) const = 0;
     virtual float operator()(int featureIdx, int sampleIdx) const = 0;
-    static Ptr<CvFeatureEvaluator> create(int type);
+    static cv::Ptr<CvFeatureEvaluator> create(int type);
 
     int getNumFeatures() const { return numFeatures; }
     int getMaxCatCount() const { return featureParams->maxCatCount; }
     int getFeatureSize() const { return featureParams->featSize; }
-    const Mat& getCls() const { return cls; }
+    const cv::Mat& getCls() const { return cls; }
     float getCls(int si) const { return cls.at<float>(si, 0); }
 protected:
     virtual void generateFeatures() = 0;
 
     int npos, nneg;
     int numFeatures;
-    Size winSize;
+    cv::Size winSize;
     CvFeatureParams *featureParams;
-    Mat cls;
+    cv::Mat cls;
 };
 
 #endif


### PR DESCRIPTION
Fixes an issue where `mat.hpp`'s `ACCESS_MASK` was being pulled into global scope and clashing with an `ACCESS_MASK` defined in windows headers.

http://answers.opencv.org/question/23608/ambiguous-symbol-error-with-windows-8-sdk-and/
