### PR TITLE
Fixed the "image sequence" capture not failing when a pattern isn't found

### DIFF
--- a/modules/highgui/src/cap_images.cpp
+++ b/modules/highgui/src/cap_images.cpp
@@ -203,7 +203,7 @@ static char* icvExtractPattern(const char *filename, unsigned *offset)
         for(at = name; *at && !isdigit(*at); at++)
             ;
 
-        if(!at)
+        if(!*at)
             return 0;
 
         sscanf(at, "%u", offset);


### PR DESCRIPTION
`at` can't be a null pointer, so the condition was always false, and a nonsensical pattern like `image.png%00d` was being inferred.
