### PR TITLE
Replace the image used in the Highgui_Video.ffmpeg_image test

### DIFF
--- a/modules/highgui/test/test_ffmpeg.cpp
+++ b/modules/highgui/test/test_ffmpeg.cpp
@@ -154,7 +154,7 @@ public:
     {
         try
         {
-            string filename = ts->get_data_path() + "../cv/features2d/tsukuba.png";
+            string filename = ts->get_data_path() + "readwrite/ordinary.bmp";
             VideoCapture cap(filename);
             Mat img0 = imread(filename, 1);
             Mat img, img_next;


### PR DESCRIPTION
Our prebuilt FFmpeg Windows binaries don't have PNG support enabled (because that requires zlib), so that makes a PNG image a bad choice for this test.

When FFmpeg doesn't support PNG, `VideoCapture` falls back to the "image sequence" implementation, which doesn't work for single images.
