### PR TITLE
In the image sequence capture, only search for the ordinal in the file name

### DIFF
--- a/modules/highgui/src/cap_images.cpp
+++ b/modules/highgui/src/cap_images.cpp
@@ -200,8 +200,18 @@ static char* icvExtractPattern(const char *filename, unsigned *offset)
     }
     else // no pattern filename was given - extract the pattern
     {
-        for(at = name; *at && !isdigit(*at); at++)
-            ;
+        at = name;
+
+        // ignore directory names
+        char *slash = strrchr(at, '/');
+        if (slash) at = slash + 1;
+
+#ifdef _WIN32
+        slash = strrchr(at, '\\');
+        if (slash) at = slash + 1;
+#endif
+
+        while (*at && !isdigit(*at)) at++;
 
         if(!*at)
             return 0;


### PR DESCRIPTION
Searching in directory names can yield confusing results; e.g. if the input is "jpeg2000/image1.jp2", it will infer the pattern "jpeg%04d/image1.jp2", which is likely not what the user intended.

If the user really desires for the variable part to be in the directory name, it can always use an explicit pattern.
