### PR TITLE
Add missing limits include

### DIFF
--- a/modules/cudaimgproc/src/precomp.hpp
+++ b/modules/cudaimgproc/src/precomp.hpp
@@ -59,4 +59,6 @@
 #  include "opencv2/cudafilters.hpp"
 #endif
 
+#include <limits>
+
 #endif /* __OPENCV_PRECOMP_H__ */


### PR DESCRIPTION
Without limits included, several CUDA related files fail to compile with
GCC on Ubuntu, with errors like:

modules/cudaimgproc/src/hough_lines.cpp:136:9: error: ‘numeric_limits’ is not a member of ‘std’
