### PR TITLE
In the example in OpenCVConfig.cmake.in, explicitly add the include paths

### DIFF
--- a/cmake/templates/OpenCVConfig.cmake.in
+++ b/cmake/templates/OpenCVConfig.cmake.in
@@ -7,6 +7,7 @@
 #    In your CMakeLists.txt, add these lines:
 #
 #    find_package(OpenCV REQUIRED)
+#    include_directories(${OpenCV_INCLUDE_DIRS})
 #    target_link_libraries(MY_TARGET_NAME ${OpenCV_LIBS})
 #
 #    Or you can search for specific OpenCV modules:


### PR DESCRIPTION
After #1801, the include directories are no longer added automatically, so we should show the user how to do that.
