### PR TITLE
Response to bug #3384 I've applied a proposed fix that was under #3017

### DIFF
--- a/modules/features2d/src/orb.cpp
+++ b/modules/features2d/src/orb.cpp
@@ -620,7 +620,8 @@ static void computeKeyPoints(const std::vector<Mat>& imagePyramid,
 
     // fill the extractors and descriptors for the corresponding scales
     float factor = (float)(1.0 / scaleFactor);
-    float ndesiredFeaturesPerScale = nfeatures*(1 - factor)/(1 - (float)std::pow((double)factor, (double)nlevels));
+        float factor2D=factor*factor;
+    float ndesiredFeaturesPerScale = nfeatures*(1 - factor2D)/(1 - (float)std::pow((double)factor2D, (double)nlevels));
 
     int sumFeatures = 0;
     for( int level = 0; level < nlevels-1; level++ )


### PR DESCRIPTION
I too had the problem described in bug #3384. On a whim (and after tearing my hair out for days) I tried to apply Zoltan Prohaszka's unused solution to his old bug #3017 - cv2.ORB works great now. Unfortunately I cannot be sure that what I changed was the source of the problem. And I can't say why Zoltan's idea wasn't already being used. I wasn't very scientific about changing one build variable at a time. I suspect the gcc version going from 4.4 to 4.8 or QT5 changes (I'm using the QT5 'stable' repo version) could be just as likely the reason everything is running better than ever now. I say better than ever because ORB is handling my items at small/distant scales about twice as well as before. That behaviour seems more like what the Zoltan change would have wrought. I can supply more detailed info about the build environment if wanted/needed.

General configuration for OpenCV 3.0.0-dev =====================================
  Version control:               2.4.7-rc1-2227-g6ad71f5

  Platform:
    Host:                        Linux 3.11.0-14-generic x86_64
    CMake:                       2.8.11.2
    CMake generator:             Unix Makefiles
    CMake build tool:            /usr/bin/make
    Configuration:               Release

  C/C++:
    Built as dynamic libs?:      YES
    C++ Compiler:                /usr/bin/c++  (ver 4.8.1)
    C++ flags (Release):         -fsigned-char -W -Wall -Werror=return-type -Werror=non-virtual-dtor -Werror=address -Werror=sequence-point -Wformat -Werror=format-security -Wmissing-declarations -Wundef -Winit-self -Wpointer-arith -Wshadow -Wsign-promo -Wno-narrowing -Wno-delete-non-virtual-dtor -fdiagnostics-show-option -Wno-long-long -pthread -fomit-frame-pointer -msse -msse2 -mavx -ffunction-sections -fvisibility=hidden -fvisibility-inlines-hidden -O3 -DNDEBUG  -DNDEBUG
    C++ flags (Debug):           -fsigned-char -W -Wall -Werror=return-type -Werror=non-virtual-dtor -Werror=address -Werror=sequence-point -Wformat -Werror=format-security -Wmissing-declarations -Wundef -Winit-self -Wpointer-arith -Wshadow -Wsign-promo -Wno-narrowing -Wno-delete-non-virtual-dtor -fdiagnostics-show-option -Wno-long-long -pthread -fomit-frame-pointer -msse -msse2 -mavx -ffunction-sections -fvisibility=hidden -fvisibility-inlines-hidden -g  -O0 -DDEBUG -D_DEBUG -ggdb3
    C Compiler:                  /usr/bin/cc
    C flags (Release):           -fsigned-char -W -Wall -Werror=return-type -Werror=non-virtual-dtor -Werror=address -Werror=sequence-point -Wformat -Werror=format-security -Wmissing-declarations -Wmissing-prototypes -Wstrict-prototypes -Wundef -Winit-self -Wpointer-arith -Wshadow -Wno-narrowing -fdiagnostics-show-option -Wno-long-long -pthread -fomit-frame-pointer -msse -msse2 -mavx -ffunction-sections -fvisibility=hidden -O3 -DNDEBUG  -DNDEBUG
    C flags (Debug):             -fsigned-char -W -Wall -Werror=return-type -Werror=non-virtual-dtor -Werror=address -Werror=sequence-point -Wformat -Werror=format-security -Wmissing-declarations -Wmissing-prototypes -Wstrict-prototypes -Wundef -Winit-self -Wpointer-arith -Wshadow -Wno-narrowing -fdiagnostics-show-option -Wno-long-long -pthread -fomit-frame-pointer -msse -msse2 -mavx -ffunction-sections -fvisibility=hidden -g  -O0 -DDEBUG -D_DEBUG -ggdb3
    Linker flags (Release):  
    Linker flags (Debug):  
    Precompiled headers:         YES

  OpenCV modules:
    To be built:                 cudev core flann imgproc highgui features2d calib3d ml objdetect video ocl bioinspired cudaarithm nonfree contrib cudalegacy cudawarping cuda cudafilters cudaimgproc legacy cudabgsegm cudacodec cudafeatures2d cudaoptflow cudastereo photo java optim softcascade python shape stitching superres ts videostab
    Disabled:                    viz world
    Disabled by dependency:      -
    Unavailable:                 androidcamera matlab

  GUI: 
    QT 5.x:                      YES (ver 5.2.0)
    QT OpenGL support:           YES (Qt5::OpenGL 5.2.0)
    OpenGL support:              YES (/usr/lib/x86_64-linux-gnu/libGLU.so /usr/lib/x86_64-linux-gnu/libGL.so /usr/lib/x86_64-linux-gnu/libSM.so /usr/lib/x86_64-linux-gnu/libICE.so /usr/lib/x86_64-linux-gnu/libX11.so /usr/lib/x86_64-linux-gnu/libXext.so)

  Media I/O: 
    ZLib:                        build (ver 1.2.8)
    JPEG:                        build (ver 90)
    WEBP:                        /usr/lib/x86_64-linux-gnu/libwebp.so (ver encoder: 0x0201)
    PNG:                         build (ver 1.5.12)
    TIFF:                        build (ver 42 - 4.0.2)
    JPEG 2000:                   build (ver 1.900.1)
    OpenEXR:                     build (ver 1.7.1)

  Video I/O:
    DC1394 1.x:                  NO
    DC1394 2.x:                  YES (ver 2.2.1)
    FFMPEG:                      YES
      codec:                     YES (ver 53.35.0)
      format:                    YES (ver 53.21.1)
      util:                      YES (ver 51.22.1)
      swscale:                   YES (ver 2.1.0)
      gentoo-style:              YES
    GStreamer:  
      base:                      YES (ver 1.2.0)
      video:                     YES (ver 1.2.0)
      app:                       YES (ver 1.2.0)
      riff:                      YES (ver 1.2.0)
      pbutils:                   YES (ver 1.2.0)
    OpenNI:                      NO
    OpenNI PrimeSensor Modules:  NO
    PvAPI:                       NO
    GigEVisionSDK:               NO
    UniCap:                      NO
    UniCap ucil:                 NO
    V4L/V4L2:                    Using libv4l (ver 0.8.9)
    XIMEA:                       NO
    Xine:                        YES (ver 1.2.3)

  Other third-party libraries:
    Use IPP:                     7.1.1 [7.1.1]
         at:                     /opt/intel/composer_xe_2013.1.117/ipp
    Use Eigen:                   YES (ver 3.2.0)
    Use TBB:                     YES (ver 4.1 interface 6105)
    Use OpenMP:                  NO
    Use GCD                      NO
    Use Concurrency              NO
    Use C=:                      NO
    Use Cuda:                    YES (ver 5.5)
    Use OpenCL:                  YES

  NVIDIA CUDA
    Use CUFFT:                   YES
    Use CUBLAS:                  YES
    USE NVCUVID:                 YES
    NVIDIA GPU arch:             30 35
    NVIDIA PTX archs:
    Use fast math:               NO

  OpenCL:
    Version:                     dynamic
    Include path:                /home/suber1/js_opencv/3rdparty/include/opencl/1.2
    Use AMDFFT:                  NO
    Use AMDBLAS:                 NO

  Python:
    Interpreter:                 /usr/bin/python2.7 (ver 2.7.5)
    Libraries:                   /usr/lib/x86_64-linux-gnu/libpython2.7.so (ver 2.7.5+)
    numpy:                       /usr/local/lib/python2.7/dist-packages/numpy/core/include (ver 1.9.0.dev-74e5c12)
    packages path:               lib/python2.7/dist-packages

  Java:
    ant:                         /usr/bin/ant (ver 1.9.2)
    JNI:                         /usr/lib/jvm/java-7-oracle/include /usr/lib/jvm/java-7-oracle/include/linux /usr/lib/jvm/java-7-oracle/include
    Java tests:                  YES

  Matlab:
    mex:                         NO

  Documentation:
    Build Documentation:         YES
    Sphinx:                      /usr/bin/sphinx-build (ver 1.1.3)
    PdfLaTeX compiler:           /usr/bin/pdflatex
    PlantUML:                    NO

  Tests and samples:
    Tests:                       YES
    Performance tests:           YES
    C/C++ Examples:              YES

  Install path:                  /usr/local
##   cvconfig.h is in:              /home/suber1/js_opencv/jsbuild

> > > exit()
> > > suber1@HAL-9001:~/js_opencv/jsbuild$ sudo update-alternatives --config gcc
> > > There are 3 choices for the alternative gcc (providing /usr/bin/gcc).
##   Selection    Path              Priority   Status
- 0            /usr/bin/gcc-4.8   60        auto mode
  1            /usr/bin/gcc-4.4   20        manual mode
  2            /usr/bin/gcc-4.7   50        manual mode
  3            /usr/bin/gcc-4.8   60        manual mode
