### PR TITLE
Give CvSVM a private copy constructor & assignment operator

### DIFF
--- a/modules/ml/include/opencv2/ml/ml.hpp
+++ b/modules/ml/include/opencv2/ml/ml.hpp
@@ -548,6 +548,10 @@ protected:
 
     CvSVMSolver* solver;
     CvSVMKernel* kernel;
+
+private:
+    CvSVM(const CvSVM&);
+    CvSVM& operator = (const CvSVM&);
 };
 
 /****************************************************************************************\


### PR DESCRIPTION
The implicitly generated ones don't work properly, and I don't want to write proper ones. :smile: 

"Fixes" http://code.opencv.org/issues/3358.
