### PR TITLE
Simplify the Windows implementation of CV_XADD

### DIFF
--- a/modules/core/include/opencv2/core/cvdef.h
+++ b/modules/core/include/opencv2/core/cvdef.h
@@ -458,15 +458,8 @@ CV_INLINE int cvIsInf( double value )
 #      define CV_XADD(addr, delta) (int)__sync_fetch_and_add((unsigned*)(addr), (unsigned)(delta))
 #    endif
 #  endif
-#elif (defined WIN32 || defined _WIN32 || defined WINCE) && (!defined RC_INVOKED)
-#  if !defined(_M_AMD64) && !defined(_M_IA64) && !defined(_M_ARM)
-     CV_EXTERN_C __declspec(dllimport) long __stdcall InterlockedExchangeAdd(long volatile *Addend, long Value);
-#    define CV_XADD(addr, delta) (int)InterlockedExchangeAdd((long volatile*)addr, delta)
-#  else
-     CV_EXTERN_C long _InterlockedExchangeAdd (long volatile *Addend, long Value);
-#    pragma intrinsic(_InterlockedExchangeAdd)
-#    define CV_XADD(addr, delta) (int)_InterlockedExchangeAdd((long volatile*)addr, delta)
-#  endif
+#elif defined _MSC_VER && !defined RC_INVOKED
+#  define CV_XADD(addr, delta) (int)_InterlockedExchangeAdd((long volatile*)addr, delta)
 #else
    CV_INLINE CV_XADD(int* addr, int delta) { int tmp = *addr; *addr += delta; return tmp; }
 #endif


### PR DESCRIPTION
`_InterlockedExchangeAdd` is a Visual Studio intrinsic that's available for all architectures and in all VS versions that we care about. It's also potentially faster than the underscore-less function, since it's an intrinsic. We also don't need to declare it ourselves.

It is, however, a Visual Studio-specific intrinsic, so I changed the preprocessing condition accordingly.

Fixes http://code.opencv.org/issues/3365.
