### PR TITLE
Applied fix mentioned in bugreport #3370. Seems to solve the issue.

### DIFF
--- a/apps/traincascade/imagestorage.cpp
+++ b/apps/traincascade/imagestorage.cpp
@@ -67,7 +67,7 @@ bool CvCascadeImageReader::NegReader::nextImg()
         _offset.x = min( (int)round % winSize.width, src.cols - winSize.width );
         _offset.y = min( (int)round / winSize.width, src.rows - winSize.height );
         if( !src.empty() && src.type() == CV_8UC1
-                && offset.x >= 0 && offset.y >= 0 )
+                && _offset.x >= 0 && _offset.y >= 0 )
             break;
     }
 


### PR DESCRIPTION
Small bug in the nextImg() function leading to a endless loop once a negative image is supplied, smaller than the actual window size. More info at: code.opencv.org/issues/3370
