### PR TITLE
Bugfix 3306

### DIFF
--- a/modules/highgui/doc/reading_and_writing_images_and_video.rst
+++ b/modules/highgui/doc/reading_and_writing_images_and_video.rst
@@ -253,7 +253,7 @@ VideoCapture constructors.
 .. ocv:cfunction:: CvCapture* cvCaptureFromFile( const char* filename )
 .. ocv:pyoldfunction:: cv.CaptureFromFile(filename) -> CvCapture
 
-    :param filename: name of the opened video file
+    :param filename: name of the opened video file (eg. video.avi) or image sequence (eg. img_%02d.jpg, which will read samples like img_00.jpg, img_01.jpg, img_02.jpg, ...)
 
     :param device: id of the opened video capturing device (i.e. a camera index). If there is a single camera connected, just pass 0.
 
@@ -270,7 +270,7 @@ Open video file or a capturing device for video capturing
 .. ocv:pyfunction:: cv2.VideoCapture.open(filename) -> retval
 .. ocv:pyfunction:: cv2.VideoCapture.open(device) -> retval
 
-    :param filename: name of the opened video file
+    :param filename: name of the opened video file (eg. video.avi) or image sequence (eg. img_%02d.jpg, which will read samples like img_00.jpg, img_01.jpg, img_02.jpg, ...)
 
     :param device: id of the opened video capturing device (i.e. a camera index).
 

--- a/samples/cpp/image_sequence.cpp
+++ b/samples/cpp/image_sequence.cpp
@@ -1,0 +1,57 @@
+#include <opencv2/core/core.hpp>
+#include <opencv2/highgui/highgui.hpp>
+
+#include <iostream>
+
+using namespace cv;
+using namespace std;
+
+static void help(char** argv)
+{
+    cout << "\nThis sample shows you how to read a sequence of images using the VideoCapture interface.\n"
+         << "Usage: " << argv[0] << " <image_mask> (example mask: example_%02d.jpg)\n"
+         << "Image mask defines the name variation for the input images that have to be read as a sequence. \n"
+         << "Using the mask example_%02d.jpg will read in images labeled as 'example_00.jpg', 'example_01.jpg', etc."
+         << endl;
+}
+
+int main(int argc, char** argv)
+{
+    if(argc != 2)
+    {
+        help(argv);
+        return 1;
+    }
+
+    string first_file = argv[1];
+    VideoCapture sequence(first_file);
+
+    if (!sequence.isOpened())
+    {
+        cerr << "Failed to open the image sequence!\n" << endl;
+        return 1;
+    }
+
+    Mat image;
+    namedWindow("Image sequence | press ESC to close", 1);
+
+    for(;;)
+    {
+        // Read in image from sequence
+        sequence >> image;
+
+        // If no image was retrieved -> end of sequence
+        if(image.empty())
+        {
+            cout << "End of Sequence" << endl;
+            break;
+        }
+
+        imshow("Image sequence | press ESC to close", image);
+
+        if(waitKey(500) == 27)
+            break;
+    }
+
+    return 0;
+}


### PR DESCRIPTION
More info: http://code.opencv.org/issues/3306
Applied fixes for the interface of image sequence reading.
It is available in openCV 2.4.7 source code but not documented.

Basically the line is scanned in opposite direction now, in order not to cope with specific formatting in the rest of the string.

Have supplied a pull request to master in the past, but master also contains errors.
Will provide fix in seperate pull request. (https://github.com/Itseez/opencv/pull/1846)
