### PR TITLE
Fixed bugs in capturing of image sequences.

### DIFF
--- a/modules/highgui/doc/reading_and_writing_images_and_video.rst
+++ b/modules/highgui/doc/reading_and_writing_images_and_video.rst
@@ -250,7 +250,7 @@ VideoCapture constructors.
 .. ocv:cfunction:: CvCapture* cvCaptureFromCAM( int device )
 .. ocv:cfunction:: CvCapture* cvCaptureFromFile( const char* filename )
 
-    :param filename: name of the opened video file (eg. video.avi) or image sequence (eg. img%02d.jpg)
+    :param filename: name of the opened video file (eg. video.avi) or image sequence (eg. img_%02d.jpg, which will read samples like img_00.jpg, img_01.jpg, img_02.jpg, ...)
 
     :param device: id of the opened video capturing device (i.e. a camera index). If there is a single camera connected, just pass 0.
 
@@ -267,7 +267,7 @@ Open video file or a capturing device for video capturing
 .. ocv:pyfunction:: cv2.VideoCapture.open(filename) -> retval
 .. ocv:pyfunction:: cv2.VideoCapture.open(device) -> retval
 
-    :param filename: name of the opened video file (eg. video.avi) or image sequence (eg. img%02d.jpg)
+    :param filename: name of the opened video file (eg. video.avi) or image sequence (eg. img_%02d.jpg, which will read samples like img_00.jpg, img_01.jpg, img_02.jpg, ...)
 
     :param device: id of the opened video capturing device (i.e. a camera index).
 

--- a/modules/highgui/src/cap_images.cpp
+++ b/modules/highgui/src/cap_images.cpp
@@ -200,25 +200,20 @@ static char* icvExtractPattern(const char *filename, unsigned *offset)
     }
     else // no pattern filename was given - extract the pattern
     {
-        at = name;
+        int len = (int)strlen(name);
+        // find last number
+        for(at = name + len - 1; at >= name && !isdigit(*at); --at)
+            ;
+        // find first digit that belongs to the last number
+        for ( ; at >= name && isdigit(*at); --at)
+            ;
 
-        // ignore directory names
-        char *slash = strrchr(at, '/');
-        if (slash) at = slash + 1;
-
-#ifdef _WIN32
-        slash = strrchr(at, '\\');
-        if (slash) at = slash + 1;
-#endif
-
-        while (*at && !isdigit(*at)) at++;
-
-        if(!*at)
+        if(at < name)
             return 0;
 
         sscanf(at, "%u", offset);
 
-        int size = (int)strlen(filename) + 20;
+        int size = len + 20;
         name = (char *)malloc(size);
         strncpy(name, filename, at - filename);
         name[at - filename] = 0;
@@ -238,7 +233,6 @@ static char* icvExtractPattern(const char *filename, unsigned *offset)
 
     return name;
 }
-
 
 bool CvCapture_Images::open(const char * _filename)
 {

--- a/samples/cpp/image_sequence.cpp
+++ b/samples/cpp/image_sequence.cpp
@@ -9,9 +9,9 @@ using namespace std;
 static void help(char** argv)
 {
     cout << "\nThis sample shows you how to read a sequence of images using the VideoCapture interface.\n"
-         << "Usage: " << argv[0] << " <image_mask> (example mask: example_%%02d.jpg)\n"
+         << "Usage: " << argv[0] << " <image_mask> (example mask: example_%02d.jpg)\n"
          << "Image mask defines the name variation for the input images that have to be read as a sequence. \n"
-         << "Using the mask example_%%02d.jpg will read in images labeled as 'example_00.jpg', 'example_01.jpg', etc."
+         << "Using the mask example_%02d.jpg will read in images labeled as 'example_00.jpg', 'example_01.jpg', etc."
          << endl;
 }
 


### PR DESCRIPTION
Adapted old pull request changes.
See http://code.opencv.org/issues/3306

Basically the line is scanned in opposite direction now, in order not to cope with specific formatting in the rest of the string.
