### PR TITLE
OCL: disable tests

### DIFF
--- a/modules/core/test/ocl/test_arithm.cpp
+++ b/modules/core/test/ocl/test_arithm.cpp
@@ -170,7 +170,8 @@ OCL_TEST_P(Add, Scalar_Mask)
 
 //////////////////////////////////////// Instantiation /////////////////////////////////////////
 
-OCL_INSTANTIATE_TEST_CASE_P(Arithm, Add, Combine(OCL_ALL_DEPTHS, OCL_ALL_CHANNELS, Bool()));
+// TODO FIXIT Invalid "add" implementation
+//OCL_INSTANTIATE_TEST_CASE_P(Arithm, Add, Combine(OCL_ALL_DEPTHS, OCL_ALL_CHANNELS, Bool()));
 
 } } // namespace cvtest::ocl
 


### PR DESCRIPTION
BTW, I believe we need to disable OpenCL build on Ubuntu (and may be on other also) buildslaves.
