### PR TITLE
correct upper bound for maximum number of labels for 8-way connectivity

### DIFF
--- a/modules/imgproc/src/connectedcomponents.cpp
+++ b/modules/imgproc/src/connectedcomponents.cpp
@@ -195,11 +195,9 @@ namespace cv{
         CV_Assert(connectivity == 8 || connectivity == 4);
         const int rows = L.rows;
         const int cols = L.cols;
-        size_t Plength = (size_t(rows + 3 - 1)/3) * (size_t(cols + 3 - 1)/3);
-        if(connectivity == 4){
-            Plength = 4 * Plength;//a quick and dirty upper bound, an exact answer exists if you want to find it
-            //the 4 comes from the fact that a 3x3 block can never have more than 4 unique labels
-        }
+        //A quick and dirty upper bound for the maximimum number of labels.  The 4 comes from
+        //the fact that a 3x3 block can never have more than 4 unique labels for both 4 & 8-way
+        const size_t Plength = 4 * (size_t(rows + 3 - 1)/3) * (size_t(cols + 3 - 1)/3);
         LabelT *P = (LabelT *) fastMalloc(sizeof(LabelT) * Plength);
         P[0] = 0;
         LabelT lunique = 1;


### PR DESCRIPTION
bugfix
