### PR TITLE
mouse_and_match.py missing import cv2

### DIFF
--- a/samples/python2/mouse_and_match.py
+++ b/samples/python2/mouse_and_match.py
@@ -9,6 +9,7 @@ Demonstrate using a mouse to interact with an image:
  ESC to exit
 '''
 import numpy as np
+import cv2
 
 # built-in modules
 import os


### PR DESCRIPTION
mouse_and_match.py is missing an "import cv2" statement ( probably removed while cleaning up the old cv api)

(master only, 2.4 is ok)
