### PR TITLE
fixed comparison to stop integer wrap around -> no more crash in cvFindCornerSubPix

### DIFF
--- a/modules/imgproc/src/samplers.cpp
+++ b/modules/imgproc/src/samplers.cpp
@@ -97,7 +97,7 @@ icvAdjustRect( const void* srcptr, int src_step, int pix_size,
             rect.x = win_size.width;
     }
 
-    if( ip.x + win_size.width < src_size.width )
+    if( ip.x < src_size.width - win_size.width )
         rect.width = win_size.width;
     else
     {
@@ -118,7 +118,7 @@ icvAdjustRect( const void* srcptr, int src_step, int pix_size,
     else
         rect.y = -ip.y;
 
-    if( ip.y + win_size.height < src_size.height )
+    if( ip.y < src_size.height - win_size.height )
         rect.height = win_size.height;
     else
     {
@@ -164,8 +164,8 @@ CvStatus CV_STDCALL icvGetRectSubPix_##flavor##_C1R                         \
     src_step /= sizeof(src[0]);                                             \
     dst_step /= sizeof(dst[0]);                                             \
                                                                             \
-    if( 0 <= ip.x && ip.x + win_size.width < src_size.width &&              \
-        0 <= ip.y && ip.y + win_size.height < src_size.height )             \
+    if( 0 <= ip.x && ip.x < src_size.width - win_size.width &&              \
+        0 <= ip.y && ip.y < src_size.height - win_size.height )             \
     {                                                                       \
         /* extracted rectangle is totally inside the image */               \
         src += ip.y * src_step + ip.x;                                      \
@@ -270,8 +270,8 @@ static CvStatus CV_STDCALL icvGetRectSubPix_##flavor##_C3R                  \
     src_step /= sizeof( src[0] );                                           \
     dst_step /= sizeof( dst[0] );                                           \
                                                                             \
-    if( 0 <= ip.x && ip.x + win_size.width < src_size.width &&              \
-        0 <= ip.y && ip.y + win_size.height < src_size.height )             \
+    if( 0 <= ip.x && ip.x < src_size.width - win_size.width &&              \
+        0 <= ip.y && ip.y < src_size.height - win_size.height )             \
     {                                                                       \
         /* extracted rectangle is totally inside the image */               \
         src += ip.y * src_step + ip.x*3;                                    \
@@ -407,8 +407,8 @@ CvStatus CV_STDCALL icvGetRectSubPix_8u32f_C1R
     src_step /= sizeof(src[0]);
     dst_step /= sizeof(dst[0]);
 
-    if( 0 <= ip.x && ip.x + win_size.width < src_size.width &&
-        0 <= ip.y && ip.y + win_size.height < src_size.height )
+    if( 0 <= ip.x && ip.x < src_size.width - win_size.width &&
+        0 <= ip.y && ip.y < src_size.height - win_size.height )
     {
         // extracted rectangle is totally inside the image
         src += ip.y * src_step + ip.x;


### PR DESCRIPTION
cvFindCornerSubpix is able to generate corner position updates far away from the image (if the determinant of the corner patch is too small). This leads to large positive numbers which lead to integer wrap arounds when added to src_size. This results in access errors in samplers.cpp (i.e. invalid memory accesses and thus crashes)
gcc 4.7.1, 64bit Alces HPC Linux
