### PR TITLE
Fixed a minor documentation typo

### DIFF
--- a/doc/tutorials/imgproc/imgtrans/warp_affine/warp_affine.rst
+++ b/doc/tutorials/imgproc/imgtrans/warp_affine/warp_affine.rst
@@ -71,7 +71,7 @@ How do we get an Affine Transformation?
 
    a. We know both :math:`X` and `T` and we also know that they are related. Then our job is to find :math:`M`
 
-   b. We know :math:`M` and :math:'X`. To obtain :math:`T` we only need to apply :math:`T = M \cdot X`. Our information for :math:`M` may be explicit (i.e. have the 2-by-3 matrix) or it can come as a geometric relation between points.
+   b. We know :math:`M` and :math:`X`. To obtain :math:`T` we only need to apply :math:`T = M \cdot X`. Our information for :math:`M` may be explicit (i.e. have the 2-by-3 matrix) or it can come as a geometric relation between points.
 
 2. Let's explain a little bit better (b). Since :math:`M` relates 02 images, we can analyze the simplest case in which it relates three points in both images. Look at the figure below:
 


### PR DESCRIPTION
In section "How do we get an Affine Transformation?", section 2 there was a ' instead of ` which caused the math to render incorrectly.
