### PR TITLE
TS: catch & append general exceptions into log

### DIFF
--- a/modules/ts/include/opencv2/ts.hpp
+++ b/modules/ts/include/opencv2/ts.hpp
@@ -250,7 +250,7 @@ struct TestInfo
     // pointer to the test
     BaseTest* test;
 
-    // failure code (CV_FAIL*)
+    // failure code (TS::FAIL_*)
     int code;
 
     // seed value right before the data for the failed test case is prepared.
@@ -324,7 +324,7 @@ public:
     virtual void set_gtest_status();
 
     // test error codes
-    enum
+    enum FailureCode
     {
         // everything is Ok
         OK=0,
@@ -397,7 +397,7 @@ public:
     RNG& get_rng() { return rng; }
 
     // returns the current error code
-    int get_err_code() { return current_test_info.code; }
+    TS::FailureCode get_err_code() { return TS::FailureCode(current_test_info.code); }
 
     // returns the test extensivity scale
     double get_test_case_count_scale() { return params.test_case_count_scale; }
@@ -405,7 +405,7 @@ public:
     const string& get_data_path() const { return data_path; }
 
     // returns textual description of failure code
-    static string str_from_code( int code );
+    static string str_from_code( const TS::FailureCode code );
 
 protected:
 


### PR DESCRIPTION
Sample of output with unhandled "Access violation" (0xc0000005 on Windows) error.
We see in LOG only OpenCV Error, which is expected and it is succesfully processed via try-catch (it is not a reason of failure):

```
..\..\..\opencv\modules\ts\src\ts.cpp(505): error: Failed

        failure reason: Hardware/OS exception
        test case #-1
        seed: ffffffffffffffff
-----------------------------------
        LOG: OpenCV Error: Unknown error code -220 (OpenCL function is not available: [clGetPlatformIDs]) in opencl_check_fn, file ..\..\..\opencv\modules\core\src\opencl\runtime\ocl_runtime.cpp, line 137

-----------------------------------
```

New output, where we can see real reason of failure with more details (instead of Hardware/OS exception) and more easily:

```
..\..\..\opencv\modules\ts\src\ts.cpp(518): error: Failed

        failure reason: Invalid memory access
        test case #-1
        seed: ffffffffffffffff
-----------------------------------
        LOG:
OpenCV Error:
        Unknown error code -220 (OpenCL function is not available: [clGetPlatformIDs]) in opencl_check_fn, file ..\..\..\opencv\modules\core\src\opencl\runtime\ocl_runtime.cpp, line 137

General failure:
        Invalid memory access (-5)

-----------------------------------
\
```
