### PR TITLE
core: added cv::error with CV_NORETURN attr

### DIFF
--- a/modules/core/include/opencv2/core/base.hpp
+++ b/modules/core/include/opencv2/core/base.hpp
@@ -222,6 +222,23 @@ enum {
  */
 CV_EXPORTS void error(int _code, const String& _err, const char* _func, const char* _file, int _line);
 
+#ifdef __GNUC__
+#  if defined __clang__ || defined __APPLE__
+#    pragma GCC diagnostic push
+#    pragma GCC diagnostic ignored "-Winvalid-noreturn"
+#  endif
+#endif
+CV_INLINE CV_NORETURN void errorNoReturn(int _code, const String& _err, const char* _func, const char* _file, int _line)
+{
+    error(_code, _err, _func, _file, _line);
+}
+#ifdef __GNUC__
+#  if defined __clang__ || defined __APPLE__
+#    pragma GCC diagnostic pop
+#  endif
+#endif
+
+
 #if defined __GNUC__
 #define CV_Func __func__
 #elif defined _MSC_VER
@@ -233,6 +250,9 @@ CV_EXPORTS void error(int _code, const String& _err, const char* _func, const ch
 #define CV_Error( code, msg ) cv::error( code, msg, CV_Func, __FILE__, __LINE__ )
 #define CV_Error_( code, args ) cv::error( code, cv::format args, CV_Func, __FILE__, __LINE__ )
 #define CV_Assert( expr ) if(!!(expr)) ; else cv::error( cv::Error::StsAssert, #expr, CV_Func, __FILE__, __LINE__ )
+
+#define CV_ErrorNoReturn( code, msg ) cv::errorNoReturn( code, msg, CV_Func, __FILE__, __LINE__ )
+#define CV_ErrorNoReturn_( code, args ) cv::errorNoReturn( code, cv::format args, CV_Func, __FILE__, __LINE__ )
 
 #ifdef _DEBUG
 #  define CV_DbgAssert(expr) CV_Assert(expr)

--- a/modules/core/include/opencv2/core/cvdef.h
+++ b/modules/core/include/opencv2/core/cvdef.h
@@ -464,4 +464,19 @@ CV_INLINE int cvIsInf( double value )
    CV_INLINE CV_XADD(int* addr, int delta) { int tmp = *addr; *addr += delta; return tmp; }
 #endif
 
+
+/****************************************************************************************\
+*                                  CV_NORETURN attribute                                 *
+\****************************************************************************************/
+
+#ifndef CV_NORETURN
+#  if defined(__GNUC__)
+#    define CV_NORETURN __attribute__((__noreturn__))
+#  elif defined(_MSC_VER) && (_MSC_VER >= 1300)
+#    define CV_NORETURN __declspec(noreturn)
+#  else
+#    define CV_NORETURN /* nothing by default */
+#  endif
+#endif
+
 #endif // __OPENCV_CORE_CVDEF_H__


### PR DESCRIPTION
To remove useless `return` statements after CV_Error().
