### PR TITLE
Scalar::all() in MatOp_Initializer::assign and setIdentity()

### DIFF
--- a/modules/core/include/opencv2/core/core.hpp
+++ b/modules/core/include/opencv2/core/core.hpp
@@ -2333,7 +2333,7 @@ CV_EXPORTS_W void perspectiveTransform(InputArray src, OutputArray dst, InputArr
 //! extends the symmetrical matrix from the lower half or from the upper half
 CV_EXPORTS_W void completeSymm(InputOutputArray mtx, bool lowerToUpper=false);
 //! initializes scaled identity matrix
-CV_EXPORTS_W void setIdentity(InputOutputArray mtx, const Scalar& s=Scalar(1));
+CV_EXPORTS_W void setIdentity(InputOutputArray mtx, const Scalar& s=Scalar::all(1));
 //! computes determinant of a square matrix
 CV_EXPORTS_W double determinant(InputArray mtx);
 //! computes trace of a matrix

--- a/modules/core/src/matop.cpp
+++ b/modules/core/src/matop.cpp
@@ -1553,11 +1553,11 @@ void MatOp_Initializer::assign(const MatExpr& e, Mat& m, int _type) const
         _type = e.a.type();
     m.create(e.a.size(), _type);
     if( e.flags == 'I' )
-        setIdentity(m, Scalar(e.alpha));
+        setIdentity(m, Scalar::all(e.alpha));
     else if( e.flags == '0' )
         m = Scalar();
     else if( e.flags == '1' )
-        m = Scalar(e.alpha);
+        m = Scalar::all(e.alpha);
     else
         CV_Error(CV_StsError, "Invalid matrix initializer type");
 }

--- a/modules/core/test/test_mat.cpp
+++ b/modules/core/test/test_mat.cpp
@@ -897,3 +897,23 @@ TEST(Core_Mat, reshape_1942)
     );
     ASSERT_EQ(1, cn);
 }
+
+static void test_mat_eye(const Mat & me)  { ASSERT_EQ(me.channels() * std::min(me.cols,me.rows), int(sum(sum(me))[0]) ); }
+static void test_mat_ones(const Mat & me) { ASSERT_EQ(me.channels() * me.total(), int(sum(sum(me))[0]) ); }
+TEST(Core_Mat, Ones)
+{ 
+    test_mat_ones(Mat::ones(Size(3,3),CV_8UC3));
+    test_mat_ones(Mat::ones(3,3,CV_8UC4));
+    test_mat_ones(Mat(3,3,CV_8UC4,Scalar::all(1)));
+}
+TEST(Core_Mat, Eye)
+{
+    test_mat_eye(Mat::eye(3,3,CV_8UC4));
+    test_mat_eye(Mat::eye(3,3,CV_64FC4));
+}
+TEST(Core_Mat, setIdentity)
+{
+    { Mat me(3,5,CV_8UC1); setIdentity(me); test_mat_eye(me); }
+    { Mat me(3,3,CV_8UC3); setIdentity(me); test_mat_eye(me); }
+    { Mat me(3,3,CV_8UC4); setIdentity(me,Scalar::all(1)); test_mat_eye(me); }
+}


### PR DESCRIPTION
fix for [issue 3227](http://code.opencv.org/issues/3227)

took the liberty to change setIdentity() in core.hpp as well, also some tests in tests/mat.cpp
