### PR TITLE
Ensure compilation to Javascript with Emscripten

### DIFF
--- a/modules/core/include/opencv2/core/cvdef.h
+++ b/modules/core/include/opencv2/core/cvdef.h
@@ -444,7 +444,7 @@ CV_INLINE int cvIsInf( double value )
    // atomic increment on the linux version of the Intel(tm) compiler
 #  define CV_XADD(addr, delta) (int)_InterlockedExchangeAdd(const_cast<void*>(reinterpret_cast<volatile void*>(addr)), delta)
 #elif defined __GNUC__
-#  if defined __clang__ && __clang_major__ >= 3 && !defined __ANDROID__
+#  if defined __clang__ && __clang_major__ >= 3 && !defined __ANDROID__ && !defined __EMSCRIPTEN__
 #    ifdef __ATOMIC_ACQ_REL
 #      define CV_XADD(addr, delta) __c11_atomic_fetch_add((_Atomic(int)*)(addr), delta, __ATOMIC_ACQ_REL)
 #    else

--- a/modules/core/src/system.cpp
+++ b/modules/core/src/system.cpp
@@ -157,7 +157,7 @@ std::wstring GetTempFileNameWinRT(std::wstring prefix)
 
 #include <stdarg.h>
 
-#if defined __linux__ || defined __APPLE__
+#if defined __linux__ || defined __APPLE__ || defined __EMSCRIPTEN__
 #include <unistd.h>
 #include <stdio.h>
 #include <sys/types.h>


### PR DESCRIPTION
This small commit ensure that (the core of) OpenCV can compile to JavaScript with Emscripten.

Successfully compiles `core`, `imgproc`, `calib3d`, `feature2d`, `video`, `highgui`, `superres`, `objdetect`, `shape`, `bioinspired`, `contrib`, `legacy`, `photo`, `ml`.

Note that one pending issue is still required in Emscripten: https://github.com/kripken/emscripten/issues/1860

Sibling pull-request for branch 2.4: #1907 
