### PR TITLE
Ensure compilation to Javascript with Emscripten

### DIFF
--- a/modules/core/include/opencv2/core/operations.hpp
+++ b/modules/core/include/opencv2/core/operations.hpp
@@ -56,7 +56,7 @@
   #define CV_XADD(addr,delta) _InterlockedExchangeAdd(const_cast<void*>(reinterpret_cast<volatile void*>(addr)), delta)
 #elif defined __GNUC__
 
-  #if defined __clang__ && __clang_major__ >= 3 && !defined __ANDROID__
+  #if defined __clang__ && __clang_major__ >= 3 && !defined __ANDROID__ && !defined __EMSCRIPTEN__
     #ifdef __ATOMIC_SEQ_CST
         #define CV_XADD(addr, delta) __c11_atomic_fetch_add((_Atomic(int)*)(addr), (delta), __ATOMIC_SEQ_CST)
     #else
@@ -66,7 +66,9 @@
 
     #if !(defined WIN32 || defined _WIN32) && (defined __i486__ || defined __i586__ || \
         defined __i686__ || defined __MMX__ || defined __SSE__  || defined __ppc__) || \
-        (defined __GNUC__ && defined _STLPORT_MAJOR)
+        (defined __GNUC__ && defined _STLPORT_MAJOR) || \
+        defined __EMSCRIPTEN__
+
       #define CV_XADD __sync_fetch_and_add
     #else
       #include <ext/atomicity.h>

--- a/modules/core/src/system.cpp
+++ b/modules/core/src/system.cpp
@@ -126,7 +126,7 @@ std::wstring GetTempFileNameWinRT(std::wstring prefix)
 
 #include <stdarg.h>
 
-#if defined __linux__ || defined __APPLE__
+#if defined __linux__ || defined __APPLE__ || defined __EMSCRIPTEN__
 #include <unistd.h>
 #include <stdio.h>
 #include <sys/types.h>


### PR DESCRIPTION
This small commit ensure that (the core of) OpenCV can compile to JavaScript with Emscripten.

Successfully compiles `core`, `imgproc`, `calib3d`, `feature2d`, `video`, `highgui`, `superres`, `objdetect`, `shape`, `bioinspired`, `contrib`, `legacy`, `photo`, `ml`.

Note that one pending issue is still required in Emscripten: https://github.com/kripken/emscripten/issues/1860

Sibling pull-request for branch master: #1904
