### PR TITLE
Fix a -Wundef warning in cl_platform.h

### DIFF
--- a/3rdparty/include/opencl/1.2/CL/cl_platform.h
+++ b/3rdparty/include/opencl/1.2/CL/cl_platform.h
@@ -454,7 +454,7 @@ typedef unsigned int cl_GLenum;
 /* Define alignment keys */
 #if defined( __GNUC__ )
     #define CL_ALIGNED(_x)          __attribute__ ((aligned(_x)))
-#elif defined( _WIN32) && (_MSC_VER)
+#elif defined( _WIN32) && defined(_MSC_VER)
     /* Alignment keys neutered on windows because MSVC can't swallow function arguments with alignment requirements     */
     /* http://msdn.microsoft.com/en-us/library/373ak2y1%28VS.71%29.aspx                                                 */
     /* #include <crtdefs.h>                                                                                             */


### PR DESCRIPTION
`_MSC_VER` -> `defined _MSC_VER`. Should fix building with MinGW. Similar to fbc91c5ee.

Example of warning: http://build.opencv.org/builders/win_x86%5Brelease%5D--%5Bsse_%3D_ON%5D--%5Btbb_%3D_OFF%5D--%5Bgpu_%3D_OFF%5D--%5Bcompiler_%3D_mingw%5D--%5Btests_%3D_ON%5D-/builds/1227/steps/compile%20release%2032%20mingw%20shared%20n/logs/build%20summary%20%28e%3A%200%2C%20w%3A%202%29
