### PR TITLE
ocl::oclMat::ptr() Remove CV_Error, method is already implemented.

### DIFF
--- a/modules/ocl/include/opencv2/ocl/matrix_operations.hpp
+++ b/modules/ocl/include/opencv2/ocl/matrix_operations.hpp
@@ -461,28 +461,24 @@ namespace cv
         inline uchar *oclMat::ptr(int y)
         {
             CV_DbgAssert( (unsigned)y < (unsigned)rows );
-            CV_Error(Error::GpuNotSupported, "This function hasn't been supported yet.\n");
             return data + step * y;
         }
 
         inline const uchar *oclMat::ptr(int y) const
         {
             CV_DbgAssert( (unsigned)y < (unsigned)rows );
-            CV_Error(Error::GpuNotSupported, "This function hasn't been supported yet.\n");
             return data + step * y;
         }
 
         template<typename _Tp> inline _Tp *oclMat::ptr(int y)
         {
             CV_DbgAssert( (unsigned)y < (unsigned)rows );
-            CV_Error(Error::GpuNotSupported, "This function hasn't been supported yet.\n");
             return (_Tp *)(data + step * y);
         }
 
         template<typename _Tp> inline const _Tp *oclMat::ptr(int y) const
         {
             CV_DbgAssert( (unsigned)y < (unsigned)rows );
-            CV_Error(Error::GpuNotSupported, "This function hasn't been supported yet.\n");
             return (const _Tp *)(data + step * y);
         }
 


### PR DESCRIPTION
Removing CV_Error() calls in ocl::oclMat::ptr() methods. The methods are already implemented and they work.
