### PR TITLE
Fixed some implicitly type conversions between vector and scalar data ty...

### DIFF
--- a/modules/ocl/src/opencl/imgproc_threshold.cl
+++ b/modules/ocl/src/opencl/imgproc_threshold.cl
@@ -74,11 +74,11 @@ __kernel void threshold(__global const T * restrict src, int src_offset, int src
         VT vthresh = (VT)(thresh);
 
 #ifdef THRESH_BINARY
-        VT vecValue = sdata > vthresh ? max_val : (VT)(0);
+        VT vecValue = sdata > vthresh ? (VT)max_val : (VT)(0);
 #elif defined THRESH_BINARY_INV
-        VT vecValue = sdata > vthresh ? (VT)(0) : max_val;
+        VT vecValue = sdata > vthresh ? (VT)(0) : (VT)max_val;
 #elif defined THRESH_TRUNC
-        VT vecValue = sdata > vthresh ? thresh : sdata;
+        VT vecValue = sdata > vthresh ? (VT)thresh : sdata;
 #elif defined THRESH_TOZERO
         VT vecValue = sdata > vthresh ? sdata : (VT)(0);
 #elif defined THRESH_TOZERO_INV


### PR DESCRIPTION
...pe.

There are some mixed implicitly/explicitly type conversion between
scalar and vector. Although the spec allows those conversion, I prefer
to make them consistent and use explicitly all the cases.

Signed-off-by: Zhigang Gong zhigang.gong@intel.com
