### PR TITLE
ocl::BruteForceMatcher fix wrong use of oclMat::ptr().

### DIFF
--- a/modules/ocl/src/brute_force_matcher.cpp
+++ b/modules/ocl/src/brute_force_matcher.cpp
@@ -677,7 +677,7 @@ void cv::ocl::BruteForceMatcher_OCL_base::matchCollection(const oclMat &query, c
     ensureSizeIsEnough(1, nQuery, CV_32S, imgIdx);
     ensureSizeIsEnough(1, nQuery, CV_32F, distance);
 
-    matchDispatcher(query, (const oclMat *)trainCollection.ptr(), trainCollection.cols, masks, trainIdx, imgIdx, distance, distType);
+    matchDispatcher(query, &trainCollection, trainCollection.cols, masks, trainIdx, imgIdx, distance, distType);
 
     return;
 }


### PR DESCRIPTION
The oclMat::ptr() method was mistakenly used in ocl::BruteForceMatcher to pass a pointer to a oclMat object. The ptr() method returns a uchar pointer to the cl_mem data structure and this method will be removed.
