### PR TITLE
OCL: Removing ocl::oclMat::ptr() method.

### DIFF
--- a/modules/ocl/doc/data_structures.rst
+++ b/modules/ocl/doc/data_structures.rst
@@ -144,14 +144,6 @@ OpenCV C++ 1-D or 2-D dense array class ::
         //! returns true if oclMatrix data is NULL
         bool empty() const;
 
-        //! returns pointer to y-th row
-        uchar* ptr(int y = 0);
-        const uchar *ptr(int y = 0) const;
-
-        //! template version of the above method
-        template<typename _Tp> _Tp *ptr(int y = 0);
-        template<typename _Tp> const _Tp *ptr(int y = 0) const;
-
         //! matrix transposition
         oclMat t() const;
 

--- a/modules/ocl/include/opencv2/ocl/matrix_operations.hpp
+++ b/modules/ocl/include/opencv2/ocl/matrix_operations.hpp
@@ -456,36 +456,6 @@ namespace cv
             return data == 0;
         }
 
-
-
-        inline uchar *oclMat::ptr(int y)
-        {
-            CV_DbgAssert( (unsigned)y < (unsigned)rows );
-            CV_Error(CV_GpuNotSupported, "This function hasn't been supported yet.\n");
-            return data + step * y;
-        }
-
-        inline const uchar *oclMat::ptr(int y) const
-        {
-            CV_DbgAssert( (unsigned)y < (unsigned)rows );
-            CV_Error(CV_GpuNotSupported, "This function hasn't been supported yet.\n");
-            return data + step * y;
-        }
-
-        template<typename _Tp> inline _Tp *oclMat::ptr(int y)
-        {
-            CV_DbgAssert( (unsigned)y < (unsigned)rows );
-            CV_Error(CV_GpuNotSupported, "This function hasn't been supported yet.\n");
-            return (_Tp *)(data + step * y);
-        }
-
-        template<typename _Tp> inline const _Tp *oclMat::ptr(int y) const
-        {
-            CV_DbgAssert( (unsigned)y < (unsigned)rows );
-            CV_Error(CV_GpuNotSupported, "This function hasn't been supported yet.\n");
-            return (const _Tp *)(data + step * y);
-        }
-
         inline oclMat oclMat::t() const
         {
             oclMat tmp;

--- a/modules/ocl/include/opencv2/ocl/ocl.hpp
+++ b/modules/ocl/include/opencv2/ocl/ocl.hpp
@@ -379,14 +379,6 @@ namespace cv
             //! returns true if oclMatrix data is NULL
             bool empty() const;
 
-            //! returns pointer to y-th row
-            uchar* ptr(int y = 0);
-            const uchar *ptr(int y = 0) const;
-
-            //! template version of the above method
-            template<typename _Tp> _Tp *ptr(int y = 0);
-            template<typename _Tp> const _Tp *ptr(int y = 0) const;
-
             //! matrix transposition
             oclMat t() const;
 


### PR DESCRIPTION
The method ocl::oclMat::ptr() is being removed because it returns a pointer to a row of oclMat::data. The data attribute is a cl_mem structure and cannot be iterated outside an OpenCL kernel.
