### PR TITLE
--no-display property fix in stereo_match.cpp sample

### DIFF
--- a/samples/cpp/stereo_match.cpp
+++ b/samples/cpp/stereo_match.cpp
@@ -45,7 +45,7 @@ int main(int argc, char** argv)
     const char* algorithm_opt = "--algorithm=";
     const char* maxdisp_opt = "--max-disparity=";
     const char* blocksize_opt = "--blocksize=";
-    const char* nodisplay_opt = "--no-display=";
+    const char* nodisplay_opt = "--no-display";
     const char* scale_opt = "--scale=";
 
     if(argc < 3)


### PR DESCRIPTION
comes from #1951, targeting 2.4 branch as requested
