### PR TITLE
disabled gcc 4.8 warning

### DIFF
--- a/modules/superres/src/optical_flow.cpp
+++ b/modules/superres/src/optical_flow.cpp
@@ -42,6 +42,10 @@
 
 #include "precomp.hpp"
 
+#if (__GNUC__ == 4) && (__GNUC_MINOR__ == 8)
+# pragma GCC diagnostic ignored "-Warray-bounds"
+#endif
+
 using namespace cv;
 using namespace cv::cuda;
 using namespace cv::superres;


### PR DESCRIPTION
It looks like a GCC 4.8 bug:

```
In file included from .../opencv/modules/core/include/opencv2/core/cuda.hpp:692:0,
                 from .../build/modules/superres/precomp.hpp:51:
.../opencv/modules/core/include/opencv2/core/cuda.inl.hpp: In member function 'virtual cv::AlgorithmInfo* {anonymous}::PyrLK_CUDA::info() const':
.../opencv/modules/core/include/opencv2/core/cuda.inl.hpp:114:14: warning: array subscript is above array bounds [-Warray-bounds]
     release();
              ^
```

gcc version 4.8.2 20131017 (Red Hat 4.8.2-1) (GCC)
