### PR TITLE
Fixed #2700: Composite feature extractors and detectors crash on AlgorithmInfo::name()

### DIFF
--- a/modules/core/include/opencv2/core/core.hpp
+++ b/modules/core/include/opencv2/core/core.hpp
@@ -4388,7 +4388,7 @@ class CV_EXPORTS_W Algorithm
 public:
     Algorithm();
     virtual ~Algorithm();
-    string name() const;
+    virtual string name() const;
 
     template<typename _Tp> typename ParamType<_Tp>::member_type get(const string& name) const;
     template<typename _Tp> typename ParamType<_Tp>::member_type get(const char* name) const;

--- a/modules/features2d/include/opencv2/features2d/features2d.hpp
+++ b/modules/features2d/include/opencv2/features2d/features2d.hpp
@@ -895,6 +895,7 @@ public:
     virtual int descriptorType() const;
 
     virtual bool empty() const;
+    virtual string name() const;
 
 protected:
     virtual void computeImpl( const Mat& image, vector<KeyPoint>& keypoints, Mat& descriptors ) const;

--- a/modules/features2d/src/descriptors.cpp
+++ b/modules/features2d/src/descriptors.cpp
@@ -43,6 +43,9 @@
 
 using namespace std;
 
+static const string feature2DPrefix = "Feature2D.";
+static const string opponentExtractorPrefix = "Opponent";
+
 namespace cv
 {
 
@@ -96,14 +99,13 @@ void DescriptorExtractor::removeBorderKeypoints( vector<KeyPoint>& keypoints,
 
 Ptr<DescriptorExtractor> DescriptorExtractor::create(const string& descriptorExtractorType)
 {
-    if( descriptorExtractorType.find("Opponent") == 0 )
+    if( descriptorExtractorType.find(opponentExtractorPrefix) == 0 )
     {
-        size_t pos = string("Opponent").size();
+        size_t pos = opponentExtractorPrefix.size();
         string type = descriptorExtractorType.substr(pos);
         return new OpponentColorDescriptorExtractor(DescriptorExtractor::create(type));
     }
-
-    return Algorithm::create<DescriptorExtractor>("Feature2D." + descriptorExtractorType);
+    return Algorithm::create<DescriptorExtractor>(feature2DPrefix + descriptorExtractorType);
 }
 
 
@@ -251,6 +253,17 @@ int OpponentColorDescriptorExtractor::descriptorType() const
 bool OpponentColorDescriptorExtractor::empty() const
 {
     return descriptorExtractor.empty() || (DescriptorExtractor*)(descriptorExtractor)->empty();
+}
+
+string OpponentColorDescriptorExtractor::name() const
+{
+    string opponentDescriptorExtractorName = descriptorExtractor->name();
+
+    if( 0 == opponentDescriptorExtractorName.find(feature2DPrefix) )
+    {
+        opponentDescriptorExtractorName.insert(feature2DPrefix.size(), opponentExtractorPrefix);
+    }
+    return opponentDescriptorExtractorName;
 }
 
 }


### PR DESCRIPTION
Fixed #2700: Composite feature extractors and detectors crash on AlgorithmInfo::name()
