### PR TITLE
OCL: process termination hung workaround

### DIFF
--- a/modules/core/src/ocl.cpp
+++ b/modules/core/src/ocl.cpp
@@ -1932,10 +1932,15 @@ struct Queue::Impl
 
     ~Impl()
     {
-        if(handle)
+#ifdef _WIN32
+        if (!cv::__termination)
+#endif
         {
-            clFinish(handle);
-            clReleaseCommandQueue(handle);
+            if(handle)
+            {
+                clFinish(handle);
+                clReleaseCommandQueue(handle);
+            }
         }
     }
 

--- a/modules/core/src/precomp.hpp
+++ b/modules/core/src/precomp.hpp
@@ -249,6 +249,9 @@ namespace ocl
     MatAllocator* getOpenCLAllocator();
 }
 
+extern bool __termination; // skip some cleanups, because process is terminating
+                           // (for example, if ExitProcess() was already called)
+
 }
 
 #endif /*_CXCORE_INTERNAL_H_*/

--- a/modules/core/src/system.cpp
+++ b/modules/core/src/system.cpp
@@ -734,18 +734,23 @@ cvErrorFromIppStatus( int status )
     }
 }
 
+namespace cv {
+bool __termination = false;
+}
 
 #if defined CVAPI_EXPORTS && defined WIN32 && !defined WINCE
 #ifdef HAVE_WINRT
     #pragma warning(disable:4447) // Disable warning 'main' signature found without threading model
 #endif
 
-BOOL WINAPI DllMain( HINSTANCE, DWORD  fdwReason, LPVOID );
+BOOL WINAPI DllMain( HINSTANCE, DWORD, LPVOID );
 
-BOOL WINAPI DllMain( HINSTANCE, DWORD  fdwReason, LPVOID )
+BOOL WINAPI DllMain( HINSTANCE, DWORD fdwReason, LPVOID lpReserved )
 {
     if( fdwReason == DLL_THREAD_DETACH || fdwReason == DLL_PROCESS_DETACH )
     {
+        if (lpReserved != NULL) // called after ExitProcess() call
+            cv::__termination = true;
         cv::deleteThreadAllocData();
         cv::deleteThreadData();
     }


### PR DESCRIPTION
http://build.opencv.org/builders/precommit_OCL-win64-vc10/builds/181/steps/test_core-plain/logs/stdio:

```
[----------] Global test environment tear-down
[==========] 2765 tests from 130 test cases ran. (118373 ms total)
[  PASSED  ] 2765 tests.

  YOU HAVE 192 DISABLED TESTS


command timed out: 60 seconds without output, attempting to kill
program finished with exit code 1
```
