### PR TITLE
T-API: fixed UMat sync problems

### DIFF
--- a/modules/core/src/umatrix.cpp
+++ b/modules/core/src/umatrix.cpp
@@ -580,7 +580,6 @@ Mat UMat::getMat(int accessFlags) const
     Mat hdr(dims, size.p, type(), u->data + offset, step.p);
     hdr.flags = flags;
     hdr.u = u;
-    hdr.flags = flags;
     hdr.datastart = u->data;
     hdr.data = hdr.datastart + offset;
     hdr.datalimit = hdr.dataend = u->data + u->size;
@@ -588,10 +587,13 @@ Mat UMat::getMat(int accessFlags) const
     return hdr;
 }
 
-void* UMat::handle(int /*accessFlags*/) const
+void* UMat::handle(int accessFlags) const
 {
     if( !u )
         return 0;
+
+    if ((accessFlags & ACCESS_WRITE) != 0)
+        u->markHostCopyObsolete(true);
 
     // check flags: if CPU copy is newer, copy it back to GPU.
     if( u->deviceCopyObsolete() )

--- a/modules/core/test/test_umat.cpp
+++ b/modules/core/test/test_umat.cpp
@@ -237,3 +237,17 @@ TEST(Core_UMat, getUMat)
     EXPECT_EQ(err, 0.);
     }
 }
+
+TEST(UMat, Sync)
+{
+    UMat um(10, 10, CV_8UC1);
+
+    {
+        Mat m = um.getMat(ACCESS_WRITE);
+        m.setTo(cv::Scalar::all(17));
+    }
+
+    um.setTo(cv::Scalar::all(19));
+
+    EXPECT_EQ(0, cv::norm(um.getMat(ACCESS_READ), cv::Mat(um.size(), um.type(), 19), NORM_INF));
+}


### PR DESCRIPTION
Test that shows the problem:

```
TEST(UMat, Sync)
{
    UMat um(10, 10, CV_8UC1);

    {
        Mat m = um.getMat(ACCESS_WRITE);
        m.setTo(cv::Scalar::all(17));
    }

    um.setTo(cv::Scalar::all(19));

    EXPECT_EQ(19, cv::norm(um.getMat(ACCESS_READ), cv::NORM_INF));
    EXPECT_EQ(19 * um.total(), cv::norm(um.getMat(ACCESS_READ), cv::NORM_L1));
}
```
