### PR TITLE
Fix algorithm setter argument validation for uchar

### DIFF
--- a/modules/core/src/algorithm.cpp
+++ b/modules/core/src/algorithm.cpp
@@ -628,7 +628,7 @@ void AlgorithmInfo::set(Algorithm* algo, const char* parameter, int argType, con
             || argType == Param::FLOAT || argType == Param::UNSIGNED_INT || argType == Param::UINT64 || argType == Param::UCHAR)
     {
         if ( !( p->type == Param::INT || p->type == Param::REAL || p->type == Param::BOOLEAN
-                || p->type == Param::UNSIGNED_INT || p->type == Param::UINT64 || p->type == Param::FLOAT || argType == Param::UCHAR) )
+                || p->type == Param::UNSIGNED_INT || p->type == Param::UINT64 || p->type == Param::FLOAT || p->type == Param::UCHAR) )
         {
             String message = getErrorMessageForWrongArgumentInSetter(algo->name(), parameter, p->type, argType);
             CV_Error(CV_StsBadArg, message);


### PR DESCRIPTION
Due to this bug, it's impossible to set any uchar parameters of algorithms.

For example, trying to set the nShadowDetection parameter of a BackgroundSubtractorMOG2 instance results in the following exception:

"Argument error: the setter method was called for the parameter 'nShadowDetection' of the algorithm 'BackgroundSubtractor.MOG2', the parameter has unsigned char type, so it should be set by integer, unsigned integer, uint64, unsigned char, boolean, float or double value, but the setter was called with integer"

The attached commit fixes this.
