### PR TITLE
Ensure KMeans++ will pick centers with a probability proportional to their squared distance

### DIFF
--- a/modules/flann/include/opencv2/flann/dist.h
+++ b/modules/flann/include/opencv2/flann/dist.h
@@ -812,6 +812,66 @@ struct ZeroIterator
 
 };
 
+
+/*
+ * Depending on processed distances, some of them are already squared (e.g. L2)
+ * and some are not (e.g.Hamming). In KMeans++ for instance we want to be sure
+ * we are working on ^2 distances, thus following templates to ensure that.
+ */
+template <typename Distance, typename ElementType>
+struct squareDistance
+{
+    typedef typename Distance::ResultType ResultType;
+    ResultType operator()( ResultType dist ) { return dist*dist; }
+};
+
+
+template <typename ElementType>
+struct squareDistance<L2_Simple<ElementType>, ElementType>
+{
+    typedef typename L2_Simple<ElementType>::ResultType ResultType;
+    ResultType operator()( ResultType dist ) { return dist; }
+};
+
+template <typename ElementType>
+struct squareDistance<L2<ElementType>, ElementType>
+{
+    typedef typename L2<ElementType>::ResultType ResultType;
+    ResultType operator()( ResultType dist ) { return dist; }
+};
+
+
+template <typename ElementType>
+struct squareDistance<MinkowskiDistance<ElementType>, ElementType>
+{
+    typedef typename MinkowskiDistance<ElementType>::ResultType ResultType;
+    ResultType operator()( ResultType dist ) { return dist; }
+};
+
+template <typename ElementType>
+struct squareDistance<HellingerDistance<ElementType>, ElementType>
+{
+    typedef typename HellingerDistance<ElementType>::ResultType ResultType;
+    ResultType operator()( ResultType dist ) { return dist; }
+};
+
+template <typename ElementType>
+struct squareDistance<ChiSquareDistance<ElementType>, ElementType>
+{
+    typedef typename ChiSquareDistance<ElementType>::ResultType ResultType;
+    ResultType operator()( ResultType dist ) { return dist; }
+};
+
+
+template <typename Distance>
+typename Distance::ResultType ensureSquareDistance( typename Distance::ResultType dist )
+{
+    typedef typename Distance::ElementType ElementType;
+
+    squareDistance<Distance, ElementType> dummy;
+    return dummy( dist );
+}
+
 }
 
 #endif //OPENCV_FLANN_DIST_H_

--- a/modules/flann/include/opencv2/flann/hierarchical_clustering_index.h
+++ b/modules/flann/include/opencv2/flann/hierarchical_clustering_index.h
@@ -214,7 +214,7 @@ private:
         // far from previous centers (and this complies to "k-means++: the advantages of careful seeding" article)
         for (int i = 0; i < n; i++) {
             closestDistSq[i] = distance(dataset[dsindices[i]], dataset[dsindices[index]], dataset.cols);
-            closestDistSq[i] *= closestDistSq[i];
+            closestDistSq[i] = ensureSquareDistance<Distance>( closestDistSq[i] );
             currentPot += closestDistSq[i];
         }
 
@@ -242,7 +242,7 @@ private:
                 double newPot = 0;
                 for (int i = 0; i < n; i++) {
                     DistanceType dist = distance(dataset[dsindices[i]], dataset[dsindices[index]], dataset.cols);
-                    newPot += std::min( dist*dist, closestDistSq[i] );
+                    newPot += std::min( ensureSquareDistance<Distance>(dist), closestDistSq[i] );
                 }
 
                 // Store the best result
@@ -257,7 +257,7 @@ private:
             currentPot = bestNewPot;
             for (int i = 0; i < n; i++) {
                 DistanceType dist = distance(dataset[dsindices[i]], dataset[dsindices[bestNewIndex]], dataset.cols);
-                closestDistSq[i] = std::min( dist*dist, closestDistSq[i] );
+                closestDistSq[i] = std::min( ensureSquareDistance<Distance>(dist), closestDistSq[i] );
             }
         }
 

--- a/modules/flann/include/opencv2/flann/kmeans_index.h
+++ b/modules/flann/include/opencv2/flann/kmeans_index.h
@@ -53,62 +53,6 @@
 namespace cvflann
 {
 
-template <typename Distance, typename ElementType>
-struct squareDistance
-{
-    typedef typename Distance::ResultType ResultType;
-    ResultType operator()( ResultType dist ) { return dist*dist; }
-};
-
-
-template <typename ElementType>
-struct squareDistance<L2_Simple<ElementType>, ElementType>
-{
-    typedef typename L2_Simple<ElementType>::ResultType ResultType;
-    ResultType operator()( ResultType dist ) { return dist; }
-};
-
-template <typename ElementType>
-struct squareDistance<L2<ElementType>, ElementType>
-{
-    typedef typename L2<ElementType>::ResultType ResultType;
-    ResultType operator()( ResultType dist ) { return dist; }
-};
-
-
-template <typename ElementType>
-struct squareDistance<MinkowskiDistance<ElementType>, ElementType>
-{
-    typedef typename MinkowskiDistance<ElementType>::ResultType ResultType;
-    ResultType operator()( ResultType dist ) { return dist; }
-};
-
-template <typename ElementType>
-struct squareDistance<HellingerDistance<ElementType>, ElementType>
-{
-    typedef typename HellingerDistance<ElementType>::ResultType ResultType;
-    ResultType operator()( ResultType dist ) { return dist; }
-};
-
-template <typename ElementType>
-struct squareDistance<ChiSquareDistance<ElementType>, ElementType>
-{
-    typedef typename ChiSquareDistance<ElementType>::ResultType ResultType;
-    ResultType operator()( ResultType dist ) { return dist; }
-};
-
-
-template <typename Distance>
-typename Distance::ResultType ensureSquareDistance( typename Distance::ResultType dist )
-{
-    typedef typename Distance::ElementType ElementType;
-
-    squareDistance<Distance, ElementType> dummy;
-    return dummy( dist );
-}
-
-
-
 struct KMeansIndexParams : public IndexParams
 {
     KMeansIndexParams(int branching = 32, int iterations = 11,


### PR DESCRIPTION
Some distances such as L2 are already returning their squared value actually, while many distances (e.g. Hamming, L1, ...) don't. It's helpful to have a way to be sure the returned value is squared without having to look at the code to check how distances are processed. This is what we do by using a template ensureSquareDistance( dist ) for efficiency to avoid passing through conditional branches at runtime.
