### PR TITLE
when computing KMeans centers on non-real points, it's better to round instead of letting the compiler truncate the centers positions

### DIFF
--- a/modules/flann/include/opencv2/flann/kmeans_index.h
+++ b/modules/flann/include/opencv2/flann/kmeans_index.h
@@ -53,8 +53,10 @@
 namespace cvflann
 {
 
+namespace {
+
 template <typename ElementType>
-static double prepareRoundingIfIntegerElementType( double value ) {
+double prepareRoundingIfIntegerElementType( double value ) {
     return value;
 };
 
@@ -110,6 +112,7 @@ double prepareRoundingIfIntegerElementType<unsigned long long>( double value ) {
     return (value + 0.5);
 };
 
+}
 
 
 struct KMeansIndexParams : public IndexParams


### PR DESCRIPTION
Explanation:
dcenters[i][k] is a double, so why do we need to round it? 
Because if Distance is belonging to the Integer space, "distance_" in the line below 
    DistanceType sq_dist = distance_(dataset_[indices[i]], dcenters[j], veclen_);
will truncate dcenters[j], so that's why we add or substract 0.5 (depends on the sign) to get the same result as round().

And why don't we use round() instead? 
Because as the result is still stored in dcenters[i][k] that is a double, 6 for instance might be stored as 5.999999999

Finally, why don't we just create a template with a int result that will do the work like that:
         DistanceType new_sq_dist = distance_(dataset_[indices[i]], roundTemplate<ElementType>(dcenters[j]), veclen_);
Because we are in an inner loop, so this would slow down process.
