### PR TITLE
imgproc: IPP compilation fix and minor cleanup

### DIFF
--- a/modules/imgproc/src/deriv.cpp
+++ b/modules/imgproc/src/deriv.cpp
@@ -472,7 +472,7 @@ void cv::Scharr( InputArray _src, OutputArray _dst, int ddepth, int dx, int dy,
 #endif
 
 #if defined (HAVE_IPP) && (IPP_VERSION_MAJOR >= 7)
-    if(dx < 2 && dy < 2 && src.channels() == 1 && borderType == 1)
+    if(dx < 2 && dy < 2 && _src.channels() == 1 && borderType == 1)
     {
         Mat src = _src.getMat(), dst = _dst.getMat();
         if(IPPDerivScharr(src, dst, ddepth, dx, dy, scale))


### PR DESCRIPTION
This PR fixes a couple of IPP compilation issues in imgproc, and cleans up a small amount of code duplication in `sumpixels`.

It also fixes a bug where, if using IPP, `_sqsum.needed()` and `sqdepth != CV_64F`, then `sqsum` would not be filled despite being needed.
