### PR TITLE
core/utility.hpp missing in flann/timer.h

### DIFF
--- a/modules/flann/include/opencv2/flann/timer.h
+++ b/modules/flann/include/opencv2/flann/timer.h
@@ -33,6 +33,7 @@
 
 #include <time.h>
 #include "opencv2/core.hpp"
+#include "opencv2/core/utility.hpp"
 
 namespace cvflann
 {


### PR DESCRIPTION
core/utility.hpp missing in flann/timer.h

cv::getTickCount(); and friends where shifted to core/utility.hpp in master
