### PR TITLE
Fix the bug 3440.

### DIFF
--- a/modules/matlab/CMakeLists.txt
+++ b/modules/matlab/CMakeLists.txt
@@ -104,7 +104,7 @@ set(RST_PARSER_PATH ${CMAKE_SOURCE_DIR}/modules/java/generator)
 
 # set mex compiler options
 prepend("-I" MEX_INCLUDE_DIRS ${CMAKE_CURRENT_SOURCE_DIR}/include)
-prepend("-L" MEX_LIB_DIR  ${LIBRARY_OUTPUT_PATH}/$<CONFIGURATION> ${LIBRARY_OUTPUT_PATH}/)
+prepend("-L" MEX_LIB_DIR  ${LIBRARY_OUTPUT_PATH}/${CMAKE_CFG_INTDIR} )
 set(MEX_OPTS "-largeArrayDims")
 
 if (BUILD_TESTS)


### PR DESCRIPTION
There are two problem in the Matlab module's CMakeLists.txt.
1. According the implementation of macro PREPEND, I think it might be designed to take various IN arguments. But in fact it's not.
2. The value of MEX_LIB_DIR was not taken into account of UNIX systems.
