### PR TITLE
OCL: fixed warning

### DIFF
--- a/modules/ocl/src/gftt.cpp
+++ b/modules/ocl/src/gftt.cpp
@@ -208,7 +208,7 @@ void cv::ocl::GoodFeaturesToTrackDetector_OCL::operator ()(const oclMat& image, 
     if(!use_cpu_sorter)
     {   // round to 2^n
         unsigned int n=1;
-        for(n=1;n<(unsigned int)corner_array_size;n<<=1);
+        for(n=1;n<(unsigned int)corner_array_size;n<<=1) ;
         corner_array_size = (int)n;
 
         ensureSizeIsEnough(1, corner_array_size , CV_32FC2, tmpCorners_);


### PR DESCRIPTION
see http://build.opencv.org/builders/macos_x64%5Bdebug%5D--%5Bsse_%3D_ON%5D--%5Btbb_%3D_OFF%5D--%5Bgpu_%3D_OFF%5D--%5Bcompiler_%3D_gcc%5D--%5Btests_%3D_ON%5D-/builds/1111/steps/compile/logs/warnings%20%281%29
