### PR TITLE
eliminate MINGW pragma warning

### DIFF
--- a/modules/core/src/system.cpp
+++ b/modules/core/src/system.cpp
@@ -982,7 +982,9 @@ public:
 };
 
 #ifdef WIN32
+#ifdef _MSC_VER
 #pragma warning(disable:4505) // unreferenced local function has been removed
+#endif
 
 #ifdef HAVE_WINRT
     // using C++11 thread attribute for local thread data


### PR DESCRIPTION
http://build.opencv.org/builders/win_x86%5Brelease%5D--%5Bsse_%3D_ON%5D--%5Btbb_%3D_OFF%5D--%5Bgpu_%3D_OFF%5D--%5Bcompiler_%3D_mingw%5D--%5Btests_%3D_ON%5D-/builds/1236/
