### PR TITLE
Fix typo of SparseMat_<_Tp>::SparseMat_(const SparseMat& m)

### DIFF
--- a/modules/core/include/opencv2/core/mat.inl.hpp
+++ b/modules/core/include/opencv2/core/mat.inl.hpp
@@ -1912,7 +1912,7 @@ SparseMat_<_Tp>::SparseMat_(const SparseMat& m)
     if( m.type() == DataType<_Tp>::type )
         *this = (const SparseMat_<_Tp>&)m;
     else
-        m.convertTo(this, DataType<_Tp>::type);
+        m.convertTo(*this, DataType<_Tp>::type);
 }
 
 template<typename _Tp> inline


### PR DESCRIPTION
Fix compilation erros when compiling this constructor.
First argument type of "convertTo" should be instance, not a pointer of instance.
