### PR TITLE
Fix typo of SparseMat_<_Tp>::SparseMat_(const SparseMat& m)

### DIFF
--- a/modules/core/include/opencv2/core/mat.hpp
+++ b/modules/core/include/opencv2/core/mat.hpp
@@ -2401,7 +2401,7 @@ template<typename _Tp> inline SparseMat_<_Tp>::SparseMat_(const SparseMat& m)
     if( m.type() == DataType<_Tp>::type )
         *this = (const SparseMat_<_Tp>&)m;
     else
-        m.convertTo(this, DataType<_Tp>::type);
+        m.convertTo(*this, DataType<_Tp>::type);
 }
 
 template<typename _Tp> inline SparseMat_<_Tp>::SparseMat_(const SparseMat_<_Tp>& m)


### PR DESCRIPTION
Fix compilation erros when compiling this constructor.
First argument type of "convertTo" should be instance, not a pointer of instance.

First pull request was created for master branch.
But it should be marged for 2.4.
Old pull request -> https://github.com/Itseez/opencv/pull/2113
