### PR TITLE
Fixed a valgrind 'Conditional jump or move depends on uninitialised valu...

### DIFF
--- a/samples/cpp/kmeans.cpp
+++ b/samples/cpp/kmeans.cpp
@@ -36,7 +36,7 @@ int main( int /*argc*/, char** /*argv*/ )
         Mat points(sampleCount, 2, CV_32F), labels;
 
         clusterCount = MIN(clusterCount, sampleCount);
-        Mat centers(clusterCount, 1, points.type());
+        Mat centers;
 
         /* generate random sample from multigaussian distribution */
         for( k = 0; k < clusterCount; k++ )


### PR DESCRIPTION
Fixed a valgrind 'Conditional jump or move depends on uninitialised value(s)' on cv::kmeans(...). The original code used points(sampleCount, 1, CV_32FC2), which confused generateCentersPP into thinking it is a 1 dimensional center, instead of 2. As a result it would set only the x variable and leave y unitialised.

This is the original error by valgrind:

==2348== Conditional jump or move depends on uninitialised value(s)
==2348==    at 0x4F9BB2D: cv::KMeansDistanceComputer::operator()(cv::Range const&) const (in /usr/local/lib/libopencv_core.so.2.4.8)
==2348==    by 0x4FDB935: cv::kmeans(cv::_InputArray const&, int, cv::_OutputArray const&, cv::TermCriteria, int, int, cv::_OutputArray const&) (in /usr/local/lib/libopencv_core.so.2.4.8)
==2348==    by 0x4015A9: main (kmeans.cpp:57)
==2348== 
==2348== Conditional jump or move depends on uninitialised value(s)
==2348==    at 0x4FDB7E2: cv::kmeans(cv::_InputArray const&, int, cv::_OutputArray const&, cv::TermCriteria, int, int, cv::_OutputArray const&) (in /usr/local/lib/libopencv_core.so.2.4.8)
==2348==    by 0x4015A9: main (kmeans.cpp:57)
==2348== 
