### PR TITLE
Fix compiler error with Android NDK r8e

### DIFF
--- a/modules/objdetect/src/cascadedetect.cpp
+++ b/modules/objdetect/src/cascadedetect.cpp
@@ -1212,7 +1212,7 @@ bool CascadeClassifierImpl::ocl_detectSingleScale( InputArray _image, Size proce
                         ocl::KernelArg::PtrWriteOnly(ufacepos), // positions
                         processingRectSize,
                         yStep, (float)factor,
-                        normrect, data.origWinSize, MAX_FACES);
+                        normrect, data.origWinSize, (int)MAX_FACES);
         ok = haarKernel.run(2, globalsize, 0, true);
     }
     else if( featureType == FeatureEvaluator::LBP )
@@ -1245,7 +1245,7 @@ bool CascadeClassifierImpl::ocl_detectSingleScale( InputArray _image, Size proce
                         ocl::KernelArg::PtrWriteOnly(ufacepos), // positions
                         processingRectSize,
                         yStep, (float)factor,
-                        data.origWinSize, MAX_FACES);
+                        data.origWinSize, (int)MAX_FACES);
         ok = lbpKernel.run(2, globalsize, 0, true);
     }
     //CV_Assert(ok);


### PR DESCRIPTION
Original error without the fix:

opencv/modules/objdetect/src/cascadedetect.cpp: In member function 'bool cv::CascadeClassifierImpl::ocl_detectSingleScale(const cv::_InputArray&, cv::Size, int, double, cv::Size)':
/opencv/modules/objdetect/src/cascadedetect.cpp:1215:
error: no matching function for call to 'cv::ocl::Kernel::args(cv::ocl::KernelArg, cv::ocl::KernelArg, cv::ocl::KernelArg, int, cv::ocl::KernelArg, cv::ocl::KernelArg, cv::ocl::KernelArg, cv::Size&, int&, float, cv::Rect&, cv::Size&, cv::CascadeClassifierImpl::<anonymous enum>)'
