### PR TITLE
Corrected package name in tutorial

### DIFF
--- a/doc/tutorials/introduction/linux_install/linux_install.rst
+++ b/doc/tutorials/introduction/linux_install/linux_install.rst
@@ -16,7 +16,7 @@ Required Packages
   * CMake 2.6 or higher;
   * Git;
   * GTK+2.x or higher, including headers (libgtk2.0-dev);
-  * pkgconfig;
+  * pkg-config;
   * Python 2.6 or later and Numpy 1.5 or later with developer packages (python-dev, python-numpy);
   * ffmpeg or libav development packages: libavcodec-dev, libavformat-dev, libswscale-dev;
   * [optional] libdc1394 2.x;


### PR DESCRIPTION
See also #2101

---

Although this is a really minor issue, it should be rightened in order to stay consistent in the list (all other package names are correctly noted).
