### PR TITLE
Fix the following error for ocl::getOpenCLPlatforms() on Ubuntu 12.04 wi...

### DIFF
--- a/3rdparty/include/opencl/1.2/CL/cl.hpp
+++ b/3rdparty/include/opencl/1.2/CL/cl.hpp
@@ -210,7 +210,7 @@
 #include <string>
 #endif 
 
-#if defined(linux) || defined(__APPLE__) || defined(__MACOSX)
+#if defined(__linux__) || defined(__APPLE__) || defined(__MACOSX)
 #include <alloca.h>
 
 #include <emmintrin.h>

--- a/modules/ocl/src/cl_runtime/cl_runtime.cpp
+++ b/modules/ocl/src/cl_runtime/cl_runtime.cpp
@@ -45,7 +45,7 @@
     #define CV_CL_GET_PROC_ADDRESS(name) WinGetProcAddress(name)
 #endif // _WIN32
 
-#if defined(linux)
+#if defined(__linux__)
     #include <dlfcn.h>
     #include <stdio.h>
 

--- a/modules/ocl/src/cl_runtime/clamdblas_runtime.cpp
+++ b/modules/ocl/src/cl_runtime/clamdblas_runtime.cpp
@@ -27,7 +27,7 @@
     #define CV_CL_GET_PROC_ADDRESS(name) WinGetProcAddress(name)
 #endif // _WIN32
 
-#if defined(linux)
+#if defined(__linux__)
     #include <dlfcn.h>
     #include <stdio.h>
 

--- a/modules/ocl/src/cl_runtime/clamdfft_runtime.cpp
+++ b/modules/ocl/src/cl_runtime/clamdfft_runtime.cpp
@@ -27,7 +27,7 @@
     #define CV_CL_GET_PROC_ADDRESS(name) WinGetProcAddress(name)
 #endif // _WIN32
 
-#if defined(linux)
+#if defined(__linux__)
     #include <dlfcn.h>
     #include <stdio.h>
 

--- a/modules/ocl/src/cl_runtime/generator/template/clamdblas_runtime.cpp.in
+++ b/modules/ocl/src/cl_runtime/generator/template/clamdblas_runtime.cpp.in
@@ -24,7 +24,7 @@
     #define CV_CL_GET_PROC_ADDRESS(name) WinGetProcAddress(name)
 #endif // _WIN32
 
-#if defined(linux)
+#if defined(__linux__)
     #include <dlfcn.h>
     #include <stdio.h>
 

--- a/modules/ocl/src/cl_runtime/generator/template/clamdfft_runtime.cpp.in
+++ b/modules/ocl/src/cl_runtime/generator/template/clamdfft_runtime.cpp.in
@@ -24,7 +24,7 @@
     #define CV_CL_GET_PROC_ADDRESS(name) WinGetProcAddress(name)
 #endif // _WIN32
 
-#if defined(linux)
+#if defined(__linux__)
     #include <dlfcn.h>
     #include <stdio.h>
 


### PR DESCRIPTION
...th gcc 4.8

OpenCV Error: Unknown error code -6 (OpenCL function is not available: [clGetPlatformIDs]) in opencl_check_fn, file /home/ahb/software/opencv/modules/ocl/src/cl_runtime/cl_runtime.cpp, line 83

The issue results from modules/ocl/src/cl_runtime/cl_runtime.cpp checking for
"linux" instead of "**linux**" (cf.  http://sourceforge.net/p/predef/wiki/OperatingSystems/)

Adjust all other occurrences of "defined(linux)" as well.
