### PR TITLE
Fixed bug #3489

### DIFF
--- a/modules/core/src/system.cpp
+++ b/modules/core/src/system.cpp
@@ -1131,17 +1131,24 @@ public:
         }
     }
 };
-static TLSContainerStorage tlsContainerStorage;
+
+// This is a wrapper function that will ensure 'tlsContainerStorage' is constructed on first use.
+// For more information: http://www.parashift.com/c++-faq/static-init-order-on-first-use.html
+static TLSContainerStorage& getTLSContainerStorage()
+{
+    static TLSContainerStorage *tlsContainerStorage = new TLSContainerStorage();
+    return *tlsContainerStorage;
+}
 
 TLSDataContainer::TLSDataContainer()
     : key_(-1)
 {
-    key_ = tlsContainerStorage.allocateKey(this);
+    key_ = getTLSContainerStorage().allocateKey(this);
 }
 
 TLSDataContainer::~TLSDataContainer()
 {
-    tlsContainerStorage.releaseKey(key_, this);
+    getTLSContainerStorage().releaseKey(key_, this);
     key_ = -1;
 }
 
@@ -1166,7 +1173,7 @@ TLSStorage::~TLSStorage()
         void*& data = tlsData_[i];
         if (data)
         {
-            tlsContainerStorage.destroyData(i, data);
+            getTLSContainerStorage().destroyData(i, data);
             data = NULL;
         }
     }


### PR DESCRIPTION
The code assumed that two global variables would be constructed in a particular order, but global variable initialization order is compiler-dependent. On CentOS 6.5, this bug caused a segmentation fault.
