### PR TITLE
Fix Bug #3477

### DIFF
--- a/modules/java/generator/src/cpp/VideoCapture.cpp
+++ b/modules/java/generator/src/cpp/VideoCapture.cpp
@@ -329,7 +329,10 @@ JNIEXPORT jstring JNICALL Java_org_opencv_highgui_VideoCapture_n_1getSupportedPr
         VideoCapture* me = (VideoCapture*) self; //TODO: check for NULL
         union {double prop; const char* name;} u;
         u.prop = me->get(CV_CAP_PROP_SUPPORTED_PREVIEW_SIZES_STRING);
-        return env->NewStringUTF(u.name);
+        // VideoCapture::get can return 0.0 or -1.0 if it doesn't support
+        // CV_CAP_PROP_SUPPORTED_PREVIEW_SIZES_STRING
+        if (u.prop != 0.0 && u.prop != -1.0)
+            return env->NewStringUTF(u.name);
     } catch(const std::exception &e) {
         throwJavaException(env, &e, method_name);
     } catch (...) {


### PR DESCRIPTION
`CV_CAP_PROP_SUPPORTED_PREVIEW_SIZES_STRING` property is not supported
by all `VideoCapture` backends. Some backends can return 0.0 or -1.0.

Link to bug : http://code.opencv.org/issues/3477
