### PR TITLE
Fix build for samples/cpp/train_HOG.cpp

### DIFF
--- a/samples/cpp/train_HOG.cpp
+++ b/samples/cpp/train_HOG.cpp
@@ -14,7 +14,7 @@ void get_svm_detector(const SVM& svm, vector< float > & hog_detector );
 void convert_to_ml(const std::vector< cv::Mat > & train_samples, cv::Mat& trainData );
 void load_images( const string & prefix, const string & filename, vector< Mat > & img_lst );
 void sample_neg( const vector< Mat > & full_neg_lst, vector< Mat > & neg_lst, const Size & size );
-Mat get_hogdescriptor_visu(Mat& color_origImg, vector<float>& descriptorValues, const Size & size );
+Mat get_hogdescriptor_visu(const Mat& color_origImg, vector<float>& descriptorValues, const Size & size );
 void compute_hog( const vector< Mat > & img_lst, vector< Mat > & gradient_lst, const Size & size );
 void train_svm( const vector< Mat > & gradient_lst, const vector< int > & labels );
 void draw_locations( Mat & img, const vector< Rect > & locations, const Scalar & color );
@@ -155,7 +155,7 @@ void sample_neg( const vector< Mat > & full_neg_lst, vector< Mat > & neg_lst, co
 }
 
 // From http://www.juergenwiki.de/work/wiki/doku.php?id=public:hog_descriptor_computation_and_visualization
-Mat get_hogdescriptor_visu(Mat& color_origImg, vector<float>& descriptorValues, const Size & size )
+Mat get_hogdescriptor_visu(const Mat& color_origImg, vector<float>& descriptorValues, const Size & size )
 {
     const int DIMX = size.width;
     const int DIMY = size.height;


### PR DESCRIPTION
`get_hogdescriptor_visu` is passed `img->clone()`, which is not usable as a non-const reference (and it doesn't modify the argument, anyway).
