### PR TITLE
Fixed Bug #3514 Incorrect Chi-Square distance used in LBPH FaceRecognize...

### DIFF
--- a/modules/contrib/src/facerec.cpp
+++ b/modules/contrib/src/facerec.cpp
@@ -833,7 +833,7 @@ void LBPH::predict(InputArray _src, int &minClass, double &minDist) const {
     minDist = DBL_MAX;
     minClass = -1;
     for(size_t sampleIdx = 0; sampleIdx < _histograms.size(); sampleIdx++) {
-        double dist = compareHist(_histograms[sampleIdx], query, HISTCMP_CHISQR);
+        double dist = compareHist(_histograms[sampleIdx], query, HISTCMP_CHISQR_ALT);
         if((dist < minDist) && (dist < _threshold)) {
             minDist = dist;
             minClass = _labels.at<int>((int) sampleIdx);

--- a/modules/imgproc/include/opencv2/imgproc.hpp
+++ b/modules/imgproc/include/opencv2/imgproc.hpp
@@ -203,7 +203,8 @@ enum { HISTCMP_CORREL        = 0,
        HISTCMP_CHISQR        = 1,
        HISTCMP_INTERSECT     = 2,
        HISTCMP_BHATTACHARYYA = 3,
-       HISTCMP_HELLINGER     = HISTCMP_BHATTACHARYYA
+       HISTCMP_HELLINGER     = HISTCMP_BHATTACHARYYA,
+       HISTCMP_CHISQR_ALT    = 4
      };
 
 //! the color conversion code


### PR DESCRIPTION
When using LBPH face recognizer, in prediction, the algorithm computes the Chi-Square distance between two spatial histograms, the correct Chi-Square distance should be CV_COMP_CHISQR_ALT introduced in this commit:
https://github.com/vkocheganov/opencv/commit/086db9d6db73956be2ee18b8a552a9179da6b6fd

Reference paper regarding LBPH: Ahonen, T., Hadid, A., and Pietikainen, M. Face Recognition with Local Binary Patterns. Computer Vision - ECCV 2004 (2004), 469–481.
