### PR TITLE
2.4 latentsvm speedup

### DIFF
--- a/modules/objdetect/src/featurepyramid.cpp
+++ b/modules/objdetect/src/featurepyramid.cpp
@@ -435,37 +435,37 @@ int PCAFeatureMaps(CvLSVMFeatureMap *map)
 
 #ifdef HAVE_TBB
 struct FeaturePyramid {
-	
-	FeaturePyramid(IplImage* _image,
-	const float _step,
-	const int _startIndex,
-	const int _sideLength,
-	CvLSVMFeaturePyramid **_maps) :
-		image(_image),
-		step(_step),
-		startIndex(_startIndex),
-		sideLength(_sideLength),
-		maps(_maps)
-	{}
 
-	IplImage * image;
-	const float step;
-	const int startIndex;
-	const int sideLength;
-	CvLSVMFeaturePyramid **maps;
+    FeaturePyramid(IplImage* _image,
+    const float _step,
+    const int _startIndex,
+    const int _sideLength,
+    CvLSVMFeaturePyramid **_maps) :
+        image(_image),
+        step(_step),
+        startIndex(_startIndex),
+        sideLength(_sideLength),
+        maps(_maps)
+    {}
 
-	void operator()( const tbb::blocked_range<int>& range ) const {
-		for( int i=range.begin(); i!=range.end(); ++i ) {
-			CvLSVMFeatureMap *map;
-			float scale = 1.0f / powf(step, (float)i);
-			IplImage* scaleTmp = resize_opencv (image, scale);
-			getFeatureMaps(scaleTmp, sideLength, &map);
-			normalizeAndTruncate(map, VAL_OF_TRUNCATE);
-			PCAFeatureMaps(map);
-			(*maps)->pyramid[startIndex + i] = map;
-			cvReleaseImage(&scaleTmp);
-		}
-	}
+    IplImage * image;
+    const float step;
+    const int startIndex;
+    const int sideLength;
+    CvLSVMFeaturePyramid **maps;
+
+    void operator()( const tbb::blocked_range<int>& range ) const {
+        for( int i=range.begin(); i!=range.end(); ++i ) {
+            CvLSVMFeatureMap *map;
+            float scale = 1.0f / powf(step, (float)i);
+            IplImage* scaleTmp = resize_opencv (image, scale);
+            getFeatureMaps(scaleTmp, sideLength, &map);
+            normalizeAndTruncate(map, VAL_OF_TRUNCATE);
+            PCAFeatureMaps(map);
+            (*maps)->pyramid[startIndex + i] = map;
+            cvReleaseImage(&scaleTmp);
+        }
+    }
 };
 #endif
 
@@ -475,8 +475,8 @@ static int getPathOfFeaturePyramid(IplImage * image,
 {
 #ifdef HAVE_TBB
 
-	FeaturePyramid fp(image, step, startIndex, sideLength, maps);
-	tbb::parallel_for( tbb::blocked_range<int>( 0, numStep ), fp );
+    FeaturePyramid fp(image, step, startIndex, sideLength, maps);
+    tbb::parallel_for( tbb::blocked_range<int>( 0, numStep ), fp );
 
 #else
 


### PR DESCRIPTION
Parallelize the latentsvm feature pyramid building stage. The feature pyramid creation was executed in serial manner which could be slow if the image size is large.
