### PR TITLE
Update cap_ios_abstract_camera.mm

### DIFF
--- a/modules/highgui/src/cap_ios_abstract_camera.mm
+++ b/modules/highgui/src/cap_ios_abstract_camera.mm
@@ -278,9 +278,21 @@
 {
     self.captureVideoPreviewLayer = [[AVCaptureVideoPreviewLayer alloc] initWithSession:self.captureSession];
 
-    if ([self.captureVideoPreviewLayer isOrientationSupported]) {
-        [self.captureVideoPreviewLayer setOrientation:self.defaultAVCaptureVideoOrientation];
-    }
+    if ([self.captureVideoPreviewLayer respondsToSelector:@selector(connection)])
+	{
+		if ([self.captureVideoPreviewLayer.connection isVideoOrientationSupported])
+		{
+			[self.captureVideoPreviewLayer.connection setVideoOrientation:self.defaultAVCaptureVideoOrientation];
+		}
+	}
+	else
+	{
+		// Deprecated in 6.0; here for backward compatibility
+		if ([self.captureVideoPreviewLayer isOrientationSupported])
+		{
+			[self.captureVideoPreviewLayer setOrientation:self.defaultAVCaptureVideoOrientation];
+		}                
+	}
 
     if (parentView != nil) {
         self.captureVideoPreviewLayer.frame = self.parentView.bounds;


### PR DESCRIPTION
AVCaptureVideoPreviewLayer setOrientation is depricated. This fixes the warning and provides backward compatibility.
