### PR TITLE
Change v4l2_scan_controls_enumerate_menu to not perror on null ioctl.

### DIFF
--- a/modules/highgui/src/cap_libv4l.cpp
+++ b/modules/highgui/src/cap_libv4l.cpp
@@ -500,13 +500,9 @@ static void v4l2_scan_controls_enumerate_menu(CvCaptureCAM_V4L* capture)
        (int)capture->querymenu.index <= capture->queryctrl.maximum;
        capture->querymenu.index++)
   {
-    if (0 == xioctl (capture->deviceHandle, VIDIOC_QUERYMENU,
-                     &capture->querymenu))
-    {
-      //printf (" %s\n", capture->querymenu.name);
-    } else {
-        perror ("VIDIOC_QUERYMENU");
-    }
+     if (xioctl (capture->deviceHandle, VIDIOC_QUERYMENU,
+                &capture->querymenu))
+                   continue;
   }
 }
 

--- a/modules/highgui/src/cap_v4l.cpp
+++ b/modules/highgui/src/cap_v4l.cpp
@@ -650,13 +650,9 @@ static void v4l2_scan_controls_enumerate_menu(CvCaptureCAM_V4L* capture)
        (int)capture->querymenu.index <= capture->queryctrl.maximum;
        capture->querymenu.index++)
   {
-    if (0 == ioctl (capture->deviceHandle, VIDIOC_QUERYMENU,
-                     &capture->querymenu))
-    {
-//      printf (" %s\n", capture->querymenu.name);
-    } else {
-        perror ("VIDIOC_QUERYMENU");
-    }
+     if (ioctl (capture->deviceHandle, VIDIOC_QUERYMENU,
+                &capture->querymenu))
+                   continue;
   }
 }
 


### PR DESCRIPTION
See http://www.raspberrypi.org/forum/viewtopic.php?f=43&t=65026 for detail. Basically, this change copies the same procedure that v4l2-ctl uses in v4l2-ctl-common.cpp/print_qctrl  (http://git.linuxtv.org/v4l-utils.git/tree/refs/heads/master:/utils/v4l2-ctl). 
