### PR TITLE
Initializer for Vec::zeros()

### DIFF
--- a/modules/core/include/opencv2/core/matx.hpp
+++ b/modules/core/include/opencv2/core/matx.hpp
@@ -313,6 +313,7 @@ public:
     Vec(const Vec<_Tp, cn>& v);
 
     static Vec all(_Tp alpha);
+    static Vec zeros();
 
     //! per-element multiplication
     Vec mul(const Vec<_Tp, cn>& v) const;
@@ -937,6 +938,12 @@ Vec<_Tp, cn> Vec<_Tp, cn>::all(_Tp alpha)
     Vec v;
     for( int i = 0; i < cn; i++ ) v.val[i] = alpha;
     return v;
+}
+
+template<typename _Tp, int cn> inline
+Vec<_Tp, cn> Vec<_Tp, cn>::zeros()
+{
+    return all(0);
 }
 
 template<typename _Tp, int cn> inline


### PR DESCRIPTION
Added `zeros()` initializer for `Vec` (Task #3380)
Passed all tests (`release/bin/opencv_test_*`)
Tested feature by:

``` c++
main() {
  Vec3f a = Vec3f::zeros();
  cout << a << endl;
}
```

PS: I'm a noob, and this is my first PR. Feel free to pick nits. And will appreciate any guidance. Thanks!
