### PR TITLE
decrease input size for several gpu tests to fix "timed out" error:

### DIFF
--- a/modules/gpu/test/test_denoising.cpp
+++ b/modules/gpu/test/test_denoising.cpp
@@ -114,6 +114,7 @@ GPU_TEST_P(BruteForceNonLocalMeans, Regression)
 
     cv::Mat bgr  = readImage("denoising/lena_noised_gaussian_sigma=20_multi_0.png", cv::IMREAD_COLOR);
     ASSERT_FALSE(bgr.empty());
+    cv::resize(bgr, bgr, cv::Size(256, 256));
 
     cv::Mat gray;
     cv::cvtColor(bgr, gray, CV_BGR2GRAY);
@@ -130,6 +131,8 @@ GPU_TEST_P(BruteForceNonLocalMeans, Regression)
     cv::Mat bgr_gold  = readImage("denoising/nlm_denoised_lena_bgr.png", cv::IMREAD_COLOR);
     cv::Mat gray_gold  = readImage("denoising/nlm_denoised_lena_gray.png", cv::IMREAD_GRAYSCALE);
     ASSERT_FALSE(bgr_gold.empty() || gray_gold.empty());
+    cv::resize(bgr_gold, bgr_gold, cv::Size(256, 256));
+    cv::resize(gray_gold, gray_gold, cv::Size(256, 256));
 
     EXPECT_MAT_NEAR(bgr_gold, dbgr, 1e-4);
     EXPECT_MAT_NEAR(gray_gold, dgray, 1e-4);

--- a/modules/gpu/test/test_optflow.cpp
+++ b/modules/gpu/test/test_optflow.cpp
@@ -483,13 +483,15 @@ GPU_TEST_P(OpticalFlowBM, Accuracy)
 
     cv::Mat frame0 = readImage("opticalflow/rubberwhale1.png", cv::IMREAD_GRAYSCALE);
     ASSERT_FALSE(frame0.empty());
+    cv::resize(frame0, frame0, cv::Size(), 0.5, 0.5);
 
     cv::Mat frame1 = readImage("opticalflow/rubberwhale2.png", cv::IMREAD_GRAYSCALE);
     ASSERT_FALSE(frame1.empty());
+    cv::resize(frame1, frame1, cv::Size(), 0.5, 0.5);
 
-    cv::Size block_size(16, 16);
+    cv::Size block_size(8, 8);
     cv::Size shift_size(1, 1);
-    cv::Size max_range(16, 16);
+    cv::Size max_range(8, 8);
 
     cv::gpu::GpuMat d_velx, d_vely, buf;
     cv::gpu::calcOpticalFlowBM(loadMat(frame0), loadMat(frame1),


### PR DESCRIPTION
- BruteForceNonLocalMeans
- OpticalFlowBM

Merge with https://github.com/Itseez/opencv_extra/pull/138
