### PR TITLE
grabcut.py sample: Allow drawing rect from bottom/right

### DIFF
--- a/samples/python2/grabcut.py
+++ b/samples/python2/grabcut.py
@@ -5,7 +5,7 @@ Interactive Image Segmentation using GrabCut algorithm.
 
 This sample shows interactive image segmentation using grabcut algorithm.
 
-USAGE :
+USAGE:
     python grabcut.py <filename>
 
 README FIRST:
@@ -63,14 +63,14 @@ def onmouse(event,x,y,flags,param):
         if rectangle == True:
             img = img2.copy()
             cv2.rectangle(img,(ix,iy),(x,y),BLUE,2)
-            rect = (ix,iy,abs(ix-x),abs(iy-y))
+            rect = (min(ix,x),min(iy,y),abs(ix-x),abs(iy-y))
             rect_or_mask = 0
 
     elif event == cv2.EVENT_RBUTTONUP:
         rectangle = False
         rect_over = True
         cv2.rectangle(img,(ix,iy),(x,y),BLUE,2)
-        rect = (ix,iy,abs(ix-x),abs(iy-y))
+        rect = (min(ix,x),min(iy,y),abs(ix-x),abs(iy-y))
         rect_or_mask = 0
         print " Now press the key 'n' a few times until no further change \n"
 
@@ -103,7 +103,7 @@ if len(sys.argv) == 2:
     filename = sys.argv[1] # for drawing purposes
 else:
     print "No input image given, so loading default image, lena.jpg \n"
-    print "Correct Usage : python grabcut.py <filename> \n"
+    print "Correct Usage: python grabcut.py <filename> \n"
     filename = '../cpp/lena.jpg'
 
 img = cv2.imread(filename)
@@ -117,7 +117,7 @@ cv2.namedWindow('input')
 cv2.setMouseCallback('input',onmouse)
 cv2.moveWindow('input',img.shape[1]+10,90)
 
-print " Instructions : \n"
+print " Instructions: \n"
 print " Draw a rectangle around the object using right mouse button \n"
 
 while(1):


### PR DESCRIPTION
The grabcut sample script isn't able to create rectangles correctly that are
drawn from e.g. bottom-right to top-left.
This small commit uses four min() calls to determine the correct
top-left point of the rectangle.
It also removes some unnecessary white spaces before colons.
