### PR TITLE
T-API: added performance tests for NLMeans

### DIFF
--- a/modules/photo/perf/opencl/perf_denoising.cpp
+++ b/modules/photo/perf/opencl/perf_denoising.cpp
@@ -1,0 +1,97 @@
+// This file is part of OpenCV project.
+// It is subject to the license terms in the LICENSE file found in the top-level directory
+// of this distribution and at http://opencv.org/license.html.
+
+// Copyright (C) 2014, Advanced Micro Devices, Inc., all rights reserved.
+// Third party copyrights are property of their respective owners.
+
+#include "perf_precomp.hpp"
+#include "opencv2/ts/ocl_perf.hpp"
+
+#ifdef HAVE_OPENCL
+
+namespace cvtest {
+namespace ocl {
+
+OCL_PERF_TEST(Photo, DenoisingGrayscale)
+{
+    Mat _original = imread(getDataPath("cv/denoising/lena_noised_gaussian_sigma=10.png"), IMREAD_GRAYSCALE);
+    ASSERT_FALSE(_original.empty()) << "Could not load input image";
+
+    UMat result(_original.size(), _original.type()), original;
+    _original.copyTo(original);
+
+    declare.in(original).out(result).iterations(10);
+
+    OCL_TEST_CYCLE()
+            cv::fastNlMeansDenoising(original, result, 10);
+
+    SANITY_CHECK(result);
+}
+
+OCL_PERF_TEST(Photo, DenoisingColored)
+{
+    Mat _original = imread(getDataPath("cv/denoising/lena_noised_gaussian_sigma=10.png"));
+    ASSERT_FALSE(_original.empty()) << "Could not load input image";
+
+    UMat result(_original.size(), _original.type()), original;
+    _original.copyTo(original);
+
+    declare.in(original).out(result).iterations(10);
+
+    OCL_TEST_CYCLE()
+            cv::fastNlMeansDenoisingColored(original, result, 10, 10);
+
+    SANITY_CHECK(result);
+}
+
+OCL_PERF_TEST(Photo, DenoisingGrayscaleMulti)
+{
+    const int imgs_count = 3;
+
+    vector<UMat> original(imgs_count);
+    Mat tmp;
+    for (int i = 0; i < imgs_count; i++)
+    {
+        string original_path = format("cv/denoising/lena_noised_gaussian_sigma=20_multi_%d.png", i);
+        tmp = imread(getDataPath(original_path), IMREAD_GRAYSCALE);
+        ASSERT_FALSE(tmp.empty()) << "Could not load input image " << original_path;
+        tmp.copyTo(original[i]);
+        declare.in(original[i]);
+    }
+    UMat result(tmp.size(), tmp.type());
+    declare.out(result).iterations(10);
+
+    OCL_TEST_CYCLE()
+            cv::fastNlMeansDenoisingMulti(original, result, imgs_count / 2, imgs_count, 15);
+
+    SANITY_CHECK(result);
+}
+
+OCL_PERF_TEST(Photo, DenoisingColoredMulti)
+{
+    const int imgs_count = 3;
+
+    vector<UMat> original(imgs_count);
+    Mat tmp;
+    for (int i = 0; i < imgs_count; i++)
+    {
+        string original_path = format("cv/denoising/lena_noised_gaussian_sigma=20_multi_%d.png", i);
+        tmp = imread(getDataPath(original_path), IMREAD_COLOR);
+        ASSERT_FALSE(tmp.empty()) << "Could not load input image " << original_path;
+
+        tmp.copyTo(original[i]);
+        declare.in(original[i]);
+    }
+    UMat result(tmp.size(), tmp.type());
+    declare.out(result).iterations(10);
+
+    OCL_TEST_CYCLE()
+            cv::fastNlMeansDenoisingColoredMulti(original, result, imgs_count / 2, imgs_count, 10, 15);
+
+    SANITY_CHECK(result);
+}
+
+} } // namespace cvtest::ocl
+
+#endif // HAVE_OPENCL


### PR DESCRIPTION
added performance tests for future T-API implementation of NLMeans

<b>merge with opencv_extra https://github.com/Itseez/opencv_extra/pull/139</b>
