### PR TITLE
Updated constant name in sample DisplayImage.cpp

### DIFF
--- a/doc/tutorials/introduction/linux_gcc_cmake/linux_gcc_cmake.rst
+++ b/doc/tutorials/introduction/linux_gcc_cmake/linux_gcc_cmake.rst
@@ -41,7 +41,7 @@ Let's use a simple program such as DisplayImage.cpp shown below.
          return -1;
        }
 
-     namedWindow( "Display Image", CV_WINDOW_AUTOSIZE );
+     namedWindow( "Display Image", WINDOW_AUTOSIZE );
      imshow( "Display Image", image );
 
      waitKey(0);


### PR DESCRIPTION
Reason: CV_WINDOW_AUTOSIZE caused error: <code>‘CV_WINDOW_AUTOSIZE’ was not declared in this scope</code>.
