### PR TITLE
Workaround a LLVM/Clang 3.3 bug.

### DIFF
--- a/modules/ocl/src/opencl/arithm_pow.cl
+++ b/modules/ocl/src/opencl/arithm_pow.cl
@@ -66,7 +66,7 @@ __kernel void arithm_pow(__global VT * src, int src_step, int src_offset,
         int dst_index = mad24(y, dst_step, x + dst_offset);
 
         VT src_data = src[src_index];
-        VT tmp = src_data > 0 ? exp(p * log(src_data)) : (src_data == 0 ? 0 : exp(p * log(fabs(src_data))));
+        VT tmp = src_data > (VT)0 ? (VT)exp(p * log(src_data)) : (src_data == (VT)0 ? (VT)0 : (VT)exp(p * log(fabs(src_data))));
 
         dst[dst_index] = tmp;
     }

--- a/modules/ocl/src/opencl/imgproc_resize.cl
+++ b/modules/ocl/src/opencl/imgproc_resize.cl
@@ -83,10 +83,10 @@ __kernel void resizeLN_C1_D0(__global uchar * dst, __global uchar const * restri
     int y = floor(sy);
     float v = sy - y;
 
-    u = x < 0 ? 0 : u;
-    u = (x >= src_cols) ? 0 : u;
-    x = x < 0 ? 0 : x;
-    x = (x >= src_cols) ? src_cols-1 : x;
+    u = x < (int4)0 ? (float4)0 : u;
+    u = (x >= (int4)src_cols) ? (float4)0 : u;
+    x = x < (int4)0 ? (int4)0 : x;
+    x = (x >= (int4)src_cols) ? (int4)(src_cols-1) : x;
 
     y<0 ? y=0,v=0 : y;
     y>=src_rows ? y=src_rows-1,v=0 : y;


### PR DESCRIPTION
The LLVM/Clang 3.3 has a bug when compile a cl kernel with
assignment of a scalar to a vector data type. This patch
could work around this bug.

Signed-off-by: Zhigang Gong zhigang.gong@intel.com
