### PR TITLE
bugfix for #3530

### DIFF
--- a/modules/objdetect/src/cascadedetect.cpp
+++ b/modules/objdetect/src/cascadedetect.cpp
@@ -1557,7 +1557,7 @@ bool CascadeClassifier::load( const String& filename )
 
 bool CascadeClassifier::read(const FileNode &root)
 {
-    Ptr<CascadeClassifierImpl> ccimpl;
+    Ptr<CascadeClassifierImpl> ccimpl = makePtr<CascadeClassifierImpl>();
     bool ok = ccimpl->read_(root);
     if( ok )
         cc = ccimpl.staticCast<BaseCascadeClassifier>();


### PR DESCRIPTION
bugfix for [#3530](http://code.opencv.org/issues/3530)

proper initialzation of ccimpl in CascadeClassifier::read(const FileNode &root) 
