### PR TITLE
bugfix: blobdetector was putting incorrect diameter value in keypoints

### DIFF
--- a/modules/features2d/src/blobdetector.cpp
+++ b/modules/features2d/src/blobdetector.cpp
@@ -336,7 +336,7 @@ void SimpleBlobDetector::detectImpl(InputArray image, std::vector<cv::KeyPoint>&
             normalizer += centers[i][j].confidence;
         }
         sumPoint *= (1. / normalizer);
-        KeyPoint kpt(sumPoint, (float)(centers[i][centers[i].size() / 2].radius));
+        KeyPoint kpt(sumPoint, (float)(centers[i][centers[i].size() / 2].radius) * 2.0f);
         keypoints.push_back(kpt);
     }
 }


### PR DESCRIPTION
This fixes Bug #3533
KeyPoint takes diameter of the neighborhood as argument, earlier we were passing radius of blob.
