### PR TITLE
Linux installation tutorial: make -j8

### DIFF
--- a/doc/tutorials/introduction/linux_install/linux_install.rst
+++ b/doc/tutorials/introduction/linux_install/linux_install.rst
@@ -74,7 +74,8 @@ Building OpenCV from Source Using CMake, Using the Command Line
 
    .. code-block:: bash
 
-      make
+      make -j8 # -j8 runs 8 jobs in parallel.
+               # Change 8 to number of hardware threads available.
       sudo make install
 
 .. note::


### PR DESCRIPTION
Added `-j8` flag to `make` in the [linux installation tutorial](http://docs.opencv.org/doc/tutorials/introduction/linux_install/linux_install.html).
I feel it's quite important for new users, who may otherwise spend a whole day just building the code!

Screenshot from built docs:
![doc_screenshot](https://f.cloud.github.com/assets/1893429/2157899/acb26e30-9488-11e3-98e2-502c51c941ac.png)
