### PR TITLE
Corrected a mistake in the template matching formula in the docs

### DIFF
--- a/doc/tutorials/imgproc/histograms/template_matching/template_matching.rst
+++ b/doc/tutorials/imgproc/histograms/template_matching/template_matching.rst
@@ -85,7 +85,7 @@ d. **method=CV\_TM\_CCORR\_NORMED**
 
    .. math::
 
-      R(x,y)= \frac{\sum_{x',y'} (T(x',y') \cdot I'(x+x',y+y'))}{\sqrt{\sum_{x',y'}T(x',y')^2 \cdot \sum_{x',y'} I(x+x',y+y')^2}}
+      R(x,y)= \frac{\sum_{x',y'} (T(x',y') \cdot I(x+x',y+y'))}{\sqrt{\sum_{x',y'}T(x',y')^2 \cdot \sum_{x',y'} I(x+x',y+y')^2}}
 
 
 e. **method=CV\_TM\_CCOEFF**


### PR DESCRIPTION
Patch #3521 

Fixed a mistake in the template matching formula "CV_TM_CCORR_NORMED". Replaced I' by I (I prime by I).

Location: doc/tutorials/imgproc/histograms/template_matching/template_matching.rst
