### PR TITLE
T-API: extended performance tests to test 3 channels

### DIFF
--- a/modules/core/perf/opencl/perf_arithm.cpp
+++ b/modules/core/perf/opencl/perf_arithm.cpp
@@ -121,7 +121,7 @@ OCL_PERF_TEST_P(LogFixture, Log, ::testing::Combine(
 typedef Size_MatType AddFixture;
 
 OCL_PERF_TEST_P(AddFixture, Add,
-                ::testing::Combine(OCL_TEST_SIZES, OCL_TEST_TYPES))
+                ::testing::Combine(OCL_TEST_SIZES, OCL_TEST_TYPES_134))
 {
     const Size srcSize = GET_PARAM(0);
     const int type = GET_PARAM(1);
@@ -141,7 +141,7 @@ OCL_PERF_TEST_P(AddFixture, Add,
 typedef Size_MatType SubtractFixture;
 
 OCL_PERF_TEST_P(SubtractFixture, Subtract,
-            ::testing::Combine(OCL_TEST_SIZES, OCL_TEST_TYPES))
+            ::testing::Combine(OCL_TEST_SIZES, OCL_TEST_TYPES_134))
 {
     const Size_MatType_t params = GetParam();
     const Size srcSize = get<0>(params);
@@ -161,7 +161,7 @@ OCL_PERF_TEST_P(SubtractFixture, Subtract,
 
 typedef Size_MatType MulFixture;
 
-OCL_PERF_TEST_P(MulFixture, Multiply, ::testing::Combine(OCL_TEST_SIZES, OCL_TEST_TYPES))
+OCL_PERF_TEST_P(MulFixture, Multiply, ::testing::Combine(OCL_TEST_SIZES, OCL_TEST_TYPES_134))
 {
     const Size_MatType_t params = GetParam();
     const Size srcSize = get<0>(params);
@@ -182,7 +182,7 @@ OCL_PERF_TEST_P(MulFixture, Multiply, ::testing::Combine(OCL_TEST_SIZES, OCL_TES
 typedef Size_MatType DivFixture;
 
 OCL_PERF_TEST_P(DivFixture, Divide,
-            ::testing::Combine(OCL_TEST_SIZES, OCL_TEST_TYPES))
+            ::testing::Combine(OCL_TEST_SIZES, OCL_TEST_TYPES_134))
 {
     const Size_MatType_t params = GetParam();
     const Size srcSize = get<0>(params);
@@ -203,7 +203,7 @@ OCL_PERF_TEST_P(DivFixture, Divide,
 typedef Size_MatType AbsDiffFixture;
 
 OCL_PERF_TEST_P(AbsDiffFixture, Absdiff,
-            ::testing::Combine(OCL_TEST_SIZES, OCL_TEST_TYPES))
+            ::testing::Combine(OCL_TEST_SIZES, OCL_TEST_TYPES_134))
 {
     const Size_MatType_t params = GetParam();
     const Size srcSize = get<0>(params);
@@ -452,7 +452,7 @@ OCL_PERF_TEST_P(PhaseFixture, Phase, ::testing::Combine(
 typedef Size_MatType BitwiseAndFixture;
 
 OCL_PERF_TEST_P(BitwiseAndFixture, Bitwise_and,
-            ::testing::Combine(OCL_TEST_SIZES, OCL_TEST_TYPES))
+            ::testing::Combine(OCL_TEST_SIZES, OCL_TEST_TYPES_134))
 {
     const Size_MatType_t params = GetParam();
     const Size srcSize = get<0>(params);
@@ -473,7 +473,7 @@ OCL_PERF_TEST_P(BitwiseAndFixture, Bitwise_and,
 typedef Size_MatType BitwiseXorFixture;
 
 OCL_PERF_TEST_P(BitwiseXorFixture, Bitwise_xor,
-            ::testing::Combine(OCL_TEST_SIZES, OCL_TEST_TYPES))
+            ::testing::Combine(OCL_TEST_SIZES, OCL_TEST_TYPES_134))
 {
     const Size_MatType_t params = GetParam();
     const Size srcSize = get<0>(params);
@@ -494,7 +494,7 @@ OCL_PERF_TEST_P(BitwiseXorFixture, Bitwise_xor,
 typedef Size_MatType BitwiseOrFixture;
 
 OCL_PERF_TEST_P(BitwiseOrFixture, Bitwise_or,
-            ::testing::Combine(OCL_TEST_SIZES, OCL_TEST_TYPES))
+            ::testing::Combine(OCL_TEST_SIZES, OCL_TEST_TYPES_134))
 {
     const Size_MatType_t params = GetParam();
     const Size srcSize = get<0>(params);
@@ -515,7 +515,7 @@ OCL_PERF_TEST_P(BitwiseOrFixture, Bitwise_or,
 typedef Size_MatType BitwiseNotFixture;
 
 OCL_PERF_TEST_P(BitwiseNotFixture, Bitwise_not,
-            ::testing::Combine(OCL_TEST_SIZES, OCL_TEST_TYPES))
+            ::testing::Combine(OCL_TEST_SIZES, OCL_TEST_TYPES_134))
 {
     const Size_MatType_t params = GetParam();
     const Size srcSize = get<0>(params);
@@ -584,7 +584,7 @@ OCL_PERF_TEST_P(PowFixture, Pow, ::testing::Combine(
 typedef Size_MatType AddWeightedFixture;
 
 OCL_PERF_TEST_P(AddWeightedFixture, AddWeighted,
-            ::testing::Combine(OCL_TEST_SIZES, OCL_TEST_TYPES))
+            ::testing::Combine(OCL_TEST_SIZES, OCL_TEST_TYPES_134))
 {
     const Size_MatType_t params = GetParam();
     const Size srcSize = get<0>(params);

--- a/modules/imgproc/perf/opencl/perf_imgwarp.cpp
+++ b/modules/imgproc/perf/opencl/perf_imgwarp.cpp
@@ -60,7 +60,7 @@ typedef tuple<Size, MatType, InterType> WarpAffineParams;
 typedef TestBaseWithParam<WarpAffineParams> WarpAffineFixture;
 
 OCL_PERF_TEST_P(WarpAffineFixture, WarpAffine,
-            ::testing::Combine(OCL_TEST_SIZES, OCL_TEST_TYPES, InterType::all()))
+            ::testing::Combine(OCL_TEST_SIZES, OCL_TEST_TYPES_134, InterType::all()))
 {
     static const double coeffs[2][3] =
     {
@@ -90,7 +90,7 @@ typedef WarpAffineParams WarpPerspectiveParams;
 typedef TestBaseWithParam<WarpPerspectiveParams> WarpPerspectiveFixture;
 
 OCL_PERF_TEST_P(WarpPerspectiveFixture, WarpPerspective,
-            ::testing::Combine(OCL_TEST_SIZES, OCL_TEST_TYPES, InterType::all()))
+            ::testing::Combine(OCL_TEST_SIZES, OCL_TEST_TYPES_134, InterType::all()))
 {
     static const double coeffs[3][3] =
     {
@@ -121,7 +121,7 @@ typedef tuple<Size, MatType, InterType, double> ResizeParams;
 typedef TestBaseWithParam<ResizeParams> ResizeFixture;
 
 OCL_PERF_TEST_P(ResizeFixture, Resize,
-            ::testing::Combine(OCL_TEST_SIZES, OCL_TEST_TYPES,
+            ::testing::Combine(OCL_TEST_SIZES, OCL_TEST_TYPES_134,
                                InterType::all(), ::testing::Values(0.5, 2.0)))
 {
     const ResizeParams params = GetParam();
@@ -146,7 +146,7 @@ typedef tuple<Size, MatType, double> ResizeAreaParams;
 typedef TestBaseWithParam<ResizeAreaParams> ResizeAreaFixture;
 
 OCL_PERF_TEST_P(ResizeAreaFixture, Resize,
-            ::testing::Combine(OCL_TEST_SIZES, OCL_TEST_TYPES, ::testing::Values(0.3, 0.5, 0.6)))
+            ::testing::Combine(OCL_TEST_SIZES, OCL_TEST_TYPES_134, ::testing::Values(0.3, 0.5, 0.6)))
 {
     const ResizeAreaParams params = GetParam();
     const Size srcSize = get<0>(params);

--- a/modules/ts/include/opencv2/ts/ocl_perf.hpp
+++ b/modules/ts/include/opencv2/ts/ocl_perf.hpp
@@ -92,6 +92,8 @@ using std::tr1::tuple;
 
 #define OCL_TEST_SIZES ::testing::Values(OCL_SIZE_1, OCL_SIZE_2, OCL_SIZE_3, OCL_SIZE_4)
 #define OCL_TEST_TYPES ::testing::Values(CV_8UC1, CV_32FC1, CV_8UC4, CV_32FC4)
+#define OCL_TEST_TYPES_14 OCL_TEST_TYPES
+#define OCL_TEST_TYPES_134 ::testing::Values(CV_8UC1, CV_32FC1, CV_8UC3, CV_32FC3, CV_8UC4, CV_32FC4)
 
 #define OCL_PERF_ENUM ::testing::Values
 


### PR DESCRIPTION
<b>merge with opencv_extra https://github.com/Itseez/opencv_extra/pull/141</b>

check_regression=_OCL_WarpAffineFixture_:_OCL_WarpPerspectiveFixture_:_OCL_ResizeFixture_:_OCL_ResizeAreaFixture_:_OCL_AddFixture_:_OCL_SubtractFixture_:_OCL_MulFixture_:_OCL_DivFixture_:_OCL_AbsDiffFixture_:_OCL_BitwiseAndFixture_:_OCL_BitwiseXorFixture_:_OCL_BitwiseOrFixture_:_OCL_BitwiseNotFixture_:_OCL_AddWeightedFixture_
