### PR TITLE
Fixed CV_ASSERT condition in the code for bag of words

### DIFF
--- a/modules/features2d/src/bagofwords.cpp
+++ b/modules/features2d/src/bagofwords.cpp
@@ -172,7 +172,7 @@ int BOWImgDescriptorExtractor::descriptorType() const
 
 void BOWImgDescriptorExtractor::compute( InputArray keypointDescriptors, OutputArray _imgDescriptor, std::vector<std::vector<int> >* pointIdxsOfClusters )
 {
-    CV_Assert( vocabulary.empty() != false );
+    CV_Assert( !vocabulary.empty() );
 
     int clusterCount = descriptorSize(); // = vocabulary.rows
 


### PR DESCRIPTION
Bug #3543

We need the "vocabulary" to not be empty (i.e vocabulary.empty() should return false).
