### PR TITLE
Minor error in the documentation Load and Save Image

### DIFF
--- a/doc/tutorials/introduction/load_save_image/load_save_image.rst
+++ b/doc/tutorials/introduction/load_save_image/load_save_image.rst
@@ -100,7 +100,7 @@ Explanation
       imshow( imageName, image );
       imshow( "Gray image", gray_image );
 
-#. Add add the *waitKey(0)* function call for the program to wait forever for an user key press.
+#. Add the *waitKey(0)* function call for the program to wait forever for an user key press.
 
 
 Result


### PR DESCRIPTION
Bug #3550

Corrected a small error that was reported in a sentence of the documentation.
