### PR TITLE
fix bug #3562:

### DIFF
--- a/modules/gpu/src/cuda/canny.cu
+++ b/modules/gpu/src/cuda/canny.cu
@@ -293,8 +293,12 @@ namespace canny
                 n += smem[threadIdx.y + 2][threadIdx.x + 2] == 2;
             }
 
+            __syncthreads();
+
             if (n > 0)
                 smem[threadIdx.y + 1][threadIdx.x + 1] = 2;
+
+            __syncthreads();
         }
 
         const int e = smem[threadIdx.y + 1][threadIdx.x + 1];


### PR DESCRIPTION
add missing `__syncthreads` to `edgesHysteresisLocalKernel`

Corresponding ticket : http://code.opencv.org/issues/3562
