### PR TITLE
OCL: backport of matchTemplate perf tests from master

### DIFF
--- a/modules/ocl/perf/perf_match_template.cpp
+++ b/modules/ocl/perf/perf_match_template.cpp
@@ -119,3 +119,60 @@ PERF_TEST_P(CV_TM_CCORR_NORMEDFixture, matchTemplate, OCL_TYPICAL_MAT_SIZES)
     else
         OCL_PERF_ELSE
 }
+
+CV_ENUM(MethodType, TM_SQDIFF, TM_SQDIFF_NORMED, TM_CCORR, TM_CCORR_NORMED, TM_CCOEFF, TM_CCOEFF_NORMED)
+
+typedef std::tr1::tuple<Size, Size, MethodType> ImgSize_TmplSize_Method_t;
+typedef TestBaseWithParam<ImgSize_TmplSize_Method_t> ImgSize_TmplSize_Method;
+
+PERF_TEST_P(ImgSize_TmplSize_Method, MatchTemplate,
+        ::testing::Combine(
+            testing::Values(szSmall128, cv::Size(320, 240),
+                            cv::Size(640, 480), cv::Size(800, 600),
+                            cv::Size(1024, 768), cv::Size(1280, 1024)),
+            testing::Values(cv::Size(12, 12), cv::Size(28, 9),
+                            cv::Size(8, 30), cv::Size(16, 16)),
+            MethodType::all()
+            )
+        )
+{
+    Size imgSz = get<0>(GetParam());
+    Size tmplSz = get<1>(GetParam());
+    int method = get<2>(GetParam());
+
+    Mat img(imgSz, CV_8UC1);
+    Mat tmpl(tmplSz, CV_8UC1);
+    Mat result(imgSz - tmplSz + Size(1, 1), CV_32F);
+
+    bool isNormed =
+        method == TM_CCORR_NORMED ||
+        method == TM_SQDIFF_NORMED ||
+        method == TM_CCOEFF_NORMED;
+
+    declare.in(img, tmpl, WARMUP_RNG).out(result).time(30);
+
+    if (RUN_OCL_IMPL)
+    {
+        ocl::oclMat oclImg(img), oclTmpl(tmpl), oclResult(result.size(), CV_32F);
+
+        OCL_TEST_CYCLE() matchTemplate(oclImg, oclTmpl, oclResult, method);
+
+        oclResult.download(result);
+    }
+    else if (RUN_PLAIN_IMPL)
+    {
+        OCL_TEST_CYCLE() matchTemplate(img, tmpl, result, method);
+    }
+    else
+        OCL_PERF_ELSE
+
+    double eps = isNormed ? 3e-2
+        : 255 * 255 * tmpl.total() * 1e-4;
+
+    if (method == TM_SQDIFF_NORMED)
+        SANITY_CHECK_NOTHING();
+    else if (isNormed)
+        SANITY_CHECK(result, eps, ERROR_RELATIVE);
+    else
+        SANITY_CHECK(result, eps);
+}

--- a/modules/ts/include/opencv2/ts/ts_perf.hpp
+++ b/modules/ts/include/opencv2/ts/ts_perf.hpp
@@ -209,7 +209,7 @@ private:
 #define SANITY_CHECK(array, ...) ::perf::Regression::add(this, #array, array , ## __VA_ARGS__)
 #define SANITY_CHECK_KEYPOINTS(array, ...) ::perf::Regression::addKeypoints(this, #array, array , ## __VA_ARGS__)
 #define SANITY_CHECK_MATCHES(array, ...) ::perf::Regression::addMatches(this, #array, array , ## __VA_ARGS__)
-#define SANITY_CHECK_NOTHING() this->setVerified();
+#define SANITY_CHECK_NOTHING() this->setVerified()
 
 class CV_EXPORTS GpuPerf
 {


### PR DESCRIPTION
<b>merge with opencv_extra https://github.com/Itseez/opencv_extra/pull/149</b>

check_regression=_ImgSize_TmplSize_Method_
