### PR TITLE
Highgui_Tiff.decode_tile16384x16384 disabled for Android.

### DIFF
--- a/modules/highgui/test/test_grfmt.cpp
+++ b/modules/highgui/test/test_grfmt.cpp
@@ -392,7 +392,13 @@ TEST(Highgui_Jpeg, encode_empty)
 #define int64 int64_hack_
 #include "tiff.h"
 
+#ifdef ANDROID
+// Test disabled as it uses a lot of memory.
+// It is killed with SIGKILL by out of memory killer.
+TEST(Highgui_Tiff, DISABLED_decode_tile16384x16384)
+#else
 TEST(Highgui_Tiff, decode_tile16384x16384)
+#endif
 {
     // see issue #2161
     cv::Mat big(16384, 16384, CV_8UC1, cv::Scalar::all(0));


### PR DESCRIPTION
Last changes in test leads to SIGKILL on Android.
SIGKILL is called by out of memory killer.
