### PR TITLE
corrected the tutorial code for meanshift and camshift

### DIFF
--- a/doc/py_tutorials/py_video/py_meanshift/py_meanshift.rst
+++ b/doc/py_tutorials/py_video/py_meanshift/py_meanshift.rst
@@ -52,7 +52,7 @@ To use meanshift in OpenCV, first we need to setup the target, find its histogra
 
     # set up the ROI for tracking
     roi = frame[r:r+h, c:c+w]
-    hsv_roi =  cv2.cvtColor(frame, cv2.COLOR_BGR2HSV)
+    hsv_roi =  cv2.cvtColor(roi, cv2.COLOR_BGR2HSV)
     mask = cv2.inRange(hsv_roi, np.array((0., 60.,32.)), np.array((180.,255.,255.)))
     roi_hist = cv2.calcHist([hsv_roi],[0],mask,[180],[0,180])
     cv2.normalize(roi_hist,roi_hist,0,255,cv2.NORM_MINMAX)
@@ -127,7 +127,7 @@ It is almost same as meanshift, but it returns a rotated rectangle (that is our 
 
     # set up the ROI for tracking
     roi = frame[r:r+h, c:c+w]
-    hsv_roi =  cv2.cvtColor(frame, cv2.COLOR_BGR2HSV)
+    hsv_roi =  cv2.cvtColor(roi, cv2.COLOR_BGR2HSV)
     mask = cv2.inRange(hsv_roi, np.array((0., 60.,32.)), np.array((180.,255.,255.)))
     roi_hist = cv2.calcHist([hsv_roi],[0],mask,[180],[0,180])
     cv2.normalize(roi_hist,roi_hist,0,255,cv2.NORM_MINMAX)


### PR DESCRIPTION
Bug #3474

"hsv_roi" should probably include only that part from the frame which is going to be tracked. This means instead of taking the whole frame, we should calculate histogram of roi only.

cv2.rectangle returns "None" so we cant use "img2". The rectangle is drawn in "frame". Thus we display "frame" instead of "img2".
