### PR TITLE
Add tgit.icon project config

### DIFF
--- a/.tgitconfig
+++ b/.tgitconfig
@@ -1,0 +1,2 @@
+[tgit]
+    icon = doc/opencv.ico


### PR DESCRIPTION
This makes it easier to distinguish the task button when multiple TortoiseGit instances are running.

![tgit-opencv-icon](https://f.cloud.github.com/assets/791115/2259071/0ca2f48e-9e31-11e3-94b1-34c4d480e77f.png)
