### PR TITLE
OCL: Fix for Haar classifier 

### DIFF
--- a/modules/ocl/src/haar.cpp
+++ b/modules/ocl/src/haar.cpp
@@ -888,12 +888,12 @@ CvSeq *cv::ocl::OclCascadeClassifier::oclHaarDetectObjects( oclMat &gimg, CvMemS
                     for(int y=0;y<WGNumY;++y)
                     {
                         int     gy = y*localThreads[1];
-                        if(gy>=(Height-cascade->orig_window_size.height))
+                        if(gy>=Height)
                             continue; // no data to process
                         for(int x=0;x<WGNumX;++x)
                         {
                             int     gx = x*localThreads[0];
-                            if(gx>=(Width-cascade->orig_window_size.width))
+                            if(gx>=Width)
                                 continue; // no data to process
 
                             if(scaleinfo[z].factor<=2)

--- a/modules/ocl/src/opencl/haarobjectdetect.cl
+++ b/modules/ocl/src/opencl/haarobjectdetect.cl
@@ -150,8 +150,8 @@ __kernel void gpuRunHaarClassifierCascadePacked(
         int     index = i+lid; // index in shared local memory
         if(index<DATA_SIZE)
         {// calc global x,y coordinat and read data from there
-            int     x = min(GroupX + (index % (DATA_SIZE_X)),Width-1);
-            int     y = min(GroupY + (index / (DATA_SIZE_X)),Height-1);
+            int     x = min(GroupX + (index % (DATA_SIZE_X)),Width-1+WND_SIZE_X);
+            int     y = min(GroupY + (index / (DATA_SIZE_X)),Height-1+WND_SIZE_Y);
             SumL[index] = sum[ImgOffset+y*pixelstep+x];
         }
     }

--- a/modules/ocl/test/test_objdetect.cpp
+++ b/modules/ocl/test/test_objdetect.cpp
@@ -226,7 +226,7 @@ OCL_TEST_P(Haar, FaceDetect)
                                 flags,
                                 Size(30, 30), Size(0, 0));
 
-    EXPECT_LT(checkRectSimilarity(img.size(), faces, oclfaces), 1.0);
+    EXPECT_LT(checkRectSimilarity(img.size(), faces, oclfaces), 0.1);
 }
 
 OCL_TEST_P(Haar, FaceDetectUseBuf)
@@ -247,7 +247,7 @@ OCL_TEST_P(Haar, FaceDetectUseBuf)
                                 Size(30, 30));
     cascadebuf.release();
 
-    EXPECT_LT(checkRectSimilarity(img.size(), faces, oclfaces), 1.0);
+    EXPECT_LT(checkRectSimilarity(img.size(), faces, oclfaces), 0.1);
 }
 
 INSTANTIATE_TEST_CASE_P(OCL_ObjDetect, Haar,


### PR DESCRIPTION
Fix for Haar classifier (Intel specific codepath). Thanks to Konstantin Rodyushkin for patch.
