### PR TITLE
OCL: adding CV_HAAR_SCALE_IMAGE mode, enabling perf test

### DIFF
--- a/modules/ocl/perf/perf_haar.cpp
+++ b/modules/ocl/perf/perf_haar.cpp
@@ -92,12 +92,12 @@ PERF_TEST(HaarFixture, Haar)
 typedef std::tr1::tuple<std::string, std::string, int> Cascade_Image_MinSize_t;
 typedef perf::TestBaseWithParam<Cascade_Image_MinSize_t> Cascade_Image_MinSize;
 
-OCL_PERF_TEST_P(Cascade_Image_MinSize, DISABLED_CascadeClassifier,
+OCL_PERF_TEST_P(Cascade_Image_MinSize, CascadeClassifier,
                 testing::Combine(testing::Values( string("cv/cascadeandhog/cascades/haarcascade_frontalface_alt.xml"),
                                                   string("cv/cascadeandhog/cascades/haarcascade_frontalface_alt2.xml") ),
-                                 testing::Values(string("cv/shared/lena.png"),
-                                                 string("cv/cascadeandhog/images/bttf301.png")/*,
-                                                 string("cv/cascadeandhog/images/class57.png")*/ ),
+                                 testing::Values( string("cv/shared/lena.png"),
+                                                  string("cv/cascadeandhog/images/bttf301.png"),
+                                                  string("cv/cascadeandhog/images/class57.png") ),
                                  testing::Values(30, 64, 90)))
 {
     const string cascasePath = get<0>(GetParam());
@@ -121,7 +121,7 @@ OCL_PERF_TEST_P(Cascade_Image_MinSize, DISABLED_CascadeClassifier,
             faces.clear();
 
             startTimer();
-            cc.detectMultiScale(img, faces, 1.1, 3, 0, minSize);
+            cc.detectMultiScale(img, faces, 1.1, 3, CV_HAAR_SCALE_IMAGE, minSize);
             stopTimer();
         }
     }
@@ -137,7 +137,7 @@ OCL_PERF_TEST_P(Cascade_Image_MinSize, DISABLED_CascadeClassifier,
             ocl::finish();
 
             startTimer();
-            cc.detectMultiScale(uimg, faces, 1.1, 3, 0, minSize);
+            cc.detectMultiScale(uimg, faces, 1.1, 3, CV_HAAR_SCALE_IMAGE, minSize);
             stopTimer();
         }
     }


### PR DESCRIPTION
check_regression=_OCL_Cascade_
