### PR TITLE
T-API: fix bitwise ops, mask support in cv::norm

### DIFF
--- a/modules/core/src/arithm.cpp
+++ b/modules/core/src/arithm.cpp
@@ -935,7 +935,7 @@ static bool ocl_binary_op(InputArray _src1, InputArray _src2, OutputArray _dst,
     bool doubleSupport = ocl::Device::getDefault().doubleFPConfig() > 0;
 
     if( oclop < 0 || ((haveMask || haveScalar) && cn > 4) ||
-            (!doubleSupport && srcdepth == CV_64F))
+            (!doubleSupport && srcdepth == CV_64F && !bitwise))
         return false;
 
     char opts[1024];
@@ -945,11 +945,11 @@ static bool ocl_binary_op(InputArray _src1, InputArray _src2, OutputArray _dst,
     sprintf(opts, "-D %s%s -D %s -D dstT=%s%s -D dstT_C1=%s -D workST=%s -D cn=%d",
             (haveMask ? "MASK_" : ""), (haveScalar ? "UNARY_OP" : "BINARY_OP"), oclop2str[oclop],
             bitwise ? ocl::memopTypeToStr(CV_MAKETYPE(srcdepth, kercn)) :
-            ocl::typeToStr(CV_MAKETYPE(srcdepth, kercn)), doubleSupport ? " -D DOUBLE_SUPPORT" : "",
+                ocl::typeToStr(CV_MAKETYPE(srcdepth, kercn)), doubleSupport ? " -D DOUBLE_SUPPORT" : "",
             bitwise ? ocl::memopTypeToStr(CV_MAKETYPE(srcdepth, 1)) :
-            ocl::typeToStr(CV_MAKETYPE(srcdepth, 1)),
+                ocl::typeToStr(CV_MAKETYPE(srcdepth, 1)),
             bitwise ? ocl::memopTypeToStr(CV_MAKETYPE(srcdepth, scalarcn)) :
-            ocl::typeToStr(CV_MAKETYPE(srcdepth, scalarcn)),
+                ocl::typeToStr(CV_MAKETYPE(srcdepth, scalarcn)),
             kercn);
 
     ocl::Kernel k("KF", ocl::core::arithm_oclsrc, opts);

--- a/modules/core/src/stat.cpp
+++ b/modules/core/src/stat.cpp
@@ -533,9 +533,9 @@ cv::Scalar cv::sum( InputArray _src )
 {
 #ifdef HAVE_OPENCL
     Scalar _res;
-    CV_OCL_RUN_( _src.isUMat() && _src.dims() <= 2,
-                 ocl_sum(_src, _res, OCL_OP_SUM),
-                 _res)
+    CV_OCL_RUN_(_src.isUMat() && _src.dims() <= 2,
+                ocl_sum(_src, _res, OCL_OP_SUM),
+                _res)
 #endif
 
     Mat src = _src.getMat();
@@ -2299,7 +2299,7 @@ double cv::norm( InputArray _src, int normType, InputArray _mask )
 
 namespace cv {
 
-static bool ocl_norm( InputArray _src1, InputArray _src2, int normType, double & result )
+static bool ocl_norm( InputArray _src1, InputArray _src2, int normType, InputArray _mask, double & result )
 {
     int type = _src1.type(), depth = CV_MAT_DEPTH(type), cn = CV_MAT_CN(type);
     bool doubleSupport = ocl::Device::getDefault().doubleFPConfig() > 0;
@@ -2329,9 +2329,9 @@ static bool ocl_norm( InputArray _src1, InputArray _src2, int normType, double &
     if (!k.run(2, globalsize, NULL, false))
         return false;
 
-    result = cv::norm(diff, normType);
+    result = cv::norm(diff, normType, _mask);
     if (relative)
-        result /= cv::norm(src2, normType) + DBL_EPSILON;
+        result /= cv::norm(src2, normType, _mask) + DBL_EPSILON;
 
     return true;
 }
@@ -2346,9 +2346,9 @@ double cv::norm( InputArray _src1, InputArray _src2, int normType, InputArray _m
 
 #ifdef HAVE_OPENCL
     double _result = 0;
-    CV_OCL_RUN_(_mask.empty() && _src1.isUMat() && _src2.isUMat() &&
+    CV_OCL_RUN_(_src1.isUMat() && _src2.isUMat() &&
                 _src1.dims() <= 2 && _src2.dims() <= 2,
-                ocl_norm(_src1, _src2, normType, _result),
+                ocl_norm(_src1, _src2, normType, _mask, _result),
                 _result)
 #endif
 


### PR DESCRIPTION
check_regression=_OCL_
