### PR TITLE
OCL: warning fix

### DIFF
--- a/modules/core/include/opencv2/core/ocl.hpp
+++ b/modules/core/include/opencv2/core/ocl.hpp
@@ -169,8 +169,8 @@ public:
         VENDOR_NVIDIA=3
     };
     int vendorID() const;
-    inline bool isAMD() const { return vendorID() == VENDOR_AMD; };
-    inline bool isIntel() const { return vendorID() == VENDOR_INTEL; };
+    inline bool isAMD() const { return vendorID() == VENDOR_AMD; }
+    inline bool isIntel() const { return vendorID() == VENDOR_INTEL; }
 
     int maxClockFrequency() const;
     int maxComputeUnits() const;


### PR DESCRIPTION
Removed semicolon after method implementation to prevent warnings.
