### PR TITLE
Made getPolicy() method thread-safe

### DIFF
--- a/modules/flann/include/opencv2/flann/any.h
+++ b/modules/flann/include/opencv2/flann/any.h
@@ -155,13 +155,27 @@ SMALL_POLICY(bool);
 
 #undef SMALL_POLICY
 
-/// This function will return a different policy for each type.
-template<typename T>
-base_any_policy* get_policy()
+template <typename T>
+class SinglePolicy
 {
+    SinglePolicy();
+    SinglePolicy(const SinglePolicy& other);
+    SinglePolicy& operator=(const SinglePolicy& other);
+
+public:
+    static base_any_policy* get_policy();
+
+private:
     static typename choose_policy<T>::type policy;
-    return &policy;
-}
+};
+
+template <typename T>
+typename choose_policy<T>::type SinglePolicy<T>::policy;
+
+/// This function will return a different policy for each type.
+template <typename T>
+inline base_any_policy* SinglePolicy<T>::get_policy() { return &policy; }
+
 } // namespace anyimpl
 
 struct any
@@ -175,26 +189,26 @@ public:
     /// Initializing constructor.
     template <typename T>
     any(const T& x)
-        : policy(anyimpl::get_policy<anyimpl::empty_any>()), object(NULL)
+        : policy(anyimpl::SinglePolicy<anyimpl::empty_any>::get_policy()), object(NULL)
     {
         assign(x);
     }
 
     /// Empty constructor.
     any()
-        : policy(anyimpl::get_policy<anyimpl::empty_any>()), object(NULL)
+        : policy(anyimpl::SinglePolicy<anyimpl::empty_any>::get_policy()), object(NULL)
     { }
 
     /// Special initializing constructor for string literals.
     any(const char* x)
-        : policy(anyimpl::get_policy<anyimpl::empty_any>()), object(NULL)
+        : policy(anyimpl::SinglePolicy<anyimpl::empty_any>::get_policy()), object(NULL)
     {
         assign(x);
     }
 
     /// Copy constructor.
     any(const any& x)
-        : policy(anyimpl::get_policy<anyimpl::empty_any>()), object(NULL)
+        : policy(anyimpl::SinglePolicy<anyimpl::empty_any>::get_policy()), object(NULL)
     {
         assign(x);
     }
@@ -219,7 +233,7 @@ public:
     any& assign(const T& x)
     {
         reset();
-        policy = anyimpl::get_policy<T>();
+        policy = anyimpl::SinglePolicy<T>::get_policy();
         policy->copy_from_value(&x, &object);
         return *this;
     }
@@ -274,7 +288,7 @@ public:
     void reset()
     {
         policy->static_delete(&object);
-        policy = anyimpl::get_policy<anyimpl::empty_any>();
+        policy = anyimpl::SinglePolicy<anyimpl::empty_any>::get_policy();
     }
 
     /// Returns true if the two types are the same.


### PR DESCRIPTION
Fix for issue #3584.
Looks a little tricky, but it made correct initialization of static variable to prevent crashing in multithreaded mode (particularly "pure virtual call" in perf_stitching tests). 
