### PR TITLE
Fix for bug #3599: cv::FileStorage does not work for std::vector of user...

### DIFF
--- a/modules/core/include/opencv2/core/persistence.hpp
+++ b/modules/core/include/opencv2/core/persistence.hpp
@@ -701,6 +701,7 @@ void write( FileStorage& fs, const String& name, const std::vector<_Tp>& vec )
     write(fs, vec);
 }
 
+
 static inline
 void read(const FileNode& node, bool& value, bool default_value)
 {

--- a/modules/core/src/persistence.cpp
+++ b/modules/core/src/persistence.cpp
@@ -5486,15 +5486,14 @@ internal::WriteStructContext::WriteStructContext(FileStorage& _fs,
 {
     cvStartWriteStruct(**fs, !name.empty() ? name.c_str() : 0, flags,
                        !typeName.empty() ? typeName.c_str() : 0);
+    fs->elname = String();
     if ((flags & FileNode::TYPE_MASK) == FileNode::SEQ)
     {
-        fs->elname = String();
         fs->state = FileStorage::VALUE_EXPECTED;
         fs->structs.push_back('[');
     }
     else
     {
-        fs->elname = String();
         fs->state = FileStorage::NAME_EXPECTED + FileStorage::INSIDE_MAP;
         fs->structs.push_back('{');
     }


### PR DESCRIPTION
...-defined struct.
Note for reviewer: This modification changes the behaviour of the function write(). It may break a code that calls write() directly (that's an undocumented way).
