### PR TITLE
OCL: workaround for Erode on Intel platform

### DIFF
--- a/modules/imgproc/src/opencl/morph.cl
+++ b/modules/imgproc/src/opencl/morph.cl
@@ -69,7 +69,12 @@
 #endif
 
 #ifdef ERODE
+#ifdef INTEL_DEVICE
+// workaround for bug in Intel HD graphics drivers (10.18.10.3496 or older)
+#define MORPH_OP(A,B) ((A) < (B) ? (A) : (B))
+#else
 #define MORPH_OP(A,B) min((A),(B))
+#endif
 #endif
 #ifdef DILATE
 #define MORPH_OP(A,B) max((A),(B))


### PR DESCRIPTION
Replaced min() with ternary operator.
Should be fixed by new driver for Intel HD Graphics, but no info when the next driver will be posted.
