### PR TITLE
modified BackgroundSubtractorMOG2::getBackgroundImage so that it can now...

### DIFF
--- a/modules/video/src/bgfg_gaussmix2.cpp
+++ b/modules/video/src/bgfg_gaussmix2.cpp
@@ -582,12 +582,12 @@ void BackgroundSubtractorMOG2::getBackgroundImage(OutputArray backgroundImage) c
     int firstGaussianIdx = 0;
     const GMM* gmm = (GMM*)bgmodel.data;
     const float* mean = reinterpret_cast<const float*>(gmm + frameSize.width*frameSize.height*nmixtures);
+    std::vector<float> meanVal(nchannels, 0.f);
     for(int row=0; row<meanBackground.rows; row++)
     {
         for(int col=0; col<meanBackground.cols; col++)
         {
             int nmodes = bgmodelUsedModes.at<uchar>(row, col);
-            std::vector<float> meanVal(nchannels, 0.f);
             float totalWeight = 0.f;
             for(int gaussianIdx = firstGaussianIdx; gaussianIdx < firstGaussianIdx + nmodes; gaussianIdx++)
             {
@@ -603,17 +603,16 @@ void BackgroundSubtractorMOG2::getBackgroundImage(OutputArray backgroundImage) c
                     break;
             }
             float invWeight = 1.f/totalWeight;
-            for(int chn = 0; chn < nchannels; chn++)
-            {
-                meanVal[chn] *= invWeight;
-            }
             switch(nchannels)
             {
             case 1:
-                meanBackground.at<uchar>(row, col) = (uchar)meanVal[0];
+                meanBackground.at<uchar>(row, col) = (uchar)(meanVal[0] * invWeight);
+                meanVal[0] = 0.f;
                 break;
             case 3:
-                meanBackground.at<Vec3b>(row, col) = Vec3b(*reinterpret_cast<Vec3f*>(&meanVal[0]));
+                Vec3f& meanVec = *reinterpret_cast<Vec3f*>(&meanVal[0]);
+                meanBackground.at<Vec3b>(row, col) = Vec3b(meanVec * invWeight);
+                meanVec = 0.f;
                 break;
             }
             firstGaussianIdx += nmixtures;


### PR DESCRIPTION
... work with gray-level images.

Explanation: Although the class in general works for gray level images, getBackgroundImage does not. This PR is an attempt to fix this problem.

Thank you.
Firat
