### PR TITLE
Fixed "Logical flaw in OpenCV 2.4.8 SIFT implementation (Bug #3585)"

### DIFF
--- a/modules/nonfree/src/sift.cpp
+++ b/modules/nonfree/src/sift.cpp
@@ -215,14 +215,12 @@ void SIFT::buildGaussianPyramid( const Mat& base, vector<Mat>& pyr, int nOctaves
     pyr.resize(nOctaves*(nOctaveLayers + 3));
 
     // precompute Gaussian sigmas using the following formula:
-    //  \sigma_{total}^2 = \sigma_{i}^2 + \sigma_{i-1}^2
+    //  \sigma_{i+1} = \k*sigma_{i}
     sig[0] = sigma;
     double k = pow( 2., 1. / nOctaveLayers );
     for( int i = 1; i < nOctaveLayers + 3; i++ )
     {
-        double sig_prev = pow(k, (double)(i-1))*sigma;
-        double sig_total = sig_prev*k;
-        sig[i] = std::sqrt(sig_total*sig_total - sig_prev*sig_prev);
+        sig[i] = k*sig[i-1];
     }
 
     for( int o = 0; o < nOctaves; o++ )


### PR DESCRIPTION
I realized after fixing that this was intially assigned to Vadim Pisarevsky. This is my first time contributing so I apologize. I'm still learning how the system works.

For an input image Z, a Gaussian pyramid is a stack or 'pyramid' of increasingly blurred (aka smoothed), scaled versions of Z by means of convolution with a Gaussian kernel. The resulting blurred image at each level is also scaled to yield a pyramid-like structure (not depicted below). The successive blurring means that the Gaussian kernel used to blur at each stage must increase in the rate of blurring/smoothing, which is done by scaling the sigma value or standard deviation of the Gaussian kernel by a factor k, which is sqrt(2). According to Lowe, the sigma value at level i is sigma(i) = k_sigma(i-1). This means for level n, sigma(n) = k^n_sigma(0). This can be seen in the image below taken from [2]. It is increased by multiplying the standard deviation by a power of the scaling factor. The issue in the code was that the first level sigma value was computed twice, so the first and second levels (sigma(0), sigma(1)) were always the same when sigma(1) should have been k*sigma(0). Due to this duplication, the rest of the sigma values were correct but were for in the incorrect indices (i.e. for the previous pyramid level).

![screen shot 2014-03-25 at 10 14 45 pm](https://f.cloud.github.com/assets/2200898/2520504/cd2448d6-b48c-11e3-99da-dd58c32d3744.png)

[1] http://www.cs.ubc.ca/~lowe/papers/ijcv04.pdf
[3] http://www.cs.ucf.edu/courses/cap4453/sift/siftppt.ppt
