### PR TITLE
Optimization of sigma computation in OpenCV 2.4.8 SIFT implementation (Bug #3625)

### DIFF
--- a/modules/nonfree/src/sift.cpp
+++ b/modules/nonfree/src/sift.cpp
@@ -215,15 +215,16 @@ void SIFT::buildGaussianPyramid( const Mat& base, std::vector<Mat>& pyr, int nOc
     pyr.resize(nOctaves*(nOctaveLayers + 3));
 
     // precompute Gaussian sigmas using the following formula:
-    //  \sigma_{total}^2 = \sigma_{i}^2 + \sigma_{i-1}^2
-    sig[0] = sigma;
+    // \sigma_{total}^2 = \sigma_{i}^2 + \sigma_{i-1}^2
+
+    // Note: sig[i] is not the sigma value at level i, but the
+    // incremental sigma that level i-1 must be convolved with
+    // to attain the desired sigma at level i.
     double k = std::pow( 2., 1. / nOctaveLayers );
-    for( int i = 1; i < nOctaveLayers + 3; i++ )
-    {
-        double sig_prev = std::pow(k, (double)(i-1))*sigma;
-        double sig_total = sig_prev*k;
-        sig[i] = std::sqrt(sig_total*sig_total - sig_prev*sig_prev);
-    }
+    sig[0] = sigma;
+    sig[1] = sigma * std::sqrt(k*k - 1);
+    for( int i = 2; i < nOctaveLayers + 3; i++ )
+        sig[i] = sig[i-1] * k;
 
     for( int o = 0; o < nOctaves; o++ )
     {


### PR DESCRIPTION
We can see that, according to the original code :

<pre>
sig[0] = sigma
sig[i] = sqrt(sig_total * sig_total - sig_prev * sig_prev )
       = sqrt(sig_prev * sig_prev * k * k - sig_prev * sig_prev )
       = sig_prev * sqrt(  k * k -  1 )
       = k^(i-1) * sigma * sqrt(  k * k -  1 )
</pre>


then:

<pre>
sig[0] = sigma
sig[1] = sigma * sqrt(  k * k -  1 )
sig[2] = k * sigma * sqrt(  k * k -  1 ) = k* sig[1] 
sig[3] = k^2 * sigma * sqrt(  k * k -  1 ) = k* sig[2] 
</pre>


We can optimize as done in the PR.

I've also added clarifying comments because of a bug report that was incorrectly filed due to lack of commentary.
