### PR TITLE
 Optimization of sigma computation in OpenCV 2.4.8 SIFT implementation (Bug #3625)

### DIFF
--- a/modules/nonfree/src/sift.cpp
+++ b/modules/nonfree/src/sift.cpp
@@ -216,7 +216,7 @@ void SIFT::buildGaussianPyramid( const Mat& base, vector<Mat>& pyr, int nOctaves
 
     // precompute Gaussian sigmas using the following formula:
     // \sigma_{total}^2 = \sigma_{i}^2 + \sigma_{i-1}^2
-    
+
     // Note: sig[i] is not the sigma value at level i, but the
     // incremental sigma that level i-1 must be convolved with
     // to attain the desired sigma at level i.


### PR DESCRIPTION
We can see that, according to the original code :

<pre>
sig[0] = sigma
sig[i] = sqrt(sig_total * sig_total - sig_prev * sig_prev )
       = sqrt(sig_prev * sig_prev * k * k - sig_prev * sig_prev )
       = sig_prev * sqrt(  k * k -  1 )
       = k^(i-1) * sigma * sqrt(  k * k -  1 )
</pre>


then:

<pre>
sig[0] = sigma
sig[1] = sigma * sqrt(  k * k -  1 )
sig[2] = k * sigma * sqrt(  k * k -  1 ) = k* sig[1] 
sig[3] = k^2 * sigma * sqrt(  k * k -  1 ) = k* sig[2] 
</pre>


We can optimize as done in the PR.

I've also added clarifying comments because of a bug report that was incorrectly filed due to lack of commentary.

http://code.opencv.org/issues/3625
