### PR TITLE
Increase epsilon for gpu::MOG2::getBackgroundImage test:

### DIFF
--- a/modules/gpu/test/test_bgfg.cpp
+++ b/modules/gpu/test/test_bgfg.cpp
@@ -336,7 +336,7 @@ GPU_TEST_P(MOG2, getBackgroundImage)
     cv::Mat background_gold;
     mog2_gold.getBackgroundImage(background_gold);
 
-    ASSERT_MAT_NEAR(background_gold, background, 0);
+    ASSERT_MAT_NEAR(background_gold, background, 1);
 }
 
 INSTANTIATE_TEST_CASE_P(GPU_Video, MOG2, testing::Combine(


### PR DESCRIPTION
it uses float arithmetics
