### PR TITLE
OCL: fixed C4505

### DIFF
--- a/modules/nonfree/perf/perf_main.cpp
+++ b/modules/nonfree/perf/perf_main.cpp
@@ -31,7 +31,9 @@ static const char * impls[] = {
 int main(int argc, char **argv)
 {
     ::perf::TestBase::setPerformanceStrategy(::perf::PERF_STRATEGY_SIMPLE);
-#if defined(HAVE_CUDA)
+#if defined(HAVE_CUDA) && defined(HAVE_OPENCL)
+    CV_PERF_TEST_MAIN_INTERNALS(nonfree, impls, perf::printCudaInfo(), dumpOpenCLDevice());
+#elif defined(HAVE_CUDA)
     CV_PERF_TEST_MAIN_INTERNALS(nonfree, impls, perf::printCudaInfo());
 #elif defined(HAVE_OPENCL)
     CV_PERF_TEST_MAIN_INTERNALS(nonfree, impls, dumpOpenCLDevice());


### PR DESCRIPTION
fix for http://build.opencv.org/builders/win_x86%5Bdebug%5D--%5Bsse_%3D_ON%5D--%5Btbb_%3D_ON%5D--%5Bgpu_%3D_ON%5D--%5Bcompiler_%3D_vc10%5D--%5Btests_%3D_ON%5D-/builds/493/steps/compile%20debug%2032%20vc10%20shared%20n/logs/build%20summary%20%28e%3A%200%2C%20w%3A%202%29 introduced by https://github.com/Itseez/opencv/pull/2527
