### PR TITLE
Fixed problem with compilation without HAVE_OPENCL

### DIFF
--- a/modules/core/src/umatrix.cpp
+++ b/modules/core/src/umatrix.cpp
@@ -667,9 +667,7 @@ void UMat::copyTo(OutputArray _dst, InputArray _mask) const
         copyTo(_dst);
         return;
     }
-    
 #ifdef HAVE_OPENCL
-
     int cn = channels(), mtype = _mask.type(), mdepth = CV_MAT_DEPTH(mtype), mcn = CV_MAT_CN(mtype);
     CV_Assert( mdepth == CV_8U && (mcn == 1 || mcn == cn) );
 
@@ -697,7 +695,6 @@ void UMat::copyTo(OutputArray _dst, InputArray _mask) const
         }
     }
 #endif
-
     Mat src = getMat(ACCESS_READ);
     src.copyTo(_dst, _mask);
 }
@@ -718,9 +715,7 @@ void UMat::convertTo(OutputArray _dst, int _type, double alpha, double beta) con
         copyTo(_dst);
         return;
     }
-    
 #ifdef HAVE_OPENCL
-    
     bool doubleSupport = ocl::Device::getDefault().doubleFPConfig() > 0;
     bool needDouble = sdepth == CV_64F || ddepth == CV_64F;
     if( dims <= 2 && cn && _dst.isUMat() && ocl::useOpenCL() &&
@@ -756,7 +751,6 @@ void UMat::convertTo(OutputArray _dst, int _type, double alpha, double beta) con
         }
     }
 #endif
-
     Mat m = getMat(ACCESS_READ);
     m.convertTo(_dst, _type, alpha, beta);
 }
@@ -764,7 +758,6 @@ void UMat::convertTo(OutputArray _dst, int _type, double alpha, double beta) con
 UMat& UMat::setTo(InputArray _value, InputArray _mask)
 {
     bool haveMask = !_mask.empty();
-    
 #ifdef HAVE_OPENCL
     int tp = type(), cn = CV_MAT_CN(tp);
 
@@ -807,7 +800,6 @@ UMat& UMat::setTo(InputArray _value, InputArray _mask)
         }
     }
 #endif
-
     Mat m = getMat(haveMask ? ACCESS_RW : ACCESS_WRITE);
     m.setTo(_value, _mask);
     return *this;


### PR DESCRIPTION
When compiling without OpenCL, some classes from its namespace are still used in code.
