### PR TITLE
Fix for GFTT

### DIFF
--- a/modules/imgproc/src/featureselect.cpp
+++ b/modules/imgproc/src/featureselect.cpp
@@ -164,6 +164,12 @@ static bool ocl_goodFeaturesToTrack( InputArray _image, OutputArray _corners,
             return false;
 
         total = std::min<size_t>(counter.getMat(ACCESS_READ).at<int>(0, 0), possibleCornersCount);
+        if (total == 0)
+        {
+            _corners.release();
+            return true;
+        }
+
         tmpCorners.resize(total);
 
         Mat mcorners(1, (int)total, CV_32FC2, &tmpCorners[0]);


### PR DESCRIPTION
Removed access to `tmpCorners[0]` in case `tmpCorners` is empty. It causes runtime error in debug mode.
