### PR TITLE
fix condition in CV_OperationsTest::operations1()

### DIFF
--- a/modules/core/test/test_operations.cpp
+++ b/modules/core/test/test_operations.cpp
@@ -988,7 +988,7 @@ bool CV_OperationsTest::operations1()
 
         Vec<double,10> v10dzero;
         for (int ii = 0; ii < 10; ++ii) {
-            if (!v10dzero[ii] == 0.0)
+            if (!(v10dzero[ii] == 0.0))
                 throw test_excep();
         }
 


### PR DESCRIPTION
Priority of '!' is higher then '==' operator.
