### PR TITLE
Corrected bug #1437.

### DIFF
--- a/modules/highgui/src/window_w32.cpp
+++ b/modules/highgui/src/window_w32.cpp
@@ -52,6 +52,7 @@
 #include <string.h>
 #include <stdio.h>
 #include <assert.h>
+#include <windowsx.h>
 
 #ifdef HAVE_OPENGL
 #include <memory>
@@ -1459,8 +1460,8 @@ static LRESULT CALLBACK HighGUIProc( HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM
             if( uMsg == WM_LBUTTONUP || uMsg == WM_RBUTTONUP || uMsg == WM_MBUTTONUP )
                 ReleaseCapture();
 
-            pt.x = LOWORD( lParam );
-            pt.y = HIWORD( lParam );
+            pt.x = GET_X_LPARAM( lParam );
+            pt.y = GET_Y_LPARAM( lParam );
 
             GetClientRect( window->hwnd, &rect );
             icvGetBitmapData( window, &size, 0, 0 );


### PR DESCRIPTION
I corrected bug #1437. Two signed-short values were not extracted corrected from an lParam coming from mouse events. The values had to be casted to signed-short before assigning to an int.
See recent discussion here http://code.opencv.org/issues/1437

This is my first pull request so let me know if I did anything wrong. I couldn't run the official opencv test set as the instructions seen here (http://code.opencv.org/projects/opencv/wiki/How_to_contribute#The-instruction-in-brief) aren't crystal clear. I clone opencv_extra but I don't know what I'm supposed to do with it...
I did create a small console app to validate my correction though.
