### PR TITLE
Resolves bug #3450 (Improperly cleaning up resources in DllMain)

### DIFF
--- a/modules/core/src/ocl.cpp
+++ b/modules/core/src/ocl.cpp
@@ -1581,7 +1581,7 @@ void finish()
 
 #define IMPLEMENT_REFCOUNTABLE() \
     void addref() { CV_XADD(&refcount, 1); } \
-    void release() { if( CV_XADD(&refcount, -1) == 1 ) delete this; } \
+    void release() { if( CV_XADD(&refcount, -1) == 1 && !cv::__termination) delete this; } \
     int refcount
 
 /////////////////////////////////////////// Platform /////////////////////////////////////////////

--- a/modules/core/src/system.cpp
+++ b/modules/core/src/system.cpp
@@ -918,16 +918,22 @@ public:
     #pragma warning(disable:4447) // Disable warning 'main' signature found without threading model
 #endif
 
-BOOL WINAPI DllMain(HINSTANCE, DWORD fdwReason, LPVOID);
-
+extern "C"
 BOOL WINAPI DllMain(HINSTANCE, DWORD fdwReason, LPVOID lpReserved)
 {
     if (fdwReason == DLL_THREAD_DETACH || fdwReason == DLL_PROCESS_DETACH)
     {
         if (lpReserved != NULL) // called after ExitProcess() call
+        {
             cv::__termination = true;
-        cv::deleteThreadAllocData();
-        cv::deleteThreadData();
+        }
+        else
+        {
+            // Not allowed to free resources if lpReserved is non-null
+            // http://msdn.microsoft.com/en-us/library/windows/desktop/ms682583.aspx
+            cv::deleteThreadAllocData();
+            cv::deleteThreadData();
+        }
     }
     return TRUE;
 }


### PR DESCRIPTION
Avoids freeing resources in DllMain on Windows in the case where the whole process is terminating.  According to Win32 API documentation, it is not legal:

http://msdn.microsoft.com/en-us/library/windows/desktop/ms682583.aspx

Resolves bug #3450.
