### PR TITLE
Removed emptiness check from cv::hconcat and cv::vconcat.

### DIFF
--- a/modules/core/test/test_concatenation.cpp
+++ b/modules/core/test/test_concatenation.cpp
@@ -72,10 +72,10 @@ private:
 
 };
 
-Core_ConcatenationTest::Core_ConcatenationTest(bool horizontal, bool firstEmpty, bool secondEmpty)
-    : horizontal(horizontal)
-    , firstEmpty(firstEmpty)
-    , secondEmpty(secondEmpty)
+Core_ConcatenationTest::Core_ConcatenationTest(bool horizontal_, bool firstEmpty_, bool secondEmpty_)
+    : horizontal(horizontal_)
+    , firstEmpty(firstEmpty_)
+    , secondEmpty(secondEmpty_)
 {
     test_case_count = 1;
 


### PR DESCRIPTION
Sometimes it is useful to concatenate with an empty matrix. For example you create a matrix with 0 rows and M columns and then iteratively grow it by vertically concatenating it with more and more matrices with M columns.
I can't find any particular reason for disallowing empty matrices.
