### PR TITLE
OCL: GaussianBlur improvements for Intel platforms

### DIFF
--- a/modules/imgproc/src/filter.cpp
+++ b/modules/imgproc/src/filter.cpp
@@ -3491,9 +3491,19 @@ static bool ocl_sepFilter2D( InputArray _src, OutputArray _dst, int ddepth,
         rtype == KERNEL_SMOOTH+KERNEL_SYMMETRICAL &&
         ctype == KERNEL_SMOOTH+KERNEL_SYMMETRICAL)
     {
-        bdepth = CV_32S;
-        kernelX.convertTo( kernelX, bdepth, 1 << shift_bits );
-        kernelY.convertTo( kernelY, bdepth, 1 << shift_bits );
+        if (ocl::Device::getDefault().isIntel())
+        {
+            for (int i=0; i<kernelX.cols; i++)
+                kernelX.at<float>(0, i) = (float) cvRound(kernelX.at<float>(0, i) * (1 << shift_bits));
+            if (kernelX.data != kernelY.data)
+                for (int i=0; i<kernelX.cols; i++)
+                    kernelY.at<float>(0, i) = (float) cvRound(kernelY.at<float>(0, i) * (1 << shift_bits));
+        } else
+        {
+            bdepth = CV_32S;
+            kernelX.convertTo( kernelX, bdepth, 1 << shift_bits );
+            kernelY.convertTo( kernelY, bdepth, 1 << shift_bits );
+        }
         int_arithm = true;
     }
 

--- a/modules/imgproc/src/opencl/filterSepCol.cl
+++ b/modules/imgproc/src/opencl/filterSepCol.cl
@@ -97,15 +97,19 @@ __kernel void col_filter(__global const uchar * src, int src_step, int src_offse
     {
         temp[0] = LDS_DAT[l_y + RADIUSY - i][l_x];
         temp[1] = LDS_DAT[l_y + RADIUSY + i][l_x];
-#ifndef INTEGER_ARITHMETIC
-        sum += mad(temp[0], mat_kernel[RADIUSY - i], temp[1] * mat_kernel[RADIUSY + i]);
-#else
+#if (defined(INTEGER_ARITHMETIC) && !INTEL_DEVICE)
         sum += mad24(temp[0],mat_kernel[RADIUSY - i], temp[1] * mat_kernel[RADIUSY + i]);
+#else
+        sum += mad(temp[0], mat_kernel[RADIUSY - i], temp[1] * mat_kernel[RADIUSY + i]);
 #endif
     }
 
 #ifdef INTEGER_ARITHMETIC
+#ifdef INTEL_DEVICE
+    sum = (sum + (1 << (SHIFT_BITS-1))) / (1 << SHIFT_BITS);
+#else
     sum = (sum + (1 << (SHIFT_BITS-1))) >> SHIFT_BITS;
+#endif
 #endif
 
     // write the result to dst

--- a/modules/imgproc/src/opencl/filterSepRow.cl
+++ b/modules/imgproc/src/opencl/filterSepRow.cl
@@ -141,12 +141,12 @@
 #define DIG(a) a,
 __constant dstT1 mat_kernel[] = { COEFF };
 
-#ifndef INTEGER_ARITHMETIC
-#define dstT4 float4
-#define convertDstVec convert_float4
-#else
+#if (defined(INTEGER_ARITHMETIC) && !INTEL_DEVICE)
 #define dstT4 int4
 #define convertDstVec convert_int4
+#else
+#define dstT4 float4
+#define convertDstVec convert_float4
 #endif
 
 __kernel void row_filter_C1_D0(__global const uchar * src, int src_step_in_pixel, int src_offset_x, int src_offset_y,
@@ -263,10 +263,10 @@ __kernel void row_filter_C1_D0(__global const uchar * src, int src_step_in_pixel
     {
         temp[0] = vload4(0, (__local uchar*)&LDS_DAT[l_y][l_x] + RADIUSX + offset - i);
         temp[1] = vload4(0, (__local uchar*)&LDS_DAT[l_y][l_x] + RADIUSX + offset + i);
-#ifndef INTEGER_ARITHMETIC
-        sum += mad(convertDstVec(temp[0]), mat_kernel[RADIUSX-i], convertDstVec(temp[1]) * mat_kernel[RADIUSX + i]);
-#else
+#if (defined(INTEGER_ARITHMETIC) && !INTEL_DEVICE)
         sum += mad24(convertDstVec(temp[0]), mat_kernel[RADIUSX-i], convertDstVec(temp[1]) * mat_kernel[RADIUSX + i]);
+#else
+        sum += mad(convertDstVec(temp[0]), mat_kernel[RADIUSX-i], convertDstVec(temp[1]) * mat_kernel[RADIUSX + i]);
 #endif
     }
 
@@ -368,10 +368,10 @@ __kernel void row_filter(__global const uchar * src, int src_step, int src_offse
     {
         temp[0] = LDS_DAT[l_y][l_x + RADIUSX - i];
         temp[1] = LDS_DAT[l_y][l_x + RADIUSX + i];
-#ifndef INTEGER_ARITHMETIC
-        sum += mad(convertToDstT(temp[0]), mat_kernel[RADIUSX - i], convertToDstT(temp[1]) * mat_kernel[RADIUSX + i]);
-#else
+#if (defined(INTEGER_ARITHMETIC) && !INTEL_DEVICE)
         sum += mad24(convertToDstT(temp[0]), mat_kernel[RADIUSX - i], convertToDstT(temp[1]) * mat_kernel[RADIUSX + i]);
+#else
+        sum += mad(convertToDstT(temp[0]), mat_kernel[RADIUSX - i], convertToDstT(temp[1]) * mat_kernel[RADIUSX + i]);
 #endif
     }
 


### PR DESCRIPTION
test_modules=imgproc
test_filter=_OCL_Gaussian*
check_regression=_OCL_Gaussian*
build_examples=OFF
Changed integer operations to float for Intel devices, since float operations are faster. Accuracy is not decreased. 
