### PR TITLE
fix for compiling ios 2.4 opencv with xcode 5.1

### DIFF
--- a/modules/world/CMakeLists.txt
+++ b/modules/world/CMakeLists.txt
@@ -103,6 +103,7 @@ macro(ios_include_3party_libs)
       list(APPEND objlist "\"${objpath3}\"")
     endforeach() # (srcname ${sources})
   endforeach()
+  ocv_list_filterout(objlist jmemansi) # <<= dirty fix
 endmacro()
 
 if(IOS AND WITH_PNG)

--- a/platforms/ios/build_framework.py
+++ b/platforms/ios/build_framework.py
@@ -40,6 +40,7 @@ def build_opencv(srcroot, buildroot, target, arch):
                 "-DCMAKE_BUILD_TYPE=Release " +
                 "-DCMAKE_TOOLCHAIN_FILE=%s/platforms/ios/cmake/Toolchains/Toolchain-%s_Xcode.cmake " +
                 "-DBUILD_opencv_world=ON " +
+                "-DCMAKE_C_FLAGS=\"-Wno-implicit-function-declaration\" " +
                 "-DCMAKE_INSTALL_PREFIX=install") % (srcroot, target)
     # if cmake cache exists, just rerun cmake to update OpenCV.xproj if necessary
     if os.path.isfile(os.path.join(builddir, "CMakeCache.txt")):


### PR DESCRIPTION
I applied change from http://stackoverflow.com/questions/16983696/how-to-build-opencv-2-4-9-for-ios
( dirty fix ? ), and disabled an error ( maybe was ignored in previous xcode release )
There's another patch to apply to cmake scripts to allow framework compilation with xcode 5.1, cfr :
http://answers.opencv.org/question/30940/opencv-builds-on-lab-computer-but-not-laptop/?answer=31466#post-id-31466
The current cmake release, 2.8.12 , does not contain the fix , next release will be ok ( i think )
