### PR TITLE
Documentation - minor fix-ups

### DIFF
--- a/doc/tutorials/core/file_input_output_with_xml_yml/file_input_output_with_xml_yml.rst
+++ b/doc/tutorials/core/file_input_output_with_xml_yml/file_input_output_with_xml_yml.rst
@@ -31,15 +31,15 @@ Here's a sample code of how to achieve all the stuff enumerated at the goal list
 Explanation
 ===========
 
-Here we talk only about XML and YAML file inputs. Your output (and its respective input) file may have only one of these extensions and the structure coming from this. They are two kinds of data structures you may serialize: *mappings* (like the STL map) and *element sequence* (like the STL vector>. The difference between these is that in a map every element has a unique name through what you may access it. For sequences you need to go through them to query a specific item.
+Here we talk only about XML and YAML file inputs. Your output (and its respective input) file may have only one of these extensions and the structure coming from this. They are two kinds of data structures you may serialize: *mappings* (like the STL map) and *element sequence* (like the STL vector). The difference between these is that in a map every element has a unique name through what you may access it. For sequences you need to go through them to query a specific item.
 
-1. **XML\\YAML File Open and Close.** Before you write any content to such file you need to open it and at the end to close it. The XML\YAML data structure in OpenCV is :xmlymlpers:`FileStorage <filestorage>`. To specify that this structure to which file binds on your hard drive you can use either its constructor or the *open()* function of this:
+1. **XML/YAML File Open and Close.** Before you write any content to such file you need to open it and at the end to close it. The XML/YAML data structure in OpenCV is :xmlymlpers:`FileStorage <filestorage>`. To specify that this structure to which file binds on your hard drive you can use either its constructor or the *open()* function of this:
 
    .. code-block:: cpp
 
       string filename = "I.xml";
       FileStorage fs(filename, FileStorage::WRITE);
-      \\...
+      //...
       fs.open(filename, FileStorage::READ);
 
    Either one of this you use the second argument is a constant specifying the type of operations you'll be able to on them: WRITE, READ or APPEND. The extension specified in the file name also determinates the output format that will be used. The output may be even compressed if you specify an extension such as *.xml.gz*.
@@ -64,7 +64,7 @@ Here we talk only about XML and YAML file inputs. Your output (and its respectiv
       fs["iterationNr"] >> itNr;
       itNr = (int) fs["iterationNr"];
 
-#. **Input\\Output of OpenCV Data structures.** Well these behave exactly just as the basic C++ types:
+#. **Input/Output of OpenCV Data structures.** Well these behave exactly just as the basic C++ types:
 
    .. code-block:: cpp
 
@@ -77,7 +77,7 @@ Here we talk only about XML and YAML file inputs. Your output (and its respectiv
       fs["R"] >> R;                                      // Read cv::Mat
       fs["T"] >> T;
 
-#. **Input\\Output of vectors (arrays) and associative maps.** As I mentioned beforehand we can output maps and sequences (array, vector) too. Again we first print the name of the variable and then we have to specify if our output is either a sequence or map.
+#. **Input/Output of vectors (arrays) and associative maps.** As I mentioned beforehand, we can output maps and sequences (array, vector) too. Again we first print the name of the variable and then we have to specify if our output is either a sequence or map.
 
    For sequence before the first element print the "[" character and after the last one the "]" character:
 

--- a/doc/tutorials/core/mat_the_basic_image_container/mat_the_basic_image_container.rst
+++ b/doc/tutorials/core/mat_the_basic_image_container/mat_the_basic_image_container.rst
@@ -113,7 +113,7 @@ Although *Mat* works really well as an image container, it is also a general mat
 
     For instance, *CV_8UC3* means we use unsigned char types that are 8 bit long and each pixel has three of these to form the three channels. This are predefined for up to four channel numbers. The :basicstructures:`Scalar <scalar>` is four element short vector. Specify this and you can initialize all matrix points with a custom value. If you need more you can create the type with the upper macro, setting the channel number in parenthesis as you can see below.
 
-   + Use C\\C++ arrays and initialize via constructor
+   + Use C/C++ arrays and initialize via constructor
 
      .. literalinclude:: ../../../../samples/cpp/tutorial_code/core/mat_the_basic_image_container/mat_the_basic_image_container.cpp
         :language: cpp

--- a/modules/highgui/doc/reading_and_writing_images_and_video.rst
+++ b/modules/highgui/doc/reading_and_writing_images_and_video.rst
@@ -141,7 +141,7 @@ Saves an image to a specified file.
 The function ``imwrite`` saves the image to the specified file. The image format is chosen based on the ``filename`` extension (see
 :ocv:func:`imread` for the list of extensions). Only 8-bit (or 16-bit unsigned (``CV_16U``) in case of PNG, JPEG 2000, and TIFF) single-channel or 3-channel (with 'BGR' channel order) images can be saved using this function. If the format, depth or channel order is different, use
 :ocv:func:`Mat::convertTo` , and
-:ocv:func:`cvtColor` to convert it before saving. Or, use the universal XML I/O functions to save the image to XML or YAML format.
+:ocv:func:`cvtColor` to convert it before saving. Or, use the universal :ocv:class:`FileStorage` I/O functions to save the image to XML or YAML format.
 
 It is possible to store PNG images with an alpha channel using this function. To do this, create 8-bit (or 16-bit) 4-channel image BGRA, where the alpha channel goes last. Fully transparent pixels should have alpha set to 0, fully opaque pixels should have alpha set to 255/65535. The sample below shows how to create such a BGRA image and store to PNG file. It also demonstrates how to set custom compression parameters ::
 


### PR DESCRIPTION
After searching the internet for the "universal XML I/O functions", and finding that it refers to the FileStorage class, I've decided to make the documentation a bit more clear by spelling its name in the tutorial.

Also, I've found some backslashes that looked wrong, so I've fixed them next.
