### PR TITLE
Ipp: fix epsilon calculation for sanity check in x32 build

### DIFF
--- a/modules/imgproc/perf/perf_matchTemplate.cpp
+++ b/modules/imgproc/perf/perf_matchTemplate.cpp
@@ -77,7 +77,7 @@ PERF_TEST_P(ImgSize_TmplSize_Method, matchTemplateBig,
         method == TM_SQDIFF_NORMED ||
         method == TM_CCOEFF_NORMED;
     double eps = isNormed ? 1e-6
-        : 255 * 255 * tmpl.total() * 1e-6;
+        : 255.0 * 255.0 * (double)tmpl.total() * 1e-6;
 
     SANITY_CHECK(result, eps);
 }


### PR DESCRIPTION
check_regression=_matchTemplateBig_
test_modules=imgproc
test_filter=_matchTemplateBig_
build_examples=OFF
