### PR TITLE
IPP: disabled IPP functions that slower than OpenCV

### DIFF
--- a/modules/core/src/copy.cpp
+++ b/modules/core/src/copy.cpp
@@ -423,7 +423,7 @@ Mat& Mat::setTo(InputArray _value, InputArray _mask)
     int cn = channels(), depth0 = depth();
 
     if (!mask.empty() && (dims <= 2 || (isContinuous() && mask.isContinuous())) &&
-            (depth0 == CV_8U || depth0 == CV_16U || depth0 == CV_16S || depth0 == CV_32S || depth0 == CV_32F) &&
+            (/*depth0 == CV_8U ||*/ depth0 == CV_16U || depth0 == CV_16S || depth0 == CV_32S || depth0 == CV_32F) &&
             (cn == 1 || cn == 3 || cn == 4))
     {
         uchar _buf[32];
@@ -442,9 +442,9 @@ Mat& Mat::setTo(InputArray _value, InputArray _mask)
 
         if (cn == 1)
         {
-            if (depth0 == CV_8U)
+            /*if (depth0 == CV_8U)
                 status = ippiSet_8u_C1MR(*(Ipp8u *)buf, (Ipp8u *)data, dstep, roisize, mask.data, mstep);
-            else if (depth0 == CV_16U)
+            else*/ if (depth0 == CV_16U)
                 status = ippiSet_16u_C1MR(*(Ipp16u *)buf, (Ipp16u *)data, dstep, roisize, mask.data, mstep);
             else if (depth0 == CV_16S)
                 status = ippiSet_16s_C1MR(*(Ipp16s *)buf, (Ipp16s *)data, dstep, roisize, mask.data, mstep);
@@ -468,9 +468,9 @@ Mat& Mat::setTo(InputArray _value, InputArray _mask)
     { \
         if (cn == ippcn) \
         { \
-            if (depth0 == CV_8U) \
+            /*if (depth0 == CV_8U) \
                 IPP_SET(8u, ippcn); \
-            else if (depth0 == CV_16U) \
+            else*/ if (depth0 == CV_16U) \
                 IPP_SET(16u, ippcn); \
             else if (depth0 == CV_16S) \
                 IPP_SET(16s, ippcn); \

--- a/modules/core/src/mathfuncs.cpp
+++ b/modules/core/src/mathfuncs.cpp
@@ -237,7 +237,7 @@ float  cubeRoot( float value )
 
 static void Magnitude_32f(const float* x, const float* y, float* mag, int len)
 {
-#if defined(HAVE_IPP)
+#if defined HAVE_IPP && 0
     IppStatus status = ippsMagnitude_32f(x, y, mag, len);
     if (status >= 0)
         return;

--- a/modules/core/src/matmul.cpp
+++ b/modules/core/src/matmul.cpp
@@ -2798,7 +2798,7 @@ dotProd_(const T* src1, const T* src2, int len)
 static double dotProd_8u(const uchar* src1, const uchar* src2, int len)
 {
     double r = 0;
-#if ARITHM_USE_IPP
+#if ARITHM_USE_IPP && 0
     if (0 <= ippiDotProd_8u64f_C1R(src1, (int)(len*sizeof(src1[0])),
                                    src2, (int)(len*sizeof(src2[0])),
                                    ippiSize(len, 1), &r))

--- a/modules/core/src/matrix.cpp
+++ b/modules/core/src/matrix.cpp
@@ -3617,25 +3617,25 @@ namespace cv
 #if IPP_VERSION_X100 > 0
 #define USE_IPP_SORT
 
-typedef IppStatus (CV_STDCALL *IppSortFunc)(void *, int);
+typedef IppStatus (CV_STDCALL * IppSortFunc)(void *, int);
 typedef IppSortFunc IppFlipFunc;
 
 static IppSortFunc getSortFunc(int depth, bool sortDescending)
 {
     if (!sortDescending)
         return depth == CV_8U ? (IppSortFunc)ippsSortAscend_8u_I :
-            depth == CV_16U ? (IppSortFunc)ippsSortAscend_16u_I :
+            /*depth == CV_16U ? (IppSortFunc)ippsSortAscend_16u_I :
             depth == CV_16S ? (IppSortFunc)ippsSortAscend_16s_I :
             depth == CV_32S ? (IppSortFunc)ippsSortAscend_32s_I :
             depth == CV_32F ? (IppSortFunc)ippsSortAscend_32f_I :
-            depth == CV_64F ? (IppSortFunc)ippsSortAscend_64f_I : 0;
+            depth == CV_64F ? (IppSortFunc)ippsSortAscend_64f_I :*/ 0;
     else
         return depth == CV_8U ? (IppSortFunc)ippsSortDescend_8u_I :
-            depth == CV_16U ? (IppSortFunc)ippsSortDescend_16u_I :
+            /*depth == CV_16U ? (IppSortFunc)ippsSortDescend_16u_I :
             depth == CV_16S ? (IppSortFunc)ippsSortDescend_16s_I :
             depth == CV_32S ? (IppSortFunc)ippsSortDescend_32s_I :
             depth == CV_32F ? (IppSortFunc)ippsSortDescend_32f_I :
-            depth == CV_64F ? (IppSortFunc)ippsSortDescend_64f_I : 0;
+            depth == CV_64F ? (IppSortFunc)ippsSortDescend_64f_I :*/ 0;
 }
 
 static IppFlipFunc getFlipFunc(int depth)
@@ -3643,9 +3643,9 @@ static IppFlipFunc getFlipFunc(int depth)
     CV_SUPPRESS_DEPRECATED_START
     return
             depth == CV_8U || depth == CV_8S ? (IppFlipFunc)ippsFlip_8u_I :
-            depth == CV_16U || depth == CV_16S ? (IppFlipFunc)ippsFlip_16u_I :
+            /*depth == CV_16U || depth == CV_16S ? (IppFlipFunc)ippsFlip_16u_I :
             depth == CV_32S || depth == CV_32F ? (IppFlipFunc)ippsFlip_32f_I :
-            depth == CV_64F ? (IppFlipFunc)ippsFlip_64f_I : 0;
+            depth == CV_64F ? (IppFlipFunc)ippsFlip_64f_I : */0;
     CV_SUPPRESS_DEPRECATED_END
 }
 
@@ -3700,7 +3700,8 @@ template<typename T> static void sort_( const Mat& src, Mat& dst, int flags )
 #endif
         {
 #ifdef USE_IPP_SORT
-            setIppErrorStatus();
+            if (depth != CV_8U)
+                setIppErrorStatus();
 #endif
             std::sort( ptr, ptr + len );
             if( sortDescending )
@@ -3732,7 +3733,7 @@ public:
     const _Tp* arr;
 };
 
-#ifdef USE_IPP_SORT
+#if defined USE_IPP_SORT && 0
 
 typedef IppStatus (CV_STDCALL *IppSortIndexFunc)(void *, int *, int);
 
@@ -3779,7 +3780,7 @@ template<typename T> static void sortIdx_( const Mat& src, Mat& dst, int flags )
     bptr = (T*)buf;
     _iptr = (int*)ibuf;
 
-#ifdef USE_IPP_SORT
+#if defined USE_IPP_SORT && 0
     int depth = src.depth();
     IppSortIndexFunc ippFunc = getSortIndexFunc(depth, sortDescending);
     IppFlipFunc ippFlipFunc = getFlipFunc(depth);
@@ -3803,21 +3804,21 @@ template<typename T> static void sortIdx_( const Mat& src, Mat& dst, int flags )
         for( j = 0; j < len; j++ )
             iptr[j] = j;
 
-#ifdef USE_IPP_SORT
+#if defined USE_IPP_SORT && 0
         if (sortRows || !ippFunc || ippFunc(ptr, iptr, len) < 0)
 #endif
         {
-#ifdef USE_IPP_SORT
+#if defined USE_IPP_SORT && 0
             setIppErrorStatus();
 #endif
             std::sort( iptr, iptr + len, LessThanIdx<T>(ptr) );
             if( sortDescending )
             {
-#ifdef USE_IPP_SORT
+#if defined USE_IPP_SORT && 0
                 if (!ippFlipFunc || ippFlipFunc(iptr, len) < 0)
 #endif
                 {
-#ifdef USE_IPP_SORT
+#if defined USE_IPP_SORT && 0
                     setIppErrorStatus();
 #endif
                     for( j = 0; j < len/2; j++ )

--- a/modules/imgproc/src/color.cpp
+++ b/modules/imgproc/src/color.cpp
@@ -3977,22 +3977,20 @@ void cv::cvtColor( InputArray _src, OutputArray _dst, int code, int dcn )
                 setIppErrorStatus();
             }
             else
-#endif
-            if (code == CV_LRGB2Lab && scn == 3 && depth == CV_8U)
+            if (code == CV_LRGB2Lab && scn == 3 && depth == CV_8U) // slower than OpenCV
             {
                 if (CvtColorIPPLoop(src, dst, IPPReorderGeneralFunctor(ippiSwapChannelsC3RTab[depth],
                                                                        (ippiGeneralFunc)ippiBGRToLab_8u_C3R, 2, 1, 0, depth)))
                     return;
                 setIppErrorStatus();
             }
-            else if (code == CV_LRGB2Lab && scn == 4 && depth == CV_8U)
+            else if (code == CV_LRGB2Lab && scn == 4 && depth == CV_8U) // slower than OpenCV
             {
                 if (CvtColorIPPLoop(src, dst, IPPReorderGeneralFunctor(ippiSwapChannelsC4C3RTab[depth],
                                                                        (ippiGeneralFunc)ippiBGRToLab_8u_C3R, 2, 1, 0, depth)))
                     return;
                 setIppErrorStatus();
             }
-#if 0
             else if (code == CV_LRGB2Luv && scn == 3)
             {
                 if (CvtColorIPPLoop(src, dst, IPPGeneralFunctor(ippiRGBToLUVTab[depth])))
@@ -4054,7 +4052,7 @@ void cv::cvtColor( InputArray _src, OutputArray _dst, int code, int dcn )
             _dst.create(sz, CV_MAKETYPE(depth, dcn));
             dst = _dst.getMat();
 
-#if defined(HAVE_IPP) && 0
+#if defined HAVE_IPP && 0
             if( code == CV_Lab2LBGR && dcn == 3 && depth == CV_8U)
             {
                 if( CvtColorIPPLoop(src, dst, IPPGeneralFunctor((ippiGeneralFunc)ippiLabToBGR_8u_C3R)) )

--- a/modules/imgproc/src/corner.cpp
+++ b/modules/imgproc/src/corner.cpp
@@ -526,7 +526,7 @@ void cv::cornerHarris( InputArray _src, OutputArray _dst, int blockSize, int ksi
     _dst.create( src.size(), CV_32FC1 );
     Mat dst = _dst.getMat();
 
-#if IPP_VERSION_X100 >= 801
+#if IPP_VERSION_X100 >= 801 && 0
     int type = src.type(), depth = CV_MAT_DEPTH(type), cn = CV_MAT_CN(type);
     int borderTypeNI = borderType & ~BORDER_ISOLATED;
     bool isolated = (borderType & BORDER_ISOLATED) != 0;
@@ -563,10 +563,8 @@ void cv::cornerHarris( InputArray _src, OutputArray _dst, int blockSize, int ksi
 
             if (status >= 0)
                 return;
-            setIppErrorStatus();
         }
-        else
-            setIppErrorStatus();
+        setIppErrorStatus();
     }
 #endif
 

--- a/modules/imgproc/src/moments.cpp
+++ b/modules/imgproc/src/moments.cpp
@@ -462,7 +462,7 @@ cv::Moments cv::moments( InputArray _src, bool binary )
         if( cn > 1 )
             CV_Error( CV_StsBadArg, "Invalid image type (must be single-channel)" );
 
-#if IPP_VERSION_X100 >= 801
+#if IPP_VERSION_X100 >= 801 && 0
         if (!binary)
         {
             IppiSize roi = { mat.cols, mat.rows };

--- a/modules/imgproc/src/pyramids.cpp
+++ b/modules/imgproc/src/pyramids.cpp
@@ -508,7 +508,7 @@ void cv::pyrDown( InputArray _src, OutputArray _dst, const Size& _dsz, int borde
         return;
 #endif
 
-#if IPP_VERSION_X100 >= 801
+#if IPP_VERSION_X100 >= 801 && 0
     bool isolated = (borderType & BORDER_ISOLATED) != 0;
     int borderTypeNI = borderType & ~BORDER_ISOLATED;
     if (borderTypeNI == BORDER_DEFAULT && (!src.isSubmatrix() || isolated) && dsz == Size((src.cols + 1)/2, (src.rows + 1)/2))
@@ -577,7 +577,7 @@ void cv::pyrUp( InputArray _src, OutputArray _dst, const Size& _dsz, int borderT
         return;
 #endif
 
-#if IPP_VERSION_X100 >= 801
+#if IPP_VERSION_X100 >= 801 && 0
     bool isolated = (borderType & BORDER_ISOLATED) != 0;
     int borderTypeNI = borderType & ~BORDER_ISOLATED;
     if (borderTypeNI == BORDER_DEFAULT && (!src.isSubmatrix() || isolated) && dsz == Size(src.cols*2, src.rows*2))
@@ -648,7 +648,7 @@ void cv::buildPyramid( InputArray _src, OutputArrayOfArrays _dst, int maxlevel, 
 
     int i=1;
 
-#if IPP_VERSION_X100 >= 801
+#if IPP_VERSION_X100 >= 801 && 0
     bool isolated = (borderType & BORDER_ISOLATED) != 0;
     int borderTypeNI = borderType & ~BORDER_ISOLATED;
     if (borderTypeNI == BORDER_DEFAULT && (!src.isSubmatrix() || isolated))
@@ -668,17 +668,20 @@ void cv::buildPyramid( InputArray _src, OutputArrayOfArrays _dst, int maxlevel, 
             pyrInitAllocFunc = (ippiPyramidLayerDownInitAlloc) ippiPyramidLayerDownInitAlloc_8u_C1R;
             pyrDownFunc = (ippiPyramidLayerDown) ippiPyramidLayerDown_8u_C1R;
             pyrFreeFunc = (ippiPyramidLayerDownFree) ippiPyramidLayerDownFree_8u_C1R;
-        } else if (type == CV_8UC3)
+        }
+        else if (type == CV_8UC3)
         {
             pyrInitAllocFunc = (ippiPyramidLayerDownInitAlloc) ippiPyramidLayerDownInitAlloc_8u_C3R;
             pyrDownFunc = (ippiPyramidLayerDown) ippiPyramidLayerDown_8u_C3R;
             pyrFreeFunc = (ippiPyramidLayerDownFree) ippiPyramidLayerDownFree_8u_C3R;
-        } else if (type == CV_32FC1)
+        }
+        else if (type == CV_32FC1)
         {
             pyrInitAllocFunc = (ippiPyramidLayerDownInitAlloc) ippiPyramidLayerDownInitAlloc_32f_C1R;
             pyrDownFunc = (ippiPyramidLayerDown) ippiPyramidLayerDown_32f_C1R;
             pyrFreeFunc = (ippiPyramidLayerDownFree) ippiPyramidLayerDownFree_32f_C1R;
-        } else if (type == CV_32FC3)
+        }
+        else if (type == CV_32FC3)
         {
             pyrInitAllocFunc = (ippiPyramidLayerDownInitAlloc) ippiPyramidLayerDownInitAlloc_32f_C3R;
             pyrDownFunc = (ippiPyramidLayerDown) ippiPyramidLayerDown_32f_C3R;
@@ -722,10 +725,10 @@ void cv::buildPyramid( InputArray _src, OutputArrayOfArrays _dst, int maxlevel, 
                     }
                 }
                 pyrFreeFunc(gPyr->pState);
-            } else
-            {
-                setIppErrorStatus();
             }
+            else
+                setIppErrorStatus();
+
             ippiPyramidFree(gPyr);
         }
     }


### PR DESCRIPTION
check_regression=_BuildPyramid_:_CartToPolar_:_Magnitude_:_Moments_:_PyrDown_:_SetToWithMask_:_Resize_:_UMatDot_:_buildPyramid_:_cornerHarris_:_2Lab_:_dot_:_pyr_sor:_OpticalFlowPyrLK_
