### PR TITLE
Fix problem with sanity check of transform ecc with ipp resize

### DIFF
--- a/modules/video/perf/perf_ecc.cpp
+++ b/modules/video/perf/perf_ecc.cpp
@@ -17,10 +17,7 @@ PERF_TEST_P(TransformationType, findTransformECC, /*testing::ValuesIn(MotionType
             (int) MOTION_AFFINE, (int) MOTION_HOMOGRAPHY)
             )
 {
-
-    Mat inputImage = imread(getDataPath("cv/shared/fruits.png"),0);
-    Mat img;
-    resize(inputImage, img, Size(216,216));
+    Mat img = imread(getDataPath("cv/shared/fruits_ecc.png"),0);
     Mat templateImage;
 
     int transform_type = get<0>(GetParam());


### PR DESCRIPTION
Itseez/opencv_extra#178

We have problem with preparinig test data for this test, if we used resize function with ipp support. 

build_examples=OFF
test_modules=video
