### PR TITLE
cv::findContours: Sanity check of output data structure

### DIFF
--- a/modules/imgproc/src/contours.cpp
+++ b/modules/imgproc/src/contours.cpp
@@ -1703,6 +1703,10 @@ cvFindContours( void*  img,  CvMemStorage*  storage,
 void cv::findContours( InputOutputArray _image, OutputArrayOfArrays _contours,
                    OutputArray _hierarchy, int mode, int method, Point offset )
 {
+    // Sanity check: output must be of type vector<vector<Point>>
+    CV_Assert( _contours.kind() == _InputArray::STD_VECTOR_VECTOR &&
+               _contours.channels() == 2 && _contours.depth() == CV_32S );
+
     Mat image = _image.getMat();
     MemStorage storage(cvCreateMemStorage());
     CvMat _cimage = image;


### PR DESCRIPTION
With reference to the issue reported in http://code.opencv.org/issues/3606 it seems that it would be good to add in cv::findContours() explicit sanity check of output data structure.
