### PR TITLE
OCL: changed epsilon for HOG perfomance test

### DIFF
--- a/modules/imgproc/test/ocl/test_warp.cpp
+++ b/modules/imgproc/test/ocl/test_warp.cpp
@@ -184,8 +184,7 @@ PARAM_TEST_CASE(Resize, MatType, double, double, Interpolation, bool, int)
 
         Size srcRoiSize = randomSize(1, MAX_VALUE), dstRoiSize;
         // Make sure the width is a multiple of the requested value, and no more
-        srcRoiSize.width &= ~((widthMultiple * 2) - 1);
-        srcRoiSize.width += widthMultiple;
+        srcRoiSize.width += widthMultiple - 1 - (srcRoiSize.width - 1) % widthMultiple;
         dstRoiSize.width = cvRound(srcRoiSize.width * fx);
         dstRoiSize.height = cvRound(srcRoiSize.height * fy);
 

--- a/modules/objdetect/perf/opencl/perf_hogdetect.cpp
+++ b/modules/objdetect/perf/opencl/perf_hogdetect.cpp
@@ -85,7 +85,7 @@ OCL_PERF_TEST(HOGFixture, HOG)
     OCL_TEST_CYCLE() hog.detectMultiScale(src, found_locations);
 
     std::sort(found_locations.begin(), found_locations.end(), RectLess());
-    SANITY_CHECK(found_locations, 1 + DBL_EPSILON);
+    SANITY_CHECK(found_locations, 3);
 }
 
 }


### PR DESCRIPTION
test_modules=objdetect
build_examples=OFF
- HOG detector is too sensible to resize accuracy.
- Fixed generation of srcRoiSize in ocl.test_warp tests, it generated only odd width before in case `widthMultiple = 1`.
