### PR TITLE
Remove unused macros from C headers

### DIFF
--- a/modules/core/include/opencv2/core/core_c.h
+++ b/modules/core/include/opencv2/core/core_c.h
@@ -1764,15 +1764,9 @@ CVAPI(int) cvGuiBoxReport( int status, const char* func_name, const char* err_ms
 #define OPENCV_ERROR(status,func,context)                           \
 cvError((status),(func),(context),__FILE__,__LINE__)
 
-#define OPENCV_ERRCHK(func,context)                                 \
-{if (cvGetErrStatus() >= 0)                         \
-{OPENCV_ERROR(CV_StsBackTrace,(func),(context));}}
-
 #define OPENCV_ASSERT(expr,func,context)                            \
 {if (! (expr))                                      \
 {OPENCV_ERROR(CV_StsInternal,(func),(context));}}
-
-#define OPENCV_RSTERR() (cvSetErrStatus(CV_StsOk))
 
 #define OPENCV_CALL( Func )                                         \
 {                                                                   \
@@ -1799,10 +1793,6 @@ static char cvFuncName[] = Name
     cvError( (Code), cvFuncName, Msg, __FILE__, __LINE__ );        \
     __CV_EXIT__;                                                   \
 }
-
-/* Simplified form of CV_ERROR */
-#define CV_ERROR_FROM_CODE( code )   \
-    CV_ERROR( code, "" )
 
 /*
  CV_CHECK macro checks error status after CV (or IPL)


### PR DESCRIPTION
After grep-ing the code, I haven't found a single instance of them being used.
They look like being phased out a long time ago.

Also: It would be ok if I removed other strange chunks of code? Because I found this, and it's actually used in few places in the library.

```
#define OPENCV_CALL( Func )                                         \
{                                                                   \
Func;                                                           \
}
```
