### PR TITLE
Fixed bug in IPPMorphOp function

### DIFF
--- a/modules/imgproc/src/morph.cpp
+++ b/modules/imgproc/src/morph.cpp
@@ -1234,7 +1234,7 @@ static bool IPPMorphOp(int op, InputArray _src, OutputArray _dst,
                     return false;
             }
         }
-        for( x = 0; y < kernel.cols; x++ )
+        for( x = 0; x < kernel.cols; x++ )
         {
             if( kernel.at<uchar>(anchor.y, x) != 0 )
                 continue;


### PR DESCRIPTION
Looks like a typo in the loop where morphology kernel elements are tested: y is used where it should have been x.
