### PR TITLE
Bugfix #3668 in FilterEngine::apply(), use the ROI properly

### DIFF
--- a/modules/imgproc/src/filter.cpp
+++ b/modules/imgproc/src/filter.cpp
@@ -454,8 +454,7 @@ void FilterEngine::apply(const Mat& src, Mat& dst,
 
     int y = start(src, srcRoi, isolated);
     proceed( src.data + y*src.step
-             + srcRoi.x*src.elemSize(),/* Bugfix #3668 use the x-shift of ROI
-                                        */
+             + srcRoi.x*src.elemSize(),
              (int)src.step, endY - startY,
              dst.data + dstOfs.y*dst.step +
              dstOfs.x*dst.elemSize(), (int)dst.step );


### PR DESCRIPTION
FilterEngine::apply() takes into account the x-coordinate of its ROI parameter.
