### PR TITLE
fixed wrong download link in tutorial

### DIFF
--- a/doc/tutorials/introduction/windows_install/windows_install.rst
+++ b/doc/tutorials/introduction/windows_install/windows_install.rst
@@ -55,7 +55,7 @@ Building the OpenCV library from scratch requires a couple of tools installed be
 .. |TortoiseGit| replace:: TortoiseGit
 .. _TortoiseGit: http://code.google.com/p/tortoisegit/wiki/Download
 .. |Python_Libraries| replace:: Python libraries
-.. _Python_Libraries: http://www.python.org/getit/
+.. _Python_Libraries: http://www.python.org/downloads/
 .. |Numpy| replace:: Numpy
 .. _Numpy: http://numpy.scipy.org/
 .. |IntelTBB| replace:: Intel |copy| Threading Building Blocks (*TBB*)


### PR DESCRIPTION
as noted in this question (http://answers.opencv.org/question/32943/dead-link-in-opencv-installation-instructions-for/) the download link in the tutorial is wrong and should thus be fixed.
