### PR TITLE
Fix non-Android cross compilation with OpenCVConfig.cmake

### DIFF
--- a/cmake/templates/OpenCVConfig.cmake.in
+++ b/cmake/templates/OpenCVConfig.cmake.in
@@ -60,7 +60,11 @@ set(OpenCV_USE_CUFFT    @HAVE_CUFFT@)
 set(OpenCV_USE_NVCUVID  @HAVE_NVCUVID@)
 
 # Android API level from which OpenCV has been compiled is remembered
-set(OpenCV_ANDROID_NATIVE_API_LEVEL @OpenCV_ANDROID_NATIVE_API_LEVEL_CONFIGCMAKE@)
+if(ANDROID)
+  set(OpenCV_ANDROID_NATIVE_API_LEVEL @OpenCV_ANDROID_NATIVE_API_LEVEL_CONFIGCMAKE@)
+else
+  set(OpenCV_ANDROID_NATIVE_API_LEVEL 0)
+endif()
 
 # Some additional settings are required if OpenCV is built as static libs
 set(OpenCV_SHARED @BUILD_SHARED_LIBS@)
@@ -71,8 +75,8 @@ set(OpenCV_USE_MANGLED_PATHS @OpenCV_USE_MANGLED_PATHS_CONFIGCMAKE@)
 # Extract the directory where *this* file has been installed (determined at cmake run-time)
 get_filename_component(OpenCV_CONFIG_PATH "${CMAKE_CURRENT_LIST_FILE}" PATH CACHE)
 
-if(NOT WIN32 OR OpenCV_ANDROID_NATIVE_API_LEVEL GREATER 0)
-  if(OpenCV_ANDROID_NATIVE_API_LEVEL GREATER 0)
+if(NOT WIN32 OR ANDROID)
+  if(ANDROID)
     set(OpenCV_INSTALL_PATH "${OpenCV_CONFIG_PATH}/../../..")
   else()
     set(OpenCV_INSTALL_PATH "${OpenCV_CONFIG_PATH}/../..")


### PR DESCRIPTION
Right now in some cases setup og OpenCV_ANDROID_NATIVE_API_LEVEL leads to invalid OpenCVConfig.cmake.
