### PR TITLE
Added doc for LinearPolar Transform

### DIFF
--- a/modules/imgproc/doc/geometric_transformations.rst
+++ b/modules/imgproc/doc/geometric_transformations.rst
@@ -256,6 +256,57 @@ The function computes an inverse affine transformation represented by
 The result is also a
 :math:`2 \times 3` matrix of the same type as ``M`` .
 
+LinearPolar
+-----------
+Remaps an image to polar space.
+
+.. ocv:cfunction:: void cvLinearPolar( const CvArr* src, CvArr* dst, CvPoint2D32f center, double maxRadius, int flags=CV_INTER_LINEAR+CV_WARP_FILL_OUTLIERS )
+
+    :param src: Source image
+
+    :param dst: Destination image
+
+    :param center: The transformation center;
+
+    :param maxRadius: Inverse magnitude scale parameter. See below
+
+    :param flags: A combination of interpolation methods and the following optional flags:
+
+            *  **CV_WARP_FILL_OUTLIERS** fills all of the destination image pixels. If some of them correspond to outliers in the source image, they are set to zero
+
+            *  **CV_WARP_INVERSE_MAP** See below
+
+The function ``cvLinearPolar`` transforms the source image using the following transformation:
+
+  *
+    Forward transformation (``CV_WARP_INVERSE_MAP`` is not set):
+
+        .. math::
+
+            dst( \phi , \rho ) = src(x,y)
+
+
+  *
+    Inverse transformation (``CV_WARP_INVERSE_MAP`` is set):
+
+        .. math::
+
+            dst(x,y) = src( \phi , \rho )
+
+
+where
+
+    .. math::
+
+        \rho = (src.width/maxRadius)  \cdot \sqrt{x^2 + y^2} , \phi =atan(y/x)
+
+
+The function can not operate in-place.
+
+.. note::
+
+   * An example using the LinearPolar operation can be found at opencv_source_code/samples/c/polar_transforms.c
+
 
 
 LogPolar


### PR DESCRIPTION
Tickets: 1729 and 3654

LogPolar is documented and has samples for both C ("samples/c/polar_transforms.c") and python ("samples/python/logpolar.py"). 

LinearPolar is not documented. It has a C sample ("samples/c/polar_transforms.c"). There seems to be no equivalent function as well as a sample in python.

However, OpenCV 3.x has cv2.linearpolar ("samples/python/logpolar.py").
