### PR TITLE
highgui: fix segfault on CvCapture_GStreamer::retrieveFrame

### DIFF
--- a/modules/highgui/src/cap_gstreamer.cpp
+++ b/modules/highgui/src/cap_gstreamer.cpp
@@ -400,6 +400,7 @@ bool CvCapture_GStreamer::open( int type, const char* filename )
     gst_app_sink_set_max_buffers (GST_APP_SINK(sink), 1);
     gst_app_sink_set_drop (GST_APP_SINK(sink), stream);
     caps = gst_caps_new_simple("video/x-raw-rgb",
+                               "bpp",        G_TYPE_INT, 24,
                                "red_mask",   G_TYPE_INT, 0x0000FF,
                                "green_mask", G_TYPE_INT, 0x00FF00,
                                "blue_mask",  G_TYPE_INT, 0xFF0000,


### PR DESCRIPTION
CvCapture_GStreamer::retrieveFrame assumes that RGB videos are 24BPP.
This is not necesarily the case, unless we explicitly tell GStreamer
that we want 24BPP RGB streams.

Adding bpp=(int)24 to the appsink caps.

Here is a video that causes a segfault without this change: 
  http://vclab.science.uoit.ca/~luis/pigbloodtests/2011.09.29.1/wolverine_drop_1.avi
If GStreamer produces a buffer smaller than 24bpp, the image will be much larger than the buffer, leading to a segmentation fault when trying to read beyond the buffer.
