### PR TITLE
T-API: preferred vector widths as a heuristic for Intel

### DIFF
--- a/modules/core/src/ocl.cpp
+++ b/modules/core/src/ocl.cpp
@@ -4414,6 +4414,12 @@ int predictOptimalVectorWidth(InputArray src1, InputArray src2, InputArray src3,
         d.preferredVectorWidthShort(), d.preferredVectorWidthShort(),
         d.preferredVectorWidthInt(), d.preferredVectorWidthFloat(),
         d.preferredVectorWidthDouble(), -1 }, width = vectorWidths[depth];
+    if (d.isIntel())
+    {
+        // it's heuristic
+        int vectorWidthsIntel[] = { 16, 16, 8, 8, 1, 1, 1, -1 };
+        width = vectorWidthsIntel[depth];
+    }
 
     if (ssize.width * cn < width || width <= 0)
         return 1;


### PR DESCRIPTION
Intel OpenCL devices return 1 as preferred vector width for all data types, but usage of vector gives performance benefits. So, this PR brings usage of vectors for some core functions like add, sub, etc. 

performance reports: http://ocl.itseez.com/intel/export/perf/pr/2723/report/

check_regression=_OCL_AddFixture_:_OCL_SubtractFixture_:_OCL_MulFixture_:_OCL_DivFixture_:_OCL_AbsDiffFixture_:_OCL_MagnitudeFixture_:_OCL_BitwiseAndFixture_:_OCL_BitwiseXorFixture_:_OCL_BitwiseOrFixture_:_OCL_BitwiseNotFixture_:_OCL_MinFixture_:_OCL_MaxFixture_:_OCL_ConvertScaleAbsFixture_:_OCL_ScaleAddFixture_:_OCL_ThreshFixture_:_OCL_CompareFixture_:_OCL_Flow*
