### PR TITLE
T-API: used native/built-in functions

### DIFF
--- a/modules/core/src/mathfuncs.cpp
+++ b/modules/core/src/mathfuncs.cpp
@@ -2501,7 +2501,7 @@ static bool ocl_patchNaNs( InputOutputArray _a, float value )
 {
     int rowsPerWI = ocl::Device::getDefault().isIntel() ? 4 : 1;
     ocl::Kernel k("KF", ocl::core::arithm_oclsrc,
-                     format("-D UNARY_OP -D OP_PATCH_NANS -D dstT=int -D rowsPerWI=%d",
+                     format("-D UNARY_OP -D OP_PATCH_NANS -D dstT=float -D rowsPerWI=%d",
                             rowsPerWI));
     if (k.empty())
         return false;


### PR DESCRIPTION
**Description:**
This PR brings performance gain for cv::exp, cv::polarToCart by using build-in functions.

**Performance report:**
http://ocl.itseez.com/intel/export/perf/pr/2732/report/

check_regression=_OCL_Divide_:_OCL_AddW_:_OCL_Exp_:_OCL_Pow_:_OCL_Sqrt_:_OCL_Log_:_OCL_ConvertScale_:_OCL_ScaleA_:_OCL_Na_:_OCL_Cart_:_OCL_Phase*
