### PR TITLE
Fix svm intro tutorial

### DIFF
--- a/doc/tutorials/ml/introduction_to_svm/introduction_to_svm.rst
+++ b/doc/tutorials/ml/introduction_to_svm/introduction_to_svm.rst
@@ -105,8 +105,8 @@ Explanation
 
   .. code-block:: cpp
 
-     Mat trainingDataMat(3, 2, CV_32FC1, trainingData);
-     Mat labelsMat      (3, 1, CV_32FC1, labels);
+     Mat trainingDataMat(4, 2, CV_32FC1, trainingData);
+     Mat labelsMat      (4, 1, CV_32FC1, labels);
 
 2. **Set up SVM's parameters**
 


### PR DESCRIPTION
This is fix for [bug #3605](http://code.opencv.org/issues/3605).
Before was https://github.com/Itseez/opencv/pull/2716, rebased onto 2.4
