### PR TITLE
Added condition to 1st test in cv::GaussianBlur

### DIFF
--- a/modules/imgproc/src/smooth.cpp
+++ b/modules/imgproc/src/smooth.cpp
@@ -837,7 +837,7 @@ void cv::GaussianBlur( InputArray _src, OutputArray _dst, Size ksize,
     _dst.create( src.size(), src.type() );
     Mat dst = _dst.getMat();
 
-    if( borderType != BORDER_CONSTANT )
+    if( borderType != BORDER_CONSTANT && (borderType & BORDER_ISOLATED) != 0 )
     {
         if( src.rows == 1 )
             ksize.height = 1;


### PR DESCRIPTION
Consistent with the test made in cv::boxFilter, it adjusts the kernel size to the source size only if the border is not BORDER_CONSTANT and if BORDER_ISOLATED is set. Otherwise, the source has to be considered possibly in a larger image (i.e. the source being a ROI) in witch the kernel should apply.
