### PR TITLE
T-API: optimized stitching warpers (buildMaps)

### DIFF
--- a/modules/stitching/src/warpers.cpp
+++ b/modules/stitching/src/warpers.cpp
@@ -103,16 +103,16 @@ Rect PlaneWarper::buildMaps(Size src_size, InputArray K, InputArray R, InputArra
         ocl::Kernel k("buildWarpPlaneMaps", ocl::stitching::warpers_oclsrc);
         if (!k.empty())
         {
-
+            int rowsPerWI = ocl::Device::getDefault().isIntel() ? 4 : 1;
             Mat k_rinv(1, 9, CV_32FC1, projector_.k_rinv), t(1, 3, CV_32FC1, projector_.t);
             UMat uxmap = _xmap.getUMat(), uymap = _ymap.getUMat(),
                     uk_rinv = k_rinv.getUMat(ACCESS_READ), ut = t.getUMat(ACCESS_READ);
 
             k.args(ocl::KernelArg::WriteOnlyNoSize(uxmap), ocl::KernelArg::WriteOnly(uymap),
                    ocl::KernelArg::PtrReadOnly(uk_rinv), ocl::KernelArg::PtrReadOnly(ut),
-                   dst_tl.x, dst_tl.y, projector_.scale);
+                   dst_tl.x, dst_tl.y, projector_.scale, rowsPerWI);
 
-            size_t globalsize[2] = { dsize.width, dsize.height };
+            size_t globalsize[2] = { dsize.width, (dsize.height + rowsPerWI - 1) / rowsPerWI };
             if (k.run(2, globalsize, NULL, true))
                 return Rect(dst_tl, dst_br);
         }
@@ -371,6 +371,7 @@ Rect SphericalWarper::buildMaps(Size src_size, InputArray K, InputArray R, Outpu
         ocl::Kernel k("buildWarpSphericalMaps", ocl::stitching::warpers_oclsrc);
         if (!k.empty())
         {
+            int rowsPerWI = ocl::Device::getDefault().isIntel() ? 4 : 1;
             projector_.setCameraParams(K, R);
 
             Point dst_tl, dst_br;
@@ -384,9 +385,9 @@ Rect SphericalWarper::buildMaps(Size src_size, InputArray K, InputArray R, Outpu
             UMat uxmap = xmap.getUMat(), uymap = ymap.getUMat(), uk_rinv = k_rinv.getUMat(ACCESS_READ);
 
             k.args(ocl::KernelArg::WriteOnlyNoSize(uxmap), ocl::KernelArg::WriteOnly(uymap),
-                   ocl::KernelArg::PtrReadOnly(uk_rinv), dst_tl.x, dst_tl.y, projector_.scale);
+                   ocl::KernelArg::PtrReadOnly(uk_rinv), dst_tl.x, dst_tl.y, projector_.scale, rowsPerWI);
 
-            size_t globalsize[2] = { dsize.width, dsize.height };
+            size_t globalsize[2] = { dsize.width, (dsize.height + rowsPerWI - 1) / rowsPerWI };
             if (k.run(2, globalsize, NULL, true))
                 return Rect(dst_tl, dst_br);
         }
@@ -415,6 +416,7 @@ Rect CylindricalWarper::buildMaps(Size src_size, InputArray K, InputArray R, Out
         ocl::Kernel k("buildWarpCylindricalMaps", ocl::stitching::warpers_oclsrc);
         if (!k.empty())
         {
+            int rowsPerWI = ocl::Device::getDefault().isIntel() ? 4 : 1;
             projector_.setCameraParams(K, R);
 
             Point dst_tl, dst_br;
@@ -428,9 +430,10 @@ Rect CylindricalWarper::buildMaps(Size src_size, InputArray K, InputArray R, Out
             UMat uxmap = xmap.getUMat(), uymap = ymap.getUMat(), uk_rinv = k_rinv.getUMat(ACCESS_READ);
 
             k.args(ocl::KernelArg::WriteOnlyNoSize(uxmap), ocl::KernelArg::WriteOnly(uymap),
-                   ocl::KernelArg::PtrReadOnly(uk_rinv), dst_tl.x, dst_tl.y, projector_.scale);
+                   ocl::KernelArg::PtrReadOnly(uk_rinv), dst_tl.x, dst_tl.y, projector_.scale,
+                   rowsPerWI);
 
-            size_t globalsize[2] = { dsize.width, dsize.height };
+            size_t globalsize[2] = { dsize.width, (dsize.height + rowsPerWI - 1) / rowsPerWI };
             if (k.run(2, globalsize, NULL, true))
                 return Rect(dst_tl, dst_br);
         }


### PR DESCRIPTION
check_regression=_OCL_Warper*
test_modules=stitching
- Used the following built-in functions:
  - `sin+cos` are combined into `sincos` function
  - instead of a*b+c `fma` is used
- Increased number of rows that are processed by work-items. 

http://ocl.itseez.com/intel/export/perf/pr/2761/report/
