### PR TITLE
T-API: added performance test for cv::norm with NORM_RELATIVE

### DIFF
--- a/modules/core/perf/opencl/perf_arithm.cpp
+++ b/modules/core/perf/opencl/perf_arithm.cpp
@@ -728,6 +728,26 @@ OCL_PERF_TEST_P(NormFixture, Norm,
     SANITY_CHECK(res, 1e-5, ERROR_RELATIVE);
 }
 
+OCL_PERF_TEST_P(NormFixture, NormRel,
+                ::testing::Combine(OCL_PERF_ENUM(OCL_SIZE_1, OCL_SIZE_2, OCL_SIZE_3),
+                                   OCL_TEST_TYPES_134, NormType::all()))
+{
+    const NormParams params = GetParam();
+    const Size srcSize = get<0>(params);
+    const int type = get<1>(params);
+    const int normType = get<2>(params);
+
+    checkDeviceMaxMemoryAllocSize(srcSize, type);
+
+    UMat src1(srcSize, type), src2(srcSize, type);
+    double res;
+    declare.in(src1, src2, WARMUP_RNG);
+
+    OCL_TEST_CYCLE() res = cv::norm(src1, src2, normType | cv::NORM_RELATIVE);
+
+    SANITY_CHECK(res, 1e-5, ERROR_RELATIVE);
+}
+
 ///////////// UMat::dot ////////////////////////
 
 typedef Size_MatType UMatDotFixture;


### PR DESCRIPTION
check_regression=_OCL_NormRel*
merge with opencv_extra https://github.com/Itseez/opencv_extra/pull/183
