### PR TITLE
Disabling BORDER_CONSTANT for pyramid functions

### DIFF
--- a/modules/imgproc/doc/filtering.rst
+++ b/modules/imgproc/doc/filtering.rst
@@ -558,6 +558,8 @@ Constructs the Gaussian pyramid for an image.
 
     :param maxlevel: 0-based index of the last (the smallest) pyramid layer. It must be non-negative.
 
+    :param borderType: Pixel extrapolation method (BORDER_CONSTANT don't supported). See  :ocv:func:`borderInterpolate` for details.
+
 The function constructs a vector of images and builds the Gaussian pyramid by recursively applying
 :ocv:func:`pyrDown` to the previously built pyramid layers, starting from ``dst[0]==src`` .
 
@@ -1343,12 +1345,16 @@ Blurs an image and downsamples it.
 
     :param dst: output image; it has the specified size and the same type as ``src``.
 
-    :param dstsize: size of the output image; by default, it is computed as ``Size((src.cols+1)/2, (src.rows+1)/2)``, but in any case, the following conditions should be satisfied:
+    :param dstsize: size of the output image.
 
-        .. math::
+    :param borderType: Pixel extrapolation method (BORDER_CONSTANT don't supported). See  :ocv:func:`borderInterpolate` for details.
 
-            \begin{array}{l}
-            | \texttt{dstsize.width} *2-src.cols| \leq  2  \\ | \texttt{dstsize.height} *2-src.rows| \leq  2 \end{array}
+By default, size of the output image is computed as ``Size((src.cols+1)/2, (src.rows+1)/2)``, but in any case, the following conditions should be satisfied:
+
+.. math::
+
+    \begin{array}{l}
+    | \texttt{dstsize.width} *2-src.cols| \leq  2  \\ | \texttt{dstsize.height} *2-src.rows| \leq  2 \end{array}
 
 The function performs the downsampling step of the Gaussian pyramid construction. First, it convolves the source image with the kernel:
 
@@ -1357,8 +1363,6 @@ The function performs the downsampling step of the Gaussian pyramid construction
     \frac{1}{256} \begin{bmatrix} 1 & 4 & 6 & 4 & 1  \\ 4 & 16 & 24 & 16 & 4  \\ 6 & 24 & 36 & 24 & 6  \\ 4 & 16 & 24 & 16 & 4  \\ 1 & 4 & 6 & 4 & 1 \end{bmatrix}
 
 Then, it downsamples the image by rejecting even rows and columns.
-
-
 
 pyrUp
 -----
@@ -1376,12 +1380,16 @@ Upsamples an image and then blurs it.
 
     :param dst: output image. It has the specified size and the same type as  ``src`` .
 
-    :param dstsize: size of the output image; by default, it is computed as ``Size(src.cols*2, (src.rows*2)``, but in any case, the following conditions should be satisfied:
+    :param dstsize: size of the output image.
 
-        .. math::
+    :param borderType: Pixel extrapolation method (only BORDER_DEFAULT supported). See  :ocv:func:`borderInterpolate` for details.
 
-            \begin{array}{l}
-            | \texttt{dstsize.width} -src.cols*2| \leq  ( \texttt{dstsize.width}   \mod  2)  \\ | \texttt{dstsize.height} -src.rows*2| \leq  ( \texttt{dstsize.height}   \mod  2) \end{array}
+By default, size of the output image is computed as ``Size(src.cols*2, (src.rows*2)``, but in any case, the following conditions should be satisfied:
+
+.. math::
+
+    \begin{array}{l}
+    | \texttt{dstsize.width} -src.cols*2| \leq  ( \texttt{dstsize.width}   \mod  2)  \\ | \texttt{dstsize.height} -src.rows*2| \leq  ( \texttt{dstsize.height}   \mod  2) \end{array}
 
 The function performs the upsampling step of the Gaussian pyramid construction, though it can actually be used to construct the Laplacian pyramid. First, it upsamples the source image by injecting even zero rows and columns and then convolves the result with the same kernel as in
 :ocv:func:`pyrDown`  multiplied by 4.

--- a/modules/imgproc/src/pyramids.cpp
+++ b/modules/imgproc/src/pyramids.cpp
@@ -403,6 +403,8 @@ typedef void (*PyrFunc)(const Mat&, Mat&, int);
 
 void cv::pyrDown( InputArray _src, OutputArray _dst, const Size& _dsz, int borderType )
 {
+    CV_Assert(borderType != BORDER_CONSTANT);
+
     Mat src = _src.getMat();
     Size dsz = _dsz == Size() ? Size((src.cols + 1)/2, (src.rows + 1)/2) : _dsz;
     _dst.create( dsz, src.type() );
@@ -433,6 +435,8 @@ void cv::pyrDown( InputArray _src, OutputArray _dst, const Size& _dsz, int borde
 
 void cv::pyrUp( InputArray _src, OutputArray _dst, const Size& _dsz, int borderType )
 {
+    CV_Assert(borderType == BORDER_DEFAULT);
+
     Mat src = _src.getMat();
     Size dsz = _dsz == Size() ? Size(src.cols*2, src.rows*2) : _dsz;
     _dst.create( dsz, src.type() );
@@ -463,6 +467,8 @@ void cv::pyrUp( InputArray _src, OutputArray _dst, const Size& _dsz, int borderT
 
 void cv::buildPyramid( InputArray _src, OutputArrayOfArrays _dst, int maxlevel, int borderType )
 {
+    CV_Assert(borderType != BORDER_CONSTANT);
+
     Mat src = _src.getMat();
     _dst.create( maxlevel + 1, 1, 0 );
     _dst.getMatRef(0) = src;


### PR DESCRIPTION
Added assert to check for borderType is not BORDER_CONSTANT for pyrDown and borderType is only  BORDER_DEFAULT for pyrUp, since another modes doesn't make sense for these functions and works incorrect.
