### PR TITLE
Remove a useless loop that copies an array to itself

### DIFF
--- a/modules/legacy/src/calibfilter.cpp
+++ b/modules/legacy/src/calibfilter.cpp
@@ -333,12 +333,6 @@ void CvCalibFilter::Stop( bool calibrate )
                                    points[0],points[1],
                                    buffer,
                                    &stereo);
-
-                for( i = 0; i < 9; i++ )
-                {
-                    stereo.fundMatr[i] = stereo.fundMatr[i];
-                }
-
             }
 
         }


### PR DESCRIPTION
[CppCat](http://www.cppcat.com/) uses this as an example. :smiley:
