### PR TITLE
Bug 3172 batch distance

### DIFF
--- a/modules/core/src/stat.cpp
+++ b/modules/core/src/stat.cpp
@@ -2463,7 +2463,7 @@ struct BatchDistInvoker : public ParallelLoopBody
 }
 
 void cv::batchDistance( InputArray _src1, InputArray _src2,
-                        OutputArray _dist, int dtype, OutputArray _nidx,
+                        InputOutputArray _dist, int dtype, OutputArray _nidx,
                         int normType, int K, InputArray _mask,
                         int update, bool crosscheck )
 {


### PR DESCRIPTION
fixed two issues for Bug #3172:
- Changed signature of cv::batchDistance to indicate that it permits repeated calls to update a preinitialized distance array. (cv::batchDistance is already used that way by DescriptorMatcher::knnMatch.)
- Fixed cv::batchDistance to not shrink (and thereby discard) a preinitialized output array if a target image has very few keypoints.
