### PR TITLE
Fix several problems found by PVS-Studio

### DIFF
--- a/modules/core/test/test_math.cpp
+++ b/modules/core/test/test_math.cpp
@@ -1353,7 +1353,7 @@ void Core_DetTest::get_test_array_types_and_sizes( int test_case_idx, vector<vec
 {
     Base::get_test_array_types_and_sizes( test_case_idx, sizes, types );
 
-    sizes[INPUT][0].width = sizes[INPUT][0].height = sizes[INPUT][0].height;
+    sizes[INPUT][0].width = sizes[INPUT][0].height;
     sizes[TEMP][0] = sizes[INPUT][0];
     types[TEMP][0] = CV_64FC1;
 }

--- a/modules/imgproc/src/contours.cpp
+++ b/modules/imgproc/src/contours.cpp
@@ -1009,7 +1009,7 @@ cvFindNextContour( CvContourScanner scanner )
     if( mode == CV_RETR_FLOODFILL )
     {
         prev = ((int*)img)[x - 1];
-        new_mask = INT_MIN >> 1;
+        new_mask = INT_MIN / 2;
     }
 
     for( ; y < height; y++, img += step )

--- a/modules/imgproc/test/test_imgwarp_strict.cpp
+++ b/modules/imgproc/test/test_imgwarp_strict.cpp
@@ -557,7 +557,6 @@ void CV_Resize_Test::resize_1d(const Mat& _src, Mat& _dst, int dy, const dim& _d
                 xyD[r] = 0;
                 for (int k = 0; k < ksize; ++k)
                     xyD[r] += w[k] * xyS[k * cn + r];
-                xyD[r] = xyD[r];
             }
         }
     }


### PR DESCRIPTION
This fixes all problems from the article [Checking OpenCV with PVS-Studio](http://www.viva64.com/en/b/0191/) that are not already fixed and are not in 3rdparty or the legacy module.

The problems fixed are two instances of useless code and one instance of unspecified behavior (right-shifting a negative number).
