### PR TITLE
T-API: optimized cv::meanStdDev

### DIFF
--- a/modules/core/src/ocl.cpp
+++ b/modules/core/src/ocl.cpp
@@ -4419,22 +4419,22 @@ int predictOptimalVectorWidth(InputArray src1, InputArray src2, InputArray src3,
                               InputArray src4, InputArray src5, InputArray src6,
                               InputArray src7, InputArray src8, InputArray src9)
 {
-    int type = src1.type(), depth = CV_MAT_DEPTH(type), cn = CV_MAT_CN(type), esz = CV_ELEM_SIZE(depth);
+    int type = src1.type(), depth = CV_MAT_DEPTH(type), cn = CV_MAT_CN(type), esz1 = CV_ELEM_SIZE1(depth);
     Size ssize = src1.size();
     const ocl::Device & d = ocl::Device::getDefault();
 
     int vectorWidths[] = { d.preferredVectorWidthChar(), d.preferredVectorWidthChar(),
         d.preferredVectorWidthShort(), d.preferredVectorWidthShort(),
         d.preferredVectorWidthInt(), d.preferredVectorWidthFloat(),
-        d.preferredVectorWidthDouble(), -1 }, width = vectorWidths[depth];
+        d.preferredVectorWidthDouble(), -1 }, kercn = vectorWidths[depth];
     if (d.isIntel())
     {
         // it's heuristic
         int vectorWidthsIntel[] = { 16, 16, 8, 8, 1, 1, 1, -1 };
-        width = vectorWidthsIntel[depth];
+        kercn = vectorWidthsIntel[depth];
     }
 
-    if (ssize.width * cn < width || width <= 0)
+    if (ssize.width * cn < kercn || kercn <= 0)
         return 1;
 
     std::vector<size_t> offsets, steps, cols;
@@ -4449,7 +4449,7 @@ int predictOptimalVectorWidth(InputArray src1, InputArray src2, InputArray src3,
     PROCESS_SRC(src9);
 
     size_t size = offsets.size();
-    int wsz = width * esz;
+    int wsz = kercn * esz1;
     std::vector<int> dividers(size, wsz);
 
     for (size_t i = 0; i < size; ++i)
@@ -4460,14 +4460,14 @@ int predictOptimalVectorWidth(InputArray src1, InputArray src2, InputArray src3,
     for (size_t i = 0; i < size; ++i)
         if (dividers[i] != wsz)
         {
-            width = 1;
+            kercn = 1;
             break;
         }
 
     // another strategy
 //    width = *std::min_element(dividers.begin(), dividers.end());
 
-    return width;
+    return kercn;
 }
 
 #undef PROCESS_SRC

--- a/modules/core/src/opencl/meanstddev.cl
+++ b/modules/core/src/opencl/meanstddev.cl
@@ -1,0 +1,129 @@
+// This file is part of OpenCV project.
+// It is subject to the license terms in the LICENSE file found in the top-level directory
+// of this distribution and at http://opencv.org/license.html.
+
+// Copyright (C) 2014, Itseez, Inc., all rights reserved.
+// Third party copyrights are property of their respective owners.
+
+#ifdef DOUBLE_SUPPORT
+#ifdef cl_amd_fp64
+#pragma OPENCL EXTENSION cl_amd_fp64:enable
+#elif defined (cl_khr_fp64)
+#pragma OPENCL EXTENSION cl_khr_fp64:enable
+#endif
+#endif
+
+#define noconvert
+
+#if cn != 3
+#define loadpix(addr) *(__global const srcT *)(addr)
+#define storepix(val, addr)  *(__global dstT *)(addr) = val
+#define storesqpix(val, addr)  *(__global sqdstT *)(addr) = val
+#define srcTSIZE (int)sizeof(srcT)
+#define dstTSIZE (int)sizeof(dstT)
+#define sqdstTSIZE (int)sizeof(sqdstT)
+#else
+#define loadpix(addr) vload3(0, (__global const srcT1 *)(addr))
+#define storepix(val, addr) vstore3(val, 0, (__global dstT1 *)(addr))
+#define storesqpix(val, addr) vstore3(val, 0, (__global sqdstT1 *)(addr))
+#define srcTSIZE ((int)sizeof(srcT1)*3)
+#define dstTSIZE ((int)sizeof(dstT1)*3)
+#define sqdstTSIZE ((int)sizeof(sqdstT1)*3)
+#endif
+
+__kernel void meanStdDev(__global const uchar * srcptr, int src_step, int src_offset, int cols,
+                         int total, int groups, __global uchar * dstptr
+ #ifdef HAVE_MASK
+                         , __global const uchar * mask, int mask_step, int mask_offset
+ #endif
+                        )
+{
+    int lid = get_local_id(0);
+    int gid = get_group_id(0);
+    int id = get_global_id(0);
+
+    __local dstT localMemSum[WGS2_ALIGNED];
+    __local sqdstT localMemSqSum[WGS2_ALIGNED];
+#ifdef HAVE_MASK
+    __local int localMemNonZero[WGS2_ALIGNED];
+#endif
+
+    dstT accSum = (dstT)(0);
+    sqdstT accSqSum = (sqdstT)(0);
+#ifdef HAVE_MASK
+    int accNonZero = 0;
+    mask += mask_offset;
+#endif
+    srcptr += src_offset;
+
+    for (int grain = groups * WGS; id < total; id += grain)
+    {
+#ifdef HAVE_MASK
+#ifdef HAVE_SRC_CONT
+        int mask_index = id;
+#else
+        int mask_index = mad24(id / cols, mask_step, id % cols);
+#endif
+        if (mask[mask_index])
+#endif
+        {
+#ifdef HAVE_SRC_CONT
+            int src_index = mul24(id, srcTSIZE);
+#else
+            int src_index = mad24(id / cols, src_step, mul24(id % cols, srcTSIZE));
+#endif
+
+            srcT value = loadpix(srcptr + src_index);
+            accSum += convertToDT(value);
+            sqdstT dvalue = convertToSDT(value);
+            accSqSum = fma(dvalue, dvalue, accSqSum);
+
+#ifdef HAVE_MASK
+            ++accNonZero;
+#endif
+        }
+    }
+
+    if (lid < WGS2_ALIGNED)
+    {
+        localMemSum[lid] = accSum;
+        localMemSqSum[lid] = accSqSum;
+#ifdef HAVE_MASK
+        localMemNonZero[lid] = accNonZero;
+#endif
+    }
+    barrier(CLK_LOCAL_MEM_FENCE);
+
+    if (lid >= WGS2_ALIGNED && total >= WGS2_ALIGNED)
+    {
+        localMemSum[lid - WGS2_ALIGNED] += accSum;
+        localMemSqSum[lid - WGS2_ALIGNED] += accSqSum;
+#ifdef HAVE_MASK
+        localMemNonZero[lid - WGS2_ALIGNED] += accNonZero;
+#endif
+    }
+    barrier(CLK_LOCAL_MEM_FENCE);
+
+    for (int lsize = WGS2_ALIGNED >> 1; lsize > 0; lsize >>= 1)
+    {
+        if (lid < lsize)
+        {
+            int lid2 = lsize + lid;
+            localMemSum[lid] += localMemSum[lid2];
+            localMemSqSum[lid] += localMemSqSum[lid2];
+#ifdef HAVE_MASK
+            localMemNonZero[lid] += localMemNonZero[lid2];
+#endif
+        }
+        barrier(CLK_LOCAL_MEM_FENCE);
+    }
+
+    if (lid == 0)
+    {
+        storepix(localMemSum[0], dstptr + dstTSIZE * gid);
+        storesqpix(localMemSqSum[0], dstptr + mad24(dstTSIZE, groups, sqdstTSIZE * gid));
+#ifdef HAVE_MASK
+        *(__global int *)(dstptr + mad24(dstTSIZE + sqdstTSIZE, groups, (int)sizeof(int) * gid)) = localMemNonZero[0];
+#endif
+    }
+}


### PR DESCRIPTION
check_regression=_OCL_MeanStdDev*
test_modules=core

Without mask this function performs 2 kernel invocation, with mask - 3. Merged these kernels into another one and simplified index calculation in case of continuous matrices.

http://ocl.itseez.com/intel/export/perf/pr/2781/report/
