### PR TITLE
Fixed MATLAB Bridge for DenseOpticalFlow

### DIFF
--- a/modules/matlab/include/opencv2/matlab/bridge.hpp
+++ b/modules/matlab/include/opencv2/matlab/bridge.hpp
@@ -50,7 +50,7 @@
 #include <opencv2/imgproc.hpp>
 #include <opencv2/calib3d.hpp>
 #include <opencv2/photo.hpp>
-#include <opencv2/video/tracking.hpp>
+#include <opencv2/video.hpp>
 
 namespace cv {
 namespace bridge {


### PR DESCRIPTION
The MATLAB module was not compiling in R2014a on my machine. After adding these lines in the same style as the other Ptr_\* bridge types, the entire MATLAB module finished compiling.
