### PR TITLE
OCL: matchTemplate: optimization

### DIFF
--- a/modules/imgproc/test/ocl/test_match_template.cpp
+++ b/modules/imgproc/test/ocl/test_match_template.cpp
@@ -71,7 +71,7 @@ PARAM_TEST_CASE(MatchTemplate, MatDepth, Channels, MatchTemplType, bool)
         type = CV_MAKE_TYPE(GET_PARAM(0), GET_PARAM(1));
         depth = GET_PARAM(0);
         method = GET_PARAM(2);
-        use_roi = false;//GET_PARAM(3);
+        use_roi = GET_PARAM(3);
     }
 
     virtual void generateTestData()
@@ -116,7 +116,7 @@ OCL_TEST_P(MatchTemplate, Mat)
     }
 }
 
-OCL_INSTANTIATE_TEST_CASE_P(ImageProc, MatchTemplate,  Combine(
+OCL_INSTANTIATE_TEST_CASE_P(ImageProc, MatchTemplate, Combine(
                                 Values(CV_8U, CV_32F),
                                 Values(1, 2, 3, 4),
                                 MatchTemplType::all(),


### PR DESCRIPTION
Merge after: https://github.com/Itseez/opencv/pull/2849

**Description:**
- changed  kernels for `CCOEFF` and `CCOEFF_NORMED`
- for `CCORR` and `SQDIFF` added implementation using `dft`, called for template size >= 18 
- for `CCORR` cn==1 used vector data types (`int4` and `float4` instead of `int` and `float`)
- used `float` instead of `int` for `CV_8U`

**Performance report:**
http://ocl.itseez.com/intel/export/perf/pr/2786/report/

check_regression=_OCL_MatchTemplate*
test_modules=imgproc
build_examples=OFF
