### PR TITLE
corrected the size of Mat 'y'

### DIFF
--- a/modules/optim/src/simplex.cpp
+++ b/modules/optim/src/simplex.cpp
@@ -123,16 +123,16 @@ namespace cv{namespace optim{
         double res;
         int i,ihi,ilo,inhi,j,mpts=ndim+1;
         double error, range,ysave,ytry;
-        Mat_<double> coord_sum(1,ndim,0.0),buf(1,ndim,0.0),y(1,ndim,0.0);
+        Mat_<double> coord_sum(1,ndim,0.0),buf(1,ndim,0.0),y(1,mpts,0.0);
 
         nfunk = 0;
 
-        for(i=0;i<ndim+1;++i)
+        for(i=0;i<mpts;++i)
         {
             y(i) = f->calc(p[i]);
         }
 
-        nfunk = ndim+1;
+        nfunk = mpts;
 
         reduce(p,coord_sum,0,CV_REDUCE_SUM);
 


### PR DESCRIPTION
http://code.opencv.org/issues/3703

'p' represents 'n+1' points (of dim 'n')  and thus has dimensions (ndim+1) x (ndim). In downhill simplex, we evaluate the function 'f' at these (n+1) points. Here we store these values in 'y', so 'y' must be of dimension 1 x (ndim + 1).

mpts = ndim + 1;

Also, to make things look consistent, I have replace some of the (ndim+1) expressions by mpts.
