### PR TITLE
run.py: added --android_env parameter

### DIFF
--- a/modules/ts/misc/run.py
+++ b/modules/ts/misc/run.py
@@ -742,9 +742,10 @@ class TestSuite(object):
                     self.setUp()
                 env = self.options.android_env.copy()
                 env['OPENCV_TEST_DATA_PATH'] = self.options.test_data_path
-                for k, v in os.environ.items():
-                    if k.startswith('OPENCV') and not k in env:
-                        env[k] = v
+                if self.options.android_propagate_opencv_env:
+                    for k, v in os.environ.items():
+                        if k.startswith('OPENCV') and not k in env:
+                            env[k] = v
                 print >> _stderr, "Android environment variables: \n", '\n'.join(['    %s=%s' % (k, v) for k, v in env.items()])
                 commandPrefix = ''.join(['export %s=%s && ' % (k, v) for k, v in env.items()])
                 Popen(self.adb + ["shell", commandPrefix + "cd " + andoidcwd + "&& ./" + command], stdout=_stdout, stderr=_stderr).wait()
@@ -860,6 +861,7 @@ if __name__ == "__main__":
     parser.add_option("-l", "--longname", dest="useLongNames", action="store_true", help="generate log files with long names", default=False)
     parser.add_option("", "--android_test_data_path", dest="test_data_path", help="OPENCV_TEST_DATA_PATH for Android run", metavar="PATH", default="/sdcard/opencv_testdata/")
     parser.add_option("", "--android_env", dest="android_env_array", help="Environment variable for Android run (NAME=VALUE)", action='append')
+    parser.add_option("", "--android_propagate_opencv_env", dest="android_propagate_opencv_env", help="Propagate OPENCV* environment variables for Android run", action="store_true", default=False)
     parser.add_option("", "--configuration", dest="configuration", help="force Debug or Release configuration", metavar="CFG", default="")
     parser.add_option("", "--serial", dest="adb_serial", help="Android: directs command to the USB device or emulator with the given serial number", metavar="serial number", default="")
     parser.add_option("", "--package", dest="junit_package", help="Android: run jUnit tests for specified package", metavar="package", default="")


### PR DESCRIPTION
This request allows:
1) adding custom environment variables for Android tests run via `--android_env VARIABLE=VALUE --android_env VARIABLE2=VALUE2` syntax
2) propagating current `OPENCV*` environment variables (for example, OpenCL related, like `OPENCV_OPENCL_DEVICE`) with `--android_propagate_opencv_env` flag
