### PR TITLE
KAZE: disable tests (too many crashes)

### DIFF
--- a/modules/features2d/test/test_keypoints.cpp
+++ b/modules/features2d/test/test_keypoints.cpp
@@ -167,13 +167,15 @@ TEST(Features2d_Detector_Keypoints_Dense, validation)
     test.safe_run();
 }
 
-TEST(Features2d_Detector_Keypoints_KAZE, validation)
+// FIXIT #2807 Crash on Windows 7 x64 MSVS 2012, Linux Fedora 19 x64 with GCC 4.8.2, Linux Ubuntu 14.04 LTS x64 with GCC 4.8.2
+TEST(Features2d_Detector_Keypoints_KAZE, DISABLED_validation)
 {
     CV_FeatureDetectorKeypointsTest test(Algorithm::create<FeatureDetector>("Feature2D.KAZE"));
     test.safe_run();
 }
 
-TEST(Features2d_Detector_Keypoints_AKAZE, validation)
+// FIXIT #2807 Crash on Windows 7 x64 MSVS 2012, Linux Fedora 19 x64 with GCC 4.8.2, Linux Ubuntu 14.04 LTS x64 with GCC 4.8.2
+TEST(Features2d_Detector_Keypoints_AKAZE, DISABLED_validation)
 {
     CV_FeatureDetectorKeypointsTest test_kaze(cv::Ptr<FeatureDetector>(new cv::AKAZE(cv::AKAZE::DESCRIPTOR_KAZE)));
     test_kaze.safe_run();

--- a/modules/features2d/test/test_rotation_and_scale_invariance.cpp
+++ b/modules/features2d/test/test_rotation_and_scale_invariance.cpp
@@ -652,7 +652,8 @@ TEST(Features2d_ScaleInvariance_Detector_BRISK, regression)
     test.safe_run();
 }
 
-TEST(Features2d_ScaleInvariance_Detector_KAZE, regression)
+// FIXIT #2807 Crash on Windows 7 x64 MSVS 2012, Linux Fedora 19 x64 with GCC 4.8.2, Linux Ubuntu 14.04 LTS x64 with GCC 4.8.2
+TEST(Features2d_ScaleInvariance_Detector_KAZE, DISABLED_regression)
 {
     DetectorScaleInvarianceTest test(Algorithm::create<FeatureDetector>("Feature2D.KAZE"),
         0.08f,
@@ -660,13 +661,15 @@ TEST(Features2d_ScaleInvariance_Detector_KAZE, regression)
     test.safe_run();
 }
 
-TEST(Features2d_ScaleInvariance_Detector_AKAZE, regression)
+// FIXIT #2807 Crash on Windows 7 x64 MSVS 2012, Linux Fedora 19 x64 with GCC 4.8.2, Linux Ubuntu 14.04 LTS x64 with GCC 4.8.2
+TEST(Features2d_ScaleInvariance_Detector_AKAZE, DISABLED_regression)
 {
     DetectorScaleInvarianceTest test(Algorithm::create<FeatureDetector>("Feature2D.AKAZE"),
         0.08f,
         0.49f);
     test.safe_run();
 }
+
 //TEST(Features2d_ScaleInvariance_Detector_ORB, regression)
 //{
 //    DetectorScaleInvarianceTest test(Algorithm::create<FeatureDetector>("Feature2D.ORB"),


### PR DESCRIPTION
Investigation and fix are required.

Related to PR #2673
