### PR TITLE
T-API: added performance test for UMat::copyTo with mask and dst uninitialized

### DIFF
--- a/modules/core/perf/opencl/perf_matop.cpp
+++ b/modules/core/perf/opencl/perf_matop.cpp
@@ -122,6 +122,29 @@ OCL_PERF_TEST_P(CopyToFixture, CopyToWithMask,
     SANITY_CHECK(dst);
 }
 
+OCL_PERF_TEST_P(CopyToFixture, CopyToWithMaskUninit,
+                ::testing::Combine(OCL_PERF_ENUM(OCL_SIZE_1, OCL_SIZE_2, OCL_SIZE_3), OCL_TEST_TYPES))
+{
+    const Size_MatType_t params = GetParam();
+    const Size srcSize = get<0>(params);
+    const int type = get<1>(params);
+
+    checkDeviceMaxMemoryAllocSize(srcSize, type);
+
+    UMat src(srcSize, type), dst, mask(srcSize, CV_8UC1);
+    declare.in(src, mask, WARMUP_RNG);
+
+    for ( ;  next(); )
+    {
+        dst.release();
+        startTimer();
+        src.copyTo(dst, mask);
+        stopTimer();
+    }
+
+    SANITY_CHECK(dst);
+}
+
 } } // namespace cvtest::ocl
 
 #endif // HAVE_OPENCL


### PR DESCRIPTION
merge with opencv extra https://github.com/Itseez/opencv_extra/pull/189

check_regression=_OCL_Uni*
test_filter=_OCL_Uni*
test_modules=core
build_examples=OFF
