### PR TITLE
OCL: A more efficient workaround for erode

### DIFF
--- a/modules/imgproc/src/opencl/morph.cl
+++ b/modules/imgproc/src/opencl/morph.cl
@@ -77,9 +77,14 @@
 #endif
 
 #ifdef ERODE
-#ifdef INTEL_DEVICE
+#if defined(INTEL_DEVICE) && (DEPTH_0)
 // workaround for bug in Intel HD graphics drivers (10.18.10.3496 or older)
-#define MORPH_OP(A,B) ((A) < (B) ? (A) : (B))
+#define __CAT(x, y) x##y
+#define CAT(x, y) __CAT(x, y)
+#define WA_CONVERT_1 CAT(convert_uint, cn)
+#define WA_CONVERT_2 CAT(convert_, T)
+#define convert_uint1 convert_uint
+#define MORPH_OP(A,B) WA_CONVERT_2(min(WA_CONVERT_1(A),WA_CONVERT_1(B)))
 #else
 #define MORPH_OP(A,B) min((A),(B))
 #endif


### PR DESCRIPTION
Uses a faster workaround path than the ternary operator.  Instead, it converts the data to int and continues to do min.  Also, only applied for the datatype that exhibits the original bug.

```
build_examples=off
check_regression=*Erode*:*Dilate*:*MorphologyEx*
test_modules=imgproc
```
