### PR TITLE
OCL: Bug fixes for filter2D and associated tests.

### DIFF
--- a/modules/imgproc/perf/opencl/perf_filters.cpp
+++ b/modules/imgproc/perf/opencl/perf_filters.cpp
@@ -272,7 +272,8 @@ OCL_PERF_TEST_P(Filter2DFixture, Filter2D,
 
     checkDeviceMaxMemoryAllocSize(srcSize, type);
 
-    UMat src(srcSize, type), dst(srcSize, type), kernel(ksize, ksize, CV_32SC1);
+    UMat src(srcSize, type), dst(srcSize, type);
+    Mat kernel(ksize, ksize, CV_32SC1);
     declare.in(src, WARMUP_RNG).in(kernel).out(dst);
     randu(kernel, -3.0, 3.0);
 

--- a/modules/imgproc/test/ocl/test_filter2d.cpp
+++ b/modules/imgproc/test/ocl/test_filter2d.cpp
@@ -57,7 +57,7 @@ PARAM_TEST_CASE(Filter2D, MatDepth, Channels, int, int, BorderType, bool, bool)
     static const int kernelMaxSize = 10;
 
     int type;
-    Size dsize;
+    Size size;
     Point anchor;
     int borderType;
     int widthMultiple;
@@ -81,17 +81,16 @@ PARAM_TEST_CASE(Filter2D, MatDepth, Channels, int, int, BorderType, bool, bool)
 
     void random_roi()
     {
-        dsize = randomSize(1, MAX_VALUE);
+        size = randomSize(1, MAX_VALUE);
         // Make sure the width is a multiple of the requested value, and no more.
-        dsize.width &= ~((widthMultiple * 2) - 1);
-        dsize.width += widthMultiple;
+        size.width &= ~((widthMultiple * 2) - 1);
+        size.width += widthMultiple;
 
-        Size roiSize = randomSize(kernel.size[0], MAX_VALUE, kernel.size[1], MAX_VALUE);
         Border srcBorder = randomBorder(0, useRoi ? MAX_VALUE : 0);
-        randomSubMat(src, src_roi, roiSize, srcBorder, type, -MAX_VALUE, MAX_VALUE);
+        randomSubMat(src, src_roi, size, srcBorder, type, -MAX_VALUE, MAX_VALUE);
 
         Border dstBorder = randomBorder(0, useRoi ? MAX_VALUE : 0);
-        randomSubMat(dst, dst_roi, dsize, dstBorder, type, -MAX_VALUE, MAX_VALUE);
+        randomSubMat(dst, dst_roi, size, dstBorder, type, -MAX_VALUE, MAX_VALUE);
 
         anchor.x = randomInt(-1, kernel.size[0]);
         anchor.y = randomInt(-1, kernel.size[1]);


### PR DESCRIPTION
Four small fixes for filter2D:
- Perf test uses Mat instead of UMat for filters (more efficient since they get turned into pre-processor strings on the CPU.)
- Fixed bug in global size calculation.
- Fixed bug in CPU path for small images.
- Changed functional test to ensure that the input image and output image are the same size (as required by the documentation).
- edit: fixed spelling

```
build_examples=off
check_regression=*Filter2D*:*Laplacian*
test_modules=imgproc
```
