### PR TITLE
fixed calculation method of "cv::TickMeter".

### DIFF
--- a/modules/contrib/src/spinimages.cpp
+++ b/modules/contrib/src/spinimages.cpp
@@ -1190,9 +1190,9 @@ private:
 
 cv::TickMeter::TickMeter() { reset(); }
 int64 cv::TickMeter::getTimeTicks() const { return sumTime; }
-double cv::TickMeter::getTimeMicro() const { return (double)getTimeTicks()/getTickFrequency(); }
-double cv::TickMeter::getTimeMilli() const { return getTimeMicro()*1e-3; }
-double cv::TickMeter::getTimeSec()   const { return getTimeMilli()*1e-3; }
+double cv::TickMeter::getTimeSec()   const { return (double)getTimeTicks()/getTickFrequency(); }
+double cv::TickMeter::getTimeMilli() const { return getTimeSec()*1e3; }
+double cv::TickMeter::getTimeMicro() const { return getTimeMilli()*1e3; }
 int64 cv::TickMeter::getCounter() const { return counter; }
 void  cv::TickMeter::reset() {startTime = 0; sumTime = 0; counter = 0; }
 


### PR DESCRIPTION
I think that the calculation method of the following function is incorrect.
- cv::TickMeter::getTimeMicro()
- cv::TickMeter::getTimeMilli()
- cv::TickMeter::getTimeSec()

> (double)getTimeTicks()/getTickFrequency();

Result of this calculation is "TimeSec". 
But, current implementation is regarded as the "TimeMicroSec".
