### PR TITLE
Fix resource leak with iOS camera due to failure to remove AVCaptureSession input/outputs on stop (Bug #3389)

### DIFF
--- a/modules/highgui/src/cap_ios_abstract_camera.mm
+++ b/modules/highgui/src/cap_ios_abstract_camera.mm
@@ -193,6 +193,14 @@
     // Release any retained subviews of the main view.
     // e.g. self.myOutlet = nil;
 
+    for (AVCaptureInput *input in self.captureSession.inputs) {
+        [self.captureSession removeInput:input];
+    }
+
+    for (AVCaptureOutput *output in self.captureSession.outputs) {
+        [self.captureSession removeOutput:output];
+    }
+
     [self.captureSession stopRunning];
     self.captureSession = nil;
     self.captureVideoPreviewLayer = nil;


### PR DESCRIPTION
Hi. This is reported in Bug #3389 as well as on the user's group: http://answers.opencv.org/question/26400/memory-leak-in-camera-start-camera-stop-methods/

Memory use after repeated start/stop calls looks stable after this commit.
