### PR TITLE
perspectiveTransform simplify assert() for better debuggin

### DIFF
--- a/modules/core/src/matmul.cpp
+++ b/modules/core/src/matmul.cpp
@@ -2020,7 +2020,8 @@ void cv::perspectiveTransform( InputArray _src, OutputArray _dst, InputArray _mt
 {
     Mat src = _src.getMat(), m = _mtx.getMat();
     int depth = src.depth(), scn = src.channels(), dcn = m.rows-1;
-    CV_Assert( scn + 1 == m.cols && (depth == CV_32F || depth == CV_64F));
+    CV_Assert( scn + 1 == m.cols );
+    CV_Assert( depth == CV_32F || depth == CV_64F );
 
     _dst.create( src.size(), CV_MAKETYPE(depth, dcn) );
     Mat dst = _dst.getMat();


### PR DESCRIPTION
When using perspectiveTransform in rather complicated settings, it would be easier for developers to have two separate assertions for each part of the boolean expression in order to pinpoint problems more efficiently. In my case I am struggling in Python2.7 with finding out whether scn+1 == m.cols or the depth == CV_32F || depth == CV_64F is making a problem, which is kind of hard.
