### PR TITLE
fix typo in linux tutorial

### DIFF
--- a/doc/tutorials/introduction/linux_install/linux_install.rst
+++ b/doc/tutorials/introduction/linux_install/linux_install.rst
@@ -23,7 +23,7 @@ The packages can be installed using a terminal and the following commands or by 
     .. code-block:: bash
 
        [compiler] sudo apt-get install build-essential
-       [required] sudo apt-get install cmake git libgtk2-dev pkg-config libavcodec-dev libavformat-dev libswscale-dev
+       [required] sudo apt-get install cmake git libgtk2.0-dev pkg-config libavcodec-dev libavformat-dev libswscale-dev
        [optional] sudo apt-get install python-dev python-numpy libtbb2 libtbb-dev libjpeg-dev libpng-dev libtiff-dev libjasper-dev libdc1394-22-dev
 
 Getting OpenCV Source Code


### PR DESCRIPTION
It seems my previous addition to this contained a typo that doesn't work on Ubuntu 14.04
