### PR TITLE
T-API: cv::flip optimization for CV_8UC1

### DIFF
--- a/modules/core/src/opencl/flip.cl
+++ b/modules/core/src/opencl/flip.cl
@@ -39,7 +39,7 @@
 //
 //M*/
 
-#if cn != 3
+#if kercn != 3
 #define loadpix(addr) *(__global const T *)(addr)
 #define storepix(val, addr)  *(__global T *)(addr) = val
 #define TSIZE (int)sizeof(T)
@@ -54,7 +54,7 @@ __kernel void arithm_flip_rows(__global const uchar * srcptr, int src_step, int 
                                int rows, int cols, int thread_rows, int thread_cols)
 {
     int x = get_global_id(0);
-    int y0 = get_global_id(1)*PIX_PER_WI_Y;
+    int y0 = get_global_id(1) * PIX_PER_WI_Y;
 
     if (x < cols)
     {
@@ -100,6 +100,21 @@ __kernel void arithm_flip_rows_cols(__global const uchar * srcptr, int src_step,
             T src0 = loadpix(srcptr + src_index0);
             T src1 = loadpix(srcptr + src_index1);
 
+#if kercn == 2
+#if cn == 1
+            src0 = src0.s10;
+            src1 = src1.s10;
+#endif
+#elif kercn == 4
+#if cn == 1
+            src0 = src0.s3210;
+            src1 = src1.s3210;
+#elif cn == 2
+            src0 = src0.s2301;
+            src1 = src1.s2301;
+#endif
+#endif
+
             storepix(src1, dstptr + dst_index0);
             storepix(src0, dstptr + dst_index1);
 
@@ -130,6 +145,21 @@ __kernel void arithm_flip_cols(__global const uchar * srcptr, int src_step, int 
         {
             T src0 = loadpix(srcptr + src_index0);
             T src1 = loadpix(srcptr + src_index1);
+
+#if kercn == 2
+#if cn == 1
+            src0 = src0.s10;
+            src1 = src1.s10;
+#endif
+#elif kercn == 4
+#if cn == 1
+            src0 = src0.s3210;
+            src1 = src1.s3210;
+#elif cn == 2
+            src0 = src0.s2301;
+            src1 = src1.s2301;
+#endif
+#endif
 
             storepix(src1, dstptr + dst_index0);
             storepix(src0, dstptr + dst_index1);


### PR DESCRIPTION
check_regression=_OCL_Flip*
test_modules=core
test_filter=_OCL_Flip*
build_examples=OFF

Used vector data types (`uchar4` instead of `uchar`)

New approach with compare to the previous one:

```
Flip::OCL_FlipFixture::(640x480, 8UC1, FLIP_BOTH)    0.230 ms  0.194 ms     1.19
Flip::OCL_FlipFixture::(640x480, 8UC1, FLIP_COLS)    0.212 ms  0.149 ms     1.42
Flip::OCL_FlipFixture::(640x480, 8UC1, FLIP_ROWS)    0.210 ms  0.158 ms     1.33
Flip::OCL_FlipFixture::(1280x720, 8UC1, FLIP_BOTH)   0.299 ms  0.221 ms     1.35
Flip::OCL_FlipFixture::(1280x720, 8UC1, FLIP_COLS)   0.289 ms  0.195 ms     1.48
Flip::OCL_FlipFixture::(1280x720, 8UC1, FLIP_ROWS)   0.287 ms  0.213 ms     1.35
Flip::OCL_FlipFixture::(1920x1080, 8UC1, FLIP_BOTH)  0.330 ms  0.202 ms     1.63
Flip::OCL_FlipFixture::(1920x1080, 8UC1, FLIP_COLS)  0.319 ms  0.205 ms     1.55
Flip::OCL_FlipFixture::(1920x1080, 8UC1, FLIP_ROWS)  0.323 ms  0.228 ms     1.42
Flip::OCL_FlipFixture::(3840x2160, 8UC1, FLIP_BOTH)  1.553 ms  0.916 ms     1.70
Flip::OCL_FlipFixture::(3840x2160, 8UC1, FLIP_COLS)  1.613 ms  0.870 ms     1.85
Flip::OCL_FlipFixture::(3840x2160, 8UC1, FLIP_ROWS)  1.606 ms  0.852 ms     1.89
```
