### PR TITLE
T-API: cv::norm with 2 args

### DIFF
--- a/modules/core/include/opencv2/core/opencl/ocl_defs.hpp
+++ b/modules/core/include/opencv2/core/opencl/ocl_defs.hpp
@@ -5,7 +5,7 @@
 // Copyright (C) 2014, Advanced Micro Devices, Inc., all rights reserved.
 // Third party copyrights are property of their respective owners.
 
-#define CV_OPENCL_RUN_ASSERT
+//#define CV_OPENCL_RUN_ASSERT
 
 #ifdef HAVE_OPENCL
 

--- a/modules/core/src/opencl/reduce.cl
+++ b/modules/core/src/opencl/reduce.cl
@@ -543,32 +543,9 @@
 #define CALC_RESULT \
     storepix(localmem[0], dstptr + dstTSIZE * gid)
 
-// norm (NORM_INF) with cn > 1 and mask
-#elif defined OP_NORM_INF_MASK
-
-#define DECLARE_LOCAL_MEM \
-    __local srcT localmem_max[WGS2_ALIGNED]
-#define DEFINE_ACCUMULATOR \
-    srcT maxval = MIN_VAL, temp
-#define REDUCE_GLOBAL \
-    MASK_INDEX; \
-    if (mask[mask_index]) \
-    { \
-        temp = loadpix(srcptr + src_index); \
-        maxval = max(maxval, (srcT)(temp >= (srcT)(0) ? temp : -temp)); \
-    }
-#define SET_LOCAL_1 \
-    localmem_max[lid] = maxval
-#define REDUCE_LOCAL_1 \
-    localmem_max[lid - WGS2_ALIGNED] = max(maxval, localmem_max[lid - WGS2_ALIGNED])
-#define REDUCE_LOCAL_2 \
-    localmem_max[lid] = max(localmem_max[lid], localmem_max[lid2])
-#define CALC_RESULT \
-    storepix(localmem_max[0], dstptr + dstTSIZE * gid)
-
 #else
 #error "No operation"
-#endif // end of norm (NORM_INF) with cn > 1 and mask
+#endif
 
 #ifdef OP_DOT
 #undef EXTRA_PARAMS


### PR DESCRIPTION
**Changes from https://github.com/Itseez/opencv/pull/2833:**
- optimized min/max calculation
- previously, `minMaxLoc` always found all min/max/minloc/maxloc, but now only if appropriate parameter isn't set to `NULL`
- used vector data types
- merged `abs`+`minMax` into `minMax` in norm with `NORM_INF`

**New changes**:
- merged multiple kernels into one

**Performance report:**
http://ocl.itseez.com/intel/export/perf/pr/2837/report/

check_regression=_OCL_Norm_:_OCL_MinMaxLoc_
test_filter=_OCL_Norm_:_OCL_MinMax_:_OCL_Count_:_OCL_Dot_:_OCL_Sum*
test_modules=core
build_examples=OFF
