### PR TITLE
Export of "bag of words" to python (2.4)

### DIFF
--- a/modules/features2d/include/opencv2/features2d/features2d.hpp
+++ b/modules/features2d/include/opencv2/features2d/features2d.hpp
@@ -1593,7 +1593,7 @@ public:
                   vector<vector<int> >* pointIdxsOfClusters=0, Mat* descriptors=0 );
     // compute() is not constant because DescriptorMatcher::match is not constant
 
-    CV_WRAP_AS(compute) void compute2( const Mat& image, vector<KeyPoint>& keypoints, Mat& imgDescriptor )
+    CV_WRAP_AS(compute) void compute2( const Mat& image, vector<KeyPoint>& keypoints, CV_OUT Mat& imgDescriptor )
     { compute(image,keypoints,imgDescriptor); }
 
     CV_WRAP int descriptorSize() const;


### PR DESCRIPTION
feature: add scripting support for "bag of words" to python / java wrappers.

unfortunately, the java side seems to need duplications of the wrapper definitions in features_manual.hpp (_removed_)
