### PR TITLE
2.4 fix python warnings

### DIFF
--- a/modules/python/src2/gen.py
+++ b/modules/python/src2/gen.py
@@ -153,6 +153,8 @@ def gen(name, args, ty, flags):
       ctype = remap.get(a.ty, a.ty)
       if a.init:
         init = " = %s" % a.init
+      elif ctype[-1] == '*':
+        init = ' = NULL'
       else:
         init = ''
       yield "  %s %s%s;" % (ctype, a.nm, init)


### PR DESCRIPTION
Force initialization of local variables-pointers with `NULL` value.
