### PR TITLE
OCL: Refactoring integral sum kernels

### DIFF
--- a/modules/imgproc/src/opencl/integral_sum.cl
+++ b/modules/imgproc/src/opencl/integral_sum.cl
@@ -71,10 +71,10 @@
 #endif
 
 
-kernel void integral_sum_cols(__global uchar4 *src, __global uchar *sum_ptr,
+kernel void integral_sum_cols(__global const uchar4 *src, __global uchar *sum_ptr,
                               int src_offset, int rows, int cols, int src_step, int dst_step)
 {
-    sumT *sum = (sumT *)sum_ptr;
+    __global sumT *sum = (__global sumT *)sum_ptr;
     int lid = get_local_id(0);
     int gid = get_group_id(0);
     vecSumT src_t[2], sum_t[2];
@@ -173,11 +173,11 @@ kernel void integral_sum_cols(__global uchar4 *src, __global uchar *sum_ptr,
 }
 
 
-kernel void integral_sum_rows(__global uchar *srcsum_ptr, __global uchar *sum_ptr,
+kernel void integral_sum_rows(__global const uchar *srcsum_ptr, __global uchar *sum_ptr,
                               int rows, int cols, int src_step, int sum_step, int sum_offset)
 {
-    vecSumT *srcsum = (vecSumT *)srcsum_ptr;
-    sumT *sum = (sumT *)sum_ptr;
+    __global const vecSumT *srcsum = (__global const vecSumT *)srcsum_ptr;
+    __global sumT *sum = (__global sumT *)sum_ptr;
     int lid = get_local_id(0);
     int gid = get_group_id(0);
     vecSumT src_t[2], sum_t[2];

--- a/modules/imgproc/src/sumpixels.cpp
+++ b/modules/imgproc/src/sumpixels.cpp
@@ -266,7 +266,7 @@ static bool ocl_integral( InputArray _src, OutputArray _sum, int sdepth )
 
     ocl::Kernel k2("integral_sum_rows", ocl::imgproc::integral_sum_oclsrc,
                    format("-D sdepth=%d", sdepth));
-    k2.args(ocl::KernelArg::PtrReadWrite(t_sum), ocl::KernelArg::PtrWriteOnly(sum),
+    k2.args(ocl::KernelArg::PtrReadOnly(t_sum), ocl::KernelArg::PtrWriteOnly(sum),
             t_sum.rows, t_sum.cols, (int)t_sum.step, (int)sum.step, sum_offset);
 
     size_t gt2 = t_sum.cols  * 32, lt2 = 256;


### PR DESCRIPTION
Merge double functions for 32S and 32F in kernel into one.

check_regression=_Integral_
test_modules=imgproc
build_examples=OFF

http://ocl.itseez.com/intel/export/perf/pr/2871/report/
