### PR TITLE
Facilitate computing SIFT descriptors one by one.

### DIFF
--- a/modules/nonfree/include/opencv2/nonfree/features2d.hpp
+++ b/modules/nonfree/include/opencv2/nonfree/features2d.hpp
@@ -79,6 +79,13 @@ public:
                     OutputArray descriptors,
                     bool useProvidedKeypoints = false) const;
 
+    //! Compute descriptors with the image pyramid already precomputed.
+    void operator()(InputArray img, InputArray mask,
+                    std::vector<KeyPoint>& keypoints,
+                    OutputArray descriptors,
+                    bool useProvidedKeypoints,
+                    std::vector<Mat>& gpyr) const;
+
     AlgorithmInfo* info() const;
 
     void buildGaussianPyramid( const Mat& base, std::vector<Mat>& pyr, int nOctaves ) const;


### PR DESCRIPTION
Some applications might want to only process as many SIFT features as
time permits before a new video frame becomes available.  This change
enables a program to detect the keypoints, then compute descriptors one
by one without recalculating the image pyramid repeatedly.
