### PR TITLE
OCL: Fix problems in LUT ocl kernel

### DIFF
--- a/modules/core/src/opencl/lut.cl
+++ b/modules/core/src/opencl/lut.cl
@@ -52,10 +52,10 @@
             dst[2] = lut_l[idx.z];
     #elif dcn == 2
         #define LUT_OP(num)\
-            __global const uchar2 * idx = (__global const uchar2 *)(srcptr + mad24(num, src_step, src_index));\
+            short idx = *(__global const short *)(srcptr + mad24(num, src_step, src_index));\
             dst = (__global dstT *)(dstptr + mad24(num, dst_step, dst_index));\
-            dst[0] = lut_l[idx->x];\
-            dst[1] = lut_l[idx->y];
+            dst[0] = lut_l[idx & 0xff];\
+            dst[1] = lut_l[(idx >> 8) & 0xff];
     #elif dcn == 1
         #define LUT_OP(num)\
             uchar idx = (srcptr + mad24(num, src_step, src_index))[0];\


### PR DESCRIPTION
Fix compile errors of LUT ocl kernel in some case.

check_regression=_OCL_LUT\* 
test_filter=_OCL_Lut*
test_modules=core
build_examples=OFF
