### PR TITLE
T-API: optimization of cv::remap

### DIFF
--- a/modules/imgproc/src/imgwarp.cpp
+++ b/modules/imgproc/src/imgwarp.cpp
@@ -3640,10 +3640,9 @@ static bool ocl_remap(InputArray _src, OutputArray _dst, InputArray _map1, Input
     }
     int scalarcn = cn == 3 ? 4 : cn;
     int sctype = CV_MAKETYPE(depth, scalarcn);
-    buildOptions += format(" -D T=%s -D T1=%s"
-                           " -D cn=%d -D ST=%s",
+    buildOptions += format(" -D T=%s -D T1=%s -D cn=%d -D ST=%s -D depth=%d",
                            ocl::typeToStr(type), ocl::typeToStr(depth),
-                           cn, ocl::typeToStr(sctype));
+                           cn, ocl::typeToStr(sctype), depth);
 
     ocl::Kernel k(kernelName.c_str(), ocl::imgproc::remap_oclsrc, buildOptions);
 

--- a/modules/imgproc/test/ocl/test_warp.cpp
+++ b/modules/imgproc/test/ocl/test_warp.cpp
@@ -267,7 +267,7 @@ PARAM_TEST_CASE(Remap, MatDepth, Channels, std::pair<MatType, MatType>, BorderTy
         Border map1Border = randomBorder(0, useRoi ? MAX_VALUE : 0);
         randomSubMat(map1, map1_roi, dstROISize, map1Border, map1Type, -mapMaxValue, mapMaxValue);
 
-        Border map2Border = randomBorder(0, useRoi ? MAX_VALUE : 0);
+        Border map2Border = randomBorder(0, useRoi ? MAX_VALUE + 1 : 0);
         if (map2Type != noType)
         {
             int mapMinValue = -mapMaxValue;


### PR DESCRIPTION
**Description:**
- increased number of rows per work-item
- used precomputed bufferof interpolation coefficients
- used `vload2` for `INTER_LINEAR`

**Performance report:**
http://ocl.itseez.com/intel/export/perf/pr/2888/report/

check_regression=_OCL_Remap_:_OCL_Warper_
test_modules=imgproc,stitching
test_filter=_OCL_Remap*
build_examples=OFF
