### PR TITLE
changed a link to software path editor

### DIFF
--- a/doc/tutorials/introduction/windows_install/windows_install.rst
+++ b/doc/tutorials/introduction/windows_install/windows_install.rst
@@ -209,7 +209,7 @@ Building the library
          setx -m QTDIR D:/OpenCV/dep/qt/qt-everywhere-opensource-src-4.7.3
 
       .. |PathEditor| replace:: Path Editor
-      .. _PathEditor: http://www.redfernplace.com/software-projects/patheditor/
+      .. _PathEditor: http://patheditor2.codeplex.com/
 
       Also, add the built binary files path to the system path by using the  |PathEditor|_. In our case this is :file:`D:/OpenCV/dep/qt/qt-everywhere-opensource-src-4.7.3/bin`.
 


### PR DESCRIPTION
The link to the software was broken and is linked to the current software page. We cannot link to the download page since it seems to change the numbers with each new release.

http://code.opencv.org/issues/3765
