### PR TITLE
Fix for Bug#3757: All dimension values are 0 after release is called

### DIFF
--- a/modules/core/include/opencv2/core/mat.hpp
+++ b/modules/core/include/opencv2/core/mat.hpp
@@ -366,7 +366,8 @@ inline void Mat::release()
     if( refcount && CV_XADD(refcount, -1) == 1 )
         deallocate();
     data = datastart = dataend = datalimit = 0;
-    size.p[0] = 0;
+    for(int i = 0; i < dims; i++)
+        size.p[i] = 0;
     refcount = 0;
 }
 


### PR DESCRIPTION
Fix for Bug #3757. 
Made all dimensions 0 after release is called on a Mat object
