### PR TITLE
Fix GCC 4.9 warning

### DIFF
--- a/modules/imgproc/src/morph.cpp
+++ b/modules/imgproc/src/morph.cpp
@@ -1258,7 +1258,7 @@ static bool IPPMorphReplicate(int op, const Mat &src, Mat &dst, const Mat &kerne
         #undef IPP_MORPH_CASE
 
 #if defined(__GNUC__) && __GNUC__ == 4 && __GNUC_MINOR__ > 8
-        return false; /// It disables false positive warning in GCC 4.8.2
+        return false; /// It disables false positive warning in GCC 4.8 and further
 #endif
     }
 }


### PR DESCRIPTION
Change Minor GCC version comparison to disable false positive warning on 4.9 and future versions
