### PR TITLE
Fixes resizeWindow() on OS X (Bug #3200)

### DIFF
--- a/modules/highgui/src/window_cocoa.mm
+++ b/modules/highgui/src/window_cocoa.mm
@@ -151,7 +151,7 @@ CV_IMPL int cvInitSystem( int , char** )
 #define NSAppKitVersionNumber10_5 949
 #endif
     if( floor(NSAppKitVersionNumber) > NSAppKitVersionNumber10_5 )
-        [application setActivationPolicy:NSApplicationActivationPolicyRegular];
+        [application setActivationPolicy:0/*NSApplicationActivationPolicyRegular*/];
 #endif
     //[application finishLaunching];
     //atexit(icvCocoaCleanup);


### PR DESCRIPTION
This pull request fixes http://code.opencv.org/issues/3200 by only allowing the window to be resized if the window flag is not CV_WINDOW_AUTOSIZE.
