### PR TITLE
Remove a couple of useless casts in core headers

### DIFF
--- a/modules/core/include/opencv2/core/core_c.h
+++ b/modules/core/include/opencv2/core/core_c.h
@@ -1107,7 +1107,7 @@ CV_INLINE  CvSetElem* cvSetNew( CvSet* set_header )
         set_header->active_count++;
     }
     else
-        cvSetAdd( set_header, NULL, (CvSetElem**)&elem );
+        cvSetAdd( set_header, NULL, &elem );
     return elem;
 }
 

--- a/modules/core/include/opencv2/core/types_c.h
+++ b/modules/core/include/opencv2/core/types_c.h
@@ -790,7 +790,7 @@ CV_INLINE  void  cvmSet( CvMat* mat, int row, int col, double value )
     else
     {
         assert( type == CV_64FC1 );
-        ((double*)(void*)(mat->data.ptr + (size_t)mat->step*row))[col] = (double)value;
+        ((double*)(void*)(mat->data.ptr + (size_t)mat->step*row))[col] = value;
     }
 }
 


### PR DESCRIPTION
This helps users who compile their code with `-Wuseless-cast`.
