### PR TITLE
OCL: read 16 uchar values in a moment instead of 4

### DIFF
--- a/modules/imgproc/src/opencl/moments.cl
+++ b/modules/imgproc/src/opencl/moments.cl
@@ -12,7 +12,7 @@ __kernel void moments(__global const uchar* src, int src_step, int src_offset,
     int x, y = get_local_id(1);
     int x_min = x0*TILE_SIZE;
     int ypix = y0*TILE_SIZE + y;
-    __local int mom[TILE_SIZE][10];
+    __local float mom[TILE_SIZE][10];
 
     if (x_min < src_cols && y0*TILE_SIZE < src_rows)
     {
@@ -20,73 +20,121 @@ __kernel void moments(__global const uchar* src, int src_step, int src_offset,
         {
             int x_max = min(src_cols - x_min, TILE_SIZE);
             __global const uchar* ptr = src + src_offset + ypix*src_step + x_min;
-            int4 S = (int4)(0, 0, 0, 0);
+            float4 S = (float4)(0, 0, 0, 0);
             x = x_max & -4;
 
 #define SUM_ELEM(elem, ofs) \
-    (int4)(1, (ofs), (ofs)*(ofs), (ofs)*(ofs)*(ofs))*elem
-
-            //get bit value
-            int bitval0 = (int)((bool)(x_max / 32));// int bv0 = (int)bitval0;
-            int bitval1 = (int)((bool)(x_max / 28));// int bv1 = (int)bitval1;
-            int bitval2 = (int)((bool)(x_max / 24));// int bv2 = (int)bitval2;
-            int bitval3 = (int)((bool)(x_max / 20));// int bv3 = (int)bitval3;
-            int bitval4 = (int)((bool)(x_max / 16));// int bv4 = (int)bitval4;
-            int bitval5 = (int)((bool)(x_max / 12));// int bv5 = (int)bitval5;
-            int bitval6 = (int)((bool)(x_max / 8));// int bv6 = (int)bitval6;
-            int bitval7 = (int)((bool)(x_max / 4));// int bv7 = (int)bitval7;
-
-            int16 p;
-            p = convert_int16(vload16(0, ptr));
+    (float4)(1, (ofs), (ofs)*(ofs), (ofs)*(ofs)*(ofs))*elem
+            float4 p;
+            if (x_max >= 4)
+            {
+                //__global const uchar* ptr = src + src_offset + ypix*src_step + x_min;
+                p = convert_float4(vload4(0, ptr));
 #ifdef OP_MOMENTS_BINARY
-            p = min(p, 1);
+                p = min(p, 1);
 #endif
-            //ptr + 0
-            S += bitval7 * ((int4)(p.s0, 0, 0, 0) + (int4)(p.s1, p.s1, p.s1, p.s1) +
-                (int4)(p.s2, p.s2 * 2, p.s2 * 4, p.s2 * 8) + (int4)(p.s3, p.s3 * 3, p.s3 * 9, p.s3 * 27)) +//ptr + 4
-                bitval6 * ((int4)(p.s4, p.s4 * 4, p.s4 * 16, p.s4 * 64) + (int4)(p.s5, p.s5 * 5, p.s5 * 25, p.s5 * 125) +
-                (int4)(p.s6, p.s6 * 6, p.s6 * 36, p.s6 * 216) + (int4)(p.s7, p.s7 * 7, p.s7 * 49, p.s7 * 343)) +//ptr + 8
-                bitval5 * ((int4)(p.s8, p.s8 * 8, p.s8 * 64, p.s8 * 512) + (int4)(p.s9, p.s9 * 9, p.s9 * 81, p.s9 * 729) +
-                (int4)(p.sa, p.sa * 10, p.sa * 100, p.sa * 1000) + (int4)(p.sb, p.sb * 11, p.sb * 121, p.sb * 1331)) +//ptr + 12
-                bitval4 * ((int4)(p.sc, p.sc * 12, p.sc * 144, p.sc * 1728) + (int4)(p.sd, p.sd * 13, p.sd * 169, p.sd * 2197) +
-                (int4)(p.se, p.se * 14, p.se * 196, p.se * 2744) + (int4)(p.sf, p.sf * 15, p.sf * 225, p.sf * 3375));
+                S += (float4)(p.s0, 0.0, 0.0, 0.0) + (float4)(p.s1, p.s1, p.s1, p.s1) +
+                    (float4)(p.s2, p.s2 * 2.0, p.s2 * 4.0, p.s2 * 8.0) + (float4)(p.s3, p.s3 * 3.0, p.s3 * 9.0, p.s3 * 27.0);
+                //SUM_ELEM(p.s0, 0) + SUM_ELEM(p.s1, 1) + SUM_ELEM(p.s2, 2) + SUM_ELEM(p.s3, 3);
 
-            //read next half of tile
-            p = convert_int16(vload16(0, ptr + 16));
+                if (x_max >= 8)
+                {
+                    p = convert_float4(vload4(0, ptr + 4));
 #ifdef OP_MOMENTS_BINARY
-            p = min(p, 1);
+                    p = min(p, 1);
 #endif
-            //ptr + 16
-            S += bitval3 * ((int4)(p.s0, p.s0 * 16, p.s0 * 256, p.s0 * 4096) + (int4)(p.s1, p.s1 * 17, p.s1 * 289, p.s1 * 4913) +
-                (int4)(p.s2, p.s2 * 18, p.s2 * 324, p.s2 * 5832) + (int4)(p.s3, p.s3 * 19, p.s3 * 361, p.s3 * 6859)) +//ptr + 20
-                bitval2 * ((int4)(p.s4, p.s4 * 20, p.s4 * 400, p.s4 * 8000) + (int4)(p.s5, p.s5 * 21, p.s5 * 441, p.s5 * 9261) +
-                (int4)(p.s6, p.s6 * 22, p.s6 * 484, p.s6 * 10648) + (int4)(p.s7, p.s7 * 23, p.s7 * 529, p.s7 * 12167)) +//ptr  + 24
-                bitval1 * ((int4)(p.s8, p.s8 * 24, p.s8 * 576, p.s8 * 13824) + (int4)(p.s9, p.s9 * 25, p.s9 * 625, p.s9 * 15625) +
-                (int4)(p.sa, p.sa * 26, p.sa * 676, p.sa * 17576) + (int4)(p.sb, p.sb * 27, p.sb * 729, p.sb * 19683)) + //ptr + 28
-                bitval0 * ((int4)(p.sc, p.sc * 28, p.sc * 784, p.sc * 21952) + (int4)(p.sd, p.sd * 29, p.sd * 841, p.sd * 24389) +
-                (int4)(p.se, p.se * 30, p.se * 900, p.se * 27000) + (int4)(p.sf, p.sf * 31, p.sf * 961, p.sf * 29791));
+                    S += (float4)(p.s0, p.s0 * 4.0, p.s0 * 16.0, p.s0 * 64.0) + (float4)(p.s1, p.s1 * 5.0, p.s1 * 25.0, p.s1 * 125.0) +
+                        (float4)(p.s2, p.s2 * 6.0, p.s2 * 36.0, p.s2 * 216.0) + (float4)(p.s3, p.s3 * 7.0, p.s3 * 49.0, p.s3 * 343.0);
+                    //SUM_ELEM(p.s0, 4) + SUM_ELEM(p.s1, 5) + SUM_ELEM(p.s2, 6) + SUM_ELEM(p.s3, 7);
 
+                    if (x_max >= 12)
+                    {
+                        p = convert_float4(vload4(0, ptr + 8));
+#ifdef OP_MOMENTS_BINARY
+                        p = min(p, 1);
+#endif
+                        S += (float4)(p.s0, p.s0 * 8.0, p.s0 * 64.0, p.s0 * 512.0) + (float4)(p.s1, p.s1 * 9.0, p.s1 * 81.0, p.s1 * 729.0) +
+                            (float4)(p.s2, p.s2 * 10.0, p.s2 * 100.0, p.s2 * 1000.0) + (float4)(p.s3, p.s3 * 11.0, p.s3 * 121.0, p.s3 * 1331.0);
+                        //SUM_ELEM(p.s0, 8) + SUM_ELEM(p.s1, 9) + SUM_ELEM(p.s2, 10) + SUM_ELEM(p.s3, 11);
+
+                        if (x_max >= 16)
+                        {
+                            p = convert_float4(vload4(0, ptr + 12));
+#ifdef OP_MOMENTS_BINARY
+                            p = min(p, 1);
+#endif
+                            S += (float4)(p.s0, p.s0 * 12.0, p.s0 * 144.0, p.s0 * 1728.0) + (float4)(p.s1, p.s1 * 13.0, p.s1 * 169.0, p.s1 * 2197.0) +
+                                (float4)(p.s2, p.s2 * 14.0, p.s2 * 196.0, p.s2 * 2744.0) + (float4)(p.s3, p.s3 * 15.0, p.s3 * 225.0, p.s3 * 3375.0);
+                            //SUM_ELEM(p.s0, 12) + SUM_ELEM(p.s1, 13) + SUM_ELEM(p.s2, 14) + SUM_ELEM(p.s3, 15);
+                        }
+                    }
+                }
+            }
+
+            if (x_max >= 20)
+            {
+                p = convert_float4(vload4(0, ptr + 16));
+#ifdef OP_MOMENTS_BINARY
+                p = min(p, 1);
+#endif
+                S += (float4)(p.s0, p.s0 * 16.0, p.s0 * 256.0, p.s0 * 4096.0) + (float4)(p.s1, p.s1 * 17.0, p.s1 * 289.0, p.s1 * 4913.0) +
+                    (float4)(p.s2, p.s2 * 18.0, p.s2 * 324.0, p.s2 * 5832.0) + (float4)(p.s3, p.s3 * 19.0, p.s3 * 361.0, p.s3 * 6859.0);
+                //SUM_ELEM(p.s0, 16) + SUM_ELEM(p.s1, 17) + SUM_ELEM(p.s2, 18) + SUM_ELEM(p.s3, 19);
+
+                if (x_max >= 24)
+                {
+                    p = convert_float4(vload4(0, ptr + 20));
+#ifdef OP_MOMENTS_BINARY
+                    p = min(p, 1);
+#endif
+                    S += (float4)(p.s0, p.s0 * 20.0, p.s0 * 400.0, p.s0 * 8000.0) + (float4)(p.s1, p.s1 * 21.0, p.s1 * 441.0, p.s1 * 9261.0) +
+                        (float4)(p.s2, p.s2 * 22.0, p.s2 * 484.0, p.s2 * 10648.0) + (float4)(p.s3, p.s3 * 23.0, p.s3 * 529.0, p.s3 * 12167.0);
+                    //SUM_ELEM(p.s0, 20) + SUM_ELEM(p.s1, 21) + SUM_ELEM(p.s2, 22) + SUM_ELEM(p.s3, 23);
+
+                    if (x_max >= 28)
+                    {
+                        p = convert_float4(vload4(0, ptr + 24));
+#ifdef OP_MOMENTS_BINARY
+                        p = min(p, 1);
+#endif
+                        S += (float4)(p.s0, p.s0 * 24.0, p.s0 * 576.0, p.s0 * 13824.0) + (float4)(p.s1, p.s1 * 25.0, p.s1 * 625.0, p.s1 * 15625.0) +
+                            (float4)(p.s2, p.s2 * 26.0, p.s2 * 676.0, p.s2 * 17576.0) + (float4)(p.s3, p.s3 * 27.0, p.s3 * 729.0, p.s3 * 19683.0);
+                        //SUM_ELEM(p.s0, 24) + SUM_ELEM(p.s1, 25) + SUM_ELEM(p.s2, 26) + SUM_ELEM(p.s3, 27);
+
+                        if (x_max >= 32)
+                        {
+                            p = convert_float4(vload4(0, ptr + 28));
+#ifdef OP_MOMENTS_BINARY
+                            p = min(p, 1);
+#endif
+                            S += (float4)(p.s0, p.s0 * 28.0, p.s0 * 784.0, p.s0 * 21952.0) + (float4)(p.s1, p.s1 * 29.0, p.s1 * 841.0, p.s1 * 24389.0) +
+                                (float4)(p.s2, p.s2 * 30.0, p.s2 * 900.0, p.s2 * 27000.0) + (float4)(p.s3, p.s3 * 31.0, p.s3 * 961.0, p.s3 * 29791.0);
+                            //SUM_ELEM(p.s0, 28) + SUM_ELEM(p.s1, 29) + SUM_ELEM(p.s2, 30) + SUM_ELEM(p.s3, 31);
+                        }
+                    }
+                }
+            }
             if (x < x_max)
             {
-                int ps = ptr[x];
+                int ps = (ptr[x]);
 #ifdef OP_MOMENTS_BINARY
-                ps = min(ps, 1);
+                ps = min((ps), 1);
 #endif
-                S += SUM_ELEM(ps, x);
+                S += SUM_ELEM(ps,(float)(x));
                 if (x + 1 < x_max)
                 {
-                    ps = ptr[x + 1];
+                    ps = (ptr[x + 1]);
 #ifdef OP_MOMENTS_BINARY
-                    ps = min(ps, 1);
+                    ps = min((ps), 1);
 #endif
-                    S += SUM_ELEM(ps, x + 1);
+                    S += SUM_ELEM(ps, (float)(x + 1));
                     if (x + 2 < x_max)
                     {
-                        ps = ptr[x + 2];
+                        ps = (ptr[x + 2]);
 #ifdef OP_MOMENTS_BINARY
-                        ps = min(ps, 1);
+                        ps = min((ps), 1);
 #endif
-                        S += SUM_ELEM(ps, x + 2);
+                        S += SUM_ELEM(ps, (float)(x + 2));
                     }
                 }
             }
@@ -106,7 +154,7 @@ __kernel void moments(__global const uchar* src, int src_step, int src_offset,
         }
         else
             mom[y][0] = mom[y][1] = mom[y][2] = mom[y][3] = mom[y][4] =
-            mom[y][5] = mom[y][6] = mom[y][7] = mom[y][8] = mom[y][9] = 0;
+            mom[y][5] = mom[y][6] = mom[y][7] = mom[y][8] = mom[y][9] = 0.0;
         barrier(CLK_LOCAL_MEM_FENCE);
 
 #define REDUCE(d) \

--- a/modules/imgproc/test/test_moments.cpp
+++ b/modules/imgproc/test/test_moments.cpp
@@ -150,7 +150,8 @@ void CV_MomentsTest::get_test_array_types_and_sizes( int test_case_idx,
 double CV_MomentsTest::get_success_error_level( int /*test_case_idx*/, int /*i*/, int /*j*/ )
 {
     int depth = test_mat[INPUT][0].depth();
-    return depth != CV_32F ? FLT_EPSILON*10 : FLT_EPSILON*100;
+    return depth != CV_32F ? 1e-3 : 1e-2;
+    //return depth != CV_32F ? FLT_EPSILON*10 : FLT_EPSILON*100;
 }
 
 int CV_MomentsTest::prepare_test_case( int test_case_idx )


### PR DESCRIPTION
**WIP**
**Optimization:** as in most of cases we work with a full tile (32 uchar values), reading by 16 uchar vector applied

**Performance report:**
http://ocl.itseez.com/intel/export/perf/pr/2916/report/

check_regression=_OCL_Moments*
build_examples=OFF
test_modules=imgproc
