### PR TITLE
opencv bug #3782: test.py: Check if camera_calibration.tar.gz file exists before downloading

### DIFF
--- a/modules/python/test/test.py
+++ b/modules/python/test/test.py
@@ -1646,7 +1646,8 @@ class AreaTests(OpenCVTests):
             cv.SetData(imagefiledata, filedata, len(filedata))
             return cv.DecodeImageM(imagefiledata)
 
-        urllib.urlretrieve("http://docs.opencv.org/data/camera_calibration.tar.gz", "camera_calibration.tar.gz")
+        if (not os.path.isfile("camera_calibration.tar.gz")):
+            urllib.urlretrieve("http://docs.opencv.org/data/camera_calibration.tar.gz", "camera_calibration.tar.gz")
         tf = tarfile.open("camera_calibration.tar.gz")
 
         num_x_ints = 8


### PR DESCRIPTION
Test script should check if file exists to save time and avoid unnecessary downloading.
