### PR TITLE
Evaluate the whole image with getSingleScale.

### DIFF
--- a/modules/objdetect/src/cascadedetect.cpp
+++ b/modules/objdetect/src/cascadedetect.cpp
@@ -972,9 +972,9 @@ public:
             Size winSize(cvRound(origWinSize.width * scalingFactor),
                          cvRound(origWinSize.height * scalingFactor));
 
-            for( int y = y0; y < y1; y += yStep )
+            for( int y = y0; y <= y1; y += yStep )
             {
-                for( int x = 0; x < szw.width; x += yStep )
+                for( int x = 0; x <= szw.width; x += yStep )
                 {
                     int result = classifier->runAt(evaluator, Point(x, y), scaleIdx, gypWeight);
                     if( rejectLevels )

--- a/modules/objdetect/src/opencl/cascadedetect.cl
+++ b/modules/objdetect/src/opencl/cascadedetect.cl
@@ -398,7 +398,7 @@ __kernel void runLBPClassifierStumpSimple(
             int iy = ((tileIdx / ntiles.x)*local_size_y + ly)*ystep;
             int ix = ((tileIdx % ntiles.x)*local_size_x + lx)*ystep;
 
-            if( ix < worksize.x && iy < worksize.y )
+            if( ix <= worksize.x && iy <= worksize.y )
             {
                 __global const int* p = sum + mad24(iy, sumstep, ix) + s->layer_ofs;
                 __global const Stump* stump = stumps;


### PR DESCRIPTION
Currently, CascadeClassifier does not find positives that are the same size as the image. In CascadeClassifierInvoker::operator(), ScaleData::getWorkingSize() is called with an argument of the detector window size. When the detector window size is the same as the scaled image size, getWorkingSize() returns Size(0,0), as it should. However, this results in y0 and y1 both being zero, and the for loop being skipped. Simply changing the <s to <=s rectified the issue for me, admittedly in an older OpenCV version. I can't think of any problems from this change that wouldn't be immediately apparent.

FOR THE OCL CHANGE, I WAS GUESSING. It would be good if someone more knowledgeable could ensure that it's the right thing to change.
