### PR TITLE
Added call to clone() to avoid unexpected change to external data.

### DIFF
--- a/modules/stitching/src/stitcher.cpp
+++ b/modules/stitching/src/stitcher.cpp
@@ -522,7 +522,7 @@ Stitcher::Status Stitcher::estimateCameraParams()
     {
         std::vector<Mat> rmats;
         for (size_t i = 0; i < cameras_.size(); ++i)
-            rmats.push_back(cameras_[i].R);
+            rmats.push_back(cameras_[i].R.clone());
         detail::waveCorrect(rmats, wave_correct_kind_);
         for (size_t i = 0; i < cameras_.size(); ++i)
             cameras_[i].R = rmats[i];

--- a/samples/cpp/stitching_detailed.cpp
+++ b/samples/cpp/stitching_detailed.cpp
@@ -527,7 +527,7 @@ int main(int argc, char* argv[])
     {
         vector<Mat> rmats;
         for (size_t i = 0; i < cameras.size(); ++i)
-            rmats.push_back(cameras[i].R);
+            rmats.push_back(cameras[i].R.clone());
         waveCorrect(rmats, wave_correct);
         for (size_t i = 0; i < cameras.size(); ++i)
             cameras[i].R = rmats[i];


### PR DESCRIPTION
- Fix both stitching_detailed.cpp sample and cv::Stitcher.
  As suggested by Alexey Spizhevoy, in the following email exchange:

Adi: (BTW, there is a redundant copy in the wave-correction part since the original mats are copied by ref and not cloned)

Alexey: Yes, but I think the code with the redundant copy is more stable to changes in waveCorrect(), because one day somebody's changes might lead to violation of the assumption that pointers remain the same.

Adi: OK, so in this case, you should add a clone() call as in:
        for (size_t i = 0; i < cameras.size(); ++i)
            rmats.push_back(cameras[i].R.clone());

As it is, the code does not do what it seems to be doing. 
It changes the external data (not a copy) and then assigns that external data to itself..

Alexey: Agree, the code can be made easier to understand by adding a clone() call. It would be great if you could make a pull request.
