### PR TITLE
imgproc: fix compiler error for gcc 4.8

### DIFF
--- a/modules/imgproc/src/morph.cpp
+++ b/modules/imgproc/src/morph.cpp
@@ -1257,7 +1257,7 @@ static bool IPPMorphReplicate(int op, const Mat &src, Mat &dst, const Mat &kerne
         }
         #undef IPP_MORPH_CASE
 
-#if defined(__GNUC__) && __GNUC__ == 4 && __GNUC_MINOR__ > 8
+#if defined(__GNUC__) && __GNUC__ == 4 && __GNUC_MINOR__ >= 8
         return false; /// It disables false positive warning in GCC 4.8 and further
 #endif
     }


### PR DESCRIPTION
this bug was introduced in a73809e6.
