### PR TITLE
Update facedetect.cpp to work with AVI

### DIFF
--- a/samples/ocl/facedetect.cpp
+++ b/samples/ocl/facedetect.cpp
@@ -93,9 +93,10 @@ static int facedetect_one_thread(bool useCPU, double scale )
         if( image.empty() )
         {
             capture = cvCaptureFromAVI( inputName.c_str() );
-            if(!capture)
+            if(!capture){
                 cout << "Capture from AVI didn't work" << endl;
-            return EXIT_FAILURE;
+                return EXIT_FAILURE;
+            }
         }
     }
 


### PR DESCRIPTION
There was a bug where the return EXIT_FAILURE was outside the capture flag, resulting in videos never actually getting processed. This will fix it.
