### PR TITLE
Double precision for solvePnPRansac()

### DIFF
--- a/modules/calib3d/src/solvepnp.cpp
+++ b/modules/calib3d/src/solvepnp.cpp
@@ -162,7 +162,7 @@ namespace cv
             for (int i = 0; i < MIN_POINTS_COUNT; i++)
                 for (int j = i + 1; j < MIN_POINTS_COUNT; j++)
                 {
-                    if (norm(modelObjectPoints.at<Vec<OpointType,3>>(0, i) - modelObjectPoints.at<Vec<OpointType,3>>(0, j)) < eps)
+                    if (norm(modelObjectPoints.at<Vec<OpointType,3> >(0, i) - modelObjectPoints.at<Vec<OpointType,3> >(0, j)) < eps)
                         num_same_points++;
                 }
             if (num_same_points > 0)
@@ -176,7 +176,7 @@ namespace cv
                      params.useExtrinsicGuess, params.flags);
 
 
-            vector<Point_<OpointType>> projected_points;
+            vector<Point_<OpointType> > projected_points;
             projected_points.resize(objectPoints.cols);
             projectPoints(objectPoints, localRvec, localTvec, params.camera.intrinsics, params.camera.distortion, projected_points);
 
@@ -187,10 +187,10 @@ namespace cv
             for (int i = 0; i < objectPoints.cols; i++)
             {
                 //Although p is a 2D point it needs the same type as the object points to enable the norm calculation
-                Point_<OpointType> p((OpointType)imagePoints.at<Vec<IpointType,2>>(0, i)[0],
-                                     (OpointType)imagePoints.at<Vec<IpointType,2>>(0, i)[1]);
+                Point_<OpointType> p((OpointType)imagePoints.at<Vec<IpointType,2> >(0, i)[0],
+                                     (OpointType)imagePoints.at<Vec<IpointType,2> >(0, i)[1]);
                 if ((norm(p - projected_points[i]) < params.reprojectionError)
-                    && (rotatedPoints.at<Vec<OpointType,3>>(0, i)[2] > 0)) //hack
+                    && (rotatedPoints.at<Vec<OpointType,3> >(0, i)[2] > 0)) //hack
                 {
                     localInliers.push_back(i);
                 }


### PR DESCRIPTION
I believe that the assertions
_CV_Assert(opoints.depth() = = CV_32F);
CV_Assert(ipoints.depth() = = CV_32F);_
in the method cv::solvePnPRansac are a bug: other PnP functions explicitly support CV_64F.
So this is a bugfix allowing solvePnPRansac() and pnpTask() to deal with CV_64F matrices.

I don't know whether the use of templates is the prettiest solution but I used them like they are used in the function p3p::solve() (in file calib3d\src\p3p.cpp)
