### PR TITLE
T-API: OpenCL before IPP in cv::Laplacian

### DIFF
--- a/modules/imgproc/src/deriv.cpp
+++ b/modules/imgproc/src/deriv.cpp
@@ -702,7 +702,7 @@ void cv::Laplacian( InputArray _src, OutputArray _dst, int ddepth, int ksize,
 
 #ifdef HAVE_IPP
     if ((ksize == 3 || ksize == 5) && ((borderType & BORDER_ISOLATED) != 0 || !_src.isSubmatrix()) &&
-        ((stype == CV_8UC1 && ddepth == CV_16S) || (ddepth == CV_32F && stype == CV_32FC1)))
+        ((stype == CV_8UC1 && ddepth == CV_16S) || (ddepth == CV_32F && stype == CV_32FC1)) && !ocl::useOpenCL())
     {
         int iscale = saturate_cast<int>(scale), idelta = saturate_cast<int>(delta);
         bool floatScale = std::fabs(scale - iscale) > DBL_EPSILON, needScale = iscale != 1;


### PR DESCRIPTION
check_regression=_OCL_Laplacian_:_OCL_Filter2D_
test_filter=_OCL_Laplacian_:_OCL_Filter2D_
test_modules=imgproc
build_examples=OFF
