### PR TITLE
fixing build of openCV traincascade tool with IDE

### DIFF
--- a/apps/traincascade/boost.cpp
+++ b/apps/traincascade/boost.cpp
@@ -17,7 +17,7 @@ using cv::ParallelLoopBody;
 #include "boost.h"
 #include "cascadeclassifier.h"
 #include <queue>
-#include "cxmisc.h"
+#include "opencv/cxmisc.h"
 
 using namespace std;
 

--- a/apps/traincascade/boost.h
+++ b/apps/traincascade/boost.h
@@ -2,7 +2,7 @@
 #define _OPENCV_BOOST_H_
 
 #include "traincascade_features.h"
-#include "ml.h"
+#include "opencv/ml.h"
 
 struct CvCascadeBoostParams : CvBoostParams
 {

--- a/apps/traincascade/cascadeclassifier.h
+++ b/apps/traincascade/cascadeclassifier.h
@@ -7,8 +7,8 @@
 #include "lbpfeatures.h"
 #include "HOGfeatures.h" //new
 #include "boost.h"
-#include "cv.h"
-#include "cxcore.h"
+#include "opencv/cv.h"
+#include "opencv/cxcore.h"
 
 #define CC_CASCADE_FILENAME "cascade.xml"
 #define CC_PARAMS_FILENAME "params.xml"

--- a/apps/traincascade/imagestorage.cpp
+++ b/apps/traincascade/imagestorage.cpp
@@ -1,7 +1,7 @@
 #include "opencv2/core/core.hpp"
 #include "opencv2/core/internal.hpp"
 
-#include "cv.h"
+#include "opencv/cv.h"
 #include "imagestorage.h"
 #include <stdio.h>
 #include <iostream>

--- a/apps/traincascade/imagestorage.h
+++ b/apps/traincascade/imagestorage.h
@@ -1,7 +1,7 @@
 #ifndef _OPENCV_IMAGESTORAGE_H_
 #define _OPENCV_IMAGESTORAGE_H_
 
-#include "highgui.h"
+#include "opencv/highgui.h"
 
 
 

--- a/apps/traincascade/traincascade.cpp
+++ b/apps/traincascade/traincascade.cpp
@@ -1,7 +1,7 @@
 #include "opencv2/core/core.hpp"
 #include "opencv2/core/internal.hpp"
 
-#include "cv.h"
+#include "opencv/cv.h"
 #include "cascadeclassifier.h"
 
 using namespace std;

--- a/apps/traincascade/traincascade_features.h
+++ b/apps/traincascade/traincascade_features.h
@@ -2,9 +2,9 @@
 #define _OPENCV_FEATURES_H_
 
 #include "imagestorage.h"
-#include "cxcore.h"
-#include "cv.h"
-#include "ml.h"
+#include "opencv/cxcore.h"
+#include "opencv/cv.h"
+#include "opencv/ml.h"
 #include <stdio.h>
 
 #define FEATURES "features"


### PR DESCRIPTION
Not specifiying that the old headers are inside the opencv/ folder causes some IDE's not te be able to build the tool. Added a fix just for that.

Tested with Codeblocks and Visual Studio on Ubuntu 14.04 and Windows 7 to ensure this works.
