### PR TITLE
T-API: fixed perf test for cv::UMat::copyTo dst with uninit

### DIFF
--- a/modules/core/perf/opencl/perf_matop.cpp
+++ b/modules/core/perf/opencl/perf_matop.cpp
@@ -139,6 +139,7 @@ OCL_PERF_TEST_P(CopyToFixture, CopyToWithMaskUninit,
         dst.release();
         startTimer();
         src.copyTo(dst, mask);
+        cv::ocl::finish();
         stopTimer();
     }
 


### PR DESCRIPTION
check_regression=_OCL_CopyToWithMaskUninit*
test_filter=fdvkfdjvkldv
test_modules=core
build_examples=OFF
