### PR TITLE
Fix build

### DIFF
--- a/modules/highgui/src/precomp.hpp
+++ b/modules/highgui/src/precomp.hpp
@@ -47,6 +47,8 @@
 #include "opencv2/core/utility.hpp"
 #include "opencv2/core/private.hpp"
 
+#include "opencv2/imgcodecs.hpp"
+
 #include "opencv2/imgproc/imgproc_c.h"
 #include "opencv2/imgcodecs/imgcodecs_c.h"
 #include "opencv2/highgui/highgui_c.h"


### PR DESCRIPTION
```
/home/build/opencv/modules/highgui/src/cap_v4l.cpp:1740:16: error: ‘imdecode’ is not a member of ‘cv’
```
