### PR TITLE
T-API: enabled BufferPool

### DIFF
--- a/modules/core/src/ocl.cpp
+++ b/modules/core/src/ocl.cpp
@@ -3494,9 +3494,8 @@ public:
     OpenCLBufferPoolImpl()
         : currentReservedSize(0), maxReservedSize(0)
     {
-        // Note: Buffer pool is disabled by default,
-        //       because we didn't receive significant performance improvement
-        maxReservedSize = getConfigurationParameterForSize("OPENCV_OPENCL_BUFFERPOOL_LIMIT", 0);
+        int poolSize = ocl::Device::getDefault().isIntel() ? 1 << 27 : 0;
+        maxReservedSize = getConfigurationParameterForSize("OPENCV_OPENCL_BUFFERPOOL_LIMIT", poolSize);
     }
     virtual ~OpenCLBufferPoolImpl()
     {


### PR DESCRIPTION
**Description:**
- set 128MB as buffer poll capacity

**Performance report:**
http://ocl.itseez.com/intel/export/perf/pr/2963/report/

check_regression=_OCL_
test_filter=dfvdvdv
test_modules=imgproc,core
build_examples=OFF
