### PR TITLE
Fixed bug in cv::detail::waveCorrect

### DIFF
--- a/modules/stitching/src/motion_estimators.cpp
+++ b/modules/stitching/src/motion_estimators.cpp
@@ -589,6 +589,11 @@ void waveCorrect(vector<Mat> &rmats, WaveCorrectKind kind)
 #if ENABLE_LOG
     int64 t = getTickCount();
 #endif
+    if (rmats.size() <= 1)
+    {
+        LOGLN("Wave correcting, time: " << ((getTickCount() - t) / getTickFrequency()) << " sec");
+        return;
+    }
 
     Mat moment = Mat::zeros(3, 3, CV_32F);
     for (size_t i = 0; i < rmats.size(); ++i)


### PR DESCRIPTION
The function cv::detail::waveCorrect makes wave correction of a stitched panorama.
Earlier it gave wrong results for panorama made from 1 frame.
