### PR TITLE
Fixed bug which caused crash of GPU version of feature matcher in stitcher

### DIFF
--- a/modules/stitching/src/matchers.cpp
+++ b/modules/stitching/src/matchers.cpp
@@ -212,6 +212,10 @@ void GpuMatcher::match(const ImageFeatures &features1, const ImageFeatures &feat
     descriptors1_.upload(features1.descriptors);
     descriptors2_.upload(features2.descriptors);
 
+    //TODO: NORM_L1 allows to avoid matcher crashes for ORB features, but is not absolutely correct for them.
+    //      The best choice for ORB features is NORM_HAMMING, but it is incorrect for SURF features.
+    //      More accurate fix in this place should be done in the future -- the type of the norm
+    //      should be either a parameter of this method, or a field of the class.
     BFMatcher_GPU matcher(NORM_L1);
     MatchesSet matches;
 


### PR DESCRIPTION
The bug caused crash of GPU version of feature matcher in stitcher when
we use ORB features.
