### PR TITLE
Doc: fix definition of macro CV_MAKETYPE

### DIFF
--- a/modules/core/doc/intro.rst
+++ b/modules/core/doc/intro.rst
@@ -176,7 +176,7 @@ Multi-channel (``n``-channel) types can be specified using the following options
 * ``CV_8UC1`` ... ``CV_64FC4`` constants (for a number of channels from 1 to 4)
 * ``CV_8UC(n)`` ... ``CV_64FC(n)`` or ``CV_MAKETYPE(CV_8U, n)`` ... ``CV_MAKETYPE(CV_64F, n)`` macros when the number of channels is more than 4 or unknown at the compilation time.
 
-.. note:: ``CV_32FC1 == CV_32F``, ``CV_32FC2 == CV_32FC(2) == CV_MAKETYPE(CV_32F, 2)``, and ``CV_MAKETYPE(depth, n) == ((x&7)<<3) + (n-1)``. This means that the  constant type is formed from the ``depth``, taking the lowest 3 bits, and the number of channels minus 1, taking the next ``log2(CV_CN_MAX)`` bits.
+.. note:: ``CV_32FC1 == CV_32F``, ``CV_32FC2 == CV_32FC(2) == CV_MAKETYPE(CV_32F, 2)``, and ``CV_MAKETYPE(depth, n) == (depth&7) + ((n-1)<<3)``. This means that the  constant type is formed from the ``depth``, taking the lowest 3 bits, and the number of channels minus 1, taking the next ``log2(CV_CN_MAX)`` bits.
 
 Examples: ::
 


### PR DESCRIPTION
At least this is how it's defined in core/types_c.h
