### PR TITLE
bug fix 3381

### DIFF
--- a/modules/core/include/opencv2/core/mat.hpp
+++ b/modules/core/include/opencv2/core/mat.hpp
@@ -684,7 +684,7 @@ template<typename _Tp> inline void Mat::push_back(const _Tp& elem)
 {
     if( !data )
     {
-    	CV_Assert((type()==0) || (DataType<_Tp>::type == type()));
+        CV_Assert((type()==0) || (DataType<_Tp>::type == type()));
 
         *this = Mat(1, 1, DataType<_Tp>::type, (void*)&elem).clone();
         return;


### PR DESCRIPTION
Fix the bug 3381 : http://www.code.opencv.org/issues/3381

I found that when the push_back is called with an empty, the matrix was allocated with the type of the first element as type for the whole matrix : 
if( !data )
{
          _this = Mat(1, 1, DataType<_Tp>::type, (void_)&elem).clone();
... 

When the matrix is a cv::Mat and is declared without any type indication, the behaviour is, to my mind, normal.
example : 
Mat A;
A.push_back(0.0f); //A becomes a matrix with float as type

But when the matrix is initially declared as a cv::Mat_<_Tp>, it becomes a problem if the type is changed.
This problem becomes visible when the reshape function is called, it raises an exception because of a type inconsistency : "Assertion failed (!fixedType() || ((Mat)obj)->type() == mtype)"

I added a line to avoid a type changing if the matrix already has a type when pushing the first element.
CV_Assert((type()==0) || (DataType<_Tp>::type == type()));
