### PR TITLE
added macro guard to enable overriding ENABLE_LOG

### DIFF
--- a/modules/stitching/include/opencv2/stitching/detail/util.hpp
+++ b/modules/stitching/include/opencv2/stitching/detail/util.hpp
@@ -46,7 +46,9 @@
 #include <list>
 #include "opencv2/core.hpp"
 
+#ifndef ENABLE_LOG
 #define ENABLE_LOG 0
+#endif
 
 // TODO remove LOG macros, add logging class
 #if ENABLE_LOG


### PR DESCRIPTION
The LOGLN macro is defined in header file only if ENABLE_LOG is 1. But ENABLE_LOG was explicitly defined to be 0 in the header without a macro guard so it was not possible to use the LOGLN macro. So i added the guard. This is used in the stitching_detailed.cpp sample code.
I am new to open source projects. This is my first contribution ever. Please let me know if I did something wrong. Thanks!
