### PR TITLE
Initialize all pointers of CvCapture_GStreamer correctly

### DIFF
--- a/modules/videoio/src/cap_gstreamer.cpp
+++ b/modules/videoio/src/cap_gstreamer.cpp
@@ -185,31 +185,41 @@ void CvCapture_GStreamer::close()
     if(pipeline) {
         gst_element_set_state(GST_ELEMENT(pipeline), GST_STATE_NULL);
         gst_object_unref(GST_OBJECT(pipeline));
+        pipeline = NULL;
     }
     if(uridecodebin){
         gst_object_unref(GST_OBJECT(uridecodebin));
+        uridecodebin = NULL;
     }
     if(color){
         gst_object_unref(GST_OBJECT(color));
+        color = NULL;
     }
     if(sink){
         gst_object_unref(GST_OBJECT(sink));
+        sink = NULL;
     }
-    if(buffer)
+    if(buffer) {
         gst_buffer_unref(buffer);
+        buffer = NULL;
+    }
     if(frame) {
         frame->imageData = 0;
         cvReleaseImage(&frame);
+        frame = NULL;
     }
     if(caps){
         gst_caps_unref(caps);
+        caps = NULL;
     }
     if(buffer_caps){
         gst_caps_unref(buffer_caps);
+        buffer_caps = NULL;
     }
 #if GST_VERSION_MAJOR > 0
     if(sample){
         gst_sample_unref(sample);
+        sample = NULL;
     }
 #endif
 


### PR DESCRIPTION
Opening a non-existing video file with `cv2.videoCapture()` (in Python) and releasing the video object will result in a segfault caused by uninitialized memory. The 'color' pointer (as well as a few other pointers) was not set to NULL, and therefore uses uninitialized memory which caused the segfault on `CvCapture_GStreamer::close()`.
