### PR TITLE
Added option to set the number of threads for traincascade

### DIFF
--- a/apps/traincascade/traincascade.cpp
+++ b/apps/traincascade/traincascade.cpp
@@ -13,6 +13,7 @@ int main( int argc, char* argv[] )
     int numPos    = 2000;
     int numNeg    = 1000;
     int numStages = 20;
+    int numThreads = getNumThreads();
     int precalcValBufSize = 256,
         precalcIdxBufSize = 256;
     bool baseFormatSave = false;
@@ -36,6 +37,7 @@ int main( int argc, char* argv[] )
         cout << "  [-precalcValBufSize <precalculated_vals_buffer_size_in_Mb = " << precalcValBufSize << ">]" << endl;
         cout << "  [-precalcIdxBufSize <precalculated_idxs_buffer_size_in_Mb = " << precalcIdxBufSize << ">]" << endl;
         cout << "  [-baseFormatSave]" << endl;
+        cout << "  [-numThreads <max_number_of_threads = " << numThreads << ">]" << endl;
         cascadeParams.printDefaults();
         stageParams.printDefaults();
         for( int fi = 0; fi < fc; fi++ )
@@ -82,6 +84,10 @@ int main( int argc, char* argv[] )
         {
             baseFormatSave = true;
         }
+        else if( !strcmp( argv[i], "-numThreads" ) )
+        {
+          numThreads = atoi(argv[++i]);
+        }
         else if ( cascadeParams.scanAttr( argv[i], argv[i+1] ) ) { i++; }
         else if ( stageParams.scanAttr( argv[i], argv[i+1] ) ) { i++; }
         else if ( !set )
@@ -98,6 +104,7 @@ int main( int argc, char* argv[] )
         }
     }
 
+    setNumThreads( numThreads );
     classifier.train( cascadeDirName,
                       vecName,
                       bgName,

--- a/doc/user_guide/ug_traincascade.rst
+++ b/doc/user_guide/ug_traincascade.rst
@@ -200,6 +200,12 @@ Command line arguments of ``opencv_traincascade`` application grouped by purpose
 
         This argument is actual in case of Haar-like features. If it is specified, the cascade will be saved in the old format.
 
+    * ``-numThreads <max_number_of_threads>``
+
+        Maximum number of threads to use during training. Notice that
+        the actual number of used threads may be lower, depending on
+        your machine and compilation options.
+
 #.
 
     Cascade parameters:


### PR DESCRIPTION
The previous behavior of opencv_traincascade was to use as many threads as available and there was no way to limit the number of threads to use. 

This was very annoying to me because I am running opencv_traincascade in a HPC cluster and I need to limit the number of threads that opencv_traincascade uses.

I added an option (`--numThreads`) that specifies the maximum number of threads to use during the cascade training. The maximum is set through `cv::setNumThreads()`. If the option is not specified, the default number of threads is used (read from `cv::getNumThreads()`). Additionally, I updated the user guide to reflect this option.
