### PR TITLE
Fix Python 2 bindings for findContours

### DIFF
--- a/modules/imgproc/src/contours.cpp
+++ b/modules/imgproc/src/contours.cpp
@@ -1704,8 +1704,10 @@ void cv::findContours( InputOutputArray _image, OutputArrayOfArrays _contours,
                    OutputArray _hierarchy, int mode, int method, Point offset )
 {
     // Sanity check: output must be of type vector<vector<Point>>
-    CV_Assert( _contours.kind() == _InputArray::STD_VECTOR_VECTOR &&
-               _contours.channels() == 2 && _contours.depth() == CV_32S );
+    CV_Assert((_contours.kind() == _InputArray::STD_VECTOR_VECTOR || _contours.kind() == _InputArray::STD_VECTOR_MAT ||
+                _contours.kind() == _InputArray::STD_VECTOR_UMAT));
+
+    CV_Assert(_contours.empty() || (_contours.channels() == 2 && _contours.depth() == CV_32S));
 
     Mat image = _image.getMat();
     MemStorage storage(cvCreateMemStorage());


### PR DESCRIPTION
The sanity check prevents Python 2 from calling `findContours`, because the
Python 2 bindings pass an empty matrix for `_contours`. If `_contours` is not
empty, the channel and depth check should determine whether the matrix is of
the correct type and size.

Note: the Python 2 bindings passes a matrix of type `STD_VECTOR_MAT` to
parameters of the type `OutputArrayOfArrays`.

This fixes the following bug reports:
- http://code.opencv.org/issues/3606
- http://code.opencv.org/issues/3809
