### PR TITLE
disable OpenCL difference norms with mask, since some of the tests fail

### DIFF
--- a/modules/core/src/stat.cpp
+++ b/modules/core/src/stat.cpp
@@ -1452,7 +1452,7 @@ static bool ocl_minMaxIdx( InputArray _src, double* minVal, double* maxVal, int*
 
     CV_Assert(!haveSrc2 || _src2.type() == type);
 
-    if (depth == CV_32F)
+    if (depth == CV_32S || depth == CV_32F)
         return false;
 
     if ((depth == CV_64F || ddepth == CV_64F) && !doubleSupport)


### PR DESCRIPTION
at least on Mac now all the norm-related tests pass
