### PR TITLE
OCL: Prevent generating test case with mask filled 0 only

### DIFF
--- a/modules/core/test/ocl/test_arithm.cpp
+++ b/modules/core/test/ocl/test_arithm.cpp
@@ -157,6 +157,7 @@ PARAM_TEST_CASE(ArithmTestBase, MatDepth, Channels, bool)
         Border maskBorder = randomBorder(0, use_roi ? MAX_VALUE : 0);
         randomSubMat(mask, mask_roi, roiSize, maskBorder, CV_8UC1, 0, 2);
         cv::threshold(mask, mask, 0.5, 255., CV_8UC1);
+        *mask.ptr(0) = 255; // prevent test case with mask filled 0 only
 
         val = cv::Scalar(rng.uniform(-100.0, 100.0), rng.uniform(-100.0, 100.0),
                          rng.uniform(-100.0, 100.0), rng.uniform(-100.0, 100.0));


### PR DESCRIPTION
With `test_loop_times > 1` we have some case with mask filled 0 only, and infinity as result of norm calculation.

check_regression=_OCL_Norm*
test_filter=_OCL_Norm*
build_examples=OFF
test_modules=core
