### PR TITLE
OCL: Fix epsilon for OpenCL function ConverTo, for convertation from float to int types

### DIFF
--- a/modules/core/test/ocl/test_matrix_operation.cpp
+++ b/modules/core/test/ocl/test_matrix_operation.cpp
@@ -96,7 +96,7 @@ OCL_TEST_P(ConvertTo, Accuracy)
         OCL_OFF(src_roi.convertTo(dst_roi, dstType, alpha, beta));
         OCL_ON(usrc_roi.convertTo(udst_roi, dstType, alpha, beta));
 
-        double eps = src_depth >= CV_32F || CV_MAT_DEPTH(dstType) >= CV_32F ? 2e-4 : 1;
+        double eps = CV_MAT_DEPTH(dstType) >= CV_32F ? 2e-4 : 1;
         OCL_EXPECT_MATS_NEAR(dst, eps);
     }
 }


### PR DESCRIPTION
Some tests failed with `test_loop_times > 1`. Change epsilon for convertion from float to integer.

check_regression=_OCL_ConvertTo*
test_filter=_OCL_ConvertTo*
build_examples=OFF
test_modules=core
