### PR TITLE
OCL: Fix error in OpenCL version of meanstddev.

### DIFF
--- a/modules/core/src/opencl/meanstddev.cl
+++ b/modules/core/src/opencl/meanstddev.cl
@@ -59,7 +59,7 @@ __kernel void meanStdDev(__global const uchar * srcptr, int src_step, int src_of
     for (int grain = groups * WGS; id < total; id += grain)
     {
 #ifdef HAVE_MASK
-#ifdef HAVE_SRC_CONT
+#ifdef HAVE_MASK_CONT
         int mask_index = id;
 #else
         int mask_index = mad24(id / cols, mask_step, id % cols);

--- a/modules/core/src/stat.cpp
+++ b/modules/core/src/stat.cpp
@@ -918,7 +918,8 @@ static bool ocl_meanStdDev( InputArray _src, OutputArray _mean, OutputArray _sdv
     {
         int type = _src.type(), depth = CV_MAT_DEPTH(type), cn = CV_MAT_CN(type);
         bool doubleSupport = ocl::Device::getDefault().doubleFPConfig() > 0,
-                isContinuous = _src.isContinuous();
+                isContinuous = _src.isContinuous(),
+                isMaskContinuous = _mask.isContinuous();
         const ocl::Device &defDev = ocl::Device::getDefault();
         int groups = defDev.maxComputeUnits();
         if (defDev.isIntel())
@@ -943,13 +944,14 @@ static bool ocl_meanStdDev( InputArray _src, OutputArray _mean, OutputArray _sdv
 
         char cvt[2][40];
         String opts = format("-D srcT=%s -D srcT1=%s -D dstT=%s -D dstT1=%s -D sqddepth=%d"
-                             " -D sqdstT=%s -D sqdstT1=%s -D convertToSDT=%s -D cn=%d%s"
+                             " -D sqdstT=%s -D sqdstT1=%s -D convertToSDT=%s -D cn=%d%s%s"
                              " -D convertToDT=%s -D WGS=%d -D WGS2_ALIGNED=%d%s%s",
                              ocl::typeToStr(type), ocl::typeToStr(depth),
                              ocl::typeToStr(dtype), ocl::typeToStr(ddepth), sqddepth,
                              ocl::typeToStr(sqdtype), ocl::typeToStr(sqddepth),
                              ocl::convertTypeStr(depth, sqddepth, cn, cvt[0]),
                              cn, isContinuous ? " -D HAVE_SRC_CONT" : "",
+                             isMaskContinuous ? " -D HAVE_MASK_CONT" : "",
                              ocl::convertTypeStr(depth, ddepth, cn, cvt[1]),
                              (int)wgs, wgs2_aligned, haveMask ? " -D HAVE_MASK" : "",
                              doubleSupport ? " -D DOUBLE_SUPPORT" : "");


### PR DESCRIPTION
Function results invalid for continues source matrix and not continues mask.

check_regression=_OCL_MeanStdDev*
test_filter=_OCL_MeanStdDev*
build_examples=OFF
test_modules=core
