### PR TITLE
fixing setting the locale back to what should be expected

### DIFF
--- a/modules/highgui/src/window_QT.cpp
+++ b/modules/highgui/src/window_QT.cpp
@@ -447,6 +447,7 @@ static int icvInitSystem(int* c, char** v)
     if (!QApplication::instance())
     {
         new QApplication(*c, v);
+        setlocale(LC_NUMERIC,"C");
 
         qDebug() << "init done";
 

--- a/modules/highgui/src/window_carbon.cpp
+++ b/modules/highgui/src/window_carbon.cpp
@@ -146,6 +146,7 @@ CV_IMPL int cvInitSystem( int argc, char** argv )
         }
         wasInitialized = 1;
     }
+    setlocale(LC_NUMERIC,"C");
 
     return 0;
 }

--- a/modules/highgui/src/window_cocoa.mm
+++ b/modules/highgui/src/window_cocoa.mm
@@ -156,6 +156,8 @@ CV_IMPL int cvInitSystem( int , char** )
     //[application finishLaunching];
     //atexit(icvCocoaCleanup);
 
+    setlocale(LC_NUMERIC,"C");
+
     return 0;
 }
 

--- a/modules/highgui/src/window_w32.cpp
+++ b/modules/highgui/src/window_w32.cpp
@@ -250,6 +250,7 @@ CV_IMPL int cvInitSystem( int, char** )
 
         wasInitialized = 1;
     }
+    setlocale(LC_NUMERIC,"C");
 
     return 0;
 }


### PR DESCRIPTION
Like discussed in http://code.opencv.org/issues/927 this bug was fixed for normal windows using the gtk interface. However I experienced similar problems using windows with Qt enabled.

Applied the fix suggest by Qt itself. Hopefully it builds perfectly without errors, as it works here applying that trick.

EDIT: after some consideration, I do not see why we shouldn't ensure that on every system this is double checked by setting the correct parameter using the POSIX function provided.
