### PR TITLE
fix misinterpretation of empty window name

### DIFF
--- a/modules/highgui/src/window_QT.cpp
+++ b/modules/highgui/src/window_QT.cpp
@@ -401,7 +401,7 @@ static CvTrackbar* icvFindTrackBarByName(const char* name_trackbar, const char* 
 {
     QString nameQt(name_trackbar);
 
-    if (!name_window && global_control_panel) //window name is null and we have a control panel
+    if ((!name_window || !name_window[0]) && global_control_panel) //window name is null and we have a control panel
         layout = global_control_panel->myLayout;
 
     if (!layout)


### PR DESCRIPTION
The documentation states, that a NULL or an empty window name can be used
to refer to the control panel. But the string parameters of the C++ frontend
methods cannot be NULL and converting an empty string to a const char\* by
c_str() doesn't produce a NULL pointer, but an empty string. Unfortunately,
the const char\* pointer is just passed on to the standard C functions in
the QT backend, which doesn't check for the empty string case.

There are two places where the empty string check could have been introduced:
inside the frontend or inside the backend. As long as the documentation only
mentions this as a special case for the QT backend, the best place seems to
be there.
