### PR TITLE
Fixed self-assignment in cv::Ptr::operator =

### DIFF
--- a/modules/core/include/opencv2/core/operations.hpp
+++ b/modules/core/include/opencv2/core/operations.hpp
@@ -2625,12 +2625,15 @@ template<typename _Tp> inline Ptr<_Tp>::Ptr(const Ptr<_Tp>& _ptr)
 
 template<typename _Tp> inline Ptr<_Tp>& Ptr<_Tp>::operator = (const Ptr<_Tp>& _ptr)
 {
-    int* _refcount = _ptr.refcount;
-    if( _refcount )
-        CV_XADD(_refcount, 1);
-    release();
-    obj = _ptr.obj;
-    refcount = _refcount;
+    if (this != &_ptr)
+    {
+      int* _refcount = _ptr.refcount;
+      if( _refcount )
+          CV_XADD(_refcount, 1);
+      release();
+      obj = _ptr.obj;
+      refcount = _refcount;
+    }
     return *this;
 }
 


### PR DESCRIPTION
A self-assignment leads to a call of release() with refcount being 2. In the release() method, refcount is decremented and then successfully checked for being 1. As a consequence, the underlying data is released. To prevent this, we test for a self-assignment.

**EDIT**: As pointed out in the comments, this is not the true cause of the error. The problem is the execution of [the last two lines in the method release()](https://github.com/PhilLab/opencv/blob/efc1c39315cfacff250a0d936c2110b9968efb9e/modules/core/include/opencv2/core/operations.hpp#L2608-L2609). Independent of the error's cause, this PR enables the following program to run **/EDIT**

The current error can be reproduced by executing the following statements:

``` cpp
cv::Ptr<cv::Mat> a(new cv::Mat(5,5, CV_8UC3));
a->setTo(100);
a = a;
cv::imshow("test", *a);
```
