### PR TITLE
OCL: small fix for GaussianBlur ocl test

### DIFF
--- a/modules/imgproc/test/ocl/test_filters.cpp
+++ b/modules/imgproc/test/ocl/test_filters.cpp
@@ -225,7 +225,7 @@ OCL_TEST_P(GaussianBlurTest, Mat)
         OCL_OFF(cv::GaussianBlur(src_roi, dst_roi, Size(ksize, ksize), sigma1, sigma2, borderType));
         OCL_ON(cv::GaussianBlur(usrc_roi, udst_roi, Size(ksize, ksize), sigma1, sigma2, borderType));
 
-        Near(CV_MAT_DEPTH(type) >= CV_32F ? 5e-5 : 1, false);
+        Near(CV_MAT_DEPTH(type) >= CV_32F ? 7e-5 : 1, false);
     }
 }
 


### PR DESCRIPTION
found with test_loop_times = 30

test_modules=imgproc
build_examples=OFF
check_regression=OCL_GaussianBlurTest
test_filter=OCL_GaussianBlurTest
