### PR TITLE
Fix binary package build

### DIFF
--- a/cmake/OpenCVDetectPython.cmake
+++ b/cmake/OpenCVDetectPython.cmake
@@ -26,6 +26,12 @@ function(find_python preferred_version min_version library_env include_dir_env
          libs_found libs_version_string libraries library debug_libraries
          debug_library include_path include_dir include_dir2 packages_path
          numpy_include_dirs numpy_version)
+
+  ocv_check_environment_variables(${executable})
+  if(${executable})
+    set(PYTHON_EXECUTABLE "${${executable}}")
+  endif()
+
   if(WIN32 AND NOT ${executable})
     # search for executable with the same bitness as resulting binaries
     # standard FindPythonInterp always prefers executable from system path


### PR DESCRIPTION
Fixes in build scripts are required (only for master, 2.4 branch should use old variant):
- all `PYTHON_*` environment variables should be renamed to `PYTHON2_*`
- `BUILD_opencv_python` flag -> `BUILD_opencv_python2`
- `opencv_python` target -> `opencv_python2` (for Windows: `modules/python2/opencv_python2`)
