### PR TITLE
OCL: fixed test for ocl PlaneWarperTest

### DIFF
--- a/modules/stitching/test/ocl/test_warpers.cpp
+++ b/modules/stitching/test/ocl/test_warpers.cpp
@@ -139,7 +139,7 @@ OCL_TEST_F(PlaneWarperTest, Mat)
         OCL_OFF(warper->warp(src, K, R, INTER_LINEAR, BORDER_REPLICATE, dst));
         OCL_ON(warper->warp(usrc, K, R, INTER_LINEAR, BORDER_REPLICATE, udst));
 
-        Near(1e-4);
+        Near(1.5e-4);
     }
 }
 


### PR DESCRIPTION
fixed test for ocl PlaneWarperTest, found with test_loop_times = 30

check_regression=OCL*
test_filter=OCL*
build_examples=OFF
