### PR TITLE
OCL: fixed Erode and Dilate in case of kernel = Mat()

### DIFF
--- a/modules/imgproc/src/morph.cpp
+++ b/modules/imgproc/src/morph.cpp
@@ -1511,22 +1511,6 @@ static bool ocl_morphOp(InputArray _src, OutputArray _dst, InputArray _kernel,
     bool haveExtraMat = !_extraMat.empty();
     CV_Assert(actual_op <= 3 || haveExtraMat);
 
-    // try to use OpenCL kernel adopted for small morph kernel
-    if (dev.isIntel() && !(dev.type() & ocl::Device::TYPE_CPU) &&
-        ((ksize.width < 5 && ksize.height < 5 && esz <= 4) ||
-         (ksize.width == 5 && ksize.height == 5 && cn == 1)) &&
-         (iterations == 1))
-    {
-        if (ocl_morphSmall(_src, _dst, _kernel, anchor, borderType, op, actual_op, _extraMat))
-            return true;
-    }
-
-    if (iterations == 0 || kernel.rows*kernel.cols == 1)
-    {
-        _src.copyTo(_dst);
-        return true;
-    }
-
     if (!kernel.data)
     {
         kernel = getStructuringElement(MORPH_RECT, Size(1+iterations*2,1+iterations*2));
@@ -1541,6 +1525,22 @@ static bool ocl_morphOp(InputArray _src, OutputArray _dst, InputArray _kernel,
                                             ksize.height + (iterations-1)*(ksize.height-1)),
                                        anchor);
         iterations = 1;
+    }
+
+    // try to use OpenCL kernel adopted for small morph kernel
+    if (dev.isIntel() && !(dev.type() & ocl::Device::TYPE_CPU) &&
+        ((ksize.width < 5 && ksize.height < 5 && esz <= 4) ||
+         (ksize.width == 5 && ksize.height == 5 && cn == 1)) &&
+         (iterations == 1))
+    {
+        if (ocl_morphSmall(_src, _dst, kernel, anchor, borderType, op, actual_op, _extraMat))
+            return true;
+    }
+
+    if (iterations == 0 || kernel.rows*kernel.cols == 1)
+    {
+        _src.copyTo(_dst);
+        return true;
     }
 
 #ifdef ANDROID

--- a/modules/imgproc/test/ocl/test_filters.cpp
+++ b/modules/imgproc/test/ocl/test_filters.cpp
@@ -242,7 +242,7 @@ OCL_TEST_P(Erode, Mat)
     for (int j = 0; j < test_loop_times; j++)
     {
         random_roi();
-        Mat kernel = randomMat(kernelSize, CV_8UC1, 0, 3);
+        Mat kernel = ksize==0 ? Mat() : randomMat(kernelSize, CV_8UC1, 0, 3);
 
         OCL_OFF(cv::erode(src_roi, dst_roi, kernel, Point(-1, -1), iterations) );
         OCL_ON(cv::erode(usrc_roi, udst_roi, kernel, Point(-1, -1), iterations) );
@@ -264,7 +264,7 @@ OCL_TEST_P(Dilate, Mat)
     for (int j = 0; j < test_loop_times; j++)
     {
         random_roi();
-        Mat kernel = randomMat(kernelSize, CV_8UC1, 0, 3);
+        Mat kernel = ksize==0 ? Mat() : randomMat(kernelSize, CV_8UC1, 0, 3);
 
         OCL_OFF(cv::dilate(src_roi, dst_roi, kernel, Point(-1, -1), iterations) );
         OCL_ON(cv::dilate(usrc_roi, udst_roi, kernel, Point(-1, -1), iterations) );
@@ -413,7 +413,7 @@ OCL_INSTANTIATE_TEST_CASE_P(Filter, GaussianBlurTest, Combine(
 
 OCL_INSTANTIATE_TEST_CASE_P(Filter, Erode, Combine(
                             Values(CV_8UC1, CV_8UC3, CV_8UC4, CV_32FC1, CV_32FC3, CV_32FC4, CV_64FC1, CV_64FC4),
-                            Values(3, 5, 7),
+                            Values(0, 3, 5, 7), // kernel size, 0 means kernel = Mat()
                             Values(Size(0, 0)), //not used
                             Values((BorderType)BORDER_CONSTANT),
                             Values(1.0, 2.0, 3.0),
@@ -422,7 +422,7 @@ OCL_INSTANTIATE_TEST_CASE_P(Filter, Erode, Combine(
 
 OCL_INSTANTIATE_TEST_CASE_P(Filter, Dilate, Combine(
                             Values(CV_8UC1, CV_8UC3, CV_8UC4, CV_32FC1, CV_32FC3, CV_32FC4, CV_64FC1, CV_64FC4),
-                            Values(3, 5, 7),
+                            Values(0, 3, 5, 7), // kernel size, 0 means kernel = Mat()
                             Values(Size(0, 0)), // not used
                             Values((BorderType)BORDER_CONSTANT),
                             Values(1.0, 2.0, 3.0),


### PR DESCRIPTION
- fixed Erode and Dilate in case of kernel = Mat(),  found in performance test OCL_stitch_a123
- added accuracy tests for kernel = Mat()

test_modules=imgproc
test_filter=OCL_Erode_:OCL_Dilate_
check_regression=OCL_Erode_:OCL_Dilate_
build_examples=OFF
