### PR TITLE
#pragma warning4127 fixed for cvstd.inl.hpp

### DIFF
--- a/modules/core/include/opencv2/core/cvstd.inl.hpp
+++ b/modules/core/include/opencv2/core/cvstd.inl.hpp
@@ -219,11 +219,14 @@ template<typename _Tp, int n> static inline
 std::ostream& operator << (std::ostream& out, const Vec<_Tp, n>& vec)
 {
     out << "[";
-
+#ifdef _MSC_VER
 #pragma warning( push )
 #pragma warning( disable: 4127 )
+#endif
     if(Vec<_Tp, n>::depth < CV_32F)
+#ifdef _MSC_VER
 #pragma warning( pop )
+#endif
     {
         for (int i = 0; i < n - 1; ++i) {
             out << (int)vec[i] << ", ";


### PR DESCRIPTION
pragma warning(disable : 4127) added on file cvstd.inl.hpp . 
If in the sample files there are the need to print OpenCV structures, this add will avoid the warning on the Windows platform at compile time.
