### PR TITLE
Intel Summer School 2014 - Insert a new IPP func (as a test only)

### DIFF
--- a/modules/imgproc/src/color.cpp
+++ b/modules/imgproc/src/color.cpp
@@ -493,18 +493,6 @@ private:
     int depth;
 };
 
-struct IPPGeneralROIFunctor
-{
-    IPPGeneralROIFunctor(ippiGeneralFunc _func, IppiSize _roi_image) : func(_func), roi_image(_roi_image){}
-    bool operator()(const void *src, int srcStep, void *dst, int dstStep, int cols, int rows) const
-    {
-        return func ? func(src, srcStep, dst, dstStep, roi_image) >= 0 : false;
-    }
-private:
-    ippiGeneralFunc func;
-    IppiSize roi_image;
-};
-
 #endif
 
 ////////////////// Various 3/4-channel to 3/4-channel RGB transformations /////////////////
@@ -4311,16 +4299,14 @@ void cv::cvtColor( InputArray _src, OutputArray _dst, int code, int dcn )
                 _dst.create(dstSz, CV_MAKETYPE(depth, dcn));
                 dst = _dst.getMat();
 #if defined HAVE_IPP
-/*Intel Summer School - 2014. Test func*/
-    {
-        if (CvtColorIPPLoop(src, dst,
-            IPPGeneralROIFunctor((ippiGeneralFunc)ippiCopy_8u_C1R, ippiSize(dstSz.width, dstSz.height))))
-                    return;
+   {
+        if (ippStsNoErr == ippiCopy_8u_C1R(src.data, src.step, dst.data, dst.step,
+                ippiSize(dstSz.width, dstSz.height)))
+        return;
         setIppErrorStatus();
         break;
-    }
+   }
 #endif
-
                 src(Range(0, dstSz.height), Range::all()).copyTo(dst);
             }
             break;


### PR DESCRIPTION
New function was inserted into ImgProc module (color.cpp). 
Conversion: YUV2GRAY_420 
IPP function: ippiCopy_8u_C1R
Also, It was written a new functor for this function.
