### PR TITLE
Add a Matx constructor to Vec

### DIFF
--- a/modules/core/include/opencv2/core/matx.hpp
+++ b/modules/core/include/opencv2/core/matx.hpp
@@ -311,6 +311,7 @@ public:
     explicit Vec(const _Tp* values);
 
     Vec(const Vec<_Tp, cn>& v);
+    Vec(const Matx<_Tp, cn, 1>& m);
 
     static Vec all(_Tp alpha);
 
@@ -918,6 +919,10 @@ Vec<_Tp, cn>::Vec(const _Tp* values)
 template<typename _Tp, int cn> inline
 Vec<_Tp, cn>::Vec(const Vec<_Tp, cn>& m)
     : Matx<_Tp, cn, 1>(m.val) {}
+
+template<typename _Tp, int cn> inline
+Vec<_Tp, cn>::Vec(const Matx<_Tp, cn, 1>& m)
+    : Matx<_Tp, cn, 1>(m) {}
 
 template<typename _Tp, int cn> inline
 Vec<_Tp, cn>::Vec(const Matx<_Tp, cn, 1>& a, const Matx<_Tp, cn, 1>& b, Matx_AddOp op)


### PR DESCRIPTION
This allows you to use `Vec` interchangeably with `Matx<T,N,1>`, for example assigning the output of `Matx::row()` to a `Vec`.
