### PR TITLE
Fix filtering ROIs of images

### DIFF
--- a/modules/imgproc/src/filter.cpp
+++ b/modules/imgproc/src/filter.cpp
@@ -410,7 +410,7 @@ void FilterEngine::apply(const Mat& src, Mat& dst,
         dstOfs.y + srcRoi.height <= dst.rows );
 
     int y = start(src, srcRoi, isolated);
-    proceed( src.ptr(y)
+    proceed( src.data + y*src.step // Can't use Mat::ptr because may be outside ROI
              + srcRoi.x*src.elemSize(),
              (int)src.step, endY - startY,
              dst.ptr(dstOfs.y) +


### PR DESCRIPTION
Reverts one line from 8a4a1bb018426087d332ab2cfe859b5cdc521620. If filtering an ROI, we may want to sample the source image outside of the ROI. But then, `y` may be negative, and passing a negative `y` into `Mat::ptr` results in an assertion fail. Since accessing values outside of the ROI is a bit hacky anyway (that is, requires knowledge of internals), best to leave this as a raw `data + y*step` calculation instead of using `Mat::ptr`.
