### PR TITLE
Fixed perf test for cvtColor (YUV2RGBA_* conversions)

### DIFF
--- a/modules/imgproc/perf/perf_cvt_color.cpp
+++ b/modules/imgproc/perf/perf_cvt_color.cpp
@@ -155,14 +155,14 @@ ChPair getConversionInfo(int cvtMode)
     case CV_BGR5552BGR: case CV_BGR5552RGB:
     case CV_BGR5652BGR: case CV_BGR5652RGB:
     case CV_YUV2RGB_UYVY: case CV_YUV2BGR_UYVY:
-    case CV_YUV2RGBA_UYVY: case CV_YUV2BGRA_UYVY:
     case CV_YUV2RGB_YUY2: case CV_YUV2BGR_YUY2:
     case CV_YUV2RGB_YVYU: case CV_YUV2BGR_YVYU:
-    case CV_YUV2RGBA_YUY2: case CV_YUV2BGRA_YUY2:
-    case CV_YUV2RGBA_YVYU: case CV_YUV2BGRA_YVYU:
         return ChPair(2,3);
     case CV_BGR5552BGRA: case CV_BGR5552RGBA:
     case CV_BGR5652BGRA: case CV_BGR5652RGBA:
+    case CV_YUV2RGBA_UYVY: case CV_YUV2BGRA_UYVY:
+    case CV_YUV2RGBA_YUY2: case CV_YUV2BGRA_YUY2:
+    case CV_YUV2RGBA_YVYU: case CV_YUV2BGRA_YVYU:
         return ChPair(2,4);
     case CV_BGR2GRAY: case CV_RGB2GRAY:
     case CV_RGB2YUV_IYUV: case CV_RGB2YUV_YV12:


### PR DESCRIPTION
Thanks to @dkanafeev for pointing this out.
Merge with extra: Itseez/opencv_extra#204

check_regression=_CvtMode2_
test_modules=imgproc
build_examples=OFF
