### PR TITLE
OCL: DFT performance stabilization

### DIFF
--- a/modules/core/src/dxt.cpp
+++ b/modules/core/src/dxt.cpp
@@ -1832,7 +1832,8 @@ public:
             n *= radix;
         }
 
-        Mat tw(1, twiddle_size, CV_32FC2);
+        twiddles.create(1, twiddle_size, CV_32FC2);
+        Mat tw = twiddles.getMat(ACCESS_WRITE);
         float* ptr = tw.ptr<float>();
         int ptr_index = 0;
 
@@ -1853,7 +1854,6 @@ public:
                 }
             }
         }
-        twiddles = tw.getUMat(ACCESS_READ);
 
         buildOptions = format("-D LOCAL_SIZE=%d -D kercn=%d -D RADIX_PROCESS=%s",
                               dft_size, min_radix, radix_processing.c_str());


### PR DESCRIPTION
**Description**
Attempt to stabilize performance tests results for DFT: changed twiddle buffer creation. 
Instead of 
"MatAllocation->Fill twiddles buffer -> clCreateBuffer(.., CL_MEM_USE_HOST_PTR or CL_MEM_COPY_HOST_PTR, ..)" 
used 
"clCreateBuffer() -> clEnqueueMapBuffer() -> Fill twiddles buffer".

**Performance report**
http://ocl.itseez.com/intel/export/perf/pr/3121/report/

check_regression=_OCL_Dft*
test_filter=_OCL_Dft*
test_modules=core
build_examples=OFF
