### PR TITLE
Clarified parameter useExtrinsicGuess in solvePnP

### DIFF
--- a/modules/calib3d/doc/camera_calibration_and_3d_reconstruction.rst
+++ b/modules/calib3d/doc/camera_calibration_and_3d_reconstruction.rst
@@ -580,7 +580,7 @@ Finds an object pose from 3D-2D point correspondences.
 
     :param tvec: Output translation vector.
 
-    :param useExtrinsicGuess: If true (1), the function uses the provided  ``rvec``  and  ``tvec``  values as initial approximations of the rotation and translation vectors, respectively, and further optimizes them.
+    :param useExtrinsicGuess: Parameter used for ITERATIVE. If true (1), the function uses the provided  ``rvec``  and  ``tvec``  values as initial approximations of the rotation and translation vectors, respectively, and further optimizes them.
 
     :param flags: Method for solving a PnP problem:
 
@@ -614,7 +614,7 @@ Finds an object pose from 3D-2D point correspondences using the RANSAC scheme.
 
     :param tvec: Output translation vector.
 
-    :param useExtrinsicGuess: If true (1), the function uses the provided  ``rvec``  and  ``tvec`` values as initial approximations of the rotation and translation vectors, respectively, and further optimizes them.
+    :param useExtrinsicGuess: Parameter used for ITERATIVE. If true (1), the function uses the provided  ``rvec``  and  ``tvec`` values as initial approximations of the rotation and translation vectors, respectively, and further optimizes them.
 
     :param iterationsCount: Number of iterations.
 


### PR DESCRIPTION
I reckon that the parameter useExtrinsicGuess is only used for the ITERATIVE method - [see solvepnp.cpp](https://github.com/PhilLab/opencv/blob/patch-2/modules/calib3d/src/solvepnp.cpp#L51-L99).
This PR clarifies the documentation.

_However_, I'm puzzled by the fact that rvec and tvec are of the type OutputArray - should this be changed to InputOutputArray?
