### PR TITLE
cvtColor: Fixed range for 'v' channel for 8U images

### DIFF
--- a/modules/imgproc/doc/miscellaneous_transformations.rst
+++ b/modules/imgproc/doc/miscellaneous_transformations.rst
@@ -383,7 +383,7 @@ The function can do the following transformations:
 
         .. math::
 
-            L  \leftarrow 255/100 L, \; u  \leftarrow 255/354 (u + 134), \; v  \leftarrow 255/256 (v + 140)
+            L  \leftarrow 255/100 L, \; u  \leftarrow 255/354 (u + 134), \; v  \leftarrow 255/262 (v + 140)
 
     * 16-bit images
         (currently not supported)

--- a/modules/imgproc/src/color.cpp
+++ b/modules/imgproc/src/color.cpp
@@ -2046,7 +2046,7 @@ struct RGB2Luv_b
             {
                 dst[j] = saturate_cast<uchar>(buf[j]*2.55f);
                 dst[j+1] = saturate_cast<uchar>(buf[j+1]*0.72033898305084743f + 96.525423728813564f);
-                dst[j+2] = saturate_cast<uchar>(buf[j+2]*0.99609375f + 139.453125f);
+                dst[j+2] = saturate_cast<uchar>(buf[j+2]*0.9732824427480916f + 136.259541984732824f);
             }
         }
     }
@@ -2078,7 +2078,7 @@ struct Luv2RGB_b
             {
                 buf[j] = src[j]*(100.f/255.f);
                 buf[j+1] = (float)(src[j+1]*1.388235294117647f - 134.f);
-                buf[j+2] = (float)(src[j+2]*1.003921568627451f - 140.f);
+                buf[j+2] = (float)(src[j+2]*1.027450980392157f - 140.f);
             }
             cvt(buf, buf, dn);
 

--- a/modules/imgproc/test/test_color.cpp
+++ b/modules/imgproc/test/test_color.cpp
@@ -1168,8 +1168,8 @@ void CV_ColorLuvTest::convert_row_bgr2abc_32f_c3( const float* src_row, float* d
     {
         u_scale = 0.720338983f;
         u_bias = 96.5254237f;
-        v_scale = 0.99609375f;
-        v_bias = 139.453125f;
+        v_scale = 0.973282442f;
+        v_bias = 136.2595419f;
     }
 
     for( j = 0; j < n*3; j += 3 )
@@ -1221,8 +1221,8 @@ void CV_ColorLuvTest::convert_row_abc2bgr_32f_c3( const float* src_row, float* d
     {
         u_scale = 1.f/0.720338983f;
         u_bias = 96.5254237f;
-        v_scale = 1.f/0.99609375f;
-        v_bias = 139.453125f;
+        v_scale = 1.f/0.973282442f;
+        v_bias = 136.2595419f;
     }
 
     for( j = 0; j < n*3; j += 3 )


### PR DESCRIPTION
cvtColor RGB<>Luv: fixed range for 'v' channel: 262 instead of 256.
Thanks to Sergey Perepelkin for reporting this issue.
Merge with extra: Itseez/opencv_extra#210

check_regression=_CvtMode_
test_filter=_Color_
test_modules=imgproc
build_examples=OFF
