### PR TITLE
Extending stitching module

### DIFF
--- a/modules/python/src2/cv2.cpp
+++ b/modules/python/src2/cv2.cpp
@@ -116,6 +116,7 @@ typedef SimpleBlobDetector::Params SimpleBlobDetector_Params;
 typedef cvflann::flann_distance_t cvflann_flann_distance_t;
 typedef cvflann::flann_algorithm_t cvflann_flann_algorithm_t;
 
+typedef Stitcher::Status Status;
 
 static PyObject* failmsgp(const char *fmt, ...)
 {
@@ -444,6 +445,12 @@ template<>
 PyObject* pyopencv_from(const bool& value)
 {
     return PyBool_FromLong(value);
+}
+
+template<>
+PyObject* pyopencv_from(const Status& value)
+{
+    return PyInt_FromLong(value);
 }
 
 template<>

--- a/modules/stitching/include/opencv2/stitching.hpp
+++ b/modules/stitching/include/opencv2/stitching.hpp
@@ -55,7 +55,7 @@
 
 namespace cv {
 
-class CV_EXPORTS Stitcher
+class CV_EXPORTS_W Stitcher
 {
 public:
     enum { ORIG_RESOL = -1 };
@@ -67,23 +67,24 @@ public:
         ERR_CAMERA_PARAMS_ADJUST_FAIL = 3
     };
 
+   // Stitcher() {}
     // Creates stitcher with default parameters
     static Stitcher createDefault(bool try_use_gpu = false);
+    
+    CV_WRAP double registrationResol() const { return registr_resol_; }
+    CV_WRAP void setRegistrationResol(double resol_mpx) { registr_resol_ = resol_mpx; }
 
-    double registrationResol() const { return registr_resol_; }
-    void setRegistrationResol(double resol_mpx) { registr_resol_ = resol_mpx; }
+    CV_WRAP double seamEstimationResol() const { return seam_est_resol_; }
+    CV_WRAP void setSeamEstimationResol(double resol_mpx) { seam_est_resol_ = resol_mpx; }
 
-    double seamEstimationResol() const { return seam_est_resol_; }
-    void setSeamEstimationResol(double resol_mpx) { seam_est_resol_ = resol_mpx; }
+    CV_WRAP double compositingResol() const { return compose_resol_; }
+    CV_WRAP void setCompositingResol(double resol_mpx) { compose_resol_ = resol_mpx; }
 
-    double compositingResol() const { return compose_resol_; }
-    void setCompositingResol(double resol_mpx) { compose_resol_ = resol_mpx; }
+    CV_WRAP double panoConfidenceThresh() const { return conf_thresh_; }
+    CV_WRAP void setPanoConfidenceThresh(double conf_thresh) { conf_thresh_ = conf_thresh; }
 
-    double panoConfidenceThresh() const { return conf_thresh_; }
-    void setPanoConfidenceThresh(double conf_thresh) { conf_thresh_ = conf_thresh; }
-
-    bool waveCorrection() const { return do_wave_correct_; }
-    void setWaveCorrection(bool flag) { do_wave_correct_ = flag; }
+    CV_WRAP bool waveCorrection() const { return do_wave_correct_; }
+    CV_WRAP void setWaveCorrection(bool flag) { do_wave_correct_ = flag; }
 
     detail::WaveCorrectKind waveCorrectKind() const { return wave_correct_kind_; }
     void setWaveCorrectKind(detail::WaveCorrectKind kind) { wave_correct_kind_ = kind; }
@@ -127,21 +128,21 @@ public:
     const Ptr<detail::Blender> blender() const { return blender_; }
     void setBlender(Ptr<detail::Blender> b) { blender_ = b; }
 
-    Status estimateTransform(InputArrayOfArrays images);
+    CV_WRAP Status estimateTransform(InputArrayOfArrays images);
     Status estimateTransform(InputArrayOfArrays images, const std::vector<std::vector<Rect> > &rois);
 
-    Status composePanorama(OutputArray pano);
+    CV_WRAP Status composePanorama(OutputArray pano);
     Status composePanorama(InputArrayOfArrays images, OutputArray pano);
 
-    Status stitch(InputArrayOfArrays images, OutputArray pano);
+    CV_WRAP Status stitch(InputArrayOfArrays images, OutputArray pano);
     Status stitch(InputArrayOfArrays images, const std::vector<std::vector<Rect> > &rois, OutputArray pano);
 
     std::vector<int> component() const { return indices_; }
     std::vector<detail::CameraParams> cameras() const { return cameras_; }
-    double workScale() const { return work_scale_; }
+    CV_WRAP double workScale() const { return work_scale_; }
 
 private:
-    Stitcher() {}
+    //Stitcher() {}
 
     Status matchImages();
     Status estimateCameraParams();
@@ -174,6 +175,8 @@ private:
     double seam_work_aspect_;
     double warped_image_scale_;
 };
+
+CV_EXPORTS_W Ptr<Stitcher> createStitcher(bool try_use_gpu = false);
 
 } // namespace cv
 


### PR DESCRIPTION
[ IMP : Please don't merge. It is in initial testing phase ] 

Trying to extend stitching functions to Python. Right now only most basic functionality of Stitcher class is extended. 
eg:

```
img1 = cv2.imread('974-1.jpg')
img2 = cv2.imread('975-1.jpg')

a = cv2.createStitcher()
ret, pano = a.stitch([img1,img2])
cv2.imwrite('pano.png', pano)
```
