### PR TITLE
Fixed range for 'v' channel for 8U images

### DIFF
--- a/modules/core/include/opencv2/core/cuda/detail/color_detail.hpp
+++ b/modules/core/include/opencv2/core/cuda/detail/color_detail.hpp
@@ -1822,7 +1822,7 @@ namespace cv { namespace cuda { namespace device
 
             dst.x = saturate_cast<uchar>(dstf.x * 2.55f);
             dst.y = saturate_cast<uchar>(dstf.y * 0.72033898305084743f + 96.525423728813564f);
-            dst.z = saturate_cast<uchar>(dstf.z * 0.99609375f + 139.453125f);
+            dst.z = saturate_cast<uchar>(dstf.z * 0.9732824427480916f + 136.259541984732824f);
         }
 
         template <typename T, int scn, int dcn, bool srgb, int blueIdx> struct RGB2Luv;
@@ -1916,7 +1916,7 @@ namespace cv { namespace cuda { namespace device
 
             srcf.x = src.x * (100.f / 255.f);
             srcf.y = src.y * 1.388235294117647f - 134.f;
-            srcf.z = src.z * 1.003921568627451f - 140.f;
+            srcf.z = src.z * 1.027450980392157f - 140.f;
 
             Luv2RGBConvert_f<srgb, blueIdx>(srcf, dstf);
 

--- a/modules/imgproc/doc/miscellaneous_transformations.rst
+++ b/modules/imgproc/doc/miscellaneous_transformations.rst
@@ -380,7 +380,7 @@ The function can do the following transformations:
 
         .. math::
 
-            L  \leftarrow 255/100 L, \; u  \leftarrow 255/354 (u + 134), \; v  \leftarrow 255/256 (v + 140)
+            L  \leftarrow 255/100 L, \; u  \leftarrow 255/354 (u + 134), \; v  \leftarrow 255/262 (v + 140)
 
     * 16-bit images
         (currently not supported)

--- a/modules/imgproc/src/color.cpp
+++ b/modules/imgproc/src/color.cpp
@@ -2090,7 +2090,7 @@ struct RGB2Luv_b
             {
                 dst[j] = saturate_cast<uchar>(buf[j]*2.55f);
                 dst[j+1] = saturate_cast<uchar>(buf[j+1]*0.72033898305084743f + 96.525423728813564f);
-                dst[j+2] = saturate_cast<uchar>(buf[j+2]*0.99609375f + 139.453125f);
+                dst[j+2] = saturate_cast<uchar>(buf[j+2]*0.9732824427480916f + 136.259541984732824f);
             }
         }
     }
@@ -2122,7 +2122,7 @@ struct Luv2RGB_b
             {
                 buf[j] = src[j]*(100.f/255.f);
                 buf[j+1] = (float)(src[j+1]*1.388235294117647f - 134.f);
-                buf[j+2] = (float)(src[j+2]*1.003921568627451f - 140.f);
+                buf[j+2] = (float)(src[j+2]*1.027450980392157f - 140.f);
             }
             cvt(buf, buf, dn);
 

--- a/modules/imgproc/src/opencl/cvtcolor.cl
+++ b/modules/imgproc/src/opencl/cvtcolor.cl
@@ -1747,7 +1747,7 @@ __kernel void BGR2Luv(__global const uchar * src, int src_step, int src_offset,
 
                 dst[0] = SAT_CAST(L * 2.55f);
                 dst[1] = SAT_CAST(fma(u, 0.72033898305084743f, 96.525423728813564f));
-                dst[2] = SAT_CAST(fma(v, 0.99609375f, 139.453125f));
+                dst[2] = SAT_CAST(fma(v, 0.9732824427480916f, 136.259541984732824f));
 
                 ++y;
                 dst += dst_step;
@@ -1843,7 +1843,7 @@ __kernel void Luv2BGR(__global const uchar * src, int src_step, int src_offset,
                 float d, X, Y, Z;
                 float L = src[0]*(100.f/255.f);
                 float u = fma(convert_float(src[1]), 1.388235294117647f, -134.f);
-                float v = fma(convert_float(src[2]), 1.003921568627451f, - 140.f);
+                float v = fma(convert_float(src[2]), 1.027450980392157f, - 140.f);
                 Y = (L + 16.f) * (1.f/116.f);
                 Y = Y*Y*Y;
                 d = (1.f/13.f)/L;

--- a/modules/imgproc/test/test_color.cpp
+++ b/modules/imgproc/test/test_color.cpp
@@ -1170,8 +1170,8 @@ void CV_ColorLuvTest::convert_row_bgr2abc_32f_c3( const float* src_row, float* d
     {
         u_scale = 0.720338983f;
         u_bias = 96.5254237f;
-        v_scale = 0.99609375f;
-        v_bias = 139.453125f;
+        v_scale = 0.973282442f;
+        v_bias = 136.2595419f;
     }
 
     for( j = 0; j < n*3; j += 3 )
@@ -1223,8 +1223,8 @@ void CV_ColorLuvTest::convert_row_abc2bgr_32f_c3( const float* src_row, float* d
     {
         u_scale = 1.f/0.720338983f;
         u_bias = 96.5254237f;
-        v_scale = 1.f/0.99609375f;
-        v_bias = 139.453125f;
+        v_scale = 1.f/0.973282442f;
+        v_bias = 136.2595419f;
     }
 
     for( j = 0; j < n*3; j += 3 )


### PR DESCRIPTION
Transfer fix from 2.4 branch: Itseez/opencv#3137
Merge with extra: Itseez/opencv_extra#211

check_regression=_CvtMode_:_OCL_CvtColor*
test_filter=_Color_
test_modules=imgproc
build_examples=OFF
