### PR TITLE
Fix UnicodeDecodeError during OpenCV compilation (Python 3.4.1)

### DIFF
--- a/modules/python/src2/hdr_parser.py
+++ b/modules/python/src2/hdr_parser.py
@@ -739,8 +739,8 @@ class CppHeaderParser(object):
         """
         self.hname = hname
         decls = []
-        f = open(hname, "rt")
-        linelist = list(f.readlines())
+        f = open(hname, "rt", encoding='UTF-8')
+        linelist = f.readlines()
         f.close()
 
         # states:


### PR DESCRIPTION
OpenCV compilation fails with UnicodeDecodeError at 99% when using Python 3.4.1
