### PR TITLE
VideoCapture did not detect an unopened camera

### DIFF
--- a/modules/videoio/src/cap.cpp
+++ b/modules/videoio/src/cap.cpp
@@ -621,15 +621,15 @@ Ptr<IVideoCapture> VideoCapture::createCameraCapture(int index)
         {
 #ifdef HAVE_DSHOW
         case CV_CAP_DSHOW:
-            capture = Ptr<IVideoCapture>(new cv::VideoCapture_DShow(index));
-            if (capture)
+            capture = makePtr<VideoCapture_DShow>(index);
+            if (capture && capture.dynamicCast<VideoCapture_DShow>()->isOpened())
                 return capture;
             break; // CV_CAP_DSHOW
 #endif
 #ifdef HAVE_INTELPERC
         case CV_CAP_INTELPERC:
-            capture = Ptr<IVideoCapture>(new cv::VideoCapture_IntelPerC());
-            if (capture)
+            capture = makePtr<VideoCapture_IntelPerC>();
+            if (capture && capture.dynamicCast<VideoCapture_IntelPerC>()->isOpened())
                 return capture;
             break; // CV_CAP_INTEL_PERC
 #endif

--- a/modules/videoio/src/cap_dshow.cpp
+++ b/modules/videoio/src/cap_dshow.cpp
@@ -1590,7 +1590,7 @@ bool videoInput::isFrameNew(int id){
 
 bool videoInput::isDeviceSetup(int id){
 
-    if(id<devicesFound && VDList[id]->readyToCapture)return true;
+    if(id>=0 && id<devicesFound && VDList[id]->readyToCapture)return true;
     else return false;
 
 }


### PR DESCRIPTION
Resolving [issue 3880](http://code.opencv.org/issues/3880): 

"I believe that during the creation of the new videoio module, VideoCapture was broken by using cv::Ptr : When using Direct Show (and most probably any other camera module), isOpened() always reports "true" even if no camera has been opened"

I don't know how VideoCapture_IntelPerC behaves but I assume/hope my code does not break it.

The change in cap_dshow.cpp is actually not necessary to fix the bug itself but I think checking for non-negativity would be a good idea. (In this line the actual run-time exception leading to the discovery of the bug was thrown.)
