### PR TITLE
OCL: ORB.cl - fixed redefinition of val

### DIFF
--- a/modules/features2d/src/opencl/orb.cl
+++ b/modules/features2d/src/opencl/orb.cl
@@ -207,7 +207,7 @@ ORB_computeDescriptor(__global const uchar* imgbuf, int imgstep, int imgoffset0,
             pattern += 12*2;
 
         #elif WTA_K == 4
-            int t0, t1, t2, t3, k, val;
+            int t0, t1, t2, t3, k;
             int a, b;
 
             t0 = GET_VALUE(0); t1 = GET_VALUE(1);


### PR DESCRIPTION
When setting WTA_K to 4, int val is redefined leading to a console error output and thus slowing the processing down massively (roughly 2 frames per second).

FYI, this is the console output at runtime:

```
OpenCL program build log: -D ORB_DESCRIPTORS -D WTA_K=4
:156:24: error: redefinition of 'val'
int t0, t1, t2, t3, k, val;
                       ^
:124:5: note: previous definition is here
int val;
```
