### PR TITLE
Doc: update video processing tutorial code for OpenCV v2.4.9 and v3a

### DIFF
--- a/doc/tutorials/ios/video_processing/video_processing.rst
+++ b/doc/tutorials/ios/video_processing/video_processing.rst
@@ -199,11 +199,16 @@ From here you can start processing video frames. For example the following snipp
     {
         // Do some OpenCV stuff with the image
         Mat image_copy;
-        cvtColor(image, image_copy, CV_BGRA2BGR);
+        cvtColor(image, image_copy, COLOR_BGR2GRAY);
 
         // invert image
         bitwise_not(image_copy, image_copy);
-        cvtColor(image_copy, image, CV_BGR2BGRA);
+
+        //Convert BGR to BGRA (three channel to four channel)
+        Mat bgr;
+        cvtColor(image_copy, bgr, COLOR_GRAY2BGR);
+
+        cvtColor(bgr, image, COLOR_BGR2BGRA);
     }
 
 


### PR DESCRIPTION
The code from the [OpenCV iOS video processing tutorial](http://docs.opencv.org/trunk/doc/tutorials/ios/video_processing/video_processing.html) is outdated and crashes at runtime. 

See this:
http://answers.opencv.org/question/40249/colorcpp3380-error-215-scn-3-scn-4-depth-cv_8u-in/

This pull request addresses this issue. 
