### PR TITLE
OCL: Disabled native_sqrt for double

### DIFF
--- a/modules/core/src/opencl/arithm.cl
+++ b/modules/core/src/opencl/arithm.cl
@@ -293,7 +293,11 @@
 #define PROCESS_ELEM storedst(pown(srcelem1, srcelem2))
 
 #elif defined OP_SQRT
+#if depth <= 5
 #define PROCESS_ELEM storedst(native_sqrt(srcelem1))
+#else
+#define PROCESS_ELEM storedst(sqrt(srcelem1))
+#endif
 
 #elif defined OP_LOG
 #define PROCESS_ELEM \


### PR DESCRIPTION
Disabled `native_sqrt` for `double`, since it may be not implemented and gives compilation error. 
Also it doesn't guarantee necessary accuracy.

check_regression=_OCL_Arithm_Sqrt*
test_filter=_OCL_Arithm_Sqrt*
test_modules=core
build_examples=OFF
