### PR TITLE
OCL: Removed redundant clFinish() after unmap

### DIFF
--- a/modules/core/src/ocl.cpp
+++ b/modules/core/src/ocl.cpp
@@ -3959,7 +3959,6 @@ public:
             u->markDeviceMemMapped(false);
             CV_Assert( (retval = clEnqueueUnmapMemObject(q,
                                 (cl_mem)u->handle, u->data, 0, 0, 0)) == CL_SUCCESS );
-            CV_OclDbgAssert(clFinish(q) == CL_SUCCESS);
             u->data = 0;
         }
         else if( u->copyOnMap() && u->deviceCopyObsolete() )


### PR DESCRIPTION
Thanks to @krodyush for pointing this.

**Performance report**
http://ocl.itseez.com/intel/export/perf/pr/3167/report/
Performance report contains some performance regression which possibly caused by instability in performance testing results.

check_regression=_OCL_
test_filter=_OCL_
build_examples=OFF
