### PR TITLE
Fixed crash in SSE implementation of FREAK descriptor when number of pai...

### DIFF
--- a/modules/features2d/src/freak.cpp
+++ b/modules/features2d/src/freak.cpp
@@ -394,7 +394,7 @@ void FREAK::computeImpl( const Mat& image, std::vector<KeyPoint>& keypoints, Mat
                 (*ptr) = result128;
                 ++ptr;
             }
-            ptr -= 8;
+            ptr -= (FREAK_NB_PAIRS/128)*2;
 #else
             // extracting descriptor preserving the order of SSE version
             int cnt = 0;


### PR DESCRIPTION
Fixed crash in SSE implementation of FREAK descriptor when number of pairs is set to something other than 512.

See http://code.opencv.org/issues/3889 for more details
