### PR TITLE
OCL: small fixes for Laplacian, Canny, etc

### DIFF
--- a/modules/imgproc/src/canny.cpp
+++ b/modules/imgproc/src/canny.cpp
@@ -195,20 +195,20 @@ static bool ocl_Canny(InputArray _src, OutputArray _dst, float low_thresh, float
             hysteresis (add weak edges if they are connected with strong edges)
     */
 
+    int sizey = lSizeY / PIX_PER_WI;
+    if (sizey == 0)
+        sizey = 1;
+
+    size_t globalsize[2] = { size.width, (size.height + PIX_PER_WI - 1) / PIX_PER_WI }, localsize[2] = { lSizeX, sizey };
+
     ocl::Kernel edgesHysteresis("stage2_hysteresis", ocl::imgproc::canny_oclsrc,
-                                format("-D STAGE2 -D PIX_PER_WI=%d", PIX_PER_WI));
+                                format("-D STAGE2 -D PIX_PER_WI=%d -D LOCAL_X=%d -D LOCAL_Y=%d",
+                                PIX_PER_WI, lSizeX, sizey));
 
     if (edgesHysteresis.empty())
         return false;
 
     edgesHysteresis.args(ocl::KernelArg::ReadWrite(map));
-
-    int sizey = lSizeY / PIX_PER_WI;
-    if (sizey == 0)
-        sizey = 1;
-
-    size_t globalsize[2] = { size.width, size.height / PIX_PER_WI }, localsize[2] = { lSizeX, sizey };
-
     if (!edgesHysteresis.run(2, globalsize, localsize, false))
         return false;
 

--- a/modules/imgproc/src/deriv.cpp
+++ b/modules/imgproc/src/deriv.cpp
@@ -672,7 +672,8 @@ static bool ocl_Laplacian5(InputArray _src, OutputArray _dst,
     size_t wgs = dev.maxWorkGroupSize();
     size_t lmsz = dev.localMemSize();
     size_t src_step = _src.step(), src_offset = _src.offset();
-    
+    const size_t tileSizeYmax = wgs / tileSizeX;
+
     // workaround for Nvidia: 3 channel vector type takes 4*elem_size in local memory
     int loc_mem_cn = dev.vendorID() == ocl::Device::VENDOR_NVIDIA && cn == 3 ? 4 : cn;
 
@@ -680,9 +681,9 @@ static bool ocl_Laplacian5(InputArray _src, OutputArray _dst,
         (
          (borderType == BORDER_CONSTANT || borderType == BORDER_REPLICATE) ||
          ((borderType == BORDER_REFLECT || borderType == BORDER_WRAP || borderType == BORDER_REFLECT_101) &&
-          (_src.cols() >= kernelX.cols && _src.rows() >= kernelY.cols))
+          (_src.cols() >= (int) (kernelX.cols + tileSizeX) && _src.rows() >= (int) (kernelY.cols + tileSizeYmax)))
         ) &&
-        (tileSizeX * tileSizeYmin  <= wgs) &&
+        (tileSizeX * tileSizeYmin <= wgs) &&
         (LAPLACIAN_LOCAL_MEM(tileSizeX, tileSizeYmin, kernelX.cols, loc_mem_cn * 4) <= lmsz)
        )
     {
@@ -691,7 +692,7 @@ static bool ocl_Laplacian5(InputArray _src, OutputArray _dst,
         int dtype = CV_MAKE_TYPE(ddepth, cn);
         int wdepth = CV_32F;
 
-        size_t tileSizeY = wgs / tileSizeX;
+        size_t tileSizeY = tileSizeYmax;
         while ((tileSizeX * tileSizeY > wgs) || (LAPLACIAN_LOCAL_MEM(tileSizeX, tileSizeY, kernelX.cols, loc_mem_cn * 4) > lmsz))
         {
             tileSizeY /= 2;

--- a/modules/imgproc/src/opencl/covardata.cl
+++ b/modules/imgproc/src/opencl/covardata.cl
@@ -28,13 +28,13 @@
 //fedcba|abcdefgh|hgfedcb
 #define EXTRAPOLATE(x, maxV) \
     { \
-        (x) = clamp(min( mad24((maxV)-1,2,-(x))+1 , max((x),-(x)-1) ), 0, (maxV)-1); \
+        (x) = min( mad24((maxV)-1,2,-(x))+1 , max((x),-(x)-1) ); \
     }
 #elif defined BORDER_REFLECT_101 || defined BORDER_REFLECT101
 //gfedcb|abcdefgh|gfedcba
 #define EXTRAPOLATE(x, maxV) \
     { \
-        (x) = clamp(min( mad24((maxV)-1,2,-(x)), max((x),-(x)) ), 0, (maxV)-1); \
+        (x) = min( mad24((maxV)-1,2,-(x)), max((x),-(x)) ); \
     }
 #else
 #error No extrapolation method

--- a/modules/imgproc/src/opencl/filterSep_singlePass.cl
+++ b/modules/imgproc/src/opencl/filterSep_singlePass.cl
@@ -62,13 +62,13 @@
 // fedcba|abcdefgh|hgfedcb
 #define EXTRAPOLATE(x, maxV) \
     { \
-        (x) = clamp(min(((maxV)-1)*2-(x)+1, max((x),-(x)-1) ), 0, (maxV)-1); \
+        (x) = min(((maxV)-1)*2-(x)+1, max((x),-(x)-1) ); \
     }
 #elif defined BORDER_REFLECT_101 || defined BORDER_REFLECT101
 // gfedcb|abcdefgh|gfedcba
 #define EXTRAPOLATE(x, maxV) \
     { \
-        (x) = clamp(min(((maxV)-1)*2-(x), max((x),-(x)) ), 0, (maxV)-1); \
+        (x) = min(((maxV)-1)*2-(x), max((x),-(x)) ); \
     }
 #else
 #error No extrapolation method

--- a/modules/imgproc/src/opencl/laplacian5.cl
+++ b/modules/imgproc/src/opencl/laplacian5.cl
@@ -61,13 +61,13 @@ __kernel void sumConvert(__global const uchar * src1ptr, int src1_step, int src1
 // fedcba|abcdefgh|hgfedcb
 #define EXTRAPOLATE(x, maxV) \
     { \
-        (x) = clamp(min(((maxV)-1)*2-(x)+1, max((x),-(x)-1) ), 0, (maxV)-1); \
+        (x) = min(((maxV)-1)*2-(x)+1, max((x),-(x)-1) ); \
     }
 #elif defined BORDER_REFLECT_101
 // gfedcb|abcdefgh|gfedcba
 #define EXTRAPOLATE(x, maxV) \
     { \
-        (x) = clamp(min(((maxV)-1)*2-(x), max((x),-(x)) ), 0, (maxV)-1); \
+        (x) = min(((maxV)-1)*2-(x), max((x),-(x)) ); \
     }
 #else
 #error No extrapolation method


### PR DESCRIPTION
Also fixed extrapolation in sepFilter2D and eigenValsVecs.

check_regression=OCL_Laplacian_:OCL_Canny_:OCL_Corner_:OCL_Sobel_:OCL_GaussianBlur_:OCL_Scharr_
test_filter=OCL_Laplacian_:OCL_Canny_:OCL_Corner_:OCL_Sobel_:OCL_GaussianBlur_:OCL_Scharr_
build_examples=OFF
test_modules=imgproc
