### PR TITLE
fix blobdetector

### DIFF
--- a/modules/features2d/src/blobdetector.cpp
+++ b/modules/features2d/src/blobdetector.cpp
@@ -282,7 +282,7 @@ void SimpleBlobDetector::detectImpl(const cv::Mat& image, std::vector<cv::KeyPoi
     else
         grayscaleImage = image;
 
-    if (grayscaleImage.type != CV_8UC1){
+    if (grayscaleImage.type() != CV_8UC1){
         CV_Error(CV_StsUnsupportedFormat, "Blob detector only supports 8-bit images!");
     }
     vector < vector<Center> > centers;


### PR DESCRIPTION
There should be an explicit convert to CV_8UC1 before passing on.
Else somebody calling the detect function from a simpleblobdetector on a 16bit image will trigger an error in the treshold function which doesn't support this.

More info: http://answers.opencv.org/question/41038/simpleblobdetector-for-16-bits-depht/?answer=41115#post-id-41115
