### PR TITLE
Fixed bad non-ASCII character in how_to_scan_images.cpp

### DIFF
--- a/samples/cpp/tutorial_code/core/how_to_scan_images/how_to_scan_images.cpp
+++ b/samples/cpp/tutorial_code/core/how_to_scan_images/how_to_scan_images.cpp
@@ -1,4 +1,4 @@
-﻿#include <opencv2/core.hpp>
+#include <opencv2/core.hpp>
 #include <opencv2/core/utility.hpp>
 #include "opencv2/imgcodecs.hpp"
 #include <opencv2/highgui.hpp>


### PR DESCRIPTION
Causes a compile error in gcc:

```
[ 97%] Building CXX object samples/cpp/CMakeFiles/tutorial_how_to_scan_images.dir/tutorial_code/core/how_to_scan_images/how_to_scan_images.cpp.o
/global/homes/j/jkua/lib/build/opencv/opencv-3.0.0-alpha/samples/cpp/tutorial_code/core/how_to_scan_images/how_to_scan_images.cpp:1: error: stray '\357' in program
/global/homes/j/jkua/lib/build/opencv/opencv-3.0.0-alpha/samples/cpp/tutorial_code/core/how_to_scan_images/how_to_scan_images.cpp:1: error: stray '\273' in program
/global/homes/j/jkua/lib/build/opencv/opencv-3.0.0-alpha/samples/cpp/tutorial_code/core/how_to_scan_images/how_to_scan_images.cpp:1: error: stray '\277' in program
/global/homes/j/jkua/lib/build/opencv/opencv-3.0.0-alpha/samples/cpp/tutorial_code/core/how_to_scan_images/how_to_scan_images.cpp:1: error: stray '#' in program
/global/homes/j/jkua/lib/build/opencv/opencv-3.0.0-alpha/samples/cpp/tutorial_code/core/how_to_scan_images/how_to_scan_images.cpp:1: error: expected constructor, destructor, or type conversion before '<' token
```
