### PR TITLE
Support invokation of cv windows in parallel to a qt app

### DIFF
--- a/modules/highgui/src/window_QT.cpp
+++ b/modules/highgui/src/window_QT.cpp
@@ -740,14 +740,14 @@ double cvGetOpenGlProp_QT(const char* name)
 GuiReceiver::GuiReceiver() : bTimeOut(false), nb_windows(0)
 {
     doesExternalQAppExist = (QApplication::instance() != 0);
-    if ( doesExternalQAppExist ) {
-        moveToThread(QApplication::instance()->thread());
-    }
     icvInitSystem(&parameterSystemC, parameterSystemV);
 
     timer = new QTimer(this);
     QObject::connect(timer, SIGNAL(timeout()), this, SLOT(timeOut()));
     timer->setSingleShot(true);
+    if ( doesExternalQAppExist ) {
+        moveToThread(QApplication::instance()->thread());
+    }
 }
 
 


### PR DESCRIPTION
Current code fails when
1. Running a generic qt application in one thread
2. Spinning off imshows from parallel background threads

with the following error:

```
QObject::moveToThread: Widgets cannot be moved to a new thread
QPixmap: It is not safe to use pixmaps outside the GUI thread
QObject: Cannot create children for a parent that is in a different thread.
(Parent is Oxygen::WidgetStateEngine(0x2fb1aa0), parent's thread is QThread(0x1dbc260), current thread is QThread(0x7f4de0001f80)
QObject: Cannot create children for a parent that is in a different thread.
```

which basically boils down to the `moveToThread` line for moving CvWindow (aka QWidget) objects [here](https://github.com/Itseez/opencv/blob/2.4/modules/highgui/src/window_QT.cpp#L1529) in `window_QT.cpp`.

The right way to do this in Qt is to move a worker class in the external QApplication's thread and invoke methods on it's QEvent queue to create this window. Luckily, it turns out most of the infrastructure is already here, just not working perfectly. i.e. there is a GuiReceiver class which can handle `invokeMethod` requests from parallel threads to fire up CvWindows.

This pull request does the following that wasn't already being done:
- Checks if there is an external QApplication and moves the GuiReceiver there.
- Fixes the invokeMethod requests to adopt the proper behaviour - auto for detecting whether it is in thread or out-of-thread as well as blocking or non-blocking depending on ensuing commands.

There is yet other issues remaining for multi-threading, but this at least fixes one of them.
