### PR TITLE
OCL: Remove mul24

### DIFF
--- a/modules/core/src/opencl/meanstddev.cl
+++ b/modules/core/src/opencl/meanstddev.cl
@@ -68,7 +68,7 @@ __kernel void meanStdDev(__global const uchar * srcptr, int src_step, int src_of
 #endif
         {
 #ifdef HAVE_SRC_CONT
-            int src_index = mul24(id, srcTSIZE);
+            int src_index = id * srcTSIZE;
 #else
             int src_index = mad24(id / cols, src_step, mul24(id % cols, srcTSIZE));
 #endif

--- a/modules/core/src/opencl/reduce.cl
+++ b/modules/core/src/opencl/reduce.cl
@@ -578,13 +578,13 @@ __kernel void reduce(__global const uchar * srcptr, int src_step, int src_offset
     for (int grain = groupnum * WGS * kercn; id < total; id += grain)
     {
 #ifdef HAVE_SRC_CONT
-        int src_index = mul24(id, srcTSIZE);
+        int src_index = id * srcTSIZE;
 #else
         int src_index = mad24(id / cols, src_step, mul24(id % cols, srcTSIZE));
 #endif
 #ifdef HAVE_SRC2
 #ifdef HAVE_SRC2_CONT
-        int src2_index = mul24(id, srcTSIZE);
+        int src2_index = id * srcTSIZE;
 #else
         int src2_index = mad24(id / cols, src2_step, mul24(id % cols, srcTSIZE));
 #endif


### PR DESCRIPTION
Remove mul24 since `id` can be larger 2^23. If id is not in [-2^23, 2^23-1], the multiplication result is implementation-defined.
For example, 4K 3-channel: 3840 × 2160 × 3 = 24883200 > 2^23.

check_regression=OCL_Norm_:OCL_MeanStdDev_
test_filter=OCL_Norm_:OCL_MeanStdDev_
build_examples=OFF
test_modules=core
