### PR TITLE
[samples/pyhton] fix common {LINE->CV}_AA

### DIFF
--- a/samples/python2/common.py
+++ b/samples/python2/common.py
@@ -71,8 +71,8 @@ def mtx2rvec(R):
     return axis * np.arctan2(s, c)
 
 def draw_str(dst, (x, y), s):
-    cv2.putText(dst, s, (x+1, y+1), cv2.FONT_HERSHEY_PLAIN, 1.0, (0, 0, 0), thickness = 2, lineType=cv2.LINE_AA)
-    cv2.putText(dst, s, (x, y), cv2.FONT_HERSHEY_PLAIN, 1.0, (255, 255, 255), lineType=cv2.LINE_AA)
+    cv2.putText(dst, s, (x+1, y+1), cv2.FONT_HERSHEY_PLAIN, 1.0, (0, 0, 0), thickness = 2, lineType=cv2.CV_AA)
+    cv2.putText(dst, s, (x, y), cv2.FONT_HERSHEY_PLAIN, 1.0, (255, 255, 255), lineType=cv2.CV_AA)
 
 class Sketcher:
     def __init__(self, windowname, dests, colors_func):


### PR DESCRIPTION
```
$ python turing.py 

USAGE: turing.py [-o <output.avi>]

Press ESC to stop.

Traceback (most recent call last):
  File "turing.py", line 62, in <module>
    draw_str(vis, (20, 20), 'frame %d' % frame_i)
  File "/home/pkoch/sandbox/opencv/samples/python2/common.py", line 74, in draw_str
    cv2.putText(dst, s, (x+1, y+1), cv2.FONT_HERSHEY_PLAIN, 1.0, (0, 0, 0), thickness = 2, lineType=cv2.LINE_AA)
AttributeError: 'module' object has no attribute 'LINE_AA'
```
- http://docs.opencv.org/modules/core/doc/drawing_functions.html#line
