### PR TITLE
fix for issue 3858 (XIMEA cam support)

### DIFF
--- a/modules/videoio/src/cap_ximea.cpp
+++ b/modules/videoio/src/cap_ximea.cpp
@@ -1,8 +1,10 @@
 #include "precomp.hpp"
 
+#ifdef WIN32
 #include "xiApi.h"
-#include "xiExt.h"
-#include "m3Api.h"
+#else
+#include <m3api/xiApi.h>
+#endif
 
 /**********************************************************************************/
 
@@ -156,7 +158,7 @@ bool CvCaptureCAM_XIMEA::grabFrame()
     image.size = sizeof(XI_IMG);
     int mvret = xiGetImage( hmv, timeout, &image);
 
-    if(mvret == MM40_ACQUISITION_STOPED)
+    if(mvret == XI_ACQUISITION_STOPED)
     {
         xiStartAcquisition(hmv);
         mvret = xiGetImage(hmv, timeout, &image);


### PR DESCRIPTION
Newer XIMEA API packages don't include xiExt.h header anymore which causes compilation to fail, so remove unneeded #include's.
Also use correct include path on Linux.
