### PR TITLE
Several fixes for GStreamer support in OpenCV

### DIFF
--- a/modules/videoio/test/test_video_io.cpp
+++ b/modules/videoio/test/test_video_io.cpp
@@ -490,7 +490,6 @@ void CV_VideoIOTest::SpecificVideoTest(const string& dir, const cvtest::VideoFor
     if (fourcc == VideoWriter::fourcc('M', 'P', 'E', 'G') && ext == "mkv")
         allowed_extra_frames = 1;
 
-/*
     if (FRAME_COUNT < IMAGE_COUNT || FRAME_COUNT > IMAGE_COUNT + allowed_extra_frames)
     {
         ts->printf(ts->LOG, "\nFrame count checking for video_%s.%s...\n", fourcc_str.c_str(), ext.c_str());
@@ -505,7 +504,7 @@ void CV_VideoIOTest::SpecificVideoTest(const string& dir, const cvtest::VideoFor
         ts->set_failed_test_info(ts->FAIL_BAD_ACCURACY);
         return;
     }
-*/
+
     for (int i = 0; (size_t)i < IMAGE_COUNT; i++)
     {
         Mat frame; cap >> frame;


### PR DESCRIPTION
- Accurate ASYC task handling for both GStreamer generations.
- Correct video duration request for videos for both GStreamer generations.
- More accurate pipeline destruction for both GStreamer generations.
- Correct color space conversion plugin for GStreamer 1.0.
