### PR TITLE
bug #3631 fixed

### DIFF
--- a/modules/highgui/src/cap_ffmpeg_impl.hpp
+++ b/modules/highgui/src/cap_ffmpeg_impl.hpp
@@ -630,7 +630,7 @@ bool CvCapture_FFMPEG::grabFrame()
     int got_picture;
 
     int count_errs = 0;
-    const int max_number_of_attempts = 1 << 16;
+    const int max_number_of_attempts = 1 << 9;
 
     if( !ic || !video_st )  return false;
 


### PR DESCRIPTION
Bug #3631. The constant max_number_of_attempts is too high and causes an unnecessary delay (around 4 seconds) after the last frame read from the video. Fixed to a smaller value.
