### PR TITLE
Fix implicit narrowing error in initializer list

### DIFF
--- a/modules/python/src2/cv2.cpp
+++ b/modules/python/src2/cv2.cpp
@@ -219,7 +219,7 @@ static bool pyopencv_to(PyObject* o, Mat& m, const ArgInfo info)
 
     if( PyInt_Check(o) )
     {
-        double v[] = {PyInt_AsLong((PyObject*)o), 0., 0., 0.};
+        double v[] = {(double)PyInt_AsLong((PyObject*)o), 0., 0., 0.};
         m = Mat(4, 1, CV_64F, v).clone();
         return true;
     }


### PR DESCRIPTION
The implicit narrowing in the initializer list throws a compiler error for some compilers with C++11 support turned on. The specific error message is: "error: narrowing conversion of 'PyInt_AsLong(((PyObject*)o))' from 'long int' to 'double' inside { }".

Tested on Clang 5.1.0 and Mac OS X 10.9.4.
