### PR TITLE
fix: medianFilter sometimes crash on in-place filtering with IPP

### DIFF
--- a/modules/imgproc/src/smooth.cpp
+++ b/modules/imgproc/src/smooth.cpp
@@ -2163,7 +2163,7 @@ void cv::medianBlur( InputArray _src0, OutputArray _dst, int ksize )
             ippDataType, CV_MAT_CN(type), &bufSize) >= 0) \
         { \
             Ipp8u * buffer = ippsMalloc_8u(bufSize); \
-            IppStatus status = ippiFilterMedianBorder_##flavor(src0.ptr<ippType>(), (int)src0.step, \
+            IppStatus status = ippiFilterMedianBorder_##flavor(src.ptr<ippType>(), (int)src.step, \
                 dst.ptr<ippType>(), (int)dst.step, dstRoiSize, maskSize, \
                 ippBorderRepl, (ippType)0, buffer); \
             ippsFree(buffer); \
@@ -2178,6 +2178,11 @@ void cv::medianBlur( InputArray _src0, OutputArray _dst, int ksize )
     {
         Ipp32s bufSize;
         IppiSize dstRoiSize = ippiSize(dst.cols, dst.rows), maskSize = ippiSize(ksize, ksize);
+        Mat src;
+        if( dst.data != src0.data )
+            src = src0;
+        else
+            src0.copyTo(src);
 
         int type = src0.type();
         if (type == CV_8UC1)


### PR DESCRIPTION
[IPP docs](https://software.intel.com/en-us/node/504115) say that in-place operation is not supported for most filters.

check_regression=_edian_
