### PR TITLE
the samples from the main repository should not depend on modules from opencv_contrib

### DIFF
--- a/samples/cpp/CMakeLists.txt
+++ b/samples/cpp/CMakeLists.txt
@@ -6,7 +6,7 @@
 SET(OPENCV_CPP_SAMPLES_REQUIRED_DEPS opencv_core opencv_imgproc opencv_flann
     opencv_imgcodecs opencv_videoio opencv_highgui opencv_ml opencv_video
     opencv_objdetect opencv_photo opencv_features2d opencv_calib3d
-    opencv_stitching opencv_videostab opencv_shape opencv_xfeatures2d)
+    opencv_stitching opencv_videostab opencv_shape)
 
 ocv_check_dependencies(${OPENCV_CPP_SAMPLES_REQUIRED_DEPS})
 


### PR DESCRIPTION
in particular, all the samples that may need SIFT or SURF, should be moved to opencv_contrib/modules/xfeatures2d/samples
