### PR TITLE
Bugfix in Gradient Boosted Tree

### DIFF
--- a/modules/ml/src/gbt.cpp
+++ b/modules/ml/src/gbt.cpp
@@ -10,6 +10,8 @@ using namespace std;
 
 #define CV_CMP_FLOAT(a,b) ((a) < (b))
 static CV_IMPLEMENT_QSORT_EX( icvSortFloat, float, CV_CMP_FLOAT, float)
+#define CV_CMP_INT(a,b) ((a) < (b))
+static CV_IMPLEMENT_QSORT_EX( icvSortInt, int, CV_CMP_INT, int)
 
 //===========================================================================
 static string ToString(int i)
@@ -282,6 +284,7 @@ CvGBTrees::train( const CvMat* _train_data, int _tflag,
                 sample_idx = cvCreateMat( 1, sample_idx_len, CV_32S );
                 for (int i=0; i<sample_idx_len; ++i)
                     sample_idx->data.i[i] = _sample_idx->data.i[i];
+                icvSortInt(sample_idx->data.i, sample_idx_len, 0);
             } break;
             case CV_8S:
             case CV_8U:
@@ -298,7 +301,6 @@ CvGBTrees::train( const CvMat* _train_data, int _tflag,
             } break;
             default: CV_Error(CV_StsUnmatchedFormats, "_sample_idx should be a 32sC1, 8sC1 or 8uC1 vector.");
         }
-        icvSortFloat(sample_idx->data.fl, sample_idx_len, 0);
     }
     else
     {


### PR DESCRIPTION
There was a bug where an integer array was sorted as a floating point array, corrupting the data in the process. 

It was only happening when a vector representing the subset to be used as training data was used.

BTW, a similar correction would be needed in the master branch.
