### PR TITLE
Fixed compilation errors under VS 2010 and Win 7

### DIFF
--- a/modules/highgui/src/cap_msmf.cpp
+++ b/modules/highgui/src/cap_msmf.cpp
@@ -1500,11 +1500,13 @@ HRESULT ImageGrabber::startGrabbing(void)
             DebugPrintOut(L"IMAGEGRABBER VIDEODEVICE %i: MESessionStopped \n", ig_DeviceID);
             break;
         }
+#if (WINVER >= 0x0602) // Available since Win 8
         if (met == MEVideoCaptureDeviceRemoved)
         {
             DebugPrintOut(L"IMAGEGRABBER VIDEODEVICE %i: MEVideoCaptureDeviceRemoved \n", ig_DeviceID);
             break;
         }
+#endif
         if ((met == MEError) || (met == MENonFatalError))
         {
             pEvent->GetStatus(&hrStatus);
@@ -4110,7 +4112,7 @@ const GUID CvVideoWriter_MSMF::FourCC2GUID(int fourcc)
             return MFVideoFormat_DVSD; break;
         case CV_FOURCC_MACRO('d', 'v', 's', 'l'):
                 return MFVideoFormat_DVSL; break;
-#if (WINVER >= _WIN32_WINNT_WIN8)
+#if (WINVER >= 0x0602)
         case CV_FOURCC_MACRO('H', '2', '6', '3'):   // Available only for Win 8 target.
                 return MFVideoFormat_H263; break;
 #endif

--- a/modules/highgui/src/cap_msmf.hpp
+++ b/modules/highgui/src/cap_msmf.hpp
@@ -333,6 +333,7 @@ MAKE_ENUM(MediaEventType) MediaEventTypePairs[] = {
     MAKE_ENUM_PAIR(MediaEventType, MEAudioSessionDisconnected),
     MAKE_ENUM_PAIR(MediaEventType, MEAudioSessionExclusiveModeOverride),
     MAKE_ENUM_PAIR(MediaEventType, MESinkV1Anchor),
+#if (WINVER >= 0x0602) // Available since Win 8
     MAKE_ENUM_PAIR(MediaEventType, MECaptureAudioSessionVolumeChanged),
     MAKE_ENUM_PAIR(MediaEventType, MECaptureAudioSessionDeviceRemoved),
     MAKE_ENUM_PAIR(MediaEventType, MECaptureAudioSessionFormatChanged),
@@ -340,6 +341,7 @@ MAKE_ENUM(MediaEventType) MediaEventTypePairs[] = {
     MAKE_ENUM_PAIR(MediaEventType, MECaptureAudioSessionExclusiveModeOverride),
     MAKE_ENUM_PAIR(MediaEventType, MECaptureAudioSessionServerShutdown),
     MAKE_ENUM_PAIR(MediaEventType, MESinkV2Anchor),
+#endif
     MAKE_ENUM_PAIR(MediaEventType, METrustUnknown),
     MAKE_ENUM_PAIR(MediaEventType, MEPolicyChanged),
     MAKE_ENUM_PAIR(MediaEventType, MEContentProtectionMessage),
@@ -361,9 +363,11 @@ MAKE_ENUM(MediaEventType) MediaEventTypePairs[] = {
     MAKE_ENUM_PAIR(MediaEventType, METransformHaveOutput),
     MAKE_ENUM_PAIR(MediaEventType, METransformDrainComplete),
     MAKE_ENUM_PAIR(MediaEventType, METransformMarker),
+#if (WINVER >= 0x0602) // Available since Win 8
     MAKE_ENUM_PAIR(MediaEventType, MEByteStreamCharacteristicsChanged),
     MAKE_ENUM_PAIR(MediaEventType, MEVideoCaptureDeviceRemoved),
     MAKE_ENUM_PAIR(MediaEventType, MEVideoCaptureDevicePreempted),
+#endif
     MAKE_ENUM_PAIR(MediaEventType, MEReservedMax)
 };
 MAKE_MAP(MediaEventType) MediaEventTypeMap(MediaEventTypePairs, MediaEventTypePairs + sizeof(MediaEventTypePairs) / sizeof(MediaEventTypePairs[0]));
@@ -1050,7 +1054,11 @@ class StreamSink :
 {
 public:
     // IUnknown methods
+#if defined(_MSC_VER) && _MSC_VER >= 1700  // '_Outptr_result_nullonfailure_' SAL is avaialable since VS 2012
     STDMETHOD(QueryInterface)(REFIID riid, _Outptr_result_nullonfailure_ void **ppv)
+#else
+    STDMETHOD(QueryInterface)(REFIID riid, void **ppv)
+#endif
     {
         if (ppv == nullptr) {
             return E_POINTER;
@@ -2389,7 +2397,11 @@ public:
         }
         return cRef;
     }
+#if defined(_MSC_VER) && _MSC_VER >= 1700  // '_Outptr_result_nullonfailure_' SAL is avaialable since VS 2012
     STDMETHOD(QueryInterface)(REFIID riid, _Outptr_result_nullonfailure_ void **ppv)
+#else
+    STDMETHOD(QueryInterface)(REFIID riid, void **ppv)
+#endif
     {
         if (ppv == nullptr) {
             return E_POINTER;


### PR DESCRIPTION
MSMF capture module after recently introduced changes doesn't compile successfully under VS 2010, Win 7 and SDK 7.
Some constants (representing media states), macros (like _WIN32_WINNT_WIN8) and some lexical constructs (SAL) are undefined or unavailable in this environment
