### PR TITLE
Fix linking error under Win 7 (MinCore_Downlevel.lib cannot be imported for Win 7 or earlier)

### DIFF
--- a/modules/highgui/src/cap_msmf.cpp
+++ b/modules/highgui/src/cap_msmf.cpp
@@ -78,7 +78,9 @@
 #pragma comment(lib, "mfuuid")
 #pragma comment(lib, "Strmiids")
 #pragma comment(lib, "Mfreadwrite")
+#if (WINVER >= 0x0602) // Available since Win 8
 #pragma comment(lib, "MinCore_Downlevel")
+#endif
 
 #include <mferror.h>
 


### PR DESCRIPTION
Because binaries that link to MinCore.lib or MinCore_Downlevel.lib are not designed to work on Windows 7, Windows Server 2008 R2 or earlier (http://msdn.microsoft.com/en-us/library/windows/desktop/hh802935%28v=vs.85%29.aspx) so MinCore_Downlevel.lib can be imported only if target is Windows 8 or newer.
