### PR TITLE
Adding support for GDAL float32 types

### DIFF
--- a/modules/imgcodecs/src/grfmt_gdal.cpp
+++ b/modules/imgcodecs/src/grfmt_gdal.cpp
@@ -123,14 +123,14 @@ int gdal2opencv( const GDALDataType& gdalType, const int& channels ){
             if( channels == 3 ){ return CV_32SC3; }
             if( channels == 4 ){ return CV_32SC4; }
             return -1;
-        
+
         /// Float32
         case GDT_Float32:
             if (channels == 1){ return CV_32FC1; }
             if (channels == 3){ return CV_32FC3; }
             if (channels == 4){ return CV_32FC4; }
             return -1;
-        
+    
         default:
             std::cout << "Unknown GDAL Data Type" << std::endl;
             std::cout << "Type: " << GDALGetDataTypeName(gdalType) << std::endl;
@@ -230,8 +230,8 @@ double range_cast( const GDALDataType& gdalType, const int& cvDepth, const doubl
     }
 
     // float32 -> float32
-    if(gdalType == GDT_Float32 && cvDepth == CV_32F){
-    	return value;
+    if( gdalType == GDT_Float32 && cvDepth == CV_32F ){
+        return value;
     }
 
     std::cout << GDALGetDataTypeName( gdalType ) << std::endl;


### PR DESCRIPTION
I came across a few file formats that could not be loaded giving the error unknown type Float32 from gdal. Fixing that made it write out alot of range convert warnings which also have been fixed in this commit.

Now one can do:

```
    cv::Mat dem = cv::imread(path, cv::IMREAD_LOAD_GDAL | cv::IMREAD_ANYDEPTH);
    std::cout << dem.rows << " " << dem.cols << " " << dem.type();
```

on file types like asc (common dem format as a Ascii text file)
