### PR TITLE
Fixed CMake problems with MSMF capture configuration

### DIFF
--- a/cmake/OpenCVFindLibsVideo.cmake
+++ b/cmake/OpenCVFindLibsVideo.cmake
@@ -228,6 +228,7 @@ if(WITH_DSHOW)
 endif(WITH_DSHOW)
 
 # --- VideoInput/Microsoft Media Foundation ---
+ocv_clear_vars(HAVE_MSMF)
 if(WITH_MSMF)
   check_include_file(Mfapi.h HAVE_MSMF)
 endif(WITH_MSMF)

--- a/modules/highgui/CMakeLists.txt
+++ b/modules/highgui/CMakeLists.txt
@@ -123,6 +123,7 @@ if (WIN32 AND HAVE_DSHOW)
 endif()
 
 if (WIN32 AND HAVE_MSMF)
+  list(APPEND highgui_srcs src/cap_msmf.hpp)
   list(APPEND highgui_srcs src/cap_msmf.cpp)
 endif()
 


### PR DESCRIPTION
Now, disabling WITH_MSMF option in CMake doesn't prevent adding cap_msmf source files to the highui project. Additionally not all cap_msmf source files are under control of CMake.
Attached patch fixes these problems.
