### PR TITLE
Fixed MSMF video capture (camera) issues

### DIFF
--- a/modules/highgui/src/cap_msmf.cpp
+++ b/modules/highgui/src/cap_msmf.cpp
@@ -1462,7 +1462,6 @@ void ImageGrabber::stopGrabbing()
 
 HRESULT ImageGrabber::startGrabbing(void)
 {
-    _ComPtr<IMFMediaEvent> pEvent = NULL;
     PROPVARIANT var;
     PropVariantInit(&var);
     HRESULT hr = ig_pSession->SetTopology(0, ig_pTopology);
@@ -1470,6 +1469,7 @@ HRESULT ImageGrabber::startGrabbing(void)
     hr = ig_pSession->Start(&GUID_NULL, &var);
     for(;;)
     {
+        _ComPtr<IMFMediaEvent> pEvent = NULL;
         HRESULT hrStatus = S_OK;
         MediaEventType met;
         if(!ig_pSession) break;


### PR DESCRIPTION
1. First patch fixes problems with finding suitable frame format when videoDevice::findType() is called with default parameters during video capture object initialization which causes reporting its state as closed after initialization (function isOpened() returns false).
   cv::VideoCapture cap(CV_CAP_MSMF);
   bool state = cap.isOpened();  // always false
2. Second patch fixes assertion warnings thrown when frames are being grabbed ('atlmfc\include\atlcomcli.h   Line:177   Expression: p==0'). These warnings occur because smart pointer is not reset at every loop (in ImageGrabber::startGrabbing).
