### PR TITLE
fixing some wrong CPP prefixes - still old interface

### DIFF
--- a/doc/tutorials/introduction/display_image/display_image.rst
+++ b/doc/tutorials/introduction/display_image/display_image.rst
@@ -83,8 +83,8 @@ After checking that the image data was loaded correctly, we want to display our 
 
 .. container:: enumeratevisibleitemswithsquare
 
-   + *CV_WINDOW_AUTOSIZE* is the only supported one if you do not use the Qt backend. In this case the window size will take up the size of the image it shows. No resize permitted!
-   + *CV_WINDOW_NORMAL* on Qt you may use this to allow window resize. The image will resize itself according to the current window size. By using the | operator you also need to specify if you would like the image to keep its aspect ratio (*CV_WINDOW_KEEPRATIO*) or not (*CV_WINDOW_FREERATIO*).
+   + *WINDOW_AUTOSIZE* is the only supported one if you do not use the Qt backend. In this case the window size will take up the size of the image it shows. No resize permitted!
+   + *WINDOW_NORMAL* on Qt you may use this to allow window resize. The image will resize itself according to the current window size. By using the | operator you also need to specify if you would like the image to keep its aspect ratio (*WINDOW_KEEPRATIO*) or not (*WINDOW_FREERATIO*).
 
 .. literalinclude:: ../../../../samples/cpp/tutorial_code/introduction/display_image/display_image.cpp
    :language: cpp

--- a/doc/tutorials/introduction/linux_gcc_cmake/linux_gcc_cmake.rst
+++ b/doc/tutorials/introduction/linux_gcc_cmake/linux_gcc_cmake.rst
@@ -46,7 +46,7 @@ Let's use a simple program such as DisplayImage.cpp shown below.
           printf("No image data \n");
           return -1;
       }
-      namedWindow("Display Image", CV_WINDOW_AUTOSIZE );
+      namedWindow("Display Image", WINDOW_AUTOSIZE );
       imshow("Display Image", image);
 
       waitKey(0);


### PR DESCRIPTION
Fix for the remarks in http://code.opencv.org/issues/3083 
- Changed the documentation compared to the loaded code snippets in the display_image section
- Changed the right commands, without CV_ in front, in the linux tutorial

For the prefixes it was still necessary to include
      #include <opencv2/highgui/highgui_c.h>
which basically seems a very wrong approach to me.
