### PR TITLE
set ffmpeg mutex to NULL on destruction.

### DIFF
--- a/modules/videoio/src/cap_ffmpeg_impl.hpp
+++ b/modules/videoio/src/cap_ffmpeg_impl.hpp
@@ -493,6 +493,7 @@ static int LockCallBack(void **mutex, AVLockOp op)
             localMutex->destroy();
             free(localMutex);
             localMutex = NULL;
+            *mutex = NULL;
         break;
     }
     return 0;


### PR DESCRIPTION
The Mutex manager registered with ffmpeg must reset the mutex to NULL after destruction, otherwise ffmpeg will give the invalid mutex to the next mutex manager when it asks it to CREATE a new mutex.
See ffmpeg code: http://git.videolan.org/?p=ffmpeg.git;a=blob;f=libavcodec/utils.c;h=28c5785398fcf11a3d3c70a8cd09e9df798e2734;hb=HEAD#l3423
