### PR TITLE
Solves issue #3925

### DIFF
--- a/modules/videoio/doc/reading_and_writing_video.rst
+++ b/modules/videoio/doc/reading_and_writing_video.rst
@@ -270,6 +270,8 @@ Sets a property in the ``VideoCapture``.
 
         * **CV_CAP_PROP_RECTIFICATION** Rectification flag for stereo cameras (note: only supported by DC1394 v 2.x backend currently)
 
+        * **CV_CAP_PROP_OUTPUT_FORMAT** Output color format, one of ``CV_CAP_ANDROID_GREY_FRAME``, ``CV_CAP_ANDROID_COLOR_FRAME_BGR``, ``CV_CAP_ANDROID_COLOR_FRAME_RGB``, ``CV_CAP_ANDROID_COLOR_FRAME_BGRA``, ``CV_CAP_ANDROID_COLOR_FRAME_RGBA`` or ``CV_CAP_ANDROID_COLOR_FRAME_YUV420sp`` (note: currently only for Android)
+
     :param value: Value of the property.
 
 

--- a/modules/videoio/include/opencv2/videoio/videoio_c.h
+++ b/modules/videoio/include/opencv2/videoio/videoio_c.h
@@ -178,9 +178,11 @@ enum
     CV_CAP_PROP_IRIS          =36,
     CV_CAP_PROP_SETTINGS      =37,
 
-    CV_CAP_PROP_AUTOGRAB      =1024, // property for videoio class CvCapture_Android only
-    CV_CAP_PROP_SUPPORTED_PREVIEW_SIZES_STRING=1025, // readonly, tricky property, returns cpnst char* indeed
-    CV_CAP_PROP_PREVIEW_FORMAT=1026, // readonly, tricky property, returns cpnst char* indeed
+    // Android specific properties
+    CV_CAP_PROP_AUTOGRAB = 1024, // property for CvCapture_Android only
+    CV_CAP_PROP_SUPPORTED_PREVIEW_SIZES_STRING = 1025, // readonly, tricky property, returns cpnst char* indeed
+    CV_CAP_PROP_PREVIEW_FORMAT = 1026, // readonly, tricky property, returns cpnst char* indeed
+    CV_CAP_PROP_OUTPUT_FORMAT = 1027, // property for CvCapture_Android only, but can be used for others is theory
 
     // OpenNI map generators
     CV_CAP_OPENNI_DEPTH_GENERATOR = 1 << 31,
@@ -320,7 +322,9 @@ enum
     CV_CAP_ANDROID_GREY_FRAME  = 1,  //Y
     CV_CAP_ANDROID_COLOR_FRAME_RGB = 2,
     CV_CAP_ANDROID_COLOR_FRAME_BGRA = 3,
-    CV_CAP_ANDROID_COLOR_FRAME_RGBA = 4
+    CV_CAP_ANDROID_COLOR_FRAME_RGBA = 4,
+    CV_CAP_ANDROID_COLOR_FRAME_YUV420sp = 5, //Default native color format for Android camera, a.k.a YUV NV21
+    CV_CAP_ANDROID_COLOR_FRAME_YUV_NV21 = CV_CAP_ANDROID_COLOR_FRAME_YUV420sp
 };
 
 // supported Android camera flash modes


### PR DESCRIPTION
```
- [android] Added CV_CAP_PROP_OUTPUT_FORMAT to indicate desired output format for CvCapture_Android
- [android] Added YUV420sp output format for CvCapture_Android
```

Solves the following: http://code.opencv.org/issues/3925.

Does not break existing functionality, as long as the `int flag` is not used in `VideoCapture::retrieve(OutputArray image, int flag)` for indicating the output format. This is the main thing this PR aims to change: Instead of this, e.g `VideoCapture::set(CV_CAP_PROP_OUTPUT_FORMAT, CV_CAP_PROP_ANDROID_COLOR_FRAME_BGRA)` should be set before reading the frame. 
