### PR TITLE
Remove ATL dependency from MSMF capture code.

### DIFF
--- a/modules/highgui/src/cap_msmf.cpp
+++ b/modules/highgui/src/cap_msmf.cpp
@@ -72,6 +72,7 @@
 #include <stdarg.h>
 #include <string.h>
 
+#ifdef _MSC_VER
 #pragma warning(disable:4503)
 #pragma comment(lib, "mfplat")
 #pragma comment(lib, "mf")
@@ -80,6 +81,7 @@
 #pragma comment(lib, "Mfreadwrite")
 #if (WINVER >= 0x0602) // Available since Win 8
 #pragma comment(lib, "MinCore_Downlevel")
+#endif
 #endif
 
 #include <mferror.h>
@@ -260,7 +262,7 @@ public:
 #include "ppltasks_winrt.h"
 #endif
 #else
-#include <atlbase.h>
+#include <comdef.h>
 #endif
 
 struct IMFMediaType;

--- a/modules/highgui/src/cap_msmf.hpp
+++ b/modules/highgui/src/cap_msmf.hpp
@@ -600,27 +600,65 @@ hr = orig.As(&obj);
 #define _ComPtr Microsoft::WRL::ComPtr
 #else
 
+#define _COM_SMARTPTR_DECLARE(T,var) T ## Ptr var
+
 template <class T>
-class ComPtr : public ATL::CComPtr<T>
+class ComPtr
 {
 public:
     ComPtr() throw()
     {
     }
-    ComPtr(int nNull) throw() :
-        CComPtr<T>((T*)nNull)
+    ComPtr(int nNull) throw()
+    {
+        assert(nNull == 0);
+        p = NULL;
+    }
+    ComPtr(T* lp) throw()
+    {
+        p = lp;
+    }
+    ComPtr(_In_ const ComPtr<T>& lp) throw()
+    {
+        p = lp.p;
+    }
+    virtual ~ComPtr()
     {
     }
-    ComPtr(T* lp) throw() :
-        CComPtr<T>(lp)
 
+    T** operator&() throw()
     {
+        assert(p == NULL);
+        return p.operator&();
     }
-    ComPtr(_In_ const CComPtr<T>& lp) throw() :
-        CComPtr<T>(lp.p)
+    T* operator->() const throw()
     {
+        assert(p != NULL);
+        return p.operator->();
     }
-    virtual ~ComPtr() {}
+    bool operator!() const throw()
+    {
+        return p.operator==(NULL);
+    }
+    bool operator==(_In_opt_ T* pT) const throw()
+    {
+        return p.operator==(pT);
+    }
+    // For comparison to NULL
+    bool operator==(int nNull) const
+    {
+        assert(nNull == 0);
+        return p.operator==(NULL);
+    }
+
+    bool operator!=(_In_opt_ T* pT) const throw()
+    {
+        return p.operator!=(pT);
+    }
+    operator bool()
+    {
+        return p.operator!=(NULL);
+    }
 
     T* const* GetAddressOf() const throw()
     {
@@ -634,7 +672,7 @@ public:
 
     T** ReleaseAndGetAddressOf() throw()
     {
-        InternalRelease();
+        p.Release();
         return &p;
     }
 
@@ -642,27 +680,38 @@ public:
     {
         return p;
     }
-    ComPtr& operator=(decltype(__nullptr)) throw()
+
+    // Attach to an existing interface (does not AddRef)
+    void Attach(_In_opt_ T* p2) throw()
     {
-        InternalRelease();
-        return *this;
+        p.Attach(p2);
     }
-    ComPtr& operator=(_In_ const int nNull) throw()
+    // Detach the interface (does not Release)
+    T* Detach() throw()
     {
-        ASSERT(nNull == 0);
-        (void)nNull;
-        InternalRelease();
-        return *this;
+        return p.Detach();
     }
-    unsigned long Reset()
+    _Check_return_ HRESULT CopyTo(_Deref_out_opt_ T** ppT) throw()
     {
-        return InternalRelease();
+        assert(ppT != NULL);
+        if (ppT == NULL)
+            return E_POINTER;
+        *ppT = p;
+        if (p != NULL)
+            p->AddRef();
+        return S_OK;
     }
+
+    void Reset()
+    {
+        p.Release();
+    }
+
     // query for U interface
     template<typename U>
     HRESULT As(_Inout_ U** lp) const throw()
     {
-        return p->QueryInterface(__uuidof(U), (void**)lp);
+        return p->QueryInterface(__uuidof(U), reinterpret_cast<void**>(lp));
     }
     // query for U interface
     template<typename U>
@@ -671,19 +720,8 @@ public:
         return p->QueryInterface(__uuidof(U), reinterpret_cast<void**>(lp->ReleaseAndGetAddressOf()));
     }
 private:
-    unsigned long InternalRelease() throw()
-    {
-        unsigned long ref = 0;
-        T* temp = p;
-
-        if (temp != nullptr)
-        {
-            p = nullptr;
-            ref = temp->Release();
-        }
-
-        return ref;
-    }
+    _COM_SMARTPTR_TYPEDEF(T, __uuidof(T));
+    _COM_SMARTPTR_DECLARE(T, p);
 };
 
 #define _ComPtr ComPtr
@@ -2262,6 +2300,11 @@ public:
 // succeed but return a nullptr pointer. By default, the list does not allow nullptr
 // pointers.
 
+#ifdef _MSC_VER
+#pragma warning(push)
+#pragma warning(disable: 4127) // constant expression
+#endif
+
 template <class T, bool NULLABLE = FALSE>
 class ComPtrList : public List<T*>
 {
@@ -2351,6 +2394,10 @@ protected:
         return hr;
     }
 };
+
+#ifdef _MSC_VER
+#pragma warning(pop)
+#endif
 
 /* Be sure to declare webcam device capability in manifest
   For better media capture support, add the following snippet with correct module name to the project manifest


### PR DESCRIPTION
Current MSMF code uses WRL smart pointers if it's compiled in Win RT and SDK 8 environment and ATL smart pointers otherwise. Due to this ATL dependency it's impossible to build the module using MinGW or VS Express because they don't support ATL.
Declaring ComPtr wrapper class (mimicking WRL smart pointer) using _com_ptr_t instead of ATL's CComPtr would make this more portable.
