### PR TITLE
fix photo::cloning::IlluminationChange when IPP is used

### DIFF
--- a/modules/photo/src/seamless_cloning.hpp
+++ b/modules/photo/src/seamless_cloning.hpp
@@ -543,19 +543,17 @@ void Cloning::illum_change(Mat &I, Mat &mask, Mat &wmask, Mat &cloned, float alp
     Mat mag = Mat(I.size(),CV_32FC3);
     magnitude(srx32,sry32,mag);
 
-    Mat magnitude_mask = mag != 0;
-
     Mat multX, multY, multx_temp, multy_temp;
 
     multiply(srx32,pow(alpha,beta),multX);
     pow(mag,-1*beta, multx_temp);
-    multiply(multX,multx_temp,multX);
-    multX.copyTo(srx32, magnitude_mask);
+    multiply(multX,multx_temp,srx32);
+    patchNaNs(srx32);
 
     multiply(sry32,pow(alpha,beta),multY);
     pow(mag,-1*beta, multy_temp);
-    multiply(multY,multy_temp,multY);
-    multY.copyTo(sry32, magnitude_mask);
+    multiply(multY,multy_temp,sry32);
+    patchNaNs(sry32);
 
     Mat zeroMask = (srx32 != 0);
 


### PR DESCRIPTION
In the discussion of PR #3268, it appears that, under cerain circumstances, the cloning method IlluminationChange could fail and generate black images (except for a 1 px widr border).
This failure was triggered only when IPP librairies were used. It appears that cv::pow yields to different results depending on the implementation.
Most notably, the default implemtation considers that 0^(negative float) is 0, where the IPP implementation yields NaN.

The proposed patch fixes this by applying a mask to the relevant parts of the image.
