### PR TITLE
fix tiff loader: fix check for infinity on 64bit machines

### DIFF
--- a/modules/highgui/src/grfmt_tiff.cpp
+++ b/modules/highgui/src/grfmt_tiff.cpp
@@ -207,10 +207,12 @@ bool  TiffDecoder::readData( Mat& img )
             if(!is_tiled)
                 TIFFGetField( tif, TIFFTAG_ROWSPERSTRIP, &tile_height0 );
 
-            if( tile_width0 <= 0 )
+            uint32 infinity = -1; // default value for TIFFTAG_ROWSPERSTRIP is 2**32-1
+
+            if( tile_width0 == 0 || tile_width0 == infinity )
                 tile_width0 = m_width;
 
-            if( tile_height0 <= 0 )
+            if( tile_height0 == 0 || tile_height0 == infinity )
                 tile_height0 = m_height;
 
             AutoBuffer<uchar> _buffer( size_t(8) * tile_height0*tile_width0);


### PR DESCRIPTION
Tiff loader crashed on 64bit machine if tiff header field Rows/Strip was set to infinity (==2^32-1).
