### PR TITLE
Turn off superres accuracy tests if video i/o is not supported.

### DIFF
--- a/modules/superres/test/test_precomp.hpp
+++ b/modules/superres/test/test_precomp.hpp
@@ -60,4 +60,17 @@
 #include "opencv2/superres/superres.hpp"
 #include "input_array_utility.hpp"
 
+#if defined(HAVE_XINE)         || \
+    defined(HAVE_GSTREAMER)    || \
+    defined(HAVE_QUICKTIME)    || \
+    defined(HAVE_QTKIT)        || \
+    defined(HAVE_AVFOUNDATION) || \
+    defined(HAVE_FFMPEG)       || \
+    defined(HAVE_MSMF)         || \
+    defined(HAVE_VFW)
+# define BUILD_WITH_VIDEO_INPUT_SUPPORT 1
+#else
+# define BUILD_WITH_VIDEO_INPUT_SUPPORT 0
+#endif
+
 #endif

--- a/modules/superres/test/test_superres.cpp
+++ b/modules/superres/test/test_superres.cpp
@@ -42,6 +42,8 @@
 
 #include "test_precomp.hpp"
 
+#if BUILD_WITH_VIDEO_INPUT_SUPPORT
+
 class AllignedFrameSource : public cv::superres::FrameSource
 {
 public:
@@ -291,3 +293,5 @@ TEST_F(SuperResolution, BTVL1_OCL)
     RunTest(cv::superres::createSuperResolution_BTVL1_OCL());
 }
 #endif
+
+#endif // BUILD_WITH_VIDEO_INPUT_SUPPORT


### PR DESCRIPTION
Superres accuracy tests use video as frame source and cannot be executed on platforms without video i/o support like Android.
