### PR TITLE
Fixed DirectShow video capture issues.

### DIFF
--- a/modules/highgui/src/cap_dshow.cpp
+++ b/modules/highgui/src/cap_dshow.cpp
@@ -2578,6 +2578,7 @@ int videoInput::start(int deviceID, videoDevice *VD){
 
             if( setSizeAndSubtype(VD, VD->tryWidth, VD->tryHeight, VD->tryVideoType) ){
                 VD->setSize(VD->tryWidth, VD->tryHeight);
+                VD->videoType = VD->tryVideoType;
                 foundSize = true;
             } else {
                 // try specified size with all formats
@@ -2588,6 +2589,7 @@ int videoInput::start(int deviceID, videoDevice *VD){
                     if(verbose)printf("SETUP: trying format %s @ %i by %i\n", guidStr, VD->tryWidth, VD->tryHeight);
                     if( setSizeAndSubtype(VD, VD->tryWidth, VD->tryHeight, mediaSubtypes[i]) ){
                         VD->setSize(VD->tryWidth, VD->tryHeight);
+                        VD->videoType = mediaSubtypes[i];
                         foundSize = true;
                         break;
                     }


### PR DESCRIPTION
1. Set correct value of sample size when calling IAMStreamConfig::SetFormat function. For non-RGB media type it can be set to zero value.
   (See http://msdn.microsoft.com/en-us/library/windows/desktop/dd373477%28v=vs.85%29.aspx)
   This fixes a bug reported in http://code.opencv.org/issues/3864.
2. Fixed media type GUID for I420 format. FCC code bytes should be placed in the reverse order.
3. Fixed getting proper FCC property value.
