### PR TITLE
Exposing the FAST detector threshold for ORB

### DIFF
--- a/modules/features2d/include/opencv2/features2d.hpp
+++ b/modules/features2d/include/opencv2/features2d.hpp
@@ -317,7 +317,7 @@ public:
     enum { kBytes = 32, HARRIS_SCORE=0, FAST_SCORE=1 };
 
     CV_WRAP explicit ORB(int nfeatures = 500, float scaleFactor = 1.2f, int nlevels = 8, int edgeThreshold = 31,
-        int firstLevel = 0, int WTA_K=2, int scoreType=ORB::HARRIS_SCORE, int patchSize=31 );
+        int firstLevel = 0, int WTA_K=2, int scoreType=ORB::HARRIS_SCORE, int patchSize=31, int fastThreshold = 20);
 
     // returns the descriptor size in bytes
     int descriptorSize() const;
@@ -348,6 +348,7 @@ protected:
     CV_PROP_RW int WTA_K;
     CV_PROP_RW int scoreType;
     CV_PROP_RW int patchSize;
+    CV_PROP_RW int fastThreshold;
 };
 
 typedef ORB OrbFeatureDetector;

--- a/modules/features2d/src/features2d_init.cpp
+++ b/modules/features2d/src/features2d_init.cpp
@@ -104,7 +104,8 @@ CV_INIT_ALGORITHM(ORB, "Feature2D.ORB",
                   obj.info()->addParam(obj, "edgeThreshold", obj.edgeThreshold);
                   obj.info()->addParam(obj, "patchSize", obj.patchSize);
                   obj.info()->addParam(obj, "WTA_K", obj.WTA_K);
-                  obj.info()->addParam(obj, "scoreType", obj.scoreType))
+                  obj.info()->addParam(obj, "scoreType", obj.scoreType);
+                  obj.info()->addParam(obj, "fastThreshold", obj.fastThreshold))
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////////////
 

--- a/modules/features2d/src/orb.cpp
+++ b/modules/features2d/src/orb.cpp
@@ -648,10 +648,10 @@ static inline float getScale(int level, int firstLevel, double scaleFactor)
  * @param detector_params parameters to use
  */
 ORB::ORB(int _nfeatures, float _scaleFactor, int _nlevels, int _edgeThreshold,
-         int _firstLevel, int _WTA_K, int _scoreType, int _patchSize) :
+         int _firstLevel, int _WTA_K, int _scoreType, int _patchSize, int _fastThreshold) :
     nfeatures(_nfeatures), scaleFactor(_scaleFactor), nlevels(_nlevels),
     edgeThreshold(_edgeThreshold), firstLevel(_firstLevel), WTA_K(_WTA_K),
-    scoreType(_scoreType), patchSize(_patchSize)
+    scoreType(_scoreType), patchSize(_patchSize), fastThreshold(_fastThreshold)
 {}
 
 
@@ -729,7 +729,7 @@ static void computeKeyPoints(const Mat& imagePyramid,
                              std::vector<KeyPoint>& allKeypoints,
                              int nfeatures, double scaleFactor,
                              int edgeThreshold, int patchSize, int scoreType,
-                             bool useOCL )
+                             bool useOCL, int fastThreshold  )
 {
     int i, nkeypoints, level, nlevels = (int)layerInfo.size();
     std::vector<int> nfeaturesPerLevel(nlevels);
@@ -780,7 +780,7 @@ static void computeKeyPoints(const Mat& imagePyramid,
         Mat mask = maskPyramid.empty() ? Mat() : maskPyramid(layerInfo[level]);
 
         // Detect FAST features, 20 is a good threshold
-        FastFeatureDetector fd(20, true);
+        FastFeatureDetector fd(fastThreshold, true);
         fd.detect(img, keypoints, mask);
 
         // Remove keypoints very close to the border
@@ -1028,7 +1028,7 @@ void ORB::operator()( InputArray _image, InputArray _mask, std::vector<KeyPoint>
         // Get keypoints, those will be far enough from the border that no check will be required for the descriptor
         computeKeyPoints(imagePyramid, uimagePyramid, maskPyramid,
                          layerInfo, ulayerInfo, layerScale, keypoints,
-                         nfeatures, scaleFactor, edgeThreshold, patchSize, scoreType, useOCL);
+                         nfeatures, scaleFactor, edgeThreshold, patchSize, scoreType, useOCL, fastThreshold);
     }
     else
     {
@@ -1125,5 +1125,6 @@ void ORB::computeImpl( InputArray image, std::vector<KeyPoint>& keypoints, Outpu
 {
     (*this)(image, Mat(), keypoints, descriptors, true);
 }
+
 
 }

--- a/modules/features2d/test/test_orb.cpp
+++ b/modules/features2d/test/test_orb.cpp
@@ -48,6 +48,8 @@ using namespace cv;
 TEST(Features2D_ORB, _1996)
 {
     Ptr<FeatureDetector> fd = FeatureDetector::create("ORB");
+    fd->set("nFeatures", 10000);//setting a higher maximum to make effect of threshold visible
+    fd->set("fastThreshold", 20);//more features than the default
     Ptr<DescriptorExtractor> de = DescriptorExtractor::create("ORB");
 
     Mat image = imread(string(cvtest::TS::ptr()->get_data_path()) + "shared/lena.png");


### PR DESCRIPTION
This is an independent precursor for the feature http://code.opencv.org/issues/3873, which is required to adapt the ORB feature. Also, it's a much smaller change, so I can quickly try out how contributing to OpenCV works.
