### PR TITLE
Process libjpeg errors the OpenCV way

### DIFF
--- a/modules/highgui/src/grfmt_jpeg.cpp
+++ b/modules/highgui/src/grfmt_jpeg.cpp
@@ -171,13 +171,13 @@ error_exit( j_common_ptr cinfo )
 METHODDEF(void)
 output_message( j_common_ptr cinfo )
 {
-  char buffer[JMSG_LENGTH_MAX];
+    char buffer[JMSG_LENGTH_MAX];
 
-  /* Create the message */
-  (*cinfo->err->format_message) (cinfo, buffer);
+    /* Create the message */
+    (*cinfo->err->format_message) (cinfo, buffer);
 
-  /* Default OpenCV error handling instead of print */
-  CV_Error(CV_StsError, buffer);
+    /* Default OpenCV error handling instead of print */
+    CV_Error(CV_StsError, buffer);
 }
 
 


### PR DESCRIPTION
Errors from libjpeg, specifically "Corrupted JPEG data" messages, are printed to stderr by the default error handler, making those errors uncatchable. By overwriting the output_message method as suggested by the libjpeg docs we can handle those errors like regular OpenCV errors.
