### PR TITLE
OCL: Added performance test for additional modes of cvtColor  

### DIFF
--- a/modules/imgproc/perf/opencl/perf_color.cpp
+++ b/modules/imgproc/perf/opencl/perf_color.cpp
@@ -58,8 +58,9 @@ using std::tr1::make_tuple;
 
 CV_ENUM(ConversionTypes, COLOR_RGB2GRAY, COLOR_RGB2BGR, COLOR_RGB2YUV, COLOR_YUV2RGB, COLOR_RGB2YCrCb,
         COLOR_YCrCb2RGB, COLOR_RGB2XYZ, COLOR_XYZ2RGB, COLOR_RGB2HSV, COLOR_HSV2RGB, COLOR_RGB2HLS,
-        COLOR_HLS2RGB, COLOR_BGR5652BGR, COLOR_BGR2BGR565, COLOR_RGBA2mRGBA, COLOR_mRGBA2RGBA, COLOR_YUV2RGB_NV12,
-        COLOR_RGB2Lab, COLOR_Lab2BGR, COLOR_RGB2Luv, COLOR_Luv2LBGR)
+        COLOR_HLS2RGB, COLOR_BGR5652BGR, COLOR_BGR2BGR565, COLOR_RGBA2mRGBA, COLOR_mRGBA2RGBA,
+        COLOR_RGB2Lab, COLOR_Lab2BGR, COLOR_RGB2Luv, COLOR_Luv2LBGR, COLOR_YUV2RGB_NV12, COLOR_YUV2RGB_IYUV,
+        COLOR_YUV2GRAY_420, COLOR_RGB2YUV_IYUV, COLOR_YUV2RGB_YUY2, COLOR_YUV2GRAY_YUY2)
 
 typedef tuple<Size, tuple<ConversionTypes, int, int> > CvtColorParams;
 typedef TestBaseWithParam<CvtColorParams> CvtColorFixture;
@@ -83,11 +84,16 @@ OCL_PERF_TEST_P(CvtColorFixture, CvtColor, testing::Combine(
                     make_tuple(ConversionTypes(COLOR_BGR2BGR565), 3, 2),
                     make_tuple(ConversionTypes(COLOR_RGBA2mRGBA), 4, 4),
                     make_tuple(ConversionTypes(COLOR_mRGBA2RGBA), 4, 4),
-                    make_tuple(ConversionTypes(COLOR_YUV2RGB_NV12), 1, 3),
                     make_tuple(ConversionTypes(COLOR_RGB2Lab), 3, 3),
                     make_tuple(ConversionTypes(COLOR_Lab2BGR), 3, 4),
                     make_tuple(ConversionTypes(COLOR_RGB2Luv), 3, 3),
-                    make_tuple(ConversionTypes(COLOR_Luv2LBGR), 3, 4)
+                    make_tuple(ConversionTypes(COLOR_Luv2LBGR), 3, 4),
+                    make_tuple(ConversionTypes(COLOR_YUV2RGB_NV12), 1, 3),
+                    make_tuple(ConversionTypes(COLOR_YUV2RGB_IYUV), 1, 3),
+                    make_tuple(ConversionTypes(COLOR_YUV2GRAY_420), 1, 1),
+                    make_tuple(ConversionTypes(COLOR_RGB2YUV_IYUV), 3, 1),
+                    make_tuple(ConversionTypes(COLOR_YUV2RGB_YUY2), 2, 3),
+                    make_tuple(ConversionTypes(COLOR_YUV2GRAY_YUY2), 2, 1)
                     )))
 {
     CvtColorParams params = GetParam();

--- a/modules/ts/include/opencv2/ts.hpp
+++ b/modules/ts/include/opencv2/ts.hpp
@@ -11,7 +11,8 @@
 #endif
 
 #ifdef _MSC_VER
-#pragma warning( disable: 4127 )
+#pragma warning( disable: 4127 ) // conditional expression is constant
+#pragma warning( disable: 4503 ) // decorated name length exceeded, name was truncated
 #endif
 
 #define GTEST_DONT_DEFINE_FAIL      0


### PR DESCRIPTION
Merge with extra: Itseez/opencv_extra#224 
New testing modes: YUV2RGB_IYUV, YUV2GRAY_420, RGB2YUV_IYUV, YUV2RGB_YUY2, YUV2GRAY_YUY2.

check_regression=_OCL_Color*
test_modules=imgproc
build_examples=OFF
