### PR TITLE
Implementation detector and selector for IPP and OpenCL;

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -222,6 +222,11 @@ OCV_OPTION(OPENCV_WARNINGS_ARE_ERRORS "Treat warnings as errors"                
 OCV_OPTION(ENABLE_WINRT_MODE          "Build with Windows Runtime support"                       OFF  IF WIN32 )
 OCV_OPTION(ENABLE_WINRT_MODE_NATIVE   "Build with Windows Runtime native C++ support"            OFF  IF WIN32 )
 OCV_OPTION(ANDROID_EXAMPLES_WITH_LIBS "Build binaries of Android examples with native libraries" OFF  IF ANDROID )
+OCV_OPTION(ENABLE_IMPL_COLLECTION     "Collect implementation data on function call"             OFF )
+
+if(ENABLE_IMPL_COLLECTION)
+  add_definitions(-DCV_COLLECT_IMPL_DATA)
+endif()
 
 
 # ----------------------------------------------------------------------------

--- a/modules/calib3d/src/stereobm.cpp
+++ b/modules/calib3d/src/stereobm.cpp
@@ -925,6 +925,7 @@ public:
                         filterSpeckles(disparr.getMat(), FILTERED, params.speckleWindowSize, params.speckleRange, slidingSumBuf);
                     if (dtype == CV_32F)
                         disparr.getUMat().convertTo(disparr, CV_32FC1, 1./(1 << DISPARITY_SHIFT), 0);
+                    CV_IMPL_ADD(CV_IMPL_OCL);
                     return;
                 }
             }

--- a/modules/calib3d/src/stereosgbm.cpp
+++ b/modules/calib3d/src/stereosgbm.cpp
@@ -1085,28 +1085,34 @@ void cv::filterSpeckles( InputOutputArray _img, double _newval, int maxSpeckleSi
     int newVal = cvRound(_newval), maxDiff = cvRound(_maxDiff);
 
 #if IPP_VERSION_X100 >= 801
-    Ipp32s bufsize = 0;
-    IppiSize roisize = { img.cols, img.rows };
-    IppDataType datatype = type == CV_8UC1 ? ipp8u : ipp16s;
-
-    if (!__buf.needed() && (type == CV_8UC1 || type == CV_16SC1))
+    CV_IPP_CHECK()
     {
-        IppStatus status = ippiMarkSpecklesGetBufferSize(roisize, datatype, CV_MAT_CN(type), &bufsize);
-        Ipp8u * buffer = ippsMalloc_8u(bufsize);
+        Ipp32s bufsize = 0;
+        IppiSize roisize = { img.cols, img.rows };
+        IppDataType datatype = type == CV_8UC1 ? ipp8u : ipp16s;
 
-        if ((int)status >= 0)
+        if (!__buf.needed() && (type == CV_8UC1 || type == CV_16SC1))
         {
-            if (type == CV_8UC1)
-                status = ippiMarkSpeckles_8u_C1IR(img.ptr<Ipp8u>(), (int)img.step, roisize,
-                                                  (Ipp8u)newVal, maxSpeckleSize, (Ipp8u)maxDiff, ippiNormL1, buffer);
-            else
-                status = ippiMarkSpeckles_16s_C1IR(img.ptr<Ipp16s>(), (int)img.step, roisize,
-                                                   (Ipp16s)newVal, maxSpeckleSize, (Ipp16s)maxDiff, ippiNormL1, buffer);
-        }
+            IppStatus status = ippiMarkSpecklesGetBufferSize(roisize, datatype, CV_MAT_CN(type), &bufsize);
+            Ipp8u * buffer = ippsMalloc_8u(bufsize);
 
-        if (status >= 0)
-            return;
-        setIppErrorStatus();
+            if ((int)status >= 0)
+            {
+                if (type == CV_8UC1)
+                    status = ippiMarkSpeckles_8u_C1IR(img.ptr<Ipp8u>(), (int)img.step, roisize,
+                                                      (Ipp8u)newVal, maxSpeckleSize, (Ipp8u)maxDiff, ippiNormL1, buffer);
+                else
+                    status = ippiMarkSpeckles_16s_C1IR(img.ptr<Ipp16s>(), (int)img.step, roisize,
+                                                       (Ipp16s)newVal, maxSpeckleSize, (Ipp16s)maxDiff, ippiNormL1, buffer);
+            }
+
+            if (status >= 0)
+            {
+                CV_IMPL_ADD(CV_IMPL_IPP);
+                return;
+            }
+            setIppErrorStatus();
+        }
     }
 #endif
 

--- a/modules/core/include/opencv2/core/base.hpp
+++ b/modules/core/include/opencv2/core/base.hpp
@@ -566,6 +566,8 @@ CV_EXPORTS void setIppStatus(int status, const char * const funcname = NULL, con
                              int line = 0);
 CV_EXPORTS int getIppStatus();
 CV_EXPORTS String getIppErrorLocation();
+CV_EXPORTS bool useIPP();
+CV_EXPORTS void setUseIPP(bool flag);
 
 } // ipp
 

--- a/modules/core/include/opencv2/core/opencl/ocl_defs.hpp
+++ b/modules/core/include/opencv2/core/opencl/ocl_defs.hpp
@@ -5,6 +5,7 @@
 // Copyright (C) 2014, Advanced Micro Devices, Inc., all rights reserved.
 // Third party copyrights are property of their respective owners.
 
+#include "opencv2/core/utility.hpp"
 //#define CV_OPENCL_RUN_ASSERT
 
 #ifdef HAVE_OPENCL
@@ -16,6 +17,7 @@
         {                                                                   \
             printf("%s: OpenCL implementation is running\n", CV_Func);      \
             fflush(stdout);                                                 \
+            CV_IMPL_ADD(CV_IMPL_OCL);                                       \
             return __VA_ARGS__;                                             \
         }                                                                   \
         else                                                                \
@@ -29,14 +31,24 @@
     {                                                                       \
         if (cv::ocl::useOpenCL() && (condition))                            \
         {                                                                   \
-            CV_Assert(func);                                                \
+            if(func)                                                        \
+            {                                                               \
+                CV_IMPL_ADD(CV_IMPL_OCL);                                   \
+            }                                                               \
+            else                                                            \
+            {                                                               \
+                CV_Error(cv::Error::StsAssert, #func);                      \
+            }                                                               \
             return __VA_ARGS__;                                             \
         }                                                                   \
     }
 #else
 #define CV_OCL_RUN_(condition, func, ...)                                   \
     if (cv::ocl::useOpenCL() && (condition) && func)                        \
-        return __VA_ARGS__;
+    {                                                                       \
+        CV_IMPL_ADD(CV_IMPL_OCL);                                           \
+        return __VA_ARGS__;                                                 \
+    }
 #endif
 
 #else

--- a/modules/core/include/opencv2/core/private.hpp
+++ b/modules/core/include/opencv2/core/private.hpp
@@ -254,6 +254,9 @@ static inline IppDataType ippiGetDataType(int depth)
 #  define IPP_VERSION_X100 0
 #endif
 
+#define CV_IPP_CHECK_COND (cv::ipp::useIPP())
+#define CV_IPP_CHECK() if(CV_IPP_CHECK_COND)
+
 #ifndef IPPI_CALL
 #  define IPPI_CALL(func) CV_Assert((func) >= 0)
 #endif

--- a/modules/core/include/opencv2/core/utility.hpp
+++ b/modules/core/include/opencv2/core/utility.hpp
@@ -53,6 +53,30 @@
 namespace cv
 {
 
+#ifdef CV_COLLECT_IMPL_DATA
+CV_EXPORTS void setImpl(int flags); // set implementation flags and reset storage arrays
+CV_EXPORTS void addImpl(int flag, const char* func = 0); // add implementation and function name to storage arrays
+// Get stored implementation flags and fucntions names arrays
+// Each implementation entry correspond to function name entry, so you can find which implementation was executed in which fucntion
+CV_EXPORTS int getImpl(std::vector<int> &impl, std::vector<String> &funName);
+
+CV_EXPORTS bool useCollection(); // return implementation colelction state
+CV_EXPORTS void setUseCollection(bool flag); // set implementation collection state
+
+#define CV_IMPL_PLAIN  0x01 // native CPU OpenCV implementation
+#define CV_IMPL_OCL    0x02 // OpenCL implementation
+#define CV_IMPL_IPP    0x04 // IPP implementation
+#define CV_IMPL_MT     0x10 // multithreaded implementation
+
+#define CV_IMPL_ADD(impl)                                                   \
+    if(cv::useCollection())                                                 \
+    {                                                                       \
+        cv::addImpl(impl, CV_Func);                                         \
+    }
+#else
+#define CV_IMPL_ADD(impl)
+#endif
+
 /*!
  Automatically Allocated Buffer Class
 

--- a/modules/core/src/arithm.cpp
+++ b/modules/core/src/arithm.cpp
@@ -562,10 +562,16 @@ static void add8u( const uchar* src1, size_t step1,
                    uchar* dst, size_t step, Size sz, void* )
 {
 #if (ARITHM_USE_IPP == 1)
-    fixSteps(sz, sizeof(dst[0]), step1, step2, step);
-    if (0 <= ippiAdd_8u_C1RSfs(src1, (int)step1, src2, (int)step2, dst, (int)step, ippiSize(sz), 0))
-        return;
-    setIppErrorStatus();
+    CV_IPP_CHECK()
+    {
+        fixSteps(sz, sizeof(dst[0]), step1, step2, step);
+        if (0 <= ippiAdd_8u_C1RSfs(src1, (int)step1, src2, (int)step2, dst, (int)step, ippiSize(sz), 0))
+        {
+            CV_IMPL_ADD(CV_IMPL_IPP);
+            return;
+        }
+        setIppErrorStatus();
+    }
 #endif
     (vBinOp<uchar, OpAdd<uchar>, IF_SIMD(VAdd<uchar>)>(src1, step1, src2, step2, dst, step, sz));
 }
@@ -582,10 +588,16 @@ static void add16u( const ushort* src1, size_t step1,
                     ushort* dst, size_t step, Size sz, void* )
 {
 #if (ARITHM_USE_IPP == 1)
-    fixSteps(sz, sizeof(dst[0]), step1, step2, step);
-    if (0 <= ippiAdd_16u_C1RSfs(src1, (int)step1, src2, (int)step2, dst, (int)step, ippiSize(sz), 0))
-        return;
-    setIppErrorStatus();
+    CV_IPP_CHECK()
+    {
+        fixSteps(sz, sizeof(dst[0]), step1, step2, step);
+        if (0 <= ippiAdd_16u_C1RSfs(src1, (int)step1, src2, (int)step2, dst, (int)step, ippiSize(sz), 0))
+        {
+            CV_IMPL_ADD(CV_IMPL_IPP);
+            return;
+        }
+        setIppErrorStatus();
+    }
 #endif
     (vBinOp<ushort, OpAdd<ushort>, IF_SIMD(VAdd<ushort>)>(src1, step1, src2, step2, dst, step, sz));
 }
@@ -595,10 +607,16 @@ static void add16s( const short* src1, size_t step1,
                     short* dst, size_t step, Size sz, void* )
 {
 #if (ARITHM_USE_IPP == 1)
-    fixSteps(sz, sizeof(dst[0]), step1, step2, step);
-    if (0 <= ippiAdd_16s_C1RSfs(src1, (int)step1, src2, (int)step2, dst, (int)step, ippiSize(sz), 0))
-        return;
-    setIppErrorStatus();
+    CV_IPP_CHECK()
+    {
+        fixSteps(sz, sizeof(dst[0]), step1, step2, step);
+        if (0 <= ippiAdd_16s_C1RSfs(src1, (int)step1, src2, (int)step2, dst, (int)step, ippiSize(sz), 0))
+        {
+            CV_IMPL_ADD(CV_IMPL_IPP);
+            return;
+        }
+        setIppErrorStatus();
+    }
 #endif
     (vBinOp<short, OpAdd<short>, IF_SIMD(VAdd<short>)>(src1, step1, src2, step2, dst, step, sz));
 }
@@ -615,10 +633,16 @@ static void add32f( const float* src1, size_t step1,
                     float* dst, size_t step, Size sz, void* )
 {
 #if (ARITHM_USE_IPP == 1)
-    fixSteps(sz, sizeof(dst[0]), step1, step2, step);
-    if (0 <= ippiAdd_32f_C1R(src1, (int)step1, src2, (int)step2, dst, (int)step, ippiSize(sz)))
-        return;
-    setIppErrorStatus();
+    CV_IPP_CHECK()
+    {
+        fixSteps(sz, sizeof(dst[0]), step1, step2, step);
+        if (0 <= ippiAdd_32f_C1R(src1, (int)step1, src2, (int)step2, dst, (int)step, ippiSize(sz)))
+        {
+            CV_IMPL_ADD(CV_IMPL_IPP);
+            return;
+        }
+        setIppErrorStatus();
+    }
 #endif
     (vBinOp32<float, OpAdd<float>, IF_SIMD(VAdd<float>)>(src1, step1, src2, step2, dst, step, sz));
 }
@@ -635,10 +659,16 @@ static void sub8u( const uchar* src1, size_t step1,
                    uchar* dst, size_t step, Size sz, void* )
 {
 #if (ARITHM_USE_IPP == 1)
-    fixSteps(sz, sizeof(dst[0]), step1, step2, step);
-    if (0 <= ippiSub_8u_C1RSfs(src2, (int)step2, src1, (int)step1, dst, (int)step, ippiSize(sz), 0))
-        return;
-    setIppErrorStatus();
+    CV_IPP_CHECK()
+    {
+        fixSteps(sz, sizeof(dst[0]), step1, step2, step);
+        if (0 <= ippiSub_8u_C1RSfs(src2, (int)step2, src1, (int)step1, dst, (int)step, ippiSize(sz), 0))
+        {
+            CV_IMPL_ADD(CV_IMPL_IPP);
+            return;
+        }
+        setIppErrorStatus();
+    }
 #endif
     (vBinOp<uchar, OpSub<uchar>, IF_SIMD(VSub<uchar>)>(src1, step1, src2, step2, dst, step, sz));
 }
@@ -655,10 +685,16 @@ static void sub16u( const ushort* src1, size_t step1,
                     ushort* dst, size_t step, Size sz, void* )
 {
 #if (ARITHM_USE_IPP == 1)
-    fixSteps(sz, sizeof(dst[0]), step1, step2, step);
-    if (0 <= ippiSub_16u_C1RSfs(src2, (int)step2, src1, (int)step1, dst, (int)step, ippiSize(sz), 0))
-        return;
-    setIppErrorStatus();
+    CV_IPP_CHECK()
+    {
+        fixSteps(sz, sizeof(dst[0]), step1, step2, step);
+        if (0 <= ippiSub_16u_C1RSfs(src2, (int)step2, src1, (int)step1, dst, (int)step, ippiSize(sz), 0))
+        {
+            CV_IMPL_ADD(CV_IMPL_IPP);
+            return;
+        }
+        setIppErrorStatus();
+    }
 #endif
     (vBinOp<ushort, OpSub<ushort>, IF_SIMD(VSub<ushort>)>(src1, step1, src2, step2, dst, step, sz));
 }
@@ -668,10 +704,16 @@ static void sub16s( const short* src1, size_t step1,
                     short* dst, size_t step, Size sz, void* )
 {
 #if (ARITHM_USE_IPP == 1)
-    fixSteps(sz, sizeof(dst[0]), step1, step2, step);
-    if (0 <= ippiSub_16s_C1RSfs(src2, (int)step2, src1, (int)step1, dst, (int)step, ippiSize(sz), 0))
-        return;
-    setIppErrorStatus();
+    CV_IPP_CHECK()
+    {
+        fixSteps(sz, sizeof(dst[0]), step1, step2, step);
+        if (0 <= ippiSub_16s_C1RSfs(src2, (int)step2, src1, (int)step1, dst, (int)step, ippiSize(sz), 0))
+        {
+            CV_IMPL_ADD(CV_IMPL_IPP);
+            return;
+        }
+        setIppErrorStatus();
+    }
 #endif
     (vBinOp<short, OpSub<short>, IF_SIMD(VSub<short>)>(src1, step1, src2, step2, dst, step, sz));
 }
@@ -688,10 +730,16 @@ static void sub32f( const float* src1, size_t step1,
                    float* dst, size_t step, Size sz, void* )
 {
 #if (ARITHM_USE_IPP == 1)
-    fixSteps(sz, sizeof(dst[0]), step1, step2, step);
-    if (0 <= ippiSub_32f_C1R(src2, (int)step2, src1, (int)step1, dst, (int)step, ippiSize(sz)))
-        return;
-    setIppErrorStatus();
+    CV_IPP_CHECK()
+    {
+        fixSteps(sz, sizeof(dst[0]), step1, step2, step);
+        if (0 <= ippiSub_32f_C1R(src2, (int)step2, src1, (int)step1, dst, (int)step, ippiSize(sz)))
+        {
+            CV_IMPL_ADD(CV_IMPL_IPP);
+            return;
+        }
+        setIppErrorStatus();
+    }
 #endif
     (vBinOp32<float, OpSub<float>, IF_SIMD(VSub<float>)>(src1, step1, src2, step2, dst, step, sz));
 }
@@ -711,22 +759,28 @@ static void max8u( const uchar* src1, size_t step1,
                    uchar* dst, size_t step, Size sz, void* )
 {
 #if (ARITHM_USE_IPP == 1)
-    uchar* s1 = (uchar*)src1;
-    uchar* s2 = (uchar*)src2;
-    uchar* d  = dst;
-    fixSteps(sz, sizeof(dst[0]), step1, step2, step);
-    int i = 0;
-    for(; i < sz.height; i++)
+    CV_IPP_CHECK()
     {
-        if (0 > ippsMaxEvery_8u(s1, s2, d, sz.width))
-            break;
-        s1 += step1;
-        s2 += step2;
-        d  += step;
+        uchar* s1 = (uchar*)src1;
+        uchar* s2 = (uchar*)src2;
+        uchar* d  = dst;
+        fixSteps(sz, sizeof(dst[0]), step1, step2, step);
+        int i = 0;
+        for(; i < sz.height; i++)
+        {
+            if (0 > ippsMaxEvery_8u(s1, s2, d, sz.width))
+                break;
+            s1 += step1;
+            s2 += step2;
+            d  += step;
+        }
+        if (i == sz.height)
+        {
+            CV_IMPL_ADD(CV_IMPL_IPP);
+            return;
+        }
+        setIppErrorStatus();
     }
-    if (i == sz.height)
-        return;
-    setIppErrorStatus();
 #endif
     vBinOp<uchar, OpMax<uchar>, IF_SIMD(VMax<uchar>)>(src1, step1, src2, step2, dst, step, sz);
 }
@@ -743,22 +797,28 @@ static void max16u( const ushort* src1, size_t step1,
                     ushort* dst, size_t step, Size sz, void* )
 {
 #if (ARITHM_USE_IPP == 1)
-    ushort* s1 = (ushort*)src1;
-    ushort* s2 = (ushort*)src2;
-    ushort* d  = dst;
-    fixSteps(sz, sizeof(dst[0]), step1, step2, step);
-    int i = 0;
-    for(; i < sz.height; i++)
+    CV_IPP_CHECK()
     {
-        if (0 > ippsMaxEvery_16u(s1, s2, d, sz.width))
-            break;
-        s1 = (ushort*)((uchar*)s1 + step1);
-        s2 = (ushort*)((uchar*)s2 + step2);
-        d  = (ushort*)((uchar*)d + step);
+        ushort* s1 = (ushort*)src1;
+        ushort* s2 = (ushort*)src2;
+        ushort* d  = dst;
+        fixSteps(sz, sizeof(dst[0]), step1, step2, step);
+        int i = 0;
+        for(; i < sz.height; i++)
+        {
+            if (0 > ippsMaxEvery_16u(s1, s2, d, sz.width))
+                break;
+            s1 = (ushort*)((uchar*)s1 + step1);
+            s2 = (ushort*)((uchar*)s2 + step2);
+            d  = (ushort*)((uchar*)d + step);
+        }
+        if (i == sz.height)
+        {
+            CV_IMPL_ADD(CV_IMPL_IPP);
+            return;
+        }
+        setIppErrorStatus();
     }
-    if (i == sz.height)
-        return;
-    setIppErrorStatus();
 #endif
     vBinOp<ushort, OpMax<ushort>, IF_SIMD(VMax<ushort>)>(src1, step1, src2, step2, dst, step, sz);
 }
@@ -782,22 +842,28 @@ static void max32f( const float* src1, size_t step1,
                     float* dst, size_t step, Size sz, void* )
 {
 #if (ARITHM_USE_IPP == 1)
-    float* s1 = (float*)src1;
-    float* s2 = (float*)src2;
-    float* d  = dst;
-    fixSteps(sz, sizeof(dst[0]), step1, step2, step);
-    int i = 0;
-    for(; i < sz.height; i++)
+    CV_IPP_CHECK()
     {
-        if (0 > ippsMaxEvery_32f(s1, s2, d, sz.width))
-            break;
-        s1 = (float*)((uchar*)s1 + step1);
-        s2 = (float*)((uchar*)s2 + step2);
-        d  = (float*)((uchar*)d + step);
+        float* s1 = (float*)src1;
+        float* s2 = (float*)src2;
+        float* d  = dst;
+        fixSteps(sz, sizeof(dst[0]), step1, step2, step);
+        int i = 0;
+        for(; i < sz.height; i++)
+        {
+            if (0 > ippsMaxEvery_32f(s1, s2, d, sz.width))
+                break;
+            s1 = (float*)((uchar*)s1 + step1);
+            s2 = (float*)((uchar*)s2 + step2);
+            d  = (float*)((uchar*)d + step);
+        }
+        if (i == sz.height)
+        {
+            CV_IMPL_ADD(CV_IMPL_IPP);
+            return;
+        }
+        setIppErrorStatus();
     }
-    if (i == sz.height)
-        return;
-    setIppErrorStatus();
 #endif
     vBinOp32<float, OpMax<float>, IF_SIMD(VMax<float>)>(src1, step1, src2, step2, dst, step, sz);
 }
@@ -807,22 +873,28 @@ static void max64f( const double* src1, size_t step1,
                     double* dst, size_t step, Size sz, void* )
 {
 #if ARITHM_USE_IPP == 1
-    double* s1 = (double*)src1;
-    double* s2 = (double*)src2;
-    double* d  = dst;
-    fixSteps(sz, sizeof(dst[0]), step1, step2, step);
-    int i = 0;
-    for(; i < sz.height; i++)
+    CV_IPP_CHECK()
     {
-        if (0 > ippsMaxEvery_64f(s1, s2, d, sz.width))
-            break;
-        s1 = (double*)((uchar*)s1 + step1);
-        s2 = (double*)((uchar*)s2 + step2);
-        d  = (double*)((uchar*)d + step);
+        double* s1 = (double*)src1;
+        double* s2 = (double*)src2;
+        double* d  = dst;
+        fixSteps(sz, sizeof(dst[0]), step1, step2, step);
+        int i = 0;
+        for(; i < sz.height; i++)
+        {
+            if (0 > ippsMaxEvery_64f(s1, s2, d, sz.width))
+                break;
+            s1 = (double*)((uchar*)s1 + step1);
+            s2 = (double*)((uchar*)s2 + step2);
+            d  = (double*)((uchar*)d + step);
+        }
+        if (i == sz.height)
+        {
+            CV_IMPL_ADD(CV_IMPL_IPP);
+            return;
+        }
+        setIppErrorStatus();
     }
-    if (i == sz.height)
-        return;
-    setIppErrorStatus();
 #endif
     vBinOp64<double, OpMax<double>, IF_SIMD(VMax<double>)>(src1, step1, src2, step2, dst, step, sz);
 }
@@ -832,22 +904,28 @@ static void min8u( const uchar* src1, size_t step1,
                    uchar* dst, size_t step, Size sz, void* )
 {
 #if (ARITHM_USE_IPP == 1)
-    uchar* s1 = (uchar*)src1;
-    uchar* s2 = (uchar*)src2;
-    uchar* d  = dst;
-    fixSteps(sz, sizeof(dst[0]), step1, step2, step);
-    int i = 0;
-    for(; i < sz.height; i++)
+    CV_IPP_CHECK()
     {
-        if (0 > ippsMinEvery_8u(s1, s2, d, sz.width))
-            break;
-        s1 += step1;
-        s2 += step2;
-        d  += step;
+        uchar* s1 = (uchar*)src1;
+        uchar* s2 = (uchar*)src2;
+        uchar* d  = dst;
+        fixSteps(sz, sizeof(dst[0]), step1, step2, step);
+        int i = 0;
+        for(; i < sz.height; i++)
+        {
+            if (0 > ippsMinEvery_8u(s1, s2, d, sz.width))
+                break;
+            s1 += step1;
+            s2 += step2;
+            d  += step;
+        }
+        if (i == sz.height)
+        {
+            CV_IMPL_ADD(CV_IMPL_IPP);
+            return;
+        }
+        setIppErrorStatus();
     }
-    if (i == sz.height)
-        return;
-    setIppErrorStatus();
 #endif
     vBinOp<uchar, OpMin<uchar>, IF_SIMD(VMin<uchar>)>(src1, step1, src2, step2, dst, step, sz);
 }
@@ -864,22 +942,28 @@ static void min16u( const ushort* src1, size_t step1,
                     ushort* dst, size_t step, Size sz, void* )
 {
 #if (ARITHM_USE_IPP == 1)
-    ushort* s1 = (ushort*)src1;
-    ushort* s2 = (ushort*)src2;
-    ushort* d  = dst;
-    fixSteps(sz, sizeof(dst[0]), step1, step2, step);
-    int i = 0;
-    for(; i < sz.height; i++)
+    CV_IPP_CHECK()
     {
-        if (0 > ippsMinEvery_16u(s1, s2, d, sz.width))
-            break;
-        s1 = (ushort*)((uchar*)s1 + step1);
-        s2 = (ushort*)((uchar*)s2 + step2);
-        d  = (ushort*)((uchar*)d + step);
+        ushort* s1 = (ushort*)src1;
+        ushort* s2 = (ushort*)src2;
+        ushort* d  = dst;
+        fixSteps(sz, sizeof(dst[0]), step1, step2, step);
+        int i = 0;
+        for(; i < sz.height; i++)
+        {
+            if (0 > ippsMinEvery_16u(s1, s2, d, sz.width))
+                break;
+            s1 = (ushort*)((uchar*)s1 + step1);
+            s2 = (ushort*)((uchar*)s2 + step2);
+            d  = (ushort*)((uchar*)d + step);
+        }
+        if (i == sz.height)
+        {
+            CV_IMPL_ADD(CV_IMPL_IPP);
+            return;
+        }
+        setIppErrorStatus();
     }
-    if (i == sz.height)
-        return;
-    setIppErrorStatus();
 #endif
     vBinOp<ushort, OpMin<ushort>, IF_SIMD(VMin<ushort>)>(src1, step1, src2, step2, dst, step, sz);
 }
@@ -903,22 +987,28 @@ static void min32f( const float* src1, size_t step1,
                     float* dst, size_t step, Size sz, void* )
 {
 #if (ARITHM_USE_IPP == 1)
-    float* s1 = (float*)src1;
-    float* s2 = (float*)src2;
-    float* d  = dst;
-    fixSteps(sz, sizeof(dst[0]), step1, step2, step);
-    int i = 0;
-    for(; i < sz.height; i++)
+    CV_IPP_CHECK()
     {
-        if (0 > ippsMinEvery_32f(s1, s2, d, sz.width))
-            break;
-        s1 = (float*)((uchar*)s1 + step1);
-        s2 = (float*)((uchar*)s2 + step2);
-        d  = (float*)((uchar*)d + step);
+        float* s1 = (float*)src1;
+        float* s2 = (float*)src2;
+        float* d  = dst;
+        fixSteps(sz, sizeof(dst[0]), step1, step2, step);
+        int i = 0;
+        for(; i < sz.height; i++)
+        {
+            if (0 > ippsMinEvery_32f(s1, s2, d, sz.width))
+                break;
+            s1 = (float*)((uchar*)s1 + step1);
+            s2 = (float*)((uchar*)s2 + step2);
+            d  = (float*)((uchar*)d + step);
+        }
+        if (i == sz.height)
+        {
+            CV_IMPL_ADD(CV_IMPL_IPP);
+            return;
+        }
+        setIppErrorStatus();
     }
-    if (i == sz.height)
-        return;
-    setIppErrorStatus();
 #endif
     vBinOp32<float, OpMin<float>, IF_SIMD(VMin<float>)>(src1, step1, src2, step2, dst, step, sz);
 }
@@ -928,22 +1018,28 @@ static void min64f( const double* src1, size_t step1,
                     double* dst, size_t step, Size sz, void* )
 {
 #if ARITHM_USE_IPP == 1
-    double* s1 = (double*)src1;
-    double* s2 = (double*)src2;
-    double* d  = dst;
-    fixSteps(sz, sizeof(dst[0]), step1, step2, step);
-    int i = 0;
-    for(; i < sz.height; i++)
+    CV_IPP_CHECK()
     {
-        if (0 > ippsMinEvery_64f(s1, s2, d, sz.width))
-            break;
-        s1 = (double*)((uchar*)s1 + step1);
-        s2 = (double*)((uchar*)s2 + step2);
-        d  = (double*)((uchar*)d + step);
+        double* s1 = (double*)src1;
+        double* s2 = (double*)src2;
+        double* d  = dst;
+        fixSteps(sz, sizeof(dst[0]), step1, step2, step);
+        int i = 0;
+        for(; i < sz.height; i++)
+        {
+            if (0 > ippsMinEvery_64f(s1, s2, d, sz.width))
+                break;
+            s1 = (double*)((uchar*)s1 + step1);
+            s2 = (double*)((uchar*)s2 + step2);
+            d  = (double*)((uchar*)d + step);
+        }
+        if (i == sz.height)
+        {
+            CV_IMPL_ADD(CV_IMPL_IPP);
+            return;
+        }
+        setIppErrorStatus();
     }
-    if (i == sz.height)
-        return;
-    setIppErrorStatus();
 #endif
     vBinOp64<double, OpMin<double>, IF_SIMD(VMin<double>)>(src1, step1, src2, step2, dst, step, sz);
 }
@@ -953,10 +1049,16 @@ static void absdiff8u( const uchar* src1, size_t step1,
                        uchar* dst, size_t step, Size sz, void* )
 {
 #if (ARITHM_USE_IPP == 1)
-    fixSteps(sz, sizeof(dst[0]), step1, step2, step);
-    if (0 <= ippiAbsDiff_8u_C1R(src1, (int)step1, src2, (int)step2, dst, (int)step, ippiSize(sz)))
-        return;
-    setIppErrorStatus();
+    CV_IPP_CHECK()
+    {
+        fixSteps(sz, sizeof(dst[0]), step1, step2, step);
+        if (0 <= ippiAbsDiff_8u_C1R(src1, (int)step1, src2, (int)step2, dst, (int)step, ippiSize(sz)))
+        {
+            CV_IMPL_ADD(CV_IMPL_IPP);
+            return;
+        }
+        setIppErrorStatus();
+    }
 #endif
     (vBinOp<uchar, OpAbsDiff<uchar>, IF_SIMD(VAbsDiff<uchar>)>(src1, step1, src2, step2, dst, step, sz));
 }
@@ -973,10 +1075,16 @@ static void absdiff16u( const ushort* src1, size_t step1,
                         ushort* dst, size_t step, Size sz, void* )
 {
 #if (ARITHM_USE_IPP == 1)
-    fixSteps(sz, sizeof(dst[0]), step1, step2, step);
-    if (0 <= ippiAbsDiff_16u_C1R(src1, (int)step1, src2, (int)step2, dst, (int)step, ippiSize(sz)))
-        return;
-    setIppErrorStatus();
+    CV_IPP_CHECK()
+    {
+        fixSteps(sz, sizeof(dst[0]), step1, step2, step);
+        if (0 <= ippiAbsDiff_16u_C1R(src1, (int)step1, src2, (int)step2, dst, (int)step, ippiSize(sz)))
+        {
+            CV_IMPL_ADD(CV_IMPL_IPP);
+            return;
+        }
+        setIppErrorStatus();
+    }
 #endif
     (vBinOp<ushort, OpAbsDiff<ushort>, IF_SIMD(VAbsDiff<ushort>)>(src1, step1, src2, step2, dst, step, sz));
 }
@@ -1000,10 +1108,16 @@ static void absdiff32f( const float* src1, size_t step1,
                         float* dst, size_t step, Size sz, void* )
 {
 #if (ARITHM_USE_IPP == 1)
-    fixSteps(sz, sizeof(dst[0]), step1, step2, step);
-    if (0 <= ippiAbsDiff_32f_C1R(src1, (int)step1, src2, (int)step2, dst, (int)step, ippiSize(sz)))
-        return;
-    setIppErrorStatus();
+    CV_IPP_CHECK()
+    {
+        fixSteps(sz, sizeof(dst[0]), step1, step2, step);
+        if (0 <= ippiAbsDiff_32f_C1R(src1, (int)step1, src2, (int)step2, dst, (int)step, ippiSize(sz)))
+        {
+            CV_IMPL_ADD(CV_IMPL_IPP);
+            return;
+        }
+        setIppErrorStatus();
+    }
 #endif
     (vBinOp32<float, OpAbsDiff<float>, IF_SIMD(VAbsDiff<float>)>(src1, step1, src2, step2, dst, step, sz));
 }
@@ -1021,10 +1135,16 @@ static void and8u( const uchar* src1, size_t step1,
                    uchar* dst, size_t step, Size sz, void* )
 {
 #if (ARITHM_USE_IPP == 1)
-    fixSteps(sz, sizeof(dst[0]), step1, step2, step);
-    if (0 <= ippiAnd_8u_C1R(src1, (int)step1, src2, (int)step2, dst, (int)step, ippiSize(sz)))
-        return;
-    setIppErrorStatus();
+    CV_IPP_CHECK()
+    {
+        fixSteps(sz, sizeof(dst[0]), step1, step2, step);
+        if (0 <= ippiAnd_8u_C1R(src1, (int)step1, src2, (int)step2, dst, (int)step, ippiSize(sz)))
+        {
+            CV_IMPL_ADD(CV_IMPL_IPP);
+            return;
+        }
+        setIppErrorStatus();
+    }
 #endif
     (vBinOp<uchar, OpAnd<uchar>, IF_SIMD(VAnd<uchar>)>(src1, step1, src2, step2, dst, step, sz));
 }
@@ -1034,10 +1154,16 @@ static void or8u( const uchar* src1, size_t step1,
                   uchar* dst, size_t step, Size sz, void* )
 {
 #if (ARITHM_USE_IPP == 1)
-    fixSteps(sz, sizeof(dst[0]), step1, step2, step);
-    if (0 <= ippiOr_8u_C1R(src1, (int)step1, src2, (int)step2, dst, (int)step, ippiSize(sz)))
-        return;
-    setIppErrorStatus();
+    CV_IPP_CHECK()
+    {
+        fixSteps(sz, sizeof(dst[0]), step1, step2, step);
+        if (0 <= ippiOr_8u_C1R(src1, (int)step1, src2, (int)step2, dst, (int)step, ippiSize(sz)))
+        {
+            CV_IMPL_ADD(CV_IMPL_IPP);
+            return;
+        }
+        setIppErrorStatus();
+    }
 #endif
     (vBinOp<uchar, OpOr<uchar>, IF_SIMD(VOr<uchar>)>(src1, step1, src2, step2, dst, step, sz));
 }
@@ -1047,10 +1173,16 @@ static void xor8u( const uchar* src1, size_t step1,
                    uchar* dst, size_t step, Size sz, void* )
 {
 #if (ARITHM_USE_IPP == 1)
-    fixSteps(sz, sizeof(dst[0]), step1, step2, step);
-    if (0 <= ippiXor_8u_C1R(src1, (int)step1, src2, (int)step2, dst, (int)step, ippiSize(sz)))
-        return;
-    setIppErrorStatus();
+    CV_IPP_CHECK()
+    {
+        fixSteps(sz, sizeof(dst[0]), step1, step2, step);
+        if (0 <= ippiXor_8u_C1R(src1, (int)step1, src2, (int)step2, dst, (int)step, ippiSize(sz)))
+        {
+            CV_IMPL_ADD(CV_IMPL_IPP);
+            return;
+        }
+        setIppErrorStatus();
+    }
 #endif
     (vBinOp<uchar, OpXor<uchar>, IF_SIMD(VXor<uchar>)>(src1, step1, src2, step2, dst, step, sz));
 }
@@ -1060,10 +1192,16 @@ static void not8u( const uchar* src1, size_t step1,
                    uchar* dst, size_t step, Size sz, void* )
 {
 #if (ARITHM_USE_IPP == 1)
-    fixSteps(sz, sizeof(dst[0]), step1, step2, step); (void)src2;
-    if (0 <= ippiNot_8u_C1R(src1, (int)step1, dst, (int)step, ippiSize(sz)))
-        return;
-    setIppErrorStatus();
+    CV_IPP_CHECK()
+    {
+        fixSteps(sz, sizeof(dst[0]), step1, step2, step); (void)src2;
+        if (0 <= ippiNot_8u_C1R(src1, (int)step1, dst, (int)step, ippiSize(sz)))
+        {
+            CV_IMPL_ADD(CV_IMPL_IPP);
+            return;
+        }
+        setIppErrorStatus();
+    }
 #endif
     (vBinOp<uchar, OpNot<uchar>, IF_SIMD(VNot<uchar>)>(src1, step1, src2, step2, dst, step, sz));
 }
@@ -2376,11 +2514,17 @@ static void mul8u( const uchar* src1, size_t step1, const uchar* src2, size_t st
 {
     float fscale = (float)*(const double*)scale;
 #if defined HAVE_IPP
-    if (std::fabs(fscale - 1) <= FLT_EPSILON)
+    CV_IPP_CHECK()
     {
-        if (ippiMul_8u_C1RSfs(src1, (int)step1, src2, (int)step2, dst, (int)step, ippiSize(sz), 0) >= 0)
-            return;
-        setIppErrorStatus();
+        if (std::fabs(fscale - 1) <= FLT_EPSILON)
+        {
+            if (ippiMul_8u_C1RSfs(src1, (int)step1, src2, (int)step2, dst, (int)step, ippiSize(sz), 0) >= 0)
+            {
+                CV_IMPL_ADD(CV_IMPL_IPP);
+                return;
+            }
+            setIppErrorStatus();
+        }
     }
 #endif
     mul_(src1, step1, src2, step2, dst, step, sz, fscale);
@@ -2397,11 +2541,17 @@ static void mul16u( const ushort* src1, size_t step1, const ushort* src2, size_t
 {
     float fscale = (float)*(const double*)scale;
 #if defined HAVE_IPP
-    if (std::fabs(fscale - 1) <= FLT_EPSILON)
+    CV_IPP_CHECK()
     {
-        if (ippiMul_16u_C1RSfs(src1, (int)step1, src2, (int)step2, dst, (int)step, ippiSize(sz), 0) >= 0)
-            return;
-        setIppErrorStatus();
+        if (std::fabs(fscale - 1) <= FLT_EPSILON)
+        {
+            if (ippiMul_16u_C1RSfs(src1, (int)step1, src2, (int)step2, dst, (int)step, ippiSize(sz), 0) >= 0)
+            {
+                CV_IMPL_ADD(CV_IMPL_IPP);
+                return;
+            }
+            setIppErrorStatus();
+        }
     }
 #endif
     mul_(src1, step1, src2, step2, dst, step, sz, fscale);
@@ -2412,11 +2562,17 @@ static void mul16s( const short* src1, size_t step1, const short* src2, size_t s
 {
     float fscale = (float)*(const double*)scale;
 #if defined HAVE_IPP
-    if (std::fabs(fscale - 1) <= FLT_EPSILON)
+    CV_IPP_CHECK()
     {
-        if (ippiMul_16s_C1RSfs(src1, (int)step1, src2, (int)step2, dst, (int)step, ippiSize(sz), 0) >= 0)
-            return;
-        setIppErrorStatus();
+        if (std::fabs(fscale - 1) <= FLT_EPSILON)
+        {
+            if (ippiMul_16s_C1RSfs(src1, (int)step1, src2, (int)step2, dst, (int)step, ippiSize(sz), 0) >= 0)
+            {
+                CV_IMPL_ADD(CV_IMPL_IPP);
+                return;
+            }
+            setIppErrorStatus();
+        }
     }
 #endif
     mul_(src1, step1, src2, step2, dst, step, sz, fscale);
@@ -2433,11 +2589,17 @@ static void mul32f( const float* src1, size_t step1, const float* src2, size_t s
 {
     float fscale = (float)*(const double*)scale;
 #if defined HAVE_IPP
-    if (std::fabs(fscale - 1) <= FLT_EPSILON)
+    CV_IPP_CHECK()
     {
-        if (ippiMul_32f_C1R(src1, (int)step1, src2, (int)step2, dst, (int)step, ippiSize(sz)) >= 0)
-            return;
-        setIppErrorStatus();
+        if (std::fabs(fscale - 1) <= FLT_EPSILON)
+        {
+            if (ippiMul_32f_C1R(src1, (int)step1, src2, (int)step2, dst, (int)step, ippiSize(sz)) >= 0)
+            {
+                CV_IMPL_ADD(CV_IMPL_IPP);
+                return;
+            }
+            setIppErrorStatus();
+        }
     }
 #endif
     mul_(src1, step1, src2, step2, dst, step, sz, fscale);
@@ -3185,13 +3347,19 @@ static void cmp8u(const uchar* src1, size_t step1, const uchar* src2, size_t ste
                   uchar* dst, size_t step, Size size, void* _cmpop)
 {
 #if ARITHM_USE_IPP
-    IppCmpOp op = convert_cmp(*(int *)_cmpop);
-    if( op  >= 0 )
+    CV_IPP_CHECK()
     {
-        fixSteps(size, sizeof(dst[0]), step1, step2, step);
-        if (0 <= ippiCompare_8u_C1R(src1, (int)step1, src2, (int)step2, dst, (int)step, ippiSize(size), op))
-            return;
-        setIppErrorStatus();
+        IppCmpOp op = convert_cmp(*(int *)_cmpop);
+        if( op  >= 0 )
+        {
+            fixSteps(size, sizeof(dst[0]), step1, step2, step);
+            if (0 <= ippiCompare_8u_C1R(src1, (int)step1, src2, (int)step2, dst, (int)step, ippiSize(size), op))
+            {
+                CV_IMPL_ADD(CV_IMPL_IPP);
+                return;
+            }
+            setIppErrorStatus();
+        }
     }
 #endif
   //vz optimized  cmp_(src1, step1, src2, step2, dst, step, size, *(int*)_cmpop);
@@ -3284,13 +3452,19 @@ static void cmp16u(const ushort* src1, size_t step1, const ushort* src2, size_t 
                   uchar* dst, size_t step, Size size, void* _cmpop)
 {
 #if ARITHM_USE_IPP
-    IppCmpOp op = convert_cmp(*(int *)_cmpop);
-    if( op  >= 0 )
+    CV_IPP_CHECK()
     {
-        fixSteps(size, sizeof(dst[0]), step1, step2, step);
-        if (0 <= ippiCompare_16u_C1R(src1, (int)step1, src2, (int)step2, dst, (int)step, ippiSize(size), op))
-            return;
-        setIppErrorStatus();
+        IppCmpOp op = convert_cmp(*(int *)_cmpop);
+        if( op  >= 0 )
+        {
+            fixSteps(size, sizeof(dst[0]), step1, step2, step);
+            if (0 <= ippiCompare_16u_C1R(src1, (int)step1, src2, (int)step2, dst, (int)step, ippiSize(size), op))
+            {
+                CV_IMPL_ADD(CV_IMPL_IPP);
+                return;
+            }
+            setIppErrorStatus();
+        }
     }
 #endif
     cmp_(src1, step1, src2, step2, dst, step, size, *(int*)_cmpop);
@@ -3300,13 +3474,19 @@ static void cmp16s(const short* src1, size_t step1, const short* src2, size_t st
                   uchar* dst, size_t step, Size size, void* _cmpop)
 {
 #if ARITHM_USE_IPP
-    IppCmpOp op = convert_cmp(*(int *)_cmpop);
-    if( op  > 0 )
+    CV_IPP_CHECK()
     {
-        fixSteps(size, sizeof(dst[0]), step1, step2, step);
-        if (0 <= ippiCompare_16s_C1R(src1, (int)step1, src2, (int)step2, dst, (int)step, ippiSize(size), op))
-            return;
-        setIppErrorStatus();
+        IppCmpOp op = convert_cmp(*(int *)_cmpop);
+        if( op  > 0 )
+        {
+            fixSteps(size, sizeof(dst[0]), step1, step2, step);
+            if (0 <= ippiCompare_16s_C1R(src1, (int)step1, src2, (int)step2, dst, (int)step, ippiSize(size), op))
+            {
+                CV_IMPL_ADD(CV_IMPL_IPP);
+                return;
+            }
+            setIppErrorStatus();
+        }
     }
 #endif
    //vz optimized cmp_(src1, step1, src2, step2, dst, step, size, *(int*)_cmpop);
@@ -3438,13 +3618,19 @@ static void cmp32f(const float* src1, size_t step1, const float* src2, size_t st
                   uchar* dst, size_t step, Size size, void* _cmpop)
 {
 #if ARITHM_USE_IPP
-    IppCmpOp op = convert_cmp(*(int *)_cmpop);
-    if( op  >= 0 )
+    CV_IPP_CHECK()
     {
-        fixSteps(size, sizeof(dst[0]), step1, step2, step);
-        if (0 <= ippiCompare_32f_C1R(src1, (int)step1, src2, (int)step2, dst, (int)step, ippiSize(size), op))
-            return;
-        setIppErrorStatus();
+        IppCmpOp op = convert_cmp(*(int *)_cmpop);
+        if( op  >= 0 )
+        {
+            fixSteps(size, sizeof(dst[0]), step1, step2, step);
+            if (0 <= ippiCompare_32f_C1R(src1, (int)step1, src2, (int)step2, dst, (int)step, ippiSize(size), op))
+            {
+                CV_IMPL_ADD(CV_IMPL_IPP);
+                return;
+            }
+            setIppErrorStatus();
+        }
     }
 #endif
     cmp_(src1, step1, src2, step2, dst, step, size, *(int*)_cmpop);

--- a/modules/core/src/copy.cpp
+++ b/modules/core/src/copy.cpp
@@ -82,9 +82,15 @@ template<> void
 copyMask_<uchar>(const uchar* _src, size_t sstep, const uchar* mask, size_t mstep, uchar* _dst, size_t dstep, Size size)
 {
 #if defined HAVE_IPP
-    if (ippiCopy_8u_C1MR(_src, (int)sstep, _dst, (int)dstep, ippiSize(size), mask, (int)mstep) >= 0)
-        return;
-    setIppErrorStatus();
+    CV_IPP_CHECK()
+    {
+        if (ippiCopy_8u_C1MR(_src, (int)sstep, _dst, (int)dstep, ippiSize(size), mask, (int)mstep) >= 0)
+        {
+            CV_IMPL_ADD(CV_IMPL_IPP);
+            return;
+        }
+        setIppErrorStatus();
+    }
 #endif
 
     for( ; size.height--; mask += mstep, _src += sstep, _dst += dstep )
@@ -126,9 +132,15 @@ template<> void
 copyMask_<ushort>(const uchar* _src, size_t sstep, const uchar* mask, size_t mstep, uchar* _dst, size_t dstep, Size size)
 {
 #if defined HAVE_IPP
-    if (ippiCopy_16u_C1MR((const Ipp16u *)_src, (int)sstep, (Ipp16u *)_dst, (int)dstep, ippiSize(size), mask, (int)mstep) >= 0)
-        return;
-    setIppErrorStatus();
+    CV_IPP_CHECK()
+    {
+        if (ippiCopy_16u_C1MR((const Ipp16u *)_src, (int)sstep, (Ipp16u *)_dst, (int)dstep, ippiSize(size), mask, (int)mstep) >= 0)
+        {
+            CV_IMPL_ADD(CV_IMPL_IPP);
+            return;
+        }
+        setIppErrorStatus();
+    }
 #endif
 
     for( ; size.height--; mask += mstep, _src += sstep, _dst += dstep )
@@ -201,9 +213,15 @@ static void copyMask##suffix(const uchar* src, size_t sstep, const uchar* mask, 
 static void copyMask##suffix(const uchar* src, size_t sstep, const uchar* mask, size_t mstep, \
                              uchar* dst, size_t dstep, Size size, void*) \
 { \
-    if (ippiCopy_##ippfavor((const ipptype *)src, (int)sstep, (ipptype *)dst, (int)dstep, ippiSize(size), (const Ipp8u *)mask, (int)mstep) >= 0) \
-        return; \
-    setIppErrorStatus(); \
+    CV_IPP_CHECK()\
+    {\
+        if (ippiCopy_##ippfavor((const ipptype *)src, (int)sstep, (ipptype *)dst, (int)dstep, ippiSize(size), (const Ipp8u *)mask, (int)mstep) >= 0) \
+        {\
+            CV_IMPL_ADD(CV_IMPL_IPP);\
+            return;\
+        }\
+        setIppErrorStatus(); \
+    }\
     copyMask_<type>(src, sstep, mask, mstep, dst, dstep, size); \
 }
 #else
@@ -301,9 +319,15 @@ void Mat::copyTo( OutputArray _dst ) const
             size_t len = sz.width*elemSize();
 
 #if defined HAVE_IPP
-            if (ippiCopy_8u_C1R(sptr, (int)step, dptr, (int)dst.step, ippiSize((int)len, sz.height)) >= 0)
-                return;
-            setIppErrorStatus();
+            CV_IPP_CHECK()
+            {
+                if (ippiCopy_8u_C1R(sptr, (int)step, dptr, (int)dst.step, ippiSize((int)len, sz.height)) >= 0)
+                {
+                    CV_IMPL_ADD(CV_IMPL_IPP)
+                    return;
+                }
+                setIppErrorStatus();
+            }
 #endif
 
             for( ; sz.height--; sptr += step, dptr += dst.step )
@@ -380,23 +404,32 @@ Mat& Mat::operator = (const Scalar& s)
     if( is[0] == 0 && is[1] == 0 && is[2] == 0 && is[3] == 0 )
     {
 #if defined HAVE_IPP && !defined HAVE_IPP_ICV_ONLY && 0
-        if (dims <= 2 || isContinuous())
+        CV_IPP_CHECK()
         {
-            IppiSize roisize = { cols, rows };
-            if (isContinuous())
+            if (dims <= 2 || isContinuous())
             {
-                roisize.width = (int)total();
-                roisize.height = 1;
+                IppiSize roisize = { cols, rows };
+                if (isContinuous())
+                {
+                    roisize.width = (int)total();
+                    roisize.height = 1;
 
-                if (ippsZero_8u(data, static_cast<int>(roisize.width * elemSize())) >= 0)
+                    if (ippsZero_8u(data, static_cast<int>(roisize.width * elemSize())) >= 0)
+                    {
+                        CV_IMPL_ADD(CV_IMPL_IPP)
+                        return *this;
+                    }
+                    setIppErrorStatus();
+                }
+                roisize.width *= (int)elemSize();
+
+                if (ippiSet_8u_C1R(0, data, (int)step, roisize) >= 0)
+                {
+                    CV_IMPL_ADD(CV_IMPL_IPP)
                     return *this;
+                }
                 setIppErrorStatus();
             }
-            roisize.width *= (int)elemSize();
-
-            if (ippiSet_8u_C1R(0, data, (int)step, roisize) >= 0)
-                return *this;
-            setIppErrorStatus();
         }
 #endif
 
@@ -439,77 +472,83 @@ Mat& Mat::setTo(InputArray _value, InputArray _mask)
     CV_Assert( mask.empty() || (mask.type() == CV_8U && size == mask.size) );
 
 #if defined HAVE_IPP
-    int cn = channels(), depth0 = depth();
-
-    if (!mask.empty() && (dims <= 2 || (isContinuous() && mask.isContinuous())) &&
-            (/*depth0 == CV_8U ||*/ depth0 == CV_16U || depth0 == CV_16S || depth0 == CV_32S || depth0 == CV_32F) &&
-            (cn == 1 || cn == 3 || cn == 4))
+    CV_IPP_CHECK()
     {
-        uchar _buf[32];
-        void * buf = _buf;
-        convertAndUnrollScalar( value, type(), _buf, 1 );
+        int cn = channels(), depth0 = depth();
 
-        IppStatus status = (IppStatus)-1;
-        IppiSize roisize = { cols, rows };
-        int mstep = (int)mask.step[0], dstep = (int)step[0];
+        if (!mask.empty() && (dims <= 2 || (isContinuous() && mask.isContinuous())) &&
+                (/*depth0 == CV_8U ||*/ depth0 == CV_16U || depth0 == CV_16S || depth0 == CV_32S || depth0 == CV_32F) &&
+                (cn == 1 || cn == 3 || cn == 4))
+        {
+            uchar _buf[32];
+            void * buf = _buf;
+            convertAndUnrollScalar( value, type(), _buf, 1 );
 
-        if (isContinuous() && mask.isContinuous())
-        {
-            roisize.width = (int)total();
-            roisize.height = 1;
-        }
+            IppStatus status = (IppStatus)-1;
+            IppiSize roisize = { cols, rows };
+            int mstep = (int)mask.step[0], dstep = (int)step[0];
 
-        if (cn == 1)
-        {
-            /*if (depth0 == CV_8U)
-                status = ippiSet_8u_C1MR(*(Ipp8u *)buf, (Ipp8u *)data, dstep, roisize, mask.data, mstep);
-            else*/ if (depth0 == CV_16U)
-                status = ippiSet_16u_C1MR(*(Ipp16u *)buf, (Ipp16u *)data, dstep, roisize, mask.data, mstep);
-            else if (depth0 == CV_16S)
-                status = ippiSet_16s_C1MR(*(Ipp16s *)buf, (Ipp16s *)data, dstep, roisize, mask.data, mstep);
-            else if (depth0 == CV_32S)
-                status = ippiSet_32s_C1MR(*(Ipp32s *)buf, (Ipp32s *)data, dstep, roisize, mask.data, mstep);
-            else if (depth0 == CV_32F)
-                status = ippiSet_32f_C1MR(*(Ipp32f *)buf, (Ipp32f *)data, dstep, roisize, mask.data, mstep);
-        }
-        else if (cn == 3 || cn == 4)
-        {
+            if (isContinuous() && mask.isContinuous())
+            {
+                roisize.width = (int)total();
+                roisize.height = 1;
+            }
+
+            if (cn == 1)
+            {
+                /*if (depth0 == CV_8U)
+                    status = ippiSet_8u_C1MR(*(Ipp8u *)buf, (Ipp8u *)data, dstep, roisize, mask.data, mstep);
+                else*/ if (depth0 == CV_16U)
+                    status = ippiSet_16u_C1MR(*(Ipp16u *)buf, (Ipp16u *)data, dstep, roisize, mask.data, mstep);
+                else if (depth0 == CV_16S)
+                    status = ippiSet_16s_C1MR(*(Ipp16s *)buf, (Ipp16s *)data, dstep, roisize, mask.data, mstep);
+                else if (depth0 == CV_32S)
+                    status = ippiSet_32s_C1MR(*(Ipp32s *)buf, (Ipp32s *)data, dstep, roisize, mask.data, mstep);
+                else if (depth0 == CV_32F)
+                    status = ippiSet_32f_C1MR(*(Ipp32f *)buf, (Ipp32f *)data, dstep, roisize, mask.data, mstep);
+            }
+            else if (cn == 3 || cn == 4)
+            {
 #define IPP_SET(ippfavor, ippcn) \
-    do \
-    { \
-        typedef Ipp##ippfavor ipptype; \
-        ipptype ippvalue[4] = { ((ipptype *)buf)[0], ((ipptype *)buf)[1], ((ipptype *)buf)[2], ((ipptype *)buf)[3] }; \
-        status = ippiSet_##ippfavor##_C##ippcn##MR(ippvalue, (ipptype *)data, dstep, roisize, mask.data, mstep); \
-    } while ((void)0, 0)
+        do \
+        { \
+            typedef Ipp##ippfavor ipptype; \
+            ipptype ippvalue[4] = { ((ipptype *)buf)[0], ((ipptype *)buf)[1], ((ipptype *)buf)[2], ((ipptype *)buf)[3] }; \
+            status = ippiSet_##ippfavor##_C##ippcn##MR(ippvalue, (ipptype *)data, dstep, roisize, mask.data, mstep); \
+        } while ((void)0, 0)
 
 #define IPP_SET_CN(ippcn) \
-    do \
-    { \
-        if (cn == ippcn) \
+        do \
         { \
-            /*if (depth0 == CV_8U) \
-                IPP_SET(8u, ippcn); \
-            else*/ if (depth0 == CV_16U) \
-                IPP_SET(16u, ippcn); \
-            else if (depth0 == CV_16S) \
-                IPP_SET(16s, ippcn); \
-            else if (depth0 == CV_32S) \
-                IPP_SET(32s, ippcn); \
-            else if (depth0 == CV_32F) \
-                IPP_SET(32f, ippcn); \
-        } \
-    } while ((void)0, 0)
+            if (cn == ippcn) \
+            { \
+                /*if (depth0 == CV_8U) \
+                    IPP_SET(8u, ippcn); \
+                else*/ if (depth0 == CV_16U) \
+                    IPP_SET(16u, ippcn); \
+                else if (depth0 == CV_16S) \
+                    IPP_SET(16s, ippcn); \
+                else if (depth0 == CV_32S) \
+                    IPP_SET(32s, ippcn); \
+                else if (depth0 == CV_32F) \
+                    IPP_SET(32f, ippcn); \
+            } \
+        } while ((void)0, 0)
 
-            IPP_SET_CN(3);
-            IPP_SET_CN(4);
+                IPP_SET_CN(3);
+                IPP_SET_CN(4);
 
 #undef IPP_SET_CN
 #undef IPP_SET
-        }
+            }
 
-        if (status >= 0)
-            return *this;
-        setIppErrorStatus();
+            if (status >= 0)
+            {
+                CV_IMPL_ADD(CV_IMPL_IPP);
+                return *this;
+            }
+            setIppErrorStatus();
+        }
     }
 #endif
 
@@ -714,66 +753,75 @@ void flip( InputArray _src, OutputArray _dst, int flip_mode )
     size_t esz = CV_ELEM_SIZE(type);
 
 #if defined HAVE_IPP
-    typedef IppStatus (CV_STDCALL * ippiMirror)(const void * pSrc, int srcStep, void * pDst, int dstStep, IppiSize roiSize, IppiAxis flip);
-    typedef IppStatus (CV_STDCALL * ippiMirrorI)(const void * pSrcDst, int srcDstStep, IppiSize roiSize, IppiAxis flip);
-    ippiMirror ippFunc = 0;
-    ippiMirrorI ippFuncI = 0;
+    CV_IPP_CHECK()
+    {
+        typedef IppStatus (CV_STDCALL * ippiMirror)(const void * pSrc, int srcStep, void * pDst, int dstStep, IppiSize roiSize, IppiAxis flip);
+        typedef IppStatus (CV_STDCALL * ippiMirrorI)(const void * pSrcDst, int srcDstStep, IppiSize roiSize, IppiAxis flip);
+        ippiMirror ippFunc = 0;
+        ippiMirrorI ippFuncI = 0;
 
-    if (src.data == dst.data)
-    {
-        CV_SUPPRESS_DEPRECATED_START
-        ippFuncI =
-            type == CV_8UC1 ? (ippiMirrorI)ippiMirror_8u_C1IR :
-            type == CV_8UC3 ? (ippiMirrorI)ippiMirror_8u_C3IR :
-            type == CV_8UC4 ? (ippiMirrorI)ippiMirror_8u_C4IR :
-            type == CV_16UC1 ? (ippiMirrorI)ippiMirror_16u_C1IR :
-            type == CV_16UC3 ? (ippiMirrorI)ippiMirror_16u_C3IR :
-            type == CV_16UC4 ? (ippiMirrorI)ippiMirror_16u_C4IR :
-            type == CV_16SC1 ? (ippiMirrorI)ippiMirror_16s_C1IR :
-            type == CV_16SC3 ? (ippiMirrorI)ippiMirror_16s_C3IR :
-            type == CV_16SC4 ? (ippiMirrorI)ippiMirror_16s_C4IR :
-            type == CV_32SC1 ? (ippiMirrorI)ippiMirror_32s_C1IR :
-            type == CV_32SC3 ? (ippiMirrorI)ippiMirror_32s_C3IR :
-            type == CV_32SC4 ? (ippiMirrorI)ippiMirror_32s_C4IR :
-            type == CV_32FC1 ? (ippiMirrorI)ippiMirror_32f_C1IR :
-            type == CV_32FC3 ? (ippiMirrorI)ippiMirror_32f_C3IR :
-            type == CV_32FC4 ? (ippiMirrorI)ippiMirror_32f_C4IR : 0;
-        CV_SUPPRESS_DEPRECATED_END
-    }
-    else
-    {
-        ippFunc =
-            type == CV_8UC1 ? (ippiMirror)ippiMirror_8u_C1R :
-            type == CV_8UC3 ? (ippiMirror)ippiMirror_8u_C3R :
-            type == CV_8UC4 ? (ippiMirror)ippiMirror_8u_C4R :
-            type == CV_16UC1 ? (ippiMirror)ippiMirror_16u_C1R :
-            type == CV_16UC3 ? (ippiMirror)ippiMirror_16u_C3R :
-            type == CV_16UC4 ? (ippiMirror)ippiMirror_16u_C4R :
-            type == CV_16SC1 ? (ippiMirror)ippiMirror_16s_C1R :
-            type == CV_16SC3 ? (ippiMirror)ippiMirror_16s_C3R :
-            type == CV_16SC4 ? (ippiMirror)ippiMirror_16s_C4R :
-            type == CV_32SC1 ? (ippiMirror)ippiMirror_32s_C1R :
-            type == CV_32SC3 ? (ippiMirror)ippiMirror_32s_C3R :
-            type == CV_32SC4 ? (ippiMirror)ippiMirror_32s_C4R :
-            type == CV_32FC1 ? (ippiMirror)ippiMirror_32f_C1R :
-            type == CV_32FC3 ? (ippiMirror)ippiMirror_32f_C3R :
-            type == CV_32FC4 ? (ippiMirror)ippiMirror_32f_C4R : 0;
-    }
-    IppiAxis axis = flip_mode == 0 ? ippAxsHorizontal :
-        flip_mode > 0 ? ippAxsVertical : ippAxsBoth;
-    IppiSize roisize = { dst.cols, dst.rows };
+        if (src.data == dst.data)
+        {
+            CV_SUPPRESS_DEPRECATED_START
+            ippFuncI =
+                type == CV_8UC1 ? (ippiMirrorI)ippiMirror_8u_C1IR :
+                type == CV_8UC3 ? (ippiMirrorI)ippiMirror_8u_C3IR :
+                type == CV_8UC4 ? (ippiMirrorI)ippiMirror_8u_C4IR :
+                type == CV_16UC1 ? (ippiMirrorI)ippiMirror_16u_C1IR :
+                type == CV_16UC3 ? (ippiMirrorI)ippiMirror_16u_C3IR :
+                type == CV_16UC4 ? (ippiMirrorI)ippiMirror_16u_C4IR :
+                type == CV_16SC1 ? (ippiMirrorI)ippiMirror_16s_C1IR :
+                type == CV_16SC3 ? (ippiMirrorI)ippiMirror_16s_C3IR :
+                type == CV_16SC4 ? (ippiMirrorI)ippiMirror_16s_C4IR :
+                type == CV_32SC1 ? (ippiMirrorI)ippiMirror_32s_C1IR :
+                type == CV_32SC3 ? (ippiMirrorI)ippiMirror_32s_C3IR :
+                type == CV_32SC4 ? (ippiMirrorI)ippiMirror_32s_C4IR :
+                type == CV_32FC1 ? (ippiMirrorI)ippiMirror_32f_C1IR :
+                type == CV_32FC3 ? (ippiMirrorI)ippiMirror_32f_C3IR :
+                type == CV_32FC4 ? (ippiMirrorI)ippiMirror_32f_C4IR : 0;
+            CV_SUPPRESS_DEPRECATED_END
+        }
+        else
+        {
+            ippFunc =
+                type == CV_8UC1 ? (ippiMirror)ippiMirror_8u_C1R :
+                type == CV_8UC3 ? (ippiMirror)ippiMirror_8u_C3R :
+                type == CV_8UC4 ? (ippiMirror)ippiMirror_8u_C4R :
+                type == CV_16UC1 ? (ippiMirror)ippiMirror_16u_C1R :
+                type == CV_16UC3 ? (ippiMirror)ippiMirror_16u_C3R :
+                type == CV_16UC4 ? (ippiMirror)ippiMirror_16u_C4R :
+                type == CV_16SC1 ? (ippiMirror)ippiMirror_16s_C1R :
+                type == CV_16SC3 ? (ippiMirror)ippiMirror_16s_C3R :
+                type == CV_16SC4 ? (ippiMirror)ippiMirror_16s_C4R :
+                type == CV_32SC1 ? (ippiMirror)ippiMirror_32s_C1R :
+                type == CV_32SC3 ? (ippiMirror)ippiMirror_32s_C3R :
+                type == CV_32SC4 ? (ippiMirror)ippiMirror_32s_C4R :
+                type == CV_32FC1 ? (ippiMirror)ippiMirror_32f_C1R :
+                type == CV_32FC3 ? (ippiMirror)ippiMirror_32f_C3R :
+                type == CV_32FC4 ? (ippiMirror)ippiMirror_32f_C4R : 0;
+        }
+        IppiAxis axis = flip_mode == 0 ? ippAxsHorizontal :
+            flip_mode > 0 ? ippAxsVertical : ippAxsBoth;
+        IppiSize roisize = { dst.cols, dst.rows };
 
-    if (ippFunc != 0)
-    {
-        if (ippFunc(src.ptr(), (int)src.step, dst.ptr(), (int)dst.step, ippiSize(src.cols, src.rows), axis) >= 0)
-            return;
-        setIppErrorStatus();
-    }
-    else if (ippFuncI != 0)
-    {
-        if (ippFuncI(dst.ptr(), (int)dst.step, roisize, axis) >= 0)
-            return;
-        setIppErrorStatus();
+        if (ippFunc != 0)
+        {
+            if (ippFunc(src.ptr(), (int)src.step, dst.ptr(), (int)dst.step, ippiSize(src.cols, src.rows), axis) >= 0)
+            {
+                CV_IMPL_ADD(CV_IMPL_IPP);
+                return;
+            }
+            setIppErrorStatus();
+        }
+        else if (ippFuncI != 0)
+        {
+            if (ippFuncI(dst.ptr(), (int)dst.step, roisize, axis) >= 0)
+            {
+                CV_IMPL_ADD(CV_IMPL_IPP);
+                return;
+            }
+            setIppErrorStatus();
+        }
     }
 #endif
 
@@ -1135,111 +1183,117 @@ void cv::copyMakeBorder( InputArray _src, OutputArray _dst, int top, int bottom,
     borderType &= ~BORDER_ISOLATED;
 
 #if defined HAVE_IPP && 0
-    typedef IppStatus (CV_STDCALL * ippiCopyMakeBorder)(const void * pSrc, int srcStep, IppiSize srcRoiSize, void * pDst,
-                                                        int dstStep, IppiSize dstRoiSize, int topBorderHeight, int leftBorderWidth);
-    typedef IppStatus (CV_STDCALL * ippiCopyMakeBorderI)(const void * pSrc, int srcDstStep, IppiSize srcRoiSize, IppiSize dstRoiSize,
-                                                         int topBorderHeight, int leftborderwidth);
-    typedef IppStatus (CV_STDCALL * ippiCopyConstBorder)(const void * pSrc, int srcStep, IppiSize srcRoiSize, void * pDst, int dstStep,
-                                                         IppiSize dstRoiSize, int topBorderHeight, int leftBorderWidth, void * value);
-
-    IppiSize srcRoiSize = { src.cols, src.rows }, dstRoiSize = { dst.cols, dst.rows };
-    ippiCopyMakeBorder ippFunc = 0;
-    ippiCopyMakeBorderI ippFuncI = 0;
-    ippiCopyConstBorder ippFuncConst = 0;
-    bool inplace = dst.datastart == src.datastart;
-
-    if (borderType == BORDER_CONSTANT)
+    CV_IPP_CHECK()
     {
-         ippFuncConst =
-//             type == CV_8UC1 ? (ippiCopyConstBorder)ippiCopyConstBorder_8u_C1R : bug in IPP 8.1
-             type == CV_16UC1 ? (ippiCopyConstBorder)ippiCopyConstBorder_16u_C1R :
-//             type == CV_16SC1 ? (ippiCopyConstBorder)ippiCopyConstBorder_16s_C1R : bug in IPP 8.1
-//             type == CV_32SC1 ? (ippiCopyConstBorder)ippiCopyConstBorder_32s_C1R : bug in IPP 8.1
-//             type == CV_32FC1 ? (ippiCopyConstBorder)ippiCopyConstBorder_32f_C1R : bug in IPP 8.1
-             type == CV_8UC3 ? (ippiCopyConstBorder)ippiCopyConstBorder_8u_C3R :
-             type == CV_16UC3 ? (ippiCopyConstBorder)ippiCopyConstBorder_16u_C3R :
-             type == CV_16SC3 ? (ippiCopyConstBorder)ippiCopyConstBorder_16s_C3R :
-             type == CV_32SC3 ? (ippiCopyConstBorder)ippiCopyConstBorder_32s_C3R :
-             type == CV_32FC3 ? (ippiCopyConstBorder)ippiCopyConstBorder_32f_C3R :
-             type == CV_8UC4 ? (ippiCopyConstBorder)ippiCopyConstBorder_8u_C4R :
-             type == CV_16UC4 ? (ippiCopyConstBorder)ippiCopyConstBorder_16u_C4R :
-             type == CV_16SC4 ? (ippiCopyConstBorder)ippiCopyConstBorder_16s_C4R :
-             type == CV_32SC4 ? (ippiCopyConstBorder)ippiCopyConstBorder_32s_C4R :
-             type == CV_32FC4 ? (ippiCopyConstBorder)ippiCopyConstBorder_32f_C4R : 0;
-    }
-    else if (borderType == BORDER_WRAP)
-    {
-        if (inplace)
-        {
-            CV_SUPPRESS_DEPRECATED_START
-            ippFuncI =
-                type == CV_32SC1 ? (ippiCopyMakeBorderI)ippiCopyWrapBorder_32s_C1IR :
-                type == CV_32FC1 ? (ippiCopyMakeBorderI)ippiCopyWrapBorder_32s_C1IR : 0;
-            CV_SUPPRESS_DEPRECATED_END
-        }
-        else
-        {
-            ippFunc =
-                type == CV_32SC1 ? (ippiCopyMakeBorder)ippiCopyWrapBorder_32s_C1R :
-                type == CV_32FC1 ? (ippiCopyMakeBorder)ippiCopyWrapBorder_32s_C1R : 0;
-        }
-    }
-    else if (borderType == BORDER_REPLICATE)
-    {
-        if (inplace)
-        {
-            CV_SUPPRESS_DEPRECATED_START
-            ippFuncI =
-                type == CV_8UC1 ? (ippiCopyMakeBorderI)ippiCopyReplicateBorder_8u_C1IR :
-                type == CV_16UC1 ? (ippiCopyMakeBorderI)ippiCopyReplicateBorder_16u_C1IR :
-                type == CV_16SC1 ? (ippiCopyMakeBorderI)ippiCopyReplicateBorder_16s_C1IR :
-                type == CV_32SC1 ? (ippiCopyMakeBorderI)ippiCopyReplicateBorder_32s_C1IR :
-                type == CV_32FC1 ? (ippiCopyMakeBorderI)ippiCopyReplicateBorder_32f_C1IR :
-                type == CV_8UC3 ? (ippiCopyMakeBorderI)ippiCopyReplicateBorder_8u_C3IR :
-                type == CV_16UC3 ? (ippiCopyMakeBorderI)ippiCopyReplicateBorder_16u_C3IR :
-                type == CV_16SC3 ? (ippiCopyMakeBorderI)ippiCopyReplicateBorder_16s_C3IR :
-                type == CV_32SC3 ? (ippiCopyMakeBorderI)ippiCopyReplicateBorder_32s_C3IR :
-                type == CV_32FC3 ? (ippiCopyMakeBorderI)ippiCopyReplicateBorder_32f_C3IR :
-                type == CV_8UC4 ? (ippiCopyMakeBorderI)ippiCopyReplicateBorder_8u_C4IR :
-                type == CV_16UC4 ? (ippiCopyMakeBorderI)ippiCopyReplicateBorder_16u_C4IR :
-                type == CV_16SC4 ? (ippiCopyMakeBorderI)ippiCopyReplicateBorder_16s_C4IR :
-                type == CV_32SC4 ? (ippiCopyMakeBorderI)ippiCopyReplicateBorder_32s_C4IR :
-                type == CV_32FC4 ? (ippiCopyMakeBorderI)ippiCopyReplicateBorder_32f_C4IR : 0;
-            CV_SUPPRESS_DEPRECATED_END
-        }
-        else
-        {
-             ippFunc =
-                 type == CV_8UC1 ? (ippiCopyMakeBorder)ippiCopyReplicateBorder_8u_C1R :
-                 type == CV_16UC1 ? (ippiCopyMakeBorder)ippiCopyReplicateBorder_16u_C1R :
-                 type == CV_16SC1 ? (ippiCopyMakeBorder)ippiCopyReplicateBorder_16s_C1R :
-                 type == CV_32SC1 ? (ippiCopyMakeBorder)ippiCopyReplicateBorder_32s_C1R :
-                 type == CV_32FC1 ? (ippiCopyMakeBorder)ippiCopyReplicateBorder_32f_C1R :
-                 type == CV_8UC3 ? (ippiCopyMakeBorder)ippiCopyReplicateBorder_8u_C3R :
-                 type == CV_16UC3 ? (ippiCopyMakeBorder)ippiCopyReplicateBorder_16u_C3R :
-                 type == CV_16SC3 ? (ippiCopyMakeBorder)ippiCopyReplicateBorder_16s_C3R :
-                 type == CV_32SC3 ? (ippiCopyMakeBorder)ippiCopyReplicateBorder_32s_C3R :
-                 type == CV_32FC3 ? (ippiCopyMakeBorder)ippiCopyReplicateBorder_32f_C3R :
-                 type == CV_8UC4 ? (ippiCopyMakeBorder)ippiCopyReplicateBorder_8u_C4R :
-                 type == CV_16UC4 ? (ippiCopyMakeBorder)ippiCopyReplicateBorder_16u_C4R :
-                 type == CV_16SC4 ? (ippiCopyMakeBorder)ippiCopyReplicateBorder_16s_C4R :
-                 type == CV_32SC4 ? (ippiCopyMakeBorder)ippiCopyReplicateBorder_32s_C4R :
-                 type == CV_32FC4 ? (ippiCopyMakeBorder)ippiCopyReplicateBorder_32f_C4R : 0;
-        }
-    }
+        typedef IppStatus (CV_STDCALL * ippiCopyMakeBorder)(const void * pSrc, int srcStep, IppiSize srcRoiSize, void * pDst,
+                                                            int dstStep, IppiSize dstRoiSize, int topBorderHeight, int leftBorderWidth);
+        typedef IppStatus (CV_STDCALL * ippiCopyMakeBorderI)(const void * pSrc, int srcDstStep, IppiSize srcRoiSize, IppiSize dstRoiSize,
+                                                             int topBorderHeight, int leftborderwidth);
+        typedef IppStatus (CV_STDCALL * ippiCopyConstBorder)(const void * pSrc, int srcStep, IppiSize srcRoiSize, void * pDst, int dstStep,
+                                                             IppiSize dstRoiSize, int topBorderHeight, int leftBorderWidth, void * value);
 
-    if (ippFunc || ippFuncI || ippFuncConst)
-    {
-        uchar scbuf[32];
-        scalarToRawData(value, scbuf, type);
+        IppiSize srcRoiSize = { src.cols, src.rows }, dstRoiSize = { dst.cols, dst.rows };
+        ippiCopyMakeBorder ippFunc = 0;
+        ippiCopyMakeBorderI ippFuncI = 0;
+        ippiCopyConstBorder ippFuncConst = 0;
+        bool inplace = dst.datastart == src.datastart;
 
-        if ( (ippFunc && ippFunc(src.data, (int)src.step, srcRoiSize, dst.data, (int)dst.step, dstRoiSize, top, left) >= 0) ||
-             (ippFuncI && ippFuncI(src.data, (int)src.step, srcRoiSize, dstRoiSize, top, left) >= 0) ||
-             (ippFuncConst && ippFuncConst(src.data, (int)src.step, srcRoiSize, dst.data, (int)dst.step,
-                                           dstRoiSize, top, left, scbuf) >= 0))
-            return;
+        if (borderType == BORDER_CONSTANT)
+        {
+             ippFuncConst =
+    //             type == CV_8UC1 ? (ippiCopyConstBorder)ippiCopyConstBorder_8u_C1R : bug in IPP 8.1
+                 type == CV_16UC1 ? (ippiCopyConstBorder)ippiCopyConstBorder_16u_C1R :
+    //             type == CV_16SC1 ? (ippiCopyConstBorder)ippiCopyConstBorder_16s_C1R : bug in IPP 8.1
+    //             type == CV_32SC1 ? (ippiCopyConstBorder)ippiCopyConstBorder_32s_C1R : bug in IPP 8.1
+    //             type == CV_32FC1 ? (ippiCopyConstBorder)ippiCopyConstBorder_32f_C1R : bug in IPP 8.1
+                 type == CV_8UC3 ? (ippiCopyConstBorder)ippiCopyConstBorder_8u_C3R :
+                 type == CV_16UC3 ? (ippiCopyConstBorder)ippiCopyConstBorder_16u_C3R :
+                 type == CV_16SC3 ? (ippiCopyConstBorder)ippiCopyConstBorder_16s_C3R :
+                 type == CV_32SC3 ? (ippiCopyConstBorder)ippiCopyConstBorder_32s_C3R :
+                 type == CV_32FC3 ? (ippiCopyConstBorder)ippiCopyConstBorder_32f_C3R :
+                 type == CV_8UC4 ? (ippiCopyConstBorder)ippiCopyConstBorder_8u_C4R :
+                 type == CV_16UC4 ? (ippiCopyConstBorder)ippiCopyConstBorder_16u_C4R :
+                 type == CV_16SC4 ? (ippiCopyConstBorder)ippiCopyConstBorder_16s_C4R :
+                 type == CV_32SC4 ? (ippiCopyConstBorder)ippiCopyConstBorder_32s_C4R :
+                 type == CV_32FC4 ? (ippiCopyConstBorder)ippiCopyConstBorder_32f_C4R : 0;
+        }
+        else if (borderType == BORDER_WRAP)
+        {
+            if (inplace)
+            {
+                CV_SUPPRESS_DEPRECATED_START
+                ippFuncI =
+                    type == CV_32SC1 ? (ippiCopyMakeBorderI)ippiCopyWrapBorder_32s_C1IR :
+                    type == CV_32FC1 ? (ippiCopyMakeBorderI)ippiCopyWrapBorder_32s_C1IR : 0;
+                CV_SUPPRESS_DEPRECATED_END
+            }
+            else
+            {
+                ippFunc =
+                    type == CV_32SC1 ? (ippiCopyMakeBorder)ippiCopyWrapBorder_32s_C1R :
+                    type == CV_32FC1 ? (ippiCopyMakeBorder)ippiCopyWrapBorder_32s_C1R : 0;
+            }
+        }
+        else if (borderType == BORDER_REPLICATE)
+        {
+            if (inplace)
+            {
+                CV_SUPPRESS_DEPRECATED_START
+                ippFuncI =
+                    type == CV_8UC1 ? (ippiCopyMakeBorderI)ippiCopyReplicateBorder_8u_C1IR :
+                    type == CV_16UC1 ? (ippiCopyMakeBorderI)ippiCopyReplicateBorder_16u_C1IR :
+                    type == CV_16SC1 ? (ippiCopyMakeBorderI)ippiCopyReplicateBorder_16s_C1IR :
+                    type == CV_32SC1 ? (ippiCopyMakeBorderI)ippiCopyReplicateBorder_32s_C1IR :
+                    type == CV_32FC1 ? (ippiCopyMakeBorderI)ippiCopyReplicateBorder_32f_C1IR :
+                    type == CV_8UC3 ? (ippiCopyMakeBorderI)ippiCopyReplicateBorder_8u_C3IR :
+                    type == CV_16UC3 ? (ippiCopyMakeBorderI)ippiCopyReplicateBorder_16u_C3IR :
+                    type == CV_16SC3 ? (ippiCopyMakeBorderI)ippiCopyReplicateBorder_16s_C3IR :
+                    type == CV_32SC3 ? (ippiCopyMakeBorderI)ippiCopyReplicateBorder_32s_C3IR :
+                    type == CV_32FC3 ? (ippiCopyMakeBorderI)ippiCopyReplicateBorder_32f_C3IR :
+                    type == CV_8UC4 ? (ippiCopyMakeBorderI)ippiCopyReplicateBorder_8u_C4IR :
+                    type == CV_16UC4 ? (ippiCopyMakeBorderI)ippiCopyReplicateBorder_16u_C4IR :
+                    type == CV_16SC4 ? (ippiCopyMakeBorderI)ippiCopyReplicateBorder_16s_C4IR :
+                    type == CV_32SC4 ? (ippiCopyMakeBorderI)ippiCopyReplicateBorder_32s_C4IR :
+                    type == CV_32FC4 ? (ippiCopyMakeBorderI)ippiCopyReplicateBorder_32f_C4IR : 0;
+                CV_SUPPRESS_DEPRECATED_END
+            }
+            else
+            {
+                 ippFunc =
+                     type == CV_8UC1 ? (ippiCopyMakeBorder)ippiCopyReplicateBorder_8u_C1R :
+                     type == CV_16UC1 ? (ippiCopyMakeBorder)ippiCopyReplicateBorder_16u_C1R :
+                     type == CV_16SC1 ? (ippiCopyMakeBorder)ippiCopyReplicateBorder_16s_C1R :
+                     type == CV_32SC1 ? (ippiCopyMakeBorder)ippiCopyReplicateBorder_32s_C1R :
+                     type == CV_32FC1 ? (ippiCopyMakeBorder)ippiCopyReplicateBorder_32f_C1R :
+                     type == CV_8UC3 ? (ippiCopyMakeBorder)ippiCopyReplicateBorder_8u_C3R :
+                     type == CV_16UC3 ? (ippiCopyMakeBorder)ippiCopyReplicateBorder_16u_C3R :
+                     type == CV_16SC3 ? (ippiCopyMakeBorder)ippiCopyReplicateBorder_16s_C3R :
+                     type == CV_32SC3 ? (ippiCopyMakeBorder)ippiCopyReplicateBorder_32s_C3R :
+                     type == CV_32FC3 ? (ippiCopyMakeBorder)ippiCopyReplicateBorder_32f_C3R :
+                     type == CV_8UC4 ? (ippiCopyMakeBorder)ippiCopyReplicateBorder_8u_C4R :
+                     type == CV_16UC4 ? (ippiCopyMakeBorder)ippiCopyReplicateBorder_16u_C4R :
+                     type == CV_16SC4 ? (ippiCopyMakeBorder)ippiCopyReplicateBorder_16s_C4R :
+                     type == CV_32SC4 ? (ippiCopyMakeBorder)ippiCopyReplicateBorder_32s_C4R :
+                     type == CV_32FC4 ? (ippiCopyMakeBorder)ippiCopyReplicateBorder_32f_C4R : 0;
+            }
+        }
 
-        setIppErrorStatus();
+        if (ippFunc || ippFuncI || ippFuncConst)
+        {
+            uchar scbuf[32];
+            scalarToRawData(value, scbuf, type);
+
+            if ( (ippFunc && ippFunc(src.data, (int)src.step, srcRoiSize, dst.data, (int)dst.step, dstRoiSize, top, left) >= 0) ||
+                 (ippFuncI && ippFuncI(src.data, (int)src.step, srcRoiSize, dstRoiSize, top, left) >= 0) ||
+                 (ippFuncConst && ippFuncConst(src.data, (int)src.step, srcRoiSize, dst.data, (int)dst.step,
+                                               dstRoiSize, top, left, scbuf) >= 0))
+            {
+                CV_IMPL_ADD(CV_IMPL_IPP);
+                return;
+            }
+
+            setIppErrorStatus();
+        }
     }
 #endif
 

--- a/modules/core/src/mathfuncs.cpp
+++ b/modules/core/src/mathfuncs.cpp
@@ -240,10 +240,16 @@ float  cubeRoot( float value )
 static void Magnitude_32f(const float* x, const float* y, float* mag, int len)
 {
 #if defined HAVE_IPP && 0
-    IppStatus status = ippsMagnitude_32f(x, y, mag, len);
-    if (status >= 0)
-        return;
-    setIppErrorStatus();
+    CV_IPP_CHECK()
+    {
+        IppStatus status = ippsMagnitude_32f(x, y, mag, len);
+        if (status >= 0)
+        {
+            CV_IMPL_ADD(CV_IMPL_IPP);
+            return;
+        }
+        setIppErrorStatus();
+    }
 #endif
 
     int i = 0;
@@ -286,10 +292,16 @@ static void Magnitude_32f(const float* x, const float* y, float* mag, int len)
 static void Magnitude_64f(const double* x, const double* y, double* mag, int len)
 {
 #if defined(HAVE_IPP)
-    IppStatus status = ippsMagnitude_64f(x, y, mag, len);
-    if (status >= 0)
-        return;
-    setIppErrorStatus();
+    CV_IPP_CHECK()
+    {
+        IppStatus status = ippsMagnitude_64f(x, y, mag, len);
+        if (status >= 0)
+        {
+            CV_IMPL_ADD(CV_IMPL_IPP);
+            return;
+        }
+        setIppErrorStatus();
+    }
 #endif
 
     int i = 0;
@@ -320,9 +332,15 @@ static void Magnitude_64f(const double* x, const double* y, double* mag, int len
 static void InvSqrt_32f(const float* src, float* dst, int len)
 {
 #if defined(HAVE_IPP)
-    if (ippsInvSqrt_32f_A21(src, dst, len) >= 0)
-        return;
-    setIppErrorStatus();
+    CV_IPP_CHECK()
+    {
+        if (ippsInvSqrt_32f_A21(src, dst, len) >= 0)
+        {
+            CV_IMPL_ADD(CV_IMPL_IPP);
+            return;
+        }
+        setIppErrorStatus();
+    }
 #endif
 
     int i = 0;
@@ -380,9 +398,15 @@ static void InvSqrt_64f(const double* src, double* dst, int len)
 static void Sqrt_32f(const float* src, float* dst, int len)
 {
 #if defined(HAVE_IPP)
-    if (ippsSqrt_32f_A21(src, dst, len) >= 0)
-        return;
-    setIppErrorStatus();
+    CV_IPP_CHECK()
+    {
+        if (ippsSqrt_32f_A21(src, dst, len) >= 0)
+        {
+            CV_IMPL_ADD(CV_IMPL_IPP);
+            return;
+        }
+        setIppErrorStatus();
+    }
 #endif
     int i = 0;
 
@@ -414,9 +438,15 @@ static void Sqrt_32f(const float* src, float* dst, int len)
 static void Sqrt_64f(const double* src, double* dst, int len)
 {
 #if defined(HAVE_IPP)
-    if (ippsSqrt_64f_A50(src, dst, len) >= 0)
-        return;
-    setIppErrorStatus();
+    CV_IPP_CHECK()
+    {
+        if (ippsSqrt_64f_A50(src, dst, len) >= 0)
+        {
+            CV_IMPL_ADD(CV_IMPL_IPP);
+            return;
+        }
+        setIppErrorStatus();
+    }
 #endif
 
     int i = 0;
@@ -790,19 +820,25 @@ void polarToCart( InputArray src1, InputArray src2,
     Mat X = dst1.getMat(), Y = dst2.getMat();
 
 #if defined(HAVE_IPP)
-    if (Mag.isContinuous() && Angle.isContinuous() && X.isContinuous() && Y.isContinuous() && !angleInDegrees)
+    CV_IPP_CHECK()
     {
-        typedef IppStatus (CV_STDCALL * ippsPolarToCart)(const void * pSrcMagn, const void * pSrcPhase,
-                                                         void * pDstRe, void * pDstIm, int len);
-        ippsPolarToCart ippFunc =
-        depth == CV_32F ? (ippsPolarToCart)ippsPolarToCart_32f :
-        depth == CV_64F ? (ippsPolarToCart)ippsPolarToCart_64f : 0;
-        CV_Assert(ippFunc != 0);
+        if (Mag.isContinuous() && Angle.isContinuous() && X.isContinuous() && Y.isContinuous() && !angleInDegrees)
+        {
+            typedef IppStatus (CV_STDCALL * ippsPolarToCart)(const void * pSrcMagn, const void * pSrcPhase,
+                                                             void * pDstRe, void * pDstIm, int len);
+            ippsPolarToCart ippFunc =
+            depth == CV_32F ? (ippsPolarToCart)ippsPolarToCart_32f :
+            depth == CV_64F ? (ippsPolarToCart)ippsPolarToCart_64f : 0;
+            CV_Assert(ippFunc != 0);
 
-        IppStatus status = ippFunc(Mag.ptr(), Angle.ptr(), X.ptr(), Y.ptr(), static_cast<int>(cn * X.total()));
-        if (status >= 0)
-            return;
-        setIppErrorStatus();
+            IppStatus status = ippFunc(Mag.ptr(), Angle.ptr(), X.ptr(), Y.ptr(), static_cast<int>(cn * X.total()));
+            if (status >= 0)
+            {
+                CV_IMPL_ADD(CV_IMPL_IPP);
+                return;
+            }
+            setIppErrorStatus();
+        }
     }
 #endif
 
@@ -1353,17 +1389,29 @@ static void Exp_64f( const double *_x, double *y, int n )
 #ifdef HAVE_IPP
 static void Exp_32f_ipp(const float *x, float *y, int n)
 {
-    if (0 <= ippsExp_32f_A21(x, y, n))
-        return;
-    setIppErrorStatus();
+    CV_IPP_CHECK()
+    {
+        if (0 <= ippsExp_32f_A21(x, y, n))
+        {
+            CV_IMPL_ADD(CV_IMPL_IPP);
+            return;
+        }
+        setIppErrorStatus();
+    }
     Exp_32f(x, y, n);
 }
 
 static void Exp_64f_ipp(const double *x, double *y, int n)
 {
-    if (0 <= ippsExp_64f_A50(x, y, n))
-        return;
-    setIppErrorStatus();
+    CV_IPP_CHECK()
+    {
+        if (0 <= ippsExp_64f_A50(x, y, n))
+        {
+            CV_IMPL_ADD(CV_IMPL_IPP);
+            return;
+        }
+        setIppErrorStatus();
+    }
     Exp_64f(x, y, n);
 }
 
@@ -2013,17 +2061,29 @@ static void Log_64f( const double *x, double *y, int n )
 #ifdef HAVE_IPP
 static void Log_32f_ipp(const float *x, float *y, int n)
 {
-    if (0 <= ippsLn_32f_A21(x, y, n))
-        return;
-    setIppErrorStatus();
+    CV_IPP_CHECK()
+    {
+        if (0 <= ippsLn_32f_A21(x, y, n))
+        {
+            CV_IMPL_ADD(CV_IMPL_IPP);
+            return;
+        }
+        setIppErrorStatus();
+    }
     Log_32f(x, y, n);
 }
 
 static void Log_64f_ipp(const double *x, double *y, int n)
 {
-    if (0 <= ippsLn_64f_A50(x, y, n))
-        return;
-    setIppErrorStatus();
+    CV_IPP_CHECK()
+    {
+        if (0 <= ippsLn_64f_A50(x, y, n))
+        {
+            CV_IMPL_ADD(CV_IMPL_IPP);
+            return;
+        }
+        setIppErrorStatus();
+    }
     Log_64f(x, y, n);
 }
 
@@ -2216,28 +2276,34 @@ void pow( InputArray _src, double power, OutputArray _dst )
             return;
         case 2:
 #if defined(HAVE_IPP)
-            if (depth == CV_32F && !same && ( (_src.dims() <= 2 && !ocl::useOpenCL()) ||
-                                              (_src.dims() > 2 && _src.isContinuous() && _dst.isContinuous()) ))
+            CV_IPP_CHECK()
             {
-                Mat src = _src.getMat();
-                _dst.create( src.dims, src.size, type );
-                Mat dst = _dst.getMat();
-
-                Size size = src.size();
-                int srcstep = (int)src.step, dststep = (int)dst.step, esz = CV_ELEM_SIZE(type);
-                if (src.isContinuous() && dst.isContinuous())
+                if (depth == CV_32F && !same && ( (_src.dims() <= 2 && !ocl::useOpenCL()) ||
+                                                  (_src.dims() > 2 && _src.isContinuous() && _dst.isContinuous()) ))
                 {
-                    size.width = (int)src.total();
-                    size.height = 1;
-                    srcstep = dststep = (int)src.total() * esz;
+                    Mat src = _src.getMat();
+                    _dst.create( src.dims, src.size, type );
+                    Mat dst = _dst.getMat();
+
+                    Size size = src.size();
+                    int srcstep = (int)src.step, dststep = (int)dst.step, esz = CV_ELEM_SIZE(type);
+                    if (src.isContinuous() && dst.isContinuous())
+                    {
+                        size.width = (int)src.total();
+                        size.height = 1;
+                        srcstep = dststep = (int)src.total() * esz;
+                    }
+                    size.width *= cn;
+
+                    IppStatus status = ippiSqr_32f_C1R(src.ptr<Ipp32f>(), srcstep, dst.ptr<Ipp32f>(), dststep, ippiSize(size.width, size.height));
+
+                    if (status >= 0)
+                    {
+                        CV_IMPL_ADD(CV_IMPL_IPP);
+                        return;
+                    }
+                    setIppErrorStatus();
                 }
-                size.width *= cn;
-
-                IppStatus status = ippiSqr_32f_C1R(src.ptr<Ipp32f>(), srcstep, dst.ptr<Ipp32f>(), dststep, ippiSize(size.width, size.height));
-
-                if (status >= 0)
-                    return;
-                setIppErrorStatus();
             }
 #endif
             if (same)
@@ -2288,15 +2354,21 @@ void pow( InputArray _src, double power, OutputArray _dst )
     else
     {
 #if defined(HAVE_IPP)
-        if (src.isContinuous() && dst.isContinuous())
+        CV_IPP_CHECK()
         {
-            IppStatus status = depth == CV_32F ?
-                        ippsPowx_32f_A21(src.ptr<Ipp32f>(), (Ipp32f)power, dst.ptr<Ipp32f>(), (Ipp32s)(src.total() * cn)) :
-                        ippsPowx_64f_A50(src.ptr<Ipp64f>(), power, dst.ptr<Ipp64f>(), (Ipp32s)(src.total() * cn));
+            if (src.isContinuous() && dst.isContinuous())
+            {
+                IppStatus status = depth == CV_32F ?
+                            ippsPowx_32f_A21(src.ptr<Ipp32f>(), (Ipp32f)power, dst.ptr<Ipp32f>(), (Ipp32s)(src.total() * cn)) :
+                            ippsPowx_64f_A50(src.ptr<Ipp64f>(), power, dst.ptr<Ipp64f>(), (Ipp32s)(src.total() * cn));
 
-            if (status >= 0)
-                return;
-            setIppErrorStatus();
+                if (status >= 0)
+                {
+                    CV_IMPL_ADD(CV_IMPL_IPP);
+                    return;
+                }
+                setIppErrorStatus();
+            }
         }
 #endif
 

--- a/modules/core/src/matmul.cpp
+++ b/modules/core/src/matmul.cpp
@@ -2821,11 +2821,17 @@ static double dotProd_8u(const uchar* src1, const uchar* src2, int len)
 {
     double r = 0;
 #if ARITHM_USE_IPP && 0
-    if (0 <= ippiDotProd_8u64f_C1R(src1, (int)(len*sizeof(src1[0])),
-                                   src2, (int)(len*sizeof(src2[0])),
-                                   ippiSize(len, 1), &r))
-        return r;
-    setIppErrorStatus();
+    CV_IPP_CHECK()
+    {
+        if (0 <= ippiDotProd_8u64f_C1R(src1, (int)(len*sizeof(src1[0])),
+                                       src2, (int)(len*sizeof(src2[0])),
+                                       ippiSize(len, 1), &r))
+        {
+            CV_IMPL_ADD(CV_IMPL_IPP);
+            return r;
+        }
+        setIppErrorStatus();
+    }
 #endif
     int i = 0;
 
@@ -2968,10 +2974,16 @@ static double dotProd_8s(const schar* src1, const schar* src2, int len)
 static double dotProd_16u(const ushort* src1, const ushort* src2, int len)
 {
 #if (ARITHM_USE_IPP == 1)
-    double r = 0;
-    if (0 <= ippiDotProd_16u64f_C1R(src1, (int)(len*sizeof(src1[0])), src2, (int)(len*sizeof(src2[0])), ippiSize(len, 1), &r))
-        return r;
-    setIppErrorStatus();
+    CV_IPP_CHECK()
+    {
+        double r = 0;
+        if (0 <= ippiDotProd_16u64f_C1R(src1, (int)(len*sizeof(src1[0])), src2, (int)(len*sizeof(src2[0])), ippiSize(len, 1), &r))
+        {
+            CV_IMPL_ADD(CV_IMPL_IPP);
+            return r;
+        }
+        setIppErrorStatus();
+    }
 #endif
     return dotProd_(src1, src2, len);
 }
@@ -2979,10 +2991,16 @@ static double dotProd_16u(const ushort* src1, const ushort* src2, int len)
 static double dotProd_16s(const short* src1, const short* src2, int len)
 {
 #if (ARITHM_USE_IPP == 1)
-    double r = 0;
-    if (0 <= ippiDotProd_16s64f_C1R(src1, (int)(len*sizeof(src1[0])), src2, (int)(len*sizeof(src2[0])), ippiSize(len, 1), &r))
-        return r;
-    setIppErrorStatus();
+    CV_IPP_CHECK()
+    {
+        double r = 0;
+        if (0 <= ippiDotProd_16s64f_C1R(src1, (int)(len*sizeof(src1[0])), src2, (int)(len*sizeof(src2[0])), ippiSize(len, 1), &r))
+        {
+            CV_IMPL_ADD(CV_IMPL_IPP);
+            return r;
+        }
+        setIppErrorStatus();
+    }
 #endif
     return dotProd_(src1, src2, len);
 }
@@ -2990,10 +3008,16 @@ static double dotProd_16s(const short* src1, const short* src2, int len)
 static double dotProd_32s(const int* src1, const int* src2, int len)
 {
 #if (ARITHM_USE_IPP == 1)
-    double r = 0;
-    if (0 <= ippiDotProd_32s64f_C1R(src1, (int)(len*sizeof(src1[0])), src2, (int)(len*sizeof(src2[0])), ippiSize(len, 1), &r))
-        return r;
-    setIppErrorStatus();
+    CV_IPP_CHECK()
+    {
+        double r = 0;
+        if (0 <= ippiDotProd_32s64f_C1R(src1, (int)(len*sizeof(src1[0])), src2, (int)(len*sizeof(src2[0])), ippiSize(len, 1), &r))
+        {
+            CV_IMPL_ADD(CV_IMPL_IPP);
+            return r;
+        }
+        setIppErrorStatus();
+    }
 #endif
     return dotProd_(src1, src2, len);
 }
@@ -3004,9 +3028,15 @@ static double dotProd_32f(const float* src1, const float* src2, int len)
     int i = 0;
 
 #if (ARITHM_USE_IPP == 1)
-    if (0 <= ippsDotProd_32f64f(src1, src2, len, &r))
-        return r;
-    setIppErrorStatus();
+    CV_IPP_CHECK()
+    {
+        if (0 <= ippsDotProd_32f64f(src1, src2, len, &r))
+        {
+            CV_IMPL_ADD(CV_IMPL_IPP);
+            return r;
+        }
+        setIppErrorStatus();
+    }
 #elif CV_NEON
     int len0 = len & -4, blockSize0 = (1 << 13), blockSize;
     float32x4_t v_zero = vdupq_n_f32(0.0f);
@@ -3035,10 +3065,16 @@ static double dotProd_32f(const float* src1, const float* src2, int len)
 static double dotProd_64f(const double* src1, const double* src2, int len)
 {
 #if (ARITHM_USE_IPP == 1)
-    double r = 0;
-    if (0 <= ippsDotProd_64f(src1, src2, len, &r))
-        return r;
-    setIppErrorStatus();
+    CV_IPP_CHECK()
+    {
+        double r = 0;
+        if (0 <= ippsDotProd_64f(src1, src2, len, &r))
+        {
+            CV_IMPL_ADD(CV_IMPL_IPP);
+            return r;
+        }
+        setIppErrorStatus();
+    }
 #endif
     return dotProd_(src1, src2, len);
 }

--- a/modules/core/src/matrix.cpp
+++ b/modules/core/src/matrix.cpp
@@ -3066,64 +3066,73 @@ void cv::transpose( InputArray _src, OutputArray _dst )
     }
 
 #if defined HAVE_IPP
-    typedef IppStatus (CV_STDCALL * ippiTranspose)(const void * pSrc, int srcStep, void * pDst, int dstStep, IppiSize roiSize);
-    typedef IppStatus (CV_STDCALL * ippiTransposeI)(const void * pSrcDst, int srcDstStep, IppiSize roiSize);
-    ippiTranspose ippFunc = 0;
-    ippiTransposeI ippFuncI = 0;
+    CV_IPP_CHECK()
+    {
+        typedef IppStatus (CV_STDCALL * ippiTranspose)(const void * pSrc, int srcStep, void * pDst, int dstStep, IppiSize roiSize);
+        typedef IppStatus (CV_STDCALL * ippiTransposeI)(const void * pSrcDst, int srcDstStep, IppiSize roiSize);
+        ippiTranspose ippFunc = 0;
+        ippiTransposeI ippFuncI = 0;
 
-    if (dst.data == src.data && dst.cols == dst.rows)
-    {
-        CV_SUPPRESS_DEPRECATED_START
-        ippFuncI =
-            type == CV_8UC1 ? (ippiTransposeI)ippiTranspose_8u_C1IR :
-            type == CV_8UC3 ? (ippiTransposeI)ippiTranspose_8u_C3IR :
-            type == CV_8UC4 ? (ippiTransposeI)ippiTranspose_8u_C4IR :
-            type == CV_16UC1 ? (ippiTransposeI)ippiTranspose_16u_C1IR :
-            type == CV_16UC3 ? (ippiTransposeI)ippiTranspose_16u_C3IR :
-            type == CV_16UC4 ? (ippiTransposeI)ippiTranspose_16u_C4IR :
-            type == CV_16SC1 ? (ippiTransposeI)ippiTranspose_16s_C1IR :
-            type == CV_16SC3 ? (ippiTransposeI)ippiTranspose_16s_C3IR :
-            type == CV_16SC4 ? (ippiTransposeI)ippiTranspose_16s_C4IR :
-            type == CV_32SC1 ? (ippiTransposeI)ippiTranspose_32s_C1IR :
-            type == CV_32SC3 ? (ippiTransposeI)ippiTranspose_32s_C3IR :
-            type == CV_32SC4 ? (ippiTransposeI)ippiTranspose_32s_C4IR :
-            type == CV_32FC1 ? (ippiTransposeI)ippiTranspose_32f_C1IR :
-            type == CV_32FC3 ? (ippiTransposeI)ippiTranspose_32f_C3IR :
-            type == CV_32FC4 ? (ippiTransposeI)ippiTranspose_32f_C4IR : 0;
-        CV_SUPPRESS_DEPRECATED_END
-    }
-    else
-    {
-        ippFunc =
-            type == CV_8UC1 ? (ippiTranspose)ippiTranspose_8u_C1R :
-            type == CV_8UC3 ? (ippiTranspose)ippiTranspose_8u_C3R :
-            type == CV_8UC4 ? (ippiTranspose)ippiTranspose_8u_C4R :
-            type == CV_16UC1 ? (ippiTranspose)ippiTranspose_16u_C1R :
-            type == CV_16UC3 ? (ippiTranspose)ippiTranspose_16u_C3R :
-            type == CV_16UC4 ? (ippiTranspose)ippiTranspose_16u_C4R :
-            type == CV_16SC1 ? (ippiTranspose)ippiTranspose_16s_C1R :
-            type == CV_16SC3 ? (ippiTranspose)ippiTranspose_16s_C3R :
-            type == CV_16SC4 ? (ippiTranspose)ippiTranspose_16s_C4R :
-            type == CV_32SC1 ? (ippiTranspose)ippiTranspose_32s_C1R :
-            type == CV_32SC3 ? (ippiTranspose)ippiTranspose_32s_C3R :
-            type == CV_32SC4 ? (ippiTranspose)ippiTranspose_32s_C4R :
-            type == CV_32FC1 ? (ippiTranspose)ippiTranspose_32f_C1R :
-            type == CV_32FC3 ? (ippiTranspose)ippiTranspose_32f_C3R :
-            type == CV_32FC4 ? (ippiTranspose)ippiTranspose_32f_C4R : 0;
-    }
+        if (dst.data == src.data && dst.cols == dst.rows)
+        {
+            CV_SUPPRESS_DEPRECATED_START
+            ippFuncI =
+                type == CV_8UC1 ? (ippiTransposeI)ippiTranspose_8u_C1IR :
+                type == CV_8UC3 ? (ippiTransposeI)ippiTranspose_8u_C3IR :
+                type == CV_8UC4 ? (ippiTransposeI)ippiTranspose_8u_C4IR :
+                type == CV_16UC1 ? (ippiTransposeI)ippiTranspose_16u_C1IR :
+                type == CV_16UC3 ? (ippiTransposeI)ippiTranspose_16u_C3IR :
+                type == CV_16UC4 ? (ippiTransposeI)ippiTranspose_16u_C4IR :
+                type == CV_16SC1 ? (ippiTransposeI)ippiTranspose_16s_C1IR :
+                type == CV_16SC3 ? (ippiTransposeI)ippiTranspose_16s_C3IR :
+                type == CV_16SC4 ? (ippiTransposeI)ippiTranspose_16s_C4IR :
+                type == CV_32SC1 ? (ippiTransposeI)ippiTranspose_32s_C1IR :
+                type == CV_32SC3 ? (ippiTransposeI)ippiTranspose_32s_C3IR :
+                type == CV_32SC4 ? (ippiTransposeI)ippiTranspose_32s_C4IR :
+                type == CV_32FC1 ? (ippiTransposeI)ippiTranspose_32f_C1IR :
+                type == CV_32FC3 ? (ippiTransposeI)ippiTranspose_32f_C3IR :
+                type == CV_32FC4 ? (ippiTransposeI)ippiTranspose_32f_C4IR : 0;
+            CV_SUPPRESS_DEPRECATED_END
+        }
+        else
+        {
+            ippFunc =
+                type == CV_8UC1 ? (ippiTranspose)ippiTranspose_8u_C1R :
+                type == CV_8UC3 ? (ippiTranspose)ippiTranspose_8u_C3R :
+                type == CV_8UC4 ? (ippiTranspose)ippiTranspose_8u_C4R :
+                type == CV_16UC1 ? (ippiTranspose)ippiTranspose_16u_C1R :
+                type == CV_16UC3 ? (ippiTranspose)ippiTranspose_16u_C3R :
+                type == CV_16UC4 ? (ippiTranspose)ippiTranspose_16u_C4R :
+                type == CV_16SC1 ? (ippiTranspose)ippiTranspose_16s_C1R :
+                type == CV_16SC3 ? (ippiTranspose)ippiTranspose_16s_C3R :
+                type == CV_16SC4 ? (ippiTranspose)ippiTranspose_16s_C4R :
+                type == CV_32SC1 ? (ippiTranspose)ippiTranspose_32s_C1R :
+                type == CV_32SC3 ? (ippiTranspose)ippiTranspose_32s_C3R :
+                type == CV_32SC4 ? (ippiTranspose)ippiTranspose_32s_C4R :
+                type == CV_32FC1 ? (ippiTranspose)ippiTranspose_32f_C1R :
+                type == CV_32FC3 ? (ippiTranspose)ippiTranspose_32f_C3R :
+                type == CV_32FC4 ? (ippiTranspose)ippiTranspose_32f_C4R : 0;
+        }
 
-    IppiSize roiSize = { src.cols, src.rows };
-    if (ippFunc != 0)
-    {
-        if (ippFunc(src.ptr(), (int)src.step, dst.ptr(), (int)dst.step, roiSize) >= 0)
-            return;
-        setIppErrorStatus();
-    }
-    else if (ippFuncI != 0)
-    {
-        if (ippFuncI(dst.ptr(), (int)dst.step, roiSize) >= 0)
-            return;
-        setIppErrorStatus();
+        IppiSize roiSize = { src.cols, src.rows };
+        if (ippFunc != 0)
+        {
+            if (ippFunc(src.ptr(), (int)src.step, dst.ptr(), (int)dst.step, roiSize) >= 0)
+            {
+                CV_IMPL_ADD(CV_IMPL_IPP);
+                return;
+            }
+            setIppErrorStatus();
+        }
+        else if (ippFuncI != 0)
+        {
+            if (ippFuncI(dst.ptr(), (int)dst.step, roiSize) >= 0)
+            {
+                CV_IMPL_ADD(CV_IMPL_IPP);
+                return;
+            }
+            setIppErrorStatus();
+        }
     }
 #endif
 
@@ -3353,27 +3362,32 @@ static inline void reduceSumC_8u16u16s32f_64f(const cv::Mat& srcmat, cv::Mat& ds
     }
     CV_Assert(!(ippFunc && ippFuncHint) && func);
 
-    if (ippFunc)
+    CV_IPP_CHECK()
     {
-        for (int y = 0; y < size.height; ++y)
-            if (ippFunc(srcmat.ptr(y), sstep, roisize, dstmat.ptr<Ipp64f>(y)) < 0)
-            {
-                setIppErrorStatus();
-                cv::Mat dstroi = dstmat.rowRange(y, y + 1);
-                func(srcmat.rowRange(y, y + 1), dstroi);
-            }
-        return;
-    }
-    else if (ippFuncHint)
-    {
-        for (int y = 0; y < size.height; ++y)
-            if (ippFuncHint(srcmat.ptr(y), sstep, roisize, dstmat.ptr<Ipp64f>(y), ippAlgHintAccurate) < 0)
-            {
-                setIppErrorStatus();
-                cv::Mat dstroi = dstmat.rowRange(y, y + 1);
-                func(srcmat.rowRange(y, y + 1), dstroi);
-            }
-        return;
+        if (ippFunc)
+        {
+            for (int y = 0; y < size.height; ++y)
+                if (ippFunc(srcmat.ptr(y), sstep, roisize, dstmat.ptr<Ipp64f>(y)) < 0)
+                {
+                    setIppErrorStatus();
+                    cv::Mat dstroi = dstmat.rowRange(y, y + 1);
+                    func(srcmat.rowRange(y, y + 1), dstroi);
+                }
+            CV_IMPL_ADD(CV_IMPL_IPP);
+            return;
+        }
+        else if (ippFuncHint)
+        {
+            for (int y = 0; y < size.height; ++y)
+                if (ippFuncHint(srcmat.ptr(y), sstep, roisize, dstmat.ptr<Ipp64f>(y), ippAlgHintAccurate) < 0)
+                {
+                    setIppErrorStatus();
+                    cv::Mat dstroi = dstmat.rowRange(y, y + 1);
+                    func(srcmat.rowRange(y, y + 1), dstroi);
+                }
+            CV_IMPL_ADD(CV_IMPL_IPP);
+            return;
+        }
     }
 
     func(srcmat, dstmat);
@@ -3409,7 +3423,7 @@ static inline void reduce##optype##C##favor(const cv::Mat& srcmat, cv::Mat& dstm
     IppiSize roisize = ippiSize(size.width, 1);\
     int sstep = (int)srcmat.step; \
      \
-    if (srcmat.channels() == 1) \
+    if (CV_IPP_CHECK_COND && (srcmat.channels() == 1)) \
     { \
         for (int y = 0; y < size.height; ++y) \
             if (ippi##optype##_##favor##_C1R(srcmat.ptr<IppType>(y), sstep, roisize, dstmat.ptr<IppType>(y)) < 0) \
@@ -3417,6 +3431,10 @@ static inline void reduce##optype##C##favor(const cv::Mat& srcmat, cv::Mat& dstm
                 setIppErrorStatus(); \
                 cv::Mat dstroi = dstmat.rowRange(y, y + 1); \
                 cv::reduceC_ < type1, type2, cv::Op##optype < type2 > >(srcmat.rowRange(y, y + 1), dstroi); \
+            } \
+            else \
+            { \
+                CV_IMPL_ADD(CV_IMPL_IPP);\
             } \
         return; \
     } \
@@ -3768,8 +3786,13 @@ template<typename T> static void sort_( const Mat& src, Mat& dst, int flags )
 
 #ifdef USE_IPP_SORT
     int depth = src.depth();
-    IppSortFunc ippSortFunc = getSortFunc(depth, sortDescending);
-    IppFlipFunc ippFlipFunc = getFlipFunc(depth);
+    IppSortFunc ippSortFunc = 0;
+    IppFlipFunc ippFlipFunc = 0;
+    CV_IPP_CHECK()
+    {
+        ippSortFunc = getSortFunc(depth, sortDescending);
+        ippFlipFunc = getFlipFunc(depth);
+    }
 #endif
 
     for( i = 0; i < n; i++ )
@@ -3812,8 +3835,20 @@ template<typename T> static void sort_( const Mat& src, Mat& dst, int flags )
                     for( j = 0; j < len/2; j++ )
                         std::swap(ptr[j], ptr[len-1-j]);
                 }
+#ifdef USE_IPP_SORT
+                else
+                {
+                    CV_IMPL_ADD(CV_IMPL_IPP);
+                }
+#endif
             }
         }
+#ifdef USE_IPP_SORT
+        else
+        {
+            CV_IMPL_ADD(CV_IMPL_IPP);
+        }
+#endif
 
         if( !sortRows )
             for( j = 0; j < len; j++ )
@@ -3878,8 +3913,13 @@ template<typename T> static void sortIdx_( const Mat& src, Mat& dst, int flags )
 
 #if defined USE_IPP_SORT && 0
     int depth = src.depth();
-    IppSortIndexFunc ippFunc = getSortIndexFunc(depth, sortDescending);
-    IppFlipFunc ippFlipFunc = getFlipFunc(depth);
+    IppSortIndexFunc ippFunc = 0;
+    IppFlipFunc ippFlipFunc = 0;
+    CV_IPP_CHECK()
+    {
+        ippFunc = getSortIndexFunc(depth, sortDescending);
+        ippFlipFunc = getFlipFunc(depth);
+    }
 #endif
 
     for( i = 0; i < n; i++ )
@@ -3920,8 +3960,20 @@ template<typename T> static void sortIdx_( const Mat& src, Mat& dst, int flags )
                     for( j = 0; j < len/2; j++ )
                         std::swap(iptr[j], iptr[len-1-j]);
                 }
+#if defined USE_IPP_SORT && 0
+                else
+                {
+                    CV_IMPL_ADD(CV_IMPL_IPP);
+                }
+#endif
             }
         }
+#if defined USE_IPP_SORT && 0
+        else
+        {
+            CV_IMPL_ADD(CV_IMPL_IPP);
+        }
+#endif
 
         if( !sortRows )
             for( j = 0; j < len; j++ )

--- a/modules/core/src/precomp.hpp
+++ b/modules/core/src/precomp.hpp
@@ -233,13 +233,25 @@ void convertAndUnrollScalar( const Mat& sc, int buftype, uchar* scbuf, size_t bl
 
 struct CoreTLSData
 {
-    CoreTLSData() : device(0), useOpenCL(-1)
-    {}
+    CoreTLSData() : device(0), useOpenCL(-1), useIPP(-1), useCollection(false)
+    {
+#ifdef CV_COLLECT_IMPL_DATA
+        implFlags = 0;
+#endif
+    }
 
     RNG rng;
     int device;
     ocl::Queue oclQueue;
     int useOpenCL; // 1 - use, 0 - do not use, -1 - auto/not initialized
+    int useIPP; // 1 - use, 0 - do not use, -1 - auto/not initialized
+    bool useCollection; // enable/disable impl data collection
+
+#ifdef CV_COLLECT_IMPL_DATA
+    int implFlags;
+    std::vector<int> implCode;
+    std::vector<String> implFun;
+#endif
 };
 
 extern TLSData<CoreTLSData> coreTlsData;

--- a/modules/core/src/umatrix.cpp
+++ b/modules/core/src/umatrix.cpp
@@ -697,7 +697,10 @@ void UMat::copyTo(OutputArray _dst, InputArray _mask) const
 
             size_t globalsize[2] = { cols, rows };
             if (k.run(2, globalsize, NULL, false))
+            {
+                CV_IMPL_ADD(CV_IMPL_OCL);
                 return;
+            }
         }
     }
 #endif
@@ -753,7 +756,10 @@ void UMat::convertTo(OutputArray _dst, int _type, double alpha, double beta) con
 
             size_t globalsize[2] = { dst.cols * cn, (dst.rows + rowsPerWI - 1) / rowsPerWI };
             if (k.run(2, globalsize, NULL, false))
+            {
+                CV_IMPL_ADD(CV_IMPL_OCL);
                 return;
+            }
         }
     }
 #endif
@@ -802,7 +808,10 @@ UMat& UMat::setTo(InputArray _value, InputArray _mask)
 
             size_t globalsize[] = { cols, (rows + rowsPerWI - 1) / rowsPerWI };
             if( setK.run(2, globalsize, NULL, false) )
+            {
+                CV_IMPL_ADD(CV_IMPL_OCL);
                 return *this;
+            }
         }
     }
 #endif

--- a/modules/features2d/src/fast.cpp
+++ b/modules/features2d/src/fast.cpp
@@ -332,7 +332,10 @@ void FAST(InputArray _img, std::vector<KeyPoint>& keypoints, int threshold, bool
 {
   if( ocl::useOpenCL() && _img.isUMat() && type == FastFeatureDetector::TYPE_9_16 &&
       ocl_FAST(_img, keypoints, threshold, nonmax_suppression, 10000))
-      return;
+  {
+    CV_IMPL_ADD(CV_IMPL_OCL);
+    return;
+  }
 
   switch(type) {
     case FastFeatureDetector::TYPE_5_8:

--- a/modules/features2d/src/matchers.cpp
+++ b/modules/features2d/src/matchers.cpp
@@ -943,12 +943,18 @@ void BFMatcher::knnMatchImpl( InputArray _queryDescriptors, std::vector<std::vec
             if(trainDescCollection.empty())
             {
                 if(ocl_match(_queryDescriptors, utrainDescCollection[0], matches, normType))
+                {
+                    CV_IMPL_ADD(CV_IMPL_OCL);
                     return;
+                }
             }
             else
             {
                 if(ocl_match(_queryDescriptors, trainDescCollection[0], matches, normType))
+                {
+                    CV_IMPL_ADD(CV_IMPL_OCL);
                     return;
+                }
             }
         }
         else
@@ -956,12 +962,18 @@ void BFMatcher::knnMatchImpl( InputArray _queryDescriptors, std::vector<std::vec
             if(trainDescCollection.empty())
             {
                 if(ocl_knnMatch(_queryDescriptors, utrainDescCollection[0], matches, knn, normType, compactResult) )
+                {
+                    CV_IMPL_ADD(CV_IMPL_OCL);
                     return;
+                }
             }
             else
             {
                 if(ocl_knnMatch(_queryDescriptors, trainDescCollection[0], matches, knn, normType, compactResult) )
+                {
+                    CV_IMPL_ADD(CV_IMPL_OCL);
                     return;
+                }
             }
         }
     }
@@ -1073,12 +1085,18 @@ void BFMatcher::radiusMatchImpl( InputArray _queryDescriptors, std::vector<std::
         if (trainDescCollection.empty())
         {
             if(ocl_radiusMatch(_queryDescriptors, utrainDescCollection[0], matches, maxDistance, normType, compactResult) )
+            {
+                CV_IMPL_ADD(CV_IMPL_OCL);
                 return;
+            }
         }
         else
         {
             if (ocl_radiusMatch(_queryDescriptors, trainDescCollection[0], matches, maxDistance, normType, compactResult) )
+            {
+                CV_IMPL_ADD(CV_IMPL_OCL);
                 return;
+            }
         }
     }
 

--- a/modules/features2d/src/orb.cpp
+++ b/modules/features2d/src/orb.cpp
@@ -823,6 +823,7 @@ static void computeKeyPoints(const Mat& imagePyramid,
                                           uresponses, nkeypoints, 7, HARRIS_K );
             if( useOCL )
             {
+                CV_IMPL_ADD(CV_IMPL_OCL);
                 uresponses.copyTo(responses);
                 for( i = 0; i < nkeypoints; i++ )
                     allKeypoints[i].response = responses.at<float>(i);
@@ -867,6 +868,7 @@ static void computeKeyPoints(const Mat& imagePyramid,
 
         if( useOCL )
         {
+            CV_IMPL_ADD(CV_IMPL_OCL);
             uresponses.copyTo(responses);
             for( i = 0; i < nkeypoints; i++ )
                 allKeypoints[i].angle = responses.at<float>(i);
@@ -1110,6 +1112,10 @@ void ORB::operator()( InputArray _image, InputArray _mask, std::vector<KeyPoint>
             useOCL = ocl_computeOrbDescriptors(uimagePyramid, ulayerInfo,
                                                ukeypoints, udescriptors, upattern,
                                                nkeypoints, dsize, WTA_K);
+            if(useOCL)
+            {
+                CV_IMPL_ADD(CV_IMPL_OCL);
+            }
         }
 
         if( !useOCL )

--- a/modules/imgproc/src/accum.cpp
+++ b/modules/imgproc/src/accum.cpp
@@ -856,54 +856,60 @@ void cv::accumulate( InputArray _src, InputOutputArray _dst, InputArray _mask )
     Mat src = _src.getMat(), dst = _dst.getMat(), mask = _mask.getMat();
 
 #if defined HAVE_IPP
-    if (src.dims <= 2 || (src.isContinuous() && dst.isContinuous() && (mask.empty() || mask.isContinuous())))
+    CV_IPP_CHECK()
     {
-        typedef IppStatus (CV_STDCALL * ippiAdd)(const void * pSrc, int srcStep, Ipp32f * pSrcDst, int srcdstStep, IppiSize roiSize);
-        typedef IppStatus (CV_STDCALL * ippiAddMask)(const void * pSrc, int srcStep, const Ipp8u * pMask, int maskStep, Ipp32f * pSrcDst,
-                                                    int srcDstStep, IppiSize roiSize);
-        ippiAdd ippFunc = 0;
-        ippiAddMask ippFuncMask = 0;
-
-        if (mask.empty())
+        if (src.dims <= 2 || (src.isContinuous() && dst.isContinuous() && (mask.empty() || mask.isContinuous())))
         {
-            CV_SUPPRESS_DEPRECATED_START
-            ippFunc = sdepth == CV_8U && ddepth == CV_32F ? (ippiAdd)ippiAdd_8u32f_C1IR :
-                sdepth == CV_16U && ddepth == CV_32F ? (ippiAdd)ippiAdd_16u32f_C1IR :
-                sdepth == CV_32F && ddepth == CV_32F ? (ippiAdd)ippiAdd_32f_C1IR : 0;
-            CV_SUPPRESS_DEPRECATED_END
-        }
-        else if (scn == 1)
-        {
-            ippFuncMask = sdepth == CV_8U && ddepth == CV_32F ? (ippiAddMask)ippiAdd_8u32f_C1IMR :
-                sdepth == CV_16U && ddepth == CV_32F ? (ippiAddMask)ippiAdd_16u32f_C1IMR :
-                sdepth == CV_32F && ddepth == CV_32F ? (ippiAddMask)ippiAdd_32f_C1IMR : 0;
-        }
-
-        if (ippFunc || ippFuncMask)
-        {
-            IppStatus status = ippStsNoErr;
-
-            Size size = src.size();
-            int srcstep = (int)src.step, dststep = (int)dst.step, maskstep = (int)mask.step;
-            if (src.isContinuous() && dst.isContinuous() && mask.isContinuous())
-            {
-                srcstep = static_cast<int>(src.total() * src.elemSize());
-                dststep = static_cast<int>(dst.total() * dst.elemSize());
-                maskstep = static_cast<int>(mask.total() * mask.elemSize());
-                size.width = static_cast<int>(src.total());
-                size.height = 1;
-            }
-            size.width *= scn;
+            typedef IppStatus (CV_STDCALL * ippiAdd)(const void * pSrc, int srcStep, Ipp32f * pSrcDst, int srcdstStep, IppiSize roiSize);
+            typedef IppStatus (CV_STDCALL * ippiAddMask)(const void * pSrc, int srcStep, const Ipp8u * pMask, int maskStep, Ipp32f * pSrcDst,
+                                                        int srcDstStep, IppiSize roiSize);
+            ippiAdd ippFunc = 0;
+            ippiAddMask ippFuncMask = 0;
 
             if (mask.empty())
-                status = ippFunc(src.ptr(), srcstep, dst.ptr<Ipp32f>(), dststep, ippiSize(size.width, size.height));
-            else
-                status = ippFuncMask(src.ptr(), srcstep, mask.ptr<Ipp8u>(), maskstep,
-                                     dst.ptr<Ipp32f>(), dststep, ippiSize(size.width, size.height));
+            {
+                CV_SUPPRESS_DEPRECATED_START
+                ippFunc = sdepth == CV_8U && ddepth == CV_32F ? (ippiAdd)ippiAdd_8u32f_C1IR :
+                    sdepth == CV_16U && ddepth == CV_32F ? (ippiAdd)ippiAdd_16u32f_C1IR :
+                    sdepth == CV_32F && ddepth == CV_32F ? (ippiAdd)ippiAdd_32f_C1IR : 0;
+                CV_SUPPRESS_DEPRECATED_END
+            }
+            else if (scn == 1)
+            {
+                ippFuncMask = sdepth == CV_8U && ddepth == CV_32F ? (ippiAddMask)ippiAdd_8u32f_C1IMR :
+                    sdepth == CV_16U && ddepth == CV_32F ? (ippiAddMask)ippiAdd_16u32f_C1IMR :
+                    sdepth == CV_32F && ddepth == CV_32F ? (ippiAddMask)ippiAdd_32f_C1IMR : 0;
+            }
 
-            if (status >= 0)
-                return;
-            setIppErrorStatus();
+            if (ippFunc || ippFuncMask)
+            {
+                IppStatus status = ippStsNoErr;
+
+                Size size = src.size();
+                int srcstep = (int)src.step, dststep = (int)dst.step, maskstep = (int)mask.step;
+                if (src.isContinuous() && dst.isContinuous() && mask.isContinuous())
+                {
+                    srcstep = static_cast<int>(src.total() * src.elemSize());
+                    dststep = static_cast<int>(dst.total() * dst.elemSize());
+                    maskstep = static_cast<int>(mask.total() * mask.elemSize());
+                    size.width = static_cast<int>(src.total());
+                    size.height = 1;
+                }
+                size.width *= scn;
+
+                if (mask.empty())
+                    status = ippFunc(src.ptr(), srcstep, dst.ptr<Ipp32f>(), dststep, ippiSize(size.width, size.height));
+                else
+                    status = ippFuncMask(src.ptr(), srcstep, mask.ptr<Ipp8u>(), maskstep,
+                                         dst.ptr<Ipp32f>(), dststep, ippiSize(size.width, size.height));
+
+                if (status >= 0)
+                {
+                    CV_IMPL_ADD(CV_IMPL_IPP);
+                    return;
+                }
+                setIppErrorStatus();
+            }
         }
     }
 #endif
@@ -935,52 +941,58 @@ void cv::accumulateSquare( InputArray _src, InputOutputArray _dst, InputArray _m
     Mat src = _src.getMat(), dst = _dst.getMat(), mask = _mask.getMat();
 
 #if defined(HAVE_IPP)
-    if (src.dims <= 2 || (src.isContinuous() && dst.isContinuous() && (mask.empty() || mask.isContinuous())))
+    CV_IPP_CHECK()
     {
-        typedef IppStatus (CV_STDCALL * ippiAddSquare)(const void * pSrc, int srcStep, Ipp32f * pSrcDst, int srcdstStep, IppiSize roiSize);
-        typedef IppStatus (CV_STDCALL * ippiAddSquareMask)(const void * pSrc, int srcStep, const Ipp8u * pMask, int maskStep, Ipp32f * pSrcDst,
-                                                           int srcDstStep, IppiSize roiSize);
-        ippiAddSquare ippFunc = 0;
-        ippiAddSquareMask ippFuncMask = 0;
-
-        if (mask.empty())
+        if (src.dims <= 2 || (src.isContinuous() && dst.isContinuous() && (mask.empty() || mask.isContinuous())))
         {
-            ippFunc = sdepth == CV_8U && ddepth == CV_32F ? (ippiAddSquare)ippiAddSquare_8u32f_C1IR :
-                sdepth == CV_16U && ddepth == CV_32F ? (ippiAddSquare)ippiAddSquare_16u32f_C1IR :
-                sdepth == CV_32F && ddepth == CV_32F ? (ippiAddSquare)ippiAddSquare_32f_C1IR : 0;
-        }
-        else if (scn == 1)
-        {
-            ippFuncMask = sdepth == CV_8U && ddepth == CV_32F ? (ippiAddSquareMask)ippiAddSquare_8u32f_C1IMR :
-                sdepth == CV_16U && ddepth == CV_32F ? (ippiAddSquareMask)ippiAddSquare_16u32f_C1IMR :
-                sdepth == CV_32F && ddepth == CV_32F ? (ippiAddSquareMask)ippiAddSquare_32f_C1IMR : 0;
-        }
-
-        if (ippFunc || ippFuncMask)
-        {
-            IppStatus status = ippStsNoErr;
-
-            Size size = src.size();
-            int srcstep = (int)src.step, dststep = (int)dst.step, maskstep = (int)mask.step;
-            if (src.isContinuous() && dst.isContinuous() && mask.isContinuous())
-            {
-                srcstep = static_cast<int>(src.total() * src.elemSize());
-                dststep = static_cast<int>(dst.total() * dst.elemSize());
-                maskstep = static_cast<int>(mask.total() * mask.elemSize());
-                size.width = static_cast<int>(src.total());
-                size.height = 1;
-            }
-            size.width *= scn;
+            typedef IppStatus (CV_STDCALL * ippiAddSquare)(const void * pSrc, int srcStep, Ipp32f * pSrcDst, int srcdstStep, IppiSize roiSize);
+            typedef IppStatus (CV_STDCALL * ippiAddSquareMask)(const void * pSrc, int srcStep, const Ipp8u * pMask, int maskStep, Ipp32f * pSrcDst,
+                                                               int srcDstStep, IppiSize roiSize);
+            ippiAddSquare ippFunc = 0;
+            ippiAddSquareMask ippFuncMask = 0;
 
             if (mask.empty())
-                status = ippFunc(src.ptr(), srcstep, dst.ptr<Ipp32f>(), dststep, ippiSize(size.width, size.height));
-            else
-                status = ippFuncMask(src.ptr(), srcstep, mask.ptr<Ipp8u>(), maskstep,
-                                     dst.ptr<Ipp32f>(), dststep, ippiSize(size.width, size.height));
+            {
+                ippFunc = sdepth == CV_8U && ddepth == CV_32F ? (ippiAddSquare)ippiAddSquare_8u32f_C1IR :
+                    sdepth == CV_16U && ddepth == CV_32F ? (ippiAddSquare)ippiAddSquare_16u32f_C1IR :
+                    sdepth == CV_32F && ddepth == CV_32F ? (ippiAddSquare)ippiAddSquare_32f_C1IR : 0;
+            }
+            else if (scn == 1)
+            {
+                ippFuncMask = sdepth == CV_8U && ddepth == CV_32F ? (ippiAddSquareMask)ippiAddSquare_8u32f_C1IMR :
+                    sdepth == CV_16U && ddepth == CV_32F ? (ippiAddSquareMask)ippiAddSquare_16u32f_C1IMR :
+                    sdepth == CV_32F && ddepth == CV_32F ? (ippiAddSquareMask)ippiAddSquare_32f_C1IMR : 0;
+            }
 
-            if (status >= 0)
-                return;
-            setIppErrorStatus();
+            if (ippFunc || ippFuncMask)
+            {
+                IppStatus status = ippStsNoErr;
+
+                Size size = src.size();
+                int srcstep = (int)src.step, dststep = (int)dst.step, maskstep = (int)mask.step;
+                if (src.isContinuous() && dst.isContinuous() && mask.isContinuous())
+                {
+                    srcstep = static_cast<int>(src.total() * src.elemSize());
+                    dststep = static_cast<int>(dst.total() * dst.elemSize());
+                    maskstep = static_cast<int>(mask.total() * mask.elemSize());
+                    size.width = static_cast<int>(src.total());
+                    size.height = 1;
+                }
+                size.width *= scn;
+
+                if (mask.empty())
+                    status = ippFunc(src.ptr(), srcstep, dst.ptr<Ipp32f>(), dststep, ippiSize(size.width, size.height));
+                else
+                    status = ippFuncMask(src.ptr(), srcstep, mask.ptr<Ipp8u>(), maskstep,
+                                         dst.ptr<Ipp32f>(), dststep, ippiSize(size.width, size.height));
+
+                if (status >= 0)
+                {
+                    CV_IMPL_ADD(CV_IMPL_IPP);
+                    return;
+                }
+                setIppErrorStatus();
+            }
         }
     }
 #endif
@@ -1014,55 +1026,61 @@ void cv::accumulateProduct( InputArray _src1, InputArray _src2,
     Mat src1 = _src1.getMat(), src2 = _src2.getMat(), dst = _dst.getMat(), mask = _mask.getMat();
 
 #if defined(HAVE_IPP)
-    if (src1.dims <= 2 || (src1.isContinuous() && src2.isContinuous() && dst.isContinuous()))
+    CV_IPP_CHECK()
     {
-        typedef IppStatus (CV_STDCALL * ippiAddProduct)(const void * pSrc1, int src1Step, const void * pSrc2,
-                                                        int src2Step, Ipp32f * pSrcDst, int srcDstStep, IppiSize roiSize);
-        typedef IppStatus (CV_STDCALL * ippiAddProductMask)(const void * pSrc1, int src1Step, const void * pSrc2, int src2Step,
-                                                            const Ipp8u * pMask, int maskStep, Ipp32f * pSrcDst, int srcDstStep, IppiSize roiSize);
-        ippiAddProduct ippFunc = 0;
-        ippiAddProductMask ippFuncMask = 0;
-
-        if (mask.empty())
+        if (src1.dims <= 2 || (src1.isContinuous() && src2.isContinuous() && dst.isContinuous()))
         {
-            ippFunc = sdepth == CV_8U && ddepth == CV_32F ? (ippiAddProduct)ippiAddProduct_8u32f_C1IR :
-                sdepth == CV_16U && ddepth == CV_32F ? (ippiAddProduct)ippiAddProduct_16u32f_C1IR :
-                sdepth == CV_32F && ddepth == CV_32F ? (ippiAddProduct)ippiAddProduct_32f_C1IR : 0;
-        }
-        else if (scn == 1)
-        {
-            ippFuncMask = sdepth == CV_8U && ddepth == CV_32F ? (ippiAddProductMask)ippiAddProduct_8u32f_C1IMR :
-                sdepth == CV_16U && ddepth == CV_32F ? (ippiAddProductMask)ippiAddProduct_16u32f_C1IMR :
-                sdepth == CV_32F && ddepth == CV_32F ? (ippiAddProductMask)ippiAddProduct_32f_C1IMR : 0;
-        }
-
-        if (ippFunc || ippFuncMask)
-        {
-            IppStatus status = ippStsNoErr;
-
-            Size size = src1.size();
-            int src1step = (int)src1.step, src2step = (int)src2.step, dststep = (int)dst.step, maskstep = (int)mask.step;
-            if (src1.isContinuous() && src2.isContinuous() && dst.isContinuous() && mask.isContinuous())
-            {
-                src1step = static_cast<int>(src1.total() * src1.elemSize());
-                src2step = static_cast<int>(src2.total() * src2.elemSize());
-                dststep = static_cast<int>(dst.total() * dst.elemSize());
-                maskstep = static_cast<int>(mask.total() * mask.elemSize());
-                size.width = static_cast<int>(src1.total());
-                size.height = 1;
-            }
-            size.width *= scn;
+            typedef IppStatus (CV_STDCALL * ippiAddProduct)(const void * pSrc1, int src1Step, const void * pSrc2,
+                                                            int src2Step, Ipp32f * pSrcDst, int srcDstStep, IppiSize roiSize);
+            typedef IppStatus (CV_STDCALL * ippiAddProductMask)(const void * pSrc1, int src1Step, const void * pSrc2, int src2Step,
+                                                                const Ipp8u * pMask, int maskStep, Ipp32f * pSrcDst, int srcDstStep, IppiSize roiSize);
+            ippiAddProduct ippFunc = 0;
+            ippiAddProductMask ippFuncMask = 0;
 
             if (mask.empty())
-                status = ippFunc(src1.ptr(), src1step, src2.ptr(), src2step, dst.ptr<Ipp32f>(),
-                                 dststep, ippiSize(size.width, size.height));
-            else
-                status = ippFuncMask(src1.ptr(), src1step, src2.ptr(), src2step, mask.ptr<Ipp8u>(), maskstep,
-                                     dst.ptr<Ipp32f>(), dststep, ippiSize(size.width, size.height));
+            {
+                ippFunc = sdepth == CV_8U && ddepth == CV_32F ? (ippiAddProduct)ippiAddProduct_8u32f_C1IR :
+                    sdepth == CV_16U && ddepth == CV_32F ? (ippiAddProduct)ippiAddProduct_16u32f_C1IR :
+                    sdepth == CV_32F && ddepth == CV_32F ? (ippiAddProduct)ippiAddProduct_32f_C1IR : 0;
+            }
+            else if (scn == 1)
+            {
+                ippFuncMask = sdepth == CV_8U && ddepth == CV_32F ? (ippiAddProductMask)ippiAddProduct_8u32f_C1IMR :
+                    sdepth == CV_16U && ddepth == CV_32F ? (ippiAddProductMask)ippiAddProduct_16u32f_C1IMR :
+                    sdepth == CV_32F && ddepth == CV_32F ? (ippiAddProductMask)ippiAddProduct_32f_C1IMR : 0;
+            }
 
-            if (status >= 0)
-                return;
-            setIppErrorStatus();
+            if (ippFunc || ippFuncMask)
+            {
+                IppStatus status = ippStsNoErr;
+
+                Size size = src1.size();
+                int src1step = (int)src1.step, src2step = (int)src2.step, dststep = (int)dst.step, maskstep = (int)mask.step;
+                if (src1.isContinuous() && src2.isContinuous() && dst.isContinuous() && mask.isContinuous())
+                {
+                    src1step = static_cast<int>(src1.total() * src1.elemSize());
+                    src2step = static_cast<int>(src2.total() * src2.elemSize());
+                    dststep = static_cast<int>(dst.total() * dst.elemSize());
+                    maskstep = static_cast<int>(mask.total() * mask.elemSize());
+                    size.width = static_cast<int>(src1.total());
+                    size.height = 1;
+                }
+                size.width *= scn;
+
+                if (mask.empty())
+                    status = ippFunc(src1.ptr(), src1step, src2.ptr(), src2step, dst.ptr<Ipp32f>(),
+                                     dststep, ippiSize(size.width, size.height));
+                else
+                    status = ippFuncMask(src1.ptr(), src1step, src2.ptr(), src2step, mask.ptr<Ipp8u>(), maskstep,
+                                         dst.ptr<Ipp32f>(), dststep, ippiSize(size.width, size.height));
+
+                if (status >= 0)
+                {
+                    CV_IMPL_ADD(CV_IMPL_IPP);
+                    return;
+                }
+                setIppErrorStatus();
+            }
         }
     }
 #endif
@@ -1095,54 +1113,60 @@ void cv::accumulateWeighted( InputArray _src, InputOutputArray _dst,
     Mat src = _src.getMat(), dst = _dst.getMat(), mask = _mask.getMat();
 
 #if defined(HAVE_IPP)
-    if (src.dims <= 2 || (src.isContinuous() && dst.isContinuous() && mask.isContinuous()))
+    CV_IPP_CHECK()
     {
-        typedef IppStatus (CV_STDCALL * ippiAddWeighted)(const void * pSrc, int srcStep, Ipp32f * pSrcDst, int srcdstStep,
-                                                         IppiSize roiSize, Ipp32f alpha);
-        typedef IppStatus (CV_STDCALL * ippiAddWeightedMask)(const void * pSrc, int srcStep, const Ipp8u * pMask,
-                                                             int maskStep, Ipp32f * pSrcDst,
-                                                             int srcDstStep, IppiSize roiSize, Ipp32f alpha);
-        ippiAddWeighted ippFunc = 0;
-        ippiAddWeightedMask ippFuncMask = 0;
-
-        if (mask.empty())
+        if (src.dims <= 2 || (src.isContinuous() && dst.isContinuous() && mask.isContinuous()))
         {
-            ippFunc = sdepth == CV_8U && ddepth == CV_32F ? (ippiAddWeighted)ippiAddWeighted_8u32f_C1IR :
-                sdepth == CV_16U && ddepth == CV_32F ? (ippiAddWeighted)ippiAddWeighted_16u32f_C1IR :
-                sdepth == CV_32F && ddepth == CV_32F ? (ippiAddWeighted)ippiAddWeighted_32f_C1IR : 0;
-        }
-        else if (scn == 1)
-        {
-            ippFuncMask = sdepth == CV_8U && ddepth == CV_32F ? (ippiAddWeightedMask)ippiAddWeighted_8u32f_C1IMR :
-                sdepth == CV_16U && ddepth == CV_32F ? (ippiAddWeightedMask)ippiAddWeighted_16u32f_C1IMR :
-                sdepth == CV_32F && ddepth == CV_32F ? (ippiAddWeightedMask)ippiAddWeighted_32f_C1IMR : 0;
-        }
-
-        if (ippFunc || ippFuncMask)
-        {
-            IppStatus status = ippStsNoErr;
-
-            Size size = src.size();
-            int srcstep = (int)src.step, dststep = (int)dst.step, maskstep = (int)mask.step;
-            if (src.isContinuous() && dst.isContinuous() && mask.isContinuous())
-            {
-                srcstep = static_cast<int>(src.total() * src.elemSize());
-                dststep = static_cast<int>(dst.total() * dst.elemSize());
-                maskstep = static_cast<int>(mask.total() * mask.elemSize());
-                size.width = static_cast<int>((int)src.total());
-                size.height = 1;
-            }
-            size.width *= scn;
+            typedef IppStatus (CV_STDCALL * ippiAddWeighted)(const void * pSrc, int srcStep, Ipp32f * pSrcDst, int srcdstStep,
+                                                             IppiSize roiSize, Ipp32f alpha);
+            typedef IppStatus (CV_STDCALL * ippiAddWeightedMask)(const void * pSrc, int srcStep, const Ipp8u * pMask,
+                                                                 int maskStep, Ipp32f * pSrcDst,
+                                                                 int srcDstStep, IppiSize roiSize, Ipp32f alpha);
+            ippiAddWeighted ippFunc = 0;
+            ippiAddWeightedMask ippFuncMask = 0;
 
             if (mask.empty())
-                status = ippFunc(src.ptr(), srcstep, dst.ptr<Ipp32f>(), dststep, ippiSize(size.width, size.height), (Ipp32f)alpha);
-            else
-                status = ippFuncMask(src.ptr(), srcstep, mask.ptr<Ipp8u>(), maskstep,
-                                     dst.ptr<Ipp32f>(), dststep, ippiSize(size.width, size.height), (Ipp32f)alpha);
+            {
+                ippFunc = sdepth == CV_8U && ddepth == CV_32F ? (ippiAddWeighted)ippiAddWeighted_8u32f_C1IR :
+                    sdepth == CV_16U && ddepth == CV_32F ? (ippiAddWeighted)ippiAddWeighted_16u32f_C1IR :
+                    sdepth == CV_32F && ddepth == CV_32F ? (ippiAddWeighted)ippiAddWeighted_32f_C1IR : 0;
+            }
+            else if (scn == 1)
+            {
+                ippFuncMask = sdepth == CV_8U && ddepth == CV_32F ? (ippiAddWeightedMask)ippiAddWeighted_8u32f_C1IMR :
+                    sdepth == CV_16U && ddepth == CV_32F ? (ippiAddWeightedMask)ippiAddWeighted_16u32f_C1IMR :
+                    sdepth == CV_32F && ddepth == CV_32F ? (ippiAddWeightedMask)ippiAddWeighted_32f_C1IMR : 0;
+            }
 
-            if (status >= 0)
-                return;
-            setIppErrorStatus();
+            if (ippFunc || ippFuncMask)
+            {
+                IppStatus status = ippStsNoErr;
+
+                Size size = src.size();
+                int srcstep = (int)src.step, dststep = (int)dst.step, maskstep = (int)mask.step;
+                if (src.isContinuous() && dst.isContinuous() && mask.isContinuous())
+                {
+                    srcstep = static_cast<int>(src.total() * src.elemSize());
+                    dststep = static_cast<int>(dst.total() * dst.elemSize());
+                    maskstep = static_cast<int>(mask.total() * mask.elemSize());
+                    size.width = static_cast<int>((int)src.total());
+                    size.height = 1;
+                }
+                size.width *= scn;
+
+                if (mask.empty())
+                    status = ippFunc(src.ptr(), srcstep, dst.ptr<Ipp32f>(), dststep, ippiSize(size.width, size.height), (Ipp32f)alpha);
+                else
+                    status = ippFuncMask(src.ptr(), srcstep, mask.ptr<Ipp8u>(), maskstep,
+                                         dst.ptr<Ipp32f>(), dststep, ippiSize(size.width, size.height), (Ipp32f)alpha);
+
+                if (status >= 0)
+                {
+                    CV_IMPL_ADD(CV_IMPL_IPP);
+                    return;
+                }
+                setIppErrorStatus();
+            }
         }
     }
 #endif

--- a/modules/imgproc/src/canny.cpp
+++ b/modules/imgproc/src/canny.cpp
@@ -265,11 +265,17 @@ void cv::Canny( InputArray _src, OutputArray _dst,
 #endif
 
 #ifdef USE_IPP_CANNY
-    if( aperture_size == 3 && !L2gradient && 1 == cn )
+    CV_IPP_CHECK()
     {
-        if (ippCanny(src, dst, (float)low_thresh, (float)high_thresh))
-            return;
-        setIppErrorStatus();
+        if( aperture_size == 3 && !L2gradient && 1 == cn )
+        {
+            if (ippCanny(src, dst, (float)low_thresh, (float)high_thresh))
+            {
+                CV_IMPL_ADD(CV_IMPL_IPP);
+                return;
+            }
+            setIppErrorStatus();
+        }
     }
 #endif
 

--- a/modules/imgproc/src/clahe.cpp
+++ b/modules/imgproc/src/clahe.cpp
@@ -404,7 +404,10 @@ namespace
 #ifdef HAVE_OPENCL
         if (useOpenCL && clahe::calcLut(_srcForLut, ulut_, tilesX_, tilesY_, tileSize, clipLimit, lutScale) )
             if( clahe::transform(_src, _dst, ulut_, tilesX_, tilesY_, tileSize) )
+            {
+                CV_IMPL_ADD(CV_IMPL_OCL);
                 return;
+            }
 #endif
 
         cv::Mat src = _src.getMat();

--- a/modules/imgproc/src/color.cpp
+++ b/modules/imgproc/src/color.cpp
@@ -223,6 +223,10 @@ public:
         void *yD = dst.ptr<uchar>(range.start);
         if( !cvt(yS, (int)src.step[0], yD, (int)dst.step[0], src.cols, range.end - range.start) )
             *ok = false;
+        else
+        {
+            CV_IMPL_ADD(CV_IMPL_IPP|CV_IMPL_MT);
+        }
     }
 
 private:
@@ -5427,44 +5431,65 @@ void cv::cvtColor( InputArray _src, OutputArray _dst, int code, int dcn )
             dst = _dst.getMat();
 
 #if defined (HAVE_IPP) && (IPP_VERSION_MAJOR >= 7)
-            if( code == CV_BGR2BGRA)
+            CV_IPP_CHECK()
             {
-                if ( CvtColorIPPLoop(src, dst, IPPReorderFunctor(ippiSwapChannelsC3C4RTab[depth], 0, 1, 2)) )
-                    return;
-                setIppErrorStatus();
-            }
-            else if( code == CV_BGRA2BGR )
-            {
-                if ( CvtColorIPPLoop(src, dst, IPPGeneralFunctor(ippiCopyAC4C3RTab[depth])) )
-                    return;
-                setIppErrorStatus();
-            }
-            else if( code == CV_BGR2RGBA )
-            {
-                if( CvtColorIPPLoop(src, dst, IPPReorderFunctor(ippiSwapChannelsC3C4RTab[depth], 2, 1, 0)) )
-                    return;
-                setIppErrorStatus();
-            }
-            else if( code == CV_RGBA2BGR )
-            {
-                if( CvtColorIPPLoop(src, dst, IPPReorderFunctor(ippiSwapChannelsC4C3RTab[depth], 2, 1, 0)) )
-                    return;
-                setIppErrorStatus();
-            }
-            else if( code == CV_RGB2BGR )
-            {
-                if( CvtColorIPPLoopCopy(src, dst, IPPReorderFunctor(ippiSwapChannelsC3RTab[depth], 2, 1, 0)) )
-                    return;
-                setIppErrorStatus();
-            }
+                if( code == CV_BGR2BGRA)
+                {
+                    if ( CvtColorIPPLoop(src, dst, IPPReorderFunctor(ippiSwapChannelsC3C4RTab[depth], 0, 1, 2)) )
+                    {
+                        CV_IMPL_ADD(CV_IMPL_IPP|CV_IMPL_MT);
+                        return;
+                    }
+                    setIppErrorStatus();
+                }
+                else if( code == CV_BGRA2BGR )
+                {
+                    if ( CvtColorIPPLoop(src, dst, IPPGeneralFunctor(ippiCopyAC4C3RTab[depth])) )
+                    {
+                        CV_IMPL_ADD(CV_IMPL_IPP|CV_IMPL_MT);
+                        return;
+                    }
+                    setIppErrorStatus();
+                }
+                else if( code == CV_BGR2RGBA )
+                {
+                    if( CvtColorIPPLoop(src, dst, IPPReorderFunctor(ippiSwapChannelsC3C4RTab[depth], 2, 1, 0)) )
+                    {
+                        CV_IMPL_ADD(CV_IMPL_IPP|CV_IMPL_MT);
+                        return;
+                    }
+                    setIppErrorStatus();
+                }
+                else if( code == CV_RGBA2BGR )
+                {
+                    if( CvtColorIPPLoop(src, dst, IPPReorderFunctor(ippiSwapChannelsC4C3RTab[depth], 2, 1, 0)) )
+                    {
+                        CV_IMPL_ADD(CV_IMPL_IPP|CV_IMPL_MT);
+                        return;
+                    }
+                    setIppErrorStatus();
+                }
+                else if( code == CV_RGB2BGR )
+                {
+                    if( CvtColorIPPLoopCopy(src, dst, IPPReorderFunctor(ippiSwapChannelsC3RTab[depth], 2, 1, 0)) )
+                    {
+                        CV_IMPL_ADD(CV_IMPL_IPP|CV_IMPL_MT);
+                        return;
+                    }
+                    setIppErrorStatus();
+                }
 #if IPP_VERSION_X100 >= 801
-            else if( code == CV_RGBA2BGRA )
-            {
-                if( CvtColorIPPLoopCopy(src, dst, IPPReorderFunctor(ippiSwapChannelsC4RTab[depth], 2, 1, 0)) )
-                    return;
-                setIppErrorStatus();
-            }
+                else if( code == CV_RGBA2BGRA )
+                {
+                    if( CvtColorIPPLoopCopy(src, dst, IPPReorderFunctor(ippiSwapChannelsC4RTab[depth], 2, 1, 0)) )
+                    {
+                        CV_IMPL_ADD(CV_IMPL_IPP|CV_IMPL_MT);
+                        return;
+                    }
+                    setIppErrorStatus();
+                }
 #endif
+            }
 #endif
 
             if( depth == CV_8U )
@@ -5487,37 +5512,52 @@ void cv::cvtColor( InputArray _src, OutputArray _dst, int code, int dcn )
             dst = _dst.getMat();
 
 #if defined(HAVE_IPP) && 0 // breaks OCL accuracy tests
-            CV_SUPPRESS_DEPRECATED_START
+            CV_IPP_CHECK()
+            {
+                CV_SUPPRESS_DEPRECATED_START
 
-            if (code == CV_BGR2BGR565 && scn == 3)
-            {
-                if (CvtColorIPPLoop(src, dst, IPPGeneralFunctor((ippiGeneralFunc)ippiBGRToBGR565_8u16u_C3R)))
-                    return;
-                setIppErrorStatus();
+                if (code == CV_BGR2BGR565 && scn == 3)
+                {
+                    if (CvtColorIPPLoop(src, dst, IPPGeneralFunctor((ippiGeneralFunc)ippiBGRToBGR565_8u16u_C3R)))
+                    {
+                        CV_IMPL_ADD(CV_IMPL_IPP|CV_IMPL_MT);
+                        return;
+                    }
+                    setIppErrorStatus();
+                }
+                else if (code == CV_BGRA2BGR565 && scn == 4)
+                {
+                    if (CvtColorIPPLoopCopy(src, dst,
+                                            IPPReorderGeneralFunctor(ippiSwapChannelsC4C3RTab[depth],
+                                            (ippiGeneralFunc)ippiBGRToBGR565_8u16u_C3R, 0, 1, 2, depth)))
+                    {
+                        CV_IMPL_ADD(CV_IMPL_IPP|CV_IMPL_MT);
+                        return;
+                    }
+                    setIppErrorStatus();
+                }
+                else if (code == CV_RGB2BGR565 && scn == 3)
+                {
+                    if( CvtColorIPPLoopCopy(src, dst, IPPReorderGeneralFunctor(ippiSwapChannelsC3RTab[depth],
+                                                                               (ippiGeneralFunc)ippiBGRToBGR565_8u16u_C3R, 2, 1, 0, depth)) )
+                    {
+                        CV_IMPL_ADD(CV_IMPL_IPP|CV_IMPL_MT);
+                        return;
+                    }
+                    setIppErrorStatus();
+                }
+                else if (code == CV_RGBA2BGR565 && scn == 4)
+                {
+                    if( CvtColorIPPLoopCopy(src, dst, IPPReorderGeneralFunctor(ippiSwapChannelsC4C3RTab[depth],
+                                                                               (ippiGeneralFunc)ippiBGRToBGR565_8u16u_C3R, 2, 1, 0, depth)) )
+                    {
+                        CV_IMPL_ADD(CV_IMPL_IPP|CV_IMPL_MT);
+                        return;
+                    }
+                    setIppErrorStatus();
+                }
+                CV_SUPPRESS_DEPRECATED_END
             }
-            else if (code == CV_BGRA2BGR565 && scn == 4)
-            {
-                if (CvtColorIPPLoopCopy(src, dst,
-                                        IPPReorderGeneralFunctor(ippiSwapChannelsC4C3RTab[depth],
-                                        (ippiGeneralFunc)ippiBGRToBGR565_8u16u_C3R, 0, 1, 2, depth)))
-                    return;
-                setIppErrorStatus();
-            }
-            else if (code == CV_RGB2BGR565 && scn == 3)
-            {
-                if( CvtColorIPPLoopCopy(src, dst, IPPReorderGeneralFunctor(ippiSwapChannelsC3RTab[depth],
-                                                                           (ippiGeneralFunc)ippiBGRToBGR565_8u16u_C3R, 2, 1, 0, depth)) )
-                    return;
-                setIppErrorStatus();
-            }
-            else if (code == CV_RGBA2BGR565 && scn == 4)
-            {
-                if( CvtColorIPPLoopCopy(src, dst, IPPReorderGeneralFunctor(ippiSwapChannelsC4C3RTab[depth],
-                                                                           (ippiGeneralFunc)ippiBGRToBGR565_8u16u_C3R, 2, 1, 0, depth)) )
-                    return;
-                setIppErrorStatus();
-            }
-            CV_SUPPRESS_DEPRECATED_END
 #endif
 
 #ifdef HAVE_TEGRA_OPTIMIZATION
@@ -5542,35 +5582,50 @@ void cv::cvtColor( InputArray _src, OutputArray _dst, int code, int dcn )
             dst = _dst.getMat();
 
 #ifdef HAVE_IPP
-            CV_SUPPRESS_DEPRECATED_START
-            if (code == CV_BGR5652BGR && dcn == 3)
+            CV_IPP_CHECK()
             {
-                if (CvtColorIPPLoop(src, dst, IPPGeneralFunctor((ippiGeneralFunc)ippiBGR565ToBGR_16u8u_C3R)))
-                    return;
-                setIppErrorStatus();
+                CV_SUPPRESS_DEPRECATED_START
+                if (code == CV_BGR5652BGR && dcn == 3)
+                {
+                    if (CvtColorIPPLoop(src, dst, IPPGeneralFunctor((ippiGeneralFunc)ippiBGR565ToBGR_16u8u_C3R)))
+                    {
+                        CV_IMPL_ADD(CV_IMPL_IPP|CV_IMPL_MT);
+                        return;
+                    }
+                    setIppErrorStatus();
+                }
+                else if (code == CV_BGR5652RGB && dcn == 3)
+                {
+                    if (CvtColorIPPLoop(src, dst, IPPGeneralReorderFunctor((ippiGeneralFunc)ippiBGR565ToBGR_16u8u_C3R,
+                                                                           ippiSwapChannelsC3RTab[depth], 2, 1, 0, depth)))
+                    {
+                        CV_IMPL_ADD(CV_IMPL_IPP|CV_IMPL_MT);
+                        return;
+                    }
+                    setIppErrorStatus();
+                }
+                else if (code == CV_BGR5652BGRA && dcn == 4)
+                {
+                    if (CvtColorIPPLoop(src, dst, IPPGeneralReorderFunctor((ippiGeneralFunc)ippiBGR565ToBGR_16u8u_C3R,
+                                                                           ippiSwapChannelsC3C4RTab[depth], 0, 1, 2, depth)))
+                    {
+                        CV_IMPL_ADD(CV_IMPL_IPP|CV_IMPL_MT);
+                        return;
+                    }
+                    setIppErrorStatus();
+                }
+                else if (code == CV_BGR5652RGBA && dcn == 4)
+                {
+                    if (CvtColorIPPLoop(src, dst, IPPGeneralReorderFunctor((ippiGeneralFunc)ippiBGR565ToBGR_16u8u_C3R,
+                                                                           ippiSwapChannelsC3C4RTab[depth], 2, 1, 0, depth)))
+                    {
+                        CV_IMPL_ADD(CV_IMPL_IPP|CV_IMPL_MT);
+                        return;
+                    }
+                    setIppErrorStatus();
+                }
+                CV_SUPPRESS_DEPRECATED_END
             }
-            else if (code == CV_BGR5652RGB && dcn == 3)
-            {
-                if (CvtColorIPPLoop(src, dst, IPPGeneralReorderFunctor((ippiGeneralFunc)ippiBGR565ToBGR_16u8u_C3R,
-                                                                       ippiSwapChannelsC3RTab[depth], 2, 1, 0, depth)))
-                    return;
-                setIppErrorStatus();
-            }
-            else if (code == CV_BGR5652BGRA && dcn == 4)
-            {
-                if (CvtColorIPPLoop(src, dst, IPPGeneralReorderFunctor((ippiGeneralFunc)ippiBGR565ToBGR_16u8u_C3R,
-                                                                       ippiSwapChannelsC3C4RTab[depth], 0, 1, 2, depth)))
-                    return;
-                setIppErrorStatus();
-            }
-            else if (code == CV_BGR5652RGBA && dcn == 4)
-            {
-                if (CvtColorIPPLoop(src, dst, IPPGeneralReorderFunctor((ippiGeneralFunc)ippiBGR565ToBGR_16u8u_C3R,
-                                                                       ippiSwapChannelsC3C4RTab[depth], 2, 1, 0, depth)))
-                    return;
-                setIppErrorStatus();
-            }
-            CV_SUPPRESS_DEPRECATED_END
 #endif
 
             CvtColorLoop(src, dst, RGB5x52RGB(dcn,
@@ -5587,29 +5642,44 @@ void cv::cvtColor( InputArray _src, OutputArray _dst, int code, int dcn )
             dst = _dst.getMat();
 
 #if defined (HAVE_IPP) && (IPP_VERSION_MAJOR >= 7)
-            if( code == CV_BGR2GRAY && depth == CV_32F )
+            CV_IPP_CHECK()
             {
-                if( CvtColorIPPLoop(src, dst, IPPColor2GrayFunctor(ippiColor2GrayC3Tab[depth])) )
-                    return;
-                setIppErrorStatus();
-            }
-            else if( code == CV_RGB2GRAY && depth == CV_32F )
-            {
-                if( CvtColorIPPLoop(src, dst, IPPGeneralFunctor(ippiRGB2GrayC3Tab[depth])) )
-                    return;
-                setIppErrorStatus();
-            }
-            else if( code == CV_BGRA2GRAY && depth == CV_32F )
-            {
-                if( CvtColorIPPLoop(src, dst, IPPColor2GrayFunctor(ippiColor2GrayC4Tab[depth])) )
-                    return;
-                setIppErrorStatus();
-            }
-            else if( code == CV_RGBA2GRAY && depth == CV_32F )
-            {
-                if( CvtColorIPPLoop(src, dst, IPPGeneralFunctor(ippiRGB2GrayC4Tab[depth])) )
-                    return;
-                setIppErrorStatus();
+                if( code == CV_BGR2GRAY && depth == CV_32F )
+                {
+                    if( CvtColorIPPLoop(src, dst, IPPColor2GrayFunctor(ippiColor2GrayC3Tab[depth])) )
+                    {
+                        CV_IMPL_ADD(CV_IMPL_IPP|CV_IMPL_MT);
+                        return;
+                    }
+                    setIppErrorStatus();
+                }
+                else if( code == CV_RGB2GRAY && depth == CV_32F )
+                {
+                    if( CvtColorIPPLoop(src, dst, IPPGeneralFunctor(ippiRGB2GrayC3Tab[depth])) )
+                    {
+                        CV_IMPL_ADD(CV_IMPL_IPP|CV_IMPL_MT);
+                        return;
+                    }
+                    setIppErrorStatus();
+                }
+                else if( code == CV_BGRA2GRAY && depth == CV_32F )
+                {
+                    if( CvtColorIPPLoop(src, dst, IPPColor2GrayFunctor(ippiColor2GrayC4Tab[depth])) )
+                    {
+                        CV_IMPL_ADD(CV_IMPL_IPP|CV_IMPL_MT);
+                        return;
+                    }
+                    setIppErrorStatus();
+                }
+                else if( code == CV_RGBA2GRAY && depth == CV_32F )
+                {
+                    if( CvtColorIPPLoop(src, dst, IPPGeneralFunctor(ippiRGB2GrayC4Tab[depth])) )
+                    {
+                        CV_IMPL_ADD(CV_IMPL_IPP|CV_IMPL_MT);
+                        return;
+                    }
+                    setIppErrorStatus();
+                }
             }
 #endif
 
@@ -5643,17 +5713,26 @@ void cv::cvtColor( InputArray _src, OutputArray _dst, int code, int dcn )
             dst = _dst.getMat();
 
 #if defined (HAVE_IPP) && (IPP_VERSION_MAJOR >= 7)
-            if( code == CV_GRAY2BGR )
+            CV_IPP_CHECK()
             {
-                if( CvtColorIPPLoop(src, dst, IPPGray2BGRFunctor(ippiCopyP3C3RTab[depth])) )
-                    return;
-                setIppErrorStatus();
-            }
-            else if( code == CV_GRAY2BGRA )
-            {
-                if( CvtColorIPPLoop(src, dst, IPPGray2BGRAFunctor(ippiCopyP3C3RTab[depth], ippiSwapChannelsC3C4RTab[depth], depth)) )
-                    return;
-                setIppErrorStatus();
+                if( code == CV_GRAY2BGR )
+                {
+                    if( CvtColorIPPLoop(src, dst, IPPGray2BGRFunctor(ippiCopyP3C3RTab[depth])) )
+                    {
+                        CV_IMPL_ADD(CV_IMPL_IPP|CV_IMPL_MT);
+                        return;
+                    }
+                    setIppErrorStatus();
+                }
+                else if( code == CV_GRAY2BGRA )
+                {
+                    if( CvtColorIPPLoop(src, dst, IPPGray2BGRAFunctor(ippiCopyP3C3RTab[depth], ippiSwapChannelsC3C4RTab[depth], depth)) )
+                    {
+                        CV_IMPL_ADD(CV_IMPL_IPP|CV_IMPL_MT);
+                        return;
+                    }
+                    setIppErrorStatus();
+                }
             }
 #endif
 
@@ -5693,32 +5772,47 @@ void cv::cvtColor( InputArray _src, OutputArray _dst, int code, int dcn )
             dst = _dst.getMat();
 
 #if defined HAVE_IPP && 0
-            if (code == CV_RGB2YUV && scn == 3 && depth == CV_8U)
+            CV_IPP_CHECK()
             {
-                if (CvtColorIPPLoop(src, dst, IPPGeneralFunctor((ippiGeneralFunc)ippiRGBToYUV_8u_C3R)))
-                    return;
-                setIppErrorStatus();
-            }
-            else if (code == CV_BGR2YUV && scn == 3 && depth == CV_8U)
-            {
-                if (CvtColorIPPLoop(src, dst, IPPReorderGeneralFunctor(ippiSwapChannelsC3RTab[depth],
-                                                                       (ippiGeneralFunc)ippiRGBToYUV_8u_C3R, 2, 1, 0, depth)))
-                    return;
-                setIppErrorStatus();
-            }
-            else if (code == CV_RGB2YUV && scn == 4 && depth == CV_8U)
-            {
-                if (CvtColorIPPLoop(src, dst, IPPReorderGeneralFunctor(ippiSwapChannelsC4C3RTab[depth],
-                                                                       (ippiGeneralFunc)ippiRGBToYUV_8u_C3R, 0, 1, 2, depth)))
-                    return;
-                setIppErrorStatus();
-            }
-            else if (code == CV_BGR2YUV && scn == 4 && depth == CV_8U)
-            {
-                if (CvtColorIPPLoop(src, dst, IPPReorderGeneralFunctor(ippiSwapChannelsC4C3RTab[depth],
-                                                                       (ippiGeneralFunc)ippiRGBToYUV_8u_C3R, 2, 1, 0, depth)))
-                    return;
-                setIppErrorStatus();
+                if (code == CV_RGB2YUV && scn == 3 && depth == CV_8U)
+                {
+                    if (CvtColorIPPLoop(src, dst, IPPGeneralFunctor((ippiGeneralFunc)ippiRGBToYUV_8u_C3R)))
+                    {
+                        CV_IMPL_ADD(CV_IMPL_IPP|CV_IMPL_MT);
+                        return;
+                    }
+                    setIppErrorStatus();
+                }
+                else if (code == CV_BGR2YUV && scn == 3 && depth == CV_8U)
+                {
+                    if (CvtColorIPPLoop(src, dst, IPPReorderGeneralFunctor(ippiSwapChannelsC3RTab[depth],
+                                                                           (ippiGeneralFunc)ippiRGBToYUV_8u_C3R, 2, 1, 0, depth)))
+                    {
+                        CV_IMPL_ADD(CV_IMPL_IPP|CV_IMPL_MT);
+                        return;
+                    }
+                    setIppErrorStatus();
+                }
+                else if (code == CV_RGB2YUV && scn == 4 && depth == CV_8U)
+                {
+                    if (CvtColorIPPLoop(src, dst, IPPReorderGeneralFunctor(ippiSwapChannelsC4C3RTab[depth],
+                                                                           (ippiGeneralFunc)ippiRGBToYUV_8u_C3R, 0, 1, 2, depth)))
+                    {
+                        CV_IMPL_ADD(CV_IMPL_IPP|CV_IMPL_MT);
+                        return;
+                    }
+                    setIppErrorStatus();
+                }
+                else if (code == CV_BGR2YUV && scn == 4 && depth == CV_8U)
+                {
+                    if (CvtColorIPPLoop(src, dst, IPPReorderGeneralFunctor(ippiSwapChannelsC4C3RTab[depth],
+                                                                           (ippiGeneralFunc)ippiRGBToYUV_8u_C3R, 2, 1, 0, depth)))
+                    {
+                        CV_IMPL_ADD(CV_IMPL_IPP|CV_IMPL_MT);
+                        return;
+                    }
+                    setIppErrorStatus();
+                }
             }
 #endif
 
@@ -5752,32 +5846,47 @@ void cv::cvtColor( InputArray _src, OutputArray _dst, int code, int dcn )
             dst = _dst.getMat();
 
 #if defined HAVE_IPP && 0
-            if (code == CV_YUV2RGB && dcn == 3 && depth == CV_8U)
+            CV_IPP_CHECK()
             {
-                if (CvtColorIPPLoop(src, dst, IPPGeneralFunctor((ippiGeneralFunc)ippiYUVToRGB_8u_C3R)))
-                    return;
-                setIppErrorStatus();
-            }
-            else if (code == CV_YUV2BGR && dcn == 3 && depth == CV_8U)
-            {
-                if (CvtColorIPPLoop(src, dst, IPPGeneralReorderFunctor((ippiGeneralFunc)ippiYUVToRGB_8u_C3R,
-                                                                       ippiSwapChannelsC3RTab[depth], 2, 1, 0, depth)))
-                    return;
-                setIppErrorStatus();
-            }
-            else if (code == CV_YUV2RGB && dcn == 4 && depth == CV_8U)
-            {
-                if (CvtColorIPPLoop(src, dst, IPPGeneralReorderFunctor((ippiGeneralFunc)ippiYUVToRGB_8u_C3R,
-                                                                       ippiSwapChannelsC3C4RTab[depth], 0, 1, 2, depth)))
-                    return;
-                setIppErrorStatus();
-            }
-            else if (code == CV_YUV2BGR && dcn == 4 && depth == CV_8U)
-            {
-                if (CvtColorIPPLoop(src, dst, IPPGeneralReorderFunctor((ippiGeneralFunc)ippiYUVToRGB_8u_C3R,
-                                                                       ippiSwapChannelsC3C4RTab[depth], 2, 1, 0, depth)))
-                    return;
-                setIppErrorStatus();
+                if (code == CV_YUV2RGB && dcn == 3 && depth == CV_8U)
+                {
+                    if (CvtColorIPPLoop(src, dst, IPPGeneralFunctor((ippiGeneralFunc)ippiYUVToRGB_8u_C3R)))
+                    {
+                        CV_IMPL_ADD(CV_IMPL_IPP|CV_IMPL_MT);
+                        return;
+                    }
+                    setIppErrorStatus();
+                }
+                else if (code == CV_YUV2BGR && dcn == 3 && depth == CV_8U)
+                {
+                    if (CvtColorIPPLoop(src, dst, IPPGeneralReorderFunctor((ippiGeneralFunc)ippiYUVToRGB_8u_C3R,
+                                                                           ippiSwapChannelsC3RTab[depth], 2, 1, 0, depth)))
+                    {
+                        CV_IMPL_ADD(CV_IMPL_IPP|CV_IMPL_MT);
+                        return;
+                    }
+                    setIppErrorStatus();
+                }
+                else if (code == CV_YUV2RGB && dcn == 4 && depth == CV_8U)
+                {
+                    if (CvtColorIPPLoop(src, dst, IPPGeneralReorderFunctor((ippiGeneralFunc)ippiYUVToRGB_8u_C3R,
+                                                                           ippiSwapChannelsC3C4RTab[depth], 0, 1, 2, depth)))
+                    {
+                        CV_IMPL_ADD(CV_IMPL_IPP|CV_IMPL_MT);
+                        return;
+                    }
+                    setIppErrorStatus();
+                }
+                else if (code == CV_YUV2BGR && dcn == 4 && depth == CV_8U)
+                {
+                    if (CvtColorIPPLoop(src, dst, IPPGeneralReorderFunctor((ippiGeneralFunc)ippiYUVToRGB_8u_C3R,
+                                                                           ippiSwapChannelsC3C4RTab[depth], 2, 1, 0, depth)))
+                    {
+                        CV_IMPL_ADD(CV_IMPL_IPP|CV_IMPL_MT);
+                        return;
+                    }
+                    setIppErrorStatus();
+                }
             }
 #endif
 
@@ -5798,29 +5907,44 @@ void cv::cvtColor( InputArray _src, OutputArray _dst, int code, int dcn )
             dst = _dst.getMat();
 
 #if defined (HAVE_IPP) && (IPP_VERSION_MAJOR >= 7)
-            if( code == CV_BGR2XYZ && scn == 3 && depth != CV_32F )
+            CV_IPP_CHECK()
             {
-                if( CvtColorIPPLoopCopy(src, dst, IPPReorderGeneralFunctor(ippiSwapChannelsC3RTab[depth], ippiRGB2XYZTab[depth], 2, 1, 0, depth)) )
-                    return;
-                setIppErrorStatus();
-            }
-            else if( code == CV_BGR2XYZ && scn == 4 && depth != CV_32F )
-            {
-                if( CvtColorIPPLoop(src, dst, IPPReorderGeneralFunctor(ippiSwapChannelsC4C3RTab[depth], ippiRGB2XYZTab[depth], 2, 1, 0, depth)) )
-                    return;
-                setIppErrorStatus();
-            }
-            else if( code == CV_RGB2XYZ && scn == 3 && depth != CV_32F )
-            {
-                if( CvtColorIPPLoopCopy(src, dst, IPPGeneralFunctor(ippiRGB2XYZTab[depth])) )
-                    return;
-                setIppErrorStatus();
-            }
-            else if( code == CV_RGB2XYZ && scn == 4 && depth != CV_32F )
-            {
-                if( CvtColorIPPLoop(src, dst, IPPReorderGeneralFunctor(ippiSwapChannelsC4C3RTab[depth], ippiRGB2XYZTab[depth], 0, 1, 2, depth)) )
-                    return;
-                setIppErrorStatus();
+                if( code == CV_BGR2XYZ && scn == 3 && depth != CV_32F )
+                {
+                    if( CvtColorIPPLoopCopy(src, dst, IPPReorderGeneralFunctor(ippiSwapChannelsC3RTab[depth], ippiRGB2XYZTab[depth], 2, 1, 0, depth)) )
+                    {
+                        CV_IMPL_ADD(CV_IMPL_IPP|CV_IMPL_MT);
+                        return;
+                    }
+                    setIppErrorStatus();
+                }
+                else if( code == CV_BGR2XYZ && scn == 4 && depth != CV_32F )
+                {
+                    if( CvtColorIPPLoop(src, dst, IPPReorderGeneralFunctor(ippiSwapChannelsC4C3RTab[depth], ippiRGB2XYZTab[depth], 2, 1, 0, depth)) )
+                    {
+                        CV_IMPL_ADD(CV_IMPL_IPP|CV_IMPL_MT);
+                        return;
+                    }
+                    setIppErrorStatus();
+                }
+                else if( code == CV_RGB2XYZ && scn == 3 && depth != CV_32F )
+                {
+                    if( CvtColorIPPLoopCopy(src, dst, IPPGeneralFunctor(ippiRGB2XYZTab[depth])) )
+                    {
+                        CV_IMPL_ADD(CV_IMPL_IPP|CV_IMPL_MT);
+                        return;
+                    }
+                    setIppErrorStatus();
+                }
+                else if( code == CV_RGB2XYZ && scn == 4 && depth != CV_32F )
+                {
+                    if( CvtColorIPPLoop(src, dst, IPPReorderGeneralFunctor(ippiSwapChannelsC4C3RTab[depth], ippiRGB2XYZTab[depth], 0, 1, 2, depth)) )
+                    {
+                        CV_IMPL_ADD(CV_IMPL_IPP|CV_IMPL_MT);
+                        return;
+                    }
+                    setIppErrorStatus();
+                }
             }
 #endif
 
@@ -5841,29 +5965,44 @@ void cv::cvtColor( InputArray _src, OutputArray _dst, int code, int dcn )
             dst = _dst.getMat();
 
 #if defined (HAVE_IPP) && (IPP_VERSION_MAJOR >= 7)
-            if( code == CV_XYZ2BGR && dcn == 3 && depth != CV_32F )
+            CV_IPP_CHECK()
             {
-                if( CvtColorIPPLoopCopy(src, dst, IPPGeneralReorderFunctor(ippiXYZ2RGBTab[depth], ippiSwapChannelsC3RTab[depth], 2, 1, 0, depth)) )
-                    return;
-                setIppErrorStatus();
-            }
-            else if( code == CV_XYZ2BGR && dcn == 4 && depth != CV_32F )
-            {
-                if( CvtColorIPPLoop(src, dst, IPPGeneralReorderFunctor(ippiXYZ2RGBTab[depth], ippiSwapChannelsC3C4RTab[depth], 2, 1, 0, depth)) )
-                    return;
-                setIppErrorStatus();
-            }
-            if( code == CV_XYZ2RGB && dcn == 3 && depth != CV_32F )
-            {
-                if( CvtColorIPPLoopCopy(src, dst, IPPGeneralFunctor(ippiXYZ2RGBTab[depth])) )
-                    return;
-                setIppErrorStatus();
-            }
-            else if( code == CV_XYZ2RGB && dcn == 4 && depth != CV_32F )
-            {
-                if( CvtColorIPPLoop(src, dst, IPPGeneralReorderFunctor(ippiXYZ2RGBTab[depth], ippiSwapChannelsC3C4RTab[depth], 0, 1, 2, depth)) )
-                    return;
-                setIppErrorStatus();
+                if( code == CV_XYZ2BGR && dcn == 3 && depth != CV_32F )
+                {
+                    if( CvtColorIPPLoopCopy(src, dst, IPPGeneralReorderFunctor(ippiXYZ2RGBTab[depth], ippiSwapChannelsC3RTab[depth], 2, 1, 0, depth)) )
+                    {
+                        CV_IMPL_ADD(CV_IMPL_IPP|CV_IMPL_MT);
+                        return;
+                    }
+                    setIppErrorStatus();
+                }
+                else if( code == CV_XYZ2BGR && dcn == 4 && depth != CV_32F )
+                {
+                    if( CvtColorIPPLoop(src, dst, IPPGeneralReorderFunctor(ippiXYZ2RGBTab[depth], ippiSwapChannelsC3C4RTab[depth], 2, 1, 0, depth)) )
+                    {
+                        CV_IMPL_ADD(CV_IMPL_IPP|CV_IMPL_MT);
+                        return;
+                    }
+                    setIppErrorStatus();
+                }
+                if( code == CV_XYZ2RGB && dcn == 3 && depth != CV_32F )
+                {
+                    if( CvtColorIPPLoopCopy(src, dst, IPPGeneralFunctor(ippiXYZ2RGBTab[depth])) )
+                    {
+                        CV_IMPL_ADD(CV_IMPL_IPP|CV_IMPL_MT);
+                        return;
+                    }
+                    setIppErrorStatus();
+                }
+                else if( code == CV_XYZ2RGB && dcn == 4 && depth != CV_32F )
+                {
+                    if( CvtColorIPPLoop(src, dst, IPPGeneralReorderFunctor(ippiXYZ2RGBTab[depth], ippiSwapChannelsC3C4RTab[depth], 0, 1, 2, depth)) )
+                    {
+                        CV_IMPL_ADD(CV_IMPL_IPP|CV_IMPL_MT);
+                        return;
+                    }
+                    setIppErrorStatus();
+                }
             }
 #endif
 
@@ -5888,57 +6027,84 @@ void cv::cvtColor( InputArray _src, OutputArray _dst, int code, int dcn )
             dst = _dst.getMat();
 
 #if defined (HAVE_IPP) && (IPP_VERSION_MAJOR >= 7)
-            if( depth == CV_8U || depth == CV_16U )
+            CV_IPP_CHECK()
             {
+                if( depth == CV_8U || depth == CV_16U )
+                {
 #if 0 // breaks OCL accuracy tests
-                if( code == CV_BGR2HSV_FULL && scn == 3 )
-                {
-                    if( CvtColorIPPLoopCopy(src, dst, IPPReorderGeneralFunctor(ippiSwapChannelsC3RTab[depth], ippiRGB2HSVTab[depth], 2, 1, 0, depth)) )
-                        return;
-                    setIppErrorStatus();
-                }
-                else if( code == CV_BGR2HSV_FULL && scn == 4 )
-                {
-                    if( CvtColorIPPLoop(src, dst, IPPReorderGeneralFunctor(ippiSwapChannelsC4C3RTab[depth], ippiRGB2HSVTab[depth], 2, 1, 0, depth)) )
-                        return;
-                    setIppErrorStatus();
-                }
-                else if( code == CV_RGB2HSV_FULL && scn == 4 )
-                {
-                    if( CvtColorIPPLoop(src, dst, IPPReorderGeneralFunctor(ippiSwapChannelsC4C3RTab[depth], ippiRGB2HSVTab[depth], 0, 1, 2, depth)) )
-                        return;
-                    setIppErrorStatus();
-                } else
+                    if( code == CV_BGR2HSV_FULL && scn == 3 )
+                    {
+                        if( CvtColorIPPLoopCopy(src, dst, IPPReorderGeneralFunctor(ippiSwapChannelsC3RTab[depth], ippiRGB2HSVTab[depth], 2, 1, 0, depth)) )
+                        {
+                            CV_IMPL_ADD(CV_IMPL_IPP|CV_IMPL_MT);
+                            return;
+                        }
+                        setIppErrorStatus();
+                    }
+                    else if( code == CV_BGR2HSV_FULL && scn == 4 )
+                    {
+                        if( CvtColorIPPLoop(src, dst, IPPReorderGeneralFunctor(ippiSwapChannelsC4C3RTab[depth], ippiRGB2HSVTab[depth], 2, 1, 0, depth)) )
+                        {
+                            CV_IMPL_ADD(CV_IMPL_IPP|CV_IMPL_MT);
+                            return;
+                        }
+                        setIppErrorStatus();
+                    }
+                    else if( code == CV_RGB2HSV_FULL && scn == 4 )
+                    {
+                        if( CvtColorIPPLoop(src, dst, IPPReorderGeneralFunctor(ippiSwapChannelsC4C3RTab[depth], ippiRGB2HSVTab[depth], 0, 1, 2, depth)) )
+                        {
+                            CV_IMPL_ADD(CV_IMPL_IPP|CV_IMPL_MT);
+                            return;
+                        }
+                        setIppErrorStatus();
+                    } else
 #endif
-                if( code == CV_RGB2HSV_FULL && scn == 3 && depth == CV_16U )
-                {
-                    if( CvtColorIPPLoopCopy(src, dst, IPPGeneralFunctor(ippiRGB2HSVTab[depth])) )
-                        return;
-                    setIppErrorStatus();
-                }
-                else if( code == CV_BGR2HLS_FULL && scn == 3 )
-                {
-                    if( CvtColorIPPLoopCopy(src, dst, IPPReorderGeneralFunctor(ippiSwapChannelsC3RTab[depth], ippiRGB2HLSTab[depth], 2, 1, 0, depth)) )
-                        return;
-                    setIppErrorStatus();
-                }
-                else if( code == CV_BGR2HLS_FULL && scn == 4 )
-                {
-                    if( CvtColorIPPLoop(src, dst, IPPReorderGeneralFunctor(ippiSwapChannelsC4C3RTab[depth], ippiRGB2HLSTab[depth], 2, 1, 0, depth)) )
-                        return;
-                    setIppErrorStatus();
-                }
-                else if( code == CV_RGB2HLS_FULL && scn == 3 )
-                {
-                    if( CvtColorIPPLoopCopy(src, dst, IPPGeneralFunctor(ippiRGB2HLSTab[depth])) )
-                        return;
-                    setIppErrorStatus();
-                }
-                else if( code == CV_RGB2HLS_FULL && scn == 4 )
-                {
-                    if( CvtColorIPPLoop(src, dst, IPPReorderGeneralFunctor(ippiSwapChannelsC4C3RTab[depth], ippiRGB2HLSTab[depth], 0, 1, 2, depth)) )
-                        return;
-                    setIppErrorStatus();
+                    if( code == CV_RGB2HSV_FULL && scn == 3 && depth == CV_16U )
+                    {
+                        if( CvtColorIPPLoopCopy(src, dst, IPPGeneralFunctor(ippiRGB2HSVTab[depth])) )
+                        {
+                            CV_IMPL_ADD(CV_IMPL_IPP|CV_IMPL_MT);
+                            return;
+                        }
+                        setIppErrorStatus();
+                    }
+                    else if( code == CV_BGR2HLS_FULL && scn == 3 )
+                    {
+                        if( CvtColorIPPLoopCopy(src, dst, IPPReorderGeneralFunctor(ippiSwapChannelsC3RTab[depth], ippiRGB2HLSTab[depth], 2, 1, 0, depth)) )
+                        {
+                            CV_IMPL_ADD(CV_IMPL_IPP|CV_IMPL_MT);
+                            return;
+                        }
+                        setIppErrorStatus();
+                    }
+                    else if( code == CV_BGR2HLS_FULL && scn == 4 )
+                    {
+                        if( CvtColorIPPLoop(src, dst, IPPReorderGeneralFunctor(ippiSwapChannelsC4C3RTab[depth], ippiRGB2HLSTab[depth], 2, 1, 0, depth)) )
+                        {
+                            CV_IMPL_ADD(CV_IMPL_IPP|CV_IMPL_MT);
+                            return;
+                        }
+                        setIppErrorStatus();
+                    }
+                    else if( code == CV_RGB2HLS_FULL && scn == 3 )
+                    {
+                        if( CvtColorIPPLoopCopy(src, dst, IPPGeneralFunctor(ippiRGB2HLSTab[depth])) )
+                        {
+                            CV_IMPL_ADD(CV_IMPL_IPP|CV_IMPL_MT);
+                            return;
+                        }
+                        setIppErrorStatus();
+                    }
+                    else if( code == CV_RGB2HLS_FULL && scn == 4 )
+                    {
+                        if( CvtColorIPPLoop(src, dst, IPPReorderGeneralFunctor(ippiSwapChannelsC4C3RTab[depth], ippiRGB2HLSTab[depth], 0, 1, 2, depth)) )
+                        {
+                            CV_IMPL_ADD(CV_IMPL_IPP|CV_IMPL_MT);
+                            return;
+                        }
+                        setIppErrorStatus();
+                    }
                 }
             }
 #endif
@@ -5979,55 +6145,82 @@ void cv::cvtColor( InputArray _src, OutputArray _dst, int code, int dcn )
             dst = _dst.getMat();
 
 #if defined (HAVE_IPP) && (IPP_VERSION_MAJOR >= 7)
-            if( depth == CV_8U || depth == CV_16U )
+            CV_IPP_CHECK()
             {
-                if( code == CV_HSV2BGR_FULL && dcn == 3 )
+                if( depth == CV_8U || depth == CV_16U )
                 {
-                    if( CvtColorIPPLoopCopy(src, dst, IPPGeneralReorderFunctor(ippiHSV2RGBTab[depth], ippiSwapChannelsC3RTab[depth], 2, 1, 0, depth)) )
-                        return;
-                    setIppErrorStatus();
-                }
-                else if( code == CV_HSV2BGR_FULL && dcn == 4 )
-                {
-                    if( CvtColorIPPLoop(src, dst, IPPGeneralReorderFunctor(ippiHSV2RGBTab[depth], ippiSwapChannelsC3C4RTab[depth], 2, 1, 0, depth)) )
-                        return;
-                    setIppErrorStatus();
-                }
-                else if( code == CV_HSV2RGB_FULL && dcn == 3 )
-                {
-                    if( CvtColorIPPLoopCopy(src, dst, IPPGeneralFunctor(ippiHSV2RGBTab[depth])) )
-                        return;
-                    setIppErrorStatus();
-                }
-                else if( code == CV_HSV2RGB_FULL && dcn == 4 )
-                {
-                    if( CvtColorIPPLoop(src, dst, IPPGeneralReorderFunctor(ippiHSV2RGBTab[depth], ippiSwapChannelsC3C4RTab[depth], 0, 1, 2, depth)) )
-                        return;
-                    setIppErrorStatus();
-                }
-                else if( code == CV_HLS2BGR_FULL && dcn == 3 )
-                {
-                    if( CvtColorIPPLoopCopy(src, dst, IPPGeneralReorderFunctor(ippiHLS2RGBTab[depth], ippiSwapChannelsC3RTab[depth], 2, 1, 0, depth)) )
-                        return;
-                    setIppErrorStatus();
-                }
-                else if( code == CV_HLS2BGR_FULL && dcn == 4 )
-                {
-                    if( CvtColorIPPLoop(src, dst, IPPGeneralReorderFunctor(ippiHLS2RGBTab[depth], ippiSwapChannelsC3C4RTab[depth], 2, 1, 0, depth)) )
-                        return;
-                    setIppErrorStatus();
-                }
-                else if( code == CV_HLS2RGB_FULL && dcn == 3 )
-                {
-                    if( CvtColorIPPLoopCopy(src, dst, IPPGeneralFunctor(ippiHLS2RGBTab[depth])) )
-                        return;
-                    setIppErrorStatus();
-                }
-                else if( code == CV_HLS2RGB_FULL && dcn == 4 )
-                {
-                    if( CvtColorIPPLoop(src, dst, IPPGeneralReorderFunctor(ippiHLS2RGBTab[depth], ippiSwapChannelsC3C4RTab[depth], 0, 1, 2, depth)) )
-                        return;
-                    setIppErrorStatus();
+                    if( code == CV_HSV2BGR_FULL && dcn == 3 )
+                    {
+                        if( CvtColorIPPLoopCopy(src, dst, IPPGeneralReorderFunctor(ippiHSV2RGBTab[depth], ippiSwapChannelsC3RTab[depth], 2, 1, 0, depth)) )
+                        {
+                            CV_IMPL_ADD(CV_IMPL_IPP|CV_IMPL_MT);
+                            return;
+                        }
+                        setIppErrorStatus();
+                    }
+                    else if( code == CV_HSV2BGR_FULL && dcn == 4 )
+                    {
+                        if( CvtColorIPPLoop(src, dst, IPPGeneralReorderFunctor(ippiHSV2RGBTab[depth], ippiSwapChannelsC3C4RTab[depth], 2, 1, 0, depth)) )
+                        {
+                            CV_IMPL_ADD(CV_IMPL_IPP|CV_IMPL_MT);
+                            return;
+                        }
+                        setIppErrorStatus();
+                    }
+                    else if( code == CV_HSV2RGB_FULL && dcn == 3 )
+                    {
+                        if( CvtColorIPPLoopCopy(src, dst, IPPGeneralFunctor(ippiHSV2RGBTab[depth])) )
+                        {
+                            CV_IMPL_ADD(CV_IMPL_IPP|CV_IMPL_MT);
+                            return;
+                        }
+                        setIppErrorStatus();
+                    }
+                    else if( code == CV_HSV2RGB_FULL && dcn == 4 )
+                    {
+                        if( CvtColorIPPLoop(src, dst, IPPGeneralReorderFunctor(ippiHSV2RGBTab[depth], ippiSwapChannelsC3C4RTab[depth], 0, 1, 2, depth)) )
+                        {
+                            CV_IMPL_ADD(CV_IMPL_IPP|CV_IMPL_MT);
+                            return;
+                        }
+                        setIppErrorStatus();
+                    }
+                    else if( code == CV_HLS2BGR_FULL && dcn == 3 )
+                    {
+                        if( CvtColorIPPLoopCopy(src, dst, IPPGeneralReorderFunctor(ippiHLS2RGBTab[depth], ippiSwapChannelsC3RTab[depth], 2, 1, 0, depth)) )
+                        {
+                            CV_IMPL_ADD(CV_IMPL_IPP|CV_IMPL_MT);
+                            return;
+                        }
+                        setIppErrorStatus();
+                    }
+                    else if( code == CV_HLS2BGR_FULL && dcn == 4 )
+                    {
+                        if( CvtColorIPPLoop(src, dst, IPPGeneralReorderFunctor(ippiHLS2RGBTab[depth], ippiSwapChannelsC3C4RTab[depth], 2, 1, 0, depth)) )
+                        {
+                            CV_IMPL_ADD(CV_IMPL_IPP|CV_IMPL_MT);
+                            return;
+                        }
+                        setIppErrorStatus();
+                    }
+                    else if( code == CV_HLS2RGB_FULL && dcn == 3 )
+                    {
+                        if( CvtColorIPPLoopCopy(src, dst, IPPGeneralFunctor(ippiHLS2RGBTab[depth])) )
+                        {
+                            CV_IMPL_ADD(CV_IMPL_IPP|CV_IMPL_MT);
+                            return;
+                        }
+                        setIppErrorStatus();
+                    }
+                    else if( code == CV_HLS2RGB_FULL && dcn == 4 )
+                    {
+                        if( CvtColorIPPLoop(src, dst, IPPGeneralReorderFunctor(ippiHLS2RGBTab[depth], ippiSwapChannelsC3C4RTab[depth], 0, 1, 2, depth)) )
+                        {
+                            CV_IMPL_ADD(CV_IMPL_IPP|CV_IMPL_MT);
+                            return;
+                        }
+                        setIppErrorStatus();
+                    }
                 }
             }
 #endif
@@ -6062,64 +6255,89 @@ void cv::cvtColor( InputArray _src, OutputArray _dst, int code, int dcn )
             _dst.create(sz, CV_MAKETYPE(depth, 3));
             dst = _dst.getMat();
 
-#ifdef HAVE_IPP
-#if 0
-            if (code == CV_LBGR2Lab && scn == 3 && depth == CV_8U)
+#if defined HAVE_IPP && 0
+            CV_IPP_CHECK()
             {
-                if (CvtColorIPPLoop(src, dst, IPPGeneralFunctor((ippiGeneralFunc)ippiBGRToLab_8u_C3R)))
-                    return;
-                setIppErrorStatus();
+                if (code == CV_LBGR2Lab && scn == 3 && depth == CV_8U)
+                {
+                    if (CvtColorIPPLoop(src, dst, IPPGeneralFunctor((ippiGeneralFunc)ippiBGRToLab_8u_C3R)))
+                    {
+                        CV_IMPL_ADD(CV_IMPL_IPP|CV_IMPL_MT);
+                        return;
+                    }
+                    setIppErrorStatus();
+                }
+                else if (code == CV_LBGR2Lab && scn == 4 && depth == CV_8U)
+                {
+                    if (CvtColorIPPLoop(src, dst, IPPReorderGeneralFunctor(ippiSwapChannelsC4C3RTab[depth],
+                                                                           (ippiGeneralFunc)ippiBGRToLab_8u_C3R, 0, 1, 2, depth)))
+                    {
+                        CV_IMPL_ADD(CV_IMPL_IPP|CV_IMPL_MT);
+                        return;
+                    }
+                    setIppErrorStatus();
+                }
+                else
+                if (code == CV_LRGB2Lab && scn == 3 && depth == CV_8U) // slower than OpenCV
+                {
+                    if (CvtColorIPPLoop(src, dst, IPPReorderGeneralFunctor(ippiSwapChannelsC3RTab[depth],
+                                                                           (ippiGeneralFunc)ippiBGRToLab_8u_C3R, 2, 1, 0, depth)))
+                    {
+                        CV_IMPL_ADD(CV_IMPL_IPP|CV_IMPL_MT);
+                        return;
+                    }
+                    setIppErrorStatus();
+                }
+                else if (code == CV_LRGB2Lab && scn == 4 && depth == CV_8U) // slower than OpenCV
+                {
+                    if (CvtColorIPPLoop(src, dst, IPPReorderGeneralFunctor(ippiSwapChannelsC4C3RTab[depth],
+                                                                           (ippiGeneralFunc)ippiBGRToLab_8u_C3R, 2, 1, 0, depth)))
+                    {
+                        CV_IMPL_ADD(CV_IMPL_IPP|CV_IMPL_MT);
+                        return;
+                    }
+                    setIppErrorStatus();
+                }
+                else if (code == CV_LRGB2Luv && scn == 3)
+                {
+                    if (CvtColorIPPLoop(src, dst, IPPGeneralFunctor(ippiRGBToLUVTab[depth])))
+                    {
+                        CV_IMPL_ADD(CV_IMPL_IPP|CV_IMPL_MT);
+                        return;
+                    }
+                    setIppErrorStatus();
+                }
+                else if (code == CV_LRGB2Luv && scn == 4)
+                {
+                    if (CvtColorIPPLoop(src, dst, IPPReorderGeneralFunctor(ippiSwapChannelsC4C3RTab[depth],
+                                                                           ippiRGBToLUVTab[depth], 0, 1, 2, depth)))
+                    {
+                        CV_IMPL_ADD(CV_IMPL_IPP|CV_IMPL_MT);
+                        return;
+                    }
+                    setIppErrorStatus();
+                }
+                else if (code == CV_LBGR2Luv && scn == 3)
+                {
+                    if (CvtColorIPPLoop(src, dst, IPPReorderGeneralFunctor(ippiSwapChannelsC3RTab[depth],
+                                                                           ippiRGBToLUVTab[depth], 2, 1, 0, depth)))
+                    {
+                        CV_IMPL_ADD(CV_IMPL_IPP|CV_IMPL_MT);
+                        return;
+                    }
+                    setIppErrorStatus();
+                }
+                else if (code == CV_LBGR2Luv && scn == 4)
+                {
+                    if (CvtColorIPPLoop(src, dst, IPPReorderGeneralFunctor(ippiSwapChannelsC4C3RTab[depth],
+                                                                           ippiRGBToLUVTab[depth], 2, 1, 0, depth)))
+                    {
+                        CV_IMPL_ADD(CV_IMPL_IPP|CV_IMPL_MT);
+                        return;
+                    }
+                    setIppErrorStatus();
+                }
             }
-            else if (code == CV_LBGR2Lab && scn == 4 && depth == CV_8U)
-            {
-                if (CvtColorIPPLoop(src, dst, IPPReorderGeneralFunctor(ippiSwapChannelsC4C3RTab[depth],
-                                                                       (ippiGeneralFunc)ippiBGRToLab_8u_C3R, 0, 1, 2, depth)))
-                    return;
-                setIppErrorStatus();
-            }
-            else
-            if (code == CV_LRGB2Lab && scn == 3 && depth == CV_8U) // slower than OpenCV
-            {
-                if (CvtColorIPPLoop(src, dst, IPPReorderGeneralFunctor(ippiSwapChannelsC3RTab[depth],
-                                                                       (ippiGeneralFunc)ippiBGRToLab_8u_C3R, 2, 1, 0, depth)))
-                    return;
-                setIppErrorStatus();
-            }
-            else if (code == CV_LRGB2Lab && scn == 4 && depth == CV_8U) // slower than OpenCV
-            {
-                if (CvtColorIPPLoop(src, dst, IPPReorderGeneralFunctor(ippiSwapChannelsC4C3RTab[depth],
-                                                                       (ippiGeneralFunc)ippiBGRToLab_8u_C3R, 2, 1, 0, depth)))
-                    return;
-                setIppErrorStatus();
-            }
-            else if (code == CV_LRGB2Luv && scn == 3)
-            {
-                if (CvtColorIPPLoop(src, dst, IPPGeneralFunctor(ippiRGBToLUVTab[depth])))
-                    return;
-                setIppErrorStatus();
-            }
-            else if (code == CV_LRGB2Luv && scn == 4)
-            {
-                if (CvtColorIPPLoop(src, dst, IPPReorderGeneralFunctor(ippiSwapChannelsC4C3RTab[depth],
-                                                                       ippiRGBToLUVTab[depth], 0, 1, 2, depth)))
-                    return;
-                setIppErrorStatus();
-            }
-            else if (code == CV_LBGR2Luv && scn == 3)
-            {
-                if (CvtColorIPPLoop(src, dst, IPPReorderGeneralFunctor(ippiSwapChannelsC3RTab[depth],
-                                                                       ippiRGBToLUVTab[depth], 2, 1, 0, depth)))
-                    return;
-                setIppErrorStatus();
-            }
-            else if (code == CV_LBGR2Luv && scn == 4)
-            {
-                if (CvtColorIPPLoop(src, dst, IPPReorderGeneralFunctor(ippiSwapChannelsC4C3RTab[depth],
-                                                                       ippiRGBToLUVTab[depth], 2, 1, 0, depth)))
-                    return;
-                setIppErrorStatus();
-            }
-#endif
 #endif
 
             if( code == CV_BGR2Lab || code == CV_RGB2Lab ||
@@ -6154,55 +6372,79 @@ void cv::cvtColor( InputArray _src, OutputArray _dst, int code, int dcn )
             dst = _dst.getMat();
 
 #if defined HAVE_IPP && 0
-            if( code == CV_Lab2LBGR && dcn == 3 && depth == CV_8U)
+            CV_IPP_CHECK()
             {
-                if( CvtColorIPPLoop(src, dst, IPPGeneralFunctor((ippiGeneralFunc)ippiLabToBGR_8u_C3R)) )
-                    return;
-                setIppErrorStatus();
-            }
-            else if( code == CV_Lab2LBGR && dcn == 4 && depth == CV_8U )
-            {
-                if( CvtColorIPPLoop(src, dst, IPPGeneralReorderFunctor((ippiGeneralFunc)ippiLabToBGR_8u_C3R,
-                                    ippiSwapChannelsC3C4RTab[depth], 0, 1, 2, depth)) )
-                    return;
-                setIppErrorStatus();
-            }
-            if( code == CV_Lab2LRGB && dcn == 3 && depth == CV_8U )
-            {
-                if( CvtColorIPPLoop(src, dst, IPPGeneralReorderFunctor((ippiGeneralFunc)ippiLabToBGR_8u_C3R,
+                if( code == CV_Lab2LBGR && dcn == 3 && depth == CV_8U)
+                {
+                    if( CvtColorIPPLoop(src, dst, IPPGeneralFunctor((ippiGeneralFunc)ippiLabToBGR_8u_C3R)) )
+                    {
+                        CV_IMPL_ADD(CV_IMPL_IPP|CV_IMPL_MT);
+                        return;
+                    }
+                    setIppErrorStatus();
+                }
+                else if( code == CV_Lab2LBGR && dcn == 4 && depth == CV_8U )
+                {
+                    if( CvtColorIPPLoop(src, dst, IPPGeneralReorderFunctor((ippiGeneralFunc)ippiLabToBGR_8u_C3R,
+                                        ippiSwapChannelsC3C4RTab[depth], 0, 1, 2, depth)) )
+                    {
+                        CV_IMPL_ADD(CV_IMPL_IPP|CV_IMPL_MT);
+                        return;
+                    }
+                    setIppErrorStatus();
+                }
+                if( code == CV_Lab2LRGB && dcn == 3 && depth == CV_8U )
+                {
+                    if( CvtColorIPPLoop(src, dst, IPPGeneralReorderFunctor((ippiGeneralFunc)ippiLabToBGR_8u_C3R,
+                                                                               ippiSwapChannelsC3RTab[depth], 2, 1, 0, depth)) )
+                    {
+                        CV_IMPL_ADD(CV_IMPL_IPP|CV_IMPL_MT);
+                        return;
+                    }
+                    setIppErrorStatus();
+                }
+                else if( code == CV_Lab2LRGB && dcn == 4 && depth == CV_8U )
+                {
+                    if( CvtColorIPPLoop(src, dst, IPPGeneralReorderFunctor((ippiGeneralFunc)ippiLabToBGR_8u_C3R,
+                                                                           ippiSwapChannelsC3C4RTab[depth], 2, 1, 0, depth)) )
+                    {
+                        CV_IMPL_ADD(CV_IMPL_IPP|CV_IMPL_MT);
+                        return;
+                    }
+                    setIppErrorStatus();
+                }
+                if( code == CV_Luv2LRGB && dcn == 3 )
+                {
+                    if( CvtColorIPPLoop(src, dst, IPPGeneralFunctor(ippiLUVToRGBTab[depth])) )
+                        return;
+                }
+                else if( code == CV_Luv2LRGB && dcn == 4 )
+                {
+                    if( CvtColorIPPLoop(src, dst, IPPGeneralReorderFunctor(ippiLUVToRGBTab[depth],
+                                                                           ippiSwapChannelsC3C4RTab[depth], 0, 1, 2, depth)) )
+                    {
+                        CV_IMPL_ADD(CV_IMPL_IPP|CV_IMPL_MT);
+                        return;
+                    }
+                }
+                if( code == CV_Luv2LBGR && dcn == 3 )
+                {
+                    if( CvtColorIPPLoop(src, dst, IPPGeneralReorderFunctor(ippiLUVToRGBTab[depth],
                                                                            ippiSwapChannelsC3RTab[depth], 2, 1, 0, depth)) )
-                    return;
-                setIppErrorStatus();
-            }
-            else if( code == CV_Lab2LRGB && dcn == 4 && depth == CV_8U )
-            {
-                if( CvtColorIPPLoop(src, dst, IPPGeneralReorderFunctor((ippiGeneralFunc)ippiLabToBGR_8u_C3R,
-                                                                       ippiSwapChannelsC3C4RTab[depth], 2, 1, 0, depth)) )
-                    return;
-                setIppErrorStatus();
-            }
-            if( code == CV_Luv2LRGB && dcn == 3 )
-            {
-                if( CvtColorIPPLoop(src, dst, IPPGeneralFunctor(ippiLUVToRGBTab[depth])) )
-                    return;
-            }
-            else if( code == CV_Luv2LRGB && dcn == 4 )
-            {
-                if( CvtColorIPPLoop(src, dst, IPPGeneralReorderFunctor(ippiLUVToRGBTab[depth],
-                                                                       ippiSwapChannelsC3C4RTab[depth], 0, 1, 2, depth)) )
-                    return;
-            }
-            if( code == CV_Luv2LBGR && dcn == 3 )
-            {
-                if( CvtColorIPPLoop(src, dst, IPPGeneralReorderFunctor(ippiLUVToRGBTab[depth],
-                                                                       ippiSwapChannelsC3RTab[depth], 2, 1, 0, depth)) )
-                    return;
-            }
-            else if( code == CV_Luv2LBGR && dcn == 4 )
-            {
-                if( CvtColorIPPLoop(src, dst, IPPGeneralReorderFunctor(ippiLUVToRGBTab[depth],
-                                                                       ippiSwapChannelsC3C4RTab[depth], 2, 1, 0, depth)) )
-                    return;
+                    {
+                        CV_IMPL_ADD(CV_IMPL_IPP|CV_IMPL_MT);
+                        return;
+                    }
+                }
+                else if( code == CV_Luv2LBGR && dcn == 4 )
+                {
+                    if( CvtColorIPPLoop(src, dst, IPPGeneralReorderFunctor(ippiLUVToRGBTab[depth],
+                                                                           ippiSwapChannelsC3C4RTab[depth], 2, 1, 0, depth)) )
+                    {
+                        CV_IMPL_ADD(CV_IMPL_IPP|CV_IMPL_MT);
+                        return;
+                    }
+                }
             }
 #endif
 
@@ -6314,10 +6556,16 @@ void cv::cvtColor( InputArray _src, OutputArray _dst, int code, int dcn )
                 _dst.create(dstSz, CV_MAKETYPE(depth, dcn));
                 dst = _dst.getMat();
 #if defined HAVE_IPP
-                if (ippStsNoErr == ippiCopy_8u_C1R(src.data, (int)src.step, dst.data, (int)dst.step,
-                        ippiSize(dstSz.width, dstSz.height)))
-                    return;
-                setIppErrorStatus();
+                CV_IPP_CHECK()
+                {
+                    if (ippStsNoErr == ippiCopy_8u_C1R(src.data, (int)src.step, dst.data, (int)dst.step,
+                            ippiSize(dstSz.width, dstSz.height)))
+                    {
+                        CV_IMPL_ADD(CV_IMPL_IPP);
+                        return;
+                    }
+                    setIppErrorStatus();
+                }
 #endif
                 src(Range(0, dstSz.height), Range::all()).copyTo(dst);
             }
@@ -6409,9 +6657,15 @@ void cv::cvtColor( InputArray _src, OutputArray _dst, int code, int dcn )
                 if( depth == CV_8U )
                 {
 #if defined(HAVE_IPP)
-                    if (CvtColorIPPLoop(src, dst, IPPGeneralFunctor((ippiGeneralFunc)ippiAlphaPremul_8u_AC4R)))
-                        return;
-                    setIppErrorStatus();
+                    CV_IPP_CHECK()
+                    {
+                        if (CvtColorIPPLoop(src, dst, IPPGeneralFunctor((ippiGeneralFunc)ippiAlphaPremul_8u_AC4R)))
+                        {
+                            CV_IMPL_ADD(CV_IMPL_IPP|CV_IMPL_MT);
+                            return;
+                        }
+                        setIppErrorStatus();
+                    }
 #endif
                     CvtColorLoop(src, dst, RGBA2mRGBA<uchar>());
                 }

--- a/modules/imgproc/src/deriv.cpp
+++ b/modules/imgproc/src/deriv.cpp
@@ -573,15 +573,24 @@ void cv::Sobel( InputArray _src, OutputArray _dst, int ddepth, int dx, int dy,
 #endif
 
 #ifdef HAVE_IPP
-    if (ksize < 0)
+    CV_IPP_CHECK()
     {
-        if (IPPDerivScharr(_src, _dst, ddepth, dx, dy, scale, delta, borderType))
-            return;
-    }
-    else if (0 < ksize)
-    {
-        if (IPPDerivSobel(_src, _dst, ddepth, dx, dy, ksize, scale, delta, borderType))
-            return;
+        if (ksize < 0)
+        {
+            if (IPPDerivScharr(_src, _dst, ddepth, dx, dy, scale, delta, borderType))
+            {
+                CV_IMPL_ADD(CV_IMPL_IPP);
+                return;
+            }
+        }
+        else if (0 < ksize)
+        {
+            if (IPPDerivSobel(_src, _dst, ddepth, dx, dy, ksize, scale, delta, borderType))
+            {
+                CV_IMPL_ADD(CV_IMPL_IPP);
+                return;
+            }
+        }
     }
 #endif
     int ktype = std::max(CV_32F, std::max(ddepth, sdepth));
@@ -620,8 +629,14 @@ void cv::Scharr( InputArray _src, OutputArray _dst, int ddepth, int dx, int dy,
 #endif
 
 #if defined (HAVE_IPP) && (IPP_VERSION_MAJOR >= 7)
-    if (IPPDerivScharr(_src, _dst, ddepth, dx, dy, scale, delta, borderType))
-        return;
+    CV_IPP_CHECK()
+    {
+        if (IPPDerivScharr(_src, _dst, ddepth, dx, dy, scale, delta, borderType))
+        {
+            CV_IMPL_ADD(CV_IMPL_IPP);
+            return;
+        }
+    }
 #endif
     int ktype = std::max(CV_32F, std::max(ddepth, sdepth));
 
@@ -793,62 +808,68 @@ void cv::Laplacian( InputArray _src, OutputArray _dst, int ddepth, int ksize,
     _dst.create( _src.size(), CV_MAKETYPE(ddepth, cn) );
 
 #ifdef HAVE_IPP
-    if ((ksize == 3 || ksize == 5) && ((borderType & BORDER_ISOLATED) != 0 || !_src.isSubmatrix()) &&
-        ((stype == CV_8UC1 && ddepth == CV_16S) || (ddepth == CV_32F && stype == CV_32FC1)) && !ocl::useOpenCL())
+    CV_IPP_CHECK()
     {
-        int iscale = saturate_cast<int>(scale), idelta = saturate_cast<int>(delta);
-        bool floatScale = std::fabs(scale - iscale) > DBL_EPSILON, needScale = iscale != 1;
-        bool floatDelta = std::fabs(delta - idelta) > DBL_EPSILON, needDelta = delta != 0;
-        int borderTypeNI = borderType & ~BORDER_ISOLATED;
-        Mat src = _src.getMat(), dst = _dst.getMat();
-
-        if (src.data != dst.data)
+        if ((ksize == 3 || ksize == 5) && ((borderType & BORDER_ISOLATED) != 0 || !_src.isSubmatrix()) &&
+            ((stype == CV_8UC1 && ddepth == CV_16S) || (ddepth == CV_32F && stype == CV_32FC1)) && !ocl::useOpenCL())
         {
-            Ipp32s bufsize;
-            IppStatus status = (IppStatus)-1;
-            IppiSize roisize = { src.cols, src.rows };
-            IppiMaskSize masksize = ksize == 3 ? ippMskSize3x3 : ippMskSize5x5;
-            IppiBorderType borderTypeIpp = ippiGetBorderType(borderTypeNI);
+            int iscale = saturate_cast<int>(scale), idelta = saturate_cast<int>(delta);
+            bool floatScale = std::fabs(scale - iscale) > DBL_EPSILON, needScale = iscale != 1;
+            bool floatDelta = std::fabs(delta - idelta) > DBL_EPSILON, needDelta = delta != 0;
+            int borderTypeNI = borderType & ~BORDER_ISOLATED;
+            Mat src = _src.getMat(), dst = _dst.getMat();
+
+            if (src.data != dst.data)
+            {
+                Ipp32s bufsize;
+                IppStatus status = (IppStatus)-1;
+                IppiSize roisize = { src.cols, src.rows };
+                IppiMaskSize masksize = ksize == 3 ? ippMskSize3x3 : ippMskSize5x5;
+                IppiBorderType borderTypeIpp = ippiGetBorderType(borderTypeNI);
 
 #define IPP_FILTER_LAPLACIAN(ippsrctype, ippdsttype, ippfavor) \
-    do \
-    { \
-        if (borderTypeIpp >= 0 && ippiFilterLaplacianGetBufferSize_##ippfavor##_C1R(roisize, masksize, &bufsize) >= 0) \
+        do \
         { \
-            Ipp8u * buffer = ippsMalloc_8u(bufsize); \
-            status = ippiFilterLaplacianBorder_##ippfavor##_C1R(src.ptr<ippsrctype>(), (int)src.step, dst.ptr<ippdsttype>(), \
-                                                                (int)dst.step, roisize, masksize, borderTypeIpp, 0, buffer); \
-            ippsFree(buffer); \
-        } \
-    } while ((void)0, 0)
+            if (borderTypeIpp >= 0 && ippiFilterLaplacianGetBufferSize_##ippfavor##_C1R(roisize, masksize, &bufsize) >= 0) \
+            { \
+                Ipp8u * buffer = ippsMalloc_8u(bufsize); \
+                status = ippiFilterLaplacianBorder_##ippfavor##_C1R(src.ptr<ippsrctype>(), (int)src.step, dst.ptr<ippdsttype>(), \
+                                                                    (int)dst.step, roisize, masksize, borderTypeIpp, 0, buffer); \
+                ippsFree(buffer); \
+            } \
+        } while ((void)0, 0)
 
-            CV_SUPPRESS_DEPRECATED_START
-            if (sdepth == CV_8U && ddepth == CV_16S && !floatScale && !floatDelta)
-            {
-                IPP_FILTER_LAPLACIAN(Ipp8u, Ipp16s, 8u16s);
+                CV_SUPPRESS_DEPRECATED_START
+                if (sdepth == CV_8U && ddepth == CV_16S && !floatScale && !floatDelta)
+                {
+                    IPP_FILTER_LAPLACIAN(Ipp8u, Ipp16s, 8u16s);
 
-                if (needScale && status >= 0)
-                    status = ippiMulC_16s_C1IRSfs((Ipp16s)iscale, dst.ptr<Ipp16s>(), (int)dst.step, roisize, 0);
-                if (needDelta && status >= 0)
-                    status = ippiAddC_16s_C1IRSfs((Ipp16s)idelta, dst.ptr<Ipp16s>(), (int)dst.step, roisize, 0);
+                    if (needScale && status >= 0)
+                        status = ippiMulC_16s_C1IRSfs((Ipp16s)iscale, dst.ptr<Ipp16s>(), (int)dst.step, roisize, 0);
+                    if (needDelta && status >= 0)
+                        status = ippiAddC_16s_C1IRSfs((Ipp16s)idelta, dst.ptr<Ipp16s>(), (int)dst.step, roisize, 0);
+                }
+                else if (sdepth == CV_32F && ddepth == CV_32F)
+                {
+                    IPP_FILTER_LAPLACIAN(Ipp32f, Ipp32f, 32f);
+
+                    if (needScale && status >= 0)
+                        status = ippiMulC_32f_C1IR((Ipp32f)scale, dst.ptr<Ipp32f>(), (int)dst.step, roisize);
+                    if (needDelta && status >= 0)
+                        status = ippiAddC_32f_C1IR((Ipp32f)delta, dst.ptr<Ipp32f>(), (int)dst.step, roisize);
+                }
+                CV_SUPPRESS_DEPRECATED_END
+
+                if (status >= 0)
+                {
+                    CV_IMPL_ADD(CV_IMPL_IPP);
+                    return;
+                }
+                setIppErrorStatus();
             }
-            else if (sdepth == CV_32F && ddepth == CV_32F)
-            {
-                IPP_FILTER_LAPLACIAN(Ipp32f, Ipp32f, 32f);
-
-                if (needScale && status >= 0)
-                    status = ippiMulC_32f_C1IR((Ipp32f)scale, dst.ptr<Ipp32f>(), (int)dst.step, roisize);
-                if (needDelta && status >= 0)
-                    status = ippiAddC_32f_C1IR((Ipp32f)delta, dst.ptr<Ipp32f>(), (int)dst.step, roisize);
-            }
-            CV_SUPPRESS_DEPRECATED_END
-
-            if (status >= 0)
-                return;
-            setIppErrorStatus();
         }
-    }
 #undef IPP_FILTER_LAPLACIAN
+    }
 #endif
 
 #ifdef HAVE_TEGRA_OPTIMIZATION

--- a/modules/imgproc/src/filter.cpp
+++ b/modules/imgproc/src/filter.cpp
@@ -1423,9 +1423,12 @@ struct RowVec_32f
     int operator()(const uchar* _src, uchar* _dst, int width, int cn) const
     {
 #if defined USE_IPP_SEP_FILTERS && 0
-        int ret = ippiOperator(_src, _dst, width, cn);
-        if (ret > 0)
-            return ret;
+        CV_IPP_CHECK()
+        {
+            int ret = ippiOperator(_src, _dst, width, cn);
+            if (ret > 0)
+                return ret;
+        }
 #endif
         int _ksize = kernel.rows + kernel.cols - 1;
         const float* src0 = (const float*)_src;
@@ -1494,6 +1497,7 @@ private:
             setIppErrorStatus();
             return 0;
         }
+        CV_IMPL_ADD(CV_IMPL_IPP);
         return width - _ksize + 1;
     }
 #endif
@@ -3743,67 +3747,73 @@ void cv::filter2D( InputArray _src, OutputArray _dst, int ddepth,
     Point anchor = normalizeAnchor(anchor0, kernel.size());
 
 #if IPP_VERSION_X100 > 0 && !defined HAVE_IPP_ICV_ONLY
-    typedef IppStatus (CV_STDCALL * ippiFilterBorder)(const void * pSrc, int srcStep, void * pDst, int dstStep, IppiSize dstRoiSize,
-                                                      IppiBorderType border, const void * borderValue,
-                                                      const IppiFilterBorderSpec* pSpec, Ipp8u* pBuffer);
-
-    int stype = src.type(), sdepth = CV_MAT_DEPTH(stype), cn = CV_MAT_CN(stype),
-            ktype = kernel.type(), kdepth = CV_MAT_DEPTH(ktype);
-    bool isolated = (borderType & BORDER_ISOLATED) != 0;
-    Point ippAnchor(kernel.cols >> 1, kernel.rows >> 1);
-    int borderTypeNI = borderType & ~BORDER_ISOLATED;
-    IppiBorderType ippBorderType = ippiGetBorderType(borderTypeNI);
-
-    if (borderTypeNI == BORDER_CONSTANT || borderTypeNI == BORDER_REPLICATE)
+    CV_IPP_CHECK()
     {
-        ippiFilterBorder ippFunc =
-            stype == CV_8UC1 ? (ippiFilterBorder)ippiFilterBorder_8u_C1R :
-            stype == CV_8UC3 ? (ippiFilterBorder)ippiFilterBorder_8u_C3R :
-            stype == CV_8UC4 ? (ippiFilterBorder)ippiFilterBorder_8u_C4R :
-            stype == CV_16UC1 ? (ippiFilterBorder)ippiFilterBorder_16u_C1R :
-            stype == CV_16UC3 ? (ippiFilterBorder)ippiFilterBorder_16u_C3R :
-            stype == CV_16UC4 ? (ippiFilterBorder)ippiFilterBorder_16u_C4R :
-            stype == CV_16SC1 ? (ippiFilterBorder)ippiFilterBorder_16s_C1R :
-            stype == CV_16SC3 ? (ippiFilterBorder)ippiFilterBorder_16s_C3R :
-            stype == CV_16SC4 ? (ippiFilterBorder)ippiFilterBorder_16s_C4R :
-            stype == CV_32FC1 ? (ippiFilterBorder)ippiFilterBorder_32f_C1R :
-            stype == CV_32FC3 ? (ippiFilterBorder)ippiFilterBorder_32f_C3R :
-            stype == CV_32FC4 ? (ippiFilterBorder)ippiFilterBorder_32f_C4R : 0;
+        typedef IppStatus (CV_STDCALL * ippiFilterBorder)(const void * pSrc, int srcStep, void * pDst, int dstStep, IppiSize dstRoiSize,
+                                                          IppiBorderType border, const void * borderValue,
+                                                          const IppiFilterBorderSpec* pSpec, Ipp8u* pBuffer);
 
-        if (sdepth == ddepth && (ktype == CV_16SC1 || ktype == CV_32FC1) &&
-                ippFunc && (int)ippBorderType >= 0 && (!src.isSubmatrix() || isolated) &&
-                std::fabs(delta - 0) < DBL_EPSILON && ippAnchor == anchor && dst.data != src.data)
+        int stype = src.type(), sdepth = CV_MAT_DEPTH(stype), cn = CV_MAT_CN(stype),
+                ktype = kernel.type(), kdepth = CV_MAT_DEPTH(ktype);
+        bool isolated = (borderType & BORDER_ISOLATED) != 0;
+        Point ippAnchor(kernel.cols >> 1, kernel.rows >> 1);
+        int borderTypeNI = borderType & ~BORDER_ISOLATED;
+        IppiBorderType ippBorderType = ippiGetBorderType(borderTypeNI);
+
+        if (borderTypeNI == BORDER_CONSTANT || borderTypeNI == BORDER_REPLICATE)
         {
-            IppiSize kernelSize = { kernel.cols, kernel.rows }, dstRoiSize = { dst.cols, dst.rows };
-            IppDataType dataType = ippiGetDataType(ddepth), kernelType = ippiGetDataType(kdepth);
-            Ipp32s specSize = 0, bufsize = 0;
-            IppStatus status = (IppStatus)-1;
+            ippiFilterBorder ippFunc =
+                stype == CV_8UC1 ? (ippiFilterBorder)ippiFilterBorder_8u_C1R :
+                stype == CV_8UC3 ? (ippiFilterBorder)ippiFilterBorder_8u_C3R :
+                stype == CV_8UC4 ? (ippiFilterBorder)ippiFilterBorder_8u_C4R :
+                stype == CV_16UC1 ? (ippiFilterBorder)ippiFilterBorder_16u_C1R :
+                stype == CV_16UC3 ? (ippiFilterBorder)ippiFilterBorder_16u_C3R :
+                stype == CV_16UC4 ? (ippiFilterBorder)ippiFilterBorder_16u_C4R :
+                stype == CV_16SC1 ? (ippiFilterBorder)ippiFilterBorder_16s_C1R :
+                stype == CV_16SC3 ? (ippiFilterBorder)ippiFilterBorder_16s_C3R :
+                stype == CV_16SC4 ? (ippiFilterBorder)ippiFilterBorder_16s_C4R :
+                stype == CV_32FC1 ? (ippiFilterBorder)ippiFilterBorder_32f_C1R :
+                stype == CV_32FC3 ? (ippiFilterBorder)ippiFilterBorder_32f_C3R :
+                stype == CV_32FC4 ? (ippiFilterBorder)ippiFilterBorder_32f_C4R : 0;
 
-            if ((status = ippiFilterBorderGetSize(kernelSize, dstRoiSize, dataType, kernelType, cn, &specSize, &bufsize)) >= 0)
+            if (sdepth == ddepth && (ktype == CV_16SC1 || ktype == CV_32FC1) &&
+                    ippFunc && (int)ippBorderType >= 0 && (!src.isSubmatrix() || isolated) &&
+                    std::fabs(delta - 0) < DBL_EPSILON && ippAnchor == anchor && dst.data != src.data)
             {
-                IppiFilterBorderSpec * spec = (IppiFilterBorderSpec *)ippMalloc(specSize);
-                Ipp8u * buffer = ippsMalloc_8u(bufsize);
-                Ipp32f borderValue[4] = { 0, 0, 0, 0 };
+                IppiSize kernelSize = { kernel.cols, kernel.rows }, dstRoiSize = { dst.cols, dst.rows };
+                IppDataType dataType = ippiGetDataType(ddepth), kernelType = ippiGetDataType(kdepth);
+                Ipp32s specSize = 0, bufsize = 0;
+                IppStatus status = (IppStatus)-1;
 
-                Mat reversedKernel;
-                flip(kernel, reversedKernel, -1);
-
-                if ((kdepth == CV_32F && (status = ippiFilterBorderInit_32f((const Ipp32f *)reversedKernel.data, kernelSize,
-                        dataType, cn, ippRndFinancial, spec)) >= 0 ) ||
-                    (kdepth == CV_16S && (status = ippiFilterBorderInit_16s((const Ipp16s *)reversedKernel.data,
-                        kernelSize, 0, dataType, cn, ippRndFinancial, spec)) >= 0))
+                if ((status = ippiFilterBorderGetSize(kernelSize, dstRoiSize, dataType, kernelType, cn, &specSize, &bufsize)) >= 0)
                 {
-                    status = ippFunc(src.data, (int)src.step, dst.data, (int)dst.step, dstRoiSize,
-                                     ippBorderType, borderValue, spec, buffer);
+                    IppiFilterBorderSpec * spec = (IppiFilterBorderSpec *)ippMalloc(specSize);
+                    Ipp8u * buffer = ippsMalloc_8u(bufsize);
+                    Ipp32f borderValue[4] = { 0, 0, 0, 0 };
+
+                    Mat reversedKernel;
+                    flip(kernel, reversedKernel, -1);
+
+                    if ((kdepth == CV_32F && (status = ippiFilterBorderInit_32f((const Ipp32f *)reversedKernel.data, kernelSize,
+                            dataType, cn, ippRndFinancial, spec)) >= 0 ) ||
+                        (kdepth == CV_16S && (status = ippiFilterBorderInit_16s((const Ipp16s *)reversedKernel.data,
+                            kernelSize, 0, dataType, cn, ippRndFinancial, spec)) >= 0))
+                    {
+                        status = ippFunc(src.data, (int)src.step, dst.data, (int)dst.step, dstRoiSize,
+                                         ippBorderType, borderValue, spec, buffer);
+                    }
+
+                    ippsFree(buffer);
+                    ippsFree(spec);
                 }
 
-                ippsFree(buffer);
-                ippsFree(spec);
+                if (status >= 0)
+                {
+                    CV_IMPL_ADD(CV_IMPL_IPP);
+                    return;
+                }
+                setIppErrorStatus();
             }
-
-            if (status >= 0)
-                return;
-            setIppErrorStatus();
         }
     }
 #endif

--- a/modules/imgproc/src/hough.cpp
+++ b/modules/imgproc/src/hough.cpp
@@ -100,25 +100,29 @@ HoughLinesStandard( const Mat& img, float rho, float theta,
     int numrho = cvRound(((width + height) * 2 + 1) / rho);
 
 #if (0 && defined(HAVE_IPP) && !defined(HAVE_IPP_ICV_ONLY) && IPP_VERSION_X100 >= 801)
-    IppiSize srcSize = { width, height };
-    IppPointPolar delta = { rho, theta };
-    IppPointPolar dstRoi[2] = {{(Ipp32f) -(width + height), (Ipp32f) min_theta},{(Ipp32f) (width + height), (Ipp32f) max_theta}};
-    int bufferSize;
-    int nz = countNonZero(img);
-    int ipp_linesMax = std::min(linesMax, nz*numangle/threshold);
-    int linesCount = 0;
-    lines.resize(ipp_linesMax);
-    IppStatus ok = ippiHoughLineGetSize_8u_C1R(srcSize, delta, ipp_linesMax, &bufferSize);
-    Ipp8u* buffer = ippsMalloc_8u(bufferSize);
-    if (ok >= 0) ok = ippiHoughLine_Region_8u32f_C1R(image, step, srcSize, (IppPointPolar*) &lines[0], dstRoi, ipp_linesMax, &linesCount, delta, threshold, buffer);
-    ippsFree(buffer);
-    if (ok >= 0)
+    CV_IPP_CHECK()
     {
-        lines.resize(linesCount);
-        return;
+        IppiSize srcSize = { width, height };
+        IppPointPolar delta = { rho, theta };
+        IppPointPolar dstRoi[2] = {{(Ipp32f) -(width + height), (Ipp32f) min_theta},{(Ipp32f) (width + height), (Ipp32f) max_theta}};
+        int bufferSize;
+        int nz = countNonZero(img);
+        int ipp_linesMax = std::min(linesMax, nz*numangle/threshold);
+        int linesCount = 0;
+        lines.resize(ipp_linesMax);
+        IppStatus ok = ippiHoughLineGetSize_8u_C1R(srcSize, delta, ipp_linesMax, &bufferSize);
+        Ipp8u* buffer = ippsMalloc_8u(bufferSize);
+        if (ok >= 0) ok = ippiHoughLine_Region_8u32f_C1R(image, step, srcSize, (IppPointPolar*) &lines[0], dstRoi, ipp_linesMax, &linesCount, delta, threshold, buffer);
+        ippsFree(buffer);
+        if (ok >= 0)
+        {
+            lines.resize(linesCount);
+            CV_IMPL_ADD(CV_IMPL_IPP);
+            return;
+        }
+        lines.clear();
+        setIppErrorStatus();
     }
-    lines.clear();
-    setIppErrorStatus();
 #endif
 
     AutoBuffer<int> _accum((numangle+2) * (numrho+2));
@@ -429,28 +433,32 @@ HoughLinesProbabilistic( Mat& image,
     int numrho = cvRound(((width + height) * 2 + 1) / rho);
 
 #if (0 && defined(HAVE_IPP) && !defined(HAVE_IPP_ICV_ONLY) && IPP_VERSION_X100 >= 801)
-    IppiSize srcSize = { width, height };
-    IppPointPolar delta = { rho, theta };
-    IppiHoughProbSpec* pSpec;
-    int bufferSize, specSize;
-    int ipp_linesMax = std::min(linesMax, numangle*numrho);
-    int linesCount = 0;
-    lines.resize(ipp_linesMax);
-    IppStatus ok = ippiHoughProbLineGetSize_8u_C1R(srcSize, delta, &specSize, &bufferSize);
-    Ipp8u* buffer = ippsMalloc_8u(bufferSize);
-    pSpec = (IppiHoughProbSpec*) malloc(specSize);
-    if (ok >= 0) ok = ippiHoughProbLineInit_8u32f_C1R(srcSize, delta, ippAlgHintNone, pSpec);
-    if (ok >= 0) ok = ippiHoughProbLine_8u32f_C1R(image.data, image.step, srcSize, threshold, lineLength, lineGap, (IppiPoint*) &lines[0], ipp_linesMax, &linesCount, buffer, pSpec);
-
-    free(pSpec);
-    ippsFree(buffer);
-    if (ok >= 0)
+    CV_IPP_CHECK()
     {
-        lines.resize(linesCount);
-        return;
+        IppiSize srcSize = { width, height };
+        IppPointPolar delta = { rho, theta };
+        IppiHoughProbSpec* pSpec;
+        int bufferSize, specSize;
+        int ipp_linesMax = std::min(linesMax, numangle*numrho);
+        int linesCount = 0;
+        lines.resize(ipp_linesMax);
+        IppStatus ok = ippiHoughProbLineGetSize_8u_C1R(srcSize, delta, &specSize, &bufferSize);
+        Ipp8u* buffer = ippsMalloc_8u(bufferSize);
+        pSpec = (IppiHoughProbSpec*) malloc(specSize);
+        if (ok >= 0) ok = ippiHoughProbLineInit_8u32f_C1R(srcSize, delta, ippAlgHintNone, pSpec);
+        if (ok >= 0) ok = ippiHoughProbLine_8u32f_C1R(image.data, image.step, srcSize, threshold, lineLength, lineGap, (IppiPoint*) &lines[0], ipp_linesMax, &linesCount, buffer, pSpec);
+
+        free(pSpec);
+        ippsFree(buffer);
+        if (ok >= 0)
+        {
+            lines.resize(linesCount);
+            CV_IMPL_ADD(CV_IMPL_IPP);
+            return;
+        }
+        lines.clear();
+        setIppErrorStatus();
     }
-    lines.clear();
-    setIppErrorStatus();
 #endif
 
     Mat accum = Mat::zeros( numangle, numrho, CV_32SC1 );

--- a/modules/imgproc/src/moments.cpp
+++ b/modules/imgproc/src/moments.cpp
@@ -578,64 +578,68 @@ cv::Moments cv::moments( InputArray _src, bool binary )
             CV_Error( CV_StsBadArg, "Invalid image type (must be single-channel)" );
 
 #if IPP_VERSION_X100 >= 801 && 0
-        if (!binary)
+        CV_IPP_CHECK()
         {
-            IppiSize roi = { mat.cols, mat.rows };
-            IppiMomentState_64f * moment = NULL;
-            // ippiMomentInitAlloc_64f, ippiMomentFree_64f are deprecated in 8.1, but there are not another way
-            // to initialize IppiMomentState_64f. When GetStateSize and Init functions will appear we have to
-            // change our code.
-            CV_SUPPRESS_DEPRECATED_START
-            if (ippiMomentInitAlloc_64f(&moment, ippAlgHintAccurate) >= 0)
+            if (!binary)
             {
-                typedef IppStatus (CV_STDCALL * ippiMoments)(const void * pSrc, int srcStep, IppiSize roiSize, IppiMomentState_64f* pCtx);
-                ippiMoments ippFunc =
-                    type == CV_8UC1 ? (ippiMoments)ippiMoments64f_8u_C1R :
-                    type == CV_16UC1 ? (ippiMoments)ippiMoments64f_16u_C1R :
-                    type == CV_32FC1? (ippiMoments)ippiMoments64f_32f_C1R : 0;
-
-                if (ippFunc)
+                IppiSize roi = { mat.cols, mat.rows };
+                IppiMomentState_64f * moment = NULL;
+                // ippiMomentInitAlloc_64f, ippiMomentFree_64f are deprecated in 8.1, but there are not another way
+                // to initialize IppiMomentState_64f. When GetStateSize and Init functions will appear we have to
+                // change our code.
+                CV_SUPPRESS_DEPRECATED_START
+                if (ippiMomentInitAlloc_64f(&moment, ippAlgHintAccurate) >= 0)
                 {
-                    if (ippFunc(mat.data, (int)mat.step, roi, moment) >= 0)
+                    typedef IppStatus (CV_STDCALL * ippiMoments)(const void * pSrc, int srcStep, IppiSize roiSize, IppiMomentState_64f* pCtx);
+                    ippiMoments ippFunc =
+                        type == CV_8UC1 ? (ippiMoments)ippiMoments64f_8u_C1R :
+                        type == CV_16UC1 ? (ippiMoments)ippiMoments64f_16u_C1R :
+                        type == CV_32FC1? (ippiMoments)ippiMoments64f_32f_C1R : 0;
+
+                    if (ippFunc)
                     {
-                        IppiPoint point = { 0, 0 };
-                        ippiGetSpatialMoment_64f(moment, 0, 0, 0, point, &m.m00);
-                        ippiGetSpatialMoment_64f(moment, 1, 0, 0, point, &m.m10);
-                        ippiGetSpatialMoment_64f(moment, 0, 1, 0, point, &m.m01);
+                        if (ippFunc(mat.data, (int)mat.step, roi, moment) >= 0)
+                        {
+                            IppiPoint point = { 0, 0 };
+                            ippiGetSpatialMoment_64f(moment, 0, 0, 0, point, &m.m00);
+                            ippiGetSpatialMoment_64f(moment, 1, 0, 0, point, &m.m10);
+                            ippiGetSpatialMoment_64f(moment, 0, 1, 0, point, &m.m01);
 
-                        ippiGetSpatialMoment_64f(moment, 2, 0, 0, point, &m.m20);
-                        ippiGetSpatialMoment_64f(moment, 1, 1, 0, point, &m.m11);
-                        ippiGetSpatialMoment_64f(moment, 0, 2, 0, point, &m.m02);
+                            ippiGetSpatialMoment_64f(moment, 2, 0, 0, point, &m.m20);
+                            ippiGetSpatialMoment_64f(moment, 1, 1, 0, point, &m.m11);
+                            ippiGetSpatialMoment_64f(moment, 0, 2, 0, point, &m.m02);
 
-                        ippiGetSpatialMoment_64f(moment, 3, 0, 0, point, &m.m30);
-                        ippiGetSpatialMoment_64f(moment, 2, 1, 0, point, &m.m21);
-                        ippiGetSpatialMoment_64f(moment, 1, 2, 0, point, &m.m12);
-                        ippiGetSpatialMoment_64f(moment, 0, 3, 0, point, &m.m03);
-                        ippiGetCentralMoment_64f(moment, 2, 0, 0, &m.mu20);
-                        ippiGetCentralMoment_64f(moment, 1, 1, 0, &m.mu11);
-                        ippiGetCentralMoment_64f(moment, 0, 2, 0, &m.mu02);
-                        ippiGetCentralMoment_64f(moment, 3, 0, 0, &m.mu30);
-                        ippiGetCentralMoment_64f(moment, 2, 1, 0, &m.mu21);
-                        ippiGetCentralMoment_64f(moment, 1, 2, 0, &m.mu12);
-                        ippiGetCentralMoment_64f(moment, 0, 3, 0, &m.mu03);
-                        ippiGetNormalizedCentralMoment_64f(moment, 2, 0, 0, &m.nu20);
-                        ippiGetNormalizedCentralMoment_64f(moment, 1, 1, 0, &m.nu11);
-                        ippiGetNormalizedCentralMoment_64f(moment, 0, 2, 0, &m.nu02);
-                        ippiGetNormalizedCentralMoment_64f(moment, 3, 0, 0, &m.nu30);
-                        ippiGetNormalizedCentralMoment_64f(moment, 2, 1, 0, &m.nu21);
-                        ippiGetNormalizedCentralMoment_64f(moment, 1, 2, 0, &m.nu12);
-                        ippiGetNormalizedCentralMoment_64f(moment, 0, 3, 0, &m.nu03);
+                            ippiGetSpatialMoment_64f(moment, 3, 0, 0, point, &m.m30);
+                            ippiGetSpatialMoment_64f(moment, 2, 1, 0, point, &m.m21);
+                            ippiGetSpatialMoment_64f(moment, 1, 2, 0, point, &m.m12);
+                            ippiGetSpatialMoment_64f(moment, 0, 3, 0, point, &m.m03);
+                            ippiGetCentralMoment_64f(moment, 2, 0, 0, &m.mu20);
+                            ippiGetCentralMoment_64f(moment, 1, 1, 0, &m.mu11);
+                            ippiGetCentralMoment_64f(moment, 0, 2, 0, &m.mu02);
+                            ippiGetCentralMoment_64f(moment, 3, 0, 0, &m.mu30);
+                            ippiGetCentralMoment_64f(moment, 2, 1, 0, &m.mu21);
+                            ippiGetCentralMoment_64f(moment, 1, 2, 0, &m.mu12);
+                            ippiGetCentralMoment_64f(moment, 0, 3, 0, &m.mu03);
+                            ippiGetNormalizedCentralMoment_64f(moment, 2, 0, 0, &m.nu20);
+                            ippiGetNormalizedCentralMoment_64f(moment, 1, 1, 0, &m.nu11);
+                            ippiGetNormalizedCentralMoment_64f(moment, 0, 2, 0, &m.nu02);
+                            ippiGetNormalizedCentralMoment_64f(moment, 3, 0, 0, &m.nu30);
+                            ippiGetNormalizedCentralMoment_64f(moment, 2, 1, 0, &m.nu21);
+                            ippiGetNormalizedCentralMoment_64f(moment, 1, 2, 0, &m.nu12);
+                            ippiGetNormalizedCentralMoment_64f(moment, 0, 3, 0, &m.nu03);
 
-                        ippiMomentFree_64f(moment);
-                        return m;
+                            ippiMomentFree_64f(moment);
+                            CV_IMPL_ADD(CV_IMPL_IPP);
+                            return m;
+                        }
+                        setIppErrorStatus();
                     }
-                    setIppErrorStatus();
+                    ippiMomentFree_64f(moment);
                 }
-                ippiMomentFree_64f(moment);
+                else
+                    setIppErrorStatus();
+                CV_SUPPRESS_DEPRECATED_END
             }
-            else
-                setIppErrorStatus();
-            CV_SUPPRESS_DEPRECATED_END
         }
 #endif
 

--- a/modules/imgproc/src/morph.cpp
+++ b/modules/imgproc/src/morph.cpp
@@ -1707,8 +1707,14 @@ static void morphOp( int op, InputArray _src, OutputArray _dst,
     }
 
 #if IPP_VERSION_X100 >= 801
-    if( IPPMorphOp(op, _src, _dst, kernel, anchor, iterations, borderType, borderValue) )
-        return;
+    CV_IPP_CHECK()
+    {
+        if( IPPMorphOp(op, _src, _dst, kernel, anchor, iterations, borderType, borderValue) )
+        {
+            CV_IMPL_ADD(CV_IMPL_IPP);
+            return;
+        }
+    }
 #endif
 
     Mat src = _src.getMat();

--- a/modules/imgproc/src/pyramids.cpp
+++ b/modules/imgproc/src/pyramids.cpp
@@ -703,36 +703,42 @@ void cv::pyrDown( InputArray _src, OutputArray _dst, const Size& _dsz, int borde
 #endif
 
 #if IPP_VERSION_X100 >= 801 && 0
-    bool isolated = (borderType & BORDER_ISOLATED) != 0;
-    int borderTypeNI = borderType & ~BORDER_ISOLATED;
-    if (borderTypeNI == BORDER_DEFAULT && (!src.isSubmatrix() || isolated) && dsz == Size((src.cols + 1)/2, (src.rows + 1)/2))
+    CV_IPP_CHECK()
     {
-        typedef IppStatus (CV_STDCALL * ippiPyrDown)(const void* pSrc, int srcStep, void* pDst, int dstStep, IppiSize srcRoi, Ipp8u* buffer);
-        int type = src.type();
-        CV_SUPPRESS_DEPRECATED_START
-        ippiPyrDown pyrDownFunc = type == CV_8UC1 ? (ippiPyrDown) ippiPyrDown_Gauss5x5_8u_C1R :
-                                  type == CV_8UC3 ? (ippiPyrDown) ippiPyrDown_Gauss5x5_8u_C3R :
-                                  type == CV_32FC1 ? (ippiPyrDown) ippiPyrDown_Gauss5x5_32f_C1R :
-                                  type == CV_32FC3 ? (ippiPyrDown) ippiPyrDown_Gauss5x5_32f_C3R : 0;
-        CV_SUPPRESS_DEPRECATED_END
-
-        if (pyrDownFunc)
+        bool isolated = (borderType & BORDER_ISOLATED) != 0;
+        int borderTypeNI = borderType & ~BORDER_ISOLATED;
+        if (borderTypeNI == BORDER_DEFAULT && (!src.isSubmatrix() || isolated) && dsz == Size((src.cols + 1)/2, (src.rows + 1)/2))
         {
-            int bufferSize;
-            IppiSize srcRoi = { src.cols, src.rows };
-            IppDataType dataType = depth == CV_8U ? ipp8u : ipp32f;
+            typedef IppStatus (CV_STDCALL * ippiPyrDown)(const void* pSrc, int srcStep, void* pDst, int dstStep, IppiSize srcRoi, Ipp8u* buffer);
+            int type = src.type();
             CV_SUPPRESS_DEPRECATED_START
-            IppStatus ok = ippiPyrDownGetBufSize_Gauss5x5(srcRoi.width, dataType, src.channels(), &bufferSize);
+            ippiPyrDown pyrDownFunc = type == CV_8UC1 ? (ippiPyrDown) ippiPyrDown_Gauss5x5_8u_C1R :
+                                      type == CV_8UC3 ? (ippiPyrDown) ippiPyrDown_Gauss5x5_8u_C3R :
+                                      type == CV_32FC1 ? (ippiPyrDown) ippiPyrDown_Gauss5x5_32f_C1R :
+                                      type == CV_32FC3 ? (ippiPyrDown) ippiPyrDown_Gauss5x5_32f_C3R : 0;
             CV_SUPPRESS_DEPRECATED_END
-            if (ok >= 0)
-            {
-                Ipp8u* buffer = ippsMalloc_8u(bufferSize);
-                ok = pyrDownFunc(src.data, (int) src.step, dst.data, (int) dst.step, srcRoi, buffer);
-                ippsFree(buffer);
 
+            if (pyrDownFunc)
+            {
+                int bufferSize;
+                IppiSize srcRoi = { src.cols, src.rows };
+                IppDataType dataType = depth == CV_8U ? ipp8u : ipp32f;
+                CV_SUPPRESS_DEPRECATED_START
+                IppStatus ok = ippiPyrDownGetBufSize_Gauss5x5(srcRoi.width, dataType, src.channels(), &bufferSize);
+                CV_SUPPRESS_DEPRECATED_END
                 if (ok >= 0)
-                    return;
-                setIppErrorStatus();
+                {
+                    Ipp8u* buffer = ippsMalloc_8u(bufferSize);
+                    ok = pyrDownFunc(src.data, (int) src.step, dst.data, (int) dst.step, srcRoi, buffer);
+                    ippsFree(buffer);
+
+                    if (ok >= 0)
+                    {
+                        CV_IMPL_ADD(CV_IMPL_IPP);
+                        return;
+                    }
+                    setIppErrorStatus();
+                }
             }
         }
     }
@@ -774,36 +780,42 @@ void cv::pyrUp( InputArray _src, OutputArray _dst, const Size& _dsz, int borderT
 #endif
 
 #if IPP_VERSION_X100 >= 801 && 0
-    bool isolated = (borderType & BORDER_ISOLATED) != 0;
-    int borderTypeNI = borderType & ~BORDER_ISOLATED;
-    if (borderTypeNI == BORDER_DEFAULT && (!src.isSubmatrix() || isolated) && dsz == Size(src.cols*2, src.rows*2))
+    CV_IPP_CHECK()
     {
-        typedef IppStatus (CV_STDCALL * ippiPyrUp)(const void* pSrc, int srcStep, void* pDst, int dstStep, IppiSize srcRoi, Ipp8u* buffer);
-        int type = src.type();
-        CV_SUPPRESS_DEPRECATED_START
-        ippiPyrUp pyrUpFunc = type == CV_8UC1 ? (ippiPyrUp) ippiPyrUp_Gauss5x5_8u_C1R :
-                              type == CV_8UC3 ? (ippiPyrUp) ippiPyrUp_Gauss5x5_8u_C3R :
-                              type == CV_32FC1 ? (ippiPyrUp) ippiPyrUp_Gauss5x5_32f_C1R :
-                              type == CV_32FC3 ? (ippiPyrUp) ippiPyrUp_Gauss5x5_32f_C3R : 0;
-        CV_SUPPRESS_DEPRECATED_END
-
-        if (pyrUpFunc)
+        bool isolated = (borderType & BORDER_ISOLATED) != 0;
+        int borderTypeNI = borderType & ~BORDER_ISOLATED;
+        if (borderTypeNI == BORDER_DEFAULT && (!src.isSubmatrix() || isolated) && dsz == Size(src.cols*2, src.rows*2))
         {
-            int bufferSize;
-            IppiSize srcRoi = { src.cols, src.rows };
-            IppDataType dataType = depth == CV_8U ? ipp8u : ipp32f;
+            typedef IppStatus (CV_STDCALL * ippiPyrUp)(const void* pSrc, int srcStep, void* pDst, int dstStep, IppiSize srcRoi, Ipp8u* buffer);
+            int type = src.type();
             CV_SUPPRESS_DEPRECATED_START
-            IppStatus ok = ippiPyrUpGetBufSize_Gauss5x5(srcRoi.width, dataType, src.channels(), &bufferSize);
+            ippiPyrUp pyrUpFunc = type == CV_8UC1 ? (ippiPyrUp) ippiPyrUp_Gauss5x5_8u_C1R :
+                                  type == CV_8UC3 ? (ippiPyrUp) ippiPyrUp_Gauss5x5_8u_C3R :
+                                  type == CV_32FC1 ? (ippiPyrUp) ippiPyrUp_Gauss5x5_32f_C1R :
+                                  type == CV_32FC3 ? (ippiPyrUp) ippiPyrUp_Gauss5x5_32f_C3R : 0;
             CV_SUPPRESS_DEPRECATED_END
-            if (ok >= 0)
-            {
-                Ipp8u* buffer = ippsMalloc_8u(bufferSize);
-                ok = pyrUpFunc(src.data, (int) src.step, dst.data, (int) dst.step, srcRoi, buffer);
-                ippsFree(buffer);
 
+            if (pyrUpFunc)
+            {
+                int bufferSize;
+                IppiSize srcRoi = { src.cols, src.rows };
+                IppDataType dataType = depth == CV_8U ? ipp8u : ipp32f;
+                CV_SUPPRESS_DEPRECATED_START
+                IppStatus ok = ippiPyrUpGetBufSize_Gauss5x5(srcRoi.width, dataType, src.channels(), &bufferSize);
+                CV_SUPPRESS_DEPRECATED_END
                 if (ok >= 0)
-                    return;
-                setIppErrorStatus();
+                {
+                    Ipp8u* buffer = ippsMalloc_8u(bufferSize);
+                    ok = pyrUpFunc(src.data, (int) src.step, dst.data, (int) dst.step, srcRoi, buffer);
+                    ippsFree(buffer);
+
+                    if (ok >= 0)
+                    {
+                        CV_IMPL_ADD(CV_IMPL_IPP);
+                        return;
+                    }
+                    setIppErrorStatus();
+                }
             }
         }
     }
@@ -847,87 +859,94 @@ void cv::buildPyramid( InputArray _src, OutputArrayOfArrays _dst, int maxlevel, 
     int i=1;
 
 #if IPP_VERSION_X100 >= 801 && 0
-    bool isolated = (borderType & BORDER_ISOLATED) != 0;
-    int borderTypeNI = borderType & ~BORDER_ISOLATED;
-    if (borderTypeNI == BORDER_DEFAULT && (!src.isSubmatrix() || isolated))
+    CV_IPP_CHECK()
     {
-        typedef IppStatus (CV_STDCALL * ippiPyramidLayerDownInitAlloc)(void** ppState, IppiSize srcRoi, Ipp32f rate, void* pKernel, int kerSize, int mode);
-        typedef IppStatus (CV_STDCALL * ippiPyramidLayerDown)(void* pSrc, int srcStep, IppiSize srcRoiSize, void* pDst, int dstStep, IppiSize dstRoiSize, void* pState);
-        typedef IppStatus (CV_STDCALL * ippiPyramidLayerDownFree)(void* pState);
-
-        int type = src.type();
-        int depth = src.depth();
-        ippiPyramidLayerDownInitAlloc pyrInitAllocFunc = 0;
-        ippiPyramidLayerDown pyrDownFunc = 0;
-        ippiPyramidLayerDownFree pyrFreeFunc = 0;
-
-        if (type == CV_8UC1)
+        bool isolated = (borderType & BORDER_ISOLATED) != 0;
+        int borderTypeNI = borderType & ~BORDER_ISOLATED;
+        if (borderTypeNI == BORDER_DEFAULT && (!src.isSubmatrix() || isolated))
         {
-            pyrInitAllocFunc = (ippiPyramidLayerDownInitAlloc) ippiPyramidLayerDownInitAlloc_8u_C1R;
-            pyrDownFunc = (ippiPyramidLayerDown) ippiPyramidLayerDown_8u_C1R;
-            pyrFreeFunc = (ippiPyramidLayerDownFree) ippiPyramidLayerDownFree_8u_C1R;
-        }
-        else if (type == CV_8UC3)
-        {
-            pyrInitAllocFunc = (ippiPyramidLayerDownInitAlloc) ippiPyramidLayerDownInitAlloc_8u_C3R;
-            pyrDownFunc = (ippiPyramidLayerDown) ippiPyramidLayerDown_8u_C3R;
-            pyrFreeFunc = (ippiPyramidLayerDownFree) ippiPyramidLayerDownFree_8u_C3R;
-        }
-        else if (type == CV_32FC1)
-        {
-            pyrInitAllocFunc = (ippiPyramidLayerDownInitAlloc) ippiPyramidLayerDownInitAlloc_32f_C1R;
-            pyrDownFunc = (ippiPyramidLayerDown) ippiPyramidLayerDown_32f_C1R;
-            pyrFreeFunc = (ippiPyramidLayerDownFree) ippiPyramidLayerDownFree_32f_C1R;
-        }
-        else if (type == CV_32FC3)
-        {
-            pyrInitAllocFunc = (ippiPyramidLayerDownInitAlloc) ippiPyramidLayerDownInitAlloc_32f_C3R;
-            pyrDownFunc = (ippiPyramidLayerDown) ippiPyramidLayerDown_32f_C3R;
-            pyrFreeFunc = (ippiPyramidLayerDownFree) ippiPyramidLayerDownFree_32f_C3R;
-        }
+            typedef IppStatus (CV_STDCALL * ippiPyramidLayerDownInitAlloc)(void** ppState, IppiSize srcRoi, Ipp32f rate, void* pKernel, int kerSize, int mode);
+            typedef IppStatus (CV_STDCALL * ippiPyramidLayerDown)(void* pSrc, int srcStep, IppiSize srcRoiSize, void* pDst, int dstStep, IppiSize dstRoiSize, void* pState);
+            typedef IppStatus (CV_STDCALL * ippiPyramidLayerDownFree)(void* pState);
 
-        if (pyrInitAllocFunc && pyrDownFunc && pyrFreeFunc)
-        {
-            float rate = 2.f;
-            IppiSize srcRoi = { src.cols, src.rows };
-            IppiPyramid *gPyr;
-            IppStatus ok = ippiPyramidInitAlloc(&gPyr, maxlevel + 1, srcRoi, rate);
+            int type = src.type();
+            int depth = src.depth();
+            ippiPyramidLayerDownInitAlloc pyrInitAllocFunc = 0;
+            ippiPyramidLayerDown pyrDownFunc = 0;
+            ippiPyramidLayerDownFree pyrFreeFunc = 0;
 
-            Ipp16s iKernel[5] = { 1, 4, 6, 4, 1 };
-            Ipp32f fKernel[5] = { 1.f, 4.f, 6.f, 4.f, 1.f };
-            void* kernel = depth >= CV_32F ? (void*) fKernel : (void*) iKernel;
-
-            if (ok >= 0) ok = pyrInitAllocFunc((void**) &(gPyr->pState), srcRoi, rate, kernel, 5, IPPI_INTER_LINEAR);
-            if (ok >= 0)
+            if (type == CV_8UC1)
             {
-                gPyr->pImage[0] = src.data;
-                gPyr->pStep[0] = (int) src.step;
-                gPyr->pRoi[0] = srcRoi;
-                for( ; i <= maxlevel; i++ )
-                {
-                    IppiSize dstRoi;
-                    ok = ippiGetPyramidDownROI(gPyr->pRoi[i-1], &dstRoi, rate);
-                    Mat& dst = _dst.getMatRef(i);
-                    dst.create(Size(dstRoi.width, dstRoi.height), type);
-                    gPyr->pImage[i] = dst.data;
-                    gPyr->pStep[i] = (int) dst.step;
-                    gPyr->pRoi[i] = dstRoi;
-
-                    if (ok >= 0) ok = pyrDownFunc(gPyr->pImage[i-1], gPyr->pStep[i-1], gPyr->pRoi[i-1],
-                                                  gPyr->pImage[i], gPyr->pStep[i], gPyr->pRoi[i], gPyr->pState);
-
-                    if (ok < 0)
-                    {
-                        setIppErrorStatus();
-                        break;
-                    }
-                }
-                pyrFreeFunc(gPyr->pState);
+                pyrInitAllocFunc = (ippiPyramidLayerDownInitAlloc) ippiPyramidLayerDownInitAlloc_8u_C1R;
+                pyrDownFunc = (ippiPyramidLayerDown) ippiPyramidLayerDown_8u_C1R;
+                pyrFreeFunc = (ippiPyramidLayerDownFree) ippiPyramidLayerDownFree_8u_C1R;
             }
-            else
-                setIppErrorStatus();
+            else if (type == CV_8UC3)
+            {
+                pyrInitAllocFunc = (ippiPyramidLayerDownInitAlloc) ippiPyramidLayerDownInitAlloc_8u_C3R;
+                pyrDownFunc = (ippiPyramidLayerDown) ippiPyramidLayerDown_8u_C3R;
+                pyrFreeFunc = (ippiPyramidLayerDownFree) ippiPyramidLayerDownFree_8u_C3R;
+            }
+            else if (type == CV_32FC1)
+            {
+                pyrInitAllocFunc = (ippiPyramidLayerDownInitAlloc) ippiPyramidLayerDownInitAlloc_32f_C1R;
+                pyrDownFunc = (ippiPyramidLayerDown) ippiPyramidLayerDown_32f_C1R;
+                pyrFreeFunc = (ippiPyramidLayerDownFree) ippiPyramidLayerDownFree_32f_C1R;
+            }
+            else if (type == CV_32FC3)
+            {
+                pyrInitAllocFunc = (ippiPyramidLayerDownInitAlloc) ippiPyramidLayerDownInitAlloc_32f_C3R;
+                pyrDownFunc = (ippiPyramidLayerDown) ippiPyramidLayerDown_32f_C3R;
+                pyrFreeFunc = (ippiPyramidLayerDownFree) ippiPyramidLayerDownFree_32f_C3R;
+            }
 
-            ippiPyramidFree(gPyr);
+            if (pyrInitAllocFunc && pyrDownFunc && pyrFreeFunc)
+            {
+                float rate = 2.f;
+                IppiSize srcRoi = { src.cols, src.rows };
+                IppiPyramid *gPyr;
+                IppStatus ok = ippiPyramidInitAlloc(&gPyr, maxlevel + 1, srcRoi, rate);
+
+                Ipp16s iKernel[5] = { 1, 4, 6, 4, 1 };
+                Ipp32f fKernel[5] = { 1.f, 4.f, 6.f, 4.f, 1.f };
+                void* kernel = depth >= CV_32F ? (void*) fKernel : (void*) iKernel;
+
+                if (ok >= 0) ok = pyrInitAllocFunc((void**) &(gPyr->pState), srcRoi, rate, kernel, 5, IPPI_INTER_LINEAR);
+                if (ok >= 0)
+                {
+                    gPyr->pImage[0] = src.data;
+                    gPyr->pStep[0] = (int) src.step;
+                    gPyr->pRoi[0] = srcRoi;
+                    for( ; i <= maxlevel; i++ )
+                    {
+                        IppiSize dstRoi;
+                        ok = ippiGetPyramidDownROI(gPyr->pRoi[i-1], &dstRoi, rate);
+                        Mat& dst = _dst.getMatRef(i);
+                        dst.create(Size(dstRoi.width, dstRoi.height), type);
+                        gPyr->pImage[i] = dst.data;
+                        gPyr->pStep[i] = (int) dst.step;
+                        gPyr->pRoi[i] = dstRoi;
+
+                        if (ok >= 0) ok = pyrDownFunc(gPyr->pImage[i-1], gPyr->pStep[i-1], gPyr->pRoi[i-1],
+                                                      gPyr->pImage[i], gPyr->pStep[i], gPyr->pRoi[i], gPyr->pState);
+
+                        if (ok < 0)
+                        {
+                            setIppErrorStatus();
+                            break;
+                        }
+                        else
+                        {
+                            CV_IMPL_ADD(CV_IMPL_IPP);
+                        }
+                    }
+                    pyrFreeFunc(gPyr->pState);
+                }
+                else
+                    setIppErrorStatus();
+
+                ippiPyramidFree(gPyr);
+            }
         }
     }
 #endif

--- a/modules/imgproc/src/samplers.cpp
+++ b/modules/imgproc/src/samplers.cpp
@@ -375,27 +375,33 @@ void cv::getRectSubPix( InputArray _image, Size patchSize, Point2f center,
     Mat patch = _patch.getMat();
 
 #if defined (HAVE_IPP) && (IPP_VERSION_MAJOR >= 7)
-    typedef IppStatus (CV_STDCALL *ippiGetRectSubPixFunc)( const void* src, int src_step,
-                                                            IppiSize src_size, void* dst,
-                                                            int dst_step, IppiSize win_size,
-                                                            IppiPoint_32f center,
-                                                            IppiPoint* minpt, IppiPoint* maxpt );
-
-    IppiPoint minpt={0,0}, maxpt={0,0};
-    IppiPoint_32f icenter = {center.x, center.y};
-    IppiSize src_size={image.cols, image.rows}, win_size={patch.cols, patch.rows};
-    int srctype = image.type();
-    ippiGetRectSubPixFunc ippfunc =
-        srctype == CV_8UC1 && ddepth == CV_8U ? (ippiGetRectSubPixFunc)ippiCopySubpixIntersect_8u_C1R :
-        srctype == CV_8UC1 && ddepth == CV_32F ? (ippiGetRectSubPixFunc)ippiCopySubpixIntersect_8u32f_C1R :
-        srctype == CV_32FC1 && ddepth == CV_32F ? (ippiGetRectSubPixFunc)ippiCopySubpixIntersect_32f_C1R : 0;
-
-    if( ippfunc)
+    CV_IPP_CHECK()
     {
-        if (ippfunc(image.ptr(), (int)image.step, src_size, patch.ptr(),
-                    (int)patch.step, win_size, icenter, &minpt, &maxpt) >= 0 )
-            return;
-        setIppErrorStatus();
+        typedef IppStatus (CV_STDCALL *ippiGetRectSubPixFunc)( const void* src, int src_step,
+                                                                IppiSize src_size, void* dst,
+                                                                int dst_step, IppiSize win_size,
+                                                                IppiPoint_32f center,
+                                                                IppiPoint* minpt, IppiPoint* maxpt );
+
+        IppiPoint minpt={0,0}, maxpt={0,0};
+        IppiPoint_32f icenter = {center.x, center.y};
+        IppiSize src_size={image.cols, image.rows}, win_size={patch.cols, patch.rows};
+        int srctype = image.type();
+        ippiGetRectSubPixFunc ippfunc =
+            srctype == CV_8UC1 && ddepth == CV_8U ? (ippiGetRectSubPixFunc)ippiCopySubpixIntersect_8u_C1R :
+            srctype == CV_8UC1 && ddepth == CV_32F ? (ippiGetRectSubPixFunc)ippiCopySubpixIntersect_8u32f_C1R :
+            srctype == CV_32FC1 && ddepth == CV_32F ? (ippiGetRectSubPixFunc)ippiCopySubpixIntersect_32f_C1R : 0;
+
+        if( ippfunc)
+        {
+            if (ippfunc(image.ptr(), (int)image.step, src_size, patch.ptr(),
+                        (int)patch.step, win_size, icenter, &minpt, &maxpt) >= 0 )
+            {
+                CV_IMPL_ADD(CV_IMPL_IPP);
+                return;
+            }
+            setIppErrorStatus();
+        }
     }
 #endif
 

--- a/modules/imgproc/src/templmatch.cpp
+++ b/modules/imgproc/src/templmatch.cpp
@@ -853,13 +853,20 @@ void cv::matchTemplate( InputArray _img, InputArray _templ, OutputArray _result,
 #endif
 
 #if defined HAVE_IPP
-    bool useIppMT = (templ.rows < img.rows/2 && templ.cols < img.cols/2);
-
-    if (method == CV_TM_SQDIFF && cn == 1 && useIppMT)
+    bool useIppMT = false;
+    CV_IPP_CHECK()
     {
-        if (ipp_sqrDistance(img, templ, result))
-            return;
-        setIppErrorStatus();
+        useIppMT = (templ.rows < img.rows/2 && templ.cols < img.cols/2);
+
+        if (method == CV_TM_SQDIFF && cn == 1 && useIppMT)
+        {
+            if (ipp_sqrDistance(img, templ, result))
+            {
+                CV_IMPL_ADD(CV_IMPL_IPP);
+                return;
+            }
+            setIppErrorStatus();
+        }
     }
 #endif
 
@@ -870,6 +877,10 @@ void cv::matchTemplate( InputArray _img, InputArray _templ, OutputArray _result,
         {
             setIppErrorStatus();
             crossCorr( img, templ, result, result.size(), result.type(), Point(0,0), 0, 0);
+        }
+        else
+        {
+            CV_IMPL_ADD(CV_IMPL_IPP);
         }
     }
     else

--- a/modules/imgproc/src/thresh.cpp
+++ b/modules/imgproc/src/thresh.cpp
@@ -69,39 +69,60 @@ thresh_8u( const Mat& _src, Mat& _dst, uchar thresh, uchar maxval, int type )
 #endif
 
 #if defined(HAVE_IPP)
-    IppiSize sz = { roi.width, roi.height };
-    CV_SUPPRESS_DEPRECATED_START
-    switch( type )
+    CV_IPP_CHECK()
     {
-    case THRESH_TRUNC:
+        IppiSize sz = { roi.width, roi.height };
+        CV_SUPPRESS_DEPRECATED_START
+        switch( type )
+        {
+        case THRESH_TRUNC:
 #ifndef HAVE_IPP_ICV_ONLY
-        if (_src.data == _dst.data && ippiThreshold_GT_8u_C1IR(_dst.ptr(), (int)dst_step, sz, thresh) >= 0)
-            return;
+            if (_src.data == _dst.data && ippiThreshold_GT_8u_C1IR(_dst.ptr(), (int)dst_step, sz, thresh) >= 0)
+            {
+                CV_IMPL_ADD(CV_IMPL_IPP);
+                return;
+            }
 #endif
-        if (ippiThreshold_GT_8u_C1R(_src.ptr(), (int)src_step, _dst.ptr(), (int)dst_step, sz, thresh) >= 0)
-            return;
-        setIppErrorStatus();
-        break;
-    case THRESH_TOZERO:
+            if (ippiThreshold_GT_8u_C1R(_src.ptr(), (int)src_step, _dst.ptr(), (int)dst_step, sz, thresh) >= 0)
+            {
+                CV_IMPL_ADD(CV_IMPL_IPP);
+                return;
+            }
+            setIppErrorStatus();
+            break;
+        case THRESH_TOZERO:
 #ifndef HAVE_IPP_ICV_ONLY
-        if (_src.data == _dst.data && ippiThreshold_LTVal_8u_C1IR(_dst.ptr(), (int)dst_step, sz, thresh+1, 0) >= 0)
-            return;
+            if (_src.data == _dst.data && ippiThreshold_LTVal_8u_C1IR(_dst.ptr(), (int)dst_step, sz, thresh+1, 0) >= 0)
+            {
+                CV_IMPL_ADD(CV_IMPL_IPP);
+                return;
+            }
 #endif
-        if (ippiThreshold_LTVal_8u_C1R(_src.ptr(), (int)src_step, _dst.ptr(), (int)dst_step, sz, thresh+1, 0) >= 0)
-            return;
-        setIppErrorStatus();
-        break;
-    case THRESH_TOZERO_INV:
+            if (ippiThreshold_LTVal_8u_C1R(_src.ptr(), (int)src_step, _dst.ptr(), (int)dst_step, sz, thresh+1, 0) >= 0)
+            {
+                CV_IMPL_ADD(CV_IMPL_IPP);
+                return;
+            }
+            setIppErrorStatus();
+            break;
+        case THRESH_TOZERO_INV:
 #ifndef HAVE_IPP_ICV_ONLY
-        if (_src.data == _dst.data && ippiThreshold_GTVal_8u_C1IR(_dst.ptr(), (int)dst_step, sz, thresh, 0) >= 0)
-            return;
+            if (_src.data == _dst.data && ippiThreshold_GTVal_8u_C1IR(_dst.ptr(), (int)dst_step, sz, thresh, 0) >= 0)
+            {
+                CV_IMPL_ADD(CV_IMPL_IPP);
+                return;
+            }
 #endif
-        if (ippiThreshold_GTVal_8u_C1R(_src.ptr(), (int)src_step, _dst.ptr(), (int)dst_step, sz, thresh, 0) >= 0)
-            return;
-        setIppErrorStatus();
-        break;
+            if (ippiThreshold_GTVal_8u_C1R(_src.ptr(), (int)src_step, _dst.ptr(), (int)dst_step, sz, thresh, 0) >= 0)
+            {
+                CV_IMPL_ADD(CV_IMPL_IPP);
+                return;
+            }
+            setIppErrorStatus();
+            break;
+        }
+        CV_SUPPRESS_DEPRECATED_END
     }
-    CV_SUPPRESS_DEPRECATED_END
 #endif
 
     switch( type )
@@ -392,39 +413,60 @@ thresh_16s( const Mat& _src, Mat& _dst, short thresh, short maxval, int type )
 #endif
 
 #if defined(HAVE_IPP)
-    IppiSize sz = { roi.width, roi.height };
-    CV_SUPPRESS_DEPRECATED_START
-    switch( type )
+    CV_IPP_CHECK()
     {
-    case THRESH_TRUNC:
+        IppiSize sz = { roi.width, roi.height };
+        CV_SUPPRESS_DEPRECATED_START
+        switch( type )
+        {
+        case THRESH_TRUNC:
 #ifndef HAVE_IPP_ICV_ONLY
-        if (_src.data == _dst.data && ippiThreshold_GT_16s_C1IR(dst, (int)dst_step*sizeof(dst[0]), sz, thresh) >= 0)
-            return;
+            if (_src.data == _dst.data && ippiThreshold_GT_16s_C1IR(dst, (int)dst_step*sizeof(dst[0]), sz, thresh) >= 0)
+            {
+                CV_IMPL_ADD(CV_IMPL_IPP);
+                return;
+            }
 #endif
-        if (ippiThreshold_GT_16s_C1R(src, (int)src_step*sizeof(src[0]), dst, (int)dst_step*sizeof(dst[0]), sz, thresh) >= 0)
-            return;
-        setIppErrorStatus();
-        break;
-    case THRESH_TOZERO:
+            if (ippiThreshold_GT_16s_C1R(src, (int)src_step*sizeof(src[0]), dst, (int)dst_step*sizeof(dst[0]), sz, thresh) >= 0)
+            {
+                CV_IMPL_ADD(CV_IMPL_IPP);
+                return;
+            }
+            setIppErrorStatus();
+            break;
+        case THRESH_TOZERO:
 #ifndef HAVE_IPP_ICV_ONLY
-        if (_src.data == _dst.data && ippiThreshold_LTVal_16s_C1IR(dst, (int)dst_step*sizeof(dst[0]), sz, thresh + 1, 0) >= 0)
-            return;
+            if (_src.data == _dst.data && ippiThreshold_LTVal_16s_C1IR(dst, (int)dst_step*sizeof(dst[0]), sz, thresh + 1, 0) >= 0)
+            {
+                CV_IMPL_ADD(CV_IMPL_IPP);
+                return;
+            }
 #endif
-        if (ippiThreshold_LTVal_16s_C1R(src, (int)src_step*sizeof(src[0]), dst, (int)dst_step*sizeof(dst[0]), sz, thresh+1, 0) >= 0)
-            return;
-        setIppErrorStatus();
-        break;
-    case THRESH_TOZERO_INV:
+            if (ippiThreshold_LTVal_16s_C1R(src, (int)src_step*sizeof(src[0]), dst, (int)dst_step*sizeof(dst[0]), sz, thresh+1, 0) >= 0)
+            {
+                CV_IMPL_ADD(CV_IMPL_IPP);
+                return;
+            }
+            setIppErrorStatus();
+            break;
+        case THRESH_TOZERO_INV:
 #ifndef HAVE_IPP_ICV_ONLY
-        if (_src.data == _dst.data && ippiThreshold_GTVal_16s_C1IR(dst, (int)dst_step*sizeof(dst[0]), sz, thresh, 0) >= 0)
-            return;
+            if (_src.data == _dst.data && ippiThreshold_GTVal_16s_C1IR(dst, (int)dst_step*sizeof(dst[0]), sz, thresh, 0) >= 0)
+            {
+                CV_IMPL_ADD(CV_IMPL_IPP);
+                return;
+            }
 #endif
-        if (ippiThreshold_GTVal_16s_C1R(src, (int)src_step*sizeof(src[0]), dst, (int)dst_step*sizeof(dst[0]), sz, thresh, 0) >= 0)
-            return;
-        setIppErrorStatus();
-        break;
+            if (ippiThreshold_GTVal_16s_C1R(src, (int)src_step*sizeof(src[0]), dst, (int)dst_step*sizeof(dst[0]), sz, thresh, 0) >= 0)
+            {
+                CV_IMPL_ADD(CV_IMPL_IPP);
+                return;
+            }
+            setIppErrorStatus();
+            break;
+        }
+        CV_SUPPRESS_DEPRECATED_END
     }
-    CV_SUPPRESS_DEPRECATED_END
 #endif
 
     switch( type )
@@ -639,24 +681,36 @@ thresh_32f( const Mat& _src, Mat& _dst, float thresh, float maxval, int type )
 #endif
 
 #if defined(HAVE_IPP)
-    IppiSize sz = { roi.width, roi.height };
-    switch( type )
+    CV_IPP_CHECK()
     {
-    case THRESH_TRUNC:
-        if (0 <= ippiThreshold_GT_32f_C1R(src, (int)src_step*sizeof(src[0]), dst, (int)dst_step*sizeof(dst[0]), sz, thresh))
-            return;
-        setIppErrorStatus();
-        break;
-    case THRESH_TOZERO:
-        if (0 <= ippiThreshold_LTVal_32f_C1R(src, (int)src_step*sizeof(src[0]), dst, (int)dst_step*sizeof(dst[0]), sz, thresh+FLT_EPSILON, 0))
-            return;
-        setIppErrorStatus();
-        break;
-    case THRESH_TOZERO_INV:
-        if (0 <= ippiThreshold_GTVal_32f_C1R(src, (int)src_step*sizeof(src[0]), dst, (int)dst_step*sizeof(dst[0]), sz, thresh, 0))
-            return;
-        setIppErrorStatus();
-        break;
+        IppiSize sz = { roi.width, roi.height };
+        switch( type )
+        {
+        case THRESH_TRUNC:
+            if (0 <= ippiThreshold_GT_32f_C1R(src, (int)src_step*sizeof(src[0]), dst, (int)dst_step*sizeof(dst[0]), sz, thresh))
+            {
+                CV_IMPL_ADD(CV_IMPL_IPP);
+                return;
+            }
+            setIppErrorStatus();
+            break;
+        case THRESH_TOZERO:
+            if (0 <= ippiThreshold_LTVal_32f_C1R(src, (int)src_step*sizeof(src[0]), dst, (int)dst_step*sizeof(dst[0]), sz, thresh+FLT_EPSILON, 0))
+            {
+                CV_IMPL_ADD(CV_IMPL_IPP);
+                return;
+            }
+            setIppErrorStatus();
+            break;
+        case THRESH_TOZERO_INV:
+            if (0 <= ippiThreshold_GTVal_32f_C1R(src, (int)src_step*sizeof(src[0]), dst, (int)dst_step*sizeof(dst[0]), sz, thresh, 0))
+            {
+                CV_IMPL_ADD(CV_IMPL_IPP);
+                return;
+            }
+            setIppErrorStatus();
+            break;
+        }
     }
 #endif
 
@@ -864,14 +918,20 @@ getThreshVal_Otsu_8u( const Mat& _src )
     }
 
 #if IPP_VERSION_X100 >= 801 && !defined(HAVE_IPP_ICV_ONLY)
-    IppiSize srcSize = { size.width, size.height };
-    Ipp8u thresh;
-    CV_SUPPRESS_DEPRECATED_START
-    IppStatus ok = ippiComputeThreshold_Otsu_8u_C1R(_src.ptr(), step, srcSize, &thresh);
-    CV_SUPPRESS_DEPRECATED_END
-    if (ok >= 0)
-        return thresh;
-    setIppErrorStatus();
+    CV_IPP_CHECK()
+    {
+        IppiSize srcSize = { size.width, size.height };
+        Ipp8u thresh;
+        CV_SUPPRESS_DEPRECATED_START
+        IppStatus ok = ippiComputeThreshold_Otsu_8u_C1R(_src.ptr(), step, srcSize, &thresh);
+        CV_SUPPRESS_DEPRECATED_END
+        if (ok >= 0)
+        {
+            CV_IMPL_ADD(CV_IMPL_IPP);
+            return thresh;
+        }
+        setIppErrorStatus();
+    }
 #endif
 
     const int N = 256;

--- a/modules/objdetect/src/cascadedetect.cpp
+++ b/modules/objdetect/src/cascadedetect.cpp
@@ -1213,6 +1213,7 @@ void CascadeClassifierImpl::detectMultiScaleNoGrouping( InputArray _image, std::
     if( maxObjectSize.height == 0 || maxObjectSize.width == 0 )
         maxObjectSize = imgsz;
 
+#ifdef HAVE_OPENCL
     bool use_ocl = tryOpenCL && ocl::useOpenCL() &&
          featureEvaluator->getLocalSize().area() > 0 &&
          ocl::Device::getDefault().type() != ocl::Device::TYPE_CPU &&
@@ -1220,6 +1221,7 @@ void CascadeClassifierImpl::detectMultiScaleNoGrouping( InputArray _image, std::
          !isOldFormatCascade() &&
          maskGenerator.empty() &&
          !outputRejectLevels;
+#endif
 
     /*if( use_ocl )
     {
@@ -1262,8 +1264,8 @@ void CascadeClassifierImpl::detectMultiScaleNoGrouping( InputArray _image, std::
         return;
 
     // OpenCL code
-    if( use_ocl && ocl_detectMultiScaleNoGrouping( scales, candidates ))
-        return;
+    CV_OCL_RUN(use_ocl, ocl_detectMultiScaleNoGrouping( scales, candidates ))
+
     tryOpenCL = false;
 
     // CPU code

--- a/modules/objdetect/src/haar.cpp
+++ b/modules/objdetect/src/haar.cpp
@@ -159,7 +159,7 @@ icvReleaseHidHaarClassifierCascade( CvHidHaarClassifierCascade** _cascade )
     {
 #ifdef HAVE_IPP
         CvHidHaarClassifierCascade* cascade = *_cascade;
-        if( cascade->ipp_stages )
+        if( CV_IPP_CHECK_COND && cascade->ipp_stages )
         {
             int i;
             for( i = 0; i < cascade->count; i++ )
@@ -338,7 +338,7 @@ icvCreateHidHaarClassifierCascade( CvHaarClassifierCascade* cascade )
     }
 /*
 #ifdef HAVE_IPP
-    int can_use_ipp = !out->has_tilted_features && !out->is_tree && out->isStumpBased;
+    int can_use_ipp = CV_IPP_CHECK_COND && (!out->has_tilted_features && !out->is_tree && out->isStumpBased);
 
     if( can_use_ipp )
     {
@@ -1315,7 +1315,7 @@ public:
         int x, y, ystep = factor > 2 ? 1 : 2;
 
 #ifdef HAVE_IPP
-        if( cascade->hid_cascade->ipp_stages )
+        if(CV_IPP_CHECK_COND && cascade->hid_cascade->ipp_stages )
         {
             IppiRect iequRect = {equRect.x, equRect.y, equRect.width, equRect.height};
             ippiRectStdDev_32f_C1R(sum1.ptr<float>(y1), (int)sum1.step,
@@ -1351,6 +1351,7 @@ public:
                 if( positive <= 0 )
                     break;
             }
+            CV_IMPL_ADD(CV_IMPL_IPP|CV_IMPL_MT);
 
             if( positive > 0 )
                 for( y = y1; y < y2; y += ystep )
@@ -1561,7 +1562,7 @@ cvHaarDetectObjectsForROC( const CvArr* _img,
     {
         CvSize winSize0 = cascade->orig_window_size;
 #ifdef HAVE_IPP
-        int use_ipp = cascade->hid_cascade->ipp_stages != 0;
+        int use_ipp = CV_IPP_CHECK_COND && (cascade->hid_cascade->ipp_stages != 0);
 
         if( use_ipp )
             normImg.reset(cvCreateMat( img->rows, img->cols, CV_32FC1));

--- a/modules/stitching/src/blenders.cpp
+++ b/modules/stitching/src/blenders.cpp
@@ -414,6 +414,12 @@ void MultiBandBlender::feed(InputArray _img, InputArray mask, Point tl)
                 }
             }
         }
+#ifdef HAVE_OPENCL
+        else
+        {
+            CV_IMPL_ADD(CV_IMPL_OCL);
+        }
+#endif
 
         x_tl /= 2; y_tl /= 2;
         x_br /= 2; y_br /= 2;
@@ -476,8 +482,8 @@ void normalizeUsingWeightMap(InputArray _weight, InputOutputArray _src)
 #endif
 
 #ifdef HAVE_OPENCL
-        if ( !cv::ocl::useOpenCL() ||
-             !ocl_normalizeUsingWeightMap(_weight, _src) )
+    if ( !cv::ocl::useOpenCL() ||
+            !ocl_normalizeUsingWeightMap(_weight, _src) )
 #endif
     {
         Mat weight = _weight.getMat();
@@ -519,6 +525,12 @@ void normalizeUsingWeightMap(InputArray _weight, InputOutputArray _src)
             }
         }
     }
+#ifdef HAVE_OPENCL
+    else
+    {
+        CV_IMPL_ADD(CV_IMPL_OCL);
+    }
+#endif
 }
 
 

--- a/modules/stitching/src/warpers.cpp
+++ b/modules/stitching/src/warpers.cpp
@@ -114,7 +114,10 @@ Rect PlaneWarper::buildMaps(Size src_size, InputArray K, InputArray R, InputArra
 
             size_t globalsize[2] = { dsize.width, (dsize.height + rowsPerWI - 1) / rowsPerWI };
             if (k.run(2, globalsize, NULL, true))
+            {
+                CV_IMPL_ADD(CV_IMPL_OCL);
                 return Rect(dst_tl, dst_br);
+            }
         }
     }
 
@@ -389,7 +392,10 @@ Rect SphericalWarper::buildMaps(Size src_size, InputArray K, InputArray R, Outpu
 
             size_t globalsize[2] = { dsize.width, (dsize.height + rowsPerWI - 1) / rowsPerWI };
             if (k.run(2, globalsize, NULL, true))
+            {
+                CV_IMPL_ADD(CV_IMPL_OCL);
                 return Rect(dst_tl, dst_br);
+            }
         }
     }
 
@@ -435,7 +441,10 @@ Rect CylindricalWarper::buildMaps(Size src_size, InputArray K, InputArray R, Out
 
             size_t globalsize[2] = { dsize.width, (dsize.height + rowsPerWI - 1) / rowsPerWI };
             if (k.run(2, globalsize, NULL, true))
+            {
+                CV_IMPL_ADD(CV_IMPL_OCL);
                 return Rect(dst_tl, dst_br);
+            }
         }
     }
 

--- a/modules/video/src/lkpyramid.cpp
+++ b/modules/video/src/lkpyramid.cpp
@@ -1096,7 +1096,10 @@ void cv::calcOpticalFlowPyrLK( InputArray _prevImg, InputArray _nextImg,
                       (_prevImg.isUMat() || _nextImg.isUMat()) &&
                       ocl::Image2D::isFormatSupported(CV_32F, 1, false);
     if ( use_opencl && ocl_calcOpticalFlowPyrLK(_prevImg, _nextImg, _prevPts, _nextPts, _status, _err, winSize, maxLevel, criteria, flags/*, minEigThreshold*/))
+    {
+        CV_IMPL_ADD(CV_IMPL_OCL);
         return;
+    }
 
     Mat prevPtsMat = _prevPts.getMat();
     const int derivDepth = DataType<cv::detail::deriv_type>::depth;

--- a/modules/video/src/optflowgf.cpp
+++ b/modules/video/src/optflowgf.cpp
@@ -1081,7 +1081,10 @@ void cv::calcOpticalFlowFarneback( InputArray _prev0, InputArray _next0,
 {
     bool use_opencl = ocl::useOpenCL() && _flow0.isUMat();
     if( use_opencl && ocl_calcOpticalFlowFarneback(_prev0, _next0, _flow0, pyr_scale, levels, winsize, iterations, poly_n, poly_sigma, flags))
+    {
+        CV_IMPL_ADD(CV_IMPL_OCL);
         return;
+    }
 
     Mat prev0 = _prev0.getMat(), next0 = _next0.getMat();
     const int min_size = 32;


### PR DESCRIPTION
IPP can be switched on and off on runtime;

Optional implementation collector was added (switched off by default in CMake). Gathers data of implementation used in functions and report this info through performance TS;

TS modifications for implementations control;
