### PR TITLE
ocl: Change static variable order in cl_context.cpp to avoid crashes dur...

### DIFF
--- a/modules/ocl/src/cl_context.cpp
+++ b/modules/ocl/src/cl_context.cpp
@@ -11,7 +11,7 @@
 //                For Open Source Computer Vision Library
 //
 // Copyright (C) 2010-2012, Institute Of Software Chinese Academy Of Science, all rights reserved.
-// Copyright (C) 2010-2012, Advanced Micro Devices, Inc., all rights reserved.
+// Copyright (C) 2010-2014, Advanced Micro Devices, Inc., all rights reserved.
 // Copyright (C) 2010-2012, Multicoreware, Inc., all rights reserved.
 // Third party copyrights are property of their respective owners.
 //
@@ -70,17 +70,6 @@ struct __Module
     cv::Mutex initializationMutex;
     cv::Mutex currentContextMutex;
 };
-static __Module __module;
-
-cv::Mutex& getInitializationMutex()
-{
-    return __module.initializationMutex;
-}
-
-static cv::Mutex& getCurrentContextMutex()
-{
-    return __module.currentContextMutex;
-}
 
 static bool parseOpenCLVersion(const std::string& versionStr, int& major, int& minor)
 {
@@ -245,6 +234,18 @@ struct DeviceInfoImpl: public DeviceInfo
 
 static std::vector<PlatformInfoImpl> global_platforms;
 static std::vector<DeviceInfoImpl> global_devices;
+static __Module __module;
+
+cv::Mutex& getInitializationMutex()
+{
+    return __module.initializationMutex;
+}
+
+static cv::Mutex& getCurrentContextMutex()
+{
+    return __module.currentContextMutex;
+}
+
 
 static void split(const std::string &s, char delim, std::vector<std::string> &elems) {
     std::stringstream ss(s);


### PR DESCRIPTION
...ing destruction

ContextImpl::currentContext contains a reference to one of the
DeviceInfoImpl objects from:

static std::vector<DeviceInfoImpl> global_devices;

ContextImpl::currentContext is destroyed in the destructor
for the statically defined object __module, and relies on its
DeviceInfoImpl reference to query some hardware features while
being destroyed.

This means that we need to ensure that the global_devices vector is
destroyed affter __module, otherwise ContextImpl::currentContext's
DeviceInfoImpl reference will no longer be valid when __module is
destroyed.

Since these variables are all confined to a single compilation unit,
they will be destructed from bottom to top, so we need to make sure
that __module is the bottom definition so it can be destroyed first.
