### PR TITLE
iOS: fix crash from overrelease in UIImageToMat

### DIFF
--- a/modules/highgui/src/ios_conversions.mm
+++ b/modules/highgui/src/ios_conversions.mm
@@ -113,5 +113,4 @@ void UIImageToMat(const UIImage* image,
     CGContextDrawImage(contextRef, CGRectMake(0, 0, cols, rows),
                        image.CGImage);
     CGContextRelease(contextRef);
-    CGColorSpaceRelease(colorSpace);
 }


### PR DESCRIPTION
There is an overrelease occurring in UIImageToMat. This overrelease will randomly cause a crash with the following assertion:

  Assertion failed: (!space->is_singleton), function color_space_dealloc, file ColorSpaces/CGColorSpace.c, line 178.

This overrelease is reported by the Xcode analyzer with the following message: 

  Incorrect decrement of the reference count of an object that is not owned at this point by the caller

The crash tends to occur after a large number of calls to UIImageToMat, around the 20th time it is called in a loop.
