### PR TITLE
viz: fixed memory leak (2.4)

### DIFF
--- a/modules/viz/src/vtk/vtkImageMatSource.cpp
+++ b/modules/viz/src/vtk/vtkImageMatSource.cpp
@@ -52,7 +52,7 @@ namespace cv { namespace viz
 cv::viz::vtkImageMatSource::vtkImageMatSource()
 {
     this->SetNumberOfInputPorts(0);
-    this->ImageData = vtkImageData::New();
+    this->ImageData = vtkSmartPointer<vtkImageData>::New();
 }
 
 int cv::viz::vtkImageMatSource::RequestInformation(vtkInformation *, vtkInformationVector**, vtkInformationVector *outputVector)


### PR DESCRIPTION
Viz module: fixed memory leak (2.4 branch)
http://code.opencv.org/issues/3961
