### PR TITLE
OCL: Optimize OpenCL version of conversScaleAbs function

### DIFF
--- a/modules/core/include/opencv2/core/ocl.hpp
+++ b/modules/core/include/opencv2/core/ocl.hpp
@@ -618,7 +618,7 @@ CV_EXPORTS int predictOptimalVectorWidth(InputArray src1, InputArray src2 = noAr
                                          InputArray src7 = noArray(), InputArray src8 = noArray(), InputArray src9 = noArray(),
                                          OclVectorStrategy strat = OCL_VECTOR_DEFAULT);
 
-CV_EXPORTS int checkOptimalVectorWidth(int *vectorWidths,
+CV_EXPORTS int checkOptimalVectorWidth(const int *vectorWidths,
                                        InputArray src1, InputArray src2 = noArray(), InputArray src3 = noArray(),
                                        InputArray src4 = noArray(), InputArray src5 = noArray(), InputArray src6 = noArray(),
                                        InputArray src7 = noArray(), InputArray src8 = noArray(), InputArray src9 = noArray(),

--- a/modules/core/src/ocl.cpp
+++ b/modules/core/src/ocl.cpp
@@ -4531,12 +4531,14 @@ int predictOptimalVectorWidth(InputArray src1, InputArray src2, InputArray src3,
     return checkOptimalVectorWidth(vectorWidths, src1, src2, src3, src4, src5, src6, src7, src8, src9, strat);
 }
 
-int checkOptimalVectorWidth(int *vectorWidths,
+int checkOptimalVectorWidth(const int *vectorWidths,
                             InputArray src1, InputArray src2, InputArray src3,
                             InputArray src4, InputArray src5, InputArray src6,
                             InputArray src7, InputArray src8, InputArray src9,
                             OclVectorStrategy strat)
 {
+    CV_Assert(vectorWidths);
+
     int ref_type = src1.type();
 
     std::vector<size_t> offsets, steps, cols;


### PR DESCRIPTION
1. Create `_dst` matrix before call `ocl::predictOptimalVectorWidth`
2. Change default vectorWidths in `ocl::predictOptimalVectorWidth` for this function

http://ocl.itseez.com/intel/export/perf/pr/3354/report/

check_regression=_OCL_ConvertScaleAbs*
test_filter=_OCL_ConvertScaleAbs*
test_modules=core
build_examples=OFF
