### PR TITLE
OCL: changed predictOptimalVectorWidth

### DIFF
--- a/modules/core/include/opencv2/core/ocl.hpp
+++ b/modules/core/include/opencv2/core/ocl.hpp
@@ -618,6 +618,12 @@ CV_EXPORTS int predictOptimalVectorWidth(InputArray src1, InputArray src2 = noAr
                                          InputArray src7 = noArray(), InputArray src8 = noArray(), InputArray src9 = noArray(),
                                          OclVectorStrategy strat = OCL_VECTOR_DEFAULT);
 
+CV_EXPORTS int checkOptimalVectorWidth(int *vectorWidths,
+                                       InputArray src1, InputArray src2 = noArray(), InputArray src3 = noArray(),
+                                       InputArray src4 = noArray(), InputArray src5 = noArray(), InputArray src6 = noArray(),
+                                       InputArray src7 = noArray(), InputArray src8 = noArray(), InputArray src9 = noArray(),
+                                       OclVectorStrategy strat = OCL_VECTOR_DEFAULT);
+
 // with OCL_VECTOR_MAX strategy
 CV_EXPORTS int predictOptimalVectorWidthMax(InputArray src1, InputArray src2 = noArray(), InputArray src3 = noArray(),
                                             InputArray src4 = noArray(), InputArray src5 = noArray(), InputArray src6 = noArray(),

--- a/modules/core/src/ocl.cpp
+++ b/modules/core/src/ocl.cpp
@@ -4513,7 +4513,6 @@ int predictOptimalVectorWidth(InputArray src1, InputArray src2, InputArray src3,
                               OclVectorStrategy strat)
 {
     const ocl::Device & d = ocl::Device::getDefault();
-    int ref_type = src1.type();
 
     int vectorWidths[] = { d.preferredVectorWidthChar(), d.preferredVectorWidthChar(),
         d.preferredVectorWidthShort(), d.preferredVectorWidthShort(),
@@ -4528,6 +4527,17 @@ int predictOptimalVectorWidth(InputArray src1, InputArray src2, InputArray src3,
         vectorWidths[CV_16U] = vectorWidths[CV_16S] = 2;
         vectorWidths[CV_32S] = vectorWidths[CV_32F] = vectorWidths[CV_64F] = 1;
     }
+
+    return checkOptimalVectorWidth(vectorWidths, src1, src2, src3, src4, src5, src6, src7, src8, src9, strat);
+}
+
+int checkOptimalVectorWidth(int *vectorWidths,
+                            InputArray src1, InputArray src2, InputArray src3,
+                            InputArray src4, InputArray src5, InputArray src6,
+                            InputArray src7, InputArray src8, InputArray src9,
+                            OclVectorStrategy strat)
+{
+    int ref_type = src1.type();
 
     std::vector<size_t> offsets, steps, cols;
     std::vector<int> dividers, kercns;


### PR DESCRIPTION
Changed predictOptimalVectorWidth function, now it is possible to choose vector size.

check_regression=_OCL_
test_filter=_OCL_
build_examples=OFF
