### PR TITLE
Disabled videoio video_prop_fps test

### DIFF
--- a/modules/videoio/test/test_basic_props.cpp
+++ b/modules/videoio/test/test_basic_props.cpp
@@ -108,7 +108,7 @@ TEST(Videoio_Video, actual_resolution)
     }
 }
 
-TEST(Videoio_Video, prop_fps)
+TEST(Videoio_Video, DISABLED_prop_fps)
 {
     const size_t n = sizeof(ext)/sizeof(ext[0]);
     const string src_dir = TS::ptr()->get_data_path();


### PR DESCRIPTION
This test does not return correct values with some software configurations. It has already been disabled on branch 2.4.
It is possible problem with ffmpeg on buildbot's linux-slave (ubuntu 14.04). Other machines with different ffmpeg versions work good.
