### PR TITLE
OCL: Added extra checks to Image2D

### DIFF
--- a/modules/core/test/ocl/test_image2d.cpp
+++ b/modules/core/test/ocl/test_image2d.cpp
@@ -13,12 +13,55 @@
 namespace cvtest {
 namespace ocl {
 
-PARAM_TEST_CASE(Image2DBasicTest, int, int)
+TEST(Image2D, createAliasEmptyUMat)
 {
-    int depth, ch;
+    if (cv::ocl::haveOpenCL())
+    {
+        UMat um;
+        EXPECT_FALSE(cv::ocl::Image2D::canCreateAlias(um));
+    }
+    else
+        std::cout << "OpenCL runtime not found. Test skipped." << std::endl;
+}
 
+TEST(Image2D, createImage2DWithEmptyUMat)
+{
+    if (cv::ocl::haveOpenCL())
+    {
+        UMat um;
+        EXPECT_ANY_THROW(cv::ocl::Image2D image(um));
+    }
+    else
+        std::cout << "OpenCL runtime not found. Test skipped." << std::endl;
+}
 
-};
+TEST(Image2D, createAlias)
+{
+    if (cv::ocl::haveOpenCL())
+    {
+        const cv::ocl::Device & d = cv::ocl::Device::getDefault();
+        int minor = d.deviceVersionMinor(), major = d.deviceVersionMajor();
+
+        // aliases is OpenCL 1.2 extension
+        if (1 < major || (1 == major && 2 <= minor))
+        {
+            UMat um(128, 128, CV_8UC1);
+            bool isFormatSupported = false, canCreateAlias = false;
+
+            EXPECT_NO_THROW(isFormatSupported = cv::ocl::Image2D::isFormatSupported(CV_8U, 1, false));
+            EXPECT_NO_THROW(canCreateAlias = cv::ocl::Image2D::canCreateAlias(um));
+
+            if (isFormatSupported && canCreateAlias)
+            {
+                EXPECT_NO_THROW(cv::ocl::Image2D image(um, false, true));
+            }
+            else
+                std::cout << "Impossible to create alias for selected image. Test skipped." << std::endl;
+        }
+    }
+    else
+        std::cout << "OpenCL runtime not found. Test skipped" << std::endl;
+}
 
 TEST(Image2D, turnOffOpenCL)
 {
@@ -26,16 +69,26 @@ TEST(Image2D, turnOffOpenCL)
     {
         // save the current state
         bool useOCL = cv::ocl::useOpenCL();
+        bool isFormatSupported = false;
 
         cv::ocl::setUseOpenCL(true);
         UMat um(128, 128, CV_8UC1);
 
         cv::ocl::setUseOpenCL(false);
-        cv::ocl::Image2D image(um);
+        EXPECT_NO_THROW(isFormatSupported = cv::ocl::Image2D::isFormatSupported(CV_8U, 1, true));
+
+        if (isFormatSupported)
+        {
+            EXPECT_NO_THROW(cv::ocl::Image2D image(um));
+        }
+        else
+            std::cout << "CV_8UC1 is not supported for OpenCL images. Test skipped." << std::endl;
     
         // reset state to the previous one
         cv::ocl::setUseOpenCL(useOCL);
     }
+    else
+        std::cout << "OpenCL runtime not found. Test skipped." << std::endl;
 }
 
 } } // namespace cvtest::ocl


### PR DESCRIPTION
- Added accuracy tests for ocl::Image2D.
- Added some check condtitions to Image2D class to prevent incorrect work when UMat is empty or have incorrect handle. Also it prevents using Image2D if OpenCL runtime not found.

test_filter=_Image2D_
test_modules=core
build_examples=OFF
