### PR TITLE
superres: Fix return value VideoFrameSource_GPU

### DIFF
--- a/modules/superres/src/frame_source.cpp
+++ b/modules/superres/src/frame_source.cpp
@@ -260,7 +260,7 @@ namespace
 
 Ptr<FrameSource> cv::superres::createFrameSource_Video_GPU(const string& fileName)
 {
-    return new VideoFrameSource(fileName);
+    return new VideoFrameSource_GPU(fileName);
 }
 
 #endif // HAVE_OPENCV_GPU


### PR DESCRIPTION
superres module fails to compile with the following error messages:

[100%] Building CXX object modules/superres/CMakeFiles/opencv_superres.dir/src/super_resolution.cpp.o
/opencv-2.4.10/modules/superres/src/frame_source.cpp: In function 'cv::Ptrcv::superres::FrameSource cv::superres::createFrameSource_Video_GPU(const string&)':
/opencv-2.4.10/modules/superres/src/frame_source.cpp:263:16: error: expected type-specifier before 'VideoFrameSource'
/opencv-2.4.10/modules/superres/src/frame_source.cpp:263:16: error: could not convert '(int_)operator new(4ul)' from 'int_' to 'cv::Ptrcv::superres::FrameSource'
/opencv-2.4.10/modules/superres/src/frame_source.cpp:263:16: error: expected ';' before 'VideoFrameSource'
/opencv-2.4.10/modules/superres/src/frame_source.cpp:263:41: error: 'VideoFrameSource' was not declared in this scope
/opencv-2.4.10/modules/superres/src/frame_source.cpp:264:1: error: control reaches end of non-void function [-Werror=return-type]
cc1plus: some warnings being treated as errors
make[3]: **\* [modules/superres/CMakeFiles/opencv_superres.dir/src/frame_source.cpp.o] Error 1
make[3]: **\* Waiting for unfinished jobs....

This is caused because the return value of the createFrameSource_Video_GPU function should be a VideoFrameSource_GPU object.
