### PR TITLE
GFTT with empty image

### DIFF
--- a/modules/imgproc/src/featureselect.cpp
+++ b/modules/imgproc/src/featureselect.cpp
@@ -275,6 +275,12 @@ void cv::goodFeaturesToTrack( InputArray _image, OutputArray _corners,
                                     _mask, blockSize, useHarrisDetector, harrisK))
 
     Mat image = _image.getMat(), eig, tmp;
+    if (image.empty())
+    {
+        _corners.release();
+        return;
+    }
+
     if( useHarrisDetector )
         cornerHarris( image, eig, blockSize, 3, harrisK );
     else


### PR DESCRIPTION
GFTT on empty image doesn't need to do processing, just return empty result.
It makes happy IPP build check.

test_filter=_Features2d_Detector_
test_modules=features2d
build_examples=OFF
