### PR TITLE
Fixed calc_output_scale with NO_OUTPUT_SCALE flag set.

### DIFF
--- a/modules/ml/src/ann_mlp.cpp
+++ b/modules/ml/src/ann_mlp.cpp
@@ -618,7 +618,7 @@ public:
                     scale[j*2] = mj;
                     scale[j*2+1] = Mj;
                 }
-                else
+                else if( !no_scale )
                 {
                     t = t*inv_scale[j*2] + inv_scale[2*j+1];
                     if( t < m1 || t > M1 )


### PR DESCRIPTION
This change makes it possible to train an MLP by using only 1 input vector at a time. Otherwise the second training run would fail with out of range error.
