### PR TITLE
OCL: fix for cv::pow

### DIFF
--- a/modules/core/src/mathfuncs.cpp
+++ b/modules/core/src/mathfuncs.cpp
@@ -2478,8 +2478,8 @@ static bool ocl_pow(InputArray _src, double power, OutputArray _dst,
     if (depth == CV_64F && !doubleSupport)
         return false;
 
-    bool issqrt = std::abs(power - 0.5) < DBL_EPSILON, nonnegative = power >= 0;
-    const char * const op = issqrt ? "OP_SQRT" : is_ipower ? nonnegative ? "OP_POWN" : "OP_ROOTN" : nonnegative ? "OP_POWR" : "OP_POW";
+    bool issqrt = std::abs(power - 0.5) < DBL_EPSILON;
+    const char * const op = issqrt ? "OP_SQRT" : is_ipower ? "OP_POWN" : "OP_POW";
 
     ocl::Kernel k("KF", ocl::core::arithm_oclsrc,
                   format("-D dstT=%s -D depth=%d -D rowsPerWI=%d -D %s -D UNARY_OP%s",

--- a/modules/core/src/opencl/arithm.cl
+++ b/modules/core/src/opencl/arithm.cl
@@ -277,16 +277,6 @@
 #elif defined OP_POW
 #define PROCESS_ELEM storedst(pow(srcelem1, srcelem2))
 
-#elif defined OP_ROOTN
-#define PROCESS_ELEM storedst(rootn(srcelem1, srcelem2))
-
-#elif defined OP_POWR
-#if depth == 5
-#define PROCESS_ELEM storedst(native_powr(srcelem1, srcelem2))
-#else
-#define PROCESS_ELEM storedst(powr(srcelem1, srcelem2))
-#endif
-
 #elif defined OP_POWN
 #undef workT
 #define workT int


### PR DESCRIPTION
Thanks Yuri Kulakov for reporting issue: http://code.opencv.org/issues/3977.

check_regression=_OCL_Pow*
test_filter=_OCL_Pow*
test_modules=core
build_examples=OFF
