### PR TITLE
OCL: fixed test for ocl WarpAffine

### DIFF
--- a/modules/imgproc/test/ocl/test_warp.cpp
+++ b/modules/imgproc/test/ocl/test_warp.cpp
@@ -121,7 +121,7 @@ OCL_TEST_P(WarpAffine, Mat)
 {
     for (int j = 0; j < test_loop_times; j++)
     {
-        double eps = depth < CV_32F ? 0.03 : 0.06;
+        double eps = depth < CV_32F ? 0.04 : 0.06;
         random_roi();
 
         Mat M = getRotationMatrix2D(Point2f(src_roi.cols / 2.0f, src_roi.rows / 2.0f),


### PR DESCRIPTION
detected with test_loop_times = 40

check_regression=OCL_WarpAffine_
test_filter=OCL_WarpAffine_
test_modules=imgproc
build_examples=OFF
