### PR TITLE
Suppress a bogus -Warray-bounds in modules/superres/src/optical_flow.cpp

### DIFF
--- a/cmake/OpenCVPCHSupport.cmake
+++ b/cmake/OpenCVPCHSupport.cmake
@@ -147,9 +147,9 @@ MACRO(_PCH_GET_TARGET_COMPILE_FLAGS _cflags  _header_name _pch_path _dowarn )
         # if you have different versions of the headers for different build types
         # you may set _pch_dowarn
         IF (_dowarn)
-            SET(${_cflags} "${PCH_ADDITIONAL_COMPILER_FLAGS} -include \"${CMAKE_CURRENT_BINARY_DIR}/${_header_name}\" -Winvalid-pch " )
+            set(${_cflags} "${PCH_ADDITIONAL_COMPILER_FLAGS} -Winvalid-pch")
         ELSE (_dowarn)
-            SET(${_cflags} "${PCH_ADDITIONAL_COMPILER_FLAGS} -include \"${CMAKE_CURRENT_BINARY_DIR}/${_header_name}\" " )
+            set(${_cflags} "${PCH_ADDITIONAL_COMPILER_FLAGS}")
         ENDIF (_dowarn)
 
     ELSE(CMAKE_COMPILER_IS_GNUCXX)

--- a/modules/superres/src/optical_flow.cpp
+++ b/modules/superres/src/optical_flow.cpp
@@ -40,6 +40,20 @@
 //
 //M*/
 
+#if defined(__arm__) && defined(__GNUC__) && (__GNUC__ == 4) && (__GNUC_MINOR__ >= 8)
+// While compiling CV_INIT_ALGORITHM(Farneback_GPU, ...) below, GCC emits a bogus
+// -Warray-bounds warning in GpuMat::~GpuMat. Also, for some reason, suppressing
+// it inside precomp.hpp doesn't work (probably because it's precompiled).
+// Thus, we include this before it's included by precomp.hpp.
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Warray-bounds"
+#include "opencv2/core/gpumat.hpp"
+#pragma GCC diagnostic pop
+
+// Even more strangely, this suppression doesn't work when cross-compiling.
+// For that, there's another suppression at the bottom of the file.
+#endif
+
 #include "precomp.hpp"
 
 using namespace std;
@@ -986,7 +1000,8 @@ Ptr<DenseOpticalFlowExt> cv::superres::createOptFlow_Farneback_OCL()
 
 #endif
 
-// Suppress specific warnings during cross-compilation for ARM
-#if defined(__arm__) && defined(__GNUC__) && (__GNUC__ == 4) && (__GNUC_MINOR__ == 8)
+// Even though this looks as if it covers nothing, it actually suppress a warning in
+// CV_INIT_ALGORITHM(Farneback_GPU, ...). See the top comment for more explanation.
+#if defined(__arm__) && defined(__GNUC__) && (__GNUC__ == 4) && (__GNUC_MINOR__ >= 8)
 # pragma GCC diagnostic ignored "-Warray-bounds"
 #endif


### PR DESCRIPTION
I delete the suppression from the bottom of the file, since it seems to be redundant (it doesn't cover any code).

I also remove the forced inclusion of precompiled headers into all sources, since otherwise this workaround doesn't work - the header with the warning is included before I can use a pragma.
