### PR TITLE
Fix canny segment fault (Bug #3978)

### DIFF
--- a/modules/imgproc/src/canny.cpp
+++ b/modules/imgproc/src/canny.cpp
@@ -453,7 +453,7 @@ void cv::Canny( InputArray _src, OutputArray _dst,
         if ((stack_top - stack_bottom) + src.cols > maxsize)
         {
             int sz = (int)(stack_top - stack_bottom);
-            maxsize = maxsize * 3/2;
+            maxsize = std::max(maxsize * 3/2, sz + src.cols);
             stack.resize(maxsize);
             stack_bottom = &stack[0];
             stack_top = stack_bottom + sz;


### PR DESCRIPTION
Avoid too large size cause std::vector::resize() failed.
Please refer to http://code.opencv.org/issues/3978.

check_regression=_anny_
