### PR TITLE
Fix for OS X compilation error in window_cocoa.mm

### DIFF
--- a/modules/highgui/src/window_cocoa.mm
+++ b/modules/highgui/src/window_cocoa.mm
@@ -150,7 +150,7 @@ CV_IMPL int cvInitSystem( int , char** )
 #define NSAppKitVersionNumber10_5 949
 #endif
     if( floor(NSAppKitVersionNumber) > NSAppKitVersionNumber10_5 )
-        [application setActivationPolicy:0/*NSApplicationActivationPolicyRegular*/];
+        [application setActivationPolicy:NSApplicationActivationPolicyRegular];
 #endif
     //[application finishLaunching];
     //atexit(icvCocoaCleanup);


### PR DESCRIPTION
Un-commented `NSApplicationActivationPolicyRegular` argument (in leu of zero) and got rid of problematic dereference – OpenCV compiles again on OS X as of this change
