### PR TITLE
Ieee1934 camera set params

### DIFF
--- a/modules/highgui/include/opencv2/highgui/highgui_c.h
+++ b/modules/highgui/include/opencv2/highgui/highgui_c.h
@@ -385,6 +385,7 @@ enum
     CV_CAP_PROP_ROLL          =35,
     CV_CAP_PROP_IRIS          =36,
     CV_CAP_PROP_SETTINGS      =37,
+    CV_CAP_PROP_BUFFERSIZE    =38,
 
     CV_CAP_PROP_AUTOGRAB      =1024, // property for highgui class CvCapture_Android only
     CV_CAP_PROP_SUPPORTED_PREVIEW_SIZES_STRING=1025, // readonly, tricky property, returns cpnst char* indeed

--- a/modules/highgui/src/cap_dc1394_v2.cpp
+++ b/modules/highgui/src/cap_dc1394_v2.cpp
@@ -278,6 +278,7 @@ CvCaptureCAM_DC1394_v2_CPP::CvCaptureCAM_DC1394_v2_CPP()
     dcCam = 0;
     isoSpeed = 400;
     fps = 15;
+    // Resetted the value here to 1 in order to ensure only a single frame is stored in the buffer!
     nDMABufs = 8;
     started = false;
     cameraId = 0;
@@ -731,6 +732,11 @@ bool CvCaptureCAM_DC1394_v2_CPP::setProperty(int propId, double value)
         if(started)
           return false;
         isoSpeed = cvRound(value);
+        break;
+    case CV_CAP_PROP_BUFFERSIZE:
+        if(started)
+            return false;
+        nDMABufs = value;
         break;
         //The code below is based on coriander, callbacks.c:795, refer to case RANGE_MENU_MAN :
          default:


### PR DESCRIPTION
For the firewire interface to the camera's one was not able to change the bufffer size which is standard set on 8. This codes add the ability to do so.

Confirmed to work on Ubuntu 14.04 x64 bit!
