### PR TITLE
ocl: Fix crash during destruction of gauss_w_lut object in hog.cpp

### DIFF
--- a/modules/ocl/include/opencv2/ocl/ocl.hpp
+++ b/modules/ocl/include/opencv2/ocl/ocl.hpp
@@ -1092,6 +1092,9 @@ namespace cv
             oclMat image_scale;
             // effect size of input image (might be different from original size after scaling)
             Size effect_size;
+
+        private:
+            oclMat gauss_w_lut;
         };
 
 

--- a/modules/ocl/src/hog.cpp
+++ b/modules/ocl/src/hog.cpp
@@ -55,7 +55,6 @@ using namespace cv::ocl;
 #define CELLS_PER_BLOCK_Y 2
 #define NTHREADS 256
 
-static oclMat gauss_w_lut;
 static bool hog_device_cpu;
 
 namespace cv


### PR DESCRIPTION
```
ocl: Fix crash during destruction of gauss_w_lut object in hog.cpp

gauss_w_lut is a statically defined variable of type oclMat.  The oclMat
destructor calls openCLFree() which via getInitializationMutex() accesses
the __module variable which has been statically defined in cl_context.cpp

Since the destruction order of statically defined variables in different
compilation units is undefined, it is possible that __module will
be destructed before gauss_w_lut, which would result in a segfault when
getInitializationMutex() is called while destructing gauss_w_lut.

In order to avoid this issue, we need to make gauss_w_lut a private
member of the HOGDescriptors class so we know it will be destroyed
before __module.
```

check_regression=_OCL_H*
test_modules=objdetect
test_filter=_OCL_H*
build_examples=OFF
