### PR TITLE
NCV.cu: include <algorithm>

### DIFF
--- a/modules/gpu/src/nvidia/core/NCV.cu
+++ b/modules/gpu/src/nvidia/core/NCV.cu
@@ -40,6 +40,7 @@
 //
 //M*/
 
+#include <algorithm>
 #include <iostream>
 #include <string>
 #include <vector>


### PR DESCRIPTION
It's needed for `std::max`.
