### PR TITLE
updated linux installation documentation

### DIFF
--- a/doc/tutorials/introduction/linux_install/linux_install.rst
+++ b/doc/tutorials/introduction/linux_install/linux_install.rst
@@ -7,16 +7,16 @@ These steps have been tested for Ubuntu 10.04 but should work with other distros
 Required Packages
 =================
 
-  * GCC 4.4.x or later
-  * CMake 2.8.7 or higher
-  * Git
-  * GTK+2.x or higher, including headers (libgtk2.0-dev)
-  * pkg-config
-  * Python 2.6 or later and Numpy 1.5 or later with developer packages (python-dev, python-numpy)
-  * ffmpeg or libav development packages: libavcodec-dev, libavformat-dev, libswscale-dev
-  * [optional] libtbb2 libtbb-dev
-  * [optional] libdc1394 2.x
-  * [optional] libjpeg-dev, libpng-dev, libtiff-dev, libjasper-dev, libdc1394-22-dev
+* GCC 4.4.x or later
+* CMake 2.8.7 or higher
+* Git
+* GTK+2.x or higher, including headers (libgtk2.0-dev)
+* pkg-config
+* Python 2.6 or later and Numpy 1.5 or later with developer packages (python-dev, python-numpy)
+* ffmpeg or libav development packages: libavcodec-dev, libavformat-dev, libswscale-dev
+* [optional] libtbb2 libtbb-dev
+* [optional] libdc1394 2.x
+* [optional] libjpeg-dev, libpng-dev, libtiff-dev, libjasper-dev, libdc1394-22-dev
 
 The packages can be installed using a terminal and the following commands or by using Synaptic Manager:
 
@@ -29,56 +29,121 @@ The packages can be installed using a terminal and the following commands or by 
 Getting OpenCV Source Code
 ==========================
 
-You can use the latest stable OpenCV version available in *sourceforge* or you can grab the latest snapshot from our `Git repository <https://github.com/Itseez/opencv.git>`_.
+You can use the latest stable OpenCV version or you can grab the latest snapshot from our `Git repository <https://github.com/Itseez/opencv.git>`_.
 
 Getting the Latest Stable OpenCV Version
 ----------------------------------------
 
-* Go to our `page on Sourceforge <http://sourceforge.net/projects/opencvlibrary>`_;
+* Go to our `downloads page <http://opencv.org/downloads.html>`_.
 
-* Download the source tarball and unpack it.
-
+* Download the source archive and unpack it.
 
 Getting the Cutting-edge OpenCV from the Git Repository
 -------------------------------------------------------
 
-Launch Git client and clone `OpenCV repository <http://github.com/itseez/opencv>`_
+Launch Git client and clone `OpenCV repository <http://github.com/itseez/opencv>`_.
+If you need modules from `OpenCV contrib repository <http://github.com/itseez/opencv_contrib>`_ then clone it too.
 
-In Linux it can be achieved with the following command in Terminal:
+For example
 
 .. code-block:: bash
 
-   cd ~/<my_working _directory>
+   cd ~/<my_working_directory>
    git clone https://github.com/Itseez/opencv.git
+   git clone https://github.com/Itseez/opencv_contrib.git
 
+Building OpenCV from Source Using CMake
+=======================================
 
-Building OpenCV from Source Using CMake, Using the Command Line
-===============================================================
-
-#. Create a temporary directory, which we denote as <cmake_binary_dir>, where you want to put the generated Makefiles, project files as well the object files and output binaries.
-
-#. Enter the <cmake_binary_dir> and type
-
-   .. code-block:: bash
-
-      cmake [<some optional parameters>] <path to the OpenCV source directory>
+#. Create a temporary directory, which we denote as <cmake_build_dir>, where you want to put the generated Makefiles, project files as well the object files and output binaries and enter there.
 
    For example
 
    .. code-block:: bash
 
       cd ~/opencv
-      mkdir release
-      cd release
-      cmake -D CMAKE_BUILD_TYPE=RELEASE -D CMAKE_INSTALL_PREFIX=/usr/local ..
+      mkdir build
+      cd build
 
-#. Enter the created temporary directory (<cmake_binary_dir>) and proceed with:
+#. Configuring. Run
+   cmake [<some optional parameters>] <path to the OpenCV source directory>
+
+   For example
 
    .. code-block:: bash
 
-      make -j8 # -j8 runs 8 jobs in parallel.
-               # Change 8 to number of hardware threads available.
+      cmake -D CMAKE_BUILD_TYPE=Release -D CMAKE_INSTALL_PREFIX=/usr/local ..
+
+   or cmake-gui
+
+   * set full path to OpenCV source code, e.g. /home/user/opencv
+   * set full path to <cmake_build_dir>, e.g. /home/user/opencv/build
+   * set optional parameters
+   * run: “Configure”
+   * run: “Generate”
+
+#. Description of some parameters
+
+   * build type: CMAKE_BUILD_TYPE=Release\\Debug
+   * to build with modules from opencv_contrib set OPENCV_EXTRA_MODULES_PATH to <path to opencv_contrib/modules/>
+   * set BUILD_DOCS for building documents
+   * set BUILD_EXAMPLES to build all examples
+
+#. [optional] Building python. Set the following python parameters:
+
+   * PYTHON2(3)_EXECUTABLE = <path to python>
+   * PYTHON_INCLUDE_DIR = /usr/include/python<version>
+   * PYTHON_INCLUDE_DIR2 = /usr/include/x86_64-linux-gnu/python<version>
+   * PYTHON_LIBRARY = /usr/lib/x86_64-linux-gnu/libpython<version>.so
+   * PYTHON2(3)_NUMPY_INCLUDE_DIRS = /usr/lib/python<version>/dist-packages/numpy/core/include/
+
+#. [optional] Building java.
+
+   * Unset parameter: BUILD_SHARED_LIBS
+   * It is useful also to unset BUILD_EXAMPLES, BUILD_TESTS, BUILD_PERF_TESTS - as they all will be statically linked with OpenCV and can take a lot of memory.
+
+#. Build. From build directory execute make, recomend to do it in several threads
+
+   For example
+
+   .. code-block:: bash
+
+      make -j7 # runs 7 jobs in parallel
+
+#. [optional] Building documents. Enter <cmake_build_dir/doc/> and run make with target "html_docs"
+
+   For example
+
+   .. code-block:: bash
+
+      cd ~/opencv/build/doc/
+      make -j7 html_docs
+
+#. To install libraries, from build directory execute
+
+   .. code-block:: bash
+
       sudo make install
+
+#. [optional] Running tests
+
+   * Get the required test data from `OpenCV extra repository <https://github.com/Itseez/opencv_extra>`_.
+
+   For example
+
+   .. code-block:: bash
+
+      git clone https://github.com/Itseez/opencv_extra.git
+
+   * set OPENCV_TEST_DATA_PATH environment variable to <path to opencv_extra/testdata>.
+
+   * execute tests from build directory.
+
+   For example
+
+   .. code-block:: bash
+
+      <cmake_build_dir>/bin/opencv_test_core
 
 .. note::
 


### PR DESCRIPTION
@vpisarev,

I updated Linux installation document mostly for instructions how to use opencv_contrib dataset module for challenge and some other descriptions.
I also think maybe to move all installation guides, placed here:
http://docs.opencv.org/master/doc/tutorials/introduction/table_of_content_introduction/table_of_content_introduction.html
http://docs.opencv.org/master/doc/py_tutorials/py_setup/py_table_of_contents_setup/py_table_of_contents_setup.html
to one topic. Please, let me know what do you think about it, we can create separate PR for that.
