### PR TITLE
Fixed variable name consistency in video module

### DIFF
--- a/modules/video/doc/motion_analysis_and_object_tracking.rst
+++ b/modules/video/doc/motion_analysis_and_object_tracking.rst
@@ -911,11 +911,11 @@ Calculates an optical flow.
 
 .. ocv:function:: void DenseOpticalFlow::calc(InputArray I0, InputArray I1, InputOutputArray flow)
 
-    :param prev: first 8-bit single-channel input image.
+    :param I0: first 8-bit single-channel input image.
 
-    :param next: second input image of the same size and the same type as ``prev`` .
+    :param I1: second input image of the same size and the same type as ``I0`` .
 
-    :param flow: computed flow image that has the same size as ``prev`` and type ``CV_32FC2`` .
+    :param flow: computed flow image that has the same size as ``I0`` and type ``CV_32FC2`` .
 
 
 


### PR DESCRIPTION
The function parameters were different from the ones described below.

P.S. Why is `flow` InputOutputArray, shouldn't it be just OutputArray? If so, shouldn't the reason be specified - e.g. so others can benefit as well (e.g. not allocating memory on every frame?)
