### PR TITLE
Fix debug build broken issue.

### DIFF
--- a/modules/python/common.cmake
+++ b/modules/python/common.cmake
@@ -38,6 +38,7 @@ endforeach(m)
 ocv_list_filterout(opencv_hdrs ".h$")
 ocv_list_filterout(opencv_hdrs "cuda")
 ocv_list_filterout(opencv_hdrs "cudev")
+ocv_list_filterout(opencv_hdrs "ts")
 ocv_list_filterout(opencv_hdrs "opencv2/objdetect/detection_based_tracker.hpp")
 
 set(cv2_generated_hdrs


### PR DESCRIPTION
Fix the following error:
/usr/bin/ld: ../../lib/libopencv_ts.a(ts_gtest.cpp.o): relocation
R_X86_64_32 against `.rodata' can not be used when making a shared object;
recompile with -fPIC
../../lib/libopencv_ts.a: could not read symbols: Bad value
collect2: error: ld returned 1 exit status
make[2]: **\* [lib/cv2.so] Error 1
make[1]: **\* [modules/python2/CMakeFiles/opencv_python2.dir/all] Error 2
make: **\* [all] Error 2
