### PR TITLE
Remove redundant -mfpu=neon flag.

### DIFF
--- a/cmake/OpenCVCompilerOptions.cmake
+++ b/cmake/OpenCVCompilerOptions.cmake
@@ -171,10 +171,6 @@ if(CMAKE_COMPILER_IS_GNUCXX)
     endif()
   endif()
 
-  if(ENABLE_NEON)
-    add_extra_compiler_option(-mfpu=neon)
-  endif()
-
   # Profiling?
   if(ENABLE_PROFILING)
     add_extra_compiler_option("-pg -g")


### PR DESCRIPTION
This flag is already added in line 131.
