### PR TITLE
Fix compilation when building without the Video I/O module.

### DIFF
--- a/modules/videostab/src/frame_source.cpp
+++ b/modules/videostab/src/frame_source.cpp
@@ -70,7 +70,7 @@ public:
         if (!vc.isOpened())
             CV_Error(0, "can't open file: " + path_);
 #else
-        CV_Error(CV_StsNotImplemented, "OpenCV has been compiled without video I/O support");
+        CV_Error(Error::StsNotImplemented, "OpenCV has been compiled without video I/O support");
 #endif
     }
 


### PR DESCRIPTION
Simple compilation fix when trying to compile without the Video I/O module.
