### PR TITLE
OCL: [fast_nlmeans_denoising_opencl]Remove unnecessary if check.

### DIFF
--- a/modules/photo/src/fast_nlmeans_denoising_opencl.hpp
+++ b/modules/photo/src/fast_nlmeans_denoising_opencl.hpp
@@ -60,7 +60,7 @@ static bool ocl_calcAlmostDist2Weight(UMat & almostDist2Weight, int searchWindow
     if (k.empty())
         return false;
 
-    k.args(ocl::KernelArg::PtrWriteOnly(almostDist2Weight), almostMaxDist,
+    k.args(ocl::KernelArg::PtrWriteOnly(almostDist2Weight),
            almostDist2ActualDistMultiplier, fixedPointMult, den, WEIGHT_THRESHOLD);
 
     size_t globalsize[1] = { almostMaxDist };


### PR DESCRIPTION
From fast_nlmeans_denoising_opencl.hpp, this condition check is
unnecessary.
