### PR TITLE
Implementation of Pei&Lin Image Normalization

### DIFF
--- a/doc/opencv.bib
+++ b/doc/opencv.bib
@@ -291,6 +291,18 @@
     year = {2005}
 }
 
+@article{PeiLin95,
+    author = {Soo-Chang Pei and Chao-Nan Lin},
+    title = {Image normalization for pattern recognition},
+    journal = {Image and Vision Computing},
+    volume = {13},
+    number = {10},
+    pages = {711-723},
+    year = {1995},
+    issn = {0262-8856},
+    doi = {http://dx.doi.org/10.1016/0262-8856(95)98753-G}
+}
+
 # '''[Bradski98]''' G.R. Bradski. Computer vision face tracking as a component of a perceptual user interface. In Workshop on Applications of Computer Vision, pages 214?219, Princeton, NJ, Oct. 1998.<<BR>> Updated version can be found at http://www.intel.com/technology/itj/q21998/articles/art\_2.htm.<<BR>> Also, it is included into OpenCV distribution ([[attachment:camshift.pdf]])
 # '''[Burt81]''' P. J. Burt, T. H. Hong, A. Rosenfeld. Segmentation and Estimation of Image Region Properties Through Cooperative Hierarchical Computation. IEEE Tran. On SMC, Vol. 11, N.12, 1981, pp. 802-809.
 # '''[Canny86]''' J. Canny. A Computational Approach to Edge Detection, IEEE Trans. on Pattern Analysis and Machine Intelligence, 8(6), pp. 679-698 (1986).

--- a/modules/imgproc/doc/geometric_transformations.rst
+++ b/modules/imgproc/doc/geometric_transformations.rst
@@ -733,3 +733,17 @@ The function is similar to
 where ``undistort()`` is an approximate iterative algorithm that estimates the normalized original point coordinates out of the normalized distorted point coordinates ("normalized" means that the coordinates do not depend on the camera matrix).
 
 The function can be used for both a stereo camera head or a monocular camera (when R is empty).
+
+
+
+
+PeiLinNormalization
+-------------------
+Calculates an affine transformation normalizing given image.
+
+.. ocv:function:: Matx23d PeiLinNormalization ( InputArray I )
+
+Assume given image :math:`I=T(\bar{I})` where :math:`\bar{I}` is a normalized image and :math:`T` is is an affine transformation distorting this image by translation, rotation, scaling and skew.
+The function returns an affine transformation matrix corresponding to the transformation :math:`T^{-1}` described in [PeiLin95].
+
+.. [PeiLin95] Soo-Chang Pei and Chao-Nan Lin. Image normalization for pattern recognition. Image and Vision Computing, Vol. 13, N.10, pp. 711-723, 1995.

--- a/modules/imgproc/include/opencv2/imgproc.hpp
+++ b/modules/imgproc/include/opencv2/imgproc.hpp
@@ -1327,6 +1327,9 @@ CV_EXPORTS_W Size getTextSize(const String& text, int fontFace,
                             double fontScale, int thickness,
                             CV_OUT int* baseLine);
 
+//! calculates an affine transformation normalizing given image
+CV_EXPORTS Matx23d PeiLinNormalization ( InputArray I );
+
 /** @} */
 
 } // cv

--- a/modules/imgproc/src/peilin.cpp
+++ b/modules/imgproc/src/peilin.cpp
@@ -1,0 +1,88 @@
+/*M///////////////////////////////////////////////////////////////////////////////////////
+//
+//  IMPORTANT: READ BEFORE DOWNLOADING, COPYING, INSTALLING OR USING.
+//
+//  By downloading, copying, installing or using the software you agree to this license.
+//  If you do not agree to this license, do not download, install,
+//  copy or use the software.
+//
+//
+//                           License Agreement
+//                For Open Source Computer Vision Library
+//
+// Copyright (C) 2008, Willow Garage Inc., all rights reserved.
+// Third party copyrights are property of their respective owners.
+//
+// Redistribution and use in source and binary forms, with or without modification,
+// are permitted provided that the following conditions are met:
+//
+//   * Redistribution's of source code must retain the above copyright notice,
+//     this list of conditions and the following disclaimer.
+//
+//   * Redistribution's in binary form must reproduce the above copyright notice,
+//     this list of conditions and the following disclaimer in the documentation
+//     and/or other materials provided with the distribution.
+//
+//   * The name of Intel Corporation may not be used to endorse or promote products
+//     derived from this software without specific prior written permission.
+//
+// This software is provided by the copyright holders and contributors "as is" and
+// any express or implied warranties, including, but not limited to, the implied
+// warranties of merchantability and fitness for a particular purpose are disclaimed.
+// In no event shall the Intel Corporation or contributors be liable for any direct,
+// indirect, incidental, special, exemplary, or consequential damages
+// (including, but not limited to, procurement of substitute goods or services;
+// loss of use, data, or profits; or business interruption) however caused
+// and on any theory of liability, whether in contract, strict liability,
+// or tort (including negligence or otherwise) arising in any way out of
+// the use of this software, even if advised of the possibility of such damage.
+//
+//M*/
+#include "precomp.hpp"
+
+namespace cv
+{
+
+    inline Moments operator& ( const Moments & lhs, const Matx22d & rhs )
+    {
+        return Moments (
+            lhs.m00,
+            rhs ( 0, 0 ) * lhs.m10 + rhs ( 0, 1 ) * lhs.m01,
+            rhs ( 1, 0 ) * lhs.m10 + rhs ( 1, 1 ) * lhs.m01,
+            rhs ( 0, 0 ) * rhs ( 0, 0 ) * lhs.m20 + rhs ( 0, 1 ) * rhs ( 0, 1 ) * lhs.m02 + 2 * rhs ( 0, 0 ) * rhs ( 0, 1 ) * lhs.m11,
+            rhs ( 0, 0 ) * rhs ( 1, 0 ) * lhs.m20 + rhs ( 0, 1 ) * rhs ( 1, 1 ) * lhs.m02 + ( rhs ( 0, 0 ) * rhs ( 1, 1 ) + rhs ( 0, 1 ) * rhs ( 1, 0 ) ) * lhs.m11,
+            rhs ( 1, 0 ) * rhs ( 1, 0 ) * lhs.m20 + rhs ( 1, 1 ) * rhs ( 1, 1 ) * lhs.m02 + 2 * rhs ( 1, 0 ) * rhs ( 1, 1 ) * lhs.m11,
+            rhs ( 0, 0 ) * rhs ( 0, 0 ) * rhs ( 0, 0 ) * lhs.m30 + 3 * rhs ( 0, 0 ) * rhs ( 0, 0 ) * rhs ( 0, 1 ) * lhs.m21 + 3 * rhs ( 0, 0 ) * rhs ( 0, 1 ) * rhs ( 0, 1 ) * lhs.m12 + rhs ( 0, 1 ) * rhs ( 0, 1 ) * rhs ( 0, 1 ) * lhs.m03,
+            rhs ( 0, 0 ) * rhs ( 0, 0 ) * rhs ( 1, 0 ) * lhs.m30 + ( rhs ( 0, 0 ) * rhs ( 0, 0 ) * rhs ( 1, 1 ) + 2 * rhs ( 0, 0 ) * rhs ( 0, 1 ) * rhs ( 1, 0 ) ) * lhs.m21 + ( 2 * rhs ( 0, 0 ) * rhs ( 0, 1 ) * rhs ( 1, 1 ) + rhs ( 0, 1 ) * rhs ( 0, 1 ) * rhs ( 1, 0 ) ) * lhs.m12 + rhs ( 0, 1 ) * rhs ( 0, 1 ) * rhs ( 1, 1 ) * lhs.m03,
+            rhs ( 0, 0 ) * rhs ( 1, 0 ) * rhs ( 1, 0 ) * lhs.m30 + ( rhs ( 1, 0 ) * rhs ( 1, 0 ) * rhs ( 0, 1 ) + 2 * rhs ( 0, 0 ) * rhs ( 1, 0 ) * rhs ( 1, 1 ) ) * lhs.m21 + ( 2 * rhs ( 0, 1 ) * rhs ( 1, 0 ) * rhs ( 1, 1 ) + rhs ( 1, 1 ) * rhs ( 1, 1 ) * rhs ( 0, 0 ) ) * lhs.m12 + rhs ( 0, 1 ) * rhs ( 1, 1 ) * rhs ( 1, 1 ) * lhs.m03,
+            rhs ( 1, 0 ) * rhs ( 1, 0 ) * rhs ( 1, 0 ) * lhs.m30 + 3 * rhs ( 1, 0 ) * rhs ( 1, 0 ) * rhs ( 1, 1 ) * lhs.m21 + 3 * rhs ( 1, 0 ) * rhs ( 1, 1 ) * rhs ( 1, 1 ) * lhs.m12 + rhs ( 1, 1 ) * rhs ( 1, 1 ) * rhs ( 1, 1 ) * lhs.m03
+        );
+    }
+
+    inline Matx23d operator| ( const Matx22d & lhs, const Matx21d & rhs )
+    {
+        return Matx23d ( lhs ( 0, 0 ), lhs ( 0, 1 ), rhs ( 0 ), lhs ( 1, 0 ), lhs ( 1, 1 ), rhs ( 1 ) );
+    }
+
+    Matx23d PeiLinNormalization ( InputArray I )
+    {
+        const Moments  M = moments ( I );
+        const double  l1 = ( M.mu20 / M.m00 + M.mu02 / M.m00 + sqrt ( ( M.mu20 / M.m00 - M.mu02 / M.m00 ) * ( M.mu20 / M.m00 - M.mu02 / M.m00 ) + 4 * M.mu11 / M.m00 * M.mu11 / M.m00 ) ) / 2;
+        const double  l2 = ( M.mu20 / M.m00 + M.mu02 / M.m00 - sqrt ( ( M.mu20 / M.m00 - M.mu02 / M.m00 ) * ( M.mu20 / M.m00 - M.mu02 / M.m00 ) + 4 * M.mu11 / M.m00 * M.mu11 / M.m00 ) ) / 2;
+        const double  ex = ( M.mu11 / M.m00 ) / sqrt ( ( l1 - M.mu20 / M.m00 ) * ( l1 - M.mu20 / M.m00 ) + M.mu11 / M.m00 * M.mu11 / M.m00 );
+        const double  ey = ( l1 - M.mu20 / M.m00 ) / sqrt ( ( l1 - M.mu20 / M.m00 ) * ( l1 - M.mu20 / M.m00 ) + M.mu11 / M.m00 * M.mu11 / M.m00 );
+        const Matx22d  E = Matx22d ( ex, ey, -ey, ex );
+        const double   p = sqrt ( I.size().height * I.size().width ) / 8;
+        const Matx22d  W = Matx22d ( p / sqrt ( l1 ), 0, 0, p / sqrt ( l2 ) );
+        const Matx21d  c = Matx21d ( M.m10 / M.m00, M.m01 / M.m00 );
+        const Matx21d  i = Matx21d ( I.size().height / 2, I.size().width / 2 );
+        const Moments  N = M & W * E;
+        const double  t1 = N.mu12 + N.mu30;
+        const double  t2 = N.mu03 + N.mu21;
+        const double phi = atan2 ( -t1, t2 );
+        const double psi = ( -t1 * sin ( phi ) + t2 * cos ( phi ) >= 0 ) ? phi : ( phi + CV_PI  );
+        const Matx22d  A = Matx22d ( cos ( psi ), sin ( psi ), -sin ( psi ), cos ( psi ) );
+        return ( A * W * E ) | ( i - A * W * E * c );
+    }
+
+}


### PR DESCRIPTION
I've implemented transformation described in article [PeiLin] as a part of my master's thesis. I would be grateful if you would consider including it into OpenCV functionalities.

This transformation may be used to get normalized image, which is invariant to translation, rotation, scaling and skew. It may be used in the process of pattern recognition or in other fields of computer vision. Algorithm is quite simple and it don't need much computation.

---

[PeiLin]: Soo-Chang Pei and Chao-Nan Lin. Image normalization for pattern recognition. Image and Vision Computing, Vol. 13, N.10, pp. 711-723, 1995. doi: [0262-8856(95)98753-G](http://dx.doi.org/10.1016/0262-8856%2895%2998753-G)
