### PR TITLE
Simplify overengineered code

### DIFF
--- a/modules/videoio/src/cap_giganetix.cpp
+++ b/modules/videoio/src/cap_giganetix.cpp
@@ -393,7 +393,8 @@ CvCaptureCAM_Giganetix::open( int index )
 
     for (int i = 0; i < (int) DevicesList.size() && !b_ret; i++)
     {
-      if((b_ret = i == index))
+      b_ret = (i == index);
+      if(b_ret)
       {
         m_device = DevicesList[i];
         b_ret = m_device->Connect ();


### PR DESCRIPTION
The original code is correct but very hard to read. The new code is fully equivalent but easier to read and debug.

This was found using Cppcheck.
