### PR TITLE
Fix#3714:Improve Display Image Tutorial

### DIFF
--- a/doc/tutorials/introduction/display_image/display_image.rst
+++ b/doc/tutorials/introduction/display_image/display_image.rst
@@ -75,6 +75,8 @@ Now we call the :imread:`imread <>` function which loads the image name specifie
    :tab-width: 4
    :lines: 17
 
+If the second argument is not specified, it is implied ``CV_LOAD_IMAGE_COLOR``
+
 .. note::
 
    OpenCV offers support for the image formats Windows bitmap (bmp), portable image formats (pbm, pgm, ppm) and Sun raster (sr, ras). With help of plugins (you need to specify to use them if you build yourself the library, nevertheless in the packages we ship present by default) you may also load image formats like JPEG (jpeg, jpg, jpe), JPEG 2000 (jp2 - codenamed in the CMake as Jasper), TIFF files (tiff, tif) and portable network graphics (png). Furthermore, OpenEXR is also a possibility.
@@ -90,6 +92,8 @@ After checking that the image data was loaded correctly, we want to display our 
    :language: cpp
    :lines: 25
    :tab-width: 4
+
+If the second argument is not specified by the user, it is implied to be ``WINDOW_AUTOSIZE``, which means you can't change the size of the image.
 
 Finally, to update the content of the OpenCV window with a new image use the :imshow:`imshow <>` function. Specify the OpenCV window name to update and the image to use during this operation:
 

--- a/modules/highgui/doc/user_interface.rst
+++ b/modules/highgui/doc/user_interface.rst
@@ -83,6 +83,8 @@ The function ``imshow`` displays an image in the specified window. If the window
 
     * If the image is 32-bit floating-point, the pixel values are multiplied by 255. That is, the value range [0,1] is mapped to [0,255].
 
+If the window was not created before this function, it is assumed creating a window with ``CV_WINDOW_AUTOSIZE``.
+
 If window was created with OpenGL support, ``imshow`` also support :ocv:class:`ogl::Buffer` ,  :ocv:class:`ogl::Texture2D` and  :ocv:class:`gpu::GpuMat` as input.
 
 namedWindow


### PR DESCRIPTION
Changing both the documentation and the tutorial to better educate the users regarding to the implicit rule in imshow() function. (i.e. without creating the window before the imshow() function is the same as creating AUTOSIZE window)

For bug information, please check this link:http://code.opencv.org/issues/3714
For previous pull request comment, please refer to pull request #3441,#3455
