### PR TITLE
Add method in StatModel class, to load from a String

### DIFF
--- a/modules/ml/include/opencv2/ml.hpp
+++ b/modules/ml/include/opencv2/ml.hpp
@@ -827,15 +827,15 @@ public:
         return model->isTrained() ? model : Ptr<_Tp>();
     }
 
-    /** @brief Loads model from an XML String
-    @param strModel The string variable containing the model (in an XML format) you want to load.
+    /** @brief Loads model from a String
+    @param strModel The string variable containing the model you want to load.
 
     This is static template method of StatModel. It's usage is following (in the case of SVM):
-        Ptr<SVM> svm = StatModel::loadFromString<SVM>(myXMLStringModel);
+        Ptr<SVM> svm = StatModel::loadFromString<SVM>(myStringModel);
      */
     template<typename _Tp> static Ptr<_Tp> loadFromString(const String& strModel)
     {
-        FileStorage fs(strModel, FileStorage::READ + FileStorage::MEMORY + FileStorage::FORMAT_XML);
+        FileStorage fs(strModel, FileStorage::READ + FileStorage::MEMORY);
         Ptr<_Tp> model = _Tp::create();
         model->read(fs.getFirstTopLevelNode());
         return model->isTrained() ? model : Ptr<_Tp>();


### PR DESCRIPTION
Added a method "loadFromString", which is based on the "load" one, to the StatModel class. It
allow to directly pass a String of a saved model which can be usefull and faster when you have a huge trained file in a variable.
