### PR TITLE
White space and spelling in meanshift tutorial

### DIFF
--- a/doc/py_tutorials/py_video/py_meanshift/py_meanshift.rst
+++ b/doc/py_tutorials/py_video/py_meanshift/py_meanshift.rst
@@ -16,7 +16,7 @@ In this chapter,
 Meanshift
 ============
 
-The intuition behind the meanshift is simple. Consider you have a set of points. (It can be a pixel distribution like histogram backprojection). You are given a small window ( may be a circle) and you have to move that window to the area of maximum pixel density (or maximum number of points). It is illustrated in the simple image given below:
+The intuition behind the meanshift is simple. Consider you have a set of points. (It can be a pixel distribution like histogram backprojection). You are given a small window (maybe a circle) and you have to move that window to the area of maximum pixel density (or maximum number of points). It is illustrated in the simple image given below:
 
     .. image:: images/meanshift_basics.jpg
         :alt: Intuition behind meanshift


### PR DESCRIPTION
Removed a leading whitespace from a parenthetical comment and corrected the spelling of "maybe"
