### PR TITLE
OCL: [ORB]Use sincos instead of sin and cos.

### DIFF
--- a/modules/features2d/src/opencl/orb.cl
+++ b/modules/features2d/src/opencl/orb.cl
@@ -148,8 +148,8 @@ ORB_computeDescriptor(__global const uchar* imgbuf, int imgstep, int imgoffset0,
         float angle = as_float(kpt[KEYPOINT_ANGLE]);
         angle *= 0.01745329251994329547f;
 
-        float sina = sin(angle);
-        float cosa = cos(angle);
+        float cosa;
+        float sina = sincos(angle, &cosa);
 
         __global uchar* desc = _desc + idx*dsize;
 


### PR DESCRIPTION
Use OpenCL builtin sincos instead of sin and cos function.
Please help review it. Thanks.

check_regression=_OCL_ORB*
test_modules=features2d
