### PR TITLE
minor fix to make "updateBackgroundModel=false" option meaningful.

### DIFF
--- a/modules/video/src/bgfg_gmg.cpp
+++ b/modules/video/src/bgfg_gmg.cpp
@@ -280,7 +280,7 @@ namespace
                         }
                     }
                 }
-                else if (updateBackgroundModel_)
+                else
                 {
                     // training-mode update
 


### PR DESCRIPTION
Hi,
Without the change I just made, I think "updateBackgroundModel=false" option does not work as intended. I think the initial training phase should not be optional. Otherwise, it is not possible to model background when updateBackgroundModel=false.
Thanks.
Firat
