### PR TITLE
fix crash when sample point out of image boundaries

### DIFF
--- a/modules/photo/src/calibrate.cpp
+++ b/modules/photo/src/calibrate.cpp
@@ -89,7 +89,7 @@ public:
             int step_y = images[0].rows / y_points;
 
             for(int i = 0, x = step_x / 2; i < x_points; i++, x += step_x) {
-                for(int j = 0, y = step_y; j < y_points; j++, y += step_y) {
+                for(int j = 0, y = step_y / 2; j < y_points; j++, y += step_y) {
                     sample_points.push_back(Point(x, y));
                 }
             }


### PR DESCRIPTION
Sample point goes out of image boundaries under certain circumstances. This causes crash as point is used for pointer arithmetic [here](https://github.com/mapycz/opencv/blob/4c426fe26ecbefc4568136083644d50ca1a30ac7/modules/photo/src/calibrate.cpp#L107).
