### PR TITLE
Added assert statement for checking null data variable when initializing

### DIFF
--- a/modules/core/include/opencv2/core/mat.hpp
+++ b/modules/core/include/opencv2/core/mat.hpp
@@ -131,6 +131,7 @@ inline Mat::Mat(int _rows, int _cols, int _type, void* _data, size_t _step)
     data((uchar*)_data), refcount(0), datastart((uchar*)_data), dataend(0),
     datalimit(0), allocator(0), size(&rows)
 {
+    CV_DbgAssert( data != 0 );
     size_t esz = CV_ELEM_SIZE(_type), minstep = cols*esz;
     if( _step == AUTO_STEP )
     {
@@ -153,6 +154,7 @@ inline Mat::Mat(Size _sz, int _type, void* _data, size_t _step)
     data((uchar*)_data), refcount(0), datastart((uchar*)_data), dataend(0),
     datalimit(0), allocator(0), size(&rows)
 {
+    CV_DbgAssert( data != 0 );
     size_t esz = CV_ELEM_SIZE(_type), minstep = cols*esz;
     if( _step == AUTO_STEP )
     {


### PR DESCRIPTION
Sometimes people make a mistake that is initializing Mat object with external data variable actually null.
It is helpful to check if data is null before creating Mat object.
