### PR TITLE
Fix memory leaks appearing when cvOpenFileStorage throws

### DIFF
--- a/modules/core/src/persistence.cpp
+++ b/modules/core/src/persistence.cpp
@@ -2683,7 +2683,6 @@ CV_IMPL CvFileStorage*
 cvOpenFileStorage( const char* filename, CvMemStorage* dststorage, int flags, const char* encoding )
 {
     CvFileStorage* fs = 0;
-    char* xml_buf = 0;
     int default_block_size = 1 << 18;
     bool append = (flags & 3) == CV_STORAGE_APPEND;
     bool mem = (flags & CV_STORAGE_MEMORY) != 0;
@@ -2822,7 +2821,7 @@ cvOpenFileStorage( const char* filename, CvMemStorage* dststorage, int flags, co
                 int last_occurence = -1;
                 xml_buf_size = MIN(xml_buf_size, int(file_size));
                 fseek( fs->file, -xml_buf_size, SEEK_END );
-                xml_buf = (char*)cvAlloc( xml_buf_size+2 );
+                char* xml_buf = (char*)cvAlloc( xml_buf_size+2 );
                 // find the last occurence of </opencv_storage>
                 for(;;)
                 {
@@ -2840,6 +2839,7 @@ cvOpenFileStorage( const char* filename, CvMemStorage* dststorage, int flags, co
                         ptr += strlen(substr);
                     }
                 }
+                cvFree( &xml_buf );
                 if( last_occurence < 0 )
                 {
                     cvReleaseFileStorage( &fs );
@@ -2954,7 +2954,6 @@ _exit_:
         }
     }
 
-    cvFree( &xml_buf );
     return  fs;
 }
 


### PR DESCRIPTION
I'm not sure why a C function throws in the first place, but changing that would probably be too backwards-incompatible (not to mention time-consuming).
