### PR TITLE
fix documentation bug 2432

### DIFF
--- a/modules/core/doc/operations_on_arrays.rst
+++ b/modules/core/doc/operations_on_arrays.rst
@@ -1902,7 +1902,7 @@ Performs the per-element multiplication of two Fourier spectrums.
 
     :param dst: output array of the same size and type as ``src1`` .
 
-    :param flags: operation flags; currently, the only supported flag is ``DFT_ROWS``, which indicates that each row of ``src1`` and ``src2`` is an independent 1D Fourier spectrum.
+    :param flags: operation flags; currently, the only supported flag is ``DFT_ROWS``, which indicates that each row of ``src1`` and ``src2`` is an independent 1D Fourier spectrum. If you do not want to use this flag, then simply add a `0` as value.
 
     :param conjB: optional flag that conjugates the second input array before the multiplication (true) or not (false).
 

--- a/modules/core/include/opencv2/core.hpp
+++ b/modules/core/include/opencv2/core.hpp
@@ -1952,7 +1952,7 @@ arrays are real, they are assumed to be CCS-packed (see dft for details).
 @param b second input array of the same size and type as src1 .
 @param c output array of the same size and type as src1 .
 @param flags operation flags; currently, the only supported flag is cv::DFT_ROWS, which indicates that
-each row of src1 and src2 is an independent 1D Fourier spectrum.
+each row of src1 and src2 is an independent 1D Fourier spectrum. If you do not want to use this flag, then simply add a `0` as value.
 @param conjB optional flag that conjugates the second input array before the multiplication (true)
 or not (false).
 */

--- a/modules/cudaarithm/doc/arithm.rst
+++ b/modules/cudaarithm/doc/arithm.rst
@@ -55,7 +55,7 @@ Performs a per-element multiplication of two Fourier spectrums.
 
     :param dst: Destination spectrum.
 
-    :param flags: Mock parameter used for CPU/CUDA interfaces similarity.
+    :param flags: Mock parameter used for CPU/CUDA interfaces similarity, simply add a `0` value.
 
     :param conjB: Optional flag to specify if the second spectrum needs to be conjugated before the multiplication.
 

--- a/modules/cudaarithm/include/opencv2/cudaarithm.hpp
+++ b/modules/cudaarithm/include/opencv2/cudaarithm.hpp
@@ -892,7 +892,7 @@ CV_EXPORTS void mulSpectrums(InputArray src1, InputArray src2, OutputArray dst, 
 @param src1 First spectrum.
 @param src2 Second spectrum with the same size and type as a .
 @param dst Destination spectrum.
-@param flags Mock parameter used for CPU/CUDA interfaces similarity.
+@param flags Mock parameter used for CPU/CUDA interfaces similarity, simply add a `0` value.
 @param scale Scale constant.
 @param conjB Optional flag to specify if the second spectrum needs to be conjugated before the
 multiplication.


### PR DESCRIPTION
Extra default parameter makes it clear what to add if no flag is used.
Did the same for the CUDA equivalent even if it is a mocking parameter there.
