### PR TITLE
fix bug 2432 for 2.4 branch

### DIFF
--- a/modules/core/doc/operations_on_arrays.rst
+++ b/modules/core/doc/operations_on_arrays.rst
@@ -1997,7 +1997,7 @@ Performs the per-element multiplication of two Fourier spectrums.
 
     :param dst: output array of the same size and type as ``src1`` .
 
-    :param flags: operation flags; currently, the only supported flag is ``DFT_ROWS``, which indicates that each row of ``src1`` and ``src2`` is an independent 1D Fourier spectrum.
+    :param flags: operation flags; currently, the only supported flag is ``DFT_ROWS``, which indicates that each row of ``src1`` and ``src2`` is an independent 1D Fourier spectrum. If you do not want to use this flag, then simply add a `0` as value.
 
     :param conjB: optional flag that conjugates the second input array before the multiplication (true) or not (false).
 

--- a/modules/gpu/doc/image_processing.rst
+++ b/modules/gpu/doc/image_processing.rst
@@ -167,7 +167,7 @@ Performs a per-element multiplication of two Fourier spectrums.
 
     :param c: Destination spectrum.
 
-    :param flags: Mock parameter used for CPU/GPU interfaces similarity.
+    :param flags: Mock parameter used for CPU/GPU interfaces similarity, simply add a `0` value.
 
     :param conjB: Optional flag to specify if the second spectrum needs to be conjugated before the multiplication.
 


### PR DESCRIPTION
Same fix as https://github.com/Itseez/opencv/pull/3499 but then for the 2.4 branch since it was mentioned that there is no auto merge of branches into master anymore.
