### PR TITLE
Declare VideoCapture::get method as a const one (bug fix #2625).

### DIFF
--- a/modules/videoio/include/opencv2/videoio.hpp
+++ b/modules/videoio/include/opencv2/videoio.hpp
@@ -558,7 +558,7 @@ public:
     **Note**: When querying a property that is not supported by the backend used by the VideoCapture
     class, value 0 is returned.
      */
-    CV_WRAP virtual double get(int propId);
+    CV_WRAP virtual double get(int propId) const;
 
 protected:
     Ptr<CvCapture> cap;

--- a/modules/videoio/src/cap.cpp
+++ b/modules/videoio/src/cap.cpp
@@ -597,7 +597,7 @@ bool VideoCapture::set(int propId, double value)
     return cvSetCaptureProperty(cap, propId, value) != 0;
 }
 
-double VideoCapture::get(int propId)
+double VideoCapture::get(int propId) const
 {
     if (!icap.empty())
         return icap->getProperty(propId);


### PR DESCRIPTION
Since VideoCapture::get method is a getter then make it a const one. The same applies to the related methods like CvCapture::getProperty and IVideoCapture::getProperty.
(See http://code.opencv.org/issues/2625)
