### PR TITLE
Implement VideoCapture::get as a constant method (bug fix #2625).

### DIFF
--- a/modules/highgui/include/opencv2/highgui/highgui.hpp
+++ b/modules/highgui/include/opencv2/highgui/highgui.hpp
@@ -220,7 +220,7 @@ public:
     CV_WRAP virtual bool read(CV_OUT Mat& image);
 
     CV_WRAP virtual bool set(int propId, double value);
-    CV_WRAP virtual double get(int propId);
+    CV_WRAP virtual double get(int propId) const;
 
 protected:
     Ptr<CvCapture> cap;

--- a/modules/highgui/src/cap.cpp
+++ b/modules/highgui/src/cap.cpp
@@ -59,6 +59,11 @@ template<> void Ptr<CvVideoWriter>::delete_obj()
 
 /************************* Reading AVIs & Camera data **************************/
 
+static inline double icvGetCaptureProperty( const CvCapture* capture, int id )
+{
+    return capture ? capture->getProperty(id) : 0;
+}
+
 CV_IMPL void cvReleaseCapture( CvCapture** pcapture )
 {
     if( pcapture && *pcapture )
@@ -90,7 +95,7 @@ CV_IMPL IplImage* cvRetrieveFrame( CvCapture* capture, int idx )
 
 CV_IMPL double cvGetCaptureProperty( CvCapture* capture, int id )
 {
-    return capture ? capture->getProperty(id) : 0;
+    return icvGetCaptureProperty(capture, id);
 }
 
 CV_IMPL int cvSetCaptureProperty( CvCapture* capture, int id, double value )
@@ -581,9 +586,9 @@ bool VideoCapture::set(int propId, double value)
     return cvSetCaptureProperty(cap, propId, value) != 0;
 }
 
-double VideoCapture::get(int propId)
+double VideoCapture::get(int propId) const
 {
-    return cvGetCaptureProperty(cap, propId);
+    return icvGetCaptureProperty(cap, propId);
 }
 
 VideoWriter::VideoWriter()

--- a/modules/highgui/src/cap_android.cpp
+++ b/modules/highgui/src/cap_android.cpp
@@ -65,7 +65,7 @@ public:
     CvCapture_Android(int);
     virtual ~CvCapture_Android();
 
-    virtual double getProperty(int propIdx);
+    virtual double getProperty(int propIdx) const;
     virtual bool setProperty(int probIdx, double propVal);
     virtual bool grabFrame();
     virtual IplImage* retrieveFrame(int outputType);
@@ -257,7 +257,7 @@ CvCapture_Android::~CvCapture_Android()
     }
 }
 
-double CvCapture_Android::getProperty( int propIdx )
+double CvCapture_Android::getProperty( int propIdx ) const
 {
     switch ( propIdx )
     {

--- a/modules/highgui/src/cap_avfoundation.mm
+++ b/modules/highgui/src/cap_avfoundation.mm
@@ -93,7 +93,7 @@ class CvCaptureCAM : public CvCapture {
         virtual bool grabFrame();
         virtual IplImage* retrieveFrame(int);
         virtual IplImage* queryFrame();
-        virtual double getProperty(int property_id);
+        virtual double getProperty(int property_id) const;
         virtual bool setProperty(int property_id, double value);
         virtual int didStart();
 
@@ -136,7 +136,7 @@ class CvCaptureFile : public CvCapture {
         virtual bool grabFrame();
         virtual IplImage* retrieveFrame(int);
         virtual IplImage* queryFrame();
-        virtual double getProperty(int property_id);
+        virtual double getProperty(int property_id) const;
         virtual bool setProperty(int property_id, double value);
         virtual int didStart();
 
@@ -480,7 +480,7 @@ enum {
 typedef NSInteger AVCaptureWhiteBalanceMode;
 */
 
-double CvCaptureCAM::getProperty(int property_id){
+double CvCaptureCAM::getProperty(int property_id) const{
     NSAutoreleasePool* localpool = [[NSAutoreleasePool alloc] init];
 
     /*
@@ -1013,7 +1013,7 @@ double CvCaptureFile::getFPS() {
     return 30.0; //TODO: Debugging
 }
 
-double CvCaptureFile::getProperty(int property_id){
+double CvCaptureFile::getProperty(int property_id) const{
     (void)property_id;
     /*
          if (mCaptureSession == nil) return 0;

--- a/modules/highgui/src/cap_cmu.cpp
+++ b/modules/highgui/src/cap_cmu.cpp
@@ -68,7 +68,7 @@ public:
 
     virtual bool open(int cameraId);
     virtual void close();
-    virtual double getProperty(int);
+    virtual double getProperty(int) const;
     virtual bool setProperty(int, double);
     virtual bool grabFrame();
     virtual IplImage* retrieveFrame(int);
@@ -422,7 +422,7 @@ IplImage* CvCaptureCAM_CMU::retrieveFrame(int)
 }
 
 
-double CvCaptureCAM_CMU::getProperty( int property_id )
+double CvCaptureCAM_CMU::getProperty( int property_id ) const
 {
     C1394Camera* cmucam = camera();
     if( !cmucam )

--- a/modules/highgui/src/cap_dc1394.cpp
+++ b/modules/highgui/src/cap_dc1394.cpp
@@ -1049,7 +1049,7 @@ public:
     virtual bool open( int index );
     virtual void close();
 
-    virtual double getProperty(int);
+    virtual double getProperty(int) const;
     virtual bool setProperty(int, double);
     virtual bool grabFrame();
     virtual IplImage* retrieveFrame(int);
@@ -1085,7 +1085,7 @@ IplImage* CvCaptureCAM_DC1394_CPP::retrieveFrame(int)
     return captureDC1394 ? (IplImage*)icvRetrieveFrameCAM_DC1394( captureDC1394, 0 ) : 0;
 }
 
-double CvCaptureCAM_DC1394_CPP::getProperty( int propId )
+double CvCaptureCAM_DC1394_CPP::getProperty( int propId ) const
 {
     return captureDC1394 ? icvGetPropertyCAM_DC1394( captureDC1394, propId ) : 0;
 }

--- a/modules/highgui/src/cap_dc1394_v2.cpp
+++ b/modules/highgui/src/cap_dc1394_v2.cpp
@@ -207,7 +207,7 @@ public:
     virtual bool open(int index);
     virtual void close();
 
-    virtual double getProperty(int);
+    virtual double getProperty(int) const;
     virtual bool setProperty(int, double);
     virtual bool grabFrame();
     virtual IplImage* retrieveFrame(int);
@@ -653,8 +653,11 @@ IplImage* CvCaptureCAM_DC1394_v2_CPP::retrieveFrame(int idx)
     return 0 <= idx && idx < nimages ? img[idx] : 0;
 }
 
-double CvCaptureCAM_DC1394_v2_CPP::getProperty(int propId)
+double CvCaptureCAM_DC1394_v2_CPP::getProperty(int propId) const
 {
+    // Simulate mutable (C++11-like) member variable
+    dc1394featureset_t& fs = const_cast<dc1394featureset_t&>(feature_set);
+
     switch (propId)
     {
     case CV_CAP_PROP_FRAME_WIDTH:
@@ -667,14 +670,14 @@ double CvCaptureCAM_DC1394_v2_CPP::getProperty(int propId)
         return rectify ? 1 : 0;
     case CV_CAP_PROP_WHITE_BALANCE_U:
         if (dc1394_feature_whitebalance_get_value(dcCam,
-                                                  &feature_set.feature[DC1394_FEATURE_WHITE_BALANCE-DC1394_FEATURE_MIN].BU_value,
-                                                  &feature_set.feature[DC1394_FEATURE_WHITE_BALANCE-DC1394_FEATURE_MIN].RV_value) == DC1394_SUCCESS)
+                                                  &fs.feature[DC1394_FEATURE_WHITE_BALANCE-DC1394_FEATURE_MIN].BU_value,
+                                                  &fs.feature[DC1394_FEATURE_WHITE_BALANCE-DC1394_FEATURE_MIN].RV_value) == DC1394_SUCCESS)
         return feature_set.feature[DC1394_FEATURE_WHITE_BALANCE-DC1394_FEATURE_MIN].BU_value;
         break;
     case CV_CAP_PROP_WHITE_BALANCE_V:
         if (dc1394_feature_whitebalance_get_value(dcCam,
-                                                  &feature_set.feature[DC1394_FEATURE_WHITE_BALANCE-DC1394_FEATURE_MIN].BU_value,
-                                                  &feature_set.feature[DC1394_FEATURE_WHITE_BALANCE-DC1394_FEATURE_MIN].RV_value) == DC1394_SUCCESS)
+                                                  &fs.feature[DC1394_FEATURE_WHITE_BALANCE-DC1394_FEATURE_MIN].BU_value,
+                                                  &fs.feature[DC1394_FEATURE_WHITE_BALANCE-DC1394_FEATURE_MIN].RV_value) == DC1394_SUCCESS)
         return feature_set.feature[DC1394_FEATURE_WHITE_BALANCE-DC1394_FEATURE_MIN].RV_value;
         break;
     case CV_CAP_PROP_GUID:
@@ -693,7 +696,7 @@ double CvCaptureCAM_DC1394_v2_CPP::getProperty(int propId)
             && dcCam)
             //&& feature_set.feature[dc1394properties[propId]-DC1394_FEATURE_MIN].on_off_capable)
             if (dc1394_feature_get_value(dcCam,(dc1394feature_t)dc1394properties[propId],
-                &feature_set.feature[dc1394properties[propId]-DC1394_FEATURE_MIN].value) == DC1394_SUCCESS)
+                &fs.feature[dc1394properties[propId]-DC1394_FEATURE_MIN].value) == DC1394_SUCCESS)
               return feature_set.feature[dc1394properties[propId]-DC1394_FEATURE_MIN].value;
     }
     return -1; // the value of the feature can be 0, so returning 0 as an error is wrong

--- a/modules/highgui/src/cap_dshow.cpp
+++ b/modules/highgui/src/cap_dshow.cpp
@@ -3125,7 +3125,7 @@ public:
 
     virtual bool open( int index );
     virtual void close();
-    virtual double getProperty(int);
+    virtual double getProperty(int) const;
     virtual bool setProperty(int, double);
     virtual bool grabFrame();
     virtual IplImage* retrieveFrame(int);
@@ -3215,7 +3215,7 @@ IplImage* CvCaptureCAM_DShow::retrieveFrame(int)
         return NULL;
 }
 
-double CvCaptureCAM_DShow::getProperty( int property_id )
+double CvCaptureCAM_DShow::getProperty( int property_id ) const
 {
 
     long min_value,max_value,stepping_delta,current_value,flags,defaultValue;

--- a/modules/highgui/src/cap_ffmpeg.cpp
+++ b/modules/highgui/src/cap_ffmpeg.cpp
@@ -167,7 +167,7 @@ public:
     CvCapture_FFMPEG_proxy() { ffmpegCapture = 0; }
     virtual ~CvCapture_FFMPEG_proxy() { close(); }
 
-    virtual double getProperty(int propId)
+    virtual double getProperty(int propId) const
     {
         return ffmpegCapture ? icvGetCaptureProperty_FFMPEG_p(ffmpegCapture, propId) : 0;
     }

--- a/modules/highgui/src/cap_ffmpeg_impl.hpp
+++ b/modules/highgui/src/cap_ffmpeg_impl.hpp
@@ -217,7 +217,7 @@ struct CvCapture_FFMPEG
     bool open( const char* filename );
     void close();
 
-    double getProperty(int);
+    double getProperty(int) const;
     bool setProperty(int, double);
     bool grabFrame();
     bool retrieveFrame(int, unsigned char** data, int* step, int* width, int* height, int* cn);
@@ -228,12 +228,12 @@ struct CvCapture_FFMPEG
     void    seek(double sec);
     bool    slowSeek( int framenumber );
 
-    int64_t get_total_frames();
-    double  get_duration_sec();
-    double  get_fps();
-    int     get_bitrate();
+    int64_t get_total_frames() const;
+    double  get_duration_sec() const;
+    double  get_fps() const;
+    int     get_bitrate() const;
 
-    double  r2d(AVRational r);
+    double  r2d(AVRational r) const;
     int64_t dts_to_frame_number(int64_t dts);
     double  dts_to_sec(int64_t dts);
 
@@ -765,7 +765,7 @@ bool CvCapture_FFMPEG::retrieveFrame(int, unsigned char** data, int* step, int* 
 }
 
 
-double CvCapture_FFMPEG::getProperty( int property_id )
+double CvCapture_FFMPEG::getProperty( int property_id ) const
 {
     if( !video_st ) return 0;
 
@@ -803,12 +803,12 @@ double CvCapture_FFMPEG::getProperty( int property_id )
     return 0;
 }
 
-double CvCapture_FFMPEG::r2d(AVRational r)
+double CvCapture_FFMPEG::r2d(AVRational r) const
 {
     return r.num == 0 || r.den == 0 ? 0. : (double)r.num / (double)r.den;
 }
 
-double CvCapture_FFMPEG::get_duration_sec()
+double CvCapture_FFMPEG::get_duration_sec() const
 {
     double sec = (double)ic->duration / (double)AV_TIME_BASE;
 
@@ -825,12 +825,12 @@ double CvCapture_FFMPEG::get_duration_sec()
     return sec;
 }
 
-int CvCapture_FFMPEG::get_bitrate()
+int CvCapture_FFMPEG::get_bitrate() const
 {
     return ic->bit_rate;
 }
 
-double CvCapture_FFMPEG::get_fps()
+double CvCapture_FFMPEG::get_fps() const
 {
     double fps = r2d(ic->streams[video_stream]->r_frame_rate);
 
@@ -849,7 +849,7 @@ double CvCapture_FFMPEG::get_fps()
     return fps;
 }
 
-int64_t CvCapture_FFMPEG::get_total_frames()
+int64_t CvCapture_FFMPEG::get_total_frames() const
 {
     int64_t nbf = ic->streams[video_stream]->nb_frames;
 

--- a/modules/highgui/src/cap_giganetix.cpp
+++ b/modules/highgui/src/cap_giganetix.cpp
@@ -294,7 +294,7 @@ class CvCaptureCAM_Giganetix : public CvCapture
 
     virtual bool open( int index );
     virtual void close();
-    virtual double getProperty(int);
+    virtual double getProperty(int) const;
     virtual bool setProperty(int, double);
     virtual bool grabFrame();
     virtual IplImage* retrieveFrame(int);
@@ -599,7 +599,7 @@ CvCaptureCAM_Giganetix::retrieveFrame(int)
 
 /*----------------------------------------------------------------------------*/
 double
-CvCaptureCAM_Giganetix::getProperty( int property_id )
+CvCaptureCAM_Giganetix::getProperty( int property_id ) const
 {
   double d_ret = -1.0;
   INT64 i;

--- a/modules/highgui/src/cap_gstreamer.cpp
+++ b/modules/highgui/src/cap_gstreamer.cpp
@@ -123,7 +123,7 @@ public:
     virtual bool open( int type, const char* filename );
     virtual void close();
 
-    virtual double getProperty(int);
+    virtual double getProperty(int) const;
     virtual bool setProperty(int, double);
     virtual bool grabFrame();
     virtual IplImage* retrieveFrame(int);
@@ -838,7 +838,7 @@ bool CvCapture_GStreamer::open( int type, const char* filename )
  * For frame-based properties, we use the caps of the lasst receivef sample. This means that some properties
  * are not available until a first frame was received
  */
-double CvCapture_GStreamer::getProperty( int propId )
+double CvCapture_GStreamer::getProperty( int propId ) const
 {
     GstFormat format;
     gint64 value;

--- a/modules/highgui/src/cap_images.cpp
+++ b/modules/highgui/src/cap_images.cpp
@@ -80,7 +80,7 @@ public:
 
     virtual bool open(const char* _filename);
     virtual void close();
-    virtual double getProperty(int);
+    virtual double getProperty(int) const;
     virtual bool setProperty(int, double);
     virtual bool grabFrame();
     virtual IplImage* retrieveFrame(int);
@@ -126,7 +126,7 @@ IplImage* CvCapture_Images::retrieveFrame(int)
     return frame;
 }
 
-double CvCapture_Images::getProperty(int id)
+double CvCapture_Images::getProperty(int id) const
 {
     switch(id)
     {

--- a/modules/highgui/src/cap_intelperc.cpp
+++ b/modules/highgui/src/cap_intelperc.cpp
@@ -63,7 +63,7 @@ public:
     }
 public:
     virtual bool initStream(PXCSession *session)            = 0;
-    virtual double getProperty(int propIdx)
+    virtual double getProperty(int propIdx) const
     {
         double ret = 0.0;
         switch (propIdx)
@@ -236,7 +236,7 @@ public:
         enumProfiles();
         return true;
     }
-    virtual double getProperty(int propIdx)
+    virtual double getProperty(int propIdx) const
     {
         switch (propIdx)
         {
@@ -454,7 +454,7 @@ public:
         enumProfiles();
         return true;
     }
-    virtual double getProperty(int propIdx)
+    virtual double getProperty(int propIdx) const
     {
         switch (propIdx)
         {
@@ -613,7 +613,7 @@ public:
     }
     virtual ~CvCapture_IntelPerC(){}
 
-    virtual double getProperty(int propIdx)
+    virtual double getProperty(int propIdx) const
     {
         double propValue = 0;
         int purePropIdx = propIdx & ~CV_CAP_INTELPERC_GENERATORS_MASK;

--- a/modules/highgui/src/cap_libv4l.cpp
+++ b/modules/highgui/src/cap_libv4l.cpp
@@ -1712,7 +1712,7 @@ public:
     virtual bool open( int index );
     virtual void close();
 
-    virtual double getProperty(int);
+    virtual double getProperty(int) const;
     virtual bool setProperty(int, double);
     virtual bool grabFrame();
     virtual IplImage* retrieveFrame(int);
@@ -1747,7 +1747,7 @@ IplImage* CvCaptureCAM_V4L_CPP::retrieveFrame(int)
     return captureV4L ? icvRetrieveFrameCAM_V4L( captureV4L, 0 ) : 0;
 }
 
-double CvCaptureCAM_V4L_CPP::getProperty( int propId )
+double CvCaptureCAM_V4L_CPP::getProperty( int propId ) const
 {
     return captureV4L ? icvGetPropertyCAM_V4L( captureV4L, propId ) : 0.0;
 }

--- a/modules/highgui/src/cap_mil.cpp
+++ b/modules/highgui/src/cap_mil.cpp
@@ -69,7 +69,7 @@ public:
     virtual bool open( int index );
     virtual void close();
 
-    virtual double getProperty(int);
+    virtual double getProperty(int) const;
     virtual bool setProperty(int, double) { return false; }
     virtual bool grabFrame();
     virtual IplImage* retrieveFrame(int);
@@ -189,7 +189,7 @@ IplImage* CvCaptureCAM_MIL::retrieveFrame(int)
     return rgb_frame;
 }
 
-double CvCaptureCAM_MIL::getProperty( int property_id )
+double CvCaptureCAM_MIL::getProperty( int property_id ) const
 {
     switch( property_id )
     {

--- a/modules/highgui/src/cap_msmf.cpp
+++ b/modules/highgui/src/cap_msmf.cpp
@@ -560,8 +560,8 @@ public:
 #endif
     wchar_t *getName();
     int getCountFormats();
-    unsigned int getWidth();
-    unsigned int getHeight();
+    unsigned int getWidth() const;
+    unsigned int getHeight() const;
     unsigned int getFrameRate() const;
     MediaType getFormat(unsigned int id);
     bool setupDevice(unsigned int w, unsigned int h, unsigned int idealFramerate = 0);
@@ -677,9 +677,9 @@ public:
     // Getting numbers of formats, which are supported by videodevice with deviceID
     unsigned int getCountFormats(int deviceID);
     // Getting width of image, which is getting from videodevice with deviceID
-    unsigned int getWidth(int deviceID);
+    unsigned int getWidth(int deviceID) const;
     // Getting height of image, which is getting from videodevice with deviceID
-    unsigned int getHeight(int deviceID);
+    unsigned int getHeight(int deviceID) const;
     // Getting frame rate, which is getting from videodevice with deviceID
     unsigned int getFrameRate(int deviceID) const;
     // Getting name of videodevice with deviceID
@@ -2405,14 +2405,14 @@ void videoDevice::closeDevice()
         DebugPrintOut(L"VIDEODEVICE %i: Device is stopped \n", vd_CurrentNumber);
     }
 }
-unsigned int videoDevice::getWidth()
+unsigned int videoDevice::getWidth() const
 {
     if(vd_IsSetuped)
         return vd_Width;
     else
         return 0;
 }
-unsigned int videoDevice::getHeight()
+unsigned int videoDevice::getHeight() const
 {
     if(vd_IsSetuped)
         return vd_Height;
@@ -3316,7 +3316,7 @@ void videoInput::closeDevice(int deviceID)
     }
 }
 
-unsigned int videoInput::getWidth(int deviceID)
+unsigned int videoInput::getWidth(int deviceID) const
 {
     if (deviceID < 0)
     {
@@ -3337,7 +3337,7 @@ unsigned int videoInput::getWidth(int deviceID)
     return 0;
 }
 
-unsigned int videoInput::getHeight(int deviceID)
+unsigned int videoInput::getHeight(int deviceID) const
 {
     if (deviceID < 0)
     {
@@ -3585,7 +3585,7 @@ public:
     virtual ~CvCaptureCAM_MSMF();
     virtual bool open( int index );
     virtual void close();
-    virtual double getProperty(int);
+    virtual double getProperty(int) const;
     virtual bool setProperty(int, double);
     virtual bool grabFrame();
     virtual IplImage* retrieveFrame(int);
@@ -3710,7 +3710,7 @@ IplImage* CvCaptureCAM_MSMF::retrieveFrame(int)
     return frame;
 }
 
-double CvCaptureCAM_MSMF::getProperty( int property_id )
+double CvCaptureCAM_MSMF::getProperty( int property_id ) const
 {
     // image format proprrties
     switch( property_id )
@@ -3777,7 +3777,7 @@ public:
     virtual bool open( const char* filename );
     virtual void close();
 
-    virtual double getProperty(int);
+    virtual double getProperty(int) const;
     virtual bool setProperty(int, double);
     virtual bool grabFrame();
     virtual IplImage* retrieveFrame(int);
@@ -3791,7 +3791,7 @@ protected:
     bool isOpened;
 
     HRESULT enumerateCaptureFormats(IMFMediaSource *pSource);
-    HRESULT getSourceDuration(IMFMediaSource *pSource, MFTIME *pDuration);
+    HRESULT getSourceDuration(IMFMediaSource *pSource, MFTIME *pDuration) const;
 };
 
 CvCaptureFile_MSMF::CvCaptureFile_MSMF():
@@ -3896,7 +3896,7 @@ bool CvCaptureFile_MSMF::setProperty(int property_id, double value)
     return false;
 }
 
-double CvCaptureFile_MSMF::getProperty(int property_id)
+double CvCaptureFile_MSMF::getProperty(int property_id) const
 {
     // image format proprrties
     switch( property_id )
@@ -4008,7 +4008,7 @@ done:
     return hr;
 }
 
-HRESULT CvCaptureFile_MSMF::getSourceDuration(IMFMediaSource *pSource, MFTIME *pDuration)
+HRESULT CvCaptureFile_MSMF::getSourceDuration(IMFMediaSource *pSource, MFTIME *pDuration) const
 {
     *pDuration = 0;
 

--- a/modules/highgui/src/cap_openni.cpp
+++ b/modules/highgui/src/cap_openni.cpp
@@ -445,7 +445,7 @@ public:
     CvCapture_OpenNI(const char * filename);
     virtual ~CvCapture_OpenNI();
 
-    virtual double getProperty(int propIdx);
+    virtual double getProperty(int propIdx) const;
     virtual bool setProperty(int probIdx, double propVal);
     virtual bool grabFrame();
     virtual IplImage* retrieveFrame(int outputType);
@@ -781,7 +781,7 @@ bool CvCapture_OpenNI::readCamerasParams()
     return true;
 }
 
-double CvCapture_OpenNI::getProperty( int propIdx )
+double CvCapture_OpenNI::getProperty( int propIdx ) const
 {
     double propValue = 0;
 

--- a/modules/highgui/src/cap_pvapi.cpp
+++ b/modules/highgui/src/cap_pvapi.cpp
@@ -81,7 +81,7 @@ public:
 
     virtual bool open( int index );
     virtual void close();
-    virtual double getProperty(int);
+    virtual double getProperty(int) const;
     virtual bool setProperty(int, double);
     virtual bool grabFrame();
     virtual IplImage* retrieveFrame(int);
@@ -274,7 +274,7 @@ IplImage* CvCaptureCAM_PvAPI::retrieveFrame(int)
     else return NULL;
 }
 
-double CvCaptureCAM_PvAPI::getProperty( int property_id )
+double CvCaptureCAM_PvAPI::getProperty( int property_id ) const
 {
     tPvUint32 nTemp;
 

--- a/modules/highgui/src/cap_qt.cpp
+++ b/modules/highgui/src/cap_qt.cpp
@@ -1441,7 +1441,7 @@ public:
     virtual bool open( const char* filename );
     virtual void close();
 
-    virtual double getProperty(int);
+    virtual double getProperty(int) const;
     virtual bool setProperty(int, double);
     virtual bool grabFrame();
     virtual IplImage* retrieveFrame(int);
@@ -1477,7 +1477,7 @@ IplImage* CvCapture_QT_Movie_CPP::retrieveFrame(int)
     return captureQT ? (IplImage*)icvRetrieveFrame_QT_Movie( captureQT, 0 ) : 0;
 }
 
-double CvCapture_QT_Movie_CPP::getProperty( int propId )
+double CvCapture_QT_Movie_CPP::getProperty( int propId ) const
 {
     return captureQT ? icvGetProperty_QT_Movie( captureQT, propId ) : 0;
 }
@@ -1510,7 +1510,7 @@ public:
     virtual bool open( int index );
     virtual void close();
 
-    virtual double getProperty(int);
+    virtual double getProperty(int) const;
     virtual bool setProperty(int, double);
     virtual bool grabFrame();
     virtual IplImage* retrieveFrame(int);
@@ -1546,7 +1546,7 @@ IplImage* CvCapture_QT_Cam_CPP::retrieveFrame(int)
     return captureQT ? (IplImage*)icvRetrieveFrame_QT_Cam( captureQT, 0 ) : 0;
 }
 
-double CvCapture_QT_Cam_CPP::getProperty( int propId )
+double CvCapture_QT_Cam_CPP::getProperty( int propId ) const
 {
     return captureQT ? icvGetProperty_QT_Cam( captureQT, propId ) : 0;
 }

--- a/modules/highgui/src/cap_qtkit.mm
+++ b/modules/highgui/src/cap_qtkit.mm
@@ -111,7 +111,7 @@ public:
     ~CvCaptureCAM();
     virtual bool grabFrame();
     virtual IplImage* retrieveFrame(int);
-    virtual double getProperty(int property_id);
+    virtual double getProperty(int property_id) const;
     virtual bool setProperty(int property_id, double value);
     virtual int didStart();
 
@@ -153,7 +153,7 @@ public:
     ~CvCaptureFile();
     virtual bool grabFrame();
     virtual IplImage* retrieveFrame(int);
-    virtual double getProperty(int property_id);
+    virtual double getProperty(int property_id) const;
     virtual bool setProperty(int property_id, double value);
     virtual int didStart();
 
@@ -442,7 +442,7 @@ void CvCaptureCAM::setWidthHeight() {
 }
 
 
-double CvCaptureCAM::getProperty(int property_id){
+double CvCaptureCAM::getProperty(int property_id) const{
     int retval;
     NSAutoreleasePool* localpool = [[NSAutoreleasePool alloc] init];
 
@@ -835,7 +835,7 @@ double CvCaptureFile::getFPS() {
     return retval;
 }
 
-double CvCaptureFile::getProperty(int property_id){
+double CvCaptureFile::getProperty(int property_id) const{
     if (mCaptureSession == nil) return 0;
 
     NSAutoreleasePool* localpool = [[NSAutoreleasePool alloc] init];

--- a/modules/highgui/src/cap_tyzx.cpp
+++ b/modules/highgui/src/cap_tyzx.cpp
@@ -60,7 +60,7 @@ public:
     virtual void close();
     bool isOpened() { return index >= 0; }
 
-    virtual double getProperty(int);
+    virtual double getProperty(int) const;
     virtual bool setProperty(int, double) { return false; }
     virtual bool grabFrame();
     virtual IplImage* retrieveFrame(int);
@@ -185,7 +185,7 @@ IplImage * CvCaptureCAM_TYZX::retrieveFrame(int)
     return image;
 }
 
-double CvCaptureCAM_TYZX::getProperty(int property_id)
+double CvCaptureCAM_TYZX::getProperty(int property_id) const
 {
     CvSize size;
     switch(capture->index)

--- a/modules/highgui/src/cap_unicap.cpp
+++ b/modules/highgui/src/cap_unicap.cpp
@@ -62,7 +62,7 @@ struct CvCapture_Unicap : public CvCapture
   virtual bool open( int index );
   virtual void close();
 
-  virtual double getProperty(int);
+  virtual double getProperty(int) const;
   virtual bool setProperty(int, double);
   virtual bool grabFrame();
   virtual IplImage* retrieveFrame(int);
@@ -241,7 +241,7 @@ IplImage * CvCapture_Unicap::retrieveFrame(int) {
   return raw_frame;
 }
 
-double CvCapture_Unicap::getProperty(int id) {
+double CvCapture_Unicap::getProperty(int id) const{
   switch (id) {
   case CV_CAP_PROP_POS_MSEC: break;
   case CV_CAP_PROP_POS_FRAMES: break;

--- a/modules/highgui/src/cap_v4l.cpp
+++ b/modules/highgui/src/cap_v4l.cpp
@@ -2856,7 +2856,7 @@ public:
     virtual bool open( int index );
     virtual void close();
 
-    virtual double getProperty(int);
+    virtual double getProperty(int) const;
     virtual bool setProperty(int, double);
     virtual bool grabFrame();
     virtual IplImage* retrieveFrame(int);
@@ -2891,7 +2891,7 @@ IplImage* CvCaptureCAM_V4L_CPP::retrieveFrame(int)
     return captureV4L ? icvRetrieveFrameCAM_V4L( captureV4L, 0 ) : 0;
 }
 
-double CvCaptureCAM_V4L_CPP::getProperty( int propId )
+double CvCaptureCAM_V4L_CPP::getProperty( int propId ) const
 {
     return captureV4L ? icvGetPropertyCAM_V4L( captureV4L, propId ) : 0.0;
 }

--- a/modules/highgui/src/cap_vfw.cpp
+++ b/modules/highgui/src/cap_vfw.cpp
@@ -99,7 +99,7 @@ public:
     virtual bool open( const char* filename );
     virtual void close();
 
-    virtual double getProperty(int);
+    virtual double getProperty(int) const;
     virtual bool setProperty(int, double);
     virtual bool grabFrame();
     virtual IplImage* retrieveFrame(int);
@@ -238,7 +238,7 @@ IplImage* CvCaptureAVI_VFW::retrieveFrame(int)
     return 0;
 }
 
-double CvCaptureAVI_VFW::getProperty( int property_id )
+double CvCaptureAVI_VFW::getProperty( int property_id ) const
 {
     switch( property_id )
     {
@@ -317,7 +317,7 @@ public:
 
     virtual bool open( int index );
     virtual void close();
-    virtual double getProperty(int);
+    virtual double getProperty(int) const;
     virtual bool setProperty(int, double);
     virtual bool grabFrame();
     virtual IplImage* retrieveFrame(int);
@@ -541,7 +541,7 @@ IplImage* CvCaptureCAM_VFW::retrieveFrame(int)
 }
 
 
-double CvCaptureCAM_VFW::getProperty( int property_id )
+double CvCaptureCAM_VFW::getProperty( int property_id ) const
 {
     switch( property_id )
     {

--- a/modules/highgui/src/cap_ximea.cpp
+++ b/modules/highgui/src/cap_ximea.cpp
@@ -16,7 +16,7 @@ public:
 
     virtual bool open( int index );
     virtual void close();
-    virtual double getProperty(int);
+    virtual double getProperty(int) const;
     virtual bool setProperty(int, double);
     virtual bool grabFrame();
     virtual IplImage* retrieveFrame(int);
@@ -226,7 +226,7 @@ void CvCaptureCAM_XIMEA::resetCvImage()
 }
 /**********************************************************************************/
 
-double CvCaptureCAM_XIMEA::getProperty( int property_id )
+double CvCaptureCAM_XIMEA::getProperty( int property_id ) const
 {
     if(hmv == NULL)
         return 0;

--- a/modules/highgui/src/cap_xine.cpp
+++ b/modules/highgui/src/cap_xine.cpp
@@ -786,7 +786,7 @@ public:
     virtual bool open( const char* filename );
     virtual void close();
 
-    virtual double getProperty(int);
+    virtual double getProperty(int) const;
     virtual bool setProperty(int, double);
     virtual bool grabFrame();
     virtual IplImage* retrieveFrame(int);
@@ -821,7 +821,7 @@ IplImage* CvCaptureAVI_XINE_CPP::retrieveFrame(int)
     return captureXINE ? (IplImage*)icvRetrieveFrameAVI_XINE( captureXINE, 0 ) : 0;
 }
 
-double CvCaptureAVI_XINE_CPP::getProperty( int propId )
+double CvCaptureAVI_XINE_CPP::getProperty( int propId ) const
 {
     return captureXINE ? icvGetPropertyAVI_XINE( captureXINE, propId ) : 0;
 }

--- a/modules/highgui/src/precomp.hpp
+++ b/modules/highgui/src/precomp.hpp
@@ -96,7 +96,7 @@
 struct CvCapture
 {
     virtual ~CvCapture() {}
-    virtual double getProperty(int) { return 0; }
+    virtual double getProperty(int) const { return 0; }
     virtual bool setProperty(int, double) { return 0; }
     virtual bool grabFrame() { return true; }
     virtual IplImage* retrieveFrame(int) { return 0; }


### PR DESCRIPTION
Since VideoCapture::get method is a getter then make it a const one. The same applies to the related methods like CvCapture::getProperty.
(See http://code.opencv.org/issues/2625)
