### PR TITLE
Implement VideoCapture::get as a constant method (bug fix #2625).

### DIFF
--- a/modules/videoio/include/opencv2/videoio.hpp
+++ b/modules/videoio/include/opencv2/videoio.hpp
@@ -558,7 +558,7 @@ public:
     **Note**: When querying a property that is not supported by the backend used by the VideoCapture
     class, value 0 is returned.
      */
-    CV_WRAP virtual double get(int propId);
+    CV_WRAP virtual double get(int propId) const;
 
 protected:
     Ptr<CvCapture> cap;

--- a/modules/videoio/src/cap.cpp
+++ b/modules/videoio/src/cap.cpp
@@ -61,6 +61,11 @@ template<> void DefaultDeleter<CvVideoWriter>::operator ()(CvVideoWriter* obj) c
 
 /************************* Reading AVIs & Camera data **************************/
 
+static inline double icvGetCaptureProperty( const CvCapture* capture, int id )
+{
+    return capture ? capture->getProperty(id) : 0;
+}
+
 CV_IMPL void cvReleaseCapture( CvCapture** pcapture )
 {
     if( pcapture && *pcapture )
@@ -92,7 +97,7 @@ CV_IMPL IplImage* cvRetrieveFrame( CvCapture* capture, int idx )
 
 CV_IMPL double cvGetCaptureProperty( CvCapture* capture, int id )
 {
-    return capture ? capture->getProperty(id) : 0;
+    return icvGetCaptureProperty(capture, id);
 }
 
 CV_IMPL int cvSetCaptureProperty( CvCapture* capture, int id, double value )
@@ -597,11 +602,11 @@ bool VideoCapture::set(int propId, double value)
     return cvSetCaptureProperty(cap, propId, value) != 0;
 }
 
-double VideoCapture::get(int propId)
+double VideoCapture::get(int propId) const
 {
     if (!icap.empty())
         return icap->getProperty(propId);
-    return cvGetCaptureProperty(cap, propId);
+    return icvGetCaptureProperty(cap, propId);
 }
 
 Ptr<IVideoCapture> VideoCapture::createCameraCapture(int index)

--- a/modules/videoio/src/cap_android.cpp
+++ b/modules/videoio/src/cap_android.cpp
@@ -65,7 +65,7 @@ public:
     CvCapture_Android(int);
     virtual ~CvCapture_Android();
 
-    virtual double getProperty(int propIdx);
+    virtual double getProperty(int propIdx) const;
     virtual bool setProperty(int probIdx, double propVal);
     virtual bool grabFrame();
     virtual IplImage* retrieveFrame(int outputType);
@@ -257,7 +257,7 @@ CvCapture_Android::~CvCapture_Android()
     }
 }
 
-double CvCapture_Android::getProperty( int propIdx )
+double CvCapture_Android::getProperty( int propIdx ) const
 {
     switch ( propIdx )
     {

--- a/modules/videoio/src/cap_avfoundation.mm
+++ b/modules/videoio/src/cap_avfoundation.mm
@@ -89,7 +89,7 @@ class CvCaptureCAM : public CvCapture {
         virtual bool grabFrame();
         virtual IplImage* retrieveFrame(int);
         virtual IplImage* queryFrame();
-        virtual double getProperty(int property_id);
+        virtual double getProperty(int property_id) const;
         virtual bool setProperty(int property_id, double value);
         virtual int didStart();
 
@@ -132,7 +132,7 @@ class CvCaptureFile : public CvCapture {
         virtual bool grabFrame();
         virtual IplImage* retrieveFrame(int);
         virtual IplImage* queryFrame();
-        virtual double getProperty(int property_id);
+        virtual double getProperty(int property_id) const;
         virtual bool setProperty(int property_id, double value);
         virtual int didStart();
 
@@ -476,7 +476,7 @@ enum {
 typedef NSInteger AVCaptureWhiteBalanceMode;
 */
 
-double CvCaptureCAM::getProperty(int property_id){
+double CvCaptureCAM::getProperty(int property_id) const{
     NSAutoreleasePool* localpool = [[NSAutoreleasePool alloc] init];
 
     /*
@@ -1010,7 +1010,7 @@ double CvCaptureFile::getFPS() {
     return 30.0; //TODO: Debugging
 }
 
-double CvCaptureFile::getProperty(int /*property_id*/){
+double CvCaptureFile::getProperty(int /*property_id*/) const{
 
     /*
          if (mCaptureSession == nil) return 0;

--- a/modules/videoio/src/cap_cmu.cpp
+++ b/modules/videoio/src/cap_cmu.cpp
@@ -68,7 +68,7 @@ public:
 
     virtual bool open(int cameraId);
     virtual void close();
-    virtual double getProperty(int);
+    virtual double getProperty(int) const;
     virtual bool setProperty(int, double);
     virtual bool grabFrame();
     virtual IplImage* retrieveFrame(int);
@@ -422,7 +422,7 @@ IplImage* CvCaptureCAM_CMU::retrieveFrame(int)
 }
 
 
-double CvCaptureCAM_CMU::getProperty( int property_id )
+double CvCaptureCAM_CMU::getProperty( int property_id ) const
 {
     C1394Camera* cmucam = camera();
     if( !cmucam )

--- a/modules/videoio/src/cap_dc1394.cpp
+++ b/modules/videoio/src/cap_dc1394.cpp
@@ -1049,7 +1049,7 @@ public:
     virtual bool open( int index );
     virtual void close();
 
-    virtual double getProperty(int);
+    virtual double getProperty(int) const;
     virtual bool setProperty(int, double);
     virtual bool grabFrame();
     virtual IplImage* retrieveFrame(int);
@@ -1085,9 +1085,13 @@ IplImage* CvCaptureCAM_DC1394_CPP::retrieveFrame(int)
     return captureDC1394 ? (IplImage*)icvRetrieveFrameCAM_DC1394( captureDC1394, 0 ) : 0;
 }
 
-double CvCaptureCAM_DC1394_CPP::getProperty( int propId )
+double CvCaptureCAM_DC1394_CPP::getProperty( int propId ) const
 {
-    return captureDC1394 ? icvGetPropertyCAM_DC1394( captureDC1394, propId ) : 0;
+    // Simulate mutable (C++11-like) member variable
+    // (some members are used to cache property settings).
+    CvCaptureCAM_DC1394* cap = const_cast<CvCaptureCAM_DC1394*>(captureDC1394);
+
+    return cap ? icvGetPropertyCAM_DC1394( cap, propId ) : 0;
 }
 
 bool CvCaptureCAM_DC1394_CPP::setProperty( int propId, double value )

--- a/modules/videoio/src/cap_dc1394_v2.cpp
+++ b/modules/videoio/src/cap_dc1394_v2.cpp
@@ -207,7 +207,7 @@ public:
     virtual bool open(int index);
     virtual void close();
 
-    virtual double getProperty(int);
+    virtual double getProperty(int) const;
     virtual bool setProperty(int, double);
     virtual bool grabFrame();
     virtual IplImage* retrieveFrame(int);
@@ -652,8 +652,11 @@ IplImage* CvCaptureCAM_DC1394_v2_CPP::retrieveFrame(int idx)
     return 0 <= idx && idx < nimages ? img[idx] : 0;
 }
 
-double CvCaptureCAM_DC1394_v2_CPP::getProperty(int propId)
+double CvCaptureCAM_DC1394_v2_CPP::getProperty(int propId) const
 {
+    // Simulate mutable (C++11-like) member variable
+    dc1394featureset_t& fs = const_cast<dc1394featureset_t&>(feature_set);
+
     switch (propId)
     {
     case CV_CAP_PROP_FRAME_WIDTH:
@@ -666,14 +669,14 @@ double CvCaptureCAM_DC1394_v2_CPP::getProperty(int propId)
         return rectify ? 1 : 0;
     case CV_CAP_PROP_WHITE_BALANCE_BLUE_U:
         if (dc1394_feature_whitebalance_get_value(dcCam,
-                                                  &feature_set.feature[DC1394_FEATURE_WHITE_BALANCE-DC1394_FEATURE_MIN].BU_value,
-                                                  &feature_set.feature[DC1394_FEATURE_WHITE_BALANCE-DC1394_FEATURE_MIN].RV_value) == DC1394_SUCCESS)
+                                                  &fs.feature[DC1394_FEATURE_WHITE_BALANCE-DC1394_FEATURE_MIN].BU_value,
+                                                  &fs.feature[DC1394_FEATURE_WHITE_BALANCE-DC1394_FEATURE_MIN].RV_value) == DC1394_SUCCESS)
         return feature_set.feature[DC1394_FEATURE_WHITE_BALANCE-DC1394_FEATURE_MIN].BU_value;
         break;
     case CV_CAP_PROP_WHITE_BALANCE_RED_V:
         if (dc1394_feature_whitebalance_get_value(dcCam,
-                                                  &feature_set.feature[DC1394_FEATURE_WHITE_BALANCE-DC1394_FEATURE_MIN].BU_value,
-                                                  &feature_set.feature[DC1394_FEATURE_WHITE_BALANCE-DC1394_FEATURE_MIN].RV_value) == DC1394_SUCCESS)
+                                                  &fs.feature[DC1394_FEATURE_WHITE_BALANCE-DC1394_FEATURE_MIN].BU_value,
+                                                  &fs.feature[DC1394_FEATURE_WHITE_BALANCE-DC1394_FEATURE_MIN].RV_value) == DC1394_SUCCESS)
         return feature_set.feature[DC1394_FEATURE_WHITE_BALANCE-DC1394_FEATURE_MIN].RV_value;
         break;
     case CV_CAP_PROP_GUID:
@@ -690,7 +693,7 @@ double CvCaptureCAM_DC1394_v2_CPP::getProperty(int propId)
             && dcCam)
             //&& feature_set.feature[dc1394properties[propId]-DC1394_FEATURE_MIN].on_off_capable)
             if (dc1394_feature_get_value(dcCam,(dc1394feature_t)dc1394properties[propId],
-                &feature_set.feature[dc1394properties[propId]-DC1394_FEATURE_MIN].value) == DC1394_SUCCESS)
+                &fs.feature[dc1394properties[propId]-DC1394_FEATURE_MIN].value) == DC1394_SUCCESS)
               return feature_set.feature[dc1394properties[propId]-DC1394_FEATURE_MIN].value;
     }
     return -1; // the value of the feature can be 0, so returning 0 as an error is wrong

--- a/modules/videoio/src/cap_dshow.cpp
+++ b/modules/videoio/src/cap_dshow.cpp
@@ -532,7 +532,7 @@ class videoInput{
         //Tells you when a new frame has arrived - you should call this if you have specified setAutoReconnectOnFreeze to true
         bool isFrameNew(int deviceID);
 
-        bool isDeviceSetup(int deviceID);
+        bool isDeviceSetup(int deviceID) const;
 
         //Returns the pixels - flipRedAndBlue toggles RGB/BGR flipping - and you can flip the image too
         unsigned char * getPixels(int deviceID, bool flipRedAndBlue = true, bool flipImage = false);
@@ -557,11 +557,11 @@ class videoInput{
         //bool setVideoSettingCam(int deviceID, long Property, long lValue, long Flags = NULL, bool useDefaultValue = false);
 
         //get width, height and number of pixels
-        int  getWidth(int deviceID);
-        int  getHeight(int deviceID);
-        int  getSize(int deviceID);
-        int  getFourcc(int deviceID);
-        double getFPS(int deviceID);
+        int  getWidth(int deviceID) const;
+        int  getHeight(int deviceID) const;
+        int  getSize(int deviceID) const;
+        int  getFourcc(int deviceID) const;
+        double getFPS(int deviceID) const;
 
         //completely stops and frees a device
         void stopDevice(int deviceID);
@@ -585,7 +585,7 @@ class videoInput{
         int  getDeviceCount();
         void getMediaSubtypeAsString(GUID type, char * typeAsString);
         GUID *getMediaSubtypeFromFourcc(int fourcc);
-        int    getFourccFromMediaSubtype(GUID type);
+        int   getFourccFromMediaSubtype(GUID type) const;
 
         void getVideoPropertyAsString(int prop, char * propertyAsString);
         void getCameraPropertyAsString(int prop, char * propertyAsString);
@@ -1422,8 +1422,8 @@ int videoInput::listDevices(bool silent){
 //
 // ----------------------------------------------------------------------
 
-int videoInput::getWidth(int id){
-
+int videoInput::getWidth(int id) const
+{
     if(isDeviceSetup(id))
     {
         return VDList[id] ->width;
@@ -1439,8 +1439,8 @@ int videoInput::getWidth(int id){
 //
 // ----------------------------------------------------------------------
 
-int videoInput::getHeight(int id){
-
+int videoInput::getHeight(int id) const
+{
     if(isDeviceSetup(id))
     {
         return VDList[id] ->height;
@@ -1454,8 +1454,8 @@ int videoInput::getHeight(int id){
 //
 //
 // ----------------------------------------------------------------------
-int videoInput::getFourcc(int id){
-
+int videoInput::getFourcc(int id) const
+{
     if(isDeviceSetup(id))
     {
         return getFourccFromMediaSubtype(VDList[id]->videoType);
@@ -1465,8 +1465,8 @@ int videoInput::getFourcc(int id){
 
 }
 
-double videoInput::getFPS(int id){
-
+double videoInput::getFPS(int id) const
+{
     if(isDeviceSetup(id))
     {
         double frameTime= VDList[id]->requestedFrameTime;
@@ -1485,8 +1485,8 @@ double videoInput::getFPS(int id){
 //
 // ----------------------------------------------------------------------
 
-int videoInput::getSize(int id){
-
+int videoInput::getSize(int id) const
+{
     if(isDeviceSetup(id))
     {
         return VDList[id] ->videoSize;
@@ -1618,11 +1618,10 @@ bool videoInput::isFrameNew(int id){
 //
 // ----------------------------------------------------------------------
 
-bool videoInput::isDeviceSetup(int id){
-
+bool videoInput::isDeviceSetup(int id) const
+{
     if(id>=0 && id<devicesFound && VDList[id]->readyToCapture)return true;
     else return false;
-
 }
 
 
@@ -2209,7 +2208,8 @@ void videoInput::getMediaSubtypeAsString(GUID type, char * typeAsString){
     memcpy(typeAsString, tmpStr, sizeof(char)*8);
 }
 
-int videoInput::getFourccFromMediaSubtype(GUID type) {
+int videoInput::getFourccFromMediaSubtype(GUID type) const
+{
     return type.Data1;
 }
 
@@ -3154,7 +3154,7 @@ VideoCapture_DShow::~VideoCapture_DShow()
     CoUninitialize();
 }
 
-double VideoCapture_DShow::getProperty(int propIdx)
+double VideoCapture_DShow::getProperty(int propIdx) const
 {
 
     long min_value, max_value, stepping_delta, current_value, flags, defaultValue;

--- a/modules/videoio/src/cap_dshow.hpp
+++ b/modules/videoio/src/cap_dshow.hpp
@@ -26,7 +26,7 @@ public:
     VideoCapture_DShow(int index);
     virtual ~VideoCapture_DShow();
 
-    virtual double getProperty(int propIdx);
+    virtual double getProperty(int propIdx) const;
     virtual bool setProperty(int propIdx, double propVal);
 
     virtual bool grabFrame();

--- a/modules/videoio/src/cap_ffmpeg.cpp
+++ b/modules/videoio/src/cap_ffmpeg.cpp
@@ -167,7 +167,7 @@ public:
     CvCapture_FFMPEG_proxy() { ffmpegCapture = 0; }
     virtual ~CvCapture_FFMPEG_proxy() { close(); }
 
-    virtual double getProperty(int propId)
+    virtual double getProperty(int propId) const
     {
         return ffmpegCapture ? icvGetCaptureProperty_FFMPEG_p(ffmpegCapture, propId) : 0;
     }

--- a/modules/videoio/src/cap_ffmpeg_impl.hpp
+++ b/modules/videoio/src/cap_ffmpeg_impl.hpp
@@ -225,7 +225,7 @@ struct CvCapture_FFMPEG
     bool open( const char* filename );
     void close();
 
-    double getProperty(int);
+    double getProperty(int) const;
     bool setProperty(int, double);
     bool grabFrame();
     bool retrieveFrame(int, unsigned char** data, int* step, int* width, int* height, int* cn);
@@ -236,12 +236,12 @@ struct CvCapture_FFMPEG
     void    seek(double sec);
     bool    slowSeek( int framenumber );
 
-    int64_t get_total_frames();
-    double  get_duration_sec();
-    double  get_fps();
-    int     get_bitrate();
+    int64_t get_total_frames() const;
+    double  get_duration_sec() const;
+    double  get_fps() const;
+    int     get_bitrate() const;
 
-    double  r2d(AVRational r);
+    double  r2d(AVRational r) const;
     int64_t dts_to_frame_number(int64_t dts);
     double  dts_to_sec(int64_t dts);
 
@@ -759,7 +759,7 @@ bool CvCapture_FFMPEG::retrieveFrame(int, unsigned char** data, int* step, int* 
 }
 
 
-double CvCapture_FFMPEG::getProperty( int property_id )
+double CvCapture_FFMPEG::getProperty( int property_id ) const
 {
     if( !video_st ) return 0;
 
@@ -797,12 +797,12 @@ double CvCapture_FFMPEG::getProperty( int property_id )
     return 0;
 }
 
-double CvCapture_FFMPEG::r2d(AVRational r)
+double CvCapture_FFMPEG::r2d(AVRational r) const
 {
     return r.num == 0 || r.den == 0 ? 0. : (double)r.num / (double)r.den;
 }
 
-double CvCapture_FFMPEG::get_duration_sec()
+double CvCapture_FFMPEG::get_duration_sec() const
 {
     double sec = (double)ic->duration / (double)AV_TIME_BASE;
 
@@ -819,12 +819,12 @@ double CvCapture_FFMPEG::get_duration_sec()
     return sec;
 }
 
-int CvCapture_FFMPEG::get_bitrate()
+int CvCapture_FFMPEG::get_bitrate() const
 {
     return ic->bit_rate;
 }
 
-double CvCapture_FFMPEG::get_fps()
+double CvCapture_FFMPEG::get_fps() const
 {
     double fps = r2d(ic->streams[video_stream]->r_frame_rate);
 
@@ -843,7 +843,7 @@ double CvCapture_FFMPEG::get_fps()
     return fps;
 }
 
-int64_t CvCapture_FFMPEG::get_total_frames()
+int64_t CvCapture_FFMPEG::get_total_frames() const
 {
     int64_t nbf = ic->streams[video_stream]->nb_frames;
 

--- a/modules/videoio/src/cap_giganetix.cpp
+++ b/modules/videoio/src/cap_giganetix.cpp
@@ -294,7 +294,7 @@ class CvCaptureCAM_Giganetix : public CvCapture
 
     virtual bool open( int index );
     virtual void close();
-    virtual double getProperty(int);
+    virtual double getProperty(int) const;
     virtual bool setProperty(int, double);
     virtual bool grabFrame();
     virtual IplImage* retrieveFrame(int);
@@ -600,7 +600,7 @@ CvCaptureCAM_Giganetix::retrieveFrame(int)
 
 /*----------------------------------------------------------------------------*/
 double
-CvCaptureCAM_Giganetix::getProperty( int property_id )
+CvCaptureCAM_Giganetix::getProperty( int property_id ) const
 {
   double d_ret = -1.0;
   INT64 i;

--- a/modules/videoio/src/cap_gstreamer.cpp
+++ b/modules/videoio/src/cap_gstreamer.cpp
@@ -123,7 +123,7 @@ public:
     virtual bool open( int type, const char* filename );
     virtual void close();
 
-    virtual double getProperty(int);
+    virtual double getProperty(int) const;
     virtual bool setProperty(int, double);
     virtual bool grabFrame();
     virtual IplImage* retrieveFrame(int);
@@ -838,7 +838,7 @@ bool CvCapture_GStreamer::open( int type, const char* filename )
  * For frame-based properties, we use the caps of the lasst receivef sample. This means that some properties
  * are not available until a first frame was received
  */
-double CvCapture_GStreamer::getProperty( int propId )
+double CvCapture_GStreamer::getProperty( int propId ) const
 {
     GstFormat format;
     gint64 value;

--- a/modules/videoio/src/cap_images.cpp
+++ b/modules/videoio/src/cap_images.cpp
@@ -80,7 +80,7 @@ public:
 
     virtual bool open(const char* _filename);
     virtual void close();
-    virtual double getProperty(int);
+    virtual double getProperty(int) const;
     virtual bool setProperty(int, double);
     virtual bool grabFrame();
     virtual IplImage* retrieveFrame(int);
@@ -126,7 +126,7 @@ IplImage* CvCapture_Images::retrieveFrame(int)
     return frame;
 }
 
-double CvCapture_Images::getProperty(int id)
+double CvCapture_Images::getProperty(int id) const
 {
     switch(id)
     {

--- a/modules/videoio/src/cap_intelperc.cpp
+++ b/modules/videoio/src/cap_intelperc.cpp
@@ -46,7 +46,7 @@ int IntelPerCStreamBase::getProfileIDX() const
 {
     return m_profileIdx;
 }
-double IntelPerCStreamBase::getProperty(int propIdx)
+double IntelPerCStreamBase::getProperty(int propIdx) const
 {
     double ret = 0.0;
     switch (propIdx)
@@ -210,7 +210,7 @@ bool IntelPerCStreamImage::initStream(PXCSession *session)
     enumProfiles();
     return true;
 }
-double IntelPerCStreamImage::getProperty(int propIdx)
+double IntelPerCStreamImage::getProperty(int propIdx) const
 {
     switch (propIdx)
     {
@@ -418,7 +418,7 @@ bool IntelPerCStreamDepth::initStream(PXCSession *session)
     enumProfiles();
     return true;
 }
-double IntelPerCStreamDepth::getProperty(int propIdx)
+double IntelPerCStreamDepth::getProperty(int propIdx) const
 {
     switch (propIdx)
     {
@@ -554,7 +554,7 @@ VideoCapture_IntelPerC::VideoCapture_IntelPerC()
 }
 VideoCapture_IntelPerC::~VideoCapture_IntelPerC(){}
 
-double VideoCapture_IntelPerC::getProperty(int propIdx)
+double VideoCapture_IntelPerC::getProperty(int propIdx) const
 {
     double propValue = 0;
     int purePropIdx = propIdx & ~CV_CAP_INTELPERC_GENERATORS_MASK;

--- a/modules/videoio/src/cap_intelperc.hpp
+++ b/modules/videoio/src/cap_intelperc.hpp
@@ -34,7 +34,7 @@ public:
     int getProfileIDX() const;
 public:
     virtual bool initStream(PXCSession *session)            = 0;
-    virtual double getProperty(int propIdx);
+    virtual double getProperty(int propIdx) const;
     virtual bool setProperty(int propIdx, double propVal);
 protected:
     PXCSmartPtr<PXCCapture::Device> m_device;
@@ -62,7 +62,7 @@ public:
     virtual ~IntelPerCStreamImage();
 
     virtual bool initStream(PXCSession *session);
-    virtual double getProperty(int propIdx);
+    virtual double getProperty(int propIdx) const;
     virtual bool setProperty(int propIdx, double propVal);
 public:
     bool retrieveAsOutputArray(OutputArray image);
@@ -76,7 +76,7 @@ public:
     virtual ~IntelPerCStreamDepth();
 
     virtual bool initStream(PXCSession *session);
-    virtual double getProperty(int propIdx);
+    virtual double getProperty(int propIdx) const;
     virtual bool setProperty(int propIdx, double propVal);
 public:
     bool retrieveDepthAsOutputArray(OutputArray image);
@@ -94,7 +94,7 @@ public:
     VideoCapture_IntelPerC();
     virtual ~VideoCapture_IntelPerC();
 
-    virtual double getProperty(int propIdx);
+    virtual double getProperty(int propIdx) const;
     virtual bool setProperty(int propIdx, double propVal);
 
     virtual bool grabFrame();

--- a/modules/videoio/src/cap_libv4l.cpp
+++ b/modules/videoio/src/cap_libv4l.cpp
@@ -1712,7 +1712,7 @@ public:
     virtual bool open( int index );
     virtual void close();
 
-    virtual double getProperty(int);
+    virtual double getProperty(int) const;
     virtual bool setProperty(int, double);
     virtual bool grabFrame();
     virtual IplImage* retrieveFrame(int);
@@ -1747,7 +1747,7 @@ IplImage* CvCaptureCAM_V4L_CPP::retrieveFrame(int)
     return captureV4L ? icvRetrieveFrameCAM_V4L( captureV4L, 0 ) : 0;
 }
 
-double CvCaptureCAM_V4L_CPP::getProperty( int propId )
+double CvCaptureCAM_V4L_CPP::getProperty( int propId ) const
 {
     return captureV4L ? icvGetPropertyCAM_V4L( captureV4L, propId ) : 0.0;
 }

--- a/modules/videoio/src/cap_msmf.cpp
+++ b/modules/videoio/src/cap_msmf.cpp
@@ -684,11 +684,11 @@ public:
     // Getting numbers of existence videodevices with listing in consol
     unsigned int listDevices(bool silent = false);
     // Getting numbers of formats, which are supported by videodevice with deviceID
-    unsigned int getCountFormats(int deviceID);
+    unsigned int getCountFormats(int deviceID) const;
     // Getting width of image, which is getting from videodevice with deviceID
-    unsigned int getWidth(int deviceID);
+    unsigned int getWidth(int deviceID) const;
     // Getting height of image, which is getting from videodevice with deviceID
-    unsigned int getHeight(int deviceID);
+    unsigned int getHeight(int deviceID) const;
     // Getting frame rate, which is getting from videodevice with deviceID
     unsigned int getFrameRate(int deviceID) const;
     // Getting name of videodevice with deviceID
@@ -3226,7 +3226,7 @@ void videoInput::waitForDevice(int deviceID)
 }
 #endif
 
-unsigned int videoInput::getCountFormats(int deviceID)
+unsigned int videoInput::getCountFormats(int deviceID) const
 {
     if (deviceID < 0)
     {
@@ -3316,7 +3316,7 @@ void videoInput::closeDevice(int deviceID)
     }
 }
 
-unsigned int videoInput::getWidth(int deviceID)
+unsigned int videoInput::getWidth(int deviceID) const
 {
     if (deviceID < 0)
     {
@@ -3337,7 +3337,7 @@ unsigned int videoInput::getWidth(int deviceID)
     return 0;
 }
 
-unsigned int videoInput::getHeight(int deviceID)
+unsigned int videoInput::getHeight(int deviceID) const
 {
     if (deviceID < 0)
     {
@@ -3585,7 +3585,7 @@ public:
     virtual ~CvCaptureCAM_MSMF();
     virtual bool open( int index );
     virtual void close();
-    virtual double getProperty(int);
+    virtual double getProperty(int) const;
     virtual bool setProperty(int, double);
     virtual bool grabFrame();
     virtual IplImage* retrieveFrame(int);
@@ -3711,7 +3711,7 @@ IplImage* CvCaptureCAM_MSMF::retrieveFrame(int)
     return frame;
 }
 
-double CvCaptureCAM_MSMF::getProperty( int property_id )
+double CvCaptureCAM_MSMF::getProperty( int property_id ) const
 {
     // image format proprrties
     switch( property_id )
@@ -3778,7 +3778,7 @@ public:
     virtual bool open( const char* filename );
     virtual void close();
 
-    virtual double getProperty(int);
+    virtual double getProperty(int) const;
     virtual bool setProperty(int, double);
     virtual bool grabFrame();
     virtual IplImage* retrieveFrame(int);
@@ -3792,7 +3792,7 @@ protected:
     bool isOpened;
 
     HRESULT enumerateCaptureFormats(IMFMediaSource *pSource);
-    HRESULT getSourceDuration(IMFMediaSource *pSource, MFTIME *pDuration);
+    HRESULT getSourceDuration(IMFMediaSource *pSource, MFTIME *pDuration) const;
 };
 
 CvCaptureFile_MSMF::CvCaptureFile_MSMF():
@@ -3897,7 +3897,7 @@ bool CvCaptureFile_MSMF::setProperty(int property_id, double value)
     return false;
 }
 
-double CvCaptureFile_MSMF::getProperty(int property_id)
+double CvCaptureFile_MSMF::getProperty(int property_id) const
 {
     // image format proprrties
     switch( property_id )
@@ -4009,7 +4009,7 @@ done:
     return hr;
 }
 
-HRESULT CvCaptureFile_MSMF::getSourceDuration(IMFMediaSource *pSource, MFTIME *pDuration)
+HRESULT CvCaptureFile_MSMF::getSourceDuration(IMFMediaSource *pSource, MFTIME *pDuration) const
 {
     *pDuration = 0;
 

--- a/modules/videoio/src/cap_openni.cpp
+++ b/modules/videoio/src/cap_openni.cpp
@@ -446,7 +446,7 @@ public:
     CvCapture_OpenNI(const char * filename);
     virtual ~CvCapture_OpenNI();
 
-    virtual double getProperty(int propIdx);
+    virtual double getProperty(int propIdx) const;
     virtual bool setProperty(int probIdx, double propVal);
     virtual bool grabFrame();
     virtual IplImage* retrieveFrame(int outputType);
@@ -771,7 +771,7 @@ bool CvCapture_OpenNI::readCamerasParams()
     return true;
 }
 
-double CvCapture_OpenNI::getProperty( int propIdx )
+double CvCapture_OpenNI::getProperty( int propIdx ) const
 {
     double propValue = 0;
 

--- a/modules/videoio/src/cap_openni2.cpp
+++ b/modules/videoio/src/cap_openni2.cpp
@@ -94,7 +94,7 @@ public:
     CvCapture_OpenNI2(const char * filename);
     virtual ~CvCapture_OpenNI2();
 
-    virtual double getProperty(int propIdx);
+    virtual double getProperty(int propIdx) const;
     virtual bool setProperty(int probIdx, double propVal);
     virtual bool grabFrame();
     virtual IplImage* retrieveFrame(int outputType);
@@ -388,7 +388,7 @@ bool CvCapture_OpenNI2::readCamerasParams()
     return true;
 }
 
-double CvCapture_OpenNI2::getProperty( int propIdx )
+double CvCapture_OpenNI2::getProperty( int propIdx ) const
 {
     double propValue = 0;
 

--- a/modules/videoio/src/cap_pvapi.cpp
+++ b/modules/videoio/src/cap_pvapi.cpp
@@ -80,7 +80,7 @@ public:
 
     virtual bool open( int index );
     virtual void close();
-    virtual double getProperty(int);
+    virtual double getProperty(int) const;
     virtual bool setProperty(int, double);
     virtual bool grabFrame();
     virtual IplImage* retrieveFrame(int);
@@ -242,7 +242,7 @@ IplImage* CvCaptureCAM_PvAPI::retrieveFrame(int)
     else return NULL;
 }
 
-double CvCaptureCAM_PvAPI::getProperty( int property_id )
+double CvCaptureCAM_PvAPI::getProperty( int property_id ) const
 {
     tPvUint32 nTemp;
 

--- a/modules/videoio/src/cap_qt.cpp
+++ b/modules/videoio/src/cap_qt.cpp
@@ -1441,7 +1441,7 @@ public:
     virtual bool open( const char* filename );
     virtual void close();
 
-    virtual double getProperty(int);
+    virtual double getProperty(int) const;
     virtual bool setProperty(int, double);
     virtual bool grabFrame();
     virtual IplImage* retrieveFrame(int);
@@ -1477,7 +1477,7 @@ IplImage* CvCapture_QT_Movie_CPP::retrieveFrame(int)
     return captureQT ? (IplImage*)icvRetrieveFrame_QT_Movie( captureQT, 0 ) : 0;
 }
 
-double CvCapture_QT_Movie_CPP::getProperty( int propId )
+double CvCapture_QT_Movie_CPP::getProperty( int propId ) const
 {
     return captureQT ? icvGetProperty_QT_Movie( captureQT, propId ) : 0;
 }
@@ -1510,7 +1510,7 @@ public:
     virtual bool open( int index );
     virtual void close();
 
-    virtual double getProperty(int);
+    virtual double getProperty(int) const;
     virtual bool setProperty(int, double);
     virtual bool grabFrame();
     virtual IplImage* retrieveFrame(int);
@@ -1546,7 +1546,7 @@ IplImage* CvCapture_QT_Cam_CPP::retrieveFrame(int)
     return captureQT ? (IplImage*)icvRetrieveFrame_QT_Cam( captureQT, 0 ) : 0;
 }
 
-double CvCapture_QT_Cam_CPP::getProperty( int propId )
+double CvCapture_QT_Cam_CPP::getProperty( int propId ) const
 {
     return captureQT ? icvGetProperty_QT_Cam( captureQT, propId ) : 0;
 }

--- a/modules/videoio/src/cap_qtkit.mm
+++ b/modules/videoio/src/cap_qtkit.mm
@@ -109,7 +109,7 @@ public:
     ~CvCaptureCAM();
     virtual bool grabFrame();
     virtual IplImage* retrieveFrame(int);
-    virtual double getProperty(int property_id);
+    virtual double getProperty(int property_id) const;
     virtual bool setProperty(int property_id, double value);
     virtual int didStart();
 
@@ -151,7 +151,7 @@ public:
     ~CvCaptureFile();
     virtual bool grabFrame();
     virtual IplImage* retrieveFrame(int);
-    virtual double getProperty(int property_id);
+    virtual double getProperty(int property_id) const;
     virtual bool setProperty(int property_id, double value);
     virtual int didStart();
 
@@ -439,7 +439,7 @@ void CvCaptureCAM::setWidthHeight() {
 }
 
 
-double CvCaptureCAM::getProperty(int property_id){
+double CvCaptureCAM::getProperty(int property_id) const{
     int retval;
     NSAutoreleasePool* localpool = [[NSAutoreleasePool alloc] init];
 
@@ -832,7 +832,7 @@ double CvCaptureFile::getFPS() {
     return retval;
 }
 
-double CvCaptureFile::getProperty(int property_id){
+double CvCaptureFile::getProperty(int property_id) const{
     if (mCaptureSession == nil) return 0;
 
     NSAutoreleasePool* localpool = [[NSAutoreleasePool alloc] init];

--- a/modules/videoio/src/cap_unicap.cpp
+++ b/modules/videoio/src/cap_unicap.cpp
@@ -62,7 +62,7 @@ struct CvCapture_Unicap : public CvCapture
   virtual bool open( int index );
   virtual void close();
 
-  virtual double getProperty(int);
+  virtual double getProperty(int) const;
   virtual bool setProperty(int, double);
   virtual bool grabFrame();
   virtual IplImage* retrieveFrame(int);
@@ -241,7 +241,8 @@ IplImage * CvCapture_Unicap::retrieveFrame(int) {
   return raw_frame;
 }
 
-double CvCapture_Unicap::getProperty(int id) {
+double CvCapture_Unicap::getProperty(int id) const
+{
   switch (id) {
   case CV_CAP_PROP_POS_MSEC: break;
   case CV_CAP_PROP_POS_FRAMES: break;

--- a/modules/videoio/src/cap_v4l.cpp
+++ b/modules/videoio/src/cap_v4l.cpp
@@ -2879,7 +2879,7 @@ public:
     virtual bool open( int index );
     virtual void close();
 
-    virtual double getProperty(int);
+    virtual double getProperty(int) const;
     virtual bool setProperty(int, double);
     virtual bool grabFrame();
     virtual IplImage* retrieveFrame(int);
@@ -2914,7 +2914,7 @@ IplImage* CvCaptureCAM_V4L_CPP::retrieveFrame(int)
     return captureV4L ? icvRetrieveFrameCAM_V4L( captureV4L, 0 ) : 0;
 }
 
-double CvCaptureCAM_V4L_CPP::getProperty( int propId )
+double CvCaptureCAM_V4L_CPP::getProperty( int propId ) const
 {
     return captureV4L ? icvGetPropertyCAM_V4L( captureV4L, propId ) : 0.0;
 }

--- a/modules/videoio/src/cap_vfw.cpp
+++ b/modules/videoio/src/cap_vfw.cpp
@@ -99,7 +99,7 @@ public:
     virtual bool open( const char* filename );
     virtual void close();
 
-    virtual double getProperty(int);
+    virtual double getProperty(int) const;
     virtual bool setProperty(int, double);
     virtual bool grabFrame();
     virtual IplImage* retrieveFrame(int);
@@ -238,7 +238,7 @@ IplImage* CvCaptureAVI_VFW::retrieveFrame(int)
     return 0;
 }
 
-double CvCaptureAVI_VFW::getProperty( int property_id )
+double CvCaptureAVI_VFW::getProperty( int property_id ) const
 {
     switch( property_id )
     {
@@ -317,7 +317,7 @@ public:
 
     virtual bool open( int index );
     virtual void close();
-    virtual double getProperty(int);
+    virtual double getProperty(int) const;
     virtual bool setProperty(int, double);
     virtual bool grabFrame();
     virtual IplImage* retrieveFrame(int);
@@ -541,7 +541,7 @@ IplImage* CvCaptureCAM_VFW::retrieveFrame(int)
 }
 
 
-double CvCaptureCAM_VFW::getProperty( int property_id )
+double CvCaptureCAM_VFW::getProperty( int property_id ) const
 {
     switch( property_id )
     {

--- a/modules/videoio/src/cap_ximea.cpp
+++ b/modules/videoio/src/cap_ximea.cpp
@@ -16,7 +16,7 @@ public:
 
     virtual bool open( int index );
     virtual void close();
-    virtual double getProperty(int);
+    virtual double getProperty(int) const;
     virtual bool setProperty(int, double);
     virtual bool grabFrame();
     virtual IplImage* retrieveFrame(int);
@@ -226,7 +226,7 @@ void CvCaptureCAM_XIMEA::resetCvImage()
 }
 /**********************************************************************************/
 
-double CvCaptureCAM_XIMEA::getProperty( int property_id )
+double CvCaptureCAM_XIMEA::getProperty( int property_id ) const
 {
     if(hmv == NULL)
         return 0;

--- a/modules/videoio/src/cap_xine.cpp
+++ b/modules/videoio/src/cap_xine.cpp
@@ -786,7 +786,7 @@ public:
     virtual bool open( const char* filename );
     virtual void close();
 
-    virtual double getProperty(int);
+    virtual double getProperty(int) const;
     virtual bool setProperty(int, double);
     virtual bool grabFrame();
     virtual IplImage* retrieveFrame(int);
@@ -821,7 +821,7 @@ IplImage* CvCaptureAVI_XINE_CPP::retrieveFrame(int)
     return captureXINE ? (IplImage*)icvRetrieveFrameAVI_XINE( captureXINE, 0 ) : 0;
 }
 
-double CvCaptureAVI_XINE_CPP::getProperty( int propId )
+double CvCaptureAVI_XINE_CPP::getProperty( int propId ) const
 {
     return captureXINE ? icvGetPropertyAVI_XINE( captureXINE, propId ) : 0;
 }

--- a/modules/videoio/src/precomp.hpp
+++ b/modules/videoio/src/precomp.hpp
@@ -85,7 +85,7 @@
 struct CvCapture
 {
     virtual ~CvCapture() {}
-    virtual double getProperty(int) { return 0; }
+    virtual double getProperty(int) const { return 0; }
     virtual bool setProperty(int, double) { return 0; }
     virtual bool grabFrame() { return true; }
     virtual IplImage* retrieveFrame(int) { return 0; }
@@ -165,7 +165,7 @@ namespace cv
     {
     public:
         virtual ~IVideoCapture() {}
-        virtual double getProperty(int) { return 0; }
+        virtual double getProperty(int) const { return 0; }
         virtual bool setProperty(int, double) { return 0; }
         virtual bool grabFrame() = 0;
         virtual bool retrieveFrame(int, cv::OutputArray) = 0;


### PR DESCRIPTION
This is a port of #3503 
Since VideoCapture::get is a getter then make it a constant method. The same applies to the related methods like CvCapture::getProperty and IVideoCapture::getProperty.
