### PR TITLE
Export thread control to generated wrappers

### DIFF
--- a/modules/core/include/opencv2/core/core.hpp
+++ b/modules/core/include/opencv2/core/core.hpp
@@ -230,9 +230,9 @@ CV_EXPORTS ErrorCallback redirectError( ErrorCallback errCallback,
 
 CV_EXPORTS void glob(String pattern, std::vector<String>& result, bool recursive = false);
 
-CV_EXPORTS void setNumThreads(int nthreads);
-CV_EXPORTS int getNumThreads();
-CV_EXPORTS int getThreadNum();
+CV_EXPORTS_W void setNumThreads(int nthreads);
+CV_EXPORTS_W int getNumThreads();
+CV_EXPORTS_W int getThreadNum();
 
 CV_EXPORTS_W const string& getBuildInformation();
 


### PR DESCRIPTION
Since the default OpenCV distribution comes precompiled with threading support enabled, it is important to have the ability to limit / disable the option in run time. Currently the relevant functions are available in C++ only, and thus force the user to have it on when being used via C/Python/...

This patch exports the functions setNumThreads, getNumThreads, getThreadNum.

The issue filed in opencv code is:
http://code.opencv.org/issues/4064
