### PR TITLE
Made migration from 2.4 easier

### DIFF
--- a/modules/calib3d/include/opencv2/calib3d.hpp
+++ b/modules/calib3d/include/opencv2/calib3d.hpp
@@ -1854,4 +1854,8 @@ namespace fisheye
 
 } // cv
 
+#ifndef DISABLE_OPENCV_24_COMPATIBILITY
+#include "opencv2/calib3d/calib3d_c.h"
+#endif
+
 #endif

--- a/modules/core/include/opencv2/core/cvdef.h
+++ b/modules/core/include/opencv2/core/cvdef.h
@@ -73,6 +73,10 @@
 #  define CV_ENABLE_UNROLLED 1
 #endif
 
+#ifdef __OPENCV_BUILD
+#  define DISABLE_OPENCV_24_COMPATIBILITY
+#endif
+
 #if (defined WIN32 || defined _WIN32 || defined WINCE || defined __CYGWIN__) && defined CVAPI_EXPORTS
 #  define CV_EXPORTS __declspec(dllexport)
 #elif defined __GNUC__ && __GNUC__ >= 4

--- a/modules/core/include/opencv2/core/cvstd.hpp
+++ b/modules/core/include/opencv2/core/cvstd.hpp
@@ -303,7 +303,10 @@ struct Ptr
     @note It is often easier to use makePtr instead.
      */
     template<typename Y>
-    explicit Ptr(Y* p);
+#ifdef DISABLE_OPENCV_24_COMPATIBILITY
+    explicit
+#endif
+    Ptr(Y* p);
 
     /** @overload
     @param d Deleter to use for the owned pointer.

--- a/modules/core/include/opencv2/core/utility.hpp
+++ b/modules/core/include/opencv2/core/utility.hpp
@@ -746,4 +746,8 @@ template<> inline std::string CommandLineParser::get<std::string>(const String& 
 
 } //namespace cv
 
+#ifndef DISABLE_OPENCV_24_COMPATIBILITY
+#include "opencv2/core/core_c.h"
+#endif
+
 #endif //__OPENCV_CORE_UTILITY_H__

--- a/modules/highgui/include/opencv2/highgui.hpp
+++ b/modules/highgui/include/opencv2/highgui.hpp
@@ -677,4 +677,9 @@ CV_EXPORTS int createButton( const String& bar_name, ButtonCallback on_change,
 //! @} highgui
 
 } // cv
+
+#ifndef DISABLE_OPENCV_24_COMPATIBILITY
+#include "opencv2/highgui/highgui_c.h"
+#endif
+
 #endif

--- a/modules/imgproc/include/opencv2/imgproc.hpp
+++ b/modules/imgproc/include/opencv2/imgproc.hpp
@@ -4217,4 +4217,8 @@ Point LineIterator::pos() const
 
 } // cv
 
+#ifndef DISABLE_OPENCV_24_COMPATIBILITY
+#include "opencv2/imgproc/imgproc_c.h"
+#endif
+
 #endif

--- a/modules/objdetect/include/opencv2/objdetect.hpp
+++ b/modules/objdetect/include/opencv2/objdetect.hpp
@@ -458,4 +458,8 @@ public:
 
 #include "opencv2/objdetect/detection_based_tracker.hpp"
 
+#ifndef DISABLE_OPENCV_24_COMPATIBILITY
+#include "opencv2/objdetect/objdetect_c.h"
+#endif
+
 #endif

--- a/modules/photo/include/opencv2/photo.hpp
+++ b/modules/photo/include/opencv2/photo.hpp
@@ -802,4 +802,8 @@ CV_EXPORTS_W void stylization(InputArray src, OutputArray dst, float sigma_s = 6
 
 } // cv
 
+#ifndef DISABLE_OPENCV_24_COMPATIBILITY
+#include "opencv2/photo/photo_c.h"
+#endif
+
 #endif

--- a/modules/video/include/opencv2/video.hpp
+++ b/modules/video/include/opencv2/video.hpp
@@ -56,4 +56,8 @@
 #include "opencv2/video/tracking.hpp"
 #include "opencv2/video/background_segm.hpp"
 
+#ifndef DISABLE_OPENCV_24_COMPATIBILITY
+#include "opencv2/video/tracking_c.h"
+#endif
+
 #endif //__OPENCV_VIDEO_HPP__


### PR DESCRIPTION
- made Ptr(T) contructor implicit for migration purposes
- included C-style API into main headers for some popular modules
