### PR TITLE
Changed CV_DbgAssert to CV_Assert when setting video modes for OpenNI2. ...

### DIFF
--- a/modules/videoio/src/cap_openni2.cpp
+++ b/modules/videoio/src/cap_openni2.cpp
@@ -243,7 +243,7 @@ CvCapture_OpenNI2::CvCapture_OpenNI2( int index )
     {
         if (depth.isValid())
         {
-            CV_DbgAssert(depth.setVideoMode(defaultDepthOutputMode()) == openni::STATUS_OK); // xn::DepthGenerator supports VGA only! (Jan 2011)
+            CV_Assert(depth.setVideoMode(defaultDepthOutputMode()) == openni::STATUS_OK); // xn::DepthGenerator supports VGA only! (Jan 2011)
         }
 
         status = depth.start();
@@ -266,7 +266,7 @@ CvCapture_OpenNI2::CvCapture_OpenNI2( int index )
         // Set map output mode.
         if (color.isValid())
         {
-            CV_DbgAssert(color.setVideoMode(defaultColorOutputMode()) == openni::STATUS_OK);
+            CV_Assert(color.setVideoMode(defaultColorOutputMode()) == openni::STATUS_OK);
         }
         status = color.start();
         if (status != openni::STATUS_OK)


### PR DESCRIPTION
...Otherwise, in release mode the default modes never get set.

When using OpenCV (master) with OpenNI2 (from occipital) in release mode, the depth and rgb images obtained have a resolution of 320x240 by default, whereas cap_openni2.cpp set them to 640x480. By changing:

CV_DbgAssert --> CV_Assert

The default size is the correct one.

PS.- I tried to manually change the resolution of the color and depth images from my project code - without altering the OpenCV source code but was not able to do so (either the Carmine hangs or get some weird error).
