### PR TITLE
fix obvious copy+paste typo in computeDistance()

### DIFF
--- a/modules/shape/src/sc_dis.cpp
+++ b/modules/shape/src/sc_dis.cpp
@@ -199,7 +199,7 @@ float ShapeContextDistanceExtractorImpl::computeDistance(InputArray contour1, In
     if (set2.type() != CV_32F)
         sset2.convertTo(set2, CV_32F);
     else
-        sset1.copyTo(set2);
+        sset2.copyTo(set2);
 
     CV_Assert((set1.channels()==2) && (set1.cols>0));
     CV_Assert((set2.channels()==2) && (set2.cols>0));


### PR DESCRIPTION
(with this else-branch, argument contour2 would not be used at all)
