### PR TITLE
Disable -Wshadow warning for CUDA modules

### DIFF
--- a/modules/cudaarithm/CMakeLists.txt
+++ b/modules/cudaarithm/CMakeLists.txt
@@ -4,7 +4,7 @@ endif()
 
 set(the_description "CUDA-accelerated Operations on Matrices")
 
-ocv_warnings_disable(CMAKE_CXX_FLAGS /wd4127 /wd4324 /wd4512 -Wundef -Wmissing-declarations)
+ocv_warnings_disable(CMAKE_CXX_FLAGS /wd4127 /wd4324 /wd4512 -Wundef -Wmissing-declarations -Wshadow)
 
 ocv_add_module(cudaarithm opencv_core OPTIONAL opencv_cudev)
 

--- a/modules/cudabgsegm/CMakeLists.txt
+++ b/modules/cudabgsegm/CMakeLists.txt
@@ -4,6 +4,6 @@ endif()
 
 set(the_description "CUDA-accelerated Background Segmentation")
 
-ocv_warnings_disable(CMAKE_CXX_FLAGS /wd4127 /wd4324 /wd4512 -Wundef -Wmissing-declarations)
+ocv_warnings_disable(CMAKE_CXX_FLAGS /wd4127 /wd4324 /wd4512 -Wundef -Wmissing-declarations -Wshadow)
 
 ocv_define_module(cudabgsegm opencv_video OPTIONAL opencv_imgproc opencv_cudaarithm opencv_cudafilters opencv_cudaimgproc)

--- a/modules/cudacodec/CMakeLists.txt
+++ b/modules/cudacodec/CMakeLists.txt
@@ -4,7 +4,7 @@ endif()
 
 set(the_description "CUDA-accelerated Video Encoding/Decoding")
 
-ocv_warnings_disable(CMAKE_CXX_FLAGS /wd4127 /wd4324 /wd4512 -Wundef)
+ocv_warnings_disable(CMAKE_CXX_FLAGS /wd4127 /wd4324 /wd4512 -Wundef -Wshadow)
 
 ocv_add_module(cudacodec opencv_core opencv_videoio OPTIONAL opencv_cudev)
 

--- a/modules/cudafeatures2d/CMakeLists.txt
+++ b/modules/cudafeatures2d/CMakeLists.txt
@@ -4,6 +4,6 @@ endif()
 
 set(the_description "CUDA-accelerated Feature Detection and Description")
 
-ocv_warnings_disable(CMAKE_CXX_FLAGS /wd4127 /wd4100 /wd4324 /wd4512 /wd4515 -Wundef -Wmissing-declarations -Wshadow -Wunused-parameter)
+ocv_warnings_disable(CMAKE_CXX_FLAGS /wd4127 /wd4100 /wd4324 /wd4512 /wd4515 -Wundef -Wmissing-declarations -Wshadow -Wunused-parameter -Wshadow)
 
 ocv_define_module(cudafeatures2d opencv_features2d opencv_cudafilters opencv_cudawarping)

--- a/modules/cudafilters/CMakeLists.txt
+++ b/modules/cudafilters/CMakeLists.txt
@@ -4,6 +4,6 @@ endif()
 
 set(the_description "CUDA-accelerated Image Filtering")
 
-ocv_warnings_disable(CMAKE_CXX_FLAGS /wd4127 /wd4324 /wd4512 -Wundef -Wmissing-declarations)
+ocv_warnings_disable(CMAKE_CXX_FLAGS /wd4127 /wd4324 /wd4512 -Wundef -Wmissing-declarations -Wshadow)
 
 ocv_define_module(cudafilters opencv_imgproc opencv_cudaarithm)

--- a/modules/cudalegacy/CMakeLists.txt
+++ b/modules/cudalegacy/CMakeLists.txt
@@ -4,6 +4,6 @@ endif()
 
 set(the_description "CUDA-accelerated Computer Vision (legacy)")
 
-ocv_warnings_disable(CMAKE_CXX_FLAGS /wd4127 /wd4130 /wd4324 /wd4512 /wd4310 -Wundef -Wmissing-declarations -Wuninitialized)
+ocv_warnings_disable(CMAKE_CXX_FLAGS /wd4127 /wd4130 /wd4324 /wd4512 /wd4310 -Wundef -Wmissing-declarations -Wuninitialized -Wshadow)
 
 ocv_define_module(cudalegacy opencv_core OPTIONAL opencv_objdetect)

--- a/modules/cudaoptflow/CMakeLists.txt
+++ b/modules/cudaoptflow/CMakeLists.txt
@@ -4,6 +4,6 @@ endif()
 
 set(the_description "CUDA-accelerated Optical Flow")
 
-ocv_warnings_disable(CMAKE_CXX_FLAGS /wd4127 /wd4324 /wd4512 -Wundef -Wmissing-declarations)
+ocv_warnings_disable(CMAKE_CXX_FLAGS /wd4127 /wd4324 /wd4512 -Wundef -Wmissing-declarations -Wshadow)
 
 ocv_define_module(cudaoptflow opencv_video opencv_cudaarithm opencv_cudawarping opencv_cudaimgproc OPTIONAL opencv_cudalegacy)

--- a/modules/cudastereo/CMakeLists.txt
+++ b/modules/cudastereo/CMakeLists.txt
@@ -4,6 +4,6 @@ endif()
 
 set(the_description "CUDA-accelerated Stereo Correspondence")
 
-ocv_warnings_disable(CMAKE_CXX_FLAGS /wd4127 /wd4324 /wd4512 -Wundef -Wmissing-declarations)
+ocv_warnings_disable(CMAKE_CXX_FLAGS /wd4127 /wd4324 /wd4512 -Wundef -Wmissing-declarations -Wshadow)
 
 ocv_define_module(cudastereo opencv_calib3d)

--- a/modules/cudawarping/CMakeLists.txt
+++ b/modules/cudawarping/CMakeLists.txt
@@ -4,6 +4,6 @@ endif()
 
 set(the_description "CUDA-accelerated Image Warping")
 
-ocv_warnings_disable(CMAKE_CXX_FLAGS /wd4127 /wd4324 /wd4512 -Wundef -Wmissing-declarations)
+ocv_warnings_disable(CMAKE_CXX_FLAGS /wd4127 /wd4324 /wd4512 -Wundef -Wmissing-declarations -Wshadow)
 
 ocv_define_module(cudawarping opencv_imgproc OPTIONAL opencv_cudalegacy)

--- a/modules/cudev/CMakeLists.txt
+++ b/modules/cudev/CMakeLists.txt
@@ -4,7 +4,7 @@ endif()
 
 set(the_description "CUDA device layer")
 
-ocv_warnings_disable(CMAKE_CXX_FLAGS /wd4189 /wd4505 -Wundef -Wmissing-declarations -Wunused-function -Wunused-variable -Wenum-compare)
+ocv_warnings_disable(CMAKE_CXX_FLAGS /wd4189 /wd4505 -Wundef -Wmissing-declarations -Wunused-function -Wunused-variable -Wenum-compare -Wshadow)
 
 ocv_add_module(cudev)
 


### PR DESCRIPTION
it is generated by CUDA headers and we can't fix it
