### PR TITLE
Fix install target on linux

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -598,10 +598,6 @@ if(INSTALL_TESTS AND OPENCV_TEST_DATA_PATH AND UNIX)
     install(PROGRAMS "${CMAKE_BINARY_DIR}/unix-install/opencv_run_all_tests.sh"
             DESTINATION ${CMAKE_INSTALL_PREFIX} COMPONENT tests)
   else()
-    configure_file("${CMAKE_CURRENT_SOURCE_DIR}/cmake/templates/opencv_testing.sh.in"
-                   "${CMAKE_BINARY_DIR}/unix-install/opencv_testing.sh" @ONLY)
-    install(FILES "${CMAKE_BINARY_DIR}/unix-install/opencv_testing.sh"
-            DESTINATION /etc/profile.d/ COMPONENT tests)
     configure_file("${CMAKE_CURRENT_SOURCE_DIR}/cmake/templates/opencv_run_all_tests_unix.sh.in"
                    "${CMAKE_BINARY_DIR}/unix-install/opencv_run_all_tests.sh" @ONLY)
     install(PROGRAMS "${CMAKE_BINARY_DIR}/unix-install/opencv_run_all_tests.sh"

--- a/cmake/templates/opencv_testing.sh.in
+++ b/cmake/templates/opencv_testing.sh.in
@@ -1,2 +1,0 @@
-# Environment setup for OpenCV testing
-export OPENCV_TEST_DATA_PATH=@CMAKE_INSTALL_PREFIX@/share/OpenCV/testdata


### PR DESCRIPTION
Removed `opencv_testing.sh` installation to `/etc/profile.d/`.
The `opencv_run_all_tests_unix.sh` script already exports `OPENCV_TEST_DATA_PATH`.
