### PR TITLE
IPPICV: don't use full paths as dependencies

### DIFF
--- a/cmake/OpenCVFindIPP.cmake
+++ b/cmake/OpenCVFindIPP.cmake
@@ -132,24 +132,22 @@ macro(ipp_detect_version)
     endif ()
     if (EXISTS ${IPP_LIBRARY_DIR}/${IPP_LIB_PREFIX}${IPP_PREFIX}${name}${IPP_SUFFIX}${IPP_LIB_SUFFIX})
       if (BUILD_WITH_DYNAMIC_IPP AND NOT HAVE_IPP_ICV_ONLY)
-        add_library(${IPP_PREFIX}${name} STATIC IMPORTED)
+        # When using dynamic libraries from standalone IPP it is your responsibility to install those on the target system
+        list(APPEND IPP_LIBRARIES ${IPP_LIBRARY_DIR}/${IPP_LIB_PREFIX}${IPP_PREFIX}${name}${IPP_SUFFIX}${IPP_LIB_SUFFIX})
       else ()
-        add_library(${IPP_PREFIX}${name} SHARED IMPORTED)
-      endif ()
-      set_target_properties(${IPP_PREFIX}${name} PROPERTIES
-        IMPORTED_LINK_INTERFACE_LIBRARIES ""
-        IMPORTED_LOCATION ${IPP_LIBRARY_DIR}/${IPP_LIB_PREFIX}${IPP_PREFIX}${name}${IPP_SUFFIX}${IPP_LIB_SUFFIX}
-      )
-      list(APPEND IPP_LIBRARIES ${IPP_LIBRARY_DIR}/${IPP_LIB_PREFIX}${IPP_PREFIX}${name}${IPP_SUFFIX}${IPP_LIB_SUFFIX})
-      # CMake doesn't support "install(TARGETS ${IPP_PREFIX}${name} " command with imported targets
-      # When using dynamic libraries from standalone IPP it is your responsibility to install those on the target system
-      if (NOT BUILD_WITH_DYNAMIC_IPP)
+        add_library(ipp${name} STATIC IMPORTED)
+        set_target_properties(ipp${name} PROPERTIES
+          IMPORTED_LINK_INTERFACE_LIBRARIES ""
+          IMPORTED_LOCATION ${IPP_LIBRARY_DIR}/${IPP_LIB_PREFIX}${IPP_PREFIX}${name}${IPP_SUFFIX}${IPP_LIB_SUFFIX}
+        )
+        list(APPEND IPP_LIBRARIES ipp${name})
+        # CMake doesn't support "install(TARGETS ${IPP_PREFIX}${name} " command with imported targets
         install(FILES ${IPP_LIBRARY_DIR}/${IPP_LIB_PREFIX}${IPP_PREFIX}${name}${IPP_SUFFIX}${IPP_LIB_SUFFIX}
                 DESTINATION ${OPENCV_3P_LIB_INSTALL_PATH} COMPONENT main)
         string(TOUPPER ${name} uname)
         set(IPP${uname}_INSTALL_PATH "${CMAKE_INSTALL_PREFIX}/${OPENCV_3P_LIB_INSTALL_PATH}/${IPP_LIB_PREFIX}${IPP_PREFIX}${name}${IPP_SUFFIX}${IPP_LIB_SUFFIX}" CACHE INTERNAL "" FORCE)
         set(IPP${uname}_LOCATION_PATH "${IPP_LIBRARY_DIR}/${IPP_LIB_PREFIX}${IPP_PREFIX}${name}${IPP_SUFFIX}${IPP_LIB_SUFFIX}" CACHE INTERNAL "" FORCE)
-      endif ()
+      endif()
     else()
       message(STATUS "Can't find IPP library: ${name} at ${IPP_LIBRARY_DIR}/${IPP_LIB_PREFIX}${IPP_PREFIX}${name}${IPP_SUFFIX}${IPP_LIB_SUFFIX}")
     endif()


### PR DESCRIPTION
Fix the problem introduced by #3510.

Full paths are removed from libraries dependencies, because they broke OpenCV package build. Use CMake targets instead of full paths to libs.
