### PR TITLE
Fix cppcheck reports warnings:

### DIFF
--- a/modules/calib3d/src/stereobm.cpp
+++ b/modules/calib3d/src/stereobm.cpp
@@ -666,7 +666,7 @@ findStereoCorrespondenceBM( const Mat& left, const Mat& right,
                 int thresh = minsad + (minsad * uniquenessRatio/100);
                 for( d = 0; d < ndisp; d++ )
                 {
-                    if( sad[d] <= thresh && (d < mind-1 || d > mind+1))
+                    if( (d < mind-1 || d > mind+1) && sad[d] <= thresh)
                         break;
                 }
                 if( d < ndisp )

--- a/modules/imgcodecs/src/loadsave.cpp
+++ b/modules/imgcodecs/src/loadsave.cpp
@@ -192,7 +192,7 @@ static ImageEncoder findEncoder( const String& _ext )
     if( !ext )
         return ImageEncoder();
     int len = 0;
-    for( ext++; isalnum(ext[len]) && len < 128; len++ )
+    for( ext++; len < 128 && isalnum(ext[len]); len++ )
         ;
 
     for( size_t i = 0; i < codecs.encoders.size(); i++ )
@@ -206,7 +206,7 @@ static ImageEncoder findEncoder( const String& _ext )
             if( !descr )
                 break;
             int j = 0;
-            for( descr++; isalnum(descr[j]) && j < len; j++ )
+            for( descr++; j < len && isalnum(descr[j]) ; j++ )
             {
                 int c1 = tolower(ext[j]);
                 int c2 = tolower(descr[j]);

--- a/modules/imgproc/src/shapedescr.cpp
+++ b/modules/imgproc/src/shapedescr.cpp
@@ -79,7 +79,7 @@ static bool findCircle( Point2f pt0, Point2f pt1, Point2f pt2,
     }
 
     center->x = center->y = 0.f;
-    radius = 0;
+    *radius = 0;
     return false;
 }
 

--- a/modules/ml/src/lr.cpp
+++ b/modules/ml/src/lr.cpp
@@ -542,7 +542,7 @@ Mat LogisticRegressionImpl::remap_labels(const Mat& _labels_i, const map<int, in
 
     Mat new_labels = Mat::zeros(labels.rows, labels.cols, labels.type());
 
-    CV_Assert( lmap.size() > 0 );
+    CV_Assert( !lmap.empty() );
 
     for(int i =0;i<labels.rows;i++)
     {


### PR DESCRIPTION
(performance) Possible inefficient checking for 'lmap' emptiness
(warning) Assignment of function parameter has no effect outside the function. Did you forget dereferencing it?
(style) Array index '<xxx>' is used before limits check
