### PR TITLE
modules/videoio/src/cap_openni.cpp: fix const-ness related compile errors

### DIFF
--- a/modules/videoio/src/cap_openni.cpp
+++ b/modules/videoio/src/cap_openni.cpp
@@ -477,11 +477,11 @@ protected:
 
     bool readCamerasParams();
 
-    double getDepthGeneratorProperty(int propIdx);
+    double getDepthGeneratorProperty(int propIdx) const;
     bool setDepthGeneratorProperty(int propIdx, double propVal);
-    double getImageGeneratorProperty(int propIdx);
+    double getImageGeneratorProperty(int propIdx) const;
     bool setImageGeneratorProperty(int propIdx, double propVal);
-    double getCommonProperty(int propIdx);
+    double getCommonProperty(int propIdx) const;
     bool setCommonProperty(int propIdx, double propVal);
 
     // OpenNI context
@@ -820,7 +820,7 @@ bool CvCapture_OpenNI::setProperty( int propIdx, double propValue )
     return isSet;
 }
 
-double CvCapture_OpenNI::getCommonProperty( int propIdx )
+double CvCapture_OpenNI::getCommonProperty( int propIdx ) const
 {
     double propValue = 0;
 
@@ -917,7 +917,7 @@ bool CvCapture_OpenNI::setCommonProperty( int propIdx, double propValue )
     return isSet;
 }
 
-double CvCapture_OpenNI::getDepthGeneratorProperty( int propIdx )
+double CvCapture_OpenNI::getDepthGeneratorProperty( int propIdx ) const
 {
     double propValue = 0;
     if( !depthGenerator.IsValid() )
@@ -953,7 +953,7 @@ double CvCapture_OpenNI::getDepthGeneratorProperty( int propIdx )
         propValue = (double)depthFocalLength_VGA;
         break;
     case CV_CAP_PROP_OPENNI_REGISTRATION :
-        propValue = depthGenerator.GetAlternativeViewPointCap().IsViewPointAs(imageGenerator) ? 1.0 : 0.0;
+        propValue = depthGenerator.GetAlternativeViewPointCap().IsViewPointAs(const_cast<xn::ImageGenerator &>(imageGenerator)) ? 1.0 : 0.0;
         break;
     case CV_CAP_PROP_POS_MSEC :
         propValue = (double)depthGenerator.GetTimestamp();
@@ -1018,7 +1018,7 @@ bool CvCapture_OpenNI::setDepthGeneratorProperty( int propIdx, double propValue 
     return isSet;
 }
 
-double CvCapture_OpenNI::getImageGeneratorProperty( int propIdx )
+double CvCapture_OpenNI::getImageGeneratorProperty( int propIdx ) const
 {
     double propValue = 0.;
     if( !imageGenerator.IsValid() )


### PR DESCRIPTION
Commit 854a722c introduced compile errors (linux, gcc 4.8.3) because CvCapture_OpenNI::getProperty was const-ified, while the methods it calls - CvCapture_OpenNI::getImageGeneratorProperty(), CvCapture_OpenNI::getDepthGeneratorProperty(), and CvCapture_OpenNI::getCommonProperty() were not.

This commit const-ifies the above three methods. In addition, a const_cast is needed for the argument of
depthGenerator.GetAlternativeViewPointCap().IsViewPointAs() in getDepthGeneratorProperty().
