### PR TITLE
modules/core: removed extra semi-colon from mat.inl.hpp and utility.hpp

### DIFF
--- a/modules/core/include/opencv2/core/mat.inl.hpp
+++ b/modules/core/include/opencv2/core/mat.inl.hpp
@@ -1005,13 +1005,13 @@ MatIterator_<_Tp> Mat::end()
 template<typename _Tp, typename Functor> inline
 void Mat::forEach(const Functor& operation) {
     this->forEach_impl<_Tp>(operation);
-};
+}
 
 template<typename _Tp, typename Functor> inline
 void Mat::forEach(const Functor& operation) const {
     // call as not const
     (const_cast<Mat*>(this))->forEach<const _Tp>(operation);
-};
+}
 
 template<typename _Tp> inline
 Mat::operator std::vector<_Tp>() const

--- a/modules/core/include/opencv2/core/utility.hpp
+++ b/modules/core/include/opencv2/core/utility.hpp
@@ -465,7 +465,7 @@ void Mat::forEach_impl(const Functor& operation) {
     };
 
     parallel_for_(cv::Range(0, LINES), PixelOperationWrapper(reinterpret_cast<Mat_<_Tp>*>(this), operation));
-};
+}
 
 /////////////////////////// Synchronization Primitives ///////////////////////////////
 


### PR DESCRIPTION
This silences the pedantic warning messages from gcc 4.8.3
