### PR TITLE
Fixed memory leak in ML module

### DIFF
--- a/modules/ml/src/data.cpp
+++ b/modules/ml/src/data.cpp
@@ -92,7 +92,7 @@ void CvMLData::free_train_test_idx()
 {
     cvReleaseMat( &train_sample_idx );
     cvReleaseMat( &test_sample_idx );
-    sample_idx = 0;
+    cvFree(&sample_idx);
 }
 
 void CvMLData::clear()


### PR DESCRIPTION
`CvMLData::sample_idx` was not freed
Allocated during `CvMLData::set_train_test_split` call, line 636.
