### PR TITLE
fix a bug in updateTrainingSet

### DIFF
--- a/apps/traincascade/cascadeclassifier.cpp
+++ b/apps/traincascade/cascadeclassifier.cpp
@@ -309,7 +309,8 @@ bool CvCascadeClassifier::updateTrainingSet( double minimumAcceptanceRatio, doub
     int proNumNeg = cvRound( ( ((double)numNeg) * ((double)posCount) ) / numPos ); // apply only a fraction of negative samples. double is required since overflow is possible
     int negCount = fillPassedSamples( posCount, proNumNeg, false, minimumAcceptanceRatio, negConsumed );
     if ( !negCount )
-        return false;
+        if ( !(negConsumed > 0 && ((double)negCount+1)/(double)negConsumed <= minimumAcceptanceRatio) )
+            return false;
 
     curNumSamples = posCount + negCount;
     acceptanceRatio = negConsumed == 0 ? 0 : ( (double)negCount/(double)(int64)negConsumed );


### PR DESCRIPTION
In case fillPassedSamples find zero passed negatives and leafFA is achieved, function updateTrainingSet will return false and print misleading information, this PR fix the case.