### PR TITLE
Fix for missing templates when ChamferMatcher is deconstructed.

### DIFF
--- a/modules/contrib/src/chamfermatching.cpp
+++ b/modules/contrib/src/chamfermatching.cpp
@@ -243,9 +243,14 @@ private:
 
         ~Matching()
         {
-            for (size_t i = 0; i<templates.size(); i++) {
-                delete templates[i];
-            }
+	  /* 
+	   *When ChamferMatcher is deleted, it tries to delete its templates as well which causes an error 
+	   *due to the templates already being deleted in the deconstructor.
+	   * Hence commenting out template delete operations.
+	   */
+	    //for (size_t i = 0; i<templates.size(); i++) {
+	    //    delete templates[i];
+	    //}
         }
 
         /**
@@ -1353,7 +1358,7 @@ const ChamferMatcher::Matches& ChamferMatcher::matching(Template& tpl, Mat& imag
 }
 
 
-int chamerMatching( Mat& img, Mat& templ,
+int chamferMatching( Mat& img, Mat& templ,
                     std::vector<std::vector<Point> >& results, std::vector<float>& costs,
                     double templScale, int maxMatches, double minMatchDistance, int padX,
                     int padY, int scales, double minScale, double maxScale,

--- a/samples/cpp/chamfer.cpp
+++ b/samples/cpp/chamfer.cpp
@@ -51,7 +51,7 @@ int main( int argc, const char** argv )
 
     vector<vector<Point> > results;
     vector<float> costs;
-    int best = chamerMatching( img, tpl, results, costs );
+    int best = chamferMatching( img, tpl, results, costs );
     if( best < 0 )
     {
         cout << "matching not found" << endl;


### PR DESCRIPTION
When the ChamferMatcher object is deconstructed, it tries deleting the templates attached to it during the `matching` function. The templates are already deleted by the Template deconstructor though, and thus an error. Hence I have commented out the delete operation in the Template deconstructor.