### PR TITLE
Better png transparency handling

### DIFF
--- a/modules/imgcodecs/src/grfmt_png.cpp
+++ b/modules/imgcodecs/src/grfmt_png.cpp
@@ -266,7 +266,7 @@ bool  PngDecoder::readData( Mat& img )
             if( m_color_type == PNG_COLOR_TYPE_PALETTE )
                 png_set_palette_to_rgb( png_ptr );
 
-            if( (m_color_type & PNG_COLOR_MASK_COLOR) != 0 && m_bit_depth < 8 )
+            if( (m_color_type & PNG_COLOR_MASK_COLOR) == 0 && m_bit_depth < 8 )
 #if (PNG_LIBPNG_VER_MAJOR*10000 + PNG_LIBPNG_VER_MINOR*100 + PNG_LIBPNG_VER_RELEASE >= 10209) || \
     (PNG_LIBPNG_VER_MAJOR == 1 && PNG_LIBPNG_VER_MINOR == 0 && PNG_LIBPNG_VER_RELEASE >= 18)
                 png_set_expand_gray_1_2_4_to_8( png_ptr );

--- a/modules/imgcodecs/src/loadsave.cpp
+++ b/modules/imgcodecs/src/loadsave.cpp
@@ -452,8 +452,6 @@ static bool imwrite_( const String& filename, const Mat& image,
     Mat temp;
     const Mat* pimage = &image;
 
-    CV_Assert( image.channels() == 1 || image.channels() == 3 || image.channels() == 4 );
-
     ImageEncoder encoder = findEncoder( filename );
     if( !encoder )
         CV_Error( CV_StsError, "could not find a writer for the specified extension" );
@@ -589,9 +587,6 @@ bool imencode( const String& ext, InputArray _image,
                std::vector<uchar>& buf, const std::vector<int>& params )
 {
     Mat image = _image.getMat();
-
-    int channels = image.channels();
-    CV_Assert( channels == 1 || channels == 3 || channels == 4 );
 
     ImageEncoder encoder = findEncoder( ext );
     if( !encoder )


### PR DESCRIPTION
### Binary transparency
The current png decoder ignores pngs binary transparency except for palette images.
This adds binary transparency awareness by adding an alpha channel to the resulting `Mat` for RGB and grayscale pngs featuring binary transparency.

### Grayscale with alpha channel
Support for grayscale pngs with alpha channel is also added to both the png decoder and the png encoder.
Note that grayscale pngs with transparency (alpha channel or binary transparency) will now result in a 2-channel image so the `imwrite`/`imencode` functions were made to accept 2-channel images.
