### PR TITLE
Ensure the Cuda context is initialized correctly

### DIFF
--- a/modules/core/src/cuda_info.cpp
+++ b/modules/core/src/cuda_info.cpp
@@ -70,8 +70,8 @@ void cv::cuda::setDevice(int device)
     (void) device;
     throw_no_cuda();
 #else
-    cudaFree(0);
     cudaSafeCall( cudaSetDevice(device) );
+    cudaSafeCall( cudaFree(0) );
 #endif
 }
 

--- a/modules/core/src/cuda_info.cpp
+++ b/modules/core/src/cuda_info.cpp
@@ -70,6 +70,7 @@ void cv::cuda::setDevice(int device)
     (void) device;
     throw_no_cuda();
 #else
+    cudaFree(0);
     cudaSafeCall( cudaSetDevice(device) );
 #endif
 }


### PR DESCRIPTION
As long as the setDevice is not called in a multi-thread environment.
This avoids having to call a cuda OpenCV function in the main thread before any multi-threads calls.
See #6086.