### PR TITLE
Tiled & thin-prism model coefficient checks modified

### DIFF
--- a/modules/calib3d/src/calibration.cpp
+++ b/modules/calib3d/src/calibration.cpp
@@ -1302,15 +1302,13 @@ CV_IMPL double cvCalibrateCamera2( const CvMat* objectPoints,
     if(flags & CV_CALIB_TILTED_MODEL)
     {
         //when the tilted sensor model is used the distortion coefficients matrix must have 14 parameters
-        if (distCoeffs->cols*distCoeffs->rows != 14)
-            CV_Error( CV_StsBadArg, "The tilted sensor model must have 14 parameters in the distortion matrix" );
-    }
-    else
-    {
+        if (distCoeffs->cols*distCoeffs->rows < 14)
+            CV_Error( CV_StsBadArg, "The tilted sensor model must have at least 14 parameters in the distortion matrix" );
+    } else {
         //when the thin prism model is used the distortion coefficients matrix must have 12 parameters
         if(flags & CV_CALIB_THIN_PRISM_MODEL)
-            if (distCoeffs->cols*distCoeffs->rows != 12)
-                CV_Error( CV_StsBadArg, "Thin prism model must have 12 parameters in the distortion matrix" );
+            if (distCoeffs->cols*distCoeffs->rows < 12)
+                CV_Error( CV_StsBadArg, "Thin prism model must have at least 12 parameters in the distortion matrix" );
     }
 
     nimages = npoints->rows*npoints->cols;


### PR DESCRIPTION
resolves #6412

Now the ```cvCalibrateCamera2``` function will fail only if there are less than 12 distortion coefficients for thin prism and 14 distortion coefficients for tiled models: it will not fail if the number of distortion coefficients in the passed-in vector is "too large", the superfluous values will simply not be used.

This fixes a bug when calibrateCamera is called from python bindings using the CALIB_THIN_PRISM_MODEL flag (where the vector is automatically initialized to maximal length, 14).
