### PR TITLE
Fixed BackgroundSubstractorMOG2 in opencv_video.

### DIFF
--- a/modules/ocl/src/opencl/bgfg_mog.cl
+++ b/modules/ocl/src/opencl/bgfg_mog.cl
@@ -369,7 +369,6 @@ __kernel void mog2_kernel(__global T_FRAME * frame, __global int* fgmask, __glob
         bool fitsPDF = false; //if it remains zero a new GMM mode will be added
 
         int nmodes = modesUsed[y * modesUsed_step + x];
-        int nNewModes = nmodes; //current number of modes in GMM
 
         float totalWeight = 0.0f;
 
@@ -429,8 +428,6 @@ __kernel void mog2_kernel(__global T_FRAME * frame, __global int* fgmask, __glob
         totalWeight = 1.f / totalWeight;
         for (int mode = 0; mode < nmodes; ++mode)
             weight[(mode * frame_row + y) * weight_step + x] *= totalWeight;
-
-        nmodes = nNewModes;
 
         if (!fitsPDF)
         {

--- a/modules/video/src/bgfg_gaussmix2.cpp
+++ b/modules/video/src/bgfg_gaussmix2.cpp
@@ -309,7 +309,7 @@ struct MOG2Invoker : ParallelLoopBody
 
                 //internal:
                 bool fitsPDF = false;//if it remains zero a new GMM mode will be added
-                int nmodes = modesUsed[x], nNewModes = nmodes;//current number of modes in GMM
+                int nmodes = modesUsed[x];//current number of modes in GMM
                 float totalWeight = 0.f;
 
                 float* mean_m = mean;
@@ -414,8 +414,6 @@ struct MOG2Invoker : ParallelLoopBody
                 {
                     gmm[mode].weight *= totalWeight;
                 }
-
-                nmodes = nNewModes;
 
                 //make new mode if needed and exit
                 if( !fitsPDF )


### PR DESCRIPTION

The number of gaussians involved in a mixture is supposed
to be dynamically adjusted. After being increased, the number
of gaussians can't be reduced anymore.

It seems to be a regression as the legacy code
located in modules/legacy/src/bgfg_gaussmix.cpp allows to reduce
such number of gaussians.