### PR TITLE
Fixed BackgroundSubstractorMOG2 in opencv_video.

### DIFF
--- a/modules/video/src/bgfg_gaussmix2.cpp
+++ b/modules/video/src/bgfg_gaussmix2.cpp
@@ -594,7 +594,7 @@ public:
 
                 //internal:
                 bool fitsPDF = false;//if it remains zero a new GMM mode will be added
-                int nmodes = modesUsed[x], nNewModes = nmodes;//current number of modes in GMM
+                int nmodes = modesUsed[x];//current number of modes in GMM
                 float totalWeight = 0.f;
 
                 float* mean_m = mean;
@@ -699,8 +699,6 @@ public:
                 {
                     gmm[mode].weight *= totalWeight;
                 }
-
-                nmodes = nNewModes;
 
                 //make new mode if needed and exit
                 if( !fitsPDF && alphaT > 0.f )


### PR DESCRIPTION

The number of gaussians involved in a mixture is supposed
to be dynamically adjusted. After being increased, the number
of gaussians can't be reduced anymore.

It seems to be a regression as the legacy code
located in modules/legacy/src/bgfg_gaussmix.cpp allows to reduce
such number of gaussians.