### PR TITLE
Optional mask argument for MatchTemplate_Demo

### DIFF
--- a/samples/cpp/tutorial_code/Histograms_Matching/MatchTemplate_Demo.cpp
+++ b/samples/cpp/tutorial_code/Histograms_Matching/MatchTemplate_Demo.cpp
@@ -13,7 +13,8 @@ using namespace std;
 using namespace cv;
 
 /// Global Variables
-Mat img; Mat templ; Mat result;
+bool use_mask;
+Mat img; Mat templ; Mat mask; Mat result;
 const char* image_window = "Source Image";
 const char* result_window = "Result window";
 
@@ -31,7 +32,7 @@ int main( int argc, char** argv )
   if (argc < 3)
   {
     cout << "Not enough parameters" << endl;
-    cout << "Usage:\n./MatchTemplate_Demo <image_name> <template_name>" << endl;
+    cout << "Usage:\n./MatchTemplate_Demo <image_name> <template_name> [<mask_name>]" << endl;
     return -1;
   }
 
@@ -39,7 +40,12 @@ int main( int argc, char** argv )
   img = imread( argv[1], IMREAD_COLOR );
   templ = imread( argv[2], IMREAD_COLOR );
 
-  if(img.empty() || templ.empty())
+  if(argc > 3) {
+    use_mask = true;
+    mask = imread(argv[3], IMREAD_COLOR);
+  }
+
+  if(img.empty() || templ.empty() || (use_mask && mask.empty()))
   {
     cout << "Can't read one of the images" << endl;
     return -1;
@@ -76,7 +82,12 @@ void MatchingMethod( int, void* )
   result.create( result_rows, result_cols, CV_32FC1 );
 
   /// Do the Matching and Normalize
-  matchTemplate( img, templ, result, match_method );
+  bool method_accepts_mask = CV_TM_SQDIFF == match_method || match_method == CV_TM_CCORR_NORMED;
+  if (use_mask && method_accepts_mask)
+    { matchTemplate( img, templ, result, match_method, mask); }
+  else
+    { matchTemplate( img, templ, result, match_method); }
+
   normalize( result, result, 0, 1, NORM_MINMAX, -1, Mat() );
 
   /// Localizing the best match with minMaxLoc


### PR DESCRIPTION
Accept and use optional mask argument for MatchTemplate_Demo.

Useful for visualizing effect of a mask on template matching.
