### PR TITLE
Segfault running merge (merge8u) on very large images. #6696

### DIFF
--- a/modules/core/src/convert.cpp
+++ b/modules/core/src/convert.cpp
@@ -107,7 +107,7 @@ void cv::split(const Mat& src, Mat* mv)
     }
 
     NAryMatIterator it(arrays, ptrs, cn+1);
-    int total = (int)it.size, blocksize = cn <= 4 ? total : std::min(total, blocksize0);
+    int total = (int)it.size, blocksize = std::min( cn <= 4 ? total : std::min(total, blocksize0) , INT_MAX / cn ) ;
 
     for( size_t i = 0; i < it.nplanes; i++, ++it )
     {
@@ -252,7 +252,7 @@ void cv::merge(const Mat* mv, size_t n, OutputArray _dst)
         arrays[k+1] = &mv[k];
 
     NAryMatIterator it(arrays, ptrs, cn+1);
-    int total = (int)it.size, blocksize = cn <= 4 ? total : std::min(total, blocksize0);
+    int total = (int)it.size, blocksize = std::min( cn <= 4 ? total : std::min(total, blocksize0) , INT_MAX / cn );
     MergeFunc func = getMergeFunc(depth);
 
     for( i = 0; i < it.nplanes; i++, ++it )


### PR DESCRIPTION
resolves #6696 

### What does this PR change?

merge_() function uses integer i /j as image offsets.
If input/output images are too large, it makes  an overflow problem about i or j.
And there are same problem in splits_() function. 

This fix splits those images so that integer counter can work well.