### PR TITLE
fixed the cuda optical flow error normalization factor

### DIFF
--- a/modules/cudaoptflow/src/cuda/pyrlk.cu
+++ b/modules/cudaoptflow/src/cuda/pyrlk.cu
@@ -344,6 +344,18 @@ namespace pyrlk
         return ret;
     }
 
+    template <typename T>
+    struct DenormalizationFactor
+    {
+        static const float factor = 1.0;
+    };
+
+    template <>
+    struct DenormalizationFactor<uchar>
+    {
+        static const float factor = 255.0;
+    };
+
     template <int cn, int PATCH_X, int PATCH_Y, bool calcErr, typename T>
     __global__ void sparseKernel(const float2* prevPts, float2* nextPts, uchar* status, float* err, const int level, const int rows, const int cols)
     {
@@ -532,7 +544,7 @@ namespace pyrlk
             nextPts[blockIdx.x] = nextPt;
 
             if (calcErr)
-                err[blockIdx.x] = static_cast<float>(errval) / (cn * c_winSize_x * c_winSize_y);
+                err[blockIdx.x] = static_cast<float>(errval) / (::min(cn, 3) * c_winSize_x * c_winSize_y) * DenormalizationFactor<T>::factor;
         }
     }
 
@@ -725,7 +737,7 @@ namespace pyrlk
             nextPts[blockIdx.x] = nextPt;
 
             if (calcErr)
-                err[blockIdx.x] = static_cast<float>(errval) / (3 * c_winSize_x * c_winSize_y);
+                err[blockIdx.x] = static_cast<float>(errval) / (::min(cn, 3)*c_winSize_x * c_winSize_y);
         }
     } // __global__ void sparseKernel_
 


### PR DESCRIPTION
partly resolves #6532

texture channels were not considered correctly, nor was the cuda texture
normalization

With these changes the error is similar at least for some matrix type/channel combinations. For those combinations where the error is not close, there seems to be a constant factor of 1.3333 between cuda and cpu implementation. Only the combination unsigned 16bit 4-channel image still gives an unusable error.