### PR TITLE
Fix for median blur of 2-channel images

### DIFF
--- a/modules/imgproc/src/smooth.cpp
+++ b/modules/imgproc/src/smooth.cpp
@@ -2848,7 +2848,7 @@ void cv::medianBlur( InputArray _src0, OutputArray _dst, int ksize )
 
     bool useSortNet = ksize == 3 || (ksize == 5
 #if !(CV_SSE2 || CV_NEON)
-            && src0.depth() > CV_8U
+            && ( src0.depth() > CV_8U || src0.channels() == 2 || src0.channels() > 4 )
 #endif
         );
 


### PR DESCRIPTION
### What does this PR change?
In case of medianBlur processing for 2-channel images `useSortNet` condition branch should be evaluated since other branch doesn't support such images.

