### PR TITLE
fix matrix type for keypoints buffer in CUDA FAST

### DIFF
--- a/modules/cudafeatures2d/src/fast.cpp
+++ b/modules/cudafeatures2d/src/fast.cpp
@@ -104,7 +104,7 @@ namespace
         }
 
         BufferPool pool(Stream::Null());
-        GpuMat d_keypoints = pool.getBuffer(ROWS_COUNT, max_npoints_, CV_16SC2);
+        GpuMat d_keypoints = pool.getBuffer(ROWS_COUNT, max_npoints_, CV_32FC1);
 
         detectAsync(_image, d_keypoints, _mask, Stream::Null());
         convert(d_keypoints, keypoints);


### PR DESCRIPTION
Merge with extra: opencv/opencv_extra#300

Use CV_32FC1 instead of CV_16SC2 since detectAsync uses CV_32FC1 to reallocate the matrix.

### Former #6776