### PR TITLE
Bugfix 6641

### DIFF
--- a/modules/imgcodecs/src/jpeg_exif.cpp
+++ b/modules/imgcodecs/src/jpeg_exif.cpp
@@ -144,7 +144,7 @@ std::map<int, ExifEntry_t > ExifReader::getExif()
     while( ( !feof( f ) ) && !exifFound )
     {
         count = fread( appMarker, sizeof(unsigned char), markerSize, f );
-        if(( count < markerSize ) || ((appMarker[0] == '\0') && (appMarker[1] == '\0')))
+        if(( count < markerSize ) || ((appMarker[0] == appMarker[1]) && (appMarker[1] == '\0')))
         {
             break;
         }

--- a/modules/imgcodecs/src/jpeg_exif.cpp
+++ b/modules/imgcodecs/src/jpeg_exif.cpp
@@ -144,7 +144,7 @@ std::map<int, ExifEntry_t > ExifReader::getExif()
     while( ( !feof( f ) ) && !exifFound )
     {
         count = fread( appMarker, sizeof(unsigned char), markerSize, f );
-        if( count < markerSize )
+        if(( count < markerSize ) || ((appMarker[0] == '\0') && (appMarker[1] == '\0')))
         {
             break;
         }


### PR DESCRIPTION
resolves 6641

### What does this PR change?
Fix bug 6641 that an endless loop will happen for reading an specific jpg file.

Root cause: In function "getExif", if both of the values for appMarker[0] and appMarker[1] are '\0', this cannot match any of the termination condition. So endless loop will happen

Signed-off-by: Zhenqing, Hu <huzq85@gmail.com>

### Former #6700