### PR TITLE
Support for super-fisheye lenses (i.e., opening angles above 180 degr…

### DIFF
--- a/modules/calib3d/src/fisheye.cpp
+++ b/modules/calib3d/src/fisheye.cpp
@@ -1507,7 +1507,13 @@ void cv::internal::EstimateUncertainties(InputArrayOfArrays objectPoints, InputA
     CV_Assert(!omc.empty() && omc.type() == CV_64FC3);
     CV_Assert(!Tc.empty() && Tc.type() == CV_64FC3);
 
-    Mat ex((int)(objectPoints.getMat(0).total() * objectPoints.total()), 1, CV_64FC2);
+    int total_ex = 0;
+    for (int image_idx = 0; image_idx < (int)objectPoints.total(); ++image_idx)
+    {
+        total_ex += (int)objectPoints.getMat(image_idx).total();
+    }
+    Mat ex(total_ex, 1, CV_64FC2);
+    int insert_idx = 0;
 
     for (int image_idx = 0; image_idx < (int)objectPoints.total(); ++image_idx)
     {
@@ -1522,7 +1528,8 @@ void cv::internal::EstimateUncertainties(InputArrayOfArrays objectPoints, InputA
         std::vector<Point2d> x;
         projectPoints(object, x, om, T, params, noArray());
         Mat ex_ = (imT ? image.t() : image) - Mat(x);
-        ex_.copyTo(ex.rowRange(ex_.rows * image_idx,  ex_.rows * (image_idx + 1)));
+	ex_.copyTo(ex.rowRange(insert_idx, insert_idx + ex_.rows));
+        insert_idx += ex_.rows;
     }
 
     meanStdDev(ex, noArray(), std_err);

--- a/modules/calib3d/src/fisheye.cpp
+++ b/modules/calib3d/src/fisheye.cpp
@@ -109,8 +109,8 @@ void cv::fisheye::projectPoints(InputArray objectPoints, OutputArray imagePoints
 
     Matx33d R;
     Matx<double, 3, 9> dRdom;
-    Rodrigues(om, R, dRdom);
-    Affine3d aff(om, T);
+    Rodrigues(om, R, jacobian.needed() ? dRdom : noArray());
+    Affine3d aff(R, T);
 
     const Vec3f* Xf = objectPoints.getMat().ptr<Vec3f>();
     const Vec3d* Xd = objectPoints.getMat().ptr<Vec3d>();
@@ -167,7 +167,7 @@ void cv::fisheye::projectPoints(InputArray objectPoints, OutputArray imagePoints
             const Vec3d& dzdom = dYdom[2];
             const Vec3d& dzdT  = dYdT[2];
 
-            // double theta_ = r<1e-8*z ? 1/z - r2/(3*z*z*z) : atan2(r, z)/r;
+            // double theta_ = r<1e-8*z ? 1/z - r2/(3*z3) : atan2(r, z)/r;
             double dtheta_dr2 = r<1e-8*z ? -1/(3*z3) : 1/(2*r2)*(z/(r2+z2) - theta_);
             double dtheta_dz  = -1/(r2+z2);
 

--- a/modules/calib3d/src/fisheye.cpp
+++ b/modules/calib3d/src/fisheye.cpp
@@ -1116,8 +1116,8 @@ cv::internal::IntrinsicParams cv::internal::IntrinsicParams::operator+(const Mat
     tmp.f[0]    = this->f[0]    + (isEstimate[0] ? ptr[j++] : 0);
     tmp.f[1]    = this->f[1]    + (isEstimate[1] ? ptr[j++] : 0);
     tmp.c[0]    = this->c[0]    + (isEstimate[2] ? ptr[j++] : 0);
-    tmp.alpha   = this->alpha   + (isEstimate[4] ? ptr[j++] : 0);
     tmp.c[1]    = this->c[1]    + (isEstimate[3] ? ptr[j++] : 0);
+    tmp.alpha   = this->alpha   + (isEstimate[4] ? ptr[j++] : 0);
     tmp.k[0]    = this->k[0]    + (isEstimate[5] ? ptr[j++] : 0);
     tmp.k[1]    = this->k[1]    + (isEstimate[6] ? ptr[j++] : 0);
     tmp.k[2]    = this->k[2]    + (isEstimate[7] ? ptr[j++] : 0);

--- a/modules/calib3d/src/fisheye.cpp
+++ b/modules/calib3d/src/fisheye.cpp
@@ -357,6 +357,7 @@ void cv::fisheye::undistortPoints( InputArray distorted, OutputArray undistorted
         Vec2d pw((pi[0] - c[0])/f[0], (pi[1] - c[1])/f[1]);      // world point
 
         double scale = 1.0;
+        double z = 1.0;
 
         double theta_d = sqrt(pw[0]*pw[0] + pw[1]*pw[1]);
         if (theta_d > 1e-8)
@@ -368,15 +369,15 @@ void cv::fisheye::undistortPoints( InputArray distorted, OutputArray undistorted
                 double theta2 = theta*theta, theta4 = theta2*theta2, theta6 = theta4*theta2, theta8 = theta6*theta2;
                 theta = theta_d / (1 + k[0] * theta2 + k[1] * theta4 + k[2] * theta6 + k[3] * theta8);
             }
-
-            scale = std::tan(theta) / theta_d;
+            scale = std::sin(theta) / theta_d;
+            z = std::cos(theta);
         }
 
         Vec2d pu = pw * scale; //undistorted point
 
         // reproject
-        Vec3d pr = RR * Vec3d(pu[0], pu[1], 1.0); // rotated point optionally multiplied by new camera matrix
-        Vec2d fi(pr[0]/pr[2], pr[1]/pr[2]);       // final
+        Vec3d pr = RR * Vec3d(pu[0], pu[1], z); // rotated point optionally multiplied by new camera matrix
+        Vec2d fi(pr[0]/pr[2], pr[1]/pr[2]);     // final
 
         if( sdepth == CV_32F )
             dstf[i] = fi;

--- a/modules/calib3d/src/fisheye.cpp
+++ b/modules/calib3d/src/fisheye.cpp
@@ -443,21 +443,21 @@ void cv::fisheye::initUndistortRectifyMap( InputArray K, InputArray D, InputArra
         short*  m1 = (short*)m1f;
         ushort* m2 = (ushort*)m2f;
 
-        double _x = i*iR(0, 1) + iR(0, 2),
-               _y = i*iR(1, 1) + iR(1, 2),
-               _w = i*iR(2, 1) + iR(2, 2);
+        double x = i*iR(0, 1) + iR(0, 2),
+               y = i*iR(1, 1) + iR(1, 2),
+               z = i*iR(2, 1) + iR(2, 2);
 
         for( int j = 0; j < size.width; ++j)
         {
-            double x = _x/_w, y = _y/_w;
+            double r2 = x*x + y*y;
 
-            double r = sqrt(x*x + y*y);
-            double theta = atan(r);
+            double r = sqrt(r2);
 
-            double theta2 = theta*theta, theta4 = theta2*theta2, theta6 = theta4*theta2, theta8 = theta4*theta4;
-            double theta_d = theta * (1 + k[0]*theta2 + k[1]*theta4 + k[2]*theta6 + k[3]*theta8);
+            double theta_ = r<1e-8*z ? (3*z*z - r2)/(3*z*z*z) : atan2(r, z)/r;
+            double theta2 = theta_*theta_*r2;
+            double scale = theta_ * (1. + theta2*(k[0] + theta2*(k[1] + theta2*(k[2] + theta2*k[3]))));
 
-            double scale = (r == 0) ? 1.0 : theta_d / r;
+            // FIXME alpha parameter is not passed
             double u = f[0]*x*scale + c[0];
             double v = f[1]*y*scale + c[1];
 
@@ -475,9 +475,9 @@ void cv::fisheye::initUndistortRectifyMap( InputArray K, InputArray D, InputArra
                 m2f[j] = (float)v;
             }
 
-            _x += iR(0, 0);
-            _y += iR(1, 0);
-            _w += iR(2, 0);
+            x += iR(0, 0);
+            y += iR(1, 0);
+            z += iR(2, 0);
         }
     }
 }

--- a/modules/calib3d/src/fisheye.hpp
+++ b/modules/calib3d/src/fisheye.hpp
@@ -28,7 +28,7 @@ void ComputeExtrinsicRefine(const Mat& imagePoints, const Mat& objectPoints, Mat
                             const IntrinsicParams& param, const double thresh_cond);
 CV_EXPORTS Mat ComputeHomography(Mat m, Mat M);
 
-CV_EXPORTS Mat NormalizePixels(const Mat& imagePoints, const IntrinsicParams& param);
+CV_EXPORTS Mat NormalizePixels(const Mat& imagePoints, const IntrinsicParams& param, OutputArray rotation = noArray());
 
 void InitExtrinsics(const Mat& _imagePoints, const Mat& _objectPoints, const IntrinsicParams& param, Mat& omckk, Mat& Tckk);
 


### PR DESCRIPTION
This PR adds support for super-fisheye lenses (i.e., lenses with opening angles above 180 degrees).

Essentially, the idea is to compute `theta` as `atan2(sqrt(x*x+y*y),z)` (where `[x,y,z]` is the point relative to the camera, with z pointing forward).

It is downward-compatible for points in front of the camera. Points behind the camera (i.e., negative z coordinates) gave bogus results previously and now only fail if they are exactly behind the camera.
The computation of the Jacobians should be slightly faster and more accurate, especially for z close to zero.

Other functions in the fisheye module would need to be ported as well and the documentation would also need to be updated. But before I proceed, are there any opinions on this?
### former #6724
