### PR TITLE
[GSoC] stitching: new API for parallel feature finding

### DIFF
--- a/modules/stitching/perf/perf_matchers.cpp
+++ b/modules/stitching/perf/perf_matchers.cpp
@@ -18,7 +18,7 @@ PERF_TEST_P(FeaturesFinderVec, ParallelFeaturesFinder, NUMBER_IMAGES)
     vector<Mat> imgs(GetParam(), img);
     vector<detail::ImageFeatures> features(imgs.size());
 
-    Ptr<detail::FeaturesFinder2> featuresFinder = makePtr<detail::OrbFeaturesFinder2>();
+    Ptr<detail::FeaturesFinder> featuresFinder = makePtr<detail::OrbFeaturesFinder>();
 
     TEST_CYCLE()
     {

--- a/modules/stitching/perf/perf_matchers.cpp
+++ b/modules/stitching/perf/perf_matchers.cpp
@@ -1,0 +1,46 @@
+#include "perf_precomp.hpp"
+#include "opencv2/imgcodecs.hpp"
+#include "opencv2/opencv_modules.hpp"
+
+using namespace std;
+using namespace cv;
+using namespace perf;
+using std::tr1::make_tuple;
+using std::tr1::get;
+
+typedef TestBaseWithParam<size_t> FeaturesFinderVec;
+
+#define NUMBER_IMAGES testing::Values(1, 5, 20)
+
+PERF_TEST_P(FeaturesFinderVec, ParallelFeaturesFinder, NUMBER_IMAGES)
+{
+    Mat img = imread( getDataPath("stitching/a1.png") );
+    vector<Mat> imgs(GetParam(), img);
+    vector<detail::ImageFeatures> features(imgs.size());
+
+    Ptr<detail::FeaturesFinder2> featuresFinder = makePtr<detail::OrbFeaturesFinder2>();
+
+    TEST_CYCLE()
+    {
+        (*featuresFinder)(imgs, features);
+    }
+
+    SANITY_CHECK_NOTHING();
+}
+
+PERF_TEST_P(FeaturesFinderVec, SerialFeaturesFinder, NUMBER_IMAGES)
+{
+    Mat img = imread( getDataPath("stitching/a1.png") );
+    vector<Mat> imgs(GetParam(), img);
+    vector<detail::ImageFeatures> features(imgs.size());
+
+    Ptr<detail::FeaturesFinder> featuresFinder = makePtr<detail::OrbFeaturesFinder>();
+
+    TEST_CYCLE()
+    {
+        for (size_t i = 0; i < imgs.size(); ++i)
+            (*featuresFinder)(imgs[i], features[i]);
+    }
+
+    SANITY_CHECK_NOTHING();
+}

--- a/modules/stitching/src/matchers.cpp
+++ b/modules/stitching/src/matchers.cpp
@@ -130,6 +130,9 @@ private:
     InputArrayOfArrays images_;
     std::vector<ImageFeatures> &features_;
     const std::vector<std::vector<cv::Rect> > *rois_;
+
+    // to cease visual studio warning
+    void operator =(const FindFeaturesBody&);
 };
 
 

--- a/modules/stitching/src/matchers.cpp
+++ b/modules/stitching/src/matchers.cpp
@@ -349,20 +349,20 @@ void FeaturesFinder::operator ()(InputArray image, ImageFeatures &features, cons
 }
 
 
-void FeaturesFinder2::operator ()(InputArrayOfArrays images, std::vector<ImageFeatures> &features)
+void FeaturesFinder::operator ()(InputArrayOfArrays images, std::vector<ImageFeatures> &features)
 {
     size_t count = images.total();
     features.resize(count);
 
     FindFeaturesBody body(*this, images, features, NULL);
-    if (is_thread_safe_)
+    if (isThreadSafe())
         parallel_for_(Range(0, static_cast<int>(count)), body);
     else
         body(Range(0, static_cast<int>(count)));
 }
 
 
-void FeaturesFinder2::operator ()(InputArrayOfArrays images, std::vector<ImageFeatures> &features,
+void FeaturesFinder::operator ()(InputArrayOfArrays images, std::vector<ImageFeatures> &features,
                                   const std::vector<std::vector<cv::Rect> > &rois)
 {
     CV_Assert(rois.size() == images.total());
@@ -370,10 +370,27 @@ void FeaturesFinder2::operator ()(InputArrayOfArrays images, std::vector<ImageFe
     features.resize(count);
 
     FindFeaturesBody body(*this, images, features, &rois);
-    if (is_thread_safe_)
+    if (isThreadSafe())
         parallel_for_(Range(0, static_cast<int>(count)), body);
     else
         body(Range(0, static_cast<int>(count)));
+}
+
+
+bool FeaturesFinder::isThreadSafe() const
+{
+    if (dynamic_cast<const SurfFeaturesFinder*>(this))
+    {
+        return true;
+    }
+    else if (dynamic_cast<const OrbFeaturesFinder*>(this))
+    {
+        return true;
+    }
+    else
+    {
+        return false;
+    }
 }
 
 

--- a/modules/stitching/test/test_matchers.cpp
+++ b/modules/stitching/test/test_matchers.cpp
@@ -42,10 +42,10 @@
 #include "test_precomp.hpp"
 #include "opencv2/opencv_modules.hpp"
 
-#ifdef HAVE_OPENCV_XFEATURES2D
-
 using namespace cv;
 using namespace std;
+
+#ifdef HAVE_OPENCV_XFEATURES2D
 
 TEST(SurfFeaturesFinder, CanFindInROIs)
 {
@@ -75,4 +75,27 @@ TEST(SurfFeaturesFinder, CanFindInROIs)
     ASSERT_EQ(bad_count, 0);
 }
 
-#endif
+#endif // HAVE_OPENCV_XFEATURES2D
+
+TEST(ParallelFeaturesFinder, IsSameWithSerial)
+{
+    Ptr<detail::FeaturesFinder2> para_finder = makePtr<detail::OrbFeaturesFinder2>();
+    Ptr<detail::FeaturesFinder> serial_finder = makePtr<detail::OrbFeaturesFinder>();
+    Mat img  = imread(string(cvtest::TS::ptr()->get_data_path()) + "stitching/a3.png", IMREAD_GRAYSCALE);
+
+    vector<Mat> imgs(50, img);
+    detail::ImageFeatures serial_features;
+    vector<detail::ImageFeatures> para_features(imgs.size());
+
+    (*serial_finder)(img, serial_features);
+    (*para_finder)(imgs, para_features);
+
+    // results must be the same
+    for(size_t i = 0; i < para_features.size(); ++i)
+    {
+        Mat diff_descriptors = serial_features.descriptors.getMat(ACCESS_READ) != para_features[i].descriptors.getMat(ACCESS_READ);
+        ASSERT_EQ(countNonZero(diff_descriptors), 0);
+        ASSERT_EQ(serial_features.img_size, para_features[i].img_size);
+        ASSERT_EQ(serial_features.keypoints.size(), para_features[i].keypoints.size());
+    }
+}

--- a/modules/stitching/test/test_matchers.cpp
+++ b/modules/stitching/test/test_matchers.cpp
@@ -79,7 +79,7 @@ TEST(SurfFeaturesFinder, CanFindInROIs)
 
 TEST(ParallelFeaturesFinder, IsSameWithSerial)
 {
-    Ptr<detail::FeaturesFinder2> para_finder = makePtr<detail::OrbFeaturesFinder2>();
+    Ptr<detail::FeaturesFinder> para_finder = makePtr<detail::OrbFeaturesFinder>();
     Ptr<detail::FeaturesFinder> serial_finder = makePtr<detail::OrbFeaturesFinder>();
     Mat img  = imread(string(cvtest::TS::ptr()->get_data_path()) + "stitching/a3.png", IMREAD_GRAYSCALE);
 


### PR DESCRIPTION
Due to ABI this could not be added to `FeaturesFinder`. Introduces new `FeaturesFinder2`. Hope this will me merge to `FeaturesFinder` in next ABI version.

Problem is that we need to know if derived finder is thread-safe or not (that seems to be the case of gpu finder). Derived classes needed to be changed too -> `SurfFeaturesFinder2` `OrbFeaturesFinder2`.

API is similar to `FeaturesMatcher`.

cc: @prclibo 

### Former #6642