### PR TITLE
Wrong assertion when using cuda::add() in combination with a mask

### DIFF
--- a/modules/cudaarithm/src/element_operations.cpp
+++ b/modules/cudaarithm/src/element_operations.cpp
@@ -139,7 +139,7 @@ namespace
 
         CV_Assert( sdepth <= CV_64F && ddepth <= CV_64F );
         CV_Assert( !scalar.empty() || (src2.type() == src1.type() && src2.size() == src1.size()) );
-        CV_Assert( mask.empty() || (cn == 1 && mask.size() == size && mask.type() == CV_8UC1) );
+        CV_Assert( mask.empty() || (mask.channels() == 1 && mask.size() == size && mask.type() == CV_8UC1) );
 
         if (sdepth == CV_64F || ddepth == CV_64F)
         {


### PR DESCRIPTION
### Former  #6624

Fixed a wrong assertion encountered when using cuda::add() in combination with a mask. The number of channels in the mask was not checked correctly.