### PR TITLE
fixing bug in py_calibration.markdown

### DIFF
--- a/doc/py_tutorials/py_calib3d/py_calibration/py_calibration.markdown
+++ b/doc/py_tutorials/py_calib3d/py_calibration/py_calibration.markdown
@@ -130,11 +130,11 @@ for fname in images:
     if ret == True:
         objpoints.append(objp)
 
-        cv2.cornerSubPix(gray,corners, (11,11), (-1,-1), criteria)
+        corners2=cv2.cornerSubPix(gray,corners, (11,11), (-1,-1), criteria)
         imgpoints.append(corners)
 
         # Draw and display the corners
-        cv2.drawChessboardCorners(img, (7,6), corners, ret)
+        cv2.drawChessboardCorners(img, (7,6), corners2, ret)
         cv2.imshow('img', img)
         cv2.waitKey(500)
 

--- a/doc/py_tutorials/py_calib3d/py_pose/py_pose.markdown
+++ b/doc/py_tutorials/py_calib3d/py_pose/py_pose.markdown
@@ -70,15 +70,15 @@ for fname in glob.glob('left*.jpg'):
         corners2 = cv2.cornerSubPix(gray,corners,(11,11),(-1,-1),criteria)
 
         # Find the rotation and translation vectors.
-        rvecs, tvecs, inliers = cv2.solvePnPRansac(objp, corners2, mtx, dist)
+        ret,rvecs, tvecs, inliers = cv2.solvePnP(objp, corners2, mtx, dist)
 
         # project 3D points to image plane
         imgpts, jac = cv2.projectPoints(axis, rvecs, tvecs, mtx, dist)
 
         img = draw(img,corners2,imgpts)
         cv2.imshow('img',img)
-        k = cv2.waitKey(0) & 0xff
-        if k == 's':
+        k = cv2.waitKey(0) & 0xFF
+        if k == ord('s'):
             cv2.imwrite(fname[:6]+'.png', img)
 
 cv2.destroyAllWindows()


### PR DESCRIPTION
### Former #6617

Resolves  cv2.cornerSubPix() and assign it to a variable and use this variable in other function call

### What does this PR change?
In the camera calibration code { cv2.cornerSubPix() } will be of no use.In the updated code it is assigned to the (corners2) variable 
which is passed down to { cv2.drawChessboardCorners() }
