### PR TITLE
[GSoC] robust function for affine transform estimation

### DIFF
--- a/modules/calib3d/include/opencv2/calib3d.hpp
+++ b/modules/calib3d/include/opencv2/calib3d.hpp
@@ -1574,6 +1574,25 @@ CV_EXPORTS_W  int estimateAffine3D(InputArray src, InputArray dst,
                                    OutputArray out, OutputArray inliers,
                                    double ransacThreshold = 3, double confidence = 0.99);
 
+/** @brief Computes an optimal affine transformation between two 2D point sets.
+
+@param src First input 2D point set.
+@param dst Second input 2D point set.
+@param out Output 2D affine transformation matrix \f$2 \times 3\f$ .
+@param inliers Output vector indicating which points are inliers.
+@param ransacThreshold Maximum reprojection error in the RANSAC algorithm to consider a point as
+an inlier.
+@param confidence Confidence level, between 0 and 1, for the estimated transformation. Anything
+between 0.95 and 0.99 is usually good enough. Values too close to 1 can slow down the estimation
+significantly. Values lower than 0.8-0.9 can result in an incorrectly estimated transformation.
+
+The function estimates an optimal 2D affine transformation between two 2D point sets using the
+RANSAC algorithm.
+ */
+CV_EXPORTS_W int estimateAffine2D(InputArray src, InputArray dst,
+                                  OutputArray out, OutputArray inliers,
+                                  double ransacThreshold = 3, double confidence = 0.99);
+
 /** @brief Decompose a homography matrix to rotation(s), translation(s) and plane normal(s).
 
 @param H The input homography matrix between two images.

--- a/modules/calib3d/include/opencv2/calib3d.hpp
+++ b/modules/calib3d/include/opencv2/calib3d.hpp
@@ -1593,6 +1593,34 @@ CV_EXPORTS_W int estimateAffine2D(InputArray src, InputArray dst,
                                   OutputArray out, OutputArray inliers,
                                   double ransacThreshold = 3, double confidence = 0.99);
 
+/** @brief Computes an optimal limited affine transformation with 4 degrees of freedom between
+two 2D point sets.
+
+@param src First input 2D point set.
+@param dst Second input 2D point set.
+@param out Output 2D affine transformation (4 degrees of freedom) matrix \f$2 \times 3\f$ .
+@param inliers Output vector indicating which points are inliers.
+@param ransacThreshold Maximum reprojection error in the RANSAC algorithm to consider a point as
+an inlier.
+@param confidence Confidence level, between 0 and 1, for the estimated transformation. Anything
+between 0.95 and 0.99 is usually good enough. Values too close to 1 can slow down the estimation
+significantly. Values lower than 0.8-0.9 can result in an incorrectly estimated transformation.
+
+The function estimates an optimal 2D affine transformation with 4 degrees of freedom limited to
+combinations of translation, rotation, and uniform scaling. Uses the RANSAC algorithm for robust
+estimation.
+
+Estimated transformation matrix is:
+\f[ \begin{bmatrix} \cos(\theta)s & -\sin(\theta)s & tx \\
+                \sin(\theta)s & \cos(\theta)s & ty
+\end{bmatrix} \f]
+Where \f$ \theta \f$ is the rotation angle, \f$ s \f$ the scaling factor and \f$ tx, ty \f$ are
+translations in \f$ x, y \f$ axes respectively.
+*/
+CV_EXPORTS_W int estimateAffinePartial2D(InputArray src, InputArray dst,
+                                         OutputArray out, OutputArray inliers,
+                                         double ransacThreshold = 3, double confidence = 0.99);
+
 /** @brief Decompose a homography matrix to rotation(s), translation(s) and plane normal(s).
 
 @param H The input homography matrix between two images.

--- a/modules/calib3d/perf/perf_affine2d.cpp
+++ b/modules/calib3d/perf/perf_affine2d.cpp
@@ -1,0 +1,167 @@
+/*M///////////////////////////////////////////////////////////////////////////////////////
+//
+// By downloading, copying, installing or using the software you agree to this license.
+// If you do not agree to this license, do not download, install,
+// copy or use the software.
+//
+//
+//                           License Agreement
+//                For Open Source Computer Vision Library
+//                        (3-clause BSD License)
+//
+// Copyright (C) 2015-2016, OpenCV Foundation, all rights reserved.
+// Third party copyrights are property of their respective owners.
+//
+// Redistribution and use in source and binary forms, with or without modification,
+// are permitted provided that the following conditions are met:
+//
+//   * Redistributions of source code must retain the above copyright notice,
+//     this list of conditions and the following disclaimer.
+//
+//   * Redistributions in binary form must reproduce the above copyright notice,
+//     this list of conditions and the following disclaimer in the documentation
+//     and/or other materials provided with the distribution.
+//
+//   * Neither the names of the copyright holders nor the names of the contributors
+//     may be used to endorse or promote products derived from this software
+//     without specific prior written permission.
+//
+// This software is provided by the copyright holders and contributors "as is" and
+// any express or implied warranties, including, but not limited to, the implied
+// warranties of merchantability and fitness for a particular purpose are disclaimed.
+// In no event shall copyright holders or contributors be liable for any direct,
+// indirect, incidental, special, exemplary, or consequential damages
+// (including, but not limited to, procurement of substitute goods or services;
+// loss of use, data, or profits; or business interruption) however caused
+// and on any theory of liability, whether in contract, strict liability,
+// or tort (including negligence or otherwise) arising in any way out of
+// the use of this software, even if advised of the possibility of such damage.
+//
+//M*/
+
+#include "perf_precomp.hpp"
+#include <algorithm>
+#include <functional>
+
+namespace cvtest
+{
+
+using std::tr1::tuple;
+using std::tr1::get;
+using namespace perf;
+using namespace testing;
+using namespace cv;
+
+typedef tuple<int, double> AffineParams;
+typedef TestBaseWithParam<AffineParams> EstimateAffine;
+
+struct Noise
+{
+    float l;
+    Noise(float level) : l(level) {}
+    Point2f operator()(const Point2f& p)
+    {
+        RNG& rng = theRNG();
+        return Point2f( p.x + l * (float)rng,  p.y + l * (float)rng );
+    }
+};
+
+struct WrapAff2D
+{
+    const double *F;
+    WrapAff2D(const Mat& aff) : F(aff.ptr<double>()) {}
+    Point2f operator()(const Point2f& p)
+    {
+        return Point2f( (float)(p.x * F[0] + p.y * F[1] + F[2]),
+                        (float)(p.x * F[3] + p.y * F[4] + F[5]) );
+    }
+};
+
+static float rngIn(float from, float to) { return from + (to-from) * (float)theRNG(); }
+
+static Mat rngPartialAffMat() {
+    double theta = rngIn(0, (float)CV_PI*2.f);
+    double scale = rngIn(0, 3);
+    double tx = rngIn(-2, 2);
+    double ty = rngIn(-2, 2);
+    double aff[2*3] = { std::cos(theta) * scale, -std::sin(theta) * scale, tx,
+                        std::sin(theta) * scale,  std::cos(theta) * scale, ty };
+    return Mat(2, 3, CV_64F, aff).clone();
+}
+
+PERF_TEST_P( EstimateAffine, EstimateAffine2D, Combine(Values(100000, 5000, 100), Values(0.99, 0.95, 0.9)) )
+{
+    AffineParams params = GetParam();
+    const int n = get<0>(params);
+    const double confidence = get<1>(params);
+
+    Mat aff(2, 3, CV_64F);
+    cv::randu(aff, Scalar(-2), Scalar(2));
+
+    // setting points that are no in the same line
+    const int m = 2*n/5;
+    const Point2f shift_outl = Point2f(15, 15);
+    const float noise_level = 20.f;
+
+    Mat fpts(1, n, CV_32FC2);
+    Mat tpts(1, n, CV_32FC2);
+
+    cv::randu(fpts, Scalar::all(0), Scalar::all(100));
+    std::transform(fpts.ptr<Point2f>(), fpts.ptr<Point2f>() + n, tpts.ptr<Point2f>(), WrapAff2D(aff));
+
+    /* adding noise*/
+    std::transform(tpts.ptr<Point2f>() + m, tpts.ptr<Point2f>() + n, tpts.ptr<Point2f>() + m, bind2nd(std::plus<Point2f>(), shift_outl));
+    std::transform(tpts.ptr<Point2f>() + m, tpts.ptr<Point2f>() + n, tpts.ptr<Point2f>() + m, Noise(noise_level));
+
+    Mat aff_est(2, 3, CV_64F);
+
+    warmup(aff_est, WARMUP_WRITE);
+    warmup(fpts, WARMUP_READ);
+    warmup(tpts, WARMUP_READ);
+
+    TEST_CYCLE()
+    {
+        estimateAffine2D(fpts, tpts, aff_est, noArray(), 3, confidence);
+    }
+
+    SANITY_CHECK(aff_est, .01, ERROR_RELATIVE);
+}
+
+PERF_TEST_P( EstimateAffine, EstimateAffinePartial2D, Combine(Values(100000, 5000, 100), Values(0.99, 0.95, 0.9)) )
+{
+    AffineParams params = GetParam();
+    const int n = get<0>(params);
+    const double confidence = get<1>(params);
+
+    Mat aff = rngPartialAffMat();
+
+    // setting points that are no in the same line
+    const int m = 2*n/5;
+    const Point2f shift_outl = Point2f(15, 15);
+    const float noise_level = 20.f;
+
+    Mat fpts(1, n, CV_32FC2);
+    Mat tpts(1, n, CV_32FC2);
+
+    cv::randu(fpts, Scalar::all(0), Scalar::all(100));
+    std::transform(fpts.ptr<Point2f>(), fpts.ptr<Point2f>() + n, tpts.ptr<Point2f>(), WrapAff2D(aff));
+
+    /* adding noise*/
+    std::transform(tpts.ptr<Point2f>() + m, tpts.ptr<Point2f>() + n, tpts.ptr<Point2f>() + m, bind2nd(std::plus<Point2f>(), shift_outl));
+    std::transform(tpts.ptr<Point2f>() + m, tpts.ptr<Point2f>() + n, tpts.ptr<Point2f>() + m, Noise(noise_level));
+
+    Mat aff_est(2, 3, CV_64F);
+
+    warmup(aff_est, WARMUP_WRITE);
+    warmup(fpts, WARMUP_READ);
+    warmup(tpts, WARMUP_READ);
+
+    TEST_CYCLE()
+    {
+        estimateAffinePartial2D(fpts, tpts, aff_est, noArray(), 3, confidence);
+    }
+
+    SANITY_CHECK(aff_est, .01, ERROR_RELATIVE);
+}
+
+} // namespace cvtest

--- a/modules/calib3d/src/ptsetreg.cpp
+++ b/modules/calib3d/src/ptsetreg.cpp
@@ -562,7 +562,7 @@ public:
             double a = F[0]*f.x + F[1]*f.y + F[2] - t.x;
             double b = F[3]*f.x + F[4]*f.y + F[5] - t.y;
 
-            errptr[i] = (float)std::sqrt(a*a + b*b);
+            errptr[i] = (float)(a*a + b*b);
         }
     }
 

--- a/modules/calib3d/test/test_affine2d_estimator.cpp
+++ b/modules/calib3d/test/test_affine2d_estimator.cpp
@@ -1,0 +1,195 @@
+/*M///////////////////////////////////////////////////////////////////////////////////////
+//
+// By downloading, copying, installing or using the software you agree to this license.
+// If you do not agree to this license, do not download, install,
+// copy or use the software.
+//
+//
+//                           License Agreement
+//                For Open Source Computer Vision Library
+//                        (3-clause BSD License)
+//
+// Copyright (C) 2015-2016, OpenCV Foundation, all rights reserved.
+// Third party copyrights are property of their respective owners.
+//
+// Redistribution and use in source and binary forms, with or without modification,
+// are permitted provided that the following conditions are met:
+//
+//   * Redistributions of source code must retain the above copyright notice,
+//     this list of conditions and the following disclaimer.
+//
+//   * Redistributions in binary form must reproduce the above copyright notice,
+//     this list of conditions and the following disclaimer in the documentation
+//     and/or other materials provided with the distribution.
+//
+//   * Neither the names of the copyright holders nor the names of the contributors
+//     may be used to endorse or promote products derived from this software
+//     without specific prior written permission.
+//
+// This software is provided by the copyright holders and contributors "as is" and
+// any express or implied warranties, including, but not limited to, the implied
+// warranties of merchantability and fitness for a particular purpose are disclaimed.
+// In no event shall copyright holders or contributors be liable for any direct,
+// indirect, incidental, special, exemplary, or consequential damages
+// (including, but not limited to, procurement of substitute goods or services;
+// loss of use, data, or profits; or business interruption) however caused
+// and on any theory of liability, whether in contract, strict liability,
+// or tort (including negligence or otherwise) arising in any way out of
+// the use of this software, even if advised of the possibility of such damage.
+//
+//M*/
+
+#include "test_precomp.hpp"
+
+using namespace cv;
+using namespace std;
+
+#include <string>
+#include <iostream>
+#include <fstream>
+#include <functional>
+#include <iterator>
+#include <limits>
+#include <numeric>
+
+class CV_Affine2D_EstTest : public cvtest::BaseTest
+{
+public:
+    CV_Affine2D_EstTest();
+    ~CV_Affine2D_EstTest();
+protected:
+    void run(int);
+
+    bool test3Points();
+    bool testNPoints();
+};
+
+CV_Affine2D_EstTest::CV_Affine2D_EstTest()
+{
+}
+CV_Affine2D_EstTest::~CV_Affine2D_EstTest() {}
+
+
+static float rngIn(float from, float to) { return from + (to-from) * (float)theRNG(); }
+
+
+struct WrapAff2D
+{
+    const double *F;
+    WrapAff2D(const Mat& aff) : F(aff.ptr<double>()) {}
+    Point2f operator()(const Point2f& p)
+    {
+        return Point2f( (float)(p.x * F[0] + p.y * F[1] + F[2]),
+                        (float)(p.x * F[3] + p.y * F[4] + F[5]) );
+    }
+};
+
+bool CV_Affine2D_EstTest::test3Points()
+{
+    Mat aff(2, 3, CV_64F);
+    cv::randu(aff, Scalar(1), Scalar(3));
+
+    // setting points that are no in the same line
+    Mat fpts(1, 3, CV_32FC2);
+    Mat tpts(1, 3, CV_32FC2);
+
+    fpts.ptr<Point2f>()[0] = Point2f( rngIn(1,2), rngIn(5,6) );
+    fpts.ptr<Point2f>()[1] = Point2f( rngIn(3,4), rngIn(3,4) );
+    fpts.ptr<Point2f>()[2] = Point2f( rngIn(1,2), rngIn(3,4) );
+
+    transform(fpts.ptr<Point2f>(), fpts.ptr<Point2f>() + 4, tpts.ptr<Point2f>(), WrapAff2D(aff));
+
+    Mat aff_est;
+    vector<uchar> inliers;
+    estimateAffine2D(fpts, tpts, aff_est, inliers);
+
+    const double thres = 1e-3;
+    if (cvtest::norm(aff_est, aff, NORM_INF) > thres)
+    {
+        cout << "norm: " << cvtest::norm(aff_est, aff, NORM_INF) << endl;
+        cout << "aff est: " << aff_est << endl;
+        cout << "aff ref: " << aff << endl;
+        ts->set_failed_test_info(cvtest::TS::FAIL_BAD_ACCURACY);
+        return false;
+    }
+    return true;
+}
+
+struct Noise
+{
+    float l;
+    Noise(float level) : l(level) {}
+    Point2f operator()(const Point2f& p)
+    {
+        RNG& rng = theRNG();
+        return Point2f( p.x + l * (float)rng,  p.y + l * (float)rng );
+    }
+};
+
+bool CV_Affine2D_EstTest::testNPoints()
+{
+    Mat aff(2, 3, CV_64F);
+    cv::randu(aff, Scalar(-2), Scalar(2));
+
+    // setting points that are no in the same line
+    const int n = 100;
+    const int m = 2*n/5;
+    const Point2f shift_outl = Point2f(15, 15);
+    const float noise_level = 20.f;
+
+    Mat fpts(1, n, CV_32FC2);
+    Mat tpts(1, n, CV_32FC2);
+
+    randu(fpts, Scalar::all(0), Scalar::all(100));
+    transform(fpts.ptr<Point2f>(), fpts.ptr<Point2f>() + n, tpts.ptr<Point2f>(), WrapAff2D(aff));
+
+    /* adding noise*/
+    transform(tpts.ptr<Point2f>() + m, tpts.ptr<Point2f>() + n, tpts.ptr<Point2f>() + m, bind2nd(plus<Point2f>(), shift_outl));
+    transform(tpts.ptr<Point2f>() + m, tpts.ptr<Point2f>() + n, tpts.ptr<Point2f>() + m, Noise(noise_level));
+
+    Mat aff_est;
+    vector<uchar> outl;
+    int res = estimateAffine2D(fpts, tpts, aff_est, outl);
+
+    if (!res)
+    {
+        ts->set_failed_test_info(cvtest::TS::FAIL_INVALID_OUTPUT);
+        return false;
+    }
+
+    const double thres = 1e-4;
+    if (cvtest::norm(aff_est, aff, NORM_INF) > thres)
+    {
+        cout << "norm: " << cvtest::norm(aff_est, aff, NORM_INF) << endl;
+        cout << "aff est: " << aff_est << endl;
+        cout << "aff ref: " << aff << endl;
+        ts->set_failed_test_info(cvtest::TS::FAIL_BAD_ACCURACY);
+        return false;
+    }
+
+    bool outl_good = count(outl.begin(), outl.end(), 1) == m &&
+        m == accumulate(outl.begin(), outl.begin() + m, 0);
+
+    if (!outl_good)
+    {
+        ts->set_failed_test_info(cvtest::TS::FAIL_INVALID_OUTPUT);
+        return false;
+    }
+    return true;
+}
+
+
+void CV_Affine2D_EstTest::run( int /* start_from */)
+{
+    cvtest::DefaultRngAuto dra;
+
+    if (!test3Points())
+        return;
+
+    if (!testNPoints())
+        return;
+
+    ts->set_failed_test_info(cvtest::TS::OK);
+}
+
+TEST(Calib3d_EstimateAffine2D, accuracy) { CV_Affine2D_EstTest test; test.safe_run(); }

--- a/modules/calib3d/test/test_affine3d_estimator.cpp
+++ b/modules/calib3d/test/test_affine3d_estimator.cpp
@@ -194,4 +194,4 @@ void CV_Affine3D_EstTest::run( int /* start_from */)
     ts->set_failed_test_info(cvtest::TS::OK);
 }
 
-TEST(Calib3d_EstimateAffineTransform, accuracy) { CV_Affine3D_EstTest test; test.safe_run(); }
+TEST(Calib3d_EstimateAffine3D, accuracy) { CV_Affine3D_EstTest test; test.safe_run(); }


### PR DESCRIPTION
### Former  #6615

implements `estimateAffine2D`. estimates affine transformation using robust RANSAC method.

* uses RANSAC framework in calib3d
* includes accuracy test
* uses SVD decomposition for solving 3 point equation

things to consider:
* is solving through SVD fast enough? should we make it symmetric and use EIGEN val decomposition?
* is checking for coplanar points robust enough? (it seems so)

I plan to write perf test to see if make sense to do some tricks and solve with EIGEN val decomp. Checking for coplanar points seems to work well for me. I adapted the check from estimateAffine3D, estimateRigidTransform have some addition checks (checking if points are not too close), but I'm not sure if it is worth to implement those.

I will implement also `estimateAffinePartial2D` that will estimate transformation using only rotation, translation an scaling (similar to `estimateRigidTransform`). I'm only not sure about the name `estimateAffinePartial2D`, any ideas welcome.

cc: @prclibo 