### PR TITLE
Rephrase parts of the templates and use comments

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,37 +1,30 @@
-This is a template helping you to create an issue which can be processes as quickly as possible. Feel free to add additional information or remove not relevant points if you do not need them.
-
+<!--
 If you have a question rather than reporting a bug please go to http://answers.opencv.org where you get much faster responses.
+If you need further assistance please read [How To Contribute](https://github.com/Itseez/opencv/wiki/How_to_contribute).
 
-### Please state the information for your system
-- OpenCV version: 2.4 / 3.x
-- Host OS: Linux (Ubuntu 14.04)  / Mac OS X 10.11.3 / Windows 10
-- *(if needed, only cross-platform builds)* Target OS: host / Android 6.0 / ARM board / Raspberry Pi 2
-- *(if needed)* Compiler & CMake: GCC 5.3 & CMake 3.5
+This is a template helping you to create an issue which can be processed as quickly as possible. This is the bug reporting section for the OpenCV library.
+-->
 
-### In which part of the OpenCV library you got the issue?
-Examples:
-- objdetect, highgui, imgproc, cuda, tests
-- face recognition, resizing an image, reading an jpg image
+##### System information (version)
+<!-- Example
+- OpenCV => 3.1
+- Operating System / Platform => Windows 64 Bit
+- Compiler => Visual Studio 2015
+-->
 
-### Expected behaviour
+- OpenCV => :grey_question:
+- Operating System / Platform => :grey_question:
+- Compiler => :grey_question:
 
-### Actual behaviour
+##### Detailed description
 
-### Additional description
+<!-- your description -->
 
-### Code example to reproduce the issue / Steps to reproduce the issue
-Please try to give a full example which will compile as is.
-```
-#include "opencv2/core.hpp"
-#include <iostream>
-using namespace std;
-using namespace cv;
+##### Steps to reproduce
 
-int main()
-{
-    double d[] = { 546,2435,7,4534,23423,3 };
-    cout << "d = 0x" << reinterpret_cast<void*>(d) << endl;
-
-    return 0;
-}
-```
+<!-- to add code example fence it with triple backticks and optional file extension
+    ```.cpp
+    // C++ code example
+    ```
+ or attach as .txt or .zip file
+-->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,4 +1,9 @@
-resolves #XXXX
+<!-- Please use this line to close one or multiple issues when this pullrequest gets merged
+You can add another line right under the first one:
+resolves #1234
+resolves #1235
+-->
 
-### What does this PR change?
-Please add your changes here.
+### This pullrequest changes
+
+<!-- Please describe what your pullrequest is changing -->


### PR DESCRIPTION
### Former #6612

### What does this PR change?
This PR changes the templates a bit so the comments are actual comments and won't be posted if not erased.

- [x] smaller headings
- [x] hidden instructions on top of each section
- [x] Guidelines for how to contribute
 - [x] link [How To Contribute](https://github.com/Itseez/opencv/wiki/How_to_contribute)
- [x] leave a mark that this is the bug report section and should not be used for general questions
 - [x] link http://answers.opencv.org
- [x] use placeholder for real values
 - [x] give example of real values in How To Contribute or comment
- [x] detailed description
 - [x] code template as hidden comment
