### PR TITLE
calibrationMatrixValues: bind C++ function in C instead of vice versa

### DIFF
--- a/modules/calib3d/src/calibration.cpp
+++ b/modules/calib3d/src/calibration.cpp
@@ -3356,8 +3356,10 @@ void cv::calibrationMatrixValues( InputArray _cameraMatrix, Size imageSize,
     }
 
     /* Calculate fovx and fovy. */
-    fovx = 2 * atan(imageSize.width / (2 * K(0, 0))) * 180.0 / CV_PI;
-    fovy = 2 * atan(imageSize.height / (2 * K(1, 1))) * 180.0 / CV_PI;
+    fovx = atan2(K(0, 2), K(0, 0)) + atan2(imageSize.width  - K(0, 2), K(0, 0));
+    fovy = atan2(K(1, 2), K(1, 1)) + atan2(imageSize.height - K(1, 2), K(1, 1));
+    fovx *= 180.0 / CV_PI;
+    fovy *= 180.0 / CV_PI;
 
     /* Calculate focal length. */
     focalLength = K(0, 0) / mx;

--- a/modules/calib3d/test/test_cameracalibration.cpp
+++ b/modules/calib3d/test/test_cameracalibration.cpp
@@ -875,8 +875,8 @@ void CV_CalibrationMatrixValuesTest::run(int)
         ny = goodAspectRatio;
     }
 
-    goodFovx = 2 * atan( imageSize.width / (2 * fx)) * 180.0 / CV_PI;
-    goodFovy = 2 * atan( imageSize.height / (2 * fy)) * 180.0 / CV_PI;
+    goodFovx = (atan2(cx, fx) + atan2(imageSize.width  - cx, fx)) * 180.0 / CV_PI;
+    goodFovy = (atan2(cy, fy) + atan2(imageSize.height - cy, fy)) * 180.0 / CV_PI;
 
     goodFocalLength = fx / nx;
 


### PR DESCRIPTION
### Former  #6480

by @paroj:

also fix FOV computation: the FOV depends on the principal point location. Use formula of
viz::Camera.