### PR TITLE
Add -maxscale parameter to limit the amount sample images can scale image

### DIFF
--- a/apps/createsamples/createsamples.cpp
+++ b/apps/createsamples/createsamples.cpp
@@ -76,6 +76,7 @@ int main( int argc, char* argv[] )
     double scale = 4.0;
     int width  = 24;
     int height = 24;
+    double maxscale = -1.0;
 
     srand((unsigned int)time(0));
 
@@ -92,9 +93,10 @@ int main( int argc, char* argv[] )
                 "  [-maxyangle <max_y_rotation_angle = %f>]\n"
                 "  [-maxzangle <max_z_rotation_angle = %f>]\n"
                 "  [-show [<scale = %f>]]\n"
-                "  [-w <sample_width = %d>]\n  [-h <sample_height = %d>]\n",
+                "  [-w <sample_width = %d>]\n  [-h <sample_height = %d>]\n"
+                "  [-maxscale <max sample scale = %f>]\n",
                 argv[0], num, bgcolor, bgthreshold, maxintensitydev,
-                maxxangle, maxyangle, maxzangle, scale, width, height );
+                maxxangle, maxyangle, maxzangle, scale, width, height, maxscale );
 
         return 0;
     }
@@ -172,6 +174,10 @@ int main( int argc, char* argv[] )
         {
             height = atoi( argv[++i] );
         }
+        else if( !strcmp( argv[i], "-maxscale" ) )
+        {
+            maxscale = atof( argv[++i] );
+        }
     }
 
     printf( "Info file name: %s\n", ((infoname == NULL) ?   nullname : infoname ) );
@@ -194,6 +200,7 @@ int main( int argc, char* argv[] )
     }
     printf( "Width: %d\n", width );
     printf( "Height: %d\n", height );
+    printf( "Max Scale: %g\n", maxscale);
 
     /* determine action */
     if( imagename && vecname )
@@ -213,7 +220,7 @@ int main( int argc, char* argv[] )
 
         cvCreateTestSamples( infoname, imagename, bgcolor, bgthreshold, bgfilename, num,
             invert, maxintensitydev,
-            maxxangle, maxyangle, maxzangle, showsamples, width, height );
+            maxxangle, maxyangle, maxzangle, showsamples, width, height, maxscale);
 
         printf( "Done\n" );
     }

--- a/apps/createsamples/utility.cpp
+++ b/apps/createsamples/utility.cpp
@@ -1372,7 +1372,7 @@ void cvCreateTestSamples( const char* infoname,
 
                 if( maxscale < 1.0F ) continue;
 
-                scale = (maxscale - 1.0F) * rand() / RAND_MAX + 1.0F;
+                scale = ((float)maxscale - 1.0F) * rand() / RAND_MAX + 1.0F;
 
                 width = (int) (scale * winwidth);
                 height = (int) (scale * winheight);

--- a/apps/createsamples/utility.cpp
+++ b/apps/createsamples/utility.cpp
@@ -38,7 +38,6 @@
 // the use of this software, even if advised of the possibility of such damage.
 //
 //M*/
-
 #include <cstring>
 #include <ctime>
 
@@ -1308,7 +1307,7 @@ void cvCreateTestSamples( const char* infoname,
                           int invert, int maxintensitydev,
                           double maxxangle, double maxyangle, double maxzangle,
                           int showsamples,
-                          int winwidth, int winheight )
+                          int winwidth, int winheight, double maxscale )
 {
     CvSampleDistortionData data;
 
@@ -1337,7 +1336,6 @@ void cvCreateTestSamples( const char* infoname,
             int i;
             int x, y, width, height;
             float scale;
-            float maxscale;
             int inverse;
 
             if( showsamples )
@@ -1366,12 +1364,16 @@ void cvCreateTestSamples( const char* infoname,
             for( i = 0; i < count; i++ )
             {
                 icvGetNextFromBackgroundData( cvbgdata, cvbgreader );
-
-                maxscale = MIN( 0.7F * cvbgreader->src.cols / winwidth,
+                if( maxscale < 0.0 )
+                {
+                    maxscale = MIN( 0.7F * cvbgreader->src.cols / winwidth,
                                    0.7F * cvbgreader->src.rows / winheight );
+                }
+
                 if( maxscale < 1.0F ) continue;
 
                 scale = (maxscale - 1.0F) * rand() / RAND_MAX + 1.0F;
+
                 width = (int) (scale * winwidth);
                 height = (int) (scale * winheight);
                 x = (int) ((0.1+0.8 * rand()/RAND_MAX) * (cvbgreader->src.cols - width));

--- a/apps/createsamples/utility.hpp
+++ b/apps/createsamples/utility.hpp
@@ -86,7 +86,7 @@ void cvCreateTestSamples( const char* infoname,
                           int invert, int maxintensitydev,
                           double maxxangle, double maxyangle, double maxzangle,
                           int showsamples,
-                          int winwidth, int winheight );
+                          int winwidth, int winheight, double maxscale );
 
 /*
  * cvCreateTrainingSamplesFromInfo


### PR DESCRIPTION
### Former #6444 by @bobpaulin

resolves #6443

### What does this PR change?
Allows user to define -maxscale parameter when generating sample images for usecases where the source image should not scale beyond a specific point.