### PR TITLE
Fix memory leak in GStreamer capture pipeline

### DIFF
--- a/modules/videoio/src/cap_gstreamer.cpp
+++ b/modules/videoio/src/cap_gstreamer.cpp
@@ -244,8 +244,7 @@ bool CvCapture_GStreamer::grabFrame()
         return false;
 
 #if GST_VERSION_MAJOR == 0
-    if(buffer)
-    {
+    if(buffer) {
         gst_buffer_unref(buffer);
         buffer = NULL;
     }

--- a/modules/videoio/src/cap_gstreamer.cpp
+++ b/modules/videoio/src/cap_gstreamer.cpp
@@ -208,6 +208,16 @@ void CvCapture_GStreamer::close()
         pipeline = NULL;
     }
 
+    if(buffer) {
+        gst_buffer_unref(buffer);
+        buffer = NULL;
+    }
+
+    if(frame) {
+        cvReleaseImageHeader(&frame);
+        frame = NULL;
+    }
+
     duration = -1;
     width = -1;
     height = -1;
@@ -235,7 +245,10 @@ bool CvCapture_GStreamer::grabFrame()
 
 #if GST_VERSION_MAJOR == 0
     if(buffer)
+    {
         gst_buffer_unref(buffer);
+        buffer = NULL;
+    }
 
     buffer = gst_app_sink_pull_buffer(GST_APP_SINK(sink));
 #else


### PR DESCRIPTION
### Former #6442 by @smarttowel:

Maybe resolves #4987
### What does this PR change?

Now buffer free only when we grab new frame but we need to free buffer and frame header when call `close()` method.
