### PR TITLE
Update README URLs based on HTTP redirects

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,11 +5,11 @@
 * Homepage: <http://opencv.org>
 * Docs: <http://docs.opencv.org/master/>
 * Q&A forum: <http://answers.opencv.org>
-* Issue tracking: <https://github.com/Itseez/opencv/issues>
+* Issue tracking: <https://github.com/opencv/opencv/issues>
 
 #### Contributing
 
-Please read before starting work on a pull request: <https://github.com/Itseez/opencv/wiki/How_to_contribute>
+Please read before starting work on a pull request: <https://github.com/opencv/opencv/wiki/How_to_contribute>
 
 Summary of guidelines:
 


### PR DESCRIPTION
Created with https://github.com/dkhamsing/frankenstein

### GitHub Corrected URLs 
Was | Now 
--- | --- 
https://github.com/Itseez/opencv/issues | https://github.com/opencv/opencv/issues 
https://github.com/Itseez/opencv/wiki/How_to_contribute | https://github.com/opencv/opencv/wiki/How_to_contribute 
