### PR TITLE
Fix handling so that V4L returns no frame if error VIDIOC_DQBUF is detected

### DIFF
--- a/modules/videoio/src/cap_libv4l.cpp
+++ b/modules/videoio/src/cap_libv4l.cpp
@@ -1926,6 +1926,9 @@ protected:
 bool CvCaptureCAM_V4L_CPP::open( int index )
 {
     close();
+    // Force a refresh of the indexList
+    numCameras = 0;
+    indexList = 0;
     captureV4L = icvCaptureFromCAM_V4L(index);
     return captureV4L != 0;
 }

--- a/modules/videoio/src/cap_libv4l.cpp
+++ b/modules/videoio/src/cap_libv4l.cpp
@@ -312,6 +312,7 @@ typedef struct CvCaptureCAM_V4L
     int deviceHandle;
     int bufferIndex;
     int FirstCapture;
+    int returnFrame;
 
     int width; int height;
     int mode;
@@ -1087,6 +1088,8 @@ static CvCaptureCAM_V4L * icvCaptureFromCAM_V4L (int index)
        capture->is_v4l2_device = 1;
    }
 
+   capture->returnFrame = 1;
+
    return capture;
 }; /* End icvOpenCAM_V4L */
 
@@ -1112,6 +1115,7 @@ static int read_frame_v4l2(CvCaptureCAM_V4L* capture) {
 
         default:
             /* display the error and stop processing */
+            capture->returnFrame = 0;
             perror ("VIDIOC_DQBUF");
             return 1;
         }
@@ -1349,7 +1353,10 @@ static IplImage* icvRetrieveFrameCAM_V4L( CvCaptureCAM_V4L* capture, int) {
 
   }
 
-   return(&capture->frame);
+  if (capture->returnFrame == 1)
+    return(&capture->frame);
+  else
+    return 0;
 }
 
 /* TODO: review this adaptation */

--- a/modules/videoio/src/cap_libv4l.cpp
+++ b/modules/videoio/src/cap_libv4l.cpp
@@ -312,6 +312,7 @@ typedef struct CvCaptureCAM_V4L
     int deviceHandle;
     int bufferIndex;
     int FirstCapture;
+    int returnFrame;
 
     int width; int height;
     int mode;
@@ -1087,6 +1088,8 @@ static CvCaptureCAM_V4L * icvCaptureFromCAM_V4L (int index)
        capture->is_v4l2_device = 1;
    }
 
+   capture->returnFrame = 1;
+
    return capture;
 }; /* End icvOpenCAM_V4L */
 
@@ -1112,6 +1115,7 @@ static int read_frame_v4l2(CvCaptureCAM_V4L* capture) {
 
         default:
             /* display the error and stop processing */
+            capture->returnFrame = 0;
             perror ("VIDIOC_DQBUF");
             return 1;
         }
@@ -1349,7 +1353,10 @@ static IplImage* icvRetrieveFrameCAM_V4L( CvCaptureCAM_V4L* capture, int) {
 
   }
 
-   return(&capture->frame);
+   if (capture->returnFrame == 1)
+     return(&capture->frame);
+   else
+     return 0;
 }
 
 /* TODO: review this adaptation */

--- a/modules/videoio/src/cap_libv4l.cpp
+++ b/modules/videoio/src/cap_libv4l.cpp
@@ -1926,9 +1926,6 @@ protected:
 bool CvCaptureCAM_V4L_CPP::open( int index )
 {
     close();
-    // Force a refresh of the indexList
-    numCameras = 0;
-    indexList = 0;
     captureV4L = icvCaptureFromCAM_V4L(index);
     return captureV4L != 0;
 }

--- a/modules/videoio/src/cap_libv4l.cpp
+++ b/modules/videoio/src/cap_libv4l.cpp
@@ -312,7 +312,6 @@ typedef struct CvCaptureCAM_V4L
     int deviceHandle;
     int bufferIndex;
     int FirstCapture;
-    int returnFrame;
 
     int width; int height;
     int mode;
@@ -1088,8 +1087,6 @@ static CvCaptureCAM_V4L * icvCaptureFromCAM_V4L (int index)
        capture->is_v4l2_device = 1;
    }
 
-   capture->returnFrame = 1;
-
    return capture;
 }; /* End icvOpenCAM_V4L */
 
@@ -1115,7 +1112,6 @@ static int read_frame_v4l2(CvCaptureCAM_V4L* capture) {
 
         default:
             /* display the error and stop processing */
-            capture->returnFrame = 0;
             perror ("VIDIOC_DQBUF");
             return 1;
         }
@@ -1353,10 +1349,7 @@ static IplImage* icvRetrieveFrameCAM_V4L( CvCaptureCAM_V4L* capture, int) {
 
   }
 
-   if (capture->returnFrame == 1)
-     return(&capture->frame);
-   else
-     return 0;
+   return(&capture->frame);
 }
 
 /* TODO: review this adaptation */

--- a/modules/videoio/src/cap_v4l.cpp
+++ b/modules/videoio/src/cap_v4l.cpp
@@ -2898,6 +2898,9 @@ protected:
 bool CvCaptureCAM_V4L_CPP::open( int index )
 {
     close();
+    // Force a refresh of the indexList
+    numCameras = 0;
+    indexList = 0;
     captureV4L = icvCaptureFromCAM_V4L(index);
     return captureV4L != 0;
 }

--- a/modules/videoio/src/cap_v4l.cpp
+++ b/modules/videoio/src/cap_v4l.cpp
@@ -303,6 +303,7 @@ typedef struct CvCaptureCAM_V4L
     int deviceHandle;
     int bufferIndex;
     int FirstCapture;
+    int returnFrame;
 #ifdef HAVE_CAMV4L
     struct video_capability capability;
     struct video_window     captureWindow;
@@ -1167,6 +1168,8 @@ static CvCaptureCAM_V4L * icvCaptureFromCAM_V4L (int index)
    }
 #endif  /* HAVE_CAMV4L2 */
 
+   capture->returnFrame = 1;
+
    return capture;
 }; /* End icvOpenCAM_V4L */
 
@@ -1197,6 +1200,7 @@ static int read_frame_v4l2(CvCaptureCAM_V4L* capture) {
 
         default:
             /* display the error and stop processing */
+            capture->returnFrame = 0;
             perror ("VIDIOC_DQBUF");
             return 1;
         }
@@ -2287,7 +2291,10 @@ static IplImage* icvRetrieveFrameCAM_V4L( CvCaptureCAM_V4L* capture, int) {
   }
 #endif /* HAVE_CAMV4L */
 
-   return(&capture->frame);
+  if (capture->returnFrame == 1)
+    return(&capture->frame);
+  else
+    return 0;
 }
 
 static double icvGetPropertyCAM_V4L (CvCaptureCAM_V4L* capture,

--- a/modules/videoio/src/cap_v4l.cpp
+++ b/modules/videoio/src/cap_v4l.cpp
@@ -2898,9 +2898,6 @@ protected:
 bool CvCaptureCAM_V4L_CPP::open( int index )
 {
     close();
-    // Force a refresh of the indexList
-    numCameras = 0;
-    indexList = 0;
     captureV4L = icvCaptureFromCAM_V4L(index);
     return captureV4L != 0;
 }


### PR DESCRIPTION
bq makes a 3d scanner kit that uses horus (https://github.com/bq/horus). They have an older fork of opencv that horus depends on. I've cleaned up their vital changes and am making pull requests for them.

This change fixes handling so that V4L returns no frame if error VIDIOC_DQBUF is detected. Original patch done by https://github.com/Jesus89

Restored #5266
