### PR TITLE
Reactivating SOLVEPNP_DLS and SOLVEPNP_UPNP

### DIFF
--- a/modules/calib3d/src/solvepnp.cpp
+++ b/modules/calib3d/src/solvepnp.cpp
@@ -87,7 +87,7 @@ bool solvePnP( InputArray _opoints, InputArray _ipoints,
     Mat distCoeffs = Mat_<double>(distCoeffs0);
     bool result = false;
 
-    if (flags == SOLVEPNP_EPNP || flags == SOLVEPNP_DLS || flags == SOLVEPNP_UPNP)
+    if (flags == SOLVEPNP_EPNP)
     {
         Mat undistortedPoints;
         undistortPoints(ipoints, undistortedPoints, cameraMatrix, distCoeffs);
@@ -120,7 +120,7 @@ bool solvePnP( InputArray _opoints, InputArray _ipoints,
                                      &c_rvec, &c_tvec, useExtrinsicGuess );
         result = true;
     }
-    /*else if (flags == SOLVEPNP_DLS)
+    else if (flags == SOLVEPNP_DLS)
     {
         Mat undistortedPoints;
         undistortPoints(ipoints, undistortedPoints, cameraMatrix, distCoeffs);
@@ -141,7 +141,7 @@ bool solvePnP( InputArray _opoints, InputArray _ipoints,
         PnP.compute_pose(R, tvec);
         Rodrigues(R, rvec);
         return true;
-    }*/
+    }
     else
         CV_Error(CV_StsBadArg, "The flags argument must be one of SOLVEPNP_ITERATIVE, SOLVEPNP_P3P, SOLVEPNP_EPNP or SOLVEPNP_DLS");
     return result;


### PR DESCRIPTION
The way how uPnP and DLS have been disabled in https://github.com/Itseez/opencv/pull/3828 is highly counter-intuitive:

Just executing EPNP [regardless of the given flag](https://github.com/vpisarev/opencv/blob/ca19ae8b5ae53afe3ca0084c55178b8d0796b28b/modules/calib3d/src/solvepnp.cpp#L66) is confusing. If somebody wants to evaluate the OpenCV version of uPnP, let him do that (and not silently executing epnp in the background). Imagine somebody wants to evaluate the available PnP solvers in OpenCV and finds out that it does not matter which one he chooses because the results are all the same.

cf. https://github.com/Itseez/opencv/issues/5065

Restored #5978