### PR TITLE
fixed memory leak in flann tests

### DIFF
--- a/modules/flann/src/miniflann.cpp
+++ b/modules/flann/src/miniflann.cpp
@@ -318,7 +318,19 @@ buildIndex_(void*& index, const Mat& data, const IndexParams& params, const Dist
 
     ::cvflann::Matrix<ElementType> dataset((ElementType*)data.data, data.rows, data.cols);
     IndexType* _index = new IndexType(dataset, get_params(params), dist);
-    _index->buildIndex();
+
+    try
+    {
+        _index->buildIndex();
+    }
+    catch (...)
+    {
+        delete _index;
+        _index = NULL;
+
+        throw;
+    }
+
     index = _index;
 }
 


### PR DESCRIPTION
resolves #6131 

Tested via valgrind tool:

```
sandye51@sandye51:~/Documents/Programming/builds/opencv-master$ valgrind --leak-check=full ./bin/opencv_test_flann 
==30472== Memcheck, a memory error detector
==30472== Copyright (C) 2002-2013, and GNU GPL'd, by Julian Seward et al.
==30472== Using Valgrind-3.10.1 and LibVEX; rerun with -h for copyright info
==30472== Command: ./bin/opencv_test_flann
==30472== 
CTEST_FULL_OUTPUT
OpenCV version: 3.1.0-dev
OpenCV VCS version: 3.1.0-805-g02aabcc
Build type: debug
Parallel framework: pthreads
CPU features: mmx sse sse2 sse3
[==========] Running 1 test from 1 test case.
[----------] Global test environment set-up.
[----------] 1 test from Flann_LshTable
[ RUN      ] Flann_LshTable.badarg
[       OK ] Flann_LshTable.badarg (238 ms)
[----------] 1 test from Flann_LshTable (249 ms total)

[----------] Global test environment tear-down
[==========] 1 test from 1 test case ran. (289 ms total)
[  PASSED  ] 1 test.
==30472== 
==30472== HEAP SUMMARY:
==30472==     in use at exit: 96 bytes in 4 blocks
==30472==   total heap usage: 1,214 allocs, 1,210 frees, 219,449 bytes allocated
==30472== 
==30472== LEAK SUMMARY:
==30472==    definitely lost: 0 bytes in 0 blocks
==30472==    indirectly lost: 0 bytes in 0 blocks
==30472==      possibly lost: 0 bytes in 0 blocks
==30472==    still reachable: 96 bytes in 4 blocks
==30472==         suppressed: 0 bytes in 0 blocks
==30472== Reachable blocks (those to which a pointer was found) are not shown.
==30472== To see them, rerun with: --leak-check=full --show-leak-kinds=all
==30472== 
==30472== For counts of detected and suppressed errors, rerun with: -v
==30472== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```