### PR TITLE
stop search of markers in Exif reader to prevent infinite loop

### DIFF
--- a/modules/imgcodecs/src/jpeg_exif.cpp
+++ b/modules/imgcodecs/src/jpeg_exif.cpp
@@ -140,8 +140,8 @@ std::map<int, ExifEntry_t > ExifReader::getExif()
         return m_exif; //Until this moment the map is empty
     }
 
-    bool exifFound = false;
-    while( ( !feof( f ) ) && !exifFound )
+    bool exifFound = false, stopSearch = false;
+    while( ( !feof( f ) ) && !exifFound && !stopSearch )
     {
         count = fread( appMarker, sizeof(unsigned char), markerSize, f );
         if( count < markerSize )
@@ -180,6 +180,7 @@ std::map<int, ExifEntry_t > ExifReader::getExif()
                 break;
 
             default: //No other markers are expected according to standard. May be a signal of error
+                stopSearch = true;
                 break;
         }
     }


### PR DESCRIPTION
resolves https://github.com/opencv/opencv/issues/6641

### This pullrequest changes

Stop exif markers search in `default` section of `switch` operator to prevent infinite loop.