### PR TITLE
BM3D noise reduction algorithm added

### DIFF
--- a/modules/photo/include/opencv2/photo.hpp
+++ b/modules/photo/include/opencv2/photo.hpp
@@ -321,7 +321,7 @@ enum { BM3D_HAAR = 0 };
 enum { BM3D_STEPALL = 0, BM3D_STEP1 = 1, BM3D_STEP2 = 2};
 
 /** @brief Performs image denoising using the Block-Matching and 3D-filtering algorithm
-<http://www.cs.tut.fi/~foi/3D-DFT/BM3DDEN_article.pdf> with several computational
+<http://www.cs.tut.fi/~foi/GCF-BM3D/BM3D_TIP_2007.pdf> with several computational
 optimizations. Noise expected to be a gaussian white noise.
 
 @param src Input 8-bit or 16-bit 1-channel image.
@@ -365,7 +365,7 @@ CV_EXPORTS_W void bm3dDenoising(
     int transformType = cv::BM3D_HAAR);
 
 /** @brief Performs image denoising using the Block-Matching and 3D-filtering algorithm
-<http://www.cs.tut.fi/~foi/3D-DFT/BM3DDEN_article.pdf> with several computational
+<http://www.cs.tut.fi/~foi/GCF-BM3D/BM3D_TIP_2007.pdf> with several computational
 optimizations. Noise expected to be a gaussian white noise.
 
 @param src Input 8-bit or 16-bit 1-channel image.

--- a/modules/photo/include/opencv2/photo.hpp
+++ b/modules/photo/include/opencv2/photo.hpp
@@ -330,6 +330,8 @@ Should be even. Recommended value 4 or 8 pixels
 @param searchWindowSize Size in pixels of the window that is used to perform block-matching.
 Should be odd. Affect performance linearly: greater searchWindowsSize - greater
 denoising time. Recommended value 16 pixels.
+@param blockMatchingThreshold Block matching threshold. The lower the threshold the higher
+the similarity required between the matched blocks.
 @param normType Norm used to calculate distance between blocks. L2 is slower than L1
 but yields more accurate results.
 @param transformType Type of the orthogonal transform used in collaborative filtering step.
@@ -344,6 +346,8 @@ CV_EXPORTS_W void bm3dDenoising(
     float h = 1,
     int templateWindowSize = 4,
     int searchWindowSize = 16,
+    int blockMatchingThreshold = 200,
+    int groupSize = 8,
     int normType = cv::NORM_L2,
     int transformType = 0);
 

--- a/modules/photo/include/opencv2/photo.hpp
+++ b/modules/photo/include/opencv2/photo.hpp
@@ -317,9 +317,9 @@ CV_EXPORTS_W void denoise_TVL1(const std::vector<Mat>& observations,Mat& result,
 //! @addtogroup photo_denoise
 //! @{
 
-/** @brief Perform image denoising using Block-Matching and 3D-filtering algorithm
-<http://www.cs.tut.fi/~foi/3D-DFT/BM3DDEN_article.pdf> with several computational
-optimizations. Noise expected to be a gaussian white noise.
+/** @brief Performs image denoising using the first step of Block-Matching and
+3D-filtering algorithm <http://www.cs.tut.fi/~foi/3D-DFT/BM3DDEN_article.pdf>
+with several computational optimizations. Noise expected to be a gaussian white noise.
 
 @param src Input 8-bit 1-channel, 2-channel, 3-channel or 4-channel image.
 @param dst Output image with the same size and type as src.
@@ -330,8 +330,8 @@ Should be even. Recommended value 4 or 8 pixels
 @param searchWindowSize Size in pixels of the window that is used to perform block-matching.
 Should be odd. Affect performance linearly: greater searchWindowsSize - greater
 denoising time. Recommended value 16 pixels.
-@param blockMatchingThreshold Block matching threshold. The lower the threshold the higher
-the similarity required between the matched blocks.
+@param blockMatchingThreshold Block matching threshold, i.e. maximum distance for which
+two blocks are considered similar. Value expressed in euclidean distance.
 @param normType Norm used to calculate distance between blocks. L2 is slower than L1
 but yields more accurate results.
 @param transformType Type of the orthogonal transform used in collaborative filtering step.
@@ -346,7 +346,7 @@ CV_EXPORTS_W void bm3dDenoising(
     float h = 1,
     int templateWindowSize = 4,
     int searchWindowSize = 16,
-    int blockMatchingThreshold = 200,
+    int blockMatchingThreshold = 2500,
     int groupSize = 8,
     int normType = cv::NORM_L2,
     int transformType = 0);

--- a/modules/photo/include/opencv2/photo.hpp
+++ b/modules/photo/include/opencv2/photo.hpp
@@ -319,17 +319,21 @@ CV_EXPORTS_W void denoise_TVL1(const std::vector<Mat>& observations,Mat& result,
 
 /** @brief Perform image denoising using Block-Matching and 3D-filtering algorithm
 <http://www.cs.tut.fi/~foi/3D-DFT/BM3DDEN_article.pdf> with several computational
-optimizations. Noise expected to be a gaussian white noise
+optimizations. Noise expected to be a gaussian white noise.
 
 @param src Input 8-bit 1-channel, 2-channel, 3-channel or 4-channel image.
-@param dst Output image with the same size and type as src .
+@param dst Output image with the same size and type as src.
+@param h Parameter regulating filter strength. Big h value perfectly removes noise but also
+removes image details, smaller h value preserves details but also preserves some noise.
 @param templateWindowSize Size in pixels of the template patch that is used for block-matching.
 Should be even. Recommended value 4 or 8 pixels
 @param searchWindowSize Size in pixels of the window that is used to perform block-matching.
 Should be odd. Affect performance linearly: greater searchWindowsSize - greater
-denoising time. Recommended value 16 pixels
-@param h Parameter regulating filter strength. Big h value perfectly removes noise but also
-removes image details, smaller h value preserves details but also preserves some noise
+denoising time. Recommended value 16 pixels.
+@param normType Norm used to calculate distance between blocks. L2 is slower than L1
+but yields more accurate results.
+@param transformType Type of the orthogonal transform used in collaborative filtering step.
+Currently only Haar transform is supported.
 
 This function expected to be applied to grayscale images. Advanced usage of this function
 can be manual denoising of colored image in different colorspaces.
@@ -340,7 +344,8 @@ CV_EXPORTS_W void bm3dDenoising(
     float h = 1,
     int templateWindowSize = 4,
     int searchWindowSize = 16,
-    int normType = cv::NORM_L2);
+    int normType = cv::NORM_L2,
+    int transformType = 0);
 
 //! @} photo_denoise
 

--- a/modules/photo/include/opencv2/photo.hpp
+++ b/modules/photo/include/opencv2/photo.hpp
@@ -314,6 +314,34 @@ increase it if the results are poor.
  */
 CV_EXPORTS_W void denoise_TVL1(const std::vector<Mat>& observations,Mat& result, double lambda=1.0, int niters=30);
 
+//! @addtogroup photo_denoise
+//! @{
+
+/** @brief Perform image denoising using Block-Matching and 3D-filtering algorithm
+<http://www.cs.tut.fi/~foi/3D-DFT/BM3DDEN_article.pdf> with several computational
+optimizations. Noise expected to be a gaussian white noise
+
+@param src Input 8-bit 1-channel, 2-channel, 3-channel or 4-channel image.
+@param dst Output image with the same size and type as src .
+@param templateWindowSize Size in pixels of the template patch that is used for block-matching.
+Should be even. Recommended value 4 or 8 pixels
+@param searchWindowSize Size in pixels of the window that is used to perform block-matching.
+Should be odd. Affect performance linearly: greater searchWindowsSize - greater
+denoising time. Recommended value 16 pixels
+@param h Parameter regulating filter strength. Big h value perfectly removes noise but also
+removes image details, smaller h value preserves details but also preserves some noise
+
+This function expected to be applied to grayscale images. Advanced usage of this function
+can be manual denoising of colored image in different colorspaces.
+*/
+CV_EXPORTS_W void bm3dDenoising(
+    InputArray src,
+    OutputArray dst,
+    float h = 1,
+    int templateWindowSize = 4,
+    int searchWindowSize = 16,
+    int normType = cv::NORM_L2);
+
 //! @} photo_denoise
 
 //! @addtogroup photo_hdr

--- a/modules/photo/include/opencv2/photo.hpp
+++ b/modules/photo/include/opencv2/photo.hpp
@@ -314,24 +314,22 @@ increase it if the results are poor.
  */
 CV_EXPORTS_W void denoise_TVL1(const std::vector<Mat>& observations,Mat& result, double lambda=1.0, int niters=30);
 
-//! @addtogroup photo_denoise
-//! @{
-
 /** @brief Performs image denoising using the first step of Block-Matching and
 3D-filtering algorithm <http://www.cs.tut.fi/~foi/3D-DFT/BM3DDEN_article.pdf>
 with several computational optimizations. Noise expected to be a gaussian white noise.
 
-@param src Input 8-bit 1-channel, 2-channel, 3-channel or 4-channel image.
+@param src Input 8-bit or 16-bit 1-channel image.
 @param dst Output image with the same size and type as src.
 @param h Parameter regulating filter strength. Big h value perfectly removes noise but also
 removes image details, smaller h value preserves details but also preserves some noise.
 @param templateWindowSize Size in pixels of the template patch that is used for block-matching.
-Should be even. Recommended value 4 or 8 pixels
+Should be power of 2. Currently supported is value 4 or 8 pixels.
 @param searchWindowSize Size in pixels of the window that is used to perform block-matching.
-Should be odd. Affect performance linearly: greater searchWindowsSize - greater
-denoising time. Recommended value 16 pixels.
+Affect performance linearly: greater searchWindowsSize - greater denoising time.
+Must be larger than templateWindowSize.
 @param blockMatchingThreshold Block matching threshold, i.e. maximum distance for which
 two blocks are considered similar. Value expressed in euclidean distance.
+@param groupSize Maximum size of the 3D group for collaborative filtering.
 @param normType Norm used to calculate distance between blocks. L2 is slower than L1
 but yields more accurate results.
 @param transformType Type of the orthogonal transform used in collaborative filtering step.

--- a/modules/photo/src/bm3d_denoising_invoker.hpp
+++ b/modules/photo/src/bm3d_denoising_invoker.hpp
@@ -128,26 +128,23 @@ Bm3dDenoisingInvoker<T, IT, UIT, D, WT, TT>::Bm3dDenoisingInvoker(
     hBM_ = D::template calcBlockMatchingThreshold<int>(hBM, templateWindowSizeSq_);
 
     // Select transforms depending on the template size
-    float *thrMap2D = NULL;
     switch (templateWindowSize_)
     {
     case 4:
-        thrMap2D = kThrMap4x4;
         haarTransform2D = Haar4x4;
         inverseHaar2D = InvHaar4x4;
         break;
     case 8:
-        thrMap2D = kThrMap8x8;
         haarTransform2D = Haar8x8;
         inverseHaar2D = InvHaar8x8;
         break;
     default:
         CV_Error(Error::StsBadArg,
-            "Unsupported template size! Only 1, 2, 4 and 8 are supported currently.");
+            "Unsupported template size! Only 4 and 8 are supported currently.");
     }
 
     // Precompute threshold map
-    calcHaarThresholdMap3D(thrMap_, thrMap2D, h, templateWindowSizeSq_, groupSize_);
+    calcHaarThresholdMap3D(thrMap_, h, templateWindowSize_, groupSize_);
 }
 
 template<typename T, typename IT, typename UIT, typename D, typename WT, typename TT>

--- a/modules/photo/src/bm3d_denoising_invoker.hpp
+++ b/modules/photo/src/bm3d_denoising_invoker.hpp
@@ -178,7 +178,6 @@ void Bm3dDenoisingInvoker<T, IT, UIT, D, WT, TT>::operator() (const Range& range
 
     const int step = srcExtended_.step / sizeof(T);
     const int cstep = step - templateWindowSize_;
-    const int csstep = step - searchWindowSize_;
 
     const int dstStep = srcExtended_.cols;
     const int weiStep = srcExtended_.cols;

--- a/modules/photo/src/bm3d_denoising_invoker.hpp
+++ b/modules/photo/src/bm3d_denoising_invoker.hpp
@@ -271,7 +271,7 @@ void Bm3dDenoisingInvoker<T, IT, UIT, D, WT>::operator() (const Range& range) co
                     // Calc distance
                     int e = 0;
                     for (int n = blockSizeSq; n--;)
-                        e += (z[elementSize][n] - r[n]) * (z[elementSize][n] - r[n]);
+                        e += D::template calcDist<short>(z[elementSize][n], r[n]);
                     e /= blockSizeSq;
 
                     // Increase the counter and save the distance

--- a/modules/photo/src/bm3d_denoising_invoker.hpp
+++ b/modules/photo/src/bm3d_denoising_invoker.hpp
@@ -1,0 +1,252 @@
+/*M///////////////////////////////////////////////////////////////////////////////////////
+//
+//  IMPORTANT: READ BEFORE DOWNLOADING, COPYING, INSTALLING OR USING.
+//
+//  By downloading, copying, installing or using the software you agree to this license.
+//  If you do not agree to this license, do not download, install,
+//  copy or use the software.
+//
+//
+//                        Intel License Agreement
+//                For Open Source Computer Vision Library
+//
+// Copyright (C) 2000, Intel Corporation, all rights reserved.
+// Third party copyrights are property of their respective icvers.
+//
+// Redistribution and use in source and binary forms, with or without modification,
+// are permitted provided that the following conditions are met:
+//
+//   * Redistribution's of source code must retain the above copyright notice,
+//     this list of conditions and the following disclaimer.
+//
+//   * Redistribution's in binary form must reproduce the above copyright notice,
+//     this list of conditions and the following disclaimer in the documentation
+//     and/or other materials provided with the distribution.
+//
+//   * The name of Intel Corporation may not be used to endorse or promote products
+//     derived from this software without specific prior written permission.
+//
+// This software is provided by the copyright holders and contributors "as is" and
+// any express or implied warranties, including, but not limited to, the implied
+// warranties of merchantability and fitness for a particular purpose are disclaimed.
+// In no event shall the Intel Corporation or contributors be liable for any direct,
+// indirect, incidental, special, exemplary, or consequential damages
+// (including, but not limited to, procurement of substitute goods or services;
+// loss of use, data, or profits; or business interruption) however caused
+// and on any theory of liability, whether in contract, strict liability,
+// or tort (including negligence or otherwise) arising in any way out of
+// the use of this software, even if advised of the possibility of such damage.
+//
+//M*/
+
+#ifndef __OPENCV_BM3D_DENOISING_INVOKER_HPP__
+#define __OPENCV_BM3D_DENOISING_INVOKER_HPP__
+
+#include "precomp.hpp"
+#include <limits>
+
+#include "bm3d_denoising_invoker_commons.hpp"
+#include "arrays.hpp"
+
+using namespace cv;
+
+template <typename T, typename IT, typename UIT, typename D, typename WT>
+struct Bm3dDenoisingInvoker :
+    public ParallelLoopBody
+{
+public:
+    Bm3dDenoisingInvoker(const Mat& src, Mat& dst,
+        int template_window_size, int search_window_size, const float &h);
+
+    void operator() (const Range& range) const;
+
+private:
+    void operator= (const Bm3dDenoisingInvoker&);
+
+    const Mat& src_;
+    Mat& dst_;
+
+    Mat extended_src_;
+    int border_size_;
+
+    int template_window_size_;
+    int search_window_size_;
+
+    int template_window_half_size_;
+    int search_window_half_size_;
+
+    typename pixelInfo<WT>::sampleType fixed_point_mult_;
+    int almost_template_window_size_sq_bin_shift_;
+    std::vector<WT> almost_dist2weight_;
+
+    //void calcDistSumsForFirstElementInRow(
+    //	int i, Array2d<int>& dist_sums,
+    //	Array3d<int>& col_dist_sums,
+    //	Array3d<int>& up_col_dist_sums) const;
+
+    //void calcDistSumsForElementInFirstRow(
+    //	int i, int j, int first_col_num,
+    //	Array2d<int>& dist_sums,
+    //	Array3d<int>& col_dist_sums,
+    //	Array3d<int>& up_col_dist_sums) const;
+};
+
+inline int getNearestPowerOf2(int value)
+{
+    int p = 0;
+    while (1 << p < value)
+        ++p;
+    return p;
+}
+
+template <typename T, typename IT, typename UIT, typename D, typename WT>
+Bm3dDenoisingInvoker<T, IT, UIT, D, WT>::Bm3dDenoisingInvoker(
+    const Mat& src, Mat& dst,
+    int template_window_size,
+    int search_window_size,
+    const float &h) :
+    src_(src), dst_(dst)
+{
+    CV_Assert(src.channels() == pixelInfo<T>::channels);
+
+    template_window_half_size_ = template_window_size / 2;
+    search_window_half_size_ = search_window_size / 2;
+    template_window_size_ = template_window_half_size_ * 2 + 1;
+    search_window_size_ = search_window_half_size_ * 2 + 1;
+
+    border_size_ = search_window_half_size_ + template_window_half_size_;
+    copyMakeBorder(src_, extended_src_, border_size_, border_size_, border_size_, border_size_, BORDER_DEFAULT);
+
+    const IT max_estimate_sum_value =
+        (IT)search_window_size_ * (IT)search_window_size_ * (IT)pixelInfo<T>::sampleMax();
+    fixed_point_mult_ = (int)std::min<IT>(std::numeric_limits<IT>::max() / max_estimate_sum_value,
+        pixelInfo<WT>::sampleMax());
+
+    // precalc weight for every possible l2 dist between blocks
+    // additional optimization of precalced weights to replace division(averaging) by binary shift
+    CV_Assert(template_window_size_ <= 46340); // sqrt(INT_MAX)
+    int template_window_size_sq = template_window_size_ * template_window_size_;
+    almost_template_window_size_sq_bin_shift_ = getNearestPowerOf2(template_window_size_sq);
+    double almost_dist2actual_dist_multiplier = ((double)(1 << almost_template_window_size_sq_bin_shift_)) / template_window_size_sq;
+
+    int max_dist = D::template maxDist<T>();
+    int almost_max_dist = (int)(max_dist / almost_dist2actual_dist_multiplier + 1);
+    almost_dist2weight_.resize(almost_max_dist);
+
+    for (int almost_dist = 0; almost_dist < almost_max_dist; almost_dist++)
+    {
+        double dist = almost_dist * almost_dist2actual_dist_multiplier;
+        almost_dist2weight_[almost_dist] =
+            D::template calcWeight<T, WT>(dist, h, fixed_point_mult_);
+    }
+
+    // additional optimization init end
+    if (dst_.empty())
+        dst_ = Mat::zeros(src_.size(), src_.type());
+}
+
+template <typename T, typename IT, typename UIT, typename D, typename WT>
+void Bm3dDenoisingInvoker<T, IT, UIT, D, WT>::operator() (const Range& range) const
+{
+    int row_from = range.start;
+    int row_to = range.end - 1;
+
+    // sums of cols anf rows for current pixel p
+    Array2d<int> dist_sums(search_window_size_, search_window_size_);
+
+    // for lazy calc optimization (sum of cols for current pixel)
+    Array3d<int> col_dist_sums(template_window_size_, search_window_size_, search_window_size_);
+
+    int first_col_num = -1;
+    // last elements of column sum (for each element in row)
+    Array3d<int> up_col_dist_sums(src_.cols, search_window_size_, search_window_size_);
+
+    for (int i = row_from; i <= row_to; i++)
+    {
+        for (int j = 0; j < src_.cols; j++)
+        {
+            int search_window_y = i - search_window_half_size_;
+            int search_window_x = j - search_window_half_size_;
+
+            // calc dist_sums
+            if (j == 0)
+            {
+                //calcDistSumsForFirstElementInRow(i, dist_sums, col_dist_sums, up_col_dist_sums);
+                first_col_num = 0;
+            }
+            else
+            {
+                // calc cur dist_sums using previous dist_sums
+                if (i == row_from)
+                {
+                    //calcDistSumsForElementInFirstRow(i, j, first_col_num,
+                    //	dist_sums, col_dist_sums, up_col_dist_sums);
+                }
+                else
+                {
+                    int ay = border_size_ + i;
+                    int ax = border_size_ + j + template_window_half_size_;
+
+                    int start_by = border_size_ + i - search_window_half_size_;
+                    int start_bx = border_size_ + j - search_window_half_size_ + template_window_half_size_;
+
+                    T a_up = extended_src_.at<T>(ay - template_window_half_size_ - 1, ax);
+                    T a_down = extended_src_.at<T>(ay + template_window_half_size_, ax);
+
+                    // copy class member to local variable for optimization
+                    int search_window_size = search_window_size_;
+
+                    for (int y = 0; y < search_window_size; y++)
+                    {
+                        int * dist_sums_row = dist_sums.row_ptr(y);
+                        int * col_dist_sums_row = col_dist_sums.row_ptr(first_col_num, y);
+                        int * up_col_dist_sums_row = up_col_dist_sums.row_ptr(j, y);
+
+                        const T * b_up_ptr = extended_src_.ptr<T>(start_by - template_window_half_size_ - 1 + y);
+                        const T * b_down_ptr = extended_src_.ptr<T>(start_by + template_window_half_size_ + y);
+
+                        for (int x = 0; x < search_window_size; x++)
+                        {
+                            // remove from current pixel sum column sum with index "first_col_num"
+                            dist_sums_row[x] -= col_dist_sums_row[x];
+
+                            int bx = start_bx + x;
+                            col_dist_sums_row[x] = up_col_dist_sums_row[x] + D::template calcUpDownDist<T>(a_up, a_down, b_up_ptr[bx], b_down_ptr[bx]);
+
+                            dist_sums_row[x] += col_dist_sums_row[x];
+                            up_col_dist_sums_row[x] = col_dist_sums_row[x];
+                        }
+                    }
+                }
+
+                first_col_num = (first_col_num + 1) % template_window_size_;
+            }
+
+            // calc weights
+            IT estimation[pixelInfo<T>::channels], weights_sum[pixelInfo<WT>::channels];
+            for (int channel_num = 0; channel_num < pixelInfo<T>::channels; channel_num++)
+                estimation[channel_num] = 0;
+            for (int channel_num = 0; channel_num < pixelInfo<WT>::channels; channel_num++)
+                weights_sum[channel_num] = 0;
+
+            for (int y = 0; y < search_window_size_; y++)
+            {
+                const T* cur_row_ptr = extended_src_.ptr<T>(border_size_ + search_window_y + y);
+                int* dist_sums_row = dist_sums.row_ptr(y);
+                for (int x = 0; x < search_window_size_; x++)
+                {
+                    int almostAvgDist = dist_sums_row[x] >> almost_template_window_size_sq_bin_shift_;
+                    WT weight = almost_dist2weight_[almostAvgDist];
+                    T p = cur_row_ptr[border_size_ + search_window_x + x];
+                    incWithWeight<T, IT, WT>(estimation, weights_sum, weight, p);
+                }
+            }
+
+            divByWeightsSum<IT, UIT, pixelInfo<T>::channels, pixelInfo<WT>::channels>(estimation,
+                weights_sum);
+            dst_.at<T>(i, j) = saturateCastFromArray<T, IT>(estimation);
+        }
+    }
+}
+
+#endif

--- a/modules/photo/src/bm3d_denoising_invoker.hpp
+++ b/modules/photo/src/bm3d_denoising_invoker.hpp
@@ -150,6 +150,14 @@ Bm3dDenoisingInvoker<T, IT, UIT, D, WT, TT>::Bm3dDenoisingInvoker(
         haarTransform2D = Haar4x4;
         inverseHaar2D = InvHaar4x4;
         break;
+    case 8:
+        // Precompute threshold map
+        ComputeThresholdMap1D(thrMap_, kThrMap1D, kThrMap8x8, h, kCoeff, templateWindowSizeSq_);
+
+        // Select transforms
+        haarTransform2D = Haar8x8;
+        inverseHaar2D = InvHaar8x8;
+        break;
     default:
         CV_Error(Error::StsBadArg,
             "Unsupported template size! Only 1, 2 and 4 are supported currently.");

--- a/modules/photo/src/bm3d_denoising_invoker.hpp
+++ b/modules/photo/src/bm3d_denoising_invoker.hpp
@@ -68,6 +68,8 @@ public:
     void operator() (const Range& range) const;
 
 private:
+    void operator= (const Bm3dDenoisingInvoker&);
+
     const Mat& src_;
     Mat& dst_;
     Mat srcExtended_;
@@ -176,7 +178,7 @@ void Bm3dDenoisingInvoker<T, IT, UIT, D, WT, TT>::operator() (const Range& range
     const int hBM = hBM_;
     const int groupSize = groupSize_;
 
-    const int step = srcExtended_.step / sizeof(T);
+    const int step = srcExtended_.cols;
     const int cstep = step - templateWindowSize_;
 
     const int dstStep = srcExtended_.cols;

--- a/modules/photo/src/bm3d_denoising_invoker.hpp
+++ b/modules/photo/src/bm3d_denoising_invoker.hpp
@@ -245,28 +245,32 @@ void Bm3dDenoisingInvoker<T, IT, UIT, D, WT, TT>::operator() (const Range& range
             case 16:
                 for (int n = 0; n < blockSizeSq; n++)
                 {
-                    sumNonZero += HaarTransformShrink16(bm, n, thrMapPtr1D);
+                    ForwardHaarTransform16(bm, n);
+                    sumNonZero += HardThreshold<16>(bm, n, thrMapPtr1D);
                     InverseHaarTransform16(bm, n);
                 }
                 break;
             case 8:
                 for (int n = 0; n < blockSizeSq; n++)
                 {
-                    sumNonZero += HaarTransformShrink8(bm, n, thrMapPtr1D);
+                    ForwardHaarTransform8(bm, n);
+                    sumNonZero += HardThreshold<8>(bm, n, thrMapPtr1D);
                     InverseHaarTransform8(bm, n);
                 }
                 break;
             case 4:
                 for (int n = 0; n < blockSizeSq; n++)
                 {
-                    sumNonZero += HaarTransformShrink4(bm, n, thrMapPtr1D);
+                    ForwardHaarTransform4(bm, n);
+                    sumNonZero += HardThreshold<4>(bm, n, thrMapPtr1D);
                     InverseHaarTransform4(bm, n);
                 }
                 break;
             case 2:
                 for (int n = 0; n < blockSizeSq; n++)
                 {
-                    sumNonZero += HaarTransformShrink2(bm, n, thrMapPtr1D);
+                    ForwardHaarTransform2(bm, n);
+                    sumNonZero += HardThreshold<2>(bm, n, thrMapPtr1D);
                     InverseHaarTransform2(bm, n);
                 }
                 break;

--- a/modules/photo/src/bm3d_denoising_invoker.hpp
+++ b/modules/photo/src/bm3d_denoising_invoker.hpp
@@ -242,6 +242,13 @@ void Bm3dDenoisingInvoker<T, IT, UIT, D, WT, TT>::operator() (const Range& range
             TT *thrMapPtr1D = thrMap_ + (elementSize - 1) * blockSizeSq;
             switch (elementSize)
             {
+            case 16:
+                for (int n = 0; n < blockSizeSq; n++)
+                {
+                    sumNonZero += HaarTransformShrink16(bm, n, thrMapPtr1D);
+                    InverseHaarTransform16(bm, n);
+                }
+                break;
             case 8:
                 for (int n = 0; n < blockSizeSq; n++)
                 {
@@ -249,7 +256,6 @@ void Bm3dDenoisingInvoker<T, IT, UIT, D, WT, TT>::operator() (const Range& range
                     InverseHaarTransform8(bm, n);
                 }
                 break;
-
             case 4:
                 for (int n = 0; n < blockSizeSq; n++)
                 {
@@ -257,7 +263,6 @@ void Bm3dDenoisingInvoker<T, IT, UIT, D, WT, TT>::operator() (const Range& range
                     InverseHaarTransform4(bm, n);
                 }
                 break;
-
             case 2:
                 for (int n = 0; n < blockSizeSq; n++)
                 {
@@ -265,7 +270,6 @@ void Bm3dDenoisingInvoker<T, IT, UIT, D, WT, TT>::operator() (const Range& range
                     InverseHaarTransform2(bm, n);
                 }
                 break;
-
             case 1:
                 {
                     TT *block = bm[0].data();
@@ -287,7 +291,7 @@ void Bm3dDenoisingInvoker<T, IT, UIT, D, WT, TT>::operator() (const Range& range
 
             // Scale weight by element size
             weight *= elementSize;
-            weight /= BM3D_MAX_3D_SIZE;
+            weight /= groupSize;
 
             // Put patches back to their original positions
             WT *dstPtr = weightedSum.data() + jj * dstStep + i;

--- a/modules/photo/src/bm3d_denoising_invoker_commons.hpp
+++ b/modules/photo/src/bm3d_denoising_invoker_commons.hpp
@@ -265,34 +265,4 @@ public:
     }
 };
 
-template <typename T>
-void ComputeThresholdMap1D(
-    T *outThrMap1D,
-    const float *thrMap1D,
-    float *thrMap2D,
-    const float &hardThr1D,
-    const float *coeff,
-    const int &templateWindowSizeSq)
-{
-    T *thrMapPtr1D = outThrMap1D;
-    for (int ii = 0; ii < 4; ++ii)
-    {
-        for (int jj = 0; jj < templateWindowSizeSq; ++jj)
-        {
-            for (int ii1 = 0; ii1 < (1 << ii); ++ii1)
-            {
-                int indexIn1D = (1 << ii) - 1 + ii1;
-                int indexIn2D = jj;
-                int thr = static_cast<int>(thrMap1D[indexIn1D] * thrMap2D[indexIn2D] * hardThr1D * coeff[ii]);
-
-                // Set DC component to zero
-                if (jj == 0 && ii1 == 0)
-                    thr = 0;
-
-                *thrMapPtr1D++ = cv::saturate_cast<T>(thr);
-           }
-        }
-    }
-}
-
 #endif

--- a/modules/photo/src/bm3d_denoising_invoker_commons.hpp
+++ b/modules/photo/src/bm3d_denoising_invoker_commons.hpp
@@ -488,14 +488,14 @@ template <typename ET, typename IT> struct saturateCastFromArray_<Vec<ET, 4>, IT
 #endif
 
 void ComputeThresholdMap1D(
-    short *thrMap1D,
-    const float *kThrMap1D,
-    float *kThrMap2D,
+    short *outThrMap1D,
+    const float *thrMap1D,
+    float *thrMap2D,
     const float &hardThr1D,
-    const float *kCoeff,
+    const float *coeff,
     const int &templateWindowSizeSq)
 {
-    short *thrMapPtr1D = thrMap1D;
+    short *thrMapPtr1D = outThrMap1D;
     for (int ii = 0; ii < 4; ++ii)
     {
 #ifdef DEBUG_PRINT
@@ -512,7 +512,7 @@ void ComputeThresholdMap1D(
             {
                 int indexIn1D = (1 << ii) - 1 + ii1;
                 int indexIn2D = jj;
-                int thr = static_cast<int>(kThrMap1D[indexIn1D] * kThrMap2D[indexIn2D] * hardThr1D * kCoeff[ii]);
+                int thr = static_cast<int>(thrMap1D[indexIn1D] * thrMap2D[indexIn2D] * hardThr1D * coeff[ii]);
                 if (thr > 32767)
                     thr = 32767;
 

--- a/modules/photo/src/bm3d_denoising_invoker_commons.hpp
+++ b/modules/photo/src/bm3d_denoising_invoker_commons.hpp
@@ -271,10 +271,6 @@ public:
     }
 };
 
-#ifdef DEBUG_PRINT
-#include <iostream>
-#endif
-
 template <typename T>
 void ComputeThresholdMap1D(
     T *outThrMap1D,
@@ -287,39 +283,21 @@ void ComputeThresholdMap1D(
     T *thrMapPtr1D = outThrMap1D;
     for (int ii = 0; ii < 4; ++ii)
     {
-#ifdef DEBUG_PRINT
-        std::cout << "group size: " << (1 << ii) << std::endl;
-#endif
         for (int jj = 0; jj < templateWindowSizeSq; ++jj)
         {
-#ifdef DEBUG_PRINT
-            if (jj % (int)std::sqrt(templateWindowSizeSq) == 0)
-                std::cout << std::endl;
-            std::cout << "\t";
-#endif
             for (int ii1 = 0; ii1 < (1 << ii); ++ii1)
             {
                 int indexIn1D = (1 << ii) - 1 + ii1;
                 int indexIn2D = jj;
                 int thr = static_cast<int>(thrMap1D[indexIn1D] * thrMap2D[indexIn2D] * hardThr1D * coeff[ii]);
-                if (thr > std::numeric_limits<T>::max())
-                    thr = std::numeric_limits<T>::max();
 
+                // Set DC component to zero
                 if (jj == 0 && ii1 == 0)
                     thr = 0;
 
-                *thrMapPtr1D++ = (T)thr;
-
-#ifdef DEBUG_PRINT
-                std::cout << thr << " ";
-            }
-            std::cout << std::endl;
-        }
-        std::cout << std::endl;
-#else
+                *thrMapPtr1D++ = cv::saturate_cast<T>(thr);
            }
         }
-#endif
     }
 }
 

--- a/modules/photo/src/bm3d_denoising_invoker_commons.hpp
+++ b/modules/photo/src/bm3d_denoising_invoker_commons.hpp
@@ -54,42 +54,16 @@ namespace std {
 }
 #endif
 
-template <typename T> struct pixelInfo_
+// Returns largest power of 2 smaller than the input value
+inline int getLargestPowerOf2SmallerThan(unsigned x)
 {
-    static const int channels = 1;
-    typedef T sampleType;
-};
-
-template <typename ET, int n> struct pixelInfo_<Vec<ET, n> >
-{
-    static const int channels = n;
-    typedef ET sampleType;
-};
-
-template <typename T> struct pixelInfo : public pixelInfo_<T>
-{
-    typedef typename pixelInfo_<T>::sampleType sampleType;
-
-    static inline sampleType sampleMax()
-    {
-        return std::numeric_limits<sampleType>::max();
-    }
-
-    static inline sampleType sampleMin()
-    {
-        return std::numeric_limits<sampleType>::min();
-    }
-
-    static inline size_t sampleBytes()
-    {
-        return sizeof(sampleType);
-    }
-
-    static inline size_t sampleBits()
-    {
-        return 8 * sampleBytes();
-    }
-};
+    x = x | (x >> 1);
+    x = x | (x >> 2);
+    x = x | (x >> 4);
+    x = x | (x >> 8);
+    x = x | (x >> 16);
+    return x - (x >> 1);
+}
 
 class DistAbs
 {

--- a/modules/photo/src/bm3d_denoising_invoker_commons.hpp
+++ b/modules/photo/src/bm3d_denoising_invoker_commons.hpp
@@ -1,0 +1,489 @@
+/*M///////////////////////////////////////////////////////////////////////////////////////
+//
+//  IMPORTANT: READ BEFORE DOWNLOADING, COPYING, INSTALLING OR USING.
+//
+//  By downloading, copying, installing or using the software you agree to this license.
+//  If you do not agree to this license, do not download, install,
+//  copy or use the software.
+//
+//
+//                        Intel License Agreement
+//                For Open Source Computer Vision Library
+//
+// Copyright (C) 2000, Intel Corporation, all rights reserved.
+// Third party copyrights are property of their respective icvers.
+//
+// Redistribution and use in source and binary forms, with or without modification,
+// are permitted provided that the following conditions are met:
+//
+//   * Redistribution's of source code must retain the above copyright notice,
+//     this list of conditions and the following disclaimer.
+//
+//   * Redistribution's in binary form must reproduce the above copyright notice,
+//     this list of conditions and the following disclaimer in the documentation
+//     and/or other materials provided with the distribution.
+//
+//   * The name of Intel Corporation may not be used to endorse or promote products
+//     derived from this software without specific prior written permission.
+//
+// This software is provided by the copyright holders and contributors "as is" and
+// any express or implied warranties, including, but not limited to, the implied
+// warranties of merchantability and fitness for a particular purpose are disclaimed.
+// In no event shall the Intel Corporation or contributors be liable for any direct,
+// indirect, incidental, special, exemplary, or consequential damages
+// (including, but not limited to, procurement of substitute goods or services;
+// loss of use, data, or profits; or business interruption) however caused
+// and on any theory of liability, whether in contract, strict liability,
+// or tort (including negligence or otherwise) arising in any way out of
+// the use of this software, even if advised of the possibility of such damage.
+//
+//M*/
+
+#ifndef __OPENCV_BM3D_DENOISING_INVOKER_COMMONS_HPP__
+#define __OPENCV_BM3D_DENOISING_INVOKER_COMMONS_HPP__
+
+using namespace cv;
+
+// std::isnan is a part of C++11 and it is not supported in MSVS2010/2012
+#if defined _MSC_VER && _MSC_VER < 1800 /* MSVC 2013 */
+#include <float.h>
+namespace std {
+    template <typename T> bool isnan(T value) { return _isnan(value) != 0; }
+}
+#endif
+
+template <typename T> struct pixelInfo_
+{
+    static const int channels = 1;
+    typedef T sampleType;
+};
+
+template <typename ET, int n> struct pixelInfo_<Vec<ET, n> >
+{
+    static const int channels = n;
+    typedef ET sampleType;
+};
+
+template <typename T> struct pixelInfo : public pixelInfo_<T>
+{
+    typedef typename pixelInfo_<T>::sampleType sampleType;
+
+    static inline sampleType sampleMax()
+    {
+        return std::numeric_limits<sampleType>::max();
+    }
+
+    static inline sampleType sampleMin()
+    {
+        return std::numeric_limits<sampleType>::min();
+    }
+
+    static inline size_t sampleBytes()
+    {
+        return sizeof(sampleType);
+    }
+
+    static inline size_t sampleBits()
+    {
+        return 8 * sampleBytes();
+    }
+};
+
+class DistAbs
+{
+    template <typename T> struct calcDist_
+    {
+        static inline int f(const T a, const T b)
+        {
+            return std::abs((int)(a - b));
+        }
+    };
+
+    template <typename ET> struct calcDist_<Vec<ET, 2> >
+    {
+        static inline int f(const Vec<ET, 2> a, const Vec<ET, 2> b)
+        {
+            return std::abs((int)(a[0] - b[0])) + std::abs((int)(a[1] - b[1]));
+        }
+    };
+
+    template <typename ET> struct calcDist_<Vec<ET, 3> >
+    {
+        static inline int f(const Vec<ET, 3> a, const Vec<ET, 3> b)
+        {
+            return
+                std::abs((int)(a[0] - b[0])) +
+                std::abs((int)(a[1] - b[1])) +
+                std::abs((int)(a[2] - b[2]));
+        }
+    };
+
+    template <typename ET> struct calcDist_<Vec<ET, 4> >
+    {
+        static inline int f(const Vec<ET, 4> a, const Vec<ET, 4> b)
+        {
+            return
+                std::abs((int)(a[0] - b[0])) +
+                std::abs((int)(a[1] - b[1])) +
+                std::abs((int)(a[2] - b[2])) +
+                std::abs((int)(a[3] - b[3]));
+        }
+    };
+
+    template <typename T, typename WT> struct calcWeight_
+    {
+        static inline WT f(double dist, const float &h, WT fixed_point_mult)
+        {
+            double w = std::exp(-dist*dist / (h * h * pixelInfo<T>::channels));
+            if (std::isnan(w)) w = 1.0; // Handle h = 0.0
+
+            static const double WEIGHT_THRESHOLD = 0.001;
+            WT weight = (WT)cvRound(fixed_point_mult * w);
+            if (weight < WEIGHT_THRESHOLD * fixed_point_mult) weight = 0;
+
+            return weight;
+        }
+    };
+
+    template <typename T, typename ET, int n> struct calcWeight_<T, Vec<ET, n> >
+    {
+        static inline Vec<ET, n> f(double dist, const float &h, ET fixed_point_mult)
+        {
+            Vec<ET, n> res;
+            for (int i = 0; i < n; i++)
+                res[i] = calcWeight<T, ET>(dist, h, fixed_point_mult);
+            return res;
+        }
+    };
+
+public:
+    template <typename T> static inline int calcDist(const T a, const T b)
+    {
+        return calcDist_<T>::f(a, b);
+    }
+
+    template <typename T>
+    static inline int calcDist(const Mat& m, int i1, int j1, int i2, int j2)
+    {
+        const T a = m.at<T>(i1, j1);
+        const T b = m.at<T>(i2, j2);
+        return calcDist<T>(a, b);
+    }
+
+    template <typename T>
+    static inline int calcUpDownDist(T a_up, T a_down, T b_up, T b_down)
+    {
+        return calcDist<T>(a_down, b_down) - calcDist<T>(a_up, b_up);
+    };
+
+    template <typename T, typename WT>
+    static inline WT calcWeight(double dist, const float &h,
+        typename pixelInfo<WT>::sampleType fixed_point_mult)
+    {
+        return calcWeight_<T, WT>::f(dist, h, fixed_point_mult);
+    }
+
+    template <typename T>
+    static inline int maxDist()
+    {
+        return (int)pixelInfo<T>::sampleMax() * pixelInfo<T>::channels;
+    }
+};
+
+class DistSquared
+{
+    template <typename T> struct calcDist_
+    {
+        static inline int f(const T a, const T b)
+        {
+            return (int)(a - b) * (int)(a - b);
+        }
+    };
+
+    template <typename ET> struct calcDist_<Vec<ET, 2> >
+    {
+        static inline int f(const Vec<ET, 2> a, const Vec<ET, 2> b)
+        {
+            return (int)(a[0] - b[0])*(int)(a[0] - b[0]) + (int)(a[1] - b[1])*(int)(a[1] - b[1]);
+        }
+    };
+
+    template <typename ET> struct calcDist_<Vec<ET, 3> >
+    {
+        static inline int f(const Vec<ET, 3> a, const Vec<ET, 3> b)
+        {
+            return
+                (int)(a[0] - b[0])*(int)(a[0] - b[0]) +
+                (int)(a[1] - b[1])*(int)(a[1] - b[1]) +
+                (int)(a[2] - b[2])*(int)(a[2] - b[2]);
+        }
+    };
+
+    template <typename ET> struct calcDist_<Vec<ET, 4> >
+    {
+        static inline int f(const Vec<ET, 4> a, const Vec<ET, 4> b)
+        {
+            return
+                (int)(a[0] - b[0])*(int)(a[0] - b[0]) +
+                (int)(a[1] - b[1])*(int)(a[1] - b[1]) +
+                (int)(a[2] - b[2])*(int)(a[2] - b[2]) +
+                (int)(a[3] - b[3])*(int)(a[3] - b[3]);
+        }
+    };
+
+    template <typename T> struct calcUpDownDist_
+    {
+        static inline int f(T a_up, T a_down, T b_up, T b_down)
+        {
+            int A = a_down - b_down;
+            int B = a_up - b_up;
+            return (A - B)*(A + B);
+        }
+    };
+
+    template <typename ET, int n> struct calcUpDownDist_<Vec<ET, n> >
+    {
+    private:
+        typedef Vec<ET, n> T;
+    public:
+        static inline int f(T a_up, T a_down, T b_up, T b_down)
+        {
+            return calcDist<T>(a_down, b_down) - calcDist<T>(a_up, b_up);
+        }
+    };
+
+    template <typename T, typename WT> struct calcWeight_
+    {
+        static inline WT f(double dist, const float &h, WT fixed_point_mult)
+        {
+            double w = std::exp(-dist / (h * h * pixelInfo<T>::channels));
+            if (std::isnan(w)) w = 1.0; // Handle h = 0.0
+
+            static const double WEIGHT_THRESHOLD = 0.001;
+            WT weight = (WT)cvRound(fixed_point_mult * w);
+            if (weight < WEIGHT_THRESHOLD * fixed_point_mult) weight = 0;
+
+            return weight;
+        }
+    };
+
+    template <typename T, typename ET, int n> struct calcWeight_<T, Vec<ET, n> >
+    {
+        static inline Vec<ET, n> f(double dist, const float &h, ET fixed_point_mult)
+        {
+            Vec<ET, n> res;
+            for (int i = 0; i < n; i++)
+                res[i] = calcWeight<T, ET>(dist, h, fixed_point_mult);
+            return res;
+        }
+    };
+
+public:
+    template <typename T> static inline int calcDist(const T a, const T b)
+    {
+        return calcDist_<T>::f(a, b);
+    }
+
+    template <typename T>
+    static inline int calcDist(const Mat& m, int i1, int j1, int i2, int j2)
+    {
+        const T a = m.at<T>(i1, j1);
+        const T b = m.at<T>(i2, j2);
+        return calcDist<T>(a, b);
+    }
+
+    template <typename T>
+    static inline int calcUpDownDist(T a_up, T a_down, T b_up, T b_down)
+    {
+        return calcUpDownDist_<T>::f(a_up, a_down, b_up, b_down);
+    };
+
+    template <typename T, typename WT>
+    static inline WT calcWeight(double dist, const float &h,
+        typename pixelInfo<WT>::sampleType fixed_point_mult)
+    {
+        return calcWeight_<T, WT>::f(dist, h, fixed_point_mult);
+    }
+
+    template <typename T>
+    static inline int maxDist()
+    {
+        return (int)pixelInfo<T>::sampleMax() * (int)pixelInfo<T>::sampleMax() *
+            pixelInfo<T>::channels;
+    }
+};
+
+template <typename T, typename IT, typename WT> struct incWithWeight_
+{
+    static inline void f(IT* estimation, IT* weights_sum, WT weight, T p)
+    {
+        estimation[0] += (IT)weight * p;
+        weights_sum[0] += (IT)weight;
+    }
+};
+
+template <typename ET, typename IT, typename WT> struct incWithWeight_<Vec<ET, 2>, IT, WT>
+{
+    static inline void f(IT* estimation, IT* weights_sum, WT weight, Vec<ET, 2> p)
+    {
+        estimation[0] += (IT)weight * p[0];
+        estimation[1] += (IT)weight * p[1];
+        weights_sum[0] += (IT)weight;
+    }
+};
+
+template <typename ET, typename IT, typename WT> struct incWithWeight_<Vec<ET, 3>, IT, WT>
+{
+    static inline void f(IT* estimation, IT* weights_sum, WT weight, Vec<ET, 3> p)
+    {
+        estimation[0] += (IT)weight * p[0];
+        estimation[1] += (IT)weight * p[1];
+        estimation[2] += (IT)weight * p[2];
+        weights_sum[0] += (IT)weight;
+    }
+};
+
+template <typename ET, typename IT, typename WT> struct incWithWeight_<Vec<ET, 4>, IT, WT>
+{
+    static inline void f(IT* estimation, IT* weights_sum, WT weight, Vec<ET, 4> p)
+    {
+        estimation[0] += (IT)weight * p[0];
+        estimation[1] += (IT)weight * p[1];
+        estimation[2] += (IT)weight * p[2];
+        estimation[3] += (IT)weight * p[3];
+        weights_sum[0] += (IT)weight;
+    }
+};
+
+template <typename ET, typename IT, typename EW> struct incWithWeight_<Vec<ET, 2>, IT, Vec<EW, 2> >
+{
+    static inline void f(IT* estimation, IT* weights_sum, Vec<EW, 2> weight, Vec<ET, 2> p)
+    {
+        estimation[0] += (IT)weight[0] * p[0];
+        estimation[1] += (IT)weight[1] * p[1];
+        weights_sum[0] += (IT)weight[0];
+        weights_sum[1] += (IT)weight[1];
+    }
+};
+
+template <typename ET, typename IT, typename EW> struct incWithWeight_<Vec<ET, 3>, IT, Vec<EW, 3> >
+{
+    static inline void f(IT* estimation, IT* weights_sum, Vec<EW, 3> weight, Vec<ET, 3> p)
+    {
+        estimation[0] += (IT)weight[0] * p[0];
+        estimation[1] += (IT)weight[1] * p[1];
+        estimation[2] += (IT)weight[2] * p[2];
+        weights_sum[0] += (IT)weight[0];
+        weights_sum[1] += (IT)weight[1];
+        weights_sum[2] += (IT)weight[2];
+    }
+};
+
+template <typename ET, typename IT, typename EW> struct incWithWeight_<Vec<ET, 4>, IT, Vec<EW, 4> >
+{
+    static inline void f(IT* estimation, IT* weights_sum, Vec<EW, 4> weight, Vec<ET, 4> p)
+    {
+        estimation[0] += (IT)weight[0] * p[0];
+        estimation[1] += (IT)weight[1] * p[1];
+        estimation[2] += (IT)weight[2] * p[2];
+        estimation[3] += (IT)weight[3] * p[3];
+        weights_sum[0] += (IT)weight[0];
+        weights_sum[1] += (IT)weight[1];
+        weights_sum[2] += (IT)weight[2];
+        weights_sum[3] += (IT)weight[3];
+    }
+};
+
+template <typename T, typename IT, typename WT>
+static inline void incWithWeight(IT* estimation, IT* weights_sum, WT weight, T p)
+{
+    return incWithWeight_<T, IT, WT>::f(estimation, weights_sum, weight, p);
+}
+
+template <typename IT, typename UIT, int nc, int nw> struct divByWeightsSum_
+{
+    static inline void f(IT* estimation, IT* weights_sum);
+};
+
+template <typename IT, typename UIT> struct divByWeightsSum_<IT, UIT, 1, 1>
+{
+    static inline void f(IT* estimation, IT* weights_sum)
+    {
+        estimation[0] = (static_cast<UIT>(estimation[0]) + weights_sum[0] / 2) / weights_sum[0];
+    }
+};
+
+template <typename IT, typename UIT, int n> struct divByWeightsSum_<IT, UIT, n, 1>
+{
+    static inline void f(IT* estimation, IT* weights_sum)
+    {
+        for (size_t i = 0; i < n; i++)
+            estimation[i] = (static_cast<UIT>(estimation[i]) + weights_sum[0] / 2) / weights_sum[0];
+    }
+};
+
+template <typename IT, typename UIT, int n> struct divByWeightsSum_<IT, UIT, n, n>
+{
+    static inline void f(IT* estimation, IT* weights_sum)
+    {
+        for (size_t i = 0; i < n; i++)
+            estimation[i] = (static_cast<UIT>(estimation[i]) + weights_sum[i] / 2) / weights_sum[i];
+    }
+};
+
+template <typename IT, typename UIT, int nc, int nw>
+static inline void divByWeightsSum(IT* estimation, IT* weights_sum)
+{
+    return divByWeightsSum_<IT, UIT, nc, nw>::f(estimation, weights_sum);
+}
+
+template <typename T, typename IT> struct saturateCastFromArray_
+{
+    static inline T f(IT* estimation)
+    {
+        return saturate_cast<T>(estimation[0]);
+    }
+};
+
+template <typename ET, typename IT> struct saturateCastFromArray_<Vec<ET, 2>, IT>
+{
+    static inline Vec<ET, 2> f(IT* estimation)
+    {
+        Vec<ET, 2> res;
+        res[0] = saturate_cast<ET>(estimation[0]);
+        res[1] = saturate_cast<ET>(estimation[1]);
+        return res;
+    }
+};
+
+template <typename ET, typename IT> struct saturateCastFromArray_<Vec<ET, 3>, IT>
+{
+    static inline Vec<ET, 3> f(IT* estimation)
+    {
+        Vec<ET, 3> res;
+        res[0] = saturate_cast<ET>(estimation[0]);
+        res[1] = saturate_cast<ET>(estimation[1]);
+        res[2] = saturate_cast<ET>(estimation[2]);
+        return res;
+    }
+};
+
+template <typename ET, typename IT> struct saturateCastFromArray_<Vec<ET, 4>, IT>
+{
+    static inline Vec<ET, 4> f(IT* estimation)
+    {
+        Vec<ET, 4> res;
+        res[0] = saturate_cast<ET>(estimation[0]);
+        res[1] = saturate_cast<ET>(estimation[1]);
+        res[2] = saturate_cast<ET>(estimation[2]);
+        res[3] = saturate_cast<ET>(estimation[3]);
+        return res;
+    }
+};
+
+template <typename T, typename IT> static inline T saturateCastFromArray(IT* estimation)
+{
+    return saturateCastFromArray_<T, IT>::f(estimation);
+}
+
+#endif

--- a/modules/photo/src/bm3d_denoising_invoker_commons.hpp
+++ b/modules/photo/src/bm3d_denoising_invoker_commons.hpp
@@ -42,6 +42,8 @@
 #ifndef __OPENCV_BM3D_DENOISING_INVOKER_COMMONS_HPP__
 #define __OPENCV_BM3D_DENOISING_INVOKER_COMMONS_HPP__
 
+//#define DEBUG_PRINT
+
 using namespace cv;
 
 // std::isnan is a part of C++11 and it is not supported in MSVS2010/2012
@@ -481,31 +483,6 @@ template <typename ET, typename IT> struct saturateCastFromArray_<Vec<ET, 4>, IT
     }
 };
 
-template <typename T, typename IT> static inline T saturateCastFromArray(IT* estimation)
-{
-    return saturateCastFromArray_<T, IT>::f(estimation);
-}
-
-void ComputeThresholdMap2D(
-    short *thrMap2D,
-    float *kThrMap2D,
-    const float &hardThr2D,
-    const float &kCoeff2D,
-    const int &templateWindowSizeSq,
-    bool print)
-{
-    for (int jj = 0; jj < templateWindowSizeSq; ++jj)
-    {
-        float thr = kThrMap2D[jj] * hardThr2D * kCoeff2D;
-        if (thr > 32767)
-            thr = 32767;
-
-        thrMap2D[jj] = thr;
-    }
-}
-
-//#define DEBUG_PRINT
-
 #ifdef DEBUG_PRINT
 #include <iostream>
 #endif
@@ -535,7 +512,7 @@ void ComputeThresholdMap1D(
             {
                 int indexIn1D = (1 << ii) - 1 + ii1;
                 int indexIn2D = jj;
-                int thr = kThrMap1D[indexIn1D] * kThrMap2D[indexIn2D] * hardThr1D * kCoeff[ii];
+                int thr = static_cast<int>(kThrMap1D[indexIn1D] * kThrMap2D[indexIn2D] * hardThr1D * kCoeff[ii]);
                 if (thr > 32767)
                     thr = 32767;
 

--- a/modules/photo/src/bm3d_denoising_invoker_commons.hpp
+++ b/modules/photo/src/bm3d_denoising_invoker_commons.hpp
@@ -375,8 +375,8 @@ void ComputeThresholdMap1D(
                 int indexIn1D = (1 << ii) - 1 + ii1;
                 int indexIn2D = jj;
                 int thr = static_cast<int>(thrMap1D[indexIn1D] * thrMap2D[indexIn2D] * hardThr1D * coeff[ii]);
-                if (thr > 32767)
-                    thr = 32767;
+                if (thr > std::numeric_limits<short>::max())
+                    thr = std::numeric_limits<short>::max();
 
                 if (jj == 0 && ii1 == 0)
                     thr = 0;

--- a/modules/photo/src/bm3d_denoising_invoker_commons.hpp
+++ b/modules/photo/src/bm3d_denoising_invoker_commons.hpp
@@ -97,7 +97,7 @@ class DistAbs
     {
         static inline int f(const T a, const T b)
         {
-            return std::abs((int)(a - b));
+            return std::abs(a - b);
         }
     };
 
@@ -132,32 +132,6 @@ class DistAbs
         }
     };
 
-    template <typename T, typename WT> struct calcWeight_
-    {
-        static inline WT f(double dist, const float &h, WT fixed_point_mult)
-        {
-            double w = std::exp(-dist*dist / (h * h * pixelInfo<T>::channels));
-            if (std::isnan(w)) w = 1.0; // Handle h = 0.0
-
-            static const double WEIGHT_THRESHOLD = 0.001;
-            WT weight = (WT)cvRound(fixed_point_mult * w);
-            if (weight < WEIGHT_THRESHOLD * fixed_point_mult) weight = 0;
-
-            return weight;
-        }
-    };
-
-    template <typename T, typename ET, int n> struct calcWeight_<T, Vec<ET, n> >
-    {
-        static inline Vec<ET, n> f(double dist, const float &h, ET fixed_point_mult)
-        {
-            Vec<ET, n> res;
-            for (int i = 0; i < n; i++)
-                res[i] = calcWeight<T, ET>(dist, h, fixed_point_mult);
-            return res;
-        }
-    };
-
 public:
     template <typename T> static inline int calcDist(const T a, const T b)
     {
@@ -171,25 +145,6 @@ public:
         const T b = m.at<T>(i2, j2);
         return calcDist<T>(a, b);
     }
-
-    template <typename T>
-    static inline int calcUpDownDist(T a_up, T a_down, T b_up, T b_down)
-    {
-        return calcDist<T>(a_down, b_down) - calcDist<T>(a_up, b_up);
-    };
-
-    template <typename T, typename WT>
-    static inline WT calcWeight(double dist, const float &h,
-        typename pixelInfo<WT>::sampleType fixed_point_mult)
-    {
-        return calcWeight_<T, WT>::f(dist, h, fixed_point_mult);
-    }
-
-    template <typename T>
-    static inline int maxDist()
-    {
-        return (int)pixelInfo<T>::sampleMax() * pixelInfo<T>::channels;
-    }
 };
 
 class DistSquared
@@ -198,7 +153,7 @@ class DistSquared
     {
         static inline int f(const T a, const T b)
         {
-            return (int)(a - b) * (int)(a - b);
+            return (a - b) * (a - b);
         }
     };
 
@@ -233,53 +188,6 @@ class DistSquared
         }
     };
 
-    template <typename T> struct calcUpDownDist_
-    {
-        static inline int f(T a_up, T a_down, T b_up, T b_down)
-        {
-            int A = a_down - b_down;
-            int B = a_up - b_up;
-            return (A - B)*(A + B);
-        }
-    };
-
-    template <typename ET, int n> struct calcUpDownDist_<Vec<ET, n> >
-    {
-    private:
-        typedef Vec<ET, n> T;
-    public:
-        static inline int f(T a_up, T a_down, T b_up, T b_down)
-        {
-            return calcDist<T>(a_down, b_down) - calcDist<T>(a_up, b_up);
-        }
-    };
-
-    template <typename T, typename WT> struct calcWeight_
-    {
-        static inline WT f(double dist, const float &h, WT fixed_point_mult)
-        {
-            double w = std::exp(-dist / (h * h * pixelInfo<T>::channels));
-            if (std::isnan(w)) w = 1.0; // Handle h = 0.0
-
-            static const double WEIGHT_THRESHOLD = 0.001;
-            WT weight = (WT)cvRound(fixed_point_mult * w);
-            if (weight < WEIGHT_THRESHOLD * fixed_point_mult) weight = 0;
-
-            return weight;
-        }
-    };
-
-    template <typename T, typename ET, int n> struct calcWeight_<T, Vec<ET, n> >
-    {
-        static inline Vec<ET, n> f(double dist, const float &h, ET fixed_point_mult)
-        {
-            Vec<ET, n> res;
-            for (int i = 0; i < n; i++)
-                res[i] = calcWeight<T, ET>(dist, h, fixed_point_mult);
-            return res;
-        }
-    };
-
 public:
     template <typename T> static inline int calcDist(const T a, const T b)
     {
@@ -292,26 +200,6 @@ public:
         const T a = m.at<T>(i1, j1);
         const T b = m.at<T>(i2, j2);
         return calcDist<T>(a, b);
-    }
-
-    template <typename T>
-    static inline int calcUpDownDist(T a_up, T a_down, T b_up, T b_down)
-    {
-        return calcUpDownDist_<T>::f(a_up, a_down, b_up, b_down);
-    };
-
-    template <typename T, typename WT>
-    static inline WT calcWeight(double dist, const float &h,
-        typename pixelInfo<WT>::sampleType fixed_point_mult)
-    {
-        return calcWeight_<T, WT>::f(dist, h, fixed_point_mult);
-    }
-
-    template <typename T>
-    static inline int maxDist()
-    {
-        return (int)pixelInfo<T>::sampleMax() * (int)pixelInfo<T>::sampleMax() *
-            pixelInfo<T>::channels;
     }
 };
 

--- a/modules/photo/src/bm3d_denoising_invoker_commons.hpp
+++ b/modules/photo/src/bm3d_denoising_invoker_commons.hpp
@@ -113,6 +113,12 @@ public:
     }
 
     template <typename T>
+    static inline T calcBlockMatchingThreshold(const T &blockMatchThrL2, const T &blockSizeSq)
+    {
+        return (T)(std::sqrt((double)blockMatchThrL2) * blockSizeSq);
+    }
+
+    template <typename T>
     static inline int calcDist(const Mat& m, int i1, int j1, int i2, int j2)
     {
         const T a = m.at<T>(i1, j1);
@@ -166,6 +172,12 @@ public:
     template <typename T> static inline int calcDist(const T a, const T b)
     {
         return calcDist_<T>::f(a, b);
+    }
+
+    template <typename T>
+    static inline T calcBlockMatchingThreshold(const T &blockMatchThrL2, const T &blockSizeSq)
+    {
+        return blockMatchThrL2 * blockSizeSq;
     }
 
     template <typename T>

--- a/modules/photo/src/bm3d_denoising_invoker_commons.hpp
+++ b/modules/photo/src/bm3d_denoising_invoker_commons.hpp
@@ -65,6 +65,25 @@ inline int getLargestPowerOf2SmallerThan(unsigned x)
     return x - (x >> 1);
 }
 
+template <typename DT, typename CT>
+struct BlockMatch
+{
+    // Block matching distance
+    DT dist;
+
+    // Relative coordinates to the current search window
+    CT coord_x;
+    CT coord_y;
+
+    // Overloaded operator for convenient assignment
+    void operator()(const DT &_dst, const CT &_coord_x, const CT &_coord_y)
+    {
+        dist = _dst;
+        coord_x = _coord_x;
+        coord_y = _coord_y;
+    }
+};
+
 class DistAbs
 {
     template <typename T>

--- a/modules/photo/src/bm3d_denoising_invoker_commons.hpp
+++ b/modules/photo/src/bm3d_denoising_invoker_commons.hpp
@@ -142,7 +142,7 @@ class DistAbs
     template <typename T>
     struct calcDist_
     {
-        static inline int f(const T a, const T b)
+        static inline int f(const T &a, const T &b)
         {
             return std::abs(a - b);
         }
@@ -184,7 +184,7 @@ class DistAbs
 
 public:
     template <typename T>
-    static inline int calcDist(const T a, const T b)
+    static inline int calcDist(const T &a, const T &b)
     {
         return calcDist_<T>::f(a, b);
     }
@@ -209,7 +209,7 @@ class DistSquared
     template <typename T>
     struct calcDist_
     {
-        static inline int f(const T a, const T b)
+        static inline int f(const T &a, const T &b)
         {
             return (a - b) * (a - b);
         }
@@ -251,7 +251,7 @@ class DistSquared
 
 public:
     template <typename T>
-    static inline int calcDist(const T a, const T b)
+    static inline int calcDist(const T &a, const T &b)
     {
         return calcDist_<T>::f(a, b);
     }

--- a/modules/photo/src/bm3d_denoising_invoker_commons.hpp
+++ b/modules/photo/src/bm3d_denoising_invoker_commons.hpp
@@ -113,12 +113,6 @@ public:
         return data_[idx];
     };
 
-    // Overloaded comparison operator
-    const inline bool operator==(const BlockMatch& other) const
-    {
-        return (coord_x == other.coord_x && coord_y == other.coord_y);
-    }
-
     // Overloaded comparison operator for sorting
     bool operator<(const BlockMatch& right) const
     {

--- a/modules/photo/src/bm3d_denoising_invoker_commons.hpp
+++ b/modules/photo/src/bm3d_denoising_invoker_commons.hpp
@@ -486,4 +486,52 @@ template <typename T, typename IT> static inline T saturateCastFromArray(IT* est
     return saturateCastFromArray_<T, IT>::f(estimation);
 }
 
+void ComputeThresholdMap2D(
+    short *thrMap2D,
+    float *kThrMap2D,
+    const float &hardThr2D,
+    const float &kCoeff2D,
+    const int &templateWindowSizeSq,
+    bool print)
+{
+    for (int jj = 0; jj < templateWindowSizeSq; ++jj)
+    {
+        float thr = kThrMap2D[jj] * hardThr2D * kCoeff2D;
+        if (thr > 32767)
+            thr = 32767;
+
+        thrMap2D[jj] = thr;
+    }
+}
+
+void ComputeThresholdMap1D(
+    short *thrMap1D,
+    const float *kThrMap1D,
+    float *kThrMap2D,
+    const float &hardThr1D,
+    const float *kCoeff,
+    const int &templateWindowSizeSq)
+{
+    short *thrMapPtr1D = thrMap1D;
+    for (int ii = 0; ii < 4; +ii)
+    {
+        for (int jj = 0; jj < templateWindowSizeSq; ++jj)
+        {
+            for (int ii1 = 0; ii1 < (1 << ii); ++ii1)
+            {
+                int indexIn1D = (1 << ii) - 1 + ii1;
+                int indexIn2D = jj;
+                int thr = kThrMap1D[indexIn1D] * kThrMap2D[indexIn2D] * hardThr1D * kCoeff[ii];
+                if (thr > 32767)
+                    thr = 32767;
+
+                if (jj == 0 && ii1 == 0)
+                    thr = 0;
+
+                *thrMapPtr1D++ = (short)thr;
+            }
+        }
+    }
+}
+
 #endif

--- a/modules/photo/src/bm3d_denoising_invoker_commons.hpp
+++ b/modules/photo/src/bm3d_denoising_invoker_commons.hpp
@@ -504,6 +504,12 @@ void ComputeThresholdMap2D(
     }
 }
 
+//#define DEBUG_PRINT
+
+#ifdef DEBUG_PRINT
+#include <iostream>
+#endif
+
 void ComputeThresholdMap1D(
     short *thrMap1D,
     const float *kThrMap1D,
@@ -515,8 +521,16 @@ void ComputeThresholdMap1D(
     short *thrMapPtr1D = thrMap1D;
     for (int ii = 0; ii < 4; ++ii)
     {
+#ifdef DEBUG_PRINT
+        std::cout << "group size: " << (1 << ii) << std::endl;
+#endif
         for (int jj = 0; jj < templateWindowSizeSq; ++jj)
         {
+#ifdef DEBUG_PRINT
+            if (jj % (int)std::sqrt(templateWindowSizeSq) == 0)
+                std::cout << std::endl;
+            std::cout << "\t";
+#endif
             for (int ii1 = 0; ii1 < (1 << ii); ++ii1)
             {
                 int indexIn1D = (1 << ii) - 1 + ii1;
@@ -529,8 +543,17 @@ void ComputeThresholdMap1D(
                     thr = 0;
 
                 *thrMapPtr1D++ = (short)thr;
+
+#ifdef DEBUG_PRINT
+                std::cout << thr << " ";
             }
+            std::cout << std::endl;
         }
+        std::cout << std::endl;
+#else
+           }
+        }
+#endif
     }
 }
 

--- a/modules/photo/src/bm3d_denoising_invoker_commons.hpp
+++ b/modules/photo/src/bm3d_denoising_invoker_commons.hpp
@@ -67,7 +67,8 @@ inline int getLargestPowerOf2SmallerThan(unsigned x)
 
 class DistAbs
 {
-    template <typename T> struct calcDist_
+    template <typename T>
+    struct calcDist_
     {
         static inline int f(const T a, const T b)
         {
@@ -75,7 +76,8 @@ class DistAbs
         }
     };
 
-    template <typename ET> struct calcDist_<Vec<ET, 2> >
+    template <typename ET>
+    struct calcDist_<Vec<ET, 2> >
     {
         static inline int f(const Vec<ET, 2> a, const Vec<ET, 2> b)
         {
@@ -83,7 +85,8 @@ class DistAbs
         }
     };
 
-    template <typename ET> struct calcDist_<Vec<ET, 3> >
+    template <typename ET>
+    struct calcDist_<Vec<ET, 3> >
     {
         static inline int f(const Vec<ET, 3> a, const Vec<ET, 3> b)
         {
@@ -94,7 +97,8 @@ class DistAbs
         }
     };
 
-    template <typename ET> struct calcDist_<Vec<ET, 4> >
+    template <typename ET>
+    struct calcDist_<Vec<ET, 4> >
     {
         static inline int f(const Vec<ET, 4> a, const Vec<ET, 4> b)
         {
@@ -107,7 +111,8 @@ class DistAbs
     };
 
 public:
-    template <typename T> static inline int calcDist(const T a, const T b)
+    template <typename T>
+    static inline int calcDist(const T a, const T b)
     {
         return calcDist_<T>::f(a, b);
     }
@@ -129,7 +134,8 @@ public:
 
 class DistSquared
 {
-    template <typename T> struct calcDist_
+    template <typename T>
+    struct calcDist_
     {
         static inline int f(const T a, const T b)
         {
@@ -137,7 +143,8 @@ class DistSquared
         }
     };
 
-    template <typename ET> struct calcDist_<Vec<ET, 2> >
+    template <typename ET>
+    struct calcDist_<Vec<ET, 2> >
     {
         static inline int f(const Vec<ET, 2> a, const Vec<ET, 2> b)
         {
@@ -145,7 +152,8 @@ class DistSquared
         }
     };
 
-    template <typename ET> struct calcDist_<Vec<ET, 3> >
+    template <typename ET>
+    struct calcDist_<Vec<ET, 3> >
     {
         static inline int f(const Vec<ET, 3> a, const Vec<ET, 3> b)
         {
@@ -156,7 +164,8 @@ class DistSquared
         }
     };
 
-    template <typename ET> struct calcDist_<Vec<ET, 4> >
+    template <typename ET>
+    struct calcDist_<Vec<ET, 4> >
     {
         static inline int f(const Vec<ET, 4> a, const Vec<ET, 4> b)
         {
@@ -169,7 +178,8 @@ class DistSquared
     };
 
 public:
-    template <typename T> static inline int calcDist(const T a, const T b)
+    template <typename T>
+    static inline int calcDist(const T a, const T b)
     {
         return calcDist_<T>::f(a, b);
     }
@@ -186,174 +196,6 @@ public:
         const T a = m.at<T>(i1, j1);
         const T b = m.at<T>(i2, j2);
         return calcDist<T>(a, b);
-    }
-};
-
-template <typename T, typename IT, typename WT> struct incWithWeight_
-{
-    static inline void f(IT* estimation, IT* weights_sum, WT weight, T p)
-    {
-        estimation[0] += (IT)weight * p;
-        weights_sum[0] += (IT)weight;
-    }
-};
-
-template <typename ET, typename IT, typename WT> struct incWithWeight_<Vec<ET, 2>, IT, WT>
-{
-    static inline void f(IT* estimation, IT* weights_sum, WT weight, Vec<ET, 2> p)
-    {
-        estimation[0] += (IT)weight * p[0];
-        estimation[1] += (IT)weight * p[1];
-        weights_sum[0] += (IT)weight;
-    }
-};
-
-template <typename ET, typename IT, typename WT> struct incWithWeight_<Vec<ET, 3>, IT, WT>
-{
-    static inline void f(IT* estimation, IT* weights_sum, WT weight, Vec<ET, 3> p)
-    {
-        estimation[0] += (IT)weight * p[0];
-        estimation[1] += (IT)weight * p[1];
-        estimation[2] += (IT)weight * p[2];
-        weights_sum[0] += (IT)weight;
-    }
-};
-
-template <typename ET, typename IT, typename WT> struct incWithWeight_<Vec<ET, 4>, IT, WT>
-{
-    static inline void f(IT* estimation, IT* weights_sum, WT weight, Vec<ET, 4> p)
-    {
-        estimation[0] += (IT)weight * p[0];
-        estimation[1] += (IT)weight * p[1];
-        estimation[2] += (IT)weight * p[2];
-        estimation[3] += (IT)weight * p[3];
-        weights_sum[0] += (IT)weight;
-    }
-};
-
-template <typename ET, typename IT, typename EW> struct incWithWeight_<Vec<ET, 2>, IT, Vec<EW, 2> >
-{
-    static inline void f(IT* estimation, IT* weights_sum, Vec<EW, 2> weight, Vec<ET, 2> p)
-    {
-        estimation[0] += (IT)weight[0] * p[0];
-        estimation[1] += (IT)weight[1] * p[1];
-        weights_sum[0] += (IT)weight[0];
-        weights_sum[1] += (IT)weight[1];
-    }
-};
-
-template <typename ET, typename IT, typename EW> struct incWithWeight_<Vec<ET, 3>, IT, Vec<EW, 3> >
-{
-    static inline void f(IT* estimation, IT* weights_sum, Vec<EW, 3> weight, Vec<ET, 3> p)
-    {
-        estimation[0] += (IT)weight[0] * p[0];
-        estimation[1] += (IT)weight[1] * p[1];
-        estimation[2] += (IT)weight[2] * p[2];
-        weights_sum[0] += (IT)weight[0];
-        weights_sum[1] += (IT)weight[1];
-        weights_sum[2] += (IT)weight[2];
-    }
-};
-
-template <typename ET, typename IT, typename EW> struct incWithWeight_<Vec<ET, 4>, IT, Vec<EW, 4> >
-{
-    static inline void f(IT* estimation, IT* weights_sum, Vec<EW, 4> weight, Vec<ET, 4> p)
-    {
-        estimation[0] += (IT)weight[0] * p[0];
-        estimation[1] += (IT)weight[1] * p[1];
-        estimation[2] += (IT)weight[2] * p[2];
-        estimation[3] += (IT)weight[3] * p[3];
-        weights_sum[0] += (IT)weight[0];
-        weights_sum[1] += (IT)weight[1];
-        weights_sum[2] += (IT)weight[2];
-        weights_sum[3] += (IT)weight[3];
-    }
-};
-
-template <typename T, typename IT, typename WT>
-static inline void incWithWeight(IT* estimation, IT* weights_sum, WT weight, T p)
-{
-    return incWithWeight_<T, IT, WT>::f(estimation, weights_sum, weight, p);
-}
-
-template <typename IT, typename UIT, int nc, int nw> struct divByWeightsSum_
-{
-    static inline void f(IT* estimation, IT* weights_sum);
-};
-
-template <typename IT, typename UIT> struct divByWeightsSum_<IT, UIT, 1, 1>
-{
-    static inline void f(IT* estimation, IT* weights_sum)
-    {
-        estimation[0] = (static_cast<UIT>(estimation[0]) + weights_sum[0] / 2) / weights_sum[0];
-    }
-};
-
-template <typename IT, typename UIT, int n> struct divByWeightsSum_<IT, UIT, n, 1>
-{
-    static inline void f(IT* estimation, IT* weights_sum)
-    {
-        for (size_t i = 0; i < n; i++)
-            estimation[i] = (static_cast<UIT>(estimation[i]) + weights_sum[0] / 2) / weights_sum[0];
-    }
-};
-
-template <typename IT, typename UIT, int n> struct divByWeightsSum_<IT, UIT, n, n>
-{
-    static inline void f(IT* estimation, IT* weights_sum)
-    {
-        for (size_t i = 0; i < n; i++)
-            estimation[i] = (static_cast<UIT>(estimation[i]) + weights_sum[i] / 2) / weights_sum[i];
-    }
-};
-
-template <typename IT, typename UIT, int nc, int nw>
-static inline void divByWeightsSum(IT* estimation, IT* weights_sum)
-{
-    return divByWeightsSum_<IT, UIT, nc, nw>::f(estimation, weights_sum);
-}
-
-template <typename T, typename IT> struct saturateCastFromArray_
-{
-    static inline T f(IT* estimation)
-    {
-        return saturate_cast<T>(estimation[0]);
-    }
-};
-
-template <typename ET, typename IT> struct saturateCastFromArray_<Vec<ET, 2>, IT>
-{
-    static inline Vec<ET, 2> f(IT* estimation)
-    {
-        Vec<ET, 2> res;
-        res[0] = saturate_cast<ET>(estimation[0]);
-        res[1] = saturate_cast<ET>(estimation[1]);
-        return res;
-    }
-};
-
-template <typename ET, typename IT> struct saturateCastFromArray_<Vec<ET, 3>, IT>
-{
-    static inline Vec<ET, 3> f(IT* estimation)
-    {
-        Vec<ET, 3> res;
-        res[0] = saturate_cast<ET>(estimation[0]);
-        res[1] = saturate_cast<ET>(estimation[1]);
-        res[2] = saturate_cast<ET>(estimation[2]);
-        return res;
-    }
-};
-
-template <typename ET, typename IT> struct saturateCastFromArray_<Vec<ET, 4>, IT>
-{
-    static inline Vec<ET, 4> f(IT* estimation)
-    {
-        Vec<ET, 4> res;
-        res[0] = saturate_cast<ET>(estimation[0]);
-        res[1] = saturate_cast<ET>(estimation[1]);
-        res[2] = saturate_cast<ET>(estimation[2]);
-        res[3] = saturate_cast<ET>(estimation[3]);
-        return res;
     }
 };
 

--- a/modules/photo/src/bm3d_denoising_invoker_commons.hpp
+++ b/modules/photo/src/bm3d_denoising_invoker_commons.hpp
@@ -513,7 +513,7 @@ void ComputeThresholdMap1D(
     const int &templateWindowSizeSq)
 {
     short *thrMapPtr1D = thrMap1D;
-    for (int ii = 0; ii < 4; +ii)
+    for (int ii = 0; ii < 4; ++ii)
     {
         for (int jj = 0; jj < templateWindowSizeSq; ++jj)
         {

--- a/modules/photo/src/bm3d_denoising_invoker_step1.hpp
+++ b/modules/photo/src/bm3d_denoising_invoker_step1.hpp
@@ -39,8 +39,8 @@
 //
 //M*/
 
-#ifndef __OPENCV_BM3D_DENOISING_INVOKER_HPP__
-#define __OPENCV_BM3D_DENOISING_INVOKER_HPP__
+#ifndef __OPENCV_BM3D_DENOISING_INVOKER_STEP1_HPP__
+#define __OPENCV_BM3D_DENOISING_INVOKER_STEP1_HPP__
 
 #include "precomp.hpp"
 #include <limits>
@@ -52,10 +52,10 @@
 using namespace cv;
 
 template <typename T, typename IT, typename UIT, typename D, typename WT, typename TT>
-struct Bm3dDenoisingInvoker : public ParallelLoopBody
+struct Bm3dDenoisingInvokerStep1 : public ParallelLoopBody
 {
 public:
-    Bm3dDenoisingInvoker(
+    Bm3dDenoisingInvokerStep1(
         const Mat& src,
         Mat& dst,
         const int &templateWindowSize,
@@ -64,11 +64,11 @@ public:
         const int &hBM,
         const int &groupSize);
 
-    virtual ~Bm3dDenoisingInvoker();
+    virtual ~Bm3dDenoisingInvokerStep1();
     void operator() (const Range& range) const;
 
 private:
-    void operator= (const Bm3dDenoisingInvoker&);
+    void operator= (const Bm3dDenoisingInvokerStep1&);
 
     const Mat& src_;
     Mat& dst_;
@@ -100,7 +100,7 @@ private:
 };
 
 template <typename T, typename IT, typename UIT, typename D, typename WT, typename TT>
-Bm3dDenoisingInvoker<T, IT, UIT, D, WT, TT>::Bm3dDenoisingInvoker(
+Bm3dDenoisingInvokerStep1<T, IT, UIT, D, WT, TT>::Bm3dDenoisingInvokerStep1(
     const Mat& src,
     Mat& dst,
     const int &templateWindowSize,
@@ -148,13 +148,13 @@ Bm3dDenoisingInvoker<T, IT, UIT, D, WT, TT>::Bm3dDenoisingInvoker(
 }
 
 template<typename T, typename IT, typename UIT, typename D, typename WT, typename TT>
-inline Bm3dDenoisingInvoker<T, IT, UIT, D, WT, TT>::~Bm3dDenoisingInvoker()
+inline Bm3dDenoisingInvokerStep1<T, IT, UIT, D, WT, TT>::~Bm3dDenoisingInvokerStep1()
 {
     delete[] thrMap_;
 }
 
 template <typename T, typename IT, typename UIT, typename D, typename WT, typename TT>
-void Bm3dDenoisingInvoker<T, IT, UIT, D, WT, TT>::operator() (const Range& range) const
+void Bm3dDenoisingInvokerStep1<T, IT, UIT, D, WT, TT>::operator() (const Range& range) const
 {
     const int size = (range.size() + 2 * borderSize_) * srcExtended_.cols;
     std::vector<WT> weightedSum(size, 0.0);

--- a/modules/photo/src/bm3d_denoising_invoker_step2.hpp
+++ b/modules/photo/src/bm3d_denoising_invoker_step2.hpp
@@ -1,0 +1,363 @@
+/*M///////////////////////////////////////////////////////////////////////////////////////
+//
+//  IMPORTANT: READ BEFORE DOWNLOADING, COPYING, INSTALLING OR USING.
+//
+//  By downloading, copying, installing or using the software you agree to this license.
+//  If you do not agree to this license, do not download, install,
+//  copy or use the software.
+//
+//
+//                        Intel License Agreement
+//                For Open Source Computer Vision Library
+//
+// Copyright (C) 2000, Intel Corporation, all rights reserved.
+// Third party copyrights are property of their respective icvers.
+//
+// Redistribution and use in source and binary forms, with or without modification,
+// are permitted provided that the following conditions are met:
+//
+//   * Redistribution's of source code must retain the above copyright notice,
+//     this list of conditions and the following disclaimer.
+//
+//   * Redistribution's in binary form must reproduce the above copyright notice,
+//     this list of conditions and the following disclaimer in the documentation
+//     and/or other materials provided with the distribution.
+//
+//   * The name of Intel Corporation may not be used to endorse or promote products
+//     derived from this software without specific prior written permission.
+//
+// This software is provided by the copyright holders and contributors "as is" and
+// any express or implied warranties, including, but not limited to, the implied
+// warranties of merchantability and fitness for a particular purpose are disclaimed.
+// In no event shall the Intel Corporation or contributors be liable for any direct,
+// indirect, incidental, special, exemplary, or consequential damages
+// (including, but not limited to, procurement of substitute goods or services;
+// loss of use, data, or profits; or business interruption) however caused
+// and on any theory of liability, whether in contract, strict liability,
+// or tort (including negligence or otherwise) arising in any way out of
+// the use of this software, even if advised of the possibility of such damage.
+//
+//M*/
+
+#ifndef __OPENCV_BM3D_DENOISING_INVOKER_STEP2_HPP__
+#define __OPENCV_BM3D_DENOISING_INVOKER_STEP2_HPP__
+
+#include "precomp.hpp"
+#include <limits>
+
+#include "bm3d_denoising_invoker_commons.hpp"
+#include "bm3d_denoising_transforms.hpp"
+#include "arrays.hpp"
+
+using namespace cv;
+
+template <typename T, typename IT, typename UIT, typename D, typename WT, typename TT>
+struct Bm3dDenoisingInvokerStep2 : public ParallelLoopBody
+{
+public:
+    Bm3dDenoisingInvokerStep2(
+        const Mat& src,
+        const Mat& basic,
+        Mat& dst,
+        const int &templateWindowSize,
+        const int &searchWindowSize,
+        const float &h,
+        const int &hBM,
+        const int &groupSize);
+
+    virtual ~Bm3dDenoisingInvokerStep2();
+    void operator() (const Range& range) const;
+
+private:
+    void operator= (const Bm3dDenoisingInvokerStep2&);
+
+    const Mat& src_;
+    const Mat& basic_;
+    Mat& dst_;
+    Mat srcExtended_;
+    Mat basicExtended_;
+
+    int borderSize_;
+
+    int templateWindowSize_;
+    int searchWindowSize_;
+
+    int halfTemplateWindowSize_;
+    int halfSearchWindowSize_;
+
+    int templateWindowSizeSq_;
+    int searchWindowSizeSq_;
+
+    // Block matching threshold
+    int hBM_;
+
+    // Maximum size of 3D group
+    int groupSize_;
+
+    // Function pointers
+    void(*haarTransform2D)(const T *ptr, TT *dst, const int &step);
+    void(*inverseHaar2D)(TT *src);
+
+    // Threshold map
+    TT *thrMap_;
+};
+
+template <typename T, typename IT, typename UIT, typename D, typename WT, typename TT>
+Bm3dDenoisingInvokerStep2<T, IT, UIT, D, WT, TT>::Bm3dDenoisingInvokerStep2(
+    const Mat& src,
+    const Mat& basic,
+    Mat& dst,
+    const int &templateWindowSize,
+    const int &searchWindowSize,
+    const float &h,
+    const int &hBM,
+    const int &groupSize) :
+    src_(src), basic_(basic), dst_(dst), groupSize_(groupSize), thrMap_(NULL)
+{
+    groupSize_ = getLargestPowerOf2SmallerThan(groupSize);
+    CV_Assert(groupSize <= BM3D_MAX_3D_SIZE && groupSize > 0);
+
+    halfTemplateWindowSize_ = templateWindowSize >> 1;
+    halfSearchWindowSize_ = searchWindowSize >> 1;
+    templateWindowSize_ = halfTemplateWindowSize_ << 1;
+    searchWindowSize_ = (halfSearchWindowSize_ << 1);
+    templateWindowSizeSq_ = templateWindowSize_ * templateWindowSize_;
+    searchWindowSizeSq_ = searchWindowSize_ * searchWindowSize_;
+
+    // Extend image to avoid border problem
+    borderSize_ = halfSearchWindowSize_ + halfTemplateWindowSize_;
+    copyMakeBorder(src_, srcExtended_, borderSize_, borderSize_, borderSize_, borderSize_, BORDER_DEFAULT);
+    copyMakeBorder(basic_, basicExtended_, borderSize_, borderSize_, borderSize_, borderSize_, BORDER_DEFAULT);
+
+    // Calculate block matching threshold
+    hBM_ = D::template calcBlockMatchingThreshold<int>(hBM, templateWindowSizeSq_);
+
+    // Select transforms depending on the template size
+    switch (templateWindowSize_)
+    {
+    case 4:
+        haarTransform2D = Haar4x4;
+        inverseHaar2D = InvHaar4x4;
+        break;
+    case 8:
+        haarTransform2D = Haar8x8;
+        inverseHaar2D = InvHaar8x8;
+        break;
+    default:
+        CV_Error(Error::StsBadArg,
+            "Unsupported template size! Only 4 and 8 are supported currently.");
+    }
+
+    // Precompute threshold map
+    calcHaarThresholdMap3D(thrMap_, h, templateWindowSize_, groupSize_);
+}
+
+template<typename T, typename IT, typename UIT, typename D, typename WT, typename TT>
+inline Bm3dDenoisingInvokerStep2<T, IT, UIT, D, WT, TT>::~Bm3dDenoisingInvokerStep2()
+{
+    delete[] thrMap_;
+}
+
+template <typename T, typename IT, typename UIT, typename D, typename WT, typename TT>
+void Bm3dDenoisingInvokerStep2<T, IT, UIT, D, WT, TT>::operator() (const Range& range) const
+{
+    const int size = (range.size() + 2 * borderSize_) * srcExtended_.cols;
+    std::vector<WT> weightedSum(size, 0.0);
+    std::vector<WT> weights(size, 0.0);
+    int row_from = range.start;
+    int row_to = range.end - 1;
+
+    // Local vars for faster processing
+    const int blockSize = templateWindowSize_;
+    const int blockSizeSq = templateWindowSizeSq_;
+    const int halfBlockSize = halfTemplateWindowSize_;
+    const int searchWindowSize = searchWindowSize_;
+    const int searchWindowSizeSq = searchWindowSizeSq_;
+    const short halfSearchWindowSize = (short)halfSearchWindowSize_;
+    const int hBM = hBM_;
+    const int groupSize = groupSize_;
+
+    const int step = srcExtended_.cols;
+    const int cstep = step - templateWindowSize_;
+
+    const int dstStep = srcExtended_.cols;
+    const int weiStep = srcExtended_.cols;
+    const int dstcstep = dstStep - blockSize;
+    const int weicstep = weiStep - blockSize;
+
+    // Buffer to store 3D group
+    BlockMatch<TT, int, TT> *bmBasic = new BlockMatch<TT, int, TT>[searchWindowSizeSq];
+    BlockMatch<TT, int, TT> *bmSrc = new BlockMatch<TT, int, TT>[searchWindowSizeSq];
+    for (int i = 0; i < searchWindowSizeSq; ++i)
+    {
+        bmBasic[i].init(blockSizeSq);
+        bmSrc[i].init(blockSizeSq);
+    }
+
+    // First element in a group is always the reference patch. Hence distance is 0.
+    bmBasic[0](0, halfSearchWindowSize, halfSearchWindowSize);
+    bmSrc[0](0, halfSearchWindowSize, halfSearchWindowSize);
+
+    for (int j = row_from, jj = 0; j <= row_to; ++j, ++jj)
+    {
+        for (int i = 0; i < src_.cols; ++i)
+        {
+            const T *referencePatchBasic = basicExtended_.ptr<T>(0) + step*(halfSearchWindowSize + j) + (halfSearchWindowSize + i);
+            const T *currentPixelSrc = srcExtended_.ptr<T>(0) + step*j + i;
+            const T *currentPixelBasic = basicExtended_.ptr<T>(0) + step*j + i;
+
+            int elementSize = 1;
+            for (short l = 0; l < searchWindowSize; ++l)
+            {
+                const T *candidatePatchBasic = currentPixelBasic + step*l;
+                for (short k = 0; k < searchWindowSize; ++k)
+                {
+                    if (l == halfSearchWindowSize && k == halfSearchWindowSize)
+                        continue;
+
+                    // Calc distance
+                    int e = 0;
+                    const T *canPtr = candidatePatchBasic + k;
+                    const T *refPtr = referencePatchBasic;
+                    for (int n = 0; n < blockSize; ++n)
+                    {
+                        for (int m = 0; m < blockSize; ++m)
+                            e += D::template calcDist<TT>(*canPtr++, *refPtr++);
+                        canPtr += cstep;
+                        refPtr += cstep;
+                    }
+
+                    // Save the distance, coordinate and increase the counter
+                    if (e < hBM)
+                        bmBasic[elementSize++](e, k, l);
+                }
+            }
+
+            // Sort bmBasic by distance (first element is already sorted)
+            std::sort(bmBasic + 1, bmBasic + elementSize);
+
+            // Find the nearest power of 2 and cap the group size from the top
+            elementSize = getLargestPowerOf2SmallerThan(elementSize);
+            if (elementSize > groupSize)
+                elementSize = groupSize;
+
+            // Transform 2D patches
+            for (int n = 0; n < elementSize; ++n)
+            {
+                const T *candidatePatchSrc = currentPixelSrc + step * bmBasic[n].coord_y + bmBasic[n].coord_x;
+                const T *candidatePatchBasic = currentPixelBasic + step * bmBasic[n].coord_y + bmBasic[n].coord_x;
+                haarTransform2D(candidatePatchSrc, bmSrc[n].data(), step);
+                haarTransform2D(candidatePatchBasic, bmBasic[n].data(), step);
+            }
+
+            // Transform and shrink 1D columns
+            int wienerCoefficients = 0;
+            TT *thrMapPtr1D = thrMap_ + (elementSize - 1) * blockSizeSq;
+            switch (elementSize)
+            {
+            case 16:
+                for (int n = 0; n < blockSizeSq; n++)
+                {
+                    ForwardHaarTransform16(bmSrc, n);
+                    ForwardHaarTransform16(bmBasic, n);
+                    wienerCoefficients += WienerFiltering<16>(bmSrc, bmBasic, n, thrMapPtr1D);
+                    InverseHaarTransform16(bmBasic, n);
+                }
+                break;
+            case 8:
+                for (int n = 0; n < blockSizeSq; n++)
+                {
+                    ForwardHaarTransform8(bmSrc, n);
+                    ForwardHaarTransform8(bmBasic, n);
+                    wienerCoefficients += WienerFiltering<8>(bmSrc, bmBasic, n, thrMapPtr1D);
+                    InverseHaarTransform8(bmBasic, n);
+                }
+                break;
+            case 4:
+                for (int n = 0; n < blockSizeSq; n++)
+                {
+                    ForwardHaarTransform4(bmSrc, n);
+                    ForwardHaarTransform4(bmBasic, n);
+                    wienerCoefficients += WienerFiltering<4>(bmSrc, bmBasic, n, thrMapPtr1D);
+                    InverseHaarTransform4(bmBasic, n);
+                }
+                break;
+            case 2:
+                for (int n = 0; n < blockSizeSq; n++)
+                {
+                    ForwardHaarTransform2(bmSrc, n);
+                    ForwardHaarTransform2(bmBasic, n);
+                    wienerCoefficients += WienerFiltering<2>(bmSrc, bmBasic, n, thrMapPtr1D);
+                    InverseHaarTransform2(bmBasic, n);
+                }
+                break;
+            case 1:
+            {
+                for (int n = 0; n < blockSizeSq; n++)
+                    wienerCoefficients += WienerFiltering<1>(bmSrc, bmBasic, n, thrMapPtr1D);
+            }
+            break;
+            case 0:
+            default:
+                continue;
+            }
+
+            // Inverse 2D transform
+            for (int n = 0; n < elementSize; ++n)
+                inverseHaar2D(bmBasic[n].data());
+
+            // Aggregate the results (increase sumNonZero to avoid division by zero)
+            float weight = 1.0f / (float)(++wienerCoefficients);
+
+            // Scale weight by element size
+            weight *= elementSize;
+            weight /= groupSize;
+
+            // Put patches back to their original positions
+            WT *dstPtr = weightedSum.data() + jj * dstStep + i;
+            WT *weiPtr = weights.data() + jj * dstStep + i;
+
+            for (int l = 0; l < elementSize; ++l)
+            {
+                const TT *block = bmBasic[l].data();
+                int offset = bmBasic[l].coord_y * dstStep + bmBasic[l].coord_x;
+                WT *d = dstPtr + offset;
+                WT *dw = weiPtr + offset;
+
+                for (int n = 0; n < blockSize; ++n)
+                {
+                    for (int m = 0; m < blockSize; ++m)
+                    {
+                        *d += block[n * blockSize + m] * weight;
+                        *dw += weight;
+                        ++d, ++dw;
+                    }
+                    d += dstcstep;
+                    dw += weicstep;
+                }
+            }
+        } // i
+    } // j
+
+    // Cleanup
+    for (int i = 0; i < searchWindowSizeSq; ++i)
+    {
+        bmBasic[i].release();
+        bmSrc[i].release();
+    }
+
+    delete[] bmSrc;
+    delete[] bmBasic;
+
+    // Divide accumulation buffer by the corresponding weights
+    for (int i = row_from, ii = 0; i <= row_to; ++i, ++ii)
+    {
+        T *d = dst_.ptr<T>(i);
+        float *dE = weightedSum.data() + (ii + halfSearchWindowSize + halfBlockSize) * dstStep + halfSearchWindowSize;
+        float *dw = weights.data() + (ii + halfSearchWindowSize + halfBlockSize) * dstStep + halfSearchWindowSize;
+        for (int j = 0; j < dst_.cols; ++j)
+            d[j] = cv::saturate_cast<T>(dE[j + halfBlockSize] / dw[j + halfBlockSize]);
+    }
+}
+
+#endif

--- a/modules/photo/src/bm3d_denoising_transforms.hpp
+++ b/modules/photo/src/bm3d_denoising_transforms.hpp
@@ -243,12 +243,12 @@ static short HaarTransformShrink8(short **z, const int &n, short *&thrMap)
 
     z[0][n] = sum000;
     z[1][n] = dif000;
-    z[1][n] = dif00;
-    z[1][n] = dif11;
-    z[2][n] = dif0;
-    z[3][n] = dif1;
-    z[3][n] = dif2;
-    z[3][n] = dif3;
+    z[2][n] = dif00;
+    z[3][n] = dif11;
+    z[4][n] = dif0;
+    z[5][n] = dif1;
+    z[6][n] = dif2;
+    z[7][n] = dif3;
 
     return nonZeroCount;
 }

--- a/modules/photo/src/bm3d_denoising_transforms.hpp
+++ b/modules/photo/src/bm3d_denoising_transforms.hpp
@@ -42,7 +42,7 @@
 #ifndef __OPENCV_BM3D_DENOISING_TRANSFORMS_HPP__
 #define __OPENCV_BM3D_DENOISING_TRANSFORMS_HPP__
 
-#define BM3D_MAX_3D_SIZE 8
+#define BM3D_MAX_3D_SIZE 16
 
 using namespace cv;
 
@@ -557,6 +557,81 @@ inline static short HaarTransformShrink8(BlockMatch<T, DT, CT> *z, const int &n,
     return nonZeroCount;
 }
 
+template <typename T, typename DT, typename CT>
+inline static short HaarTransformShrink16(BlockMatch<T, DT, CT> *z, const int &n, T *&thrMap)
+{
+    T sum0 = (z[0][n] + z[1][n] + 1) >> 1;
+    T sum1 = (z[2][n] + z[3][n] + 1) >> 1;
+    T sum2 = (z[4][n] + z[5][n] + 1) >> 1;
+    T sum3 = (z[6][n] + z[7][n] + 1) >> 1;
+    T sum4 = (z[8][n] + z[9][n] + 1) >> 1;
+    T sum5 = (z[10][n] + z[11][n] + 1) >> 1;
+    T sum6 = (z[12][n] + z[13][n] + 1) >> 1;
+    T sum7 = (z[14][n] + z[15][n] + 1) >> 1;
+    T dif0 = z[0][n] - z[1][n];
+    T dif1 = z[2][n] - z[3][n];
+    T dif2 = z[4][n] - z[5][n];
+    T dif3 = z[6][n] - z[7][n];
+    T dif4 = z[8][n] - z[9][n];
+    T dif5 = z[10][n] - z[11][n];
+    T dif6 = z[12][n] - z[13][n];
+    T dif7 = z[14][n] - z[15][n];
+
+    T sum00 = (sum0 + sum1 + 1) >> 1;
+    T sum11 = (sum2 + sum3 + 1) >> 1;
+    T sum22 = (sum4 + sum5 + 1) >> 1;
+    T sum33 = (sum6 + sum7 + 1) >> 1;
+    T dif00 = sum0 - sum1;
+    T dif11 = sum2 - sum3;
+    T dif22 = sum4 - sum5;
+    T dif33 = sum6 - sum7;
+
+    T sum000 = (sum00 + sum11 + 1) >> 1;
+    T sum111 = (sum22 + sum33 + 1) >> 1;
+    T dif000 = sum00 - sum11;
+    T dif111 = sum22 - sum33;
+
+    T sum0000 = (sum000 + sum111 + 1) >> 1;
+    T dif0000 = dif000 - dif111;
+
+    short nonZeroCount = 0;
+    shrink(sum0000, nonZeroCount, *thrMap++);
+    shrink(dif0000, nonZeroCount, *thrMap++);
+    shrink(dif000, nonZeroCount, *thrMap++);
+    shrink(dif111, nonZeroCount, *thrMap++);
+    shrink(dif00, nonZeroCount, *thrMap++);
+    shrink(dif11, nonZeroCount, *thrMap++);
+    shrink(dif22, nonZeroCount, *thrMap++);
+    shrink(dif33, nonZeroCount, *thrMap++);
+    shrink(dif0, nonZeroCount, *thrMap++);
+    shrink(dif1, nonZeroCount, *thrMap++);
+    shrink(dif2, nonZeroCount, *thrMap++);
+    shrink(dif3, nonZeroCount, *thrMap++);
+    shrink(dif4, nonZeroCount, *thrMap++);
+    shrink(dif5, nonZeroCount, *thrMap++);
+    shrink(dif6, nonZeroCount, *thrMap++);
+    shrink(dif7, nonZeroCount, *thrMap++);
+
+    z[0][n] = sum0000;
+    z[1][n] = dif0000;
+    z[2][n] = dif000;
+    z[3][n] = dif111;
+    z[4][n] = dif00;
+    z[5][n] = dif11;
+    z[6][n] = dif22;
+    z[7][n] = dif33;
+    z[8][n] = dif0;
+    z[9][n] = dif1;
+    z[10][n] = dif2;
+    z[11][n] = dif3;
+    z[12][n] = dif4;
+    z[13][n] = dif5;
+    z[14][n] = dif6;
+    z[15][n] = dif7;
+
+    return nonZeroCount;
+}
+
 /// Functions for inverse 1D transforms
 
 template <typename T, typename DT, typename CT>
@@ -614,6 +689,61 @@ inline static void InverseHaarTransform8(BlockMatch<T, DT, CT> *src, const int &
     src[5][n] = (sum11 - src6) >> 1;
     src[6][n] = (dif11 + src7) >> 1;
     src[7][n] = (dif11 - src7) >> 1;
+}
+
+template <typename T, typename DT, typename CT>
+inline static void InverseHaarTransform16(BlockMatch<T, DT, CT> *src, const int &n)
+{
+    T src0 = src[0][n] * 2;
+    T src1 = src[1][n];
+    T src2 = src[2][n];
+    T src3 = src[3][n];
+    T src4 = src[4][n];
+    T src5 = src[5][n];
+    T src6 = src[6][n];
+    T src7 = src[7][n];
+    T src8 = src[8][n];
+    T src9 = src[9][n];
+    T src10 = src[10][n];
+    T src11 = src[11][n];
+    T src12 = src[12][n];
+    T src13 = src[13][n];
+    T src14 = src[14][n];
+    T src15 = src[15][n];
+
+    T sum0 = src0 + src1;
+    T dif0 = src0 - src1;
+
+    T sum00 = sum0 + src2;
+    T dif00 = sum0 - src2;
+    T sum11 = dif0 + src3;
+    T dif11 = dif0 - src3;
+
+    T sum000 = sum00 + src4;
+    T dif000 = sum00 - src4;
+    T sum111 = dif00 + src5;
+    T dif111 = dif00 - src5;
+    T sum222 = sum11 + src6;
+    T dif222 = sum11 - src6;
+    T sum333 = dif11 + src7;
+    T dif333 = dif11 - src7;
+
+    src[0][n] = (sum000 + src8) >> 1;
+    src[1][n] = (sum000 - src8) >> 1;
+    src[2][n] = (dif000 + src9) >> 1;
+    src[3][n] = (dif000 - src9) >> 1;
+    src[4][n] = (sum111 + src10) >> 1;
+    src[5][n] = (sum111 - src10) >> 1;
+    src[6][n] = (dif111 + src11) >> 1;
+    src[7][n] = (dif111 - src11) >> 1;
+    src[8][n] = (sum222 + src12) >> 1;
+    src[9][n] = (sum222 - src12) >> 1;
+    src[10][n] = (dif222 + src13) >> 1;
+    src[11][n] = (dif222 - src13) >> 1;
+    src[12][n] = (sum333 + src14) >> 1;
+    src[13][n] = (sum333 - src14) >> 1;
+    src[14][n] = (dif333 + src15) >> 1;
+    src[15][n] = (dif333 - src15) >> 1;
 }
 
 #endif

--- a/modules/photo/src/bm3d_denoising_transforms.hpp
+++ b/modules/photo/src/bm3d_denoising_transforms.hpp
@@ -62,6 +62,37 @@ inline static void hardThreshold2D(short *dst, short *thrMap, const int &templat
     }
 }
 
+/// 1D and 2D threshold map coefficients. Implementation dependent, thus stored
+/// together with transforms.
+
+#define BM3D_MAX_3D_SIZE 8
+
+const float sqrt2 = std::sqrt(2.0f);
+
+// 2D map of threshold multipliers in case of 4x4 block size
+static float kThrMap4x4[16] = {
+    0.25f,           0.5f,       1.0f / sqrt2,    1.0f / sqrt2,
+    0.5f,            1.0f,       sqrt2,           sqrt2,
+    1.0f / sqrt2,    sqrt2,      2.0f,            2.0f,
+    1.0f / sqrt2,    sqrt2,      2.0f,            2.0f
+};
+
+// 1D map of threshold multipliers for up to 8 elements in a group
+static const float kThrMap1D[(BM3D_MAX_3D_SIZE << 1) - 1] = {
+    1.0f,  // 1 element
+    1.0f / sqrt2,    sqrt2, // 2 elements
+    0.5f,            1.0f,            sqrt2,       sqrt2,  // 4 elements
+    sqrt2 / 4.0f,    1.0f / sqrt2,    1.0f,        1.0f, sqrt2, sqrt2, sqrt2, sqrt2  // 8 elements
+};
+
+// 2D threshold multipliers for up to 8 elements in a group
+static const float kCoeff[4] = {
+    1.0f,                             // 1 element
+    std::sqrt(2.0f * std::log(2.0f)), // 2 elements
+    std::sqrt(2.0f * std::log(4.0f)), // 4 elements
+    std::sqrt(2.0f * std::log(8.0f))  // 8 elements
+};
+
 // Forward transform 4x4 block
 template <typename T>
 static void HaarColumn4x4(const T *src, short *dst, const int &step)
@@ -103,7 +134,7 @@ static void HaarRow4x4(const T *src, short *dst)
 }
 
 template <typename T>
-static void Haar4x4(const T *ptr, short *dst, const short &step)
+static void Haar4x4(const T *ptr, short *dst, const int &step)
 {
     short temp[16];
 

--- a/modules/photo/src/bm3d_denoising_transforms.hpp
+++ b/modules/photo/src/bm3d_denoising_transforms.hpp
@@ -1,0 +1,323 @@
+/*M///////////////////////////////////////////////////////////////////////////////////////
+//
+//  IMPORTANT: READ BEFORE DOWNLOADING, COPYING, INSTALLING OR USING.
+//
+//  By downloading, copying, installing or using the software you agree to this license.
+//  If you do not agree to this license, do not download, install,
+//  copy or use the software.
+//
+//
+//                        Intel License Agreement
+//                For Open Source Computer Vision Library
+//
+// Copyright (C) 2000, Intel Corporation, all rights reserved.
+// Third party copyrights are property of their respective icvers.
+//
+// Redistribution and use in source and binary forms, with or without modification,
+// are permitted provided that the following conditions are met:
+//
+//   * Redistribution's of source code must retain the above copyright notice,
+//     this list of conditions and the following disclaimer.
+//
+//   * Redistribution's in binary form must reproduce the above copyright notice,
+//     this list of conditions and the following disclaimer in the documentation
+//     and/or other materials provided with the distribution.
+//
+//   * The name of Intel Corporation may not be used to endorse or promote products
+//     derived from this software without specific prior written permission.
+//
+// This software is provided by the copyright holders and contributors "as is" and
+// any express or implied warranties, including, but not limited to, the implied
+// warranties of merchantability and fitness for a particular purpose are disclaimed.
+// In no event shall the Intel Corporation or contributors be liable for any direct,
+// indirect, incidental, special, exemplary, or consequential damages
+// (including, but not limited to, procurement of substitute goods or services;
+// loss of use, data, or profits; or business interruption) however caused
+// and on any theory of liability, whether in contract, strict liability,
+// or tort (including negligence or otherwise) arising in any way out of
+// the use of this software, even if advised of the possibility of such damage.
+//
+//M*/
+
+#ifndef __OPENCV_BM3D_DENOISING_TRANSFORMS_HPP__
+#define __OPENCV_BM3D_DENOISING_TRANSFORMS_HPP__
+
+using namespace cv;
+
+template <typename T>
+inline static void shrink(T &val, T &nonZeroCount, const short &threshold)
+{
+    if (std::abs(val) < threshold)
+        val = 0;
+    else
+        ++nonZeroCount;
+}
+
+inline static void HardThreshold2D(short *dst, short *thrMap, const int &templateWindowSizeSq)
+{
+    for (int i = 1; i < templateWindowSizeSq; ++i)
+    {
+        if (std::abs(dst[i] < thrMap[i]))
+            dst[i] = 0;
+    }
+}
+
+// Forward transform 4x4 block
+template <typename T>
+static void HaarColumn4x4(T *src, short *dst, const int &step)
+{
+    T *src0 = src;
+    T *src1 = src + 1 * step;
+    T *src2 = src + 2 * step;
+    T *src3 = src + 3 * step;
+
+    short sum0 = (*src0 + *src1 + 1) >> 1;
+    short sum1 = (*src2 + *src3 + 1) >> 1;
+    short dif0 = *src0 - *src1;
+    short dif1 = *src2 - *src3;
+
+    short sum00 = (sum0 + sum1 + 1) >> 1;
+    short dif00 = sum0 - sum1;
+
+    dst[0 * 4] = sum00;
+    dst[1 * 4] = dif00;
+    dst[2 * 4] = dif0;
+    dst[3 * 4] = dif1;
+}
+
+template <typename T>
+static void HaarRow4x4(T *src, short *dst)
+{
+    short sum0 = (src[0] + src[1] + 1) >> 1;
+    short sum1 = (src[2] + src[3] + 1) >> 1;
+    short dif0 = src[0] - src[1];
+    short dif1 = src[2] - src[3];
+
+    short sum00 = (sum0 + sum1 + 1) >> 1;
+    short dif00 = sum0 - sum1;
+
+    dst[0] = sum00;
+    dst[1] = dif00;
+    dst[2] = dif0;
+    dst[3] = dif1;
+}
+
+template <typename T>
+static void Haar4x4(T *ptr, short *dst, const short &step)
+{
+    short temp[16];
+
+    // Trans col
+    HaarColumn4x4(ptr, temp, step);
+    HaarColumn4x4(ptr + 1, temp + 1, step);
+    HaarColumn4x4(ptr + 2, temp + 2, step);
+    HaarColumn4x4(ptr + 3, temp + 3, step);
+
+    // Trans rows
+    HaarRow4x4(temp, dst);
+    HaarRow4x4(temp + 1 * 4, dst + 1 * 4);
+    HaarRow4x4(temp + 2 * 4, dst + 2 * 4);
+    HaarRow4x4(temp + 3 * 4, dst + 3 * 4);
+}
+
+static void InvHaarColumn4x4(short * src, short *dst)
+{
+    short src0 = src[0 * 4] * 2;
+    short src1 = src[1 * 4];
+    short src2 = src[2 * 4];
+    short src3 = src[3 * 4];
+
+    short sum0 = (src0 + src1) >> 1;
+    short dif0 = (src0 - src1) >> 1; // this stinks!
+    sum0 *= 2;
+    dif0 *= 2;
+
+    dst[0 * 4] = (sum0 + src2) >> 1;
+    dst[1 * 4] = (sum0 - src2) >> 1;
+    dst[2 * 4] = (dif0 + src3) >> 1;
+    dst[3 * 4] = (dif0 - src3) >> 1;
+}
+
+static void InvHaarRow4x4(short * src, short *dst)
+{
+    short src0 = src[0] * 2;
+    short src1 = src[1];
+    short src2 = src[2];
+    short src3 = src[3];
+
+    short sum0 = (src0 + src1) >> 1;
+    short dif0 = (src0 - src1) >> 1; // this stinks!
+    sum0 *= 2;
+    dif0 *= 2;
+
+    dst[0] = (sum0 + src2) >> 1;
+    dst[1] = (sum0 - src2) >> 1;
+    dst[2] = (dif0 + src3) >> 1;
+    dst[3] = (dif0 - src3) >> 1;
+}
+
+static void InvHaar4x4(short *src)
+{
+    short temp[16];
+
+    InvHaarColumn4x4(src, temp);
+    InvHaarColumn4x4(src + 1, temp + 1);
+    InvHaarColumn4x4(src + 2, temp + 2);
+    InvHaarColumn4x4(src + 3, temp + 3);
+
+    InvHaarRow4x4(temp, src);
+    InvHaarRow4x4(temp + 1 * 4, src + 1 * 4);
+    InvHaarRow4x4(temp + 2 * 4, src + 2 * 4);
+    InvHaarRow4x4(temp + 3 * 4, src + 3 * 4);
+}
+
+/// 1D forward transformations
+
+static short HaarTransformShrink2(short **z, const int &n, short *&thrMap)
+{
+    short sum = (z[0][n] + z[1][n] + 1) >> 1;
+    short dif = z[0][n] - z[1][n];
+
+    short nonZeroCount = 0;
+    shrink(sum, nonZeroCount, *thrMap++);
+    shrink(dif, nonZeroCount, *thrMap++);
+
+    z[0][n] = sum;
+    z[1][n] = dif;
+
+    return nonZeroCount;
+}
+
+static short HaarTransformShrink4(short **z, const int &n, short *&thrMap)
+{
+    short sum0 = (z[0][n] + z[1][n] + 1) >> 1;
+    short sum1 = (z[2][n] + z[3][n] + 1) >> 1;
+    short dif0 = z[0][n] - z[1][n];
+    short dif1 = z[2][n] - z[3][n];
+
+    short sum00 = (sum0 + sum1 + 1) >> 1;
+    short dif00 = sum0 - sum1;
+
+    short nonZeroCount = 0;
+    shrink(sum00, nonZeroCount, *thrMap++);
+    shrink(dif00, nonZeroCount, *thrMap++);
+    shrink(dif0, nonZeroCount, *thrMap++);
+    shrink(dif1, nonZeroCount, *thrMap++);
+
+    z[0][n] = sum00;
+    z[1][n] = dif00;
+    z[2][n] = dif0;
+    z[3][n] = dif1;
+
+    return nonZeroCount;
+}
+
+static short HaarTransformShrink8(short **z, const int &n, short *&thrMap)
+{
+    short sum0 = (z[0][n] + z[1][n] + 1) >> 1;
+    short sum1 = (z[2][n] + z[3][n] + 1) >> 1;
+    short sum2 = (z[4][n] + z[5][n] + 1) >> 1;
+    short sum3 = (z[6][n] + z[7][n] + 1) >> 1;
+    short dif0 = z[0][n] - z[1][n];
+    short dif1 = z[2][n] - z[3][n];
+    short dif2 = z[4][n] - z[5][n];
+    short dif3 = z[6][n] - z[7][n];
+
+    short sum00 = (sum0 + sum1 + 1) >> 1;
+    short sum11 = (sum2 + sum3 + 1) >> 1;
+    short dif00 = sum0 - sum1;
+    short dif11 = sum2 - sum3;
+
+    short sum000 = (sum00 + sum11 + 1) >> 1;
+    short dif000 = sum00 - sum11;
+
+    short nonZeroCount = 0;
+    shrink(sum000, nonZeroCount, *thrMap++);
+    shrink(dif000, nonZeroCount, *thrMap++);
+    shrink(dif00, nonZeroCount, *thrMap++);
+    shrink(dif11, nonZeroCount, *thrMap++);
+    shrink(dif0, nonZeroCount, *thrMap++);
+    shrink(dif1, nonZeroCount, *thrMap++);
+    shrink(dif2, nonZeroCount, *thrMap++);
+    shrink(dif3, nonZeroCount, *thrMap++);
+
+    z[0][n] = sum000;
+    z[1][n] = dif000;
+    z[1][n] = dif00;
+    z[1][n] = dif11;
+    z[2][n] = dif0;
+    z[3][n] = dif1;
+    z[3][n] = dif2;
+    z[3][n] = dif3;
+
+    return nonZeroCount;
+}
+
+/// Functions for inverse 1D transforms
+
+template <typename T>
+static void InverseHaarTransform2(T **src, const int &n)
+{
+    T src0 = src[0][n] * 2;
+    T src1 = src[1][n];
+
+    src[0][n] = (src0 + src1) >> 1;
+    src[1][n] = (src0 - src1) >> 1;
+}
+
+template <typename T>
+static void InverseHaarTransform4(T **src, const int &n)
+{
+    T src0 = src[0][n] * 2;
+    T src1 = src[1][n];
+    T src2 = src[2][n];
+    T src3 = src[3][n];
+
+    T sum0 = (src0 + src1) >> 1;
+    T dif0 = (src0 - src1) >> 1;
+    sum0 *= 2;
+    dif0 *= 2;
+
+    src[0][n] = (sum0 + src2) >> 1;
+    src[1][n] = (sum0 - src2) >> 1;
+    src[2][n] = (dif0 + src3) >> 1;
+    src[3][n] = (dif0 - src3) >> 1;
+}
+
+template <typename T>
+static void InverseHaarTransform8(T **src, const int &n)
+{
+    T src0 = src[0][n] * 2;
+    T src1 = src[1][n];
+    T src2 = src[2][n];
+    T src3 = src[3][n];
+    T src4 = src[4][n];
+    T src5 = src[5][n];
+    T src6 = src[6][n];
+    T src7 = src[7][n];
+
+    T sum0 = (src0 + src1) >> 1;
+    T dif0 = (src0 - src1) >> 1;
+    sum0 *= 2;
+    dif0 *= 2;
+
+    T sum00 = (sum0 + src2) >> 1;
+    T dif00 = (sum0 - src2) >> 1;
+    T sum11 = (dif0 + src3) >> 1;
+    T dif11 = (dif0 - src3) >> 1;
+    sum00 *= 2;
+    dif00 *= 2;
+    sum11 *= 2;
+    dif11 *= 2;
+
+    src[0][n] = (sum00 + src4) >> 1;
+    src[1][n] = (sum00 - src4) >> 1;
+    src[2][n] = (dif00 + src5) >> 1;
+    src[3][n] = (dif00 - src5) >> 1;
+    src[4][n] = (sum11 + src6) >> 1;
+    src[5][n] = (sum11 - src6) >> 1;
+    src[6][n] = (dif11 + src7) >> 1;
+    src[7][n] = (dif11 - src7) >> 1;
+}
+
+#endif

--- a/modules/photo/src/bm3d_denoising_transforms.hpp
+++ b/modules/photo/src/bm3d_denoising_transforms.hpp
@@ -65,6 +65,17 @@ inline static void hardThreshold2D(T *dst, T *thrMap, const int &templateWindowS
     }
 }
 
+template <int N, typename T, typename DT, typename CT>
+inline static short HardThreshold(BlockMatch<T, DT, CT> *z, const int &n, T *&thrMap)
+{
+    short nonZeroCount = 0;
+
+    for (int i = 0; i < N; ++i)
+        shrink(z[i][n], nonZeroCount, *thrMap++);
+
+    return nonZeroCount;
+}
+
 /// 1D and 2D threshold map coefficients. Implementation dependent, thus stored
 /// together with transforms.
 
@@ -117,7 +128,7 @@ static void fillHaarCoefficients1D(float *thrCoeff1D, int &idx, const int &numbe
     }
 }
 
-// Method to generate threshold coefficients for 1D transform depending on the number of elements.
+// Method to generate threshold coefficients for 2D transform depending on the number of elements.
 static void fillHaarCoefficients2D(float *thrCoeff2D, const int &templateWindowSize)
 {
     cv::Mat coeff1D;
@@ -475,23 +486,17 @@ inline static void InvHaar8x8(TT *src)
 /// 1D forward transformations
 
 template <typename T, typename DT, typename CT>
-inline static short HaarTransformShrink2(BlockMatch<T, DT, CT> *z, const int &n, T *&thrMap)
+inline static void ForwardHaarTransform2(BlockMatch<T, DT, CT> *z, const int &n)
 {
     T sum = (z[0][n] + z[1][n] + 1) >> 1;
     T dif = z[0][n] - z[1][n];
 
-    short nonZeroCount = 0;
-    shrink(sum, nonZeroCount, *thrMap++);
-    shrink(dif, nonZeroCount, *thrMap++);
-
     z[0][n] = sum;
     z[1][n] = dif;
-
-    return nonZeroCount;
 }
 
 template <typename T, typename DT, typename CT>
-inline static short HaarTransformShrink4(BlockMatch<T, DT, CT> *z, const int &n, T *&thrMap)
+inline static void ForwardHaarTransform4(BlockMatch<T, DT, CT> *z, const int &n)
 {
     T sum0 = (z[0][n] + z[1][n] + 1) >> 1;
     T sum1 = (z[2][n] + z[3][n] + 1) >> 1;
@@ -501,22 +506,14 @@ inline static short HaarTransformShrink4(BlockMatch<T, DT, CT> *z, const int &n,
     T sum00 = (sum0 + sum1 + 1) >> 1;
     T dif00 = sum0 - sum1;
 
-    short nonZeroCount = 0;
-    shrink(sum00, nonZeroCount, *thrMap++);
-    shrink(dif00, nonZeroCount, *thrMap++);
-    shrink(dif0, nonZeroCount, *thrMap++);
-    shrink(dif1, nonZeroCount, *thrMap++);
-
     z[0][n] = sum00;
     z[1][n] = dif00;
     z[2][n] = dif0;
     z[3][n] = dif1;
-
-    return nonZeroCount;
 }
 
 template <typename T, typename DT, typename CT>
-inline static short HaarTransformShrink8(BlockMatch<T, DT, CT> *z, const int &n, T *&thrMap)
+inline static void ForwardHaarTransform8(BlockMatch<T, DT, CT> *z, const int &n)
 {
     T sum0 = (z[0][n] + z[1][n] + 1) >> 1;
     T sum1 = (z[2][n] + z[3][n] + 1) >> 1;
@@ -535,16 +532,6 @@ inline static short HaarTransformShrink8(BlockMatch<T, DT, CT> *z, const int &n,
     T sum000 = (sum00 + sum11 + 1) >> 1;
     T dif000 = sum00 - sum11;
 
-    short nonZeroCount = 0;
-    shrink(sum000, nonZeroCount, *thrMap++);
-    shrink(dif000, nonZeroCount, *thrMap++);
-    shrink(dif00, nonZeroCount, *thrMap++);
-    shrink(dif11, nonZeroCount, *thrMap++);
-    shrink(dif0, nonZeroCount, *thrMap++);
-    shrink(dif1, nonZeroCount, *thrMap++);
-    shrink(dif2, nonZeroCount, *thrMap++);
-    shrink(dif3, nonZeroCount, *thrMap++);
-
     z[0][n] = sum000;
     z[1][n] = dif000;
     z[2][n] = dif00;
@@ -553,12 +540,10 @@ inline static short HaarTransformShrink8(BlockMatch<T, DT, CT> *z, const int &n,
     z[5][n] = dif1;
     z[6][n] = dif2;
     z[7][n] = dif3;
-
-    return nonZeroCount;
 }
 
 template <typename T, typename DT, typename CT>
-inline static short HaarTransformShrink16(BlockMatch<T, DT, CT> *z, const int &n, T *&thrMap)
+inline static void ForwardHaarTransform16(BlockMatch<T, DT, CT> *z, const int &n)
 {
     T sum0 = (z[0][n] + z[1][n] + 1) >> 1;
     T sum1 = (z[2][n] + z[3][n] + 1) >> 1;
@@ -594,24 +579,6 @@ inline static short HaarTransformShrink16(BlockMatch<T, DT, CT> *z, const int &n
     T sum0000 = (sum000 + sum111 + 1) >> 1;
     T dif0000 = dif000 - dif111;
 
-    short nonZeroCount = 0;
-    shrink(sum0000, nonZeroCount, *thrMap++);
-    shrink(dif0000, nonZeroCount, *thrMap++);
-    shrink(dif000, nonZeroCount, *thrMap++);
-    shrink(dif111, nonZeroCount, *thrMap++);
-    shrink(dif00, nonZeroCount, *thrMap++);
-    shrink(dif11, nonZeroCount, *thrMap++);
-    shrink(dif22, nonZeroCount, *thrMap++);
-    shrink(dif33, nonZeroCount, *thrMap++);
-    shrink(dif0, nonZeroCount, *thrMap++);
-    shrink(dif1, nonZeroCount, *thrMap++);
-    shrink(dif2, nonZeroCount, *thrMap++);
-    shrink(dif3, nonZeroCount, *thrMap++);
-    shrink(dif4, nonZeroCount, *thrMap++);
-    shrink(dif5, nonZeroCount, *thrMap++);
-    shrink(dif6, nonZeroCount, *thrMap++);
-    shrink(dif7, nonZeroCount, *thrMap++);
-
     z[0][n] = sum0000;
     z[1][n] = dif0000;
     z[2][n] = dif000;
@@ -628,8 +595,6 @@ inline static short HaarTransformShrink16(BlockMatch<T, DT, CT> *z, const int &n
     z[13][n] = dif5;
     z[14][n] = dif6;
     z[15][n] = dif7;
-
-    return nonZeroCount;
 }
 
 /// Functions for inverse 1D transforms

--- a/modules/photo/src/bm3d_denoising_transforms.hpp
+++ b/modules/photo/src/bm3d_denoising_transforms.hpp
@@ -95,7 +95,7 @@ static const float kCoeff[4] = {
 
 // Forward transform 4x4 block
 template <typename T>
-static void HaarColumn4x4(const T *src, short *dst, const int &step)
+inline static void HaarColumn4x4(const T *src, short *dst, const int &step)
 {
     const T *src0 = src;
     const T *src1 = src + 1 * step;
@@ -117,7 +117,7 @@ static void HaarColumn4x4(const T *src, short *dst, const int &step)
 }
 
 template <typename T>
-static void HaarRow4x4(const T *src, short *dst)
+inline static void HaarRow4x4(const T *src, short *dst)
 {
     short sum0 = (src[0] + src[1] + 1) >> 1;
     short sum1 = (src[2] + src[3] + 1) >> 1;
@@ -134,34 +134,28 @@ static void HaarRow4x4(const T *src, short *dst)
 }
 
 template <typename T>
-static void Haar4x4(const T *ptr, short *dst, const int &step)
+inline static void Haar4x4(const T *ptr, short *dst, const int &step)
 {
     short temp[16];
 
-    // Trans col
-    HaarColumn4x4(ptr, temp, step);
-    HaarColumn4x4(ptr + 1, temp + 1, step);
-    HaarColumn4x4(ptr + 2, temp + 2, step);
-    HaarColumn4x4(ptr + 3, temp + 3, step);
+    // Transform columns first
+    for (int i = 0; i < 4; ++i)
+        HaarColumn4x4(ptr + i, temp + i, step);
 
-    // Trans rows
-    HaarRow4x4(temp, dst);
-    HaarRow4x4(temp + 1 * 4, dst + 1 * 4);
-    HaarRow4x4(temp + 2 * 4, dst + 2 * 4);
-    HaarRow4x4(temp + 3 * 4, dst + 3 * 4);
+    // Then transform rows
+    for (int i = 0; i < 4; ++i)
+        HaarRow4x4(temp + i * 4, dst + i * 4);
 }
 
-static void InvHaarColumn4x4(short *src, short *dst)
+inline static void InvHaarColumn4x4(short *src, short *dst)
 {
     short src0 = src[0 * 4] * 2;
     short src1 = src[1 * 4];
     short src2 = src[2 * 4];
     short src3 = src[3 * 4];
 
-    short sum0 = (src0 + src1) >> 1;
-    short dif0 = (src0 - src1) >> 1; // this stinks!
-    sum0 *= 2;
-    dif0 *= 2;
+    short sum0 = src0 + src1;
+    short dif0 = src0 - src1;
 
     dst[0 * 4] = (sum0 + src2) >> 1;
     dst[1 * 4] = (sum0 - src2) >> 1;
@@ -169,17 +163,15 @@ static void InvHaarColumn4x4(short *src, short *dst)
     dst[3 * 4] = (dif0 - src3) >> 1;
 }
 
-static void InvHaarRow4x4(short *src, short *dst)
+inline static void InvHaarRow4x4(short *src, short *dst)
 {
     short src0 = src[0] * 2;
     short src1 = src[1];
     short src2 = src[2];
     short src3 = src[3];
 
-    short sum0 = (src0 + src1) >> 1;
-    short dif0 = (src0 - src1) >> 1; // this stinks!
-    sum0 *= 2;
-    dif0 *= 2;
+    short sum0 = src0 + src1;
+    short dif0 = src0 - src1;
 
     dst[0] = (sum0 + src2) >> 1;
     dst[1] = (sum0 - src2) >> 1;
@@ -187,24 +179,22 @@ static void InvHaarRow4x4(short *src, short *dst)
     dst[3] = (dif0 - src3) >> 1;
 }
 
-static void InvHaar4x4(short *src)
+inline static void InvHaar4x4(short *src)
 {
     short temp[16];
 
-    InvHaarColumn4x4(src, temp);
-    InvHaarColumn4x4(src + 1, temp + 1);
-    InvHaarColumn4x4(src + 2, temp + 2);
-    InvHaarColumn4x4(src + 3, temp + 3);
+    // Invert columns first
+    for (int i = 0; i < 4; ++i)
+        InvHaarColumn4x4(src + i, temp + i);
 
-    InvHaarRow4x4(temp, src);
-    InvHaarRow4x4(temp + 1 * 4, src + 1 * 4);
-    InvHaarRow4x4(temp + 2 * 4, src + 2 * 4);
-    InvHaarRow4x4(temp + 3 * 4, src + 3 * 4);
+    // Then invert rows
+    for (int i = 0; i < 4; ++i)
+        InvHaarRow4x4(temp + i * 4, src + i * 4);
 }
 
 /// 1D forward transformations
 
-static short HaarTransformShrink2(short **z, const int &n, short *&thrMap)
+inline static short HaarTransformShrink2(short **z, const int &n, short *&thrMap)
 {
     short sum = (z[0][n] + z[1][n] + 1) >> 1;
     short dif = z[0][n] - z[1][n];
@@ -219,7 +209,7 @@ static short HaarTransformShrink2(short **z, const int &n, short *&thrMap)
     return nonZeroCount;
 }
 
-static short HaarTransformShrink4(short **z, const int &n, short *&thrMap)
+inline static short HaarTransformShrink4(short **z, const int &n, short *&thrMap)
 {
     short sum0 = (z[0][n] + z[1][n] + 1) >> 1;
     short sum1 = (z[2][n] + z[3][n] + 1) >> 1;
@@ -243,7 +233,7 @@ static short HaarTransformShrink4(short **z, const int &n, short *&thrMap)
     return nonZeroCount;
 }
 
-static short HaarTransformShrink8(short **z, const int &n, short *&thrMap)
+inline static short HaarTransformShrink8(short **z, const int &n, short *&thrMap)
 {
     short sum0 = (z[0][n] + z[1][n] + 1) >> 1;
     short sum1 = (z[2][n] + z[3][n] + 1) >> 1;
@@ -287,7 +277,7 @@ static short HaarTransformShrink8(short **z, const int &n, short *&thrMap)
 /// Functions for inverse 1D transforms
 
 template <typename T>
-static void InverseHaarTransform2(T **src, const int &n)
+inline static void InverseHaarTransform2(T **src, const int &n)
 {
     T src0 = src[0][n] * 2;
     T src1 = src[1][n];
@@ -297,17 +287,15 @@ static void InverseHaarTransform2(T **src, const int &n)
 }
 
 template <typename T>
-static void InverseHaarTransform4(T **src, const int &n)
+inline static void InverseHaarTransform4(T **src, const int &n)
 {
     T src0 = src[0][n] * 2;
     T src1 = src[1][n];
     T src2 = src[2][n];
     T src3 = src[3][n];
 
-    T sum0 = (src0 + src1) >> 1;
-    T dif0 = (src0 - src1) >> 1;
-    sum0 *= 2;
-    dif0 *= 2;
+    T sum0 = src0 + src1;
+    T dif0 = src0 - src1;
 
     src[0][n] = (sum0 + src2) >> 1;
     src[1][n] = (sum0 - src2) >> 1;
@@ -316,7 +304,7 @@ static void InverseHaarTransform4(T **src, const int &n)
 }
 
 template <typename T>
-static void InverseHaarTransform8(T **src, const int &n)
+inline static void InverseHaarTransform8(T **src, const int &n)
 {
     T src0 = src[0][n] * 2;
     T src1 = src[1][n];
@@ -327,19 +315,13 @@ static void InverseHaarTransform8(T **src, const int &n)
     T src6 = src[6][n];
     T src7 = src[7][n];
 
-    T sum0 = (src0 + src1) >> 1;
-    T dif0 = (src0 - src1) >> 1;
-    sum0 *= 2;
-    dif0 *= 2;
+    T sum0 = src0 + src1;
+    T dif0 = src0 - src1;
 
-    T sum00 = (sum0 + src2) >> 1;
-    T dif00 = (sum0 - src2) >> 1;
-    T sum11 = (dif0 + src3) >> 1;
-    T dif11 = (dif0 - src3) >> 1;
-    sum00 *= 2;
-    dif00 *= 2;
-    sum11 *= 2;
-    dif11 *= 2;
+    T sum00 = sum0 + src2;
+    T dif00 = sum0 - src2;
+    T sum11 = dif0 + src3;
+    T dif11 = dif0 - src3;
 
     src[0][n] = (sum00 + src4) >> 1;
     src[1][n] = (sum00 - src4) >> 1;

--- a/modules/photo/src/bm3d_denoising_transforms.hpp
+++ b/modules/photo/src/bm3d_denoising_transforms.hpp
@@ -53,7 +53,7 @@ inline static void shrink(T &val, T &nonZeroCount, const short &threshold)
         ++nonZeroCount;
 }
 
-inline static void HardThreshold2D(short *dst, short *thrMap, const int &templateWindowSizeSq)
+inline static void hardThreshold2D(short *dst, short *thrMap, const int &templateWindowSizeSq)
 {
     for (int i = 1; i < templateWindowSizeSq; ++i)
     {
@@ -64,12 +64,12 @@ inline static void HardThreshold2D(short *dst, short *thrMap, const int &templat
 
 // Forward transform 4x4 block
 template <typename T>
-static void HaarColumn4x4(T *src, short *dst, const int &step)
+static void HaarColumn4x4(const T *src, short *dst, const int &step)
 {
-    T *src0 = src;
-    T *src1 = src + 1 * step;
-    T *src2 = src + 2 * step;
-    T *src3 = src + 3 * step;
+    const T *src0 = src;
+    const T *src1 = src + 1 * step;
+    const T *src2 = src + 2 * step;
+    const T *src3 = src + 3 * step;
 
     short sum0 = (*src0 + *src1 + 1) >> 1;
     short sum1 = (*src2 + *src3 + 1) >> 1;
@@ -86,7 +86,7 @@ static void HaarColumn4x4(T *src, short *dst, const int &step)
 }
 
 template <typename T>
-static void HaarRow4x4(T *src, short *dst)
+static void HaarRow4x4(const T *src, short *dst)
 {
     short sum0 = (src[0] + src[1] + 1) >> 1;
     short sum1 = (src[2] + src[3] + 1) >> 1;
@@ -103,7 +103,7 @@ static void HaarRow4x4(T *src, short *dst)
 }
 
 template <typename T>
-static void Haar4x4(T *ptr, short *dst, const short &step)
+static void Haar4x4(const T *ptr, short *dst, const short &step)
 {
     short temp[16];
 
@@ -120,7 +120,7 @@ static void Haar4x4(T *ptr, short *dst, const short &step)
     HaarRow4x4(temp + 3 * 4, dst + 3 * 4);
 }
 
-static void InvHaarColumn4x4(short * src, short *dst)
+static void InvHaarColumn4x4(short *src, short *dst)
 {
     short src0 = src[0 * 4] * 2;
     short src1 = src[1 * 4];
@@ -138,7 +138,7 @@ static void InvHaarColumn4x4(short * src, short *dst)
     dst[3 * 4] = (dif0 - src3) >> 1;
 }
 
-static void InvHaarRow4x4(short * src, short *dst)
+static void InvHaarRow4x4(short *src, short *dst)
 {
     short src0 = src[0] * 2;
     short src1 = src[1];

--- a/modules/photo/src/bm3d_denoising_transforms.hpp
+++ b/modules/photo/src/bm3d_denoising_transforms.hpp
@@ -45,7 +45,7 @@
 using namespace cv;
 
 template <typename T>
-inline static void shrink(T &val, T &nonZeroCount, const short &threshold)
+inline static void shrink(T &val, T &nonZeroCount, const T &threshold)
 {
     if (std::abs(val) < threshold)
         val = 0;
@@ -53,7 +53,8 @@ inline static void shrink(T &val, T &nonZeroCount, const short &threshold)
         ++nonZeroCount;
 }
 
-inline static void hardThreshold2D(short *dst, short *thrMap, const int &templateWindowSizeSq)
+template <typename T>
+inline static void hardThreshold2D(T *dst, T *thrMap, const int &templateWindowSizeSq)
 {
     for (int i = 1; i < templateWindowSizeSq; ++i)
     {
@@ -94,21 +95,21 @@ static const float kCoeff[4] = {
 };
 
 // Forward transform 4x4 block
-template <typename T>
-inline static void HaarColumn4x4(const T *src, short *dst, const int &step)
+template <typename T, typename TT>
+inline static void HaarColumn4x4(const T *src, TT *dst, const int &step)
 {
     const T *src0 = src;
     const T *src1 = src + 1 * step;
     const T *src2 = src + 2 * step;
     const T *src3 = src + 3 * step;
 
-    short sum0 = (*src0 + *src1 + 1) >> 1;
-    short sum1 = (*src2 + *src3 + 1) >> 1;
-    short dif0 = *src0 - *src1;
-    short dif1 = *src2 - *src3;
+    TT sum0 = (*src0 + *src1 + 1) >> 1;
+    TT sum1 = (*src2 + *src3 + 1) >> 1;
+    TT dif0 = *src0 - *src1;
+    TT dif1 = *src2 - *src3;
 
-    short sum00 = (sum0 + sum1 + 1) >> 1;
-    short dif00 = sum0 - sum1;
+    TT sum00 = (sum0 + sum1 + 1) >> 1;
+    TT dif00 = sum0 - sum1;
 
     dst[0 * 4] = sum00;
     dst[1 * 4] = dif00;
@@ -116,16 +117,16 @@ inline static void HaarColumn4x4(const T *src, short *dst, const int &step)
     dst[3 * 4] = dif1;
 }
 
-template <typename T>
-inline static void HaarRow4x4(const T *src, short *dst)
+template <typename T, typename TT>
+inline static void HaarRow4x4(const T *src, TT *dst)
 {
-    short sum0 = (src[0] + src[1] + 1) >> 1;
-    short sum1 = (src[2] + src[3] + 1) >> 1;
-    short dif0 = src[0] - src[1];
-    short dif1 = src[2] - src[3];
+    TT sum0 = (src[0] + src[1] + 1) >> 1;
+    TT sum1 = (src[2] + src[3] + 1) >> 1;
+    TT dif0 = src[0] - src[1];
+    TT dif1 = src[2] - src[3];
 
-    short sum00 = (sum0 + sum1 + 1) >> 1;
-    short dif00 = sum0 - sum1;
+    TT sum00 = (sum0 + sum1 + 1) >> 1;
+    TT dif00 = sum0 - sum1;
 
     dst[0] = sum00;
     dst[1] = dif00;
@@ -133,10 +134,10 @@ inline static void HaarRow4x4(const T *src, short *dst)
     dst[3] = dif1;
 }
 
-template <typename T>
-inline static void Haar4x4(const T *ptr, short *dst, const int &step)
+template <typename T, typename TT>
+inline static void Haar4x4(const T *ptr, TT *dst, const int &step)
 {
-    short temp[16];
+    TT temp[16];
 
     // Transform columns first
     for (int i = 0; i < 4; ++i)
@@ -147,15 +148,16 @@ inline static void Haar4x4(const T *ptr, short *dst, const int &step)
         HaarRow4x4(temp + i * 4, dst + i * 4);
 }
 
-inline static void InvHaarColumn4x4(short *src, short *dst)
+template <typename TT>
+inline static void InvHaarColumn4x4(TT *src, TT *dst)
 {
-    short src0 = src[0 * 4] * 2;
-    short src1 = src[1 * 4];
-    short src2 = src[2 * 4];
-    short src3 = src[3 * 4];
+    TT src0 = src[0 * 4] * 2;
+    TT src1 = src[1 * 4];
+    TT src2 = src[2 * 4];
+    TT src3 = src[3 * 4];
 
-    short sum0 = src0 + src1;
-    short dif0 = src0 - src1;
+    TT sum0 = src0 + src1;
+    TT dif0 = src0 - src1;
 
     dst[0 * 4] = (sum0 + src2) >> 1;
     dst[1 * 4] = (sum0 - src2) >> 1;
@@ -163,15 +165,16 @@ inline static void InvHaarColumn4x4(short *src, short *dst)
     dst[3 * 4] = (dif0 - src3) >> 1;
 }
 
-inline static void InvHaarRow4x4(short *src, short *dst)
+template <typename TT>
+inline static void InvHaarRow4x4(TT *src, TT *dst)
 {
-    short src0 = src[0] * 2;
-    short src1 = src[1];
-    short src2 = src[2];
-    short src3 = src[3];
+    TT src0 = src[0] * 2;
+    TT src1 = src[1];
+    TT src2 = src[2];
+    TT src3 = src[3];
 
-    short sum0 = src0 + src1;
-    short dif0 = src0 - src1;
+    TT sum0 = src0 + src1;
+    TT dif0 = src0 - src1;
 
     dst[0] = (sum0 + src2) >> 1;
     dst[1] = (sum0 - src2) >> 1;
@@ -179,9 +182,10 @@ inline static void InvHaarRow4x4(short *src, short *dst)
     dst[3] = (dif0 - src3) >> 1;
 }
 
-inline static void InvHaar4x4(short *src)
+template <typename TT>
+inline static void InvHaar4x4(TT *src)
 {
-    short temp[16];
+    TT temp[16];
 
     // Invert columns first
     for (int i = 0; i < 4; ++i)
@@ -194,10 +198,11 @@ inline static void InvHaar4x4(short *src)
 
 /// 1D forward transformations
 
-inline static short HaarTransformShrink2(short **z, const int &n, short *&thrMap)
+template <typename T, typename DT, typename CT>
+inline static short HaarTransformShrink2(BlockMatch<T, DT, CT> *z, const int &n, T *&thrMap)
 {
-    short sum = (z[0][n] + z[1][n] + 1) >> 1;
-    short dif = z[0][n] - z[1][n];
+    T sum = (z[0][n] + z[1][n] + 1) >> 1;
+    T dif = z[0][n] - z[1][n];
 
     short nonZeroCount = 0;
     shrink(sum, nonZeroCount, *thrMap++);
@@ -209,15 +214,16 @@ inline static short HaarTransformShrink2(short **z, const int &n, short *&thrMap
     return nonZeroCount;
 }
 
-inline static short HaarTransformShrink4(short **z, const int &n, short *&thrMap)
+template <typename T, typename DT, typename CT>
+inline static short HaarTransformShrink4(BlockMatch<T, DT, CT> *z, const int &n, T *&thrMap)
 {
-    short sum0 = (z[0][n] + z[1][n] + 1) >> 1;
-    short sum1 = (z[2][n] + z[3][n] + 1) >> 1;
-    short dif0 = z[0][n] - z[1][n];
-    short dif1 = z[2][n] - z[3][n];
+    T sum0 = (z[0][n] + z[1][n] + 1) >> 1;
+    T sum1 = (z[2][n] + z[3][n] + 1) >> 1;
+    T dif0 = z[0][n] - z[1][n];
+    T dif1 = z[2][n] - z[3][n];
 
-    short sum00 = (sum0 + sum1 + 1) >> 1;
-    short dif00 = sum0 - sum1;
+    T sum00 = (sum0 + sum1 + 1) >> 1;
+    T dif00 = sum0 - sum1;
 
     short nonZeroCount = 0;
     shrink(sum00, nonZeroCount, *thrMap++);
@@ -233,7 +239,8 @@ inline static short HaarTransformShrink4(short **z, const int &n, short *&thrMap
     return nonZeroCount;
 }
 
-inline static short HaarTransformShrink8(short **z, const int &n, short *&thrMap)
+template <typename T, typename DT, typename CT>
+inline static short HaarTransformShrink8(BlockMatch<T, DT, CT> *z, const int &n, short *&thrMap)
 {
     short sum0 = (z[0][n] + z[1][n] + 1) >> 1;
     short sum1 = (z[2][n] + z[3][n] + 1) >> 1;
@@ -276,8 +283,8 @@ inline static short HaarTransformShrink8(short **z, const int &n, short *&thrMap
 
 /// Functions for inverse 1D transforms
 
-template <typename T>
-inline static void InverseHaarTransform2(T **src, const int &n)
+template <typename T, typename DT, typename CT>
+inline static void InverseHaarTransform2(BlockMatch<T, DT, CT> *src, const int &n)
 {
     T src0 = src[0][n] * 2;
     T src1 = src[1][n];
@@ -286,8 +293,8 @@ inline static void InverseHaarTransform2(T **src, const int &n)
     src[1][n] = (src0 - src1) >> 1;
 }
 
-template <typename T>
-inline static void InverseHaarTransform4(T **src, const int &n)
+template <typename T, typename DT, typename CT>
+inline static void InverseHaarTransform4(BlockMatch<T, DT, CT> *src, const int &n)
 {
     T src0 = src[0][n] * 2;
     T src1 = src[1][n];
@@ -303,8 +310,8 @@ inline static void InverseHaarTransform4(T **src, const int &n)
     src[3][n] = (dif0 - src3) >> 1;
 }
 
-template <typename T>
-inline static void InverseHaarTransform8(T **src, const int &n)
+template <typename T, typename DT, typename CT>
+inline static void InverseHaarTransform8(BlockMatch<T, DT, CT> *src, const int &n)
 {
     T src0 = src[0][n] * 2;
     T src1 = src[1][n];

--- a/modules/photo/src/bm3d_denoising_transforms.hpp
+++ b/modules/photo/src/bm3d_denoising_transforms.hpp
@@ -76,6 +76,27 @@ inline static short HardThreshold(BlockMatch<T, DT, CT> *z, const int &n, T *&th
     return nonZeroCount;
 }
 
+template <int N, typename T, typename DT, typename CT>
+inline static int WienerFiltering(BlockMatch<T, DT, CT> *zSrc, BlockMatch<T, DT, CT> *zBasic, const int &n, T *&thrMap)
+{
+    int wienerCoeffs = 0;
+
+    for (int i = 0; i < N; ++i)
+    {
+        // Possible optimization point here to get rid of floats and casts
+        int basicSq = zBasic[i][n] * zBasic[i][n];
+        int sigmaSq = *thrMap * *thrMap;
+        int denom = basicSq + sigmaSq;
+        float wie = (denom == 0) ? 1.0f : ((float)basicSq / (float)denom);
+
+        zBasic[i][n] = (T)(zSrc[i][n] * wie);
+        wienerCoeffs += (int)wie;
+        ++thrMap;
+    }
+
+    return wienerCoeffs;
+}
+
 /// 1D and 2D threshold map coefficients. Implementation dependent, thus stored
 /// together with transforms.
 

--- a/modules/photo/src/denoise_bm3d.cpp
+++ b/modules/photo/src/denoise_bm3d.cpp
@@ -1,0 +1,157 @@
+/*M///////////////////////////////////////////////////////////////////////////////////////
+//
+//  IMPORTANT: READ BEFORE DOWNLOADING, COPYING, INSTALLING OR USING.
+//
+//  By downloading, copying, installing or using the software you agree to this license.
+//  If you do not agree to this license, do not download, install,
+//  copy or use the software.
+//
+//
+//                        Intel License Agreement
+//                For Open Source Computer Vision Library
+//
+// Copyright (C) 2000, Intel Corporation, all rights reserved.
+// Third party copyrights are property of their respective icvers.
+//
+// Redistribution and use in source and binary forms, with or without modification,
+// are permitted provided that the following conditions are met:
+//
+//   * Redistribution's of source code must retain the above copyright notice,
+//     this list of conditions and the following disclaimer.
+//
+//   * Redistribution's in binary form must reproduce the above copyright notice,
+//     this list of conditions and the following disclaimer in the documentation
+//     and/or other materials provided with the distribution.
+//
+//   * The name of Intel Corporation may not be used to endorse or promote products
+//     derived from this software without specific prior written permission.
+//
+// This software is provided by the copyright holders and contributors "as is" and
+// any express or implied warranties, including, but not limited to, the implied
+// warranties of merchantability and fitness for a particular purpose are disclaimed.
+// In no event shall the Intel Corporation or contributors be liable for any direct,
+// indirect, incidental, special, exemplary, or consequential damages
+// (including, but not limited to, procurement of substitute goods or services;
+// loss of use, data, or profits; or business interruption) however caused
+// and on any theory of liability, whether in contract, strict liability,
+// or tort (including negligence or otherwise) arising in any way out of
+// the use of this software, even if advised of the possibility of such damage.
+//
+//M*/
+
+#include "precomp.hpp"
+
+#include "bm3d_denoising_invoker.hpp"
+
+template<typename ST, typename IT, typename UIT, typename D>
+static void bm3dDenoising_(const Mat& src, Mat& dst, const float& h,
+    int templateWindowSize, int searchWindowSize)
+{
+    int hn = 1;
+    double granularity = (double)std::max(1., (double)dst.total() / (1 << 17));
+
+    switch (CV_MAT_CN(src.type())) {
+    case 1:
+        parallel_for_(cv::Range(0, src.rows),
+            Bm3dDenoisingInvoker<ST, IT, UIT, D, int>(
+                src, dst, templateWindowSize, searchWindowSize, h),
+            granularity);
+        break;
+    case 2:
+        if (hn == 1)
+            parallel_for_(cv::Range(0, src.rows),
+                Bm3dDenoisingInvoker<Vec<ST, 2>, IT, UIT, D, int>(
+                    src, dst, templateWindowSize, searchWindowSize, h),
+                granularity);
+        else
+            parallel_for_(cv::Range(0, src.rows),
+                Bm3dDenoisingInvoker<Vec<ST, 2>, IT, UIT, D, Vec2i>(
+                    src, dst, templateWindowSize, searchWindowSize, h),
+                granularity);
+        break;
+    case 3:
+        if (hn == 1)
+            parallel_for_(cv::Range(0, src.rows),
+                Bm3dDenoisingInvoker<Vec<ST, 3>, IT, UIT, D, int>(
+                    src, dst, templateWindowSize, searchWindowSize, h),
+                granularity);
+        else
+            parallel_for_(cv::Range(0, src.rows),
+                Bm3dDenoisingInvoker<Vec<ST, 3>, IT, UIT, D, Vec3i>(
+                    src, dst, templateWindowSize, searchWindowSize, h),
+                granularity);
+        break;
+    case 4:
+        if (hn == 1)
+            parallel_for_(cv::Range(0, src.rows),
+                Bm3dDenoisingInvoker<Vec<ST, 4>, IT, UIT, D, int>(
+                    src, dst, templateWindowSize, searchWindowSize, h),
+                granularity);
+        else
+            parallel_for_(cv::Range(0, src.rows),
+                Bm3dDenoisingInvoker<Vec<ST, 4>, IT, UIT, D, Vec4i>(
+                    src, dst, templateWindowSize, searchWindowSize, h),
+                granularity);
+        break;
+    default:
+        CV_Error(Error::StsBadArg,
+            "Unsupported number of channels! Only 1, 2, 3, and 4 are supported");
+    }
+}
+
+void cv::bm3dDenoising(
+    InputArray _src,
+    OutputArray _dst,
+    float h,
+    int templateWindowSize,
+    int searchWindowSize,
+    int normType)
+{
+    int type = _src.type(), depth = CV_MAT_DEPTH(type), cn = CV_MAT_CN(type);
+    CV_Assert(1 == cn);
+
+    Size src_size = _src.size();
+    Mat src = _src.getMat();
+    _dst.create(src_size, src.type());
+    Mat dst = _dst.getMat();
+
+    switch (normType) {
+    case cv::NORM_L2:
+#ifdef HAVE_TEGRA_OPTIMIZATION
+        if (hn == 1 && tegra::useTegra() &&
+            tegra::fastNlMeansDenoising(src, dst, h[0], templateWindowSize, searchWindowSize))
+            return;
+#endif
+        switch (depth) {
+        case CV_8U:
+            bm3dDenoising_<uchar, int, unsigned, DistSquared>(src, dst, h,
+                templateWindowSize,
+                searchWindowSize);
+            break;
+        default:
+            CV_Error(Error::StsBadArg,
+                "Unsupported depth! Only CV_8U is supported for NORM_L2");
+        }
+        break;
+    case cv::NORM_L1:
+        switch (depth) {
+        case CV_8U:
+            bm3dDenoising_<uchar, int, unsigned, DistAbs>(src, dst, h,
+                templateWindowSize,
+                searchWindowSize);
+            break;
+        case CV_16U:
+            bm3dDenoising_<ushort, int64, uint64, DistAbs>(src, dst, h,
+                templateWindowSize,
+                searchWindowSize);
+            break;
+        default:
+            CV_Error(Error::StsBadArg,
+                "Unsupported depth! Only CV_8U and CV_16U are supported for NORM_L1");
+        }
+        break;
+    default:
+        CV_Error(Error::StsBadArg,
+            "Unsupported norm type! Only NORM_L2 and NORM_L1 are supported");
+    }
+}

--- a/modules/photo/src/denoise_bm3d.cpp
+++ b/modules/photo/src/denoise_bm3d.cpp
@@ -120,6 +120,7 @@ void cv::bm3dDenoising(
 {
     int type = _src.type(), depth = CV_MAT_DEPTH(type), cn = CV_MAT_CN(type);
     CV_Assert(1 == cn);
+    CV_Assert(0 == transformType);
 
     Size srcSize = _src.size();
     Mat src = _src.getMat();

--- a/modules/photo/src/denoise_bm3d.cpp
+++ b/modules/photo/src/denoise_bm3d.cpp
@@ -54,9 +54,7 @@ static void bm3dDenoising_(
     const int &hBM,
     const int &groupSize)
 {
-
     double granularity = (double)std::max(1., (double)dst.total() / (1 << 16));
-    printf("Granularity: %.4f\n", granularity);
 
     switch (CV_MAT_CN(src.type())) {
     case 1:
@@ -65,45 +63,9 @@ static void bm3dDenoising_(
                 src, dst, templateWindowSize, searchWindowSize, h, hBM, groupSize),
             granularity);
         break;
-    /*case 2:
-        if (hn == 1)
-            parallel_for_(cv::Range(0, src.rows),
-                Bm3dDenoisingInvoker<Vec<ST, 2>, IT, UIT, D, int>(
-                    src, dst, templateWindowSize, searchWindowSize, h),
-                granularity);
-        else
-            parallel_for_(cv::Range(0, src.rows),
-                Bm3dDenoisingInvoker<Vec<ST, 2>, IT, UIT, D, Vec2i>(
-                    src, dst, templateWindowSize, searchWindowSize, h),
-                granularity);
-        break;
-    case 3:
-        if (hn == 1)
-            parallel_for_(cv::Range(0, src.rows),
-                Bm3dDenoisingInvoker<Vec<ST, 3>, IT, UIT, D, int>(
-                    src, dst, templateWindowSize, searchWindowSize, h),
-                granularity);
-        else
-            parallel_for_(cv::Range(0, src.rows),
-                Bm3dDenoisingInvoker<Vec<ST, 3>, IT, UIT, D, Vec3i>(
-                    src, dst, templateWindowSize, searchWindowSize, h),
-                granularity);
-        break;
-    case 4:
-        if (hn == 1)
-            parallel_for_(cv::Range(0, src.rows),
-                Bm3dDenoisingInvoker<Vec<ST, 4>, IT, UIT, D, int>(
-                    src, dst, templateWindowSize, searchWindowSize, h),
-                granularity);
-        else
-            parallel_for_(cv::Range(0, src.rows),
-                Bm3dDenoisingInvoker<Vec<ST, 4>, IT, UIT, D, Vec4i>(
-                    src, dst, templateWindowSize, searchWindowSize, h),
-                granularity);
-        break;*/
     default:
         CV_Error(Error::StsBadArg,
-            "Unsupported number of channels! Only 1, 2, 3, and 4 are supported");
+            "Unsupported number of channels! Only 1 channel is supported at the moment.");
     }
 }
 

--- a/modules/photo/src/denoise_bm3d.cpp
+++ b/modules/photo/src/denoise_bm3d.cpp
@@ -54,14 +54,14 @@ static void bm3dDenoising_(
     const int &hBM,
     const int &groupSize)
 {
-    double granularity = (double)std::max(1., (double)dst.total() / (1 << 17));
 
+    double granularity = (double)std::max(1., (double)dst.total() / (1 << 16));
     printf("Granularity: %.4f\n", granularity);
 
     switch (CV_MAT_CN(src.type())) {
     case 1:
         parallel_for_(cv::Range(0, src.rows),
-            Bm3dDenoisingInvoker<ST, IT, UIT, D, int>(
+            Bm3dDenoisingInvoker<ST, IT, UIT, D, float, short>(
                 src, dst, templateWindowSize, searchWindowSize, h, hBM, groupSize),
             granularity);
         break;

--- a/modules/photo/src/denoise_bm3d.cpp
+++ b/modules/photo/src/denoise_bm3d.cpp
@@ -50,13 +50,19 @@ static void bm3dDenoising_(const Mat& src, Mat& dst, const float& h,
 {
     int hn = 1;
     double granularity = (double)std::max(1., (double)dst.total() / (1 << 17));
+    cv::Mutex lock = cv::Mutex();
+
+    printf("Granularity: %.4f\n", granularity);
+    granularity = 1;
 
     switch (CV_MAT_CN(src.type())) {
     case 1:
+        printf("Entering Bm3dDenoisingInvoker...\n");
         parallel_for_(cv::Range(0, src.rows),
             Bm3dDenoisingInvoker<ST, IT, UIT, D, int>(
-                src, dst, templateWindowSize, searchWindowSize, h),
+                src, dst, templateWindowSize, searchWindowSize, h, lock),
             granularity);
+
         break;
     /*case 2:
         if (hn == 1)

--- a/modules/photo/src/denoise_bm3d.cpp
+++ b/modules/photo/src/denoise_bm3d.cpp
@@ -106,7 +106,8 @@ void cv::bm3dDenoising(
     float h,
     int templateWindowSize,
     int searchWindowSize,
-    int normType)
+    int normType,
+    int transformType)
 {
     int type = _src.type(), depth = CV_MAT_DEPTH(type), cn = CV_MAT_CN(type);
     CV_Assert(1 == cn);

--- a/modules/photo/test/test_denoise_bm3d.cpp
+++ b/modules/photo/test/test_denoise_bm3d.cpp
@@ -106,7 +106,7 @@ TEST(Photo_DenoisingBm3dGrayscale, regression_L1)
 
 #ifdef TEST_TRANSFORMS
 
-TEST(Photo_DenoisingBm3dTransforms, regression_2D)
+TEST(Photo_DenoisingBm3dTransforms, regression_2D_4x4)
 {
     const int templateWindowSize = 4;
     const int templateWindowSizeSq = templateWindowSize * templateWindowSize;
@@ -122,6 +122,27 @@ TEST(Photo_DenoisingBm3dTransforms, regression_2D)
 
     Haar4x4(src, dst, templateWindowSize);
     InvHaar4x4(dst);
+
+    for (uchar i = 0; i < templateWindowSizeSq; ++i)
+        ASSERT_EQ(static_cast<short>(src[i]), dst[i]);
+}
+
+TEST(Photo_DenoisingBm3dTransforms, regression_2D_8x8)
+{
+    const int templateWindowSize = 8;
+    const int templateWindowSizeSq = templateWindowSize * templateWindowSize;
+
+    uchar src[templateWindowSizeSq];
+    short dst[templateWindowSizeSq];
+
+    // Initialize array
+    for (uchar i = 0; i < templateWindowSizeSq; ++i)
+    {
+        src[i] = i;
+    }
+
+    Haar8x8(src, dst, templateWindowSize);
+    InvHaar8x8(dst);
 
     for (uchar i = 0; i < templateWindowSizeSq; ++i)
         ASSERT_EQ(static_cast<short>(src[i]), dst[i]);

--- a/modules/photo/test/test_denoise_bm3d.cpp
+++ b/modules/photo/test/test_denoise_bm3d.cpp
@@ -75,7 +75,7 @@ TEST(Photo_DenoisingBm3dGrayscale, regression_L2)
 
     DUMP(result, expected_path + ".res.png");
 
-    ASSERT_EQ(0, cvtest::norm(result, expected, cv::NORM_L2));
+    ASSERT_LT(cvtest::norm(result, expected, cv::NORM_L2), 200);
 }
 
 TEST(Photo_DenoisingBm3dGrayscale, regression_L1)
@@ -95,7 +95,7 @@ TEST(Photo_DenoisingBm3dGrayscale, regression_L1)
 
     DUMP(result, expected_path + ".res.png");
 
-    ASSERT_EQ(0, cvtest::norm(result, expected, cv::NORM_L2));
+    ASSERT_LT(cvtest::norm(result, expected, cv::NORM_L2), 200);
 }
 
 TEST(Photo_DenoisingBm3dGrayscale, regression_L2_8x8)
@@ -115,7 +115,7 @@ TEST(Photo_DenoisingBm3dGrayscale, regression_L2_8x8)
 
     DUMP(result, expected_path + ".res.png");
 
-    ASSERT_EQ(0, cvtest::norm(result, expected, cv::NORM_L2));
+    ASSERT_LT(cvtest::norm(result, expected, cv::NORM_L2), 200);
 }
 
 #ifdef TEST_TRANSFORMS

--- a/modules/photo/test/test_denoise_bm3d.cpp
+++ b/modules/photo/test/test_denoise_bm3d.cpp
@@ -63,7 +63,7 @@ TEST(Photo_DenoisingBm3dGrayscale, regression_L2)
 {
     std::string folder = std::string(cvtest::TS::ptr()->get_data_path()) + "denoising/";
     std::string original_path = folder + "lena_noised_gaussian_sigma=10.png";
-    std::string expected_path = folder + "lena_noised_denoised_bm3d_grayscale_l2_tw=4_sw=16_h=20_bm=50.png";
+    std::string expected_path = folder + "lena_noised_denoised_bm3d_grayscale_l2_tw=4_sw=16_h=10_bm=2500.png";
 
     cv::Mat original = cv::imread(original_path, cv::IMREAD_GRAYSCALE);
     cv::Mat expected = cv::imread(expected_path, cv::IMREAD_GRAYSCALE);
@@ -73,7 +73,7 @@ TEST(Photo_DenoisingBm3dGrayscale, regression_L2)
 
     cv::Mat result;
     double t = (double)getTickCount();
-    cv::bm3dDenoising(original, result, 20, 4, 16, 50, 8, cv::NORM_L2);
+    cv::bm3dDenoising(original, result, 10, 4, 16, 2500, 8, cv::NORM_L2);
     t = (double)getTickCount() - t;
     printf("execution time: %gms\n", t*1000. / getTickFrequency());
 
@@ -86,7 +86,7 @@ TEST(Photo_DenoisingBm3dGrayscale, regression_L1)
 {
     std::string folder = std::string(cvtest::TS::ptr()->get_data_path()) + "denoising/";
     std::string original_path = folder + "lena_noised_gaussian_sigma=10.png";
-    std::string expected_path = folder + "lena_noised_denoised_bm3d_grayscale_l1_tw=4_sw=16_h=20_bm=50.png";
+    std::string expected_path = folder + "lena_noised_denoised_bm3d_grayscale_l1_tw=4_sw=16_h=10_bm=2500.png";
 
     cv::Mat original = cv::imread(original_path, cv::IMREAD_GRAYSCALE);
     cv::Mat expected = cv::imread(expected_path, cv::IMREAD_GRAYSCALE);
@@ -96,7 +96,7 @@ TEST(Photo_DenoisingBm3dGrayscale, regression_L1)
 
     cv::Mat result;
     double t = (double)getTickCount();
-    cv::bm3dDenoising(original, result, 10, 4, 16, 50, 8, cv::NORM_L1);
+    cv::bm3dDenoising(original, result, 10, 4, 16, 2500, 8, cv::NORM_L1);
     t = (double)getTickCount() - t;
     printf("execution time: %gms\n", t*1000. / getTickFrequency());
 

--- a/modules/photo/test/test_denoise_bm3d.cpp
+++ b/modules/photo/test/test_denoise_bm3d.cpp
@@ -1,0 +1,74 @@
+/*M///////////////////////////////////////////////////////////////////////////////////////
+//
+//  IMPORTANT: READ BEFORE DOWNLOADING, COPYING, INSTALLING OR USING.
+//
+//  By downloading, copying, installing or using the software you agree to this license.
+//  If you do not agree to this license, do not download, install,
+//  copy or use the software.
+//
+//
+//                           License Agreement
+//                For Open Source Computer Vision Library
+//
+// Copyright (C) 2000-2008, Intel Corporation, all rights reserved.
+// Copyright (C) 2009, Willow Garage Inc., all rights reserved.
+// Third party copyrights are property of their respective owners.
+//
+// Redistribution and use in source and binary forms, with or without modification,
+// are permitted provided that the following conditions are met:
+//
+//   * Redistribution's of source code must retain the above copyright notice,
+//     this list of conditions and the following disclaimer.
+//
+//   * Redistribution's in binary form must reproduce the above copyright notice,
+//     this list of conditions and the following disclaimer in the documentation
+//     and/or other materials provided with the distribution.
+//
+//   * The name of the copyright holders may not be used to endorse or promote products
+//     derived from this software without specific prior written permission.
+//
+// This software is provided by the copyright holders and contributors "as is" and
+// any express or implied warranties, including, but not limited to, the implied
+// warranties of merchantability and fitness for a particular purpose are disclaimed.
+// In no event shall the Intel Corporation or contributors be liable for any direct,
+// indirect, incidental, special, exemplary, or consequential damages
+// (including, but not limited to, procurement of substitute goods or services;
+// loss of use, data, or profits; or business interruption) however caused
+// and on any theory of liability, whether in contract, strict liability,
+// or tort (including negligence or otherwise) arising in any way out of
+// the use of this software, even if advised of the possibility of such damage.
+//
+//M*/
+
+#include "test_precomp.hpp"
+#include "opencv2/photo.hpp"
+#include <string>
+
+//#define DUMP_RESULTS
+
+#ifdef DUMP_RESULTS
+#  define DUMP(image, path) imwrite(path, image)
+#else
+#  define DUMP(image, path)
+#endif
+
+
+TEST(Photo_DenoisingGrayscaleBM3D, regression)
+{
+    std::string folder = std::string(cvtest::TS::ptr()->get_data_path()) + "denoising/";
+    std::string original_path = folder + "lena_noised_gaussian_sigma=10.png";
+    std::string expected_path = folder + "lena_noised_denoised_grayscale_tw=7_sw=21_h=10.png";
+
+    cv::Mat original = cv::imread(original_path, cv::IMREAD_GRAYSCALE);
+    cv::Mat expected = cv::imread(expected_path, cv::IMREAD_GRAYSCALE);
+
+    ASSERT_FALSE(original.empty()) << "Could not load input image " << original_path;
+    ASSERT_FALSE(expected.empty()) << "Could not load reference image " << expected_path;
+
+    cv::Mat result;
+    cv::bm3dDenoising(original, result, 10);
+
+    DUMP(result, expected_path + ".res.png");
+
+    ASSERT_EQ(0, cvtest::norm(result, expected, cv::NORM_L2));
+}

--- a/modules/photo/test/test_denoise_bm3d.cpp
+++ b/modules/photo/test/test_denoise_bm3d.cpp
@@ -204,7 +204,7 @@ TEST(Photo_DenoisingBm3dTransforms, regression_1D_transform)
     const int searchWindowSize = 16;
     const int searchWindowSizeSq = searchWindowSize * searchWindowSize;
     const float h = 10;
-    int maxGroupSize = 8;
+    int maxGroupSize = 16;
 
     // Precompute separate maps for transform and shrinkage verification
     short *thrMapTransform = NULL;
@@ -237,6 +237,8 @@ TEST(Photo_DenoisingBm3dTransforms, regression_1D_transform)
         HaarTransformShrink4<short, int, short>, InverseHaarTransform4<short, int, short>);
     Test1dTransform<short, int, short>(thrMapTransform, 8, templateWindowSizeSq, bm, bmOrig,
         HaarTransformShrink8<short, int, short>, InverseHaarTransform8<short, int, short>);
+    Test1dTransform<short, int, short>(thrMapTransform, 16, templateWindowSizeSq, bm, bmOrig,
+        HaarTransformShrink16<short, int, short>, InverseHaarTransform16<short, int, short>);
 
     // Verify shrinkage
     Test1dTransform<short, int, short>(thrMapShrinkage, 2, templateWindowSizeSq, bm, bmOrig,
@@ -245,6 +247,8 @@ TEST(Photo_DenoisingBm3dTransforms, regression_1D_transform)
         HaarTransformShrink4<short, int, short>, InverseHaarTransform4<short, int, short>, 6);
     Test1dTransform<short, int, short>(thrMapShrinkage, 8, templateWindowSizeSq, bm, bmOrig,
         HaarTransformShrink8<short, int, short>, InverseHaarTransform8<short, int, short>, 6);
+    Test1dTransform<short, int, short>(thrMapShrinkage, 16, templateWindowSizeSq, bm, bmOrig,
+        HaarTransformShrink16<short, int, short>, InverseHaarTransform16<short, int, short>, 6);
 }
 
 const float sqrt2 = std::sqrt(2.0f);

--- a/modules/photo/test/test_denoise_bm3d.cpp
+++ b/modules/photo/test/test_denoise_bm3d.cpp
@@ -207,10 +207,10 @@ TEST(Photo_DenoisingBm3dTransforms, regression_1D_transform)
     int maxGroupSize = 8;
 
     // Precompute separate maps for transform and shrinkage verification
-    short *thrMapTransform = new short[templateWindowSizeSq * ((BM3D_MAX_3D_SIZE << 1) - 1)];
-    short *thrMapShrinkage = new short[templateWindowSizeSq * ((BM3D_MAX_3D_SIZE << 1) - 1)];
-    ComputeThresholdMap1D(thrMapTransform, kThrMap1D, kThrMap4x4, 0, kCoeff, templateWindowSizeSq);
-    ComputeThresholdMap1D(thrMapShrinkage, kThrMap1D, kThrMap4x4, h, kCoeff, templateWindowSizeSq);
+    short *thrMapTransform = NULL;
+    short *thrMapShrinkage = NULL;
+    calcHaarThresholdMap3D(thrMapTransform, kThrMap4x4, 0, templateWindowSizeSq, maxGroupSize);
+    calcHaarThresholdMap3D(thrMapShrinkage, kThrMap4x4, h, templateWindowSizeSq, maxGroupSize);
 
     // Generate some data
     BlockMatch<short, int, short> *bm = new BlockMatch<short, int, short>[maxGroupSize];
@@ -245,6 +245,27 @@ TEST(Photo_DenoisingBm3dTransforms, regression_1D_transform)
         HaarTransformShrink4<short, int, short>, InverseHaarTransform4<short, int, short>, 6);
     Test1dTransform<short, int, short>(thrMapShrinkage, 8, templateWindowSizeSq, bm, bmOrig,
         HaarTransformShrink8<short, int, short>, InverseHaarTransform8<short, int, short>, 6);
+}
+
+TEST(Photo_DenoisingBm3dTransforms, regression_1D_generate)
+{
+    const int numberOfElements = 8;
+    const int arrSize = (numberOfElements << 1) - 1;
+    float *thrMap1D = NULL;
+    calcHaarThresholdMap1D(thrMap1D, numberOfElements);
+
+    // Expected array
+    const float kThrMap1D[arrSize] = {
+        1.0f,  // 1 element
+        sqrt2 / 2.0f,    sqrt2, // 2 elements
+        0.5f,            1.0f,            sqrt2,       sqrt2,  // 4 elements
+        sqrt2 / 4.0f,    sqrt2 / 2.0f,    1.0f,        1.0f,  sqrt2, sqrt2, sqrt2, sqrt2  // 8 elements
+    };
+
+    for (int j = 0; j < arrSize; ++j)
+        ASSERT_EQ(thrMap1D[j], kThrMap1D[j]);
+
+    delete[] thrMap1D;
 }
 
 TEST(Photo_Bm3dDenoising, powerOf2)

--- a/modules/photo/test/test_denoise_bm3d.cpp
+++ b/modules/photo/test/test_denoise_bm3d.cpp
@@ -44,11 +44,11 @@
 #include "opencv2/photo.hpp"
 #include <string>
 
-#define DUMP_RESULTS
+//#define DUMP_RESULTS
 //#define TEST_TRANSFORMS
 
 #ifdef TEST_TRANSFORMS
-#include "..\..\photo\src\bm3d_denoising_invoker.hpp"
+#include "..\..\photo\src\bm3d_denoising_invoker_commons.hpp"
 #include "..\..\photo\src\bm3d_denoising_transforms.hpp"
 #endif
 
@@ -62,7 +62,7 @@ TEST(Photo_DenoisingBm3dGrayscale, regression_L2)
 {
     std::string folder = std::string(cvtest::TS::ptr()->get_data_path()) + "denoising/";
     std::string original_path = folder + "lena_noised_gaussian_sigma=10.png";
-    std::string expected_path = folder + "lena_noised_denoised_bm3d_grayscale_l2_tw=4_sw=16_h=10_bm=2500.png";
+    std::string expected_path = folder + "lena_noised_denoised_bm3d_wiener_grayscale_l2_tw=4_sw=16_h=10_bm=400.png";
 
     cv::Mat original = cv::imread(original_path, cv::IMREAD_GRAYSCALE);
     cv::Mat expected = cv::imread(expected_path, cv::IMREAD_GRAYSCALE);
@@ -70,8 +70,43 @@ TEST(Photo_DenoisingBm3dGrayscale, regression_L2)
     ASSERT_FALSE(original.empty()) << "Could not load input image " << original_path;
     ASSERT_FALSE(expected.empty()) << "Could not load reference image " << expected_path;
 
-    cv::Mat result;
-    cv::bm3dDenoising(original, result, 10, 4, 16, 2500, 8, cv::NORM_L2);
+    // BM3D: two different calls doing exactly the same thing
+    cv::Mat result, resultSec;
+    cv::bm3dDenoising(original, cv::Mat(), resultSec, 10, 4, 16, 2500, 400, 8, cv::NORM_L2, cv::BM3D_STEPALL);
+    cv::bm3dDenoising(original, result, 10, 4, 16, 2500, 400, 8, cv::NORM_L2, cv::BM3D_STEPALL);
+
+    DUMP(result, expected_path + ".res.png");
+
+    ASSERT_EQ(cvtest::norm(result, resultSec, cv::NORM_L2), 0);
+    ASSERT_LT(cvtest::norm(result, expected, cv::NORM_L2), 200);
+}
+
+TEST(Photo_DenoisingBm3dGrayscale, regression_L2_separate)
+{
+    std::string folder = std::string(cvtest::TS::ptr()->get_data_path()) + "denoising/";
+    std::string original_path = folder + "lena_noised_gaussian_sigma=10.png";
+    std::string expected_basic_path = folder + "lena_noised_denoised_bm3d_grayscale_l2_tw=4_sw=16_h=10_bm=2500.png";
+    std::string expected_path = folder + "lena_noised_denoised_bm3d_wiener_grayscale_l2_tw=4_sw=16_h=10_bm=400.png";
+
+    cv::Mat original = cv::imread(original_path, cv::IMREAD_GRAYSCALE);
+    cv::Mat expected_basic = cv::imread(expected_basic_path, cv::IMREAD_GRAYSCALE);
+    cv::Mat expected = cv::imread(expected_path, cv::IMREAD_GRAYSCALE);
+
+    ASSERT_FALSE(original.empty()) << "Could not load input image " << original_path;
+    ASSERT_FALSE(expected_basic.empty()) << "Could not load reference image " << expected_basic_path;
+    ASSERT_FALSE(expected.empty()) << "Could not load input image " << expected_path;
+
+    cv::Mat basic, result;
+
+    // BM3D step 1
+    cv::bm3dDenoising(original, basic, 10, 4, 16, 2500, -1, 8, cv::NORM_L2, cv::BM3D_STEP1);
+    ASSERT_EQ(cvtest::norm(basic, expected_basic, cv::NORM_L2), 0);
+    DUMP(basic, expected_basic_path + ".res.basic.png");
+
+    // BM3D step 2
+    cv::bm3dDenoising(original, basic, result, 10, 4, 16, 2500, 400, 8, cv::NORM_L2, cv::BM3D_STEP2);
+    ASSERT_EQ(cvtest::norm(basic, expected_basic, cv::NORM_L2), 0);
+    DUMP(basic, expected_basic_path + ".res.basic2.png");
 
     DUMP(result, expected_path + ".res.png");
 
@@ -91,7 +126,7 @@ TEST(Photo_DenoisingBm3dGrayscale, regression_L1)
     ASSERT_FALSE(expected.empty()) << "Could not load reference image " << expected_path;
 
     cv::Mat result;
-    cv::bm3dDenoising(original, result, 10, 4, 16, 2500, 8, cv::NORM_L1);
+    cv::bm3dDenoising(original, result, 10, 4, 16, 2500, -1, 8, cv::NORM_L1, cv::BM3D_STEP1);
 
     DUMP(result, expected_path + ".res.png");
 
@@ -111,7 +146,7 @@ TEST(Photo_DenoisingBm3dGrayscale, regression_L2_8x8)
     ASSERT_FALSE(expected.empty()) << "Could not load reference image " << expected_path;
 
     cv::Mat result;
-    cv::bm3dDenoising(original, result, 10, 8, 16, 2500, 8, cv::NORM_L2);
+    cv::bm3dDenoising(original, result, 10, 8, 16, 2500, -1, 8, cv::NORM_L2, cv::BM3D_STEP1);
 
     DUMP(result, expected_path + ".res.png");
 
@@ -350,7 +385,7 @@ TEST(Photo_DenoisingBm3d, speed)
     cv::Mat src = cv::imread(imgname, 0), dst;
 
     double t = (double)cv::getTickCount();
-    cv::bm3dDenoising(src, dst, 1, 4, 8, 1);
+    cv::bm3dDenoising(src, dst, 1, 4, 8, 1, -1, 8, cv::NORM_L2, cv::BM3D_STEP1);
     t = (double)cv::getTickCount() - t;
     printf("execution time: %gms\n", t*1000. / cv::getTickFrequency());
 }

--- a/modules/photo/test/test_denoise_bm3d.cpp
+++ b/modules/photo/test/test_denoise_bm3d.cpp
@@ -49,6 +49,7 @@
 
 #ifdef TEST_TRANSFORMS
 #include "..\..\photo\src\bm3d_denoising_transforms.hpp"
+#include "..\..\photo\src\bm3d_denoising_invoker.hpp"
 #endif
 
 #ifdef DUMP_RESULTS
@@ -62,7 +63,7 @@ TEST(Photo_DenoisingBm3dGrayscale, regression)
 {
     std::string folder = std::string(cvtest::TS::ptr()->get_data_path()) + "denoising/";
     std::string original_path = folder + "lena_noised_gaussian_sigma=10.png";
-    std::string expected_path = folder + "lena_noised_denoised_grayscale_tw=7_sw=21_h=10.png";
+    std::string expected_path = folder + "lena_noised_gaussian_sigma=10.png";
 
     cv::Mat original = cv::imread(original_path, cv::IMREAD_GRAYSCALE);
     cv::Mat expected = cv::imread(expected_path, cv::IMREAD_GRAYSCALE);
@@ -71,42 +72,139 @@ TEST(Photo_DenoisingBm3dGrayscale, regression)
     ASSERT_FALSE(expected.empty()) << "Could not load reference image " << expected_path;
 
     cv::Mat result;
-    cv::bm3dDenoising(original, result, 1);
+    cv::bm3dDenoising(original, result, 20, 4, 16, 50);
 
+    original_path = folder + "lena_noised_noisy_bm3d_grayscale.png";
+    DUMP(original, original_path + ".res.png");
+    expected_path = folder + "lena_noised_denoised_bm3d_grayscale.png";
     DUMP(result, expected_path + ".res.png");
 
     ASSERT_EQ(0, cvtest::norm(result, expected, cv::NORM_L2));
 }
-//
-//#ifdef TEST_TRANSFORMS
-//TEST(Photo_DenoisingBm3dTransforms, regression)
-//{
-//    const int templateWindowSize = 4;
-//    const int templateWindowSizeSq = templateWindowSize * templateWindowSize;
-//
-//    uchar src[templateWindowSizeSq];
-//    short dst[templateWindowSizeSq];
-//
-//    for (uchar i = 0; i < templateWindowSizeSq; ++i)
-//    {
-//        src[i] = i;
-//    }
-//
-//    Haar4x4(src, dst, templateWindowSize);
-//    InvHaar4x4(dst);
-//
-//    for (uchar i = 0; i < templateWindowSizeSq; ++i)
-//        ASSERT_EQ(static_cast<short>(src[i]), dst[i]);
-//}
-//#endif
-//
+
+#ifdef TEST_TRANSFORMS
+
+TEST(Photo_DenoisingBm3dTransforms, regression_2D)
+{
+    const int templateWindowSize = 4;
+    const int templateWindowSizeSq = templateWindowSize * templateWindowSize;
+
+    uchar src[templateWindowSizeSq];
+    short dst[templateWindowSizeSq];
+
+    // Initialize array
+    for (uchar i = 0; i < templateWindowSizeSq; ++i)
+    {
+        src[i] = i;
+    }
+
+    Haar4x4(src, dst, templateWindowSize);
+    InvHaar4x4(dst);
+
+    for (uchar i = 0; i < templateWindowSizeSq; ++i)
+        ASSERT_EQ(static_cast<short>(src[i]), dst[i]);
+}
+
+static void Test1dTransform(
+    short *thrMap,
+    int groupSize,
+    int templateWindowSizeSq,
+    short **z,
+    short **zOrig,
+    short (*HaarTransformShrink)(short **z, const int &n, short *&thrMap),
+    void (*InverseHaarTransform)(short **src, const int &n),
+    int expectedNonZeroCount = -1)
+{
+    if (expectedNonZeroCount < 0)
+        expectedNonZeroCount = groupSize * templateWindowSizeSq;
+
+    // Test group size
+    short sumNonZero = 0;
+    short *thrMapPtr1D = thrMap + (groupSize - 1) * templateWindowSizeSq;
+    for (int n = 0; n < templateWindowSizeSq; n++)
+    {
+        sumNonZero += HaarTransformShrink(z, n, thrMapPtr1D);
+        InverseHaarTransform(z, n);
+    }
+
+    //// Print
+    //for (int i = 0; i < groupSize; ++i)
+    //{
+    //    for (int j = 0; j < templateWindowSizeSq; ++j)
+    //    {
+    //        if (j % 4 == 0)
+    //            std::cout << std::endl;
+    //        std::cout << z[i][j] << " (" << zOrig[i][j] << ") ";
+    //    }
+    //    std::cout << std::endl;
+    //}
+
+    // Assert transform
+    if (expectedNonZeroCount == groupSize * templateWindowSizeSq)
+    {
+        for (int i = 0; i < groupSize; ++i)
+            for (int j = 0; j < templateWindowSizeSq; ++j)
+                ASSERT_EQ(z[i][j], zOrig[i][j]);
+    }
+
+    // Assert shrinkage
+    printf("sumNonZero: %d\n", sumNonZero);
+    ASSERT_EQ(sumNonZero, expectedNonZeroCount);
+}
+
+TEST(Photo_DenoisingBm3dTransforms, regression_1D_transform)
+{
+    const int templateWindowSize = 4;
+    const int templateWindowSizeSq = templateWindowSize * templateWindowSize;
+    const int searchWindowSize = 16;
+    const int searchWindowSizeSq = searchWindowSize * searchWindowSize;
+    const float h = 10;
+    int maxGroupSize = 8;
+
+    // Precompute separate maps for transform and shrinkage verification
+    short *thrMapTransform = new short[templateWindowSizeSq * ((BM3D_MAX_3D_SIZE << 1) - 1)];
+    short *thrMapShrinkage = new short[templateWindowSizeSq * ((BM3D_MAX_3D_SIZE << 1) - 1)];
+    ComputeThresholdMap1D(thrMapTransform, kThrMap1D, kThrMap4x4, 0, kCoeff, templateWindowSizeSq);
+    ComputeThresholdMap1D(thrMapShrinkage, kThrMap1D, kThrMap4x4, h, kCoeff, templateWindowSizeSq);
+
+    // Generate some data
+    short **z = new short*[maxGroupSize];
+    short **zOrig = new short*[maxGroupSize];
+    for (int i = 0; i < maxGroupSize; ++i)
+    {
+        z[i] = new short[templateWindowSizeSq];
+        zOrig[i] = new short[templateWindowSizeSq];
+    }
+
+    for (int i = 0; i < maxGroupSize; ++i)
+    {
+        for (int j = 0; j < templateWindowSizeSq; ++j)
+        {
+            z[i][j] = (j + 1);
+            zOrig[i][j] = z[i][j];
+        }
+    }
+
+    // Verify transforms
+    Test1dTransform(thrMapTransform, 2, templateWindowSizeSq, z, zOrig, HaarTransformShrink2, InverseHaarTransform2);
+    Test1dTransform(thrMapTransform, 4, templateWindowSizeSq, z, zOrig, HaarTransformShrink4, InverseHaarTransform4);
+    Test1dTransform(thrMapTransform, 8, templateWindowSizeSq, z, zOrig, HaarTransformShrink8, InverseHaarTransform8);
+
+    // Verify shrinkage
+    Test1dTransform(thrMapShrinkage, 2, templateWindowSizeSq, z, zOrig, HaarTransformShrink2, InverseHaarTransform2, 6);
+    Test1dTransform(thrMapShrinkage, 4, templateWindowSizeSq, z, zOrig, HaarTransformShrink4, InverseHaarTransform4, 6);
+    Test1dTransform(thrMapShrinkage, 8, templateWindowSizeSq, z, zOrig, HaarTransformShrink8, InverseHaarTransform8, 6);
+}
+
+#endif
+
 //TEST(Photo_Bm3dDenoising, speed)
 //{
 //    std::string imgname = std::string(cvtest::TS::ptr()->get_data_path()) + "shared/5MP.png";
 //    Mat src = imread(imgname, 0), dst;
 //
 //    double t = (double)getTickCount();
-//    bm3dDenoising(src, dst, 1);
+//    bm3dDenoising(src, dst, 1, 4, 16, 1);
 //    t = (double)getTickCount() - t;
 //    printf("execution time: %gms\n", t*1000. / getTickFrequency());
 //}

--- a/modules/photo/test/test_denoise_bm3d.cpp
+++ b/modules/photo/test/test_denoise_bm3d.cpp
@@ -59,11 +59,11 @@
 #endif
 
 
-TEST(Photo_DenoisingBm3dGrayscale, regression)
+TEST(Photo_DenoisingBm3dGrayscale, regression_L2)
 {
     std::string folder = std::string(cvtest::TS::ptr()->get_data_path()) + "denoising/";
     std::string original_path = folder + "lena_noised_gaussian_sigma=10.png";
-    std::string expected_path = folder + "lena_noised_gaussian_sigma=10.png";
+    std::string expected_path = folder + "lena_noised_denoised_bm3d_grayscale_l2_tw=4_sw=16_h=20_bm=50.png";
 
     cv::Mat original = cv::imread(original_path, cv::IMREAD_GRAYSCALE);
     cv::Mat expected = cv::imread(expected_path, cv::IMREAD_GRAYSCALE);
@@ -73,13 +73,34 @@ TEST(Photo_DenoisingBm3dGrayscale, regression)
 
     cv::Mat result;
     double t = (double)getTickCount();
-    cv::bm3dDenoising(original, result, 20, 4, 16, 50);
+    cv::bm3dDenoising(original, result, 20, 4, 16, 50, 8, cv::NORM_L2);
     t = (double)getTickCount() - t;
     printf("execution time: %gms\n", t*1000. / getTickFrequency());
 
-    original_path = folder + "lena_noised_noisy_bm3d_grayscale.png";
-    DUMP(original, original_path + ".res.png");
-    expected_path = folder + "lena_noised_denoised_bm3d_grayscale.png";
+    DUMP(result, expected_path + ".res.png");
+
+    ASSERT_EQ(0, cvtest::norm(result, expected, cv::NORM_L2));
+}
+
+TEST(Photo_DenoisingBm3dGrayscale, regression_L1)
+{
+    std::string folder = std::string(cvtest::TS::ptr()->get_data_path()) + "denoising/";
+    std::string original_path = folder + "lena_noised_gaussian_sigma=10.png";
+    std::string expected_path = folder + "lena_noised_denoised_bm3d_grayscale_l1_tw=4_sw=16_h=20_bm=50.png";
+
+    cv::Mat original = cv::imread(original_path, cv::IMREAD_GRAYSCALE);
+    cv::Mat expected = cv::imread(expected_path, cv::IMREAD_GRAYSCALE);
+
+    ASSERT_FALSE(original.empty()) << "Could not load input image " << original_path;
+    ASSERT_FALSE(expected.empty()) << "Could not load reference image " << expected_path;
+
+    cv::Mat result;
+    double t = (double)getTickCount();
+    cv::bm3dDenoising(original, result, 20, 4, 16, 50, 8, cv::NORM_L1);
+    t = (double)getTickCount() - t;
+    printf("execution time: %gms\n", t*1000. / getTickFrequency());
+
+    expected_path = folder + "lena_noised_denoised_bm3d_grayscale_l1_tw=4_sw=16_h=20_bm=50";
     DUMP(result, expected_path + ".res.png");
 
     ASSERT_EQ(0, cvtest::norm(result, expected, cv::NORM_L2));

--- a/modules/photo/test/test_denoise_bm3d.cpp
+++ b/modules/photo/test/test_denoise_bm3d.cpp
@@ -71,10 +71,7 @@ TEST(Photo_DenoisingBm3dGrayscale, regression_L2)
     ASSERT_FALSE(expected.empty()) << "Could not load reference image " << expected_path;
 
     cv::Mat result;
-    double t = (double)cv::getTickCount();
     cv::bm3dDenoising(original, result, 10, 4, 16, 2500, 8, cv::NORM_L2);
-    t = (double)cv::getTickCount() - t;
-    printf("execution time: %gms\n", t*1000. / cv::getTickFrequency());
 
     DUMP(result, expected_path + ".res.png");
 
@@ -94,10 +91,7 @@ TEST(Photo_DenoisingBm3dGrayscale, regression_L1)
     ASSERT_FALSE(expected.empty()) << "Could not load reference image " << expected_path;
 
     cv::Mat result;
-    double t = (double)cv::getTickCount();
     cv::bm3dDenoising(original, result, 10, 4, 16, 2500, 8, cv::NORM_L1);
-    t = (double)cv::getTickCount() - t;
-    printf("execution time: %gms\n", t*1000. / cv::getTickFrequency());
 
     DUMP(result, expected_path + ".res.png");
 
@@ -117,10 +111,7 @@ TEST(Photo_DenoisingBm3dGrayscale, regression_L2_8x8)
     ASSERT_FALSE(expected.empty()) << "Could not load reference image " << expected_path;
 
     cv::Mat result;
-    double t = (double)cv::getTickCount();
     cv::bm3dDenoising(original, result, 10, 8, 16, 2500, 8, cv::NORM_L2);
-    t = (double)cv::getTickCount() - t;
-    printf("execution time: %gms\n", t*1000. / cv::getTickFrequency());
 
     DUMP(result, expected_path + ".res.png");
 
@@ -203,7 +194,6 @@ static void Test1dTransform(
     }
 
     // Assert shrinkage
-    printf("sumNonZero: %d\n", sumNonZero);
     ASSERT_EQ(sumNonZero, expectedNonZeroCount);
 }
 

--- a/modules/photo/test/test_denoise_bm3d.cpp
+++ b/modules/photo/test/test_denoise_bm3d.cpp
@@ -209,8 +209,8 @@ TEST(Photo_DenoisingBm3dTransforms, regression_1D_transform)
     // Precompute separate maps for transform and shrinkage verification
     short *thrMapTransform = NULL;
     short *thrMapShrinkage = NULL;
-    calcHaarThresholdMap3D(thrMapTransform, kThrMap4x4, 0, templateWindowSizeSq, maxGroupSize);
-    calcHaarThresholdMap3D(thrMapShrinkage, kThrMap4x4, h, templateWindowSizeSq, maxGroupSize);
+    calcHaarThresholdMap3D(thrMapTransform, 0, templateWindowSize, maxGroupSize);
+    calcHaarThresholdMap3D(thrMapShrinkage, h, templateWindowSize, maxGroupSize);
 
     // Generate some data
     BlockMatch<short, int, short> *bm = new BlockMatch<short, int, short>[maxGroupSize];
@@ -247,6 +247,8 @@ TEST(Photo_DenoisingBm3dTransforms, regression_1D_transform)
         HaarTransformShrink8<short, int, short>, InverseHaarTransform8<short, int, short>, 6);
 }
 
+const float sqrt2 = std::sqrt(2.0f);
+
 TEST(Photo_DenoisingBm3dTransforms, regression_1D_generate)
 {
     const int numberOfElements = 8;
@@ -266,6 +268,50 @@ TEST(Photo_DenoisingBm3dTransforms, regression_1D_generate)
         ASSERT_EQ(thrMap1D[j], kThrMap1D[j]);
 
     delete[] thrMap1D;
+}
+
+TEST(Photo_DenoisingBm3dTransforms, regression_2D_generate_4x4)
+{
+    const int templateWindowSize = 4;
+    float *thrMap2D = NULL;
+    calcHaarThresholdMap2D(thrMap2D, templateWindowSize);
+
+    // Expected array
+    const float kThrMap4x4[templateWindowSize * templateWindowSize] = {
+        0.25f,           0.5f,       sqrt2 / 2.0f,    sqrt2 / 2.0f,
+        0.5f,            1.0f,       sqrt2,           sqrt2,
+        sqrt2 / 2.0f,    sqrt2,      2.0f,            2.0f,
+        sqrt2 / 2.0f,    sqrt2,      2.0f,            2.0f
+    };
+
+    for (int j = 0; j < templateWindowSize * templateWindowSize; ++j)
+        ASSERT_EQ(thrMap2D[j], kThrMap4x4[j]);
+
+    delete[] thrMap2D;
+}
+
+TEST(Photo_DenoisingBm3dTransforms, regression_2D_generate_8x8)
+{
+    const int templateWindowSize = 8;
+    float *thrMap2D = NULL;
+    calcHaarThresholdMap2D(thrMap2D, templateWindowSize);
+
+    // Expected array
+    const float kThrMap8x8[templateWindowSize * templateWindowSize] = {
+        0.125f,       0.25f,        sqrt2 / 4.0f, sqrt2 / 4.0f, 0.5f,  0.5f,  0.5f,  0.5f,
+        0.25f,        0.5f,         sqrt2 / 2.0f, sqrt2 / 2.0f, 1.0f,  1.0f,  1.0f,  1.0f,
+        sqrt2 / 4.0f, sqrt2 / 2.0f, 1.0f,         1.0f,         sqrt2, sqrt2, sqrt2, sqrt2,
+        sqrt2 / 4.0f, sqrt2 / 2.0f, 1.0f,         1.0f,         sqrt2, sqrt2, sqrt2, sqrt2,
+        0.5f,         1.0f,         sqrt2,        sqrt2,        2.0f,  2.0f,  2.0f,  2.0f,
+        0.5f,         1.0f,         sqrt2,        sqrt2,        2.0f,  2.0f,  2.0f,  2.0f,
+        0.5f,         1.0f,         sqrt2,        sqrt2,        2.0f,  2.0f,  2.0f,  2.0f,
+        0.5f,         1.0f,         sqrt2,        sqrt2,        2.0f,  2.0f,  2.0f,  2.0f
+    };
+
+    for (int j = 0; j < templateWindowSize * templateWindowSize; ++j)
+        ASSERT_EQ(thrMap2D[j], kThrMap8x8[j]);
+
+    delete[] thrMap2D;
 }
 
 TEST(Photo_Bm3dDenoising, powerOf2)

--- a/modules/photo/test/test_denoise_bm3d.cpp
+++ b/modules/photo/test/test_denoise_bm3d.cpp
@@ -71,42 +71,42 @@ TEST(Photo_DenoisingBm3dGrayscale, regression)
     ASSERT_FALSE(expected.empty()) << "Could not load reference image " << expected_path;
 
     cv::Mat result;
-    //cv::bm3dDenoising(original, result, 10);
+    cv::bm3dDenoising(original, result, 1);
 
     DUMP(result, expected_path + ".res.png");
 
     ASSERT_EQ(0, cvtest::norm(result, expected, cv::NORM_L2));
 }
-
-#ifdef TEST_TRANSFORMS
-TEST(Photo_DenoisingBm3dTransforms, regression)
-{
-    const int templateWindowSize = 4;
-    const int templateWindowSizeSq = templateWindowSize * templateWindowSize;
-
-    uchar src[templateWindowSizeSq];
-    short dst[templateWindowSizeSq];
-
-    for (uchar i = 0; i < templateWindowSizeSq; ++i)
-    {
-        src[i] = i;
-    }
-
-    Haar4x4(src, dst, templateWindowSize);
-    InvHaar4x4(dst);
-
-    for (uchar i = 0; i < templateWindowSizeSq; ++i)
-        ASSERT_EQ(static_cast<short>(src[i]), dst[i]);
-}
-#endif
-
-TEST(Photo_Bm3dDenoising, speed)
-{
-    std::string imgname = std::string(cvtest::TS::ptr()->get_data_path()) + "shared/5MP.png";
-    Mat src = imread(imgname, 0), dst;
-
-    double t = (double)getTickCount();
-    //bm3dDenoising(src, dst, 5, 7, 21);
-    t = (double)getTickCount() - t;
-    printf("execution time: %gms\n", t*1000. / getTickFrequency());
-}
+//
+//#ifdef TEST_TRANSFORMS
+//TEST(Photo_DenoisingBm3dTransforms, regression)
+//{
+//    const int templateWindowSize = 4;
+//    const int templateWindowSizeSq = templateWindowSize * templateWindowSize;
+//
+//    uchar src[templateWindowSizeSq];
+//    short dst[templateWindowSizeSq];
+//
+//    for (uchar i = 0; i < templateWindowSizeSq; ++i)
+//    {
+//        src[i] = i;
+//    }
+//
+//    Haar4x4(src, dst, templateWindowSize);
+//    InvHaar4x4(dst);
+//
+//    for (uchar i = 0; i < templateWindowSizeSq; ++i)
+//        ASSERT_EQ(static_cast<short>(src[i]), dst[i]);
+//}
+//#endif
+//
+//TEST(Photo_Bm3dDenoising, speed)
+//{
+//    std::string imgname = std::string(cvtest::TS::ptr()->get_data_path()) + "shared/5MP.png";
+//    Mat src = imread(imgname, 0), dst;
+//
+//    double t = (double)getTickCount();
+//    bm3dDenoising(src, dst, 1);
+//    t = (double)getTickCount() - t;
+//    printf("execution time: %gms\n", t*1000. / getTickFrequency());
+//}

--- a/modules/photo/test/test_denoise_bm3d.cpp
+++ b/modules/photo/test/test_denoise_bm3d.cpp
@@ -200,9 +200,9 @@ TEST(Photo_DenoisingBm3dTransforms, regression_1D_transform)
         zOrig[i] = new short[templateWindowSizeSq];
     }
 
-    for (int i = 0; i < maxGroupSize; ++i)
+    for (short i = 0; i < maxGroupSize; ++i)
     {
-        for (int j = 0; j < templateWindowSizeSq; ++j)
+        for (short j = 0; j < templateWindowSizeSq; ++j)
         {
             z[i][j] = (j + 1);
             zOrig[i][j] = z[i][j];
@@ -221,6 +221,19 @@ TEST(Photo_DenoisingBm3dTransforms, regression_1D_transform)
 }
 
 #endif
+
+TEST(Photo_Bm3dDenoising, powerOf2)
+{
+    ASSERT_EQ(8, getLargestPowerOf2SmallerThan(9));
+    ASSERT_EQ(16, getLargestPowerOf2SmallerThan(21));
+    ASSERT_EQ(4, getLargestPowerOf2SmallerThan(7));
+    ASSERT_EQ(8, getLargestPowerOf2SmallerThan(8));
+    ASSERT_EQ(4, getLargestPowerOf2SmallerThan(5));
+    ASSERT_EQ(4, getLargestPowerOf2SmallerThan(4));
+    ASSERT_EQ(2, getLargestPowerOf2SmallerThan(3));
+    ASSERT_EQ(1, getLargestPowerOf2SmallerThan(1));
+    ASSERT_EQ(0, getLargestPowerOf2SmallerThan(0));
+}
 
 //TEST(Photo_Bm3dDenoising, speed)
 //{

--- a/modules/photo/test/test_denoise_bm3d.cpp
+++ b/modules/photo/test/test_denoise_bm3d.cpp
@@ -45,7 +45,7 @@
 #include <string>
 
 #define DUMP_RESULTS
-#define TEST_TRANSFORMS
+//#define TEST_TRANSFORMS
 
 #ifdef TEST_TRANSFORMS
 #include "..\..\photo\src\bm3d_denoising_invoker.hpp"
@@ -262,13 +262,13 @@ TEST(Photo_Bm3dDenoising, powerOf2)
 
 #endif
 
-//TEST(Photo_Bm3dDenoising, speed)
-//{
-//    std::string imgname = std::string(cvtest::TS::ptr()->get_data_path()) + "shared/5MP.png";
-//    Mat src = imread(imgname, 0), dst;
-//
-//    double t = (double)getTickCount();
-//    bm3dDenoising(src, dst, 1, 4, 16, 1);
-//    t = (double)getTickCount() - t;
-//    printf("execution time: %gms\n", t*1000. / getTickFrequency());
-//}
+TEST(Photo_DenoisingBm3d, speed)
+{
+    std::string imgname = std::string(cvtest::TS::ptr()->get_data_path()) + "shared/5MP.png";
+    cv::Mat src = cv::imread(imgname, 0), dst;
+
+    double t = (double)cv::getTickCount();
+    cv::bm3dDenoising(src, dst, 1, 4, 8, 1);
+    t = (double)cv::getTickCount() - t;
+    printf("execution time: %gms\n", t*1000. / cv::getTickFrequency());
+}

--- a/modules/photo/test/test_denoise_bm3d.cpp
+++ b/modules/photo/test/test_denoise_bm3d.cpp
@@ -72,7 +72,10 @@ TEST(Photo_DenoisingBm3dGrayscale, regression)
     ASSERT_FALSE(expected.empty()) << "Could not load reference image " << expected_path;
 
     cv::Mat result;
+    double t = (double)getTickCount();
     cv::bm3dDenoising(original, result, 20, 4, 16, 50);
+    t = (double)getTickCount() - t;
+    printf("execution time: %gms\n", t*1000. / getTickFrequency());
 
     original_path = folder + "lena_noised_noisy_bm3d_grayscale.png";
     DUMP(original, original_path + ".res.png");

--- a/modules/photo/test/test_denoise_bm3d.cpp
+++ b/modules/photo/test/test_denoise_bm3d.cpp
@@ -104,6 +104,29 @@ TEST(Photo_DenoisingBm3dGrayscale, regression_L1)
     ASSERT_EQ(0, cvtest::norm(result, expected, cv::NORM_L2));
 }
 
+TEST(Photo_DenoisingBm3dGrayscale, regression_L2_8x8)
+{
+    std::string folder = std::string(cvtest::TS::ptr()->get_data_path()) + "denoising/";
+    std::string original_path = folder + "lena_noised_gaussian_sigma=10.png";
+    std::string expected_path = folder + "lena_noised_denoised_bm3d_grayscale_l2_tw=8_sw=16_h=10_bm=2500.png";
+
+    cv::Mat original = cv::imread(original_path, cv::IMREAD_GRAYSCALE);
+    cv::Mat expected = cv::imread(expected_path, cv::IMREAD_GRAYSCALE);
+
+    ASSERT_FALSE(original.empty()) << "Could not load input image " << original_path;
+    ASSERT_FALSE(expected.empty()) << "Could not load reference image " << expected_path;
+
+    cv::Mat result;
+    double t = (double)cv::getTickCount();
+    cv::bm3dDenoising(original, result, 10, 8, 16, 2500, 8, cv::NORM_L2);
+    t = (double)cv::getTickCount() - t;
+    printf("execution time: %gms\n", t*1000. / cv::getTickFrequency());
+
+    DUMP(result, expected_path + ".res.png");
+
+    ASSERT_EQ(0, cvtest::norm(result, expected, cv::NORM_L2));
+}
+
 #ifdef TEST_TRANSFORMS
 
 TEST(Photo_DenoisingBm3dTransforms, regression_2D_4x4)

--- a/modules/photo/test/test_denoise_bm3d.cpp
+++ b/modules/photo/test/test_denoise_bm3d.cpp
@@ -96,11 +96,10 @@ TEST(Photo_DenoisingBm3dGrayscale, regression_L1)
 
     cv::Mat result;
     double t = (double)getTickCount();
-    cv::bm3dDenoising(original, result, 20, 4, 16, 50, 8, cv::NORM_L1);
+    cv::bm3dDenoising(original, result, 10, 4, 16, 50, 8, cv::NORM_L1);
     t = (double)getTickCount() - t;
     printf("execution time: %gms\n", t*1000. / getTickFrequency());
 
-    expected_path = folder + "lena_noised_denoised_bm3d_grayscale_l1_tw=4_sw=16_h=20_bm=50";
     DUMP(result, expected_path + ".res.png");
 
     ASSERT_EQ(0, cvtest::norm(result, expected, cv::NORM_L2));

--- a/modules/photo/test/test_denoise_bm3d.cpp
+++ b/modules/photo/test/test_denoise_bm3d.cpp
@@ -100,12 +100,12 @@ TEST(Photo_DenoisingBm3dGrayscale, regression_L2_separate)
 
     // BM3D step 1
     cv::bm3dDenoising(original, basic, 10, 4, 16, 2500, -1, 8, cv::NORM_L2, cv::BM3D_STEP1);
-    ASSERT_EQ(cvtest::norm(basic, expected_basic, cv::NORM_L2), 0);
+    ASSERT_LT(cvtest::norm(basic, expected_basic, cv::NORM_L2), 200);
     DUMP(basic, expected_basic_path + ".res.basic.png");
 
     // BM3D step 2
     cv::bm3dDenoising(original, basic, result, 10, 4, 16, 2500, 400, 8, cv::NORM_L2, cv::BM3D_STEP2);
-    ASSERT_EQ(cvtest::norm(basic, expected_basic, cv::NORM_L2), 0);
+    ASSERT_LT(cvtest::norm(basic, expected_basic, cv::NORM_L2), 200);
     DUMP(basic, expected_basic_path + ".res.basic2.png");
 
     DUMP(result, expected_path + ".res.png");


### PR DESCRIPTION
**Merge with extra**: https://github.com/opencv/opencv_extra/pull/301

resolves #6757

### This pullrequest adds

- BM3D denoising algorithm (both first and second step):
   http://www.cs.tut.fi/~foi/GCF-BM3D/BM3D_TIP_2007.pdf
- For performance reasons, only Haar transform is used.
- Template window sizes supported: 4x4 and 8x8
- Maximum number of elements in 3D group: 16
