### PR TITLE
disable ippiMinMaxIndx_32f_C1R usage since it crashes on Nans

### DIFF
--- a/modules/core/src/stat.cpp
+++ b/modules/core/src/stat.cpp
@@ -2280,7 +2280,9 @@ static bool ipp_minMaxIdx( Mat &src, double* minVal, double* maxVal, int* minIdx
 #endif
                 depth == CV_16U ? (ippiMinMaxIndxFuncC1)ippiMinMaxIndx_16u_C1R :
 #if !((defined _MSC_VER && defined _M_IX86) || defined __i386__)
-                depth == CV_32F ? (ippiMinMaxIndxFuncC1)ippiMinMaxIndx_32f_C1R :
+                // See bug #4955: the function fails with SEGFAULT when the source matrix contains NANs
+                // IPPICV version is 9.0.1.
+                // depth == CV_32F ? (ippiMinMaxIndxFuncC1)ippiMinMaxIndx_32f_C1R :
 #endif
                 0;
             CV_SUPPRESS_DEPRECATED_END

--- a/modules/core/test/test_arithm.cpp
+++ b/modules/core/test/test_arithm.cpp
@@ -1844,3 +1844,12 @@ TEST(Normalize, regression_5876_inplace_change_type)
     normalize(m, m, 1, 0, NORM_MINMAX, CV_32F);
     EXPECT_EQ(0, cvtest::norm(m, result, NORM_INF));
 }
+
+TEST(MinMaxLoc, regression_4955_nans)
+{
+    cv::Mat one_mat(2, 2, CV_32F, cv::Scalar(1));
+    cv::minMaxLoc(one_mat, NULL, NULL, NULL, NULL);
+
+    cv::Mat nan_mat(2, 2, CV_32F, cv::Scalar(NAN));
+    cv::minMaxLoc(nan_mat, NULL, NULL, NULL, NULL);
+}


### PR DESCRIPTION
resolves #4955

