### PR TITLE
videoio: ffmpeg: fix get_fps() implementation

### DIFF
--- a/modules/videoio/src/cap_ffmpeg_impl.hpp
+++ b/modules/videoio/src/cap_ffmpeg_impl.hpp
@@ -1135,11 +1135,7 @@ int CvCapture_FFMPEG::get_bitrate() const
 
 double CvCapture_FFMPEG::get_fps() const
 {
-#if LIBAVCODEC_BUILD >= CALC_FFMPEG_VERSION(54, 1, 0)
-    double fps = r2d(ic->streams[video_stream]->avg_frame_rate);
-#else
     double fps = r2d(ic->streams[video_stream]->r_frame_rate);
-#endif
 
 #if LIBAVFORMAT_BUILD >= CALC_FFMPEG_VERSION(52, 111, 0)
     if (fps < eps_zero)


### PR DESCRIPTION
Problem is observed with ffmpeg 3.1.1.

This patch removes change which is proposed in PR #2293 ([commit](https://github.com/opencv/opencv/pull/2293/commits/0c8faf17694baaf62ad120b6b3103b5d022e04ed)) and which is merged in #3952.

ffprobe output (ffmpeg 3.1.1) for "Videoio_Video.write_read" test:
```
$ ~/build/ffmpeg/install/bin/ffprobe -i /tmp/__opencv_temp.htOv64.XVID.mkv -v error -show_format -show_streams[STREAM]
index=0
codec_name=mpeg4
codec_long_name=MPEG-4 part 2
profile=Simple Profile
codec_type=video
codec_time_base=1/1000
codec_tag_string=[0][0][0][0]
codec_tag=0x0000
width=968
height=756
coded_width=968
coded_height=756
has_b_frames=0
sample_aspect_ratio=1:1
display_aspect_ratio=242:189
pix_fmt=yuv420p
level=1
color_range=N/A
color_space=unknown
color_transfer=unknown
color_primaries=unknown
chroma_location=left
timecode=N/A
refs=1
quarter_sample=false
divx_packed=false
id=N/A
r_frame_rate=25/1        # OK
avg_frame_rate=1000/1    # BAD
time_base=1/1000
start_pts=0
start_time=0.000000
duration_ts=N/A
duration=N/A
bit_rate=N/A
max_bit_rate=N/A
bits_per_raw_sample=N/A
nb_frames=N/A            # BAD
nb_read_frames=N/A
nb_read_packets=N/A
DISPOSITION:default=1
DISPOSITION:dub=0
DISPOSITION:original=0
DISPOSITION:forced=0
DISPOSITION:hearing_impaired=0
DISPOSITION:visual_impaired=0
DISPOSITION:clean_effects=0
DISPOSITION:attached_pic=0
TAG:DURATION=00:00:01.200000000
[/STREAM]
[FORMAT]
filename=/tmp/__opencv_temp.htOv64.XVID.mkv
nb_streams=1
nb_programs=0
format_name=matroska,webm
format_long_name=Matroska / WebM
start_time=0.000000
duration=1.200000         # OK
size=310255
bit_rate=2068366
probe_score=100
TAG:ENCODER=Lavf57.41.100
[/FORMAT]
```

avg_frame_rate and nb_frames are not available, but r_frame_rate and duration work fine (MKV + XVID case, but codec is MPEG4).