### PR TITLE
Fix video_reader GPU sample compilation after latest changes in master

### DIFF
--- a/samples/gpu/video_reader.cpp
+++ b/samples/gpu/video_reader.cpp
@@ -31,7 +31,7 @@ int main(int argc, const char* argv[])
     cv::cuda::GpuMat d_frame;
     cv::Ptr<cv::cudacodec::VideoReader> d_reader = cv::cudacodec::createVideoReader(fname);
 
-    TickMeter tm;
+    cv::TickMeter tm;
     std::vector<double> cpu_times;
     std::vector<double> gpu_times;
 


### PR DESCRIPTION
### This pullrequest changes

Added `cv::` prefix to `TickMeter` class, since `cv` namespace is not imported via `using namespace`.

