### PR TITLE
fixed clone of empty Mat_

### DIFF
--- a/modules/core/src/array.cpp
+++ b/modules/core/src/array.cpp
@@ -115,12 +115,13 @@ cvCreateMatHeader( int rows, int cols, int type )
 {
     type = CV_MAT_TYPE(type);
 
-    if( rows < 0 || cols <= 0 )
+    if( rows < 0 || cols < 0 )
         CV_Error( CV_StsBadSize, "Non-positive width or height" );
 
-    int min_step = CV_ELEM_SIZE(type)*cols;
+    int min_step = CV_ELEM_SIZE(type);
     if( min_step <= 0 )
         CV_Error( CV_StsUnsupportedFormat, "Invalid matrix type" );
+    min_step *= cols;
 
     CvMat* arr = (CvMat*)cvAlloc( sizeof(*arr));
 
@@ -148,7 +149,7 @@ cvInitMatHeader( CvMat* arr, int rows, int cols,
     if( (unsigned)CV_MAT_DEPTH(type) > CV_DEPTH_MAX )
         CV_Error( CV_BadNumChannels, "" );
 
-    if( rows < 0 || cols <= 0 )
+    if( rows < 0 || cols < 0 )
         CV_Error( CV_StsBadSize, "Non-positive cols or rows" );
 
     type = CV_MAT_TYPE( type );

--- a/modules/core/src/copy.cpp
+++ b/modules/core/src/copy.cpp
@@ -259,12 +259,6 @@ void Mat::copyTo( OutputArray _dst ) const
         return;
     }
 
-    if( empty() )
-    {
-        _dst.release();
-        return;
-    }
-
     if( _dst.isUMat() )
     {
         _dst.create( dims, size.p, type() );

--- a/modules/core/src/persistence.cpp
+++ b/modules/core/src/persistence.cpp
@@ -3909,8 +3909,6 @@ icvReadMat( CvFileStorage* fs, CvFileNode* node )
         mat = cvCreateMat( rows, cols, elem_type );
         cvReadRawData( fs, data, mat->data.ptr, dt );
     }
-    else if( rows == 0 && cols == 0 )
-        mat = cvCreateMatHeader( 0, 1, elem_type );
     else
         mat = cvCreateMatHeader( rows, cols, elem_type );
 

--- a/modules/core/test/test_io.cpp
+++ b/modules/core/test/test_io.cpp
@@ -706,7 +706,6 @@ protected:
 
             EXPECT_EQ(_em_in.rows   , _em_out.rows);
             EXPECT_EQ(_em_in.cols   , _em_out.cols);
-            EXPECT_EQ(_em_in.dims   , _em_out.dims);
             EXPECT_EQ(_em_in.depth(), _em_out.depth());
             EXPECT_TRUE(_em_in.empty());
 

--- a/modules/core/test/test_mat.cpp
+++ b/modules/core/test/test_mat.cpp
@@ -1538,3 +1538,11 @@ TEST(Mat, push_back_vector)
 
     ASSERT_EQ(6, result.rows);
 }
+
+TEST(Mat, regression_5917_clone_empty)
+{
+    Mat cloned;
+    Mat_<Point2f> source(5, 0);
+
+    ASSERT_NO_THROW(cloned = source.clone());
+}


### PR DESCRIPTION
resolves https://github.com/opencv/opencv/issues/5917

### This pullrequest changes

Remove empty check from `CopyTo` since metadata like number of channels and depth, etc is not copied into destination matrix in this case.
