### PR TITLE
Set threshold to 1 in sanity test for GPU rotate on 8UC1

### DIFF
--- a/modules/gpu/perf/perf_imgproc.cpp
+++ b/modules/gpu/perf/perf_imgproc.cpp
@@ -1373,7 +1373,10 @@ PERF_TEST_P(Sz_Depth_Cn_Inter, ImgProc_Rotate,
 
         TEST_CYCLE() cv::gpu::rotate(d_src, dst, size, 30.0, 0, 0, interpolation);
 
-        GPU_SANITY_CHECK(dst, 1e-3, ERROR_RELATIVE);
+        if (depth == CV_8U)
+            GPU_SANITY_CHECK(dst, 1);
+        else
+            GPU_SANITY_CHECK(dst, 1e-3, ERROR_RELATIVE);
     }
     else
     {


### PR DESCRIPTION
To fix difference with CUDA 8.0 results.