### PR TITLE
Use HAVE_OPENGL instead of WITH_OPENGL for GPU opengl sample

### DIFF
--- a/samples/gpu/CMakeLists.txt
+++ b/samples/gpu/CMakeLists.txt
@@ -81,9 +81,9 @@ if(BUILD_EXAMPLES AND OCV_DEPENDENCIES_FOUND)
 
   file(GLOB all_samples RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} *.cpp)
 
-  if(NOT WITH_OPENGL)
+  if(NOT HAVE_OPENGL)
     list(REMOVE_ITEM all_samples "opengl.cpp")
-  endif(NOT WITH_OPENGL)
+  endif()
 
   foreach(sample_filename ${all_samples})
     get_filename_component(sample ${sample_filename} NAME_WE)
@@ -96,9 +96,9 @@ endif()
 
 if(INSTALL_C_EXAMPLES AND NOT WIN32)
   file(GLOB install_list *.c *.cpp *.jpg *.png *.data makefile.* build_all.sh *.dsp *.cmd )
-  if(NOT WITH_OPENGL)
+  if(NOT HAVE_OPENGL)
     list(REMOVE_ITEM install_list "opengl.cpp")
-  endif(NOT WITH_OPENGL)
+  endif()
   install(FILES ${install_list}
           DESTINATION ${OPENCV_SAMPLES_SRC_INSTALL_PATH}/gpu
           PERMISSIONS OWNER_READ GROUP_READ WORLD_READ COMPONENT samples)


### PR DESCRIPTION
In this case the sample will not be built if OpenGL is not found.