### PR TITLE
Add bib reference for overall hit rate and false alarm formulas.

### DIFF
--- a/doc/opencv.bib
+++ b/doc/opencv.bib
@@ -750,13 +750,23 @@
   organization = {ACM}
 }
 @INPROCEEDINGS{Viola01,
-  author = {Viola, Paul and Jones, Michael},
+  author = {Viola, Paul and Jones, Michael J.},
   title = {Rapid object detection using a boosted cascade of simple features},
   booktitle = {Computer Vision and Pattern Recognition, 2001. CVPR 2001. Proceedings of the 2001 IEEE Computer Society Conference on},
   year = {2001},
   pages = {I--511},
   volume = {1},
   organization = {IEEE}
+}
+@ARTICLE{Viola04,
+  author = {Viola, Paul and Jones, Michael J.},
+  title = {Robust real-time face detection},
+  journal = {International Journal of Computer Vision},
+  year = {2004},
+  volume = {57},
+  number = {2},
+  pages = {137--154},
+  publisher = {Kluwer Academic Publishers}
 }
 @INPROCEEDINGS{WJ10,
   author = {Xu, Wei and Mulligan, Jane},

--- a/doc/tutorials/objdetect/traincascade.markdown
+++ b/doc/tutorials/objdetect/traincascade.markdown
@@ -288,12 +288,12 @@ Command line arguments of opencv_traincascade application grouped by purposes:
     -   -minHitRate \<min_hit_rate\>
 
         Minimal desired hit rate for each stage of the classifier. Overall hit rate may be estimated
-        as (min_hit_rate\^number_of_stages).
+        as (min_hit_rate ^ number_of_stages), @cite Viola04 §4.1.
 
     -   -maxFalseAlarmRate \<max_false_alarm_rate\>
 
         Maximal desired false alarm rate for each stage of the classifier. Overall false alarm rate
-        may be estimated as (max_false_alarm_rate\^number_of_stages).
+        may be estimated as (max_false_alarm_rate ^ number_of_stages), @cite Viola04 §4.1.
 
     -   -weightTrimRate \<weight_trim_rate\>
 


### PR DESCRIPTION
### This pullrequest adds

the bib reference for overall hit rate and overall false alarm rate in the train cascade tutorial.

Related: #6439