### PR TITLE
fixed bug #5775

### DIFF
--- a/modules/core/src/arithm.cpp
+++ b/modules/core/src/arithm.cpp
@@ -643,7 +643,7 @@ static void arithm_op(InputArray _src1, InputArray _src2, OutputArray _dst,
         if (!muldiv)
         {
             Mat sc = psrc2->getMat();
-            depth2 = actualScalarDepth(sc.ptr<double>(), cn);
+            depth2 = actualScalarDepth(sc.ptr<double>(), sz2 == Size(1, 1) ? cn2 : cn);
             if( depth2 == CV_64F && (depth1 < CV_32S || depth1 == CV_32F) )
                 depth2 = CV_32F;
         }

--- a/modules/core/test/test_arithm.cpp
+++ b/modules/core/test/test_arithm.cpp
@@ -1910,3 +1910,21 @@ TEST(MinMaxLoc, regression_4955_nans)
     cv::Mat nan_mat(2, 2, CV_32F, cv::Scalar(NAN));
     cv::minMaxLoc(nan_mat, NULL, NULL, NULL, NULL);
 }
+
+TEST(Subtract, scalarc1_matc3)
+{
+    int scalar = 255;
+    cv::Mat srcImage(5, 5, CV_8UC3, cv::Scalar::all(5)), destImage;
+    cv::subtract(scalar, srcImage, destImage);
+
+    ASSERT_EQ(0, cv::norm(cv::Mat(5, 5, CV_8UC3, cv::Scalar::all(250)), destImage, cv::NORM_INF));
+}
+
+TEST(Subtract, scalarc4_matc4)
+{
+    cv::Scalar sc(255, 255, 255, 255);
+    cv::Mat srcImage(5, 5, CV_8UC4, cv::Scalar::all(5)), destImage;
+    cv::subtract(sc, srcImage, destImage);
+
+    ASSERT_EQ(0, cv::norm(cv::Mat(5, 5, CV_8UC4, cv::Scalar::all(250)), destImage, cv::NORM_INF));
+}


### PR DESCRIPTION
resolves #5775

This fix ensures correct `depth2` calculation without our of memory reading.