### PR TITLE
Better stereo bm

### DIFF
--- a/modules/calib3d/src/stereobm.cpp
+++ b/modules/calib3d/src/stereobm.cpp
@@ -1096,14 +1096,14 @@ public:
         if( params.uniquenessRatio < 0 )
             CV_Error( Error::StsOutOfRange, "uniqueness ratio must be non-negative" );
 
-	int disp_shift;
-	if (dtype == CV_16SC1)
-		disp_shift = DISPARITY_SHIFT_16S;
-	else
-		disp_shift = DISPARITY_SHIFT_32S;
+        int disp_shift;
+        if (dtype == CV_16SC1)
+            disp_shift = DISPARITY_SHIFT_16S;
+        else
+            disp_shift = DISPARITY_SHIFT_32S;
 
 
-	int FILTERED = (params.minDisparity - 1) << disp_shift;
+        int FILTERED = (params.minDisparity - 1) << disp_shift;
 
 #ifdef HAVE_OPENCL
         if(ocl::useOpenCL() && disparr.isUMat() && params.textureThreshold == 0)
@@ -1116,7 +1116,7 @@ public:
                     if( params.speckleRange >= 0 && params.speckleWindowSize > 0 )
                         filterSpeckles(disparr.getMat(), FILTERED, params.speckleWindowSize, params.speckleRange, slidingSumBuf);
                     if (dtype == CV_32F)
-			disparr.getUMat().convertTo(disparr, CV_32FC1, 1./(1 << disp_shift), 0);
+                        disparr.getUMat().convertTo(disparr, CV_32FC1, 1./(1 << disp_shift), 0);
                     CV_IMPL_ADD(CV_IMPL_OCL);
                     return;
                 }
@@ -1145,7 +1145,7 @@ public:
 
         if( lofs >= width || rofs >= width || width1 < 1 )
         {
-	    disp0 = Scalar::all( FILTERED * ( disp0.type() < CV_32F ? 1 : 1./(1 << disp_shift) ) );
+            disp0 = Scalar::all( FILTERED * ( disp0.type() < CV_32F ? 1 : 1./(1 << disp_shift) ) );
             return;
         }
 
@@ -1201,7 +1201,7 @@ public:
             filterSpeckles(disp, FILTERED, params.speckleWindowSize, params.speckleRange, slidingSumBuf);
 
         if (disp0.data != disp.data)
-	    disp.convertTo(disp0, disp0.type(), 1./(1 << disp_shift), 0);
+            disp.convertTo(disp0, disp0.type(), 1./(1 << disp_shift), 0);
     }
 
     int getMinDisparity() const { return params.minDisparity; }

--- a/modules/calib3d/src/stereobm.cpp
+++ b/modules/calib3d/src/stereobm.cpp
@@ -338,7 +338,7 @@ static void findStereoCorrespondenceBM_SSE2( const Mat& left, const Mat& right,
     int ftzero = state.preFilterCap;
     int textureThreshold = state.textureThreshold;
     int uniquenessRatio = state.uniquenessRatio;
-    short FILTERED = (short)((mindisp - 1) << DISPARITY_SHIFT);
+    short FILTERED = (short)((mindisp - 1) << DISPARITY_SHIFT_16S);
 
     ushort *sad, *hsad0, *hsad, *hsad_sub;
     int *htext;
@@ -1096,7 +1096,14 @@ public:
         if( params.uniquenessRatio < 0 )
             CV_Error( Error::StsOutOfRange, "uniqueness ratio must be non-negative" );
 
-        int FILTERED = (params.minDisparity - 1) << DISPARITY_SHIFT;
+	int disp_shift;
+	if (dtype == CV_16SC1)
+		disp_shift = DISPARITY_SHIFT_16S;
+	else
+		disp_shift = DISPARITY_SHIFT_32S;
+
+
+	int FILTERED = (params.minDisparity - 1) << disp_shift;
 
 #ifdef HAVE_OPENCL
         if(ocl::useOpenCL() && disparr.isUMat() && params.textureThreshold == 0)
@@ -1109,7 +1116,7 @@ public:
                     if( params.speckleRange >= 0 && params.speckleWindowSize > 0 )
                         filterSpeckles(disparr.getMat(), FILTERED, params.speckleWindowSize, params.speckleRange, slidingSumBuf);
                     if (dtype == CV_32F)
-                        disparr.getUMat().convertTo(disparr, CV_32FC1, 1./(1 << DISPARITY_SHIFT), 0);
+			disparr.getUMat().convertTo(disparr, CV_32FC1, 1./(1 << disp_shift), 0);
                     CV_IMPL_ADD(CV_IMPL_OCL);
                     return;
                 }
@@ -1138,7 +1145,7 @@ public:
 
         if( lofs >= width || rofs >= width || width1 < 1 )
         {
-            disp0 = Scalar::all( FILTERED * ( disp0.type() < CV_32F ? 1 : 1./(1 << DISPARITY_SHIFT) ) );
+	    disp0 = Scalar::all( FILTERED * ( disp0.type() < CV_32F ? 1 : 1./(1 << disp_shift) ) );
             return;
         }
 
@@ -1194,7 +1201,7 @@ public:
             filterSpeckles(disp, FILTERED, params.speckleWindowSize, params.speckleRange, slidingSumBuf);
 
         if (disp0.data != disp.data)
-            disp.convertTo(disp0, disp0.type(), 1./(1 << DISPARITY_SHIFT), 0);
+	    disp.convertTo(disp0, disp0.type(), 1./(1 << disp_shift), 0);
     }
 
     int getMinDisparity() const { return params.minDisparity; }


### PR DESCRIPTION
'resolves' 6898

I have seen that you can input a Mat_\<float\> on StereoBM, but the value seems the same as CV_16S.

I changed it so, only if you input a Mat_\<float\> it makes use of a previously truncated 4 bits, giving more resolution to Disparity Matrix. (The algorithm stays the same, it's not more precise).

If any other input Mat is given, it changes nothing.

The difference (Using PCL to visualize) can be seen bellow:
![before-after](https://cloud.githubusercontent.com/assets/19741247/16964916/1a299432-4dd4-11e6-8d62-52e75f698693.png)

