### PR TITLE
add note of minimum requirement of CUDA

### DIFF
--- a/doc/tutorials/introduction/linux_install/linux_install.markdown
+++ b/doc/tutorials/introduction/linux_install/linux_install.markdown
@@ -16,6 +16,7 @@ Required Packages
 -   [optional] libtbb2 libtbb-dev
 -   [optional] libdc1394 2.x
 -   [optional] libjpeg-dev, libpng-dev, libtiff-dev, libjasper-dev, libdc1394-22-dev
+-   [optional] CUDA Toolkit 6.5 or higher
 
 The packages can be installed using a terminal and the following commands or by using Synaptic
 Manager:


### PR DESCRIPTION
<!-- Please use this line to close one or multiple issues when this pullrequest gets merged
You can add another line right under the first one:
resolves #1234
resolves #1235
-->

### This pullrequest changes
 * doc and describe the minimum requirement for CUDA

### Other proposal
 * I've just wasted couple of hours just trying to figure out why my build doesn't enable CUDA. 
 * I finally figured out that 112903c2bdc5854da3fac82cb57bd83dc0a98aef changed the minimum requirement, when my CUDA was still 6.0.
 * I'm not talking whether CUDA 6.0 is old or not, but the point is that it would be easier for me to have some minimum requirement explained in doc.
 * Further more, this is the only place I could find which explains the minimum requirement, but I think there should be a independent page which explains the minimum requirement
 * In extra, it would be very nice if the dependency information is automatically generated from [OpenCVMinDepVersions.cmake](https://github.com/opencv/opencv/blob/master/cmake/OpenCVMinDepVersions.cmake)
 * Since I prefer to keep a PR small, I just wrote the information in Linux Installation page.

<!-- Please describe what your pullrequest is changing -->

