### PR TITLE
[fix] a typo: cuda resize interpolation method

### DIFF
--- a/modules/cudawarping/src/cuda/resize.cu
+++ b/modules/cudawarping/src/cuda/resize.cu
@@ -456,7 +456,7 @@ namespace cv { namespace cuda { namespace device
         };
 
         // change to linear if area interpolation upscaling
-        if (interpolation == 3 && (fx <= 1.f || fy <= 1.f))
+        if (interpolation == 3 && (fx > 1.f || fy > 1.f))
             interpolation = 1;
 
         funcs[interpolation](static_cast< PtrStepSz<T> >(src), static_cast< PtrStepSz<T> >(srcWhole), yoff, xoff, static_cast< PtrStepSz<T> >(dst), fy, fx, stream);


### PR DESCRIPTION
### This pullrequest changes
The PR is pretty transparent and self-explanitory.
In the device code for cv::cuda::resize there is crlearly a typo that incorrectly changes area interpolation for linear. 
As the comment says area interpolation should be changed for linear in case of upscaling. 

Upscaling means increasing image size, i.e. fx = dst.width / src.width > 1 and fy = dst.height / src.height > 1. 

However, the next line does the opposing so area interpolation is inaccesable when it's needed.

edit:
Oops, found out that is reverse scale. Close this PR as it is wrong