### PR TITLE
core: fix build error when NAN is undeclared

### DIFF
--- a/modules/core/test/test_arithm.cpp
+++ b/modules/core/test/test_arithm.cpp
@@ -1902,6 +1902,11 @@ TEST(Normalize, regression_5876_inplace_change_type)
     EXPECT_EQ(0, cvtest::norm(m, result, NORM_INF));
 }
 
+#ifndef NAN
+#include <limits> // numeric_limits<T>::quiet_NaN()
+#define NAN std::numeric_limits<float>::quiet_NaN()
+#endif
+
 TEST(MinMaxLoc, regression_4955_nans)
 {
     cv::Mat one_mat(2, 2, CV_32F, cv::Scalar(1));

--- a/modules/core/test/test_arithm.cpp
+++ b/modules/core/test/test_arithm.cpp
@@ -1,4 +1,5 @@
 #include "test_precomp.hpp"
+#include <cmath>
 
 using namespace cv;
 using namespace std;
@@ -1901,11 +1902,6 @@ TEST(Normalize, regression_5876_inplace_change_type)
     normalize(m, m, 1, 0, NORM_MINMAX, CV_32F);
     EXPECT_EQ(0, cvtest::norm(m, result, NORM_INF));
 }
-
-#ifndef NAN
-#include <limits> // numeric_limits<T>::quiet_NaN()
-#define NAN std::numeric_limits<float>::quiet_NaN()
-#endif
 
 TEST(MinMaxLoc, regression_4955_nans)
 {


### PR DESCRIPTION
follow-up commit of #6904

### This pullrequest changes
  * NAN is not defined on some platform
  * I confirmed on Visual Studio 2012 Update 5 and finished by error ```NAN : undeclared identifier```
  * I'm happy to have a discussion of how to fix in a better way