### PR TITLE
highgui: window QT+OpenGL mouse wheel support, build fix

### DIFF
--- a/modules/highgui/src/window_QT.cpp
+++ b/modules/highgui/src/window_QT.cpp
@@ -2637,9 +2637,6 @@ void DefaultViewPort::wheelEvent(QWheelEvent* evnt)
     icvmouseHandler((QMouseEvent*)evnt, mouse_wheel, cv_event, flags);
     icvmouseProcessing(QPointF(pt), cv_event, flags);
 
-    scaleView(delta / 240.0, pt);
-    viewport()->update();
-
     QWidget::wheelEvent(evnt);
 }
 


### PR DESCRIPTION
Fix window_QT.cpp code with enabled OpenGL. Removed undefined methods calls.
https://github.com/opencv/opencv/pull/6966#issuecomment-234693374


resolves #6978