### PR TITLE
core: fix build error when NAN is undeclared

### DIFF
--- a/modules/core/test/test_arithm.cpp
+++ b/modules/core/test/test_arithm.cpp
@@ -1,5 +1,9 @@
 #include "test_precomp.hpp"
 #include <cmath>
+#ifndef NAN
+#include <limits> // numeric_limits<T>::quiet_NaN()
+#define NAN std::numeric_limits<float>::quiet_NaN()
+#endif
 
 using namespace cv;
 using namespace std;


### PR DESCRIPTION
<!-- Please use this line to close one or multiple issues when this pullrequest gets merged
You can add another line right under the first one:
resolves #1234
resolves #1235
-->

re-open of #6975 

### This pullrequest changes
  * NAN is not defined on some platform
  * I'm sorry to make a misleading in #6975 but commit 70dcd10 causes error on VS 2012
  * I was expecting the test to fail, but it seems it passed and then, merged