### PR TITLE
Non existent definition of _FPU_EXTENDED definition prevent compi…

### DIFF
--- a/modules/cudalegacy/test/TestHaarCascadeApplication.cpp
+++ b/modules/cudalegacy/test/TestHaarCascadeApplication.cpp
@@ -52,7 +52,8 @@ namespace
         ~FpuControl();
 
     private:
-    #if defined(__GNUC__) && !defined(__APPLE__) && !defined(__arm__) && !defined(__aarch64__)
+    #if defined(__GNUC__) && !defined(__APPLE__) && !defined(__arm__) &&
+        !defined(__aarch64__) && !defined(__powerpc64__)
         fpu_control_t fpu_oldcw, fpu_cw;
     #elif defined(_WIN32) && !defined(_WIN64)
         unsigned int fpu_oldcw, fpu_cw;
@@ -61,7 +62,8 @@ namespace
 
     FpuControl::FpuControl()
     {
-    #if defined(__GNUC__) && !defined(__APPLE__) && !defined(__arm__) && !defined(__aarch64__)
+    #if defined(__GNUC__) && !defined(__APPLE__) && !defined(__arm__) &&
+        !defined(__aarch64__) && !defined(__powerpc64__)
         _FPU_GETCW(fpu_oldcw);
         fpu_cw = (fpu_oldcw & ~_FPU_EXTENDED & ~_FPU_DOUBLE & ~_FPU_SINGLE) | _FPU_SINGLE;
         _FPU_SETCW(fpu_cw);
@@ -74,7 +76,8 @@ namespace
 
     FpuControl::~FpuControl()
     {
-    #if defined(__GNUC__) && !defined(__APPLE__) && !defined(__arm__) && !defined(__aarch64__)
+    #if defined(__GNUC__) && !defined(__APPLE__) && !defined(__arm__) &&
+        !defined(__aarch64__) && !defined(__powerpc64__)
         _FPU_SETCW(fpu_oldcw);
     #elif defined(_WIN32) && !defined(_WIN64)
         _controlfp_s(&fpu_cw, fpu_oldcw, _MCW_PC);

--- a/modules/cudalegacy/test/test_precomp.hpp
+++ b/modules/cudalegacy/test/test_precomp.hpp
@@ -51,7 +51,8 @@
 #ifndef __OPENCV_TEST_PRECOMP_HPP__
 #define __OPENCV_TEST_PRECOMP_HPP__
 
-#if defined(__GNUC__) && !defined(__APPLE__) && !defined(__arm__) && !defined(__aarch64__)
+#if defined(__GNUC__) && !defined(__APPLE__) && !defined(__arm__) &&
+    !defined(__aarch64__) && !defined(__powerpc64__)
     #include <fpu_control.h>
 #endif
 


### PR DESCRIPTION
### This pullrequest changes 
modules/cudalegacy/test/TestHaarCascadeApplication.cpp and 
modules/cudalegacy/test/test_precomp.hpp 
for powerpc64 platform where _FPU_EXTENDED doesn't exist as a definition in fpu_control.h. 
As such adding powerpc64 platform like apple and arm in the #ifdef