### PR TITLE
Make goodFeaturesToTrack() return deterministic results

### DIFF
--- a/modules/imgproc/src/featureselect.cpp
+++ b/modules/imgproc/src/featureselect.cpp
@@ -54,7 +54,8 @@ struct greaterThanPtr :
         public std::binary_function<const float *, const float *, bool>
 {
     bool operator () (const float * a, const float * b) const
-    { return *a > *b; }
+    // Ensure a fully deterministic result of the sort
+    { return (*a > *b) ? true : (*a < *b) ? false : (a > b); }
 };
 
 #ifdef HAVE_OPENCL
@@ -66,7 +67,8 @@ struct Corner
     short x;
 
     bool operator < (const Corner & c) const
-    {  return val > c.val; }
+    // Ensure a fully deterministic result of the sort
+    {  return (val > c.val) ? true : (val < c.val) ? false : (y > c.y) ? true : (y < c.y) ? false : (x > c.x); }
 };
 
 static bool ocl_goodFeaturesToTrack( InputArray _image, OutputArray _corners,


### PR DESCRIPTION
Fixes Issue 6988.

When using OCL, the results of goodFeaturesToTrack() vary slightly from run to run. This appears to be because the order of the results from
the findCorners kernel depends on thread execution and the sorting
function that is used at the end to rank the features only enforces are
partial sort order.

This does not materially impact the quality of the results, but it
makes it hard to build regression tests and generally introduces noise
into the system that should be avoided.

An easy fix is to change the sort function to enforce a total sort on
the features, even in cases where the match quality is exactly the same
for two features.