### PR TITLE
fix a bug in MergeDebevec (modify input times)

### DIFF
--- a/modules/photo/src/merge.cpp
+++ b/modules/photo/src/merge.cpp
@@ -85,7 +85,7 @@ public:
         CV_Assert(log_response.rows == LDR_SIZE && log_response.cols == 1 &&
                   log_response.channels() == channels);
 
-        Mat exp_values(times);
+        Mat exp_values(times.clone());
         log(exp_values, exp_values);
 
         result = Mat::zeros(size, CV_32FCC);


### PR DESCRIPTION
<!-- Please use this line to close one or multiple issues when this pullrequest gets merged
You can add another line right under the first one:
resolves #1234
resolves #1235
-->

### This pullrequest fixes a potential bug in the HDR imaging module (MergeDebevec).
Input times are modified when calling the `process` function, which can invalidate next results, for example, when testing different merging functions:

```
vector<Mat> images;
vector<float> times;
...
Ptr<MergeDebevec> merge_debevec = createMergeDebevec();
merge_debevec->process(images, hdrDebevec, times, responseDebevec);  // "times" is modified
Ptr<MergeRobertson> merge_robertson = createMergeRobertson();
merge_robertson->process(images, hdrRobertson, times, responseRobertson);  // incorrect times 
```

This PR fixes the problem by cloning times.


<!-- Please describe what your pullrequest is changing -->

