### PR TITLE
core: check FP16 feature correctly

### DIFF
--- a/modules/core/include/opencv2/core/cvdef.h
+++ b/modules/core/include/opencv2/core/cvdef.h
@@ -193,10 +193,6 @@ enum CpuFeatures {
 #    endif
 #    define CV_POPCNT 1
 #  endif
-#  if defined HAVE_FP16 && (defined __F16C__ || (defined _MSC_VER && _MSC_VER >= 1700))
-#    include <immintrin.h>
-#    define CV_FP16 1
-#  endif
 #  if defined __AVX__ || (defined _MSC_VER && _MSC_VER >= 1600 && 0)
 // MS Visual Studio 2010 (2012?) has no macro pre-defined to identify the use of /arch:AVX
 // See: http://connect.microsoft.com/VisualStudio/feedback/details/605858/arch-avx-should-define-a-predefined-macro-in-x64-and-set-a-unique-value-for-m-ix86-fp-in-win32
@@ -231,10 +227,6 @@ enum CpuFeatures {
 #  include <arm_neon.h>
 #endif
 
-#if defined HAVE_FP16 && defined __GNUC__
-#  define CV_FP16 1
-#endif
-
 #if defined __GNUC__ && defined __arm__ && (defined __ARM_PCS_VFP || defined __ARM_VFPV3__ || defined __ARM_NEON__) && !defined __SOFTFP__
 #  define CV_VFP 1
 #endif
@@ -264,9 +256,6 @@ enum CpuFeatures {
 #endif
 #ifndef CV_SSE4_2
 #  define CV_SSE4_2 0
-#endif
-#ifndef CV_FP16
-#  define CV_FP16 0
 #endif
 #ifndef CV_AVX
 #  define CV_AVX 0

--- a/modules/core/include/opencv2/core/private.hpp
+++ b/modules/core/include/opencv2/core/private.hpp
@@ -71,6 +71,17 @@
 #  endif
 #endif
 
+#if defined HAVE_FP16 && (defined __F16C__ || (defined _MSC_VER && _MSC_VER >= 1700))
+#  include <immintrin.h>
+#  define CV_FP16 1
+#elif defined HAVE_FP16 && defined __GNUC__
+#  define CV_FP16 1
+#endif
+
+#ifndef CV_FP16
+#  define CV_FP16 0
+#endif
+
 //! @cond IGNORED
 
 namespace cv

--- a/modules/core/src/convert.cpp
+++ b/modules/core/src/convert.cpp
@@ -4568,7 +4568,7 @@ cvtScaleHalf_<float, short>( const float* src, size_t sstep, short* dst, size_t 
     sstep /= sizeof(src[0]);
     dstep /= sizeof(dst[0]);
 
-    if( checkHardwareSupport(CV_FP16) )
+    if( checkHardwareSupport(CV_CPU_FP16) )
     {
         for( ; size.height--; src += sstep, dst += dstep )
         {
@@ -4622,7 +4622,7 @@ cvtScaleHalf_<short, float>( const short* src, size_t sstep, float* dst, size_t 
     sstep /= sizeof(src[0]);
     dstep /= sizeof(dst[0]);
 
-    if( checkHardwareSupport(CV_FP16) )
+    if( checkHardwareSupport(CV_CPU_FP16) )
     {
         for( ; size.height--; src += sstep, dst += dstep )
         {


### PR DESCRIPTION
### This pullrequest changes
  * activate HW FP16 feature
  * follow up commit of #6830 #6447 and #6942 
  * ```HAVE_FP16``` macro is very useful, but since [cvdef.h](https://github.com/opencv/opencv/blob/167a4e65929c830c2ed279f6215020fad937cc5b/modules/core/include/opencv2/core/cvdef.h#L196) is not including cvconfig.h, it always rely on SW implementation.