### PR TITLE
highgui: window QT+OpenGL mouse wheel support, another build fix

### DIFF
--- a/modules/highgui/src/window_QT.cpp
+++ b/modules/highgui/src/window_QT.cpp
@@ -3201,9 +3201,6 @@ void OpenGlViewPort::wheelEvent(QWheelEvent* evnt)
     icvmouseHandler((QMouseEvent*)evnt, mouse_wheel, cv_event, flags);
     icvmouseProcessing(QPointF(pt), cv_event, flags);
 
-    scaleView(delta / 240.0, pt);
-    viewport()->update();
-
     QWidget::wheelEvent(evnt);
 }
 


### PR DESCRIPTION
### This pullrequest fixes build with QT+OpenGl

Pull request #6976, which attempted to do the same thing, left out the corresponding changes in `OpenGlViewPort`.

