### PR TITLE
Fix crash on double-stop of CvVideoCamera

### DIFF
--- a/modules/videoio/src/cap_ios_video_camera.mm
+++ b/modules/videoio/src/cap_ios_video_camera.mm
@@ -100,6 +100,10 @@ static CGFloat DegreesToRadians(CGFloat degrees) {return degrees * M_PI / 180;}
 
 - (void)start;
 {
+    if (self.running == YES) {
+        return;
+    }
+
     recordingCountDown = 10;
     [super start];
 
@@ -118,6 +122,10 @@ static CGFloat DegreesToRadians(CGFloat degrees) {return degrees * M_PI / 180;}
 
 - (void)stop;
 {
+    if (self.running == NO) {
+        return;
+    }
+
     [super stop];
 
     self.videoDataOutput = nil;


### PR DESCRIPTION
### Fix a crash when [CvVideoCamera stop] is called twice

Currently calling `[CvVideoCamear stop]` twice will cause a crash from `_os_object_release`.

This patch ensures `CvVideoCamera` will handle multiple calls to `start` and `stop` sensibly.

