### PR TITLE
Update bagofwords.cpp

### DIFF
--- a/modules/features2d/src/bagofwords.cpp
+++ b/modules/features2d/src/bagofwords.cpp
@@ -91,11 +91,7 @@ Mat BOWKMeansTrainer::cluster() const
 {
     CV_Assert( !descriptors.empty() );
 
-    int descCount = 0;
-    for( size_t i = 0; i < descriptors.size(); i++ )
-        descCount += descriptors[i].rows;
-
-    Mat mergedDescriptors( descCount, descriptors[0].cols, descriptors[0].type() );
+    Mat mergedDescriptors( descriptorsCount(), descriptors[0].cols, descriptors[0].type() );
     for( size_t i = 0, start = 0; i < descriptors.size(); i++ )
     {
         Mat submut = mergedDescriptors.rowRange((int)start, (int)(start + descriptors[i].rows));


### PR DESCRIPTION
Unnecessary for loop in `BOWKMeansTrainer::cluster()` method for calculate descriptors count, because that value has accumulated in size during previous `BOWTrainer::add()` calls, and is available through of BOWTrainer::descriptorsCount() 

https://github.com/opencv/opencv/commit/ba5f9d68c4f5000400190684bb86eda8a2d41bed