### PR TITLE
fix including of correct header files #7027

### DIFF
--- a/include/opencv2/opencv.hpp
+++ b/include/opencv2/opencv.hpp
@@ -43,38 +43,99 @@
 #ifndef __OPENCV_ALL_HPP__
 #define __OPENCV_ALL_HPP__
 
+// File that defines what modules where included during the build of OpenCV
+// These are purely the defines of the correct HAVE_OPENCV_modulename values
 #include "opencv2/opencv_modules.hpp"
 
+// Then the list of defines is checked to include the correct headers
+// Core library is always included --> without no OpenCV functionality available
 #include "opencv2/core.hpp"
-#ifdef HAVE_OPENCV_IMGPROC
-#include "opencv2/imgproc.hpp"
+
+// Then the optional modules are checked
+// REMARK: keep the includes ordened as the module order on the GitHub repo
+#ifdef HAVE_OPENCV_CALIB3D
+#include "opencv2/calib3d.hpp"
 #endif
-#ifdef HAVE_OPENCV_PHOTO
-#include "opencv2/photo.hpp"
+#ifdef HAVE_OPENCV_CUDAARITHM
+#include "opencv2/cudaarithm.hpp"
 #endif
-#ifdef HAVE_OPENCV_VIDEO
-#include "opencv2/video.hpp"
+#ifdef HAVE_OPENCV_CUDABGSEGM
+#include "opencv2/cudabgsegm.hpp"
+#endif
+#ifdef HAVE_OPENCV_CUDACODEC
+#include "opencv2/cudacodec.hpp"
+#endif
+#ifdef HAVE_OPENCV_CUDAFEATURES2D
+#include "opencv2/cudafeatures2d.hpp"
+#endif
+#ifdef HAVE_OPENCV_CUDAFILTERS
+#include "opencv2/cudafilters.hpp"
+#endif
+#ifdef HAVE_OPENCV_CUDAIMGPROC
+#include "opencv2/cudaimgproc.hpp"
+#endif
+#ifdef HAVE_OPENCV_CUDALEGACY
+#include "opencv2/cudalegacy.hpp"
+#endif
+#ifdef HAVE_OPENCV_CUDAOBJDETECT
+#include "opencv2/cudaobjdetect.hpp"
+#endif
+#ifdef HAVE_OPENCV_CUDAOPTFLOW
+#include "opencv2/cudaoptflow.hpp"
+#endif
+#ifdef HAVE_OPENCV_CUDASTEREO
+#include "opencv2/cudastereo.hpp"
+#endif
+#ifdef HAVE_OPENCV_CUDAWARPING
+#include "opencv2/cudawarping.hpp"
+#endif
+#ifdef HAVE_OPENCV_CUDEV
+#include "opencv2/cudev.hpp"
 #endif
 #ifdef HAVE_OPENCV_FEATURES2D
 #include "opencv2/features2d.hpp"
 #endif
-#ifdef HAVE_OPENCV_OBJDETECT
-#include "opencv2/objdetect.hpp"
-#endif
-#ifdef HAVE_OPENCV_CALIB3D
-#include "opencv2/calib3d.hpp"
-#endif
-#ifdef HAVE_OPENCV_IMGCODECS
-#include "opencv2/imgcodecs.hpp"
-#endif
-#ifdef HAVE_OPENCV_VIDEOIO
-#include "opencv2/videoio.hpp"
+#ifdef HAVE_OPENCV_FLANN
+#include "opencv2/flann.hpp"
 #endif
 #ifdef HAVE_OPENCV_HIGHGUI
 #include "opencv2/highgui.hpp"
 #endif
+#ifdef HAVE_OPENCV_IMGCODECS
+#include "opencv2/imgcodecs.hpp"
+#endif
+#ifdef HAVE_OPENCV_IMGPROC
+#include "opencv2/imgproc.hpp"
+#endif
 #ifdef HAVE_OPENCV_ML
 #include "opencv2/ml.hpp"
+#endif
+#ifdef HAVE_OPENCV_OBJDETECT
+#include "opencv2/objdetect.hpp"
+#endif
+#ifdef HAVE_OPENCV_PHOTO
+#include "opencv2/photo.hpp"
+#endif
+#ifdef HAVE_OPENCV_SHAPE
+#include "opencv2/shape.hpp"
+#endif
+#ifdef HAVE_OPENCV_STITCHING
+#include "opencv2/stitching.hpp"
+#endif
+#ifdef HAVE_OPENCV_SUPERRES
+#include "opencv2/superres.hpp"
+#endif
+#ifdef HAVE_OPENCV_VIDEO
+#include "opencv2/video.hpp"
+#endif
+#ifdef HAVE_OPENCV_VIDEOIO
+#include "opencv2/videoio.hpp"
+#endif
+#ifdef HAVE_OPENCV_VIDEOSTAB
+#include "opencv2/videostab.hpp"
+#endif
+#ifdef HAVE_OPENCV_VIZ
+#include "opencv2/viz.hpp"
 #endif
 
 #endif


### PR DESCRIPTION
resolves #7027

### This pullrequest changes

the including of modules in the opencv main repository. Through `opencv_modules.hpp`, which is automatically generated using CMAKE, the included modules are defined. Then they are correctly checked, in the module order of the GitHub repo, and headers are added if needed.

This solves the issue that `include "opencv2/opencv.hpp"` did not include all available and build modules as it should do.

