### PR TITLE
compile warning fix for Xcode; small fix in TrainData::loadFromCSV()

### DIFF
--- a/modules/ml/src/data.cpp
+++ b/modules/ml/src/data.cpp
@@ -747,9 +747,6 @@ public:
                     }
                 }
                 while(*stopstring != ']');
-
-                if( stopstring[1] != '\0' && stopstring[1] != ',')
-                    CV_Error( CV_StsBadArg, errmsg );
             }
         }
 

--- a/modules/ts/include/opencv2/ts/ts_perf.hpp
+++ b/modules/ts/include/opencv2/ts/ts_perf.hpp
@@ -371,8 +371,8 @@ public:
 
     class PerfSkipTestException: public cv::Exception
     {
-        int dummy; // workaround for MacOSX Xcode 7.3 bug (don't make class "empty")
     public:
+        int dummy; // workaround for MacOSX Xcode 7.3 bug (don't make class "empty")
         PerfSkipTestException() : dummy(0) {}
     };
 


### PR DESCRIPTION
1. fix warning from Xcode 7.x

2. fixed parsing of "cat[range_spec]ord[range_spec]" type specification string when using ml::TrainData::loadFromCSV(). Thanks to A. Kaehler for reporting it