### PR TITLE
Cleaner fix for crash on double-stop of CvVideoCamera

### DIFF
--- a/modules/videoio/src/cap_ios_abstract_camera.mm
+++ b/modules/videoio/src/cap_ios_abstract_camera.mm
@@ -193,16 +193,19 @@
 
     // Release any retained subviews of the main view.
     // e.g. self.myOutlet = nil;
-    for (AVCaptureInput *input in self.captureSession.inputs) {
-        [self.captureSession removeInput:input];
+    if (self.captureSession) {
+        for (AVCaptureInput *input in self.captureSession.inputs) {
+            [self.captureSession removeInput:input];
+        }
+
+        for (AVCaptureOutput *output in self.captureSession.outputs) {
+            [self.captureSession removeOutput:output];
+        }
+
+        [self.captureSession stopRunning];
+        self.captureSession = nil;
     }
 
-    for (AVCaptureOutput *output in self.captureSession.outputs) {
-        [self.captureSession removeOutput:output];
-    }
-
-    [self.captureSession stopRunning];
-    self.captureSession = nil;
     self.captureVideoPreviewLayer = nil;
     self.videoCaptureConnection = nil;
     captureSessionLoaded = NO;

--- a/modules/videoio/src/cap_ios_video_camera.mm
+++ b/modules/videoio/src/cap_ios_video_camera.mm
@@ -122,10 +122,6 @@ static CGFloat DegreesToRadians(CGFloat degrees) {return degrees * M_PI / 180;}
 
 - (void)stop;
 {
-    if (self.running == NO) {
-        return;
-    }
-
     [super stop];
 
     self.videoDataOutput = nil;
@@ -134,21 +130,24 @@ static CGFloat DegreesToRadians(CGFloat degrees) {return degrees * M_PI / 180;}
     }
 
     if (self.recordVideo == YES) {
-
-        if (self.recordAssetWriter.status == AVAssetWriterStatusWriting) {
-            [self.recordAssetWriter finishWriting];
-            NSLog(@"[Camera] recording stopped");
-        } else {
-            NSLog(@"[Camera] Recording Error: asset writer status is not writing");
+        if (self.recordAssetWriter) {
+            if (self.recordAssetWriter.status == AVAssetWriterStatusWriting) {
+                [self.recordAssetWriter finishWriting];
+                NSLog(@"[Camera] recording stopped");
+            } else {
+                NSLog(@"[Camera] Recording Error: asset writer status is not writing");
+            }
+            self.recordAssetWriter = nil;
         }
 
-        self.recordAssetWriter = nil;
         self.recordAssetWriterInput = nil;
         self.recordPixelBufferAdaptor = nil;
     }
 
-    [self.customPreviewLayer removeFromSuperlayer];
-    self.customPreviewLayer = nil;
+    if (self.customPreviewLayer) {
+        [self.customPreviewLayer removeFromSuperlayer];
+        self.customPreviewLayer = nil;
+    }
 }
 
 // TODO fix


### PR DESCRIPTION
Update #7029 so resources will be freed if `stop` is called after `pause`.

