### PR TITLE
python docs: fix missing output image in cv2.drawKeypoint examples

### DIFF
--- a/doc/py_tutorials/py_feature2d/py_fast/py_fast.markdown
+++ b/doc/py_tutorials/py_feature2d/py_fast/py_fast.markdown
@@ -105,7 +105,7 @@ fast = cv2.FastFeatureDetector_create()
 
 # find and draw the keypoints
 kp = fast.detect(img,None)
-img2 = cv2.drawKeypoints(img, kp, color=(255,0,0))
+img2 = cv2.drawKeypoints(img, kp, None, color=(255,0,0))
 
 # Print all default params
 print "Threshold: ", fast.getInt('threshold')
@@ -121,7 +121,7 @@ kp = fast.detect(img,None)
 
 print "Total Keypoints without nonmaxSuppression: ", len(kp)
 
-img3 = cv2.drawKeypoints(img, kp, color=(255,0,0))
+img3 = cv2.drawKeypoints(img, kp, None, color=(255,0,0))
 
 cv2.imwrite('fast_false.png',img3)
 @endcode

--- a/doc/py_tutorials/py_feature2d/py_orb/py_orb.markdown
+++ b/doc/py_tutorials/py_feature2d/py_orb/py_orb.markdown
@@ -79,8 +79,8 @@ kp = orb.detect(img,None)
 kp, des = orb.compute(img, kp)
 
 # draw only keypoints location,not size and orientation
-img2 = cv2.drawKeypoints(img,kp,color=(0,255,0), flags=0)
-plt.imshow(img2),plt.show()
+img2 = cv2.drawKeypoints(img, kp, None, color=(0,255,0), flags=0)
+plt.imshow(img2), plt.show()
 @endcode
 See the result below:
 

--- a/doc/py_tutorials/py_feature2d/py_sift_intro/py_sift_intro.markdown
+++ b/doc/py_tutorials/py_feature2d/py_sift_intro/py_sift_intro.markdown
@@ -122,7 +122,7 @@ gray= cv2.cvtColor(img,cv2.COLOR_BGR2GRAY)
 sift = cv2.xfeatures2d.SIFT_create()
 kp = sift.detect(gray,None)
 
-img=cv2.drawKeypoints(gray,kp)
+img=cv2.drawKeypoints(gray,kp,img)
 
 cv2.imwrite('sift_keypoints.jpg',img)
 @endcode
@@ -135,7 +135,7 @@ OpenCV also provides **cv2.drawKeyPoints()** function which draws the small circ
 of keypoints. If you pass a flag, **cv2.DRAW_MATCHES_FLAGS_DRAW_RICH_KEYPOINTS** to it, it will
 draw a circle with size of keypoint and it will even show its orientation. See below example.
 @code{.py}
-img=cv2.drawKeypoints(gray,kp,flags=cv2.DRAW_MATCHES_FLAGS_DRAW_RICH_KEYPOINTS)
+img=cv2.drawKeypoints(gray,kp,img,flags=cv2.DRAW_MATCHES_FLAGS_DRAW_RICH_KEYPOINTS)
 cv2.imwrite('sift_keypoints.jpg',img)
 @endcode
 See the two results below:


### PR DESCRIPTION
resolves #6487 

unlike 2.4, the ouput image is required now. if a color image is available, use that, None otherwise.
