### PR TITLE
improve LKTrackerInvoker::operator()

### DIFF
--- a/modules/video/src/lkpyramid.cpp
+++ b/modules/video/src/lkpyramid.cpp
@@ -567,18 +567,14 @@ void cv::detail::LKTrackerInvoker::operator()(const Range& range) const
                     diff0 = _mm_unpacklo_epi16(diff0, diff0); // It0 It0 It1 It1 ...
                     v00 = _mm_loadu_si128((const __m128i*)(dIptr)); // Ix0 Iy0 Ix1 Iy1 ...
                     v01 = _mm_loadu_si128((const __m128i*)(dIptr + 8));
-                    v10 = _mm_mullo_epi16(v00, diff0);
-                    v11 = _mm_mulhi_epi16(v00, diff0);
-                    v00 = _mm_unpacklo_epi16(v10, v11);
-                    v10 = _mm_unpackhi_epi16(v10, v11);
+                    v10 = _mm_unpacklo_epi16(v00, v01);
+                    v11 = _mm_unpackhi_epi16(v00, v01);
+                    v00 = _mm_unpacklo_epi16(diff0, diff1);
+                    v01 = _mm_unpackhi_epi16(diff0, diff1);
+                    v00 = _mm_madd_epi16(v00, v10);
+                    v11 = _mm_madd_epi16(v01, v11);
                     qb0 = _mm_add_ps(qb0, _mm_cvtepi32_ps(v00));
-                    qb1 = _mm_add_ps(qb1, _mm_cvtepi32_ps(v10));
-                    v10 = _mm_mullo_epi16(v01, diff1);
-                    v11 = _mm_mulhi_epi16(v01, diff1);
-                    v00 = _mm_unpacklo_epi16(v10, v11);
-                    v10 = _mm_unpackhi_epi16(v10, v11);
-                    qb0 = _mm_add_ps(qb0, _mm_cvtepi32_ps(v00));
-                    qb1 = _mm_add_ps(qb1, _mm_cvtepi32_ps(v10));
+                    qb1 = _mm_add_ps(qb1, _mm_cvtepi32_ps(v11));
                 }
 #endif
 


### PR DESCRIPTION
I eliminate wasted '_mm_mullo_epi16()' and '_mm_mulhi_epi16()'.

<table border=1>
 <tr><th>range.end - range.start</th><th>winSize.height x winSize.width</th><th>Average Clocks (original code)</th><th>Average Clocks (new code)</th><th>Faster Rate (compared with original code)</th></tr>
 <tr><td>1</td><td>16</td><td>363.0</td><td>338.4</td><td>7.3%</td></tr>
 <tr><td>1</td><td>32</td><td>9152.4</td><td>8647.0</td><td>5.8%</td></tr>
 <tr><td>2</td><td>16</td><td>17263.4</td><td>16412.2</td><td>5.2%</td></tr>
 <tr><td>2</td><td>32</td><td>38845.6</td><td>37352.0</td><td>4.0%</td></tr>
 <tr><td>4</td><td>16</td><td>32288.8</td><td>31350.0</td><td>3.0%</td></tr>
 <tr><td>4</td><td>32</td><td>98957.4</td><td>95435.2</td><td>3.7%</td></tr>
</table>

Measurement Conditions
OS : Ubuntu 16.04
Compiler : g++ (Ubuntu 5.3.1-13ubuntu3) 5.3.1 20160330
CPU : Intel(R) Core(TM)2 Duo CPU E8500 @ 3.16GHz
Compiler Option : -msse2 -mssse3 -msse4.1 -O3
Measurement Function: rdtsc()


