### PR TITLE
Fix typo bug in cvProjectPoints2 for 2.4 branch.

### DIFF
--- a/modules/calib3d/src/calibration.cpp
+++ b/modules/calib3d/src/calibration.cpp
@@ -1078,9 +1078,9 @@ CV_IMPL void cvProjectPoints2( const CvMat* objectPoints,
                     double dicdist2_dt = -icdist2*icdist2*(k[5]*dr2dt + 2*k[6]*r2*dr2dt + 3*k[7]*r4*dr2dt);
                     double da1dt = 2*(x*dydt[j] + y*dxdt[j]);
                     double dmxdt = fx*(dxdt[j]*cdist*icdist2 + x*dcdist_dt*icdist2 + x*cdist*dicdist2_dt +
-                                       k[2]*da1dt + k[3]*(dr2dt + 2*x*dxdt[j]));
+                                       k[2]*da1dt + k[3]*(dr2dt + 4*x*dxdt[j]));
                     double dmydt = fy*(dydt[j]*cdist*icdist2 + y*dcdist_dt*icdist2 + y*cdist*dicdist2_dt +
-                                       k[2]*(dr2dt + 2*y*dydt[j]) + k[3]*da1dt);
+                                       k[2]*(dr2dt + 4*y*dydt[j]) + k[3]*da1dt);
                     dpdt_p[j] = dmxdt;
                     dpdt_p[dpdt_step+j] = dmydt;
                 }
@@ -1116,9 +1116,9 @@ CV_IMPL void cvProjectPoints2( const CvMat* objectPoints,
                     double dicdist2_dr = -icdist2*icdist2*(k[5]*dr2dr + 2*k[6]*r2*dr2dr + 3*k[7]*r4*dr2dr);
                     double da1dr = 2*(x*dydr + y*dxdr);
                     double dmxdr = fx*(dxdr*cdist*icdist2 + x*dcdist_dr*icdist2 + x*cdist*dicdist2_dr +
-                                       k[2]*da1dr + k[3]*(dr2dr + 2*x*dxdr));
+                                       k[2]*da1dr + k[3]*(dr2dr + 4*x*dxdr));
                     double dmydr = fy*(dydr*cdist*icdist2 + y*dcdist_dr*icdist2 + y*cdist*dicdist2_dr +
-                                       k[2]*(dr2dr + 2*y*dydr) + k[3]*da1dr);
+                                       k[2]*(dr2dr + 4*y*dydr) + k[3]*da1dr);
                     dpdr_p[j] = dmxdr;
                     dpdr_p[dpdr_step+j] = dmydr;
                 }


### PR DESCRIPTION
<!-- Please use this line to close one or multiple issues when this pullrequest gets merged
You can add another line right under the first one:
resolves #1234
resolves #1235
-->
Resolves #6921 

### This pullrequest fixes

<!-- Please describe what your pullrequest is changing -->

some typo bugs in the calculation of some derivatives (dmxdt, dmydt, dmxdr, dmydr) in cvProjectPoints2 function for the 2.4 branch.

Quick and simple comparison between the previous and the correct version using the calibration sample and the `left*.jpg` and `right*.jpg` image samples.

Left images, NOK:
```
image_width: 640
image_height: 480
board_width: 9
board_height: 6
square_size: 1.
flags: 0
camera_matrix: !!opencv-matrix
   rows: 3
   cols: 3
   dt: d
   data: [ 5.3587498963333883e+02, 0., 3.4227227423970436e+02, 0.,
       5.3583178327211658e+02, 2.3553678108793176e+02, 0., 0., 1. ]
distortion_coefficients: !!opencv-matrix
   rows: 5
   cols: 1
   dt: d
   data: [ -2.6623602055300505e-01, -3.9595039971096049e-02,
       1.7947849463309442e-03, -2.9420531086738800e-04,
       2.3992825059021328e-01 ]
avg_reprojection_error: 3.9228558873654706e-01
```

Left images, OK:
```
image_width: 640
image_height: 480
board_width: 9
board_height: 6
square_size: 1.
flags: 0
camera_matrix: !!opencv-matrix
   rows: 3
   cols: 3
   dt: d
   data: [ 5.3587802270685938e+02, 0., 3.4227255772111226e+02, 0.,
       5.3583454950863336e+02, 2.3553003733180523e+02, 0., 0., 1. ]
distortion_coefficients: !!opencv-matrix
   rows: 5
   cols: 1
   dt: d
   data: [ -2.6624509189394469e-01, -3.9512422422126742e-02,
       1.7945331509809884e-03, -2.9439386325367704e-04,
       2.3975438216860628e-01 ]
avg_reprojection_error: 3.9228557734638947e-01
```

Right images, NOK:
```
image_width: 640
image_height: 480
board_width: 9
board_height: 6
square_size: 1.
flags: 0
camera_matrix: !!opencv-matrix
   rows: 3
   cols: 3
   dt: d
   data: [ 5.4211330070507688e+02, 0., 3.2836976808487481e+02, 0.,
       5.4138068607188666e+02, 2.4704051570871658e+02, 0., 0., 1. ]
distortion_coefficients: !!opencv-matrix
   rows: 5
   cols: 1
   dt: d
   data: [ -2.8158519085530337e-01, 1.0798030417595533e-01,
       -5.5690346433308476e-04, 1.2602739244433842e-03,
       -2.7920666373137920e-02 ]
avg_reprojection_error: 4.4545272993464352e-01
```

Right images, OK:
```
image_width: 640
image_height: 480
board_width: 9
board_height: 6
square_size: 1.
flags: 0
camera_matrix: !!opencv-matrix
   rows: 3
   cols: 3
   dt: d
   data: [ 5.4212379057410556e+02, 0., 3.2836790378774890e+02, 0.,
       5.4139107581480357e+02, 2.4703840367279460e+02, 0., 0., 1. ]
distortion_coefficients: !!opencv-matrix
   rows: 5
   cols: 1
   dt: d
   data: [ -2.8159281640107015e-01, 1.0800253989325134e-01,
       -5.5736073816777887e-04, 1.2606750188270956e-03,
       -2.7948326302958900e-02 ]
avg_reprojection_error: 4.4545278565551827e-01
```

For the left images, the average reprojection error is slightly lower with the correct version but it is the opposite with the right images.

In both cases, the calibration sample outputs:
(left)
```
RMS error reported by calibrateCamera: 0.392286
Calibration succeeded. avg reprojection error = 0.39
```
(right)
```
RMS error reported by calibrateCamera: 0.445453
Calibration succeeded. avg reprojection error = 0.45
```
