### PR TITLE
Fix for MSER::detectRegions crash

### DIFF
--- a/modules/features2d/include/opencv2/features2d.hpp
+++ b/modules/features2d/include/opencv2/features2d.hpp
@@ -355,7 +355,7 @@ public:
 
     /** @brief Detect %MSER regions
 
-    @param image input image (8UC1, 8UC3 or 8UC4)
+    @param image input image (8UC1, 8UC3 or 8UC4, must be greater or equal than 3x3)
     @param msers resulting list of point sets
     @param bboxes resulting bounding boxes
     */

--- a/modules/features2d/src/mser.cpp
+++ b/modules/features2d/src/mser.cpp
@@ -1020,12 +1020,11 @@ extractMSER_8uC3( const Mat& src,
 void MSER_Impl::detectRegions( InputArray _src, vector<vector<Point> >& msers, vector<Rect>& bboxes )
 {
     Mat src = _src.getMat();
-    size_t npix = src.total();
 
     msers.clear();
     bboxes.clear();
 
-    if( npix == 0 )
+    if( src.rows < 3 || src.cols < 3 )
         return;
 
     Size size = src.size();

--- a/modules/features2d/src/mser.cpp
+++ b/modules/features2d/src/mser.cpp
@@ -1025,7 +1025,7 @@ void MSER_Impl::detectRegions( InputArray _src, vector<vector<Point> >& msers, v
     bboxes.clear();
 
     if( src.rows < 3 || src.cols < 3 )
-        return;
+        CV_Error(Error::StsBadArg, "Input image is too small. Expected at least 3x3");
 
     Size size = src.size();
 


### PR DESCRIPTION
resolves #6686
resolves #5705

### This pullrequest changes

MSER restricted to process small size images(width or height lesser than 3)