### PR TITLE
Fix temporary file removal in imdecode for tiff

### DIFF
--- a/modules/imgcodecs/src/loadsave.cpp
+++ b/modules/imgcodecs/src/loadsave.cpp
@@ -514,8 +514,14 @@ imdecode_( const Mat& buf, int flags, int hdrtype, Mat* mat=0 )
 
     if( !decoder->readHeader() )
     {
-        if( !filename.empty() )
-            remove(filename.c_str());
+        decoder.release();
+        if ( !filename.empty() )
+        {
+            if ( remove(filename.c_str()) != 0 )
+            {
+                CV_Error( CV_StsError, "unable to remove temporary file" );
+            }
+        }
         return 0;
     }
 
@@ -556,8 +562,14 @@ imdecode_( const Mat& buf, int flags, int hdrtype, Mat* mat=0 )
     }
 
     bool code = decoder->readData( *data );
-    if( !filename.empty() )
-        remove(filename.c_str());
+    decoder.release();
+    if ( !filename.empty() )
+    {
+        if ( remove(filename.c_str()) != 0 )
+        {
+            CV_Error( CV_StsError, "unable to remove temporary file" );
+        }
+    }
 
     if( !code )
     {

--- a/modules/imgcodecs/test/test_grfmt.cpp
+++ b/modules/imgcodecs/test/test_grfmt.cpp
@@ -890,6 +890,19 @@ TEST(Imgcodecs_Tiff, decode_multipage)
     CV_GrfmtReadTifMultiPage test; test.safe_run();
 }
 
+TEST(Imgcodecs_Tiff, imdecode_no_exception_temporary_file_removed)
+{
+    cvtest::TS& ts = *cvtest::TS::ptr();
+    string input = string(ts.get_data_path()) + "../cv/shared/lena.png";
+    cv::Mat img = cv::imread(input);
+    ASSERT_FALSE(img.empty());
+
+    std::vector<uchar> buf;
+    EXPECT_NO_THROW(cv::imencode(".tiff", img, buf));
+
+    EXPECT_NO_THROW(cv::imdecode(buf, IMREAD_UNCHANGED));
+}
+
 #endif
 
 #ifdef HAVE_WEBP


### PR DESCRIPTION
<!-- Please use this line to close one or multiple issues when this pullrequest gets merged
You can add another line right under the first one:
resolves #1234
resolves #1235
-->
resolves #7116

### This pullrequest changes

<!-- Please describe what your pullrequest is changing -->

The `TiffDecoder` keeps an open file handle. As a consequence the file cannot be removed before the `TiffDecoder` closes the file.
This change makes sure the decoder is destructed and thus the file is closed.
Moreover, an error is generated if the call to `remove` fails. In the test case it is asserted that no error occurs in the call to `imdecode`.