### PR TITLE
handle images with alpha better

### DIFF
--- a/modules/imgcodecs/src/ios_conversions.mm
+++ b/modules/imgcodecs/src/ios_conversions.mm
@@ -106,6 +106,8 @@ void UIImageToMat(const UIImage* image,
         bitmapInfo = kCGImageAlphaNone;
         if (!alphaExist)
             bitmapInfo = kCGImageAlphaNone;
+        else
+            m = cv::Scalar(0);
         contextRef = CGBitmapContextCreate(m.data, m.cols, m.rows, 8,
                                            m.step[0], colorSpace,
                                            bitmapInfo);
@@ -116,6 +118,8 @@ void UIImageToMat(const UIImage* image,
         if (!alphaExist)
             bitmapInfo = kCGImageAlphaNoneSkipLast |
                                 kCGBitmapByteOrderDefault;
+        else
+            m = cv::Scalar(0);
         contextRef = CGBitmapContextCreate(m.data, m.cols, m.rows, 8,
                                            m.step[0], colorSpace,
                                            bitmapInfo);


### PR DESCRIPTION
resolves #7121 

### This pullrequest changes
initializes the Mat before drawing a UIImage with an alpha channel onto it.

UIImages with alpha were ending up with garbage pixels in background (random memory values).  Need to initialize matrix pixels before drawing UIImage with alpha on it.

Note: didn’t fix Grayscale image with alpha stripping alpha in UIImage -> Mat conversion. Couldn't get that working; may be that CGBitmapContext doesn't support a Gray + Alpha two-channel configuration.