### PR TITLE
ocl: fix accuracy of RGB2HLS kernel on Intel device

### DIFF
--- a/modules/imgproc/src/opencl/cvtcolor.cl
+++ b/modules/imgproc/src/opencl/cvtcolor.cl
@@ -1326,7 +1326,7 @@ __kernel void RGB2HLS(__global const uchar* src, int src_step, int src_offset,
                     else
                         h = fma(r - g, diff, 240.f);
 
-                    if( h < 0.f )
+                    if( h <= -0.5f*hscale )
                         h += 360.f;
                 }
 


### PR DESCRIPTION
Affected device:
iGPU: Intel(R) HD Graphics 520 (OpenCL 2.0 )