### PR TITLE
Fix enum for stitching which was colliding with X11 macro

### DIFF
--- a/modules/stitching/include/opencv2/stitching.hpp
+++ b/modules/stitching/include/opencv2/stitching.hpp
@@ -97,7 +97,7 @@ class CV_EXPORTS_W Stitcher
 {
 public:
     enum { ORIG_RESOL = -1 };
-    enum Status
+    enum status
     {
         OK = 0,
         ERR_NEED_MORE_IMGS = 1,


### PR DESCRIPTION
resolves #7113