### PR TITLE
Fix Windows build for Win2000 SDKs

### DIFF
--- a/modules/core/src/parallel.cpp
+++ b/modules/core/src/parallel.cpp
@@ -521,7 +521,7 @@ int cv::getNumberOfCPUs(void)
 {
 #if defined WIN32 || defined _WIN32
     SYSTEM_INFO sysinfo;
-#if defined(_M_ARM) || defined(_M_X64) || defined(WINRT)
+#if (defined(_M_ARM) || defined(_M_X64) || defined(WINRT)) && _WIN32_WINNT >= 0x501
     GetNativeSystemInfo( &sysinfo );
 #else
     GetSystemInfo( &sysinfo );

--- a/modules/highgui/src/precomp.hpp
+++ b/modules/highgui/src/precomp.hpp
@@ -61,14 +61,6 @@
 #include <assert.h>
 
 #if defined WIN32 || defined WINCE
-    #if !defined _WIN32_WINNT
-        #ifdef HAVE_MSMF
-            #define _WIN32_WINNT 0x0600 // Windows Vista
-        #else
-            #define _WIN32_WINNT 0x0500 // Windows 2000
-        #endif
-    #endif
-
     #include <windows.h>
     #undef small
     #undef min

--- a/modules/imgcodecs/src/precomp.hpp
+++ b/modules/imgcodecs/src/precomp.hpp
@@ -59,14 +59,6 @@
 #include <assert.h>
 
 #if defined WIN32 || defined WINCE
-    #if !defined _WIN32_WINNT
-        #ifdef HAVE_MSMF
-            #define _WIN32_WINNT 0x0600 // Windows Vista
-        #else
-            #define _WIN32_WINNT 0x0500 // Windows 2000
-        #endif
-    #endif
-
     #include <windows.h>
     #undef small
     #undef min

--- a/modules/videoio/src/cap_ffmpeg.cpp
+++ b/modules/videoio/src/cap_ffmpeg.cpp
@@ -65,9 +65,11 @@ static cv::Mutex _icvInitFFMPEG_mutex;
 static const HMODULE cv_GetCurrentModule()
 {
     HMODULE h = 0;
+#if _WIN32_WINNT >= 0x0501
     ::GetModuleHandleEx(GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS | GET_MODULE_HANDLE_EX_FLAG_UNCHANGED_REFCOUNT,
         reinterpret_cast<LPCTSTR>(cv_GetCurrentModule),
         &h);
+#endif
     return h;
 }
 #endif
@@ -98,22 +100,16 @@ private:
     icvInitFFMPEG()
     {
     #if defined WIN32 || defined _WIN32
+        const wchar_t* module_name_ = L"opencv_ffmpeg"
+            CVAUX_STRW(CV_MAJOR_VERSION) CVAUX_STRW(CV_MINOR_VERSION) CVAUX_STRW(CV_SUBMINOR_VERSION)
+        #if (defined _MSC_VER && defined _M_X64) || (defined __GNUC__ && defined __x86_64__)
+            L"_64"
+        #endif
+            L".dll";
     # ifdef WINRT
-        const wchar_t* module_name = L"opencv_ffmpeg"
-            CVAUX_STRW(CV_MAJOR_VERSION) CVAUX_STRW(CV_MINOR_VERSION) CVAUX_STRW(CV_SUBMINOR_VERSION)
-        #if (defined _MSC_VER && defined _M_X64) || (defined __GNUC__ && defined __x86_64__)
-            L"_64"
-        #endif
-            L".dll";
-
-        icvFFOpenCV = LoadPackagedLibrary( module_name, 0 );
+        icvFFOpenCV = LoadPackagedLibrary( module_name_, 0 );
     # else
-        const std::wstring module_name = L"opencv_ffmpeg"
-            CVAUX_STRW(CV_MAJOR_VERSION) CVAUX_STRW(CV_MINOR_VERSION) CVAUX_STRW(CV_SUBMINOR_VERSION)
-        #if (defined _MSC_VER && defined _M_X64) || (defined __GNUC__ && defined __x86_64__)
-            L"_64"
-        #endif
-            L".dll";
+        const std::wstring module_name(module_name_);
 
         const wchar_t* ffmpeg_env_path = _wgetenv(L"OPENCV_FFMPEG_DLL_DIR");
         std::wstring module_path =

--- a/modules/videoio/src/precomp.hpp
+++ b/modules/videoio/src/precomp.hpp
@@ -66,7 +66,7 @@
         #ifdef HAVE_MSMF
             #define _WIN32_WINNT 0x0600 // Windows Vista
         #else
-            #define _WIN32_WINNT 0x0500 // Windows 2000
+            #define _WIN32_WINNT 0x0501 // Windows XP
         #endif
     #endif
 


### PR DESCRIPTION
Resolves #7143

Default WINNT macro value is changed from Win2k to WinXP.

Returning to Win2k value is possible via this CMake option:
```
    cmake -DOPENCV_EXTRA_FLAGS="/D_WIN32_WINNT=0x0500" ...
```