### PR TITLE
Unifies Obj-C property attributes changing retain to strong

### DIFF
--- a/modules/videoio/include/opencv2/videoio/cap_ios.h
+++ b/modules/videoio/include/opencv2/videoio/cap_ios.h
@@ -64,8 +64,8 @@
     int imageHeight;
 }
 
-@property (nonatomic, retain) AVCaptureSession* captureSession;
-@property (nonatomic, retain) AVCaptureConnection* videoCaptureConnection;
+@property (nonatomic, strong) AVCaptureSession* captureSession;
+@property (nonatomic, strong) AVCaptureConnection* videoCaptureConnection;
 
 @property (nonatomic, readonly) BOOL running;
 @property (nonatomic, readonly) BOOL captureSessionLoaded;
@@ -80,7 +80,7 @@
 @property (nonatomic, assign) int imageWidth;
 @property (nonatomic, assign) int imageHeight;
 
-@property (nonatomic, retain) UIView* parentView;
+@property (nonatomic, strong) UIView* parentView;
 
 - (void)start;
 - (void)stop;
@@ -138,9 +138,9 @@
 
 @property (nonatomic, assign) BOOL recordVideo;
 @property (nonatomic, assign) BOOL rotateVideo;
-@property (nonatomic, retain) AVAssetWriterInput* recordAssetWriterInput;
-@property (nonatomic, retain) AVAssetWriterInputPixelBufferAdaptor* recordPixelBufferAdaptor;
-@property (nonatomic, retain) AVAssetWriter* recordAssetWriter;
+@property (nonatomic, strong) AVAssetWriterInput* recordAssetWriterInput;
+@property (nonatomic, strong) AVAssetWriterInputPixelBufferAdaptor* recordPixelBufferAdaptor;
+@property (nonatomic, strong) AVAssetWriter* recordAssetWriter;
 
 - (void)adjustLayoutToInterfaceOrientation:(UIInterfaceOrientation)interfaceOrientation;
 - (void)layoutPreviewLayer;

--- a/modules/videoio/src/cap_ios_abstract_camera.mm
+++ b/modules/videoio/src/cap_ios_abstract_camera.mm
@@ -37,7 +37,7 @@
 
 @interface CvAbstractCamera ()
 
-@property (nonatomic, retain) AVCaptureVideoPreviewLayer* captureVideoPreviewLayer;
+@property (nonatomic, strong) AVCaptureVideoPreviewLayer* captureVideoPreviewLayer;
 
 - (void)deviceOrientationDidChange:(NSNotification*)notification;
 - (void)startCaptureSession;

--- a/modules/videoio/src/cap_ios_photo_camera.mm
+++ b/modules/videoio/src/cap_ios_photo_camera.mm
@@ -37,7 +37,7 @@
 
 @interface CvPhotoCamera ()
 
-@property (nonatomic, retain) AVCaptureStillImageOutput* stillImageOutput;
+@property (nonatomic, strong) AVCaptureStillImageOutput* stillImageOutput;
 
 @end
 

--- a/modules/videoio/src/cap_ios_video_camera.mm
+++ b/modules/videoio/src/cap_ios_video_camera.mm
@@ -49,8 +49,8 @@ static CGFloat DegreesToRadians(CGFloat degrees) {return degrees * M_PI / 180;}
 - (void)createVideoFileOutput;
 
 
-@property (nonatomic, retain) CALayer *customPreviewLayer;
-@property (nonatomic, retain) AVCaptureVideoDataOutput *videoDataOutput;
+@property (nonatomic, strong) CALayer *customPreviewLayer;
+@property (nonatomic, strong) AVCaptureVideoDataOutput *videoDataOutput;
 
 @end
 


### PR DESCRIPTION
strong and retain are synonymous but using strong along with  obsolete synonym retain in one file is negligent