### PR TITLE
CMake: reduce MSVS projects layout

### DIFF
--- a/cmake/OpenCVModule.cmake
+++ b/cmake/OpenCVModule.cmake
@@ -779,6 +779,8 @@ macro(_ocv_create_module)
     endforeach()
   endif()
 
+  source_group("Include" FILES "${OPENCV_CONFIG_FILE_INCLUDE_DIR}/cvconfig.h" "${OPENCV_CONFIG_FILE_INCLUDE_DIR}/opencv2/opencv_modules.hpp")
+  source_group("Src" FILES "${${the_module}_pch}")
   ocv_add_library(${the_module} ${OPENCV_MODULE_TYPE} ${OPENCV_MODULE_${the_module}_HEADERS} ${OPENCV_MODULE_${the_module}_SOURCES}
     "${OPENCV_CONFIG_FILE_INCLUDE_DIR}/cvconfig.h" "${OPENCV_CONFIG_FILE_INCLUDE_DIR}/opencv2/opencv_modules.hpp"
     ${${the_module}_pch} ${sub_objs})
@@ -1015,6 +1017,7 @@ function(ocv_add_perf_tests)
         get_native_precompiled_header(${the_target} perf_precomp.hpp)
       endif()
 
+      source_group("Src" FILES "${${the_target}_pch}")
       ocv_add_executable(${the_target} ${OPENCV_PERF_${the_module}_SOURCES} ${${the_target}_pch})
       ocv_target_include_modules(${the_target} ${perf_deps} "${perf_path}")
       ocv_target_link_libraries(${the_target} ${perf_deps} ${OPENCV_MODULE_${the_module}_DEPS} ${OPENCV_LINKER_LIBS})
@@ -1091,6 +1094,7 @@ function(ocv_add_accuracy_tests)
         get_native_precompiled_header(${the_target} test_precomp.hpp)
       endif()
 
+      source_group("Src" FILES "${${the_target}_pch}")
       ocv_add_executable(${the_target} ${OPENCV_TEST_${the_module}_SOURCES} ${${the_target}_pch})
       ocv_target_include_modules(${the_target} ${test_deps} "${test_path}")
       ocv_target_link_libraries(${the_target} ${test_deps} ${OPENCV_MODULE_${the_module}_DEPS} ${OPENCV_LINKER_LIBS})

--- a/cmake/OpenCVUtils.cmake
+++ b/cmake/OpenCVUtils.cmake
@@ -815,7 +815,7 @@ function(ocv_add_library target)
   add_library(${target} ${ARGN} ${cuda_objs})
 
   # Add OBJECT library (added in cmake 2.8.8) to use in compound modules
-  if (NOT CMAKE_VERSION VERSION_LESS "2.8.8"
+  if (NOT CMAKE_VERSION VERSION_LESS "2.8.8" AND OPENCV_ENABLE_OBJECT_TARGETS
       AND NOT OPENCV_MODULE_${target}_CHILDREN
       AND NOT OPENCV_MODULE_${target}_CLASS STREQUAL "BINDINGS"
       AND NOT ${target} STREQUAL "opencv_ts"

--- a/modules/core/CMakeLists.txt
+++ b/modules/core/CMakeLists.txt
@@ -22,8 +22,10 @@ endif()
 file(GLOB lib_cuda_hdrs        "include/opencv2/${name}/cuda/*.hpp"        "include/opencv2/${name}/cuda/*.h")
 file(GLOB lib_cuda_hdrs_detail "include/opencv2/${name}/cuda/detail/*.hpp" "include/opencv2/${name}/cuda/detail/*.h")
 
-source_group("Cuda Headers"         FILES ${lib_cuda_hdrs})
-source_group("Cuda Headers\\Detail" FILES ${lib_cuda_hdrs_detail})
+source_group("Include\\Cuda Headers"         FILES ${lib_cuda_hdrs})
+source_group("Include\\Cuda Headers\\Detail" FILES ${lib_cuda_hdrs_detail})
+
+source_group("Src" FILES "${OPENCV_MODULE_opencv_core_BINARY_DIR}/version_string.inc")
 
 ocv_glob_module_sources(SOURCES "${OPENCV_MODULE_opencv_core_BINARY_DIR}/version_string.inc"
                         HEADERS ${lib_cuda_hdrs} ${lib_cuda_hdrs_detail})


### PR DESCRIPTION
Merge "Include"/"Headers Files", "Src/Source Files" and CUDA entries.

Also turn off "object" targets by default (they don't work well and are not used at this moment).
They can be enabled back by setting `OPENCV_ENABLE_OBJECT_TARGETS=ON`