### PR TITLE
Changes delegate property from assign to weak

### DIFF
--- a/modules/videoio/include/opencv2/videoio/cap_ios.h
+++ b/modules/videoio/include/opencv2/videoio/cap_ios.h
@@ -133,7 +133,7 @@
 
 }
 
-@property (nonatomic, assign) id<CvVideoCameraDelegate> delegate;
+@property (nonatomic, weak) id<CvVideoCameraDelegate> delegate;
 @property (nonatomic, assign) BOOL grayscaleMode;
 
 @property (nonatomic, assign) BOOL recordVideo;
@@ -167,7 +167,7 @@
     AVCaptureStillImageOutput *stillImageOutput;
 }
 
-@property (nonatomic, assign) id<CvPhotoCameraDelegate> delegate;
+@property (nonatomic, weak) id<CvPhotoCameraDelegate> delegate;
 
 - (void)takePicture;
 

--- a/modules/videoio/src/cap_ios_photo_camera.mm
+++ b/modules/videoio/src/cap_ios_photo_camera.mm
@@ -106,9 +106,7 @@
                  cameraAvailable = YES;
 
                  NSLog(@"CvPhotoCamera captured image");
-                 if (self.delegate) {
-                     [self.delegate photoCamera:self capturedImage:newImage];
-                 }
+                 [self.delegate photoCamera:self capturedImage:newImage];
 
                  [self.captureSession startRunning];
              });

--- a/modules/videoio/src/cap_ios_photo_camera.mm
+++ b/modules/videoio/src/cap_ios_photo_camera.mm
@@ -36,6 +36,9 @@
 
 
 @interface CvPhotoCamera ()
+{
+    id<CvPhotoCameraDelegate> _delegate;
+}
 
 @property (nonatomic, strong) AVCaptureStillImageOutput* stillImageOutput;
 
@@ -53,8 +56,14 @@
 #pragma mark Public
 
 @synthesize stillImageOutput;
-@synthesize delegate;
 
+- (void)setDelegate:(id<CvPhotoCameraDelegate>)newDelegate {
+    _delegate = newDelegate;
+}
+
+- (id<CvPhotoCameraDelegate>)delegate {
+    return _delegate;
+}
 
 #pragma mark - Public interface
 

--- a/modules/videoio/src/cap_ios_video_camera.mm
+++ b/modules/videoio/src/cap_ios_video_camera.mm
@@ -61,11 +61,12 @@ static CGFloat DegreesToRadians(CGFloat degrees) {return degrees * M_PI / 180;}
 
 
 @implementation CvVideoCamera
+{
+    id<CvVideoCameraDelegate> _delegate;
+}
 
 
 
-
-@synthesize delegate;
 @synthesize grayscaleMode;
 
 @synthesize customPreviewLayer;
@@ -78,7 +79,13 @@ static CGFloat DegreesToRadians(CGFloat degrees) {return degrees * M_PI / 180;}
 @synthesize recordPixelBufferAdaptor;
 @synthesize recordAssetWriter;
 
+- (void)setDelegate:(id<CvVideoCameraDelegate>)newDelegate {
+    _delegate = newDelegate;
+}
 
+- (id<CvVideoCameraDelegate>)delegate {
+    return _delegate;
+}
 
 #pragma mark - Constructors
 

--- a/modules/videoio/src/cap_ios_video_camera.mm
+++ b/modules/videoio/src/cap_ios_video_camera.mm
@@ -450,7 +450,8 @@ static CGFloat DegreesToRadians(CGFloat degrees) {return degrees * M_PI / 180;}
 {
     (void)captureOutput;
     (void)connection;
-    if (self.delegate) {
+    auto strongDelegate = self.delegate;
+    if (strongDelegate) {
 
         // convert from Core Media to Core Video
         CVImageBufferRef imageBuffer = CMSampleBufferGetImageBuffer(sampleBuffer);
@@ -492,8 +493,8 @@ static CGFloat DegreesToRadians(CGFloat degrees) {return degrees * M_PI / 180;}
 
         CGImage* dstImage;
 
-        if ([self.delegate respondsToSelector:@selector(processImage:)]) {
-            [self.delegate processImage:image];
+        if ([strongDelegate respondsToSelector:@selector(processImage:)]) {
+            [strongDelegate processImage:image];
         }
 
         // check if matrix data pointer or dimensions were changed by the delegate


### PR DESCRIPTION
In modern Objective-C delegate should be weak. In very rare conditions you might want delegate be strong.
Assign for delegate is sign of legacy code.
This change prevents crash when you forget nil delegate in dealloc and makes rush with nilling delegate unnecessary.
This change shouldn't break any existing code.