### PR TITLE
Cleans up declarations in window_cocoa.mm

### DIFF
--- a/modules/highgui/src/window_cocoa.mm
+++ b/modules/highgui/src/window_cocoa.mm
@@ -82,42 +82,26 @@ static NSAutoreleasePool *pool = nil;
 static NSMutableDictionary *windows = nil;
 static bool wasInitialized = false;
 
-@interface CVView : NSView {
-    NSImage *image;
-}
-@property(retain) NSImage *image;
+@interface CVView : NSView
+@property(strong) NSImage *image;
 - (void)setImageData:(CvArr *)arr;
 @end
 
-@interface CVSlider : NSView {
-    NSSlider *slider;
-    NSTextField *name;
-    int *value;
-    void *userData;
-    CvTrackbarCallback callback;
-    CvTrackbarCallback2 callback2;
-}
-@property(retain) NSSlider *slider;
-@property(retain) NSTextField *name;
+@interface CVSlider : NSView
+@property(strong) NSSlider *slider;
+@property(strong) NSTextField *name;
 @property(assign) int *value;
 @property(assign) void *userData;
 @property(assign) CvTrackbarCallback callback;
 @property(assign) CvTrackbarCallback2 callback2;
 @end
 
-@interface CVWindow : NSWindow {
-    NSMutableDictionary *sliders;
-    CvMouseCallback mouseCallback;
-    void *mouseParam;
-    BOOL autosize;
-    BOOL firstContent;
-    int status;
-}
+@interface CVWindow : NSWindow
 @property(assign) CvMouseCallback mouseCallback;
 @property(assign) void *mouseParam;
 @property(assign) BOOL autosize;
 @property(assign) BOOL firstContent;
-@property(retain) NSMutableDictionary *sliders;
+@property(strong) NSMutableDictionary *sliders;
 @property(readwrite) int status;
 - (CVView *)contentView;
 - (void)cvSendMouseEvent:(NSEvent *)event type:(int)type flags:(int)flags;


### PR DESCRIPTION
Cleans up declarations in window_cocoa.mm removing unnecessary iVars declarations and changing retain property attribute to strong.