### PR TITLE
Improve findContours using SSE2 instruction to find next contour

### DIFF
--- a/modules/imgproc/src/contours.cpp
+++ b/modules/imgproc/src/contours.cpp
@@ -1048,7 +1048,7 @@ cvFindNextContour( CvContourScanner scanner )
                     goto _next_contour;
                 } else if (haveSSE2) {
 
-                    __m128i v_prev = _mm_set1_epi8(prev);
+                    __m128i v_prev = _mm_set1_epi8((char)prev);
                     int v_size = width - 32;
 
                     for (; x <= v_size; x += 32) {

--- a/modules/imgproc/src/contours.cpp
+++ b/modules/imgproc/src/contours.cpp
@@ -59,10 +59,10 @@ inline unsigned int trailingZeros(unsigned int value) {
 #endif
 #elif defined(__GNUC__) || defined(__GNUG__)
     return __builtin_ctz(value);
-//#elif defined(__ICC) || defined(__INTEL_COMPILER)
-//    return _bit_scan_forward(value);
-//#elif defined(__clang__)
-//    return llvm.cttz.i32(value, true);
+#elif defined(__ICC) || defined(__INTEL_COMPILER)
+    return _bit_scan_forward(value);
+#elif defined(__clang__)
+    return llvm.cttz.i32(value, true);
 #else
     static const int MultiplyDeBruijnBitPosition[32] = {
         0, 1, 28, 2, 29, 14, 24, 3, 30, 22, 20, 15, 25, 17, 4, 8,

--- a/modules/imgproc/src/contours.cpp
+++ b/modules/imgproc/src/contours.cpp
@@ -55,7 +55,7 @@ inline unsigned int trailingZeros(unsigned int value) {
     return _tzcnt_u32(value);
 #elif defined(_GCC)
     return __builtin_ctz(value);
-#elif defined(__INTEL_COMPILER)
+//#elif defined(__INTEL_COMPILER)
     //return _bit_scan_reverse(value);
 #else
     static const int MultiplyDeBruijnBitPosition[32] = {

--- a/modules/imgproc/src/contours.cpp
+++ b/modules/imgproc/src/contours.cpp
@@ -1390,6 +1390,8 @@ inline int findStartContourPoint(uchar *src_data, CvSize img_size, int j, bool h
             j += 16;
         }
     }
+#else
+    CV_UNUSED(haveSIMD);
 #endif
     for (; j < img_size.width && !src_data[j]; ++j)
         ;
@@ -1437,6 +1439,8 @@ inline int findEndContourPoint(uchar *src_data, CvSize img_size, int j, bool hav
             j += 16;
         }
     }
+#else
+    CV_UNUSED(haveSIMD);
 #endif
     for (; j < img_size.width && src_data[j]; ++j)
         ;
@@ -1466,6 +1470,7 @@ icvFindContoursInInterval( const CvArr* src,
     int  lower_total;
     int  upper_total;
     int  all_total;
+    bool haveSIMD = false;
 
     CvSeq*  runs;
     CvLinkedRunPoint  tmp;
@@ -1496,7 +1501,7 @@ icvFindContoursInInterval( const CvArr* src,
     if( contourHeaderSize < (int)sizeof(CvContour))
         CV_Error( CV_StsBadSize, "Contour header size must be >= sizeof(CvContour)" );
 #if CV_SSE2
-    bool haveSIMD = cv::checkHardwareSupport(CPU_SSE2);
+    haveSIMD = cv::checkHardwareSupport(CPU_SSE2);
 #endif
     storage00.reset(cvCreateChildMemStorage(storage));
     storage01.reset(cvCreateChildMemStorage(storage));
@@ -1540,7 +1545,7 @@ icvFindContoursInInterval( const CvArr* src,
         tmp_prev->next = (CvLinkedRunPoint*)CV_GET_WRITTEN_ELEM( writer );
         tmp_prev = tmp_prev->next;
 
-        j = findEndContourPoint(src_data, img_size, j+1, haveSIMD);
+        j = findEndContourPoint(src_data, img_size, j + 1, haveSIMD);
 
         tmp.pt.x = j - 1;
         CV_WRITE_SEQ_ELEM( tmp, writer );
@@ -1573,7 +1578,7 @@ icvFindContoursInInterval( const CvArr* src,
             tmp_prev->next = (CvLinkedRunPoint*)CV_GET_WRITTEN_ELEM( writer );
             tmp_prev = tmp_prev->next;
 
-            j = findEndContourPoint(src_data, img_size, j+1, haveSIMD);
+            j = findEndContourPoint(src_data, img_size, j + 1, haveSIMD);
 
             tmp.pt.x = j - 1;
             CV_WRITE_SEQ_ELEM( tmp, writer );

--- a/modules/imgproc/src/contours.cpp
+++ b/modules/imgproc/src/contours.cpp
@@ -1408,7 +1408,7 @@ inline int findEndContourPoint(uchar *src_data, CvSize img_size, int j) {
 #endif
 #if CV_SSE2
     if (j < img_size.width && !src_data[j]) {
-        return j - 1;
+        return j;
     } else if (haveSSE2) {
         __m128i v_zero = _mm_setzero_si128();
         int v_size = img_size.width - 32;
@@ -1424,12 +1424,12 @@ inline int findEndContourPoint(uchar *src_data, CvSize img_size, int j) {
             unsigned int mask2 = _mm_movemask_epi8(v_cmp2);
 
             if (mask1) {
-                j += (trailingZeros(mask1) - 1);
+                j += trailingZeros(mask1);
                 return j;
             }
 
             if (mask2) {
-                j += trailingZeros(mask2 << 15);
+                j += trailingZeros(mask2 << 16);
                 return j;
             }
         }
@@ -1440,7 +1440,7 @@ inline int findEndContourPoint(uchar *src_data, CvSize img_size, int j) {
             unsigned int mask = _mm_movemask_epi8(_mm_cmpeq_epi8(v_p, v_zero));
 
             if (mask) {
-                j += (trailingZeros(mask) - 1);
+                j += trailingZeros(mask);
                 return j;
             }
             j += 16;
@@ -1450,7 +1450,7 @@ inline int findEndContourPoint(uchar *src_data, CvSize img_size, int j) {
     for (; j < img_size.width && src_data[j]; ++j)
         ;
 
-    return j - 1;
+    return j;
 }
 
 static int
@@ -1556,7 +1556,7 @@ icvFindContoursInInterval( const CvArr* src,
 #else
         j = findEndContourPoint(src_data, img_size, j+1);
 #endif
-        tmp.pt.x = j;
+        tmp.pt.x = j - 1;
         CV_WRITE_SEQ_ELEM( tmp, writer );
         tmp_prev->next = (CvLinkedRunPoint*)CV_GET_WRITTEN_ELEM( writer );
         tmp_prev->link = tmp_prev->next;
@@ -1594,7 +1594,7 @@ icvFindContoursInInterval( const CvArr* src,
 #else
             j = findEndContourPoint(src_data, img_size, j+1);
 #endif
-            tmp.pt.x = j;
+            tmp.pt.x = j - 1;
             CV_WRITE_SEQ_ELEM( tmp, writer );
             tmp_prev = tmp_prev->next = (CvLinkedRunPoint*)CV_GET_WRITTEN_ELEM( writer );
         }//j


### PR DESCRIPTION
<!-- Please use this line to close one or multiple issues when this pullrequest gets merged
You can add another line right under the first one:
resolves #1234
resolves #1235
-->

Improve findContours by using SSE2 instruction to find next contour point. Also the code is cleaned up a little bit.

<!-- Please describe what your pullrequest is changing -->

I have added a trailing zeros wrapper function for this in contours.cpp because every compiler has its own implementation. I think this could be used on several places. So it would be great if it could be implemented in a more global location in the library, but for this I need an advice.

I have added native implementations for Visual Studio and GCC. The rest has to use a general calculation. Perhabs I can implement more compiler specific implementations.