### PR TITLE
[2.4] types_c.h: Fix compiling VFP assembler code

### DIFF
--- a/modules/core/include/opencv2/core/types_c.h
+++ b/modules/core/include/opencv2/core/types_c.h
@@ -318,7 +318,7 @@ enum {
     int res; \
     float temp; \
     (void)temp; \
-    asm(_asm_string : [res] "=r" (res), [temp] "=w" (temp) : [value] "w" (_value)); \
+    __asm__(_asm_string : [res] "=r" (res), [temp] "=w" (temp) : [value] "w" (_value)); \
     return res;
 // 2. version for double
 #ifdef __clang__


### PR DESCRIPTION
Replace asm by __asm__ according to
https://gcc.gnu.org/onlinedocs/gcc/Alternate-Keywords.html#Alternate-Keywords
as suggested by Arnout Vandecappelle:
http://lists.busybox.net/pipermail/buildroot/2016-September/171491.html

to fix build errors in ffmpeg with opencv2 support detected by
buildroot autobuilders:
http://autobuild.buildroot.net/results/c32/c32a21240a9933796ee850349a62ff3c2314f25c/build-end.log

Signed-off-by: Bernd Kuhls <bernd.kuhls@t-online.de>