### PR TITLE
BackgroundSubtractorMOG2Impl: only use OpenCL if input image is UMat

### DIFF
--- a/modules/video/src/bgfg_gaussmix2.cpp
+++ b/modules/video/src/bgfg_gaussmix2.cpp
@@ -846,7 +846,7 @@ void BackgroundSubtractorMOG2Impl::apply(InputArray _image, OutputArray _fgmask,
 #ifdef HAVE_OPENCL
     if (opencl_ON)
     {
-        CV_OCL_RUN(opencl_ON, ocl_apply(_image, _fgmask, learningRate))
+        CV_OCL_RUN(_image.isUMat(), ocl_apply(_image, _fgmask, learningRate))
 
         opencl_ON = false;
         initialize(_image.size(), _image.type());


### PR DESCRIPTION
otherwise the python bindings break in a manner similar to #6081.


