### PR TITLE
CHAT-2608 new methods to open directshow with width, height set

### DIFF
--- a/modules/videoio/include/opencv2/videoio.hpp
+++ b/modules/videoio/include/opencv2/videoio.hpp
@@ -433,6 +433,12 @@ public:
     camera connected, just pass 0. Advanced Usage: to open Camera 1 using the MS Media Foundation API: index = 1 + CAP_MSMF
     */
     CV_WRAP virtual bool open(int index);
+  
+    /** @overload
+    @param index = camera_id + domain_offset (CAP_*). id of the video capturing device to open. If there is a single
+    camera connected, just pass 0. Advanced Usage: to open Camera 1 using the MS Media Foundation API: index = 1 + CAP_MSMF
+    */
+    CV_WRAP virtual bool open(int index, int width, int height);
 
     /** @brief Returns true if video capturing has been initialized already.
 

--- a/modules/videoio/src/cap.cpp
+++ b/modules/videoio/src/cap.cpp
@@ -503,6 +503,78 @@ static Ptr<IVideoCapture> IVideoCapture_create(int index)
     return Ptr<IVideoCapture>();
 }
 
+static Ptr<IVideoCapture> IVideoCapture_create(int index, int width, int height)
+{
+    int  domains[] =
+    {
+#ifdef HAVE_DSHOW
+        CV_CAP_DSHOW,
+#endif
+#ifdef HAVE_INTELPERC
+        CV_CAP_INTELPERC,
+#endif
+#ifdef WINRT_VIDEO
+        CAP_WINRT,
+#endif
+#ifdef HAVE_GPHOTO2
+        CV_CAP_GPHOTO2,
+#endif
+        - 1, -1
+    };
+
+    // interpret preferred interface (0 = autodetect)
+    int pref = (index / 100) * 100;
+    if (pref)
+    {
+        domains[0] = pref;
+        index %= 100;
+        domains[1] = -1;
+    }
+
+    // try every possibly installed camera API
+    for (int i = 0; domains[i] >= 0; i++)
+    {
+#if defined(HAVE_DSHOW)        || \
+    defined(HAVE_INTELPERC)    || \
+    defined(WINRT_VIDEO)       || \
+    defined(HAVE_GPHOTO2)      || \
+    (0)
+        Ptr<IVideoCapture> capture;
+
+        switch (domains[i])
+        {
+#ifdef HAVE_DSHOW
+        case CV_CAP_DSHOW:
+            capture = makePtr<VideoCapture_DShow>(index, width, height);
+            break; // CV_CAP_DSHOW
+#endif
+#ifdef HAVE_INTELPERC
+        case CV_CAP_INTELPERC:
+            capture = makePtr<VideoCapture_IntelPerC>();
+            break; // CV_CAP_INTEL_PERC
+#endif
+#ifdef WINRT_VIDEO
+        case CAP_WINRT:
+            capture = Ptr<IVideoCapture>(new cv::VideoCapture_WinRT(index));
+            if (capture)
+                return capture;
+            break; // CAP_WINRT
+#endif
+#ifdef HAVE_GPHOTO2
+        case CV_CAP_GPHOTO2:
+            capture = createGPhoto2Capture(index);
+            break;
+#endif
+        }
+        if (capture && capture->isOpened())
+            return capture;
+#endif
+    }
+
+    // failed open a camera
+    return Ptr<IVideoCapture>();
+}
+
 
 static Ptr<IVideoCapture> IVideoCapture_create(const String& filename)
 {
@@ -593,6 +665,16 @@ bool VideoCapture::open(int index)
 {
     if (isOpened()) release();
     icap = IVideoCapture_create(index);
+    if (!icap.empty())
+        return true;
+    cap.reset(cvCreateCameraCapture(index));
+    return isOpened();
+}
+
+bool VideoCapture::open(int index, int width, int height)
+{
+    if (isOpened()) release();
+    icap = IVideoCapture_create(index, width, height);
     if (!icap.empty())
         return true;
     cap.reset(cvCreateCameraCapture(index));

--- a/modules/videoio/src/cap_dshow.cpp
+++ b/modules/videoio/src/cap_dshow.cpp
@@ -3149,6 +3149,19 @@ VideoCapture_DShow::VideoCapture_DShow(int index)
     CoInitialize(0);
     open(index);
 }
+
+VideoCapture_DShow::VideoCapture_DShow(int index, int width, int height)
+    : m_index(-1)
+    , m_width(-1)
+    , m_height(-1)
+    , m_fourcc(-1)
+    , m_widthSet(width)
+    , m_heightSet(height)
+{
+    CoInitialize(0);
+    open(index, width, height);
+}
+
 VideoCapture_DShow::~VideoCapture_DShow()
 {
     close();
@@ -3324,7 +3337,7 @@ bool VideoCapture_DShow::isOpened() const
     return (-1 != m_index);
 }
 
-void VideoCapture_DShow::open(int index)
+void VideoCapture_DShow::open(int index, int width, int height)
 {
     close();
     int devices = g_VI.listDevices(true);
@@ -3332,6 +3345,34 @@ void VideoCapture_DShow::open(int index)
         return;
     if (index < 0 || index > devices-1)
         return;
+
+    // Don't attempt to open Personify devices (e.g. Cameo by Personify -- this might create a loop situation!
+    if (nullptr != strstr(g_VI.getDeviceName(index), "Personify"))
+    {
+        return;
+    }
+
+    g_VI.setupDeviceFourcc(index, width,height, -1);
+    if (!g_VI.isDeviceSetup(index))
+        return;
+    m_index = index;
+}
+
+void VideoCapture_DShow::open(int index)
+{
+    close();
+    int devices = g_VI.listDevices(true);
+    if (0 == devices)
+        return;
+    if (index < 0 || index > devices - 1)
+        return;
+
+    // Don't attempt to open Personify devices (e.g. Cameo by Personify -- this might create a loop situation!
+    if (nullptr != strstr(g_VI.getDeviceName(index), "Personify"))
+    {
+        return;
+    }
+
     g_VI.setupDevice(index);
     if (!g_VI.isDeviceSetup(index))
         return;

--- a/modules/videoio/src/cap_dshow.hpp
+++ b/modules/videoio/src/cap_dshow.hpp
@@ -24,6 +24,7 @@ class VideoCapture_DShow : public IVideoCapture
 {
 public:
     VideoCapture_DShow(int index);
+    VideoCapture_DShow(int index, int width, int height);
     virtual ~VideoCapture_DShow();
 
     virtual double getProperty(int propIdx) const;
@@ -34,6 +35,7 @@ public:
     virtual int getCaptureDomain();
     virtual bool isOpened() const;
 protected:
+    void open(int index, int width, int height);
     void open(int index);
     void close();
 


### PR DESCRIPTION
 resolves CHAT-2608


### This pullrequest changes

Adds methods to open video capture device with desired width and height initially, instead of waiting to call set methods for performance reasons.

