### PR TITLE
(2.4) Android: workaround for Android NDK-8e clang ICE

### DIFF
--- a/modules/ocl/src/stereo_csbp.cpp
+++ b/modules/ocl/src/stereo_csbp.cpp
@@ -76,11 +76,11 @@ namespace cv
             /////////////////////////////////init_data_cost//////////////////////////////////
             //////////////////////////////////////////////////////////////////////////////////
             static void init_data_cost_caller(const oclMat &left, const oclMat &right, oclMat &temp,
-                StereoConstantSpaceBP &rthis,
+                StereoConstantSpaceBP *pThis,
                 int msg_step, int h, int w, int level)
             {
                 Context  *clCxt = left.clCxt;
-                int data_type = rthis.msg_type;
+                int data_type = pThis->msg_type;
                 int channels = left.oclchannels();
 
                 string kernelName = get_kernel_name("init_data_cost_", data_type);
@@ -104,12 +104,12 @@ namespace cv
                 openCLSafeCall(clSetKernelArg(kernel, 5, sizeof(cl_int),  (void *)&level));
                 openCLSafeCall(clSetKernelArg(kernel, 6, sizeof(cl_int),  (void *)&channels));
                 openCLSafeCall(clSetKernelArg(kernel, 7, sizeof(cl_int),  (void *)&msg_step));
-                openCLSafeCall(clSetKernelArg(kernel, 8, sizeof(cl_float), (void *)&rthis.data_weight));
-                openCLSafeCall(clSetKernelArg(kernel, 9, sizeof(cl_float), (void *)&rthis.max_data_term));
+                openCLSafeCall(clSetKernelArg(kernel, 8, sizeof(cl_float), (void *)&pThis->data_weight));
+                openCLSafeCall(clSetKernelArg(kernel, 9, sizeof(cl_float), (void *)&pThis->max_data_term));
                 openCLSafeCall(clSetKernelArg(kernel, 10, sizeof(cl_int), (void *)&cdisp_step1));
-                openCLSafeCall(clSetKernelArg(kernel, 11, sizeof(cl_int), (void *)&rthis.min_disp_th));
+                openCLSafeCall(clSetKernelArg(kernel, 11, sizeof(cl_int), (void *)&pThis->min_disp_th));
                 openCLSafeCall(clSetKernelArg(kernel, 12, sizeof(cl_int), (void *)&left.step));
-                openCLSafeCall(clSetKernelArg(kernel, 13, sizeof(cl_int), (void *)&rthis.ndisp));
+                openCLSafeCall(clSetKernelArg(kernel, 13, sizeof(cl_int), (void *)&pThis->ndisp));
                 openCLSafeCall(clEnqueueNDRangeKernel(*(cl_command_queue*)getClCommandQueuePtr(), kernel, 2, NULL,
                     globalThreads, localThreads, 0, NULL, NULL));
 
@@ -118,12 +118,12 @@ namespace cv
             }
 
             static void init_data_cost_reduce_caller(const oclMat &left, const oclMat &right, oclMat &temp,
-                StereoConstantSpaceBP &rthis,
+                StereoConstantSpaceBP *pThis,
                 int msg_step, int h, int w, int level)
             {
 
                 Context  *clCxt = left.clCxt;
-                int data_type = rthis.msg_type;
+                int data_type = pThis->msg_type;
                 int channels = left.oclchannels();
                 int win_size = (int)std::pow(2.f, level);
 
@@ -135,7 +135,7 @@ namespace cv
                 //size_t blockSize = threadsNum;
                 size_t localThreads[3]  = {(size_t)win_size, 1, (size_t)threadsNum / win_size};
                 size_t globalThreads[3] = { w *localThreads[0],
-                    h * divUp(rthis.ndisp, localThreads[2]) *localThreads[1], 1 * localThreads[2]
+                    h * divUp(pThis->ndisp, localThreads[2]) *localThreads[1], 1 * localThreads[2]
                 };
 
                 int local_mem_size = threadsNum * sizeof(float);
@@ -153,11 +153,11 @@ namespace cv
                 openCLSafeCall(clSetKernelArg(kernel, 7,  sizeof(cl_int),  (void *)&h));
                 openCLSafeCall(clSetKernelArg(kernel, 8,  sizeof(cl_int),  (void *)&win_size));
                 openCLSafeCall(clSetKernelArg(kernel, 9,  sizeof(cl_int),  (void *)&channels));
-                openCLSafeCall(clSetKernelArg(kernel, 10, sizeof(cl_int),  (void *)&rthis.ndisp));
+                openCLSafeCall(clSetKernelArg(kernel, 10, sizeof(cl_int),  (void *)&pThis->ndisp));
                 openCLSafeCall(clSetKernelArg(kernel, 11, sizeof(cl_int),  (void *)&left.step));
-                openCLSafeCall(clSetKernelArg(kernel, 12, sizeof(cl_float), (void *)&rthis.data_weight));
-                openCLSafeCall(clSetKernelArg(kernel, 13, sizeof(cl_float), (void *)&rthis.max_data_term));
-                openCLSafeCall(clSetKernelArg(kernel, 14, sizeof(cl_int),  (void *)&rthis.min_disp_th));
+                openCLSafeCall(clSetKernelArg(kernel, 12, sizeof(cl_float), (void *)&pThis->data_weight));
+                openCLSafeCall(clSetKernelArg(kernel, 13, sizeof(cl_float), (void *)&pThis->max_data_term));
+                openCLSafeCall(clSetKernelArg(kernel, 14, sizeof(cl_int),  (void *)&pThis->min_disp_th));
                 openCLSafeCall(clSetKernelArg(kernel, 15, sizeof(cl_int),  (void *)&cdisp_step1));
                 openCLSafeCall(clSetKernelArg(kernel, 16, sizeof(cl_int),  (void *)&msg_step));
                 openCLSafeCall(clEnqueueNDRangeKernel(*(cl_command_queue*)getClCommandQueuePtr(), kernel, 3, NULL,
@@ -167,11 +167,11 @@ namespace cv
             }
 
             static void get_first_initial_local_caller(uchar *data_cost_selected, uchar *disp_selected_pyr,
-                oclMat &temp, StereoConstantSpaceBP &rthis,
+                oclMat &temp, StereoConstantSpaceBP *pThis,
                 int h, int w, int nr_plane, int msg_step)
             {
                 Context  *clCxt = temp.clCxt;
-                int data_type = rthis.msg_type;
+                int data_type = pThis->msg_type;
 
                 string kernelName = get_kernel_name("get_first_k_initial_local_", data_type);
 
@@ -191,7 +191,7 @@ namespace cv
                 openCLSafeCall(clSetKernelArg(kernel, 5, sizeof(cl_int), (void *)&nr_plane));
                 openCLSafeCall(clSetKernelArg(kernel, 6, sizeof(cl_int), (void *)&msg_step));
                 openCLSafeCall(clSetKernelArg(kernel, 7, sizeof(cl_int), (void *)&disp_step));
-                openCLSafeCall(clSetKernelArg(kernel, 8, sizeof(cl_int), (void *)&rthis.ndisp));
+                openCLSafeCall(clSetKernelArg(kernel, 8, sizeof(cl_int), (void *)&pThis->ndisp));
                 openCLSafeCall(clEnqueueNDRangeKernel(*(cl_command_queue*)getClCommandQueuePtr(), kernel, 2, NULL,
                     globalThreads, localThreads, 0, NULL, NULL));
 
@@ -199,11 +199,11 @@ namespace cv
                 openCLSafeCall(clReleaseKernel(kernel));
             }
             static void get_first_initial_global_caller(uchar *data_cost_selected, uchar *disp_selected_pyr,
-                oclMat &temp, StereoConstantSpaceBP &rthis,
+                oclMat &temp, StereoConstantSpaceBP *pThis,
                 int h, int w, int nr_plane, int msg_step)
             {
                 Context  *clCxt = temp.clCxt;
-                int data_type = rthis.msg_type;
+                int data_type = pThis->msg_type;
 
                 string kernelName = get_kernel_name("get_first_k_initial_global_", data_type);
 
@@ -226,7 +226,7 @@ namespace cv
                 openCLSafeCall(clSetKernelArg(kernel, 5, sizeof(cl_int), (void *)&nr_plane));
                 openCLSafeCall(clSetKernelArg(kernel, 6, sizeof(cl_int), (void *)&msg_step));
                 openCLSafeCall(clSetKernelArg(kernel, 7, sizeof(cl_int), (void *)&disp_step));
-                openCLSafeCall(clSetKernelArg(kernel, 8, sizeof(cl_int), (void *)&rthis.ndisp));
+                openCLSafeCall(clSetKernelArg(kernel, 8, sizeof(cl_int), (void *)&pThis->ndisp));
                 openCLSafeCall(clEnqueueNDRangeKernel(*(cl_command_queue*)getClCommandQueuePtr(), kernel, 2, NULL,
                     globalThreads, localThreads, 0, NULL, NULL));
 
@@ -234,23 +234,23 @@ namespace cv
                 openCLSafeCall(clReleaseKernel(kernel));
             }
 
-            static void init_data_cost(const oclMat &left, const oclMat &right, oclMat &temp, StereoConstantSpaceBP &rthis,
+            static void init_data_cost(const oclMat &left, const oclMat &right, oclMat &temp, StereoConstantSpaceBP *pThis,
                 uchar *disp_selected_pyr, uchar *data_cost_selected,
                 size_t msg_step, int h, int w, int level, int nr_plane)
             {
 
                 if(level <= 1)
-                    init_data_cost_caller(left, right, temp, rthis, msg_step, h, w, level);
+                    init_data_cost_caller(left, right, temp, pThis, msg_step, h, w, level);
                 else
-                    init_data_cost_reduce_caller(left, right, temp, rthis, msg_step, h, w, level);
+                    init_data_cost_reduce_caller(left, right, temp, pThis, msg_step, h, w, level);
 
-                if(rthis.use_local_init_data_cost == true)
+                if(pThis->use_local_init_data_cost == true)
                 {
-                    get_first_initial_local_caller(data_cost_selected, disp_selected_pyr, temp, rthis, h, w, nr_plane, msg_step);
+                    get_first_initial_local_caller(data_cost_selected, disp_selected_pyr, temp, pThis, h, w, nr_plane, msg_step);
                 }
                 else
                 {
-                    get_first_initial_global_caller(data_cost_selected, disp_selected_pyr, temp, rthis, h, w,
+                    get_first_initial_global_caller(data_cost_selected, disp_selected_pyr, temp, pThis, h, w,
                         nr_plane, msg_step);
                 }
             }
@@ -259,13 +259,13 @@ namespace cv
             ///////////////////////////////////compute_data_cost//////////////////////////////////////////////
             ////////////////////////////////////////////////////////////////////////////////////////////////
             static void compute_data_cost_caller(uchar *disp_selected_pyr, uchar *data_cost,
-                StereoConstantSpaceBP &rthis, int msg_step1,
+                StereoConstantSpaceBP *pThis, int msg_step1,
                 int msg_step2, const oclMat &left, const oclMat &right, int h,
                 int w, int h2, int level, int nr_plane)
             {
                 Context  *clCxt = left.clCxt;
                 int channels = left.oclchannels();
-                int data_type = rthis.msg_type;
+                int data_type = pThis->msg_type;
 
                 string kernelName = get_kernel_name("compute_data_cost_", data_type);
 
@@ -290,10 +290,10 @@ namespace cv
                 openCLSafeCall(clSetKernelArg(kernel, 10, sizeof(cl_int),  (void *)&msg_step2));
                 openCLSafeCall(clSetKernelArg(kernel, 11, sizeof(cl_int),  (void *)&disp_step1));
                 openCLSafeCall(clSetKernelArg(kernel, 12, sizeof(cl_int),  (void *)&disp_step2));
-                openCLSafeCall(clSetKernelArg(kernel, 13, sizeof(cl_float), (void *)&rthis.data_weight));
-                openCLSafeCall(clSetKernelArg(kernel, 14, sizeof(cl_float), (void *)&rthis.max_data_term));
+                openCLSafeCall(clSetKernelArg(kernel, 13, sizeof(cl_float), (void *)&pThis->data_weight));
+                openCLSafeCall(clSetKernelArg(kernel, 14, sizeof(cl_float), (void *)&pThis->max_data_term));
                 openCLSafeCall(clSetKernelArg(kernel, 15, sizeof(cl_int),  (void *)&left.step));
-                openCLSafeCall(clSetKernelArg(kernel, 16, sizeof(cl_int),  (void *)&rthis.min_disp_th));
+                openCLSafeCall(clSetKernelArg(kernel, 16, sizeof(cl_int),  (void *)&pThis->min_disp_th));
                 openCLSafeCall(clEnqueueNDRangeKernel(*(cl_command_queue*)getClCommandQueuePtr(), kernel, 2, NULL,
                     globalThreads, localThreads, 0, NULL, NULL));
 
@@ -301,12 +301,12 @@ namespace cv
                 openCLSafeCall(clReleaseKernel(kernel));
             }
             static void compute_data_cost_reduce_caller(uchar *disp_selected_pyr, uchar *data_cost,
-                StereoConstantSpaceBP &rthis, int msg_step1,
+                StereoConstantSpaceBP *pThis, int msg_step1,
                 int msg_step2, const oclMat &left, const oclMat &right, int h,
                 int w, int h2, int level, int nr_plane)
             {
                 Context  *clCxt = left.clCxt;
-                int data_type = rthis.msg_type;
+                int data_type = pThis->msg_type;
                 int channels = left.oclchannels();
                 int win_size = (int)std::pow(2.f, level);
 
@@ -341,25 +341,25 @@ namespace cv
                 openCLSafeCall(clSetKernelArg(kernel, 13, sizeof(cl_int),  (void *)&msg_step2));
                 openCLSafeCall(clSetKernelArg(kernel, 14, sizeof(cl_int),  (void *)&disp_step1));
                 openCLSafeCall(clSetKernelArg(kernel, 15, sizeof(cl_int),  (void *)&disp_step2));
-                openCLSafeCall(clSetKernelArg(kernel, 16, sizeof(cl_float), (void *)&rthis.data_weight));
-                openCLSafeCall(clSetKernelArg(kernel, 17, sizeof(cl_float), (void *)&rthis.max_data_term));
+                openCLSafeCall(clSetKernelArg(kernel, 16, sizeof(cl_float), (void *)&pThis->data_weight));
+                openCLSafeCall(clSetKernelArg(kernel, 17, sizeof(cl_float), (void *)&pThis->max_data_term));
                 openCLSafeCall(clSetKernelArg(kernel, 18, sizeof(cl_int),  (void *)&left.step));
-                openCLSafeCall(clSetKernelArg(kernel, 19, sizeof(cl_int),  (void *)&rthis.min_disp_th));
+                openCLSafeCall(clSetKernelArg(kernel, 19, sizeof(cl_int),  (void *)&pThis->min_disp_th));
                 openCLSafeCall(clEnqueueNDRangeKernel(*(cl_command_queue*)getClCommandQueuePtr(), kernel, 3, NULL,
                     globalThreads, localThreads, 0, NULL, NULL));
 
                 clFinish(*(cl_command_queue*)getClCommandQueuePtr());
                 openCLSafeCall(clReleaseKernel(kernel));
             }
-            static void compute_data_cost(uchar *disp_selected_pyr, uchar *data_cost, StereoConstantSpaceBP &rthis,
+            static void compute_data_cost(uchar *disp_selected_pyr, uchar *data_cost, StereoConstantSpaceBP *pThis,
                 int msg_step1, int msg_step2, const oclMat &left, const oclMat &right, int h, int w,
                 int h2, int level, int nr_plane)
             {
                 if(level <= 1)
-                    compute_data_cost_caller(disp_selected_pyr, data_cost, rthis, msg_step1, msg_step2,
+                    compute_data_cost_caller(disp_selected_pyr, data_cost, pThis, msg_step1, msg_step2,
                     left, right, h, w, h2, level, nr_plane);
                 else
-                    compute_data_cost_reduce_caller(disp_selected_pyr, data_cost, rthis,  msg_step1, msg_step2,
+                    compute_data_cost_reduce_caller(disp_selected_pyr, data_cost, pThis,  msg_step1, msg_step2,
                     left, right, h, w, h2, level, nr_plane);
             }
             ////////////////////////////////////////////////////////////////////////////////////////////////
@@ -368,12 +368,12 @@ namespace cv
             static void init_message(uchar *u_new, uchar *d_new, uchar *l_new, uchar *r_new,
                 uchar *u_cur, uchar *d_cur, uchar *l_cur, uchar *r_cur,
                 uchar *disp_selected_pyr_new, uchar *disp_selected_pyr_cur,
-                uchar *data_cost_selected, uchar *data_cost, oclMat &temp, StereoConstantSpaceBP rthis,
+                uchar *data_cost_selected, uchar *data_cost, oclMat &temp, StereoConstantSpaceBP *pThis,
                 size_t msg_step1, size_t msg_step2, int h, int w, int nr_plane,
                 int h2, int w2, int nr_plane2)
             {
                 Context  *clCxt = temp.clCxt;
-                int data_type = rthis.msg_type;
+                int data_type = pThis->msg_type;
 
                 string kernelName = get_kernel_name("init_message_", data_type);
 
@@ -419,11 +419,11 @@ namespace cv
             ///////////////////////////calc_all_iterations////////////////////////////////////////////////
             //////////////////////////////////////////////////////////////////////////////////////////////
             static void calc_all_iterations_caller(uchar *u, uchar *d, uchar *l, uchar *r, uchar *data_cost_selected,
-                uchar *disp_selected_pyr, oclMat &temp, StereoConstantSpaceBP rthis,
+                uchar *disp_selected_pyr, oclMat &temp, StereoConstantSpaceBP *pThis,
                 int msg_step, int h, int w, int nr_plane, int i)
             {
                 Context  *clCxt = temp.clCxt;
-                int data_type = rthis.msg_type;
+                int data_type = pThis->msg_type;
 
                 string kernelName = get_kernel_name("compute_message_", data_type);
 
@@ -447,10 +447,10 @@ namespace cv
                 openCLSafeCall(clSetKernelArg(kernel, 8,  sizeof(cl_int),  (void *)&w));
                 openCLSafeCall(clSetKernelArg(kernel, 9,  sizeof(cl_int),  (void *)&nr_plane));
                 openCLSafeCall(clSetKernelArg(kernel, 10, sizeof(cl_int),  (void *)&i));
-                openCLSafeCall(clSetKernelArg(kernel, 11, sizeof(cl_float), (void *)&rthis.max_disc_term));
+                openCLSafeCall(clSetKernelArg(kernel, 11, sizeof(cl_float), (void *)&pThis->max_disc_term));
                 openCLSafeCall(clSetKernelArg(kernel, 12, sizeof(cl_int),  (void *)&disp_step));
                 openCLSafeCall(clSetKernelArg(kernel, 13, sizeof(cl_int),  (void *)&msg_step));
-                openCLSafeCall(clSetKernelArg(kernel, 14, sizeof(cl_float), (void *)&rthis.disc_single_jump));
+                openCLSafeCall(clSetKernelArg(kernel, 14, sizeof(cl_float), (void *)&pThis->disc_single_jump));
                 openCLSafeCall(clEnqueueNDRangeKernel(*(cl_command_queue*)getClCommandQueuePtr(), kernel, 2, NULL,
                     globalThreads, localThreads, 0, NULL, NULL));
 
@@ -458,11 +458,11 @@ namespace cv
                 openCLSafeCall(clReleaseKernel(kernel));
             }
             static void calc_all_iterations(uchar *u, uchar *d, uchar *l, uchar *r, uchar *data_cost_selected,
-                uchar *disp_selected_pyr, oclMat &temp, StereoConstantSpaceBP rthis,
+                uchar *disp_selected_pyr, oclMat &temp, StereoConstantSpaceBP *pThis,
                 int msg_step, int h, int w, int nr_plane)
             {
-                for(int t = 0; t < rthis.iters; t++)
-                    calc_all_iterations_caller(u, d, l, r, data_cost_selected, disp_selected_pyr, temp, rthis,
+                for(int t = 0; t < pThis->iters; t++)
+                    calc_all_iterations_caller(u, d, l, r, data_cost_selected, disp_selected_pyr, temp, pThis,
                     msg_step, h, w, nr_plane, t & 1);
             }
 
@@ -470,11 +470,11 @@ namespace cv
             //////////////////////////compute_disp////////////////////////////////////////////////////////
             /////////////////////////////////////////////////////////////////////////////////////////////
             static void compute_disp(uchar *u, uchar *d, uchar *l, uchar *r, uchar *data_cost_selected,
-                uchar *disp_selected_pyr, StereoConstantSpaceBP &rthis, size_t msg_step,
+                uchar *disp_selected_pyr, StereoConstantSpaceBP *pThis, size_t msg_step,
                 oclMat &disp, int nr_plane)
             {
                 Context  *clCxt = disp.clCxt;
-                int data_type = rthis.msg_type;
+                int data_type = pThis->msg_type;
 
                 string kernelName = get_kernel_name("compute_disp_", data_type);
 
@@ -550,20 +550,20 @@ cv::ocl::StereoConstantSpaceBP::StereoConstantSpaceBP(int ndisp_, int iters_, in
     : ndisp(ndisp_), iters(iters_), levels(levels_), nr_plane(nr_plane_),
     max_data_term(max_data_term_), data_weight(data_weight_),
     max_disc_term(max_disc_term_), disc_single_jump(disc_single_jump_), min_disp_th(min_disp_th_),
-    msg_type(msg_type_), use_local_init_data_cost(true)
+    msg_type(msg_type_), use_local_init_data_cost(TRUE)
 {
     CV_Assert(msg_type_ == CV_32F || msg_type_ == CV_16S);
 }
 
 template<class T>
-static void csbp_operator(StereoConstantSpaceBP &rthis, oclMat u[2], oclMat d[2], oclMat l[2], oclMat r[2],
+static void csbp_operator(StereoConstantSpaceBP *pThis, oclMat u[2], oclMat d[2], oclMat l[2], oclMat r[2],
     oclMat disp_selected_pyr[2], oclMat &data_cost, oclMat &data_cost_selected,
     oclMat &temp, oclMat &out, const oclMat &left, const oclMat &right, oclMat &disp)
 {
-    CV_DbgAssert(0 < rthis.ndisp && 0 < rthis.iters && 0 < rthis.levels && 0 < rthis.nr_plane
+    CV_DbgAssert(0 < pThis->ndisp && 0 < pThis->iters && 0 < pThis->levels && 0 < pThis->nr_plane
         && left.rows == right.rows && left.cols == right.cols && left.type() == right.type());
 
-    CV_Assert(rthis.levels <= 8 && (left.type() == CV_8UC1 || left.type() == CV_8UC3));
+    CV_Assert(pThis->levels <= 8 && (left.type() == CV_8UC1 || left.type() == CV_8UC3));
 
     const Scalar zero = Scalar::all(0);
 
@@ -571,8 +571,8 @@ static void csbp_operator(StereoConstantSpaceBP &rthis, oclMat u[2], oclMat d[2]
     int rows = left.rows;
     int cols = left.cols;
 
-    rthis.levels = min(rthis.levels, int(log((double)rthis.ndisp) / log(2.0)));
-    int levels = rthis.levels;
+    pThis->levels = min(pThis->levels, int(log((double)pThis->ndisp) / log(2.0)));
+    int levels = pThis->levels;
 
     AutoBuffer<int> buf(levels * 4);
 
@@ -583,7 +583,7 @@ static void csbp_operator(StereoConstantSpaceBP &rthis, oclMat u[2], oclMat d[2]
 
     cols_pyr[0] = cols;
     rows_pyr[0] = rows;
-    nr_plane_pyr[0] = rthis.nr_plane;
+    nr_plane_pyr[0] = pThis->nr_plane;
 
     const int n = 64;
     step_pyr[0] = alignSize(cols * sizeof(T), n) / sizeof(T);
@@ -617,16 +617,16 @@ static void csbp_operator(StereoConstantSpaceBP &rthis, oclMat u[2], oclMat d[2]
     data_cost_selected.create(msg_size, DataType<T>::type);
 
     Size temp_size = data_cost_size;
-    if (data_cost_size.width * data_cost_size.height < step_pyr[0] * rows_pyr[levels - 1] * rthis.ndisp)
-        temp_size = Size(step_pyr[0], rows_pyr[levels - 1] * rthis.ndisp);
+    if (data_cost_size.width * data_cost_size.height < step_pyr[0] * rows_pyr[levels - 1] * pThis->ndisp)
+        temp_size = Size(step_pyr[0], rows_pyr[levels - 1] * pThis->ndisp);
 
     temp.create(temp_size, DataType<T>::type);
     temp = zero;
 
     ///////////////////////////////// Compute////////////////////////////////////////////////
 
-    //csbp::load_constants(rthis.ndisp, rthis.max_data_term, rthis.data_weight,
-    //   rthis.max_disc_term, rthis.disc_single_jump, rthis.min_disp_th, left, right, temp);
+    //csbp::load_constants(pThis->ndisp, pThis->max_data_term, pThis->data_weight,
+    //   pThis->max_disc_term, pThis->disc_single_jump, pThis->min_disp_th, left, right, temp);
 
     l[0] = zero;
     d[0] = zero;
@@ -650,14 +650,14 @@ static void csbp_operator(StereoConstantSpaceBP &rthis, oclMat u[2], oclMat d[2]
     {
         if (i == levels - 1)
         {
-            cv::ocl::stereoCSBP::init_data_cost(left, right, temp, rthis, disp_selected_pyr[cur_idx].data,
+            cv::ocl::stereoCSBP::init_data_cost(left, right, temp, pThis, disp_selected_pyr[cur_idx].data,
                 data_cost_selected.data, step_pyr[0], rows_pyr[i], cols_pyr[i],
                 i, nr_plane_pyr[i]);
         }
         else
         {
             cv::ocl::stereoCSBP::compute_data_cost(
-                disp_selected_pyr[cur_idx].data, data_cost.data, rthis, step_pyr[0],
+                disp_selected_pyr[cur_idx].data, data_cost.data, pThis, step_pyr[0],
                 step_pyr[0], left, right, rows_pyr[i], cols_pyr[i], rows_pyr[i + 1], i,
                 nr_plane_pyr[i + 1]);
 
@@ -666,14 +666,14 @@ static void csbp_operator(StereoConstantSpaceBP &rthis, oclMat u[2], oclMat d[2]
             cv::ocl::stereoCSBP::init_message(u[new_idx].data, d[new_idx].data, l[new_idx].data, r[new_idx].data,
                 u[cur_idx].data, d[cur_idx].data, l[cur_idx].data, r[cur_idx].data,
                 disp_selected_pyr[new_idx].data, disp_selected_pyr[cur_idx].data,
-                data_cost_selected.data, data_cost.data, temp, rthis, step_pyr[0],
+                data_cost_selected.data, data_cost.data, temp, pThis, step_pyr[0],
                 step_pyr[0], rows_pyr[i], cols_pyr[i], nr_plane_pyr[i], rows_pyr[i + 1],
                 cols_pyr[i + 1], nr_plane_pyr[i + 1]);
             cur_idx = new_idx;
         }
         cv::ocl::stereoCSBP::calc_all_iterations(u[cur_idx].data, d[cur_idx].data, l[cur_idx].data, r[cur_idx].data,
             data_cost_selected.data, disp_selected_pyr[cur_idx].data, temp,
-            rthis, step_pyr[0], rows_pyr[i], cols_pyr[i], nr_plane_pyr[i]);
+            pThis, step_pyr[0], rows_pyr[i], cols_pyr[i], nr_plane_pyr[i]);
     }
 
     if (disp.empty())
@@ -683,23 +683,21 @@ static void csbp_operator(StereoConstantSpaceBP &rthis, oclMat u[2], oclMat d[2]
     out = zero;
 
     stereoCSBP::compute_disp(u[cur_idx].data, d[cur_idx].data, l[cur_idx].data, r[cur_idx].data,
-        data_cost_selected.data, disp_selected_pyr[cur_idx].data, rthis, step_pyr[0],
+        data_cost_selected.data, disp_selected_pyr[cur_idx].data, pThis, step_pyr[0],
         out, nr_plane_pyr[0]);
     if (disp.type() != CV_16S)
         out.convertTo(disp, disp.type());
 }
 
 
-typedef void (*csbp_operator_t)(StereoConstantSpaceBP &rthis, oclMat u[2], oclMat d[2], oclMat l[2], oclMat r[2],
-    oclMat disp_selected_pyr[2], oclMat &data_cost, oclMat &data_cost_selected,
-    oclMat &temp, oclMat &out, const oclMat &left, const oclMat &right, oclMat &disp);
-
-const static csbp_operator_t operators[] = {0, 0, 0, csbp_operator<short>, 0, csbp_operator<float>, 0, 0};
-
 void cv::ocl::StereoConstantSpaceBP::operator()(const oclMat &left, const oclMat &right, oclMat &disp)
 {
 
     CV_Assert(msg_type == CV_32F || msg_type == CV_16S);
-    operators[msg_type](*this, u, d, l, r, disp_selected_pyr, data_cost, data_cost_selected, temp, out,
-        left, right, disp);
+    if (msg_type == CV_16S)
+        csbp_operator<short>(this, u, d, l, r, disp_selected_pyr, data_cost, data_cost_selected, temp, out,
+            left, right, disp);
+    else
+        csbp_operator<float>(this, u, d, l, r, disp_selected_pyr, data_cost, data_cost_selected, temp, out,
+            left, right, disp);
 }


### PR DESCRIPTION
Internal compiler error log:
```
FAILED: modules/ocl/CMakeFiles/opencv_ocl.dir/src/stereo_csbp.cpp.o 
/usr/bin/ccache /opt/android/android-ndk-r8e/toolchains/llvm-3.1/prebuilt/linux-x86_64/bin/clang++  -DANDROID -DTBB_USE_GCC_BUILTINS=1 -D__TBB_GCC_BUILTIN_ATOMICS_PRESENT=1 -I/home/alalek/projects/opencv/dev24/3rdparty/include/opencl/1.2 -I/home/alalek/projects/opencv/dev24/modules/video/include -I/home/alalek/projects/opencv/dev24/modules/objdetect/include -I/home/alalek/projects/opencv/dev24/modules/ml/include -I/home/alalek/projects/opencv/dev24/modules/calib3d/include -I/home/alalek/projects/opencv/dev24/modules/features2d/include -I/home/alalek/projects/opencv/dev24/modules/highgui/include -I/home/alalek/projects/opencv/dev24/modules/imgproc/include -I/home/alalek/projects/opencv/dev24/modules/flann/include -I/home/alalek/projects/opencv/dev24/modules/androidcamera/include -I/home/alalek/projects/opencv/dev24/modules/core/include -Imodules/ocl -I/home/alalek/projects/opencv/dev24/modules/ocl/src -I/home/alalek/projects/opencv/dev24/modules/ocl/include -I. -isystem /opt/android/android-ndk-r8e/platforms/android-9/arch-x86/usr/include -isystem /opt/android/android-ndk-r8e/sources/cxx-stl/gnu-libstdc++/4.6/include -isystem /opt/android/android-ndk-r8e/sources/cxx-stl/gnu-libstdc++/4.6/libs/x86/include -isystem /opt/android/android-ndk-r8e/sources/cxx-stl/gnu-libstdc++/4.6/include/backward -isystem 3rdparty/tbb/tbb43_20141204oss/include -fexceptions -frtti -fpic -gcc-toolchain /opt/android/android-ndk-r8e/toolchains/x86-4.6/prebuilt/linux-x86_64 -target i686-none-linux-android -Qunused-arguments --sysroot=/opt/android/android-ndk-r8e/platforms/android-9/arch-x86 -funwind-tables -fsigned-char -no-canonical-prefixes -fdata-sections -ffunction-sections -Xclang -mnoexecstack    -fsigned-char -W -Werror=return-type -Werror=address -Werror=sequence-point -Wformat -Werror=format-security -Wmissing-declarations -Wmissing-prototypes -Wstrict-prototypes -Wundef -Winit-self -Wpointer-arith  -Wsign-promo -Wno-narrowing -Wno-delete-non-virtual-dtor -Wno-unnamed-type-template-args -Wno-array-bounds -Wno-aggressive-loop-optimizations -fdiagnostics-show-option -march=i686 -fomit-frame-pointer -msse -msse2 -msse3 -mfpmath=sse -Wno-shadow -fomit-frame-pointer -fstrict-aliasing -O2 -DNDEBUG  -DNDEBUG -MMD -MT modules/ocl/CMakeFiles/opencv_ocl.dir/src/stereo_csbp.cpp.o -MF modules/ocl/CMakeFiles/opencv_ocl.dir/src/stereo_csbp.cpp.o.d -o modules/ocl/CMakeFiles/opencv_ocl.dir/src/stereo_csbp.cpp.o -c /home/alalek/projects/opencv/dev24/modules/ocl/src/stereo_csbp.cpp
clang++: /ssd/ndk-toolchain/src/llvm-3.1/llvm/include/llvm/Support/Casting.h:194: typename llvm::cast_retty<To, From>::ret_type llvm::cast(const Y&) [with X = llvm::ArrayType, Y = llvm::Type*, typename llvm::cast_retty<To, From>::ret_type = llvm::ArrayType*]: Assertion `isa<X>(Val) && "cast<Ty>() argument of incompatible type!"' failed.
0  clang++         0x0000000001c5cd8f
1  clang++         0x0000000001c5d4b9
2  libpthread.so.0 0x00007efc7dd21c30
3  libc.so.6       0x00007efc7ced86f5 gsignal + 53
4  libc.so.6       0x00007efc7ceda2fa abort + 362
5  libc.so.6       0x00007efc7ced0f97
6  libc.so.6       0x00007efc7ced1042
7  clang++         0x0000000000983412 clang::CodeGen::CodeGenFunction::emitArrayLength(clang::ArrayType const*, clang::QualType&, llvm::Value*&) + 1602
8  clang++         0x00000000008c7b4f clang::CodeGen::CodeGenFunction::emitDestroy(llvm::Value*, clang::QualType, void (*)(clang::CodeGen::CodeGenFunction&, llvm::Value*, clang::QualType), bool) + 111
9  clang++         0x00000000008ab87f
10 clang++         0x00000000008ac92a clang::CodeGen::CodeGenFunction::PopCleanupBlock(bool) + 1738
11 clang++         0x00000000008adc80 clang::CodeGen::CodeGenFunction::PopCleanupBlocks(clang::CodeGen::EHScopeStack::stable_iterator) + 48
12 clang++         0x00000000008a8c7b clang::CodeGen::CodeGenFunction::EmitConstructorBody(clang::CodeGen::FunctionArgList&) + 155
13 clang++         0x0000000000986fcf clang::CodeGen::CodeGenFunction::GenerateCode(clang::GlobalDecl, llvm::Function*, clang::CodeGen::CGFunctionInfo const&) + 1087
14 clang++         0x000000000088f8ef clang::CodeGen::CodeGenModule::EmitCXXConstructor(clang::CXXConstructorDecl const*, clang::CXXCtorType) + 191
15 clang++         0x0000000000869be1 clang::CodeGen::CodeGenModule::EmitGlobalDefinition(clang::GlobalDecl) + 305
16 clang++         0x000000000086c646 clang::CodeGen::CodeGenModule::EmitDeferred() + 150
17 clang++         0x000000000086c6c9 clang::CodeGen::CodeGenModule::Release() + 9
18 clang++         0x000000000085476d
19 clang++         0x00000000009a34ff clang::ParseAST(clang::Sema&, bool, bool) + 447
20 clang++         0x0000000000718a31 clang::CompilerInstance::ExecuteAction(clang::FrontendAction&) + 337
21 clang++         0x00000000006ff12a clang::ExecuteCompilerInvocation(clang::CompilerInstance*) + 1130
22 clang++         0x00000000006f5fe8 cc1_main(char const**, char const**, char const*, void*) + 712
23 clang++         0x00000000006e45ae main + 670
24 libc.so.6       0x00007efc7cec4731 __libc_start_main + 241
25 clang++         0x00000000006f5be5
Stack dump:
0.	Program arguments: /opt/android/android-ndk-r8e/toolchains/llvm-3.1/prebuilt/linux-x86_64/bin/clang++ -cc1 -triple i686-none-linux-android -emit-obj -disable-free -main-file-name stereo_csbp.cpp -pic-level 2 -masm-verbose -mconstructor-aliases -munwind-tables -fuse-init-array -backend-option -x86-force-gv-stack-cookie -target-cpu i686 -target-feature +sse -target-feature +sse2 -target-feature +sse3 -target-linker-version 2.22 -momit-leaf-frame-pointer -ffunction-sections -fdata-sections -coverage-file modules/ocl/CMakeFiles/opencv_ocl.dir/src/stereo_csbp.cpp.o -resource-dir /opt/android/android-ndk-r8e/toolchains/llvm-3.1/prebuilt/linux-x86_64/bin/../lib/clang/3.1 -isystem /opt/android/android-ndk-r8e/platforms/android-9/arch-x86/usr/include -isystem /opt/android/android-ndk-r8e/sources/cxx-stl/gnu-libstdc++/4.6/include -isystem /opt/android/android-ndk-r8e/sources/cxx-stl/gnu-libstdc++/4.6/libs/x86/include -isystem /opt/android/android-ndk-r8e/sources/cxx-stl/gnu-libstdc++/4.6/include/backward -isystem 3rdparty/tbb/tbb43_20141204oss/include -D ANDROID -D TBB_USE_GCC_BUILTINS=1 -D __TBB_GCC_BUILTIN_ATOMICS_PRESENT=1 -D NDEBUG -D NDEBUG -I /home/alalek/projects/opencv/dev24/3rdparty/include/opencl/1.2 -I /home/alalek/projects/opencv/dev24/modules/video/include -I /home/alalek/projects/opencv/dev24/modules/objdetect/include -I /home/alalek/projects/opencv/dev24/modules/ml/include -I /home/alalek/projects/opencv/dev24/modules/calib3d/include -I /home/alalek/projects/opencv/dev24/modules/features2d/include -I /home/alalek/projects/opencv/dev24/modules/highgui/include -I /home/alalek/projects/opencv/dev24/modules/imgproc/include -I /home/alalek/projects/opencv/dev24/modules/flann/include -I /home/alalek/projects/opencv/dev24/modules/androidcamera/include -I /home/alalek/projects/opencv/dev24/modules/core/include -I modules/ocl -I /home/alalek/projects/opencv/dev24/modules/ocl/src -I /home/alalek/projects/opencv/dev24/modules/ocl/include -I . -isysroot /opt/android/android-ndk-r8e/platforms/android-9/arch-x86 -fmodule-cache-path /var/tmp/clang-module-cache -internal-isystem /opt/android/android-ndk-r8e/platforms/android-9/arch-x86/usr/local/include -internal-isystem /opt/android/android-ndk-r8e/toolchains/llvm-3.1/prebuilt/linux-x86_64/bin/../lib/clang/3.1/include -internal-externc-isystem /opt/android/android-ndk-r8e/platforms/android-9/arch-x86/include -internal-externc-isystem /opt/android/android-ndk-r8e/platforms/android-9/arch-x86/usr/include -O2 -W -Werror=return-type -Werror=address -Werror=sequence-point -Wformat -Werror=format-security -Wmissing-declarations -Wmissing-prototypes -Wstrict-prototypes -Wundef -Winit-self -Wpointer-arith -Wsign-promo -Wno-narrowing -Wno-delete-non-virtual-dtor -Wno-unnamed-type-template-args -Wno-array-bounds -Wno-aggressive-loop-optimizations -Wno-shadow -fdeprecated-macro -fdebug-compilation-dir /home/alalek/projects/opencv/build/android/o4a -ferror-limit 19 -fmessage-length 0 -backend-option -force-align-stack -mstackrealign -fgnu-runtime -fobjc-runtime-has-arc -fobjc-runtime-has-weak -fobjc-fragile-abi -fcxx-exceptions -fexceptions -fdiagnostics-show-option -mnoexecstack -o modules/ocl/CMakeFiles/opencv_ocl.dir/src/stereo_csbp.cpp.o -x c++ /home/alalek/projects/opencv/dev24/modules/ocl/src/stereo_csbp.cpp 
1.	<eof> parser at end of file
2.	Per-file LLVM IR generation
3.	/home/alalek/projects/opencv/dev24/modules/ocl/include/opencv2/ocl/ocl.hpp:1616:26: Generating code for declaration 'cv::ocl::StereoConstantSpaceBP::StereoConstantSpaceBP'
clang++: error: unable to execute command: Aborted (core dumped)
clang++: error: clang frontend command failed due to signal (use -v to see invocation)
```