### PR TITLE
build: fix build error on CUDA + Aarch64

### DIFF
--- a/modules/core/include/opencv2/core/cvdef.h
+++ b/modules/core/include/opencv2/core/cvdef.h
@@ -310,7 +310,7 @@ enum CpuFeatures {
 typedef union Cv16suf
 {
     short i;
-#if ( defined (__arm__) || defined (__aarch64__) ) && ( defined (__GNUC__) && ( ( ( 4 <= __GNUC__ ) && ( 7 <= __GNUC__ ) ) || ( 5 <= __GNUC__ ) ) )
+#if ( defined (__arm__) || defined (__aarch64__) ) && !defined (__CUDACC__) && ( defined (__GNUC__) && ( ( ( 4 <= __GNUC__ ) && ( 7 <= __GNUC__ ) ) || ( 5 <= __GNUC__ ) ) )
     __fp16 h;
 #endif
     struct _fp16Format


### PR DESCRIPTION
### This pullrequest changes
  * guard correct on CUDA + ARM 64bit
  * __fp16 doesn't exist on nvcc, but it slips through ifdef guard
  * [noticed](https://github.com/opencv/opencv/commit/c5d7791b67cb2810bff9a3123f9f640e5dcc7530#commitcomment-19046269) by @hkozachkov