### PR TITLE
Fix for detecting the correct Python major version

### DIFF
--- a/cmake/OpenCVDetectPython.cmake
+++ b/cmake/OpenCVDetectPython.cmake
@@ -47,19 +47,24 @@ if(NOT ${found})
     endforeach()
   endif()
 
+  string(REGEX MATCH "^[0-9]+" _preferred_version_major ${preferred_version})
+
   find_host_package(PythonInterp "${preferred_version}")
   if(NOT PYTHONINTERP_FOUND)
     find_host_package(PythonInterp "${min_version}")
   endif()
 
   if(PYTHONINTERP_FOUND)
-    # Copy outputs
-    set(_found ${PYTHONINTERP_FOUND})
-    set(_executable ${PYTHON_EXECUTABLE})
-    set(_version_string ${PYTHON_VERSION_STRING})
-    set(_version_major ${PYTHON_VERSION_MAJOR})
-    set(_version_minor ${PYTHON_VERSION_MINOR})
-    set(_version_patch ${PYTHON_VERSION_PATCH})
+    # Check if python major version is correct
+    if(${_preferred_version_major} EQUAL ${PYTHON_VERSION_MAJOR})
+      # Copy outputs
+      set(_found ${PYTHONINTERP_FOUND})
+      set(_executable ${PYTHON_EXECUTABLE})
+      set(_version_string ${PYTHON_VERSION_STRING})
+      set(_version_major ${PYTHON_VERSION_MAJOR})
+      set(_version_minor ${PYTHON_VERSION_MINOR})
+      set(_version_patch ${PYTHON_VERSION_PATCH})
+    endif()
 
     # Clear find_host_package side effects
     unset(PYTHONINTERP_FOUND)


### PR DESCRIPTION
Resolves a build issue where Python 3.x is detected as a suitable Python 2 interpreter (because 3.x > 2.7), ultimately resulting in `${PYTHON_DEFAULT_EXECUTABLE}` being set to empty string.

I ran into this issue when trying to build the Matlab wrappers from opencv/opencv_contrib, specifically  [this build command](https://github.com/opencv/opencv_contrib/blob/master/modules/matlab/CMakeLists.txt#L217).

This fix makes sure that the found Python matches the requested major version (2 or 3).

### Build output before

In the build output, note how the Python 2 `Interpreter:` shows as available, but points to an empty string. Also note how the last line `Python (for build):` shows that `${PYTHON_DEFAULT_EXECUTABLE}` has been set to empty string.

```
-- Found PythonInterp: C:/Python/python (found suitable version "3.4.5", minimum required is "2.7")
-- Found PythonLibs: C:/Python/libs/python34.lib (found suitable exact version "3.4.5")
-- Found PythonInterp: C:/Python/python (found suitable version "3.4.5", minimum required is "3.4")

[...]

--   Python 2:
--     Interpreter:                 (ver 3.4.5)
--
--   Python 3:
--     Interpreter:                 C:/Python/python (ver 3.4.5)
--     Libraries:                   C:/Python/libs/python34.lib (ver 3.4.5)
--     numpy:                       C:/Python/Lib/site-packages/numpy/core/include (ver 1.11.1)
--     packages path:               C:/Python/site-packages
--
--   Python (for build):
--
```

### After

```
-- Found PythonInterp: C:/Python/python (found suitable version "3.4.5", minimum required is "2.7")
-- Found PythonInterp: C:/Python/python (found suitable version "3.4.5", minimum required is "3.4")
-- Found PythonLibs: C:/Python/libs/python34.lib (found suitable exact version "3.4.5")

[...]

--   Python 2:
--     Interpreter:                 NO
--
--   Python 3:
--     Interpreter:                 C:/Python/python (ver 3.4.5)
--     Libraries:                   C:/Python/libs/python34.lib (ver 3.4.5)
--     numpy:                       C:/Python/Lib/site-packages/numpy/core/include (ver 1.11.1)
--     packages path:               C:/Python/Lib/site-packages
--
--   Python (for build):            C:/Python/python
```
