### PR TITLE
fixed unnecessary reconstruction in seamlessclone

### DIFF
--- a/modules/photo/src/seamless_cloning.cpp
+++ b/modules/photo/src/seamless_cloning.cpp
@@ -56,15 +56,13 @@ void cv::seamlessClone(InputArray _src, InputArray _dst, InputArray _mask, Point
     const Mat mask = _mask.getMat();
     _blend.create(dest.size(), CV_8UC3);
     Mat blend = _blend.getMat();
+    dest.copyTo(blend);
 
     int minx = INT_MAX, miny = INT_MAX, maxx = INT_MIN, maxy = INT_MIN;
     int h = mask.size().height;
     int w = mask.size().width;
 
     Mat gray = Mat(mask.size(),CV_8UC1);
-    Mat dst_mask = Mat::zeros(dest.size(),CV_8UC1);
-    Mat cs_mask = Mat::zeros(src.size(),CV_8UC3);
-    Mat cd_mask = Mat::zeros(dest.size(),CV_8UC3);
 
     if(mask.channels() == 3)
         cvtColor(mask, gray, COLOR_BGR2GRAY );
@@ -100,19 +98,16 @@ void cv::seamlessClone(InputArray _src, InputArray _dst, InputArray _mask, Point
     Rect roi_d(minyd,minxd,leny,lenx);
     Rect roi_s(miny,minx,leny,lenx);
 
-    Mat destinationROI = dst_mask(roi_d);
-    Mat sourceROI = cs_mask(roi_s);
+    Mat destinationROI = dest(roi_d).clone();
 
-    gray(roi_s).copyTo(destinationROI);
+    Mat sourceROI = Mat::zeros(leny, lenx, src.type());
     src(roi_s).copyTo(sourceROI,gray(roi_s));
-    src(roi_s).copyTo(patch, gray(roi_s));
 
-    destinationROI = cd_mask(roi_d);
-    cs_mask(roi_s).copyTo(destinationROI);
-
+    Mat maskROI = gray(roi_s);
+    Mat recoveredROI = blend(roi_d);
 
     Cloning obj;
-    obj.normalClone(dest,cd_mask,dst_mask,blend,flags);
+    obj.normalClone(destinationROI,sourceROI,maskROI,recoveredROI,flags);
 
 }
 

--- a/modules/photo/src/seamless_cloning.cpp
+++ b/modules/photo/src/seamless_cloning.cpp
@@ -86,8 +86,6 @@ void cv::seamlessClone(InputArray _src, InputArray _dst, InputArray _mask, Point
     int lenx = maxx - minx;
     int leny = maxy - miny;
 
-    Mat patch = Mat::zeros(Size(leny, lenx), CV_8UC3);
-
     int minxd = p.y - lenx/2;
     int maxxd = p.y + lenx/2;
     int minyd = p.x - leny/2;


### PR DESCRIPTION
<!-- Please use this line to close one or multiple issues when this pullrequest gets merged
You can add another line right under the first one:
resolves #1234
resolves #1235
-->

resolves [#5045](https://github.com/opencv/opencv/issues/5045)
### This pullrequest changes

<!-- Please describe what your pullrequest is changing -->

Fixed unnecessary reconstruction in seamlessClone() by passing only the rectangular ROI area of input images to Cloning::normalClone().

Earlier, Cloning::normalClone() was called with full-size images; now destinatinoROI, sourceROI, maskROI and recoveredROI basically denote the rectangular ROI regions in destination, source, mask and output image.
