### PR TITLE
LSD optimizations

### DIFF
--- a/modules/imgproc/src/lsd.cpp
+++ b/modules/imgproc/src/lsd.cpp
@@ -474,7 +474,6 @@ void LineSegmentDetectorImpl::flsd(std::vector<Vec4f>& lines,
     std::vector<RegionPoint> reg(img_width * img_height);
 
     // Search for line segments
-    unsigned int ls_count = 0;
     for(size_t i = 0, list_size = list.size(); i < list_size; ++i)
     {
         unsigned int adx = list[i].p.x + list[i].p.y * img_width;
@@ -505,7 +504,6 @@ void LineSegmentDetectorImpl::flsd(std::vector<Vec4f>& lines,
                 }
             }
             // Found new line
-            ++ls_count;
 
             // Add the offset
             rec.x1 += 0.5; rec.y1 += 0.5;
@@ -524,13 +522,6 @@ void LineSegmentDetectorImpl::flsd(std::vector<Vec4f>& lines,
             if(w_needed) widths.push_back(rec.width);
             if(p_needed) precisions.push_back(rec.p);
             if(n_needed && doRefine >= LSD_REFINE_ADV) nfas.push_back(log_nfa);
-
-
-            // //Add the linesID to the region on the image
-            // for(unsigned int el = 0; el < reg_size; el++)
-            // {
-            //     region.data[reg[i].x + reg[i].y * width] = ls_count;
-            // }
         }
     }
 }

--- a/modules/imgproc/src/lsd.cpp
+++ b/modules/imgproc/src/lsd.cpp
@@ -964,7 +964,7 @@ double LineSegmentDetectorImpl::rect_nfa(const rect& rec) const
     double dyhw = rec.dy * half_width;
     double dxhw = rec.dx * half_width;
 
-    std::vector<edge> ordered_x(4);
+    edge ordered_x[4];
     edge* min_y = &ordered_x[0];
     edge* max_y = &ordered_x[0]; // Will be used for loop range
 
@@ -973,7 +973,7 @@ double LineSegmentDetectorImpl::rect_nfa(const rect& rec) const
     ordered_x[2].p.x = int(rec.x2 + dyhw); ordered_x[2].p.y = int(rec.y2 - dxhw); ordered_x[2].taken = false;
     ordered_x[3].p.x = int(rec.x1 + dyhw); ordered_x[3].p.y = int(rec.y1 - dxhw); ordered_x[3].taken = false;
 
-    std::sort(ordered_x.begin(), ordered_x.end(), AsmallerB_XoverY);
+    std::sort(ordered_x, ordered_x + 4, AsmallerB_XoverY);
 
     // Find min y. And mark as taken. find max y.
     for(unsigned int i = 1; i < 4; ++i)

--- a/modules/imgproc/src/lsd.cpp
+++ b/modules/imgproc/src/lsd.cpp
@@ -230,8 +230,8 @@ public:
 
 private:
     Mat image;
-    Mat_<double> scaled_image;
-    double *scaled_image_data;
+    Mat scaled_image;
+    uchar *scaled_image_data;
     Mat_<double> angles;     // in rads
     double *angles_data;
     Mat_<double> modgrad;
@@ -414,11 +414,8 @@ void LineSegmentDetectorImpl::detect(InputArray _image, OutputArray _lines,
 {
     CV_INSTRUMENT_REGION()
 
-    Mat_<double> img = _image.getMat();
-    CV_Assert(!img.empty() && img.channels() == 1);
-
-    // Convert image to double
-    img.convertTo(image, CV_64FC1);
+    image = _image.getMat();
+    CV_Assert(!image.empty() && image.type() == CV_8UC1);
 
     std::vector<Vec4f> lines;
     std::vector<double> w, p, n;
@@ -536,7 +533,7 @@ void LineSegmentDetectorImpl::ll_angle(const double& threshold,
 
     angles_data = angles.ptr<double>(0);
     modgrad_data = modgrad.ptr<double>(0);
-    scaled_image_data = scaled_image.ptr<double>(0);
+    scaled_image_data = scaled_image.ptr<uchar>(0);
 
     img_width = scaled_image.cols;
     img_height = scaled_image.rows;
@@ -555,11 +552,11 @@ void LineSegmentDetectorImpl::ll_angle(const double& threshold,
     {
         for(int addr = y * img_width, addr_end = addr + img_width - 1; addr < addr_end; ++addr)
         {
-            double DA = scaled_image_data[addr + img_width + 1] - scaled_image_data[addr];
-            double BC = scaled_image_data[addr + 1] - scaled_image_data[addr + img_width];
-            double gx = DA + BC;    // gradient x component
-            double gy = DA - BC;    // gradient y component
-            double norm = std::sqrt((gx * gx + gy * gy) / 4); // gradient norm
+            int DA = scaled_image_data[addr + img_width + 1] - scaled_image_data[addr];
+            int BC = scaled_image_data[addr + 1] - scaled_image_data[addr + img_width];
+            int gx = DA + BC;    // gradient x component
+            int gy = DA - BC;    // gradient y component
+            double norm = std::sqrt((gx * gx + gy * gy) / 4.0); // gradient norm
 
             modgrad_data[addr] = norm;    // store gradient
 

--- a/modules/imgproc/src/lsd.cpp
+++ b/modules/imgproc/src/lsd.cpp
@@ -267,6 +267,8 @@ private:
         struct coorlist* next;
     };
 
+    std::vector<coorlist> list;
+
     struct rect
     {
         double x1, y1, x2, y2;    // first and second point of the line segment
@@ -306,7 +308,7 @@ private:
  * @param list      Return: Vector of coordinate points that are pseudo ordered by magnitude.
  *                  Pixels would be ordered by norm value, up to a precision given by max_grad/n_bins.
  */
-    void ll_angle(const double& threshold, const unsigned int& n_bins, std::vector<coorlist>& list);
+    void ll_angle(const double& threshold, const unsigned int& n_bins);
 
 /**
  * Grow a region starting from point s with a defined precision,
@@ -438,7 +440,6 @@ void LineSegmentDetectorImpl::flsd(std::vector<Vec4f>& lines,
     const double p = ANG_TH / 180;
     const double rho = QUANT / sin(prec);    // gradient magnitude threshold
 
-    std::vector<coorlist> list;
     if(SCALE != 1)
     {
         Mat gaussian_img;
@@ -449,12 +450,12 @@ void LineSegmentDetectorImpl::flsd(std::vector<Vec4f>& lines,
         GaussianBlur(image, gaussian_img, ksize, sigma);
         // Scale image to needed size
         resize(gaussian_img, scaled_image, Size(), SCALE, SCALE);
-        ll_angle(rho, N_BINS, list);
+        ll_angle(rho, N_BINS);
     }
     else
     {
         scaled_image = image;
-        ll_angle(rho, N_BINS, list);
+        ll_angle(rho, N_BINS);
     }
 
     LOG_NT = 5 * (log10(double(img_width)) + log10(double(img_height))) / 2 + log10(11.0);
@@ -518,8 +519,7 @@ void LineSegmentDetectorImpl::flsd(std::vector<Vec4f>& lines,
 }
 
 void LineSegmentDetectorImpl::ll_angle(const double& threshold,
-                                   const unsigned int& n_bins,
-                                   std::vector<coorlist>& list)
+                                   const unsigned int& n_bins)
 {
     //Initialize data
     angles = Mat_<double>(scaled_image.size());
@@ -564,7 +564,7 @@ void LineSegmentDetectorImpl::ll_angle(const double& threshold,
     }
 
     // Compute histogram of gradient values
-    list = std::vector<coorlist>(img_width * img_height);
+    list.resize(img_width * img_height);
     std::vector<coorlist*> range_s(n_bins);
     std::vector<coorlist*> range_e(n_bins);
     unsigned int count = 0;


### PR DESCRIPTION
### This pullrequest changes

 * Uses the 8-bit image directly instead of converting it to 64-bit floating point first
 * Works with non-continuous images
 * Avoids big ```std::vector``` allocation

Running the test cases the total run time went from ```~3300ms``` to ```~2400ms``` in my Macbook Pro.