### PR TITLE
3rdparty: remove unsupported comiper option when using clang

### DIFF
--- a/3rdparty/carotene/hal/CMakeLists.txt
+++ b/3rdparty/carotene/hal/CMakeLists.txt
@@ -25,6 +25,8 @@ endif()
 if(CMAKE_COMPILER_IS_GNUCXX)
   if(X86 OR ARMEABI_V6 OR (MIPS AND ANDROID_COMPILER_VERSION VERSION_LESS "4.6"))
     list(APPEND TEGRA_COMPILER_FLAGS -fweb -fwrapv -frename-registers -fsched-stalled-insns-dep=100 -fsched-stalled-insns=2)
+  elseif(CMAKE_COMPILER_IS_CLANGCXX)
+    list(APPEND TEGRA_COMPILER_FLAGS -fwrapv)
   else()
     list(APPEND TEGRA_COMPILER_FLAGS -fweb -fwrapv -frename-registers -fsched2-use-superblocks -fsched2-use-traces
                                      -fsched-stalled-insns-dep=100 -fsched-stalled-insns=2)


### PR DESCRIPTION
resolves  #7346

### This pullrequest changes
 - avoid build error using clang on ARM