### PR TITLE
Fix build-break on iOS due to missing lseek

### DIFF
--- a/3rdparty/zlib/gzguts.h
+++ b/3rdparty/zlib/gzguts.h
@@ -207,3 +207,5 @@ char ZLIB_INTERNAL *gz_strwinerror OF((DWORD error));
 unsigned ZLIB_INTERNAL gz_intmax OF((void));
 #  define GT_OFF(x) (sizeof(int) == sizeof(z_off64_t) && (x) > gz_intmax())
 #endif
+#include <stdio.h>
+#include <unistd.h> // Includes explicit declaration of lseek


### PR DESCRIPTION
<!-- Please use this line to close one or multiple issues when this pullrequest gets merged
You can add another line right under the first one:
resolves #1234
resolves #1235
-->
### This pullrequest changes

Building for ios using the python script breaks due to an issue in zlib not being able to find the LSEEK definition. Adding an include for stdio and unistd.h seems to clear this up, as recommended on Internet forums.
