### PR TITLE
Fix dead link for hit or miss 2.4 documentation.

### DIFF
--- a/modules/imgproc/doc/filtering.rst
+++ b/modules/imgproc/doc/filtering.rst
@@ -1271,7 +1271,7 @@ Morphological gradient:
 
     \texttt{dst} = \mathrm{blackhat} ( \texttt{src} , \texttt{element} )= \mathrm{close} ( \texttt{src} , \texttt{element} )- \texttt{src}
 
-"Hit and Miss": Only supported for CV_8UC1 binary images. Tutorial can be found in this page: http://opencv-code.com/tutorials/hit-or-miss-transform-in-opencv/
+"Hit and Miss": Only supported for CV_8UC1 binary images. Tutorial can be found in this page: https://web.archive.org/web/20160316070407/http://opencv-code.com/tutorials/hit-or-miss-transform-in-opencv/
 
 Any of the operations can be done in-place. In case of multi-channel images, each channel is processed independently.
 


### PR DESCRIPTION
<!-- Please use this line to close one or multiple issues when this pullrequest gets merged
You can add another line right under the first one:
resolves #1234
resolves #1235
-->

### This pullrequest fixes

<!-- Please describe what your pullrequest is changing -->
dead link for hit or miss [documentation](http://docs.opencv.org/2.4.13/modules/imgproc/doc/filtering.html#morphologyex).