### PR TITLE
make sure that the empty mat is copied to UMat properly

### DIFF
--- a/modules/core/src/copy.cpp
+++ b/modules/core/src/copy.cpp
@@ -263,6 +263,11 @@ void Mat::copyTo( OutputArray _dst ) const
 
     if( _dst.isUMat() )
     {
+        if( empty() )
+        {
+            _dst.release();
+            return;
+        }
         _dst.create( dims, size.p, type() );
         UMat dst = _dst.getUMat();
 

--- a/modules/videoio/src/cap_avfoundation_mac.mm
+++ b/modules/videoio/src/cap_avfoundation_mac.mm
@@ -118,7 +118,6 @@ private:
     int height;
     int settingWidth;
     int settingHeight;
-    OSType mInputPixelFormat;
 
     int started;
 };
@@ -163,7 +162,6 @@ private:
 
     CMTime mFrameTimestamp;
     size_t mFrameNum;
-    OSType mInputPixelFormat;
 
     int started;
 };


### PR DESCRIPTION
this patch solves crashes in Python tests in #6078 