### PR TITLE
add simd code when scn equals 4 at RGB2HLS_b().

### DIFF
--- a/modules/imgproc/src/color.cpp
+++ b/modules/imgproc/src/color.cpp
@@ -4835,6 +4835,26 @@ struct RGB2HLS_b
                 if (jr)
                     src -= jr, j -= jr;
             }
+            else if (scn == 4 && haveSIMD)
+            {
+                for ( ; j <= (dn * 3 - 12); j += 12, src += 16)
+                {
+                    __m128i v_src = _mm_loadu_si128((__m128i const *)src);
+
+                    __m128i v_src_lo = _mm_unpacklo_epi8(v_src, v_zero);
+                    __m128i v_src_hi = _mm_unpackhi_epi8(v_src, v_zero);
+                    _mm_storeu_ps(buf + j, _mm_mul_ps(_mm_cvtepi32_ps(_mm_unpacklo_epi16(v_src_lo, v_zero)), v_scale_inv));
+                    _mm_storeu_ps(buf + j + 3, _mm_mul_ps(_mm_cvtepi32_ps(_mm_unpackhi_epi16(v_src_lo, v_zero)), v_scale_inv));
+                    _mm_storeu_ps(buf + j + 6, _mm_mul_ps(_mm_cvtepi32_ps(_mm_unpacklo_epi16(v_src_hi, v_zero)), v_scale_inv));
+                    float tmp = buf[j + 8];
+                    _mm_storeu_ps(buf + j + 8, _mm_mul_ps(_mm_cvtepi32_ps(_mm_shuffle_epi32(_mm_unpackhi_epi16(v_src_hi, v_zero), 0x90)), v_scale_inv));
+                    buf[j + 8] = tmp;
+                }
+
+                int jr = j % 3;
+                if (jr)
+                    src -= jr, j -= jr;
+            }
             #endif
             for( ; j < dn*3; j += 3, src += scn )
             {


### PR DESCRIPTION
I improve RGB2HLS_b() for adding simd code when scn equels 4.

<table border=1>
 <tr><th>n</th><th>Average Clocks (original code)</th><th>Average Clocks (new code)</th><th>Faster Rate (compared with original code)</th></tr>
 <tr><td>32</td><td>789.4</td><td>527.6</td><td>49.6%</td></tr>
 <tr><td>64</td><td>1485.2</td><td>928.4</td><td>60.0%</td></tr>
 <tr><td>96</td><td>2186.2</td><td>1422.2</td><td>53.7%</td></tr>
</table>
_srccn:4
cvt() is not called.

Measurement Conditions
OS : Ubuntu 16.04
Compiler : g++ (Ubuntu 5.3.1-13ubuntu3) 5.3.1 20160330
CPU : Intel(R) Core(TM)2 Duo CPU E8500 @ 3.16GHz
Compiler Option : -msse2 -O3
Measurement Function: rdtsc()
