### PR TITLE
core: remove duplicated include

### DIFF
--- a/modules/core/include/opencv2/core/cvdef.h
+++ b/modules/core/include/opencv2/core/cvdef.h
@@ -223,10 +223,6 @@ enum CpuFeatures {
 #  define CV_NEON 1
 #endif
 
-#if defined(__ARM_NEON__) || defined(__aarch64__)
-#  include <arm_neon.h>
-#endif
-
 #if defined __GNUC__ && defined __arm__ && (defined __ARM_PCS_VFP || defined __ARM_VFPV3__ || defined __ARM_NEON__) && !defined __SOFTFP__
 #  define CV_VFP 1
 #endif


### PR DESCRIPTION
### This pullrequest changes
  * duplicate include
  * the include of ```arm_neon.h``` exists just above
