### PR TITLE
Suggested correction for issue  #7408

### DIFF
--- a/modules/imgcodecs/src/grfmt_pxm.cpp
+++ b/modules/imgcodecs/src/grfmt_pxm.cpp
@@ -309,7 +309,7 @@ bool  PxMDecoder::readData( Mat& img )
                         }
                     }
                     else
-                        memcpy( data, src, m_width);
+                        memcpy( data, src, CV_ELEM_SIZE1(m_type)*m_width);
                 }
                 else
                 {


### PR DESCRIPTION
Scaling of data size in regard to pixel size in bytes.
Without it, loading of 16-bit files fails.
