### PR TITLE
Added getLeadingEdges function to subdivision2d

### DIFF
--- a/modules/imgproc/include/opencv2/imgproc.hpp
+++ b/modules/imgproc/include/opencv2/imgproc.hpp
@@ -1012,6 +1012,14 @@ public:
      */
     CV_WRAP void getEdgeList(CV_OUT std::vector<Vec4f>& edgeList) const;
 
+    /** @brief Returns a list of the leading edge ID connected to each triangle.
+
+    @param leadingEdgeList – Output vector.
+
+    The function gives one edge ID for each triangle.
+     */
+    CV_WRAP void getLeadingEdgeList(CV_OUT std::vector<int>& leadingEdgeList) const;
+
     /** @brief Returns a list of all triangles.
 
     @param triangleList – Output vector.

--- a/modules/imgproc/src/subdivision2d.cpp
+++ b/modules/imgproc/src/subdivision2d.cpp
@@ -733,6 +733,26 @@ void Subdiv2D::getEdgeList(std::vector<Vec4f>& edgeList) const
     }
 }
 
+void Subdiv2D::getLeadingEdgeList(std::vector<int>& leadingEdgeList) const
+{
+    leadingEdgeList.clear();
+    int i, total = (int)(qedges.size()*4);
+    std::vector<bool> edgemask(total, false);
+
+    for( i = 4; i < total; i += 2 )
+    {
+        if( edgemask[i] )
+            continue;
+        int edge = i;
+        edgemask[edge] = true;
+        edge = getEdge(edge, NEXT_AROUND_LEFT);
+        edgemask[edge] = true;
+        edge = getEdge(edge, NEXT_AROUND_LEFT);
+        edgemask[edge] = true;
+        leadingEdgeList.push_back(i);
+    }
+}
+
 void Subdiv2D::getTriangleList(std::vector<Vec6f>& triangleList) const
 {
     triangleList.clear();


### PR DESCRIPTION
### This pullrequest changes

Adds getLeadingEdges function to Subdiv2D (subdivision2d.cpp). Returns a list of the leading edge ID connected to each triangle. This provides a nice way to associate edges and triangles.
