### PR TITLE
Java.wrapper.fix.opencv.3.1

### DIFF
--- a/modules/java/generator/gen_java.py
+++ b/modules/java/generator/gen_java.py
@@ -807,6 +807,8 @@ class ClassInfo(GeneralInfo):
             self.imports.add("java.util.List")
             self.imports.add("java.util.ArrayList")
             self.addImports(ctype.replace('vector_vector', 'vector'))
+        elif ctype.startswith('Feature2D'):
+            self.imports.add("org.opencv.features2d.Feature2D")            
         elif ctype.startswith('vector'):
             self.imports.add("org.opencv.core.Mat")
             self.imports.add('java.util.ArrayList')

--- a/modules/java/generator/gen_java.py
+++ b/modules/java/generator/gen_java.py
@@ -807,8 +807,6 @@ class ClassInfo(GeneralInfo):
             self.imports.add("java.util.List")
             self.imports.add("java.util.ArrayList")
             self.addImports(ctype.replace('vector_vector', 'vector'))
-        elif ctype.startswith('Feature2D'):
-            self.imports.add("org.opencv.features2d.Feature2D")            
         elif ctype.startswith('vector'):
             self.imports.add("org.opencv.core.Mat")
             self.imports.add('java.util.ArrayList')

--- a/modules/java/generator/gen_java.py
+++ b/modules/java/generator/gen_java.py
@@ -807,6 +807,8 @@ class ClassInfo(GeneralInfo):
             self.imports.add("java.util.List")
             self.imports.add("java.util.ArrayList")
             self.addImports(ctype.replace('vector_vector', 'vector'))
+        elif ctype.startswith('Feature2D'):
+            self.imports.add("org.opencv.features2d.Feature2D")
         elif ctype.startswith('vector'):
             self.imports.add("org.opencv.core.Mat")
             self.imports.add('java.util.ArrayList')


### PR DESCRIPTION
<!-- Please use this line to close one or multiple issues when this pullrequest gets merged
You can add another line right under the first one:
resolves #1234
resolves #1235
-->

### This pullrequest changes

<!-- Please describe what your pullrequest is changing -->
This change is to add missing import of org.opencv.features2d.Feature2D class to java wrappers. 
The fix is required for successful generation of java wrappers for xfeatures2d module.

Details are in [this article](http://answers.opencv.org/question/101675/surfsift-java-wrapper-for-opencv-3xosx-1011/). 