### PR TITLE
cmake: fix ocv_check_compiler_flag

### DIFF
--- a/apps/traincascade/CMakeLists.txt
+++ b/apps/traincascade/CMakeLists.txt
@@ -8,6 +8,8 @@ endif()
 project(traincascade)
 set(the_target opencv_traincascade)
 
+ocv_warnings_disable(CMAKE_CXX_FLAGS -Woverloaded-virtual)
+
 ocv_target_include_directories(${the_target} PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}" "${OpenCV_SOURCE_DIR}/include/opencv")
 ocv_target_include_modules_recurse(${the_target} ${OPENCV_TRAINCASCADE_DEPS})
 

--- a/modules/core/test/ocl/test_arithm.cpp
+++ b/modules/core/test/ocl/test_arithm.cpp
@@ -134,7 +134,7 @@ PARAM_TEST_CASE(ArithmTestBase, MatDepth, Channels, bool)
         use_roi = GET_PARAM(2);
     }
 
-    virtual void generateTestData(bool with_val_in_range = false)
+    void generateTestData(bool with_val_in_range = false)
     {
         const int type = CV_MAKE_TYPE(depth, cn);
 
@@ -897,7 +897,7 @@ struct RepeatTestCase :
 {
     int nx, ny;
 
-    virtual void generateTestData()
+    void generateTestData()
     {
         const int type = CV_MAKE_TYPE(depth, cn);
 
@@ -1495,7 +1495,7 @@ PARAM_TEST_CASE(InRange, MatDepth, Channels, bool /*Scalar or not*/, bool /*Roi*
         use_roi = GET_PARAM(3);
     }
 
-    virtual void generateTestData()
+    void generateTestData()
     {
         const int type = CV_MAKE_TYPE(depth, cn);
 
@@ -1574,7 +1574,7 @@ PARAM_TEST_CASE(ConvertScaleAbs, MatDepth, Channels, bool)
         use_roi = GET_PARAM(2);
     }
 
-    virtual void generateTestData()
+    void generateTestData()
     {
         const int stype = CV_MAKE_TYPE(depth, cn);
         const int dtype = CV_MAKE_TYPE(CV_8U, cn);
@@ -1647,7 +1647,7 @@ PARAM_TEST_CASE(PatchNaNs, Channels, bool)
         use_roi = GET_PARAM(1);
     }
 
-    virtual void generateTestData()
+    void generateTestData()
     {
         const int type = CV_MAKE_TYPE(CV_32F, cn);
 
@@ -1727,7 +1727,7 @@ PARAM_TEST_CASE(Reduce, std::pair<MatDepth, MatDepth>, Channels, int, bool)
         use_roi = GET_PARAM(3);
     }
 
-    virtual void generateTestData()
+    void generateTestData()
     {
         const int stype = CV_MAKE_TYPE(sdepth, cn);
         dtype = CV_MAKE_TYPE(ddepth, cn);

--- a/modules/core/test/ocl/test_matrix_operation.cpp
+++ b/modules/core/test/ocl/test_matrix_operation.cpp
@@ -71,7 +71,7 @@ PARAM_TEST_CASE(ConvertTo, MatDepth, MatDepth, Channels, bool)
         use_roi = GET_PARAM(3);
     }
 
-    virtual void generateTestData()
+    void generateTestData()
     {
         Size roiSize = randomSize(1, MAX_VALUE);
         Border srcBorder = randomBorder(0, use_roi ? MAX_VALUE : 0);

--- a/modules/core/test/test_ippasync.cpp
+++ b/modules/core/test/test_ippasync.cpp
@@ -32,7 +32,7 @@ PARAM_TEST_CASE(IPPAsync, MatDepth, Channels, hppAccelType)
         accelType = GET_PARAM(2);
     }
 
-    virtual void generateTestData()
+    void generateTestData()
     {
         Size matrix_Size = randomSize(2, 100);
         const double upValue = 100;
@@ -102,7 +102,7 @@ PARAM_TEST_CASE(IPPAsyncShared, Channels, hppAccelType)
         type=CV_MAKE_TYPE(CV_8U, GET_PARAM(0));
     }
 
-    virtual void generateTestData()
+    void generateTestData()
     {
         Size matrix_Size = randomSize(2, 100);
         hpp32u pitch, size;

--- a/modules/imgproc/test/ocl/test_histogram.cpp
+++ b/modules/imgproc/test/ocl/test_histogram.cpp
@@ -94,7 +94,7 @@ PARAM_TEST_CASE(CalcBackProject, MatDepth, int, bool)
         uimages_roi.resize(N);
     }
 
-    virtual void random_roi()
+    void random_roi()
     {
         Size roiSize = randomSize(1, MAX_VALUE);
 
@@ -233,7 +233,7 @@ PARAM_TEST_CASE(CalcHist, bool)
         useRoi = GET_PARAM(0);
     }
 
-    virtual void random_roi()
+    void random_roi()
     {
         Size roiSize = randomSize(1, MAX_VALUE);
 

--- a/modules/imgproc/test/ocl/test_houghlines.cpp
+++ b/modules/imgproc/test/ocl/test_houghlines.cpp
@@ -40,7 +40,7 @@ PARAM_TEST_CASE(HoughLines, double, double, int)
         threshold = GET_PARAM(2);
     }
 
-    virtual void generateTestData()
+    void generateTestData()
     {
         src_size = randomSize(500, 1920);
         src.create(src_size, CV_8UC1);
@@ -55,7 +55,7 @@ PARAM_TEST_CASE(HoughLines, double, double, int)
         src.copyTo(usrc);
     }
 
-    virtual void readRealTestData()
+    void readRealTestData()
     {
         Mat img = readImage("shared/pic5.png", IMREAD_GRAYSCALE);
         Canny(img, src, 100, 150, 3);
@@ -63,7 +63,7 @@ PARAM_TEST_CASE(HoughLines, double, double, int)
         src.copyTo(usrc);
     }
 
-    virtual void Near(double eps = 0.)
+    void Near(double eps = 0.)
     {
         EXPECT_EQ(dst.size(), udst.size());
 
@@ -124,7 +124,7 @@ PARAM_TEST_CASE(HoughLinesP, int, double, double)
         maxGap = GET_PARAM(2);
     }
 
-    virtual void readRealTestData()
+    void readRealTestData()
     {
         Mat img = readImage("shared/pic5.png", IMREAD_GRAYSCALE);
         Canny(img, src, 50, 200, 3);
@@ -132,7 +132,7 @@ PARAM_TEST_CASE(HoughLinesP, int, double, double)
         src.copyTo(usrc);
     }
 
-    virtual void Near(double eps = 0.)
+    void Near(double eps = 0.)
     {
         Mat lines_gpu = udst.getMat(ACCESS_READ);
 

--- a/modules/imgproc/test/ocl/test_imgproc.cpp
+++ b/modules/imgproc/test/ocl/test_imgproc.cpp
@@ -81,7 +81,7 @@ PARAM_TEST_CASE(ImgprocTestBase, MatType,
         useRoi = GET_PARAM(3);
     }
 
-    virtual void random_roi()
+    void random_roi()
     {
         Size roiSize = randomSize(1, MAX_VALUE);
         Border srcBorder = randomBorder(0, useRoi ? MAX_VALUE : 0);
@@ -193,7 +193,7 @@ OCL_TEST_P(EqualizeHist, Mat)
 struct CornerTestBase :
         public ImgprocTestBase
 {
-    virtual void random_roi()
+    void random_roi()
     {
         Mat image = readImageType("../gpu/stereobm/aloe-L.png", type);
         ASSERT_FALSE(image.empty());
@@ -296,7 +296,7 @@ struct Integral :
         useRoi = GET_PARAM(3);
     }
 
-    virtual void random_roi()
+    void random_roi()
     {
         ASSERT_EQ(CV_MAT_CN(type), 1);
 

--- a/modules/imgproc/test/ocl/test_match_template.cpp
+++ b/modules/imgproc/test/ocl/test_match_template.cpp
@@ -74,7 +74,7 @@ PARAM_TEST_CASE(MatchTemplate, MatDepth, Channels, MatchTemplType, bool)
         use_roi = GET_PARAM(3);
     }
 
-    virtual void generateTestData()
+    void generateTestData()
     {
         Size image_roiSize = randomSize(2, 100);
         Size templ_roiSize = Size(randomInt(1, image_roiSize.width), randomInt(1, image_roiSize.height));

--- a/modules/imgproc/test/ocl/test_medianfilter.cpp
+++ b/modules/imgproc/test/ocl/test_medianfilter.cpp
@@ -67,7 +67,7 @@ PARAM_TEST_CASE(MedianFilter, MatDepth, Channels, int, bool)
         use_roi = GET_PARAM(3);
     }
 
-    virtual void generateTestData()
+    void generateTestData()
     {
         Size roiSize = randomSize(1, MAX_VALUE);
         Border srcBorder = randomBorder(0, use_roi ? MAX_VALUE : 0);

--- a/modules/java/CMakeLists.txt
+++ b/modules/java/CMakeLists.txt
@@ -349,6 +349,7 @@ endif(ANDROID)
 
 # workarounding lack of `__attribute__ ((visibility("default")))` in jni_md.h/JNIEXPORT
 string(REPLACE "-fvisibility=hidden" "" CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
+ocv_warnings_disable(CMAKE_CXX_FLAGS -Wunused-const-variable)
 
 ocv_add_library(${the_module} SHARED ${handwritten_h_sources} ${handwritten_cpp_sources} ${generated_cpp_sources}
                                  ${copied_files}

--- a/modules/java/generator/gen_java.py
+++ b/modules/java/generator/gen_java.py
@@ -996,7 +996,7 @@ class JavaWrapperGenerator(object):
         type_dict["Ptr_"+name] = \
             { "j_type" : name,
               "jn_type" : "long", "jn_args" : (("__int64", ".nativeObj"),),
-              "jni_name" : "Ptr<"+name+">(("+classinfo.fullName(isCPP=True)+"*)%(n)s_nativeObj)", "jni_type" : "jlong",
+              "jni_name" : "Ptr<"+classinfo.fullName(isCPP=True)+">(("+classinfo.fullName(isCPP=True)+"*)%(n)s_nativeObj)", "jni_type" : "jlong",
               "suffix" : "J" }
         logging.info('ok: class %s, name: %s, base: %s', classinfo, name, classinfo.base)
 

--- a/modules/photo/test/ocl/test_denoising.cpp
+++ b/modules/photo/test/ocl/test_denoising.cpp
@@ -37,7 +37,7 @@ PARAM_TEST_CASE(FastNlMeansDenoisingTestBase, Channels, int, bool, bool)
             h[i] = 3.0f + 0.5f*i;
     }
 
-    virtual void generateTestData()
+    void generateTestData()
     {
         const int type = CV_8UC(cn);
         Mat image;

--- a/modules/python/common.cmake
+++ b/modules/python/common.cmake
@@ -112,6 +112,8 @@ if(MSVC AND NOT ENABLE_NOISY_WARNINGS)
   string(REPLACE "/W4" "/W3" CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
 endif()
 
+ocv_warnings_disable(CMAKE_CXX_FLAGS -Woverloaded-virtual -Wunused-private-field)
+
 if(MSVC AND NOT BUILD_SHARED_LIBS)
   set_target_properties(${the_module} PROPERTIES LINK_FLAGS "/NODEFAULTLIB:atlthunk.lib /NODEFAULTLIB:atlsd.lib /DEBUG")
 endif()

--- a/modules/stitching/test/ocl/test_warpers.cpp
+++ b/modules/stitching/test/ocl/test_warpers.cpp
@@ -55,7 +55,7 @@ struct WarperTestBase :
     UMat usrc, udst, uxmap, uymap;
     Mat K, R;
 
-    virtual void generateTestData()
+    void generateTestData()
     {
         Size size = randomSize(1, MAX_VALUE);
 

--- a/modules/ts/include/opencv2/ts/ts_perf.hpp
+++ b/modules/ts/include/opencv2/ts/ts_perf.hpp
@@ -121,7 +121,7 @@ private:
         }                                                                               \
     private: int val_;                                                                  \
     };                                                                                  \
-    inline void PrintTo(const class_name& t, std::ostream* os) { t.PrintTo(os); } }
+    static inline void PrintTo(const class_name& t, std::ostream* os) { t.PrintTo(os); } }
 
 #define CV_FLAGS(class_name, ...)                                                       \
     namespace {                                                                         \
@@ -150,7 +150,7 @@ private:
         }                                                                               \
     private: int val_;                                                                  \
     };                                                                                  \
-    inline void PrintTo(const class_name& t, std::ostream* os) { t.PrintTo(os); } }
+    static inline void PrintTo(const class_name& t, std::ostream* os) { t.PrintTo(os); } }
 
 CV_ENUM(MatDepth, CV_8U, CV_8S, CV_16U, CV_16S, CV_32S, CV_32F, CV_64F, CV_USRTYPE1)
 

--- a/modules/ts/src/ts_gtest.cpp
+++ b/modules/ts/src/ts_gtest.cpp
@@ -7954,7 +7954,7 @@ namespace internal {
 // of them.
 const char kPathSeparator = '\\';
 const char kAlternatePathSeparator = '/';
-const char kPathSeparatorString[] = "\\";
+//const char kPathSeparatorString[] = "\\";
 const char kAlternatePathSeparatorString[] = "/";
 # if GTEST_OS_WINDOWS_MOBILE
 // Windows CE doesn't have a current directory. You should not use
@@ -7968,7 +7968,7 @@ const char kCurrentDirectoryString[] = ".\\";
 # endif  // GTEST_OS_WINDOWS_MOBILE
 #else
 const char kPathSeparator = '/';
-const char kPathSeparatorString[] = "/";
+//const char kPathSeparatorString[] = "/";
 const char kCurrentDirectoryString[] = "./";
 #endif  // GTEST_OS_WINDOWS
 

--- a/modules/video/perf/opencl/perf_optflow_pyrlk.cpp
+++ b/modules/video/perf/opencl/perf_optflow_pyrlk.cpp
@@ -54,9 +54,6 @@ using std::tr1::make_tuple;
 namespace cvtest {
 namespace ocl {
 
-///////////// FarnebackOpticalFlow ////////////////////////
-CV_ENUM(farneFlagType, 0, OPTFLOW_FARNEBACK_GAUSSIAN)
-
 typedef tuple< int > PyrLKOpticalFlowParams;
 typedef TestBaseWithParam<PyrLKOpticalFlowParams> PyrLKOpticalFlowFixture;
 

--- a/samples/cpp/detect_mser.cpp
+++ b/samples/cpp/detect_mser.cpp
@@ -97,8 +97,10 @@ static String Legende(MSERParams &pAct)
 }
 
 
+#ifdef HAVE_OPENGL
 const int win_width = 800;
 const int win_height = 640;
+#endif
 bool    rotateEnable=true;
 bool    keyPressed=false;
 

--- a/samples/cpp/videostab.cpp
+++ b/samples/cpp/videostab.cpp
@@ -224,6 +224,8 @@ public:
             kbest->setOutlierRejector(outlierRejector);
             return kbest;
         }
+#else
+        CV_Assert(gpu == false && "CUDA modules are not available");
 #endif
 
         Ptr<KeypointBasedMotionEstimator> kbest = makePtr<KeypointBasedMotionEstimator>(est);
@@ -265,6 +267,8 @@ public:
             kbest->setOutlierRejector(outlierRejector);
             return kbest;
         }
+#else
+        CV_Assert(gpu == false && "CUDA modules are not available");
 #endif
 
         Ptr<KeypointBasedMotionEstimator> kbest = makePtr<KeypointBasedMotionEstimator>(est);


### PR DESCRIPTION
**Merge with:** https://github.com/opencv/opencv_contrib/pull/807

Some supported flags were rejected. Reason of this is regex applied to full build logs which causes false alarms for error/warning message detection.
This patch scans build log by lines (with replacement of ';' to ',' due CMake lists implementation issues).