### PR TITLE
Add information in the findContours documentation.

### DIFF
--- a/modules/core/include/opencv2/core.hpp
+++ b/modules/core/include/opencv2/core.hpp
@@ -300,19 +300,19 @@ function does not copy src itself but simply constructs the border, for example:
 @endcode
 @note When the source image is a part (ROI) of a bigger image, the function will try to use the
 pixels outside of the ROI to form a border. To disable this feature and always do extrapolation, as
-if src was not a ROI, use borderType | BORDER_ISOLATED.
+if src was not a ROI, use borderType | cv::BORDER_ISOLATED.
 
 @param src Source image.
 @param dst Destination image of the same type as src and the size Size(src.cols+left+right,
 src.rows+top+bottom) .
-@param top
-@param bottom
-@param left
-@param right Parameter specifying how many pixels in each direction from the source image rectangle
+@param top Top padding size. Parameter specifying how many pixels in each direction from the source image rectangle
 to extrapolate. For example, top=1, bottom=1, left=1, right=1 mean that 1 pixel-wide border needs
 to be built.
-@param borderType Border type. See borderInterpolate for details.
-@param value Border value if borderType==BORDER_CONSTANT .
+@param bottom Bottom padding size.
+@param left Left padding size.
+@param right Right padding size.
+@param borderType Border type. See cv::borderInterpolate for details.
+@param value Border value if borderType==cv::BORDER_CONSTANT .
 
 @sa  borderInterpolate
 */

--- a/modules/imgproc/include/opencv2/imgproc.hpp
+++ b/modules/imgproc/include/opencv2/imgproc.hpp
@@ -3730,20 +3730,22 @@ CV_EXPORTS_W int connectedComponentsWithStats(InputArray image, OutputArray labe
 /** @brief Finds contours in a binary image.
 
 The function retrieves contours from the binary image using the algorithm @cite Suzuki85 . The contours
-are a useful tool for shape analysis and object detection and recognition. See squares.c in the
+are a useful tool for shape analysis and object detection and recognition. See squares.cpp in the
 OpenCV sample directory.
 
 @note Source image is modified by this function. Also, the function does not take into account
 1-pixel border of the image (it's filled with 0's and used for neighbor analysis in the algorithm),
 therefore the contours touching the image border will be clipped.
+To overcome this, you can use the cv::copyMakeBorder function to add a 1-pixel border around the image
+and then correct the offset with offset=cv::Point(-1,-1).
 
 @param image Source, an 8-bit single-channel image. Non-zero pixels are treated as 1's. Zero
 pixels remain 0's, so the image is treated as binary . You can use compare , inRange , threshold ,
 adaptiveThreshold , Canny , and others to create a binary image out of a grayscale or color one.
 The function modifies the image while extracting the contours. If mode equals to RETR_CCOMP
 or RETR_FLOODFILL, the input can also be a 32-bit integer image of labels (CV_32SC1).
-@param contours Detected contours. Each contour is stored as a vector of points.
-@param hierarchy Optional output vector, containing information about the image topology. It has
+@param contours Detected contours. Each contour is stored as a vector of points (e.g. std::vector<std::vector<cv::Point> >).
+@param hierarchy Optional output vector (e.g. std::vector<cv::Vec4i>), containing information about the image topology. It has
 as many elements as the number of contours. For each i-th contour contours[i] , the elements
 hierarchy[i][0] , hiearchy[i][1] , hiearchy[i][2] , and hiearchy[i][3] are set to 0-based indices
 in contours of the next and previous contours at the same hierarchical level, the first child


### PR DESCRIPTION
I propose to add in the findContours documentation a way to retrieve the contours located at the border.
I propose to add also the type (`std::vector<std::vector<cv::Point> >` for contours and `std::vector<cv::Vec4i>` for hierarchy) that should suit to most of the users.

Related issues #4374 and #4988. 

Edit:
the following code should highlight the "issue" at the border and the proposed workaroung:
 ```
cv::Mat img = cv::Mat::ones(8, 10, CV_8U);
std::cout << "img:\n" << img << std::endl;

cv::Mat img_with_border;
cv::copyMakeBorder(img, img_with_border, 1, 1, 1, 1, cv::BORDER_CONSTANT, cv::Scalar(0));
std::cout << "\nimg_with_border:\n" << img_with_border << std::endl;

std::vector<std::vector<cv::Point> > contours;
cv::findContours(img, contours, cv::RETR_LIST, cv::CHAIN_APPROX_NONE);

cv::Mat img_draw_contours = cv::Mat::zeros(img.size(), CV_8U);
for (size_t cpt = 0; cpt < contours.size(); cpt++) {
  cv::drawContours(img_draw_contours, contours, cpt, cv::Scalar(255));
}
std::cout << "\nimg_draw_contours:\n" << img_draw_contours << std::endl;

std::vector<std::vector<cv::Point> > contours_border;
cv::findContours(img_with_border, contours_border, cv::RETR_LIST, cv::CHAIN_APPROX_NONE, cv::Point(-1,-1));

cv::Mat img_draw_contours_border = cv::Mat::zeros(img.size(), CV_8U);
for (size_t cpt = 0; cpt < contours_border.size(); cpt++) {
  cv::drawContours(img_draw_contours_border, contours_border, cpt, cv::Scalar(255));
}
std::cout << "\nimg_draw_contours_border:\n" << img_draw_contours_border << std::endl;
```

Corresponding output:
```
img:
[  1,   1,   1,   1,   1,   1,   1,   1,   1,   1;
   1,   1,   1,   1,   1,   1,   1,   1,   1,   1;
   1,   1,   1,   1,   1,   1,   1,   1,   1,   1;
   1,   1,   1,   1,   1,   1,   1,   1,   1,   1;
   1,   1,   1,   1,   1,   1,   1,   1,   1,   1;
   1,   1,   1,   1,   1,   1,   1,   1,   1,   1;
   1,   1,   1,   1,   1,   1,   1,   1,   1,   1;
   1,   1,   1,   1,   1,   1,   1,   1,   1,   1]

img_with_border:
[  0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0;
   0,   1,   1,   1,   1,   1,   1,   1,   1,   1,   1,   0;
   0,   1,   1,   1,   1,   1,   1,   1,   1,   1,   1,   0;
   0,   1,   1,   1,   1,   1,   1,   1,   1,   1,   1,   0;
   0,   1,   1,   1,   1,   1,   1,   1,   1,   1,   1,   0;
   0,   1,   1,   1,   1,   1,   1,   1,   1,   1,   1,   0;
   0,   1,   1,   1,   1,   1,   1,   1,   1,   1,   1,   0;
   0,   1,   1,   1,   1,   1,   1,   1,   1,   1,   1,   0;
   0,   1,   1,   1,   1,   1,   1,   1,   1,   1,   1,   0;
   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0]

img_draw_contours:
[  0,   0,   0,   0,   0,   0,   0,   0,   0,   0;
   0, 255, 255, 255, 255, 255, 255, 255, 255,   0;
   0, 255,   0,   0,   0,   0,   0,   0, 255,   0;
   0, 255,   0,   0,   0,   0,   0,   0, 255,   0;
   0, 255,   0,   0,   0,   0,   0,   0, 255,   0;
   0, 255,   0,   0,   0,   0,   0,   0, 255,   0;
   0, 255, 255, 255, 255, 255, 255, 255, 255,   0;
   0,   0,   0,   0,   0,   0,   0,   0,   0,   0]

img_draw_contours_border:
[255, 255, 255, 255, 255, 255, 255, 255, 255, 255;
 255,   0,   0,   0,   0,   0,   0,   0,   0, 255;
 255,   0,   0,   0,   0,   0,   0,   0,   0, 255;
 255,   0,   0,   0,   0,   0,   0,   0,   0, 255;
 255,   0,   0,   0,   0,   0,   0,   0,   0, 255;
 255,   0,   0,   0,   0,   0,   0,   0,   0, 255;
 255,   0,   0,   0,   0,   0,   0,   0,   0, 255;
 255, 255, 255, 255, 255, 255, 255, 255, 255, 255]
```