### PR TITLE
Added AKAZE features in the stitcher pipeline (issue #6474)

### DIFF
--- a/modules/stitching/include/opencv2/stitching/detail/matchers.hpp
+++ b/modules/stitching/include/opencv2/stitching/detail/matchers.hpp
@@ -131,6 +131,27 @@ private:
     Size grid_size;
 };
 
+/** @brief AKAZE features finder. :
+
+@sa detail::FeaturesFinder, AKAZE
+*/
+class CV_EXPORTS AKAZEFeaturesFinder : public detail::FeaturesFinder
+{
+public:
+    AKAZEFeaturesFinder(int descriptor_type = AKAZE::DESCRIPTOR_MLDB,
+                        int descriptor_size = 0,
+                        int descriptor_channels = 3,
+                        float threshold = 0.001f,
+                        int nOctaves = 4,
+                        int nOctaveLayers = 4,
+                        int diffusivity = KAZE::DIFF_PM_G2);
+
+private:
+    void find(InputArray image, detail::ImageFeatures &features);
+
+    Ptr<AKAZE> akaze;
+};
+
 
 #ifdef HAVE_OPENCV_XFEATURES2D
 class CV_EXPORTS SurfFeaturesFinderGpu : public FeaturesFinder

--- a/modules/stitching/src/matchers.cpp
+++ b/modules/stitching/src/matchers.cpp
@@ -462,6 +462,27 @@ void OrbFeaturesFinder::find(InputArray image, ImageFeatures &features)
     }
 }
 
+AKAZEFeaturesFinder::AKAZEFeaturesFinder(int descriptor_type,
+                                         int descriptor_size,
+                                         int descriptor_channels,
+                                         float threshold,
+                                         int nOctaves,
+                                         int nOctaveLayers,
+                                         int diffusivity)
+{
+    akaze = AKAZE::create(descriptor_type, descriptor_size, descriptor_channels,
+                          threshold, nOctaves, nOctaveLayers, diffusivity);
+}
+
+void AKAZEFeaturesFinder::find(InputArray image, detail::ImageFeatures &features)
+{
+    CV_Assert((image.type() == CV_8UC3) || (image.type() == CV_8UC1));
+    Mat descriptors;
+    UMat uimage = image.getUMat();
+    akaze->detectAndCompute(uimage, UMat(), features.keypoints, descriptors);
+    features.descriptors = descriptors.getUMat(ACCESS_READ);
+}
+
 #ifdef HAVE_OPENCV_XFEATURES2D
 SurfFeaturesFinderGpu::SurfFeaturesFinderGpu(double hess_thresh, int num_octaves, int num_layers,
                                              int num_octaves_descr, int num_layers_descr)


### PR DESCRIPTION
<!-- Please use this line to close one or multiple issues when this pullrequest gets merged
You can add another line right under the first one:
resolves #1234
resolves #1235
-->

### Resolve #6474

Adds AKAZE features to the stiching pipeline.

Had to use Mat instead of UMat for the descriptors in the detectAndCompute function since AKAZE implementation doesn't seem to support UMat for descriptors.

