### PR TITLE
imgproc: fix Canny bindings mixup

### DIFF
--- a/modules/imgproc/include/opencv2/imgproc.hpp
+++ b/modules/imgproc/include/opencv2/imgproc.hpp
@@ -1681,7 +1681,8 @@ Finds edges in an image using the Canny algorithm with custom image gradient.
 @param dy 16-bit y derivative of input image (same type as dx).
 @param edges,threshold1,threshold2,L2gradient See cv::Canny
  */
-CV_EXPORTS_W void Canny( InputArray dx, InputArray dy,
+CV_EXPORTS_AS(CannyGradient)
+             void Canny( InputArray dx, InputArray dy,
                          OutputArray edges,
                          double threshold1, double threshold2,
                          bool L2gradient = false );


### PR DESCRIPTION
**DO NOT MERGE**
**WIP**
Problem is reported here: https://github.com/opencv/opencv/commit/460b1dc2faf030c171fc2fd43ddb113bc800596e#commitcomment-19376346

BTW, Bindings generator should detect and not allow duplicates for overloaded functions/methods.