### PR TITLE
java: integrate code from base modules

### DIFF
--- a/modules/features2d/misc/java/filelist_common
+++ b/modules/features2d/misc/java/filelist_common
@@ -1,0 +1,1 @@
+misc/java/src/cpp/features2d_converters.hpp

--- a/modules/features2d/misc/java/src/cpp/features2d_converters.hpp
+++ b/modules/features2d/misc/java/src/cpp/features2d_converters.hpp
@@ -3,8 +3,7 @@
 
 #include "opencv2/opencv_modules.hpp"
 #include "opencv2/core.hpp"
-
-#include "features2d_manual.hpp"
+#include "opencv2/features2d.hpp"
 
 void Mat_to_vector_KeyPoint(cv::Mat& mat, std::vector<cv::KeyPoint>& v_kp);
 void vector_KeyPoint_to_Mat(std::vector<cv::KeyPoint>& v_kp, cv::Mat& mat);

--- a/modules/java/CMakeLists.txt
+++ b/modules/java/CMakeLists.txt
@@ -129,7 +129,7 @@ set(scripts_gen_java "${CMAKE_CURRENT_SOURCE_DIR}/generator/gen_java.py")
 set(scripts_hdr_parser "${CMAKE_CURRENT_SOURCE_DIR}/../python/src2/hdr_parser.py")
 
 # directory to store temporary files generated on first gen_java.py run
-set(probe_dir "${CMAKE_CURRENT_BINARY_DIR}/gen_java_out")
+set(probe_dir "${CMAKE_CURRENT_BINARY_DIR}/test_gen")
 
 # handwritten C/C++ and Java sources
 glob_more_specific_sources(H "${CMAKE_CURRENT_SOURCE_DIR}/generator" handwritten_h_sources)
@@ -159,9 +159,18 @@ foreach(module ${OPENCV_JAVA_MODULES})
 
   set(opencv_public_headers_${module} ${module_headers})
   list(APPEND opencv_public_headers ${module_headers})
-  list(APPEND generated_cpp_sources "${CMAKE_CURRENT_BINARY_DIR}/${module}.cpp")
+  list(APPEND generated_cpp_sources "${CMAKE_CURRENT_BINARY_DIR}/gen/${module}.cpp")
 
   include_directories("${module_java_dir}/src/cpp")
+
+  foreach(m ${OPENCV_MODULE_opencv_${module}_DEPS})
+    set(common_header_list "${OPENCV_MODULE_${m}_LOCATION}/misc/java/filelist_common")
+    if(EXISTS "${common_header_list}")
+      file(STRINGS "${common_header_list}" __headers)
+      ocv_list_add_prefix(__headers "${OPENCV_MODULE_${m}_LOCATION}/")
+      list(APPEND opencv_java_common_headers_${module} ${__headers})
+    endif()
+  endforeach()
 
   glob_more_specific_sources(H "${module_java_dir}" handwritten_h_sources)
   glob_more_specific_sources(CPP "${module_java_dir}" handwritten_cpp_sources)
@@ -171,11 +180,11 @@ foreach(module ${OPENCV_JAVA_MODULES})
   # first run of gen_java.py (to get list of generated files)
   file(REMOVE_RECURSE "${probe_dir}")
   file(MAKE_DIRECTORY "${probe_dir}")
-  execute_process(COMMAND ${PYTHON_DEFAULT_EXECUTABLE} "${scripts_gen_java}" "${scripts_hdr_parser}" ${module} ${opencv_public_headers_${module}}
+  execute_process(COMMAND ${PYTHON_DEFAULT_EXECUTABLE} "${scripts_gen_java}" "${scripts_hdr_parser}" ${module} ${opencv_public_headers_${module}} "--common" ${opencv_java_common_headers_${module}}
                   WORKING_DIRECTORY "${probe_dir}"
                   OUTPUT_QUIET ERROR_QUIET)
   file(GLOB_RECURSE generated_java_sources_${module} RELATIVE "${probe_dir}" "${probe_dir}/*.java")
-  ocv_list_add_prefix(generated_java_sources_${module} "${CMAKE_CURRENT_BINARY_DIR}/")
+  ocv_list_add_prefix(generated_java_sources_${module} "${CMAKE_CURRENT_BINARY_DIR}/gen/")
   list(APPEND generated_java_sources ${generated_java_sources_${module}})
 endforeach()
 
@@ -205,13 +214,14 @@ add_cmake_dependencies(${scripts_gen_java} ${scripts_hdr_parser} ${opencv_public
 ######################################################################################################################################
 
 # step 1: generate .cpp/.java from OpenCV headers
+file(MAKE_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/gen")
 set(step1_depends "${scripts_gen_java}" "${scripts_hdr_parser}" ${opencv_public_headers})
 foreach(module ${OPENCV_JAVA_MODULES})
   # second run of gen_java.py (at build time)
-  add_custom_command(OUTPUT ${generated_java_sources_${module}} "${CMAKE_CURRENT_BINARY_DIR}/${module}.cpp"
-                     COMMAND ${PYTHON_DEFAULT_EXECUTABLE} "${scripts_gen_java}" "${scripts_hdr_parser}" ${module} ${opencv_public_headers_${module}}
-                     WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
-                     DEPENDS "${scripts_gen_java}" "${scripts_hdr_parser}" ${opencv_public_headers_${module}}
+  add_custom_command(OUTPUT ${generated_java_sources_${module}} "${CMAKE_CURRENT_BINARY_DIR}/gen/${module}.cpp"
+                     COMMAND ${PYTHON_DEFAULT_EXECUTABLE} "${scripts_gen_java}" "${scripts_hdr_parser}" ${module} ${opencv_public_headers_${module}} "--common" ${opencv_java_common_headers_${module}}
+                     WORKING_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/gen/"
+                     DEPENDS "${scripts_gen_java}" "${scripts_hdr_parser}" ${opencv_public_headers_${module}} ${opencv_java_common_headers_${module}}
                     )
 endforeach()
 

--- a/modules/java/generator/gen_java.py
+++ b/modules/java/generator/gen_java.py
@@ -1039,7 +1039,7 @@ class JavaWrapperGenerator(object):
         f.write(buf)
         f.close()
 
-    def gen(self, srcfiles, module, output_path):
+    def gen(self, srcfiles, module, output_path, common_headers):
         self.clear()
         self.module = module
         self.Module = module.capitalize()
@@ -1050,6 +1050,9 @@ class JavaWrapperGenerator(object):
 
         # scan the headers and build more descriptive maps of classes, consts, functions
         includes = [];
+        for hdr in common_headers:
+            logging.info("\n===== Common header : %s =====", hdr)
+            includes.append('#include "' + hdr + '"')
         for hdr in srcfiles:
             decls = parser.parse(hdr)
             self.namespaces = parser.namespaces
@@ -1057,6 +1060,8 @@ class JavaWrapperGenerator(object):
             logging.info("Namespaces: %s", parser.namespaces)
             if decls:
                 includes.append('#include "' + hdr + '"')
+            else:
+                logging.info("Ignore header: %s", hdr)
             for decl in decls:
                 logging.info("\n--- Incoming ---\n%s", pformat(decl, 4))
                 name = decl[0]
@@ -1568,10 +1573,15 @@ if __name__ == "__main__":
     import hdr_parser
     module = sys.argv[2]
     srcfiles = sys.argv[3:]
+    common_headers = []
+    if '--common' in srcfiles:
+        pos = srcfiles.index('--common')
+        common_headers = srcfiles[pos+1:]
+        srcfiles = srcfiles[:pos]
     logging.basicConfig(filename='%s/%s.log' % (dstdir, module), format=None, filemode='w', level=logging.INFO)
     handler = logging.StreamHandler()
     handler.setLevel(logging.WARNING)
     logging.getLogger().addHandler(handler)
     #print("Generating module '" + module + "' from headers:\n\t" + "\n\t".join(srcfiles))
     generator = JavaWrapperGenerator()
-    generator.gen(srcfiles, module, dstdir)
+    generator.gen(srcfiles, module, dstdir, common_headers)


### PR DESCRIPTION
To resolve undefined "Mat_to_vector_KeyPoint" error in opencv_contrib modules.