### PR TITLE
fix for legacy FeatureDetector and DescriptorMatcher classes

### DIFF
--- a/modules/features2d/misc/java/src/cpp/features2d_manual.hpp
+++ b/modules/features2d/misc/java/src/cpp/features2d_manual.hpp
@@ -89,7 +89,7 @@ public:
 
     //supported: FAST STAR SIFT SURF ORB MSER GFTT HARRIS BRISK AKAZE Grid(XXXX) Pyramid(XXXX) Dynamic(XXXX)
     //not supported: SimpleBlob, Dense
-    CV_WRAP static javaFeatureDetector* create( int detectorType )
+    CV_WRAP static Ptr<javaFeatureDetector> create( int detectorType )
     {
         //String name;
         if (detectorType > DYNAMICDETECTOR)
@@ -156,7 +156,7 @@ public:
             break;
         }
 
-        return new javaFeatureDetector(fd);
+        return makePtr<javaFeatureDetector>(fd);
     }
 
     CV_WRAP void write( const String& fileName ) const
@@ -171,9 +171,10 @@ public:
         wrapped->read(fs.root());
     }
 
-private:
     javaFeatureDetector(Ptr<FeatureDetector> _wrapped) : wrapped(_wrapped)
     {}
+
+private:
 
     Ptr<FeatureDetector> wrapped;
 };
@@ -222,7 +223,7 @@ public:
 
     //supported SIFT, SURF, ORB, BRIEF, BRISK, FREAK, AKAZE, Opponent(XXXX)
     //not supported: Calonder
-    CV_WRAP static javaDescriptorExtractor* create( int extractorType )
+    CV_WRAP static Ptr<javaDescriptorExtractor> create( int extractorType )
     {
         //String name;
 
@@ -261,7 +262,7 @@ public:
             break;
         }
 
-        return new javaDescriptorExtractor(de);
+        return makePtr<javaDescriptorExtractor>(de);
     }
 
     CV_WRAP void write( const String& fileName ) const
@@ -276,9 +277,10 @@ public:
         wrapped->read(fs.root());
     }
 
-private:
     javaDescriptorExtractor(Ptr<DescriptorExtractor> _wrapped) : wrapped(_wrapped)
     {}
+
+private:
 
     Ptr<DescriptorExtractor> wrapped;
 };

--- a/modules/java/generator/gen_java.py
+++ b/modules/java/generator/gen_java.py
@@ -994,7 +994,7 @@ class JavaWrapperGenerator(object):
         if classinfo.base:
             classinfo.addImports(classinfo.base)
         type_dict["Ptr_"+name] = \
-            { "j_type" : name,
+            { "j_type" : classinfo.jname,
               "jn_type" : "long", "jn_args" : (("__int64", ".nativeObj"),),
               "jni_name" : "Ptr<"+classinfo.fullName(isCPP=True)+">(("+classinfo.fullName(isCPP=True)+"*)%(n)s_nativeObj)", "jni_type" : "jlong",
               "suffix" : "J" }


### PR DESCRIPTION
<!-- Please use this line to close one or multiple issues when this pullrequest gets merged
You can add another line right under the first one:
resolves #1234
resolves #1235
-->
resolves #7475, #7486, #7400  
### This pullrequest changes

features2d_manual.hpp
gen_java.py

<!-- Please describe what your pullrequest is changing -->
This fix addresses several problems: 

- The legacy classes for wrapping feature2d algorithms javaFeatureDetector and javaDescriptorExtractor were not instantiating properly in java on the build from upstream/master (4ed40fd6946269ea36c58e5c76a277e7a871c269) - issue #7475. The fix is employing Ptr<> template, which should also help with proper memory handling and garbage collection in Java. 
- Java wrapper generator was not properly handling C_EXPORTS_AS C++ macro together with Ptr<> template. The issue was: although the class name was generating in accordance with the synonym specified in the macro, any function returning the class type was using the original name, which was leading to compilation errors.   
- Classes which are not using Ptr<> wrapper and not descending from any base class (ex VideoCapture, CascadeClassifier etc) were failing because of unreliable logic, which was responsible for determining such classes. New approach suggests the following criteria:
- if the class base is not empty then we believe that the class is using Ptr<> 
- if the class base is empty we are looking for presence of "create" method. if it is there we believe it is also using Ptr<>. 
(IMHO also unreliable but I don't know any better option. Welcome to suggest alternatives)
With these changes all classes are instantiating successfully.