### PR TITLE
ARM: video: disable NEON optimization in lkpyramid

### DIFF
--- a/modules/video/src/lkpyramid.cpp
+++ b/modules/video/src/lkpyramid.cpp
@@ -46,6 +46,16 @@
 #include "opencl_kernels_video.hpp"
 #include "opencv2/core/hal/intrin.hpp"
 
+// 2016/10 There is observed problem on Tegra TK1 devices
+// (Path_Idx_Cn_NPoints_WSize_OpticalFlowPyrLK_full.OpticalFlowPyrLK* tests)
+// Se we disable NEON optimization on ARM devices to workaround this problem
+#if defined __arm__
+#undef CV_SIMD128
+#define CV_SIMD128 0
+#undef CV_NEON
+#define CV_NEON 0
+#endif
+
 #define  CV_DESCALE(x,n)     (((x) + (1 << ((n)-1))) >> (n))
 
 namespace


### PR DESCRIPTION
Test log with failed test (with additional dump of values) on Terga TK1 is available here: http://pullrequest.opencv.org/buildbot/builders/precommit_armv7/builds/55/steps/distributed%20test/logs/log_1.txt