### PR TITLE
fix the problem: the headers of cudev module are not installed if BUI…

### DIFF
--- a/modules/cudev/CMakeLists.txt
+++ b/modules/cudev/CMakeLists.txt
@@ -10,10 +10,13 @@ ocv_add_module(cudev)
 
 ocv_module_include_directories(opencv_core opencv_hal)
 
-file(GLOB_RECURSE lib_hdrs "include/opencv2/*.hpp")
-file(GLOB         lib_srcs "src/*.cpp")
+file(GLOB_RECURSE lib_hdrs "${CMAKE_CURRENT_LIST_DIR}/include/opencv2/${name}/*.hpp")
+file(GLOB         lib_srcs "${CMAKE_CURRENT_LIST_DIR}/src/*.cpp")
 
-ocv_set_module_sources(HEADERS ${lib_hdrs} SOURCES ${lib_srcs})
+source_group("Include" FILES ${lib_hdrs})
+source_group("Src" FILES ${lib_srcs})
+
+ocv_glob_module_sources(HEADERS ${lib_hdrs} SOURCES ${lib_srcs})
 
 ocv_create_module()
 


### PR DESCRIPTION
<!-- Please use this line to close one or multiple issues when this pullrequest gets merged
You can add another line right under the first one:
resolves  #7491 
-->

This PR resolves  #7491 
### This pullrequest changes

Modify modules/cudev/CMakeLists.txt to fix the bug that I submitted in #7491.
What's more, after applied this fix, the cudev module will display as a sub-directory of the opencv_world project when using Visual Studio. 
