### PR TITLE
ARM: fix error from performance test of LK pyramid

### DIFF
--- a/modules/video/src/lkpyramid.cpp
+++ b/modules/video/src/lkpyramid.cpp
@@ -384,9 +384,9 @@ void cv::detail::LKTrackerInvoker::operator()(const Range& range) const
                 q8 = vmulq_s32(q4, q6);
                 q15 = vmulq_s32(q6, q6);
 
-                nq0 = vaddq_f32(nq0, vreinterpretq_f32_s32(q7));
-                nq1 = vaddq_f32(nq1, vreinterpretq_f32_s32(q8));
-                nq2 = vaddq_f32(nq2, vreinterpretq_f32_s32(q15));
+                nq0 = vaddq_f32(nq0, vcvtq_f32_s32(q7));
+                nq1 = vaddq_f32(nq1, vcvtq_f32_s32(q8));
+                nq2 = vaddq_f32(nq2, vcvtq_f32_s32(q15));
 
                 vst1q_f32(nA11, nq0);
                 vst1q_f32(nA12, nq1);
@@ -599,8 +599,8 @@ void cv::detail::LKTrackerInvoker::operator()(const Range& range) const
                     nq9 = vaddq_s32(nq9, nq10);
                     nq4 = vaddq_s32(nq4, nq5);
 
-                    nB1v = vaddq_f32(nB1v, vreinterpretq_f32_s32(nq9));
-                    nB2v = vaddq_f32(nB2v, vreinterpretq_f32_s32(nq4));
+                    nB1v = vaddq_f32(nB1v, vcvtq_f32_s32(nq9));
+                    nB2v = vaddq_f32(nB2v, vcvtq_f32_s32(nq4));
 
                     vst1q_f32(nB1, nB1v);
                     vst1q_f32(nB2, nB2v);


### PR DESCRIPTION
The main problem is described in #7488.
I looked in this problem a bit more.
I think that the real cause of this problem is  [here] (https://github.com/opencv/opencv/blob/7a286ab64f443ffbf0594cdd2402632c473156be/modules/video/src/lkpyramid.cpp#L397-L399) and [here] (https://github.com/opencv/opencv/blob/7a286ab64f443ffbf0594cdd2402632c473156be/modules/video/src/lkpyramid.cpp#L612-L613).
The values are supposed to be treated as `int` when it's directly treated as `float` without conversion.


I confirmed this fix works on Jetson TK1 without the workaround on #7488. Also confirmed on ODROID-X2 and Raspberry Pi 3(32bit).
Could someone review this problem, please ?
