### PR TITLE
ocl kernel performance optimization for box filter

### DIFF
--- a/modules/imgproc/src/opencl/boxFilter3x3.cl
+++ b/modules/imgproc/src/opencl/boxFilter3x3.cl
@@ -1,0 +1,78 @@
+// This file is part of OpenCV project.
+// It is subject to the license terms in the LICENSE file found in the top-level directory
+// of this distribution and at http://opencv.org/license.html.
+
+__kernel void boxFilter3x3_8UC1_cols16_rows2(__global const uint* src, int src_step,
+                                             __global uint* dst, int dst_step, int dst_offset, int rows, int cols
+#ifdef NORMALIZE
+                                             , float alpha
+#endif
+                         )
+{
+    int block_x = get_global_id(0);
+    int block_y = get_global_id(1) * 2;
+    int ssx, dsx;
+
+    if ((block_x * 16) >= cols || block_y >= rows) return;
+
+    uint4 line[4];
+    uint4 line_out[2];
+    ushort a; ushort16 b; ushort c;
+    ushort d; ushort16 e; ushort f;
+    ushort g; ushort16 h; ushort i;
+    ushort j; ushort16 k; ushort l;
+
+    ssx = dsx = 1;
+    int src_index = block_x * 4 * ssx + (block_y - 1) * (src_step / 4);
+    line[0] = (block_y == 0) ? (uint4)0 : vload4(0, src + src_index);
+    line[1] = vload4(0, src + src_index + (src_step / 4));
+    line[2] = vload4(0, src + src_index + 2 * (src_step / 4));
+    line[3] = (block_y == (rows - 2)) ? (uint4)0 : vload4(0, src + src_index + 3 * (src_step / 4));
+
+    ushort16 sum, mid;
+    __global uchar *src_p = (__global uchar *)src;
+
+    src_index = block_x * 16 * ssx + (block_y - 1) * src_step;
+    bool line_end = ((block_x + 1) * 16 == cols);
+
+    a = (block_x == 0 || block_y == 0) ? 0 : convert_ushort(src_p[src_index - 1]);
+    b = convert_ushort16(as_uchar16(line[0]));
+    c = (line_end || block_y == 0) ? 0 : convert_ushort(src_p[src_index + 16]);
+
+    d = (block_x == 0) ? 0 : convert_ushort(src_p[src_index + src_step - 1]);
+    e = convert_ushort16(as_uchar16(line[1]));
+    f = line_end ? 0 : convert_ushort(src_p[src_index + src_step + 16]);
+
+    g = (block_x == 0) ? 0 : convert_ushort(src_p[src_index + 2 * src_step - 1]);
+    h = convert_ushort16(as_uchar16(line[2]));
+    i = line_end ? 0 : convert_ushort(src_p[src_index + 2 * src_step + 16]);
+
+    j = (block_x == 0 || block_y == (rows - 2)) ? 0 : convert_ushort(src_p[src_index + 3 * src_step - 1]);
+    k = convert_ushort16(as_uchar16(line[3]));
+    l = (line_end || block_y == (rows - 2))? 0 : convert_ushort(src_p[src_index + 3 * src_step + 16]);
+
+    mid = (ushort16)(d, e.s0123, e.s456789ab, e.scde) + e + (ushort16)(e.s123, e.s4567, e.s89abcdef, f) +
+          (ushort16)(g, h.s0123, h.s456789ab, h.scde) + h + (ushort16)(h.s123, h.s4567, h.s89abcdef, i);
+
+    sum = (ushort16)(a, b.s0123, b.s456789ab, b.scde) + b + (ushort16)(b.s123, b.s4567, b.s89abcdef, c) +
+          mid;
+
+#ifdef NORMALIZE
+    line_out[0] = as_uint4(convert_uchar16_sat_rte((convert_float16(sum) * alpha)));
+#else
+    line_out[0] = as_uint4(convert_uchar16_sat_rte(sum));
+#endif
+
+    sum = mid +
+          (ushort16)(j, k.s0123, k.s456789ab, k.scde) + k + (ushort16)(k.s123, k.s4567, k.s89abcdef, l);
+
+#ifdef NORMALIZE
+    line_out[1] = as_uint4(convert_uchar16_sat_rte((convert_float16(sum) * alpha)));
+#else
+    line_out[1] = as_uint4(convert_uchar16_sat_rte(sum));
+#endif
+
+    int dst_index = block_x * 4 * dsx + block_y * (dst_step / 4);
+    vstore4(line_out[0], 0, dst + dst_index);
+    vstore4(line_out[1], 0, dst + dst_index + (dst_step / 4));
+}

--- a/modules/imgproc/src/smooth.cpp
+++ b/modules/imgproc/src/smooth.cpp
@@ -1295,6 +1295,52 @@ struct ColumnSum<int, float> :
 
 #ifdef HAVE_OPENCL
 
+static bool ocl_boxFilter3x3_8UC1( InputArray _src, OutputArray _dst, int ddepth,
+                                   Size ksize, Point anchor, bool normalize, bool sqr = false )
+{
+    const ocl::Device & dev = ocl::Device::getDefault();
+    int type = _src.type(), sdepth = CV_MAT_DEPTH(type), cn = CV_MAT_CN(type);
+
+    if (ddepth < 0)
+        ddepth = sdepth;
+
+    if (anchor.x < 0)
+        anchor.x = ksize.width / 2;
+    if (anchor.y < 0)
+        anchor.y = ksize.height / 2;
+
+    if ( dev.isIntel() && !sqr && !((type == CV_8UC1) &&
+         (_src.cols() % 16 == 0) && (_src.rows() % 2 == 0) &&
+         (anchor.x == 1) && (anchor.y == 1) &&
+         (ksize.width == 3) && (ksize.height == 3)) )
+        return false;
+
+    float alpha = 1.0f / (ksize.height * ksize.width);
+    Size size = _src.size();
+    size_t globalsize[2] = { 0, 0 };
+    size_t localsize[2] = { 0, 0 };
+
+    globalsize[0] = size.width / 16;
+    globalsize[1] = size.height / 2;
+
+    String opts = format(normalize ? " -D NORMALIZE" : "");
+    ocl::Kernel kernel("boxFilter3x3_8UC1_cols16_rows2", cv::ocl::imgproc::boxFilter3x3_oclsrc, opts);
+    if (kernel.empty())
+        return false;
+
+    UMat src = _src.getUMat();
+    _dst.create(size, CV_MAKETYPE(ddepth, cn));
+    UMat dst = _dst.getUMat();
+
+    int idxArg = kernel.set(0, ocl::KernelArg::PtrReadOnly(src));
+    idxArg = kernel.set(idxArg, (int)src.step);
+    idxArg = kernel.set(idxArg, ocl::KernelArg::WriteOnly(dst));
+    if (normalize)
+        idxArg = kernel.set(idxArg, (float)alpha);
+
+    return kernel.run(2, globalsize, (localsize[0] == 0) ? NULL : localsize, false);
+}
+
 #define DIVUP(total, grain) ((total + grain - 1) / (grain))
 #define ROUNDUP(sz, n)      ((sz) + (n) - 1 - (((sz) + (n) - 1) % (n)))
 
@@ -1682,6 +1728,9 @@ void cv::boxFilter( InputArray _src, OutputArray _dst, int ddepth,
                 bool normalize, int borderType )
 {
     CV_INSTRUMENT_REGION()
+
+    CV_OCL_RUN(_dst.isUMat() && borderType == BORDER_CONSTANT && !_src.isSubmatrix(),
+               ocl_boxFilter3x3_8UC1(_src, _dst, ddepth, ksize, anchor, normalize))
 
     CV_OCL_RUN(_dst.isUMat(), ocl_boxFilter(_src, _dst, ddepth, ksize, anchor, borderType, normalize))
 


### PR DESCRIPTION
box filter ocl kernel v2 update

update code per comment in pull request 7500.

### This pullrequest changes

<!-- Please describe what your pullrequest is changing -->

The optimization is for CV_8UC1 format and 3x3 box filter,
it is 15%~87% faster than current ocl kernel with below perf test

./modules/ts/misc/run.py -t imgproc --gtest_filter=OCL_BlurFixture*

Signed-off-by: Li Peng <peng.li@intel.com>