### PR TITLE
Fix issue #7504: filterSmall.cl reports error of unknown type double1 with OpenCL #7504

### DIFF
--- a/modules/imgproc/src/opencl/filterSmall.cl
+++ b/modules/imgproc/src/opencl/filterSmall.cl
@@ -154,6 +154,7 @@ inline bool isBorder(const struct RectCoords bounds, int2 coord, int numPixels)
 #endif
 
 #define float1 float
+#define double1 double
 #define uchar1 uchar
 #define int1 int
 #define uint1 unit


### PR DESCRIPTION
resolves #7504 

### This pullrequest changes

add a marco to define double1 to double
