### PR TITLE
videoio: fix segfault if CONVERT_RGB is false (issue #7465)

### DIFF
--- a/modules/videoio/src/cap_v4l.cpp
+++ b/modules/videoio/src/cap_v4l.cpp
@@ -1849,7 +1849,7 @@ static void icvCloseCAM_V4L( CvCaptureCAM_V4L* capture ){
      if (capture->deviceHandle != -1)
        close(capture->deviceHandle);
 
-     if (capture->frame.imageData)
+     if (capture->frame_allocated && capture->frame.imageData)
          cvFree(&capture->frame.imageData);
 
      capture->deviceName.clear(); // flag that the capture is closed


### PR DESCRIPTION
<!-- Please use this line to close one or multiple issues when this pullrequest gets merged
You can add another line right under the first one:
resolves #1234
resolves #1235
-->
resolves #7465 

### This pullrequest changes

<!-- Please describe what your pullrequest is changing -->

When VideoCapture is released, it attempts to free memory that it doesn't own when the cap property CONVERT_RGB is false. Relying on the value of CvCaptureCAM_V4L::frame_allocated prevents a segfault.