### PR TITLE
Aravis several updates

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1125,7 +1125,7 @@ if(DEFINED WITH_GIGEAPI)
 endif(DEFINED WITH_GIGEAPI)
 
 if(DEFINED WITH_ARAVIS)
-  status("    Aravis SDK:"     HAVE_ARAVIS_API     THEN YES                                        ELSE NO)
+  status("    Aravis SDK:"     HAVE_ARAVIS_API     THEN "YES (${ARAVIS_LIBRARIES})"                ELSE NO)
 endif(DEFINED WITH_ARAVIS)
 
 if(DEFINED APPLE)

--- a/cmake/OpenCVFindLibsVideo.cmake
+++ b/cmake/OpenCVFindLibsVideo.cmake
@@ -129,9 +129,9 @@ ocv_clear_vars(HAVE_ARAVIS_API)
 if(WITH_ARAVIS)
   find_path(ARAVIS_INCLUDE_PATH "arv.h"
             PATHS /usr/local /var /opt /usr ENV ProgramFiles ENV ProgramW6432
-            PATH_SUFFIXES include "aravis-0.6"
+            PATH_SUFFIXES include "aravis-0.6" "aravis-0.4"
             DOC "The path to Aravis SDK headers")
-  find_library(ARAVIS_LIBRARIES "aravis-0.6")
+  find_library(ARAVIS_LIBRARIES NAMES "aravis-0.6" "aravis-0.4" )
   if(ARAVIS_LIBRARIES AND ARAVIS_INCLUDE_PATH)
     set(HAVE_ARAVIS_API TRUE)
   endif()

--- a/modules/videoio/src/cap_aravis.cpp
+++ b/modules/videoio/src/cap_aravis.cpp
@@ -65,6 +65,7 @@
 //      CAP_PROP_GAIN(g), g >=0 or -1 for automatic control if CAP_PROP_AUTO_EXPOSURE is true
 //      CAP_PROP_FPS(f)
 //      CAP_PROP_FOURCC(type)
+//      CV_CAP_PROP_BUFFERSIZE(n)
 //
 //  Supported types of data:
 //      video/x-raw, fourcc:'GREY'  -> 8bit, 1 channel
@@ -433,6 +434,16 @@ double CvCaptureCAM_Aravis::getProperty( int property_id ) const
                         return MODE_Y12;
                 }
             }
+            break;
+
+        case CV_CAP_PROP_BUFFERSIZE:
+            if(stream) {
+                int in, out;
+                arv_stream_get_n_buffers(stream, &in, &out);
+                // return number of available buffers in Aravis output queue
+                return out;
+            }
+            break;
     }
     return -1.0;
 }
@@ -494,6 +505,18 @@ bool CvCaptureCAM_Aravis::setProperty( int property_id, double value )
                 }
             }
             break;
+
+        case CV_CAP_PROP_BUFFERSIZE:
+            {
+                int x = (int)value;
+                if((x > 0) && (x != num_buffers)) {
+                    stopCapture();
+                    num_buffers = x;
+                    startCapture();
+                }
+            }
+            break;
+
 
         default:
             return false;

--- a/modules/videoio/src/cap_aravis.cpp
+++ b/modules/videoio/src/cap_aravis.cpp
@@ -82,7 +82,7 @@
 #define MODE_Y800   CV_FOURCC_MACRO('Y','8','0','0')
 #define MODE_Y12    CV_FOURCC_MACRO('Y','1','2',' ')
 
-#define LIMIT(a,b,c) (cv::max(cv::min((a),(c)),(b)))
+#define CLIP(a,b,c) (cv::max(cv::min((a),(c)),(b)))
 
 /********************* Capturing video from camera via Aravis *********************/
 
@@ -367,7 +367,7 @@ void CvCaptureCAM_Aravis::autoExposureControl(IplImage* image)
     midGrey = brightness;
 
     double maxe = 1e6 / fps;
-    double ne = LIMIT( ( exposure * d ) / dmid, exposureMin, maxe);
+    double ne = CLIP( ( exposure * d ) / dmid, exposureMin, maxe);
 
     // if change of value requires intervention
     if(fabs(d-dmid) > 5) {
@@ -375,7 +375,7 @@ void CvCaptureCAM_Aravis::autoExposureControl(IplImage* image)
 
         if(gainAvailable && autoGain) {
             ev = log( d / dmid ) / log(2);
-            ng = LIMIT( gain + ev, gainMin, gainMax);
+            ng = CLIP( gain + ev, gainMin, gainMax);
 
             if( ng < gain ) {
                 // piority 1 - reduce gain
@@ -410,7 +410,7 @@ void CvCaptureCAM_Aravis::autoExposureControl(IplImage* image)
     // if gain can be reduced - do it
     if(gainAvailable && autoGain && exposureAvailable) {
         if(gain > gainMin && exposure < maxe) {
-            exposure = LIMIT( ne * 1.05, exposureMin, maxe);
+            exposure = CLIP( ne * 1.05, exposureMin, maxe);
             arv_camera_set_exposure_time(camera, exposure );
         }
     }
@@ -491,13 +491,13 @@ bool CvCaptureCAM_Aravis::setProperty( int property_id, double value )
                 /* exposure time in seconds, like 1/100 s */
                 value *= 1e6; // -> from s to us
 
-                arv_camera_set_exposure_time(camera, exposure = LIMIT(value, exposureMin, exposureMax));
+                arv_camera_set_exposure_time(camera, exposure = CLIP(value, exposureMin, exposureMax));
                 break;
             } else return false;
 
         case CV_CAP_PROP_FPS:
             if(fpsAvailable) {
-                arv_camera_set_frame_rate(camera, fps = LIMIT(value, fpsMin, fpsMax));
+                arv_camera_set_frame_rate(camera, fps = CLIP(value, fpsMin, fpsMax));
                 break;
             } else return false;
 
@@ -506,7 +506,7 @@ bool CvCaptureCAM_Aravis::setProperty( int property_id, double value )
                 if ( (autoGain = (-1 == value) ) )
                     break;
 
-                arv_camera_set_gain(camera, gain = LIMIT(value, gainMin, gainMax));
+                arv_camera_set_gain(camera, gain = CLIP(value, gainMin, gainMax));
                 break;
             } else return false;
 

--- a/modules/videoio/src/cap_aravis.cpp
+++ b/modules/videoio/src/cap_aravis.cpp
@@ -282,7 +282,7 @@ bool CvCaptureCAM_Aravis::grabFrame()
                 arv_stream_push_buffer (stream, arv_buffer);
             } else break;
         }
-        if (tries < max_tries) {
+        if(arv_buffer != NULL && tries < max_tries) {
             size_t buffer_size;
             framebuffer = (void*)arv_buffer_get_data (arv_buffer, &buffer_size);
 
@@ -371,7 +371,7 @@ void CvCaptureCAM_Aravis::autoExposureControl(IplImage* image)
 
     // if change of value requires intervention
     if(fabs(d-dmid) > 5) {
-        double ev, ng;
+        double ev, ng = 0;
 
         if(gainAvailable && autoGain) {
             ev = log( d / dmid ) / log(2);

--- a/modules/videoio/src/cap_aravis.cpp
+++ b/modules/videoio/src/cap_aravis.cpp
@@ -51,7 +51,8 @@
 
 //
 // This file provides wrapper for using Aravis SDK library to access GigE Vision cameras.
-// aravis-0.6 library shall be installed else this code will not be included in build.
+// Aravis library (version 0.4 or 0.6) shall be installed else this code will not be included in build.
+//
 // To include this module invoke cmake with -DWITH_ARAVIS=ON
 //
 // Please obvserve, that jumbo frames are required when high fps & 16bit data is selected.
@@ -189,6 +190,9 @@ void CvCaptureCAM_Aravis::close()
 {
     if(camera)
         stopCapture();
+
+    g_object_unref(camera);
+    camera = NULL;
 }
 
 bool CvCaptureCAM_Aravis::getDeviceNameById(int id, std::string &device)

--- a/modules/videoio/src/cap_aravis.cpp
+++ b/modules/videoio/src/cap_aravis.cpp
@@ -181,7 +181,7 @@ bool CvCaptureCAM_Aravis::getDeviceNameById(int id, std::string &device)
 {
     arv_update_device_list();
 
-    if(id > 0 && id < arv_get_n_devices()){
+    if((id >= 0) && (id < (int)arv_get_n_devices())) {
         device = arv_get_device_id(id);
         return true;
     }
@@ -311,7 +311,7 @@ IplImage* CvCaptureCAM_Aravis::retrieveFrame(int)
             }
             cvCopy(&src, frame);
 
-            if(controlExposure && !(framesCnt % 2)) {
+            if(controlExposure && (framesCnt & 1)) {
                 // control exposure every second frame
                 // i.e. skip frame taken with previous exposure setup
                 autoExposureControl(frame);


### PR DESCRIPTION
Did small typo last time hence camera with 0-index is skipped.  My bad :(

As pushing correction with one character added is worthless ;) I  have created combined PR to address:

- accessing camera with index 0 (bug fix)
- adding control of Aravis transmission buffer size (write CAP_PROP_BUFFERSIZE)
- adding possibility to monitor current status of Aravis output buffer (read CAP_PROP_BUFFERSIZE)
- reading current image region size (CAP_PROP_FRAME_WIDTH & CAP_PROP_FRAME_HEIGHT)
- reading current frame time (in ms) sent by camera (CAP_PROP_POS_MSEC) as frameID/fps

Having frame ID directly from camera, I have also redesigned auto exposure to skip frames taken while exposure params have changed. Also if no change is needed but gain can be reduced, it is done as simply image quality is top prio. Now this code is much more stable.

I am in contact with Aravis author, thus in some time will push another update, to handle situation when camera gets accidentally disconnected. 