### PR TITLE
videoio: Fix for valgrind warning in icvGetPropertyCAM_V4L

### DIFF
--- a/modules/videoio/src/cap_v4l.cpp
+++ b/modules/videoio/src/cap_v4l.cpp
@@ -1613,6 +1613,7 @@ static double icvGetPropertyCAM_V4L (const CvCaptureCAM_V4L* capture,
                                      int property_id ) {
   {
       v4l2_format form;
+      memset(&form, 0, sizeof(v4l2_format));
       form.type = V4L2_BUF_TYPE_VIDEO_CAPTURE;
       if (-1 == ioctl (capture->deviceHandle, VIDIOC_G_FMT, &form)) {
           /* display an error message, and return an error code */


### PR DESCRIPTION
<!-- Please use this line to close one or multiple issues when this pullrequest gets merged
You can add another line right under the first one:
resolves #1234
resolves #1235
-->
resolves #7380 

### This pullrequest changes
This zeroes out a structure before it gets put into an ioctl in order to ensure that it's initialized before use.

<!-- Please describe what your pullrequest is changing -->

https://github.com/opencv/opencv/issues/7380