### PR TITLE
VTK and gstreamer updates

### DIFF
--- a/cmake/FindGstreamerWindows.cmake
+++ b/cmake/FindGstreamerWindows.cmake
@@ -15,7 +15,7 @@ FIND_PATH(GSTREAMER_glibconfig_INCLUDE_DIR glibconfig.h
     ENV INCLUDE DOC "Directory containing glibconfig.h include file")
 
 FIND_PATH(GSTREAMER_gstconfig_INCLUDE_DIR gst/gstconfig.h
-                                          PATHS ${GSTREAMER_DIR}/lib/gstreamer-1.0/include ${GSTREAMER_DIR}/include ${GSTREAMER_DIR}/lib/include /usr/local/include/gstreamer-1.0 /usr/include/gstreamer-1.0 /usr/local/lib/include/gstreamer-1.0 /usr/lib/include/gstreamer-1.0
+                                          PATHS ${GSTREAMER_DIR}/lib/gstreamer-1.0/include ${GSTREAMER_DIR}/include ${GSTREAMER_DIR}/include/gstreamer-1.0 ${GSTREAMER_DIR}/lib/include /usr/local/include/gstreamer-1.0 /usr/include/gstreamer-1.0 /usr/local/lib/include/gstreamer-1.0 /usr/lib/include/gstreamer-1.0
                                           ENV INCLUDE DOC "Directory containing gst/gstconfig.h include file")
 
 FIND_LIBRARY(GSTREAMER_gstaudio_LIBRARY NAMES gstaudio libgstaudio-1.0 gstaudio-1.0

--- a/cmake/OpenCVDetectVTK.cmake
+++ b/cmake/OpenCVDetectVTK.cmake
@@ -6,7 +6,7 @@ endif()
 find_package(VTK QUIET COMPONENTS vtkInteractionStyle vtkRenderingLOD vtkIOPLY vtkFiltersTexture vtkRenderingFreeType vtkIOExport NO_MODULE)
 IF(VTK_FOUND)
   IF(VTK_RENDERING_BACKEND) #in vtk 7, the rendering backend is exported as a var.
-      find_package(VTK QUIET COMPONENTS vtkRendering${VTK_RENDERING_BACKEND} vtkInteractionStyle vtkRenderingLOD vtkIOPLY vtkFiltersTexture vtkRenderingFreeType vtkIOExport NO_MODULE)
+      find_package(VTK QUIET COMPONENTS vtkRendering${VTK_RENDERING_BACKEND} vtkInteractionStyle vtkRenderingLOD vtkIOPLY vtkFiltersTexture vtkRenderingFreeType vtkIOExport vtkIOGeometry NO_MODULE)
   ELSE(VTK_RENDERING_BACKEND)
       find_package(VTK QUIET COMPONENTS vtkRenderingOpenGL vtkInteractionStyle vtkRenderingLOD vtkIOPLY vtkFiltersTexture vtkRenderingFreeType vtkIOExport NO_MODULE)
   ENDIF(VTK_RENDERING_BACKEND)


### PR DESCRIPTION
### This pullrequest changes
Updated include paths for newer binary distributions of gstreamer on windows. (1.8.2)
Updated find vtk to look for vtkIOGeometry which is where vtkOBJReader now resides.

I'm currently working on the master branch of vtk, which seems to have moved vtkOBJReader into vtkIOGeometry without so much as a minor version update (still version 7.1), thus I'm not certain how I can differentiate between when the reader was in vtkIOGeometry and when it was not.