### PR TITLE
Eliminated use of obsolete 'register' keyword

### DIFF
--- a/modules/calib3d/src/rho.cpp
+++ b/modules/calib3d/src/rho.cpp
@@ -2370,7 +2370,7 @@ static inline float  sacLMGain(const float*  dH,
 static inline int    sacChol8x8Damped(const float (*A)[8],
                                       float         lambda,
                                       float       (*L)[8]){
-    const register int N = 8;
+    const int N = 8;
     int i, j, k;
     float  lambdap1 = lambda + 1.0f;
     float  x;

--- a/modules/features2d/doc/agast.txt
+++ b/modules/features2d/doc/agast.txt
@@ -65,24 +65,24 @@ static void AGAST_5_8(InputArray _img, std::vector<KeyPoint>& keypoints, int thr
     int xsize = img.cols;
     int ysize = img.rows;
     size_t nExpectedCorners = keypoints.capacity();
-    register int x, y;
-    register int xsizeB = xsize - 2;
-    register int ysizeB = ysize - 1;
-    register int width;
+    int x, y;
+    int xsizeB = xsize - 2;
+    int ysizeB = ysize - 1;
+    int width;
 
     keypoints.resize(0);
 
     int pixel_5_8_[16];
     makeAgastOffsets(pixel_5_8_, (int)img.step, AgastFeatureDetector::AGAST_5_8);
 
-    register short offset0 = (short) pixel_5_8_[0];
-    register short offset1 = (short) pixel_5_8_[1];
-    register short offset2 = (short) pixel_5_8_[2];
-    register short offset3 = (short) pixel_5_8_[3];
-    register short offset4 = (short) pixel_5_8_[4];
-    register short offset5 = (short) pixel_5_8_[5];
-    register short offset6 = (short) pixel_5_8_[6];
-    register short offset7 = (short) pixel_5_8_[7];
+    short offset0 = (short) pixel_5_8_[0];
+    short offset1 = (short) pixel_5_8_[1];
+    short offset2 = (short) pixel_5_8_[2];
+    short offset3 = (short) pixel_5_8_[3];
+    short offset4 = (short) pixel_5_8_[4];
+    short offset5 = (short) pixel_5_8_[5];
+    short offset6 = (short) pixel_5_8_[6];
+    short offset7 = (short) pixel_5_8_[7];
 
     width = xsize;
 
@@ -98,9 +98,9 @@ static void AGAST_5_8(InputArray _img, std::vector<KeyPoint>& keypoints, int thr
                 break;
             else
             {
-                register const unsigned char* const ptr = img.ptr() + y*width + x;
-                register const int cb = *ptr + threshold;
-                register const int c_b = *ptr - threshold;
+                const unsigned char* const ptr = img.ptr() + y*width + x;
+                const int cb = *ptr + threshold;
+                const int c_b = *ptr - threshold;
                 if(ptr[offset0] > cb)
                   if(ptr[offset2] > cb)
                     if(ptr[offset3] > cb)
@@ -435,9 +435,9 @@ static void AGAST_5_8(InputArray _img, std::vector<KeyPoint>& keypoints, int thr
                 break;
             else
             {
-                register const unsigned char* const ptr = img.ptr() + y*width + x;
-                register const int cb = *ptr + threshold;
-                register const int c_b = *ptr - threshold;
+                const unsigned char* const ptr = img.ptr() + y*width + x;
+                const int cb = *ptr + threshold;
+                const int c_b = *ptr - threshold;
                 if(ptr[offset0] > cb)
                   if(ptr[offset2] > cb)
                     if(ptr[offset3] > cb)
@@ -827,28 +827,28 @@ static void AGAST_7_12d(InputArray _img, std::vector<KeyPoint>& keypoints, int t
     int xsize = img.cols;
     int ysize = img.rows;
     size_t nExpectedCorners = keypoints.capacity();
-    register int x, y;
-    register int xsizeB = xsize - 4;
-    register int ysizeB = ysize - 3;
-    register int width;
+    int x, y;
+    int xsizeB = xsize - 4;
+    int ysizeB = ysize - 3;
+    int width;
 
     keypoints.resize(0);
 
     int pixel_7_12d_[16];
     makeAgastOffsets(pixel_7_12d_, (int)img.step, AgastFeatureDetector::AGAST_7_12d);
 
-    register short offset0 = (short) pixel_7_12d_[0];
-    register short offset1 = (short) pixel_7_12d_[1];
-    register short offset2 = (short) pixel_7_12d_[2];
-    register short offset3 = (short) pixel_7_12d_[3];
-    register short offset4 = (short) pixel_7_12d_[4];
-    register short offset5 = (short) pixel_7_12d_[5];
-    register short offset6 = (short) pixel_7_12d_[6];
-    register short offset7 = (short) pixel_7_12d_[7];
-    register short offset8 = (short) pixel_7_12d_[8];
-    register short offset9 = (short) pixel_7_12d_[9];
-    register short offset10 = (short) pixel_7_12d_[10];
-    register short offset11 = (short) pixel_7_12d_[11];
+    short offset0 = (short) pixel_7_12d_[0];
+    short offset1 = (short) pixel_7_12d_[1];
+    short offset2 = (short) pixel_7_12d_[2];
+    short offset3 = (short) pixel_7_12d_[3];
+    short offset4 = (short) pixel_7_12d_[4];
+    short offset5 = (short) pixel_7_12d_[5];
+    short offset6 = (short) pixel_7_12d_[6];
+    short offset7 = (short) pixel_7_12d_[7];
+    short offset8 = (short) pixel_7_12d_[8];
+    short offset9 = (short) pixel_7_12d_[9];
+    short offset10 = (short) pixel_7_12d_[10];
+    short offset11 = (short) pixel_7_12d_[11];
 
     width = xsize;
 
@@ -864,9 +864,9 @@ static void AGAST_7_12d(InputArray _img, std::vector<KeyPoint>& keypoints, int t
                 break;
             else
             {
-                register const unsigned char* const ptr = img.ptr() + y*width + x;
-                register const int cb = *ptr + threshold;
-                register const int c_b = *ptr - threshold;
+                const unsigned char* const ptr = img.ptr() + y*width + x;
+                const int cb = *ptr + threshold;
+                const int c_b = *ptr - threshold;
                 if(ptr[offset0] > cb)
                   if(ptr[offset5] > cb)
                     if(ptr[offset2] > cb)
@@ -2047,9 +2047,9 @@ static void AGAST_7_12d(InputArray _img, std::vector<KeyPoint>& keypoints, int t
                 break;
             else
             {
-                register const unsigned char* const ptr = img.ptr() + y*width + x;
-                register const int cb = *ptr + threshold;
-                register const int c_b = *ptr - threshold;
+                const unsigned char* const ptr = img.ptr() + y*width + x;
+                const int cb = *ptr + threshold;
+                const int c_b = *ptr - threshold;
                 if(ptr[offset0] > cb)
                   if(ptr[offset5] > cb)
                     if(ptr[offset2] > cb)
@@ -3273,28 +3273,28 @@ static void AGAST_7_12s(InputArray _img, std::vector<KeyPoint>& keypoints, int t
     int xsize = img.cols;
     int ysize = img.rows;
     size_t nExpectedCorners = keypoints.capacity();
-    register int x, y;
-    register int xsizeB=xsize - 3; //2, +1 due to faster test x>xsizeB
-    register int ysizeB=ysize - 2;
-    register int width;
+    int x, y;
+    int xsizeB=xsize - 3; //2, +1 due to faster test x>xsizeB
+    int ysizeB=ysize - 2;
+    int width;
 
     keypoints.resize(0);
 
     int pixel_7_12s_[16];
     makeAgastOffsets(pixel_7_12s_, (int)img.step, AgastFeatureDetector::AGAST_7_12s);
 
-    register short offset0 = (short) pixel_7_12s_[0];
-    register short offset1 = (short) pixel_7_12s_[1];
-    register short offset2 = (short) pixel_7_12s_[2];
-    register short offset3 = (short) pixel_7_12s_[3];
-    register short offset4 = (short) pixel_7_12s_[4];
-    register short offset5 = (short) pixel_7_12s_[5];
-    register short offset6 = (short) pixel_7_12s_[6];
-    register short offset7 = (short) pixel_7_12s_[7];
-    register short offset8 = (short) pixel_7_12s_[8];
-    register short offset9 = (short) pixel_7_12s_[9];
-    register short offset10 = (short) pixel_7_12s_[10];
-    register short offset11 = (short) pixel_7_12s_[11];
+    short offset0 = (short) pixel_7_12s_[0];
+    short offset1 = (short) pixel_7_12s_[1];
+    short offset2 = (short) pixel_7_12s_[2];
+    short offset3 = (short) pixel_7_12s_[3];
+    short offset4 = (short) pixel_7_12s_[4];
+    short offset5 = (short) pixel_7_12s_[5];
+    short offset6 = (short) pixel_7_12s_[6];
+    short offset7 = (short) pixel_7_12s_[7];
+    short offset8 = (short) pixel_7_12s_[8];
+    short offset9 = (short) pixel_7_12s_[9];
+    short offset10 = (short) pixel_7_12s_[10];
+    short offset11 = (short) pixel_7_12s_[11];
 
     width = xsize;
 
@@ -3310,9 +3310,9 @@ static void AGAST_7_12s(InputArray _img, std::vector<KeyPoint>& keypoints, int t
                 break;
             else
             {
-                register const unsigned char* const ptr = img.ptr() + y*width + x;
-                register const int cb = *ptr + threshold;
-                register const int c_b = *ptr - threshold;
+                const unsigned char* const ptr = img.ptr() + y*width + x;
+                const int cb = *ptr + threshold;
+                const int c_b = *ptr - threshold;
                 if(ptr[offset0] > cb)
                   if(ptr[offset2] > cb)
                     if(ptr[offset5] > cb)
@@ -4349,9 +4349,9 @@ static void AGAST_7_12s(InputArray _img, std::vector<KeyPoint>& keypoints, int t
                 break;
             else
             {
-                register const unsigned char* const ptr = img.ptr() + y*width + x;
-                register const int cb = *ptr + threshold;
-                register const int c_b = *ptr - threshold;
+                const unsigned char* const ptr = img.ptr() + y*width + x;
+                const int cb = *ptr + threshold;
+                const int c_b = *ptr - threshold;
                 if(ptr[offset0] > cb)
                   if(ptr[offset2] > cb)
                     if(ptr[offset5] > cb)
@@ -5356,32 +5356,32 @@ static void OAST_9_16(InputArray _img, std::vector<KeyPoint>& keypoints, int thr
     int xsize = img.cols;
     int ysize = img.rows;
     size_t nExpectedCorners = keypoints.capacity();
-    register int x, y;
-    register int xsizeB=xsize - 4;
-    register int ysizeB=ysize - 3;
-    register int width;
+    int x, y;
+    int xsizeB=xsize - 4;
+    int ysizeB=ysize - 3;
+    int width;
 
     keypoints.resize(0);
 
     int pixel_9_16_[16];
     makeAgastOffsets(pixel_9_16_, (int)img.step, AgastFeatureDetector::OAST_9_16);
 
-    register short offset0 = (short) pixel_9_16_[0];
-    register short offset1 = (short) pixel_9_16_[1];
-    register short offset2 = (short) pixel_9_16_[2];
-    register short offset3 = (short) pixel_9_16_[3];
-    register short offset4 = (short) pixel_9_16_[4];
-    register short offset5 = (short) pixel_9_16_[5];
-    register short offset6 = (short) pixel_9_16_[6];
-    register short offset7 = (short) pixel_9_16_[7];
-    register short offset8 = (short) pixel_9_16_[8];
-    register short offset9 = (short) pixel_9_16_[9];
-    register short offset10 = (short) pixel_9_16_[10];
-    register short offset11 = (short) pixel_9_16_[11];
-    register short offset12 = (short) pixel_9_16_[12];
-    register short offset13 = (short) pixel_9_16_[13];
-    register short offset14 = (short) pixel_9_16_[14];
-    register short offset15 = (short) pixel_9_16_[15];
+    short offset0 = (short) pixel_9_16_[0];
+    short offset1 = (short) pixel_9_16_[1];
+    short offset2 = (short) pixel_9_16_[2];
+    short offset3 = (short) pixel_9_16_[3];
+    short offset4 = (short) pixel_9_16_[4];
+    short offset5 = (short) pixel_9_16_[5];
+    short offset6 = (short) pixel_9_16_[6];
+    short offset7 = (short) pixel_9_16_[7];
+    short offset8 = (short) pixel_9_16_[8];
+    short offset9 = (short) pixel_9_16_[9];
+    short offset10 = (short) pixel_9_16_[10];
+    short offset11 = (short) pixel_9_16_[11];
+    short offset12 = (short) pixel_9_16_[12];
+    short offset13 = (short) pixel_9_16_[13];
+    short offset14 = (short) pixel_9_16_[14];
+    short offset15 = (short) pixel_9_16_[15];
 
     width = xsize;
 
@@ -5395,9 +5395,9 @@ static void OAST_9_16(InputArray _img, std::vector<KeyPoint>& keypoints, int thr
                 break;
             else
             {
-                register const unsigned char* const ptr = img.ptr() + y*width + x;
-                register const int cb = *ptr + threshold;
-                register const int c_b = *ptr - threshold;
+                const unsigned char* const ptr = img.ptr() + y*width + x;
+                const int cb = *ptr + threshold;
+                const int c_b = *ptr - threshold;
                 if(ptr[offset0] > cb)
                   if(ptr[offset2] > cb)
                     if(ptr[offset4] > cb)

--- a/modules/features2d/doc/agast_score.txt
+++ b/modules/features2d/doc/agast_score.txt
@@ -97,27 +97,27 @@ int agast_cornerScore<AgastFeatureDetector::OAST_9_16>(const uchar* ptr, const i
     int bmax = 255;
     int b_test = (bmax + bmin) / 2;
 
-    register short offset0 = (short) pixel[0];
-    register short offset1 = (short) pixel[1];
-    register short offset2 = (short) pixel[2];
-    register short offset3 = (short) pixel[3];
-    register short offset4 = (short) pixel[4];
-    register short offset5 = (short) pixel[5];
-    register short offset6 = (short) pixel[6];
-    register short offset7 = (short) pixel[7];
-    register short offset8 = (short) pixel[8];
-    register short offset9 = (short) pixel[9];
-    register short offset10 = (short) pixel[10];
-    register short offset11 = (short) pixel[11];
-    register short offset12 = (short) pixel[12];
-    register short offset13 = (short) pixel[13];
-    register short offset14 = (short) pixel[14];
-    register short offset15 = (short) pixel[15];
+    short offset0 = (short) pixel[0];
+    short offset1 = (short) pixel[1];
+    short offset2 = (short) pixel[2];
+    short offset3 = (short) pixel[3];
+    short offset4 = (short) pixel[4];
+    short offset5 = (short) pixel[5];
+    short offset6 = (short) pixel[6];
+    short offset7 = (short) pixel[7];
+    short offset8 = (short) pixel[8];
+    short offset9 = (short) pixel[9];
+    short offset10 = (short) pixel[10];
+    short offset11 = (short) pixel[11];
+    short offset12 = (short) pixel[12];
+    short offset13 = (short) pixel[13];
+    short offset14 = (short) pixel[14];
+    short offset15 = (short) pixel[15];
 
     while(true)
     {
-        register const int cb = *ptr + b_test;
-        register const int c_b = *ptr - b_test;
+        const int cb = *ptr + b_test;
+        const int c_b = *ptr - b_test;
         if(ptr[offset0] > cb)
           if(ptr[offset2] > cb)
             if(ptr[offset4] > cb)
@@ -2196,23 +2196,23 @@ int agast_cornerScore<AgastFeatureDetector::AGAST_7_12d>(const uchar* ptr, const
     int bmax = 255;
     int b_test = (bmax + bmin)/2;
 
-    register short offset0 = (short) pixel[0];
-    register short offset1 = (short) pixel[1];
-    register short offset2 = (short) pixel[2];
-    register short offset3 = (short) pixel[3];
-    register short offset4 = (short) pixel[4];
-    register short offset5 = (short) pixel[5];
-    register short offset6 = (short) pixel[6];
-    register short offset7 = (short) pixel[7];
-    register short offset8 = (short) pixel[8];
-    register short offset9 = (short) pixel[9];
-    register short offset10 = (short) pixel[10];
-    register short offset11 = (short) pixel[11];
+    short offset0 = (short) pixel[0];
+    short offset1 = (short) pixel[1];
+    short offset2 = (short) pixel[2];
+    short offset3 = (short) pixel[3];
+    short offset4 = (short) pixel[4];
+    short offset5 = (short) pixel[5];
+    short offset6 = (short) pixel[6];
+    short offset7 = (short) pixel[7];
+    short offset8 = (short) pixel[8];
+    short offset9 = (short) pixel[9];
+    short offset10 = (short) pixel[10];
+    short offset11 = (short) pixel[11];
 
     while(true)
     {
-        register const int cb = *ptr + b_test;
-        register const int c_b = *ptr - b_test;
+        const int cb = *ptr + b_test;
+        const int c_b = *ptr - b_test;
         if(ptr[offset0] > cb)
           if(ptr[offset5] > cb)
             if(ptr[offset2] > cb)
@@ -3409,23 +3409,23 @@ int agast_cornerScore<AgastFeatureDetector::AGAST_7_12s>(const uchar* ptr, const
     int bmax = 255;
     int b_test = (bmax + bmin)/2;
 
-    register short offset0 = (short) pixel[0];
-    register short offset1 = (short) pixel[1];
-    register short offset2 = (short) pixel[2];
-    register short offset3 = (short) pixel[3];
-    register short offset4 = (short) pixel[4];
-    register short offset5 = (short) pixel[5];
-    register short offset6 = (short) pixel[6];
-    register short offset7 = (short) pixel[7];
-    register short offset8 = (short) pixel[8];
-    register short offset9 = (short) pixel[9];
-    register short offset10 = (short) pixel[10];
-    register short offset11 = (short) pixel[11];
+    short offset0 = (short) pixel[0];
+    short offset1 = (short) pixel[1];
+    short offset2 = (short) pixel[2];
+    short offset3 = (short) pixel[3];
+    short offset4 = (short) pixel[4];
+    short offset5 = (short) pixel[5];
+    short offset6 = (short) pixel[6];
+    short offset7 = (short) pixel[7];
+    short offset8 = (short) pixel[8];
+    short offset9 = (short) pixel[9];
+    short offset10 = (short) pixel[10];
+    short offset11 = (short) pixel[11];
 
     while(true)
     {
-        register const int cb = *ptr + b_test;
-        register const int c_b = *ptr - b_test;
+        const int cb = *ptr + b_test;
+        const int c_b = *ptr - b_test;
         if(ptr[offset0] > cb)
           if(ptr[offset5] > cb)
             if(ptr[offset2] < c_b)
@@ -9044,19 +9044,19 @@ int agast_cornerScore<AgastFeatureDetector::AGAST_5_8>(const uchar* ptr, const i
     int bmax = 255;
     int b_test = (bmax + bmin)/2;
 
-    register short offset0 = (short) pixel[0];
-    register short offset1 = (short) pixel[1];
-    register short offset2 = (short) pixel[2];
-    register short offset3 = (short) pixel[3];
-    register short offset4 = (short) pixel[4];
-    register short offset5 = (short) pixel[5];
-    register short offset6 = (short) pixel[6];
-    register short offset7 = (short) pixel[7];
+    short offset0 = (short) pixel[0];
+    short offset1 = (short) pixel[1];
+    short offset2 = (short) pixel[2];
+    short offset3 = (short) pixel[3];
+    short offset4 = (short) pixel[4];
+    short offset5 = (short) pixel[5];
+    short offset6 = (short) pixel[6];
+    short offset7 = (short) pixel[7];
 
     while(true)
     {
-        register const int cb = *ptr + b_test;
-        register const int c_b = *ptr - b_test;
+        const int cb = *ptr + b_test;
+        const int c_b = *ptr - b_test;
         if(ptr[offset0] > cb)
           if(ptr[offset2] > cb)
             if(ptr[offset3] > cb)

--- a/modules/features2d/src/agast.cpp
+++ b/modules/features2d/src/agast.cpp
@@ -67,24 +67,24 @@ static void AGAST_5_8(InputArray _img, std::vector<KeyPoint>& keypoints, int thr
     int xsize = img.cols;
     int ysize = img.rows;
     size_t nExpectedCorners = keypoints.capacity();
-    register int x, y;
-    register int xsizeB = xsize - 2;
-    register int ysizeB = ysize - 1;
-    register int width;
+    int x, y;
+    int xsizeB = xsize - 2;
+    int ysizeB = ysize - 1;
+    int width;
 
     keypoints.resize(0);
 
     int pixel_5_8_[16];
     makeAgastOffsets(pixel_5_8_, (int)img.step, AgastFeatureDetector::AGAST_5_8);
 
-    register short offset0 = (short) pixel_5_8_[0];
-    register short offset1 = (short) pixel_5_8_[1];
-    register short offset2 = (short) pixel_5_8_[2];
-    register short offset3 = (short) pixel_5_8_[3];
-    register short offset4 = (short) pixel_5_8_[4];
-    register short offset5 = (short) pixel_5_8_[5];
-    register short offset6 = (short) pixel_5_8_[6];
-    register short offset7 = (short) pixel_5_8_[7];
+    short offset0 = (short) pixel_5_8_[0];
+    short offset1 = (short) pixel_5_8_[1];
+    short offset2 = (short) pixel_5_8_[2];
+    short offset3 = (short) pixel_5_8_[3];
+    short offset4 = (short) pixel_5_8_[4];
+    short offset5 = (short) pixel_5_8_[5];
+    short offset6 = (short) pixel_5_8_[6];
+    short offset7 = (short) pixel_5_8_[7];
 
     width = xsize;
 
@@ -100,9 +100,9 @@ static void AGAST_5_8(InputArray _img, std::vector<KeyPoint>& keypoints, int thr
                 break;
             else
             {
-                register const unsigned char* const ptr = img.ptr() + y*width + x;
-                register const int cb = *ptr + threshold;
-                register const int c_b = *ptr - threshold;
+                const unsigned char* const ptr = img.ptr() + y*width + x;
+                const int cb = *ptr + threshold;
+                const int c_b = *ptr - threshold;
                 if(ptr[offset0] > cb)
                   if(ptr[offset2] > cb)
                     if(ptr[offset3] > cb)
@@ -437,9 +437,9 @@ static void AGAST_5_8(InputArray _img, std::vector<KeyPoint>& keypoints, int thr
                 break;
             else
             {
-                register const unsigned char* const ptr = img.ptr() + y*width + x;
-                register const int cb = *ptr + threshold;
-                register const int c_b = *ptr - threshold;
+                const unsigned char* const ptr = img.ptr() + y*width + x;
+                const int cb = *ptr + threshold;
+                const int c_b = *ptr - threshold;
                 if(ptr[offset0] > cb)
                   if(ptr[offset2] > cb)
                     if(ptr[offset3] > cb)
@@ -829,28 +829,28 @@ static void AGAST_7_12d(InputArray _img, std::vector<KeyPoint>& keypoints, int t
     int xsize = img.cols;
     int ysize = img.rows;
     size_t nExpectedCorners = keypoints.capacity();
-    register int x, y;
-    register int xsizeB = xsize - 4;
-    register int ysizeB = ysize - 3;
-    register int width;
+    int x, y;
+    int xsizeB = xsize - 4;
+    int ysizeB = ysize - 3;
+    int width;
 
     keypoints.resize(0);
 
     int pixel_7_12d_[16];
     makeAgastOffsets(pixel_7_12d_, (int)img.step, AgastFeatureDetector::AGAST_7_12d);
 
-    register short offset0 = (short) pixel_7_12d_[0];
-    register short offset1 = (short) pixel_7_12d_[1];
-    register short offset2 = (short) pixel_7_12d_[2];
-    register short offset3 = (short) pixel_7_12d_[3];
-    register short offset4 = (short) pixel_7_12d_[4];
-    register short offset5 = (short) pixel_7_12d_[5];
-    register short offset6 = (short) pixel_7_12d_[6];
-    register short offset7 = (short) pixel_7_12d_[7];
-    register short offset8 = (short) pixel_7_12d_[8];
-    register short offset9 = (short) pixel_7_12d_[9];
-    register short offset10 = (short) pixel_7_12d_[10];
-    register short offset11 = (short) pixel_7_12d_[11];
+    short offset0 = (short) pixel_7_12d_[0];
+    short offset1 = (short) pixel_7_12d_[1];
+    short offset2 = (short) pixel_7_12d_[2];
+    short offset3 = (short) pixel_7_12d_[3];
+    short offset4 = (short) pixel_7_12d_[4];
+    short offset5 = (short) pixel_7_12d_[5];
+    short offset6 = (short) pixel_7_12d_[6];
+    short offset7 = (short) pixel_7_12d_[7];
+    short offset8 = (short) pixel_7_12d_[8];
+    short offset9 = (short) pixel_7_12d_[9];
+    short offset10 = (short) pixel_7_12d_[10];
+    short offset11 = (short) pixel_7_12d_[11];
 
     width = xsize;
 
@@ -866,9 +866,9 @@ static void AGAST_7_12d(InputArray _img, std::vector<KeyPoint>& keypoints, int t
                 break;
             else
             {
-                register const unsigned char* const ptr = img.ptr() + y*width + x;
-                register const int cb = *ptr + threshold;
-                register const int c_b = *ptr - threshold;
+                const unsigned char* const ptr = img.ptr() + y*width + x;
+                const int cb = *ptr + threshold;
+                const int c_b = *ptr - threshold;
                 if(ptr[offset0] > cb)
                   if(ptr[offset5] > cb)
                     if(ptr[offset2] > cb)
@@ -2048,9 +2048,9 @@ static void AGAST_7_12d(InputArray _img, std::vector<KeyPoint>& keypoints, int t
                 break;
             else
             {
-                register const unsigned char* const ptr = img.ptr() + y*width + x;
-                register const int cb = *ptr + threshold;
-                register const int c_b = *ptr - threshold;
+                const unsigned char* const ptr = img.ptr() + y*width + x;
+                const int cb = *ptr + threshold;
+                const int c_b = *ptr - threshold;
                 if(ptr[offset0] > cb)
                   if(ptr[offset5] > cb)
                     if(ptr[offset2] > cb)
@@ -3274,28 +3274,28 @@ static void AGAST_7_12s(InputArray _img, std::vector<KeyPoint>& keypoints, int t
     int xsize = img.cols;
     int ysize = img.rows;
     size_t nExpectedCorners = keypoints.capacity();
-    register int x, y;
-    register int xsizeB=xsize - 3; //2, +1 due to faster test x>xsizeB
-    register int ysizeB=ysize - 2;
-    register int width;
+    int x, y;
+    int xsizeB=xsize - 3; //2, +1 due to faster test x>xsizeB
+    int ysizeB=ysize - 2;
+    int width;
 
     keypoints.resize(0);
 
     int pixel_7_12s_[16];
     makeAgastOffsets(pixel_7_12s_, (int)img.step, AgastFeatureDetector::AGAST_7_12s);
 
-    register short offset0 = (short) pixel_7_12s_[0];
-    register short offset1 = (short) pixel_7_12s_[1];
-    register short offset2 = (short) pixel_7_12s_[2];
-    register short offset3 = (short) pixel_7_12s_[3];
-    register short offset4 = (short) pixel_7_12s_[4];
-    register short offset5 = (short) pixel_7_12s_[5];
-    register short offset6 = (short) pixel_7_12s_[6];
-    register short offset7 = (short) pixel_7_12s_[7];
-    register short offset8 = (short) pixel_7_12s_[8];
-    register short offset9 = (short) pixel_7_12s_[9];
-    register short offset10 = (short) pixel_7_12s_[10];
-    register short offset11 = (short) pixel_7_12s_[11];
+    short offset0 = (short) pixel_7_12s_[0];
+    short offset1 = (short) pixel_7_12s_[1];
+    short offset2 = (short) pixel_7_12s_[2];
+    short offset3 = (short) pixel_7_12s_[3];
+    short offset4 = (short) pixel_7_12s_[4];
+    short offset5 = (short) pixel_7_12s_[5];
+    short offset6 = (short) pixel_7_12s_[6];
+    short offset7 = (short) pixel_7_12s_[7];
+    short offset8 = (short) pixel_7_12s_[8];
+    short offset9 = (short) pixel_7_12s_[9];
+    short offset10 = (short) pixel_7_12s_[10];
+    short offset11 = (short) pixel_7_12s_[11];
 
     width = xsize;
 
@@ -3311,9 +3311,9 @@ static void AGAST_7_12s(InputArray _img, std::vector<KeyPoint>& keypoints, int t
                 break;
             else
             {
-                register const unsigned char* const ptr = img.ptr() + y*width + x;
-                register const int cb = *ptr + threshold;
-                register const int c_b = *ptr - threshold;
+                const unsigned char* const ptr = img.ptr() + y*width + x;
+                const int cb = *ptr + threshold;
+                const int c_b = *ptr - threshold;
                 if(ptr[offset0] > cb)
                   if(ptr[offset2] > cb)
                     if(ptr[offset5] > cb)
@@ -4349,9 +4349,9 @@ static void AGAST_7_12s(InputArray _img, std::vector<KeyPoint>& keypoints, int t
                 break;
             else
             {
-                register const unsigned char* const ptr = img.ptr() + y*width + x;
-                register const int cb = *ptr + threshold;
-                register const int c_b = *ptr - threshold;
+                const unsigned char* const ptr = img.ptr() + y*width + x;
+                const int cb = *ptr + threshold;
+                const int c_b = *ptr - threshold;
                 if(ptr[offset0] > cb)
                   if(ptr[offset2] > cb)
                     if(ptr[offset5] > cb)
@@ -5355,32 +5355,32 @@ static void OAST_9_16(InputArray _img, std::vector<KeyPoint>& keypoints, int thr
     int xsize = img.cols;
     int ysize = img.rows;
     size_t nExpectedCorners = keypoints.capacity();
-    register int x, y;
-    register int xsizeB=xsize - 4;
-    register int ysizeB=ysize - 3;
-    register int width;
+    int x, y;
+    int xsizeB=xsize - 4;
+    int ysizeB=ysize - 3;
+    int width;
 
     keypoints.resize(0);
 
     int pixel_9_16_[16];
     makeAgastOffsets(pixel_9_16_, (int)img.step, AgastFeatureDetector::OAST_9_16);
 
-    register short offset0 = (short) pixel_9_16_[0];
-    register short offset1 = (short) pixel_9_16_[1];
-    register short offset2 = (short) pixel_9_16_[2];
-    register short offset3 = (short) pixel_9_16_[3];
-    register short offset4 = (short) pixel_9_16_[4];
-    register short offset5 = (short) pixel_9_16_[5];
-    register short offset6 = (short) pixel_9_16_[6];
-    register short offset7 = (short) pixel_9_16_[7];
-    register short offset8 = (short) pixel_9_16_[8];
-    register short offset9 = (short) pixel_9_16_[9];
-    register short offset10 = (short) pixel_9_16_[10];
-    register short offset11 = (short) pixel_9_16_[11];
-    register short offset12 = (short) pixel_9_16_[12];
-    register short offset13 = (short) pixel_9_16_[13];
-    register short offset14 = (short) pixel_9_16_[14];
-    register short offset15 = (short) pixel_9_16_[15];
+    short offset0 = (short) pixel_9_16_[0];
+    short offset1 = (short) pixel_9_16_[1];
+    short offset2 = (short) pixel_9_16_[2];
+    short offset3 = (short) pixel_9_16_[3];
+    short offset4 = (short) pixel_9_16_[4];
+    short offset5 = (short) pixel_9_16_[5];
+    short offset6 = (short) pixel_9_16_[6];
+    short offset7 = (short) pixel_9_16_[7];
+    short offset8 = (short) pixel_9_16_[8];
+    short offset9 = (short) pixel_9_16_[9];
+    short offset10 = (short) pixel_9_16_[10];
+    short offset11 = (short) pixel_9_16_[11];
+    short offset12 = (short) pixel_9_16_[12];
+    short offset13 = (short) pixel_9_16_[13];
+    short offset14 = (short) pixel_9_16_[14];
+    short offset15 = (short) pixel_9_16_[15];
 
     width = xsize;
 
@@ -5394,9 +5394,9 @@ static void OAST_9_16(InputArray _img, std::vector<KeyPoint>& keypoints, int thr
                 break;
             else
             {
-                register const unsigned char* const ptr = img.ptr() + y*width + x;
-                register const int cb = *ptr + threshold;
-                register const int c_b = *ptr - threshold;
+                const unsigned char* const ptr = img.ptr() + y*width + x;
+                const int cb = *ptr + threshold;
+                const int c_b = *ptr - threshold;
                 if(ptr[offset0] > cb)
                   if(ptr[offset2] > cb)
                     if(ptr[offset4] > cb)
@@ -7817,10 +7817,10 @@ static void AGAST_ALL(InputArray _img, std::vector<KeyPoint>& keypoints, int thr
     int xsize = img.cols;
     int ysize = img.rows;
     size_t nExpectedCorners = keypoints.capacity();
-    register int x, y;
-    register int xsizeB = xsize - (agastbase + 2);
-    register int ysizeB = ysize - (agastbase + 1);
-    register int width;
+    int x, y;
+    int xsizeB = xsize - (agastbase + 2);
+    int ysizeB = ysize - (agastbase + 1);
+    int width;
 
     keypoints.resize(0);
 
@@ -7841,7 +7841,7 @@ static void AGAST_ALL(InputArray _img, std::vector<KeyPoint>& keypoints, int thr
                 break;
             else
             {
-                register const unsigned char* const ptr = img.ptr() + y*width + x;
+                const unsigned char* const ptr = img.ptr() + y*width + x;
                 result = agast_tree_search(table_struct1, pixel, ptr, threshold);
                 switch (result)
                 {
@@ -7863,7 +7863,7 @@ static void AGAST_ALL(InputArray _img, std::vector<KeyPoint>& keypoints, int thr
                 break;
             else
             {
-                register const unsigned char* const ptr = img.ptr() + y*width + x;
+                const unsigned char* const ptr = img.ptr() + y*width + x;
                 result = agast_tree_search(table_struct2, pixel, ptr, threshold);
                 switch (result)
                 {

--- a/modules/features2d/src/agast_score.cpp
+++ b/modules/features2d/src/agast_score.cpp
@@ -98,27 +98,27 @@ int agast_cornerScore<AgastFeatureDetector::OAST_9_16>(const uchar* ptr, const i
     int bmax = 255;
     int b_test = (bmax + bmin) / 2;
 
-    register short offset0 = (short) pixel[0];
-    register short offset1 = (short) pixel[1];
-    register short offset2 = (short) pixel[2];
-    register short offset3 = (short) pixel[3];
-    register short offset4 = (short) pixel[4];
-    register short offset5 = (short) pixel[5];
-    register short offset6 = (short) pixel[6];
-    register short offset7 = (short) pixel[7];
-    register short offset8 = (short) pixel[8];
-    register short offset9 = (short) pixel[9];
-    register short offset10 = (short) pixel[10];
-    register short offset11 = (short) pixel[11];
-    register short offset12 = (short) pixel[12];
-    register short offset13 = (short) pixel[13];
-    register short offset14 = (short) pixel[14];
-    register short offset15 = (short) pixel[15];
+    short offset0 = (short) pixel[0];
+    short offset1 = (short) pixel[1];
+    short offset2 = (short) pixel[2];
+    short offset3 = (short) pixel[3];
+    short offset4 = (short) pixel[4];
+    short offset5 = (short) pixel[5];
+    short offset6 = (short) pixel[6];
+    short offset7 = (short) pixel[7];
+    short offset8 = (short) pixel[8];
+    short offset9 = (short) pixel[9];
+    short offset10 = (short) pixel[10];
+    short offset11 = (short) pixel[11];
+    short offset12 = (short) pixel[12];
+    short offset13 = (short) pixel[13];
+    short offset14 = (short) pixel[14];
+    short offset15 = (short) pixel[15];
 
     while(true)
     {
-        register const int cb = *ptr + b_test;
-        register const int c_b = *ptr - b_test;
+        const int cb = *ptr + b_test;
+        const int c_b = *ptr - b_test;
         if(ptr[offset0] > cb)
           if(ptr[offset2] > cb)
             if(ptr[offset4] > cb)
@@ -2173,23 +2173,23 @@ int agast_cornerScore<AgastFeatureDetector::AGAST_7_12d>(const uchar* ptr, const
     int bmax = 255;
     int b_test = (bmax + bmin)/2;
 
-    register short offset0 = (short) pixel[0];
-    register short offset1 = (short) pixel[1];
-    register short offset2 = (short) pixel[2];
-    register short offset3 = (short) pixel[3];
-    register short offset4 = (short) pixel[4];
-    register short offset5 = (short) pixel[5];
-    register short offset6 = (short) pixel[6];
-    register short offset7 = (short) pixel[7];
-    register short offset8 = (short) pixel[8];
-    register short offset9 = (short) pixel[9];
-    register short offset10 = (short) pixel[10];
-    register short offset11 = (short) pixel[11];
+    short offset0 = (short) pixel[0];
+    short offset1 = (short) pixel[1];
+    short offset2 = (short) pixel[2];
+    short offset3 = (short) pixel[3];
+    short offset4 = (short) pixel[4];
+    short offset5 = (short) pixel[5];
+    short offset6 = (short) pixel[6];
+    short offset7 = (short) pixel[7];
+    short offset8 = (short) pixel[8];
+    short offset9 = (short) pixel[9];
+    short offset10 = (short) pixel[10];
+    short offset11 = (short) pixel[11];
 
     while(true)
     {
-        register const int cb = *ptr + b_test;
-        register const int c_b = *ptr - b_test;
+        const int cb = *ptr + b_test;
+        const int c_b = *ptr - b_test;
         if(ptr[offset0] > cb)
           if(ptr[offset5] > cb)
             if(ptr[offset2] > cb)
@@ -3385,23 +3385,23 @@ int agast_cornerScore<AgastFeatureDetector::AGAST_7_12s>(const uchar* ptr, const
     int bmax = 255;
     int b_test = (bmax + bmin)/2;
 
-    register short offset0 = (short) pixel[0];
-    register short offset1 = (short) pixel[1];
-    register short offset2 = (short) pixel[2];
-    register short offset3 = (short) pixel[3];
-    register short offset4 = (short) pixel[4];
-    register short offset5 = (short) pixel[5];
-    register short offset6 = (short) pixel[6];
-    register short offset7 = (short) pixel[7];
-    register short offset8 = (short) pixel[8];
-    register short offset9 = (short) pixel[9];
-    register short offset10 = (short) pixel[10];
-    register short offset11 = (short) pixel[11];
+    short offset0 = (short) pixel[0];
+    short offset1 = (short) pixel[1];
+    short offset2 = (short) pixel[2];
+    short offset3 = (short) pixel[3];
+    short offset4 = (short) pixel[4];
+    short offset5 = (short) pixel[5];
+    short offset6 = (short) pixel[6];
+    short offset7 = (short) pixel[7];
+    short offset8 = (short) pixel[8];
+    short offset9 = (short) pixel[9];
+    short offset10 = (short) pixel[10];
+    short offset11 = (short) pixel[11];
 
     while(true)
     {
-        register const int cb = *ptr + b_test;
-        register const int c_b = *ptr - b_test;
+        const int cb = *ptr + b_test;
+        const int c_b = *ptr - b_test;
         if(ptr[offset0] > cb)
           if(ptr[offset5] > cb)
             if(ptr[offset2] < c_b)
@@ -9019,19 +9019,19 @@ int agast_cornerScore<AgastFeatureDetector::AGAST_5_8>(const uchar* ptr, const i
     int bmax = 255;
     int b_test = (bmax + bmin)/2;
 
-    register short offset0 = (short) pixel[0];
-    register short offset1 = (short) pixel[1];
-    register short offset2 = (short) pixel[2];
-    register short offset3 = (short) pixel[3];
-    register short offset4 = (short) pixel[4];
-    register short offset5 = (short) pixel[5];
-    register short offset6 = (short) pixel[6];
-    register short offset7 = (short) pixel[7];
+    short offset0 = (short) pixel[0];
+    short offset1 = (short) pixel[1];
+    short offset2 = (short) pixel[2];
+    short offset3 = (short) pixel[3];
+    short offset4 = (short) pixel[4];
+    short offset5 = (short) pixel[5];
+    short offset6 = (short) pixel[6];
+    short offset7 = (short) pixel[7];
 
     while(true)
     {
-        register const int cb = *ptr + b_test;
-        register const int c_b = *ptr - b_test;
+        const int cb = *ptr + b_test;
+        const int c_b = *ptr - b_test;
         if(ptr[offset0] > cb)
           if(ptr[offset2] > cb)
             if(ptr[offset3] > cb)
@@ -9377,11 +9377,11 @@ int agast_cornerScore<AgastFeatureDetector::AGAST_5_8>(const uchar* ptr, const i
 
 int agast_tree_search(const uint32_t table_struct32[], int pixel_[], const unsigned char* const ptr, int threshold)
 {
-    register const int cb = *ptr + threshold;
-    register const int c_b = *ptr - threshold;
-    register int index;
-    register int offset;
-    register int cmpresult;
+    const int cb = *ptr + threshold;
+    const int c_b = *ptr - threshold;
+    int index;
+    int offset;
+    int cmpresult;
     index = 0;
     while ((table_struct32[index]>>16)!=0)
     {

--- a/modules/videoio/src/cap_dc1394.cpp
+++ b/modules/videoio/src/cap_dc1394.cpp
@@ -907,10 +907,10 @@ b = b > 255 ? 255 : b
 uyv2bgr(const unsigned char *src, unsigned char *dest,
         unsigned long long int NumPixels)
 {
-    register int i = NumPixels + (NumPixels << 1) - 1;
-    register int j = NumPixels + (NumPixels << 1) - 1;
-    register int y, u, v;
-    register int r, g, b;
+    int i = NumPixels + (NumPixels << 1) - 1;
+    int j = NumPixels + (NumPixels << 1) - 1;
+    int y, u, v;
+    int r, g, b;
 
     while (i > 0) {
         v = src[i--] - 128;
@@ -927,10 +927,10 @@ uyv2bgr(const unsigned char *src, unsigned char *dest,
 uyvy2bgr(const unsigned char *src, unsigned char *dest,
         unsigned long long int NumPixels)
 {
-    register int i = (NumPixels << 1) - 1;
-    register int j = NumPixels + (NumPixels << 1) - 1;
-    register int y0, y1, u, v;
-    register int r, g, b;
+    int i = (NumPixels << 1) - 1;
+    int j = NumPixels + (NumPixels << 1) - 1;
+    int y0, y1, u, v;
+    int r, g, b;
 
     while (i > 0) {
         y1 = src[i--];
@@ -953,10 +953,10 @@ uyvy2bgr(const unsigned char *src, unsigned char *dest,
 uyyvyy2bgr(const unsigned char *src, unsigned char *dest,
         unsigned long long int NumPixels)
 {
-    register int i = NumPixels + (NumPixels >> 1) - 1;
-    register int j = NumPixels + (NumPixels << 1) - 1;
-    register int y0, y1, y2, y3, u, v;
-    register int r, g, b;
+    int i = NumPixels + (NumPixels >> 1) - 1;
+    int j = NumPixels + (NumPixels << 1) - 1;
+    int y0, y1, y2, y3, u, v;
+    int r, g, b;
 
     while (i > 0) {
         y3 = src[i--];
@@ -988,9 +988,9 @@ uyyvyy2bgr(const unsigned char *src, unsigned char *dest,
 y2bgr(const unsigned char *src, unsigned char *dest,
         unsigned long long int NumPixels)
 {
-    register int i = NumPixels - 1;
-    register int j = NumPixels + (NumPixels << 1) - 1;
-    register int y;
+    int i = NumPixels - 1;
+    int j = NumPixels + (NumPixels << 1) - 1;
+    int y;
 
     while (i > 0) {
         y = src[i--];
@@ -1004,9 +1004,9 @@ y2bgr(const unsigned char *src, unsigned char *dest,
 y162bgr(const unsigned char *src, unsigned char *dest,
         unsigned long long int NumPixels, int bits)
 {
-    register int i = (NumPixels << 1) - 1;
-    register int j = NumPixels + (NumPixels << 1) - 1;
-    register int y;
+    int i = (NumPixels << 1) - 1;
+    int j = NumPixels + (NumPixels << 1) - 1;
+    int y;
 
     while (i > 0) {
         y = src[i--];
@@ -1022,9 +1022,9 @@ y162bgr(const unsigned char *src, unsigned char *dest,
 rgb482bgr(const unsigned char *src, unsigned char *dest,
         unsigned long long int NumPixels, int bits)
 {
-    register int i = (NumPixels << 1) - 1;
-    register int j = NumPixels + (NumPixels << 1) - 1;
-    register int y;
+    int i = (NumPixels << 1) - 1;
+    int j = NumPixels + (NumPixels << 1) - 1;
+    int y;
 
     while (i > 0) {
         y = src[i--];


### PR DESCRIPTION
Fixes clang warnings about uses of this obsolete keyword.