### PR TITLE
Fix CLAHE for 16-bit data and fix residual distribution logic error.

### DIFF
--- a/modules/imgproc/src/clahe.cpp
+++ b/modules/imgproc/src/clahe.cpp
@@ -212,8 +212,12 @@ namespace
                 for (int i = 0; i < histSize; ++i)
                     tileHist[i] += redistBatch;
 
-                for (int i = 0; i < residual; ++i)
-                    tileHist[i]++;
+                if (residual != 0)
+                {
+                    int residualStep = MAX(histSize / residual, 1);
+                    for (int i = 0; i < histSize; i += residualStep)
+                        tileHist[i]++;
+                }
             }
 
             // calc Lut
@@ -359,7 +363,7 @@ namespace
         bool useOpenCL = cv::ocl::useOpenCL() && _src.isUMat() && _src.dims()<=2 && _src.type() == CV_8UC1;
 #endif
 
-        int histSize = _src.type() == CV_8UC1 ? 256 : 4096;
+        int histSize = _src.type() == CV_8UC1 ? 256 : 65536;
 
         cv::Size tileSize;
         cv::_InputArray _srcForLut;
@@ -416,7 +420,7 @@ namespace
         if (_src.type() == CV_8UC1)
             calcLutBody = cv::makePtr<CLAHE_CalcLut_Body<uchar, 256, 0> >(srcForLut, lut_, tileSize, tilesX_, clipLimit, lutScale);
         else if (_src.type() == CV_16UC1)
-            calcLutBody = cv::makePtr<CLAHE_CalcLut_Body<ushort, 4096, 4> >(srcForLut, lut_, tileSize, tilesX_, clipLimit, lutScale);
+            calcLutBody = cv::makePtr<CLAHE_CalcLut_Body<ushort, 65536, 0> >(srcForLut, lut_, tileSize, tilesX_, clipLimit, lutScale);
         else
             CV_Error( CV_StsBadArg, "Unsupported type" );
 
@@ -426,7 +430,7 @@ namespace
         if (_src.type() == CV_8UC1)
             interpolationBody = cv::makePtr<CLAHE_Interpolation_Body<uchar, 0> >(src, dst, lut_, tileSize, tilesX_, tilesY_);
         else if (_src.type() == CV_16UC1)
-            interpolationBody = cv::makePtr<CLAHE_Interpolation_Body<ushort, 4> >(src, dst, lut_, tileSize, tilesX_, tilesY_);
+            interpolationBody = cv::makePtr<CLAHE_Interpolation_Body<ushort, 0> >(src, dst, lut_, tileSize, tilesX_, tilesY_);
 
         cv::parallel_for_(cv::Range(0, src.rows), *interpolationBody);
     }

--- a/modules/imgproc/src/clahe.cpp
+++ b/modules/imgproc/src/clahe.cpp
@@ -215,7 +215,7 @@ namespace
                 if (residual != 0)
                 {
                     int residualStep = MAX(histSize / residual, 1);
-                    for (int i = 0; i < histSize; i += residualStep)
+                    for (int i = 0; i < histSize && residual > 0; i += residualStep, residual--)
                         tileHist[i]++;
                 }
             }

--- a/modules/imgproc/src/opencl/clahe.cl
+++ b/modules/imgproc/src/opencl/clahe.cl
@@ -201,7 +201,10 @@ __kernel void calcLut(__global __const uchar * src, const int srcStep,
         tHistVal += redistBatch;
 
         int residual = totalClipped - redistBatch * 256;
-        if (tid < residual)
+        int rStep = 256 / residual;
+        if (rStep < 1)
+            rStep = 1;
+        if (tid%rStep == 0 && (tid/rStep)<residual)
             ++tHistVal;
     }
 


### PR DESCRIPTION
See Topic
http://answers.opencv.org/question/105472/result-of-clahe-is-different-on-8-and-16-bit-grayscale-image/?answer=105510#post-id-105510

This pullrequest changes

The residual distribution in the histogram of CLAHE.
The 16-bit range being used, it should be all 16 bits, not just 12.
The shift is made 0, not 4. Not sure why it ever was 4, but 0 looks much better.
