### PR TITLE
Add 90 degree rotation methods.

### DIFF
--- a/modules/core/include/opencv2/core.hpp
+++ b/modules/core/include/opencv2/core.hpp
@@ -1022,6 +1022,24 @@ around both axes.
 */
 CV_EXPORTS_W void flip(InputArray src, OutputArray dst, int flipCode);
 
+enum RotateFlags {
+    ROTATE_90 = 0, //Rotate 90 degrees clockwise
+    ROTATE_180 = 1, //Rotate 180 degrees clockwise
+    ROTATE_270 = 2, //Rotate 270 degrees clockwise
+};
+/** @brief Rotates a 2D array in multiples of 90 degrees.
+The function rotate rotates the array in one of three different ways:
+*   Rotate by 90 degrees clockwise (rotateCode = ROTATE_90).
+*   Rotate by 180 degrees clockwise (rotateCode = ROTATE_180).
+*   Rotate by 270 degrees clockwise (rotateCode = ROTATE_270).
+@param src input array.
+@param dst output array of the same type as src.  The size is the same with ROTATE_180,
+and the rows and cols are switched for ROTATE_90 and ROTATE_270.
+@param rotateCode an enum to specify how to rotate the array; see the enum RotateFlags
+@sa transpose , repeat , completeSymm, flip, RotateFlags
+*/
+CV_EXPORTS_W void rotate(InputArray src, OutputArray dst, int rotateCode);
+
 /** @brief Fills the output array with repeated copies of the input array.
 
 The function cv::repeat duplicates the input array one or more times along each of the two axes:

--- a/modules/core/include/opencv2/core.hpp
+++ b/modules/core/include/opencv2/core.hpp
@@ -1023,9 +1023,9 @@ around both axes.
 CV_EXPORTS_W void flip(InputArray src, OutputArray dst, int flipCode);
 
 enum RotateFlags {
-    ROTATE_90 = 0, //Rotate 90 degrees clockwise
+    ROTATE_90_CLOCKWISE = 0, //Rotate 90 degrees clockwise
     ROTATE_180 = 1, //Rotate 180 degrees clockwise
-    ROTATE_270 = 2, //Rotate 270 degrees clockwise
+    ROTATE_90_COUNTERCLOCKWISE = 2, //Rotate 270 degrees clockwise
 };
 /** @brief Rotates a 2D array in multiples of 90 degrees.
 The function rotate rotates the array in one of three different ways:

--- a/modules/core/src/copy.cpp
+++ b/modules/core/src/copy.cpp
@@ -832,14 +832,16 @@ static bool ocl_rotate(InputArray _src, OutputArray _dst, int rotateMode)
 {
     switch (rotateMode)
     {
-    case ROTATE_90:
-        flip(_src.getUMat().t(), _dst, 1);
+    case ROTATE_90_CLOCKWISE:
+        _dst.getUMat() = _src.getUMat().t();
+        flip(_dst, _dst, 1);
         break;
     case ROTATE_180:
         flip(_src, _dst, -1);
         break;
-    case ROTATE_270:
-        flip(_src.getUMat().t(), _dst, 0);
+    case ROTATE_90_COUNTERCLOCKWISE:
+        _dst.getUMat() = _src.getUMat().t();
+        flip(_dst, _dst, 0);
         break;
     default:
         break;
@@ -856,14 +858,16 @@ void rotate(InputArray _src, OutputArray _dst, int rotateMode)
 
     switch (rotateMode)
     {
-    case ROTATE_90:
-        flip(_src.getMat().t(), _dst, 1);
+    case ROTATE_90_CLOCKWISE:
+        _dst.getMat() = _src.getMat().t();
+        flip(_dst, _dst, 1);
         break;
     case ROTATE_180:
         flip(_src, _dst, -1);
         break;
-    case ROTATE_270:
-        flip(_src.getMat().t(), _dst, 0);
+    case ROTATE_90_COUNTERCLOCKWISE:
+        _dst.getMat() = _src.getMat().t();
+        flip(_dst, _dst, 0);
         break;
     default:
         break;

--- a/modules/core/src/copy.cpp
+++ b/modules/core/src/copy.cpp
@@ -833,14 +833,14 @@ static bool ocl_rotate(InputArray _src, OutputArray _dst, int rotateMode)
     switch (rotateMode)
     {
     case ROTATE_90_CLOCKWISE:
-        _dst.getUMat() = _src.getUMat().t();
+        transpose(_src, _dst);
         flip(_dst, _dst, 1);
         break;
     case ROTATE_180:
         flip(_src, _dst, -1);
         break;
     case ROTATE_90_COUNTERCLOCKWISE:
-        _dst.getUMat() = _src.getUMat().t();
+        transpose(_src, _dst);
         flip(_dst, _dst, 0);
         break;
     default:
@@ -859,14 +859,14 @@ void rotate(InputArray _src, OutputArray _dst, int rotateMode)
     switch (rotateMode)
     {
     case ROTATE_90_CLOCKWISE:
-        _dst.getMat() = _src.getMat().t();
+        transpose(_src, _dst);
         flip(_dst, _dst, 1);
         break;
     case ROTATE_180:
         flip(_src, _dst, -1);
         break;
     case ROTATE_90_COUNTERCLOCKWISE:
-        _dst.getMat() = _src.getMat().t();
+        transpose(_src, _dst);
         flip(_dst, _dst, 0);
         break;
     default:

--- a/modules/core/src/copy.cpp
+++ b/modules/core/src/copy.cpp
@@ -826,6 +826,50 @@ void flip( InputArray _src, OutputArray _dst, int flip_mode )
         flipHoriz( dst.ptr(), dst.step, dst.ptr(), dst.step, dst.size(), esz );
 }
 
+#ifdef HAVE_OPENCL
+
+static bool ocl_rotate(InputArray _src, OutputArray _dst, int rotateMode)
+{
+    switch (rotateMode)
+    {
+    case ROTATE_90:
+        flip(_src.getUMat().t(), _dst, 1);
+        break;
+    case ROTATE_180:
+        flip(_src, _dst, -1);
+        break;
+    case ROTATE_270:
+        flip(_src.getUMat().t(), _dst, 0);
+        break;
+    default:
+        break;
+    }
+    return true;
+}
+#endif
+
+void rotate(InputArray _src, OutputArray _dst, int rotateMode)
+{
+    CV_Assert(_src.dims() <= 2);
+
+    CV_OCL_RUN(_dst.isUMat(), ocl_rotate(_src, _dst, rotateMode))
+
+    switch (rotateMode)
+    {
+    case ROTATE_90:
+        flip(_src.getMat().t(), _dst, 1);
+        break;
+    case ROTATE_180:
+        flip(_src, _dst, -1);
+        break;
+    case ROTATE_270:
+        flip(_src.getMat().t(), _dst, 0);
+        break;
+    default:
+        break;
+    }
+}
+
 #if defined HAVE_OPENCL && !defined __APPLE__
 
 static bool ocl_repeat(InputArray _src, int ny, int nx, OutputArray _dst)


### PR DESCRIPTION
Adds a method for fast 90 degree rotations.  It is a common task, but there is no method for it.  It can be done with just transpose and flips, but this saves people from having to try each time to get it right.
