### PR TITLE
Use colon in "%YAML:1.0" directive when persisting to YAML-files

### DIFF
--- a/modules/core/src/persistence.cpp
+++ b/modules/core/src/persistence.cpp
@@ -4332,7 +4332,7 @@ cvOpenFileStorage( const char* query, CvMemStorage* dststorage, int flags, const
         else if( fs->fmt == CV_STORAGE_FORMAT_YAML )
         {
             if( !append )
-                icvPuts( fs, "%YAML 1.0\n---\n" );
+                icvPuts( fs, "%YAML:1.0\n---\n" );
             else
                 icvPuts( fs, "...\n---\n" );
             fs->start_write_struct = icvYMLStartWriteStruct;

--- a/modules/core/test/test_io.cpp
+++ b/modules/core/test/test_io.cpp
@@ -584,7 +584,7 @@ TEST(Core_InputOutput, FileStorageKey)
     EXPECT_NO_THROW(f << "key1" << "value1");
     EXPECT_NO_THROW(f << "_key2" << "value2");
     EXPECT_NO_THROW(f << "key_3" << "value3");
-    const std::string expected = "%YAML 1.0\n---\nkey1: value1\n_key2: value2\nkey_3: value3\n";
+    const std::string expected = "%YAML:1.0\n---\nkey1: value1\n_key2: value2\nkey_3: value3\n";
     ASSERT_STREQ(f.releaseAndGetString().c_str(), expected.c_str());
 }
 


### PR DESCRIPTION
### This pullrequest changes

In YAML 1.0 the colon is mandatory. See http://yaml.org/spec/1.0/#id2558635.

This also allows prior releases to read YAML files created with the current version.