### PR TITLE
Correct cast for _InterlockedExchangeAdd on ICC

### DIFF
--- a/modules/core/include/opencv2/core/cvdef.h
+++ b/modules/core/include/opencv2/core/cvdef.h
@@ -418,10 +418,7 @@ Cv64suf;
 *          exchange-add operation for atomic operations on reference counters            *
 \****************************************************************************************/
 
-#if defined __INTEL_COMPILER && !(defined WIN32 || defined _WIN32)
-   // atomic increment on the linux version of the Intel(tm) compiler
-#  define CV_XADD(addr, delta) (int)_InterlockedExchangeAdd(const_cast<long*>(reinterpret_cast<volatile long*>(addr)), delta)
-#elif defined __GNUC__
+#if defined __GNUC__
 #  if defined __clang__ && __clang_major__ >= 3 && !defined __ANDROID__ && !defined __EMSCRIPTEN__ && !defined(__CUDACC__)
 #    ifdef __ATOMIC_ACQ_REL
 #      define CV_XADD(addr, delta) __c11_atomic_fetch_add((_Atomic(int)*)(addr), delta, __ATOMIC_ACQ_REL)

--- a/modules/core/include/opencv2/core/cvdef.h
+++ b/modules/core/include/opencv2/core/cvdef.h
@@ -420,7 +420,7 @@ Cv64suf;
 
 #if defined __INTEL_COMPILER && !(defined WIN32 || defined _WIN32)
    // atomic increment on the linux version of the Intel(tm) compiler
-#  define CV_XADD(addr, delta) (int)_InterlockedExchangeAdd(const_cast<void*>(reinterpret_cast<volatile void*>(addr)), delta)
+#  define CV_XADD(addr, delta) (int)_InterlockedExchangeAdd(const_cast<long*>(reinterpret_cast<volatile long*>(addr)), delta)
 #elif defined __GNUC__
 #  if defined __clang__ && __clang_major__ >= 3 && !defined __ANDROID__ && !defined __EMSCRIPTEN__ && !defined(__CUDACC__)
 #    ifdef __ATOMIC_ACQ_REL


### PR DESCRIPTION
<!-- Please use this line to close one or multiple issues when this pullrequest gets merged
You can add another line right under the first one:
resolves #1234
resolves #1235
-->

### This pullrequest changes

<!-- Please describe what your pullrequest is changing -->

A bug in ICC improperly identified the first parameter as "void*"
rather than the proper "volatile long*".  This is scheduled to be
fixed in ICC in a future release.

This patch casts only to a "long*" to preserve backwards compatibility
with the ICC 16 and ICC 17 releases.  Future versions of ICC will
break due to the type checking being stricter.