### PR TITLE
add steady_clock to getTickCount()

### DIFF
--- a/modules/core/src/system.cpp
+++ b/modules/core/src/system.cpp
@@ -51,7 +51,7 @@
 #endif
 
 #if HAVE_CPP11
- #include <chrono>
+# include <chrono>
 #endif
 
 namespace cv {
@@ -423,7 +423,8 @@ int64 getTickCount(void)
 {
 #if HAVE_CPP11
     std::chrono::steady_clock::time_point now = std::chrono::steady_clock::now();
-    return now.time_since_epoch().count();
+    return std::chrono::duration_cast<std::chrono::microseconds>(now.time_since_epoch()).count();
+    //return now.time_since_epoch().count();
 #elif defined WIN32 || defined _WIN32 || defined WINCE
     LARGE_INTEGER counter;
     QueryPerformanceCounter( &counter );
@@ -445,7 +446,8 @@ int64 getTickCount(void)
 double getTickFrequency(void)
 {
 #if HAVE_CPP11
-    return 1e9;
+    //return 1e9;
+    return 1e6;
 #elif defined WIN32 || defined _WIN32 || defined WINCE
     LARGE_INTEGER freq;
     QueryPerformanceFrequency(&freq);

--- a/modules/core/src/system.cpp
+++ b/modules/core/src/system.cpp
@@ -423,8 +423,7 @@ int64 getTickCount(void)
 {
 #if HAVE_CPP11
     std::chrono::steady_clock::time_point now = std::chrono::steady_clock::now();
-    return std::chrono::duration_cast<std::chrono::microseconds>(now.time_since_epoch()).count();
-    //return now.time_since_epoch().count();
+    return now.time_since_epoch().count();
 #elif defined WIN32 || defined _WIN32 || defined WINCE
     LARGE_INTEGER counter;
     QueryPerformanceCounter( &counter );
@@ -446,8 +445,7 @@ int64 getTickCount(void)
 double getTickFrequency(void)
 {
 #if HAVE_CPP11
-    //return 1e9;
-    return 1e6;
+    return 1e9;
 #elif defined WIN32 || defined _WIN32 || defined WINCE
     LARGE_INTEGER freq;
     QueryPerformanceFrequency(&freq);

--- a/modules/core/src/system.cpp
+++ b/modules/core/src/system.cpp
@@ -44,6 +44,16 @@
 #include "precomp.hpp"
 #include <iostream>
 
+#if (__cplusplus >= 201103L || ((defined(_MSC_VER) && _MSC_VER >= 1800)))
+    #define HAVE_CPP11 1
+#else
+    #define HAVE_CPP11 0
+#endif
+
+#if HAVE_CPP11
+ #include <chrono>
+#endif
+
 namespace cv {
 
 static Mutex* __initialization_mutex = NULL;
@@ -408,9 +418,13 @@ bool useOptimized(void)
     return useOptimizedFlag;
 }
 
+
 int64 getTickCount(void)
 {
-#if defined WIN32 || defined _WIN32 || defined WINCE
+#if HAVE_CPP11
+    std::chrono::steady_clock::time_point now = std::chrono::steady_clock::now();
+    return now.time_since_epoch().count();
+#elif defined WIN32 || defined _WIN32 || defined WINCE
     LARGE_INTEGER counter;
     QueryPerformanceCounter( &counter );
     return (int64)counter.QuadPart;
@@ -430,7 +444,9 @@ int64 getTickCount(void)
 
 double getTickFrequency(void)
 {
-#if defined WIN32 || defined _WIN32 || defined WINCE
+#if HAVE_CPP11
+    return 1e9;
+#elif defined WIN32 || defined _WIN32 || defined WINCE
     LARGE_INTEGER freq;
     QueryPerformanceFrequency(&freq);
     return (double)freq.QuadPart;


### PR DESCRIPTION
resolves #6902
### This pullrequest changes

try to use std::chrono::steady_clock in cv::getTickCount(), if c++11 features are available.
