### PR TITLE
highgui: window_QT: added missing virtual method specifier

### DIFF
--- a/modules/highgui/src/window_QT.h
+++ b/modules/highgui/src/window_QT.h
@@ -414,7 +414,7 @@ public:
 protected:
     void icvmouseEvent(QMouseEvent* event, type_mouse_event category);
     void icvmouseHandler(QMouseEvent* event, type_mouse_event category, int& cv_event, int& flags);
-    void icvmouseProcessing(QPointF pt, int cv_event, int flags);
+    virtual void icvmouseProcessing(QPointF pt, int cv_event, int flags);
 
     CvMouseCallback mouseCallback;
     void* mouseData;


### PR DESCRIPTION
resolves #7603

Resolves #7603, which was caused by OCVViewPort::icvmouseProcessing
not being declared as virtual, and hence was not overriden by
DefaultViewPort::icvmouseProcessing (which does the inverse
coordinate mapping).