### PR TITLE
Update of instrumentation framework

### DIFF
--- a/modules/core/src/dxt.cpp
+++ b/modules/core/src/dxt.cpp
@@ -1564,8 +1564,6 @@ public:
 
     virtual void operator()(const Range& range) const
     {
-        CV_INSTRUMENT_REGION_IPP();
-
         IppStatus status;
         Ipp8u* pBuffer = 0;
         Ipp8u* pMemInit= 0;
@@ -1647,8 +1645,6 @@ public:
 
     virtual void operator()(const Range& range) const
     {
-        CV_INSTRUMENT_REGION_IPP();
-
         IppStatus status;
         Ipp8u* pBuffer = 0;
         Ipp8u* pMemInit= 0;
@@ -3809,8 +3805,6 @@ public:
 
     virtual void operator()(const Range& range) const
     {
-        CV_INSTRUMENT_REGION_IPP()
-
         if(*ok == false)
             return;
 

--- a/modules/core/src/ocl.cpp
+++ b/modules/core/src/ocl.cpp
@@ -3450,7 +3450,7 @@ int Kernel::set(int i, const KernelArg& arg)
 bool Kernel::run(int dims, size_t _globalsize[], size_t _localsize[],
                  bool sync, const Queue& q)
 {
-    CV_INSTRUMENT_REGION_META(p->name.c_str(), instr::TYPE_FUN, instr::IMPL_OPENCL);
+    CV_INSTRUMENT_REGION_OPENCL_RUN(p->name.c_str());
 
     if(!p || !p->handle || p->e != 0)
         return false;
@@ -3563,7 +3563,7 @@ struct Program::Impl
     Impl(const ProgramSource& _src,
          const String& _buildflags, String& errmsg)
     {
-        CV_INSTRUMENT_REGION_OPENCL_(cv::format("Compile: %" PRIx64 " options: %s", _src.hash(), _buildflags.c_str()).c_str());
+        CV_INSTRUMENT_REGION_OPENCL_COMPILE(cv::format("Compile: %" PRIx64 " options: %s", _src.hash(), _buildflags.c_str()).c_str());
         refcount = 1;
         const Context& ctx = Context::getDefault();
         src = _src;

--- a/modules/core/src/stat.cpp
+++ b/modules/core/src/stat.cpp
@@ -1597,7 +1597,7 @@ static bool ocl_meanStdDev( InputArray _src, OutputArray _mean, OutputArray _sdv
 
         size_t globalsize = groups * wgs;
 
-        if(!CV_INSTRUMENT_FUN_OPENCL_KERNEL(k.run, 1, &globalsize, &wgs, false))
+        if(!k.run(1, &globalsize, &wgs, false))
             return false;
 
         typedef Scalar (* part_sum)(Mat m);

--- a/modules/core/src/system.cpp
+++ b/modules/core/src/system.cpp
@@ -1340,7 +1340,7 @@ void resetTrace()
 void setFlags(FLAGS modeFlags)
 {
 #ifdef ENABLE_INSTRUMENTATION
-    getInstrumentStruct().enableMapping = (modeFlags & FLAGS_MAPPING);
+    getInstrumentStruct().flags = modeFlags;
 #else
     CV_UNUSED(modeFlags);
 #endif
@@ -1348,31 +1348,27 @@ void setFlags(FLAGS modeFlags)
 FLAGS getFlags()
 {
 #ifdef ENABLE_INSTRUMENTATION
-    int flags = 0;
-    if(getInstrumentStruct().enableMapping)
-        flags |= FLAGS_MAPPING;
-    return (FLAGS)flags;
+    return (FLAGS)getInstrumentStruct().flags;
 #else
     return (FLAGS)0;
 #endif
 }
 
-NodeData::NodeData(const char* funName, const char* fileName, int lineNum, cv::instr::TYPE instrType, cv::instr::IMPL implType)
+NodeData::NodeData(const char* funName, const char* fileName, int lineNum, void* retAddress, bool alwaysExpand, cv::instr::TYPE instrType, cv::instr::IMPL implType)
 {
-    m_instrType = TYPE_GENERAL;
-    m_implType  = IMPL_PLAIN;
+    m_funName       = funName;
+    m_instrType     = instrType;
+    m_implType      = implType;
+    m_fileName      = fileName;
+    m_lineNum       = lineNum;
+    m_retAddress    = retAddress;
+    m_alwaysExpand  = alwaysExpand;
 
-    m_funName     = funName;
-    m_instrType   = instrType;
-    m_implType    = implType;
-    m_fileName    = fileName;
-    m_lineNum     = lineNum;
-
-    m_counter = 0;
+    m_threads    = 1;
+    m_counter    = 0;
     m_ticksTotal = 0;
 
-    m_funError = false;
-    m_stopPoint = false;
+    m_funError  = false;
 }
 NodeData::NodeData(NodeData &ref)
 {
@@ -1380,15 +1376,20 @@ NodeData::NodeData(NodeData &ref)
 }
 NodeData& NodeData::operator=(const NodeData &right)
 {
-    this->m_funName     = right.m_funName;
-    this->m_instrType   = right.m_instrType;
-    this->m_implType    = right.m_implType;
-    this->m_fileName    = right.m_fileName;
-    this->m_lineNum     = right.m_lineNum;
+    this->m_funName      = right.m_funName;
+    this->m_instrType    = right.m_instrType;
+    this->m_implType     = right.m_implType;
+    this->m_fileName     = right.m_fileName;
+    this->m_lineNum      = right.m_lineNum;
+    this->m_retAddress   = right.m_retAddress;
+    this->m_alwaysExpand = right.m_alwaysExpand;
+
+    this->m_threads     = right.m_threads;
     this->m_counter     = right.m_counter;
     this->m_ticksTotal  = right.m_ticksTotal;
+
     this->m_funError    = right.m_funError;
-    this->m_stopPoint   = right.m_stopPoint;
+
     return *this;
 }
 NodeData::~NodeData()
@@ -1397,7 +1398,10 @@ NodeData::~NodeData()
 bool operator==(const NodeData& left, const NodeData& right)
 {
     if(left.m_lineNum == right.m_lineNum && left.m_funName == right.m_funName && left.m_fileName == right.m_fileName)
-        return true;
+    {
+        if(left.m_retAddress == right.m_retAddress || !(cv::instr::getFlags()&cv::instr::FLAGS_EXPAND_SAME_NAMES || left.m_alwaysExpand))
+            return true;
+    }
     return false;
 }
 
@@ -1418,7 +1422,7 @@ InstrNode* getCurrentNode()
     return getInstrumentTLSStruct().pCurrentNode;
 }
 
-IntrumentationRegion::IntrumentationRegion(const char* funName, const char* fileName, int lineNum, TYPE instrType, IMPL implType)
+IntrumentationRegion::IntrumentationRegion(const char* funName, const char* fileName, int lineNum, void *retAddress, bool alwaysExpand, TYPE instrType, IMPL implType)
 {
     m_disabled    = false;
     m_regionTicks = 0;
@@ -1435,14 +1439,17 @@ IntrumentationRegion::IntrumentationRegion(const char* funName, const char* file
             return;
         }
 
-        m_disabled = pTLS->pCurrentNode->m_payload.m_stopPoint;
-        if(m_disabled)
+        int depth = pTLS->pCurrentNode->getDepth();
+        if(pStruct->maxDepth && pStruct->maxDepth <= depth)
+        {
+            m_disabled = true;
             return;
+        }
 
-        NodeData payload(funName, fileName, lineNum, instrType, implType);
+        NodeData payload(funName, fileName, lineNum, retAddress, alwaysExpand, instrType, implType);
         Node<NodeData>* pChild = NULL;
 
-        if(pStruct->enableMapping)
+        if(pStruct->flags&FLAGS_MAPPING)
         {
             // Critical section
             cv::AutoLock guard(pStruct->mutexCreate); // Guard from concurrent child creation
@@ -1458,7 +1465,7 @@ IntrumentationRegion::IntrumentationRegion(const char* funName, const char* file
             pChild = pTLS->pCurrentNode->findChild(payload);
             if(!pChild)
             {
-                pTLS->pCurrentNode->m_payload.m_stopPoint = true;
+                m_disabled = true;
                 return;
             }
         }
@@ -1476,28 +1483,23 @@ IntrumentationRegion::~IntrumentationRegion()
         if(!m_disabled)
         {
             InstrTLSStruct *pTLS = &getInstrumentTLSStruct();
-            if(pTLS->pCurrentNode->m_payload.m_stopPoint)
-            {
-                pTLS->pCurrentNode->m_payload.m_stopPoint = false;
-            }
-            else
-            {
-                if (pTLS->pCurrentNode->m_payload.m_implType == cv::instr::IMPL_OPENCL &&
-                    (pTLS->pCurrentNode->m_payload.m_instrType == cv::instr::TYPE_FUN ||
-                        pTLS->pCurrentNode->m_payload.m_instrType == cv::instr::TYPE_WRAPPER))
-                {
-                    cv::ocl::finish(); // TODO Support "async" OpenCL instrumentation
-                }
 
-                uint64 ticks = (getTickCount() - m_regionTicks);
-                {
-                    cv::AutoLock guard(pStruct->mutexCount); // Concurrent ticks accumulation
-                    pTLS->pCurrentNode->m_payload.m_counter++;
-                    pTLS->pCurrentNode->m_payload.m_ticksTotal += ticks;
-                }
-
-                pTLS->pCurrentNode = pTLS->pCurrentNode->m_pParent;
+            if (pTLS->pCurrentNode->m_payload.m_implType == cv::instr::IMPL_OPENCL &&
+                (pTLS->pCurrentNode->m_payload.m_instrType == cv::instr::TYPE_FUN ||
+                    pTLS->pCurrentNode->m_payload.m_instrType == cv::instr::TYPE_WRAPPER))
+            {
+                cv::ocl::finish(); // TODO Support "async" OpenCL instrumentation
             }
+
+            uint64 ticks = (getTickCount() - m_regionTicks);
+            {
+                cv::AutoLock guard(pStruct->mutexCount); // Concurrent ticks accumulation
+                pTLS->pCurrentNode->m_payload.m_counter++;
+                pTLS->pCurrentNode->m_payload.m_ticksTotal += ticks;
+                pTLS->pCurrentNode->m_payload.m_tls.get()->m_ticksTotal += ticks;
+            }
+
+            pTLS->pCurrentNode = pTLS->pCurrentNode->m_pParent;
         }
     }
 }

--- a/modules/imgproc/src/canny.cpp
+++ b/modules/imgproc/src/canny.cpp
@@ -142,6 +142,8 @@ template <bool useCustomDeriv>
 static bool ocl_Canny(InputArray _src, const UMat& dx_, const UMat& dy_, OutputArray _dst, float low_thresh, float high_thresh,
                       int aperture_size, bool L2gradient, int cn, const Size & size)
 {
+    CV_INSTRUMENT_REGION_OPENCL()
+
     UMat map;
 
     const ocl::Device &dev = ocl::Device::getDefault();

--- a/modules/imgproc/src/color.cpp
+++ b/modules/imgproc/src/color.cpp
@@ -259,8 +259,6 @@ public:
 
     virtual void operator()(const Range& range) const
     {
-        CV_INSTRUMENT_REGION_IPP();
-
         const void *yS = src_data + src_step * range.start;
         void *yD = dst_data + dst_step * range.start;
         if( !cvt(yS, static_cast<int>(src_step), yD, static_cast<int>(dst_step), width, range.end - range.start) )

--- a/modules/imgproc/src/histogram.cpp
+++ b/modules/imgproc/src/histogram.cpp
@@ -1188,8 +1188,6 @@ public:
 
     virtual void operator() (const Range & range) const
     {
-        CV_INSTRUMENT_REGION_IPP()
-
         Ipp32s levelNum = histSize + 1;
         Mat phist(hist->size(), hist->type(), Scalar::all(0));
 #if IPP_VERSION_X100 >= 900

--- a/modules/imgproc/src/imgwarp.cpp
+++ b/modules/imgproc/src/imgwarp.cpp
@@ -2795,8 +2795,6 @@ public:
 
     virtual void operator() (const Range& range) const
     {
-        CV_INSTRUMENT_REGION_IPP()
-
         if (*ok == false)
             return;
 
@@ -4772,8 +4770,6 @@ public:
 
     virtual void operator() (const Range & range) const
     {
-        CV_INSTRUMENT_REGION_IPP()
-
         IppiRect srcRoiRect = { 0, 0, src.cols, src.rows };
         Mat dstRoi = dst.rowRange(range);
         IppiSize dstRoiSize = ippiSize(dstRoi.size());
@@ -5609,8 +5605,6 @@ public:
 
     virtual void operator() (const Range& range) const
     {
-        CV_INSTRUMENT_REGION_IPP()
-
         IppiSize srcsize = { src.cols, src.rows };
         IppiRect srcroi = { 0, 0, src.cols, src.rows };
         IppiRect dstroi = { 0, range.start, dst.cols, range.end - range.start };
@@ -6254,8 +6248,6 @@ public:
 
     virtual void operator() (const Range& range) const
     {
-        CV_INSTRUMENT_REGION_IPP()
-
         IppiSize srcsize = {src.cols, src.rows};
         IppiRect srcroi = {0, 0, src.cols, src.rows};
         IppiRect dstroi = {0, range.start, dst.cols, range.end - range.start};

--- a/modules/imgproc/src/smooth.cpp
+++ b/modules/imgproc/src/smooth.cpp
@@ -3368,8 +3368,6 @@ public:
 
       virtual void operator() (const Range& range) const
       {
-          CV_INSTRUMENT_REGION_IPP()
-
           int d = radius * 2 + 1;
           IppiSize kernel = {d, d};
           IppiSize roi={dst.cols, range.end - range.start};

--- a/modules/ts/src/ts_perf.cpp
+++ b/modules/ts/src/ts_perf.cpp
@@ -46,7 +46,7 @@ static bool         param_verify_sanity;
 static bool         param_collect_impl;
 #endif
 #ifdef ENABLE_INSTRUMENTATION
-static bool         param_instrument;
+static int          param_instrument;
 #endif
 extern bool         test_ipp_check;
 
@@ -744,7 +744,7 @@ static void printShift(cv::instr::InstrNode *pNode, cv::instr::InstrNode* pRoot)
         }
     }
 
-    // Check if parents have more childs
+    // Check if parents have more childes
     std::vector<cv::instr::InstrNode*> cache;
     cv::instr::InstrNode *pTmpNode = pNode;
     while(pTmpNode->m_pParent && pTmpNode->m_pParent != pRoot)
@@ -756,7 +756,7 @@ static void printShift(cv::instr::InstrNode *pNode, cv::instr::InstrNode* pRoot)
     {
         if(cache[i]->m_pParent)
         {
-            if(cache[i]->m_pParent->findChild(cache[i]) == cache[i]->m_pParent->m_childs.size()-1)
+            if(cache[i]->m_pParent->findChild(cache[i]) == (int)cache[i]->m_pParent->m_childs.size()-1)
                 printf("    ");
             else
                 printf("|   ");
@@ -810,48 +810,39 @@ static void printNodeRec(cv::instr::InstrNode *pNode, cv::instr::InstrNode *pRoo
 
     if(pNode->m_pParent)
     {
-        printf(" - C:%d", pNode->m_payload.m_counter);
-        printf(" T:%.4fms", pNode->m_payload.getMeanMs());
+        printf(" - TC:%d C:%d", pNode->m_payload.m_threads, pNode->m_payload.m_counter);
+        printf(" T:%.2fms", pNode->m_payload.getTotalMs());
         if(pNode->m_pParent->m_pParent)
             printf(" L:%.0f%% G:%.0f%%", calcLocalWeight(pNode), calcGlobalWeight(pNode));
     }
     printf("\n");
 
-    // Group childes
-    std::vector<cv::String> groups;
     {
-        bool bFound = false;
-        for(size_t i = 0; i < pNode->m_childs.size(); i++)
+        // Group childes by name
+        for(size_t i = 1; i < pNode->m_childs.size(); i++)
         {
-            bFound = false;
-            for(size_t j = 0; j < groups.size(); j++)
+            if(pNode->m_childs[i-1]->m_payload.m_funName == pNode->m_childs[i]->m_payload.m_funName )
+                continue;
+            for(size_t j = i+1; j < pNode->m_childs.size(); j++)
             {
-                if(groups[j] == pNode->m_childs[i]->m_payload.m_funName)
+                if(pNode->m_childs[i-1]->m_payload.m_funName == pNode->m_childs[j]->m_payload.m_funName )
                 {
-                    bFound = true;
-                    break;
+                    cv::swap(pNode->m_childs[i], pNode->m_childs[j]);
+                    i++;
                 }
             }
-            if(!bFound)
-                groups.push_back(pNode->m_childs[i]->m_payload.m_funName);
         }
     }
 
-    for(size_t g = 0; g < groups.size(); g++)
+    for(size_t i = 0; i < pNode->m_childs.size(); i++)
     {
-        for(size_t i = 0; i < pNode->m_childs.size(); i++)
-        {
-            if(pNode->m_childs[i]->m_payload.m_funName == groups[g])
-            {
-                printShift(pNode->m_childs[i], pRoot);
+        printShift(pNode->m_childs[i], pRoot);
 
-                if(pNode->m_childs.size()-1 == pNode->m_childs[i]->m_pParent->findChild(pNode->m_childs[i]))
-                    printf("\\---");
-                else
-                    printf("|---");
-                printNodeRec(pNode->m_childs[i], pRoot);
-            }
-        }
+        if(i == pNode->m_childs.size()-1)
+            printf("\\---");
+        else
+            printf("|---");
+        printNodeRec(pNode->m_childs[i], pRoot);
     }
 }
 
@@ -871,7 +862,7 @@ static cv::String nodeToString(cv::instr::InstrNode *pNode)
     else
     {
         string = "#";
-        string += std::to_string(pNode->m_payload.m_instrType);
+        string += std::to_string((int)pNode->m_payload.m_instrType);
         string += pNode->m_payload.m_funName;
         string += " - L:";
         string += to_string_with_precision(calcLocalWeight(pNode));
@@ -931,19 +922,16 @@ static uint64 getTotalTime()
 
 void InstumentData::printTree()
 {
-    if(cv::instr::getTrace()->m_childs.size())
-    {
-        printf("[ TRACE    ]\n");
-        printNodeRec(cv::instr::getTrace(), cv::instr::getTrace());
+    printf("[ TRACE    ]\n");
+    printNodeRec(cv::instr::getTrace(), cv::instr::getTrace());
 #ifdef HAVE_IPP
-        printf("\nIPP weight: %.1f%%", ((double)getImplTime(cv::instr::IMPL_IPP)*100/(double)getTotalTime()));
+    printf("\nIPP weight: %.1f%%", ((double)getImplTime(cv::instr::IMPL_IPP)*100/(double)getTotalTime()));
 #endif
 #ifdef HAVE_OPENCL
-        printf("\nOPENCL weight: %.1f%%", ((double)getImplTime(cv::instr::IMPL_OPENCL)*100/(double)getTotalTime()));
+    printf("\nOPENCL weight: %.1f%%", ((double)getImplTime(cv::instr::IMPL_OPENCL)*100/(double)getTotalTime()));
 #endif
-        printf("\n[/TRACE    ]\n");
-        fflush(stdout);
-    }
+    printf("\n[/TRACE    ]\n");
+    fflush(stdout);
 }
 #endif
 
@@ -994,7 +982,7 @@ void TestBase::Init(const std::vector<std::string> & availableImpls,
         "{   perf_collect_impl           |false    |collect info about executed implementations}"
 #endif
 #ifdef ENABLE_INSTRUMENTATION
-        "{   perf_instrument             |false    |instrument code to collect implementations trace}"
+        "{   perf_instrument             |0        |instrument code to collect implementations trace: 1 - perform instrumentation; 2 - separate functions with the same name }"
 #endif
         "{   help h                      |false    |print help info}"
 #ifdef HAVE_CUDA
@@ -1048,7 +1036,7 @@ void TestBase::Init(const std::vector<std::string> & availableImpls,
     param_collect_impl  = args.get<bool>("perf_collect_impl");
 #endif
 #ifdef ENABLE_INSTRUMENTATION
-    param_instrument    = args.get<bool>("perf_instrument");
+    param_instrument    = args.get<int>("perf_instrument");
 #endif
 #ifdef ANDROID
     param_affinity_mask   = args.get<int>("perf_affinity_mask");
@@ -1081,8 +1069,12 @@ void TestBase::Init(const std::vector<std::string> & availableImpls,
         cv::setUseCollection(0);
 #endif
 #ifdef ENABLE_INSTRUMENTATION
-    if(param_instrument)
+    if(param_instrument > 0)
+    {
+        if(param_instrument == 2)
+            cv::instr::setFlags(cv::instr::getFlags()|cv::instr::FLAGS_EXPAND_SAME_NAMES);
         cv::instr::setUseInstrumentation(true);
+    }
     else
         cv::instr::setUseInstrumentation(false);
 #endif
@@ -1856,6 +1848,11 @@ void TestBase::TearDown()
         if (HasFailure())
         {
             reportMetrics(false);
+
+#ifdef ENABLE_INSTRUMENTATION
+            if(cv::instr::useInstrumentation())
+                InstumentData::printTree();
+#endif
             return;
         }
     }


### PR DESCRIPTION
### This pullrequest changes

- --perf_instrument parameter now has int type and 0, 1, 2 modes (1 - simple trees, 2 - expanded trees for functions with same name but different calling address);
- Maximum depth limit var was added to the instrumentation structure;
- Trace names output console output fix: improper tree formatting could happen;
- Trace output in case of error was added;
- Custom regions improvements;
- Improved timing and weight calculation for parallel regions;
- New TC (threads counter) value to indicate how many different threads accessed particular node;
- parallel_for fix, warnings fixes and ReturnAddress idea from Alexander Alekhin;