### PR TITLE
Add support of vector of vectors serialization to FileStorage

### DIFF
--- a/modules/core/include/opencv2/core/persistence.hpp
+++ b/modules/core/include/opencv2/core/persistence.hpp
@@ -958,7 +958,6 @@ void write( FileStorage& fs, const std::vector<_Tp>& vec )
     w(vec);
 }
 
-
 template<typename _Tp> static inline
 void write(FileStorage& fs, const String& name, const Point_<_Tp>& pt )
 {
@@ -1020,6 +1019,17 @@ void write( FileStorage& fs, const String& name, const std::vector<_Tp>& vec )
 {
     cv::internal::WriteStructContext ws(fs, name, FileNode::SEQ+(DataType<_Tp>::fmt != 0 ? FileNode::FLOW : 0));
     write(fs, vec);
+}
+
+template<typename _Tp> static inline
+void write( FileStorage& fs, const String& name, const std::vector< std::vector<_Tp> >& vec )
+{
+    cv::internal::WriteStructContext ws(fs, name, FileNode::SEQ);
+    for(size_t i = 0; i < vec.size(); i++)
+    {
+        cv::internal::WriteStructContext ws_(fs, name, FileNode::SEQ+(DataType<_Tp>::fmt != 0 ? FileNode::FLOW : 0));
+        write(fs, vec[i]);
+    }
 }
 
 //! @} FileStorage

--- a/modules/core/test/test_io.cpp
+++ b/modules/core/test/test_io.cpp
@@ -950,3 +950,49 @@ TEST(Core_InputOutput, filestorage_utf8_bom)
         fs.release();
     });
 }
+
+TEST(Core_InputOutput, filestorage_vec_vec_io)
+{
+    std::vector<std::vector<Mat> > outputMats(3);
+    for(size_t i = 0; i < outputMats.size(); i++)
+    {
+        outputMats[i].resize(i+1);
+        for(size_t j = 0; j < outputMats[i].size(); j++)
+        {
+            outputMats[i][j] = Mat::eye((int)i + 1, (int)i + 1, CV_8U);
+        }
+    }
+
+    String fileName = "vec_test.";
+
+    std::vector<String> formats;
+    formats.push_back("xml");
+    formats.push_back("yml");
+    formats.push_back("json");
+
+    for(size_t i = 0; i < formats.size(); i++)
+    {
+        FileStorage writer(fileName + formats[i], FileStorage::WRITE);
+        writer << "vecVecMat" << outputMats;
+        writer.release();
+
+        FileStorage reader(fileName + formats[i], FileStorage::READ);
+        std::vector<std::vector<Mat> > testMats;
+        reader["vecVecMat"] >> testMats;
+
+        ASSERT_EQ(testMats.size(), testMats.size());
+
+        for(size_t j = 0; j < testMats.size(); j++)
+        {
+            ASSERT_EQ(testMats[j].size(), outputMats[j].size());
+
+            for(size_t k = 0; k < testMats[j].size(); k++)
+            {
+                ASSERT_TRUE(norm(outputMats[j][k] - testMats[j][k], NORM_INF) == 0);
+            }
+        }
+
+        reader.release();
+        remove((fileName + formats[i]).c_str());
+    }
+}


### PR DESCRIPTION
Resolves #5013
Example of `vector<vector<Mat>>` serialization:
```
%YAML:1.0
---
vecVecMat:
   -
      - !!opencv-matrix
         rows: 1
         cols: 1
         dt: u
         data: [ 1 ]
   -
      - !!opencv-matrix
         rows: 2
         cols: 2
         dt: u
         data: [ 1, 0, 0, 1 ]
      - !!opencv-matrix
         rows: 2
         cols: 2
         dt: u
         data: [ 1, 0, 0, 1 ]
   -
      - !!opencv-matrix
         rows: 3
         cols: 3
         dt: u
         data: [ 1, 0, 0, 0, 1, 0, 0, 0, 1 ]
      - !!opencv-matrix
         rows: 3
         cols: 3
         dt: u
         data: [ 1, 0, 0, 0, 1, 0, 0, 0, 1 ]
      - !!opencv-matrix
         rows: 3
         cols: 3
         dt: u
         data: [ 1, 0, 0, 0, 1, 0, 0, 0, 1 ]

```