### PR TITLE
viz: free new[] allocated arrays using delete[] instead of free

### DIFF
--- a/modules/viz/src/precomp.hpp
+++ b/modules/viz/src/precomp.hpp
@@ -282,7 +282,7 @@ namespace cv
                 scalars->SetName("Colors");
                 scalars->SetNumberOfComponents(3);
                 scalars->SetNumberOfTuples((vtkIdType)size);
-                scalars->SetArray(color_data->val, (vtkIdType)(size * 3), 0);
+                scalars->SetArray(color_data->val, (vtkIdType)(size * 3), 0, vtkUnsignedCharArray::VTK_DATA_ARRAY_DELETE);
                 return scalars;
             }
 

--- a/modules/viz/src/vtk/vtkCloudMatSource.cpp
+++ b/modules/viz/src/vtk/vtkCloudMatSource.cpp
@@ -235,7 +235,7 @@ void cv::viz::vtkCloudMatSource::filterNanColorsCopy(const Mat& cloud_colors, co
     scalars->SetName("Colors");
     scalars->SetNumberOfComponents(3);
     scalars->SetNumberOfTuples(total);
-    scalars->SetArray(array->val, total * 3, 0);
+    scalars->SetArray(array->val, total * 3, 0, vtkUnsignedCharArray::VTK_DATA_ARRAY_DELETE);
 }
 
 template<typename _Tn, typename _Msk>


### PR DESCRIPTION
<!-- Please use this line to close one or multiple issues when this pullrequest gets merged
You can add another line right under the first one:
resolves #1234
resolves #1235
-->

### This pullrequest changes

<!-- Please describe what your pullrequest is changing -->

Data allocated using `new[]` is freed using `free` which is incorrect. This was caught using Clang's AddressSanitizer which throws an alloc-dealloc-mismatch (operator new[] vs free) error here.