### PR TITLE
2.4

### DIFF
--- a/modules/ts/src/ts_perf.cpp
+++ b/modules/ts/src/ts_perf.cpp
@@ -41,6 +41,7 @@ static bool         log_power_checkpoints;
 
 #include <sys/syscall.h>
 #include <pthread.h>
+#include <cerrno>
 static void setCurrentThreadAffinityMask(int mask)
 {
     pid_t pid=gettid();


### PR DESCRIPTION

resolves #7670

### This pullrequest changes

adds a cmake parameter for configuring a build for android so that it uses Android ndk platform 9 (as opposed to the default 8 which is no longer available)

adds an #include to modules/ts/src/ts_perf.cpp so that the build no longer fails with gnu-5 toolchain
