### PR TITLE
calib3d: fix missing cv::redirectError symbol error

### DIFF
--- a/modules/core/src/system.cpp
+++ b/modules/core/src/system.cpp
@@ -621,7 +621,7 @@ String tempfile( const char* suffix )
     return fname;
 }
 
-static CvErrorCallback customErrorCallback = 0;
+static ErrorCallback customErrorCallback = 0;
 static void* customErrorCallbackData = 0;
 static bool breakOnError = false;
 
@@ -666,13 +666,13 @@ void error(int _code, const String& _err, const char* _func, const char* _file, 
     error(cv::Exception(_code, _err, _func, _file, _line));
 }
 
-CvErrorCallback
-redirectError( CvErrorCallback errCallback, void* userdata, void** prevUserdata)
+ErrorCallback
+redirectError( ErrorCallback errCallback, void* userdata, void** prevUserdata)
 {
     if( prevUserdata )
         *prevUserdata = customErrorCallbackData;
 
-    CvErrorCallback prevCallback = customErrorCallback;
+    ErrorCallback prevCallback = customErrorCallback;
 
     customErrorCallback     = errCallback;
     customErrorCallbackData = userdata;


### PR DESCRIPTION
resolves #7014

### This pullrequest changes

This PR fixes a linking error :

> [ 95%] Linking CXX shared library ..\..\bin\libopencv_calib3d310.dll
CMakeFiles\opencv_calib3d.dir/objects.a(calibinit.cpp.obj):calibinit.cpp:(.text$_ZN2cv15findCirclesGridERKNS_11_InputArrayENS_5Size_IiEERKNS_12_OutputArrayEiRKNS_3PtrINS_9Feature2DEEE+0x426): undefined reference to `cv::redirectError(int (*)(int, char const*, char const*, char const*, int, void*), void*, void**)'

Happens on msys2 with gcc 6.2.0

See also http://stackoverflow.com/questions/38552221/undefined-reference-to-cvredirecterror-while-creating-shared-build-of-opencv-3