### PR TITLE
Aravis: fixing releasing object when no communication with camera is possible

### DIFF
--- a/modules/videoio/src/cap_aravis.cpp
+++ b/modules/videoio/src/cap_aravis.cpp
@@ -208,7 +208,6 @@ bool CvCaptureCAM_Aravis::getDeviceNameById(int id, std::string &device)
     return false;
 }
 
-#include <iostream>
 bool CvCaptureCAM_Aravis::create( int index )
 {
     std::string deviceName;

--- a/modules/videoio/src/cap_aravis.cpp
+++ b/modules/videoio/src/cap_aravis.cpp
@@ -188,11 +188,12 @@ CvCaptureCAM_Aravis::CvCaptureCAM_Aravis()
 
 void CvCaptureCAM_Aravis::close()
 {
-    if(camera)
+    if(camera) {
         stopCapture();
 
-    g_object_unref(camera);
-    camera = NULL;
+        g_object_unref(camera);
+        camera = NULL;
+    }
 }
 
 bool CvCaptureCAM_Aravis::getDeviceNameById(int id, std::string &device)
@@ -207,6 +208,7 @@ bool CvCaptureCAM_Aravis::getDeviceNameById(int id, std::string &device)
     return false;
 }
 
+#include <iostream>
 bool CvCaptureCAM_Aravis::create( int index )
 {
     std::string deviceName;
@@ -559,8 +561,10 @@ void CvCaptureCAM_Aravis::stopCapture()
 {
     arv_camera_stop_acquisition(camera);
 
-    g_object_unref(stream);
-    stream = NULL;
+    if(stream) {
+        g_object_unref(stream);
+        stream = NULL;
+    }
 }
 
 bool CvCaptureCAM_Aravis::startCapture()


### PR DESCRIPTION
Small fix for bug -  while releasing VideoCapture/Aravis object  when no communication is established (i.e. other process already is  using camera)  an error on console is printed:
```
(process:32685): GLib-GObject-CRITICAL **: g_object_unref: assertion 'G_IS_OBJECT (object)' failed
```
### This pullrequest changes

Simply prevent call g_object_unref()  for uninitialized objects.