### PR TITLE
Update exif.cpp

### DIFF
--- a/modules/imgcodecs/src/exif.cpp
+++ b/modules/imgcodecs/src/exif.cpp
@@ -160,6 +160,10 @@ std::map<int, ExifEntry_t > ExifReader::getExif()
             case APP9: case APP10: case APP11: case APP12: case APP13: case APP14: case APP15:
             case COM:
                 bytesToSkip = getFieldSize( f );
+                if (bytesToSkip < markerSize) {
+                    fclose(f);
+                    throw ExifParsingError();
+                }
                 fseek( f, static_cast<long>( bytesToSkip - markerSize ), SEEK_CUR );
                 break;
 


### PR DESCRIPTION
<!-- Please use this line to close one or multiple issues when this pullrequest gets merged
You can add another line right under the first one:
resolves #1234
resolves #1235
-->

### This pullrequest changes
ExifReader::getExif may enter infinite loop with jpeg image which have no EOI.

For example, bytesToSkip may be set to 0 and fseek seems like fseek(f, -2 , SEEK_CUR) for image that end with RST7(FF D7) instead of EOI.