### PR TITLE
Solve exception for 3D Mat

### DIFF
--- a/modules/core/src/convert.cpp
+++ b/modules/core/src/convert.cpp
@@ -5692,7 +5692,7 @@ void cv::normalize( InputArray _src, InputOutputArray _dst, double a, double b,
     {
         double smin = 0, smax = 0;
         double dmin = MIN( a, b ), dmax = MAX( a, b );
-        minMaxLoc( _src, &smin, &smax, 0, 0, _mask );
+        minMaxIdx( _src, &smin, &smax, 0, 0, _mask );
         scale = (dmax - dmin)*(smax - smin > DBL_EPSILON ? 1./(smax - smin) : 0);
         shift = dmin - smin*scale;
     }


### PR DESCRIPTION
Hi,

When I call normalize with a 3D Mat there is an exception in minMaxLoc (see http://answers.opencv.org/question/115042/exception-for-normalize-3d-histogram-minmaxloc/). To solve this I have just replace minMaxLoc with minMaxIdx in normalize

opencv 3.1.0-dev Visual Studio 2015 Windows 10