### PR TITLE
Allow V4L, V4L2 to be used as preferred capture API

### DIFF
--- a/modules/videoio/src/cap.cpp
+++ b/modules/videoio/src/cap.cpp
@@ -186,11 +186,11 @@ CV_IMPL CvCapture * cvCreateCameraCapture (int index)
 #ifdef HAVE_VFW
         TRY_OPEN(capture, cvCreateCameraCapture_VFW(index))
 #endif
-        if (pref) break; // CV_CAP_VFW
 
 #if defined HAVE_LIBV4L || defined HAVE_CAMV4L || defined HAVE_CAMV4L2 || defined HAVE_VIDEOIO
         TRY_OPEN(capture, cvCreateCameraCapture_V4L(index))
 #endif
+        if (pref) break; // CV_CAP_VFW
 
 #ifdef HAVE_GSTREAMER
         TRY_OPEN(capture, cvCreateCapture_GStreamer(CV_CAP_GSTREAMER_V4L2, reinterpret_cast<char *>(index)))
@@ -302,15 +302,15 @@ CV_IMPL CvCapture * cvCreateFileCaptureWithPreference (const char * filename, in
         if (apiPreference) break;
 #endif
 
-#ifdef HAVE_VFW
     case CV_CAP_VFW:
+#ifdef HAVE_VFW
         TRY_OPEN(result, cvCreateFileCapture_VFW (filename))
-        if (apiPreference) break;
 #endif
+
 #if defined HAVE_LIBV4L || defined HAVE_CAMV4L || defined HAVE_CAMV4L2 || defined HAVE_VIDEOIO
         TRY_OPEN(result, cvCreateCameraCapture_V4L(filename))
-        if (apiPreference) break;
 #endif
+        if (apiPreference) break;
 
     case CV_CAP_MSMF:
 #ifdef HAVE_MSMF


### PR DESCRIPTION


### This pullrequest changes

Allow V4L, V4L2 to be used as preferred capture API as it shares the enum value with VFW but only the latter had a corresponding case in the switch. This caused all V4L and V4L2 API preference arguments to automatically fail even when they should not have.

