### PR TITLE
Introducing boundingRect2f to return exact bounding float rectangle f…

### DIFF
--- a/modules/core/include/opencv2/core/core.hpp
+++ b/modules/core/include/opencv2/core/core.hpp
@@ -912,6 +912,8 @@ public:
     void points(Point2f pts[]) const;
     //! returns the minimal up-right rectangle containing the rotated rectangle
     Rect boundingRect() const;
+    //! returns the minimal (exact) rectangle containg the rotated floating point rectangle, not intended for use with images
+    Rect_<float> boundingRect2f() const;
     //! conversion to the old-style CvBox2D structure
     operator CvBox2D() const;
 

--- a/modules/core/src/matrix.cpp
+++ b/modules/core/src/matrix.cpp
@@ -4277,6 +4277,15 @@ Rect RotatedRect::boundingRect() const
     return r;
 }
 
+Rect_<float> RotatedRect::boundingRect() const
+{
+    Point2f pt[4];
+    points(pt);
+    Rect_<float> r(min({pt[0].x, pt[1].x, pt[2].x, pt[3].x}),
+                   min({pt[0].y, pt[1].y, pt[2].y, pt[3].y}),
+                   max({pt[0].x, pt[1].x, pt[2].x, pt[3].x}),
+                   max({pt[0].y, pt[1].y, pt[2].y, pt[3].y}));
+    return r;
 }
 
 /* End of file. */


### PR DESCRIPTION
resolves #6219 

Just introducing the exact floating bounding rectangle for RotatedRect.
Also more specifics in comments. 
Uses min{} pattern instead if multiple min(min(min())) which is more efficient. May be fix it in other places in the next PR.