### PR TITLE
Introducing boundingRect2f to return exact bounding float rectangle f…

### DIFF
--- a/modules/core/include/opencv2/core/core.hpp
+++ b/modules/core/include/opencv2/core/core.hpp
@@ -910,8 +910,10 @@ public:
 
     //! returns 4 vertices of the rectangle
     void points(Point2f pts[]) const;
-    //! returns the minimal up-right rectangle containing the rotated rectangle
+    //! returns the minimal up-right integer rectangle containing the rotated rectangle
     Rect boundingRect() const;
+    //! returns the minimal (exact) floating point rectangle containing the rotated rectangle, not intended for use with images
+    Rect_<float> boundingRect2f() const;
     //! conversion to the old-style CvBox2D structure
     operator CvBox2D() const;
 

--- a/modules/core/src/matrix.cpp
+++ b/modules/core/src/matrix.cpp
@@ -4277,6 +4277,17 @@ Rect RotatedRect::boundingRect() const
     return r;
 }
 
+Rect_<float> RotatedRect::boundingRect2f() const
+{
+    Point2f pt[4];
+    points(pt);
+    Rect_<float> r(min({pt[0].x, pt[1].x, pt[2].x, pt[3].x}),
+           min({pt[0].y, pt[1].y, pt[2].y, pt[3].y}),
+           max({pt[0].x, pt[1].x, pt[2].x, pt[3].x}),
+           max({pt[0].y, pt[1].y, pt[2].y, pt[3].y}));
+    return r;
+}
+
 }
 
 /* End of file. */


### PR DESCRIPTION
resolves #6219

Just introducing boundingRect2f()
the exact floating bounding rectangle for RotatedRect.
+ more specifics in comments for bounding methods.
+ min{} pattern instead of multiple min(min(min())) 's more efficient. however it is supported since std-c++11 
