### PR TITLE
Add support image save parameters in VideoWriter

### DIFF
--- a/modules/videoio/include/opencv2/videoio.hpp
+++ b/modules/videoio/include/opencv2/videoio.hpp
@@ -556,6 +556,20 @@ enum { CAP_PROP_GPHOTO2_PREVIEW           = 17001, //!< Capture only preview fro
 
 //! @} gPhoto2
 
+
+/** @name Images backend
+    @{
+*/
+
+/** @brief Images backend properties
+
+*/
+enum { CAP_PROP_IMAGES_BASE = 18000,
+       CAP_PROP_IMAGES_LAST = 19000 // excluding
+     };
+
+//! @} Images
+
 //! @} videoio_flags_others
 
 

--- a/modules/videoio/src/cap_images.cpp
+++ b/modules/videoio/src/cap_images.cpp
@@ -345,7 +345,10 @@ bool CvVideoWriter_Images::writeFrame( const IplImage* image )
 {
     char str[_MAX_PATH];
     sprintf(str, filename, currentframe);
-    int ret = cvSaveImage(str, image, &params[0]);
+    std::vector<int> image_params = params;
+    image_params.push_back(0); // append parameters 'stop' mark
+    image_params.push_back(0);
+    int ret = cvSaveImage(str, image, &image_params[0]);
 
     currentframe++;
 

--- a/modules/videoio/src/cap_images.cpp
+++ b/modules/videoio/src/cap_images.cpp
@@ -332,18 +332,20 @@ public:
 
     virtual bool open( const char* _filename );
     virtual void close();
+    virtual bool setProperty( int, double );
     virtual bool writeFrame( const IplImage* );
 
 protected:
     char* filename;
     unsigned currentframe;
+    std::vector<int> params;
 };
 
 bool CvVideoWriter_Images::writeFrame( const IplImage* image )
 {
     char str[_MAX_PATH];
     sprintf(str, filename, currentframe);
-    int ret = cvSaveImage(str, image);
+    int ret = cvSaveImage(str, image, &params[0]);
 
     currentframe++;
 
@@ -358,6 +360,7 @@ void CvVideoWriter_Images::close()
         filename = 0;
     }
     currentframe = 0;
+    params.clear();
 }
 
 
@@ -380,6 +383,15 @@ bool CvVideoWriter_Images::open( const char* _filename )
     }
 
     currentframe = offset;
+    params.clear();
+    return true;
+}
+
+
+bool CvVideoWriter_Images::setProperty( int id, double value )
+{
+    params.push_back( id );
+    params.push_back( static_cast<int>( value ) );
     return true;
 }
 

--- a/modules/videoio/src/cap_images.cpp
+++ b/modules/videoio/src/cap_images.cpp
@@ -393,9 +393,13 @@ bool CvVideoWriter_Images::open( const char* _filename )
 
 bool CvVideoWriter_Images::setProperty( int id, double value )
 {
-    params.push_back( id );
-    params.push_back( static_cast<int>( value ) );
-    return true;
+    if (id >= cv::CAP_PROP_IMAGES_BASE && id < cv::CAP_PROP_IMAGES_LAST)
+    {
+        params.push_back( id - cv::CAP_PROP_IMAGES_BASE );
+        params.push_back( static_cast<int>( value ) );
+        return true;
+    }
+    return false; // not supported
 }
 
 


### PR DESCRIPTION
<!-- Please use this line to close one or multiple issues when this pullrequest gets merged
You can add another line right under the first one:
resolves #1234
resolves #1235
-->

### This pullrequest changes

<!-- Please describe what your pullrequest is changing -->

Add support image save parameters in <code>cv::VideoWriter</code>.
This change will become available setting same parameters as <code>cv::imwrite()</code> to <code>cv::VideoWriter::set( cv::IMWRITE_*, value )</code>.

e.g.
```cpp
cv::VideoWriter writer( "img_%02d.jpg", 0, 0.0, cv::Size( 640, 480 ) );
if( !writer.isOpened() ){
    return -1;
}

writer.set( cv::IMWRITE_JPEG_QUALITY, 80 );
```