### PR TITLE
videoio: add support for API backend-based property indexes (proposal)

### DIFF
--- a/modules/videoio/include/opencv2/videoio.hpp
+++ b/modules/videoio/include/opencv2/videoio.hpp
@@ -914,6 +914,46 @@ protected:
 template<> CV_EXPORTS void DefaultDeleter<CvCapture>::operator ()(CvCapture* obj) const;
 template<> CV_EXPORTS void DefaultDeleter<CvVideoWriter>::operator ()(CvVideoWriter* obj) const;
 
+namespace videoio {
+
+/** @brief Constructs property index for custom backend API for cv::VideoReader and cv::VideoWriter
+
+Support of these properties are optional and depends on backend
+
+Sample usage:
+@code
+    cv::VideoWriter writer("img_%05d.jpg", 0, 0.0, cv::Size(640, 480));
+    if (!writer.isOpened()) {
+        return -1;
+    }
+
+    // Set property specific to Image backend
+    bool result = writer.set(cv::videoio::apiProp(cv::CAP_IMAGES, cv::IMWRITE_JPEG_QUALITY), 80);
+    if (!result) {
+       // something is wrong
+    }
+@endcode
+
+@param api API backend to use (see cv::VideoCaptureAPIs)
+@param prop Backend specific property value
+
+@return Property index for get/set methods of VideoWriter / VideoReader
+*/
+CV_EXPORTS_W int apiProp(int api, int prop);
+
+/** @brief Extracts information from backend-related property index
+
+@param apiProp Property index (see cv::VideoWriter::apiProp() call)
+@param prop Backend-specific property index
+
+@return API backend index (returns 0 for common properties)
+
+@see apiProp
+*/
+CV_EXPORTS_W int apiPropInfo(int apiProp, CV_OUT int& prop);
+
+} // namespace
+
 //! @} videoio
 
 } // cv

--- a/modules/videoio/src/cap_images.cpp
+++ b/modules/videoio/src/cap_images.cpp
@@ -345,7 +345,10 @@ bool CvVideoWriter_Images::writeFrame( const IplImage* image )
 {
     char str[_MAX_PATH];
     sprintf(str, filename, currentframe);
-    int ret = cvSaveImage(str, image, &params[0]);
+    std::vector<int> image_params = params;
+    image_params.push_back(0); // append parameters 'stop' mark
+    image_params.push_back(0);
+    int ret = cvSaveImage(str, image, &image_params[0]);
 
     currentframe++;
 

--- a/modules/videoio/src/cap_images.cpp
+++ b/modules/videoio/src/cap_images.cpp
@@ -332,18 +332,20 @@ public:
 
     virtual bool open( const char* _filename );
     virtual void close();
+    virtual bool setProperty( int, double );
     virtual bool writeFrame( const IplImage* );
 
 protected:
     char* filename;
     unsigned currentframe;
+    std::vector<int> params;
 };
 
 bool CvVideoWriter_Images::writeFrame( const IplImage* image )
 {
     char str[_MAX_PATH];
     sprintf(str, filename, currentframe);
-    int ret = cvSaveImage(str, image);
+    int ret = cvSaveImage(str, image, &params[0]);
 
     currentframe++;
 
@@ -358,6 +360,7 @@ void CvVideoWriter_Images::close()
         filename = 0;
     }
     currentframe = 0;
+    params.clear();
 }
 
 
@@ -380,6 +383,15 @@ bool CvVideoWriter_Images::open( const char* _filename )
     }
 
     currentframe = offset;
+    params.clear();
+    return true;
+}
+
+
+bool CvVideoWriter_Images::setProperty( int id, double value )
+{
+    params.push_back( id );
+    params.push_back( static_cast<int>( value ) );
     return true;
 }
 

--- a/modules/videoio/src/cap_images.cpp
+++ b/modules/videoio/src/cap_images.cpp
@@ -393,9 +393,14 @@ bool CvVideoWriter_Images::open( const char* _filename )
 
 bool CvVideoWriter_Images::setProperty( int id, double value )
 {
-    params.push_back( id );
-    params.push_back( static_cast<int>( value ) );
-    return true;
+    int prop = 0;
+    if (cv::videoio::apiPropInfo(id, prop) == cv::CAP_IMAGES)
+    {
+        params.push_back( prop );
+        params.push_back( static_cast<int>( value ) );
+        return true;
+    }
+    return false; // not supported
 }
 
 

--- a/modules/videoio/test/test_main.cpp
+++ b/modules/videoio/test/test_main.cpp
@@ -1,3 +1,16 @@
 #include "test_precomp.hpp"
 
 CV_TEST_MAIN("highgui")
+
+
+TEST(apiPropInfo, simple)
+{
+  int prop_id = 10; // some value, it doesn't used actually
+  int api = cv::CAP_IMAGES;
+  int id = cv::videoio::apiProp(api, prop_id);
+  int result_prop = -1;
+  int result_api = cv::videoio::apiPropInfo(id, result_prop);
+
+  EXPECT_EQ(prop_id, result_prop);
+  EXPECT_EQ(api, result_api);
+}


### PR DESCRIPTION
**WIP**
Related to #7761

Currently we just adding new enumeration groups with some 'base' (without any coherence with `CAP_` enums):
```
//! Properties of cameras available through OpenNI backend
enum { CAP_PROP_OPENNI_OUTPUT_MODE = 100,
    ...

//! PVAPI
enum { CAP_PROP_PVAPI_MULTICASTIP = 300,disable multicast.
    ...

//! Properties of cameras available through XIMEA SDK backend
enum { CAP_PROP_XI_DOWNSAMPLING = 400,
    ...

//! Properties of cameras available through AVFOUNDATION backend
enum { CAP_PROP_IOS_DEVICE_FOCUS = 9001,
    ...

enum { CAP_PROP_GIGA_FRAME_OFFSET_X = 10001,
    ...

enum { CAP_PROP_INTELPERC_PROFILE_COUNT = 11001,
    ...

enum { CAP_PROP_GPHOTO2_PREVIEW = 17001,
    ...
```

Another way is to implement new calls for API-related calls:
```
bool setAPI(int api, int propId, double value);
double getAPI(int api, int propId) const;
```