### PR TITLE
Fixed Intel C++ 17 build in VS2015

### DIFF
--- a/3rdparty/openexr/CMakeLists.txt
+++ b/3rdparty/openexr/CMakeLists.txt
@@ -52,6 +52,11 @@ if(UNIX AND (CMAKE_COMPILER_IS_GNUCXX OR CV_ICC))
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fPIC")
 endif()
 
+if(MSVC AND CV_ICC)
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /Qrestrict")
+  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} /Qrestrict")
+endif()
+
 add_library(IlmImf STATIC ${lib_hdrs} ${lib_srcs})
 target_link_libraries(IlmImf ${ZLIB_LIBRARIES})
 

--- a/cmake/OpenCVDetectCXXCompiler.cmake
+++ b/cmake/OpenCVDetectCXXCompiler.cmake
@@ -41,7 +41,7 @@ if(UNIX)
   endif()
 endif()
 
-if(MSVC AND CMAKE_C_COMPILER MATCHES "icc")
+if(MSVC AND CMAKE_C_COMPILER MATCHES "icc|icl")
   set(CV_ICC   __INTEL_COMPILER_FOR_WINDOWS)
 endif()
 


### PR DESCRIPTION
### This pullrequest changes

- the compiler has not been detected in cmake scripts, because executable name has changed(?)
- the compiler did not recognize `restrict` keyword in `openexr` code

<!--
docker_image-Linux x64=ubuntu-icc:16.04
-->