### PR TITLE
OpenVX optical flow PyrLK wrappers added

### DIFF
--- a/3rdparty/openvx/include/ivx.hpp
+++ b/3rdparty/openvx/include/ivx.hpp
@@ -343,6 +343,15 @@ template <> struct RefTypeTraits <vx_lut>
     static vx_status release(vxType& ref) { return vxReleaseLUT(&ref); }
 };
 
+class Pyramid;
+template <> struct RefTypeTraits <vx_pyramid>
+{
+    typedef vx_pyramid vxType;
+    typedef Pyramid wrapperType;
+    static const vx_enum vxTypeEnum = VX_TYPE_PYRAMID;
+    static vx_status release(vxType& ref) { return vxReleasePyramid(&ref); }
+};
+
 class Distribution;
 template <> struct RefTypeTraits <vx_distribution>
 {
@@ -2753,6 +2762,74 @@ public:
         copyFrom(m.isContinuous() ? m.ptr() : m.clone().ptr());
     }
 #endif //IVX_USE_OPENCV
+};
+
+/*
+ * Pyramid
+ */
+class Pyramid : public RefWrapper<vx_pyramid>
+{
+public:
+    IVX_REF_STD_CTORS_AND_ASSIGNMENT(Pyramid)
+
+    static Pyramid create(vx_context context, vx_size levels, vx_float32 scale,
+                          vx_uint32 width, vx_uint32 height, vx_df_image format)
+    {return Pyramid(vxCreatePyramid(context, levels, scale, width, height, format));}
+
+    static Pyramid createVirtual(vx_graph graph, vx_size levels, vx_float32 scale,
+                                 vx_uint32 width, vx_uint32 height, vx_df_image format)
+    {return Pyramid(vxCreateVirtualPyramid(graph, levels, scale, width, height, format));}
+
+#ifndef VX_VERSION_1_1
+    static const vx_enum
+        VX_PYRAMID_LEVELS = VX_PYRAMID_ATTRIBUTE_LEVELS,
+        VX_PYRAMID_SCALE  = VX_PYRAMID_ATTRIBUTE_SCALE,
+        VX_PYRAMID_WIDTH  = VX_PYRAMID_ATTRIBUTE_WIDTH,
+        VX_PYRAMID_HEIGHT = VX_PYRAMID_ATTRIBUTE_HEIGHT,
+        VX_PYRAMID_FORMAT = VX_PYRAMID_ATTRIBUTE_FORMAT;
+#endif
+
+    template<typename T>
+    void query(vx_enum att, T& value) const
+    { IVX_CHECK_STATUS( vxQueryPyramid(ref, att, &value, sizeof(value)) ); }
+
+    vx_size levels() const
+    {
+        vx_size l;
+        query(VX_PYRAMID_LEVELS, l);
+        return l;
+    }
+
+    vx_float32 scale() const
+    {
+        vx_float32 s;
+        query(VX_PYRAMID_SCALE, s);
+        return s;
+    }
+
+    vx_uint32 width() const
+    {
+        vx_uint32 v;
+        query(VX_PYRAMID_WIDTH, v);
+        return v;
+    }
+
+    vx_uint32 height() const
+    {
+        vx_uint32 v;
+        query(VX_PYRAMID_HEIGHT, v);
+        return v;
+    }
+
+    vx_df_image format() const
+    {
+        vx_df_image f;
+        query(VX_PYRAMID_FORMAT, f);
+        return f;
+    }
+
+    Image getLevel(vx_uint32 index)
+    { return Image(vxGetPyramidLevel(ref, index)); }
 };
 
 /*

--- a/modules/video/src/lkpyramid.cpp
+++ b/modules/video/src/lkpyramid.cpp
@@ -46,11 +46,7 @@
 #include "opencl_kernels_video.hpp"
 #include "opencv2/core/hal/intrin.hpp"
 
-#ifdef HAVE_OPENVX
-#define IVX_USE_OPENCV
-#define IVX_HIDE_INFO_WARNINGS
-#include "ivx.hpp"
-#endif
+#include "opencv2/core/openvx/ovx_defs.hpp"
 
 #define  CV_DESCALE(x,n)     (((x) + (1 << ((n)-1))) >> (n))
 
@@ -1200,11 +1196,11 @@ namespace
         }
         catch (RuntimeError & e)
         {
-            CV_Error(cv::Error::StsInternal, e.what());
+            VX_DbgThrow(e.what());
         }
         catch (WrapperError & e)
         {
-            CV_Error(cv::Error::StsInternal, e.what());
+            VX_DbgThrow(e.what());
         }
 
         return true;
@@ -1225,14 +1221,9 @@ void SparsePyrLKOpticalFlowImpl::calc( InputArray _prevImg, InputArray _nextImg,
                ocl::Image2D::isFormatSupported(CV_32F, 1, false),
                ocl_calcOpticalFlowPyrLK(_prevImg, _nextImg, _prevPts, _nextPts, _status, _err))
 
-#ifdef HAVE_OPENVX
     // Disabled due to bad accuracy
-    if(false &&
-       openvx_pyrlk(_prevImg, _nextImg, _prevPts, _nextPts, _status, _err))
-    {
-        return;
-    }
-#endif
+    CV_OVX_RUN(false,
+               openvx_pyrlk(_prevImg, _nextImg, _prevPts, _nextPts, _status, _err))
 
     Mat prevPtsMat = _prevPts.getMat();
     const int derivDepth = DataType<cv::detail::deriv_type>::depth;


### PR DESCRIPTION
### This pullrequest changes
* wrappers for PyrLK added
* `vx_pyramid` wrappers and some fixes for type conversion and array access added to `ivx.hpp`

**Disabled due to bad accuracy**

Issues:
* Pyramids as inputs are not acceptable because there's no (direct or simple) way to build `vx_pyramid` on user data
* In OpenVX 1.0.1 by Khronos PyrLK crashes because of incorrectly called vxCommitImagePatch()
* Different border mode (in OpenCV the mode is `BORDER_REPLICATE_101`) which is ignored by Khronos implementation anyway
* `minEigThreshold` is fixed to be 0.0001f
* `winSize` is assumed to be square
* OpenVX kernel doesn't return detection errors