### PR TITLE
Several fixes for OpenVX wrappers

### DIFF
--- a/3rdparty/openvx/include/ivx.hpp
+++ b/3rdparty/openvx/include/ivx.hpp
@@ -20,6 +20,7 @@ Details: TBD
 
 
 #include <VX/vx.h>
+#include <VX/vxu.h>
 
 #ifndef IVX_USE_CXX98
     // checking compiler
@@ -152,6 +153,7 @@ template<> struct EnumToType<VX_TYPE_ENUM>     { typedef vx_enum type;      stat
 template<> struct EnumToType<VX_TYPE_SIZE>     { typedef vx_size type;      static const vx_size bytes = sizeof(type); };
 template<> struct EnumToType<VX_TYPE_DF_IMAGE> { typedef vx_df_image type;  static const vx_size bytes = sizeof(type); };
 template<> struct EnumToType<VX_TYPE_BOOL>     { typedef vx_bool type;      static const vx_size bytes = sizeof(type); };
+template<> struct EnumToType<VX_TYPE_KEYPOINT> { typedef vx_keypoint_t type;static const vx_size bytes = sizeof(type); };
 #ifndef IVX_USE_CXX98
 template <vx_enum E> using EnumToType_t = typename EnumToType<E>::type;
 #endif
@@ -176,6 +178,7 @@ inline vx_size enumToTypeSize(vx_enum type)
     case VX_TYPE_SIZE:      return EnumToType<VX_TYPE_SIZE>::bytes;
     case VX_TYPE_DF_IMAGE:  return EnumToType<VX_TYPE_DF_IMAGE>::bytes;
     case VX_TYPE_BOOL:      return EnumToType<VX_TYPE_BOOL>::bytes;
+    case VX_TYPE_KEYPOINT:  return EnumToType<VX_TYPE_KEYPOINT>::bytes;
     default: throw WrapperError(std::string(__func__) + ": unsupported type enum");
     }
 }
@@ -194,10 +197,40 @@ template<> struct TypeToEnum<vx_uint64>   { static const vx_enum value = VX_TYPE
 template<> struct TypeToEnum<vx_float32>  { static const vx_enum value = VX_TYPE_FLOAT32; };
 template<> struct TypeToEnum<vx_float64>  { static const vx_enum value = VX_TYPE_FLOAT64; };
 template<> struct TypeToEnum<vx_bool>     { static const vx_enum value = VX_TYPE_BOOL; };
+template<> struct TypeToEnum<vx_keypoint_t> {static const vx_enum value = VX_TYPE_KEYPOINT; };
 // the commented types are aliases (of integral tyes) and have conflicts with the types above
 //template<> struct TypeToEnum<vx_enum>     { static const vx_enum val = VX_TYPE_ENUM; };
 //template<> struct TypeToEnum<vx_size>     { static const vx_enum val = VX_TYPE_SIZE; };
 //template<> struct TypeToEnum<vx_df_image> { static const vx_enum val = VX_TYPE_DF_IMAGE; };
+
+inline vx_enum fixEnum(const vx_enum a)
+{
+    switch (a)
+    {
+    case VX_TYPE_CHAR:      return TypeToEnum<EnumToType<VX_TYPE_CHAR>::type>::value;
+    case VX_TYPE_INT8:      return TypeToEnum<EnumToType<VX_TYPE_INT8>::type>::value;
+    case VX_TYPE_UINT8:     return TypeToEnum<EnumToType<VX_TYPE_UINT8>::type>::value;
+    case VX_TYPE_INT16:     return TypeToEnum<EnumToType<VX_TYPE_INT16>::type>::value;
+    case VX_TYPE_UINT16:    return TypeToEnum<EnumToType<VX_TYPE_UINT16>::type>::value;
+    case VX_TYPE_INT32:     return TypeToEnum<EnumToType<VX_TYPE_INT32>::type>::value;
+    case VX_TYPE_UINT32:    return TypeToEnum<EnumToType<VX_TYPE_UINT32>::type>::value;
+    case VX_TYPE_INT64:     return TypeToEnum<EnumToType<VX_TYPE_INT64>::type>::value;
+    case VX_TYPE_UINT64:    return TypeToEnum<EnumToType<VX_TYPE_UINT64>::type>::value;
+    case VX_TYPE_FLOAT32:   return TypeToEnum<EnumToType<VX_TYPE_FLOAT32>::type>::value;
+    case VX_TYPE_FLOAT64:   return TypeToEnum<EnumToType<VX_TYPE_FLOAT64>::type>::value;
+    case VX_TYPE_ENUM:      return TypeToEnum<EnumToType<VX_TYPE_ENUM>::type>::value;
+    case VX_TYPE_SIZE:      return TypeToEnum<EnumToType<VX_TYPE_SIZE>::type>::value;
+    case VX_TYPE_DF_IMAGE:  return TypeToEnum<EnumToType<VX_TYPE_DF_IMAGE>::type>::value;
+    case VX_TYPE_BOOL:      return TypeToEnum<EnumToType<VX_TYPE_BOOL>::type>::value;
+    case VX_TYPE_KEYPOINT:  return TypeToEnum<EnumToType<VX_TYPE_KEYPOINT>::type>::value;
+    default: throw WrapperError(std::string(__func__) + ": unsupported type enum");
+    }
+}
+
+inline bool areEqualTypes(const vx_enum a, const vx_enum b)
+{
+    return fixEnum(a) == fixEnum(b);
+}
 
 #ifdef IVX_USE_OPENCV
 inline int enumToCVType(vx_enum type)
@@ -1021,6 +1054,89 @@ public:
         return create(g, Kernel::getByEnum(Context::getFrom(g), kernelID), params);
     }
 
+    /// Create node for the kernel ID and set seven parameters
+    template<typename T0, typename T1, typename T2, typename T3, typename T4, typename T5,
+             typename T6>
+    static Node create(vx_graph g, vx_enum kernelID,
+                       const T0& arg0, const T1& arg1, const T2& arg2,
+                       const T3& arg3, const T4& arg4, const T5& arg5,
+                       const T6& arg6)
+    {
+        std::vector<vx_reference> params;
+        params.push_back(castToReference(arg0));
+        params.push_back(castToReference(arg1));
+        params.push_back(castToReference(arg2));
+        params.push_back(castToReference(arg3));
+        params.push_back(castToReference(arg4));
+        params.push_back(castToReference(arg5));
+        params.push_back(castToReference(arg6));
+        return create(g, Kernel::getByEnum(Context::getFrom(g), kernelID), params);
+    }
+
+    /// Create node for the kernel ID and set eight parameters
+    template<typename T0, typename T1, typename T2, typename T3, typename T4, typename T5,
+             typename T6, typename T7>
+    static Node create(vx_graph g, vx_enum kernelID,
+                       const T0& arg0, const T1& arg1, const T2& arg2,
+                       const T3& arg3, const T4& arg4, const T5& arg5,
+                       const T6& arg6, const T7& arg7)
+    {
+        std::vector<vx_reference> params;
+        params.push_back(castToReference(arg0));
+        params.push_back(castToReference(arg1));
+        params.push_back(castToReference(arg2));
+        params.push_back(castToReference(arg3));
+        params.push_back(castToReference(arg4));
+        params.push_back(castToReference(arg5));
+        params.push_back(castToReference(arg6));
+        params.push_back(castToReference(arg7));
+        return create(g, Kernel::getByEnum(Context::getFrom(g), kernelID), params);
+    }
+
+    /// Create node for the kernel ID and set nine parameters
+    template<typename T0, typename T1, typename T2, typename T3, typename T4, typename T5,
+             typename T6, typename T7, typename T8>
+    static Node create(vx_graph g, vx_enum kernelID,
+                       const T0& arg0, const T1& arg1, const T2& arg2,
+                       const T3& arg3, const T4& arg4, const T5& arg5,
+                       const T6& arg6, const T7& arg7, const T8& arg8)
+    {
+        std::vector<vx_reference> params;
+        params.push_back(castToReference(arg0));
+        params.push_back(castToReference(arg1));
+        params.push_back(castToReference(arg2));
+        params.push_back(castToReference(arg3));
+        params.push_back(castToReference(arg4));
+        params.push_back(castToReference(arg5));
+        params.push_back(castToReference(arg6));
+        params.push_back(castToReference(arg7));
+        params.push_back(castToReference(arg8));
+        return create(g, Kernel::getByEnum(Context::getFrom(g), kernelID), params);
+    }
+
+    /// Create node for the kernel ID and set ten parameters
+    template<typename T0, typename T1, typename T2, typename T3, typename T4, typename T5,
+             typename T6, typename T7, typename T8, typename T9>
+    static Node create(vx_graph g, vx_enum kernelID,
+                       const T0& arg0, const T1& arg1, const T2& arg2,
+                       const T3& arg3, const T4& arg4, const T5& arg5,
+                       const T6& arg6, const T7& arg7, const T8& arg8,
+                       const T9& arg9)
+    {
+        std::vector<vx_reference> params;
+        params.push_back(castToReference(arg0));
+        params.push_back(castToReference(arg1));
+        params.push_back(castToReference(arg2));
+        params.push_back(castToReference(arg3));
+        params.push_back(castToReference(arg4));
+        params.push_back(castToReference(arg5));
+        params.push_back(castToReference(arg6));
+        params.push_back(castToReference(arg7));
+        params.push_back(castToReference(arg8));
+        params.push_back(castToReference(arg9));
+        return create(g, Kernel::getByEnum(Context::getFrom(g), kernelID), params);
+    }
+
     /// vxSetParameterByIndex() wrapper
     void setParameterByIndex(vx_uint32 index, vx_reference value)
     { IVX_CHECK_STATUS(vxSetParameterByIndex(ref, index, value)); }
@@ -1702,7 +1818,7 @@ static const vx_enum VX_SCALAR_TYPE = VX_SCALAR_ATTRIBUTE_TYPE;
     template<typename T>
     void getValue(T& val)
     {
-        if(TypeToEnum<T>::value != type()) throw WrapperError(std::string(__func__)+"(): incompatible types");
+        if(!areEqualTypes(TypeToEnum<T>::value, type())) throw WrapperError(std::string(__func__)+"(): incompatible types");
 #ifdef VX_VERSION_1_1
         IVX_CHECK_STATUS( vxCopyScalar(ref, &val, VX_READ_ONLY, VX_MEMORY_TYPE_HOST) );
 #else
@@ -1724,7 +1840,7 @@ static const vx_enum VX_SCALAR_TYPE = VX_SCALAR_ATTRIBUTE_TYPE;
     template<typename T>
     void setValue(T val)
     {
-        if (TypeToEnum<T>::value != type()) throw WrapperError(std::string(__func__)+"(): incompatible types");
+        if (!areEqualTypes(TypeToEnum<T>::value, type())) throw WrapperError(std::string(__func__)+"(): incompatible types");
 #ifdef VX_VERSION_1_1
         IVX_CHECK_STATUS(vxCopyScalar(ref, &val, VX_WRITE_ONLY, VX_MEMORY_TYPE_HOST));
 #else
@@ -1909,6 +2025,11 @@ public:
         return v;
     }
 
+    void addItems(vx_size count, const void* ptr, vx_size stride)
+    {
+        IVX_CHECK_STATUS(vxAddArrayItems(ref, count, ptr, stride));
+    }
+
     void copyRangeTo(size_t start, size_t end, void* data)
     {
         if (!data) throw WrapperError(std::string(__func__) + "(): output pointer is 0");
@@ -1957,7 +2078,7 @@ public:
 
     template<typename T> void copyRangeTo(size_t start, size_t end, std::vector<T>& data)
     {
-        if (TypeToEnum<T>::value != itemType()) throw WrapperError(std::string(__func__) + "(): destination type is wrong");
+        if (!areEqualTypes(TypeToEnum<T>::value, itemType())) throw WrapperError(std::string(__func__) + "(): destination type is wrong");
         if (data.size() != (end - start))
         {
             if (data.size() == 0)
@@ -1973,13 +2094,18 @@ public:
 
     template<typename T> void copyRangeFrom(size_t start, size_t end, const std::vector<T>& data)
     {
-        if (TypeToEnum<T>::value != itemType()) throw WrapperError(std::string(__func__) + "(): source type is wrong");
+        if (!areEqualTypes(TypeToEnum<T>::value, itemType())) throw WrapperError(std::string(__func__) + "(): source type is wrong");
         if (data.size() != (end - start)) throw WrapperError(std::string(__func__) + "(): source size is wrong");
         copyRangeFrom(start, end, &data[0]);
     }
 
     template<typename T> void copyFrom(std::vector<T>& data)
-    { copyRangeFrom(0, itemCount(), data); }
+    {
+        if(itemCount() > 0)
+            copyRangeFrom(0, itemCount(), data);
+        else
+            addItems(data.size(), &data[0], itemSize());
+    }
 
 #ifdef IVX_USE_OPENCV
     void copyRangeTo(size_t start, size_t end, cv::Mat& m)
@@ -2019,7 +2145,13 @@ public:
     }
 
     void copyFrom(const cv::Mat& m)
-    { copyRangeFrom(0, itemCount(), m); }
+    {
+        if(itemCount() > 0)
+            copyRangeFrom(0, itemCount(), m);
+        else
+            addItems(m.total(), m.isContinuous() ? m.ptr() : m.clone().ptr(),
+                     (vx_size)(m.elemSize()));
+    }
 #endif //IVX_USE_OPENCV
 };
 
@@ -2121,7 +2253,7 @@ public:
 
     template<typename T> void copyTo(std::vector<T>& data)
     {
-        if (TypeToEnum<T>::value != dataType()) throw WrapperError(std::string(__func__) + "(): destination type is wrong");
+        if (!areEqualTypes(TypeToEnum<T>::value, dataType())) throw WrapperError(std::string(__func__) + "(): destination type is wrong");
         if (data.size() != size())
         {
             if (data.size() == 0)
@@ -2134,7 +2266,7 @@ public:
 
     template<typename T> void copyFrom(const std::vector<T>& data)
     {
-        if (TypeToEnum<T>::value != dataType()) throw WrapperError(std::string(__func__) + "(): source type is wrong");
+        if (!areEqualTypes(TypeToEnum<T>::value, dataType())) throw WrapperError(std::string(__func__) + "(): source type is wrong");
         if (data.size() != size()) throw WrapperError(std::string(__func__) + "(): source size is wrong");
         copyFrom(&data[0]);
     }
@@ -2281,7 +2413,7 @@ public:
 
     template<typename T> void copyTo(std::vector<T>& data)
     {
-        if (TypeToEnum<T>::value != dataType()) throw WrapperError(std::string(__func__) + "(): destination type is wrong");
+        if (!areEqualTypes(TypeToEnum<T>::value, dataType())) throw WrapperError(std::string(__func__) + "(): destination type is wrong");
         if (data.size() != size())
         {
             if (data.size() == 0)
@@ -2294,7 +2426,7 @@ public:
 
     template<typename T> void copyFrom(const std::vector<T>& data)
     {
-        if (TypeToEnum<T>::value != dataType()) throw WrapperError(std::string(__func__) + "(): source type is wrong");
+        if (!areEqualTypes(TypeToEnum<T>::value, dataType())) throw WrapperError(std::string(__func__) + "(): source type is wrong");
         if (data.size() != size()) throw WrapperError(std::string(__func__) + "(): source size is wrong");
         copyFrom(&data[0]);
     }
@@ -2432,7 +2564,7 @@ public:
 
     template<typename T> void copyTo(std::vector<T>& data)
     {
-        if (TypeToEnum<T>::value != dataType()) throw WrapperError(std::string(__func__) + "(): destination type is wrong");
+        if (!areEqualTypes(TypeToEnum<T>::value, dataType())) throw WrapperError(std::string(__func__) + "(): destination type is wrong");
         if (data.size() != count())
         {
             if (data.size() == 0)
@@ -2445,7 +2577,7 @@ public:
 
     template<typename T> void copyFrom(const std::vector<T>& data)
     {
-        if (TypeToEnum<T>::value != dataType()) throw WrapperError(std::string(__func__) + "(): source type is wrong");
+        if (!areEqualTypes(TypeToEnum<T>::value, dataType())) throw WrapperError(std::string(__func__) + "(): source type is wrong");
         if (data.size() != count()) throw WrapperError(std::string(__func__) + "(): source size is wrong");
         copyFrom(&data[0]);
     }


### PR DESCRIPTION
### This pullrequest fixes

* `#include <VX/vxu.h>`
* `vx_keypoint_t` support added
* type check fixed
* fixed `Node::create()` for >6 args in c++98
* fixed `Array::copyFrom(std::vector<T>)` if array is empty