### PR TITLE
OCL: stop using of OpenCL without explicit UMat arguments

### DIFF
--- a/modules/core/include/opencv2/core/ocl.hpp
+++ b/modules/core/include/opencv2/core/ocl.hpp
@@ -739,6 +739,9 @@ CV_EXPORTS MatAllocator* getOpenCLAllocator();
 #ifdef __OPENCV_BUILD
 namespace internal {
 
+CV_EXPORTS bool isOpenCLForced();
+#define OCL_FORCE_CHECK(condition) (cv::ocl::internal::isOpenCLForced() || (condition))
+
 CV_EXPORTS bool isPerformanceCheckBypassed();
 #define OCL_PERFORMANCE_CHECK(condition) (cv::ocl::internal::isPerformanceCheckBypassed() || (condition))
 

--- a/modules/core/src/ocl.cpp
+++ b/modules/core/src/ocl.cpp
@@ -6073,6 +6073,18 @@ void* Image2D::ptr() const
     return p ? p->handle : 0;
 }
 
+bool internal::isOpenCLForced()
+{
+    static bool initialized = false;
+    static bool value = false;
+    if (!initialized)
+    {
+        value = getBoolParameter("OPENCV_OPENCL_FORCE", false);
+        initialized = true;
+    }
+    return value;
+}
+
 bool internal::isPerformanceCheckBypassed()
 {
     static bool initialized = false;

--- a/modules/features2d/src/orb.cpp
+++ b/modules/features2d/src/orb.cpp
@@ -972,7 +972,7 @@ void ORB_Impl::detectAndCompute( InputArray _image, InputArray _mask,
     int halfPatchSize = patchSize / 2;
     int border = std::max(edgeThreshold, std::max(halfPatchSize, HARRIS_BLOCK_SIZE/2))+1;
 
-    bool useOCL = ocl::useOpenCL();
+    bool useOCL = ocl::useOpenCL() && OCL_FORCE_CHECK(_image.isUMat() || _descriptors.isUMat());
 
     Mat image = _image.getMat(), mask = _mask.getMat();
     if( image.type() != CV_8UC1 )

--- a/modules/objdetect/src/cascadedetect.cpp
+++ b/modules/objdetect/src/cascadedetect.cpp
@@ -1290,8 +1290,8 @@ void CascadeClassifierImpl::detectMultiScaleNoGrouping( InputArray _image, std::
 
 #ifdef HAVE_OPENCL
     bool use_ocl = tryOpenCL && ocl::useOpenCL() &&
+         OCL_FORCE_CHECK(_image.isUMat()) &&
          featureEvaluator->getLocalSize().area() > 0 &&
-         ocl::Device::getDefault().type() != ocl::Device::TYPE_CPU &&
          (data.minNodesPerTree == data.maxNodesPerTree) &&
          !isOldFormatCascade() &&
          maskGenerator.empty() &&
@@ -1316,7 +1316,8 @@ void CascadeClassifierImpl::detectMultiScaleNoGrouping( InputArray _image, std::
     // OpenCL code
     CV_OCL_RUN(use_ocl, ocl_detectMultiScaleNoGrouping( scales, candidates ))
 
-    tryOpenCL = false;
+    if (use_ocl)
+        tryOpenCL = false;
 #endif
 
     // CPU code


### PR DESCRIPTION
Resolves #6081
Resolves #6969
Resolves #4968
Resolves #4967
and many others...