### PR TITLE
Fixed OpenVX wrapper for Mat::convertTo()

### DIFF
--- a/modules/core/src/convert.cpp
+++ b/modules/core/src/convert.cpp
@@ -4643,24 +4643,35 @@ cvtScaleHalf_<short, float>( const short* src, size_t sstep, float* dst, size_t 
 #ifdef HAVE_OPENVX
 template<typename T, typename DT>
 static bool _openvx_cvt(const T* src, size_t sstep,
-                        DT* dst, size_t dstep, Size size)
+                        DT* dst, size_t dstep, Size continuousSize)
 {
     using namespace ivx;
 
-    if(!(size.width > 0 && size.height > 0))
+    if(!(continuousSize.width > 0 && continuousSize.height > 0 && sstep > 0 && dstep > 0))
     {
         return true;
+    }
+
+    //.height is for number of continuous pieces
+    //.width  is for length of one piece
+
+    Size imgSize = continuousSize;
+    if(continuousSize.height == 1)
+    {
+        //continuous case
+        imgSize.width  = sstep / sizeof(T);
+        imgSize.height = continuousSize.width / (sstep / sizeof(T));
     }
 
     try
     {
         Context context = Context::create();
         Image srcImage = Image::createFromHandle(context, Image::matTypeToFormat(DataType<T>::type),
-                                                 Image::createAddressing(size.width, size.height,
+                                                 Image::createAddressing(imgSize.width, imgSize.height,
                                                                          (vx_uint32)sizeof(T), (vx_uint32)sstep),
                                                  (void*)src);
         Image dstImage = Image::createFromHandle(context, Image::matTypeToFormat(DataType<DT>::type),
-                                                 Image::createAddressing(size.width, size.height,
+                                                 Image::createAddressing(imgSize.width, imgSize.height,
                                                                          (vx_uint32)sizeof(DT), (vx_uint32)dstep),
                                                  (void*)dst);
 
@@ -4674,13 +4685,11 @@ static bool _openvx_cvt(const T* src, size_t sstep,
     }
     catch (RuntimeError & e)
     {
-        CV_Error(CV_StsInternal, e.what());
-        return false;
+        CV_Error(cv::Error::StsInternal, e.what());
     }
     catch (WrapperError & e)
     {
-        CV_Error(CV_StsInternal, e.what());
-        return false;
+        CV_Error(cv::Error::StsInternal, e.what());
     }
 
     return true;

--- a/modules/core/src/convert.cpp
+++ b/modules/core/src/convert.cpp
@@ -4641,6 +4641,13 @@ cvtScaleHalf_<short, float>( const short* src, size_t sstep, float* dst, size_t 
 }
 
 #ifdef HAVE_OPENVX
+
+#ifdef _DEBUG
+#define VX_DbgThrow(s) CV_Error(cv::Error::StsInternal, (s))
+#else
+#define VX_DbgThrow(s) return false;
+#endif
+
 template<typename T, typename DT>
 static bool _openvx_cvt(const T* src, size_t sstep,
                         DT* dst, size_t dstep, Size continuousSize)
@@ -4652,9 +4659,10 @@ static bool _openvx_cvt(const T* src, size_t sstep,
         return true;
     }
 
+    CV_Assert(sstep / sizeof(T) == dstep / sizeof(DT));
+
     //.height is for number of continuous pieces
     //.width  is for length of one piece
-
     Size imgSize = continuousSize;
     if(continuousSize.height == 1)
     {
@@ -4685,11 +4693,11 @@ static bool _openvx_cvt(const T* src, size_t sstep,
     }
     catch (RuntimeError & e)
     {
-        CV_Error(cv::Error::StsInternal, e.what());
+        VX_DbgThrow(e.what());
     }
     catch (WrapperError & e)
     {
-        CV_Error(cv::Error::StsInternal, e.what());
+        VX_DbgThrow(e.what());
     }
 
     return true;


### PR DESCRIPTION
Fixed case of unrolled continuous Mat's
