### PR TITLE
fisheye::undistortPoints: sanitize theta values

### DIFF
--- a/modules/calib3d/src/fisheye.cpp
+++ b/modules/calib3d/src/fisheye.cpp
@@ -377,6 +377,12 @@ void cv::fisheye::undistortPoints( InputArray distorted, OutputArray undistorted
         double scale = 1.0;
 
         double theta_d = sqrt(pw[0]*pw[0] + pw[1]*pw[1]);
+
+        // the current camera model is only valid up to 180° FOV
+        // for larger FOV the loop below does not converge
+        // clip values so we still get plausible results for super fisheye images > 180°
+        theta_d = min(max(-CV_PI/2., theta_d), CV_PI/2.);
+
         if (theta_d > 1e-8)
         {
             // compensate distortion iteratively


### PR DESCRIPTION
the current camera model is only valid up to 180° FOV for larger FOV the undistort loop does not converge.
Clip values so we still get plausible results for super fisheye images > 180°.

related: #6801