### PR TITLE
java: fix PATH environment variable

### DIFF
--- a/modules/java/pure_test/build.xml
+++ b/modules/java/pure_test/build.xml
@@ -1,4 +1,5 @@
 <project>
+  <property environment="env"/>
   <property file="ant-${opencv.build.type}.properties"/>
   <property name="test.dir" value="testResults"/>
   <property name="build.dir" value="build"/>
@@ -39,7 +40,7 @@
     <mkdir dir="${test.dir}"/>
     <junit printsummary="true" haltonfailure="false" haltonerror="false" showoutput="true" logfailedtests="true" maxmemory="256m">
       <sysproperty key="java.library.path" path="${opencv.lib.path}"/>
-      <env key="PATH" path="${opencv.lib.path}"/>
+      <env key="PATH" path="${opencv.lib.path}:${env.PATH}:${env.Path}"/>
       <classpath refid="master-classpath"/>
       <classpath>
         <pathelement location="build/classes"/>


### PR DESCRIPTION
Variable name is case sensitive:
- `PATH` - Unix based systems
- `Path` - Windows