### PR TITLE
test: fix Core_ArithmMask.uninitialized test

### DIFF
--- a/modules/core/test/test_arithm.cpp
+++ b/modules/core/test/test_arithm.cpp
@@ -1496,7 +1496,7 @@ TEST(Core_ArithmMask, uninitialized)
                 int depth = rng.uniform(CV_8U, CV_64F+1);
                 int cn = rng.uniform(1, 6);
                 int type = CV_MAKETYPE(depth, cn);
-                int op = rng.uniform(0, 5);
+                int op = rng.uniform(0, depth < CV_32F ? 5 : 2); // don't run binary operations between floating-point values
                 int depth1 = op <= 1 ? CV_64F : depth;
                 for (int k = 0; k < MAX_DIM; k++)
                 {


### PR DESCRIPTION
Don't run binary operations for floating-point numbers.
norm() will fail with NAN result.

> C:\builds\precommit_windows_ten\opencv\modules\core\test\test_arithm.cpp(1556): error: Expected: (cvtest::norm(c, d1, 1)) <= (2.2204460492503131e-016), actual: nan vs 2.22045e-16
Google Test trace:
C:\builds\precommit_windows_ten\opencv\modules\core\test\test_arithm.cpp(1506): iter=23 dims=2 depth=6 cn=5 type=38 op=3 depth1=6 dims=[29; 1; 0]

http://pullrequest.opencv.org/buildbot/builders/precommit_windows_ten/builds/3727