### PR TITLE
test: fix test random generator

### DIFF
--- a/modules/calib3d/test/test_chessboardgenerator.cpp
+++ b/modules/calib3d/test/test_chessboardgenerator.cpp
@@ -51,7 +51,7 @@ using namespace cv;
 using namespace std;
 
 ChessBoardGenerator::ChessBoardGenerator(const Size& _patternSize) : sensorWidth(32), sensorHeight(24),
-    squareEdgePointsNum(200), min_cos(std::sqrt(2.f)*0.5f), cov(0.5),
+    squareEdgePointsNum(200), min_cos(std::sqrt(3.f)*0.5f), cov(0.5),
     patternSize(_patternSize), rendererResolutionMultiplier(4), tvec(Mat::zeros(1, 3, CV_32F))
 {
     Rodrigues(Mat::eye(3, 3, CV_32F), rvec);
@@ -85,8 +85,10 @@ void cv::ChessBoardGenerator::generateBasis(Point3f& pb1, Point3f& pb2) const
     {
         n[0] = rng.uniform(-1.f, 1.f);
         n[1] = rng.uniform(-1.f, 1.f);
-        n[2] = rng.uniform(-1.f, 1.f);
+        n[2] = rng.uniform(0.0f, 1.f);
         float len = (float)norm(n);
+        if (len < 1e-3)
+            continue;
         n[0]/=len;
         n[1]/=len;
         n[2]/=len;

--- a/modules/ts/include/opencv2/ts.hpp
+++ b/modules/ts/include/opencv2/ts.hpp
@@ -539,11 +539,13 @@ protected:
     }
 };
 
+extern uint64 param_seed;
+
 struct CV_EXPORTS DefaultRngAuto
 {
     const uint64 old_state;
 
-    DefaultRngAuto() : old_state(cv::theRNG().state) { cv::theRNG().state = (uint64)-1; }
+    DefaultRngAuto() : old_state(cv::theRNG().state) { cv::theRNG().state = cvtest::param_seed; }
     ~DefaultRngAuto() { cv::theRNG().state = old_state; }
 
     DefaultRngAuto& operator=(const DefaultRngAuto&);

--- a/modules/ts/include/opencv2/ts/ts_ext.hpp
+++ b/modules/ts/include/opencv2/ts/ts_ext.hpp
@@ -12,7 +12,9 @@ namespace cvtest {
 void checkIppStatus();
 }
 
-#define CV_TEST_INIT cv::ipp::setIppStatus(0);
+#define CV_TEST_INIT \
+    cv::ipp::setIppStatus(0); \
+    cv::theRNG().state = cvtest::param_seed;
 #define CV_TEST_CLEANUP ::cvtest::checkIppStatus();
 #define CV_TEST_BODY_IMPL \
     { \

--- a/modules/ts/src/ts.cpp
+++ b/modules/ts/src/ts.cpp
@@ -80,6 +80,8 @@
 namespace cvtest
 {
 
+uint64 param_seed = 0x12345678; // real value is passed via parseCustomOptions function
+
 static std::string path_join(const std::string& prefix, const std::string& subpath)
 {
     CV_Assert(subpath.empty() || subpath[0] != '/');
@@ -695,6 +697,7 @@ void parseCustomOptions(int argc, char **argv)
 {
     const char * const command_line_keys =
         "{ ipp test_ipp_check |false    |check whether IPP works without failures }"
+        "{ test_seed          |809564   |seed for random numbers generator }"
         "{ h   help           |false    |print help info                          }";
 
     cv::CommandLineParser parser(argc, argv, command_line_keys);
@@ -711,6 +714,8 @@ void parseCustomOptions(int argc, char **argv)
 #else
         test_ipp_check = false;
 #endif
+
+    param_seed = parser.get<unsigned int>("test_seed");
 }
 
 

--- a/modules/ts/src/ts_perf.cpp
+++ b/modules/ts/src/ts_perf.cpp
@@ -38,7 +38,6 @@ static double       param_max_outliers;
 static double       param_max_deviation;
 static unsigned int param_min_samples;
 static unsigned int param_force_samples;
-static uint64       param_seed;
 static double       param_time_limit;
 static int          param_threads;
 static bool         param_write_sanity;


### PR DESCRIPTION
It must produce the same values independent on other test runs.

Failure sample:
http://pullrequest.opencv.org/buildbot/builders/precommit_windows_ten/builds/3750
http://pullrequest.opencv.org/buildbot/builders/precommit_windows64/builds/8118