### PR TITLE
Fixed segfault at ORB::compute() near image's border

### DIFF
--- a/modules/features2d/src/orb.cpp
+++ b/modules/features2d/src/orb.cpp
@@ -970,7 +970,9 @@ void ORB_Impl::detectAndCompute( InputArray _image, InputArray _mask,
     //ROI handling
     const int HARRIS_BLOCK_SIZE = 9;
     int halfPatchSize = patchSize / 2;
-    int border = std::max(edgeThreshold, std::max(halfPatchSize, HARRIS_BLOCK_SIZE/2))+1;
+    // sqrt(2.0) is for handling patch rotation
+    int descPatchSize = cvCeil(halfPatchSize*sqrt(2.0));
+    int border = std::max(edgeThreshold, std::max(descPatchSize, HARRIS_BLOCK_SIZE/2))+1;
 
     bool useOCL = ocl::useOpenCL() && OCL_FORCE_CHECK(_image.isUMat() || _descriptors.isUMat());
 

--- a/modules/features2d/test/test_orb.cpp
+++ b/modules/features2d/test/test_orb.cpp
@@ -90,3 +90,36 @@ TEST(Features2D_ORB, _1996)
 
     ASSERT_EQ(0, roiViolations);
 }
+
+TEST(Features2D_ORB, crash)
+{
+    cv::Mat image = cv::Mat::zeros(cv::Size(1920, 1080), CV_8UC3);
+
+    int nfeatures = 8000;
+    float orbScaleFactor = 1.2f;
+    int nlevels = 18;
+    int edgeThreshold = 4;
+    int firstLevel = 0;
+    int WTA_K = 2;
+    int scoreType = cv::ORB::HARRIS_SCORE;
+    int patchSize = 47;
+    int fastThreshold = 20;
+
+    Ptr<ORB> orb = cv::ORB::create(nfeatures, orbScaleFactor, nlevels, edgeThreshold, firstLevel, WTA_K, scoreType, patchSize, fastThreshold);
+
+    std::vector<cv::KeyPoint> keypoints;
+    cv::Mat descriptors;
+
+    cv::KeyPoint kp;
+    kp.pt.x = 443;
+    kp.pt.y = 5;
+    kp.size = 47;
+    kp.angle = 53.4580612f;
+    kp.response = 0.0000470733867f;
+    kp.octave = 0;
+    kp.class_id = -1;
+
+    keypoints.push_back(kp);
+
+    ASSERT_NO_THROW(orb->compute(image, keypoints, descriptors));
+}


### PR DESCRIPTION
resolves #5031
fixes fails of ORB tests if they are run in random order


