### PR TITLE
resolves #4958 cv::ml::StatModel::calcError not working for responses of type CV_32S

### DIFF
--- a/modules/ml/src/inner_functions.cpp
+++ b/modules/ml/src/inner_functions.cpp
@@ -74,6 +74,7 @@ float StatModel::calcError( const Ptr<TrainData>& data, bool testerr, OutputArra
     int i, n = (int)sidx.total();
     bool isclassifier = isClassifier();
     Mat responses = data->getResponses();
+    int responses_type = responses.type();
 
     if( n == 0 )
         n = data->getNSamples();
@@ -91,7 +92,7 @@ float StatModel::calcError( const Ptr<TrainData>& data, bool testerr, OutputArra
         int si = sidx_ptr ? sidx_ptr[i] : i;
         Mat sample = layout == ROW_SAMPLE ? samples.row(si) : samples.col(si);
         float val = predict(sample);
-        float val0 = responses.at<float>(si);
+        float val0 = (responses_type == CV_32S) ? (float)responses.at<int>(si) : responses.at<float>(si);
 
         if( isclassifier )
             err += fabs(val - val0) > FLT_EPSILON;


### PR DESCRIPTION
resolves #4958 
Update inner_functions.cpp
cv::ml::StatModel::calcError not working for responses of type CV_32S