### PR TITLE
Test script: added long test filter for valgrind

### DIFF
--- a/modules/ts/misc/run_suite.py
+++ b/modules/ts/misc/run_suite.py
@@ -2,6 +2,7 @@
 
 import datetime
 from run_utils import *
+from run_long import LONG_TESTS_DEBUG_VALGRIND, longTestFilter
 
 class TestSuite(object):
     def __init__(self, options, cache):
@@ -99,7 +100,7 @@ class TestSuite(object):
             if self.options.valgrind_supp:
                 res.append("--suppressions=%s" % self.options.valgrind_supp)
             res.extend(self.options.valgrind_opt)
-            return res + cmd
+            return res + cmd + [longTestFilter(LONG_TESTS_DEBUG_VALGRIND)]
         return cmd
 
     def tryCommand(self, cmd):


### PR DESCRIPTION
Some tests take too long to run under valgrind, making corresponding builders fail. This PR adds fixed test filter inside _run.py_ script.

**Notes:**
- list of long tests has been generated from logs written by valgrind test run on average Linux machine similar to buildbot builder
- module name and time stored in the list are not used, but can become more useful to generate more specific test filter for the module or to apply bigger limit during runtime
- accuracy tests do not store _module_name_ in the log and some modules from _opencv_contrib_ write wrong name, so we use filename guess at first place
- _run_long.py_ can be used to generate list of long tests from all xml logs in current folder