### PR TITLE
OpenVX wrappers rewritten with CV_OVX_RUN, VX_DbgThrow

### DIFF
--- a/modules/core/include/opencv2/core/openvx/ovx_defs.hpp
+++ b/modules/core/include/opencv2/core/openvx/ovx_defs.hpp
@@ -30,4 +30,11 @@
     #define CV_OVX_RUN(condition, func, ...)
 #endif // HAVE_OPENVX
 
+// Throw an error in debug mode or try another implementation in release
+#ifdef _DEBUG
+#define VX_DbgThrow(s) CV_Error(cv::Error::StsInternal, (s))
+#else
+#define VX_DbgThrow(s) return false
+#endif
+
 #endif // OPENCV_OVX_DEFS_HPP

--- a/modules/core/src/convert.cpp
+++ b/modules/core/src/convert.cpp
@@ -4638,12 +4638,6 @@ cvtScaleHalf_<short, float>( const short* src, size_t sstep, float* dst, size_t 
 
 #ifdef HAVE_OPENVX
 
-#ifdef _DEBUG
-#define VX_DbgThrow(s) CV_Error(cv::Error::StsInternal, (s))
-#else
-#define VX_DbgThrow(s) return false;
-#endif
-
 template<typename T, typename DT>
 static bool _openvx_cvt(const T* src, size_t sstep,
                         DT* dst, size_t dstep, Size continuousSize)
@@ -4734,7 +4728,7 @@ cvt_( const T* src, size_t sstep,
     CV_OVX_RUN(
         false,
         openvx_cvt(src, sstep, dst, dstep, size)
-    );
+    )
 
     sstep /= sizeof(src[0]);
     dstep /= sizeof(dst[0]);
@@ -5407,13 +5401,11 @@ static bool openvx_LUT(Mat src, Mat dst, Mat _lut)
     }
     catch (ivx::RuntimeError & e)
     {
-        CV_Error(CV_StsInternal, e.what());
-        return false;
+        VX_DbgThrow(e.what());
     }
     catch (ivx::WrapperError & e)
     {
-        CV_Error(CV_StsInternal, e.what());
-        return false;
+        VX_DbgThrow(e.what());
     }
 
     return true;
@@ -5685,10 +5677,8 @@ void cv::LUT( InputArray _src, InputArray _lut, OutputArray _dst )
     _dst.create(src.dims, src.size, CV_MAKETYPE(_lut.depth(), cn));
     Mat dst = _dst.getMat();
 
-#ifdef HAVE_OPENVX
-    if (openvx_LUT(src, dst, lut))
-        return;
-#endif
+    CV_OVX_RUN(true,
+               openvx_LUT(src, dst, lut))
 
     CV_IPP_RUN(_src.dims() <= 2, ipp_lut(src, lut, dst));
 

--- a/modules/core/src/stat.cpp
+++ b/modules/core/src/stat.cpp
@@ -47,11 +47,7 @@
 
 #include "opencl_kernels_core.hpp"
 
-#ifdef HAVE_OPENVX
-#define IVX_HIDE_INFO_WARNINGS
-#define IVX_USE_OPENCV
-#include "ivx.hpp"
-#endif
+#include "opencv2/core/openvx/ovx_defs.hpp"
 
 namespace cv
 {
@@ -1706,19 +1702,17 @@ namespace cv
                 for (int c = 1; c < (int)stddev.total(); c++)
                     pstddev[c] = 0;
             }
-
-            return true;
         }
         catch (ivx::RuntimeError & e)
         {
-            CV_Error(CV_StsInternal, e.what());
-            return false;
+            VX_DbgThrow(e.what());
         }
         catch (ivx::WrapperError & e)
         {
-            CV_Error(CV_StsInternal, e.what());
-            return false;
+            VX_DbgThrow(e.what());
         }
+
+        return true;
     }
 }
 #endif
@@ -1848,10 +1842,8 @@ void cv::meanStdDev( InputArray _src, OutputArray _mean, OutputArray _sdv, Input
     Mat src = _src.getMat(), mask = _mask.getMat();
     CV_Assert( mask.empty() || mask.type() == CV_8UC1 );
 
-#ifdef HAVE_OPENVX
-    if (openvx_meanStdDev(src, _mean, _sdv, mask))
-        return;
-#endif
+    CV_OVX_RUN(true,
+               openvx_meanStdDev(src, _mean, _sdv, mask))
 
     CV_IPP_RUN(IPP_VERSION_X100 >= 700, ipp_meanStdDev(src, _mean, _sdv, mask));
 
@@ -2365,19 +2357,17 @@ static bool openvx_minMaxIdx(Mat &src, double* minVal, double* maxVal, int* minI
             size_t maxidx = loc.y * cols + loc.x + 1;
             ofs2idx(src, maxidx, maxIdx);
         }
-
-        return true;
     }
     catch (ivx::RuntimeError & e)
     {
-        CV_Error(CV_StsInternal, e.what());
-        return false;
+        VX_DbgThrow(e.what());
     }
     catch (ivx::WrapperError & e)
     {
-        CV_Error(CV_StsInternal, e.what());
-        return false;
+        VX_DbgThrow(e.what());
     }
+
+    return true;
 }
 #endif
 
@@ -2505,10 +2495,8 @@ void cv::minMaxIdx(InputArray _src, double* minVal,
 
     Mat src = _src.getMat(), mask = _mask.getMat();
 
-#ifdef HAVE_OPENVX
-    if (openvx_minMaxIdx(src, minVal, maxVal, minIdx, maxIdx, mask))
-        return;
-#endif
+    CV_OVX_RUN(true,
+               openvx_minMaxIdx(src, minVal, maxVal, minIdx, maxIdx, mask))
 
     CV_IPP_RUN(IPP_VERSION_X100 >= 700, ipp_minMaxIdx(src, minVal, maxVal, minIdx, maxIdx, mask))
 

--- a/modules/imgproc/src/accum.cpp
+++ b/modules/imgproc/src/accum.cpp
@@ -45,11 +45,7 @@
 #include "opencl_kernels_imgproc.hpp"
 #include "opencv2/core/hal/intrin.hpp"
 
-#ifdef HAVE_OPENVX
-#define IVX_USE_OPENCV
-#define IVX_HIDE_INFO_WARNINGS
-#include "ivx.hpp"
-#endif
+#include "opencv2/core/openvx/ovx_defs.hpp"
 
 namespace cv
 {
@@ -1993,13 +1989,11 @@ static bool openvx_accumulate(InputArray _src, InputOutputArray _dst, InputArray
     }
     catch (ivx::RuntimeError & e)
     {
-        CV_Error(CV_StsInternal, e.what());
-        return false;
+        VX_DbgThrow(e.what());
     }
     catch (ivx::WrapperError & e)
     {
-        CV_Error(CV_StsInternal, e.what());
-        return false;
+        VX_DbgThrow(e.what());
     }
 
     return true;
@@ -2023,12 +2017,8 @@ void cv::accumulate( InputArray _src, InputOutputArray _dst, InputArray _mask )
     CV_IPP_RUN((_src.dims() <= 2 || (_src.isContinuous() && _dst.isContinuous() && (_mask.empty() || _mask.isContinuous()))),
         ipp_accumulate(_src, _dst, _mask));
 
-#ifdef HAVE_OPENVX
-    if(openvx_accumulate(_src, _dst, _mask, 0.0, VX_ACCUMULATE_OP))
-    {
-        return;
-    }
-#endif
+    CV_OVX_RUN(_src.dims() <= 2,
+               openvx_accumulate(_src, _dst, _mask, 0.0, VX_ACCUMULATE_OP))
 
     Mat src = _src.getMat(), dst = _dst.getMat(), mask = _mask.getMat();
 
@@ -2126,12 +2116,8 @@ void cv::accumulateSquare( InputArray _src, InputOutputArray _dst, InputArray _m
     CV_IPP_RUN((_src.dims() <= 2 || (_src.isContinuous() && _dst.isContinuous() && (_mask.empty() || _mask.isContinuous()))),
         ipp_accumulate_square(_src, _dst, _mask));
 
-#ifdef HAVE_OPENVX
-    if(openvx_accumulate(_src, _dst, _mask, 0.0, VX_ACCUMULATE_SQUARE_OP))
-    {
-        return;
-    }
-#endif
+    CV_OVX_RUN(_src.dims() <= 2,
+               openvx_accumulate(_src, _dst, _mask, 0.0, VX_ACCUMULATE_SQUARE_OP))
 
     Mat src = _src.getMat(), dst = _dst.getMat(), mask = _mask.getMat();
 
@@ -2334,12 +2320,8 @@ void cv::accumulateWeighted( InputArray _src, InputOutputArray _dst,
 
     CV_IPP_RUN((_src.dims() <= 2 || (_src.isContinuous() && _dst.isContinuous() && _mask.isContinuous())), ipp_accumulate_weighted(_src, _dst, alpha, _mask));
 
-#ifdef HAVE_OPENVX
-    if(openvx_accumulate(_src, _dst, _mask, alpha, VX_ACCUMULATE_WEIGHTED_OP))
-    {
-        return;
-    }
-#endif
+    CV_OVX_RUN(_src.dims() <= 2,
+               openvx_accumulate(_src, _dst, _mask, alpha, VX_ACCUMULATE_WEIGHTED_OP))
 
     Mat src = _src.getMat(), dst = _dst.getMat(), mask = _mask.getMat();
 

--- a/modules/imgproc/src/canny.cpp
+++ b/modules/imgproc/src/canny.cpp
@@ -822,13 +822,11 @@ static bool openvx_canny(const Mat& src, Mat& dst, int loVal, int hiVal, int kSi
     }
     catch(const WrapperError& e)
     {
-        //CV_DbgAssert(!"openvx_canny - WrapperError");
-        return false;
+        VX_DbgThrow(e.what());
     }
     catch(const RuntimeError& e)
     {
-        //CV_DbgAssert(!"openvx_canny - RuntimeError");
-        return false;
+        VX_DbgThrow(e.what());
     }
 
     return true;
@@ -877,7 +875,7 @@ void Canny( InputArray _src, OutputArray _dst,
             cvFloor(low_thresh),
             cvFloor(high_thresh),
             aperture_size,
-            L2gradient ) );
+            L2gradient ) )
 
 #ifdef HAVE_TEGRA_OPTIMIZATION
     if (tegra::useTegra() && tegra::canny(src, dst, low_thresh, high_thresh, aperture_size, L2gradient))

--- a/modules/imgproc/src/deriv.cpp
+++ b/modules/imgproc/src/deriv.cpp
@@ -43,11 +43,7 @@
 #include "precomp.hpp"
 #include "opencl_kernels_imgproc.hpp"
 
-#ifdef HAVE_OPENVX
-#define IVX_HIDE_INFO_WARNINGS
-#define IVX_USE_OPENCV
-#include "ivx.hpp"
-#endif
+#include "opencv2/core/openvx/ovx_defs.hpp"
 
 /****************************************************************************************\
                              Sobel & Scharr Derivative Filters
@@ -293,18 +289,17 @@ namespace cv
                 ivx::IVX_CHECK_STATUS(vxuConvolve(ctx, ia, cnv, ib));
             }
             ctx.setImmediateBorder(prevBorder);
-            return true;
         }
         catch (ivx::RuntimeError & e)
         {
-            CV_Error(CV_StsInternal, e.what());
-            return false;
+            VX_DbgThrow(e.what());
         }
         catch (ivx::WrapperError & e)
         {
-            CV_Error(CV_StsInternal, e.what());
-            return false;
+            VX_DbgThrow(e.what());
         }
+
+        return true;
     }
 }
 #endif
@@ -729,10 +724,8 @@ void cv::Sobel( InputArray _src, OutputArray _dst, int ddepth, int dx, int dy,
     }
 #endif
 
-#ifdef HAVE_OPENVX
-    if (openvx_sobel(_src, _dst, dx, dy, ksize, scale, delta, borderType))
-        return;
-#endif
+    CV_OVX_RUN(true,
+               openvx_sobel(_src, _dst, dx, dy, ksize, scale, delta, borderType))
 
     CV_IPP_RUN(!(ocl::useOpenCL() && _dst.isUMat()), ipp_sobel(_src, _dst, ddepth, dx, dy, ksize, scale, delta, borderType));
 

--- a/modules/imgproc/src/histogram.cpp
+++ b/modules/imgproc/src/histogram.cpp
@@ -1307,13 +1307,11 @@ namespace cv
         }
         catch (ivx::RuntimeError & e)
         {
-            CV_Error(CV_StsInternal, e.what());
-            return false;
+            VX_DbgThrow(e.what());
         }
         catch (ivx::WrapperError & e)
         {
-            CV_Error(CV_StsInternal, e.what());
-            return false;
+            VX_DbgThrow(e.what());
         }
 
         return true;
@@ -1379,7 +1377,7 @@ void cv::calcHist( const Mat* images, int nimages, const int* channels,
         nimages == 1 && images[0].type() == CV_8UC1 && dims == 1 && _mask.getMat().empty() &&
         (!channels || channels[0] == 0) && !accumulate && uniform &&
         ranges && ranges[0],
-        openvx_calchist(images[0], _hist, histSize[0], ranges[0]));
+        openvx_calchist(images[0], _hist, histSize[0], ranges[0]))
 
     CV_IPP_RUN(nimages == 1 && images[0].type() == CV_8UC1 && dims == 1 && channels &&
                 channels[0] == 0 && _mask.getMat().empty() && images[0].dims <= 2 &&
@@ -3791,13 +3789,11 @@ static bool openvx_equalize_hist(Mat srcMat, Mat dstMat)
     }
     catch (RuntimeError & e)
     {
-        CV_Error(CV_StsInternal, e.what());
-        return false;
+        VX_DbgThrow(e.what());
     }
     catch (WrapperError & e)
     {
-        CV_Error(CV_StsInternal, e.what());
-        return false;
+        VX_DbgThrow(e.what());
     }
 
     return true;
@@ -3821,12 +3817,8 @@ void cv::equalizeHist( InputArray _src, OutputArray _dst )
     _dst.create( src.size(), src.type() );
     Mat dst = _dst.getMat();
 
-#ifdef HAVE_OPENVX
-    if(openvx_equalize_hist(src, dst))
-    {
-        return;
-    }
-#endif
+    CV_OVX_RUN(true,
+               openvx_equalize_hist(src, dst))
 
     Mutex histogramLockInstance;
 

--- a/modules/imgproc/src/smooth.cpp
+++ b/modules/imgproc/src/smooth.cpp
@@ -44,11 +44,8 @@
 #include "precomp.hpp"
 #include "opencl_kernels_imgproc.hpp"
 
-#ifdef HAVE_OPENVX
-#define IVX_HIDE_INFO_WARNINGS
-#define IVX_USE_OPENCV
-#include "ivx.hpp"
-#endif
+#include "opencv2/core/openvx/ovx_defs.hpp"
+
 /*
  * This file includes the code, contributed by Simon Perreault
  * (the function icvMedianBlur_8u_O1)
@@ -1730,13 +1727,11 @@ namespace cv
         }
         catch (ivx::RuntimeError & e)
         {
-            CV_Error(CV_StsInternal, e.what());
-            return false;
+            VX_DbgThrow(e.what());
         }
         catch (ivx::WrapperError & e)
         {
-            CV_Error(CV_StsInternal, e.what());
-            return false;
+            VX_DbgThrow(e.what());
         }
 
         return true;
@@ -1855,10 +1850,8 @@ void cv::boxFilter( InputArray _src, OutputArray _dst, int ddepth,
 
     CV_OCL_RUN(_dst.isUMat(), ocl_boxFilter(_src, _dst, ddepth, ksize, anchor, borderType, normalize))
 
-#ifdef HAVE_OPENVX
-    if (openvx_boxfilter(_src, _dst, ddepth, ksize, anchor, normalize, borderType))
-        return;
-#endif
+    CV_OVX_RUN(true,
+               openvx_boxfilter(_src, _dst, ddepth, ksize, anchor, normalize, borderType))
 
     Mat src = _src.getMat();
     int stype = src.type(), sdepth = CV_MAT_DEPTH(stype), cn = CV_MAT_CN(stype);
@@ -2300,13 +2293,11 @@ static bool openvx_gaussianBlur(InputArray _src, OutputArray _dst, Size ksize,
     }
     catch (ivx::RuntimeError & e)
     {
-        CV_Error(CV_StsInternal, e.what());
-        return false;
+        VX_DbgThrow(e.what());
     }
     catch (ivx::WrapperError & e)
     {
-        CV_Error(CV_StsInternal, e.what());
-        return false;
+        VX_DbgThrow(e.what());
     }
     return true;
 }
@@ -2433,10 +2424,8 @@ void cv::GaussianBlur( InputArray _src, OutputArray _dst, Size ksize,
         return;
     }
 
-#ifdef HAVE_OPENVX
-    if (openvx_gaussianBlur(_src, _dst, ksize, sigma1, sigma2, borderType))
-        return;
-#endif
+    CV_OVX_RUN(true,
+               openvx_gaussianBlur(_src, _dst, ksize, sigma1, sigma2, borderType))
 
 #ifdef HAVE_TEGRA_OPTIMIZATION
     Mat src = _src.getMat();
@@ -3439,13 +3428,11 @@ namespace cv
         }
         catch (ivx::RuntimeError & e)
         {
-            CV_Error(CV_StsInternal, e.what());
-            return false;
+            VX_DbgThrow(e.what());
         }
         catch (ivx::WrapperError & e)
         {
-            CV_Error(CV_StsInternal, e.what());
-            return false;
+            VX_DbgThrow(e.what());
         }
 
         return true;
@@ -3533,10 +3520,8 @@ void cv::medianBlur( InputArray _src0, OutputArray _dst, int ksize )
     _dst.create( src0.size(), src0.type() );
     Mat dst = _dst.getMat();
 
-#ifdef HAVE_OPENVX
-    if (openvx_medianFilter(_src0, _dst, ksize))
-        return;
-#endif
+    CV_OVX_RUN(true,
+               openvx_medianFilter(_src0, _dst, ksize))
 
     CV_IPP_RUN(IPP_VERSION_X100 >= 810 && ksize <= 5, ipp_medianFilter(_src0,_dst, ksize));
 

--- a/modules/imgproc/src/thresh.cpp
+++ b/modules/imgproc/src/thresh.cpp
@@ -44,11 +44,7 @@
 #include "opencl_kernels_imgproc.hpp"
 #include "opencv2/core/hal/intrin.hpp"
 
-#ifdef HAVE_OPENVX
-#define IVX_HIDE_INFO_WARNINGS
-#define IVX_USE_OPENCV
-#include "ivx.hpp"
-#endif
+#include "opencv2/core/openvx/ovx_defs.hpp"
 
 namespace cv
 {
@@ -1330,13 +1326,11 @@ static bool openvx_threshold(Mat src, Mat dst, int thresh, int maxval, int type)
     }
     catch (ivx::RuntimeError & e)
     {
-        CV_Error(CV_StsInternal, e.what());
-        return false;
+        VX_DbgThrow(e.what());
     }
     catch (ivx::WrapperError & e)
     {
-        CV_Error(CV_StsInternal, e.what());
-        return false;
+        VX_DbgThrow(e.what());
     }
 
     return true;
@@ -1396,10 +1390,8 @@ double cv::threshold( InputArray _src, OutputArray _dst, double thresh, double m
             return thresh;
         }
 
-#ifdef HAVE_OPENVX
-        if (openvx_threshold(src, dst, ithresh, imaxval, type))
-            return thresh;
-#endif
+       CV_OVX_RUN(true,
+                  openvx_threshold(src, dst, ithresh, imaxval, type), (double)ithresh)
 
         thresh = ithresh;
         maxval = imaxval;


### PR DESCRIPTION
* all errors are processed with `VX_DbgThrow` macro
* all calls to wrappers are replaced by `CV_OVX_RUN` macro