### PR TITLE
(2.4) Fix CUDA warnings

### DIFF
--- a/modules/gpu/CMakeLists.txt
+++ b/modules/gpu/CMakeLists.txt
@@ -29,7 +29,7 @@ if(HAVE_CUDA)
 
   source_group("Src\\NVidia" FILES ${ncv_files})
   ocv_include_directories("src/nvidia" "src/nvidia/core" "src/nvidia/NPP_staging" ${CUDA_INCLUDE_DIRS})
-  ocv_warnings_disable(CMAKE_CXX_FLAGS -Wundef -Wmissing-declarations -Wshadow -Wunused-parameter /wd4211 /wd4201 /wd4100 /wd4505 /wd4408)
+  ocv_warnings_disable(CMAKE_CXX_FLAGS -Wundef -Wmissing-declarations -Wshadow -Wunused-parameter -Wstrict-aliasing /wd4211 /wd4201 /wd4100 /wd4505 /wd4408)
 
   if(MSVC)
     if(NOT ENABLE_NOISY_WARNINGS)

--- a/modules/gpu/src/nvidia/NCVHaarObjectDetection.hpp
+++ b/modules/gpu/src/nvidia/NCVHaarObjectDetection.hpp
@@ -59,6 +59,11 @@
 #ifndef _ncvhaarobjectdetection_hpp_
 #define _ncvhaarobjectdetection_hpp_
 
+#ifdef __GNUC__
+# pragma GCC diagnostic push
+# pragma GCC diagnostic ignored "-Wstrict-aliasing"
+#endif
+
 #include <string>
 #include "NCV.hpp"
 
@@ -458,5 +463,8 @@ NCV_EXPORTS NCVStatus ncvHaarStoreNVBIN_host(const std::string &filename,
                                              NCVVector<HaarFeature64> &h_HaarFeatures);
 
 
+#ifdef __GNUC__
+# pragma GCC diagnostic pop
+#endif
 
 #endif // _ncvhaarobjectdetection_hpp_


### PR DESCRIPTION
Examples:
- NPP_staging.cu:1606:105: warning: dereferencing type-punned pointer will break strict-aliasing rules [-Wstrict-aliasing]
- NCVHaarObjectDetection.hpp:95:37: warning: dereferencing type-punned pointer will break strict-aliasing rules [-Wstrict-aliasing]