### PR TITLE
fix the equation of filter2D

### DIFF
--- a/doc/tutorials/imgproc/imgtrans/filter_2d/filter_2d.markdown
+++ b/doc/tutorials/imgproc/imgtrans/filter_2d/filter_2d.markdown
@@ -38,7 +38,7 @@ convolution is calculated in the following way:
 
 Expressing the procedure above in the form of an equation we would have:
 
-\f[H(x,y) = \sum_{i=0}^{M_{i} - 1} \sum_{j=0}^{M_{j}-1} I(x+i - a_{i}, y + j - a_{j})K(i,j)\f]
+\f[H(x,y) = \sum_{i=0}^{M_{i} - 1} \sum_{j=0}^{M_{j}-1} I(x+i + a_{i}, y + j + a_{j})K(i,j)\f]
 
 Fortunately, OpenCV provides you with the function @ref cv::filter2D so you do not have to code all
 these operations.


### PR DESCRIPTION
the equation of the procedure of `filter2D` should be like this:
\f[H(x,y) = \sum_{i=0}^{M_{i} - 1} \sum_{j=0}^{M_{j}-1} I(x+i + a_{i}, y + j + a_{j})K(i,j)\f]
because the default value of anchor is cv::Point(-1, -1) not cv::Point(1, 1)

<!-- Please use this line to close one or multiple issues when this pullrequest gets merged
You can add another line right under the first one:
resolves #1234
resolves #1235
-->

### This pullrequest changes
the equaltion of the procedure of `filter2D`
<!-- Please describe what your pullrequest is changing -->
