### PR TITLE
[traincascade] add type_id to the old save format

### DIFF
--- a/apps/traincascade/cascadeclassifier.cpp
+++ b/apps/traincascade/cascadeclassifier.cpp
@@ -412,6 +412,7 @@ bool CvCascadeClassifier::readStages( const FileNode &node)
 }
 
 // For old Haar Classifier file saving
+#define ICV_HAAR_TYPE_ID              "opencv-haar-classifier"
 #define ICV_HAAR_SIZE_NAME            "size"
 #define ICV_HAAR_STAGES_NAME          "stages"
 #define ICV_HAAR_TREES_NAME             "trees"
@@ -434,11 +435,12 @@ void CvCascadeClassifier::save( const string filename, bool baseFormat )
     if ( !fs.isOpened() )
         return;
 
-    fs << FileStorage::getDefaultObjectName(filename) << "{";
+    fs << FileStorage::getDefaultObjectName(filename);
     if ( !baseFormat )
     {
         Mat featureMap;
         getUsedFeaturesIdxMap( featureMap );
+        fs << "{";
         writeParams( fs );
         fs << CC_STAGE_NUM << (int)stageClassifiers.size();
         writeStages( fs, featureMap );
@@ -450,6 +452,7 @@ void CvCascadeClassifier::save( const string filename, bool baseFormat )
         CvSeq* weak;
         if ( cascadeParams.featureType != CvFeatureParams::HAAR )
             CV_Error( CV_StsBadFunc, "old file format is used for Haar-like features only");
+        fs << "{:" ICV_HAAR_TYPE_ID;
         fs << ICV_HAAR_SIZE_NAME << "[:" << cascadeParams.winSize.width <<
             cascadeParams.winSize.height << "]";
         fs << ICV_HAAR_STAGES_NAME << "[";


### PR DESCRIPTION
### This pullrequest changes

This PR adds the `type_id` of `opencv-haar-classifier` to the saved model when using the latest `traincascade` program with the `-baseFormatSave` option.

### Background
I recently trained a cascade classifier using the `traincascade` program with the `-baseFormatSave` option because I needed to use the GPU version of the classifier for detection. After training when I went to load my `cascade.yml` file I encountered the following error:

```
OpenCV Error: Unspecified error (The node does not represent a user object (unknown type?)) in cvRead, file /home/kevin/src/opencv/modules/core/src/persistence.cpp, line 6628
terminate called after throwing an instance of 'cv::Exception'
  what():  /home/kevin/src/opencv/modules/core/src/persistence.cpp:6628: error: (-2) The node does not represent a user object (unknown type?) in function cvRead
``` 

I started investigating by looking at the cascades provided by opencv:

**new format (from data/haarcascades):**
```xml
<opencv_storage>
<cascade type_id="opencv-cascade-classifier"><stageType>BOOST</stageType>
  <featureType>HAAR</featureType>
  <height>20</height>
  <width>20</width>
  <stageParams>
  ...
</opencv_storage>
```

**gpu format (from data/haarcascades_gpu):**

```xml
<opencv_storage>
<haarcascade_frontaleye type_id="opencv-haar-classifier">
  <size>
    20 20</size>
  <stages>
    <_>
      <!-- stage 0 -->
      <trees>
        <_>
          <!-- tree 0 -->
          <_>
            <!-- root node -->
    ...
<opencv_storage>
```

and compared them to the file that was saved after my classifier was trained:

**traincascade with -baseFormatSave option:**
```xml
<?xml version="1.0"?>
<opencv_storage>
<cascade>
  <size>
    100 40</size>
  <stages>
    <_>
      <trees>
        <_>
          <_>
  ...
<opencv_storage>
```

This is when I noticed that my output was missing the `type_id`. Adding this manually fixed the issue and I was able to load and run my classifier. Note that this only affected the old file format and if I saved my classifier in the new format I was able to load it.

From here I started looking into how the classifier is saved to see if I could fix the problem. I am including the notes I took while exploring the `FileStorage` code in case others find it useful.

* The `traincascade` program writes to `FileStorage` using a hash like DSL [starting here](https://github.com/opencv/opencv/blob/master/apps/traincascade/cascadeclassifier.cpp#L430)
* The [persistence module](https://github.com/opencv/opencv/blob/master/modules/core/src/persistence.cpp) converts the hash like structure into NODE types. This is how this module is able to support multiple output formats (yml and xml).
* [Here](http://github.com/opencv/opencv/blob/master/modules/core/src/persistence.cpp#L6894) is where the `{` char is converted to a node by calling [cvStartWriteStruct](https://github.com/opencv/opencv/blob/master/modules/core/src/persistence.cpp#L4498) with anything trailing the `:` as `type_name`
* Which writes to type_id [here](http://github.com/opencv/opencv/blob/master/modules/core/src/persistence.cpp#L2958)

### Testing
There doesn't seem to be any tests for the `traincascade` app so I wrote a small program to confirm my fix:

```cpp
#include <opencv2/core/core.hpp>

using namespace cv;

int main() {
  string filename = "cascade.xml";
  FileStorage fs( filename, FileStorage::WRITE );
  fs << FileStorage::getDefaultObjectName(filename) << "{:opencv-haar-classifier";
  fs << "}";
}
```

which when ran produces:

```xml
<?xml version="1.0"?>
<opencv_storage>
<cascade type_id="opencv-haar-classifier"></cascade>
</opencv_storage>
```
