### PR TITLE
Print a warning message with flags SOLVEPNP_DLS or SOLVEPNP_UPNP.

### DIFF
--- a/modules/calib3d/src/solvepnp.cpp
+++ b/modules/calib3d/src/solvepnp.cpp
@@ -91,6 +91,12 @@ bool solvePnP( InputArray _opoints, InputArray _ipoints,
 
     if (flags == SOLVEPNP_EPNP || flags == SOLVEPNP_DLS || flags == SOLVEPNP_UPNP)
     {
+        if (flags == SOLVEPNP_DLS || flags == SOLVEPNP_UPNP)
+        {
+            cout << "Flags SOLVEPNP_DLS and SOLVEPNP_UPNP are currently disabled due to instable results.\n"
+                 << "Switch to SOLVEPNP_EPNP method automatically." << endl;
+        }
+
         Mat undistortedPoints;
         undistortPoints(ipoints, undistortedPoints, cameraMatrix, distCoeffs);
         epnp PnP(cameraMatrix, opoints, undistortedPoints);
@@ -145,7 +151,7 @@ bool solvePnP( InputArray _opoints, InputArray _ipoints,
         return true;
     }*/
     else
-        CV_Error(CV_StsBadArg, "The flags argument must be one of SOLVEPNP_ITERATIVE, SOLVEPNP_P3P, SOLVEPNP_EPNP or SOLVEPNP_DLS");
+        CV_Error(CV_StsBadArg, "The flags argument must be one of SOLVEPNP_ITERATIVE, SOLVEPNP_P3P, SOLVEPNP_EPNP, SOLVEPNP_DLS or SOLVEPNP_UPNP.");
     return result;
 }
 


### PR DESCRIPTION
<!-- Please use this line to close one or multiple issues when this pullrequest gets merged
You can add another line right under the first one:
resolves #1234
resolves #1235
-->

### This pullrequest adds

<!-- Please describe what your pullrequest is changing -->
a warning message when flags `SOLVEPNP_DLS` or `SOLVEPNP_UPNP` are used.
I think a message should be printed in the console to warn the user that these two flags cannot be used and `SOLVEPNP_EPNP`will be used instead.

Related #7818 