### PR TITLE
Add method KeypointBasedMotionEstimator::estimate(InputArray, InputArray) to support both CPU & OpenCL processing

### DIFF
--- a/modules/videostab/include/opencv2/videostab/global_motion.hpp
+++ b/modules/videostab/include/opencv2/videostab/global_motion.hpp
@@ -236,6 +236,7 @@ public:
     Ptr<IOutlierRejector> outlierRejector() const { return outlierRejector_; }
 
     virtual Mat estimate(const Mat &frame0, const Mat &frame1, bool *ok = 0);
+    Mat estimate(InputArray frame0, InputArray frame1, bool *ok = 0);
 
 private:
     Ptr<MotionEstimatorBase> motionEstimator_;

--- a/modules/videostab/src/global_motion.cpp
+++ b/modules/videostab/src/global_motion.cpp
@@ -711,6 +711,14 @@ KeypointBasedMotionEstimator::KeypointBasedMotionEstimator(Ptr<MotionEstimatorBa
 
 Mat KeypointBasedMotionEstimator::estimate(const Mat &frame0, const Mat &frame1, bool *ok)
 {
+    InputArray image0 = frame0;
+    InputArray image1 = frame1;
+
+    return estimate(image0, image1, ok);
+}
+
+Mat KeypointBasedMotionEstimator::estimate(InputArray frame0, InputArray frame1, bool *ok)
+{
     // find keypoints
     detector_->detect(frame0, keypointsPrev_);
     if (keypointsPrev_.empty())
@@ -722,7 +730,34 @@ Mat KeypointBasedMotionEstimator::estimate(const Mat &frame0, const Mat &frame1,
         pointsPrev_[i] = keypointsPrev_[i].pt;
 
     // find correspondences
-    optFlowEstimator_->run(frame0, frame1, pointsPrev_, points_, status_, noArray());
+    if (frame0.isUMat() || frame1.isUMat())
+    {
+        UMat ugrayImage0;
+        UMat ugrayImage1;
+        if ( frame0.type() != CV_8U )
+        {
+            cvtColor( frame0, ugrayImage0, COLOR_BGR2GRAY );
+        }
+        else
+        {
+            ugrayImage0 = frame0.getUMat();
+        }
+
+        if ( frame1.type() != CV_8U )
+        {
+            cvtColor( frame1, ugrayImage1, COLOR_BGR2GRAY );
+        }
+        else
+        {
+            ugrayImage1 = frame1.getUMat();
+        }
+
+        optFlowEstimator_->run(ugrayImage0, ugrayImage1, pointsPrev_, points_, status_, noArray());
+    }
+    else
+    {
+        optFlowEstimator_->run(frame0, frame1, pointsPrev_, points_, status_, noArray());
+    }
 
     // leave good correspondences only
 
@@ -766,6 +801,7 @@ Mat KeypointBasedMotionEstimator::estimate(const Mat &frame0, const Mat &frame1,
 
     // estimate motion
     return motionEstimator_->estimate(pointsPrevGood_, pointsGood_, ok);
+
 }
 
 #if defined(HAVE_OPENCV_CUDAIMGPROC) && defined(HAVE_OPENCV_CUDAOPTFLOW)


### PR DESCRIPTION
the original estimate function's input parameters is defined as "Mat", this prevent users to call into algorithm opencl path

<!-- Please use this line to close one or multiple issues when this pullrequest gets merged
You can add another line right under the first one:
resolves #1234
resolves #1235
-->

### This pullrequest changes

<!-- Please describe what your pullrequest is changing -->

1. it's impossible to call into openCL implementation of algorithm "feature detect and optical flow" through the original function KeypointBasedMotionEstimator::estimate(const Mat &frame0, const Mat &frame1, bool *ok = 0) 

the parameter "Mat" passed into feature detect and optical flow algorithm will choose Non-opencl path. add a new function with input parameters "UMat", so that if user can choose run the algorithum with opencl.

2. ocl_calcOpticalFlowPyrLK function only accept 1 channel gray image, so have to convert input image format into one channel grey image if it is necessary.