### PR TITLE
Speed up cuda::MedianFilter::apply() when calling it repeatedly

### DIFF
--- a/modules/cudafilters/src/filtering.cpp
+++ b/modules/cudafilters/src/filtering.cpp
@@ -1100,13 +1100,9 @@ namespace
 
         // Note - these are hardcoded in the actual GPU kernel. Do not change these values.
         int histSize=256, histCoarseSize=8;
-        int devHistCols = src.cols*histSize*partitions, devCoarseHistCols = src.cols*histCoarseSize*partitions;
-        if(devHist.empty() || devCoarseHist.empty() || devHist.cols != devHistCols || devCoarseHist.cols != devCoarseHistCols)
-        {
-          BufferPool pool(_stream);
-          devHist = pool.getBuffer(1, devHistCols, CV_32SC1);
-          devCoarseHist = pool.getBuffer(1, devCoarseHistCols, CV_32SC1);
-        }
+
+        devHist.create(1, src.cols*histSize*partitions, CV_32SC1);
+        devCoarseHist.create(1, src.cols*histCoarseSize*partitions, CV_32SC1);
 
         devHist.setTo(0, _stream);
         devCoarseHist.setTo(0, _stream);

--- a/modules/cudafilters/src/filtering.cpp
+++ b/modules/cudafilters/src/filtering.cpp
@@ -1068,6 +1068,8 @@ namespace
     private:
         int windowSize;
         int partitions;
+        GpuMat devHist;
+        GpuMat devCoarseHist;
     };
 
     MedianFilter::MedianFilter(int srcType, int _windowSize, int _partitions) :
@@ -1098,10 +1100,13 @@ namespace
 
         // Note - these are hardcoded in the actual GPU kernel. Do not change these values.
         int histSize=256, histCoarseSize=8;
-
-        BufferPool pool(_stream);
-        GpuMat devHist = pool.getBuffer(1, src.cols*histSize*partitions,CV_32SC1);
-        GpuMat devCoarseHist = pool.getBuffer(1,src.cols*histCoarseSize*partitions,CV_32SC1);
+        int devHistCols = src.cols*histSize*partitions, devCoarseHistCols = src.cols*histCoarseSize*partitions;
+        if(devHist.empty() || devCoarseHist.empty() || devHist.cols != devHistCols || devCoarseHist.cols != devCoarseHistCols)
+        {
+          BufferPool pool(_stream);
+          devHist = pool.getBuffer(1, devHistCols, CV_32SC1);
+          devCoarseHist = pool.getBuffer(1, devCoarseHistCols, CV_32SC1);
+        }
 
         devHist.setTo(0, _stream);
         devCoarseHist.setTo(0, _stream);


### PR DESCRIPTION
<!-- Please use this line to close one or multiple issues when this pullrequest gets merged
You can add another line right under the first one:
resolves #1234
resolves #1235
-->

This pullrequest accelerates cuda::MedianFilter::apply(). which avoid to newly create the two GpuMat everytime calling filter->apply(), which is very time consuming.
The diff moves the two GpuMat into class MedianFilter,  and they are not allocated again unless the src size changes. Got 4x performance boost compared with the original cuda version ( tested with 2000 frames in same size of 300 * 230).

<!-- Please describe what your pullrequest is changing -->
