### PR TITLE
Avoid segmentation fault

### DIFF
--- a/modules/core/src/command_line_parser.cpp
+++ b/modules/core/src/command_line_parser.cpp
@@ -10,7 +10,7 @@ static const char* noneValue = "<none>";
 static String cat_string(const String& str)
 {
     int left = 0, right = (int)str.length();
-    while( left <= right && str[left] == ' ' )
+    while( left < right && str[left] == ' ' )
         left++;
     while( right > left && str[right-1] == ' ' )
         right--;


### PR DESCRIPTION
Change `<=` to `<` to avoid accessing the first character of an empty string in `cat_string()`

resolves #7936

### This pullrequest changes

`cat_string()` in command_line_parser.cpp
