### PR TITLE
Append zero to trailing decimal place for FileStorage JSON write of a float or double value

### DIFF
--- a/modules/core/src/persistence.cpp
+++ b/modules/core/src/persistence.cpp
@@ -4025,7 +4025,14 @@ static void
 icvJSONWriteReal( CvFileStorage* fs, const char* key, double value )
 {
     char buf[128];
-    icvJSONWrite( fs, key, icvDoubleToString( buf, value ));
+    int len = (int)strlen( icvDoubleToString( buf, value ) );
+    if( len > 0 && buf[len-1] == '.' )
+    {
+        // append zero if string ends with decimal place to match JSON standard
+        buf[len] = '0';
+        buf[len+1] = '\0';
+    }
+    icvJSONWrite( fs, key, buf );
 }
 
 
@@ -4829,6 +4836,17 @@ cvWriteRawData( CvFileStorage* fs, const void* _data, int len, const char* dt )
                 }
                 else
                 {
+                    if( elem_type == CV_32F || elem_type == CV_64F )
+                    {
+                        int buf_len = (int)strlen(ptr);
+                        if( buf_len > 0 && ptr[buf_len-1] == '.' )
+                        {
+                            // append zero if CV_32F or CV_64F string ends with decimal place to match JSON standard
+                            // ptr will point to buf, so can write to buf given ptr is const
+                            buf[buf_len] = '0';
+                            buf[buf_len+1] = '\0';
+                        }
+                    }
                     icvJSONWrite( fs, 0, ptr );
                 }
             }

--- a/modules/core/src/persistence.cpp
+++ b/modules/core/src/persistence.cpp
@@ -4025,7 +4025,7 @@ static void
 icvJSONWriteReal( CvFileStorage* fs, const char* key, double value )
 {
     char buf[128];
-    int len = (int)strlen( icvDoubleToString( buf, value ) );
+    size_t len = strlen( icvDoubleToString( buf, value ) );
     if( len > 0 && buf[len-1] == '.' )
     {
         // append zero if string ends with decimal place to match JSON standard
@@ -4838,7 +4838,7 @@ cvWriteRawData( CvFileStorage* fs, const void* _data, int len, const char* dt )
                 {
                     if( elem_type == CV_32F || elem_type == CV_64F )
                     {
-                        int buf_len = (int)strlen(ptr);
+                        size_t buf_len = strlen(ptr);
                         if( buf_len > 0 && ptr[buf_len-1] == '.' )
                         {
                             // append zero if CV_32F or CV_64F string ends with decimal place to match JSON standard


### PR DESCRIPTION
<!-- Please use this line to close one or multiple issues when this pullrequest gets merged
You can add another line right under the first one:
resolves #1234
resolves #1235
-->
resolves #7951
### This pullrequest changes

- Appends zero to trailing decimal place for FileStorage JSON write of a float or double value
- Needed to meet JSON standard
- Previous text output "1." now becomes "1.0"
- Only JSON format is modified, no change to XML or YAML output
