### PR TITLE
added to check the support of AVX2

### DIFF
--- a/modules/core/src/stat.cpp
+++ b/modules/core/src/stat.cpp
@@ -4253,6 +4253,7 @@ int normHamming(const uchar* a, int n)
         result += vgetq_lane_s32 (vreinterpretq_s32_u64(bitSet2),2);
     }
 #elif CV_AVX2
+    if (USE_AVX2)
     {
         __m256i _r0 = _mm256_setzero_si256();
         __m256i _0 = _mm256_setzero_si256();
@@ -4303,6 +4304,7 @@ int normHamming(const uchar* a, const uchar* b, int n)
         result += vgetq_lane_s32 (vreinterpretq_s32_u64(bitSet2),2);
     }
 #elif CV_AVX2
+    if (USE_AVX2)
     {
         __m256i _r0 = _mm256_setzero_si256();
         __m256i _0 = _mm256_setzero_si256();


### PR DESCRIPTION
resolves #7981

### This pullrequest changes
Now, <code>cv::normHamming</code> has AVX2 implementation.
But, [current code](https://github.com/opencv/opencv/blob/3.2.0/modules/core/src/stat.cpp#L4256) doesn't check the support of AVX2 on system.
I think that it's better to use [USE_AVX2](https://github.com/opencv/opencv/blob/3.2.0/modules/core/src/precomp.hpp#L81) for checking.