### PR TITLE
cuda: fix CUDA tests initialization

### DIFF
--- a/modules/ts/include/opencv2/ts.hpp
+++ b/modules/ts/include/opencv2/ts.hpp
@@ -604,12 +604,17 @@ void dumpOpenCLDevice();
 
 void parseCustomOptions(int argc, char **argv);
 
-#define CV_TEST_MAIN(resourcesubdir, ...) \
+#define CV_TEST_INIT0_NOOP (void)0
+
+#define CV_TEST_MAIN(resourcesubdir, ...) CV_TEST_MAIN_EX(resourcesubdir, NOOP, __VA_ARGS__)
+
+#define CV_TEST_MAIN_EX(resourcesubdir, INIT0, ...) \
 int main(int argc, char **argv) \
 { \
     using namespace cvtest; \
     TS* ts = TS::ptr(); \
     ts->init(resourcesubdir); \
+    __CV_TEST_EXEC_ARGS(CV_TEST_INIT0_ ## INIT0) \
     ::testing::InitGoogleTest(&argc, argv); \
     cvtest::printVersionInfo(); \
     TEST_DUMP_OCL_INFO \

--- a/modules/ts/include/opencv2/ts/cuda_test.hpp
+++ b/modules/ts/include/opencv2/ts/cuda_test.hpp
@@ -351,8 +351,10 @@ namespace cv { namespace cuda
 
 #ifdef HAVE_CUDA
 
-#define CV_CUDA_TEST_MAIN(resourcesubdir) \
-    CV_TEST_MAIN(resourcesubdir, cvtest::parseCudaDeviceOptions(argc, argv), cvtest::printCudaInfo(), cv::setUseOptimized(false))
+#define CV_TEST_INIT0_CUDA cvtest::parseCudaDeviceOptions(argc, argv), cvtest::printCudaInfo(), cv::setUseOptimized(false)
+
+#define CV_CUDA_TEST_MAIN(resourcesubdir, ...) \
+    CV_TEST_MAIN_EX(resourcesubdir, CUDA, __VA_ARGS__)
 
 #else // HAVE_CUDA
 


### PR DESCRIPTION
resolves #7993

CUDA tests require device list initialization before `InitGoogleTest()` call.