### PR TITLE
imgproc/CLAHE/ocl: Removed unnecessary __local variable

### DIFF
--- a/modules/imgproc/src/opencl/clahe.cl
+++ b/modules/imgproc/src/opencl/clahe.cl
@@ -186,21 +186,13 @@ __kernel void calcLut(__global __const uchar * src, const int srcStep,
 #else
         clipped = smem[0];
 #endif
-
-        // broadcast evaluated value
-
-        __local int totalClipped;
-
-        if (tid == 0)
-            totalClipped = clipped;
         barrier(CLK_LOCAL_MEM_FENCE);
 
         // redistribute clipped samples evenly
-
-        int redistBatch = totalClipped / 256;
+        int redistBatch = clipped / 256;
         tHistVal += redistBatch;
 
-        int residual = totalClipped - redistBatch * 256;
+        int residual = clipped - redistBatch * 256;
         int rStep = 256 / residual;
         if (rStep < 1)
             rStep = 1;


### PR DESCRIPTION
resolves opencv/opencv_contrib#843

### This pullrequest changes

*__local* variable should not be defined in function scope by specification. In this case _totalClipped_ variable can be removed.
