### PR TITLE
(2.4) cmake: add defines to enable useful macroses

### DIFF
--- a/cmake/OpenCVModule.cmake
+++ b/cmake/OpenCVModule.cmake
@@ -170,6 +170,10 @@ macro(ocv_add_module _name)
       return() # extra protection from redefinition
     endif()
     project(${the_module})
+    add_definitions(
+        -D_USE_MATH_DEFINES  # M_PI constant in MSVS
+        -D__STDC_CONSTANT_MACROS -D__STDC_LIMIT_MACROS  # to use C libraries from C++ code (ffmpeg)
+    )
   endif(OPENCV_INITIAL_PASS)
 endmacro()
 


### PR DESCRIPTION
Resolves #7891
