### PR TITLE
RTrees: Add wrapper for RTrees_load method to enable loading trained …

### DIFF
--- a/modules/ml/include/opencv2/ml.hpp
+++ b/modules/ml/include/opencv2/ml.hpp
@@ -1169,6 +1169,17 @@ public:
     Algorithm::load to load the pre-trained model.
      */
     CV_WRAP static Ptr<RTrees> create();
+
+    /** @brief Loads and creates a serialized RTree from a file
+     *
+     * Use RTree::save to serialize and store an RTree to disk.
+     * Load the RTree from this file again, by calling this function with the path to the file.
+     * Optionally specify the node for the file containing the classifier
+     *
+     * @param filepath path to serialized RTree
+     * @param nodeName name of node containing the classifier
+     */
+    CV_WRAP static Ptr<RTrees> load(const String& filepath , const String& nodeName = String());
 };
 
 /****************************************************************************************\

--- a/modules/ml/src/rtrees.cpp
+++ b/modules/ml/src/rtrees.cpp
@@ -41,7 +41,6 @@
 //M*/
 
 #include "precomp.hpp"
-
 namespace cv {
 namespace ml {
 
@@ -420,6 +419,12 @@ public:
 Ptr<RTrees> RTrees::create()
 {
     return makePtr<RTreesImpl>();
+}
+
+//Function needed for Python and Java wrappers
+Ptr<RTrees> RTrees::load(const String& filepath, const String& nodeName)
+{
+    return Algorithm::load<RTrees>(filepath, nodeName);
 }
 
 }}


### PR DESCRIPTION
…RTrees

<!-- Please use this line to close one or multiple issues when this pullrequest gets merged
You can add another line right under the first one:
resolves #1234
resolves #1235
-->
resolves http://answers.opencv.org/question/122375/how-to-load-a-trained-random-trees-model-in-opencv-3-in-python/

### This pullrequest changes

<!-- Please describe what your pullrequest is changing -->
Adds a method to load a trained RTree for the Python wrapper.
Function was not available in Python