### PR TITLE
shape: force column-based vector

### DIFF
--- a/modules/python/test/test_shape.py
+++ b/modules/python/test/test_shape.py
@@ -1,0 +1,23 @@
+#!/usr/bin/env python
+import cv2
+
+from tests_common import NewOpenCVTests
+
+class shape_test(NewOpenCVTests):
+
+    def test_computeDistance(self):
+
+        a = self.get_sample('samples/data/shape_sample/1.png', cv2.IMREAD_GRAYSCALE);
+        b = self.get_sample('samples/data/shape_sample/2.png', cv2.IMREAD_GRAYSCALE);
+
+        _, ca, _ = cv2.findContours(a, cv2.RETR_CCOMP, cv2.CHAIN_APPROX_TC89_KCOS)
+        _, cb, _ = cv2.findContours(b, cv2.RETR_CCOMP, cv2.CHAIN_APPROX_TC89_KCOS)
+
+        hd = cv2.createHausdorffDistanceExtractor()
+        sd = cv2.createShapeContextDistanceExtractor()
+
+        d1 = hd.computeDistance(ca[0], cb[0])
+        d2 = sd.computeDistance(ca[0], cb[0])
+
+        self.assertAlmostEqual(d1, 26.4196891785, 3, "HausdorffDistanceExtractor")
+        self.assertAlmostEqual(d2, 0.25804194808, 3, "ShapeContextDistanceExtractor")

--- a/modules/shape/src/haus_dis.cpp
+++ b/modules/shape/src/haus_dis.cpp
@@ -138,6 +138,13 @@ float HausdorffDistanceExtractorImpl::computeDistance(InputArray contour1, Input
         set2.convertTo(set2, CV_32F);
     CV_Assert((set1.channels()==2) && (set1.cols>0));
     CV_Assert((set2.channels()==2) && (set2.cols>0));
+
+    // Force vectors column-based
+    if (set1.dims > 1)
+        set1 = set1.reshape(2, 1);
+    if (set2.dims > 1)
+        set2 = set2.reshape(2, 1);
+
     return std::max( _apply(set1, set2, distanceFlag, rankProportion),
                      _apply(set2, set1, distanceFlag, rankProportion) );
 }

--- a/modules/shape/src/sc_dis.cpp
+++ b/modules/shape/src/sc_dis.cpp
@@ -202,6 +202,13 @@ float ShapeContextDistanceExtractorImpl::computeDistance(InputArray contour1, In
 
     CV_Assert((set1.channels()==2) && (set1.cols>0));
     CV_Assert((set2.channels()==2) && (set2.cols>0));
+
+    // Force vectors column-based
+    if (set1.dims > 1)
+        set1 = set1.reshape(2, 1);
+    if (set2.dims > 1)
+        set2 = set2.reshape(2, 1);
+
     if (imageAppearanceWeight!=0)
     {
         CV_Assert((!image1.empty()) && (!image2.empty()));

--- a/modules/shape/test/test_shape.cpp
+++ b/modules/shape/test/test_shape.cpp
@@ -299,3 +299,22 @@ TEST(Hauss, regression)
     ShapeBaseTest<int, computeShapeDistance_Haussdorf> test(NSN_val, NP_val, CURRENT_MAX_ACCUR_val);
     test.safe_run();
 }
+
+TEST(computeDistance, regression_4976)
+{
+    Mat a = imread(cvtest::findDataFile("shape/samples/1.png"), 0);
+    Mat b = imread(cvtest::findDataFile("shape/samples/2.png"), 0);
+
+    vector<vector<Point> > ca,cb;
+    findContours(a, ca, cv::RETR_CCOMP, cv::CHAIN_APPROX_TC89_KCOS);
+    findContours(b, cb, cv::RETR_CCOMP, cv::CHAIN_APPROX_TC89_KCOS);
+
+    Ptr<HausdorffDistanceExtractor> hd = createHausdorffDistanceExtractor();
+    Ptr<ShapeContextDistanceExtractor> sd = createShapeContextDistanceExtractor();
+
+    double d1 = hd->computeDistance(ca[0],cb[0]);
+    double d2 = sd->computeDistance(ca[0],cb[0]);
+
+    EXPECT_NEAR(d1, 26.4196891785, 1e-3) << "HausdorffDistanceExtractor";
+    EXPECT_NEAR(d2, 0.25804194808, 1e-3) << "ShapeContextDistanceExtractor";
+}


### PR DESCRIPTION
**Merge with**: https://github.com/opencv/opencv_extra/pull/320

resolves #4976

Before:
- C++: Hausdorff=26.4197 ShapeContext=0.258042
- Python: Hausdorff=32.3109893799 ShapeContext=0.0

After:
- C++: Hausdorff=26.4197 ShapeContext=0.258042 (unchanged)
- Python: Hausdorff=26.4196891785 ShapeContext=0.25804194808 (**both changed**)

BTW, All shape accuracy tests are disabled on CI.