### PR TITLE
Fix HAMMING2 popcnt

### DIFF
--- a/modules/flann/include/opencv2/flann/dist.h
+++ b/modules/flann/include/opencv2/flann/dist.h
@@ -520,6 +520,7 @@ struct Hamming2
     unsigned int popcnt32(uint32_t n) const
     {
         n -= ((n >> 1) & 0x55555555);
+        n = ((n & 0xAAAAAAAA)>>1) | (n & 0x55555555);
         n = (n & 0x33333333) + ((n >> 2) & 0x33333333);
         return (((n + (n >> 4))& 0xF0F0F0F)* 0x1010101) >> 24;
     }
@@ -528,6 +529,7 @@ struct Hamming2
     unsigned int popcnt64(uint64_t n) const
     {
         n -= ((n >> 1) & 0x5555555555555555);
+        n = ((n & 0xAAAAAAAAAAAAAAAA)>>1) | (n & 0x5555555555555555);
         n = (n & 0x3333333333333333) + ((n >> 2) & 0x3333333333333333);
         return (((n + (n >> 4))& 0x0f0f0f0f0f0f0f0f)* 0x0101010101010101) >> 56;
     }


### PR DESCRIPTION
resolves #7989

### This pullrequest changes

For binary descriptors that output 2 bits per bin/element the NORM_HAMMING2 distance should be used (especially for ORB with WTA_K== 3 or 4). The current popcnt32/64 count every set bit, so for each different bin/element/2bits it counts 2 different elements instead of 1 as expected, this outputs the wrong distance, for example if an XOR'd byte result is say 11111111 the expected distance is 4, the distance with popcnt is 8, which could overlook a good match. This pullrequest changes popcnt32/64 to count every 2 different bits as 1.