### PR TITLE
Added export functions for ObjC classes and fixed OSX build script

### DIFF
--- a/modules/videoio/include/opencv2/videoio/cap_ios.h
+++ b/modules/videoio/include/opencv2/videoio/cap_ios.h
@@ -32,8 +32,6 @@
 #import <ImageIO/ImageIO.h>
 #include "opencv2/core.hpp"
 
-#define OPENCV_OBJC_EXPORT __attribute__((visibility("default")))
-
 //! @addtogroup videoio_ios
 //! @{
 
@@ -41,7 +39,7 @@
 
 @class CvAbstractCamera;
 
-OPENCV_OBJC_EXPORT @interface CvAbstractCamera : NSObject
+CV_EXPORTS @interface CvAbstractCamera : NSObject
 {
     UIDeviceOrientation currentDeviceOrientation;
 
@@ -89,7 +87,7 @@ OPENCV_OBJC_EXPORT @interface CvAbstractCamera : NSObject
 
 @class CvVideoCamera;
 
-OPENCV_OBJC_EXPORT @protocol CvVideoCameraDelegate <NSObject>
+CV_EXPORTS @protocol CvVideoCameraDelegate <NSObject>
 
 #ifdef __cplusplus
 // delegate method for processing image frames
@@ -98,7 +96,7 @@ OPENCV_OBJC_EXPORT @protocol CvVideoCameraDelegate <NSObject>
 
 @end
 
-OPENCV_OBJC_EXPORT @interface CvVideoCamera : CvAbstractCamera<AVCaptureVideoDataOutputSampleBufferDelegate>
+CV_EXPORTS @interface CvVideoCamera : CvAbstractCamera<AVCaptureVideoDataOutputSampleBufferDelegate>
 {
     AVCaptureVideoDataOutput *videoDataOutput;
 
@@ -131,14 +129,14 @@ OPENCV_OBJC_EXPORT @interface CvVideoCamera : CvAbstractCamera<AVCaptureVideoDat
 
 @class CvPhotoCamera;
 
-OPENCV_OBJC_EXPORT @protocol CvPhotoCameraDelegate <NSObject>
+CV_EXPORTS @protocol CvPhotoCameraDelegate <NSObject>
 
 - (void)photoCamera:(CvPhotoCamera*)photoCamera capturedImage:(UIImage *)image;
 - (void)photoCameraCancel:(CvPhotoCamera*)photoCamera;
 
 @end
 
-OPENCV_OBJC_EXPORT @interface CvPhotoCamera : CvAbstractCamera
+CV_EXPORTS @interface CvPhotoCamera : CvAbstractCamera
 {
     AVCaptureStillImageOutput *stillImageOutput;
 }

--- a/modules/videoio/include/opencv2/videoio/cap_ios.h
+++ b/modules/videoio/include/opencv2/videoio/cap_ios.h
@@ -32,6 +32,8 @@
 #import <ImageIO/ImageIO.h>
 #include "opencv2/core.hpp"
 
+#define OPENCV_OBJC_EXPORT __attribute__((visibility("default")))
+
 //! @addtogroup videoio_ios
 //! @{
 
@@ -39,7 +41,7 @@
 
 @class CvAbstractCamera;
 
-@interface CvAbstractCamera : NSObject
+OPENCV_OBJC_EXPORT @interface CvAbstractCamera : NSObject
 {
     UIDeviceOrientation currentDeviceOrientation;
 
@@ -87,7 +89,7 @@
 
 @class CvVideoCamera;
 
-@protocol CvVideoCameraDelegate <NSObject>
+OPENCV_OBJC_EXPORT @protocol CvVideoCameraDelegate <NSObject>
 
 #ifdef __cplusplus
 // delegate method for processing image frames
@@ -96,7 +98,7 @@
 
 @end
 
-@interface CvVideoCamera : CvAbstractCamera<AVCaptureVideoDataOutputSampleBufferDelegate>
+OPENCV_OBJC_EXPORT @interface CvVideoCamera : CvAbstractCamera<AVCaptureVideoDataOutputSampleBufferDelegate>
 {
     AVCaptureVideoDataOutput *videoDataOutput;
 
@@ -129,14 +131,14 @@
 
 @class CvPhotoCamera;
 
-@protocol CvPhotoCameraDelegate <NSObject>
+OPENCV_OBJC_EXPORT @protocol CvPhotoCameraDelegate <NSObject>
 
 - (void)photoCamera:(CvPhotoCamera*)photoCamera capturedImage:(UIImage *)image;
 - (void)photoCameraCancel:(CvPhotoCamera*)photoCamera;
 
 @end
 
-@interface CvPhotoCamera : CvAbstractCamera
+OPENCV_OBJC_EXPORT @interface CvPhotoCamera : CvAbstractCamera
 {
     AVCaptureStillImageOutput *stillImageOutput;
 }

--- a/platforms/osx/build_framework.py
+++ b/platforms/osx/build_framework.py
@@ -15,10 +15,10 @@ class OSXBuilder(Builder):
     def getToolchain(self, arch, target):
         return None
 
-    def getBuildCommand(self, arch, target):
+    def getBuildCommand(self, archs, target):
         buildcmd = [
             "xcodebuild",
-            "ARCHS=%s" % arch,
+            "ARCHS=%s" % archs[0],
             "-sdk", target.lower(),
             "-configuration", "Release",
             "-parallelizeTargets",
@@ -39,8 +39,8 @@ if __name__ == "__main__":
     parser.add_argument('--without', metavar='MODULE', default=[], action='append', help='OpenCV modules to exclude from the framework')
     args = parser.parse_args()
 
-    b = OSXBuilder(args.opencv, args.contrib, args.without,
+    b = OSXBuilder(args.opencv, args.contrib, False, False, args.without,
         [
-            ("x86_64", "MacOSX")
+            (["x86_64"], "MacOSX")
         ])
     b.build(args.out)


### PR DESCRIPTION
### This pullrequest changes

- Adds additional export macro for Objective-C classes, which are marked as invisible by default. This enables the linker to correctly link to dynamic framework, when using Objective-C classes defined in `cap_ios.h`
- Fixes `build_framework.py` osx script, as mentioned by @Jaykob in https://github.com/opencv/opencv/pull/8009#issuecomment-274870169