### PR TITLE
Enable GNU STL debug mode for debug builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -295,6 +295,7 @@ OCV_OPTION(OPENCV_WARNINGS_ARE_ERRORS "Treat warnings as errors"                
 OCV_OPTION(ANDROID_EXAMPLES_WITH_LIBS "Build binaries of Android examples with native libraries" OFF  IF ANDROID )
 OCV_OPTION(ENABLE_IMPL_COLLECTION     "Collect implementation data on function call"             OFF )
 OCV_OPTION(ENABLE_INSTRUMENTATION     "Instrument functions to collect calls trace and performance" OFF )
+OCV_OPTION(ENABLE_GNU_STL_DEBUG       "Enable GNU STL Debug mode (defines _GLIBCXX_DEBUG)"       OFF IF ((NOT CMAKE_VERSION VERSION_LESS "2.8.11") AND CMAKE_COMPILER_IS_GNUCXX) )
 OCV_OPTION(GENERATE_ABI_DESCRIPTOR    "Generate XML file for abi_compliance_checker tool" OFF IF UNIX)
 
 OCV_OPTION(DOWNLOAD_EXTERNAL_TEST_DATA "Download external test data (Python executable and OPENCV_TEST_DATA_PATH environment variable may be required)" OFF )

--- a/cmake/OpenCVModule.cmake
+++ b/cmake/OpenCVModule.cmake
@@ -858,8 +858,11 @@ macro(_ocv_create_module)
 
   if((NOT DEFINED OPENCV_MODULE_TYPE AND BUILD_SHARED_LIBS)
       OR (DEFINED OPENCV_MODULE_TYPE AND OPENCV_MODULE_TYPE STREQUAL SHARED))
-    set_target_properties(${the_module} PROPERTIES COMPILE_DEFINITIONS CVAPI_EXPORTS)
     set_target_properties(${the_module} PROPERTIES DEFINE_SYMBOL CVAPI_EXPORTS)
+  endif()
+
+  if (ENABLE_GNU_STL_DEBUG)
+    target_compile_definitions(${the_module} PUBLIC _GLIBCXX_DEBUG)
   endif()
 
   if(MSVC)


### PR DESCRIPTION
<!-- Please use this line to close one or multiple issues when this pullrequest gets merged
You can add another line right under the first one:
resolves #1234
resolves #1235
-->

### This pullrequest changes

A proposal to enable STL debug mode for GNUCXX debug builds.

[Debug mode description](https://gcc.gnu.org/onlinedocs/libstdc++/manual/debug_mode_using.html)

Example:
```.cpp
std::vector<int> foo(10);
// 1
std::vector<int>::iterator i = foo.begin();
--i;
// 2
std::cout << foo[11] << std::endl;
```
stderr output:
```
// ==== 1 ====
/usr/include/c++/5/debug/safe_iterator.h:361:error: attempt to decrement a 
    dereferenceable (start-of-sequence) iterator.

Objects involved in the operation:
iterator "this" @ 0x0x7ffdbeab21a0 {
type = N11__gnu_debug14_Safe_iteratorIN9__gnu_cxx17__normal_iteratorIPiNSt9__cxx19986vectorIiSaIiEEEEENSt7__debug6vectorIiS6_EEEE (mutable iterator);
  state = dereferenceable (start-of-sequence);
  references sequence with type `NSt7__debug6vectorIiSaIiEEE' @ 0x0x7ffdbeab21d0
}
Segmentation fault (core dumped)

// ==== 2 ====
/usr/include/c++/5/debug/vector:409:error: attempt to subscript container 
    with out-of-bounds index 11, but container only holds 10 elements.

Objects involved in the operation:
sequence "this" @ 0x0x7ffd5962f4b0 {
  type = NSt7__debug6vectorIiSaIiEEE;
}
Segmentation fault (core dumped)
```

<!-- Please describe what your pullrequest is changing -->
