### PR TITLE
core: check correct flag

### DIFF
--- a/modules/core/src/precomp.hpp
+++ b/modules/core/src/precomp.hpp
@@ -75,7 +75,7 @@
 #include <cstring>
 #include <cassert>
 
-#define USE_SSE2  (cv::checkHardwareSupport(CV_CPU_SSE))
+#define USE_SSE2  (cv::checkHardwareSupport(CV_CPU_SSE2))
 #define USE_SSE4_2  (cv::checkHardwareSupport(CV_CPU_SSE4_2))
 #define USE_AVX  (cv::checkHardwareSupport(CV_CPU_AVX))
 #define USE_AVX2  (cv::checkHardwareSupport(CV_CPU_AVX2))


### PR DESCRIPTION
<!-- Please use this line to close one or multiple issues when this pullrequest gets merged
You can add another line right under the first one:
resolves #1234
resolves #1235
-->

### This pullrequest changes
 - check SSE2 flag by ```USE_SSE2``` macro
 - I'm quite sure this won't affect any modern CPU, but the name doesn't match with what it's doing.
<!-- Please describe what your pullrequest is changing -->
