### PR TITLE
Add wrappers for load functions for DTrees and Boost classifiers

### DIFF
--- a/modules/ml/include/opencv2/ml.hpp
+++ b/modules/ml/include/opencv2/ml.hpp
@@ -1115,6 +1115,17 @@ public:
     file using Algorithm::load\<DTrees\>(filename).
      */
     CV_WRAP static Ptr<DTrees> create();
+
+    /** @brief Loads and creates a serialized DTrees from a file
+     *
+     * Use DTree::save to serialize and store an DTree to disk.
+     * Load the DTree from this file again, by calling this function with the path to the file.
+     * Optionally specify the node for the file containing the classifier
+     *
+     * @param filepath path to serialized DTree
+     * @param nodeName name of node containing the classifier
+     */
+    CV_WRAP static Ptr<DTrees> load(const String& filepath , const String& nodeName = String());
 };
 
 /****************************************************************************************\
@@ -1229,6 +1240,17 @@ public:
     /** Creates the empty model.
     Use StatModel::train to train the model, Algorithm::load\<Boost\>(filename) to load the pre-trained model. */
     CV_WRAP static Ptr<Boost> create();
+
+    /** @brief Loads and creates a serialized Boost from a file
+     *
+     * Use Boost::save to serialize and store an RTree to disk.
+     * Load the Boost from this file again, by calling this function with the path to the file.
+     * Optionally specify the node for the file containing the classifier
+     *
+     * @param filepath path to serialized Boost
+     * @param nodeName name of node containing the classifier
+     */
+    CV_WRAP static Ptr<Boost> load(const String& filepath , const String& nodeName = String());
 };
 
 /****************************************************************************************\

--- a/modules/ml/src/boost.cpp
+++ b/modules/ml/src/boost.cpp
@@ -507,6 +507,11 @@ Ptr<Boost> Boost::create()
     return makePtr<BoostImpl>();
 }
 
+Ptr<Boost> Boost::load(const String& filepath, const String& nodeName)
+{
+    return Algorithm::load<Boost>(filepath, nodeName);
+}
+
 }}
 
 /* End of file. */

--- a/modules/ml/src/tree.cpp
+++ b/modules/ml/src/tree.cpp
@@ -1941,6 +1941,12 @@ Ptr<DTrees> DTrees::create()
     return makePtr<DTreesImpl>();
 }
 
+Ptr<DTrees> DTrees::load(const String& filepath, const String& nodeName)
+{
+    return Algorithm::load<DTrees>(filepath, nodeName);
+}
+
+
 }
 }
 


### PR DESCRIPTION
<!-- Please use this line to close one or multiple issues when this pullrequest gets merged
You can add another line right under the first one:
resolves #1234
resolves #1235
-->

### This pullrequest changes
Adding wrappers for the load method of DTrees and Boost classifiers. 
Using the implementation suggested in #8004 .

<!-- Please describe what your pullrequest is changing -->
