### PR TITLE
Fix #8093: CV_DbgAssert that the result of area() fits in the return value

### DIFF
--- a/modules/core/include/opencv2/core/types.hpp
+++ b/modules/core/include/opencv2/core/types.hpp
@@ -1592,7 +1592,10 @@ Size_<_Tp>& Size_<_Tp>::operator = (const Size_<_Tp>& sz)
 template<typename _Tp> inline
 _Tp Size_<_Tp>::area() const
 {
-    return width * height;
+    const _Tp result = width * height;
+    CV_DbgAssert(!std::numeric_limits<_Tp>::is_integer
+        || width == 0 || result / width == height); // make sure the result fits in the return value
+    return result;
 }
 
 template<typename _Tp> static inline
@@ -1731,7 +1734,10 @@ Size_<_Tp> Rect_<_Tp>::size() const
 template<typename _Tp> inline
 _Tp Rect_<_Tp>::area() const
 {
-    return width * height;
+    const _Tp result = width * height;
+    CV_DbgAssert(!std::numeric_limits<_Tp>::is_integer
+        || width == 0 || result / width == height); // make sure the result fits in the return value
+    return result;
 }
 
 template<typename _Tp> template<typename _Tp2> inline


### PR DESCRIPTION
resolves #8093

A cleaned-up version of #8102:

> This pull request fixes (at least partially) the problem described in #8093: the result of Rect::area() and Size::area() may rather easily be too large to fit in the return value type, causing bugs that can be difficult to find (because depending on the situation, they may surface in a completely different part of an application).
> 
> Personally I might be inclined towards changing the return value type to intmax_t or so, but I do understand that this approach may not be great for everyone.