### PR TITLE
Add a link to MatExpr in Detailed Description of Mat

### DIFF
--- a/modules/core/include/opencv2/core/mat.hpp
+++ b/modules/core/include/opencv2/core/mat.hpp
@@ -736,6 +736,8 @@ Finally, there are STL-style iterators that are smart enough to skip gaps betwee
 @endcode
 The matrix iterators are random-access iterators, so they can be passed to any STL algorithm,
 including std::sort().
+
+@note Matrix Expressions and arithmetic see MatExpr
 */
 class CV_EXPORTS Mat
 {


### PR DESCRIPTION
Just a small link doc to [help user](http://answers.opencv.org/question/124786/why-are-mat-operators-seeing-wrong-type/)