### PR TITLE
added dense flow sample

### DIFF
--- a/samples/gpu/pyrlk_optical_flow.cpp
+++ b/samples/gpu/pyrlk_optical_flow.cpp
@@ -268,15 +268,6 @@ int main(int argc, const char* argv[])
         return -1;
     }
 
-    if(is_sparse)
-    {
-        namedWindow("PyrLK [Sparse]", WINDOW_NORMAL);
-    }
-    else
-    {
-        namedWindow("PyrLK [Dense] Flow Field", WINDOW_NORMAL);
-    }
-
     cout << "Image size : " << frame0.cols << " x " << frame0.rows << endl;
     cout << "Points count : " << points << endl;
 
@@ -318,6 +309,7 @@ int main(int argc, const char* argv[])
         vector<uchar> status(d_status.cols);
         download(d_status, status);
 
+        namedWindow("PyrLK [Sparse]", WINDOW_NORMAL);
         drawArrows(frame0, prevPts, nextPts, status, Scalar(255, 0, 0));
         imshow("PyrLK [Sparse]", frame0);
     }
@@ -329,6 +321,7 @@ int main(int argc, const char* argv[])
         d_pyrLK_dense->calc(d_frame0Gray, d_frame1Gray, d_flow);
 
         // Draw flows
+        namedWindow("PyrLK [Dense] Flow Field", WINDOW_NORMAL);
         showFlow("PyrLK [Dense] Flow Field", d_flow);
     }
 

--- a/samples/gpu/pyrlk_optical_flow.cpp
+++ b/samples/gpu/pyrlk_optical_flow.cpp
@@ -2,12 +2,13 @@
 #include <vector>
 
 #include "opencv2/core.hpp"
-#include <opencv2/core/utility.hpp>
+#include "opencv2/core/utility.hpp"
 #include "opencv2/imgproc.hpp"
 #include "opencv2/highgui.hpp"
 #include "opencv2/video.hpp"
 #include "opencv2/cudaoptflow.hpp"
 #include "opencv2/cudaimgproc.hpp"
+#include "opencv2/cudaarithm.hpp"
 
 using namespace std;
 using namespace cv;
@@ -64,6 +65,132 @@ static void drawArrows(Mat& frame, const vector<Point2f>& prevPts, const vector<
             line(frame, p, q, line_color, line_thickness);
         }
     }
+}
+
+inline bool isFlowCorrect(Point2f u)
+{
+    return !cvIsNaN(u.x) && !cvIsNaN(u.y) && fabs(u.x) < 1e9 && fabs(u.y) < 1e9;
+}
+
+static Vec3b computeColor(float fx, float fy)
+{
+    static bool first = true;
+
+    // relative lengths of color transitions:
+    // these are chosen based on perceptual similarity
+    // (e.g. one can distinguish more shades between red and yellow
+    //  than between yellow and green)
+    const int RY = 15;
+    const int YG = 6;
+    const int GC = 4;
+    const int CB = 11;
+    const int BM = 13;
+    const int MR = 6;
+    const int NCOLS = RY + YG + GC + CB + BM + MR;
+    static Vec3i colorWheel[NCOLS];
+
+    if (first)
+    {
+        int k = 0;
+
+        for (int i = 0; i < RY; ++i, ++k)
+            colorWheel[k] = Vec3i(255, 255 * i / RY, 0);
+
+        for (int i = 0; i < YG; ++i, ++k)
+            colorWheel[k] = Vec3i(255 - 255 * i / YG, 255, 0);
+
+        for (int i = 0; i < GC; ++i, ++k)
+            colorWheel[k] = Vec3i(0, 255, 255 * i / GC);
+
+        for (int i = 0; i < CB; ++i, ++k)
+            colorWheel[k] = Vec3i(0, 255 - 255 * i / CB, 255);
+
+        for (int i = 0; i < BM; ++i, ++k)
+            colorWheel[k] = Vec3i(255 * i / BM, 0, 255);
+
+        for (int i = 0; i < MR; ++i, ++k)
+            colorWheel[k] = Vec3i(255, 0, 255 - 255 * i / MR);
+
+        first = false;
+    }
+
+    const float rad = sqrt(fx * fx + fy * fy);
+    const float a = atan2(-fy, -fx) / (float)CV_PI;
+
+    const float fk = (a + 1.0f) / 2.0f * (NCOLS - 1);
+    const int k0 = static_cast<int>(fk);
+    const int k1 = (k0 + 1) % NCOLS;
+    const float f = fk - k0;
+
+    Vec3b pix;
+
+    for (int b = 0; b < 3; b++)
+    {
+        const float col0 = colorWheel[k0][b] / 255.0f;
+        const float col1 = colorWheel[k1][b] / 255.0f;
+
+        float col = (1 - f) * col0 + f * col1;
+
+        if (rad <= 1)
+            col = 1 - rad * (1 - col); // increase saturation with radius
+        else
+            col *= .75; // out of range
+
+        pix[2 - b] = static_cast<uchar>(255.0 * col);
+    }
+
+    return pix;
+}
+
+static void drawOpticalFlow(const Mat_<float>& flowx, const Mat_<float>& flowy, Mat& dst, float maxmotion = -1)
+{
+    dst.create(flowx.size(), CV_8UC3);
+    dst.setTo(Scalar::all(0));
+
+    // determine motion range:
+    float maxrad = maxmotion;
+
+    if (maxmotion <= 0)
+    {
+        maxrad = 1;
+        for (int y = 0; y < flowx.rows; ++y)
+        {
+            for (int x = 0; x < flowx.cols; ++x)
+            {
+                Point2f u(flowx(y, x), flowy(y, x));
+
+                if (!isFlowCorrect(u))
+                    continue;
+
+                maxrad = max(maxrad, sqrt(u.x * u.x + u.y * u.y));
+            }
+        }
+    }
+
+    for (int y = 0; y < flowx.rows; ++y)
+    {
+        for (int x = 0; x < flowx.cols; ++x)
+        {
+            Point2f u(flowx(y, x), flowy(y, x));
+
+            if (isFlowCorrect(u))
+                dst.at<Vec3b>(y, x) = computeColor(u.x / maxrad, u.y / maxrad);
+        }
+    }
+}
+
+static void showFlow(const char* name, const GpuMat& d_flow)
+{
+    GpuMat planes[2];
+    cuda::split(d_flow, planes);
+
+    Mat flowx(planes[0]);
+    Mat flowy(planes[1]);
+
+    Mat out;
+    drawOpticalFlow(flowx, flowy, out, 10);
+
+    imshow(name, out);
 }
 
 template <typename T> inline T clamp (T x, T a, T b)
@@ -148,7 +275,7 @@ int main(int argc, const char* argv[])
 
     // Sparse
 
-    Ptr<cuda::SparsePyrLKOpticalFlow> d_pyrLK = cuda::SparsePyrLKOpticalFlow::create(
+    Ptr<cuda::SparsePyrLKOpticalFlow> d_pyrLK_sparse = cuda::SparsePyrLKOpticalFlow::create(
                 Size(winSize, winSize), maxLevel, iters);
 
     GpuMat d_frame0(frame0);
@@ -157,7 +284,16 @@ int main(int argc, const char* argv[])
     GpuMat d_nextPts;
     GpuMat d_status;
 
-    d_pyrLK->calc(useGray ? d_frame0Gray : d_frame0, useGray ? d_frame1Gray : d_frame1, d_prevPts, d_nextPts, d_status);
+    d_pyrLK_sparse->calc(useGray ? d_frame0Gray : d_frame0, useGray ? d_frame1Gray : d_frame1, d_prevPts, d_nextPts, d_status);
+
+    // Dense
+
+    Ptr<cuda::DensePyrLKOpticalFlow> d_pyrLK_dense = cuda::DensePyrLKOpticalFlow::create(
+                Size(winSize, winSize), maxLevel, iters);
+
+    GpuMat d_flow(frame0.size(), CV_32FC2);
+
+    d_pyrLK_dense->calc(d_frame0Gray, d_frame1Gray, d_flow);
 
     // Draw arrows
 
@@ -171,8 +307,11 @@ int main(int argc, const char* argv[])
     download(d_status, status);
 
     drawArrows(frame0, prevPts, nextPts, status, Scalar(255, 0, 0));
-
     imshow("PyrLK [Sparse]", frame0);
+
+    // Draw flows
+
+    showFlow("PyrLK [Dense] Flow Field", d_flow);
 
     waitKey();
 

--- a/samples/gpu/pyrlk_optical_flow.cpp
+++ b/samples/gpu/pyrlk_optical_flow.cpp
@@ -1,14 +1,14 @@
 #include <iostream>
 #include <vector>
 
-#include "opencv2/core.hpp"
-#include "opencv2/core/utility.hpp"
-#include "opencv2/imgproc.hpp"
-#include "opencv2/highgui.hpp"
-#include "opencv2/video.hpp"
-#include "opencv2/cudaoptflow.hpp"
-#include "opencv2/cudaimgproc.hpp"
-#include "opencv2/cudaarithm.hpp"
+#include <opencv2/core.hpp>
+#include <opencv2/core/utility.hpp>
+#include <opencv2/imgproc.hpp>
+#include <opencv2/highgui.hpp>
+#include <opencv2/video.hpp>
+#include <opencv2/cudaoptflow.hpp>
+#include <opencv2/cudaimgproc.hpp>
+#include <opencv2/cudaarithm.hpp>
 
 using namespace std;
 using namespace cv;

--- a/samples/gpu/pyrlk_optical_flow.cpp
+++ b/samples/gpu/pyrlk_optical_flow.cpp
@@ -269,7 +269,7 @@ int main(int argc, const char* argv[])
     }
 
     if(is_sparse)
-    { 
+    {
         namedWindow("PyrLK [Sparse]", WINDOW_NORMAL);
     }
     else
@@ -321,7 +321,8 @@ int main(int argc, const char* argv[])
         drawArrows(frame0, prevPts, nextPts, status, Scalar(255, 0, 0));
         imshow("PyrLK [Sparse]", frame0);
     }
-    else {
+    else
+    {
         // Dense
         Ptr<cuda::DensePyrLKOpticalFlow> d_pyrLK_dense = cuda::DensePyrLKOpticalFlow::create(
             Size(winSize, winSize), maxLevel, iters);


### PR DESCRIPTION
The [samples/gpu/pyrlk_optical_flow.cpp](https://github.com/opencv/opencv/blob/3.2.0/samples/gpu/pyrlk_optical_flow.cpp) make a window to visualize dense flow(please see [this code](https://github.com/opencv/opencv/blob/3.2.0/samples/gpu/pyrlk_optical_flow.cpp#L128)). But, dense flow is not calculated.

### This pullrequest changes
I added dense flow code to this sample code.
