### PR TITLE
highgui: use forward slash for gl.h include

### DIFF
--- a/modules/highgui/src/window_w32.cpp
+++ b/modules/highgui/src/window_w32.cpp
@@ -65,7 +65,7 @@
 #include <vector>
 #include <functional>
 #include "opencv2/highgui.hpp"
-#include <GL\gl.h>
+#include <GL/gl.h>
 #endif
 
 static const char* trackbar_text =


### PR DESCRIPTION
The backslash causes build failure when cross-compiling with mingw-w64.