### PR TITLE
enable processing of 16 bit 4 channel data using GDAL1.2

### DIFF
--- a/modules/imgcodecs/src/grfmt_gdal.cpp
+++ b/modules/imgcodecs/src/grfmt_gdal.cpp
@@ -308,6 +308,11 @@ void write_pixel( const double& pixelValue,
     // input: 4 channel, output: 4 channel
     else if( gdalChannels == 4 && image.channels() == 4 ){
         if( image.depth() == CV_8U ){  image.at<Vec4b>(row,col)[channel] = newValue;  }
+        else if( image.depth() == CV_16U ){  image.at<Vec4s>(row,col)[channel] = newValue;  }
+        else if( image.depth() == CV_16S ){  image.at<Vec4s>(row,col)[channel] = newValue;  }
+        else if( image.depth() == CV_32S ){  image.at<Vec4i>(row,col)[channel] = newValue;  }
+        else if( image.depth() == CV_32F ){  image.at<Vec4f>(row,col)[channel] = newValue;  }
+        else if( image.depth() == CV_64F ){  image.at<Vec4d>(row,col)[channel] = newValue;  }
         else{ throw std::runtime_error("Unknown image depth, gdal: 4, image: 4"); }
     }
 


### PR DESCRIPTION
There was an issue with the current GDAL support for 16 bit 4 channel images (RGBA).
There was only implemented support for 8 bit depth, while 16 bit is quite standard in aerial imagery.

### This pullrequest changes
Adds this 16 bit support

### How to confirm this
**[First rebuild OpenCV with libgdal support enabled]**

Before the change using the following code:

```
#include <iostream>
#include "opencv2/opencv.hpp"

using namespace std;
using namespace cv;

int main()
{
    Mat img = imread("/data/coconut/sample_coconut.tif", IMREAD_LOAD_GDAL);
    cout << img.size() << " " << img.channels() << endl;

    imshow("temp", img); waitKey(0);

    return 0;
}
```

resulted in `Unknown image depth, gdal: 4, image: 4` generated by line 309-311. Adding this extra lines loads the image just fine and generates an actual visualisation of the map.