### PR TITLE
cv2.findContours() no longer modifies source image

### DIFF
--- a/doc/py_tutorials/py_imgproc/py_contours/py_contours_begin/py_contours_begin.markdown
+++ b/doc/py_tutorials/py_imgproc/py_contours/py_contours_begin/py_contours_begin.markdown
@@ -17,23 +17,22 @@ detection and recognition.
 
 -   For better accuracy, use binary images. So before finding contours, apply threshold or canny
     edge detection.
--   findContours function modifies the source image. So if you want source image even after
-    finding contours, already store it to some other variables.
+-   Since OpenCV 3.2, findContours() no longer modifies the source image but returns a modified image as the first of three return parameters.
 -   In OpenCV, finding contours is like finding white object from black background. So remember,
     object to be found should be white and background should be black.
 
 Let's see how to find contours of a binary image:
-@code{.py}
+```python
 import numpy as np
 import cv2
 
 im = cv2.imread('test.jpg')
-imgray = cv2.cvtColor(im,cv2.COLOR_BGR2GRAY)
-ret,thresh = cv2.threshold(imgray,127,255,0)
-im2, contours, hierarchy = cv2.findContours(thresh,cv2.RETR_TREE,cv2.CHAIN_APPROX_SIMPLE)
-@endcode
+imgray = cv2.cvtColor(im, cv2.COLOR_BGR2GRAY)
+ret, thresh = cv2.threshold(imgray, 127, 255, 0)
+im2, contours, hierarchy = cv2.findContours(thresh, cv2.RETR_TREE, cv2.CHAIN_APPROX_SIMPLE)
+```
 See, there are three arguments in **cv2.findContours()** function, first one is source image, second
-is contour retrieval mode, third is contour approximation method. And it outputs the contours and
+is contour retrieval mode, third is contour approximation method. And it outputs a modified image, the contours and
 hierarchy. contours is a Python list of all the contours in the image. Each individual contour is a
 Numpy array of (x,y) coordinates of boundary points of the object.
 
@@ -49,19 +48,19 @@ contours which should be passed as a Python list, third argument is index of con
 drawing individual contour. To draw all contours, pass -1) and remaining arguments are color,
 thickness etc.
 
-To draw all the contours in an image:
-@code{.py}
+* To draw all the contours in an image:
+```python
 cv2.drawContours(img, contours, -1, (0,255,0), 3)
-@endcode
-To draw an individual contour, say 4th contour:
-@code{.py}
+```
+* To draw an individual contour, say 4th contour:
+```python
 cv2.drawContours(img, contours, 3, (0,255,0), 3)
-@endcode
-But most of the time, below method will be useful:
-@code{.py}
+```
+* But most of the time, below method will be useful:
+```python
 cnt = contours[4]
 cv2.drawContours(img, [cnt], 0, (0,255,0), 3)
-@endcode
+```
 
 @note Last two methods are same, but when you go forward, you will see last one is more useful.
 

--- a/doc/py_tutorials/py_imgproc/py_contours/py_contours_begin/py_contours_begin.markdown
+++ b/doc/py_tutorials/py_imgproc/py_contours/py_contours_begin/py_contours_begin.markdown
@@ -22,7 +22,7 @@ detection and recognition.
     object to be found should be white and background should be black.
 
 Let's see how to find contours of a binary image:
-```python
+@code{.py}
 import numpy as np
 import cv2
 
@@ -30,7 +30,7 @@ im = cv2.imread('test.jpg')
 imgray = cv2.cvtColor(im, cv2.COLOR_BGR2GRAY)
 ret, thresh = cv2.threshold(imgray, 127, 255, 0)
 im2, contours, hierarchy = cv2.findContours(thresh, cv2.RETR_TREE, cv2.CHAIN_APPROX_SIMPLE)
-```
+@endcode
 See, there are three arguments in **cv2.findContours()** function, first one is source image, second
 is contour retrieval mode, third is contour approximation method. And it outputs a modified image, the contours and
 hierarchy. contours is a Python list of all the contours in the image. Each individual contour is a
@@ -49,18 +49,18 @@ drawing individual contour. To draw all contours, pass -1) and remaining argumen
 thickness etc.
 
 * To draw all the contours in an image:
-```python
+@code{.py}
 cv2.drawContours(img, contours, -1, (0,255,0), 3)
-```
+@endcode
 * To draw an individual contour, say 4th contour:
-```python
+@code{.py}
 cv2.drawContours(img, contours, 3, (0,255,0), 3)
-```
+@endcode
 * But most of the time, below method will be useful:
-```python
+@code{.py}
 cnt = contours[4]
 cv2.drawContours(img, [cnt], 0, (0,255,0), 3)
-```
+@endcode
 
 @note Last two methods are same, but when you go forward, you will see last one is more useful.
 


### PR DESCRIPTION
Since OpenCV v3.2, cv2.findContours() no longer modifies the source image but returns a modified image as the first of three return parameters.  ??? Do I have that correct ???

Also fixed up the code blocks to be valid markdown.

<!-- Please use this line to close one or multiple issues when this pullrequest gets merged
You can add another line right under the first one:
resolves #1234
resolves #1235
-->

### This pullrequest changes

Updates docs for the changes to cv2.findContours() since OpenCV v3.2

I can not find the 3.2 doc page that corresponds to http://docs.opencv.org/2.4/modules/imgproc/doc/structural_analysis_and_shape_descriptors.html#cv2.findContours
