### PR TITLE
Allocate 1000 floats to match the documentation

### DIFF
--- a/modules/core/include/opencv2/core/utility.hpp
+++ b/modules/core/include/opencv2/core/utility.hpp
@@ -102,7 +102,7 @@ CV_EXPORTS void setUseCollection(bool flag); // set implementation collection st
  \code
  void my_func(const cv::Mat& m)
  {
-    cv::AutoBuffer<float> buf; // create automatic buffer containing 1000 floats
+    cv::AutoBuffer<float> buf(1000); // create automatic buffer containing 1000 floats
 
     buf.allocate(m.rows); // if m.rows <= 1000, the pre-allocated buffer is used,
                           // otherwise the buffer of "m.rows" floats will be allocated


### PR DESCRIPTION
Fix the documentation of `AutoBuffer`. By default, the following code
```.cpp
cv::AutoBuffer<float> m;
```` 
allocates only 264 floats. But the comment in the demonstration code says it allocates 1000 floats, which is 
not correct.

<!-- Please use this line to close one or multiple issues when this pullrequest gets merged
You can add another line right under the first one:
resolves #1234
resolves #1235
-->

### This pullrequest changes

Change the demo code for `AutoBuffer` to match its comment.

<!-- Please describe what your pullrequest is changing -->
