### PR TITLE
Update ocl.hpp, remove Device::OpenCLVersion()

### DIFF
--- a/modules/core/include/opencv2/core/ocl.hpp
+++ b/modules/core/include/opencv2/core/ocl.hpp
@@ -94,7 +94,6 @@ public:
     String version() const;
     String vendorName() const;
     String OpenCL_C_Version() const;
-    String OpenCLVersion() const;
     int deviceVersionMajor() const;
     int deviceVersionMinor() const;
     String driverVersion() const;

--- a/modules/core/src/ocl.cpp
+++ b/modules/core/src/ocl.cpp
@@ -1934,9 +1934,6 @@ int Device::vendorID() const
 String Device::OpenCL_C_Version() const
 { return p ? p->getStrProp(CL_DEVICE_OPENCL_C_VERSION) : String(); }
 
-String Device::OpenCLVersion() const
-{ return p ? p->getStrProp(CL_DEVICE_EXTENSIONS) : String(); }
-
 int Device::deviceVersionMajor() const
 { return p ? p->deviceVersionMajor_ : 0; }
 


### PR DESCRIPTION
Removing Member Function declaration for OpenCLVersion(). This function queries the same information as Device::version() does. Hence it is advisable to remove.

<!-- Please use this line to close one or multiple issues when this pullrequest gets merged
You can add another line right under the first one:
resolves #1234
resolves #1235
-->

### This pullrequest changes

<!-- Please describe what your pullrequest is changing -->
