### PR TITLE
Update ocl.cpp, removed Device::OpenCLVersion()

### DIFF
--- a/modules/core/src/ocl.cpp
+++ b/modules/core/src/ocl.cpp
@@ -1934,9 +1934,6 @@ int Device::vendorID() const
 String Device::OpenCL_C_Version() const
 { return p ? p->getStrProp(CL_DEVICE_OPENCL_C_VERSION) : String(); }
 
-String Device::OpenCLVersion() const
-{ return p ? p->getStrProp(CL_DEVICE_EXTENSIONS) : String(); }
-
 int Device::deviceVersionMajor() const
 { return p ? p->deviceVersionMajor_ : 0; }
 


### PR DESCRIPTION
Device::version() is doing the same job of querying OpenCL Device for CL_DEVICE_VERSION hence there is no need for OpenCLVersion().

<!-- Please use this line to close one or multiple issues when this pullrequest gets merged
You can add another line right under the first one:
resolves #1234
resolves #1235
-->

### This pullrequest changes

<!-- Please describe what your pullrequest is changing -->
