### PR TITLE
imgproc HAL header inclusion moved to OpenVX HAL module

### DIFF
--- a/3rdparty/openvx/hal/openvx_hal.cpp
+++ b/3rdparty/openvx/hal/openvx_hal.cpp
@@ -1,4 +1,5 @@
 #include "openvx_hal.hpp"
+#include "opencv2/imgproc/hal/interface.h"
 
 #define IVX_HIDE_INFO_WARNINGS
 #include "ivx.hpp"

--- a/3rdparty/openvx/hal/openvx_hal.hpp
+++ b/3rdparty/openvx/hal/openvx_hal.hpp
@@ -2,7 +2,6 @@
 #define OPENCV_OPENVX_HAL_HPP_INCLUDED
 
 #include "opencv2/core/hal/interface.h"
-#include "opencv2/imgproc/hal/interface.h"
 
 #include "VX/vx.h"
 


### PR DESCRIPTION
### This pullrequest changes
imgproc HAL header inclusion moved from OpenVX HAL header to OpenVX HAL module in order to fix the build with enabled OpenVX HAL