### PR TITLE
Add support to print `cv::UMat`.

### DIFF
--- a/modules/core/include/opencv2/core/cvstd.inl.hpp
+++ b/modules/core/include/opencv2/core/cvstd.inl.hpp
@@ -183,6 +183,12 @@ std::ostream& operator << (std::ostream& out, const Mat& mtx)
     return out << Formatter::get()->format(mtx);
 }
 
+static inline
+std::ostream& operator << (std::ostream& out, const UMat& m)
+{
+    return out << m.getMat(ACCESS_READ);
+}
+
 template<typename _Tp> static inline
 std::ostream& operator << (std::ostream& out, const std::vector<Point_<_Tp> >& vec)
 {


### PR DESCRIPTION
Now a user can use `std::cout` to print an object of `cv::UMat` just like `cv::Mat`.

<!-- Please use this line to close one or multiple issues when this pullrequest gets merged
You can add another line right under the first one:
resolves #1234
resolves #1235
-->

### This pullrequest changes
Support to print `cv::UMat` with `std::cout`.

<!-- Please describe what your pullrequest is changing -->
