### PR TITLE
Update type_c.h to fix Issue #8192

### DIFF
--- a/modules/core/include/opencv2/core/types_c.h
+++ b/modules/core/include/opencv2/core/types_c.h
@@ -255,7 +255,7 @@ CV_INLINE double cvRandReal( CvRNG* rng )
  * is an extract from IPL headers.
  * Copyright (c) 1995 Intel Corporation.
  */
-#define IPL_DEPTH_SIGN 0x80000000
+#define IPL_DEPTH_SIGN (int)(0x80000000)
 
 #define IPL_DEPTH_1U     1
 #define IPL_DEPTH_8U     8


### PR DESCRIPTION
typecast internal macro definition IPL_DEPTH_SIGN to int type in order to allow OR or AND operations results in valid Integer Number and Recent Compiler Standards such as c++11 would consider this change valid and avoid Compiler Errors if IPL_DEPTH_* macros are used without typecasting to (int) or other data types.

This resolves issue #8192 

<!-- Please use this line to close one or multiple issues when this pullrequest gets merged
You can add another line right under the first one:
resolves #1234
resolves #1235
-->

### This pullrequest changes
type_c.h to have IPL_DEPTH_SIGN macro to be type casted to (int) data type as it is being used by other Macros and performed OR or AND with this.

<!-- Please describe what your pullrequest is changing -->
