### PR TITLE
python tutorial: Fix/add FLANN_INDEX_KDTREE, FLANN_INDEX_LSH initialisations

### DIFF
--- a/doc/py_tutorials/py_calib3d/py_epipolar_geometry/py_epipolar_geometry.markdown
+++ b/doc/py_tutorials/py_calib3d/py_epipolar_geometry/py_epipolar_geometry.markdown
@@ -86,7 +86,7 @@ kp1, des1 = sift.detectAndCompute(img1,None)
 kp2, des2 = sift.detectAndCompute(img2,None)
 
 # FLANN parameters
-FLANN_INDEX_KDTREE = 0
+FLANN_INDEX_KDTREE = 1
 index_params = dict(algorithm = FLANN_INDEX_KDTREE, trees = 5)
 search_params = dict(checks=50)
 

--- a/doc/py_tutorials/py_feature2d/py_feature_homography/py_feature_homography.markdown
+++ b/doc/py_tutorials/py_feature2d/py_feature_homography/py_feature_homography.markdown
@@ -50,7 +50,7 @@ sift = cv2.xfeatures2d.SIFT_create()
 kp1, des1 = sift.detectAndCompute(img1,None)
 kp2, des2 = sift.detectAndCompute(img2,None)
 
-FLANN_INDEX_KDTREE = 0
+FLANN_INDEX_KDTREE = 1
 index_params = dict(algorithm = FLANN_INDEX_KDTREE, trees = 5)
 search_params = dict(checks = 50)
 

--- a/doc/py_tutorials/py_feature2d/py_matcher/py_matcher.markdown
+++ b/doc/py_tutorials/py_feature2d/py_matcher/py_matcher.markdown
@@ -148,11 +148,13 @@ its related parameters etc. First one is IndexParams. For various algorithms, th
 passed is explained in FLANN docs. As a summary, for algorithms like SIFT, SURF etc. you can pass
 following:
 @code{.py}
+FLANN_INDEX_KDTREE = 1
 index_params = dict(algorithm = FLANN_INDEX_KDTREE, trees = 5)
 @endcode
 While using ORB, you can pass the following. The commented values are recommended as per the docs,
 but it didn't provide required results in some cases. Other values worked fine.:
 @code{.py}
+FLANN_INDEX_LSH = 6
 index_params= dict(algorithm = FLANN_INDEX_LSH,
                    table_number = 6, # 12
                    key_size = 12,     # 20
@@ -179,7 +181,7 @@ kp1, des1 = sift.detectAndCompute(img1,None)
 kp2, des2 = sift.detectAndCompute(img2,None)
 
 # FLANN parameters
-FLANN_INDEX_KDTREE = 0
+FLANN_INDEX_KDTREE = 1
 index_params = dict(algorithm = FLANN_INDEX_KDTREE, trees = 5)
 search_params = dict(checks=50)   # or pass empty dictionary
 


### PR DESCRIPTION
Add initialisations to make clear what values actually have to be passed.

Moreover, in accordance with [modules/flann/include/opencv2/flann/defines.h](https://github.com/opencv/opencv/blob/383559c2285baaf3df8cf0088072d104451a30ce/modules/flann/include/opencv2/flann/defines.h#L68) , I believe `FLANN_INDEX_KDTREE` was being initialised wrongly in the code example, 1 should be correct, whereas 0 is `FLANN_INDEX_LINEAR`.

(I apologise that this pull request has three commits, one for each file, I don't know how to smash them on github (as opposed to locally)) 

<!-- Please use this line to close one or multiple issues when this pullrequest gets merged
You can add another line right under the first one:
resolves #1234
resolves #1235
-->

### This pullrequest changes

<!-- Please describe what your pullrequest is changing -->