### PR TITLE
Features/python/generic types

### DIFF
--- a/modules/python/src2/cv2.cpp
+++ b/modules/python/src2/cv2.cpp
@@ -467,11 +467,11 @@ PYOBJ_FROM_MAT(Matx23d)
 PYOBJ_FROM_MAT(Matx23f)
 PYOBJ_FROM_MAT(Matx22d)
 PYOBJ_FROM_MAT(Matx22f)
-PYOBJ_FROM_MAT(Vec4d)
+PYOBJ_FROM_MAT(Scalar) //Vec4d
 PYOBJ_FROM_MAT(Vec4f)
-//PYOBJ_FROM_MAT(Vec3d)
+PYOBJ_FROM_MAT(Vec3d)
 PYOBJ_FROM_MAT(Vec3f)
-//PYOBJ_FROM_MAT(Vec2d)
+PYOBJ_FROM_MAT(Vec2d)
 PYOBJ_FROM_MAT(Vec2f)
 
 PYOBJ_TO_MAT(Matx44d)
@@ -484,9 +484,9 @@ PYOBJ_TO_MAT(Matx23d)
 PYOBJ_TO_MAT(Matx23f)
 PYOBJ_TO_MAT(Matx22d)
 PYOBJ_TO_MAT(Matx22f)
-//PYOBJ_TO_MAT(Vec4d) //Conflicts with: pyopencv_to(PyObject *, Scalar&, const char *)
+PYOBJ_TO_MAT(Scalar) //Vec4d
 PYOBJ_TO_MAT(Vec4f)
-//PYOBJ_TO_MAT(Vec3d)
+PYOBJ_TO_MAT(Vec3d)
 PYOBJ_TO_MAT(Vec3f)
 PYOBJ_TO_MAT(Vec2d)
 PYOBJ_TO_MAT(Vec2f)
@@ -678,47 +678,6 @@ PyObject* pyopencv_from(const UMat& m) {
     PyObject *o = PyObject_CallObject((PyObject *) &cv2_UMatWrapperType, NULL);
     *((cv2_UMatWrapperObject *) o)->um = m;
     return o;
-}
-
-template<>
-bool pyopencv_to(PyObject *o, Scalar& s, const char *name)
-{
-    if(!o || o == Py_None)
-        return true;
-    if (PySequence_Check(o)) {
-        PyObject *fi = PySequence_Fast(o, name);
-        if (fi == NULL)
-            return false;
-        if (4 < PySequence_Fast_GET_SIZE(fi))
-        {
-            failmsg("Scalar value for argument '%s' is longer than 4", name);
-            return false;
-        }
-        for (Py_ssize_t i = 0; i < PySequence_Fast_GET_SIZE(fi); i++) {
-            PyObject *item = PySequence_Fast_GET_ITEM(fi, i);
-            if (PyFloat_Check(item) || PyInt_Check(item)) {
-                s[(int)i] = PyFloat_AsDouble(item);
-            } else {
-                failmsg("Scalar value for argument '%s' is not numeric", name);
-                return false;
-            }
-        }
-        Py_DECREF(fi);
-    } else {
-        if (PyFloat_Check(o) || PyInt_Check(o)) {
-            s[0] = PyFloat_AsDouble(o);
-        } else {
-            failmsg("Scalar value for argument '%s' is not numeric", name);
-            return false;
-        }
-    }
-    return true;
-}
-
-template<>
-PyObject* pyopencv_from(const Scalar& src)
-{
-    return Py_BuildValue("(dddd)", src[0], src[1], src[2], src[3]);
 }
 
 template<>
@@ -1004,27 +963,6 @@ template<>
 PyObject* pyopencv_from(const Point3f& p)
 {
     return Py_BuildValue("(ddd)", p.x, p.y, p.z);
-}
-
-template<>
-bool pyopencv_to(PyObject* obj, Vec3d& v, const char* name)
-{
-    (void)name;
-    if(!obj)
-        return true;
-    return PyArg_ParseTuple(obj, "ddd", &v[0], &v[1], &v[2]) > 0;
-}
-
-template<>
-PyObject* pyopencv_from(const Vec3d& v)
-{
-    return Py_BuildValue("(ddd)", v[0], v[1], v[2]);
-}
-
-template<>
-PyObject* pyopencv_from(const Vec2d& v)
-{
-    return Py_BuildValue("(dd)", v[0], v[1]);
 }
 
 template<>

--- a/modules/python/test/test_types.py
+++ b/modules/python/test/test_types.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python
+
+'''
+Vector binding types
+'''
+
+# Python 2/3 compatibility
+from __future__ import print_function
+
+import numpy as np
+import cv2
+
+from tests_common import NewOpenCVTests
+
+class types_test(NewOpenCVTests):
+
+    def setUp(self):
+        self.valid_scalars = [
+            None, #Default argument
+            0, (0), (0, 0), (0, 0, 0), (0, 0, 0, 0),
+            np.array([0]), np.array([0, 0]), np.array([0, 0, 0]), np.array([0, 0, 0, 0]),
+            np.zeros((1, 1)), np.zeros((1, 2)), np.zeros((1, 3)), np.zeros((1, 4)),
+            np.zeros((2, 1)), np.zeros((3, 1)), np.zeros((4, 1)),
+        ]
+
+        self.invalid_scalars = [
+            '', (0, ''), (0, 0, 0, 0, 0),
+        ]
+
+        self.scalar_values = range(0, 256)
+
+        self.width = 10
+        self.pt1 = (0, 0)
+        self.pt2 = (self.width - 1, self.width - 1)
+        self.img = np.ones((self.width, self.width), np.uint8)
+        self.returned_scalar = cv2.mean(self.img)
+
+    def test_types_setting_valid_scalars(self):
+
+        for scalar in self.valid_scalars:
+            try:
+                cv2.line(self.img, self.pt1, self.pt2, scalar)
+            except:
+                self.assertTrue(False,
+                    "Valid scalar was rejected!"
+                    "\tType: {0}\n"
+                    "\tValue: {1}".format(type(scalar).__name__, scalar))
+            self.assertTrue(np.trace(self.img) == 0, "Unexpected trace value")
+            expected_count = self.width * (self.width - 1)
+            count = np.count_nonzero(self.img)
+            self.assertTrue(count == expected_count,
+                "Expected non-zero elements count of {0}, got {1}".format(expected_count, count))
+
+    def test_types_setting_invalid_scalars(self):
+
+        for scalar in self.invalid_scalars:
+            try:
+                cv2.line(self.img, self.pt1, self.pt2, scalar)
+            except:
+                continue
+            self.assertTrue(False,
+                "Invalid scalar was accepted!\n"
+                "\tType: {0}\n"
+                "\tValue: {1}".format(type(scalar).__name__, scalar))
+
+    def test_types_getter(self):
+
+        length = len(self.returned_scalar)
+        self.assertTrue(length == 4,
+            "Expected scalar length of 4, got {0}".format(length))
+        for i in range(4):
+            expected_mean = (i == 0) * 1
+            self.assertTrue(self.returned_scalar[i] == expected_mean,
+                "Expected mean value of {0}, got {1}".format(expected_mean, self.returned_scalar[i]))
+
+    def test_types_setter(self):
+        try:
+            self.test_types_setting_valid_scalars()
+        except:
+            self.skipTest("Expected setting valid scalars to pass first")
+
+        for scalar in self.scalar_values:
+            cv2.line(self.img, self.pt1, self.pt2, scalar)
+            expected_trace = self.width * scalar
+            expected_count = self.width * (self.width if scalar else self.width - 1)
+            trace = np.trace(self.img)
+            count = np.count_nonzero(self.img)
+            self.assertTrue(trace == expected_trace,
+                "Expected trace value of {0}, got {1}".format(expected_trace, trace))
+            self.assertTrue(count == expected_count,
+                "Expected non-zero elements count of {0}, got {1}".format(expected_count, count))
+
+if __name__ == '__main__':
+    import unittest
+    unittest.main()


### PR DESCRIPTION
Removes old binders and utilize the generic ones introduced in PR #8319.
The new binders' behavior is guaranteed to be backward-compatible based on the provided tests.

### This pullrequest changes
- Removes old bindings
- Tests the behavior for backward-compatibility

### What is the problem with the in-use bindings?
- Only some vector are supported
- They are implemented in different ways, hence non-uniform behavior
- They accept only tuples (hard-coded)! Numpy arrays are rejected