### PR TITLE
Solve issue #8264

### DIFF
--- a/samples/cpp/tutorial_code/calib3d/camera_calibration/camera_calibration.cpp
+++ b/samples/cpp/tutorial_code/calib3d/camera_calibration/camera_calibration.cpp
@@ -101,7 +101,7 @@ public:
             }
             else
             {
-                if (readStringList(input, imageList))
+                if (isListOfImages(input) && readStringList(input, imageList))
                     {
                         inputType = IMAGE_LIST;
                         nrFrames = (nrFrames < (int)imageList.size()) ? nrFrames : (int)imageList.size();
@@ -168,6 +168,16 @@ public:
         for( ; it != it_end; ++it )
             l.push_back((string)*it);
         return true;
+    }
+
+    static bool isListOfImages( const string& filename)
+    {
+        string s(filename);
+        // Look for file extension
+        if( s.find(".xml") == string::npos && s.find(".yaml") == string::npos && s.find(".yml") == string::npos )
+            return false;
+        else
+            return true;
     }
 public:
     Size boardSize;            // The size of the board -> Number of items by width and height


### PR DESCRIPTION
Fix bug in camera_calibration.cpp that the program tries to parse input of type VIDEO_FILE as IMAGE_LIST which causes the program to crash.

<!-- Please use this line to close one or multiple issues when this pullrequest gets merged
You can add another line right under the first one:
resolves #1234
resolves #1235
-->
resolves #8264 

### This pullrequest changes

<!-- Please describe what your pullrequest is changing -->
Add a function to judge if the input file is a XML/YAML file. If not, the file will not be parsed as image list.