### PR TITLE
Add AVMediaTypeMuxed capture devices to AVFoundation, just as QTKit d…

### DIFF
--- a/modules/videoio/src/cap_avfoundation.mm
+++ b/modules/videoio/src/cap_avfoundation.mm
@@ -317,7 +317,8 @@ int CvCaptureCAM::startCaptureDevice(int cameraNum) {
     capture = [[CaptureDelegate alloc] init];
 
     AVCaptureDevice *device;
-    NSArray* devices = [AVCaptureDevice devicesWithMediaType:AVMediaTypeVideo];
+    NSArray* devices = [[AVCaptureDevice devicesWithMediaType:AVMediaTypeVideo]
+            arrayByAddingObjectsFromArray:[AVCaptureDevice devicesWithMediaType:AVMediaTypeMuxed]];
     if ([devices count] == 0) {
         std::cout << "AV Foundation didn't find any attached Video Input Devices!" << std::endl;
         [localpool drain];

--- a/modules/videoio/src/cap_avfoundation_mac.mm
+++ b/modules/videoio/src/cap_avfoundation_mac.mm
@@ -305,7 +305,8 @@ int CvCaptureCAM::startCaptureDevice(int cameraNum) {
     NSAutoreleasePool *localpool = [[NSAutoreleasePool alloc] init];
 
     // get capture device
-    NSArray *devices = [AVCaptureDevice devicesWithMediaType: AVMediaTypeVideo];
+    NSArray *devices = [[AVCaptureDevice devicesWithMediaType: AVMediaTypeVideo]
+            arrayByAddingObjectsFromArray:[AVCaptureDevice devicesWithMediaType:AVMediaTypeMuxed]];
 
     if ( devices.count == 0 ) {
         fprintf(stderr, "OpenCV: AVFoundation didn't find any attached Video Input Devices!\n");


### PR DESCRIPTION
…oes.

<!-- Please use this line to close one or multiple issues when this pullrequest gets merged
You can add another line right under the first one:
resolves #1234
resolves #1235
-->

### This pullrequest changes

<!-- Please describe what your pullrequest is changing -->
Firewire camcorders appeared in the list of video capture devices in OpenCV 3.1.0, but are missing in 3.2.0.  3.1.0 used QTKit, 3.2.0 uses AVFoundation.  This fix adds AVMediaTypeMuxed capture devices to the AVFoundation code, just as the QTKit code does.