### PR TITLE
Change the value of bit/pixel from channels to 8*channels because vid…

### DIFF
--- a/modules/videoio/src/cap_mjpeg_encoder.cpp
+++ b/modules/videoio/src/cap_mjpeg_encoder.cpp
@@ -720,7 +720,7 @@ public:
         strm.putInt(height);
         strm.putShort(1); // planes (1 means interleaved data (after decompression))
 
-        strm.putShort(channels); // bits per pixel
+        strm.putShort(8 * channels); // bits per pixel
         strm.putInt(fourCC('M', 'J', 'P', 'G'));
         strm.putInt(width * height * channels);
         strm.putInt(0);


### PR DESCRIPTION
resolves #8113 

### This pullrequest changes

I updated the value of bit/pixel from 3 to 24 because videos encoded with cap_mjpeg_encoder.cpp don't play on windows media player
