### PR TITLE
fix medianBlur accessviolation

### DIFF
--- a/modules/imgproc/src/smooth.cpp
+++ b/modules/imgproc/src/smooth.cpp
@@ -3494,7 +3494,7 @@ void cv::medianBlur( InputArray _src0, OutputArray _dst, int ksize )
 
     CV_Assert( (ksize % 2 == 1) && (_src0.dims() <= 2 ));
 
-    if( ksize <= 1 )
+    if( ksize <= 1 || _src0.empty() )
     {
         _src0.copyTo(_dst);
         return;


### PR DESCRIPTION
medianBlur called with "empty" source and ksize >= 7 crashes application with accessviolation. With this extra assert this is avoided and the application may normally catch the thrown exception.

resolves #8287

This pullrequest adds an assert to assure that a specific pointer is valid.
