### PR TITLE
Fix stitching failure

### DIFF
--- a/modules/flann/include/opencv2/flann/kdtree_index.h
+++ b/modules/flann/include/opencv2/flann/kdtree_index.h
@@ -125,7 +125,12 @@ public:
         /* Construct the randomized trees. */
         for (int i = 0; i < trees_; i++) {
             /* Randomize the order of vectors to allow for unbiased sampling. */
+#ifndef OPENCV_FLANN_USE_STD_RAND
+            cv::randShuffle(vind_);
+#else
             std::random_shuffle(vind_.begin(), vind_.end());
+#endif
+
             tree_roots_[i] = divideTree(&vind_[0], int(size_) );
         }
     }

--- a/modules/flann/include/opencv2/flann/lsh_table.h
+++ b/modules/flann/include/opencv2/flann/lsh_table.h
@@ -350,7 +350,11 @@ inline LshTable<unsigned char>::LshTable(unsigned int feature_size, unsigned int
     // A bit brutal but fast to code
     std::vector<size_t> indices(feature_size * CHAR_BIT);
     for (size_t i = 0; i < feature_size * CHAR_BIT; ++i) indices[i] = i;
+#ifndef OPENCV_FLANN_USE_STD_RAND
+    cv::randShuffle(indices);
+#else
     std::random_shuffle(indices.begin(), indices.end());
+#endif
 
     // Generate a random set of order of subsignature_size_ bits
     for (unsigned int i = 0; i < key_size_; ++i) {

--- a/modules/flann/include/opencv2/flann/random.h
+++ b/modules/flann/include/opencv2/flann/random.h
@@ -40,13 +40,31 @@
 namespace cvflann
 {
 
+inline int rand()
+{
+#ifndef OPENCV_FLANN_USE_STD_RAND
+#   if INT_MAX == RAND_MAX
+    int v = cv::theRNG().next() & INT_MAX;
+#   else
+    int v = cv::theRNG().uniform(0, RAND_MAX + 1);
+#   endif
+#else
+    int v = std::rand();
+#endif // OPENCV_FLANN_USE_STD_RAND
+    return v;
+}
+
 /**
  * Seeds the random number generator
  *  @param seed Random seed
  */
 inline void seed_random(unsigned int seed)
 {
-    srand(seed);
+#ifndef OPENCV_FLANN_USE_STD_RAND
+    cv::theRNG() = cv::RNG(seed);
+#else
+    std::srand(seed);
+#endif
 }
 
 /*
@@ -60,7 +78,7 @@ inline void seed_random(unsigned int seed)
  */
 inline double rand_double(double high = 1.0, double low = 0)
 {
-    return low + ((high-low) * (std::rand() / (RAND_MAX + 1.0)));
+    return low + ((high-low) * (rand() / (RAND_MAX + 1.0)));
 }
 
 /**
@@ -71,7 +89,7 @@ inline double rand_double(double high = 1.0, double low = 0)
  */
 inline int rand_int(int high = RAND_MAX, int low = 0)
 {
-    return low + (int) ( double(high-low) * (std::rand() / (RAND_MAX + 1.0)));
+    return low + (int) ( double(high-low) * (rand() / (RAND_MAX + 1.0)));
 }
 
 /**
@@ -107,7 +125,11 @@ public:
         for (int i = 0; i < size_; ++i) vals_[i] = i;
 
         // shuffle the elements in the array
+#ifndef OPENCV_FLANN_USE_STD_RAND
+        cv::randShuffle(vals_);
+#else
         std::random_shuffle(vals_.begin(), vals_.end());
+#endif
 
         counter_ = 0;
     }

--- a/modules/stitching/perf/perf_stich.cpp
+++ b/modules/stitching/perf/perf_stich.cpp
@@ -2,6 +2,8 @@
 #include "opencv2/imgcodecs.hpp"
 #include "opencv2/opencv_modules.hpp"
 
+#include "opencv2/core/ocl.hpp"
+
 using namespace std;
 using namespace cv;
 using namespace perf;
@@ -160,6 +162,9 @@ PERF_TEST_P(stitchDatasets, affine, testing::Combine(AFFINE_DATASETS, TEST_DETEC
     {
         Ptr<Stitcher> stitcher = Stitcher::create(Stitcher::SCANS, false);
         stitcher->setFeaturesFinder(featuresFinder);
+
+        if (cv::ocl::useOpenCL())
+            cv::theRNG() = cv::RNG(12345); // prevent fails of Windows OpenCL builds (see #8294)
 
         startTimer();
         stitcher->stitch(imgs, pano);

--- a/modules/stitching/src/matchers.cpp
+++ b/modules/stitching/src/matchers.cpp
@@ -70,9 +70,12 @@ struct MatchPairsBody : ParallelLoopBody
 
     void operator ()(const Range &r) const
     {
+        cv::RNG rng = cv::theRNG(); // save entry rng state
         const int num_images = static_cast<int>(features.size());
         for (int i = r.start; i < r.end; ++i)
         {
+            cv::theRNG() = cv::RNG(rng.state + i); // force "stable" RNG seed for each processed pair
+
             int from = near_pairs[i].first;
             int to = near_pairs[i].second;
             int pair_idx = from*num_images + to;


### PR DESCRIPTION
**Merge after:** #8293

Eliminate uncontrolled randomness in stitching multi-threaded code.

It still depends on initial RNG seed value, so provided results may be different. But results with same initial seed should be equal.