### PR TITLE
Fix issue #8280: "fastmath.h related compile errors with Embarcadero C++ Builder 10.1"

### DIFF
--- a/modules/core/include/opencv2/core/cvdef.h
+++ b/modules/core/include/opencv2/core/cvdef.h
@@ -438,7 +438,7 @@ Cv64suf;
 
 #ifdef CV_XADD
   // allow to use user-defined macro
-#elif defined __GNUC__
+#elif defined __GNUC__ || defined __clang__
 #  if defined __clang__ && __clang_major__ >= 3 && !defined __ANDROID__ && !defined __EMSCRIPTEN__ && !defined(__CUDACC__)
 #    ifdef __ATOMIC_ACQ_REL
 #      define CV_XADD(addr, delta) __c11_atomic_fetch_add((_Atomic(int)*)(addr), delta, __ATOMIC_ACQ_REL)

--- a/modules/core/include/opencv2/core/fast_math.hpp
+++ b/modules/core/include/opencv2/core/fast_math.hpp
@@ -54,12 +54,14 @@
 *                                      fast math                                         *
 \****************************************************************************************/
 
-#if defined __BORLANDC__
-#  include <fastmath.h>
-#elif defined __cplusplus
+#ifdef __cplusplus
 #  include <cmath>
 #else
-#  include <math.h>
+#  ifdef __BORLANDC__
+#    include <fastmath.h>
+#  else
+#    include <math.h>
+#  endif
 #endif
 
 #ifdef HAVE_TEGRA_OPTIMIZATION


### PR DESCRIPTION
Fix issue #8280: "fastmath.h related compile errors with Embarcadero C++ Builder 10.1"

resolves #8280
resolves #8278

### This pullrequest changes

Include fastmath.h only when __cplusplus is not defined.
