### PR TITLE
Improved documentation for Mat

### DIFF
--- a/modules/core/include/opencv2/core/mat.hpp
+++ b/modules/core/include/opencv2/core/mat.hpp
@@ -1970,9 +1970,11 @@ public:
     //! pointer to the data
     uchar* data;
 
-    //! helper fields used in locateROI and adjustROI
+    //! beginning of (parent) matrix -> needed when submatrix
     const uchar* datastart;
+    //! end of (parent) matrix -> needed when submatrix
     const uchar* dataend;
+    //! end of allocated data (might be after dataend because of alignment area)
     const uchar* datalimit;
 
     //! custom allocator


### PR DESCRIPTION
Added documentation for members `Mat::datastart`, `Mat::dataend`, `Mat::datalimit`.

Can somebody please review if the definition of `datalimit` is correct?
Depending on the answer, [this line](https://github.com/opencv/opencv/blob/master/modules/core/src/matrix.cpp#L839) should be changed accordingly → **yes:** replace `dataend` by `datalimit`, **no:** remove comment

resolves #8304
