### PR TITLE
Updated OpenCVFindMKL.cmake

### DIFF
--- a/cmake/OpenCVFindMKL.cmake
+++ b/cmake/OpenCVFindMKL.cmake
@@ -48,7 +48,7 @@ endif()
 #check current MKL_ROOT_DIR
 if(NOT MKL_ROOT_DIR OR NOT EXISTS ${MKL_ROOT_DIR}/include/mkl.h)
     set(mkl_root_paths ${MKL_ROOT_DIR})
-    if(DEFINED $ENV{MKLROOT})
+    if(DEFINED ENV{MKLROOT})
         list(APPEND mkl_root_paths $ENV{MKLROOT})
     endif()
     if(WIN32)


### PR DESCRIPTION
Current version of search for MLKROOT environment variable is wrong and should be corrected to (DEFINED ENV{MKLROOT})
Current version isn't working under Linux if MKL is situated in custom folder.

<!-- Please use this line to close one or multiple issues when this pullrequest gets merged
You can add another line right under the first one:
resolves #1234
resolves #1235
-->

### This pullrequest changes
OpenCVFindMKL.cmake and search strategy for MKL libraries.

<!-- Please describe what your pullrequest is changing -->
