### PR TITLE
QT: disable debug output in Release mode

### DIFF
--- a/modules/highgui/src/window_QT.h
+++ b/modules/highgui/src/window_QT.h
@@ -42,6 +42,10 @@
 
 #include "precomp.hpp"
 
+#ifndef _DEBUG
+#define QT_NO_DEBUG_OUTPUT
+#endif
+
 #if defined( HAVE_QT_OPENGL )
 #include <QtOpenGL>
 #include <QGLWidget>


### PR DESCRIPTION
Get rid of annoying message `init done` when QT is used as highgui backend.