### PR TITLE
Fixes/python wrapper/flann

### DIFF
--- a/modules/flann/misc/python/pyopencv_flann.hpp
+++ b/modules/flann/misc/python/pyopencv_flann.hpp
@@ -23,6 +23,9 @@ bool pyopencv_to(PyObject *o, cv::flann::IndexParams& p, const char *name)
     PyObject* item = NULL;
     Py_ssize_t pos = 0;
 
+    if (!o || o == Py_None)
+        return true;
+
     if(PyDict_Check(o)) {
         while(PyDict_Next(o, &pos, &key, &item)) {
             if( !PyString_Check(key) ) {


### PR DESCRIPTION
resolves #4296

Currently, executing a code like this in Python will cause a crash:
```py
flann_params = dict(algorithm=0, trees=4)
matcher = cv2.FlannBasedMatcher(flann_params)
```

And the widely used workaround is to pass an empty `dict` as a second argument 
```py
flann_params = dict(algorithm=0, trees=4)
matcher = cv2.FlannBasedMatcher(flann_params, {})
```

This needs to be corrected in a similar way to other wrappers!

### This pullrequest changes
- Makes the FLANN index parameters optional (as per the documentation)