### PR TITLE
Mark search functions as const

### DIFF
--- a/modules/flann/include/opencv2/flann.hpp
+++ b/modules/flann/include/opencv2/flann.hpp
@@ -214,13 +214,13 @@ public:
         @param params SearchParams
          */
         void knnSearch(const std::vector<ElementType>& query, std::vector<int>& indices,
-                       std::vector<DistanceType>& dists, int knn, const ::cvflann::SearchParams& params);
-        void knnSearch(const Mat& queries, Mat& indices, Mat& dists, int knn, const ::cvflann::SearchParams& params);
+                       std::vector<DistanceType>& dists, int knn, const ::cvflann::SearchParams& params) const;
+        void knnSearch(const Mat& queries, Mat& indices, Mat& dists, int knn, const ::cvflann::SearchParams& params) const;
 
         int radiusSearch(const std::vector<ElementType>& query, std::vector<int>& indices,
-                         std::vector<DistanceType>& dists, DistanceType radius, const ::cvflann::SearchParams& params);
+                         std::vector<DistanceType>& dists, DistanceType radius, const ::cvflann::SearchParams& params) const;
         int radiusSearch(const Mat& query, Mat& indices, Mat& dists,
-                         DistanceType radius, const ::cvflann::SearchParams& params);
+                         DistanceType radius, const ::cvflann::SearchParams& params) const;
 
         void save(String filename) { nnIndex->save(filename); }
 
@@ -268,7 +268,7 @@ GenericIndex<Distance>::~GenericIndex()
 }
 
 template <typename Distance>
-void GenericIndex<Distance>::knnSearch(const std::vector<ElementType>& query, std::vector<int>& indices, std::vector<DistanceType>& dists, int knn, const ::cvflann::SearchParams& searchParams)
+void GenericIndex<Distance>::knnSearch(const std::vector<ElementType>& query, std::vector<int>& indices, std::vector<DistanceType>& dists, int knn, const ::cvflann::SearchParams& searchParams) const
 {
     ::cvflann::Matrix<ElementType> m_query((ElementType*)&query[0], 1, query.size());
     ::cvflann::Matrix<int> m_indices(&indices[0], 1, indices.size());
@@ -281,7 +281,7 @@ void GenericIndex<Distance>::knnSearch(const std::vector<ElementType>& query, st
 
 
 template <typename Distance>
-void GenericIndex<Distance>::knnSearch(const Mat& queries, Mat& indices, Mat& dists, int knn, const ::cvflann::SearchParams& searchParams)
+void GenericIndex<Distance>::knnSearch(const Mat& queries, Mat& indices, Mat& dists, int knn, const ::cvflann::SearchParams& searchParams) const
 {
     CV_Assert(queries.type() == CvType<ElementType>::type());
     CV_Assert(queries.isContinuous());
@@ -301,7 +301,7 @@ void GenericIndex<Distance>::knnSearch(const Mat& queries, Mat& indices, Mat& di
 }
 
 template <typename Distance>
-int GenericIndex<Distance>::radiusSearch(const std::vector<ElementType>& query, std::vector<int>& indices, std::vector<DistanceType>& dists, DistanceType radius, const ::cvflann::SearchParams& searchParams)
+int GenericIndex<Distance>::radiusSearch(const std::vector<ElementType>& query, std::vector<int>& indices, std::vector<DistanceType>& dists, DistanceType radius, const ::cvflann::SearchParams& searchParams) const
 {
     ::cvflann::Matrix<ElementType> m_query((ElementType*)&query[0], 1, query.size());
     ::cvflann::Matrix<int> m_indices(&indices[0], 1, indices.size());
@@ -313,7 +313,7 @@ int GenericIndex<Distance>::radiusSearch(const std::vector<ElementType>& query, 
 }
 
 template <typename Distance>
-int GenericIndex<Distance>::radiusSearch(const Mat& query, Mat& indices, Mat& dists, DistanceType radius, const ::cvflann::SearchParams& searchParams)
+int GenericIndex<Distance>::radiusSearch(const Mat& query, Mat& indices, Mat& dists, DistanceType radius, const ::cvflann::SearchParams& searchParams) const
 {
     CV_Assert(query.type() == CvType<ElementType>::type());
     CV_Assert(query.isContinuous());
@@ -374,7 +374,7 @@ public:
         if (nnIndex_L2) delete nnIndex_L2;
     }
 
-    CV_DEPRECATED void knnSearch(const std::vector<ElementType>& query, std::vector<int>& indices, std::vector<DistanceType>& dists, int knn, const ::cvflann::SearchParams& searchParams)
+    CV_DEPRECATED void knnSearch(const std::vector<ElementType>& query, std::vector<int>& indices, std::vector<DistanceType>& dists, int knn, const ::cvflann::SearchParams& searchParams) const
     {
         ::cvflann::Matrix<ElementType> m_query((ElementType*)&query[0], 1, query.size());
         ::cvflann::Matrix<int> m_indices(&indices[0], 1, indices.size());
@@ -383,7 +383,7 @@ public:
         if (nnIndex_L1) nnIndex_L1->knnSearch(m_query,m_indices,m_dists,knn,searchParams);
         if (nnIndex_L2) nnIndex_L2->knnSearch(m_query,m_indices,m_dists,knn,searchParams);
     }
-    CV_DEPRECATED void knnSearch(const Mat& queries, Mat& indices, Mat& dists, int knn, const ::cvflann::SearchParams& searchParams)
+    CV_DEPRECATED void knnSearch(const Mat& queries, Mat& indices, Mat& dists, int knn, const ::cvflann::SearchParams& searchParams) const
     {
         CV_Assert(queries.type() == CvType<ElementType>::type());
         CV_Assert(queries.isContinuous());
@@ -401,7 +401,7 @@ public:
         if (nnIndex_L2) nnIndex_L2->knnSearch(m_queries,m_indices,m_dists,knn, searchParams);
     }
 
-    CV_DEPRECATED int radiusSearch(const std::vector<ElementType>& query, std::vector<int>& indices, std::vector<DistanceType>& dists, DistanceType radius, const ::cvflann::SearchParams& searchParams)
+    CV_DEPRECATED int radiusSearch(const std::vector<ElementType>& query, std::vector<int>& indices, std::vector<DistanceType>& dists, DistanceType radius, const ::cvflann::SearchParams& searchParams) const
     {
         ::cvflann::Matrix<ElementType> m_query((ElementType*)&query[0], 1, query.size());
         ::cvflann::Matrix<int> m_indices(&indices[0], 1, indices.size());
@@ -411,7 +411,7 @@ public:
         if (nnIndex_L2) return nnIndex_L2->radiusSearch(m_query,m_indices,m_dists,radius,searchParams);
     }
 
-    CV_DEPRECATED int radiusSearch(const Mat& query, Mat& indices, Mat& dists, DistanceType radius, const ::cvflann::SearchParams& searchParams)
+    CV_DEPRECATED int radiusSearch(const Mat& query, Mat& indices, Mat& dists, DistanceType radius, const ::cvflann::SearchParams& searchParams) const
     {
         CV_Assert(query.type() == CvType<ElementType>::type());
         CV_Assert(query.isContinuous());

--- a/modules/flann/include/opencv2/flann/autotuned_index.h
+++ b/modules/flann/include/opencv2/flann/autotuned_index.h
@@ -148,7 +148,7 @@ public:
     /**
      *      Method that searches for nearest-neighbors
      */
-    virtual void findNeighbors(ResultSet<DistanceType>& result, const ElementType* vec, const SearchParams& searchParams)
+    virtual void findNeighbors(ResultSet<DistanceType>& result, const ElementType* vec, const SearchParams& searchParams) const
     {
         int checks = get_param<int>(searchParams,"checks",FLANN_CHECKS_AUTOTUNED);
         if (checks == FLANN_CHECKS_AUTOTUNED) {

--- a/modules/flann/include/opencv2/flann/composite_index.h
+++ b/modules/flann/include/opencv2/flann/composite_index.h
@@ -172,7 +172,7 @@ public:
     /**
      * \brief Method that searches for nearest-neighbours
      */
-    void findNeighbors(ResultSet<DistanceType>& result, const ElementType* vec, const SearchParams& searchParams)
+    void findNeighbors(ResultSet<DistanceType>& result, const ElementType* vec, const SearchParams& searchParams) const
     {
         kmeans_index_->findNeighbors(result, vec, searchParams);
         kdtree_index_->findNeighbors(result, vec, searchParams);

--- a/modules/flann/include/opencv2/flann/flann_base.hpp
+++ b/modules/flann/include/opencv2/flann/flann_base.hpp
@@ -211,7 +211,7 @@ public:
      * \param[in] knn Number of nearest neighbors to return
      * \param[in] params Search parameters
      */
-    void knnSearch(const Matrix<ElementType>& queries, Matrix<int>& indices, Matrix<DistanceType>& dists, int knn, const SearchParams& params)
+    void knnSearch(const Matrix<ElementType>& queries, Matrix<int>& indices, Matrix<DistanceType>& dists, int knn, const SearchParams& params) const
     {
         nnIndex_->knnSearch(queries, indices, dists, knn, params);
     }
@@ -225,7 +225,7 @@ public:
      * \param[in] params Search parameters
      * \returns Number of neighbors found
      */
-    int radiusSearch(const Matrix<ElementType>& query, Matrix<int>& indices, Matrix<DistanceType>& dists, float radius, const SearchParams& params)
+    int radiusSearch(const Matrix<ElementType>& query, Matrix<int>& indices, Matrix<DistanceType>& dists, float radius, const SearchParams& params) const
     {
         return nnIndex_->radiusSearch(query, indices, dists, radius, params);
     }
@@ -233,7 +233,7 @@ public:
     /**
      * \brief Method that searches for nearest-neighbours
      */
-    void findNeighbors(ResultSet<DistanceType>& result, const ElementType* vec, const SearchParams& searchParams)
+    void findNeighbors(ResultSet<DistanceType>& result, const ElementType* vec, const SearchParams& searchParams) const
     {
         nnIndex_->findNeighbors(result, vec, searchParams);
     }

--- a/modules/flann/include/opencv2/flann/hierarchical_clustering_index.h
+++ b/modules/flann/include/opencv2/flann/hierarchical_clustering_index.h
@@ -544,7 +544,7 @@ public:
      *     vec = the vector for which to search the nearest neighbors
      *     searchParams = parameters that influence the search algorithm (checks)
      */
-    void findNeighbors(ResultSet<DistanceType>& result, const ElementType* vec, const SearchParams& searchParams)
+    void findNeighbors(ResultSet<DistanceType>& result, const ElementType* vec, const SearchParams& searchParams) const
     {
 
         int maxChecks = get_param(searchParams,"checks",32);
@@ -744,7 +744,7 @@ private:
 
 
     void findNN(NodePtr node, ResultSet<DistanceType>& result, const ElementType* vec, int& checks, int maxChecks,
-                Heap<BranchSt>* heap, std::vector<bool>& checked)
+                Heap<BranchSt>* heap, std::vector<bool>& checked) const
     {
         if (node->childs==NULL) {
             if (checks>=maxChecks) {

--- a/modules/flann/include/opencv2/flann/kdtree_index.h
+++ b/modules/flann/include/opencv2/flann/kdtree_index.h
@@ -201,7 +201,7 @@ public:
      *     vec = the vector for which to search the nearest neighbors
      *     maxCheck = the maximum number of restarts (in a best-bin-first manner)
      */
-    void findNeighbors(ResultSet<DistanceType>& result, const ElementType* vec, const SearchParams& searchParams)
+    void findNeighbors(ResultSet<DistanceType>& result, const ElementType* vec, const SearchParams& searchParams) const
     {
         int maxChecks = get_param(searchParams,"checks", 32);
         float epsError = 1+get_param(searchParams,"eps",0.0f);
@@ -421,7 +421,7 @@ private:
      * Performs an exact nearest neighbor search. The exact search performs a full
      * traversal of the tree.
      */
-    void getExactNeighbors(ResultSet<DistanceType>& result, const ElementType* vec, float epsError)
+    void getExactNeighbors(ResultSet<DistanceType>& result, const ElementType* vec, float epsError) const
     {
         //		checkID -= 1;  /* Set a different unique ID for each search. */
 
@@ -439,7 +439,7 @@ private:
      * because the tree traversal is abandoned after a given number of descends in
      * the tree.
      */
-    void getNeighbors(ResultSet<DistanceType>& result, const ElementType* vec, int maxCheck, float epsError)
+    void getNeighbors(ResultSet<DistanceType>& result, const ElementType* vec, int maxCheck, float epsError) const
     {
         int i;
         BranchSt branch;
@@ -470,7 +470,7 @@ private:
      *  at least "mindistsq".
      */
     void searchLevel(ResultSet<DistanceType>& result_set, const ElementType* vec, NodePtr node, DistanceType mindist, int& checkCount, int maxCheck,
-                     float epsError, Heap<BranchSt>* heap, DynamicBitset& checked)
+                     float epsError, Heap<BranchSt>* heap, DynamicBitset& checked) const
     {
         if (result_set.worstDist()<mindist) {
             //			printf("Ignoring branch, too far\n");
@@ -521,7 +521,7 @@ private:
     /**
      * Performs an exact search in the tree starting from a node.
      */
-    void searchLevelExact(ResultSet<DistanceType>& result_set, const ElementType* vec, const NodePtr node, DistanceType mindist, const float epsError)
+    void searchLevelExact(ResultSet<DistanceType>& result_set, const ElementType* vec, const NodePtr node, DistanceType mindist, const float epsError) const
     {
         /* If this is a leaf node, then do check and return. */
         if ((node->child1 == NULL)&&(node->child2 == NULL)) {

--- a/modules/flann/include/opencv2/flann/kdtree_single_index.h
+++ b/modules/flann/include/opencv2/flann/kdtree_single_index.h
@@ -209,7 +209,7 @@ public:
      * \param[in] knn Number of nearest neighbors to return
      * \param[in] params Search parameters
      */
-    void knnSearch(const Matrix<ElementType>& queries, Matrix<int>& indices, Matrix<DistanceType>& dists, int knn, const SearchParams& params)
+    void knnSearch(const Matrix<ElementType>& queries, Matrix<int>& indices, Matrix<DistanceType>& dists, int knn, const SearchParams& params) const
     {
         assert(queries.cols == veclen());
         assert(indices.rows >= queries.rows);
@@ -238,7 +238,7 @@ public:
      *     vec = the vector for which to search the nearest neighbors
      *     maxCheck = the maximum number of restarts (in a best-bin-first manner)
      */
-    void findNeighbors(ResultSet<DistanceType>& result, const ElementType* vec, const SearchParams& searchParams)
+    void findNeighbors(ResultSet<DistanceType>& result, const ElementType* vec, const SearchParams& searchParams) const
     {
         float epsError = 1+get_param(searchParams,"eps",0.0f);
 
@@ -518,7 +518,7 @@ private:
         lim2 = left;
     }
 
-    DistanceType computeInitialDistances(const ElementType* vec, std::vector<DistanceType>& dists)
+    DistanceType computeInitialDistances(const ElementType* vec, std::vector<DistanceType>& dists) const
     {
         DistanceType distsq = 0.0;
 
@@ -540,7 +540,7 @@ private:
      * Performs an exact search in the tree starting from a node.
      */
     void searchLevel(ResultSet<DistanceType>& result_set, const ElementType* vec, const NodePtr node, DistanceType mindistsq,
-                     std::vector<DistanceType>& dists, const float epsError)
+                     std::vector<DistanceType>& dists, const float epsError) const
     {
         /* If this is a leaf node, then do check and return. */
         if ((node->child1 == NULL)&&(node->child2 == NULL)) {

--- a/modules/flann/include/opencv2/flann/kmeans_index.h
+++ b/modules/flann/include/opencv2/flann/kmeans_index.h
@@ -495,7 +495,7 @@ public:
      *     vec = the vector for which to search the nearest neighbors
      *     searchParams = parameters that influence the search algorithm (checks, cb_index)
      */
-    void findNeighbors(ResultSet<DistanceType>& result, const ElementType* vec, const SearchParams& searchParams)
+    void findNeighbors(ResultSet<DistanceType>& result, const ElementType* vec, const SearchParams& searchParams) const
     {
 
         int maxChecks = get_param(searchParams,"checks",32);
@@ -894,7 +894,7 @@ private:
 
 
     void findNN(KMeansNodePtr node, ResultSet<DistanceType>& result, const ElementType* vec, int& checks, int maxChecks,
-                Heap<BranchSt>* heap)
+                Heap<BranchSt>* heap) const
     {
         // Ignore those clusters that are too far away
         {
@@ -938,7 +938,7 @@ private:
      *     distances = array with the distances to each child node.
      * Returns:
      */
-    int exploreNodeBranches(KMeansNodePtr node, const ElementType* q, DistanceType* domain_distances, Heap<BranchSt>* heap)
+    int exploreNodeBranches(KMeansNodePtr node, const ElementType* q, DistanceType* domain_distances, Heap<BranchSt>* heap) const
     {
 
         int best_index = 0;
@@ -970,7 +970,7 @@ private:
     /**
      * Function the performs exact nearest neighbor search by traversing the entire tree.
      */
-    void findExactNN(KMeansNodePtr node, ResultSet<DistanceType>& result, const ElementType* vec)
+    void findExactNN(KMeansNodePtr node, ResultSet<DistanceType>& result, const ElementType* vec) const
     {
         // Ignore those clusters that are too far away
         {
@@ -1014,7 +1014,7 @@ private:
      *
      * I computes the order in which to traverse the child nodes of a particular node.
      */
-    void getCenterOrdering(KMeansNodePtr node, const ElementType* q, int* sort_indices)
+    void getCenterOrdering(KMeansNodePtr node, const ElementType* q, int* sort_indices) const
     {
         DistanceType* domain_distances = new DistanceType[branching_];
         for (int i=0; i<branching_; ++i) {

--- a/modules/flann/include/opencv2/flann/linear_index.h
+++ b/modules/flann/include/opencv2/flann/linear_index.h
@@ -103,7 +103,7 @@ public:
         index_params_["algorithm"] = getType();
     }
 
-    void findNeighbors(ResultSet<DistanceType>& resultSet, const ElementType* vec, const SearchParams& /*searchParams*/)
+    void findNeighbors(ResultSet<DistanceType>& resultSet, const ElementType* vec, const SearchParams& /*searchParams*/) const
     {
         ElementType* data = dataset_.data;
         for (size_t i = 0; i < dataset_.rows; ++i, data += dataset_.cols) {

--- a/modules/flann/include/opencv2/flann/lsh_index.h
+++ b/modules/flann/include/opencv2/flann/lsh_index.h
@@ -187,7 +187,7 @@ public:
      * \param[in] knn Number of nearest neighbors to return
      * \param[in] params Search parameters
      */
-    virtual void knnSearch(const Matrix<ElementType>& queries, Matrix<int>& indices, Matrix<DistanceType>& dists, int knn, const SearchParams& params)
+    virtual void knnSearch(const Matrix<ElementType>& queries, Matrix<int>& indices, Matrix<DistanceType>& dists, int knn, const SearchParams& params) const
     {
         assert(queries.cols == veclen());
         assert(indices.rows >= queries.rows);
@@ -217,7 +217,7 @@ public:
      *     vec = the vector for which to search the nearest neighbors
      *     maxCheck = the maximum number of restarts (in a best-bin-first manner)
      */
-    void findNeighbors(ResultSet<DistanceType>& result, const ElementType* vec, const SearchParams& /*searchParams*/)
+    void findNeighbors(ResultSet<DistanceType>& result, const ElementType* vec, const SearchParams& /*searchParams*/) const
     {
         getNeighbors(vec, result);
     }
@@ -261,7 +261,7 @@ private:
      * @param checked_average used for debugging
      */
     void getNeighbors(const ElementType* vec, bool /*do_radius*/, float radius, bool do_k, unsigned int k_nn,
-                      float& /*checked_average*/)
+                      float& /*checked_average*/) const
     {
         static std::vector<ScoreIndexPair> score_index_heap;
 
@@ -336,7 +336,7 @@ private:
      * This is a slower version than the above as it uses the ResultSet
      * @param vec the feature to analyze
      */
-    void getNeighbors(const ElementType* vec, ResultSet<DistanceType>& result)
+    void getNeighbors(const ElementType* vec, ResultSet<DistanceType>& result) const
     {
         typename std::vector<lsh::LshTable<ElementType> >::const_iterator table = tables_.begin();
         typename std::vector<lsh::LshTable<ElementType> >::const_iterator table_end = tables_.end();

--- a/modules/flann/include/opencv2/flann/miniflann.hpp
+++ b/modules/flann/include/opencv2/flann/miniflann.hpp
@@ -134,11 +134,11 @@ public:
 
     CV_WRAP virtual void build(InputArray features, const IndexParams& params, cvflann::flann_distance_t distType=cvflann::FLANN_DIST_L2);
     CV_WRAP virtual void knnSearch(InputArray query, OutputArray indices,
-                   OutputArray dists, int knn, const SearchParams& params=SearchParams());
+                   OutputArray dists, int knn, const SearchParams& params=SearchParams()) const;
 
     CV_WRAP virtual int radiusSearch(InputArray query, OutputArray indices,
                              OutputArray dists, double radius, int maxResults,
-                             const SearchParams& params=SearchParams());
+                             const SearchParams& params=SearchParams()) const;
 
     CV_WRAP virtual void save(const String& filename) const;
     CV_WRAP virtual bool load(InputArray features, const String& filename);

--- a/modules/flann/include/opencv2/flann/nn_index.h
+++ b/modules/flann/include/opencv2/flann/nn_index.h
@@ -65,7 +65,7 @@ public:
      * \param[in] knn Number of nearest neighbors to return
      * \param[in] params Search parameters
      */
-    virtual void knnSearch(const Matrix<ElementType>& queries, Matrix<int>& indices, Matrix<DistanceType>& dists, int knn, const SearchParams& params)
+    virtual void knnSearch(const Matrix<ElementType>& queries, Matrix<int>& indices, Matrix<DistanceType>& dists, int knn, const SearchParams& params) const
     {
         assert(queries.cols == veclen());
         assert(indices.rows >= queries.rows);
@@ -99,7 +99,7 @@ public:
      * \param[in] params Search parameters
      * \returns Number of neighbors found
      */
-    virtual int radiusSearch(const Matrix<ElementType>& query, Matrix<int>& indices, Matrix<DistanceType>& dists, float radius, const SearchParams& params)
+    virtual int radiusSearch(const Matrix<ElementType>& query, Matrix<int>& indices, Matrix<DistanceType>& dists, float radius, const SearchParams& params) const
     {
         if (query.rows != 1) {
             fprintf(stderr, "I can only search one feature at a time for range search\n");
@@ -169,7 +169,7 @@ public:
     /**
      * \brief Method that searches for nearest-neighbours
      */
-    virtual void findNeighbors(ResultSet<DistanceType>& result, const ElementType* vec, const SearchParams& searchParams) = 0;
+    virtual void findNeighbors(ResultSet<DistanceType>& result, const ElementType* vec, const SearchParams& searchParams) const = 0;
 };
 
 }

--- a/modules/flann/src/miniflann.cpp
+++ b/modules/flann/src/miniflann.cpp
@@ -475,7 +475,7 @@ void Index::release()
 }
 
 template<typename Distance, typename IndexType>
-void runKnnSearch_(void* index, const Mat& query, Mat& indices, Mat& dists,
+void runKnnSearch_(const void* const index, const Mat& query, Mat& indices, Mat& dists,
                   int knn, const SearchParams& params)
 {
     typedef typename Distance::ElementType ElementType;
@@ -494,14 +494,14 @@ void runKnnSearch_(void* index, const Mat& query, Mat& indices, Mat& dists,
 }
 
 template<typename Distance>
-void runKnnSearch(void* index, const Mat& query, Mat& indices, Mat& dists,
+void runKnnSearch(const void* const index, const Mat& query, Mat& indices, Mat& dists,
                   int knn, const SearchParams& params)
 {
     runKnnSearch_<Distance, ::cvflann::Index<Distance> >(index, query, indices, dists, knn, params);
 }
 
 template<typename Distance, typename IndexType>
-int runRadiusSearch_(void* index, const Mat& query, Mat& indices, Mat& dists,
+int runRadiusSearch_(const void* const index, const Mat& query, Mat& indices, Mat& dists,
                     double radius, const SearchParams& params)
 {
     typedef typename Distance::ElementType ElementType;
@@ -521,7 +521,7 @@ int runRadiusSearch_(void* index, const Mat& query, Mat& indices, Mat& dists,
 }
 
 template<typename Distance>
-int runRadiusSearch(void* index, const Mat& query, Mat& indices, Mat& dists,
+int runRadiusSearch(const void* const index, const Mat& query, Mat& indices, Mat& dists,
                      double radius, const SearchParams& params)
 {
     return runRadiusSearch_<Distance, ::cvflann::Index<Distance> >(index, query, indices, dists, radius, params);
@@ -565,7 +565,7 @@ static void createIndicesDists(OutputArray _indices, OutputArray _dists,
 
 
 void Index::knnSearch(InputArray _query, OutputArray _indices,
-               OutputArray _dists, int knn, const SearchParams& params)
+               OutputArray _dists, int knn, const SearchParams& params) const
 {
     CV_INSTRUMENT_REGION()
 
@@ -609,7 +609,7 @@ void Index::knnSearch(InputArray _query, OutputArray _indices,
 
 int Index::radiusSearch(InputArray _query, OutputArray _indices,
                         OutputArray _dists, double radius, int maxResults,
-                        const SearchParams& params)
+                        const SearchParams& params) const
 {
     CV_INSTRUMENT_REGION()
 


### PR DESCRIPTION
FLANN search is thread UNSAFE for some reason that is unknown yet!
Although this PR does not have crucial rule, it is a tiny effort towards finding the cause behind `knnSearch` returning nans sometimes when queried in parallel.

### This pullrequest changes
Ensures that search functions does not change the index