### PR TITLE
Fixes the constructor of 1x14, 2x7, 7x2 or 14x1 matrix

### DIFF
--- a/modules/core/include/opencv2/core/matx.hpp
+++ b/modules/core/include/opencv2/core/matx.hpp
@@ -590,11 +590,12 @@ Matx<_Tp,m,n>::Matx(_Tp v0, _Tp v1, _Tp v2, _Tp v3, _Tp v4, _Tp v5, _Tp v6, _Tp 
 template<typename _Tp, int m, int n> inline
 Matx<_Tp,m,n>::Matx(_Tp v0, _Tp v1, _Tp v2, _Tp v3, _Tp v4, _Tp v5, _Tp v6, _Tp v7, _Tp v8, _Tp v9, _Tp v10, _Tp v11, _Tp v12, _Tp v13)
 {
-    CV_StaticAssert(channels == 14, "Matx should have at least 14 elements.");
+    CV_StaticAssert(channels >= 14, "Matx should have at least 14 elements.");
     val[0] = v0; val[1] = v1; val[2] = v2; val[3] = v3;
     val[4] = v4; val[5] = v5; val[6] = v6; val[7] = v7;
     val[8] = v8; val[9] = v9; val[10] = v10; val[11] = v11;
     val[12] = v12; val[13] = v13;
+    for (int i = 14; i < channels; i++) val[i] = _Tp(0);
 }
 
 


### PR DESCRIPTION
### This pullrequest changes
Initializes the `val` array when the constructor of 1x14, 2x7, 7x2 or 14x1 matrix is called