### PR TITLE
Provides `copyTo()` functions for Matx/Vec to Matx/Vec or plain arrays

### DIFF
--- a/modules/core/include/opencv2/core/matx.hpp
+++ b/modules/core/include/opencv2/core/matx.hpp
@@ -154,6 +154,12 @@ public:
     //! extract the matrix column
     Matx<_Tp, m, 1> col(int i) const;
 
+    //! copies the matrix to another one.
+    void copyTo(Matx<_Tp, m, n>& matx) const;
+
+    //! copies the matrix to a plain array.
+    void copyTo(_Tp* arr) const;
+
     //! extract the matrix diagonal
     diag_type diag() const;
 
@@ -711,6 +717,18 @@ Matx<_Tp, m, 1> Matx<_Tp, m, n>::col(int j) const
     for( int i = 0; i < m; i++ )
         v.val[i] = val[i*n + j];
     return v;
+}
+
+template<typename _Tp, int m, int n> inline
+void Matx<_Tp, m, n>::copyTo(Matx<_Tp, m, n>& matx) const
+{
+    for (int i = 0; i < channels; i++) matx.val[i] = val[i];
+}
+
+template<typename _Tp, int m, int n> inline
+void Matx<_Tp, m, n>::copyTo(_Tp* arr) const
+{
+    for (int i = 0; i < channels; i++) arr[i] = val[i];
 }
 
 template<typename _Tp, int m, int n> inline

--- a/modules/core/test/test_operations.cpp
+++ b/modules/core/test/test_operations.cpp
@@ -1254,3 +1254,43 @@ TEST(MatTestRoi, adjustRoiOverflow)
 
     ASSERT_EQ(roi.rows, m.rows);
 }
+
+TEST(MatxTestCopyTo, matx_8381)
+{
+    Matx22d a(13, 11, 7, 5);
+    Matx22d b(a.val);
+    b *= 3;
+    b.copyTo(a);
+
+    ASSERT_EQ(cvtest::norm(a, b, NORM_INF), 0.);
+}
+
+TEST(MatxTestCopyTo, arr_8381)
+{
+    Matx22d a(3, 5, 13, 11);
+    Matx22d b(a.val);
+    b *= 7;
+    b.copyTo(a.val);
+
+    ASSERT_EQ(cvtest::norm(a, b, NORM_INF), 0.);
+}
+
+TEST(VecTestCopyTo, vec_8381)
+{
+    Vec4d a(5, 3, 11, 7);
+    Vec4d b(a);
+    b *= 13;
+    b.copyTo(a);
+
+    ASSERT_EQ(cvtest::norm(a, b, NORM_INF), 0.);
+}
+
+TEST(VecTestCopyTo, arr_8381)
+{
+    Vec4d a(7, 13, 5, 3);
+    Vec4d b(a);
+    b *= 11;
+    b.copyTo(a.val);
+
+    ASSERT_EQ(cvtest::norm(a, b, NORM_INF), 0.);
+}


### PR DESCRIPTION
I made the PR #8374 in hope to achieve inplace manipulation of data using Matx/Vec utilities, but it required introducing additional pointer and was not passing the ABI tests.
Alternatively, this PR should do the job for now...

The annoying copy process of:
```.cpp
Mat a;
Vec3d b;
//...
Mat(b).reshape(1, 1).copyTo(a.row(5).colRange(3, 6));
```
Should be just:
```.cpp
b.copyTo(a.ptr<double>(5) + 3);
```

### This pullrequest changes
- Provides copyTo functions for Matx/Vec to Matx/Vec or to plain arrays