### PR TITLE
Callib3d 4channel image detection

### DIFF
--- a/modules/calib3d/src/calibinit.cpp
+++ b/modules/calib3d/src/calibinit.cpp
@@ -442,7 +442,7 @@ int cvFindChessboardCorners( const void* arr, CvSize pattern_size,
 
     Mat img = cvarrToMat((CvMat*)arr).clone();
 
-    if( img.depth() != CV_8U || (img.channels() != 1 && img.channels() != 3) )
+    if( img.depth() != CV_8U || (img.channels() != 1 && img.channels() != 3 && img.channels() != 4) )
        CV_Error( CV_StsUnsupportedFormat, "Only 8-bit grayscale or color images are supported" );
 
     if( pattern_size.width <= 2 || pattern_size.height <= 2 )
@@ -451,9 +451,14 @@ int cvFindChessboardCorners( const void* arr, CvSize pattern_size,
     if( !out_corners )
         CV_Error( CV_StsNullPtr, "Null pointer to corners" );
 
-    if (img.channels() != 1)
+    if (img.channels() == 3)
     {
         cvtColor(img, img, COLOR_BGR2GRAY);
+    }
+
+    if(img.channels() == 4)
+    {
+        cvtColor(img, img, COLOR_BGRA2GRAY);
     }
 
 

--- a/modules/imgproc/src/imgwarp.cpp
+++ b/modules/imgproc/src/imgwarp.cpp
@@ -5019,10 +5019,14 @@ void cv::remap( InputArray _src, OutputArray _dst,
     {
         if( interpolation == INTER_LINEAR )
             ifunc = linear_tab[depth];
-        else if( interpolation == INTER_CUBIC )
+        else if( interpolation == INTER_CUBIC ){
             ifunc = cubic_tab[depth];
-        else if( interpolation == INTER_LANCZOS4 )
+            CV_Assert( _src.channels() <= 4 );
+        }
+        else if( interpolation == INTER_LANCZOS4 ){
             ifunc = lanczos4_tab[depth];
+            CV_Assert( _src.channels() <= 4 );
+        }
         else
             CV_Error( CV_StsBadArg, "Unknown interpolation method" );
         CV_Assert( ifunc != 0 );
@@ -5960,6 +5964,8 @@ void cv::warpAffine( InputArray _src, OutputArray _dst,
                      InputArray _M0, Size dsize,
                      int flags, int borderType, const Scalar& borderValue )
 {
+    CV_Assert( _src.channels() <= 4 || !(flags & (INTER_LANCZOS4 | INTER_CUBIC) ) );
+
     CV_INSTRUMENT_REGION()
 
     CV_OCL_RUN(_src.dims() <= 2 && _dst.isUMat() &&


### PR DESCRIPTION
3.2 version doesn't support 4 channel color image detections, unlike 3.1. Now, we don't call
CV_Error() if a 4 channel image is given. And process it, using COLOR_BGRA2GRAY flag

resolve #8326

I am doubting COLOR_RGBA2GRAY flag is needed instead of COLOR_BGRA2GRAY?