### PR TITLE
Callib3d 4channel image detection

### DIFF
--- a/modules/calib3d/src/calibinit.cpp
+++ b/modules/calib3d/src/calibinit.cpp
@@ -442,7 +442,7 @@ int cvFindChessboardCorners( const void* arr, CvSize pattern_size,
 
     Mat img = cvarrToMat((CvMat*)arr).clone();
 
-    if( img.depth() != CV_8U || (img.channels() != 1 && img.channels() != 3) )
+    if( img.depth() != CV_8U || (img.channels() != 1 && img.channels() != 3 && img.channels() != 4) )
        CV_Error( CV_StsUnsupportedFormat, "Only 8-bit grayscale or color images are supported" );
 
     if( pattern_size.width <= 2 || pattern_size.height <= 2 )


### PR DESCRIPTION
3.2 version doesn't support 4 channel color image
detections, unlike 3.1. Now, we don't call
CV_Error() if 4 channel image is given.

resolve #8326