### PR TITLE
Support for creating streams with custom allocator

### DIFF
--- a/modules/core/include/opencv2/core/cuda.hpp
+++ b/modules/core/include/opencv2/core/cuda.hpp
@@ -507,6 +507,9 @@ public:
     //! creates a new asynchronous stream
     Stream();
 
+    //! creates a new asynchronous stream with custom allocator
+    Stream(const Ptr<GpuMat::Allocator>& allocator);
+
     /** @brief Returns true if the current stream queue is finished. Otherwise, it returns false.
     */
     bool queryIfComplete() const;


### PR DESCRIPTION
The patch helps specify custom allocator for Stream, similar to GpuMat taking custom allocator. This is particularly needed when I have section of software where all its entities (GpuMats, Streams and processing) share the same custom allocator different from rest.