### PR TITLE
Added new 2d bool vector InputArray constructor

### DIFF
--- a/modules/core/include/opencv2/core/mat.hpp
+++ b/modules/core/include/opencv2/core/mat.hpp
@@ -165,7 +165,8 @@ public:
         UMAT              =10 << KIND_SHIFT,
         STD_VECTOR_UMAT   =11 << KIND_SHIFT,
         STD_BOOL_VECTOR   =12 << KIND_SHIFT,
-        STD_VECTOR_CUDA_GPU_MAT = 13 << KIND_SHIFT
+        STD_VECTOR_CUDA_GPU_MAT = 13 << KIND_SHIFT,
+        STD_BOOL_VECTOR_VECTOR = 14 << KIND_SHIFT
     };
 
     _InputArray();
@@ -177,6 +178,7 @@ public:
     template<typename _Tp> _InputArray(const std::vector<_Tp>& vec);
     _InputArray(const std::vector<bool>& vec);
     template<typename _Tp> _InputArray(const std::vector<std::vector<_Tp> >& vec);
+    _InputArray(const std::vector<std::vector<bool> >& vec);
     template<typename _Tp> _InputArray(const std::vector<Mat_<_Tp> >& vec);
     template<typename _Tp> _InputArray(const _Tp* vec, int n);
     template<typename _Tp, int m, int n> _InputArray(const Matx<_Tp, m, n>& matx);

--- a/modules/core/include/opencv2/core/mat.inl.hpp
+++ b/modules/core/include/opencv2/core/mat.inl.hpp
@@ -81,6 +81,10 @@ inline
 _InputArray::_InputArray(const std::vector<bool>& vec)
 { init(FIXED_TYPE + STD_BOOL_VECTOR + DataType<bool>::type + ACCESS_READ, &vec); }
 
+inline
+_InputArray::_InputArray(const std::vector<std::vector<bool> >& vec)
+{ init(FIXED_TYPE + STD_BOOL_VECTOR_VECTOR + DataType<bool>::type + ACCESS_READ, &vec); }
+
 template<typename _Tp> inline
 _InputArray::_InputArray(const std::vector<std::vector<_Tp> >& vec)
 { init(FIXED_TYPE + STD_VECTOR_VECTOR + DataType<_Tp>::type + ACCESS_READ, &vec); }

--- a/modules/core/src/matrix.cpp
+++ b/modules/core/src/matrix.cpp
@@ -1278,6 +1278,16 @@ Mat _InputArray::getMat_(int i) const
         return !v.empty() ? Mat(size(i), t, (void*)&v[0]) : Mat();
     }
 
+    if( k == STD_BOOL_VECTOR_VECTOR )
+    {
+        const std::vector<std::vector<bool> >& bool_vv = *(const std::vector<std::vector<bool> >*)obj;
+        CV_Assert( 0 <= i && i < (int)bool_vv.size() );
+        const std::vector<bool>& bool_v = bool_vv[i];
+        InputArray bool_input(bool_v);
+
+        return bool_input.getMat();
+    }
+
     if( k == STD_VECTOR_MAT )
     {
         const std::vector<Mat>& v = *(const std::vector<Mat>*)obj;


### PR DESCRIPTION
<!-- Please use this line to close one or multiple issues when this pullrequest gets merged
You can add another line right under the first one:
resolves #1234
resolves #1235
-->
resolves #8411 

### This pullrequest changes

<!-- Please describe what your pullrequest is changing -->
This pull request adds a new InputArray constructor to allow InputArrays to be constructed from 2d Boolean vectors, as they should be able to according to [documentation](http://docs.opencv.org/3.2.0/d4/d32/classcv_1_1__InputArray.html). It also modifies matrix.cpp to solve the case described in #8411.
