### PR TITLE
Fix build under directories with '.cpp' string.

### DIFF
--- a/cmake/cl2cpp.cmake
+++ b/cmake/cl2cpp.cmake
@@ -9,7 +9,7 @@ if (NOT cl_list)
   message(FATAL_ERROR "Can't find OpenCL kernels in directory: ${CL_DIR}")
 endif()
 
-string(REPLACE ".cpp" ".hpp" OUTPUT_HPP "${OUTPUT}")
+string(REGEX REPLACE "\\.cpp$" ".hpp" OUTPUT_HPP "${OUTPUT}")
 get_filename_component(OUTPUT_HPP_NAME "${OUTPUT_HPP}" NAME)
 
 if("${MODULE_NAME}" STREQUAL "ocl")


### PR DESCRIPTION
<!-- Please use this line to close one or multiple issues when this pullrequest gets merged
You can add another line right under the first one:
resolves #1234
resolves #1235
-->

### This pullrequest changes

When building opencv under directories that contain `.cpp` substring, it is replaced with `.hpp` in `cl2cpp.cmake` file, so generated headers cannot be found.
