### PR TITLE
Make stitching panoramas reusable after estimating transform once

### DIFF
--- a/modules/stitching/include/opencv2/stitching/detail/camera.hpp
+++ b/modules/stitching/include/opencv2/stitching/detail/camera.hpp
@@ -66,6 +66,7 @@ struct CV_EXPORTS CameraParams
     double aspect; // Aspect ratio
     double ppx; // Principal point X
     double ppy; // Principal point Y
+    double scale; // Scale factor
     Mat R; // Rotation
     Mat t; // Translation
 };

--- a/modules/stitching/src/camera.cpp
+++ b/modules/stitching/src/camera.cpp
@@ -45,7 +45,7 @@
 namespace cv {
 namespace detail {
 
-CameraParams::CameraParams() : focal(1), aspect(1), ppx(0), ppy(0),
+CameraParams::CameraParams() : focal(1), aspect(1), ppx(0), ppy(0), scale(1),
                                R(Mat::eye(3, 3, CV_64F)), t(Mat::zeros(3, 1, CV_64F)) {}
 
 CameraParams::CameraParams(const CameraParams &other) { *this = other; }
@@ -56,6 +56,7 @@ const CameraParams& CameraParams::operator =(const CameraParams &other)
     ppx = other.ppx;
     ppy = other.ppy;
     aspect = other.aspect;
+    scale = other.scale;
     R = other.R.clone();
     t = other.t.clone();
     return *this;
@@ -63,10 +64,12 @@ const CameraParams& CameraParams::operator =(const CameraParams &other)
 
 Mat CameraParams::K() const
 {
-    Mat_<double> k = Mat::eye(3, 3, CV_64F);
-    k(0,0) = focal; k(0,2) = ppx;
-    k(1,1) = focal * aspect; k(1,2) = ppy;
-    return k;
+  Mat_<double> k = Mat::eye(3,3, CV_64F);
+  k(0,0) = focal * scale;
+  k(0,2) = ppx * scale;
+  k(1,1) = focal * scale * aspect;
+  k(1,2) = ppy * scale;
+  return k;
 }
 
 } // namespace detail

--- a/modules/stitching/src/stitcher.cpp
+++ b/modules/stitching/src/stitcher.cpp
@@ -281,17 +281,15 @@ Stitcher::Status Stitcher::composePanorama(InputArrayOfArrays images, OutputArra
             //compose_seam_aspect = compose_scale / seam_scale_;
             compose_work_aspect = compose_scale / work_scale_;
 
-            // Update warped image scale
-            warped_image_scale_ *= static_cast<float>(compose_work_aspect);
-            w = warper_->create((float)warped_image_scale_);
+            // Calculate temporary warp scale
+            float warp_scale = warped_image_scale_ * static_cast<float>(compose_work_aspect);
+            w = warper_->create(warp_scale);
 
             // Update corners and sizes
             for (size_t i = 0; i < imgs_.size(); ++i)
             {
                 // Update intrinsics
-                cameras_[i].focal *= compose_work_aspect;
-                cameras_[i].ppx *= compose_work_aspect;
-                cameras_[i].ppy *= compose_work_aspect;
+                cameras_[i].scale = compose_work_aspect;
 
                 // Update corner and size
                 Size sz = full_img_sizes_[i];


### PR DESCRIPTION
This resolves #4480.

### This pullrequest changes

Camera now has an additional parameter for scale. Side effects of composePanorama are now limited to this one parameter.

