### PR TITLE
Restricted OpenVX HAL separable filter implementation to 3x3 kernel size

### DIFF
--- a/3rdparty/openvx/hal/openvx_hal.cpp
+++ b/3rdparty/openvx/hal/openvx_hal.cpp
@@ -601,7 +601,7 @@ int ovx_hal_sepFilterInit(cvhalFilter2D **filter_context, int src_type, int dst_
 {
     if (!filter_context || !kernelx_data || !kernely_data || delta != 0 ||
         src_type != CV_8UC1 || (dst_type != CV_8UC1 && dst_type != CV_16SC1) ||
-        kernelx_length % 2 == 0 || kernely_length % 2 == 0 || anchor_x != kernelx_length / 2 || anchor_y != kernely_length / 2)
+        kernelx_length != 3 || kernely_length != 3 || anchor_x != 1 || anchor_y != 1)
         return CV_HAL_ERROR_NOT_IMPLEMENTED;
 
     ivx::border_t border;


### PR DESCRIPTION
### This pullrequest changes

OpenVX API have no separable filter implementation so HAL sepfilter call is implemented as convolution and though have to be restricted to 3x3 kernels only to avoid performance degradation.
