### PR TITLE
OpenVX HAL calls disabled for images less than certain threshold

### DIFF
--- a/3rdparty/openvx/hal/openvx_hal.cpp
+++ b/3rdparty/openvx/hal/openvx_hal.cpp
@@ -82,10 +82,13 @@ inline bool dimTooBig(int size)
 }
 
 //OpenVX calls have essential overhead so it make sense to skip them for small images
-template <int kernel_id> inline bool              skipSmallImages(int w, int h) { return w*h < 7680 * 4320; }
-template <> inline bool       skipSmallImages<VX_KERNEL_MULTIPLY>(int w, int h) { return w*h <  640 *  480; }
-template <> inline bool  skipSmallImages<VX_KERNEL_COLOR_CONVERT>(int w, int h) { return w*h < 2048 * 1536; }
-template <> inline bool skipSmallImages<VX_KERNEL_INTEGRAL_IMAGE>(int w, int h) { return w*h <  640 *  480; }
+template <int kernel_id> inline bool                  skipSmallImages(int w, int h) { return w*h < 7680 * 4320; }
+template <> inline bool           skipSmallImages<VX_KERNEL_MULTIPLY>(int w, int h) { return w*h <  640 *  480; }
+template <> inline bool      skipSmallImages<VX_KERNEL_COLOR_CONVERT>(int w, int h) { return w*h < 2048 * 1536; }
+template <> inline bool     skipSmallImages<VX_KERNEL_INTEGRAL_IMAGE>(int w, int h) { return w*h <  640 *  480; }
+template <> inline bool        skipSmallImages<VX_KERNEL_WARP_AFFINE>(int w, int h) { return w*h < 1280 *  720; }
+template <> inline bool   skipSmallImages<VX_KERNEL_WARP_PERSPECTIVE>(int w, int h) { return w*h <  320 *  240; }
+template <> inline bool skipSmallImages<VX_KERNEL_CUSTOM_CONVOLUTION>(int w, int h) { return w*h <  320 *  240; }
 
 inline void setConstantBorder(ivx::border_t &border, vx_uint8 val)
 {
@@ -553,6 +556,7 @@ int ovx_hal_filterInit(cvhalFilter2D **filter_context, uchar *kernel_data, size_
             for (int i = 0; i < kernel_width; ++i)
                 data.push_back(row[i]);
         }
+        break;
     default:
         return CV_HAL_ERROR_NOT_IMPLEMENTED;
     }

--- a/3rdparty/openvx/hal/openvx_hal.cpp
+++ b/3rdparty/openvx/hal/openvx_hal.cpp
@@ -84,10 +84,22 @@ inline bool dimTooBig(int size)
 inline bool skipSmallImages(int w, int h, int kernel_id)
 {
 //OpenVX calls have essential overhead so it make sense to skip them for small images
-    if (w*h < 1920 * 1080)
-        return true;
-    else
-        return false;
+    switch (kernel_id)
+    {
+    case VX_KERNEL_MULTIPLY:
+        if (w*h < 640 * 480)
+            return true;
+        break;
+    case VX_KERNEL_COLOR_CONVERT:
+        if (w*h < 2048 * 1536)
+            return true;
+        break;
+    default:
+        if (w*h < 3840 * 2160)
+            return true;
+        break;
+    }
+    return false;
 }
 
 inline void setConstantBorder(ivx::border_t &border, vx_uint8 val)

--- a/3rdparty/openvx/hal/openvx_hal.cpp
+++ b/3rdparty/openvx/hal/openvx_hal.cpp
@@ -82,9 +82,10 @@ inline bool dimTooBig(int size)
 }
 
 //OpenVX calls have essential overhead so it make sense to skip them for small images
-template <int kernel_id> inline bool             skipSmallImages(int w, int h) { return w*h < 7680 * 4320; }
-template <> inline bool      skipSmallImages<VX_KERNEL_MULTIPLY>(int w, int h) { return w*h <  640 *  480; }
-template <> inline bool skipSmallImages<VX_KERNEL_COLOR_CONVERT>(int w, int h) { return w*h < 2048 * 1536; }
+template <int kernel_id> inline bool              skipSmallImages(int w, int h) { return w*h < 7680 * 4320; }
+template <> inline bool       skipSmallImages<VX_KERNEL_MULTIPLY>(int w, int h) { return w*h <  640 *  480; }
+template <> inline bool  skipSmallImages<VX_KERNEL_COLOR_CONVERT>(int w, int h) { return w*h < 2048 * 1536; }
+template <> inline bool skipSmallImages<VX_KERNEL_INTEGRAL_IMAGE>(int w, int h) { return w*h <  640 *  480; }
 
 inline void setConstantBorder(ivx::border_t &border, vx_uint8 val)
 {

--- a/3rdparty/openvx/hal/openvx_hal.cpp
+++ b/3rdparty/openvx/hal/openvx_hal.cpp
@@ -82,7 +82,7 @@ inline bool dimTooBig(int size)
 }
 
 //OpenVX calls have essential overhead so it make sense to skip them for small images
-template <int kernel_id> inline bool             skipSmallImages(int w, int h) { return w*h < 3840 * 2160; }
+template <int kernel_id> inline bool             skipSmallImages(int w, int h) { return w*h < 7680 * 4320; }
 template <> inline bool      skipSmallImages<VX_KERNEL_MULTIPLY>(int w, int h) { return w*h <  640 *  480; }
 template <> inline bool skipSmallImages<VX_KERNEL_COLOR_CONVERT>(int w, int h) { return w*h < 2048 * 1536; }
 
@@ -175,7 +175,9 @@ OVX_BINARY_OP(xor, { ivx::IVX_CHECK_STATUS(vxuXor(ctx, ia, ib, ic)); }, VX_KERNE
 template <typename T>
 int ovx_hal_mul(const T *a, size_t astep, const T *b, size_t bstep, T *c, size_t cstep, int w, int h, double scale)
 {
-    if(skipSmallImages<VX_KERNEL_MULTIPLY>(w, h))
+    if(scale == 1.0 || sizeof(T) > 1 ?
+       skipSmallImages<VX_KERNEL_ADD>(w, h) : /*actually it could be any kernel with generic minimum size*/
+       skipSmallImages<VX_KERNEL_MULTIPLY>(w, h) )
         return CV_HAL_ERROR_NOT_IMPLEMENTED;
     if (dimTooBig(w) || dimTooBig(h))
         return CV_HAL_ERROR_NOT_IMPLEMENTED;

--- a/3rdparty/openvx/hal/openvx_hal.hpp
+++ b/3rdparty/openvx/hal/openvx_hal.hpp
@@ -106,12 +106,12 @@ int ovx_hal_integral(int depth, int sdepth, int, const uchar * a, size_t astep, 
 #undef cv_hal_filterFree
 #define cv_hal_filterFree ovx_hal_filterFree
 
-#undef cv_hal_sepFilterInit
-#define cv_hal_sepFilterInit ovx_hal_sepFilterInit
-#undef cv_hal_sepFilter
-#define cv_hal_sepFilter ovx_hal_filter
-#undef cv_hal_sepFilterFree
-#define cv_hal_sepFilterFree ovx_hal_filterFree
+//#undef cv_hal_sepFilterInit
+//#define cv_hal_sepFilterInit ovx_hal_sepFilterInit
+//#undef cv_hal_sepFilter
+//#define cv_hal_sepFilter ovx_hal_filter
+//#undef cv_hal_sepFilterFree
+//#define cv_hal_sepFilterFree ovx_hal_filterFree
 
 #if VX_VERSION > VX_VERSION_1_0
 

--- a/modules/core/include/opencv2/core/openvx/ovx_defs.hpp
+++ b/modules/core/include/opencv2/core/openvx/ovx_defs.hpp
@@ -26,15 +26,6 @@ namespace ovx{
 CV_EXPORTS_W ivx::Context& getOpenVXContext();
 
 template <int kernel_id> inline bool skipSmallImages(int w, int h)     { return w*h < 3840 * 2160; }
-template <> inline bool skipSmallImages<VX_KERNEL_MINMAXLOC>(int w, int h) { return w*h < 3840 * 2160; }
-template <> inline bool skipSmallImages<VX_KERNEL_MEDIAN_3x3>(int w, int h) { return w*h < 1280 * 720; }
-template <> inline bool skipSmallImages<VX_KERNEL_GAUSSIAN_3x3>(int w, int h) { return w*h < 320 * 240; }
-template <> inline bool skipSmallImages<VX_KERNEL_BOX_3x3>(int w, int h) { return w*h < 640 * 480; }
-template <> inline bool skipSmallImages<VX_KERNEL_HISTOGRAM>(int w, int h) { return w*h < 2048 * 1536; }
-template <> inline bool skipSmallImages<VX_KERNEL_SOBEL_3x3>(int w, int h) { return w*h < 320 * 240; }
-template <> inline bool skipSmallImages<VX_KERNEL_CANNY_EDGE_DETECTOR>(int w, int h) { return w*h < 640 * 480; }
-template <> inline bool skipSmallImages<VX_KERNEL_ACCUMULATE>(int w, int h) { return w*h < 120 * 60; }
-template <> inline bool skipSmallImages<VX_KERNEL_FAST_CORNERS>(int w, int h) { return w*h < 800 * 600; }
 }}
 
 #define CV_OVX_RUN(condition, func, ...)          \

--- a/modules/core/include/opencv2/core/openvx/ovx_defs.hpp
+++ b/modules/core/include/opencv2/core/openvx/ovx_defs.hpp
@@ -24,6 +24,16 @@ namespace cv{
 namespace ovx{
 // Get common thread local OpenVX context
 CV_EXPORTS_W ivx::Context& getOpenVXContext();
+
+template <int kernel_id> inline bool skipSmallImages(int w, int h)     { return w*h < 3840 * 2160; }
+template <> inline bool skipSmallImages<VX_KERNEL_MINMAXLOC>(int w, int h) { return w*h < 1280*720; }
+template <> inline bool skipSmallImages<VX_KERNEL_MEDIAN_3x3>(int w, int h) { return w*h < 1280 * 720; }
+template <> inline bool skipSmallImages<VX_KERNEL_GAUSSIAN_3x3>(int w, int h) { return w*h < 1280 * 720; }
+template <> inline bool skipSmallImages<VX_KERNEL_BOX_3x3>(int w, int h) { return w*h < 1280 * 720; }
+template <> inline bool skipSmallImages<VX_KERNEL_HISTOGRAM>(int w, int h) { return w*h < 2048 * 1536; }
+template <> inline bool skipSmallImages<VX_KERNEL_SOBEL_3x3>(int w, int h) { return w*h < 640 * 480; }
+template <> inline bool skipSmallImages<VX_KERNEL_CUSTOM_CONVOLUTION>(int w, int h) { return w*h < 1280 * 720; }
+
 }}
 
 #define CV_OVX_RUN(condition, func, ...)          \

--- a/modules/core/include/opencv2/core/openvx/ovx_defs.hpp
+++ b/modules/core/include/opencv2/core/openvx/ovx_defs.hpp
@@ -28,11 +28,11 @@ CV_EXPORTS_W ivx::Context& getOpenVXContext();
 template <int kernel_id> inline bool skipSmallImages(int w, int h)     { return w*h < 3840 * 2160; }
 template <> inline bool skipSmallImages<VX_KERNEL_MINMAXLOC>(int w, int h) { return w*h < 3840 * 2160; }
 template <> inline bool skipSmallImages<VX_KERNEL_MEDIAN_3x3>(int w, int h) { return w*h < 1280 * 720; }
-template <> inline bool skipSmallImages<VX_KERNEL_GAUSSIAN_3x3>(int w, int h) { return w*h < 1280 * 720; }
-template <> inline bool skipSmallImages<VX_KERNEL_BOX_3x3>(int w, int h) { return w*h < 1920 * 1080; }
+template <> inline bool skipSmallImages<VX_KERNEL_GAUSSIAN_3x3>(int w, int h) { return w*h < 320 * 240; }
+template <> inline bool skipSmallImages<VX_KERNEL_BOX_3x3>(int w, int h) { return w*h < 640 * 480; }
 template <> inline bool skipSmallImages<VX_KERNEL_HISTOGRAM>(int w, int h) { return w*h < 2048 * 1536; }
-template <> inline bool skipSmallImages<VX_KERNEL_SOBEL_3x3>(int w, int h) { return w*h < 1280 * 720; }
-template <> inline bool skipSmallImages<VX_KERNEL_CUSTOM_CONVOLUTION>(int w, int h) { return w*h < 1280 * 720; }
+template <> inline bool skipSmallImages<VX_KERNEL_SOBEL_3x3>(int w, int h) { return w*h < 320 * 240; }
+template <> inline bool skipSmallImages<VX_KERNEL_CUSTOM_CONVOLUTION>(int w, int h) { return w*h < 640 * 480; }
 
 }}
 

--- a/modules/core/include/opencv2/core/openvx/ovx_defs.hpp
+++ b/modules/core/include/opencv2/core/openvx/ovx_defs.hpp
@@ -32,7 +32,9 @@ template <> inline bool skipSmallImages<VX_KERNEL_GAUSSIAN_3x3>(int w, int h) { 
 template <> inline bool skipSmallImages<VX_KERNEL_BOX_3x3>(int w, int h) { return w*h < 640 * 480; }
 template <> inline bool skipSmallImages<VX_KERNEL_HISTOGRAM>(int w, int h) { return w*h < 2048 * 1536; }
 template <> inline bool skipSmallImages<VX_KERNEL_SOBEL_3x3>(int w, int h) { return w*h < 320 * 240; }
-
+template <> inline bool skipSmallImages<VX_KERNEL_CANNY_EDGE_DETECTOR>(int w, int h) { return w*h < 640 * 480; }
+template <> inline bool skipSmallImages<VX_KERNEL_ACCUMULATE>(int w, int h) { return w*h < 120 * 60; }
+template <> inline bool skipSmallImages<VX_KERNEL_FAST_CORNERS>(int w, int h) { return w*h < 800 * 600; }
 }}
 
 #define CV_OVX_RUN(condition, func, ...)          \

--- a/modules/core/include/opencv2/core/openvx/ovx_defs.hpp
+++ b/modules/core/include/opencv2/core/openvx/ovx_defs.hpp
@@ -32,7 +32,6 @@ template <> inline bool skipSmallImages<VX_KERNEL_GAUSSIAN_3x3>(int w, int h) { 
 template <> inline bool skipSmallImages<VX_KERNEL_BOX_3x3>(int w, int h) { return w*h < 640 * 480; }
 template <> inline bool skipSmallImages<VX_KERNEL_HISTOGRAM>(int w, int h) { return w*h < 2048 * 1536; }
 template <> inline bool skipSmallImages<VX_KERNEL_SOBEL_3x3>(int w, int h) { return w*h < 320 * 240; }
-template <> inline bool skipSmallImages<VX_KERNEL_CUSTOM_CONVOLUTION>(int w, int h) { return w*h < 640 * 480; }
 
 }}
 

--- a/modules/core/include/opencv2/core/openvx/ovx_defs.hpp
+++ b/modules/core/include/opencv2/core/openvx/ovx_defs.hpp
@@ -26,12 +26,12 @@ namespace ovx{
 CV_EXPORTS_W ivx::Context& getOpenVXContext();
 
 template <int kernel_id> inline bool skipSmallImages(int w, int h)     { return w*h < 3840 * 2160; }
-template <> inline bool skipSmallImages<VX_KERNEL_MINMAXLOC>(int w, int h) { return w*h < 1280*720; }
+template <> inline bool skipSmallImages<VX_KERNEL_MINMAXLOC>(int w, int h) { return w*h < 3840 * 2160; }
 template <> inline bool skipSmallImages<VX_KERNEL_MEDIAN_3x3>(int w, int h) { return w*h < 1280 * 720; }
 template <> inline bool skipSmallImages<VX_KERNEL_GAUSSIAN_3x3>(int w, int h) { return w*h < 1280 * 720; }
-template <> inline bool skipSmallImages<VX_KERNEL_BOX_3x3>(int w, int h) { return w*h < 1280 * 720; }
+template <> inline bool skipSmallImages<VX_KERNEL_BOX_3x3>(int w, int h) { return w*h < 1920 * 1080; }
 template <> inline bool skipSmallImages<VX_KERNEL_HISTOGRAM>(int w, int h) { return w*h < 2048 * 1536; }
-template <> inline bool skipSmallImages<VX_KERNEL_SOBEL_3x3>(int w, int h) { return w*h < 640 * 480; }
+template <> inline bool skipSmallImages<VX_KERNEL_SOBEL_3x3>(int w, int h) { return w*h < 1280 * 720; }
 template <> inline bool skipSmallImages<VX_KERNEL_CUSTOM_CONVOLUTION>(int w, int h) { return w*h < 1280 * 720; }
 
 }}

--- a/modules/core/src/convert.cpp
+++ b/modules/core/src/convert.cpp
@@ -4671,6 +4671,9 @@ static bool _openvx_cvt(const T* src, size_t sstep,
 
     int srcType = DataType<T>::type, dstType = DataType<DT>::type;
 
+    if (ovx::skipSmallImages<VX_KERNEL_CONVERTDEPTH>(imgSize.width, imgSize.height))
+        return false;
+
     try
     {
         Context context = ovx::getOpenVXContext();
@@ -5696,7 +5699,7 @@ void cv::LUT( InputArray _src, InputArray _lut, OutputArray _dst )
     _dst.create(src.dims, src.size, CV_MAKETYPE(_lut.depth(), cn));
     Mat dst = _dst.getMat();
 
-    CV_OVX_RUN(true,
+    CV_OVX_RUN(!ovx::skipSmallImages<VX_KERNEL_TABLE_LOOKUP>(src.cols, src.rows),
                openvx_LUT(src, dst, lut))
 
     CV_IPP_RUN(_src.dims() <= 2, ipp_lut(src, lut, dst));

--- a/modules/core/src/stat.cpp
+++ b/modules/core/src/stat.cpp
@@ -2300,6 +2300,9 @@ static bool ocl_minMaxIdx( InputArray _src, double* minVal, double* maxVal, int*
 #endif
 
 #ifdef HAVE_OPENVX
+namespace ovx {
+    template <> inline bool skipSmallImages<VX_KERNEL_MINMAXLOC>(int w, int h) { return w*h < 3840 * 2160; }
+}
 static bool openvx_minMaxIdx(Mat &src, double* minVal, double* maxVal, int* minIdx, int* maxIdx, Mat &mask)
 {
     int stype = src.type();

--- a/modules/core/src/stat.cpp
+++ b/modules/core/src/stat.cpp
@@ -1843,7 +1843,7 @@ void cv::meanStdDev( InputArray _src, OutputArray _mean, OutputArray _sdv, Input
     Mat src = _src.getMat(), mask = _mask.getMat();
     CV_Assert( mask.empty() || mask.type() == CV_8UC1 );
 
-    CV_OVX_RUN(true,
+    CV_OVX_RUN(!ovx::skipSmallImages<VX_KERNEL_MEAN_STDDEV>(src.cols, src.rows),
                openvx_meanStdDev(src, _mean, _sdv, mask))
 
     CV_IPP_RUN(IPP_VERSION_X100 >= 700, ipp_meanStdDev(src, _mean, _sdv, mask));
@@ -2496,7 +2496,7 @@ void cv::minMaxIdx(InputArray _src, double* minVal,
 
     Mat src = _src.getMat(), mask = _mask.getMat();
 
-    CV_OVX_RUN(true,
+    CV_OVX_RUN(!ovx::skipSmallImages<VX_KERNEL_MINMAXLOC>(src.cols, src.rows),
                openvx_minMaxIdx(src, minVal, maxVal, minIdx, maxIdx, mask))
 
     CV_IPP_RUN(IPP_VERSION_X100 >= 700, ipp_minMaxIdx(src, minVal, maxVal, minIdx, maxIdx, mask))

--- a/modules/features2d/src/fast.cpp
+++ b/modules/features2d/src/fast.cpp
@@ -338,6 +338,9 @@ static bool ocl_FAST( InputArray _img, std::vector<KeyPoint>& keypoints,
 
 
 #ifdef HAVE_OPENVX
+namespace ovx {
+    template <> inline bool skipSmallImages<VX_KERNEL_FAST_CORNERS>(int w, int h) { return w*h < 800 * 600; }
+}
 static bool openvx_FAST(InputArray _img, std::vector<KeyPoint>& keypoints,
                         int _threshold, bool nonmaxSuppression, int type)
 {

--- a/modules/features2d/src/fast.cpp
+++ b/modules/features2d/src/fast.cpp
@@ -352,6 +352,9 @@ static bool openvx_FAST(InputArray _img, std::vector<KeyPoint>& keypoints,
     if(imgMat.empty() || imgMat.type() != CV_8UC1)
         return false;
 
+    if (ovx::skipSmallImages<VX_KERNEL_FAST_CORNERS>(imgMat.cols, imgMat.rows))
+        return false;
+
     try
     {
         Context context = ovx::getOpenVXContext();

--- a/modules/imgproc/src/accum.cpp
+++ b/modules/imgproc/src/accum.cpp
@@ -1942,6 +1942,9 @@ enum
     VX_ACCUMULATE_WEIGHTED_OP = 2
 };
 
+namespace ovx {
+    template <> inline bool skipSmallImages<VX_KERNEL_ACCUMULATE>(int w, int h) { return w*h < 120 * 60; }
+}
 static bool openvx_accumulate(InputArray _src, InputOutputArray _dst, InputArray _mask, double _weight, int opType)
 {
     Mat srcMat = _src.getMat(), dstMat = _dst.getMat();

--- a/modules/imgproc/src/accum.cpp
+++ b/modules/imgproc/src/accum.cpp
@@ -1945,6 +1945,8 @@ enum
 static bool openvx_accumulate(InputArray _src, InputOutputArray _dst, InputArray _mask, double _weight, int opType)
 {
     Mat srcMat = _src.getMat(), dstMat = _dst.getMat();
+    if (ovx::skipSmallImages<VX_KERNEL_ACCUMULATE>(srcMat.cols, srcMat.rows))
+        return false;
     if(!_mask.empty() ||
        (opType == VX_ACCUMULATE_WEIGHTED_OP && dstMat.type() != CV_8UC1  ) ||
        (opType != VX_ACCUMULATE_WEIGHTED_OP && dstMat.type() != CV_16SC1 ) ||

--- a/modules/imgproc/src/canny.cpp
+++ b/modules/imgproc/src/canny.cpp
@@ -778,6 +778,9 @@ private:
 };
 
 #ifdef HAVE_OPENVX
+namespace ovx {
+    template <> inline bool skipSmallImages<VX_KERNEL_CANNY_EDGE_DETECTOR>(int w, int h) { return w*h < 640 * 480; }
+}
 static bool openvx_canny(const Mat& src, Mat& dst, int loVal, int hiVal, int kSize, bool useL2)
 {
     using namespace ivx;

--- a/modules/imgproc/src/canny.cpp
+++ b/modules/imgproc/src/canny.cpp
@@ -868,7 +868,8 @@ void Canny( InputArray _src, OutputArray _dst,
             src.type() == CV_8UC1 &&
             !src.isSubmatrix() &&
             src.cols >= aperture_size &&
-            src.rows >= aperture_size,
+            src.rows >= aperture_size &&
+            !ovx::skipSmallImages<VX_KERNEL_CANNY_EDGE_DETECTOR>(src.cols, src.rows),
         openvx_canny(
             src,
             dst,

--- a/modules/imgproc/src/deriv.cpp
+++ b/modules/imgproc/src/deriv.cpp
@@ -184,6 +184,9 @@ cv::Ptr<cv::FilterEngine> cv::createDerivFilter(int srcType, int dstType,
 #ifdef HAVE_OPENVX
 namespace cv
 {
+    namespace ovx {
+        template <> inline bool skipSmallImages<VX_KERNEL_SOBEL_3x3>(int w, int h) { return w*h < 320 * 240; }
+    }
     static bool openvx_sobel(InputArray _src, OutputArray _dst,
                              int dx, int dy, int ksize,
                              double scale, double delta, int borderType)

--- a/modules/imgproc/src/deriv.cpp
+++ b/modules/imgproc/src/deriv.cpp
@@ -234,8 +234,8 @@ namespace cv
             border = VX_BORDER_CONSTANT;
             break;
         case BORDER_REPLICATE:
-            border = VX_BORDER_REPLICATE;
-            break;
+//            border = VX_BORDER_REPLICATE;
+//            break;
         default:
             return false;
         }

--- a/modules/imgproc/src/deriv.cpp
+++ b/modules/imgproc/src/deriv.cpp
@@ -188,42 +188,16 @@ namespace cv
                              int dx, int dy, int ksize,
                              double scale, double delta, int borderType)
     {
-        int stype = _src.type();
-        int dtype = _dst.type();
-        if (stype != CV_8UC1 || (dtype != CV_16SC1 && dtype != CV_8UC1) ||
-            ksize != 3 || delta != 0.0)//Restrict to 3x3 kernels since otherwise convolution would be slower than separable filter
+        if (_src.type() != CV_8UC1 || _dst.type() != CV_16SC1 ||
+            ksize != 3 || scale != 1.0 || delta != 0.0 ||
+            (dx | dy) != 1 || (dx + dy) != 1 ||
+            _src.cols < ksize || _src.rows < ksize ||
+            ovx::skipSmallImages<VX_KERNEL_SOBEL_3x3>(_src.cols, _src.rows)
+            )
             return false;
 
         Mat src = _src.getMat();
         Mat dst = _dst.getMat();
-
-        if (src.cols < ksize || src.rows < ksize)
-            return false;
-
-        if (dtype == CV_16SC1 && ksize == 3 && ((dx | dy) == 1) && (dx + dy) == 1 ?
-            ovx::skipSmallImages<VX_KERNEL_SOBEL_3x3>(src.cols, src.rows) :
-            ovx::skipSmallImages<VX_KERNEL_CUSTOM_CONVOLUTION>(src.cols, src.rows)
-            )
-            return false;
-
-        int iscale = 1;
-        vx_uint32 cscale = 1;
-        if(scale != 1.0)
-        {
-            iscale = static_cast<int>(scale);
-            if (std::abs(scale - iscale) >= DBL_EPSILON)
-            {
-                int exp = 0;
-                float significand = frexp(scale, &exp);
-                if ((significand == 0.5f) && (exp <= 0))
-                {
-                    iscale = 1;
-                    cscale = 1 << (exp = -exp + 1);
-                }
-                else
-                    return false;
-            }
-        }
 
         if ((borderType & BORDER_ISOLATED) == 0 && src.isSubmatrix())
             return false; //Process isolated borders only
@@ -255,40 +229,17 @@ namespace cv
             ivx::Image
                 ia = ivx::Image::createFromHandle(ctx, VX_DF_IMAGE_U8,
                     ivx::Image::createAddressing(a.cols, a.rows, 1, (vx_int32)(a.step)), a.data),
-                ib = ivx::Image::createFromHandle(ctx, dtype == CV_16SC1 ? VX_DF_IMAGE_S16 : VX_DF_IMAGE_U8,
-                    ivx::Image::createAddressing(dst.cols, dst.rows, dtype == CV_16SC1 ? 2 : 1, (vx_int32)(dst.step)), dst.data);
+                ib = ivx::Image::createFromHandle(ctx, VX_DF_IMAGE_S16,
+                    ivx::Image::createAddressing(dst.cols, dst.rows, 2, (vx_int32)(dst.step)), dst.data);
 
             //ATTENTION: VX_CONTEXT_IMMEDIATE_BORDER attribute change could lead to strange issues in multi-threaded environments
             //since OpenVX standart says nothing about thread-safety for now
             ivx::border_t prevBorder = ctx.immediateBorder();
             ctx.setImmediateBorder(border, (vx_uint8)(0));
-            if (dtype == CV_16SC1 && ksize == 3 && ((dx | dy) == 1) && (dx + dy) == 1)
-            {
-                if(dx)
-                    ivx::IVX_CHECK_STATUS(vxuSobel3x3(ctx, ia, ib, NULL));
-                else
-                    ivx::IVX_CHECK_STATUS(vxuSobel3x3(ctx, ia, NULL, ib));
-            }
+            if(dx)
+                ivx::IVX_CHECK_STATUS(vxuSobel3x3(ctx, ia, ib, NULL));
             else
-            {
-#if VX_VERSION <= VX_VERSION_1_0
-                if (ctx.vendorID() == VX_ID_KHRONOS && ((vx_size)(src.cols) <= ctx.convolutionMaxDimension() || (vx_size)(src.rows) <= ctx.convolutionMaxDimension()))
-                {
-                    ctx.setImmediateBorder(prevBorder);
-                    return false;
-                }
-#endif
-                Mat kx, ky;
-                getDerivKernels(kx, ky, dx, dy, ksize, false);
-                flip(kx, kx, 0);
-                flip(ky, ky, 0);
-                Mat convData;
-                cv::Mat(ky*kx.t()).convertTo(convData, CV_16SC1, iscale);
-                ivx::Convolution cnv = ivx::Convolution::create(ctx, convData.cols, convData.rows);
-                cnv.copyFrom(convData);
-                cnv.setScale(cscale);
-                ivx::IVX_CHECK_STATUS(vxuConvolve(ctx, ia, cnv, ib));
-            }
+                ivx::IVX_CHECK_STATUS(vxuSobel3x3(ctx, ia, NULL, ib));
             ctx.setImmediateBorder(prevBorder);
         }
         catch (ivx::RuntimeError & e)

--- a/modules/imgproc/src/deriv.cpp
+++ b/modules/imgproc/src/deriv.cpp
@@ -191,8 +191,8 @@ namespace cv
         if (_src.type() != CV_8UC1 || _dst.type() != CV_16SC1 ||
             ksize != 3 || scale != 1.0 || delta != 0.0 ||
             (dx | dy) != 1 || (dx + dy) != 1 ||
-            _src.cols < ksize || _src.rows < ksize ||
-            ovx::skipSmallImages<VX_KERNEL_SOBEL_3x3>(_src.cols, _src.rows)
+            _src.cols() < ksize || _src.rows() < ksize ||
+            ovx::skipSmallImages<VX_KERNEL_SOBEL_3x3>(_src.cols(), _src.rows())
             )
             return false;
 

--- a/modules/imgproc/src/featureselect.cpp
+++ b/modules/imgproc/src/featureselect.cpp
@@ -377,7 +377,8 @@ void cv::goodFeaturesToTrack( InputArray _image, OutputArray _corners,
     }
 
     // Disabled due to bad accuracy
-    CV_OVX_RUN(false && useHarrisDetector && _mask.empty(),
+    CV_OVX_RUN(false && useHarrisDetector && _mask.empty() &&
+               !ovx::skipSmallImages<VX_KERNEL_HARRIS_CORNERS>(image.cols, image.rows),
                openvx_harris(image, _corners, maxCorners, qualityLevel, minDistance, blockSize, harrisK))
 
     if( useHarrisDetector )

--- a/modules/imgproc/src/histogram.cpp
+++ b/modules/imgproc/src/histogram.cpp
@@ -1267,6 +1267,9 @@ private:
 #ifdef HAVE_OPENVX
 namespace cv
 {
+    namespace ovx {
+        template <> inline bool skipSmallImages<VX_KERNEL_HISTOGRAM>(int w, int h) { return w*h < 2048 * 1536; }
+    }
     static bool openvx_calchist(const Mat& image, OutputArray _hist, const int histSize,
         const float* _range)
     {

--- a/modules/imgproc/src/histogram.cpp
+++ b/modules/imgproc/src/histogram.cpp
@@ -1376,7 +1376,8 @@ void cv::calcHist( const Mat* images, int nimages, const int* channels,
         images && histSize &&
         nimages == 1 && images[0].type() == CV_8UC1 && dims == 1 && _mask.getMat().empty() &&
         (!channels || channels[0] == 0) && !accumulate && uniform &&
-        ranges && ranges[0],
+        ranges && ranges[0] &&
+        !ovx::skipSmallImages<VX_KERNEL_HISTOGRAM>(images[0].cols, images[0].rows),
         openvx_calchist(images[0], _hist, histSize[0], ranges[0]))
 
     CV_IPP_RUN(nimages == 1 && images[0].type() == CV_8UC1 && dims == 1 && channels &&
@@ -3817,7 +3818,7 @@ void cv::equalizeHist( InputArray _src, OutputArray _dst )
     _dst.create( src.size(), src.type() );
     Mat dst = _dst.getMat();
 
-    CV_OVX_RUN(true,
+    CV_OVX_RUN(!ovx::skipSmallImages<VX_KERNEL_EQUALIZE_HISTOGRAM>(src.cols, src.rows),
                openvx_equalize_hist(src, dst))
 
     Mutex histogramLockInstance;

--- a/modules/imgproc/src/imgwarp.cpp
+++ b/modules/imgproc/src/imgwarp.cpp
@@ -4935,6 +4935,7 @@ void cv::remap( InputArray _src, OutputArray _dst,
 
     CV_OVX_RUN(
         src.type() == CV_8UC1 && dst.type() == CV_8UC1 &&
+        !ovx::skipSmallImages<VX_KERNEL_REMAP>(src.cols, src.rows) &&
         (borderType& ~BORDER_ISOLATED) == BORDER_CONSTANT &&
         ((map1.type() == CV_32FC2 && map2.empty() && map1.size == dst.size) ||
          (map1.type() == CV_32FC1 && map2.type() == CV_32FC1 && map1.size == dst.size && map2.size == dst.size) ||

--- a/modules/imgproc/src/pyramids.cpp
+++ b/modules/imgproc/src/pyramids.cpp
@@ -1265,6 +1265,9 @@ static bool openvx_pyrDown( InputArray _src, OutputArray _dst, const Size& _dsz,
 
     Mat srcMat = _src.getMat();
 
+    if (ovx::skipSmallImages<VX_KERNEL_HALFSCALE_GAUSSIAN>(srcMat.cols, srcMat.rows))
+        return false;
+
     CV_Assert(!srcMat.empty());
 
     Size ssize = _src.size();

--- a/modules/imgproc/src/smooth.cpp
+++ b/modules/imgproc/src/smooth.cpp
@@ -1639,6 +1639,9 @@ cv::Ptr<cv::FilterEngine> cv::createBoxFilter( int srcType, int dstType, Size ks
 #ifdef HAVE_OPENVX
 namespace cv
 {
+    namespace ovx {
+        template <> inline bool skipSmallImages<VX_KERNEL_BOX_3x3>(int w, int h) { return w*h < 640 * 480; }
+    }
     static bool openvx_boxfilter(InputArray _src, OutputArray _dst, int ddepth,
                                  Size ksize, Point anchor,
                                  bool normalize, int borderType)
@@ -2172,6 +2175,9 @@ static bool ocl_GaussianBlur_8UC1(InputArray _src, OutputArray _dst, Size ksize,
 
 #ifdef HAVE_OPENVX
 
+namespace ovx {
+    template <> inline bool skipSmallImages<VX_KERNEL_GAUSSIAN_3x3>(int w, int h) { return w*h < 320 * 240; }
+}
 static bool openvx_gaussianBlur(InputArray _src, OutputArray _dst, Size ksize,
                                 double sigma1, double sigma2, int borderType)
 {
@@ -3302,6 +3308,9 @@ static bool ocl_medianFilter(InputArray _src, OutputArray _dst, int m)
 #ifdef HAVE_OPENVX
 namespace cv
 {
+    namespace ovx {
+        template <> inline bool skipSmallImages<VX_KERNEL_MEDIAN_3x3>(int w, int h) { return w*h < 1280 * 720; }
+    }
     static bool openvx_medianFilter(InputArray _src, OutputArray _dst, int ksize)
     {
         if (_src.type() != CV_8UC1 || _dst.type() != CV_8U

--- a/modules/imgproc/src/smooth.cpp
+++ b/modules/imgproc/src/smooth.cpp
@@ -1646,11 +1646,11 @@ namespace cv
         if (ddepth < 0)
             ddepth = CV_8UC1;
         if (_src.type() != CV_8UC1 || ddepth != CV_8U || !normalize ||
-            _src.cols < 3 || _src.rows < 3 ||
+            _src.cols() < 3 || _src.rows() < 3 ||
             ksize.width != 3 || ksize.height != 3 ||
             (anchor.x >= 0 && anchor.x != 1) ||
             (anchor.y >= 0 && anchor.y != 1) ||
-            ovx::skipSmallImages<VX_KERNEL_BOX_3x3>(_src.cols, _src.rows))
+            ovx::skipSmallImages<VX_KERNEL_BOX_3x3>(_src.cols(), _src.rows()))
             return false;
 
         Mat src = _src.getMat();
@@ -2184,7 +2184,7 @@ static bool openvx_gaussianBlur(InputArray _src, OutputArray _dst, Size ksize,
         ksize.height = cvRound(sigma2*6 + 1) | 1;
 
     if (_src.type() != CV_8UC1 ||
-        _src.cols < 3 || _src.rows < 3 ||
+        _src.cols() < 3 || _src.rows() < 3 ||
         ksize.width != 3 || ksize.height != 3)
         return false;
 
@@ -2192,7 +2192,7 @@ static bool openvx_gaussianBlur(InputArray _src, OutputArray _dst, Size ksize,
     sigma2 = std::max(sigma2, 0.);
 
     if (!(sigma1 == 0.0 || (sigma1 - 0.8) < DBL_EPSILON) || !(sigma2 == 0.0 || (sigma2 - 0.8) < DBL_EPSILON) ||
-        ovx::skipSmallImages<VX_KERNEL_GAUSSIAN_3x3>(_src.cols, _src.rows))
+        ovx::skipSmallImages<VX_KERNEL_GAUSSIAN_3x3>(_src.cols(), _src.rows()))
         return false;
 
     Mat src = _src.getMat();

--- a/modules/imgproc/src/smooth.cpp
+++ b/modules/imgproc/src/smooth.cpp
@@ -1643,28 +1643,17 @@ namespace cv
                                  Size ksize, Point anchor,
                                  bool normalize, int borderType)
     {
-        int stype = _src.type();
         if (ddepth < 0)
             ddepth = CV_8UC1;
-        if (stype != CV_8UC1 || (ddepth != CV_8U && ddepth != CV_16S) ||
-            (anchor.x >= 0 && anchor.x != ksize.width / 2) ||
-            (anchor.y >= 0 && anchor.y != ksize.height / 2) ||
-            ksize.width != 3 || ksize.height != 3)
+        if (_src.type() != CV_8UC1 || ddepth != CV_8U || !normalize ||
+            _src.cols < 3 || _src.rows < 3 ||
+            ksize.width != 3 || ksize.height != 3 ||
+            (anchor.x >= 0 && anchor.x != 1) ||
+            (anchor.y >= 0 && anchor.y != 1) ||
+            ovx::skipSmallImages<VX_KERNEL_BOX_3x3>(_src.cols, _src.rows))
             return false;
 
         Mat src = _src.getMat();
-
-        if (ddepth == CV_8U && ksize.width == 3 && ksize.height == 3 && normalize ?
-            ovx::skipSmallImages<VX_KERNEL_BOX_3x3>(src.cols, src.rows) :
-            ovx::skipSmallImages<VX_KERNEL_CUSTOM_CONVOLUTION>(src.cols, src.rows)
-            )
-            return false;
-
-        _dst.create(src.size(), CV_MAKETYPE(ddepth, 1));
-        Mat dst = _dst.getMat();
-
-        if (src.cols < ksize.width || src.rows < ksize.height)
-            return false;
 
         if ((borderType & BORDER_ISOLATED) == 0 && src.isSubmatrix())
             return false; //Process isolated borders only
@@ -1681,11 +1670,12 @@ namespace cv
             return false;
         }
 
+        _dst.create(src.size(), CV_8UC1);
+        Mat dst = _dst.getMat();
+
         try
         {
             ivx::Context ctx = ovx::getOpenVXContext();
-            //if ((vx_size)(ksize.width) > ctx.convolutionMaxDimension() || (vx_size)(ksize.height) > ctx.convolutionMaxDimension())
-            //    return false;
 
             Mat a;
             if (dst.data != src.data)
@@ -1696,34 +1686,14 @@ namespace cv
             ivx::Image
                 ia = ivx::Image::createFromHandle(ctx, VX_DF_IMAGE_U8,
                                                   ivx::Image::createAddressing(a.cols, a.rows, 1, (vx_int32)(a.step)), a.data),
-                ib = ivx::Image::createFromHandle(ctx, ddepth == CV_16S ? VX_DF_IMAGE_S16 : VX_DF_IMAGE_U8,
-                                                  ivx::Image::createAddressing(dst.cols, dst.rows, ddepth == CV_16S ? 2 : 1, (vx_int32)(dst.step)), dst.data);
+                ib = ivx::Image::createFromHandle(ctx, VX_DF_IMAGE_U8,
+                                                  ivx::Image::createAddressing(dst.cols, dst.rows, 1, (vx_int32)(dst.step)), dst.data);
 
             //ATTENTION: VX_CONTEXT_IMMEDIATE_BORDER attribute change could lead to strange issues in multi-threaded environments
             //since OpenVX standart says nothing about thread-safety for now
             ivx::border_t prevBorder = ctx.immediateBorder();
             ctx.setImmediateBorder(border, (vx_uint8)(0));
-            if (ddepth == CV_8U && ksize.width == 3 && ksize.height == 3 && normalize)
-            {
-                ivx::IVX_CHECK_STATUS(vxuBox3x3(ctx, ia, ib));
-            }
-            else
-            {
-#if VX_VERSION <= VX_VERSION_1_0
-                if (ctx.vendorID() == VX_ID_KHRONOS && ((vx_size)(src.cols) <= ctx.convolutionMaxDimension() || (vx_size)(src.rows) <= ctx.convolutionMaxDimension()))
-                {
-                    ctx.setImmediateBorder(prevBorder);
-                    return false;
-                }
-#endif
-                Mat convData(ksize, CV_16SC1);
-                convData = normalize ? (1 << 15) / (ksize.width * ksize.height) : 1;
-                ivx::Convolution cnv = ivx::Convolution::create(ctx, convData.cols, convData.rows);
-                cnv.copyFrom(convData);
-                if (normalize)
-                    cnv.setScale(1 << 15);
-                ivx::IVX_CHECK_STATUS(vxuConvolve(ctx, ia, cnv, ib));
-            }
+            ivx::IVX_CHECK_STATUS(vxuBox3x3(ctx, ia, ib));
             ctx.setImmediateBorder(prevBorder);
         }
         catch (ivx::RuntimeError & e)
@@ -2205,7 +2175,6 @@ static bool ocl_GaussianBlur_8UC1(InputArray _src, OutputArray _dst, Size ksize,
 static bool openvx_gaussianBlur(InputArray _src, OutputArray _dst, Size ksize,
                                 double sigma1, double sigma2, int borderType)
 {
-    int stype = _src.type();
     if (sigma2 <= 0)
         sigma2 = sigma1;
     // automatic detection of kernel size from sigma
@@ -2214,26 +2183,20 @@ static bool openvx_gaussianBlur(InputArray _src, OutputArray _dst, Size ksize,
     if (ksize.height <= 0 && sigma2 > 0)
         ksize.height = cvRound(sigma2*6 + 1) | 1;
 
-    if (stype != CV_8UC1 ||
-        ksize.width < 3 || ksize.height < 3 ||
-        ksize.width > 5 || ksize.height > 5 ||
-        ksize.width % 2 != 1 || ksize.height % 2 != 1)
+    if (_src.type() != CV_8UC1 ||
+        _src.cols < 3 || _src.rows < 3 ||
+        ksize.width != 3 || ksize.height != 3)
         return false;
 
     sigma1 = std::max(sigma1, 0.);
     sigma2 = std::max(sigma2, 0.);
 
+    if (!(sigma1 == 0.0 || (sigma1 - 0.8) < DBL_EPSILON) || !(sigma2 == 0.0 || (sigma2 - 0.8) < DBL_EPSILON) ||
+        ovx::skipSmallImages<VX_KERNEL_GAUSSIAN_3x3>(_src.cols, _src.rows))
+        return false;
+
     Mat src = _src.getMat();
     Mat dst = _dst.getMat();
-
-    if (ksize.width == 3 && ksize.height == 3 && (sigma1 == 0.0 || (sigma1 - 0.8) < DBL_EPSILON) && (sigma2 == 0.0 || (sigma2 - 0.8) < DBL_EPSILON) ?
-        ovx::skipSmallImages<VX_KERNEL_GAUSSIAN_3x3>(src.cols, src.rows) :
-        ovx::skipSmallImages<VX_KERNEL_CUSTOM_CONVOLUTION>(src.cols, src.rows)
-        )
-        return false;
-
-    if (src.cols < ksize.width || src.rows < ksize.height)
-        return false;
 
     if ((borderType & BORDER_ISOLATED) == 0 && src.isSubmatrix())
         return false; //Process isolated borders only
@@ -2253,8 +2216,6 @@ static bool openvx_gaussianBlur(InputArray _src, OutputArray _dst, Size ksize,
     try
     {
         ivx::Context ctx = ovx::getOpenVXContext();
-        if ((vx_size)(ksize.width) > ctx.convolutionMaxDimension() || (vx_size)(ksize.height) > ctx.convolutionMaxDimension())
-            return false;
 
         Mat a;
         if (dst.data != src.data)
@@ -2272,26 +2233,7 @@ static bool openvx_gaussianBlur(InputArray _src, OutputArray _dst, Size ksize,
         //since OpenVX standart says nothing about thread-safety for now
         ivx::border_t prevBorder = ctx.immediateBorder();
         ctx.setImmediateBorder(border, (vx_uint8)(0));
-        if (ksize.width == 3 && ksize.height == 3 && (sigma1 == 0.0 || (sigma1 - 0.8) < DBL_EPSILON) && (sigma2 == 0.0 || (sigma2 - 0.8) < DBL_EPSILON))
-        {
-            ivx::IVX_CHECK_STATUS(vxuGaussian3x3(ctx, ia, ib));
-        }
-        else
-        {
-#if VX_VERSION <= VX_VERSION_1_0
-            if (ctx.vendorID() == VX_ID_KHRONOS && ((vx_size)(a.cols) <= ctx.convolutionMaxDimension() || (vx_size)(a.rows) <= ctx.convolutionMaxDimension()))
-            {
-                ctx.setImmediateBorder(prevBorder);
-                return false;
-            }
-#endif
-            Mat convData;
-            cv::Mat(cv::getGaussianKernel(ksize.height, sigma2)*cv::getGaussianKernel(ksize.width, sigma1).t()).convertTo(convData, CV_16SC1, (1 << 15));
-            ivx::Convolution cnv = ivx::Convolution::create(ctx, convData.cols, convData.rows);
-            cnv.copyFrom(convData);
-            cnv.setScale(1 << 15);
-            ivx::IVX_CHECK_STATUS(vxuConvolve(ctx, ia, cnv, ib));
-        }
+        ivx::IVX_CHECK_STATUS(vxuGaussian3x3(ctx, ia, ib));
         ctx.setImmediateBorder(prevBorder);
     }
     catch (ivx::RuntimeError & e)

--- a/modules/imgproc/src/thresh.cpp
+++ b/modules/imgproc/src/thresh.cpp
@@ -1390,7 +1390,7 @@ double cv::threshold( InputArray _src, OutputArray _dst, double thresh, double m
             return thresh;
         }
 
-       CV_OVX_RUN(true,
+       CV_OVX_RUN(!ovx::skipSmallImages<VX_KERNEL_THRESHOLD>(src.cols, src.rows),
                   openvx_threshold(src, dst, ithresh, imaxval, type), (double)ithresh)
 
         thresh = ithresh;

--- a/modules/video/src/lkpyramid.cpp
+++ b/modules/video/src/lkpyramid.cpp
@@ -1074,6 +1074,9 @@ namespace
         if(prevImgMat.type() != CV_8UC1 || nextImgMat.type() != CV_8UC1)
             return false;
 
+        if (ovx::skipSmallImages<VX_KERNEL_OPTICAL_FLOW_PYR_LK>(prevImgMat.cols, prevImgMat.rows))
+            return false;
+
         CV_Assert(prevImgMat.size() == nextImgMat.size());
         Mat prevPtsMat = _prevPts.getMat();
         int checkPrev = prevPtsMat.checkVector(2, CV_32F, false);


### PR DESCRIPTION
### This pullrequest changes
Disable calls to OpenVX for small image processing in order to avoid slowdown due to call overhead

