### PR TITLE
cmake: add OPENCV_EXPORT_TS flag

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -118,6 +118,7 @@ endif()
 ocv_cmake_eval(DEBUG_PRE ONCE)
 
 ocv_clear_vars(OpenCVModules_TARGETS)
+ocv_clear_vars(OpenCVTest_TARGETS)
 
 # ----------------------------------------------------------------------------
 # Break in case of popular CMake configuration mistakes

--- a/cmake/OpenCVGenConfig.cmake
+++ b/cmake/OpenCVGenConfig.cmake
@@ -25,6 +25,7 @@ if(ANDROID)
 endif()
 
 set(OPENCV_MODULES_CONFIGCMAKE ${OPENCV_MODULES_PUBLIC})
+set(OPENCV_TEST_MODULES_CONFIGCMAKE opencv_ts)
 
 if(BUILD_FAT_JAVA_LIB AND HAVE_opencv_java)
   list(APPEND OPENCV_MODULES_CONFIGCMAKE opencv_java)
@@ -41,7 +42,14 @@ foreach(m ${OPENCV_MODULES_BUILD})
   endif()
 endforeach()
 
+if(OPENCV_EXPORT_TS)
+  set(OpenCVTest_INCLUDE_DIRS_CONFIGCMAKE "${OpenCV_INCLUDE_DIRS_CONFIGCMAKE} \"${OPENCV_MODULE_opencv_ts_LOCATION}/include\"")
+endif()
+
 export(TARGETS ${OpenCVModules_TARGETS} FILE "${CMAKE_BINARY_DIR}/OpenCVModules.cmake")
+if(OPENCV_EXPORT_TS)
+  export(TARGETS ${OpenCVTest_TARGETS} FILE "${CMAKE_BINARY_DIR}/OpenCVTestModules.cmake")
+endif()
 
 if(TARGET ippicv AND NOT BUILD_SHARED_LIBS)
   set(USE_IPPICV TRUE)
@@ -52,14 +60,21 @@ else()
 endif()
 
 configure_file("${OpenCV_SOURCE_DIR}/cmake/templates/OpenCVConfig.cmake.in" "${CMAKE_BINARY_DIR}/OpenCVConfig.cmake" @ONLY)
-#support for version checking when finding opencv. find_package(OpenCV 2.3.1 EXACT) should now work.
 configure_file("${OpenCV_SOURCE_DIR}/cmake/templates/OpenCVConfig-version.cmake.in" "${CMAKE_BINARY_DIR}/OpenCVConfig-version.cmake" @ONLY)
+if(OPENCV_EXPORT_TS)
+  configure_file("${OpenCV_SOURCE_DIR}/cmake/templates/OpenCVTestConfig.cmake.in" "${CMAKE_BINARY_DIR}/OpenCVTestConfig.cmake" @ONLY)
+  configure_file("${OpenCV_SOURCE_DIR}/cmake/templates/OpenCVConfig-version.cmake.in" "${CMAKE_BINARY_DIR}/OpenCVTestConfig-version.cmake" @ONLY)
+endif()
 
 # --------------------------------------------------------------------------------------------
 #  Part 2/3: ${BIN_DIR}/unix-install/OpenCVConfig.cmake -> For use *with* "make install"
 # -------------------------------------------------------------------------------------------
 file(RELATIVE_PATH OpenCV_INSTALL_PATH_RELATIVE_CONFIGCMAKE "${CMAKE_INSTALL_PREFIX}/${OPENCV_CONFIG_INSTALL_PATH}/" ${CMAKE_INSTALL_PREFIX})
 set(OpenCV_INCLUDE_DIRS_CONFIGCMAKE "\"\${OpenCV_INSTALL_PATH}/${OPENCV_INCLUDE_INSTALL_PATH}\" \"\${OpenCV_INSTALL_PATH}/${OPENCV_INCLUDE_INSTALL_PATH}/opencv\"")
+
+if(OPENCV_EXPORT_TS)
+  set(OpenCVTest_INCLUDE_DIRS_CONFIGCMAKE "${OpenCV_INCLUDE_DIRS_CONFIGCMAKE}")
+endif()
 
 if(USE_IPPICV)
   file(RELATIVE_PATH IPPICV_INSTALL_PATH_RELATIVE_CONFIGCMAKE "${CMAKE_INSTALL_PREFIX}" ${IPPICV_INSTALL_PATH})
@@ -88,6 +103,26 @@ function(ocv_gen_config TMP_DIR NESTED_PATH ROOT_NAME)
         "${TMP_DIR}/OpenCVConfig-version.cmake"
         "${TMP_DIR}/OpenCVConfig.cmake"
         DESTINATION "${OPENCV_CONFIG_INSTALL_PATH}" COMPONENT dev)
+  endif()
+
+  if(OPENCV_EXPORT_TS)
+    if(NOT OPENCV_TEST_CONFIG_INSTALL_PATH)
+      string(REGEX REPLACE "OpenCV$" "OpenCVTest" OPENCV_TEST_CONFIG_INSTALL_PATH "${OPENCV_CONFIG_INSTALL_PATH}")
+      if(OPENCV_TEST_CONFIG_INSTALL_PATH STREQUAL OPENCV_CONFIG_INSTALL_PATH)
+        string(REGEX REPLACE "opencv$" "opencvtest" OPENCV_TEST_CONFIG_INSTALL_PATH "${OPENCV_CONFIG_INSTALL_PATH}")
+      endif()
+    endif()
+    ocv_path_join(__install_nested "${OPENCV_TEST_CONFIG_INSTALL_PATH}" "${NESTED_PATH}")
+
+    install(EXPORT OpenCVTest DESTINATION "${__install_nested}" FILE OpenCVTestModules.cmake COMPONENT dev)
+    configure_file("${OpenCV_SOURCE_DIR}/cmake/templates/OpenCVConfig-version.cmake.in" "${TMP_DIR}/OpenCVTestConfig-version.cmake" @ONLY)
+
+    configure_file("${OpenCV_SOURCE_DIR}/cmake/templates/OpenCVTestConfig.cmake.in" "${__tmp_nested}/OpenCVTestConfig.cmake" @ONLY)
+    install(EXPORT OpenCVTest DESTINATION "${__install_nested}" FILE OpenCVTestModules.cmake COMPONENT dev)
+    install(FILES
+        "${TMP_DIR}/OpenCVTestConfig-version.cmake"
+        "${__tmp_nested}/OpenCVTestConfig.cmake"
+        DESTINATION "${__install_nested}" COMPONENT dev)
   endif()
 endfunction()
 

--- a/cmake/templates/OpenCVTestConfig.cmake.in
+++ b/cmake/templates/OpenCVTestConfig.cmake.in
@@ -1,0 +1,108 @@
+# ===================================================================================
+#  The OpenCV Test framework CMake configuration file (opencv_ts module)
+#
+#             ** File generated automatically, do not modify **
+#
+#  Usage from an external project:
+#    In your CMakeLists.txt, add these lines:
+#
+#    find_package(OpenCVTest REQUIRED)
+#    target_link_libraries(MY_TEST_TARGET_NAME ${OpenCVTest_LIBS})
+#
+#    This file will define the following variables:
+#      - OpenCVTest_LIBS                     : The list of all imported targets for OpenCV modules.
+#      - OpenCVTest_INCLUDE_DIRS             : The OpenCV include directories (for CMake < 2.8.11)
+#
+# ===================================================================================
+
+SET(OpenCVTest_VERSION @OPENCV_VERSION_PLAIN@)
+SET(OpenCVTest_VERSION_MAJOR  @OPENCV_VERSION_MAJOR@)
+SET(OpenCVTest_VERSION_MINOR  @OPENCV_VERSION_MINOR@)
+SET(OpenCVTest_VERSION_PATCH  @OPENCV_VERSION_PATCH@)
+SET(OpenCVTest_VERSION_STATUS "@OPENCV_VERSION_STATUS@")
+
+include(FindPackageHandleStandardArgs)
+
+find_package(OpenCV ${OpenCVTest_VERSION} EXACT REQUIRED QUIET)
+
+# Extract the directory where *this* file has been installed (determined at cmake run-time)
+# Get the absolute path with no ../.. relative marks, to eliminate implicit linker warnings
+set(OpenCVTest_CONFIG_PATH "${CMAKE_CURRENT_LIST_DIR}")
+if(NOT DEFINED OpenCV_INSTALL_PATH)
+  get_filename_component(OpenCV_INSTALL_PATH "${OpenCVTest_CONFIG_PATH}/@OpenCV_INSTALL_PATH_RELATIVE_CONFIGCMAKE@" REALPATH)
+endif()
+set(OpenCVTest_INSTALL_PATH "${OpenCV_INSTALL_PATH}")
+
+# Some additional settings are required if OpenCV is built as static libs
+set(OpenCVTest_SHARED @BUILD_SHARED_LIBS@)
+
+# Enables mangled install paths, that help with side by side installs
+set(OpenCVTest_USE_MANGLED_PATHS @OpenCV_USE_MANGLED_PATHS_CONFIGCMAKE@)
+
+set(OpenCVTest_LIB_COMPONENTS @OPENCV_TEST_MODULES_CONFIGCMAKE@)
+set(OpenCVTest_INCLUDE_DIRS @OpenCV_INCLUDE_DIRS_CONFIGCMAKE@)
+
+if(NOT TARGET opencv_ts)
+  include(${CMAKE_CURRENT_LIST_DIR}/OpenCVTestModules${OpenCVTest_MODULES_SUFFIX}.cmake)
+endif()
+
+if(NOT CMAKE_VERSION VERSION_LESS "2.8.11")
+  # Target property INTERFACE_INCLUDE_DIRECTORIES available since 2.8.11:
+  # * http://www.cmake.org/cmake/help/v2.8.11/cmake.html#prop_tgt:INTERFACE_INCLUDE_DIRECTORIES
+  foreach(__component ${OpenCVTest_LIB_COMPONENTS})
+    if(TARGET ${__component})
+      set_target_properties(
+          ${__component}
+          PROPERTIES
+          INTERFACE_INCLUDE_DIRECTORIES "${OpenCVTest_INCLUDE_DIRS}"
+      )
+    endif()
+  endforeach()
+endif()
+
+# ==============================================================
+#  Form list of modules (components) to find
+# ==============================================================
+if(NOT OpenCVTest_FIND_COMPONENTS)
+  set(OpenCVTest_FIND_COMPONENTS ${OpenCVTest_LIB_COMPONENTS})
+endif()
+
+# expand short module names and see if requested components exist
+foreach(__cvcomponent ${OpenCVTest_FIND_COMPONENTS})
+  # Store the name of the original component so we can set the
+  # OpenCVTest_<component>_FOUND variable which can be checked by the user.
+  set (__original_cvcomponent ${__cvcomponent})
+  if(NOT __cvcomponent MATCHES "^opencv_")
+    set(__cvcomponent opencv_${__cvcomponent})
+  endif()
+  list(FIND OpenCVTest_LIB_COMPONENTS ${__cvcomponent} __cvcomponentIdx)
+  if(__cvcomponentIdx LESS 0)
+      # Either the component is required or the user did not set any components at
+      # all. In the latter case, the OpenCVTest_FIND_REQUIRED_<component> variable
+      # will not be defined since it is not set by this config. So let's assume
+      # the implicitly set components are always required.
+      if(NOT DEFINED OpenCVTest_FIND_REQUIRED_${__original_cvcomponent} OR
+          OpenCVTest_FIND_REQUIRED_${__original_cvcomponent})
+        message(FATAL_ERROR "${__cvcomponent} is required but was not found")
+      elseif(NOT OpenCVTest_FIND_QUIETLY)
+        # The component was marked as optional using OPTIONAL_COMPONENTS
+        message(WARNING "Optional component ${__cvcomponent} was not found")
+      endif()
+    #indicate that module is NOT found
+    string(TOUPPER "${__cvcomponent}" __cvcomponentUP)
+    set(${__cvcomponentUP}_FOUND "${__cvcomponentUP}_FOUND-NOTFOUND")
+    set(OpenCVTest_${__original_cvcomponent}_FOUND FALSE)
+  else()
+    # Not using list(APPEND) here, because OpenCVTest_LIBS may not exist yet.
+    # Also not clearing OpenCVTest_LIBS anywhere, so that multiple calls
+    # to find_package(OpenCV) with different component lists add up.
+    set(OpenCVTest_LIBS ${OpenCVTest_LIBS} "${__cvcomponent}")
+    #indicate that module is found
+    string(TOUPPER "${__cvcomponent}" __cvcomponentUP)
+    set(${__cvcomponentUP}_FOUND 1)
+    set(OpenCVTest_${__original_cvcomponent}_FOUND TRUE)
+  endif()
+endforeach()
+
+find_package_handle_standard_args(OpenCVTest REQUIRED_VARS OpenCVTest_INSTALL_PATH
+                                  VERSION_VAR OpenCVTest_VERSION)

--- a/modules/ts/CMakeLists.txt
+++ b/modules/ts/CMakeLists.txt
@@ -1,10 +1,16 @@
 set(the_description "The ts module")
 
-if(NOT BUILD_opencv_ts AND NOT BUILD_TESTS AND NOT BUILD_PERF_TESTS)
+if(NOT BUILD_opencv_ts
+    AND NOT BUILD_TESTS
+    AND NOT BUILD_PERF_TESTS
+    AND NOT OPENCV_EXPORT_TS
+)
   ocv_module_disable(ts)
 endif()
 
-set(OPENCV_MODULE_TYPE STATIC)
+if(NOT OPENCV_EXPORT_TS)
+  set(OPENCV_MODULE_TYPE STATIC)
+endif()
 set(OPENCV_MODULE_IS_PART_OF_WORLD FALSE)
 
 if(WINRT)
@@ -40,4 +46,20 @@ if(EXISTS "${OPENCV_TESTS_CONFIG_FILE}")
 endif()
 if(NOT OPENCV_TESTS_CONFIG_STR STREQUAL "${__content}")
   file(WRITE "${OPENCV_TESTS_CONFIG_FILE}" "${OPENCV_TESTS_CONFIG_STR}")
+endif()
+
+if(OPENCV_EXPORT_TS)
+  set(m ${the_module})
+  foreach(hdr ${OPENCV_MODULE_${m}_HEADERS})
+    string(REGEX REPLACE "^.*opencv2/" "opencv2/" hdr2 "${hdr}")
+    if(NOT hdr2 MATCHES "opencv2/${m}/private.*" AND hdr2 MATCHES "^(opencv2/?.*)/[^/]+.h(..)?$" )
+      install(FILES ${hdr} OPTIONAL DESTINATION "${OPENCV_INCLUDE_INSTALL_PATH}/${CMAKE_MATCH_1}" COMPONENT dev)
+    endif()
+  endforeach()
+
+  ocv_install_target(${the_module} EXPORT OpenCVTest OPTIONAL
+    RUNTIME DESTINATION ${OPENCV_BIN_INSTALL_PATH} COMPONENT dev
+    LIBRARY DESTINATION ${OPENCV_LIB_INSTALL_PATH} COMPONENT dev NAMELINK_SKIP
+    ARCHIVE DESTINATION ${OPENCV_LIB_INSTALL_PATH} COMPONENT dev
+  )
 endif()

--- a/modules/ts/include/opencv2/ts.hpp
+++ b/modules/ts/include/opencv2/ts.hpp
@@ -539,7 +539,7 @@ protected:
     }
 };
 
-extern uint64 param_seed;
+extern CV_EXPORTS uint64 param_seed;
 
 struct CV_EXPORTS DefaultRngAuto
 {
@@ -595,14 +595,14 @@ CV_EXPORTS std::string findDataFile(const std::string& relative_path, bool requi
 
 #ifdef HAVE_OPENCL
 namespace ocl {
-void dumpOpenCLDevice();
+CV_EXPORTS void dumpOpenCLDevice();
 }
 #define TEST_DUMP_OCL_INFO cvtest::ocl::dumpOpenCLDevice();
 #else
 #define TEST_DUMP_OCL_INFO
 #endif
 
-void parseCustomOptions(int argc, char **argv);
+CV_EXPORTS void parseCustomOptions(int argc, char **argv);
 
 #define CV_TEST_INIT0_NOOP (void)0
 

--- a/modules/ts/include/opencv2/ts/ocl_test.hpp
+++ b/modules/ts/include/opencv2/ts/ocl_test.hpp
@@ -84,7 +84,7 @@ inline UMat ToUMat(InputArray src)
     return dst;
 }
 
-extern int test_loop_times;
+extern CV_EXPORTS int test_loop_times;
 
 #define MAX_VALUE 357
 

--- a/modules/ts/include/opencv2/ts/ts_ext.hpp
+++ b/modules/ts/include/opencv2/ts/ts_ext.hpp
@@ -9,7 +9,7 @@
 #define OPENCV_TS_EXT_HPP
 
 namespace cvtest {
-void checkIppStatus();
+CV_EXPORTS void checkIppStatus();
 }
 
 #define CV_TEST_INIT \


### PR DESCRIPTION
Use this flag to create separate package "OpenCVTest" with opencv_ts module.

Tested on Linux with shared/static build configuration.
There is no support for Android.mk.

<!--
======================================================================
======================================================================
======================================================================
======================================================================
-->

CMakeLists.txt example:
```
project(example_test_project)

# this line is not necessary
find_package(OpenCV REQUIRED)

# contains "find_package(OpenCV)" statement with the the same exact version
find_package(OpenCVTest REQUIRED)

add_executable(opencv_example_test test.cpp)

# add opencv_ts dependency to test app
target_link_libraries(opencv_example_test ${OpenCVTest_LIBS})
```