### PR TITLE
Standalone opencv_ts build

### DIFF
--- a/modules/core/include/opencv2/core/private.hpp
+++ b/modules/core/include/opencv2/core/private.hpp
@@ -165,11 +165,6 @@ static inline cv::Size cvGetMatSize( const CvMat* mat )
 }
 #endif
 
-namespace cv
-{
-CV_EXPORTS void scalarToRawData(const cv::Scalar& s, void* buf, int type, int unroll_to = 0);
-}
-
 // property implementation macros
 
 #define CV_IMPL_PROPERTY_RO(type, name, member) \

--- a/modules/core/include/opencv2/core/types.hpp
+++ b/modules/core/include/opencv2/core/types.hpp
@@ -622,7 +622,7 @@ public:
     typedef Vec<channel_type, channels> vec_type;
 };
 
-
+CV_EXPORTS void scalarToRawData(const cv::Scalar& s, void* buf, int type, int unroll_to = 0);
 
 /////////////////////////////// KeyPoint ////////////////////////////////
 

--- a/modules/ts/CMakeLists.txt
+++ b/modules/ts/CMakeLists.txt
@@ -1,3 +1,9 @@
+if(NOT DEFINED OPENCV_INITIAL_PASS)
+  cmake_minimum_required(VERSION 2.8)
+  include(standalone.cmake)
+  return()
+endif()
+
 set(the_description "The ts module")
 
 if(NOT BUILD_opencv_ts AND NOT BUILD_TESTS AND NOT BUILD_PERF_TESTS)

--- a/modules/ts/include/opencv2/ts.hpp
+++ b/modules/ts/include/opencv2/ts.hpp
@@ -4,7 +4,11 @@
 #include "opencv2/core/cvdef.h"
 #include <stdarg.h> // for va_list
 
+#if __OPENCV_BUILD
 #include "cvconfig.h"
+#else
+#include "opencv2/cvconfig.h"
+#endif
 
 #ifdef WINRT
     #pragma warning(disable:4447) // Disable warning 'main' signature found without threading model

--- a/modules/ts/include/opencv2/ts/cuda_perf.hpp
+++ b/modules/ts/include/opencv2/ts/cuda_perf.hpp
@@ -43,12 +43,12 @@
 #ifndef OPENCV_CUDA_PERF_UTILITY_HPP
 #define OPENCV_CUDA_PERF_UTILITY_HPP
 
+#include "opencv2/ts.hpp"
+#include "opencv2/ts/ts_perf.hpp"
 #include "opencv2/core.hpp"
 #include "opencv2/imgcodecs.hpp"
 #include "opencv2/videoio.hpp"
 #include "opencv2/imgproc.hpp"
-#include "opencv2/ts/ts_perf.hpp"
-#include "cvconfig.h"
 
 namespace perf
 {

--- a/modules/ts/include/opencv2/ts/cuda_test.hpp
+++ b/modules/ts/include/opencv2/ts/cuda_test.hpp
@@ -44,13 +44,12 @@
 #define OPENCV_CUDA_TEST_UTILITY_HPP
 
 #include <stdexcept>
-#include "cvconfig.h"
+#include "opencv2/ts.hpp"
 #include "opencv2/core.hpp"
 #include "opencv2/core/cuda.hpp"
 #include "opencv2/imgcodecs.hpp"
 #include "opencv2/highgui.hpp"
 #include "opencv2/imgproc.hpp"
-#include "opencv2/ts.hpp"
 
 namespace cvtest
 {

--- a/modules/ts/src/precomp.hpp
+++ b/modules/ts/src/precomp.hpp
@@ -1,7 +1,8 @@
 #include "opencv2/core/utility.hpp"
+#if __OPENCV_BUILD
 #include "opencv2/core/private.hpp"
+#endif
 #include "opencv2/ts.hpp"
-#include "cvconfig.h"
 
 #ifdef GTEST_LINKED_AS_SHARED_LIBRARY
 #error ts module should not have GTEST_LINKED_AS_SHARED_LIBRARY defined

--- a/modules/ts/src/ts.cpp
+++ b/modules/ts/src/ts.cpp
@@ -74,8 +74,9 @@
 # include <sys/stat.h>
 #endif
 
-
+#if __OPENCV_BUILD
 #include "opencv_tests_config.hpp"
+#endif
 
 namespace cvtest
 {

--- a/modules/ts/src/ts_func.cpp
+++ b/modules/ts/src/ts_func.cpp
@@ -2992,12 +2992,14 @@ void printVersionInfo(bool useStdOut)
     ::testing::Test::RecordProperty("cv_build_type", build_type);
     if (useStdOut) std::cout << "Build type: " << build_type << std::endl;
 
+#if __OPENCV_BUILD
     const char* parallel_framework = currentParallelFramework();
 
     if (parallel_framework) {
         ::testing::Test::RecordProperty("cv_parallel_framework", parallel_framework);
         if (useStdOut) std::cout << "Parallel framework: " << parallel_framework << std::endl;
     }
+#endif
 
     std::string cpu_features;
 

--- a/modules/ts/standalone.cmake
+++ b/modules/ts/standalone.cmake
@@ -1,0 +1,15 @@
+find_package(OpenCV REQUIRED opencv_core opencv_imgproc opencv_imgcodecs opencv_videoio opencv_highgui)
+if(CMAKE_VERSION VERSION_LESS "2.8.11")
+  include_directories(${OpenCV_INCLUDE_DIRS})
+endif()
+
+message(STATUS "OpenCV INCLUDES: ${OpenCV_INCLUDE_DIRS}")
+
+file(GLOB SRCS src/*.cpp)
+add_library(opencv_ts SHARED ${SRCS})
+target_include_directories(opencv_ts PRIVATE include ${OpenCV_INCLUDE_DIRS})
+target_link_libraries(opencv_ts PRIVATE ${OpenCV_LIBS})
+
+install(TARGETS opencv_ts EXPORT opencv_ts LIBRARY DESTINATION lib INCLUDES DESTINATION include)
+install(DIRECTORY include/opencv2 DESTINATION include)
+install(EXPORT opencv_ts DESTINATION share/OpenCV)


### PR DESCRIPTION
This experimental patch adds an ability to build standalone shared _opencv_ts_ library (alternative to #8461).
The process is:
* build and install OpenCV
* build and install _opencv_ts_
* build a test application which uses both OpenCV and _opencv_ts_

#### Standalone _opencv_ts_ library
Build command (install to _build/install_):
```.sh
cmake  ../opencv/modules/ts \
    -DOpenCV_DIR=$OPENCV_INSTALL_DIR/share/OpenCV \
    -DCMAKE_INSTALL_PREFIX=install
make install
```

#### Example application:
CMakeLists.txt:
```.cmake
cmake_minimum_required(VERSION 2.8)
project(my_example)
find_package(OpenCV REQUIRED)
include(${opencv_ts_DIR}/opencv_ts.cmake)
add_executable(my_example example.cpp)
target_link_libraries(my_example ${OpenCV_LIBS} opencv_ts)
```
example.cpp:
```.cpp
#include "opencv2/ts.hpp"
#include "opencv2/core.hpp"
CV_TEST_MAIN(".")
TEST(MyExample, Test1) {
    cv::Mat a(1, 1, CV_8U), b(1, 1, CV_8U);
    a = 0; b = 1; cv::swap(a, b);
    EXPECT_EQ(1, a.at<uchar>(0));
}
```
Build command:
```.sh
cmake ../test \
  -DOpenCV_DIR=$OPENCV_INSTALL_DIR/share/OpenCV \
  -Dopencv_ts_DIR=$TS_INSTALL_DIR/share/OpenCV
make
```