### PR TITLE
Clear old CameraParameters in AffineBasedEstimator

### DIFF
--- a/modules/stitching/src/motion_estimators.cpp
+++ b/modules/stitching/src/motion_estimators.cpp
@@ -199,7 +199,7 @@ bool AffineBasedEstimator::estimate(const std::vector<ImageFeatures> &features,
                                     const std::vector<MatchesInfo> &pairwise_matches,
                                     std::vector<CameraParams> &cameras)
 {
-    cameras.resize(features.size());
+    cameras.assign(features.size(), CameraParams());
     const int num_images = static_cast<int>(features.size());
 
     // find maximum spaning tree on pairwise matches


### PR DESCRIPTION
AffineBasedEstimator crashed when called with an existing CameraParameters.
This happens e.g. when using Stitcher in SCANS mode.
CameraraParameters is now cleared before any calculation is executed.

<!-- Please use this line to close one or multiple issues when this pullrequest gets merged
You can add another line right under the first one:
resolves #1234
resolves #1235
-->


<!-- Please describe what your pullrequest is changing -->
