### PR TITLE
fix comment in optim.hpp

### DIFF
--- a/modules/core/include/opencv2/core/optim.hpp
+++ b/modules/core/include/opencv2/core/optim.hpp
@@ -73,7 +73,7 @@ public:
     /** @brief Getter for the optimized function.
 
     The optimized function is represented by Function interface, which requires derivatives to
-    implement the sole method calc(double*) to evaluate the function.
+    implement the calc(double*) and getDim() methods to evaluate the function.
 
     @return Smart-pointer to an object that implements Function interface - it represents the
     function that is being optimized. It can be empty, if no function was given so far.


### PR DESCRIPTION
[this previous commit](https://github.com/berak/opencv/commit/63a63e3eaa1fb6e350fabcff29d1144229fc2ad6#diff-664c796960424d36f8af4a50f1845856) added another pure virtual `int getDims()` method, which has to be implemented.