### PR TITLE
autorotate in-memory jpegs

### DIFF
--- a/modules/imgcodecs/src/exif.hpp
+++ b/modules/imgcodecs/src/exif.hpp
@@ -51,6 +51,7 @@
 #include <stdint.h>
 #include <string>
 #include <vector>
+#include <iostream>
 
 namespace cv
 {
@@ -168,9 +169,9 @@ public:
     /**
      * @brief ExifReader constructor. Constructs an object of exif reader
      *
-     * @param [in]filename The name of file to look exif info in
+     * @param [in]stream An istream to look for EXIF bytes from
      */
-    explicit ExifReader( std::string filename );
+    explicit ExifReader( std::istream& stream );
     ~ExifReader();
 
 
@@ -190,7 +191,7 @@ public:
     ExifEntry_t getTag( const ExifTagName tag );
 
 private:
-    std::string m_filename;
+    std::istream& m_stream;
     std::vector<unsigned char> m_data;
     std::map<int, ExifEntry_t > m_exif;
     Endianess_t m_format;
@@ -198,7 +199,7 @@ private:
     void parseExif();
     bool checkTagMark() const;
 
-    size_t getFieldSize ( FILE* f ) const;
+    size_t getFieldSize ();
     size_t getNumDirEntry() const;
     uint32_t getStartOffset() const;
     uint16_t getExifTag( const size_t offset ) const;
@@ -245,7 +246,6 @@ private:
     //number of Reference Black&White components
     static const size_t refBWComponents = 6;
 };
-
 
 
 }

--- a/modules/imgcodecs/src/loadsave.cpp
+++ b/modules/imgcodecs/src/loadsave.cpp
@@ -82,13 +82,13 @@ protected:
         }
 
         // check limits
-        if (off < (off_type)0 || off >= egptr() - eback())
+        if (off >= (off_type)0 && off <= egptr() - eback())
         {
-            return -1;
+            setg(eback(), gptr() + off, egptr());
+            return gptr() - eback();
         }
 
-        setg(eback(), gptr() + off, egptr());
-        return gptr() - eback();
+        return -1;
     }
 };
 

--- a/modules/imgcodecs/src/loadsave.cpp
+++ b/modules/imgcodecs/src/loadsave.cpp
@@ -66,23 +66,28 @@ public:
     }
 
 protected:
-    virtual pos_type seekoff( off_type off,
+    virtual pos_type seekoff( off_type offset,
                               std::ios_base::seekdir dir,
                               std::ios_base::openmode )
     {
+        // get absolute offset
+        off_type off = offset;
         if (dir == std::ios_base::cur)
         {
-            if (gptr() + off >= egptr())
-            {
-                return -1;
-            }
-            if (gptr() + off < eback())
-            {
-                return -1;
-            }
-            setg(eback(), gptr() + off, egptr());
+            off += gptr() - eback();
+        }
+        else if (dir == std::ios_base::end)
+        {
+            off += egptr() - eback();
         }
 
+        // check limits
+        if (off < (off_type)0 || off >= egptr() - eback())
+        {
+            return -1;
+        }
+
+        setg(eback(), gptr() + off, egptr());
         return gptr() - eback();
     }
 };

--- a/modules/imgcodecs/src/loadsave.cpp
+++ b/modules/imgcodecs/src/loadsave.cpp
@@ -558,7 +558,7 @@ Mat imread( const String& filename, int flags )
     imread_( filename, flags, LOAD_MAT, &img );
 
     /// optionally rotate the data if EXIF' orientation flag says so
-    if( (flags & IMREAD_IGNORE_ORIENTATION) == 0 && flags != IMREAD_UNCHANGED )
+    if( !img.empty() && (flags & IMREAD_IGNORE_ORIENTATION) == 0 && flags != IMREAD_UNCHANGED )
     {
         ApplyExifOrientation(filename, img);
     }
@@ -724,7 +724,7 @@ Mat imdecode( InputArray _buf, int flags )
     imdecode_( buf, flags, LOAD_MAT, &img );
 
     /// optionally rotate the data if EXIF' orientation flag says so
-    if( (flags & IMREAD_IGNORE_ORIENTATION) == 0 && flags != IMREAD_UNCHANGED )
+    if( !img.empty() && (flags & IMREAD_IGNORE_ORIENTATION) == 0 && flags != IMREAD_UNCHANGED )
     {
         ApplyExifOrientation(buf, img);
     }
@@ -739,7 +739,7 @@ Mat imdecode( InputArray _buf, int flags, Mat* dst )
     imdecode_( buf, flags, LOAD_MAT, dst );
 
     /// optionally rotate the data if EXIF' orientation flag says so
-    if( (flags & IMREAD_IGNORE_ORIENTATION) == 0 && flags != IMREAD_UNCHANGED )
+    if( !dst->empty() && (flags & IMREAD_IGNORE_ORIENTATION) == 0 && flags != IMREAD_UNCHANGED )
     {
         ApplyExifOrientation(buf, *dst);
     }

--- a/modules/imgcodecs/src/loadsave.cpp
+++ b/modules/imgcodecs/src/loadsave.cpp
@@ -57,34 +57,34 @@
 \****************************************************************************************/
 namespace {
 
-class ByteStreamBuffer : public std::streambuf
+class ByteStreamBuffer: public std::streambuf
 {
 public:
-   ByteStreamBuffer(char* base, size_t length)
-   {
-      setg( base, base, base + length );
-   };
+    ByteStreamBuffer(char* base, size_t length)
+    {
+        setg(base, base, base + length);
+    }
 
 protected:
-   virtual pos_type seekoff( off_type off,
-                             std::ios_base::seekdir dir,
-                             std::ios_base::openmode )
-   {
-      if( dir == std::ios_base::cur )
-      {
-         if( gptr() + off >= egptr() )
-         {
-            return -1;
-         }
-         if( gptr() + off < eback() )
-         {
-            return -1;
-         }
-         setg( eback(), gptr() + off, egptr() );
-      }
+    virtual pos_type seekoff( off_type off,
+                              std::ios_base::seekdir dir,
+                              std::ios_base::openmode )
+    {
+        if (dir == std::ios_base::cur)
+        {
+            if (gptr() + off >= egptr())
+            {
+                return -1;
+            }
+            if (gptr() + off < eback())
+            {
+                return -1;
+            }
+            setg(eback(), gptr() + off, egptr());
+        }
 
-      return gptr() - eback();
-   }
+        return gptr() - eback();
+    }
 };
 
 }
@@ -310,17 +310,17 @@ static void ApplyExifOrientation(const String& filename, Mat& img)
 
     if (filename.size() > 0)
     {
-       std::ifstream stream( filename.c_str(), std::ios_base::in | std::ios_base::binary );
-       ExifReader reader( stream );
-       if( reader.parse() )
-       {
-           ExifEntry_t entry = reader.getTag( ORIENTATION );
-           if (entry.tag != INVALID_TAG)
-           {
-               orientation = entry.field_u16; //orientation is unsigned short, so check field_u16
-           }
-       }
-       stream.close();
+        std::ifstream stream( filename.c_str(), std::ios_base::in | std::ios_base::binary );
+        ExifReader reader( stream );
+        if( reader.parse() )
+        {
+            ExifEntry_t entry = reader.getTag( ORIENTATION );
+            if (entry.tag != INVALID_TAG)
+            {
+                orientation = entry.field_u16; //orientation is unsigned short, so check field_u16
+            }
+        }
+        stream.close();
     }
 
     ExifTransform(orientation, img);
@@ -332,17 +332,17 @@ static void ApplyExifOrientation(const Mat& buf, Mat& img)
 
     if( buf.isContinuous() )
     {
-       ByteStreamBuffer bsb( reinterpret_cast<char*>(buf.data), buf.total() * buf.elemSize() );
-       std::istream stream( &bsb );
-       ExifReader reader( stream );
-       if( reader.parse() )
-       {
-           ExifEntry_t entry = reader.getTag( ORIENTATION );
-           if (entry.tag != INVALID_TAG)
-           {
-               orientation = entry.field_u16; //orientation is unsigned short, so check field_u16
-           }
-       }
+        ByteStreamBuffer bsb( reinterpret_cast<char*>(buf.data), buf.total() * buf.elemSize() );
+        std::istream stream( &bsb );
+        ExifReader reader( stream );
+        if( reader.parse() )
+        {
+            ExifEntry_t entry = reader.getTag( ORIENTATION );
+            if (entry.tag != INVALID_TAG)
+            {
+                orientation = entry.field_u16; //orientation is unsigned short, so check field_u16
+            }
+        }
     }
 
     ExifTransform(orientation, img);

--- a/modules/imgcodecs/src/loadsave.cpp
+++ b/modules/imgcodecs/src/loadsave.cpp
@@ -50,10 +50,45 @@
 #undef min
 #undef max
 #include <iostream>
+#include <fstream>
 
 /****************************************************************************************\
 *                                      Image Codecs                                      *
 \****************************************************************************************/
+namespace {
+
+class ByteStreamBuffer : public std::streambuf
+{
+public:
+   ByteStreamBuffer(char* base, size_t length)
+   {
+      setg( base, base, base + length );
+   };
+
+protected:
+   virtual pos_type seekoff( off_type off,
+                             std::ios_base::seekdir dir,
+                             std::ios_base::openmode )
+   {
+      if( dir == std::ios_base::cur )
+      {
+         if( gptr() + off >= egptr() )
+         {
+            return -1;
+         }
+         if( gptr() + off < eback() )
+         {
+            return -1;
+         }
+         setg( eback(), gptr() + off, egptr() );
+      }
+
+      return gptr() - eback();
+   }
+};
+
+}
+
 namespace cv
 {
 
@@ -232,23 +267,8 @@ static ImageEncoder findEncoder( const String& _ext )
 
 enum { LOAD_CVMAT=0, LOAD_IMAGE=1, LOAD_MAT=2 };
 
-static void ApplyExifOrientation(const String& filename, Mat& img)
+static void ExifTransform(int orientation, Mat& img)
 {
-    int orientation = IMAGE_ORIENTATION_TL;
-
-    if (filename.size() > 0)
-    {
-        ExifReader reader( filename );
-        if( reader.parse() )
-        {
-            ExifEntry_t entry = reader.getTag( ORIENTATION );
-            if (entry.tag != INVALID_TAG)
-            {
-                orientation = entry.field_u16; //orientation is unsigned short, so check field_u16
-            }
-        }
-    }
-
     switch( orientation )
     {
         case    IMAGE_ORIENTATION_TL: //0th row == visual top, 0th column == visual left-hand side
@@ -282,6 +302,50 @@ static void ApplyExifOrientation(const String& filename, Mat& img)
             //by default the image read has normal (JPEG_ORIENTATION_TL) orientation
             break;
     }
+}
+
+static void ApplyExifOrientation(const String& filename, Mat& img)
+{
+    int orientation = IMAGE_ORIENTATION_TL;
+
+    if (filename.size() > 0)
+    {
+       std::ifstream stream( filename.c_str(), std::ios_base::in | std::ios_base::binary );
+       ExifReader reader( stream );
+       if( reader.parse() )
+       {
+           ExifEntry_t entry = reader.getTag( ORIENTATION );
+           if (entry.tag != INVALID_TAG)
+           {
+               orientation = entry.field_u16; //orientation is unsigned short, so check field_u16
+           }
+       }
+       stream.close();
+    }
+
+    ExifTransform(orientation, img);
+}
+
+static void ApplyExifOrientation(const Mat& buf, Mat& img)
+{
+    int orientation = IMAGE_ORIENTATION_TL;
+
+    if( buf.isContinuous() )
+    {
+       ByteStreamBuffer bsb( reinterpret_cast<char*>(buf.data), buf.total() * buf.elemSize() );
+       std::istream stream( &bsb );
+       ExifReader reader( stream );
+       if( reader.parse() )
+       {
+           ExifEntry_t entry = reader.getTag( ORIENTATION );
+           if (entry.tag != INVALID_TAG)
+           {
+               orientation = entry.field_u16; //orientation is unsigned short, so check field_u16
+           }
+       }
+    }
+
+    ExifTransform(orientation, img);
 }
 
 /**
@@ -658,6 +722,13 @@ Mat imdecode( InputArray _buf, int flags )
 {
     Mat buf = _buf.getMat(), img;
     imdecode_( buf, flags, LOAD_MAT, &img );
+
+    /// optionally rotate the data if EXIF' orientation flag says so
+    if( (flags & IMREAD_IGNORE_ORIENTATION) == 0 && flags != IMREAD_UNCHANGED )
+    {
+        ApplyExifOrientation(buf, img);
+    }
+
     return img;
 }
 
@@ -666,6 +737,13 @@ Mat imdecode( InputArray _buf, int flags, Mat* dst )
     Mat buf = _buf.getMat(), img;
     dst = dst ? dst : &img;
     imdecode_( buf, flags, LOAD_MAT, dst );
+
+    /// optionally rotate the data if EXIF' orientation flag says so
+    if( (flags & IMREAD_IGNORE_ORIENTATION) == 0 && flags != IMREAD_UNCHANGED )
+    {
+        ApplyExifOrientation(buf, *dst);
+    }
+
     return *dst;
 }
 

--- a/modules/videoio/src/cap_mjpeg_decoder.cpp
+++ b/modules/videoio/src/cap_mjpeg_decoder.cpp
@@ -821,7 +821,7 @@ bool MotionJpegCapture::retrieveFrame(int, OutputArray output_frame)
 
         if(data.size())
         {
-            m_current_frame = imdecode(data, CV_LOAD_IMAGE_ANYDEPTH | CV_LOAD_IMAGE_COLOR);
+            m_current_frame = imdecode(data, CV_LOAD_IMAGE_ANYDEPTH | CV_LOAD_IMAGE_COLOR | IMREAD_IGNORE_ORIENTATION);
         }
 
         m_current_frame.copyTo(output_frame);


### PR DESCRIPTION
resolves #8172

This pull request changes ExifReader to operate on istreams rather than filenames. It then builds a streambuf on top of Mat so that imdecode may use ApplyExifOrientation like imread does.