### PR TITLE
Wraps cv::EMD for Python and Java

### DIFF
--- a/modules/imgproc/include/opencv2/imgproc.hpp
+++ b/modules/imgproc/include/opencv2/imgproc.hpp
@@ -3280,6 +3280,10 @@ CV_EXPORTS float EMD( InputArray signature1, InputArray signature2,
                       int distType, InputArray cost=noArray(),
                       float* lowerBound = 0, OutputArray flow = noArray() );
 
+CV_EXPORTS_AS(EMD) float wrapperEMD( InputArray signature1, InputArray signature2,
+                      int distType, InputArray cost=noArray(),
+                      CV_IN_OUT Ptr<float> lowerBound = Ptr<float>(), OutputArray flow = noArray() );
+
 //! @} imgproc_hist
 
 /** @example watershed.cpp

--- a/modules/imgproc/src/emd.cpp
+++ b/modules/imgproc/src/emd.cpp
@@ -1164,4 +1164,11 @@ float cv::EMD( InputArray _signature1, InputArray _signature2,
                        _flow.needed() ? &_cflow : 0, lowerBound, 0 );
 }
 
+float cv::wrapperEMD(InputArray _signature1, InputArray _signature2,
+               int distType, InputArray _cost,
+               Ptr<float> lowerBound, OutputArray _flow)
+{
+    return EMD(_signature1, _signature2, distType, _cost, lowerBound.get(), _flow);
+}
+
 /* End of file. */


### PR DESCRIPTION
resolves #5565
resolves http://code.opencv.org/issues/3406

### This pullrequest changes
- Wraps `cv::EMD` by making `lowerBound` a smart pointer
- Provides needed Python conversions
