### PR TITLE
Wraps smart pointers properly

### DIFF
--- a/modules/python/src2/cv2.cpp
+++ b/modules/python/src2/cv2.cpp
@@ -1271,9 +1271,17 @@ PyObject* pyopencv_from(const Moments& m)
                          "nu30", m.nu30, "nu21", m.nu21, "nu12", m.nu12, "nu03", m.nu03);
 }
 
+template<typename T>
+PyObject* pyopencv_from(const cv::Ptr<T>& p)
+{
+    if (!p) return Py_None;
+    return pyopencv_from(*p);
+}
+
 template <typename T>
 bool pyopencv_to(PyObject *o, Ptr<T>& p, const char *name)
 {
+    if (!o || o == Py_None) return true;
     p = makePtr<T>();
     return pyopencv_to(o, *p, name);
 }


### PR DESCRIPTION
The currently implemented smart pointers wrapper changes the content of a possible default argument before checking if an object was passed or not, in which it might corrupt the arguments logic. Further, there is no implementation of a converter from smart pointer to Python data types.

### This pullrequest changes
- Avoids changing the smart pointer if no python object is provided
- Provides a converter from smart pointer to Python data types