### PR TITLE
Update research paper link in Python sample

### DIFF
--- a/samples/python/mosse.py
+++ b/samples/python/mosse.py
@@ -18,7 +18,7 @@ Keys:
   c        - clear targets
 
 [1] David S. Bolme et al. "Visual Object Tracking using Adaptive Correlation Filters"
-    http://www.cs.colostate.edu/~bolme/publications/Bolme2010Tracking.pdf
+    http://www.cs.colostate.edu/~draper/papers/bolme_cvpr10.pdf
 '''
 
 # Python 2/3 compatibility


### PR DESCRIPTION
The docstring for one of the Python sample programs includes a link to the research paper describing the main algorithm. That link is no longer valid (results in a 404 error) so this update replaces it with another link from the same institution which is currently valid.
