### PR TITLE
Fix StereoBM ROI selection

### DIFF
--- a/modules/calib3d/src/stereobm.cpp
+++ b/modules/calib3d/src/stereobm.cpp
@@ -1184,8 +1184,8 @@ public:
         parallel_for_(Range(0, 2), PrefilterInvoker(left0, right0, left, right, _buf, _buf + bufSize1, &params), 1);
 
         Rect validDisparityRect(0, 0, width, height), R1 = params.roi1, R2 = params.roi2;
-        validDisparityRect = getValidDisparityROI(R1.area() > 0 ? Rect(0, 0, width, height) : validDisparityRect,
-                                                  R2.area() > 0 ? Rect(0, 0, width, height) : validDisparityRect,
+        validDisparityRect = getValidDisparityROI(R1.area() > 0 ? R1 : validDisparityRect,
+                                                  R2.area() > 0 ? R2 : validDisparityRect,
                                                   params.minDisparity, params.numDisparities,
                                                   params.SADWindowSize);
 


### PR DESCRIPTION
- Fix StereoBM ROI (Region of interest) selection for stereo
images used by block matching algorithm
- Resolves #8503

### This pull request changes

- Replace whole image `Rect` selection with user provided ROIs (R1 and/or R2)
