### PR TITLE
Prevent cv::Mat_<T> move assignment from copying

### DIFF
--- a/modules/core/include/opencv2/core/mat.inl.hpp
+++ b/modules/core/include/opencv2/core/mat.inl.hpp
@@ -1818,7 +1818,7 @@ Mat_<_Tp>::Mat_(Mat_&& m)
 template<typename _Tp> inline
 Mat_<_Tp>& Mat_<_Tp>::operator = (Mat_&& m)
 {
-    Mat::operator = (m);
+    Mat::operator = (std::move(m));
     return *this;
 }
 


### PR DESCRIPTION
This PR fixes `cv::Mat_<T>::operator=(cv::Mat_&&)` by preventing it from making an unnecessary copy.

`cv::Mat_<T>::operator=(cv::Mat_&&)` incorrectly calls `cv::Mat::operator=` without converting the parameter to an r-value reference. In turn, this causes the copy assignment operator from the base class to be called instead of the move assignment operator.