### PR TITLE
Add method KeypointBasedMotionEstimator::estimate(InputArray, InputAr…

### DIFF
--- a/modules/videostab/include/opencv2/videostab/global_motion.hpp
+++ b/modules/videostab/include/opencv2/videostab/global_motion.hpp
@@ -236,6 +236,7 @@ public:
     Ptr<IOutlierRejector> outlierRejector() const { return outlierRejector_; }
 
     virtual Mat estimate(const Mat &frame0, const Mat &frame1, bool *ok = 0);
+    Mat estimate(InputArray frame0, InputArray frame1, bool *ok = 0);
 
 private:
     Ptr<MotionEstimatorBase> motionEstimator_;

--- a/modules/videostab/src/global_motion.cpp
+++ b/modules/videostab/src/global_motion.cpp
@@ -711,6 +711,14 @@ KeypointBasedMotionEstimator::KeypointBasedMotionEstimator(Ptr<MotionEstimatorBa
 
 Mat KeypointBasedMotionEstimator::estimate(const Mat &frame0, const Mat &frame1, bool *ok)
 {
+    InputArray image0 = frame0;
+    InputArray image1 = frame1;
+
+    return estimate(image0, image1, ok);
+}
+
+Mat KeypointBasedMotionEstimator::estimate(InputArray frame0, InputArray frame1, bool *ok)
+{
     // find keypoints
     detector_->detect(frame0, keypointsPrev_);
     if (keypointsPrev_.empty())


### PR DESCRIPTION
the orignal estimate function has input parameters defined as "Mat", this prevent users to call into algorithm opencl path

### This pullrequest changes
1.	it's impossible to call into openCL implementation of algorithm "feature detect and optical flow" through the original function KeypointBasedMotionEstimator::estimate(const Mat &frame0, const Mat &frame1, bool *ok = 0)
the parameter "Mat" passed into feature detect and optical flow algorithm will choose Non-opencl path. add a new function with input parameters "UMat", so that if user can choose run the algorithum with opencl.
2.	ocl_calcOpticalFlowPyrLK function only accept 1 channel gray image, so have to convert input image format into one channel grey image if it is necessary.

