### PR TITLE
Fixed cvtColor OCL compilation issue (BGRA2mBGRA)

### DIFF
--- a/modules/imgproc/src/opencl/cvtcolor.cl
+++ b/modules/imgproc/src/opencl/cvtcolor.cl
@@ -132,16 +132,10 @@ enum
 #define R_COMP z
 #define G_COMP y
 #define B_COMP x
-#elif bidx == 2
+#else
 #define R_COMP x
 #define G_COMP y
 #define B_COMP z
-#elif bidx == 3
-// The only kernel that uses bidx == 3 doesn't use these macros.
-// But we still need to make the compiler happy.
-#define R_COMP w
-#define G_COMP w
-#define B_COMP w
 #endif
 
 #ifndef uidx


### PR DESCRIPTION
### This pullrequest changes
Compilation error log:
```
Using build options: -D depth=0 -D scn=4 -D PIX_PER_WI_Y=4 -D dcn=4 -D bidx=3 -D INTEL_DEVICE
OpenCL Intel(R) Graphics device was found!
Device name: Intel(R) HD Graphics
Device version: OpenCL 2.0 
Device vendor: Intel(R) Corporation
Device profile: FULL_PROFILE
opencv/modules/imgproc/src/opencl/cvtcolor.cl:190:61: error: vector component access exceeds type 'uchar3' (vector of 3 'uchar' values)
opencv/modules/imgproc/src/opencl/cvtcolor.cl:74:28: note: expanded from macro 'CV_DESCALE'
opencv/modules/imgproc/src/opencl/cvtcolor.cl:190:88: error: vector component access exceeds type 'uchar3' (vector of 3 'uchar' values)
opencv/modules/imgproc/src/opencl/cvtcolor.cl:74:28: note: expanded from macro 'CV_DESCALE'
opencv/modules/imgproc/src/opencl/cvtcolor.cl:190:115: error: vector component access exceeds type 'uchar3' (vector of 3 'uchar' values)
opencv/modules/imgproc/src/opencl/cvtcolor.cl:74:28: note: expanded from macro 'CV_DESCALE'
opencv/modules/imgproc/src/opencl/cvtcolor.cl:261:38: error: vector component access exceeds type 'uchar3' (vector of 3 'uchar' values)
opencv/modules/imgproc/src/opencl/cvtcolor.cl:261:58: error: vector component access exceeds type 'uchar3' (vector of 3 'uchar' values)
opencv/modules/imgproc/src/opencl/cvtcolor.cl:261:78: error: vector component access exceeds type 'uchar3' (vector of 3 'uchar' values)
```

