### PR TITLE
Add support for std::array<T, N>

### DIFF
--- a/modules/core/include/opencv2/core/cvdef.h
+++ b/modules/core/include/opencv2/core/cvdef.h
@@ -364,6 +364,21 @@ Cv64suf;
 #  endif
 #endif
 
+/****************************************************************************************\
+*                                    C++11 std::array                                    *
+\****************************************************************************************/
+
+#ifndef CV_CXX_STD_ARRAY
+#  if __cplusplus >= 201103L
+#    define CV_CXX_STD_ARRAY 1
+#    include <array>
+#  endif
+#else
+#  if CV_CXX_STD_ARRAY == 0
+#    undef CV_CXX_STD_ARRAY
+#  endif
+#endif
+
 //! @}
 
 #endif // OPENCV_CORE_CVDEF_H

--- a/modules/core/include/opencv2/core/mat.hpp
+++ b/modules/core/include/opencv2/core/mat.hpp
@@ -166,7 +166,8 @@ public:
         STD_VECTOR_UMAT   =11 << KIND_SHIFT,
         STD_BOOL_VECTOR   =12 << KIND_SHIFT,
         STD_VECTOR_CUDA_GPU_MAT = 13 << KIND_SHIFT,
-        STD_ARRAY         =14 << KIND_SHIFT
+        STD_ARRAY         =14 << KIND_SHIFT,
+        STD_ARRAY_MAT     =15 << KIND_SHIFT
     };
 
     _InputArray();
@@ -192,6 +193,7 @@ public:
 
 #ifdef CV_CXX_STD_ARRAY
     template<typename _Tp, std::size_t _N> _InputArray(const std::array<_Tp, _N>& arr);
+    template<std::size_t _N> _InputArray(const std::array<Mat, _N>& arr);
 #endif
 
     Mat getMat(int idx=-1) const;
@@ -231,7 +233,6 @@ public:
     bool isUMatVector() const;
     bool isMatx() const;
     bool isVector() const;
-    bool isArray() const;
     bool isGpuMatVector() const;
     ~_InputArray();
 
@@ -325,6 +326,8 @@ public:
 #ifdef CV_CXX_STD_ARRAY
     template<typename _Tp, std::size_t _N> _OutputArray(std::array<_Tp, _N>& arr);
     template<typename _Tp, std::size_t _N> _OutputArray(const std::array<_Tp, _N>& arr);
+    template<std::size_t _N> _OutputArray(std::array<Mat, _N>& arr);
+    template<std::size_t _N> _OutputArray(const std::array<Mat, _N>& arr);
 #endif
 
     bool fixedSize() const;
@@ -389,6 +392,8 @@ public:
 #ifdef CV_CXX_STD_ARRAY
     template<typename _Tp, std::size_t _N> _InputOutputArray(std::array<_Tp, _N>& arr);
     template<typename _Tp, std::size_t _N> _InputOutputArray(const std::array<_Tp, _N>& arr);
+    template<std::size_t _N> _InputOutputArray(std::array<Mat, _N>& arr);
+    template<std::size_t _N> _InputOutputArray(const std::array<Mat, _N>& arr);
 #endif
 
 };

--- a/modules/core/include/opencv2/core/mat.hpp
+++ b/modules/core/include/opencv2/core/mat.hpp
@@ -2324,11 +2324,6 @@ public:
     //! builds matrix from std::vector with or without copying the data
     template<typename _Tp> explicit UMat(const std::vector<_Tp>& vec, bool copyData=false);
 
-#ifdef CV_CXX_STD_ARRAY
-    //! builds matrix from std::array with or without copying the data
-    template<typename _Tp, std::size_t _N> explicit UMat(const std::array<_Tp, _N>& vec, bool copyData=false);
-#endif
-
     //! builds matrix from cv::Vec; the data is copied by default
     template<typename _Tp, int n> explicit UMat(const Vec<_Tp, n>& vec, bool copyData=true);
     //! builds matrix from cv::Matx; the data is copied by default

--- a/modules/core/include/opencv2/core/mat.hpp
+++ b/modules/core/include/opencv2/core/mat.hpp
@@ -165,7 +165,8 @@ public:
         UMAT              =10 << KIND_SHIFT,
         STD_VECTOR_UMAT   =11 << KIND_SHIFT,
         STD_BOOL_VECTOR   =12 << KIND_SHIFT,
-        STD_VECTOR_CUDA_GPU_MAT = 13 << KIND_SHIFT
+        STD_VECTOR_CUDA_GPU_MAT = 13 << KIND_SHIFT,
+        STD_ARRAY         =14 << KIND_SHIFT
     };
 
     _InputArray();
@@ -188,6 +189,10 @@ public:
     template<typename _Tp> _InputArray(const cudev::GpuMat_<_Tp>& m);
     _InputArray(const UMat& um);
     _InputArray(const std::vector<UMat>& umv);
+
+#ifdef CV_CXX_STD_ARRAY
+    template<typename _Tp, std::size_t _N> _InputArray(const std::array<_Tp, _N>& arr);
+#endif
 
     Mat getMat(int idx=-1) const;
     Mat getMat_(int idx=-1) const;
@@ -226,6 +231,7 @@ public:
     bool isUMatVector() const;
     bool isMatx() const;
     bool isVector() const;
+    bool isArray() const;
     bool isGpuMatVector() const;
     ~_InputArray();
 
@@ -316,6 +322,11 @@ public:
     _OutputArray(const UMat& m);
     _OutputArray(const std::vector<UMat>& vec);
 
+#ifdef CV_CXX_STD_ARRAY
+    template<typename _Tp, std::size_t _N> _OutputArray(std::array<_Tp, _N>& arr);
+    template<typename _Tp, std::size_t _N> _OutputArray(const std::array<_Tp, _N>& arr);
+#endif
+
     bool fixedSize() const;
     bool fixedType() const;
     bool needed() const;
@@ -374,6 +385,12 @@ public:
     template<typename _Tp, int m, int n> _InputOutputArray(const Matx<_Tp, m, n>& matx);
     _InputOutputArray(const UMat& m);
     _InputOutputArray(const std::vector<UMat>& vec);
+
+#ifdef CV_CXX_STD_ARRAY
+    template<typename _Tp, std::size_t _N> _InputOutputArray(std::array<_Tp, _N>& arr);
+    template<typename _Tp, std::size_t _N> _InputOutputArray(const std::array<_Tp, _N>& arr);
+#endif
+
 };
 
 typedef const _InputArray& InputArray;
@@ -954,6 +971,12 @@ public:
     destructed.
     */
     template<typename _Tp> explicit Mat(const std::vector<_Tp>& vec, bool copyData=false);
+
+#ifdef CV_CXX_STD_ARRAY
+    /** @overload
+    */
+    template<typename _Tp, size_t _N> explicit Mat(const std::array<_Tp, _N>& arr, bool copyData=false);
+#endif
 
     /** @overload
     */
@@ -1575,6 +1598,10 @@ public:
     template<typename _Tp, int n> operator Vec<_Tp, n>() const;
     template<typename _Tp, int m, int n> operator Matx<_Tp, m, n>() const;
 
+#ifdef CV_CXX_STD_ARRAY
+    template<typename _Tp, std::size_t _N> operator std::array<_Tp, _N>() const;
+#endif
+
     /** @brief Reports whether the matrix is continuous or not.
 
     The method returns true if the matrix elements are stored continuously without gaps at the end of
@@ -2114,6 +2141,10 @@ public:
     explicit Mat_(const Point3_<typename DataType<_Tp>::channel_type>& pt, bool copyData=true);
     explicit Mat_(const MatCommaInitializer_<_Tp>& commaInitializer);
 
+#ifdef CV_CXX_STD_ARRAY
+    template <std::size_t _N> explicit Mat_(const std::array<_Tp, _N>& arr, bool copyData=false);
+#endif
+
     Mat_& operator = (const Mat& m);
     Mat_& operator = (const Mat_& m);
     //! set all the elements to s.
@@ -2207,6 +2238,12 @@ public:
 
     //! conversion to vector.
     operator std::vector<_Tp>() const;
+
+#ifdef CV_CXX_STD_ARRAY
+    //! conversion to array.
+    template<std::size_t _N> operator std::array<_Tp, _N>() const;
+#endif
+
     //! conversion to Vec
     template<int n> operator Vec<typename DataType<_Tp>::channel_type, n>() const;
     //! conversion to Matx
@@ -2281,6 +2318,12 @@ public:
     UMat(const UMat& m, const std::vector<Range>& ranges);
     //! builds matrix from std::vector with or without copying the data
     template<typename _Tp> explicit UMat(const std::vector<_Tp>& vec, bool copyData=false);
+
+#ifdef CV_CXX_STD_ARRAY
+    //! builds matrix from std::array with or without copying the data
+    template<typename _Tp, std::size_t _N> explicit UMat(const std::array<_Tp, _N>& vec, bool copyData=false);
+#endif
+
     //! builds matrix from cv::Vec; the data is copied by default
     template<typename _Tp, int n> explicit UMat(const Vec<_Tp, n>& vec, bool copyData=true);
     //! builds matrix from cv::Matx; the data is copied by default

--- a/modules/core/include/opencv2/core/mat.inl.hpp
+++ b/modules/core/include/opencv2/core/mat.inl.hpp
@@ -81,6 +81,10 @@ _InputArray::_InputArray(const std::vector<_Tp>& vec)
 template<typename _Tp, std::size_t _N> inline
 _InputArray::_InputArray(const std::array<_Tp, _N>& arr)
 { init(FIXED_TYPE + FIXED_SIZE + STD_ARRAY + DataType<_Tp>::type + ACCESS_READ, arr.data(), Size(1, _N)); }
+
+template<std::size_t _N> inline
+_InputArray::_InputArray(const std::array<Mat, _N>& arr)
+{ init(STD_ARRAY_MAT + ACCESS_READ, arr.data(), Size(1, _N)); }
 #endif
 
 inline
@@ -139,8 +143,9 @@ inline bool _InputArray::isUMat() const  { return kind() == _InputArray::UMAT; }
 inline bool _InputArray::isMatVector() const { return kind() == _InputArray::STD_VECTOR_MAT; }
 inline bool _InputArray::isUMatVector() const  { return kind() == _InputArray::STD_VECTOR_UMAT; }
 inline bool _InputArray::isMatx() const { return kind() == _InputArray::MATX; }
-inline bool _InputArray::isVector() const { return kind() == _InputArray::STD_VECTOR || kind() == _InputArray::STD_BOOL_VECTOR; }
-inline bool _InputArray::isArray() const { return kind() == _InputArray::STD_ARRAY; }
+inline bool _InputArray::isVector() const { return kind() == _InputArray::STD_VECTOR ||
+                                                   kind() == _InputArray::STD_BOOL_VECTOR ||
+                                                   kind() == _InputArray::STD_ARRAY; }
 inline bool _InputArray::isGpuMatVector() const { return kind() == _InputArray::STD_VECTOR_CUDA_GPU_MAT; }
 
 ////////////////////////////////////////////////////////////////////////////////////////
@@ -160,6 +165,10 @@ _OutputArray::_OutputArray(std::vector<_Tp>& vec)
 template<typename _Tp, std::size_t _N> inline
 _OutputArray::_OutputArray(std::array<_Tp, _N>& arr)
 { init(FIXED_TYPE + FIXED_SIZE + STD_ARRAY + DataType<_Tp>::type + ACCESS_WRITE, arr.data(), Size(1, _N)); }
+
+template<std::size_t _N> inline
+_OutputArray::_OutputArray(std::array<Mat, _N>& arr)
+{ init(STD_ARRAY_MAT + ACCESS_WRITE, arr.data(), Size(1, _N)); }
 #endif
 
 inline
@@ -194,6 +203,10 @@ _OutputArray::_OutputArray(const std::vector<_Tp>& vec)
 template<typename _Tp, std::size_t _N> inline
 _OutputArray::_OutputArray(const std::array<_Tp, _N>& arr)
 { init(FIXED_TYPE + FIXED_SIZE + STD_ARRAY + DataType<_Tp>::type + ACCESS_WRITE, arr.data(), Size(1, _N)); }
+
+template<std::size_t _N> inline
+_OutputArray::_OutputArray(const std::array<Mat, _N>& arr)
+{ init(FIXED_SIZE + STD_ARRAY_MAT + ACCESS_WRITE, arr.data(), Size(1, _N)); }
 #endif
 
 template<typename _Tp> inline
@@ -267,6 +280,10 @@ _InputOutputArray::_InputOutputArray(std::vector<_Tp>& vec)
 template<typename _Tp, std::size_t _N> inline
 _InputOutputArray::_InputOutputArray(std::array<_Tp, _N>& arr)
 { init(FIXED_TYPE + FIXED_SIZE + STD_ARRAY + DataType<_Tp>::type + ACCESS_RW, arr.data(), Size(1, _N)); }
+
+template<std::size_t _N> inline
+_InputOutputArray::_InputOutputArray(std::array<Mat, _N>& arr)
+{ init(STD_ARRAY_MAT + ACCESS_RW, arr.data(), Size(1, _N)); }
 #endif
 
 inline _InputOutputArray::_InputOutputArray(std::vector<bool>&)
@@ -300,6 +317,10 @@ _InputOutputArray::_InputOutputArray(const std::vector<_Tp>& vec)
 template<typename _Tp, std::size_t _N> inline
 _InputOutputArray::_InputOutputArray(const std::array<_Tp, _N>& arr)
 { init(FIXED_TYPE + FIXED_SIZE + STD_ARRAY + DataType<_Tp>::type + ACCESS_RW, arr.data(), Size(1, _N)); }
+
+template<std::size_t _N> inline
+_InputOutputArray::_InputOutputArray(const std::array<Mat, _N>& arr)
+{ init(FIXED_SIZE + STD_ARRAY_MAT + ACCESS_RW, arr.data(), Size(1, _N)); }
 #endif
 
 template<typename _Tp> inline

--- a/modules/core/include/opencv2/core/mat.inl.hpp
+++ b/modules/core/include/opencv2/core/mat.inl.hpp
@@ -3524,24 +3524,6 @@ cols(1), allocator(0), usageFlags(USAGE_DEFAULT), u(0), offset(0), size(&rows)
         Mat((int)vec.size(), 1, DataType<_Tp>::type, (uchar*)&vec[0]).copyTo(*this);
 }
 
-#ifdef CV_CXX_STD_ARRAY
-template<typename _Tp, std::size_t _N> inline
-UMat::UMat(const std::array<_Tp, _N>& arr, bool copyData)
-: flags(MAGIC_VAL | DataType<_Tp>::type | CV_MAT_CONT_FLAG), dims(2), rows((int)arr.size()),
-cols(1), allocator(0), usageFlags(USAGE_DEFAULT), u(0), offset(0), size(&rows)
-{
-    if(arr.empty())
-        return;
-    if( !copyData )
-    {
-        // !!!TODO!!!
-        CV_Error(Error::StsNotImplemented, "");
-    }
-    else
-        Mat((int)arr.size(), 1, DataType<_Tp>::type, (uchar*)arr.data()).copyTo(*this);
-}
-#endif
-
 inline
 UMat& UMat::operator = (const UMat& m)
 {

--- a/modules/core/src/convert.cpp
+++ b/modules/core/src/convert.cpp
@@ -637,9 +637,11 @@ void cv::mixChannels(InputArrayOfArrays src, InputOutputArrayOfArrays dst,
                ocl_mixChannels(src, dst, fromTo, npairs))
 
     bool src_is_mat = src.kind() != _InputArray::STD_VECTOR_MAT &&
+            src.kind() != _InputArray::STD_ARRAY_MAT &&
             src.kind() != _InputArray::STD_VECTOR_VECTOR &&
             src.kind() != _InputArray::STD_VECTOR_UMAT;
     bool dst_is_mat = dst.kind() != _InputArray::STD_VECTOR_MAT &&
+            dst.kind() != _InputArray::STD_ARRAY_MAT &&
             dst.kind() != _InputArray::STD_VECTOR_VECTOR &&
             dst.kind() != _InputArray::STD_VECTOR_UMAT;
     int i;
@@ -668,9 +670,11 @@ void cv::mixChannels(InputArrayOfArrays src, InputOutputArrayOfArrays dst,
                ocl_mixChannels(src, dst, &fromTo[0], fromTo.size()>>1))
 
     bool src_is_mat = src.kind() != _InputArray::STD_VECTOR_MAT &&
+            src.kind() != _InputArray::STD_ARRAY_MAT &&
             src.kind() != _InputArray::STD_VECTOR_VECTOR &&
             src.kind() != _InputArray::STD_VECTOR_UMAT;
     bool dst_is_mat = dst.kind() != _InputArray::STD_VECTOR_MAT &&
+            dst.kind() != _InputArray::STD_ARRAY_MAT &&
             dst.kind() != _InputArray::STD_VECTOR_VECTOR &&
             dst.kind() != _InputArray::STD_VECTOR_UMAT;
     int i;

--- a/modules/core/src/copy.cpp
+++ b/modules/core/src/copy.cpp
@@ -292,7 +292,7 @@ void Mat::copyTo( OutputArray _dst ) const
         {
             // For some cases (with vector) dst.size != src.size, so force to column-based form
             // It prevents memory corruption in case of column-based src
-            if (_dst.isVector() || _dst.isArray())
+            if (_dst.isVector())
                 dst = dst.reshape(0, (int)dst.total());
 
             const uchar* sptr = data;

--- a/modules/core/src/copy.cpp
+++ b/modules/core/src/copy.cpp
@@ -292,7 +292,7 @@ void Mat::copyTo( OutputArray _dst ) const
         {
             // For some cases (with vector) dst.size != src.size, so force to column-based form
             // It prevents memory corruption in case of column-based src
-            if (_dst.isVector())
+            if (_dst.isVector() || _dst.isArray())
                 dst = dst.reshape(0, (int)dst.total());
 
             const uchar* sptr = data;

--- a/modules/core/src/lda.cpp
+++ b/modules/core/src/lda.cpp
@@ -53,7 +53,8 @@ static Mat argsort(InputArray _src, bool ascending=true)
 
 static Mat asRowMatrix(InputArrayOfArrays src, int rtype, double alpha=1, double beta=0) {
     // make sure the input data is a vector of matrices or vector of vector
-    if(src.kind() != _InputArray::STD_VECTOR_MAT && src.kind() != _InputArray::STD_VECTOR_VECTOR) {
+    if(src.kind() != _InputArray::STD_VECTOR_MAT && src.kind() != _InputArray::STD_ARRAY_MAT &&
+        src.kind() != _InputArray::STD_VECTOR_VECTOR) {
         String error_message = "The data is expected as InputArray::STD_VECTOR_MAT (a std::vector<Mat>) or _InputArray::STD_VECTOR_VECTOR (a std::vector< std::vector<...> >).";
         CV_Error(Error::StsBadArg, error_message);
     }
@@ -1096,6 +1097,7 @@ void LDA::lda(InputArrayOfArrays _src, InputArray _lbls) {
 void LDA::compute(InputArrayOfArrays _src, InputArray _lbls) {
     switch(_src.kind()) {
     case _InputArray::STD_VECTOR_MAT:
+    case _InputArray::STD_ARRAY_MAT:
         lda(asRowMatrix(_src, CV_64FC1), _lbls);
         break;
     case _InputArray::MAT:

--- a/modules/core/src/matmul.cpp
+++ b/modules/core/src/matmul.cpp
@@ -2551,7 +2551,7 @@ void cv::calcCovarMatrix( InputArray _src, OutputArray _covar, InputOutputArray 
 {
     CV_INSTRUMENT_REGION()
 
-    if(_src.kind() == _InputArray::STD_VECTOR_MAT)
+    if(_src.kind() == _InputArray::STD_VECTOR_MAT || _src.kind() == _InputArray::STD_ARRAY_MAT)
     {
         std::vector<cv::Mat> src;
         _src.getMatVector(src);

--- a/modules/core/src/matrix.cpp
+++ b/modules/core/src/matrix.cpp
@@ -1235,7 +1235,7 @@ Mat _InputArray::getMat_(int i) const
         return (Mat)*((const MatExpr*)obj);
     }
 
-    if( k == MATX )
+    if( k == MATX || k == STD_ARRAY )
     {
         CV_Assert( i < 0 );
         return Mat(sz, flags, obj);
@@ -1381,7 +1381,7 @@ void _InputArray::getMatVector(std::vector<Mat>& mv) const
         return;
     }
 
-    if( k == MATX )
+    if( k == MATX || k == STD_ARRAY )
     {
         size_t n = sz.height, esz = CV_ELEM_SIZE(flags);
         mv.resize(n);
@@ -1584,7 +1584,7 @@ Size _InputArray::size(int i) const
         return ((const UMat*)obj)->size();
     }
 
-    if( k == MATX )
+    if( k == MATX || k == STD_ARRAY )
     {
         CV_Assert( i < 0 );
         return sz;
@@ -1789,7 +1789,7 @@ int _InputArray::dims(int i) const
         return ((const UMat*)obj)->dims;
     }
 
-    if( k == MATX )
+    if( k == MATX || k == STD_ARRAY )
     {
         CV_Assert( i < 0 );
         return 2;
@@ -1908,7 +1908,7 @@ int _InputArray::type(int i) const
     if( k == EXPR )
         return ((const MatExpr*)obj)->type();
 
-    if( k == MATX || k == STD_VECTOR || k == STD_VECTOR_VECTOR || k == STD_BOOL_VECTOR )
+    if( k == MATX || k == STD_VECTOR || k == STD_ARRAY || k == STD_VECTOR_VECTOR || k == STD_BOOL_VECTOR )
         return CV_MAT_TYPE(flags);
 
     if( k == NONE )
@@ -1986,7 +1986,7 @@ bool _InputArray::empty() const
     if( k == EXPR )
         return false;
 
-    if( k == MATX )
+    if( k == MATX || k == STD_ARRAY )
         return false;
 
     if( k == STD_VECTOR )
@@ -2051,7 +2051,7 @@ bool _InputArray::isContinuous(int i) const
     if( k == UMAT )
         return i < 0 ? ((const UMat*)obj)->isContinuous() : true;
 
-    if( k == EXPR || k == MATX || k == STD_VECTOR ||
+    if( k == EXPR || k == MATX || k == STD_VECTOR || k == STD_ARRAY ||
         k == NONE || k == STD_VECTOR_VECTOR || k == STD_BOOL_VECTOR )
         return true;
 
@@ -2086,7 +2086,7 @@ bool _InputArray::isSubmatrix(int i) const
     if( k == UMAT )
         return i < 0 ? ((const UMat*)obj)->isSubmatrix() : false;
 
-    if( k == EXPR || k == MATX || k == STD_VECTOR ||
+    if( k == EXPR || k == MATX || k == STD_VECTOR || k == STD_ARRAY ||
         k == NONE || k == STD_VECTOR_VECTOR || k == STD_BOOL_VECTOR )
         return false;
 
@@ -2125,7 +2125,7 @@ size_t _InputArray::offset(int i) const
         return ((const UMat*)obj)->offset;
     }
 
-    if( k == EXPR || k == MATX || k == STD_VECTOR ||
+    if( k == EXPR || k == MATX || k == STD_VECTOR || k == STD_ARRAY ||
         k == NONE || k == STD_VECTOR_VECTOR || k == STD_BOOL_VECTOR )
         return 0;
 
@@ -2180,7 +2180,7 @@ size_t _InputArray::step(int i) const
         return ((const UMat*)obj)->step;
     }
 
-    if( k == EXPR || k == MATX || k == STD_VECTOR ||
+    if( k == EXPR || k == MATX || k == STD_VECTOR || k == STD_ARRAY ||
         k == NONE || k == STD_VECTOR_VECTOR || k == STD_BOOL_VECTOR )
         return 0;
 
@@ -2222,7 +2222,7 @@ void _InputArray::copyTo(const _OutputArray& arr) const
 
     if( k == NONE )
         arr.release();
-    else if( k == MAT || k == MATX || k == STD_VECTOR || k == STD_BOOL_VECTOR )
+    else if( k == MAT || k == MATX || k == STD_VECTOR || k == STD_ARRAY || k == STD_BOOL_VECTOR )
     {
         Mat m = getMat();
         m.copyTo(arr);
@@ -2247,7 +2247,7 @@ void _InputArray::copyTo(const _OutputArray& arr, const _InputArray & mask) cons
 
     if( k == NONE )
         arr.release();
-    else if( k == MAT || k == MATX || k == STD_VECTOR || k == STD_BOOL_VECTOR )
+    else if( k == MAT || k == MATX || k == STD_VECTOR || k == STD_ARRAY || k == STD_BOOL_VECTOR )
     {
         Mat m = getMat();
         m.copyTo(arr, mask);
@@ -2433,6 +2433,14 @@ void _OutputArray::create(int d, const int* sizes, int mtype, int i,
         CV_Assert( mtype == type0 || (CV_MAT_CN(mtype) == 1 && ((1 << type0) & fixedDepthMask) != 0) );
         CV_Assert( d == 2 && ((sizes[0] == sz.height && sizes[1] == sz.width) ||
                                  (allowTransposed && sizes[0] == sz.width && sizes[1] == sz.height)));
+        return;
+    }
+
+    if( k == STD_ARRAY )
+    {
+        int type0 = CV_MAT_TYPE(flags);
+        CV_Assert( mtype == type0 || (CV_MAT_CN(mtype) == 1 && ((1 << type0) & fixedDepthMask) != 0) );
+        CV_Assert( d == 2 && sz.area() == sizes[0]*sizes[1]);
         return;
     }
 
@@ -2807,7 +2815,7 @@ void _OutputArray::setTo(const _InputArray& arr, const _InputArray & mask) const
 
     if( k == NONE )
         ;
-    else if( k == MAT || k == MATX || k == STD_VECTOR )
+    else if( k == MAT || k == MATX || k == STD_VECTOR || k == STD_ARRAY )
     {
         Mat m = getMat();
         m.setTo(arr, mask);

--- a/modules/core/test/test_mat.cpp
+++ b/modules/core/test/test_mat.cpp
@@ -1704,4 +1704,25 @@ TEST(Core_Mat_array, copyTo_roi_row)
     EXPECT_EQ(4, (int)dst2[3]);
     EXPECT_EQ(5, (int)dst2[4]);
 }
+
+TEST(Core_Mat_array, SplitMerge)
+{
+    std::array<cv::Mat, 3> src;
+    for(size_t i=0; i<src.size(); ++i) {
+        src[i].create(10, 10, CV_8U);
+        src[i] = 127 * i;
+    }
+
+    Mat merged;
+    merge(src, merged);
+
+    std::array<cv::Mat, 3> dst;
+    split(merged, dst);
+
+    Mat diff;
+    for(size_t i=0; i<dst.size(); ++i) {
+        absdiff(src[i], dst[i], diff);
+        EXPECT_EQ(0, countNonZero(diff));
+    }
+}
 #endif

--- a/modules/core/test/test_mat.cpp
+++ b/modules/core/test/test_mat.cpp
@@ -1634,3 +1634,74 @@ TEST(Mat, regression_7873_mat_vector_initialize)
     ASSERT_EQ(3, sub_mat.size[1]);
     ASSERT_EQ(2, sub_mat.size[2]);
 }
+
+#ifdef CV_CXX_STD_ARRAY
+TEST(Core_Mat_array, outputArray_create_getMat)
+{
+    cv::Mat_<uchar> src_base(5, 1);
+    std::array<uchar, 5> dst8;
+
+    src_base << 1, 2, 3, 4, 5;
+
+    Mat src(src_base);
+    OutputArray _dst(dst8);
+
+    {
+        _dst.create(src.rows, src.cols, src.type());
+        Mat dst = _dst.getMat();
+        EXPECT_EQ(src.dims, dst.dims);
+        EXPECT_EQ(src.cols, dst.cols);
+        EXPECT_EQ(src.rows, dst.rows);
+    }
+}
+
+TEST(Core_Mat_array, copyTo_roi_column)
+{
+    cv::Mat_<uchar> src_base(5, 2);
+
+    src_base << 1, 2, 3, 4, 5, 6, 7, 8, 9, 10;
+
+    Mat src_full(src_base);
+    Mat src(src_full.col(0));
+
+    std::array<uchar, 5> dst1;
+    src.copyTo(dst1);
+    std::cout << "src = " << src << std::endl;
+    std::cout << "dst = " << Mat(dst1) << std::endl;
+    EXPECT_EQ((size_t)5, dst1.size());
+    EXPECT_EQ(1, (int)dst1[0]);
+    EXPECT_EQ(3, (int)dst1[1]);
+    EXPECT_EQ(5, (int)dst1[2]);
+    EXPECT_EQ(7, (int)dst1[3]);
+    EXPECT_EQ(9, (int)dst1[4]);
+}
+
+TEST(Core_Mat_array, copyTo_roi_row)
+{
+    cv::Mat_<uchar> src_base(2, 5);
+    std::array<uchar, 5> dst1;
+
+    src_base << 1, 2, 3, 4, 5, 6, 7, 8, 9, 10;
+
+    Mat src_full(src_base);
+    Mat src(src_full.row(0));
+    OutputArray _dst(dst1);
+    {
+        _dst.create(5, 1, src.type());
+        Mat dst = _dst.getMat();
+        EXPECT_EQ(src.dims, dst.dims);
+        EXPECT_EQ(1, dst.cols);
+        EXPECT_EQ(5, dst.rows);
+    }
+
+    std::array<uchar, 5> dst2;
+    src.copyTo(dst2);
+    std::cout << "src = " << src << std::endl;
+    std::cout << "dst = " << Mat(dst2) << std::endl;
+    EXPECT_EQ(1, (int)dst2[0]);
+    EXPECT_EQ(2, (int)dst2[1]);
+    EXPECT_EQ(3, (int)dst2[2]);
+    EXPECT_EQ(4, (int)dst2[3]);
+    EXPECT_EQ(5, (int)dst2[4]);
+}
+#endif


### PR DESCRIPTION
resolves #5086

Partially adds support for std::array from request "Add InputArray and OutputArray overloads for std::array #5086"

* `CV_CXX_STD_ARRAY` is defined to know if `std::array` is supported by the compiler
* New constructors for `InputArray`, `OutputArray`, `InputOutputArray`, and `Mat` that take `std::array` and `std::array<Mat>` as input.
* Add tests (similar to `std::vector` tests)