### PR TITLE
Update documentation for getCudaEnabledDeviceCount

### DIFF
--- a/modules/core/include/opencv2/core/cuda.hpp
+++ b/modules/core/include/opencv2/core/cuda.hpp
@@ -595,7 +595,8 @@ private:
 /** @brief Returns the number of installed CUDA-enabled devices.
 
 Use this function before any other CUDA functions calls. If OpenCV is compiled without CUDA support,
-this function returns 0.
+this function returns 0. If the CUDA driver is not installed, or is incompatible, this function
+returns -1.
  */
 CV_EXPORTS int getCudaEnabledDeviceCount();
 


### PR DESCRIPTION
### This pullrequest changes

Inform users that `getCudaEnabledDeviceCount()` can return `-1` in some cases. This can cause confusion on non-CUDA machines, as using `getCudaEnabledDeviceCount() != 0` (rather than ` > 0`) will evalulate to true and suggest (incorrectly) that there is a card available.