### PR TITLE
avoid allocating memory for strings with a length of zero.

### DIFF
--- a/modules/core/include/opencv2/core/cvstd.hpp
+++ b/modules/core/include/opencv2/core/cvstd.hpp
@@ -489,7 +489,7 @@ public:
 
     static const size_t npos = size_t(-1);
 
-    explicit String();
+    String();
     String(const String& str);
     String(const String& str, size_t pos, size_t len = npos);
     String(const char* s);
@@ -627,6 +627,7 @@ String::String(const char* s, size_t n)
     : cstr_(0), len_(0)
 {
     if (!n) return;
+    if (!s) return;
     memcpy(allocate(n), s, n);
 }
 
@@ -634,6 +635,7 @@ inline
 String::String(size_t n, char c)
     : cstr_(0), len_(0)
 {
+    if (!n) return;
     memset(allocate(n), c, n);
 }
 
@@ -642,6 +644,7 @@ String::String(const char* first, const char* last)
     : cstr_(0), len_(0)
 {
     size_t len = (size_t)(last - first);
+    if (!len) return;
     memcpy(allocate(len), first, len);
 }
 
@@ -650,6 +653,7 @@ String::String(Iterator first, Iterator last)
     : cstr_(0), len_(0)
 {
     size_t len = (size_t)(last - first);
+    if (!len) return;
     char* str = allocate(len);
     while (first != last)
     {


### PR DESCRIPTION
1. Avoid allocating memory for strings with a length of zero.

2. Remove the specifier "explicit", because the constructor has no parameter. There is no point to add it here.

<!-- Please use this line to close one or multiple issues when this pullrequest gets merged
You can add another line right under the first one:
resolves #1234
resolves #1235
-->


<!-- Please describe what your pullrequest is changing -->