### PR TITLE
Initialize the empty InputOutputArray parameter in findTransformECC

### DIFF
--- a/modules/video/include/opencv2/video/tracking.hpp
+++ b/modules/video/include/opencv2/video/tracking.hpp
@@ -297,7 +297,7 @@ row is ignored.
 Unlike findHomography and estimateRigidTransform, the function findTransformECC implements an
 area-based alignment that builds on intensity similarities. In essence, the function updates the
 initial transformation that roughly aligns the images. If this information is missing, the identity
-warp (unity matrix) should be given as input. Note that if images undergo strong
+warp (unity matrix) is used as an initialization. Note that if images undergo strong
 displacements/rotations, an initial transformation that roughly aligns the images is necessary
 (e.g., a simple euclidean/similarity transform that allows for the images showing the same image
 content approximately). Use inverse warping in the second image to take an image close to the first

--- a/modules/video/src/ecc.cpp
+++ b/modules/video/src/ecc.cpp
@@ -325,6 +325,16 @@ double cv::findTransformECC(InputArray templateImage,
     CV_Assert(!src.empty());
     CV_Assert(!dst.empty());
 
+    // If the user passed an un-initialized warpMatrix, initialize to identity
+    if(map.empty()) {
+        int rowCount = 2;
+        if(motionType == MOTION_HOMOGRAPHY)
+            rowCount = 3;
+
+        warpMatrix.create(rowCount, 3, CV_32FC1);
+        map = warpMatrix.getMat();
+        map = Mat::eye(rowCount, 3, CV_32F);
+    }
 
     if( ! (src.type()==dst.type()))
         CV_Error( Error::StsUnmatchedFormats, "Both input images must have the same data type" );


### PR DESCRIPTION
Currently, `findTransformECC` expects (at least) three parameters. The third parameter is the warp matrix (2x3 or 3x3 depending on the type of warp specified) that aligns the other two parameters.

If this parameter is provided, it is used for initializing the optimization. Otherwise, the user currently needs to [initialize it to identity themselves](https://github.com/opencv/opencv/blob/master/samples/cpp/image_alignment.cpp#L286-L290). This can be seen in the `image_alignment.cpp` sample.

This PR changes this behavior. If the function `findTransformECC` notices that the `InputOutputArray` is empty, it initializes it to the correct sized identity matrix.
