### PR TITLE
(2.4) ffmpeg: add __STDC_CONSTANT_MACROS to check code

### DIFF
--- a/cmake/checks/ffmpeg_test.cpp
+++ b/cmake/checks/ffmpeg_test.cpp
@@ -1,3 +1,5 @@
+#define __STDC_CONSTANT_MACROS
+
 #include <stdlib.h>
 
 extern "C" {


### PR DESCRIPTION
Backport #8561