### PR TITLE
Remove stdout log when destructor called.

### DIFF
--- a/modules/videoio/src/cap_qtkit.mm
+++ b/modules/videoio/src/cap_qtkit.mm
@@ -270,8 +270,6 @@ CvCaptureCAM::CvCaptureCAM(int cameraNum) {
 
 CvCaptureCAM::~CvCaptureCAM() {
     stopCaptureDevice();
-
-    std::cout << "Cleaned up camera." << std::endl;
 }
 
 int CvCaptureCAM::didStart() {


### PR DESCRIPTION
### This pullrequest changes

We tried to execute opencv video capture using Python bindings, we have get “Clean up camera” log. I checked this logs so I faced this commented out log https://github.com/opencv/opencv/blob/05b15943d6a42c99e5f921b7dbaa8323f3c042c6/modules/videoio/src/cap_avfoundation.mm#L255

### Question
Is this message really necessary?
If no, I would like to remove this message in the destructure method …
