### PR TITLE
Initialize background model in background subtraction KNN.

### DIFF
--- a/modules/video/src/bgfg_KNN.cpp
+++ b/modules/video/src/bgfg_KNN.cpp
@@ -122,7 +122,7 @@ public:
     //! computes a background image which are the mean of all background gaussians
     virtual void getBackgroundImage(OutputArray backgroundImage) const;
 
-    //! re-initiaization method
+    //! re-initialization method
     void initialize(Size _frameSize, int _frameType)
     {
     frameSize = _frameSize;
@@ -137,6 +137,7 @@ public:
     // for each sample of 3 speed pixel models each pixel bg model we store ...
     // values + flag (nchannels+1 values)
     bgmodel.create( 1,(nN * 3) * (nchannels+1)* size,CV_8U);
+    bgmodel = Scalar::all(0);
 
     //index through the three circular lists
     aModelIndexShort.create(1,size,CV_8U);


### PR DESCRIPTION
### This pullrequest changes

The algorithm does cvCheckPixelBackgroundNP (which reads bgmodel) before it is ever updated (in cvUpdatePixelBackgroundNP). This initialization is thus needed to avoid reads of unitialized values.

Minimal program to reproduce the issue:

```
/*
 * opencv_bgs_knn_play.cc
 * g++ -std=c++11 -Wall -g opencv_bgs_knn_play.cc -lopencv_core -lopencv_video -o opencv_bgs_knn_play
 */

#include <opencv2/opencv.hpp>

int main()
{
  auto background_subtractor = cv::createBackgroundSubtractorKNN();

  cv::Mat frame;
  frame.create(3, 3, CV_8UC3);
  frame = cv::Scalar::all(0);

  cv::Mat fgmask;
  background_subtractor->apply(frame, fgmask);
}
```

Valgrind output:

```
$ valgrind --track-origins=yes ./opencv_bgs_knn_play
==3460== Memcheck, a memory error detector
==3460== Copyright (C) 2002-2015, and GNU GPL'd, by Julian Seward et al.
==3460== Using Valgrind-3.11.0 and LibVEX; rerun with -h for copyright info
==3460== Command: ./opencv_bgs_knn_play
==3460== 
==3460== Conditional jump or move depends on uninitialised value(s)
==3460==    at 0x5B8DFFF: cv::BackgroundSubtractorKNNImpl::apply(cv::_InputArray const&, cv::_OutputArray const&, double) (in /usr/local/lib/libopencv_video.so.3.2.0)
==3460==    by 0x4012BD: main (opencv_bgs_knn_play.cc:12)
==3460==  Uninitialised value was created by a heap allocation
==3460==    at 0x4C2DB8F: malloc (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==3460==    by 0x4F6F451: cv::fastMalloc(unsigned long) (in /usr/local/lib/libopencv_core.so.3.2.0)
==3460==    by 0x50F0AC3: cv::Mat::create(int, int const*, int) (in /usr/local/lib/libopencv_core.so.3.2.0)
==3460==    by 0x5B8D916: cv::BackgroundSubtractorKNNImpl::apply(cv::_InputArray const&, cv::_OutputArray const&, double) (in /usr/local/lib/libopencv_video.so.3.2.0)
==3460==    by 0x4012BD: main (opencv_bgs_knn_play.cc:12)
==3460== 
==3460== Conditional jump or move depends on uninitialised value(s)
==3460==    at 0x5B8E009: cv::BackgroundSubtractorKNNImpl::apply(cv::_InputArray const&, cv::_OutputArray const&, double) (in /usr/local/lib/libopencv_video.so.3.2.0)
==3460==    by 0x4012BD: main (opencv_bgs_knn_play.cc:12)
==3460==  Uninitialised value was created by a heap allocation
==3460==    at 0x4C2DB8F: malloc (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==3460==    by 0x4F6F451: cv::fastMalloc(unsigned long) (in /usr/local/lib/libopencv_core.so.3.2.0)
==3460==    by 0x50F0AC3: cv::Mat::create(int, int const*, int) (in /usr/local/lib/libopencv_core.so.3.2.0)
==3460==    by 0x5B8D916: cv::BackgroundSubtractorKNNImpl::apply(cv::_InputArray const&, cv::_OutputArray const&, double) (in /usr/local/lib/libopencv_video.so.3.2.0)
==3460==    by 0x4012BD: main (opencv_bgs_knn_play.cc:12)
==3460== 
==3460== Conditional jump or move depends on uninitialised value(s)
==3460==    at 0x5B8E04C: cv::BackgroundSubtractorKNNImpl::apply(cv::_InputArray const&, cv::_OutputArray const&, double) (in /usr/local/lib/libopencv_video.so.3.2.0)
==3460==    by 0x4012BD: main (opencv_bgs_knn_play.cc:12)
==3460==  Uninitialised value was created by a heap allocation
==3460==    at 0x4C2DB8F: malloc (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==3460==    by 0x4F6F451: cv::fastMalloc(unsigned long) (in /usr/local/lib/libopencv_core.so.3.2.0)
==3460==    by 0x50F0AC3: cv::Mat::create(int, int const*, int) (in /usr/local/lib/libopencv_core.so.3.2.0)
==3460==    by 0x5B8D916: cv::BackgroundSubtractorKNNImpl::apply(cv::_InputArray const&, cv::_OutputArray const&, double) (in /usr/local/lib/libopencv_video.so.3.2.0)
==3460==    by 0x4012BD: main (opencv_bgs_knn_play.cc:12)
==3460== 
==3460== 
==3460== HEAP SUMMARY:
==3460==     in use at exit: 72,800 bytes in 5 blocks
==3460==   total heap usage: 66 allocs, 61 frees, 79,205 bytes allocated
==3460== 
==3460== LEAK SUMMARY:
==3460==    definitely lost: 0 bytes in 0 blocks
==3460==    indirectly lost: 0 bytes in 0 blocks
==3460==      possibly lost: 0 bytes in 0 blocks
==3460==    still reachable: 72,800 bytes in 5 blocks
==3460==         suppressed: 0 bytes in 0 blocks
==3460== Rerun with --leak-check=full to see details of leaked memory
==3460== 
==3460== For counts of detected and suppressed errors, rerun with: -v
==3460== ERROR SUMMARY: 567 errors from 3 contexts (suppressed: 0 from 0)
```