### PR TITLE
cmake: fix optimization filter

### DIFF
--- a/cmake/OpenCVCompilerOptimizations.cmake
+++ b/cmake/OpenCVCompilerOptimizations.cmake
@@ -520,6 +520,7 @@ macro(ocv_compiler_optimization_process_sources SOURCES_VAR_NAME LIBS_VAR_NAME T
   endforeach()
   foreach(fname ${${SOURCES_VAR_NAME}})
     string(TOLOWER "${fname}" fname_LOWER)
+    get_filename_component(fname_LOWER "${fname_LOWER}" NAME)
     if(fname_LOWER MATCHES "\\.(.*)\\.cpp$")
       string(TOUPPER "${CMAKE_MATCH_1}" OPT_)
       if(OPT_ MATCHES "(CUDA.*|DISPATCH.*|OCL)") # don't touch files like filename.cuda.cpp


### PR DESCRIPTION
Check file name only:
```
Excluding from source files list (optimization is disabled):
C:/Code/SrcExt/OpenCV/Buildv3.2_x64/modules/core/opencl_kernels_core.cpp
```

Related #8532