### PR TITLE
fix creation homogeneous affine matrix when constructing from 4x3 cv::Mat

### DIFF
--- a/modules/core/include/opencv2/core/affine.hpp
+++ b/modules/core/include/opencv2/core/affine.hpp
@@ -203,11 +203,13 @@ cv::Affine3<T>::Affine3(const cv::Mat& data, const Vec3& t)
     {
         rotation(data(Rect(0, 0, 3, 3)));
         translation(data(Rect(3, 0, 1, 3)));
-        return;
+    }
+    else
+    {
+        rotation(data);
+        translation(t);
     }
 
-    rotation(data);
-    translation(t);
     matrix.val[12] = matrix.val[13] = matrix.val[14] = 0;
     matrix.val[15] = 1;
 }


### PR DESCRIPTION
### This pullrequest changes

Constructing an cv::Affine3 from cv::Mat with dimensionss 4x3 results in the 16th element of the matrix not being 1 but 0. Since this would not be a homogeneous matrix, this behaviour is not desired.
This PR fixes the issue by preventing a return in the case of a 4x3 matrix before the 4th row is initialized with [0,0,0,1].
