### PR TITLE
cmake: disallow in-source builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,6 +6,13 @@
 #
 # ----------------------------------------------------------------------------
 
+# Disable in-source builds to prevent source tree corruption.
+if(" ${CMAKE_SOURCE_DIR}" STREQUAL " ${CMAKE_BINARY_DIR}")
+  message(FATAL_ERROR "
+FATAL: In-source builds are not allowed.
+       You should create separate directory for build files.
+")
+endif()
 
 
 include(cmake/OpenCVMinDepVersions.cmake)
@@ -1385,13 +1392,6 @@ status("-----------------------------------------------------------------")
 status("")
 
 ocv_finalize_status()
-
-# ----------------------------------------------------------------------------
-# Warn in the case of in-source build
-# ----------------------------------------------------------------------------
-if("${CMAKE_CURRENT_SOURCE_DIR}" STREQUAL "${CMAKE_CURRENT_BINARY_DIR}")
-  message(WARNING "The source directory is the same as binary directory. \"make clean\" may damage the source tree")
-endif()
 
 # ----------------------------------------------------------------------------
 # CPack stuff


### PR DESCRIPTION
Currently even CMake process modifies source tree (rewrites 3rdparty/ippicv).

There is another approach:
```
set(CMAKE_DISABLE_IN_SOURCE_BUILD ON)
set(CMAKE_DISABLE_SOURCE_CHANGES ON)
```

but these variables are not documented in CMake. Also they prevent using of in-source `.cache` directory


BTW, You still need to delete `CMakeFiles` / `CMakeCache.txt` from source tree after in-source build attempt.

Related CMake issues:
- https://gitlab.kitware.com/cmake/cmake/issues/11343
- https://gitlab.kitware.com/cmake/cmake/issues/6672