### PR TITLE
Set Mac OS X deployment target to 10.9

### DIFF
--- a/platforms/osx/build_framework.py
+++ b/platforms/osx/build_framework.py
@@ -18,6 +18,7 @@ class OSXBuilder(Builder):
     def getBuildCommand(self, archs, target):
         buildcmd = [
             "xcodebuild",
+            "MACOSX_DEPLOYMENT_TARGET=10.9",
             "ARCHS=%s" % archs[0],
             "-sdk", target.lower(),
             "-configuration", "Release",


### PR DESCRIPTION
### This pullrequest changes

Sets the MACOSX_DEPLOYMENT_TARGET to 10.9. Without it set, the build will choose the current OS version as the deployment target. Libraries should be built with a deployment target of the earliest compatible version. 10.9 is the earliest usable, since that is when OS X introduced libc++.

Tested on OS X 10.12.4 using opencv master (10787c6) with a test project that builds for a deployment target of 10.9.