### PR TITLE
cmake/OpenCVGenPkgconfig.cmake: fix static linking

### DIFF
--- a/cmake/OpenCVGenPkgconfig.cmake
+++ b/cmake/OpenCVGenPkgconfig.cmake
@@ -74,7 +74,12 @@ if(OpenCV_EXTRA_COMPONENTS)
       list(APPEND OpenCV_LIB_COMPONENTS_ "${extra_component}")
     elseif(extra_component MATCHES "[\\/]")
       get_filename_component(libdir "${extra_component}" PATH)
-      get_filename_component(libname "${extra_component}" NAME_WE)
+# cannot use longest extension function, since some libnames contain
+# multiple dots, like libglib-2.0.a.
+# Instead write out own shortest extension function:
+      get_filename_component(libname "${extra_component}" NAME)
+      string(FIND ${libname} "." SHORTEST_EXT_POS REVERSE)
+      string(SUBSTRING ${libname} 0 ${SHORTEST_EXT_POS} libname)
       string(REGEX REPLACE "^lib" "" libname "${libname}")
       list(APPEND OpenCV_LIB_COMPONENTS_ "-L${libdir}" "-l${libname}")
     else()


### PR DESCRIPTION
https://github.com/opencv/opencv/commit/671a630f47635ee8e44daf5ae6e94969ac4b8e0f#diff-9076fba682f6d51a018b6de8648e1cdb
updated the code to create opencv.pc to fix build errors in buildroot.

In case of static-only builds with glib-enabled qt this however creates
a broken opencv.pc because libname gets truncated from libglib-2.0.a to
libglib-2, same is valid for libgobject-2.0.a and libgthread-2.0.a.

CMake get_filename_component removes all extensions from the filename
https://cmake.org/cmake/help/v3.0/command/get_filename_component.html
which is too much for our use-case.

opencv.pc currently contains -lgobject-2 -lglib-2 -lgthread-2, linking
against these libs will fail, for example in ffmpeg, because the files
do not exist:
http://autobuild.buildroot.net/results/7e6/7e67d7e6e33b52ce7fbb9cb180b2b9b19e116eee/build-end.log

Quoting ffmpeg configure.log:

i586-buildroot-linux-musl/bin/ld: cannot find -lgobject-2
i586-buildroot-linux-musl/bin/ld: cannot find -lglib-2
i586-buildroot-linux-musl/bin/ld: cannot find -lgthread-2

Instead of using get_filename_component we need a function which only
strips the last extension, copied from openjpeg:

https://github.com/uclouvain/openjpeg/commit/820c04c6799ea38aacd4e5d637073e6ab1ec643c#diff-53c915af197ccc28c0551ce6aae49af7R53
