### PR TITLE
Expose UMat OpenCL handles to python

### DIFF
--- a/modules/core/include/opencv2/core/mat.hpp
+++ b/modules/core/include/opencv2/core/mat.hpp
@@ -2464,6 +2464,10 @@ public:
     UMat& operator = (UMat&& m);
 #endif
 
+    /*! Returns the OpenCL buffer handle on which UMat operates on.
+        The UMat instance should be kept alive during the use of the handle to prevent the buffer to be
+        returned to the OpenCV buffer pool.
+     */
     void* handle(int accessFlags) const;
     void ndoffset(size_t* ofs) const;
 

--- a/modules/python/src2/cv2.cpp
+++ b/modules/python/src2/cv2.cpp
@@ -508,13 +508,71 @@ static PyObject * UMatWrapper_get(cv2_UMatWrapperObject* self)
     return pyopencv_from(m);
 }
 
+// UMatWrapper.handle() - returns the OpenCL handle of the UMat object
+static PyObject * UMatWrapper_handle(cv2_UMatWrapperObject* self, PyObject *args, PyObject *kwds)
+{
+    const char *kwlist[] = {"accessFlags", NULL};
+    int accessFlags;
+    if (!PyArg_ParseTupleAndKeywords(args, kwds, "i", (char**) kwlist, &accessFlags))
+        return 0;
+    return PyLong_FromVoidPtr(self->um->handle(accessFlags));
+}
+
+// UMatWrapper.isContinuous() - returns true if the matrix data is continuous
+static PyObject * UMatWrapper_isContinuous(cv2_UMatWrapperObject* self)
+{
+    return PyBool_FromLong(self->um->isContinuous());
+}
+
+// UMatWrapper.isContinuous() - returns true if the matrix is a submatrix of another matrix
+static PyObject * UMatWrapper_isSubmatrix(cv2_UMatWrapperObject* self)
+{
+    return PyBool_FromLong(self->um->isSubmatrix());
+}
+
+// UMatWrapper.context() - returns the OpenCL context used by OpenCV UMat
+static PyObject * UMatWrapper_context(cv2_UMatWrapperObject*)
+{
+    return PyLong_FromVoidPtr(cv::ocl::Context::getDefault().ptr());
+}
+
+// UMatWrapper.context() - returns the OpenCL queue used by OpenCV UMat
+static PyObject * UMatWrapper_queue(cv2_UMatWrapperObject*)
+{
+    return PyLong_FromVoidPtr(cv::ocl::Queue::getDefault().ptr());
+}
+
+static PyObject * UMatWrapper_offset_getter(cv2_UMatWrapperObject* self, void*)
+{
+    return PyLong_FromSsize_t(self->um->offset);
+}
+
 static PyMethodDef UMatWrapper_methods[] = {
         {"get", (PyCFunction)UMatWrapper_get, METH_NOARGS,
                 "Returns numpy array"
         },
+        {"handle", (PyCFunction)UMatWrapper_handle, METH_VARARGS | METH_KEYWORDS,
+                "Returns UMat native handle"
+        },
+        {"isContinuous", (PyCFunction)UMatWrapper_isContinuous, METH_NOARGS,
+                "Returns true if the matrix data is continuous"
+        },
+        {"isSubmatrix", (PyCFunction)UMatWrapper_isSubmatrix, METH_NOARGS,
+                "Returns true if the matrix is a submatrix of another matrix"
+        },
+        {"context", (PyCFunction)UMatWrapper_context, METH_NOARGS | METH_STATIC,
+                "Returns OpenCL context handle"
+        },
+        {"queue", (PyCFunction)UMatWrapper_queue, METH_NOARGS | METH_STATIC,
+                "Returns OpenCL queue handle"
+        },
         {NULL, NULL, 0, NULL}  /* Sentinel */
 };
 
+static PyGetSetDef UMatWrapper_getset[] = {
+        {(char*) "offset", (getter) UMatWrapper_offset_getter, NULL, NULL, NULL},
+        {NULL, NULL, NULL, NULL, NULL}  /* Sentinel */
+};
 
 static PyTypeObject cv2_UMatWrapperType = {
 #if PY_MAJOR_VERSION >= 3
@@ -551,7 +609,7 @@ static PyTypeObject cv2_UMatWrapperType = {
         0,                             /* tp_iternext */
         UMatWrapper_methods,           /* tp_methods */
         0,                             /* tp_members */
-        0,                             /* tp_getset */
+        UMatWrapper_getset,            /* tp_getset */
         0,                             /* tp_base */
         0,                             /* tp_dict */
         0,                             /* tp_descr_get */

--- a/modules/python/test/test.py
+++ b/modules/python/test/test.py
@@ -127,12 +127,21 @@ class Hackathon244Tests(NewOpenCVTests):
         data = np.random.random([512, 512])
         # UMat constructors
         data_um = cv2.UMat(data)  # from ndarray
-        data_sub_um = cv2.UMat(data_um, [0, 256], [0, 256])  # from UMat
-        data_dst_um = cv2.UMat(256, 256, cv2.CV_64F)  # from size/type
-
-        # simple test
+        data_sub_um = cv2.UMat(data_um, [128, 256], [128, 256])  # from UMat
+        data_dst_um = cv2.UMat(128, 128, cv2.CV_64F)  # from size/type
+        # test continuous and submatrix flags
+        assert data_um.isContinuous() and not data_um.isSubmatrix()
+        assert not data_sub_um.isContinuous() and data_sub_um.isSubmatrix()
+        # test operation on submatrix
         cv2.multiply(data_sub_um, 2., dst=data_dst_um)
-        assert np.allclose(2. * data[:256, :256], data_dst_um.get())
+        assert np.allclose(2. * data[128:256, 128:256], data_dst_um.get())
+
+    def test_umat_handle(self):
+        a_um = cv2.UMat(256, 256, cv2.CV_32F)
+        ctx_handle = cv2.UMat.context()  # obtain context handle
+        queue_handle = cv2.UMat.queue()  # obtain queue handle
+        a_handle = a_um.handle(cv2.ACCESS_READ)  # obtain buffer handle
+        offset = a_um.offset  # obtain buffer offset
 
     def test_umat_matching(self):
         img1 = self.get_sample("samples/data/right01.jpg")


### PR DESCRIPTION
This is a suggestion for adding OpenCL interoperability to the python UMat interface. The pull request exposes the `UMat::handle` method for obtaining native OpenCL buffer handles. I also added new static methods for obtaining the context and queue handles.

<!--############################################################################################################################################################# -->

This allows running custom OpenCL kernels on UMat buffers using PyOpenCV (zero copy). Example usage:
```python
import numpy as np
import cv2
import pyopencl as cl
import pyopencl.reduction
import pyopencl.array

# Create OpenCL buffer via OpenCV UMat
a_np = np.arange(512, dtype=np.float32)
a_um = cv2.UMat(a_np)

# Obtain native OpenCL handles from OpenCV
ctx_handle = cv2.UMat.context()
queue_handle = cv2.UMat.queue()
a_um_handle = a_um.handle(cv2.ACCESS_READ)

# Access context, queue and buffer using PyOpenCL
ctx = cl.Context.from_int_ptr(ctx_handle)
queue = cl.CommandQueue.from_int_ptr(queue_handle)
a_cl = cl.Buffer.from_int_ptr(a_um_handle)

# Run PyOpenCL kernel on UMat data
a_cl_ary = pyopencl.array.Array(queue, a_np.shape, a_np.dtype, data=a_cl)
krnl = pyopencl.reduction.ReductionKernel(ctx, np.float32,
    neutral="0", reduce_expr="a+b", map_expr="x[i]",
    arguments="__global float *x")
sum_cl = krnl(a_cl_ary).get()
assert np.allclose(sum_cl, a_np.sum())
```