### PR TITLE
Fix build error (8623) which might be a regression issue.

### DIFF
--- a/modules/core/src/intel_gpu_gemm.inl.hpp
+++ b/modules/core/src/intel_gpu_gemm.inl.hpp
@@ -87,7 +87,7 @@ static bool intel_gpu_gemm(
 
     ocl::Queue q;
     String errmsg;
-    const ocl::Program program = ocl::Context::getDefault().getProg(ocl::core::intel_gemm_oclsrc, "", errmsg);
+    const ocl::Program program = ocl::Context::getDefault().getProg(ocl::core::gemm_oclsrc, "", errmsg);
 
     if(!atrans && btrans)
     {


### PR DESCRIPTION
Signed-off-by: Zhenqing Hu <huzq85@gmail.com>

<!-- Please use this line to close one or multiple issues when this pullrequest gets merged
You can add another line right under the first one:
resolves #8623 
-->

### This pullrequest changes

<!-- Please describe what your pullrequest is changing -->
This pullrequest is try to resolve #8623, which is a build issue in Win7 64 bit platform with VS2015 x64 compiler.
The key build error message is:
 3>c:\1work\2opensource\opencv-fork\modules\core\src\intel_gpu_gemm.inl.hpp(90): error C2039: 'intel_gemm_oclsrc': is not a member of 'cv::ocl::core'
3>  C:\1Work\2OpenSource\OpenCVTrunkBuild\modules\world\opencl_kernels_core.hpp(13): note: see declaration of 'cv::ocl::core'
3>c:\1work\2opensource\opencv-fork\modules\core\src\intel_gpu_gemm.inl.hpp(90): error C2065: 'intel_gemm_oclsrc': undeclared identifier
So this PR is try to replace the undeclared variable named "intel_gemm_oclsrc" with "gemm_oclsrc".

