### PR TITLE
Fix webp grayscale loading

### DIFF
--- a/modules/imgcodecs/src/grfmt_webp.cpp
+++ b/modules/imgcodecs/src/grfmt_webp.cpp
@@ -162,6 +162,8 @@ bool WebPDecoder::readData(Mat &img)
 {
     if( m_width > 0 && m_height > 0 )
     {
+        bool convert_grayscale = (img.type() == CV_8UC1); // IMREAD_GRAYSCALE requested
+
         if (img.cols != m_width || img.rows != m_height || img.type() != m_type)
         {
             img.create(m_height, m_width, m_type);
@@ -184,6 +186,10 @@ bool WebPDecoder::readData(Mat &img)
 
         if(res_ptr == out_data)
         {
+            if (convert_grayscale)
+            {
+                cvtColor(img, img, COLOR_BGR2GRAY);
+            }
             return true;
         }
     }


### PR DESCRIPTION
resolves #8637

webp does not support grayscale images natively. there's a cvtColor() applied internally, when trying to write a grayscale img to webp, so there should be an internal cvtColor() applied, too, when IMREAD_GRAYSCALE was specified