### PR TITLE
fix ByteStreamBuffer

### DIFF
--- a/modules/imgcodecs/src/loadsave.cpp
+++ b/modules/imgcodecs/src/loadsave.cpp
@@ -70,21 +70,21 @@ protected:
                               std::ios_base::seekdir dir,
                               std::ios_base::openmode )
     {
-        // get absolute offset
-        off_type off = offset;
+        char* whence = eback();
         if (dir == std::ios_base::cur)
         {
-            off += gptr() - eback();
+            whence = gptr();
         }
         else if (dir == std::ios_base::end)
         {
-            off += egptr() - eback();
+            whence = egptr();
         }
+        char* to = whence + offset;
 
         // check limits
-        if (off >= (off_type)0 && off <= egptr() - eback())
+        if (to >= eback() && to <= egptr())
         {
-            setg(eback(), gptr() + off, egptr());
+            setg(eback(), to, egptr());
             return gptr() - eback();
         }
 


### PR DESCRIPTION
The changes to make this handle all seek directions broke the ByteStreamBuffer. This patch fixes it so that inmemory exif orientation works.