### PR TITLE
8632: Corrected cv::seamlessClone doc to reflect actual name of flag …

### DIFF
--- a/modules/photo/include/opencv2/photo.hpp
+++ b/modules/photo/include/opencv2/photo.hpp
@@ -748,7 +748,7 @@ complex outlines into a new background
 consuming and often leaves an undesirable halo. Seamless cloning, even averaged with the
 original image, is not effective. Mixed seamless cloning based on a loose selection proves
 effective.
--   **FEATURE_EXCHANGE** Feature exchange allows the user to easily replace certain features of
+-   **MONOCHROME_TRANSFER** Monochrome transfer allows the user to easily replace certain features of
 one object by alternative features.
  */
 CV_EXPORTS_W void seamlessClone( InputArray src, InputArray dst, InputArray mask, Point p,


### PR DESCRIPTION
…used in code

resolves #8632 

### This pullrequest changes

<!-- Please describe what your pullrequest is changing -->
Doc proffered `FEATURE_EXCHANGE` as an option. Actually code uses `MONOCHROME_TRANSFER`. See issue 8632 for context.