### PR TITLE
cmake: fix POPCNT & SSE4.2 detection code

### DIFF
--- a/cmake/checks/cpu_popcnt.cpp
+++ b/cmake/checks/cpu_popcnt.cpp
@@ -1,8 +1,22 @@
-#include <nmmintrin.h>
-#ifndef _MSC_VER
-#include <popcntintrin.h>
+#ifdef _MSC_VER
+#  include <nmmintrin.h>
+#  if defined(_M_X64)
+#    define CV_POPCNT_U64 _mm_popcnt_u64
+#  endif
+#  define CV_POPCNT_U32 _mm_popcnt_u32
+#else
+#  include <popcntintrin.h>
+#  if defined(__x86_64__)
+#    define CV_POPCNT_U64 __builtin_popcountll
+#  endif
+#  define CV_POPCNT_U32 __builtin_popcount
 #endif
-int main() {
-    int i = _mm_popcnt_u64(1);
+
+int main()
+{
+#ifdef CV_POPCNT_U64
+    int i = CV_POPCNT_U64(1);
+#endif
+    int j = CV_POPCNT_U32(1);
     return 0;
 }

--- a/cmake/checks/cpu_sse42.cpp
+++ b/cmake/checks/cpu_sse42.cpp
@@ -1,5 +1,7 @@
 #include <nmmintrin.h>
-int main() {
-    int i = _mm_popcnt_u64(1);
+
+int main()
+{
+    unsigned int res = _mm_crc32_u8(1, 2);
     return 0;
 }


### PR DESCRIPTION
Fix problem with Linux 32-bit builds:
```
-- Performing Test HAVE_CXX_MPOPCNT (check file: cmake/checks/cpu_popcnt.cpp)
-- Performing Test HAVE_CXX_MPOPCNT - Failed
-- POPCNT is not supported by C++ compiler
-- Performing Test HAVE_CXX_MSSE4_2 (check file: cmake/checks/cpu_sse42.cpp)
-- Performing Test HAVE_CXX_MSSE4_2 - Failed
-- SSE4_2 is not supported by C++ compiler
```