### PR TITLE
Fix Farneback GPU Sample in GCC6

### DIFF
--- a/samples/gpu/farneback_optical_flow.cpp
+++ b/samples/gpu/farneback_optical_flow.cpp
@@ -1,6 +1,7 @@
 #include <iostream>
 #include <vector>
 #include <sstream>
+#include <cmath>
 
 #include "opencv2/core.hpp"
 #include "opencv2/core/utility.hpp"


### PR DESCRIPTION
resolves #8312

Fix adds a single general include to the farneback gpu sample. It allows CUDA builds to proceed on Arch linux (or other machines that build with gcc-6 by default). This is necessary even when specifically setting cmake flags to require CUDA to compile against gcc-5

Use same 1 line fix suggested in original issue submitter. Was helpful and worked for me too so submitting.


For refererence, I built with the following cmake flags:


            '-D CUDA_FAST_MATH=1'
            '-D ENABLE_FAST_MATH=1'
            '-D WITH_CUBLAS=1'
            '-D WITH_CUFFT=ON'
            '-D CUDA_HOST_COMPILER=/usr/bin/gcc-5'

            '-D WITH_OPENCL=ON'
            '-D WITH_OPENGL=ON'
            '-D WITH_TBB=ON'
            '-D WITH_XINE=ON'
            '-D BUILD_WITH_DEBUG_INFO=OFF'
            '-D BUILD_TESTS=OFF'
            '-D BUILD_PERF_TESTS=OFF'
            '-D BUILD_EXAMPLES=ON'
            '-D INSTALL_C_EXAMPLES=ON'
            '-D INSTALL_PYTHON_EXAMPLES=ON'
            '-D CMAKE_BUILD_TYPE=Release'
            '-D CMAKE_INSTALL_PREFIX=/usr'
            '-D CMAKE_SKIP_RPATH=ON'
