### PR TITLE
Add default parameters for SGBM::create

### DIFF
--- a/modules/calib3d/include/opencv2/calib3d.hpp
+++ b/modules/calib3d/include/opencv2/calib3d.hpp
@@ -1917,7 +1917,7 @@ public:
     set StereoSGBM::numDisparities at minimum. The second constructor enables you to set each parameter
     to a custom value.
      */
-    CV_WRAP static Ptr<StereoSGBM> create(int minDisparity, int numDisparities, int blockSize,
+    CV_WRAP static Ptr<StereoSGBM> create(int minDisparity = 0, int numDisparities = 16, int blockSize = 3,
                                           int P1 = 0, int P2 = 0, int disp12MaxDiff = 0,
                                           int preFilterCap = 0, int uniquenessRatio = 0,
                                           int speckleWindowSize = 0, int speckleRange = 0,


### PR DESCRIPTION
### This pullrequest changes

Adds some default parameters to `SGBM::create`, namely mindisparity, disparity range and SAD window size.

Fixes a bug where `cv::StereoSGBM::load<cv::StereoSGBM>` would not compile because `SGBM::create` has a few parameters with no default values.

Previously the code below would fail to compile on MSVC2015 (Error C2660):

`auto matcher = cv::StereoSGBM::load<cv::StereoSGBM>("./some_path/stereo_sgbm_params.xml");`
