### PR TITLE
Update imgwarp.cpp

### DIFF
--- a/modules/imgproc/src/imgwarp.cpp
+++ b/modules/imgproc/src/imgwarp.cpp
@@ -4368,13 +4368,13 @@ public:
                                     _mm_storeu_si128((__m128i*)(XY + x1*2 + 8), iy1);
                                 }
                             }
-                        #endif
-
+                        #else 
                             for( ; x1 < bcols; x1++ )
                             {
                                 XY[x1*2] = saturate_cast<short>(sX[x1]);
                                 XY[x1*2+1] = saturate_cast<short>(sY[x1]);
                             }
+                        #endif
                         }
                     }
                     nnfunc( *src, dpart, bufxy, borderType, borderValue );


### PR DESCRIPTION
2 float displacement maps conversion to a single interleaved unsigned int displacement map is being done twice if SSE2 because the #else directive was forgotten; at 4350

<!-- Please use this line to close one or multiple issues when this pullrequest gets merged
You can add another line right under the first one:
resolves #1234
resolves #1235
-->

### This pullrequest changes

<!-- Please describe what your pullrequest is changing -->
