### PR TITLE
fix Mat::release() resets channels info for Mat_

### DIFF
--- a/modules/core/include/opencv2/core/mat.hpp
+++ b/modules/core/include/opencv2/core/mat.hpp
@@ -2185,6 +2185,8 @@ public:
     void create(Size _size);
     //! equivalent to Mat::create(_ndims, _sizes, DatType<_Tp>::type)
     void create(int _ndims, const int* _sizes);
+    //! equivalent to Mat::release()
+    void release();
     //! cross-product
     Mat_ cross(const Mat_& m) const;
     //! data type conversion
@@ -2676,11 +2678,11 @@ public:
     /*!
         @param [out] m - output matrix; if it does not have a proper size or type before the operation,
             it is reallocated
-        @param [in] rtype – desired output matrix type or, rather, the depth since the number of channels
+        @param [in] rtype - desired output matrix type or, rather, the depth since the number of channels
             are the same as the input has; if rtype is negative, the output matrix will have the
             same type as the input.
-        @param [in] alpha – optional scale factor
-        @param [in] beta – optional delta added to the scaled values
+        @param [in] alpha - optional scale factor
+        @param [in] beta - optional delta added to the scaled values
     */
     void convertTo( Mat& m, int rtype, double alpha=1, double beta=0 ) const;
 

--- a/modules/core/include/opencv2/core/mat.inl.hpp
+++ b/modules/core/include/opencv2/core/mat.inl.hpp
@@ -1626,6 +1626,15 @@ void Mat_<_Tp>::create(int _dims, const int* _sz)
 }
 
 template<typename _Tp> inline
+void Mat_<_Tp>::release()
+{
+    Mat::release();
+#ifdef _DEBUG
+    flags = (flags & ~CV_MAT_TYPE_MASK) | DataType<_Tp>::type;
+#endif
+}
+
+template<typename _Tp> inline
 Mat_<_Tp> Mat_<_Tp>::cross(const Mat_& m) const
 {
     return Mat_<_Tp>(Mat::cross(m));

--- a/modules/core/test/test_mat.cpp
+++ b/modules/core/test/test_mat.cpp
@@ -1726,3 +1726,11 @@ TEST(Core_Mat_array, SplitMerge)
     }
 }
 #endif
+
+TEST(Mat, regression_8680)
+{
+   Mat_<Point2i> mat(3,1);
+   ASSERT_EQ(mat.channels(), 2);
+   mat.release();
+   ASSERT_EQ(mat.channels(), 2);
+}


### PR DESCRIPTION
resolves #8680 

test code:
```
void main() {
   cv::Mat_<cv::Point2i> mat(3,1);
   assert(mat.channels() == 2);
   mat.release();
   assert(mat.channels() == 2);
}
```