### PR TITLE
py_samples: fix digits.py

### DIFF
--- a/samples/python/digits.py
+++ b/samples/python/digits.py
@@ -109,7 +109,7 @@ def evaluate_model(model, digits, samples, labels):
 
     confusion = np.zeros((10, 10), np.int32)
     for i, j in zip(labels, resp):
-        confusion[i, j] += 1
+        confusion[i, int(j)] += 1
     print('confusion matrix:')
     print(confusion)
     print()


### PR DESCRIPTION
resolves #8714

samples/python/digits.py:   add a cast to int when accessing the confusion matrix