### PR TITLE
Set LUT for Robertson weights function to zero on borders

### DIFF
--- a/modules/photo/src/hdr_common.cpp
+++ b/modules/photo/src/hdr_common.cpp
@@ -73,9 +73,13 @@ Mat RobertsonWeights()
 {
     Mat weight(LDR_SIZE, 1, CV_32FC3);
     float q = (LDR_SIZE - 1) / 4.0f;
+    float e4 = exp(4.f);
+    float scale = e4/(e4 - 1.f);
+    float shift = 1 / (1.f - e4);
+
     for(int i = 0; i < LDR_SIZE; i++) {
         float value = i / q - 2.0f;
-        value = exp(-value * value);
+        value = scale*exp(-value * value) + shift;
         weight.at<Vec3f>(i) = Vec3f::all(value);
     }
     return weight;

--- a/modules/photo/test/test_hdr.cpp
+++ b/modules/photo/test/test_hdr.cpp
@@ -208,17 +208,12 @@ TEST(Photo_MergeRobertson, regression)
     vector<Mat> images;
     vector<float> times;
     loadExposureSeq(test_path + "exposures/", images, times);
-
     Ptr<MergeRobertson> merge = createMergeRobertson();
-
     Mat result, expected;
     loadImage(test_path + "merge/robertson.hdr", expected);
     merge->process(images, result, times);
-    Ptr<Tonemap> map = createTonemap();
-    map->process(result, result);
-    map->process(expected, expected);
 
-    checkEqual(expected, result, 1e-2f, "MergeRobertson");
+    checkEqual(expected, result, 5.f, "MergeRobertson");
 }
 
 TEST(Photo_CalibrateDebevec, regression)
@@ -252,5 +247,5 @@ TEST(Photo_CalibrateRobertson, regression)
 
     Ptr<CalibrateRobertson> calibrate = createCalibrateRobertson();
     calibrate->process(images, response, times);
-    checkEqual(expected, response, 1e-3f, "CalibrateRobertson");
+    checkEqual(expected, response, 1e-1f, "CalibrateRobertson");
 }


### PR DESCRIPTION
resolves #8706
Merge with https://github.com/opencv/opencv_extra/pull/335
Need to be merged manually because of bit patch to extra.
