### PR TITLE
CUDA median_filter.cu: remove #include precomp.hpp

### DIFF
--- a/modules/cudafilters/src/cuda/median_filter.cu
+++ b/modules/cudafilters/src/cuda/median_filter.cu
@@ -42,11 +42,6 @@
 
 #if !defined CUDA_DISABLER
 
-#include "precomp.hpp"
-
-using namespace cv;
-using namespace cv::cuda;
-
 #include "opencv2/core/cuda/common.hpp"
 #include "opencv2/core/cuda/vec_traits.hpp"
 #include "opencv2/core/cuda/vec_math.hpp"


### PR DESCRIPTION
resolves #8730

### This pullrequest changes

Removed redundant precompiled header include and using-namespaces from `modules/cudafilters/src/cuda/median_filter.cu`
