### PR TITLE
Fix icvJSONParseKey function for case big JSON file with only one line inside

### DIFF
--- a/modules/core/src/persistence.cpp
+++ b/modules/core/src/persistence.cpp
@@ -3373,6 +3373,27 @@ static char* icvJSONParseKey( CvFileStorage* fs, char* ptr, CvFileNode* map, CvF
     do ++ptr;
     while( cv_isprint(*ptr) && *ptr != '"' );
 
+    if (*ptr == 0)
+    {
+        if (fs->buffer_start < beg)
+        {
+            int sz = static_cast<int>(ptr - beg);
+            memcpy(fs->buffer_start, beg, sz);
+            beg = fs->buffer_start;
+            if (static_cast<int>(fs->buffer_end - fs->buffer_start) < sz)
+                CV_PARSE_ERROR("Key name is too long");
+            ptr = icvGets(fs, fs->buffer_start + sz, static_cast<int>(fs->buffer_end - fs->buffer_start - sz));
+            if (!ptr)
+            {
+                fs->dummy_eof = true;
+                CV_PARSE_ERROR("Key must end with \'\"\'");
+            }
+
+            while (cv_isprint(*ptr) && *ptr != '"')
+                ++ptr;
+        }
+    }
+
     if( *ptr != '"' )
         CV_PARSE_ERROR( "Key must end with \'\"\'" );
 


### PR DESCRIPTION
If we try to load big JSON file then our internal buffer can split keyname. We have problem with loading JSON file in these cases.

### This pullrequest changes 

icvJSONParseKey function - Try to load next part of the file into internal buffer if we obtain end of buffer when parse key name.
