### PR TITLE
[photo] CalibrateDebevec fix and updates

### DIFF
--- a/modules/photo/include/opencv2/photo.hpp
+++ b/modules/photo/include/opencv2/photo.hpp
@@ -591,7 +591,7 @@ public:
 @param samples number of pixel locations to use
 @param lambda smoothness term weight. Greater values produce smoother results, but can alter the
 response.
-@param random if true sample pixel locations are chosen at random, otherwise the form a
+@param random if true sample pixel locations are chosen at random, otherwise they form a
 rectangular grid.
  */
 CV_EXPORTS_W Ptr<CalibrateDebevec> createCalibrateDebevec(int samples = 70, float lambda = 10.0f, bool random = false);

--- a/modules/photo/src/hdr_common.cpp
+++ b/modules/photo/src/hdr_common.cpp
@@ -59,8 +59,9 @@ void checkImageDimensions(const std::vector<Mat>& images)
     }
 }
 
-Mat tringleWeights()
+Mat triangleWeights()
 {
+    // hat function
     Mat w(LDR_SIZE, 1, CV_32F);
     int half = LDR_SIZE / 2;
     for(int i = 0; i < LDR_SIZE; i++) {

--- a/modules/photo/src/hdr_common.hpp
+++ b/modules/photo/src/hdr_common.hpp
@@ -50,7 +50,7 @@ namespace cv
 
 void checkImageDimensions(const std::vector<Mat>& images);
 
-Mat tringleWeights();
+Mat triangleWeights();
 
 void mapLuminance(Mat src, Mat dst, Mat lum, Mat new_lum, float saturation);
 

--- a/modules/photo/src/merge.cpp
+++ b/modules/photo/src/merge.cpp
@@ -52,7 +52,7 @@ class MergeDebevecImpl : public MergeDebevec
 public:
     MergeDebevecImpl() :
         name("MergeDebevec"),
-        weights(tringleWeights())
+        weights(triangleWeights())
     {
     }
 


### PR DESCRIPTION
The code had `3` hard-coded as number of channels when accessing image pixels. I changed it to use `img.channels()`, that way it works even for grayscale images. This is the first commit.

The other two commits are minor updates (fix typos, add comments, add extra checks, etc.)

Note: I checked the code against the reference paper, which includes a MATLAB implementation in the appendix: http://www.pauldebevec.com/Research/HDR/debevec-siggraph97.pdf
