### PR TITLE
Correct findChessboardCorners flags naming in calib3d doc.

### DIFF
--- a/modules/calib3d/doc/camera_calibration_and_3d_reconstruction.rst
+++ b/modules/calib3d/doc/camera_calibration_and_3d_reconstruction.rst
@@ -483,11 +483,11 @@ Finds the positions of internal corners of the chessboard.
 
     :param flags: Various operation flags that can be zero or a combination of the following values:
 
-            * **CV_CALIB_CB_ADAPTIVE_THRESH** Use adaptive thresholding to convert the image to black and white, rather than a fixed threshold level (computed from the average image brightness).
+            * **CALIB_CB_ADAPTIVE_THRESH** Use adaptive thresholding to convert the image to black and white, rather than a fixed threshold level (computed from the average image brightness).
 
-            * **CV_CALIB_CB_NORMALIZE_IMAGE** Normalize the image gamma with  :ocv:func:`equalizeHist`  before applying fixed or adaptive thresholding.
+            * **CALIB_CB_NORMALIZE_IMAGE** Normalize the image gamma with  :ocv:func:`equalizeHist`  before applying fixed or adaptive thresholding.
 
-            * **CV_CALIB_CB_FILTER_QUADS** Use additional criteria (like contour area, perimeter, square-like shape) to filter out false quads extracted at the contour retrieval stage.
+            * **CALIB_CB_FILTER_QUADS** Use additional criteria (like contour area, perimeter, square-like shape) to filter out false quads extracted at the contour retrieval stage.
 
             * **CALIB_CB_FAST_CHECK** Run a fast check on the image that looks for chessboard corners, and shortcut the call if none is found. This can drastically speed up the call in the degenerate condition when no chessboard is observed.
 


### PR DESCRIPTION
#8760 

### This pullrequest changes

Corrects findChessboardCorners flags naming in the existing calib3d documentation.