### PR TITLE
V4L: do not return frame if it can not be retrieved

### DIFF
--- a/modules/videoio/src/cap_libv4l.cpp
+++ b/modules/videoio/src/cap_libv4l.cpp
@@ -312,6 +312,7 @@ typedef struct CvCaptureCAM_V4L
     int deviceHandle;
     int bufferIndex;
     int FirstCapture;
+    bool returnFrame;
 
     int width; int height;
     int mode;
@@ -1094,6 +1095,8 @@ static CvCaptureCAM_V4L * icvCaptureFromCAM_V4L (const char* deviceName)
        capture->is_v4l2_device = 1;
    }
 
+   capture->returnFrame = true;
+
    return capture;
 }; /* End icvOpenCAM_V4L */
 
@@ -1119,6 +1122,7 @@ static int read_frame_v4l2(CvCaptureCAM_V4L* capture) {
 
         default:
             /* display the error and stop processing */
+            capture->returnFrame = false;
             perror ("VIDIOC_DQBUF");
             return -1;
         }
@@ -1360,7 +1364,10 @@ static IplImage* icvRetrieveFrameCAM_V4L( CvCaptureCAM_V4L* capture, int) {
 
   }
 
-   return(&capture->frame);
+  if (capture->returnFrame)
+    return(&capture->frame);
+  else
+    return 0;
 }
 
 static int zeroPropertyQuietly(CvCaptureCAM_V4L* capture, int property_id, int value)

--- a/modules/videoio/src/cap_v4l.cpp
+++ b/modules/videoio/src/cap_v4l.cpp
@@ -280,6 +280,7 @@ struct CvCaptureCAM_V4L : public CvCapture
    __u32 fps;
    bool convert_rgb;
    bool frame_allocated;
+   bool returnFrame;
 
    /* V4L2 variables */
    buffer buffers[MAX_V4L_BUFFERS + 1];
@@ -820,6 +821,7 @@ bool CvCaptureCAM_V4L::open(const char* _deviceName)
     fps = DEFAULT_V4L_FPS;
     convert_rgb = true;
     deviceName = _deviceName;
+    returnFrame = true;
 
     return _capture_V4L2(this) == 1;
 }
@@ -847,6 +849,7 @@ static int read_frame_v4l2(CvCaptureCAM_V4L* capture) {
 
         default:
             /* display the error and stop processing */
+            capture->returnFrame = false;
             perror ("VIDIOC_DQBUF");
             return -1;
         }
@@ -1581,7 +1584,10 @@ static IplImage* icvRetrieveFrameCAM_V4L( CvCaptureCAM_V4L* capture, int) {
         break;
     }
 
-    return(&capture->frame);
+    if (capture->returnFrame)
+        return(&capture->frame);
+    else
+        return 0;
 }
 
 static inline __u32 capPropertyToV4L2(int prop) {


### PR DESCRIPTION
rebased and modified #6853

### This pullrequest changes

Do not return frame if `ioctl(VIDIOC_DQBUF)` returned error.
