### PR TITLE
fix the mser issue

### DIFF
--- a/modules/features2d/src/mser.cpp
+++ b/modules/features2d/src/mser.cpp
@@ -335,6 +335,8 @@ public:
             head = comp1->head;
             tail = comp2->tail;
             size = comp1->size + comp2->size;
+            // update the history size
+            history->size =size;
 
             CompHistory *h1 = history->child_;
             CompHistory *h2 = comp2->history;


### PR DESCRIPTION
<!-- Please use this line to close one or multiple issues when this pullrequest gets merged
You can add another line right under the first one:
-->

### This pullrequest changes
fix the mser detectRegions bug,  detectRegions would miss some msers sometimes.
I hava found the mser do not work correctly for special image file.

<!-- Please describe what your pullrequest is changing -->
The comp1's history size may be never updated after merging two comps, so one history's parent history size maybe smaller than its child history.
and when the history var is smaller than 0,f, it parent history will be ignored, so it will miss some usefull msers.

it need to update the comp1's history size when its size changed.