### PR TITLE
Removed CMake configuration files from gitignore.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,8 +17,6 @@ bin/
 *.rule
 *.tmp
 */debug
-*/CMakeFiles
-CMakeCache.txt
 *.suo
 *.log
 *.tlog


### PR DESCRIPTION
### This pullrequest changes
Since builds should be performed out of the source tree now it looks useful to be able to find out accidentally created cmake configs with `git status`
