### PR TITLE
Filestorage node read default and std::string

### DIFF
--- a/modules/core/include/opencv2/core/cvstd.inl.hpp
+++ b/modules/core/include/opencv2/core/cvstd.inl.hpp
@@ -151,9 +151,7 @@ FileNode::operator std::string() const
 template<> inline
 void operator >> (const FileNode& n, std::string& value)
 {
-    String val;
-    read(n, val, val);
-    value = val;
+    read(n, value, std::string());
 }
 
 template<> inline

--- a/modules/core/include/opencv2/core/persistence.hpp
+++ b/modules/core/include/opencv2/core/persistence.hpp
@@ -730,6 +730,9 @@ CV_EXPORTS void read(const FileNode& node, int& value, int default_value);
 CV_EXPORTS void read(const FileNode& node, float& value, float default_value);
 CV_EXPORTS void read(const FileNode& node, double& value, double default_value);
 CV_EXPORTS void read(const FileNode& node, String& value, const String& default_value);
+#ifndef OPENCV_NOSTL
+CV_EXPORTS void read(const FileNode& node, std::string& value, const std::string& default_value);
+#endif
 CV_EXPORTS void read(const FileNode& node, Mat& mat, const Mat& default_mat = Mat() );
 CV_EXPORTS void read(const FileNode& node, SparseMat& mat, const SparseMat& default_mat = SparseMat() );
 CV_EXPORTS void read(const FileNode& node, std::vector<KeyPoint>& keypoints);

--- a/modules/core/src/persistence.cpp
+++ b/modules/core/src/persistence.cpp
@@ -7374,26 +7374,26 @@ void read(const FileNode& node, int& value, int default_value)
 {
     value = !node.node ? default_value :
     CV_NODE_IS_INT(node.node->tag) ? node.node->data.i :
-    CV_NODE_IS_REAL(node.node->tag) ? cvRound(node.node->data.f) : 0x7fffffff;
+    CV_NODE_IS_REAL(node.node->tag) ? cvRound(node.node->data.f) : default_value;
 }
 
 void read(const FileNode& node, float& value, float default_value)
 {
     value = !node.node ? default_value :
-        CV_NODE_IS_INT(node.node->tag) ? (float)node.node->data.i :
-        CV_NODE_IS_REAL(node.node->tag) ? (float)node.node->data.f : 1e30f;
+        CV_NODE_IS_REAL(node.node->tag) ? saturate_cast<float>(node.node->data.f):
+        CV_NODE_IS_INT(node.node->tag) ? (float)node.node->data.i :default_value;
 }
 
 void read(const FileNode& node, double& value, double default_value)
 {
     value = !node.node ? default_value :
-        CV_NODE_IS_INT(node.node->tag) ? (double)node.node->data.i :
-        CV_NODE_IS_REAL(node.node->tag) ? node.node->data.f : 1e300;
+        CV_NODE_IS_REAL(node.node->tag) ? node.node->data.f :
+        CV_NODE_IS_INT(node.node->tag) ? (double)node.node->data.i : default_value;
 }
 
 void read(const FileNode& node, String& value, const String& default_value)
 {
-    value = !node.node ? default_value : CV_NODE_IS_STRING(node.node->tag) ? String(node.node->data.str.ptr) : String();
+    value = !node.node ? default_value : CV_NODE_IS_STRING(node.node->tag) ? String(node.node->data.str.ptr) : default_value;
 }
 
 }

--- a/modules/core/src/persistence.cpp
+++ b/modules/core/src/persistence.cpp
@@ -7396,6 +7396,13 @@ void read(const FileNode& node, String& value, const String& default_value)
     value = !node.node ? default_value : CV_NODE_IS_STRING(node.node->tag) ? String(node.node->data.str.ptr) : default_value;
 }
 
+#ifndef OPENCV_NOSTL
+void read(const FileNode& node, std::string& value, const std::string& default_value)
+{
+    value = !node.node ? default_value : CV_NODE_IS_STRING(node.node->tag) ? std::string(node.node->data.str.ptr) : default_value;
+}
+#endif
+
 }
 
 

--- a/samples/cpp/tutorial_code/core/file_input_output/file_input_output.cpp
+++ b/samples/cpp/tutorial_code/core/file_input_output/file_input_output.cpp
@@ -133,7 +133,7 @@ int main(int ac, char** av)
         Mat R, T;
 
         fs["R"] >> R;                                      // Read cv::Mat
-        fs["T"] >> T;
+        cv::read(fs["T"], T, R);                           // Read with default
         fs["MyData"] >> m;                                 // Read your own structure_
 
         cout << endl


### PR DESCRIPTION
resolves #8767

### This pullrequest changes
in cv::read(FileNode, ...) 
- use default_value even if data type mismatch
- add std::string overload
- little changes in the related doc
