### PR TITLE
Do not clean src and gen directories when java is disabled

### DIFF
--- a/modules/java/CMakeLists.txt
+++ b/modules/java/CMakeLists.txt
@@ -8,6 +8,9 @@ if(APPLE_FRAMEWORK OR WINRT OR NOT PYTHON_DEFAULT_AVAILABLE OR NOT ANT_EXECUTABL
   ocv_module_disable(java)
 endif()
 
+set(the_description "The java bindings")
+ocv_add_module(java BINDINGS opencv_core opencv_imgproc)
+
 if(EXISTS ${CMAKE_BINARY_DIR}/src)
   execute_process(COMMAND ${CMAKE_COMMAND} -E remove_directory "${CMAKE_BINARY_DIR}/src")
 endif()
@@ -15,8 +18,6 @@ if(EXISTS ${CMAKE_BINARY_DIR}/gen)
   execute_process(COMMAND ${CMAKE_COMMAND} -E remove_directory "${CMAKE_BINARY_DIR}/gen")
 endif()
 
-set(the_description "The java bindings")
-ocv_add_module(java BINDINGS opencv_core opencv_imgproc)
 ocv_module_include_directories("${CMAKE_CURRENT_SOURCE_DIR}/generator/src/cpp")
 ocv_module_include_directories("${OpenCV_SOURCE_DIR}/include")
 


### PR DESCRIPTION
### This pullrequest changes

When _java_ is disabled with `-DBUILD_opencv_java=OFF`, but _ant_ and _JNI_ are installed in the system cmake script removes `<build>/src` and `<build>/gen` directories. this behaviour could lead to build directory corruption in some configurations.

This is just a workaround, it should be better to use `CMAKE_CURRENT_BINARY_DIR` instead of hardcoded paths.