### PR TITLE
Fix a typo in OpenCVUtils.cmake

### DIFF
--- a/cmake/OpenCVUtils.cmake
+++ b/cmake/OpenCVUtils.cmake
@@ -725,7 +725,7 @@ function(ocv_install_target)
     set(${__package}_TARGETS "${${__package}_TARGETS}" CACHE INTERNAL "List of ${__package} targets")
   endif()
 
-  if(MSVS)
+  if(MSVC)
     if(NOT INSTALL_IGNORE_PDB AND
         (INSTALL_PDB OR
           (INSTALL_CREATE_DISTRIB AND NOT BUILD_SHARED_LIBS)


### PR DESCRIPTION
### This pullrequest changes

To test for Visual Studio generator, MSVC and not MSVS should be used
