### PR TITLE
Modify the pyrlk.cl to support winSize from 8*8 to 24*24 for optical …

### DIFF
--- a/modules/video/src/lkpyramid.cpp
+++ b/modules/video/src/lkpyramid.cpp
@@ -849,7 +849,7 @@ namespace
                 return false;
             if (maxLevel < 0 || winSize.width <= 2 || winSize.height <= 2)
                 return false;
-            if (winSize.width < 16 || winSize.height < 16 ||
+            if (winSize.width < 8 || winSize.height < 8 ||
                 winSize.width > 24 || winSize.height > 24)
                 return false;
             calcPatchSize();
@@ -967,11 +967,17 @@ namespace
             size_t globalThreads[3] = { 8 * (size_t)ptcount, 8};
             char calcErr = (0 == level) ? 1 : 0;
 
+            int wsx = 1, wsy = 1;
+            if(winSize.width < 16)
+                wsx = 0;
+            if(winSize.height < 16)
+                wsy = 0;
             cv::String build_options;
             if (isDeviceCPU())
                 build_options = " -D CPU";
             else
-                build_options = cv::format("-D WAVE_SIZE=%d", waveSize);
+                build_options = cv::format("-D WAVE_SIZE=%d -D WSX=%d -D WSY=%d",
+                                           waveSize, wsx, wsy);
 
             ocl::Kernel kernel;
             if (!kernel.create("lkSparse", cv::ocl::video::pyrlk_oclsrc, build_options))

--- a/modules/video/src/opencl/pyrlk.cl
+++ b/modules/video/src/opencl/pyrlk.cl
@@ -258,9 +258,9 @@ inline void GetPatch(image2d_t J, float x, float y,
     *b2 = mad(diff, *Dy, *b2);
 }
 
-inline void GetError(image2d_t J, const float x, const float y, const float* Pch, float* errval)
+inline void GetError(image2d_t J, const float x, const float y, const float* Pch, float* errval, float w)
 {
-    float diff = (((read_imagef(J, sampler, (float2)(x,y)).x * 16384) + 256) / 512) - (((*Pch * 16384) + 256) /512);
+    float diff = ((((read_imagef(J, sampler, (float2)(x,y)).x * 16384) + 256) / 512) - (((*Pch * 16384) + 256) /512)) * w;
     *errval += fabs(diff);
 }
 
@@ -310,10 +310,34 @@ __kernel void lkSparse(image2d_t I, image2d_t J,
     int xsize=get_local_size(0);
     int ysize=get_local_size(1);
     int k;
+
+#ifdef CPU
+    float wx0 = 1.0f;
+    float wy0 = 1.0f;
     int xBase = mad24(xsize, 2, xid);
     int yBase = mad24(ysize, 2, yid);
-    float wx = (xBase < c_winSize_x) ? 1 : 0;
-    float wy = (yBase < c_winSize_y) ? 1 : 0;
+    float wx1 = (xBase < c_winSize_x) ? 1 : 0;
+    float wy1 = (yBase < c_winSize_y) ? 1 : 0;
+#else
+#if WSX == 1
+    float wx0 = 1.0f;
+    int xBase = mad24(xsize, 2, xid);
+    float wx1 = (xBase < c_winSize_x) ? 1 : 0;
+#else
+    int xBase = mad24(xsize, 1, xid);
+    float wx0 = (xBase < c_winSize_x) ? 1 : 0;
+    float wx1 = 0.0f;
+#endif
+#if WSY == 1
+    float wy0 = 1.0f;
+    int yBase = mad24(ysize, 2, yid);
+    float wy1 = (yBase < c_winSize_y) ? 1 : 0;
+#else
+    int yBase = mad24(ysize, 1, yid);
+    float wy0 = (yBase < c_winSize_y) ? 1 : 0;
+    float wy1 = 0.0f;
+#endif
+#endif
 
     float2 c_halfWin = (float2)((c_winSize_x - 1)>>1, (c_winSize_y - 1)>>1);
 
@@ -354,39 +378,39 @@ __kernel void lkSparse(image2d_t I, image2d_t J,
 
         SetPatch(IPatchLocal, 0, 1,
                  &I_patch[0][1], &dIdx_patch[0][1], &dIdy_patch[0][1],
-                 &A11, &A12, &A22,1);
+                 &A11, &A12, &A22,wx0);
 
         SetPatch(IPatchLocal, 0, 2,
                     &I_patch[0][2], &dIdx_patch[0][2], &dIdy_patch[0][2],
-                    &A11, &A12, &A22,wx);
+                    &A11, &A12, &A22,wx1);
     }
     {
         SetPatch(IPatchLocal, 1, 0,
                  &I_patch[1][0], &dIdx_patch[1][0], &dIdy_patch[1][0],
-                 &A11, &A12, &A22,1);
+                 &A11, &A12, &A22,wy0);
 
 
         SetPatch(IPatchLocal, 1,1,
                  &I_patch[1][1], &dIdx_patch[1][1], &dIdy_patch[1][1],
-                 &A11, &A12, &A22,1);
+                 &A11, &A12, &A22,wx0*wy0);
 
         SetPatch(IPatchLocal, 1,2,
                     &I_patch[1][2], &dIdx_patch[1][2], &dIdy_patch[1][2],
-                    &A11, &A12, &A22,wx);
+                    &A11, &A12, &A22,wx1*wy0);
     }
     {
         SetPatch(IPatchLocal, 2,0,
                  &I_patch[2][0], &dIdx_patch[2][0], &dIdy_patch[2][0],
-                 &A11, &A12, &A22,wy);
+                 &A11, &A12, &A22,wy1);
 
 
         SetPatch(IPatchLocal, 2,1,
                  &I_patch[2][1], &dIdx_patch[2][1], &dIdy_patch[2][1],
-                 &A11, &A12, &A22,wy);
+                 &A11, &A12, &A22,wx0*wy1);
 
         SetPatch(IPatchLocal, 2,2,
                     &I_patch[2][2], &dIdx_patch[2][2], &dIdy_patch[2][2],
-                    &A11, &A12, &A22,wx*wy);
+                    &A11, &A12, &A22,wx1*wy1);
     }
 
 
@@ -496,24 +520,24 @@ __kernel void lkSparse(image2d_t I, image2d_t J,
     if (calcErr)
     {
         {
-            GetError(J, loc0.x, loc0.y, &I_patch[0][0], &D);
-            GetError(J, loc1.x, loc0.y, &I_patch[0][1], &D);
+            GetError(J, loc0.x, loc0.y, &I_patch[0][0], &D, 1);
+            GetError(J, loc1.x, loc0.y, &I_patch[0][1], &D, wx0);
         }
         {
-            GetError(J, loc0.x, loc1.y, &I_patch[1][0], &D);
-            GetError(J, loc1.x, loc1.y, &I_patch[1][1], &D);
+            GetError(J, loc0.x, loc1.y, &I_patch[1][0], &D, wy0);
+            GetError(J, loc1.x, loc1.y, &I_patch[1][1], &D, wx0*wy0);
         }
         if(xBase < c_winSize_x)
         {
-            GetError(J, loc2.x, loc0.y, &I_patch[0][2], &D);
-            GetError(J, loc2.x, loc1.y, &I_patch[1][2], &D);
+            GetError(J, loc2.x, loc0.y, &I_patch[0][2], &D, wx1);
+            GetError(J, loc2.x, loc1.y, &I_patch[1][2], &D, wx1*wy0);
         }
         if(yBase < c_winSize_y)
         {
-            GetError(J, loc0.x, loc2.y, &I_patch[2][0], &D);
-            GetError(J, loc1.x, loc2.y, &I_patch[2][1], &D);
+            GetError(J, loc0.x, loc2.y, &I_patch[2][0], &D, wy1);
+            GetError(J, loc1.x, loc2.y, &I_patch[2][1], &D, wx0*wy1);
             if(xBase < c_winSize_x)
-                GetError(J, loc2.x, loc2.y, &I_patch[2][2], &D);
+                GetError(J, loc2.x, loc2.y, &I_patch[2][2], &D, wx1*wy1);
         }
 
         reduce1(D, smem1, tid);

--- a/modules/video/test/ocl/test_optflowpyrlk.cpp
+++ b/modules/video/test/ocl/test_optflowpyrlk.cpp
@@ -144,7 +144,7 @@ OCL_TEST_P(PyrLKOpticalFlow, Mat)
 
 OCL_INSTANTIATE_TEST_CASE_P(Video, PyrLKOpticalFlow,
                             Combine(
-                                Values(21, 25),
+                                Values(11, 15, 21, 25),
                                 Values(3, 5)
                                 )
                            );


### PR DESCRIPTION
### System information (version)
Platform:
CPU: Intel 6th generation i5-6260U
GPU: Intel Iris Graphics 540 (Skylake GT3e)
OS: Linux Ubuntu 16.04 LTS x64
Compiler:
gcc: gcc (Ubuntu 5.4.0-6ubuntu1~16.04.4) 5.4.0 20160609
OpenCL: intel-opencl-2.0-r4.1.61547
OpenCV:
OpenCV => 3.1.0
WITH_OPENCL true

### Detailed description
In pull request #8609, the winSize has been limited to `16*16` - `24*24` for outputing correct err value. As we discussed in that case, I have modified the opencl kernel - pyrlk.cl - to support smaller winSize. Therefore, the pyrlk.cl supports winSize from `8*8` - `24*24`.

### This pullrequest changes
1. The /modules/video/src/lkpyramid.cpp
           /modules/video/src/opencl/pyrlk.cl 
are changed in order to support smaller winSize.

2. The /modules/video/test/ocl/test_optflowpyrlk.cpp is changed to add test case with winSize 11 and 15.

### Performance
1. The original performance test's winSize is `21*21`. With this changing, the performance is the same as before.

2. With the patch shown below, I test the performance with winSize `11*11`
```diff --git a/modules/video/perf/opencl/perf_optflow_pyrlk.cpp b/modules/video/perf/opencl/perf_optflow_pyrlk.cpp
index 81c8ed9..d565ec6 100644
--- a/modules/video/perf/opencl/perf_optflow_pyrlk.cpp
+++ b/modules/video/perf/opencl/perf_optflow_pyrlk.cpp
@@ -70,7 +70,7 @@ OCL_PERF_TEST_P(PyrLKOpticalFlowFixture, PyrLKOpticalFlow,
     UMat uFrame0; frame0.copyTo(uFrame0);
     UMat uFrame1; frame1.copyTo(uFrame1);
 
-    const Size winSize = Size(21, 21);
+    const Size winSize = Size(11, 11);
     const int maxLevel = 3;
     const TermCriteria criteria = TermCriteria(TermCriteria::COUNT+TermCriteria::EPS, 30, 0.01);
     const int flags = 0;
diff --git a/modules/video/perf/perf_optflowpyrlk.cpp b/modules/video/perf/perf_optflowpyrlk.cpp
index a17a0f3..5a36067 100644
--- a/modules/video/perf/perf_optflowpyrlk.cpp
+++ b/modules/video/perf/perf_optflowpyrlk.cpp
@@ -271,3 +271,34 @@ PERF_TEST_P(Path_Win_Deriv_Border_Reuse, OpticalFlowPyrLK_pyr, testing::Combine(
 
     SANITY_CHECK(pyramid);
 }
+
+typedef tr1::tuple< int > Path_Idx_Cn_NPoints_WSize_cpu_t;
+typedef TestBaseWithParam<Path_Idx_Cn_NPoints_WSize_cpu_t> Path_Idx_Cn_NPoints_WSize_cpu;
+PERF_TEST_P(Path_Idx_Cn_NPoints_WSize_cpu, OpticalFlowPyrLK_cpu,
+            testing::Values<int>(1000, 2000, 4000)
+            ) {
+    Mat frame0 = imread(getDataPath("gpu/opticalflow/rubberwhale1.png"), cv::IMREAD_GRAYSCALE);
+    ASSERT_FALSE(frame0.empty()) << "can't load rubberwhale1.png";
+
+    Mat frame1 = imread(getDataPath("gpu/opticalflow/rubberwhale2.png"), cv::IMREAD_GRAYSCALE);
+    ASSERT_FALSE(frame1.empty()) << "can't load rubberwhale2.png";
+
+    const Size winSize = Size(11, 11);
+    const int maxLevel = 3;
+    const TermCriteria criteria = TermCriteria(TermCriteria::COUNT+TermCriteria::EPS, 30, 0.01);
+    const int flags = 0;
+    const float minEigThreshold = 1e-4f;
+    const double eps = 1.0;
+
+    int pointsCount = get<0>(GetParam());
+
+    vector<Point2f> pts;
+    goodFeaturesToTrack(frame0, pts, pointsCount, 0.01, 0.0);
+
+    declare.in(frame0, frame1, WARMUP_READ);
+    Mat NextPts, Status, Err;
+
+    TEST_CYCLE_N(30)
+        cv::calcOpticalFlowPyrLK(frame0, frame1, pts, NextPts, Status, Err, winSize, maxLevel, criteria, flags, minEigThreshold);
+    SANITY_CHECK(NextPts, eps);
+}```

The test result is showed in the table:
```
Key Points | CPU / ms | GPU / ms
:--------------: | :------------: | :-----------:
 1000 | 4.66 | 4.0 
 2000 | 8.67 | 6.02
 4000 | 15.63 | 9.91 
```
With winSize `11*11`, GPU is still faster than CPU on the test platform.