### PR TITLE
build: fix build for MSVS2010-2013, remove softfloat from default scope

### DIFF
--- a/modules/core/include/opencv2/core.hpp
+++ b/modules/core/include/opencv2/core.hpp
@@ -58,7 +58,6 @@
 #include "opencv2/core/types.hpp"
 #include "opencv2/core/mat.hpp"
 #include "opencv2/core/persistence.hpp"
-#include "opencv2/core/softfloat.hpp"
 
 /**
 @defgroup core Core functionality

--- a/modules/core/include/opencv2/core/softfloat.hpp
+++ b/modules/core/include/opencv2/core/softfloat.hpp
@@ -83,6 +83,18 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include "cvdef.h"
 
+// int32_t / uint32_t
+#if defined(_MSC_VER) && _MSC_VER < 1600 /* MSVS 2010 */
+namespace cv {
+typedef signed int int32_t;
+typedef unsigned int uint32_t;
+}
+#elif defined(_MSC_VER) || __cplusplus >= 201103L
+#include <cstdint>
+#else
+#include <stdint.h>
+#endif
+
 namespace cv
 {
 

--- a/modules/core/src/precomp.hpp
+++ b/modules/core/src/precomp.hpp
@@ -58,8 +58,6 @@
 #include "opencv2/core/ocl.hpp"
 #endif
 
-#include "opencv2/core/softfloat.hpp"
-
 #include <assert.h>
 #include <ctype.h>
 #include <float.h>

--- a/modules/core/src/softfloat.cpp
+++ b/modules/core/src/softfloat.cpp
@@ -79,6 +79,8 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include "precomp.hpp"
 
+#include "opencv2/core/softfloat.hpp"
+
 namespace cv
 {
 

--- a/modules/core/test/test_math.cpp
+++ b/modules/core/test/test_math.cpp
@@ -5,6 +5,7 @@
 #include "test_precomp.hpp"
 #include <float.h>
 #include <math.h>
+#include "opencv2/core/softfloat.hpp"
 
 using namespace cv;
 using namespace std;


### PR DESCRIPTION
"softfloat" is new experimental feature, so no need to force it as part of public API.