### PR TITLE
Enforce --std=c++98 flags for NVCC CUDA compiler

### DIFF
--- a/cmake/OpenCVDetectCUDA.cmake
+++ b/cmake/OpenCVDetectCUDA.cmake
@@ -123,7 +123,7 @@ if(CUDA_FOUND)
   endif()
 
   # NVCC flags to be set
-  set(NVCC_FLAGS_EXTRA "")
+  set(NVCC_FLAGS_EXTRA "--std=c++98")
 
   # These vars will be passed into the templates
   set(OPENCV_CUDA_ARCH_BIN "")


### PR DESCRIPTION
### This pull request changes

This fixes incompatibility of CUDA NVCC compiler with GCC 6.* and later by adding std++98 flag, CUDA NVCC compiler (8.0) doesn't support in the moment c++11 and later.

