### PR TITLE
fix clang/c2 error "Unexpected atomic instruction -- use Windows inte…

### DIFF
--- a/modules/core/include/opencv2/core/operations.hpp
+++ b/modules/core/include/opencv2/core/operations.hpp
@@ -54,7 +54,7 @@
 /////// exchange-add operation for atomic operations on reference counters ///////
 #ifdef CV_XADD
   // allow to use user-defined macro
-#elif defined __GNUC__
+#elif !defined(__c2__) && defined __GNUC__
 
   #if defined __clang__ && __clang_major__ >= 3 && !defined __ANDROID__ && !defined __EMSCRIPTEN__  && !defined(__CUDACC__)
     #ifdef __ATOMIC_SEQ_CST


### PR DESCRIPTION
fix clang/c2 build fail "Unexpected atomic instruction -- use Windows interlock intrinsics"

ref:

https://blogs.msdn.microsoft.com/vcblog/2015/12/04/clang-with-microsoft-codegen-in-vs-2015-update-1/