### PR TITLE
Update doc build instructions for doxygen

### DIFF
--- a/doc/py_tutorials/py_setup/py_setup_in_fedora/py_setup_in_fedora.markdown
+++ b/doc/py_tutorials/py_setup/py_setup_in_fedora/py_setup_in_fedora.markdown
@@ -234,10 +234,9 @@ Thus OpenCV installation is finished. Open a terminal and try import cv2.
 
 To build the documentation, just enter following commands:
 @code{.sh}
-make docs
-make html_docs
+make doxygen
 @endcode
-Then open opencv/build/doc/_html/index.html and bookmark it in the browser.
+Then open opencv/build/doc/doxygen/html/index.html and bookmark it in the browser.
 
 Additional Resources
 --------------------

--- a/doc/tutorials/introduction/linux_install/linux_install.markdown
+++ b/doc/tutorials/introduction/linux_install/linux_install.markdown
@@ -104,12 +104,12 @@ Building OpenCV from Source Using CMake
     make -j7 # runs 7 jobs in parallel
     @endcode
 -#  [optional] Building documents. Enter \<cmake_build_dir/doc/\> and run make with target
-    "html_docs"
+    "doxygen"
 
     For example
     @code{.bash}
     cd ~/opencv/build/doc/
-    make -j7 html_docs
+    make -j7 doxygen
     @endcode
 -#  To install libraries, execute the following command from build directory
     @code{.bash}


### PR DESCRIPTION
### This pull request changes documentation

Pretty simple PR. Currently the documentation on how to build the docs is outdated (uses `make html_docs`), this PR updates it to use the new way (`make doxygen`).