### PR TITLE
More information from Hough Circles

### DIFF
--- a/modules/imgproc/src/hough.cpp
+++ b/modules/imgproc/src/hough.cpp
@@ -1259,7 +1259,7 @@ cvHoughCircles( CvArr* src_image, void* circle_storage,
     if( CV_IS_STORAGE( circle_storage ))
     {
         circles = cvCreateSeq( CV_32FC3, sizeof(CvSeq),
-            sizeof(float)*3, (CvMemStorage*)circle_storage );
+            sizeof(float)*4, (CvMemStorage*)circle_storage );
     }
     else if( CV_IS_MAT( circle_storage ))
     {
@@ -1270,7 +1270,7 @@ cvHoughCircles( CvArr* src_image, void* circle_storage,
             CV_Error( CV_StsBadArg,
             "The destination matrix should be continuous and have a single row or a single column" );
 
-        circles = cvMakeSeqHeaderForArray( CV_32FC3, sizeof(CvSeq), sizeof(float)*3,
+        circles = cvMakeSeqHeaderForArray( CV_32FC3, sizeof(CvSeq), sizeof(float)*4,
                 mat->data.ptr, mat->rows + mat->cols - 1, &circles_header, &circles_block );
         circles_max = circles->total;
         cvClearSeq( circles );

--- a/modules/imgproc/src/hough.cpp
+++ b/modules/imgproc/src/hough.cpp
@@ -1210,10 +1210,11 @@ icvHoughCirclesGradient( CvMat* img, float dp, float min_dist,
         // Check if the circle has enough support
         if( max_count > acc_threshold )
         {
-            float c[3];
+            float c[4];
             c[0] = cx;
             c[1] = cy;
             c[2] = (float)r_best;
+            c[3] = (float)max_count;
             cvSeqPush( circles, c );
             if( circles->total > circles_max )
                 return;

--- a/modules/imgproc/src/hough.cpp
+++ b/modules/imgproc/src/hough.cpp
@@ -1258,7 +1258,7 @@ cvHoughCircles( CvArr* src_image, void* circle_storage,
 
     if( CV_IS_STORAGE( circle_storage ))
     {
-        circles = cvCreateSeq( CV_32FC3, sizeof(CvSeq),
+        circles = cvCreateSeq( CV_32FC4, sizeof(CvSeq),
             sizeof(float)*4, (CvMemStorage*)circle_storage );
     }
     else if( CV_IS_MAT( circle_storage ))
@@ -1270,7 +1270,7 @@ cvHoughCircles( CvArr* src_image, void* circle_storage,
             CV_Error( CV_StsBadArg,
             "The destination matrix should be continuous and have a single row or a single column" );
 
-        circles = cvMakeSeqHeaderForArray( CV_32FC3, sizeof(CvSeq), sizeof(float)*4,
+        circles = cvMakeSeqHeaderForArray( CV_32FC4, sizeof(CvSeq), sizeof(float)*4,
                 mat->data.ptr, mat->rows + mat->cols - 1, &circles_header, &circles_block );
         circles_max = circles->total;
         cvClearSeq( circles );


### PR DESCRIPTION
Added extra element to object in circle CvSeq to record the support of each circle for ranking

<!-- Please use this line to close one or multiple issues when this pullrequest gets merged
You can add another line right under the first one:
resolves #1234
resolves #1235
-->

### This pullrequest changes

The `icvHoughCirclesGradient` function in `modules/imgproc/src/hough.cpp` has been updated to now return the number of supporting pixels as part of each circle object to allow for more analysis of each detected circle that may be required on a per-application basis.

<!-- Please describe what your pullrequest is changing -->
