### PR TITLE
macOS cocoa window autosize could not access image dimensions

### DIFF
--- a/modules/highgui/src/window_cocoa.mm
+++ b/modules/highgui/src/window_cocoa.mm
@@ -862,11 +862,7 @@ void cv::setWindowTitle(const String& winname, const String& title)
 @end
 
 @implementation CVView
-#if defined(__LP64__)
-@synthesize image;
-#else // 32-bit Obj-C does not have automatic synthesize
 @synthesize image = _image;
-#endif
 
 - (id)init {
     //cout << "CVView init" << endl;


### PR DESCRIPTION
resolves #8885 

### This pullrequest changes

Window autosize was not working for macOS using cocoa. The window's image dimensions could not be found. This has been fixed by removing __IP64__ specific synthesize in window_cocoa.mm that was causing null reference for the window's contentView image property in cvShowImage (image reference was not linked to _image). The cause of this was code previously added as part of #8307 to allow 32-bit OSX builds. It is possible similar modifications may be required should functions need to access CVWindow and CVSlider properties.