### PR TITLE
cuda: suppress warning on Jetson TK1

### DIFF
--- a/modules/cudaarithm/src/cuda/absdiff_scalar.cu
+++ b/modules/cudaarithm/src/cuda/absdiff_scalar.cu
@@ -119,10 +119,9 @@ void absDiffScalar(const GpuMat& src, cv::Scalar val, bool, GpuMat& dst, const G
     };
 
     const int sdepth = src.depth();
-    const int ddepth = dst.depth();
     const int cn = src.channels();
 
-    CV_DbgAssert( sdepth <= CV_64F && ddepth <= CV_64F && cn <= 4 && src.type() == dst.type());
+    CV_DbgAssert( sdepth <= CV_64F && cn <= 4 && src.type() == dst.type());
 
     const func_t func = funcs[sdepth][cn - 1];
     if (!func)


### PR DESCRIPTION
<!-- Please use this line to close one or multiple issues when this pullrequest gets merged
You can add another line right under the first one:
resolves #1234
resolves #1235
-->

### This pullrequest changes

<!-- Please describe what your pullrequest is changing -->

 - suppress warning on Jetson TK1
 - following warning appears when building on Jetson TK1
```
/home/ubuntu/opencv-fork/modules/cudaarithm/src/cuda/absdiff_scalar.cu: In function ‘void absDiffScalar(const cv::cuda::GpuMat&, cv::Scalar, bool, cv::cuda::GpuMat&, const cv::cuda::GpuMat&, double, cv::cuda::Stream&, int)’:
/home/ubuntu/opencv-fork/modules/cudaarithm/src/cuda/absdiff_scalar.cu:122:11: warning: unused variable ‘ddepth’ [-Wunused-variable]
     const int ddepth = dst.depth();
           ^
```