### PR TITLE
imgproc: suppress warnings

### DIFF
--- a/modules/imgproc/src/imgwarp.cpp
+++ b/modules/imgproc/src/imgwarp.cpp
@@ -428,7 +428,9 @@ public:
     {
     }
 
+#if defined(__INTEL_COMPILER)
 #pragma optimization_parameter target_arch=AVX
+#endif
     virtual void operator() (const Range& range) const
     {
         Size ssize = src.size(), dsize = dst.size();
@@ -504,7 +506,9 @@ public:
     {
     }
 
+#if defined(__INTEL_COMPILER)
 #pragma optimization_parameter target_arch=AVX
+#endif
     virtual void operator() (const Range& range) const
     {
         Size ssize = src.size(), dsize = dst.size();
@@ -605,11 +609,13 @@ public:
     {
     }
 
+#if defined(__INTEL_COMPILER)
 #pragma optimization_parameter target_arch=SSE4.2
+#endif
     virtual void operator() (const Range& range) const
     {
         Size ssize = src.size(), dsize = dst.size();
-        int y, x, pix_size = (int)src.elemSize();
+        int y, x;
         int width = dsize.width;
         int sseWidth = width - (width & 0x7);
         for(y = range.start; y < range.end; y++)
@@ -666,11 +672,13 @@ public:
         ify(_ify)
     {
     }
+#if defined(__INTEL_COMPILER)
 #pragma optimization_parameter target_arch=SSE4.2
+#endif
     virtual void operator() (const Range& range) const
     {
         Size ssize = src.size(), dsize = dst.size();
-        int y, x, pix_size = (int)src.elemSize();
+        int y, x;
         int width = dsize.width;
         int sseWidth = width - (width & 0x3);
         for(y = range.start; y < range.end; y++)


### PR DESCRIPTION
<!-- Please use this line to close one or multiple issues when this pullrequest gets merged
You can add another line right under the first one:
resolves #1234
resolves #1235
-->

### This pullrequest changes
 - remove warnings on VS2012
 - probably happens on other compilers, too
 - check if compiler is Intel compiler
 - remove not referenced variables

```
1>C:\work\opencv-fork\modules\imgproc\src\imgwarp.cpp(669): warning C4068: unknown pragma
```
```
1>C:\work\opencv-fork\modules\imgproc\src\imgwarp.cpp(673): warning C4189: 'pix_size' : local variable is initialized but not referenced
```
<!-- Please describe what your pullrequest is changing -->
