### PR TITLE
Fixed clipLine evaluation for very long lines

### DIFF
--- a/modules/imgproc/src/drawing.cpp
+++ b/modules/imgproc/src/drawing.cpp
@@ -111,14 +111,14 @@ bool clipLine( Size2l img_size, Point2l& pt1, Point2l& pt2 )
         if( c1 & 12 )
         {
             a = c1 < 8 ? 0 : bottom;
-            x1 +=  (a - y1) * (x2 - x1) / (y2 - y1);
+            x1 += (int64)((double)(a - y1) * (x2 - x1) / (y2 - y1));
             y1 = a;
             c1 = (x1 < 0) + (x1 > right) * 2;
         }
         if( c2 & 12 )
         {
             a = c2 < 8 ? 0 : bottom;
-            x2 += (a - y2) * (x2 - x1) / (y2 - y1);
+            x2 += (int64)((double)(a - y2) * (x2 - x1) / (y2 - y1));
             y2 = a;
             c2 = (x2 < 0) + (x2 > right) * 2;
         }
@@ -127,14 +127,14 @@ bool clipLine( Size2l img_size, Point2l& pt1, Point2l& pt2 )
             if( c1 )
             {
                 a = c1 == 1 ? 0 : right;
-                y1 += (a - x1) * (y2 - y1) / (x2 - x1);
+                y1 += (int64)((double)(a - x1) * (y2 - y1) / (x2 - x1));
                 x1 = a;
                 c1 = 0;
             }
             if( c2 )
             {
                 a = c2 == 1 ? 0 : right;
-                y2 += (a - x2) * (y2 - y1) / (x2 - x1);
+                y2 += (int64)((double)(a - x2) * (y2 - y1) / (x2 - x1));
                 x2 = a;
                 c2 = 0;
             }
@@ -311,7 +311,7 @@ LineAA( Mat& img, Point2l pt1, Point2l pt2, const void* color )
 
     if( !((nch == 1 || nch == 3 || nch == 4) && img.depth() == CV_8U) )
     {
-        Line(img, Point((int)(pt1.x<<XY_SHIFT), (int)(pt1.y<<XY_SHIFT)), Point((int)(pt2.x<<XY_SHIFT), (int)(pt2.y<<XY_SHIFT)), color);
+        Line(img, Point((int)(pt1.x>>XY_SHIFT), (int)(pt1.y>>XY_SHIFT)), Point((int)(pt2.x>>XY_SHIFT), (int)(pt2.y>>XY_SHIFT)), color);
         return;
     }
 

--- a/modules/imgproc/test/test_drawing.cpp
+++ b/modules/imgproc/test/test_drawing.cpp
@@ -709,6 +709,31 @@ TEST(Drawing, polylines)
     ASSERT_EQ(cnt, 21);
 }
 
+TEST(Drawing, longline)
+{
+    Mat mat = Mat::zeros(256, 256, CV_8UC1);
+
+    line(mat, cv::Point(34, 204), cv::Point(46400, 47400), cv::Scalar(255), 3);
+    EXPECT_EQ(310, cv::countNonZero(mat));
+
+    Point pt[6];
+    pt[0].x = 32;
+    pt[0].y = 204;
+    pt[1].x = 34;
+    pt[1].y = 202;
+    pt[2].x = 87;
+    pt[2].y = 255;
+    pt[3].x = 82;
+    pt[3].y = 255;
+    pt[4].x = 37;
+    pt[4].y = 210;
+    pt[5].x = 37;
+    pt[5].y = 209;
+    fillConvexPoly(mat, pt, 6, cv::Scalar(0));
+
+    EXPECT_EQ(0, cv::countNonZero(mat));
+}
+
 
 TEST(Drawing, putText_no_garbage)
 {


### PR DESCRIPTION
resolves #8846

### This pullrequest changes
Change evaluation of clipLine in order to avoid overflow for very long lines