### PR TITLE
Synthesize & property & explicit property declaration are referring p…

### DIFF
--- a/modules/highgui/src/window_cocoa.mm
+++ b/modules/highgui/src/window_cocoa.mm
@@ -862,11 +862,7 @@ void cv::setWindowTitle(const String& winname, const String& title)
 @end
 
 @implementation CVView
-#if defined(__LP64__)
-@synthesize image;
-#else // 32-bit Obj-C does not have automatic synthesize
 @synthesize image = _image;
-#endif
 
 - (id)init {
     //cout << "CVView init" << endl;


### PR DESCRIPTION
Synthesize & property & explicit property declaration are referring partially to different attributes

To solve this issue the @synthesize statement should always be used.
