### PR TITLE
Fixed gray window for gpu stereo BP and CSBP

### DIFF
--- a/samples/gpu/stereo_match.cpp
+++ b/samples/gpu/stereo_match.cpp
@@ -212,7 +212,7 @@ void App::run()
         // Show results
         d_disp.download(disp);
         putText(disp, text(), Point(5, 25), FONT_HERSHEY_SIMPLEX, 1.0, Scalar::all(255));
-        imshow("disparity", disp);
+        imshow("disparity", (Mat_<uchar>)disp);
 
         handleKey((char)waitKey(3));
     }


### PR DESCRIPTION
<!-- Please use this line to close one or multiple issues when this pullrequest gets merged
You can add another line right under the first one:
resolves #1234
resolves #1235
-->

### This pullrequest changes

<!-- Please describe what your pullrequest is changing -->compute() for BP and CSBP output 32-bit floating-point mat, and in cv::imshow() 32-bit floating-point is recognized as [0,1] and maped to [0,255], that causes gray window for BP and CSBP.
