### PR TITLE
[GSOC] Speeding-up AKAZE, part #2

### DIFF
--- a/modules/features2d/perf/perf_feature2d.cpp
+++ b/modules/features2d/perf/perf_feature2d.cpp
@@ -12,8 +12,6 @@ PERF_TEST_P(feature2d, detect, testing::Combine(Feature2DType::all(), TEST_IMAGE
     declare.in(img);
     Mat mask;
     vector<KeyPoint> points;
-    // initialize task scheduler for TBB
-    cv::setNumThreads(cv::getNumberOfCPUs());
 
     TEST_CYCLE() detector->detect(img, points, mask);
 
@@ -34,10 +32,8 @@ PERF_TEST_P(feature2d, extract, testing::Combine(testing::Values(DETECTORS_EXTRA
     declare.in(img);
     Mat mask;
     vector<KeyPoint> points;
-    // initialize task scheduler for TBB
-    cv::setNumThreads(cv::getNumberOfCPUs());
-
     detector->detect(img, points, mask);
+
     EXPECT_GT(points.size(), 20u);
 
     Mat descriptors;
@@ -61,8 +57,6 @@ PERF_TEST_P(feature2d, detectAndExtract, testing::Combine(testing::Values(DETECT
     Mat mask;
     vector<KeyPoint> points;
     Mat descriptors;
-    // initialize task scheduler for TBB
-    cv::setNumThreads(cv::getNumberOfCPUs());
 
     TEST_CYCLE() detector->detectAndCompute(img, mask, points, descriptors, false);
 

--- a/modules/features2d/perf/perf_feature2d.cpp
+++ b/modules/features2d/perf/perf_feature2d.cpp
@@ -12,6 +12,8 @@ PERF_TEST_P(feature2d, detect, testing::Combine(Feature2DType::all(), TEST_IMAGE
     declare.in(img);
     Mat mask;
     vector<KeyPoint> points;
+    // initialize task scheduler for TBB
+    cv::setNumThreads(cv::getNumberOfCPUs());
 
     TEST_CYCLE() detector->detect(img, points, mask);
 
@@ -32,8 +34,10 @@ PERF_TEST_P(feature2d, extract, testing::Combine(testing::Values(DETECTORS_EXTRA
     declare.in(img);
     Mat mask;
     vector<KeyPoint> points;
-    detector->detect(img, points, mask);
+    // initialize task scheduler for TBB
+    cv::setNumThreads(cv::getNumberOfCPUs());
 
+    detector->detect(img, points, mask);
     EXPECT_GT(points.size(), 20u);
 
     Mat descriptors;
@@ -57,6 +61,8 @@ PERF_TEST_P(feature2d, detectAndExtract, testing::Combine(testing::Values(DETECT
     Mat mask;
     vector<KeyPoint> points;
     Mat descriptors;
+    // initialize task scheduler for TBB
+    cv::setNumThreads(cv::getNumberOfCPUs());
 
     TEST_CYCLE() detector->detectAndCompute(img, mask, points, descriptors, false);
 

--- a/modules/features2d/perf/perf_feature2d.hpp
+++ b/modules/features2d/perf/perf_feature2d.hpp
@@ -35,7 +35,8 @@ typedef perf::TestBaseWithParam<Feature2DType_String_t> feature2d;
 
 #define TEST_IMAGES testing::Values(\
     "cv/detectors_descriptors_evaluation/images_datasets/leuven/img1.png",\
-    "stitching/a3.png")
+    "stitching/a3.png", \
+    "stitching/s2.jpg")
 
 static inline Ptr<Feature2D> getFeature2D(Feature2DType type)
 {

--- a/modules/features2d/src/akaze.cpp
+++ b/modules/features2d/src/akaze.cpp
@@ -210,13 +210,10 @@ namespace cv
 
             if( descriptors.needed() )
             {
-                Mat desc;
-                impl.Compute_Descriptors(keypoints, desc);
-                // TODO optimize this copy
-                desc.copyTo(descriptors);
+                impl.Compute_Descriptors(keypoints, descriptors);
 
-                CV_Assert((!desc.rows || desc.cols == descriptorSize()));
-                CV_Assert((!desc.rows || (desc.type() == descriptorType())));
+                CV_Assert((descriptors.empty() || descriptors.cols() == descriptorSize()));
+                CV_Assert((descriptors.empty() || (descriptors.type() == descriptorType())));
             }
         }
 

--- a/modules/features2d/src/kaze/AKAZEFeatures.cpp
+++ b/modules/features2d/src/kaze/AKAZEFeatures.cpp
@@ -931,7 +931,7 @@ void Compute_Main_Orientation(KeyPoint& kpt, const std::vector<TEvolution>& evol
   }
 
   // Store the final result
-  kpt.angle = getAngle(maxX, maxY) * 180.f / static_cast<float>(CV_PI);;
+  kpt.angle = fastAtan2(maxY, maxX);
 }
 
 /**

--- a/modules/features2d/src/kaze/AKAZEFeatures.cpp
+++ b/modules/features2d/src/kaze/AKAZEFeatures.cpp
@@ -793,8 +793,8 @@ void Sample_Derivative_Response_Radius6(const Mat &Lx, const Mat &Ly,
           for (int j = -6; j <= 6; ++j) {
             if (i*i + j*j < 36) {
               weight[k] = gauss25[id[i + 6]][id[j + 6]];
-              yidx[k] = i;
-              xidx[k] = j;
+              yidx[k] = static_cast<int8_t>(i);
+              xidx[k] = static_cast<int8_t>(j);
               ++k;
             }
           }
@@ -848,7 +848,7 @@ void quantized_counting_sort(const float a[], const int n,
 
   // Generate the sorted indices; cum[] becomes the exclusive prefix sum i.e. the start indices of keys
   for (int i = 0; i < n; i++)
-    idx[--cum[(int)(a[i] / quantum)]] = i;
+    idx[--cum[(int)(a[i] / quantum)]] = static_cast<uint8_t>(i);
 }
 
 /**

--- a/modules/features2d/src/kaze/AKAZEFeatures.cpp
+++ b/modules/features2d/src/kaze/AKAZEFeatures.cpp
@@ -254,19 +254,20 @@ compute_kcontrast(const cv::Mat& Lx, const cv::Mat& Ly, float perc, int nbins)
   Mat modgs (Lx.rows - 2, Lx.cols - 2, CV_32F);
   const int total = modgs.cols * modgs.rows;
   float *modg = modgs.ptr<float>();
+  float hmax = 0.0f;
 
   for (int i = 1; i < Lx.rows - 1; i++) {
     const float *lx = Lx.ptr<float>(i) + 1;
     const float *ly = Ly.ptr<float>(i) + 1;
     const int cols = Lx.cols - 2;
 
-    for (int j = 0; j < cols; j++)
-        *modg++ = sqrtf(lx[j] * lx[j] + ly[j] * ly[j]);
+    for (int j = 0; j < cols; j++) {
+      float dist = sqrtf(lx[j] * lx[j] + ly[j] * ly[j]);
+      *modg++ = dist;
+      hmax = std::max(hmax, dist);
+    }
   }
   modg = modgs.ptr<float>();
-
-  // Get the maximum
-  float hmax = *std::max_element(modg, modg + total);
 
   if (hmax == 0.0f)
     return 0.03f;  // e.g. a blank image

--- a/modules/features2d/src/kaze/AKAZEFeatures.cpp
+++ b/modules/features2d/src/kaze/AKAZEFeatures.cpp
@@ -43,6 +43,7 @@ AKAZEFeatures::AKAZEFeatures(const AKAZEOptions& options) : options_(options) {
  * @brief This method allocates the memory for the nonlinear diffusion evolution
  */
 void AKAZEFeatures::Allocate_Memory_Evolution(void) {
+  CV_INSTRUMENT_REGION()
 
   float rfactor = 0.0f;
   int level_height = 0, level_width = 0;
@@ -99,6 +100,7 @@ void AKAZEFeatures::Allocate_Memory_Evolution(void) {
  */
 int AKAZEFeatures::Create_Nonlinear_Scale_Space(const Mat& img)
 {
+  CV_INSTRUMENT_REGION()
   CV_Assert(evolution_.size() > 0);
 
   // Copy the original image to the first level of the evolution
@@ -169,6 +171,8 @@ int AKAZEFeatures::Create_Nonlinear_Scale_Space(const Mat& img)
  */
 void AKAZEFeatures::Feature_Detection(std::vector<KeyPoint>& kpts)
 {
+  CV_INSTRUMENT_REGION()
+
   kpts.clear();
   Compute_Determinant_Hessian_Response();
   Find_Scale_Space_Extrema(kpts);
@@ -229,6 +233,7 @@ void AKAZEFeatures::Compute_Multiscale_Derivatives(void)
  * @note We use the Hessian determinant as the feature detector response
  */
 void AKAZEFeatures::Compute_Determinant_Hessian_Response(void) {
+  CV_INSTRUMENT_REGION()
 
   // Firstly compute the multiscale derivatives
   Compute_Multiscale_Derivatives();
@@ -255,6 +260,7 @@ void AKAZEFeatures::Compute_Determinant_Hessian_Response(void) {
  */
 void AKAZEFeatures::Find_Scale_Space_Extrema(std::vector<KeyPoint>& kpts)
 {
+  CV_INSTRUMENT_REGION()
 
   float value = 0.0;
   float dist = 0.0, ratio = 0.0, smax = 0.0;
@@ -394,6 +400,8 @@ void AKAZEFeatures::Find_Scale_Space_Extrema(std::vector<KeyPoint>& kpts)
  */
 void AKAZEFeatures::Do_Subpixel_Refinement(std::vector<KeyPoint>& kpts)
 {
+  CV_INSTRUMENT_REGION()
+
   float Dx = 0.0, Dy = 0.0, ratio = 0.0;
   float Dxx = 0.0, Dyy = 0.0, Dxy = 0.0;
   int x = 0, y = 0;
@@ -705,6 +713,8 @@ private:
  */
 void AKAZEFeatures::Compute_Descriptors(std::vector<KeyPoint>& kpts, Mat& desc)
 {
+  CV_INSTRUMENT_REGION()
+
   for(size_t i = 0; i < kpts.size(); i++)
   {
       CV_Assert(0 <= kpts[i].class_id && kpts[i].class_id < static_cast<int>(evolution_.size()));
@@ -849,6 +859,8 @@ void AKAZEFeatures::Compute_Main_Orientation(KeyPoint& kpt, const std::vector<TE
  */
 void AKAZEFeatures::Compute_Keypoints_Orientation(std::vector<KeyPoint>& kpts) const
 {
+  CV_INSTRUMENT_REGION()
+
      for(size_t i = 0; i < kpts.size(); i++)
          Compute_Main_Orientation(kpts[i], evolution_);
 }

--- a/modules/features2d/src/kaze/AKAZEFeatures.cpp
+++ b/modules/features2d/src/kaze/AKAZEFeatures.cpp
@@ -580,7 +580,7 @@ public:
       e.Lsmooth.release();
 
       // compute determinant scaled by sigma
-      const int sigma_size_quat = e.sigma_size * e.sigma_size * e.sigma_size * e.sigma_size;
+      float sigma_size_quat = (float)(e.sigma_size * e.sigma_size * e.sigma_size * e.sigma_size);
       compute_determinant(Lxx, Lxy, Lyy, e.Ldet, sigma_size_quat);
     }
   }

--- a/modules/features2d/src/kaze/AKAZEFeatures.cpp
+++ b/modules/features2d/src/kaze/AKAZEFeatures.cpp
@@ -138,7 +138,11 @@ nld_step_scalar_one_lane(const Mat& Lt, const Mat& Lf, Mat& Lstep, float step_si
     lf_c = Lf.ptr<float>(0) + 1;
     lt_b = Lt.ptr<float>(1) + 1;
     lf_b = Lf.ptr<float>(1) + 1;
-    dst = Lstep.ptr<float>(0) + 1;
+
+    // fill the corner to prevent uninitialized values
+    dst = Lstep.ptr<float>(0);
+    dst[0] = 0.0f;
+    ++dst;
 
     for (int j = 0; j < cols; j++) {
       step_r = (lf_c[j] + lf_c[j + 1])*(lt_c[j + 1] - lt_c[j]) +
@@ -146,6 +150,9 @@ nld_step_scalar_one_lane(const Mat& Lt, const Mat& Lf, Mat& Lstep, float step_si
                (lf_c[j] + lf_b[j    ])*(lt_b[j    ] - lt_c[j]);
       dst[j] = step_r * step_size;
     }
+
+    // fill the corner to prevent uninitialized values
+    dst[cols] = 0.0f;
     ++row;
   }
 
@@ -194,7 +201,11 @@ nld_step_scalar_one_lane(const Mat& Lt, const Mat& Lf, Mat& Lstep, float step_si
     lf_a = Lf.ptr<float>(row - 1) + 1;
     lt_c = Lt.ptr<float>(row    ) + 1;
     lf_c = Lf.ptr<float>(row    ) + 1;
-    dst = Lstep.ptr<float>(row) +1;
+
+    // fill the corner to prevent uninitialized values
+    dst = Lstep.ptr<float>(row);
+    dst[0] = 0.0f;
+    ++dst;
 
     for (int j = 0; j < cols; j++) {
       step_r = (lf_c[j] + lf_c[j + 1])*(lt_c[j + 1] - lt_c[j]) +
@@ -202,6 +213,9 @@ nld_step_scalar_one_lane(const Mat& Lt, const Mat& Lf, Mat& Lstep, float step_si
                (lf_c[j] + lf_a[j    ])*(lt_a[j    ] - lt_c[j]);
       dst[j] = step_r * step_size;
     }
+
+    // fill the corner to prevent uninitialized values
+    dst[cols] = 0.0f;
   }
 }
 
@@ -1088,6 +1102,9 @@ void Sample_Derivative_Response_Radius6(const Mat &Lx, const Mat &Ly,
 
     resX[i] = g.weight[i] * lx[j];
     resY[i] = g.weight[i] * ly[j];
+
+    CV_DbgAssert(isfinite(resX[i]));
+    CV_DbgAssert(isfinite(resY[i]));
   }
 }
 

--- a/modules/features2d/src/kaze/AKAZEFeatures.cpp
+++ b/modules/features2d/src/kaze/AKAZEFeatures.cpp
@@ -294,6 +294,8 @@ int AKAZEFeatures::Create_Nonlinear_Scale_Space(const Mat& img)
     }
   }
 
+  Compute_Determinant_Hessian_Response();
+
   return 0;
 }
 
@@ -307,7 +309,6 @@ void AKAZEFeatures::Feature_Detection(std::vector<KeyPoint>& kpts)
   CV_INSTRUMENT_REGION()
 
   kpts.clear();
-  Compute_Determinant_Hessian_Response();
   Find_Scale_Space_Extrema(kpts);
   Do_Subpixel_Refinement(kpts);
 }

--- a/modules/features2d/src/kaze/AKAZEFeatures.cpp
+++ b/modules/features2d/src/kaze/AKAZEFeatures.cpp
@@ -262,6 +262,8 @@ ocl_non_linear_diffusion_step(const UMat& Lt, const UMat& Lf, UMat& Lstep, float
 static inline void
 non_linear_diffusion_step(const UMat& Lt, const UMat& Lf, UMat& Lstep, float step_size)
 {
+  CV_INSTRUMENT_REGION()
+
   Lstep.create(Lt.size(), Lt.type());
 
   CV_OCL_RUN(true, ocl_non_linear_diffusion_step(Lt, Lf, Lstep, step_size));

--- a/modules/features2d/src/kaze/AKAZEFeatures.h
+++ b/modules/features2d/src/kaze/AKAZEFeatures.h
@@ -47,7 +47,6 @@ public:
   int Create_Nonlinear_Scale_Space(const cv::Mat& img);
   void Feature_Detection(std::vector<cv::KeyPoint>& kpts);
   void Compute_Determinant_Hessian_Response(void);
-  void Compute_Multiscale_Derivatives(void);
   void Find_Scale_Space_Extrema(std::vector<cv::KeyPoint>& kpts);
   void Do_Subpixel_Refinement(std::vector<cv::KeyPoint>& kpts);
 

--- a/modules/features2d/src/kaze/AKAZEFeatures.h
+++ b/modules/features2d/src/kaze/AKAZEFeatures.h
@@ -52,7 +52,6 @@ public:
 
   /// Feature description methods
   void Compute_Descriptors(std::vector<cv::KeyPoint>& kpts, cv::Mat& desc);
-  static void Compute_Main_Orientation(cv::KeyPoint& kpt, const std::vector<TEvolution>& evolution_);
   void Compute_Keypoints_Orientation(std::vector<cv::KeyPoint>& kpts) const;
 };
 

--- a/modules/features2d/src/kaze/AKAZEFeatures.h
+++ b/modules/features2d/src/kaze/AKAZEFeatures.h
@@ -12,10 +12,34 @@
 /* ************************************************************************* */
 // Includes
 #include "AKAZEConfig.h"
-#include "TEvolution.h"
 
 namespace cv
 {
+
+/// A-KAZE nonlinear diffusion filtering evolution
+struct Evolution
+{
+  Evolution() {
+    etime = 0.0f;
+    esigma = 0.0f;
+    octave = 0;
+    sublevel = 0;
+    sigma_size = 0;
+  }
+
+  Mat Lx, Ly;           ///< First order spatial derivatives
+  Mat Lt;               ///< Evolution image
+  Mat Lsmooth;          ///< Smoothed image
+  Mat Ldet;             ///< Detector response
+
+  Size size;                ///< Size of the layer
+  float etime;              ///< Evolution time
+  float esigma;             ///< Evolution sigma. For linear diffusion t = sigma^2 / 2
+  int octave;               ///< Image octave
+  int sublevel;             ///< Image sublevel in each octave
+  int sigma_size;           ///< Integer esigma. For computing the feature detector responses
+  float octave_ratio;       ///< Scaling ratio of this octave. ratio = 2^octave
+};
 
 /* ************************************************************************* */
 // AKAZE Class Declaration
@@ -24,7 +48,7 @@ class AKAZEFeatures {
 private:
 
   AKAZEOptions options_;                ///< Configuration options for AKAZE
-  std::vector<TEvolution> evolution_;        ///< Vector of nonlinear diffusion evolution
+  std::vector<Evolution> evolution_;        ///< Vector of nonlinear diffusion evolution
 
   /// FED parameters
   int ncycles_;                  ///< Number of cycles
@@ -44,14 +68,14 @@ public:
 
   /// Scale Space methods
   void Allocate_Memory_Evolution();
-  int Create_Nonlinear_Scale_Space(const cv::Mat& img);
+  void Create_Nonlinear_Scale_Space(InputArray img);
   void Feature_Detection(std::vector<cv::KeyPoint>& kpts);
   void Compute_Determinant_Hessian_Response(void);
   void Find_Scale_Space_Extrema(std::vector<cv::KeyPoint>& kpts);
   void Do_Subpixel_Refinement(std::vector<cv::KeyPoint>& kpts);
 
   /// Feature description methods
-  void Compute_Descriptors(std::vector<cv::KeyPoint>& kpts, cv::Mat& desc);
+  void Compute_Descriptors(std::vector<cv::KeyPoint>& kpts, OutputArray desc);
   void Compute_Keypoints_Orientation(std::vector<cv::KeyPoint>& kpts) const;
 };
 

--- a/modules/features2d/src/kaze/AKAZEFeatures.h
+++ b/modules/features2d/src/kaze/AKAZEFeatures.h
@@ -27,7 +27,7 @@ struct Evolution
     sigma_size = 0;
   }
 
-  Mat Lx, Ly;           ///< First order spatial derivatives
+  UMat Lx, Ly;           ///< First order spatial derivatives
   Mat Lt;               ///< Evolution image
   UMat Lsmooth;          ///< Smoothed image
   Mat Ldet;             ///< Detector response

--- a/modules/features2d/src/kaze/AKAZEFeatures.h
+++ b/modules/features2d/src/kaze/AKAZEFeatures.h
@@ -29,7 +29,7 @@ struct Evolution
 
   Mat Lx, Ly;           ///< First order spatial derivatives
   Mat Lt;               ///< Evolution image
-  Mat Lsmooth;          ///< Smoothed image
+  UMat Lsmooth;          ///< Smoothed image
   Mat Ldet;             ///< Detector response
 
   Size size;                ///< Size of the layer

--- a/modules/features2d/src/kaze/AKAZEFeatures.h
+++ b/modules/features2d/src/kaze/AKAZEFeatures.h
@@ -28,12 +28,13 @@ struct Evolution
   }
 
   UMat Lx, Ly;           ///< First order spatial derivatives
-  Mat Lt;               ///< Evolution image
-  UMat Lsmooth;          ///< Smoothed image
+  UMat Lt;               ///< Evolution image
+  UMat Lsmooth;          ///< Smoothed image, used only for computing determinant, released afterwards
   Mat Ldet;             ///< Detector response
 
   // the same as above, holding CPU mapping to UMats above
   Mat Mx, My;
+  Mat Mt;
 
   Size size;                ///< Size of the layer
   float etime;              ///< Evolution time

--- a/modules/features2d/src/kaze/AKAZEFeatures.h
+++ b/modules/features2d/src/kaze/AKAZEFeatures.h
@@ -32,6 +32,9 @@ struct Evolution
   UMat Lsmooth;          ///< Smoothed image
   Mat Ldet;             ///< Detector response
 
+  // the same as above, holding CPU mapping to UMats above
+  Mat Mx, My;
+
   Size size;                ///< Size of the layer
   float etime;              ///< Evolution time
   float esigma;             ///< Evolution sigma. For linear diffusion t = sigma^2 / 2

--- a/modules/features2d/src/kaze/AKAZEFeatures.h
+++ b/modules/features2d/src/kaze/AKAZEFeatures.h
@@ -30,11 +30,12 @@ struct Evolution
   UMat Lx, Ly;           ///< First order spatial derivatives
   UMat Lt;               ///< Evolution image
   UMat Lsmooth;          ///< Smoothed image, used only for computing determinant, released afterwards
-  Mat Ldet;             ///< Detector response
+  UMat Ldet;             ///< Detector response
 
   // the same as above, holding CPU mapping to UMats above
   Mat Mx, My;
   Mat Mt;
+  Mat Mdet;
 
   Size size;                ///< Size of the layer
   float etime;              ///< Evolution time

--- a/modules/features2d/src/kaze/TEvolution.h
+++ b/modules/features2d/src/kaze/TEvolution.h
@@ -35,6 +35,7 @@ struct TEvolution
   int octave;               ///< Image octave
   int sublevel;             ///< Image sublevel in each octave
   int sigma_size;           ///< Integer esigma. For computing the feature detector responses
+  float octave_ratio;       ///< Scaling ratio of this octave. ratio = 2^octave
 };
 
 }

--- a/modules/features2d/src/kaze/TEvolution.h
+++ b/modules/features2d/src/kaze/TEvolution.h
@@ -29,13 +29,11 @@ struct TEvolution
   Mat Lsmooth;          ///< Smoothed image
   Mat Ldet;             ///< Detector response
 
-  Size size;                ///< Size of the layer
   float etime;              ///< Evolution time
   float esigma;             ///< Evolution sigma. For linear diffusion t = sigma^2 / 2
   int octave;               ///< Image octave
   int sublevel;             ///< Image sublevel in each octave
   int sigma_size;           ///< Integer esigma. For computing the feature detector responses
-  float octave_ratio;       ///< Scaling ratio of this octave. ratio = 2^octave
 };
 
 }

--- a/modules/features2d/src/kaze/TEvolution.h
+++ b/modules/features2d/src/kaze/TEvolution.h
@@ -28,6 +28,8 @@ struct TEvolution
   Mat Lt;               ///< Evolution image
   Mat Lsmooth;          ///< Smoothed image
   Mat Ldet;             ///< Detector response
+  Mat Lflow;
+  Mat Lstep;
   float etime;              ///< Evolution time
   float esigma;             ///< Evolution sigma. For linear diffusion t = sigma^2 / 2
   int octave;               ///< Image octave

--- a/modules/features2d/src/kaze/TEvolution.h
+++ b/modules/features2d/src/kaze/TEvolution.h
@@ -28,8 +28,8 @@ struct TEvolution
   Mat Lt;               ///< Evolution image
   Mat Lsmooth;          ///< Smoothed image
   Mat Ldet;             ///< Detector response
-  Mat Lflow;
-  Mat Lstep;
+
+  Size size;                ///< Size of the layer
   float etime;              ///< Evolution time
   float esigma;             ///< Evolution sigma. For linear diffusion t = sigma^2 / 2
   int octave;               ///< Image octave

--- a/modules/features2d/src/kaze/nldiffusion_functions.cpp
+++ b/modules/features2d/src/kaze/nldiffusion_functions.cpp
@@ -91,7 +91,11 @@ void image_derivatives_scharr(const cv::Mat& src, cv::Mat& dst, int xorder, int 
  * @param dst Output image
  * @param k Contrast factor parameter
  */
-void pm_g1(const cv::Mat& Lx, const cv::Mat& Ly, cv::Mat& dst, float k) {
+void pm_g1(InputArray _Lx, InputArray _Ly, OutputArray _dst, float k) {
+  _dst.create(_Lx.size(), _Lx.type());
+  Mat Lx = _Lx.getMat();
+  Mat Ly = _Ly.getMat();
+  Mat dst = _dst.getMat();
 
   Size sz = Lx.size();
   float inv_k = 1.0f / (k*k);
@@ -118,8 +122,13 @@ void pm_g1(const cv::Mat& Lx, const cv::Mat& Ly, cv::Mat& dst, float k) {
  * @param dst Output image
  * @param k Contrast factor parameter
  */
-void pm_g2(const cv::Mat &Lx, const cv::Mat& Ly, cv::Mat& dst, float k) {
+void pm_g2(InputArray _Lx, InputArray _Ly, OutputArray _dst, float k) {
     CV_INSTRUMENT_REGION()
+
+    _dst.create(_Lx.size(), _Lx.type());
+    Mat Lx = _Lx.getMat();
+    Mat Ly = _Ly.getMat();
+    Mat dst = _dst.getMat();
 
     Size sz = Lx.size();
     dst.create(sz, Lx.type());
@@ -145,7 +154,11 @@ void pm_g2(const cv::Mat &Lx, const cv::Mat& Ly, cv::Mat& dst, float k) {
  * Applications of nonlinear diffusion in image processing and computer vision,
  * Proceedings of Algorithmy 2000
  */
-void weickert_diffusivity(const cv::Mat& Lx, const cv::Mat& Ly, cv::Mat& dst, float k) {
+void weickert_diffusivity(InputArray _Lx, InputArray _Ly, OutputArray _dst, float k) {
+  _dst.create(_Lx.size(), _Lx.type());
+  Mat Lx = _Lx.getMat();
+  Mat Ly = _Ly.getMat();
+  Mat dst = _dst.getMat();
 
   Size sz = Lx.size();
   float inv_k = 1.0f / (k*k);
@@ -178,7 +191,11 @@ void weickert_diffusivity(const cv::Mat& Lx, const cv::Mat& Ly, cv::Mat& dst, fl
 * Applications of nonlinear diffusion in image processing and computer vision,
 * Proceedings of Algorithmy 2000
 */
-void charbonnier_diffusivity(const cv::Mat& Lx, const cv::Mat& Ly, cv::Mat& dst, float k) {
+void charbonnier_diffusivity(InputArray _Lx, InputArray _Ly, OutputArray _dst, float k) {
+  _dst.create(_Lx.size(), _Lx.type());
+  Mat Lx = _Lx.getMat();
+  Mat Ly = _Ly.getMat();
+  Mat dst = _dst.getMat();
 
   Size sz = Lx.size();
   float inv_k = 1.0f / (k*k);

--- a/modules/features2d/src/kaze/nldiffusion_functions.cpp
+++ b/modules/features2d/src/kaze/nldiffusion_functions.cpp
@@ -323,6 +323,7 @@ void compute_derivative_kernels(cv::OutputArray _kx, cv::OutputArray _ky, int dx
     _ky.create(ksize, 1, CV_32F, -1, true);
     Mat kx = _kx.getMat();
     Mat ky = _ky.getMat();
+    std::vector<float> kerI;
 
     float w = 10.0f / 3.0f;
     float norm = 1.0f / (2.0f*scale*(w + 2.0f));
@@ -330,7 +331,7 @@ void compute_derivative_kernels(cv::OutputArray _kx, cv::OutputArray _ky, int dx
     for (int k = 0; k < 2; k++) {
         Mat* kernel = k == 0 ? &kx : &ky;
         int order = k == 0 ? dx : dy;
-        std::vector<float> kerI(ksize, 0.0f);
+        kerI.assign(ksize, 0.0f);
 
         if (order == 0) {
             kerI[0] = norm, kerI[ksize / 2] = w*norm, kerI[ksize - 1] = norm;

--- a/modules/features2d/src/kaze/nldiffusion_functions.cpp
+++ b/modules/features2d/src/kaze/nldiffusion_functions.cpp
@@ -119,6 +119,7 @@ void pm_g1(const cv::Mat& Lx, const cv::Mat& Ly, cv::Mat& dst, float k) {
  * @param k Contrast factor parameter
  */
 void pm_g2(const cv::Mat &Lx, const cv::Mat& Ly, cv::Mat& dst, float k) {
+    CV_INSTRUMENT_REGION()
 
     Size sz = Lx.size();
     dst.create(sz, Lx.type());
@@ -209,6 +210,7 @@ void charbonnier_diffusivity(const cv::Mat& Lx, const cv::Mat& Ly, cv::Mat& dst,
  * @return k contrast factor
  */
 float compute_k_percentile(const cv::Mat& img, float perc, float gscale, int nbins, int ksize_x, int ksize_y) {
+    CV_INSTRUMENT_REGION()
 
     int nbin = 0, nelements = 0, nthreshold = 0, k = 0;
     float kperc = 0.0, modg = 0.0;
@@ -307,6 +309,7 @@ void compute_scharr_derivatives(const cv::Mat& src, cv::Mat& dst, int xorder, in
  * @param scale_ Scale factor or derivative size
  */
 void compute_derivative_kernels(cv::OutputArray _kx, cv::OutputArray _ky, int dx, int dy, int scale) {
+    CV_INSTRUMENT_REGION()
 
     int ksize = 3 + 2 * (scale - 1);
 
@@ -403,6 +406,7 @@ private:
 * dL_by_ds = d(c dL_by_dx)_by_dx + d(c dL_by_dy)_by_dy
 */
 void nld_step_scalar(cv::Mat& Ld, const cv::Mat& c, cv::Mat& Lstep, float stepsize) {
+    CV_INSTRUMENT_REGION()
 
     cv::parallel_for_(cv::Range(1, Lstep.rows - 1), Nld_Step_Scalar_Invoker(Ld, c, Lstep, stepsize), (double)Ld.total()/(1 << 16));
 
@@ -472,7 +476,6 @@ void nld_step_scalar(cv::Mat& Ld, const cv::Mat& c, cv::Mat& Lstep, float stepsi
 * @param dst Output image with half of the resolution of the input image
 */
 void halfsample_image(const cv::Mat& src, cv::Mat& dst) {
-
     // Make sure the destination image is of the right size
     CV_Assert(src.cols / 2 == dst.cols);
     CV_Assert(src.rows / 2 == dst.rows);

--- a/modules/features2d/src/kaze/nldiffusion_functions.h
+++ b/modules/features2d/src/kaze/nldiffusion_functions.h
@@ -21,10 +21,10 @@ namespace cv
 void gaussian_2D_convolution(const cv::Mat& src, cv::Mat& dst, int ksize_x, int ksize_y, float sigma);
 
 // Diffusivity functions
-void pm_g1(const cv::Mat& Lx, const cv::Mat& Ly, cv::Mat& dst, float k);
-void pm_g2(const cv::Mat& Lx, const cv::Mat& Ly, cv::Mat& dst, float k);
-void weickert_diffusivity(const cv::Mat& Lx, const cv::Mat& Ly, cv::Mat& dst, float k);
-void charbonnier_diffusivity(const cv::Mat& Lx, const cv::Mat& Ly, cv::Mat& dst, float k);
+void pm_g1(InputArray Lx, InputArray Ly, OutputArray dst, float k);
+void pm_g2(InputArray Lx, InputArray Ly, OutputArray dst, float k);
+void weickert_diffusivity(InputArray Lx, InputArray Ly, OutputArray dst, float k);
+void charbonnier_diffusivity(InputArray Lx, InputArray Ly, OutputArray dst, float k);
 
 float compute_k_percentile(const cv::Mat& img, float perc, float gscale, int nbins, int ksize_x, int ksize_y);
 

--- a/modules/features2d/src/keypoint.cpp
+++ b/modules/features2d/src/keypoint.cpp
@@ -156,6 +156,8 @@ private:
 
 void KeyPointsFilter::runByPixelsMask( std::vector<KeyPoint>& keypoints, const Mat& mask )
 {
+    CV_INSTRUMENT_REGION()
+
     if( mask.empty() )
         return;
 

--- a/modules/features2d/src/opencl/akaze.cl
+++ b/modules/features2d/src/opencl/akaze.cl
@@ -18,3 +18,66 @@ AKAZE_pm_g2(__global const float* lx, __global const float* ly, __global float* 
     int i = get_global_id(0);
     dst[i] = 1.0f / (1.0f + ((lx[i] * lx[i] + ly[i] * ly[i]) * k2inv));
 }
+
+__kernel void
+AKAZE_nld_step_scalar(__global const float* lt, int lt_step, int lt_offset,
+    __global const float* lf, __global float* dst, float step_size)
+{
+    /* The labeling scheme for this five star stencil:
+        [    a    ]
+        [ -1 c +1 ]
+        [    b    ]
+    */
+    int i = get_global_id(0);
+    int j = get_global_id(1);
+    size_t rows = get_global_size(0);
+    size_t cols = get_global_size(1);
+
+    // get row indexes
+    int a = (i - 1) * lt_step;
+    int c = (i    ) * lt_step;
+    int b = (i + 1) * lt_step;
+    int dst_idx = c;
+    // compute stencil
+    float res = 0.0f;
+    if (i == 0) // first rows
+    {
+        if (j == 0 || j == (cols - 1))
+        {
+            return; // we do not compute these
+        }
+        res = (lf[c + j] + lf[c + j + 1])*(lt[c + j + 1] - lt[c + j]) +
+              (lf[c + j] + lf[c + j - 1])*(lt[c + j - 1] - lt[c + j]) +
+              (lf[c + j] + lf[b + j    ])*(lt[b + j    ] - lt[c + j]);
+    } else if (i == (rows - 1)) // last row
+    {
+        if (j == 0 || j == (cols - 1))
+        {
+            return; // we do not compute these
+        }
+        res = (lf[c + j] + lf[c + j + 1])*(lt[c + j + 1] - lt[c + j]) +
+              (lf[c + j] + lf[c + j - 1])*(lt[c + j - 1] - lt[c + j]) +
+              (lf[c + j] + lf[a + j    ])*(lt[a + j    ] - lt[c + j]);
+    } else // inner rows
+    {
+        if (j == 0) // first column
+        {
+            res = (lf[c + 0] + lf[c + 1])*(lt[c + 1] - lt[c + 0]) +
+                  (lf[c + 0] + lf[b + 0])*(lt[b + 0] - lt[c + 0]) +
+                  (lf[c + 0] + lf[a + 0])*(lt[a + 0] - lt[c + 0]);
+        } else if (j == (cols - 1)) // last column
+        {
+            res = (lf[c + j] + lf[c + j - 1])*(lt[c + j - 1] - lt[c + j]) +
+                  (lf[c + j] + lf[b + j    ])*(lt[b + j    ] - lt[c + j]) +
+                  (lf[c + j] + lf[a + j    ])*(lt[a + j    ] - lt[c + j]);
+        } else
+        {
+            res = (lf[c + j] + lf[c + j + 1])*(lt[c + j + 1] - lt[c + j]) +
+                  (lf[c + j] + lf[c + j - 1])*(lt[c + j - 1] - lt[c + j]) +
+                  (lf[c + j] + lf[b + j    ])*(lt[b + j    ] - lt[c + j]) +
+                  (lf[c + j] + lf[a + j    ])*(lt[a + j    ] - lt[c + j]);
+        }
+    }
+
+    dst[dst_idx] = res * step_size;
+}

--- a/modules/features2d/src/opencl/akaze.cl
+++ b/modules/features2d/src/opencl/akaze.cl
@@ -44,20 +44,24 @@ AKAZE_nld_step_scalar(__global const float* lt, int lt_step, int lt_offset,
     {
         if (j == 0 || j == (cols - 1))
         {
-            return; // we do not compute these
+            res = 0.0f;
+        } else
+        {
+            res = (lf[c + j] + lf[c + j + 1])*(lt[c + j + 1] - lt[c + j]) +
+                  (lf[c + j] + lf[c + j - 1])*(lt[c + j - 1] - lt[c + j]) +
+                  (lf[c + j] + lf[b + j    ])*(lt[b + j    ] - lt[c + j]);
         }
-        res = (lf[c + j] + lf[c + j + 1])*(lt[c + j + 1] - lt[c + j]) +
-              (lf[c + j] + lf[c + j - 1])*(lt[c + j - 1] - lt[c + j]) +
-              (lf[c + j] + lf[b + j    ])*(lt[b + j    ] - lt[c + j]);
     } else if (i == (rows - 1)) // last row
     {
         if (j == 0 || j == (cols - 1))
         {
-            return; // we do not compute these
+            res = 0.0f;
+        } else
+        {
+            res = (lf[c + j] + lf[c + j + 1])*(lt[c + j + 1] - lt[c + j]) +
+                  (lf[c + j] + lf[c + j - 1])*(lt[c + j - 1] - lt[c + j]) +
+                  (lf[c + j] + lf[a + j    ])*(lt[a + j    ] - lt[c + j]);
         }
-        res = (lf[c + j] + lf[c + j + 1])*(lt[c + j + 1] - lt[c + j]) +
-              (lf[c + j] + lf[c + j - 1])*(lt[c + j - 1] - lt[c + j]) +
-              (lf[c + j] + lf[a + j    ])*(lt[a + j    ] - lt[c + j]);
     } else // inner rows
     {
         if (j == 0) // first column
@@ -70,7 +74,7 @@ AKAZE_nld_step_scalar(__global const float* lt, int lt_step, int lt_offset,
             res = (lf[c + j] + lf[c + j - 1])*(lt[c + j - 1] - lt[c + j]) +
                   (lf[c + j] + lf[b + j    ])*(lt[b + j    ] - lt[c + j]) +
                   (lf[c + j] + lf[a + j    ])*(lt[a + j    ] - lt[c + j]);
-        } else
+        } else // inner stencil
         {
             res = (lf[c + j] + lf[c + j + 1])*(lt[c + j + 1] - lt[c + j]) +
                   (lf[c + j] + lf[c + j - 1])*(lt[c + j - 1] - lt[c + j]) +

--- a/modules/features2d/src/opencl/akaze.cl
+++ b/modules/features2d/src/opencl/akaze.cl
@@ -96,3 +96,27 @@ AKAZE_nld_step_scalar(__global const float* lt, int lt_step, int lt_offset, int 
 
     dst[c + j] = res * step_size;
 }
+
+/**
+ * @brief Compute determinant from hessians
+ * @details Compute Ldet by (Lxx.mul(Lyy) - Lxy.mul(Lxy)) * sigma
+ *
+ * @param lxx spatial derivates
+ * @param lxy spatial derivates
+ * @param lyy spatial derivates
+ * @param dst output determinant
+ * @param sigma determinant will be scaled by this sigma
+ */
+__kernel void
+AKAZE_compute_determinant(__global const float* lxx, __global const float* lxy, __global const float* lyy,
+    __global float* dst, float sigma, int size)
+{
+    int i = get_global_id(0);
+    // OpenCV plays with dimensions so we need explicit check for this
+    if (!(i < size))
+    {
+        return;
+    }
+
+    dst[i] = (lxx[i] * lyy[i] - lxy[i] * lxy[i]) * sigma;
+}

--- a/modules/features2d/src/opencl/akaze.cl
+++ b/modules/features2d/src/opencl/akaze.cl
@@ -1,0 +1,20 @@
+// This file is part of OpenCV project.
+// It is subject to the license terms in the LICENSE file found in the top-level directory
+// of this distribution and at http://opencv.org/license.html
+
+
+/**
+ * @brief This function computes the Perona and Malik conductivity coefficient g2
+ * g2 = 1 / (1 + dL^2 / k^2)
+ * @param Lx First order image derivative in X-direction (horizontal)
+ * @param Ly First order image derivative in Y-direction (vertical)
+ * @param dst Output image
+ * @param k Contrast factor parameter
+ */
+__kernel void
+AKAZE_pm_g2(__global const float* lx, __global const float* ly, __global float* dst, float k)
+{
+    const float k2inv = 1.0f / (k * k);
+    int i = get_global_id(0);
+    dst[i] = 1.0f / (1.0f + ((lx[i] * lx[i] + ly[i] * ly[i]) * k2inv));
+}

--- a/modules/features2d/test/test_akaze.cpp
+++ b/modules/features2d/test/test_akaze.cpp
@@ -1,0 +1,47 @@
+// This file is part of OpenCV project.
+// It is subject to the license terms in the LICENSE file found in the top-level directory
+// of this distribution and at http://opencv.org/license.html
+
+#include "test_precomp.hpp"
+
+using namespace std;
+using namespace cv;
+
+TEST(Features2d_AKAZE, detect_and_compute_split)
+{
+    Mat testImg(100, 100, CV_8U);
+    RNG rng(101);
+    rng.fill(testImg, RNG::UNIFORM, Scalar(0), Scalar(255), true);
+
+    Ptr<Feature2D> ext = AKAZE::create(AKAZE::DESCRIPTOR_MLDB, 0, 3, 0.001f, 1, 1, KAZE::DIFF_PM_G2);
+    vector<KeyPoint> detAndCompKps;
+    Mat desc;
+    ext->detectAndCompute(testImg, noArray(), detAndCompKps, desc);
+
+    vector<KeyPoint> detKps;
+    ext->detect(testImg, detKps);
+
+    ASSERT_EQ(detKps.size(), detAndCompKps.size());
+
+    for(size_t i = 0; i < detKps.size(); i++)
+        ASSERT_EQ(detKps[i].hash(), detAndCompKps[i].hash());
+}
+
+/**
+ * This test is here to guard propagation of NaNs that happens on this image. NaNs are guarded
+ * by debug asserts in AKAZE, which should fire for you if you are lucky.
+ *
+ * This test also reveals problems with uninitialized memory that happens only on this image.
+ * This is very hard to hit and depends a lot on particular allocator. Run this test in valgrind and check
+ * for uninitialized values if you think you are hitting this problem again.
+ */
+TEST(Features2d_AKAZE, uninitialized_and_nans)
+{
+    Mat b1 = imread(cvtest::TS::ptr()->get_data_path() + "../stitching/b1.png");
+    ASSERT_FALSE(b1.empty());
+
+    vector<KeyPoint> keypoints;
+    Mat desc;
+    Ptr<Feature2D> akaze = AKAZE::create();
+    akaze->detectAndCompute(b1, noArray(), keypoints, desc);
+}

--- a/modules/features2d/test/test_descriptors_invariance.cpp
+++ b/modules/features2d/test/test_descriptors_invariance.cpp
@@ -179,7 +179,7 @@ INSTANTIATE_TEST_CASE_P(AKAZE, DescriptorRotationInvariance,
                         Value(IMAGE_TSUKUBA, AKAZE::create(), AKAZE::create(), 0.99f));
 
 INSTANTIATE_TEST_CASE_P(AKAZE_DESCRIPTOR_KAZE, DescriptorRotationInvariance,
-                        Value(IMAGE_TSUKUBA, AKAZE::create(AKAZE::DESCRIPTOR_KAZE), AKAZE::create(AKAZE::DESCRIPTOR_KAZE), 0.002f));
+                        Value(IMAGE_TSUKUBA, AKAZE::create(AKAZE::DESCRIPTOR_KAZE), AKAZE::create(AKAZE::DESCRIPTOR_KAZE), 0.99f));
 
 /*
  * Descriptor's scale invariance check
@@ -189,4 +189,4 @@ INSTANTIATE_TEST_CASE_P(AKAZE, DescriptorScaleInvariance,
                         Value(IMAGE_BIKES, AKAZE::create(), AKAZE::create(), 0.6f));
 
 INSTANTIATE_TEST_CASE_P(AKAZE_DESCRIPTOR_KAZE, DescriptorScaleInvariance,
-                        Value(IMAGE_BIKES, AKAZE::create(AKAZE::DESCRIPTOR_KAZE), AKAZE::create(AKAZE::DESCRIPTOR_KAZE), 0.0004f));
+                        Value(IMAGE_BIKES, AKAZE::create(AKAZE::DESCRIPTOR_KAZE), AKAZE::create(AKAZE::DESCRIPTOR_KAZE), 0.55f));

--- a/modules/features2d/test/test_detectors_regression.cpp
+++ b/modules/features2d/test/test_detectors_regression.cpp
@@ -307,24 +307,3 @@ TEST( Features2d_Detector_AKAZE_DESCRIPTOR_KAZE, regression )
     CV_FeatureDetectorTest test( "detector-akaze-with-kaze-desc", AKAZE::create(AKAZE::DESCRIPTOR_KAZE) );
     test.safe_run();
 }
-
-
-TEST( Features2d_Detector_AKAZE, detect_and_compute_split )
-{
-    Mat testImg(100, 100, CV_8U);
-    RNG rng(101);
-    rng.fill(testImg, RNG::UNIFORM, Scalar(0), Scalar(255), true);
-
-    Ptr<Feature2D> ext = AKAZE::create(AKAZE::DESCRIPTOR_MLDB, 0, 3, 0.001f, 1, 1, KAZE::DIFF_PM_G2);
-    vector<KeyPoint> detAndCompKps;
-    Mat desc;
-    ext->detectAndCompute(testImg, noArray(), detAndCompKps, desc);
-
-    vector<KeyPoint> detKps;
-    ext->detect(testImg, detKps);
-
-    ASSERT_EQ(detKps.size(), detAndCompKps.size());
-
-    for(size_t i = 0; i < detKps.size(); i++)
-        ASSERT_EQ(detKps[i].hash(), detAndCompKps[i].hash());
-}

--- a/modules/imgproc/src/smooth.cpp
+++ b/modules/imgproc/src/smooth.cpp
@@ -2386,7 +2386,7 @@ void cv::GaussianBlur( InputArray _src, OutputArray _dst, Size ksize,
     if(sigma1 == 0 && sigma2 == 0 && tegra::useTegra() && tegra::gaussian(src, dst, ksize, borderType))
         return;
 #endif
-    bool useOpenCL = (_dst.isUMat() && _src.dims() <= 2 &&
+    bool useOpenCL = (ocl::useOpenCL() && _dst.isUMat() && _src.dims() <= 2 &&
                ((ksize.width == 3 && ksize.height == 3) ||
                (ksize.width == 5 && ksize.height == 5)) &&
                _src.rows() > ksize.height && _src.cols() > ksize.width);


### PR DESCRIPTION
This part focuses on performance improvements for AKAZE on CPU and implementing basic OCL support.

cc: @bmagyar

OpenCL:
=======

some parts (mainly construction of the pyramid) execute OpenCL paths.

* `Create_Nonlinear_Scale_Space` almost all operatiins are OpenCl enabled
    * GaussianBlur - executes OCL, but less effective path through sepFilter2D
    * Scharr - has ocl
    * resize - has ocl
    * kfactor estimation - needs custom ocl kernel, might reuse some parts for computing histogram
    * diffussion + conductivity - needs custom ocl kernel
    * `Compute_Determinant_Hessian_Response` executes OpenCL general sepFilter2D, computing determinant would need custom kernel, but is not currently blocker
* `Feature_Detection` no OCL
* `Compute_Keypoints_Orientation` no OCL
* `Compute_Descriptors` no OCL


CPU status:
===========

* `Create_Nonlinear_Scale_Space` reworked, some intrinsics might help with diffusion
    * `Compute_Determinant_Hessian_Response` reworked, needs specialized fine tuning for kernels 5x5, 7x7, 9x9
* `Feature_Detection` this will be reworked together with GPU part, we might want the same format of keypoints on GPU and CPU
* `Compute_Keypoints_Orientation` reworked
* `Compute_Descriptors` not a blocker

The main parts (and largest bottlenecks) are:
=============================================

* `Create_Nonlinear_Scale_Space` ~19% ~21ms
    * needs to be reworked
* `Feature_Detection` ~52% ~60ms, of which:
    * `Compute_Determinant_Hessian_Response` 83% (over 43% of the whole algorithm)
        * reworked slightly -> reduced Feature_Detection to ~58ms
    * `Find_Scale_Space_Extrema` 16% (globally just 8%)
        * this might be worth to look into when other parts will be optimized
    * `Do_Subpixel_Refinement` 1%
        * not a bottleneck in the current state
* `Compute_Keypoints_Orientation` ~21% ~24ms
     * reworked completely, replaced by a faster implementation, parallelized -> reduced to 3.69ms
* `Compute_Descriptors` ~4% ~4.8ms
    * not a bottleneck in the current state

Improvement in `Compute_Determinant_Hessian_Response` is of cause not very
satisfying. The main problem there is that AKAZE uses Scharr with non-standard
size kernel (different from 3x3). Implementing Scharr with sepFilter2D is much
slower than specialized `cv::Scharr` we have.

I have tried to replace the `sepFilter2D` implementation with `cv:Scharr`,
just to get the idea of possible speedup. It is in the separate [branch](https://github.com/hrnr/opencv/compare/akaze_part2...hrnr:test_scharr). With
`cv::Scharr` `Compute_Determinant_Hessian_Response` went from ~47ms to ~11ms,
which is quite significant. However it is not possible to replace Scharr just
like, so the tests are failing. I have opened pablofdezalc/akaze#32 to get
some addition info on this.

Performance stats per commit:
=============================

I'm testing all CPU performance on `Intel(R) Core(TM) i7-6700 CPU @ 3.40GHz`.

```

Geometric mean

                                                   Name of Test                                                        perf       perf       perf       perf       perf       perf       perf       perf       perf       perf       perf       perf       perf       perf       perf       perf       perf       perf       perf
                                                                                                                    8200996b1  b12facf48  aa5a72b46  8cc0b286c  1d3f7fe9e  c13351891  76151e566  ea089a8ab  f9c2951fa  ba071d1ad  b12facf48  aa5a72b46  8cc0b286c  1d3f7fe9e  c13351891  76151e566  ea089a8ab  f9c2951fa  ba071d1ad
                                                                                                                                                                                                                                      vs         vs         vs         vs         vs         vs         vs         vs         vs
                                                                                                                                                                                                                                     perf       perf       perf       perf       perf       perf       perf       perf       perf
                                                                                                                                                                                                                                  8200996b1  8200996b1  8200996b1  8200996b1  8200996b1  8200996b1  8200996b1  8200996b1  8200996b1
                                                                                                                                                                                                                                  (x-factor) (x-factor) (x-factor) (x-factor) (x-factor) (x-factor) (x-factor) (x-factor) (x-factor)
detectAndExtract::feature2d::(AKAZE_DEFAULT, "cv/detectors_descriptors_evaluation/images_datasets/leuven/img1.png") 71.572 ms  67.583 ms  44.742 ms  45.349 ms  42.336 ms  40.726 ms  38.732 ms  38.268 ms  43.283 ms  38.549 ms     1.06       1.60       1.58       1.69       1.76       1.85       1.87       1.65       1.86
detectAndExtract::feature2d::(AKAZE_DEFAULT, "stitching/a3.png")                                                    56.269 ms  52.597 ms  34.432 ms  34.941 ms  32.298 ms  31.299 ms  29.619 ms  29.137 ms  31.197 ms  29.492 ms     1.07       1.63       1.61       1.74       1.80       1.90       1.93       1.80       1.91
detectAndExtract::feature2d::(AKAZE_DEFAULT, "stitching/s2.jpg")                                                    273.459 ms 263.874 ms 163.169 ms 168.078 ms 153.912 ms 164.177 ms 147.598 ms 145.255 ms 156.495 ms 150.994 ms    1.04       1.68       1.63       1.78       1.67       1.85       1.88       1.75       1.81

```

If you want to reproduce these results you on your own machine, you might find this [performance evaluation script](https://gist.github.com/hrnr/045b5e8efdfd4713957ce0be2ba2f23a) helpful. It automates running perf tests for this pull request across many revisions, it generates this summary along with xml test outputs and instrumentation output as shown below.

Instrumentation output:
=======================

INITIAL:
--------

```
Time compensation is 0
CTEST_FULL_OUTPUT
OpenCV version: 3.2.0-dev
OpenCV VCS version: 3.2.0-816-g28d66b332
Build type: release
Parallel framework: tbb
CPU features: popcnt mmx sse sse2 sse3 ssse3 sse4.1 sse4.2 avx avx2 fma3 fp16
cl_get_gt_device(): error, unknown device: ffffffff
cl_get_gt_device(): error, unknown device: ffffffff
cl_get_gt_device(): error, unknown device: ffffffff
OpenCL is disabled
Note: Google Test filter = feature2d_detectAndExtract.detectAndExtract/4
[==========] Running 1 test from 1 test case.
[----------] Global test environment set-up.
[----------] 1 test from feature2d_detectAndExtract
[ RUN      ] feature2d_detectAndExtract.detectAndExtract/4
[ PERFSTAT ]    (samples = 13, mean = 114.95, median = 115.11, stddev = 1.16 (1.0%))
[ VALUE    ]    (AKAZE_DEFAULT, "cv/detectors_descriptors_evaluation/images_datasets/leuven/img1.png")
[ TRACE    ]
ROOT
\---detectAndCompute - TC:1 C:13 T:1513.67ms
    |---convertTo - TC:1 C:13 T:2.22ms L:0% G:0%
    |   \---ipp_convertTo<W_IPP> - TC:1 C:13 T:2.18ms L:98% G:0%
    |       \---::ipp::iwiScale<F_IPP> - TC:1 C:13 T:2.17ms L:99% G:0%
    |
    |---zeros - TC:1 C:1664 T:0.75ms L:0% G:0%
    |---operator= - TC:1 C:1664 T:55.10ms L:4% G:4%
    |---Create_Nonlinear_Scale_Space - TC:1 C:13 T:281.87ms L:19% G:19%
    |   |---copyTo - TC:1 C:182 T:17.01ms L:6% G:1%
    |   |   \---ippicviCopy_8u_C1R_L<F_IPP> - TC:1 C:182 T:16.84ms L:99% G:1%
    |   |
    |   |---GaussianBlur - TC:1 C:221 T:50.43ms L:18% G:3%
    |   |   |---ipp_GaussianBlur<W_IPP> - TC:1 C:221 T:27.69ms L:55% G:2%
    |   |   |   |---parallel_for_ - TC:1 C:117 T:25.80ms L:93% G:2%
    |   |   |   |   \---operator() - TC:5 C:2912 T:90.64ms L:351% G:6%
    |   |   |   |       \---operator()<W_IPP> - TC:8 C:2912 T:73.70ms L:81% G:5%
    |   |   |   |           \---::ipp::iwiFilterGaussian<F_IPP> - TC:8 C:2593 T:60.24ms L:82% G:4%
    |   |   |   |               \---::ipp::iwiFilterGaussian - BadExit<MARK_IPP> - TC:8 C:97 T:0.05ms L:0% G:0%
    |   |   |   |
    |   |   |   \---::ipp::iwiFilterGaussian<F_IPP> - TC:1 C:104 T:1.61ms L:6% G:0%
    |   |   |
    |   |   \---sepFilter2D - TC:1 C:13 T:22.39ms L:44% G:1%
    |   |       |---convertTo - TC:1 C:26 T:0.09ms L:0% G:0%
    |   |       |   \---ipp_convertTo<W_IPP> - TC:1 C:26 T:0.06ms L:66% G:0%
    |   |       |       \---::ipp::iwiScale<F_IPP> - TC:1 C:26 T:0.03ms L:60% G:0%
    |   |       |
    |   |       \---apply - TC:1 C:13 T:21.93ms L:98% G:1%
    |   |           |---borderInterpolate - TC:1 C:23608 T:2.98ms L:14% G:0%
    |   |           \---ippiOperator<W_IPP> - TC:1 C:7800 T:8.71ms L:40% G:1%
    |   |               \---ippicviFilterRowBorderPipeline_32f_C1R<F_IPP> - TC:1 C:7800 T:6.43ms L:74% G:0%
    |   |
    |   |---zeros - TC:1 C:143 T:0.09ms L:0% G:0%
    |   |---operator= - TC:1 C:143 T:6.98ms L:2% G:0%
    |   |---Scharr - TC:1 C:416 T:31.74ms L:11% G:2%
    |   |   \---ipp_Deriv<W_IPP> - TC:1 C:416 T:31.45ms L:99% G:2%
    |   |       \---::ipp::iwiFilterScharr<F_IPP> - TC:1 C:416 T:31.04ms L:99% G:2%
    |   |
    |   |---parallel_for_ - TC:1 C:2158 T:72.07ms L:26% G:5%
    |   |   \---operator() - TC:5 C:1612 T:143.77ms L:199% G:9%
    |   |
    |   |---add - TC:1 C:2158 T:29.22ms L:10% G:2%
    |   |   \---ippicviAdd_32f_C1R<F_IPP> - TC:1 C:2158 T:27.56ms L:94% G:2%
    |   |
    |   \---resize - TC:1 C:39 T:2.46ms L:1% G:0%
    |       \---resize - TC:1 C:39 T:2.40ms L:97% G:0%
    |           |---ipp_resize<W_IPP> - TC:1 C:39 T:0.01ms L:1% G:0%
    |           |---parallel_for_ - TC:1 C:26 T:1.56ms L:65% G:0%
    |           |   \---operator() - TC:1 C:26 T:1.49ms L:96% G:0%
    |           |
    |           \---parallel_for_ - TC:1 C:13 T:0.65ms L:27% G:0%
    |
    |---Feature_Detection - TC:1 C:13 T:785.74ms L:52% G:52%
    |   |---Compute_Determinant_Hessian_Response - TC:1 C:13 T:652.72ms L:83% G:43%
    |   |   \---parallel_for_ - TC:1 C:13 T:625.91ms L:96% G:41%
    |   |       \---operator() - TC:1 C:208 T:4019.96ms L:642% G:266%
    |   |           |---copyTo - TC:8 C:2080 T:3.92ms L:0% G:0%
    |   |           |   \---ippicviCopy_8u_C1R_L<F_IPP> - TC:8 C:2080 T:1.48ms L:38% G:0%
    |   |           |
    |   |           |---sepFilter2D - TC:8 C:1040 T:1295.68ms L:32% G:86%
    |   |           |   |---convertTo - TC:8 C:2080 T:6.56ms L:1% G:0%
    |   |           |   |   \---ipp_convertTo<W_IPP> - TC:8 C:2080 T:4.00ms L:61% G:0%
    |   |           |   |       \---::ipp::iwiScale<F_IPP> - TC:8 C:2080 T:1.41ms L:35% G:0%
    |   |           |   |
    |   |           |   \---apply - TC:8 C:1040 T:1287.03ms L:99% G:85%
    |   |           |       |---borderInterpolate - TC:8 C:744900 T:207.46ms L:16% G:14%
    |   |           |       \---ippiOperator<W_IPP> - TC:8 C:219375 T:220.04ms L:17% G:15%
    |   |           |           \---ippicviFilterRowBorderPipeline_32f_C1R<F_IPP> - TC:8 C:219375 T:103.64ms L:47% G:7%
    |   |           |
    |   |           \---convertTo - TC:3 C:1040 T:59.62ms L:1% G:4%
    |   |               \---ipp_convertTo<W_IPP> - TC:3 C:1040 T:56.39ms L:95% G:4%
    |   |                   \---::ipp::iwiScale<F_IPP> - TC:3 C:1040 T:53.24ms L:94% G:4%
    |   |
    |   |---Find_Scale_Space_Extrema - TC:1 C:13 T:122.20ms L:16% G:8%
    |   \---Do_Subpixel_Refinement - TC:1 C:13 T:10.79ms L:1% G:1%
    |       \---solve - TC:1 C:23985 T:5.07ms L:47% G:0%
    |
    |---Compute_Keypoints_Orientation - TC:1 C:13 T:321.29ms L:21% G:21%
    |   \---fastAtan32f - TC:1 C:23946 T:14.92ms L:5% G:1%
    |       \---fastAtan32f - TC:1 C:23946 T:7.91ms L:53% G:1%
    |
    |---Compute_Descriptors - TC:1 C:13 T:63.65ms L:4% G:4%
    |   |---zeros - TC:1 C:13 T:0.01ms L:0% G:0%
    |   |---operator= - TC:1 C:13 T:0.06ms L:0% G:0%
    |   \---parallel_for_ - TC:1 C:13 T:63.48ms L:100% G:4%
    |       \---operator() - TC:8 C:10239 T:149.85ms L:236% G:10%
    |
    \---copyTo - TC:1 C:13 T:0.27ms L:0% G:0%
        \---ippicviCopy_8u_C1R_L<F_IPP> - TC:1 C:13 T:0.24ms L:89% G:0%

IPP weight: 20.2%
OPENCL weight: 0.0%
[/TRACE    ]
[       OK ] feature2d_detectAndExtract.detectAndExtract/4 (1528 ms)
[----------] 1 test from feature2d_detectAndExtract (1528 ms total)

[----------] Global test environment tear-down
[==========] 1 test from 1 test case ran. (1528 ms total)
[  PASSED  ] 1 test.

```

CURRENT (ba071d1ad):
--------------------
```
Time compensation is 0
CTEST_FULL_OUTPUT
OpenCV version: 3.2.0-dev
OpenCV VCS version: 3.2.0-932-g6744b7cc3
Build type: release
Parallel framework: tbb
CPU features: popcnt mmx sse sse2 sse3 ssse3 sse4.1 sse4.2 avx avx2 fma3 fp16
cl_get_gt_device(): error, unknown device: ffffffff
cl_get_gt_device(): error, unknown device: ffffffff
cl_get_gt_device(): error, unknown device: ffffffff
OpenCL is disabled
Note: Google Test filter = feature2d_detectAndExtract.detectAndExtract/6:feature2d_detectAndExtract.detectAndExtract/7:feature2d_detectAndExtract.detectAndExtract/8
[==========] Running 3 tests from 1 test case.
[----------] Global test environment set-up.
[----------] 3 tests from feature2d_detectAndExtract
[ RUN      ] feature2d_detectAndExtract.detectAndExtract/6
[ PERFSTAT ]    (samples = 10, mean = 76.67, median = 76.70, stddev = 1.14 (1.5%))
[ VALUE    ]    (AKAZE_DEFAULT, "cv/detectors_descriptors_evaluation/images_datasets/leuven/img1.png")
[ TRACE    ]
ROOT
\---detectAndCompute - TC:1 C:10 T:766.70ms
    |---convertTo - TC:1 C:10 T:1.90ms L:0% G:0%
    |   \---ipp_convertTo<W_IPP> - TC:1 C:10 T:1.86ms L:98% G:0%
    |       \---::ipp::iwiScale<F_IPP> - TC:1 C:10 T:1.84ms L:99% G:0%
    |
    |---Allocate_Memory_Evolution - TC:1 C:10 T:0.14ms L:0% G:0%
    |---Create_Nonlinear_Scale_Space - TC:1 C:10 T:575.78ms L:75% G:75%
    |   |---GaussianBlur - TC:1 C:170 T:16.65ms L:3% G:2%
    |   |   \---ipp_GaussianBlur<W_IPP> - TC:1 C:170 T:16.28ms L:98% G:2%
    |   |       |---parallel_for_ - TC:1 C:90 T:14.42ms L:89% G:2%
    |   |       |   \---operator() - TC:8 C:2240 T:12.98ms L:90% G:2%
    |   |       |       \---operator()<W_IPP> - TC:8 C:2240 T:12.47ms L:96% G:2%
    |   |       |           \---::ipp::iwiFilterGaussian<F_IPP> - TC:8 C:2240 T:11.99ms L:96% G:2%
    |   |       |
    |   |       \---::ipp::iwiFilterGaussian<F_IPP> - TC:1 C:80 T:1.52ms L:9% G:0%
    |   |
    |   |---copyTo - TC:1 C:10 T:1.63ms L:0% G:0%
    |   |---copyTo - TC:1 C:120 T:9.20ms L:2% G:1%
    |   |   \---ippicviCopy_8u_C1R_L<F_IPP> - TC:1 C:120 T:8.88ms L:97% G:1%
    |   |
    |   |---compute_kcontrast - TC:1 C:10 T:17.30ms L:3% G:2%
    |   |   \---convertTo - TC:1 C:10 T:0.66ms L:4% G:0%
    |   |       \---ipp_convertTo<W_IPP> - TC:1 C:10 T:0.64ms L:97% G:0%
    |   |           \---::ipp::iwiScale<F_IPP> - TC:1 C:10 T:0.63ms L:98% G:0%
    |   |
    |   |---Scharr - TC:1 C:320 T:26.78ms L:5% G:3%
    |   |   \---ipp_Deriv<W_IPP> - TC:1 C:320 T:26.43ms L:99% G:3%
    |   |       \---::ipp::iwiFilterScharr<F_IPP> - TC:1 C:320 T:26.03ms L:98% G:3%
    |   |
    |   |---pm_g2 - TC:1 C:150 T:11.74ms L:2% G:2%
    |   |---parallel_for_ - TC:1 C:1660 T:269.44ms L:47% G:35%
    |   |   \---operator() - TC:8 C:253923 T:205.26ms L:76% G:27%
    |   |       \---nld_step_scalar_one_lane - TC:8 C:253923 T:88.20ms L:43% G:12%
    |   |
    |   |---add - TC:1 C:1660 T:25.94ms L:5% G:3%
    |   |   \---ippicviAdd_32f_C1R<F_IPP> - TC:1 C:1660 T:23.99ms L:92% G:3%
    |   |
    |   |---resize - TC:1 C:30 T:1.99ms L:0% G:0%
    |   |   \---resize - TC:1 C:30 T:1.88ms L:94% G:0%
    |   |       |---ipp_resize<W_IPP> - TC:1 C:30 T:0.01ms L:1% G:0%
    |   |       |---parallel_for_ - TC:1 C:20 T:1.09ms L:58% G:0%
    |   |       |   \---operator() - TC:2 C:20 T:0.80ms L:73% G:0%
    |   |       |
    |   |       \---parallel_for_ - TC:1 C:10 T:0.63ms L:33% G:0%
    |   |
    |   \---Compute_Determinant_Hessian_Response - TC:1 C:10 T:193.26ms L:34% G:25%
    |       \---parallel_for_ - TC:1 C:10 T:193.24ms L:100% G:25%
    |           \---operator() - TC:8 C:160 T:193.08ms L:100% G:25%
    |               |---compute_derivative_kernels - TC:8 C:320 T:1.17ms L:1% G:0%
    |               |   \---copyTo - TC:8 C:640 T:0.72ms L:62% G:0%
    |               |       \---ippicviCopy_8u_C1R_L<F_IPP> - TC:8 C:640 T:0.25ms L:35% G:0%
    |               |
    |               \---sepFilter2D - TC:8 C:800 T:186.08ms L:96% G:24%
    |                   |---convertTo - TC:8 C:1600 T:2.43ms L:1% G:0%
    |                   |   \---ipp_convertTo<W_IPP> - TC:8 C:1600 T:1.42ms L:58% G:0%
    |                   |       \---::ipp::iwiScale<F_IPP> - TC:8 C:1600 T:0.45ms L:32% G:0%
    |                   |
    |                   \---apply - TC:8 C:800 T:183.31ms L:99% G:24%
    |                       \---ippiOperator<W_IPP> - TC:8 C:168750 T:113.84ms L:62% G:15%
    |                           \---ippicviFilterRowBorderPipeline_32f_C1R<F_IPP> - TC:8 C:168750 T:57.25ms L:50% G:7%
    |
    |---Feature_Detection - TC:1 C:10 T:96.31ms L:13% G:13%
    |   |---Find_Scale_Space_Extrema - TC:1 C:10 T:87.95ms L:91% G:11%
    |   \---Do_Subpixel_Refinement - TC:1 C:10 T:8.33ms L:9% G:1%
    |       \---solve - TC:1 C:18400 T:3.88ms L:46% G:1%
    |
    |---Compute_Keypoints_Orientation - TC:1 C:10 T:32.10ms L:4% G:4%
    |   \---parallel_for_ - TC:1 C:10 T:32.10ms L:100% G:4%
    |       \---operator() - TC:8 C:7555 T:30.50ms L:95% G:4%
    |           \---fastAtan2 - TC:8 C:18360 T:18.38ms L:60% G:2%
    |               \---fastAtan32f - TC:8 C:18360 T:11.48ms L:62% G:1%
    |                   \---fastAtan32f - TC:8 C:18360 T:4.18ms L:36% G:1%
    |
    \---Compute_Descriptors - TC:1 C:10 T:54.78ms L:7% G:7%
        \---parallel_for_ - TC:1 C:10 T:54.71ms L:100% G:7%
            \---operator() - TC:8 C:8067 T:54.17ms L:99% G:7%

IPP weight: 17.3%
OPENCL weight: 0.0%
[/TRACE    ]
[       OK ] feature2d_detectAndExtract.detectAndExtract/6 (779 ms)
[ RUN      ] feature2d_detectAndExtract.detectAndExtract/7
[ PERFSTAT ]    (samples = 10, mean = 66.97, median = 67.19, stddev = 0.65 (1.0%))
[ VALUE    ]    (AKAZE_DEFAULT, "stitching/a3.png")
[ TRACE    ]
ROOT
\---detectAndCompute - TC:1 C:10 T:669.65ms
    |---convertTo - TC:1 C:10 T:1.56ms L:0% G:0%
    |   \---ipp_convertTo<W_IPP> - TC:1 C:10 T:1.52ms L:98% G:0%
    |       \---::ipp::iwiScale<F_IPP> - TC:1 C:10 T:1.50ms L:99% G:0%
    |
    |---Allocate_Memory_Evolution - TC:1 C:10 T:0.10ms L:0% G:0%
    |---Create_Nonlinear_Scale_Space - TC:1 C:10 T:539.96ms L:81% G:81%
    |   |---GaussianBlur - TC:1 C:130 T:13.03ms L:2% G:2%
    |   |   \---ipp_GaussianBlur<W_IPP> - TC:1 C:130 T:12.80ms L:98% G:2%
    |   |       |---parallel_for_ - TC:1 C:90 T:11.45ms L:89% G:2%
    |   |       |   \---operator() - TC:8 C:2080 T:10.16ms L:89% G:2%
    |   |       |       \---operator()<W_IPP> - TC:8 C:2080 T:9.68ms L:95% G:1%
    |   |       |           \---::ipp::iwiFilterGaussian<F_IPP> - TC:8 C:2080 T:9.24ms L:95% G:1%
    |   |       |
    |   |       \---::ipp::iwiFilterGaussian<F_IPP> - TC:1 C:40 T:1.10ms L:9% G:0%
    |   |
    |   |---copyTo - TC:1 C:10 T:1.35ms L:0% G:0%
    |   |---copyTo - TC:1 C:90 T:5.47ms L:1% G:1%
    |   |   \---ippicviCopy_8u_C1R_L<F_IPP> - TC:1 C:90 T:5.27ms L:96% G:1%
    |   |
    |   |---compute_kcontrast - TC:1 C:10 T:14.72ms L:3% G:2%
    |   |   \---convertTo - TC:1 C:10 T:0.56ms L:4% G:0%
    |   |       \---ipp_convertTo<W_IPP> - TC:1 C:10 T:0.55ms L:97% G:0%
    |   |           \---::ipp::iwiScale<F_IPP> - TC:1 C:10 T:0.54ms L:98% G:0%
    |   |
    |   |---Scharr - TC:1 C:240 T:19.86ms L:4% G:3%
    |   |   \---ipp_Deriv<W_IPP> - TC:1 C:240 T:19.62ms L:99% G:3%
    |   |       \---::ipp::iwiFilterScharr<F_IPP> - TC:1 C:240 T:19.32ms L:98% G:3%
    |   |
    |   |---pm_g2 - TC:1 C:110 T:7.88ms L:1% G:1%
    |   |---parallel_for_ - TC:1 C:760 T:239.34ms L:44% G:36%
    |   |   \---operator() - TC:8 C:227591 T:183.49ms L:77% G:27%
    |   |       \---nld_step_scalar_one_lane - TC:8 C:227591 T:74.65ms L:41% G:11%
    |   |
    |   |---add - TC:1 C:760 T:19.87ms L:4% G:3%
    |   |   \---ippicviAdd_32f_C1R<F_IPP> - TC:1 C:760 T:18.89ms L:95% G:3%
    |   |
    |   |---resize - TC:1 C:20 T:0.87ms L:0% G:0%
    |   |   \---resize - TC:1 C:20 T:0.81ms L:93% G:0%
    |   |       |---ipp_resize<W_IPP> - TC:1 C:20 T:0.01ms L:1% G:0%
    |   |       \---parallel_for_ - TC:1 C:20 T:0.74ms L:91% G:0%
    |   |           \---operator() - TC:2 C:20 T:0.46ms L:62% G:0%
    |   |
    |   \---Compute_Determinant_Hessian_Response - TC:1 C:10 T:216.48ms L:40% G:32%
    |       \---parallel_for_ - TC:1 C:10 T:216.47ms L:100% G:32%
    |           \---operator() - TC:8 C:120 T:216.33ms L:100% G:32%
    |               |---compute_derivative_kernels - TC:8 C:240 T:0.91ms L:0% G:0%
    |               |   \---copyTo - TC:8 C:480 T:0.58ms L:64% G:0%
    |               |       \---ippicviCopy_8u_C1R_L<F_IPP> - TC:8 C:480 T:0.21ms L:36% G:0%
    |               |
    |               \---sepFilter2D - TC:8 C:600 T:210.64ms L:97% G:31%
    |                   |---convertTo - TC:8 C:1200 T:2.11ms L:1% G:0%
    |                   |   \---ipp_convertTo<W_IPP> - TC:8 C:1200 T:1.22ms L:58% G:0%
    |                   |       \---::ipp::iwiScale<F_IPP> - TC:8 C:1200 T:0.42ms L:35% G:0%
    |                   |
    |                   \---apply - TC:8 C:600 T:208.67ms L:99% G:31%
    |                       \---ippiOperator<W_IPP> - TC:8 C:201600 T:140.09ms L:67% G:21%
    |                           \---ippicviFilterRowBorderPipeline_32f_C1R<F_IPP> - TC:8 C:201600 T:65.83ms L:47% G:10%
    |
    |---Feature_Detection - TC:1 C:10 T:61.85ms L:9% G:9%
    |   |---Find_Scale_Space_Extrema - TC:1 C:10 T:55.59ms L:90% G:8%
    |   \---Do_Subpixel_Refinement - TC:1 C:10 T:6.24ms L:10% G:1%
    |       \---solve - TC:1 C:14180 T:2.97ms L:48% G:0%
    |
    |---Compute_Keypoints_Orientation - TC:1 C:10 T:25.25ms L:4% G:4%
    |   \---parallel_for_ - TC:1 C:10 T:25.24ms L:100% G:4%
    |       \---operator() - TC:8 C:6788 T:23.82ms L:94% G:4%
    |           \---fastAtan2 - TC:8 C:14180 T:14.28ms L:60% G:2%
    |               \---fastAtan32f - TC:8 C:14180 T:8.90ms L:62% G:1%
    |                   \---fastAtan32f - TC:8 C:14180 T:3.32ms L:37% G:0%
    |
    \---Compute_Descriptors - TC:1 C:10 T:40.64ms L:6% G:6%
        \---parallel_for_ - TC:1 C:10 T:40.59ms L:100% G:6%
            \---operator() - TC:8 C:7038 T:40.12ms L:99% G:6%

IPP weight: 18.3%
OPENCL weight: 0.0%
[/TRACE    ]
[       OK ] feature2d_detectAndExtract.detectAndExtract/7 (682 ms)
[ RUN      ] feature2d_detectAndExtract.detectAndExtract/8
[ PERFSTAT ]    (samples = 10, mean = 196.35, median = 195.55, stddev = 1.82 (0.9%))
[ VALUE    ]    (AKAZE_DEFAULT, "stitching/s2.jpg")
[ TRACE    ]
ROOT
\---detectAndCompute - TC:1 C:10 T:1963.44ms
    |---convertTo - TC:1 C:10 T:2.85ms L:0% G:0%
    |   \---ipp_convertTo<W_IPP> - TC:1 C:10 T:2.82ms L:99% G:0%
    |       \---::ipp::iwiScale<F_IPP> - TC:1 C:10 T:2.80ms L:99% G:0%
    |
    |---Allocate_Memory_Evolution - TC:1 C:10 T:0.13ms L:0% G:0%
    |---Create_Nonlinear_Scale_Space - TC:1 C:10 T:779.65ms L:40% G:40%
    |   |---GaussianBlur - TC:1 C:170 T:33.91ms L:4% G:2%
    |   |   \---ipp_GaussianBlur<W_IPP> - TC:1 C:170 T:33.45ms L:99% G:2%
    |   |       |---parallel_for_ - TC:1 C:90 T:30.99ms L:93% G:2%
    |   |       |   \---operator() - TC:8 C:2720 T:29.24ms L:94% G:1%
    |   |       |       \---operator()<W_IPP> - TC:8 C:2720 T:28.67ms L:98% G:1%
    |   |       |           \---::ipp::iwiFilterGaussian<F_IPP> - TC:8 C:2720 T:28.17ms L:98% G:1%
    |   |       |
    |   |       \---::ipp::iwiFilterGaussian<F_IPP> - TC:1 C:80 T:2.07ms L:6% G:0%
    |   |
    |   |---copyTo - TC:1 C:10 T:3.12ms L:0% G:0%
    |   |---copyTo - TC:1 C:120 T:16.78ms L:2% G:1%
    |   |   \---ippicviCopy_8u_C1R_L<F_IPP> - TC:1 C:120 T:16.39ms L:98% G:1%
    |   |
    |   |---compute_kcontrast - TC:1 C:10 T:31.24ms L:4% G:2%
    |   |   \---convertTo - TC:1 C:10 T:1.23ms L:4% G:0%
    |   |       \---ipp_convertTo<W_IPP> - TC:1 C:10 T:1.21ms L:98% G:0%
    |   |           \---::ipp::iwiScale<F_IPP> - TC:1 C:10 T:1.20ms L:99% G:0%
    |   |
    |   |---Scharr - TC:1 C:320 T:47.77ms L:6% G:2%
    |   |   \---ipp_Deriv<W_IPP> - TC:1 C:320 T:47.43ms L:99% G:2%
    |   |       \---::ipp::iwiFilterScharr<F_IPP> - TC:1 C:320 T:46.99ms L:99% G:2%
    |   |
    |   |---pm_g2 - TC:1 C:150 T:21.81ms L:3% G:1%
    |   |---parallel_for_ - TC:1 C:1660 T:311.89ms L:40% G:16%
    |   |   \---operator() - TC:8 C:289449 T:242.03ms L:78% G:12%
    |   |       \---nld_step_scalar_one_lane - TC:8 C:289449 T:115.17ms L:48% G:6%
    |   |
    |   |---add - TC:1 C:1660 T:50.06ms L:6% G:3%
    |   |   \---ippicviAdd_32f_C1R<F_IPP> - TC:1 C:1660 T:48.02ms L:96% G:2%
    |   |
    |   |---resize - TC:1 C:30 T:7.97ms L:1% G:0%
    |   |   \---resize - TC:1 C:30 T:7.88ms L:99% G:0%
    |   |       |---ipp_resize<W_IPP> - TC:1 C:30 T:0.01ms L:0% G:0%
    |   |       |---parallel_for_ - TC:1 C:20 T:7.29ms L:93% G:0%
    |   |       |   \---operator() - TC:4 C:40 T:6.14ms L:84% G:0%
    |   |       |
    |   |       \---parallel_for_ - TC:1 C:10 T:0.30ms L:4% G:0%
    |   |
    |   \---Compute_Determinant_Hessian_Response - TC:1 C:10 T:253.08ms L:32% G:13%
    |       \---parallel_for_ - TC:1 C:10 T:253.07ms L:100% G:13%
    |           \---operator() - TC:8 C:160 T:252.89ms L:100% G:13%
    |               |---compute_derivative_kernels - TC:8 C:320 T:1.20ms L:0% G:0%
    |               |   \---copyTo - TC:8 C:640 T:0.74ms L:62% G:0%
    |               |       \---ippicviCopy_8u_C1R_L<F_IPP> - TC:8 C:640 T:0.24ms L:32% G:0%
    |               |
    |               \---sepFilter2D - TC:8 C:800 T:243.93ms L:96% G:12%
    |                   |---convertTo - TC:8 C:1600 T:2.40ms L:1% G:0%
    |                   |   \---ipp_convertTo<W_IPP> - TC:8 C:1600 T:1.38ms L:58% G:0%
    |                   |       \---::ipp::iwiScale<F_IPP> - TC:8 C:1600 T:0.46ms L:33% G:0%
    |                   |
    |                   \---apply - TC:8 C:800 T:241.43ms L:99% G:12%
    |                       \---ippiOperator<W_IPP> - TC:8 C:196800 T:144.94ms L:60% G:7%
    |                           \---ippicviFilterRowBorderPipeline_32f_C1R<F_IPP> - TC:8 C:196800 T:82.44ms L:57% G:4%
    |
    |---Feature_Detection - TC:1 C:10 T:824.76ms L:42% G:42%
    |   |---Find_Scale_Space_Extrema - TC:1 C:10 T:790.53ms L:96% G:40%
    |   \---Do_Subpixel_Refinement - TC:1 C:10 T:34.20ms L:4% G:2%
    |       \---solve - TC:1 C:75310 T:15.64ms L:46% G:1%
    |
    |---Compute_Keypoints_Orientation - TC:1 C:10 T:119.35ms L:6% G:6%
    |   \---parallel_for_ - TC:1 C:10 T:119.33ms L:100% G:6%
    |       \---operator() - TC:8 C:10596 T:117.30ms L:98% G:6%
    |           \---fastAtan2 - TC:8 C:75200 T:72.71ms L:62% G:4%
    |               \---fastAtan32f - TC:8 C:75200 T:45.09ms L:62% G:2%
    |                   \---fastAtan32f - TC:8 C:75200 T:16.34ms L:36% G:1%
    |
    \---Compute_Descriptors - TC:1 C:10 T:228.30ms L:12% G:12%
        \---parallel_for_ - TC:1 C:10 T:228.09ms L:100% G:12%
            \---operator() - TC:8 C:10921 T:227.32ms L:100% G:12%

IPP weight: 11.7%
OPENCL weight: 0.0%
[/TRACE    ]
[       OK ] feature2d_detectAndExtract.detectAndExtract/8 (1988 ms)
[----------] 3 tests from feature2d_detectAndExtract (3449 ms total)

[----------] Global test environment tear-down
[==========] 3 tests from 1 test case ran. (3449 ms total)
[  PASSED  ] 3 tests.
```

Failed branches:
================

These are branches that contains code that is faster, but not suitable for
including into main branch (there might be failing tests etc.):

[test_scharr](https://github.com/hrnr/opencv/tree/test_scharr) I have tried to
[replace Scharr operator in `Compute_Determinant_Hessian_Response` with Scharr
[with fixed 3x3 kernel.

[akaze_octaves](https://github.com/hrnr/opencv/tree/akaze_octaves) Reworked
[non-linear scale space pyramid so that diffusivity is propagated only inside
[octaves. Probably not worth it, since it damages accuracy.
