### PR TITLE
(2.4) .gitignore: add .cache directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@
 .sw[a-z]
 tags
 tegra/
+.cache


### PR DESCRIPTION
to be consistent with master branch and prevent unintended removals of download cache.