### PR TITLE
More accurate condition to detect emulator

### DIFF
--- a/modules/java/generator/src/java/android+JavaCameraView.java
+++ b/modules/java/generator/src/java/android+JavaCameraView.java
@@ -147,7 +147,14 @@ public class JavaCameraView extends CameraBridgeViewBase implements PreviewCallb
                     Size frameSize = calculateCameraFrameSize(sizes, new JavaCameraSizeAccessor(), width, height);
 
                     /* Image format NV21 causes issues in the Android emulators */
-                    if (Build.BRAND.equalsIgnoreCase("generic") || Build.BRAND.equalsIgnoreCase("Android"))
+                    if (Build.FINGERPRINT.startsWith("generic")
+                            || Build.FINGERPRINT.startsWith("unknown")
+                            || Build.MODEL.contains("google_sdk")
+                            || Build.MODEL.contains("Emulator")
+                            || Build.MODEL.contains("Android SDK built for x86")
+                            || Build.MANUFACTURER.contains("Genymotion")
+                            || (Build.BRAND.startsWith("generic") && Build.DEVICE.startsWith("generic"))
+                            || "google_sdk".equals(Build.PRODUCT))
                         params.setPreviewFormat(ImageFormat.YV12);  // "generic" or "android" = android emulator
                     else
                         params.setPreviewFormat(ImageFormat.NV21);


### PR DESCRIPTION
resolves #8166
### This pullrequest changes

Previous commit, 6f39f9a, tries to fix the color issue for emulator. But the condition for detecting emulator is incomplete, e.g. it stops working for emulators using Google Play, whose Build.BRAND=="google". https://stackoverflow.com/a/21505193 shows a more accurate condition for this.

