### PR TITLE
Fix possible uninitialized memory in libtiff

### DIFF
--- a/3rdparty/libtiff/tif_dirread.c
+++ b/3rdparty/libtiff/tif_dirread.c
@@ -3707,7 +3707,7 @@ TIFFReadDirectory(TIFF* tif)
             case TIFFTAG_SMAXSAMPLEVALUE:
                 {
 
-                    double *data;
+                    double *data = 0;
                     enum TIFFReadDirEntryErr err;
                     uint32 saved_flags;
                     int m;


### PR DESCRIPTION
Visual Studio 2015 emits a warning C4703 on line 3726.