### PR TITLE
RGB2Lab_f: performance improved

### DIFF
--- a/modules/photo/test/test_npr.cpp
+++ b/modules/photo/test/test_npr.cpp
@@ -62,8 +62,9 @@ TEST(Photo_NPR_EdgePreserveSmoothing_RecursiveFilter, regression)
     edgePreservingFilter(source,result,1);
 
     Mat reference = imread(folder + "smoothened_RF_reference.png");
-    double error = cvtest::norm(reference, result, NORM_L1);
-    EXPECT_LE(error, numerical_precision);
+
+    double psnr = cvtest::PSNR(reference, result);
+    EXPECT_GT(psnr, 60.0);
 }
 
 TEST(Photo_NPR_EdgePreserveSmoothing_NormConvFilter, regression)
@@ -79,9 +80,9 @@ TEST(Photo_NPR_EdgePreserveSmoothing_NormConvFilter, regression)
     edgePreservingFilter(source,result,2);
 
     Mat reference = imread(folder + "smoothened_NCF_reference.png");
-    double error = cvtest::norm(reference, result, NORM_L1);
-    EXPECT_LE(error, numerical_precision);
 
+    double psnr = cvtest::PSNR(reference, result);
+    EXPECT_GT(psnr, 60.0);
 }
 
 TEST(Photo_NPR_DetailEnhance, regression)
@@ -97,8 +98,8 @@ TEST(Photo_NPR_DetailEnhance, regression)
     detailEnhance(source,result);
 
     Mat reference = imread(folder + "detail_enhanced_reference.png");
-    double error = cvtest::norm(reference, result, NORM_L1);
-    EXPECT_LE(error, numerical_precision);
+    double psnr = cvtest::PSNR(reference, result);
+    EXPECT_GT(psnr, 60.0);
 }
 
 TEST(Photo_NPR_PencilSketch, regression)


### PR DESCRIPTION
### This pullrequest changes
* Trilinear interpolation is used to speed up calculations when standard coefficients are used
* `std::pow(x, 1.f/3.f)` is replaced by `cubeRoot(x)` for other cases since it's extremely slow on Linux

### Performance
Measured 100 runs on random 257x257 image
Repeated 100 times and then averaged

Version | Linux x64 Core i5-6600 @ 3.3 GHz |  Win x64 Core i5-6300U @ 2.4 GHz
------------ | ------------- | -------------
New version, seconds | 0.058 to 0.079 | 0.100 to 0.414
Original, seconds | 0.306 to 0.362 (*) | 0.505 to 1.127
Avg improvement, times | 4.94 | 4.27

(*) measured using `cubeRoot()`, using original code `std::pow(x, 1.f/3.f)` it performs about 1.5 s

### Accuracy
Channels are [L, a, b]
Value range per channel is 100 for L and 255 for a and b

max error per channel: 0.395
mean: [0.00947879, 0.0293681, 0.064303]
stddev: [0.01188, 0.0290731, 0.0368989]