### PR TITLE
fast_math.hpp: Use __asm__ rather than asm; fixes including with -std=c99

### DIFF
--- a/modules/core/include/opencv2/core/fast_math.hpp
+++ b/modules/core/include/opencv2/core/fast_math.hpp
@@ -80,7 +80,7 @@
         int res; \
         float temp; \
         (void)temp; \
-        asm(_asm_string : [res] "=r" (res), [temp] "=w" (temp) : [value] "w" (_value)); \
+        __asm__(_asm_string : [res] "=r" (res), [temp] "=w" (temp) : [value] "w" (_value)); \
         return res
     // 2. version for double
     #ifdef __clang__


### PR DESCRIPTION
This is very similar to #7242; MRPT was failing to build on armhf, as it is compiled with -std=c99.