### PR TITLE
Add a note to morphologyEx documentation when iterations > 1

### DIFF
--- a/modules/imgproc/include/opencv2/imgproc.hpp
+++ b/modules/imgproc/include/opencv2/imgproc.hpp
@@ -2181,6 +2181,9 @@ kernel center.
 @param borderValue Border value in case of a constant border. The default value has a special
 meaning.
 @sa  dilate, erode, getStructuringElement
+@note The number of iterations is the number of times erosion or dilatation operation will be applied.
+For instance, an opening operation (#MORPH_OPEN) with two iterations is equivalent to apply
+successively: erode -> erode -> dilate -> dilate (and not erode -> dilate -> erode -> dilate).
  */
 CV_EXPORTS_W void morphologyEx( InputArray src, OutputArray dst,
                                 int op, InputArray kernel,


### PR DESCRIPTION
resolves #8955

### This pullrequest adds

<!-- Please describe what your pullrequest is changing -->
a note to morphologyEx documentation to clarify the behavior when iterations > 1 (source code is [here](https://github.com/opencv/opencv/blob/3.2.0/modules/imgproc/src/morph.cpp#L2065)). See #8955 