### PR TITLE
core: forbid handling of the case when src=dst in cv::repeat

### DIFF
--- a/modules/core/src/copy.cpp
+++ b/modules/core/src/copy.cpp
@@ -856,6 +856,7 @@ void repeat(InputArray _src, int ny, int nx, OutputArray _dst)
 {
     CV_INSTRUMENT_REGION()
 
+    CV_Assert(_src.getObj() != _dst.getObj());
     CV_Assert( _src.dims() <= 2 );
     CV_Assert( ny > 0 && nx > 0 );
 

--- a/modules/core/test/test_misc.cpp
+++ b/modules/core/test/test_misc.cpp
@@ -145,3 +145,12 @@ TEST(Core_String, end_method_regression)
     cv::String new_string(old_string.begin(), old_string.end());
     EXPECT_EQ(6u, new_string.size());
 }
+
+TEST(Core_Copy, repeat_regression_8972)
+{
+    Mat src = (Mat_<int>(1, 4) << 1, 2, 3, 4);
+
+    ASSERT_ANY_THROW({
+                         repeat(src, 5, 1, src);
+                     });
+}


### PR DESCRIPTION
resolves #8972 