### PR TITLE
Fixed some bugs from Halide tests

### DIFF
--- a/modules/dnn/src/layers/elementwise_layers.cpp
+++ b/modules/dnn/src/layers/elementwise_layers.cpp
@@ -192,7 +192,7 @@ struct ReLUFunctor
         Halide::Var x("x"), y("y"), c("c"), n("n");
         if (slope)
         {
-            top(x, y, c, n) = select(input >= 0.0f, input, slope);
+            top(x, y, c, n) = select(input >= 0.0f, input, slope * input);
         }
         else
         {

--- a/modules/dnn/src/layers/fully_connected_layer.cpp
+++ b/modules/dnn/src/layers/fully_connected_layer.cpp
@@ -77,7 +77,6 @@ public:
             wpadding.setTo(Scalar::all(0.));
             weightsMat = weightsBuf.colRange(0, vecsize);
             blobs[0].copyTo(weightsMat);
-            blobs[0] = weightsMat;
         }
 
         if (bias)


### PR DESCRIPTION
### This pullrequest changes

* Fixed ReLU Halide function with non-zero negative slope
* Keep origin fully-connected weights (Halide buffer wrap pointer to data. So in case of vector alignment it would be shifted)
* Modified Concat and Element-wise (sum, mult, max) tests considering layers order
