### PR TITLE
flann: fix build with MSVC /sdl option

### DIFF
--- a/modules/flann/include/opencv2/flann/logger.h
+++ b/modules/flann/include/opencv2/flann/logger.h
@@ -63,7 +63,12 @@ class Logger
             stream = stdout;
         }
         else {
+#ifdef _MSC_VER
+            if (fopen_s(&stream, name, "w") != 0)
+                stream = NULL;
+#else
             stream = fopen(name,"w");
+#endif
             if (stream == NULL) {
                 stream = stdout;
             }


### PR DESCRIPTION
In case of `#include <opencv2/opencv.hpp>`