### PR TITLE
dnn: added "hidden" experimental namespace

### DIFF
--- a/modules/dnn/include/opencv2/dnn/all_layers.hpp
+++ b/modules/dnn/include/opencv2/dnn/all_layers.hpp
@@ -43,10 +43,9 @@
 #define OPENCV_DNN_DNN_ALL_LAYERS_HPP
 #include <opencv2/dnn.hpp>
 
-namespace cv
-{
-namespace dnn
-{
+namespace cv {
+namespace dnn {
+CV__DNN_EXPERIMENTAL_NS_BEGIN
 //! @addtogroup dnn
 //! @{
 
@@ -459,7 +458,7 @@ namespace dnn
 
 //! @}
 //! @}
-
+CV__DNN_EXPERIMENTAL_NS_END
 }
 }
 #endif

--- a/modules/dnn/include/opencv2/dnn/dict.hpp
+++ b/modules/dnn/include/opencv2/dnn/dict.hpp
@@ -46,10 +46,9 @@
 #include <map>
 #include <ostream>
 
-namespace cv
-{
-namespace dnn
-{
+namespace cv {
+namespace dnn {
+CV__DNN_EXPERIMENTAL_NS_BEGIN
 //! @addtogroup dnn
 //! @{
 
@@ -140,6 +139,7 @@ public:
 };
 
 //! @}
+CV__DNN_EXPERIMENTAL_NS_END
 }
 }
 

--- a/modules/dnn/include/opencv2/dnn/dnn.hpp
+++ b/modules/dnn/include/opencv2/dnn/dnn.hpp
@@ -44,12 +44,23 @@
 
 #include <vector>
 #include <opencv2/core.hpp>
+
+#if !defined CV_DOXYGEN && !defined CV_DNN_DONT_ADD_EXPERIMENTAL_NS
+#define CV__DNN_EXPERIMENTAL_NS_USE using namespace experimental_dnn_v1;
+#define CV__DNN_EXPERIMENTAL_NS_BEGIN namespace experimental_dnn_v1 {
+#define CV__DNN_EXPERIMENTAL_NS_END }
+#else
+#define CV__DNN_EXPERIMENTAL_NS_USE
+#define CV__DNN_EXPERIMENTAL_NS_BEGIN
+#define CV__DNN_EXPERIMENTAL_NS_END
+#endif
+
 #include <opencv2/dnn/dict.hpp>
 
-namespace cv
-{
-namespace dnn //! This namespace is used for dnn module functionlaity.
-{
+namespace cv {
+namespace dnn {
+CV__DNN_EXPERIMENTAL_NS_USE
+CV__DNN_EXPERIMENTAL_NS_BEGIN
 //! @addtogroup dnn
 //! @{
 
@@ -658,6 +669,7 @@ namespace dnn //! This namespace is used for dnn module functionlaity.
                                     Size size = Size(), const Scalar& mean = Scalar(), bool swapRB=true);
 
 //! @}
+CV__DNN_EXPERIMENTAL_NS_END
 }
 }
 

--- a/modules/dnn/include/opencv2/dnn/dnn.inl.hpp
+++ b/modules/dnn/include/opencv2/dnn/dnn.inl.hpp
@@ -44,10 +44,9 @@
 
 #include <opencv2/dnn.hpp>
 
-namespace cv
-{
-namespace dnn
-{
+namespace cv {
+namespace dnn {
+CV__DNN_EXPERIMENTAL_NS_BEGIN
 
 template<typename TypeIter>
 DictValue DictValue::arrayInt(TypeIter begin, int size)
@@ -351,6 +350,7 @@ inline std::ostream &operator<<(std::ostream &stream, const Dict &dict)
     return stream;
 }
 
+CV__DNN_EXPERIMENTAL_NS_END
 }
 }
 

--- a/modules/dnn/include/opencv2/dnn/layer.details.hpp
+++ b/modules/dnn/include/opencv2/dnn/layer.details.hpp
@@ -7,10 +7,9 @@
 
 #include <opencv2/dnn/layer.hpp>
 
-namespace cv
-{
-namespace dnn
-{
+namespace cv {
+namespace dnn {
+CV__DNN_EXPERIMENTAL_NS_BEGIN
 
 /** @brief Registers layer constructor in runtime.
 *   @param type string, containing type name of the layer.
@@ -72,6 +71,8 @@ public:
     }
 };
 
-}}} //namespace
+} // namespace
+CV__DNN_EXPERIMENTAL_NS_END
+}} // namespace
 
 #endif

--- a/modules/dnn/include/opencv2/dnn/layer.hpp
+++ b/modules/dnn/include/opencv2/dnn/layer.hpp
@@ -43,10 +43,9 @@
 #define OPENCV_DNN_LAYER_HPP
 #include <opencv2/dnn.hpp>
 
-namespace cv
-{
-namespace dnn
-{
+namespace cv {
+namespace dnn {
+CV__DNN_EXPERIMENTAL_NS_BEGIN
 //! @addtogroup dnn
 //! @{
 //!
@@ -80,7 +79,7 @@ private:
 
 //! @}
 //! @}
-
+CV__DNN_EXPERIMENTAL_NS_END
 }
 }
 #endif

--- a/modules/dnn/include/opencv2/dnn/shape_utils.hpp
+++ b/modules/dnn/include/opencv2/dnn/shape_utils.hpp
@@ -48,6 +48,7 @@
 
 namespace cv {
 namespace dnn {
+CV__DNN_EXPERIMENTAL_NS_BEGIN
 
 //Useful shortcut
 inline std::ostream &operator<< (std::ostream &s, cv::Range &r)
@@ -190,6 +191,7 @@ inline int clamp(int ax, const MatShape& shape)
     return clamp(ax, (int)shape.size());
 }
 
+CV__DNN_EXPERIMENTAL_NS_END
 }
 }
 #endif

--- a/modules/dnn/src/caffe/caffe_importer.cpp
+++ b/modules/dnn/src/caffe/caffe_importer.cpp
@@ -40,8 +40,6 @@
 //M*/
 
 #include "../precomp.hpp"
-using namespace cv;
-using namespace cv::dnn;
 
 #if HAVE_PROTOBUF
 #include "caffe.pb.h"
@@ -54,7 +52,13 @@ using namespace cv::dnn;
 #include <google/protobuf/text_format.h>
 #include <google/protobuf/io/zero_copy_stream_impl.h>
 #include "caffe_io.hpp"
+#endif
 
+namespace cv {
+namespace dnn {
+CV__DNN_EXPERIMENTAL_NS_BEGIN
+
+#ifdef HAVE_PROTOBUF
 using ::google::protobuf::RepeatedField;
 using ::google::protobuf::RepeatedPtrField;
 using ::google::protobuf::Message;
@@ -357,14 +361,14 @@ public:
 
 }
 
-Ptr<Importer> cv::dnn::createCaffeImporter(const String &prototxt, const String &caffeModel)
+Ptr<Importer> createCaffeImporter(const String &prototxt, const String &caffeModel)
 {
     return Ptr<Importer>(new CaffeImporter(prototxt.c_str(), caffeModel.c_str()));
 }
 
 #else //HAVE_PROTOBUF
 
-Ptr<Importer> cv::dnn::createCaffeImporter(const String&, const String&)
+Ptr<Importer> createCaffeImporter(const String&, const String&)
 {
     CV_Error(cv::Error::StsNotImplemented, "libprotobuf required to import data from Caffe models");
     return Ptr<Importer>();
@@ -372,7 +376,7 @@ Ptr<Importer> cv::dnn::createCaffeImporter(const String&, const String&)
 
 #endif //HAVE_PROTOBUF
 
-Net cv::dnn::readNetFromCaffe(const String &prototxt, const String &caffeModel /*= String()*/)
+Net readNetFromCaffe(const String &prototxt, const String &caffeModel /*= String()*/)
 {
     Ptr<Importer> caffeImporter = createCaffeImporter(prototxt, caffeModel);
     Net net;
@@ -380,3 +384,6 @@ Net cv::dnn::readNetFromCaffe(const String &prototxt, const String &caffeModel /
         caffeImporter->populateNet(net);
     return net;
 }
+
+CV__DNN_EXPERIMENTAL_NS_END
+}} // namespace

--- a/modules/dnn/src/dnn.cpp
+++ b/modules/dnn/src/dnn.cpp
@@ -50,8 +50,9 @@
 #include <opencv2/dnn/shape_utils.hpp>
 #include <opencv2/imgproc.hpp>
 
-using namespace cv;
-using namespace cv::dnn;
+namespace cv {
+namespace dnn {
+CV__DNN_EXPERIMENTAL_NS_BEGIN
 
 using std::vector;
 using std::map;
@@ -73,11 +74,6 @@ namespace
         LayerShapes() {supportInPlace = false;}
     };
 }
-
-namespace cv
-{
-namespace dnn
-{
 
 template<typename T>
 static String toString(const T &v)
@@ -2030,5 +2026,5 @@ BackendWrapper::BackendWrapper(const Ptr<BackendWrapper>& base, const MatShape& 
 
 BackendWrapper::~BackendWrapper() {}
 
-}
-}
+CV__DNN_EXPERIMENTAL_NS_END
+}} // namespace

--- a/modules/dnn/src/init.cpp
+++ b/modules/dnn/src/init.cpp
@@ -42,10 +42,9 @@
 #include "precomp.hpp"
 #include <opencv2/dnn/layer.details.hpp>
 
-namespace cv
-{
-namespace dnn
-{
+namespace cv {
+namespace dnn {
+CV__DNN_EXPERIMENTAL_NS_BEGIN
 
 static Mutex* __initialization_mutex = NULL;
 Mutex& getInitializationMutex()
@@ -98,4 +97,5 @@ void initializeLayerFactory()
     CV_DNN_REGISTER_LAYER_CLASS(Scale,          ScaleLayer);
 }
 
-}} //namespace
+CV__DNN_EXPERIMENTAL_NS_END
+}} // namespace

--- a/modules/dnn/src/precomp.hpp
+++ b/modules/dnn/src/precomp.hpp
@@ -45,6 +45,8 @@
 #include <opencv2/dnn/all_layers.hpp>
 
 namespace cv { namespace dnn {
+CV__DNN_EXPERIMENTAL_NS_BEGIN
 Mutex& getInitializationMutex();
 void initializeLayerFactory();
+CV__DNN_EXPERIMENTAL_NS_END
 }} // namespace

--- a/modules/dnn/src/tensorflow/tf_importer.cpp
+++ b/modules/dnn/src/tensorflow/tf_importer.cpp
@@ -10,8 +10,6 @@ Implementation of Tensorflow models parser
 */
 
 #include "../precomp.hpp"
-using namespace cv;
-using namespace cv::dnn;
 
 #if HAVE_PROTOBUF
 #include "graph.pb.h"
@@ -24,6 +22,13 @@ using namespace cv::dnn;
 #include <google/protobuf/text_format.h>
 #include <google/protobuf/io/zero_copy_stream_impl.h>
 #include "tf_io.hpp"
+#endif
+
+namespace cv {
+namespace dnn {
+CV__DNN_EXPERIMENTAL_NS_BEGIN
+
+#if HAVE_PROTOBUF
 
 using ::google::protobuf::RepeatedField;
 using ::google::protobuf::RepeatedPtrField;
@@ -734,14 +739,14 @@ void TFImporter::populateNet(Net dstNet)
 
 } // namespace
 
-Ptr<Importer> cv::dnn::createTensorflowImporter(const String &model)
+Ptr<Importer> createTensorflowImporter(const String &model)
 {
     return Ptr<Importer>(new TFImporter(model.c_str()));
 }
 
 #else //HAVE_PROTOBUF
 
-Ptr<Importer> cv::dnn::createTensorflowImporter(const String&)
+Ptr<Importer> createTensorflowImporter(const String&)
 {
     CV_Error(cv::Error::StsNotImplemented, "libprotobuf required to import data from TensorFlow models");
     return Ptr<Importer>();
@@ -749,7 +754,7 @@ Ptr<Importer> cv::dnn::createTensorflowImporter(const String&)
 
 #endif //HAVE_PROTOBUF
 
-Net cv::dnn::readNetFromTensorflow(const String &model)
+Net readNetFromTensorflow(const String &model)
 {
     Ptr<Importer> importer = createTensorflowImporter(model);
     Net net;
@@ -757,3 +762,6 @@ Net cv::dnn::readNetFromTensorflow(const String &model)
         importer->populateNet(net);
     return net;
 }
+
+CV__DNN_EXPERIMENTAL_NS_END
+}} // namespace

--- a/modules/dnn/src/torch/torch_importer.cpp
+++ b/modules/dnn/src/torch/torch_importer.cpp
@@ -49,6 +49,8 @@
 
 namespace cv {
 namespace dnn {
+CV__DNN_EXPERIMENTAL_NS_BEGIN
+
 #if defined(ENABLE_TORCH_IMPORTER) && ENABLE_TORCH_IMPORTER
 #include "THDiskFile.h"
 
@@ -1021,5 +1023,5 @@ Net readNetFromTorch(const String &model, bool isBinary)
     return net;
 }
 
-}
-}
+CV__DNN_EXPERIMENTAL_NS_END
+}} // namespace


### PR DESCRIPTION
Current public API of DNN module is not stabilized yet (especially on the "binary compatibility" level).
- there are some interfaces that require changes for better "const ref" parameters:
```
static Ptr<Layer> createLayerInstance(const String &type, LayerParams& params);
typedef Ptr<Layer>(*Constuctor)(LayerParams &params);
virtual void forward(std::vector<Mat*> &input, ...)
virtual int inputNameToIndex(String inputName);
...
```
- many "virtual" methods
- TODOs in public headers

Main purpose of this namespace is to avoid using of incompatible binaries that will cause applications crashes.

This additional namespace will not impact "Source code API". This change allows to continue maintaining of ABI checks for other OpenCV modules (with easy filtering out of DNN code).

This patch doesn't require any changes in tests or samples.