### PR TITLE
Fix WinRT build breaks in highgui and videoio.

### DIFF
--- a/modules/highgui/src/window.cpp
+++ b/modules/highgui/src/window.cpp
@@ -218,7 +218,7 @@ int cv::waitKey(int delay)
 {
     CV_TRACE_FUNCTION();
     int code = waitKeyEx(delay);
-#ifndef HAVE_WINRT
+#ifndef WINRT
     static int use_legacy = -1;
     if (use_legacy < 0)
     {

--- a/modules/highgui/src/window_winrt_bridge.cpp
+++ b/modules/highgui/src/window_winrt_bridge.cpp
@@ -24,6 +24,8 @@
 // NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 
+#include "precomp.hpp"
+
 #include "opencv2\highgui\highgui_winrt.hpp"
 #include "window_winrt_bridge.hpp"
 

--- a/modules/videoio/CMakeLists.txt
+++ b/modules/videoio/CMakeLists.txt
@@ -256,6 +256,9 @@ endif()
 
 if(MSVC)
   set_target_properties(${the_module} PROPERTIES LINK_FLAGS "/NODEFAULTLIB:atlthunk.lib /NODEFAULTLIB:atlsd.lib /NODEFAULTLIB:libcmt.lib /DEBUG")
+  if(DEFINED WINRT AND NOT DEFINED ENABLE_WINRT_MODE_NATIVE)
+    set_target_properties(${the_module} PROPERTIES VS_DESKTOP_EXTENSIONS_VERSION "${CMAKE_VS_WINDOWS_TARGET_PLATFORM_VERSION}")
+  endif()
 endif()
 
 #stop automatic dependencies propagation for this module


### PR DESCRIPTION
resolves #9043 

### This pullrequest changes

Fixes build breaks in Visual Studio for WinRT Windows build.