### PR TITLE
imgproc: fix MORPH_HITMISS operation when kernel has no negative values

### DIFF
--- a/modules/imgproc/test/test_filter.cpp
+++ b/modules/imgproc/test/test_filter.cpp
@@ -2065,3 +2065,36 @@ TEST(Imgproc_Sobel, borderTypes)
     EXPECT_EQ(expected_dst.size(), dst.size());
     EXPECT_DOUBLE_EQ(0.0, cvtest::norm(expected_dst, dst, NORM_INF));
 }
+
+TEST(Imgproc_MorphEx, hitmiss_regression_8957)
+{
+    Mat_<uchar> src(3, 3);
+    src << 0, 255, 0,
+           0,   0, 0,
+           0, 255, 0;
+
+    Mat_<uchar> kernel = src / 255;
+
+    Mat dst;
+    morphologyEx(src, dst, MORPH_HITMISS, kernel);
+
+    Mat ref = Mat::zeros(3, 3, CV_8U);
+    ref.at<uchar>(1, 1) = 255;
+
+    ASSERT_DOUBLE_EQ(norm(dst, ref, NORM_INF), 0.);
+}
+
+TEST(Imgproc_MorphEx, hitmiss_zero_kernel)
+{
+    Mat_<uchar> src(3, 3);
+    src << 0, 255, 0,
+           0,   0, 0,
+           0, 255, 0;
+
+    Mat_<uchar> kernel = Mat_<uchar>::zeros(3, 3);
+
+    Mat dst;
+    morphologyEx(src, dst, MORPH_HITMISS, kernel);
+
+    ASSERT_DOUBLE_EQ(norm(dst, src, NORM_INF), 0.);
+}


### PR DESCRIPTION
resolves #8957