### PR TITLE
Remove debugging code from DirectShow video capture

### DIFF
--- a/modules/ml/src/data.cpp
+++ b/modules/ml/src/data.cpp
@@ -403,7 +403,7 @@ public:
             Mat(tempCatMap).copyTo(catMap);
         }
 
-        if( varType.at<uchar>(ninputvars) == VAR_CATEGORICAL )
+        if( noutputvars > 0 && varType.at<uchar>(ninputvars) == VAR_CATEGORICAL )
         {
             preprocessCategorical(responses, &normCatResponses, labels, &counters, sortbuf);
             Mat(labels).copyTo(classLabels);


### PR DESCRIPTION
This code is impossible to enable or disable at runtime, and that wouldn't be very useful either due to the static VideoCapture_DShow::g_VI declaration.

As this code is unavailable in release mode anyway and only seemed to have served purpose when creating this code (it was present in the original version in
github ofTheo/videoInput), I suggest it be removed.

resolves #8926 

### This pullrequest changes

This code removes the debugging code from the DirectShow video input, which is always enabled in debugging mode. As the code has been remarkably stable for the last 6 years, I hope we can do without it.
