### PR TITLE
a fix for open issue 4772

### DIFF
--- a/cmake/OpenCVCompilerOptions.cmake
+++ b/cmake/OpenCVCompilerOptions.cmake
@@ -248,7 +248,9 @@ endif()
 # Extra link libs if the user selects building static libs:
 if(NOT BUILD_SHARED_LIBS AND CMAKE_COMPILER_IS_GNUCXX AND NOT ANDROID)
   # Android does not need these settings because they are already set by toolchain file
-  set(OPENCV_LINKER_LIBS ${OPENCV_LINKER_LIBS} stdc++)
+  if(NOT MINGW)
+    set(OPENCV_LINKER_LIBS ${OPENCV_LINKER_LIBS} stdc++)
+  endif()
   set(OPENCV_EXTRA_FLAGS "-fPIC ${OPENCV_EXTRA_FLAGS}")
 endif()
 


### PR DESCRIPTION
resolves #4772

### This pullrequest changes

<!-- Please describe what your pullrequest is changing -->
As described in open issue #4772 (Static build error because of libstdc++ "multiple definitions"), this error still exists in current opencv 3.2.0.

When `BUILD_SHARED_LIBS` is turned off, `-lstdc++` flag will be added to g++. In this case, `libstdc++.a` and `libstdc++.dll.a` will be all linked, as described in the issue 4772, resulting "multiple definitions" error to occur in several places.

However, the default settings of g++ compiler in TDM-GCC behaves just rightly, which links runtimes statically by default. So I think this line of code should be ommited at least in MINGW case. In my case, it works in windows 10, TDM-GCC Compiler Suite for Windows GCC 5 Series MinGW-w64 64/32-bit Edition.

As has such a fix, I successfully compiled out static libraries of opencv 3.2.0 without any error. And I have tried `opencv_test_core.exe` produced in the process of the whole building, passing all the tests.