### PR TITLE
Prevent crash when attempting to create training data without responses.

### DIFF
--- a/modules/ml/src/data.cpp
+++ b/modules/ml/src/data.cpp
@@ -403,7 +403,7 @@ public:
             Mat(tempCatMap).copyTo(catMap);
         }
 
-        if( varType.at<uchar>(ninputvars) == VAR_CATEGORICAL )
+        if( noutputvars > 0 && varType.at<uchar>(ninputvars) == VAR_CATEGORICAL )
         {
             preprocessCategorical(responses, &normCatResponses, labels, &counters, sortbuf);
             Mat(labels).copyTo(classLabels);


### PR DESCRIPTION
This is at least useful when using an SVM one-class linear classifier, so there are valid use cases.

resolves #8927 

### This pullrequest changes

This prevents the crash and is a no-op if responses are provided. I've performed some quick tests and I did not notice any different behaviour between this change or supplying zero response values.

However, I am absolutely no expert in this area - careful review would be most welcome.