### PR TITLE
static build workaround

### DIFF
--- a/modules/viz/CMakeLists.txt
+++ b/modules/viz/CMakeLists.txt
@@ -4,6 +4,26 @@ endif()
 
 set(the_description "Viz")
 include(${VTK_USE_FILE})
+
+if(NOT BUILD_SHARED_LIBS)
+  # We observed conflict between builtin 3rdparty libraries and
+  # system-wide similar libraries (but with different versions) from VTK dependencies
+  set(_conflicts "")
+  foreach(dep ${VTK_LIBRARIES})
+    if(("${dep}" MATCHES "libz\\." AND BUILD_ZLIB)
+      OR ("${dep}" MATCHES "libjpeg\\." AND BUILD_JPEG)
+      OR ("${dep}" MATCHES "libpng\\." AND BUILD_PNG)
+      OR ("${dep}" MATCHES "libtiff\\." AND BUILD_TIFF)
+    )
+      list(APPEND _conflicts "${dep}")
+    endif()
+  endforeach()
+  if(_conflicts)
+    message(STATUS "Disabling VIZ module due conflicts with VTK dependencies: ${_conflicts}")
+    ocv_module_disable(viz)
+  endif()
+endif()
+
 ocv_define_module(viz opencv_core WRAP python)
 ocv_target_link_libraries(${the_module} ${VTK_LIBRARIES})
 


### PR DESCRIPTION
[Validated](http://pullrequest.opencv.org/buildbot/builders/master_noOCL-mac-static/builds/10144).