### PR TITLE
Fix error message fisheye CALIB_CHECK_COND

### DIFF
--- a/modules/calib3d/src/fisheye.cpp
+++ b/modules/calib3d/src/fisheye.cpp
@@ -1401,7 +1401,8 @@ void cv::internal::CalibrateExtrinsics(InputArrayOfArrays objectPoints, InputArr
         if (check_cond)
         {
             SVD svd(JJ_kk, SVD::NO_UV);
-            CV_Assert(svd.w.at<double>(0) / svd.w.at<double>((int)svd.w.total() - 1) < thresh_cond);
+            if(svd.w.at<double>(0) / svd.w.at<double>((int)svd.w.total() - 1) > thresh_cond )
+                CV_Error( cv::Error::StsInternal, format("CALIB_CHECK_COND - Ill-conditioned matrix for input array %d",image_idx));
         }
         omckk.reshape(3,1).copyTo(omc.getMat().col(image_idx));
         Tckk.reshape(3,1).copyTo(Tc.getMat().col(image_idx));


### PR DESCRIPTION
The old error message was not giving any hint which input array (image)
led to an ill conditioned matrix. This made it near impossible to
identify poor images in a larger set.

A better approach would be to implement a checker function which gives
each image a rating before the real calibration is performed. This could
also include some image properties like sharpness, etc.

<!-- Please use this line to close one or multiple issues when this pullrequest gets merged
You can add another line right under the first one:
-->

### This pullrequest changes

<!-- Fix error message fisheye CALIB_CHECK_COND -->