### PR TITLE
Fix ffmpeg detection with -D OPENCV_WARNINGS_ARE_ERRORS=ON option

### DIFF
--- a/cmake/checks/ffmpeg_test.cpp
+++ b/cmake/checks/ffmpeg_test.cpp
@@ -15,12 +15,15 @@ static void test()
   AVFormatContext* c = 0;
   AVCodec* avcodec = 0;
   AVFrame* frame = 0;
+  (void)avcodec;
+  (void)frame;
 
 #if LIBAVFORMAT_BUILD >= CALC_FFMPEG_VERSION(52, 111, 0)
   int err = avformat_open_input(&c, "", NULL, NULL);
 #else
   int err = av_open_input_file(&c, "", NULL, 0, NULL);
 #endif
+  (void)err;
 }
 
 int main() { test(); return 0; }


### PR DESCRIPTION
<!-- Please use this line to close one or multiple issues when this pullrequest gets merged
You can add another line right under the first one:
resolves #1234
resolves #1235
-->

### This pullrequest changes

<!-- Please describe what your pullrequest is changing -->
resolves #9047 
These variables are not used and fail the detection of ffmpeg with warnings are errors flag. With these changes, ffmpeg should be correctly detected.