### PR TITLE
Improve solvePnPRansac

### DIFF
--- a/modules/calib3d/include/opencv2/calib3d.hpp
+++ b/modules/calib3d/include/opencv2/calib3d.hpp
@@ -627,6 +627,13 @@ makes the function resistant to outliers.
 @note
    -   An example of how to use solvePNPRansac for object detection can be found at
         opencv_source_code/samples/cpp/tutorial_code/calib3d/real_time_pose_estimation/
+   -   The default method used to estimate the camera pose for the Minimal Sample Sets step
+       is #SOLVEPNP_EPNP. Exceptions are:
+         - if you choose #SOLVEPNP_P3P or #SOLVEPNP_AP3P, these methods will be used.
+         - if the number of input points is equal to 4, #SOLVEPNP_P3P is used.
+   -   The method used to estimate the camera pose using all the inliers is defined by the
+       flags parameters unless it is equal to #SOLVEPNP_P3P or #SOLVEPNP_AP3P. In this case,
+       the method #SOLVEPNP_EPNP will be used instead.
  */
 CV_EXPORTS_W bool solvePnPRansac( InputArray objectPoints, InputArray imagePoints,
                                   InputArray cameraMatrix, InputArray distCoeffs,


### PR DESCRIPTION
<!-- Please use this line to close one or multiple issues when this pullrequest gets merged
You can add another line right under the first one:
resolves #1234
resolves #1235
-->

### This pullrequest changes
<!-- Please describe what your pullrequest is changing -->

This PR is an attempt to improve and clarify the "algorithm" behind `solvePnPRansac`, see also #8782.
From what I have understood of the code:
 - when the number of input points is equal to the number of model points, `rvec` and `tvec` are estimated two times: once [here](https://github.com/opencv/opencv/blob/3.3.0-rc/modules/calib3d/src/ptsetreg.cpp#L198) and another time [here](https://github.com/opencv/opencv/blob/3.3.0-rc/modules/calib3d/src/solvepnp.cpp#L311)
 - this should be unnecessary and this PR "short-circuits" by calling directly `solvePnP`
 - the `useExtrinsicGuess` parameters has no effect as `ransac_kernel_method` is set by [default](https://github.com/opencv/opencv/blob/3.3.0-rc/modules/calib3d/src/solvepnp.cpp#L269) to `SOLVEPNP_EPNP` or `SOLVEPNP_P3P`, `SOLVEPNP_AP3P` by the user and is not used for the final call to `solvePnP`
 - with this PR, `useExtrinsicGuess` is used with `solvePnP` with all the inliers
 - document a little the behavior of `solvePnPRansac`
 - resolves #9085 there is an issue for me as the function returns the best `rvec` and `tvec` estimated during the Minimal Sample Sets step and not `rvec` and `tvec` estimated using all the inliers

Before this PR:
```
[----------] 3 tests from Calib3d_SolvePnPRansac
[ RUN      ] Calib3d_SolvePnPRansac.accuracy
mode: 0, method: 0 -> 100% (err < 5.08272e-06)
mode: 0, method: 1 -> 100% (err < 1.90336e-05)
mode: 0, method: 2 -> 100% (err < 6.83566e-05)
mode: 0, method: 3 -> 100% (err < 1.48587e-06)
mode: 0, method: 4 -> 100% (err < 3.88479e-05)
mode: 0, method: 5 -> 100% (err < 0.000988152)
mode: 1, method: 0 -> 100% (err < 0.000211219)
mode: 1, method: 1 -> 100% (err < 1.80233e-06)
mode: 1, method: 2 -> 100% (err < 1.70374e-05)
mode: 1, method: 3 -> 100% (err < 5.7117e-06)
mode: 1, method: 4 -> 100% (err < 5.93684e-06)
mode: 1, method: 5 -> 100% (err < 0.00151996)
[       OK ] Calib3d_SolvePnPRansac.accuracy (68 ms)
```

With this PR:
```
[----------] 3 tests from Calib3d_SolvePnPRansac
[ RUN      ] Calib3d_SolvePnPRansac.accuracy
mode: 0, method: 0 -> 100% (err < 1.15535e-07)
mode: 0, method: 1 -> 100% (err < 0.000260042)
mode: 0, method: 2 -> 100% (err < 0.00487855)
mode: 0, method: 3 -> 100% (err < 9.49898e-08)
mode: 0, method: 4 -> 90% (err < 0.0643757)
mode: 0, method: 5 -> 80% (err < 0.063708)
mode: 1, method: 0 -> 100% (err < 5.12943e-07)
mode: 1, method: 1 -> 100% (err < 1.98415e-07)
mode: 1, method: 2 -> 100% (err < 1.5598e-07)
mode: 1, method: 3 -> 100% (err < 0.00293191)
mode: 1, method: 4 -> 100% (err < 0.00293468)
mode: 1, method: 5 -> 100% (err < 0.000291018)
[       OK ] Calib3d_SolvePnPRansac.accuracy (76 ms)
```

At first sight, the accuracy is worse. But before the function returned the best `rvec` and `tvec` estimated during the Minimal Sample Sets step and now `rvec` and `tvec` estimated using all the inliers, the 
RANSAC parameters could be not optimal here.