### PR TITLE
core: get rid of OPENCV_NOSTL definition

### DIFF
--- a/modules/core/include/opencv2/core/cvstd.hpp
+++ b/modules/core/include/opencv2/core/cvstd.hpp
@@ -53,12 +53,9 @@
 #include <cstring>
 #include <cctype>
 
-#ifndef OPENCV_NOSTL
-#  include <string>
-#endif
+#include <string>
 
 // import useful primitives from stl
-#ifndef OPENCV_NOSTL_TRANSITIONAL
 #  include <algorithm>
 #  include <utility>
 #  include <cstdlib> //for abs(int)
@@ -80,21 +77,6 @@ namespace cv
     using std::pow;
     using std::log;
 }
-
-#else
-namespace cv
-{
-    template<typename T> static inline T min(T a, T b) { return a < b ? a : b; }
-    template<typename T> static inline T max(T a, T b) { return a > b ? a : b; }
-    template<typename T> static inline T abs(T a) { return a < 0 ? -a : a; }
-    template<typename T> static inline void swap(T& a, T& b) { T tmp = a; a = b; b = tmp; }
-
-    template<> inline uchar abs(uchar a) { return a; }
-    template<> inline ushort abs(ushort a) { return a; }
-    template<> inline unsigned abs(unsigned a) { return a; }
-    template<> inline uint64 abs(uint64 a) { return a; }
-}
-#endif
 
 namespace cv {
 
@@ -555,7 +537,6 @@ public:
 
     String toLowerCase() const;
 
-#ifndef OPENCV_NOSTL
     String(const std::string& str);
     String(const std::string& str, size_t pos, size_t len = npos);
     String& operator=(const std::string& str);
@@ -564,7 +545,6 @@ public:
 
     friend String operator+ (const String& lhs, const std::string& rhs);
     friend String operator+ (const std::string& lhs, const String& rhs);
-#endif
 
 private:
     char*  cstr_;
@@ -1049,21 +1029,10 @@ static inline bool operator>= (const String& lhs, const char*   rhs) { return lh
 
 } // cv
 
-#ifndef OPENCV_NOSTL_TRANSITIONAL
 namespace std
 {
     static inline void swap(cv::String& a, cv::String& b) { a.swap(b); }
 }
-#else
-namespace cv
-{
-    template<> inline
-    void swap<cv::String>(cv::String& a, cv::String& b)
-    {
-        a.swap(b);
-    }
-}
-#endif
 
 #include "opencv2/core/ptr.inl.hpp"
 

--- a/modules/core/include/opencv2/core/cvstd.inl.hpp
+++ b/modules/core/include/opencv2/core/cvstd.inl.hpp
@@ -44,10 +44,8 @@
 #ifndef OPENCV_CORE_CVSTDINL_HPP
 #define OPENCV_CORE_CVSTDINL_HPP
 
-#ifndef OPENCV_NOSTL
-#  include <complex>
-#  include <ostream>
-#endif
+#include <complex>
+#include <ostream>
 
 //! @cond IGNORED
 
@@ -58,7 +56,6 @@
 
 namespace cv
 {
-#ifndef OPENCV_NOSTL
 
 template<typename _Tp> class DataType< std::complex<_Tp> >
 {
@@ -280,7 +277,6 @@ static inline std::ostream& operator << (std::ostream& out, const MatSize& msize
     return out;
 }
 
-#endif // OPENCV_NOSTL
 } // cv
 
 #ifdef _MSC_VER

--- a/modules/core/include/opencv2/core/mat.hpp
+++ b/modules/core/include/opencv2/core/mat.hpp
@@ -2967,9 +2967,7 @@ public:
     typedef const uchar** pointer;
     typedef uchar* reference;
 
-#ifndef OPENCV_NOSTL
     typedef std::random_access_iterator_tag iterator_category;
-#endif
 
     //! default constructor
     MatConstIterator();
@@ -3034,9 +3032,7 @@ public:
     typedef const _Tp* pointer;
     typedef const _Tp& reference;
 
-#ifndef OPENCV_NOSTL
     typedef std::random_access_iterator_tag iterator_category;
-#endif
 
     //! default constructor
     MatConstIterator_();
@@ -3087,9 +3083,7 @@ public:
     typedef _Tp* pointer;
     typedef _Tp& reference;
 
-#ifndef OPENCV_NOSTL
     typedef std::random_access_iterator_tag iterator_category;
-#endif
 
     //! the default constructor
     MatIterator_();
@@ -3223,9 +3217,7 @@ template<typename _Tp> class SparseMatConstIterator_ : public SparseMatConstIter
 {
 public:
 
-#ifndef OPENCV_NOSTL
     typedef std::forward_iterator_tag iterator_category;
-#endif
 
     //! the default constructor
     SparseMatConstIterator_();
@@ -3259,9 +3251,7 @@ template<typename _Tp> class SparseMatIterator_ : public SparseMatConstIterator_
 {
 public:
 
-#ifndef OPENCV_NOSTL
     typedef std::forward_iterator_tag iterator_category;
-#endif
 
     //! the default constructor
     SparseMatIterator_();

--- a/modules/core/include/opencv2/core/persistence.hpp
+++ b/modules/core/include/opencv2/core/persistence.hpp
@@ -570,9 +570,7 @@ public:
     operator double() const;
     //! returns the node content as text string
     operator String() const;
-#ifndef OPENCV_NOSTL
     operator std::string() const;
-#endif
 
     //! returns pointer to the underlying file node
     CvFileNode* operator *();

--- a/modules/core/include/opencv2/core/utility.hpp
+++ b/modules/core/include/opencv2/core/utility.hpp
@@ -1022,7 +1022,6 @@ template<typename _Tp, size_t fixed_size> inline
 AutoBuffer<_Tp, fixed_size>::operator const _Tp* () const
 { return ptr; }
 
-#ifndef OPENCV_NOSTL
 template<> inline std::string CommandLineParser::get<std::string>(int index, bool space_delete) const
 {
     return get<String>(index, space_delete);
@@ -1031,7 +1030,6 @@ template<> inline std::string CommandLineParser::get<std::string>(const String& 
 {
     return get<String>(name, space_delete);
 }
-#endif // OPENCV_NOSTL
 
 //! @endcond
 

--- a/modules/photo/src/denoise_tvl1.cpp
+++ b/modules/photo/src/denoise_tvl1.cpp
@@ -56,21 +56,8 @@ namespace cv{
             double _scale;
     };
 
-#ifndef OPENCV_NOSTL
     using std::transform;
-#else
-    template <class InputIterator, class InputIterator2, class OutputIterator, class BinaryOperator>
-    static OutputIterator transform (InputIterator first1, InputIterator last1, InputIterator2 first2,
-                                     OutputIterator result, BinaryOperator binary_op)
-    {
-        while (first1 != last1)
-        {
-            *result = binary_op(*first1, *first2);
-            ++result; ++first1; ++first2;
-        }
-        return result;
-    }
-#endif
+
     void denoise_TVL1(const std::vector<Mat>& observations,Mat& result, double lambda, int niters){
 
         CV_Assert(observations.size()>0 && niters>0 && lambda>0);


### PR DESCRIPTION
`OPENCV_NOSTL` is completely useless since OpenCV uses `std::vector` and etc. and thus can't be built without STL.