### PR TITLE
ocl_calcHist1: Use proper local size for merge_histogram kernel

### DIFF
--- a/modules/imgproc/src/histogram.cpp
+++ b/modules/imgproc/src/histogram.cpp
@@ -1723,6 +1723,7 @@ static bool ocl_calcHist1(InputArray _src, OutputArray _hist, int ddepth = CV_32
     if (!k1.run(1, &globalsize, &wgs, false))
         return false;
 
+    wgs = std::min<size_t>(ocl::Device::getDefault().maxWorkGroupSize(), BINS);
     char cvt[40];
     ocl::Kernel k2("merge_histogram", ocl::imgproc::histogram_oclsrc,
                    format("-D BINS=%d -D HISTS_COUNT=%d -D WGS=%d -D convertToHT=%s -D HT=%s",


### PR DESCRIPTION
merge_histogram kernel only need "BINS" theads to accumulate the
histgrams, it is not efficient to directly use maxGroupSize as
local size if maxGroupSize is far greater then BINS.