### PR TITLE
videoio: fixes for GStreamer support

### DIFF
--- a/modules/videoio/test/test_mfx.cpp
+++ b/modules/videoio/test/test_mfx.cpp
@@ -71,14 +71,7 @@ const int FRAME_COUNT = 20;
 
 inline void generateFrame(int i, Mat & frame)
 {
-    frame = 0;
-    ostringstream buf; buf << "Frame " << setw(2) << setfill('0') << i + 1;
-    int baseLine = 0;
-    Size box = getTextSize(buf.str(), FONT_HERSHEY_COMPLEX, 2, 5, &baseLine);
-    putText(frame, buf.str(), Point((frame.cols - box.width) / 2, (frame.rows - box.height) / 2 + baseLine),
-            FONT_HERSHEY_COMPLEX, 2, Scalar(255, 255, 255), 5, LINE_AA);
-    Point p(i * frame.cols / (FRAME_COUNT - 1), i * frame.rows / (FRAME_COUNT - 1));
-    circle(frame, p, 20, Scalar(200, 25, 55), 5, LINE_AA);
+    generateFrame(i, FRAME_COUNT, frame);
 }
 
 inline int fourccByExt(const String &ext)

--- a/modules/videoio/test/test_precomp.hpp
+++ b/modules/videoio/test/test_precomp.hpp
@@ -33,14 +33,20 @@ inline void generateFrame(int i, int FRAME_COUNT, cv::Mat & frame)
 {
     using namespace cv;
     using namespace std;
-    frame = Scalar(30, 140, 10);
+    int offset = (((i * 5) % FRAME_COUNT) - FRAME_COUNT / 2) * (frame.cols / 2) / FRAME_COUNT;
+    frame(cv::Rect(0, 0, frame.cols / 2 + offset, frame.rows)) = Scalar(255, 255, 255);
+    frame(cv::Rect(frame.cols / 2 + offset, 0, frame.cols - frame.cols / 2 - offset, frame.rows)) = Scalar(0, 0, 0);
     ostringstream buf; buf << "Frame " << setw(2) << setfill('0') << i + 1;
     int baseLine = 0;
     Size box = getTextSize(buf.str(), FONT_HERSHEY_COMPLEX, 2, 5, &baseLine);
     putText(frame, buf.str(), Point((frame.cols - box.width) / 2, (frame.rows - box.height) / 2 + baseLine),
-            FONT_HERSHEY_COMPLEX, 2, Scalar(255, 255, 255), 5, LINE_AA);
+            FONT_HERSHEY_COMPLEX, 2, Scalar(0, 0, 255), 5, LINE_AA);
     Point p(i * frame.cols / (FRAME_COUNT - 1), i * frame.rows / (FRAME_COUNT - 1));
-    circle(frame, p, 20, Scalar(200, 25, 55), 5, LINE_AA);
+    circle(frame, p, 50, Scalar(200, 25, 55), 8, LINE_AA);
+#if 0
+    imshow("frame", frame);
+    waitKey();
+#endif
 }
 
 #endif


### PR DESCRIPTION
- emulated frame counter (with autodetection of GStreamer broken behavior)
- skip 'seek' tests if seeking is not supported by backend
- update 'fps' and total frames checks (increase error tolerance)
- update synthetic image generation