### PR TITLE
Suggests the cv::Rect() to be the identity under | operation

### DIFF
--- a/modules/core/include/opencv2/core/types.hpp
+++ b/modules/core/include/opencv2/core/types.hpp
@@ -1803,12 +1803,17 @@ Rect_<_Tp>& operator &= ( Rect_<_Tp>& a, const Rect_<_Tp>& b )
 template<typename _Tp> static inline
 Rect_<_Tp>& operator |= ( Rect_<_Tp>& a, const Rect_<_Tp>& b )
 {
-    _Tp x1 = std::min(a.x, b.x);
-    _Tp y1 = std::min(a.y, b.y);
-    a.width = std::max(a.x + a.width, b.x + b.width) - x1;
-    a.height = std::max(a.y + a.height, b.y + b.height) - y1;
-    a.x = x1;
-    a.y = y1;
+    if (!a.area()) {
+        a = b;
+    }
+    else if (b.area()) {
+        _Tp x1 = std::min(a.x, b.x);
+        _Tp y1 = std::min(a.y, b.y);
+        a.width = std::max(a.x + a.width, b.x + b.width) - x1;
+        a.height = std::max(a.y + a.height, b.y + b.height) - y1;
+        a.x = x1;
+        a.y = y1;
+    }
     return a;
 }
 


### PR DESCRIPTION
Please find the minimal nonworking example below:

```
#include <opencv2/core.hpp>
#include <cstdlib>
#include <random>
#include <cassert>

#include <iostream>


int main(int argc, char** argv) {
    using std::rand;

    // Check the monoid's identity laws for rect "union".
    cv::Rect id;
    cv::Rect x(rand(), rand(), rand(), rand());

    assert(("(id | x) == x", (id | x) == x));  // Failed.
    assert(("(x | id) == x", (x | id) == x));  // Failed.

    return EXIT_SUCCESS;
}
```
This commit fixes this bug.