### PR TITLE
Added support for thresholding CV_16U images.

### DIFF
--- a/modules/imgproc/src/thresh.cpp
+++ b/modules/imgproc/src/thresh.cpp
@@ -462,7 +462,7 @@ thresh_16u(const Mat& _src, Mat& _dst, ushort thresh, ushort maxval, int type)
 			}
 			break;
 		default:
-			CV_Error( CV_StsBadArg, "" ); return;
+			return CV_Error(CV_StsBadArg, "");
 		}
 	}
 }

--- a/modules/imgproc/src/thresh.cpp
+++ b/modules/imgproc/src/thresh.cpp
@@ -462,7 +462,7 @@ thresh_16u(const Mat& _src, Mat& _dst, ushort thresh, ushort maxval, int type)
 			}
 			break;
 		default:
-			return CV_Error(CV_StsBadArg, "");
+			CV_Error( CV_StsBadArg, "" ); return;
 		}
 	}
 }


### PR DESCRIPTION
I work a lot with images of type CV_64F and CV_16U. Unfortunatly many of OpenCV's functions do not have support for these types, which requires a lot of extra work.

This patch includes support for thresholding CV_16U images. There is no support for HAVE_TEGRA_OPTIMIZATION or HAVE_IPP, but CV_SIMD128 is implemented.

This pull request is mostly a test of how easy it is to get patches merged upstream :)