### PR TITLE
Fix msvc virtual destructor

### DIFF
--- a/modules/core/include/opencv2/core/bufferpool.hpp
+++ b/modules/core/include/opencv2/core/bufferpool.hpp
@@ -7,6 +7,11 @@
 #ifndef OPENCV_CORE_BUFFER_POOL_HPP
 #define OPENCV_CORE_BUFFER_POOL_HPP
 
+#ifdef _MSC_VER
+#pragma warning(push)
+#pragma warning(disable: 4265)
+#endif
+
 namespace cv
 {
 
@@ -27,5 +32,9 @@ public:
 //! @}
 
 }
+
+#ifdef _MSC_VER
+#pragma warning(pop)
+#endif
 
 #endif // OPENCV_CORE_BUFFER_POOL_HPP


### PR DESCRIPTION
BufferPoolController has a non virtual protected destructor (which is legitimate)

However, Visual Studio sees this as a bug, if you enable more warnings, like below (example with cmake)
```
add_compile_options(/W3)     # level 3 warnings
add_compile_options(/we4265) # warning about missing virtual destructors
```

This is a proposition in order to silence this warning.

See https://github.com/ivsgroup/boost_warnings_minimal_demo for a demo of the same problem
with boost/exception.hpp and Visual Studio 2015.

Hoping this will be useful