### PR TITLE
Fix draw contours

### DIFF
--- a/modules/imgproc/src/drawing.cpp
+++ b/modules/imgproc/src/drawing.cpp
@@ -2600,12 +2600,13 @@ cvDrawContours( void* _img, CvSeq* contour,
         void* clr = (contour->flags & CV_SEQ_FLAG_HOLE) == 0 ? ext_buf : hole_buf;
 
         cvStartReadSeq( contour, &reader, 0 );
-        CV_Assert(reader.ptr != NULL);
         if( thickness < 0 )
             pts.resize(0);
 
         if( CV_IS_SEQ_CHAIN_CONTOUR( contour ))
         {
+            CV_Assert(reader.ptr != NULL);
+
             cv::Point pt = ((CvChain*)contour)->origin;
             cv::Point prev_pt = pt;
             char prev_code = reader.ptr ? reader.ptr[0] : '\0';
@@ -2643,6 +2644,8 @@ cvDrawContours( void* _img, CvSeq* contour,
         }
         else if( CV_IS_SEQ_POLYLINE( contour ))
         {
+            CV_Assert(reader.ptr != NULL);
+
             CV_Assert( elem_type == CV_32SC2 );
             cv::Point pt1, pt2;
             int shift = 0;

--- a/modules/imgproc/test/test_contours.cpp
+++ b/modules/imgproc/test/test_contours.cpp
@@ -485,4 +485,21 @@ TEST(Imgproc_FindContours, border)
     ASSERT_TRUE(norm(img - img_draw_contours, NORM_INF) == 0.0);
 }
 
+TEST(Imgproc_drawContours, regression_empty)
+{
+    Mat mat = Mat::zeros(Size(640,480), CV_8UC1);
+    std::vector< std::vector<Point> > contours(5);
+
+    for (size_t i = 0; i < contours.size(); i++)
+    {
+        // One contour is "empty"
+        for (size_t j = 0; j < (unsigned)std::max(0, (int)i - 3); j++)
+        {
+            contours[i].push_back(cv::Point((int)(i + j + 10), (int)(i - j + 10)));
+        }
+    }
+
+    ASSERT_NO_THROW(drawContours(mat, contours, -1, cv::Scalar(0), CV_FILLED, 8));
+}
+
 /* End of file. */


### PR DESCRIPTION
Restored old behavior without throwing an exception.

Perhaps we should warn user/developer about invalid data and throw exceptions anyway. So this PR should be closed.