### PR TITLE
ipp(minmaxIdx): disable SSE4.2 optimizations for 32f datatype

### DIFF
--- a/modules/core/include/opencv2/core/private.hpp
+++ b/modules/core/include/opencv2/core/private.hpp
@@ -209,6 +209,8 @@ CV_EXPORTS void scalarToRawData(const cv::Scalar& s, void* buf, int type, int un
 #define IPP_DISABLE_RESIZE_NEAREST      1 // Accuracy mismatch (max diff 1)
 #define IPP_DISABLE_RESIZE_AREA         1 // Accuracy mismatch (max diff 1)
 
+#define IPP_DISABLE_MINMAX_NAN_SSE42    1 // cv::minMaxIdx problem with NaN input
+
 // Temporary disabled named IPP region. Performance
 #define IPP_DISABLE_PERF_COPYMAKE       1 // performance variations
 #define IPP_DISABLE_PERF_LUT            1 // there are no performance benefits (PR #2653)

--- a/modules/core/src/stat.cpp
+++ b/modules/core/src/stat.cpp
@@ -2534,6 +2534,12 @@ static bool ipp_minMaxIdx(Mat &src, double* _minVal, double* _maxVal, int* _minI
 #if IPP_VERSION_X100 >= 700
     CV_INSTRUMENT_REGION_IPP()
 
+#if IPP_DISABLE_MINMAX_NAN_SSE42
+    // Disable 32F processing only
+    if(src.depth() == CV_32F && !(ipp::getIppFeatures()&ippCPUID_AVX))
+        return false;
+#endif
+
     IppStatus   status;
     IppDataType dataType = ippiGetDataType(src.depth());
     float       minVal = 0;


### PR DESCRIPTION
Workaround for NaN values handling issue