### PR TITLE
core(test): fix input data for OCL FP16 test

### DIFF
--- a/modules/core/test/ocl/test_arithm.cpp
+++ b/modules/core/test/ocl/test_arithm.cpp
@@ -1639,6 +1639,14 @@ PARAM_TEST_CASE(ConvertFp16, Channels, bool)
         Size roiSize = randomSize(1, MAX_VALUE);
         Border srcBorder = randomBorder(0, 0);
         randomSubMat(src, src_roi, roiSize, srcBorder, stype, -11, 11); // FIXIT: Test with minV, maxV
+        if (stype == CV_MAKE_TYPE(CV_16S, cn)) // eliminate NaN/Inf FP16 values
+        {
+            RNG dataRng(rng.next());
+            Mat src_i32 = cvtest::randomMat(dataRng, roiSize, CV_MAKE_TYPE(CV_32S, cn), 0, 0x7c00, false);
+            Mat shift_i32 = cvtest::randomMat(dataRng, roiSize, src_i32.type(), -1, 1, false); // values: -1, 0
+            src_i32 = src_i32 + (shift_i32 * 0x8000);
+            src_i32.convertTo(src_roi, stype);
+        }
 
         Border dstBorder = randomBorder(0, 0);
         randomSubMat(dst, dst_roi, roiSize, dstBorder, dtype, 5, 16);


### PR DESCRIPTION
resolves #9148