### PR TITLE
dshow: Only show debugging messages if environment variable is set

### DIFF
--- a/modules/videoio/src/cap_dshow.cpp
+++ b/modules/videoio/src/cap_dshow.cpp
@@ -337,11 +337,17 @@ interface ISampleGrabber : public IUnknown
 #ifdef _DEBUG
 #include <strsafe.h>
 
-//change for verbose debug info
-static bool gs_verbose = true;
-
 static void DebugPrintOut(const char *format, ...)
 {
+    static int gs_verbose = -1;
+    if (gs_verbose < 0)
+    {
+        // Fetch initial debug state from environment - defaults to disabled
+        const char* s = getenv("OPENCV_DSHOW_DEBUG");
+        gs_verbose = s != NULL && atoi(s) != 0;
+    }
+
+
     if (gs_verbose)
     {
         va_list args;
@@ -486,9 +492,6 @@ class videoInput{
     public:
         videoInput();
         ~videoInput();
-
-        //turns off console messages - default is to print messages
-        static void setVerbose(bool _verbose);
 
         //Functions in rough order they should be used.
         static int listDevices(bool silent = false);
@@ -1118,20 +1121,6 @@ videoInput::videoInput(){
     formatTypes[VI_SECAM_K1]    = AnalogVideo_SECAM_K1;
     formatTypes[VI_SECAM_L]     = AnalogVideo_SECAM_L;
 
-}
-
-
-// ----------------------------------------------------------------------
-// static - set whether messages get printed to console or not
-//
-// ----------------------------------------------------------------------
-
-void videoInput::setVerbose(bool _verbose){
-#ifdef _DEBUG
-    gs_verbose = _verbose;
-#else
-    (void)_verbose; // Suppress 'unreferenced parameter' warning
-#endif
 }
 
 // ----------------------------------------------------------------------


### PR DESCRIPTION
This will change the DirectShow input module so that it will only display debugging messages if the environment variable OPENCV_DSHOW_SHOW_DEBUG is explicitly set to non-zero.

Only debug mode is affected by this change; the messages are never visible in release mode anyway.

Based on discussion at: https://github.com/opencv/opencv/pull/9051

resolves #8926