### PR TITLE
build: added DEBUG build guard (cv::debug_build_guard::_InputArray error LNK2019)

### DIFF
--- a/modules/core/include/opencv2/core/cvdef.h
+++ b/modules/core/include/opencv2/core/cvdef.h
@@ -48,6 +48,23 @@
 //! @addtogroup core_utils
 //! @{
 
+#if !defined CV_DOXYGEN && !defined CV_IGNORE_DEBUG_BUILD_GUARD
+#if (defined(_MSC_VER) && (defined(DEBUG) || defined(_DEBUG))) || \
+    (defined(_GLIBCXX_DEBUG) || defined(_GLIBCXX_DEBUG_PEDANTIC))
+// Guard to prevent using of binary incompatible binaries / runtimes
+// https://github.com/opencv/opencv/pull/9161
+#define CV__DEBUG_NS_BEGIN namespace debug_build_guard {
+#define CV__DEBUG_NS_END }
+namespace cv { namespace debug_build_guard { } using namespace debug_build_guard; }
+#endif
+#endif
+
+#ifndef CV__DEBUG_NS_BEGIN
+#define CV__DEBUG_NS_BEGIN
+#define CV__DEBUG_NS_END
+#endif
+
+
 #ifdef __OPENCV_BUILD
 #include "cvconfig.h"
 #endif

--- a/modules/core/include/opencv2/core/mat.hpp
+++ b/modules/core/include/opencv2/core/mat.hpp
@@ -62,6 +62,8 @@ namespace cv
 enum { ACCESS_READ=1<<24, ACCESS_WRITE=1<<25,
     ACCESS_RW=3<<24, ACCESS_MASK=ACCESS_RW, ACCESS_FAST=1<<26 };
 
+CV__DEBUG_NS_BEGIN
+
 class CV_EXPORTS _OutputArray;
 
 //////////////////////// Input/Output Array Arguments /////////////////////////////////
@@ -399,6 +401,8 @@ public:
 #endif
 
 };
+
+CV__DEBUG_NS_END
 
 typedef const _InputArray& InputArray;
 typedef InputArray InputArrayOfArrays;

--- a/modules/core/include/opencv2/core/mat.inl.hpp
+++ b/modules/core/include/opencv2/core/mat.inl.hpp
@@ -56,6 +56,8 @@
 
 namespace cv
 {
+CV__DEBUG_NS_BEGIN
+
 
 //! @cond IGNORED
 
@@ -391,6 +393,8 @@ inline _InputOutputArray::_InputOutputArray(const ogl::Buffer& buf)
 
 inline _InputOutputArray::_InputOutputArray(const cuda::HostMem& cuda_mem)
 { init(FIXED_TYPE + FIXED_SIZE + CUDA_HOST_MEM + ACCESS_RW, &cuda_mem); }
+
+CV__DEBUG_NS_END
 
 //////////////////////////////////////////// Mat //////////////////////////////////////////
 


### PR DESCRIPTION
To prevent linkage of binary incompatible DEBUG/RELEASE binaries/runtimes.

resolves #5227
resolves #6070

It is [hard to debug](https://github.com/opencv/opencv/issues/5227#issuecomment-267056761) this kind of issues. Application just crash / hangs without any useful information from debugger.

- This patch doesn't change release builds
- Minimal set of entities are wrapped: "InputArray" types subset, but it is enough to catch problem configuration.
- It prevents to link OpenCV RELEASE binaries with Applications in DEBUG mode (MSVS or GCC with `_GLIBCXX_DEBUG` macro).
- This check doesn't require using of CMake scripts.
- Error message example from linker:
> error LNK2019: unresolved external symbol "void __cdecl cv::cvtColor(class cv::debug_build_guard::_InputArray const &,class cv::debug_build_guard::_OutputArray const &,int,int)"

> error LNK2019: unresolved external symbol "void __cdecl cv::imshow(class cv::String const &,class cv::debug_build_guard::_InputArray const &)"

There is a special marker in these messages: **debug_build_guard** / **cv::debug_build_guard::_InputArray** .
If you see this then you should get debug version of OpenCV binaries or switch your application build mode to "release".
BTW, you can improve experience of "release builds" debugging by using of these safe hacks:
- enable debug information: /Z7 compiler option works fine for MSVS
- disable optimization flags (/O2 -> /O0 for MSVS)