### PR TITLE
photo: crash workaround for MSVC 2015 32-bit

### DIFF
--- a/modules/photo/src/fast_nlmeans_denoising_invoker.hpp
+++ b/modules/photo/src/fast_nlmeans_denoising_invoker.hpp
@@ -205,6 +205,10 @@ void FastNlMeansDenoisingInvoker<T, IT, UIT, D, WT>::operator() (const Range& ra
                         const T * b_up_ptr = extended_src_.ptr<T>(start_by - template_window_half_size_ - 1 + y);
                         const T * b_down_ptr = extended_src_.ptr<T>(start_by + template_window_half_size_ + y);
 
+// MSVC 2015 generates unaligned destination for "movaps" instruction for 32-bit builds
+#if defined _MSC_VER && _MSC_VER == 1900 && !defined _WIN64
+#pragma loop(no_vector)
+#endif
                         for (int x = 0; x < search_window_size; x++)
                         {
                             // remove from current pixel sum column sum with index "first_col_num"


### PR DESCRIPTION
Workaround for MSVC 2015 32-bit compiler bug.

[Win32 nightly build](http://pullrequest.opencv.org/buildbot/builders/master_noICV-win32-vc14/builds/10160):
```
[ RUN      ] OCL_Photo/FastNlMeansDenoising.Mat/2
unknown file: error: SEH exception with code 0xc0000005 thrown in the test body.
[  FAILED  ] OCL_Photo/FastNlMeansDenoising.Mat/2, where GetParam() = (Channels(1), 2, false, true) (467 ms)
[ RUN      ] OCL_Photo/FastNlMeansDenoising.Mat/3
unknown file: error: SEH exception with code 0xc0000005 thrown in the test body.
[  FAILED  ] OCL_Photo/FastNlMeansDenoising.Mat/3, where GetParam() = (Channels(1), 2, true, true) (41 ms)
```

[Validated](http://pullrequest.opencv.org/buildbot/builders/master_noICV-win32-vc14/builds/10161)