### PR TITLE
stitching(perf): check for available OpenCL memory

### DIFF
--- a/modules/stitching/perf/opencl/perf_stitch.cpp
+++ b/modules/stitching/perf/opencl/perf_stitch.cpp
@@ -101,6 +101,9 @@ OCL_PERF_TEST_P(stitch, b12, TEST_DETECTORS)
 
 OCL_PERF_TEST_P(stitch, boat, TEST_DETECTORS)
 {
+    Size expected_dst_size(10789, 2663);
+    checkDeviceMaxMemoryAllocSize(expected_dst_size, CV_16SC3, 4);
+
     UMat pano;
 
     vector<Mat> _imgs;
@@ -132,8 +135,8 @@ OCL_PERF_TEST_P(stitch, boat, TEST_DETECTORS)
         stopTimer();
     }
 
-    EXPECT_NEAR(pano.size().width, 10789, 200);
-    EXPECT_NEAR(pano.size().height, 2663, 100);
+    EXPECT_NEAR(pano.size().width, expected_dst_size.width, 200);
+    EXPECT_NEAR(pano.size().height, expected_dst_size.height, 100);
 
     SANITY_CHECK_NOTHING();
 }


### PR DESCRIPTION
Don't run tests if there is no enough memory.

```
[ RUN      ] OCL_stitch_boat.boat/0
OpenCV Error: Assertion failed (retval == CL_SUCCESS) in cv::ocl::OpenCLBufferPoolImpl::_allocateBufferEntry, file C:\build\master_noICV-win32-vc14\opencv\modules\core\src\ocl.cpp, line 2934
OpenCV Error: Insufficient memory (Failed to allocate 173924352 bytes) in cv::OutOfMemoryError, file C:\build\master_noICV-win32-vc14\opencv\modules\core\src\alloc.cpp, line 52
```
