### PR TITLE
Fix Halide performance test

### DIFF
--- a/modules/dnn/perf/perf_halide_net.cpp
+++ b/modules/dnn/perf/perf_halide_net.cpp
@@ -83,7 +83,7 @@ PERF_TEST(ResNet50, HalidePerfTest)
 PERF_TEST(SqueezeNet_v1_1, HalidePerfTest)
 {
     Net net;
-    loadNet("dnn/squeezenet_v1_1.caffemodel", "dnn/squeezenet_v1_1.prototxt",
+    loadNet("dnn/squeezenet_v1.1.caffemodel", "dnn/squeezenet_v1.1.prototxt",
             "dnn/halide_scheduler_squeezenet_v1_1.yml", 227, 227, "prob",
             "caffe", DNN_TARGET_CPU, &net);
     TEST_CYCLE() net.forward();
@@ -144,7 +144,7 @@ PERF_TEST(ResNet50_opencl, HalidePerfTest)
 PERF_TEST(SqueezeNet_v1_1_opencl, HalidePerfTest)
 {
     Net net;
-    loadNet("dnn/squeezenet_v1_1.caffemodel", "dnn/squeezenet_v1_1.prototxt",
+    loadNet("dnn/squeezenet_v1.1.caffemodel", "dnn/squeezenet_v1.1.prototxt",
             "dnn/halide_scheduler_opencl_squeezenet_v1_1.yml", 227, 227, "prob",
             "caffe", DNN_TARGET_OPENCL, &net);
     TEST_CYCLE() net.forward();

--- a/modules/ts/src/ts_perf.cpp
+++ b/modules/ts/src/ts_perf.cpp
@@ -197,6 +197,10 @@ void Regression::init(const std::string& testSuitName, const std::string& ext)
 #else
     const char *data_path_dir = OPENCV_TEST_DATA_PATH;
 #endif
+
+    cvtest::addDataSearchSubDirectory("");
+    cvtest::addDataSearchSubDirectory(testSuitName);
+
     const char *path_separator = "/";
 
     if (data_path_dir)


### PR DESCRIPTION
**Merge with extra**: https://github.com/opencv/opencv_extra/pull/355

SqueezeNet in Halide performance test (model name from `squeezenet_v1_1` to `squeezenet_v1.1`).
