### PR TITLE
Fix WinRT build

### DIFF
--- a/3rdparty/openvx/hal/openvx_hal.cpp
+++ b/3rdparty/openvx/hal/openvx_hal.cpp
@@ -59,7 +59,7 @@ inline ivx::Context& getOpenVXHALContext()
     static thread_local ivx::Context instance = ivx::Context::create();
 #else //__cplusplus >= 201103L || _MSC_VER >= 1800
     //CXX98
-#ifdef WIN32
+#ifdef _WIN32
         static __declspec(thread) ivx::Context instance = ivx::Context::create();
 #else
         static __thread ivx::Context instance = ivx::Context::create();

--- a/cmake/checks/cpu_neon.cpp
+++ b/cmake/checks/cpu_neon.cpp
@@ -1,6 +1,6 @@
 #include <stdio.h>
 
-#if (defined WIN32 || defined _WIN32) && defined(_M_ARM)
+#if defined _WIN32 && defined(_M_ARM)
 # include <Intrin.h>
 # include <arm_neon.h>
 # define CV_NEON 1

--- a/modules/core/include/opencv2/core/cv_cpu_dispatch.h
+++ b/modules/core/include/opencv2/core/cv_cpu_dispatch.h
@@ -86,7 +86,7 @@
 #  define CV_FMA3 1
 #endif
 
-#if (defined WIN32 || defined _WIN32) && defined(_M_ARM)
+#if defined _WIN32 && defined(_M_ARM)
 # include <Intrin.h>
 # include <arm_neon.h>
 # define CV_NEON 1
@@ -128,7 +128,7 @@ struct VZeroUpperGuard {
 #  define CV_MMX 1
 #  define CV_SSE 1
 #  define CV_SSE2 1
-#elif (defined WIN32 || defined _WIN32) && defined(_M_ARM)
+#elif defined _WIN32 && defined(_M_ARM)
 # include <Intrin.h>
 # include <arm_neon.h>
 # define CV_NEON 1

--- a/modules/core/include/opencv2/core/cvdef.h
+++ b/modules/core/include/opencv2/core/cvdef.h
@@ -244,7 +244,7 @@ Cv64suf;
 #  define DISABLE_OPENCV_24_COMPATIBILITY
 #endif
 
-#if (defined WIN32 || defined _WIN32 || defined WINCE || defined __CYGWIN__) && defined CVAPI_EXPORTS
+#if (defined _WIN32 || defined WINCE || defined __CYGWIN__) && defined CVAPI_EXPORTS
 #  define CV_EXPORTS __declspec(dllexport)
 #elif defined __GNUC__ && __GNUC__ >= 4
 #  define CV_EXPORTS __attribute__ ((visibility ("default")))

--- a/modules/core/include/opencv2/core/opencl/runtime/opencl_clamdblas.hpp
+++ b/modules/core/include/opencv2/core/opencl/runtime/opencl_clamdblas.hpp
@@ -45,7 +45,7 @@
 #ifdef HAVE_CLAMDBLAS
 
 #ifndef CL_RUNTIME_EXPORT
-#if (defined(BUILD_SHARED_LIBS) || defined(OPENCV_CORE_SHARED)) && (defined WIN32 || defined _WIN32 || defined WINCE)
+#if (defined(BUILD_SHARED_LIBS) || defined(OPENCV_CORE_SHARED)) && (defined _WIN32 || defined WINCE)
 #define CL_RUNTIME_EXPORT __declspec(dllimport)
 #else
 #define CL_RUNTIME_EXPORT

--- a/modules/core/include/opencv2/core/opencl/runtime/opencl_clamdfft.hpp
+++ b/modules/core/include/opencv2/core/opencl/runtime/opencl_clamdfft.hpp
@@ -45,7 +45,7 @@
 #ifdef HAVE_CLAMDFFT
 
 #ifndef CL_RUNTIME_EXPORT
-#if (defined(BUILD_SHARED_LIBS) || defined(OPENCV_CORE_SHARED)) && (defined WIN32 || defined _WIN32 || defined WINCE)
+#if (defined(BUILD_SHARED_LIBS) || defined(OPENCV_CORE_SHARED)) && (defined _WIN32 || defined WINCE)
 #define CL_RUNTIME_EXPORT __declspec(dllimport)
 #else
 #define CL_RUNTIME_EXPORT

--- a/modules/core/include/opencv2/core/opencl/runtime/opencl_core.hpp
+++ b/modules/core/include/opencv2/core/opencl/runtime/opencl_core.hpp
@@ -55,7 +55,7 @@
 #else // HAVE_OPENCL_STATIC
 
 #ifndef CL_RUNTIME_EXPORT
-#if (defined(BUILD_SHARED_LIBS) || defined(OPENCV_CORE_SHARED)) && (defined WIN32 || defined _WIN32 || defined WINCE)
+#if (defined(BUILD_SHARED_LIBS) || defined(OPENCV_CORE_SHARED)) && (defined _WIN32 || defined WINCE)
 #define CL_RUNTIME_EXPORT __declspec(dllimport)
 #else
 #define CL_RUNTIME_EXPORT

--- a/modules/core/include/opencv2/core/types_c.h
+++ b/modules/core/include/opencv2/core/types_c.h
@@ -46,7 +46,7 @@
 
 #ifdef HAVE_IPL
 #  ifndef __IPL_H__
-#    if defined WIN32 || defined _WIN32
+#    if defined _WIN32
 #      include <ipl.h>
 #    else
 #      include <ipl/ipl.h>
@@ -65,7 +65,7 @@
 #include <float.h>
 #endif // SKIP_INCLUDES
 
-#if defined WIN32 || defined _WIN32
+#if defined _WIN32
 #  define CV_CDECL __cdecl
 #  define CV_STDCALL __stdcall
 #else

--- a/modules/core/src/alloc.cpp
+++ b/modules/core/src/alloc.cpp
@@ -55,7 +55,7 @@ static void* OutOfMemoryError(size_t size)
 
 #if CV_USE_SYSTEM_MALLOC
 
-#if defined WIN32 || defined _WIN32
+#if defined _WIN32
 void deleteThreadAllocData() {}
 #endif
 
@@ -93,7 +93,7 @@ void fastFree(void* ptr)
 
 #define STAT(stmt)
 
-#ifdef WIN32
+#ifdef _WIN32
 #if (_WIN32_WINNT >= 0x0602)
 #include <synchapi.h>
 #endif
@@ -126,7 +126,7 @@ void SystemFree(void* ptr, size_t)
 {
     free(ptr);
 }
-#else //WIN32
+#else //_WIN32
 
 #include <sys/mman.h>
 
@@ -155,7 +155,7 @@ void SystemFree(void* ptr, size_t size)
 {
     munmap(ptr, size);
 }
-#endif //WIN32
+#endif //_WIN32
 
 struct AutoLock
 {
@@ -399,7 +399,7 @@ struct ThreadData
 
     Block* bins[MAX_BIN+1][3];
 
-#ifdef WIN32
+#ifdef _WIN32
 #ifdef WINCE
 #   define TLS_OUT_OF_INDEXES ((DWORD)0xFFFFFFFF)
 #endif //WINCE
@@ -418,7 +418,7 @@ struct ThreadData
         }
         return data;
     }
-#else //WIN32
+#else //_WIN32
     static void deleteData(void* data)
     {
         delete (ThreadData*)data;
@@ -438,10 +438,10 @@ struct ThreadData
         }
         return data;
     }
-#endif //WIN32
+#endif //_WIN32
 };
 
-#ifdef WIN32
+#ifdef _WIN32
 DWORD ThreadData::tlsKey = TLS_OUT_OF_INDEXES;
 
 void deleteThreadAllocData()
@@ -450,9 +450,9 @@ void deleteThreadAllocData()
         delete (ThreadData*)TlsGetValue( ThreadData::tlsKey );
 }
 
-#else //WIN32
+#else //_WIN32
 pthread_key_t ThreadData::tlsKey = 0;
-#endif //WIN32
+#endif //_WIN32
 
 #if 0
 static void checkList(ThreadData* tls, int idx)

--- a/modules/core/src/glob.cpp
+++ b/modules/core/src/glob.cpp
@@ -42,7 +42,7 @@
 
 #include "precomp.hpp"
 
-#if defined WIN32 || defined _WIN32 || defined WINCE
+#if defined _WIN32 || defined WINCE
 # include <windows.h>
 const char dir_separators[] = "/\\";
 const char native_separator = '\\';
@@ -139,7 +139,7 @@ const char native_separator = '/';
 
 static bool isDir(const cv::String& path, DIR* dir)
 {
-#if defined WIN32 || defined _WIN32 || defined WINCE
+#if defined _WIN32 || defined WINCE
     DWORD attributes;
     BOOL status = TRUE;
     if (dir)

--- a/modules/core/src/ocl_deprecated.hpp
+++ b/modules/core/src/ocl_deprecated.hpp
@@ -578,7 +578,7 @@ static void* initOpenCLAndLoad(const char* funcname)
     return funcname && handle ? dlsym(handle, funcname) : 0;
 }
 
-#elif (defined WIN32 || defined _WIN32) && defined(HAVE_OPENCL)
+#elif defined _WIN32 && defined(HAVE_OPENCL)
 
 #ifndef _WIN32_WINNT           // This is needed for the declaration of TryEnterCriticalSection in winbase.h with Visual Studio 2005 (and older?)
   #define _WIN32_WINNT 0x0400  // http://msdn.microsoft.com/en-us/library/ms686857(VS.85).aspx

--- a/modules/core/src/opengl.cpp
+++ b/modules/core/src/opengl.cpp
@@ -1655,7 +1655,7 @@ Context& initializeContextFromGL()
 
         cl_context_properties properties[] =
         {
-#if defined(WIN32) || defined(_WIN32)
+#if defined(_WIN32)
             CL_CONTEXT_PLATFORM, (cl_context_properties)platforms[i],
             CL_GL_CONTEXT_KHR, (cl_context_properties)wglGetCurrentContext(),
             CL_WGL_HDC_KHR, (cl_context_properties)wglGetCurrentDC(),

--- a/modules/core/src/parallel.cpp
+++ b/modules/core/src/parallel.cpp
@@ -44,7 +44,7 @@
 
 #include <opencv2/core/utils/trace.private.hpp>
 
-#if defined WIN32 || defined WINCE
+#if defined _WIN32 || defined WINCE
     #include <windows.h>
     #undef small
     #undef min
@@ -632,7 +632,7 @@ static inline int getNumberOfCPUsImpl()
 
 int cv::getNumberOfCPUs(void)
 {
-#if defined WIN32 || defined _WIN32
+#if defined _WIN32
     SYSTEM_INFO sysinfo;
 #if (defined(_M_ARM) || defined(_M_X64) || defined(WINRT)) && _WIN32_WINNT >= 0x501
     GetNativeSystemInfo( &sysinfo );

--- a/modules/core/src/precomp.hpp
+++ b/modules/core/src/precomp.hpp
@@ -148,7 +148,7 @@ BinaryFunc getCopyMaskFunc(size_t esz);
 /* maximal average node_count/hash_size ratio beyond which hash table is resized */
 #define  CV_SPARSE_HASH_RATIO    3
 
-#if defined WIN32 || defined _WIN32
+#if defined _WIN32
 void deleteThreadAllocData();
 #endif
 
@@ -288,7 +288,7 @@ struct CoreTLSData
 TLSData<CoreTLSData>& getCoreTlsData();
 
 #if defined(BUILD_SHARED_LIBS)
-#if defined WIN32 || defined _WIN32 || defined WINCE
+#if defined _WIN32 || defined WINCE
 #define CL_RUNTIME_EXPORT __declspec(dllexport)
 #elif defined __GNUC__ && __GNUC__ >= 4
 #define CL_RUNTIME_EXPORT __attribute__ ((visibility ("default")))

--- a/modules/core/src/rand.cpp
+++ b/modules/core/src/rand.cpp
@@ -48,14 +48,12 @@
 
 #include "precomp.hpp"
 
-#if defined WIN32 || defined WINCE
+#if defined _WIN32 || defined WINCE
     #include <windows.h>
     #undef small
     #undef min
     #undef max
     #undef abs
-#else
-    #include <pthread.h>
 #endif
 
 #if defined __SSE2__ || (defined _M_IX86_FP && 2 == _M_IX86_FP)

--- a/modules/core/src/system.cpp
+++ b/modules/core/src/system.cpp
@@ -79,7 +79,7 @@ Mutex* __initialization_mutex_initializer = &getInitializationMutex();
 #  include <cpu-features.h>
 #endif
 
-#if defined WIN32 || defined _WIN32 || defined WINCE
+#if defined _WIN32 || defined WINCE
 #ifndef _WIN32_WINNT           // This is needed for the declaration of TryEnterCriticalSection in winbase.h with Visual Studio 2005 (and older?)
   #define _WIN32_WINNT 0x0400  // http://msdn.microsoft.com/en-us/library/ms686857(VS.85).aspx
 #endif
@@ -655,7 +655,7 @@ bool useOptimized(void)
 
 int64 getTickCount(void)
 {
-#if defined WIN32 || defined _WIN32 || defined WINCE
+#if defined _WIN32 || defined WINCE
     LARGE_INTEGER counter;
     QueryPerformanceCounter( &counter );
     return (int64)counter.QuadPart;
@@ -675,7 +675,7 @@ int64 getTickCount(void)
 
 double getTickFrequency(void)
 {
-#if defined WIN32 || defined _WIN32 || defined WINCE
+#if defined _WIN32 || defined WINCE
     LARGE_INTEGER freq;
     QueryPerformanceFrequency(&freq);
     return (double)freq.QuadPart;
@@ -737,7 +737,7 @@ int64 getCPUTickCount(void)
 
 #endif
 
-#elif defined _MSC_VER && defined WIN32 && defined _M_IX86
+#elif defined _MSC_VER && defined _WIN32 && defined _M_IX86
 
 int64 getCPUTickCount(void)
 {
@@ -799,7 +799,7 @@ String tempfile( const char* suffix )
     const char *temp_dir = getenv("OPENCV_TEMP_PATH");
 #endif
 
-#if defined WIN32 || defined _WIN32
+#if defined _WIN32
 #ifdef WINRT
     RoInitialize(RO_INIT_MULTITHREADED);
     std::wstring temp_dir = GetTempPathWinRT();
@@ -1124,7 +1124,7 @@ bool __termination = false;
 namespace cv
 {
 
-#if defined WIN32 || defined _WIN32 || defined WINCE
+#if defined _WIN32 || defined WINCE
 
 struct Mutex::Impl
 {
@@ -1210,7 +1210,7 @@ bool Mutex::trylock() { return impl->trylock(); }
 
 //////////////////////////////// thread-local storage ////////////////////////////////
 
-#ifdef WIN32
+#ifdef _WIN32
 #ifdef _MSC_VER
 #pragma warning(disable:4505) // unreferenced local function has been removed
 #endif
@@ -1229,16 +1229,16 @@ public:
     void  SetData(void *pData);
 
 private:
-#ifdef WIN32
+#ifdef _WIN32
 #ifndef WINRT
     DWORD tlsKey;
 #endif
-#else // WIN32
+#else // _WIN32
     pthread_key_t  tlsKey;
 #endif
 };
 
-#ifdef WIN32
+#ifdef _WIN32
 #ifdef WINRT
 static __declspec( thread ) void* tlsData = NULL; // using C++11 thread attribute for local thread data
 TlsAbstraction::TlsAbstraction() {}
@@ -1270,7 +1270,7 @@ void  TlsAbstraction::SetData(void *pData)
     CV_Assert(TlsSetValue(tlsKey, pData) == TRUE);
 }
 #endif
-#else // WIN32
+#else // _WIN32
 TlsAbstraction::TlsAbstraction()
 {
     CV_Assert(pthread_key_create(&tlsKey, NULL) == 0);
@@ -1511,7 +1511,7 @@ TLSData<CoreTLSData>& getCoreTlsData()
     CV_SINGLETON_LAZY_INIT_REF(TLSData<CoreTLSData>, new TLSData<CoreTLSData>())
 }
 
-#if defined CVAPI_EXPORTS && defined WIN32 && !defined WINCE
+#if defined CVAPI_EXPORTS && defined _WIN32 && !defined WINCE
 #ifdef WINRT
     #pragma warning(disable:4447) // Disable warning 'main' signature found without threading model
 #endif

--- a/modules/cudacodec/perf/perf_video.cpp
+++ b/modules/cudacodec/perf/perf_video.cpp
@@ -88,7 +88,7 @@ PERF_TEST_P(FileName, VideoReader, Values("gpu/video/768x576.avi", "gpu/video/19
 //////////////////////////////////////////////////////
 // VideoWriter
 
-#if defined(HAVE_NVCUVID) && defined(WIN32)
+#if defined(HAVE_NVCUVID) && defined(_WIN32)
 
 PERF_TEST_P(FileName, VideoWriter, Values("gpu/video/768x576.avi", "gpu/video/1920x1080.avi"))
 {

--- a/modules/cudacodec/src/ffmpeg_video_source.cpp
+++ b/modules/cudacodec/src/ffmpeg_video_source.cpp
@@ -61,7 +61,7 @@ namespace
 
         if (!initialized)
         {
-            #if defined WIN32 || defined _WIN32
+            #if defined _WIN32
                 const char* module_name = "opencv_ffmpeg"
                     CVAUX_STR(CV_VERSION_MAJOR) CVAUX_STR(CV_VERSION_MINOR) CVAUX_STR(CV_VERSION_REVISION)
                 #if (defined _MSC_VER && defined _M_X64) || (defined __GNUC__ && defined __x86_64__)

--- a/modules/cudacodec/src/precomp.hpp
+++ b/modules/cudacodec/src/precomp.hpp
@@ -58,7 +58,7 @@
 #ifdef HAVE_NVCUVID
     #include <nvcuvid.h>
 
-    #ifdef WIN32
+    #ifdef _WIN32
         #define NOMINMAX
         #include <windows.h>
         #ifdef HAVE_NVCUVENC

--- a/modules/cudacodec/src/thread.cpp
+++ b/modules/cudacodec/src/thread.cpp
@@ -47,7 +47,7 @@
 
 using namespace cv::cudacodec::detail;
 
-#ifdef WIN32
+#ifdef _WIN32
 
 namespace
 {
@@ -160,7 +160,7 @@ void cv::cudacodec::detail::Thread::wait()
 
 void cv::cudacodec::detail::Thread::sleep(int ms)
 {
-#ifdef WIN32
+#ifdef _WIN32
     ::Sleep(ms);
 #else
     ::usleep(ms * 1000);

--- a/modules/cudacodec/src/video_writer.cpp
+++ b/modules/cudacodec/src/video_writer.cpp
@@ -47,7 +47,7 @@ using namespace cv;
 using namespace cv::cuda;
 using namespace cv::cudacodec;
 
-#if !defined(HAVE_NVCUVENC) || !defined(WIN32)
+#if !defined(HAVE_NVCUVENC) || !defined(_WIN32)
 
 cv::cudacodec::EncoderParams::EncoderParams() { throw_no_cuda(); }
 cv::cudacodec::EncoderParams::EncoderParams(const String&) { throw_no_cuda(); }
@@ -60,7 +60,7 @@ Ptr<VideoWriter> cv::cudacodec::createVideoWriter(const String&, Size, double, c
 Ptr<VideoWriter> cv::cudacodec::createVideoWriter(const Ptr<EncoderCallBack>&, Size, double, SurfaceFormat) { throw_no_cuda(); return Ptr<VideoWriter>(); }
 Ptr<VideoWriter> cv::cudacodec::createVideoWriter(const Ptr<EncoderCallBack>&, Size, double, const EncoderParams&, SurfaceFormat) { throw_no_cuda(); return Ptr<VideoWriter>(); }
 
-#else // !defined HAVE_NVCUVENC || !defined WIN32
+#else // !defined HAVE_NVCUVENC || !defined _WIN32
 
 void RGB_to_YV12(const GpuMat& src, GpuMat& dst);
 
@@ -731,7 +731,7 @@ namespace
 
         if (!initialized)
         {
-            #if defined(WIN32) || defined(_WIN32)
+            #if defined(_WIN32)
                 const char* module_name = "opencv_ffmpeg"
                     CVAUX_STR(CV_VERSION_MAJOR) CVAUX_STR(CV_VERSION_MINOR) CVAUX_STR(CV_VERSION_REVISION)
                 #if (defined _MSC_VER && defined _M_X64) || (defined __GNUC__ && defined __x86_64__)
@@ -913,4 +913,4 @@ Ptr<VideoWriter> cv::cudacodec::createVideoWriter(const Ptr<EncoderCallBack>& en
     return makePtr<VideoWriterImpl>(encoderCallback, frameSize, fps, params, format);
 }
 
-#endif // !defined HAVE_NVCUVENC || !defined WIN32
+#endif // !defined HAVE_NVCUVENC || !defined _WIN32

--- a/modules/cudacodec/test/test_video.cpp
+++ b/modules/cudacodec/test/test_video.cpp
@@ -71,7 +71,7 @@ CUDA_TEST_P(Video, Reader)
 //////////////////////////////////////////////////////
 // VideoWriter
 
-#ifdef WIN32
+#ifdef _WIN32
 
 CUDA_TEST_P(Video, Writer)
 {
@@ -116,7 +116,7 @@ CUDA_TEST_P(Video, Writer)
     }
 }
 
-#endif // WIN32
+#endif // _WIN32
 
 INSTANTIATE_TEST_CASE_P(CUDA_Codec, Video, testing::Combine(
     ALL_DEVICES,

--- a/modules/flann/include/opencv2/flann/defines.h
+++ b/modules/flann/include/opencv2/flann/defines.h
@@ -35,7 +35,7 @@
 #ifdef FLANN_EXPORT
 #undef FLANN_EXPORT
 #endif
-#ifdef WIN32
+#ifdef _WIN32
 /* win32 dll export/import directives */
  #ifdef FLANN_EXPORTS
   #define FLANN_EXPORT __declspec(dllexport)

--- a/modules/flann/include/opencv2/flann/dist.h
+++ b/modules/flann/include/opencv2/flann/dist.h
@@ -43,7 +43,7 @@ typedef unsigned __int64 uint64_t;
 
 #include "defines.h"
 
-#if (defined WIN32 || defined _WIN32) && defined(_M_ARM)
+#if defined _WIN32 && defined(_M_ARM)
 # include <Intrin.h>
 #endif
 

--- a/modules/flann/include/opencv2/flann/dummy.h
+++ b/modules/flann/include/opencv2/flann/dummy.h
@@ -5,7 +5,7 @@
 namespace cvflann
 {
 
-#if (defined WIN32 || defined _WIN32 || defined WINCE) && defined CVAPI_EXPORTS
+#if (defined _WIN32 || defined WINCE) && defined CVAPI_EXPORTS
 __declspec(dllexport)
 #endif
 void dummyfunc();

--- a/modules/highgui/include/opencv2/highgui/highgui_c.h
+++ b/modules/highgui/include/opencv2/highgui/highgui_c.h
@@ -239,7 +239,7 @@ CVAPI(void) cvUpdateWindow(const char* window_name);
 #define set_preprocess_func cvSetPreprocessFuncWin32
 #define set_postprocess_func cvSetPostprocessFuncWin32
 
-#if defined WIN32 || defined _WIN32
+#if defined _WIN32
 
 CVAPI(void) cvSetPreprocessFuncWin32_(const void* callback);
 CVAPI(void) cvSetPostprocessFuncWin32_(const void* callback);

--- a/modules/highgui/src/precomp.hpp
+++ b/modules/highgui/src/precomp.hpp
@@ -60,7 +60,7 @@
 #include <ctype.h>
 #include <assert.h>
 
-#if defined WIN32 || defined WINCE
+#if defined _WIN32 || defined WINCE
     #include <windows.h>
     #undef small
     #undef min

--- a/modules/highgui/src/window_QT.cpp
+++ b/modules/highgui/src/window_QT.cpp
@@ -351,7 +351,7 @@ CV_IMPL int cvWaitKey(int delay)
 
                 //to decrease CPU usage
                 //sleep 1 millisecond
-#if defined WIN32 || defined _WIN32 || defined WIN64 || defined _WIN64
+#if defined _WIN32
                 Sleep(1);
 #else
                 usleep(1000);

--- a/modules/highgui/src/window_gtk.cpp
+++ b/modules/highgui/src/window_gtk.cpp
@@ -42,7 +42,7 @@
 #include "precomp.hpp"
 #include "opencv2/imgproc.hpp"
 
-#ifndef WIN32
+#ifndef _WIN32
 
 #if defined (HAVE_GTK)
 
@@ -2097,6 +2097,6 @@ CV_IMPL int cvWaitKey( int delay )
 
 
 #endif  // HAVE_GTK
-#endif  // WIN32
+#endif  // _WIN32
 
 /* End of file. */

--- a/modules/highgui/src/window_w32.cpp
+++ b/modules/highgui/src/window_w32.cpp
@@ -42,7 +42,7 @@
 #include "precomp.hpp"
 #include <windowsx.h> // required for GET_X_LPARAM() and GET_Y_LPARAM() macros
 
-#if defined WIN32 || defined _WIN32
+#if defined _WIN32
 
 #ifdef __GNUC__
 #  pragma GCC diagnostic ignored "-Wmissing-declarations"
@@ -2426,4 +2426,4 @@ cvSetPostprocessFuncWin32_(const void* callback)
     hg_on_postprocess = (CvWin32WindowCallback)callback;
 }
 
-#endif //WIN32
+#endif //_WIN32

--- a/modules/imgcodecs/src/grfmt_jpeg.cpp
+++ b/modules/imgcodecs/src/grfmt_jpeg.cpp
@@ -57,14 +57,14 @@
 #define mingw_getsp(...) 0
 #define __builtin_frame_address(...) 0
 
-#ifdef WIN32
+#ifdef _WIN32
 
 #define XMD_H // prevent redefinition of INT32
 #undef FAR  // prevent FAR redefinition
 
 #endif
 
-#if defined WIN32 && defined __GNUC__
+#if defined _WIN32 && defined __GNUC__
 typedef unsigned char boolean;
 #endif
 

--- a/modules/imgcodecs/src/grfmt_jpeg2000.cpp
+++ b/modules/imgcodecs/src/grfmt_jpeg2000.cpp
@@ -47,7 +47,7 @@
 #include "grfmt_jpeg2000.hpp"
 #include "opencv2/imgproc.hpp"
 
-#ifdef WIN32
+#ifdef _WIN32
 #define JAS_WIN_MSVC_BUILD 1
 #ifdef __GNUC__
 #define HAVE_STDINT_H 1
@@ -160,7 +160,7 @@ bool  Jpeg2KDecoder::readData( Mat& img )
     jas_stream_t* stream = (jas_stream_t*)m_stream;
     jas_image_t* image = (jas_image_t*)m_image;
 
-#ifndef WIN32
+#ifndef _WIN32
     // At least on some Linux instances the
     // system libjasper segfaults when
     // converting color to grey.
@@ -272,7 +272,7 @@ bool  Jpeg2KDecoder::readData( Mat& img )
 
     close();
 
-#ifndef WIN32
+#ifndef _WIN32
     if (!clr.empty())
     {
         cv::cvtColor(clr, img, COLOR_BGR2GRAY);

--- a/modules/imgcodecs/src/grfmt_tiff.cpp
+++ b/modules/imgcodecs/src/grfmt_tiff.cpp
@@ -732,7 +732,7 @@ bool  TiffEncoder::write( const Mat& img, const std::vector<int>& /*params*/)
     if( m_buf )
         m_buf->reserve( alignSize(stripCount*8 + fileStep*height + 256, 256) );
 
-/*#if defined _DEBUG || !defined WIN32
+/*#if defined _DEBUG || !defined _WIN32
     int uncompressedRowSize = rowsPerStrip * fileStep;
 #endif*/
     int directoryOffset = 0;

--- a/modules/imgcodecs/src/precomp.hpp
+++ b/modules/imgcodecs/src/precomp.hpp
@@ -58,7 +58,7 @@
 #include <ctype.h>
 #include <assert.h>
 
-#if defined WIN32 || defined WINCE
+#if defined _WIN32 || defined WINCE
     #include <windows.h>
     #undef small
     #undef min

--- a/modules/ts/src/ts.cpp
+++ b/modules/ts/src/ts.cpp
@@ -47,7 +47,7 @@
 #include <stdlib.h>
 #include <fcntl.h>
 #include <time.h>
-#if defined WIN32 || defined _WIN32 || defined WIN64 || defined _WIN64
+#if defined _WIN32
 #include <io.h>
 
 #include <windows.h>
@@ -67,7 +67,7 @@
 #endif
 
 // isDirectory
-#if defined WIN32 || defined _WIN32 || defined WINCE
+#if defined _WIN32 || defined WINCE
 # include <windows.h>
 #else
 # include <dirent.h>
@@ -100,7 +100,7 @@ static std::string path_join(const std::string& prefix, const std::string& subpa
 
 // a few platform-dependent declarations
 
-#if defined WIN32 || defined _WIN32 || defined WIN64 || defined _WIN64
+#if defined _WIN32
 #ifdef _MSC_VER
 static void SEHTranslator( unsigned int /*u*/, EXCEPTION_POINTERS* pExp )
 {
@@ -236,7 +236,7 @@ void BaseTest::safe_run( int start_from )
     {
         try
         {
-        #if !defined WIN32 && !defined _WIN32
+        #if !defined _WIN32
         int _code = setjmp( tsJmpMark );
         if( !_code )
             run( start_from );
@@ -491,7 +491,7 @@ void TS::init( const string& modulename )
 
     if( ::testing::GTEST_FLAG(catch_exceptions) )
     {
-#if defined WIN32 || defined _WIN32
+#if defined _WIN32
 #ifdef _MSC_VER
         _set_se_translator( SEHTranslator );
 #endif
@@ -502,7 +502,7 @@ void TS::init( const string& modulename )
     }
     else
     {
-#if defined WIN32 || defined _WIN32
+#if defined _WIN32
 #ifdef _MSC_VER
         _set_se_translator( 0 );
 #endif
@@ -722,7 +722,7 @@ void parseCustomOptions(int argc, char **argv)
 
 static bool isDirectory(const std::string& path)
 {
-#if defined WIN32 || defined _WIN32 || defined WINCE
+#if defined _WIN32 || defined WINCE
     WIN32_FILE_ATTRIBUTE_DATA all_attrs;
 #ifdef WINRT
     wchar_t wpath[MAX_PATH];

--- a/modules/ts/src/ts_perf.cpp
+++ b/modules/ts/src/ts_perf.cpp
@@ -4,7 +4,7 @@
 #include <iostream>
 #include <fstream>
 
-#if defined WIN32 || defined _WIN32 || defined WIN64 || defined _WIN64
+#if defined _WIN32
 #ifndef NOMINMAX
 #define NOMINMAX
 #endif
@@ -1430,7 +1430,7 @@ bool TestBase::next()
                         CV_TRACE_REGION("idle_delay");
                         printf("Performance is unstable, it may be a result of overheat problems\n");
                         printf("Idle delay for %d ms... \n", perf_validation_idle_delay_ms);
-#if defined WIN32 || defined _WIN32 || defined WIN64 || defined _WIN64
+#if defined _WIN32
 #ifndef WINRT_8_0
                         Sleep(perf_validation_idle_delay_ms);
 #else

--- a/modules/video/test/test_camshift.cpp
+++ b/modules/video/test/test_camshift.cpp
@@ -346,7 +346,7 @@ _exit_:
 
     if( code < 0 )
     {
-#if 0 //defined _DEBUG && defined WIN32
+#if 0 //defined _DEBUG && defined _WIN32
         IplImage* dst = cvCreateImage( img_size, 8, 3 );
         cvNamedWindow( "test", 1 );
         cvCmpS( img, 0, img, CV_CMP_GT );
@@ -485,7 +485,7 @@ _exit_:
 
     if( code < 0 )
     {
-#if 0// defined _DEBUG && defined WIN32
+#if 0// defined _DEBUG && defined _WIN32
         IplImage* dst = cvCreateImage( img_size, 8, 3 );
         cvNamedWindow( "test", 1 );
         cvCmpS( img, 0, img, CV_CMP_GT );

--- a/modules/videoio/src/cap_cmu.cpp
+++ b/modules/videoio/src/cap_cmu.cpp
@@ -41,7 +41,7 @@
 
 #include "precomp.hpp"
 
-#ifdef WIN32
+#ifdef _WIN32
 
 /****************** Capturing video from camera via CMU lib *******************/
 
@@ -548,4 +548,4 @@ CvCapture * cvCreateCameraCapture_CMU (int index)
 }
 
 #endif // CMU
-#endif // WIN32
+#endif // _WIN32

--- a/modules/videoio/src/cap_dc1394.cpp
+++ b/modules/videoio/src/cap_dc1394.cpp
@@ -97,7 +97,7 @@ Tested with 2.6.12 with libdc1394-1.0.0, libraw1394-0.10.1 using a Point Grey Fl
 
 #include "precomp.hpp"
 
-#if !defined WIN32 && defined HAVE_DC1394
+#if !defined _WIN32 && defined HAVE_DC1394
 
 #include <unistd.h>
 #include <stdint.h>

--- a/modules/videoio/src/cap_dc1394_v2.cpp
+++ b/modules/videoio/src/cap_dc1394_v2.cpp
@@ -45,7 +45,7 @@
 
 #include <unistd.h>
 #include <stdint.h>
-#ifdef WIN32
+#ifdef _WIN32
   // On Windows, we have no sys/select.h, but we need to pick up
   // select() which is in winsock2.
   #ifndef __SYS_SELECT_H__
@@ -54,7 +54,7 @@
   #endif
 #else
   #include <sys/select.h>
-#endif /*WIN32*/
+#endif /*_WIN32*/
 #include <dc1394/dc1394.h>
 #include <stdlib.h>
 #include <string.h>

--- a/modules/videoio/src/cap_dshow.cpp
+++ b/modules/videoio/src/cap_dshow.cpp
@@ -41,7 +41,7 @@
 
 #include "precomp.hpp"
 
-#if (defined WIN32 || defined _WIN32) && defined HAVE_DSHOW
+#if defined _WIN32 && defined HAVE_DSHOW
 #include "cap_dshow.hpp"
 
 /*

--- a/modules/videoio/src/cap_ffmpeg.cpp
+++ b/modules/videoio/src/cap_ffmpeg.cpp
@@ -43,7 +43,7 @@
 
 #include <string>
 
-#if defined HAVE_FFMPEG && !defined WIN32
+#if defined HAVE_FFMPEG && !defined _WIN32
 #include "cap_ffmpeg_impl.hpp"
 #else
 #include "cap_ffmpeg_api.hpp"
@@ -61,7 +61,7 @@ static CvWriteFrame_Plugin icvWriteFrame_FFMPEG_p = 0;
 
 static cv::Mutex _icvInitFFMPEG_mutex;
 
-#if defined WIN32 || defined _WIN32
+#if defined _WIN32
 static const HMODULE cv_GetCurrentModule()
 {
     HMODULE h = 0;
@@ -84,7 +84,7 @@ public:
     }
 
 private:
-    #if defined WIN32 || defined _WIN32
+    #if defined _WIN32
     HMODULE icvFFOpenCV;
 
     ~icvInitFFMPEG()
@@ -99,7 +99,7 @@ private:
 
     icvInitFFMPEG()
     {
-    #if defined WIN32 || defined _WIN32
+    #if defined _WIN32
         const wchar_t* module_name_ = L"opencv_ffmpeg"
             CVAUX_STRW(CV_MAJOR_VERSION) CVAUX_STRW(CV_MINOR_VERSION) CVAUX_STRW(CV_SUBMINOR_VERSION)
         #if (defined _MSC_VER && defined _M_X64) || (defined __GNUC__ && defined __x86_64__)

--- a/modules/videoio/src/cap_ffmpeg_api.hpp
+++ b/modules/videoio/src/cap_ffmpeg_api.hpp
@@ -6,7 +6,7 @@ extern "C"
 {
 #endif
 
-#if defined WIN32 || defined _WIN32
+#if defined _WIN32
 #   define OPENCV_FFMPEG_API __declspec(dllexport)
 #elif defined __GNUC__ && __GNUC__ >= 4
 #   define OPENCV_FFMPEG_API __attribute__ ((visibility ("default")))

--- a/modules/videoio/src/cap_ffmpeg_impl.hpp
+++ b/modules/videoio/src/cap_ffmpeg_impl.hpp
@@ -41,7 +41,7 @@
 //M*/
 
 #include "cap_ffmpeg_api.hpp"
-#if !(defined(WIN32) || defined(_WIN32) || defined(WINCE))
+#if !(defined(_WIN32) || defined(WINCE))
 # include <pthread.h>
 #endif
 #include <assert.h>
@@ -92,7 +92,7 @@ extern "C" {
 #define CV_WARN(message) fprintf(stderr, "warning: %s (%s:%d)\n", message, __FILE__, __LINE__)
 #endif
 
-#if defined WIN32 || defined _WIN32
+#if defined _WIN32
     #include <windows.h>
     #if defined _MSC_VER && _MSC_VER < 1900
     struct timespec
@@ -172,7 +172,7 @@ extern "C" {
 #define LIBAVFORMAT_INTERRUPT_OPEN_TIMEOUT_MS 30000
 #define LIBAVFORMAT_INTERRUPT_READ_TIMEOUT_MS 30000
 
-#ifdef WIN32
+#ifdef _WIN32
 // http://stackoverflow.com/questions/5404277/porting-clock-gettime-to-windows
 
 static
@@ -289,7 +289,7 @@ static int get_number_of_cpus(void)
 {
 #if LIBAVFORMAT_BUILD < CALC_FFMPEG_VERSION(52, 111, 0)
     return 1;
-#elif defined WIN32 || defined _WIN32
+#elif defined _WIN32
     SYSTEM_INFO sysinfo;
     GetSystemInfo( &sysinfo );
 
@@ -584,7 +584,7 @@ private:
     ImplMutex& operator = (const ImplMutex& m);
 };
 
-#if defined WIN32 || defined _WIN32 || defined WINCE
+#if defined _WIN32 || defined WINCE
 
 struct ImplMutex::Impl
 {

--- a/modules/videoio/src/cap_giganetix.cpp
+++ b/modules/videoio/src/cap_giganetix.cpp
@@ -48,7 +48,7 @@
 #include <GigEVisionSDK.h>
 #include <GigEVisionSDK.cpp>
 
-#ifdef WIN32
+#ifdef _WIN32
 #include <io.h>
 #else
 #include <stdio.h>

--- a/modules/videoio/src/cap_gphoto2.cpp
+++ b/modules/videoio/src/cap_gphoto2.cpp
@@ -1184,7 +1184,7 @@ void DigitalCameraCapture::message(MsgType msgType, const char * msg,
         msgsBuffer << out;
     }
 #if !defined(NDEBUG)
-#if defined(WIN32) || defined(_WIN32)
+#if defined(_WIN32)
     ::OutputDebugString(out.c_str());
 #else
     fputs(out.c_str(), stderr);

--- a/modules/videoio/src/cap_libv4l.cpp
+++ b/modules/videoio/src/cap_libv4l.cpp
@@ -239,7 +239,7 @@ make & enjoy!
 
 #include "precomp.hpp"
 
-#if !defined WIN32 && defined HAVE_LIBV4L
+#if !defined _WIN32 && defined HAVE_LIBV4L
 
 #define CLEAR(x) memset (&(x), 0, sizeof (x))
 

--- a/modules/videoio/src/cap_msmf.cpp
+++ b/modules/videoio/src/cap_msmf.cpp
@@ -39,7 +39,7 @@
 //
 //M*/
 #include "precomp.hpp"
-#if (defined WIN32 || defined _WIN32) && defined HAVE_MSMF
+#if defined _WIN32 && defined HAVE_MSMF
 /*
    Media Foundation-based Video Capturing module is based on
    videoInput library by Evgeny Pereguda:

--- a/modules/videoio/src/cap_pvapi.cpp
+++ b/modules/videoio/src/cap_pvapi.cpp
@@ -46,7 +46,7 @@
 #include "precomp.hpp"
 
 #ifdef HAVE_PVAPI
-#if !defined WIN32 && !defined _WIN32 && !defined _LINUX
+#if !defined _WIN32 && !defined _LINUX
 #define _LINUX
 #endif
 
@@ -57,7 +57,7 @@
 #endif
 
 #include <PvApi.h>
-#ifdef WIN32
+#ifdef _WIN32
 #  include <io.h>
 #else
 #  include <time.h>
@@ -91,7 +91,7 @@ public:
     }
 
 protected:
-#ifndef WIN32
+#ifndef _WIN32
     virtual void Sleep(unsigned int time);
 #endif
 
@@ -118,7 +118,7 @@ CvCaptureCAM_PvAPI::CvCaptureCAM_PvAPI()
     memset(&this->Camera, 0, sizeof(this->Camera));
 }
 
-#ifndef WIN32
+#ifndef _WIN32
 void CvCaptureCAM_PvAPI::Sleep(unsigned int time)
 {
     struct timespec t,r;

--- a/modules/videoio/src/cap_v4l.cpp
+++ b/modules/videoio/src/cap_v4l.cpp
@@ -209,7 +209,7 @@ make & enjoy!
 
 #include "precomp.hpp"
 
-#if !defined WIN32 && (defined HAVE_CAMV4L2 || defined HAVE_VIDEOIO)
+#if !defined _WIN32 && (defined HAVE_CAMV4L2 || defined HAVE_VIDEOIO)
 
 #include <stdio.h>
 #include <unistd.h>

--- a/modules/videoio/src/cap_ximea.cpp
+++ b/modules/videoio/src/cap_ximea.cpp
@@ -1,7 +1,7 @@
 
 #include "precomp.hpp"
 
-#ifdef WIN32
+#ifdef _WIN32
 #include <xiApi.h>
 #else
 #include <m3api/xiApi.h>
@@ -55,7 +55,7 @@ CvCapture* cvCreateCameraCapture_XIMEA( int index )
 // Enumerate connected devices
 void CvCaptureCAM_XIMEA::init()
 {
-#if defined WIN32 || defined _WIN32
+#if defined _WIN32
     xiGetNumberDevices( &numDevices);
 #else
     // try second re-enumeration if first one fails
@@ -84,7 +84,7 @@ bool CvCaptureCAM_XIMEA::open( int wIndex )
 
     if((mvret = xiOpenDevice( wIndex, &hmv)) != XI_OK)
     {
-#if defined WIN32 || defined _WIN32
+#if defined _WIN32
         errMsg("Open XI_DEVICE failed", mvret);
         return false;
 #else
@@ -1751,7 +1751,7 @@ void CvCaptureCAM_XIMEA::errMsg(const char* msg, int errNum) const
         error_message = "Unknown error value";
     }
 
-    #if defined WIN32 || defined _WIN32
+    #if defined _WIN32
     char buf[512]="";
     sprintf( buf, "%s : %d, %s\n", msg, errNum, error_message.c_str());
     OutputDebugString(buf);

--- a/modules/videoio/src/ffmpeg_codecs.hpp
+++ b/modules/videoio/src/ffmpeg_codecs.hpp
@@ -44,7 +44,7 @@
 extern "C" {
 #endif
 
-#if !defined(WIN32) || defined(__MINGW32__)
+#if !defined(_WIN32) || defined(__MINGW32__)
 // some versions of FFMPEG assume a C99 compiler, and don't define INT64_C
 #include <stdint.h>
 

--- a/modules/videoio/src/precomp.hpp
+++ b/modules/videoio/src/precomp.hpp
@@ -61,7 +61,7 @@
 #include <ctype.h>
 #include <assert.h>
 
-#if defined WIN32 || defined WINCE
+#if defined _WIN32 || defined WINCE
     #if !defined _WIN32_WINNT
         #ifdef HAVE_MSMF
             #define _WIN32_WINNT 0x0600 // Windows Vista

--- a/platforms/winrt/setup_winrt.ps1
+++ b/platforms/winrt/setup_winrt.ps1
@@ -58,8 +58,8 @@ Param(
     [parameter(Mandatory=$False)]
     [String]
     [ValidateNotNull()]
-    [ValidateSet("Visual Studio 12 2013","Visual Studio 11 2012")]
-    $GENERATOR = "Visual Studio 12 2013",
+    [ValidateSet("Visual Studio 15 2017","Visual Studio 14 2015","Visual Studio 12 2013","Visual Studio 11 2012")]
+    $GENERATOR = "Visual Studio 15 2017",
 
     [parameter(Mandatory=$False)]
     [String]
@@ -168,11 +168,11 @@ Function Execute() {
     $versions = New-Object System.Collections.ArrayList
     $VERSIONS_IN.Split("," ,[System.StringSplitOptions]::RemoveEmptyEntries) | ForEach {
         $_ = $_.Trim()
-        if ("8.0","8.1" -Contains $_) {
+        if ("8.0","8.1","10.0" -Contains $_) {
             [void]$versions.Add($_)
             D "$_ is valid"
         } else {
-            Throw "$($_) is not valid! Please use 8.0, 8.1"
+            Throw "$($_) is not valid! Please use 8.0, 8.1, 10.0"
         }
     }
     D "Processed Versions: $versions"
@@ -345,7 +345,7 @@ Function ShowHelp() {
     Write-Host "     setup_winrt -b 'WP' 'x86,ARM' -test PERF "
     Write-Host "     setup_winrt -architecture x86 -platform WP "
     Write-Host "     setup_winrt -arc x86 -plat 'WP,WS' "
-    Write-Host "     setup_winrt -a x86 -g 'Visual Studio 11 2012' -pl WP "
+    Write-Host "     setup_winrt -a x86 -g 'Visual Studio 15 2017' -pl WP "
     Write-Host " WHERE: "
     Write-Host "     options -  Options to call "
     Write-Host "                 -h: diplays command line help "
@@ -358,7 +358,7 @@ Function ShowHelp() {
     Write-Host "     version - Array of platform versions. "
     Write-Host "                 Default: 8.1 "
     Write-Host "                 Example: '8.0,8.1' "
-    Write-Host "                 Options: 8.0, 8.1. Available options may be limited depending on your local setup (e.g. SDK availability). "
+    Write-Host "                 Options: 8.0, 8.1, 10.0. Available options may be limited depending on your local setup (e.g. SDK availability). "
     Write-Host "                 Note that you'll need to use quotes to specify more than one version. "
     Write-Host "     architecture - Array of target architectures to build for. "
     Write-Host "                 Default: x86 "

--- a/samples/cpp/detect_mser.cpp
+++ b/samples/cpp/detect_mser.cpp
@@ -6,7 +6,7 @@
 #include <map>
 #include <iostream>
 #ifdef HAVE_OPENGL
-#ifdef WIN32
+#ifdef _WIN32
 #define WIN32_LEAN_AND_MEAN 1
 #define NOMINMAX 1
 #include <windows.h>

--- a/samples/gpu/opengl.cpp
+++ b/samples/gpu/opengl.cpp
@@ -1,11 +1,8 @@
 #include <iostream>
 
-#ifdef WIN32
+#ifdef _WIN32
     #define WIN32_LEAN_AND_MEAN 1
     #define NOMINMAX 1
-    #include <windows.h>
-#endif
-#if defined(_WIN64)
     #include <windows.h>
 #endif
 

--- a/samples/gpu/stereo_multi.cpp
+++ b/samples/gpu/stereo_multi.cpp
@@ -1,7 +1,7 @@
 // This sample demonstrates working on one piece of data using two GPUs.
 // It splits input into two parts and processes them separately on different GPUs.
 
-#ifdef WIN32
+#ifdef _WIN32
     #define NOMINMAX
     #include <windows.h>
 #else
@@ -25,7 +25,7 @@ using namespace cv::cuda;
 // Thread
 // OS-specific wrappers for multi-threading
 
-#ifdef WIN32
+#ifdef _WIN32
 class Thread
 {
     struct UserData

--- a/samples/gpu/video_writer.cpp
+++ b/samples/gpu/video_writer.cpp
@@ -2,7 +2,7 @@
 
 #include "opencv2/opencv_modules.hpp"
 
-#if defined(HAVE_OPENCV_CUDACODEC) && defined(WIN32)
+#if defined(HAVE_OPENCV_CUDACODEC) && defined(_WIN32)
 
 #include <vector>
 #include <numeric>

--- a/samples/opengl/opengl_interop.cpp
+++ b/samples/opengl/opengl_interop.cpp
@@ -5,7 +5,7 @@
 // and call cv::Blur function. The result is mapped back to OpenGL texture
 // and rendered through OpenGL API.
 */
-#if defined(WIN32) || defined(_WIN32)
+#if defined(_WIN32)
 # define WIN32_LEAN_AND_MEAN
 # include <windows.h>
 #elif defined(__linux__)
@@ -27,7 +27,7 @@
 
 #include "winapp.hpp"
 
-#if defined(WIN32) || defined(_WIN32)
+#if defined(_WIN32)
 # pragma comment(lib, "opengl32.lib")
 # pragma comment(lib, "glu32.lib")
 #endif
@@ -74,7 +74,7 @@ public:
         WinApp::cleanup();
     }
 
-#if defined(WIN32) || defined(_WIN32)
+#if defined(_WIN32)
     virtual LRESULT CALLBACK WndProc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam)
     {
         switch (message)
@@ -169,7 +169,7 @@ public:
 
     int init()
     {
-#if defined(WIN32) || defined(_WIN32)
+#if defined(_WIN32)
         m_hDC = GetDC(m_hWnd);
 
         if (setup_pixel_format() != 0)
@@ -219,7 +219,7 @@ public:
 
     void print_info(MODE mode, float time, cv::String& oclDevName)
     {
-#if defined(WIN32) || defined(_WIN32)
+#if defined(_WIN32)
         HDC hDC = m_hDC;
 
         HFONT hFont = (HFONT)::GetStockObject(SYSTEM_FONT);
@@ -323,7 +323,7 @@ public:
             glTexCoord2f(1.0f, 0.0f); glVertex3f(1.0f, 1.0f, 0.1f);
             glEnd();
 
-#if defined(WIN32) || defined(_WIN32)
+#if defined(_WIN32)
             SwapBuffers(m_hDC);
 #elif defined(__linux__)
             glXSwapBuffers(m_display, m_window);
@@ -394,7 +394,7 @@ protected:
         m_timer.stop();
     }
 
-#if defined(WIN32) || defined(_WIN32)
+#if defined(_WIN32)
     int setup_pixel_format()
     {
         PIXELFORMATDESCRIPTOR  pfd;
@@ -459,7 +459,7 @@ private:
     bool               m_demo_processing;
     MODE               m_mode;
     cv::String         m_modeStr[2];
-#if defined(WIN32) || defined(_WIN32)
+#if defined(_WIN32)
     HDC                m_hDC;
     HGLRC              m_hRC;
 #elif defined(__linux__)
@@ -524,7 +524,7 @@ int main(int argc, char** argv)
     int width  = (int)cap.get(CAP_PROP_FRAME_WIDTH);
     int height = (int)cap.get(CAP_PROP_FRAME_HEIGHT);
 
-#if defined(WIN32) || defined(_WIN32)
+#if defined(_WIN32)
     string wndname = "WGL Window";
 #elif defined(__linux__)
     string wndname = "GLX Window";

--- a/samples/opengl/winapp.hpp
+++ b/samples/opengl/winapp.hpp
@@ -1,4 +1,4 @@
-#if defined(WIN32) || defined(_WIN32)
+#if defined(_WIN32)
 # define WIN32_LEAN_AND_MEAN
 # include <windows.h>
 #elif defined(__linux__)
@@ -10,13 +10,13 @@
 #include <string>
 
 #include <GL/gl.h>
-#if defined(WIN32) || defined(_WIN32)
+#if defined(_WIN32)
 # include <GL/glu.h>
 #elif defined(__linux__)
 # include <GL/glx.h>
 #endif
 
-#if defined(WIN32) || defined(_WIN32)
+#if defined(_WIN32)
 # define WINCLASS "WinAppWnd"
 #endif
 
@@ -78,21 +78,21 @@ public:
         m_width       = width;
         m_height      = height;
         m_window_name = window_name;
-#if defined(WIN32) || defined(_WIN32)
+#if defined(_WIN32)
         m_hInstance   = ::GetModuleHandle(NULL);
 #endif
     }
 
     virtual ~WinApp()
     {
-#if defined(WIN32) || defined(_WIN32)
+#if defined(_WIN32)
         ::UnregisterClass(WINCLASS, m_hInstance);
 #endif
     }
 
     int create()
     {
-#if defined(WIN32) || defined(_WIN32)
+#if defined(_WIN32)
         WNDCLASSEX wcex;
 
         wcex.cbSize        = sizeof(WNDCLASSEX);
@@ -166,7 +166,7 @@ public:
 
     virtual void cleanup()
     {
-#if defined(WIN32) || defined(_WIN32)
+#if defined(_WIN32)
         ::DestroyWindow(m_hWnd);
 #elif defined(__linux__)
         XDestroyWindow(m_display, m_window);
@@ -174,13 +174,13 @@ public:
 #endif
     }
 
-#if defined(WIN32) || defined(_WIN32)
+#if defined(_WIN32)
     virtual LRESULT CALLBACK WndProc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam) = 0;
 #endif
 
     int run()
     {
-#if defined(WIN32) || defined(_WIN32)
+#if defined(_WIN32)
         MSG msg;
 
         ::ZeroMemory(&msg, sizeof(msg));
@@ -217,7 +217,7 @@ public:
 
 protected:
 
-#if defined(WIN32) || defined(_WIN32)
+#if defined(_WIN32)
     static LRESULT CALLBACK StaticWndProc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam)
     {
         WinApp* pWnd;
@@ -252,7 +252,7 @@ protected:
 
     virtual void idle() = 0;
 
-#if defined(WIN32) || defined(_WIN32)
+#if defined(_WIN32)
     HINSTANCE    m_hInstance;
     HWND         m_hWnd;
 #elif defined(__linux__)


### PR DESCRIPTION
- WinRT compiler doesn't define `WIN32` anymore (`_WIN32` is defined). `WIN32` is not conformant to C/C++ standard, so it was eliminated/replaced.
- added options to build with MSVS 2017 / SDK 10.0