### PR TITLE
loadsave: check for errors when using temp file

### DIFF
--- a/modules/imgcodecs/src/loadsave.cpp
+++ b/modules/imgcodecs/src/loadsave.cpp
@@ -651,8 +651,15 @@ imdecode_( const Mat& buf, int flags, int hdrtype, Mat* mat=0 )
         if( !f )
             return 0;
         size_t bufSize = buf.cols*buf.rows*buf.elemSize();
-        fwrite( buf.ptr(), 1, bufSize, f );
-        fclose(f);
+        if( fwrite( buf.ptr(), 1, bufSize, f ) != bufSize )
+        {
+            fclose( f );
+            CV_Error( CV_StsError, "failed to write image data to temporary file" );
+        }
+        if( fclose(f) != 0 )
+        {
+            CV_Error( CV_StsError, "failed to write image data to temporary file" );
+        }
         decoder->setSource(filename);
     }
 


### PR DESCRIPTION
Previously, the return value of fwrite and fclose were not properly
checked, leading to possible silent truncation of the data if writing
failed, e.g. due to lack of disk space.

Fixes #9251.

