### PR TITLE
Removed _gpu-suffix from usage messages to align with executable name

### DIFF
--- a/samples/gpu/cascadeclassifier.cpp
+++ b/samples/gpu/cascadeclassifier.cpp
@@ -20,7 +20,7 @@ using namespace cv::cuda;
 
 static void help()
 {
-    cout << "Usage: ./cascadeclassifier_gpu \n\t--cascade <cascade_file>\n\t(<image>|--video <video>|--camera <camera_id>)\n"
+    cout << "Usage: ./cascadeclassifier \n\t--cascade <cascade_file>\n\t(<image>|--video <video>|--camera <camera_id>)\n"
             "Using OpenCV version " << CV_VERSION << endl << endl;
 }
 

--- a/samples/gpu/driver_api_stereo_multi.cpp
+++ b/samples/gpu/driver_api_stereo_multi.cpp
@@ -85,7 +85,7 @@ GpuMat d_result[2];
 
 static void printHelp()
 {
-    std::cout << "Usage: driver_api_stereo_multi_gpu --left <left_image> --right <right_image>\n";
+    std::cout << "Usage: driver_api_stereo_multi --left <left_image> --right <right_image>\n";
 }
 
 int main(int argc, char** argv)

--- a/samples/gpu/hog.cpp
+++ b/samples/gpu/hog.cpp
@@ -99,7 +99,7 @@ private:
 static void printHelp()
 {
     cout << "Histogram of Oriented Gradients descriptor and detector sample.\n"
-         << "\nUsage: hog_gpu\n"
+         << "\nUsage: hog\n"
          << "  (<image>|--video <vide>|--camera <camera_id>) # frames source\n"
          << "  or"
          << "  (--folder <folder_path>) # load images from folder\n"

--- a/samples/gpu/stereo_match.cpp
+++ b/samples/gpu/stereo_match.cpp
@@ -76,7 +76,7 @@ private:
 
 static void printHelp()
 {
-    cout << "Usage: stereo_match_gpu\n"
+    cout << "Usage: stereo_match\n"
         << "\t--left <left_view> --right <right_view> # must be rectified\n"
         << "\t--method <stereo_match_method> # BM | BP | CSBP\n"
         << "\t--ndisp <number> # number of disparity levels\n";

--- a/samples/gpu/stereo_multi.cpp
+++ b/samples/gpu/stereo_multi.cpp
@@ -355,7 +355,7 @@ int main(int argc, char** argv)
 {
     if (argc != 3)
     {
-        cerr << "Usage: stereo_multi_gpu <left_video> <right_video>" << endl;
+        cerr << "Usage: stereo_multi <left_video> <right_video>" << endl;
         return -1;
     }
 

--- a/samples/gpu/surf_keypoint_matcher.cpp
+++ b/samples/gpu/surf_keypoint_matcher.cpp
@@ -17,7 +17,7 @@ using namespace cv::cuda;
 static void help()
 {
     cout << "\nThis program demonstrates using SURF_CUDA features detector, descriptor extractor and BruteForceMatcher_CUDA" << endl;
-    cout << "\nUsage:\n\tmatcher_simple_gpu --left <image1> --right <image2>" << endl;
+    cout << "\nUsage:\n\tsurf_keypoint_matcher --left <image1> --right <image2>" << endl;
 }
 
 int main(int argc, char* argv[])


### PR DESCRIPTION
### This pullrequest changes

Removed _gpu-suffix in various GPU samples to align with executable name. 