### PR TITLE
Honor fixing principal point in camera calib tutorial.

### DIFF
--- a/samples/cpp/tutorial_code/calib3d/camera_calibration/camera_calibration.cpp
+++ b/samples/cpp/tutorial_code/calib3d/camera_calibration/camera_calibration.cpp
@@ -143,10 +143,11 @@ public:
         if (useFisheye) {
             // the fisheye model has its own enum, so overwrite the flags
             flag = fisheye::CALIB_FIX_SKEW | fisheye::CALIB_RECOMPUTE_EXTRINSIC;
-            if(fixK1)                  flag |= fisheye::CALIB_FIX_K1;
-            if(fixK2)                  flag |= fisheye::CALIB_FIX_K2;
-            if(fixK3)                  flag |= fisheye::CALIB_FIX_K3;
-            if(fixK4)                  flag |= fisheye::CALIB_FIX_K4;
+            if(fixK1)                   flag |= fisheye::CALIB_FIX_K1;
+            if(fixK2)                   flag |= fisheye::CALIB_FIX_K2;
+            if(fixK3)                   flag |= fisheye::CALIB_FIX_K3;
+            if(fixK4)                   flag |= fisheye::CALIB_FIX_K4;
+            if (calibFixPrincipalPoint) flag |= fisheye::CALIB_FIX_PRINCIPAL_POINT;
         }
 
         calibrationPattern = NOT_EXISTING;


### PR DESCRIPTION
<!-- Please use this line to close one or multiple issues when this pullrequest gets merged
You can add another line right under the first one:
resolves #1234
resolves #1235
-->

### This pullrequest changes

the c++ camera calibration tutorial/sample, to honor the `calibFixPrincipalPoint` option that may be passed in the config file for a fisheye model calibration, which was previously only honored for non-fisheye calibrations despite being available in the fisheye model.