### PR TITLE
Using environment variable to store capture options

### DIFF
--- a/modules/videoio/src/cap_ffmpeg_impl.hpp
+++ b/modules/videoio/src/cap_ffmpeg_impl.hpp
@@ -780,7 +780,7 @@ bool CvCapture_FFMPEG::open( const char* _filename )
     ic->interrupt_callback.opaque = &interrupt_metadata;
 #endif
 
-#if LIBAVFORMAT_BUILD >= CALC_FFMPEG_VERSION(52, 111, 0)
+#if LIBAVFORMAT_BUILD > CALC_FFMPEG_VERSION(51,11,0)
 #ifndef NO_GETENV
     char* options = getenv("OPENCV_FFMPEG_CAPTURE_OPTIONS");
     if(options == NULL)
@@ -789,7 +789,11 @@ bool CvCapture_FFMPEG::open( const char* _filename )
     }
     else
     {
+#if LIBAVUTIL_BUILD > CALC_FFMPEG_VERSION(52,6,0)
         av_dict_parse_string(&dict, options, ";", "|", 0);
+#else
+        av_dict_set(&dict, "rtsp_transport", "tcp", 0);
+#endif
     }
 #else
     av_dict_set(&dict, "rtsp_transport", "tcp", 0);

--- a/modules/videoio/src/cap_ffmpeg_impl.hpp
+++ b/modules/videoio/src/cap_ffmpeg_impl.hpp
@@ -780,7 +780,7 @@ bool CvCapture_FFMPEG::open( const char* _filename )
     ic->interrupt_callback.opaque = &interrupt_metadata;
 #endif
 
-#if LIBAVFORMAT_BUILD > CALC_FFMPEG_VERSION(51,11,0)
+#if LIBAVFORMAT_BUILD >= CALC_FFMPEG_VERSION(52, 111, 0)
 #ifndef NO_GETENV
     char* options = getenv("OPENCV_FFMPEG_CAPTURE_OPTIONS");
     if(options == NULL)
@@ -789,7 +789,7 @@ bool CvCapture_FFMPEG::open( const char* _filename )
     }
     else
     {
-#if LIBAVUTIL_BUILD > CALC_FFMPEG_VERSION(52,6,0)
+#if LIBAVUTIL_BUILD >= (LIBAVUTIL_VERSION_MICRO >= 100 ? CALC_FFMPEG_VERSION(52, 17, 100) : CALC_FFMPEG_VERSION(52, 7, 0))
         av_dict_parse_string(&dict, options, ";", "|", 0);
 #else
         av_dict_set(&dict, "rtsp_transport", "tcp", 0);

--- a/modules/videoio/src/cap_ffmpeg_impl.hpp
+++ b/modules/videoio/src/cap_ffmpeg_impl.hpp
@@ -789,7 +789,7 @@ bool CvCapture_FFMPEG::open( const char* _filename )
     }
     else
     {
-        av_dict_parse_string(&dict, options, ";", "|");
+        av_dict_parse_string(&dict, options, ";", "|", 0);
     }
 #else
     av_dict_set(&dict, "rtsp_transport", "tcp", 0);

--- a/modules/videoio/src/cap_ffmpeg_impl.hpp
+++ b/modules/videoio/src/cap_ffmpeg_impl.hpp
@@ -781,7 +781,19 @@ bool CvCapture_FFMPEG::open( const char* _filename )
 #endif
 
 #if LIBAVFORMAT_BUILD >= CALC_FFMPEG_VERSION(52, 111, 0)
+#ifndef NO_GETENV
+    char* options = getenv("OPENCV_FFMPEG_CAPTURE_OPTIONS");
+    if(options == NULL)
+    {
+        av_dict_set(&dict, "rtsp_transport", "tcp", 0);
+    }
+    else
+    {
+        av_dict_parse_string(&dict, options, ";", "|");
+    }
+#else
     av_dict_set(&dict, "rtsp_transport", "tcp", 0);
+#endif
     int err = avformat_open_input(&ic, _filename, NULL, &dict);
 #else
     int err = av_open_input_file(&ic, _filename, NULL, 0, NULL);


### PR DESCRIPTION
String is parsed by av_dict_parse_string(ENV{OPENCV_FFMPEG_CAPTURE_OPTIONS}, ";", "|")

resolves #9290 

### This pullrequest changes

Allows configuration of ffmpeg capture options via environment variable. If variable is not set or OpenCV cannot read env variables, defaults to TCP as per previous behaviour.
