### PR TITLE
Resolves #9191: Grabcut relearns GMM when called with GC_EVAL

### DIFF
--- a/modules/imgproc/src/grabcut.cpp
+++ b/modules/imgproc/src/grabcut.cpp
@@ -571,7 +571,8 @@ void cv::grabCut( InputArray _img, InputOutputArray _mask, Rect rect,
     {
         GCGraph<double> graph;
         assignGMMsComponents( img, mask, bgdGMM, fgdGMM, compIdxs );
-        learnGMMs( img, mask, compIdxs, bgdGMM, fgdGMM );
+        if( mode != GC_EVAL )
+            learnGMMs( img, mask, compIdxs, bgdGMM, fgdGMM );
         constructGCGraph(img, mask, bgdGMM, fgdGMM, lambda, leftW, upleftW, upW, uprightW, graph );
         estimateSegmentation( graph, mask );
     }

--- a/modules/imgproc/test/test_grabcut.cpp
+++ b/modules/imgproc/test/test_grabcut.cpp
@@ -99,12 +99,12 @@ void CV_GrabcutTest::run( int /* start_from */)
 	bgdModel.copyTo(exp_bgdModel);
 	fgdModel.copyTo(exp_fgdModel);
     grabCut( img, mask, rect, bgdModel, fgdModel, 2, GC_EVAL );
-	
+
     // Multiply images by 255 for more visuality of test data.
     if( mask_prob.empty() )
     {
 		mask.copyTo( mask_prob );
-        imwrite(string(ts->get_data_path()) + "grabcut/mask_prob1.png", mask_prob);
+        imwrite(string(ts->get_data_path()) + "grabcut/mask_prob.png", mask_prob);
     }
     if( exp_mask1.empty() )
     {


### PR DESCRIPTION
**Merge with extra:** https://github.com/opencv/opencv_extra/pull/359

### Resolves #9191: Grabcut relearns GMM when called with GC_EVAL

Issue #9191: When grabcut is called with GC_EVAL it should not relearn the GMM provided but rather use them to run the algorithm. 

The code was changed as discussed in the [Stackoverflow question](https://stackoverflow.com/questions/45195532/reusing-models-from-grabcut-in-opencv), such that if GC_EVAL is used the learnGMM method is not called.

Tests were also modified to check that after calling grabcut with GC_EVAL, the background and foreground models are not changed.