### PR TITLE
perf_tests: disable sanity check in tests without generated data

### DIFF
--- a/modules/calib3d/perf/perf_stereosgbm.cpp
+++ b/modules/calib3d/perf/perf_stereosgbm.cpp
@@ -76,7 +76,7 @@ PERF_TEST_P( TestStereoCorresp, DISABLED_TooLongInDebug_SGBM, Combine(Values(Siz
         sgbm->compute(src_left,src_right,dst);
     }
 
-    SANITY_CHECK(dst, .01, ERROR_RELATIVE);
+    SANITY_CHECK_NOTHING();
 }
 
 void MakeArtificialExample(RNG rng, Mat& dst_left_view, Mat& dst_right_view)

--- a/modules/core/perf/perf_lut.cpp
+++ b/modules/core/perf/perf_lut.cpp
@@ -22,5 +22,5 @@ PERF_TEST_P( SizePrm, LUT,
 
     TEST_CYCLE() LUT(src, lut, dst);
 
-    SANITY_CHECK(dst, 0.1);
+    SANITY_CHECK_NOTHING();
 }

--- a/modules/imgproc/perf/perf_filter2d.cpp
+++ b/modules/imgproc/perf/perf_filter2d.cpp
@@ -66,7 +66,7 @@ PERF_TEST_P(TestFilter2d, Filter2d_ovx,
 
     TEST_CYCLE() filter2D(src, dst, CV_16SC1, kernel, Point(kSize / 2, kSize / 2), 0., borderMode);
 
-    SANITY_CHECK(dst, 1);
+    SANITY_CHECK_NOTHING();
 }
 
 PERF_TEST_P( Image_KernelSize, GaborFilter2d,

--- a/modules/imgproc/perf/perf_pyramids.cpp
+++ b/modules/imgproc/perf/perf_pyramids.cpp
@@ -35,8 +35,6 @@ PERF_TEST_P(Size_MatType, pyrDown_ovx, testing::Combine(
 {
     Size sz = get<0>(GetParam());
     int matType = get<1>(GetParam());
-    const double eps = CV_MAT_DEPTH(matType) <= CV_32S ? 1 : 1e-5;
-    perf::ERROR_TYPE error_type = CV_MAT_DEPTH(matType) <= CV_32S ? ERROR_ABSOLUTE : ERROR_RELATIVE;
 
     Mat src(sz, matType);
     Mat dst((sz.height + 1) / 2, (sz.width + 1) / 2, matType);
@@ -45,7 +43,7 @@ PERF_TEST_P(Size_MatType, pyrDown_ovx, testing::Combine(
 
     TEST_CYCLE() pyrDown(src, dst, cv::Size(), BORDER_REPLICATE);
 
-    SANITY_CHECK(dst, eps, error_type);
+    SANITY_CHECK_NOTHING();
 }
 
 PERF_TEST_P(Size_MatType, pyrUp, testing::Combine(

--- a/modules/imgproc/perf/perf_warp.cpp
+++ b/modules/imgproc/perf/perf_warp.cpp
@@ -149,11 +149,7 @@ PERF_TEST_P(TestWarpPerspective, WarpPerspective_ovx,
 
     TEST_CYCLE() warpPerspective(src, dst, warpMat, sz, interType, borderMode, borderColor);
 
-#ifdef __ANDROID__
-    SANITY_CHECK(dst, interType == INTER_LINEAR ? 5 : 10);
-#else
-    SANITY_CHECK(dst, 1);
-#endif
+    SANITY_CHECK_NOTHING();
 }
 
 PERF_TEST_P( TestWarpPerspectiveNear_t, WarpPerspectiveNear,

--- a/modules/video/perf/perf_optflowpyrlk.cpp
+++ b/modules/video/perf/perf_optflowpyrlk.cpp
@@ -145,8 +145,7 @@ PERF_TEST_P(Path_Idx_NPoints_WSize, OpticalFlowPyrLK_ovx, testing::Combine(
                              flags, minEigThreshold);
     }
 
-    SANITY_CHECK(outPoints, 0.3);
-    SANITY_CHECK(status);
+    SANITY_CHECK_NOTHING();
 }
 
 typedef tr1::tuple<std::string, int, int, tr1::tuple<int,int>, int, bool> Path_Idx_Cn_NPoints_WSize_Deriv_t;


### PR DESCRIPTION
__WIP__

### This pullrequest changes

Some performance tests do not have sanity check data, hence they fail when option `--perf_verify_sanity` is provided.
I've disabled sanity check for such tests.

