### PR TITLE
Performance test for Caffe efficiency measurements

### DIFF
--- a/doc/tutorials/dnn/dnn_halide/dnn_halide.markdown
+++ b/doc/tutorials/dnn/dnn_halide/dnn_halide.markdown
@@ -8,20 +8,7 @@ according to specific device and evaluate it with a quite good efficiency.
 
 An official website of the Halide project: http://halide-lang.org/.
 
-## Efficiency comparison
-Measured on Intel&reg; Core&trade; i7-6700K CPU @ 4.00GHz x 8.
-
-Single image forward pass (in milliseconds):
-
-|     Architecture | MKL backend | Halide backend | Speed Up ratio |
-|-----------------:|------------:|---------------:|---------------:|
-|          AlexNet |       16.55 |          22.38 |          x0.73 |
-|        ResNet-50 |       63.69 |          73.91 |          x0.86 |
-|  SqueezeNet v1.1 |       10.11 |           8.21 |          x1.23 |
-|     Inception-5h |       35.38 |          37.06 |          x0.95 |
-| ENet @ 3x512x256 |       82.26 |          41.21 |          x1.99 |
-
-Scheduling directives might be found @ [opencv_extra/testdata/dnn](https://github.com/opencv/opencv_extra/tree/master/testdata/dnn).
+An up to date efficiency comparison: https://github.com/opencv/opencv/wiki/DNN-Efficiency
 
 ## Requirements
 ### LLVM compiler
@@ -80,6 +67,8 @@ MSBuild.exe /m:4 /t:Build /p:Configuration=Release .\\ALL_BUILD.vcxproj
 
 ## Build OpenCV with Halide backend
 When you build OpenCV add the following configuration flags:
+
+- `ENABLE_CXX11` - enable C++11 standard
 
 - `WITH_HALIDE` - enable Halide linkage
 

--- a/modules/dnn/CMakeLists.txt
+++ b/modules/dnn/CMakeLists.txt
@@ -77,6 +77,24 @@ ocv_add_samples()
 ocv_add_accuracy_tests()
 ocv_add_perf_tests()
 
+ocv_option(${the_module}_PERF_CAFFE "Add performance tests of Caffe framework" OFF)
+ocv_option(${the_module}_PERF_CLCAFFE "Add performance tests of clCaffe framework" OFF)
+if(BUILD_PERF_TESTS)
+  if (${the_module}_PERF_CAFFE)
+    find_package(Caffe QUIET)
+    if (Caffe_FOUND)
+      add_definitions(-DHAVE_CAFFE=1)
+      ocv_target_link_libraries(opencv_perf_dnn caffe)
+    endif()
+  elseif(${the_module}_PERF_CLCAFFE)
+    find_package(Caffe QUIET)
+    if (Caffe_FOUND)
+      add_definitions(-DHAVE_CLCAFFE=1)
+      ocv_target_link_libraries(opencv_perf_dnn caffe)
+    endif()
+  endif()
+endif()
+
 # ----------------------------------------------------------------------------
 # Torch7 importer of blobs and models, produced by Torch.nn module
 # ----------------------------------------------------------------------------

--- a/modules/dnn/include/opencv2/dnn/dnn.hpp
+++ b/modules/dnn/include/opencv2/dnn/dnn.hpp
@@ -428,21 +428,21 @@ CV__DNN_EXPERIMENTAL_NS_BEGIN
          * specific target. For layers that not represented in scheduling file
          * or if no manual scheduling used at all, automatic scheduling will be applied.
          */
-        void setHalideScheduler(const String& scheduler);
+        CV_WRAP void setHalideScheduler(const String& scheduler);
 
         /**
          * @brief Ask network to use specific computation backend where it supported.
          * @param[in] backendId backend identifier.
          * @see Backend
          */
-        void setPreferableBackend(int backendId);
+        CV_WRAP void setPreferableBackend(int backendId);
 
         /**
          * @brief Ask network to make computations on specific target device.
          * @param[in] targetId target identifier.
          * @see Target
          */
-        void setPreferableTarget(int targetId);
+        CV_WRAP void setPreferableTarget(int targetId);
 
         /** @brief Sets the new value for the layer output blob
          *  @param name descriptor of the updating layer output blob.

--- a/modules/dnn/perf/perf_caffe.cpp
+++ b/modules/dnn/perf/perf_caffe.cpp
@@ -1,0 +1,105 @@
+// This file is part of OpenCV project.
+// It is subject to the license terms in the LICENSE file found in the top-level directory
+// of this distribution and at http://opencv.org/license.html.
+//
+// Copyright (C) 2017, Intel Corporation, all rights reserved.
+// Third party copyrights are property of their respective owners.
+
+// Recommends run this performance test via
+// ./bin/opencv_perf_dnn 2> /dev/null | grep "PERFSTAT" -A 3
+// because whole output includes Caffe's logs.
+//
+// Note: Be sure that interesting version of Caffe was linked.
+// Note: There is an impact on Halide performance. Comment this tests if you
+//       want to run the last one.
+//
+// How to build Intel-Caffe with MKLDNN backend
+// ============================================
+// mkdir build && cd build
+// cmake -DCMAKE_BUILD_TYPE=Release \
+//       -DUSE_MKLDNN_AS_DEFAULT_ENGINE=ON \
+//       -DUSE_MKL2017_AS_DEFAULT_ENGINE=OFF \
+//       -DCPU_ONLY=ON \
+//       -DCMAKE_INSTALL_PREFIX=/usr/local .. && make -j8
+// sudo make install
+//
+// In case of problems with cublas_v2.h at include/caffe/util/device_alternate.hpp: add line
+// #define CPU_ONLY
+// before the first line
+// #ifdef CPU_ONLY  // CPU-only Caffe.
+
+#if defined(HAVE_CAFFE) || defined(HAVE_CLCAFFE)
+
+#include "perf_precomp.hpp"
+#include <iostream>
+#include <caffe/caffe.hpp>
+
+namespace cvtest
+{
+
+static caffe::Net<float>* initNet(std::string proto, std::string weights)
+{
+    proto = findDataFile(proto, false);
+    weights = findDataFile(weights, false);
+
+#ifdef HAVE_CLCAFFE
+    caffe::Caffe::set_mode(caffe::Caffe::GPU);
+    caffe::Caffe::SetDevice(0);
+
+    caffe::Net<float>* net =
+        new caffe::Net<float>(proto, caffe::TEST, caffe::Caffe::GetDefaultDevice());
+#else
+    caffe::Caffe::set_mode(caffe::Caffe::CPU);
+
+    caffe::Net<float>* net = new caffe::Net<float>(proto, caffe::TEST);
+#endif
+
+    net->CopyTrainedLayersFrom(weights);
+
+    caffe::Blob<float>* input = net->input_blobs()[0];
+
+    CV_Assert(input->num() == 1);
+    CV_Assert(input->channels() == 3);
+
+    Mat inputMat(input->height(), input->width(), CV_32FC3, (char*)input->cpu_data());
+    randu(inputMat, 0.0f, 1.0f);
+
+    net->Forward();
+    return net;
+}
+
+PERF_TEST(GoogLeNet_caffe, CaffePerfTest)
+{
+    caffe::Net<float>* net = initNet("dnn/bvlc_googlenet.prototxt",
+                                     "dnn/bvlc_googlenet.caffemodel");
+    TEST_CYCLE() net->Forward();
+    SANITY_CHECK_NOTHING();
+}
+
+PERF_TEST(AlexNet_caffe, CaffePerfTest)
+{
+    caffe::Net<float>* net = initNet("dnn/bvlc_alexnet.prototxt",
+                                     "dnn/bvlc_alexnet.caffemodel");
+    TEST_CYCLE() net->Forward();
+    SANITY_CHECK_NOTHING();
+}
+
+PERF_TEST(ResNet50_caffe, CaffePerfTest)
+{
+    caffe::Net<float>* net = initNet("dnn/ResNet-50-deploy.prototxt",
+                                     "dnn/ResNet-50-model.caffemodel");
+    TEST_CYCLE() net->Forward();
+    SANITY_CHECK_NOTHING();
+}
+
+PERF_TEST(SqueezeNet_v1_1_caffe, CaffePerfTest)
+{
+    caffe::Net<float>* net = initNet("dnn/squeezenet_v1.1.prototxt",
+                                     "dnn/squeezenet_v1.1.caffemodel");
+    TEST_CYCLE() net->Forward();
+    SANITY_CHECK_NOTHING();
+}
+
+}  // namespace cvtest
+
+#endif  // HAVE_CAFFE

--- a/modules/dnn/perf/perf_halide_net.cpp
+++ b/modules/dnn/perf/perf_halide_net.cpp
@@ -55,7 +55,7 @@ PERF_TEST(GoogLeNet, HalidePerfTest)
 {
     Net net;
     loadNet("dnn/bvlc_googlenet.caffemodel", "dnn/bvlc_googlenet.prototxt",
-            "", 227, 227, "prob", "caffe", DNN_TARGET_CPU, &net);
+            "", 224, 224, "prob", "caffe", DNN_TARGET_CPU, &net);
     TEST_CYCLE() net.forward();
     SANITY_CHECK_NOTHING();
 }

--- a/modules/dnn/test/test_halide_nets.cpp
+++ b/modules/dnn/test/test_halide_nets.cpp
@@ -83,7 +83,7 @@ TEST(Reproducibility_GoogLeNet_Halide, Accuracy)
 {
     test(findDataFile("dnn/bvlc_googlenet.caffemodel", false),
          findDataFile("dnn/bvlc_googlenet.prototxt", false),
-         "", 227, 227, "prob", "caffe", DNN_TARGET_CPU);
+         "", 224, 224, "prob", "caffe", DNN_TARGET_CPU);
 };
 
 TEST(Reproducibility_AlexNet_Halide, Accuracy)

--- a/samples/dnn/squeezenet_halide.cpp
+++ b/samples/dnn/squeezenet_halide.cpp
@@ -1,10 +1,3 @@
-// This file is part of OpenCV project.
-// It is subject to the license terms in the LICENSE file found in the top-level directory
-// of this distribution and at http://opencv.org/license.html.
-//
-// Copyright (C) 2017, Intel Corporation, all rights reserved.
-// Third party copyrights are property of their respective owners.
-
 // Sample of using Halide backend in OpenCV deep learning module.
 // Based on caffe_googlenet.cpp.
 


### PR DESCRIPTION
<!-- Please use this line to close one or multiple issues when this pullrequest gets merged
You can add another line right under the first one:
resolves #1234
resolves #1235
-->

### This pullrequest changes

* Added performance test for Caffe
* Remove out-date performance statistics from tutorial
* Added `ENABLE_CXX11` flag into OpenCV+Halide build guide
* Wrappers for DNN's backends and targets

Achieved statistics (minimal observed **median** performance metrics)

|          Model |       DNN, C++ (CPU) |    DNN, Halide (CPU) |          Intel-Caffe + MKLDNN (CPU) | clCaffe (GPU)|
|----------------|----------------|----------------|----------------|---|
|      GoogLeNet |        27.39ms |        39.52ms |         **9.31ms** | 18.59ms|
|        AlexNet |        16.86ms |        28.15ms |        **11.95ms** |15.22ms|
|      ResNet-50 |        62.4ms |        104.39ms |        **22.54ms** |57.77ms|
|SqueezeNet v1.1 |         7.46ms |         8.53ms |         **3.01ms** | 5.58ms|
|   Inception-5h |        **29.03ms** |        41.72ms |          ||
| ENet @ 512x256 |        115.76ms |        **58.42ms** |         ||


* CPU: Intel&reg; Core&trade; i7-6700K CPU @ 4.00GHz
* GPU: Intel&reg; HD Graphics 530 (Skylake GT2)
* Disabled hyper-threading and turbo boost technologies
* Fixed CPU freq
  ```bash
  $ cat /proc/cpuinfo | grep "MHz"
  cpu MHz		: 3877.197
  cpu MHz		: 4000.000
  cpu MHz		: 4000.000
  cpu MHz		: 4000.000
  ```

**Merge with extra**: https://github.com/opencv/opencv_extra/pull/361