### PR TITLE
videoio: don't pass zero fps value to 3rd-party codecs

### DIFF
--- a/modules/videoio/src/cap.cpp
+++ b/modules/videoio/src/cap.cpp
@@ -382,6 +382,8 @@ static CvVideoWriter* cvCreateVideoWriterWithPreference(const char* filename, in
     if(!fourcc || !fps)
         TRY_OPEN(result, cvCreateVideoWriter_Images(filename))
 
+    CV_Assert(result || fps != 0);
+
     switch(apiPreference)
     {
         default:


### PR DESCRIPTION
resolves #9321 