### PR TITLE
SoftFloat: added sin, cos and docs

### DIFF
--- a/modules/core/include/opencv2/core.hpp
+++ b/modules/core/include/opencv2/core.hpp
@@ -74,6 +74,7 @@
     @{
         @defgroup core_utils_sse SSE utilities
         @defgroup core_utils_neon NEON utilities
+        @defgroup core_utils_softfloat Softfloat support
     @}
     @defgroup core_opengl OpenGL interoperability
     @defgroup core_ipp Intel IPP Asynchronous C/C++ Converters

--- a/modules/core/include/opencv2/core/softfloat.hpp
+++ b/modules/core/include/opencv2/core/softfloat.hpp
@@ -60,36 +60,96 @@ typedef unsigned int uint32_t;
 namespace cv
 {
 
+/** @addtogroup core_utils_softfloat
+
+  [SoftFloat](http://www.jhauser.us/arithmetic/SoftFloat.html) is a software implementation
+  of floating-point calculations according to IEEE 754 standard.
+  All calculations are done in integers, that's why they are machine-independent and bit-exact.
+  This library can be useful in accuracy-critical parts like look-up tables generation, tests, etc.
+  OpenCV contains a subset of SoftFloat partially rewritten to C++.
+
+  ### Types
+
+  There are two basic types: @ref softfloat and @ref softdouble.
+  These types are binary compatible with float and double types respectively
+  and support conversions to/from them.
+  Other types from original SoftFloat library like fp16 or fp128 were thrown away
+  as well as quiet/signaling NaN support, on-the-fly rounding mode switch
+  and exception flags (though exceptions can be implemented in the future).
+
+  ### Operations
+
+  Both types support the following:
+  - Construction from signed and unsigned 32-bit and 64 integers,
+  float/double or raw binary representation
+  - Conversions betweeen each other, to float or double and to int
+  using @ref cvRound, @ref cvTrunc, @ref cvFloor, @ref cvCeil or a bunch of
+  saturate_cast functions
+  - Add, subtract, multiply, divide, remainder, square root, FMA with absolute precision
+  - Comparison operations
+  - Explicit sign, exponent and significand manipulation through get/set methods,
+ number state indicators (isInf, isNan, isSubnormal)
+  - Type-specific constants like eps, minimum/maximum value, best pi approximation, etc.
+  - min(), max(), abs(), exp(), log() and pow() functions
+
+*/
+//! @{
+
 struct softfloat;
 struct softdouble;
 
 struct CV_EXPORTS softfloat
 {
 public:
+    /** @brief Default constructor */
     softfloat() { v = 0; }
+    /** @brief Copy constructor */
     softfloat( const softfloat& c) { v = c.v; }
+    /** @brief Assign constructor */
     softfloat& operator=( const softfloat& c )
     {
         if(&c != this) v = c.v;
         return *this;
     }
+    /** @brief Construct from raw
+
+    Builds new value from raw binary representation
+    */
     static const softfloat fromRaw( const uint32_t a ) { softfloat x; x.v = a; return x; }
 
+    /** @brief Construct from integer */
     explicit softfloat( const uint32_t );
     explicit softfloat( const uint64_t );
     explicit softfloat( const int32_t );
     explicit softfloat( const int64_t );
+    /** @brief Construct from float */
     explicit softfloat( const float a ) { Cv32suf s; s.f = a; v = s.u; }
 
+    /** @brief Type casts  */
     operator softdouble() const;
     operator float() const { Cv32suf s; s.u = v; return s.f; }
 
+    /** @brief Basic arithmetics */
     softfloat operator + (const softfloat&) const;
     softfloat operator - (const softfloat&) const;
     softfloat operator * (const softfloat&) const;
     softfloat operator / (const softfloat&) const;
-    softfloat operator % (const softfloat&) const;
     softfloat operator - () const { softfloat x; x.v = v ^ (1U << 31); return x; }
+
+    /** @brief Remainder operator
+
+    A quote from original SoftFloat manual:
+
+    > The IEEE Standard remainder operation computes the value
+    > a - n * b, where n is the integer closest to a / b.
+    > If a / b is exactly halfway between two integers, n is the even integer
+    > closest to a / b. The IEEE Standard’s remainder operation is always exact and so requires no rounding.
+    > Depending on the relative magnitudes of the operands, the remainder functions
+    > can take considerably longer to execute than the other SoftFloat functions.
+    > This is an inherent characteristic of the remainder operation itself and is not a flaw
+    > in the SoftFloat implementation.
+    */
+    softfloat operator % (const softfloat&) const;
 
     softfloat& operator += (const softfloat& a) { *this = *this + a; return *this; }
     softfloat& operator -= (const softfloat& a) { *this = *this - a; return *this; }
@@ -97,6 +157,12 @@ public:
     softfloat& operator /= (const softfloat& a) { *this = *this / a; return *this; }
     softfloat& operator %= (const softfloat& a) { *this = *this % a; return *this; }
 
+    /** @brief Comparison operations
+
+     - Any operation with NaN produces false
+       + The only exception is when x is NaN: x != y for any y.
+     - Positive and negative zeros are equal
+    */
     inline bool operator == ( const softfloat& a ) const
     {
         if(this->isNaN() || a.isNaN()) return false;
@@ -153,21 +219,35 @@ public:
         }
     }
 
+    /** @brief NaN state indicator */
     inline bool isNaN() const { return (v & 0x7fffffff)  > 0x7f800000; }
+    /** @brief Inf state indicator */
     inline bool isInf() const { return (v & 0x7fffffff) == 0x7f800000; }
+    /** @brief Subnormal number indicator */
     inline bool isSubnormal() const { return ((v >> 23) & 0xFF) == 0; }
 
+    /** @brief Get sign bit */
     inline bool getSign() const { return (v >> 31) != 0; }
+    /** @brief Construct a copy with new sign bit */
     inline softfloat setSign(bool sign) const { softfloat x; x.v = (v & ((1U << 31) - 1)) | ((uint32_t)sign << 31); return x; }
+    /** @brief Get 0-based exponent */
     inline int getExp() const { return ((v >> 23) & 0xFF) - 127; }
+    /** @brief Construct a copy with new 0-based exponent */
     inline softfloat setExp(int e) const { softfloat x; x.v = (v & 0x807fffff) | (((e + 127) & 0xFF) << 23 ); return x; }
 
-    // 1 <= frac < 2
+    /** @brief Get a fraction part
+
+    Returns a number 1 <= x < 2 with the same significand
+    */
     inline softfloat getFrac() const
     {
         uint_fast32_t vv = (v & 0x007fffff) | (127 << 23);
         return softfloat::fromRaw(vv);
     }
+    /** @brief Construct a copy with provided significand
+
+    Constructs a copy of a number with significand taken from parameter
+    */
     inline softfloat setFrac(const softfloat& s) const
     {
         softfloat x;
@@ -175,13 +255,21 @@ public:
         return x;
     }
 
+    /** @brief Zero constant */
     static softfloat zero() { return softfloat::fromRaw( 0 ); }
+    /** @brief Positive infinity constant */
     static softfloat  inf() { return softfloat::fromRaw( 0xFF << 23 ); }
+    /** @brief Default NaN constant */
     static softfloat  nan() { return softfloat::fromRaw( 0x7fffffff ); }
+    /** @brief One constant */
     static softfloat  one() { return softfloat::fromRaw(  127 << 23 ); }
+    /** @brief Smallest normalized value */
     static softfloat  min() { return softfloat::fromRaw( 0x01 << 23 ); }
+    /** @brief Difference between 1 and next representable value */
     static softfloat  eps() { return softfloat::fromRaw( (127 - 23) << 23 ); }
+    /** @brief Biggest finite value */
     static softfloat  max() { return softfloat::fromRaw( (0xFF << 23) - 1 ); }
+    /** @brief Correct pi approximation */
     static softfloat   pi() { return softfloat::fromRaw( 0x40490fdb ); }
 
     uint32_t v;
@@ -193,30 +281,55 @@ public:
 struct CV_EXPORTS softdouble
 {
 public:
+    /** @brief Default constructor */
     softdouble() : v(0) { }
+    /** @brief Copy constructor */
     softdouble( const softdouble& c) { v = c.v; }
+    /** @brief Assign constructor */
     softdouble& operator=( const softdouble& c )
     {
         if(&c != this) v = c.v;
         return *this;
     }
+    /** @brief Construct from raw
+
+    Builds new value from raw binary representation
+    */
     static softdouble fromRaw( const uint64_t a ) { softdouble x; x.v = a; return x; }
 
+    /** @brief Construct from integer */
     explicit softdouble( const uint32_t );
     explicit softdouble( const uint64_t );
     explicit softdouble( const  int32_t );
     explicit softdouble( const  int64_t );
+    /** @brief Construct from double */
     explicit softdouble( const double a ) { Cv64suf s; s.f = a; v = s.u; }
 
+    /** @brief Type casts  */
     operator softfloat() const;
     operator double() const { Cv64suf s; s.u = v; return s.f; }
 
+    /** @brief Basic arithmetics */
     softdouble operator + (const softdouble&) const;
     softdouble operator - (const softdouble&) const;
     softdouble operator * (const softdouble&) const;
     softdouble operator / (const softdouble&) const;
-    softdouble operator % (const softdouble&) const;
     softdouble operator - () const { softdouble x; x.v = v ^ (1ULL << 63); return x; }
+
+    /** @brief Remainder operator
+
+    A quote from original SoftFloat manual:
+
+    > The IEEE Standard remainder operation computes the value
+    > a - n * b, where n is the integer closest to a / b.
+    > If a / b is exactly halfway between two integers, n is the even integer
+    > closest to a / b. The IEEE Standard’s remainder operation is always exact and so requires no rounding.
+    > Depending on the relative magnitudes of the operands, the remainder functions
+    > can take considerably longer to execute than the other SoftFloat functions.
+    > This is an inherent characteristic of the remainder operation itself and is not a flaw
+    > in the SoftFloat implementation.
+    */
+    softdouble operator % (const softdouble&) const;
 
     softdouble& operator += (const softdouble& a) { *this = *this + a; return *this; }
     softdouble& operator -= (const softdouble& a) { *this = *this - a; return *this; }
@@ -224,6 +337,12 @@ public:
     softdouble& operator /= (const softdouble& a) { *this = *this / a; return *this; }
     softdouble& operator %= (const softdouble& a) { *this = *this % a; return *this; }
 
+    /** @brief Comparison operations
+
+     - Any operation with NaN produces false
+       + The only exception is when x is NaN: x != y for any y.
+     - Positive and negative zeros are equal
+    */
     inline bool operator == (const softdouble& a) const
     {
         if(this->isNaN() || a.isNaN()) return false;
@@ -280,14 +399,20 @@ public:
         }
     }
 
+    /** @brief NaN state indicator */
     inline bool isNaN() const { return (v & 0x7fffffffffffffff)  > 0x7ff0000000000000; }
+    /** @brief Inf state indicator */
     inline bool isInf() const { return (v & 0x7fffffffffffffff) == 0x7ff0000000000000; }
+    /** @brief Subnormal number indicator */
     inline bool isSubnormal() const { return ((v >> 52) & 0x7FF) == 0; }
 
+    /** @brief Get sign bit */
     inline bool getSign() const { return (v >> 63) != 0; }
+    /** @brief Construct a copy with new sign bit */
     softdouble setSign(bool sign) const { softdouble x; x.v = (v & ((1ULL << 63) - 1)) | ((uint_fast64_t)(sign) << 63); return x; }
-
+    /** @brief Get 0-based exponent */
     inline int getExp() const { return ((v >> 52) & 0x7FF) - 1023; }
+    /** @brief Construct a copy with new 0-based exponent */
     inline softdouble setExp(int e) const
     {
         softdouble x;
@@ -295,12 +420,19 @@ public:
         return x;
     }
 
-    // 1 <= frac < 2
+    /** @brief Get a fraction part
+
+    Returns a number 1 <= x < 2 with the same significand
+    */
     inline softdouble getFrac() const
     {
         uint_fast64_t vv = (v & 0x000FFFFFFFFFFFFF) | ((uint_fast64_t)(1023) << 52);
         return softdouble::fromRaw(vv);
     }
+    /** @brief Construct a copy with provided significand
+
+    Constructs a copy of a number with significand taken from parameter
+    */
     inline softdouble setFrac(const softdouble& s) const
     {
         softdouble x;
@@ -308,13 +440,21 @@ public:
         return x;
     }
 
+    /** @brief Zero constant */
     static softdouble zero() { return softdouble::fromRaw( 0 ); }
+    /** @brief Positive infinity constant */
     static softdouble  inf() { return softdouble::fromRaw( (uint_fast64_t)(0x7FF) << 52 ); }
+    /** @brief Default NaN constant */
     static softdouble  nan() { return softdouble::fromRaw( CV_BIG_INT(0x7FFFFFFFFFFFFFFF) ); }
+    /** @brief One constant */
     static softdouble  one() { return softdouble::fromRaw( (uint_fast64_t)( 1023) << 52 ); }
+    /** @brief Smallest normalized value */
     static softdouble  min() { return softdouble::fromRaw( (uint_fast64_t)( 0x01) << 52 ); }
+    /** @brief Difference between 1 and next representable value */
     static softdouble  eps() { return softdouble::fromRaw( (uint_fast64_t)( 1023 - 52 ) << 52 ); }
+    /** @brief Biggest finite value */
     static softdouble  max() { return softdouble::fromRaw( ((uint_fast64_t)(0x7FF) << 52) - 1 ); }
+    /** @brief Correct pi approximation */
     static softdouble   pi() { return softdouble::fromRaw( CV_BIG_INT(0x400921FB54442D18) ); }
 
     uint64_t v;
@@ -323,9 +463,14 @@ public:
 /*----------------------------------------------------------------------------
 *----------------------------------------------------------------------------*/
 
+/** @brief Fused Multiplication and Addition
+
+Computes (a*b)+c with single rounding
+*/
 CV_EXPORTS softfloat  mulAdd( const softfloat&  a, const softfloat&  b, const softfloat & c);
 CV_EXPORTS softdouble mulAdd( const softdouble& a, const softdouble& b, const softdouble& c);
 
+/** @brief Square root */
 CV_EXPORTS softfloat  sqrt( const softfloat&  a );
 CV_EXPORTS softdouble sqrt( const softdouble& a );
 }
@@ -334,20 +479,25 @@ CV_EXPORTS softdouble sqrt( const softdouble& a );
 | Ported from OpenCV and added for usability
 *----------------------------------------------------------------------------*/
 
+/** @brief Truncates number to integer with minimum magnitude */
 CV_EXPORTS int cvTrunc(const cv::softfloat&  a);
 CV_EXPORTS int cvTrunc(const cv::softdouble& a);
 
+/** @brief Rounds a number to nearest even integer */
 CV_EXPORTS int cvRound(const cv::softfloat&  a);
 CV_EXPORTS int cvRound(const cv::softdouble& a);
 
+/** @brief Rounds a number down to integer */
 CV_EXPORTS int cvFloor(const cv::softfloat&  a);
 CV_EXPORTS int cvFloor(const cv::softdouble& a);
 
+/** @brief Rounds number up to integer */
 CV_EXPORTS int  cvCeil(const cv::softfloat&  a);
 CV_EXPORTS int  cvCeil(const cv::softdouble& a);
 
 namespace cv
 {
+/** @brief Saturate casts */
 template<typename _Tp> static inline _Tp saturate_cast(softfloat  a) { return _Tp(a); }
 template<typename _Tp> static inline _Tp saturate_cast(softdouble a) { return _Tp(a); }
 
@@ -366,40 +516,88 @@ template<> inline short saturate_cast<short>(softdouble a) { return (short)std::
 template<> inline int saturate_cast<int>(softfloat  a) { return cvRound(a); }
 template<> inline int saturate_cast<int>(softdouble a) { return cvRound(a); }
 
-// we intentionally do not clip negative numbers, to make -1 become 0xffffffff etc.
+/** @brief Saturate cast to unsigned integer
+We intentionally do not clip negative numbers, to make -1 become 0xffffffff etc.
+*/
 template<> inline unsigned saturate_cast<unsigned>(softfloat  a) { return cvRound(a); }
 template<> inline unsigned saturate_cast<unsigned>(softdouble a) { return cvRound(a); }
 
+/** @brief Min and Max functions */
 inline softfloat  min(const softfloat&  a, const softfloat&  b) { return (a > b) ? b : a; }
 inline softdouble min(const softdouble& a, const softdouble& b) { return (a > b) ? b : a; }
 
 inline softfloat  max(const softfloat&  a, const softfloat&  b) { return (a > b) ? a : b; }
 inline softdouble max(const softdouble& a, const softdouble& b) { return (a > b) ? a : b; }
 
+/** @brief Absolute value */
 inline softfloat  abs( softfloat  a) { softfloat  x; x.v = a.v & ((1U   << 31) - 1); return x; }
 inline softdouble abs( softdouble a) { softdouble x; x.v = a.v & ((1ULL << 63) - 1); return x; }
 
+/** @brief Exponent
+
+Special cases:
+- exp(NaN) is NaN
+- exp(-Inf) == 0
+- exp(+Inf) == +Inf
+*/
 CV_EXPORTS softfloat  exp( const softfloat&  a);
 CV_EXPORTS softdouble exp( const softdouble& a);
 
+/** @brief Natural logarithm
+
+Special cases:
+- log(NaN), log(x < 0) are NaN
+- log(0) == -Inf
+*/
 CV_EXPORTS softfloat  log( const softfloat&  a );
 CV_EXPORTS softdouble log( const softdouble& a );
 
+/** @brief Raising to the power
+
+Special cases:
+- x**NaN is NaN for any x
+- ( |x| == 1 )**Inf is NaN
+- ( |x|  > 1 )**+Inf or ( |x| < 1 )**-Inf is +Inf
+- ( |x|  > 1 )**-Inf or ( |x| < 1 )**+Inf is 0
+- x ** 0 == 1 for any x
+- x ** 1 == 1 for any x
+- NaN ** y is NaN for any other y
+- Inf**(y < 0) == 0
+- Inf ** y is +Inf for any other y
+- (x < 0)**y is NaN for any other y if x can't be correctly rounded to integer
+- 0 ** 0 == 1
+- 0 ** (y < 0) is +Inf
+- 0 ** (y > 0) is 0
+*/
 CV_EXPORTS softfloat  pow( const softfloat&  a, const softfloat&  b);
 CV_EXPORTS softdouble pow( const softdouble& a, const softdouble& b);
 
+/** @brief Cube root
+
+Special cases:
+- cbrt(NaN) is NaN
+- cbrt(+/-Inf) is +/-Inf
+*/
 CV_EXPORTS softfloat cbrt( const softfloat& a );
 
+/** @brief Sine
+
+Special cases:
+- sin(Inf) or sin(NaN) is NaN
+- sin(x) == x when sin(x) is close to zero
+*/
 CV_EXPORTS softdouble sin( const softdouble& a );
+
+/** @brief Cosine
+ *
+Special cases:
+- cos(Inf) or cos(NaN) is NaN
+- cos(x) == +/- 1 when cos(x) is close to +/- 1
+*/
 CV_EXPORTS softdouble cos( const softdouble& a );
 
-/*
-TODOs:
-
-sin, cos, pi
-
-*/
-
 }
+
+//! @}
 
 #endif

--- a/modules/core/include/opencv2/core/softfloat.hpp
+++ b/modules/core/include/opencv2/core/softfloat.hpp
@@ -160,8 +160,19 @@ public:
     inline bool getSign() const { return (v >> 31) != 0; }
     inline softfloat& setSign(bool sign) { v = (v & ((1U << 31) - 1)) | ((uint32_t)sign << 31); return *this; }
     inline int getExp() const { return ((v >> 23) & 0xFF) - 127; }
-    inline softfloat& setExp(int e) { v = (v & 0x807fffff) | (((e + 127) & 0xFF) << 23 ) ; return *this; }
+    inline softfloat& setExp(int e) { v = (v & 0x807fffff) | (((e + 127) & 0xFF) << 23 ); return *this; }
 
+    // 1 <= frac < 2
+    inline softfloat getFrac() const
+    {
+        uint_fast32_t vv = (v & 0x007fffff) | (127 << 23);
+        return softfloat::fromRaw(vv);
+    }
+    inline softfloat& setFrac(const softfloat& s)
+    {
+        v = (v & 0xff800000) | (s.v & 0x007fffff);
+        return *this;
+    }
 
     static softfloat zero() { return softfloat::fromRaw( 0 ); }
     static softfloat  inf() { return softfloat::fromRaw( 0xFF << 23 ); }
@@ -275,8 +286,23 @@ public:
     softdouble& setSign(bool sign) { v = (v & ((1ULL << 63) - 1)) | ((uint_fast64_t)(sign) << 63); return *this; }
 
     inline int getExp() const { return ((v >> 52) & 0x7FF) - 1023; }
-    inline softdouble& setExp(int e) { v = (v & 0x800FFFFFFFFFFFFF) | (((e + 1023) & 0x7FF) << 52); return *this; }
+    inline softdouble& setExp(int e)
+    {
+        v = (v & 0x800FFFFFFFFFFFFF) | ((uint_fast64_t)((e + 1023) & 0x7FF) << 52);
+        return *this;
+    }
 
+    // 1 <= frac < 2
+    inline softdouble getFrac() const
+    {
+        uint_fast64_t vv = (v & 0x000FFFFFFFFFFFFF) | ((uint_fast64_t)(1023) << 52);
+        return softdouble::fromRaw(vv);
+    }
+    inline softdouble& setFrac(const softdouble& s)
+    {
+        v = (v & 0xFFF0000000000000) | (s.v & 0x000FFFFFFFFFFFFF);
+        return *this;
+    }
 
     static softdouble zero() { return softdouble::fromRaw( 0 ); }
     static softdouble  inf() { return softdouble::fromRaw( (uint_fast64_t)(0x7FF) << 52 ); }
@@ -362,10 +388,8 @@ CV_EXPORTS softfloat cbrt(const softfloat& a);
 /*
 TODOs:
 
-sin, cos
+sin, cos, pi
 
-nextafter
-frexp, ldexp
 */
 
 }

--- a/modules/core/include/opencv2/core/softfloat.hpp
+++ b/modules/core/include/opencv2/core/softfloat.hpp
@@ -163,61 +163,12 @@ public:
        + The only exception is when x is NaN: x != y for any y.
      - Positive and negative zeros are equal
     */
-    inline bool operator == ( const softfloat& a ) const
-    {
-        if(this->isNaN() || a.isNaN()) return false;
-        else return (v == a.v) || ! (uint32_t) ((v | a.v)<<1);
-    }
-
-    inline bool operator != ( const softfloat& a ) const { return !(*this == a); }
-
-    inline bool operator > ( const softfloat& a ) const
-    {
-        if(this->isNaN() || a.isNaN()) return false;
-        else
-        {
-            uint_fast32_t uiA = a.v, uiB = v;
-            bool signA = (uiA >> 31) != 0, signB = (uiB >> 31) != 0;
-            return (signA != signB) ? (signA && ((uint32_t) ((uiA | uiB)<<1) != 0)) :
-                                      (uiA != uiB) && (signA ^ (uiA < uiB));
-        }
-    }
-
-    inline bool operator < ( const softfloat& a ) const
-    {
-        if(this->isNaN() || a.isNaN()) return false;
-        else
-        {
-            uint_fast32_t uiA = v, uiB = a.v;
-            bool signA = (uiA >> 31) != 0, signB = (uiB >> 31) != 0;
-            return (signA != signB) ? signA && ((uint32_t) ((uiA | uiB)<<1) != 0) :
-                                      (uiA != uiB) && (signA ^ (uiA < uiB));
-        }
-    }
-
-    inline bool operator >= ( const softfloat& a ) const
-    {
-        if(this->isNaN() || a.isNaN()) return false;
-        else
-        {
-            uint_fast32_t uiA = a.v, uiB = v;
-            bool signA = (uiA >> 31) != 0, signB = (uiB >> 31) != 0;
-            return (signA != signB) ? signA || ! (uint32_t) ((uiA | uiB)<<1) :
-                                      (uiA == uiB) || (signA ^ (uiA < uiB));
-        }
-    }
-
-    inline bool operator <= ( const softfloat& a ) const
-    {
-        if(this->isNaN() || a.isNaN()) return false;
-        else
-        {
-            uint_fast32_t uiA = v, uiB = a.v;
-            bool signA = (uiA >> 31) != 0, signB = (uiB >> 31) != 0;
-            return (signA != signB) ? signA || ! (uint32_t) ((uiA | uiB)<<1) :
-                                      (uiA == uiB) || (signA ^ (uiA < uiB));
-        }
-    }
+    bool operator == ( const softfloat& ) const;
+    bool operator != ( const softfloat& ) const;
+    bool operator >  ( const softfloat& ) const;
+    bool operator >= ( const softfloat& ) const;
+    bool operator <  ( const softfloat& ) const;
+    bool operator <= ( const softfloat& ) const;
 
     /** @brief NaN state indicator */
     inline bool isNaN() const { return (v & 0x7fffffff)  > 0x7f800000; }
@@ -343,61 +294,12 @@ public:
        + The only exception is when x is NaN: x != y for any y.
      - Positive and negative zeros are equal
     */
-    inline bool operator == (const softdouble& a) const
-    {
-        if(this->isNaN() || a.isNaN()) return false;
-        else return (v == a.v) || ! ((v | a.v) & UINT64_C( 0x7FFFFFFFFFFFFFFF ));
-    }
-
-    inline bool operator != (const softdouble& a) const { return !(*this == a); }
-
-    inline bool operator > (const softdouble& a) const
-    {
-        if(this->isNaN() || a.isNaN()) return false;
-        else
-        {
-            uint_fast64_t uiA = a.v, uiB = v;
-            bool signA = ((uiA >> 63) != 0), signB = ((uiB >> 63) != 0);
-            return (signA != signB) ? signA && ((uiA | uiB) & UINT64_C( 0x7FFFFFFFFFFFFFFF )) :
-                                      (uiA != uiB) && (signA ^ (uiA < uiB));
-        }
-    }
-
-    inline bool operator < (const softdouble& a) const
-    {
-        if(this->isNaN() || a.isNaN()) return false;
-        else
-        {
-            uint_fast64_t uiA = v, uiB = a.v;
-            bool signA = ((uiA >> 63) != 0), signB = ((uiB >> 63) != 0);
-            return (signA != signB) ? signA && ((uiA | uiB) & UINT64_C( 0x7FFFFFFFFFFFFFFF )) :
-                                      (uiA != uiB) && (signA ^ (uiA < uiB));
-        }
-    }
-
-    inline bool operator >= (const softdouble& a) const
-    {
-        if(this->isNaN() || a.isNaN()) return false;
-        else
-        {
-            uint_fast64_t uiA = a.v, uiB = v;
-            bool signA = ((uiA >> 63) != 0), signB = ((uiB >> 63) != 0);
-            return (signA != signB) ? signA || ! ((uiA | uiB) & UINT64_C( 0x7FFFFFFFFFFFFFFF )) :
-                                      (uiA == uiB) || (signA ^ (uiA < uiB));
-        }
-    }
-
-    inline bool operator <= (const softdouble& a) const
-    {
-        if(this->isNaN() || a.isNaN()) return false;
-        else
-        {
-            uint_fast64_t uiA = v, uiB = a.v;
-            bool signA = ((uiA >> 63) != 0), signB = ((uiB >> 63) != 0);
-            return (signA != signB) ? signA || ! ((uiA | uiB) & UINT64_C( 0x7FFFFFFFFFFFFFFF )) :
-                                      (uiA == uiB) || (signA ^ (uiA < uiB));
-        }
-    }
+    bool operator == ( const softdouble& ) const;
+    bool operator != ( const softdouble& ) const;
+    bool operator >  ( const softdouble& ) const;
+    bool operator >= ( const softdouble& ) const;
+    bool operator <  ( const softdouble& ) const;
+    bool operator <= ( const softdouble& ) const;
 
     /** @brief NaN state indicator */
     inline bool isNaN() const { return (v & 0x7fffffffffffffff)  > 0x7ff0000000000000; }

--- a/modules/core/include/opencv2/core/softfloat.hpp
+++ b/modules/core/include/opencv2/core/softfloat.hpp
@@ -181,6 +181,7 @@ public:
     static softfloat  min() { return softfloat::fromRaw( 0x01 << 23 ); }
     static softfloat  eps() { return softfloat::fromRaw( (127 - 23) << 23 ); }
     static softfloat  max() { return softfloat::fromRaw( (0xFF << 23) - 1 ); }
+    static softfloat   pi() { return softfloat::fromRaw( 0x40490fdb ); }
 
     uint32_t v;
 };
@@ -311,6 +312,7 @@ public:
     static softdouble  min() { return softdouble::fromRaw( (uint_fast64_t)( 0x01) << 52 ); }
     static softdouble  eps() { return softdouble::fromRaw( (uint_fast64_t)( 1023 - 52 ) << 52 ); }
     static softdouble  max() { return softdouble::fromRaw( ((uint_fast64_t)(0x7FF) << 52) - 1 ); }
+    static softdouble   pi() { return softdouble::fromRaw( CV_BIG_INT(0x400921FB54442D18) ); }
 
     uint64_t v;
 };
@@ -383,7 +385,10 @@ CV_EXPORTS softdouble log( const softdouble& a );
 CV_EXPORTS softfloat  pow( const softfloat&  a, const softfloat&  b);
 CV_EXPORTS softdouble pow( const softdouble& a, const softdouble& b);
 
-CV_EXPORTS softfloat cbrt(const softfloat& a);
+CV_EXPORTS softfloat cbrt( const softfloat& a );
+
+CV_EXPORTS softdouble sin( const softdouble& a );
+CV_EXPORTS softdouble cos( const softdouble& a );
 
 /*
 TODOs:

--- a/modules/core/include/opencv2/core/softfloat.hpp
+++ b/modules/core/include/opencv2/core/softfloat.hpp
@@ -157,6 +157,12 @@ public:
     inline bool isInf() const { return (v & 0x7fffffff) == 0x7f800000; }
     inline bool isSubnormal() const { return ((v >> 23) & 0xFF) == 0; }
 
+    inline bool getSign() const { return (v >> 31) != 0; }
+    inline softfloat& setSign(bool sign) { v = (v & ((1U << 31) - 1)) | ((uint32_t)sign << 31); return *this; }
+    inline int getExp() const { return ((v >> 23) & 0xFF) - 127; }
+    inline softfloat& setExp(int e) { v = (v & 0x807fffff) | (((e + 127) & 0xFF) << 23 ) ; return *this; }
+
+
     static softfloat zero() { return softfloat::fromRaw( 0 ); }
     static softfloat  inf() { return softfloat::fromRaw( 0xFF << 23 ); }
     static softfloat  nan() { return softfloat::fromRaw( 0x7fffffff ); }
@@ -219,7 +225,7 @@ public:
         else
         {
             uint_fast64_t uiA = a.v, uiB = v;
-            bool signA = (((uint64_t) (uiA)>>63) != 0), signB = (((uint64_t) (uiB)>>63) != 0);
+            bool signA = ((uiA >> 63) != 0), signB = ((uiB >> 63) != 0);
             return (signA != signB) ? signA && ((uiA | uiB) & UINT64_C( 0x7FFFFFFFFFFFFFFF )) :
                                       (uiA != uiB) && (signA ^ (uiA < uiB));
         }
@@ -231,7 +237,7 @@ public:
         else
         {
             uint_fast64_t uiA = v, uiB = a.v;
-            bool signA = (((uint64_t) (uiA)>>63) != 0), signB = (((uint64_t) (uiB)>>63) != 0);
+            bool signA = ((uiA >> 63) != 0), signB = ((uiB >> 63) != 0);
             return (signA != signB) ? signA && ((uiA | uiB) & UINT64_C( 0x7FFFFFFFFFFFFFFF )) :
                                       (uiA != uiB) && (signA ^ (uiA < uiB));
         }
@@ -243,7 +249,7 @@ public:
         else
         {
             uint_fast64_t uiA = a.v, uiB = v;
-            bool signA = (((uint64_t) (uiA)>>63) != 0), signB = (((uint64_t) (uiB)>>63) != 0);
+            bool signA = ((uiA >> 63) != 0), signB = ((uiB >> 63) != 0);
             return (signA != signB) ? signA || ! ((uiA | uiB) & UINT64_C( 0x7FFFFFFFFFFFFFFF )) :
                                       (uiA == uiB) || (signA ^ (uiA < uiB));
         }
@@ -255,7 +261,7 @@ public:
         else
         {
             uint_fast64_t uiA = v, uiB = a.v;
-            bool signA = (((uint64_t) (uiA)>>63) != 0), signB = (((uint64_t) (uiB)>>63) != 0);
+            bool signA = ((uiA >> 63) != 0), signB = ((uiB >> 63) != 0);
             return (signA != signB) ? signA || ! ((uiA | uiB) & UINT64_C( 0x7FFFFFFFFFFFFFFF )) :
                                       (uiA == uiB) || (signA ^ (uiA < uiB));
         }
@@ -263,7 +269,14 @@ public:
 
     inline bool isNaN() const { return (v & 0x7fffffffffffffff)  > 0x7ff0000000000000; }
     inline bool isInf() const { return (v & 0x7fffffffffffffff) == 0x7ff0000000000000; }
-    inline bool isSubnormal() const { return ((v >> 52) & (uint_fast64_t)(0x7FF)) == 0; }
+    inline bool isSubnormal() const { return ((v >> 52) & 0x7FF) == 0; }
+
+    inline bool getSign() const { return (v >> 63) != 0; }
+    softdouble& setSign(bool sign) { v = (v & ((1ULL << 63) - 1)) | ((uint_fast64_t)(sign) << 63); return *this; }
+
+    inline int getExp() const { return ((v >> 52) & 0x7FF) - 1023; }
+    inline softdouble& setExp(int e) { v = (v & 0x800FFFFFFFFFFFFF) | (((e + 1023) & 0x7FF) << 52); return *this; }
+
 
     static softdouble zero() { return softdouble::fromRaw( 0 ); }
     static softdouble  inf() { return softdouble::fromRaw( (uint_fast64_t)(0x7FF) << 52 ); }
@@ -351,7 +364,6 @@ TODOs:
 
 sin, cos
 
-signbit, copysign
 nextafter
 frexp, ldexp
 */

--- a/modules/core/include/opencv2/core/softfloat.hpp
+++ b/modules/core/include/opencv2/core/softfloat.hpp
@@ -158,9 +158,9 @@ public:
     inline bool isSubnormal() const { return ((v >> 23) & 0xFF) == 0; }
 
     inline bool getSign() const { return (v >> 31) != 0; }
-    inline softfloat& setSign(bool sign) { v = (v & ((1U << 31) - 1)) | ((uint32_t)sign << 31); return *this; }
+    inline softfloat setSign(bool sign) const { softfloat x; x.v = (v & ((1U << 31) - 1)) | ((uint32_t)sign << 31); return x; }
     inline int getExp() const { return ((v >> 23) & 0xFF) - 127; }
-    inline softfloat& setExp(int e) { v = (v & 0x807fffff) | (((e + 127) & 0xFF) << 23 ); return *this; }
+    inline softfloat setExp(int e) const { softfloat x; x.v = (v & 0x807fffff) | (((e + 127) & 0xFF) << 23 ); return x; }
 
     // 1 <= frac < 2
     inline softfloat getFrac() const
@@ -168,10 +168,11 @@ public:
         uint_fast32_t vv = (v & 0x007fffff) | (127 << 23);
         return softfloat::fromRaw(vv);
     }
-    inline softfloat& setFrac(const softfloat& s)
+    inline softfloat setFrac(const softfloat& s) const
     {
-        v = (v & 0xff800000) | (s.v & 0x007fffff);
-        return *this;
+        softfloat x;
+        x.v = (v & 0xff800000) | (s.v & 0x007fffff);
+        return x;
     }
 
     static softfloat zero() { return softfloat::fromRaw( 0 ); }
@@ -284,13 +285,14 @@ public:
     inline bool isSubnormal() const { return ((v >> 52) & 0x7FF) == 0; }
 
     inline bool getSign() const { return (v >> 63) != 0; }
-    softdouble& setSign(bool sign) { v = (v & ((1ULL << 63) - 1)) | ((uint_fast64_t)(sign) << 63); return *this; }
+    softdouble setSign(bool sign) const { softdouble x; x.v = (v & ((1ULL << 63) - 1)) | ((uint_fast64_t)(sign) << 63); return x; }
 
     inline int getExp() const { return ((v >> 52) & 0x7FF) - 1023; }
-    inline softdouble& setExp(int e)
+    inline softdouble setExp(int e) const
     {
-        v = (v & 0x800FFFFFFFFFFFFF) | ((uint_fast64_t)((e + 1023) & 0x7FF) << 52);
-        return *this;
+        softdouble x;
+        x.v = (v & 0x800FFFFFFFFFFFFF) | ((uint_fast64_t)((e + 1023) & 0x7FF) << 52);
+        return x;
     }
 
     // 1 <= frac < 2
@@ -299,10 +301,11 @@ public:
         uint_fast64_t vv = (v & 0x000FFFFFFFFFFFFF) | ((uint_fast64_t)(1023) << 52);
         return softdouble::fromRaw(vv);
     }
-    inline softdouble& setFrac(const softdouble& s)
+    inline softdouble setFrac(const softdouble& s) const
     {
-        v = (v & 0xFFF0000000000000) | (s.v & 0x000FFFFFFFFFFFFF);
-        return *this;
+        softdouble x;
+        x.v = (v & 0xFFF0000000000000) | (s.v & 0x000FFFFFFFFFFFFF);
+        return x;
     }
 
     static softdouble zero() { return softdouble::fromRaw( 0 ); }

--- a/modules/core/src/softfloat.cpp
+++ b/modules/core/src/softfloat.cpp
@@ -146,9 +146,6 @@ static float32_t f32_mulAdd( float32_t, float32_t, float32_t );
 static float32_t f32_div( float32_t, float32_t );
 static float32_t f32_rem( float32_t, float32_t );
 static float32_t f32_sqrt( float32_t );
-static bool f32_eq( float32_t, float32_t );
-static bool f32_le( float32_t, float32_t );
-static bool f32_lt( float32_t, float32_t );
 
 /*----------------------------------------------------------------------------
 | 64-bit (double-precision) floating-point operations.
@@ -164,9 +161,6 @@ static float64_t f64_mulAdd( float64_t, float64_t, float64_t );
 static float64_t f64_div( float64_t, float64_t );
 static float64_t f64_rem( float64_t, float64_t );
 static float64_t f64_sqrt( float64_t );
-static bool f64_eq( float64_t, float64_t );
-static bool f64_le( float64_t, float64_t );
-static bool f64_lt( float64_t, float64_t );
 
 /*----------------------------------------------------------------------------
 | Ported from OpenCV and added for usability
@@ -200,13 +194,6 @@ softfloat softfloat::operator * (const softfloat& a) const { return f32_mul(*thi
 softfloat softfloat::operator / (const softfloat& a) const { return f32_div(*this, a); }
 softfloat softfloat::operator % (const softfloat& a) const { return f32_rem(*this, a); }
 
-bool softfloat::operator == ( const softfloat& a ) const { return  f32_eq(*this, a); }
-bool softfloat::operator != ( const softfloat& a ) const { return !f32_eq(*this, a); }
-bool softfloat::operator >  ( const softfloat& a ) const { return  f32_lt(a, *this); }
-bool softfloat::operator >= ( const softfloat& a ) const { return  f32_le(a, *this); }
-bool softfloat::operator <  ( const softfloat& a ) const { return  f32_lt(*this, a); }
-bool softfloat::operator <= ( const softfloat& a ) const { return  f32_le(*this, a); }
-
 softdouble::softdouble( const uint32_t a ) { *this = ui32_to_f64(a); }
 softdouble::softdouble( const uint64_t a ) { *this = ui64_to_f64(a); }
 softdouble::softdouble( const  int32_t a ) { *this =  i32_to_f64(a); }
@@ -233,13 +220,6 @@ softdouble softdouble::operator - (const softdouble& a) const { return f64_sub(*
 softdouble softdouble::operator * (const softdouble& a) const { return f64_mul(*this, a); }
 softdouble softdouble::operator / (const softdouble& a) const { return f64_div(*this, a); }
 softdouble softdouble::operator % (const softdouble& a) const { return f64_rem(*this, a); }
-
-bool softdouble::operator == (const softdouble& a) const { return  f64_eq(*this, a); }
-bool softdouble::operator != (const softdouble& a) const { return !f64_eq(*this, a); }
-bool softdouble::operator >  (const softdouble& a) const { return  f64_lt(a, *this); }
-bool softdouble::operator >= (const softdouble& a) const { return  f64_le(a, *this); }
-bool softdouble::operator <  (const softdouble& a) const { return  f64_lt(*this, a); }
-bool softdouble::operator <= (const softdouble& a) const { return  f64_le(*this, a); }
 
 /*----------------------------------------------------------------------------
 | Overloads for math functions
@@ -764,62 +744,6 @@ static float32_t f32_div( float32_t a, float32_t b )
     uiZ = packToF32UI( signZ, 0, 0 );
  uiZ:
     return float32_t::fromRaw(uiZ);
-}
-
-static bool f32_eq( float32_t a, float32_t b )
-{
-    uint_fast32_t uiA;
-    uint_fast32_t uiB;
-
-    uiA = a.v;
-    uiB = b.v;
-    if ( isNaNF32UI( uiA ) || isNaNF32UI( uiB ) ) {
-        if (
-            softfloat_isSigNaNF32UI( uiA ) || softfloat_isSigNaNF32UI( uiB )
-        ) {
-            raiseFlags( flag_invalid );
-        }
-        return false;
-    }
-    return (uiA == uiB) || ! (uint32_t) ((uiA | uiB)<<1);
-}
-
-static bool f32_le( float32_t a, float32_t b )
-{
-    uint_fast32_t uiA;
-    uint_fast32_t uiB;
-    bool signA, signB;
-
-    uiA = a.v;
-    uiB = b.v;
-    if ( isNaNF32UI( uiA ) || isNaNF32UI( uiB ) ) {
-        raiseFlags( flag_invalid );
-        return false;
-    }
-    signA = signF32UI( uiA );
-    signB = signF32UI( uiB );
-    return
-        (signA != signB) ? signA || ! (uint32_t) ((uiA | uiB)<<1)
-            : (uiA == uiB) || (signA ^ (uiA < uiB));
-}
-
-static bool f32_lt( float32_t a, float32_t b )
-{
-    uint_fast32_t uiA;
-    uint_fast32_t uiB;
-    bool signA, signB;
-
-    uiA = a.v;
-    uiB = b.v;
-    if ( isNaNF32UI( uiA ) || isNaNF32UI( uiB ) ) {
-        raiseFlags( flag_invalid );
-        return false;
-    }
-    signA = signF32UI( uiA );
-    signB = signF32UI( uiB );
-    return
-        (signA != signB) ? signA && ((uint32_t) ((uiA | uiB)<<1) != 0)
-            : (uiA != uiB) && (signA ^ (uiA < uiB));
 }
 
 static float32_t f32_mulAdd( float32_t a, float32_t b, float32_t c )
@@ -1456,64 +1380,6 @@ static float64_t f64_div( float64_t a, float64_t b )
     uiZ = packToF64UI( signZ, 0, 0 );
  uiZ:
     return float64_t::fromRaw(uiZ);
-}
-
-static bool f64_eq( float64_t a, float64_t b )
-{
-    uint_fast64_t uiA;
-    uint_fast64_t uiB;
-
-    uiA = a.v;
-    uiB = b.v;
-    if ( isNaNF64UI( uiA ) || isNaNF64UI( uiB ) ) {
-        if (
-            softfloat_isSigNaNF64UI( uiA ) || softfloat_isSigNaNF64UI( uiB )
-        ) {
-            raiseFlags( flag_invalid );
-        }
-        return false;
-    }
-    return (uiA == uiB) || ! ((uiA | uiB) & UINT64_C( 0x7FFFFFFFFFFFFFFF ));
-}
-
-static bool f64_le( float64_t a, float64_t b )
-{
-    uint_fast64_t uiA;
-    uint_fast64_t uiB;
-    bool signA, signB;
-
-    uiA = a.v;
-    uiB = b.v;
-    if ( isNaNF64UI( uiA ) || isNaNF64UI( uiB ) ) {
-        raiseFlags( flag_invalid );
-        return false;
-    }
-    signA = signF64UI( uiA );
-    signB = signF64UI( uiB );
-    return
-        (signA != signB)
-            ? signA || ! ((uiA | uiB) & UINT64_C( 0x7FFFFFFFFFFFFFFF ))
-            : (uiA == uiB) || (signA ^ (uiA < uiB));
-}
-
-static bool f64_lt( float64_t a, float64_t b )
-{
-    uint_fast64_t uiA;
-    uint_fast64_t uiB;
-    bool signA, signB;
-
-    uiA = a.v;
-    uiB = b.v;
-    if ( isNaNF64UI( uiA ) || isNaNF64UI( uiB ) ) {
-        raiseFlags( flag_invalid );
-        return false;
-    }
-    signA = signF64UI( uiA );
-    signB = signF64UI( uiB );
-    return
-        (signA != signB)
-            ? signA && ((uiA | uiB) & UINT64_C( 0x7FFFFFFFFFFFFFFF ))
-            : (uiA != uiB) && (signA ^ (uiA < uiB));
 }
 
 static float64_t f64_mulAdd( float64_t a, float64_t b, float64_t c )

--- a/modules/core/src/softfloat.cpp
+++ b/modules/core/src/softfloat.cpp
@@ -4013,52 +4013,23 @@ static void f64_sincos_reduce(const float64_t& x, float64_t& y, int& n)
     else
     {
         /* argument reduction needed */
-        float64_t kf = f64_roundToInt(x/piby2, round_near_even, false);
-        //TODO: fix this
-        y = f64_rem(x, piby2);
-        //y = x - kf*piby2;
-
-        //TODO: remove it
-//        float64_t dd = abs(abs(y) - piby4);
-//        printf("dd: %a\n", (double)dd);
-
-        //TODO: try to get rid of 2nd _rem()
-        if(abs(abs(y) - piby4) < float64_t::eps().setExp(-10))
+        float64_t p = f64_rem(x, pi2);
+        float64_t v = p - float64_t::eps().setExp(-10);
+        if(abs(v) <= piby4)
         {
-            float64_t p = f64_rem(x, pi2);
-            y = y > 0 ? y : y + piby2;
-            if(p < -piby2)
-            {
-                n = 2;
-            }
-            else if(p > p.zero() && p < piby2)
-            {
-                n = 0;
-            }
-            else if(p > piby2)
-            {
-                n = 1;
-            }
-            else
-            {
-                n = 3;
-            }
+            n = 0; y = p;
+        }
+        else if(abs(v) <= (float64_t(3)*piby4))
+        {
+            n = (p > 0) ? 1 : 3;
+            y = (p > 0) ? p - piby2 : p + piby2;
+            if(p > 0) n = 1, y = p - piby2;
+            else      n = 3, y = p + piby2;
         }
         else
         {
-            //TODO: workaround against huge y values
-            int k;
-            int kex = kf.getExp();
-            uint64 u = (kf.v & ((1ULL << 52) - 1)) | (1ULL << 52);
-            if(kex >= 54) k = 0; // step of floats is 4+ in that case
-            else if(kex == 53)
-                k = u << 1;
-            else
-            {
-                k = u >> (52 - kex);
-            }
-            k = kf.getSign() ? -k : k;
-            n = k & 3;
+            n = 2;
+            y = (p > 0) ? p - p.pi() : p + p.pi();
         }
     }
 }

--- a/modules/core/src/softfloat.cpp
+++ b/modules/core/src/softfloat.cpp
@@ -102,13 +102,18 @@ static inline void raiseFlags( uint_fast8_t /* flags */)
 | Software floating-point rounding mode.
 *----------------------------------------------------------------------------*/
 enum {
-    round_near_even   = 0,
-    round_minMag      = 1,
-    round_min         = 2,
-    round_max         = 3,
-    round_near_maxMag = 4,
-    round_odd         = 5
+    round_near_even   = 0, // round to nearest, with ties to even
+    round_minMag      = 1, // round to minimum magnitude (toward zero)
+    round_min         = 2, // round to minimum (down)
+    round_max         = 3, // round to maximum (up)
+    round_near_maxMag = 4, // round to nearest, with ties to maximum magnitude (away from zero)
+    round_odd         = 5  // round to odd (jamming)
 };
+/* What is round_odd (from SoftFloat manual):
+ * If supported, mode round_odd first rounds a floating-point result to minimum magnitude,
+ * the same as round_minMag, and then, if the result is inexact, the least-significant bit
+ * of the result is set to 1. This rounding mode is also known as jamming.
+ */
 
 //fixed to make softfloat code stateless
 static const uint_fast8_t globalRoundingMode = round_near_even;

--- a/modules/core/test/test_math.cpp
+++ b/modules/core/test/test_math.cpp
@@ -3647,7 +3647,7 @@ TEST(Core_SoftFloat, sincos64)
         softdouble x;
         uint64 mantissa = (((long long int)((unsigned int)(rng)) << 32 ) | (unsigned int)(rng)) & ((1LL << 52) - 1);
         x.v = mantissa;
-        x = x.setSign(rng() % 2);
+        x = x.setSign((rng() % 2) != 0);
         x = x.setExp(exponents[rng() % exponents.size()]);
         inputs.push_back(x);
     }

--- a/modules/core/test/test_math.cpp
+++ b/modules/core/test/test_math.cpp
@@ -3583,8 +3583,6 @@ TEST(Core_SoftFloat, pow64)
 
 TEST(Core_SoftFloat, sincos64)
 {
-
-
     static const softdouble
             two = softdouble(2), three = softdouble(3),
             half = softdouble::one()/two,
@@ -3612,52 +3610,14 @@ TEST(Core_SoftFloat, sincos64)
             softdouble x = stdAngles[k*3] + pi*softdouble(2*((int)i-(int)nStdValues/2));
             softdouble s = stdAngles[k*3+1];
             softdouble c = stdAngles[k*3+2];
-
-            //TODO: remove it
-            printf("%a", (double)(sin(x) - s));
-            cout << endl;
-
             ASSERT_LE(abs(sin(x) - s), stdEps);
-
-            //TODO: remove it
-            printf("%a", (double)(cos(x) - c));
-            cout << endl;
-
             ASSERT_LE(abs(cos(x) - c), stdEps);
-
-            //TODO: remove it
-            printf("%a", (double)(sin(x + piby2) - c));
-            cout << endl;
-
             //sin(x+pi/2) = cos(x)
             ASSERT_LE(abs(sin(x + piby2) - c), stdEps);
-
-            //TODO: remove it
-            printf("%a", (double)(sin(x + pi) + s));
-            cout << endl;
-
             //sin(x+pi) = -sin(x)
             ASSERT_LE(abs(sin(x + pi) + s), stdEps);
-
-            //TODO: remove it
-            printf("%a", (double)(cos(x+piby2) + s));
-            cout << endl;
-
-            //TODO: remove it
-            printf("%a", (double)(sin(x) - s));
-            cout << endl;
-            printf("%a %a %a",(double)(x+piby2), (double)(cos(x+piby2)), (double)(-s));
-            cout << endl;
-            printf("%f %f %f",(double)(x+piby2), (double)(cos(x+piby2)), (double)(-s));
-            cout << endl;
-
             //cos(x+pi/2) = -sin(x)
             ASSERT_LE(abs(cos(x+piby2) + s), stdEps);
-
-            //TODO: remove it
-            printf("%a", (double)(cos(x+pi) + c));
-            cout << endl;
-
             //cos(x+pi) = -cos(x)
             ASSERT_LE(abs(cos(x+pi) + c), stdEps);
         }
@@ -3696,124 +3656,22 @@ TEST(Core_SoftFloat, sincos64)
     {
         softdouble x = inputs[i];
 
-        //TODO: remove it
-        printf("x: %a", (double)x);
-        cout << endl;
-
         int xexp = x.getExp();
-        //we don't guarantee values for huge numbers at all
-//        softdouble randEps = (xexp >= 43) ? eps.setExp(  1) :
-//                             (xexp >= 20) ? eps.setExp(-10) :
-//                             (xexp >= 19) ? eps.setExp(-34) :
-//                             (xexp >= 17) ? eps.setExp(-37) :
-//                             (xexp >= 14) ? eps.setExp(-39) :
-//                             (xexp >= 12) ? eps.setExp(-41) :
-//                             (xexp >= 11) ? eps.setExp(-42) :
-//                             (xexp >=  9) ? eps.setExp(-44) :
-//                                            eps.setExp(-46);
         softdouble randEps = eps.setExp(max(xexp-52, -46));
-
-        //TODO: remove it
-        printf("randEps: %a", (double)randEps);
-        cout << endl;
-
         softdouble sx = sin(x);
         softdouble cx = cos(x);
         ASSERT_FALSE(sx.isInf()); ASSERT_FALSE(cx.isInf());
         ASSERT_FALSE(sx.isNaN()); ASSERT_FALSE(cx.isNaN());
         ASSERT_LE(abs(sx), one); ASSERT_LE(abs(cx), one);
-
-        //TODO: remove it
-        printf("%a", (double)((sx*sx + cx*cx) - one));
-        cout << endl;
-
         ASSERT_LE(abs((sx*sx + cx*cx) - one), eps);
-
-        //TODO: remove it
-        printf("%a", (double)(sin(x*two) - two*sx*cx));
-        cout << endl;
-
         ASSERT_LE(abs(sin(x*two) - two*sx*cx), randEps);
-
-        //TODO: remove it
-        printf("%a", (double)(cos(x*two) - (cx*cx - sx*sx)));
-        cout << endl;
-
-        //            printf("%a %a %a %a %a %a",
-        //                   (double)x, (double)(x*two), (double)(cos(x*two)),
-        //                   (double)(cx), (double)(sx),
-        //                   (double)(cos(x*two) - (cx*cx - sx*sx)));
-        //            cout << endl;
-        //            printf("%20.17f %20.17f %20.17f %20.17f %20.17f %20.17f",
-        //                   (double)x, (double)(x*two), (double)(cos(x*two)),
-        //                   (double)(cx), (double)(sx),
-        //                   (double)(cos(x*two) - (cx*cx - sx*sx)));
-        //            cout << endl;
-
         ASSERT_LE(abs(cos(x*two) - (cx*cx - sx*sx)), randEps);
-
         ASSERT_LE(abs(sin(-x) + sx), eps);
         ASSERT_LE(abs(cos(-x) - cx), eps);
-
-        //TODO: remove it
-        printf("%a", (double)(sin(x + piby2) - cx));
-        cout << endl;
-
-//        printf("%a %a %a %a %a",
-//               (double)x, (double)(x+piby2), (double)(sin(x+piby2)),
-//               (double)(cos(x)),
-//               (double)(sin(x + piby2) - cx));
-//        cout << endl;
-//        printf("%f %f %f %f %f",
-//               (double)x, (double)(x+piby2), (double)(sin(x+piby2)),
-//               (double)(cos(x)),
-//               (double)(sin(x + piby2) - cx));
-//        cout << endl;
-
-//        softdouble sp2 = abs(sin(x + piby2) - cx);
-//        if(sp2 > randEps)
-//        {
-//            cout << "aaa" << endl;
-//        }
-
         ASSERT_LE(abs(sin(x + piby2) - cx), randEps);
-
-        //TODO: remove it
-        printf("%a", (double)(sin(x + pi) + sx));
-        cout << endl;
-
         ASSERT_LE(abs(sin(x + pi) + sx), randEps);
-
-        //TODO: remove it
-        printf("%a", (double)(cos(x+piby2) + sx));
-        cout << endl;
-
-//        printf("%a %a %a %a %a",
-//               (double)x, (double)(x+piby2), (double)(cos(x+piby2)),
-//               (double)(-sin(x)),
-//               (double)(cos(x + piby2) + sx));
-//        cout << endl;
-//        printf("%f %f %f %f %f",
-//               (double)x, (double)(x+piby2), (double)(cos(x+piby2)),
-//               (double)(-sin(x)),
-//               (double)(cos(x + piby2) + sx));
-//        cout << endl;
-
-//        if(abs(cos(x+piby2) + sx) >= randEps)
-//        {
-//            cout << "aaaa" << endl;
-//        }
-
         ASSERT_LE(abs(cos(x+piby2) + sx), randEps);
-
-        //TODO: remove it
-        printf("%a", (double)(cos(x+pi) + cx));
-        cout << endl;
-
         ASSERT_LE(abs(cos(x+pi) + cx), randEps);
-
-        //TODO: remove it
-        printf("%d\n", i);
     }
 }
 

--- a/modules/core/test/test_math.cpp
+++ b/modules/core/test/test_math.cpp
@@ -3591,7 +3591,6 @@ TEST(Core_SoftFloat, sincos64)
             zero = softdouble::zero(), one = softdouble::one(),
             pi = softdouble::pi(), piby2 = pi/two, eps = softdouble::eps();
 
-    //TODO: check standard angles, +k*pi, +k*2*pi
     softdouble vstdAngles[] =
     //x, sin(x), cos(x)
     {
@@ -3603,23 +3602,62 @@ TEST(Core_SoftFloat, sincos64)
     vector<softdouble> stdAngles;
     stdAngles.assign(vstdAngles, vstdAngles + 3*4);
 
+    static const softdouble stdEps = eps.setExp(-39);
     for(size_t i = 0; i < nValues; i++)
     {
-        for(size_t k = 0; k < stdAngles.size(); k++)
+        for(size_t k = 0; k < stdAngles.size()/3; k++)
         {
-            softdouble x = stdAngles[k*3] + pi*softdouble(2*(i-nValues/2));
+            softdouble x = stdAngles[k*3] + pi*softdouble(2*((int)i-(int)nValues/2));
             softdouble s = stdAngles[k*3+1];
             softdouble c = stdAngles[k*3+2];
-            ASSERT_LE(abs(sin(x) - s), eps);
-            ASSERT_LE(abs(cos(x) - c), eps);
+
+            //TODO: remove it
+            printf("%a", (double)(sin(x) - s));
+            cout << endl;
+
+            ASSERT_LE(abs(sin(x) - s), stdEps);
+
+            //TODO: remove it
+            printf("%a", (double)(cos(x) - c));
+            cout << endl;
+
+            ASSERT_LE(abs(cos(x) - c), stdEps);
+
+            //TODO: remove it
+            printf("%a", (double)(sin(x + piby2) - c));
+            cout << endl;
+
             //sin(x+pi/2) = cos(x)
-            ASSERT_LE(abs(sin(x + piby2) - c), eps);
+            ASSERT_LE(abs(sin(x + piby2) - c), stdEps);
+
+            //TODO: remove it
+            printf("%a", (double)(sin(x + pi) + s));
+            cout << endl;
+
             //sin(x+pi) = -sin(x)
-            ASSERT_LE(abs(sin(x + pi) + s), eps);
+            ASSERT_LE(abs(sin(x + pi) + s), stdEps);
+
+            //TODO: remove it
+            printf("%a", (double)(cos(x+piby2) + s));
+            cout << endl;
+
+            //TODO: remove it
+            printf("%a", (double)(sin(x) - s));
+            cout << endl;
+            printf("%a %a %a",(double)(x+piby2), (double)(cos(x+piby2)), (double)(-s));
+            cout << endl;
+            printf("%f %f %f",(double)(x+piby2), (double)(cos(x+piby2)), (double)(-s));
+            cout << endl;
+
             //cos(x+pi/2) = -sin(x)
-            ASSERT_LE(abs(cos(x+piby2) + s), eps);
+            ASSERT_LE(abs(cos(x+piby2) + s), stdEps);
+
+            //TODO: remove it
+            printf("%a", (double)(cos(x+pi) + c));
+            cout << endl;
+
             //cos(x+pi) = -cos(x)
-            ASSERT_LE(abs(cos(x+pi) + c), eps);
+            ASSERT_LE(abs(cos(x+pi) + c), stdEps);
         }
     }
 
@@ -3646,33 +3684,120 @@ TEST(Core_SoftFloat, sincos64)
         softdouble x;
         uint64 mantissa = (((long long int)((unsigned int)(rng)) << 32 ) | (unsigned int)(rng)) & ((1LL << 52) - 1);
         x.v = mantissa;
-        x.setSign(rng() % 2);
-        x.setExp(exponents[rng() % exponents.size()]);
+        x = x.setSign(rng() % 2);
+        x = x.setExp(exponents[rng() % exponents.size()]);
         inputs.push_back(x);
     }
+
 
     for(size_t i = 0; i < nValues; i++)
     {
         softdouble x = inputs[i];
+
+        //TODO: remove it
+        printf("x: %a", (double)x);
+        cout << endl;
+
+        int xexp = x.getExp();
+        //we don't guarantee values for huge numbers at all
+        softdouble randEps = (xexp >= 43) ? eps.setExp(1) :
+                             (xexp >= 20) ? eps.setExp(-10) :
+                             (xexp >=  9) ? eps.setExp(-30) :
+                                            eps.setExp(-46);
+
         softdouble sx = sin(x);
         softdouble cx = cos(x);
         ASSERT_FALSE(sx.isInf()); ASSERT_FALSE(cx.isInf());
         ASSERT_FALSE(sx.isNaN()); ASSERT_FALSE(cx.isNaN());
         ASSERT_LE(abs(sx), one); ASSERT_LE(abs(cx), one);
         ASSERT_LE(abs((sx*sx + cx*cx) - one), eps);
-        //workaround inf overflow
-        if(abs(x.getExp()) < 1023)
+        if(xexp < 10)
         {
-            ASSERT_LE(abs(sin(x*two) - two*sx*cx), eps);
-            ASSERT_LE(abs(cos(x*two) - (cx*cx - sx*sx)), eps);
+            //TODO: remove it
+            printf("%a", (double)(sin(x*two) - two*sx*cx));
+            cout << endl;
+
+            ASSERT_LE(abs(sin(x*two) - two*sx*cx), randEps);
+
+            //TODO: remove it
+            printf("%a", (double)(cos(x*two) - (cx*cx - sx*sx)));
+            cout << endl;
+
+//            printf("%a %a %a %a %a %a",
+//                   (double)x, (double)(x*two), (double)(cos(x*two)),
+//                   (double)(cx), (double)(sx),
+//                   (double)(cos(x*two) - (cx*cx - sx*sx)));
+//            cout << endl;
+//            printf("%20.17f %20.17f %20.17f %20.17f %20.17f %20.17f",
+//                   (double)x, (double)(x*two), (double)(cos(x*two)),
+//                   (double)(cx), (double)(sx),
+//                   (double)(cos(x*two) - (cx*cx - sx*sx)));
+//            cout << endl;
+
+            ASSERT_LE(abs(cos(x*two) - (cx*cx - sx*sx)), randEps);
         }
         ASSERT_LE(abs(sin(-x) + sx), eps);
         ASSERT_LE(abs(cos(-x) - cx), eps);
 
-        ASSERT_LE(abs(sin(x + piby2) - cx), eps);
-        ASSERT_LE(abs(sin(x + pi) + sx), eps);
-        ASSERT_LE(abs(cos(x+piby2) + sx), eps);
-        ASSERT_LE(abs(cos(x+pi) + cx), eps);
+        //TODO: remove it
+        printf("%a", (double)(sin(x + piby2) - cx));
+        cout << endl;
+
+//        printf("%a %a %a %a %a",
+//               (double)x, (double)(x+piby2), (double)(sin(x+piby2)),
+//               (double)(cos(x)),
+//               (double)(sin(x + piby2) - cx));
+//        cout << endl;
+//        printf("%f %f %f %f %f",
+//               (double)x, (double)(x+piby2), (double)(sin(x+piby2)),
+//               (double)(cos(x)),
+//               (double)(sin(x + piby2) - cx));
+//        cout << endl;
+
+//        softdouble sp2 = abs(sin(x + piby2) - cx);
+//        if(sp2 > randEps)
+//        {
+//            cout << "aaa" << endl;
+//        }
+
+        ASSERT_LE(abs(sin(x + piby2) - cx), randEps);
+
+        //TODO: remove it
+        printf("%a", (double)(sin(x + pi) + sx));
+        cout << endl;
+
+        ASSERT_LE(abs(sin(x + pi) + sx), randEps);
+
+        //TODO: remove it
+        printf("%a", (double)(cos(x+piby2) + sx));
+        cout << endl;
+
+//        printf("%a %a %a %a %a",
+//               (double)x, (double)(x+piby2), (double)(cos(x+piby2)),
+//               (double)(-sin(x)),
+//               (double)(cos(x + piby2) + sx));
+//        cout << endl;
+//        printf("%f %f %f %f %f",
+//               (double)x, (double)(x+piby2), (double)(cos(x+piby2)),
+//               (double)(-sin(x)),
+//               (double)(cos(x + piby2) + sx));
+//        cout << endl;
+
+//        if(abs(cos(x+piby2) + sx) >= randEps)
+//        {
+//            cout << "aaaa" << endl;
+//        }
+
+        ASSERT_LE(abs(cos(x+piby2) + sx), randEps);
+
+        //TODO: remove it
+        printf("%a", (double)(cos(x+pi) + cx));
+        cout << endl;
+
+        ASSERT_LE(abs(cos(x+pi) + cx), randEps);
+
+        //TODO: remove it
+        printf("%d\n", i);
     }
 }
 


### PR DESCRIPTION
### This pullrequest changes

- `sin` and `cos` functions added for `softdouble`, ported from [fdlibm](http://www.netlib.org/fdlibm/)
- tests added for `sin` and `cos`
- documentation written
- `softfloat` and `softdouble` classes:
     * added more methods: getters/setters for sign bit, exponent and significand, `isSubnormal`
     * added more static constants: `min`, `max`, `eps`, `pi`

<!-- Please describe what your pullrequest is changing -->
