### PR TITLE
Maven build improvements

### DIFF
--- a/platforms/maven/.gitignore
+++ b/platforms/maven/.gitignore
@@ -1,0 +1,3 @@
+**/*.iml
+.idea/
+**/*.versionsBackup

--- a/platforms/maven/README.md
+++ b/platforms/maven/README.md
@@ -47,13 +47,13 @@ By default the following build directories are created.
 
 `<OpenCV_root_dir>/build/maven/opencv-it/target`
 
-Under `build` are the standard OpenCV artifacts. Under `build/maven/opencv/target` can be found the OSGi compatible Java bundle. When deploying the bundle into an OSGi framework e.g. [Apache Karaf](http://karaf.apache.org/), loading of the native library is automatically taken care of. An integration testing module is created under the `open-cv` directory and is only of use during the build. The standard Java library as created by the CMake process is also available as specified in the existing OpenCV documentation.
+Under `build` are the standard OpenCV artifacts. Under `build/maven/opencv/target` can be found the OSGi compatible Java bundle. When deploying the bundle into an OSGi framework e.g. [Apache Karaf](http://karaf.apache.org/), loading of the native library is automatically taken care of. An integration testing module is created under the `opencv-it` directory and is only of use during the build but is disabled by fault. The standard Java library as created by the CMake process is also available as specified in the existing OpenCV documentation.
 
 The Maven build is initiated from the directory contain the `pom.xml` file.
 #### 3.3 - x86 or x86_64 Architecture:
 Generally all that is required is the standard Maven command:
 
-`mvn clean install -Ddownload.cmake=false`
+`mvn clean install`
 
 One of the first things the build will do is check the required native dependencies. The Maven build indicates the status of the required dependencies and will fail at this point if any are missing. Install using the package manager e.g. aptitude or apt-get, and restart the build with the above command.
 
@@ -64,8 +64,32 @@ Similar to the x86 architecture the native dependencies are first checked so ins
 
 **PLEASE NOTE THESE ARE NOT OFFICIAL RASPBIAN PACKAGES. INSTALL AT YOUR OWN RISK.**
 
-OpenCV is built using CMake and the Maven build process uses the the [cmake-maven plugin](https://github.com/cmake-maven-project/cmake-maven-project). The cmake-maven plugin by default downloads CMake at build time but unfortunately there is no binary for ARM architecture currently available. As a work around it is possible to use the native CMake (which is checked for availability in the above dependency checks). Assuming all native dependencies are available the build can be started with the following command:
+The build can be started with the following command:
 
-`mvn clean install -Ddownload.cmake=false`
+`mvn clean install`
 
 Upon a successful build the libraries will be available as described above in 'Build Directory'.
+
+#### 3.5 CMake
+**Applicability:** x86 processors
+
+The CMake Maven plugin is configured to use the native CMake package (recommended) i.e. it will NOT download the latest CMake binary. Should you require CMake download then include the following Maven commandline switch when building:
+
+ `-Ddownload.cmake=true`
+
+ #### 3.6 Integration Tests
+ **Applicability:** All processors
+
+ OSGi integration tests can be run as part of the build by including the following commandline switch to Maven:
+
+ `-Pintegration`
+
+### 4.0 Maintainer Notes
+This section is relevant to those maintaining the Maven platform build. If you just want to build the library then you do not need to refer to this section.
+
+#### 4.1 Updating POM Version to Match Core Version
+Maven requires the version to be hard-coded in the POM or in otherwords it cannot be changed at runtime. When the core C/C++ code version changes it is easy to forget to update the Maven version. The POM utilises the enforcer plugin to ensure the POM and Core versions match causing the build to fail if they do not.
+
+Should the POM version require updating then this can be done utilising the Maven 'versions' plugin and this will apply the correct version to all POMs within the project. Execute the following Maven command from the root directory of the Maven project:
+
+`mvn versions:set -DnewVersion=$(. ./opencv/scripts/functions && cd ./opencv/scripts && extract_version && echo $REPLY)`

--- a/platforms/maven/opencv-it/pom.xml
+++ b/platforms/maven/opencv-it/pom.xml
@@ -89,6 +89,19 @@
         <testOutputDirectory>../../../build/maven/opencv-it/target</testOutputDirectory>
         <plugins>
             <plugin>
+                <groupId>org.apache.servicemix.tooling</groupId>
+                <artifactId>depends-maven-plugin</artifactId>
+                <version>1.4.0</version>
+                <executions>
+                    <execution>
+                        <id>generate-depends-file</id>
+                        <goals>
+                            <goal>generate-depends-file</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>2.15</version>

--- a/platforms/maven/opencv-it/src/test/java/org/opencv/osgi/DeployOpenCVTest.java
+++ b/platforms/maven/opencv-it/src/test/java/org/opencv/osgi/DeployOpenCVTest.java
@@ -65,7 +65,7 @@ public class DeployOpenCVTest {
             mavenBundle()
             .groupId("org.opencv")
             .artifactId("opencv")
-            .version("3.3.0"),
+            .versionAsInProject(),
             logLevel(LogLevelOption.LogLevel.INFO)
         };
     }

--- a/platforms/maven/opencv/pom.xml
+++ b/platforms/maven/opencv/pom.xml
@@ -50,7 +50,6 @@
                             <workingDirectory>${project.basedir}/scripts</workingDirectory>
                             <arguments>
                                 <argument>properties</argument>
-                                <argument>../../../../modules/core/include/opencv2/core/version.hpp</argument>
                                 <argument>${build.directory}</argument>
                                 <argument>build.properties</argument>
                             </arguments>
@@ -66,6 +65,8 @@
                             <executable>bash</executable>
                             <workingDirectory>${project.basedir}/scripts</workingDirectory>
                             <arguments>
+                              <!-- Optional packages should be placed BEFORE required ones
+                              in the following argument list. -->
                                 <argument>deb_package_check</argument>
                                 <argument>-olibpng-dev|libpng12-dev</argument>
                                 <argument>-olibopenjp2-7-dev|libjasper-dev</argument>
@@ -175,14 +176,14 @@
                         <configuration>
                             <rules>
                                 <requireEnvironmentVariable>
-                                    <level>WARN</level>
+                                    <level>ERROR</level>
                                     <variableName>ANT_HOME</variableName>
                                     <message>$ANT_HOME is not set. Build may fail.</message>
                                 </requireEnvironmentVariable>
                                 <requireEnvironmentVariable>
-                                    <level>WARN</level>
+                                    <level>ERROR</level>
                                     <variableName>JAVA_HOME</variableName>
-                                    <message>$JAVA_HOME is not set. Build may fail.</message>
+                                    <message>$JAVA_HOME is not set. Build will fail.</message>
                                 </requireEnvironmentVariable>
                                 <requireEnvironmentVariable>
                                     <level>WARN</level>
@@ -204,7 +205,9 @@ To speed up the build you can try exporting MAKEFLAGS=-jX where X equals the num
                                 <requireProperty>
                                     <property>project.version</property>
                                     <regex>${opencv.version}</regex>
-                                    <regexMessage>The Maven POM version ${project.version} does not match the extracted OpenCV version ${opencv.version}.</regexMessage>
+                                    <regexMessage>The Maven POM version ${project.version} does not match the extracted OpenCV version ${opencv.version}.
+To correct this please execute the following Maven command from the Maven root directory:
+    mvn versions:set -DnewVersion=$(. ./opencv/scripts/functions &amp;&amp; cd ./opencv/scripts &amp;&amp; extract_version &amp;&amp; echo $REPLY)</regexMessage>
                                 </requireProperty>
                             </rules>
                         </configuration>

--- a/platforms/maven/opencv/scripts/functions
+++ b/platforms/maven/opencv/scripts/functions
@@ -1,0 +1,21 @@
+#!/bin/bash
+###############################################################
+#
+# Defines some common functions.
+#
+# Kerry Billingham <contact [At] AvionicEngineers.{com]>
+#
+##############################################################
+majorHashDefine="#define CV_VERSION_MAJOR"
+minorHashDefine="#define CV_VERSION_MINOR"
+revisionHashDefine="#define CV_VERSION_REVISION"
+statusHashDefine="#define CV_VERSION_STATUS"
+versionHeader="../../../../modules/core/include/opencv2/core/version.hpp"
+
+function extract_version() {
+    minorVersion=$(grep "${minorHashDefine}" $versionHeader | grep -o ".$")
+    majorVersion=$(grep "${majorHashDefine}" $versionHeader | grep -o ".$")
+    revision=$(grep "${revisionHashDefine}" $versionHeader | grep -o ".$")
+
+    REPLY="${majorVersion}.${minorVersion}.${revision}"
+}

--- a/platforms/maven/opencv/scripts/properties
+++ b/platforms/maven/opencv/scripts/properties
@@ -13,9 +13,8 @@
 # called during the Maven build process.
 #
 # Command-line parameters:
-#   $1 - Absolute path to the file containing Open CV version
-#   $2 - The build directory and where the output file will be written
-#   $3 - The name of the output file to write to.
+#   $1 - The build directory and where the output file will be written
+#   $2 - The name of the output file to write to.
 #
 # Returns:
 #   0 - Successfully written the properties file.
@@ -28,21 +27,18 @@
 #
 #####################################################################
 
-majorHashDefine="#define CV_VERSION_MAJOR"
-minorHashDefine="#define CV_VERSION_MINOR"
-revisionHashDefine="#define CV_VERSION_REVISION"
-statusHashDefine="#define CV_VERSION_STATUS"
+# Include some external functions and variables
+. ./functions
 
 #Test build directory exists
-if [  ! -n "$2" ] || [ ! -d $2 ];then
+if [  ! -n "$1" ] || [ ! -d $1 ];then
     echo "Build directory not specified or does not exist!"
     exit 1
 fi
 
-if [ -n "$1" ] && [ -e $1 ];then
-    minorVersion=$(grep "${minorHashDefine}" $1 | grep -o ".$")
-    majorVersion=$(grep "${majorHashDefine}" $1 | grep -o ".$")
-    revision=$(grep "${revisionHashDefine}" $1 | grep -o ".$")
+if [ -n "${versionHeader}" ] && [ -e ${versionHeader} ];then
+
+    extract_version
 
     bits=$(getconf LONG_BIT)
     architecture=$(arch)
@@ -78,13 +74,13 @@ if [ -n "$1" ] && [ -e $1 ];then
         esac
 
     echo "The version number will be ${majorVersion}.${minorVersion}.${revision}"
-    echo "opencv.version=${majorVersion}.${minorVersion}.${revision}" > ${2}/${3}
-    echo "lib.version.string=${majorVersion}${minorVersion}${revision}" >> ${2}/${3}
-    echo "bits=${bits}" >> ${2}/${3}
-    echo "architecture=$(arch)" >> ${2}/${3}
-    echo "osgi.processor=${osgiProcessor}" >> ${2}/${3}
+    echo "opencv.version=${majorVersion}.${minorVersion}.${revision}" > ${1}/${2}
+    echo "lib.version.string=${majorVersion}${minorVersion}${revision}" >> ${1}/${2}
+    echo "bits=${bits}" >> ${1}/${2}
+    echo "architecture=$(arch)" >> ${1}/${2}
+    echo "osgi.processor=${osgiProcessor}" >> ${1}/${2}
     exit 0
 else
-    echo "Could not locate file $1 to determine versioning."
+    echo "Could not locate file ${versionHeader} to determine versioning."
     exit 1
 fi

--- a/platforms/maven/pom.xml
+++ b/platforms/maven/pom.xml
@@ -31,6 +31,7 @@
         <pax.exam.version>4.8.0</pax.exam.version>
         <maven.compiler.source>1.7</maven.compiler.source>
         <maven.compiler.target>1.7</maven.compiler.target>
+        <download.cmake>false</download.cmake>
     </properties>
     <distributionManagement>
         <snapshotRepository>
@@ -41,6 +42,16 @@
 
     <modules>
         <module>opencv</module>
-        <module>opencv-it</module>
     </modules>
+    <profiles>
+        <profile>
+            <id>integration</id>
+            <activation>
+                <activeByDefault>false</activeByDefault>
+            </activation>
+            <modules>
+                <module>opencv-it</module>
+            </modules>
+        </profile>
+    </profiles>
 </project>


### PR DESCRIPTION
### This pullrequest changes

Documented how to change the version of Maven to match OpenCV core and modified bash scripts accordingly.

Changed from WARN to ERROR the environment variable checks - I found that without these set the build would fail on Linux Mint and less experienced individuals may be mystified by the CMake fail message. This change hopefully makes the failure more obvious.

Extracted integration test module and placed into own profile.

Configured CMake Maven plugin to use native CMake by default.

Updated documentation.

<!-- Please describe what your pullrequest is changing -->
