### PR TITLE
Fixed some OpenCL interface bugs

### DIFF
--- a/modules/core/include/opencv2/core/ocl.hpp
+++ b/modules/core/include/opencv2/core/ocl.hpp
@@ -584,7 +584,6 @@ public:
     Program();
     Program(const ProgramSource& src,
             const String& buildflags, String& errmsg);
-    explicit Program(const String& buf);
     Program(const Program& prog);
 
     Program& operator = (const Program& prog);

--- a/modules/core/src/ocl.cpp
+++ b/modules/core/src/ocl.cpp
@@ -2143,7 +2143,7 @@ int Kernel::set(int i, const Image2D& image2D)
 
 int Kernel::set(int i, const UMat& m)
 {
-    return set(i, KernelArg(KernelArg::READ_WRITE, (UMat*)&m, 0, 0));
+    return set(i, KernelArg(KernelArg::READ_WRITE, (UMat*)&m));
 }
 
 int Kernel::set(int i, const KernelArg& arg)


### PR DESCRIPTION
<!-- Please use this line to close one or multiple issues when this pullrequest gets merged
You can add another line right under the first one:
resolves #1234
resolves #1235
-->

### This pullrequest changes

* Removed constructor without body
* Keep arguments `wscale` and `iwscale` by default (ones). Otherwise it gives floating point exception because of 0 by 0 division at https://github.com/opencv/opencv/blob/master/modules/core/src/ocl.cpp#L2204.