### PR TITLE
calib3d: suppress warning message

### DIFF
--- a/modules/calib3d/src/calibration.cpp
+++ b/modules/calib3d/src/calibration.cpp
@@ -2758,7 +2758,7 @@ void cv::reprojectImageTo3D( InputArray _disparity,
     __3dImage.create(disparity.size(), CV_MAKETYPE(dtype, 3));
     Mat _3dImage = __3dImage.getMat();
 
-    const double bigZ = 10000.;
+    const float bigZ = 10000.f;
     Matx44d _Q;
     Q.convertTo(_Q, CV_64F);
 


### PR DESCRIPTION
<!-- Please use this line to close one or multiple issues when this pullrequest gets merged
You can add another line right under the first one:
resolves #1234
resolves #1235
-->

### This pullrequest changes
 - suppress warning message
 - ```bigZ``` is **only** used [here ](https://github.com/opencv/opencv/blob/800f656402740948a498023202cc597f96cc140b/modules/calib3d/src/calibration.cpp#L2816)
```cpp
dptr[x][2] = bigZ;
```
 - where ```dptr``` is an array of ```float```
 - I guess ```const float``` should be good enough for ```bigZ```

<!-- Please describe what your pullrequest is changing -->
