### PR TITLE
core(build): fix compilation of parallel.cpp (OpenMP configuration)

### DIFF
--- a/modules/core/src/parallel.cpp
+++ b/modules/core/src/parallel.cpp
@@ -125,6 +125,8 @@
 #  define CV_PARALLEL_FRAMEWORK "pthreads"
 #endif
 
+using namespace cv;
+
 namespace cv
 {
     ParallelLoopBody::~ParallelLoopBody() {}


### PR DESCRIPTION
resolves #9351
