### PR TITLE
imgproc: fix winSize in createHanningWindow()

### DIFF
--- a/modules/imgproc/include/opencv2/imgproc.hpp
+++ b/modules/imgproc/include/opencv2/imgproc.hpp
@@ -2723,7 +2723,7 @@ An example is shown below:
     createHanningWindow(hann, Size(100, 100), CV_32F);
 @endcode
 @param dst Destination array to place Hann coefficients in
-@param winSize The window size specifications
+@param winSize The window size specifications (both width and height must be > 1)
 @param type Created array type
  */
 CV_EXPORTS_W void createHanningWindow(OutputArray dst, Size winSize, int type);

--- a/modules/imgproc/src/phasecorr.cpp
+++ b/modules/imgproc/src/phasecorr.cpp
@@ -579,6 +579,7 @@ void cv::createHanningWindow(OutputArray _dst, cv::Size winSize, int type)
     CV_INSTRUMENT_REGION()
 
     CV_Assert( type == CV_32FC1 || type == CV_64FC1 );
+    CV_Assert( winSize.width > 1 && winSize.height > 1 );
 
     _dst.create(winSize, type);
     Mat dst = _dst.getMat();


### PR DESCRIPTION
resolves #9378

add a note in docs, that winSize has to be > 1. (a winSize of 2 will still produce an all zero output)
add an assertion in createHanningWindow