### PR TITLE
Torch's Concat and ConcatTable doesn't use Split layer

### DIFF
--- a/modules/dnn/src/layers/split_layer.cpp
+++ b/modules/dnn/src/layers/split_layer.cpp
@@ -75,7 +75,7 @@ public:
 
         Layer::getMemoryShapes(inputs, max(1, outputsCount >= 0 ? outputsCount : requiredOutputs),
                                outputs, internals);
-        return true;
+        return false;
     }
 
     void forward(std::vector<Mat*> &inputs, std::vector<Mat> &outputs, std::vector<Mat> &internals)
@@ -86,8 +86,7 @@ public:
         for (size_t i = 0; i < outputs.size(); i++)
         {
             CV_Assert(inputs[0]->total() == outputs[i].total());
-            if (outputs[i].data != inputs[0]->data)
-                inputs[0]->copyTo(outputs[i]);
+            inputs[0]->copyTo(outputs[i]);
         }
     }
 };


### PR DESCRIPTION
<!-- Please use this line to close one or multiple issues when this pullrequest gets merged
You can add another line right under the first one:
resolves #1234
resolves #1235
-->

### This pullrequest changes
Proposed not use Split layer in case of Torch's `nn.Concat` and `nn.ConcatTable`.
Both modules are used to apply a set of transformations for the same input. In example,
```lua
net = nn.Concat()
net:add(nn.ReLU())
net:add(nn.SpatialConvolution(inCh, outCh, kw, kh, dx, dy))
```
This graph looks like
```
input
  |                      ________
  +------> ReLU ------> |        |
  |                     | Concat |
  +------> Conv ------> |________|

```

But if we have something like
```lua
net = nn.Concat()
net:add(nn.ReLU(true))
net:add(nn.SpatialConvolution(inCh, outCh, kw, kh, dx, dy))
```
where `true` means `inplace` ReLU, then

```
                                   ________
input ---> ReLU ----------------> |        |
            |                     | Concat |
            +------> Conv ------> |________|
```

But it may be simply replaced by something like
```lua
net = nn.Sequential()
net:add(nn.ReLU(true))
concat = nn.Concat()
concat:add(nn.Identity())
concat:add(nn.SpatialConvolution(inCh, outCh, kw, kh, dx, dy))
net:add(concat)
```
`nn.ConcatTable` works in a similar way.

So, proposed to remove `inplace` mode of Split layer because it can't be responsible to the future layers behavior. Also, removed Split layer insertion at Torch importer.
Currently, we make element-wise layers not to work in-place until input is used by someone (references counter), so Split layer here is useless. In example, out test case:
```lua
net = nn.Concat(2)
net:add(nn.ReLU())
net:add(nn.Tanh())
net:add(nn.Sigmoid())
```
Here `ReLU` and `TanH` have `dst != src` but `Simoid` works in-place because there is no layers after it who use `Concat` block's input.
 