### PR TITLE
Advanced memory management for DNN blobs

### DIFF
--- a/modules/dnn/include/opencv2/dnn/dnn.hpp
+++ b/modules/dnn/include/opencv2/dnn/dnn.hpp
@@ -118,27 +118,6 @@ CV__DNN_EXPERIMENTAL_NS_BEGIN
     public:
         BackendWrapper(int backendId, int targetId);
 
-        /**
-         * @brief Wrap cv::Mat for specific backend and target.
-         * @param[in] targetId Target identifier.
-         * @param[in] m cv::Mat for wrapping.
-         *
-         * Make CPU->GPU data transfer if it's require for the target.
-         */
-        BackendWrapper(int targetId, const cv::Mat& m);
-
-        /**
-         * @brief Make wrapper for reused cv::Mat.
-         * @param[in] base Wrapper of cv::Mat that will be reused.
-         * @param[in] shape Specific shape.
-         *
-         * Initialize wrapper from another one. It'll wrap the same host CPU
-         * memory and mustn't allocate memory on device(i.e. GPU). It might
-         * has different shape. Use in case of CPU memory reusing for reuse
-         * associented memory on device too.
-         */
-        BackendWrapper(const Ptr<BackendWrapper>& base, const MatShape& shape);
-
         virtual ~BackendWrapper(); //!< Virtual destructor to make polymorphism.
 
         /**

--- a/modules/dnn/src/memory_manager.cpp
+++ b/modules/dnn/src/memory_manager.cpp
@@ -1,0 +1,148 @@
+// This file is part of OpenCV project.
+// It is subject to the license terms in the LICENSE file found in the top-level directory
+// of this distribution and at http://opencv.org/license.html.
+//
+// Copyright (C) 2017, Intel Corporation, all rights reserved.
+// Third party copyrights are property of their respective owners.
+
+#include "precomp.hpp"
+#include "memory_manager.hpp"
+
+namespace cv { namespace dnn {
+
+MemoryUser::MemoryUser(uint64_t startIter, uint64_t endIter, uint64_t memSize)
+    : startIter(startIter), endIter(endIter), memSize(memSize) {}
+
+bool MemoryUser::isActual(uint64_t iter)
+{
+    return startIter <= iter && iter <= endIter;
+}
+
+// Check if two intervals are intersected. Both bounds are inclusive.
+// l_from      l_to
+//   [----------]
+//         [---------]
+//        r_from    r_to
+// It isn't necessary to keep 'left' and 'right', it's just for naming.
+static bool isIntersection(uint64_t l_from, uint64_t l_to, uint64_t r_from,
+                           uint64_t r_to)
+{
+    return l_to >= r_from && l_from <= r_to;
+}
+
+static bool compareByMemSize(const MemoryUser& l, const MemoryUser& r)
+{
+    return l.memSize > r.memSize;
+}
+
+static bool compareByMemPos(const std::pair<MemoryUser, uint64_t>& l,
+                            const std::pair<MemoryUser, uint64_t>& r)
+{
+    return l.second < r.second;
+}
+
+// Check correctness.
+static void internalCheck(const std::vector<MemoryUser>& users,
+                          const std::vector<uint64_t>& memPoses)
+{
+    for (int i = 0; i < users.size(); ++i)
+    {
+        for (int j = i + 1; j < users.size(); ++j)
+        {
+            if (isIntersection(users[i].startIter, users[i].endIter,
+                               users[j].startIter, users[j].endIter)) {
+                uint64_t iMemPos = memPoses[users[i].id];
+                uint64_t jMemPos = memPoses[users[j].id];
+                CV_Assert(!isIntersection(iMemPos, iMemPos + users[i].memSize - 1,
+                                          jMemPos, jMemPos + users[j].memSize - 1));
+            }
+        }
+    }
+}
+
+void MemoryManager::solveOpt(std::vector<MemoryUser> users,
+                             std::vector<uint64_t>& memPoses, uint64_t* memUsage)
+{
+    const int numUsers = users.size();
+    memPoses.resize(numUsers, 0);
+    for (int i = 0; i < numUsers; ++i)
+        users[i].id = i;
+
+    // Sort by memory size in descending order.
+    std::sort(users.begin(), users.end(), compareByMemSize);
+
+    *memUsage = 0;
+    for (int i = 0; i < numUsers; ++i)
+    {
+        // Collect processed users that are actual at the same time.
+        std::vector<std::pair<MemoryUser, uint64_t> > processedUsers;
+        for (int j = 0; j < i; ++j)
+        {
+            if (isIntersection(users[i].startIter, users[i].endIter,
+                               users[j].startIter, users[j].endIter))
+            {
+                std::pair<MemoryUser, uint64_t> term(users[j], memPoses[users[j].id]);
+                processedUsers.push_back(term);
+            }
+        }
+        std::sort(processedUsers.begin(), processedUsers.end(), compareByMemPos);
+
+        uint64_t memPos = 0;
+        for (int j = 0; j < processedUsers.size(); ++j)
+        {
+            if (isIntersection(memPos, memPos + users[i].memSize - 1,
+                               processedUsers[j].second,
+                               processedUsers[j].second + processedUsers[j].first.memSize - 1))
+            {
+                memPos = processedUsers[j].second + processedUsers[j].first.memSize;
+            }
+        }
+        memPoses[users[i].id] = memPos;
+        *memUsage = std::max(*memUsage, memPos + users[i].memSize);
+    }
+    internalCheck(users, memPoses);
+}
+
+void MemoryManager::solveReuseOrCreate(std::vector<MemoryUser> users,
+                                       std::vector<uint64_t>& memPoses,
+                                       std::vector<int>& hostIds,
+                                       uint64_t* memUsage)
+{
+    hostIds.clear();
+    memPoses.resize(users.size(), 0);
+    for (int i = 0; i < users.size(); ++i)
+        users[i].id = i;
+
+    std::sort(users.begin(), users.end(), compareByMemSize);
+
+    *memUsage = 0;
+    std::vector<MemoryUser> layer;
+    layer.reserve(users.size());
+    do
+    {
+        for (int i = 0; i < users.size(); ++i)
+        {
+            bool addToLayer = true;
+            for (int j = 0; addToLayer && j < layer.size(); ++j)
+            {
+                addToLayer = !isIntersection(users[i].startIter, users[i].endIter,
+                                             layer[j].startIter, layer[j].endIter);
+            }
+            if (addToLayer)
+            {
+                memPoses[users[i].id] = *memUsage;
+                layer.push_back(users[i]);
+                users.erase(users.begin() + i);
+                --i;
+            }
+        }
+        hostIds.push_back(layer[0].id);
+        *memUsage += layer[0].memSize;
+        layer.clear();
+    }
+    while (!users.empty());
+    internalCheck(users, memPoses);
+}
+
+}  // namespace dnn
+}  // namespace cv

--- a/modules/dnn/src/memory_manager.hpp
+++ b/modules/dnn/src/memory_manager.hpp
@@ -1,0 +1,66 @@
+// This file is part of OpenCV project.
+// It is subject to the license terms in the LICENSE file found in the top-level directory
+// of this distribution and at http://opencv.org/license.html.
+//
+// Copyright (C) 2017, Intel Corporation, all rights reserved.
+// Third party copyrights are property of their respective owners.
+
+// There are several memory management models in this file. They are actual for
+// pipelines where we completely know about intervals of time and memory sizes
+// what will be required for every stage.
+
+#ifndef __OPENCV_DNN_MEMORY_MANAGER_HPP__
+#define __OPENCV_DNN_MEMORY_MANAGER_HPP__
+
+#include <opencv2/dnn.hpp>
+
+namespace cv { namespace dnn {
+
+// Memory user entity. It has request for memory size and it wants
+// to use it from the start iteration until the end iteration (inclusive both).
+// User expects continuous memory block that won't be damaged by other users
+// during mentioned period of time.
+struct MemoryUser
+{
+    MemoryUser(uint64_t startIter = 0, uint64_t endIter = 0, uint64_t memSize = 0);
+
+    uint64_t id;  // Optional field (is used internally).
+    uint64_t startIter;
+    uint64_t endIter;
+    uint64_t memSize;
+
+    bool isActual(uint64_t iter);
+};
+
+// Class that provides different memory management models.
+// Expected that users has similar dimensionalities of memSize, in bytes.
+class MemoryManager
+{
+public:
+    // Solve memory mamagement task in the most optimal way. It distributes
+    // pointers to memory blocks inside the single memory buffer.
+    // Returns offsets in the same order as users and size of buffer that
+    // must be allocated for pipeline (total memory usage).
+    static void solveOpt(std::vector<MemoryUser> users,
+                         std::vector<uint64_t>& memPoses, uint64_t* memUsage);
+
+    // Except this model is not optimal, it is one and only way to reuse
+    // memory on devices that have no pointers arithmetic. In example, we can't
+    // offset OpenCL's cl_mem memory object in C++ runtime, but we can offset
+    // destination pointer inside the kernel (pass cl_mem and offset pair).
+    // To simplify memory reusing, this model solves memory management task in
+    // the way when new users reuse memory block that was used before but
+    // is free now. Otherwise we just allocate the new one memory block.
+    // Returns offsets and indices of users that must be allocated on device
+    // (the rest of users has offsets considering to allocated memory). Also
+    // returns total memory usage.
+    static void solveReuseOrCreate(std::vector<MemoryUser> users,
+                                   std::vector<uint64_t>& memPoses,
+                                   std::vector<int>& hostIds,
+                                   uint64_t* memUsage);
+};
+
+}  // namespace dnn
+}  // namespace cv
+
+#endif  // __OPENCV_DNN_MEMORY_MANAGER_HPP__

--- a/modules/dnn/src/op_halide.cpp
+++ b/modules/dnn/src/op_halide.cpp
@@ -112,13 +112,12 @@ HalideBackendWrapper::HalideBackendWrapper(int targetId, const cv::Mat& m)
 }
 
 HalideBackendWrapper::HalideBackendWrapper(const Ptr<BackendWrapper>& base,
-                                           const MatShape& shape)
+                                           const MatShape& shape, const Mat& host)
     : BackendWrapper(DNN_BACKEND_HALIDE, base->targetId)
 {
     managesDevMemory = false;
     Halide::Buffer<float> baseBuffer = halideBuffer(base);
-    buffer = Halide::Buffer<float>((float*)baseBuffer.raw_buffer()->host,
-                                   getBufferShape(shape));
+    buffer = Halide::Buffer<float>((float*)host.data, getBufferShape(shape));
     if (baseBuffer.has_device_allocation())
     {
         buffer.raw_buffer()->device = baseBuffer.raw_buffer()->device;
@@ -195,7 +194,6 @@ void compileHalide(const std::vector<Mat> &outputs, Ptr<BackendNode>& node, int 
        .bound(c, 0, outC).bound(n, 0, outN);
 
     Halide::Target target = Halide::get_host_target();
-    target.set_feature(Halide::Target::NoAsserts);
     if (targetId == DNN_TARGET_OPENCL)
     {
         target.set_feature(Halide::Target::OpenCL);

--- a/modules/dnn/src/op_halide.hpp
+++ b/modules/dnn/src/op_halide.hpp
@@ -53,9 +53,9 @@ namespace dnn
     class HalideBackendWrapper : public BackendWrapper
     {
     public:
-        HalideBackendWrapper(int targetId, const cv::Mat& m);
+        HalideBackendWrapper(int targetId, const Mat& m);
 
-        HalideBackendWrapper(const Ptr<BackendWrapper>& base, const MatShape& shape);
+        HalideBackendWrapper(const Ptr<BackendWrapper>& base, const MatShape& shape, const Mat& host);
 
         ~HalideBackendWrapper();
 

--- a/modules/dnn/test/test_caffe_importer.cpp
+++ b/modules/dnn/test/test_caffe_importer.cpp
@@ -84,6 +84,8 @@ TEST(Reproducibility_AlexNet, Accuracy)
     Mat out = net.forward("prob");
     Mat ref = blobFromNPY(_tf("caffe_alexnet_prob.npy"));
     normAssert(ref, out);
+    // Network must produce the same output if input isn't changed.
+    normAssert(ref, net.forward("prob"), "Second run");
 }
 
 #if !defined(_WIN32) || defined(_WIN64)

--- a/modules/dnn/test/test_halide_nets.cpp
+++ b/modules/dnn/test/test_halide_nets.cpp
@@ -56,12 +56,15 @@ static void test(const std::string& weights, const std::string& proto,
 
     normAssert(outputDefault, outputHalide, "First run", l1, lInf);
 
+    // Expect to achieve the same output.
+    normAssert(netHalide.forward(outputLayer), outputHalide, "Second run", l1, lInf);
+
     // An extra test: change input.
     input *= 0.1f;
     netDefault.setInput(blobFromImage(input.clone(), 1.0, Size(), Scalar(), false));
     netHalide.setInput(blobFromImage(input.clone(), 1.0, Size(), Scalar(), false));
 
-    normAssert(outputDefault, outputHalide, "Second run", l1, lInf);
+    normAssert(outputDefault, outputHalide, "Third run", l1, lInf);
     std::cout << "." << std::endl;
 
     // Swap backends.
@@ -87,13 +90,12 @@ TEST(Reproducibility_MobileNetSSD_Halide, Accuracy)
          "", 300, 300, "detection_out", "caffe", DNN_TARGET_CPU);
 };
 
-// TODO: Segmentation fault from time to time.
-// TEST(Reproducibility_SSD_Halide, Accuracy)
-// {
-//     test(findDataFile("dnn/VGG_ILSVRC2016_SSD_300x300_iter_440000.caffemodel", false),
-//          findDataFile("dnn/ssd_vgg16.prototxt", false),
-//          "", 300, 300, "detection_out", "caffe", DNN_TARGET_CPU);
-// };
+TEST(Reproducibility_SSD_Halide, Accuracy)
+{
+    test(findDataFile("dnn/VGG_ILSVRC2016_SSD_300x300_iter_440000.caffemodel", false),
+         findDataFile("dnn/ssd_vgg16.prototxt", false),
+         "", 300, 300, "detection_out", "caffe", DNN_TARGET_CPU);
+};
 
 TEST(Reproducibility_GoogLeNet_Halide, Accuracy)
 {


### PR DESCRIPTION
<!-- Please use this line to close one or multiple issues when this pullrequest gets merged
You can add another line right under the first one:
resolves #1234
resolves #1235
-->

### This pullrequest changes
There are two methods: optimal for host memory that will be processed on CPU and a less optimal for device memory (OpenCL). The last one follows the same `reuse or create` strategy as we use now, but it makes more dense packing. Achieved results:

Model | with PR, host memory | with PR, device memory | before PR, host / dev | No reusing
-- | -- | -- | -- | --
AlexNet | 2.32MB | 2.6MB | 3.72MB | 6.14MB
Inception-5h | 5.2MB | 8.65MB | 15.62MB | 33.13MB
GoogLeNet | 5.21MB | 8.76MB | 15.74MB | 33.43MB
ENet, 512x256 | 23.59MB | 26.24MB | 72.22MB | 137.9MB
SqueezeNet v1.1 | 4.87MB | 5.07MB | 11.71MB | 20.71MB
ResNet-50 | 9.63MB | 10.43MB | 31.51MB | 66.64MB

* Despite at the same time is actual only one memory block (host or device) and we can skip some allocations of host memory, we can't make a decision about it at the allocation stage. So, in case of OpenCL backend, we allocate both CPU and GPU memory (as it was before PR).
* Outputs with no references (like indices of MaxPooling) are allocated too. Otherwise it will be more complicated for maintaining.
* Required changes: https://github.com/opencv/opencv/pull/9384.
