### PR TITLE
Fix Halide OpenCL buffer deallocation

### DIFF
--- a/modules/dnn/src/op_halide.hpp
+++ b/modules/dnn/src/op_halide.hpp
@@ -57,9 +57,14 @@ namespace dnn
 
         HalideBackendWrapper(const Ptr<BackendWrapper>& base, const MatShape& shape);
 
+        ~HalideBackendWrapper();
+
         virtual void copyToHost();
 
         Halide::Buffer<float> buffer;
+
+    private:
+        bool managesDevMemory;
     };
 #endif  // HAVE_HALIDE
 


### PR DESCRIPTION
<!-- Please use this line to close one or multiple issues when this pullrequest gets merged
You can add another line right under the first one:
resolves #1234
resolves #1235
-->

### This pullrequest changes
Unset device allocation from Halide buffers that just reuse it. Newer Halide frees it twice.
