### PR TITLE
opengl_interop build fix for macOS

### DIFF
--- a/samples/opengl/opengl_interop.cpp
+++ b/samples/opengl/opengl_interop.cpp
@@ -528,6 +528,8 @@ int main(int argc, char** argv)
     string wndname = "WGL Window";
 #elif defined(__linux__)
     string wndname = "GLX Window";
+#else
+    string wndname = "GL? Window";
 #endif
 
     GLWinApp app(width, height, wndname, cap);

--- a/samples/opengl/winapp.hpp
+++ b/samples/opengl/winapp.hpp
@@ -212,6 +212,8 @@ public:
         } while (!m_end_loop);
 
         return 0;
+#else
+        return 0;
 #endif
     }
 


### PR DESCRIPTION
resolves #9422

### This pullrequest changes

opengl_interop.cpp (definition of wndname)
winapp.hpp (return 0);

On platforms other than Linux and Windows interoperability would not work but at least this example builds and then it crashes at start. 

bin/opengl-example-opengl_interop