### PR TITLE
fix cv::CommandLineParser.

### DIFF
--- a/modules/core/include/opencv2/core/utility.hpp
+++ b/modules/core/include/opencv2/core/utility.hpp
@@ -808,7 +808,7 @@ public:
 
     This method returns the path to the executable from the command line (`argv[0]`).
 
-    For example, if the application has been started with such command:
+    For example, if the application has been started with such a command:
     @code{.sh}
     $ ./bin/my-executable
     @endcode
@@ -914,7 +914,7 @@ public:
     */
     void printMessage() const;
 
-    /** @brief Print list of errors occured
+    /** @brief Print list of errors occurred
 
     @sa check
     */

--- a/modules/core/src/command_line_parser.cpp
+++ b/modules/core/src/command_line_parser.cpp
@@ -69,6 +69,15 @@ static const char* get_type_name(int type)
     return "unknown";
 }
 
+static bool parse_bool(std::string str)
+{
+    std::transform(str.begin(), str.end(), str.begin(), ::tolower);
+    std::istringstream is(str);
+    bool b;
+    is >> (str.size() > 1 ? std::boolalpha : std::noboolalpha) >> b;
+    return b;
+}
+
 static void from_str(const String& str, int type, void* dst)
 {
     std::stringstream ss(str.c_str());
@@ -78,7 +87,7 @@ static void from_str(const String& str, int type, void* dst)
     {
         std::string temp;
         ss >> temp;
-        *(bool*) dst = temp == "true";
+        *(bool*) dst = parse_bool(temp);
     }
     else if( type == Param::UNSIGNED_INT )
         ss >> *(unsigned*)dst;
@@ -113,7 +122,7 @@ void CommandLineParser::getByName(const String& name, bool space_delete, int typ
                     if (space_delete)
                         v = cat_string(v);
 
-                    // the key was neither specified nor has it a default value
+                    // the key was neither specified nor has a default value
                     if((v.empty() && type != Param::STRING) || v == noneValue) {
                         impl->error = true;
                         impl->error_message = impl->error_message + "Missing parameter: '" + name + "'\n";
@@ -148,7 +157,7 @@ void CommandLineParser::getByIndex(int index, bool space_delete, int type, void*
                 String v = impl->data[i].def_value;
                 if (space_delete == true) v = cat_string(v);
 
-                // the key was neither specified nor has it a default value
+                // the key was neither specified nor has a default value
                 if((v.empty() && type != Param::STRING) || v == noneValue) {
                     impl->error = true;
                     impl->error_message = impl->error_message + format("Missing parameter #%d\n", index);

--- a/modules/core/test/test_utils.cpp
+++ b/modules/core/test/test_utils.cpp
@@ -35,8 +35,14 @@ TEST(CommandLineParser, testHas_noValues)
     cv::CommandLineParser parser(argc, argv, keys);
     EXPECT_TRUE(parser.has("help"));
     EXPECT_TRUE(parser.has("h"));
+    EXPECT_TRUE(parser.get<bool>("help"));
+    EXPECT_TRUE(parser.get<bool>("h"));
     EXPECT_TRUE(parser.has("info"));
     EXPECT_TRUE(parser.has("i"));
+    EXPECT_TRUE(parser.get<bool>("info"));
+    EXPECT_TRUE(parser.get<bool>("i"));
+    EXPECT_TRUE(parser.get<bool>("true"));
+    EXPECT_TRUE(parser.get<bool>("t"));
     EXPECT_FALSE(parser.has("n"));
     EXPECT_FALSE(parser.has("unused"));
 }
@@ -47,8 +53,14 @@ TEST(CommandLineParser, testHas_TrueValues)
     cv::CommandLineParser parser(argc, argv, keys);
     EXPECT_TRUE(parser.has("help"));
     EXPECT_TRUE(parser.has("h"));
+    EXPECT_TRUE(parser.get<bool>("help"));
+    EXPECT_TRUE(parser.get<bool>("h"));
     EXPECT_TRUE(parser.has("info"));
     EXPECT_TRUE(parser.has("i"));
+    EXPECT_TRUE(parser.get<bool>("info"));
+    EXPECT_TRUE(parser.get<bool>("i"));
+    EXPECT_TRUE(parser.get<bool>("true"));
+    EXPECT_TRUE(parser.get<bool>("t"));
     EXPECT_FALSE(parser.has("n"));
     EXPECT_FALSE(parser.has("unused"));
 }
@@ -59,8 +71,14 @@ TEST(CommandLineParser, testHas_TrueValues1)
     cv::CommandLineParser parser(argc, argv, keys);
     EXPECT_TRUE(parser.has("help"));
     EXPECT_TRUE(parser.has("h"));
+    EXPECT_TRUE(parser.get<bool>("help"));
+    EXPECT_TRUE(parser.get<bool>("h"));
     EXPECT_TRUE(parser.has("info"));
     EXPECT_TRUE(parser.has("i"));
+    EXPECT_TRUE(parser.get<bool>("info"));
+    EXPECT_TRUE(parser.get<bool>("i"));
+    EXPECT_TRUE(parser.get<bool>("true"));
+    EXPECT_TRUE(parser.get<bool>("t"));
     EXPECT_FALSE(parser.has("n"));
     EXPECT_FALSE(parser.has("unused"));
 }
@@ -71,8 +89,14 @@ TEST(CommandLineParser, testHas_FalseValues0)
     cv::CommandLineParser parser(argc, argv, keys);
     EXPECT_TRUE(parser.has("help"));
     EXPECT_TRUE(parser.has("h"));
+    EXPECT_FALSE(parser.get<bool>("help"));
+    EXPECT_FALSE(parser.get<bool>("h"));
     EXPECT_TRUE(parser.has("info"));
     EXPECT_TRUE(parser.has("i"));
+    EXPECT_FALSE(parser.get<bool>("info"));
+    EXPECT_FALSE(parser.get<bool>("i"));
+    EXPECT_TRUE(parser.get<bool>("true"));
+    EXPECT_TRUE(parser.get<bool>("t"));
     EXPECT_FALSE(parser.has("n"));
     EXPECT_FALSE(parser.has("unused"));
 }
@@ -99,30 +123,38 @@ TEST(CommandLineParser, testBoolOption_noValues)
     EXPECT_TRUE(parser.get<bool>("h"));
     EXPECT_TRUE(parser.get<bool>("info"));
     EXPECT_TRUE(parser.get<bool>("i"));
+    EXPECT_TRUE(parser.get<bool>("true"));
+    EXPECT_TRUE(parser.get<bool>("t"));
 }
 
 TEST(CommandLineParser, testBoolOption_TrueValues)
 {
-    const char* argv[] = {"<bin>", "-h=TRUE", "--info=true"};
-    const int argc = 3;
+    const char* argv[] = {"<bin>", "-h=TrUe", "-t=1", "--info=true", "-n=truE"};
+    const int argc = 5;
     cv::CommandLineParser parser(argc, argv, keys);
-    //EXPECT_TRUE(parser.get<bool>("help"));
-    //EXPECT_TRUE(parser.get<bool>("h"));
+    EXPECT_TRUE(parser.get<bool>("help"));
+    EXPECT_TRUE(parser.get<bool>("h"));
     EXPECT_TRUE(parser.get<bool>("info"));
     EXPECT_TRUE(parser.get<bool>("i"));
-    EXPECT_FALSE(parser.get<bool>("unused"));
-    EXPECT_FALSE(parser.get<bool>("n"));
+    EXPECT_TRUE(parser.get<bool>("true"));
+    EXPECT_TRUE(parser.get<bool>("t"));
+    EXPECT_TRUE(parser.get<bool>("unused"));
+    EXPECT_TRUE(parser.get<bool>("n"));
 }
 
 TEST(CommandLineParser, testBoolOption_FalseValues)
 {
-    const char* argv[] = {"<bin>", "--help=FALSE", "-i=false"};
-    const int argc = 3;
+    const char* argv[] = {"<bin>", "--help=FALSE", "-t=FaLsE", "-i=false", "-n=0"};
+    const int argc = 5;
     cv::CommandLineParser parser(argc, argv, keys);
     EXPECT_FALSE(parser.get<bool>("help"));
     EXPECT_FALSE(parser.get<bool>("h"));
     EXPECT_FALSE(parser.get<bool>("info"));
     EXPECT_FALSE(parser.get<bool>("i"));
+    EXPECT_FALSE(parser.get<bool>("true"));
+    EXPECT_FALSE(parser.get<bool>("t"));
+    EXPECT_FALSE(parser.get<bool>("unused"));
+    EXPECT_FALSE(parser.get<bool>("n"));
 }
 
 


### PR DESCRIPTION
<!-- Please use this line to close one or multiple issues when this pullrequest gets merged
You can add another line right under the first one:
resolves #1234
resolves #1235
-->

### This pullrequest changes
Fix commandline parser.

It should handle bool value not only of "true" but also of "TRUE" and "True".

<!-- Please describe what your pullrequest is changing -->
