### PR TITLE
python: eliminate -Wundef warning about NPY_INTERNAL_BUILD

### DIFF
--- a/modules/python/common.cmake
+++ b/modules/python/common.cmake
@@ -118,6 +118,7 @@ if(MSVC AND NOT ENABLE_NOISY_WARNINGS)
 endif()
 
 ocv_warnings_disable(CMAKE_CXX_FLAGS -Woverloaded-virtual -Wunused-private-field)
+ocv_warnings_disable(CMAKE_CXX_FLAGS -Wundef) # accurate guard via #pragma doesn't work (C++ preprocessor doesn't handle #pragma)
 
 if(MSVC AND NOT BUILD_SHARED_LIBS)
   set_target_properties(${the_module} PROPERTIES LINK_FLAGS "/NODEFAULTLIB:atlthunk.lib /NODEFAULTLIB:atlsd.lib /DEBUG")


### PR DESCRIPTION
numpy 1.13.0+

```
In file included from .../site-packages/numpy/core/include/numpy/ndarraytypes.h:4:0,
                 from .../site-packages/numpy/core/include/numpy/ndarrayobject.h:18,
                 from /home/alalek/projects/opencv/dev/modules/python/src2/cv2.cpp:10:
.../site-packages/numpy/core/include/numpy/npy_common.h:17:5: warning: "NPY_INTERNAL_BUILD" is not defined, evaluates to 0 [-Wundef]
 #if NPY_INTERNAL_BUILD
     ^~~~~~~~~~~~~~~~~~
```