### PR TITLE
ocl: Add a function to delete a cached program.

### DIFF
--- a/modules/core/include/opencv2/core/ocl.hpp
+++ b/modules/core/include/opencv2/core/ocl.hpp
@@ -248,6 +248,7 @@ public:
     const Device& device(size_t idx) const;
     Program getProg(const ProgramSource& prog,
                     const String& buildopt, String& errmsg);
+    void unloadProg(Program& prog);
 
     static Context& getDefault(bool initialize = true);
     void* ptr() const;

--- a/modules/core/src/ocl.cpp
+++ b/modules/core/src/ocl.cpp
@@ -1397,6 +1397,23 @@ struct Context::Impl
         return prog;
     }
 
+    void unloadProg(Program& prog)
+    {
+        cv::AutoLock lock(program_cache_mutex);
+        for (CacheList::iterator i = cacheList.begin(); i != cacheList.end(); ++i)
+        {
+              phash_t::iterator it = phash.find(*i);
+              if (it != phash.end())
+              {
+                  if (it->second.ptr() == prog.ptr())
+                  {
+                      phash.erase(*i);
+                      cacheList.erase(i);
+                      return;
+                  }
+              }
+        }
+    }
 
     IMPLEMENT_REFCOUNTABLE();
 
@@ -1660,7 +1677,11 @@ Program Context::getProg(const ProgramSource& prog,
     return p ? p->getProg(prog, buildopts, errmsg) : Program();
 }
 
-
+void Context::unloadProg(Program& prog)
+{
+    if (p)
+        p->unloadProg(prog);
+}
 
 #ifdef HAVE_OPENCL_SVM
 bool Context::useSVM() const


### PR DESCRIPTION
This is the counterpart of "Context::getProg". With this function,
user have chance to delete a program he don't need anymore from
global cached programs, and save resource.

<!-- Please use this line to close one or multiple issues when this pullrequest gets merged
You can add another line right under the first one:
resolves #1234
resolves #1235
-->

### This pullrequest changes

<!-- Please describe what your pullrequest is changing -->
