### PR TITLE
[GSOC] Speeding-up AKAZE, tracking tutorial

### DIFF
--- a/samples/cpp/tutorial_code/features2D/AKAZE_tracking/planar_tracking.cpp
+++ b/samples/cpp/tutorial_code/features2D/AKAZE_tracking/planar_tracking.cpp
@@ -62,8 +62,11 @@ void Tracker::setFirstFrame(const Mat frame, vector<Point2f> bb, string title, S
 
 Mat Tracker::process(const Mat frame, Stats& stats)
 {
+    TickMeter tm;
     vector<KeyPoint> kp;
     Mat desc;
+
+    tm.start();
     detector->detectAndCompute(frame, noArray(), kp, desc);
     stats.keypoints = (int)kp.size();
 
@@ -85,6 +88,8 @@ Mat Tracker::process(const Mat frame, Stats& stats)
         homography = findHomography(Points(matched1), Points(matched2),
                                     RANSAC, ransac_thresh, inlier_mask);
     }
+    tm.stop();
+    stats.fps = 1. / tm.getTimeSec();
 
     if(matched1.size() < 4 || homography.empty()) {
         Mat res;

--- a/samples/cpp/tutorial_code/features2D/AKAZE_tracking/stats.h
+++ b/samples/cpp/tutorial_code/features2D/AKAZE_tracking/stats.h
@@ -7,11 +7,13 @@ struct Stats
     int inliers;
     double ratio;
     int keypoints;
+    double fps;
 
     Stats() : matches(0),
         inliers(0),
         ratio(0),
-        keypoints(0)
+        keypoints(0),
+        fps(0.)
     {}
 
     Stats& operator+=(const Stats& op) {
@@ -19,6 +21,7 @@ struct Stats
         inliers += op.inliers;
         ratio += op.ratio;
         keypoints += op.keypoints;
+        fps += op.fps;
         return *this;
     }
     Stats& operator/=(int num)
@@ -27,6 +30,7 @@ struct Stats
         inliers /= num;
         ratio /= num;
         keypoints /= num;
+        fps /= num;
         return *this;
     }
 };

--- a/samples/cpp/tutorial_code/features2D/AKAZE_tracking/utils.h
+++ b/samples/cpp/tutorial_code/features2D/AKAZE_tracking/utils.h
@@ -25,15 +25,17 @@ void drawBoundingBox(Mat image, vector<Point2f> bb)
 void drawStatistics(Mat image, const Stats& stats)
 {
     static const int font = FONT_HERSHEY_PLAIN;
-    stringstream str1, str2, str3;
+    stringstream str1, str2, str3, str4;
 
     str1 << "Matches: " << stats.matches;
     str2 << "Inliers: " << stats.inliers;
     str3 << "Inlier ratio: " << setprecision(2) << stats.ratio;
+    str4 << "FPS: " << std::fixed << setprecision(2) << stats.fps;
 
-    putText(image, str1.str(), Point(0, image.rows - 90), font, 2, Scalar::all(255), 3);
-    putText(image, str2.str(), Point(0, image.rows - 60), font, 2, Scalar::all(255), 3);
-    putText(image, str3.str(), Point(0, image.rows - 30), font, 2, Scalar::all(255), 3);
+    putText(image, str1.str(), Point(0, image.rows - 120), font, 2, Scalar::all(255), 3);
+    putText(image, str2.str(), Point(0, image.rows - 90), font, 2, Scalar::all(255), 3);
+    putText(image, str3.str(), Point(0, image.rows - 60), font, 2, Scalar::all(255), 3);
+    putText(image, str4.str(), Point(0, image.rows - 30), font, 2, Scalar::all(255), 3);
 }
 
 void printStatistics(string name, Stats stats)
@@ -45,6 +47,7 @@ void printStatistics(string name, Stats stats)
     cout << "Inliers " << stats.inliers << endl;
     cout << "Inlier ratio " << setprecision(2) << stats.ratio << endl;
     cout << "Keypoints " << stats.keypoints << endl;
+    cout << "FPS " << std::fixed << setprecision(2) << stats.fps << endl;
     cout << endl;
 }
 


### PR DESCRIPTION
This PR adds FPS stats to tracking demo with AKAZE and ORB. This allows to easily compare performace of AKAZE vs ORB, note that fps are measured for whole pipeline of features + matching + homography estimation.

This is the last PR in series implementing GSoC project "Speeding-up AKAZE features":

mentor: @bmagyar

# Previous PRs

#8869 extends tests for AKAZE, reworks perf tests and fixes several bugs
#8951 first version of OCL implementation, many CPU improvements
#9249 reworks feature detection with the new faster algorithm
#9330 rework OCL implementation after feedback from @alalek, new test for OCL

# Project proposal

AKAZE features are scale-invariant binary features. They are licence-free and
currently available in main OpenCV repository. AKAZE features show for many
applications better accuracy than widely used ORB features (also implemented
in OpenCV) [0]. However currently the implementation of AKAZE features in
OpenCV is 4-5 times slower than implementation of ORB features and the
implementation of AKAZE features lacks GPU acceleration. I’d like to address
both issues with current implementation of AKAZE features.

There already exists improvements of original Pablo F. Alcantarilla code [1],
which was the base of the current OpenCV code. Most notably there is a fast
parallel CPU version [2], and CUDA-based GPU implementation [3], [4]. Both
implementations promise a major speedup. I’d like to integrate this work to
OpenCV.

## CPU version

CPU version should probably build upon [2], but much integration work and
improvement is needed. CPU version should use common techniques in OpenCV, for
example existing parallel framework and not custom parallelism. I’d like to
extend the code to use vector intrinsics (probably through the new dispatched
intrinsics framework), IPP and OpenCV hal functions where applicable to get
the further performance benefit. Careful integration (backed by tests) must be
done to preserve improvements made to OpenCV code over the time.

* base on [2]
* get some more performance using vectorization, IPP, hal
* new tests

## GPU version

GPU version should be transparently available through the T-API. We should probably prefer OpenCl version to integrate seamlessly into existing infrastructure in OpenCV. Although we might use some ideas from CUDA version [3], [4], it might be necessary to write the GPU kernel from scratch.

* new OpenCl kernel

## Benefits to OpenCV

* faster AKAZE feature detector/descriptor
* GPU version of AKAZE

## References

[0] http://ieeexplore.ieee.org/document/7804434/
[1] https://github.com/pablofdezalc/akaze
[2] https://github.com/h2suzuki/fast_akaze
[3] https://github.com/nbergst/akaze
[4] https://arxiv.org/abs/1607.06178


# Implemented features (all from proposal implemented)

* speed-up 2.2x - 3.77x on CPU measured on Intel(R) Core(TM) i7-6700 CPU @ 3.40GHz

![chart](https://user-images.githubusercontent.com/1316311/29688146-f50fd562-891e-11e7-9e61-8451ee2f6c90.png)

* extended tests coverage, added new tests for AKAZE (including stitching tests with AKAZE)
* reworked invariance tests in features2d
* reworked perf tests for features2d module
* fixed several bugs in AKAZE implementation
* improved CPU implementation on many places
* new algorithm for finding features - extensively tested to ensure it gives comparable (or even better) results that original implementation
* added OCL version for creation of scale space pyramid. Added tests to ensure OCL results are the same as CPU results.

Most of these improvements have been included in OpenCV 3.3 release (the first 3 PRs).


# Video

[![short video presenting this project](https://img.youtube.com/vi/k8nKPc4044A/0.jpg)](https://www.youtube.com/watch?v=k8nKPc4044A)

# Other work

Some code that hasn't been merged. This includes performance improvements that
wasn't worth the trade-off and explored approaches that didn't brought the
performance benefit.

[test_scharr](https://github.com/hrnr/opencv/tree/test_scharr) I have tried to
[replace Scharr operator in `Compute_Determinant_Hessian_Response` with Scharr
[with fixed 3x3 kernel.

[akaze_octaves](https://github.com/hrnr/opencv/tree/akaze_octaves) Reworked
[non-linear scale space pyramid so that diffusivity is propagated only inside
[octaves. Probably not worth it, since it damages accuracy.

[test_l1](https://github.com/hrnr/opencv/tree/test_l1) Using L1 metric for keypoints pruning is
surprisingly slower that computing L2 metric.

#9401 Reworked non-linear diffusion in cache optimal manner, but it didn't brought a nice speed-up.
After all it is better to stick to current (already reworked in #8951) parallel approach.

# Blogs

[Speeding-up OpenCV Features](https://medium.com/@hrnr_/speeding-up-opencv-features-2ae1bc700b9a)
