### PR TITLE
Adds cv::resizeWindow() overload taking a single cv::Size argument.

### DIFF
--- a/modules/highgui/include/opencv2/highgui.hpp
+++ b/modules/highgui/include/opencv2/highgui.hpp
@@ -401,13 +401,7 @@ CV_EXPORTS_W void imshow(const String& winname, InputArray mat);
  */
 CV_EXPORTS_W void resizeWindow(const String& winname, int width, int height);
 
-/** @brief Resizes window to the specified size
-
-@note
-
--   The specified window size is for the image area. Toolbars are not counted.
--   Only windows created without cv::WINDOW_AUTOSIZE flag can be resized.
-
+/** @overload
 @param winname Window name.
 @param size The new window size.
 */

--- a/modules/highgui/include/opencv2/highgui.hpp
+++ b/modules/highgui/include/opencv2/highgui.hpp
@@ -401,6 +401,18 @@ CV_EXPORTS_W void imshow(const String& winname, InputArray mat);
  */
 CV_EXPORTS_W void resizeWindow(const String& winname, int width, int height);
 
+/** @brief Resizes window to the specified size
+
+@note
+
+-   The specified window size is for the image area. Toolbars are not counted.
+-   Only windows created without cv::WINDOW_AUTOSIZE flag can be resized.
+
+@param winname Window name.
+@param size The new window size.
+*/
+CV_EXPORTS_W void resizeWindow(const String& winname, const cv::Size& size);
+
 /** @brief Moves window to the specified position
 
 @param winname Name of the window.

--- a/modules/highgui/src/window.cpp
+++ b/modules/highgui/src/window.cpp
@@ -190,6 +190,12 @@ void cv::resizeWindow( const String& winname, int width, int height )
     cvResizeWindow( winname.c_str(), width, height );
 }
 
+void cv::resizeWindow(const String& winname, const cv::Size& size)
+{
+   CV_TRACE_FUNCTION();
+   cvResizeWindow(winname.c_str(), size.width, size.height);
+}
+
 void cv::moveWindow( const String& winname, int x, int y )
 {
     CV_TRACE_FUNCTION();

--- a/samples/cpp/tutorial_code/features2D/AKAZE_tracking/planar_tracking.cpp
+++ b/samples/cpp/tutorial_code/features2D/AKAZE_tracking/planar_tracking.cpp
@@ -155,7 +155,7 @@ int main(int argc, char **argv)
     Mat frame;
     video_in >> frame;
     namedWindow(video_name, WINDOW_NORMAL);
-    cv::resizeWindow(video_name, frame.cols, frame.rows);
+    cv::resizeWindow(video_name, frame.size());
 
     cout << "Please select a bounding box, and press any key to continue." << endl;
     vector<Point2f> bb;


### PR DESCRIPTION
Adds `cv::resizeWindow()` overload taking a single `cv::Size` argument instead of 2 separate `width` and `height`.
