### PR TITLE
Restrict std::initializer_list constructors to arithmetic types.

### DIFF
--- a/modules/core/include/opencv2/core/mat.hpp
+++ b/modules/core/include/opencv2/core/mat.hpp
@@ -53,6 +53,10 @@
 
 #include "opencv2/core/bufferpool.hpp"
 
+#ifdef CV_CXX11
+#include <type_traits>
+#endif
+
 namespace cv
 {
 
@@ -988,7 +992,8 @@ public:
 #ifdef CV_CXX11
     /** @overload
     */
-    template<typename _Tp> explicit Mat(const std::initializer_list<_Tp> list);
+    template<typename _Tp, typename = typename std::enable_if<std::is_arithmetic<_Tp>::value>::type>
+    explicit Mat(const std::initializer_list<_Tp> list);
 #endif
 
 #ifdef CV_CXX_STD_ARRAY

--- a/modules/core/include/opencv2/core/mat.inl.hpp
+++ b/modules/core/include/opencv2/core/mat.inl.hpp
@@ -575,7 +575,7 @@ Mat::Mat(const std::vector<_Tp>& vec, bool copyData)
 }
 
 #ifdef CV_CXX11
-template<typename _Tp> inline
+template<typename _Tp, typename> inline
 Mat::Mat(const std::initializer_list<_Tp> list)
     : flags(MAGIC_VAL | DataType<_Tp>::type | CV_MAT_CONT_FLAG), dims(2), rows((int)list.size()),
       cols(1), data(0), datastart(0), dataend(0), datalimit(0), allocator(0), u(0), size(&rows), step(0)


### PR DESCRIPTION
This PR restricts the `cv::Mat::Mat(const std::initializer_list<_Tp>)` constructor to arithmetic types. That way, it won't be used in place of the copy constructor in this code:

```
cv::Mat image = cv::imread("image.png");
cv::Mat copy{image};  // Currently calls the initializer_list constructor which turns it into a 1x1 matrix.
```

Or:
```
struct Foo {
  cv::Mat image;
  Foo(cv::Mat const & mat) : image{mat} {} // also calls wrong cv::Mat constructor 
}
```

The `initializer_list` constructor broke existing code where the copy constructor was invoked with curly braces. The code worked fine with opencv 3.2, but not anymore with 3.3. I think it is quite important to fix quickly.

The initializer list constructor doesn't make sense for non-scalar values anyway.
