### PR TITLE
Addressing CUDA9 shfl deprecation

### DIFF
--- a/modules/core/include/opencv2/core/cuda/warp_shuffle.hpp
+++ b/modules/core/include/opencv2/core/cuda/warp_shuffle.hpp
@@ -51,6 +51,11 @@
 
 namespace cv { namespace cuda { namespace device
 {
+#if __CUDACC_VER_MAJOR__ >= 9
+#  define __shfl(x, y, z) __shfl_sync(0xFFFFFFFFU, x, y, z)
+#  define __shfl_up(x, y, z) __shfl_up_sync(0xFFFFFFFFU, x, y, z)
+#  define __shfl_down(x, y, z) __shfl_down_sync(0xFFFFFFFFU, x, y, z)
+#endif
     template <typename T>
     __device__ __forceinline__ T shfl(T val, int srcLane, int width = warpSize)
     {
@@ -147,6 +152,10 @@ namespace cv { namespace cuda { namespace device
     #endif
     }
 }}}
+
+#  undef __shfl
+#  undef __shfl_up
+#  undef __shfl_down
 
 //! @endcond
 


### PR DESCRIPTION

### This pullrequest changes

<!-- Please describe what your pullrequest is changing -->
In CUDA9, non-sync __shfl's are deprecated - they generate warnings and may not work properly. 