### PR TITLE
Layers for MobileNet from TensorFlow

### DIFF
--- a/modules/dnn/include/opencv2/dnn/all_layers.hpp
+++ b/modules/dnn/include/opencv2/dnn/all_layers.hpp
@@ -359,6 +359,12 @@ CV__DNN_EXPERIMENTAL_NS_BEGIN
         static Ptr<ReLULayer> create(const LayerParams &params);
     };
 
+    class CV_EXPORTS ReLU6Layer : public ActivationLayer
+    {
+    public:
+        static Ptr<ReLU6Layer> create(const LayerParams &params);
+    };
+
     class CV_EXPORTS ChannelsPReLULayer : public ActivationLayer
     {
     public:

--- a/modules/dnn/src/init.cpp
+++ b/modules/dnn/src/init.cpp
@@ -94,6 +94,7 @@ void initializeLayerFactory()
     CV_DNN_REGISTER_LAYER_CLASS(LPNormalize,    LPNormalizeLayer);
 
     CV_DNN_REGISTER_LAYER_CLASS(ReLU,           ReLULayer);
+    CV_DNN_REGISTER_LAYER_CLASS(ReLU6,          ReLU6Layer);
     CV_DNN_REGISTER_LAYER_CLASS(ChannelsPReLU,  ChannelsPReLULayer);
     CV_DNN_REGISTER_LAYER_CLASS(Sigmoid,        SigmoidLayer);
     CV_DNN_REGISTER_LAYER_CLASS(TanH,           TanHLayer);

--- a/modules/dnn/test/test_tf_importer.cpp
+++ b/modules/dnn/test/test_tf_importer.cpp
@@ -93,11 +93,12 @@ static void runTensorFlowNet(const std::string& prefix,
     normAssert(target, output, "", l1, lInf);
 }
 
-TEST(Test_TensorFlow, single_conv)
+TEST(Test_TensorFlow, conv)
 {
     runTensorFlowNet("single_conv");
     runTensorFlowNet("atrous_conv2d_valid");
     runTensorFlowNet("atrous_conv2d_same");
+    runTensorFlowNet("depthwise_conv2d");
 }
 
 TEST(Test_TensorFlow, padding)
@@ -116,8 +117,9 @@ TEST(Test_TensorFlow, pad_and_concat)
     runTensorFlowNet("pad_and_concat");
 }
 
-TEST(Test_TensorFlow, fused_batch_norm)
+TEST(Test_TensorFlow, batch_norm)
 {
+    runTensorFlowNet("batch_norm");
     runTensorFlowNet("fused_batch_norm");
 }
 
@@ -131,6 +133,11 @@ TEST(Test_TensorFlow, pooling)
 TEST(Test_TensorFlow, deconvolution)
 {
     runTensorFlowNet("deconvolution");
+}
+
+TEST(Test_TensorFlow, matmul)
+{
+    runTensorFlowNet("matmul");
 }
 
 TEST(Test_TensorFlow, fp16)


### PR DESCRIPTION
<!-- Please use this line to close one or multiple issues when this pullrequest gets merged
You can add another line right under the first one:
resolves #1234
resolves #1235
-->

### This pullrequest changes

resolves https://github.com/opencv/opencv/issues/9462 (waiting for feedback)

* ReLU6 layer added
* `depthwise_conv2d` layer from TensorFlow (convolution with #groups == #input_channels)
* Not fused batch normalization by single `Mul` and `Add` support

**Merge with extra**: https://github.com/opencv/opencv_extra/pull/370

How to run MobileNet using DNN:
* Go to https://github.com/tensorflow/models/blob/master/slim/nets/mobilenet_v1.md and download checkpoint for `MobileNet_v1_1.0_224` model. Unpack and navigate into the folder that contains:

  ```
  mobilenet_v1_1.0_224.ckpt.data-00000-of-00001
  mobilenet_v1_1.0_224.ckpt.index
  mobilenet_v1_1.0_224.ckpt.meta
  ```
* Create `.pb` model by:
  ```bash
  python ~/tensorflow/tensorflow_models/slim/export_inference_graph.py  \
    --model_name=mobilenet_v1 \
    --output_file=mobilenet_v1.pb \
    --image_size=224
  ```
  source: https://github.com/tensorflow/models/blob/master/slim/README.md#exporting-the-inference-graph

* Freeze
  
  ```bash
  python ~/tensorflow/tensorflow/python/tools/freeze_graph.py \
    --input_graph=mobilenet_v1.pb \
    --input_checkpoint=mobilenet_v1_1.0_224.ckpt \
    --output_graph=mobilenet_v1_frozen.pb \
    --output_node_names=MobilenetV1/Predictions/Softmax \
    --input_binary
  ```
  source: https://github.com/tensorflow/models/blob/master/slim/README.md#freezing-the-exported-graph

* Modify for DNN: fuse batch normalizations and remove `Squeeze` op.

  ```bash
  ~/tensorflow/bazel-bin/tensorflow/tools/graph_transforms/transform_graph \
    --in_graph=mobilenet_v1_frozen.pb \
    --out_graph=mobilenet_v1_for_dnn.pb \
    --inputs=input \
    --outputs=MobilenetV1/Predictions/Softmax \
    --transforms="fold_constants sort_by_execution_order remove_nodes(op=Squeeze)"
  ```

* Enjoy with DNN:
  ```cpp
  #include <iostream>
  
  #include <opencv2/opencv.hpp>
  #include <opencv2/dnn.hpp>
  
  int main() {
    cv::dnn::Net net = cv::dnn::readNetFromTensorflow("../mobilenet_v1_for_dnn.pb");
  
    cv::Mat input = cv::imread("toucan.jpg");
    cv::Mat blob = cv::dnn::blobFromImage(input, 1.0 / 255, cv::Size(224, 224));
  
    net.setInput(blob);
    cv::Mat output = net.forward();
  
    double minVal, maxVal;
    cv::Point minLoc, maxLoc;
    cv::minMaxLoc(output, &minVal, &maxVal, &minLoc, &maxLoc);
    std::cout << maxLoc << " " << maxVal << std::endl;
  
    return 0;
  }
  ```
  output:
  ```
  [97, 0] 0.999997
  ```
  And if I'm right and MobileNet uses 0th class as None, 97th class is a toucan (see [synset_words.txt](https://github.com/opencv/opencv/blob/master/samples/data/dnn/synset_words.txt#L97))

  <img src="https://user-images.githubusercontent.com/25801568/29870991-d04459ec-8d92-11e7-81be-310bdffe6df8.jpg" width="128">
