### PR TITLE
Don't truncate label for tracknbar name (Qt)

### DIFF
--- a/modules/highgui/src/window_QT.cpp
+++ b/modules/highgui/src/window_QT.cpp
@@ -1409,7 +1409,7 @@ void CvTrackbar::update(int myvalue)
 
 void CvTrackbar::setLabel(int myvalue)
 {
-    QString nameNormalized = name_bar.leftJustified( 10, ' ', true );
+    QString nameNormalized = name_bar.leftJustified( 10, ' ', false );
     QString valueMaximum = QString("%1").arg(slider->maximum());
     QString str = QString("%1 (%2/%3)").arg(nameNormalized).arg(myvalue,valueMaximum.length(),10,QChar('0')).arg(valueMaximum);
     label->setText(str);


### PR DESCRIPTION
resolves #9489 

### This pullrequest changes

Setting truncate option for QString leftJustified method to false fixes 10 character truncation issue noted in issue 9489. This will allow trackbar names > 10 character in length to show up.
