### PR TITLE
Import and convert FP16 weights from TensorFlow

### DIFF
--- a/modules/dnn/test/test_tf_importer.cpp
+++ b/modules/dnn/test/test_tf_importer.cpp
@@ -76,7 +76,8 @@ static std::string path(const std::string& file)
     return findDataFile("dnn/tensorflow/" + file, false);
 }
 
-static void runTensorFlowNet(const std::string& prefix)
+static void runTensorFlowNet(const std::string& prefix,
+                             double l1 = 1e-5, double lInf = 1e-4)
 {
     std::string netPath = path(prefix + "_net.pb");
     std::string inpPath = path(prefix + "_in.npy");
@@ -89,7 +90,7 @@ static void runTensorFlowNet(const std::string& prefix)
 
     net.setInput(input);
     cv::Mat output = net.forward();
-    normAssert(target, output);
+    normAssert(target, output, "", l1, lInf);
 }
 
 TEST(Test_TensorFlow, single_conv)
@@ -128,6 +129,21 @@ TEST(Test_TensorFlow, pooling)
 TEST(Test_TensorFlow, deconvolution)
 {
     runTensorFlowNet("deconvolution");
+}
+
+TEST(Test_TensorFlow, fp16)
+{
+    const float l1 = 1e-3;
+    const float lInf = 1e-2;
+    runTensorFlowNet("fp16_single_conv", l1, lInf);
+    runTensorFlowNet("fp16_deconvolution", l1, lInf);
+    runTensorFlowNet("fp16_max_pool_odd_same", l1, lInf);
+    runTensorFlowNet("fp16_padding_valid", l1, lInf);
+    runTensorFlowNet("fp16_eltwise_add_mul", l1, lInf);
+    runTensorFlowNet("fp16_max_pool_odd_valid", l1, lInf);
+    runTensorFlowNet("fp16_pad_and_concat", l1, lInf);
+    runTensorFlowNet("fp16_max_pool_even", l1, lInf);
+    runTensorFlowNet("fp16_padding_same", l1, lInf);
 }
 
 }


### PR DESCRIPTION
<!-- Please use this line to close one or multiple issues when this pullrequest gets merged
You can add another line right under the first one:
resolves #1234
resolves #1235
-->

### This pullrequest changes
Experimental import of float16 weights from TensorFlow models and convert it into float32.
**Merge with extra**: https://github.com/opencv/opencv_extra/pull/373
