### PR TITLE
Enabled forEach for const Mats

### DIFF
--- a/modules/core/include/opencv2/core/mat.inl.hpp
+++ b/modules/core/include/opencv2/core/mat.inl.hpp
@@ -1214,7 +1214,7 @@ void Mat::forEach(const Functor& operation) {
 template<typename _Tp, typename Functor> inline
 void Mat::forEach(const Functor& operation) const {
     // call as not const
-    (const_cast<Mat*>(this))->forEach<const _Tp>(operation);
+    (const_cast<Mat*>(this))->forEach<_Tp>(operation);
 }
 
 template<typename _Tp> inline

--- a/modules/core/test/test_mat.cpp
+++ b/modules/core/test/test_mat.cpp
@@ -671,6 +671,13 @@ struct InitializerFunctor5D{
     }
 };
 
+template<typename Pixel>
+struct EmptyFunctor
+{
+    void operator()(const Pixel &, const int *) const {}
+};
+
+
 void Core_ArrayOpTest::run( int /* start_from */)
 {
     int errcount = 0;
@@ -797,6 +804,17 @@ void Core_ArrayOpTest::run( int /* start_from */)
             ts->printf(cvtest::TS::LOG, "forEach is not correct because total is invalid.\n");
             errcount++;
         }
+    }
+
+    // test const cv::Mat::forEach
+    {
+        const Mat a(10, 10, CV_32SC3);
+        Mat b(10, 10, CV_32SC3);
+        const Mat & c = b;
+        a.forEach<Point3i>(EmptyFunctor<Point3i>());
+        b.forEach<Point3i>(EmptyFunctor<const Point3i>());
+        c.forEach<Point3i>(EmptyFunctor<Point3i>());
+        // tests compilation, no runtime check is needed
     }
 
     RNG rng;


### PR DESCRIPTION
resolves #8531

### This pullrequest changes

After merging PR #9457, the problem described in #8531 become visible at compilation time. Since there were no template specialization for const types (`DataType<const Point3i>` for example), the default values for type and channels has been used causing invalid access to Mat elements.
