### PR TITLE
OCL: imgproc: don't use doubles to process float data

### DIFF
--- a/modules/imgproc/src/opencl/warp_affine.cl
+++ b/modules/imgproc/src/opencl/warp_affine.cl
@@ -49,9 +49,6 @@
 #elif defined (cl_khr_fp64)
 #pragma OPENCL EXTENSION cl_khr_fp64:enable
 #endif
-#define CT double
-#else
-#define CT float
 #endif
 
 #define INTER_BITS 5

--- a/modules/imgproc/src/opencl/warp_perspective.cl
+++ b/modules/imgproc/src/opencl/warp_perspective.cl
@@ -49,9 +49,6 @@
 #elif defined (cl_khr_fp64)
 #pragma OPENCL EXTENSION cl_khr_fp64:enable
 #endif
-#define CT double
-#else
-#define CT float
 #endif
 
 #define INTER_BITS 5


### PR DESCRIPTION
Changed functions: `warpAffine`/`warpPerspective`