### PR TITLE
cmake: switching between old and new libstdc++ ABI

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -325,12 +325,20 @@ OCV_OPTION(GENERATE_ABI_DESCRIPTOR    "Generate XML file for abi_compliance_chec
 OCV_OPTION(CV_ENABLE_INTRINSICS       "Use intrinsic-based optimized code" ON )
 OCV_OPTION(CV_DISABLE_OPTIMIZATION    "Disable explicit optimized code (dispatched code/intrinsics/loop unrolling/etc)" OFF )
 OCV_OPTION(CV_TRACE                   "Enable OpenCV code trace" ON)
+OCV_OPTION(GLIBCXX_USE_CXX11_ABI      "Controls whether the declarations in the library headers use old or new ABI" ON IF (CMAKE_COMPILER_IS_GNUCXX AND CMAKE_CXX_COMPILER_VERSION VERSION_GREATER "5.0"))
 
 
 if(ENABLE_IMPL_COLLECTION)
   add_definitions(-DCV_COLLECT_IMPL_DATA)
 endif()
 
+if(CMAKE_COMPILER_IS_GNUCXX AND CMAKE_CXX_COMPILER_VERSION VERSION_GREATER "5.0")
+  if(GLIBCXX_USE_CXX11_ABI)
+    add_definitions(-D_GLIBCXX_USE_CXX11_ABI=1)
+  else()
+    add_definitions(-D_GLIBCXX_USE_CXX11_ABI=0)
+  endif()
+endif()
 
 # ----------------------------------------------------------------------------
 #  Get actual OpenCV version number from sources
@@ -970,6 +978,9 @@ status("  C/C++:")
 status("    Built as dynamic libs?:" BUILD_SHARED_LIBS THEN YES ELSE NO)
 if(ENABLE_CXX11 OR HAVE_CXX11)
 status("    C++11:" HAVE_CXX11 THEN YES ELSE NO)
+endif()
+if(CMAKE_COMPILER_IS_GNUCXX AND CMAKE_CXX_COMPILER_VERSION VERSION_GREATER "5.0")
+  status("    libstdc++ uses new ABI:" GLIBCXX_USE_CXX11_ABI THEN YES ELSE NO)
 endif()
 status("    C++ Compiler:"           ${OPENCV_COMPILER_STR})
 status("    C++ flags (Release):"    ${CMAKE_CXX_FLAGS} ${CMAKE_CXX_FLAGS_RELEASE})


### PR DESCRIPTION
Add cmake option GLIBCXX_USE_CXX11_ABI, controlling switching between
old and new ABI of libstdc++.

In the GCC 5.1 release libstdc++ introduces a new library ABI that includes new implementations of std::string and std::list. In order to maintain backward compatibility for existing code linked to libstdc++, they put new implementation of std::string and std::list inside std::__cxx11 namespace, making it possible to keep the old and the new implementations in the same library. Macro definition _GLIBCXX_USE_CXX11_ABI allows to switch between old and new versions of ABI.

Detailed description can be found [here](https://gcc.gnu.org/onlinedocs/libstdc++/manual/using_dual_abi.html).

I do cross-compilation of some code that uses OpenCV. And I faced a situation where the target platform has been upgraded to GCC 5.4, and it was way easier to build OpenCV inside the target platform using target's compiler, but the platform's vendor hasn't provided us with GCC 5 cross compiler yet: we still have to do cross-compilation using GCC 4.9. By default, GCC 5.4 uses new ABI, which renders our project built with GCC 4.9 cross-compiler not linkable with OpenCV built with GCC 5.4. With this new cmake option we can switch between versions of ABI used by OpenCV.

### This pullrequest changes

<!-- Please describe what your pullrequest is changing -->

Add cmake option GLIBCXX_USE_CXX11_ABI, controlling switching between
old and new ABI of libstdc++.