### PR TITLE
Disable SSD on CPU Halide test

### DIFF
--- a/modules/dnn/test/test_halide_nets.cpp
+++ b/modules/dnn/test/test_halide_nets.cpp
@@ -87,12 +87,13 @@ TEST(Reproducibility_MobileNetSSD_Halide, Accuracy)
          "", 300, 300, "detection_out", "caffe", DNN_TARGET_CPU);
 };
 
-TEST(Reproducibility_SSD_Halide, Accuracy)
-{
-    test(findDataFile("dnn/VGG_ILSVRC2016_SSD_300x300_iter_440000.caffemodel", false),
-         findDataFile("dnn/ssd_vgg16.prototxt", false),
-         "", 300, 300, "detection_out", "caffe", DNN_TARGET_CPU);
-};
+// TODO: Segmentation fault from time to time.
+// TEST(Reproducibility_SSD_Halide, Accuracy)
+// {
+//     test(findDataFile("dnn/VGG_ILSVRC2016_SSD_300x300_iter_440000.caffemodel", false),
+//          findDataFile("dnn/ssd_vgg16.prototxt", false),
+//          "", 300, 300, "detection_out", "caffe", DNN_TARGET_CPU);
+// };
 
 TEST(Reproducibility_GoogLeNet_Halide, Accuracy)
 {


### PR DESCRIPTION
<!-- Please use this line to close one or multiple issues when this pullrequest gets merged
You can add another line right under the first one:
resolves #1234
resolves #1235
-->

### This pullrequest changes

Segmentation fault appears from time to time at SSD network compilation (CPU target only, mbox_conf concat layer with `1 754 328` output channels and `1x1` `width x height`).