### PR TITLE
Overloading getDefaultName method for Feature2D and its child classes

### DIFF
--- a/modules/features2d/include/opencv2/features2d.hpp
+++ b/modules/features2d/include/opencv2/features2d.hpp
@@ -206,6 +206,7 @@ public:
 
     //! Return true if detector object is empty
     CV_WRAP virtual bool empty() const;
+    CV_WRAP virtual String getDefaultName() const;
 };
 
 /** Feature detectors in OpenCV have wrappers with a common interface that enables you to easily switch
@@ -267,6 +268,7 @@ public:
     CV_WRAP static Ptr<BRISK> create(int thresh, int octaves, const std::vector<float> &radiusList,
         const std::vector<int> &numberList, float dMax=5.85f, float dMin=8.2f,
         const std::vector<int>& indexChange=std::vector<int>());
+    CV_WRAP virtual String getDefaultName() const;
 };
 
 /** @brief Class implementing the ORB (*oriented BRIEF*) keypoint detector and descriptor extractor
@@ -340,6 +342,7 @@ public:
 
     CV_WRAP virtual void setFastThreshold(int fastThreshold) = 0;
     CV_WRAP virtual int getFastThreshold() const = 0;
+    CV_WRAP virtual String getDefaultName() const;
 };
 
 /** @brief Maximally stable extremal region extractor
@@ -399,6 +402,7 @@ public:
 
     CV_WRAP virtual void setPass2Only(bool f) = 0;
     CV_WRAP virtual bool getPass2Only() const = 0;
+    CV_WRAP virtual String getDefaultName() const;
 };
 
 /** @overload */
@@ -454,6 +458,7 @@ public:
 
     CV_WRAP virtual void setType(int type) = 0;
     CV_WRAP virtual int getType() const = 0;
+    CV_WRAP virtual String getDefaultName() const;
 };
 
 /** @overload */
@@ -508,6 +513,7 @@ public:
 
     CV_WRAP virtual void setType(int type) = 0;
     CV_WRAP virtual int getType() const = 0;
+    CV_WRAP virtual String getDefaultName() const;
 };
 
 /** @brief Wrapping class for feature detection using the goodFeaturesToTrack function. :
@@ -534,6 +540,7 @@ public:
 
     CV_WRAP virtual void setK(double k) = 0;
     CV_WRAP virtual double getK() const = 0;
+    CV_WRAP virtual String getDefaultName() const;
 };
 
 /** @brief Class for extracting blobs from an image. :
@@ -600,6 +607,7 @@ public:
 
   CV_WRAP static Ptr<SimpleBlobDetector>
     create(const SimpleBlobDetector::Params &parameters = SimpleBlobDetector::Params());
+  CV_WRAP virtual String getDefaultName() const;
 };
 
 //! @} features2d_main
@@ -656,6 +664,7 @@ public:
 
     CV_WRAP virtual void setDiffusivity(int diff) = 0;
     CV_WRAP virtual int getDiffusivity() const = 0;
+    CV_WRAP virtual String getDefaultName() const;
 };
 
 /** @brief Class implementing the AKAZE keypoint detector and descriptor extractor, described in @cite ANB13.
@@ -723,6 +732,7 @@ public:
 
     CV_WRAP virtual void setDiffusivity(int diff) = 0;
     CV_WRAP virtual int getDiffusivity() const = 0;
+    CV_WRAP virtual String getDefaultName() const;
 };
 
 //! @} features2d_main

--- a/modules/features2d/src/agast.cpp
+++ b/modules/features2d/src/agast.cpp
@@ -8169,4 +8169,9 @@ void AGAST(InputArray _img, std::vector<KeyPoint>& keypoints, int threshold, boo
     }
 }
 
+String AgastFeatureDetector::getDefaultName() const
+{
+    return(Feature2D::getDefaultName() + ".AgastFeatureDetector");
+}
+
 } // END NAMESPACE CV

--- a/modules/features2d/src/akaze.cpp
+++ b/modules/features2d/src/akaze.cpp
@@ -244,4 +244,10 @@ namespace cv
         return makePtr<AKAZE_Impl>(descriptor_type, descriptor_size, descriptor_channels,
                                    threshold, octaves, sublevels, diffusivity);
     }
+
+    String AKAZE::getDefaultName() const
+    {
+        return (Feature2D::getDefaultName() + ".AKAZE");
+    }
+
 }

--- a/modules/features2d/src/blobdetector.cpp
+++ b/modules/features2d/src/blobdetector.cpp
@@ -379,4 +379,9 @@ Ptr<SimpleBlobDetector> SimpleBlobDetector::create(const SimpleBlobDetector::Par
     return makePtr<SimpleBlobDetectorImpl>(params);
 }
 
+String SimpleBlobDetector::getDefaultName() const
+{
+    return (Feature2D::getDefaultName() + ".SimpleBlobDetector");
+}
+
 }

--- a/modules/features2d/src/brisk.cpp
+++ b/modules/features2d/src/brisk.cpp
@@ -2345,4 +2345,9 @@ Ptr<BRISK> BRISK::create(int thresh, int octaves, const std::vector<float> &radi
     return makePtr<BRISK_Impl>(thresh, octaves, radiusList, numberList, dMax, dMin, indexChange);
 }
 
+String BRISK::getDefaultName() const
+{
+    return (Feature2D::getDefaultName() + ".BRISK");
+}
+
 }

--- a/modules/features2d/src/fast.cpp
+++ b/modules/features2d/src/fast.cpp
@@ -512,5 +512,9 @@ Ptr<FastFeatureDetector> FastFeatureDetector::create( int threshold, bool nonmax
     return makePtr<FastFeatureDetector_Impl>(threshold, nonmaxSuppression, type);
 }
 
+String FastFeatureDetector::getDefaultName() const
+{
+    return (Feature2D::getDefaultName() + ".FastFeatureDetector");
+}
 
 }

--- a/modules/features2d/src/feature2d.cpp
+++ b/modules/features2d/src/feature2d.cpp
@@ -196,4 +196,9 @@ bool Feature2D::empty() const
     return true;
 }
 
+String Feature2D::getDefaultName() const
+{
+    return "Feature2D";
+}
+
 }

--- a/modules/features2d/src/gftt.cpp
+++ b/modules/features2d/src/gftt.cpp
@@ -125,4 +125,9 @@ Ptr<GFTTDetector> GFTTDetector::create( int _nfeatures, double _qualityLevel,
                                       _minDistance, _blockSize, _useHarrisDetector, _k);
 }
 
+String GFTTDetector::getDefaultName() const
+{
+    return (Feature2D::getDefaultName() + ".GFTTDetector");
+}
+
 }

--- a/modules/features2d/src/kaze.cpp
+++ b/modules/features2d/src/kaze.cpp
@@ -196,4 +196,10 @@ namespace cv
     {
         return makePtr<KAZE_Impl>(extended, upright, threshold, octaves, sublevels, diffusivity);
     }
+
+    String KAZE::getDefaultName() const
+    {
+        return (Feature2D::getDefaultName() + ".KAZE");
+    }
+
 }

--- a/modules/features2d/src/mser.cpp
+++ b/modules/features2d/src/mser.cpp
@@ -1109,4 +1109,9 @@ Ptr<MSER> MSER::create( int _delta, int _min_area, int _max_area,
                           _min_margin, _edge_blur_size));
 }
 
+String MSER::getDefaultName() const
+{
+    return (Feature2D::getDefaultName() + ".MSER");
+}
+
 }

--- a/modules/features2d/src/orb.cpp
+++ b/modules/features2d/src/orb.cpp
@@ -1198,4 +1198,9 @@ Ptr<ORB> ORB::create(int nfeatures, float scaleFactor, int nlevels, int edgeThre
                              firstLevel, wta_k, scoreType, patchSize, fastThreshold);
 }
 
+String ORB::getDefaultName() const
+{
+    return (Feature2D::getDefaultName() + ".ORB");
+}
+
 }


### PR DESCRIPTION
Overloading getDefaultName method for Feature2D and its child classes

Signed-off-by: Vipin Anand <anand.vipin@gmail.com>
Signed-off-by: Prashanth Voora <prashanthx85@gmail.com>
Signed-off-by: Patel, Nilaykumar K <nilay.nilpat@gmail.com>

<!-- Please use this line to close one or multiple issues when this pullrequest gets merged
You can add another line right under the first one:
resolves #6387
-->

resolves https://github.com/opencv/opencv/issues/6387 
<!-- Please describe what your pullrequest is changing -->
