### PR TITLE
fisheye: fix initUndistortRectifyMap()

### DIFF
--- a/modules/calib3d/src/fisheye.cpp
+++ b/modules/calib3d/src/fisheye.cpp
@@ -475,17 +475,26 @@ void cv::fisheye::initUndistortRectifyMap( InputArray K, InputArray D, InputArra
 
         for( int j = 0; j < size.width; ++j)
         {
-            double x = _x/_w, y = _y/_w;
+            double u, v;
+            if( _w <= 0)
+            {
+                _x > 0 ? u = -std::numeric_limits<double>::infinity() : u = std::numeric_limits<double>::infinity();
+                _y > 0 ? v = -std::numeric_limits<double>::infinity() : v = std::numeric_limits<double>::infinity();
+            }
+            else
+            {
+                double x = _x/_w, y = _y/_w;
 
-            double r = sqrt(x*x + y*y);
-            double theta = atan(r);
+                double r = sqrt(x*x + y*y);
+                double theta = atan(r);
 
-            double theta2 = theta*theta, theta4 = theta2*theta2, theta6 = theta4*theta2, theta8 = theta4*theta4;
-            double theta_d = theta * (1 + k[0]*theta2 + k[1]*theta4 + k[2]*theta6 + k[3]*theta8);
+                double theta2 = theta*theta, theta4 = theta2*theta2, theta6 = theta4*theta2, theta8 = theta4*theta4;
+                double theta_d = theta * (1 + k[0]*theta2 + k[1]*theta4 + k[2]*theta6 + k[3]*theta8);
 
-            double scale = (r == 0) ? 1.0 : theta_d / r;
-            double u = f[0]*x*scale + c[0];
-            double v = f[1]*y*scale + c[1];
+                double scale = (r == 0) ? 1.0 : theta_d / r;
+                u = f[0]*x*scale + c[0];
+                v = f[1]*y*scale + c[1];
+            }
 
             if( m1type == CV_16SC2 )
             {

--- a/modules/calib3d/src/fisheye.cpp
+++ b/modules/calib3d/src/fisheye.cpp
@@ -478,8 +478,8 @@ void cv::fisheye::initUndistortRectifyMap( InputArray K, InputArray D, InputArra
             double u, v;
             if( _w <= 0)
             {
-                _x > 0 ? u = -std::numeric_limits<double>::infinity() : u = std::numeric_limits<double>::infinity();
-                _y > 0 ? v = -std::numeric_limits<double>::infinity() : v = std::numeric_limits<double>::infinity();
+                u = (_x > 0) ? -std::numeric_limits<double>::infinity() : std::numeric_limits<double>::infinity();
+                v = (_y > 0) ? -std::numeric_limits<double>::infinity() : std::numeric_limits<double>::infinity();
             }
             else
             {


### PR DESCRIPTION
### This pullrequest changes

There is a bug in `cv::fisheye::initUndistortRectifyMap()` when you undistort fish-eye image with such `RectifyMap` that part of fisheye remains behind new camera view (`_w <= 0` in code) undistortion work incorrectly (see the photos). Also there is division by `_w` with no zero check. The fixed `initUndistortRectifyMap()` works fine in such situations.

![bad](https://user-images.githubusercontent.com/16744368/30428945-48c93550-995e-11e7-9090-f91df307dad1.png)

![good](https://user-images.githubusercontent.com/16744368/30428951-4d0deb4c-995e-11e7-893f-253edddd14ba.png)
