### PR TITLE
Add some useful input assertions to PSNR function

### DIFF
--- a/modules/core/src/stat.cpp
+++ b/modules/core/src/stat.cpp
@@ -4150,7 +4150,10 @@ double cv::PSNR(InputArray _src1, InputArray _src2)
 {
     CV_INSTRUMENT_REGION()
 
-    CV_Assert( _src1.depth() == CV_8U );
+    //Input arrays must have depth CV_8U and be of identical size
+    CV_Assert( _src1.depth() == CV_8U && _src2.depth() == CV_8U );
+    CV_Assert( _src1.rows() == _src2.rows() && _src1.cols() == _src2.cols() && _src1.dims() == _src2.dims() );
+
     double diff = std::sqrt(norm(_src1, _src2, NORM_L2SQR)/(_src1.total()*_src1.channels()));
     return 20*log10(255./(diff+DBL_EPSILON));
 }

--- a/modules/core/src/stat.cpp
+++ b/modules/core/src/stat.cpp
@@ -4150,9 +4150,8 @@ double cv::PSNR(InputArray _src1, InputArray _src2)
 {
     CV_INSTRUMENT_REGION()
 
-    //Input arrays must have depth CV_8U and be of identical size
+    //Input arrays must have depth CV_8U
     CV_Assert( _src1.depth() == CV_8U && _src2.depth() == CV_8U );
-    CV_Assert( _src1.rows() == _src2.rows() && _src1.cols() == _src2.cols() && _src1.dims() == _src2.dims() );
 
     double diff = std::sqrt(norm(_src1, _src2, NORM_L2SQR)/(_src1.total()*_src1.channels()));
     return 20*log10(255./(diff+DBL_EPSILON));


### PR DESCRIPTION
Input arrays must be depth CV_8U and of identical size.

Intended this to be part of PR #9633 but that PR got merged and closed.

Original assertion was insufficient.

Now asserts that both input arrays are depth CV_8U and have same sizes.

### This pullrequest changes

<!-- Please describe what your pullrequest is changing -->
