### PR TITLE
Remove data permutation from Reshape layer

### DIFF
--- a/modules/dnn/src/layers/permute_layer.cpp
+++ b/modules/dnn/src/layers/permute_layer.cpp
@@ -132,6 +132,7 @@ public:
 
         for (size_t i = 0; i < inputs.size(); i++)
         {
+            CV_Assert(inputs[i].size() == 4);
             CV_Assert(inputs[i][2] == shapeBefore[2] && inputs[i][3] == shapeBefore[3]);
             CV_Assert(total(inputs[i]) == total(shapeAfter));
             outputs.push_back(shapeAfter);

--- a/modules/dnn/src/tensorflow/tf_importer.cpp
+++ b/modules/dnn/src/tensorflow/tf_importer.cpp
@@ -771,7 +771,6 @@ void TFImporter::populateNet(Net dstNet)
         else if (type == "Reshape")
         {
             layerParams.set("dim", parseDims(getConstBlob(layer, value_id, 1)));
-            layerParams.set("reorder_dims", true);
 
             int id = dstNet.addLayer(name, "Reshape", layerParams);
             layer_id[name] = id;

--- a/modules/dnn/test/test_layers.cpp
+++ b/modules/dnn/test/test_layers.cpp
@@ -166,13 +166,12 @@ TEST(Layer_Test_MVN, Accuracy)
 }
 
 void testReshape(const MatShape& inputShape, const MatShape& targetShape,
-                 int axis = 0, int num_axes = -1, bool reorder_dims = false,
+                 int axis = 0, int num_axes = -1,
                  MatShape mask = MatShape())
 {
     LayerParams params;
     params.set("axis", axis);
     params.set("num_axes", num_axes);
-    params.set("reorder_dims", reorder_dims);
     if (!mask.empty())
     {
         params.set("dim", DictValue::arrayInt<int*>(&mask[0], mask.size()));
@@ -201,7 +200,7 @@ TEST(Layer_Test_Reshape, Accuracy)
         int inp[] = {1, 128, 4, 4};
         int out[] = {1, 2048};
         int mask[] = {-1, 2048};
-        testReshape(MatShape(inp, inp + 4), MatShape(out, out + 2), 0, -1, true,
+        testReshape(MatShape(inp, inp + 4), MatShape(out, out + 2), 0, -1,
                     MatShape(mask, mask + 2));
     }
 }

--- a/modules/dnn/test/test_tf_importer.cpp
+++ b/modules/dnn/test/test_tf_importer.cpp
@@ -143,6 +143,11 @@ TEST(Test_TensorFlow, defun)
     runTensorFlowNet("defun_dropout");
 }
 
+TEST(Test_TensorFlow, reshape)
+{
+    runTensorFlowNet("shift_reshape_no_reorder");
+}
+
 TEST(Test_TensorFlow, fp16)
 {
     const float l1 = 1e-3;


### PR DESCRIPTION
<!-- Please use this line to close one or multiple issues when this pullrequest gets merged
You can add another line right under the first one:
resolves #1234
resolves #1235
-->

### This pullrequest changes

Removed `reorder_dims` attribute from Reshape layer. This flag is `true` for TensorFlow models but [tf.reshape](https://www.tensorflow.org/versions/master/api_docs/python/tf/reshape) doesn't make a permutation. However [tf.transpose](https://www.tensorflow.org/versions/master/api_docs/python/tf/transpose) does.

Import of a `Transpose` op is better to do with a some real network.

**Merge with extra**: https://github.com/opencv/opencv_extra/pull/377