### PR TITLE
cmake: map RelWithDebInfo and MinSizeRel configurations to Release

### DIFF
--- a/cmake/templates/OpenCVConfig.cmake.in
+++ b/cmake/templates/OpenCVConfig.cmake.in
@@ -199,6 +199,14 @@ foreach(__cvcomponent ${OpenCV_FIND_COMPONENTS})
       )
     endif()
   endif()
+  # OpenCV supports Debug and Release only.
+  # RelWithDebInfo and MinSizeRel are mapped to Release
+  if(TARGET ${__cvcomponent})
+      set_target_properties(${__cvcomponent} PROPERTIES
+          MAP_IMPORTED_CONFIG_MINSIZEREL "Release"
+          MAP_IMPORTED_CONFIG_RELWITHDEBINFO "Release"
+      )
+  endif()
 endforeach()
 
 # ==============================================================


### PR DESCRIPTION
resolves #5564

This Pull Request allows a user to compile her project with configurations RelWithDebInfo and MinSizeRel.
It was previously not possible as CMake was incorrectly linking with the Debug version of the library when using RelWithDebInfo  or MinSizeRel.

See https://github.com/opencv/opencv/pull/9161#issuecomment-330226465 for initial motivation.
@alalek, I didn't added a condition on `MSVC`, as this feature is not specific to Visual Studio.

Note that, this is not the same as #6496 because this Pull Request doesn't add new configurations to OpenCV, it only allows all configuration in the user's project.