### PR TITLE
Import models with Dropout nodes from TensorFlow

### DIFF
--- a/modules/dnn/src/tensorflow/tf_importer.cpp
+++ b/modules/dnn/src/tensorflow/tf_importer.cpp
@@ -363,7 +363,7 @@ void RemoveIdentityOps(tensorflow::GraphDef& net) {
         const tensorflow::NodeDef &layer = net.node(li);
         String type = layer.op();
 
-        if (type == "Identity") {
+        if (type == "Identity" || type == "Dropout") {
             identity_ops_idx.push_back(li);
             identity_ops[layer.name()] = layer.input(0);
         }

--- a/modules/dnn/test/test_tf_importer.cpp
+++ b/modules/dnn/test/test_tf_importer.cpp
@@ -138,6 +138,11 @@ TEST(Test_TensorFlow, matmul)
     runTensorFlowNet("matmul");
 }
 
+TEST(Test_TensorFlow, defun)
+{
+    runTensorFlowNet("defun_dropout");
+}
+
 TEST(Test_TensorFlow, fp16)
 {
     const float l1 = 1e-3;


### PR DESCRIPTION
<!-- Please use this line to close one or multiple issues when this pullrequest gets merged
You can add another line right under the first one:
resolves #1234
resolves #1235
-->

### This pullrequest changes
resolves https://github.com/opencv/opencv/issues/9536

Introduce an elegant way to fuse TensorFlow nodes: [Defun](https://github.com/tensorflow/tensorflow/blob/master/tensorflow/python/framework/function.py#L43).

Defun is a decorator that allow us wrap TensorFlow's subgraphs into a single node.

Let we have a graph that uses dropout during training:
```python
isTraining = tf.placeholder(tf.bool, name='isTraining')

inp = tf.placeholder(tf.float32, [1, 10, 10, 3], 'input')
conv = tf.layers.conv2d(inp, filters=3, kernel_size=[1, 1])
dropout = tf.layers.dropout(conv, rate=0.1, training=isTraining)
relu = tf.nn.relu(dropout)
```
Graph definition has a subgraph to support training and inference modes.

<details>
 <summary>Corresponding graph definition</summary>

```
node {
  name: "isTraining"
  op: "Placeholder"
  attr {
    key: "dtype"
    value {
      type: DT_BOOL
    }
  }
  attr {
    key: "shape"
    value {
      shape {
        unknown_rank: true
      }
    }
  }
}
node {
  name: "input"
  op: "Placeholder"
  attr {
    key: "dtype"
    value {
      type: DT_FLOAT
    }
  }
}
node {
  name: "conv2d/kernel"
  op: "Const"
  attr {
    key: "dtype"
    value {
      type: DT_FLOAT
    }
  }
  attr {
    key: "value"
    value {
      tensor {
        dtype: DT_FLOAT
        tensor_shape {
          dim {
            size: 1
          }
          dim {
            size: 1
          }
          dim {
            size: 3
          }
          dim {
            size: 3
          }
        }
        tensor_content: "\310\010\240\276\020Kd>\374X\034\277@\313`>\014\007\025\277\340\301\334\276\034\221\177\277\200Z\223<\200bw="
      }
    }
  }
}
node {
  name: "conv2d/bias"
  op: "Const"
  attr {
    key: "dtype"
    value {
      type: DT_FLOAT
    }
  }
  attr {
    key: "value"
    value {
      tensor {
        dtype: DT_FLOAT
        tensor_shape {
          dim {
            size: 3
          }
        }
        tensor_content: "\000\000\000\000\000\000\000\000\000\000\000\000"
      }
    }
  }
}
node {
  name: "conv2d/convolution"
  op: "Conv2D"
  input: "input"
  input: "conv2d/kernel"
  attr {
    key: "T"
    value {
      type: DT_FLOAT
    }
  }
  attr {
    key: "data_format"
    value {
      s: "NHWC"
    }
  }
  attr {
    key: "padding"
    value {
      s: "VALID"
    }
  }
  attr {
    key: "strides"
    value {
      list {
        i: 1
        i: 1
        i: 1
        i: 1
      }
    }
  }
  attr {
    key: "use_cudnn_on_gpu"
    value {
      b: true
    }
  }
}
node {
  name: "conv2d/BiasAdd"
  op: "BiasAdd"
  input: "conv2d/convolution"
  input: "conv2d/bias"
  attr {
    key: "T"
    value {
      type: DT_FLOAT
    }
  }
  attr {
    key: "data_format"
    value {
      s: "NHWC"
    }
  }
}
node {
  name: "dropout/cond/Switch"
  op: "Switch"
  input: "isTraining"
  input: "isTraining"
  attr {
    key: "T"
    value {
      type: DT_BOOL
    }
  }
}
node {
  name: "dropout/cond/dropout/keep_prob"
  op: "Const"
  input: "dropout/cond/Switch:1"
  attr {
    key: "dtype"
    value {
      type: DT_FLOAT
    }
  }
  attr {
    key: "value"
    value {
      tensor {
        dtype: DT_FLOAT
        tensor_shape {
        }
        float_val: 0.899999976158
      }
    }
  }
}
node {
  name: "dropout/cond/dropout/Shape"
  op: "Const"
  input: "dropout/cond/Switch:1"
  attr {
    key: "dtype"
    value {
      type: DT_INT32
    }
  }
  attr {
    key: "value"
    value {
      tensor {
        dtype: DT_INT32
        tensor_shape {
          dim {
            size: 4
          }
        }
        tensor_content: "\001\000\000\000\n\000\000\000\n\000\000\000\003\000\000\000"
      }
    }
  }
}
node {
  name: "dropout/cond/dropout/random_uniform/min"
  op: "Const"
  input: "dropout/cond/Switch:1"
  attr {
    key: "dtype"
    value {
      type: DT_FLOAT
    }
  }
  attr {
    key: "value"
    value {
      tensor {
        dtype: DT_FLOAT
        tensor_shape {
        }
        float_val: 0.0
      }
    }
  }
}
node {
  name: "dropout/cond/dropout/random_uniform/max"
  op: "Const"
  input: "dropout/cond/Switch:1"
  attr {
    key: "dtype"
    value {
      type: DT_FLOAT
    }
  }
  attr {
    key: "value"
    value {
      tensor {
        dtype: DT_FLOAT
        tensor_shape {
        }
        float_val: 1.0
      }
    }
  }
}
node {
  name: "dropout/cond/dropout/random_uniform/RandomUniform"
  op: "RandomUniform"
  input: "dropout/cond/dropout/Shape"
  attr {
    key: "T"
    value {
      type: DT_INT32
    }
  }
  attr {
    key: "dtype"
    value {
      type: DT_FLOAT
    }
  }
  attr {
    key: "seed"
    value {
      i: 324
    }
  }
  attr {
    key: "seed2"
    value {
      i: 28
    }
  }
}
node {
  name: "dropout/cond/dropout/random_uniform/sub"
  op: "Sub"
  input: "dropout/cond/dropout/random_uniform/max"
  input: "dropout/cond/dropout/random_uniform/min"
  attr {
    key: "T"
    value {
      type: DT_FLOAT
    }
  }
}
node {
  name: "dropout/cond/dropout/random_uniform/mul"
  op: "Mul"
  input: "dropout/cond/dropout/random_uniform/RandomUniform"
  input: "dropout/cond/dropout/random_uniform/sub"
  attr {
    key: "T"
    value {
      type: DT_FLOAT
    }
  }
}
node {
  name: "dropout/cond/dropout/random_uniform"
  op: "Add"
  input: "dropout/cond/dropout/random_uniform/mul"
  input: "dropout/cond/dropout/random_uniform/min"
  attr {
    key: "T"
    value {
      type: DT_FLOAT
    }
  }
}
node {
  name: "dropout/cond/dropout/add"
  op: "Add"
  input: "dropout/cond/dropout/keep_prob"
  input: "dropout/cond/dropout/random_uniform"
  attr {
    key: "T"
    value {
      type: DT_FLOAT
    }
  }
}
node {
  name: "dropout/cond/dropout/Floor"
  op: "Floor"
  input: "dropout/cond/dropout/add"
  attr {
    key: "T"
    value {
      type: DT_FLOAT
    }
  }
}
node {
  name: "dropout/cond/dropout/div/Switch"
  op: "Switch"
  input: "conv2d/BiasAdd"
  input: "isTraining"
  attr {
    key: "T"
    value {
      type: DT_FLOAT
    }
  }
  attr {
    key: "_class"
    value {
      list {
        s: "loc:@conv2d/BiasAdd"
      }
    }
  }
}
node {
  name: "dropout/cond/dropout/div"
  op: "RealDiv"
  input: "dropout/cond/dropout/div/Switch:1"
  input: "dropout/cond/dropout/keep_prob"
  attr {
    key: "T"
    value {
      type: DT_FLOAT
    }
  }
}
node {
  name: "dropout/cond/dropout/mul"
  op: "Mul"
  input: "dropout/cond/dropout/div"
  input: "dropout/cond/dropout/Floor"
  attr {
    key: "T"
    value {
      type: DT_FLOAT
    }
  }
}
node {
  name: "dropout/cond/Identity/Switch"
  op: "Switch"
  input: "conv2d/BiasAdd"
  input: "isTraining"
  attr {
    key: "T"
    value {
      type: DT_FLOAT
    }
  }
  attr {
    key: "_class"
    value {
      list {
        s: "loc:@conv2d/BiasAdd"
      }
    }
  }
}
node {
  name: "dropout/cond/Merge"
  op: "Merge"
  input: "dropout/cond/Identity/Switch"
  input: "dropout/cond/dropout/mul"
  attr {
    key: "N"
    value {
      i: 2
    }
  }
  attr {
    key: "T"
    value {
      type: DT_FLOAT
    }
  }
}
node {
  name: "Relu"
  op: "Relu"
  input: "dropout/cond/Merge"
  attr {
    key: "T"
    value {
      type: DT_FLOAT
    }
  }
}

```
</details>

But using Defun we can keep the same behavior of graph in runtime but serialize it with a customly named fused node:

```python
from tensorflow.python.framework import function

@function.Defun(tf.float32, func_name='Dropout')
def my_dropout(x):
    return tf.layers.dropout(x, rate=0.1, training=isTraining)

inp = tf.placeholder(tf.float32, [1, 10, 10, 3], 'input')
conv = tf.layers.conv2d(inp, filters=3, kernel_size=[1, 1])
dropout = my_dropout(conv)
relu = tf.nn.relu(dropout)
```

<details>
 <summary>Graph definition using Defun</summary>

```
node {
  name: "isTraining"
  op: "Placeholder"
  attr {
    key: "dtype"
    value {
      type: DT_BOOL
    }
  }
  attr {
    key: "shape"
    value {
      shape {
        unknown_rank: true
      }
    }
  }
}
node {
  name: "input"
  op: "Placeholder"
  attr {
    key: "dtype"
    value {
      type: DT_FLOAT
    }
  }
}
node {
  name: "conv2d/kernel"
  op: "Const"
  attr {
    key: "dtype"
    value {
      type: DT_FLOAT
    }
  }
  attr {
    key: "value"
    value {
      tensor {
        dtype: DT_FLOAT
        tensor_shape {
          dim {
            size: 1
          }
          dim {
            size: 1
          }
          dim {
            size: 3
          }
          dim {
            size: 3
          }
        }
        tensor_content: "\310\010\240\276\020Kd>\374X\034\277@\313`>\014\007\025\277\340\301\334\276\034\221\177\277\200Z\223<\200bw="
      }
    }
  }
}
node {
  name: "conv2d/bias"
  op: "Const"
  attr {
    key: "dtype"
    value {
      type: DT_FLOAT
    }
  }
  attr {
    key: "value"
    value {
      tensor {
        dtype: DT_FLOAT
        tensor_shape {
          dim {
            size: 3
          }
        }
        tensor_content: "\000\000\000\000\000\000\000\000\000\000\000\000"
      }
    }
  }
}
node {
  name: "conv2d/convolution"
  op: "Conv2D"
  input: "input"
  input: "conv2d/kernel"
  attr {
    key: "T"
    value {
      type: DT_FLOAT
    }
  }
  attr {
    key: "data_format"
    value {
      s: "NHWC"
    }
  }
  attr {
    key: "padding"
    value {
      s: "VALID"
    }
  }
  attr {
    key: "strides"
    value {
      list {
        i: 1
        i: 1
        i: 1
        i: 1
      }
    }
  }
  attr {
    key: "use_cudnn_on_gpu"
    value {
      b: true
    }
  }
}
node {
  name: "conv2d/BiasAdd"
  op: "BiasAdd"
  input: "conv2d/convolution"
  input: "conv2d/bias"
  attr {
    key: "T"
    value {
      type: DT_FLOAT
    }
  }
  attr {
    key: "data_format"
    value {
      s: "NHWC"
    }
  }
}
node {
  name: "Dropout"
  op: "Dropout"
  input: "conv2d/BiasAdd"
  input: "isTraining"
}
node {
  name: "Relu"
  op: "Relu"
  input: "Dropout"
  attr {
    key: "T"
    value {
      type: DT_FLOAT
    }
  }
}
```
</details>

This patch let to use the function name `Dropout` for import corresponding models.

**Merge with extra**: https://github.com/opencv/opencv_extra/pull/381