### PR TITLE
Fix 'directory does not exist' in windows tutorial

### DIFF
--- a/doc/tutorials/introduction/windows_install/windows_install.markdown
+++ b/doc/tutorials/introduction/windows_install/windows_install.markdown
@@ -50,6 +50,7 @@ if [  ! -d "$myRepo/opencv"  ]; then
     git clone https://github.com/opencv/opencv.git
     mkdir Build
     mkdir Build/opencv
+    mkdir Install
     mkdir Install/opencv
 else
     cd opencv


### PR DESCRIPTION
<!-- Please use this line to close one or multiple issues when this pullrequest gets merged
You can add another line right under the first one:
resolves #1234
resolves #1235
-->

### Fix for directory does not exist
Missing command in bash script tutorial. Alternative is to use the `-p` flag with `mkdir` to also create missing parents.

<!-- Please describe what your pullrequest is changing -->
