### PR TITLE
Refactored Padding layer

### DIFF
--- a/modules/dnn/include/opencv2/dnn/all_layers.hpp
+++ b/modules/dnn/include/opencv2/dnn/all_layers.hpp
@@ -337,6 +337,25 @@ CV__DNN_EXPERIMENTAL_NS_BEGIN
         static Ptr<PermuteLayer> create(const LayerParams& params);
     };
 
+    /**
+     * @brief Adds extra values for specific axes.
+     * @param paddings Vector of paddings in format
+     *                 @code
+     *                 [ pad_before, pad_after,  // [0]th dimension
+     *                   pad_before, pad_after,  // [1]st dimension
+     *                   ...
+     *                   pad_before, pad_after ] // [n]th dimension
+     *                 @endcode
+     *                 that represents number of padded values at every dimension
+     *                 starting from the first one. The rest of dimensions won't
+     *                 be padded.
+     * @param value Value to be padded. Defaults to zero.
+     * @param input_dims Torch's parameter. If @p input_dims is not equal to the
+     *                   actual input dimensionality then the `[0]th` dimension
+     *                   is considered as a batch dimension and @p paddings are shifted
+     *                   to a one dimension. Defaults to `-1` that means padding
+     *                   corresponding to @p paddings.
+     */
     class CV_EXPORTS PaddingLayer : public Layer
     {
     public:

--- a/modules/dnn/test/test_halide_layers.cpp
+++ b/modules/dnn/test/test_halide_layers.cpp
@@ -35,6 +35,28 @@ static void test(LayerParams& params, Mat& input)
 }
 
 ////////////////////////////////////////////////////////////////////////////////
+// Padding
+////////////////////////////////////////////////////////////////////////////////
+TEST(Padding_Halide, Accuracy)
+{
+    static const int kNumRuns = 10;
+    std::vector<int> paddings(8);
+    for (int t = 0; t < kNumRuns; ++t)
+    {
+        for (int i = 0; i < paddings.size(); ++i)
+            paddings[i] = rand() % 5;
+
+        LayerParams lp;
+        lp.set("paddings", DictValue::arrayInt<int*>(&paddings[0], paddings.size()));
+        lp.type = "Padding";
+        lp.name = "testLayer";
+
+        Mat input({1 + rand() % 10, 1 + rand() % 10, 1 + rand() % 10, 1 + rand() % 10}, CV_32F);
+        test(lp, input);
+    }
+}
+
+////////////////////////////////////////////////////////////////////////////////
 // Convolution
 ////////////////////////////////////////////////////////////////////////////////
 typedef TestWithParam<tuple<Vec3i, Size, Size, Size, Size, Size, bool> > Convolution;

--- a/modules/dnn/test/test_tf_importer.cpp
+++ b/modules/dnn/test/test_tf_importer.cpp
@@ -103,6 +103,7 @@ TEST(Test_TensorFlow, padding)
 {
     runTensorFlowNet("padding_same");
     runTensorFlowNet("padding_valid");
+    runTensorFlowNet("spatial_padding");
 }
 
 TEST(Test_TensorFlow, eltwise_add_mul)

--- a/modules/dnn/test/test_torch_importer.cpp
+++ b/modules/dnn/test/test_torch_importer.cpp
@@ -190,6 +190,12 @@ TEST(Torch_Importer, net_normalize)
     runTorchNet("net_normalize", "", false, true);
 }
 
+TEST(Torch_Importer, net_padding)
+{
+    runTorchNet("net_padding", "", false, true);
+    runTorchNet("net_spatial_zero_padding", "", false, true);
+}
+
 TEST(Torch_Importer, ENet_accuracy)
 {
     Net net;


### PR DESCRIPTION
<!-- Please use this line to close one or multiple issues when this pullrequest gets merged
You can add another line right under the first one:
resolves #1234
resolves #1235
-->

### This pullrequest changes
Extend Padding layer to process multidimensional padding that means it pads several blob axes from different sides (from the left/right) simultaneously.

PR helps to use single `tf.pad` in case of spatial padding:
```python
padded = tf.pad(inp, [[0, 0], [3, 3], [3, 3], [0, 0]])
```
And `nn.SpatialZeroPadding` layer from Torch.

**Merge with extra**: https://github.com/opencv/opencv_extra/pull/384
