### PR TITLE
Support @deprecated tag in java wrappers

### DIFF
--- a/modules/dnn/misc/java/test/DnnTensorFlowTest.java
+++ b/modules/dnn/misc/java/test/DnnTensorFlowTest.java
@@ -9,7 +9,6 @@ import org.opencv.core.Scalar;
 import org.opencv.core.Size;
 import org.opencv.dnn.DictValue;
 import org.opencv.dnn.Dnn;
-import org.opencv.dnn.Importer;
 import org.opencv.dnn.Layer;
 import org.opencv.dnn.Net;
 import org.opencv.imgcodecs.Imgcodecs;

--- a/modules/features2d/misc/java/src/cpp/features2d_manual.hpp
+++ b/modules/features2d/misc/java/src/cpp/features2d_manual.hpp
@@ -12,6 +12,9 @@
 namespace cv
 {
 
+/**
+ * @deprecated Please use direct instantiation of Feature2D classes
+ */
 class CV_EXPORTS_AS(FeatureDetector) javaFeatureDetector
 {
 public:
@@ -87,8 +90,11 @@ public:
         DYNAMIC_AKAZE      = DYNAMICDETECTOR + AKAZE
     };
 
-    //supported: FAST STAR SIFT SURF ORB MSER GFTT HARRIS BRISK AKAZE Grid(XXXX) Pyramid(XXXX) Dynamic(XXXX)
-    //not supported: SimpleBlob, Dense
+    /**
+     * supported: FAST STAR SIFT SURF ORB MSER GFTT HARRIS BRISK AKAZE Grid(XXXX) Pyramid(XXXX) Dynamic(XXXX)
+     * not supported: SimpleBlob, Dense
+     * @deprecated
+     */
     CV_WRAP static Ptr<javaFeatureDetector> create( int detectorType )
     {
         //String name;
@@ -179,6 +185,9 @@ private:
     Ptr<FeatureDetector> wrapped;
 };
 
+/**
+ * @deprecated
+ */
 class CV_EXPORTS_AS(DescriptorExtractor) javaDescriptorExtractor
 {
 public:

--- a/modules/java/generator/gen_java.py
+++ b/modules/java/generator/gen_java.py
@@ -92,6 +92,7 @@ package org.opencv.$module;
 $imports
 
 $docs
+$annotation
 public class $jname extends $base {
 
     protected $jname(long addr) { super(addr); }
@@ -107,6 +108,7 @@ package org.opencv.$module;
 $imports
 
 $docs
+$annotation
 public class $jname {
 
     protected final long nativeObj;
@@ -124,6 +126,7 @@ package org.opencv.$module;
 $imports
 
 $docs
+$annotation
 public class $jname {
 """
 
@@ -186,13 +189,15 @@ class GeneralInfo():
 
         # parse doxygen comments
         self.params={}
+        self.annotation=[]
         if type == "class":
             docstring="// C++: class " + self.name + "\n//javadoc: " + self.name
         else:
             docstring=""
         if len(decl)>5 and decl[5]:
+            logging.info('docstring: %s', decl[5])
             if re.search("(@|\\\\)deprecated", decl[5]):
-                docstring += "\n@Deprecated"
+                self.annotation.append("@Deprecated")
 
         self.docstring = docstring
 
@@ -347,6 +352,7 @@ class ClassInfo(GeneralInfo):
                             jname = self.jname,
                             imports = "\n".join(self.getAllImports(M)),
                             docs = self.docstring,
+                            annotation = "\n".join(self.annotation),
                             base = self.base)
 
     def generateCppCode(self):
@@ -757,6 +763,8 @@ class JavaWrapperGenerator(object):
                 lines = StringIO(fi.docstring)
                 for line in lines:
                     j_code.write(" "*4 + line + "\n")
+            if fi.annotation:
+                j_code.write(" "*4 + "\n".join(fi.annotation) + "\n")
 
             # public java wrapper method impl (calling native one above)
             # e.g.


### PR DESCRIPTION
<!-- Please use this line to close one or multiple issues when this pullrequest gets merged
You can add another line right under the first one:
resolves #1234
resolves #1235
-->
resolves #9699 

### This pullrequest changes

gen_java.py

<!-- Please describe what your pullrequest is changing -->
Deprecated interfaces in C/C++ code  shall be declared with @Deprecated tag in java wrappers thus encouraging java community to utilize new API.

Tests: FeatureDetector and DescriptorExtractor in features2d_maunual.hpp deprecated as no longer required - direct istantiation of Feature2D covers all the cases and is more flexible.
