### PR TITLE
imgcodecs(tiff): drop legacy code

### DIFF
--- a/modules/imgcodecs/src/grfmt_tiff.hpp
+++ b/modules/imgcodecs/src/grfmt_tiff.hpp
@@ -45,6 +45,8 @@
 
 #include "grfmt_base.hpp"
 
+#ifdef HAVE_TIFF
+
 namespace cv
 {
 
@@ -87,12 +89,7 @@ enum TiffFieldType
 };
 
 
-#ifdef HAVE_TIFF
-
 // libtiff based TIFF codec
-
-class TiffDecoderBufHelper;
-
 class TiffDecoder : public BaseImageDecoder
 {
 public:
@@ -109,9 +106,6 @@ public:
     ImageDecoder newDecoder() const;
 
 protected:
-
-    friend class TiffDecoderBufHelper;
-
     void* m_tif;
     int normalizeChannelsNumber(int channels) const;
     bool readHdrData(Mat& img);
@@ -122,8 +116,6 @@ private:
     TiffDecoder(const TiffDecoder &); // copy disabled
     TiffDecoder& operator=(const TiffDecoder &); // assign disabled
 };
-
-#endif
 
 // ... and writer
 class TiffEncoder : public BaseImageEncoder
@@ -144,8 +136,14 @@ protected:
 
     bool writeLibTiff( const Mat& img, const std::vector<int>& params );
     bool writeHdr( const Mat& img );
+
+private:
+    TiffEncoder(const TiffEncoder &); // copy disabled
+    TiffEncoder& operator=(const TiffEncoder &); // assign disabled
 };
 
 }
+
+#endif // HAVE_TIFF
 
 #endif/*_GRFMT_TIFF_H_*/

--- a/modules/imgcodecs/src/loadsave.cpp
+++ b/modules/imgcodecs/src/loadsave.cpp
@@ -147,8 +147,8 @@ struct ImageCodecInitializer
         encoders.push_back( makePtr<PxMEncoder>() );
     #ifdef HAVE_TIFF
         decoders.push_back( makePtr<TiffDecoder>() );
-    #endif
         encoders.push_back( makePtr<TiffEncoder>() );
+    #endif
     #ifdef HAVE_PNG
         decoders.push_back( makePtr<PngDecoder>() );
         encoders.push_back( makePtr<PngEncoder>() );


### PR DESCRIPTION
Drop code under *undefined* HAVE_TIFF
(violates several policies, like a way to turn off tiff support)