### PR TITLE
Fix out of bounds write

### DIFF
--- a/modules/imgcodecs/src/grfmt_bmp.cpp
+++ b/modules/imgcodecs/src/grfmt_bmp.cpp
@@ -375,6 +375,9 @@ decode_rle4_bad: ;
                                                 gray_palette[code] );
 
                         line_end_flag = y - prev_y;
+
+                        if( y >= m_height )
+                            break;
                     }
                     else if( code > 2 ) // absolute mode
                     {


### PR DESCRIPTION
resolves #9723 

Analysis
===
**rle8** is missing a check when in encoding mode to see if we are writing past the height, `y`, of the image. This leads to an oob write. 

Fix
===
Same fix that is in place for **rle4** and **rle8** in default mode.