### PR TITLE
Fix bug: non-maximum suppression for hough circle

### DIFF
--- a/modules/imgproc/src/hough.cpp
+++ b/modules/imgproc/src/hough.cpp
@@ -1112,8 +1112,8 @@ icvHoughCirclesGradient( CvMat* img, float dp, float min_dist,
         {
             int base = y*(acols+2) + x;
             if( adata[base] > acc_threshold &&
-                adata[base] > adata[base-1] && adata[base] > adata[base+1] &&
-                adata[base] > adata[base-acols-2] && adata[base] > adata[base+acols+2] )
+                adata[base] > adata[base-1] && adata[base] >= adata[base+1] &&
+                adata[base] > adata[base-acols-2] && adata[base] >= adata[base+acols+2] )
                 cvSeqPush(centers, &base);
         }
     }


### PR DESCRIPTION
The non-maximum suppression in the Hough accumulator incorrectly ignores maxima that extend over more than one cell, i.e. two neighboring cells both have the same accumulator value. This maximum is dropped completely instead of picking at least one of the entries. This frequently results in obvious circles being missed.

The behavior is now changed to be the same as for hough_lines.

See also https://github.com/opencv/opencv/issues/4440

<!-- Please use this line to close one or multiple issues when this pullrequest gets merged
You can add another line right under the first one:
resolves #1234
resolves #1235
-->

### This pullrequest changes

<!-- Please describe what your pullrequest is changing -->
