### PR TITLE
Use horizontal input/output images layout in OpenCV.js tutorials

### DIFF
--- a/doc/js_tutorials/js_assets/js_basic_ops_copymakeborder.html
+++ b/doc/js_tutorials/js_assets/js_basic_ops_copymakeborder.html
@@ -19,14 +19,24 @@
 <p class="err" id="errorMessage"></p>
 </div>
 <div>
-    <div class="inputoutput">
-        <canvas id="canvasInput"></canvas>
-        <div class="caption">canvasInput <input type="file" id="fileInput" name="file" accept="image/*" /></div>
-    </div>
-    <div class="inputoutput">
-        <canvas id="canvasOutput"></canvas>
-        <div class="caption">canvasOutput</div>
-    </div>
+    <table cellpadding="0" cellspacing="0" width="0" border="0">
+    <tr>
+        <td>
+            <canvas id="canvasInput"></canvas>
+        </td>
+        <td>
+            <canvas id="canvasOutput"></canvas>
+        </td>
+    </tr>
+    <tr>
+        <td>
+            <div class="caption">canvasInput <input type="file" id="fileInput" name="file" accept="image/*" /></div>
+        </td>
+        <td>
+            <div class="caption">canvasOutput</div>
+        </td>
+    </tr>
+    </table>
 </div>
 <script src="utils.js" type="text/javascript"></script>
 <script id="codeSnippet" type="text/code-snippet">

--- a/doc/js_tutorials/js_assets/js_basic_ops_roi.html
+++ b/doc/js_tutorials/js_assets/js_basic_ops_roi.html
@@ -19,14 +19,24 @@
 <p class="err" id="errorMessage"></p>
 </div>
 <div>
-    <div class="inputoutput">
-        <canvas id="canvasInput"></canvas>
-        <div class="caption">canvasInput <input type="file" id="fileInput" name="file" accept="image/*" /></div>
-    </div>
-    <div class="inputoutput">
-        <canvas id="canvasOutput"></canvas>
-        <div class="caption">canvasOutput</div>
-    </div>
+    <table cellpadding="0" cellspacing="0" width="0" border="0">
+    <tr>
+        <td>
+            <canvas id="canvasInput"></canvas>
+        </td>
+        <td>
+            <canvas id="canvasOutput"></canvas>
+        </td>
+    </tr>
+    <tr>
+        <td>
+            <div class="caption">canvasInput <input type="file" id="fileInput" name="file" accept="image/*" /></div>
+        </td>
+        <td>
+            <div class="caption">canvasOutput</div>
+        </td>
+    </tr>
+    </table>
 </div>
 <script src="utils.js" type="text/javascript"></script>
 <script id="codeSnippet" type="text/code-snippet">

--- a/doc/js_tutorials/js_assets/js_canny.html
+++ b/doc/js_tutorials/js_assets/js_canny.html
@@ -19,14 +19,24 @@
 <p class="err" id="errorMessage"></p>
 </div>
 <div>
-    <div class="inputoutput">
-        <canvas id="canvasInput"></canvas>
-        <div class="caption">canvasInput <input type="file" id="fileInput" name="file" accept="image/*" /></div>
-    </div>
-    <div class="inputoutput">
-        <canvas id="canvasOutput"></canvas>
-        <div class="caption">canvasOutput</div>
-    </div>
+    <table cellpadding="0" cellspacing="0" width="0" border="0">
+    <tr>
+        <td>
+            <canvas id="canvasInput"></canvas>
+        </td>
+        <td>
+            <canvas id="canvasOutput"></canvas>
+        </td>
+    </tr>
+    <tr>
+        <td>
+            <div class="caption">canvasInput <input type="file" id="fileInput" name="file" accept="image/*" /></div>
+        </td>
+        <td>
+            <div class="caption">canvasOutput</div>
+        </td>
+    </tr>
+    </table>
 </div>
 <script src="utils.js" type="text/javascript"></script>
 <script id="codeSnippet" type="text/code-snippet">

--- a/doc/js_tutorials/js_assets/js_colorspaces_cvtColor.html
+++ b/doc/js_tutorials/js_assets/js_colorspaces_cvtColor.html
@@ -19,14 +19,24 @@
 <p class="err" id="errorMessage"></p>
 </div>
 <div>
-    <div class="inputoutput">
-        <canvas id="canvasInput"></canvas>
-        <div class="caption">canvasInput <input type="file" id="fileInput" name="file" accept="image/*" /></div>
-    </div>
-    <div class="inputoutput">
-        <canvas id="canvasOutput"></canvas>
-        <div class="caption">canvasOutput</div>
-    </div>
+    <table cellpadding="0" cellspacing="0" width="0" border="0">
+    <tr>
+        <td>
+            <canvas id="canvasInput"></canvas>
+        </td>
+        <td>
+            <canvas id="canvasOutput"></canvas>
+        </td>
+    </tr>
+    <tr>
+        <td>
+            <div class="caption">canvasInput <input type="file" id="fileInput" name="file" accept="image/*" /></div>
+        </td>
+        <td>
+            <div class="caption">canvasOutput</div>
+        </td>
+    </tr>
+    </table>
 </div>
 <script src="utils.js" type="text/javascript"></script>
 <script id="codeSnippet" type="text/code-snippet">

--- a/doc/js_tutorials/js_assets/js_colorspaces_inRange.html
+++ b/doc/js_tutorials/js_assets/js_colorspaces_inRange.html
@@ -19,14 +19,24 @@
 <p class="err" id="errorMessage"></p>
 </div>
 <div>
-    <div class="inputoutput">
-        <canvas id="canvasInput"></canvas>
-        <div class="caption">canvasInput <input type="file" id="fileInput" name="file" accept="image/*" /></div>
-    </div>
-    <div class="inputoutput">
-        <canvas id="canvasOutput"></canvas>
-        <div class="caption">canvasOutput</div>
-    </div>
+    <table cellpadding="0" cellspacing="0" width="0" border="0">
+    <tr>
+        <td>
+            <canvas id="canvasInput"></canvas>
+        </td>
+        <td>
+            <canvas id="canvasOutput"></canvas>
+        </td>
+    </tr>
+    <tr>
+        <td>
+            <div class="caption">canvasInput <input type="file" id="fileInput" name="file" accept="image/*" /></div>
+        </td>
+        <td>
+            <div class="caption">canvasOutput</div>
+        </td>
+    </tr>
+    </table>
 </div>
 <script src="utils.js" type="text/javascript"></script>
 <script id="codeSnippet" type="text/code-snippet">

--- a/doc/js_tutorials/js_assets/js_contour_features_approxPolyDP.html
+++ b/doc/js_tutorials/js_assets/js_contour_features_approxPolyDP.html
@@ -19,14 +19,24 @@
 <p class="err" id="errorMessage"></p>
 </div>
 <div>
-    <div class="inputoutput">
-        <canvas id="canvasInput"></canvas>
-        <div class="caption">canvasInput <input type="file" id="fileInput" name="file" accept="image/*" /></div>
-    </div>
-    <div class="inputoutput">
-        <canvas id="canvasOutput"></canvas>
-        <div class="caption">canvasOutput</div>
-    </div>
+    <table cellpadding="0" cellspacing="0" width="0" border="0">
+    <tr>
+        <td>
+            <canvas id="canvasInput"></canvas>
+        </td>
+        <td>
+            <canvas id="canvasOutput"></canvas>
+        </td>
+    </tr>
+    <tr>
+        <td>
+            <div class="caption">canvasInput <input type="file" id="fileInput" name="file" accept="image/*" /></div>
+        </td>
+        <td>
+            <div class="caption">canvasOutput</div>
+        </td>
+    </tr>
+    </table>
 </div>
 <script src="utils.js" type="text/javascript"></script>
 <script id="codeSnippet" type="text/code-snippet">

--- a/doc/js_tutorials/js_assets/js_contour_features_area.html
+++ b/doc/js_tutorials/js_assets/js_contour_features_area.html
@@ -19,11 +19,11 @@
 <p class="err" id="errorMessage"></p>
 </div>
 <div>
-    <div class="inputoutput">
+    <div>
         <canvas id="canvasInput"></canvas>
         <div class="caption">canvasInput <input type="file" id="fileInput" name="file" accept="image/*" /></div>
     </div>
-    <div class="inputoutput">
+    <div>
         <p><strong>The area is: </strong><span id="areaOutput"></span></p>
     </div>
 

--- a/doc/js_tutorials/js_assets/js_contour_features_boundingRect.html
+++ b/doc/js_tutorials/js_assets/js_contour_features_boundingRect.html
@@ -19,14 +19,24 @@
 <p class="err" id="errorMessage"></p>
 </div>
 <div>
-    <div class="inputoutput">
-        <canvas id="canvasInput"></canvas>
-        <div class="caption">canvasInput <input type="file" id="fileInput" name="file" accept="image/*" /></div>
-    </div>
-    <div class="inputoutput">
-        <canvas id="canvasOutput"></canvas>
-        <div class="caption">canvasOutput</div>
-    </div>
+    <table cellpadding="0" cellspacing="0" width="0" border="0">
+    <tr>
+        <td>
+            <canvas id="canvasInput"></canvas>
+        </td>
+        <td>
+            <canvas id="canvasOutput"></canvas>
+        </td>
+    </tr>
+    <tr>
+        <td>
+            <div class="caption">canvasInput <input type="file" id="fileInput" name="file" accept="image/*" /></div>
+        </td>
+        <td>
+            <div class="caption">canvasOutput</div>
+        </td>
+    </tr>
+    </table>
 </div>
 <script src="utils.js" type="text/javascript"></script>
 <script id="codeSnippet" type="text/code-snippet">

--- a/doc/js_tutorials/js_assets/js_contour_features_convexHull.html
+++ b/doc/js_tutorials/js_assets/js_contour_features_convexHull.html
@@ -19,14 +19,24 @@
 <p class="err" id="errorMessage"></p>
 </div>
 <div>
-    <div class="inputoutput">
-        <canvas id="canvasInput"></canvas>
-        <div class="caption">canvasInput <input type="file" id="fileInput" name="file" accept="image/*" /></div>
-    </div>
-    <div class="inputoutput">
-        <canvas id="canvasOutput"></canvas>
-        <div class="caption">canvasOutput</div>
-    </div>
+    <table cellpadding="0" cellspacing="0" width="0" border="0">
+    <tr>
+        <td>
+            <canvas id="canvasInput"></canvas>
+        </td>
+        <td>
+            <canvas id="canvasOutput"></canvas>
+        </td>
+    </tr>
+    <tr>
+        <td>
+            <div class="caption">canvasInput <input type="file" id="fileInput" name="file" accept="image/*" /></div>
+        </td>
+        <td>
+            <div class="caption">canvasOutput</div>
+        </td>
+    </tr>
+    </table>
 </div>
 <script src="utils.js" type="text/javascript"></script>
 <script id="codeSnippet" type="text/code-snippet">

--- a/doc/js_tutorials/js_assets/js_contour_features_fitEllipse.html
+++ b/doc/js_tutorials/js_assets/js_contour_features_fitEllipse.html
@@ -19,14 +19,24 @@
 <p class="err" id="errorMessage"></p>
 </div>
 <div>
-    <div class="inputoutput">
-        <canvas id="canvasInput"></canvas>
-        <div class="caption">canvasInput <input type="file" id="fileInput" name="file" accept="image/*" /></div>
-    </div>
-    <div class="inputoutput">
-        <canvas id="canvasOutput"></canvas>
-        <div class="caption">canvasOutput</div>
-    </div>
+    <table cellpadding="0" cellspacing="0" width="0" border="0">
+    <tr>
+        <td>
+            <canvas id="canvasInput"></canvas>
+        </td>
+        <td>
+            <canvas id="canvasOutput"></canvas>
+        </td>
+    </tr>
+    <tr>
+        <td>
+            <div class="caption">canvasInput <input type="file" id="fileInput" name="file" accept="image/*" /></div>
+        </td>
+        <td>
+            <div class="caption">canvasOutput</div>
+        </td>
+    </tr>
+    </table>
 </div>
 <script src="utils.js" type="text/javascript"></script>
 <script id="codeSnippet" type="text/code-snippet">

--- a/doc/js_tutorials/js_assets/js_contour_features_fitLine.html
+++ b/doc/js_tutorials/js_assets/js_contour_features_fitLine.html
@@ -19,14 +19,24 @@
 <p class="err" id="errorMessage"></p>
 </div>
 <div>
-    <div class="inputoutput">
-        <canvas id="canvasInput"></canvas>
-        <div class="caption">canvasInput <input type="file" id="fileInput" name="file" accept="image/*" /></div>
-    </div>
-    <div class="inputoutput">
-        <canvas id="canvasOutput"></canvas>
-        <div class="caption">canvasOutput</div>
-    </div>
+    <table cellpadding="0" cellspacing="0" width="0" border="0">
+    <tr>
+        <td>
+            <canvas id="canvasInput"></canvas>
+        </td>
+        <td>
+            <canvas id="canvasOutput"></canvas>
+        </td>
+    </tr>
+    <tr>
+        <td>
+            <div class="caption">canvasInput <input type="file" id="fileInput" name="file" accept="image/*" /></div>
+        </td>
+        <td>
+            <div class="caption">canvasOutput</div>
+        </td>
+    </tr>
+    </table>
 </div>
 <script src="utils.js" type="text/javascript"></script>
 <script id="codeSnippet" type="text/code-snippet">

--- a/doc/js_tutorials/js_assets/js_contour_features_minAreaRect.html
+++ b/doc/js_tutorials/js_assets/js_contour_features_minAreaRect.html
@@ -19,14 +19,24 @@
 <p class="err" id="errorMessage"></p>
 </div>
 <div>
-    <div class="inputoutput">
-        <canvas id="canvasInput"></canvas>
-        <div class="caption">canvasInput <input type="file" id="fileInput" name="file" accept="image/*" /></div>
-    </div>
-    <div class="inputoutput">
-        <canvas id="canvasOutput"></canvas>
-        <div class="caption">canvasOutput</div>
-    </div>
+    <table cellpadding="0" cellspacing="0" width="0" border="0">
+    <tr>
+        <td>
+            <canvas id="canvasInput"></canvas>
+        </td>
+        <td>
+            <canvas id="canvasOutput"></canvas>
+        </td>
+    </tr>
+    <tr>
+        <td>
+            <div class="caption">canvasInput <input type="file" id="fileInput" name="file" accept="image/*" /></div>
+        </td>
+        <td>
+            <div class="caption">canvasOutput</div>
+        </td>
+    </tr>
+    </table>
 </div>
 <script src="utils.js" type="text/javascript"></script>
 <script id="codeSnippet" type="text/code-snippet">

--- a/doc/js_tutorials/js_assets/js_contour_features_minEnclosingCircle.html
+++ b/doc/js_tutorials/js_assets/js_contour_features_minEnclosingCircle.html
@@ -19,14 +19,24 @@
 <p class="err" id="errorMessage"></p>
 </div>
 <div>
-    <div class="inputoutput">
-        <canvas id="canvasInput"></canvas>
-        <div class="caption">canvasInput <input type="file" id="fileInput" name="file" accept="image/*" /></div>
-    </div>
-    <div class="inputoutput">
-        <canvas id="canvasOutput"></canvas>
-        <div class="caption">canvasOutput</div>
-    </div>
+    <table cellpadding="0" cellspacing="0" width="0" border="0">
+    <tr>
+        <td>
+            <canvas id="canvasInput"></canvas>
+        </td>
+        <td>
+            <canvas id="canvasOutput"></canvas>
+        </td>
+    </tr>
+    <tr>
+        <td>
+            <div class="caption">canvasInput <input type="file" id="fileInput" name="file" accept="image/*" /></div>
+        </td>
+        <td>
+            <div class="caption">canvasOutput</div>
+        </td>
+    </tr>
+    </table>
 </div>
 <script src="utils.js" type="text/javascript"></script>
 <script id="codeSnippet" type="text/code-snippet">

--- a/doc/js_tutorials/js_assets/js_contour_features_moments.html
+++ b/doc/js_tutorials/js_assets/js_contour_features_moments.html
@@ -19,11 +19,11 @@
 <p class="err" id="errorMessage"></p>
 </div>
 <div>
-    <div class="inputoutput">
+    <div>
         <canvas id="canvasInput"></canvas>
         <div class="caption">canvasInput <input type="file" id="fileInput" name="file" accept="image/*" /></div>
     </div>
-    <div class="inputoutput">
+    <div>
         <p><strong>The m00 is: </strong><span id="momentsOutput"></span></p>
     </div>
 </div>

--- a/doc/js_tutorials/js_assets/js_contour_features_perimeter.html
+++ b/doc/js_tutorials/js_assets/js_contour_features_perimeter.html
@@ -19,11 +19,11 @@
 <p class="err" id="errorMessage"></p>
 </div>
 <div>
-    <div class="inputoutput">
+    <div>
         <canvas id="canvasInput"></canvas>
         <div class="caption">canvasInput <input type="file" id="fileInput" name="file" accept="image/*" /></div>
     </div>
-    <div class="inputoutput">
+    <div>
         <p><strong>The perimeter is: </strong><span id="perimeterOutput"></span></p>
     </div>
 </div>

--- a/doc/js_tutorials/js_assets/js_contour_properties_transpose.html
+++ b/doc/js_tutorials/js_assets/js_contour_properties_transpose.html
@@ -19,14 +19,24 @@
 <p class="err" id="errorMessage"></p>
 </div>
 <div>
-    <div class="inputoutput">
-        <canvas id="canvasInput"></canvas>
-        <div class="caption">canvasInput <input type="file" id="fileInput" name="file" accept="image/*" /></div>
-    </div>
-    <div class="inputoutput">
-        <canvas id="canvasOutput"></canvas>
-        <div class="caption">canvasOutput</div>
-    </div>
+    <table cellpadding="0" cellspacing="0" width="0" border="0">
+    <tr>
+        <td>
+            <canvas id="canvasInput"></canvas>
+        </td>
+        <td>
+            <canvas id="canvasOutput"></canvas>
+        </td>
+    </tr>
+    <tr>
+        <td>
+            <div class="caption">canvasInput <input type="file" id="fileInput" name="file" accept="image/*" /></div>
+        </td>
+        <td>
+            <div class="caption">canvasOutput</div>
+        </td>
+    </tr>
+    </table>
 </div>
 <script src="utils.js" type="text/javascript"></script>
 <script id="codeSnippet" type="text/code-snippet">

--- a/doc/js_tutorials/js_assets/js_contours_begin_contours.html
+++ b/doc/js_tutorials/js_assets/js_contours_begin_contours.html
@@ -19,14 +19,24 @@
 <p class="err" id="errorMessage"></p>
 </div>
 <div>
-    <div class="inputoutput">
-        <canvas id="canvasInput"></canvas>
-        <div class="caption">canvasInput <input type="file" id="fileInput" name="file" accept="image/*" /></div>
-    </div>
-    <div class="inputoutput">
-        <canvas id="canvasOutput"></canvas>
-        <div class="caption">canvasOutput</div>
-    </div>
+    <table cellpadding="0" cellspacing="0" width="0" border="0">
+    <tr>
+        <td>
+            <canvas id="canvasInput"></canvas>
+        </td>
+        <td>
+            <canvas id="canvasOutput"></canvas>
+        </td>
+    </tr>
+    <tr>
+        <td>
+            <div class="caption">canvasInput <input type="file" id="fileInput" name="file" accept="image/*" /></div>
+        </td>
+        <td>
+            <div class="caption">canvasOutput</div>
+        </td>
+    </tr>
+    </table>
 </div>
 <script src="utils.js" type="text/javascript"></script>
 <script id="codeSnippet" type="text/code-snippet">

--- a/doc/js_tutorials/js_assets/js_contours_more_functions_convexityDefects.html
+++ b/doc/js_tutorials/js_assets/js_contours_more_functions_convexityDefects.html
@@ -19,14 +19,24 @@
 <p class="err" id="errorMessage"></p>
 </div>
 <div>
-    <div class="inputoutput">
-        <canvas id="canvasInput"></canvas>
-        <div class="caption">canvasInput <input type="file" id="fileInput" name="file" accept="image/*" /></div>
-    </div>
-    <div class="inputoutput">
-        <canvas id="canvasOutput"></canvas>
-        <div class="caption">canvasOutput</div>
-    </div>
+    <table cellpadding="0" cellspacing="0" width="0" border="0">
+    <tr>
+        <td>
+            <canvas id="canvasInput"></canvas>
+        </td>
+        <td>
+            <canvas id="canvasOutput"></canvas>
+        </td>
+    </tr>
+    <tr>
+        <td>
+            <div class="caption">canvasInput <input type="file" id="fileInput" name="file" accept="image/*" /></div>
+        </td>
+        <td>
+            <div class="caption">canvasOutput</div>
+        </td>
+    </tr>
+    </table>
 </div>
 <script src="utils.js" type="text/javascript"></script>
 <script id="codeSnippet" type="text/code-snippet">

--- a/doc/js_tutorials/js_assets/js_contours_more_functions_shape.html
+++ b/doc/js_tutorials/js_assets/js_contours_more_functions_shape.html
@@ -19,18 +19,27 @@
 <p class="err" id="errorMessage"></p>
 </div>
 <div>
-    <div class="inputoutput">
-        <canvas id="canvasInput"></canvas>
-        <div class="caption">canvasInput <input type="file" id="fileInput" name="file" accept="image/*" /></div>
-    </div>
-    <div class="inputoutput">
-        <canvas id="canvasOutput"></canvas>
-        <div class="caption">canvasOutput</div>
-    </div>
-    <div class="inputoutput">
-        <p><strong>The result is: </strong><span id="matchShapesOutput"></span></p>
-    </div>
-
+    <table cellpadding="0" cellspacing="0" width="0" border="0">
+    <tr>
+        <td>
+            <canvas id="canvasInput"></canvas>
+        </td>
+        <td>
+            <canvas id="canvasOutput"></canvas>
+        </td>
+    </tr>
+    <tr>
+        <td>
+            <div class="caption">canvasInput <input type="file" id="fileInput" name="file" accept="image/*" /></div>
+        </td>
+        <td>
+            <div class="caption">canvasOutput</div>
+        </td>
+    </tr>
+    </table>
+</div>
+<div>
+    <p><strong>The result is: </strong><span id="matchShapesOutput"></span></p>
 </div>
 <script src="utils.js" type="text/javascript"></script>
 <script id="codeSnippet" type="text/code-snippet">

--- a/doc/js_tutorials/js_assets/js_example_style.css
+++ b/doc/js_tutorials/js_assets/js_example_style.css
@@ -45,10 +45,6 @@ button[disabled] {
     color: red;
     font-weight: bold;
 }
-.inputoutput {
-    margin-top: 1em;
-    margin-bottom: 1em;
-}
 .caption {
     margin: 0;
     font-weight: bold;
@@ -68,4 +64,7 @@ button[disabled] {
 }
 .hidden {
     display: none;
+}
+.small {
+    max-width: 300px;
 }

--- a/doc/js_tutorials/js_assets/js_face_detection.html
+++ b/doc/js_tutorials/js_assets/js_face_detection.html
@@ -19,14 +19,24 @@
 <p class="err" id="errorMessage"></p>
 </div>
 <div>
-    <div class="inputoutput">
-        <canvas id="canvasInput"></canvas>
-        <div class="caption">canvasInput <input type="file" id="fileInput" name="file" accept="image/*" /></div>
-    </div>
-    <div class="inputoutput">
-        <canvas id="canvasOutput"></canvas>
-        <div class="caption">canvasOutput</div>
-    </div>
+    <table cellpadding="0" cellspacing="0" width="0" border="0">
+    <tr>
+        <td>
+            <canvas id="canvasInput"></canvas>
+        </td>
+        <td>
+            <canvas id="canvasOutput"></canvas>
+        </td>
+    </tr>
+    <tr>
+        <td>
+            <div class="caption">canvasInput <input type="file" id="fileInput" name="file" accept="image/*" /></div>
+        </td>
+        <td>
+            <div class="caption">canvasOutput</div>
+        </td>
+    </tr>
+    </table>
 </div>
 <script src="utils.js" type="text/javascript"></script>
 <script id="codeSnippet" type="text/code-snippet">

--- a/doc/js_tutorials/js_assets/js_filtering_GaussianBlur.html
+++ b/doc/js_tutorials/js_assets/js_filtering_GaussianBlur.html
@@ -19,14 +19,24 @@
 <p class="err" id="errorMessage"></p>
 </div>
 <div>
-    <div class="inputoutput">
-        <canvas id="canvasInput"></canvas>
-        <div class="caption">canvasInput <input type="file" id="fileInput" name="file" accept="image/*" /></div>
-    </div>
-    <div class="inputoutput">
-        <canvas id="canvasOutput"></canvas>
-        <div class="caption">canvasOutput</div>
-    </div>
+    <table cellpadding="0" cellspacing="0" width="0" border="0">
+    <tr>
+        <td>
+            <canvas id="canvasInput"></canvas>
+        </td>
+        <td>
+            <canvas id="canvasOutput"></canvas>
+        </td>
+    </tr>
+    <tr>
+        <td>
+            <div class="caption">canvasInput <input type="file" id="fileInput" name="file" accept="image/*" /></div>
+        </td>
+        <td>
+            <div class="caption">canvasOutput</div>
+        </td>
+    </tr>
+    </table>
 </div>
 <script src="utils.js" type="text/javascript"></script>
 <script id="codeSnippet" type="text/code-snippet">

--- a/doc/js_tutorials/js_assets/js_filtering_bilateralFilter.html
+++ b/doc/js_tutorials/js_assets/js_filtering_bilateralFilter.html
@@ -19,14 +19,24 @@
 <p class="err" id="errorMessage"></p>
 </div>
 <div>
-    <div class="inputoutput">
-        <canvas id="canvasInput"></canvas>
-        <div class="caption">canvasInput <input type="file" id="fileInput" name="file" accept="image/*" /></div>
-    </div>
-    <div class="inputoutput">
-        <canvas id="canvasOutput"></canvas>
-        <div class="caption">canvasOutput</div>
-    </div>
+    <table cellpadding="0" cellspacing="0" width="0" border="0">
+    <tr>
+        <td>
+            <canvas id="canvasInput"></canvas>
+        </td>
+        <td>
+            <canvas id="canvasOutput"></canvas>
+        </td>
+    </tr>
+    <tr>
+        <td>
+            <div class="caption">canvasInput <input type="file" id="fileInput" name="file" accept="image/*" /></div>
+        </td>
+        <td>
+            <div class="caption">canvasOutput</div>
+        </td>
+    </tr>
+    </table>
 </div>
 <script src="utils.js" type="text/javascript"></script>
 <script id="codeSnippet" type="text/code-snippet">

--- a/doc/js_tutorials/js_assets/js_filtering_blur.html
+++ b/doc/js_tutorials/js_assets/js_filtering_blur.html
@@ -19,14 +19,24 @@
 <p class="err" id="errorMessage"></p>
 </div>
 <div>
-    <div class="inputoutput">
-        <canvas id="canvasInput"></canvas>
-        <div class="caption">canvasInput <input type="file" id="fileInput" name="file" accept="image/*" /></div>
-    </div>
-    <div class="inputoutput">
-        <canvas id="canvasOutput"></canvas>
-        <div class="caption">canvasOutput</div>
-    </div>
+    <table cellpadding="0" cellspacing="0" width="0" border="0">
+    <tr>
+        <td>
+            <canvas id="canvasInput"></canvas>
+        </td>
+        <td>
+            <canvas id="canvasOutput"></canvas>
+        </td>
+    </tr>
+    <tr>
+        <td>
+            <div class="caption">canvasInput <input type="file" id="fileInput" name="file" accept="image/*" /></div>
+        </td>
+        <td>
+            <div class="caption">canvasOutput</div>
+        </td>
+    </tr>
+    </table>
 </div>
 <script src="utils.js" type="text/javascript"></script>
 <script id="codeSnippet" type="text/code-snippet">

--- a/doc/js_tutorials/js_assets/js_filtering_filter.html
+++ b/doc/js_tutorials/js_assets/js_filtering_filter.html
@@ -19,14 +19,24 @@
 <p class="err" id="errorMessage"></p>
 </div>
 <div>
-    <div class="inputoutput">
-        <canvas id="canvasInput"></canvas>
-        <div class="caption">canvasInput <input type="file" id="fileInput" name="file" accept="image/*" /></div>
-    </div>
-    <div class="inputoutput">
-        <canvas id="canvasOutput"></canvas>
-        <div class="caption">canvasOutput</div>
-    </div>
+    <table cellpadding="0" cellspacing="0" width="0" border="0">
+    <tr>
+        <td>
+            <canvas id="canvasInput"></canvas>
+        </td>
+        <td>
+            <canvas id="canvasOutput"></canvas>
+        </td>
+    </tr>
+    <tr>
+        <td>
+            <div class="caption">canvasInput <input type="file" id="fileInput" name="file" accept="image/*" /></div>
+        </td>
+        <td>
+            <div class="caption">canvasOutput</div>
+        </td>
+    </tr>
+    </table>
 </div>
 <script src="utils.js" type="text/javascript"></script>
 <script id="codeSnippet" type="text/code-snippet">

--- a/doc/js_tutorials/js_assets/js_filtering_medianBlur.html
+++ b/doc/js_tutorials/js_assets/js_filtering_medianBlur.html
@@ -19,14 +19,24 @@
 <p class="err" id="errorMessage"></p>
 </div>
 <div>
-    <div class="inputoutput">
-        <canvas id="canvasInput"></canvas>
-        <div class="caption">canvasInput <input type="file" id="fileInput" name="file" accept="image/*" /></div>
-    </div>
-    <div class="inputoutput">
-        <canvas id="canvasOutput"></canvas>
-        <div class="caption">canvasOutput</div>
-    </div>
+    <table cellpadding="0" cellspacing="0" width="0" border="0">
+    <tr>
+        <td>
+            <canvas id="canvasInput"></canvas>
+        </td>
+        <td>
+            <canvas id="canvasOutput"></canvas>
+        </td>
+    </tr>
+    <tr>
+        <td>
+            <div class="caption">canvasInput <input type="file" id="fileInput" name="file" accept="image/*" /></div>
+        </td>
+        <td>
+            <div class="caption">canvasOutput</div>
+        </td>
+    </tr>
+    </table>
 </div>
 <script src="utils.js" type="text/javascript"></script>
 <script id="codeSnippet" type="text/code-snippet">

--- a/doc/js_tutorials/js_assets/js_fourier_transform_dft.html
+++ b/doc/js_tutorials/js_assets/js_fourier_transform_dft.html
@@ -19,14 +19,24 @@
 <p class="err" id="errorMessage"></p>
 </div>
 <div>
-    <div class="inputoutput">
-        <canvas id="canvasInput"></canvas>
-        <div class="caption">canvasInput <input type="file" id="fileInput" name="file" accept="image/*" /></div>
-    </div>
-    <div class="inputoutput">
-        <canvas id="canvasOutput"></canvas>
-        <div class="caption">canvasOutput</div>
-    </div>
+    <table cellpadding="0" cellspacing="0" width="0" border="0">
+    <tr>
+        <td>
+            <canvas id="canvasInput"></canvas>
+        </td>
+        <td>
+            <canvas id="canvasOutput"></canvas>
+        </td>
+    </tr>
+    <tr>
+        <td>
+            <div class="caption">canvasInput <input type="file" id="fileInput" name="file" accept="image/*" /></div>
+        </td>
+        <td>
+            <div class="caption">canvasOutput</div>
+        </td>
+    </tr>
+    </table>
 </div>
 <script src="utils.js" type="text/javascript"></script>
 <script id="codeSnippet" type="text/code-snippet">

--- a/doc/js_tutorials/js_assets/js_geometric_transformations_getAffineTransform.html
+++ b/doc/js_tutorials/js_assets/js_geometric_transformations_getAffineTransform.html
@@ -19,14 +19,24 @@
 <p class="err" id="errorMessage"></p>
 </div>
 <div>
-    <div class="inputoutput">
-        <canvas id="canvasInput"></canvas>
-        <div class="caption">canvasInput <input type="file" id="fileInput" name="file" accept="image/*" /></div>
-    </div>
-    <div class="inputoutput">
-        <canvas id="canvasOutput"></canvas>
-        <div class="caption">canvasOutput</div>
-    </div>
+    <table cellpadding="0" cellspacing="0" width="0" border="0">
+    <tr>
+        <td>
+            <canvas id="canvasInput"></canvas>
+        </td>
+        <td>
+            <canvas id="canvasOutput"></canvas>
+        </td>
+    </tr>
+    <tr>
+        <td>
+            <div class="caption">canvasInput <input type="file" id="fileInput" name="file" accept="image/*" /></div>
+        </td>
+        <td>
+            <div class="caption">canvasOutput</div>
+        </td>
+    </tr>
+    </table>
 </div>
 <script src="utils.js" type="text/javascript"></script>
 <script id="codeSnippet" type="text/code-snippet">

--- a/doc/js_tutorials/js_assets/js_geometric_transformations_resize.html
+++ b/doc/js_tutorials/js_assets/js_geometric_transformations_resize.html
@@ -19,14 +19,24 @@
 <p class="err" id="errorMessage"></p>
 </div>
 <div>
-    <div class="inputoutput">
-        <canvas id="canvasInput"></canvas>
-        <div class="caption">canvasInput <input type="file" id="fileInput" name="file" accept="image/*" /></div>
-    </div>
-    <div class="inputoutput">
-        <canvas id="canvasOutput"></canvas>
-        <div class="caption">canvasOutput</div>
-    </div>
+    <table cellpadding="0" cellspacing="0" width="0" border="0">
+    <tr>
+        <td>
+            <canvas id="canvasInput"></canvas>
+        </td>
+        <td>
+            <canvas id="canvasOutput"></canvas>
+        </td>
+    </tr>
+    <tr>
+        <td>
+            <div class="caption">canvasInput <input type="file" id="fileInput" name="file" accept="image/*" /></div>
+        </td>
+        <td>
+            <div class="caption">canvasOutput</div>
+        </td>
+    </tr>
+    </table>
 </div>
 <script src="utils.js" type="text/javascript"></script>
 <script id="codeSnippet" type="text/code-snippet">

--- a/doc/js_tutorials/js_assets/js_geometric_transformations_rotateWarpAffine.html
+++ b/doc/js_tutorials/js_assets/js_geometric_transformations_rotateWarpAffine.html
@@ -19,14 +19,24 @@
 <p class="err" id="errorMessage"></p>
 </div>
 <div>
-    <div class="inputoutput">
-        <canvas id="canvasInput"></canvas>
-        <div class="caption">canvasInput <input type="file" id="fileInput" name="file" accept="image/*" /></div>
-    </div>
-    <div class="inputoutput">
-        <canvas id="canvasOutput"></canvas>
-        <div class="caption">canvasOutput</div>
-    </div>
+    <table cellpadding="0" cellspacing="0" width="0" border="0">
+    <tr>
+        <td>
+            <canvas id="canvasInput"></canvas>
+        </td>
+        <td>
+            <canvas id="canvasOutput"></canvas>
+        </td>
+    </tr>
+    <tr>
+        <td>
+            <div class="caption">canvasInput <input type="file" id="fileInput" name="file" accept="image/*" /></div>
+        </td>
+        <td>
+            <div class="caption">canvasOutput</div>
+        </td>
+    </tr>
+    </table>
 </div>
 <script src="utils.js" type="text/javascript"></script>
 <script id="codeSnippet" type="text/code-snippet">

--- a/doc/js_tutorials/js_assets/js_geometric_transformations_warpAffine.html
+++ b/doc/js_tutorials/js_assets/js_geometric_transformations_warpAffine.html
@@ -19,14 +19,24 @@
 <p class="err" id="errorMessage"></p>
 </div>
 <div>
-    <div class="inputoutput">
-        <canvas id="canvasInput"></canvas>
-        <div class="caption">canvasInput <input type="file" id="fileInput" name="file" accept="image/*" /></div>
-    </div>
-    <div class="inputoutput">
-        <canvas id="canvasOutput"></canvas>
-        <div class="caption">canvasOutput</div>
-    </div>
+    <table cellpadding="0" cellspacing="0" width="0" border="0">
+    <tr>
+        <td>
+            <canvas id="canvasInput"></canvas>
+        </td>
+        <td>
+            <canvas id="canvasOutput"></canvas>
+        </td>
+    </tr>
+    <tr>
+        <td>
+            <div class="caption">canvasInput <input type="file" id="fileInput" name="file" accept="image/*" /></div>
+        </td>
+        <td>
+            <div class="caption">canvasOutput</div>
+        </td>
+    </tr>
+    </table>
 </div>
 <script src="utils.js" type="text/javascript"></script>
 <script id="codeSnippet" type="text/code-snippet">

--- a/doc/js_tutorials/js_assets/js_geometric_transformations_warpPerspective.html
+++ b/doc/js_tutorials/js_assets/js_geometric_transformations_warpPerspective.html
@@ -19,14 +19,24 @@
 <p class="err" id="errorMessage"></p>
 </div>
 <div>
-    <div class="inputoutput">
-        <canvas id="canvasInput"></canvas>
-        <div class="caption">canvasInput <input type="file" id="fileInput" name="file" accept="image/*" /></div>
-    </div>
-    <div class="inputoutput">
-        <canvas id="canvasOutput"></canvas>
-        <div class="caption">canvasOutput</div>
-    </div>
+    <table cellpadding="0" cellspacing="0" width="0" border="0">
+    <tr>
+        <td>
+            <canvas id="canvasInput"></canvas>
+        </td>
+        <td>
+            <canvas id="canvasOutput"></canvas>
+        </td>
+    </tr>
+    <tr>
+        <td>
+            <div class="caption">canvasInput <input type="file" id="fileInput" name="file" accept="image/*" /></div>
+        </td>
+        <td>
+            <div class="caption">canvasOutput</div>
+        </td>
+    </tr>
+    </table>
 </div>
 <script src="utils.js" type="text/javascript"></script>
 <script id="codeSnippet" type="text/code-snippet">

--- a/doc/js_tutorials/js_assets/js_grabcut_grabCut.html
+++ b/doc/js_tutorials/js_assets/js_grabcut_grabCut.html
@@ -19,14 +19,24 @@
 <p class="err" id="errorMessage"></p>
 </div>
 <div>
-    <div class="inputoutput">
-        <canvas id="canvasInput"></canvas>
-        <div class="caption">canvasInput <input type="file" id="fileInput" name="file" accept="image/*" /></div>
-    </div>
-    <div class="inputoutput">
-        <canvas id="canvasOutput"></canvas>
-        <div class="caption">canvasOutput</div>
-    </div>
+    <table cellpadding="0" cellspacing="0" width="0" border="0">
+    <tr>
+        <td>
+            <canvas id="canvasInput"></canvas>
+        </td>
+        <td>
+            <canvas id="canvasOutput"></canvas>
+        </td>
+    </tr>
+    <tr>
+        <td>
+            <div class="caption">canvasInput <input type="file" id="fileInput" name="file" accept="image/*" /></div>
+        </td>
+        <td>
+            <div class="caption">canvasOutput</div>
+        </td>
+    </tr>
+    </table>
 </div>
 <script src="utils.js" type="text/javascript"></script>
 <script id="codeSnippet" type="text/code-snippet">

--- a/doc/js_tutorials/js_assets/js_gradients_Laplacian.html
+++ b/doc/js_tutorials/js_assets/js_gradients_Laplacian.html
@@ -19,14 +19,24 @@
 <p class="err" id="errorMessage"></p>
 </div>
 <div>
-    <div class="inputoutput">
-        <canvas id="canvasInput"></canvas>
-        <div class="caption">canvasInput <input type="file" id="fileInput" name="file" accept="image/*" /></div>
-    </div>
-    <div class="inputoutput">
-        <canvas id="canvasOutput"></canvas>
-        <div class="caption">canvasOutput</div>
-    </div>
+    <table cellpadding="0" cellspacing="0" width="0" border="0">
+    <tr>
+        <td>
+            <canvas id="canvasInput"></canvas>
+        </td>
+        <td>
+            <canvas id="canvasOutput"></canvas>
+        </td>
+    </tr>
+    <tr>
+        <td>
+            <div class="caption">canvasInput <input type="file" id="fileInput" name="file" accept="image/*" /></div>
+        </td>
+        <td>
+            <div class="caption">canvasOutput</div>
+        </td>
+    </tr>
+    </table>
 </div>
 <script src="utils.js" type="text/javascript"></script>
 <script id="codeSnippet" type="text/code-snippet">

--- a/doc/js_tutorials/js_assets/js_gradients_Sobel.html
+++ b/doc/js_tutorials/js_assets/js_gradients_Sobel.html
@@ -19,18 +19,30 @@
 <p class="err" id="errorMessage"></p>
 </div>
 <div>
-    <div class="inputoutput">
-        <canvas id="canvasInput"></canvas>
-        <div class="caption">canvasInput <input type="file" id="fileInput" name="file" accept="image/*" /></div>
-    </div>
-    <div class="inputoutput">
-        <canvas id="canvasOutputx"></canvas>
-        <div class="caption">canvasOutputx</div>
-    </div>
-    <div class="inputoutput">
-        <canvas id="canvasOutputy"></canvas>
-        <div class="caption">canvasOutputy</div>
-    </div>
+    <table cellpadding="0" cellspacing="0" width="0" border="0">
+    <tr>
+        <td>
+            <canvas id="canvasInput" class="small"></canvas>
+        </td>
+        <td>
+            <canvas id="canvasOutputx" class="small"></canvas>
+        </td>
+        <td>
+            <canvas id="canvasOutputy" class="small"></canvas>
+        </td>
+    </tr>
+    <tr>
+        <td>
+            <div class="caption">canvasInput <input type="file" id="fileInput" name="file" accept="image/*" /></div>
+        </td>
+        <td>
+            <div class="caption">canvasOutputx</div>
+        </td>
+        <td>
+            <div class="caption">canvasOutputy</div>
+        </td>
+    </tr>
+    </table>
 </div>
 <script src="utils.js" type="text/javascript"></script>
 <script id="codeSnippet" type="text/code-snippet">

--- a/doc/js_tutorials/js_assets/js_gradients_absSobel.html
+++ b/doc/js_tutorials/js_assets/js_gradients_absSobel.html
@@ -19,18 +19,30 @@
 <p class="err" id="errorMessage"></p>
 </div>
 <div>
-    <div class="inputoutput">
-        <canvas id="canvasInput"></canvas>
-        <div class="caption">canvasInput <input type="file" id="fileInput" name="file" accept="image/*" /></div>
-    </div>
-    <div class="inputoutput">
-        <canvas id="canvasOutput8U"></canvas>
-        <div class="caption">canvasOutput8U</div>
-    </div>
-    <div class="inputoutput">
-        <canvas id="canvasOutput64F"></canvas>
-        <div class="caption">canvasOutput64F</div>
-    </div>
+    <table cellpadding="0" cellspacing="0" width="0" border="0">
+    <tr>
+        <td>
+            <canvas id="canvasInput" class="small"></canvas>
+        </td>
+        <td>
+            <canvas id="canvasOutput8U" class="small"></canvas>
+        </td>
+        <td>
+            <canvas id="canvasOutput64F" class="small"></canvas>
+        </td>
+    </tr>
+    <tr>
+        <td>
+            <div class="caption">canvasInput <input type="file" id="fileInput" name="file" accept="image/*" /></div>
+        </td>
+        <td>
+            <div class="caption">canvasOutput8U</div>
+        </td>
+        <td>
+            <div class="caption">canvasOutput64F</div>
+        </td>
+    </tr>
+    </table>
 </div>
 <script src="utils.js" type="text/javascript"></script>
 <script id="codeSnippet" type="text/code-snippet">

--- a/doc/js_tutorials/js_assets/js_histogram_backprojection_calcBackProject.html
+++ b/doc/js_tutorials/js_assets/js_histogram_backprojection_calcBackProject.html
@@ -19,18 +19,30 @@
 <p class="err" id="errorMessage"></p>
 </div>
 <div>
-    <div class="inputoutput">
-        <canvas id="srcCanvasInput"></canvas>
-        <div class="caption">srcCanvasInput <input type="file" id="srcFileInput" name="file" /></div>
-    </div>
-    <div class="inputoutput">
-        <canvas id="dstCanvasInput"></canvas>
-        <div class="caption">dstCanvasInput <input type="file" id="dstFileInput" name="file" /></div>
-    </div>
-    <div class="inputoutput">
-        <canvas id="canvasOutput"></canvas>
-        <div class="caption">canvasOutput</div>
-    </div>
+    <table cellpadding="0" cellspacing="0" width="0" border="0">
+    <tr>
+        <td>
+            <canvas id="srcCanvasInput" class="small"></canvas>
+        </td>
+        <td>
+            <canvas id="dstCanvasInput" class="small"></canvas>
+        </td>
+        <td>
+            <canvas id="canvasOutput" class="small"></canvas>
+        </td>
+    </tr>
+    <tr>
+        <td>
+            <div class="caption">srcCanvasInput <input type="file" id="srcFileInput" name="file" accept="image/*" /></div>
+        </td>
+        <td>
+            <div class="caption">dstCanvasInput <input type="file" id="dstFileInput" name="file" accept="image/*" /></div>
+        </td>
+        <td>
+            <div class="caption">canvasOutput</div>
+        </td>
+    </tr>
+    </table>
 </div>
 <script src="utils.js" type="text/javascript"></script>
 <script id="codeSnippet" type="text/code-snippet">

--- a/doc/js_tutorials/js_assets/js_histogram_begins_calcHist.html
+++ b/doc/js_tutorials/js_assets/js_histogram_begins_calcHist.html
@@ -19,14 +19,24 @@
 <p class="err" id="errorMessage"></p>
 </div>
 <div>
-    <div class="inputoutput">
-        <canvas id="canvasInput"></canvas>
-        <div class="caption">canvasInput <input type="file" id="fileInput" name="file" accept="image/*" /></div>
-    </div>
-    <div class="inputoutput">
-        <canvas id="canvasOutput"></canvas>
-        <div class="caption">canvasOutput</div>
-    </div>
+    <table cellpadding="0" cellspacing="0" width="0" border="0">
+    <tr>
+        <td>
+            <canvas id="canvasInput"></canvas>
+        </td>
+        <td>
+            <canvas id="canvasOutput"></canvas>
+        </td>
+    </tr>
+    <tr>
+        <td>
+            <div class="caption">canvasInput <input type="file" id="fileInput" name="file" accept="image/*" /></div>
+        </td>
+        <td>
+            <div class="caption">canvasOutput</div>
+        </td>
+    </tr>
+    </table>
 </div>
 <script src="utils.js" type="text/javascript"></script>
 <script id="codeSnippet" type="text/code-snippet">

--- a/doc/js_tutorials/js_assets/js_histogram_equalization_createCLAHE.html
+++ b/doc/js_tutorials/js_assets/js_histogram_equalization_createCLAHE.html
@@ -19,14 +19,24 @@
 <p class="err" id="errorMessage"></p>
 </div>
 <div>
-    <div class="inputoutput">
-        <canvas id="canvasInput"></canvas>
-        <div class="caption">canvasInput <input type="file" id="fileInput" name="file" accept="image/*" /></div>
-    </div>
-    <div class="inputoutput">
-        <canvas id="canvasOutput"></canvas>
-        <div class="caption">canvasOutput</div>
-    </div>
+    <table cellpadding="0" cellspacing="0" width="0" border="0">
+    <tr>
+        <td>
+            <canvas id="canvasInput"></canvas>
+        </td>
+        <td>
+            <canvas id="canvasOutput"></canvas>
+        </td>
+    </tr>
+    <tr>
+        <td>
+            <div class="caption">canvasInput <input type="file" id="fileInput" name="file" accept="image/*" /></div>
+        </td>
+        <td>
+            <div class="caption">canvasOutput</div>
+        </td>
+    </tr>
+    </table>
 </div>
 <script src="utils.js" type="text/javascript"></script>
 <script id="codeSnippet" type="text/code-snippet">

--- a/doc/js_tutorials/js_assets/js_histogram_equalization_equalizeHist.html
+++ b/doc/js_tutorials/js_assets/js_histogram_equalization_equalizeHist.html
@@ -19,14 +19,24 @@
 <p class="err" id="errorMessage"></p>
 </div>
 <div>
-    <div class="inputoutput">
-        <canvas id="canvasInput"></canvas>
-        <div class="caption">canvasInput <input type="file" id="fileInput" name="file" accept="image/*" /></div>
-    </div>
-    <div class="inputoutput">
-        <canvas id="canvasOutput"></canvas>
-        <div class="caption">canvasOutput</div>
-    </div>
+    <table cellpadding="0" cellspacing="0" width="0" border="0">
+    <tr>
+        <td>
+            <canvas id="canvasInput"></canvas>
+        </td>
+        <td>
+            <canvas id="canvasOutput"></canvas>
+        </td>
+    </tr>
+    <tr>
+        <td>
+            <div class="caption">canvasInput <input type="file" id="fileInput" name="file" accept="image/*" /></div>
+        </td>
+        <td>
+            <div class="caption">canvasOutput</div>
+        </td>
+    </tr>
+    </table>
 </div>
 <script src="utils.js" type="text/javascript"></script>
 <script id="codeSnippet" type="text/code-snippet">

--- a/doc/js_tutorials/js_assets/js_houghcircles_HoughCirclesP.html
+++ b/doc/js_tutorials/js_assets/js_houghcircles_HoughCirclesP.html
@@ -19,14 +19,24 @@
 <p class="err" id="errorMessage"></p>
 </div>
 <div>
-    <div class="inputoutput">
-        <canvas id="canvasInput"></canvas>
-        <div class="caption">canvasInput <input type="file" id="fileInput" name="file" accept="image/*" /></div>
-    </div>
-    <div class="inputoutput">
-        <canvas id="canvasOutput"></canvas>
-        <div class="caption">canvasOutput</div>
-    </div>
+    <table cellpadding="0" cellspacing="0" width="0" border="0">
+    <tr>
+        <td>
+            <canvas id="canvasInput"></canvas>
+        </td>
+        <td>
+            <canvas id="canvasOutput"></canvas>
+        </td>
+    </tr>
+    <tr>
+        <td>
+            <div class="caption">canvasInput <input type="file" id="fileInput" name="file" accept="image/*" /></div>
+        </td>
+        <td>
+            <div class="caption">canvasOutput</div>
+        </td>
+    </tr>
+    </table>
 </div>
 <script src="utils.js" type="text/javascript"></script>
 <script id="codeSnippet" type="text/code-snippet">

--- a/doc/js_tutorials/js_assets/js_houghlines_HoughLines.html
+++ b/doc/js_tutorials/js_assets/js_houghlines_HoughLines.html
@@ -19,14 +19,24 @@
 <p class="err" id="errorMessage"></p>
 </div>
 <div>
-    <div class="inputoutput">
-        <canvas id="canvasInput"></canvas>
-        <div class="caption">canvasInput <input type="file" id="fileInput" name="file" accept="image/*" /></div>
-    </div>
-    <div class="inputoutput">
-        <canvas id="canvasOutput"></canvas>
-        <div class="caption">canvasOutput</div>
-    </div>
+    <table cellpadding="0" cellspacing="0" width="0" border="0">
+    <tr>
+        <td>
+            <canvas id="canvasInput"></canvas>
+        </td>
+        <td>
+            <canvas id="canvasOutput"></canvas>
+        </td>
+    </tr>
+    <tr>
+        <td>
+            <div class="caption">canvasInput <input type="file" id="fileInput" name="file" accept="image/*" /></div>
+        </td>
+        <td>
+            <div class="caption">canvasOutput</div>
+        </td>
+    </tr>
+    </table>
 </div>
 <script src="utils.js" type="text/javascript"></script>
 <script id="codeSnippet" type="text/code-snippet">

--- a/doc/js_tutorials/js_assets/js_houghlines_HoughLinesP.html
+++ b/doc/js_tutorials/js_assets/js_houghlines_HoughLinesP.html
@@ -19,14 +19,24 @@
 <p class="err" id="errorMessage"></p>
 </div>
 <div>
-    <div class="inputoutput">
-        <canvas id="canvasInput"></canvas>
-        <div class="caption">canvasInput <input type="file" id="fileInput" name="file" accept="image/*" /></div>
-    </div>
-    <div class="inputoutput">
-        <canvas id="canvasOutput"></canvas>
-        <div class="caption">canvasOutput</div>
-    </div>
+    <table cellpadding="0" cellspacing="0" width="0" border="0">
+    <tr>
+        <td>
+            <canvas id="canvasInput"></canvas>
+        </td>
+        <td>
+            <canvas id="canvasOutput"></canvas>
+        </td>
+    </tr>
+    <tr>
+        <td>
+            <div class="caption">canvasInput <input type="file" id="fileInput" name="file" accept="image/*" /></div>
+        </td>
+        <td>
+            <div class="caption">canvasOutput</div>
+        </td>
+    </tr>
+    </table>
 </div>
 <script src="utils.js" type="text/javascript"></script>
 <script id="codeSnippet" type="text/code-snippet">

--- a/doc/js_tutorials/js_assets/js_image_arithmetics_bitwise.html
+++ b/doc/js_tutorials/js_assets/js_image_arithmetics_bitwise.html
@@ -19,18 +19,38 @@
 <p class="err" id="errorMessage"></p>
 </div>
 <div>
-    <div class="inputoutput">
-        <canvas id="imageCanvasInput"></canvas>
-        <div class="caption">imageCanvasInput <input type="file" id="imageFileInput" name="file" /></div>
-    </div>
-    <div class="inputoutput">
-        <canvas id="logoCanvasInput"></canvas>
-        <div class="caption">logoCanvasInput <input type="file" id="logoFileInput" name="file" /></div>
-    </div>
-    <div class="inputoutput">
-        <canvas id="canvasOutput"></canvas>
-        <div class="caption">canvasOutput</div>
-    </div>
+    <table cellpadding="0" cellspacing="0" width="0" border="0">
+    <tr>
+        <td>
+            <canvas id="imageCanvasInput"></canvas>
+        </td>
+        <td>
+            <canvas id="canvasOutput"></canvas>
+        </td>
+    </tr>
+    <tr>
+        <td>
+            <div class="caption">imageCanvasInput <input type="file" id="imageFileInput" name="file" accept="image/*" /></div>
+        </td>
+        <td>
+            <div class="caption">canvasOutput</div>
+        </td>
+    </tr>
+    <tr>
+        <td>
+            <canvas id="logoCanvasInput"></canvas>
+        </td>
+        <td>
+        </td>
+    </tr>
+    <tr>
+        <td>
+            <div class="caption">logoCanvasInput <input type="file" id="logoFileInput" name="file" accept="image/*" /></div>
+        </td>
+        <td>
+        </td>
+    </tr>
+    </table>
 </div>
 <script src="utils.js" type="text/javascript"></script>
 <script id="codeSnippet" type="text/code-snippet">

--- a/doc/js_tutorials/js_assets/js_image_display.html
+++ b/doc/js_tutorials/js_assets/js_image_display.html
@@ -19,14 +19,24 @@
 <p class="err" id="errorMessage"></p>
 </div>
 <div>
-    <div class="inputoutput">
-        <canvas id="canvasInput"></canvas>
-        <div class="caption">canvasInput <input type="file" id="fileInput" name="file" accept="image/*" /></div>
-    </div>
-    <div class="inputoutput">
-        <canvas id="canvasOutput"></canvas>
-        <div class="caption">canvasOutput</div>
-    </div>
+    <table cellpadding="0" cellspacing="0" width="0" border="0">
+    <tr>
+        <td>
+            <canvas id="canvasInput"></canvas>
+        </td>
+        <td>
+            <canvas id="canvasOutput"></canvas>
+        </td>
+    </tr>
+    <tr>
+        <td>
+            <div class="caption">canvasInput <input type="file" id="fileInput" name="file" accept="image/*" /></div>
+        </td>
+        <td>
+            <div class="caption">canvasOutput</div>
+        </td>
+    </tr>
+    </table>
 </div>
 <script src="utils.js" type="text/javascript"></script>
 <script id="codeSnippet" type="text/code-snippet">

--- a/doc/js_tutorials/js_assets/js_morphological_ops_blackHat.html
+++ b/doc/js_tutorials/js_assets/js_morphological_ops_blackHat.html
@@ -19,14 +19,24 @@
 <p class="err" id="errorMessage"></p>
 </div>
 <div>
-    <div class="inputoutput">
-        <canvas id="canvasInput"></canvas>
-        <div class="caption">canvasInput <input type="file" id="fileInput" name="file" accept="image/*" /></div>
-    </div>
-    <div class="inputoutput">
-        <canvas id="canvasOutput"></canvas>
-        <div class="caption">canvasOutput</div>
-    </div>
+    <table cellpadding="0" cellspacing="0" width="0" border="0">
+    <tr>
+        <td>
+            <canvas id="canvasInput"></canvas>
+        </td>
+        <td>
+            <canvas id="canvasOutput"></canvas>
+        </td>
+    </tr>
+    <tr>
+        <td>
+            <div class="caption">canvasInput <input type="file" id="fileInput" name="file" accept="image/*" /></div>
+        </td>
+        <td>
+            <div class="caption">canvasOutput</div>
+        </td>
+    </tr>
+    </table>
 </div>
 <script src="utils.js" type="text/javascript"></script>
 <script id="codeSnippet" type="text/code-snippet">

--- a/doc/js_tutorials/js_assets/js_morphological_ops_closing.html
+++ b/doc/js_tutorials/js_assets/js_morphological_ops_closing.html
@@ -19,14 +19,24 @@
 <p class="err" id="errorMessage"></p>
 </div>
 <div>
-    <div class="inputoutput">
-        <canvas id="canvasInput"></canvas>
-        <div class="caption">canvasInput <input type="file" id="fileInput" name="file" accept="image/*" /></div>
-    </div>
-    <div class="inputoutput">
-        <canvas id="canvasOutput"></canvas>
-        <div class="caption">canvasOutput</div>
-    </div>
+    <table cellpadding="0" cellspacing="0" width="0" border="0">
+    <tr>
+        <td>
+            <canvas id="canvasInput"></canvas>
+        </td>
+        <td>
+            <canvas id="canvasOutput"></canvas>
+        </td>
+    </tr>
+    <tr>
+        <td>
+            <div class="caption">canvasInput <input type="file" id="fileInput" name="file" accept="image/*" /></div>
+        </td>
+        <td>
+            <div class="caption">canvasOutput</div>
+        </td>
+    </tr>
+    </table>
 </div>
 <script src="utils.js" type="text/javascript"></script>
 <script id="codeSnippet" type="text/code-snippet">

--- a/doc/js_tutorials/js_assets/js_morphological_ops_dilate.html
+++ b/doc/js_tutorials/js_assets/js_morphological_ops_dilate.html
@@ -19,14 +19,24 @@
 <p class="err" id="errorMessage"></p>
 </div>
 <div>
-    <div class="inputoutput">
-        <canvas id="canvasInput"></canvas>
-        <div class="caption">canvasInput <input type="file" id="fileInput" name="file" accept="image/*" /></div>
-    </div>
-    <div class="inputoutput">
-        <canvas id="canvasOutput"></canvas>
-        <div class="caption">canvasOutput</div>
-    </div>
+    <table cellpadding="0" cellspacing="0" width="0" border="0">
+    <tr>
+        <td>
+            <canvas id="canvasInput"></canvas>
+        </td>
+        <td>
+            <canvas id="canvasOutput"></canvas>
+        </td>
+    </tr>
+    <tr>
+        <td>
+            <div class="caption">canvasInput <input type="file" id="fileInput" name="file" accept="image/*" /></div>
+        </td>
+        <td>
+            <div class="caption">canvasOutput</div>
+        </td>
+    </tr>
+    </table>
 </div>
 <script src="utils.js" type="text/javascript"></script>
 <script id="codeSnippet" type="text/code-snippet">

--- a/doc/js_tutorials/js_assets/js_morphological_ops_erode.html
+++ b/doc/js_tutorials/js_assets/js_morphological_ops_erode.html
@@ -19,14 +19,24 @@
 <p class="err" id="errorMessage"></p>
 </div>
 <div>
-    <div class="inputoutput">
-        <canvas id="canvasInput"></canvas>
-        <div class="caption">canvasInput <input type="file" id="fileInput" name="file" accept="image/*" /></div>
-    </div>
-    <div class="inputoutput">
-        <canvas id="canvasOutput"></canvas>
-        <div class="caption">canvasOutput</div>
-    </div>
+    <table cellpadding="0" cellspacing="0" width="0" border="0">
+    <tr>
+        <td>
+            <canvas id="canvasInput"></canvas>
+        </td>
+        <td>
+            <canvas id="canvasOutput"></canvas>
+        </td>
+    </tr>
+    <tr>
+        <td>
+            <div class="caption">canvasInput <input type="file" id="fileInput" name="file" accept="image/*" /></div>
+        </td>
+        <td>
+            <div class="caption">canvasOutput</div>
+        </td>
+    </tr>
+    </table>
 </div>
 <script src="utils.js" type="text/javascript"></script>
 <script id="codeSnippet" type="text/code-snippet">

--- a/doc/js_tutorials/js_assets/js_morphological_ops_getStructuringElement.html
+++ b/doc/js_tutorials/js_assets/js_morphological_ops_getStructuringElement.html
@@ -19,14 +19,24 @@
 <p class="err" id="errorMessage"></p>
 </div>
 <div>
-    <div class="inputoutput">
-        <canvas id="canvasInput"></canvas>
-        <div class="caption">canvasInput <input type="file" id="fileInput" name="file" accept="image/*" /></div>
-    </div>
-    <div class="inputoutput">
-        <canvas id="canvasOutput"></canvas>
-        <div class="caption">canvasOutput</div>
-    </div>
+    <table cellpadding="0" cellspacing="0" width="0" border="0">
+    <tr>
+        <td>
+            <canvas id="canvasInput"></canvas>
+        </td>
+        <td>
+            <canvas id="canvasOutput"></canvas>
+        </td>
+    </tr>
+    <tr>
+        <td>
+            <div class="caption">canvasInput <input type="file" id="fileInput" name="file" accept="image/*" /></div>
+        </td>
+        <td>
+            <div class="caption">canvasOutput</div>
+        </td>
+    </tr>
+    </table>
 </div>
 <script src="utils.js" type="text/javascript"></script>
 <script id="codeSnippet" type="text/code-snippet">

--- a/doc/js_tutorials/js_assets/js_morphological_ops_gradient.html
+++ b/doc/js_tutorials/js_assets/js_morphological_ops_gradient.html
@@ -19,14 +19,24 @@
 <p class="err" id="errorMessage"></p>
 </div>
 <div>
-    <div class="inputoutput">
-        <canvas id="canvasInput"></canvas>
-        <div class="caption">canvasInput <input type="file" id="fileInput" name="file" accept="image/*" /></div>
-    </div>
-    <div class="inputoutput">
-        <canvas id="canvasOutput"></canvas>
-        <div class="caption">canvasOutput</div>
-    </div>
+    <table cellpadding="0" cellspacing="0" width="0" border="0">
+    <tr>
+        <td>
+            <canvas id="canvasInput"></canvas>
+        </td>
+        <td>
+            <canvas id="canvasOutput"></canvas>
+        </td>
+    </tr>
+    <tr>
+        <td>
+            <div class="caption">canvasInput <input type="file" id="fileInput" name="file" accept="image/*" /></div>
+        </td>
+        <td>
+            <div class="caption">canvasOutput</div>
+        </td>
+    </tr>
+    </table>
 </div>
 <script src="utils.js" type="text/javascript"></script>
 <script id="codeSnippet" type="text/code-snippet">

--- a/doc/js_tutorials/js_assets/js_morphological_ops_opening.html
+++ b/doc/js_tutorials/js_assets/js_morphological_ops_opening.html
@@ -19,14 +19,24 @@
 <p class="err" id="errorMessage"></p>
 </div>
 <div>
-    <div class="inputoutput">
-        <canvas id="canvasInput"></canvas>
-        <div class="caption">canvasInput <input type="file" id="fileInput" name="file" accept="image/*" /></div>
-    </div>
-    <div class="inputoutput">
-        <canvas id="canvasOutput"></canvas>
-        <div class="caption">canvasOutput</div>
-    </div>
+    <table cellpadding="0" cellspacing="0" width="0" border="0">
+    <tr>
+        <td>
+            <canvas id="canvasInput"></canvas>
+        </td>
+        <td>
+            <canvas id="canvasOutput"></canvas>
+        </td>
+    </tr>
+    <tr>
+        <td>
+            <div class="caption">canvasInput <input type="file" id="fileInput" name="file" accept="image/*" /></div>
+        </td>
+        <td>
+            <div class="caption">canvasOutput</div>
+        </td>
+    </tr>
+    </table>
 </div>
 <script src="utils.js" type="text/javascript"></script>
 <script id="codeSnippet" type="text/code-snippet">

--- a/doc/js_tutorials/js_assets/js_morphological_ops_topHat.html
+++ b/doc/js_tutorials/js_assets/js_morphological_ops_topHat.html
@@ -19,14 +19,24 @@
 <p class="err" id="errorMessage"></p>
 </div>
 <div>
-    <div class="inputoutput">
-        <canvas id="canvasInput"></canvas>
-        <div class="caption">canvasInput <input type="file" id="fileInput" name="file" accept="image/*" /></div>
-    </div>
-    <div class="inputoutput">
-        <canvas id="canvasOutput"></canvas>
-        <div class="caption">canvasOutput</div>
-    </div>
+    <table cellpadding="0" cellspacing="0" width="0" border="0">
+    <tr>
+        <td>
+            <canvas id="canvasInput"></canvas>
+        </td>
+        <td>
+            <canvas id="canvasOutput"></canvas>
+        </td>
+    </tr>
+    <tr>
+        <td>
+            <div class="caption">canvasInput <input type="file" id="fileInput" name="file" accept="image/*" /></div>
+        </td>
+        <td>
+            <div class="caption">canvasOutput</div>
+        </td>
+    </tr>
+    </table>
 </div>
 <script src="utils.js" type="text/javascript"></script>
 <script id="codeSnippet" type="text/code-snippet">

--- a/doc/js_tutorials/js_assets/js_pyramids_pyrDown.html
+++ b/doc/js_tutorials/js_assets/js_pyramids_pyrDown.html
@@ -19,14 +19,24 @@
 <p class="err" id="errorMessage"></p>
 </div>
 <div>
-    <div class="inputoutput">
-        <canvas id="canvasInput"></canvas>
-        <div class="caption">canvasInput <input type="file" id="fileInput" name="file" accept="image/*" /></div>
-    </div>
-    <div class="inputoutput">
-        <canvas id="canvasOutput"></canvas>
-        <div class="caption">canvasOutput</div>
-    </div>
+    <table cellpadding="0" cellspacing="0" width="0" border="0">
+    <tr>
+        <td>
+            <canvas id="canvasInput"></canvas>
+        </td>
+        <td>
+            <canvas id="canvasOutput"></canvas>
+        </td>
+    </tr>
+    <tr>
+        <td>
+            <div class="caption">canvasInput <input type="file" id="fileInput" name="file" accept="image/*" /></div>
+        </td>
+        <td>
+            <div class="caption">canvasOutput</div>
+        </td>
+    </tr>
+    </table>
 </div>
 <script src="utils.js" type="text/javascript"></script>
 <script id="codeSnippet" type="text/code-snippet">

--- a/doc/js_tutorials/js_assets/js_pyramids_pyrUp.html
+++ b/doc/js_tutorials/js_assets/js_pyramids_pyrUp.html
@@ -19,14 +19,24 @@
 <p class="err" id="errorMessage"></p>
 </div>
 <div>
-    <div class="inputoutput">
-        <canvas id="canvasInput"></canvas>
-        <div class="caption">canvasInput <input type="file" id="fileInput" name="file" accept="image/*" /></div>
-    </div>
-    <div class="inputoutput">
-        <canvas id="canvasOutput"></canvas>
-        <div class="caption">canvasOutput</div>
-    </div>
+    <table cellpadding="0" cellspacing="0" width="0" border="0">
+    <tr>
+        <td>
+            <canvas id="canvasInput"></canvas>
+        </td>
+        <td>
+            <canvas id="canvasOutput"></canvas>
+        </td>
+    </tr>
+    <tr>
+        <td>
+            <div class="caption">canvasInput <input type="file" id="fileInput" name="file" accept="image/*" /></div>
+        </td>
+        <td>
+            <div class="caption">canvasOutput</div>
+        </td>
+    </tr>
+    </table>
 </div>
 <script src="utils.js" type="text/javascript"></script>
 <script id="codeSnippet" type="text/code-snippet">

--- a/doc/js_tutorials/js_assets/js_setup_usage.html
+++ b/doc/js_tutorials/js_assets/js_setup_usage.html
@@ -9,14 +9,24 @@
 <h2>Hello OpenCV.js</h2>
 <p id="status">OpenCV.js is loading...</p>
 <div>
-    <div class="inputoutput">
-        <img id="imageSrc" alt="No Image" />
-        <div class="caption">imageSrc <input type="file" id="fileInput" name="file" accept="image/*" /></div>
-    </div>
-    <div class="inputoutput">
-        <canvas id="canvasOutput" ></canvas>
-        <div class="caption">canvasOutput</div>
-    </div>
+    <table cellpadding="0" cellspacing="0" width="0" border="0">
+    <tr>
+        <td>
+            <img id="imageSrc" alt="No Image" class="small" />
+        </td>
+        <td>
+            <canvas id="canvasOutput" class="small" height="300px"></canvas>
+        </td>
+    </tr>
+    <tr>
+        <td>
+            <div class="caption">imageSrc <input type="file" id="fileInput" name="file" accept="image/*" /></div>
+        </td>
+        <td>
+            <div class="caption">canvasOutput</div>
+        </td>
+    </tr>
+    </table>
 </div>
 <script src="utils.js" type="text/javascript"></script>
 <script type="text/javascript">

--- a/doc/js_tutorials/js_assets/js_template_matching_matchTemplate.html
+++ b/doc/js_tutorials/js_assets/js_template_matching_matchTemplate.html
@@ -20,18 +20,38 @@
 <p class="err" id="errorMessage"></p>
 </div>
 <div>
-    <div class="inputoutput">
-        <canvas id="imageCanvasInput"></canvas>
-        <div class="caption">imageCanvasInput <input type="file" id="fileInput" name="file" accept="image/*" /></div>
-    </div>
-    <div class="inputoutput">
-        <canvas id="templateCanvasInput"></canvas>
-        <div class="caption">templateCanvasInput <input type="file" id="templateFileInput" name="file" /></div>
-    </div>
-    <div class="inputoutput">
-        <canvas id="canvasOutput"></canvas>
-        <div class="caption">canvasOutput</div>
-    </div>
+    <table cellpadding="0" cellspacing="0" width="0" border="0">
+    <tr>
+        <td>
+            <canvas id="imageCanvasInput"></canvas>
+        </td>
+        <td>
+            <canvas id="canvasOutput"></canvas>
+        </td>
+    </tr>
+    <tr>
+        <td>
+            <div class="caption">imageCanvasInput <input type="file" id="fileInput" name="file" accept="image/*" /></div>
+        </td>
+        <td>
+            <div class="caption">canvasOutput</div>
+        </td>
+    </tr>
+    <tr>
+        <td>
+            <canvas id="templateCanvasInput"></canvas>
+        </td>
+        <td>
+        </td>
+    </tr>
+    <tr>
+        <td>
+            <div class="caption">templateCanvasInput <input type="file" id="templateFileInput" name="file" accept="image/*" /></div>
+        </td>
+        <td>
+        </td>
+    </tr>
+    </table>
 </div>
 <script src="utils.js" type="text/javascript"></script>
 <script id="codeSnippet" type="text/code-snippet">

--- a/doc/js_tutorials/js_assets/js_thresholding_adaptiveThreshold.html
+++ b/doc/js_tutorials/js_assets/js_thresholding_adaptiveThreshold.html
@@ -19,14 +19,24 @@
 <p class="err" id="errorMessage"></p>
 </div>
 <div>
-    <div class="inputoutput">
-        <canvas id="canvasInput"></canvas>
-        <div class="caption">canvasInput <input type="file" id="fileInput" name="file" accept="image/*" /></div>
-    </div>
-    <div class="inputoutput">
-        <canvas id="canvasOutput"></canvas>
-        <div class="caption">canvasOutput</div>
-    </div>
+    <table cellpadding="0" cellspacing="0" width="0" border="0">
+    <tr>
+        <td>
+            <canvas id="canvasInput"></canvas>
+        </td>
+        <td>
+            <canvas id="canvasOutput"></canvas>
+        </td>
+    </tr>
+    <tr>
+        <td>
+            <div class="caption">canvasInput <input type="file" id="fileInput" name="file" accept="image/*" /></div>
+        </td>
+        <td>
+            <div class="caption">canvasOutput</div>
+        </td>
+    </tr>
+    </table>
 </div>
 <script src="utils.js" type="text/javascript"></script>
 <script id="codeSnippet" type="text/code-snippet">

--- a/doc/js_tutorials/js_assets/js_thresholding_threshold.html
+++ b/doc/js_tutorials/js_assets/js_thresholding_threshold.html
@@ -19,14 +19,24 @@
 <p class="err" id="errorMessage"></p>
 </div>
 <div>
-    <div class="inputoutput">
-        <canvas id="canvasInput"></canvas>
-        <div class="caption">canvasInput <input type="file" id="fileInput" name="file" accept="image/*" /></div>
-    </div>
-    <div class="inputoutput">
-        <canvas id="canvasOutput"></canvas>
-        <div class="caption">canvasOutput</div>
-    </div>
+    <table cellpadding="0" cellspacing="0" width="0" border="0">
+    <tr>
+        <td>
+            <canvas id="canvasInput"></canvas>
+        </td>
+        <td>
+            <canvas id="canvasOutput"></canvas>
+        </td>
+    </tr>
+    <tr>
+        <td>
+            <div class="caption">canvasInput <input type="file" id="fileInput" name="file" accept="image/*" /></div>
+        </td>
+        <td>
+            <div class="caption">canvasOutput</div>
+        </td>
+    </tr>
+    </table>
 </div>
 <script src="utils.js" type="text/javascript"></script>
 <script id="codeSnippet" type="text/code-snippet">

--- a/doc/js_tutorials/js_assets/js_trackbar.html
+++ b/doc/js_tutorials/js_assets/js_trackbar.html
@@ -21,47 +21,31 @@
     <b>trackbar</b>
     <input type="range" id="trackbar" disabled value="50" min="0" max="100" step="1">
     <label id="weightValue" ></label>
-    <div class="inputoutput">
-        <div>
-            <table cellpadding="0" cellspacing="0" width="0" border="0">
-            <tr>
-                <td>
-                    <canvas id="canvasInput1"></canvas>
-                </td>
-                <td>
-                    <canvas id="canvasInput2"></canvas>
-                </td>
-                <td></td>
-                <td></td>
-            </tr>
-            <tr>
-                <td>
-                    <p class="caption">canvasInput1</p>
-                </td>
-                <td>
-                    <p class="caption">canvasInput2</p>
-                </td>
-                <td></td>
-                <td></td>
-            </tr>
-            <tr>
-                <td>
-                    <canvas id="canvasOutput"></canvas>
-                </td>
-                <td></td>
-                <td></td>
-                <td></td>
-            </tr>
-            <tr>
-                <td>
-                    <div class="caption">canvasOutput</div>
-                </td>
-                <td></td>
-                <td></td>
-                <td></td>
-            </tr>
-            </table>
-        </div>
+    <div>
+        <table cellpadding="0" cellspacing="0" width="0" border="0">
+        <tr>
+            <td>
+                <canvas id="canvasInput1" class="small"></canvas>
+            </td>
+            <td>
+                <canvas id="canvasInput2" class="small"></canvas>
+            </td>
+            <td>
+                <canvas id="canvasOutput" class="small"></canvas>
+            </td>
+        </tr>
+        <tr>
+            <td>
+                <div class="caption">canvasInput1</div>
+            </td>
+            <td>
+                <div class="caption">canvasInput2</div>
+            </td>
+            <td>
+                <div class="caption">canvasOutput</div>
+            </td>
+        </tr>
+        </table>
     </div>
 </div>
 <script src="utils.js" type="text/javascript"></script>

--- a/doc/js_tutorials/js_assets/js_watershed_background.html
+++ b/doc/js_tutorials/js_assets/js_watershed_background.html
@@ -19,14 +19,24 @@
 <p class="err" id="errorMessage"></p>
 </div>
 <div>
-    <div class="inputoutput">
-        <canvas id="canvasInput"></canvas>
-        <div class="caption">canvasInput <input type="file" id="fileInput" name="file" accept="image/*" /></div>
-    </div>
-    <div class="inputoutput">
-        <canvas id="canvasOutput"></canvas>
-        <div class="caption">canvasOutput</div>
-    </div>
+    <table cellpadding="0" cellspacing="0" width="0" border="0">
+    <tr>
+        <td>
+            <canvas id="canvasInput"></canvas>
+        </td>
+        <td>
+            <canvas id="canvasOutput"></canvas>
+        </td>
+    </tr>
+    <tr>
+        <td>
+            <div class="caption">canvasInput <input type="file" id="fileInput" name="file" accept="image/*" /></div>
+        </td>
+        <td>
+            <div class="caption">canvasOutput</div>
+        </td>
+    </tr>
+    </table>
 </div>
 <script src="utils.js" type="text/javascript"></script>
 <script id="codeSnippet" type="text/code-snippet">

--- a/doc/js_tutorials/js_assets/js_watershed_distanceTransform.html
+++ b/doc/js_tutorials/js_assets/js_watershed_distanceTransform.html
@@ -19,14 +19,24 @@
 <p class="err" id="errorMessage"></p>
 </div>
 <div>
-    <div class="inputoutput">
-        <canvas id="canvasInput"></canvas>
-        <div class="caption">canvasInput <input type="file" id="fileInput" name="file" accept="image/*" /></div>
-    </div>
-    <div class="inputoutput">
-        <canvas id="canvasOutput"></canvas>
-        <div class="caption">canvasOutput</div>
-    </div>
+    <table cellpadding="0" cellspacing="0" width="0" border="0">
+    <tr>
+        <td>
+            <canvas id="canvasInput"></canvas>
+        </td>
+        <td>
+            <canvas id="canvasOutput"></canvas>
+        </td>
+    </tr>
+    <tr>
+        <td>
+            <div class="caption">canvasInput <input type="file" id="fileInput" name="file" accept="image/*" /></div>
+        </td>
+        <td>
+            <div class="caption">canvasOutput</div>
+        </td>
+    </tr>
+    </table>
 </div>
 <script src="utils.js" type="text/javascript"></script>
 <script id="codeSnippet" type="text/code-snippet">

--- a/doc/js_tutorials/js_assets/js_watershed_foreground.html
+++ b/doc/js_tutorials/js_assets/js_watershed_foreground.html
@@ -19,14 +19,24 @@
 <p class="err" id="errorMessage"></p>
 </div>
 <div>
-    <div class="inputoutput">
-        <canvas id="canvasInput"></canvas>
-        <div class="caption">canvasInput <input type="file" id="fileInput" name="file" accept="image/*" /></div>
-    </div>
-    <div class="inputoutput">
-        <canvas id="canvasOutput"></canvas>
-        <div class="caption">canvasOutput</div>
-    </div>
+    <table cellpadding="0" cellspacing="0" width="0" border="0">
+    <tr>
+        <td>
+            <canvas id="canvasInput"></canvas>
+        </td>
+        <td>
+            <canvas id="canvasOutput"></canvas>
+        </td>
+    </tr>
+    <tr>
+        <td>
+            <div class="caption">canvasInput <input type="file" id="fileInput" name="file" accept="image/*" /></div>
+        </td>
+        <td>
+            <div class="caption">canvasOutput</div>
+        </td>
+    </tr>
+    </table>
 </div>
 <script src="utils.js" type="text/javascript"></script>
 <script id="codeSnippet" type="text/code-snippet">

--- a/doc/js_tutorials/js_assets/js_watershed_threshold.html
+++ b/doc/js_tutorials/js_assets/js_watershed_threshold.html
@@ -19,14 +19,24 @@
 <p class="err" id="errorMessage"></p>
 </div>
 <div>
-    <div class="inputoutput">
-        <canvas id="canvasInput"></canvas>
-        <div class="caption">canvasInput <input type="file" id="fileInput" name="file" accept="image/*" /></div>
-    </div>
-    <div class="inputoutput">
-        <canvas id="canvasOutput"></canvas>
-        <div class="caption">canvasOutput</div>
-    </div>
+    <table cellpadding="0" cellspacing="0" width="0" border="0">
+    <tr>
+        <td>
+            <canvas id="canvasInput"></canvas>
+        </td>
+        <td>
+            <canvas id="canvasOutput"></canvas>
+        </td>
+    </tr>
+    <tr>
+        <td>
+            <div class="caption">canvasInput <input type="file" id="fileInput" name="file" accept="image/*" /></div>
+        </td>
+        <td>
+            <div class="caption">canvasOutput</div>
+        </td>
+    </tr>
+    </table>
 </div>
 <script src="utils.js" type="text/javascript"></script>
 <script id="codeSnippet" type="text/code-snippet">

--- a/doc/js_tutorials/js_assets/js_watershed_watershed.html
+++ b/doc/js_tutorials/js_assets/js_watershed_watershed.html
@@ -19,14 +19,24 @@
 <p class="err" id="errorMessage"></p>
 </div>
 <div>
-    <div class="inputoutput">
-        <canvas id="canvasInput"></canvas>
-        <div class="caption">canvasInput <input type="file" id="fileInput" name="file" accept="image/*" /></div>
-    </div>
-    <div class="inputoutput">
-        <canvas id="canvasOutput"></canvas>
-        <div class="caption">canvasOutput</div>
-    </div>
+    <table cellpadding="0" cellspacing="0" width="0" border="0">
+    <tr>
+        <td>
+            <canvas id="canvasInput"></canvas>
+        </td>
+        <td>
+            <canvas id="canvasOutput"></canvas>
+        </td>
+    </tr>
+    <tr>
+        <td>
+            <div class="caption">canvasInput <input type="file" id="fileInput" name="file" accept="image/*" /></div>
+        </td>
+        <td>
+            <div class="caption">canvasOutput</div>
+        </td>
+    </tr>
+    </table>
 </div>
 <script src="utils.js" type="text/javascript"></script>
 <script id="codeSnippet" type="text/code-snippet">


### PR DESCRIPTION
```
docker_image-Docs=docs-js
```

resolves #9729 

### This pullrequest changes


* Use horizontal input/output images layout in OpenCV.js tutorials

For example, before this PR, the http://docs.opencv.org/master/df/d24/tutorial_js_image_display.html looks like

![scroll](https://user-images.githubusercontent.com/1005673/30946080-7538e294-a434-11e7-8463-36c4b4a97548.png)

After this PR:

![horizental](https://user-images.githubusercontent.com/1005673/30946105-951e193a-a434-11e7-8ef1-04640186d61b.png)
