### PR TITLE
imgcodecs: fix reading 4 channel bmp images

### DIFF
--- a/modules/imgcodecs/src/grfmt_bmp.cpp
+++ b/modules/imgcodecs/src/grfmt_bmp.cpp
@@ -481,8 +481,10 @@ decode_rle8_bad: ;
 
                 if( !color )
                     icvCvt_BGRA2Gray_8u_C4C1R( src, 0, data, 0, cvSize(m_width,1) );
-                else
-                    icvCvt_BGRA2BGR_8u_C4C3R( src, 0, data, 0, cvSize(m_width,1) );
+                else if( img.channels() == 3 )
+                    icvCvt_BGRA2BGR_8u_C4C3R(src, 0, data, 0, cvSize(m_width, 1));
+                else if( img.channels() == 4 )
+                    memcpy(data, src, m_width * 4);
             }
             result = true;
             break;


### PR DESCRIPTION
resolves #9748

### This pullrequest changes

properly copy pixel data for 32bit