### PR TITLE
core: Increased maximum abs_error for hal_intrin.float* tests

### DIFF
--- a/modules/core/test/test_intrin_utils.hpp
+++ b/modules/core/test/test_intrin_utils.hpp
@@ -156,15 +156,19 @@ template <typename R> std::ostream & operator<<(std::ostream & out, const Data<R
     return out;
 }
 
+#ifndef EXPECT_COMPARE_EQ_FLOAT_ABS_ERROR
+#  define EXPECT_COMPARE_EQ_FLOAT_ABS_ERROR 0.00002f
+#endif
+
 template<typename T> static inline void EXPECT_COMPARE_EQ_(const T a, const T b);
 template<> inline void EXPECT_COMPARE_EQ_<float>(const float a, const float b)
 {
-    EXPECT_FLOAT_EQ( a, b );
+    EXPECT_NEAR( a, b, EXPECT_COMPARE_EQ_FLOAT_ABS_ERROR );
 }
 
 template<> inline void EXPECT_COMPARE_EQ_<double>(const double a, const double b)
 {
-    EXPECT_DOUBLE_EQ( a, b );
+    EXPECT_NEAR( a, b, EXPECT_COMPARE_EQ_FLOAT_ABS_ERROR );
 }
 
 template<typename R> struct TheTest

--- a/modules/core/test/test_intrin_utils.hpp
+++ b/modules/core/test/test_intrin_utils.hpp
@@ -156,19 +156,31 @@ template <typename R> std::ostream & operator<<(std::ostream & out, const Data<R
     return out;
 }
 
-#ifndef EXPECT_COMPARE_EQ_FLOAT_ABS_ERROR
-#  define EXPECT_COMPARE_EQ_FLOAT_ABS_ERROR 0.00002f
+#ifdef __PPC64__
+// Some of VSX floating point intrins' results don't fit to gtest's default absolute error so we have to increase it.
+#  ifndef EXPECT_COMPARE_EQ_FLOAT_ABS_ERROR
+#    define EXPECT_COMPARE_EQ_FLOAT_ABS_ERROR 0.00002f
+#  endif
 #endif
 
 template<typename T> static inline void EXPECT_COMPARE_EQ_(const T a, const T b);
 template<> inline void EXPECT_COMPARE_EQ_<float>(const float a, const float b)
 {
+#ifndef __PPC64__
+    EXPECT_FLOAT_EQ( a, b );
+#else
     EXPECT_NEAR( a, b, EXPECT_COMPARE_EQ_FLOAT_ABS_ERROR );
+#endif
 }
 
 template<> inline void EXPECT_COMPARE_EQ_<double>(const double a, const double b)
 {
+
+#ifndef __PPC64__
+    EXPECT_DOUBLE_EQ( a, b );
+#else
     EXPECT_NEAR( a, b, EXPECT_COMPARE_EQ_FLOAT_ABS_ERROR );
+#endif
 }
 
 template<typename R> struct TheTest


### PR DESCRIPTION
### This pullrequest changes
This commit fixes failing of tests on PowerPC platform.

The maximum error of floating point comparations on PCC64 platform is 1.5259999999961416E-05 for hal_intrin.float32x4 test. This is a bit greater than standard allowed deviation for gtest's float comparations (1.0E-05, according to float.h man). This pull request affects PPC64 only since the other architectures fit the 1.0E-05 abs_error value.