### PR TITLE
Cleanup HOGDescriptor

### DIFF
--- a/modules/js/test/test_objdetect.js
+++ b/modules/js/test/test_objdetect.js
@@ -145,9 +145,7 @@ QUnit.test('Cascade classification', function(assert) {
         assert.equal(hog.winSize.height, 128);
         assert.equal(hog.winSize.width, 64);
         assert.equal(hog.nbins, 9);
-        assert.equal(hog.derivAperture, 1);
         assert.equal(hog.winSigma, -1);
-        assert.equal(hog.histogramNormType, 0);
         assert.equal(hog.nlevels, 64);
 
         hog.nlevels = 32;

--- a/modules/objdetect/include/opencv2/objdetect.hpp
+++ b/modules/objdetect/include/opencv2/objdetect.hpp
@@ -372,8 +372,6 @@ http://www.learnopencv.com/handwritten-digits-classification-an-opencv-c-python-
 struct CV_EXPORTS_W HOGDescriptor
 {
 public:
-    enum { L2Hys = 0 //!< Default histogramNormType
-         };
     enum { DEFAULT_NLEVELS = 64 //!< Default nlevels value.
          };
     /**@brief Creates the HOG descriptor and detector with default params.
@@ -381,8 +379,7 @@ public:
     aqual to HOGDescriptor(Size(64,128), Size(16,16), Size(8,8), Size(8,8), 9, 1 )
     */
     CV_WRAP HOGDescriptor() : winSize(64,128), blockSize(16,16), blockStride(8,8),
-        cellSize(8,8), nbins(9), derivAperture(1), winSigma(-1),
-        histogramNormType(HOGDescriptor::L2Hys), L2HysThreshold(0.2), gammaCorrection(true),
+        cellSize(8,8), nbins(9), winSigma(-1), L2HysThreshold(0.2), gammaCorrection(true),
         free_coef(-1.f), nlevels(HOGDescriptor::DEFAULT_NLEVELS), signedGradient(false)
     {}
 
@@ -392,22 +389,18 @@ public:
     @param _blockStride sets blockStride with given value.
     @param _cellSize sets cellSize with given value.
     @param _nbins sets nbins with given value.
-    @param _derivAperture sets derivAperture with given value.
     @param _winSigma sets winSigma with given value.
-    @param _histogramNormType sets histogramNormType with given value.
     @param _L2HysThreshold sets L2HysThreshold with given value.
     @param _gammaCorrection sets gammaCorrection with given value.
     @param _nlevels sets nlevels with given value.
     @param _signedGradient sets signedGradient with given value.
     */
     CV_WRAP HOGDescriptor(Size _winSize, Size _blockSize, Size _blockStride,
-                  Size _cellSize, int _nbins, int _derivAperture=1, double _winSigma=-1,
-                  int _histogramNormType=HOGDescriptor::L2Hys,
+                  Size _cellSize, int _nbins, double _winSigma=-1,
                   double _L2HysThreshold=0.2, bool _gammaCorrection=false,
                   int _nlevels=HOGDescriptor::DEFAULT_NLEVELS, bool _signedGradient=false)
     : winSize(_winSize), blockSize(_blockSize), blockStride(_blockStride), cellSize(_cellSize),
-    nbins(_nbins), derivAperture(_derivAperture), winSigma(_winSigma),
-    histogramNormType(_histogramNormType), L2HysThreshold(_L2HysThreshold),
+    nbins(_nbins), winSigma(_winSigma), L2HysThreshold(_L2HysThreshold),
     gammaCorrection(_gammaCorrection), free_coef(-1.f), nlevels(_nlevels), signedGradient(_signedGradient)
     {}
 
@@ -596,14 +589,8 @@ public:
     //! Number of bins used in the calculation of histogram of gradients. Default value is 9.
     CV_PROP int nbins;
 
-    //! not documented
-    CV_PROP int derivAperture;
-
     //! Gaussian smoothing window parameter.
     CV_PROP double winSigma;
-
-    //! histogramNormType
-    CV_PROP int histogramNormType;
 
     //! L2-Hys normalization method shrinkage.
     CV_PROP double L2HysThreshold;

--- a/modules/objdetect/src/hog.cpp
+++ b/modules/objdetect/src/hog.cpp
@@ -149,9 +149,7 @@ bool HOGDescriptor::read(FileNode& obj)
     it = obj["cellSize"].begin();
     it >> cellSize.width >> cellSize.height;
     obj["nbins"] >> nbins;
-    obj["derivAperture"] >> derivAperture;
     obj["winSigma"] >> winSigma;
-    obj["histogramNormType"] >> histogramNormType;
     obj["L2HysThreshold"] >> L2HysThreshold;
     obj["gammaCorrection"] >> gammaCorrection;
     obj["nlevels"] >> nlevels;
@@ -180,9 +178,7 @@ void HOGDescriptor::write(FileStorage& fs, const String& objName) const
        << "blockStride" << blockStride
        << "cellSize" << cellSize
        << "nbins" << nbins
-       << "derivAperture" << derivAperture
        << "winSigma" << getWinSigma()
-       << "histogramNormType" << histogramNormType
        << "L2HysThreshold" << L2HysThreshold
        << "gammaCorrection" << gammaCorrection
        << "nlevels" << nlevels
@@ -212,9 +208,7 @@ void HOGDescriptor::copyTo(HOGDescriptor& c) const
     c.blockStride = blockStride;
     c.cellSize = cellSize;
     c.nbins = nbins;
-    c.derivAperture = derivAperture;
     c.winSigma = winSigma;
-    c.histogramNormType = histogramNormType;
     c.L2HysThreshold = L2HysThreshold;
     c.gammaCorrection = gammaCorrection;
     c.svmDetector = svmDetector;

--- a/samples/tapi/hog.cpp
+++ b/samples/tapi/hog.cpp
@@ -141,8 +141,7 @@ void App::run()
 
     // Create HOG descriptors and detectors here
 
-    HOGDescriptor hog(win_size, Size(16, 16), Size(8, 8), Size(8, 8), 9, 1, -1,
-                          HOGDescriptor::L2Hys, 0.2, gamma_corr, cv::HOGDescriptor::DEFAULT_NLEVELS);
+    HOGDescriptor hog(win_size, Size(16, 16), Size(8, 8), Size(8, 8), 9, -1, 0.2, gamma_corr, cv::HOGDescriptor::DEFAULT_NLEVELS);
     hog.setSVMDetector( HOGDescriptor::getDaimlerPeopleDetector() );
 
     while (running)


### PR DESCRIPTION
Before this pull request I opened #9224 and no-one could find what these parameters should do in two months.
Remove unused parameters since several years <code>derivAperture</code> and <code>histogramNormType</code> (it was not used in ["atomic bomb" commit](https://github.com/opencv/opencv/blob/127d6649a1c83397bf42799ac807af41aa507b30/modules/objdetect/src/hog.cpp)).
