### PR TITLE
tests: refactor test files

### DIFF
--- a/modules/calib3d/perf/opencl/perf_stereobm.cpp
+++ b/modules/calib3d/perf/opencl/perf_stereobm.cpp
@@ -45,10 +45,10 @@
 
 #ifdef HAVE_OPENCL
 
-namespace cvtest {
+namespace opencv_test {
 namespace ocl {
 
-typedef std::tr1::tuple<int, int> StereoBMFixture_t;
+typedef tuple<int, int> StereoBMFixture_t;
 typedef TestBaseWithParam<StereoBMFixture_t> StereoBMFixture;
 
 OCL_PERF_TEST_P(StereoBMFixture, StereoBM, ::testing::Combine(OCL_PERF_ENUM(32, 64, 128), OCL_PERF_ENUM(11,21) ) )

--- a/modules/calib3d/perf/perf_affine2d.cpp
+++ b/modules/calib3d/perf/perf_affine2d.cpp
@@ -43,14 +43,9 @@
 #include <algorithm>
 #include <functional>
 
-namespace cvtest
+namespace opencv_test
 {
-
-using std::tr1::tuple;
-using std::tr1::get;
 using namespace perf;
-using namespace testing;
-using namespace cv;
 
 CV_ENUM(Method, RANSAC, LMEDS)
 typedef tuple<int, double, Method, size_t> AffineParams;
@@ -167,4 +162,4 @@ PERF_TEST_P( EstimateAffine, EstimateAffinePartial2D, ESTIMATE_PARAMS )
     SANITY_CHECK_NOTHING();
 }
 
-} // namespace cvtest
+} // namespace opencv_test

--- a/modules/calib3d/perf/perf_cicrlesGrid.cpp
+++ b/modules/calib3d/perf/perf_cicrlesGrid.cpp
@@ -1,12 +1,10 @@
 #include "perf_precomp.hpp"
 
-using namespace std;
-using namespace cv;
+namespace opencv_test
+{
 using namespace perf;
-using std::tr1::make_tuple;
-using std::tr1::get;
 
-typedef std::tr1::tuple<std::string, cv::Size> String_Size_t;
+typedef tuple<std::string, cv::Size> String_Size_t;
 typedef perf::TestBaseWithParam<String_Size_t> String_Size;
 
 PERF_TEST_P(String_Size, asymm_circles_grid, testing::Values(
@@ -40,3 +38,5 @@ PERF_TEST_P(String_Size, asymm_circles_grid, testing::Values(
 
     SANITY_CHECK(ptvec, 2);
 }
+
+} // namespace

--- a/modules/calib3d/perf/perf_pnp.cpp
+++ b/modules/calib3d/perf/perf_pnp.cpp
@@ -1,18 +1,12 @@
 #include "perf_precomp.hpp"
 
-#ifdef HAVE_TBB
-#include "tbb/task_scheduler_init.h"
-#endif
-
-using namespace std;
-using namespace cv;
+namespace opencv_test
+{
 using namespace perf;
-using std::tr1::make_tuple;
-using std::tr1::get;
 
 CV_ENUM(pnpAlgo, SOLVEPNP_ITERATIVE, SOLVEPNP_EPNP, SOLVEPNP_P3P, SOLVEPNP_DLS, SOLVEPNP_UPNP)
 
-typedef std::tr1::tuple<int, pnpAlgo> PointsNum_Algo_t;
+typedef tuple<int, pnpAlgo> PointsNum_Algo_t;
 typedef perf::TestBaseWithParam<PointsNum_Algo_t> PointsNum_Algo;
 
 typedef perf::TestBaseWithParam<int> PointsNum;
@@ -48,14 +42,14 @@ PERF_TEST_P(PointsNum_Algo, solvePnP,
     //add noise
     Mat noise(1, (int)points2d.size(), CV_32FC2);
     randu(noise, 0, 0.01);
-    add(points2d, noise, points2d);
+    cv::add(points2d, noise, points2d);
 
     declare.in(points3d, points2d);
     declare.time(100);
 
     TEST_CYCLE_N(1000)
     {
-        solvePnP(points3d, points2d, intrinsics, distortion, rvec, tvec, false, algo);
+        cv::solvePnP(points3d, points2d, intrinsics, distortion, rvec, tvec, false, algo);
     }
 
     SANITY_CHECK(rvec, 1e-6);
@@ -92,22 +86,22 @@ PERF_TEST_P(PointsNum_Algo, solvePnPSmallPoints,
 
     // normalize Rodrigues vector
     Mat rvec_tmp = Mat::eye(3, 3, CV_32F);
-    Rodrigues(rvec, rvec_tmp);
-    Rodrigues(rvec_tmp, rvec);
+    cv::Rodrigues(rvec, rvec_tmp);
+    cv::Rodrigues(rvec_tmp, rvec);
 
-    projectPoints(points3d, rvec, tvec, intrinsics, distortion, points2d);
+    cv::projectPoints(points3d, rvec, tvec, intrinsics, distortion, points2d);
 
     //add noise
     Mat noise(1, (int)points2d.size(), CV_32FC2);
     randu(noise, -0.001, 0.001);
-    add(points2d, noise, points2d);
+    cv::add(points2d, noise, points2d);
 
     declare.in(points3d, points2d);
     declare.time(100);
 
     TEST_CYCLE_N(1000)
     {
-        solvePnP(points3d, points2d, intrinsics, distortion, rvec, tvec, false, algo);
+        cv::solvePnP(points3d, points2d, intrinsics, distortion, rvec, tvec, false, algo);
     }
 
     SANITY_CHECK(rvec, 1e-1);
@@ -144,16 +138,13 @@ PERF_TEST_P(PointsNum, DISABLED_SolvePnPRansac, testing::Values(5, 3*9, 7*13))
     Mat rvec;
     Mat tvec;
 
-#ifdef HAVE_TBB
-    // limit concurrency to get deterministic result
-    tbb::task_scheduler_init one_thread(1);
-#endif
-
     TEST_CYCLE()
     {
-        solvePnPRansac(object, image, camera_mat, dist_coef, rvec, tvec);
+        cv::solvePnPRansac(object, image, camera_mat, dist_coef, rvec, tvec);
     }
 
     SANITY_CHECK(rvec, 1e-6);
     SANITY_CHECK(tvec, 1e-6);
 }
+
+} // namespace

--- a/modules/calib3d/perf/perf_precomp.hpp
+++ b/modules/calib3d/perf/perf_precomp.hpp
@@ -1,21 +1,10 @@
-#ifdef __GNUC__
-#  pragma GCC diagnostic ignored "-Wmissing-declarations"
-#  if defined __clang__ || defined __APPLE__
-#    pragma GCC diagnostic ignored "-Wmissing-prototypes"
-#    pragma GCC diagnostic ignored "-Wextra"
-#  endif
-#endif
-
+// This file is part of OpenCV project.
+// It is subject to the license terms in the LICENSE file found in the top-level directory
+// of this distribution and at http://opencv.org/license.html
 #ifndef __OPENCV_PERF_PRECOMP_HPP__
 #define __OPENCV_PERF_PRECOMP_HPP__
 
 #include "opencv2/ts.hpp"
 #include "opencv2/calib3d.hpp"
-#include "opencv2/imgcodecs.hpp"
-#include "opencv2/imgproc.hpp"
-
-#ifdef GTEST_CREATE_SHARED_LIBRARY
-#error no modules except ts should have GTEST_CREATE_SHARED_LIBRARY defined
-#endif
 
 #endif

--- a/modules/calib3d/perf/perf_stereosgbm.cpp
+++ b/modules/calib3d/perf/perf_stereosgbm.cpp
@@ -36,7 +36,7 @@
 
 #include "perf_precomp.hpp"
 
-namespace cvtest
+namespace opencv_test
 {
 using namespace perf;
 using namespace testing;

--- a/modules/calib3d/test/opencl/test_stereobm.cpp
+++ b/modules/calib3d/test/opencl/test_stereobm.cpp
@@ -46,7 +46,7 @@
 
 #ifdef HAVE_OPENCL
 
-namespace cvtest {
+namespace opencv_test {
 namespace ocl {
 
 PARAM_TEST_CASE(StereoBMFixture, int, int)

--- a/modules/calib3d/test/test_affine2d_estimator.cpp
+++ b/modules/calib3d/test/test_affine2d_estimator.cpp
@@ -41,12 +41,7 @@
 
 #include "test_precomp.hpp"
 
-using namespace cv;
-using namespace std;
-using namespace testing;
-
-#include <vector>
-#include <numeric>
+namespace opencv_test { namespace {
 
 CV_ENUM(Method, RANSAC, LMEDS)
 typedef TestWithParam<Method> EstimateAffine2D;
@@ -156,3 +151,5 @@ TEST_P(EstimateAffine2D, testConversion)
 }
 
 INSTANTIATE_TEST_CASE_P(Calib3d, EstimateAffine2D, Method::all());
+
+}} // namespace

--- a/modules/calib3d/test/test_affine3.cpp
+++ b/modules/calib3d/test/test_affine3.cpp
@@ -42,8 +42,8 @@
 
 #include "test_precomp.hpp"
 #include "opencv2/core/affine.hpp"
-#include "opencv2/calib3d.hpp"
-#include <iostream>
+
+namespace opencv_test { namespace {
 
 TEST(Calib3d_Affine3f, accuracy)
 {
@@ -106,3 +106,5 @@ TEST(Calib3d_Affine3f, accuracy_rvec)
         ASSERT_LT(cvtest::norm(va, vo, cv::NORM_L2), 1e-9);
     }
 }
+
+}} // namespace

--- a/modules/calib3d/test/test_affine3d_estimator.cpp
+++ b/modules/calib3d/test/test_affine3d_estimator.cpp
@@ -42,16 +42,7 @@
 
 #include "test_precomp.hpp"
 
-using namespace cv;
-using namespace std;
-
-#include <string>
-#include <iostream>
-#include <fstream>
-#include <functional>
-#include <iterator>
-#include <limits>
-#include <numeric>
+namespace opencv_test { namespace {
 
 class CV_Affine3D_EstTest : public cvtest::BaseTest
 {
@@ -101,7 +92,7 @@ bool CV_Affine3D_EstTest::test4Points()
     fpts.ptr<Point3f>()[2] = Point3f( rngIn(1,2), rngIn(3,4), rngIn(5, 6) );
     fpts.ptr<Point3f>()[3] = Point3f( rngIn(3,4), rngIn(1,2), rngIn(5, 6) );
 
-    transform(fpts.ptr<Point3f>(), fpts.ptr<Point3f>() + 4, tpts.ptr<Point3f>(), WrapAff(aff));
+    std::transform(fpts.ptr<Point3f>(), fpts.ptr<Point3f>() + 4, tpts.ptr<Point3f>(), WrapAff(aff));
 
     Mat aff_est;
     vector<uchar> outliers;
@@ -144,11 +135,11 @@ bool CV_Affine3D_EstTest::testNPoints()
     Mat tpts(1, n, CV_32FC3);
 
     randu(fpts, Scalar::all(0), Scalar::all(100));
-    transform(fpts.ptr<Point3f>(), fpts.ptr<Point3f>() + n, tpts.ptr<Point3f>(), WrapAff(aff));
+    std::transform(fpts.ptr<Point3f>(), fpts.ptr<Point3f>() + n, tpts.ptr<Point3f>(), WrapAff(aff));
 
     /* adding noise*/
-    transform(tpts.ptr<Point3f>() + m, tpts.ptr<Point3f>() + n, tpts.ptr<Point3f>() + m, bind2nd(plus<Point3f>(), shift_outl));
-    transform(tpts.ptr<Point3f>() + m, tpts.ptr<Point3f>() + n, tpts.ptr<Point3f>() + m, Noise(noise_level));
+    std::transform(tpts.ptr<Point3f>() + m, tpts.ptr<Point3f>() + n, tpts.ptr<Point3f>() + m, std::bind2nd(std::plus<Point3f>(), shift_outl));
+    std::transform(tpts.ptr<Point3f>() + m, tpts.ptr<Point3f>() + n, tpts.ptr<Point3f>() + m, Noise(noise_level));
 
     Mat aff_est;
     vector<uchar> outl;
@@ -195,3 +186,5 @@ void CV_Affine3D_EstTest::run( int /* start_from */)
 }
 
 TEST(Calib3d_EstimateAffine3D, accuracy) { CV_Affine3D_EstTest test; test.safe_run(); }
+
+}} // namespace

--- a/modules/calib3d/test/test_affine_partial2d_estimator.cpp
+++ b/modules/calib3d/test/test_affine_partial2d_estimator.cpp
@@ -41,12 +41,7 @@
 
 #include "test_precomp.hpp"
 
-using namespace cv;
-using namespace std;
-using namespace testing;
-
-#include <vector>
-#include <numeric>
+namespace opencv_test { namespace {
 
 CV_ENUM(Method, RANSAC, LMEDS)
 typedef TestWithParam<Method> EstimateAffinePartial2D;
@@ -165,3 +160,5 @@ TEST_P(EstimateAffinePartial2D, testConversion)
 }
 
 INSTANTIATE_TEST_CASE_P(Calib3d, EstimateAffinePartial2D, Method::all());
+
+}} // namespace

--- a/modules/calib3d/test/test_cameracalibration.cpp
+++ b/modules/calib3d/test/test_cameracalibration.cpp
@@ -42,10 +42,7 @@
 #include "test_precomp.hpp"
 #include "opencv2/calib3d/calib3d_c.h"
 
-#include <limits>
-
-using namespace std;
-using namespace cv;
+namespace opencv_test { namespace {
 
 #if 0
 class CV_ProjectPointsTest : public cvtest::ArrayTest
@@ -861,7 +858,7 @@ void CV_CameraCalibrationTest_CPP::calibrate(int imageCount, int* pointCounts,
     for( int i = 0; i < imageCount; ++rvecsIt, ++tvecsIt, i++, rm+=9, tm+=3 )
     {
         Mat r9( 3, 3, CV_64FC1 );
-        Rodrigues( *rvecsIt, r9 );
+        cvtest::Rodrigues( *rvecsIt, r9 );
         memcpy( rm, r9.ptr(), 9*sizeof(double) );
         memcpy( tm, tvecsIt->ptr(), 3*sizeof(double) );
     }
@@ -878,7 +875,7 @@ void CV_CameraCalibrationTest_CPP::project( int pointCount, CvPoint3D64f* _objec
     Mat cameraMatrix( 3, 3, CV_64FC1, _cameraMatrix );
     Mat distCoeffs( 1, 4, CV_64FC1, distortion );
     vector<Point2f> imagePoints;
-    Rodrigues( rmat, rvec );
+    cvtest::Rodrigues( rmat, rvec );
 
     objectPoints.convertTo( objectPoints, CV_32FC1 );
     projectPoints( objectPoints, rvec, tvec,
@@ -982,7 +979,7 @@ void CV_CalibrationMatrixValuesTest::run(int)
         code = cvtest::TS::FAIL_BAD_ACCURACY;
         goto _exit_;
     }
-    if( norm( principalPoint - goodPrincipalPoint ) > FLT_EPSILON )
+    if( cv::norm(principalPoint - goodPrincipalPoint) > FLT_EPSILON ) // Point2d
     {
         ts->printf( cvtest::TS::LOG, "bad principalPoint\n" );
         code = cvtest::TS::FAIL_BAD_ACCURACY;
@@ -1117,7 +1114,8 @@ void CV_ProjectPointsTest::run(int)
     rvec(0,0) = rng.uniform( rMinVal, rMaxVal );
     rvec(0,1) = rng.uniform( rMinVal, rMaxVal );
     rvec(0,2) = rng.uniform( rMinVal, rMaxVal );
-    Rodrigues( rvec, rmat );
+    rmat = cv::Mat_<float>::zeros(3, 3);
+    cvtest::Rodrigues( rvec, rmat );
 
     tvec(0,0) = rng.uniform( tMinVal, tMaxVal );
     tvec(0,1) = rng.uniform( tMinVal, tMaxVal );
@@ -2135,7 +2133,7 @@ TEST(Calib3d_Triangulate, accuracy)
     Mat res_, res;
 
     triangulatePoints(P1, P2, x1, x2, res_);
-    transpose(res_, res_);
+    cv::transpose(res_, res_); // TODO cvtest (transpose doesn't support inplace)
     convertPointsFromHomogeneous(res_, res);
     res = res.reshape(1, 1);
 
@@ -2143,7 +2141,7 @@ TEST(Calib3d_Triangulate, accuracy)
     cout << "\tres0: " << res0 << endl;
     cout << "\tres: " << res << endl;
 
-    ASSERT_LE(norm(res, res0, NORM_INF), 1e-1);
+    ASSERT_LE(cvtest::norm(res, res0, NORM_INF), 1e-1);
     }
 
     // another testcase http://code.opencv.org/issues/3461
@@ -2175,7 +2173,7 @@ TEST(Calib3d_Triangulate, accuracy)
     Mat res_, res;
 
     triangulatePoints(P1, P2, x1, x2, res_);
-    transpose(res_, res_);
+    cv::transpose(res_, res_); // TODO cvtest (transpose doesn't support inplace)
     convertPointsFromHomogeneous(res_, res);
     res = res.reshape(1, 1);
 
@@ -2183,6 +2181,8 @@ TEST(Calib3d_Triangulate, accuracy)
     cout << "\tres0: " << res0 << endl;
     cout << "\tres: " << res << endl;
 
-    ASSERT_LE(norm(res, res0, NORM_INF), 2);
+    ASSERT_LE(cvtest::norm(res, res0, NORM_INF), 2);
     }
 }
+
+}} // namespace

--- a/modules/calib3d/test/test_cameracalibration_artificial.cpp
+++ b/modules/calib3d/test/test_cameracalibration_artificial.cpp
@@ -41,18 +41,9 @@
 //M*/
 
 #include "test_precomp.hpp"
-
-#include <string>
-#include <limits>
-#include <vector>
-#include <iostream>
-#include <sstream>
-#include <iomanip>
-
 #include "test_chessboardgenerator.hpp"
 
-using namespace cv;
-using namespace std;
+namespace opencv_test { namespace {
 
 //template<class T> ostream& operator<<(ostream& out, const Mat_<T>& mat)
 //{
@@ -75,10 +66,10 @@ Mat calcRvec(const vector<Point3f>& points, const Size& cornerSize)
     Mat rot(3, 3, CV_64F);
     *rot.ptr<Vec3d>(0) = ex;
     *rot.ptr<Vec3d>(1) = ey;
-    *rot.ptr<Vec3d>(2) = ez * (1.0/norm(ez));
+    *rot.ptr<Vec3d>(2) = ez * (1.0/cv::norm(ez)); // TODO cvtest
 
     Mat res;
-    Rodrigues(rot.t(), res);
+    cvtest::Rodrigues(rot.t(), res);
     return res.reshape(1, 1);
 }
 
@@ -174,7 +165,9 @@ protected:
             const Point3d& tvec = *tvecs[i].ptr<Point3d>();
             const Point3d& tvec_est = *tvecs_est[i].ptr<Point3d>();
 
-            if (norm(tvec_est - tvec) > eps* (norm(tvec) + dlt))
+            double n1 = cv::norm(tvec_est - tvec); // TODO cvtest
+            double n2 = cv::norm(tvec); // TODO cvtest
+            if (n1 > eps* (n2 + dlt))
             {
                 if (err_count++ < errMsgNum)
                 {
@@ -183,7 +176,7 @@ protected:
                     else
                     {
                         ts->printf( cvtest::TS::LOG, "%d) Bad accuracy in returned tvecs. Index = %d\n", r, i);
-                        ts->printf( cvtest::TS::LOG, "%d) norm(tvec_est - tvec) = %f, norm(tvec_exp) = %f \n", r, norm(tvec_est - tvec), norm(tvec));
+                        ts->printf( cvtest::TS::LOG, "%d) norm(tvec_est - tvec) = %f, norm(tvec_exp) = %f \n", r, n1, n2);
                     }
                 }
                 ts->set_failed_test_info(cvtest::TS::FAIL_BAD_ACCURACY);
@@ -201,8 +194,8 @@ protected:
         const int errMsgNum = 4;
         for(size_t i = 0; i < rvecs.size(); ++i)
         {
-            Rodrigues(rvecs[i], rmat);
-            Rodrigues(rvecs_est[i], rmat_est);
+            cvtest::Rodrigues(rvecs[i], rmat);
+            cvtest::Rodrigues(rvecs_est[i], rmat_est);
 
             if (cvtest::norm(rmat_est, rmat, NORM_L2) > eps* (cvtest::norm(rmat, NORM_L2) + dlt))
             {
@@ -237,7 +230,7 @@ protected:
             projectPoints(_chessboard3D, _rvecs_exp[i], _tvecs_exp[i], eye33, zero15, uv_exp);
             projectPoints(_chessboard3D, rvecs_est[i], tvecs_est[i], eye33, zero15, uv_est);
             for(size_t j = 0; j < cb3d.size(); ++j)
-                res += norm(uv_exp[i] - uv_est[i]);
+                res += cv::norm(uv_exp[i] - uv_est[i]); // TODO cvtest
         }
         return res;
     }
@@ -429,3 +422,5 @@ protected:
 };
 
 TEST(Calib3d_CalibrateCamera_CPP, DISABLED_accuracy_on_artificial_data) { CV_CalibrateCameraArtificialTest test; test.safe_run(); }
+
+}} // namespace

--- a/modules/calib3d/test/test_cameracalibration_badarg.cpp
+++ b/modules/calib3d/test/test_cameracalibration_badarg.cpp
@@ -43,10 +43,7 @@
 #include "test_chessboardgenerator.hpp"
 #include "opencv2/calib3d/calib3d_c.h"
 
-#include <iostream>
-
-using namespace cv;
-using namespace std;
+namespace opencv_test { namespace {
 
 class CV_CameraCalibrationBadArgTest : public cvtest::BadArgTest
 {
@@ -507,8 +504,8 @@ protected:
         objectPoints_c = objectPoints_cpp;
 
         Mat t_vec_cpp(Mat::zeros(1, 3, CV_32F)); t_vec_c = t_vec_cpp;
-        Mat r_vec_cpp;
-        Rodrigues(Mat::eye(3, 3, CV_32F), r_vec_cpp); r_vec_c = r_vec_cpp;
+        Mat r_vec_cpp(3, 1, CV_32F);
+        cvtest::Rodrigues(Mat::eye(3, 3, CV_32F), r_vec_cpp); r_vec_c = r_vec_cpp;
 
         Mat A_cpp = camMat.clone(); A_c = A_cpp;
         Mat distCoeffs_cpp = distCoeffs.clone(); distCoeffs_c = distCoeffs_cpp;
@@ -735,3 +732,5 @@ protected:
 TEST(Calib3d_CalibrateCamera_C, badarg) { CV_CameraCalibrationBadArgTest test; test.safe_run(); }
 TEST(Calib3d_Rodrigues_C, badarg) { CV_Rodrigues2BadArgTest test; test.safe_run(); }
 TEST(Calib3d_ProjectPoints_C, badarg) { CV_ProjectPoints2BadArgTest test; test.safe_run(); }
+
+}} // namespace

--- a/modules/calib3d/test/test_cameracalibration_tilt.cpp
+++ b/modules/calib3d/test/test_cameracalibration_tilt.cpp
@@ -41,8 +41,9 @@
 //M*/
 
 #include "test_precomp.hpp"
-#include <opencv2/ts/cuda_test.hpp>
-#include "opencv2/calib3d.hpp"
+#include "opencv2/ts/cuda_test.hpp" // EXPECT_MAT_NEAR
+
+namespace opencv_test { namespace {
 
 #define NUM_DIST_COEFF_TILT 14
 
@@ -664,24 +665,14 @@ TEST_F(cameraCalibrationTiltTest, calibrateCamera)
             // back projection error
             for (size_t i = 0; i < viewsNoisyImagePoints.size(); ++i)
             {
-                double dRvec = norm(
-                    m_pointTargetRvec[i] -
-                    cv::Vec3d(
-                    outRvecs[i].at<double>(0),
-                    outRvecs[i].at<double>(1),
-                    outRvecs[i].at<double>(2)));
-                // std::cout << dRvec << "  " << tolRvec << "\n";
-                EXPECT_LE(dRvec,
-                    tolRvec);
-                double dTvec = norm(
-                    m_pointTargetTvec[i] -
-                    cv::Vec3d(
-                    outTvecs[i].at<double>(0),
-                    outTvecs[i].at<double>(1),
-                    outTvecs[i].at<double>(2)));
-                // std::cout << dTvec << "  " << tolTvec << "\n";
-                EXPECT_LE(dTvec,
-                    tolTvec);
+                double dRvec = cv::norm(m_pointTargetRvec[i],
+                        cv::Vec3d(outRvecs[i].at<double>(0), outRvecs[i].at<double>(1), outRvecs[i].at<double>(2))
+                );
+                EXPECT_LE(dRvec, tolRvec);
+                double dTvec = cv::norm(m_pointTargetTvec[i],
+                        cv::Vec3d(outTvecs[i].at<double>(0), outTvecs[i].at<double>(1), outTvecs[i].at<double>(2))
+                );
+                EXPECT_LE(dTvec, tolTvec);
 
                 std::vector<cv::Point2f> backProjection;
                 cv::projectPoints(
@@ -698,3 +689,5 @@ TEST_F(cameraCalibrationTiltTest, calibrateCamera)
         pixelNoiseHalfWidth *= .25;
     }
 }
+
+}} // namespace

--- a/modules/calib3d/test/test_chessboardgenerator.cpp
+++ b/modules/calib3d/test/test_chessboardgenerator.cpp
@@ -43,28 +43,24 @@
 #include "test_precomp.hpp"
 #include "test_chessboardgenerator.hpp"
 
-#include <vector>
-#include <iterator>
-#include <algorithm>
-
-using namespace cv;
-using namespace std;
+namespace cv {
 
 ChessBoardGenerator::ChessBoardGenerator(const Size& _patternSize) : sensorWidth(32), sensorHeight(24),
     squareEdgePointsNum(200), min_cos(std::sqrt(3.f)*0.5f), cov(0.5),
     patternSize(_patternSize), rendererResolutionMultiplier(4), tvec(Mat::zeros(1, 3, CV_32F))
 {
-    Rodrigues(Mat::eye(3, 3, CV_32F), rvec);
+    rvec.create(3, 1, CV_32F);
+    cvtest::Rodrigues(Mat::eye(3, 3, CV_32F), rvec);
 }
 
-void cv::ChessBoardGenerator::generateEdge(const Point3f& p1, const Point3f& p2, vector<Point3f>& out) const
+void ChessBoardGenerator::generateEdge(const Point3f& p1, const Point3f& p2, vector<Point3f>& out) const
 {
     Point3f step = (p2 - p1) * (1.f/squareEdgePointsNum);
     for(size_t n = 0; n < squareEdgePointsNum; ++n)
         out.push_back( p1 + step * (float)n);
 }
 
-Size cv::ChessBoardGenerator::cornersSize() const
+Size ChessBoardGenerator::cornersSize() const
 {
     return Size(patternSize.width-1, patternSize.height-1);
 }
@@ -76,7 +72,7 @@ struct Mult
     Point2f operator()(const Point2f& p)const { return p * m; }
 };
 
-void cv::ChessBoardGenerator::generateBasis(Point3f& pb1, Point3f& pb2) const
+void ChessBoardGenerator::generateBasis(Point3f& pb1, Point3f& pb2) const
 {
     RNG& rng = theRNG();
 
@@ -108,7 +104,7 @@ void cv::ChessBoardGenerator::generateBasis(Point3f& pb1, Point3f& pb2) const
 }
 
 
-Mat cv::ChessBoardGenerator::generateChessBoard(const Mat& bg, const Mat& camMat, const Mat& distCoeffs,
+Mat ChessBoardGenerator::generateChessBoard(const Mat& bg, const Mat& camMat, const Mat& distCoeffs,
                                                 const Point3f& zero, const Point3f& pb1, const Point3f& pb2,
                                                 float sqWidth, float sqHeight, const vector<Point3f>& whole,
                                                 vector<Point2f>& corners) const
@@ -178,7 +174,7 @@ Mat cv::ChessBoardGenerator::generateChessBoard(const Mat& bg, const Mat& camMat
     return result;
 }
 
-Mat cv::ChessBoardGenerator::operator ()(const Mat& bg, const Mat& camMat, const Mat& distCoeffs, vector<Point2f>& corners) const
+Mat ChessBoardGenerator::operator ()(const Mat& bg, const Mat& camMat, const Mat& distCoeffs, vector<Point2f>& corners) const
 {
     cov = std::min(cov, 0.8);
     double fovx, fovy, focalLen;
@@ -242,7 +238,7 @@ Mat cv::ChessBoardGenerator::operator ()(const Mat& bg, const Mat& camMat, const
 }
 
 
-Mat cv::ChessBoardGenerator::operator ()(const Mat& bg, const Mat& camMat, const Mat& distCoeffs,
+Mat ChessBoardGenerator::operator ()(const Mat& bg, const Mat& camMat, const Mat& distCoeffs,
                                          const Size2f& squareSize, vector<Point2f>& corners) const
 {
     cov = std::min(cov, 0.8);
@@ -301,7 +297,7 @@ Mat cv::ChessBoardGenerator::operator ()(const Mat& bg, const Mat& camMat, const
         squareSize.width, squareSize.height, pts3d, corners);
 }
 
-Mat cv::ChessBoardGenerator::operator ()(const Mat& bg, const Mat& camMat, const Mat& distCoeffs,
+Mat ChessBoardGenerator::operator ()(const Mat& bg, const Mat& camMat, const Mat& distCoeffs,
                                          const Size2f& squareSize, const Point3f& pos, vector<Point2f>& corners) const
 {
     cov = std::min(cov, 0.8);
@@ -331,3 +327,5 @@ Mat cv::ChessBoardGenerator::operator ()(const Mat& bg, const Mat& camMat, const
     return generateChessBoard(bg, camMat, distCoeffs, zero, pb1, pb2,
         squareSize.width, squareSize.height,  pts3d, corners);
 }
+
+} // namespace

--- a/modules/calib3d/test/test_chessboardgenerator.hpp
+++ b/modules/calib3d/test/test_chessboardgenerator.hpp
@@ -1,10 +1,13 @@
+// This file is part of OpenCV project.
+// It is subject to the license terms in the LICENSE file found in the top-level directory
+// of this distribution and at http://opencv.org/license.html.
 #ifndef CV_CHESSBOARDGENERATOR_H143KJTVYM389YTNHKFDHJ89NYVMO3VLMEJNTBGUEIYVCM203P
 #define CV_CHESSBOARDGENERATOR_H143KJTVYM389YTNHKFDHJ89NYVMO3VLMEJNTBGUEIYVCM203P
 
-#include "opencv2/calib3d.hpp"
-
 namespace cv
 {
+
+using std::vector;
 
 class ChessBoardGenerator
 {

--- a/modules/calib3d/test/test_chesscorners.cpp
+++ b/modules/calib3d/test/test_chesscorners.cpp
@@ -43,18 +43,14 @@
 #include "test_chessboardgenerator.hpp"
 
 #include <functional>
-#include <limits>
-#include <numeric>
 
-using namespace std;
-using namespace cv;
+namespace opencv_test { namespace {
 
 #define _L2_ERR
 
 //#define DEBUG_CHESSBOARD
 
 #ifdef DEBUG_CHESSBOARD
-#include "opencv2/highgui.hpp"
 void show_points( const Mat& gray, const Mat& expected, const vector<Point2f>& actual, bool was_found )
 {
     Mat rgb( gray.size(), CV_8U);
@@ -103,7 +99,7 @@ double calcError(const vector<Point2f>& v, const Mat& u)
     int count_exp = u.cols * u.rows;
     const Point2f* u_data = u.ptr<Point2f>();
 
-    double err = numeric_limits<double>::max();
+    double err = std::numeric_limits<double>::max();
     for( int k = 0; k < 2; ++k )
     {
         double err1 = 0;
@@ -336,19 +332,19 @@ bool validateData(const ChessBoardGenerator& cbg, const Size& imgSz,
         {
             const Point2f& cur = mat(i, j);
 
-            tmp = norm( cur - mat(i + 1, j + 1) );
+            tmp = cv::norm(cur - mat(i + 1, j + 1)); // TODO cvtest
             if (tmp < minNeibDist)
                 tmp = minNeibDist;
 
-            tmp = norm( cur - mat(i - 1, j + 1 ) );
+            tmp = cv::norm(cur - mat(i - 1, j + 1)); // TODO cvtest
             if (tmp < minNeibDist)
                 tmp = minNeibDist;
 
-            tmp = norm( cur - mat(i + 1, j - 1) );
+            tmp = cv::norm(cur - mat(i + 1, j - 1)); // TODO cvtest
             if (tmp < minNeibDist)
                 tmp = minNeibDist;
 
-            tmp = norm( cur - mat(i - 1, j - 1) );
+            tmp = cv::norm(cur - mat(i - 1, j - 1)); // TODO cvtest
             if (tmp < minNeibDist)
                 tmp = minNeibDist;
         }
@@ -438,7 +434,7 @@ bool CV_ChessboardDetectorTest::checkByGenerator()
         if (found)
             res = false;
 
-        Point2f c = std::accumulate(cg.begin(), cg.end(), Point2f(), plus<Point2f>()) * (1.f/cg.size());
+        Point2f c = std::accumulate(cg.begin(), cg.end(), Point2f(), std::plus<Point2f>()) * (1.f/cg.size());
 
         Mat_<double> aff(2, 3);
         aff << 1.0, 0.0, -(double)c.x, 0.0, 1.0, 0.0;
@@ -472,4 +468,5 @@ TEST(Calib3d_AsymmetricCirclesPatternDetector, accuracy) { CV_ChessboardDetector
 TEST(Calib3d_AsymmetricCirclesPatternDetectorWithClustering, accuracy) { CV_ChessboardDetectorTest test( ASYMMETRIC_CIRCLES_GRID, CALIB_CB_CLUSTERING ); test.safe_run(); }
 #endif
 
+}} // namespace
 /* End of file. */

--- a/modules/calib3d/test/test_chesscorners_badarg.cpp
+++ b/modules/calib3d/test/test_chesscorners_badarg.cpp
@@ -43,10 +43,7 @@
 #include "test_chessboardgenerator.hpp"
 #include "opencv2/calib3d/calib3d_c.h"
 
-#include <limits>
-
-using namespace std;
-using namespace cv;
+namespace opencv_test { namespace {
 
 class CV_ChessboardDetectorBadArgTest : public cvtest::BadArgTest
 {
@@ -151,4 +148,5 @@ void CV_ChessboardDetectorBadArgTest::run( int /*start_from */)
 
 TEST(Calib3d_ChessboardDetector, badarg) { CV_ChessboardDetectorBadArgTest test; test.safe_run(); }
 
+}} // namespace
 /* End of file. */

--- a/modules/calib3d/test/test_chesscorners_timing.cpp
+++ b/modules/calib3d/test/test_chesscorners_timing.cpp
@@ -43,6 +43,8 @@
 #include "opencv2/imgproc/imgproc_c.h"
 #include "opencv2/calib3d/calib3d_c.h"
 
+namespace opencv_test { namespace {
+
 class CV_ChessboardDetectorTimingTest : public cvtest::BaseTest
 {
 public:
@@ -182,4 +184,5 @@ _exit_:
 
 TEST(Calib3d_ChessboardDetector, timing) { CV_ChessboardDetectorTimingTest test; test.safe_run(); }
 
+}} // namespace
 /* End of file. */

--- a/modules/calib3d/test/test_compose_rt.cpp
+++ b/modules/calib3d/test/test_compose_rt.cpp
@@ -42,8 +42,7 @@
 
 #include "test_precomp.hpp"
 
-using namespace cv;
-using namespace std;
+namespace opencv_test { namespace {
 
 class Differential
 {
@@ -155,14 +154,14 @@ protected:
         Mat rvec3_exp, tvec3_exp;
 
         Mat rmat1, rmat2;
-        Rodrigues(rvec1, rmat1);
-        Rodrigues(rvec2, rmat2);
-        Rodrigues(rmat2 * rmat1, rvec3_exp);
+        cv::Rodrigues(rvec1, rmat1); // TODO cvtest
+        cv::Rodrigues(rvec2, rmat2); // TODO cvtest
+        cv::Rodrigues(rmat2 * rmat1, rvec3_exp); // TODO cvtest
 
         tvec3_exp = rmat2 * tvec1 + tvec2;
 
         const double thres = 1e-5;
-        if (norm(rvec3_exp, rvec3) > thres ||  norm(tvec3_exp, tvec3) > thres)
+        if (cv::norm(rvec3_exp, rvec3) > thres ||  cv::norm(tvec3_exp, tvec3) > thres)
             ts->set_failed_test_info(cvtest::TS::FAIL_BAD_ACCURACY);
 
         const double eps = 1e-3;
@@ -176,7 +175,7 @@ protected:
         Mat_<double> dr3_dr1, dt3_dr1;
            diff.dRv1(dr3_dr1, dt3_dr1);
 
-        if (norm(dr3_dr1, dr3dr1) > thres || norm(dt3_dr1, dt3dr1) > thres)
+        if (cv::norm(dr3_dr1, dr3dr1) > thres || cv::norm(dt3_dr1, dt3dr1) > thres)
         {
             ts->printf( cvtest::TS::LOG, "Invalid derivates by r1\n" );
             ts->set_failed_test_info(cvtest::TS::FAIL_BAD_ACCURACY);
@@ -185,7 +184,7 @@ protected:
         Mat_<double> dr3_dr2, dt3_dr2;
            diff.dRv2(dr3_dr2, dt3_dr2);
 
-        if (norm(dr3_dr2, dr3dr2) > thres || norm(dt3_dr2, dt3dr2) > thres)
+        if (cv::norm(dr3_dr2, dr3dr2) > thres || cv::norm(dt3_dr2, dt3dr2) > thres)
         {
             ts->printf( cvtest::TS::LOG, "Invalid derivates by r2\n" );
             ts->set_failed_test_info(cvtest::TS::FAIL_BAD_ACCURACY);
@@ -194,7 +193,7 @@ protected:
         Mat_<double> dr3_dt1, dt3_dt1;
            diff.dTv1(dr3_dt1, dt3_dt1);
 
-        if (norm(dr3_dt1, dr3dt1) > thres || norm(dt3_dt1, dt3dt1) > thres)
+        if (cv::norm(dr3_dt1, dr3dt1) > thres || cv::norm(dt3_dt1, dt3dt1) > thres)
         {
             ts->printf( cvtest::TS::LOG, "Invalid derivates by t1\n" );
             ts->set_failed_test_info(cvtest::TS::FAIL_BAD_ACCURACY);
@@ -203,7 +202,7 @@ protected:
         Mat_<double> dr3_dt2, dt3_dt2;
            diff.dTv2(dr3_dt2, dt3_dt2);
 
-        if (norm(dr3_dt2, dr3dt2) > thres || norm(dt3_dt2, dt3dt2) > thres)
+        if (cv::norm(dr3_dt2, dr3dt2) > thres || cv::norm(dt3_dt2, dt3dt2) > thres)
         {
             ts->printf( cvtest::TS::LOG, "Invalid derivates by t2\n" );
             ts->set_failed_test_info(cvtest::TS::FAIL_BAD_ACCURACY);
@@ -212,3 +211,5 @@ protected:
 };
 
 TEST(Calib3d_ComposeRT, accuracy) { CV_composeRT_Test test; test.safe_run(); }
+
+}} // namespace

--- a/modules/calib3d/test/test_cornerssubpix.cpp
+++ b/modules/calib3d/test/test_cornerssubpix.cpp
@@ -41,11 +41,9 @@
 
 #include "test_precomp.hpp"
 #include "opencv2/imgproc/imgproc_c.h"
-#include <limits>
 #include "test_chessboardgenerator.hpp"
 
-using namespace std;
-using namespace cv;
+namespace opencv_test { namespace {
 
 class CV_ChessboardSubpixelTest : public cvtest::BaseTest
 {
@@ -78,7 +76,7 @@ int calcDistance(const vector<Point2f>& set1, const vector<Point2f>& set2, doubl
 
         for(int j = 0; j < (int)set2.size(); j++)
         {
-            double dist = norm(set1[i] - set2[j]);
+            double dist = cv::norm(set1[i] - set2[j]); // TODO cvtest
             if(dist < min_dist)
             {
                 min_idx = j;
@@ -256,4 +254,5 @@ TEST(Calib3d_CornerSubPix, regression_7204)
         cv::TermCriteria(CV_TERMCRIT_EPS + CV_TERMCRIT_ITER, 30, 0.1));
 }
 
+}} // namespace
 /* End of file. */

--- a/modules/calib3d/test/test_decompose_projection.cpp
+++ b/modules/calib3d/test/test_decompose_projection.cpp
@@ -42,6 +42,8 @@
 
 #include "test_precomp.hpp"
 
+namespace opencv_test { namespace {
+
 class CV_DecomposeProjectionMatrixTest : public cvtest::BaseTest
 {
 public:
@@ -86,7 +88,7 @@ void CV_DecomposeProjectionMatrixTest::run(int start_from)
         rng.fill(rVec, cv::RNG::UNIFORM, -CV_PI, CV_PI);
 
         cv::Matx33d origR;
-        Rodrigues(rVec, origR);
+        cv::Rodrigues(rVec, origR); // TODO cvtest
 
         cv::Vec3d origT;
         rng.fill(origT, cv::RNG::NORMAL, 0, 1);
@@ -111,19 +113,19 @@ void CV_DecomposeProjectionMatrixTest::run(int start_from)
 
 
         const double thresh = 1e-6;
-        if ( norm(origK, K, cv::NORM_INF) > thresh )
+        if (cv::norm(origK, K, cv::NORM_INF) > thresh)
         {
             ts->set_failed_test_info(cvtest::TS::FAIL_BAD_ACCURACY);
             break;
         }
 
-        if ( norm(origR, R, cv::NORM_INF) > thresh )
+        if (cv::norm(origR, R, cv::NORM_INF) > thresh)
         {
             ts->set_failed_test_info(cvtest::TS::FAIL_BAD_ACCURACY);
             break;
         }
 
-        if ( norm(origT, t, cv::NORM_INF) > thresh )
+        if (cv::norm(origT, t, cv::NORM_INF) > thresh)
         {
             ts->set_failed_test_info(cvtest::TS::FAIL_BAD_ACCURACY);
             break;
@@ -138,3 +140,5 @@ TEST(Calib3d_DecomposeProjectionMatrix, accuracy)
     CV_DecomposeProjectionMatrixTest test;
     test.safe_run();
 }
+
+}} // namespace

--- a/modules/calib3d/test/test_fisheye.cpp
+++ b/modules/calib3d/test/test_fisheye.cpp
@@ -41,9 +41,11 @@
 //M*/
 
 #include "test_precomp.hpp"
-#include <opencv2/ts/cuda_test.hpp>
+#include <opencv2/ts/cuda_test.hpp> // EXPECT_MAT_NEAR
 #include "../src/fisheye.hpp"
 #include "opencv2/videoio.hpp"
+
+namespace opencv_test { namespace {
 
 class fisheyeTest : public ::testing::Test {
 
@@ -701,3 +703,5 @@ void fisheyeTest::merge4(const cv::Mat& tl, const cv::Mat& tr, const cv::Mat& bl
     bl.copyTo(merged(cv::Rect(0, sz.height, sz.width, sz.height)));
     br.copyTo(merged(cv::Rect(sz.width, sz.height, sz.width, sz.height)));
 }
+
+}} // namespace

--- a/modules/calib3d/test/test_fundam.cpp
+++ b/modules/calib3d/test/test_fundam.cpp
@@ -42,10 +42,9 @@
 #include "test_precomp.hpp"
 #include "opencv2/calib3d/calib3d_c.h"
 
-using namespace cv;
-using namespace std;
+namespace cvtest {
 
-int cvTsRodrigues( const CvMat* src, CvMat* dst, CvMat* jacobian )
+static int cvTsRodrigues( const CvMat* src, CvMat* dst, CvMat* jacobian )
 {
     int depth;
     int i;
@@ -348,14 +347,18 @@ int cvTsRodrigues( const CvMat* src, CvMat* dst, CvMat* jacobian )
 }
 
 
-void cvtest::Rodrigues(const Mat& src, Mat& dst, Mat* jac)
+/*extern*/ void Rodrigues(const Mat& src, Mat& dst, Mat* jac)
 {
+    CV_Assert(src.data != dst.data && "Inplace is not supported");
+    CV_Assert(!dst.empty() && "'dst' must be allocated");
     CvMat _src = src, _dst = dst, _jac;
     if( jac )
         _jac = *jac;
     cvTsRodrigues(&_src, &_dst, jac ? &_jac : 0);
 }
 
+} // namespace
+namespace opencv_test {
 
 static void test_convertHomogeneous( const Mat& _src, Mat& _dst )
 {
@@ -463,6 +466,7 @@ static void test_convertHomogeneous( const Mat& _src, Mat& _dst )
         dst.convertTo(_dst, _dst.depth());
 }
 
+namespace {
 
 void
 test_projectPoints( const Mat& _3d, const Mat& Rt, const Mat& A, Mat& _2d, RNG* rng, double sigma )
@@ -728,7 +732,7 @@ void CV_RodriguesTest::prepare_to_validation( int /*test_case_idx*/ )
     cvtest::Rodrigues( m, vec2, m2v_jac );
     cvtest::copy( vec, vec2 );
 
-    theta0 = norm( vec2, CV_L2 );
+    theta0 = cvtest::norm( vec2, CV_L2 );
     theta1 = fmod( theta0, CV_PI*2 );
 
     if( theta1 > CV_PI )
@@ -1067,7 +1071,9 @@ protected:
     void run_func();
     void prepare_to_validation( int );
 
+#if 0
     double sampson_error(const double* f, double x1, double y1, double x2, double y2);
+#endif
 
     int method;
     int img_size;
@@ -1299,6 +1305,7 @@ void CV_EssentialMatTest::run_func()
     mask2.copyTo(test_mat[TEMP][4]);
 }
 
+#if 0
 double CV_EssentialMatTest::sampson_error(const double * f, double x1, double y1, double x2, double y2)
 {
     double Fx1[3] = {
@@ -1316,8 +1323,8 @@ double CV_EssentialMatTest::sampson_error(const double * f, double x1, double y1
     double error = x2tFx1 * x2tFx1 / (Fx1[0] * Fx1[0] + Fx1[1] * Fx1[1] + Ftx2[0] * Ftx2[0] + Ftx2[1] * Ftx2[1]);
     error = sqrt(error);
     return error;
-
 }
+#endif
 
 void CV_EssentialMatTest::prepare_to_validation( int test_case_idx )
 {
@@ -1395,10 +1402,10 @@ void CV_EssentialMatTest::prepare_to_validation( int test_case_idx )
 
     double* pose_prop1 = test_mat[REF_OUTPUT][2].ptr<double>();
     double* pose_prop2 = test_mat[OUTPUT][2].ptr<double>();
-    double terr1 = cvtest::norm(Rt0.col(3) / norm(Rt0.col(3)) + test_mat[TEMP][3], NORM_L2);
-    double terr2 = cvtest::norm(Rt0.col(3) / norm(Rt0.col(3)) - test_mat[TEMP][3], NORM_L2);
-    Mat rvec;
-    Rodrigues(Rt0.colRange(0, 3), rvec);
+    double terr1 = cvtest::norm(Rt0.col(3) / cvtest::norm(Rt0.col(3), NORM_L2) + test_mat[TEMP][3], NORM_L2);
+    double terr2 = cvtest::norm(Rt0.col(3) / cvtest::norm(Rt0.col(3), NORM_L2) - test_mat[TEMP][3], NORM_L2);
+    Mat rvec(3, 1, CV_32F);
+    cvtest::Rodrigues(Rt0.colRange(0, 3), rvec);
     pose_prop1[0] = 0;
     // No check for CV_LMeDS on translation. Since it
     // involves with some degraded problem, when data is exact inliers.
@@ -1726,4 +1733,5 @@ TEST(Calib3d_FindFundamentalMat, correctMatches)
     cout << np2 << endl;
 }
 
+}} // namespace
 /* End of file. */

--- a/modules/calib3d/test/test_homography.cpp
+++ b/modules/calib3d/test/test_homography.cpp
@@ -42,7 +42,8 @@
 //M*/
 
 #include "test_precomp.hpp"
-#include <time.h>
+
+namespace opencv_test { namespace {
 
 #define CALIB3D_HOMOGRAPHY_ERROR_MATRIX_SIZE 1
 #define CALIB3D_HOMOGRAPHY_ERROR_MATRIX_DIFF 2
@@ -622,7 +623,7 @@ TEST(Calib3d_Homography, EKcase)
     Mat h = findHomography(p1, p2, RANSAC, 0.01, mask);
     ASSERT_TRUE(!h.empty());
 
-    transpose(mask, mask);
+    cv::transpose(mask, mask);
     Mat p3, mask2;
     int ninliers = countNonZero(mask);
     Mat nmask[] = { mask, mask };
@@ -631,7 +632,7 @@ TEST(Calib3d_Homography, EKcase)
     mask2 = mask2.reshape(1);
     p2 = p2.reshape(1);
     p3 = p3.reshape(1);
-    double err = norm(p2, p3, NORM_INF, mask2);
+    double err = cvtest::norm(p2, p3, NORM_INF, mask2);
 
     printf("ninliers: %d, inliers err: %.2g\n", ninliers, err);
     ASSERT_GE(ninliers, 10);
@@ -709,3 +710,5 @@ TEST(Calib3d_Homography, fromImages)
     ASSERT_TRUE(!H1.empty());
     ASSERT_GE(ninliers1, 80);
 }
+
+}} // namespace

--- a/modules/calib3d/test/test_homography_decomp.cpp
+++ b/modules/calib3d/test/test_homography_decomp.cpp
@@ -44,11 +44,8 @@
  //M*/
 
 #include "test_precomp.hpp"
-#include "opencv2/calib3d.hpp"
-#include <vector>
 
-using namespace cv;
-using namespace std;
+namespace opencv_test { namespace {
 
 class CV_HomographyDecompTest: public cvtest::BaseTest {
 
@@ -118,9 +115,9 @@ private:
              riter != rotations.end() && titer != translations.end() && niter != normals.end();
              ++riter, ++titer, ++niter) {
 
-            double rdist = norm(*riter, _R, NORM_INF);
-            double tdist = norm(*titer, _t, NORM_INF);
-            double ndist = norm(*niter, _n, NORM_INF);
+            double rdist = cvtest::norm(*riter, _R, NORM_INF);
+            double tdist = cvtest::norm(*titer, _t, NORM_INF);
+            double ndist = cvtest::norm(*niter, _n, NORM_INF);
 
             if (   rdist < max_error
                 && tdist < max_error
@@ -136,3 +133,5 @@ private:
 };
 
 TEST(Calib3d_DecomposeHomography, regression) { CV_HomographyDecompTest test; test.safe_run(); }
+
+}} // namespace

--- a/modules/calib3d/test/test_main.cpp
+++ b/modules/calib3d/test/test_main.cpp
@@ -1,3 +1,6 @@
+// This file is part of OpenCV project.
+// It is subject to the license terms in the LICENSE file found in the top-level directory
+// of this distribution and at http://opencv.org/license.html.
 #include "test_precomp.hpp"
 
 CV_TEST_MAIN("")

--- a/modules/calib3d/test/test_posit.cpp
+++ b/modules/calib3d/test/test_posit.cpp
@@ -42,8 +42,7 @@
 #include "test_precomp.hpp"
 #include "opencv2/calib3d/calib3d_c.h"
 
-using namespace cv;
-using namespace std;
+namespace opencv_test { namespace {
 
 class CV_POSITTest : public cvtest::BaseTest
 {
@@ -219,4 +218,5 @@ void CV_POSITTest::run( int start_from )
 
 TEST(Calib3d_POSIT, accuracy) { CV_POSITTest test; test.safe_run(); }
 
+}} // namespace
 /* End of file. */

--- a/modules/calib3d/test/test_precomp.hpp
+++ b/modules/calib3d/test/test_precomp.hpp
@@ -1,23 +1,22 @@
-#ifdef __GNUC__
-#  pragma GCC diagnostic ignored "-Wmissing-declarations"
-#  if defined __clang__ || defined __APPLE__
-#    pragma GCC diagnostic ignored "-Wmissing-prototypes"
-#    pragma GCC diagnostic ignored "-Wextra"
-#  endif
-#endif
-
+// This file is part of OpenCV project.
+// It is subject to the license terms in the LICENSE file found in the top-level directory
+// of this distribution and at http://opencv.org/license.html.
 #ifndef __OPENCV_TEST_PRECOMP_HPP__
 #define __OPENCV_TEST_PRECOMP_HPP__
 
-#include <iostream>
+#include <functional>
+#include <numeric>
+
 #include "opencv2/ts.hpp"
-#include "opencv2/imgproc.hpp"
 #include "opencv2/calib3d.hpp"
-#include "opencv2/imgcodecs.hpp"
 
 namespace cvtest
 {
     void Rodrigues(const Mat& src, Mat& dst, Mat* jac=0);
 }
+
+namespace opencv_test {
+CVTEST_GUARD_SYMBOL(Rodrigues)
+} // namespace
 
 #endif

--- a/modules/calib3d/test/test_reproject_image_to_3d.cpp
+++ b/modules/calib3d/test/test_reproject_image_to_3d.cpp
@@ -42,11 +42,8 @@
 
 #include "test_precomp.hpp"
 #include "opencv2/calib3d/calib3d_c.h"
-#include <string>
-#include <limits>
 
-using namespace cv;
-using namespace std;
+namespace opencv_test { namespace {
 
 template<class T> double thres() { return 1.0; }
 template<> double thres<float>() { return 1e-5; }
@@ -130,7 +127,7 @@ protected:
         CvMat cvdisp = disp; CvMat cv_3dImg = _3dImg; CvMat cvQ = Q;
         cvReprojectImageTo3D( &cvdisp, &cv_3dImg, &cvQ, handleMissingValues );
 
-        if (numeric_limits<OutT>::max() == numeric_limits<float>::max())
+        if (std::numeric_limits<OutT>::max() == std::numeric_limits<float>::max())
             reprojectImageTo3D(disp, _3dImg, Q, handleMissingValues);
 
         for(int y = 0; y < disp.rows; ++y)
@@ -178,3 +175,5 @@ protected:
 };
 
 TEST(Calib3d_ReprojectImageTo3D, accuracy) { CV_ReprojectImageTo3DTest test; test.safe_run(); }
+
+}} // namespace

--- a/modules/calib3d/test/test_solvepnp_ransac.cpp
+++ b/modules/calib3d/test/test_solvepnp_ransac.cpp
@@ -42,12 +42,7 @@
 
 #include "test_precomp.hpp"
 
-#ifdef HAVE_TBB
-#include "tbb/task_scheduler_init.h"
-#endif
-
-using namespace cv;
-using namespace std;
+namespace opencv_test { namespace {
 
 class CV_solvePnPRansac_Test : public cvtest::BaseTest
 {
@@ -69,7 +64,7 @@ protected:
         Point3f pmin = Point3f(-1, -1, 5),
         Point3f pmax = Point3f(1, 1, 10))
     {
-        RNG rng = ::theRNG(); // fix the seed to use "fixed" input 3D points
+        RNG rng = cv::theRNG(); // fix the seed to use "fixed" input 3D points
 
         for (size_t i = 0; i < points.size(); i++)
         {
@@ -142,7 +137,7 @@ protected:
 
         bool isTestSuccess = inliers.size() >= points.size()*0.95;
 
-        double rvecDiff = norm(rvec-trueRvec), tvecDiff = norm(tvec-trueTvec);
+        double rvecDiff = cvtest::norm(rvec, trueRvec, NORM_L2), tvecDiff = cvtest::norm(tvec, trueTvec, NORM_L2);
         isTestSuccess = isTestSuccess && rvecDiff < epsilon[method] && tvecDiff < epsilon[method];
         double error = rvecDiff > tvecDiff ? rvecDiff : tvecDiff;
         //cout << error << " " << inliers.size() << " " << eps[method] << endl;
@@ -254,7 +249,7 @@ protected:
             return isEstimateSuccess;
         }
 
-        double rvecDiff = norm(rvec-trueRvec), tvecDiff = norm(tvec-trueTvec);
+        double rvecDiff = cvtest::norm(rvec, trueRvec, NORM_L2), tvecDiff = cvtest::norm(tvec, trueTvec, NORM_L2);
         bool isTestSuccess = rvecDiff < epsilon[method] && tvecDiff < epsilon[method];
 
         double error = rvecDiff > tvecDiff ? rvecDiff : tvecDiff;
@@ -305,8 +300,8 @@ class CV_solveP3P_Test : public CV_solvePnPRansac_Test
     bool isTestSuccess = false;
     double error = DBL_MAX;
     for (unsigned int i = 0; i < rvecs.size() && !isTestSuccess; ++i) {
-      double rvecDiff = norm(rvecs[i]-trueRvec);
-      double tvecDiff = norm(tvecs[i]-trueTvec);
+      double rvecDiff = cvtest::norm(rvecs[i], trueRvec, NORM_L2);
+      double tvecDiff = cvtest::norm(tvecs[i], trueTvec, NORM_L2);
       isTestSuccess = rvecDiff < epsilon[method] && tvecDiff < epsilon[method];
       error = std::min(error, std::max(rvecDiff, tvecDiff));
     }
@@ -450,12 +445,12 @@ TEST(Calib3d_SolvePnPRansac, input_type)
     points2dMat = points2dMat.reshape(1, numPoints);
     EXPECT_TRUE(solvePnPRansac(points3dMat, points2dMat, intrinsics, cv::Mat(), R4, t4));
 
-    EXPECT_LE(norm(R1, R2, NORM_INF), 1e-6);
-    EXPECT_LE(norm(t1, t2, NORM_INF), 1e-6);
-    EXPECT_LE(norm(R1, R3, NORM_INF), 1e-6);
-    EXPECT_LE(norm(t1, t3, NORM_INF), 1e-6);
-    EXPECT_LE(norm(R1, R4, NORM_INF), 1e-6);
-    EXPECT_LE(norm(t1, t4, NORM_INF), 1e-6);
+    EXPECT_LE(cvtest::norm(R1, R2, NORM_INF), 1e-6);
+    EXPECT_LE(cvtest::norm(t1, t2, NORM_INF), 1e-6);
+    EXPECT_LE(cvtest::norm(R1, R3, NORM_INF), 1e-6);
+    EXPECT_LE(cvtest::norm(t1, t3, NORM_INF), 1e-6);
+    EXPECT_LE(cvtest::norm(R1, R4, NORM_INF), 1e-6);
+    EXPECT_LE(cvtest::norm(t1, t4, NORM_INF), 1e-6);
 }
 
 TEST(Calib3d_SolvePnP, double_support)
@@ -483,8 +478,8 @@ TEST(Calib3d_SolvePnP, double_support)
     solvePnPRansac(points3dF, points2dF, intrinsics, cv::Mat(), RF, tF, true, 100, 8.f, 0.999, inliers, cv::SOLVEPNP_P3P);
     solvePnPRansac(points3d, points2d, intrinsics, cv::Mat(), R, t, true, 100, 8.f, 0.999, inliers, cv::SOLVEPNP_P3P);
 
-    EXPECT_LE(norm(R, Mat_<double>(RF), NORM_INF), 1e-3);
-    EXPECT_LE(norm(t, Mat_<double>(tF), NORM_INF), 1e-3);
+    EXPECT_LE(cvtest::norm(R, Mat_<double>(RF), NORM_INF), 1e-3);
+    EXPECT_LE(cvtest::norm(t, Mat_<double>(tF), NORM_INF), 1e-3);
 }
 
 TEST(Calib3d_SolvePnP, translation)
@@ -556,8 +551,8 @@ TEST(Calib3d_SolvePnP, iterativeInitialGuess3pts)
         std::cout << "tvec_ground_truth: " << tvec_ground_truth.t() << std::endl;
         std::cout << "tvec_est: " << tvec_est.t() << std::endl;
 
-        EXPECT_LE(norm(rvec_ground_truth, rvec_est, NORM_INF), 1e-6);
-        EXPECT_LE(norm(tvec_ground_truth, tvec_est, NORM_INF), 1e-6);
+        EXPECT_LE(cvtest::norm(rvec_ground_truth, rvec_est, NORM_INF), 1e-6);
+        EXPECT_LE(cvtest::norm(tvec_ground_truth, tvec_est, NORM_INF), 1e-6);
     }
 
     {
@@ -587,7 +582,9 @@ TEST(Calib3d_SolvePnP, iterativeInitialGuess3pts)
         std::cout << "tvec_ground_truth: " << tvec_ground_truth.t() << std::endl;
         std::cout << "tvec_est: " << tvec_est.t() << std::endl;
 
-        EXPECT_LE(norm(rvec_ground_truth, rvec_est, NORM_INF), 1e-6);
-        EXPECT_LE(norm(tvec_ground_truth, tvec_est, NORM_INF), 1e-6);
+        EXPECT_LE(cvtest::norm(rvec_ground_truth, rvec_est, NORM_INF), 1e-6);
+        EXPECT_LE(cvtest::norm(tvec_ground_truth, tvec_est, NORM_INF), 1e-6);
     }
 }
+
+}} // namespace

--- a/modules/calib3d/test/test_stereomatching.cpp
+++ b/modules/calib3d/test/test_stereomatching.cpp
@@ -46,12 +46,8 @@
 */
 
 #include "test_precomp.hpp"
-#include <limits>
-#include <cstdio>
-#include <map>
 
-using namespace std;
-using namespace cv;
+namespace opencv_test { namespace {
 
 const float EVAL_BAD_THRESH = 1.f;
 const int EVAL_TEXTURELESS_WIDTH = 3;
@@ -238,10 +234,10 @@ void computeDepthDiscontMask( const Mat& disp, Mat& depthDiscontMask, const Mat&
 
     Mat curDisp; disp.copyTo( curDisp );
     if( !unknDispMask.empty() )
-        curDisp.setTo( Scalar(numeric_limits<float>::min()), unknDispMask );
+        curDisp.setTo( Scalar(std::numeric_limits<float>::min()), unknDispMask );
     Mat maxNeighbDisp; dilate( curDisp, maxNeighbDisp, Mat(3, 3, CV_8UC1, Scalar(1)) );
     if( !unknDispMask.empty() )
-        curDisp.setTo( Scalar(numeric_limits<float>::max()), unknDispMask );
+        curDisp.setTo( Scalar(std::numeric_limits<float>::max()), unknDispMask );
     Mat minNeighbDisp; erode( curDisp, minNeighbDisp, Mat(3, 3, CV_8UC1, Scalar(1)) );
     depthDiscontMask = max( (Mat)(maxNeighbDisp-disp), (Mat)(disp-minNeighbDisp) ) > dispGap;
     if( !unknDispMask.empty() )
@@ -566,12 +562,12 @@ int CV_StereoMatchingTest::processStereoMatchingResults( FileStorage& fs, int ca
     Mat leftUnknMask, rightUnknMask;
     DatasetParams params = datasetsParams[caseDatasets[caseIdx]];
     absdiff( trueLeftDisp, Scalar(params.dispUnknVal), leftUnknMask );
-    leftUnknMask = leftUnknMask < numeric_limits<float>::epsilon();
+    leftUnknMask = leftUnknMask < std::numeric_limits<float>::epsilon();
     assert(leftUnknMask.type() == CV_8UC1);
     if( !trueRightDisp.empty() )
     {
         absdiff( trueRightDisp, Scalar(params.dispUnknVal), rightUnknMask );
-        rightUnknMask = rightUnknMask < numeric_limits<float>::epsilon();
+        rightUnknMask = rightUnknMask < std::numeric_limits<float>::epsilon();
         assert(rightUnknMask.type() == CV_8UC1);
     }
 
@@ -892,3 +888,5 @@ TEST(Calib3d_StereoSGBM_HH4, regression)
     absdiff(toCheck, testData,diff);
     CV_Assert( countNonZero(diff)==0);
 }
+
+}} // namespace

--- a/modules/calib3d/test/test_undistort.cpp
+++ b/modules/calib3d/test/test_undistort.cpp
@@ -43,8 +43,7 @@
 #include "test_precomp.hpp"
 #include "opencv2/imgproc/imgproc_c.h"
 
-using namespace cv;
-using namespace std;
+namespace opencv_test { namespace {
 
 class CV_DefaultNewCameraMatrixTest : public cvtest::ArrayTest
 {
@@ -67,7 +66,7 @@ private:
 
     static const int MAX_X = 2048;
     static const int MAX_Y = 2048;
-    static const int MAX_VAL = 10000;
+    //static const int MAX_VAL = 10000;
 };
 
 CV_DefaultNewCameraMatrixTest::CV_DefaultNewCameraMatrixTest()
@@ -938,3 +937,5 @@ double CV_InitUndistortRectifyMapTest::get_success_error_level( int /*test_case_
 TEST(Calib3d_DefaultNewCameraMatrix, accuracy) { CV_DefaultNewCameraMatrixTest test; test.safe_run(); }
 TEST(Calib3d_UndistortPoints, accuracy) { CV_UndistortPointsTest test; test.safe_run(); }
 TEST(Calib3d_InitUndistortRectifyMap, accuracy) { CV_InitUndistortRectifyMapTest test; test.safe_run(); }
+
+}} // namespace

--- a/modules/calib3d/test/test_undistort_badarg.cpp
+++ b/modules/calib3d/test/test_undistort_badarg.cpp
@@ -42,6 +42,8 @@
 #include "test_precomp.hpp"
 #include "opencv2/imgproc/imgproc_c.h"
 
+namespace opencv_test { namespace {
+
 class CV_UndistortPointsBadArgTest : public cvtest::BadArgTest
 {
 public:
@@ -525,4 +527,5 @@ TEST(Calib3d_UndistortPoints, badarg) { CV_UndistortPointsBadArgTest test; test.
 TEST(Calib3d_InitUndistortRectifyMap, badarg) { CV_InitUndistortRectifyMapBadArgTest test; test.safe_run(); }
 TEST(Calib3d_Undistort, badarg) { CV_UndistortBadArgTest test; test.safe_run(); }
 
+}} // namespace
 /* End of file. */

--- a/modules/calib3d/test/test_undistort_points.cpp
+++ b/modules/calib3d/test/test_undistort_points.cpp
@@ -1,8 +1,9 @@
+// This file is part of OpenCV project.
+// It is subject to the license terms in the LICENSE file found in the top-level directory
+// of this distribution and at http://opencv.org/license.html.
 #include "test_precomp.hpp"
-#include <string>
 
-using namespace cv;
-using namespace std;
+namespace opencv_test { namespace {
 
 class CV_UndistortTest : public cvtest::BaseTest
 {
@@ -29,7 +30,7 @@ CV_UndistortTest::~CV_UndistortTest() {}
 
 void CV_UndistortTest::generate3DPointCloud(vector<Point3f>& points, Point3f pmin, Point3f pmax)
 {
-    RNG rng_Point = ::theRNG(); // fix the seed to use "fixed" input 3D points
+    RNG rng_Point = cv::theRNG(); // fix the seed to use "fixed" input 3D points
     for (size_t i = 0; i < points.size(); i++)
     {
         float _x = rng_Point.uniform(pmin.x, pmax.x);
@@ -117,3 +118,5 @@ TEST(Calib3d_Undistort, stop_criteria)
 
     ASSERT_LE(obtainedError, maxError);
 }
+
+}} // namespace

--- a/modules/core/include/opencv2/core/cuda/detail/color_detail.hpp
+++ b/modules/core/include/opencv2/core/cuda/detail/color_detail.hpp
@@ -1027,8 +1027,8 @@ namespace cv { namespace cuda { namespace device
             vmin = fmin(vmin, b);
 
             diff = v - vmin;
-            s = diff / (float)(::fabs(v) + numeric_limits<float>::epsilon());
-            diff = (float)(60. / (diff + numeric_limits<float>::epsilon()));
+            s = diff / (float)(::fabs(v) + std::numeric_limits<float>::epsilon());
+            diff = (float)(60. / (diff + std::numeric_limits<float>::epsilon()));
 
             h  = (v == r) * (g - b) * diff;
             h += (v != r && v == g) * ((b - r) * diff + 120.f);
@@ -1261,7 +1261,7 @@ namespace cv { namespace cuda { namespace device
             diff = vmax - vmin;
             l = (vmax + vmin) * 0.5f;
 
-            if (diff > numeric_limits<float>::epsilon())
+            if (diff > std::numeric_limits<float>::epsilon())
             {
                 s = (l < 0.5f) * diff / (vmax + vmin);
                 s += (l >= 0.5f) * diff / (2.0f - vmax - vmin);
@@ -1802,7 +1802,7 @@ namespace cv { namespace cuda { namespace device
             float L = splineInterpolate(Y * (LAB_CBRT_TAB_SIZE / 1.5f), c_LabCbrtTab, LAB_CBRT_TAB_SIZE);
             L = 116.f * L - 16.f;
 
-            const float d = (4 * 13) / ::fmaxf(X + 15 * Y + 3 * Z, numeric_limits<float>::epsilon());
+            const float d = (4 * 13) / ::fmaxf(X + 15 * Y + 3 * Z, std::numeric_limits<float>::epsilon());
             float u = L * (X * d - _un);
             float v = L * ((9 * 0.25f) * Y * d - _vn);
 

--- a/modules/core/include/opencv2/core/cuda/detail/color_detail.hpp
+++ b/modules/core/include/opencv2/core/cuda/detail/color_detail.hpp
@@ -1027,8 +1027,8 @@ namespace cv { namespace cuda { namespace device
             vmin = fmin(vmin, b);
 
             diff = v - vmin;
-            s = diff / (float)(::fabs(v) + std::numeric_limits<float>::epsilon());
-            diff = (float)(60. / (diff + std::numeric_limits<float>::epsilon()));
+            s = diff / (float)(::fabs(v) + numeric_limits<float>::epsilon());
+            diff = (float)(60. / (diff + numeric_limits<float>::epsilon()));
 
             h  = (v == r) * (g - b) * diff;
             h += (v != r && v == g) * ((b - r) * diff + 120.f);
@@ -1261,7 +1261,7 @@ namespace cv { namespace cuda { namespace device
             diff = vmax - vmin;
             l = (vmax + vmin) * 0.5f;
 
-            if (diff > std::numeric_limits<float>::epsilon())
+            if (diff > numeric_limits<float>::epsilon())
             {
                 s = (l < 0.5f) * diff / (vmax + vmin);
                 s += (l >= 0.5f) * diff / (2.0f - vmax - vmin);
@@ -1802,7 +1802,7 @@ namespace cv { namespace cuda { namespace device
             float L = splineInterpolate(Y * (LAB_CBRT_TAB_SIZE / 1.5f), c_LabCbrtTab, LAB_CBRT_TAB_SIZE);
             L = 116.f * L - 16.f;
 
-            const float d = (4 * 13) / ::fmaxf(X + 15 * Y + 3 * Z, std::numeric_limits<float>::epsilon());
+            const float d = (4 * 13) / ::fmaxf(X + 15 * Y + 3 * Z, numeric_limits<float>::epsilon());
             float u = L * (X * d - _un);
             float v = L * ((9 * 0.25f) * Y * d - _vn);
 

--- a/modules/core/perf/cuda/perf_gpumat.cpp
+++ b/modules/core/perf/cuda/perf_gpumat.cpp
@@ -47,7 +47,7 @@
 #include "opencv2/core/cuda.hpp"
 #include "opencv2/ts/cuda_perf.hpp"
 
-using namespace std;
+namespace opencv_test { namespace {
 using namespace testing;
 using namespace perf;
 
@@ -193,4 +193,5 @@ PERF_TEST_P(Sz_2Depth, CUDA_GpuMat_ConvertTo,
     SANITY_CHECK_NOTHING();
 }
 
+}} // namespace
 #endif

--- a/modules/core/perf/opencl/perf_arithm.cpp
+++ b/modules/core/perf/opencl/perf_arithm.cpp
@@ -44,7 +44,7 @@
 
 #ifdef HAVE_OPENCL
 
-namespace cvtest {
+namespace opencv_test {
 namespace ocl {
 
 ///////////// Lut ////////////////////////
@@ -352,7 +352,7 @@ enum
 
 CV_ENUM(FlipType, FLIP_BOTH, FLIP_ROWS, FLIP_COLS)
 
-typedef std::tr1::tuple<Size, MatType, FlipType> FlipParams;
+typedef tuple<Size, MatType, FlipType> FlipParams;
 typedef TestBaseWithParam<FlipParams> FlipFixture;
 
 OCL_PERF_TEST_P(FlipFixture, Flip,
@@ -570,7 +570,7 @@ OCL_PERF_TEST_P(BitwiseNotFixture, Bitwise_not,
 
 CV_ENUM(CmpCode, CMP_LT, CMP_LE, CMP_EQ, CMP_NE, CMP_GE, CMP_GT)
 
-typedef std::tr1::tuple<Size, MatType, CmpCode> CompareParams;
+typedef tuple<Size, MatType, CmpCode> CompareParams;
 typedef TestBaseWithParam<CompareParams> CompareFixture;
 
 OCL_PERF_TEST_P(CompareFixture, Compare,
@@ -773,7 +773,7 @@ OCL_PERF_TEST_P(MeanStdDevFixture, MeanStdDevWithMask,
 
 CV_ENUM(NormType, NORM_INF, NORM_L1, NORM_L2)
 
-typedef std::tr1::tuple<Size, MatType, NormType> NormParams;
+typedef tuple<Size, MatType, NormType> NormParams;
 typedef TestBaseWithParam<NormParams> NormFixture;
 
 OCL_PERF_TEST_P(NormFixture, Norm1Arg,
@@ -1176,6 +1176,6 @@ OCL_PERF_TEST_P(ReduceAccFixture, Reduce,
     SANITY_CHECK(dst, eps);
 }
 
-} } // namespace cvtest::ocl
+} } // namespace opencv_test::ocl
 
 #endif // HAVE_OPENCL

--- a/modules/core/perf/opencl/perf_bufferpool.cpp
+++ b/modules/core/perf/opencl/perf_bufferpool.cpp
@@ -9,7 +9,7 @@
 
 #ifdef HAVE_OPENCL
 
-namespace cvtest {
+namespace opencv_test {
 namespace ocl {
 
 struct BufferPoolState
@@ -127,6 +127,6 @@ OCL_PERF_TEST_P(BufferPoolFixture, BufferPool_UMatIntegral10, Bool())
     SANITY_CHECK_NOTHING();
 }
 
-} } // namespace cvtest::ocl
+} } // namespace opencv_test::ocl
 
 #endif // HAVE_OPENCL

--- a/modules/core/perf/opencl/perf_channels.cpp
+++ b/modules/core/perf/opencl/perf_channels.cpp
@@ -49,7 +49,7 @@
 
 #ifdef HAVE_OPENCL
 
-namespace cvtest {
+namespace opencv_test {
 namespace ocl {
 
 ///////////// Merge////////////////////////
@@ -156,7 +156,7 @@ OCL_PERF_TEST_P(MixChannelsFixture, MixChannels,
 
 ///////////// InsertChannel ////////////////////////
 
-typedef std::tr1::tuple<cv::Size, MatDepth> Size_MatDepth_t;
+typedef tuple<cv::Size, MatDepth> Size_MatDepth_t;
 typedef TestBaseWithParam<Size_MatDepth_t> Size_MatDepth;
 
 typedef Size_MatDepth InsertChannelFixture;
@@ -201,6 +201,6 @@ OCL_PERF_TEST_P(ExtractChannelFixture, ExtractChannel,
     SANITY_CHECK(dst);
 }
 
-} } // namespace cvtest::ocl
+} } // namespace opencv_test::ocl
 
 #endif // HAVE_OPENCL

--- a/modules/core/perf/opencl/perf_dxt.cpp
+++ b/modules/core/perf/opencl/perf_dxt.cpp
@@ -49,7 +49,7 @@
 
 #ifdef HAVE_OPENCL
 
-namespace cvtest {
+namespace opencv_test {
 namespace ocl {
 
 ///////////// dft ////////////////////////
@@ -113,6 +113,6 @@ OCL_PERF_TEST_P(MulSpectrumsFixture, MulSpectrums,
     SANITY_CHECK(dst, 1e-3);
 }
 
-} } // namespace cvtest::ocl
+} } // namespace opencv_test::ocl
 
 #endif // HAVE_OPENCL

--- a/modules/core/perf/opencl/perf_gemm.cpp
+++ b/modules/core/perf/opencl/perf_gemm.cpp
@@ -49,7 +49,7 @@
 
 #ifdef HAVE_OPENCL
 
-namespace cvtest {
+namespace opencv_test {
 namespace ocl {
 
 ///////////// gemm ////////////////////////
@@ -79,6 +79,6 @@ OCL_PERF_TEST_P(GemmFixture, Gemm, ::testing::Combine(
     SANITY_CHECK(dst, 0.01);
 }
 
-} } // namespace cvtest::ocl
+} } // namespace opencv_test::ocl
 
 #endif // HAVE_OPENCL

--- a/modules/core/perf/opencl/perf_matop.cpp
+++ b/modules/core/perf/opencl/perf_matop.cpp
@@ -10,7 +10,7 @@
 
 #ifdef HAVE_OPENCL
 
-namespace cvtest {
+namespace opencv_test {
 namespace ocl {
 
 ///////////// SetTo ////////////////////////
@@ -146,6 +146,6 @@ OCL_PERF_TEST_P(CopyToFixture, CopyToWithMaskUninit,
     SANITY_CHECK(dst);
 }
 
-} } // namespace cvtest::ocl
+} } // namespace opencv_test::ocl
 
 #endif // HAVE_OPENCL

--- a/modules/core/perf/opencl/perf_usage_flags.cpp
+++ b/modules/core/perf/opencl/perf_usage_flags.cpp
@@ -9,10 +9,10 @@
 
 #ifdef HAVE_OPENCL
 
-namespace cvtest {
+namespace opencv_test {
 namespace ocl {
 
-typedef TestBaseWithParam<std::tr1::tuple<cv::Size, bool> > UsageFlagsBoolFixture;
+typedef TestBaseWithParam<tuple<cv::Size, bool> > UsageFlagsBoolFixture;
 
 OCL_PERF_TEST_P(UsageFlagsBoolFixture, UsageFlags_AllocHostMem, ::testing::Combine(OCL_TEST_SIZES, Bool()))
 {
@@ -37,6 +37,6 @@ OCL_PERF_TEST_P(UsageFlagsBoolFixture, UsageFlags_AllocHostMem, ::testing::Combi
     SANITY_CHECK_NOTHING();
 }
 
-} } // namespace cvtest::ocl
+} } // namespace opencv_test::ocl
 
 #endif // HAVE_OPENCL

--- a/modules/core/perf/perf_abs.cpp
+++ b/modules/core/perf/perf_abs.cpp
@@ -1,10 +1,8 @@
 #include "perf_precomp.hpp"
 
-using namespace std;
-using namespace cv;
+namespace opencv_test
+{
 using namespace perf;
-using std::tr1::make_tuple;
-using std::tr1::get;
 
 #define TYPICAL_MAT_SIZES_ABS  TYPICAL_MAT_SIZES
 #define TYPICAL_MAT_TYPES_ABS  CV_8SC1, CV_8SC4, CV_32SC1, CV_32FC1
@@ -24,3 +22,5 @@ PERF_TEST_P(Size_MatType, abs, TYPICAL_MATS_ABS)
 
     SANITY_CHECK(c);
 }
+
+} // namespace

--- a/modules/core/perf/perf_addWeighted.cpp
+++ b/modules/core/perf/perf_addWeighted.cpp
@@ -1,10 +1,8 @@
 #include "perf_precomp.hpp"
 
-using namespace std;
-using namespace cv;
+namespace opencv_test
+{
 using namespace perf;
-using std::tr1::make_tuple;
-using std::tr1::get;
 
 #define TYPICAL_MAT_TYPES_ADWEIGHTED  CV_8UC1, CV_8UC4, CV_8SC1, CV_16UC1, CV_16SC1, CV_32SC1
 #define TYPICAL_MATS_ADWEIGHTED       testing::Combine(testing::Values(szVGA, sz720p, sz1080p), testing::Values(TYPICAL_MAT_TYPES_ADWEIGHTED))
@@ -34,3 +32,5 @@ PERF_TEST_P(Size_MatType, addWeighted, TYPICAL_MATS_ADWEIGHTED)
 
     SANITY_CHECK(dst, 1);
 }
+
+} // namespace

--- a/modules/core/perf/perf_arithm.cpp
+++ b/modules/core/perf/perf_arithm.cpp
@@ -1,12 +1,10 @@
 #include "perf_precomp.hpp"
 
-using namespace std;
-using namespace cv;
+namespace opencv_test
+{
 using namespace perf;
-using std::tr1::make_tuple;
-using std::tr1::get;
 
-#define TYPICAL_MAT_SIZES_CORE_ARITHM   ::szVGA, ::sz720p, ::sz1080p
+#define TYPICAL_MAT_SIZES_CORE_ARITHM   szVGA, sz720p, sz1080p
 #define TYPICAL_MAT_TYPES_CORE_ARITHM   CV_8UC1, CV_8SC1, CV_16SC1, CV_16SC2, CV_16SC3, CV_16SC4, CV_8UC4, CV_32SC1, CV_32FC1
 #define TYPICAL_MATS_CORE_ARITHM        testing::Combine( testing::Values( TYPICAL_MAT_SIZES_CORE_ARITHM ), testing::Values( TYPICAL_MAT_TYPES_CORE_ARITHM ) )
 
@@ -20,7 +18,7 @@ PERF_TEST_P(Size_MatType, min, TYPICAL_MATS_CORE_ARITHM)
 
     declare.in(a, b, WARMUP_RNG).out(c);
 
-    TEST_CYCLE() min(a, b, c);
+    TEST_CYCLE() cv::min(a, b, c);
 
     SANITY_CHECK(c);
 }
@@ -35,7 +33,7 @@ PERF_TEST_P(Size_MatType, minScalar, TYPICAL_MATS_CORE_ARITHM)
 
     declare.in(a, b, WARMUP_RNG).out(c);
 
-    TEST_CYCLE() min(a, b, c);
+    TEST_CYCLE() cv::min(a, b, c);
 
     SANITY_CHECK(c);
 }
@@ -50,7 +48,7 @@ PERF_TEST_P(Size_MatType, max, TYPICAL_MATS_CORE_ARITHM)
 
     declare.in(a, b, WARMUP_RNG).out(c);
 
-    TEST_CYCLE() max(a, b, c);
+    TEST_CYCLE() cv::max(a, b, c);
 
     SANITY_CHECK(c);
 }
@@ -65,7 +63,7 @@ PERF_TEST_P(Size_MatType, maxScalar, TYPICAL_MATS_CORE_ARITHM)
 
     declare.in(a, b, WARMUP_RNG).out(c);
 
-    TEST_CYCLE() max(a, b, c);
+    TEST_CYCLE() cv::max(a, b, c);
 
     SANITY_CHECK(c);
 }
@@ -89,7 +87,7 @@ PERF_TEST_P(Size_MatType, absdiff, TYPICAL_MATS_CORE_ARITHM)
         eps = 1;
     }
 
-    TEST_CYCLE() absdiff(a, b, c);
+    TEST_CYCLE() cv::absdiff(a, b, c);
 
     SANITY_CHECK(c, eps);
 }
@@ -113,7 +111,7 @@ PERF_TEST_P(Size_MatType, absdiffScalar, TYPICAL_MATS_CORE_ARITHM)
         eps = 1;
     }
 
-    TEST_CYCLE() absdiff(a, b, c);
+    TEST_CYCLE() cv::absdiff(a, b, c);
 
     SANITY_CHECK(c, eps);
 }
@@ -138,7 +136,7 @@ PERF_TEST_P(Size_MatType, add, TYPICAL_MATS_CORE_ARITHM)
         eps = 1;
     }
 
-    TEST_CYCLE() add(a, b, c);
+    TEST_CYCLE() cv::add(a, b, c);
 
     SANITY_CHECK(c, eps);
 }
@@ -162,7 +160,7 @@ PERF_TEST_P(Size_MatType, addScalar, TYPICAL_MATS_CORE_ARITHM)
         eps = 1;
     }
 
-    TEST_CYCLE() add(a, b, c);
+    TEST_CYCLE() cv::add(a, b, c);
 
     SANITY_CHECK(c, eps);
 }
@@ -186,7 +184,7 @@ PERF_TEST_P(Size_MatType, subtract, TYPICAL_MATS_CORE_ARITHM)
         eps = 1;
     }
 
-    TEST_CYCLE() subtract(a, b, c);
+    TEST_CYCLE() cv::subtract(a, b, c);
 
     SANITY_CHECK(c, eps);
 }
@@ -210,7 +208,7 @@ PERF_TEST_P(Size_MatType, subtractScalar, TYPICAL_MATS_CORE_ARITHM)
         eps = 1;
     }
 
-    TEST_CYCLE() subtract(a, b, c);
+    TEST_CYCLE() cv::subtract(a, b, c);
 
     SANITY_CHECK(c, eps);
 }
@@ -229,7 +227,7 @@ PERF_TEST_P(Size_MatType, multiply, TYPICAL_MATS_CORE_ARITHM)
         b /= (2 << 16);
     }
 
-    TEST_CYCLE() multiply(a, b, c);
+    TEST_CYCLE() cv::multiply(a, b, c);
 
     SANITY_CHECK(c, 1e-8);
 }
@@ -250,7 +248,7 @@ PERF_TEST_P(Size_MatType, multiplyScale, TYPICAL_MATS_CORE_ARITHM)
         b /= (2 << 16);
     }
 
-    TEST_CYCLE() multiply(a, b, c, scale);
+    TEST_CYCLE() cv::multiply(a, b, c, scale);
 
     SANITY_CHECK(c, 1e-8);
 }
@@ -264,7 +262,7 @@ PERF_TEST_P(Size_MatType, divide, TYPICAL_MATS_CORE_ARITHM)
 
     declare.in(a, b, WARMUP_RNG).out(c);
 
-    TEST_CYCLE() divide(a, b, c, scale);
+    TEST_CYCLE() cv::divide(a, b, c, scale);
 
     SANITY_CHECK_NOTHING();
 }
@@ -278,7 +276,9 @@ PERF_TEST_P(Size_MatType, reciprocal, TYPICAL_MATS_CORE_ARITHM)
 
     declare.in(b, WARMUP_RNG).out(c);
 
-    TEST_CYCLE() divide(scale, b, c);
+    TEST_CYCLE() cv::divide(scale, b, c);
 
     SANITY_CHECK_NOTHING();
 }
+
+} // namespace

--- a/modules/core/perf/perf_bitwise.cpp
+++ b/modules/core/perf/perf_bitwise.cpp
@@ -1,10 +1,8 @@
 #include "perf_precomp.hpp"
 
-using namespace std;
-using namespace cv;
+namespace opencv_test
+{
 using namespace perf;
-using std::tr1::make_tuple;
-using std::tr1::get;
 
 #define TYPICAL_MAT_SIZES_BITW_ARITHM  TYPICAL_MAT_SIZES
 #define TYPICAL_MAT_TYPES_BITW_ARITHM  CV_8UC1, CV_8SC1, CV_8UC4, CV_32SC1, CV_32SC4
@@ -73,3 +71,5 @@ PERF_TEST_P(Size_MatType, bitwise_xor, TYPICAL_MATS_BITW_ARITHM)
 
     SANITY_CHECK(c);
 }
+
+} // namespace

--- a/modules/core/perf/perf_compare.cpp
+++ b/modules/core/perf/perf_compare.cpp
@@ -1,14 +1,12 @@
 #include "perf_precomp.hpp"
 
-using namespace std;
-using namespace cv;
+namespace opencv_test
+{
 using namespace perf;
-using std::tr1::make_tuple;
-using std::tr1::get;
 
 CV_ENUM(CmpType, CMP_EQ, CMP_GT, CMP_GE, CMP_LT, CMP_LE, CMP_NE)
 
-typedef std::tr1::tuple<Size, MatType, CmpType> Size_MatType_CmpType_t;
+typedef tuple<Size, MatType, CmpType> Size_MatType_CmpType_t;
 typedef perf::TestBaseWithParam<Size_MatType_CmpType_t> Size_MatType_CmpType;
 
 PERF_TEST_P( Size_MatType_CmpType, compare,
@@ -57,3 +55,5 @@ PERF_TEST_P( Size_MatType_CmpType, compareScalar,
 
     SANITY_CHECK(dst);
 }
+
+} // namespace

--- a/modules/core/perf/perf_convertTo.cpp
+++ b/modules/core/perf/perf_convertTo.cpp
@@ -1,12 +1,10 @@
 #include "perf_precomp.hpp"
 
-using namespace std;
-using namespace cv;
+namespace opencv_test
+{
 using namespace perf;
-using std::tr1::make_tuple;
-using std::tr1::get;
 
-typedef std::tr1::tuple<Size, MatType, MatType, int, double> Size_DepthSrc_DepthDst_Channels_alpha_t;
+typedef tuple<Size, MatType, MatType, int, double> Size_DepthSrc_DepthDst_Channels_alpha_t;
 typedef perf::TestBaseWithParam<Size_DepthSrc_DepthDst_Channels_alpha_t> Size_DepthSrc_DepthDst_Channels_alpha;
 
 PERF_TEST_P( Size_DepthSrc_DepthDst_Channels_alpha, convertTo,
@@ -39,3 +37,5 @@ PERF_TEST_P( Size_DepthSrc_DepthDst_Channels_alpha, convertTo,
     eps = eps * std::max(1.0, fabs(alpha));
     SANITY_CHECK(dst, eps);
 }
+
+} // namespace

--- a/modules/core/perf/perf_cvround.cpp
+++ b/modules/core/perf/perf_cvround.cpp
@@ -1,10 +1,8 @@
 #include "perf_precomp.hpp"
 
-using namespace std;
-using namespace cv;
+namespace opencv_test
+{
 using namespace perf;
-using std::tr1::make_tuple;
-using std::tr1::get;
 
 template <typename T>
 static void CvRoundMat(const cv::Mat & src, cv::Mat & dst)
@@ -43,3 +41,5 @@ PERF_TEST_P(Size_MatType, CvRound_Float,
 
     SANITY_CHECK_NOTHING();
 }
+
+} // namespace

--- a/modules/core/perf/perf_dft.cpp
+++ b/modules/core/perf/perf_dft.cpp
@@ -1,10 +1,8 @@
 #include "perf_precomp.hpp"
 
-using namespace std;
-using namespace cv;
+namespace opencv_test
+{
 using namespace perf;
-using std::tr1::make_tuple;
-using std::tr1::get;
 
 ///////////////////////////////////////////////////////dft//////////////////////////////////////////////////////////////
 
@@ -13,7 +11,7 @@ using std::tr1::get;
 CV_ENUM(FlagsType, 0, DFT_INVERSE, DFT_SCALE, DFT_COMPLEX_OUTPUT, DFT_ROWS, DFT_INVERSE|DFT_COMPLEX_OUTPUT)
 #define TEST_MATS_DFT  testing::Combine(testing::Values(MAT_SIZES_DFT), testing::Values(MAT_TYPES_DFT), FlagsType::all(), testing::Values(true, false))
 
-typedef std::tr1::tuple<Size, MatType, FlagsType, bool> Size_MatType_FlagsType_NzeroRows_t;
+typedef tuple<Size, MatType, FlagsType, bool> Size_MatType_FlagsType_NzeroRows_t;
 typedef perf::TestBaseWithParam<Size_MatType_FlagsType_NzeroRows_t> Size_MatType_FlagsType_NzeroRows;
 
 PERF_TEST_P(Size_MatType_FlagsType_NzeroRows, dft, TEST_MATS_DFT)
@@ -42,7 +40,7 @@ PERF_TEST_P(Size_MatType_FlagsType_NzeroRows, dft, TEST_MATS_DFT)
 
 CV_ENUM(DCT_FlagsType, 0, DCT_INVERSE , DCT_ROWS, DCT_INVERSE|DCT_ROWS)
 
-typedef std::tr1::tuple<Size, MatType, DCT_FlagsType> Size_MatType_Flag_t;
+typedef tuple<Size, MatType, DCT_FlagsType> Size_MatType_Flag_t;
 typedef perf::TestBaseWithParam<Size_MatType_Flag_t> Size_MatType_Flag;
 
 PERF_TEST_P(Size_MatType_Flag, dct, testing::Combine(
@@ -67,3 +65,5 @@ PERF_TEST_P(Size_MatType_Flag, dct, testing::Combine(
 
     SANITY_CHECK(dst, 1e-5, ERROR_RELATIVE);
 }
+
+} // namespace

--- a/modules/core/perf/perf_dot.cpp
+++ b/modules/core/perf/perf_dot.cpp
@@ -1,12 +1,10 @@
 #include "perf_precomp.hpp"
 
-using namespace std;
-using namespace cv;
+namespace opencv_test
+{
 using namespace perf;
-using std::tr1::make_tuple;
-using std::tr1::get;
 
-typedef tr1::tuple<MatType, int> MatType_Length_t;
+typedef tuple<MatType, int> MatType_Length_t;
 typedef TestBaseWithParam<MatType_Length_t> MatType_Length;
 
 PERF_TEST_P( MatType_Length, dot,
@@ -29,3 +27,5 @@ PERF_TEST_P( MatType_Length, dot,
 
     SANITY_CHECK(product, 1e-6, ERROR_RELATIVE);
 }
+
+} // namespace

--- a/modules/core/perf/perf_inRange.cpp
+++ b/modules/core/perf/perf_inRange.cpp
@@ -1,10 +1,8 @@
 #include "perf_precomp.hpp"
 
-using namespace std;
-using namespace cv;
+namespace opencv_test
+{
 using namespace perf;
-using std::tr1::make_tuple;
-using std::tr1::get;
 
 #define TYPICAL_MAT_TYPES_INRANGE  CV_8UC1, CV_8UC4, CV_8SC1, CV_16UC1, CV_16SC1, CV_32SC1, CV_32FC1, CV_32FC4
 #define TYPICAL_MATS_INRANGE       testing::Combine(testing::Values(szVGA, sz720p, sz1080p), testing::Values(TYPICAL_MAT_TYPES_INRANGE))
@@ -24,3 +22,5 @@ PERF_TEST_P(Size_MatType, inRange, TYPICAL_MATS_INRANGE)
 
     SANITY_CHECK(dst);
 }
+
+} // namespace

--- a/modules/core/perf/perf_io_base64.cpp
+++ b/modules/core/perf/perf_io_base64.cpp
@@ -1,12 +1,10 @@
 #include "perf_precomp.hpp"
 
-using namespace std;
-using namespace cv;
+namespace opencv_test
+{
 using namespace perf;
-using std::tr1::make_tuple;
-using std::tr1::get;
 
-typedef std::tr1::tuple<cv::Size, MatType, String> Size_MatType_Str_t;
+typedef tuple<cv::Size, MatType, String> Size_MatType_Str_t;
 typedef TestBaseWithParam<Size_MatType_Str_t> Size_Mat_StrType;
 
 #define MAT_SIZES      ::perf::sz1080p/*, ::perf::sz4320p*/
@@ -84,3 +82,5 @@ PERF_TEST_P(Size_Mat_StrType, fs_base64,
     remove(file_name.c_str());
     SANITY_CHECK_NOTHING();
 }
+
+} // namespace

--- a/modules/core/perf/perf_lut.cpp
+++ b/modules/core/perf/perf_lut.cpp
@@ -1,7 +1,6 @@
 #include "perf_precomp.hpp"
 
-using namespace std;
-using namespace cv;
+namespace opencv_test { namespace {
 using namespace perf;
 
 typedef perf::TestBaseWithParam<Size> SizePrm;
@@ -24,3 +23,5 @@ PERF_TEST_P( SizePrm, LUT,
 
     SANITY_CHECK(dst, 0.1);
 }
+
+}} // namespace

--- a/modules/core/perf/perf_mat.cpp
+++ b/modules/core/perf/perf_mat.cpp
@@ -1,10 +1,8 @@
 #include "perf_precomp.hpp"
 
-using namespace std;
-using namespace cv;
+namespace opencv_test
+{
 using namespace perf;
-using std::tr1::make_tuple;
-using std::tr1::get;
 
 PERF_TEST_P(Size_MatType, Mat_Eye,
             testing::Combine(testing::Values(TYPICAL_MAT_SIZES),
@@ -124,3 +122,5 @@ PERF_TEST_P(Size_MatType, Mat_Transform,
 
     SANITY_CHECK(dst, 1e-6, ERROR_RELATIVE);
 }
+
+} // namespace

--- a/modules/core/perf/perf_math.cpp
+++ b/modules/core/perf/perf_math.cpp
@@ -1,7 +1,7 @@
 #include "perf_precomp.hpp"
 
-using namespace std;
-using namespace cv;
+namespace opencv_test
+{
 using namespace perf;
 
 namespace {
@@ -158,3 +158,5 @@ INSTANTIATE_TEST_CASE_P(/*nothing*/ , KMeans,
 );
 
 }
+
+} // namespace

--- a/modules/core/perf/perf_merge.cpp
+++ b/modules/core/perf/perf_merge.cpp
@@ -1,12 +1,10 @@
 #include "perf_precomp.hpp"
 
-using namespace std;
-using namespace cv;
+namespace opencv_test
+{
 using namespace perf;
-using std::tr1::make_tuple;
-using std::tr1::get;
 
-typedef std::tr1::tuple<Size, MatType, int> Size_SrcDepth_DstChannels_t;
+typedef tuple<Size, MatType, int> Size_SrcDepth_DstChannels_t;
 typedef perf::TestBaseWithParam<Size_SrcDepth_DstChannels_t> Size_SrcDepth_DstChannels;
 
 PERF_TEST_P( Size_SrcDepth_DstChannels, merge,
@@ -38,3 +36,5 @@ PERF_TEST_P( Size_SrcDepth_DstChannels, merge,
     double eps = srcDepth <= CV_32S ? 1e-12 : (FLT_EPSILON * maxValue);
     SANITY_CHECK(dst, eps);
 }
+
+} // namespace

--- a/modules/core/perf/perf_minmaxloc.cpp
+++ b/modules/core/perf/perf_minmaxloc.cpp
@@ -1,10 +1,8 @@
 #include "perf_precomp.hpp"
 
-using namespace std;
-using namespace cv;
+namespace opencv_test
+{
 using namespace perf;
-using std::tr1::make_tuple;
-using std::tr1::get;
 
 PERF_TEST_P(Size_MatType, minMaxLoc, testing::Combine(
                  testing::Values(TYPICAL_MAT_SIZES),
@@ -33,3 +31,5 @@ PERF_TEST_P(Size_MatType, minMaxLoc, testing::Combine(
     SANITY_CHECK(minVal, 1e-12);
     SANITY_CHECK(maxVal, 1e-12);
 }
+
+} // namespace

--- a/modules/core/perf/perf_norm.cpp
+++ b/modules/core/perf/perf_norm.cpp
@@ -1,16 +1,14 @@
 #include "perf_precomp.hpp"
 
-using namespace std;
-using namespace cv;
+namespace opencv_test
+{
 using namespace perf;
-using std::tr1::make_tuple;
-using std::tr1::get;
 
 #define HAMMING_NORM_SIZES cv::Size(640, 480), cv::Size(1920, 1080)
 #define HAMMING_NORM_TYPES CV_8UC1
 
 CV_FLAGS(NormType, NORM_HAMMING2, NORM_HAMMING, NORM_INF, NORM_L1, NORM_L2, NORM_TYPE_MASK, NORM_RELATIVE, NORM_MINMAX)
-typedef std::tr1::tuple<Size, MatType, NormType> Size_MatType_NormType_t;
+typedef tuple<Size, MatType, NormType> Size_MatType_NormType_t;
 typedef perf::TestBaseWithParam<Size_MatType_NormType_t> Size_MatType_NormType;
 
 PERF_TEST_P(Size_MatType_NormType, norm,
@@ -30,7 +28,7 @@ PERF_TEST_P(Size_MatType_NormType, norm,
 
     declare.in(src, WARMUP_RNG);
 
-    TEST_CYCLE() n = norm(src, normType);
+    TEST_CYCLE() n = cv::norm(src, normType);
 
     SANITY_CHECK(n, 1e-6, ERROR_RELATIVE);
 }
@@ -53,7 +51,7 @@ PERF_TEST_P(Size_MatType_NormType, norm_mask,
 
     declare.in(src, WARMUP_RNG).in(mask);
 
-    TEST_CYCLE() n = norm(src, normType, mask);
+    TEST_CYCLE() n = cv::norm(src, normType, mask);
 
     SANITY_CHECK(n, 1e-6, ERROR_RELATIVE);
 }
@@ -76,7 +74,7 @@ PERF_TEST_P(Size_MatType_NormType, norm2,
 
     declare.in(src1, src2, WARMUP_RNG);
 
-    TEST_CYCLE() n = norm(src1, src2, normType);
+    TEST_CYCLE() n = cv::norm(src1, src2, normType);
 
     SANITY_CHECK(n, 1e-5, ERROR_RELATIVE);
 }
@@ -100,13 +98,13 @@ PERF_TEST_P(Size_MatType_NormType, norm2_mask,
 
     declare.in(src1, src2, WARMUP_RNG).in(mask);
 
-    TEST_CYCLE() n = norm(src1, src2, normType, mask);
+    TEST_CYCLE() n = cv::norm(src1, src2, normType, mask);
 
     SANITY_CHECK(n, 1e-5, ERROR_RELATIVE);
 }
 
 namespace {
-typedef std::tr1::tuple<NormType, MatType, Size> PerfHamming_t;
+typedef tuple<NormType, MatType, Size> PerfHamming_t;
 typedef perf::TestBaseWithParam<PerfHamming_t> PerfHamming;
 
 PERF_TEST_P(PerfHamming, norm,
@@ -126,7 +124,7 @@ PERF_TEST_P(PerfHamming, norm,
 
     declare.in(src, WARMUP_RNG);
 
-    TEST_CYCLE() n = norm(src, normType);
+    TEST_CYCLE() n = cv::norm(src, normType);
 
     (void)n;
     SANITY_CHECK_NOTHING();
@@ -150,7 +148,7 @@ PERF_TEST_P(PerfHamming, norm2,
 
     declare.in(src1, src2, WARMUP_RNG);
 
-    TEST_CYCLE() n = norm(src1, src2, normType);
+    TEST_CYCLE() n = cv::norm(src1, src2, normType);
 
     (void)n;
     SANITY_CHECK_NOTHING();
@@ -180,7 +178,7 @@ PERF_TEST_P(Size_MatType_NormType, normalize,
 
     declare.in(src, WARMUP_RNG).out(dst);
 
-    TEST_CYCLE() normalize(src, dst, alpha, 0., normType);
+    TEST_CYCLE() cv::normalize(src, dst, alpha, 0., normType);
 
     SANITY_CHECK(dst, 1e-6);
 }
@@ -208,7 +206,7 @@ PERF_TEST_P(Size_MatType_NormType, normalize_mask,
     declare.in(src, WARMUP_RNG).in(mask).out(dst);
     declare.time(100);
 
-    TEST_CYCLE() normalize(src, dst, alpha, 0., normType, -1, mask);
+    TEST_CYCLE() cv::normalize(src, dst, alpha, 0., normType, -1, mask);
 
     SANITY_CHECK(dst, 1e-6);
 }
@@ -234,7 +232,7 @@ PERF_TEST_P(Size_MatType_NormType, normalize_32f,
 
     declare.in(src, WARMUP_RNG).out(dst);
 
-    TEST_CYCLE() normalize(src, dst, alpha, 0., normType, CV_32F);
+    TEST_CYCLE() cv::normalize(src, dst, alpha, 0., normType, CV_32F);
 
     SANITY_CHECK(dst, 1e-6, ERROR_RELATIVE);
 }
@@ -250,7 +248,9 @@ PERF_TEST_P( Size_MatType, normalize_minmax, TYPICAL_MATS )
     declare.in(src, WARMUP_RNG).out(dst);
     declare.time(30);
 
-    TEST_CYCLE() normalize(src, dst, 20., 100., NORM_MINMAX);
+    TEST_CYCLE() cv::normalize(src, dst, 20., 100., NORM_MINMAX);
 
     SANITY_CHECK(dst, 1e-6, ERROR_RELATIVE);
 }
+
+} // namespace

--- a/modules/core/perf/perf_precomp.hpp
+++ b/modules/core/perf/perf_precomp.hpp
@@ -1,18 +1,9 @@
-#ifdef __GNUC__
-#  pragma GCC diagnostic ignored "-Wmissing-declarations"
-#  if defined __clang__ || defined __APPLE__
-#    pragma GCC diagnostic ignored "-Wmissing-prototypes"
-#    pragma GCC diagnostic ignored "-Wextra"
-#  endif
-#endif
-
+// This file is part of OpenCV project.
+// It is subject to the license terms in the LICENSE file found in the top-level directory
+// of this distribution and at http://opencv.org/license.html
 #ifndef __OPENCV_PERF_PRECOMP_HPP__
 #define __OPENCV_PERF_PRECOMP_HPP__
 
 #include "opencv2/ts.hpp"
-
-#ifdef GTEST_CREATE_SHARED_LIBRARY
-#error no modules except ts should have GTEST_CREATE_SHARED_LIBRARY defined
-#endif
 
 #endif

--- a/modules/core/perf/perf_reduce.cpp
+++ b/modules/core/perf/perf_reduce.cpp
@@ -1,14 +1,12 @@
 #include "perf_precomp.hpp"
 #include "opencv2/core/core_c.h"
 
-using namespace std;
-using namespace cv;
+namespace opencv_test
+{
 using namespace perf;
-using std::tr1::make_tuple;
-using std::tr1::get;
 
 CV_ENUM(ROp, CV_REDUCE_SUM, CV_REDUCE_AVG, CV_REDUCE_MAX, CV_REDUCE_MIN)
-typedef std::tr1::tuple<Size, MatType, ROp> Size_MatType_ROp_t;
+typedef tuple<Size, MatType, ROp> Size_MatType_ROp_t;
 typedef perf::TestBaseWithParam<Size_MatType_ROp_t> Size_MatType_ROp;
 
 
@@ -66,3 +64,5 @@ PERF_TEST_P(Size_MatType_ROp, reduceC,
 
     SANITY_CHECK(vec, 1);
 }
+
+} // namespace

--- a/modules/core/perf/perf_sort.cpp
+++ b/modules/core/perf/perf_sort.cpp
@@ -1,12 +1,8 @@
 #include "perf_precomp.hpp"
 
-using namespace std;
-using namespace cv;
+namespace opencv_test
+{
 using namespace perf;
-
-using std::tr1::tuple;
-using std::tr1::make_tuple;
-using std::tr1::get;
 
 #define TYPICAL_MAT_SIZES_SORT  TYPICAL_MAT_SIZES
 #define TYPICAL_MAT_TYPES_SORT  CV_8UC1, CV_16UC1, CV_32FC1
@@ -50,3 +46,5 @@ PERF_TEST_P(sortIdxFixture, sorIdx, TYPICAL_MATS_SORT)
 
     SANITY_CHECK_NOTHING();
 }
+
+} // namespace

--- a/modules/core/perf/perf_split.cpp
+++ b/modules/core/perf/perf_split.cpp
@@ -1,12 +1,10 @@
 #include "perf_precomp.hpp"
 
-using namespace std;
-using namespace cv;
+namespace opencv_test
+{
 using namespace perf;
-using std::tr1::make_tuple;
-using std::tr1::get;
 
-typedef std::tr1::tuple<Size, MatType, int> Size_Depth_Channels_t;
+typedef tuple<Size, MatType, int> Size_Depth_Channels_t;
 typedef perf::TestBaseWithParam<Size_Depth_Channels_t> Size_Depth_Channels;
 
 PERF_TEST_P( Size_Depth_Channels, split,
@@ -35,3 +33,5 @@ PERF_TEST_P( Size_Depth_Channels, split,
     SANITY_CHECK(mv, 1e-12);
 #endif
 }
+
+} // namespace

--- a/modules/core/perf/perf_stat.cpp
+++ b/modules/core/perf/perf_stat.cpp
@@ -1,10 +1,8 @@
 #include "perf_precomp.hpp"
 
-using namespace std;
-using namespace cv;
+namespace opencv_test
+{
 using namespace perf;
-using std::tr1::make_tuple;
-using std::tr1::get;
 
 PERF_TEST_P(Size_MatType, sum, TYPICAL_MATS)
 {
@@ -102,3 +100,5 @@ PERF_TEST_P(Size_MatType, countNonZero, testing::Combine( testing::Values( TYPIC
 
     SANITY_CHECK(cnt);
 }
+
+} // namespace

--- a/modules/core/perf/perf_umat.cpp
+++ b/modules/core/perf/perf_umat.cpp
@@ -5,13 +5,10 @@
 #include "perf_precomp.hpp"
 #include "opencv2/ts/ocl_perf.hpp"
 
-using namespace std;
-using namespace cv;
-using namespace ::perf;
+namespace opencv_test
+{
+using namespace perf;
 using namespace ::cvtest::ocl;
-using namespace ::testing;
-using std::tr1::tuple;
-using std::tr1::get;
 
 
 struct OpenCLState
@@ -63,3 +60,5 @@ OCL_PERF_TEST_P(UMatTest, CustomPtr, Combine(Values(sz1080p, sz2160p), Bool(), :
 
     SANITY_CHECK_NOTHING();
 }
+
+} // namespace

--- a/modules/core/test/ocl/test_arithm.cpp
+++ b/modules/core/test/ocl/test_arithm.cpp
@@ -42,11 +42,9 @@
 #include "../test_precomp.hpp"
 #include "opencv2/ts/ocl_test.hpp"
 
-#include <cmath>
-
 #ifdef HAVE_OPENCL
 
-namespace cvtest {
+namespace opencv_test {
 namespace ocl {
 
 //////////////////////////////// LUT /////////////////////////////////////////////////
@@ -138,8 +136,8 @@ PARAM_TEST_CASE(ArithmTestBase, MatDepth, Channels, bool)
     {
         const int type = CV_MAKE_TYPE(depth, cn);
 
-        double minV = getMinVal(type);
-        double maxV = getMaxVal(type);
+        double minV = cvtest::getMinVal(type);
+        double maxV = cvtest::getMaxVal(type);
 
         Size roiSize = randomSize(1, MAX_VALUE);
         Border src1Border = randomBorder(0, use_roi ? MAX_VALUE : 0);
@@ -1964,6 +1962,6 @@ OCL_TEST(Normalize, DISABLED_regression_5876_inplace_change_type)
     EXPECT_EQ(0, cvtest::norm(um, uresult, NORM_INF));
 }
 
-} } // namespace cvtest::ocl
+} } // namespace opencv_test::ocl
 
 #endif // HAVE_OPENCL

--- a/modules/core/test/ocl/test_channels.cpp
+++ b/modules/core/test/ocl/test_channels.cpp
@@ -49,7 +49,7 @@
 
 #ifdef HAVE_OPENCL
 
-namespace cvtest {
+namespace opencv_test {
 namespace ocl {
 
 //////////////////////////////////////// Merge ///////////////////////////////////////////////
@@ -464,6 +464,6 @@ OCL_INSTANTIATE_TEST_CASE_P(Channels, MixChannels, Combine(OCL_ALL_DEPTHS, Bool(
 OCL_INSTANTIATE_TEST_CASE_P(Channels, InsertChannel, Combine(OCL_ALL_DEPTHS, OCL_ALL_CHANNELS, Bool()));
 OCL_INSTANTIATE_TEST_CASE_P(Channels, ExtractChannel, Combine(OCL_ALL_DEPTHS, OCL_ALL_CHANNELS, Bool()));
 
-} } // namespace cvtest::ocl
+} } // namespace opencv_test::ocl
 
 #endif // HAVE_OPENCL

--- a/modules/core/test/ocl/test_dft.cpp
+++ b/modules/core/test/ocl/test_dft.cpp
@@ -56,7 +56,7 @@ enum OCL_FFT_TYPE
     C2C = 3
 };
 
-namespace cvtest {
+namespace opencv_test {
 namespace ocl {
 
 ////////////////////////////////////////////////////////////////////////////
@@ -185,6 +185,6 @@ OCL_INSTANTIATE_TEST_CASE_P(Core, Dft, Combine(Values(cv::Size(45, 72), cv::Size
                                                )
                             );
 
-} } // namespace cvtest::ocl
+} } // namespace opencv_test::ocl
 
 #endif // HAVE_OPENCL

--- a/modules/core/test/ocl/test_gemm.cpp
+++ b/modules/core/test/ocl/test_gemm.cpp
@@ -47,7 +47,7 @@
 
 #ifdef HAVE_OPENCL
 
-namespace cvtest {
+namespace opencv_test {
 namespace ocl {
 
 ////////////////////////////////////////////////////////////////////////////
@@ -145,6 +145,6 @@ OCL_INSTANTIATE_TEST_CASE_P(Core, Gemm, ::testing::Combine(
                             testing::Values(CV_32FC1, CV_32FC2, CV_64FC1, CV_64FC2),
                             Bool(), Bool(), Bool(), Bool()));
 
-} } // namespace cvtest::ocl
+} } // namespace opencv_test::ocl
 
 #endif // HAVE_OPENCL

--- a/modules/core/test/ocl/test_image2d.cpp
+++ b/modules/core/test/ocl/test_image2d.cpp
@@ -10,7 +10,7 @@
 
 #ifdef HAVE_OPENCL
 
-namespace cvtest {
+namespace opencv_test {
 namespace ocl {
 
 TEST(Image2D, createAliasEmptyUMat)
@@ -91,6 +91,6 @@ TEST(Image2D, turnOffOpenCL)
         std::cout << "OpenCL runtime not found. Test skipped." << std::endl;
 }
 
-} } // namespace cvtest::ocl
+} } // namespace opencv_test::ocl
 
 #endif // HAVE_OPENCL

--- a/modules/core/test/ocl/test_matrix_expr.cpp
+++ b/modules/core/test/ocl/test_matrix_expr.cpp
@@ -10,7 +10,7 @@
 
 #ifdef HAVE_OPENCL
 
-namespace cvtest {
+namespace opencv_test {
 namespace ocl {
 
 //////////////////////////////// UMat Expressions /////////////////////////////////////////////////
@@ -80,6 +80,6 @@ OCL_TEST_P(UMatExpr, Ones)
 
 OCL_INSTANTIATE_TEST_CASE_P(MatrixOperation, UMatExpr, Combine(OCL_ALL_DEPTHS, OCL_ALL_CHANNELS));
 
-} } // namespace cvtest::ocl
+} } // namespace opencv_test::ocl
 
 #endif

--- a/modules/core/test/ocl/test_matrix_operation.cpp
+++ b/modules/core/test/ocl/test_matrix_operation.cpp
@@ -49,7 +49,7 @@
 
 #ifdef HAVE_OPENCL
 
-namespace cvtest {
+namespace opencv_test {
 namespace ocl {
 
 ////////////////////////////////converto/////////////////////////////////////////////////
@@ -219,6 +219,6 @@ OCL_INSTANTIATE_TEST_CASE_P(MatrixOperation, CopyTo, Combine(
 OCL_INSTANTIATE_TEST_CASE_P(MatrixOperation, SetTo, Combine(
                                 OCL_ALL_DEPTHS, OCL_ALL_CHANNELS, Bool(), Bool()));
 
-} } // namespace cvtest::ocl
+} } // namespace opencv_test::ocl
 
 #endif

--- a/modules/core/test/ocl/test_opencl.cpp
+++ b/modules/core/test/ocl/test_opencl.cpp
@@ -4,7 +4,6 @@
 #include "../test_precomp.hpp"
 
 #include <opencv2/core/ocl.hpp>
-#include <fstream>
 
 namespace opencv_test { namespace {
 

--- a/modules/core/test/test_arithm.cpp
+++ b/modules/core/test/test_arithm.cpp
@@ -1,11 +1,9 @@
-﻿#include "test_precomp.hpp"
-#include <cmath>
+// This file is part of OpenCV project.
+// It is subject to the license terms in the LICENSE file found in the top-level directory
+// of this distribution and at http://opencv.org/license.html.
+#include "test_precomp.hpp"
 
-using namespace cv;
-using namespace std;
-
-namespace cvtest
-{
+namespace opencv_test { namespace {
 
 const int ARITHM_NTESTS = 1000;
 const int ARITHM_RNG_SEED = -1;
@@ -31,7 +29,7 @@ struct BaseElemWiseOp
 
     virtual void getRandomSize(RNG& rng, vector<int>& size)
     {
-        cvtest::randomSize(rng, 2, ARITHM_MAX_NDIMS, cvtest::ARITHM_MAX_SIZE_LOG, size);
+        cvtest::randomSize(rng, 2, ARITHM_MAX_NDIMS, ARITHM_MAX_SIZE_LOG, size);
     }
 
     virtual int getRandomType(RNG& rng)
@@ -119,9 +117,9 @@ struct AddOp : public BaseAddOp
     void op(const vector<Mat>& src, Mat& dst, const Mat& mask)
     {
         if( mask.empty() )
-            add(src[0], src[1], dst);
+            cv::add(src[0], src[1], dst);
         else
-            add(src[0], src[1], dst, mask);
+            cv::add(src[0], src[1], dst, mask);
     }
 };
 
@@ -132,9 +130,9 @@ struct SubOp : public BaseAddOp
     void op(const vector<Mat>& src, Mat& dst, const Mat& mask)
     {
         if( mask.empty() )
-            subtract(src[0], src[1], dst);
+            cv::subtract(src[0], src[1], dst);
         else
-            subtract(src[0], src[1], dst, mask);
+            cv::subtract(src[0], src[1], dst, mask);
     }
 };
 
@@ -145,9 +143,9 @@ struct AddSOp : public BaseAddOp
     void op(const vector<Mat>& src, Mat& dst, const Mat& mask)
     {
         if( mask.empty() )
-            add(src[0], gamma, dst);
+            cv::add(src[0], gamma, dst);
         else
-            add(src[0], gamma, dst, mask);
+            cv::add(src[0], gamma, dst, mask);
     }
 };
 
@@ -158,9 +156,9 @@ struct SubRSOp : public BaseAddOp
     void op(const vector<Mat>& src, Mat& dst, const Mat& mask)
     {
         if( mask.empty() )
-            subtract(gamma, src[0], dst);
+            cv::subtract(gamma, src[0], dst);
         else
-            subtract(gamma, src[0], dst, mask);
+            cv::subtract(gamma, src[0], dst, mask);
     }
 };
 
@@ -170,7 +168,7 @@ struct ScaleAddOp : public BaseAddOp
     ScaleAddOp() : BaseAddOp(2, FIX_BETA+FIX_GAMMA, 1, 1, Scalar::all(0)) {}
     void op(const vector<Mat>& src, Mat& dst, const Mat&)
     {
-        scaleAdd(src[0], alpha, src[1], dst);
+        cv::scaleAdd(src[0], alpha, src[1], dst);
     }
     double getMaxErr(int depth)
     {
@@ -184,7 +182,7 @@ struct AddWeightedOp : public BaseAddOp
     AddWeightedOp() : BaseAddOp(2, REAL_GAMMA, 1, 1, Scalar::all(0)) {}
     void op(const vector<Mat>& src, Mat& dst, const Mat&)
     {
-        addWeighted(src[0], alpha, src[1], beta, gamma[0], dst);
+        cv::addWeighted(src[0], alpha, src[1], beta, gamma[0], dst);
     }
     double getMaxErr(int depth)
     {
@@ -282,11 +280,11 @@ struct LogicOp : public BaseElemWiseOp
     void op(const vector<Mat>& src, Mat& dst, const Mat& mask)
     {
         if( opcode == '&' )
-            bitwise_and(src[0], src[1], dst, mask);
+            cv::bitwise_and(src[0], src[1], dst, mask);
         else if( opcode == '|' )
-            bitwise_or(src[0], src[1], dst, mask);
+            cv::bitwise_or(src[0], src[1], dst, mask);
         else
-            bitwise_xor(src[0], src[1], dst, mask);
+            cv::bitwise_xor(src[0], src[1], dst, mask);
     }
     void refop(const vector<Mat>& src, Mat& dst, const Mat& mask)
     {
@@ -313,13 +311,13 @@ struct LogicSOp : public BaseElemWiseOp
     void op(const vector<Mat>& src, Mat& dst, const Mat& mask)
     {
         if( opcode == '&' )
-            bitwise_and(src[0], gamma, dst, mask);
+            cv::bitwise_and(src[0], gamma, dst, mask);
         else if( opcode == '|' )
-            bitwise_or(src[0], gamma, dst, mask);
+            cv::bitwise_or(src[0], gamma, dst, mask);
         else if( opcode == '^' )
-            bitwise_xor(src[0], gamma, dst, mask);
+            cv::bitwise_xor(src[0], gamma, dst, mask);
         else
-            bitwise_not(src[0], dst);
+            cv::bitwise_not(src[0], dst);
     }
     void refop(const vector<Mat>& src, Mat& dst, const Mat& mask)
     {
@@ -547,6 +545,7 @@ template<typename _Tp> static void inRange_(const _Tp* src, const _Tp* a, const 
     }
 }
 
+namespace reference {
 
 static void inRange(const Mat& src, const Mat& lb, const Mat& rb, Mat& dst)
 {
@@ -597,7 +596,6 @@ static void inRange(const Mat& src, const Mat& lb, const Mat& rb, Mat& dst)
     }
 }
 
-
 static void inRangeS(const Mat& src, const Scalar& lb, const Scalar& rb, Mat& dst)
 {
     dst.create( src.dims, &src.size[0], CV_8U );
@@ -647,6 +645,8 @@ static void inRangeS(const Mat& src, const Scalar& lb, const Scalar& rb, Mat& ds
     }
 }
 
+} // namespace
+CVTEST_GUARD_SYMBOL(inRange);
 
 struct InRangeSOp : public BaseElemWiseOp
 {
@@ -657,7 +657,7 @@ struct InRangeSOp : public BaseElemWiseOp
     }
     void refop(const vector<Mat>& src, Mat& dst, const Mat&)
     {
-        cvtest::inRangeS(src[0], gamma, gamma1, dst);
+        reference::inRangeS(src[0], gamma, gamma1, dst);
     }
     double getMaxErr(int)
     {
@@ -695,7 +695,7 @@ struct InRangeOp : public BaseElemWiseOp
         cvtest::min(src[1], src[2], lb);
         cvtest::max(src[1], src[2], rb);
 
-        cvtest::inRange(src[0], lb, rb, dst);
+        reference::inRange(src[0], lb, rb, dst);
     }
     double getMaxErr(int)
     {
@@ -827,6 +827,7 @@ struct ConvertScaleAbsOp : public BaseElemWiseOp
     }
 };
 
+namespace reference {
 
 static void flip(const Mat& src, Mat& dst, int flipcode)
 {
@@ -867,13 +868,14 @@ static void setIdentity(Mat& dst, const Scalar& s)
     }
 }
 
+} // namespace
 
 struct FlipOp : public BaseElemWiseOp
 {
     FlipOp() : BaseElemWiseOp(1, FIX_ALPHA+FIX_BETA+FIX_GAMMA, 1, 1, Scalar::all(0)) { flipcode = 0; }
     void getRandomSize(RNG& rng, vector<int>& size)
     {
-        cvtest::randomSize(rng, 2, 2, cvtest::ARITHM_MAX_SIZE_LOG, size);
+        cvtest::randomSize(rng, 2, 2, ARITHM_MAX_SIZE_LOG, size);
     }
     void op(const vector<Mat>& src, Mat& dst, const Mat&)
     {
@@ -881,7 +883,7 @@ struct FlipOp : public BaseElemWiseOp
     }
     void refop(const vector<Mat>& src, Mat& dst, const Mat&)
     {
-        cvtest::flip(src[0], dst, flipcode);
+        reference::flip(src[0], dst, flipcode);
     }
     void generateScalars(int, RNG& rng)
     {
@@ -899,7 +901,7 @@ struct TransposeOp : public BaseElemWiseOp
     TransposeOp() : BaseElemWiseOp(1, FIX_ALPHA+FIX_BETA+FIX_GAMMA, 1, 1, Scalar::all(0)) {}
     void getRandomSize(RNG& rng, vector<int>& size)
     {
-        cvtest::randomSize(rng, 2, 2, cvtest::ARITHM_MAX_SIZE_LOG, size);
+        cvtest::randomSize(rng, 2, 2, ARITHM_MAX_SIZE_LOG, size);
     }
     void op(const vector<Mat>& src, Mat& dst, const Mat&)
     {
@@ -920,7 +922,7 @@ struct SetIdentityOp : public BaseElemWiseOp
     SetIdentityOp() : BaseElemWiseOp(0, FIX_ALPHA+FIX_BETA, 1, 1, Scalar::all(0)) {}
     void getRandomSize(RNG& rng, vector<int>& size)
     {
-        cvtest::randomSize(rng, 2, 2, cvtest::ARITHM_MAX_SIZE_LOG, size);
+        cvtest::randomSize(rng, 2, 2, ARITHM_MAX_SIZE_LOG, size);
     }
     void op(const vector<Mat>&, Mat& dst, const Mat&)
     {
@@ -928,7 +930,7 @@ struct SetIdentityOp : public BaseElemWiseOp
     }
     void refop(const vector<Mat>&, Mat& dst, const Mat&)
     {
-        cvtest::setIdentity(dst, gamma);
+        reference::setIdentity(dst, gamma);
     }
     double getMaxErr(int)
     {
@@ -953,7 +955,7 @@ struct SetZeroOp : public BaseElemWiseOp
     }
 };
 
-
+namespace reference {
 static void exp(const Mat& src, Mat& dst)
 {
     dst.create( src.dims, &src.size[0], src.type() );
@@ -1012,6 +1014,8 @@ static void log(const Mat& src, Mat& dst)
     }
 }
 
+} // namespace
+
 struct ExpOp : public BaseElemWiseOp
 {
     ExpOp() : BaseElemWiseOp(1, FIX_ALPHA+FIX_BETA+FIX_GAMMA, 1, 1, Scalar::all(0)) {}
@@ -1030,7 +1034,7 @@ struct ExpOp : public BaseElemWiseOp
     }
     void refop(const vector<Mat>& src, Mat& dst, const Mat&)
     {
-        cvtest::exp(src[0], dst);
+        reference::exp(src[0], dst);
     }
     double getMaxErr(int depth)
     {
@@ -1054,14 +1058,14 @@ struct LogOp : public BaseElemWiseOp
     void op(const vector<Mat>& src, Mat& dst, const Mat&)
     {
         Mat temp;
-        cvtest::exp(src[0], temp);
+        reference::exp(src[0], temp);
         cv::log(temp, dst);
     }
     void refop(const vector<Mat>& src, Mat& dst, const Mat&)
     {
         Mat temp;
-        cvtest::exp(src[0], temp);
-        cvtest::log(temp, dst);
+        reference::exp(src[0], temp);
+        reference::log(temp, dst);
     }
     double getMaxErr(int depth)
     {
@@ -1070,6 +1074,7 @@ struct LogOp : public BaseElemWiseOp
 };
 
 
+namespace reference {
 static void cartToPolar(const Mat& mx, const Mat& my, Mat& mmag, Mat& mangle, bool angleInDegrees)
 {
     CV_Assert( (mx.type() == CV_32F || mx.type() == CV_64F) &&
@@ -1120,6 +1125,7 @@ static void cartToPolar(const Mat& mx, const Mat& my, Mat& mmag, Mat& mangle, bo
     }
 }
 
+} // namespace
 
 struct CartToPolarToCartOp : public BaseElemWiseOp
 {
@@ -1147,7 +1153,7 @@ struct CartToPolarToCartOp : public BaseElemWiseOp
     void refop(const vector<Mat>& src, Mat& dst, const Mat&)
     {
         Mat mag, angle;
-        cvtest::cartToPolar(src[0], src[1], mag, angle, angleInDegrees);
+        reference::cartToPolar(src[0], src[1], mag, angle, angleInDegrees);
         Mat msrc[] = {mag, angle, src[0], src[1]};
         int pairs[] = {0, 0, 1, 1, 2, 2, 3, 3};
         dst.create(src[0].dims, src[0].size, CV_MAKETYPE(src[0].depth(), 4));
@@ -1382,9 +1388,7 @@ struct MinMaxLocOp : public BaseElemWiseOp
 };
 
 
-}
-
-typedef Ptr<cvtest::BaseElemWiseOp> ElemWiseOpPtr;
+typedef Ptr<BaseElemWiseOp> ElemWiseOpPtr;
 class ElemWiseTest : public ::testing::TestWithParam<ElemWiseOpPtr> {};
 
 TEST_P(ElemWiseTest, accuracy)
@@ -1392,15 +1396,15 @@ TEST_P(ElemWiseTest, accuracy)
     ElemWiseOpPtr op = GetParam();
 
     int testIdx = 0;
-    RNG rng((uint64)cvtest::ARITHM_RNG_SEED);
-    for( testIdx = 0; testIdx < cvtest::ARITHM_NTESTS; testIdx++ )
+    RNG rng((uint64)ARITHM_RNG_SEED);
+    for( testIdx = 0; testIdx < ARITHM_NTESTS; testIdx++ )
     {
         vector<int> size;
         op->getRandomSize(rng, size);
         int type = op->getRandomType(rng);
         int depth = CV_MAT_DEPTH(type);
-        bool haveMask = ((op->flags & cvtest::BaseElemWiseOp::SUPPORT_MASK) != 0
-                || (op->flags & cvtest::BaseElemWiseOp::SUPPORT_MULTICHANNELMASK) != 0) && rng.uniform(0, 4) == 0;
+        bool haveMask = ((op->flags & BaseElemWiseOp::SUPPORT_MASK) != 0
+                || (op->flags & BaseElemWiseOp::SUPPORT_MULTICHANNELMASK) != 0) && rng.uniform(0, 4) == 0;
 
         double minval=0, maxval=0;
         op->getValueRange(depth, minval, maxval);
@@ -1410,13 +1414,13 @@ TEST_P(ElemWiseTest, accuracy)
             src[i] = cvtest::randomMat(rng, size, type, minval, maxval, true);
         Mat dst0, dst, mask;
         if( haveMask ) {
-            bool multiChannelMask = (op->flags & cvtest::BaseElemWiseOp::SUPPORT_MULTICHANNELMASK) != 0
+            bool multiChannelMask = (op->flags & BaseElemWiseOp::SUPPORT_MULTICHANNELMASK) != 0
                     && rng.uniform(0, 2) == 0;
             int masktype = CV_8UC(multiChannelMask ? CV_MAT_CN(type) : 1);
             mask = cvtest::randomMat(rng, size, masktype, 0, 2, true);
         }
 
-        if( (haveMask || ninputs == 0) && !(op->flags & cvtest::BaseElemWiseOp::SCALAR_OUTPUT))
+        if( (haveMask || ninputs == 0) && !(op->flags & BaseElemWiseOp::SCALAR_OUTPUT))
         {
             dst0 = cvtest::randomMat(rng, size, type, minval, maxval, false);
             dst = cvtest::randomMat(rng, size, type, minval, maxval, true);
@@ -1434,61 +1438,61 @@ TEST_P(ElemWiseTest, accuracy)
 }
 
 
-INSTANTIATE_TEST_CASE_P(Core_Copy, ElemWiseTest, ::testing::Values(ElemWiseOpPtr(new cvtest::CopyOp)));
-INSTANTIATE_TEST_CASE_P(Core_Set, ElemWiseTest, ::testing::Values(ElemWiseOpPtr(new cvtest::SetOp)));
-INSTANTIATE_TEST_CASE_P(Core_SetZero, ElemWiseTest, ::testing::Values(ElemWiseOpPtr(new cvtest::SetZeroOp)));
-INSTANTIATE_TEST_CASE_P(Core_ConvertScale, ElemWiseTest, ::testing::Values(ElemWiseOpPtr(new cvtest::ConvertScaleOp)));
-INSTANTIATE_TEST_CASE_P(Core_ConvertScaleFp16, ElemWiseTest, ::testing::Values(ElemWiseOpPtr(new cvtest::ConvertScaleFp16Op)));
-INSTANTIATE_TEST_CASE_P(Core_ConvertScaleAbs, ElemWiseTest, ::testing::Values(ElemWiseOpPtr(new cvtest::ConvertScaleAbsOp)));
+INSTANTIATE_TEST_CASE_P(Core_Copy, ElemWiseTest, ::testing::Values(ElemWiseOpPtr(new CopyOp)));
+INSTANTIATE_TEST_CASE_P(Core_Set, ElemWiseTest, ::testing::Values(ElemWiseOpPtr(new SetOp)));
+INSTANTIATE_TEST_CASE_P(Core_SetZero, ElemWiseTest, ::testing::Values(ElemWiseOpPtr(new SetZeroOp)));
+INSTANTIATE_TEST_CASE_P(Core_ConvertScale, ElemWiseTest, ::testing::Values(ElemWiseOpPtr(new ConvertScaleOp)));
+INSTANTIATE_TEST_CASE_P(Core_ConvertScaleFp16, ElemWiseTest, ::testing::Values(ElemWiseOpPtr(new ConvertScaleFp16Op)));
+INSTANTIATE_TEST_CASE_P(Core_ConvertScaleAbs, ElemWiseTest, ::testing::Values(ElemWiseOpPtr(new ConvertScaleAbsOp)));
 
-INSTANTIATE_TEST_CASE_P(Core_Add, ElemWiseTest, ::testing::Values(ElemWiseOpPtr(new cvtest::AddOp)));
-INSTANTIATE_TEST_CASE_P(Core_Sub, ElemWiseTest, ::testing::Values(ElemWiseOpPtr(new cvtest::SubOp)));
-INSTANTIATE_TEST_CASE_P(Core_AddS, ElemWiseTest, ::testing::Values(ElemWiseOpPtr(new cvtest::AddSOp)));
-INSTANTIATE_TEST_CASE_P(Core_SubRS, ElemWiseTest, ::testing::Values(ElemWiseOpPtr(new cvtest::SubRSOp)));
-INSTANTIATE_TEST_CASE_P(Core_ScaleAdd, ElemWiseTest, ::testing::Values(ElemWiseOpPtr(new cvtest::ScaleAddOp)));
-INSTANTIATE_TEST_CASE_P(Core_AddWeighted, ElemWiseTest, ::testing::Values(ElemWiseOpPtr(new cvtest::AddWeightedOp)));
-INSTANTIATE_TEST_CASE_P(Core_AbsDiff, ElemWiseTest, ::testing::Values(ElemWiseOpPtr(new cvtest::AbsDiffOp)));
+INSTANTIATE_TEST_CASE_P(Core_Add, ElemWiseTest, ::testing::Values(ElemWiseOpPtr(new AddOp)));
+INSTANTIATE_TEST_CASE_P(Core_Sub, ElemWiseTest, ::testing::Values(ElemWiseOpPtr(new SubOp)));
+INSTANTIATE_TEST_CASE_P(Core_AddS, ElemWiseTest, ::testing::Values(ElemWiseOpPtr(new AddSOp)));
+INSTANTIATE_TEST_CASE_P(Core_SubRS, ElemWiseTest, ::testing::Values(ElemWiseOpPtr(new SubRSOp)));
+INSTANTIATE_TEST_CASE_P(Core_ScaleAdd, ElemWiseTest, ::testing::Values(ElemWiseOpPtr(new ScaleAddOp)));
+INSTANTIATE_TEST_CASE_P(Core_AddWeighted, ElemWiseTest, ::testing::Values(ElemWiseOpPtr(new AddWeightedOp)));
+INSTANTIATE_TEST_CASE_P(Core_AbsDiff, ElemWiseTest, ::testing::Values(ElemWiseOpPtr(new AbsDiffOp)));
 
 
-INSTANTIATE_TEST_CASE_P(Core_AbsDiffS, ElemWiseTest, ::testing::Values(ElemWiseOpPtr(new cvtest::AbsDiffSOp)));
+INSTANTIATE_TEST_CASE_P(Core_AbsDiffS, ElemWiseTest, ::testing::Values(ElemWiseOpPtr(new AbsDiffSOp)));
 
-INSTANTIATE_TEST_CASE_P(Core_And, ElemWiseTest, ::testing::Values(ElemWiseOpPtr(new cvtest::LogicOp('&'))));
-INSTANTIATE_TEST_CASE_P(Core_AndS, ElemWiseTest, ::testing::Values(ElemWiseOpPtr(new cvtest::LogicSOp('&'))));
-INSTANTIATE_TEST_CASE_P(Core_Or, ElemWiseTest, ::testing::Values(ElemWiseOpPtr(new cvtest::LogicOp('|'))));
-INSTANTIATE_TEST_CASE_P(Core_OrS, ElemWiseTest, ::testing::Values(ElemWiseOpPtr(new cvtest::LogicSOp('|'))));
-INSTANTIATE_TEST_CASE_P(Core_Xor, ElemWiseTest, ::testing::Values(ElemWiseOpPtr(new cvtest::LogicOp('^'))));
-INSTANTIATE_TEST_CASE_P(Core_XorS, ElemWiseTest, ::testing::Values(ElemWiseOpPtr(new cvtest::LogicSOp('^'))));
-INSTANTIATE_TEST_CASE_P(Core_Not, ElemWiseTest, ::testing::Values(ElemWiseOpPtr(new cvtest::LogicSOp('~'))));
+INSTANTIATE_TEST_CASE_P(Core_And, ElemWiseTest, ::testing::Values(ElemWiseOpPtr(new LogicOp('&'))));
+INSTANTIATE_TEST_CASE_P(Core_AndS, ElemWiseTest, ::testing::Values(ElemWiseOpPtr(new LogicSOp('&'))));
+INSTANTIATE_TEST_CASE_P(Core_Or, ElemWiseTest, ::testing::Values(ElemWiseOpPtr(new LogicOp('|'))));
+INSTANTIATE_TEST_CASE_P(Core_OrS, ElemWiseTest, ::testing::Values(ElemWiseOpPtr(new LogicSOp('|'))));
+INSTANTIATE_TEST_CASE_P(Core_Xor, ElemWiseTest, ::testing::Values(ElemWiseOpPtr(new LogicOp('^'))));
+INSTANTIATE_TEST_CASE_P(Core_XorS, ElemWiseTest, ::testing::Values(ElemWiseOpPtr(new LogicSOp('^'))));
+INSTANTIATE_TEST_CASE_P(Core_Not, ElemWiseTest, ::testing::Values(ElemWiseOpPtr(new LogicSOp('~'))));
 
-INSTANTIATE_TEST_CASE_P(Core_Max, ElemWiseTest, ::testing::Values(ElemWiseOpPtr(new cvtest::MaxOp)));
-INSTANTIATE_TEST_CASE_P(Core_MaxS, ElemWiseTest, ::testing::Values(ElemWiseOpPtr(new cvtest::MaxSOp)));
-INSTANTIATE_TEST_CASE_P(Core_Min, ElemWiseTest, ::testing::Values(ElemWiseOpPtr(new cvtest::MinOp)));
-INSTANTIATE_TEST_CASE_P(Core_MinS, ElemWiseTest, ::testing::Values(ElemWiseOpPtr(new cvtest::MinSOp)));
+INSTANTIATE_TEST_CASE_P(Core_Max, ElemWiseTest, ::testing::Values(ElemWiseOpPtr(new MaxOp)));
+INSTANTIATE_TEST_CASE_P(Core_MaxS, ElemWiseTest, ::testing::Values(ElemWiseOpPtr(new MaxSOp)));
+INSTANTIATE_TEST_CASE_P(Core_Min, ElemWiseTest, ::testing::Values(ElemWiseOpPtr(new MinOp)));
+INSTANTIATE_TEST_CASE_P(Core_MinS, ElemWiseTest, ::testing::Values(ElemWiseOpPtr(new MinSOp)));
 
-INSTANTIATE_TEST_CASE_P(Core_Mul, ElemWiseTest, ::testing::Values(ElemWiseOpPtr(new cvtest::MulOp)));
-INSTANTIATE_TEST_CASE_P(Core_Div, ElemWiseTest, ::testing::Values(ElemWiseOpPtr(new cvtest::DivOp)));
-INSTANTIATE_TEST_CASE_P(Core_Recip, ElemWiseTest, ::testing::Values(ElemWiseOpPtr(new cvtest::RecipOp)));
+INSTANTIATE_TEST_CASE_P(Core_Mul, ElemWiseTest, ::testing::Values(ElemWiseOpPtr(new MulOp)));
+INSTANTIATE_TEST_CASE_P(Core_Div, ElemWiseTest, ::testing::Values(ElemWiseOpPtr(new DivOp)));
+INSTANTIATE_TEST_CASE_P(Core_Recip, ElemWiseTest, ::testing::Values(ElemWiseOpPtr(new RecipOp)));
 
-INSTANTIATE_TEST_CASE_P(Core_Cmp, ElemWiseTest, ::testing::Values(ElemWiseOpPtr(new cvtest::CmpOp)));
-INSTANTIATE_TEST_CASE_P(Core_CmpS, ElemWiseTest, ::testing::Values(ElemWiseOpPtr(new cvtest::CmpSOp)));
+INSTANTIATE_TEST_CASE_P(Core_Cmp, ElemWiseTest, ::testing::Values(ElemWiseOpPtr(new CmpOp)));
+INSTANTIATE_TEST_CASE_P(Core_CmpS, ElemWiseTest, ::testing::Values(ElemWiseOpPtr(new CmpSOp)));
 
-INSTANTIATE_TEST_CASE_P(Core_InRangeS, ElemWiseTest, ::testing::Values(ElemWiseOpPtr(new cvtest::InRangeSOp)));
-INSTANTIATE_TEST_CASE_P(Core_InRange, ElemWiseTest, ::testing::Values(ElemWiseOpPtr(new cvtest::InRangeOp)));
+INSTANTIATE_TEST_CASE_P(Core_InRangeS, ElemWiseTest, ::testing::Values(ElemWiseOpPtr(new InRangeSOp)));
+INSTANTIATE_TEST_CASE_P(Core_InRange, ElemWiseTest, ::testing::Values(ElemWiseOpPtr(new InRangeOp)));
 
-INSTANTIATE_TEST_CASE_P(Core_Flip, ElemWiseTest, ::testing::Values(ElemWiseOpPtr(new cvtest::FlipOp)));
-INSTANTIATE_TEST_CASE_P(Core_Transpose, ElemWiseTest, ::testing::Values(ElemWiseOpPtr(new cvtest::TransposeOp)));
-INSTANTIATE_TEST_CASE_P(Core_SetIdentity, ElemWiseTest, ::testing::Values(ElemWiseOpPtr(new cvtest::SetIdentityOp)));
+INSTANTIATE_TEST_CASE_P(Core_Flip, ElemWiseTest, ::testing::Values(ElemWiseOpPtr(new FlipOp)));
+INSTANTIATE_TEST_CASE_P(Core_Transpose, ElemWiseTest, ::testing::Values(ElemWiseOpPtr(new TransposeOp)));
+INSTANTIATE_TEST_CASE_P(Core_SetIdentity, ElemWiseTest, ::testing::Values(ElemWiseOpPtr(new SetIdentityOp)));
 
-INSTANTIATE_TEST_CASE_P(Core_Exp, ElemWiseTest, ::testing::Values(ElemWiseOpPtr(new cvtest::ExpOp)));
-INSTANTIATE_TEST_CASE_P(Core_Log, ElemWiseTest, ::testing::Values(ElemWiseOpPtr(new cvtest::LogOp)));
+INSTANTIATE_TEST_CASE_P(Core_Exp, ElemWiseTest, ::testing::Values(ElemWiseOpPtr(new ExpOp)));
+INSTANTIATE_TEST_CASE_P(Core_Log, ElemWiseTest, ::testing::Values(ElemWiseOpPtr(new LogOp)));
 
-INSTANTIATE_TEST_CASE_P(Core_CountNonZero, ElemWiseTest, ::testing::Values(ElemWiseOpPtr(new cvtest::CountNonZeroOp)));
-INSTANTIATE_TEST_CASE_P(Core_Mean, ElemWiseTest, ::testing::Values(ElemWiseOpPtr(new cvtest::MeanOp)));
-INSTANTIATE_TEST_CASE_P(Core_MeanStdDev, ElemWiseTest, ::testing::Values(ElemWiseOpPtr(new cvtest::MeanStdDevOp)));
-INSTANTIATE_TEST_CASE_P(Core_Sum, ElemWiseTest, ::testing::Values(ElemWiseOpPtr(new cvtest::SumOp)));
-INSTANTIATE_TEST_CASE_P(Core_Norm, ElemWiseTest, ::testing::Values(ElemWiseOpPtr(new cvtest::NormOp)));
-INSTANTIATE_TEST_CASE_P(Core_MinMaxLoc, ElemWiseTest, ::testing::Values(ElemWiseOpPtr(new cvtest::MinMaxLocOp)));
-INSTANTIATE_TEST_CASE_P(Core_CartToPolarToCart, ElemWiseTest, ::testing::Values(ElemWiseOpPtr(new cvtest::CartToPolarToCartOp)));
+INSTANTIATE_TEST_CASE_P(Core_CountNonZero, ElemWiseTest, ::testing::Values(ElemWiseOpPtr(new CountNonZeroOp)));
+INSTANTIATE_TEST_CASE_P(Core_Mean, ElemWiseTest, ::testing::Values(ElemWiseOpPtr(new MeanOp)));
+INSTANTIATE_TEST_CASE_P(Core_MeanStdDev, ElemWiseTest, ::testing::Values(ElemWiseOpPtr(new MeanStdDevOp)));
+INSTANTIATE_TEST_CASE_P(Core_Sum, ElemWiseTest, ::testing::Values(ElemWiseOpPtr(new SumOp)));
+INSTANTIATE_TEST_CASE_P(Core_Norm, ElemWiseTest, ::testing::Values(ElemWiseOpPtr(new NormOp)));
+INSTANTIATE_TEST_CASE_P(Core_MinMaxLoc, ElemWiseTest, ::testing::Values(ElemWiseOpPtr(new MinMaxLocOp)));
+INSTANTIATE_TEST_CASE_P(Core_CartToPolarToCart, ElemWiseTest, ::testing::Values(ElemWiseOpPtr(new CartToPolarToCartOp)));
 
 
 TEST(Core_ArithmMask, uninitialized)
@@ -1528,34 +1532,34 @@ TEST(Core_ArithmMask, uninitialized)
                 a.convertTo(a1, depth1);
                 b.convertTo(b1, depth1);
                 // invert the mask
-                compare(mask, 0, mask1, CMP_EQ);
+                cv::compare(mask, 0, mask1, CMP_EQ);
                 a1.setTo(0, mask1);
                 b1.setTo(0, mask1);
 
                 if( op == 0 )
                 {
-                    add(a, b, c, mask);
-                    add(a1, b1, d);
+                    cv::add(a, b, c, mask);
+                    cv::add(a1, b1, d);
                 }
                 else if( op == 1 )
                 {
-                    subtract(a, b, c, mask);
-                    subtract(a1, b1, d);
+                    cv::subtract(a, b, c, mask);
+                    cv::subtract(a1, b1, d);
                 }
                 else if( op == 2 )
                 {
-                    bitwise_and(a, b, c, mask);
-                    bitwise_and(a1, b1, d);
+                    cv::bitwise_and(a, b, c, mask);
+                    cv::bitwise_and(a1, b1, d);
                 }
                 else if( op == 3 )
                 {
-                    bitwise_or(a, b, c, mask);
-                    bitwise_or(a1, b1, d);
+                    cv::bitwise_or(a, b, c, mask);
+                    cv::bitwise_or(a1, b1, d);
                 }
                 else if( op == 4 )
                 {
-                    bitwise_xor(a, b, c, mask);
-                    bitwise_xor(a1, b1, d);
+                    cv::bitwise_xor(a, b, c, mask);
+                    cv::bitwise_xor(a1, b1, d);
                 }
                 Mat d1;
                 d.convertTo(d1, depth);
@@ -1630,7 +1634,7 @@ TEST_P(Mul1, One)
 
 INSTANTIATE_TEST_CASE_P(Arithm, Mul1, testing::Values(Size(2, 2), Size(1, 1)));
 
-class SubtractOutputMatNotEmpty : public testing::TestWithParam< std::tr1::tuple<cv::Size, perf::MatType, perf::MatDepth, bool> >
+class SubtractOutputMatNotEmpty : public testing::TestWithParam< tuple<cv::Size, perf::MatType, perf::MatDepth, bool> >
 {
 public:
     cv::Size size;
@@ -1640,10 +1644,10 @@ public:
 
     void SetUp()
     {
-        size = std::tr1::get<0>(GetParam());
-        src_type = std::tr1::get<1>(GetParam());
-        dst_depth = std::tr1::get<2>(GetParam());
-        fixed = std::tr1::get<3>(GetParam());
+        size = get<0>(GetParam());
+        src_type = get<1>(GetParam());
+        dst_depth = get<2>(GetParam());
+        fixed = get<3>(GetParam());
     }
 };
 
@@ -1864,13 +1868,13 @@ TEST(Core_BoolVector, support)
         nz += (int)test[i];
     }
     ASSERT_EQ( nz, countNonZero(test) );
-    ASSERT_FLOAT_EQ((float)nz/n, (float)(mean(test)[0]));
+    ASSERT_FLOAT_EQ((float)nz/n, (float)(cv::mean(test)[0]));
 }
 
 TEST(MinMaxLoc, Mat_UcharMax_Without_Loc)
 {
     Mat_<uchar> mat(50, 50);
-    uchar iMaxVal = numeric_limits<uchar>::max();
+    uchar iMaxVal = std::numeric_limits<uchar>::max();
     mat.setTo(iMaxVal);
 
     double min, max;
@@ -1888,7 +1892,7 @@ TEST(MinMaxLoc, Mat_UcharMax_Without_Loc)
 TEST(MinMaxLoc, Mat_IntMax_Without_Mask)
 {
     Mat_<int> mat(50, 50);
-    int iMaxVal = numeric_limits<int>::max();
+    int iMaxVal = std::numeric_limits<int>::max();
     mat.setTo(iMaxVal);
 
     double min, max;
@@ -1957,8 +1961,8 @@ TEST(Compare, regression_8999)
     Mat_<double> B(1,1); B << 2;
     Mat C;
     ASSERT_ANY_THROW({
-                        compare(A, B, C, CMP_LT);
-                     });
+        cv::compare(A, B, C, CMP_LT);
+    });
 }
 
 
@@ -1982,7 +1986,7 @@ TEST(Core_minMaxIdx, regression_9207_1)
     Mat src(Size(cols, rows), CV_8UC1, src_);
     double minVal = -0.0, maxVal = -0.0;
     int minIdx[2] = { -2, -2 }, maxIdx[2] = { -2, -2 };
-    minMaxIdx(src, &minVal, &maxVal, minIdx, maxIdx, mask);
+    cv::minMaxIdx(src, &minVal, &maxVal, minIdx, maxIdx, mask);
     EXPECT_EQ(0, minIdx[0]);
     EXPECT_EQ(0, minIdx[1]);
     EXPECT_EQ(0, maxIdx[0]);
@@ -2028,9 +2032,11 @@ TEST(Core_minMaxIdx, regression_9207_2)
     Mat src(Size(cols, rows), CV_8UC1, src_);
     double minVal = -0.0, maxVal = -0.0;
     int minIdx[2] = { -2, -2 }, maxIdx[2] = { -2, -2 };
-    minMaxIdx(src, &minVal, &maxVal, minIdx, maxIdx, mask);
+    cv::minMaxIdx(src, &minVal, &maxVal, minIdx, maxIdx, mask);
     EXPECT_EQ(0, minIdx[0]);
     EXPECT_EQ(14, minIdx[1]);
     EXPECT_EQ(0, maxIdx[0]);
     EXPECT_EQ(14, maxIdx[1]);
 }
+
+}} // namespace

--- a/modules/core/test/test_concatenation.cpp
+++ b/modules/core/test/test_concatenation.cpp
@@ -41,8 +41,7 @@
 
 #include "test_precomp.hpp"
 
-using namespace cv;
-using namespace std;
+namespace opencv_test { namespace {
 
 class Core_ConcatenationTest : public cvtest::BaseTest
 {
@@ -145,3 +144,5 @@ TEST(Core_Concatenation, hconcat_empty_empty) { Core_ConcatenationTest test(true
 TEST(Core_Concatenation, vconcat_empty_nonempty) { Core_ConcatenationTest test(false, true, false); test.safe_run(); }
 TEST(Core_Concatenation, vconcat_nonempty_empty) { Core_ConcatenationTest test(false, false, true); test.safe_run(); }
 TEST(Core_Concatenation, vconcat_empty_empty) { Core_ConcatenationTest test(false, true, true); test.safe_run(); }
+
+}} // namespace

--- a/modules/core/test/test_conjugate_gradient.cpp
+++ b/modules/core/test/test_conjugate_gradient.cpp
@@ -39,7 +39,8 @@
 //
 //M*/
 #include "test_precomp.hpp"
-#include <cstdlib>
+
+namespace opencv_test { namespace {
 
 static void mytest(cv::Ptr<cv::ConjGradSolver> solver,cv::Ptr<cv::MinProblemSolver::Function> ptr_F,cv::Mat& x,
         cv::Mat& etalon_x,double etalon_res){
@@ -103,3 +104,5 @@ TEST(Core_ConjGradSolver, regression_basic){
     }
 #endif
 }
+
+}} // namespace

--- a/modules/core/test/test_countnonzero.cpp
+++ b/modules/core/test/test_countnonzero.cpp
@@ -41,10 +41,8 @@
 //M*/
 
 #include "test_precomp.hpp"
-#include <time.h>
-#include <limits>
-using namespace cv;
-using namespace std;
+
+namespace opencv_test { namespace {
 
 #define CORE_COUNTNONZERO_ERROR_COUNT 1
 
@@ -252,12 +250,12 @@ void CV_CountNonZeroTest::run(int)
 TEST (Core_CountNonZero, accuracy) { CV_CountNonZeroTest test; test.safe_run(); }
 
 
-typedef testing::TestWithParam<std::tr1::tuple<int, int> > CountNonZeroND;
+typedef testing::TestWithParam<tuple<int, int> > CountNonZeroND;
 
 TEST_P (CountNonZeroND, ndim)
 {
-    const int dims = std::tr1::get<0>(GetParam());
-    const int type = std::tr1::get<1>(GetParam());
+    const int dims = get<0>(GetParam());
+    const int type = get<1>(GetParam());
     const int ONE_SIZE = 5;
 
     vector<int> sizes(dims);
@@ -277,3 +275,5 @@ INSTANTIATE_TEST_CASE_P(Core, CountNonZeroND,
         testing::Values(CV_8U, CV_8S, CV_32F)
     )
 );
+
+}} // namespace

--- a/modules/core/test/test_downhill_simplex.cpp
+++ b/modules/core/test/test_downhill_simplex.cpp
@@ -39,9 +39,8 @@
 //
 //M*/
 #include "test_precomp.hpp"
-#include <cstdlib>
-#include <cmath>
-#include <algorithm>
+
+namespace opencv_test { namespace {
 
 static void mytest(cv::Ptr<cv::DownhillSolver> solver,cv::Ptr<cv::MinProblemSolver::Function> ptr_F,cv::Mat& x,cv::Mat& step,
         cv::Mat& etalon_x,double etalon_res){
@@ -103,3 +102,5 @@ TEST(Core_DownhillSolver, regression_basic){
     }
 #endif
 }
+
+}} // namespace

--- a/modules/core/test/test_ds.cpp
+++ b/modules/core/test/test_ds.cpp
@@ -1,7 +1,9 @@
+// This file is part of OpenCV project.
+// It is subject to the license terms in the LICENSE file found in the top-level directory
+// of this distribution and at http://opencv.org/license.html.
 #include "test_precomp.hpp"
 
-using namespace cv;
-using namespace std;
+namespace opencv_test { namespace {
 
 typedef  struct  CvTsSimpleSeq
 {
@@ -2130,3 +2132,5 @@ TEST(Core_DS_Seq, sort_invert) { Core_SeqSortInvTest test; test.safe_run(); }
 TEST(Core_DS_Set, basic_operations) { Core_SetTest test; test.safe_run(); }
 TEST(Core_DS_Graph, basic_operations) { Core_GraphTest test; test.safe_run(); }
 TEST(Core_DS_Graph, scan) { Core_GraphScanTest test; test.safe_run(); }
+
+}} // namespace

--- a/modules/core/test/test_dxt.cpp
+++ b/modules/core/test/test_dxt.cpp
@@ -1,10 +1,9 @@
+// This file is part of OpenCV project.
+// It is subject to the license terms in the LICENSE file found in the top-level directory
+// of this distribution and at http://opencv.org/license.html.
 #include "test_precomp.hpp"
 
-using namespace cv;
-using namespace std;
-
-namespace cvtest
-{
+namespace opencv_test { namespace {
 
 static Mat initDFTWave( int n, bool inv )
 {
@@ -497,9 +496,6 @@ static void mulComplex( const Mat& src1, const Mat& src2, Mat& dst, int flags )
     }
 }
 
-}
-
-
 class CxCore_DXTBaseTest : public cvtest::ArrayTest
 {
 public:
@@ -661,7 +657,7 @@ int CxCore_DXTBaseTest::prepare_test_case( int test_case_idx )
         int out_type = test_mat[OUTPUT][0].type();
 
         if( CV_MAT_CN(in_type) == 2 && CV_MAT_CN(out_type) == 1 )
-            cvtest::fixCCS( test_mat[INPUT][0], test_mat[OUTPUT][0].cols, flags );
+            fixCCS( test_mat[INPUT][0], test_mat[OUTPUT][0].cols, flags );
 
         if( inplace )
             cvtest::copy( test_mat[INPUT][test_case_idx & (int)spectrum_mode],
@@ -718,22 +714,22 @@ void CxCore_DFTTest::prepare_to_validation( int /*test_case_idx*/ )
         if( !(flags & CV_DXT_INVERSE ) )
         {
             Mat& cvdft_dst = test_mat[TEMP][1];
-            cvtest::convertFromCCS( cvdft_dst, cvdft_dst,
-                               test_mat[OUTPUT][0], flags );
+            convertFromCCS( cvdft_dst, cvdft_dst,
+                            test_mat[OUTPUT][0], flags );
             *tmp_src = Scalar::all(0);
             cvtest::insert( src, *tmp_src, 0 );
         }
         else
         {
-            cvtest::convertFromCCS( src, src, *tmp_src, flags );
+            convertFromCCS( src, src, *tmp_src, flags );
             tmp_dst = &test_mat[TEMP][1];
         }
     }
 
     if( src.rows == 1 || (src.cols == 1 && !(flags & CV_DXT_ROWS)) )
-        cvtest::DFT_1D( *tmp_src, *tmp_dst, flags );
+        DFT_1D( *tmp_src, *tmp_dst, flags );
     else
-        cvtest::DFT_2D( *tmp_src, *tmp_dst, flags );
+        DFT_2D( *tmp_src, *tmp_dst, flags );
 
     if( tmp_dst != &dst )
         cvtest::extract( *tmp_dst, dst, 0 );
@@ -773,9 +769,9 @@ void CxCore_DCTTest::prepare_to_validation( int /*test_case_idx*/ )
     Mat& dst = test_mat[REF_OUTPUT][0];
 
     if( src.rows == 1 || (src.cols == 1 && !(flags & CV_DXT_ROWS)) )
-        cvtest::DCT_1D( src, dst, flags );
+        DCT_1D( src, dst, flags );
     else
-        cvtest::DCT_2D( src, dst, flags );
+        DCT_2D( src, dst, flags );
 }
 
 
@@ -837,17 +833,17 @@ void CxCore_MulSpectrumsTest::prepare_to_validation( int /*test_case_idx*/ )
 
     if( cn == 1 )
     {
-        cvtest::convertFromCCS( *src1, *src1, dst, flags );
-        cvtest::convertFromCCS( *src2, *src2, dst0, flags );
+        convertFromCCS( *src1, *src1, dst, flags );
+        convertFromCCS( *src2, *src2, dst0, flags );
         src1 = &dst;
         src2 = &dst0;
     }
 
-    cvtest::mulComplex( *src1, *src2, dst0, flags );
+    mulComplex( *src1, *src2, dst0, flags );
     if( cn == 1 )
     {
         Mat& temp = test_mat[TEMP][0];
-        cvtest::convertFromCCS( temp, temp, dst, flags );
+        convertFromCCS( temp, temp, dst, flags );
     }
 }
 
@@ -900,7 +896,7 @@ TEST(Core_DFT, complex_output2)
         Mat x(m, n, type), out;
         randu(x, -1., 1.);
         dft(x, out, DFT_ROWS | DFT_COMPLEX_OUTPUT);
-        double nrm = norm(out, NORM_INF);
+        double nrm = cvtest::norm(out, NORM_INF);
         double thresh = n*m*2;
         if( nrm > thresh )
         {
@@ -986,3 +982,5 @@ protected:
 
 TEST(Core_DFT, reverse) { Core_DXTReverseTest test(Core_DXTReverseTest::ModeDFT); test.safe_run(); }
 TEST(Core_DCT, reverse) { Core_DXTReverseTest test(Core_DXTReverseTest::ModeDCT); test.safe_run(); }
+
+}} // namespace

--- a/modules/core/test/test_eigen.cpp
+++ b/modules/core/test/test_eigen.cpp
@@ -39,12 +39,9 @@
 // the use of this software, even if advised of the possibility of such damage.
 //
 //M*/
-
 #include "test_precomp.hpp"
-#include <time.h>
 
-using namespace cv;
-using namespace std;
+namespace opencv_test { namespace {
 
 #define sign(a) a > 0 ? 1 : a == 0 ? 0 : -1
 
@@ -374,7 +371,7 @@ bool Core_EigenTest::check_full(int type)
 {
     const int MAX_DEGREE = 7;
 
-    RNG rng = ::theRNG(); // fix the seed
+    RNG rng = cv::theRNG(); // fix the seed
 
     for (int i = 0; i < ntests; ++i)
     {
@@ -518,3 +515,5 @@ static void testEigen3x3()
 }
 TEST(Core_EigenNonSymmetric, float3x3) { testEigen3x3<float>(); }
 TEST(Core_EigenNonSymmetric, double3x3) { testEigen3x3<double>(); }
+
+}} // namespace

--- a/modules/core/test/test_hal_core.cpp
+++ b/modules/core/test/test_hal_core.cpp
@@ -38,10 +38,9 @@
 // the use of this software, even if advised of the possibility of such damage.
 //
 //M*/
-
 #include "test_precomp.hpp"
 
-using namespace cv;
+namespace opencv_test { namespace {
 
 enum
 {
@@ -111,7 +110,7 @@ TEST(Core_HAL, mathfuncs)
             t = (double)getTickCount() - t;
             min_ocv_t = std::min(min_ocv_t, t);
         }
-        EXPECT_LE(norm(dst, dst0, NORM_INF | NORM_RELATIVE), eps);
+        EXPECT_LE(cvtest::norm(dst, dst0, NORM_INF | NORM_RELATIVE), eps);
 
         double freq = getTickFrequency();
         printf("%s (N=%d, %s): hal time=%.2fusec, ocv time=%.2fusec\n",
@@ -119,8 +118,6 @@ TEST(Core_HAL, mathfuncs)
                n, (depth == CV_32F ? "f32" : "f64"), min_hal_t*1e6/freq, min_ocv_t*1e6/freq);
     }
 }
-
-namespace {
 
 enum
 {
@@ -188,7 +185,7 @@ TEST_P(HAL, mat_decomp)
         //std::cout << "x: " << Mat(x.t()) << std::endl;
         //std::cout << "x0: " << Mat(x0.t()) << std::endl;
 
-        EXPECT_LE(norm(x, x0, NORM_INF | NORM_RELATIVE), eps)
+        EXPECT_LE(cvtest::norm(x, x0, NORM_INF | NORM_RELATIVE), eps)
             << "x:  " << Mat(x.t())
             << "\nx0: " << Mat(x0.t())
             << "\na0: " << a0
@@ -205,4 +202,4 @@ TEST_P(HAL, mat_decomp)
 
 INSTANTIATE_TEST_CASE_P(Core, HAL, testing::Range(0, 16));
 
-} // namespace
+}} // namespace

--- a/modules/core/test/test_intrin.cpp
+++ b/modules/core/test/test_intrin.cpp
@@ -1,5 +1,7 @@
+// This file is part of OpenCV project.
+// It is subject to the license terms in the LICENSE file found in the top-level directory
+// of this distribution and at http://opencv.org/license.html.
 #include "test_precomp.hpp"
-#include <climits>
 
 #include "test_intrin_utils.hpp"
 
@@ -10,7 +12,7 @@
 
 using namespace cv;
 
-namespace cvtest { namespace hal {
+namespace opencv_test { namespace hal {
 using namespace CV_CPU_OPTIMIZATION_NAMESPACE;
 
 //=============  8-bit integer =====================================================================

--- a/modules/core/test/test_intrin.fp16.cpp
+++ b/modules/core/test/test_intrin.fp16.cpp
@@ -1,7 +1,10 @@
+// This file is part of OpenCV project.
+// It is subject to the license terms in the LICENSE file found in the top-level directory
+// of this distribution and at http://opencv.org/license.html.
 #include "test_precomp.hpp"
 #include "test_intrin_utils.hpp"
 
-namespace cvtest { namespace hal {
+namespace opencv_test { namespace hal {
 CV_CPU_OPTIMIZATION_NAMESPACE_BEGIN
 
 void test_hal_intrin_float16x4()

--- a/modules/core/test/test_intrin_utils.hpp
+++ b/modules/core/test/test_intrin_utils.hpp
@@ -1,6 +1,9 @@
+// This file is part of OpenCV project.
+// It is subject to the license terms in the LICENSE file found in the top-level directory
+// of this distribution and at http://opencv.org/license.html.
 #include "opencv2/core/hal/intrin.hpp"
 
-namespace cvtest { namespace hal {
+namespace opencv_test { namespace hal {
 CV_CPU_OPTIMIZATION_NAMESPACE_BEGIN
 
 void test_hal_intrin_float16x4();

--- a/modules/core/test/test_io.cpp
+++ b/modules/core/test/test_io.cpp
@@ -1,7 +1,9 @@
+// This file is part of OpenCV project.
+// It is subject to the license terms in the LICENSE file found in the top-level directory
+// of this distribution and at http://opencv.org/license.html.
 #include "test_precomp.hpp"
 
-using namespace cv;
-using namespace std;
+namespace opencv_test { namespace {
 
 static SparseMat cvTsGetRandomSparseMat(int dims, const int* sz, int type,
                                         int nzcount, double a, double b, RNG& rng)
@@ -122,7 +124,7 @@ protected:
                 exp(test_mat, test_mat);
                 Mat test_mat_scale(test_mat.size(), test_mat.type());
                 rng0.fill(test_mat_scale, CV_RAND_UNI, Scalar::all(-1), Scalar::all(1));
-                multiply(test_mat, test_mat_scale, test_mat);
+                cv::multiply(test_mat, test_mat_scale, test_mat);
             }
 
             CvSeq* seq = cvCreateSeq(test_mat.type(), (int)sizeof(CvSeq),
@@ -158,7 +160,7 @@ protected:
                 exp(test_mat_nd, test_mat_nd);
                 MatND test_mat_scale(test_mat_nd.dims, test_mat_nd.size, test_mat_nd.type());
                 rng0.fill(test_mat_scale, CV_RAND_UNI, Scalar::all(-1), Scalar::all(1));
-                multiply(test_mat_nd, test_mat_scale, test_mat_nd);
+                cv::multiply(test_mat_nd, test_mat_scale, test_mat_nd);
             }
 
             int ssz[] = {
@@ -386,8 +388,6 @@ protected:
 };
 
 TEST(Core_InputOutput, write_read_consistency) { Core_IOTest test; test.safe_run(); }
-
-extern void testFormatter();
 
 
 struct UserDefinedType
@@ -1058,7 +1058,7 @@ TEST(Core_InputOutput, filestorage_vec_vec_io)
 
             for(size_t k = 0; k < testMats[j].size(); k++)
             {
-                ASSERT_TRUE(norm(outputMats[j][k] - testMats[j][k], NORM_INF) == 0);
+                ASSERT_TRUE(cvtest::norm(outputMats[j][k] - testMats[j][k], NORM_INF) == 0);
             }
         }
 
@@ -1597,7 +1597,7 @@ TEST(Core_InputOutput, FileStorage_free_file_after_exception)
     const std::string fileName = "FileStorage_free_file_after_exception_test.yml";
     const std::string content = "%YAML:1.0\n cameraMatrix;:: !<tag:yaml.org,2002:opencv-matrix>\n";
 
-    fstream testFile;
+    std::fstream testFile;
     testFile.open(fileName.c_str(), std::fstream::out);
     if(!testFile.is_open()) FAIL();
     testFile << content;
@@ -1611,5 +1611,7 @@ TEST(Core_InputOutput, FileStorage_free_file_after_exception)
     catch (const std::exception&)
     {
     }
-    ASSERT_EQ(std::remove(fileName.c_str()), 0);
+    ASSERT_EQ(0, std::remove(fileName.c_str()));
 }
+
+}} // namespace

--- a/modules/core/test/test_ippasync.cpp
+++ b/modules/core/test/test_ippasync.cpp
@@ -1,3 +1,6 @@
+// This file is part of OpenCV project.
+// It is subject to the license terms in the LICENSE file found in the top-level directory
+// of this distribution and at http://opencv.org/license.html.
 #include "test_precomp.hpp"
 #include "opencv2/ts/ocl_test.hpp"
 
@@ -6,9 +9,9 @@
 
 using namespace cv;
 using namespace std;
-using namespace cvtest;
+using namespace opencv_test;
 
-namespace cvtest {
+namespace opencv_test {
 namespace ocl {
 
 PARAM_TEST_CASE(IPPAsync, MatDepth, Channels, hppAccelType)

--- a/modules/core/test/test_lpsolver.cpp
+++ b/modules/core/test/test_lpsolver.cpp
@@ -39,7 +39,8 @@
 //
 //M*/
 #include "test_precomp.hpp"
-#include <iostream>
+
+namespace opencv_test { namespace {
 
 TEST(Core_LPSolver, regression_basic){
     cv::Mat A,B,z,etalon_z;
@@ -139,3 +140,5 @@ TEST(Core_LPSolver, regression_cycling){
     //ASSERT_EQ(res,1);
 #endif
 }
+
+}} // namespace

--- a/modules/core/test/test_main.cpp
+++ b/modules/core/test/test_main.cpp
@@ -1,10 +1,6 @@
-#ifdef _MSC_VER
-# if _MSC_VER >= 1700
-#  pragma warning(disable:4447) // Disable warning 'main' signature found without threading model
-# endif
-#endif
-
-
+// This file is part of OpenCV project.
+// It is subject to the license terms in the LICENSE file found in the top-level directory
+// of this distribution and at http://opencv.org/license.html.
 #include "test_precomp.hpp"
 
 CV_TEST_MAIN("cv")

--- a/modules/core/test/test_mat.cpp
+++ b/modules/core/test/test_mat.cpp
@@ -1,10 +1,9 @@
+// This file is part of OpenCV project.
+// It is subject to the license terms in the LICENSE file found in the top-level directory
+// of this distribution and at http://opencv.org/license.html.
 #include "test_precomp.hpp"
 
-#include <map>
-
-using namespace cv;
-using namespace std;
-
+namespace opencv_test { namespace {
 
 class Core_ReduceTest : public cvtest::BaseTest
 {
@@ -770,8 +769,8 @@ void Core_ArrayOpTest::run( int /* start_from */)
         SparseMat M( dims, size, depth );
         map<string, double> M0;
 
-        int nz0 = (unsigned)rng % max(p/5,10);
-        nz0 = min(max(nz0, 1), p);
+        int nz0 = (unsigned)rng % std::max(p/5,10);
+        nz0 = std::min(std::max(nz0, 1), p);
         all_vals.resize(nz0);
         all_vals2.resize(nz0);
         Mat_<double> _all_vals(all_vals), _all_vals2(all_vals2);
@@ -791,9 +790,9 @@ void Core_ArrayOpTest::run( int /* start_from */)
         }
 
         minMaxLoc(_all_vals, &min_val, &max_val);
-        double _norm0 = cvtest::norm(_all_vals, CV_C);
-        double _norm1 = cvtest::norm(_all_vals, CV_L1);
-        double _norm2 = cvtest::norm(_all_vals, CV_L2);
+        double _norm0 = cv/*test*/::norm(_all_vals, CV_C);
+        double _norm1 = cv/*test*/::norm(_all_vals, CV_L1);
+        double _norm2 = cv/*test*/::norm(_all_vals, CV_L2);
 
         for( i = 0; i < nz0; i++ )
         {
@@ -828,9 +827,9 @@ void Core_ArrayOpTest::run( int /* start_from */)
         SparseMat M3; SparseMat(Md).convertTo(M3, Md.type(), 2);
 
         int nz1 = (int)M.nzcount(), nz2 = (int)M3.nzcount();
-        double norm0 = norm(M, CV_C);
-        double norm1 = norm(M, CV_L1);
-        double norm2 = norm(M, CV_L2);
+        double norm0 = cv/*test*/::norm(M, CV_C);
+        double norm1 = cv/*test*/::norm(M, CV_L1);
+        double norm2 = cv/*test*/::norm(M, CV_L2);
         double eps = depth == CV_32F ? FLT_EPSILON*100 : DBL_EPSILON*1000;
 
         if( nz1 != nz0 || nz2 != nz0)
@@ -851,8 +850,8 @@ void Core_ArrayOpTest::run( int /* start_from */)
             break;
         }
 
-        int n = (unsigned)rng % max(p/5,10);
-        n = min(max(n, 1), p) + nz0;
+        int n = (unsigned)rng % std::max(p/5,10);
+        n = std::min(std::max(n, 1), p) + nz0;
 
         for( i = 0; i < n; i++ )
         {
@@ -919,7 +918,7 @@ void Core_ArrayOpTest::run( int /* start_from */)
         int idx1[MAX_DIM], idx2[MAX_DIM];
         double val1 = 0, val2 = 0;
         M3 = SparseMat(Md);
-        minMaxLoc(M3, &val1, &val2, idx1, idx2);
+        cv::minMaxLoc(M3, &val1, &val2, idx1, idx2);
         string s1 = idx2string(idx1, dims), s2 = idx2string(idx2, dims);
         if( val1 != min_val || val2 != max_val || s1 != min_sidx || s2 != max_sidx )
         {
@@ -930,7 +929,7 @@ void Core_ArrayOpTest::run( int /* start_from */)
             break;
         }
 
-        minMaxIdx(Md, &val1, &val2, idx1, idx2);
+        cv::minMaxIdx(Md, &val1, &val2, idx1, idx2);
         s1 = idx2string(idx1, dims), s2 = idx2string(idx2, dims);
         if( (min_val < 0 && (val1 != min_val || s1 != min_sidx)) ||
            (max_val > 0 && (val2 != max_val || s2 != max_sidx)) )
@@ -1066,7 +1065,7 @@ protected:
         merge(src, dst);
 
         // check result
-        stringstream commonLog;
+        std::stringstream commonLog;
         commonLog << "Depth " << depth << " :";
         if(dst.depth() != depth)
         {
@@ -1115,7 +1114,7 @@ protected:
         split(src, dst);
 
         // check result
-        stringstream commonLog;
+        std::stringstream commonLog;
         commonLog << "Depth " << depth << " :";
         if(dst.size() != channels)
         {
@@ -1391,7 +1390,7 @@ TEST(Core_SVD, orthogonality)
         Mat mat_U, mat_W;
         SVD::compute(mat_D, mat_W, mat_U, noArray(), SVD::FULL_UV);
         mat_U *= mat_U.t();
-        ASSERT_LT(norm(mat_U, Mat::eye(2, 2, type), NORM_INF), 1e-5);
+        ASSERT_LT(cvtest::norm(mat_U, Mat::eye(2, 2, type), NORM_INF), 1e-5);
     }
 }
 
@@ -1713,7 +1712,7 @@ TEST(Mat_, range_based_for)
 
     Mat_<uchar> ref(3, 3);
     ref.setTo(Scalar(1));
-    ASSERT_DOUBLE_EQ(norm(img, ref), 0.);
+    ASSERT_DOUBLE_EQ(cvtest::norm(img, ref, NORM_INF), 0.);
 }
 
 TEST(Mat, from_initializer_list)
@@ -1722,7 +1721,7 @@ TEST(Mat, from_initializer_list)
     Mat_<float> B(3, 1); B << 1, 2, 3;
 
     ASSERT_EQ(A.type(), CV_32F);
-    ASSERT_DOUBLE_EQ(norm(A, B, NORM_INF), 0.);
+    ASSERT_DOUBLE_EQ(cvtest::norm(A, B, NORM_INF), 0.);
 }
 
 TEST(Mat_, from_initializer_list)
@@ -1730,7 +1729,7 @@ TEST(Mat_, from_initializer_list)
     Mat_<float> A = {1, 2, 3};
     Mat_<float> B(3, 1); B << 1, 2, 3;
 
-    ASSERT_DOUBLE_EQ(norm(A, B, NORM_INF), 0.);
+    ASSERT_DOUBLE_EQ(cvtest::norm(A, B, NORM_INF), 0.);
 }
 
 
@@ -1754,3 +1753,5 @@ TEST(Mat_, template_based_ptr)
 }
 
 #endif
+
+}} // namespace

--- a/modules/core/test/test_math.cpp
+++ b/modules/core/test/test_math.cpp
@@ -1,3 +1,7 @@
+// This file is part of OpenCV project.
+// It is subject to the license terms in the LICENSE file found in the top-level directory
+// of this distribution and at http://opencv.org/license.html.
+
 //////////////////////////////////////////////////////////////////////////////////////////
 /////////////////// tests for matrix operations and math functions ///////////////////////
 //////////////////////////////////////////////////////////////////////////////////////////
@@ -7,8 +11,7 @@
 #include <math.h>
 #include "opencv2/core/softfloat.hpp"
 
-using namespace cv;
-using namespace std;
+namespace opencv_test { namespace {
 
 /// !!! NOTE !!! These tests happily avoid overflow cases & out-of-range arguments
 /// so that output arrays contain neigher Inf's nor Nan's.
@@ -3079,7 +3082,7 @@ TEST(Core_Cholesky, accuracy64f)
    for (int i = 0; i < A.rows; i++)
        for (int j = i + 1; j < A.cols; j++)
            A.at<double>(i, j) = 0.0;
-   EXPECT_LE(norm(refA, A*A.t(), CV_RELATIVE_L2), FLT_EPSILON);
+   EXPECT_LE(cvtest::norm(refA, A*A.t(), CV_RELATIVE_L2), FLT_EPSILON);
 }
 
 TEST(Core_QR_Solver, accuracy64f)
@@ -3099,7 +3102,7 @@ TEST(Core_QR_Solver, accuracy64f)
 
     //solve system with square matrix
     solve(A, B, solutionQR, DECOMP_QR);
-    EXPECT_LE(norm(A*solutionQR, B, CV_RELATIVE_L2), FLT_EPSILON);
+    EXPECT_LE(cvtest::norm(A*solutionQR, B, CV_RELATIVE_L2), FLT_EPSILON);
 
     A = Mat(m, n, CV_64F);
     B = Mat(m, n, CV_64F);
@@ -3108,13 +3111,13 @@ TEST(Core_QR_Solver, accuracy64f)
 
     //solve normal system
     solve(A, B, solutionQR, DECOMP_QR | DECOMP_NORMAL);
-    EXPECT_LE(norm(A.t()*(A*solutionQR), A.t()*B, CV_RELATIVE_L2), FLT_EPSILON);
+    EXPECT_LE(cvtest::norm(A.t()*(A*solutionQR), A.t()*B, CV_RELATIVE_L2), FLT_EPSILON);
 
     //solve overdeterminated system as a least squares problem
     Mat solutionSVD;
     solve(A, B, solutionQR, DECOMP_QR);
     solve(A, B, solutionSVD, DECOMP_SVD);
-    EXPECT_LE(norm(solutionQR, solutionSVD, CV_RELATIVE_L2), FLT_EPSILON);
+    EXPECT_LE(cvtest::norm(solutionQR, solutionSVD, CV_RELATIVE_L2), FLT_EPSILON);
 
     //solve system with singular matrix
     A = Mat(10, 10, CV_64F);
@@ -3718,7 +3721,7 @@ TEST(Core_SoftFloat, sincos64)
         softdouble x = inputs[i];
 
         int xexp = x.getExp();
-        softdouble randEps = eps.setExp(max(xexp-52, -46));
+        softdouble randEps = eps.setExp(std::max(xexp-52, -46));
         softdouble sx = sin(x);
         softdouble cx = cos(x);
         ASSERT_FALSE(sx.isInf()); ASSERT_FALSE(cx.isInf());
@@ -3862,4 +3865,5 @@ TEST(Core_SoftFloat, CvRound)
     }
 }
 
+}} // namespace
 /* End of file. */

--- a/modules/core/test/test_misc.cpp
+++ b/modules/core/test/test_misc.cpp
@@ -1,7 +1,9 @@
+// This file is part of OpenCV project.
+// It is subject to the license terms in the LICENSE file found in the top-level directory
+// of this distribution and at http://opencv.org/license.html.
 #include "test_precomp.hpp"
 
-using namespace cv;
-using namespace std;
+namespace opencv_test { namespace {
 
 TEST(Core_OutputArrayCreate, _1997)
 {
@@ -154,3 +156,5 @@ TEST(Core_Copy, repeat_regression_8972)
                          repeat(src, 5, 1, src);
                      });
 }
+
+}} // namespace

--- a/modules/core/test/test_operations.cpp
+++ b/modules/core/test/test_operations.cpp
@@ -43,7 +43,7 @@
 #include "test_precomp.hpp"
 #include "opencv2/ts/ocl_test.hpp" // T-API like tests
 
-namespace cvtest {
+namespace opencv_test {
 namespace {
 
 class CV_OperationsTest : public cvtest::BaseTest
@@ -134,16 +134,16 @@ bool CV_OperationsTest::TestMat()
         res = Mat(Mat(2 * rot_2x3) * res - shi_2x1) + shift;
 
         Mat tmp, res2;
-        add(one_3x1, shi_3x1, tmp);
-        add(tmp, shi_3x1, tmp);
-        add(tmp, shi_3x1, tmp);
-        gemm(rot_2x3, tmp, 2, shi_2x1, -1, res2, 0);
-        add(res2, Mat(2, 1, CV_32F, shift), res2);
+        cv::add(one_3x1, shi_3x1, tmp);
+        cv::add(tmp, shi_3x1, tmp);
+        cv::add(tmp, shi_3x1, tmp);
+        cv::gemm(rot_2x3, tmp, 2, shi_2x1, -1, res2, 0);
+        cv::add(res2, Mat(2, 1, CV_32F, shift), res2);
 
         CHECK_DIFF(res, res2);
 
         Mat mat4x4(4, 4, CV_32F);
-        randu(mat4x4, Scalar(0), Scalar(10));
+        cv::randu(mat4x4, Scalar(0), Scalar(10));
 
         Mat roi1 = mat4x4(Rect(Point(1, 1), Size(2, 2)));
         Mat roi2 = mat4x4(Range(1, 3), Range(1, 3));
@@ -508,19 +508,19 @@ bool CV_OperationsTest::TestTemplateMat()
         Mat_<float> resS = rot_2x3 * one_3x1;
 
         Mat_<float> tmp, res2, resS2;
-        add(one_3x1, shi_3x1, tmp);
-        add(tmp, shi_3x1, tmp);
-        add(tmp, shi_3x1, tmp);
-        gemm(rot_2x3, tmp, 2, shi_2x1, -1, res2, 0);
-        add(res2, Mat(2, 1, CV_32F, shift), res2);
+        cv::add(one_3x1, shi_3x1, tmp);
+        cv::add(tmp, shi_3x1, tmp);
+        cv::add(tmp, shi_3x1, tmp);
+        cv::gemm(rot_2x3, tmp, 2, shi_2x1, -1, res2, 0);
+        cv::add(res2, Mat(2, 1, CV_32F, shift), res2);
 
-        gemm(rot_2x3, one_3x1, 1, shi_2x1, 0, resS2, 0);
+        cv::gemm(rot_2x3, one_3x1, 1, shi_2x1, 0, resS2, 0);
         CHECK_DIFF(res, res2);
         CHECK_DIFF(resS, resS2);
 
 
         Mat_<float> mat4x4(4, 4);
-        randu(mat4x4, Scalar(0), Scalar(10));
+        cv::randu(mat4x4, Scalar(0), Scalar(10));
 
         Mat_<float> roi1 = mat4x4(Rect(Point(1, 1), Size(2, 2)));
         Mat_<float> roi2 = mat4x4(Range(1, 3), Range(1, 3));
@@ -988,17 +988,17 @@ bool CV_OperationsTest::operations1()
         Mat A(1, 32, CV_32F), B;
         for( int i = 0; i < A.cols; i++ )
             A.at<float>(i) = (float)(i <= 12 ? i : 24 - i);
-        transpose(A, B);
+        cv::transpose(A, B);
 
         int minidx[2] = {0, 0}, maxidx[2] = {0, 0};
         double minval = 0, maxval = 0;
-        minMaxIdx(A, &minval, &maxval, minidx, maxidx);
+        cv::minMaxIdx(A, &minval, &maxval, minidx, maxidx);
 
         if( !(minidx[0] == 0 && minidx[1] == 31 && maxidx[0] == 0 && maxidx[1] == 12 &&
                   minval == -7 && maxval == 12))
             throw test_excep();
 
-        minMaxIdx(B, &minval, &maxval, minidx, maxidx);
+        cv::minMaxIdx(B, &minval, &maxval, minidx, maxidx);
 
         if( !(minidx[0] == 31 && minidx[1] == 0 && maxidx[0] == 12 && maxidx[1] == 0 &&
               minval == -7 && maxval == 12))
@@ -1006,13 +1006,13 @@ bool CV_OperationsTest::operations1()
 
         Matx33f b(1.f, 2.f, 3.f, 4.f, 5.f, 6.f, 7.f, 8.f, 9.f);
         Mat c;
-        add(Mat::zeros(3, 3, CV_32F), b, c);
+        cv::add(Mat::zeros(3, 3, CV_32F), b, c);
         CV_Assert( cvtest::norm(b, c, CV_C) == 0 );
 
-        add(Mat::zeros(3, 3, CV_64F), b, c, noArray(), c.type());
+        cv::add(Mat::zeros(3, 3, CV_64F), b, c, noArray(), c.type());
         CV_Assert( cvtest::norm(b, c, CV_C) == 0 );
 
-        add(Mat::zeros(6, 1, CV_64F), 1, c, noArray(), c.type());
+        cv::add(Mat::zeros(6, 1, CV_64F), 1, c, noArray(), c.type());
         CV_Assert( cvtest::norm(Matx61f(1.f, 1.f, 1.f, 1.f, 1.f, 1.f), c, CV_C) == 0 );
 
         vector<Point2f> pt2d(3);
@@ -1025,7 +1025,7 @@ bool CV_OperationsTest::operations1()
                 0.9058f, 0.0975f, 0.9649f, 0.4854f,
                 0.1270f, 0.2785f, 0.1576f, 0.8003f,
                 0.9134f, 0.5469f, 0.9706f, 0.1419f);
-        double d = determinant(m44);
+        double d = cv::determinant(m44);
         CV_Assert( fabs(d - (-0.0262)) <= 0.001 );
 
         Cv32suf z;

--- a/modules/core/test/test_precomp.hpp
+++ b/modules/core/test/test_precomp.hpp
@@ -1,15 +1,9 @@
-#ifdef __GNUC__
-#  pragma GCC diagnostic ignored "-Wmissing-declarations"
-#  if defined __clang__ || defined __APPLE__
-#    pragma GCC diagnostic ignored "-Wmissing-prototypes"
-#    pragma GCC diagnostic ignored "-Wextra"
-#  endif
-#endif
-
+// This file is part of OpenCV project.
+// It is subject to the license terms in the LICENSE file found in the top-level directory
+// of this distribution and at http://opencv.org/license.html.
 #ifndef __OPENCV_TEST_PRECOMP_HPP__
 #define __OPENCV_TEST_PRECOMP_HPP__
 
-#include <iostream>
 #include "opencv2/ts.hpp"
 #include "opencv2/ts/ocl_test.hpp"
 #include "opencv2/core/core_c.h"

--- a/modules/core/test/test_ptr.cpp
+++ b/modules/core/test/test_ptr.cpp
@@ -41,6 +41,8 @@
 
 #include "test_precomp.hpp"
 
+namespace opencv_test { namespace {
+
 #ifdef GTEST_CAN_COMPARE_NULL
 #  define EXPECT_NULL(ptr) EXPECT_EQ(NULL, ptr)
 #else
@@ -366,6 +368,8 @@ TEST(Core_Ptr, make)
     EXPECT_TRUE(deleted);
 }
 
+}} // namespace
+
 namespace {
 
 struct SpeciallyDeletable
@@ -385,6 +389,8 @@ void DefaultDeleter<SpeciallyDeletable>::operator()(SpeciallyDeletable * obj) co
 
 }
 
+namespace opencv_test { namespace {
+
 TEST(Core_Ptr, specialized_deleter)
 {
     SpeciallyDeletable sd;
@@ -393,3 +399,5 @@ TEST(Core_Ptr, specialized_deleter)
 
     ASSERT_TRUE(sd.deleted);
 }
+
+}} // namespace

--- a/modules/core/test/test_rand.cpp
+++ b/modules/core/test/test_rand.cpp
@@ -1,7 +1,9 @@
+// This file is part of OpenCV project.
+// It is subject to the license terms in the LICENSE file found in the top-level directory
+// of this distribution and at http://opencv.org/license.html.
 #include "test_precomp.hpp"
 
-using namespace cv;
-using namespace std;
+namespace opencv_test { namespace {
 
 class Core_RandTest : public cvtest::BaseTest
 {
@@ -383,7 +385,6 @@ TEST(Core_Rand, Regression_Stack_Corruption)
     ASSERT_EQ(param2,  2);
 }
 
-namespace {
 
 class RandRowFillParallelLoopBody : public cv::ParallelLoopBody
 {
@@ -417,4 +418,4 @@ TEST(Core_Rand, parallel_for_stable_results)
     ASSERT_EQ(0, countNonZero(dst1 != dst2));
 }
 
-} // namespace
+}} // namespace

--- a/modules/core/test/test_rotatedrect.cpp
+++ b/modules/core/test/test_rotatedrect.cpp
@@ -41,8 +41,7 @@
 
 #include "test_precomp.hpp"
 
-using namespace cv;
-using namespace std;
+namespace opencv_test { namespace {
 
 class Core_RotatedRectConstructorTest : public cvtest::BaseTest
 {
@@ -72,7 +71,7 @@ int Core_RotatedRectConstructorTest::prepare_test_case( int test_case_idx )
     {
         b = Point2f( rng.uniform(-MAX_COORD_VAL, MAX_COORD_VAL), rng.uniform(-MAX_COORD_VAL, MAX_COORD_VAL) );
     }
-    while( norm(a - b) <= FLT_EPSILON );
+    while( cv::norm(a - b) <= FLT_EPSILON );
     Vec2f along(a - b);
     Vec2f perp = Vec2f(-along[1], along[0]);
     double d = (double) rng.uniform(1.0f, 5.0f);
@@ -93,9 +92,9 @@ int Core_RotatedRectConstructorTest::validate_test_results( int )
     int count_match = 0;
     for( int i = 0; i < 4; i++ )
     {
-        if( norm(vertices[i] - a) <= 0.001 ) count_match++;
-        else if( norm(vertices[i] - b) <= 0.001 ) count_match++;
-        else if( norm(vertices[i] - c) <= 0.001 ) count_match++;
+        if( cv::norm(vertices[i] - a) <= 0.001 ) count_match++;
+        else if( cv::norm(vertices[i] - b) <= 0.001 ) count_match++;
+        else if( cv::norm(vertices[i] - c) <= 0.001 ) count_match++;
     }
     if( count_match == 3 )
         return cvtest::TS::OK;
@@ -105,3 +104,5 @@ int Core_RotatedRectConstructorTest::validate_test_results( int )
 }
 
 TEST(Core_RotatedRect, three_point_constructor) { Core_RotatedRectConstructorTest test; test.safe_run(); }
+
+}} // namespace

--- a/modules/core/test/test_umat.cpp
+++ b/modules/core/test/test_umat.cpp
@@ -42,11 +42,11 @@
 #include "test_precomp.hpp"
 #include "opencv2/ts/ocl_test.hpp"
 
-using namespace cvtest;
+using namespace opencv_test;
 using namespace testing;
 using namespace cv;
 
-namespace cvtest {
+namespace opencv_test {
 namespace ocl {
 
 #define UMAT_TEST_SIZES testing::Values(cv::Size(1, 1), cv::Size(1,128), cv::Size(128, 1), \
@@ -1073,7 +1073,7 @@ TEST(UMat, async_unmap)
             Mat m = Mat(1000, 1000, CV_8UC1, Scalar::all(0));
             UMat u = m.getUMat(ACCESS_READ);
             UMat dst;
-            add(u, Scalar::all(0), dst); // start async operation
+            cv::add(u, Scalar::all(0), dst); // start async operation
             u.release();
             m.release();
         }
@@ -1233,7 +1233,7 @@ TEST(UMat, DISABLED_Test_same_behaviour_read_and_read)
         UMat u(Size(10, 10), CV_8UC1, Scalar::all(0));
         Mat m = u.getMat(ACCESS_READ);
         UMat dst;
-        add(u, Scalar::all(1), dst);
+        cv::add(u, Scalar::all(1), dst);
     }
     catch (...)
     {
@@ -1250,7 +1250,7 @@ TEST(UMat, DISABLED_Test_same_behaviour_read_and_write)
     {
         UMat u(Size(10, 10), CV_8UC1, Scalar::all(0));
         Mat m = u.getMat(ACCESS_READ);
-        add(u, Scalar::all(1), u);
+        cv::add(u, Scalar::all(1), u);
     }
     catch (...)
     {
@@ -1267,7 +1267,7 @@ TEST(UMat, DISABLED_Test_same_behaviour_write_and_read)
         UMat u(Size(10, 10), CV_8UC1, Scalar::all(0));
         Mat m = u.getMat(ACCESS_WRITE);
         UMat dst;
-        add(u, Scalar::all(1), dst);
+        cv::add(u, Scalar::all(1), dst);
     }
     catch (...)
     {
@@ -1283,7 +1283,7 @@ TEST(UMat, DISABLED_Test_same_behaviour_write_and_write)
     {
         UMat u(Size(10, 10), CV_8UC1, Scalar::all(0));
         Mat m = u.getMat(ACCESS_WRITE);
-        add(u, Scalar::all(1), u);
+        cv::add(u, Scalar::all(1), u);
     }
     catch (...)
     {
@@ -1301,7 +1301,7 @@ TEST(UMat, mat_umat_sync)
     }
 
     UMat uDiff;
-    compare(u, 255, uDiff, CMP_NE);
+    cv::compare(u, 255, uDiff, CMP_NE);
     ASSERT_EQ(0, countNonZero(uDiff));
 }
 
@@ -1314,7 +1314,7 @@ TEST(UMat, testTempObjects_UMat)
     }
 
     UMat uDiff;
-    compare(u, 255, uDiff, CMP_NE);
+    cv::compare(u, 255, uDiff, CMP_NE);
     ASSERT_EQ(0, countNonZero(uDiff));
 }
 
@@ -1383,4 +1383,4 @@ TEST(UMat, testTempObjects_Mat_issue_8693)
     EXPECT_EQ(0, cvtest::norm(srcUMat.getMat(ACCESS_READ), srcMat, NORM_INF));
 }
 
-} } // namespace cvtest::ocl
+} } // namespace opencv_test::ocl

--- a/modules/core/test/test_utils.cpp
+++ b/modules/core/test/test_utils.cpp
@@ -1,12 +1,9 @@
 // This file is part of OpenCV project.
 // It is subject to the license terms in the LICENSE file found in the top-level directory
 // of this distribution and at http://opencv.org/license.html.
-
 #include "test_precomp.hpp"
 
-using namespace cv;
-
-namespace {
+namespace opencv_test { namespace {
 
 static const char * const keys =
     "{ h help    |       | print help }"
@@ -264,4 +261,4 @@ TEST(AutoBuffer, allocate_test)
     EXPECT_EQ(6u, abuf.size());
 }
 
-} // namespace
+}} // namespace

--- a/modules/cudaarithm/perf/perf_arithm.cpp
+++ b/modules/cudaarithm/perf/perf_arithm.cpp
@@ -42,11 +42,7 @@
 
 #include "perf_precomp.hpp"
 
-using namespace std;
-using namespace testing;
-using namespace perf;
-
-namespace { // workaround conflict with DftFlags
+namespace opencv_test { namespace {
 
 //////////////////////////////////////////////////////////////////////
 // GEMM
@@ -255,4 +251,4 @@ PERF_TEST_P(Sz_KernelSz_Ccorr, Convolve,
     }
 }
 
-} // namespace
+}} // namespace

--- a/modules/cudaarithm/perf/perf_core.cpp
+++ b/modules/cudaarithm/perf/perf_core.cpp
@@ -42,9 +42,7 @@
 
 #include "perf_precomp.hpp"
 
-using namespace std;
-using namespace testing;
-using namespace perf;
+namespace opencv_test { namespace {
 
 #define ARITHM_MAT_DEPTH Values(CV_8U, CV_16U, CV_32F, CV_64F)
 
@@ -321,3 +319,5 @@ PERF_TEST_P(Sz_Depth_Cn_Border, CopyMakeBorder,
         CPU_SANITY_CHECK(dst);
     }
 }
+
+}} // namespace

--- a/modules/cudaarithm/perf/perf_element_operations.cpp
+++ b/modules/cudaarithm/perf/perf_element_operations.cpp
@@ -42,9 +42,7 @@
 
 #include "perf_precomp.hpp"
 
-using namespace std;
-using namespace testing;
-using namespace perf;
+namespace opencv_test { namespace {
 
 #define ARITHM_MAT_DEPTH Values(CV_8U, CV_16U, CV_32F, CV_64F)
 
@@ -1499,3 +1497,5 @@ PERF_TEST_P(Sz_Depth_Op, Threshold,
         CPU_SANITY_CHECK(dst);
     }
 }
+
+}} // namespace

--- a/modules/cudaarithm/perf/perf_precomp.hpp
+++ b/modules/cudaarithm/perf/perf_precomp.hpp
@@ -39,15 +39,6 @@
 // the use of this software, even if advised of the possibility of such damage.
 //
 //M*/
-
-#ifdef __GNUC__
-#  pragma GCC diagnostic ignored "-Wmissing-declarations"
-#  if defined __clang__ || defined __APPLE__
-#    pragma GCC diagnostic ignored "-Wmissing-prototypes"
-#    pragma GCC diagnostic ignored "-Wextra"
-#  endif
-#endif
-
 #ifndef __OPENCV_PERF_PRECOMP_HPP__
 #define __OPENCV_PERF_PRECOMP_HPP__
 
@@ -55,11 +46,10 @@
 #include "opencv2/ts/cuda_perf.hpp"
 
 #include "opencv2/cudaarithm.hpp"
-#include "opencv2/core.hpp"
-#include "opencv2/imgproc.hpp"
 
-#ifdef GTEST_CREATE_SHARED_LIBRARY
-#error no modules except ts should have GTEST_CREATE_SHARED_LIBRARY defined
-#endif
+namespace opencv_test {
+using namespace perf;
+using namespace testing;
+}
 
 #endif

--- a/modules/cudaarithm/perf/perf_reductions.cpp
+++ b/modules/cudaarithm/perf/perf_reductions.cpp
@@ -42,9 +42,7 @@
 
 #include "perf_precomp.hpp"
 
-using namespace std;
-using namespace testing;
-using namespace perf;
+namespace opencv_test { namespace {
 
 //////////////////////////////////////////////////////////////////////
 // Norm
@@ -518,3 +516,5 @@ PERF_TEST_P(Sz, IntegralSqr,
         FAIL_NO_CPU();
     }
 }
+
+}} // namespace

--- a/modules/cudaarithm/test/test_arithm.cpp
+++ b/modules/cudaarithm/test/test_arithm.cpp
@@ -44,9 +44,7 @@
 
 #ifdef HAVE_CUDA
 
-using namespace cvtest;
-
-namespace {
+namespace opencv_test { namespace {
 
 //////////////////////////////////////////////////////////////////////////////
 // GEMM
@@ -430,6 +428,6 @@ INSTANTIATE_TEST_CASE_P(CUDA_Arithm, Convolve, testing::Combine(
 
 #endif // HAVE_CUBLAS
 
-} // namespace
+}} // namespace
 
 #endif // HAVE_CUDA

--- a/modules/cudaarithm/test/test_buffer_pool.cpp
+++ b/modules/cudaarithm/test/test_buffer_pool.cpp
@@ -48,9 +48,7 @@
 #include "opencv2/core/private.cuda.hpp"
 #include "opencv2/ts/cuda_test.hpp"
 
-using namespace testing;
-using namespace cv;
-using namespace cv::cuda;
+namespace opencv_test { namespace {
 
 struct BufferPoolTest : TestWithParam<DeviceInfo>
 {
@@ -116,4 +114,5 @@ CUDA_TEST_P(BufferPoolTest, From2Streams)
 
 INSTANTIATE_TEST_CASE_P(CUDA_Stream, BufferPoolTest, ALL_DEVICES);
 
+}} // namespace
 #endif // HAVE_CUDA

--- a/modules/cudaarithm/test/test_core.cpp
+++ b/modules/cudaarithm/test/test_core.cpp
@@ -44,9 +44,7 @@
 
 #ifdef HAVE_CUDA
 
-using namespace cvtest;
-
-namespace {
+namespace opencv_test { namespace {
 
 ////////////////////////////////////////////////////////////////////////////////
 // Merge
@@ -418,6 +416,6 @@ INSTANTIATE_TEST_CASE_P(CUDA_Arithm, CopyMakeBorder, testing::Combine(
     ALL_BORDER_TYPES,
     WHOLE_SUBMAT));
 
-} //namespace
 
+}} // namespace
 #endif // HAVE_CUDA

--- a/modules/cudaarithm/test/test_element_operations.cpp
+++ b/modules/cudaarithm/test/test_element_operations.cpp
@@ -44,7 +44,7 @@
 
 #ifdef HAVE_CUDA
 
-using namespace cvtest;
+namespace opencv_test { namespace {
 
 ////////////////////////////////////////////////////////////////////////////////
 // Add_Array
@@ -2795,4 +2795,5 @@ INSTANTIATE_TEST_CASE_P(CUDA_Arithm, PolarToCart, testing::Combine(
     testing::Values(AngleInDegrees(false), AngleInDegrees(true)),
     WHOLE_SUBMAT));
 
+}} // namespace
 #endif // HAVE_CUDA

--- a/modules/cudaarithm/test/test_gpumat.cpp
+++ b/modules/cudaarithm/test/test_gpumat.cpp
@@ -47,7 +47,7 @@
 #include "opencv2/core/cuda.hpp"
 #include "opencv2/ts/cuda_test.hpp"
 
-using namespace cvtest;
+namespace opencv_test { namespace {
 
 ////////////////////////////////////////////////////////////////////////////////
 // SetTo
@@ -408,4 +408,5 @@ CUDA_TEST_P(CreateContinuous, BufferReuse)
 
 INSTANTIATE_TEST_CASE_P(CUDA, CreateContinuous, ALL_DEVICES);
 
+}} // namespace
 #endif // HAVE_CUDA

--- a/modules/cudaarithm/test/test_opengl.cpp
+++ b/modules/cudaarithm/test/test_opengl.cpp
@@ -48,7 +48,7 @@
 #include "opencv2/core/opengl.hpp"
 #include "opencv2/ts/cuda_test.hpp"
 
-using namespace cvtest;
+namespace opencv_test { namespace {
 
 /////////////////////////////////////////////
 // Buffer
@@ -453,4 +453,5 @@ CUDA_TEST_P(Texture2D, CopyToBuffer)
 
 INSTANTIATE_TEST_CASE_P(OpenGL, Texture2D, testing::Combine(DIFFERENT_SIZES, testing::Values(CV_8UC1, CV_8UC3, CV_8UC4, CV_32FC1, CV_32FC3, CV_32FC4)));
 
+}} // namespace
 #endif

--- a/modules/cudaarithm/test/test_precomp.hpp
+++ b/modules/cudaarithm/test/test_precomp.hpp
@@ -39,27 +39,18 @@
 // the use of this software, even if advised of the possibility of such damage.
 //
 //M*/
-
-#ifdef __GNUC__
-#  pragma GCC diagnostic ignored "-Wmissing-declarations"
-#  if defined __clang__ || defined __APPLE__
-#    pragma GCC diagnostic ignored "-Wmissing-prototypes"
-#    pragma GCC diagnostic ignored "-Wextra"
-#  endif
-#endif
-
 #ifndef __OPENCV_TEST_PRECOMP_HPP__
 #define __OPENCV_TEST_PRECOMP_HPP__
-
-#include <functional>
 
 #include "opencv2/ts.hpp"
 #include "opencv2/ts/cuda_test.hpp"
 
 #include "opencv2/cudaarithm.hpp"
-#include "opencv2/core.hpp"
-#include "opencv2/imgproc.hpp"
 
 #include "cvconfig.h"
+
+namespace opencv_test {
+using namespace cv::cuda;
+}
 
 #endif

--- a/modules/cudaarithm/test/test_reductions.cpp
+++ b/modules/cudaarithm/test/test_reductions.cpp
@@ -44,7 +44,7 @@
 
 #ifdef HAVE_CUDA
 
-using namespace cvtest;
+namespace opencv_test { namespace {
 
 ////////////////////////////////////////////////////////////////////////////////
 // Norm
@@ -1116,4 +1116,6 @@ INSTANTIATE_TEST_CASE_P(CUDA_Arithm, IntegralSqr, testing::Combine(
     DIFFERENT_SIZES,
     WHOLE_SUBMAT));
 
+
+}} // namespace
 #endif // HAVE_CUDA

--- a/modules/cudaarithm/test/test_stream.cpp
+++ b/modules/cudaarithm/test/test_stream.cpp
@@ -50,7 +50,7 @@
 #include "opencv2/core/cuda_stream_accessor.hpp"
 #include "opencv2/ts/cuda_test.hpp"
 
-using namespace cvtest;
+namespace opencv_test { namespace {
 
 struct Async : testing::TestWithParam<cv::cuda::DeviceInfo>
 {
@@ -172,4 +172,5 @@ CUDA_TEST_P(Async, HostMemAllocator)
 
 INSTANTIATE_TEST_CASE_P(CUDA_Stream, Async, ALL_DEVICES);
 
+}} // namespace
 #endif // HAVE_CUDA

--- a/modules/cudabgsegm/perf/perf_bgsegm.cpp
+++ b/modules/cudabgsegm/perf/perf_bgsegm.cpp
@@ -42,9 +42,7 @@
 
 #include "perf_precomp.hpp"
 
-using namespace std;
-using namespace testing;
-using namespace perf;
+namespace opencv_test { namespace {
 
 //////////////////////////////////////////////////////
 // MOG
@@ -390,3 +388,5 @@ PERF_TEST_P(Video_Cn, MOG2GetBackgroundImage,
 }
 
 #endif
+
+}} // namespace

--- a/modules/cudabgsegm/perf/perf_precomp.hpp
+++ b/modules/cudabgsegm/perf/perf_precomp.hpp
@@ -39,15 +39,6 @@
 // the use of this software, even if advised of the possibility of such damage.
 //
 //M*/
-
-#ifdef __GNUC__
-#  pragma GCC diagnostic ignored "-Wmissing-declarations"
-#  if defined __clang__ || defined __APPLE__
-#    pragma GCC diagnostic ignored "-Wmissing-prototypes"
-#    pragma GCC diagnostic ignored "-Wextra"
-#  endif
-#endif
-
 #ifndef OPENCV_PERF_PRECOMP_HPP
 #define OPENCV_PERF_PRECOMP_HPP
 
@@ -57,10 +48,8 @@
 #include "opencv2/cudabgsegm.hpp"
 #include "opencv2/video.hpp"
 
-#include "opencv2/opencv_modules.hpp"
-
-#ifdef GTEST_CREATE_SHARED_LIBRARY
-#error no modules except ts should have GTEST_CREATE_SHARED_LIBRARY defined
-#endif
+namespace opencv_test {
+using namespace perf;
+}
 
 #endif

--- a/modules/cudabgsegm/test/test_bgsegm.cpp
+++ b/modules/cudabgsegm/test/test_bgsegm.cpp
@@ -44,7 +44,7 @@
 
 #ifdef HAVE_CUDA
 
-using namespace cvtest;
+namespace opencv_test { namespace {
 
 //////////////////////////////////////////////////////
 // MOG2
@@ -167,4 +167,5 @@ INSTANTIATE_TEST_CASE_P(CUDA_BgSegm, MOG2, testing::Combine(
 
 #endif
 
+}} // namespace
 #endif // HAVE_CUDA

--- a/modules/cudabgsegm/test/test_precomp.hpp
+++ b/modules/cudabgsegm/test/test_precomp.hpp
@@ -39,19 +39,8 @@
 // the use of this software, even if advised of the possibility of such damage.
 //
 //M*/
-
-#ifdef __GNUC__
-#  pragma GCC diagnostic ignored "-Wmissing-declarations"
-#  if defined __clang__ || defined __APPLE__
-#    pragma GCC diagnostic ignored "-Wmissing-prototypes"
-#    pragma GCC diagnostic ignored "-Wextra"
-#  endif
-#endif
-
 #ifndef OPENCV_TEST_PRECOMP_HPP
 #define OPENCV_TEST_PRECOMP_HPP
-
-#include <fstream>
 
 #include "opencv2/ts.hpp"
 #include "opencv2/ts/cuda_test.hpp"

--- a/modules/cudacodec/perf/perf_precomp.hpp
+++ b/modules/cudacodec/perf/perf_precomp.hpp
@@ -39,15 +39,6 @@
 // the use of this software, even if advised of the possibility of such damage.
 //
 //M*/
-
-#ifdef __GNUC__
-#  pragma GCC diagnostic ignored "-Wmissing-declarations"
-#  if defined __clang__ || defined __APPLE__
-#    pragma GCC diagnostic ignored "-Wmissing-prototypes"
-#    pragma GCC diagnostic ignored "-Wextra"
-#  endif
-#endif
-
 #ifndef OPENCV_PERF_PRECOMP_HPP
 #define OPENCV_PERF_PRECOMP_HPP
 
@@ -55,10 +46,9 @@
 #include "opencv2/ts/cuda_perf.hpp"
 
 #include "opencv2/cudacodec.hpp"
-#include "opencv2/highgui.hpp"
 
-#ifdef GTEST_CREATE_SHARED_LIBRARY
-#error no modules except ts should have GTEST_CREATE_SHARED_LIBRARY defined
-#endif
+namespace opencv_test {
+using namespace perf;
+}
 
 #endif

--- a/modules/cudacodec/perf/perf_video.cpp
+++ b/modules/cudacodec/perf/perf_video.cpp
@@ -43,9 +43,7 @@
 #include "perf_precomp.hpp"
 #include "opencv2/highgui/highgui_c.h"
 
-using namespace std;
-using namespace testing;
-using namespace perf;
+namespace opencv_test { namespace {
 
 DEF_PARAM_TEST_1(FileName, string);
 
@@ -147,3 +145,4 @@ PERF_TEST_P(FileName, VideoWriter, Values("gpu/video/768x576.avi", "gpu/video/19
 }
 
 #endif
+}} // namespace

--- a/modules/cudacodec/test/test_precomp.hpp
+++ b/modules/cudacodec/test/test_precomp.hpp
@@ -39,15 +39,6 @@
 // the use of this software, even if advised of the possibility of such damage.
 //
 //M*/
-
-#ifdef __GNUC__
-#  pragma GCC diagnostic ignored "-Wmissing-declarations"
-#  if defined __clang__ || defined __APPLE__
-#    pragma GCC diagnostic ignored "-Wmissing-prototypes"
-#    pragma GCC diagnostic ignored "-Wextra"
-#  endif
-#endif
-
 #ifndef OPENCV_TEST_PRECOMP_HPP
 #define OPENCV_TEST_PRECOMP_HPP
 
@@ -55,7 +46,6 @@
 #include "opencv2/ts/cuda_test.hpp"
 
 #include "opencv2/cudacodec.hpp"
-#include "opencv2/highgui.hpp"
 
 #include "cvconfig.h"
 

--- a/modules/cudacodec/test/test_video.cpp
+++ b/modules/cudacodec/test/test_video.cpp
@@ -42,6 +42,8 @@
 
 #include "test_precomp.hpp"
 
+namespace opencv_test { namespace {
+
 #ifdef HAVE_NVCUVID
 
 PARAM_TEST_CASE(Video, cv::cuda::DeviceInfo, std::string)
@@ -123,3 +125,4 @@ INSTANTIATE_TEST_CASE_P(CUDA_Codec, Video, testing::Combine(
     testing::Values(std::string("768x576.avi"), std::string("1920x1080.avi"))));
 
 #endif // HAVE_NVCUVID
+}} // namespace

--- a/modules/cudafeatures2d/perf/perf_features2d.cpp
+++ b/modules/cudafeatures2d/perf/perf_features2d.cpp
@@ -42,9 +42,7 @@
 
 #include "perf_precomp.hpp"
 
-using namespace std;
-using namespace testing;
-using namespace perf;
+namespace opencv_test { namespace {
 
 //////////////////////////////////////////////////////////////////////
 // FAST
@@ -310,3 +308,5 @@ PERF_TEST_P(DescSize_Norm, BFRadiusMatch,
         SANITY_CHECK_MATCHES(cpu_matches);
     }
 }
+
+}} // namespace

--- a/modules/cudafeatures2d/perf/perf_precomp.hpp
+++ b/modules/cudafeatures2d/perf/perf_precomp.hpp
@@ -39,15 +39,6 @@
 // the use of this software, even if advised of the possibility of such damage.
 //
 //M*/
-
-#ifdef __GNUC__
-#  pragma GCC diagnostic ignored "-Wmissing-declarations"
-#  if defined __clang__ || defined __APPLE__
-#    pragma GCC diagnostic ignored "-Wmissing-prototypes"
-#    pragma GCC diagnostic ignored "-Wextra"
-#  endif
-#endif
-
 #ifndef __OPENCV_PERF_PRECOMP_HPP__
 #define __OPENCV_PERF_PRECOMP_HPP__
 
@@ -57,8 +48,9 @@
 #include "opencv2/cudafeatures2d.hpp"
 #include "opencv2/features2d.hpp"
 
-#ifdef GTEST_CREATE_SHARED_LIBRARY
-#error no modules except ts should have GTEST_CREATE_SHARED_LIBRARY defined
-#endif
+namespace opencv_test {
+using namespace perf;
+using namespace testing;
+}
 
 #endif

--- a/modules/cudafeatures2d/test/test_features2d.cpp
+++ b/modules/cudafeatures2d/test/test_features2d.cpp
@@ -44,7 +44,7 @@
 
 #ifdef HAVE_CUDA
 
-using namespace cvtest;
+namespace opencv_test { namespace {
 
 /////////////////////////////////////////////////////////////////////////////////////////////////
 // FAST
@@ -54,8 +54,6 @@ namespace
     IMPLEMENT_PARAM_CLASS(FAST_Threshold, int)
     IMPLEMENT_PARAM_CLASS(FAST_NonmaxSuppression, bool)
 }
-
-namespace {
 
 PARAM_TEST_CASE(FAST, cv::cuda::DeviceInfo, FAST_Threshold, FAST_NonmaxSuppression)
 {
@@ -710,6 +708,5 @@ INSTANTIATE_TEST_CASE_P(CUDA_Features2D, BruteForceMatcher, testing::Combine(
     testing::Values(DescriptorSize(57), DescriptorSize(64), DescriptorSize(83), DescriptorSize(128), DescriptorSize(179), DescriptorSize(256), DescriptorSize(304)),
     testing::Values(UseMask(false), UseMask(true))));
 
-} // namespace
-
+}} // namespace
 #endif // HAVE_CUDA

--- a/modules/cudafeatures2d/test/test_precomp.hpp
+++ b/modules/cudafeatures2d/test/test_precomp.hpp
@@ -39,15 +39,6 @@
 // the use of this software, even if advised of the possibility of such damage.
 //
 //M*/
-
-#ifdef __GNUC__
-#  pragma GCC diagnostic ignored "-Wmissing-declarations"
-#  if defined __clang__ || defined __APPLE__
-#    pragma GCC diagnostic ignored "-Wmissing-prototypes"
-#    pragma GCC diagnostic ignored "-Wextra"
-#  endif
-#endif
-
 #ifndef __OPENCV_TEST_PRECOMP_HPP__
 #define __OPENCV_TEST_PRECOMP_HPP__
 

--- a/modules/cudafilters/perf/perf_filters.cpp
+++ b/modules/cudafilters/perf/perf_filters.cpp
@@ -42,9 +42,7 @@
 
 #include "perf_precomp.hpp"
 
-using namespace std;
-using namespace testing;
-using namespace perf;
+namespace opencv_test { namespace {
 
 //////////////////////////////////////////////////////////////////////
 // Blur
@@ -415,3 +413,5 @@ PERF_TEST_P(Sz_KernelSz, Median, Combine(CUDA_TYPICAL_MAT_SIZES, Values(3, 5, 7,
         SANITY_CHECK_NOTHING();
     }
 }
+
+}} // namespace

--- a/modules/cudafilters/perf/perf_precomp.hpp
+++ b/modules/cudafilters/perf/perf_precomp.hpp
@@ -40,14 +40,6 @@
 //
 //M*/
 
-#ifdef __GNUC__
-#  pragma GCC diagnostic ignored "-Wmissing-declarations"
-#  if defined __clang__ || defined __APPLE__
-#    pragma GCC diagnostic ignored "-Wmissing-prototypes"
-#    pragma GCC diagnostic ignored "-Wextra"
-#  endif
-#endif
-
 #ifndef __OPENCV_PERF_PRECOMP_HPP__
 #define __OPENCV_PERF_PRECOMP_HPP__
 
@@ -55,10 +47,9 @@
 #include "opencv2/ts/cuda_perf.hpp"
 
 #include "opencv2/cudafilters.hpp"
-#include "opencv2/imgproc.hpp"
 
-#ifdef GTEST_CREATE_SHARED_LIBRARY
-#error no modules except ts should have GTEST_CREATE_SHARED_LIBRARY defined
-#endif
+namespace opencv_test {
+using namespace perf;
+}
 
 #endif

--- a/modules/cudafilters/test/test_filters.cpp
+++ b/modules/cudafilters/test/test_filters.cpp
@@ -44,7 +44,7 @@
 
 #ifdef HAVE_CUDA
 
-using namespace cvtest;
+namespace opencv_test { namespace {
 
 namespace
 {
@@ -62,8 +62,6 @@ namespace
         return m(roi);
     }
 }
-
-namespace {
 
 /////////////////////////////////////////////////////////////////////////////////////////////////
 // Blur
@@ -705,6 +703,6 @@ INSTANTIATE_TEST_CASE_P(CUDA_Filters, Median, testing::Combine(
     WHOLE_SUBMAT)
     );
 
-} //namespace
+}} // namespace
 
 #endif // HAVE_CUDA

--- a/modules/cudafilters/test/test_precomp.hpp
+++ b/modules/cudafilters/test/test_precomp.hpp
@@ -39,15 +39,6 @@
 // the use of this software, even if advised of the possibility of such damage.
 //
 //M*/
-
-#ifdef __GNUC__
-#  pragma GCC diagnostic ignored "-Wmissing-declarations"
-#  if defined __clang__ || defined __APPLE__
-#    pragma GCC diagnostic ignored "-Wmissing-prototypes"
-#    pragma GCC diagnostic ignored "-Wextra"
-#  endif
-#endif
-
 #ifndef __OPENCV_TEST_PRECOMP_HPP__
 #define __OPENCV_TEST_PRECOMP_HPP__
 
@@ -55,7 +46,6 @@
 #include "opencv2/ts/cuda_test.hpp"
 
 #include "opencv2/cudafilters.hpp"
-#include "opencv2/imgproc.hpp"
 
 #include "cvconfig.h"
 

--- a/modules/cudaimgproc/perf/perf_bilateral_filter.cpp
+++ b/modules/cudaimgproc/perf/perf_bilateral_filter.cpp
@@ -42,9 +42,7 @@
 
 #include "perf_precomp.hpp"
 
-using namespace std;
-using namespace testing;
-using namespace perf;
+namespace opencv_test { namespace {
 
 //////////////////////////////////////////////////////////////////////
 // BilateralFilter
@@ -91,3 +89,5 @@ PERF_TEST_P(Sz_Depth_Cn_KernelSz, BilateralFilter,
         CPU_SANITY_CHECK(dst);
     }
 }
+
+}} // namespace

--- a/modules/cudaimgproc/perf/perf_blend.cpp
+++ b/modules/cudaimgproc/perf/perf_blend.cpp
@@ -42,9 +42,7 @@
 
 #include "perf_precomp.hpp"
 
-using namespace std;
-using namespace testing;
-using namespace perf;
+namespace opencv_test { namespace {
 
 //////////////////////////////////////////////////////////////////////
 // BlendLinear
@@ -86,3 +84,5 @@ PERF_TEST_P(Sz_Depth_Cn, BlendLinear,
         FAIL_NO_CPU();
     }
 }
+
+}} // namespace

--- a/modules/cudaimgproc/perf/perf_canny.cpp
+++ b/modules/cudaimgproc/perf/perf_canny.cpp
@@ -42,9 +42,7 @@
 
 #include "perf_precomp.hpp"
 
-using namespace std;
-using namespace testing;
-using namespace perf;
+namespace opencv_test { namespace {
 
 //////////////////////////////////////////////////////////////////////
 // Canny
@@ -86,3 +84,5 @@ PERF_TEST_P(Image_AppertureSz_L2gradient, Canny,
         CPU_SANITY_CHECK(dst);
     }
 }
+
+}} // namespace

--- a/modules/cudaimgproc/perf/perf_color.cpp
+++ b/modules/cudaimgproc/perf/perf_color.cpp
@@ -42,9 +42,7 @@
 
 #include "perf_precomp.hpp"
 
-using namespace std;
-using namespace testing;
-using namespace perf;
+namespace opencv_test { namespace {
 
 //////////////////////////////////////////////////////////////////////
 // CvtColor
@@ -251,3 +249,5 @@ PERF_TEST_P(Sz_Type_Op, AlphaComp,
         FAIL_NO_CPU();
     }
 }
+
+}} // namespace

--- a/modules/cudaimgproc/perf/perf_corners.cpp
+++ b/modules/cudaimgproc/perf/perf_corners.cpp
@@ -42,9 +42,7 @@
 
 #include "perf_precomp.hpp"
 
-using namespace std;
-using namespace testing;
-using namespace perf;
+namespace opencv_test { namespace {
 
 //////////////////////////////////////////////////////////////////////
 // CornerHarris
@@ -133,3 +131,5 @@ PERF_TEST_P(Image_Type_Border_BlockSz_ApertureSz, CornerMinEigenVal,
         CPU_SANITY_CHECK(dst);
     }
 }
+
+}} // namespace

--- a/modules/cudaimgproc/perf/perf_gftt.cpp
+++ b/modules/cudaimgproc/perf/perf_gftt.cpp
@@ -42,9 +42,7 @@
 
 #include "perf_precomp.hpp"
 
-using namespace std;
-using namespace testing;
-using namespace perf;
+namespace opencv_test { namespace {
 
 //////////////////////////////////////////////////////
 // GoodFeaturesToTrack
@@ -84,3 +82,5 @@ PERF_TEST_P(Image_MinDistance, GoodFeaturesToTrack,
         CPU_SANITY_CHECK(pts);
     }
 }
+
+}} // namespace

--- a/modules/cudaimgproc/perf/perf_histogram.cpp
+++ b/modules/cudaimgproc/perf/perf_histogram.cpp
@@ -42,9 +42,7 @@
 
 #include "perf_precomp.hpp"
 
-using namespace std;
-using namespace testing;
-using namespace perf;
+namespace opencv_test { namespace {
 
 //////////////////////////////////////////////////////////////////////
 // HistEvenC1
@@ -217,3 +215,5 @@ PERF_TEST_P(Sz_ClipLimit, CLAHE,
         CPU_SANITY_CHECK(dst);
     }
 }
+
+}} // namespace

--- a/modules/cudaimgproc/perf/perf_hough.cpp
+++ b/modules/cudaimgproc/perf/perf_hough.cpp
@@ -42,9 +42,7 @@
 
 #include "perf_precomp.hpp"
 
-using namespace std;
-using namespace testing;
-using namespace perf;
+namespace opencv_test { namespace {
 
 //////////////////////////////////////////////////////////////////////
 // HoughLines
@@ -346,3 +344,5 @@ PERF_TEST_P(Sz, DISABLED_GeneralizedHoughGuil, CUDA_TYPICAL_MAT_SIZES)
     // The algorithm is not stable yet.
     SANITY_CHECK_NOTHING();
 }
+
+}} // namespace

--- a/modules/cudaimgproc/perf/perf_match_template.cpp
+++ b/modules/cudaimgproc/perf/perf_match_template.cpp
@@ -42,9 +42,7 @@
 
 #include "perf_precomp.hpp"
 
-using namespace std;
-using namespace testing;
-using namespace perf;
+namespace opencv_test { namespace {
 
 ////////////////////////////////////////////////////////////////////////////////
 // MatchTemplate8U
@@ -133,3 +131,5 @@ PERF_TEST_P(Sz_TemplateSz_Cn_Method, MatchTemplate32F,
         CPU_SANITY_CHECK(dst);
     }
 }
+
+}} // namespace

--- a/modules/cudaimgproc/perf/perf_mean_shift.cpp
+++ b/modules/cudaimgproc/perf/perf_mean_shift.cpp
@@ -42,9 +42,7 @@
 
 #include "perf_precomp.hpp"
 
-using namespace std;
-using namespace testing;
-using namespace perf;
+namespace opencv_test { namespace {
 
 //////////////////////////////////////////////////////////////////////
 // MeanShiftFiltering
@@ -150,3 +148,5 @@ PERF_TEST_P(Image, MeanShiftSegmentation,
         FAIL_NO_CPU();
     }
 }
+
+}} // namespace

--- a/modules/cudaimgproc/perf/perf_precomp.hpp
+++ b/modules/cudaimgproc/perf/perf_precomp.hpp
@@ -39,15 +39,6 @@
 // the use of this software, even if advised of the possibility of such damage.
 //
 //M*/
-
-#ifdef __GNUC__
-#  pragma GCC diagnostic ignored "-Wmissing-declarations"
-#  if defined __clang__ || defined __APPLE__
-#    pragma GCC diagnostic ignored "-Wmissing-prototypes"
-#    pragma GCC diagnostic ignored "-Wextra"
-#  endif
-#endif
-
 #ifndef __OPENCV_PERF_PRECOMP_HPP__
 #define __OPENCV_PERF_PRECOMP_HPP__
 
@@ -55,10 +46,10 @@
 #include "opencv2/ts/cuda_perf.hpp"
 
 #include "opencv2/cudaimgproc.hpp"
-#include "opencv2/imgproc.hpp"
 
-#ifdef GTEST_CREATE_SHARED_LIBRARY
-#error no modules except ts should have GTEST_CREATE_SHARED_LIBRARY defined
-#endif
+namespace opencv_test {
+using namespace perf;
+using namespace testing;
+}
 
 #endif

--- a/modules/cudaimgproc/test/test_bilateral_filter.cpp
+++ b/modules/cudaimgproc/test/test_bilateral_filter.cpp
@@ -44,7 +44,7 @@
 
 #ifdef HAVE_CUDA
 
-using namespace cvtest;
+namespace opencv_test { namespace {
 
 ////////////////////////////////////////////////////////
 // BilateralFilter
@@ -94,4 +94,5 @@ INSTANTIATE_TEST_CASE_P(CUDA_ImgProc, BilateralFilter, testing::Combine(
     ));
 
 
+}} // namespace
 #endif // HAVE_CUDA

--- a/modules/cudaimgproc/test/test_blend.cpp
+++ b/modules/cudaimgproc/test/test_blend.cpp
@@ -44,7 +44,7 @@
 
 #ifdef HAVE_CUDA
 
-using namespace cvtest;
+namespace opencv_test { namespace {
 
 ////////////////////////////////////////////////////////////////////////////
 // Blend
@@ -121,4 +121,6 @@ INSTANTIATE_TEST_CASE_P(CUDA_ImgProc, Blend, testing::Combine(
     testing::Values(MatType(CV_8UC1), MatType(CV_8UC3), MatType(CV_8UC4), MatType(CV_32FC1), MatType(CV_32FC3), MatType(CV_32FC4)),
     WHOLE_SUBMAT));
 
+
+}} // namespace
 #endif // HAVE_CUDA

--- a/modules/cudaimgproc/test/test_canny.cpp
+++ b/modules/cudaimgproc/test/test_canny.cpp
@@ -44,7 +44,7 @@
 
 #ifdef HAVE_CUDA
 
-using namespace cvtest;
+namespace opencv_test { namespace {
 
 ////////////////////////////////////////////////////////
 // Canny
@@ -54,8 +54,6 @@ namespace
     IMPLEMENT_PARAM_CLASS(AppertureSize, int)
     IMPLEMENT_PARAM_CLASS(L2gradient, bool)
 }
-
-namespace {
 
 PARAM_TEST_CASE(Canny, cv::cuda::DeviceInfo, AppertureSize, L2gradient, UseRoi)
 {
@@ -100,6 +98,6 @@ INSTANTIATE_TEST_CASE_P(CUDA_ImgProc, Canny, testing::Combine(
     testing::Values(L2gradient(false), L2gradient(true)),
     WHOLE_SUBMAT));
 
-} // namespace
 
+}} // namespace
 #endif // HAVE_CUDA

--- a/modules/cudaimgproc/test/test_color.cpp
+++ b/modules/cudaimgproc/test/test_color.cpp
@@ -44,7 +44,7 @@
 
 #ifdef HAVE_CUDA
 
-using namespace cvtest;
+namespace opencv_test { namespace {
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////////
 // cvtColor
@@ -2508,4 +2508,6 @@ INSTANTIATE_TEST_CASE_P(CUDA_ImgProc, SwapChannels, testing::Combine(
     DIFFERENT_SIZES,
     WHOLE_SUBMAT));
 
+
+}} // namespace
 #endif // HAVE_CUDA

--- a/modules/cudaimgproc/test/test_corners.cpp
+++ b/modules/cudaimgproc/test/test_corners.cpp
@@ -44,7 +44,7 @@
 
 #ifdef HAVE_CUDA
 
-using namespace cvtest;
+namespace opencv_test { namespace {
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////////
 // CornerHarris
@@ -146,4 +146,6 @@ INSTANTIATE_TEST_CASE_P(CUDA_ImgProc, CornerMinEigen, testing::Combine(
     testing::Values(BlockSize(3), BlockSize(5), BlockSize(7)),
     testing::Values(ApertureSize(0), ApertureSize(3), ApertureSize(5), ApertureSize(7))));
 
+
+}} // namespace
 #endif // HAVE_CUDA

--- a/modules/cudaimgproc/test/test_gftt.cpp
+++ b/modules/cudaimgproc/test/test_gftt.cpp
@@ -44,7 +44,7 @@
 
 #ifdef HAVE_CUDA
 
-using namespace cvtest;
+namespace opencv_test { namespace {
 
 //////////////////////////////////////////////////////
 // GoodFeaturesToTrack
@@ -128,4 +128,6 @@ INSTANTIATE_TEST_CASE_P(CUDA_ImgProc, GoodFeaturesToTrack, testing::Combine(
     ALL_DEVICES,
     testing::Values(MinDistance(0.0), MinDistance(3.0))));
 
+
+}} // namespace
 #endif // HAVE_CUDA

--- a/modules/cudaimgproc/test/test_histogram.cpp
+++ b/modules/cudaimgproc/test/test_histogram.cpp
@@ -44,9 +44,7 @@
 
 #ifdef HAVE_CUDA
 
-using namespace cvtest;
-
-namespace {
+namespace opencv_test { namespace {
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////////
 // HistEven
@@ -257,6 +255,6 @@ INSTANTIATE_TEST_CASE_P(CUDA_ImgProc, CLAHE, testing::Combine(
     DIFFERENT_SIZES,
     testing::Values(0.0, 40.0)));
 
-} // namespace
 
+}} // namespace
 #endif // HAVE_CUDA

--- a/modules/cudaimgproc/test/test_hough.cpp
+++ b/modules/cudaimgproc/test/test_hough.cpp
@@ -44,9 +44,7 @@
 
 #ifdef HAVE_CUDA
 
-using namespace cvtest;
-
-namespace {
+namespace opencv_test { namespace {
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////////
 // HoughLines
@@ -258,6 +256,6 @@ INSTANTIATE_TEST_CASE_P(CUDA_ImgProc, GeneralizedHough, testing::Combine(
     ALL_DEVICES,
     WHOLE_SUBMAT));
 
-} // namespace
 
+}} // namespace
 #endif // HAVE_CUDA

--- a/modules/cudaimgproc/test/test_match_template.cpp
+++ b/modules/cudaimgproc/test/test_match_template.cpp
@@ -44,7 +44,7 @@
 
 #ifdef HAVE_CUDA
 
-using namespace cvtest;
+namespace opencv_test { namespace {
 
 ////////////////////////////////////////////////////////////////////////////////
 // MatchTemplate8U
@@ -336,4 +336,6 @@ CUDA_TEST_P(MatchTemplate_CanFindBigTemplate, SQDIFF)
 
 INSTANTIATE_TEST_CASE_P(CUDA_ImgProc, MatchTemplate_CanFindBigTemplate, ALL_DEVICES);
 
+
+}} // namespace
 #endif // HAVE_CUDA

--- a/modules/cudaimgproc/test/test_mean_shift.cpp
+++ b/modules/cudaimgproc/test/test_mean_shift.cpp
@@ -44,7 +44,7 @@
 
 #ifdef HAVE_CUDA
 
-using namespace cvtest;
+namespace opencv_test { namespace {
 
 ////////////////////////////////////////////////////////////////////////////////
 // MeanShift
@@ -171,4 +171,6 @@ INSTANTIATE_TEST_CASE_P(CUDA_ImgProc, MeanShiftSegmentation, testing::Combine(
     ALL_DEVICES,
     testing::Values(MinSize(0), MinSize(4), MinSize(20), MinSize(84), MinSize(340), MinSize(1364))));
 
+
+}} // namespace
 #endif // HAVE_CUDA

--- a/modules/cudaimgproc/test/test_precomp.hpp
+++ b/modules/cudaimgproc/test/test_precomp.hpp
@@ -39,15 +39,6 @@
 // the use of this software, even if advised of the possibility of such damage.
 //
 //M*/
-
-#ifdef __GNUC__
-#  pragma GCC diagnostic ignored "-Wmissing-declarations"
-#  if defined __clang__ || defined __APPLE__
-#    pragma GCC diagnostic ignored "-Wmissing-prototypes"
-#    pragma GCC diagnostic ignored "-Wextra"
-#  endif
-#endif
-
 #ifndef __OPENCV_TEST_PRECOMP_HPP__
 #define __OPENCV_TEST_PRECOMP_HPP__
 
@@ -55,7 +46,6 @@
 #include "opencv2/ts/cuda_test.hpp"
 
 #include "opencv2/cudaimgproc.hpp"
-#include "opencv2/imgproc.hpp"
 
 #include "cvconfig.h"
 

--- a/modules/cudalegacy/include/opencv2/cudalegacy/NCVPyramid.hpp
+++ b/modules/cudalegacy/include/opencv2/cudalegacy/NCVPyramid.hpp
@@ -74,11 +74,11 @@ public:
             pop_back();
         }
     }
-    void push_back(NCVMatrix<T> *elem) {this->_arr.push_back(std::tr1::shared_ptr< NCVMatrix<T> >(elem));}
+    void push_back(NCVMatrix<T> *elem) {this->_arr.push_back(std::shared_ptr< NCVMatrix<T> >(elem));}
     void pop_back() {this->_arr.pop_back();}
     NCVMatrix<T> * operator [] (int i) const {return this->_arr[i].get();}
 private:
-    std::vector< std::tr1::shared_ptr< NCVMatrix<T> > > _arr;
+    std::vector< std::shared_ptr< NCVMatrix<T> > > _arr;
 };
 
 

--- a/modules/cudalegacy/perf/perf_bgsegm.cpp
+++ b/modules/cudalegacy/perf/perf_bgsegm.cpp
@@ -46,9 +46,7 @@
 #  include "opencv2/cudaimgproc.hpp"
 #endif
 
-using namespace std;
-using namespace testing;
-using namespace perf;
+namespace opencv_test { namespace {
 
 //////////////////////////////////////////////////////
 // FGDStatModel
@@ -234,3 +232,5 @@ PERF_TEST_P(Video_Cn_MaxFeatures, GMG,
 }
 
 #endif
+
+}} // namespace

--- a/modules/cudalegacy/perf/perf_calib3d.cpp
+++ b/modules/cudalegacy/perf/perf_calib3d.cpp
@@ -46,9 +46,7 @@
 
 #include "opencv2/calib3d.hpp"
 
-using namespace std;
-using namespace testing;
-using namespace perf;
+namespace opencv_test { namespace {
 
 DEF_PARAM_TEST_1(Count, int);
 
@@ -138,4 +136,5 @@ PERF_TEST_P(Count, Calib3D_SolvePnPRansac,
     }
 }
 
+}} // namespace
 #endif

--- a/modules/cudalegacy/perf/perf_labeling.cpp
+++ b/modules/cudalegacy/perf/perf_labeling.cpp
@@ -42,9 +42,7 @@
 
 #include "perf_precomp.hpp"
 
-using namespace std;
-using namespace testing;
-using namespace perf;
+namespace opencv_test { namespace {
 
 DEF_PARAM_TEST_1(Image, string);
 
@@ -193,3 +191,5 @@ PERF_TEST_P(Image, DISABLED_Labeling_ConnectedComponents,
         CPU_SANITY_CHECK(components);
     }
 }
+
+}} // namespace

--- a/modules/cudalegacy/perf/perf_precomp.hpp
+++ b/modules/cudalegacy/perf/perf_precomp.hpp
@@ -39,15 +39,6 @@
 // the use of this software, even if advised of the possibility of such damage.
 //
 //M*/
-
-#ifdef __GNUC__
-#  pragma GCC diagnostic ignored "-Wmissing-declarations"
-#  if defined __clang__ || defined __APPLE__
-#    pragma GCC diagnostic ignored "-Wmissing-prototypes"
-#    pragma GCC diagnostic ignored "-Wextra"
-#  endif
-#endif
-
 #ifndef __OPENCV_PERF_PRECOMP_HPP__
 #define __OPENCV_PERF_PRECOMP_HPP__
 
@@ -59,8 +50,8 @@
 
 #include "opencv2/opencv_modules.hpp"
 
-#ifdef GTEST_CREATE_SHARED_LIBRARY
-#error no modules except ts should have GTEST_CREATE_SHARED_LIBRARY defined
-#endif
+namespace opencv_test {
+using namespace perf;
+}
 
 #endif

--- a/modules/cudalegacy/test/test_calib3d.cpp
+++ b/modules/cudalegacy/test/test_calib3d.cpp
@@ -46,7 +46,7 @@
 
 #include "opencv2/calib3d.hpp"
 
-using namespace cvtest;
+namespace opencv_test { namespace {
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////////
 // transformPoints
@@ -189,4 +189,5 @@ CUDA_TEST_P(SolvePnPRansac, Accuracy)
 
 INSTANTIATE_TEST_CASE_P(CUDA_Calib3D, SolvePnPRansac, ALL_DEVICES);
 
+}} // namespace
 #endif // HAVE_CUDA

--- a/modules/cudalegacy/test/test_labeling.cpp
+++ b/modules/cudalegacy/test/test_labeling.cpp
@@ -44,6 +44,8 @@
 
 #ifdef HAVE_CUDA
 
+namespace opencv_test { namespace {
+
 namespace
 {
     struct GreedyLabeling
@@ -194,4 +196,5 @@ CUDA_TEST_P(Labeling, DISABLED_ConnectedComponents)
 
 INSTANTIATE_TEST_CASE_P(CUDA_ConnectedComponents, Labeling, ALL_DEVICES);
 
+}} // namespace
 #endif // HAVE_CUDA

--- a/modules/cudalegacy/test/test_main.cpp
+++ b/modules/cudalegacy/test/test_main.cpp
@@ -47,7 +47,7 @@
 using namespace std;
 using namespace cv;
 using namespace cv::cuda;
-using namespace cvtest;
+using namespace opencv_test;
 using namespace testing;
 
 int main(int argc, char** argv)

--- a/modules/cudalegacy/test/test_nvidia.cpp
+++ b/modules/cudalegacy/test/test_nvidia.cpp
@@ -46,8 +46,7 @@
 
 OutputLevel nvidiaTestOutputLevel = OutputLevelNone;
 
-using namespace cvtest;
-using namespace testing;
+namespace opencv_test { namespace {
 
 struct NVidiaTest : TestWithParam<cv::cuda::DeviceInfo>
 {
@@ -148,4 +147,6 @@ CUDA_TEST_P(NCV, Visualization)
 INSTANTIATE_TEST_CASE_P(CUDA_Legacy, NPPST, ALL_DEVICES);
 INSTANTIATE_TEST_CASE_P(CUDA_Legacy, NCV, ALL_DEVICES);
 
+
+}} // namespace
 #endif // HAVE_CUDA

--- a/modules/cudalegacy/test/test_precomp.hpp
+++ b/modules/cudalegacy/test/test_precomp.hpp
@@ -39,15 +39,6 @@
 // the use of this software, even if advised of the possibility of such damage.
 //
 //M*/
-
-#ifdef __GNUC__
-#  pragma GCC diagnostic ignored "-Wmissing-declarations"
-#  if defined __clang__ || defined __APPLE__
-#    pragma GCC diagnostic ignored "-Wmissing-prototypes"
-#    pragma GCC diagnostic ignored "-Wextra"
-#  endif
-#endif
-
 #ifndef __OPENCV_TEST_PRECOMP_HPP__
 #define __OPENCV_TEST_PRECOMP_HPP__
 

--- a/modules/cudaobjdetect/perf/perf_objdetect.cpp
+++ b/modules/cudaobjdetect/perf/perf_objdetect.cpp
@@ -42,9 +42,7 @@
 
 #include "perf_precomp.hpp"
 
-using namespace std;
-using namespace testing;
-using namespace perf;
+namespace opencv_test { namespace {
 
 ///////////////////////////////////////////////////////////////
 // HOG
@@ -171,3 +169,5 @@ PERF_TEST_P(ImageAndCascade, ObjDetect_LBPClassifier,
         SANITY_CHECK(cpu_rects);
     }
 }
+
+}} // namespace

--- a/modules/cudaobjdetect/perf/perf_precomp.hpp
+++ b/modules/cudaobjdetect/perf/perf_precomp.hpp
@@ -39,15 +39,6 @@
 // the use of this software, even if advised of the possibility of such damage.
 //
 //M*/
-
-#ifdef __GNUC__
-#  pragma GCC diagnostic ignored "-Wmissing-declarations"
-#  if defined __clang__ || defined __APPLE__
-#    pragma GCC diagnostic ignored "-Wmissing-prototypes"
-#    pragma GCC diagnostic ignored "-Wextra"
-#  endif
-#endif
-
 #ifndef __OPENCV_PERF_PRECOMP_HPP__
 #define __OPENCV_PERF_PRECOMP_HPP__
 
@@ -57,8 +48,6 @@
 #include "opencv2/cudaobjdetect.hpp"
 #include "opencv2/objdetect.hpp"
 
-#ifdef GTEST_CREATE_SHARED_LIBRARY
-#error no modules except ts should have GTEST_CREATE_SHARED_LIBRARY defined
-#endif
+namespace opencv_test { using namespace perf; }
 
 #endif

--- a/modules/cudaobjdetect/test/test_objdetect.cpp
+++ b/modules/cudaobjdetect/test/test_objdetect.cpp
@@ -44,9 +44,7 @@
 
 #ifdef HAVE_CUDA
 
-using namespace cvtest;
-
-namespace {
+namespace opencv_test { namespace {
 
 //#define DUMP
 
@@ -224,7 +222,7 @@ INSTANTIATE_TEST_CASE_P(CUDA_ObjDetect, HOG, ALL_DEVICES);
 */
 //============== caltech hog tests =====================//
 
-struct CalTech : public ::testing::TestWithParam<std::tr1::tuple<cv::cuda::DeviceInfo, std::string> >
+struct CalTech : public ::testing::TestWithParam<tuple<cv::cuda::DeviceInfo, std::string> >
 {
     cv::cuda::DeviceInfo devInfo;
     cv::Mat img;
@@ -272,7 +270,7 @@ INSTANTIATE_TEST_CASE_P(detect, CalTech, testing::Combine(ALL_DEVICES,
 
 
 //------------------------variable GPU HOG Tests------------------------//
-struct Hog_var : public ::testing::TestWithParam<std::tr1::tuple<cv::cuda::DeviceInfo, std::string> >
+struct Hog_var : public ::testing::TestWithParam<tuple<cv::cuda::DeviceInfo, std::string> >
 {
     cv::cuda::DeviceInfo devInfo;
     cv::Mat img, c_img;
@@ -330,7 +328,7 @@ CUDA_TEST_P(Hog_var, HOG)
 INSTANTIATE_TEST_CASE_P(detect, Hog_var, testing::Combine(ALL_DEVICES,
     ::testing::Values<std::string>("/hog/road.png")));
 
-struct Hog_var_cell : public ::testing::TestWithParam<std::tr1::tuple<cv::cuda::DeviceInfo, std::string> >
+struct Hog_var_cell : public ::testing::TestWithParam<tuple<cv::cuda::DeviceInfo, std::string> >
 {
     cv::cuda::DeviceInfo devInfo;
     cv::Mat img, c_img, c_img2, c_img3, c_img4;
@@ -560,6 +558,6 @@ CUDA_TEST_P(LBP_classify, Accuracy)
 INSTANTIATE_TEST_CASE_P(CUDA_ObjDetect, LBP_classify,
                         testing::Combine(ALL_DEVICES, testing::Values<int>(0)));
 
-} // namespace
 
+}} // namespace
 #endif // HAVE_CUDA

--- a/modules/cudaobjdetect/test/test_precomp.hpp
+++ b/modules/cudaobjdetect/test/test_precomp.hpp
@@ -39,15 +39,6 @@
 // the use of this software, even if advised of the possibility of such damage.
 //
 //M*/
-
-#ifdef __GNUC__
-#  pragma GCC diagnostic ignored "-Wmissing-declarations"
-#  if defined __clang__ || defined __APPLE__
-#    pragma GCC diagnostic ignored "-Wmissing-prototypes"
-#    pragma GCC diagnostic ignored "-Wextra"
-#  endif
-#endif
-
 #ifndef __OPENCV_TEST_PRECOMP_HPP__
 #define __OPENCV_TEST_PRECOMP_HPP__
 

--- a/modules/cudaoptflow/perf/perf_optflow.cpp
+++ b/modules/cudaoptflow/perf/perf_optflow.cpp
@@ -42,9 +42,7 @@
 
 #include "perf_precomp.hpp"
 
-using namespace std;
-using namespace testing;
-using namespace perf;
+namespace opencv_test { namespace {
 
 typedef pair<string, string> pair_string;
 
@@ -327,3 +325,5 @@ PERF_TEST_P(ImagePair, OpticalFlowDual_TVL1,
         CPU_SANITY_CHECK(flow);
     }
 }
+
+}} // namespace

--- a/modules/cudaoptflow/perf/perf_precomp.hpp
+++ b/modules/cudaoptflow/perf/perf_precomp.hpp
@@ -39,15 +39,6 @@
 // the use of this software, even if advised of the possibility of such damage.
 //
 //M*/
-
-#ifdef __GNUC__
-#  pragma GCC diagnostic ignored "-Wmissing-declarations"
-#  if defined __clang__ || defined __APPLE__
-#    pragma GCC diagnostic ignored "-Wmissing-prototypes"
-#    pragma GCC diagnostic ignored "-Wextra"
-#  endif
-#endif
-
 #ifndef __OPENCV_PERF_PRECOMP_HPP__
 #define __OPENCV_PERF_PRECOMP_HPP__
 
@@ -58,8 +49,9 @@
 #include "opencv2/cudaarithm.hpp"
 #include "opencv2/video.hpp"
 
-#ifdef GTEST_CREATE_SHARED_LIBRARY
-#error no modules except ts should have GTEST_CREATE_SHARED_LIBRARY defined
-#endif
+namespace opencv_test {
+using namespace perf;
+using namespace testing;
+}
 
 #endif

--- a/modules/cudaoptflow/test/test_optflow.cpp
+++ b/modules/cudaoptflow/test/test_optflow.cpp
@@ -44,9 +44,7 @@
 
 #ifdef HAVE_CUDA
 
-using namespace cvtest;
-
-namespace {
+namespace opencv_test { namespace {
 
 //////////////////////////////////////////////////////
 // BroxOpticalFlow
@@ -403,6 +401,6 @@ INSTANTIATE_TEST_CASE_P(CUDA_OptFlow, OpticalFlowDual_TVL1, testing::Combine(
     ALL_DEVICES,
     testing::Values(Gamma(0.0), Gamma(1.0))));
 
-} // namespace
 
+}} // namespace
 #endif // HAVE_CUDA

--- a/modules/cudaoptflow/test/test_precomp.hpp
+++ b/modules/cudaoptflow/test/test_precomp.hpp
@@ -39,19 +39,8 @@
 // the use of this software, even if advised of the possibility of such damage.
 //
 //M*/
-
-#ifdef __GNUC__
-#  pragma GCC diagnostic ignored "-Wmissing-declarations"
-#  if defined __clang__ || defined __APPLE__
-#    pragma GCC diagnostic ignored "-Wmissing-prototypes"
-#    pragma GCC diagnostic ignored "-Wextra"
-#  endif
-#endif
-
 #ifndef __OPENCV_TEST_PRECOMP_HPP__
 #define __OPENCV_TEST_PRECOMP_HPP__
-
-#include <fstream>
 
 #include "opencv2/ts.hpp"
 #include "opencv2/ts/cuda_test.hpp"

--- a/modules/cudastereo/perf/perf_precomp.hpp
+++ b/modules/cudastereo/perf/perf_precomp.hpp
@@ -39,15 +39,6 @@
 // the use of this software, even if advised of the possibility of such damage.
 //
 //M*/
-
-#ifdef __GNUC__
-#  pragma GCC diagnostic ignored "-Wmissing-declarations"
-#  if defined __clang__ || defined __APPLE__
-#    pragma GCC diagnostic ignored "-Wmissing-prototypes"
-#    pragma GCC diagnostic ignored "-Wextra"
-#  endif
-#endif
-
 #ifndef __OPENCV_PERF_PRECOMP_HPP__
 #define __OPENCV_PERF_PRECOMP_HPP__
 
@@ -57,8 +48,8 @@
 #include "opencv2/cudastereo.hpp"
 #include "opencv2/calib3d.hpp"
 
-#ifdef GTEST_CREATE_SHARED_LIBRARY
-#error no modules except ts should have GTEST_CREATE_SHARED_LIBRARY defined
-#endif
+namespace opencv_test {
+using namespace perf;
+}
 
 #endif

--- a/modules/cudastereo/perf/perf_stereo.cpp
+++ b/modules/cudastereo/perf/perf_stereo.cpp
@@ -42,14 +42,12 @@
 
 #include "perf_precomp.hpp"
 
-using namespace std;
-using namespace testing;
-using namespace perf;
+namespace opencv_test { namespace {
 
 //////////////////////////////////////////////////////////////////////
 // StereoBM
 
-typedef std::tr1::tuple<string, string> pair_string;
+typedef tuple<string, string> pair_string;
 DEF_PARAM_TEST_1(ImagePair, pair_string);
 
 PERF_TEST_P(ImagePair, StereoBM,
@@ -253,3 +251,5 @@ PERF_TEST_P(Sz_Depth, DrawColorDisp,
         FAIL_NO_CPU();
     }
 }
+
+}} // namespace

--- a/modules/cudastereo/test/test_precomp.hpp
+++ b/modules/cudastereo/test/test_precomp.hpp
@@ -39,15 +39,6 @@
 // the use of this software, even if advised of the possibility of such damage.
 //
 //M*/
-
-#ifdef __GNUC__
-#  pragma GCC diagnostic ignored "-Wmissing-declarations"
-#  if defined __clang__ || defined __APPLE__
-#    pragma GCC diagnostic ignored "-Wmissing-prototypes"
-#    pragma GCC diagnostic ignored "-Wextra"
-#  endif
-#endif
-
 #ifndef __OPENCV_TEST_PRECOMP_HPP__
 #define __OPENCV_TEST_PRECOMP_HPP__
 

--- a/modules/cudastereo/test/test_stereo.cpp
+++ b/modules/cudastereo/test/test_stereo.cpp
@@ -44,9 +44,7 @@
 
 #ifdef HAVE_CUDA
 
-using namespace cvtest;
-
-namespace {
+namespace opencv_test { namespace {
 
 //////////////////////////////////////////////////////////////////////////
 // StereoBM
@@ -211,6 +209,6 @@ INSTANTIATE_TEST_CASE_P(CUDA_Stereo, ReprojectImageTo3D, testing::Combine(
     testing::Values(MatDepth(CV_8U), MatDepth(CV_16S)),
     WHOLE_SUBMAT));
 
-} // namespace
 
+}} // namespace
 #endif // HAVE_CUDA

--- a/modules/cudawarping/perf/perf_precomp.hpp
+++ b/modules/cudawarping/perf/perf_precomp.hpp
@@ -40,14 +40,6 @@
 //
 //M*/
 
-#ifdef __GNUC__
-#  pragma GCC diagnostic ignored "-Wmissing-declarations"
-#  if defined __clang__ || defined __APPLE__
-#    pragma GCC diagnostic ignored "-Wmissing-prototypes"
-#    pragma GCC diagnostic ignored "-Wextra"
-#  endif
-#endif
-
 #ifndef __OPENCV_PERF_PRECOMP_HPP__
 #define __OPENCV_PERF_PRECOMP_HPP__
 
@@ -55,10 +47,9 @@
 #include "opencv2/ts/cuda_perf.hpp"
 
 #include "opencv2/cudawarping.hpp"
-#include "opencv2/imgproc.hpp"
 
-#ifdef GTEST_CREATE_SHARED_LIBRARY
-#error no modules except ts should have GTEST_CREATE_SHARED_LIBRARY defined
-#endif
+namespace opencv_test {
+using namespace perf;
+}
 
 #endif

--- a/modules/cudawarping/perf/perf_warping.cpp
+++ b/modules/cudawarping/perf/perf_warping.cpp
@@ -42,9 +42,7 @@
 
 #include "perf_precomp.hpp"
 
-using namespace std;
-using namespace testing;
-using namespace perf;
+namespace opencv_test { namespace {
 
 //////////////////////////////////////////////////////////////////////
 // Remap
@@ -434,3 +432,5 @@ PERF_TEST_P(Sz_Depth_Cn, PyrUp,
         CPU_SANITY_CHECK(dst);
     }
 }
+
+}} // namespace

--- a/modules/cudawarping/test/test_precomp.hpp
+++ b/modules/cudawarping/test/test_precomp.hpp
@@ -39,15 +39,6 @@
 // the use of this software, even if advised of the possibility of such damage.
 //
 //M*/
-
-#ifdef __GNUC__
-#  pragma GCC diagnostic ignored "-Wmissing-declarations"
-#  if defined __clang__ || defined __APPLE__
-#    pragma GCC diagnostic ignored "-Wmissing-prototypes"
-#    pragma GCC diagnostic ignored "-Wextra"
-#  endif
-#endif
-
 #ifndef __OPENCV_TEST_PRECOMP_HPP__
 #define __OPENCV_TEST_PRECOMP_HPP__
 
@@ -55,7 +46,6 @@
 #include "opencv2/ts/cuda_test.hpp"
 
 #include "opencv2/cudawarping.hpp"
-#include "opencv2/imgproc.hpp"
 
 #include "cvconfig.h"
 

--- a/modules/cudawarping/test/test_pyramids.cpp
+++ b/modules/cudawarping/test/test_pyramids.cpp
@@ -44,7 +44,7 @@
 
 #ifdef HAVE_CUDA
 
-using namespace cvtest;
+namespace opencv_test { namespace {
 
 ////////////////////////////////////////////////////////
 // pyrDown
@@ -126,4 +126,6 @@ INSTANTIATE_TEST_CASE_P(CUDA_Warping, PyrUp, testing::Combine(
     testing::Values(MatType(CV_8UC1), MatType(CV_8UC3), MatType(CV_8UC4), MatType(CV_16UC1), MatType(CV_16UC3), MatType(CV_16UC4), MatType(CV_32FC1), MatType(CV_32FC3), MatType(CV_32FC4)),
     WHOLE_SUBMAT));
 
+
+}} // namespace
 #endif // HAVE_CUDA

--- a/modules/cudawarping/test/test_remap.cpp
+++ b/modules/cudawarping/test/test_remap.cpp
@@ -44,7 +44,7 @@
 
 #ifdef HAVE_CUDA
 
-using namespace cvtest;
+namespace opencv_test { namespace {
 
 ///////////////////////////////////////////////////////////////////
 // Gold implementation
@@ -177,4 +177,6 @@ INSTANTIATE_TEST_CASE_P(CUDA_Warping, Remap, testing::Combine(
     testing::Values(BorderType(cv::BORDER_REFLECT101), BorderType(cv::BORDER_REPLICATE), BorderType(cv::BORDER_CONSTANT), BorderType(cv::BORDER_REFLECT), BorderType(cv::BORDER_WRAP)),
     WHOLE_SUBMAT));
 
+
+}} // namespace
 #endif // HAVE_CUDA

--- a/modules/cudawarping/test/test_resize.cpp
+++ b/modules/cudawarping/test/test_resize.cpp
@@ -44,7 +44,7 @@
 
 #ifdef HAVE_CUDA
 
-using namespace cvtest;
+namespace opencv_test { namespace {
 
 ///////////////////////////////////////////////////////////////////
 // Gold implementation
@@ -206,4 +206,6 @@ INSTANTIATE_TEST_CASE_P(CUDA_Warping, ResizeSameAsHost, testing::Combine(
     testing::Values(Interpolation(cv::INTER_NEAREST), Interpolation(cv::INTER_AREA)),
     WHOLE_SUBMAT));
 
+
+}} // namespace
 #endif // HAVE_CUDA

--- a/modules/cudawarping/test/test_warp_affine.cpp
+++ b/modules/cudawarping/test/test_warp_affine.cpp
@@ -44,7 +44,7 @@
 
 #ifdef HAVE_CUDA
 
-using namespace cvtest;
+namespace opencv_test { namespace {
 
 namespace
 {
@@ -277,4 +277,6 @@ INSTANTIATE_TEST_CASE_P(CUDA_Warping, WarpAffineNPP, testing::Combine(
     DIRECT_INVERSE,
     testing::Values(Interpolation(cv::INTER_NEAREST), Interpolation(cv::INTER_LINEAR), Interpolation(cv::INTER_CUBIC))));
 
+
+}} // namespace
 #endif // HAVE_CUDA

--- a/modules/cudawarping/test/test_warp_perspective.cpp
+++ b/modules/cudawarping/test/test_warp_perspective.cpp
@@ -44,7 +44,7 @@
 
 #ifdef HAVE_CUDA
 
-using namespace cvtest;
+namespace opencv_test { namespace {
 
 namespace
 {
@@ -280,4 +280,6 @@ INSTANTIATE_TEST_CASE_P(CUDA_Warping, WarpPerspectiveNPP, testing::Combine(
     DIRECT_INVERSE,
     testing::Values(Interpolation(cv::INTER_NEAREST), Interpolation(cv::INTER_LINEAR), Interpolation(cv::INTER_CUBIC))));
 
+
+}} // namespace
 #endif // HAVE_CUDA

--- a/modules/cudev/test/test_precomp.hpp
+++ b/modules/cudev/test/test_precomp.hpp
@@ -46,6 +46,7 @@
 
 #include "opencv2/cudev.hpp"
 
+#define CV_TEST_SKIP_NAMESPACE_CHECK
 #include "opencv2/ts.hpp"
 #include "opencv2/ts/cuda_test.hpp"
 

--- a/modules/cudev/test/test_precomp.hpp
+++ b/modules/cudev/test/test_precomp.hpp
@@ -44,9 +44,6 @@
 #ifndef __OPENCV_TEST_PRECOMP_HPP__
 #define __OPENCV_TEST_PRECOMP_HPP__
 
-#include "opencv2/core.hpp"
-#include "opencv2/imgproc.hpp"
-#include "opencv2/highgui.hpp"
 #include "opencv2/cudev.hpp"
 
 #include "opencv2/ts.hpp"

--- a/modules/dnn/perf/opencl/perf_convolution.cpp
+++ b/modules/dnn/perf/opencl/perf_convolution.cpp
@@ -4,25 +4,16 @@
 
 #ifdef HAVE_OPENCL
 
-namespace cvtest
-{
-namespace ocl
-{
+namespace opencv_test { namespace ocl {
+using namespace ::perf;
 
-using std::tr1::tuple;
-using std::tr1::get;
-using std::tr1::make_tuple;
-using std::make_pair;
-using namespace perf;
-using namespace testing;
-using namespace cv;
-using namespace cv::dnn;
-
+namespace {
 enum {STRIDE_OFF = 1, STRIDE_ON = 2};
 CV_ENUM(StrideSize, STRIDE_OFF, STRIDE_ON);
 
 enum {GROUP_OFF = 1, GROUP_2 = 2};
 CV_ENUM(GroupSize, GROUP_OFF, GROUP_2);
+} // namespace
 
 //Squared Size
 #define SSZ(n) cv::Size(n, n)
@@ -80,11 +71,11 @@ OCL_PERF_TEST_P( ConvolutionPerfTest, perf, Combine(
     Ptr<Layer> layer = cv::dnn::LayerFactory::createLayerInstance("Convolution", lp);
     std::vector<MatShape> inputShapes(1, shape(inpBlob)), outShapes, internals;
     layer->getMemoryShapes(inputShapes, 0, outShapes, internals);
-    for (int i = 0; i < outShapes.size(); i++)
+    for (size_t i = 0; i < outShapes.size(); i++)
     {
         outBlobs.push_back(Mat(outShapes[i], CV_32F));
     }
-    for (int i = 0; i < internals.size(); i++)
+    for (size_t i = 0; i < internals.size(); i++)
     {
         internalBlobs.push_back(Mat());
         if (total(internals[i]))

--- a/modules/dnn/perf/perf_caffe.cpp
+++ b/modules/dnn/perf/perf_caffe.cpp
@@ -34,8 +34,7 @@
 #include <iostream>
 #include <caffe/caffe.hpp>
 
-namespace cvtest
-{
+namespace opencv_test {
 
 static caffe::Net<float>* initNet(std::string proto, std::string weights)
 {
@@ -108,6 +107,5 @@ PERF_TEST(MobileNet_SSD, CaffePerfTest)
     SANITY_CHECK_NOTHING();
 }
 
-}  // namespace cvtest
-
+} // namespace
 #endif  // HAVE_CAFFE

--- a/modules/dnn/perf/perf_convolution.cpp
+++ b/modules/dnn/perf/perf_convolution.cpp
@@ -1,8 +1,7 @@
 #include "perf_precomp.hpp"
 #include <opencv2/dnn/shape_utils.hpp>
 
-namespace
-{
+namespace opencv_test {
 
 enum {STRIDE_OFF = 1, STRIDE_ON = 2};
 CV_ENUM(StrideSize, STRIDE_OFF, STRIDE_ON);

--- a/modules/dnn/perf/perf_net.cpp
+++ b/modules/dnn/perf/perf_net.cpp
@@ -10,8 +10,7 @@
 
 #include "opencv2/dnn/shape_utils.hpp"
 
-namespace
-{
+namespace opencv_test {
 
 #ifdef HAVE_HALIDE
 #define TEST_DNN_BACKEND DNN_BACKEND_DEFAULT, DNN_BACKEND_HALIDE
@@ -44,7 +43,7 @@ public:
             if (!cv::ocl::useOpenCL())
 #endif
             {
-                throw ::SkipTestException("OpenCL is not available/disabled in OpenCV");
+                throw cvtest::SkipTestException("OpenCL is not available/disabled in OpenCV");
             }
         }
 
@@ -56,7 +55,7 @@ public:
         if (backend == DNN_BACKEND_HALIDE)
         {
             if (halide_scheduler == "disabled")
-                throw ::SkipTestException("Halide test is disabled");
+                throw cvtest::SkipTestException("Halide test is disabled");
             if (!halide_scheduler.empty())
                 halide_scheduler = findDataFile(std::string("dnn/halide_scheduler_") + (target == DNN_TARGET_OPENCL ? "opencl_" : "") + halide_scheduler, true);
         }

--- a/modules/dnn/perf/perf_precomp.hpp
+++ b/modules/dnn/perf/perf_precomp.hpp
@@ -2,13 +2,11 @@
 #define __OPENCV_PERF_PRECOMP_HPP__
 
 #include <opencv2/ts.hpp>
-#include <opencv2/imgproc.hpp>
-#include <opencv2/highgui.hpp>
 #include <opencv2/dnn.hpp>
 
-using namespace cvtest;
+namespace opencv_test {
 using namespace perf;
-using namespace cv;
-using namespace dnn;
+using namespace cv::dnn;
+} // namespace
 
 #endif

--- a/modules/dnn/test/npy_blob.cpp
+++ b/modules/dnn/test/npy_blob.cpp
@@ -85,7 +85,7 @@ Mat blobFromNPY(const std::string& path)
 
     Mat blob(shape, CV_32F);
     ifs.read((char*)blob.data, blob.total() * blob.elemSize());
-    CV_Assert(ifs.gcount() == blob.total() * blob.elemSize());
+    CV_Assert((size_t)ifs.gcount() == blob.total() * blob.elemSize());
 
     return blob;
 }

--- a/modules/dnn/test/test_backends.cpp
+++ b/modules/dnn/test/test_backends.cpp
@@ -8,11 +8,7 @@
 #include "test_precomp.hpp"
 #include "opencv2/core/ocl.hpp"
 
-namespace cvtest {
-
-using namespace cv;
-using namespace dnn;
-using namespace testing;
+namespace opencv_test { namespace {
 
 CV_ENUM(DNNBackend, DNN_BACKEND_DEFAULT, DNN_BACKEND_HALIDE)
 CV_ENUM(DNNTarget, DNN_TARGET_CPU, DNN_TARGET_OPENCL)
@@ -190,6 +186,6 @@ const tuple<DNNBackend, DNNTarget> testCases[] = {
     tuple<DNNBackend, DNNTarget>(DNN_BACKEND_DEFAULT, DNN_TARGET_OPENCL)
 };
 
-INSTANTIATE_TEST_CASE_P(/*nothing*/, DNNTestNetwork, ValuesIn(testCases));
+INSTANTIATE_TEST_CASE_P(/*nothing*/, DNNTestNetwork, testing::ValuesIn(testCases));
 
-}  // namespace cvtest
+}} // namespace

--- a/modules/dnn/test/test_caffe_importer.cpp
+++ b/modules/dnn/test/test_caffe_importer.cpp
@@ -45,11 +45,7 @@
 #include <opencv2/core/ocl.hpp>
 #include <opencv2/ts/ocl_test.hpp>
 
-namespace cvtest
-{
-
-using namespace cv;
-using namespace cv::dnn;
+namespace opencv_test { namespace {
 
 template<typename TString>
 static std::string _tf(TString filename)
@@ -525,4 +521,4 @@ TEST(Test_Caffe, FasterRCNN_and_RFCN)
     }
 }
 
-}
+}} // namespace

--- a/modules/dnn/test/test_darknet_importer.cpp
+++ b/modules/dnn/test/test_darknet_importer.cpp
@@ -43,15 +43,10 @@
 
 #include "test_precomp.hpp"
 #include <opencv2/dnn/shape_utils.hpp>
-#include <algorithm>
 #include <opencv2/core/ocl.hpp>
 #include <opencv2/ts/ocl_test.hpp>
 
-namespace cvtest
-{
-
-using namespace cv;
-using namespace cv::dnn;
+namespace opencv_test { namespace {
 
 template<typename TString>
 static std::string _tf(TString filename)
@@ -305,4 +300,4 @@ TEST(Reproducibility_YoloVoc, Accuracy)
     normAssert(ref, detection);
 }
 
-}
+}} // namespace

--- a/modules/dnn/test/test_googlenet.cpp
+++ b/modules/dnn/test/test_googlenet.cpp
@@ -44,11 +44,7 @@
 #include <opencv2/core/ocl.hpp>
 #include <opencv2/ts/ocl_test.hpp>
 
-namespace cvtest
-{
-
-using namespace cv;
-using namespace cv::dnn;
+namespace opencv_test { namespace {
 
 template<typename TString>
 static std::string _tf(TString filename)
@@ -109,7 +105,7 @@ TEST(IntermediateBlobs_GoogLeNet, Accuracy)
     net.forward(outs, blobsNames);
     CV_Assert(outs.size() == blobsNames.size());
 
-    for (int i = 0; i < blobsNames.size(); i++)
+    for (size_t i = 0; i < blobsNames.size(); i++)
     {
         std::string filename = blobsNames[i];
         std::replace( filename.begin(), filename.end(), '/', '#');
@@ -138,7 +134,7 @@ OCL_TEST(IntermediateBlobs_GoogLeNet, Accuracy)
     net.forward(outs, blobsNames);
     CV_Assert(outs.size() == blobsNames.size());
 
-    for (int i = 0; i < blobsNames.size(); i++)
+    for (size_t i = 0; i < blobsNames.size(); i++)
     {
         std::string filename = blobsNames[i];
         std::replace( filename.begin(), filename.end(), '/', '#');
@@ -209,4 +205,4 @@ OCL_TEST(SeveralCalls_GoogLeNet, Accuracy)
     normAssert(outs[0], ref, "", 1E-4, 1E-2);
 }
 
-}
+}} // namespace

--- a/modules/dnn/test/test_halide_layers.cpp
+++ b/modules/dnn/test/test_halide_layers.cpp
@@ -10,8 +10,7 @@
 
 #include "test_precomp.hpp"
 
-namespace cvtest
-{
+namespace opencv_test { namespace {
 
 #ifdef HAVE_HALIDE
 using namespace cv;
@@ -712,4 +711,4 @@ TEST(MixedBackends_Halide_Default_Halide, Accuracy)
 }
 #endif  // HAVE_HALIDE
 
-}  // namespace cvtest
+}} // namespace

--- a/modules/dnn/test/test_layers.cpp
+++ b/modules/dnn/test/test_layers.cpp
@@ -41,17 +41,12 @@
 
 #include "test_precomp.hpp"
 #include <opencv2/core/ocl.hpp>
-#include <iostream>
 #include "npy_blob.hpp"
 #include <opencv2/dnn/shape_utils.hpp>
 #include <opencv2/dnn/all_layers.hpp>
 #include <opencv2/ts/ocl_test.hpp>
 
-namespace cvtest
-{
-
-using namespace cv;
-using namespace cv::dnn;
+namespace opencv_test { namespace {
 
 template<typename TString>
 static String _tf(TString filename)
@@ -65,13 +60,13 @@ static String _tf(TString filename)
 
 void runLayer(Ptr<Layer> layer, std::vector<Mat> &inpBlobs, std::vector<Mat> &outBlobs)
 {
-    size_t i, ninputs = inpBlobs.size();
+    size_t ninputs = inpBlobs.size();
     std::vector<Mat> inp_(ninputs);
     std::vector<Mat*> inp(ninputs);
     std::vector<Mat> outp, intp;
     std::vector<MatShape> inputs, outputs, internals;
 
-    for( i = 0; i < ninputs; i++ )
+    for (size_t i = 0; i < ninputs; i++)
     {
         inp_[i] = inpBlobs[i].clone();
         inp[i] = &inp_[i];
@@ -79,11 +74,11 @@ void runLayer(Ptr<Layer> layer, std::vector<Mat> &inpBlobs, std::vector<Mat> &ou
     }
 
     layer->getMemoryShapes(inputs, 0, outputs, internals);
-    for(int i = 0; i < outputs.size(); i++)
+    for (size_t i = 0; i < outputs.size(); i++)
     {
         outp.push_back(Mat(outputs[i], CV_32F));
     }
-    for(int i = 0; i < internals.size(); i++)
+    for (size_t i = 0; i < internals.size(); i++)
     {
         intp.push_back(Mat(internals[i], CV_32F));
     }
@@ -93,7 +88,7 @@ void runLayer(Ptr<Layer> layer, std::vector<Mat> &inpBlobs, std::vector<Mat> &ou
 
     size_t noutputs = outp.size();
     outBlobs.resize(noutputs);
-    for( i = 0; i < noutputs; i++ )
+    for (size_t i = 0; i < noutputs; i++)
         outBlobs[i] = outp[i];
 }
 
@@ -811,4 +806,4 @@ INSTANTIATE_TEST_CASE_P(Layer_Test, Crop, Combine(
 /*offset value*/        Values(3, 4)
 ));
 
-}
+}} // namespace

--- a/modules/dnn/test/test_main.cpp
+++ b/modules/dnn/test/test_main.cpp
@@ -11,7 +11,7 @@ CV_TEST_MAIN("",
     extraTestDataPath ? (void)cvtest::addDataSearchPath(extraTestDataPath) : (void)0
 )
 
-namespace cvtest
+namespace opencv_test
 {
 
 using namespace cv;

--- a/modules/dnn/test/test_misc.cpp
+++ b/modules/dnn/test/test_misc.cpp
@@ -7,8 +7,7 @@
 
 #include "test_precomp.hpp"
 
-namespace cvtest
-{
+namespace opencv_test { namespace {
 
 TEST(blobFromImage_4ch, Regression)
 {
@@ -37,4 +36,4 @@ TEST(blobFromImage, allocated)
     ASSERT_EQ(blobData, blob.data);
 }
 
-}
+}} // namespace

--- a/modules/dnn/test/test_nms.cpp
+++ b/modules/dnn/test/test_nms.cpp
@@ -7,8 +7,7 @@
 
 #include "test_precomp.hpp"
 
-namespace cvtest
-{
+namespace opencv_test { namespace {
 
 TEST(NMS, Accuracy)
 {
@@ -38,4 +37,4 @@ TEST(NMS, Accuracy)
         ASSERT_EQ(indices[i], ref_indices[i]);
 }
 
-}//cvtest
+}} // namespace

--- a/modules/dnn/test/test_precomp.hpp
+++ b/modules/dnn/test/test_precomp.hpp
@@ -38,25 +38,18 @@
 // the use of this software, even if advised of the possibility of such damage.
 //
 //M*/
-
-#ifdef __GNUC__
-#  pragma GCC diagnostic ignored "-Wmissing-declarations"
-#  if defined __clang__ || defined __APPLE__
-#    pragma GCC diagnostic ignored "-Wmissing-prototypes"
-#    pragma GCC diagnostic ignored "-Wextra"
-#  endif
-#endif
-
 #ifndef __OPENCV_TEST_PRECOMP_HPP__
 #define __OPENCV_TEST_PRECOMP_HPP__
 
-#include "opencv2/core.hpp"
-#include "opencv2/dnn.hpp"
-#include "opencv2/highgui.hpp"
-#include "opencv2/imgproc.hpp"
 #include "opencv2/ts.hpp"
-#include <opencv2/ts/ts_perf.hpp>
-#include <opencv2/core/utility.hpp>
+#include "opencv2/ts/ts_perf.hpp"
+#include "opencv2/core/utility.hpp"
+
+#include "opencv2/dnn.hpp"
 #include "test_common.hpp"
+
+namespace opencv_test {
+using namespace cv::dnn;
+}
 
 #endif

--- a/modules/dnn/test/test_tf_importer.cpp
+++ b/modules/dnn/test/test_tf_importer.cpp
@@ -14,7 +14,7 @@ Test for Tensorflow models loading
 #include <opencv2/core/ocl.hpp>
 #include <opencv2/ts/ocl_test.hpp>
 
-namespace cvtest
+namespace opencv_test
 {
 
 using namespace cv;

--- a/modules/dnn/test/test_torch_importer.cpp
+++ b/modules/dnn/test/test_torch_importer.cpp
@@ -44,7 +44,7 @@
 #include <opencv2/dnn/shape_utils.hpp>
 #include <opencv2/ts/ocl_test.hpp>
 
-namespace cvtest
+namespace opencv_test
 {
 
 using namespace std;

--- a/modules/features2d/perf/opencl/perf_brute_force_matcher.cpp
+++ b/modules/features2d/perf/opencl/perf_brute_force_matcher.cpp
@@ -48,7 +48,7 @@
 
 #ifdef HAVE_OPENCL
 
-namespace cvtest {
+namespace opencv_test {
 namespace ocl {
 
 //////////////////// BruteForceMatch /////////////////

--- a/modules/features2d/perf/opencl/perf_feature2d.cpp
+++ b/modules/features2d/perf/opencl/perf_feature2d.cpp
@@ -4,7 +4,7 @@
 
 #ifdef HAVE_OPENCL
 
-namespace cvtest {
+namespace opencv_test {
 namespace ocl {
 
 OCL_PERF_TEST_P(feature2d, detect, testing::Combine(Feature2DType::all(), TEST_IMAGES))

--- a/modules/features2d/perf/perf_batchDistance.cpp
+++ b/modules/features2d/perf/perf_batchDistance.cpp
@@ -1,20 +1,18 @@
 #include "perf_precomp.hpp"
 
-using namespace std;
-using namespace cv;
+namespace opencv_test
+{
 using namespace perf;
-using std::tr1::make_tuple;
-using std::tr1::get;
 
 CV_ENUM(NormType, NORM_L1, NORM_L2, NORM_L2SQR, NORM_HAMMING, NORM_HAMMING2)
 
-typedef std::tr1::tuple<NormType, MatType, bool> Norm_Destination_CrossCheck_t;
+typedef tuple<NormType, MatType, bool> Norm_Destination_CrossCheck_t;
 typedef perf::TestBaseWithParam<Norm_Destination_CrossCheck_t> Norm_Destination_CrossCheck;
 
-typedef std::tr1::tuple<NormType, bool> Norm_CrossCheck_t;
+typedef tuple<NormType, bool> Norm_CrossCheck_t;
 typedef perf::TestBaseWithParam<Norm_CrossCheck_t> Norm_CrossCheck;
 
-typedef std::tr1::tuple<MatType, bool> Source_CrossCheck_t;
+typedef tuple<MatType, bool> Source_CrossCheck_t;
 typedef perf::TestBaseWithParam<Source_CrossCheck_t> Source_CrossCheck;
 
 void generateData( Mat& query, Mat& train, const int sourceType );
@@ -165,3 +163,5 @@ void generateData( Mat& query, Mat& train, const int sourceType )
         }
     }
 }
+
+} // namespace

--- a/modules/features2d/perf/perf_feature2d.cpp
+++ b/modules/features2d/perf/perf_feature2d.cpp
@@ -1,5 +1,9 @@
 #include "perf_feature2d.hpp"
 
+namespace opencv_test
+{
+using namespace perf;
+
 PERF_TEST_P(feature2d, detect, testing::Combine(Feature2DType::all(), TEST_IMAGES))
 {
     Ptr<Feature2D> detector = getFeature2D(get<0>(GetParam()));
@@ -64,3 +68,5 @@ PERF_TEST_P(feature2d, detectAndExtract, testing::Combine(testing::Values(DETECT
     EXPECT_EQ((size_t)descriptors.rows, points.size());
     SANITY_CHECK_NOTHING();
 }
+
+} // namespace

--- a/modules/features2d/perf/perf_feature2d.hpp
+++ b/modules/features2d/perf/perf_feature2d.hpp
@@ -3,13 +3,11 @@
 
 #include "perf_precomp.hpp"
 
+namespace opencv_test
+{
+
 /* cofiguration for tests of detectors/descriptors. shared between ocl and cpu tests. */
 
-using namespace std;
-using namespace cv;
-using namespace perf;
-using std::tr1::make_tuple;
-using std::tr1::get;
 // detectors/descriptors configurations to test
 #define DETECTORS_ONLY                                                                  \
     FAST_DEFAULT, FAST_20_TRUE_TYPE5_8, FAST_20_TRUE_TYPE7_12, FAST_20_TRUE_TYPE9_16,   \
@@ -30,7 +28,7 @@ using std::tr1::get;
 enum Feature2DVals { DETECTORS_ONLY, DETECTORS_EXTRACTORS };
 CV_ENUM_EXPAND(Feature2DType, DETECTORS_ONLY, DETECTORS_EXTRACTORS)
 
-typedef std::tr1::tuple<Feature2DType, string> Feature2DType_String_t;
+typedef tuple<Feature2DType, string> Feature2DType_String_t;
 typedef perf::TestBaseWithParam<Feature2DType_String_t> feature2d;
 
 #define TEST_IMAGES testing::Values(\
@@ -83,5 +81,7 @@ static inline Ptr<Feature2D> getFeature2D(Feature2DType type)
         return Ptr<Feature2D>();
     }
 }
+
+} // namespace
 
 #endif // __OPENCV_PERF_FEATURE2D_HPP__

--- a/modules/features2d/perf/perf_precomp.hpp
+++ b/modules/features2d/perf/perf_precomp.hpp
@@ -1,20 +1,7 @@
-#ifdef __GNUC__
-#  pragma GCC diagnostic ignored "-Wmissing-declarations"
-#  if defined __clang__ || defined __APPLE__
-#    pragma GCC diagnostic ignored "-Wmissing-prototypes"
-#    pragma GCC diagnostic ignored "-Wextra"
-#  endif
-#endif
-
 #ifndef __OPENCV_PERF_PRECOMP_HPP__
 #define __OPENCV_PERF_PRECOMP_HPP__
 
 #include "opencv2/ts.hpp"
-#include "opencv2/imgcodecs.hpp"
 #include "opencv2/features2d.hpp"
-
-#ifdef GTEST_CREATE_SHARED_LIBRARY
-#error no modules except ts should have GTEST_CREATE_SHARED_LIBRARY defined
-#endif
 
 #endif

--- a/modules/features2d/test/ocl/test_brute_force_matcher.cpp
+++ b/modules/features2d/test/ocl/test_brute_force_matcher.cpp
@@ -54,7 +54,7 @@
 
 #ifdef HAVE_OPENCL
 
-namespace cvtest {
+namespace opencv_test {
 namespace ocl {
 PARAM_TEST_CASE(BruteForceMatcher, int, int)
 {

--- a/modules/features2d/test/ocl/test_feature2d.cpp
+++ b/modules/features2d/test/ocl/test_feature2d.cpp
@@ -8,7 +8,7 @@
 
 #ifdef HAVE_OPENCL
 
-namespace cvtest {
+namespace opencv_test {
 namespace ocl {
 
 #define TEST_IMAGES testing::Values(\

--- a/modules/features2d/test/test_agast.cpp
+++ b/modules/features2d/test/test_agast.cpp
@@ -42,8 +42,7 @@
 
 #include "test_precomp.hpp"
 
-using namespace std;
-using namespace cv;
+namespace opencv_test { namespace {
 
 class CV_AgastTest : public cvtest::BaseTest
 {
@@ -135,3 +134,5 @@ void CV_AgastTest::run( int )
 }
 
 TEST(Features2d_AGAST, regression) { CV_AgastTest test; test.safe_run(); }
+
+}} // namespace

--- a/modules/features2d/test/test_akaze.cpp
+++ b/modules/features2d/test/test_akaze.cpp
@@ -4,8 +4,7 @@
 
 #include "test_precomp.hpp"
 
-using namespace std;
-using namespace cv;
+namespace opencv_test { namespace {
 
 TEST(Features2d_AKAZE, detect_and_compute_split)
 {
@@ -45,3 +44,5 @@ TEST(Features2d_AKAZE, uninitialized_and_nans)
     Ptr<Feature2D> akaze = AKAZE::create();
     akaze->detectAndCompute(b1, noArray(), keypoints, desc);
 }
+
+}} // namespace

--- a/modules/features2d/test/test_brisk.cpp
+++ b/modules/features2d/test/test_brisk.cpp
@@ -42,8 +42,7 @@
 
 #include "test_precomp.hpp"
 
-using namespace std;
-using namespace cv;
+namespace opencv_test { namespace {
 
 class CV_BRISKTest : public cvtest::BaseTest
 {
@@ -93,3 +92,5 @@ void CV_BRISKTest::run( int )
 }
 
 TEST(Features2d_BRISK, regression) { CV_BRISKTest test; test.safe_run(); }
+
+}} // namespace

--- a/modules/features2d/test/test_descriptors_invariance.cpp
+++ b/modules/features2d/test/test_descriptors_invariance.cpp
@@ -5,15 +5,11 @@
 #include "test_precomp.hpp"
 #include "test_invariance_utils.hpp"
 
-using namespace std;
-using namespace cv;
-using std::tr1::make_tuple;
-using std::tr1::get;
-using namespace testing;
+namespace opencv_test { namespace {
 
 #define SHOW_DEBUG_LOG 1
 
-typedef std::tr1::tuple<std::string, Ptr<FeatureDetector>, Ptr<DescriptorExtractor>, float>
+typedef tuple<std::string, Ptr<FeatureDetector>, Ptr<DescriptorExtractor>, float>
     String_FeatureDetector_DescriptorExtractor_Float_t;
 const static std::string IMAGE_TSUKUBA = "features2d/tsukuba.png";
 const static std::string IMAGE_BIKES = "detectors_descriptors_evaluation/images_datasets/bikes/img1.png";
@@ -192,3 +188,5 @@ INSTANTIATE_TEST_CASE_P(AKAZE, DescriptorScaleInvariance,
 
 INSTANTIATE_TEST_CASE_P(AKAZE_DESCRIPTOR_KAZE, DescriptorScaleInvariance,
                         Value(IMAGE_BIKES, AKAZE::create(AKAZE::DESCRIPTOR_KAZE), AKAZE::create(AKAZE::DESCRIPTOR_KAZE), 0.55f));
+
+}} // namespace

--- a/modules/features2d/test/test_descriptors_regression.cpp
+++ b/modules/features2d/test/test_descriptors_regression.cpp
@@ -41,9 +41,7 @@
 
 #include "test_precomp.hpp"
 
-using namespace std;
-using namespace cv;
-using namespace testing;
+namespace opencv_test { namespace {
 
 const string FEATURES2D_DIR = "features2d";
 const string IMAGE_FILENAME = "tsukuba.png";
@@ -151,7 +149,7 @@ protected:
 
         float exact_percents = (100 * (float)exact_count / validDescriptors.rows);
         float failed_percents = (100 * (float)failed_count / validDescriptors.rows);
-        stringstream ss;
+        std::stringstream ss;
         ss << "Exact count (dist == 0): " << exact_count << " (" << (int)exact_percents << "%)" << std::endl
                 << "Failed count (dist > " << maxDist << "): " << failed_count << " (" << (int)failed_percents << "%)" << std::endl
                 << "Max distance between valid and computed descriptors (" << validDescriptors.size() << "): " << curMaxDist;
@@ -497,3 +495,5 @@ INSTANTIATE_TEST_CASE_P(Features2d, DescriptorImage,
             "shared/templ.png"
         )
 );
+
+}} // namespace

--- a/modules/features2d/test/test_detectors_invariance.cpp
+++ b/modules/features2d/test/test_detectors_invariance.cpp
@@ -5,15 +5,12 @@
 #include "test_precomp.hpp"
 #include "test_invariance_utils.hpp"
 
-using namespace std;
-using namespace cv;
-using std::tr1::make_tuple;
-using std::tr1::get;
-using namespace testing;
+namespace opencv_test { namespace {
+using namespace perf;
 
 #define SHOW_DEBUG_LOG 1
 
-typedef std::tr1::tuple<std::string, Ptr<FeatureDetector>, float, float> String_FeatureDetector_Float_Float_t;
+typedef tuple<std::string, Ptr<FeatureDetector>, float, float> String_FeatureDetector_Float_Float_t;
 const static std::string IMAGE_TSUKUBA = "features2d/tsukuba.png";
 const static std::string IMAGE_BIKES = "detectors_descriptors_evaluation/images_datasets/bikes/img1.png";
 #define Value(...) Values(String_FeatureDetector_Float_Float_t(__VA_ARGS__))
@@ -253,3 +250,5 @@ INSTANTIATE_TEST_CASE_P(AKAZE, DetectorScaleInvariance,
 
 INSTANTIATE_TEST_CASE_P(AKAZE_DESCRIPTOR_KAZE, DetectorScaleInvariance,
                         Value(IMAGE_BIKES, AKAZE::create(AKAZE::DESCRIPTOR_KAZE), 0.08f, 0.49f));
+
+}} // namespace

--- a/modules/features2d/test/test_detectors_regression.cpp
+++ b/modules/features2d/test/test_detectors_regression.cpp
@@ -41,8 +41,7 @@
 
 #include "test_precomp.hpp"
 
-using namespace std;
-using namespace cv;
+namespace opencv_test { namespace {
 
 const string FEATURES2D_DIR = "features2d";
 const string IMAGE_FILENAME = "tsukuba.png";
@@ -114,7 +113,7 @@ bool CV_FeatureDetectorTest::isSimilarKeypoints( const KeyPoint& p1, const KeyPo
     const float maxAngleDif = 2.f;
     const float maxResponseDif = 0.1f;
 
-    float dist = (float)norm( p1.pt - p2.pt );
+    float dist = (float)cv::norm( p1.pt - p2.pt );
     return (dist < maxPtDif &&
             fabs(p1.size - p2.size) < maxSizeDif &&
             abs(p1.angle - p2.angle) < maxAngleDif &&
@@ -147,7 +146,7 @@ void CV_FeatureDetectorTest::compareKeypointSets( const vector<KeyPoint>& validK
         for( size_t c = 0; c < calcKeypoints.size(); c++ )
         {
             progress = update_progress( progress, (int)(v*calcKeypoints.size() + c), progressCount, 0 );
-            float curDist = (float)norm( calcKeypoints[c].pt - validKeypoints[v].pt );
+            float curDist = (float)cv::norm( calcKeypoints[c].pt - validKeypoints[v].pt );
             if( curDist < minDist )
             {
                 minDist = curDist;
@@ -307,3 +306,5 @@ TEST( Features2d_Detector_AKAZE_DESCRIPTOR_KAZE, regression )
     CV_FeatureDetectorTest test( "detector-akaze-with-kaze-desc", AKAZE::create(AKAZE::DESCRIPTOR_KAZE) );
     test.safe_run();
 }
+
+}} // namespace

--- a/modules/features2d/test/test_fast.cpp
+++ b/modules/features2d/test/test_fast.cpp
@@ -42,8 +42,7 @@
 
 #include "test_precomp.hpp"
 
-using namespace std;
-using namespace cv;
+namespace opencv_test { namespace {
 
 class CV_FastTest : public cvtest::BaseTest
 {
@@ -135,3 +134,5 @@ void CV_FastTest::run( int )
 }
 
 TEST(Features2d_FAST, regression) { CV_FastTest test; test.safe_run(); }
+
+}} // namespace

--- a/modules/features2d/test/test_invariance_utils.hpp
+++ b/modules/features2d/test/test_invariance_utils.hpp
@@ -5,12 +5,8 @@
 #ifndef __OPENCV_TEST_INVARIANCE_UTILS_HPP__
 #define __OPENCV_TEST_INVARIANCE_UTILS_HPP__
 
-#include "test_precomp.hpp"
+namespace opencv_test { namespace {
 
-using namespace std;
-using namespace cv;
-
-static
 Mat generateHomography(float angle)
 {
     // angle - rotation around Oz in degrees
@@ -23,7 +19,6 @@ Mat generateHomography(float angle)
     return H;
 }
 
-static
 Mat rotateImage(const Mat& srcImage, const Mat& srcMask, float angle, Mat& dstImage, Mat& dstMask)
 {
     // angle - rotation around Oz in degrees
@@ -43,10 +38,9 @@ Mat rotateImage(const Mat& srcImage, const Mat& srcMask, float angle, Mat& dstIm
     return H;
 }
 
-static
 float calcCirclesIntersectArea(const Point2f& p0, float r0, const Point2f& p1, float r1)
 {
-    float c = static_cast<float>(norm(p0 - p1)), sqr_c = c * c;
+    float c = static_cast<float>(cv::norm(p0 - p1)), sqr_c = c * c;
 
     float sqr_r0 = r0 * r0;
     float sqr_r1 = r1 * r1;
@@ -69,7 +63,6 @@ float calcCirclesIntersectArea(const Point2f& p0, float r0, const Point2f& p1, f
             0.5f * sqr_r1 * (A1 - sin(A1));
 }
 
-static
 float calcIntersectRatio(const Point2f& p0, float r0, const Point2f& p1, float r1)
 {
     float intersectArea = calcCirclesIntersectArea(p0, r0, p1, r1);
@@ -77,7 +70,6 @@ float calcIntersectRatio(const Point2f& p0, float r0, const Point2f& p1, float r
     return intersectArea / unionArea;
 }
 
-static
 void scaleKeyPoints(const vector<KeyPoint>& src, vector<KeyPoint>& dst, float scale)
 {
     dst.resize(src.size());
@@ -89,4 +81,5 @@ void scaleKeyPoints(const vector<KeyPoint>& src, vector<KeyPoint>& dst, float sc
     }
 }
 
+}} // namespace
 #endif // __OPENCV_TEST_INVARIANCE_UTILS_HPP__

--- a/modules/features2d/test/test_keypoints.cpp
+++ b/modules/features2d/test/test_keypoints.cpp
@@ -42,8 +42,7 @@
 #include "test_precomp.hpp"
 #include "opencv2/core/core_c.h"
 
-using namespace std;
-using namespace cv;
+namespace opencv_test { namespace {
 
 const string FEATURES2D_DIR = "features2d";
 const string IMAGE_FILENAME = "tsukuba.png";
@@ -177,3 +176,5 @@ TEST(Features2d_Detector_Keypoints_AKAZE, validation)
     CV_FeatureDetectorKeypointsTest test_mldb(AKAZE::create(AKAZE::DESCRIPTOR_MLDB));
     test_mldb.safe_run();
 }
+
+}} // namespace

--- a/modules/features2d/test/test_main.cpp
+++ b/modules/features2d/test/test_main.cpp
@@ -1,3 +1,6 @@
+// This file is part of OpenCV project.
+// It is subject to the license terms in the LICENSE file found in the top-level directory
+// of this distribution and at http://opencv.org/license.html.
 #include "test_precomp.hpp"
 
 CV_TEST_MAIN("cv")

--- a/modules/features2d/test/test_matchers_algorithmic.cpp
+++ b/modules/features2d/test/test_matchers_algorithmic.cpp
@@ -41,8 +41,7 @@
 
 #include "test_precomp.hpp"
 
-using namespace std;
-using namespace cv;
+namespace opencv_test { namespace {
 
 const string FEATURES2D_DIR = "features2d";
 const string IMAGE_FILENAME = "tsukuba.png";
@@ -65,7 +64,9 @@ protected:
     virtual void run( int );
     void generateData( Mat& query, Mat& train );
 
-    void emptyDataTest();
+#if 0
+    void emptyDataTest(); // FIXIT not used
+#endif
     void matchTest( const Mat& query, const Mat& train );
     void knnMatchTest( const Mat& query, const Mat& train );
     void radiusMatchTest( const Mat& query, const Mat& train );
@@ -77,6 +78,7 @@ private:
     CV_DescriptorMatcherTest& operator=(const CV_DescriptorMatcherTest&) { return *this; }
 };
 
+#if 0
 void CV_DescriptorMatcherTest::emptyDataTest()
 {
     assert( !dmatcher.empty() );
@@ -156,6 +158,7 @@ void CV_DescriptorMatcherTest::emptyDataTest()
     }
 
 }
+#endif
 
 void CV_DescriptorMatcherTest::generateData( Mat& query, Mat& train )
 {
@@ -554,3 +557,5 @@ TEST( Features2d_DMatch, read_write )
     String str = fs.releaseAndGetString();
     ASSERT_NE( strstr(str.c_str(), "4.5"), (char*)0 );
 }
+
+}} // namespace

--- a/modules/features2d/test/test_mser.cpp
+++ b/modules/features2d/test/test_mser.cpp
@@ -41,12 +41,8 @@
 //M*/
 
 #include "test_precomp.hpp"
-#include "opencv2/highgui.hpp"
 
-#include <vector>
-#include <string>
-using namespace std;
-using namespace cv;
+namespace opencv_test { namespace {
 
 #undef RENDER_MSERS
 #define RENDER_MSERS 0
@@ -127,7 +123,7 @@ TEST(Features2d_MSER, cases)
         if( invert )
             bitwise_not(src, src);
         if( binarize )
-            threshold(src, src, thresh, 255, THRESH_BINARY);
+            cv::threshold(src, src, thresh, 255, THRESH_BINARY);
         if( blur )
             GaussianBlur(src, src, Size(5, 5), 1.5, 1.5);
 
@@ -182,3 +178,5 @@ TEST(Features2d_MSER, history_update_regression)
         }
     }
 }
+
+}} // namespace

--- a/modules/features2d/test/test_nearestneighbors.cpp
+++ b/modules/features2d/test/test_nearestneighbors.cpp
@@ -43,12 +43,8 @@
 
 #include "test_precomp.hpp"
 
-#include <algorithm>
-#include <vector>
-#include <iostream>
+namespace opencv_test { namespace {
 
-using namespace std;
-using namespace cv;
 #ifdef HAVE_OPENCV_FLANN
 using namespace cv::flann;
 #endif
@@ -337,3 +333,5 @@ TEST(Features2d_FLANN_Auto, regression) { CV_FlannAutotunedIndexTest test; test.
 TEST(Features2d_FLANN_Saved, regression) { CV_FlannSavedIndexTest test; test.safe_run(); }
 
 #endif
+
+}} // namespace

--- a/modules/features2d/test/test_orb.cpp
+++ b/modules/features2d/test/test_orb.cpp
@@ -41,8 +41,7 @@
 
 #include "test_precomp.hpp"
 
-using namespace std;
-using namespace cv;
+namespace opencv_test { namespace {
 
 TEST(Features2D_ORB, _1996)
 {
@@ -123,3 +122,5 @@ TEST(Features2D_ORB, crash)
 
     ASSERT_NO_THROW(orb->compute(image, keypoints, descriptors));
 }
+
+}} // namespace

--- a/modules/features2d/test/test_precomp.hpp
+++ b/modules/features2d/test/test_precomp.hpp
@@ -1,18 +1,10 @@
-#ifdef __GNUC__
-#  pragma GCC diagnostic ignored "-Wmissing-declarations"
-#  if defined __clang__ || defined __APPLE__
-#    pragma GCC diagnostic ignored "-Wmissing-prototypes"
-#    pragma GCC diagnostic ignored "-Wextra"
-#  endif
-#endif
-
+// This file is part of OpenCV project.
+// It is subject to the license terms in the LICENSE file found in the top-level directory
+// of this distribution and at http://opencv.org/license.html.
 #ifndef __OPENCV_TEST_PRECOMP_HPP__
 #define __OPENCV_TEST_PRECOMP_HPP__
 
 #include "opencv2/ts.hpp"
-#include "opencv2/imgproc.hpp"
 #include "opencv2/features2d.hpp"
-#include "opencv2/imgcodecs.hpp"
-#include <iostream>
 
 #endif

--- a/modules/flann/test/test_lshtable_badarg.cpp
+++ b/modules/flann/test/test_lshtable_badarg.cpp
@@ -41,7 +41,7 @@
 
 #include "test_precomp.hpp"
 
-using namespace cv;
+namespace opencv_test { namespace {
 
 class CV_LshTableBadArgTest : public cvtest::BadArgTest
 {
@@ -89,3 +89,5 @@ void CV_LshTableBadArgTest::run( int /* start_from */ )
 }
 
 TEST(Flann_LshTable, badarg) { CV_LshTableBadArgTest test; test.safe_run(); }
+
+}} // namespace

--- a/modules/flann/test/test_precomp.hpp
+++ b/modules/flann/test/test_precomp.hpp
@@ -1,16 +1,7 @@
-#ifdef __GNUC__
-#  pragma GCC diagnostic ignored "-Wmissing-declarations"
-#  if defined __clang__ || defined __APPLE__
-#    pragma GCC diagnostic ignored "-Wmissing-prototypes"
-#    pragma GCC diagnostic ignored "-Wextra"
-#  endif
-#endif
-
 #ifndef OPENCV_TEST_PRECOMP_HPP
 #define OPENCV_TEST_PRECOMP_HPP
 
 #include "opencv2/ts.hpp"
 #include "opencv2/flann.hpp"
-#include <iostream>
 
 #endif

--- a/modules/highgui/test/test_gui.cpp
+++ b/modules/highgui/test/test_gui.cpp
@@ -41,12 +41,10 @@
 //M*/
 
 #include "test_precomp.hpp"
-#include "opencv2/highgui.hpp"
+
+namespace opencv_test { namespace {
 
 #if defined HAVE_GTK || defined HAVE_QT || defined HAVE_WIN32UI || defined HAVE_CARBON || defined HAVE_COCOA
-
-using namespace cv;
-using namespace std;
 
 class CV_HighGuiOnlyGuiTest : public cvtest::BaseTest
 {
@@ -54,7 +52,7 @@ protected:
     void run(int);
 };
 
-void Foo(int /*k*/, void* /*z*/) {}
+static void Foo(int /*k*/, void* /*z*/) {}
 
 void CV_HighGuiOnlyGuiTest::run( int /*start_from */)
 {
@@ -95,3 +93,5 @@ void CV_HighGuiOnlyGuiTest::run( int /*start_from */)
 TEST(Highgui_GUI,    regression) { CV_HighGuiOnlyGuiTest test; test.safe_run(); }
 
 #endif
+
+}} // namespace

--- a/modules/highgui/test/test_main.cpp
+++ b/modules/highgui/test/test_main.cpp
@@ -1,3 +1,6 @@
+// This file is part of OpenCV project.
+// It is subject to the license terms in the LICENSE file found in the top-level directory
+// of this distribution and at http://opencv.org/license.html.
 #include "test_precomp.hpp"
 
 CV_TEST_MAIN("highgui")

--- a/modules/highgui/test/test_precomp.hpp
+++ b/modules/highgui/test/test_precomp.hpp
@@ -1,9 +1,5 @@
-#ifdef __GNUC__
-#  pragma GCC diagnostic ignored "-Wmissing-declarations"
-#  if defined __clang__ || defined __APPLE__
-#    pragma GCC diagnostic ignored "-Wmissing-prototypes"
-#    pragma GCC diagnostic ignored "-Wextra"
-#  endif
-#endif
-
+// This file is part of OpenCV project.
+// It is subject to the license terms in the LICENSE file found in the top-level directory
+// of this distribution and at http://opencv.org/license.html.
 #include "opencv2/ts.hpp"
+#include "opencv2/highgui.hpp"

--- a/modules/imgcodecs/perf/perf_main.cpp
+++ b/modules/imgcodecs/perf/perf_main.cpp
@@ -1,3 +1,6 @@
+// This file is part of OpenCV project.
+// It is subject to the license terms in the LICENSE file found in the top-level directory
+// of this distribution and at http://opencv.org/license.html
 #include "perf_precomp.hpp"
 
 CV_PERF_TEST_MAIN(imgcodecs)

--- a/modules/imgcodecs/perf/perf_precomp.hpp
+++ b/modules/imgcodecs/perf/perf_precomp.hpp
@@ -1,19 +1,10 @@
-#ifdef __GNUC__
-#  pragma GCC diagnostic ignored "-Wmissing-declarations"
-#  if defined __clang__ || defined __APPLE__
-#    pragma GCC diagnostic ignored "-Wmissing-prototypes"
-#    pragma GCC diagnostic ignored "-Wextra"
-#  endif
-#endif
-
+// This file is part of OpenCV project.
+// It is subject to the license terms in the LICENSE file found in the top-level directory
+// of this distribution and at http://opencv.org/license.html
 #ifndef __OPENCV_PERF_PRECOMP_HPP__
 #define __OPENCV_PERF_PRECOMP_HPP__
 
 #include "opencv2/ts.hpp"
 #include "opencv2/imgcodecs.hpp"
-
-#ifdef GTEST_CREATE_SHARED_LIBRARY
-#error no modules except ts should have GTEST_CREATE_SHARED_LIBRARY defined
-#endif
 
 #endif

--- a/modules/imgcodecs/test/test_grfmt.cpp
+++ b/modules/imgcodecs/test/test_grfmt.cpp
@@ -42,9 +42,7 @@
 
 #include "test_precomp.hpp"
 
-using namespace cv;
-using namespace std;
-using namespace std::tr1;
+namespace opencv_test { namespace {
 
 typedef tuple<string, int> File_Mode;
 typedef testing::TestWithParam<File_Mode> Imgcodecs_FileMode;
@@ -119,8 +117,8 @@ struct notForGDAL {
 inline vector<string> gdal_images()
 {
     vector<string> res;
-    back_insert_iterator< vector<string> > it(res);
-    remove_copy_if(all_images, all_images + sizeof(all_images)/sizeof(all_images[0]), it, notForGDAL());
+    std::back_insert_iterator< vector<string> > it(res);
+    std::remove_copy_if(all_images, all_images + sizeof(all_images)/sizeof(all_images[0]), it, notForGDAL());
     return res;
 }
 
@@ -327,3 +325,5 @@ TEST(Imgcodecs_Pam, read_write)
     remove(writefile.c_str());
     remove(writefile_no_param.c_str());
 }
+
+}} // namespace

--- a/modules/imgcodecs/test/test_jpeg.cpp
+++ b/modules/imgcodecs/test/test_jpeg.cpp
@@ -1,8 +1,9 @@
+// This file is part of OpenCV project.
+// It is subject to the license terms in the LICENSE file found in the top-level directory
+// of this distribution and at http://opencv.org/license.html
 #include "test_precomp.hpp"
 
-using namespace cv;
-using namespace std;
-using namespace std::tr1;
+namespace opencv_test { namespace {
 
 #ifdef HAVE_JPEG
 
@@ -178,3 +179,5 @@ TEST(Imgcodecs_Jpeg, encode_decode_rst_jpeg)
 }
 
 #endif // HAVE_JPEG
+
+}} // namespace

--- a/modules/imgcodecs/test/test_main.cpp
+++ b/modules/imgcodecs/test/test_main.cpp
@@ -1,3 +1,6 @@
+// This file is part of OpenCV project.
+// It is subject to the license terms in the LICENSE file found in the top-level directory
+// of this distribution and at http://opencv.org/license.html
 #include "test_precomp.hpp"
 
 CV_TEST_MAIN("highgui")

--- a/modules/imgcodecs/test/test_png.cpp
+++ b/modules/imgcodecs/test/test_png.cpp
@@ -1,8 +1,9 @@
+// This file is part of OpenCV project.
+// It is subject to the license terms in the LICENSE file found in the top-level directory
+// of this distribution and at http://opencv.org/license.html
 #include "test_precomp.hpp"
 
-using namespace cv;
-using namespace std;
-using namespace std::tr1;
+namespace opencv_test { namespace {
 
 #ifdef HAVE_PNG
 
@@ -93,3 +94,5 @@ TEST(Imgcodecs_Png, read_color_palette_with_alpha)
 }
 
 #endif // HAVE_PNG
+
+}} // namespace

--- a/modules/imgcodecs/test/test_precomp.hpp
+++ b/modules/imgcodecs/test/test_precomp.hpp
@@ -1,25 +1,11 @@
-#ifdef __GNUC__
-#  pragma GCC diagnostic ignored "-Wmissing-declarations"
-#  if defined __clang__ || defined __APPLE__
-#    pragma GCC diagnostic ignored "-Wmissing-prototypes"
-#    pragma GCC diagnostic ignored "-Wextra"
-#  endif
-#endif
-
+// This file is part of OpenCV project.
+// It is subject to the license terms in the LICENSE file found in the top-level directory
+// of this distribution and at http://opencv.org/license.html
 #ifndef __OPENCV_TEST_PRECOMP_HPP__
 #define __OPENCV_TEST_PRECOMP_HPP__
 
 #include "opencv2/ts.hpp"
-#include "opencv2/imgproc.hpp"
 #include "opencv2/imgcodecs.hpp"
 #include "opencv2/imgproc/imgproc_c.h"
-
-#include "opencv2/core/private.hpp"
-
-#include <fstream>
-#include <sstream>
-#include <iostream>
-#include <algorithm>
-#include <iterator>
 
 #endif

--- a/modules/imgcodecs/test/test_read_write.cpp
+++ b/modules/imgcodecs/test/test_read_write.cpp
@@ -1,12 +1,9 @@
+// This file is part of OpenCV project.
+// It is subject to the license terms in the LICENSE file found in the top-level directory
+// of this distribution and at http://opencv.org/license.html
 #include "test_precomp.hpp"
 
-#include <fstream>
-#include <sstream>
-#include <iostream>
-
-using namespace cv;
-using namespace std;
-using namespace cvtest;
+namespace opencv_test { namespace {
 
 TEST(Imgcodecs_Image, read_write_bmp)
 {
@@ -129,3 +126,5 @@ TEST(Imgcodecs_Image, regression_9376)
     EXPECT_EQ(32, m.cols);
     EXPECT_EQ(32, m.rows);
 }
+
+}} // namespace

--- a/modules/imgcodecs/test/test_tiff.cpp
+++ b/modules/imgcodecs/test/test_tiff.cpp
@@ -1,8 +1,9 @@
+// This file is part of OpenCV project.
+// It is subject to the license terms in the LICENSE file found in the top-level directory
+// of this distribution and at http://opencv.org/license.html
 #include "test_precomp.hpp"
 
-using namespace cv;
-using namespace std;
-using namespace std::tr1;
+namespace opencv_test { namespace {
 
 #ifdef HAVE_TIFF
 
@@ -217,3 +218,5 @@ TEST(Imgcodecs_Tiff, imdecode_no_exception_temporary_file_removed)
 }
 
 #endif
+
+}} // namespace

--- a/modules/imgcodecs/test/test_webp.cpp
+++ b/modules/imgcodecs/test/test_webp.cpp
@@ -1,8 +1,9 @@
+// This file is part of OpenCV project.
+// It is subject to the license terms in the LICENSE file found in the top-level directory
+// of this distribution and at http://opencv.org/license.html
 #include "test_precomp.hpp"
 
-using namespace cv;
-using namespace std;
-using namespace std::tr1;
+namespace opencv_test { namespace {
 
 #ifdef HAVE_WEBP
 
@@ -104,3 +105,5 @@ TEST(Imgcodecs_WebP, encode_decode_with_alpha_webp)
 }
 
 #endif // HAVE_WEBP
+
+}} // namespace

--- a/modules/imgproc/perf/opencl/perf_3vs4.cpp
+++ b/modules/imgproc/perf/opencl/perf_3vs4.cpp
@@ -10,7 +10,7 @@
 
 #ifdef HAVE_OPENCL
 
-namespace cvtest {
+namespace opencv_test {
 namespace ocl {
 
 ///////////// 3 channels Vs 4 ////////////////////////
@@ -132,6 +132,6 @@ OCL_PERF_TEST_P(_3vs4_Fixture, Subtract,
     SANITY_CHECK_NOTHING();
 }
 
-} } // namespace cvtest::ocl
+} } // namespace opencv_test::ocl
 
 #endif // HAVE_OPENCL

--- a/modules/imgproc/perf/opencl/perf_accumulate.cpp
+++ b/modules/imgproc/perf/opencl/perf_accumulate.cpp
@@ -48,7 +48,7 @@
 
 #ifdef HAVE_OPENCL
 
-namespace cvtest {
+namespace opencv_test {
 namespace ocl {
 
 /////////////////////////////////// Accumulate ///////////////////////////////////
@@ -135,6 +135,6 @@ OCL_PERF_TEST_P(AccumulateWeightedFixture, AccumulateWeighted,
     SANITY_CHECK_NOTHING();
 }
 
-} } // namespace cvtest::ocl
+} } // namespace opencv_test::ocl
 
 #endif

--- a/modules/imgproc/perf/opencl/perf_blend.cpp
+++ b/modules/imgproc/perf/opencl/perf_blend.cpp
@@ -49,7 +49,7 @@
 
 #ifdef HAVE_OPENCL
 
-namespace cvtest {
+namespace opencv_test {
 namespace ocl {
 
 ///////////// BlendLinear ////////////////////////
@@ -77,6 +77,6 @@ OCL_PERF_TEST_P(BlendLinearFixture, BlendLinear, ::testing::Combine(OCL_TEST_SIZ
     SANITY_CHECK(dst, eps);
 }
 
-} } // namespace cvtest::ocl
+} } // namespace opencv_test::ocl
 
 #endif // HAVE_OPENCL

--- a/modules/imgproc/perf/opencl/perf_color.cpp
+++ b/modules/imgproc/perf/opencl/perf_color.cpp
@@ -49,10 +49,8 @@
 
 #ifdef HAVE_OPENCL
 
-namespace cvtest {
+namespace opencv_test {
 namespace ocl {
-
-using std::tr1::make_tuple;
 
 ///////////// cvtColor////////////////////////
 
@@ -110,6 +108,6 @@ OCL_PERF_TEST_P(CvtColorFixture, CvtColor, testing::Combine(
     SANITY_CHECK(dst, 1);
 }
 
-} } // namespace cvtest::ocl
+} } // namespace opencv_test::ocl
 
 #endif // HAVE_OPENCL

--- a/modules/imgproc/perf/opencl/perf_filters.cpp
+++ b/modules/imgproc/perf/opencl/perf_filters.cpp
@@ -49,7 +49,7 @@
 
 #ifdef HAVE_OPENCL
 
-namespace cvtest {
+namespace opencv_test {
 namespace ocl {
 
 typedef tuple<Size, MatType, int> FilterParams;
@@ -323,6 +323,6 @@ OCL_PERF_TEST_P(MedianBlurFixture, Bilateral, ::testing::Combine(OCL_TEST_SIZES,
     SANITY_CHECK(dst);
 }
 
-} } // namespace cvtest::ocl
+} } // namespace opencv_test::ocl
 
 #endif // HAVE_OPENCL

--- a/modules/imgproc/perf/opencl/perf_gftt.cpp
+++ b/modules/imgproc/perf/opencl/perf_gftt.cpp
@@ -48,7 +48,7 @@
 
 #ifdef HAVE_OPENCL
 
-namespace cvtest {
+namespace opencv_test {
 namespace ocl {
 
 //////////////////////////// GoodFeaturesToTrack //////////////////////////
@@ -82,6 +82,6 @@ OCL_PERF_TEST_P(GoodFeaturesToTrackFixture, GoodFeaturesToTrack,
     SANITY_CHECK(dst);
 }
 
-} } // namespace cvtest::ocl
+} } // namespace opencv_test::ocl
 
 #endif

--- a/modules/imgproc/perf/opencl/perf_houghlines.cpp
+++ b/modules/imgproc/perf/opencl/perf_houghlines.cpp
@@ -10,7 +10,7 @@
 
 #ifdef HAVE_OPENCL
 
-namespace cvtest {
+namespace opencv_test {
 namespace ocl {
 
 ///////////// HoughLines //////////////////////
@@ -24,7 +24,7 @@ struct Vec2fComparator
     }
 };
 
-typedef std::tr1::tuple<Size, double, double> ImageSize_RhoStep_ThetaStep_t;
+typedef tuple<Size, double, double> ImageSize_RhoStep_ThetaStep_t;
 typedef TestBaseWithParam<ImageSize_RhoStep_ThetaStep_t> HoughLinesFixture;
 
 OCL_PERF_TEST_P(HoughLinesFixture, HoughLines, Combine(OCL_TEST_SIZES,
@@ -60,7 +60,7 @@ OCL_PERF_TEST_P(HoughLinesFixture, HoughLines, Combine(OCL_TEST_SIZES,
 
 ///////////// HoughLinesP /////////////////////
 
-typedef std::tr1::tuple<string, double, double> Image_RhoStep_ThetaStep_t;
+typedef tuple<string, double, double> Image_RhoStep_ThetaStep_t;
 typedef TestBaseWithParam<Image_RhoStep_ThetaStep_t> HoughLinesPFixture;
 
 OCL_PERF_TEST_P(HoughLinesPFixture, HoughLinesP, Combine(Values("cv/shared/pic5.png", "stitching/a1.png"),
@@ -86,6 +86,6 @@ OCL_PERF_TEST_P(HoughLinesPFixture, HoughLinesP, Combine(Values("cv/shared/pic5.
     SANITY_CHECK_NOTHING();
 }
 
-} } // namespace cvtest::ocl
+} } // namespace opencv_test::ocl
 
 #endif // HAVE_OPENCL

--- a/modules/imgproc/perf/opencl/perf_imgproc.cpp
+++ b/modules/imgproc/perf/opencl/perf_imgproc.cpp
@@ -47,7 +47,7 @@
 #include "../perf_precomp.hpp"
 #include "opencv2/ts/ocl_perf.hpp"
 
-namespace cvtest {
+namespace opencv_test {
 namespace ocl {
 
 ///////////// equalizeHist ////////////////////////
@@ -323,4 +323,4 @@ OCL_PERF_TEST_P(CannyFixture, Canny, ::testing::Combine(OCL_TEST_SIZES, OCL_PERF
     SANITY_CHECK_NOTHING();
 }
 
-} } // namespace cvtest::ocl
+} } // namespace opencv_test::ocl

--- a/modules/imgproc/perf/opencl/perf_imgwarp.cpp
+++ b/modules/imgproc/perf/opencl/perf_imgwarp.cpp
@@ -49,7 +49,7 @@
 
 #ifdef HAVE_OPENCL
 
-namespace cvtest {
+namespace opencv_test {
 namespace ocl {
 
 ///////////// WarpAffine ////////////////////////
@@ -232,6 +232,6 @@ OCL_PERF_TEST_P(RemapFixture, Remap,
     SANITY_CHECK(dst, eps);
 }
 
-} } // namespace cvtest::ocl
+} } // namespace opencv_test::ocl
 
 #endif // HAVE_OPENCL

--- a/modules/imgproc/perf/opencl/perf_matchTemplate.cpp
+++ b/modules/imgproc/perf/opencl/perf_matchTemplate.cpp
@@ -3,13 +3,12 @@
 
 #ifdef HAVE_OPENCL
 
-namespace cvtest {
-
+namespace opencv_test {
 namespace ocl {
 
 CV_ENUM(MethodType, TM_SQDIFF, TM_SQDIFF_NORMED, TM_CCORR, TM_CCORR_NORMED, TM_CCOEFF, TM_CCOEFF_NORMED)
 
-typedef std::tr1::tuple<Size, Size, MethodType, MatType> ImgSize_TmplSize_Method_MatType_t;
+typedef tuple<Size, Size, MethodType, MatType> ImgSize_TmplSize_Method_MatType_t;
 typedef TestBaseWithParam<ImgSize_TmplSize_Method_MatType_t> ImgSize_TmplSize_Method_MatType;
 
 OCL_PERF_TEST_P(ImgSize_TmplSize_Method_MatType, MatchTemplate,
@@ -84,6 +83,6 @@ OCL_PERF_TEST_P(CV_TM_CCORR_NORMEDFixture, matchTemplate,
     SANITY_CHECK(dst, 3e-2);
 }
 
-} }
+} } // namespace
 
 #endif // HAVE_OPENCL

--- a/modules/imgproc/perf/opencl/perf_moments.cpp
+++ b/modules/imgproc/perf/opencl/perf_moments.cpp
@@ -49,7 +49,7 @@
 
 #ifdef HAVE_OPENCL
 
-namespace cvtest {
+namespace opencv_test {
 namespace ocl {
 
 ///////////// Moments ////////////////////////
@@ -73,6 +73,6 @@ OCL_PERF_TEST_P(MomentsFixture, Moments,
     SANITY_CHECK_MOMENTS(m, 1e-6, ERROR_RELATIVE);
 }
 
-} } // namespace cvtest::ocl
+} } // namespace opencv_test::ocl
 
 #endif // HAVE_OPENCL

--- a/modules/imgproc/perf/opencl/perf_pyramid.cpp
+++ b/modules/imgproc/perf/opencl/perf_pyramid.cpp
@@ -49,7 +49,7 @@
 
 #ifdef HAVE_OPENCL
 
-namespace cvtest {
+namespace opencv_test {
 namespace ocl {
 
 ///////////// PyrDown //////////////////////
@@ -129,6 +129,6 @@ OCL_PERF_TEST_P(BuildPyramidFixture, BuildPyramid,
     SANITY_CHECK(dst4, eps);
 }
 
-} } // namespace cvtest::ocl
+} } // namespace opencv_test::ocl
 
 #endif // HAVE_OPENCL

--- a/modules/imgproc/perf/perf_accumulate.cpp
+++ b/modules/imgproc/perf/perf_accumulate.cpp
@@ -1,9 +1,9 @@
+// This file is part of OpenCV project.
+// It is subject to the license terms in the LICENSE file found in the top-level directory
+// of this distribution and at http://opencv.org/license.html.
 #include "perf_precomp.hpp"
 
-using namespace std;
-using namespace cv;
-using namespace perf;
-using std::tr1::get;
+namespace opencv_test {
 
 #ifdef HAVE_OPENVX
 PERF_TEST_P(Size_MatType, Accumulate,
@@ -94,3 +94,5 @@ PERF_TEST_P( Size_MatType, AccumulateWeighted,
 
     SANITY_CHECK_NOTHING();
 }
+
+} // namespace

--- a/modules/imgproc/perf/perf_bilateral.cpp
+++ b/modules/imgproc/perf/perf_bilateral.cpp
@@ -1,15 +1,13 @@
+// This file is part of OpenCV project.
+// It is subject to the license terms in the LICENSE file found in the top-level directory
+// of this distribution and at http://opencv.org/license.html.
 #include "perf_precomp.hpp"
 
-using namespace std;
-using namespace cv;
-using namespace perf;
-using namespace testing;
-using std::tr1::make_tuple;
-using std::tr1::get;
+namespace opencv_test {
 
 CV_ENUM(Mat_Type, CV_8UC1, CV_8UC3, CV_32FC1, CV_32FC3)
 
-typedef TestBaseWithParam< tr1::tuple<Size, int, Mat_Type> > TestBilateralFilter;
+typedef TestBaseWithParam< tuple<Size, int, Mat_Type> > TestBilateralFilter;
 
 PERF_TEST_P( TestBilateralFilter, BilateralFilter,
              Combine(
@@ -36,3 +34,5 @@ PERF_TEST_P( TestBilateralFilter, BilateralFilter,
 
     SANITY_CHECK(dst, .01, ERROR_RELATIVE);
 }
+
+} // namespace

--- a/modules/imgproc/perf/perf_blur.cpp
+++ b/modules/imgproc/perf/perf_blur.cpp
@@ -1,12 +1,11 @@
+// This file is part of OpenCV project.
+// It is subject to the license terms in the LICENSE file found in the top-level directory
+// of this distribution and at http://opencv.org/license.html.
 #include "perf_precomp.hpp"
 
-using namespace std;
-using namespace cv;
-using namespace perf;
-using std::tr1::make_tuple;
-using std::tr1::get;
+namespace opencv_test {
 
-typedef std::tr1::tuple<Size, MatType, int> Size_MatType_kSize_t;
+typedef tuple<Size, MatType, int> Size_MatType_kSize_t;
 typedef perf::TestBaseWithParam<Size_MatType_kSize_t> Size_MatType_kSize;
 
 PERF_TEST_P(Size_MatType_kSize, medianBlur,
@@ -37,13 +36,13 @@ PERF_TEST_P(Size_MatType_kSize, medianBlur,
 CV_ENUM(BorderType3x3, BORDER_REPLICATE, BORDER_CONSTANT)
 CV_ENUM(BorderType, BORDER_REPLICATE, BORDER_CONSTANT, BORDER_REFLECT, BORDER_REFLECT101)
 
-typedef std::tr1::tuple<Size, MatType, BorderType3x3> Size_MatType_BorderType3x3_t;
+typedef tuple<Size, MatType, BorderType3x3> Size_MatType_BorderType3x3_t;
 typedef perf::TestBaseWithParam<Size_MatType_BorderType3x3_t> Size_MatType_BorderType3x3;
 
-typedef std::tr1::tuple<Size, MatType, BorderType> Size_MatType_BorderType_t;
+typedef tuple<Size, MatType, BorderType> Size_MatType_BorderType_t;
 typedef perf::TestBaseWithParam<Size_MatType_BorderType_t> Size_MatType_BorderType;
 
-typedef std::tr1::tuple<Size, int, BorderType3x3> Size_ksize_BorderType_t;
+typedef tuple<Size, int, BorderType3x3> Size_ksize_BorderType_t;
 typedef perf::TestBaseWithParam<Size_ksize_BorderType_t> Size_ksize_BorderType;
 
 PERF_TEST_P(Size_MatType_BorderType3x3, gaussianBlur3x3,
@@ -230,3 +229,5 @@ PERF_TEST_P(Size_MatType_BorderType, blur5x5,
 
     SANITY_CHECK(dst, 1);
 }
+
+} // namespace

--- a/modules/imgproc/perf/perf_canny.cpp
+++ b/modules/imgproc/perf/perf_canny.cpp
@@ -1,12 +1,11 @@
+// This file is part of OpenCV project.
+// It is subject to the license terms in the LICENSE file found in the top-level directory
+// of this distribution and at http://opencv.org/license.html.
 #include "perf_precomp.hpp"
 
-using namespace std;
-using namespace cv;
-using namespace perf;
-using std::tr1::make_tuple;
-using std::tr1::get;
+namespace opencv_test {
 
-typedef std::tr1::tuple<string, int, bool, std::tr1::tuple<double, double> > Img_Aperture_L2_thresholds_t;
+typedef tuple<string, int, bool, tuple<double, double> > Img_Aperture_L2_thresholds_t;
 typedef perf::TestBaseWithParam<Img_Aperture_L2_thresholds_t> Img_Aperture_L2_thresholds;
 
 PERF_TEST_P(Img_Aperture_L2_thresholds, canny,
@@ -37,3 +36,5 @@ PERF_TEST_P(Img_Aperture_L2_thresholds, canny,
 
     SANITY_CHECK(edges);
 }
+
+} // namespace

--- a/modules/imgproc/perf/perf_corners.cpp
+++ b/modules/imgproc/perf/perf_corners.cpp
@@ -1,14 +1,13 @@
+// This file is part of OpenCV project.
+// It is subject to the license terms in the LICENSE file found in the top-level directory
+// of this distribution and at http://opencv.org/license.html.
 #include "perf_precomp.hpp"
 
-using namespace std;
-using namespace cv;
-using namespace perf;
-using std::tr1::make_tuple;
-using std::tr1::get;
+namespace opencv_test {
 
 CV_ENUM(BorderType, BORDER_REPLICATE, BORDER_CONSTANT, BORDER_REFLECT, BORDER_REFLECT_101)
 
-typedef std::tr1::tuple<string, int, int, double, BorderType> Img_BlockSize_ApertureSize_k_BorderType_t;
+typedef tuple<string, int, int, double, BorderType> Img_BlockSize_ApertureSize_k_BorderType_t;
 typedef perf::TestBaseWithParam<Img_BlockSize_ApertureSize_k_BorderType_t> Img_BlockSize_ApertureSize_k_BorderType;
 
 PERF_TEST_P(Img_BlockSize_ApertureSize_k_BorderType, cornerHarris,
@@ -37,7 +36,7 @@ PERF_TEST_P(Img_BlockSize_ApertureSize_k_BorderType, cornerHarris,
     SANITY_CHECK(dst, 2e-5, ERROR_RELATIVE);
 }
 
-typedef std::tr1::tuple<string, int, int, BorderType> Img_BlockSize_ApertureSize_BorderType_t;
+typedef tuple<string, int, int, BorderType> Img_BlockSize_ApertureSize_BorderType_t;
 typedef perf::TestBaseWithParam<Img_BlockSize_ApertureSize_BorderType_t> Img_BlockSize_ApertureSize_BorderType;
 
 PERF_TEST_P(Img_BlockSize_ApertureSize_BorderType, cornerEigenValsAndVecs,
@@ -90,3 +89,5 @@ PERF_TEST_P(Img_BlockSize_ApertureSize_BorderType, cornerMinEigenVal,
 
     SANITY_CHECK(dst, 2e-5, ERROR_RELATIVE);
 }
+
+} // namespace

--- a/modules/imgproc/perf/perf_cvt_color.cpp
+++ b/modules/imgproc/perf/perf_cvt_color.cpp
@@ -1,10 +1,9 @@
+// This file is part of OpenCV project.
+// It is subject to the license terms in the LICENSE file found in the top-level directory
+// of this distribution and at http://opencv.org/license.html.
 #include "perf_precomp.hpp"
 
-using namespace std;
-using namespace cv;
-using namespace perf;
-using std::tr1::make_tuple;
-using std::tr1::get;
+namespace opencv_test {
 
 //extra color conversions supported implicitly
 enum
@@ -124,7 +123,7 @@ struct ChPair
     int scn, dcn;
 };
 
-ChPair getConversionInfo(int cvtMode)
+static ChPair getConversionInfo(int cvtMode)
 {
     switch(cvtMode)
     {
@@ -239,7 +238,7 @@ ChPair getConversionInfo(int cvtMode)
     return ChPair(0,0);
 }
 
-typedef std::tr1::tuple<Size, CvtMode> Size_CvtMode_t;
+typedef tuple<Size, CvtMode> Size_CvtMode_t;
 typedef perf::TestBaseWithParam<Size_CvtMode_t> Size_CvtMode;
 
 PERF_TEST_P(Size_CvtMode, cvtColor8u,
@@ -275,7 +274,7 @@ PERF_TEST_P(Size_CvtMode, cvtColor8u,
 #endif
 }
 
-typedef std::tr1::tuple<Size, CvtModeBayer> Size_CvtMode_Bayer_t;
+typedef tuple<Size, CvtModeBayer> Size_CvtMode_Bayer_t;
 typedef perf::TestBaseWithParam<Size_CvtMode_Bayer_t> Size_CvtMode_Bayer;
 
 PERF_TEST_P(Size_CvtMode_Bayer, cvtColorBayer8u,
@@ -301,7 +300,7 @@ PERF_TEST_P(Size_CvtMode_Bayer, cvtColorBayer8u,
     SANITY_CHECK(dst, 1);
 }
 
-typedef std::tr1::tuple<Size, CvtMode2> Size_CvtMode2_t;
+typedef tuple<Size, CvtMode2> Size_CvtMode2_t;
 typedef perf::TestBaseWithParam<Size_CvtMode2_t> Size_CvtMode2;
 
 PERF_TEST_P(Size_CvtMode2, cvtColorYUV420,
@@ -326,7 +325,7 @@ PERF_TEST_P(Size_CvtMode2, cvtColorYUV420,
     SANITY_CHECK(dst, 1);
 }
 
-typedef std::tr1::tuple<Size, CvtMode3> Size_CvtMode3_t;
+typedef tuple<Size, CvtMode3> Size_CvtMode3_t;
 typedef perf::TestBaseWithParam<Size_CvtMode3_t> Size_CvtMode3;
 
 PERF_TEST_P(Size_CvtMode3, cvtColorRGB2YUV420p,
@@ -354,7 +353,7 @@ PERF_TEST_P(Size_CvtMode3, cvtColorRGB2YUV420p,
 
 CV_ENUM(EdgeAwareBayerMode, COLOR_BayerBG2BGR_EA, COLOR_BayerGB2BGR_EA, COLOR_BayerRG2BGR_EA, COLOR_BayerGR2BGR_EA)
 
-typedef std::tr1::tuple<Size, EdgeAwareBayerMode> EdgeAwareParams;
+typedef tuple<Size, EdgeAwareBayerMode> EdgeAwareParams;
 typedef perf::TestBaseWithParam<EdgeAwareParams> EdgeAwareDemosaicingTest;
 
 PERF_TEST_P(EdgeAwareDemosaicingTest, demosaicingEA,
@@ -376,3 +375,5 @@ PERF_TEST_P(EdgeAwareDemosaicingTest, demosaicingEA,
 
     SANITY_CHECK(dst, 1);
 }
+
+} // namespace

--- a/modules/imgproc/perf/perf_distanceTransform.cpp
+++ b/modules/imgproc/perf/perf_distanceTransform.cpp
@@ -1,42 +1,17 @@
-/*#include "perf_precomp.hpp"
-#include "distransform.cpp"
-
-using namespace std;
-using namespace cv;
-using namespace perf;
-
-typedef perf::TestBaseWithParam<Size> Size_DistanceTransform;
-
-PERF_TEST_P(Size_DistanceTransform, icvTrueDistTrans, testing::Values(TYPICAL_MAT_SIZES))
-{
-    Size size = GetParam();
-    Mat src(size, CV_8UC1);
-    Mat dst(size, CV_32FC1);
-    CvMat srcStub = src;
-    CvMat dstStub = dst;
-
-    declare.in(src, WARMUP_RNG).out(dst);
-
-    TEST_CYCLE() icvTrueDistTrans(&srcStub, &dstStub);
-
-    SANITY_CHECK(dst, 1);
-}*/
-
+// This file is part of OpenCV project.
+// It is subject to the license terms in the LICENSE file found in the top-level directory
+// of this distribution and at http://opencv.org/license.html.
 #include "perf_precomp.hpp"
 
-using namespace std;
-using namespace cv;
-using namespace perf;
-using std::tr1::make_tuple;
-using std::tr1::get;
+namespace opencv_test {
 
 CV_ENUM(DistanceType, DIST_L1, DIST_L2 , DIST_C)
 CV_ENUM(MaskSize, DIST_MASK_3, DIST_MASK_5, DIST_MASK_PRECISE)
 CV_ENUM(DstType, CV_8U, CV_32F)
 CV_ENUM(LabelType, DIST_LABEL_CCOMP, DIST_LABEL_PIXEL)
 
-typedef std::tr1::tuple<Size, DistanceType, MaskSize, DstType> SrcSize_DistType_MaskSize_DstType;
-typedef std::tr1::tuple<Size, DistanceType, MaskSize, LabelType> SrcSize_DistType_MaskSize_LabelType;
+typedef tuple<Size, DistanceType, MaskSize, DstType> SrcSize_DistType_MaskSize_DstType;
+typedef tuple<Size, DistanceType, MaskSize, LabelType> SrcSize_DistType_MaskSize_LabelType;
 typedef perf::TestBaseWithParam<SrcSize_DistType_MaskSize_DstType> DistanceTransform_Test;
 typedef perf::TestBaseWithParam<SrcSize_DistType_MaskSize_LabelType> DistanceTransform_NeedLabels_Test;
 
@@ -100,3 +75,5 @@ PERF_TEST_P(DistanceTransform_NeedLabels_Test, distanceTransform_NeedLabels,
     SANITY_CHECK(label, eps);
     SANITY_CHECK(dst, eps);
 }
+
+} // namespace

--- a/modules/imgproc/perf/perf_filter2d.cpp
+++ b/modules/imgproc/perf/perf_filter2d.cpp
@@ -1,17 +1,14 @@
+// This file is part of OpenCV project.
+// It is subject to the license terms in the LICENSE file found in the top-level directory
+// of this distribution and at http://opencv.org/license.html.
 #include "perf_precomp.hpp"
 
-using namespace std;
-using namespace cv;
-using namespace perf;
-using namespace testing;
-using std::tr1::make_tuple;
-using std::tr1::get;
-
+namespace opencv_test {
 
 CV_ENUM(BorderMode, BORDER_CONSTANT, BORDER_REPLICATE, BORDER_REFLECT_101)
 
-typedef TestBaseWithParam< tr1::tuple<Size, int, BorderMode> > TestFilter2d;
-typedef TestBaseWithParam< tr1::tuple<string, int> > Image_KernelSize;
+typedef TestBaseWithParam< tuple<Size, int, BorderMode> > TestFilter2d;
+typedef TestBaseWithParam< tuple<string, int> > Image_KernelSize;
 
 PERF_TEST_P( TestFilter2d, Filter2d,
              Combine(
@@ -37,7 +34,7 @@ PERF_TEST_P( TestFilter2d, Filter2d,
 
     declare.in(src, WARMUP_RNG).out(dst).time(20);
 
-    TEST_CYCLE() filter2D(src, dst, CV_8UC4, kernel, Point(1, 1), 0., borderMode);
+    TEST_CYCLE() cv::filter2D(src, dst, CV_8UC4, kernel, Point(1, 1), 0., borderMode);
 
     SANITY_CHECK(dst, 1);
 }
@@ -64,7 +61,7 @@ PERF_TEST_P(TestFilter2d, Filter2d_ovx,
 
     declare.in(src, WARMUP_RNG).out(dst).time(20);
 
-    TEST_CYCLE() filter2D(src, dst, CV_16SC1, kernel, Point(kSize / 2, kSize / 2), 0., borderMode);
+    TEST_CYCLE() cv::filter2D(src, dst, CV_16SC1, kernel, Point(kSize / 2, kSize / 2), 0., borderMode);
 
     SANITY_CHECK(dst, 1);
 }
@@ -94,8 +91,10 @@ PERF_TEST_P( Image_KernelSize, GaborFilter2d,
 
     TEST_CYCLE()
     {
-        filter2D(sourceImage, filteredImage, CV_32F, gaborKernel);
+        cv::filter2D(sourceImage, filteredImage, CV_32F, gaborKernel);
     }
 
     SANITY_CHECK(filteredImage, 1e-6, ERROR_RELATIVE);
 }
+
+} // namespace

--- a/modules/imgproc/perf/perf_floodfill.cpp
+++ b/modules/imgproc/perf/perf_floodfill.cpp
@@ -7,14 +7,9 @@
 
 #include "perf_precomp.hpp"
 
-using namespace std;
-using namespace cv;
-using namespace perf;
-using namespace testing;
-using std::tr1::make_tuple;
-using std::tr1::get;
+namespace opencv_test {
 
-typedef std::tr1::tuple<string, Point, int, int, int, int> Size_Source_Fl_t;
+typedef tuple<string, Point, int, int, int, int> Size_Source_Fl_t;
 typedef perf::TestBaseWithParam<Size_Source_Fl_t> Size_Source_Fl;
 
 PERF_TEST_P(Size_Source_Fl, floodFill1, Combine(
@@ -71,3 +66,5 @@ PERF_TEST_P(Size_Source_Fl, floodFill1, Combine(
     EXPECT_EQ(image0.rows, source.rows);
     SANITY_CHECK_NOTHING();
 }
+
+} // namespace

--- a/modules/imgproc/perf/perf_goodFeaturesToTrack.cpp
+++ b/modules/imgproc/perf/perf_goodFeaturesToTrack.cpp
@@ -1,12 +1,11 @@
+// This file is part of OpenCV project.
+// It is subject to the license terms in the LICENSE file found in the top-level directory
+// of this distribution and at http://opencv.org/license.html.
 #include "perf_precomp.hpp"
 
-using namespace std;
-using namespace cv;
-using namespace perf;
-using std::tr1::make_tuple;
-using std::tr1::get;
+namespace opencv_test {
 
-typedef std::tr1::tuple<string, int, double, int, int, bool> Image_MaxCorners_QualityLevel_MinDistance_BlockSize_gradientSize_UseHarris_t;
+typedef tuple<string, int, double, int, int, bool> Image_MaxCorners_QualityLevel_MinDistance_BlockSize_gradientSize_UseHarris_t;
 typedef perf::TestBaseWithParam<Image_MaxCorners_QualityLevel_MinDistance_BlockSize_gradientSize_UseHarris_t> Image_MaxCorners_QualityLevel_MinDistance_BlockSize_gradientSize_UseHarris;
 
 PERF_TEST_P(Image_MaxCorners_QualityLevel_MinDistance_BlockSize_gradientSize_UseHarris, goodFeaturesToTrack,
@@ -41,3 +40,5 @@ PERF_TEST_P(Image_MaxCorners_QualityLevel_MinDistance_BlockSize_gradientSize_Use
 
     SANITY_CHECK(corners);
 }
+
+} // namespace

--- a/modules/imgproc/perf/perf_histogram.cpp
+++ b/modules/imgproc/perf/perf_histogram.cpp
@@ -1,13 +1,11 @@
+// This file is part of OpenCV project.
+// It is subject to the license terms in the LICENSE file found in the top-level directory
+// of this distribution and at http://opencv.org/license.html.
 #include "perf_precomp.hpp"
 
-using namespace std;
-using namespace cv;
-using namespace perf;
-using namespace testing;
-using std::tr1::make_tuple;
-using std::tr1::get;
+namespace opencv_test {
 
-typedef tr1::tuple<Size, MatType> Size_Source_t;
+typedef tuple<Size, MatType> Size_Source_t;
 typedef TestBaseWithParam<Size_Source_t> Size_Source;
 typedef TestBaseWithParam<Size> TestMatSize;
 
@@ -118,7 +116,7 @@ PERF_TEST_P(MatSize, equalizeHist,
 }
 #undef MatSize
 
-typedef tr1::tuple<Size, double> Sz_ClipLimit_t;
+typedef tuple<Size, double> Sz_ClipLimit_t;
 typedef TestBaseWithParam<Sz_ClipLimit_t> Sz_ClipLimit;
 
 PERF_TEST_P(Sz_ClipLimit, CLAHE,
@@ -139,3 +137,5 @@ PERF_TEST_P(Sz_ClipLimit, CLAHE,
 
     SANITY_CHECK(dst);
 }
+
+} // namespace

--- a/modules/imgproc/perf/perf_houghcircles.cpp
+++ b/modules/imgproc/perf/perf_houghcircles.cpp
@@ -1,10 +1,10 @@
+// This file is part of OpenCV project.
+// It is subject to the license terms in the LICENSE file found in the top-level directory
+// of this distribution and at http://opencv.org/license.html.
 #include "perf_precomp.hpp"
-#include "opencv2/imgproc.hpp"
 #include "opencv2/imgproc/types_c.h"
 
-using namespace std;
-using namespace cv;
-using namespace perf;
+namespace opencv_test {
 
 PERF_TEST(PerfHoughCircles, Basic)
 {
@@ -55,3 +55,5 @@ PERF_TEST(PerfHoughCircles2, ManySmallCircles)
 
     SANITY_CHECK_NOTHING();
 }
+
+} // namespace

--- a/modules/imgproc/perf/perf_houghlines.cpp
+++ b/modules/imgproc/perf/perf_houghlines.cpp
@@ -1,14 +1,11 @@
+// This file is part of OpenCV project.
+// It is subject to the license terms in the LICENSE file found in the top-level directory
+// of this distribution and at http://opencv.org/license.html.
 #include "perf_precomp.hpp"
 
-#include "cmath"
+namespace opencv_test {
 
-using namespace std;
-using namespace cv;
-using namespace perf;
-using std::tr1::make_tuple;
-using std::tr1::get;
-
-typedef std::tr1::tuple<string, double, double, double> Image_RhoStep_ThetaStep_Threshold_t;
+typedef tuple<string, double, double, double> Image_RhoStep_ThetaStep_Threshold_t;
 typedef perf::TestBaseWithParam<Image_RhoStep_ThetaStep_Threshold_t> Image_RhoStep_ThetaStep_Threshold;
 
 PERF_TEST_P(Image_RhoStep_ThetaStep_Threshold, HoughLines,
@@ -38,9 +35,9 @@ PERF_TEST_P(Image_RhoStep_ThetaStep_Threshold, HoughLines,
     vector<Vec2f> lines;
     declare.time(60);
 
-    int threshold = (int)(std::min(image.cols, image.rows) * threshold_ratio);
+    int hough_threshold = (int)(std::min(image.cols, image.rows) * threshold_ratio);
 
-    TEST_CYCLE() HoughLines(image, lines, rhoStep, thetaStep, threshold);
+    TEST_CYCLE() HoughLines(image, lines, rhoStep, thetaStep, hough_threshold);
 
     printf("%dx%d: %d lines\n", image.cols, image.rows, (int)lines.size());
 
@@ -71,3 +68,5 @@ PERF_TEST_P(Image_RhoStep_ThetaStep_Threshold, HoughLines,
 
     SANITY_CHECK_NOTHING();
 }
+
+} // namespace

--- a/modules/imgproc/perf/perf_integral.cpp
+++ b/modules/imgproc/perf/perf_integral.cpp
@@ -1,12 +1,11 @@
+// This file is part of OpenCV project.
+// It is subject to the license terms in the LICENSE file found in the top-level directory
+// of this distribution and at http://opencv.org/license.html.
 #include "perf_precomp.hpp"
 
-using namespace std;
-using namespace cv;
-using namespace perf;
-using std::tr1::make_tuple;
-using std::tr1::get;
+namespace opencv_test {
 
-typedef std::tr1::tuple<Size, MatType, MatDepth> Size_MatType_OutMatDepth_t;
+typedef tuple<Size, MatType, MatDepth> Size_MatType_OutMatDepth_t;
 typedef perf::TestBaseWithParam<Size_MatType_OutMatDepth_t> Size_MatType_OutMatDepth;
 
 PERF_TEST_P(Size_MatType_OutMatDepth, integral,
@@ -82,3 +81,5 @@ PERF_TEST_P( Size_MatType_OutMatDepth, integral_sqsum_tilted,
     SANITY_CHECK(sqsum, 1e-6);
     SANITY_CHECK(tilted, 1e-6, tilted.depth() > CV_32S ? ERROR_RELATIVE : ERROR_ABSOLUTE);
 }
+
+} // namespace

--- a/modules/imgproc/perf/perf_main.cpp
+++ b/modules/imgproc/perf/perf_main.cpp
@@ -1,3 +1,6 @@
+// This file is part of OpenCV project.
+// It is subject to the license terms in the LICENSE file found in the top-level directory
+// of this distribution and at http://opencv.org/license.html.
 #include "perf_precomp.hpp"
 
 CV_PERF_TEST_MAIN(imgproc)

--- a/modules/imgproc/perf/perf_matchTemplate.cpp
+++ b/modules/imgproc/perf/perf_matchTemplate.cpp
@@ -1,14 +1,13 @@
+// This file is part of OpenCV project.
+// It is subject to the license terms in the LICENSE file found in the top-level directory
+// of this distribution and at http://opencv.org/license.html.
 #include "perf_precomp.hpp"
 
-using namespace std;
-using namespace cv;
-using namespace perf;
-using std::tr1::make_tuple;
-using std::tr1::get;
+namespace opencv_test {
 
 CV_ENUM(MethodType, TM_SQDIFF, TM_SQDIFF_NORMED, TM_CCORR, TM_CCORR_NORMED, TM_CCOEFF, TM_CCOEFF_NORMED)
 
-typedef std::tr1::tuple<Size, Size, MethodType> ImgSize_TmplSize_Method_t;
+typedef tuple<Size, Size, MethodType> ImgSize_TmplSize_Method_t;
 typedef perf::TestBaseWithParam<ImgSize_TmplSize_Method_t> ImgSize_TmplSize_Method;
 
 PERF_TEST_P(ImgSize_TmplSize_Method, matchTemplateSmall,
@@ -81,3 +80,5 @@ PERF_TEST_P(ImgSize_TmplSize_Method, matchTemplateBig,
 
     SANITY_CHECK(result, eps);
 }
+
+} // namespace

--- a/modules/imgproc/perf/perf_moments.cpp
+++ b/modules/imgproc/perf/perf_moments.cpp
@@ -7,14 +7,9 @@
 
 #include "perf_precomp.hpp"
 
-using namespace std;
-using namespace cv;
-using namespace perf;
-using namespace testing;
-using std::tr1::make_tuple;
-using std::tr1::get;
+namespace opencv_test {
 
-typedef std::tr1::tuple<Size, MatDepth, bool> MomentsParams_t;
+typedef tuple<Size, MatDepth, bool> MomentsParams_t;
 typedef perf::TestBaseWithParam<MomentsParams_t> MomentsFixture_val;
 
 PERF_TEST_P(MomentsFixture_val, Moments1,
@@ -42,3 +37,5 @@ PERF_TEST_P(MomentsFixture_val, Moments1,
 
     SANITY_CHECK_MOMENTS(m, 2e-4, ERROR_RELATIVE);
 }
+
+} // namespace

--- a/modules/imgproc/perf/perf_morph.cpp
+++ b/modules/imgproc/perf/perf_morph.cpp
@@ -1,10 +1,9 @@
+// This file is part of OpenCV project.
+// It is subject to the license terms in the LICENSE file found in the top-level directory
+// of this distribution and at http://opencv.org/license.html.
 #include "perf_precomp.hpp"
 
-using namespace std;
-using namespace cv;
-using namespace perf;
-using std::tr1::make_tuple;
-using std::tr1::get;
+namespace opencv_test {
 
 #define TYPICAL_MAT_TYPES_MORPH  CV_8UC1, CV_8UC4
 #define TYPICAL_MATS_MORPH       testing::Combine(SZ_ALL_GA, testing::Values(TYPICAL_MAT_TYPES_MORPH))
@@ -39,3 +38,5 @@ PERF_TEST_P(Size_MatType, dilate, TYPICAL_MATS_MORPH)
 
     SANITY_CHECK(dst);
 }
+
+} // namespace

--- a/modules/imgproc/perf/perf_phasecorr.cpp
+++ b/modules/imgproc/perf/perf_phasecorr.cpp
@@ -1,11 +1,9 @@
+// This file is part of OpenCV project.
+// It is subject to the license terms in the LICENSE file found in the top-level directory
+// of this distribution and at http://opencv.org/license.html.
 #include "perf_precomp.hpp"
 
-using namespace std;
-using namespace cv;
-using namespace perf;
-using namespace testing;
-using std::tr1::make_tuple;
-using std::tr1::get;
+namespace opencv_test {
 
 typedef TestBaseWithParam<Size > CreateHanningWindowFixture;
 
@@ -20,3 +18,5 @@ PERF_TEST_P( CreateHanningWindowFixture, CreateHanningWindow, Values(szVGA, sz10
 
     SANITY_CHECK(dst, 1e-6, ERROR_RELATIVE);
 }
+
+} // namespace

--- a/modules/imgproc/perf/perf_precomp.hpp
+++ b/modules/imgproc/perf/perf_precomp.hpp
@@ -1,20 +1,14 @@
-#ifdef __GNUC__
-#  pragma GCC diagnostic ignored "-Wmissing-declarations"
-#  if defined __clang__ || defined __APPLE__
-#    pragma GCC diagnostic ignored "-Wmissing-prototypes"
-#    pragma GCC diagnostic ignored "-Wextra"
-#  endif
-#endif
-
+// This file is part of OpenCV project.
+// It is subject to the license terms in the LICENSE file found in the top-level directory
+// of this distribution and at http://opencv.org/license.html.
 #ifndef __OPENCV_PERF_PRECOMP_HPP__
 #define __OPENCV_PERF_PRECOMP_HPP__
 
 #include "opencv2/ts.hpp"
 #include "opencv2/imgproc.hpp"
-#include "opencv2/imgcodecs.hpp"
 
-#ifdef GTEST_CREATE_SHARED_LIBRARY
-#error no modules except ts should have GTEST_CREATE_SHARED_LIBRARY defined
-#endif
+namespace opencv_test {
+using namespace perf;
+} // namespace
 
 #endif

--- a/modules/imgproc/perf/perf_pyramids.cpp
+++ b/modules/imgproc/perf/perf_pyramids.cpp
@@ -1,10 +1,9 @@
+// This file is part of OpenCV project.
+// It is subject to the license terms in the LICENSE file found in the top-level directory
+// of this distribution and at http://opencv.org/license.html.
 #include "perf_precomp.hpp"
 
-using namespace std;
-using namespace cv;
-using namespace perf;
-using std::tr1::make_tuple;
-using std::tr1::get;
+namespace opencv_test {
 
 PERF_TEST_P(Size_MatType, pyrDown, testing::Combine(
                 testing::Values(sz1080p, sz720p, szVGA, szQVGA, szODD),
@@ -95,3 +94,5 @@ PERF_TEST_P(Size_MatType, buildPyramid, testing::Combine(
     SANITY_CHECK(dst3, eps, error_type);
     SANITY_CHECK(dst4, eps, error_type);
 }
+
+} // namespace

--- a/modules/imgproc/perf/perf_remap.cpp
+++ b/modules/imgproc/perf/perf_remap.cpp
@@ -1,15 +1,13 @@
+// This file is part of OpenCV project.
+// It is subject to the license terms in the LICENSE file found in the top-level directory
+// of this distribution and at http://opencv.org/license.html.
 #include "perf_precomp.hpp"
 
-using namespace std;
-using namespace cv;
-using namespace perf;
-using namespace testing;
-using std::tr1::make_tuple;
-using std::tr1::get;
+namespace opencv_test {
 
 CV_ENUM(InterType, INTER_NEAREST, INTER_LINEAR, INTER_CUBIC, INTER_LANCZOS4)
 
-typedef TestBaseWithParam< tr1::tuple<Size, MatType, MatType, InterType> > TestRemap;
+typedef TestBaseWithParam< tuple<Size, MatType, MatType, InterType> > TestRemap;
 
 PERF_TEST_P( TestRemap, Remap,
              Combine(
@@ -68,3 +66,5 @@ PERF_TEST_P( TestRemap, Remap,
 
     SANITY_CHECK(dst);
 }
+
+} // namespace

--- a/modules/imgproc/perf/perf_resize.cpp
+++ b/modules/imgproc/perf/perf_resize.cpp
@@ -1,12 +1,11 @@
+// This file is part of OpenCV project.
+// It is subject to the license terms in the LICENSE file found in the top-level directory
+// of this distribution and at http://opencv.org/license.html.
 #include "perf_precomp.hpp"
 
-using namespace std;
-using namespace cv;
-using namespace perf;
-using std::tr1::make_tuple;
-using std::tr1::get;
+namespace opencv_test {
 
-typedef tr1::tuple<MatType, Size, Size> MatInfo_Size_Size_t;
+typedef tuple<MatType, Size, Size> MatInfo_Size_Size_t;
 typedef TestBaseWithParam<MatInfo_Size_Size_t> MatInfo_Size_Size;
 
 PERF_TEST_P(MatInfo_Size_Size, resizeUpLinear,
@@ -82,7 +81,7 @@ PERF_TEST_P(MatInfo_Size_Size, resizeDownLinear,
 }
 
 
-typedef tr1::tuple<MatType, Size, int> MatInfo_Size_Scale_t;
+typedef tuple<MatType, Size, int> MatInfo_Size_Scale_t;
 typedef TestBaseWithParam<MatInfo_Size_Scale_t> MatInfo_Size_Scale;
 
 PERF_TEST_P(MatInfo_Size_Scale, ResizeAreaFast,
@@ -113,7 +112,7 @@ PERF_TEST_P(MatInfo_Size_Scale, ResizeAreaFast,
 }
 
 
-typedef TestBaseWithParam<tr1::tuple<MatType, Size, double> > MatInfo_Size_Scale_Area;
+typedef TestBaseWithParam<tuple<MatType, Size, double> > MatInfo_Size_Scale_Area;
 
 PERF_TEST_P(MatInfo_Size_Scale_Area, ResizeArea,
             testing::Combine(
@@ -168,3 +167,5 @@ PERF_TEST_P(MatInfo_Size_Scale_NN, ResizeNN,
     EXPECT_GT(countNonZero(dst.reshape(1)), 0);
     SANITY_CHECK_NOTHING();
 }
+
+} // namespace

--- a/modules/imgproc/perf/perf_sepfilters.cpp
+++ b/modules/imgproc/perf/perf_sepfilters.cpp
@@ -1,10 +1,9 @@
+// This file is part of OpenCV project.
+// It is subject to the license terms in the LICENSE file found in the top-level directory
+// of this distribution and at http://opencv.org/license.html.
 #include "perf_precomp.hpp"
 
-using namespace std;
-using namespace cv;
-using namespace perf;
-using std::tr1::make_tuple;
-using std::tr1::get;
+namespace opencv_test {
 
 #define FILTER_SRC_SIZES szODD, szQVGA, szVGA
 
@@ -14,16 +13,16 @@ CV_ENUM(BorderType3x3ROI, BORDER_DEFAULT, BORDER_REPLICATE|BORDER_ISOLATED, BORD
 CV_ENUM(BorderType, BORDER_REPLICATE, BORDER_CONSTANT, BORDER_REFLECT, BORDER_REFLECT101)
 CV_ENUM(BorderTypeROI, BORDER_DEFAULT, BORDER_REPLICATE|BORDER_ISOLATED, BORDER_CONSTANT|BORDER_ISOLATED, BORDER_REFLECT|BORDER_ISOLATED, BORDER_REFLECT101|BORDER_ISOLATED)
 
-typedef std::tr1::tuple<Size, MatType, std::tr1::tuple<int, int>, BorderType3x3> Size_MatType_dx_dy_Border3x3_t;
+typedef tuple<Size, MatType, tuple<int, int>, BorderType3x3> Size_MatType_dx_dy_Border3x3_t;
 typedef perf::TestBaseWithParam<Size_MatType_dx_dy_Border3x3_t> Size_MatType_dx_dy_Border3x3;
 
-typedef std::tr1::tuple<Size, MatType, std::tr1::tuple<int, int>, BorderType3x3ROI> Size_MatType_dx_dy_Border3x3ROI_t;
+typedef tuple<Size, MatType, tuple<int, int>, BorderType3x3ROI> Size_MatType_dx_dy_Border3x3ROI_t;
 typedef perf::TestBaseWithParam<Size_MatType_dx_dy_Border3x3ROI_t> Size_MatType_dx_dy_Border3x3ROI;
 
-typedef std::tr1::tuple<Size, MatType, std::tr1::tuple<int, int>, BorderType> Size_MatType_dx_dy_Border5x5_t;
+typedef tuple<Size, MatType, tuple<int, int>, BorderType> Size_MatType_dx_dy_Border5x5_t;
 typedef perf::TestBaseWithParam<Size_MatType_dx_dy_Border5x5_t> Size_MatType_dx_dy_Border5x5;
 
-typedef std::tr1::tuple<Size, MatType, std::tr1::tuple<int, int>, BorderTypeROI> Size_MatType_dx_dy_Border5x5ROI_t;
+typedef tuple<Size, MatType, tuple<int, int>, BorderTypeROI> Size_MatType_dx_dy_Border5x5ROI_t;
 typedef perf::TestBaseWithParam<Size_MatType_dx_dy_Border5x5ROI_t> Size_MatType_dx_dy_Border5x5ROI;
 
 
@@ -242,3 +241,5 @@ PERF_TEST_P(Size_MatType_dx_dy_Border3x3ROI, scharrViaSobelFilter,
 
     SANITY_CHECK(dst);
 }
+
+} // namespace

--- a/modules/imgproc/perf/perf_spatialgradient.cpp
+++ b/modules/imgproc/perf/perf_spatialgradient.cpp
@@ -1,13 +1,11 @@
+// This file is part of OpenCV project.
+// It is subject to the license terms in the LICENSE file found in the top-level directory
+// of this distribution and at http://opencv.org/license.html.
 #include "perf_precomp.hpp"
 
-using namespace std;
-using namespace cv;
-using namespace perf;
-using namespace testing;
-using std::tr1::make_tuple;
-using std::tr1::get;
+namespace opencv_test {
 
-typedef std::tr1::tuple<Size, int, int> Size_Ksize_BorderType_t;
+typedef tuple<Size, int, int> Size_Ksize_BorderType_t;
 typedef perf::TestBaseWithParam<Size_Ksize_BorderType_t> Size_Ksize_BorderType;
 
 PERF_TEST_P( Size_Ksize_BorderType, spatialGradient,
@@ -18,9 +16,9 @@ PERF_TEST_P( Size_Ksize_BorderType, spatialGradient,
     )
 )
 {
-    Size size = std::tr1::get<0>(GetParam());
-    int ksize = std::tr1::get<1>(GetParam());
-    int borderType = std::tr1::get<2>(GetParam());
+    Size size = get<0>(GetParam());
+    int ksize = get<1>(GetParam());
+    int borderType = get<2>(GetParam());
 
     Mat src(size, CV_8UC1);
     Mat dx(size, CV_16SC1);
@@ -33,3 +31,5 @@ PERF_TEST_P( Size_Ksize_BorderType, spatialGradient,
     SANITY_CHECK(dx);
     SANITY_CHECK(dy);
 }
+
+} // namespace

--- a/modules/imgproc/perf/perf_threshold.cpp
+++ b/modules/imgproc/perf/perf_threshold.cpp
@@ -1,14 +1,13 @@
+// This file is part of OpenCV project.
+// It is subject to the license terms in the LICENSE file found in the top-level directory
+// of this distribution and at http://opencv.org/license.html.
 #include "perf_precomp.hpp"
 
-using namespace std;
-using namespace cv;
-using namespace perf;
-using std::tr1::make_tuple;
-using std::tr1::get;
+namespace opencv_test {
 
 CV_ENUM(ThreshType, THRESH_BINARY, THRESH_BINARY_INV, THRESH_TRUNC, THRESH_TOZERO, THRESH_TOZERO_INV)
 
-typedef std::tr1::tuple<Size, MatType, ThreshType> Size_MatType_ThreshType_t;
+typedef tuple<Size, MatType, ThreshType> Size_MatType_ThreshType_t;
 typedef perf::TestBaseWithParam<Size_MatType_ThreshType_t> Size_MatType_ThreshType;
 
 PERF_TEST_P(Size_MatType_ThreshType, threshold,
@@ -33,7 +32,7 @@ PERF_TEST_P(Size_MatType_ThreshType, threshold,
     declare.in(src, WARMUP_RNG).out(dst);
 
     int runs = (sz.width <= 640) ? 40 : 1;
-    TEST_CYCLE_MULTIRUN(runs) threshold(src, dst, thresh, maxval, threshType);
+    TEST_CYCLE_MULTIRUN(runs) cv::threshold(src, dst, thresh, maxval, threshType);
 
     SANITY_CHECK(dst);
 }
@@ -52,7 +51,7 @@ PERF_TEST_P(Size_Only, threshold_otsu, testing::Values(TYPICAL_MAT_SIZES))
     declare.in(src, WARMUP_RNG).out(dst);
 
     int runs = 15;
-    TEST_CYCLE_MULTIRUN(runs) threshold(src, dst, 0, maxval, THRESH_BINARY|THRESH_OTSU);
+    TEST_CYCLE_MULTIRUN(runs) cv::threshold(src, dst, 0, maxval, THRESH_BINARY|THRESH_OTSU);
 
     SANITY_CHECK(dst);
 }
@@ -60,7 +59,7 @@ PERF_TEST_P(Size_Only, threshold_otsu, testing::Values(TYPICAL_MAT_SIZES))
 CV_ENUM(AdaptThreshType, THRESH_BINARY, THRESH_BINARY_INV)
 CV_ENUM(AdaptThreshMethod, ADAPTIVE_THRESH_MEAN_C, ADAPTIVE_THRESH_GAUSSIAN_C)
 
-typedef std::tr1::tuple<Size, AdaptThreshType, AdaptThreshMethod, int, double> Size_AdaptThreshType_AdaptThreshMethod_BlockSize_Delta_t;
+typedef tuple<Size, AdaptThreshType, AdaptThreshMethod, int, double> Size_AdaptThreshType_AdaptThreshMethod_BlockSize_Delta_t;
 typedef perf::TestBaseWithParam<Size_AdaptThreshType_AdaptThreshMethod_BlockSize_Delta_t> Size_AdaptThreshType_AdaptThreshMethod_BlockSize_Delta;
 
 PERF_TEST_P(Size_AdaptThreshType_AdaptThreshMethod_BlockSize_Delta, adaptiveThreshold,
@@ -89,7 +88,9 @@ PERF_TEST_P(Size_AdaptThreshType_AdaptThreshMethod_BlockSize_Delta, adaptiveThre
 
     declare.in(src, WARMUP_RNG).out(dst);
 
-    TEST_CYCLE() adaptiveThreshold(src, dst, maxValue, adaptThreshMethod, adaptThreshType, blockSize, C);
+    TEST_CYCLE() cv::adaptiveThreshold(src, dst, maxValue, adaptThreshMethod, adaptThreshType, blockSize, C);
 
     SANITY_CHECK(dst);
 }
+
+} // namespace

--- a/modules/imgproc/perf/perf_warp.cpp
+++ b/modules/imgproc/perf/perf_warp.cpp
@@ -1,11 +1,9 @@
+// This file is part of OpenCV project.
+// It is subject to the license terms in the LICENSE file found in the top-level directory
+// of this distribution and at http://opencv.org/license.html.
 #include "perf_precomp.hpp"
 
-using namespace std;
-using namespace cv;
-using namespace perf;
-using namespace testing;
-using std::tr1::make_tuple;
-using std::tr1::get;
+namespace opencv_test {
 
 enum{HALF_SIZE=0, UPSIDE_DOWN, REFLECTION_X, REFLECTION_BOTH};
 
@@ -13,10 +11,10 @@ CV_ENUM(BorderMode, BORDER_CONSTANT, BORDER_REPLICATE)
 CV_ENUM(InterType, INTER_NEAREST, INTER_LINEAR)
 CV_ENUM(RemapMode, HALF_SIZE, UPSIDE_DOWN, REFLECTION_X, REFLECTION_BOTH)
 
-typedef TestBaseWithParam< tr1::tuple<Size, InterType, BorderMode> > TestWarpAffine;
-typedef TestBaseWithParam< tr1::tuple<Size, InterType, BorderMode> > TestWarpPerspective;
-typedef TestBaseWithParam< tr1::tuple<Size, InterType, BorderMode, MatType> > TestWarpPerspectiveNear_t;
-typedef TestBaseWithParam< tr1::tuple<MatType, Size, InterType, BorderMode, RemapMode> > TestRemap;
+typedef TestBaseWithParam< tuple<Size, InterType, BorderMode> > TestWarpAffine;
+typedef TestBaseWithParam< tuple<Size, InterType, BorderMode> > TestWarpPerspective;
+typedef TestBaseWithParam< tuple<Size, InterType, BorderMode, MatType> > TestWarpPerspectiveNear_t;
+typedef TestBaseWithParam< tuple<MatType, Size, InterType, BorderMode, RemapMode> > TestRemap;
 
 void update_map(const Mat& src, Mat& map_x, Mat& map_y, const int remapMode );
 
@@ -289,3 +287,5 @@ PERF_TEST(Transform, getPerspectiveTransform)
 
     SANITY_CHECK(transformCoefficient, 1e-5);
 }
+
+} // namespace

--- a/modules/imgproc/test/ocl/test_accumulate.cpp
+++ b/modules/imgproc/test/ocl/test_accumulate.cpp
@@ -44,12 +44,11 @@
 //M*/
 
 #include "../test_precomp.hpp"
-#include "cvconfig.h"
 #include "opencv2/ts/ocl_test.hpp"
 
 #ifdef HAVE_OPENCL
 
-namespace cvtest {
+namespace opencv_test {
 namespace ocl {
 
 PARAM_TEST_CASE(AccumulateBase, std::pair<MatDepth, MatDepth>, Channels, bool)
@@ -82,7 +81,7 @@ PARAM_TEST_CASE(AccumulateBase, std::pair<MatDepth, MatDepth>, Channels, bool)
 
         Border maskBorder = randomBorder(0, useRoi ? MAX_VALUE : 0);
         randomSubMat(mask, mask_roi, roiSize, maskBorder, CV_8UC1, -MAX_VALUE, MAX_VALUE);
-        threshold(mask, mask, 80, 255, THRESH_BINARY);
+        cvtest::threshold(mask, mask, 80, 255, THRESH_BINARY);
 
         Border src2Border = randomBorder(0, useRoi ? MAX_VALUE : 0);
         randomSubMat(src2, src2_roi, roiSize, src2Border, stype, -MAX_VALUE, MAX_VALUE);
@@ -235,6 +234,6 @@ OCL_INSTANTIATE_TEST_CASE_P(ImgProc, AccumulateSquare, Combine(OCL_DEPTH_ALL_COM
 OCL_INSTANTIATE_TEST_CASE_P(ImgProc, AccumulateProduct, Combine(OCL_DEPTH_ALL_COMBINATIONS, OCL_ALL_CHANNELS, Bool()));
 OCL_INSTANTIATE_TEST_CASE_P(ImgProc, AccumulateWeighted, Combine(OCL_DEPTH_ALL_COMBINATIONS, OCL_ALL_CHANNELS, Bool()));
 
-} } // namespace cvtest::ocl
+} } // namespace opencv_test::ocl
 
 #endif

--- a/modules/imgproc/test/ocl/test_blend.cpp
+++ b/modules/imgproc/test/ocl/test_blend.cpp
@@ -44,12 +44,11 @@
 //M*/
 
 #include "../test_precomp.hpp"
-#include "cvconfig.h"
 #include "opencv2/ts/ocl_test.hpp"
 
 #ifdef HAVE_OPENCL
 
-namespace cvtest {
+namespace opencv_test {
 namespace ocl {
 
 PARAM_TEST_CASE(BlendLinear, MatDepth, Channels, bool)
@@ -123,6 +122,6 @@ OCL_TEST_P(BlendLinear, Accuracy)
 
 OCL_INSTANTIATE_TEST_CASE_P(ImgProc, BlendLinear, Combine(testing::Values(CV_8U, CV_32F), OCL_ALL_CHANNELS, Bool()));
 
-} } // namespace cvtest::ocl
+} } // namespace opencv_test::ocl
 
 #endif

--- a/modules/imgproc/test/ocl/test_boxfilter.cpp
+++ b/modules/imgproc/test/ocl/test_boxfilter.cpp
@@ -46,7 +46,7 @@
 
 #ifdef HAVE_OPENCL
 
-namespace cvtest {
+namespace opencv_test {
 namespace ocl {
 
 ////////////////////////////////////////// boxFilter ///////////////////////////////////////////////////////
@@ -231,6 +231,6 @@ OCL_INSTANTIATE_TEST_CASE_P(ImageProc, BoxFilter3x3_cols16_rows2,
                                 )
                            );
 
-} } // namespace cvtest::ocl
+} } // namespace opencv_test::ocl
 
 #endif // HAVE_OPENCL

--- a/modules/imgproc/test/ocl/test_canny.cpp
+++ b/modules/imgproc/test/ocl/test_canny.cpp
@@ -48,7 +48,7 @@
 
 #ifdef HAVE_OPENCL
 
-namespace cvtest {
+namespace opencv_test {
 namespace ocl {
 
 ////////////////////////////////////////////////////////
@@ -135,6 +135,6 @@ OCL_INSTANTIATE_TEST_CASE_P(ImgProc, Canny, testing::Combine(
 
 } // namespace ocl
 
-} // namespace cvtest
+} // namespace opencv_test
 
 #endif // HAVE_OPENCL

--- a/modules/imgproc/test/ocl/test_color.cpp
+++ b/modules/imgproc/test/ocl/test_color.cpp
@@ -48,7 +48,7 @@
 
 #ifdef HAVE_OPENCL
 
-namespace cvtest {
+namespace opencv_test {
 namespace ocl {
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -482,6 +482,6 @@ OCL_INSTANTIATE_TEST_CASE_P(ImgProc, CvtColor_YUV2RGB_422,
                                 testing::Values(MatDepth(CV_8U)),
                                 Bool()));
 
-} } // namespace cvtest::ocl
+} } // namespace opencv_test::ocl
 
 #endif

--- a/modules/imgproc/test/ocl/test_filter2d.cpp
+++ b/modules/imgproc/test/ocl/test_filter2d.cpp
@@ -46,7 +46,7 @@
 
 #ifdef HAVE_OPENCL
 
-namespace cvtest {
+namespace opencv_test {
 namespace ocl {
 
 /////////////////////////////////////////////////////////////////////////////////////////////////
@@ -137,6 +137,6 @@ OCL_INSTANTIATE_TEST_CASE_P(ImageProc, Filter2D,
                            );
 
 
-} } // namespace cvtest::ocl
+} } // namespace opencv_test::ocl
 
 #endif // HAVE_OPENCL

--- a/modules/imgproc/test/ocl/test_filters.cpp
+++ b/modules/imgproc/test/ocl/test_filters.cpp
@@ -54,7 +54,7 @@
 
 #ifdef HAVE_OPENCL
 
-namespace cvtest {
+namespace opencv_test {
 namespace ocl {
 
 PARAM_TEST_CASE(FilterTestBase, MatType,
@@ -761,6 +761,6 @@ OCL_INSTANTIATE_TEST_CASE_P(Filter, MorphologyEx, Combine(
                             Bool()));
 
 
-} } // namespace cvtest::ocl
+} } // namespace opencv_test::ocl
 
 #endif // HAVE_OPENCL

--- a/modules/imgproc/test/ocl/test_gftt.cpp
+++ b/modules/imgproc/test/ocl/test_gftt.cpp
@@ -46,7 +46,7 @@
 
 #ifdef HAVE_OPENCL
 
-namespace cvtest {
+namespace opencv_test {
 namespace ocl {
 
 //////////////////////////// GoodFeaturesToTrack //////////////////////////
@@ -139,6 +139,6 @@ OCL_TEST_P(GoodFeaturesToTrack, EmptyCorners)
 OCL_INSTANTIATE_TEST_CASE_P(Imgproc, GoodFeaturesToTrack,
                             ::testing::Combine(testing::Values(0.0, 3.0), Bool()));
 
-} } // namespace cvtest::ocl
+} } // namespace opencv_test::ocl
 
 #endif

--- a/modules/imgproc/test/ocl/test_histogram.cpp
+++ b/modules/imgproc/test/ocl/test_histogram.cpp
@@ -53,12 +53,11 @@
 //M*/
 
 #include "../test_precomp.hpp"
-#include "cvconfig.h"
 #include "opencv2/ts/ocl_test.hpp"
 
 #ifdef HAVE_OPENCL
 
-namespace cvtest {
+namespace opencv_test {
 namespace ocl {
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -272,6 +271,6 @@ OCL_TEST_P(CalcHist, Mat)
 OCL_INSTANTIATE_TEST_CASE_P(Imgproc, CalcBackProject, Combine(Values((MatDepth)CV_8U), Values(1, 2), Bool()));
 OCL_INSTANTIATE_TEST_CASE_P(Imgproc, CalcHist, Values(true, false));
 
-} } // namespace cvtest::ocl
+} } // namespace opencv_test::ocl
 
 #endif // HAVE_OPENCL

--- a/modules/imgproc/test/ocl/test_houghlines.cpp
+++ b/modules/imgproc/test/ocl/test_houghlines.cpp
@@ -10,7 +10,7 @@
 
 #ifdef HAVE_OPENCL
 
-namespace cvtest {
+namespace opencv_test {
 namespace ocl {
 
 struct Vec2fComparator
@@ -179,6 +179,6 @@ OCL_INSTANTIATE_TEST_CASE_P(Imgproc, HoughLinesP, Combine(Values(100, 150),     
                                                           Values(50, 100),                      // minLineLength
                                                           Values(5, 10)));                      // maxLineGap
 
-} } // namespace cvtest::ocl
+} } // namespace opencv_test::ocl
 
 #endif // HAVE_OPENCL

--- a/modules/imgproc/test/ocl/test_imgproc.cpp
+++ b/modules/imgproc/test/ocl/test_imgproc.cpp
@@ -52,12 +52,11 @@
 //M*/
 
 #include "../test_precomp.hpp"
-#include "cvconfig.h"
 #include "opencv2/ts/ocl_test.hpp"
 
 #ifdef HAVE_OPENCL
 
-namespace cvtest {
+namespace opencv_test {
 namespace ocl {
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -492,6 +491,6 @@ OCL_INSTANTIATE_TEST_CASE_P(ImgprocTestBase, CopyMakeBorder, Combine(
                                    (BorderType)BORDER_WRAP, (BorderType)BORDER_REFLECT_101),
                             Bool()));
 
-} } // namespace cvtest::ocl
+} } // namespace opencv_test::ocl
 
 #endif // HAVE_OPENCL

--- a/modules/imgproc/test/ocl/test_match_template.cpp
+++ b/modules/imgproc/test/ocl/test_match_template.cpp
@@ -43,12 +43,10 @@
 
 #include "../test_precomp.hpp"
 #include "opencv2/ts/ocl_test.hpp"
-#include "iostream"
-#include "fstream"
 
 #ifdef HAVE_OPENCL
 
-namespace cvtest {
+namespace opencv_test {
 namespace ocl {
 
 ///////////////////////////////////////////// matchTemplate //////////////////////////////////////////////////////////
@@ -130,6 +128,6 @@ OCL_INSTANTIATE_TEST_CASE_P(ImageProc, MatchTemplate, Combine(
                                 MatchTemplType::all(),
                                 Bool())
                            );
-} } // namespace cvtest::ocl
+} } // namespace opencv_test::ocl
 
 #endif

--- a/modules/imgproc/test/ocl/test_medianfilter.cpp
+++ b/modules/imgproc/test/ocl/test_medianfilter.cpp
@@ -46,7 +46,7 @@
 
 #ifdef HAVE_OPENCL
 
-namespace cvtest {
+namespace opencv_test {
 namespace ocl {
 
 /////////////////////////////////////////////medianFilter//////////////////////////////////////////////////////////
@@ -106,6 +106,6 @@ OCL_INSTANTIATE_TEST_CASE_P(ImageProc, MedianFilter, Combine(
                                 Values(3, 5),
                                 Bool())
                            );
-} } // namespace cvtest::ocl
+} } // namespace opencv_test::ocl
 
 #endif

--- a/modules/imgproc/test/ocl/test_pyramids.cpp
+++ b/modules/imgproc/test/ocl/test_pyramids.cpp
@@ -49,7 +49,7 @@
 
 #ifdef HAVE_OPENCL
 
-namespace cvtest {
+namespace opencv_test {
 namespace ocl {
 
 PARAM_TEST_CASE(PyrTestBase, MatDepth, Channels, BorderType, bool)
@@ -166,6 +166,6 @@ OCL_INSTANTIATE_TEST_CASE_P(ImgprocPyr, PyrUp_cols2, Combine(
                             Bool()
                             ));
 
-} } // namespace cvtest::ocl
+} } // namespace opencv_test::ocl
 
 #endif // HAVE_OPENCL

--- a/modules/imgproc/test/ocl/test_sepfilter2d.cpp
+++ b/modules/imgproc/test/ocl/test_sepfilter2d.cpp
@@ -46,7 +46,7 @@
 
 #ifdef HAVE_OPENCL
 
-namespace cvtest {
+namespace opencv_test {
 namespace ocl {
 
 /////////////////////////////////////////////////////////////////////////////////////////////////
@@ -134,6 +134,6 @@ OCL_INSTANTIATE_TEST_CASE_P(ImageProc, SepFilter2D,
                            );
 
 
-} } // namespace cvtest::ocl
+} } // namespace opencv_test::ocl
 
 #endif // HAVE_OPENCL

--- a/modules/imgproc/test/ocl/test_warp.cpp
+++ b/modules/imgproc/test/ocl/test_warp.cpp
@@ -56,7 +56,7 @@
 
 #ifdef HAVE_OPENCL
 
-namespace cvtest {
+namespace opencv_test {
 namespace ocl {
 
 enum
@@ -504,6 +504,6 @@ OCL_INSTANTIATE_TEST_CASE_P(ImgprocWarp, Remap_INTER_NEAREST, Combine(
                                    (BorderType)BORDER_REFLECT_101),
                             Bool()));
 
-} } // namespace cvtest::ocl
+} } // namespace opencv_test::ocl
 
 #endif // HAVE_OPENCL

--- a/modules/imgproc/test/test_approxpoly.cpp
+++ b/modules/imgproc/test/test_approxpoly.cpp
@@ -40,10 +40,8 @@
 //M*/
 
 #include "test_precomp.hpp"
-#include <limits.h>
 
-using namespace cv;
-using namespace std;
+namespace opencv_test { namespace {
 
 //
 // TODO!!!:
@@ -356,3 +354,5 @@ _exit_:
 }
 
 TEST(Imgproc_ApproxPoly, accuracy) { CV_ApproxPolyTest test; test.safe_run(); }
+
+}} // namespace

--- a/modules/imgproc/test/test_bilateral_filter.cpp
+++ b/modules/imgproc/test/test_bilateral_filter.cpp
@@ -42,10 +42,8 @@
 
 #include "test_precomp.hpp"
 
-using namespace cv;
+namespace opencv_test { namespace {
 
-namespace cvtest
-{
     class CV_BilateralFilterTest :
         public cvtest::BaseTest
     {
@@ -128,7 +126,8 @@ namespace cvtest
         d = radius*2 + 1;
         // compute the min/max range for the input image (even if multichannel)
 
-        minMaxLoc( src.reshape(1), &minValSrc, &maxValSrc );
+        // TODO cvtest
+        cv::minMaxLoc( src.reshape(1), &minValSrc, &maxValSrc );
         if(std::abs(minValSrc - maxValSrc) < FLT_EPSILON)
         {
             src.copyTo(dst);
@@ -137,8 +136,8 @@ namespace cvtest
 
         // temporary copy of the image with borders for easy processing
         Mat temp;
-        copyMakeBorder( src, temp, radius, radius, radius, radius, borderType );
-        patchNaNs(temp);
+        cv::copyMakeBorder( src, temp, radius, radius, radius, radius, borderType );
+        cv::patchNaNs(temp);
 
         // allocate lookup tables
         vector<float> _space_weight(d*d);
@@ -290,4 +289,4 @@ namespace cvtest
         test.safe_run();
     }
 
-} // end of namespace cvtest
+}} // namespace

--- a/modules/imgproc/test/test_boundingrect.cpp
+++ b/modules/imgproc/test/test_boundingrect.cpp
@@ -41,14 +41,12 @@
 //M*/
 
 #include "test_precomp.hpp"
-#include <time.h>
+
+namespace opencv_test { namespace {
 
 #define IMGPROC_BOUNDINGRECT_ERROR_DIFF 1
 
 #define MESSAGE_ERROR_DIFF "Bounding rectangle found by boundingRect function is incorrect."
-
-using namespace cv;
-using namespace std;
 
 class CV_BoundingRectTest: public cvtest::ArrayTest
 {
@@ -142,3 +140,5 @@ void CV_BoundingRectTest::run(int)
 }
 
 TEST (Imgproc_BoundingRect, accuracy) { CV_BoundingRectTest test; test.safe_run(); }
+
+}} // namespace

--- a/modules/imgproc/test/test_canny.cpp
+++ b/modules/imgproc/test/test_canny.cpp
@@ -41,8 +41,7 @@
 
 #include "test_precomp.hpp"
 
-using namespace cv;
-using namespace std;
+namespace opencv_test { namespace {
 
 class CV_CannyTest : public cvtest::ArrayTest
 {
@@ -426,4 +425,5 @@ TEST_P(CannyVX, Accuracy)
                 )
     );
 
+}} // namespace
 /* End of file. */

--- a/modules/imgproc/test/test_color.cpp
+++ b/modules/imgproc/test/test_color.cpp
@@ -41,8 +41,7 @@
 
 #include "test_precomp.hpp"
 
-using namespace cv;
-using namespace std;
+namespace opencv_test { namespace {
 
 /////////////////////////// base test class for color transformations /////////////////////////
 
@@ -2338,9 +2337,9 @@ static void initLabTabs()
                     #define FILL(_p, _q, _r) \
                         do {\
                         int idxold = 0;\
-                        idxold += min(p+(_p), (int)(LAB_LUT_DIM-1))*3;\
-                        idxold += min(q+(_q), (int)(LAB_LUT_DIM-1))*LAB_LUT_DIM*3;\
-                        idxold += min(r+(_r), (int)(LAB_LUT_DIM-1))*LAB_LUT_DIM*LAB_LUT_DIM*3;\
+                        idxold += std::min(p+(_p), (int)(LAB_LUT_DIM-1))*3;\
+                        idxold += std::min(q+(_q), (int)(LAB_LUT_DIM-1))*LAB_LUT_DIM*3;\
+                        idxold += std::min(r+(_r), (int)(LAB_LUT_DIM-1))*LAB_LUT_DIM*LAB_LUT_DIM*3;\
                         int idxnew = p*3*8 + q*LAB_LUT_DIM*3*8 + r*LAB_LUT_DIM*LAB_LUT_DIM*3*8+4*(_p)+2*(_q)+(_r);\
                         RGB2LuvLUT_s16[idxnew]    = RGB2Luvprev[idxold];\
                         RGB2LuvLUT_s16[idxnew+8]  = RGB2Luvprev[idxold+1];\
@@ -2464,9 +2463,9 @@ int row8uLab2RGB(const uchar* src_row, uchar *dst_row, int n, int cn, int blue_i
         go = CV_DESCALE(coeffs[3]*xx + coeffs[4]*yy + coeffs[5]*zz, shift);
         bo = CV_DESCALE(coeffs[6]*xx + coeffs[7]*yy + coeffs[8]*zz, shift);
 
-        ro = max(0, min((int)INV_GAMMA_TAB_SIZE-1, ro));
-        go = max(0, min((int)INV_GAMMA_TAB_SIZE-1, go));
-        bo = max(0, min((int)INV_GAMMA_TAB_SIZE-1, bo));
+        ro = std::max(0, std::min((int)INV_GAMMA_TAB_SIZE-1, ro));
+        go = std::max(0, std::min((int)INV_GAMMA_TAB_SIZE-1, go));
+        bo = std::max(0, std::min((int)INV_GAMMA_TAB_SIZE-1, bo));
 
         ro = tab[ro];
         go = tab[go];
@@ -2580,16 +2579,16 @@ int row8uLuv2RGB(const uchar* src_row, uchar *dst_row, int n, int cn, int blue_i
         int z = zm/256 + zm/65536;
 
         //limit X, Y, Z to [0, 2] to fit white point
-        x = max(0, min(2*BASE, x)); z = max(0, min(2*BASE, z));
+        x = std::max(0, std::min(2*BASE, x)); z = std::max(0, std::min(2*BASE, z));
 
         int ro, go, bo;
         ro = CV_DESCALE(C0 * x + C1 * y + C2 * z, shift);
         go = CV_DESCALE(C3 * x + C4 * y + C5 * z, shift);
         bo = CV_DESCALE(C6 * x + C7 * y + C8 * z, shift);
 
-        ro = max(0, min((int)INV_GAMMA_TAB_SIZE-1, ro));
-        go = max(0, min((int)INV_GAMMA_TAB_SIZE-1, go));
-        bo = max(0, min((int)INV_GAMMA_TAB_SIZE-1, bo));
+        ro = max(0, std::min((int)INV_GAMMA_TAB_SIZE-1, ro));
+        go = max(0, std::min((int)INV_GAMMA_TAB_SIZE-1, go));
+        bo = max(0, std::min((int)INV_GAMMA_TAB_SIZE-1, bo));
 
         ro = tab[ro];
         go = tab[go];
@@ -3046,7 +3045,7 @@ TEST(ImgProc_BGR2RGBA, regression_8696)
     Mat dst;
     cvtColor(src, dst, COLOR_BGR2BGRA);
 
-    EXPECT_DOUBLE_EQ(norm(dst - src, NORM_INF), 0.);
+    EXPECT_DOUBLE_EQ(cvtest::norm(dst - src, NORM_INF), 0.);
 }
 
 TEST(ImgProc_BGR2RGBA, 3ch24ch)
@@ -3060,5 +3059,7 @@ TEST(ImgProc_BGR2RGBA, 3ch24ch)
     Mat expected(Size(80, 10), CV_8UC4);
     expected.setTo(Scalar(80, 0, 200, 255));
 
-    EXPECT_DOUBLE_EQ(norm(expected - dst, NORM_INF), 0.);
+    EXPECT_DOUBLE_EQ(cvtest::norm(expected - dst, NORM_INF), 0.);
 }
+
+}} // namespace

--- a/modules/imgproc/test/test_connectedcomponents.cpp
+++ b/modules/imgproc/test/test_connectedcomponents.cpp
@@ -41,11 +41,8 @@
 //M*/
 
 #include "test_precomp.hpp"
-#include <string>
-#include <vector>
 
-using namespace cv;
-using namespace std;
+namespace opencv_test { namespace {
 
 class CV_ConnectedComponentsTest : public cvtest::BaseTest
 {
@@ -138,3 +135,5 @@ void CV_ConnectedComponentsTest::run( int /* start_from */)
 }
 
 TEST(Imgproc_ConnectedComponents, regression) { CV_ConnectedComponentsTest test; test.safe_run(); }
+
+}} // namespace

--- a/modules/imgproc/test/test_contours.cpp
+++ b/modules/imgproc/test/test_contours.cpp
@@ -40,9 +40,9 @@
 //M*/
 
 #include "test_precomp.hpp"
+#include <opencv2/highgui.hpp>
 
-using namespace cv;
-using namespace std;
+namespace opencv_test { namespace {
 
 class CV_FindContourTest : public cvtest::BaseTest
 {
@@ -471,7 +471,7 @@ TEST(Imgproc_FindContours, hilbert)
 TEST(Imgproc_FindContours, border)
 {
     Mat img;
-    copyMakeBorder(Mat::zeros(8, 10, CV_8U), img, 1, 1, 1, 1, BORDER_CONSTANT, Scalar(1));
+    cv::copyMakeBorder(Mat::zeros(8, 10, CV_8U), img, 1, 1, 1, 1, BORDER_CONSTANT, Scalar(1));
 
     std::vector<std::vector<cv::Point> > contours;
     findContours(img, contours, RETR_LIST, CHAIN_APPROX_NONE);
@@ -479,10 +479,10 @@ TEST(Imgproc_FindContours, border)
     Mat img_draw_contours = Mat::zeros(img.size(), CV_8U);
     for (size_t cpt = 0; cpt < contours.size(); cpt++)
     {
-      drawContours(img_draw_contours, contours, static_cast<int>(cpt), cv::Scalar(255));
+      drawContours(img_draw_contours, contours, static_cast<int>(cpt), cv::Scalar(1));
     }
 
-    ASSERT_TRUE(norm(img - img_draw_contours, NORM_INF) == 0.0);
+    ASSERT_EQ(0, cvtest::norm(img, img_draw_contours, NORM_INF));
 }
 
 TEST(Imgproc_PointPolygonTest, regression_10222)
@@ -499,4 +499,5 @@ TEST(Imgproc_PointPolygonTest, regression_10222)
     EXPECT_GT(result, 0) << "Desired result: point is inside polygon - actual result: point is not inside polygon";
 }
 
+}} // namespace
 /* End of file. */

--- a/modules/imgproc/test/test_convhull.cpp
+++ b/modules/imgproc/test/test_convhull.cpp
@@ -41,8 +41,7 @@
 
 #include "test_precomp.hpp"
 
-using namespace cv;
-using namespace std;
+namespace opencv_test { namespace {
 
 /*static int
 cvTsPointConvexPolygon( CvPoint2D32f pt, CvPoint2D32f* v, int n )
@@ -1058,7 +1057,7 @@ void CV_MinCircleTest2::run_func()
     Point2f calcCenter;
     float calcRadius;
     minEnclosingCircle(pts, calcCenter, calcRadius);
-    delta = (float)norm(calcCenter - center) + abs(calcRadius - radius);
+    delta = (float)cv::norm(calcCenter - center) + abs(calcRadius - radius);
 }
 
 int CV_MinCircleTest2::validate_test_results( int test_case_idx )
@@ -2027,4 +2026,5 @@ INSTANTIATE_TEST_CASE_P(Imgproc, ConvexityDefects_regression_5908,
                 testing::Values(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10)
         ));
 
+}} // namespace
 /* End of file. */

--- a/modules/imgproc/test/test_cvtyuv.cpp
+++ b/modules/imgproc/test/test_cvtyuv.cpp
@@ -1,7 +1,6 @@
 #include "test_precomp.hpp"
 
-using namespace cv;
-using namespace std;
+namespace opencv_test { namespace {
 
 #undef RGB
 #undef YUV
@@ -724,3 +723,5 @@ INSTANTIATE_TEST_CASE_P(cvt422, Imgproc_ColorYUV,
                       (int)CV_YUV2RGB_YUY2, (int)CV_YUV2BGR_YUY2, (int)CV_YUV2RGB_YVYU, (int)CV_YUV2BGR_YVYU,
                       (int)CV_YUV2RGBA_YUY2, (int)CV_YUV2BGRA_YUY2, (int)CV_YUV2RGBA_YVYU, (int)CV_YUV2BGRA_YVYU,
                       (int)CV_YUV2GRAY_UYVY, (int)CV_YUV2GRAY_YUY2));
+
+}} // namespace

--- a/modules/imgproc/test/test_distancetransform.cpp
+++ b/modules/imgproc/test/test_distancetransform.cpp
@@ -41,8 +41,7 @@
 
 #include "test_precomp.hpp"
 
-using namespace cv;
-using namespace std;
+namespace opencv_test { namespace {
 
 class CV_DisTransTest : public cvtest::ArrayTest
 {
@@ -283,3 +282,5 @@ void CV_DisTransTest::prepare_to_validation( int /*test_case_idx*/ )
 
 
 TEST(Imgproc_DistanceTransform, accuracy) { CV_DisTransTest test; test.safe_run(); }
+
+}} // namespace

--- a/modules/imgproc/test/test_drawing.cpp
+++ b/modules/imgproc/test/test_drawing.cpp
@@ -42,10 +42,7 @@
 
 #include "test_precomp.hpp"
 
-namespace {
-
-using namespace std;
-using namespace cv;
+namespace opencv_test { namespace {
 
 //#define DRAW_TEST_IMAGE
 
@@ -757,4 +754,4 @@ TEST(Drawing, line)
     ASSERT_THROW(line(mat, Point(1,1),Point(99,99),Scalar(255),0), cv::Exception);
 }
 
-} // namespace
+}} // namespace

--- a/modules/imgproc/test/test_emd.cpp
+++ b/modules/imgproc/test/test_emd.cpp
@@ -41,10 +41,7 @@
 
 #include "test_precomp.hpp"
 
-using namespace cv;
-using namespace std;
-
-/*////////////////////// emd_test /////////////////////////*/
+namespace opencv_test { namespace {
 
 class CV_EMDTest : public cvtest::BaseTest
 {
@@ -92,4 +89,5 @@ void CV_EMDTest::run( int )
 
 TEST(Imgproc_EMD, regression) { CV_EMDTest test; test.safe_run(); }
 
+}} // namespace
 /* End of file. */

--- a/modules/imgproc/test/test_filter.cpp
+++ b/modules/imgproc/test/test_filter.cpp
@@ -41,8 +41,7 @@
 
 #include "test_precomp.hpp"
 
-using namespace cv;
-using namespace std;
+namespace opencv_test { namespace {
 
 class CV_FilterBaseTest : public cvtest::ArrayTest
 {
@@ -1905,27 +1904,27 @@ protected:
                 randu(src, 0, 100);
                 // non-separable filtering with a small kernel
                 fidx = 0;
-                filter2D(src, dst, ddepth, small_kernel);
+                cv::filter2D(src, dst, ddepth, small_kernel);
                 fidx++;
-                filter2D(src, dst, ddepth, big_kernel);
+                cv::filter2D(src, dst, ddepth, big_kernel);
                 fidx++;
-                sepFilter2D(src, dst, ddepth, kernelX, kernelY);
+                cv::sepFilter2D(src, dst, ddepth, kernelX, kernelY);
                 fidx++;
-                sepFilter2D(src, dst, ddepth, symkernelX, symkernelY);
+                cv::sepFilter2D(src, dst, ddepth, symkernelX, symkernelY);
                 fidx++;
-                Sobel(src, dst, ddepth, 2, 0, 5);
+                cv::Sobel(src, dst, ddepth, 2, 0, 5);
                 fidx++;
-                Scharr(src, dst, ddepth, 0, 1);
+                cv::Scharr(src, dst, ddepth, 0, 1);
                 if( sdepth != ddepth )
                     continue;
                 fidx++;
-                GaussianBlur(src, dst, Size(5, 5), 1.2, 1.2);
+                cv::GaussianBlur(src, dst, Size(5, 5), 1.2, 1.2);
                 fidx++;
-                blur(src, dst, Size(11, 11));
+                cv::blur(src, dst, Size(11, 11));
                 fidx++;
-                morphologyEx(src, dst, MORPH_GRADIENT, elem_ellipse);
+                cv::morphologyEx(src, dst, MORPH_GRADIENT, elem_ellipse);
                 fidx++;
-                morphologyEx(src, dst, MORPH_GRADIENT, elem_rect);
+                cv::morphologyEx(src, dst, MORPH_GRADIENT, elem_rect);
             }
         }
         catch(...)
@@ -1964,7 +1963,7 @@ TEST(Imgproc_Blur, borderTypes)
     EXPECT_EQ(227, dst.at<uchar>(0, 0));
 
     // should work like BORDER_ISOLATED
-    blur(src_roi, dst, kernelSize, Point(-1, -1), BORDER_REPLICATE | BORDER_ISOLATED);
+    cv::blur(src_roi, dst, kernelSize, Point(-1, -1), BORDER_REPLICATE | BORDER_ISOLATED);
     EXPECT_EQ(0, dst.at<uchar>(0, 0));
 
     /// ksize <= src_roi.size()
@@ -1974,7 +1973,7 @@ TEST(Imgproc_Blur, borderTypes)
     src.at<uchar>(2, 2) = 255;
 
     // should work like !BORDER_ISOLATED
-    blur(src_roi, dst, kernelSize, Point(-1, -1), BORDER_REPLICATE);
+    cv::blur(src_roi, dst, kernelSize, Point(-1, -1), BORDER_REPLICATE);
     Mat expected_dst =
             (Mat_<uchar>(3, 3) << 170, 113, 170, 113, 28, 113, 170, 113, 170);
     EXPECT_EQ(expected_dst.type(), dst.type());
@@ -2017,23 +2016,23 @@ TEST(Imgproc_Morphology, iterated)
 
         randu(src, 0, 256);
         if( op == 0 )
-            dilate(src, dst0, Mat(), Point(-1,-1), iterations);
+            cv::dilate(src, dst0, Mat(), Point(-1,-1), iterations);
         else
-            erode(src, dst0, Mat(), Point(-1,-1), iterations);
+            cv::erode(src, dst0, Mat(), Point(-1,-1), iterations);
 
         for( int i = 0; i < iterations; i++ )
             if( op == 0 )
-                dilate(i == 0 ? src : dst1, dst1, Mat(), Point(-1,-1), 1);
+                cv::dilate(i == 0 ? src : dst1, dst1, Mat(), Point(-1,-1), 1);
             else
-                erode(i == 0 ? src : dst1, dst1, Mat(), Point(-1,-1), 1);
+                cv::erode(i == 0 ? src : dst1, dst1, Mat(), Point(-1,-1), 1);
 
         Mat kern = getStructuringElement(MORPH_RECT, Size(3,3));
         if( op == 0 )
-            dilate(src, dst2, kern, Point(-1,-1), iterations);
+            cv::dilate(src, dst2, kern, Point(-1,-1), iterations);
         else
-            erode(src, dst2, kern, Point(-1,-1), iterations);
-        ASSERT_EQ(0.0, norm(dst0, dst1, NORM_INF));
-        ASSERT_EQ(0.0, norm(dst0, dst2, NORM_INF));
+            cv::erode(src, dst2, kern, Point(-1,-1), iterations);
+        ASSERT_EQ(0.0, cvtest::norm(dst0, dst1, NORM_INF));
+        ASSERT_EQ(0.0, cvtest::norm(dst0, dst2, NORM_INF));
     }
 }
 
@@ -2047,15 +2046,15 @@ TEST(Imgproc_Sobel, borderTypes)
     src_roi.setTo(cv::Scalar::all(0));
 
     // should work like !BORDER_ISOLATED, so the function MUST read values in full matrix
-    Sobel(src_roi, dst, CV_16S, 1, 0, kernelSize, 1, 0, BORDER_REPLICATE);
+    cv::Sobel(src_roi, dst, CV_16S, 1, 0, kernelSize, 1, 0, BORDER_REPLICATE);
     EXPECT_EQ(8, dst.at<short>(0, 0));
-    Sobel(src_roi, dst, CV_16S, 1, 0, kernelSize, 1, 0, BORDER_REFLECT);
+    cv::Sobel(src_roi, dst, CV_16S, 1, 0, kernelSize, 1, 0, BORDER_REFLECT);
     EXPECT_EQ(8, dst.at<short>(0, 0));
 
     // should work like BORDER_ISOLATED
-    Sobel(src_roi, dst, CV_16S, 1, 0, kernelSize, 1, 0, BORDER_REPLICATE | BORDER_ISOLATED);
+    cv::Sobel(src_roi, dst, CV_16S, 1, 0, kernelSize, 1, 0, BORDER_REPLICATE | BORDER_ISOLATED);
     EXPECT_EQ(0, dst.at<short>(0, 0));
-    Sobel(src_roi, dst, CV_16S, 1, 0, kernelSize, 1, 0, BORDER_REFLECT | BORDER_ISOLATED);
+    cv::Sobel(src_roi, dst, CV_16S, 1, 0, kernelSize, 1, 0, BORDER_REFLECT | BORDER_ISOLATED);
     EXPECT_EQ(0, dst.at<short>(0, 0));
 
     /// ksize <= src_roi.size()
@@ -2066,22 +2065,22 @@ TEST(Imgproc_Sobel, borderTypes)
     // should work like !BORDER_ISOLATED, so the function MUST read values in full matrix
     expected_dst =
         (Mat_<short>(3, 3) << -15, 0, 15, -20, 0, 20, -15, 0, 15);
-    Sobel(src_roi, dst, CV_16S, 1, 0, kernelSize, 1, 0, BORDER_REPLICATE);
+    cv::Sobel(src_roi, dst, CV_16S, 1, 0, kernelSize, 1, 0, BORDER_REPLICATE);
     EXPECT_EQ(expected_dst.type(), dst.type());
     EXPECT_EQ(expected_dst.size(), dst.size());
     EXPECT_DOUBLE_EQ(0.0, cvtest::norm(expected_dst, dst, NORM_INF));
-    Sobel(src_roi, dst, CV_16S, 1, 0, kernelSize, 1, 0, BORDER_REFLECT);
+    cv::Sobel(src_roi, dst, CV_16S, 1, 0, kernelSize, 1, 0, BORDER_REFLECT);
     EXPECT_EQ(expected_dst.type(), dst.type());
     EXPECT_EQ(expected_dst.size(), dst.size());
     EXPECT_DOUBLE_EQ(0.0, cvtest::norm(expected_dst, dst, NORM_INF));
 
     // should work like !BORDER_ISOLATED, so the function MUST read values in full matrix
     expected_dst = Mat::zeros(3, 3, CV_16SC1);
-    Sobel(src_roi, dst, CV_16S, 1, 0, kernelSize, 1, 0, BORDER_REPLICATE | BORDER_ISOLATED);
+    cv::Sobel(src_roi, dst, CV_16S, 1, 0, kernelSize, 1, 0, BORDER_REPLICATE | BORDER_ISOLATED);
     EXPECT_EQ(expected_dst.type(), dst.type());
     EXPECT_EQ(expected_dst.size(), dst.size());
     EXPECT_DOUBLE_EQ(0.0, cvtest::norm(expected_dst, dst, NORM_INF));
-    Sobel(src_roi, dst, CV_16S, 1, 0, kernelSize, 1, 0, BORDER_REFLECT | BORDER_ISOLATED);
+    cv::Sobel(src_roi, dst, CV_16S, 1, 0, kernelSize, 1, 0, BORDER_REFLECT | BORDER_ISOLATED);
     EXPECT_EQ(expected_dst.type(), dst.type());
     EXPECT_EQ(expected_dst.size(), dst.size());
     EXPECT_DOUBLE_EQ(0.0, cvtest::norm(expected_dst, dst, NORM_INF));
@@ -2097,12 +2096,12 @@ TEST(Imgproc_MorphEx, hitmiss_regression_8957)
     Mat_<uchar> kernel = src / 255;
 
     Mat dst;
-    morphologyEx(src, dst, MORPH_HITMISS, kernel);
+    cv::morphologyEx(src, dst, MORPH_HITMISS, kernel);
 
     Mat ref = Mat::zeros(3, 3, CV_8U);
     ref.at<uchar>(1, 1) = 255;
 
-    ASSERT_DOUBLE_EQ(norm(dst, ref, NORM_INF), 0.);
+    ASSERT_DOUBLE_EQ(cvtest::norm(dst, ref, NORM_INF), 0.);
 }
 
 TEST(Imgproc_MorphEx, hitmiss_zero_kernel)
@@ -2115,7 +2114,9 @@ TEST(Imgproc_MorphEx, hitmiss_zero_kernel)
     Mat_<uchar> kernel = Mat_<uchar>::zeros(3, 3);
 
     Mat dst;
-    morphologyEx(src, dst, MORPH_HITMISS, kernel);
+    cv::morphologyEx(src, dst, MORPH_HITMISS, kernel);
 
-    ASSERT_DOUBLE_EQ(norm(dst, src, NORM_INF), 0.);
+    ASSERT_DOUBLE_EQ(cvtest::norm(dst, src, NORM_INF), 0.);
 }
+
+}} // namespace

--- a/modules/imgproc/test/test_fitellipse.cpp
+++ b/modules/imgproc/test/test_fitellipse.cpp
@@ -5,11 +5,8 @@
 // Copyright (C) 2016, Itseez, Inc, all rights reserved.
 
 #include "test_precomp.hpp"
-#include <vector>
-#include <cmath>
 
-using namespace cv;
-using namespace std;
+namespace opencv_test { namespace {
 
 // return true if point lies inside ellipse
 static bool check_pt_in_ellipse(const Point2f& pt, const RotatedRect& el) {
@@ -19,7 +16,7 @@ static bool check_pt_in_ellipse(const Point2f& pt, const RotatedRect& el) {
     double x_dist = 0.5 * el.size.width * cos(pt_angle + el_angle);
     double y_dist = 0.5 * el.size.height * sin(pt_angle + el_angle);
     double el_dist = sqrt(x_dist * x_dist + y_dist * y_dist);
-    return norm(to_pt) < el_dist;
+    return cv::norm(to_pt) < el_dist;
 }
 
 // Return true if mass center of fitted points lies inside ellipse
@@ -68,3 +65,5 @@ TEST(Imgproc_FitEllipse_Issue_6544, accuracy) {
 
     EXPECT_TRUE(fit_and_check_ellipse(pts));
 }
+
+}} // namespace

--- a/modules/imgproc/test/test_fitellipse_ams.cpp
+++ b/modules/imgproc/test/test_fitellipse_ams.cpp
@@ -5,11 +5,8 @@
 // Copyright (C) 2016, Itseez, Inc, all rights reserved.
 
 #include "test_precomp.hpp"
-#include <vector>
-#include <cmath>
 
-using namespace cv;
-using namespace std;
+namespace opencv_test { namespace {
 
 TEST(Imgproc_FitEllipseAMS_Issue_1, accuracy) {
     vector<Point2f>pts;
@@ -439,3 +436,5 @@ TEST(Imgproc_FitEllipseAMS_Issue_7, accuracy) {
 
     EXPECT_TRUE(AMSGoodQ);
 }
+
+}} // namespace

--- a/modules/imgproc/test/test_fitellipse_direct.cpp
+++ b/modules/imgproc/test/test_fitellipse_direct.cpp
@@ -5,12 +5,8 @@
 // Copyright (C) 2016, Itseez, Inc, all rights reserved.
 
 #include "test_precomp.hpp"
-#include <vector>
-#include <cmath>
 
-using namespace cv;
-using namespace std;
-
+namespace opencv_test { namespace {
 
 TEST(Imgproc_FitEllipseDirect_Issue_1, accuracy) {
     vector<Point2f>pts;
@@ -440,3 +436,5 @@ TEST(Imgproc_FitEllipseDirect_Issue_7, accuracy) {
 
     EXPECT_TRUE(directGoodQ);
 }
+
+}} // namespace

--- a/modules/imgproc/test/test_floodfill.cpp
+++ b/modules/imgproc/test/test_floodfill.cpp
@@ -41,8 +41,7 @@
 
 #include "test_precomp.hpp"
 
-using namespace cv;
-using namespace std;
+namespace opencv_test { namespace {
 
 class CV_FloodFillTest : public cvtest::ArrayTest
 {
@@ -539,7 +538,8 @@ TEST(Imgproc_FloodFill, maskValue)
     int flags = 4 + CV_FLOODFILL_MASK_ONLY;
     floodFill(img, mask, Point(n/2 + 13, n/2), Scalar(100), NULL, Scalar(),  Scalar(), flags);
 
-    ASSERT_TRUE(norm(mask.rowRange(1, n-1).colRange(1, n-1), NORM_INF) == 1.);
+    ASSERT_EQ(1, cvtest::norm(mask.rowRange(1, n-1).colRange(1, n-1), NORM_INF));
 }
 
+}} // namespace
 /* End of file. */

--- a/modules/imgproc/test/test_goodfeaturetotrack.cpp
+++ b/modules/imgproc/test/test_goodfeaturetotrack.cpp
@@ -41,8 +41,7 @@
 
 #include "test_precomp.hpp"
 
-using namespace cv;
-using namespace std;
+namespace opencv_test { namespace {
 
 enum { MINEIGENVAL=0, HARRIS=1, EIGENVALSVECS=2 };
 
@@ -465,7 +464,7 @@ int CV_GoodFeatureToTTest::validate_test_results( int test_case_idx )
                k );
     }
 
-    double e =norm(corners, Refcorners);
+    double e = cv::norm(corners, Refcorners); // TODO cvtest
 
     if (e > eps)
     {
@@ -497,4 +496,5 @@ int CV_GoodFeatureToTTest::validate_test_results( int test_case_idx )
 TEST(Imgproc_GoodFeatureToT, accuracy) { CV_GoodFeatureToTTest test; test.safe_run(); }
 
 
+}} // namespace
 /* End of file. */

--- a/modules/imgproc/test/test_grabcut.cpp
+++ b/modules/imgproc/test/test_grabcut.cpp
@@ -42,11 +42,7 @@
 
 #include "test_precomp.hpp"
 
-#include <string>
-#include <iostream>
-
-using namespace std;
-using namespace cv;
+namespace opencv_test { namespace {
 
 class CV_GrabcutTest : public cvtest::BaseTest
 {
@@ -170,3 +166,5 @@ TEST(Imgproc_GrabCut, repeatability)
     EXPECT_EQ(0, countNonZero(mask_1 != mask_3));
     EXPECT_EQ(0, countNonZero(mask_2 != mask_3));
 }
+
+}} // namespace

--- a/modules/imgproc/test/test_histograms.cpp
+++ b/modules/imgproc/test/test_histograms.cpp
@@ -41,8 +41,7 @@
 
 #include "test_precomp.hpp"
 
-using namespace cv;
-using namespace std;
+namespace opencv_test { namespace {
 
 class CV_BaseHistTest : public cvtest::BaseTest
 {
@@ -1919,4 +1918,5 @@ TEST(Imgproc_Hist_CalcBackProject, accuracy) { CV_CalcBackProjectTest test; test
 TEST(Imgproc_Hist_CalcBackProjectPatch, accuracy) { CV_CalcBackProjectPatchTest test; test.safe_run(); }
 TEST(Imgproc_Hist_BayesianProb, accuracy) { CV_BayesianProbTest test; test.safe_run(); }
 
+}} // namespace
 /* End Of File */

--- a/modules/imgproc/test/test_houghcircles.cpp
+++ b/modules/imgproc/test/test_houghcircles.cpp
@@ -43,6 +43,8 @@
 
 #include "test_precomp.hpp"
 
+namespace opencv_test { namespace {
+
 #ifndef DEBUG_IMAGES
 #define DEBUG_IMAGES 0
 #endif
@@ -81,7 +83,7 @@ static void highlightCircles(const string& imagePath, const vector<Vec3f>& circl
 }
 #endif
 
-typedef std::tr1::tuple<string, double, double, double, int, int> Image_MinDist_EdgeThreshold_AccumThreshold_MinRadius_MaxRadius_t;
+typedef tuple<string, double, double, double, int, int> Image_MinDist_EdgeThreshold_AccumThreshold_MinRadius_MaxRadius_t;
 class HoughCirclesTestFixture : public testing::TestWithParam<Image_MinDist_EdgeThreshold_AccumThreshold_MinRadius_MaxRadius_t>
 {
     string picture_name;
@@ -94,12 +96,12 @@ class HoughCirclesTestFixture : public testing::TestWithParam<Image_MinDist_Edge
 public:
     HoughCirclesTestFixture()
     {
-        picture_name = std::tr1::get<0>(GetParam());
-        minDist = std::tr1::get<1>(GetParam());
-        edgeThreshold = std::tr1::get<2>(GetParam());
-        accumThreshold = std::tr1::get<3>(GetParam());
-        minRadius = std::tr1::get<4>(GetParam());
-        maxRadius = std::tr1::get<5>(GetParam());
+        picture_name = get<0>(GetParam());
+        minDist = get<1>(GetParam());
+        edgeThreshold = get<2>(GetParam());
+        accumThreshold = get<3>(GetParam());
+        minRadius = get<4>(GetParam());
+        maxRadius = get<5>(GetParam());
     }
 
     HoughCirclesTestFixture(const string& picture, double minD, double edge, double accum, int minR, int maxR) :
@@ -257,3 +259,5 @@ TEST(HoughCirclesTest, ManySmallCircles)
 
     EXPECT_GT(circles.size(), size_t(3000)) << "Should find a lot of circles";
 }
+
+}} // namespace

--- a/modules/imgproc/test/test_houghlines.cpp
+++ b/modules/imgproc/test/test_houghlines.cpp
@@ -43,8 +43,7 @@
 
 #include "test_precomp.hpp"
 
-using namespace cv;
-using namespace std;
+namespace opencv_test { namespace {
 
 template<typename T>
 struct SimilarWith
@@ -59,13 +58,13 @@ struct SimilarWith
 template<>
 bool SimilarWith<Vec2f>::operator()(Vec2f other)
 {
-    return abs(other[0] - value[0]) < rho_eps && abs(other[1] - value[1]) < theta_eps;
+    return std::abs(other[0] - value[0]) < rho_eps && std::abs(other[1] - value[1]) < theta_eps;
 }
 
 template<>
 bool SimilarWith<Vec4i>::operator()(Vec4i other)
 {
-    return norm(value, other) < theta_eps;
+    return cv::norm(value, other) < theta_eps;
 }
 
 template <typename T>
@@ -110,33 +109,33 @@ protected:
     int maxGap;
 };
 
-typedef std::tr1::tuple<string, double, double, int> Image_RhoStep_ThetaStep_Threshold_t;
+typedef tuple<string, double, double, int> Image_RhoStep_ThetaStep_Threshold_t;
 class StandartHoughLinesTest : public BaseHoughLineTest, public testing::TestWithParam<Image_RhoStep_ThetaStep_Threshold_t>
 {
 public:
     StandartHoughLinesTest()
     {
-        picture_name = std::tr1::get<0>(GetParam());
-        rhoStep = std::tr1::get<1>(GetParam());
-        thetaStep = std::tr1::get<2>(GetParam());
-        threshold = std::tr1::get<3>(GetParam());
+        picture_name = get<0>(GetParam());
+        rhoStep = get<1>(GetParam());
+        thetaStep = get<2>(GetParam());
+        threshold = get<3>(GetParam());
         minLineLength = 0;
         maxGap = 0;
     }
 };
 
-typedef std::tr1::tuple<string, double, double, int, int, int> Image_RhoStep_ThetaStep_Threshold_MinLine_MaxGap_t;
+typedef tuple<string, double, double, int, int, int> Image_RhoStep_ThetaStep_Threshold_MinLine_MaxGap_t;
 class ProbabilisticHoughLinesTest : public BaseHoughLineTest, public testing::TestWithParam<Image_RhoStep_ThetaStep_Threshold_MinLine_MaxGap_t>
 {
 public:
     ProbabilisticHoughLinesTest()
     {
-        picture_name = std::tr1::get<0>(GetParam());
-        rhoStep = std::tr1::get<1>(GetParam());
-        thetaStep = std::tr1::get<2>(GetParam());
-        threshold = std::tr1::get<3>(GetParam());
-        minLineLength = std::tr1::get<4>(GetParam());
-        maxGap = std::tr1::get<5>(GetParam());
+        picture_name = get<0>(GetParam());
+        rhoStep = get<1>(GetParam());
+        thetaStep = get<2>(GetParam());
+        threshold = get<3>(GetParam());
+        minLineLength = get<4>(GetParam());
+        maxGap = get<5>(GetParam());
     }
 };
 
@@ -219,3 +218,5 @@ INSTANTIATE_TEST_CASE_P( ImgProc, ProbabilisticHoughLinesTest, testing::Combine(
                                                                                 testing::Values( 0, 10 ),
                                                                                 testing::Values( 0, 4 )
                                                                                 ));
+
+}} // namespace

--- a/modules/imgproc/test/test_imgproc_umat.cpp
+++ b/modules/imgproc/test/test_imgproc_umat.cpp
@@ -41,10 +41,8 @@
 //M*/
 
 #include "test_precomp.hpp"
-#include <string>
 
-using namespace cv;
-using namespace std;
+namespace opencv_test { namespace {
 
 class CV_ImgprocUMatTest : public cvtest::BaseTest
 {
@@ -82,3 +80,5 @@ protected:
 };
 
 TEST(Imgproc_UMat, regression) { CV_ImgprocUMatTest test; test.safe_run(); }
+
+}} // namespace

--- a/modules/imgproc/test/test_imgwarp.cpp
+++ b/modules/imgproc/test/test_imgwarp.cpp
@@ -41,8 +41,7 @@
 
 #include "test_precomp.hpp"
 
-using namespace cv;
-using namespace std;
+namespace opencv_test { namespace {
 
 class CV_ImgWarpBaseTest : public cvtest::ArrayTest
 {
@@ -1419,7 +1418,7 @@ static void check_resize_area(const Mat& expected, const Mat& actual, double tol
         for (int dx = 0; dx < dsize.width && next; ++dx)
             if (fabs(static_cast<double>(aD[dx] - eD[dx])) > tolerance)
             {
-                cvtest::TS::ptr()->printf(cvtest::TS::SUMMARY, "Inf norm: %f\n", static_cast<float>(norm(actual, expected, NORM_INF)));
+                cvtest::TS::ptr()->printf(cvtest::TS::SUMMARY, "Inf norm: %f\n", static_cast<float>(cvtest::norm(actual, expected, NORM_INF)));
                 cvtest::TS::ptr()->printf(cvtest::TS::SUMMARY, "Error in : (%d, %d)\n", dx, dy);
 
                 const int radius = 3;
@@ -1434,7 +1433,7 @@ static void check_resize_area(const Mat& expected, const Mat& actual, double tol
             }
     }
 
-    ASSERT_EQ(0, norm(one_channel_diff, cv::NORM_INF));
+    ASSERT_EQ(0, cvtest::norm(one_channel_diff, cv::NORM_INF));
 }
 
 ///////////////////////////////////////////////////////////////////////////
@@ -1736,11 +1735,11 @@ TEST(Imgproc_Warp, multichannel)
 
         Mat rot = getRotationMatrix2D(Point2f(0.f, 0.f), 1.0, 1.0);
         warpAffine(src, dst, rot, src.size(), inter, border);
-        ASSERT_EQ(0.0, norm(dst, NORM_INF));
+        ASSERT_EQ(0.0, cvtest::norm(dst, NORM_INF));
         Mat rot2 = Mat::eye(3, 3, rot.type());
         rot.copyTo(rot2.rowRange(0, 2));
         warpPerspective(src, dst, rot2, src.size(), inter, border);
-        ASSERT_EQ(0.0, norm(dst, NORM_INF));
+        ASSERT_EQ(0.0, cvtest::norm(dst, NORM_INF));
     }
 }
 
@@ -1755,7 +1754,7 @@ TEST(Imgproc_GetAffineTransform, singularity)
     B_sample[1] = Point2f(15.0113f, 12.8994f);
     B_sample[2] = Point2f(38.9943f, 9.56297f);
     Mat trans = getAffineTransform(A_sample, B_sample);
-    ASSERT_EQ(0.0, norm(trans, NORM_INF));
+    ASSERT_EQ(0.0, cvtest::norm(trans, NORM_INF));
 }
 
 TEST(Imgproc_Remap, DISABLED_memleak)
@@ -1864,4 +1863,5 @@ TEST(Imgproc_logPolar, identity)
 }
 
 
+}} // namespace
 /* End of file. */

--- a/modules/imgproc/test/test_imgwarp_strict.cpp
+++ b/modules/imgproc/test/test_imgwarp_strict.cpp
@@ -41,26 +41,19 @@
 
 #include "test_precomp.hpp"
 
-#include <cmath>
-#include <vector>
-#include <iostream>
+namespace opencv_test { namespace {
 
-using namespace cv;
-
-namespace
+void __wrap_printf_func(const char* fmt, ...)
 {
-    void __wrap_printf_func(const char* fmt, ...)
-    {
-        va_list args;
-        va_start(args, fmt);
-        char buffer[256];
-        vsprintf (buffer, fmt, args);
-        cvtest::TS::ptr()->printf(cvtest::TS::SUMMARY, buffer);
-        va_end(args);
-    }
-
-    #define PRINT_TO_LOG __wrap_printf_func
+    va_list args;
+    va_start(args, fmt);
+    char buffer[256];
+    vsprintf (buffer, fmt, args);
+    cvtest::TS::ptr()->printf(cvtest::TS::SUMMARY, buffer);
+    va_end(args);
 }
+
+#define PRINT_TO_LOG __wrap_printf_func
 
 #define SHOW_IMAGE
 #undef SHOW_IMAGE
@@ -674,12 +667,15 @@ void CV_Resize_Test::resize_generic()
     for (int dy = 0; dy < tmp.rows; ++dy)
         resize_1d(src, tmp, dy, dims[0]);
 
-    transpose(tmp, tmp);
-    transpose(reference_dst, reference_dst);
+    cv::Mat tmp_t(tmp.cols, tmp.rows, tmp.type());
+    cvtest::transpose(tmp, tmp_t);
+    cv::Mat reference_dst_t(reference_dst.cols, reference_dst.rows, reference_dst.type());
+    cvtest::transpose(reference_dst, reference_dst_t);
 
-    for (int dy = 0; dy < tmp.rows; ++dy)
-        resize_1d(tmp, reference_dst, dy, dims[1]);
-    transpose(reference_dst, reference_dst);
+    for (int dy = 0; dy < tmp_t.rows; ++dy)
+        resize_1d(tmp_t, reference_dst_t, dy, dims[1]);
+
+    cvtest::transpose(reference_dst_t, reference_dst);
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -1318,3 +1314,5 @@ TEST_P(Imgproc_Resize, BigSize)
 INSTANTIATE_TEST_CASE_P(Imgproc, Imgproc_Resize, Interpolation::all());
 
 #endif
+
+}} // namespace

--- a/modules/imgproc/test/test_intersection.cpp
+++ b/modules/imgproc/test/test_intersection.cpp
@@ -45,8 +45,7 @@
 
 #include "test_precomp.hpp"
 
-using namespace cv;
-using namespace std;
+namespace opencv_test { namespace {
 
 #define ACCURACY 0.00001
 
@@ -497,3 +496,5 @@ void CV_RotatedRectangleIntersectionTest::test9()
 }
 
 TEST (Imgproc_RotatedRectangleIntersection, accuracy) { CV_RotatedRectangleIntersectionTest test; test.safe_run(); }
+
+}} // namespace

--- a/modules/imgproc/test/test_lsd.cpp
+++ b/modules/imgproc/test/test_lsd.cpp
@@ -1,9 +1,9 @@
+// This file is part of OpenCV project.
+// It is subject to the license terms in the LICENSE file found in the top-level directory
+// of this distribution and at http://opencv.org/license.html.
 #include "test_precomp.hpp"
 
-#include <vector>
-
-using namespace cv;
-using namespace std;
+namespace opencv_test { namespace {
 
 const Size img_size(640, 480);
 const int LSD_TEST_SEED = 0x134679;
@@ -263,3 +263,5 @@ TEST_F(Imgproc_LSD_NONE, rotatedRect)
     }
     ASSERT_EQ(EPOCHS, passedtests);
 }
+
+}} // namespace

--- a/modules/imgproc/test/test_main.cpp
+++ b/modules/imgproc/test/test_main.cpp
@@ -1,3 +1,6 @@
+// This file is part of OpenCV project.
+// It is subject to the license terms in the LICENSE file found in the top-level directory
+// of this distribution and at http://opencv.org/license.html.
 #include "test_precomp.hpp"
 
 CV_TEST_MAIN("cv")

--- a/modules/imgproc/test/test_moments.cpp
+++ b/modules/imgproc/test/test_moments.cpp
@@ -41,8 +41,7 @@
 #include "test_precomp.hpp"
 #include "opencv2/ts/ocl_test.hpp"
 
-using namespace cv;
-using namespace std;
+namespace opencv_test { namespace {
 
 #define OCL_TUNING_MODE 0
 #if OCL_TUNING_MODE
@@ -442,3 +441,5 @@ protected:
 };
 
 TEST(Imgproc_ContourMoment, small) { CV_SmallContourMomentTest test; test.safe_run(); }
+
+}} // namespace

--- a/modules/imgproc/test/test_pc.cpp
+++ b/modules/imgproc/test/test_pc.cpp
@@ -42,11 +42,7 @@
 
 #include "test_precomp.hpp"
 
-using namespace cv;
-using namespace std;
-
-namespace cvtest
-{
+namespace opencv_test { namespace {
 
 /// phase correlation
 class CV_PhaseCorrelatorTest : public cvtest::ArrayTest
@@ -124,4 +120,4 @@ TEST(Imgproc_PhaseCorrelatorTest, accuracy_1d_odd_fft) {
     ASSERT_NEAR(phaseShift.x, (double)xShift, 1.);
 }
 
-}
+}} // namespace

--- a/modules/imgproc/test/test_precomp.hpp
+++ b/modules/imgproc/test/test_precomp.hpp
@@ -1,21 +1,15 @@
-#ifdef __GNUC__
-#  pragma GCC diagnostic ignored "-Wmissing-declarations"
-#  if defined __clang__ || defined __APPLE__
-#    pragma GCC diagnostic ignored "-Wmissing-prototypes"
-#    pragma GCC diagnostic ignored "-Wextra"
-#  endif
-#endif
-
+// This file is part of OpenCV project.
+// It is subject to the license terms in the LICENSE file found in the top-level directory
+// of this distribution and at http://opencv.org/license.html.
 #ifndef __OPENCV_TEST_PRECOMP_HPP__
 #define __OPENCV_TEST_PRECOMP_HPP__
 
-#include <iostream>
 #include "opencv2/ts.hpp"
-#include "opencv2/core/private.hpp"
 #include "opencv2/imgproc.hpp"
-#include "opencv2/imgcodecs.hpp"
-#include "opencv2/core/softfloat.hpp"
-
 #include "opencv2/imgproc/imgproc_c.h"
+
+#include "opencv2/core/private.hpp"
+
+#include "opencv2/core/softfloat.hpp"  // softfloat, uint32_t
 
 #endif

--- a/modules/imgproc/test/test_resize_bitexact.cpp
+++ b/modules/imgproc/test/test_resize_bitexact.cpp
@@ -4,11 +4,8 @@
 
 #include "test_precomp.hpp"
 
-using namespace cv;
-using namespace std;
+namespace opencv_test { namespace {
 
-namespace
-{
     static const int fixedShiftU8 = 8;
 
     template <typename T, int fixedShift>
@@ -20,7 +17,6 @@ namespace
                       (((T*)src_pt10)[cn] * xcoeff0 + ((T*)src_pt11)[cn] * xcoeff1) * ycoeff1 ;
         ((T*)dst_pt)[cn] = saturate_cast<T>((val + fixedRound) >> (fixedShift * 2));
     }
-}
 
 TEST(Resize_Bitexact, Linear8U)
 {
@@ -156,4 +152,4 @@ TEST(Resize_Bitexact, Linear8U)
         }
 }
 
-///* End of file. */
+}} // namespace

--- a/modules/imgproc/test/test_smooth_bitexact.cpp
+++ b/modules/imgproc/test/test_smooth_bitexact.cpp
@@ -4,13 +4,8 @@
 
 #include "test_precomp.hpp"
 
-#include <vector>
+namespace opencv_test { namespace {
 
-using namespace cv;
-using namespace std;
-
-namespace
-{
     static const int fixedShiftU8 = 8;
     static const int64_t fixedOne = (1L << fixedShiftU8);
 
@@ -40,7 +35,6 @@ namespace
         }
         return saturate_cast<T>((val + fixedRound) >> (fixedShift * 2));
     }
-}
 
 TEST(GaussianBlur_Bitexact, Linear8U)
 {
@@ -131,7 +125,7 @@ TEST(GaussianBlur_Bitexact, Linear8U)
         for (int borderind = 0, _bordercnt = sizeof(bordermodes) / sizeof(bordermodes[0]); borderind < _bordercnt; ++borderind)
         {
             Mat src_border;
-            copyMakeBorder(src_roi, src_border, kernel.height / 2, kernel.height / 2, kernel.width / 2, kernel.width / 2, bordermodes[borderind]);
+            cv::copyMakeBorder(src_roi, src_border, kernel.height / 2, kernel.height / 2, kernel.width / 2, kernel.width / 2, bordermodes[borderind]);
             for (int c = 0; c < src_border.channels(); c++)
             {
                 int fromTo[2] = { c, 0 };
@@ -156,7 +150,7 @@ TEST(GaussianBlur_Bitexact, Linear8U)
                 mixChannels(dst_chan, refdst, toFrom, 1);
             }
 
-            GaussianBlur(src_roi, dst, kernel, modes[modeind].sigma_x, modes[modeind].sigma_y, bordermodes[borderind]);
+            cv::GaussianBlur(src_roi, dst, kernel, modes[modeind].sigma_x, modes[modeind].sigma_y, bordermodes[borderind]);
 
             EXPECT_GE(0, cvtest::norm(refdst, dst, cv::NORM_L1))
                 << "GaussianBlur " << cn << "-chan mat " << drows << "x" << dcols << " by kernel " << kernel << " sigma(" << modes[modeind].sigma_x << ";" << modes[modeind].sigma_y << ") failed with max diff " << cvtest::norm(refdst, dst, cv::NORM_INF);
@@ -164,4 +158,4 @@ TEST(GaussianBlur_Bitexact, Linear8U)
     }
 }
 
-///* End of file. */
+}} // namespace

--- a/modules/imgproc/test/test_templmatch.cpp
+++ b/modules/imgproc/test/test_templmatch.cpp
@@ -41,8 +41,7 @@
 
 #include "test_precomp.hpp"
 
-using namespace cv;
-using namespace std;
+namespace opencv_test { namespace {
 
 class CV_TemplMatchTest : public cvtest::ArrayTest
 {
@@ -334,3 +333,5 @@ void CV_TemplMatchTest::prepare_to_validation( int /*test_case_idx*/ )
 }
 
 TEST(Imgproc_MatchTemplate, accuracy) { CV_TemplMatchTest test; test.safe_run(); }
+
+}} // namespace

--- a/modules/imgproc/test/test_thresh.cpp
+++ b/modules/imgproc/test/test_thresh.cpp
@@ -41,8 +41,7 @@
 
 #include "test_precomp.hpp"
 
-using namespace cv;
-using namespace std;
+namespace opencv_test { namespace {
 
 class CV_ThreshTest : public cvtest::ArrayTest
 {
@@ -420,3 +419,5 @@ void CV_ThreshTest::prepare_to_validation( int /*test_case_idx*/ )
 }
 
 TEST(Imgproc_Threshold, accuracy) { CV_ThreshTest test; test.safe_run(); }
+
+}} // namespace

--- a/modules/imgproc/test/test_watershed.cpp
+++ b/modules/imgproc/test/test_watershed.cpp
@@ -41,10 +41,8 @@
 //M*/
 
 #include "test_precomp.hpp"
-#include <string>
 
-using namespace cv;
-using namespace std;
+namespace opencv_test { namespace {
 
 class CV_WatershedTest : public cvtest::BaseTest
 {
@@ -121,12 +119,9 @@ void CV_WatershedTest::run( int /* start_from */)
         exp = markers8U;
     }
 
-    if (0 != norm(markers8U, exp, NORM_INF))
-    {
-        ts->set_failed_test_info( cvtest::TS::FAIL_MISMATCH );
-        return;
-    }
-    ts->set_failed_test_info(cvtest::TS::OK);
+    ASSERT_EQ(0, cvtest::norm(markers8U, exp, NORM_INF));
 }
 
 TEST(Imgproc_Watershed, regression) { CV_WatershedTest test; test.safe_run(); }
+
+}} // namespace

--- a/modules/ml/test/test_emknearestkmeans.cpp
+++ b/modules/ml/test/test_emknearestkmeans.cpp
@@ -41,13 +41,12 @@
 
 #include "test_precomp.hpp"
 
-using namespace std;
-using namespace cv;
+namespace opencv_test { namespace {
+
 using cv::ml::TrainData;
 using cv::ml::EM;
 using cv::ml::KNearest;
 
-static
 void defaultDistribs( Mat& means, vector<Mat>& covs, int type=CV_32FC1 )
 {
     CV_TRACE_FUNCTION();
@@ -74,7 +73,6 @@ void defaultDistribs( Mat& means, vector<Mat>& covs, int type=CV_32FC1 )
 }
 
 // generate points sets by normal distributions
-static
 void generateData( Mat& data, Mat& labels, const vector<int>& sizes, const Mat& _means, const vector<Mat>& covs, int dataType, int labelType )
 {
     CV_TRACE_FUNCTION();
@@ -117,7 +115,6 @@ void generateData( Mat& data, Mat& labels, const vector<int>& sizes, const Mat& 
     }
 }
 
-static
 int maxIdx( const vector<int>& count )
 {
     int idx = -1;
@@ -135,7 +132,6 @@ int maxIdx( const vector<int>& count )
     return idx;
 }
 
-static
 bool getLabelsMap( const Mat& labels, const vector<int>& sizes, vector<int>& labelsMap, bool checkClusterUniq=true )
 {
     size_t total = 0, nclusters = sizes.size();
@@ -182,7 +178,6 @@ bool getLabelsMap( const Mat& labels, const vector<int>& sizes, vector<int>& lab
     return true;
 }
 
-static
 bool calcErr( const Mat& labels, const Mat& origLabels, const vector<int>& sizes, float& err, bool labelsEquivalent = true, bool checkClusterUniq=true )
 {
     err = 0;
@@ -706,3 +701,5 @@ TEST(ML_KNearest, accuracy) { CV_KNearestTest test; test.safe_run(); }
 TEST(ML_EM, accuracy) { CV_EMTest test; test.safe_run(); }
 TEST(ML_EM, save_load) { CV_EMTest_SaveLoad test; test.safe_run(); }
 TEST(ML_EM, classification) { CV_EMTest_Classification test; test.safe_run(); }
+
+}} // namespace

--- a/modules/ml/test/test_gbttest.cpp
+++ b/modules/ml/test/test_gbttest.cpp
@@ -3,10 +3,6 @@
 
 #if 0
 
-#include <string>
-#include <fstream>
-#include <iostream>
-
 using namespace std;
 
 

--- a/modules/ml/test/test_lr.cpp
+++ b/modules/ml/test/test_lr.cpp
@@ -58,11 +58,9 @@
 
 #include "test_precomp.hpp"
 
-using namespace std;
-using namespace cv;
-using namespace cv::ml;
+namespace opencv_test { namespace {
 
-static bool calculateError( const Mat& _p_labels, const Mat& _o_labels, float& error)
+bool calculateError( const Mat& _p_labels, const Mat& _o_labels, float& error)
 {
     CV_TRACE_FUNCTION();
     error = 0.0f;
@@ -226,3 +224,5 @@ void CV_LRTest_SaveLoad::run( int /*start_from*/ )
 
 TEST(ML_LR, accuracy) { CV_LRTest test; test.safe_run(); }
 TEST(ML_LR, save_load) { CV_LRTest_SaveLoad test; test.safe_run(); }
+
+}} // namespace

--- a/modules/ml/test/test_main.cpp
+++ b/modules/ml/test/test_main.cpp
@@ -1,3 +1,6 @@
+// This file is part of OpenCV project.
+// It is subject to the license terms in the LICENSE file found in the top-level directory
+// of this distribution and at http://opencv.org/license.html.
 #include "test_precomp.hpp"
 
 CV_TEST_MAIN("ml")

--- a/modules/ml/test/test_mltests.cpp
+++ b/modules/ml/test/test_mltests.cpp
@@ -41,8 +41,7 @@
 
 #include "test_precomp.hpp"
 
-using namespace cv;
-using namespace std;
+namespace opencv_test {
 
 CV_AMLTest::CV_AMLTest( const char* _modelName ) : CV_MLBaseTest( _modelName )
 {
@@ -124,6 +123,8 @@ int CV_AMLTest::validate_test_results( int testCaseIdx )
     }
     return cvtest::TS::OK;
 }
+
+namespace {
 
 TEST(ML_DTree, regression) { CV_AMLTest test( CV_DTREE ); test.safe_run(); }
 TEST(ML_Boost, regression) { CV_AMLTest test( CV_BOOST ); test.safe_run(); }
@@ -219,4 +220,5 @@ TEST(ML_RTrees, getVotes)
     EXPECT_EQ(result.at<float>(0, predicted_class), rt->predict(test));
 }
 
+}} // namespace
 /* End of file. */

--- a/modules/ml/test/test_mltests2.cpp
+++ b/modules/ml/test/test_mltests2.cpp
@@ -43,8 +43,7 @@
 
 //#define GENERATE_TESTDATA
 
-using namespace cv;
-using namespace std;
+namespace opencv_test { namespace {
 
 int str_to_svm_type(String& str)
 {
@@ -89,6 +88,7 @@ int str_to_ann_train_method( String& str )
     return -1;
 }
 
+#if 0
 int str_to_ann_activation_function(String& str)
 {
     if (!str.compare("IDENTITY"))
@@ -104,6 +104,7 @@ int str_to_ann_activation_function(String& str)
     CV_Error(CV_StsBadArg, "incorrect ann activation function string");
     return -1;
 }
+#endif
 
 void ann_check_data( Ptr<TrainData> _data )
 {
@@ -372,6 +373,8 @@ int str_to_margin_type( String& str )
         return SVMSGD::HARD_MARGIN;
     CV_Error( CV_StsBadArg, "incorrect svmsgd margin type string" );
     return -1;
+}
+
 }
 // ---------------------------------- MLBaseTest ---------------------------------------------------
 
@@ -700,4 +703,5 @@ void CV_MLBaseTest::load( const char* filename )
         CV_Error( CV_StsNotImplemented, "invalid stat model name");
 }
 
+} // namespace
 /* End of file. */

--- a/modules/ml/test/test_precomp.hpp
+++ b/modules/ml/test/test_precomp.hpp
@@ -1,19 +1,12 @@
-#ifdef __GNUC__
-#  pragma GCC diagnostic ignored "-Wmissing-declarations"
-#  if defined __clang__ || defined __APPLE__
-#    pragma GCC diagnostic ignored "-Wmissing-prototypes"
-#    pragma GCC diagnostic ignored "-Wextra"
-#  endif
-#endif
-
 #ifndef __OPENCV_TEST_PRECOMP_HPP__
 #define __OPENCV_TEST_PRECOMP_HPP__
 
-#include <iostream>
-#include <map>
 #include "opencv2/ts.hpp"
 #include "opencv2/ml.hpp"
 #include "opencv2/core/core_c.h"
+
+namespace opencv_test {
+using namespace cv::ml;
 
 #define CV_NBAYES   "nbayes"
 #define CV_KNEAREST "knearest"
@@ -93,5 +86,7 @@ protected:
     std::vector<float> test_resps1, test_resps2; // predicted responses for test data
     std::string fname1, fname2;
 };
+
+} // namespace
 
 #endif

--- a/modules/ml/test/test_save_load.cpp
+++ b/modules/ml/test/test_save_load.cpp
@@ -41,11 +41,7 @@
 
 #include "test_precomp.hpp"
 
-#include <iostream>
-#include <fstream>
-
-using namespace cv;
-using namespace std;
+namespace opencv_test {
 
 CV_SLMLTest::CV_SLMLTest( const char* _modelName ) : CV_MLBaseTest( _modelName )
 {
@@ -147,6 +143,8 @@ int CV_SLMLTest::validate_test_results( int testCaseIdx )
     }
     return code;
 }
+
+namespace {
 
 TEST(ML_NaiveBayes, save_load) { CV_SLMLTest test( CV_NBAYES ); test.safe_run(); }
 TEST(ML_KNearest, save_load) { CV_SLMLTest test( CV_KNEAREST ); test.safe_run(); }
@@ -295,10 +293,11 @@ TEST(DISABLED_ML_SVM, linear_save_load)
     svm3->predict(samples, r3);
 
     double eps = 1e-4;
-    EXPECT_LE(norm(r1, r2, NORM_INF), eps);
-    EXPECT_LE(norm(r1, r3, NORM_INF), eps);
+    EXPECT_LE(cvtest::norm(r1, r2, NORM_INF), eps);
+    EXPECT_LE(cvtest::norm(r1, r3, NORM_INF), eps);
 
     remove(tname.c_str());
 }
 
+}} // namespace
 /* End of file. */

--- a/modules/ml/test/test_svmsgd.cpp
+++ b/modules/ml/test/test_svmsgd.cpp
@@ -40,14 +40,11 @@
 //M*/
 
 #include "test_precomp.hpp"
-#include "opencv2/highgui.hpp"
 
-using namespace cv;
-using namespace cv::ml;
+namespace opencv_test { namespace {
+
 using cv::ml::SVMSGD;
 using cv::ml::TrainData;
-
-
 
 class CV_SVMSGDTrainTest : public cvtest::BaseTest
 {
@@ -300,7 +297,7 @@ TEST(ML_SVMSGD, twoPoints)
 
     float realShift = -500000.5;
 
-    float normRealWeights = static_cast<float>(norm(realWeights));
+    float normRealWeights = static_cast<float>(cv::norm(realWeights)); // TODO cvtest
     realWeights /= normRealWeights;
     realShift /= normRealWeights;
 
@@ -311,8 +308,11 @@ TEST(ML_SVMSGD, twoPoints)
     Mat foundWeights = svmsgd->getWeights();
     float foundShift = svmsgd->getShift();
 
-    float normFoundWeights = static_cast<float>(norm(foundWeights));
+    float normFoundWeights = static_cast<float>(cv::norm(foundWeights)); // TODO cvtest
     foundWeights /= normFoundWeights;
     foundShift /= normFoundWeights;
-    CV_Assert((norm(foundWeights - realWeights) < 0.001) && (abs((foundShift - realShift) / realShift) < 0.05));
+    EXPECT_LE(cv::norm(Mat(foundWeights - realWeights)), 0.001); // TODO cvtest
+    EXPECT_LE(std::abs((foundShift - realShift) / realShift), 0.05);
 }
+
+}} // namespace

--- a/modules/ml/test/test_svmtrainauto.cpp
+++ b/modules/ml/test/test_svmtrainauto.cpp
@@ -41,8 +41,8 @@
 
 #include "test_precomp.hpp"
 
-using namespace cv;
-using namespace std;
+namespace opencv_test { namespace {
+
 using cv::ml::SVM;
 using cv::ml::TrainData;
 
@@ -166,3 +166,5 @@ void CV_SVMGetSupportVectorsTest::run(int /*startFrom*/ )
 
 
 TEST(ML_SVM, getSupportVectors) { CV_SVMGetSupportVectorsTest test; test.safe_run(); }
+
+}} // namespace

--- a/modules/objdetect/perf/opencl/perf_cascades.cpp
+++ b/modules/objdetect/perf/opencl/perf_cascades.cpp
@@ -3,13 +3,11 @@
 
 #include "opencv2/ts/ocl_perf.hpp"
 
-using namespace std;
-using namespace cv;
+namespace opencv_test
+{
 using namespace perf;
-using std::tr1::make_tuple;
-using std::tr1::get;
 
-typedef std::tr1::tuple<std::string, std::string, int> Cascade_Image_MinSize_t;
+typedef tuple<std::string, std::string, int> Cascade_Image_MinSize_t;
 typedef perf::TestBaseWithParam<Cascade_Image_MinSize_t> Cascade_Image_MinSize;
 
 #ifdef HAVE_OPENCL
@@ -59,3 +57,5 @@ OCL_PERF_TEST_P(Cascade_Image_MinSize, CascadeClassifier,
 }
 
 #endif //HAVE_OPENCL
+
+} // namespace

--- a/modules/objdetect/perf/opencl/perf_hogdetect.cpp
+++ b/modules/objdetect/perf/opencl/perf_hogdetect.cpp
@@ -49,7 +49,7 @@
 
 #ifdef HAVE_OPENCL
 
-namespace cvtest {
+namespace opencv_test {
 namespace ocl {
 ///////////// HOG////////////////////////
 

--- a/modules/objdetect/perf/perf_precomp.hpp
+++ b/modules/objdetect/perf/perf_precomp.hpp
@@ -1,20 +1,7 @@
-#ifdef __GNUC__
-#  pragma GCC diagnostic ignored "-Wmissing-declarations"
-#  if defined __clang__ || defined __APPLE__
-#    pragma GCC diagnostic ignored "-Wmissing-prototypes"
-#    pragma GCC diagnostic ignored "-Wextra"
-#  endif
-#endif
-
 #ifndef __OPENCV_PERF_PRECOMP_HPP__
 #define __OPENCV_PERF_PRECOMP_HPP__
 
 #include "opencv2/ts.hpp"
 #include "opencv2/objdetect.hpp"
-#include "opencv2/highgui.hpp"
-
-#ifdef GTEST_CREATE_SHARED_LIBRARY
-#error no modules except ts should have GTEST_CREATE_SHARED_LIBRARY defined
-#endif
 
 #endif

--- a/modules/objdetect/test/opencl/test_hogdetector.cpp
+++ b/modules/objdetect/test/opencl/test_hogdetector.cpp
@@ -55,7 +55,7 @@
 
 #ifdef HAVE_OPENCL
 
-namespace cvtest {
+namespace opencv_test {
 namespace ocl {
 
 ///////////////////// HOG /////////////////////////////
@@ -117,5 +117,5 @@ INSTANTIATE_TEST_CASE_P(OCL_ObjDetect, HOG, testing::Combine(
                             testing::Values(Size(64, 128), Size(48, 96)),
                             testing::Values( MatType(CV_8UC1) ) ) );
 
-}}
+}} // namespace
 #endif

--- a/modules/objdetect/test/test_cascadeandhog.cpp
+++ b/modules/objdetect/test/test_cascadeandhog.cpp
@@ -40,11 +40,8 @@
 //M*/
 
 #include "test_precomp.hpp"
-#include "opencv2/imgproc.hpp"
-#include "opencv2/objdetect/objdetect_c.h"
 
-using namespace cv;
-using namespace std;
+namespace opencv_test { namespace {
 
 //#define GET_STAT
 
@@ -209,8 +206,7 @@ void CV_DetectorTest::run( int )
         vector<string>::const_iterator it = imageFilenames.begin();
         for( int ii = 0; it != imageFilenames.end(); ++it, ii++ )
         {
-            char buf[16] = {0};
-            sprintf( buf, "%s%d", "img_", ii );
+            //String buf = cv::format("img_%d", ii);
             //cvWriteComment( validationFS.fs, buf, 0 );
             validationFS << *it;
         }
@@ -265,9 +261,8 @@ int CV_DetectorTest::runTestCase( int detectorIdx, vector<vector<Rect> >& object
         Mat image = images[ii];
         if( image.empty() )
         {
-            char msg[50] = {0};
-            sprintf( msg, "%s %d %s", "image ", ii, " can not be read" );
-            ts->printf( cvtest::TS::LOG, msg );
+            String msg = cv::format("image %d is empty", ii);
+            ts->printf( cvtest::TS::LOG, msg.c_str() );
             return cvtest::TS::FAIL_INVALID_TEST_DATA;
         }
         int code = detectMultiScale( detectorIdx, image, imgObjects );
@@ -278,9 +273,7 @@ int CV_DetectorTest::runTestCase( int detectorIdx, vector<vector<Rect> >& object
 
         if( write_results )
         {
-            char buf[16] = {0};
-            sprintf( buf, "%s%d", "img_", ii );
-            string imageIdxStr = buf;
+            String imageIdxStr = cv::format("img_%d", ii);
             validationFS << imageIdxStr << "[:";
             for( vector<Rect>::const_iterator it = imgObjects.begin();
                     it != imgObjects.end(); ++it )
@@ -294,7 +287,7 @@ int CV_DetectorTest::runTestCase( int detectorIdx, vector<vector<Rect> >& object
 }
 
 
-bool isZero( uchar i ) {return i == 0;}
+static bool isZero( uchar i ) {return i == 0;}
 
 int CV_DetectorTest::validate( int detectorIdx, vector<vector<Rect> >& objects )
 {
@@ -313,9 +306,7 @@ int CV_DetectorTest::validate( int detectorIdx, vector<vector<Rect> >& objects )
         int noPair = 0;
 
         // read validation rectangles
-        char buf[16] = {0};
-        sprintf( buf, "%s%d", "img_", imageIdx );
-        string imageIdxStr = buf;
+        String imageIdxStr = cv::format("img_%d", imageIdx);
         FileNode node = validationFS.getFirstTopLevelNode()[VALIDATION][detectorNames[detectorIdx]][imageIdxStr];
         vector<Rect> valRects;
         if( node.size() != 0 )
@@ -337,12 +328,12 @@ int CV_DetectorTest::validate( int detectorIdx, vector<vector<Rect> >& objects )
             // find nearest rectangle
             Point2f cp1 = Point2f( cr->x + (float)cr->width/2.0f, cr->y + (float)cr->height/2.0f );
             int minIdx = -1, vi = 0;
-            float minDist = (float)norm( Point(imgSize.width, imgSize.height) );
+            float minDist = (float)cv::norm( Point(imgSize.width, imgSize.height) );
             for( vector<Rect>::const_iterator vr = valRects.begin();
                 vr != valRects.end(); ++vr, vi++ )
             {
                 Point2f cp2 = Point2f( vr->x + (float)vr->width/2.0f, vr->y + (float)vr->height/2.0f );
-                float curDist = (float)norm(cp1-cp2);
+                float curDist = (float)cv::norm(cp1-cp2);
                 if( curDist < minDist )
                 {
                     minIdx = vi;
@@ -598,7 +589,6 @@ struct HOGCacheTester
         float gradWeight;
     };
 
-    HOGCacheTester();
     HOGCacheTester(const HOGDescriptorTester* descriptor,
         const Mat& img, Size paddingTL, Size paddingBR,
         bool useCache, Size cacheStride);
@@ -628,14 +618,10 @@ struct HOGCacheTester
 
     Mat grad, qangle;
     const HOGDescriptorTester* descriptor;
-};
 
-HOGCacheTester::HOGCacheTester()
-{
-    useCache = false;
-    blockHistogramSize = count1 = count2 = count4 = 0;
-    descriptor = 0;
-}
+private:
+    HOGCacheTester();  //= delete
+};
 
 HOGCacheTester::HOGCacheTester(const HOGDescriptorTester* _descriptor,
     const Mat& _img, Size _paddingTL, Size _paddingBR,
@@ -1386,3 +1372,5 @@ TEST(Objdetect_CascadeDetector, small_img)
         }
     }
 }
+
+}} // namespace

--- a/modules/objdetect/test/test_main.cpp
+++ b/modules/objdetect/test/test_main.cpp
@@ -1,3 +1,6 @@
+// This file is part of OpenCV project.
+// It is subject to the license terms in the LICENSE file found in the top-level directory
+// of this distribution and at http://opencv.org/license.html.
 #include "test_precomp.hpp"
 
 CV_TEST_MAIN("cv")

--- a/modules/objdetect/test/test_precomp.hpp
+++ b/modules/objdetect/test/test_precomp.hpp
@@ -1,17 +1,11 @@
-#ifdef __GNUC__
-#  pragma GCC diagnostic ignored "-Wmissing-declarations"
-#  if defined __clang__ || defined __APPLE__
-#    pragma GCC diagnostic ignored "-Wmissing-prototypes"
-#    pragma GCC diagnostic ignored "-Wextra"
-#  endif
-#endif
-
+// This file is part of OpenCV project.
+// It is subject to the license terms in the LICENSE file found in the top-level directory
+// of this distribution and at http://opencv.org/license.html.
 #ifndef __OPENCV_TEST_PRECOMP_HPP__
 #define __OPENCV_TEST_PRECOMP_HPP__
 
 #include "opencv2/ts.hpp"
 #include "opencv2/objdetect.hpp"
-#include "opencv2/imgproc.hpp"
-#include "opencv2/imgcodecs.hpp"
+#include "opencv2/objdetect/objdetect_c.h"
 
 #endif

--- a/modules/photo/perf/opencl/perf_denoising.cpp
+++ b/modules/photo/perf/opencl/perf_denoising.cpp
@@ -10,7 +10,7 @@
 
 #ifdef HAVE_OPENCL
 
-namespace cvtest {
+namespace opencv_test {
 namespace ocl {
 
 OCL_PERF_TEST(Photo, DenoisingGrayscale)
@@ -92,6 +92,6 @@ OCL_PERF_TEST(Photo, DISABLED_DenoisingColoredMulti)
     SANITY_CHECK(result);
 }
 
-} } // namespace cvtest::ocl
+} } // namespace opencv_test::ocl
 
 #endif // HAVE_OPENCL

--- a/modules/photo/perf/perf_cuda.cpp
+++ b/modules/photo/perf/perf_cuda.cpp
@@ -49,8 +49,7 @@
 
 #if defined (HAVE_CUDA) && defined(HAVE_OPENCV_CUDAARITHM) && defined(HAVE_OPENCV_CUDAIMGPROC)
 
-using namespace std;
-using namespace testing;
+namespace opencv_test { namespace {
 using namespace perf;
 
 #define CUDA_DENOISING_IMAGE_SIZES testing::Values(perf::szVGA, perf::sz720p)
@@ -186,4 +185,5 @@ PERF_TEST_P(Sz_Depth_WinSz_BlockSz, CUDA_FastNonLocalMeansColored,
     }
 }
 
+}} // namespace
 #endif

--- a/modules/photo/perf/perf_inpaint.cpp
+++ b/modules/photo/perf/perf_inpaint.cpp
@@ -1,13 +1,10 @@
 #include "perf_precomp.hpp"
 
-using namespace std;
-using namespace cv;
-using namespace perf;
-using std::tr1::make_tuple;
-using std::tr1::get;
+namespace opencv_test
+{
 
 CV_ENUM(InpaintingMethod, INPAINT_NS, INPAINT_TELEA)
-typedef std::tr1::tuple<Size, InpaintingMethod> InpaintArea_InpaintingMethod_t;
+typedef tuple<Size, InpaintingMethod> InpaintArea_InpaintingMethod_t;
 typedef perf::TestBaseWithParam<InpaintArea_InpaintingMethod_t> InpaintArea_InpaintingMethod;
 
 
@@ -36,3 +33,5 @@ PERF_TEST_P(InpaintArea_InpaintingMethod, inpaint,
     Mat inpaintedArea = result(inpaintArea);
     SANITY_CHECK(inpaintedArea);
 }
+
+} // namespace

--- a/modules/photo/perf/perf_precomp.hpp
+++ b/modules/photo/perf/perf_precomp.hpp
@@ -1,20 +1,7 @@
-#ifdef __GNUC__
-#  pragma GCC diagnostic ignored "-Wmissing-declarations"
-#  if defined __clang__ || defined __APPLE__
-#    pragma GCC diagnostic ignored "-Wmissing-prototypes"
-#    pragma GCC diagnostic ignored "-Wextra"
-#  endif
-#endif
-
 #ifndef __OPENCV_PERF_PRECOMP_HPP__
 #define __OPENCV_PERF_PRECOMP_HPP__
 
 #include "opencv2/ts.hpp"
 #include "opencv2/photo.hpp"
-#include "opencv2/imgcodecs.hpp"
-
-#ifdef GTEST_CREATE_SHARED_LIBRARY
-#error no modules except ts should have GTEST_CREATE_SHARED_LIBRARY defined
-#endif
 
 #endif

--- a/modules/photo/test/ocl/test_denoising.cpp
+++ b/modules/photo/test/ocl/test_denoising.cpp
@@ -10,7 +10,7 @@
 
 #ifdef HAVE_OPENCL
 
-namespace cvtest {
+namespace opencv_test {
 namespace ocl {
 
 PARAM_TEST_CASE(FastNlMeansDenoisingTestBase, Channels, int, bool, bool)
@@ -128,6 +128,6 @@ OCL_INSTANTIATE_TEST_CASE_P(Photo, FastNlMeansDenoising_hsep,
 OCL_INSTANTIATE_TEST_CASE_P(Photo, FastNlMeansDenoisingColored,
                             Combine(Values(3, 4), Values((int)NORM_L2), Bool(), Values(false)));
 
-} } // namespace cvtest::ocl
+} } // namespace opencv_test::ocl
 
 #endif // HAVE_OPENCL

--- a/modules/photo/test/test_cloning.cpp
+++ b/modules/photo/test/test_cloning.cpp
@@ -39,6 +39,10 @@
 //
 //M*/
 
+#include "test_precomp.hpp"
+
+namespace opencv_test { namespace {
+
 #define OUTPUT_SAVING 0
 #if OUTPUT_SAVING
 #define SAVE(x) std::vector<int> params;\
@@ -48,13 +52,6 @@
 #else
 #define SAVE(x)
 #endif
-
-#include "test_precomp.hpp"
-#include "opencv2/photo.hpp"
-#include <string>
-
-using namespace cv;
-using namespace std;
 
 static const double numerical_precision = 1000.;
 
@@ -228,3 +225,5 @@ TEST(Photo_SeamlessClone_textureFlattening, regression)
     EXPECT_LE(error, numerical_precision);
 
 }
+
+}} // namespace

--- a/modules/photo/test/test_decolor.cpp
+++ b/modules/photo/test/test_decolor.cpp
@@ -39,13 +39,9 @@
 //
 //M*/
 
-
 #include "test_precomp.hpp"
-#include "opencv2/photo.hpp"
-#include <string>
 
-using namespace cv;
-using namespace std;
+namespace opencv_test { namespace {
 
 TEST(Photo_Decolor, regression)
 {
@@ -68,3 +64,5 @@ TEST(Photo_Decolor, regression)
         double boost_psnr = cvtest::PSNR(reference_boost, color_boost);
         EXPECT_GT(boost_psnr, 60.0);
 }
+
+}} // namespace

--- a/modules/photo/test/test_denoise_tvl1.cpp
+++ b/modules/photo/test/test_denoise_tvl1.cpp
@@ -40,6 +40,8 @@
 //M*/
 #include "test_precomp.hpp"
 
+namespace opencv_test { namespace {
+
 void make_noisy(const cv::Mat& img, cv::Mat& noisy, double sigma, double pepper_salt_ratio,cv::RNG& rng)
 {
     noisy.create(img.size(), img.type());
@@ -55,6 +57,7 @@ void make_noisy(const cv::Mat& img, cv::Mat& noisy, double sigma, double pepper_
     cv::addWeighted(noisy, 1, noise, 1, -128, noisy);
 }
 
+#if 0
 void make_spotty(cv::Mat& img,cv::RNG& rng, int r=3,int n=1000)
 {
     for(int i=0;i<n;i++)
@@ -66,6 +69,7 @@ void make_spotty(cv::Mat& img,cv::RNG& rng, int r=3,int n=1000)
             img(cv::Range(y,y+r),cv::Range(x,x+r))=(uchar)255;
     }
 }
+#endif
 
 bool validate_pixel(const cv::Mat& image,int x,int y,uchar val)
 {
@@ -121,3 +125,5 @@ TEST(Optim_denoise_tvl1, regression_basic)
 #endif
 
 }
+
+}} // namespace

--- a/modules/photo/test/test_denoising.cpp
+++ b/modules/photo/test/test_denoising.cpp
@@ -41,11 +41,8 @@
 //M*/
 
 #include "test_precomp.hpp"
-#include "opencv2/photo.hpp"
-#include <string>
 
-using namespace cv;
-using namespace std;
+namespace opencv_test { namespace {
 
 //#define DUMP_RESULTS
 
@@ -167,3 +164,5 @@ TEST(Photo_Denoising, speed)
     t = (double)getTickCount() - t;
     printf("execution time: %gms\n", t*1000./getTickFrequency());
 }
+
+}} // namespace

--- a/modules/photo/test/test_denoising.cuda.cpp
+++ b/modules/photo/test/test_denoising.cuda.cpp
@@ -50,7 +50,7 @@
 
 #if defined (HAVE_CUDA) && defined(HAVE_OPENCV_CUDAARITHM) && defined(HAVE_OPENCV_CUDAIMGPROC)
 
-using namespace cvtest;
+namespace opencv_test { namespace {
 
 ////////////////////////////////////////////////////////
 // Brute Force Non local means
@@ -116,4 +116,5 @@ TEST(CUDA_FastNonLocalMeans, Regression)
     EXPECT_MAT_NEAR(gray_gold, dgray, 1);
 }
 
+}} // namespace
 #endif // HAVE_CUDA

--- a/modules/photo/test/test_hdr.cpp
+++ b/modules/photo/test/test_hdr.cpp
@@ -41,8 +41,7 @@
 
 #include "test_precomp.hpp"
 
-using namespace cv;
-using namespace std;
+namespace opencv_test { namespace {
 
 void loadImage(string path, Mat &img)
 {
@@ -60,7 +59,7 @@ void checkEqual(Mat img0, Mat img1, double threshold, const string& name)
 static vector<float> DEFAULT_VECTOR;
 void loadExposureSeq(String path, vector<Mat>& images, vector<float>& times = DEFAULT_VECTOR)
 {
-    ifstream list_file((path + "list.txt").c_str());
+    std::ifstream list_file((path + "list.txt").c_str());
     ASSERT_TRUE(list_file.is_open());
     string name;
     float val;
@@ -76,7 +75,7 @@ void loadExposureSeq(String path, vector<Mat>& images, vector<float>& times = DE
 void loadResponseCSV(String path, Mat& response)
 {
     response = Mat(256, 1, CV_32FC3);
-    ifstream resp_file(path.c_str());
+    std::ifstream resp_file(path.c_str());
     for(int i = 0; i < 256; i++) {
         for(int c = 0; c < 3; c++) {
             resp_file >> response.at<Vec3f>(i)[c];
@@ -141,7 +140,7 @@ TEST(Photo_AlignMTB, regression)
     int errors = 0;
 
     Ptr<AlignMTB> align = createAlignMTB(max_bits);
-    RNG rng = ::theRNG();
+    RNG rng = theRNG();
 
     for(int i = 0; i < TESTS_COUNT; i++) {
         Point shift(rng.uniform(0, max_shift), rng.uniform(0, max_shift));
@@ -255,3 +254,5 @@ TEST(Photo_CalibrateRobertson, regression)
     calibrate->process(images, response, times);
     checkEqual(expected, response, 1e-1f, "CalibrateRobertson");
 }
+
+}} // namespace

--- a/modules/photo/test/test_inpaint.cpp
+++ b/modules/photo/test/test_inpaint.cpp
@@ -41,10 +41,8 @@
 //M*/
 
 #include "test_precomp.hpp"
-#include <string>
 
-using namespace std;
-using namespace cv;
+namespace opencv_test { namespace {
 
 class CV_InpaintTest : public cvtest::BaseTest
 {
@@ -118,11 +116,11 @@ void CV_InpaintTest::run( int )
 
 TEST(Photo_Inpaint, regression) { CV_InpaintTest test; test.safe_run(); }
 
-typedef testing::TestWithParam<std::tr1::tuple<int> > formats;
+typedef testing::TestWithParam<tuple<int> > formats;
 
 TEST_P(formats, 1c)
 {
-    const int type = std::tr1::get<0>(GetParam());
+    const int type = get<0>(GetParam());
     Mat src(100, 100, type);
     src.setTo(Scalar::all(128));
     Mat ref = src.clone();
@@ -140,3 +138,5 @@ TEST_P(formats, 1c)
 }
 
 INSTANTIATE_TEST_CASE_P(Photo_Inpaint, formats, testing::Values(CV_32F, CV_16U, CV_8U));
+
+}} // namespace

--- a/modules/photo/test/test_main.cpp
+++ b/modules/photo/test/test_main.cpp
@@ -1,3 +1,6 @@
+// This file is part of OpenCV project.
+// It is subject to the license terms in the LICENSE file found in the top-level directory
+// of this distribution and at http://opencv.org/license.html.
 #include "test_precomp.hpp"
 
 CV_TEST_MAIN("cv")

--- a/modules/photo/test/test_npr.cpp
+++ b/modules/photo/test/test_npr.cpp
@@ -39,13 +39,9 @@
 //
 //M*/
 
-
 #include "test_precomp.hpp"
-#include "opencv2/photo.hpp"
-#include <string>
 
-using namespace cv;
-using namespace std;
+namespace opencv_test { namespace {
 
 static const double numerical_precision = 100.;
 
@@ -115,7 +111,7 @@ TEST(Photo_NPR_PencilSketch, regression)
     pencilSketch(source,pencil_result, color_pencil_result, 10, 0.1f, 0.03f);
 
     Mat pencil_reference = imread(folder + "pencil_sketch_reference.png", 0 /* == grayscale*/);
-    double pencil_error = norm(pencil_reference, pencil_result, NORM_L1);
+    double pencil_error = cvtest::norm(pencil_reference, pencil_result, NORM_L1);
     EXPECT_LE(pencil_error, numerical_precision);
 
     Mat color_pencil_reference = imread(folder + "color_pencil_sketch_reference.png");
@@ -140,3 +136,5 @@ TEST(Photo_NPR_Stylization, regression)
     EXPECT_LE(stylized_error, numerical_precision);
 
 }
+
+}} // namespace

--- a/modules/photo/test/test_precomp.hpp
+++ b/modules/photo/test/test_precomp.hpp
@@ -1,21 +1,10 @@
-#ifdef __GNUC__
-#  pragma GCC diagnostic ignored "-Wmissing-declarations"
-#  if defined __clang__ || defined __APPLE__
-#    pragma GCC diagnostic ignored "-Wmissing-prototypes"
-#    pragma GCC diagnostic ignored "-Wextra"
-#  endif
-#endif
-
+// This file is part of OpenCV project.
+// It is subject to the license terms in the LICENSE file found in the top-level directory
+// of this distribution and at http://opencv.org/license.html.
 #ifndef __OPENCV_TEST_PRECOMP_HPP__
 #define __OPENCV_TEST_PRECOMP_HPP__
 
-#include <iostream>
 #include "opencv2/ts.hpp"
 #include "opencv2/photo.hpp"
-#include "opencv2/imgcodecs.hpp"
-#include <string>
-#include <algorithm>
-#include <fstream>
-#include <ctime>
 
 #endif

--- a/modules/shape/test/test_main.cpp
+++ b/modules/shape/test/test_main.cpp
@@ -1,3 +1,6 @@
+// This file is part of OpenCV project.
+// It is subject to the license terms in the LICENSE file found in the top-level directory
+// of this distribution and at http://opencv.org/license.html.
 #include "test_precomp.hpp"
 
 CV_TEST_MAIN("cv")

--- a/modules/shape/test/test_precomp.hpp
+++ b/modules/shape/test/test_precomp.hpp
@@ -1,19 +1,10 @@
-#ifdef __GNUC__
-#  pragma GCC diagnostic ignored "-Wmissing-declarations"
-#  if defined __clang__ || defined __APPLE__
-#    pragma GCC diagnostic ignored "-Wmissing-prototypes"
-#    pragma GCC diagnostic ignored "-Wextra"
-#  endif
-#endif
-
+// This file is part of OpenCV project.
+// It is subject to the license terms in the LICENSE file found in the top-level directory
+// of this distribution and at http://opencv.org/license.html.
 #ifndef __OPENCV_TEST_PRECOMP_HPP__
 #define __OPENCV_TEST_PRECOMP_HPP__
 
-#include <iostream>
 #include "opencv2/ts.hpp"
-#include "opencv2/core.hpp"
-#include "opencv2/imgproc.hpp"
-#include "opencv2/imgcodecs.hpp"
 #include "opencv2/shape.hpp"
 
 #endif

--- a/modules/shape/test/test_shape.cpp
+++ b/modules/shape/test/test_shape.cpp
@@ -41,8 +41,7 @@
 
 #include "test_precomp.hpp"
 
-using namespace cv;
-using namespace std;
+namespace opencv_test { namespace {
 
 template <typename T, typename compute>
 class ShapeBaseTest : public cvtest::BaseTest
@@ -63,7 +62,7 @@ public:
         {
             for (int j = 0; j < NSN; ++j)
             {
-                stringstream filename;
+                std::stringstream filename;
                 filename << cvtest::TS::ptr()->get_data_path()
                          << "shape/mpeg_test/" << *i << "-" << j + 1 << ".png";
                 filenames.push_back(filename.str());
@@ -321,3 +320,5 @@ TEST(computeDistance, regression_4976)
     EXPECT_NEAR(d1, 26.4196891785, 1e-3) << "HausdorffDistanceExtractor";
     EXPECT_NEAR(d2, 0.25804194808, 1e-3) << "ShapeContextDistanceExtractor";
 }
+
+}} // namespace

--- a/modules/stitching/perf/opencl/perf_stitch.cpp
+++ b/modules/stitching/perf/opencl/perf_stitch.cpp
@@ -9,13 +9,9 @@
 
 #ifdef HAVE_OPENCL
 
-namespace cvtest {
-namespace ocl {
-
-using namespace cv;
+namespace opencv_test {
 using namespace perf;
-using namespace std;
-using namespace std::tr1;
+namespace ocl {
 
 #define SURF_MATCH_CONFIDENCE 0.65f
 #define ORB_MATCH_CONFIDENCE  0.3f
@@ -146,6 +142,6 @@ OCL_PERF_TEST_P(stitch, boat, TEST_DETECTORS)
     SANITY_CHECK_NOTHING();
 }
 
-} } // namespace cvtest::ocl
+} } // namespace opencv_test::ocl
 
 #endif // HAVE_OPENCL

--- a/modules/stitching/perf/opencl/perf_warpers.cpp
+++ b/modules/stitching/perf/opencl/perf_warpers.cpp
@@ -45,7 +45,7 @@
 
 #ifdef HAVE_OPENCL
 
-namespace cvtest {
+namespace opencv_test {
 namespace ocl {
 
 ///////////////////////// Stitching Warpers ///////////////////////////
@@ -157,6 +157,6 @@ OCL_PERF_TEST_P(StitchingWarpersFixture, StitchingWarpers_Warp,
     SANITY_CHECK(dst, 1e-5);
 }
 
-} } // namespace cvtest::ocl
+} } // namespace opencv_test::ocl
 
 #endif // HAVE_OPENCL

--- a/modules/stitching/perf/perf_estimators.cpp
+++ b/modules/stitching/perf/perf_estimators.cpp
@@ -2,11 +2,9 @@
 #include "opencv2/imgcodecs.hpp"
 #include "opencv2/opencv_modules.hpp"
 
-using namespace std;
-using namespace cv;
+namespace opencv_test
+{
 using namespace perf;
-using std::tr1::tuple;
-using std::tr1::get;
 
 typedef TestBaseWithParam<tuple<string, string> > bundleAdjuster;
 
@@ -98,3 +96,5 @@ PERF_TEST_P(bundleAdjuster, affine, testing::Combine(TEST_DETECTORS, AFFINE_FUNC
     EXPECT_FLOAT_EQ(h.at<float>(1), 0.f);
     EXPECT_FLOAT_EQ(h.at<float>(2), 1.f);
 }
+
+} // namespace

--- a/modules/stitching/perf/perf_matchers.cpp
+++ b/modules/stitching/perf/perf_matchers.cpp
@@ -3,15 +3,13 @@
 #include "opencv2/opencv_modules.hpp"
 #include "opencv2/flann.hpp"
 
-using namespace std;
-using namespace cv;
+namespace opencv_test
+{
 using namespace perf;
-using std::tr1::make_tuple;
-using std::tr1::get;
 
 typedef TestBaseWithParam<size_t> FeaturesFinderVec;
 typedef TestBaseWithParam<string> match;
-typedef std::tr1::tuple<string, int> matchVector_t;
+typedef tuple<string, int> matchVector_t;
 typedef TestBaseWithParam<matchVector_t> matchVector;
 
 #define NUMBER_IMAGES testing::Values(1, 5, 20)
@@ -299,3 +297,5 @@ PERF_TEST_P( matchVector, affineBestOf2NearestVectorFeatures, testing::Combine(
 
     SANITY_CHECK_NOTHING();
 }
+
+} // namespace

--- a/modules/stitching/perf/perf_precomp.hpp
+++ b/modules/stitching/perf/perf_precomp.hpp
@@ -1,20 +1,8 @@
-#ifdef __GNUC__
-#  pragma GCC diagnostic ignored "-Wmissing-declarations"
-#  if defined __clang__ || defined __APPLE__
-#    pragma GCC diagnostic ignored "-Wmissing-prototypes"
-#    pragma GCC diagnostic ignored "-Wextra"
-#  endif
-#endif
-
 #ifndef __OPENCV_PERF_PRECOMP_HPP__
 #define __OPENCV_PERF_PRECOMP_HPP__
 
 #include "opencv2/ts.hpp"
 #include "opencv2/stitching.hpp"
-
-#ifdef GTEST_CREATE_SHARED_LIBRARY
-#error no modules except ts should have GTEST_CREATE_SHARED_LIBRARY defined
-#endif
 
 namespace cv
 {

--- a/modules/stitching/perf/perf_stich.cpp
+++ b/modules/stitching/perf/perf_stich.cpp
@@ -4,11 +4,9 @@
 
 #include "opencv2/core/ocl.hpp"
 
-using namespace std;
-using namespace cv;
+namespace opencv_test
+{
 using namespace perf;
-using std::tr1::tuple;
-using std::tr1::get;
 
 #define SURF_MATCH_CONFIDENCE 0.65f
 #define ORB_MATCH_CONFIDENCE  0.3f
@@ -167,3 +165,5 @@ PERF_TEST_P(stitchDatasets, affine, testing::Combine(AFFINE_DATASETS, TEST_DETEC
 
     SANITY_CHECK_NOTHING();
 }
+
+} // namespace

--- a/modules/stitching/test/ocl/test_warpers.cpp
+++ b/modules/stitching/test/ocl/test_warpers.cpp
@@ -45,7 +45,7 @@
 
 #ifdef HAVE_OPENCL
 
-namespace cvtest {
+namespace opencv_test {
 namespace ocl {
 
 struct WarperTestBase :
@@ -164,6 +164,6 @@ OCL_TEST_F(AffineWarperTest, Mat)
     }
 }
 
-} } // namespace cvtest::ocl
+} } // namespace opencv_test::ocl
 
 #endif // HAVE_OPENCL

--- a/modules/stitching/test/test_blenders.cpp
+++ b/modules/stitching/test/test_blenders.cpp
@@ -41,8 +41,7 @@
 
 #include "test_precomp.hpp"
 
-using namespace cv;
-using namespace std;
+namespace opencv_test { namespace {
 
 TEST(MultiBandBlender, CanBlendTwoImages)
 {
@@ -76,3 +75,5 @@ TEST(MultiBandBlender, CanBlendTwoImages)
     double psnr = cvtest::PSNR(expected, result);
     EXPECT_GE(psnr, 50);
 }
+
+}} // namespace

--- a/modules/stitching/test/test_blenders.cuda.cpp
+++ b/modules/stitching/test/test_blenders.cuda.cpp
@@ -42,13 +42,9 @@
 #include "test_precomp.hpp"
 #include "opencv2/ts/cuda_test.hpp"
 
+namespace opencv_test { namespace {
 #if defined(HAVE_OPENCV_CUDAARITHM) && defined(HAVE_OPENCV_CUDAWARPING)
 
-using namespace cv;
-using namespace std;
-
-namespace
-{
     void multiBandBlend(const cv::Mat& im1, const cv::Mat& im2, const cv::Mat& mask1, const cv::Mat& mask2, cv::Mat& result, bool try_cuda)
     {
         detail::MultiBandBlender blender(try_cuda, 5);
@@ -61,7 +57,6 @@ namespace
         blender.blend(result_s, result_mask);
         result_s.convertTo(result, CV_8U);
     }
-}
 
 TEST(CUDA_MultiBandBlender, Accuracy)
 {
@@ -91,3 +86,4 @@ TEST(CUDA_MultiBandBlender, Accuracy)
 }
 
 #endif
+}} // namespace

--- a/modules/stitching/test/test_main.cpp
+++ b/modules/stitching/test/test_main.cpp
@@ -1,3 +1,6 @@
+// This file is part of OpenCV project.
+// It is subject to the license terms in the LICENSE file found in the top-level directory
+// of this distribution and at http://opencv.org/license.html.
 #include "test_precomp.hpp"
 
 CV_TEST_MAIN(".")

--- a/modules/stitching/test/test_matchers.cpp
+++ b/modules/stitching/test/test_matchers.cpp
@@ -42,8 +42,7 @@
 #include "test_precomp.hpp"
 #include "opencv2/opencv_modules.hpp"
 
-using namespace cv;
-using namespace std;
+namespace opencv_test { namespace {
 
 #ifdef HAVE_OPENCV_XFEATURES2D
 
@@ -99,3 +98,5 @@ TEST(ParallelFeaturesFinder, IsSameWithSerial)
         ASSERT_EQ(serial_features.keypoints.size(), para_features[i].keypoints.size());
     }
 }
+
+}} // namespace

--- a/modules/stitching/test/test_precomp.hpp
+++ b/modules/stitching/test/test_precomp.hpp
@@ -1,20 +1,12 @@
-#ifdef __GNUC__
-#  pragma GCC diagnostic ignored "-Wmissing-declarations"
-#  if defined __clang__ || defined __APPLE__
-#    pragma GCC diagnostic ignored "-Wmissing-prototypes"
-#    pragma GCC diagnostic ignored "-Wextra"
-#  endif
-#endif
-
+// This file is part of OpenCV project.
+// It is subject to the license terms in the LICENSE file found in the top-level directory
+// of this distribution and at http://opencv.org/license.html.
 #ifndef __OPENCV_TEST_PRECOMP_HPP__
 #define __OPENCV_TEST_PRECOMP_HPP__
 
-#include <iostream>
-#include <string>
-#include <opencv2/ts.hpp>
-#include <opencv2/imgcodecs.hpp>
-#include <opencv2/stitching.hpp>
-#include <opencv2/stitching/detail/matchers.hpp>
-#include <opencv2/stitching/detail/blenders.hpp>
+#include "opencv2/ts.hpp"
+#include "opencv2/stitching.hpp"
+#include "opencv2/stitching/detail/matchers.hpp"
+#include "opencv2/stitching/detail/blenders.hpp"
 
 #endif

--- a/modules/superres/perf/perf_precomp.hpp
+++ b/modules/superres/perf/perf_precomp.hpp
@@ -39,27 +39,13 @@
 // the use of this software, even if advised of the possibility of such damage.
 //
 //M*/
-
-#ifdef __GNUC__
-#  pragma GCC diagnostic ignored "-Wmissing-declarations"
-#  if defined __clang__ || defined __APPLE__
-#    pragma GCC diagnostic ignored "-Wmissing-prototypes"
-#    pragma GCC diagnostic ignored "-Wextra"
-#  endif
-#endif
-
 #ifndef __OPENCV_PERF_PRECOMP_HPP__
 #define __OPENCV_PERF_PRECOMP_HPP__
 
-#include "opencv2/core.hpp"
-#include "opencv2/core/cuda.hpp"
 #include "opencv2/ts.hpp"
+#include "opencv2/core/cuda.hpp"
 #include "opencv2/ts/cuda_perf.hpp"
 #include "opencv2/superres.hpp"
 #include "opencv2/superres/optical_flow.hpp"
-
-#ifdef GTEST_CREATE_SHARED_LIBRARY
-#error no modules except ts should have GTEST_CREATE_SHARED_LIBRARY defined
-#endif
 
 #endif

--- a/modules/superres/perf/perf_superres.cpp
+++ b/modules/superres/perf/perf_superres.cpp
@@ -43,11 +43,9 @@
 #include "perf_precomp.hpp"
 #include "opencv2/ts/ocl_perf.hpp"
 
-using namespace std;
-using namespace std::tr1;
-using namespace testing;
+namespace opencv_test
+{
 using namespace perf;
-using namespace cv;
 using namespace cv::superres;
 using namespace cv::cuda;
 
@@ -115,7 +113,7 @@ namespace
         {
         }
     };
-}
+} // namespace
 
 PERF_TEST_P(Size_MatType, SuperResolution_BTVL1,
             Combine(Values(szSmall64, szSmall128),
@@ -174,7 +172,6 @@ PERF_TEST_P(Size_MatType, SuperResolution_BTVL1,
 
 #ifdef HAVE_OPENCL
 
-namespace cvtest {
 namespace ocl {
 
 typedef Size_MatType SuperResolution_BTVL1;
@@ -213,6 +210,8 @@ OCL_PERF_TEST_P(SuperResolution_BTVL1 ,BTVL1,
     SANITY_CHECK_NOTHING();
 }
 
-} } // namespace cvtest::ocl
+} // namespace ocl
 
 #endif // HAVE_OPENCL
+
+} // namespace

--- a/modules/superres/test/test_precomp.hpp
+++ b/modules/superres/test/test_precomp.hpp
@@ -39,24 +39,10 @@
 // the use of this software, even if advised of the possibility of such damage.
 //
 //M*/
-
-#ifdef __GNUC__
-#  pragma GCC diagnostic ignored "-Wmissing-declarations"
-#  if defined __clang__ || defined __APPLE__
-#    pragma GCC diagnostic ignored "-Wmissing-prototypes"
-#    pragma GCC diagnostic ignored "-Wextra"
-#  endif
-#endif
-
 #ifndef __OPENCV_TEST_PRECOMP_HPP__
 #define __OPENCV_TEST_PRECOMP_HPP__
 
-#include "opencv2/opencv_modules.hpp"
-#include "opencv2/core/ocl.hpp"
 #include "opencv2/ts.hpp"
-#include "opencv2/imgproc.hpp"
 #include "opencv2/superres.hpp"
-#include "cvconfig.h"
-#include "../src/input_array_utility.hpp"
 
 #endif

--- a/modules/superres/test/test_superres.cpp
+++ b/modules/superres/test/test_superres.cpp
@@ -41,9 +41,15 @@
 //M*/
 
 #include "test_precomp.hpp"
+#include "cvconfig.h"
+#include "../src/input_array_utility.hpp"
 #include "opencv2/ts/ocl_test.hpp"
 
+namespace opencv_test {
+
 #ifdef HAVE_VIDEO_INPUT
+
+namespace {
 
 class AllignedFrameSource : public cv::superres::FrameSource
 {
@@ -281,9 +287,10 @@ TEST_F(SuperResolution, BTVL1_CUDA)
 
 #endif
 
+} // namespace
+
 #ifdef HAVE_OPENCL
 
-namespace cvtest {
 namespace ocl {
 
 OCL_TEST_F(SuperResolution, BTVL1)
@@ -291,8 +298,10 @@ OCL_TEST_F(SuperResolution, BTVL1)
     RunTest<cv::UMat>(cv::superres::createSuperResolution_BTVL1());
 }
 
-} } // namespace cvtest::ocl
+} // namespace opencv_test::ocl
 
 #endif
 
 #endif // HAVE_VIDEO_INPUT
+
+} // namespace

--- a/modules/ts/include/opencv2/ts.hpp
+++ b/modules/ts/include/opencv2/ts.hpp
@@ -21,13 +21,21 @@
 
 #include "cvconfig.h"
 
+#include <cmath>
+#include <vector>
+#include <list>
+#include <map>
+#include <queue>
 #include <string>
 #include <iostream>
 #include <fstream>
+#include <iomanip>
 #include <sstream>
+#include <cstdio>
 #include <iterator>
 #include <limits>
-#include <numeric>
+#include <algorithm>
+
 
 #ifdef WINRT
     #pragma warning(disable:4447) // Disable warning 'main' signature found without threading model
@@ -72,10 +80,34 @@ namespace cvtest
 {
 
 using std::vector;
+using std::map;
 using std::string;
-using namespace cv;
+using std::stringstream;
+using std::cout;
+using std::cerr;
+using std::endl;
+using std::min;
+using std::max;
+using std::numeric_limits;
+using std::pair;
+using std::make_pair;
+using testing::TestWithParam;
 using testing::Values;
 using testing::Combine;
+
+using cv::Mat;
+using cv::Mat_;
+using cv::UMat;
+using cv::InputArray;
+using cv::OutputArray;
+using cv::noArray;
+
+using cv::Range;
+using cv::Point;
+using cv::Rect;
+using cv::Size;
+using cv::Scalar;
+using cv::RNG;
 
 // Tuple stuff from Google Tests
 using testing::get;
@@ -669,6 +701,7 @@ int main(int argc, char **argv) \
 
 namespace cvtest {
 using perf::MatDepth;
+using perf::MatType;
 }
 
 #ifdef WINRT
@@ -769,5 +802,32 @@ public:
 } // namespace std
 #endif // __FSTREAM_EMULATED__
 #endif // WINRT
+
+
+namespace opencv_test {
+using namespace cvtest;
+using namespace cv;
+
+#ifdef CV_CXX11
+#define CVTEST_GUARD_SYMBOL(name) \
+    class required_namespace_specificatin_here_for_symbol_ ## name {}; \
+    using name = required_namespace_specificatin_here_for_symbol_ ## name;
+#else
+#define CVTEST_GUARD_SYMBOL(name) /* nothing */
+#endif
+
+CVTEST_GUARD_SYMBOL(norm)
+CVTEST_GUARD_SYMBOL(add)
+CVTEST_GUARD_SYMBOL(multiply)
+CVTEST_GUARD_SYMBOL(divide)
+CVTEST_GUARD_SYMBOL(transpose)
+CVTEST_GUARD_SYMBOL(copyMakeBorder)
+CVTEST_GUARD_SYMBOL(filter2D)
+CVTEST_GUARD_SYMBOL(compare)
+CVTEST_GUARD_SYMBOL(minMaxIdx)
+CVTEST_GUARD_SYMBOL(threshold)
+
+extern bool required_opencv_test_namespace;  // compilation check for non-refactored tests
+}
 
 #endif // OPENCV_TS_HPP

--- a/modules/ts/include/opencv2/ts.hpp
+++ b/modules/ts/include/opencv2/ts.hpp
@@ -47,6 +47,14 @@
 #define GTEST_DONT_DEFINE_ASSERT_GT 0
 #define GTEST_DONT_DEFINE_TEST      0
 
+#ifndef GTEST_LANG_CXX11
+#if __cplusplus >= 201103L || (defined(_MSVC_LANG) && !(_MSVC_LANG < 201103))
+#  define GTEST_LANG_CXX11 1
+#  define GTEST_HAS_TR1_TUPLE 0
+#  define GTEST_HAS_COMBINE 1
+# endif
+#endif
+
 #include "opencv2/ts/ts_gtest.h"
 #include "opencv2/ts/ts_ext.hpp"
 

--- a/modules/ts/include/opencv2/ts/ocl_test.hpp
+++ b/modules/ts/include/opencv2/ts/ocl_test.hpp
@@ -364,4 +364,9 @@ CV_ENUM(BorderType, BORDER_CONSTANT, BORDER_REPLICATE, BORDER_REFLECT, BORDER_WR
 
 } } // namespace cvtest::ocl
 
+namespace opencv_test {
+namespace ocl {
+using namespace cvtest::ocl;
+}} // namespace
+
 #endif // OPENCV_TS_OCL_TEST_HPP

--- a/modules/ts/include/opencv2/ts/ts_ext.hpp
+++ b/modules/ts/include/opencv2/ts/ts_ext.hpp
@@ -14,7 +14,15 @@ extern bool skipUnstableTests;
 extern int testThreads;
 }
 
+// check for required "opencv_test" namespace
+#if !defined(CV_TEST_SKIP_NAMESPACE_CHECK) && defined(__OPENCV_BUILD)
+#define CV__TEST_NAMESPACE_CHECK required_opencv_test_namespace = true;
+#else
+#define CV__TEST_NAMESPACE_CHECK  // nothing
+#endif
+
 #define CV__TEST_INIT \
+    CV__TEST_NAMESPACE_CHECK \
     cv::ipp::setIppStatus(0); \
     cv::theRNG().state = cvtest::param_seed; \
     cv::setNumThreads(cvtest::testThreads);

--- a/modules/ts/include/opencv2/ts/ts_gtest.h
+++ b/modules/ts/include/opencv2/ts/ts_gtest.h
@@ -18240,9 +18240,9 @@ internal::CartesianProductHolder10<Generator1, Generator2, Generator3,
 // alphanumeric characters or underscore.
 
 # define INSTANTIATE_TEST_CASE_P(prefix, test_case_name, generator, ...) \
-  ::testing::internal::ParamGenerator<test_case_name::ParamType> \
+  static ::testing::internal::ParamGenerator<test_case_name::ParamType> \
       gtest_##prefix##test_case_name##_EvalGenerator_() { return generator; } \
-  ::std::string gtest_##prefix##test_case_name##_EvalGenerateName_( \
+  static ::std::string gtest_##prefix##test_case_name##_EvalGenerateName_( \
       const ::testing::TestParamInfo<test_case_name::ParamType>& info) { \
     return ::testing::internal::GetParamNameGen<test_case_name::ParamType> \
         (__VA_ARGS__)(info); \

--- a/modules/ts/include/opencv2/ts/ts_perf.hpp
+++ b/modules/ts/include/opencv2/ts/ts_perf.hpp
@@ -526,6 +526,7 @@ void PrintTo(const Size& sz, ::std::ostream* os);
 
 #define CV__PERF_TEST_BODY_IMPL(name) \
     { \
+       CV__TEST_NAMESPACE_CHECK \
        CV__TRACE_APP_FUNCTION_NAME("PERF_TEST: " name); \
        RunPerfTestBody(); \
     }

--- a/modules/ts/src/ts.cpp
+++ b/modules/ts/src/ts.cpp
@@ -77,6 +77,10 @@
 
 #include "opencv_tests_config.hpp"
 
+namespace opencv_test {
+bool required_opencv_test_namespace = false;  // compilation check for non-refactored tests
+}
+
 namespace cvtest
 {
 

--- a/modules/ts/src/ts_func.cpp
+++ b/modules/ts/src/ts_func.cpp
@@ -514,6 +514,7 @@ void extract(const Mat& src, Mat& dst, int coi)
 
 void transpose(const Mat& src, Mat& dst)
 {
+    CV_Assert(src.data != dst.data && "Inplace is not support in cvtest::transpose");
     CV_Assert(src.dims == 2);
     dst.create(src.cols, src.rows, src.type());
     int i, j, k, esz = (int)src.elemSize();

--- a/modules/video/perf/opencl/perf_bgfg_mog2.cpp
+++ b/modules/video/perf/opencl/perf_bgfg_mog2.cpp
@@ -9,7 +9,7 @@
 #ifdef HAVE_VIDEO_INPUT
 #include "../perf_bgfg_utils.hpp"
 
-namespace cvtest {
+namespace opencv_test {
 namespace ocl {
 
 //////////////////////////// Mog2//////////////////////////
@@ -89,7 +89,7 @@ OCL_PERF_TEST_P(MOG2_GetBackgroundImage, Mog2, Values(
     SANITY_CHECK_NOTHING();
 }
 
-}}// namespace cvtest::ocl
+}}// namespace opencv_test::ocl
 
 #endif
 #endif

--- a/modules/video/perf/opencl/perf_motempl.cpp
+++ b/modules/video/perf/opencl/perf_motempl.cpp
@@ -10,7 +10,7 @@
 
 #if 0 //def HAVE_OPENCL
 
-namespace cvtest {
+namespace opencv_test {
 namespace ocl {
 
 ///////////// UpdateMotionHistory ////////////////////////
@@ -31,6 +31,6 @@ OCL_PERF_TEST_P(UpdateMotionHistoryFixture, UpdateMotionHistory, OCL_TEST_SIZES)
     SANITY_CHECK(mhi);
 }
 
-} } // namespace cvtest::ocl
+} } // namespace opencv_test::ocl
 
 #endif // HAVE_OPENCL

--- a/modules/video/perf/opencl/perf_optflow_dualTVL1.cpp
+++ b/modules/video/perf/opencl/perf_optflow_dualTVL1.cpp
@@ -47,11 +47,9 @@
 #include "../perf_precomp.hpp"
 #include "opencv2/ts/ocl_perf.hpp"
 
-using std::tr1::make_tuple;
-
 #ifdef HAVE_OPENCL
 
-namespace cvtest {
+namespace opencv_test {
 namespace ocl {
 
 ///////////// OpticalFlow Dual TVL1 ////////////////////////
@@ -107,6 +105,7 @@ OCL_PERF_TEST_P(OpticalFlowDualTVL1Fixture, OpticalFlowDualTVL1,
         SANITY_CHECK(uFlow, eps, ERROR_RELATIVE);
     }
 }
-} // namespace cvtest::ocl
+
+} // namespace opencv_test::ocl
 
 #endif // HAVE_OPENCL

--- a/modules/video/perf/opencl/perf_optflow_farneback.cpp
+++ b/modules/video/perf/opencl/perf_optflow_farneback.cpp
@@ -47,11 +47,9 @@
 #include "../perf_precomp.hpp"
 #include "opencv2/ts/ocl_perf.hpp"
 
-using std::tr1::make_tuple;
-
 #ifdef HAVE_OPENCL
 
-namespace cvtest {
+namespace opencv_test {
 namespace ocl {
 
 ///////////// FarnebackOpticalFlow ////////////////////////
@@ -109,6 +107,6 @@ OCL_PERF_TEST_P(FarnebackOpticalFlowFixture, FarnebackOpticalFlow,
     SANITY_CHECK(uFlow, eps, ERROR_RELATIVE);
 }
 
-} } // namespace cvtest::ocl
+} } // namespace opencv_test::ocl
 
 #endif // HAVE_OPENCL

--- a/modules/video/perf/opencl/perf_optflow_pyrlk.cpp
+++ b/modules/video/perf/opencl/perf_optflow_pyrlk.cpp
@@ -47,11 +47,9 @@
 #include "../perf_precomp.hpp"
 #include "opencv2/ts/ocl_perf.hpp"
 
-using std::tr1::make_tuple;
-
 #ifdef HAVE_OPENCL
 
-namespace cvtest {
+namespace opencv_test {
 namespace ocl {
 
 typedef tuple< int > PyrLKOpticalFlowParams;
@@ -101,6 +99,6 @@ OCL_PERF_TEST_P(PyrLKOpticalFlowFixture, PyrLKOpticalFlow,
     SANITY_CHECK(uNextPts, eps);
 }
 
-} } // namespace cvtest::ocl
+} } // namespace opencv_test::ocl
 
 #endif // HAVE_OPENCL

--- a/modules/video/perf/perf_ecc.cpp
+++ b/modules/video/perf/perf_ecc.cpp
@@ -1,14 +1,12 @@
 #include "perf_precomp.hpp"
 
-using namespace std;
-using namespace cv;
+namespace opencv_test
+{
 using namespace perf;
-using std::tr1::make_tuple;
-using std::tr1::get;
 
 CV_ENUM(MotionType, MOTION_TRANSLATION, MOTION_EUCLIDEAN, MOTION_AFFINE, MOTION_HOMOGRAPHY)
 
-typedef std::tr1::tuple<MotionType> MotionType_t;
+typedef tuple<MotionType> MotionType_t;
 typedef perf::TestBaseWithParam<MotionType_t> TransformationType;
 
 
@@ -69,3 +67,5 @@ PERF_TEST_P(TransformationType, findTransformECC, /*testing::ValuesIn(MotionType
     }
     SANITY_CHECK(warpMat, 3e-3);
 }
+
+} // namespace

--- a/modules/video/perf/perf_optflowpyrlk.cpp
+++ b/modules/video/perf/perf_optflowpyrlk.cpp
@@ -1,12 +1,9 @@
 #include "perf_precomp.hpp"
 
-using namespace std;
-using namespace cv;
+namespace opencv_test { namespace {
 using namespace perf;
-using std::tr1::make_tuple;
-using std::tr1::get;
 
-typedef tr1::tuple<std::string, int, int, tr1::tuple<int,int>, int> Path_Idx_Cn_NPoints_WSize_t;
+typedef tuple<std::string, int, int, tuple<int,int>, int> Path_Idx_Cn_NPoints_WSize_t;
 typedef TestBaseWithParam<Path_Idx_Cn_NPoints_WSize_t> Path_Idx_Cn_NPoints_WSize;
 
 void FormTrackingPointsArray(vector<Point2f>& points, int width, int height, int nPointsX, int nPointsY)
@@ -45,8 +42,8 @@ PERF_TEST_P(Path_Idx_Cn_NPoints_WSize, OpticalFlowPyrLK_full, testing::Combine(
     if (img2.empty()) FAIL() << "Unable to load source image " << filename2;
 
     int cn = get<2>(GetParam());
-    int nPointsX = min(get<0>(get<3>(GetParam())), img1.cols);
-    int nPointsY = min(get<1>(get<3>(GetParam())), img1.rows);
+    int nPointsX = std::min(get<0>(get<3>(GetParam())), img1.cols);
+    int nPointsY = std::min(get<1>(get<3>(GetParam())), img1.rows);
     int winSize = get<4>(GetParam());
 
     int maxLevel = 2;
@@ -97,7 +94,7 @@ PERF_TEST_P(Path_Idx_Cn_NPoints_WSize, OpticalFlowPyrLK_full, testing::Combine(
     SANITY_CHECK(err, 2);
 }
 
-typedef tr1::tuple<std::string, int, tr1::tuple<int, int>, int> Path_Idx_NPoints_WSize_t;
+typedef tuple<std::string, int, tuple<int, int>, int> Path_Idx_NPoints_WSize_t;
 typedef TestBaseWithParam<Path_Idx_NPoints_WSize_t> Path_Idx_NPoints_WSize;
 
 PERF_TEST_P(Path_Idx_NPoints_WSize, OpticalFlowPyrLK_ovx, testing::Combine(
@@ -115,8 +112,8 @@ PERF_TEST_P(Path_Idx_NPoints_WSize, OpticalFlowPyrLK_ovx, testing::Combine(
     if (img1.empty()) FAIL() << "Unable to load source image " << filename1;
     if (img2.empty()) FAIL() << "Unable to load source image " << filename2;
 
-    int nPointsX = min(get<0>(get<2>(GetParam())), img1.cols);
-    int nPointsY = min(get<1>(get<2>(GetParam())), img1.rows);
+    int nPointsX = std::min(get<0>(get<2>(GetParam())), img1.cols);
+    int nPointsY = std::min(get<1>(get<2>(GetParam())), img1.rows);
     int winSize = get<3>(GetParam());
 
     int maxLevel = 2;
@@ -149,7 +146,7 @@ PERF_TEST_P(Path_Idx_NPoints_WSize, OpticalFlowPyrLK_ovx, testing::Combine(
     SANITY_CHECK(status);
 }
 
-typedef tr1::tuple<std::string, int, int, tr1::tuple<int,int>, int, bool> Path_Idx_Cn_NPoints_WSize_Deriv_t;
+typedef tuple<std::string, int, int, tuple<int,int>, int, bool> Path_Idx_Cn_NPoints_WSize_Deriv_t;
 typedef TestBaseWithParam<Path_Idx_Cn_NPoints_WSize_Deriv_t> Path_Idx_Cn_NPoints_WSize_Deriv;
 
 PERF_TEST_P(Path_Idx_Cn_NPoints_WSize_Deriv, OpticalFlowPyrLK_self, testing::Combine(
@@ -170,8 +167,8 @@ PERF_TEST_P(Path_Idx_Cn_NPoints_WSize_Deriv, OpticalFlowPyrLK_self, testing::Com
     if (img2.empty()) FAIL() << "Unable to load source image " << filename2;
 
     int cn = get<2>(GetParam());
-    int nPointsX = min(get<0>(get<3>(GetParam())), img1.cols);
-    int nPointsY = min(get<1>(get<3>(GetParam())), img1.rows);
+    int nPointsX = std::min(get<0>(get<3>(GetParam())), img1.cols);
+    int nPointsY = std::min(get<1>(get<3>(GetParam())), img1.rows);
     int winSize = get<4>(GetParam());
     bool withDerivatives = get<5>(GetParam());
 
@@ -231,7 +228,7 @@ PERF_TEST_P(Path_Idx_Cn_NPoints_WSize_Deriv, OpticalFlowPyrLK_self, testing::Com
 }
 
 CV_ENUM(PyrBorderMode, BORDER_DEFAULT, BORDER_TRANSPARENT)
-typedef tr1::tuple<std::string, int, bool, PyrBorderMode, bool> Path_Win_Deriv_Border_Reuse_t;
+typedef tuple<std::string, int, bool, PyrBorderMode, bool> Path_Win_Deriv_Border_Reuse_t;
 typedef TestBaseWithParam<Path_Win_Deriv_Border_Reuse_t> Path_Win_Deriv_Border_Reuse;
 
 PERF_TEST_P(Path_Win_Deriv_Border_Reuse, OpticalFlowPyrLK_pyr, testing::Combine(
@@ -271,3 +268,5 @@ PERF_TEST_P(Path_Win_Deriv_Border_Reuse, OpticalFlowPyrLK_pyr, testing::Combine(
 
     SANITY_CHECK(pyramid);
 }
+
+}} // namespace

--- a/modules/video/perf/perf_precomp.hpp
+++ b/modules/video/perf/perf_precomp.hpp
@@ -1,21 +1,10 @@
-#ifdef __GNUC__
-#  pragma GCC diagnostic ignored "-Wmissing-declarations"
-#  if defined __clang__ || defined __APPLE__
-#    pragma GCC diagnostic ignored "-Wmissing-prototypes"
-#    pragma GCC diagnostic ignored "-Wextra"
-#  endif
-#endif
-
+// This file is part of OpenCV project.
+// It is subject to the license terms in the LICENSE file found in the top-level directory
+// of this distribution and at http://opencv.org/license.html.
 #ifndef __OPENCV_VIDEO_PRECOMP_HPP__
 #define __OPENCV_VIDEO_PRECOMP_HPP__
 
 #include "opencv2/ts.hpp"
-#include <opencv2/imgproc.hpp>
 #include <opencv2/video.hpp>
-#include <opencv2/imgcodecs.hpp>
-
-#ifdef GTEST_CREATE_SHARED_LIBRARY
-#error no modules except ts should have GTEST_CREATE_SHARED_LIBRARY defined
-#endif
 
 #endif

--- a/modules/video/perf/perf_tvl1optflow.cpp
+++ b/modules/video/perf/perf_tvl1optflow.cpp
@@ -1,14 +1,13 @@
 #include "perf_precomp.hpp"
 
-using namespace std;
-using namespace cv;
+namespace opencv_test { namespace {
 using namespace perf;
 
-typedef TestBaseWithParam< pair<string, string> > ImagePair;
+typedef TestBaseWithParam< std::pair<string, string> > ImagePair;
 
-pair<string, string> impair(const char* im1, const char* im2)
+std::pair<string, string> impair(const char* im1, const char* im2)
 {
-    return make_pair(string(im1), string(im2));
+    return std::make_pair(string(im1), string(im2));
 }
 
 PERF_TEST_P(ImagePair, OpticalFlowDual_TVL1, testing::Values(impair("cv/optflow/RubberWhale1.png", "cv/optflow/RubberWhale2.png")))
@@ -28,3 +27,5 @@ PERF_TEST_P(ImagePair, OpticalFlowDual_TVL1, testing::Values(impair("cv/optflow/
 
     SANITY_CHECK_NOTHING();
 }
+
+}} // namespace

--- a/modules/video/test/ocl/test_bgfg_mog2.cpp
+++ b/modules/video/test/ocl/test_bgfg_mog2.cpp
@@ -4,7 +4,7 @@
 #ifdef HAVE_OPENCL
 #ifdef HAVE_VIDEO_INPUT
 
-namespace cvtest {
+namespace opencv_test {
 namespace ocl {
 
 //////////////////////////Mog2_Update///////////////////////////////////
@@ -139,7 +139,7 @@ OCL_INSTANTIATE_TEST_CASE_P(OCL_Video, Mog2_getBackgroundImage, Combine(
                                                      Values(UseFloat(false),UseFloat(true)))
                            );
 
-}}// namespace cvtest::ocl
+}}// namespace opencv_test::ocl
 
 #endif
 #endif

--- a/modules/video/test/ocl/test_optflow_farneback.cpp
+++ b/modules/video/test/ocl/test_optflow_farneback.cpp
@@ -46,7 +46,7 @@
 
 #ifdef HAVE_OPENCL
 
-namespace cvtest {
+namespace opencv_test {
 namespace ocl {
 
 /////////////////////////////////////////////////////////////////////////////////////////////////
@@ -115,6 +115,6 @@ OCL_INSTANTIATE_TEST_CASE_P(Video, FarnebackOpticalFlow,
                            );
 
 
-} } // namespace cvtest::ocl
+} } // namespace opencv_test::ocl
 
 #endif // HAVE_OPENCL

--- a/modules/video/test/ocl/test_optflow_tvl1flow.cpp
+++ b/modules/video/test/ocl/test_optflow_tvl1flow.cpp
@@ -46,7 +46,7 @@
 
 #ifdef HAVE_OPENCL
 
-namespace cvtest {
+namespace opencv_test {
 namespace ocl {
 
 /////////////////////////////////////////////////////////////////////////////////////////////////
@@ -112,6 +112,6 @@ OCL_INSTANTIATE_TEST_CASE_P(Video, OpticalFlowTVL1,
     )
     );
 
-} } // namespace cvtest::ocl
+} } // namespace opencv_test::ocl
 
 #endif // HAVE_OPENCL

--- a/modules/video/test/ocl/test_optflowpyrlk.cpp
+++ b/modules/video/test/ocl/test_optflowpyrlk.cpp
@@ -48,9 +48,7 @@
 
 #ifdef HAVE_OPENCL
 
-
-namespace cvtest {
-namespace ocl {
+namespace opencv_test { namespace ocl {
 
 /////////////////////////////////////////////////////////////////////////////////////////////////
 // PyrLKOpticalFlow
@@ -158,7 +156,6 @@ OCL_INSTANTIATE_TEST_CASE_P(Video, PyrLKOpticalFlow,
                                 )
                            );
 
-} } // namespace cvtest::ocl
 
-
+}} // namespace
 #endif // HAVE_OPENCL

--- a/modules/video/test/test_accum.cpp
+++ b/modules/video/test/test_accum.cpp
@@ -42,8 +42,7 @@
 #include "test_precomp.hpp"
 #include "opencv2/imgproc/imgproc_c.h"
 
-using namespace cv;
-using namespace std;
+namespace opencv_test { namespace {
 
 class CV_AccumBaseTest : public cvtest::ArrayTest
 {
@@ -246,3 +245,5 @@ TEST(Video_Acc, accuracy) { CV_AccTest test; test.safe_run(); }
 TEST(Video_AccSquared, accuracy) { CV_SquareAccTest test; test.safe_run(); }
 TEST(Video_AccProduct, accuracy) { CV_MultiplyAccTest test; test.safe_run(); }
 TEST(Video_RunningAvg, accuracy) { CV_RunningAvgTest test; test.safe_run(); }
+
+}} // namespace

--- a/modules/video/test/test_camshift.cpp
+++ b/modules/video/test/test_camshift.cpp
@@ -42,8 +42,7 @@
 #include "test_precomp.hpp"
 #include "opencv2/video/tracking_c.h"
 
-using namespace cv;
-using namespace std;
+namespace opencv_test { namespace {
 
 class CV_TrackBaseTest : public cvtest::BaseTest
 {
@@ -509,4 +508,5 @@ _exit_:
 TEST(Video_CAMShift, accuracy) { CV_CamShiftTest test; test.safe_run(); }
 TEST(Video_MeanShift, accuracy) { CV_MeanShiftTest test; test.safe_run(); }
 
+}} // namespace
 /* End of file. */

--- a/modules/video/test/test_ecc.cpp
+++ b/modules/video/test/test_ecc.cpp
@@ -42,8 +42,7 @@
 
 #include "test_precomp.hpp"
 
-using namespace cv;
-using namespace std;
+namespace opencv_test { namespace {
 
 class CV_ECC_BaseTest : public cvtest::BaseTest
 {
@@ -482,3 +481,5 @@ TEST(Video_ECC_Euclidean, accuracy) { CV_ECC_Test_Euclidean test; test.safe_run(
 TEST(Video_ECC_Affine, accuracy) { CV_ECC_Test_Affine test; test.safe_run(); }
 TEST(Video_ECC_Homography, accuracy) { CV_ECC_Test_Homography test; test.safe_run(); }
 TEST(Video_ECC_Mask, accuracy) { CV_ECC_Test_Mask test; test.safe_run(); }
+
+}} // namespace

--- a/modules/video/test/test_estimaterigid.cpp
+++ b/modules/video/test/test_estimaterigid.cpp
@@ -42,15 +42,7 @@
 
 #include "test_precomp.hpp"
 
-#include <string>
-#include <iostream>
-#include <fstream>
-#include <iterator>
-#include <limits>
-#include <numeric>
-
-using namespace cv;
-using namespace std;
+namespace opencv_test { namespace {
 
 class CV_RigidTransform_Test : public cvtest::BaseTest
 {
@@ -101,7 +93,7 @@ bool CV_RigidTransform_Test::testNPoints(int from)
         Mat tpts(1, n, CV_32FC2);
 
         rng.fill(fpts, RNG::UNIFORM, Scalar(0,0), Scalar(10,10));
-        transform(fpts.ptr<Point2f>(), fpts.ptr<Point2f>() + n, tpts.ptr<Point2f>(), WrapAff2D(aff));
+        std::transform(fpts.ptr<Point2f>(), fpts.ptr<Point2f>() + n, tpts.ptr<Point2f>(), WrapAff2D(aff));
 
         Mat noise(1, n, CV_32FC2);
         rng.fill(noise, RNG::NORMAL, Scalar::all(0), Scalar::all(0.001*(n<=7 ? 0 : n <= 30 ? 1 : 10)));
@@ -179,3 +171,5 @@ void CV_RigidTransform_Test::run( int start_from )
 }
 
 TEST(Video_RigidFlow, accuracy) { CV_RigidTransform_Test test; test.safe_run(); }
+
+}} // namespace

--- a/modules/video/test/test_kalman.cpp
+++ b/modules/video/test/test_kalman.cpp
@@ -42,7 +42,7 @@
 #include "test_precomp.hpp"
 #include "opencv2/video/tracking_c.h"
 
-using namespace cv;
+namespace opencv_test { namespace {
 
 class CV_KalmanTest : public cvtest::BaseTest
 {
@@ -122,4 +122,5 @@ void CV_KalmanTest::run( int )
 
 TEST(Video_Kalman, accuracy) { CV_KalmanTest test; test.safe_run(); }
 
+}} // namespace
 /* End of file. */

--- a/modules/video/test/test_main.cpp
+++ b/modules/video/test/test_main.cpp
@@ -1,3 +1,6 @@
+// This file is part of OpenCV project.
+// It is subject to the license terms in the LICENSE file found in the top-level directory
+// of this distribution and at http://opencv.org/license.html.
 #include "test_precomp.hpp"
 
 CV_TEST_MAIN("cv")

--- a/modules/video/test/test_optflowpyrlk.cpp
+++ b/modules/video/test/test_optflowpyrlk.cpp
@@ -42,6 +42,8 @@
 #include "test_precomp.hpp"
 #include "opencv2/video/tracking_c.h"
 
+namespace opencv_test { namespace {
+
 /* ///////////////////// pyrlk_test ///////////////////////// */
 
 class CV_OptFlowPyrLKTest : public cvtest::BaseTest
@@ -256,3 +258,5 @@ TEST(Video_OpticalFlowPyrLK, submat)
 
     ASSERT_NO_THROW(cv::calcOpticalFlowPyrLK(img1, img2, prev, next, status, error));
 }
+
+}} // namespace

--- a/modules/video/test/test_precomp.hpp
+++ b/modules/video/test/test_precomp.hpp
@@ -1,18 +1,10 @@
-#ifdef __GNUC__
-#  pragma GCC diagnostic ignored "-Wmissing-declarations"
-#  if defined __clang__ || defined __APPLE__
-#    pragma GCC diagnostic ignored "-Wmissing-prototypes"
-#    pragma GCC diagnostic ignored "-Wextra"
-#  endif
-#endif
-
+// This file is part of OpenCV project.
+// It is subject to the license terms in the LICENSE file found in the top-level directory
+// of this distribution and at http://opencv.org/license.html.
 #ifndef __OPENCV_TEST_PRECOMP_HPP__
 #define __OPENCV_TEST_PRECOMP_HPP__
 
-#include <iostream>
 #include "opencv2/ts.hpp"
-#include "opencv2/imgproc.hpp"
 #include "opencv2/video.hpp"
-#include "opencv2/imgcodecs.hpp"
 
 #endif

--- a/modules/video/test/test_tvl1optflow.cpp
+++ b/modules/video/test/test_tvl1optflow.cpp
@@ -40,16 +40,11 @@
 //M*/
 
 #include "test_precomp.hpp"
-#include <fstream>
 
-using namespace std;
-using namespace cv;
-using namespace cvtest;
+namespace opencv_test { namespace {
 
 //#define DUMP
 
-namespace
-{
     // first four bytes, should be the same in little endian
     const float FLO_TAG_FLOAT = 202021.25f;  // check for this when READING the file
 
@@ -83,7 +78,7 @@ namespace
     // http://vision.middlebury.edu/flow/data/
     void readOpticalFlowFromFile(Mat_<Point2f>& flow, const string& fileName)
     {
-        ifstream file(fileName.c_str(), ios_base::binary);
+        std::ifstream file(fileName.c_str(), std::ios_base::binary);
 
         float tag;
         file.read((char*) &tag, sizeof(float));
@@ -145,7 +140,6 @@ namespace
         }
         EXPECT_GE(valid_counter, expectedAccuracy * gold_counter);
     }
-}
 
 TEST(Video_calcOpticalFlowDual_TVL1, Regression)
 {
@@ -175,3 +169,5 @@ TEST(Video_calcOpticalFlowDual_TVL1, Regression)
     check(gold, flow);
 #endif
 }
+
+}} // namespace

--- a/modules/videoio/perf/perf_input.cpp
+++ b/modules/videoio/perf/perf_input.cpp
@@ -1,13 +1,13 @@
+// This file is part of OpenCV project.
+// It is subject to the license terms in the LICENSE file found in the top-level directory
+// of this distribution and at http://opencv.org/license.html
 #include "perf_precomp.hpp"
 
 #ifdef HAVE_VIDEO_INPUT
 
-using namespace std;
-using namespace cv;
+namespace opencv_test
+{
 using namespace perf;
-using std::tr1::make_tuple;
-using std::tr1::get;
-
 
 typedef perf::TestBaseWithParam<std::string> VideoCapture_Reading;
 
@@ -33,5 +33,7 @@ PERF_TEST_P(VideoCapture_Reading, ReadFile, testing::ValuesIn(bunny_files) )
 
   SANITY_CHECK_NOTHING();
 }
+
+} // namespace
 
 #endif // HAVE_VIDEO_INPUT

--- a/modules/videoio/perf/perf_main.cpp
+++ b/modules/videoio/perf/perf_main.cpp
@@ -1,3 +1,6 @@
+// This file is part of OpenCV project.
+// It is subject to the license terms in the LICENSE file found in the top-level directory
+// of this distribution and at http://opencv.org/license.html
 #include "perf_precomp.hpp"
 
 CV_PERF_TEST_MAIN(videoio)

--- a/modules/videoio/perf/perf_output.cpp
+++ b/modules/videoio/perf/perf_output.cpp
@@ -1,14 +1,15 @@
+// This file is part of OpenCV project.
+// It is subject to the license terms in the LICENSE file found in the top-level directory
+// of this distribution and at http://opencv.org/license.html
 #include "perf_precomp.hpp"
 
 #ifdef HAVE_VIDEO_OUTPUT
 
-using namespace std;
-using namespace cv;
+namespace opencv_test
+{
 using namespace perf;
-using std::tr1::make_tuple;
-using std::tr1::get;
 
-typedef std::tr1::tuple<std::string, bool> VideoWriter_Writing_t;
+typedef tuple<std::string, bool> VideoWriter_Writing_t;
 typedef perf::TestBaseWithParam<VideoWriter_Writing_t> VideoWriter_Writing;
 
 const string image_files[] = {
@@ -41,5 +42,7 @@ PERF_TEST_P(VideoWriter_Writing, WriteFrame,
   SANITY_CHECK_NOTHING();
   remove(outfile.c_str());
 }
+
+} // namespace
 
 #endif // HAVE_VIDEO_OUTPUT

--- a/modules/videoio/perf/perf_precomp.hpp
+++ b/modules/videoio/perf/perf_precomp.hpp
@@ -1,20 +1,10 @@
-#ifdef __GNUC__
-#  pragma GCC diagnostic ignored "-Wmissing-declarations"
-#  if defined __clang__ || defined __APPLE__
-#    pragma GCC diagnostic ignored "-Wmissing-prototypes"
-#    pragma GCC diagnostic ignored "-Wextra"
-#  endif
-#endif
-
+// This file is part of OpenCV project.
+// It is subject to the license terms in the LICENSE file found in the top-level directory
+// of this distribution and at http://opencv.org/license.html
 #ifndef __OPENCV_PERF_PRECOMP_HPP__
 #define __OPENCV_PERF_PRECOMP_HPP__
 
 #include "opencv2/ts.hpp"
-#include "opencv2/imgcodecs.hpp"
 #include "opencv2/videoio.hpp"
-
-#ifdef GTEST_CREATE_SHARED_LIBRARY
-#error no modules except ts should have GTEST_CREATE_SHARED_LIBRARY defined
-#endif
 
 #endif

--- a/modules/videoio/test/test_ffmpeg.cpp
+++ b/modules/videoio/test/test_ffmpeg.cpp
@@ -41,9 +41,8 @@
 //M*/
 
 #include "test_precomp.hpp"
-#include "opencv2/videoio.hpp"
 
-using namespace cv;
+namespace opencv_test { namespace {
 
 #ifdef HAVE_FFMPEG
 
@@ -441,3 +440,4 @@ TEST(Videoio_Video_parallel_writers_and_readers, accuracy)
 }
 
 #endif
+}} // namespace

--- a/modules/videoio/test/test_fourcc.cpp
+++ b/modules/videoio/test/test_fourcc.cpp
@@ -41,7 +41,8 @@
 //M*/
 
 #include "test_precomp.hpp"
-#include "opencv2/videoio.hpp"
+
+namespace opencv_test { namespace {
 
 #undef DEFINE_GUID
 #define DEFINE_GUID(n, fourcc, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10) fourcc,
@@ -113,3 +114,5 @@ TEST(Videoio_dshow, fourcc_conversion)
         EXPECT_EQ(fourcc, (unsigned long)(unsigned)fourccFromParam);
     }
 }
+
+}} // namespace

--- a/modules/videoio/test/test_main.cpp
+++ b/modules/videoio/test/test_main.cpp
@@ -1,3 +1,6 @@
+// This file is part of OpenCV project.
+// It is subject to the license terms in the LICENSE file found in the top-level directory
+// of this distribution and at http://opencv.org/license.html.
 #include "test_precomp.hpp"
 
 CV_TEST_MAIN("highgui")

--- a/modules/videoio/test/test_mfx.cpp
+++ b/modules/videoio/test/test_mfx.cpp
@@ -3,18 +3,10 @@
 // of this distribution and at http://opencv.org/license.html
 
 #include "test_precomp.hpp"
-#include "opencv2/videoio.hpp"
-#include "opencv2/highgui.hpp"
-#include <sstream>
-#include <queue>
-#include <cstdio>
 
 #ifdef HAVE_MFX
 
-using namespace cv;
-using namespace std;
-using namespace std::tr1;
-
+namespace opencv_test { namespace {
 
 TEST(Videoio_MFX, read_invalid)
 {
@@ -71,7 +63,7 @@ const int FRAME_COUNT = 20;
 
 inline void generateFrame(int i, Mat & frame)
 {
-    generateFrame(i, FRAME_COUNT, frame);
+    ::generateFrame(i, FRAME_COUNT, frame);
 }
 
 inline int fourccByExt(const String &ext)
@@ -99,7 +91,7 @@ TEST_P(Videoio_MFX, read_write_raw)
     const int fourcc = fourccByExt(ext);
 
     bool isColor = true;
-    queue<Mat> goodFrames;
+    std::queue<Mat> goodFrames;
 
     // Write video
     VideoWriter writer;
@@ -150,5 +142,7 @@ INSTANTIATE_TEST_CASE_P(videoio, Videoio_MFX,
                             testing::Values(Size(640, 480), Size(638, 478), Size(636, 476), Size(1920, 1080)),
                             testing::Values(1, 30, 100),
                             testing::Values(".mpeg2", ".264", ".265")));
+
+}} // namespace
 
 #endif

--- a/modules/videoio/test/test_precomp.hpp
+++ b/modules/videoio/test/test_precomp.hpp
@@ -1,18 +1,10 @@
-#ifdef __GNUC__
-#  pragma GCC diagnostic ignored "-Wmissing-declarations"
-#  if defined __clang__ || defined __APPLE__
-#    pragma GCC diagnostic ignored "-Wmissing-prototypes"
-#    pragma GCC diagnostic ignored "-Wextra"
-#  endif
-#endif
-
+// This file is part of OpenCV project.
+// It is subject to the license terms in the LICENSE file found in the top-level directory
+// of this distribution and at http://opencv.org/license.html.
 #ifndef __OPENCV_TEST_PRECOMP_HPP__
 #define __OPENCV_TEST_PRECOMP_HPP__
 
-#include <iostream>
 #include "opencv2/ts.hpp"
-#include "opencv2/imgproc.hpp"
-#include "opencv2/imgcodecs.hpp"
 #include "opencv2/videoio.hpp"
 #include "opencv2/imgproc/imgproc_c.h"
 

--- a/modules/videoio/test/test_video_io.cpp
+++ b/modules/videoio/test/test_video_io.cpp
@@ -42,12 +42,9 @@
 
 #include "test_precomp.hpp"
 #include "opencv2/videoio/videoio_c.h"
-#include "opencv2/highgui.hpp"
-#include <cstdio>
 
-using namespace cv;
-using namespace std;
-using namespace std::tr1;
+namespace opencv_test
+{
 
 class Videoio_Test_Base
 {
@@ -454,3 +451,5 @@ INSTANTIATE_TEST_CASE_P(videoio, Videoio_Synthetic,
                         testing::Combine(
                             testing::ValuesIn(all_sizes),
                             testing::ValuesIn(synthetic_params)));
+
+} // namespace

--- a/modules/videostab/test/test_main.cpp
+++ b/modules/videostab/test/test_main.cpp
@@ -1,3 +1,7 @@
+// This file is part of OpenCV project.
+// It is subject to the license terms in the LICENSE file found in the top-level directory
+// of this distribution and at http://opencv.org/license.html
+
 #include "test_precomp.hpp"
 
 CV_TEST_MAIN("cv")

--- a/modules/videostab/test/test_motion_estimation.cpp
+++ b/modules/videostab/test/test_motion_estimation.cpp
@@ -4,6 +4,8 @@
 
 #include "test_precomp.hpp"
 
+namespace opencv_test { namespace {
+
 namespace testUtil
 {
 
@@ -169,3 +171,5 @@ TEST(Regression, MM_AFFINE)
 {
     EXPECT_LT(testUtil::performTest(cv::videostab::MM_AFFINE, 6), 9.f);
 }
+
+}} // namespace

--- a/modules/videostab/test/test_precomp.hpp
+++ b/modules/videostab/test/test_precomp.hpp
@@ -1,15 +1,10 @@
-#ifdef __GNUC__
-#  pragma GCC diagnostic ignored "-Wmissing-declarations"
-#  if defined __clang__ || defined __APPLE__
-#    pragma GCC diagnostic ignored "-Wmissing-prototypes"
-#    pragma GCC diagnostic ignored "-Wextra"
-#  endif
-#endif
+// This file is part of OpenCV project.
+// It is subject to the license terms in the LICENSE file found in the top-level directory
+// of this distribution and at http://opencv.org/license.html
 
 #ifndef __OPENCV_TEST_PRECOMP_HPP__
 #define __OPENCV_TEST_PRECOMP_HPP__
 
-#include <iostream>
 #include "opencv2/ts.hpp"
 #include "opencv2/videostab.hpp"
 

--- a/modules/viz/test/test_common.cpp
+++ b/modules/viz/test/test_common.cpp
@@ -1,3 +1,6 @@
+// This file is part of OpenCV project.
+// It is subject to the license terms in the LICENSE file found in the top-level directory
+// of this distribution and at http://opencv.org/license.html.
 #include "test_precomp.hpp"
 
 cv::String cv::Path::combine(const String& item1, const String& item2)

--- a/modules/viz/test/test_common.hpp
+++ b/modules/viz/test/test_common.hpp
@@ -48,11 +48,6 @@
 
 #include <opencv2/viz/vizcore.hpp>
 
-#include <iostream>
-#include <fstream>
-#include <string>
-#include <limits>
-
 namespace cv
 {
     struct Path

--- a/modules/viz/test/test_main.cpp
+++ b/modules/viz/test/test_main.cpp
@@ -1,3 +1,6 @@
+// This file is part of OpenCV project.
+// It is subject to the license terms in the LICENSE file found in the top-level directory
+// of this distribution and at http://opencv.org/license.html.
 #include "test_precomp.hpp"
 
 CV_TEST_MAIN("viz")

--- a/modules/viz/test/test_precomp.hpp
+++ b/modules/viz/test/test_precomp.hpp
@@ -1,2 +1,10 @@
+// This file is part of OpenCV project.
+// It is subject to the license terms in the LICENSE file found in the top-level directory
+// of this distribution and at http://opencv.org/license.html.
 #include "opencv2/ts.hpp"
 #include "test_common.hpp"
+
+namespace opencv_test
+{
+using namespace cv::viz;
+}

--- a/modules/viz/test/test_tutorial2.cpp
+++ b/modules/viz/test/test_tutorial2.cpp
@@ -1,7 +1,9 @@
+// This file is part of OpenCV project.
+// It is subject to the license terms in the LICENSE file found in the top-level directory
+// of this distribution and at http://opencv.org/license.html.
 #include "test_precomp.hpp"
 
-using namespace cv;
-using namespace std;
+namespace opencv_test { namespace {
 
 static void tutorial2()
 {
@@ -52,3 +54,5 @@ TEST(Viz, DISABLED_tutorial2_pose_of_widget)
 {
     tutorial2();
 }
+
+}} // namespace

--- a/modules/viz/test/test_tutorial3.cpp
+++ b/modules/viz/test/test_tutorial3.cpp
@@ -1,7 +1,9 @@
+// This file is part of OpenCV project.
+// It is subject to the license terms in the LICENSE file found in the top-level directory
+// of this distribution and at http://opencv.org/license.html.
 #include "test_precomp.hpp"
 
-using namespace cv;
-using namespace std;
+namespace opencv_test { namespace {
 
 /**
  * @function main
@@ -58,3 +60,5 @@ TEST(Viz, tutorial3_camera_view)
 {
     tutorial3(true);
 }
+
+}} // namespace

--- a/modules/viz/test/test_viz3d.cpp
+++ b/modules/viz/test/test_viz3d.cpp
@@ -41,7 +41,7 @@
  //M*/
 #include "test_precomp.hpp"
 
-using namespace cv;
+namespace opencv_test { namespace {
 
 TEST(Viz_viz3d, DISABLED_develop)
 {
@@ -61,3 +61,5 @@ TEST(Viz_viz3d, DISABLED_develop)
 
     viz.spin();
 }
+
+}} // namespace

--- a/modules/viz/test/tests_simple.cpp
+++ b/modules/viz/test/tests_simple.cpp
@@ -42,8 +42,7 @@
 
 #include "test_precomp.hpp"
 
-using namespace cv;
-using namespace cv::viz;
+namespace opencv_test { namespace {
 
 TEST(Viz, show_cloud_bluberry)
 {
@@ -451,3 +450,5 @@ TEST(Viz, show_follower)
     viz.getWidget("t3d_2").cast<WText3D>().setText("Updated follower 3D");
     viz.spin();
 }
+
+}} // namespace

--- a/samples/gpu/opticalflow_nvidia_api.cpp
+++ b/samples/gpu/opticalflow_nvidia_api.cpp
@@ -24,7 +24,7 @@ int main( int, const char** )
 }
 #else
 
-//using std::tr1::shared_ptr;
+//using std::shared_ptr;
 using cv::Ptr;
 
 #define PARAM_LEFT  "--left"


### PR DESCRIPTION
**Merge with contrib**: https://github.com/opencv/opencv_contrib/pull/1542

- removed tr1 usage (dropped in C++17)
- moved includes of vector/map/iostream/limits into ts.hpp
- require opencv_test (added compile check) + anonymous namespace
- fixed norm() usage (must be from cvtest::norm for checks) and other conflict functions
- added missing license headers


Resolves `_SILENCE_TR1_NAMESPACE_DEPRECATION_WARNING` MSVS warning.
Wiki page [proposals](https://github.com/alalek/opencv/wiki/_history).

```
force_builders=Custom
docker_image:Custom=ubuntu-cuda:16.04
allow_multiple_commits=1
```