### PR TITLE
videoio: remove AssetsLibrary dependency.

### DIFF
--- a/modules/videoio/CMakeLists.txt
+++ b/modules/videoio/CMakeLists.txt
@@ -219,10 +219,7 @@ if(IOS)
        ${CMAKE_CURRENT_LIST_DIR}/src/cap_ios_photo_camera.mm
        ${CMAKE_CURRENT_LIST_DIR}/src/cap_ios_video_camera.mm)
 
-  list(APPEND VIDEOIO_LIBRARIES "-framework Accelerate" "-framework AVFoundation" "-framework CoreGraphics" "-framework CoreImage" "-framework CoreMedia" "-framework CoreVideo" "-framework QuartzCore" "-framework AssetsLibrary")
-  if(APPLE_FRAMEWORK)
-    list(APPEND VIDEOIO_LIBRARIES "-framework UIKit")
-  endif()
+  list(APPEND VIDEOIO_LIBRARIES "-framework Accelerate" "-framework AVFoundation" "-framework CoreGraphics" "-framework CoreImage" "-framework CoreMedia" "-framework CoreVideo" "-framework QuartzCore" "-framework UIKit")
 endif()
 
 if(WIN32)

--- a/modules/videoio/src/cap_ios_video_camera.mm
+++ b/modules/videoio/src/cap_ios_video_camera.mm
@@ -31,7 +31,7 @@
 
 #import "opencv2/videoio/cap_ios.h"
 #include "precomp.hpp"
-#import <AssetsLibrary/AssetsLibrary.h>
+#import <UIKit/UIKit.h>
 
 
 static CGFloat DegreesToRadians(CGFloat degrees) {return degrees * M_PI / 180;}
@@ -626,11 +626,7 @@ static CGFloat DegreesToRadians(CGFloat degrees) {return degrees * M_PI / 180;}
         return;
     }
 
-    ALAssetsLibrary *library = [[ALAssetsLibrary alloc] init];
-    if ([library videoAtPathIsCompatibleWithSavedPhotosAlbum:[self videoFileURL]]) {
-        [library writeVideoAtPathToSavedPhotosAlbum:[self videoFileURL]
-                                    completionBlock:^(NSURL *assetURL, NSError *error){ (void)assetURL; (void)error; }];
-    }
+    UISaveVideoAtPathToSavedPhotosAlbum([self videoFileString], nil, nil, NULL);
 }
 
 


### PR DESCRIPTION
### This pullrequest changes

The entire AssetsLibrary framework is deprecated since iOS 8.0. The code
used in the camera example code can use UIKit to save videos to the
camera instead, which allows to avoid linking with PhotoKit instead to
prevent increasing the iOS deployment target.