### PR TITLE
js: skip 'utils' headers

### DIFF
--- a/modules/js/CMakeLists.txt
+++ b/modules/js/CMakeLists.txt
@@ -38,7 +38,7 @@ ocv_list_filterout(opencv_hdrs "modules/cuda.*")
 ocv_list_filterout(opencv_hdrs "modules/cudev")
 ocv_list_filterout(opencv_hdrs "modules/core/.*/hal/")
 ocv_list_filterout(opencv_hdrs "modules/.*/detection_based_tracker.hpp") # Conditional compilation
-ocv_list_filterout(opencv_hdrs "modules/core/include/opencv2/core/utils/trace.*.hpp")
+ocv_list_filterout(opencv_hdrs "modules/core/include/opencv2/core/utils/.*")
 
 file(WRITE "${CMAKE_CURRENT_BINARY_DIR}/headers.txt" "${opencv_hdrs}")
 


### PR DESCRIPTION
Fixes [nightly](http://pullrequest.opencv.org/buildbot/builders/master_docs-lin64/builds/10241) builds.
```
docker_image-Docs=docs-js
```
