### PR TITLE
fix StereoBM disparity map right margin truncation when minDisparities > 0

### DIFF
--- a/modules/calib3d/src/stereosgbm.cpp
+++ b/modules/calib3d/src/stereosgbm.cpp
@@ -2273,10 +2273,10 @@ Rect getValidDisparityROI( Rect roi1, Rect roi2,
                           int SADWindowSize )
 {
     int SW2 = SADWindowSize/2;
-    int minD = minDisparity, maxD = minDisparity + numberOfDisparities - 1;
+    int maxD = minDisparity + numberOfDisparities - 1;
 
     int xmin = std::max(roi1.x, roi2.x + maxD) + SW2;
-    int xmax = std::min(roi1.x + roi1.width, roi2.x + roi2.width - minD) - SW2;
+    int xmax = std::min(roi1.x + roi1.width, roi2.x + roi2.width) - SW2;
     int ymin = std::max(roi1.y, roi2.y) + SW2;
     int ymax = std::min(roi1.y + roi1.height, roi2.y + roi2.height) - SW2;
 


### PR DESCRIPTION
…s > 0

resolves #9783 for the opencv master branch

This pullrequest modifies StereoSGBM::getValidDisparityROI() to return the correct disparity map region of interest, the right edge of which should be at x = width - SADWindowSize / 2.

The major effect of this is that the StereoBM::compute algorithm, which calls this function, will correctly calculate disparity to SADWindowSize / 2 of the right margin of the disparity map, instead of only to minDisparities + SADWindowSize / 2.

This allows StereoBM to compute a disparity map covering an ROI roughly the same size as StereoSGBM and the StereoBinary algorithms do, instead of being reduced in width by minDisparities on the right edge.