### PR TITLE
Enable OpenCL HAAR Cascades to leverage OpenCL for NVIDIA device.

### DIFF
--- a/modules/objdetect/src/cascadedetect.cpp
+++ b/modules/objdetect/src/cascadedetect.cpp
@@ -609,7 +609,7 @@ bool HaarEvaluator::read(const FileNode& node, Size _origWinSize)
     localSize = lbufSize = Size(0, 0);
     if (ocl::haveOpenCL())
     {
-        if (ocl::Device::getDefault().isAMD() || ocl::Device::getDefault().isIntel())
+        if (ocl::Device::getDefault().isAMD() || ocl::Device::getDefault().isIntel() || ocl::Device::getDefault().isNVidia())
         {
             localSize = Size(8, 8);
             lbufSize = Size(origWinSize.width + localSize.width,


### PR DESCRIPTION
### This pullrequest changes

The change allows the HAAR cascade featureEvaluator to get a localSize with an area > 0.
Without this change "localSize" on the featureEvaluator remains Size(0, 0) which sets the bool "use_ocl" to false. 

```
#ifdef HAVE_OPENCL
    bool use_ocl = tryOpenCL && ocl::useOpenCL() &&
         OCL_FORCE_CHECK(_image.isUMat()) &&
         featureEvaluator->getLocalSize().area() > 0 &&
         (data.minNodesPerTree == data.maxNodesPerTree) &&
         !isOldFormatCascade() &&
         maskGenerator.empty() &&
         !outputRejectLevels;
#endif
```
NVidia GPU's never get a ```featureEvaluator->getLocalSize().area() > 0```

I have tested this on two GPU's (GeForce GTX 965m & GeForce GTX 970) and it cuts the processing time in half and the rects returned are the same as the CPU impl.

I tried to run the tests but it appears that the test data is missing from the repository which is disappointing.
