### PR TITLE
fix some grammatical errors in python stereo tutorial

### DIFF
--- a/doc/py_tutorials/py_calib3d/py_depthmap/py_depthmap.markdown
+++ b/doc/py_tutorials/py_calib3d/py_depthmap/py_depthmap.markdown
@@ -5,14 +5,14 @@ Goal
 ----
 
 In this session,
-    -   We will learn to create depth map from stereo images.
+    -   We will learn to create a depth map from stereo images.
 
 Basics
 ------
 
-In last session, we saw basic concepts like epipolar constraints and other related terms. We also
+In the last session, we saw basic concepts like epipolar constraints and other related terms. We also
 saw that if we have two images of same scene, we can get depth information from that in an intuitive
-way. Below is an image and some simple mathematical formulas which proves that intuition. (Image
+way. Below is an image and some simple mathematical formulas which prove that intuition. (Image
 Courtesy :
 
 ![image](images/stereo_depth.jpg)
@@ -24,7 +24,7 @@ following result:
 
 \f$x\f$ and \f$x'\f$ are the distance between points in image plane corresponding to the scene point 3D and
 their camera center. \f$B\f$ is the distance between two cameras (which we know) and \f$f\f$ is the focal
-length of camera (already known). So in short, above equation says that the depth of a point in a
+length of camera (already known). So in short, the above equation says that the depth of a point in a
 scene is inversely proportional to the difference in distance of corresponding image points and
 their camera centers. So with this information, we can derive the depth of all pixels in an image.
 
@@ -35,7 +35,7 @@ how we can do it with OpenCV.
 Code
 ----
 
-Below code snippet shows a simple procedure to create disparity map.
+Below code snippet shows a simple procedure to create a disparity map.
 @code{.py}
 import numpy as np
 import cv2
@@ -49,7 +49,7 @@ disparity = stereo.compute(imgL,imgR)
 plt.imshow(disparity,'gray')
 plt.show()
 @endcode
-Below image contains the original image (left) and its disparity map (right). As you can see, result
+Below image contains the original image (left) and its disparity map (right). As you can see, the result
 is contaminated with high degree of noise. By adjusting the values of numDisparities and blockSize,
 you can get a better result.
 


### PR DESCRIPTION
<!-- Please use this line to close one or multiple issues when this pullrequest gets merged
You can add another line right under the first one:
resolves #1234
resolves #1235
-->

### This pullrequest changes

This pullrequest corrects some phrasing in the Python tutorial for stereo depthmap generation.
