### PR TITLE
MediaSDK video backend: Windows support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -245,7 +245,7 @@ OCV_OPTION(WITH_INTELPERC      "Include Intel Perceptual Computing support"  OFF
 OCV_OPTION(WITH_MATLAB         "Include Matlab support"                      ON   IF (NOT ANDROID AND NOT IOS AND NOT WINRT))
 OCV_OPTION(WITH_VA             "Include VA support"                          OFF  IF (UNIX AND NOT ANDROID) )
 OCV_OPTION(WITH_VA_INTEL       "Include Intel VA-API/OpenCL support"         OFF  IF (UNIX AND NOT ANDROID) )
-OCV_OPTION(WITH_MFX            "Include Intel Media SDK support"             OFF   IF (UNIX AND NOT ANDROID) )
+OCV_OPTION(WITH_MFX            "Include Intel Media SDK support"             OFF   IF ((UNIX AND NOT ANDROID) OR (WIN32 AND NOT WINRT AND NOT MINGW)) )
 OCV_OPTION(WITH_GDAL           "Include GDAL Support"                        OFF  IF (NOT ANDROID AND NOT IOS AND NOT WINRT) )
 OCV_OPTION(WITH_GPHOTO2        "Include gPhoto2 library support"             ON   IF (UNIX AND NOT ANDROID) )
 OCV_OPTION(WITH_LAPACK         "Include Lapack library support"              ON   IF (NOT ANDROID AND NOT IOS) )

--- a/modules/videoio/src/cap_mfx_common.cpp
+++ b/modules/videoio/src/cap_mfx_common.cpp
@@ -5,10 +5,12 @@
 #include "cap_mfx_common.hpp"
 
 // Linux specific
+#ifdef __linux__
 #include <unistd.h>
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <fcntl.h>
+#endif
 
 using namespace std;
 using namespace cv;
@@ -35,6 +37,8 @@ bool DeviceHandler::init(MFXVideoSession &session)
 }
 
 //==================================================================================================
+
+#ifdef __linux__
 
 VAHandle::VAHandle() {
     // TODO: provide a way of modifying this path
@@ -68,6 +72,19 @@ bool VAHandle::initDeviceSession(MFXVideoSession &session) {
     return false;
 }
 
+#endif // __linux__
+
+DeviceHandler * createDeviceHandler()
+{
+#if defined __linux__
+    return new VAHandle();
+#elif defined _WIN32
+    return new DXHandle();
+#else
+    return 0;
+#endif
+}
+
 //==================================================================================================
 
 SurfacePool::SurfacePool(ushort width_, ushort height_, ushort count, const mfxFrameInfo &frameInfo, uchar bpp)
@@ -85,7 +102,8 @@ SurfacePool::SurfacePool(ushort width_, ushort height_, ushort count, const mfxF
         surface.Info = frameInfo;
         surface.Data.Y = dataPtr;
         surface.Data.UV = dataPtr + width * height;
-        surface.Data.Pitch = width;
+        surface.Data.PitchLow = width & 0xFFFF;
+        surface.Data.PitchHigh = (width >> 16) & 0xFFFF;
         DBG(cout << "allocate surface " << (void*)&surface << ", Y = " << (void*)dataPtr << " (" << width << "x" << height << ")" << endl);
     }
     DBG(cout << "Allocated: " << endl
@@ -112,7 +130,7 @@ ReadBitstream::ReadBitstream(const char *filename, size_t maxSize) : drain(false
     input.open(filename, std::ios::in | std::ios::binary);
     DBG(cout << "Open " << filename << " -> " << input.is_open() << std::endl);
     memset(&stream, 0, sizeof(stream));
-    stream.MaxLength = maxSize;
+    stream.MaxLength = (mfxU32)maxSize;
     stream.Data = new mfxU8[stream.MaxLength];
     CV_Assert(stream.Data);
 }
@@ -139,7 +157,7 @@ bool ReadBitstream::read()
     input.read((char*)(stream.Data + stream.DataLength), stream.MaxLength - stream.DataLength);
     if (input.eof() || input.good())
     {
-        mfxU32 bytesRead = input.gcount();
+        mfxU32 bytesRead = (mfxU32)input.gcount();
         if (bytesRead > 0)
         {
             stream.DataLength += bytesRead;
@@ -157,7 +175,7 @@ WriteBitstream::WriteBitstream(const char * filename, size_t maxSize)
     output.open(filename, std::ios::out | std::ios::binary);
     DBG(cout << "BS Open " << filename << " -> " << output.is_open() << std::endl);
     memset(&stream, 0, sizeof(stream));
-    stream.MaxLength = maxSize;
+    stream.MaxLength = (mfxU32)maxSize;
     stream.Data = new mfxU8[stream.MaxLength];
     DBG(cout << "BS Allocate " << maxSize << " bytes (" << ((float)maxSize / (1 << 20)) << " Mb)" << endl);
     CV_Assert(stream.Data);

--- a/modules/videoio/src/cap_mfx_common.hpp
+++ b/modules/videoio/src/cap_mfx_common.hpp
@@ -168,7 +168,7 @@ inline void cleanup(T * &ptr)
 
 //==================================================================================================
 
-struct Plugin
+class Plugin
 {
 public:
     static Plugin * loadEncoderPlugin(MFXVideoSession &session, mfxU32 codecId)
@@ -206,7 +206,7 @@ private:
 
 //==================================================================================================
 
-struct ReadBitstream
+class ReadBitstream
 {
 public:
     ReadBitstream(const char * filename, size_t maxSize = 10 * 1024 * 1024);
@@ -225,7 +225,7 @@ public:
 
 //==================================================================================================
 
-struct WriteBitstream
+class WriteBitstream
 {
 public:
     WriteBitstream(const char * filename, size_t maxSize);
@@ -268,7 +268,7 @@ private:
     SurfacePool(const SurfacePool &);
     SurfacePool &operator=(const SurfacePool &);
 public:
-    ushort width, height;
+    size_t width, height;
     size_t oneSize;
     cv::AutoBuffer<uchar, 0> buffers;
     std::vector<mfxFrameSurface1> surfaces;
@@ -286,6 +286,7 @@ protected:
 
 
 // Linux specific
+#ifdef __linux__
 
 #include <va/va_drm.h>
 
@@ -302,7 +303,26 @@ private:
     int file;
 };
 
-// TODO: Windows specific
+#endif // __linux__
 
+// Windows specific
+#ifdef _WIN32
+
+#include <Windows.h>
+inline void sleep(unsigned long sec) { Sleep(1000 * sec); }
+
+class DXHandle : public DeviceHandler {
+public:
+    DXHandle() {}
+    ~DXHandle() {}
+private:
+    DXHandle(const DXHandle &);
+    DXHandle &operator=(const DXHandle &);
+    virtual bool initDeviceSession(MFXVideoSession &) { return true; }
+};
+
+#endif // _WIN32
+
+DeviceHandler * createDeviceHandler();
 
 #endif // MFXHELPER_H

--- a/modules/videoio/src/cap_mfx_reader.cpp
+++ b/modules/videoio/src/cap_mfx_reader.cpp
@@ -38,8 +38,7 @@ VideoCapture_IntelMFX::VideoCapture_IntelMFX(const cv::String &filename)
     mfxStatus res = MFX_ERR_NONE;
 
     // Init device and session
-
-    deviceHandler = new VAHandle();
+    deviceHandler = createDeviceHandler();
     session = new MFXVideoSession();
     if (!deviceHandler->init(*session))
     {
@@ -227,7 +226,6 @@ bool VideoCapture_IntelMFX::grabFrame()
             MSG(cerr << "MFX: Bad status: " << res << endl);
             return false;
         }
-        return false;
     }
 }
 

--- a/modules/videoio/src/cap_mfx_writer.cpp
+++ b/modules/videoio/src/cap_mfx_writer.cpp
@@ -40,8 +40,7 @@ VideoWriter_IntelMFX::VideoWriter_IntelMFX(const String &filename, int _fourcc, 
     }
 
     // Init device and session
-
-    deviceHandler = new VAHandle();
+    deviceHandler = createDeviceHandler();
     session = new MFXVideoSession();
     if (!deviceHandler->init(*session))
     {
@@ -71,7 +70,7 @@ VideoWriter_IntelMFX::VideoWriter_IntelMFX(const String &filename, int _fourcc, 
     memset(&params, 0, sizeof(params));
     params.mfx.CodecId = codecId;
     params.mfx.TargetUsage = MFX_TARGETUSAGE_BALANCED;
-    params.mfx.TargetKbps = frameSize.area() * fps / 500; // TODO: set in options
+    params.mfx.TargetKbps = (mfxU16)cvRound(frameSize.area() * fps / 500); // TODO: set in options
     params.mfx.RateControlMethod = MFX_RATECONTROL_VBR;
     params.mfx.FrameInfo.FrameRateExtN = cvRound(fps * 1000);
     params.mfx.FrameInfo.FrameRateExtD = 1000;
@@ -80,10 +79,10 @@ VideoWriter_IntelMFX::VideoWriter_IntelMFX(const String &filename, int _fourcc, 
     params.mfx.FrameInfo.PicStruct = MFX_PICSTRUCT_PROGRESSIVE;
     params.mfx.FrameInfo.CropX = 0;
     params.mfx.FrameInfo.CropY = 0;
-    params.mfx.FrameInfo.CropW = frameSize.width;
-    params.mfx.FrameInfo.CropH = frameSize.height;
-    params.mfx.FrameInfo.Width = alignSize(frameSize.width, 32);
-    params.mfx.FrameInfo.Height = alignSize(frameSize.height, 32);
+    params.mfx.FrameInfo.CropW = (mfxU16)frameSize.width;
+    params.mfx.FrameInfo.CropH = (mfxU16)frameSize.height;
+    params.mfx.FrameInfo.Width = (mfxU16)alignSize(frameSize.width, 32);
+    params.mfx.FrameInfo.Height = (mfxU16)alignSize(frameSize.height, 32);
     params.IOPattern = MFX_IOPATTERN_IN_SYSTEM_MEMORY;
     res = encoder->Query(&params, &params);
     DBG(cout << "MFX Query: " << res << endl << params.mfx << params.mfx.FrameInfo);
@@ -263,7 +262,6 @@ bool VideoWriter_IntelMFX::write_one(cv::InputArray bgr)
             MSG(cerr << "MFX: Bad status: " << res << endl);
             return false;
         }
-        return true;
     }
 }
 


### PR DESCRIPTION
### This pullrequest changes

Adds support for Windows version of MediaSDK. Specific `DeviceHandler` instance is empty, internal MediaSDK DirectX device will be used. 

Several warnings have been fixed.