### PR TITLE
fix StereoBM disparity map right margin truncation when minDisparitie…

### DIFF
--- a/modules/calib3d/src/stereosgbm.cpp
+++ b/modules/calib3d/src/stereosgbm.cpp
@@ -864,10 +864,10 @@ Rect getValidDisparityROI( Rect roi1, Rect roi2,
                           int SADWindowSize )
 {
     int SW2 = SADWindowSize/2;
-    int minD = minDisparity, maxD = minDisparity + numberOfDisparities - 1;
+    int maxD = minDisparity + numberOfDisparities - 1;
 
     int xmin = max(roi1.x, roi2.x + maxD) + SW2;
-    int xmax = min(roi1.x + roi1.width, roi2.x + roi2.width - minD) - SW2;
+    int xmax = min(roi1.x + roi1.width, roi2.x + roi2.width) - SW2;
     int ymin = max(roi1.y, roi2.y) + SW2;
     int ymax = min(roi1.y + roi1.height, roi2.y + roi2.height) - SW2;
 


### PR DESCRIPTION
…s > 0

Backport fix on master to resolve #9783 in 2.4 branch.

Backport #9816