### PR TITLE
Fix some DNN samples for compatibility with Python 3

### DIFF
--- a/modules/dnn/misc/python/pyopencv_dnn.hpp
+++ b/modules/dnn/misc/python/pyopencv_dnn.hpp
@@ -16,6 +16,11 @@ bool pyopencv_to(PyObject *o, dnn::DictValue &dv, const char *name)
         dv = dnn::DictValue((int64)PyLong_AsLongLong(o));
         return true;
     }
+    else if (PyInt_Check(o))
+    {
+        dv = dnn::DictValue((int64)PyInt_AS_LONG(o));
+        return true;
+    }
     else if (PyFloat_Check(o))
     {
         dv = dnn::DictValue(PyFloat_AS_DOUBLE(o));

--- a/samples/dnn/colorization.py
+++ b/samples/dnn/colorization.py
@@ -1,4 +1,6 @@
-# Script is based on https://github.com/richzhang/colorization/colorize.py
+# Script is based on https://github.com/richzhang/colorization/blob/master/colorize.py
+# To download the caffemodel and the prototxt, see: https://github.com/richzhang/colorization/tree/master/models
+# To download pts_in_hull.npy, see: https://github.com/richzhang/colorization/blob/master/resources/pts_in_hull.npy
 import numpy as np
 import argparse
 import cv2 as cv
@@ -27,8 +29,8 @@ if __name__ == '__main__':
 
     # populate cluster centers as 1x1 convolution kernel
     pts_in_hull = pts_in_hull.transpose().reshape(2, 313, 1, 1)
-    net.getLayer(long(net.getLayerId('class8_ab'))).blobs = [pts_in_hull.astype(np.float32)]
-    net.getLayer(long(net.getLayerId('conv8_313_rh'))).blobs = [np.full([1, 313], 2.606, np.float32)]
+    net.getLayer(net.getLayerId('class8_ab')).blobs = [pts_in_hull.astype(np.float32)]
+    net.getLayer(net.getLayerId('conv8_313_rh')).blobs = [np.full([1, 313], 2.606, np.float32)]
 
     if args.input:
         cap = cv.VideoCapture(args.input)

--- a/samples/dnn/mobilenet_ssd_python.py
+++ b/samples/dnn/mobilenet_ssd_python.py
@@ -95,9 +95,9 @@ if __name__ == "__main__":
         else:
             cropSize = (cols, int(cols / WHRatio))
 
-        y1 = (rows - cropSize[1]) / 2
+        y1 = int((rows - cropSize[1]) / 2)
         y2 = y1 + cropSize[1]
-        x1 = (cols - cropSize[0]) / 2
+        x1 = int((cols - cropSize[0]) / 2)
         x2 = x1 + cropSize[0]
         frame = frame[y1:y2, x1:x2]
 

--- a/samples/dnn/resnet_ssd_face_python.py
+++ b/samples/dnn/resnet_ssd_face_python.py
@@ -1,8 +1,5 @@
 import numpy as np
 import argparse
-import os
-import sys
-sys.path.append('/home/arrybn/build/opencv/lib')
 import cv2 as cv
 try:
     import cv2 as cv


### PR DESCRIPTION
<!-- Please use this line to close one or multiple issues when this pullrequest gets merged
You can add another line right under the first one:
resolves #1234
resolves #1235
-->

### This pullrequest introduces
small changes to be able to run some DNN samples with Python 3:

- integer division returns float in Python 3, [see](https://stackoverflow.com/questions/1282945/python-integer-division-yields-float)
- long renamed to int in Python 3

I hope these changes do not break the compatibility with Python 2.

<!-- Please describe what your pullrequest is changing -->
