### PR TITLE
Fix build for non-linux architectures but still glibc-based

### DIFF
--- a/modules/core/src/parallel.cpp
+++ b/modules/core/src/parallel.cpp
@@ -52,7 +52,7 @@
     #undef abs
 #endif
 
-#if defined __linux__ || defined __APPLE__
+#if defined __linux__ || defined __APPLE__ || defined __GLIBC__
     #include <unistd.h>
     #include <stdio.h>
     #include <sys/types.h>
@@ -672,7 +672,7 @@ int cv::getNumberOfCPUs(void)
 #elif defined __ANDROID__
     static int ncpus = getNumberOfCPUsImpl();
     return ncpus;
-#elif defined __linux__
+#elif defined __linux__ || defined __GLIBC__
     return (int)sysconf( _SC_NPROCESSORS_ONLN );
 #elif defined __APPLE__
     int numCPU=0;

--- a/modules/core/src/system.cpp
+++ b/modules/core/src/system.cpp
@@ -215,7 +215,7 @@ std::wstring GetTempFileNameWinRT(std::wstring prefix)
 #include "omp.h"
 #endif
 
-#if defined __linux__ || defined __APPLE__ || defined __EMSCRIPTEN__ || defined __FreeBSD__ || defined __HAIKU__
+#if defined __linux__ || defined __APPLE__ || defined __EMSCRIPTEN__ || defined __FreeBSD__ || defined __GLIBC__ || defined __HAIKU__
 #include <unistd.h>
 #include <stdio.h>
 #include <sys/types.h>


### PR DESCRIPTION
Exampls of these are gnu/kfreebsd and gnu/hurd, both available as
unofficial Debian ports.

They don't define `__linux__` (as they are non-linux…) but still define
`__GLIBC__`, so check on that.