### PR TITLE
Add const to getViewerPose()

### DIFF
--- a/modules/viz/src/vizimpl.cpp
+++ b/modules/viz/src/vizimpl.cpp
@@ -509,7 +509,7 @@ void cv::viz::Viz3d::VizImpl::setViewerPose(const Affine3d &pose)
 }
 
 /////////////////////////////////////////////////////////////////////////////////////////////
-cv::Affine3d cv::viz::Viz3d::VizImpl::getViewerPose()
+cv::Affine3d cv::viz::Viz3d::VizImpl::getViewerPose() const
 {
     vtkCamera& camera = *renderer_->GetActiveCamera();
 

--- a/modules/viz/src/vizimpl.hpp
+++ b/modules/viz/src/vizimpl.hpp
@@ -88,7 +88,7 @@ public:
     void resetCamera();
 
     void setViewerPose(const Affine3d &pose);
-    Affine3d getViewerPose();
+    Affine3d getViewerPose() const;
 
     void convertToWindowCoordinates(const Point3d &pt, Point3d &window_coord);
     void converTo3DRay(const Point3d &window_coord, Point3d &origin, Vec3d &direction);


### PR DESCRIPTION
### This pullrequest changes
As described in the issue: #9393 method is not defined as `const cv::Affine3d cv::viz::Viz3d::VizImpl::getViewerPose()` however it doesn't modify the instance of the class. This PR adds the const qualifier to the method. Beside this function not being const may cause some problems it's also not consistent with other getters as they are defined as const. Hence making this method const is a good idea.

resolves #9393
