### PR TITLE
Binary data for batch normalization test from Torch

### DIFF
--- a/modules/dnn/test/test_torch_importer.cpp
+++ b/modules/dnn/test/test_torch_importer.cpp
@@ -169,7 +169,7 @@ TEST(Torch_Importer, run_deconv)
 
 TEST(Torch_Importer, run_batch_norm)
 {
-    runTorchNet("net_batch_norm");
+    runTorchNet("net_batch_norm", DNN_TARGET_CPU, "", false, true);
 }
 
 TEST(Torch_Importer, net_prelu)

--- a/samples/dnn/resnet_ssd_face_python.py
+++ b/samples/dnn/resnet_ssd_face_python.py
@@ -24,7 +24,7 @@ if __name__ == '__main__':
         cols = frame.shape[1]
         rows = frame.shape[0]
 
-        net.setInput(dnn.blobFromImage(frame, 1.0, (inWidth, inHeight), (104.0, 177.0, 123.0), False))
+        net.setInput(dnn.blobFromImage(frame, 1.0, (inWidth, inHeight), (104.0, 177.0, 123.0), False, False))
         detections = net.forward()
 
         perf_stats = net.getPerfProfile()


### PR DESCRIPTION
<!-- Please use this line to close one or multiple issues when this pullrequest gets merged
You can add another line right under the first one:
resolves #1234
resolves #1235
-->

### This pullrequest changes

* Binary data for batch norm test.
* Resize face detector input without keeping an aspect ratio.

**Merge with extra**: https://github.com/opencv/opencv_extra/pull/398
