### PR TITLE
Fixed CvCaptureCAM_V4L CAP_PROP_FORMAT evaluation

### DIFF
--- a/modules/videoio/src/cap_v4l.cpp
+++ b/modules/videoio/src/cap_v4l.cpp
@@ -1636,7 +1636,7 @@ static double icvGetPropertyCAM_V4L (const CvCaptureCAM_V4L* capture,
       case CV_CAP_PROP_MODE:
           return capture->palette;
       case CV_CAP_PROP_FORMAT:
-          return CV_MAKETYPE(CV_8U, capture->frame.nChannels);
+          return CV_MAKETYPE(IPL2CV_DEPTH(capture->frame.depth), capture->frame.nChannels);
       case CV_CAP_PROP_CONVERT_RGB:
           return capture->convert_rgb;
       }


### PR DESCRIPTION
This patch is reworked enhacement of CvCaptureCAM_V4L submitted by @shawndfernandes in PR #8396
### This pullrequest changes
Fixed evaluation of CAP_PROP_FORMAT value in case CvCaptureCAM_V4L returns CV_16U image
