### PR TITLE
Fix out of bounds write

### DIFF
--- a/modules/imgcodecs/src/grfmt_bmp.cpp
+++ b/modules/imgcodecs/src/grfmt_bmp.cpp
@@ -118,7 +118,7 @@ bool  BmpDecoder::readHeader()
 
                 if( m_bpp <= 8 )
                 {
-                    CV_Assert(clrused <= 256);
+                    CV_Assert(clrused >= 0 && clrused <= 256);
                     memset(m_palette, 0, sizeof(m_palette));
                     m_strm.getBytes(m_palette, (clrused == 0? 1<<m_bpp : clrused)*4 );
                     iscolor = IsColorPalette( m_palette, m_bpp );


### PR DESCRIPTION
Fix for #9902 

Analysis
===
Check for integer overflow on [line 121](https://github.com/opencv/opencv/blob/master/modules/imgcodecs/src/grfmt_bmp.cpp#L121) does not account for integer underflow. Leads to out of bounds write

Fix
===
Check that `clrused` is greater than zero