### PR TITLE
OCL: cache result of program build failures

### DIFF
--- a/modules/core/src/ocl.cpp
+++ b/modules/core/src/ocl.cpp
@@ -1387,7 +1387,7 @@ struct Context::Impl
             }
         }
         Program prog(src, buildflags, errmsg);
-        if(prog.ptr())
+        // Cache result of build failures too (to prevent unnecessary compiler invocations)
         {
             cv::AutoLock lock(program_cache_mutex);
             phash.insert(std::pair<std::string, Program>(key, prog));


### PR DESCRIPTION
To prevent unnecessary compiler invocations

[Example](http://pullrequest.opencv.org/buildbot/builders/master-mac/builds/10258/steps/test_dnn-ippicv-opencl/logs/stdio):
```
OpenCL program build log: dummy (dnn)
Status -43: CL_INVALID_BUILD_OPTIONS
-cl-no-subgroup-ifp -D INTEL_DEVICE
```
x 400 times

```
force_builders=Mac OpenCL
```