### PR TITLE
ocl(macosx): fix CL_INVALID_BUILD_OPTIONS for gemm programs

### DIFF
--- a/modules/core/src/matmul.cpp
+++ b/modules/core/src/matmul.cpp
@@ -845,11 +845,11 @@ static bool ocl_gemm( InputArray matA, InputArray matB, double alpha,
         int vectorWidths[] = { 4, 4, 2, 2, 1, 4, cn, -1 };
         int kercn = ocl::checkOptimalVectorWidth(vectorWidths, B, D);
 
-        opts += format(" -D T=%s -D T1=%s -D WT=%s -D cn=%d -D kercn=%d -D LOCAL_SIZE=%d %s %s %s",
+        opts += format(" -D T=%s -D T1=%s -D WT=%s -D cn=%d -D kercn=%d -D LOCAL_SIZE=%d%s%s%s",
                           ocl::typeToStr(type), ocl::typeToStr(depth), ocl::typeToStr(CV_MAKETYPE(depth, kercn)),
                           cn, kercn, block_size,
-                          (sizeA.width % block_size !=0) ? "-D NO_MULT" : "",
-                          haveC ? "-D HAVE_C" : "",
+                          (sizeA.width % block_size !=0) ? " -D NO_MULT" : "",
+                          haveC ? " -D HAVE_C" : "",
                           doubleSupport ? " -D DOUBLE_SUPPORT" : "");
 
         ocl::Kernel k("gemm", cv::ocl::core::gemm_oclsrc, opts);


### PR DESCRIPTION
MacOSX OpenCL compiler is very strict to whitespace issues

[Example](http://pullrequest.opencv.org/buildbot/builders/master-mac/builds/10258/steps/test_core-ippicv-opencl/logs/stdio)
```
OpenCL program build log: gemm (core)
Status -43: CL_INVALID_BUILD_OPTIONS
 -D T=float -D T1=float -D WT=float -D cn=1 -D kercn=1 -D LOCAL_SIZE=16 -D NO_MULT -D HAVE_C  -D INTEL_DEVICE
```
There are two spaces after `HAVE_C`.

```
force_builders=Mac OpenCL
```