### PR TITLE
PReLU layer for multidimensional input

### DIFF
--- a/modules/dnn/src/layers/elementwise_layers.cpp
+++ b/modules/dnn/src/layers/elementwise_layers.cpp
@@ -80,20 +80,19 @@ public:
 
         void operator()(const Range &r) const
         {
-            int nstripes = nstripes_, nsamples, outCn;
-            size_t planeSize;
+            int nstripes = nstripes_, nsamples = 1, outCn = 1;
+            size_t planeSize = 1;
 
-            if( src_->dims == 4 )
+            if (src_->dims > 1)
             {
                 nsamples = src_->size[0];
                 outCn = src_->size[1];
-                planeSize = (size_t)src_->size[2]*src_->size[3];
             }
             else
-            {
-                nsamples = outCn = 1;
-                planeSize = (size_t)src_->total();
-            }
+                outCn = src_->size[0];
+
+            for (int i = 2; i < src_->dims; ++i)
+                planeSize *= src_->size[i];
 
             size_t stripeSize = (planeSize + nstripes - 1)/nstripes;
             size_t stripeStart = r.start*stripeSize;

--- a/modules/dnn/src/layers/fully_connected_layer.cpp
+++ b/modules/dnn/src/layers/fully_connected_layer.cpp
@@ -242,9 +242,8 @@ public:
                     }
                 }
 
-                // TODO: check whether this is correct in the case of ChannelsPReLU.
                 if(activ)
-                    activ->forwardSlice(dptr, dptr, nw, 0, 0, 1);
+                    activ->forwardSlice(dptr, dptr, 1, 1, delta, delta + nw);
 
                 ofs += nw;
             }

--- a/modules/dnn/src/layers/prior_box_layer.cpp
+++ b/modules/dnn/src/layers/prior_box_layer.cpp
@@ -177,7 +177,7 @@ public:
         : _boxWidth(0), _boxHeight(0)
     {
         setParamsFrom(params);
-        _minSize = getParameter<unsigned>(params, "min_size");
+        _minSize = getParameter<float>(params, "min_size");
         CV_Assert(_minSize > 0);
 
         _flip = getParameter<bool>(params, "flip");

--- a/modules/dnn/test/test_layers.cpp
+++ b/modules/dnn/test/test_layers.cpp
@@ -282,6 +282,7 @@ TEST(Layer_Test_Eltwise, Accuracy)
 TEST(Layer_Test_PReLU, Accuracy)
 {
     testLayerUsingCaffeModels("layer_prelu", DNN_TARGET_CPU, true);
+    testLayerUsingCaffeModels("layer_prelu_fc", DNN_TARGET_CPU, true, false);
 }
 
 //template<typename XMat>


### PR DESCRIPTION
<!-- Please use this line to close one or multiple issues when this pullrequest gets merged
You can add another line right under the first one:
resolves #1234
resolves #1235
-->

### This pullrequest changes

Fix PReLU activation after fully-connected layer: both in-place and standalone cases.

**Merge with extra**: https://github.com/opencv/opencv_extra/pull/399
