### PR TITLE
core: fix getUMat() crashes

### DIFF
--- a/modules/core/src/matrix.cpp
+++ b/modules/core/src/matrix.cpp
@@ -184,7 +184,14 @@ public:
                     total = step[i];
                 }
                 else
+                {
                     step[i] = total;
+                    total *= sizes[i];
+                }
+            }
+            else
+            {
+                total *= sizes[i];
             }
             total *= sizes[i];
         }


### PR DESCRIPTION
There is invalid calculation of buffer size.
Statement "total *= sizes[i]" should not be executed in a case of reusing predefined steps: "total = step[i]"

Problem is [observed](http://pullrequest.opencv.org/buildbot/builders/precommit_opencl/builds/12965/steps/test_dnn-ippicv-opencl/logs/stdio) via these sporadic failures:
```
[ RUN      ] Test_TensorFlow.conv
unknown file: error: SEH exception with code 0xc0000005 thrown in the test body.
[  FAILED  ] Test_TensorFlow.conv (10 ms)
```
