### PR TITLE
dnn: fix sporadic crashes in getUMat()

### DIFF
--- a/modules/dnn/src/tensorflow/tf_importer.cpp
+++ b/modules/dnn/src/tensorflow/tf_importer.cpp
@@ -692,8 +692,11 @@ void TFImporter::populateNet(Net dstNet)
                                 int dst_i = (j * chMultiplier + i) * height* width + s;
                                 dst[dst_i] = src[src_i];
                             }
+                // TODO Use reshape instead
                 kshape[0] = inCh * chMultiplier;
                 kshape[1] = 1;
+                size_t* kstep = layerParams.blobs[0].step.p;
+                kstep[0] = kstep[1]; // fix steps too
             }
             layerParams.set("kernel_h", kshape[2]);
             layerParams.set("kernel_w", kshape[3]);


### PR DESCRIPTION
Incorrect "total" buffer size is calculated in StdMatAllocator::allocate() due wrong step values.

Problem is [observed](http://pullrequest.opencv.org/buildbot/builders/precommit_opencl/builds/12965/steps/test_dnn-ippicv-opencl/logs/stdio) via these sporadic failures:
```
[ RUN      ] Test_TensorFlow.conv
unknown file: error: SEH exception with code 0xc0000005 thrown in the test body.
[  FAILED  ] Test_TensorFlow.conv (10 ms)
```