### PR TITLE
Fix the outputs remain the same bug in detection_ouput

### DIFF
--- a/modules/dnn/src/layers/detection_output_layer.cpp
+++ b/modules/dnn/src/layers/detection_output_layer.cpp
@@ -240,6 +240,7 @@ public:
 
         if (numKept == 0)
         {
+            outputs[0].release();
             return;
         }
         int outputShape[] = {1, 1, (int)numKept, 7};


### PR DESCRIPTION
If the results do not have any detections, direct return  will cause the results are the same with the last one.

<!-- Please use this line to close one or multiple issues when this pullrequest gets merged
You can add another line right under the first one:
resolves #1234
resolves #1235
-->

### This pullrequest changes
Release the output Mat if the result is empty.
<!-- Please describe what your pullrequest is changing -->
