### PR TITLE
MediaSDK: fixed Linux build, improved BGR<->NV12 conversions

### DIFF
--- a/modules/imgproc/include/opencv2/imgproc/hal/hal.hpp
+++ b/modules/imgproc/include/opencv2/imgproc/hal/hal.hpp
@@ -192,6 +192,12 @@ CV_EXPORTS void cvtTwoPlaneYUVtoBGR(const uchar * src_data, size_t src_step,
                                     int dst_width, int dst_height,
                                     int dcn, bool swapBlue, int uIdx);
 
+//! Separate Y and UV planes
+CV_EXPORTS void cvtTwoPlaneYUVtoBGR(const uchar * y_data, const uchar * uv_data, size_t src_step,
+                                    uchar * dst_data, size_t dst_step,
+                                    int dst_width, int dst_height,
+                                    int dcn, bool swapBlue, int uIdx);
+
 CV_EXPORTS void cvtThreePlaneYUVtoBGR(const uchar * src_data, size_t src_step,
                                       uchar * dst_data, size_t dst_step,
                                       int dst_width, int dst_height,
@@ -201,6 +207,12 @@ CV_EXPORTS void cvtBGRtoThreePlaneYUV(const uchar * src_data, size_t src_step,
                                       uchar * dst_data, size_t dst_step,
                                       int width, int height,
                                       int scn, bool swapBlue, int uIdx);
+
+//! Separate Y and UV planes
+CV_EXPORTS void cvtBGRtoTwoPlaneYUV(const uchar * src_data, size_t src_step,
+                                    uchar * y_data, uchar * uv_data, size_t dst_step,
+                                    int width, int height,
+                                    int scn, bool swapBlue, int uIdx);
 
 CV_EXPORTS void cvtOnePlaneYUVtoBGR(const uchar * src_data, size_t src_step,
                                     uchar * dst_data, size_t dst_step,

--- a/modules/videoio/src/cap_mfx_common.cpp
+++ b/modules/videoio/src/cap_mfx_common.cpp
@@ -6,7 +6,6 @@
 
 // Linux specific
 #ifdef __linux__
-#include <unistd.h>
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <fcntl.h>

--- a/modules/videoio/src/cap_mfx_common.hpp
+++ b/modules/videoio/src/cap_mfx_common.hpp
@@ -288,6 +288,7 @@ protected:
 // Linux specific
 #ifdef __linux__
 
+#include <unistd.h>
 #include <va/va_drm.h>
 
 class VAHandle : public DeviceHandler {

--- a/modules/videoio/src/cap_mfx_reader.cpp
+++ b/modules/videoio/src/cap_mfx_reader.cpp
@@ -5,6 +5,7 @@
 #include "cap_mfx_reader.hpp"
 #include "opencv2/core/base.hpp"
 #include "cap_mfx_common.hpp"
+#include "opencv2/imgproc/hal/hal.hpp"
 
 using namespace cv;
 using namespace std;
@@ -243,17 +244,11 @@ bool VideoCapture_IntelMFX::retrieveFrame(int, OutputArray out)
 
     const int cols = info.CropW;
     const int rows = info.CropH;
-    Mat nv12(rows * 3 / 2, cols, CV_8UC1);
 
-    Mat Y(rows, cols, CV_8UC1, data.Y, data.Pitch);
-    Mat UV(rows / 2, cols, CV_8UC1, data.UV, data.Pitch);
+    out.create(rows, cols, CV_8UC3);
+    Mat res = out.getMat();
 
-    Y.copyTo(Mat(nv12, Rect(0, 0, cols, rows)));
-    UV.copyTo(Mat(nv12, Rect(0, rows, cols, rows / 2)));
-
-    Mat u_and_v[2];
-    split(UV.reshape(2), u_and_v);
-    cvtColor(nv12, out, COLOR_YUV2BGR_NV12);
+    hal::cvtTwoPlaneYUVtoBGR(data.Y, data.UV, data.Pitch, res.data, res.step, cols, rows, 3, false, 0);
 
     return true;
 }

--- a/modules/videoio/src/cap_mfx_writer.cpp
+++ b/modules/videoio/src/cap_mfx_writer.cpp
@@ -5,6 +5,7 @@
 #include "cap_mfx_writer.hpp"
 #include "opencv2/core/base.hpp"
 #include "cap_mfx_common.hpp"
+#include "opencv2/imgproc/hal/hal.hpp"
 
 using namespace std;
 using namespace cv;
@@ -166,26 +167,6 @@ void VideoWriter_IntelMFX::write(cv::InputArray input)
     write_one(input);
 }
 
-inline static void to_nv12(cv::InputArray bgr, cv::Mat & Y, cv::Mat & UV)
-{
-    const int height = bgr.rows();
-    const int width = bgr.cols();
-    Mat yuv;
-    cvtColor(bgr, yuv, CV_BGR2YUV_I420);
-    CV_Assert(yuv.isContinuous());
-    Mat Y_(Y, Rect(0, 0, width, height));
-    yuv.rowRange(0, height).copyTo(Y_);
-    Mat UV_planar(height, width / 2, CV_8UC1, yuv.ptr(height));
-    Mat u_and_v[2] = {
-        UV_planar.rowRange(0, height / 2),
-        UV_planar.rowRange(height / 2, height),
-    };
-    Mat uv;
-    cv::merge(u_and_v, 2, uv);
-    Mat UV_(UV, Rect(0, 0, width, height / 2));
-    uv.reshape(1).copyTo(UV_);
-}
-
 bool VideoWriter_IntelMFX::write_one(cv::InputArray bgr)
 {
     mfxStatus res;
@@ -209,13 +190,11 @@ bool VideoWriter_IntelMFX::write_one(cv::InputArray bgr)
             MSG(cerr << "MFX: Failed to get free surface" << endl);
             return false;
         }
-        const int rows = workSurface->Info.Height;
-        const int cols = workSurface->Info.Width;
-        Mat Y(rows, cols, CV_8UC1, workSurface->Data.Y, workSurface->Data.Pitch);
-        Mat UV(rows / 2, cols, CV_8UC1, workSurface->Data.UV, workSurface->Data.Pitch);
-        to_nv12(bgr, Y, UV);
-        CV_Assert(Y.ptr() == workSurface->Data.Y);
-        CV_Assert(UV.ptr() == workSurface->Data.UV);
+        Mat src = bgr.getMat();
+        hal::cvtBGRtoTwoPlaneYUV(src.data, src.step,
+                                 workSurface->Data.Y, workSurface->Data.UV, workSurface->Data.Pitch,
+                                 workSurface->Info.CropW, workSurface->Info.CropH,
+                                 3, false, 1);
     }
 
     while (true)


### PR DESCRIPTION
### This pullrequest changes

- fixed compilation on Linux
- use `cv::hal::` functions to convert between BGR and NV12 formats in MediaSDK backend

**Notes:**
- performance improvement ~3-5% for `opencv_test_videoio --gtest_filter=*MFX*` (encode-decode test)
- -2 KiB to binary size
