### PR TITLE
core(ocl): fix parameters for 'intelblas_gemm_buffer_NT' kernel

### DIFF
--- a/modules/core/src/intel_gpu_gemm.inl.hpp
+++ b/modules/core/src/intel_gpu_gemm.inl.hpp
@@ -108,9 +108,8 @@ static bool intel_gpu_gemm(
                (float)beta,
                (int)(A.step / sizeof(float)),
                (int)(B.step / sizeof(float)),
-               (int)(D.step / sizeof(float)),
-               (int) 0,                          // 14 start_index
-               stride);
+               (int)(D.step / sizeof(float))
+        );
 
         ret = k.run(2, global, local, false, q);
     }


### PR DESCRIPTION
resolves #9989