### PR TITLE
Fixed minor issues reported by GCC 7.2

### DIFF
--- a/3rdparty/libjasper/CMakeLists.txt
+++ b/3rdparty/libjasper/CMakeLists.txt
@@ -25,7 +25,7 @@ endif(WIN32 AND NOT MINGW)
 
 ocv_warnings_disable(CMAKE_C_FLAGS -Wno-implicit-function-declaration -Wno-uninitialized -Wmissing-prototypes
                                    -Wno-unused-but-set-parameter -Wmissing-declarations -Wunused -Wshadow
-                                   -Wsign-compare -Wstrict-overflow)
+                                   -Wsign-compare -Wstrict-overflow -Wpointer-compare)
 ocv_warnings_disable(CMAKE_C_FLAGS -Wunused-parameter) # clang
 ocv_warnings_disable(CMAKE_C_FLAGS /wd4013 /wd4018 /wd4101 /wd4244 /wd4267 /wd4715) # vs2005
 

--- a/apps/traincascade/cascadeclassifier.cpp
+++ b/apps/traincascade/cascadeclassifier.cpp
@@ -534,7 +534,7 @@ bool CvCascadeClassifier::load( const string cascadeDirName )
     featureEvaluator->init( featureParams, numPos + numNeg, cascadeParams.winSize );
     fs.release();
 
-    char buf[10];
+    char buf[16] = {0};
     for ( int si = 0; si < numStages; si++ )
     {
         sprintf( buf, "%s%d", "stage", si);

--- a/modules/core/src/lda.cpp
+++ b/modules/core/src/lda.cpp
@@ -519,7 +519,7 @@ private:
 
                 // Double QR step involving rows l:n and columns m:n
 
-                for (int k = m; k <= n1 - 1; k++) {
+                for (int k = m; k < n1; k++) {
                     bool notlast = (k != n1 - 1);
                     if (k != m) {
                         p = H[k][k - 1];
@@ -761,7 +761,7 @@ private:
         int low = 0;
         int high = n - 1;
 
-        for (int m = low + 1; m <= high - 1; m++) {
+        for (int m = low + 1; m < high; m++) {
 
             // Scale column.
 
@@ -822,7 +822,7 @@ private:
             }
         }
 
-        for (int m = high - 1; m >= low + 1; m--) {
+        for (int m = high - 1; m > low; m--) {
             if (H[m][m - 1] != 0.0) {
                 for (int i = m + 1; i <= high; i++) {
                     ort[i] = H[i][m - 1];
@@ -1083,7 +1083,7 @@ void LDA::lda(InputArrayOfArrays _src, InputArray _lbls) {
                   << std::endl;
     }
     // clip number of components to be a valid number
-    if ((_num_components <= 0) || (_num_components > (C - 1))) {
+    if ((_num_components <= 0) || (_num_components >= C)) {
         _num_components = (C - 1);
     }
     // holds the mean over all classes

--- a/modules/imgproc/src/resize.cpp
+++ b/modules/imgproc/src/resize.cpp
@@ -3173,7 +3173,7 @@ void resize(int src_type,
     short* ialpha = (short*)alpha;
     float* beta = alpha + width*ksize;
     short* ibeta = ialpha + width*ksize;
-    float cbuf[MAX_ESIZE];
+    float cbuf[MAX_ESIZE] = {0};
 
     for( dx = 0; dx < dsize.width; dx++ )
     {

--- a/modules/objdetect/test/test_cascadeandhog.cpp
+++ b/modules/objdetect/test/test_cascadeandhog.cpp
@@ -209,7 +209,7 @@ void CV_DetectorTest::run( int )
         vector<string>::const_iterator it = imageFilenames.begin();
         for( int ii = 0; it != imageFilenames.end(); ++it, ii++ )
         {
-            char buf[10];
+            char buf[16] = {0};
             sprintf( buf, "%s%d", "img_", ii );
             //cvWriteComment( validationFS.fs, buf, 0 );
             validationFS << *it;
@@ -265,7 +265,7 @@ int CV_DetectorTest::runTestCase( int detectorIdx, vector<vector<Rect> >& object
         Mat image = images[ii];
         if( image.empty() )
         {
-            char msg[30];
+            char msg[50] = {0};
             sprintf( msg, "%s %d %s", "image ", ii, " can not be read" );
             ts->printf( cvtest::TS::LOG, msg );
             return cvtest::TS::FAIL_INVALID_TEST_DATA;
@@ -278,7 +278,7 @@ int CV_DetectorTest::runTestCase( int detectorIdx, vector<vector<Rect> >& object
 
         if( write_results )
         {
-            char buf[10];
+            char buf[16] = {0};
             sprintf( buf, "%s%d", "img_", ii );
             string imageIdxStr = buf;
             validationFS << imageIdxStr << "[:";
@@ -313,7 +313,7 @@ int CV_DetectorTest::validate( int detectorIdx, vector<vector<Rect> >& objects )
         int noPair = 0;
 
         // read validation rectangles
-        char buf[10];
+        char buf[16] = {0};
         sprintf( buf, "%s%d", "img_", imageIdx );
         string imageIdxStr = buf;
         FileNode node = validationFS.getFirstTopLevelNode()[VALIDATION][detectorNames[detectorIdx]][imageIdxStr];

--- a/modules/videoio/src/cap_libv4l.cpp
+++ b/modules/videoio/src/cap_libv4l.cpp
@@ -393,27 +393,27 @@ static int xioctl( int fd, int request, void *arg)
    Returns the global numCameras with the correct value (we hope) */
 
 static void icvInitCapture_V4L() {
-   int deviceHandle;
-   int CameraNumber;
-   char deviceName[MAX_DEVICE_DRIVER_NAME];
+    int deviceHandle;
+    int CameraNumber;
+    char deviceName[MAX_DEVICE_DRIVER_NAME];
 
-   CameraNumber = 0;
-   while(CameraNumber < MAX_CAMERAS) {
-      /* Print the CameraNumber at the end of the string with a width of one character */
-      sprintf(deviceName, "/dev/video%1d", CameraNumber);
-      /* Test using an open to see if this new device name really does exists. */
-      deviceHandle = open(deviceName, O_RDONLY);
-      if (deviceHandle != -1) {
-         /* This device does indeed exist - add it to the total so far */
-    // add indexList
-    indexList|=(1 << CameraNumber);
-        numCameras++;
-    }
-    if (deviceHandle != -1)
-      close(deviceHandle);
-      /* Set up to test the next /dev/video source in line */
-      CameraNumber++;
-   } /* End while */
+    CameraNumber = 0;
+    while(CameraNumber < MAX_CAMERAS) {
+        /* Print the CameraNumber at the end of the string with a width of one character */
+        sprintf(deviceName, "/dev/video%1d", CameraNumber);
+        /* Test using an open to see if this new device name really does exists. */
+        deviceHandle = open(deviceName, O_RDONLY);
+        if (deviceHandle != -1) {
+            /* This device does indeed exist - add it to the total so far */
+            numCameras++;
+            // add indexList
+            indexList|=(1 << CameraNumber);
+        }
+        if (deviceHandle != -1)
+            close(deviceHandle);
+        /* Set up to test the next /dev/video source in line */
+        CameraNumber++;
+    } /* End while */
 
 }; /* End icvInitCapture_V4L */
 


### PR DESCRIPTION
One warning left:
```
[511/1816 374.1/sec] Building CXX object modules/core/CMakeFiles/opencv_core.dir/src/lda.cpp.o
In member function ‘void cv::EigenvalueDecomposition::compute(cv::InputArray, bool)’:
cc1plus: warning: assuming signed overflow does not occur when assuming that (X - c) > X is always false [-Wstrict-overflow]
```
