### PR TITLE
Matrices in colorizeSegmentation were not initialized.

### DIFF
--- a/samples/dnn/fcn_semsegm.cpp
+++ b/samples/dnn/fcn_semsegm.cpp
@@ -50,8 +50,8 @@ static void colorizeSegmentation(const Mat &score, const vector<cv::Vec3b> &colo
     const int cols = score.size[3];
     const int chns = score.size[1];
 
-    cv::Mat maxCl(rows, cols, CV_8UC1);
-    cv::Mat maxVal(rows, cols, CV_32FC1);
+    cv::Mat maxCl=cv::Mat::zeros(rows, cols, CV_8UC1);
+    cv::Mat maxVal(rows, cols, CV_32FC1, cv::Scalar(-FLT_MAX));
     for (int ch = 0; ch < chns; ch++)
     {
         for (int row = 0; row < rows; row++)


### PR DESCRIPTION
### This pullrequest changes

It initializes matrices before use. In previous version uninitialized matrices gave random segmentation mask result.

#9984