### PR TITLE
Clearing data into the detect method of the class cv::LineSegmentDete…

### DIFF
--- a/modules/imgproc/src/lsd.cpp
+++ b/modules/imgproc/src/lsd.cpp
@@ -430,6 +430,9 @@ void LineSegmentDetectorImpl::detect(InputArray _image, OutputArray _lines,
     if(w_needed) Mat(w).copyTo(_width);
     if(p_needed) Mat(p).copyTo(_prec);
     if(n_needed) Mat(n).copyTo(_nfa);
+
+    // Clear used structures
+    list.clear();
 }
 
 void LineSegmentDetectorImpl::flsd(std::vector<Vec4f>& lines,


### PR DESCRIPTION
close #10023 

### Clearing data into the detect method of the class cv::LineSegmentDetectorImpl

This pull request adds a last line into the method:
https://github.com/opencv/opencv/blob/7267e94be78b3c8be4f1f08b912ab57a52cf0954/modules/imgproc/src/lsd.cpp#L410
that clears the vector `list` avoiding the crash detailed in the issue #10023 .
