### PR TITLE
(2.4) git: .gitignore update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,10 +1,10 @@
+# ignore dot files/directories
+.*
+!.gitignore
+
 *.autosave
 *.pyc
 *.user
 *~
-.*.swp
-.DS_Store
-.sw[a-z]
 tags
 tegra/
-.cache


### PR DESCRIPTION
ignore all "dot" files/directories by default.
'ignored' files can be added via 'git add -f' command if necessary.

Backport #10037