### PR TITLE
java/CMakeLists: Fix build error with OpenEmbedded

### DIFF
--- a/modules/java/CMakeLists.txt
+++ b/modules/java/CMakeLists.txt
@@ -291,7 +291,7 @@ foreach(java_file ${step3_input_files})
   endif()
   if(__configure)
     configure_file("${java_file}" "${java_src_dir}/${output_name}" @ONLY)
-  elseif(NOT "${java_file}" MATCHES "${OpenCV_BINARY_DIR}/")
+  elseif(EXISTS "${java_file}" AND NOT "${java_file}" MATCHES "${OpenCV_BINARY_DIR}/")
     configure_file("${java_file}" "${java_src_dir}/${output_name}" COPYONLY)
   else()
     add_custom_command(OUTPUT "${java_src_dir}/${output_name}"


### PR DESCRIPTION
Latest OE version fails to build the java module with a bunch of this error:

| CMake Error: File /home/ricardo/curro/qt5022/build-qt5022-open/build/tmp/work/bobcat_64-poky-linux/opencv/3.3+gitAUTOINC+87c27a074d_2a9d1b22ed_a62e20676a_34e4206aef_fccf7cd6a4-r0/build/modules/java/gen/core+Core.java does not exist.
| CMake Error at modules/java/CMakeLists.txt:295 (configure_file):
|   configure_file Problem configuring file

This patch makes sure that the .java file exists before copying it
(otherwise it is generated).

Signed-off-by: Ricardo Ribalda Delgado <ricardo.ribalda@gmail.com>

<!-- Please use this line to close one or multiple issues when this pullrequest gets merged
You can add another line right under the first one:
resolves #1234
resolves #1235
-->

### This pullrequest changes

<!-- Please describe what your pullrequest is changing -->
