### PR TITLE
HoughCircles rewritten (PR #7434 updated)

### DIFF
--- a/modules/imgproc/include/opencv2/imgproc.hpp
+++ b/modules/imgproc/include/opencv2/imgproc.hpp
@@ -2090,7 +2090,7 @@ Example: :
 
 @note Usually the function detects the centers of circles well. However, it may fail to find correct
 radii. You can assist to the function by specifying the radius range ( minRadius and maxRadius ) if
-you know it. Or, you may ignore the returned radius, use only the center, and find the correct
+you know it. Or, you may set maxRadius to 0 to return centers only without radius search, and find the correct
 radius using an additional procedure.
 
 @param image 8-bit, single-channel, grayscale input image.

--- a/modules/imgproc/src/hough.cpp
+++ b/modules/imgproc/src/hough.cpp
@@ -58,7 +58,7 @@ struct LinePolar
 struct hough_cmp_gt
 {
     hough_cmp_gt(const int* _aux) : aux(_aux) {}
-    bool operator()(int l1, int l2) const
+    inline bool operator()(int l1, int l2) const
     {
         return aux[l1] > aux[l2] || (aux[l1] == aux[l2] && l1 < l2);
     }
@@ -844,11 +844,9 @@ static bool ocl_HoughLinesP(InputArray _src, OutputArray _lines, double rho, dou
 
 #endif /* HAVE_OPENCL */
 
-}
-
-void cv::HoughLines( InputArray _image, OutputArray _lines,
-                    double rho, double theta, int threshold,
-                    double srn, double stn, double min_theta, double max_theta )
+void HoughLines( InputArray _image, OutputArray _lines,
+                 double rho, double theta, int threshold,
+                 double srn, double stn, double min_theta, double max_theta )
 {
     CV_INSTRUMENT_REGION()
 
@@ -867,9 +865,9 @@ void cv::HoughLines( InputArray _image, OutputArray _lines,
 }
 
 
-void cv::HoughLinesP(InputArray _image, OutputArray _lines,
-                     double rho, double theta, int threshold,
-                     double minLineLength, double maxGap )
+void HoughLinesP(InputArray _image, OutputArray _lines,
+                 double rho, double theta, int threshold,
+                 double minLineLength, double maxGap )
 {
     CV_INSTRUMENT_REGION()
 
@@ -882,6 +880,746 @@ void cv::HoughLinesP(InputArray _image, OutputArray _lines,
     Mat(lines).copyTo(_lines);
 }
 
+/****************************************************************************************\
+*                                     Circle Detection                                   *
+\****************************************************************************************/
+struct markedCircle
+{
+    markedCircle(Vec3f _c, int _idx, int _idxC) :
+        c(_c), idx(_idx), idxC(_idxC) {}
+    Vec3f c;
+    int idx, idxC;
+};
+
+inline bool cmpCircleIndex(const markedCircle &left, const markedCircle &right)
+{
+    return left.idx > right.idx;
+}
+
+class HoughCirclesAccumInvoker : public ParallelLoopBody
+{
+public:
+    HoughCirclesAccumInvoker(const Mat &_edges, const Mat &_dx, const Mat &_dy, Mat &_accum, Seq<Point> &_nz,
+                             int _minRadius, int _maxRadius, float _idp) :
+        edges(_edges), dx(_dx), dy(_dy), accum(_accum), nz(_nz), minRadius(_minRadius), maxRadius(_maxRadius), idp(_idp)
+    {
+        acols = cvCeil(edges.cols * idp), arows = cvCeil(edges.rows * idp);
+        astep = acols + 2;
+        nz.clear();
+#if CV_SIMD128
+        haveSIMD = checkHardwareSupport(CPU_SSE2) || checkHardwareSupport(CPU_NEON);
+#endif
+    }
+
+    ~HoughCirclesAccumInvoker() {}
+
+    HoughCirclesAccumInvoker& operator=(const HoughCirclesAccumInvoker&) {return *this;}
+
+    void operator()(const cv::Range &boundaries) const
+    {
+        Mat accumLocal = Mat(arows + 2, acols + 2, CV_32SC1, Scalar::all(0));
+        int *adataLocal = accumLocal.ptr<int>();
+        MemStorage storage;
+        Seq<Point> nzLocal;
+        int endRow = boundaries.end;
+        int numCols = edges.cols;
+        bool singleThread = (boundaries == Range(0, edges.rows));
+
+        if (singleThread)
+            nzLocal = nz;
+        else
+        {
+            storage = MemStorage(cvCreateMemStorage(0));
+            nzLocal = Seq<Point>(storage);
+        }
+
+        if(edges.isContinuous() && dx.isContinuous() && dy.isContinuous())
+        {
+            numCols *= (boundaries.end - boundaries.start);
+            endRow = boundaries.start + 1;
+        }
+
+        // Accumulate circle evidence for each edge pixel
+        for(int y = boundaries.start; y < endRow; ++y )
+        {
+            const uchar* edgeData = edges.ptr<const uchar>(y);
+            const short* dxData = dx.ptr<const short>(y);
+            const short* dyData = dy.ptr<const short>(y);
+            int x = 0;
+
+            for(; x < numCols; ++x )
+            {
+#if CV_SIMD128
+                if(haveSIMD) {
+                    v_uint8x16 v_zero = v_setzero_u8();
+
+                    for(; x <= numCols - 32; x += 32) {
+                        v_uint8x16 v_edge1 = v_load(edgeData + x);
+                        v_uint8x16 v_edge2 = v_load(edgeData + x + 16);
+
+                        v_uint8x16 v_cmp1 = (v_edge1 == v_zero);
+                        v_uint8x16 v_cmp2 = (v_edge2 == v_zero);
+
+                        unsigned int mask1 = v_signmask(v_cmp1);
+                        unsigned int mask2 = v_signmask(v_cmp2);
+
+                        mask1 ^= 0x0000ffff;
+                        mask2 ^= 0x0000ffff;
+
+                        if(mask1)
+                        {
+                            x += trailingZeros32(mask1);
+                            goto _next_step;
+                        }
+
+                        if(mask2)
+                        {
+                            x += trailingZeros32(mask2 << 16);
+                            goto _next_step;
+                        }
+                    }
+                }
+#endif
+                for(; x < numCols && !edgeData[x]; ++x)
+                    ;
+
+                if(x == numCols)
+                    continue;
+#if CV_SIMD128
+_next_step:
+#endif
+                float vx, vy;
+                int sx, sy, x0, y0, x1, y1;
+
+                vx = dxData[x];
+                vy = dyData[x];
+
+                if(vx == 0 && vy == 0)
+                    continue;
+
+                float mag = std::sqrt(vx*vx+vy*vy);
+
+                if(mag < 1.0f)
+                    continue;
+
+                Point pt = Point(x % edges.cols, y + x / edges.cols);
+                nzLocal.push_back(pt);
+
+                sx = cvRound((vx * idp) * 1024 / mag);
+                sy = cvRound((vy * idp) * 1024 / mag);
+
+                x0 = cvRound((pt.x * idp) * 1024);
+                y0 = cvRound((pt.y * idp) * 1024);
+
+                // Step from min_radius to max_radius in both directions of the gradient
+                for(int k1 = 0; k1 < 2; k1++ )
+                {
+                    x1 = x0 + minRadius * sx;
+                    y1 = y0 + minRadius * sy;
+
+                    for(int r = minRadius; r <= maxRadius; x1 += sx, y1 += sy, r++ )
+                    {
+                        int x2 = x1 >> 10, y2 = y1 >> 10;
+                        if( (unsigned)x2 >= (unsigned)acols ||
+                                (unsigned)y2 >= (unsigned)arows )
+                            break;
+
+                        adataLocal[y2*astep + x2]++;
+                    }
+
+                    sx = -sx; sy = -sy;
+                }
+            }
+        }
+
+        if (singleThread)
+            accum = accumLocal;
+        else
+        {
+            std::vector<Point> tmp;
+            nzLocal.copyTo(tmp);
+
+            AutoLock lock(_lock);
+            if(accum.empty())
+            {
+                accum = accumLocal;
+                nz.push_back(&tmp[0], tmp.size());
+            }
+            else
+            {
+                add(accum, accumLocal, accum);
+                nz.push_back(&tmp[0], tmp.size());
+            }
+        }
+    }
+
+private:
+    const Mat &edges, &dx, &dy;
+    Mat &accum;
+    Seq<Point> &nz;
+    int minRadius, maxRadius;
+    float idp;
+
+    int acols, arows, astep;
+#if CV_SIMD128
+    bool haveSIMD;
+#endif
+
+    mutable Mutex _lock;
+};
+
+class HoughCirclesFindCentersInvoker : public ParallelLoopBody
+{
+public:
+    HoughCirclesFindCentersInvoker(const Mat &_accum, Seq<int> &_centers, int _accThreshold) :
+        accum(_accum), centers(_centers), accThreshold(_accThreshold)
+    {
+        acols = accum.cols;
+        arows = accum.rows;
+        adata = accum.ptr<int>();
+        centers.clear();
+    }
+
+    ~HoughCirclesFindCentersInvoker() {}
+
+    HoughCirclesFindCentersInvoker& operator=(const HoughCirclesFindCentersInvoker&) {return *this;}
+
+    void operator()(const cv::Range &boundaries) const
+    {
+        int startRow = boundaries.start;
+        int endRow = boundaries.end;
+        MemStorage storage;
+        Seq<int> centersLocal;
+        bool singleThread = (boundaries == Range(1, accum.rows - 1));
+
+        if (singleThread)
+            centersLocal = centers;
+        else
+        {
+            storage = MemStorage(cvCreateMemStorage(0));
+            centersLocal = Seq<int>(storage);
+        }
+
+        startRow = max(1, startRow);
+        endRow = min(arows - 1, endRow);
+
+        //Find possible circle centers
+        for(int y = startRow; y < endRow; ++y )
+        {
+            int x = 1;
+            int base = y * acols + x;
+
+            for(; x < acols - 1; ++x, ++base )
+            {
+                if( adata[base] > accThreshold &&
+                        adata[base] > adata[base-1] && adata[base] > adata[base+1] &&
+                        adata[base] > adata[base-acols] && adata[base] > adata[base+acols] )
+                    centersLocal.push_back(base);
+            }
+        }
+
+        if (!singleThread && !centersLocal.empty())
+        {
+            std::vector<int> tmp;
+            centersLocal.copyTo(tmp);
+
+            AutoLock alock(_lock);
+            centers.push_back(&tmp[0], tmp.size());
+        }
+    }
+
+private:
+    const Mat &accum;
+    Seq<int> &centers;
+    int accThreshold;
+
+    int acols, arows;
+    const int *adata;
+    mutable Mutex _lock;
+};
+
+class HoughCircleEstimateRadiusInvoker : public ParallelLoopBody
+{
+public:
+    HoughCircleEstimateRadiusInvoker(const Seq<Point> &_nz, Seq<int> &_centers, Seq<Vec3f> &_circles,
+                                     int _acols, int _circlesMax, int _accThreshold, int _minRadius, int _maxRadius,
+                                     float _minDist, float _dp) :
+        nz(_nz), centers(_centers), circles(_circles), acols(_acols), circlesMax(_circlesMax), accThreshold(_accThreshold),
+        minRadius(_minRadius), maxRadius(_maxRadius), minDist(_minDist), dr(_dp)
+    {
+        minRadius2 = (float)minRadius * minRadius;
+        maxRadius2 = (float)maxRadius * maxRadius;
+        minDist = std::max(dr, minDist);
+        minDist *= minDist;
+        nzSz = (int)nz.size();
+        centerSz = (int)centers.size();
+
+        iMax = -1;
+        isMaxCircles = false;
+        isLastCenter = false;
+        mc.reserve(64);
+        loopIdx = std::vector<bool>(centerSz + 1, false);
+#if CV_SSE2
+        haveSIMD = checkHardwareSupport(CPU_SSE2); // || checkHardwareSupport(CPU_NEON);
+        if(haveSIMD)
+        {
+            //                v_minRadius2 = v_setall_f32(minRadius2);
+            //                v_maxRadius2 = v_setall_f32(maxRadius2);
+            v_minRadius2 = _mm_load1_ps(&minRadius2);
+            v_maxRadius2 = _mm_load1_ps(&maxRadius2);
+        }
+#endif
+    }
+
+    ~HoughCircleEstimateRadiusInvoker() {_lock.unlock();}
+
+    HoughCircleEstimateRadiusInvoker& operator=(const HoughCircleEstimateRadiusInvoker&) {return *this;}
+
+    void operator()(const cv::Range &boundaries) const
+    {
+        if (isMaxCircles)
+            return;
+
+        Mat distBuf, distSqrBuf;
+        bool singleThread = (boundaries == Range(0, centerSz));
+        int i = boundaries.start;
+
+        if(boundaries.end == centerSz)
+            isLastCenter = true;
+
+        // For each found possible center
+        // Estimate radius and check support
+        for(; i < boundaries.end; ++i)
+        {
+            if (isMaxCircles)
+                return;
+
+            int ofs = centers[i];
+            int y = ofs / acols;
+            int x = ofs - y * acols;
+
+            //Calculate circle's center in pixels
+            Point2f curCenter = Point2f((x + 0.5f) * dr, (y + 0.5f) * dr);
+            float startDist, rBest = 0;
+            float *ddata = NULL, *dSqrData = NULL;
+            int maxCount = 0, j = 0, k = 0, nzCnt, startIdx;
+
+            // Check distance with previously detected valid circles
+            int curCircleSz = (int)circles.size();
+            bool valid = checkDistance(curCenter, 0, curCircleSz);
+
+            if (isMaxCircles)
+                return;
+
+            if(!valid)
+                goto _next;
+
+            distBuf.create(1, nzSz, CV_32FC1);
+            ddata = distBuf.ptr<float>();
+#if CV_SSE2
+            if(haveSIMD)
+            {
+                //                    v_float32x4 v_curCenterX = v_setall_f32(curCenter.x);
+                //                    v_float32x4 v_curCenterY = v_setall_f32(curCenter.y);
+                __m128 v_curCenter = _mm_castsi128_ps(_mm_loadl_epi64((const __m128i*)&curCenter));
+                v_curCenter = _mm_shuffle_ps(v_curCenter, v_curCenter, _MM_SHUFFLE(1, 0, 1, 0));
+
+                for(; j <= nzSz - 4; j += 4)
+                {
+                    // nz storage block has to be a multiple of 8! not good...
+                    //                        v_float32x4 v_nzX, v_nzY;
+                    //                        v_load_deinterleave((const float*)&nz[j], v_nzX, v_nzY);
+                    // nz storage block has to be a multiple of 4
+                    __m128i v_nz1 = _mm_loadu_si128((const __m128i*)&nz[j]);
+                    __m128i v_nz2 = _mm_loadu_si128((const __m128i*)&nz[j + 2]);
+
+                    //                        v_float32x4 v_x = v_cvt_f32(v_reinterpret_as_s32(v_nzX));
+                    //                        v_float32x4 v_y = v_cvt_f32(v_reinterpret_as_s32(v_nzY));
+                    __m128 v_tmp1 = _mm_cvtepi32_ps(v_nz1);
+                    __m128 v_tmp2 = _mm_cvtepi32_ps(v_nz2);
+
+                    //                        v_x = v_x - v_curCenterX;
+                    //                        v_y = v_y - v_curCenterY;
+                    v_tmp1 = _mm_sub_ps(v_tmp1, v_curCenter);
+                    v_tmp2 = _mm_sub_ps(v_tmp2, v_curCenter);
+
+                    // no shuffle found...
+                    __m128 v_x = _mm_shuffle_ps(v_tmp1, v_tmp2, _MM_SHUFFLE(2, 0, 2, 0));
+                    __m128 v_y = _mm_shuffle_ps(v_tmp1, v_tmp2, _MM_SHUFFLE(3, 1, 3, 1));
+
+                    //                        v_x = (v_x * v_x) + (v_y * v_y);
+                    v_tmp1 = _mm_add_ps(_mm_mul_ps(v_x, v_x), _mm_mul_ps(v_y, v_y));
+
+                    //                        v_y = (v_minRadius2 <= v_x) & (v_x <= v_maxRadius2);
+                    v_tmp2 = _mm_and_ps(_mm_cmple_ps(v_minRadius2, v_tmp1), _mm_cmple_ps(v_tmp1, v_maxRadius2));
+
+                    //                        unsigned int mask = v_signmask(v_y);
+                    unsigned int mask = _mm_movemask_epi8(_mm_castps_si128(v_tmp2));
+
+                    if(mask)
+                    {
+                        if(mask == 0x0000ffff)
+                        {
+                            //                                v_store(ddata + k, v_x);
+                            _mm_storeu_ps((ddata + k), v_tmp1);
+                            k += 4;
+                            continue;
+                        }
+                        else if((mask & 0x000000ff) == 0x000000ff)
+                        {
+                            //                                v_store_low(ddata + k, v_x);
+                            //                                v_x = v_reinterpret_as_f32( v_reinterpret_as_u8(v_x) >> 8);
+                            _mm_storel_pd((double*)(ddata + k), _mm_castps_pd(v_tmp1));
+                            v_tmp1 = _mm_castsi128_ps(_mm_srli_si128(_mm_castps_si128(v_tmp1), 8));
+                            k += 2;
+                            mask >>= 8;
+                        }
+                        else if((mask & 0x0000ff00) == 0x0000ff00)
+                        {
+                            //                                v_store_high(ddata + k, v_x);
+                            _mm_storeh_pd((double*)(ddata + k), _mm_castps_pd(v_tmp1));
+                            k += 2;
+                            mask ^= 0x0000ff00;
+                        }
+
+                        while(mask)
+                        {
+                            if(mask & 0x00000001)
+                            {
+                                //                                    ddata[k] = v_x.get0();
+                                ddata[k] = _mm_cvtss_f32(v_tmp1);
+                                ++k;
+                            }
+                            //                                v_x = v_reinterpret_as_f32( v_reinterpret_as_s8(v_x) >> 4);
+                            v_tmp1 = _mm_castsi128_ps(_mm_srli_si128(_mm_castps_si128(v_tmp1), 4));
+                            mask >>= 4;
+                        }
+                    }
+                }
+            }
+#endif
+            // Estimate best radius
+            for(; j < nzSz; ++j)
+            {
+                Point pt = nz[j];
+                float _dx = curCenter.x - pt.x, _dy = curCenter.y - pt.y;
+                float _r2 = _dx * _dx + _dy * _dy;
+
+                if(minRadius2 <= _r2 && _r2 <= maxRadius2)
+                {
+                    ddata[k] = _r2;
+                    ++k;
+                }
+            }
+
+            if (isMaxCircles)
+                return;
+
+            nzCnt = k, startIdx = k - 1;
+
+            if(!nzCnt)
+                goto _next;
+
+            pow(distBuf.colRange(Range(0, nzCnt)), 0.5, distSqrBuf);
+
+            // Sort non-zero pixels according to their distance from the center.
+            sort(distSqrBuf, distSqrBuf, SORT_ASCENDING | SORT_EVERY_ROW);
+            flip(distSqrBuf, distSqrBuf, 1);
+            dSqrData = distSqrBuf.ptr<float>();
+
+            if (isMaxCircles)
+                return;
+
+            startDist = dSqrData[startIdx];
+            for(j = nzCnt - 2; j >= 0; --j)
+            {
+                float d = dSqrData[j];
+
+                if( d - startDist > dr )
+                {
+                    float rCur = dSqrData[(j + startIdx) / 2];
+                    if( (startIdx - j) * rBest >= maxCount * rCur ||
+                            (rBest < FLT_EPSILON && startIdx - j >= maxCount) )
+                    {
+                        rBest = rCur;
+                        maxCount = startIdx - j;
+                    }
+                    startDist = d;
+                    startIdx = j;
+                }
+            }
+
+_next:
+            if(singleThread)
+            {
+                // Check if the circle has enough support
+                if(maxCount > accThreshold)
+                {
+                    circles.push_back(Vec3f(curCenter.x, curCenter.y, rBest));
+
+                    if( circles.size() >= (unsigned int)circlesMax )
+                        return;
+                }
+            }
+            else
+            {
+                _lock.lock();
+                if(isMaxCircles)
+                {
+                    _lock.unlock();
+                    return;
+                }
+
+                loopIdx[i] = true;
+
+                if( maxCount > accThreshold )
+                {
+                    while(loopIdx[iMax + 1])
+                        ++iMax;
+
+                    // Temporary store circle, index and already checked index for block wise testing
+                    mc.push_back(markedCircle(Vec3f(curCenter.x, curCenter.y, rBest),
+                                              i, curCircleSz));
+
+                    if(i <= iMax)
+                    {
+                        std::sort(mc.begin(), mc.end(), cmpCircleIndex);
+                        for(k = (int)mc.size() - 1; k >= 0; --k)
+                        {
+                            if(mc[k].idx <= iMax)
+                            {
+                                if(checkDistance(Point2f(mc[k].c[0], mc[k].c[1]),
+                                                 mc[k].idxC, (int)circles.size()))
+                                {
+                                    circles.push_back(mc[k].c);
+                                    if(circles.size() >= (unsigned int)circlesMax)
+                                    {
+                                        isMaxCircles = true;
+                                        _lock.unlock();
+                                        return;
+                                    }
+                                }
+                                mc.pop_back();
+                            }
+                            else
+                                break;
+                        }
+                    }
+                }
+
+                if(isLastCenter && !mc.empty())
+                {
+                    while(loopIdx[iMax + 1])
+                        ++iMax;
+
+                    if(iMax == centerSz - 1)
+                    {
+                        std::sort(mc.begin(), mc.end(), cmpCircleIndex);
+                        for(k = (int)mc.size() - 1; k >= 0; --k)
+                        {
+                            if(checkDistance(Point2f(mc[k].c[0], mc[k].c[1]), mc[k].idxC, (int)circles.size()))
+                            {
+                                circles.push_back(mc[k].c);
+                                if(circles.size() >= (unsigned int)circlesMax)
+                                {
+                                    isMaxCircles = true;
+                                    _lock.unlock();
+                                    return;
+                                }
+                            }
+                        }
+                    }
+                }
+                _lock.unlock();
+            }
+        }
+    }
+
+private:
+    bool checkDistance(Point2f curCenter, int startIdx, int endIdx) const
+    {
+        // Check distance with previously detected circles
+        for(int j = startIdx; j < endIdx; ++j )
+        {
+            float dx = circles[j][0] - curCenter.x;
+            float dy = circles[j][1] - curCenter.y;
+
+            if( dx * dx + dy * dy < minDist )
+                return false;
+        }
+        return true;
+    }
+
+    const Seq<Point> &nz;
+    Seq<int> &centers;
+    Seq<Vec3f> &circles;
+    int acols, circlesMax, accThreshold, minRadius, maxRadius;
+    float minDist, dr;
+
+#if CV_SSE2
+    bool haveSIMD;
+    //        v_float32x4 v_minRadius2, v_maxRadius2;
+    __m128 v_minRadius2, v_maxRadius2;
+#endif
+    int nzSz, centerSz;
+    float minRadius2, maxRadius2;
+
+    mutable std::vector<bool> loopIdx;
+    mutable std::vector<markedCircle> mc;
+    mutable volatile int iMax;
+    mutable volatile bool isMaxCircles, isLastCenter;
+    mutable Mutex _lock;
+};
+
+static void HoughCirclesGradient(InputArray _image, OutputArray _circles, float dp, float minDist,
+                                 int minRadius, int maxRadius, int cannyThreshold,
+                                 int accThreshold, int maxCircles, int kernelSize )
+{
+    CV_Assert(kernelSize == -1 || kernelSize == 3 || kernelSize == 5 || kernelSize == 7);
+
+    Mat accum;
+    //        UMat edges, dx, dy;
+    Mat edges, dx, dy;
+
+    MemStorage storage(cvCreateMemStorage(0));
+    Seq<Point> nz(storage);
+    int numberOfThreads = 1;
+    int numThreads = std::max(1, std::min(getNumThreads(), getNumberOfCPUs()));
+
+    Sobel(_image, dx, CV_16S, 1, 0, kernelSize, 1, 0, BORDER_REPLICATE);
+    Sobel(_image, dy, CV_16S, 0, 1, kernelSize, 1, 0, BORDER_REPLICATE);
+    Canny(dx, dy, edges, std::max(1, cannyThreshold / 2), cannyThreshold, false);
+
+    // Max 2 threads as long as no thread safe container exists, otherwise adding accum at the end has a huge overhead
+    // 1 Thread overhead is 0, 2 Threads if (maxRadius - minRadius) is large and cost is more than add accum
+    if(maxRadius - minRadius > 32)
+        numberOfThreads = std::max(1, std::min(numThreads, 2));
+
+    //        parallel_for_(Range(0, edges.rows),
+    //                      HoughCirclesAccumInvoker(edges.getMat(ACCESS_READ), dx.getMat(ACCESS_READ), dy.getMat(ACCESS_READ),
+    //                                               accum, nz, minRadius, maxRadius, dp),
+    //                      numberOfThreads);
+    parallel_for_(Range(0, edges.rows),
+                  HoughCirclesAccumInvoker(edges, dx, dy,
+                                           accum, nz, minRadius, maxRadius, dp),
+                  numberOfThreads);
+
+    if(nz.empty())
+        return;
+
+    Seq<int> centers(storage);
+
+    // 4 rows when multithreaded because there is a bit overhead
+    // and on the other side there are some row ranges where centers are concentrated
+    numberOfThreads = (numThreads > 1) ? ((accum.rows - 2) / 4) : 1;
+
+    parallel_for_(Range(1, accum.rows - 1),
+                  HoughCirclesFindCentersInvoker(accum, centers, accThreshold),
+                  numberOfThreads);
+
+    int centerCnt = (int)centers.size();
+    if(centerCnt == 0)
+        return;
+
+    std::vector<int> sortBuffer;
+    centers.copyTo(sortBuffer);
+    std::sort(sortBuffer.begin(), sortBuffer.begin() + centers.size(), hough_cmp_gt(accum.ptr<int>()));
+    centers.clear();
+    centers.push_back((int*)&sortBuffer[0], sortBuffer.size());
+
+    Seq<Vec3f> circles(storage);
+
+    if(maxCircles == 0)
+    {
+        minDist *= minDist;
+        for(int i = 0; i < centerCnt; ++i)
+        {
+            int _centers = centers[i];
+            int y = _centers / accum.cols;
+            int x = _centers - y * accum.cols;
+
+            for(uint j = 0; j < circles.size(); ++j)
+            {
+                Vec3f pt = circles[j];
+                float distX = x - pt[0], distY = y - pt[1];
+                if (distX * distX + distY * distY < minDist)
+                    goto _skip;
+            }
+
+            circles.push_back(Vec3f((x + 0.5f) * dp, (y + 0.5f) * dp, 0));
+_skip: ;
+        }
+
+        _circles.create(1, (int)circles.size(), CV_32FC3, -1, true);
+        Mat circ = _circles.getMat();
+        cvCvtSeqToArray(circles.seq, circ.ptr());
+        return;
+    }
+
+    numberOfThreads = (numThreads > 1) ? centerCnt : 1;
+
+    // One loop iteration per thread if multithreaded.
+    parallel_for_(Range(0, centerCnt),
+                  HoughCircleEstimateRadiusInvoker(nz, centers, circles, accum.cols, maxCircles,
+                                                   accThreshold, minRadius, maxRadius, minDist, dp),
+                  numberOfThreads);
+
+    if (!circles.empty())
+    {
+        _circles.create(1, (int)circles.size(), CV_32FC3, -1, true);
+        Mat circ = _circles.getMat();
+        cvCvtSeqToArray(circles.seq, circ.ptr());
+    } else
+        _circles.release();
+}
+
+void HoughCircles( InputArray _image, OutputArray _circles,
+                   int method, double dp, double minDist,
+                   double param1, double param2,
+                   int minRadius, int maxRadius,
+                   int maxCircles, double param3 )
+{
+    CV_INSTRUMENT_REGION()
+
+    CV_Assert(!_image.empty() && _image.type() == CV_8UC1 && (_image.isMat() || _image.isUMat()));
+    CV_Assert(_circles.isMat() || _circles.isVector());
+
+    if( dp <= 0 || minDist <= 0 || param1 <= 0 || param2 <= 0)
+        CV_Error( CV_StsOutOfRange, "dp, min_dist, canny_threshold and acc_threshold must be all positive numbers" );
+
+    int cannyThresh = cvRound(param1), accThresh = cvRound(param2), kernelSize = cvRound(param3);
+
+    minRadius = std::max(0, minRadius);
+
+    if(maxCircles < 0)
+        maxCircles = INT_MAX;
+
+    if( maxRadius <= 0 )
+        maxRadius = std::max( _image.rows(), _image.cols() );
+    else if( maxRadius <= minRadius )
+        maxRadius = minRadius + 2;
+
+    switch( method )
+    {
+    case CV_HOUGH_GRADIENT:
+        HoughCirclesGradient(_image, _circles, (float)dp, (float)minDist,
+                             minRadius, maxRadius, cannyThresh,
+                             accThresh, maxCircles, kernelSize);
+        break;
+    default:
+        CV_Error( CV_StsBadArg, "Unrecognized method id. Actually only CV_HOUGH_GRADIENT is supported." );
+    }
+}
+
+void HoughCircles( InputArray _image, OutputArray _circles,
+                   int method, double dp, double minDist,
+                   double param1, double param2,
+                   int minRadius, int maxRadius )
+{
+    HoughCircles(_image, _circles, method, dp, minDist, param1, param2, minRadius, maxRadius, -1, 3);
+}
+
+} // \namespace cv
 
 
 /* Wrapper function for standard hough transform */
@@ -997,260 +1735,18 @@ cvHoughLines2( CvArr* src_image, void* lineStorage, int method,
 }
 
 
-/****************************************************************************************\
-*                                     Circle Detection                                   *
-\****************************************************************************************/
-
-static void
-icvHoughCirclesGradient( CvMat* img, float dp, float min_dist,
-                         int min_radius, int max_radius,
-                         int canny_threshold, int acc_threshold,
-                         CvSeq* circles, int circles_max )
-{
-    const int SHIFT = 10, ONE = 1 << SHIFT;
-    cv::Ptr<CvMat> dx, dy;
-    cv::Ptr<CvMat> edges, accum, dist_buf;
-    std::vector<int> sort_buf;
-    cv::Ptr<CvMemStorage> storage;
-
-    int x, y, i, j, k, center_count, nz_count;
-    float min_radius2 = (float)min_radius*min_radius;
-    float max_radius2 = (float)max_radius*max_radius;
-    int rows, cols, arows, acols;
-    int astep, *adata;
-    float* ddata;
-    CvSeq *nz, *centers;
-    float idp, dr;
-    CvSeqReader reader;
-
-    edges.reset(cvCreateMat( img->rows, img->cols, CV_8UC1 ));
-
-    // Use the Canny Edge Detector to detect all the edges in the image.
-    cvCanny( img, edges, MAX(canny_threshold/2,1), canny_threshold, 3 );
-
-    dx.reset(cvCreateMat( img->rows, img->cols, CV_16SC1 ));
-    dy.reset(cvCreateMat( img->rows, img->cols, CV_16SC1 ));
-
-    /*Use the Sobel Derivative to compute the local gradient of all the non-zero pixels in the edge image.*/
-    cvSobel( img, dx, 1, 0, 3 );
-    cvSobel( img, dy, 0, 1, 3 );
-
-    if( dp < 1.f )
-        dp = 1.f;
-    idp = 1.f/dp;
-    accum.reset(cvCreateMat( cvCeil(img->rows*idp)+2, cvCeil(img->cols*idp)+2, CV_32SC1 ));
-    cvZero(accum);
-
-    storage.reset(cvCreateMemStorage());
-    /* Create sequences for the nonzero pixels in the edge image and the centers of circles
-    which could be detected.*/
-    nz = cvCreateSeq( CV_32SC2, sizeof(CvSeq), sizeof(CvPoint), storage );
-    centers = cvCreateSeq( CV_32SC1, sizeof(CvSeq), sizeof(int), storage );
-
-    rows = img->rows;
-    cols = img->cols;
-    arows = accum->rows - 2;
-    acols = accum->cols - 2;
-    adata = accum->data.i;
-    astep = accum->step/sizeof(adata[0]);
-    // Accumulate circle evidence for each edge pixel
-    for( y = 0; y < rows; y++ )
-    {
-        const uchar* edges_row = edges->data.ptr + y*edges->step;
-        const short* dx_row = (const short*)(dx->data.ptr + y*dx->step);
-        const short* dy_row = (const short*)(dy->data.ptr + y*dy->step);
-
-        for( x = 0; x < cols; x++ )
-        {
-            float vx, vy;
-            int sx, sy, x0, y0, x1, y1, r;
-            CvPoint pt;
-
-            vx = dx_row[x];
-            vy = dy_row[x];
-
-            if( !edges_row[x] || (vx == 0 && vy == 0) )
-                continue;
-
-            float mag = std::sqrt(vx*vx+vy*vy);
-            assert( mag >= 1 );
-            sx = cvRound((vx*idp)*ONE/mag);
-            sy = cvRound((vy*idp)*ONE/mag);
-
-            x0 = cvRound((x*idp)*ONE);
-            y0 = cvRound((y*idp)*ONE);
-            // Step from min_radius to max_radius in both directions of the gradient
-            for(int k1 = 0; k1 < 2; k1++ )
-            {
-                x1 = x0 + min_radius * sx;
-                y1 = y0 + min_radius * sy;
-
-                for( r = min_radius; r <= max_radius; x1 += sx, y1 += sy, r++ )
-                {
-                    int x2 = x1 >> SHIFT, y2 = y1 >> SHIFT;
-                    if( (unsigned)x2 >= (unsigned)acols ||
-                        (unsigned)y2 >= (unsigned)arows )
-                        break;
-                    adata[y2*astep + x2]++;
-                }
-
-                sx = -sx; sy = -sy;
-            }
-
-            pt.x = x; pt.y = y;
-            cvSeqPush( nz, &pt );
-        }
-    }
-
-    nz_count = nz->total;
-    if( !nz_count )
-        return;
-    //Find possible circle centers
-    for( y = 1; y < arows - 1; y++ )
-    {
-        for( x = 1; x < acols - 1; x++ )
-        {
-            int base = y*(acols+2) + x;
-            if( adata[base] > acc_threshold &&
-                adata[base] > adata[base-1] && adata[base] >= adata[base+1] &&
-                adata[base] > adata[base-acols-2] && adata[base] >= adata[base+acols+2] )
-                cvSeqPush(centers, &base);
-        }
-    }
-
-    center_count = centers->total;
-    if( !center_count )
-        return;
-
-    sort_buf.resize( MAX(center_count,nz_count) );
-    cvCvtSeqToArray( centers, &sort_buf[0] );
-    /*Sort candidate centers in descending order of their accumulator values, so that the centers
-    with the most supporting pixels appear first.*/
-    std::sort(sort_buf.begin(), sort_buf.begin() + center_count, cv::hough_cmp_gt(adata));
-    cvClearSeq( centers );
-    cvSeqPushMulti( centers, &sort_buf[0], center_count );
-
-    dist_buf.reset(cvCreateMat( 1, nz_count, CV_32FC1 ));
-    ddata = dist_buf->data.fl;
-
-    dr = dp;
-    min_dist = MAX( min_dist, dp );
-    min_dist *= min_dist;
-    // For each found possible center
-    // Estimate radius and check support
-    for( i = 0; i < centers->total; i++ )
-    {
-        int ofs = *(int*)cvGetSeqElem( centers, i );
-        y = ofs/(acols+2);
-        x = ofs - (y)*(acols+2);
-        //Calculate circle's center in pixels
-        float cx = (float)((x + 0.5f)*dp), cy = (float)(( y + 0.5f )*dp);
-        float start_dist, dist_sum;
-        float r_best = 0;
-        int max_count = 0;
-        // Check distance with previously detected circles
-        for( j = 0; j < circles->total; j++ )
-        {
-            float* c = (float*)cvGetSeqElem( circles, j );
-            if( (c[0] - cx)*(c[0] - cx) + (c[1] - cy)*(c[1] - cy) < min_dist )
-                break;
-        }
-
-        if( j < circles->total )
-            continue;
-        // Estimate best radius
-        cvStartReadSeq( nz, &reader );
-        for( j = k = 0; j < nz_count; j++ )
-        {
-            CvPoint pt;
-            float _dx, _dy, _r2;
-            CV_READ_SEQ_ELEM( pt, reader );
-            _dx = cx - pt.x; _dy = cy - pt.y;
-            _r2 = _dx*_dx + _dy*_dy;
-            if(min_radius2 <= _r2 && _r2 <= max_radius2 )
-            {
-                ddata[k] = _r2;
-                sort_buf[k] = k;
-                k++;
-            }
-        }
-
-        int nz_count1 = k, start_idx = nz_count1 - 1;
-        if( nz_count1 == 0 )
-            continue;
-        dist_buf->cols = nz_count1;
-        cvPow( dist_buf, dist_buf, 0.5 );
-        // Sort non-zero pixels according to their distance from the center.
-        std::sort(sort_buf.begin(), sort_buf.begin() + nz_count1, cv::hough_cmp_gt((int*)ddata));
-
-        dist_sum = start_dist = ddata[sort_buf[nz_count1-1]];
-        for( j = nz_count1 - 2; j >= 0; j-- )
-        {
-            float d = ddata[sort_buf[j]];
-
-            if( d > max_radius )
-                break;
-
-            if( d - start_dist > dr )
-            {
-                float r_cur = ddata[sort_buf[(j + start_idx)/2]];
-                if( (start_idx - j)*r_best >= max_count*r_cur ||
-                    (r_best < FLT_EPSILON && start_idx - j >= max_count) )
-                {
-                    r_best = r_cur;
-                    max_count = start_idx - j;
-                }
-                start_dist = d;
-                start_idx = j;
-                dist_sum = 0;
-            }
-            dist_sum += d;
-        }
-        // Check if the circle has enough support
-        if( max_count > acc_threshold )
-        {
-            float c[3];
-            c[0] = cx;
-            c[1] = cy;
-            c[2] = (float)r_best;
-            cvSeqPush( circles, c );
-            if( circles->total > circles_max )
-                return;
-        }
-    }
-}
-
 CV_IMPL CvSeq*
 cvHoughCircles( CvArr* src_image, void* circle_storage,
                 int method, double dp, double min_dist,
                 double param1, double param2,
                 int min_radius, int max_radius )
 {
-    CvMat stub, *img = (CvMat*)src_image;
-    CvMat* mat = 0;
-    CvSeq* circles = 0;
-    CvSeq circles_header;
-    CvSeqBlock circles_block;
+    CvSeq* circles = NULL;
     int circles_max = INT_MAX;
-    int canny_threshold = cvRound(param1);
-    int acc_threshold = cvRound(param2);
-
-    img = cvGetMat( img, &stub );
-
-    if( !CV_IS_MASK_ARR(img))
-        CV_Error( CV_StsBadArg, "The source image must be 8-bit, single-channel" );
+    cv::Mat src = cv::cvarrToMat(src_image), circles_mat;
 
     if( !circle_storage )
         CV_Error( CV_StsNullPtr, "NULL destination" );
-
-    if( dp <= 0 || min_dist <= 0 || canny_threshold <= 0 || acc_threshold <= 0 )
-        CV_Error( CV_StsOutOfRange, "dp, min_dist, canny_threshold and acc_threshold must be all positive numbers" );
-
-    min_radius = MAX( min_radius, 0 );
-    if( max_radius <= 0 )
-        max_radius = MAX( img->rows, img->cols );
-    else if( max_radius <= min_radius )
-        max_radius = min_radius + 2;
 
     bool isStorage = isStorageOrMat(circle_storage);
 
@@ -1261,12 +1757,14 @@ cvHoughCircles( CvArr* src_image, void* circle_storage,
     }
     else
     {
-        mat = (CvMat*)circle_storage;
+        CvSeq circles_header;
+        CvSeqBlock circles_block;
+        CvMat *mat = (CvMat*)circle_storage;
 
         if( !CV_IS_MAT_CONT( mat->type ) || (mat->rows != 1 && mat->cols != 1) ||
             CV_MAT_TYPE(mat->type) != CV_32FC3 )
             CV_Error( CV_StsBadArg,
-            "The destination matrix should be continuous and have a single row or a single column" );
+                      "The destination matrix should be continuous and have a single row or a single column" );
 
         circles = cvMakeSeqHeaderForArray( CV_32FC3, sizeof(CvSeq), sizeof(float)*3,
                 mat->data.ptr, mat->rows + mat->cols - 1, &circles_header, &circles_block );
@@ -1274,63 +1772,9 @@ cvHoughCircles( CvArr* src_image, void* circle_storage,
         cvClearSeq( circles );
     }
 
-    switch( method )
-    {
-    case CV_HOUGH_GRADIENT:
-        icvHoughCirclesGradient( img, (float)dp, (float)min_dist,
-                                min_radius, max_radius, canny_threshold,
-                                acc_threshold, circles, circles_max );
-          break;
-    default:
-        CV_Error( CV_StsBadArg, "Unrecognized method id" );
-    }
-
-    if (isStorage)
-        return circles;
-    else
-    {
-        if( mat->cols > mat->rows )
-            mat->cols = circles->total;
-        else
-            mat->rows = circles->total;
-    }
-
-    return 0;
-}
-
-
-namespace cv
-{
-
-const int STORAGE_SIZE = 1 << 12;
-
-static void seqToMat(const CvSeq* seq, OutputArray _arr)
-{
-    if( seq && seq->total > 0 )
-    {
-        _arr.create(1, seq->total, seq->flags, -1, true);
-        Mat arr = _arr.getMat();
-        cvCvtSeqToArray(seq, arr.ptr());
-    }
-    else
-        _arr.release();
-}
-
-}
-
-void cv::HoughCircles( InputArray _image, OutputArray _circles,
-                       int method, double dp, double min_dist,
-                       double param1, double param2,
-                       int minRadius, int maxRadius )
-{
-    CV_INSTRUMENT_REGION()
-
-    Ptr<CvMemStorage> storage(cvCreateMemStorage(STORAGE_SIZE));
-    Mat image = _image.getMat();
-    CvMat c_image = image;
-    CvSeq* seq = cvHoughCircles( &c_image, storage, method,
-                    dp, min_dist, param1, param2, minRadius, maxRadius );
-    seqToMat(seq, _circles);
+    cv::HoughCircles(src, circles_mat, method, dp, min_dist, param1, param2, min_radius, max_radius, circles_max, 3);
+    cvSeqPushMulti(circles, circles_mat.data, (int)circles_mat.total());
+    return circles;
 }
 
 /* End of file. */

--- a/modules/imgproc/src/hough.cpp
+++ b/modules/imgproc/src/hough.cpp
@@ -1144,7 +1144,7 @@ public:
             return;
 
         const int nBinsPerDr = 10;
-        int nBins = (maxRadius - minRadius)/dr*nBinsPerDr;
+        int nBins = cvRound((maxRadius - minRadius)/dr*nBinsPerDr);
         std::vector<int> bins(nBins, 0);
         Mat distBuf(1, nzSz, CV_32FC1), distSqrBuf(1, nzSz, CV_32FC1);
         float *ddata = distBuf.ptr<float>();

--- a/modules/imgproc/src/hough.cpp
+++ b/modules/imgproc/src/hough.cpp
@@ -883,6 +883,37 @@ void HoughLinesP(InputArray _image, OutputArray _lines,
 /****************************************************************************************\
 *                                     Circle Detection                                   *
 \****************************************************************************************/
+template<> class DataType<Point>
+{
+public:
+    typedef int        value_type;
+    typedef int         work_type;
+    typedef value_type  channel_type;
+    typedef value_type  vec_type;
+    enum { generic_type = 0,
+           depth        = CV_32S,
+           channels     = 2,
+           fmt          = (int)'i',
+           type         = CV_MAKETYPE(depth, channels)
+         };
+};
+
+template<> class DataType<Vec3f>
+{
+public:
+    typedef float      value_type;
+    typedef int         work_type;
+    typedef value_type  channel_type;
+    typedef value_type  vec_type;
+    enum { generic_type = 0,
+           depth        = CV_32F,
+           channels     = 3,
+           fmt          = (int)'i',
+           type         = CV_MAKETYPE(depth, channels)
+         };
+};
+
+
 struct markedCircle
 {
     markedCircle(Vec3f _c, int _idx, int _idxC) :

--- a/modules/imgproc/src/hough.cpp
+++ b/modules/imgproc/src/hough.cpp
@@ -43,6 +43,7 @@
 
 #include "precomp.hpp"
 #include "opencl_kernels_imgproc.hpp"
+#include "opencv2/core/hal/intrin.hpp"
 
 namespace cv
 {
@@ -938,7 +939,7 @@ public:
         astep = acols + 2;
         nz.clear();
 #if CV_SIMD128
-        haveSIMD = checkHardwareSupport(CPU_SSE2) || checkHardwareSupport(CPU_NEON);
+        haveSIMD = hasSIMD128();
 #endif
     }
 
@@ -1604,11 +1605,11 @@ _skip: ;
         _circles.release();
 }
 
-void HoughCircles( InputArray _image, OutputArray _circles,
-                   int method, double dp, double minDist,
-                   double param1, double param2,
-                   int minRadius, int maxRadius,
-                   int maxCircles, double param3 )
+static void HoughCircles( InputArray _image, OutputArray _circles,
+                          int method, double dp, double minDist,
+                          double param1, double param2,
+                          int minRadius, int maxRadius,
+                          int maxCircles, double param3 )
 {
     CV_INSTRUMENT_REGION()
 

--- a/modules/imgproc/src/hough.cpp
+++ b/modules/imgproc/src/hough.cpp
@@ -1144,8 +1144,8 @@ public:
             for(; x < acols - 1; ++x, ++base )
             {
                 if( adata[base] > accThreshold &&
-                        adata[base] > adata[base-1] && adata[base] > adata[base+1] &&
-                        adata[base] > adata[base-acols] && adata[base] > adata[base+acols] )
+                    adata[base] > adata[base-1] && adata[base] >= adata[base+1] &&
+                    adata[base] > adata[base-acols] && adata[base] >= adata[base+acols] )
                     centersLocal.push_back(base);
             }
         }

--- a/modules/imgproc/src/hough.cpp
+++ b/modules/imgproc/src/hough.cpp
@@ -898,12 +898,6 @@ inline bool cmpCircleIndex(const markedCircle &left, const markedCircle &right)
     return left.idx > right.idx;
 }
 
-struct AccumTLSData
-{
-    Mat accum;
-    std::vector<Point> nz;
-};
-
 class HoughCirclesAccumInvoker : public ParallelLoopBody
 {
 public:

--- a/modules/imgproc/src/hough.cpp
+++ b/modules/imgproc/src/hough.cpp
@@ -734,13 +734,13 @@ static bool ocl_HoughLines(InputArray _src, OutputArray _lines, double rho, doub
     CV_Assert(_src.type() == CV_8UC1);
 
     if (max_theta < 0 || max_theta > CV_PI ) {
-        CV_Error( CV_StsBadArg, "max_theta must fall between 0 and pi" );
+        CV_Error( Error::StsBadArg, "max_theta must fall between 0 and pi" );
     }
     if (min_theta < 0 || min_theta > max_theta ) {
-        CV_Error( CV_StsBadArg, "min_theta must fall between 0 and max_theta" );
+        CV_Error( Error::StsBadArg, "min_theta must fall between 0 and max_theta" );
     }
     if (!(rho > 0 && theta > 0)) {
-        CV_Error( CV_StsBadArg, "rho and theta must be greater 0" );
+        CV_Error( Error::StsBadArg, "rho and theta must be greater 0" );
     }
 
     UMat src = _src.getUMat();
@@ -794,7 +794,7 @@ static bool ocl_HoughLinesP(InputArray _src, OutputArray _lines, double rho, dou
     CV_Assert(_src.type() == CV_8UC1);
 
     if (!(rho > 0 && theta > 0)) {
-        CV_Error( CV_StsBadArg, "rho and theta must be greater 0" );
+        CV_Error( Error::StsBadArg, "rho and theta must be greater 0" );
     }
 
     UMat src = _src.getUMat();
@@ -884,36 +884,6 @@ void HoughLinesP(InputArray _image, OutputArray _lines,
 /****************************************************************************************\
 *                                     Circle Detection                                   *
 \****************************************************************************************/
-template<> class DataType<Point>
-{
-public:
-    typedef int        value_type;
-    typedef int         work_type;
-    typedef value_type  channel_type;
-    typedef value_type  vec_type;
-    enum { generic_type = 0,
-           depth        = CV_32S,
-           channels     = 2,
-           fmt          = (int)'i',
-           type         = CV_MAKETYPE(depth, channels)
-         };
-};
-
-template<> class DataType<Vec3f>
-{
-public:
-    typedef float      value_type;
-    typedef int         work_type;
-    typedef value_type  channel_type;
-    typedef value_type  vec_type;
-    enum { generic_type = 0,
-           depth        = CV_32F,
-           channels     = 3,
-           fmt          = (int)'i',
-           type         = CV_MAKETYPE(depth, channels)
-         };
-};
-
 
 struct markedCircle
 {
@@ -930,7 +900,7 @@ inline bool cmpCircleIndex(const markedCircle &left, const markedCircle &right)
 
 struct AccumTLSData
 {
-    cv::Mat accum;
+    Mat accum;
     std::vector<Point> nz;
 };
 
@@ -949,7 +919,7 @@ public:
 
     ~HoughCirclesAccumInvoker() {}
 
-    void operator()(const cv::Range &boundaries) const
+    void operator()(const Range &boundaries) const
     {
         Mat accumLocal = Mat(arows + 2, acols + 2, CV_32SC1, Scalar::all(0));
         int *adataLocal = accumLocal.ptr<int>();
@@ -1047,7 +1017,7 @@ _next_step:
                     {
                         int x2 = x1 >> 10, y2 = y1 >> 10;
                         if( (unsigned)x2 >= (unsigned)acols ||
-                                (unsigned)y2 >= (unsigned)arows )
+                            (unsigned)y2 >= (unsigned)arows )
                             break;
 
                         adataLocal[y2*astep + x2]++;
@@ -1063,7 +1033,7 @@ _next_step:
         localData.nz = nzLocal;
     }
 
-    void gather(std::vector<cv::Mat>& accumVec, std::vector<Point>& nz)
+    void gather(std::vector<Mat>& accumVec, std::vector<Point>& nz)
     {
         std::vector<AccumTLSData*> localVec;
         tls.gather(localVec);
@@ -1100,9 +1070,7 @@ public:
 
     ~HoughCirclesFindCentersInvoker() {}
 
-    HoughCirclesFindCentersInvoker& operator=(const HoughCirclesFindCentersInvoker&) {return *this;}
-
-    void operator()(const cv::Range &boundaries) const
+    void operator()(const Range &boundaries) const
     {
         int startRow = boundaries.start;
         int endRow = boundaries.end;
@@ -1182,9 +1150,7 @@ public:
 
     ~HoughCircleEstimateRadiusInvoker() {_lock.unlock();}
 
-    HoughCircleEstimateRadiusInvoker& operator=(const HoughCircleEstimateRadiusInvoker&) {return *this;}
-
-    void operator()(const cv::Range &boundaries) const
+    void operator()(const Range &boundaries) const
     {
         if (isMaxCircles)
             return;
@@ -1537,7 +1503,7 @@ static void HoughCircles( InputArray _image, OutputArray _circles,
     CV_Assert(_circles.isMat() || _circles.isVector());
 
     if( dp <= 0 || minDist <= 0 || param1 <= 0 || param2 <= 0)
-        CV_Error( CV_StsOutOfRange, "dp, min_dist, canny_threshold and acc_threshold must be all positive numbers" );
+        CV_Error( Error::StsOutOfRange, "dp, min_dist, canny_threshold and acc_threshold must be all positive numbers" );
 
     int cannyThresh = cvRound(param1), accThresh = cvRound(param2), kernelSize = cvRound(param3);
 
@@ -1559,7 +1525,7 @@ static void HoughCircles( InputArray _image, OutputArray _circles,
                              accThresh, maxCircles, kernelSize);
         break;
     default:
-        CV_Error( CV_StsBadArg, "Unrecognized method id. Actually only CV_HOUGH_GRADIENT is supported." );
+        CV_Error( Error::StsBadArg, "Unrecognized method id. Actually only CV_HOUGH_GRADIENT is supported." );
     }
 }
 
@@ -1594,10 +1560,10 @@ cvHoughLines2( CvArr* src_image, void* lineStorage, int method,
     int iparam1, iparam2;
 
     if( !lineStorage )
-        CV_Error( CV_StsNullPtr, "NULL destination" );
+        CV_Error(cv::Error::StsNullPtr, "NULL destination" );
 
     if( rho <= 0 || theta <= 0 || threshold <= 0 )
-        CV_Error( CV_StsOutOfRange, "rho, theta and threshold must be positive" );
+        CV_Error( cv::Error::StsOutOfRange, "rho, theta and threshold must be positive" );
 
     if( method != CV_HOUGH_PROBABILISTIC )
     {


### PR DESCRIPTION
### This pullrequest changes

Old pull request #7434 updated:
* merge conflicts fixed
* got rid of outdated cv::Seq containters and SSE2 intrinsics
* performance improved (from 2x to 8x depending on a number of candidate circles)
* radius search partially rewritten (histogram of radiuses is build instead of sorting; it is up to 2x faster for cases with big number of edge points)

### Perf tests results

Time of 8 runs is measured in milliseconds

Canny threshold | Accumulator threshold | Original #detected circles |  New #circles | Original code | Improved Code
--------------------- | ---------------------------- | ---------------------- | ---------------- | ---------------- | --------------------
20  |  10  |  59  |  61  |  3984.81  |  1158.9
20  |  30  |  57  |  54  |  9090.84  |  2812.07
20  |  50  |  52  |  55  |  45642.2  |  6522.96
20  |  100  |  23  |  22  |  282254  |  11317.3
50  |  10  |  58  |  57  |  3057.06  |  754.356
50  |  30  |  58  |  53  |  5116.18  |  1394.3
50  |  50  |  51  |  51  |  19703.4  |  1838.52
50  |  100  |  11  |  11  |  51612.8  |  1582.63
100  |  10  |  57  |  56  |  1890.26  |  524.728
100  |  30  |  54  |  53  |  4605.53  |  681.481
100  |  50  |  34  |  31  |  9136.89  |  830.344
100  |  100  |  5  |  6  |  17737.9  |  617.138
150  |  10  |  54  |  50  |  1339.33  |  434.024
150  |  30  |  47  |  49  |  6773.36  |  468.236
150  |  50  |  13  |  14  |  3191.05  |  379.194
150  |  100  |  4  |  4  |  1517.61  |  263.796


The image was used for perf tests:
![detect_circles_soda](https://user-images.githubusercontent.com/10323511/32551991-7c147c4c-c4a3-11e7-8572-300c63a7172e.jpg)
Several other images showed even worse performance of original code.