### PR TITLE
Added Python setup docs for Ubuntu Machines

### DIFF
--- a/doc/py_tutorials/py_setup/py_setup_in_ubuntu/py_setup_in_ubuntu.markdown
+++ b/doc/py_tutorials/py_setup/py_setup_in_ubuntu/py_setup_in_ubuntu.markdown
@@ -119,17 +119,17 @@ For additional information about CMake options refer to OpenCV [C++ compilation]
 Refer to the [OpenCV Python tutorials](http://opencv-python-tutroals.readthedocs.io/en/latest/py_tutorials/py_tutorials.html)
 **cmake output**
 ```
- --   Python 2:
- --     Interpreter:                 /usr/bin/python2.7 (ver 2.7.6)
- --     Libraries:                   /usr/lib/x86_64-linux-gnu/libpython2.7.so (ver 2.7.6)
- --     numpy:                       /usr/lib/python2.7/dist-packages/numpy/core/include (ver 1.8.2)
- --     packages path:               lib/python2.7/dist-packages
+ -- Python 2:
+ -- Interpreter: /usr/bin/python2.7 (ver 2.7.6)
+ -- Libraries: /usr/lib/x86_64-linux-gnu/libpython2.7.so (ver 2.7.6)
+ -- numpy: /usr/lib/python2.7/dist-packages/numpy/core/include (ver 1.8.2)
+ -- packages path: lib/python2.7/dist-packages
  -- 
- --   Python 3:
- --     Interpreter:                 /usr/bin/python3.4 (ver 3.4.3)
- --     Libraries:                   /usr/lib/x86_64-linux-gnu/libpython3.4m.so (ver 3.4.3)
- --     numpy:                       /usr/lib/python3/dist-packages/numpy/core/include (ver 1.8.2)
- --     packages path:               lib/python3.4/dist-packages
+ -- Python 3:
+ -- Interpreter: /usr/bin/python3.4 (ver 3.4.3)
+ -- Libraries: /usr/lib/x86_64-linux-gnu/libpython3.4m.so (ver 3.4.3)
+ -- numpy: /usr/lib/python3/dist-packages/numpy/core/include (ver 1.8.2)
+ -- packages path: lib/python3.4/dist-packages
  ```
 - Enable documentation and disable tests and samples
 ```
@@ -140,7 +140,7 @@ cmake -D BUILD_DOCS=ON -D BUILD_TESTS=OFF -D BUILD_PERF_TESTS=OFF -D BUILD_EXAMP
 ```
 cmake -D WITH_OPENCL=OFF -D WITH_CUDA=OFF
 ```
-    
+ 
 Now you build the files using make command and install it using make install command.
 
 ```

--- a/doc/py_tutorials/py_setup/py_setup_in_ubuntu/py_setup_in_ubuntu.markdown
+++ b/doc/py_tutorials/py_setup/py_setup_in_ubuntu/py_setup_in_ubuntu.markdown
@@ -1,51 +1,42 @@
-Install OpenCV-Python in Ubunu {#tutorial_py_setup_in_ubuntu}
+Install OpenCV-Python in Ubuntu {#tutorial_py_setup_in_ubuntu}
 ===============================
 
 Goals
 -----
 
-In this tutorial
-    -   We will learn to setup OpenCV-Python in Ubuntu System. Below steps are tested for
-        Ubuntu 16.04 (64-bit) and Ubuntu 14.04 (32-bit).
+In this tutorial We will learn to setup OpenCV-Python in Ubuntu System. <br>
+Below steps are tested for Ubuntu 16.04 (64-bit) and Ubuntu 14.04 (32-bit).<br>
 
-Introduction:
 OpenCV-Python can be installed in Ubuntu in two ways:
 - Install from pre-built binaries available in Ubuntu repositories<br>
 - Compile from the source. In this section, we will see both.
 
-Another important thing is the additional libraries required. OpenCV-Python requires only **Numpy**<br>
-(in addition to other dependencies, which we will see later). But in this tutorials, we also use
-**Matplotlib** for some easy and nice plotting purposes (which I feel much better compared to
-OpenCV). Matplotlib is optional, but highly recommended. Similarly we will also see **IPython**, an
-Interactive Python Terminal, which is also highly recommended.<br>
+Another important thing is the additional libraries required. OpenCV-Python requires only **Numpy** (in addition to other dependencies, which we will see later). But in this tutorials, we also use **Matplotlib** for some easy and nice plotting purposes (which I feel much better compared to OpenCV). Matplotlib is optional, but highly recommended. Similarly we will also see **IPython**, an Interactive Python Terminal, which is also highly recommended.<br>
 
 Installing OpenCV-Python from Pre-built Binaries<br>
 ------------------------------------------------
 
 Install all packages with following command in terminal as root.<br>
 **This method serves best when using just for programming and developing OpenCV applications.**<br>
-
-`$ sudo apt-get install python-opencv`<br>
+```
+$ sudo apt-get install python-opencv
+```
 
 
 Open Python IDLE (or IPython) and type following codes in Python terminal.
-<br>
-`import cv2`<br>
-`print( cv2.__version__ )`
-
+```
+import cv2
+print( cv2.__version__ )
+```
 If the results are printed out without any errors, congratulations !!! You have installed
 OpenCV-Python successfully.
 
-It is quite easy. But there is a problem with this. Apt repositories may not contain the latest
-version of OpenCV always. For example, at the time of writing this tutorial, apt repository contains
-2.4.8 while latest OpenCV version is 3.x With respect to Python API, latest version will always
-contain much better support. Also, there may be chance of problems with camera support, video
-playback etc depending upon the drivers, ffmpeg, gstreamer packages present etc.
+It is quite easy. But there is a problem with this. Apt repositories may not contain the latest version of OpenCV always. For example, at the time of writing this tutorial, apt repository contains 2.4.8 while latest OpenCV version is 3.x With respect to Python API, latest version will always contain much better support. Also, there may be chance of problems with camera support, video playback etc depending upon the drivers, ffmpeg, gstreamer packages present etc.<br>
 
-So for getting latetest source codes preference is next method, i.e. compiling from source. Also at some point in time,
+So for getting latest source codes preference is next method, i.e. compiling from source. Also at some point in time,
 if you want to contribute to OpenCV, you will need this.
 
-Installing OpenCV from source
+Building OpenCV from source
 -----------------------------
 
 Compiling from source may seem a little complicated at first, but once you succeeded in it, there is
@@ -59,19 +50,22 @@ dependencies, you can leave if you don't want.<br>
 We need **CMake** to configure the installation, **GCC** for compilation, **Python-devel** and
 **Numpy** for creating Python extensions etc.<br>
 
-`sudo apt-get install cmake`<br>
-`sudo apt-get install python-devel numpy`<br>
-`sudo apt-get install gcc gcc-c++`<br>
+```
+sudo apt-get install cmake
+sudo apt-get install python-devel numpy
+sudo apt-get install gcc gcc-c++
+```
 
 Next we need **GTK** support for GUI features, Camera support (libdc1394, libv4l), Media Support
 (ffmpeg, gstreamer) etc.<br>
 
-`sudo apt-get install gtk2-devel`<br>
-`sudo apt-get install libdc1394-devel`<br>
-`sudo apt-get install libv4l-devel`<br>
-`sudo apt-get install ffmpeg-devel`<br>
-`sudo apt-get install gstreamer-plugins-base-devel`<br>
-
+```
+sudo apt-get install gtk2-devel
+sudo apt-get install libdc1394-devel
+sudo apt-get install libv4l-devel
+sudo apt-get install ffmpeg-devel
+sudo apt-get install gstreamer-plugins-base-devel
+```
 ### Optional Dependencies
 
 Above dependencies are sufficient to install OpenCV in your ubuntu machine. But depending upon your
@@ -82,63 +76,79 @@ OpenCV comes with supporting files for image formats like PNG, JPEG, JPEG2000, T
 it may be a little old. If you want to get latest libraries, you can install development files for
 these formats.
 <br>
-`sudo apt-get install libpng-devel`<br>
-`sudo apt-get install libjpeg-turbo-devel`<br>
-`sudo apt-get install jasper-devel`<br>
-`sudo apt-get install openexr-devel`<br>
-`sudo apt-get install libtiff-devel`<br>
-`sudo apt-get install libwebp-devel`<br>
-
+```
+sudo apt-get install libpng-devel
+sudo apt-get install libjpeg-turbo-devel
+sudo apt-get install jasper-devel
+sudo apt-get install openexr-devel
+sudo apt-get install libtiff-devel
+sudo apt-get install libwebp-devel
+```
 Several OpenCV functions are parallelized with **Intel(R) Threading Building Blocks** (TBB). But if
 you want to enable it, you need to install TBB first. ( Also while configuring installation with
 CMake, don't forget to pass -D WITH_TBB=ON. More details below.)
 <br>
 ` sudo apt-get install tbb-devel`<br>
+
 ### Downloading OpenCV
 
 To download the latest source from OpenCV's [GitHub Repository](https://github.com/opencv/opencv). (If you want to contribute to OpenCV choose this. For that, you need to install **Git** first.
 <br>
-`sudo apt-get install git`<br>
-`git clone https://github.com/opencv/opencv.git`
+```
+sudo apt-get install git
+git clone https://github.com/opencv/opencv.git
+```
 <br>
-It will create a folder opencv in current directory. The cloning may
-take some time depending upon your internet connection.
+It will create a folder opencv in current directory. The cloning may take some time depending upon your internet connection.<br>
+Now open a terminal window and navigate to the downloaded OpenCV folder. Create a new build folder and navigate to it.
 
-Now open a terminal window and navigate to the downloaded OpenCV folder. Create a new build folder
-and navigate to it.
+```
+mkdir build
+cd build
+```
 <br>
-`mkdir build`<br>
-`cd build`
-<br>
+
 ### Configuring and Installing
+Now we have installed all the required dependencies, let's install OpenCV. Installation has to be configured with CMake. It specifies which modules are to be installed, installation path, which additional libraries to be used, whether documentation and examples to be compiled etc. 
+Below command is normally used for configuration with OpenCV's default parameters (executed from build folder):
+```
+$ cmake ../
+```
+OpenCV defaults assume "Release" build type and installation path is "/usr/local".
+For additional information about CMake options refer to OpenCV [C++ compilation](): 
+Refer to the [OpenCV Python tutorials](http://opencv-python-tutroals.readthedocs.io/en/latest/py_tutorials/py_tutorials.html)
+**cmake output**
+```
+ --   Python 2:
+ --     Interpreter:                 /usr/bin/python2.7 (ver 2.7.6)
+ --     Libraries:                   /usr/lib/x86_64-linux-gnu/libpython2.7.so (ver 2.7.6)
+ --     numpy:                       /usr/lib/python2.7/dist-packages/numpy/core/include (ver 1.8.2)
+ --     packages path:               lib/python2.7/dist-packages
+ -- 
+ --   Python 3:
+ --     Interpreter:                 /usr/bin/python3.4 (ver 3.4.3)
+ --     Libraries:                   /usr/lib/x86_64-linux-gnu/libpython3.4m.so (ver 3.4.3)
+ --     numpy:                       /usr/lib/python3/dist-packages/numpy/core/include (ver 1.8.2)
+ --     packages path:               lib/python3.4/dist-packages
+ ```
+- Enable documentation and disable tests and samples
+```
+cmake -D BUILD_DOCS=ON -D BUILD_TESTS=OFF -D BUILD_PERF_TESTS=OFF -D BUILD_EXAMPLES=OFF ..
+```
+- Disable all GPU related modules.
 
-Now we have installed all the required dependencies, let's install OpenCV. Installation has to be
-configured with CMake. It specifies which modules are to be installed, installation path, which
-additional libraries to be used, whether documentation and examples to be compiled etc. Below
-command is normally used for configuration (executed from build folder).
-<br>`CMAKE_CONFIGURATION_TYPES=Debug;Release`
-<br>
-It specifies that build type is "Release Mode" and installation path is /usr/local. Observe the -D
-before each option and .. at the end. In short, this is the format:
-<br>
-cmake [-D <flag>] [-D <flag>] ..
-<br>
-You can specify as many flags you want, but each flag should be preceded by -D.<br>
-
-*(All the below commands can be done in a single cmake statement, but it is split here for better
-understanding.)*
-
--   Enable documentation and disable tests and samples<br>
+```
+cmake -D WITH_OPENCL=OFF -D WITH_CUDA=OFF
+```
     
-    `cmake -D BUILD_DOCS=ON -D BUILD_TESTS=OFF -D BUILD_PERF_TESTS=OFF -D BUILD_EXAMPLES=OFF ..`<br>
-   <br>
--   Disable all GPU related modules.<br>
-    <br>
-    `cmake -D WITH_OPENCL=OFF -D WITH_CUDA=OFF`
-    
-Installation is over. All files are installed in /usr/local/ folder.<br>
 Now you build the files using make command and install it using make install command.
 
-`sudo make install`
-<br>
-Thus OpenCV installation is finished. Open a terminal and try import cv2.
+```
+sudo make install
+```
+Installation is over. All files are installed in /usr/local/ folder.Open a terminal and try import cv2.
+
+```
+import cv2
+print( cv2.__version__ )
+```

--- a/doc/py_tutorials/py_setup/py_setup_in_ubuntu/py_setup_in_ubuntu.markdown
+++ b/doc/py_tutorials/py_setup/py_setup_in_ubuntu/py_setup_in_ubuntu.markdown
@@ -109,13 +109,13 @@ cd build
 <br>
 
 ### Configuring and Installing
-Now we have installed all the required dependencies, let's install OpenCV. Installation has to be configured with CMake. It specifies which modules are to be installed, installation path, which additional libraries to be used, whether documentation and examples to be compiled etc. 
+Now we have installed all the required dependencies, let's install OpenCV. Installation has to be configured with CMake. It specifies which modules are to be installed, installation path, which additional libraries to be used, whether documentation and examples to be compiled etc.
 Below command is normally used for configuration with OpenCV's default parameters (executed from build folder):
 ```
 $ cmake ../
 ```
 OpenCV defaults assume "Release" build type and installation path is "/usr/local".
-For additional information about CMake options refer to OpenCV [C++ compilation](): 
+For additional information about CMake options refer to OpenCV [C++ compilation]():
 Refer to the [OpenCV Python tutorials](http://opencv-python-tutroals.readthedocs.io/en/latest/py_tutorials/py_tutorials.html)
 **cmake output**
 ```
@@ -124,7 +124,7 @@ Refer to the [OpenCV Python tutorials](http://opencv-python-tutroals.readthedocs
  -- Libraries: /usr/lib/x86_64-linux-gnu/libpython2.7.so (ver 2.7.6)
  -- numpy: /usr/lib/python2.7/dist-packages/numpy/core/include (ver 1.8.2)
  -- packages path: lib/python2.7/dist-packages
- -- 
+ --
  -- Python 3:
  -- Interpreter: /usr/bin/python3.4 (ver 3.4.3)
  -- Libraries: /usr/lib/x86_64-linux-gnu/libpython3.4m.so (ver 3.4.3)
@@ -140,7 +140,7 @@ cmake -D BUILD_DOCS=ON -D BUILD_TESTS=OFF -D BUILD_PERF_TESTS=OFF -D BUILD_EXAMP
 ```
 cmake -D WITH_OPENCL=OFF -D WITH_CUDA=OFF
 ```
- 
+
 Now you build the files using make command and install it using make install command.
 
 ```

--- a/doc/py_tutorials/py_setup/py_setup_in_ubuntu/py_setup_in_ubuntu.markdown
+++ b/doc/py_tutorials/py_setup/py_setup_in_ubuntu/py_setup_in_ubuntu.markdown
@@ -147,7 +147,6 @@ Now you build the files using make command and install it using make install com
 sudo make install
 ```
 Installation is over. All files are installed in /usr/local/ folder.Open a terminal and try import cv2.
-
 ```
 import cv2
 print( cv2.__version__ )

--- a/doc/py_tutorials/py_setup/py_setup_in_ubuntu/py_setup_in_ubuntu.markdown
+++ b/doc/py_tutorials/py_setup/py_setup_in_ubuntu/py_setup_in_ubuntu.markdown
@@ -1,0 +1,241 @@
+Install OpenCV-Python in Fedora {#tutorial_py_setup_in_ubuntu}
+===============================
+
+Goals
+-----
+
+In this tutorial
+    -   We will learn to setup OpenCV-Python in Ubuntu System. Below steps are tested for
+        Ubuntu 16.04 (64-bit) and Ubuntu 14.04 (32-bit).
+
+Introduction
+------------
+
+OpenCV-Python can be installed in Ubuntu in two ways:<br> 
+1) Install from pre-built binaries available
+in Ubuntu repositories<br>
+2) Compile from the source. In this section, we will see both.
+
+Another important thing is the additional libraries required. OpenCV-Python requires only **Numpy** and **Scipy**<br>
+(in addition to other dependencies, which we will see later). But in this tutorials, we also use
+**Matplotlib** for some easy and nice plotting purposes (which I feel much better compared to
+OpenCV). Matplotlib is optional, but highly recommended. Similarly we will also see **IPython**, an
+Interactive Python Terminal, which is also highly recommended.<br>
+
+Installing OpenCV-Python from Pre-built Binaries<br>
+------------------------------------------------
+
+Install all packages with following command in terminal as root.<br>
+**This method serves best when using just for programming and developing openCV applications.**<br>
+
+`$ sudo apt-get install python`<br>
+`$ sudo apt-get install python-numpy`<br>
+`$ sudo apt-get install python-scipy`<br>
+`$ sudo apt-get install libopencv-*`<br>
+`$ sudo apt-get install python-opencv`<br>
+
+Open Python IDLE (or IPython) and type following codes in Python terminal.
+<br>
+>>> import cv2
+>>> print( cv2.__version__ )
+
+If the results are printed out without any errors, congratulations !!! You have installed
+OpenCV-Python successfully.
+
+It is quite easy. But there is a problem with this. Yum repositories may not contain the latest
+version of OpenCV always. For example, at the time of writing this tutorial, apt repository contains
+2.4.5 while latest OpenCV version is 2.4.6. With respect to Python API, latest version will always
+contain much better support. Also, there may be chance of problems with camera support, video
+playback etc depending upon the drivers, ffmpeg, gstreamer packages present etc.
+
+So my personal preference is next method, i.e. compiling from source. Also at some point in time,
+if you want to contribute to OpenCV, you will need this.
+
+Installing OpenCV from source
+-----------------------------
+
+Compiling from source may seem a little complicated at first, but once you succeeded in it, there is
+nothing complicated.<br>
+
+First we will install some dependencies. Some are compulsory, some are optional. Optional
+dependencies, you can leave if you don't want.<br>
+
+### Compulsory Dependencies
+
+We need **CMake** to configure the installation, **GCC** for compilation, **Python-devel** and
+**Numpy** for creating Python extensions etc.<br>
+
+`sudo apt-get install cmake`<br>
+`sudo apt-get install python-devel numpy`<br>
+`sudo apt-get install gcc gcc-c++`<br>
+
+Next we need **GTK** support for GUI features, Camera support (libdc1394, libv4l), Media Support
+(ffmpeg, gstreamer) etc.<br>
+
+`sudo apt-get install gtk2-devel`<br>
+`sudo apt-get install libdc1394-devel`<br>
+`sudo apt-get install libv4l-devel`<br>
+`sudo apt-get install ffmpeg-devel`<br>
+`sudo apt-get install gstreamer-plugins-base-devel`<br>
+
+### Optional Dependencies
+
+Above dependencies are sufficient to install OpenCV in your ubuntu machine. But depending upon your
+requirements, you may need some extra dependencies. A list of such optional dependencies are given
+below. You can either leave it or install it, your call :)
+
+OpenCV comes with supporting files for image formats like PNG, JPEG, JPEG2000, TIFF, WebP etc. But
+it may be a little old. If you want to get latest libraries, you can install development files for
+these formats.
+<br>
+`sudo apt-get install libpng-devel`<br>
+`sudo apt-get install libjpeg-turbo-devel`<br>
+`sudo apt-get install jasper-devel`<br>
+`sudo apt-get install openexr-devel`<br>
+`sudo apt-get install libtiff-devel`<br>
+`sudo apt-get install libwebp-devel`<br>
+
+Several OpenCV functions are parallelized with **Intel's Threading Building Blocks** (TBB). But if
+you want to enable it, you need to install TBB first. ( Also while configuring installation with
+CMake, don't forget to pass -D WITH_TBB=ON. More details below.)
+<br>
+` sudo apt-get install tbb-devel`<br>
+### Downloading OpenCV
+
+Next we have to download OpenCV. You can download the latest release of OpenCV from [sourceforge
+site](http://sourceforge.net/projects/opencvlibrary/). Then extract the folder.
+
+Or you can download latest source from OpenCV's github repo. (If you want to contribute to OpenCV,
+choose this. It always keeps your OpenCV up-to-date). For that, you need to install **Git** first.
+<br>
+`sudo apt-get install git`<br>
+`git clone https://github.com/opencv/opencv.git`
+<br>
+It will create a folder OpenCV in home directory (or the directory you specify). The cloning may
+take some time depending upon your internet connection.
+
+Now open a terminal window and navigate to the downloaded OpenCV folder. Create a new build folder
+and navigate to it.
+<br>
+`mkdir build`<br>
+`cd build`
+<br>
+### Configuring and Installing
+
+Now we have installed all the required dependencies, let's install OpenCV. Installation has to be
+configured with CMake. It specifies which modules are to be installed, installation path, which
+additional libraries to be used, whether documentation and examples to be compiled etc. Below
+command is normally used for configuration (executed from build folder).
+<br>
+`cmake -D CMAKE_BUILD_TYPE=RELEASE -D CMAKE_INSTALL_PREFIX=/usr/local ..`
+<br>
+It specifies that build type is "Release Mode" and installation path is /usr/local. Observe the -D
+before each option and .. at the end. In short, this is the format:
+<br>
+cmake [-D <flag>] [-D <flag>] ..
+<br>
+You can specify as many flags you want, but each flag should be preceded by -D.<br>
+
+So in this tutorial, we are installing OpenCV with TBB. We also build the
+documentation, but we exclude Performance tests and building samples. We also disable GPU related
+modules (since we use OpenCV-Python, we don't need GPU related modules. It saves us some time).<br>
+
+*(All the below commands can be done in a single cmake statement, but it is split here for better
+understanding.)*
+
+-   Enable TBB and Eigen support:
+    <br>
+    `cmake -D WITH_TBB=ON -D WITH_EIGEN=ON ..`
+    <br>
+-   Enable documentation and disable tests and samples<br>
+    
+    `cmake -D BUILD_DOCS=ON -D BUILD_TESTS=OFF -D BUILD_PERF_TESTS=OFF -D BUILD_EXAMPLES=OFF ..`<br>
+   <br>
+-   Disable all GPU related modules.<br>
+    <br>
+    `cmake -D WITH_OPENCL=OFF -D WITH_CUDA=OFF -D BUILD_opencv_gpu=OFF -D BUILD_opencv_gpuarithm=OFF -D BUILD_opencv_gpubgsegm=OFF -D BUILD_opencv_gpucodec=OFF -D BUILD_opencv_gpufeatures2d=OFF -D BUILD_opencv_gpufilters=OFF -D BUILD_opencv_gpuimgproc=OFF -D BUILD_opencv_gpulegacy=OFF -D BUILD_opencv_gpuoptflow=OFF -D BUILD_opencv_gpustereo=OFF -D BUILD_opencv_gpuwarping=OFF ..`
+    <br>
+-   Set installation path and build type<br>
+    <br>
+    `cmake -D CMAKE_BUILD_TYPE=RELEASE -D CMAKE_INSTALL_PREFIX=/usr/local ..`
+   <br>
+Each time you enter cmake statement, it prints out the resulting configuration setup. In the final
+setup you got, make sure that following fields are filled (below is the some important parts of
+configuration I got). These fields should be filled appropriately in your system also. Otherwise
+some problem has happened. So check if you have correctly performed above steps.
+@code{.sh}
+...
+--   GUI:
+--     GTK+ 2.x:                    YES (ver 2.24.19)
+--     GThread :                    YES (ver 2.36.3)
+
+--   Video I/O:
+--     DC1394 2.x:                  YES (ver 2.2.0)
+--     FFMPEG:                      YES
+--       codec:                     YES (ver 54.92.100)
+--       format:                    YES (ver 54.63.104)
+--       util:                      YES (ver 52.18.100)
+--       swscale:                   YES (ver 2.2.100)
+--       gentoo-style:              YES
+--     GStreamer:
+--       base:                      YES (ver 0.10.36)
+--       video:                     YES (ver 0.10.36)
+--       app:                       YES (ver 0.10.36)
+--       riff:                      YES (ver 0.10.36)
+--       pbutils:                   YES (ver 0.10.36)
+
+--     V4L/V4L2:                    Using libv4l (ver 1.0.0)
+
+--   Other third-party libraries:
+--     Use Eigen:                   YES (ver 3.1.4)
+--     Use TBB:                     YES (ver 4.0 interface 6004)
+
+--   Python:
+--     Interpreter:                 /usr/bin/python2 (ver 2.7.5)
+--     Libraries:                   /lib/libpython2.7.so (ver 2.7.5)
+--     numpy:                       /usr/lib/python2.7/site-packages/numpy/core/include (ver 1.7.1)
+--     packages path:               lib/python2.7/site-packages
+
+...
+@endcode
+Many other flags and settings are there. It is left for you for further exploration.
+<br>
+Now you build the files using make command and install it using make install command. make install
+should be executed as root.<br>
+@code{.sh}
+make
+su
+make install
+@endcode
+Installation is over. All files are installed in /usr/local/ folder. But to use it, your Python
+should be able to find OpenCV module. You have two options for that.
+
+-#  **Move the module to any folder in Python Path** : Python path can be found out by entering
+    `import sys; print(sys.path)` in Python terminal. It will print out many locations. Move
+    /usr/local/lib/python2.7/site-packages/cv2.so to any of this folder. For example,
+    @code{.sh}
+    su mv /usr/local/lib/python2.7/site-packages/cv2.so /usr/lib/python2.7/site-packages
+    @endcode
+But you will have to do this every time you install OpenCV.
+
+-#  **Add /usr/local/lib/python2.7/site-packages to the PYTHON_PATH**: It is to be done only once.
+    Just open \~/.bashrc and add following line to it, then log out and come back.
+    @code{.sh}
+    export PYTHONPATH=$PYTHONPATH:/usr/local/lib/python2.7/site-packages
+    @endcode
+Thus OpenCV installation is finished. Open a terminal and try import cv2.
+
+To build the documentation, just enter following commands:
+@code{.sh}
+make doxygen
+@endcode
+Then open opencv/build/doc/doxygen/html/index.html and bookmark it in the browser.
+
+Additional Resources
+--------------------
+
+Exercises
+---------
+
+-#  Compile OpenCV from source in your Ubuntu machine.
+

--- a/doc/py_tutorials/py_setup/py_setup_in_ubuntu/py_setup_in_ubuntu.markdown
+++ b/doc/py_tutorials/py_setup/py_setup_in_ubuntu/py_setup_in_ubuntu.markdown
@@ -4,51 +4,61 @@ Install OpenCV-Python in Ubuntu {#tutorial_py_setup_in_ubuntu}
 Goals
 -----
 
-In this tutorial We will learn to setup OpenCV-Python in Ubuntu System. <br>
-Below steps are tested for Ubuntu 16.04 (64-bit) and Ubuntu 14.04 (32-bit).<br>
+In this tutorial We will learn to setup OpenCV-Python in Ubuntu System.
+Below steps are tested for Ubuntu 16.04 (64-bit) and Ubuntu 14.04 (32-bit).
 
 OpenCV-Python can be installed in Ubuntu in two ways:
-- Install from pre-built binaries available in Ubuntu repositories<br>
+- Install from pre-built binaries available in Ubuntu repositories
 - Compile from the source. In this section, we will see both.
 
-Another important thing is the additional libraries required. OpenCV-Python requires only **Numpy** (in addition to other dependencies, which we will see later). But in this tutorials, we also use **Matplotlib** for some easy and nice plotting purposes (which I feel much better compared to OpenCV). Matplotlib is optional, but highly recommended. Similarly we will also see **IPython**, an Interactive Python Terminal, which is also highly recommended.<br>
+Another important thing is the additional libraries required.
+OpenCV-Python requires only **Numpy** (in addition to other dependencies, which we will see later).
+But in this tutorials, we also use **Matplotlib** for some easy and nice plotting purposes (which I feel much better compared to OpenCV).
+Matplotlib is optional, but highly recommended.
+Similarly we will also see **IPython**, an Interactive Python Terminal, which is also highly recommended.
 
-Installing OpenCV-Python from Pre-built Binaries<br>
+Installing OpenCV-Python from Pre-built Binaries
 ------------------------------------------------
 
-Install all packages with following command in terminal as root.<br>
-**This method serves best when using just for programming and developing OpenCV applications.**<br>
+This method serves best when using just for programming and developing OpenCV applications.
+
+Install package [python-opencv](https://packages.ubuntu.com/trusty/python-opencv) with following command in terminal (as root user).
+
 ```
 $ sudo apt-get install python-opencv
 ```
 
-
 Open Python IDLE (or IPython) and type following codes in Python terminal.
+
 ```
 import cv2
-print( cv2.__version__ )
+print(cv2.__version__)
 ```
-If the results are printed out without any errors, congratulations !!! You have installed
-OpenCV-Python successfully.
 
-It is quite easy. But there is a problem with this. Apt repositories may not contain the latest version of OpenCV always. For example, at the time of writing this tutorial, apt repository contains 2.4.8 while latest OpenCV version is 3.x With respect to Python API, latest version will always contain much better support. Also, there may be chance of problems with camera support, video playback etc depending upon the drivers, ffmpeg, gstreamer packages present etc.<br>
+If the results are printed out without any errors, congratulations !!!
+You have installed OpenCV-Python successfully.
 
-So for getting latest source codes preference is next method, i.e. compiling from source. Also at some point in time,
-if you want to contribute to OpenCV, you will need this.
+It is quite easy. But there is a problem with this.
+Apt repositories may not contain the latest version of OpenCV always.
+For example, at the time of writing this tutorial, apt repository contains 2.4.8 while latest OpenCV version is 3.x.
+With respect to Python API, latest version will always contain much better support and latest bug fixes.
+
+So for getting latest source codes preference is next method, i.e. compiling from source.
+Also at some point in time, if you want to contribute to OpenCV, you will need this.
 
 Building OpenCV from source
------------------------------
+---------------------------
 
-Compiling from source may seem a little complicated at first, but once you succeeded in it, there is
-nothing complicated.<br>
+Compiling from source may seem a little complicated at first, but once you succeeded in it, there is nothing complicated.
 
-First we will install some dependencies. Some are compulsory, some are optional. Optional
-dependencies, you can leave if you don't want.<br>
+First we will install some dependencies.
+Some are required, some are optional.
+You can skip optional dependencies if you don't want.
 
-### Required Build Dependencies
+### Required build dependencies
 
 We need **CMake** to configure the installation, **GCC** for compilation, **Python-devel** and
-**Numpy** for creating Python extensions etc.<br>
+**Numpy** for building Python bindings etc.
 
 ```
 sudo apt-get install cmake
@@ -56,26 +66,26 @@ sudo apt-get install python-devel numpy
 sudo apt-get install gcc gcc-c++
 ```
 
-Next we need **GTK** support for GUI features, Camera support (libdc1394, libv4l), Media Support
-(ffmpeg, gstreamer) etc.<br>
+Next we need **GTK** support for GUI features, Camera support (libv4l), Media Support
+(ffmpeg, gstreamer) etc.
 
 ```
 sudo apt-get install gtk2-devel
-sudo apt-get install libdc1394-devel
 sudo apt-get install libv4l-devel
 sudo apt-get install ffmpeg-devel
 sudo apt-get install gstreamer-plugins-base-devel
 ```
+
 ### Optional Dependencies
 
-Above dependencies are sufficient to install OpenCV in your ubuntu machine. But depending upon your
-requirements, you may need some extra dependencies. A list of such optional dependencies are given
-below. You can either leave it or install it, your call :)
+Above dependencies are sufficient to install OpenCV in your Ubuntu machine.
+But depending upon your requirements, you may need some extra dependencies.
+A list of such optional dependencies are given below. You can either leave it or install it, your call :)
 
-OpenCV comes with supporting files for image formats like PNG, JPEG, JPEG2000, TIFF, WebP etc. But
-it may be a little old. If you want to get latest libraries, you can install development files for
-these formats.
-<br>
+OpenCV comes with supporting files for image formats like PNG, JPEG, JPEG2000, TIFF, WebP etc.
+But it may be a little old.
+If you want to get latest libraries, you can install development files for system libraries of these formats.
+
 ```
 sudo apt-get install libpng-devel
 sudo apt-get install libjpeg-turbo-devel
@@ -84,70 +94,72 @@ sudo apt-get install openexr-devel
 sudo apt-get install libtiff-devel
 sudo apt-get install libwebp-devel
 ```
-Several OpenCV functions are parallelized with **Intel(R) Threading Building Blocks** (TBB). But if
-you want to enable it, you need to install TBB first. ( Also while configuring installation with
-CMake, don't forget to pass -D WITH_TBB=ON. More details below.)
-<br>
-` sudo apt-get install tbb-devel`<br>
 
 ### Downloading OpenCV
 
-To download the latest source from OpenCV's [GitHub Repository](https://github.com/opencv/opencv). (If you want to contribute to OpenCV choose this. For that, you need to install **Git** first.
-<br>
-```
-sudo apt-get install git
-git clone https://github.com/opencv/opencv.git
-```
-<br>
-It will create a folder opencv in current directory. The cloning may take some time depending upon your internet connection.<br>
-Now open a terminal window and navigate to the downloaded OpenCV folder. Create a new build folder and navigate to it.
+To download the latest source from OpenCV's [GitHub Repository](https://github.com/opencv/opencv).
+(If you want to contribute to OpenCV choose this. For that, you need to install **Git** first)
 
 ```
-mkdir build
-cd build
+$ sudo apt-get install git
+$ git clone https://github.com/opencv/opencv.git
 ```
-<br>
+
+It will create a folder "opencv" in current directory.
+The cloning may take some time depending upon your internet connection.
+
+Now open a terminal window and navigate to the downloaded "opencv" folder.
+Create a new "build" folder and navigate to it.
+
+```
+$ mkdir build
+$ cd build
+```
 
 ### Configuring and Installing
-Now we have installed all the required dependencies, let's install OpenCV. Installation has to be configured with CMake. It specifies which modules are to be installed, installation path, which additional libraries to be used, whether documentation and examples to be compiled etc.
-Below command is normally used for configuration with OpenCV's default parameters (executed from build folder):
+
+Now we have all the required dependencies, let's install OpenCV.
+Installation has to be configured with CMake.
+It specifies which modules are to be installed, installation path, which additional libraries to be used, whether documentation and examples to be compiled etc.
+Most of this work are done automatically with well configured default parameters.
+
+Below command is normally used for configuration of OpenCV library build (executed from build folder):
+
 ```
 $ cmake ../
 ```
+
 OpenCV defaults assume "Release" build type and installation path is "/usr/local".
-For additional information about CMake options refer to OpenCV [C++ compilation]():
-Refer to the [OpenCV Python tutorials](http://opencv-python-tutroals.readthedocs.io/en/latest/py_tutorials/py_tutorials.html)
-**cmake output**
-```
- -- Python 2:
- -- Interpreter: /usr/bin/python2.7 (ver 2.7.6)
- -- Libraries: /usr/lib/x86_64-linux-gnu/libpython2.7.so (ver 2.7.6)
- -- numpy: /usr/lib/python2.7/dist-packages/numpy/core/include (ver 1.8.2)
- -- packages path: lib/python2.7/dist-packages
- --
- -- Python 3:
- -- Interpreter: /usr/bin/python3.4 (ver 3.4.3)
- -- Libraries: /usr/lib/x86_64-linux-gnu/libpython3.4m.so (ver 3.4.3)
- -- numpy: /usr/lib/python3/dist-packages/numpy/core/include (ver 1.8.2)
- -- packages path: lib/python3.4/dist-packages
- ```
-- Enable documentation and disable tests and samples
-```
-cmake -D BUILD_DOCS=ON -D BUILD_TESTS=OFF -D BUILD_PERF_TESTS=OFF -D BUILD_EXAMPLES=OFF ..
-```
-- Disable all GPU related modules.
+For additional information about CMake options refer to OpenCV @ref tutorial_linux_install "C++ compilation guide":
+
+You should see these lines in your CMake output (they mean that Python is properly found):
 
 ```
-cmake -D WITH_OPENCL=OFF -D WITH_CUDA=OFF
+--   Python 2:
+--     Interpreter:                 /usr/bin/python2.7 (ver 2.7.6)
+--     Libraries:                   /usr/lib/x86_64-linux-gnu/libpython2.7.so (ver 2.7.6)
+--     numpy:                       /usr/lib/python2.7/dist-packages/numpy/core/include (ver 1.8.2)
+--     packages path:               lib/python2.7/dist-packages
+--
+--   Python 3:
+--     Interpreter:                 /usr/bin/python3.4 (ver 3.4.3)
+--     Libraries:                   /usr/lib/x86_64-linux-gnu/libpython3.4m.so (ver 3.4.3)
+--     numpy:                       /usr/lib/python3/dist-packages/numpy/core/include (ver 1.8.2)
+--     packages path:               lib/python3.4/dist-packages
 ```
 
-Now you build the files using make command and install it using make install command.
+Now you build the files using "make" command and install it using "make install" command.
 
 ```
-sudo make install
+$ make
+# sudo make install
 ```
-Installation is over. All files are installed in /usr/local/ folder.Open a terminal and try import cv2.
+
+Installation is over.
+All files are installed in "/usr/local/" folder.
+Open a terminal and try import "cv2".
+
 ```
 import cv2
-print( cv2.__version__ )
+print(cv2.__version__)
 ```

--- a/doc/py_tutorials/py_setup/py_setup_in_ubuntu/py_setup_in_ubuntu.markdown
+++ b/doc/py_tutorials/py_setup/py_setup_in_ubuntu/py_setup_in_ubuntu.markdown
@@ -1,4 +1,4 @@
-Install OpenCV-Python in Fedora {#tutorial_py_setup_in_ubuntu}
+Install OpenCV-Python in Ubunu {#tutorial_py_setup_in_ubuntu}
 ===============================
 
 Goals
@@ -8,15 +8,12 @@ In this tutorial
     -   We will learn to setup OpenCV-Python in Ubuntu System. Below steps are tested for
         Ubuntu 16.04 (64-bit) and Ubuntu 14.04 (32-bit).
 
-Introduction
-------------
+Introduction:
+OpenCV-Python can be installed in Ubuntu in two ways:
+- Install from pre-built binaries available in Ubuntu repositories<br>
+- Compile from the source. In this section, we will see both.
 
-OpenCV-Python can be installed in Ubuntu in two ways:<br> 
-1) Install from pre-built binaries available
-in Ubuntu repositories<br>
-2) Compile from the source. In this section, we will see both.
-
-Another important thing is the additional libraries required. OpenCV-Python requires only **Numpy** and **Scipy**<br>
+Another important thing is the additional libraries required. OpenCV-Python requires only **Numpy**<br>
 (in addition to other dependencies, which we will see later). But in this tutorials, we also use
 **Matplotlib** for some easy and nice plotting purposes (which I feel much better compared to
 OpenCV). Matplotlib is optional, but highly recommended. Similarly we will also see **IPython**, an
@@ -26,30 +23,26 @@ Installing OpenCV-Python from Pre-built Binaries<br>
 ------------------------------------------------
 
 Install all packages with following command in terminal as root.<br>
-**This method serves best when using just for programming and developing openCV applications.**<br>
+**This method serves best when using just for programming and developing OpenCV applications.**<br>
 
-`$ sudo apt-get install python`<br>
-`$ sudo apt-get install python-numpy`<br>
-`$ sudo apt-get install python-scipy`<br>
-`$ sudo apt-get install libopencv-*`<br>
 `$ sudo apt-get install python-opencv`<br>
 
 
 Open Python IDLE (or IPython) and type following codes in Python terminal.
 <br>
->>> import cv2
->>> print( cv2.__version__ )
+`import cv2`<br>
+`print( cv2.__version__ )`
 
 If the results are printed out without any errors, congratulations !!! You have installed
 OpenCV-Python successfully.
 
-It is quite easy. But there is a problem with this. Yum repositories may not contain the latest
+It is quite easy. But there is a problem with this. Apt repositories may not contain the latest
 version of OpenCV always. For example, at the time of writing this tutorial, apt repository contains
-2.4.5 while latest OpenCV version is 2.4.6. With respect to Python API, latest version will always
+2.4.8 while latest OpenCV version is 3.x With respect to Python API, latest version will always
 contain much better support. Also, there may be chance of problems with camera support, video
 playback etc depending upon the drivers, ffmpeg, gstreamer packages present etc.
 
-So my personal preference is next method, i.e. compiling from source. Also at some point in time,
+So for getting latetest source codes preference is next method, i.e. compiling from source. Also at some point in time,
 if you want to contribute to OpenCV, you will need this.
 
 Installing OpenCV from source
@@ -61,7 +54,7 @@ nothing complicated.<br>
 First we will install some dependencies. Some are compulsory, some are optional. Optional
 dependencies, you can leave if you don't want.<br>
 
-### Compulsory Dependencies
+### Required Build Dependencies
 
 We need **CMake** to configure the installation, **GCC** for compilation, **Python-devel** and
 **Numpy** for creating Python extensions etc.<br>
@@ -96,23 +89,19 @@ these formats.
 `sudo apt-get install libtiff-devel`<br>
 `sudo apt-get install libwebp-devel`<br>
 
-Several OpenCV functions are parallelized with **Intel's Threading Building Blocks** (TBB). But if
+Several OpenCV functions are parallelized with **Intel(R) Threading Building Blocks** (TBB). But if
 you want to enable it, you need to install TBB first. ( Also while configuring installation with
 CMake, don't forget to pass -D WITH_TBB=ON. More details below.)
 <br>
 ` sudo apt-get install tbb-devel`<br>
 ### Downloading OpenCV
 
-Next we have to download OpenCV. You can download the latest release of OpenCV from [sourceforge
-site](http://sourceforge.net/projects/opencvlibrary/). Then extract the folder.
-
-Or you can download latest source from OpenCV's github repo. (If you want to contribute to OpenCV,
-choose this. It always keeps your OpenCV up-to-date). For that, you need to install **Git** first.
+To download the latest source from OpenCV's [GitHub Repository](https://github.com/opencv/opencv). (If you want to contribute to OpenCV choose this. For that, you need to install **Git** first.
 <br>
 `sudo apt-get install git`<br>
 `git clone https://github.com/opencv/opencv.git`
 <br>
-It will create a folder OpenCV in home directory (or the directory you specify). The cloning may
+It will create a folder opencv in current directory. The cloning may
 take some time depending upon your internet connection.
 
 Now open a terminal window and navigate to the downloaded OpenCV folder. Create a new build folder
@@ -127,8 +116,7 @@ Now we have installed all the required dependencies, let's install OpenCV. Insta
 configured with CMake. It specifies which modules are to be installed, installation path, which
 additional libraries to be used, whether documentation and examples to be compiled etc. Below
 command is normally used for configuration (executed from build folder).
-<br>
-`cmake -D CMAKE_BUILD_TYPE=RELEASE -D CMAKE_INSTALL_PREFIX=/usr/local ..`
+<br>`CMAKE_CONFIGURATION_TYPES=Debug;Release`
 <br>
 It specifies that build type is "Release Mode" and installation path is /usr/local. Observe the -D
 before each option and .. at the end. In short, this is the format:
@@ -137,106 +125,20 @@ cmake [-D <flag>] [-D <flag>] ..
 <br>
 You can specify as many flags you want, but each flag should be preceded by -D.<br>
 
-So in this tutorial, we are installing OpenCV with TBB. We also build the
-documentation, but we exclude Performance tests and building samples. We also disable GPU related
-modules (since we use OpenCV-Python, we don't need GPU related modules. It saves us some time).<br>
-
 *(All the below commands can be done in a single cmake statement, but it is split here for better
 understanding.)*
 
--   Enable TBB and Eigen support:
-    <br>
-    `cmake -D WITH_TBB=ON -D WITH_EIGEN=ON ..`
-    <br>
 -   Enable documentation and disable tests and samples<br>
     
     `cmake -D BUILD_DOCS=ON -D BUILD_TESTS=OFF -D BUILD_PERF_TESTS=OFF -D BUILD_EXAMPLES=OFF ..`<br>
    <br>
 -   Disable all GPU related modules.<br>
     <br>
-    `cmake -D WITH_OPENCL=OFF -D WITH_CUDA=OFF -D BUILD_opencv_gpu=OFF -D BUILD_opencv_gpuarithm=OFF -D BUILD_opencv_gpubgsegm=OFF -D BUILD_opencv_gpucodec=OFF -D BUILD_opencv_gpufeatures2d=OFF -D BUILD_opencv_gpufilters=OFF -D BUILD_opencv_gpuimgproc=OFF -D BUILD_opencv_gpulegacy=OFF -D BUILD_opencv_gpuoptflow=OFF -D BUILD_opencv_gpustereo=OFF -D BUILD_opencv_gpuwarping=OFF ..`
-    <br>
--   Set installation path and build type<br>
-    <br>
-    `cmake -D CMAKE_BUILD_TYPE=RELEASE -D CMAKE_INSTALL_PREFIX=/usr/local ..`
-   <br>
-Each time you enter cmake statement, it prints out the resulting configuration setup. In the final
-setup you got, make sure that following fields are filled (below is the some important parts of
-configuration I got). These fields should be filled appropriately in your system also. Otherwise
-some problem has happened. So check if you have correctly performed above steps.
-@code{.sh}
-...
---   GUI:
---     GTK+ 2.x:                    YES (ver 2.24.19)
---     GThread :                    YES (ver 2.36.3)
+    `cmake -D WITH_OPENCL=OFF -D WITH_CUDA=OFF`
+    
+Installation is over. All files are installed in /usr/local/ folder.<br>
+Now you build the files using make command and install it using make install command.
 
---   Video I/O:
---     DC1394 2.x:                  YES (ver 2.2.0)
---     FFMPEG:                      YES
---       codec:                     YES (ver 54.92.100)
---       format:                    YES (ver 54.63.104)
---       util:                      YES (ver 52.18.100)
---       swscale:                   YES (ver 2.2.100)
---       gentoo-style:              YES
---     GStreamer:
---       base:                      YES (ver 0.10.36)
---       video:                     YES (ver 0.10.36)
---       app:                       YES (ver 0.10.36)
---       riff:                      YES (ver 0.10.36)
---       pbutils:                   YES (ver 0.10.36)
-
---     V4L/V4L2:                    Using libv4l (ver 1.0.0)
-
---   Other third-party libraries:
---     Use Eigen:                   YES (ver 3.1.4)
---     Use TBB:                     YES (ver 4.0 interface 6004)
-
---   Python:
---     Interpreter:                 /usr/bin/python2 (ver 2.7.5)
---     Libraries:                   /lib/libpython2.7.so (ver 2.7.5)
---     numpy:                       /usr/lib/python2.7/site-packages/numpy/core/include (ver 1.7.1)
---     packages path:               lib/python2.7/site-packages
-
-...
-@endcode
-Many other flags and settings are there. It is left for you for further exploration.
+`sudo make install`
 <br>
-Now you build the files using make command and install it using make install command. make install
-should be executed as root.<br>
-@code{.sh}
-make
-su
-make install
-@endcode
-Installation is over. All files are installed in /usr/local/ folder. But to use it, your Python
-should be able to find OpenCV module. You have two options for that.
-
--#  **Move the module to any folder in Python Path** : Python path can be found out by entering
-    `import sys; print(sys.path)` in Python terminal. It will print out many locations. Move
-    /usr/local/lib/python2.7/site-packages/cv2.so to any of this folder. For example,
-    @code{.sh}
-    su mv /usr/local/lib/python2.7/site-packages/cv2.so /usr/lib/python2.7/site-packages
-    @endcode
-But you will have to do this every time you install OpenCV.
-
--#  **Add /usr/local/lib/python2.7/site-packages to the PYTHON_PATH**: It is to be done only once.
-    Just open \~/.bashrc and add following line to it, then log out and come back.
-    @code{.sh}
-    export PYTHONPATH=$PYTHONPATH:/usr/local/lib/python2.7/site-packages
-    @endcode
-Thus OpenCV installation is finished. Open a terminal and try import cv2.
-
-To build the documentation, just enter following commands:
-@code{.sh}
-make doxygen
-@endcode
-Then open opencv/build/doc/doxygen/html/index.html and bookmark it in the browser.
-
-Additional Resources
---------------------
-
-Exercises
----------
-
--#  Compile OpenCV from source in your Ubuntu machine.
-
+Thus OpenCV installation is finished. Open a terminal and try import cv2.<br>

--- a/doc/py_tutorials/py_setup/py_setup_in_ubuntu/py_setup_in_ubuntu.markdown
+++ b/doc/py_tutorials/py_setup/py_setup_in_ubuntu/py_setup_in_ubuntu.markdown
@@ -141,4 +141,4 @@ Now you build the files using make command and install it using make install com
 
 `sudo make install`
 <br>
-Thus OpenCV installation is finished. Open a terminal and try import cv2.<br>
+Thus OpenCV installation is finished. Open a terminal and try import cv2.

--- a/doc/py_tutorials/py_setup/py_setup_in_ubuntu/py_setup_in_ubuntu.markdown
+++ b/doc/py_tutorials/py_setup/py_setup_in_ubuntu/py_setup_in_ubuntu.markdown
@@ -34,6 +34,7 @@ Install all packages with following command in terminal as root.<br>
 `$ sudo apt-get install libopencv-*`<br>
 `$ sudo apt-get install python-opencv`<br>
 
+
 Open Python IDLE (or IPython) and type following codes in Python terminal.
 <br>
 >>> import cv2

--- a/doc/py_tutorials/py_setup/py_table_of_contents_setup.markdown
+++ b/doc/py_tutorials/py_setup/py_table_of_contents_setup.markdown
@@ -15,7 +15,7 @@ Introduction to OpenCV {#tutorial_py_table_of_contents_setup}
 
     Set Up
     OpenCV-Python in Fedora
-    
+
 -   @subpage tutorial_py_setup_in_ubuntu
 
     Set Up


### PR DESCRIPTION
### This pullrequest changes:
Added Documentations for Python OpenCV setup for Ubuntu machines. Though fedora setup docs were present but for a newcomer in Linux will find difficult to follow the complete steps.
Ubuntu specific guides have been added in this PR.

[Tutorial link](http://pullrequest.opencv.org/buildbot/export/pr/10056/docs/da/df6/tutorial_py_table_of_contents_setup.html) (for this patch).

```
force_builders=Docs
```