### PR TITLE
Opened up for core/traits/DataDepth class, making members public.

### DIFF
--- a/modules/core/include/opencv2/core/traits.hpp
+++ b/modules/core/include/opencv2/core/traits.hpp
@@ -282,6 +282,7 @@ public:
 
 template<int _depth> class TypeDepth
 {
+public:
 #ifdef OPENCV_TRAITS_ENABLE_LEGACY_DEFAULTS
     enum { depth = CV_USRTYPE1 };
     typedef void value_type;
@@ -290,42 +291,49 @@ template<int _depth> class TypeDepth
 
 template<> class TypeDepth<CV_8U>
 {
+public:
     enum { depth = CV_8U };
     typedef uchar value_type;
 };
 
 template<> class TypeDepth<CV_8S>
 {
+public:
     enum { depth = CV_8S };
     typedef schar value_type;
 };
 
 template<> class TypeDepth<CV_16U>
 {
+public:
     enum { depth = CV_16U };
     typedef ushort value_type;
 };
 
 template<> class TypeDepth<CV_16S>
 {
+public:
     enum { depth = CV_16S };
     typedef short value_type;
 };
 
 template<> class TypeDepth<CV_32S>
 {
+public:
     enum { depth = CV_32S };
     typedef int value_type;
 };
 
 template<> class TypeDepth<CV_32F>
 {
+public:
     enum { depth = CV_32F };
     typedef float value_type;
 };
 
 template<> class TypeDepth<CV_64F>
 {
+public:
     enum { depth = CV_64F };
     typedef double value_type;
 };


### PR DESCRIPTION
### This pullrequest changes
This pullrequest makes members of core/traits/TypeDepth public and usable. 
This is very useful for templated serialization of vectors/matrices, and as far as I can tell the only way to convert OpenCV types (`CV_32F`) into system types (`float`)

Beware: Typo in title, involved class is TypeDepth, not DataDepth! Sorry for the confusion
