### PR TITLE
Fix #7084 Thin Plate Spline warpImage() error

### DIFF
--- a/modules/shape/src/tps_trans.cpp
+++ b/modules/shape/src/tps_trans.cpp
@@ -161,8 +161,9 @@ void ThinPlateSplineShapeTransformerImpl::warpImage(InputArray transformingImage
         for (int col = 0; col < theinput.cols; col++)
         {
             Point2f pt = _applyTransformation(shapeReference, Point2f(float(col), float(row)), tpsParameters);
-            mapX.at<float>(row, col) = pt.x;
-            mapY.at<float>(row, col) = pt.y;
+
+            mapX.at<float>(row, col) = col - (pt.x - col);
+            mapY.at<float>(row, col) = row - (pt.y - row);
         }
     }
     remap(transformingImage, output, mapX, mapY, flags, borderMode, borderValue);


### PR DESCRIPTION
<!-- Please use this line to close one or multiple issues when this pullrequest gets merged
You can add another line right under the first one:
resolves #7084
-->

### Resolves issue with warpImage() in Thin Plate Spline mentioned in #7084
* As suggested in #7084 by @WIStudent, the `ThinPlateSplineShapeTransformer` is working fine with `estimateTransformation()` and `applyTransformation()`. 
But `warpImage()` has got wrong with how `remap()` works.

* `remap()` performs:  ``` dst(x, y) = src(map_x(x, y), map_y(x, y)) ```
But what we really want is:  __``` dst(map_x(x, y), map_y(x, y)) = src(x, y) ```__

### Some math in the code
* Given that TPS is actually learning a translation 
`(x, y) -> (map_x(x, y), map_y(x, y)) = (x + \delta x, y + \delta y)`
* let `x1 = map_x(x, y)`, `y1 = map_y(x, y)`
* Then:`\delta x = x1 - x`, `\delta y = y1 - y`, `x = x1 - \delta x`, `y = y1 - \delta y`
* So: `dst(x1, y1) = dst(map_x(x, y), map_y(x, y)) = src(x, y) = src(x1 - \delta x, y1 - \delta y)`
* See x1, y1 as new x, y: `dst(x, y) = src(x - \delta x, y - \delta y)`
which is going to be:
```cpp
// deltax = pt.x - col;
// deltay = pt.y - row;
mapX.at<float>(row, col) = col - (pt.x - col);
mapY.at<float>(row, col) = row - (pt.y - row);
```

### P.S. Why don't we directly using something like the following?
```cpp
mapX.at<float>(pt.y, pt.x) = col;
mapY.at<float>(pt.y, pt.x) = row;
```
The above code is definitely fine to represent `dst(map_x(x, y), map_y(x, y)) = src(x, y)`
But using it would cause so many pixels with unknown value.
