### PR TITLE
Fix GDAL image decoding color problems identified by issue #10089, by:

### DIFF
--- a/modules/imgcodecs/src/grfmt_gdal.cpp
+++ b/modules/imgcodecs/src/grfmt_gdal.cpp
@@ -78,7 +78,7 @@ int  gdalPaletteInterpretation2OpenCV( GDALPaletteInterp const& paletteInterp, G
 
         /// RGB
         case GPI_RGB:
-            if( gdalType == GDT_Byte    ){ return CV_8UC1;  }
+            if( gdalType == GDT_Byte    ){ return CV_8UC3;  }
             if( gdalType == GDT_UInt16  ){ return CV_16UC3; }
             if( gdalType == GDT_Int16   ){ return CV_16SC3; }
             if( gdalType == GDT_UInt32  ){ return CV_32SC3; }
@@ -256,35 +256,35 @@ void write_pixel( const double& pixelValue,
 
     // input: 3 channel, output: 3 channel
     else if( gdalChannels == 3 && image.channels() == 3 ){
-        if( image.depth() == CV_8U ){  image.at<Vec3b>(row,col)[channel] = newValue;  }
-        else if( image.depth() == CV_16U ){  image.ptr<Vec3s>(row,col)[channel] = newValue;  }
-        else if( image.depth() == CV_16S ){  image.ptr<Vec3s>(row,col)[channel] = newValue;  }
-        else if( image.depth() == CV_32S ){  image.ptr<Vec3i>(row,col)[channel] = newValue;  }
-        else if( image.depth() == CV_32F ){  image.ptr<Vec3f>(row,col)[channel] = newValue;  }
-        else if( image.depth() == CV_64F ){  image.ptr<Vec3d>(row,col)[channel] = newValue;  }
+        if( image.depth() == CV_8U ){  (*image.ptr<Vec3b>(row,col))[channel] = newValue;  }
+        else if( image.depth() == CV_16U ){  (*image.ptr<Vec3s>(row,col))[channel] = newValue;  }
+        else if( image.depth() == CV_16S ){  (*image.ptr<Vec3s>(row,col))[channel] = newValue;  }
+        else if( image.depth() == CV_32S ){  (*image.ptr<Vec3i>(row,col))[channel] = newValue;  }
+        else if( image.depth() == CV_32F ){  (*image.ptr<Vec3f>(row,col))[channel] = newValue;  }
+        else if( image.depth() == CV_64F ){  (*image.ptr<Vec3d>(row,col))[channel] = newValue;  }
         else{ throw std::runtime_error("Unknown image depth, gdal: 3, image: 3"); }
     }
 
     // input: 4 channel, output: 3 channel
     else if( gdalChannels == 4 && image.channels() == 3 ){
         if( channel >= 4 ){ return; }
-        else if( image.depth() == CV_8U  && channel < 4 ){  image.ptr<Vec3b>(row,col)[channel] = newValue;  }
-        else if( image.depth() == CV_16U && channel < 4 ){  image.ptr<Vec3s>(row,col)[channel] = newValue;  }
-        else if( image.depth() == CV_16S && channel < 4 ){  image.ptr<Vec3s>(row,col)[channel] = newValue;  }
-        else if( image.depth() == CV_32S && channel < 4 ){  image.ptr<Vec3i>(row,col)[channel] = newValue;  }
-        else if( image.depth() == CV_32F && channel < 4 ){  image.ptr<Vec3f>(row,col)[channel] = newValue;  }
-        else if( image.depth() == CV_64F && channel < 4 ){  image.ptr<Vec3d>(row,col)[channel] = newValue;  }
+        else if( image.depth() == CV_8U  && channel < 4 ){  (*image.ptr<Vec3b>(row,col))[channel] = newValue;  }
+        else if( image.depth() == CV_16U && channel < 4 ){  (*image.ptr<Vec3s>(row,col))[channel] = newValue;  }
+        else if( image.depth() == CV_16S && channel < 4 ){  (*image.ptr<Vec3s>(row,col))[channel] = newValue;  }
+        else if( image.depth() == CV_32S && channel < 4 ){  (*image.ptr<Vec3i>(row,col))[channel] = newValue;  }
+        else if( image.depth() == CV_32F && channel < 4 ){  (*image.ptr<Vec3f>(row,col))[channel] = newValue;  }
+        else if( image.depth() == CV_64F && channel < 4 ){  (*image.ptr<Vec3d>(row,col))[channel] = newValue;  }
         else{ throw std::runtime_error("Unknown image depth, gdal: 4, image: 3"); }
     }
 
     // input: 4 channel, output: 4 channel
     else if( gdalChannels == 4 && image.channels() == 4 ){
-        if( image.depth() == CV_8U ){  image.at<Vec4b>(row,col)[channel] = newValue;  }
-        else if( image.depth() == CV_16U ){  image.at<Vec4s>(row,col)[channel] = newValue;  }
-        else if( image.depth() == CV_16S ){  image.at<Vec4s>(row,col)[channel] = newValue;  }
-        else if( image.depth() == CV_32S ){  image.at<Vec4i>(row,col)[channel] = newValue;  }
-        else if( image.depth() == CV_32F ){  image.at<Vec4f>(row,col)[channel] = newValue;  }
-        else if( image.depth() == CV_64F ){  image.at<Vec4d>(row,col)[channel] = newValue;  }
+        if( image.depth() == CV_8U ){  (*image.ptr<Vec4b>(row,col))[channel] = newValue;  }
+        else if( image.depth() == CV_16U ){  (*image.ptr<Vec4s>(row,col))[channel] = newValue;  }
+        else if( image.depth() == CV_16S ){  (*image.ptr<Vec4s>(row,col))[channel] = newValue;  }
+        else if( image.depth() == CV_32S ){  (*image.ptr<Vec4i>(row,col))[channel] = newValue;  }
+        else if( image.depth() == CV_32F ){  (*image.ptr<Vec4f>(row,col))[channel] = newValue;  }
+        else if( image.depth() == CV_64F ){  (*image.ptr<Vec4d>(row,col))[channel] = newValue;  }
         else{ throw std::runtime_error("Unknown image depth, gdal: 4, image: 4"); }
     }
 
@@ -388,38 +388,66 @@ bool GdalDecoder::readData( Mat& img ){
         // get the GDAL Band
         GDALRasterBand* band = m_dataset->GetRasterBand(c+1);
 
-        // make sure the image band has the same dimensions as the image
-        if( band->GetXSize() != m_width || band->GetYSize() != m_height ){ return false; }
-
-        // grab the raster size
-        nRows = band->GetYSize();
-        nCols = band->GetXSize();
-
-        // create a temporary scanline pointer to store data
-        double* scanline = new double[nCols];
-
-        // iterate over each row and column
-        for( int y=0; y<nRows; y++ ){
-
-            // get the entire row
-            band->RasterIO( GF_Read, 0, y, nCols, 1, scanline, nCols, 1, GDT_Float64, 0, 0);
-
-            // set inside the image
-            for( int x=0; x<nCols; x++ ){
-
-                // set depending on image types
-                //   given boost, I would use enable_if to speed up.  Avoid for now.
-                if( hasColorTable == false ){
-                    write_pixel( scanline[x], gdalType, nChannels, img, y, x, c );
-                }
-                else{
-                    write_ctable_pixel( scanline[x], gdalType, gdalColorTable, img, y, x, c );
-                }
-            }
+        /* Map palette band and gray band to color index 0 and red, green,
+           blue, alpha bands to BGRA indexes. Note: ignoring HSL, CMY,
+           CMYK, and YCbCr color spaces, rather than converting them
+           to BGR. */
+        int color = -1;
+        switch (band->GetColorInterpretation()) {
+        case GCI_PaletteIndex:
+        case GCI_GrayIndex:
+        case GCI_BlueBand:
+            color = 0;
+            break;
+        case GCI_GreenBand:
+            color = 1;
+            break;
+        case GCI_RedBand:
+            color = 2;
+            break;
+        case GCI_AlphaBand:
+            color = 3;
+            break;
+        default:
+            color = -1;
+            break;
         }
 
-        // delete our temp pointer
-        delete [] scanline;
+        if (color >= 0) {
+
+            // make sure the image band has the same dimensions as the image
+            if( band->GetXSize() != m_width || band->GetYSize() != m_height ){ return false; }
+
+            // grab the raster size
+            nRows = band->GetYSize();
+            nCols = band->GetXSize();
+
+            // create a temporary scanline pointer to store data
+            double* scanline = new double[nCols];
+
+            // iterate over each row and column
+            for( int y=0; y<nRows; y++ ){
+
+                // get the entire row
+                band->RasterIO( GF_Read, 0, y, nCols, 1, scanline, nCols, 1, GDT_Float64, 0, 0);
+
+                // set inside the image
+                for( int x=0; x<nCols; x++ ){
+
+                    // set depending on image types
+                    //   given boost, I would use enable_if to speed up.  Avoid for now.
+                    if( hasColorTable == false ){
+                        write_pixel( scanline[x], gdalType, nChannels, img, y, x, color );
+                    }
+                    else{
+                        write_ctable_pixel( scanline[x], gdalType, gdalColorTable, img, y, x, color );
+                    }
+                }
+            }
+
+            // delete our temp pointer
+            delete [] scanline;
+        }
     }
 
     return true;


### PR DESCRIPTION
Fixing CV_8UC1 symbol, which should be CV_8UC3 for RGB GDAL color table images.

Fixing image.ptr<VecX>(row,col)[] to be (*image.ptr<VecX>(row,col))[] to correctly access VecX array elements, as ptr<VecX>() returns a pointer to the VecX, not the first element of VecX. This fixes the color problem with color table gif images, and avoids out-of-bounds memory access.

Respecting the color identification of raster bands provided by the GDAL image driver, and produce BGR or BGRA images. Note that color bands of images using the HSL, CMY, CMYK, or YCbCr color space are ignored, rather than converting them to BGR.

<!-- Please use this line to close one or multiple issues when this pullrequest gets merged
You can add another line right under the first one:
resolves #1234
resolves #1235
-->
resolves #10089

### This pullrequest changes

<!-- Please describe what your pullrequest is changing -->

Changes modules/imgcodecs/src/grfmt_gdal.cpp to correct image read using the GDAL decoder.
Test images:
[GdalTestImages.zip](https://github.com/opencv/opencv/files/1475472/GdalTestImages.zip)

Code to test changes:
```.cpp
/*
 * Test GDAL image read
 */

#include <iostream>

#include <opencv2/core/core.hpp>
#include <opencv2/highgui/highgui.hpp>

void printUsage(char *progName)
{
    std::cout << "Usage: " << progName << " [option(s)] image1 ...\n";
    std::cout << "Options:\n"
              << "  -h   Help\n";
}

int main( int argc, char** argv )
{
  int firstArg = 1;
  
  if (argc > 1)
  {
    if (strcmp(argv[1], "-h") == 0)
    {
      printUsage(argv[0]);
      return -1;
    }
  }

  if((argc-firstArg) == 0)
  {
    printUsage(argv[0]);
    return -1;
  }

  // Create a window for display.
  cv::namedWindow( "Display window", cv::WINDOW_AUTOSIZE );

  for (size_t i=firstArg; i < argc; i++)
  {
    std::cout << "Loading image file " << argv[i] << "...\n";

    cv::Mat image;

    // Read the file
    int readFlags = CV_LOAD_IMAGE_COLOR | cv::IMREAD_LOAD_GDAL;
    image = cv::imread(argv[i], readFlags);

    // Check for invalid input
    if(image.empty())
    {
      std::cerr <<  "Could not open or find the image\n";
    }
    else
    {
      std::cout << "Read " << image.cols << " x " << image.rows << " x "
                << image.elemSize() << " image\n";

      // Show our image inside it.
      if ((image.depth() == CV_16S) || (image.depth() == CV_16U))
      {
        cv::convertScaleAbs(image, image, 1.0/256.0);
      }
      else if (image.depth() == CV_32S)
      {
        cv::convertScaleAbs(image, image, 1.0/(256.0*256.0*256.0));
      }
      else if ((image.depth() == CV_32F) || (image.depth() == CV_64F))
      {
        cv::normalize(image, image, 255, 0);
      }
      cv::imshow( "Display window", image );
    }

    // Wait for a keystroke in the window
    cv::waitKey(0);
  }
  return 0;
}
```

```
docker_image:Custom=ubuntu:17.10
```
