### PR TITLE
dnn(ocl4dnn): Fix wrong measurement for tuning time

### DIFF
--- a/modules/dnn/src/ocl4dnn/include/ocl4dnn.hpp
+++ b/modules/dnn/src/ocl4dnn/include/ocl4dnn.hpp
@@ -217,8 +217,7 @@ class OCL4DNNConvSpatial
         bool convolve(const UMat &bottom, UMat &top,
                       const UMat &weight, const UMat &bias,
                       int32_t numImages,
-                      kernelConfig* config,
-                      const cv::ocl::Queue& queue);
+                      kernelConfig* config);
         float timedConvolve(const UMat &bottom, UMat &top,
                             const UMat &weight, const UMat &bias,
                             int32_t numImages, kernelConfig* config);


### PR DESCRIPTION
convolution kernel use default queue to run, so that ocl::Timer
, to measure the kernel run time, should use the default queue too.

Also remove useless parameter for convolve()

Signed-off-by: Wu Zhiwen <zhiwen.wu@intel.com>

<!-- Please use this line to close one or multiple issues when this pullrequest gets merged
You can add another line right under the first one:
resolves #1234
resolves #1235
-->

### This pullrequest changes

<!-- Please describe what your pullrequest is changing -->
