### PR TITLE
js: fix tests (qunit -> node-qunit)

### DIFF
--- a/modules/js/test/package.json
+++ b/modules/js/test/package.json
@@ -3,7 +3,7 @@
   "description": "Tests for opencv js bindings",
   "version": "1.0.0",
   "dependencies" : {
-    "qunit" : "latest"
+    "node-qunit" : "latest"
   },
   "devDependencies": {
     "eslint" : "latest",
@@ -18,7 +18,7 @@
   },
   "keywords": [],
   "author": "",
-  "license": "BSD-4-Clause",
+  "license": "BSD-3-Clause",
   "bugs": {
     "url": "https://github.com/opencv/opencv/issues"
   },

--- a/modules/js/test/tests.js
+++ b/modules/js/test/tests.js
@@ -38,7 +38,7 @@
 // the use of this software, even if advised of the possibility of such damage.
 //
 
-let testrunner = require('qunit');
+let testrunner = require('node-qunit');
 testrunner.options.maxBlockDuration = 20000; // cause opencv_js.js need time to load
 
 testrunner.run(
@@ -49,5 +49,10 @@ testrunner.run(
     },
     function(err, report) {
         console.log(report.failed + ' failed, ' + report.passed + ' passed');
+        if (report.failed) {
+            process.on('exit', function() {
+                process.exit(1);
+            });
+        }
     }
 );


### PR DESCRIPTION
https://www.npmjs.com/package/node-qunit:
> Up until version 1.0.0, this package was published under the name qunit. That name is now used by the official QUnit package and CLI, and this package will be published as node-qunit from version 1.0.0 onward.

```
docker_image:Custom=javascript
```