### PR TITLE
dnn(ocl4dnn): Fix relu fusion bug

### DIFF
--- a/modules/dnn/src/ocl4dnn/include/ocl4dnn.hpp
+++ b/modules/dnn/src/ocl4dnn/include/ocl4dnn.hpp
@@ -302,7 +302,7 @@ class OCL4DNNConvSpatial
         std::stringstream options_;
         cv::ocl::ProgramSource src_;
         int32_t prev_kernel_type_;
-        bool negative_slope_;
+        float negative_slope_;
         UMat negative_slope_umat_;
         ocl4dnnFusedActiv_t fused_activ_;
 };

--- a/modules/dnn/test/test_darknet_importer.cpp
+++ b/modules/dnn/test/test_darknet_importer.cpp
@@ -44,6 +44,8 @@
 #include "test_precomp.hpp"
 #include <opencv2/dnn/shape_utils.hpp>
 #include <algorithm>
+#include <opencv2/core/ocl.hpp>
+#include <opencv2/ts/ocl_test.hpp>
 
 namespace cvtest
 {
@@ -67,6 +69,64 @@ TEST(Test_Darknet, read_yolo_voc)
 {
     Net net = readNetFromDarknet(_tf("yolo-voc.cfg"));
     ASSERT_FALSE(net.empty());
+}
+
+OCL_TEST(Reproducibility_TinyYoloVoc, Accuracy)
+{
+    Net net;
+    {
+        const string cfg = findDataFile("dnn/tiny-yolo-voc.cfg", false);
+        const string model = findDataFile("dnn/tiny-yolo-voc.weights", false);
+        net = readNetFromDarknet(cfg, model);
+        ASSERT_FALSE(net.empty());
+    }
+
+    net.setPreferableBackend(DNN_BACKEND_DEFAULT);
+    net.setPreferableTarget(DNN_TARGET_OPENCL);
+
+    // dog416.png is dog.jpg that resized to 416x416 in the lossless PNG format
+    Mat sample = imread(_tf("dog416.png"));
+    ASSERT_TRUE(!sample.empty());
+
+    Size inputSize(416, 416);
+
+    if (sample.size() != inputSize)
+        resize(sample, sample, inputSize);
+
+    net.setInput(blobFromImage(sample, 1 / 255.F), "data");
+    Mat out = net.forward("detection_out");
+
+    Mat detection;
+    const float confidenceThreshold = 0.24;
+
+    for (int i = 0; i < out.rows; i++) {
+        const int probability_index = 5;
+        const int probability_size = out.cols - probability_index;
+        float *prob_array_ptr = &out.at<float>(i, probability_index);
+        size_t objectClass = std::max_element(prob_array_ptr, prob_array_ptr + probability_size) - prob_array_ptr;
+        float confidence = out.at<float>(i, (int)objectClass + probability_index);
+
+        if (confidence > confidenceThreshold)
+            detection.push_back(out.row(i));
+    }
+
+    // obtained by: ./darknet detector test ./cfg/voc.data  ./cfg/tiny-yolo-voc.cfg ./tiny-yolo-voc.weights -thresh 0.24 ./dog416.png
+    // There are 2 objects (6-car, 11-dog) with 25 values for each:
+    // { relative_center_x, relative_center_y, relative_width, relative_height, unused_t0, probability_for_each_class[20] }
+    float ref_array[] = {
+        0.736762F, 0.239551F, 0.315440F, 0.160779F, 0.761977F, 0.000000F, 0.000000F, 0.000000F, 0.000000F,
+        0.000000F, 0.000000F, 0.761967F, 0.000000F, 0.000000F, 0.000000F, 0.000000F, 0.000000F,
+        0.000000F, 0.000000F, 0.000000F, 0.000000F, 0.000000F, 0.000000F, 0.000000F, 0.000000F,
+
+        0.287486F, 0.653731F, 0.315579F, 0.534527F, 0.782737F, 0.000000F, 0.000000F, 0.000000F, 0.000000F,
+        0.000000F, 0.000000F, 0.000000F, 0.000000F, 0.000000F, 0.000000F, 0.000000F, 0.780595F,
+        0.000000F, 0.000000F, 0.000000F, 0.000000F, 0.000000F, 0.000000F, 0.000000F, 0.000000F
+    };
+
+    const int number_of_objects = 2;
+    Mat ref(number_of_objects, sizeof(ref_array) / (number_of_objects * sizeof(float)), CV_32FC1, &ref_array);
+
+    normAssert(ref, detection);
 }
 
 TEST(Reproducibility_TinyYoloVoc, Accuracy)


### PR DESCRIPTION
Incorrect type of negative_slope result in this bug.

Also add OCL test for darknet to validate this patch.

Signed-off-by: Wu Zhiwen <zhiwen.wu@intel.com>

<!-- Please use this line to close one or multiple issues when this pullrequest gets merged
You can add another line right under the first one:
resolves #1234
resolves #1235
-->

### This pullrequest changes

<!-- Please describe what your pullrequest is changing -->
