### PR TITLE
dnn: Avoid name collisions with other caffe protobuf

### DIFF
--- a/modules/dnn/src/caffe/caffe_importer.cpp
+++ b/modules/dnn/src/caffe/caffe_importer.cpp
@@ -77,8 +77,8 @@ static cv::String toString(const T &v)
 
 class CaffeImporter : public Importer
 {
-    caffe::NetParameter net;
-    caffe::NetParameter netBinary;
+    opencvcaffe::NetParameter net;
+    opencvcaffe::NetParameter netBinary;
 
 public:
 
@@ -196,7 +196,7 @@ public:
         }
     }
 
-    void blobShapeFromProto(const caffe::BlobProto &pbBlob, MatShape& shape)
+    void blobShapeFromProto(const opencvcaffe::BlobProto &pbBlob, MatShape& shape)
     {
         shape.clear();
         if (pbBlob.has_num() || pbBlob.has_channels() || pbBlob.has_height() || pbBlob.has_width())
@@ -208,7 +208,7 @@ public:
         }
         else if (pbBlob.has_shape())
         {
-            const caffe::BlobShape &_shape = pbBlob.shape();
+            const opencvcaffe::BlobShape &_shape = pbBlob.shape();
 
             for (int i = 0; i < _shape.dim_size(); i++)
                 shape.push_back((int)_shape.dim(i));
@@ -217,7 +217,7 @@ public:
             shape.resize(1, 1);  // Is a scalar.
     }
 
-    void blobFromProto(const caffe::BlobProto &pbBlob, cv::Mat &dstBlob)
+    void blobFromProto(const opencvcaffe::BlobProto &pbBlob, cv::Mat &dstBlob)
     {
         MatShape shape;
         blobShapeFromProto(pbBlob, shape);
@@ -237,7 +237,7 @@ public:
         else
         {
             // Half precision floats.
-            CV_Assert(pbBlob.raw_data_type() == caffe::FLOAT16);
+            CV_Assert(pbBlob.raw_data_type() == opencvcaffe::FLOAT16);
             std::string raw_data = pbBlob.raw_data();
 
             CV_Assert(raw_data.size() / 2 == (int)dstBlob.total());
@@ -247,7 +247,7 @@ public:
         }
     }
 
-    void extractBinaryLayerParms(const caffe::LayerParameter& layer, LayerParams& layerParams)
+    void extractBinaryLayerParms(const opencvcaffe::LayerParameter& layer, LayerParams& layerParams)
     {
         const std::string &name = layer.name();
 
@@ -261,7 +261,7 @@ public:
         if (li == netBinary.layer_size() || netBinary.layer(li).blobs_size() == 0)
             return;
 
-        const caffe::LayerParameter &binLayer = netBinary.layer(li);
+        const opencvcaffe::LayerParameter &binLayer = netBinary.layer(li);
         layerParams.blobs.resize(binLayer.blobs_size());
         for (int bi = 0; bi < binLayer.blobs_size(); bi++)
         {
@@ -302,7 +302,7 @@ public:
 
         for (int li = 0; li < layersSize; li++)
         {
-            const caffe::LayerParameter &layer = net.layer(li);
+            const opencvcaffe::LayerParameter &layer = net.layer(li);
             String name = layer.name();
             String type = layer.type();
             LayerParams layerParams;
@@ -334,7 +334,7 @@ public:
         addedBlobs.clear();
     }
 
-    void addOutput(const caffe::LayerParameter &layer, int layerId, int outNum)
+    void addOutput(const opencvcaffe::LayerParameter &layer, int layerId, int outNum)
     {
         const std::string &name = layer.top(outNum);
 

--- a/modules/dnn/src/caffe/caffe_io.cpp
+++ b/modules/dnn/src/caffe/caffe_io.cpp
@@ -107,7 +107,7 @@ namespace dnn {
 
 using std::string;
 using std::map;
-using namespace caffe;
+using namespace opencvcaffe;
 using namespace ::google::protobuf;
 using namespace ::google::protobuf::io;
 

--- a/modules/dnn/src/caffe/caffe_io.hpp
+++ b/modules/dnn/src/caffe/caffe_io.hpp
@@ -98,9 +98,9 @@ namespace dnn {
 
 // Read parameters from a file into a NetParameter proto message.
 void ReadNetParamsFromTextFileOrDie(const char* param_file,
-                                    caffe::NetParameter* param);
+                                    opencvcaffe::NetParameter* param);
 void ReadNetParamsFromBinaryFileOrDie(const char* param_file,
-                                      caffe::NetParameter* param);
+                                      opencvcaffe::NetParameter* param);
 
 }
 }

--- a/modules/dnn/src/caffe/caffe_shrinker.cpp
+++ b/modules/dnn/src/caffe/caffe_shrinker.cpp
@@ -28,19 +28,19 @@ void shrinkCaffeModel(const String& src, const String& dst, const std::vector<St
         types.push_back("InnerProduct");
     }
 
-    caffe::NetParameter net;
+    opencvcaffe::NetParameter net;
     ReadNetParamsFromBinaryFileOrDie(src.c_str(), &net);
 
     for (int i = 0; i < net.layer_size(); ++i)
     {
-        caffe::LayerParameter* lp = net.mutable_layer(i);
+        opencvcaffe::LayerParameter* lp = net.mutable_layer(i);
         if (std::find(types.begin(), types.end(), lp->type()) == types.end())
         {
             continue;
         }
         for (int j = 0; j < lp->blobs_size(); ++j)
         {
-            caffe::BlobProto* blob = lp->mutable_blobs(j);
+            opencvcaffe::BlobProto* blob = lp->mutable_blobs(j);
             CV_Assert(blob->data_size() != 0);  // float32 array.
 
             Mat floats(1, blob->data_size(), CV_32FC1, (void*)blob->data().data());
@@ -51,7 +51,7 @@ void shrinkCaffeModel(const String& src, const String& dst, const std::vector<St
 
             // Set float16 data.
             blob->set_raw_data(halfs.data, halfs.total() * halfs.elemSize());
-            blob->set_raw_data_type(caffe::FLOAT16);
+            blob->set_raw_data_type(opencvcaffe::FLOAT16);
         }
     }
     size_t msgSize = net.ByteSizeLong();

--- a/modules/dnn/src/caffe/opencv-caffe.proto
+++ b/modules/dnn/src/caffe/opencv-caffe.proto
@@ -48,7 +48,7 @@
 
 syntax = "proto2";
 
-package caffe;
+package opencvcaffe;
 
 // NVidia's Caffe feature is used to store fp16 weights, https://github.com/NVIDIA/caffe:
 // Math and storage types


### PR DESCRIPTION
Resolves errors like:

root@qt5122:~# python3
Python 3.5.3 (default, Nov 18 2017, 22:27:37)
[GCC 7.2.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import cv2
[libprotobuf ERROR google/protobuf/descriptor_database.cc:111] Symbol name "caffe.BlobShape" conflicts with the existing symbol "caffe.BlobShape".
[libprotobuf FATAL google/protobuf/descriptor.cc:1315] CHECK failed: generated_database_->Add(encoded_file_descriptor, size):
terminate called after throwing an instance of 'google::protobuf::FatalException'
  what():  CHECK failed: generated_database_->Add(encoded_file_descriptor, size):
Aborted
root@qt5122:~#

Signed-off-by: Ricardo Ribalda Delgado <ricardo.ribalda@gmail.com>

resolves #10092 


