### PR TITLE
videoio: fixed capture open order, added apiPrefernce to FFMPEG tests

### DIFF
--- a/modules/videoio/src/cap.cpp
+++ b/modules/videoio/src/cap.cpp
@@ -527,49 +527,35 @@ static Ptr<IVideoCapture> IVideoCapture_create(int index)
 }
 
 
-static Ptr<IVideoCapture> IVideoCapture_create(const String& filename)
+static Ptr<IVideoCapture> IVideoCapture_create(const String& filename, int apiPreference)
 {
-    int  domains[] =
-    {
-        CAP_ANY,
+    bool useAny = (apiPreference == CAP_ANY);
+    Ptr<IVideoCapture> capture;
 #ifdef HAVE_GPHOTO2
-        CAP_GPHOTO2,
-#endif
-#ifdef HAVE_MFX
-        CAP_INTEL_MFX,
-#endif
-        -1, -1
-    };
-
-    // try every possibly installed camera API
-    for (int i = 0; domains[i] >= 0; i++)
+    if (useAny || apiPreference == CAP_GPHOTO2)
     {
-        Ptr<IVideoCapture> capture;
-
-        switch (domains[i])
-        {
-        case CAP_ANY:
-            capture = createMotionJpegCapture(filename);
-            break;
-#ifdef HAVE_GPHOTO2
-        case CAP_GPHOTO2:
-            capture = createGPhoto2Capture(filename);
-            break;
-#endif
-#ifdef HAVE_MFX
-        case CAP_INTEL_MFX:
-            capture = makePtr<VideoCapture_IntelMFX>(filename);
-            break;
-#endif
-        }
-
+        capture = createGPhoto2Capture(filename);
         if (capture && capture->isOpened())
-        {
             return capture;
-        }
     }
-    // failed open a camera
-    return Ptr<IVideoCapture>();
+#endif
+#ifdef HAVE_MFX
+    if (useAny || apiPreference == CAP_INTEL_MFX)
+    {
+        capture = makePtr<VideoCapture_IntelMFX>(filename);
+        if (capture && capture->isOpened())
+            return capture;
+    }
+#endif
+    if (useAny || apiPreference == CAP_OPENCV_MJPEG)
+    {
+        capture = createMotionJpegCapture(filename);
+        if (capture && capture->isOpened())
+            return capture;
+    }
+    if (capture && !capture->isOpened())
+        capture.release();
+    return capture;
 }
 
 static Ptr<IVideoWriter> IVideoWriter_create(const String& filename, int apiPreference, int _fourcc, double fps, Size frameSize, bool isColor)
@@ -625,7 +611,7 @@ bool VideoCapture::open(const String& filename, int apiPreference)
     CV_TRACE_FUNCTION();
 
     if (isOpened()) release();
-    icap = IVideoCapture_create(filename);
+    icap = IVideoCapture_create(filename, apiPreference);
     if (!icap.empty())
         return true;
 

--- a/modules/videoio/test/test_ffmpeg.cpp
+++ b/modules/videoio/test/test_ffmpeg.cpp
@@ -131,7 +131,7 @@ public:
                     fps = 25;
                 }
 
-                VideoWriter writer(filename, tag, fps, frame_s);
+                VideoWriter writer(filename, CAP_FFMPEG, tag, fps, frame_s);
 
                 if (writer.isOpened() == false)
                 {
@@ -194,7 +194,7 @@ public:
         try
         {
             string filename = ts->get_data_path() + "readwrite/ordinary.bmp";
-            VideoCapture cap(filename);
+            VideoCapture cap(filename, CAP_FFMPEG);
             Mat img0 = imread(filename, 1);
             Mat img, img_next;
             cap >> img;
@@ -242,7 +242,7 @@ public:
             std::string fileName = tempfile(stream.str().c_str());
 
             files->operator[](i) = fileName;
-            writers->operator[](i) = new VideoWriter(fileName, VideoWriter::fourcc('X','V','I','D'), 25.0f, FrameSize);
+            writers->operator[](i) = new VideoWriter(fileName, CAP_FFMPEG, VideoWriter::fourcc('X','V','I','D'), 25.0f, FrameSize);
 
             CV_Assert(writers->operator[](i)->isOpened());
         }
@@ -325,7 +325,7 @@ public:
     {
         for (int i = range.start; i != range.end; ++i)
         {
-            readers->operator[](i) = new VideoCapture(files->operator[](i));
+            readers->operator[](i) = new VideoCapture(files->operator[](i), CAP_FFMPEG);
             CV_Assert(readers->operator[](i)->isOpened());
         }
     }


### PR DESCRIPTION
### This pullrequest changes

- VideoCapture backend creation algorithm did not take in account API preference parameter
- two FFMPEG-specific tests did not provide API preference

Fixes crash in _Videoio_Video_parallllel_writers_and_readers_ test when GPhoto2 backend is available.

```
docker_image:Custom=ubuntu:17.10
```