### PR TITLE
videoio(ffmpeg): more workarounds for sws_scale() crash

### DIFF
--- a/modules/videoio/src/cap_ffmpeg_impl.hpp
+++ b/modules/videoio/src/cap_ffmpeg_impl.hpp
@@ -1317,6 +1317,7 @@ struct CvVideoWriter_FFMPEG
     AVStream        * video_st;
     int               input_pix_fmt;
     unsigned char   * aligned_input;
+    size_t            aligned_input_size;
     int               frame_width, frame_height;
     int               frame_idx;
     bool              ok;
@@ -1394,6 +1395,7 @@ void CvVideoWriter_FFMPEG::init()
     video_st = 0;
     input_pix_fmt = 0;
     aligned_input = NULL;
+    aligned_input_size = 0;
     img_convert_ctx = 0;
     frame_width = frame_height = 0;
     frame_idx = 0;
@@ -1702,17 +1704,28 @@ bool CvVideoWriter_FFMPEG::writeFrame( const unsigned char* data, int step, int 
 #endif
 
     // FFmpeg contains SIMD optimizations which can sometimes read data past
-    // the supplied input buffer. To ensure that doesn't happen, we pad the
-    // step to a multiple of 32 (that's the minimal alignment for which Valgrind
-    // doesn't raise any warnings).
-    const int STEP_ALIGNMENT = 32;
-    if( step % STEP_ALIGNMENT != 0 )
+    // the supplied input buffer.
+    // Related info: https://trac.ffmpeg.org/ticket/6763
+    // 1. To ensure that doesn't happen, we pad the step to a multiple of 32
+    // (that's the minimal alignment for which Valgrind doesn't raise any warnings).
+    // 2. (dataend - SIMD_SIZE) and (dataend + SIMD_SIZE) is from the same 4k page
+    const int CV_STEP_ALIGNMENT = 32;
+    const size_t CV_SIMD_SIZE = 32;
+    const size_t CV_PAGE_MASK = ~(4096 - 1);
+    const uchar* dataend = data + ((size_t)height * step);
+    if (step % CV_STEP_ALIGNMENT != 0 ||
+        (((size_t)dataend - CV_SIMD_SIZE) & CV_PAGE_MASK) != (((size_t)dataend + CV_SIMD_SIZE) & CV_PAGE_MASK))
     {
-        int aligned_step = (step + STEP_ALIGNMENT - 1) & -STEP_ALIGNMENT;
+        int aligned_step = (step + CV_STEP_ALIGNMENT - 1) & ~(CV_STEP_ALIGNMENT - 1);
 
-        if( !aligned_input )
+        size_t new_size = (aligned_step * height + CV_SIMD_SIZE);
+
+        if (!aligned_input || aligned_input_size < new_size)
         {
-            aligned_input = (unsigned char*)av_mallocz(aligned_step * height);
+            if (aligned_input)
+                av_freep(&aligned_input);
+            aligned_input_size = new_size;
+            aligned_input = (unsigned char*)av_mallocz(aligned_input_size);
         }
 
         if (origin == 1)

--- a/platforms/scripts/valgrind_3rdparty.supp
+++ b/platforms/scripts/valgrind_3rdparty.supp
@@ -111,3 +111,12 @@
    ...
    obj:/usr/lib/libgdal.so.1.17.1
 }
+
+{
+   FFMPEG-sws_scale
+   Memcheck:Addr16
+   ...
+   fun:sws_scale
+   ...
+   fun:cvWriteFrame_FFMPEG
+}


### PR DESCRIPTION
avoid access data out of input buffer

Stacktrace example:
```
(gdb) bt
#0  0x00007fffed8a3774 in ff_rgb24ToY_avx () at /lib64/libswscale.so.4
#1  0x00007fffed85e57f in lum_convert () at /lib64/libswscale.so.4
#2  0x00007fffed89142e in swscale () at /lib64/libswscale.so.4
#3  0x00007fffed892638 in sws_scale () at /lib64/libswscale.so.4
#4  0x00007ffff73886fe in CvVideoWriter_FFMPEG::writeFrame(unsigned char const*, int, int, int, int, int) () at /home/alalek/projects/opencv/build/opencv/lib/libopencv_videoio.so.3.3
#5  0x00007ffff738891e in cvWriteFrame_FFMPEG () at /home/alalek/projects/opencv/build/opencv/lib/libopencv_videoio.so.3.3
#6  0x00007ffff7386d7d in CvVideoWriter_FFMPEG_proxy::writeFrame(_IplImage const*) () at /home/alalek/projects/opencv/build/opencv/lib/libopencv_videoio.so.3.3
#7  0x00007ffff736fc96 in cvWriteFrame () at /home/alalek/projects/opencv/build/opencv/lib/libopencv_videoio.so.3.3
#8  0x00007ffff736fd2c in cv::VideoWriter::write(cv::Mat const&) () at /home/alalek/projects/opencv/build/opencv/lib/libopencv_videoio.so.3.3
#9  0x00007ffff736e77c in cv::VideoWriter::operator<<(cv::Mat const&) () at /home/alalek/projects/opencv/build/opencv/lib/libopencv_videoio.so.3.3
#10 0x000000000041c717 in CV_FFmpegWriteBigVideoTest::run(int) ()
#11 0x0000000000434533 in cvtest::BaseTest::safe_run(int) ()
#12 0x000000000041810f in Videoio_Video_ffmpeg_writebig_Test::Body() ()
#13 0x0000000000417e8a in Videoio_Video_ffmpeg_writebig_Test::TestBody() ()
#14 0x00000000004732ca in void testing::internal::HandleExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) ()
#15 0x0000000000473495 in testing::Test::Run() [clone .part.533] ()
#16 0x0000000000473885 in testing::TestInfo::Run() [clone .part.534] ()
#17 0x0000000000473b65 in testing::TestCase::Run() [clone .part.535] ()
#18 0x000000000047411a in testing::internal::UnitTestImpl::RunAllTests() ()
#19 0x000000000047430a in bool testing::internal::HandleExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) ()
#20 0x0000000000474494 in testing::UnitTest::Run() ()
#21 0x0000000000417020 in main ()
(gdb) x/4i $rip
=> 0x7fffed8a3774 <ff_rgb24ToY_avx+52>:	vmovdqu 0xc(%rsi),%xmm2
   0x7fffed8a3779 <ff_rgb24ToY_avx+57>:	vpshufb %xmm10,%xmm0,%xmm1
   0x7fffed8a377e <ff_rgb24ToY_avx+62>:	vpshufb %xmm7,%xmm0,%xmm0
   0x7fffed8a3783 <ff_rgb24ToY_avx+67>:	vpshufb %xmm10,%xmm2,%xmm3
```
