### PR TITLE
Convert Keypoint and DMatch objects into Python `dict`s

### DIFF
--- a/modules/core/include/opencv2/core/types.hpp
+++ b/modules/core/include/opencv2/core/types.hpp
@@ -704,7 +704,7 @@ keypoint neighborhood is then analyzed by another algorithm that builds a descri
 represented as a feature vector). The keypoints representing the same object in different images
 can then be matched using cv::KDTree or another method.
 */
-class CV_EXPORTS_W_SIMPLE KeyPoint
+class CV_EXPORTS_W_MAP KeyPoint
 {
 public:
     //! the default constructor
@@ -801,7 +801,7 @@ public:
 query descriptor index, train descriptor index, train image index, and distance between
 descriptors.
 */
-class CV_EXPORTS_W_SIMPLE DMatch
+class CV_EXPORTS_W_MAP DMatch
 {
 public:
     CV_WRAP DMatch();

--- a/modules/python/src2/cv2.cpp
+++ b/modules/python/src2/cv2.cpp
@@ -1511,6 +1511,30 @@ PyObject* pyopencv_from(const RotatedRect& src)
 }
 
 template<>
+PyObject* pyopencv_from(const KeyPoint& kp)
+{
+    return Py_BuildValue("{s:O,s:f,s:f,s:f,s:i,s:i}",
+        "pt", pyopencv_from(kp.pt),
+        "size", kp.size,
+        "angle", kp.angle,
+        "response", kp.response,
+        "octave", kp.octave,
+        "class_id", kp.class_id
+    );
+}
+
+template<>
+PyObject* pyopencv_from(const DMatch& m)
+{
+    return Py_BuildValue("{s:i,s:i,s:i,s:f}",
+        "queryIdx", m.queryIdx,
+        "trainIdx", m.trainIdx,
+        "imgIdx", m.imgIdx,
+        "distance", m.distance
+    );
+}
+
+template<>
 PyObject* pyopencv_from(const Moments& m)
 {
     return Py_BuildValue("{s:d,s:d,s:d,s:d,s:d,s:d,s:d,s:d,s:d,s:d,s:d,s:d,s:d,s:d,s:d,s:d,s:d,s:d,s:d,s:d,s:d,s:d,s:d,s:d}",

--- a/modules/python/test/test_feature_homography.py
+++ b/modules/python/test/test_feature_homography.py
@@ -103,7 +103,7 @@ class PlaneTracker:
         raw_points, raw_descrs = self.detect_features(image)
         points, descs = [], []
         for kp, desc in zip(raw_points, raw_descrs):
-            x, y = kp.pt
+            x, y = kp['pt']
             if x0 <= x <= x1 and y0 <= y <= y1:
                 points.append(kp)
                 descs.append(desc)
@@ -123,19 +123,19 @@ class PlaneTracker:
         if len(self.frame_points) < MIN_MATCH_COUNT:
             return []
         matches = self.matcher.knnMatch(frame_descrs, k = 2)
-        matches = [m[0] for m in matches if len(m) == 2 and m[0].distance < m[1].distance * 0.75]
+        matches = [m[0] for m in matches if len(m) == 2 and m[0]['distance'] < m[1]['distance'] * 0.75]
         if len(matches) < MIN_MATCH_COUNT:
             return []
         matches_by_id = [[] for _ in xrange(len(self.targets))]
         for m in matches:
-            matches_by_id[m.imgIdx].append(m)
+            matches_by_id[m['imgIdx']].append(m)
         tracked = []
         for imgIdx, matches in enumerate(matches_by_id):
             if len(matches) < MIN_MATCH_COUNT:
                 continue
             target = self.targets[imgIdx]
-            p0 = [target.keypoints[m.trainIdx].pt for m in matches]
-            p1 = [self.frame_points[m.queryIdx].pt for m in matches]
+            p0 = [target.keypoints[m['trainIdx']]['pt'] for m in matches]
+            p1 = [self.frame_points[m['queryIdx']]['pt'] for m in matches]
             p0, p1 = np.float32((p0, p1))
             H, status = cv2.findHomography(p0, p1, cv2.RANSAC, 3.0)
             status = status.ravel() != 0

--- a/modules/python/test/test_legacy.py
+++ b/modules/python/test/test_legacy.py
@@ -51,7 +51,7 @@ class Hackathon244Tests(NewOpenCVTests):
         keypoints = fd.detect(img)
         self.assertTrue(600 <= len(keypoints) <= 700)
         for kpt in keypoints:
-            self.assertNotEqual(kpt.response, 0)
+            self.assertNotEqual(kpt['response'], 0)
 
     def check_close_angles(self, a, b, angle_delta):
         self.assertTrue(abs(a - b) <= angle_delta or

--- a/samples/python/asift.py
+++ b/samples/python/asift.py
@@ -86,8 +86,8 @@ def affine_detect(detector, img, mask=None, pool=None):
         timg, tmask, Ai = affine_skew(t, phi, img)
         keypoints, descrs = detector.detectAndCompute(timg, tmask)
         for kp in keypoints:
-            x, y = kp.pt
-            kp.pt = tuple( np.dot(Ai, (x, y, 1)) )
+            x, y = kp['pt']
+            kp['pt'] = tuple( np.dot(Ai, (x, y, 1)) )
         if descrs is None:
             descrs = []
         return keypoints, descrs

--- a/samples/python/common.py
+++ b/samples/python/common.py
@@ -233,5 +233,5 @@ def mdot(*args):
 
 def draw_keypoints(vis, keypoints, color = (0, 255, 255)):
     for kp in keypoints:
-        x, y = kp.pt
+        x, y = kp['pt']
         cv2.circle(vis, (int(x), int(y)), 2, color)

--- a/samples/python/find_obj.py
+++ b/samples/python/find_obj.py
@@ -61,12 +61,12 @@ def init_feature(name):
 def filter_matches(kp1, kp2, matches, ratio = 0.75):
     mkp1, mkp2 = [], []
     for m in matches:
-        if len(m) == 2 and m[0].distance < m[1].distance * ratio:
+        if len(m) == 2 and m[0]['distance'] < m[1]['distance'] * ratio:
             m = m[0]
-            mkp1.append( kp1[m.queryIdx] )
-            mkp2.append( kp2[m.trainIdx] )
-    p1 = np.float32([kp.pt for kp in mkp1])
-    p2 = np.float32([kp.pt for kp in mkp2])
+            mkp1.append( kp1[m['queryIdx']] )
+            mkp2.append( kp2[m['trainIdx']] )
+    p1 = np.float32([kp['pt'] for kp in mkp1])
+    p2 = np.float32([kp['pt'] for kp in mkp2])
     kp_pairs = zip(mkp1, mkp2)
     return p1, p2, list(kp_pairs)
 
@@ -87,8 +87,8 @@ def explore_match(win, img1, img2, kp_pairs, status = None, H = None):
         status = np.ones(len(kp_pairs), np.bool_)
     p1, p2 = [], []  # python 2 / python 3 change of zip unpacking
     for kpp in kp_pairs:
-        p1.append(np.int32(kpp[0].pt))
-        p2.append(np.int32(np.array(kpp[1].pt) + [w1, 0]))
+        p1.append(np.int32(kpp[0]['pt']))
+        p2.append(np.int32(np.array(kpp[1]['pt']) + [w1, 0]))
 
     green = (0, 255, 0)
     red = (0, 0, 255)

--- a/samples/python/plane_tracker.py
+++ b/samples/python/plane_tracker.py
@@ -81,7 +81,7 @@ class PlaneTracker:
         raw_points, raw_descrs = self.detect_features(image)
         points, descs = [], []
         for kp, desc in zip(raw_points, raw_descrs):
-            x, y = kp.pt
+            x, y = kp['pt']
             if x0 <= x <= x1 and y0 <= y <= y1:
                 points.append(kp)
                 descs.append(desc)
@@ -101,19 +101,19 @@ class PlaneTracker:
         if len(self.frame_points) < MIN_MATCH_COUNT:
             return []
         matches = self.matcher.knnMatch(frame_descrs, k = 2)
-        matches = [m[0] for m in matches if len(m) == 2 and m[0].distance < m[1].distance * 0.75]
+        matches = [m[0] for m in matches if len(m) == 2 and m[0]['distance'] < m[1]['distance'] * 0.75]
         if len(matches) < MIN_MATCH_COUNT:
             return []
         matches_by_id = [[] for _ in xrange(len(self.targets))]
         for m in matches:
-            matches_by_id[m.imgIdx].append(m)
+            matches_by_id[m['imgIdx']].append(m)
         tracked = []
         for imgIdx, matches in enumerate(matches_by_id):
             if len(matches) < MIN_MATCH_COUNT:
                 continue
             target = self.targets[imgIdx]
-            p0 = [target.keypoints[m.trainIdx].pt for m in matches]
-            p1 = [self.frame_points[m.queryIdx].pt for m in matches]
+            p0 = [target.keypoints[m['trainIdx']]['pt'] for m in matches]
+            p1 = [self.frame_points[m['queryIdx']]['pt'] for m in matches]
             p0, p1 = np.float32((p0, p1))
             H, status = cv2.findHomography(p0, p1, cv2.RANSAC, 3.0)
             status = status.ravel() != 0


### PR DESCRIPTION
### This pullrequest changes
resolves #10158
- Convert DMatch objects into Python dicts
- Convert Keypoint objects into Python dicts


Although current python code will get broken, but fixing it is very easy
Just replace the dots with the brackets (e.g. `m['queryIdx']` instead of
`m.queryIdx`)
Alternatively, you can recover the legacy behaviour using namedtuple. Example:
```
from collections import namedtuple
m = namedtuple("DMatch", m.keys())(*m.values())
print(m.queryIdx)
```

The great news is that we can now vectorize the code and avoid using
loops to access the attributes, by converting the list of dicts into
numpy arrays. Example:

```
import pandas
matches = pandas.DataFrame(matches).values #queryIdx, trainIdx, imgIdx, distance
src_kps[matches[0]]
```