### PR TITLE
Fixes Issue #10181

### DIFF
--- a/modules/core/src/arithm_simd.hpp
+++ b/modules/core/src/arithm_simd.hpp
@@ -1724,8 +1724,8 @@ struct Div_SIMD<double>
             v_float64x2 res0 = f0 * v_scale / f2;
             v_float64x2 res1 = f1 * v_scale / f3;
 
-            res0 = v_select(f0 == v_zero, v_zero, res0);
-            res1 = v_select(f1 == v_zero, v_zero, res1);
+            res0 = v_select(f2 == v_zero, v_zero, res0);
+            res1 = v_select(f3 == v_zero, v_zero, res1);
 
             v_store(dst + x, res0);
             v_store(dst + x + 2, res1);


### PR DESCRIPTION
resolves #10181 

### This pullrequest changes

This PR fixes incorrect division by zero handling in template specialization of `Div_SIMD` for type `double`.

It now checks whether or not the denominator (and not the nominator) is zero. This is consistent with implementations for other datatypes.
