### PR TITLE
build: eliminate Xcode 9.1 warnings

### DIFF
--- a/3rdparty/libjasper/CMakeLists.txt
+++ b/3rdparty/libjasper/CMakeLists.txt
@@ -26,7 +26,7 @@ endif(WIN32 AND NOT MINGW)
 ocv_warnings_disable(CMAKE_C_FLAGS -Wno-implicit-function-declaration -Wno-uninitialized -Wmissing-prototypes
                                    -Wno-unused-but-set-parameter -Wmissing-declarations -Wunused -Wshadow
                                    -Wsign-compare -Wstrict-overflow -Wpointer-compare)
-ocv_warnings_disable(CMAKE_C_FLAGS -Wunused-parameter) # clang
+ocv_warnings_disable(CMAKE_C_FLAGS -Wunused-parameter -Wstrict-prototypes) # clang
 ocv_warnings_disable(CMAKE_C_FLAGS /wd4013 /wd4018 /wd4101 /wd4244 /wd4267 /wd4715) # vs2005
 
 if(UNIX)

--- a/cmake/OpenCVCompilerOptions.cmake
+++ b/cmake/OpenCVCompilerOptions.cmake
@@ -160,7 +160,7 @@ if(CMAKE_COMPILER_IS_GNUCXX)
   # Other optimizations
   if(ENABLE_OMIT_FRAME_POINTER)
     add_extra_compiler_option(-fomit-frame-pointer)
-  else()
+  elseif(DEFINED ENABLE_OMIT_FRAME_POINTER)
     add_extra_compiler_option(-fno-omit-frame-pointer)
   endif()
   if(ENABLE_FAST_MATH)

--- a/platforms/ios/cmake/Modules/Platform/iOS.cmake
+++ b/platforms/ios/cmake/Modules/Platform/iOS.cmake
@@ -51,7 +51,10 @@ set (no_warn "-Wno-unused-function -Wno-overloaded-virtual")
 set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${no_warn}")
 set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -stdlib=libc++ -fvisibility=hidden -fvisibility-inlines-hidden ${no_warn}")
 
-set (CMAKE_CXX_FLAGS_RELEASE "-DNDEBUG -O3 -fomit-frame-pointer -ffast-math")
+set(CMAKE_CXX_FLAGS_RELEASE "-DNDEBUG -O3 -ffast-math")
+if(NOT IOS_ARCH STREQUAL "armv7")
+  set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -fomit-frame-pointer")
+endif()
 
 if (HAVE_FLAG_SEARCH_PATHS_FIRST)
     set (CMAKE_C_LINK_FLAGS "-Wl,-search_paths_first ${CMAKE_C_LINK_FLAGS}")


### PR DESCRIPTION
- 3rdparty/libjasper/jas_getopt.c:129:25: warning: this function declaration is not a prototype [-Wstrict-prototypes]
- clang: warning: optimization flag '-fomit-frame-pointer' is not supported for target 'armv7' [-Wignored-optimization-argument]

```
buildworker:Mac=macosx-2
buildworker:iOS=macosx-2
```