### PR TITLE
core:ppc Fixed compilation with xlc, clang.

### DIFF
--- a/modules/core/include/opencv2/core/hal/intrin_vsx.hpp
+++ b/modules/core/include/opencv2/core/hal/intrin_vsx.hpp
@@ -638,7 +638,11 @@ inline _Tpvec v_rotate_right(const _Tpvec& a, const _Tpvec& b)
     enum { CV_SHIFT = 16 - imm * (sizeof(typename _Tpvec::lane_type)) };
     if (CV_SHIFT == 16)
         return a;
+#ifdef __IBMCPP__
+    return _Tpvec(vec_sld(b.val, a.val, CV_SHIFT & 15));
+#else
     return _Tpvec(vec_sld(b.val, a.val, CV_SHIFT));
+#endif
 }
 
 template<int imm, typename _Tpvec>

--- a/modules/core/include/opencv2/core/vsx_utils.hpp
+++ b/modules/core/include/opencv2/core/vsx_utils.hpp
@@ -420,6 +420,21 @@ FORCE_INLINE(rt) fnm(const rg& a) { return __builtin_convertvector(a, rt); }
     { return vec_div(vec_double2_sp(1), vec_sqrt(a)); }
 #endif
 
+// vec_promote missing support for doubleword
+FORCE_INLINE(vec_dword2) vec_promote(long long a, int b)
+{
+    vec_dword2 ret = vec_dword2_z;
+    ret[b & 1] = a;
+    return ret;
+}
+
+FORCE_INLINE(vec_udword2) vec_promote(unsigned long long a, int b)
+{
+    vec_udword2 ret = vec_udword2_z;
+    ret[b & 1] = a;
+    return ret;
+}
+
 // vec_popcnt should return unsigned but clang has different thought just like gcc in vec_vpopcnt
 #define VSX_IMPL_POPCNTU(Tvec, Tvec2, ucast)   \
 FORCE_INLINE(Tvec) vec_popcntu(const Tvec2& a) \
@@ -569,6 +584,12 @@ VSX_IMPL_DIRTY_ODD(vec_udword2, vec_float4, vec_ctulo, vec_ctul)
 
     FORCE_INLINE(vec_dword2) vec_splats(int64 v)
     { return vec_splats((long long) v); }
+
+    FORCE_INLINE(vec_udword2) vec_promote(uint64 a, int b)
+    { return vec_promote((unsigned long long) a, b); }
+
+    FORCE_INLINE(vec_dword2) vec_promote(int64 a, int b)
+    { return vec_promote((long long) a, b); }
 #endif
 
 /*

--- a/modules/core/test/test_ptr.cpp
+++ b/modules/core/test/test_ptr.cpp
@@ -41,6 +41,12 @@
 
 #include "test_precomp.hpp"
 
+#ifdef GTEST_CAN_COMPARE_NULL
+#  define EXPECT_NULL(ptr) EXPECT_EQ(NULL, ptr)
+#else
+#  define EXPECT_NULL(ptr) EXPECT_TRUE(ptr == NULL)
+#endif
+
 using namespace cv;
 
 namespace {
@@ -78,7 +84,7 @@ int dummyObject;
 TEST(Core_Ptr, default_ctor)
 {
     Ptr<int> p;
-    EXPECT_EQ(NULL, p.get());
+    EXPECT_NULL(p.get());
 }
 
 TEST(Core_Ptr, owning_ctor)
@@ -102,7 +108,7 @@ TEST(Core_Ptr, owning_ctor)
 
     {
         Ptr<void> p((void*)0, ReportingDeleter(&deleted));
-        EXPECT_EQ(NULL, p.get());
+        EXPECT_NULL(p.get());
     }
 
     EXPECT_FALSE(deleted);
@@ -187,7 +193,7 @@ TEST(Core_Ptr, release)
     Ptr<Reporter> p1(new Reporter(&deleted));
     p1.release();
     EXPECT_TRUE(deleted);
-    EXPECT_EQ(NULL, p1.get());
+    EXPECT_NULL(p1.get());
 }
 
 TEST(Core_Ptr, reset)
@@ -253,7 +259,7 @@ TEST(Core_Ptr, accessors)
 {
     {
         Ptr<int> p;
-        EXPECT_EQ(NULL, static_cast<int*>(p));
+        EXPECT_NULL(static_cast<int*>(p));
         EXPECT_TRUE(p.empty());
     }
 
@@ -327,7 +333,7 @@ TEST(Core_Ptr, casts)
     {
         Ptr<Reporter> p1(new Reporter(&deleted));
         Ptr<SubReporter> p2 = p1.dynamicCast<SubReporter>();
-        EXPECT_EQ(NULL, p2.get());
+        EXPECT_NULL(p2.get());
         p1.release();
         EXPECT_FALSE(deleted);
     }


### PR DESCRIPTION
resolves #10189

- Use EXPECT_TRUE instead of EXPECT_EQ for comparing NULL in xlc
- Added support for int64 to vec_promote in xlc, clang
- Fixed v_rotate_right in xlc

`docker_image:Custom=powerpc64le`