### PR TITLE
Fixed/disabled warnings produced by GCC 7

### DIFF
--- a/cmake/OpenCVCompilerOptions.cmake
+++ b/cmake/OpenCVCompilerOptions.cmake
@@ -128,6 +128,9 @@ if(CMAKE_COMPILER_IS_GNUCXX)
     add_extra_compiler_option(-Wno-unnamed-type-template-args)
     add_extra_compiler_option(-Wno-comment)
     add_extra_compiler_option(-Wno-implicit-fallthrough)
+    if(CMAKE_COMPILER_IS_GNUCXX AND CMAKE_CXX_COMPILER_VERSION VERSION_EQUAL 7.2.0)
+      add_extra_compiler_option(-Wno-strict-overflow) # Issue is fixed in GCC 7.2.1
+    endif()
   endif()
   add_extra_compiler_option(-fdiagnostics-show-option)
 

--- a/modules/imgcodecs/src/grfmt_gdal.cpp
+++ b/modules/imgcodecs/src/grfmt_gdal.cpp
@@ -426,7 +426,8 @@ bool GdalDecoder::readData( Mat& img ){
         for( int y=0; y<nRows; y++ ){
 
             // get the entire row
-            band->RasterIO( GF_Read, 0, y, nCols, 1, scanline, nCols, 1, GDT_Float64, 0, 0);
+            CPLErr err = band->RasterIO( GF_Read, 0, y, nCols, 1, scanline, nCols, 1, GDT_Float64, 0, 0);
+            CV_Assert(err == CE_None);
 
             // set inside the image
             for( int x=0; x<nCols; x++ ){

--- a/modules/videoio/src/cap_openni2.cpp
+++ b/modules/videoio/src/cap_openni2.cpp
@@ -609,7 +609,7 @@ bool CvCapture_OpenNI2::setDepthGeneratorProperty( int propIdx, double propValue
                 if ( streams[CV_COLOR_STREAM].isValid() )
                 {
                     openni::ImageRegistrationMode mode = propValue != 0.0 ? openni::IMAGE_REGISTRATION_DEPTH_TO_COLOR : openni::IMAGE_REGISTRATION_OFF;
-                    if( !device.getImageRegistrationMode() == mode )
+                    if( device.getImageRegistrationMode() != mode )
                     {
                         if (device.isImageRegistrationModeSupported(mode))
                         {


### PR DESCRIPTION
### This pullrequest changes

GCC 7.2.0 emits `strict-overflow` warnings in compiler generated code with no exact mapping to source code, in next version 7.2.1 this issue have been fixed.

```
force_builders=Custom
docker_image:Custom=ubuntu:17.10
```