### PR TITLE
nn.BatchNormalization and nn.Dropout layers from Torch

### DIFF
--- a/modules/dnn/src/layers/batch_norm_layer.cpp
+++ b/modules/dnn/src/layers/batch_norm_layer.cpp
@@ -119,8 +119,9 @@ public:
         CV_Assert(inputs.size() == 1);
 
         Mat &inpBlob = *inputs[0];
-        int rows = inpBlob.size[2];
-        int cols = inpBlob.size[3];
+        CV_Assert(inpBlob.dims == 2 || inpBlob.dims == 4);
+        int rows = inpBlob.dims > 2 ? inpBlob.size[2] : 1;
+        int cols = inpBlob.dims > 2 ? inpBlob.size[3] : 1;
 
         for (size_t ii = 0; ii < outputs.size(); ii++)
         {

--- a/modules/dnn/test/test_torch_importer.cpp
+++ b/modules/dnn/test/test_torch_importer.cpp
@@ -234,6 +234,11 @@ TEST(Torch_Importer, net_padding)
     runTorchNet("net_spatial_reflection_padding", DNN_TARGET_CPU, "", false, true);
 }
 
+TEST(Torch_Importer, net_non_spatial)
+{
+    runTorchNet("net_non_spatial", DNN_TARGET_CPU, "", false, true);
+}
+
 TEST(Torch_Importer, ENet_accuracy)
 {
     Net net;


### PR DESCRIPTION
<!-- Please use this line to close one or multiple issues when this pullrequest gets merged
You can add another line right under the first one:
resolves #1234
resolves #1235
-->

### This pullrequest changes

Non-spatial versions of batch normalization and dropout layers from Torch: `nn.BatchNormalization` and `nn.Dropout`.

resolves https://github.com/opencv/opencv/issues/10128

**Merge with extra**: https://github.com/opencv/opencv_extra/pull/413