### PR TITLE
FFMPEG isn't loaded from the package directory sometimes

### DIFF
--- a/modules/videoio/src/cap_ffmpeg.cpp
+++ b/modules/videoio/src/cap_ffmpeg.cpp
@@ -124,8 +124,10 @@ private:
             if (m)
             {
                 wchar_t path[MAX_PATH];
-                size_t sz = GetModuleFileNameW(m, path, sizeof(path));
-                if (sz > 0 && ERROR_SUCCESS == GetLastError())
+                const size_t path_size = sizeof(path)/sizeof(*path);
+                size_t sz = GetModuleFileNameW(m, path, path_size);
+                /* Don't handle paths longer than MAX_PATH until that becomes a real issue */
+                if (sz > 0 && sz < path_size)
                 {
                     wchar_t* s = wcsrchr(path, L'\\');
                     if (s)


### PR DESCRIPTION
As per https://msdn.microsoft.com/en-us/library/windows/desktop/ms683197(v=vs.85).aspx , `GetModuleFileName` isn't required to reset `GetLastError` on success, the return value alone is the error indicator.

I actually hit this in XP where the value still was the `ERROR_MOD_NOT_FOUND` from failed `PATH` search.