### PR TITLE
Remove typo/repeated code block

### DIFF
--- a/modules/videoio/src/cap_ffmpeg_impl.hpp
+++ b/modules/videoio/src/cap_ffmpeg_impl.hpp
@@ -1113,11 +1113,6 @@ double CvCapture_FFMPEG::get_duration_sec() const
         sec = (double)ic->streams[video_stream]->duration * r2d(ic->streams[video_stream]->time_base);
     }
 
-    if (sec < eps_zero)
-    {
-        sec = (double)ic->streams[video_stream]->duration * r2d(ic->streams[video_stream]->time_base);
-    }
-
     return sec;
 }
 


### PR DESCRIPTION
resolves #10209 

The repeated conditional statement has been removed, from here:
https://github.com/opencv/opencv/blame/3.3.1/modules/videoio/src/cap_ffmpeg_impl.hpp#L1111-L1115