### PR TITLE
Scale layer in case of 2D inputs

### DIFF
--- a/modules/dnn/src/layers/scale_layer.cpp
+++ b/modules/dnn/src/layers/scale_layer.cpp
@@ -74,8 +74,8 @@ public:
                 {
                     float w = blobs[0].at<float>(n);
                     float b = hasBias ? blobs[1].at<float>(n) : 0;
-                    Mat outBlobPlane = getPlane(outBlob, cn, n);
-                    Mat inpBlobPlane = getPlane(inpBlob, cn, n);
+                    Mat outBlobPlane = slice(outBlob, cn, n);
+                    Mat inpBlobPlane = slice(inpBlob, cn, n);
                     inpBlobPlane.convertTo(outBlobPlane, CV_32F, w, b);
                 }
             }


### PR DESCRIPTION
<!-- Please use this line to close one or multiple issues when this pullrequest gets merged
You can add another line right under the first one:
resolves #1234
resolves #1235
-->

### This pullrequest changes

Test case with scale layer right after a fully-connected one: `getPlane` has [an assertion](https://github.com/opencv/opencv/blob/master/modules/dnn/include/opencv2/dnn/shape_utils.hpp#L114) that number of dimensions is greater than 2.

**Merge with extra**: https://github.com/opencv/opencv_extra/pull/417
