### PR TITLE
core: fix persistence with deprecated traits

### DIFF
--- a/modules/core/include/opencv2/core/persistence.hpp
+++ b/modules/core/include/opencv2/core/persistence.hpp
@@ -851,7 +851,9 @@ namespace internal
             size_t remaining = it->remaining;
             size_t cn = DataType<_Tp>::channels;
             int _fmt = traits::SafeFmt<_Tp>::fmt;
+            CV_Assert((_fmt >> 8) < 9);
             char fmt[] = { (char)((_fmt >> 8)+'1'), (char)_fmt, '\0' };
+            CV_Assert((remaining % cn) == 0);
             size_t remaining1 = remaining / cn;
             count = count < remaining1 ? count : remaining1;
             vec.resize(count);

--- a/modules/core/src/persistence.cpp
+++ b/modules/core/src/persistence.cpp
@@ -7367,8 +7367,18 @@ void read(const FileNode& node, std::vector<KeyPoint>& keypoints)
     if (first_node.isSeq())
     {
         // modern scheme
+#ifdef OPENCV_TRAITS_ENABLE_DEPRECATED
+        FileNodeIterator it = node.begin();
+        size_t total = (size_t)it.remaining;
+        keypoints.resize(total);
+        for (size_t i = 0; i < total; ++i, ++it)
+        {
+            (*it) >> keypoints[i];
+        }
+#else
         FileNodeIterator it = node.begin();
         it >> keypoints;
+#endif
         return;
     }
     keypoints.clear();
@@ -7394,8 +7404,18 @@ void read(const FileNode& node, std::vector<DMatch>& matches)
     if (first_node.isSeq())
     {
         // modern scheme
+#ifdef OPENCV_TRAITS_ENABLE_DEPRECATED
+        FileNodeIterator it = node.begin();
+        size_t total = (size_t)it.remaining;
+        matches.resize(total);
+        for (size_t i = 0; i < total; ++i, ++it)
+        {
+            (*it) >> matches[i];
+        }
+#else
         FileNodeIterator it = node.begin();
         it >> matches;
+#endif
         return;
     }
     matches.clear();

--- a/modules/core/test/test_io.cpp
+++ b/modules/core/test/test_io.cpp
@@ -1199,6 +1199,7 @@ TEST(Core_InputOutput, FileStorage_DMatch_vector_vector)
 
     EXPECT_NO_THROW(fs << "dvv" << dvv);
     cv::String fs_result = fs.releaseAndGetString();
+#ifndef OPENCV_TRAITS_ENABLE_DEPRECATED
 #if defined _MSC_VER && _MSC_VER <= 1700 /* MSVC 2012 and older */
     EXPECT_STREQ(fs_result.c_str(),
 "%YAML:1.0\n"
@@ -1226,6 +1227,7 @@ TEST(Core_InputOutput, FileStorage_DMatch_vector_vector)
 "      - [ 1, 2, 3, -1.5000000000000000e+00 ]\n"
 );
 #endif
+#endif // OPENCV_TRAITS_ENABLE_DEPRECATED
 
     cv::FileStorage fs_read(fs_result, cv::FileStorage::READ | cv::FileStorage::MEMORY);
 
@@ -1344,6 +1346,7 @@ TEST(Core_InputOutput, FileStorage_KeyPoint_vector_vector)
 
     EXPECT_NO_THROW(fs << "kvv" << kvv);
     cv::String fs_result = fs.releaseAndGetString();
+#ifndef OPENCV_TRAITS_ENABLE_DEPRECATED
     EXPECT_STREQ(fs_result.c_str(),
 "<?xml version=\"1.0\"?>\n"
 "<opencv_storage>\n"
@@ -1362,6 +1365,7 @@ TEST(Core_InputOutput, FileStorage_KeyPoint_vector_vector)
 "      1. 2. 16. 0. 100. 1 -1</_></_></kvv>\n"
 "</opencv_storage>\n"
 );
+#endif //OPENCV_TRAITS_ENABLE_DEPRECATED
 
     cv::FileStorage fs_read(fs_result, cv::FileStorage::READ | cv::FileStorage::MEMORY);
 


### PR DESCRIPTION
resolves #10291

Fixes these tests (`-DCMAKE_CXX_FLAGS="-D OPENCV_TRAITS_ENABLE_DEPRECATED=1"`):
```
[  FAILED  ] 5 tests, listed below:
[  FAILED  ] Core_InputOutput.filestorage_keypoints_vec_vec_io
[  FAILED  ] Core_InputOutput.FileStorage_DMatch_vector
[  FAILED  ] Core_InputOutput.FileStorage_DMatch_vector_vector
[  FAILED  ] Core_InputOutput.FileStorage_KeyPoint_vector
[  FAILED  ] Core_InputOutput.FileStorage_KeyPoint_vector_vector
```

/cc @tomoaki0705 

```
docker_image:Custom=ubuntu-cuda:16.04
```