### PR TITLE
CMake: add option to workaround issue observed with old CMake

### DIFF
--- a/cmake/OpenCVDownload.cmake
+++ b/cmake/OpenCVDownload.cmake
@@ -156,10 +156,12 @@ function(ocv_download)
          TIMEOUT 600
          STATUS status
          LOG __log)
-    string(LENGTH "${__log}" __log_length)
-    if(__log_length LESS 65536)
-      string(REPLACE "\n" "\n# " __log "${__log}")
-      ocv_download_log("# ${__log}\n")
+    if(NOT OPENCV_SKIP_FILE_DOWNLOAD_DUMP)  # workaround problem with old CMake versions: "Invalid escape sequence"
+      string(LENGTH "${__log}" __log_length)
+      if(__log_length LESS 65536)
+        string(REPLACE "\n" "\n# " __log "${__log}")
+        ocv_download_log("# ${__log}\n")
+      endif()
     endif()
     if(NOT status EQUAL 0)
       set(msg_level FATAL_ERROR)


### PR DESCRIPTION
CMake message contains this: "Invalid escape sequence \\"

resolves #9185