### PR TITLE
core: suppress warnings on OpenCL build

### DIFF
--- a/modules/core/src/ocl.cpp
+++ b/modules/core/src/ocl.cpp
@@ -4339,9 +4339,6 @@ public:
 
 
 
-#if defined _MSC_VER
-#pragma warning(disable:4127) // conditional expression is constant
-#endif
 template <bool readAccess, bool writeAccess>
 class AlignedDataPtr
 {
@@ -4446,9 +4443,6 @@ private:
     AlignedDataPtr2D(const AlignedDataPtr2D&); // disabled
     AlignedDataPtr2D& operator=(const AlignedDataPtr2D&); // disabled
 };
-#if defined _MSC_VER
-#pragma warning(default:4127) // conditional expression is constant
-#endif
 
 #ifndef CV_OPENCL_DATA_PTR_ALIGNMENT
 #define CV_OPENCL_DATA_PTR_ALIGNMENT 16


### PR DESCRIPTION
### This pullrequest changes
  * close #10296 
  * stop re-enabling the warning C4127
  * disabling is done in CMakeLists.txt

