### PR TITLE
cmake: update CMAKE_POSITION_INDEPENDENT_CODE

### DIFF
--- a/3rdparty/carotene/CMakeLists.txt
+++ b/3rdparty/carotene/CMakeLists.txt
@@ -37,6 +37,4 @@ if(WITH_NEON)
     target_compile_definitions(carotene_objs PRIVATE "-DWITH_NEON")
 endif()
 
-set_target_properties(carotene_objs PROPERTIES POSITION_INDEPENDENT_CODE TRUE)
-
 add_library(carotene STATIC EXCLUDE_FROM_ALL "$<TARGET_OBJECTS:carotene_objs>")

--- a/3rdparty/carotene/hal/CMakeLists.txt
+++ b/3rdparty/carotene/hal/CMakeLists.txt
@@ -3,8 +3,6 @@ cmake_minimum_required(VERSION 2.8.8 FATAL_ERROR)
 include(CheckCCompilerFlag)
 include(CheckCXXCompilerFlag)
 
-set(CMAKE_POSITION_INDEPENDENT_CODE ON)
-
 set(TEGRA_HAL_DIR "${CMAKE_CURRENT_SOURCE_DIR}")
 set(CAROTENE_DIR "${TEGRA_HAL_DIR}/../")
 
@@ -95,7 +93,6 @@ set_property(DIRECTORY APPEND PROPERTY COMPILE_DEFINITIONS ${carotene_defs})
   endif()
 
 add_library(tegra_hal STATIC $<TARGET_OBJECTS:carotene_objs>)
-set_target_properties(tegra_hal PROPERTIES POSITION_INDEPENDENT_CODE TRUE)
 set_target_properties(tegra_hal PROPERTIES ARCHIVE_OUTPUT_DIRECTORY ${3P_LIBRARY_OUTPUT_PATH})
 set(OPENCV_SRC_DIR "${CMAKE_SOURCE_DIR}")
 if(NOT BUILD_SHARED_LIBS)

--- a/3rdparty/ippicv/CMakeLists.txt
+++ b/3rdparty/ippicv/CMakeLists.txt
@@ -21,7 +21,7 @@ add_library(${IPP_IW_LIBRARY} STATIC ${lib_srcs} ${lib_hdrs})
 
 if(UNIX)
   if(CMAKE_COMPILER_IS_GNUCXX OR CV_ICC)
-    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fPIC -Wno-unused-function -Wno-missing-braces -Wno-missing-field-initializers")
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wno-unused-function -Wno-missing-braces -Wno-missing-field-initializers")
   endif()
   if (CMAKE_C_COMPILER_ID MATCHES "Clang")
     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wno-self-assign")

--- a/3rdparty/ittnotify/CMakeLists.txt
+++ b/3rdparty/ittnotify/CMakeLists.txt
@@ -43,12 +43,6 @@ if(NOT WIN32)
   endif()
 endif()
 
-if(UNIX)
-  if(CMAKE_COMPILER_IS_GNUCXX OR CV_ICC)
-     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fPIC")
-  endif()
-endif()
-
 set_target_properties(${ITT_LIBRARY} PROPERTIES
         OUTPUT_NAME ${ITT_LIBRARY}
         DEBUG_POSTFIX "${OPENCV_DEBUG_POSTFIX}"

--- a/3rdparty/libjasper/CMakeLists.txt
+++ b/3rdparty/libjasper/CMakeLists.txt
@@ -31,12 +31,6 @@ ocv_warnings_disable(CMAKE_C_FLAGS -Wno-implicit-function-declaration -Wno-unini
 ocv_warnings_disable(CMAKE_C_FLAGS -Wunused-parameter -Wstrict-prototypes) # clang
 ocv_warnings_disable(CMAKE_C_FLAGS /wd4013 /wd4018 /wd4101 /wd4244 /wd4267 /wd4715) # vs2005
 
-if(UNIX)
-  if(CMAKE_COMPILER_IS_GNUCXX OR CV_ICC)
-    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fPIC")
-  endif()
-endif()
-
 set_target_properties(${JASPER_LIBRARY}
   PROPERTIES
   OUTPUT_NAME ${JASPER_LIBRARY}

--- a/3rdparty/libjpeg/CMakeLists.txt
+++ b/3rdparty/libjpeg/CMakeLists.txt
@@ -28,12 +28,6 @@ endif()
 
 add_library(${JPEG_LIBRARY} STATIC ${lib_srcs} ${lib_hdrs})
 
-if(UNIX)
-  if(CMAKE_COMPILER_IS_GNUCXX OR CV_ICC)
-    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fPIC")
-  endif()
-endif()
-
 if(CMAKE_COMPILER_IS_GNUCXX)
   set_source_files_properties(jcdctmgr.c PROPERTIES COMPILE_FLAGS "-O1")
 endif()

--- a/3rdparty/libpng/CMakeLists.txt
+++ b/3rdparty/libpng/CMakeLists.txt
@@ -63,12 +63,6 @@ endif(MSVC)
 add_library(${PNG_LIBRARY} STATIC ${lib_srcs} ${lib_hdrs})
 target_link_libraries(${PNG_LIBRARY} ${ZLIB_LIBRARIES})
 
-if(UNIX)
-  if(CMAKE_COMPILER_IS_GNUCXX OR CV_ICC)
-    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fPIC")
-  endif()
-endif()
-
 ocv_warnings_disable(CMAKE_C_FLAGS -Wcast-align)
 
 set_target_properties(${PNG_LIBRARY}

--- a/3rdparty/libtiff/CMakeLists.txt
+++ b/3rdparty/libtiff/CMakeLists.txt
@@ -449,10 +449,6 @@ ocv_warnings_disable(CMAKE_CXX_FLAGS /wd4456 /wd4457 /wd4312) # vs2015
 
 ocv_warnings_disable(CMAKE_C_FLAGS /wd4267 /wd4244 /wd4018 /wd4311 /wd4312)
 
-if(UNIX AND (CMAKE_COMPILER_IS_GNUCXX OR CV_ICC))
-  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fPIC")
-endif()
-
 add_library(${TIFF_LIBRARY} STATIC ${lib_srcs})
 target_link_libraries(${TIFF_LIBRARY} ${ZLIB_LIBRARIES})
 

--- a/3rdparty/openexr/CMakeLists.txt
+++ b/3rdparty/openexr/CMakeLists.txt
@@ -51,10 +51,6 @@ ocv_warnings_disable(CMAKE_CXX_FLAGS /wd4244) # vs2008
 ocv_warnings_disable(CMAKE_CXX_FLAGS /wd4267) # vs2008 Win64
 ocv_warnings_disable(CMAKE_CXX_FLAGS /wd4456) # vs2015
 
-if(UNIX AND (CMAKE_COMPILER_IS_GNUCXX OR CV_ICC))
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fPIC")
-endif()
-
 if(MSVC AND CV_ICC)
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /Qrestrict")
   set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} /Qrestrict")

--- a/3rdparty/openvx/hal/CMakeLists.txt
+++ b/3rdparty/openvx/hal/CMakeLists.txt
@@ -6,7 +6,6 @@ target_include_directories(openvx_hal PUBLIC
   ${CMAKE_SOURCE_DIR}/modules/imgproc/include
   ${OPENVX_INCLUDE_DIR})
 target_link_libraries(openvx_hal LINK_PUBLIC ${OPENVX_LIBRARIES})
-set_target_properties(openvx_hal PROPERTIES POSITION_INDEPENDENT_CODE TRUE)
 set_target_properties(openvx_hal PROPERTIES ARCHIVE_OUTPUT_DIRECTORY ${3P_LIBRARY_OUTPUT_PATH})
 if(NOT BUILD_SHARED_LIBS)
   ocv_install_target(openvx_hal EXPORT OpenCVModules ARCHIVE DESTINATION ${OPENCV_3P_LIB_INSTALL_PATH} COMPONENT dev)

--- a/3rdparty/protobuf/CMakeLists.txt
+++ b/3rdparty/protobuf/CMakeLists.txt
@@ -127,17 +127,12 @@ append_if_exist(Protobuf_SRCS
   ${PROTOBUF_ROOT}/src/google/protobuf/wrappers.pb.cc
 )
 
-if(CMAKE_VERSION VERSION_LESS 2.8.9 AND UNIX)
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fPIC")
-endif()
-
 add_library(libprotobuf STATIC ${Protobuf_SRCS})
 ocv_include_directories(${PROTOBUF_ROOT}/src)
 
 set_target_properties(libprotobuf
     PROPERTIES
     FOLDER "3rdparty"
-    POSITION_INDEPENDENT_CODE 1    # CMake 2.8.9+
     OUTPUT_NAME libprotobuf
     DEBUG_POSTFIX "${OPENCV_DEBUG_POSTFIX}"
     ARCHIVE_OUTPUT_DIRECTORY ${3P_LIBRARY_OUTPUT_PATH}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,7 +29,8 @@ else()
   cmake_minimum_required(VERSION "${MIN_VER_CMAKE}" FATAL_ERROR)
 endif()
 
-set(CMAKE_POSITION_INDEPENDENT_CODE TRUE)
+option(ENABLE_PIC "Generate position independent code (necessary for shared libraries)" TRUE)
+set(CMAKE_POSITION_INDEPENDENT_CODE ${ENABLE_PIC})
 
 # Following block can break build in case of cross-compilng
 # but CMAKE_CROSSCOMPILING variable will be set only on project(OpenCV) command


### PR DESCRIPTION
- add option to disable -fPIC/-fPIE flag (`ENABLE_PIC=ON` by default). Turning off could be used for ES builds with `BUILD_SHARED_LIBS=OFF`
- remove duplicate code which controls this behavior