### PR TITLE
remove VTK legacy functions

### DIFF
--- a/modules/viz/src/clouds.cpp
+++ b/modules/viz/src/clouds.cpp
@@ -77,7 +77,9 @@ cv::viz::WCloud::WCloud(cv::InputArray cloud, cv::InputArray colors, cv::InputAr
     vtkSmartPointer<vtkPolyDataMapper> mapper = vtkSmartPointer<vtkPolyDataMapper>::New();
     VtkUtils::SetInputData(mapper, cloud_source->GetOutput());
     mapper->SetScalarModeToUsePointData();
+#if VTK_MAJOR_VERSION < 8
     mapper->ImmediateModeRenderingOff();
+#endif
     mapper->SetScalarRange(0, 255);
     mapper->ScalarVisibilityOn();
 
@@ -117,7 +119,9 @@ cv::viz::WPaintedCloud::WPaintedCloud(InputArray cloud)
 
     vtkSmartPointer<vtkPolyDataMapper> mapper = vtkSmartPointer<vtkPolyDataMapper>::New();
     VtkUtils::SetInputData(mapper, vtkPolyData::SafeDownCast(elevation->GetOutput()));
+#if VTK_MAJOR_VERSION < 8
     mapper->ImmediateModeRenderingOff();
+#endif
     mapper->ScalarVisibilityOn();
     mapper->SetColorModeToMapScalars();
 
@@ -143,7 +147,9 @@ cv::viz::WPaintedCloud::WPaintedCloud(InputArray cloud, const Point3d& p1, const
 
     vtkSmartPointer<vtkPolyDataMapper> mapper = vtkSmartPointer<vtkPolyDataMapper>::New();
     VtkUtils::SetInputData(mapper, vtkPolyData::SafeDownCast(elevation->GetOutput()));
+#if VTK_MAJOR_VERSION < 8
     mapper->ImmediateModeRenderingOff();
+#endif
     mapper->ScalarVisibilityOn();
     mapper->SetColorModeToMapScalars();
 
@@ -182,7 +188,9 @@ cv::viz::WPaintedCloud::WPaintedCloud(InputArray cloud, const Point3d& p1, const
 
     vtkSmartPointer<vtkPolyDataMapper> mapper = vtkSmartPointer<vtkPolyDataMapper>::New();
     VtkUtils::SetInputData(mapper, vtkPolyData::SafeDownCast(elevation->GetOutput()));
+#if VTK_MAJOR_VERSION < 8
     mapper->ImmediateModeRenderingOff();
+#endif
     mapper->ScalarVisibilityOn();
     mapper->SetColorModeToMapScalars();
     mapper->SetLookupTable(color_transfer);
@@ -211,7 +219,9 @@ cv::viz::WCloudCollection::WCloudCollection()
     vtkSmartPointer<vtkPolyDataMapper> mapper = vtkSmartPointer<vtkPolyDataMapper>::New();
     mapper->SetInputConnection(append_filter->GetOutputPort());
     mapper->SetScalarModeToUsePointData();
+#if VTK_MAJOR_VERSION < 8
     mapper->ImmediateModeRenderingOff();
+#endif
     mapper->SetScalarRange(0, 255);
     mapper->ScalarVisibilityOn();
 
@@ -416,7 +426,9 @@ cv::viz::WMesh::WMesh(const Mesh &mesh)
 
     vtkSmartPointer<vtkPolyDataMapper> mapper = vtkSmartPointer<vtkPolyDataMapper>::New();
     mapper->SetScalarModeToUsePointData();
+#if VTK_MAJOR_VERSION < 8
     mapper->ImmediateModeRenderingOff();
+#endif
     VtkUtils::SetInputData(mapper, polydata);
 
     vtkSmartPointer<vtkActor> actor = vtkSmartPointer<vtkActor>::New();
@@ -468,7 +480,9 @@ cv::viz::WWidgetMerger::WWidgetMerger()
     vtkSmartPointer<vtkPolyDataMapper> mapper = vtkSmartPointer<vtkPolyDataMapper>::New();
     mapper->SetInputConnection(append_filter->GetOutputPort());
     mapper->SetScalarModeToUsePointData();
+#if VTK_MAJOR_VERSION < 8
     mapper->ImmediateModeRenderingOff();
+#endif
     mapper->SetScalarRange(0, 255);
     mapper->ScalarVisibilityOn();
 

--- a/modules/viz/src/widget.cpp
+++ b/modules/viz/src/widget.cpp
@@ -91,7 +91,9 @@ cv::viz::Widget cv::viz::Widget::fromPlyFile(const String &file_name)
 
     vtkSmartPointer<vtkDataSetMapper> mapper = vtkSmartPointer<vtkDataSetMapper>::New();
     mapper->SetInputConnection( reader->GetOutputPort() );
+#if VTK_MAJOR_VERSION < 8
     mapper->ImmediateModeRenderingOff();
+#endif
 
     vtkSmartPointer<vtkActor> actor = vtkSmartPointer<vtkActor>::New();
     actor->GetProperty()->SetInterpolationToFlat();
@@ -113,7 +115,11 @@ void cv::viz::Widget::setRenderingProperty(int property, double value)
         case POINT_SIZE:          actor->GetProperty()->SetPointSize(float(value)); break;
         case OPACITY:             actor->GetProperty()->SetOpacity(value);          break;
         case LINE_WIDTH:          actor->GetProperty()->SetLineWidth(float(value)); break;
+#if VTK_MAJOR_VERSION < 8
         case IMMEDIATE_RENDERING: actor->GetMapper()->SetImmediateModeRendering(int(value)); break;
+#else
+        case IMMEDIATE_RENDERING: std::cerr << "this property has no effect" << std::endl; break;
+#endif
         case AMBIENT:             actor->GetProperty()->SetAmbient(float(value)); break;
         case LIGHTING:
         {
@@ -191,8 +197,11 @@ double cv::viz::Widget::getRenderingProperty(int property) const
         case POINT_SIZE: value = actor->GetProperty()->GetPointSize(); break;
         case OPACITY:    value = actor->GetProperty()->GetOpacity();   break;
         case LINE_WIDTH: value = actor->GetProperty()->GetLineWidth(); break;
+#if VTK_MAJOR_VERSION < 8
         case IMMEDIATE_RENDERING:  value = actor->GetMapper()->GetImmediateModeRendering();  break;
-
+#else
+        case IMMEDIATE_RENDERING: std::cerr << "this property has no effect" << std::endl; break;
+#endif
         case FONT_SIZE:
         {
             vtkTextActor* text_actor = vtkTextActor::SafeDownCast(actor);


### PR DESCRIPTION
### This pullrequest changes

Recently VTK removes some legacy functions that causes OpenCV to stop compiling.

https://github.com/Kitware/VTK/commit/fc2ac65dc798d932974abc500f14b94e2a5208f9

The fix is applied according to the suggestion of the VTK devs.

I tested and it compiles and runs without a problem on Ubuntu 16.04 latest OpenCV.

```
force_builders=Custom
docker_image:Custom=ubuntu:17.10
```