### PR TITLE
fix build with instrumentation enabled

### DIFF
--- a/modules/core/src/ocl.cpp
+++ b/modules/core/src/ocl.cpp
@@ -3660,9 +3660,9 @@ struct Program::Impl
         CV_Assert(src_);
         CV_Assert(src_->kind_ == ProgramSource::Impl::PROGRAM_SOURCE_CODE);
         CV_Assert(handle == NULL);
-        CV_INSTRUMENT_REGION_OPENCL_COMPILE(cv::format("Build OpenCL program: %s/%s %" PRIx64 " options: %s",
+        CV_INSTRUMENT_REGION_OPENCL_COMPILE(cv::format("Build OpenCL program: %s/%s %s options: %s",
                 sourceModule_.c_str(), sourceName_.c_str(),
-                src.hash(), buildflags.c_str()).c_str());
+                src_->sourceHash_.c_str(), buildflags.c_str()).c_str());
 
         CV_LOG_VERBOSE(NULL, 0, "Compile... " << sourceModule_.c_str() << "/" << sourceName_.c_str());
 


### PR DESCRIPTION
* since #10231 opencv with instrumentation does not build (`src` undefined)

fixes #10322

@alalek please check if this fix is correct after the refactoring.
