### PR TITLE
3rdparty: suppress warning on Visual Studio

### DIFF
--- a/3rdparty/libwebp/src/enc/histogram_enc.c
+++ b/3rdparty/libwebp/src/enc/histogram_enc.c
@@ -605,7 +605,7 @@ static void HistogramCombineEntropyBin(VP8LHistogramSet* const image_histo,
 }
 
 // Implement a Lehmer random number generator with a multiplicative constant of
-// 48271 and a modulo constant of 2^31 − 1.
+// 48271 and a modulo constant of 2^31 - 1.
 static uint32_t MyRand(uint32_t* const seed) {
   *seed = (uint32_t)(((uint64_t)(*seed) * 48271u) % 2147483647u);
   assert(*seed > 0);


### PR DESCRIPTION
  * remove non ASCII character from the comment
```
  C:\opencv\3rdparty\libwebp\src\enc\histogram_enc.c : warning C4819: The file contains a character that cannot be represented in the current code page (932). Save the file in Unicode format to prevent data loss [c:\opencv\build\3rdparty\libwebp\libwebp.vcxproj]
```
### This pullrequest changes

<!-- Please describe what your pullrequest is changing -->
