### PR TITLE
Resolved fatal error during initial compilation

### DIFF
--- a/modules/python/common.cmake
+++ b/modules/python/common.cmake
@@ -1,6 +1,9 @@
 # This file is included from a subdirectory
 set(PYTHON_SOURCE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../")
 
+find_package(HDF5)
+include_directories(${HDF5_INCLUDE_DIRS})
+
 ocv_add_module(${MODULE_NAME} BINDINGS PRIVATE_REQUIRED opencv_python_bindings_generator)
 
 ocv_module_include_directories(


### PR DESCRIPTION
fatal error is encountered when compiling OpenCV for Python (in Ubuntu 16.04) which is 'fatal error hdf5.h no such file or directory'.
Changes made looks for the HDF5 package and finds and loads settings from the external project.