### PR TITLE
imgcodecs(pxm): fix memcpy size

### DIFF
--- a/modules/imgcodecs/src/grfmt_pxm.cpp
+++ b/modules/imgcodecs/src/grfmt_pxm.cpp
@@ -333,7 +333,7 @@ bool PxMDecoder::readData( Mat& img )
                         }
                     }
                     else
-                        memcpy( data, src, CV_ELEM_SIZE1(m_type)*m_width);
+                        memcpy(data, src, img.elemSize1()*m_width);
                 }
                 else
                 {


### PR DESCRIPTION
resolves #10351

Observed in this case:
- source image type (m_type) is `CV_16U`
- destination image type (with GRAYSCALE flag) is `CV_8U`