### PR TITLE
Added performance tests for linear resize of 2 and 3-channel images

### DIFF
--- a/modules/imgproc/perf/perf_resize.cpp
+++ b/modules/imgproc/perf/perf_resize.cpp
@@ -12,7 +12,12 @@ typedef TestBaseWithParam<MatInfo_Size_Size_t> MatInfo_Size_Size;
 PERF_TEST_P(MatInfo_Size_Size, resizeUpLinear,
             testing::Values(
                 MatInfo_Size_Size_t(CV_8UC1, szVGA, szqHD),
+                MatInfo_Size_Size_t(CV_8UC2, szVGA, szqHD),
+                MatInfo_Size_Size_t(CV_8UC3, szVGA, szqHD),
+                MatInfo_Size_Size_t(CV_8UC4, szVGA, szqHD),
                 MatInfo_Size_Size_t(CV_8UC1, szVGA, sz720p),
+                MatInfo_Size_Size_t(CV_8UC2, szVGA, sz720p),
+                MatInfo_Size_Size_t(CV_8UC3, szVGA, sz720p),
                 MatInfo_Size_Size_t(CV_8UC4, szVGA, sz720p)
                 )
             )
@@ -37,9 +42,24 @@ PERF_TEST_P(MatInfo_Size_Size, resizeUpLinear,
 PERF_TEST_P(MatInfo_Size_Size, resizeDownLinear,
             testing::Values(
                 MatInfo_Size_Size_t(CV_8UC1, szVGA, szQVGA),
+                MatInfo_Size_Size_t(CV_8UC2, szVGA, szQVGA),
+                MatInfo_Size_Size_t(CV_8UC3, szVGA, szQVGA),
+                MatInfo_Size_Size_t(CV_8UC4, szVGA, szQVGA),
+                MatInfo_Size_Size_t(CV_8UC1, szqHD, szVGA),
+                MatInfo_Size_Size_t(CV_8UC2, szqHD, szVGA),
+                MatInfo_Size_Size_t(CV_8UC3, szqHD, szVGA),
                 MatInfo_Size_Size_t(CV_8UC4, szqHD, szVGA),
                 MatInfo_Size_Size_t(CV_8UC1, sz720p, Size(120 * sz720p.width / sz720p.height, 120)),//face detection min_face_size = 20%
+                MatInfo_Size_Size_t(CV_8UC2, sz720p, Size(120 * sz720p.width / sz720p.height, 120)),//face detection min_face_size = 20%
+                MatInfo_Size_Size_t(CV_8UC3, sz720p, Size(120 * sz720p.width / sz720p.height, 120)),//face detection min_face_size = 20%
+                MatInfo_Size_Size_t(CV_8UC4, sz720p, Size(120 * sz720p.width / sz720p.height, 120)),//face detection min_face_size = 20%
+                MatInfo_Size_Size_t(CV_8UC1, sz720p, szVGA),
+                MatInfo_Size_Size_t(CV_8UC2, sz720p, szVGA),
+                MatInfo_Size_Size_t(CV_8UC3, sz720p, szVGA),
                 MatInfo_Size_Size_t(CV_8UC4, sz720p, szVGA),
+                MatInfo_Size_Size_t(CV_8UC1, sz720p, szQVGA),
+                MatInfo_Size_Size_t(CV_8UC2, sz720p, szQVGA),
+                MatInfo_Size_Size_t(CV_8UC3, sz720p, szQVGA),
                 MatInfo_Size_Size_t(CV_8UC4, sz720p, szQVGA)
                 )
             )


### PR DESCRIPTION
### This pullrequest changes
Added performance tests for linear resize of 2 and 3-channel images