### PR TITLE
Remove redundant return variable in tutorials

### DIFF
--- a/doc/py_tutorials/py_calib3d/py_pose/py_pose.markdown
+++ b/doc/py_tutorials/py_calib3d/py_pose/py_pose.markdown
@@ -70,7 +70,7 @@ for fname in glob.glob('left*.jpg'):
         corners2 = cv.cornerSubPix(gray,corners,(11,11),(-1,-1),criteria)
 
         # Find the rotation and translation vectors.
-        ret,rvecs, tvecs, inliers = cv.solvePnP(objp, corners2, mtx, dist)
+        ret,rvecs, tvecs = cv.solvePnP(objp, corners2, mtx, dist)
 
         # project 3D points to image plane
         imgpts, jac = cv.projectPoints(axis, rvecs, tvecs, mtx, dist)


### PR DESCRIPTION
<!-- Please use this line to close one or multiple issues when this pullrequest gets merged
You can add another line right under the first one:
resolves #1234
resolves #1235
-->

### This pullrequest changes

<!-- Please describe what your pullrequest is changing -->
cv.solvePnP() can return three variables instead of four.
https://docs.opencv.org/master/d9/d0c/group__calib3d.html#ga549c2075fac14829ff4a58bc931c033d