### PR TITLE
Fallback from bit-exact to generic linear resize for CV_32F and CV_64F

### DIFF
--- a/modules/imgproc/src/resize.cpp
+++ b/modules/imgproc/src/resize.cpp
@@ -4153,6 +4153,9 @@ void cv::resize( InputArray _src, OutputArray _dst, Size dsize,
         inv_scale_y = (double)dsize.height/ssize.height;
     }
 
+    if (interpolation == INTER_LINEAR_EXACT && (_src.depth() == CV_32F || _src.depth() == CV_64F))
+        interpolation = INTER_LINEAR; // If depth isn't supported fallback to generic resize
+
     CV_OCL_RUN(_src.dims() <= 2 && _dst.isUMat() && _src.cols() > 10 && _src.rows() > 10,
                ocl_resize(_src, _dst, dsize, inv_scale_x, inv_scale_y, interpolation))
 


### PR DESCRIPTION
### This pullrequest changes
Fallback from bit-exact to generic linear resize for CV_32F and CV_64F

