### PR TITLE
Suggestion: add link to Android Studio package

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 * Docs: <http://docs.opencv.org/master/>
 * Q&A forum: <http://answers.opencv.org>
 * Issue tracking: <https://github.com/opencv/opencv/issues>
+* Android Studio Package: <https://github.com/floe/opencv-android>
 
 ### Contributing
 


### PR DESCRIPTION
I've spent a bit of work to make a "proper" Android Studio package from the Android SDK, which is available at https://github.com/floe/opencv-android. Not sure if the README is actually the right place for this, just wanted to suggest that this link may be useful. I've also enabled JitPack for this repo, so now the OpenCV SDK can be pulled into any Android Studio project by adding two lines to the Gradle build files.