### PR TITLE
Replaced incorrect CV_Assert calls with CV_Error

### DIFF
--- a/modules/dnn/src/tensorflow/tf_importer.cpp
+++ b/modules/dnn/src/tensorflow/tf_importer.cpp
@@ -930,7 +930,7 @@ void TFImporter::populateNet(Net dstNet)
                         data_layouts[name] = DATA_LAYOUT_NHWC;
                     }
                     else
-                        CV_Assert(Error::StsParseError, "Only NHWC <-> NCHW permutations are allowed.");
+                        CV_Error(Error::StsParseError, "Only NHWC <-> NCHW permutations are allowed.");
                 }
                 else if (data_layouts[layer.input(0)] == DATA_LAYOUT_NCHW)
                 {
@@ -947,7 +947,7 @@ void TFImporter::populateNet(Net dstNet)
                         data_layouts[name] = DATA_LAYOUT_NCHW;
                     }
                     else
-                        CV_Assert(Error::StsParseError, "Only NHWC <-> NCHW permutations are allowed.");
+                        CV_Error(Error::StsParseError, "Only NHWC <-> NCHW permutations are allowed.");
                 }
                 int id = dstNet.addLayer(name, "Identity", layerParams);
                 layer_id[name] = id;


### PR DESCRIPTION
### This pullrequest changes

Warnings produced by GCC 7:
```
/opencv/modules/core/include/opencv2/core/base.hpp:458:39: warning: enum constant in boolean context [-Wint-in-bool-context]
 #define CV_Assert_1( expr ) if(!!(expr)) ; else cv::error( cv::Error::StsAssert, #expr, CV_Func, __FILE__, __LINE__ )
                                       ^
/opencv/modules/core/include/opencv2/core/base.hpp:459:37: note: in expansion of macro ‘CV_Assert_1’
 #define CV_Assert_2( expr1, expr2 ) CV_Assert_1(expr1); CV_Assert_1(expr2)
                                     ^~~~~~~~~~~
/opencv/modules/core/include/opencv2/core/base.hpp:289:32: note: in expansion of macro ‘CV_Assert_2’
 #define CVAUX_CONCAT_EXP(a, b) a##b
                                ^
/opencv/modules/core/include/opencv2/core/base.hpp:290:28: note: in expansion of macro ‘CVAUX_CONCAT_EXP’
 #define CVAUX_CONCAT(a, b) CVAUX_CONCAT_EXP(a,b)
                            ^~~~~~~~~~~~~~~~
/opencv/modules/core/include/opencv2/core/base.hpp:469:38: note: in expansion of macro ‘CVAUX_CONCAT’
 #define CV_Assert(...)               CVAUX_CONCAT(CV_Assert_, CV_VA_NUM_ARGS(__VA_ARGS__)) (__VA_ARGS__)
                                      ^~~~~~~~~~~~
/opencv/modules/dnn/src/tensorflow/tf_importer.cpp:950:25: note: in expansion of macro ‘CV_Assert’
                         CV_Assert(Error::StsParseError, "Only NHWC <-> NCHW permutations are allowed.");
                         ^~~~~~~~~
```

```
docker_image:Custom=ubuntu:17.10
```