### PR TITLE
Reverted calls back to linear resize for floating point matrices

### DIFF
--- a/modules/photo/src/contrast_preserve.hpp
+++ b/modules/photo/src/contrast_preserve.hpp
@@ -233,7 +233,7 @@ void Decolor::weak_order(Mat img, vector <double> &alf)
     if((h + w) > 800)
     {
         sizefactor = (double)800/(h+w);
-        resize(img,img,Size(round_num(h*sizefactor),round_num(w*sizefactor)), 0, 0, INTER_LINEAR_EXACT);
+        resize(img,img,Size(round_num(h*sizefactor),round_num(w*sizefactor)));
     }
 
     Mat curIm = Mat(img.size(),CV_32FC1);
@@ -309,7 +309,7 @@ void Decolor::grad_system(Mat img, vector < vector < double > > &polyGrad,
     if((h + w) > 800)
     {
         sizefactor = (double)800/(h+w);
-        resize(img,img,Size(round_num(h*sizefactor),round_num(w*sizefactor)), 0, 0, INTER_LINEAR_EXACT);
+        resize(img,img,Size(round_num(h*sizefactor),round_num(w*sizefactor)));
     }
 
     h = img.size().height;

--- a/modules/video/src/optflowgf.cpp
+++ b/modules/video/src/optflowgf.cpp
@@ -767,7 +767,7 @@ private:
                 {
                     if (!gaussianBlurOcl(frames_[i], smoothSize/2, blurredFrame[i]))
                         return false;
-                    resize(blurredFrame[i], pyrLevel[i], Size(width, height), INTER_LINEAR_EXACT);
+                    resize(blurredFrame[i], pyrLevel[i], Size(width, height), INTER_LINEAR);
                     if (!polynomialExpansionOcl(pyrLevel[i], R[i]))
                         return false;
                 }
@@ -1153,7 +1153,7 @@ void FarnebackOpticalFlowImpl::calc(InputArray _prev0, InputArray _next0,
         }
         else
         {
-            resize( prevFlow, flow, Size(width, height), 0, 0, INTER_LINEAR);
+            resize( prevFlow, flow, Size(width, height), 0, 0, INTER_LINEAR );
             flow *= 1./pyrScale_;
         }
 
@@ -1162,7 +1162,7 @@ void FarnebackOpticalFlowImpl::calc(InputArray _prev0, InputArray _next0,
         {
             img[i]->convertTo(fimg, CV_32F);
             GaussianBlur(fimg, fimg, Size(smooth_sz, smooth_sz), sigma, sigma);
-            resize( fimg, I, Size(width, height), INTER_LINEAR);
+            resize( fimg, I, Size(width, height), INTER_LINEAR );
             FarnebackPolyExp( I, R[i], polyN_, polySigma_ );
         }
 


### PR DESCRIPTION
### This pullrequest changes
Reverted calls back to linear resize for floating point matrices