### PR TITLE
opencl/cvtclr_dx: fix not compile-time constants issue.

### DIFF
--- a/modules/core/src/opencl/cvtclr_dx.cl
+++ b/modules/core/src/opencl/cvtclr_dx.cl
@@ -71,12 +71,12 @@ float c_YUV2RGBCoeffs_420[5] =
      1.5959997177f
 };
 
-static __constant float CV_8U_MAX         = 255.0f;
-static __constant float CV_8U_HALF        = 128.0f;
-static __constant float BT601_BLACK_RANGE = 16.0f;
-static __constant float CV_8U_SCALE       = 1.0f / 255.0f;
-static __constant float d1                = BT601_BLACK_RANGE / CV_8U_MAX;
-static __constant float d2                = CV_8U_HALF / CV_8U_MAX;
+static const __constant float CV_8U_MAX         = 255.0f;
+static const __constant float CV_8U_HALF        = 128.0f;
+static const __constant float BT601_BLACK_RANGE = 16.0f;
+static const __constant float CV_8U_SCALE       = 1.0f / 255.0f;
+static const __constant float d1                = BT601_BLACK_RANGE / CV_8U_MAX;
+static const __constant float d2                = CV_8U_HALF / CV_8U_MAX;
 
 #define NCHANNELS 3
 


### PR DESCRIPTION
fix the "initializing global variables with values that are not
compile-time constants" issue in Intel SDK for OpenCL. The root cause
is when initializing global variables with value, the variable need is
compile-time constants.

Thanks Zheng, Yang <yang.zheng@intel.com>,
Chodor, Jaroslaw <jaroslaw.chodor@intel.com> give a help.

Signed-off-by: Liu,Kaixuan <kaixuan.liu@intel.com>
Signed-off-by: Jun Zhao <jun.zhao@intel.com>