### PR TITLE
JS examples - FFT didn't work for non-square images because rows/cols…

### DIFF
--- a/doc/js_tutorials/js_assets/js_fourier_transform_dft.html
+++ b/doc/js_tutorials/js_assets/js_fourier_transform_dft.html
@@ -56,7 +56,7 @@ let plane0 = new cv.Mat();
 padded.convertTo(plane0, cv.CV_32F);
 let planes = new cv.MatVector();
 let complexI = new cv.Mat();
-let plane1 = new cv.Mat.zeros(padded.cols, padded.rows, cv.CV_32F);
+let plane1 = new cv.Mat.zeros(padded.rows, padded.cols, cv.CV_32F);
 planes.push_back(plane0);
 planes.push_back(plane1);
 cv.merge(planes, complexI);

--- a/doc/js_tutorials/js_assets/js_histogram_begins_calcHist.html
+++ b/doc/js_tutorials/js_assets/js_histogram_begins_calcHist.html
@@ -61,9 +61,9 @@ let dst = new cv.Mat.zeros(src.rows, histSize[0] * scale,
 // draw histogram
 for (let i = 0; i < histSize[0]; i++) {
     let binVal = hist.data32F[i] * src.rows / max;
-    let pioint1 = new cv.Point(i * scale, src.rows - 1);
-    let pioint2 = new cv.Point((i + 1) * scale - 1, src.rows - binVal);
-    cv.rectangle(dst, pioint1, pioint2, color, cv.FILLED);
+    let point1 = new cv.Point(i * scale, src.rows - 1);
+    let point2 = new cv.Point((i + 1) * scale - 1, src.rows - binVal);
+    cv.rectangle(dst, point1, point2, color, cv.FILLED);
 }
 cv.imshow('canvasOutput', dst);
 src.delete(); dst.delete(); srcVec.delete(); mask.delete(); hist.delete();


### PR DESCRIPTION
… were switched, Histogram example misspelled point

```
docker_images:Docs=docs-js
```