### PR TITLE
Update resize inline comments

### DIFF
--- a/modules/imgproc/src/resize.cpp
+++ b/modules/imgproc/src/resize.cpp
@@ -3945,7 +3945,7 @@ void resize(int src_type,
         if( interpolation == INTER_LINEAR && is_area_fast && iscale_x == 2 && iscale_y == 2 )
             interpolation = INTER_AREA;
 
-        // true "area" interpolation is only implemented for the case (scale_x <= 1 && scale_y <= 1).
+        // true "area" interpolation is only implemented for the case (scale_x >= 1 && scale_y >= 1).
         // In other cases it is emulated using some variant of bilinear interpolation
         if( interpolation == INTER_AREA && scale_x >= 1 && scale_y >= 1 )
         {


### PR DESCRIPTION
 I already opened a PR at #10388 but it was not well explained so the maintainer closed it without leaving the option for me to reopen. So I recreate this PR adding detailed explanation on why this is wrong.

If you look at the if clause under the comments, it is actually

```cpp
if( interpolation == INTER_AREA && scale_x >= 1 && scale_y >= 1 )
```
and only inside this if, are the actually area resize implementation called [here](https://github.com/opencv/opencv/blob/master/modules/imgproc/src/resize.cpp#L3861) and [here](https://github.com/opencv/opencv/blob/master/modules/imgproc/src/resize.cpp#L3901).

and if you look at scale_x and scale_y's definitions, it is ssize / dsize(inv_scale_x and inv_scale_y definitions [here](https://github.com/opencv/opencv/blob/master/modules/imgproc/src/resize.cpp#L3678)), which means if the destination image is smaller than the source one, scale_x and scale_y will be greater than 1.0.

Therefore the original comment is wrong.

### This pullrequest changes

Just one inline comment.
