### PR TITLE
imgcodecs(png): resolve ASAN issue with vars scope and setjmp() call

### DIFF
--- a/modules/imgcodecs/src/grfmt_png.cpp
+++ b/modules/imgcodecs/src/grfmt_png.cpp
@@ -228,12 +228,12 @@ bool  PngDecoder::readData( Mat& img )
     uchar** buffer = _buffer;
     int color = img.channels() > 1;
 
+    png_structp png_ptr = (png_structp)m_png_ptr;
+    png_infop info_ptr = (png_infop)m_info_ptr;
+    png_infop end_info = (png_infop)m_end_info;
+
     if( m_png_ptr && m_info_ptr && m_end_info && m_width && m_height )
     {
-        png_structp png_ptr = (png_structp)m_png_ptr;
-        png_infop info_ptr = (png_infop)m_info_ptr;
-        png_infop end_info = (png_infop)m_end_info;
-
         if( setjmp( png_jmpbuf ( png_ptr ) ) == 0 )
         {
             int y;


### PR DESCRIPTION
ASAN message:
```
=================================================================
==18078==ERROR: AddressSanitizer: stack-use-after-scope on address 0x7ffed0f91a70 at pc 0x7f5c9b886a91 bp 0x7ffed0f919b0 sp 0x7ffed0f919a0
READ of size 8 at 0x7ffed0f91a70 thread T0
    #0 0x7f5c9b886a90 in cv::PngDecoder::readData(cv::Mat&) .../modules/imgcodecs/src/grfmt_png.cpp:287
    #1 0x7f5c9b840086 in imread_ .../modules/imgcodecs/src/loadsave.cpp:487
    #2 0x7f5c9b845bee in cv::imread(cv::String const&, int) .../modules/imgcodecs/src/loadsave.cpp:638
<...>

Address 0x7ffed0f91a70 is located in stack of thread T0 at offset 96 in frame
    #0 0x7f5c9b88649f in cv::PngDecoder::readData(cv::Mat&) .../modules/imgcodecs/src/grfmt_png.cpp:225

  This frame has 3 object(s):
    [32, 33) 'result'
    [96, 104) 'png_ptr' <== Memory access at offset 96 is inside this variable
    [160, 1264) '_buffer'
HINT: this may be a false positive if your program uses some custom stack unwind mechanism or swapcontext
      (longjmp and C++ exceptions *are* supported)
SUMMARY: AddressSanitizer: stack-use-after-scope .../modules/imgcodecs/src/grfmt_png.cpp:287 in cv::PngDecoder::readData(cv::Mat&)
Shadow bytes around the buggy address:
  0x10005a1ea2f0: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x10005a1ea300: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x10005a1ea310: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x10005a1ea320: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x10005a1ea330: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
=>0x10005a1ea340: 00 00 f1 f1 f1 f1 01 f2 f2 f2 f2 f2 f2 f2[f8]f2
  0x10005a1ea350: f2 f2 f2 f2 f2 f2 00 00 00 00 00 00 00 00 00 00
  0x10005a1ea360: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x10005a1ea370: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x10005a1ea380: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x10005a1ea390: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
Shadow byte legend (one shadow byte represents 8 application bytes):
  Addressable:           00
  Partially addressable: 01 02 03 04 05 06 07 
  Heap left redzone:       fa
  Freed heap region:       fd
  Stack left redzone:      f1
  Stack mid redzone:       f2
  Stack right redzone:     f3
  Stack after return:      f5
  Stack use after scope:   f8
  Global redzone:          f9
  Global init order:       f6
  Poisoned by user:        f7
  Container overflow:      fc
  Array cookie:            ac
  Intra object redzone:    bb
  ASan internal:           fe
  Left alloca redzone:     ca
  Right alloca redzone:    cb
==18078==ABORTING
```