### PR TITLE
video(perf): add Mog2/KNN tests, fixed bug in prepareData()

### DIFF
--- a/modules/video/perf/perf_bgfg_knn.cpp
+++ b/modules/video/perf/perf_bgfg_knn.cpp
@@ -1,0 +1,89 @@
+// This file is part of OpenCV project.
+// It is subject to the license terms in the LICENSE file found in the top-level directory
+// of this distribution and at http://opencv.org/license.html.
+
+#include "perf_precomp.hpp"
+
+#ifdef HAVE_VIDEO_INPUT
+#include "perf_bgfg_utils.hpp"
+
+namespace opencv_test { namespace {
+
+//////////////////////////// KNN//////////////////////////
+
+typedef tuple<std::string, int> VideoKNNParamType;
+typedef TestBaseWithParam<VideoKNNParamType> KNN_Apply;
+typedef TestBaseWithParam<VideoKNNParamType> KNN_GetBackgroundImage;
+
+PERF_TEST_P(KNN_Apply, KNN, Combine(Values("gpu/video/768x576.avi", "gpu/video/1920x1080.avi"), Values(1,3)))
+{
+    VideoKNNParamType params = GetParam();
+
+    const string inputFile = getDataPath(get<0>(params));
+
+    const int cn = get<1>(params);
+    int nFrame = 5;
+
+    vector<Mat> frame_buffer(nFrame);
+
+    cv::VideoCapture cap(inputFile);
+    ASSERT_TRUE(cap.isOpened());
+    prepareData(cap, cn, frame_buffer);
+
+    Mat foreground;
+
+    TEST_CYCLE()
+    {
+        Ptr<cv::BackgroundSubtractorKNN> knn = createBackgroundSubtractorKNN();
+        knn->setDetectShadows(false);
+        foreground.release();
+        for (int i = 0; i < nFrame; i++)
+        {
+            knn->apply(frame_buffer[i], foreground);
+        }
+    }
+    SANITY_CHECK_NOTHING();
+}
+
+PERF_TEST_P(KNN_GetBackgroundImage, KNN, Values(
+        std::make_pair<string, int>("gpu/video/768x576.avi", 5),
+        std::make_pair<string, int>("gpu/video/1920x1080.avi", 5)))
+{
+    VideoKNNParamType params = GetParam();
+
+    const string inputFile = getDataPath(get<0>(params));
+
+    const int cn = 3;
+    const int skipFrames = get<1>(params);
+    int nFrame = 10;
+
+    vector<Mat> frame_buffer(nFrame);
+
+    cv::VideoCapture cap(inputFile);
+    ASSERT_TRUE(cap.isOpened());
+    prepareData(cap, cn, frame_buffer, skipFrames);
+
+    Mat foreground, background;
+
+    TEST_CYCLE()
+    {
+        Ptr<cv::BackgroundSubtractorKNN> knn = createBackgroundSubtractorKNN();
+        knn->setDetectShadows(false);
+        foreground.release();
+        background.release();
+        for (int i = 0; i < nFrame; i++)
+        {
+            knn->apply(frame_buffer[i], foreground);
+        }
+        knn->getBackgroundImage(background);
+    }
+#ifdef DEBUG_BGFG
+    imwrite(format("fg_%d_%d_knn.png", frame_buffer[0].rows, cn), foreground);
+    imwrite(format("bg_%d_%d_knn.png", frame_buffer[0].rows, cn), background);
+#endif
+    SANITY_CHECK_NOTHING();
+}
+
+}}// namespace
+
+#endif

--- a/modules/video/perf/perf_bgfg_mog2.cpp
+++ b/modules/video/perf/perf_bgfg_mog2.cpp
@@ -2,25 +2,20 @@
 // It is subject to the license terms in the LICENSE file found in the top-level directory
 // of this distribution and at http://opencv.org/license.html.
 
-#include "../perf_precomp.hpp"
-#include "opencv2/ts/ocl_perf.hpp"
+#include "perf_precomp.hpp"
 
-#ifdef HAVE_OPENCL
 #ifdef HAVE_VIDEO_INPUT
-#include "../perf_bgfg_utils.hpp"
+#include "perf_bgfg_utils.hpp"
 
-namespace cvtest {
-namespace ocl {
+namespace opencv_test { namespace {
 
 //////////////////////////// Mog2//////////////////////////
 
-typedef tuple<string, int> VideoMOG2ParamType;
+typedef tuple<std::string, int> VideoMOG2ParamType;
 typedef TestBaseWithParam<VideoMOG2ParamType> MOG2_Apply;
 typedef TestBaseWithParam<VideoMOG2ParamType> MOG2_GetBackgroundImage;
 
-using namespace opencv_test;
-
-OCL_PERF_TEST_P(MOG2_Apply, Mog2, Combine(Values("gpu/video/768x576.avi", "gpu/video/1920x1080.avi"), Values(1,3)))
+PERF_TEST_P(MOG2_Apply, Mog2, Combine(Values("gpu/video/768x576.avi", "gpu/video/1920x1080.avi"), Values(1,3)))
 {
     VideoMOG2ParamType params = GetParam();
 
@@ -35,22 +30,22 @@ OCL_PERF_TEST_P(MOG2_Apply, Mog2, Combine(Values("gpu/video/768x576.avi", "gpu/v
     ASSERT_TRUE(cap.isOpened());
     prepareData(cap, cn, frame_buffer);
 
-    UMat u_foreground;
+    Mat foreground;
 
-    OCL_TEST_CYCLE()
+    TEST_CYCLE()
     {
         Ptr<cv::BackgroundSubtractorMOG2> mog2 = createBackgroundSubtractorMOG2();
         mog2->setDetectShadows(false);
-        u_foreground.release();
+        foreground.release();
         for (int i = 0; i < nFrame; i++)
         {
-            mog2->apply(frame_buffer[i], u_foreground);
+            mog2->apply(frame_buffer[i], foreground);
         }
     }
     SANITY_CHECK_NOTHING();
 }
 
-OCL_PERF_TEST_P(MOG2_GetBackgroundImage, Mog2, Values(
+PERF_TEST_P(MOG2_GetBackgroundImage, Mog2, Values(
         std::make_pair<string, int>("gpu/video/768x576.avi", 5),
         std::make_pair<string, int>("gpu/video/1920x1080.avi", 5)))
 {
@@ -68,28 +63,27 @@ OCL_PERF_TEST_P(MOG2_GetBackgroundImage, Mog2, Values(
     ASSERT_TRUE(cap.isOpened());
     prepareData(cap, cn, frame_buffer, skipFrames);
 
-    UMat u_foreground, u_background;
+    Mat foreground, background;
 
-    OCL_TEST_CYCLE()
+    TEST_CYCLE()
     {
         Ptr<cv::BackgroundSubtractorMOG2> mog2 = createBackgroundSubtractorMOG2();
         mog2->setDetectShadows(false);
-        u_foreground.release();
-        u_background.release();
+        foreground.release();
+        background.release();
         for (int i = 0; i < nFrame; i++)
         {
-            mog2->apply(frame_buffer[i], u_foreground);
+            mog2->apply(frame_buffer[i], foreground);
         }
-        mog2->getBackgroundImage(u_background);
+        mog2->getBackgroundImage(background);
     }
 #ifdef DEBUG_BGFG
-    imwrite(format("fg_%d_%d_mog2_ocl.png", frame_buffer[0].rows, cn), u_foreground.getMat(ACCESS_READ));
-    imwrite(format("bg_%d_%d_mog2_ocl.png", frame_buffer[0].rows, cn), u_background.getMat(ACCESS_READ));
+    imwrite(format("fg_%d_%d_mog2.png", frame_buffer[0].rows, cn), foreground);
+    imwrite(format("bg_%d_%d_mog2.png", frame_buffer[0].rows, cn), background);
 #endif
     SANITY_CHECK_NOTHING();
 }
 
-}}// namespace cvtest::ocl
+}}// namespace
 
-#endif
 #endif

--- a/modules/video/perf/perf_bgfg_utils.hpp
+++ b/modules/video/perf/perf_bgfg_utils.hpp
@@ -1,0 +1,48 @@
+// This file is part of OpenCV project.
+// It is subject to the license terms in the LICENSE file found in the top-level directory
+// of this distribution and at http://opencv.org/license.html.
+
+namespace opencv_test {
+
+//#define DEBUG_BGFG
+
+using namespace testing;
+using namespace cvtest;
+using namespace perf;
+
+namespace {
+
+using namespace cv;
+
+static void cvtFrameFmt(std::vector<Mat>& input, std::vector<Mat>& output)
+{
+    for(int i = 0; i< (int)(input.size()); i++)
+    {
+        cvtColor(input[i], output[i], COLOR_RGB2GRAY);
+    }
+}
+
+static void prepareData(VideoCapture& cap, int cn, std::vector<Mat>& frame_buffer, int skipFrames = 0)
+{
+    std::vector<Mat> frame_buffer_init;
+    int nFrame = (int)frame_buffer.size();
+    for (int i = 0; i < skipFrames; i++)
+    {
+        cv::Mat frame;
+        cap >> frame;
+    }
+    for (int i = 0; i < nFrame; i++)
+    {
+        cv::Mat frame;
+        cap >> frame;
+        ASSERT_FALSE(frame.empty());
+        frame_buffer_init.push_back(frame);
+    }
+
+    if (cn == 1)
+        cvtFrameFmt(frame_buffer_init, frame_buffer);
+    else
+        frame_buffer.swap(frame_buffer_init);
+}
+
+}}


### PR DESCRIPTION
prepareData() bug feeds the same image (the latest).
OCL perf test doesn't pass accuracy(!) check now, so this check is disabled.

related #10432