### PR TITLE
Multichannel Mat::ones and UMat::ones initialization

### DIFF
--- a/modules/core/src/matop.cpp
+++ b/modules/core/src/matop.cpp
@@ -1634,11 +1634,11 @@ void MatOp_Initializer::assign(const MatExpr& e, Mat& m, int _type) const
         m.create(e.a.dims, e.a.size, _type);
 
     if( e.flags == 'I' && e.a.dims <= 2 )
-        setIdentity(m, Scalar(e.alpha));
+        setIdentity(m, Scalar::all(e.alpha));
     else if( e.flags == '0' )
         m = Scalar();
     else if( e.flags == '1' )
-        m = Scalar(e.alpha);
+        m = Scalar::all(e.alpha);
     else
         CV_Error(CV_StsError, "Invalid matrix initializer type");
 }

--- a/modules/core/src/matrix.cpp
+++ b/modules/core/src/matrix.cpp
@@ -5406,7 +5406,7 @@ void SparseMat::convertTo( Mat& m, int rtype, double alpha, double beta ) const
 
     CV_Assert( hdr );
     m.create( dims(), hdr->size, rtype );
-    m = Scalar(beta);
+    m = Scalar::all(beta);
 
     SparseMatConstIterator from = begin();
     size_t N = nzcount();

--- a/modules/core/src/umatrix.cpp
+++ b/modules/core/src/umatrix.cpp
@@ -1146,12 +1146,12 @@ UMat UMat::ones(int rows, int cols, int type)
 
 UMat UMat::ones(Size size, int type)
 {
-    return UMat(size, type, Scalar(1));
+    return UMat(size, type, Scalar::all(1));
 }
 
 UMat UMat::ones(int ndims, const int* sz, int type)
 {
-    return UMat(ndims, sz, type, Scalar(1));
+    return UMat(ndims, sz, type, Scalar::all(1));
 }
 
 UMat UMat::eye(int rows, int cols, int type)

--- a/modules/core/test/test_umat.cpp
+++ b/modules/core/test/test_umat.cpp
@@ -1383,4 +1383,21 @@ TEST(UMat, testTempObjects_Mat_issue_8693)
     EXPECT_EQ(0, cvtest::norm(srcUMat.getMat(ACCESS_READ), srcMat, NORM_INF));
 }
 
+typedef TestWithParam<tuple<int, Size, int> > UMat_init;
+TEST_P(UMat_init, ones)
+{
+    int depth = get<0>(GetParam());
+    Size size = get<1>(GetParam());
+    int ch = get<2>(GetParam());
+
+    UMat m = UMat::ones(size, CV_MAKETYPE(depth, ch));
+    ASSERT_EQ(countNonZero(m.getMat(ACCESS_READ) != 1), 0);
+}
+
+INSTANTIATE_TEST_CASE_P(Core, UMat_init, Combine(
+        Values(CV_8U, CV_8S, CV_16S, CV_32S, CV_32F, CV_64F), // depth
+        Values(Size(3, 3), Size(16, 8)),  // input size
+        Values(1, 2, 3, 4)  // number of channels
+));
+
 } } // namespace cvtest::ocl


### PR DESCRIPTION
<!-- Please use this line to close one or multiple issues when this pullrequest gets merged
You can add another line right under the first one:
resolves #1234
resolves #1235
-->

### This pullrequest changes

Before PR
```cpp
std::cout << cv::Mat::ones(3, 4, CV_8UC3) << std::endl;
```
produced
```
[  1,   0,   0,   1,   0,   0,   1,   0,   0,   1,   0,   0;
   1,   0,   0,   1,   0,   0,   1,   0,   0,   1,   0,   0;
   1,   0,   0,   1,   0,   0,   1,   0,   0,   1,   0,   0]
```
