### PR TITLE
Newton's method can be more efficient

### DIFF
--- a/modules/calib3d/src/fisheye.cpp
+++ b/modules/calib3d/src/fisheye.cpp
@@ -388,19 +388,20 @@ void cv::fisheye::undistortPoints( InputArray distorted, OutputArray undistorted
         {
             // compensate distortion iteratively
             double theta = theta_d;
-	    const double EPS = 1e-8;
-           
-	    for (int j=0; j<10; j++)
-	    {
-		double theta2 = theta*theta, theta4 = theta2*theta2, theta6 = theta4*theta2, theta8 = theta6*theta2;
-		double k0_theta2 = k[0] * theta2, k1_theta4 = k[1] * theta4, k2_theta6 = k[2] * theta6, k3_theta8 = k[3] * theta8;
-		double _theta = theta - (theta * (1 + k0_theta2 + k1_theta4 + k2_theta6 + k3_theta8) - theta_d) /
-					 (1 + 3*k0_theta2 + 5*k1_theta4 + 7*k2_theta6 + 9*k3_theta8);
-		if (EPS > fabs(_theta - theta))
-		{ break; }
-		theta = _theta;
-	    }
-            
+
+            const double EPS = 1e-8; // or std::numeric_limits<double>::epsilon();
+            for (int j = 0; j < 10; j++)
+            {
+                double theta2 = theta*theta, theta4 = theta2*theta2, theta6 = theta4*theta2, theta8 = theta6*theta2;
+                double k0_theta2 = k[0] * theta2, k1_theta4 = k[1] * theta4, k2_theta6 = k[2] * theta6, k3_theta8 = k[3] * theta8;
+                /* new_theta = theta - theta_fix, theta_fix = f0(theta) / f0'(theta) */
+                double theta_fix = (theta * (1 + k0_theta2 + k1_theta4 + k2_theta6 + k3_theta8) - theta_d) /
+                                   (1 + 3*k0_theta2 + 5*k1_theta4 + 7*k2_theta6 + 9*k3_theta8);
+                theta = theta - theta_fix;
+                if (fabs(theta_fix) < EPS)
+                    break;
+            }
+
             scale = std::tan(theta) / theta_d;
         }
 

--- a/modules/calib3d/src/fisheye.cpp
+++ b/modules/calib3d/src/fisheye.cpp
@@ -388,12 +388,19 @@ void cv::fisheye::undistortPoints( InputArray distorted, OutputArray undistorted
         {
             // compensate distortion iteratively
             double theta = theta_d;
-            for(int j = 0; j < 10; j++ )
-            {
-                double theta2 = theta*theta, theta4 = theta2*theta2, theta6 = theta4*theta2, theta8 = theta6*theta2;
-                theta = theta_d / (1 + k[0] * theta2 + k[1] * theta4 + k[2] * theta6 + k[3] * theta8);
-            }
-
+            int j;
+			double eps0 = 1e-8, eps = 1;
+           
+			for (j=0; j<10 && eps > eps0; j++)
+			{
+				double theta2 = theta*theta, theta4 = theta2*theta2, theta6 = theta4*theta2, theta8 = theta6*theta2;
+				double theta3 = theta*theta2, theta5 = theta4*theta, theta7 = theta6*theta, theta9 = theta8*theta;
+				double _theta = theta - (theta + k[0]*theta3 + k[1]*theta5 + k[2]*theta7 + k[3]*theta9 - theta_d) /
+						 (1 + 3*k[0]*theta2 + 5*k[1]*theta4 + 7*k[2]*theta6 + 9*k[3]*theta8);
+				eps = fabs(_theta - theta);
+				theta = _theta;
+			}
+            
             scale = std::tan(theta) / theta_d;
         }
 

--- a/modules/calib3d/src/fisheye.cpp
+++ b/modules/calib3d/src/fisheye.cpp
@@ -388,18 +388,18 @@ void cv::fisheye::undistortPoints( InputArray distorted, OutputArray undistorted
         {
             // compensate distortion iteratively
             double theta = theta_d;
-            int j;
-			double eps0 = 1e-8, eps = 1;
+	    const double EPS = 1e-8;
            
-			for (j=0; j<10 && eps > eps0; j++)
-			{
-				double theta2 = theta*theta, theta4 = theta2*theta2, theta6 = theta4*theta2, theta8 = theta6*theta2;
-				double theta3 = theta*theta2, theta5 = theta4*theta, theta7 = theta6*theta, theta9 = theta8*theta;
-				double _theta = theta - (theta + k[0]*theta3 + k[1]*theta5 + k[2]*theta7 + k[3]*theta9 - theta_d) /
-						 (1 + 3*k[0]*theta2 + 5*k[1]*theta4 + 7*k[2]*theta6 + 9*k[3]*theta8);
-				eps = fabs(_theta - theta);
-				theta = _theta;
-			}
+	    for (int j=0; j<10; j++)
+	    {
+		double theta2 = theta*theta, theta4 = theta2*theta2, theta6 = theta4*theta2, theta8 = theta6*theta2;
+		double k0_theta2 = k[0] * theta2, k1_theta4 = k[1] * theta4, k2_theta6 = k[2] * theta6, k3_theta8 = k[3] * theta8;
+		double _theta = theta - (theta * (1 + k0_theta2 + k1_theta4 + k2_theta6 + k3_theta8) - theta_d) /
+					 (1 + 3*k0_theta2 + 5*k1_theta4 + 7*k2_theta6 + 9*k3_theta8);
+		if (EPS > fabs(_theta - theta))
+		{ break; }
+		theta = _theta;
+	    }
             
             scale = std::tan(theta) / theta_d;
         }


### PR DESCRIPTION
when we get the result of function distortPoint with a point (0, 0) and then undistortPoint with  the result, we get the point not (0, 0). and then we discovered that the old method is not convergence sometimes. finally we have gotten the right values by Newton's method.

<!-- Please use this line to close one or multiple issues when this pullrequest gets merged
You can add another line right under the first one:
resolves #1234
resolves #1235
-->

### This pullrequest changes

<!-- Please describe what your pullrequest is changing -->
