### PR TITLE
Propagate calculated Gaussian kernel size(ref)

### DIFF
--- a/modules/imgproc/src/smooth.cpp
+++ b/modules/imgproc/src/smooth.cpp
@@ -1763,7 +1763,7 @@ cv::Mat cv::getGaussianKernel( int n, double sigma, int ktype )
 
 namespace cv {
 
-static void createGaussianKernels( Mat & kx, Mat & ky, int type, Size ksize,
+static void createGaussianKernels( Mat & kx, Mat & ky, int type, Size & ksize,
                                    double sigma1, double sigma2 )
 {
     int depth = CV_MAT_DEPTH(type);


### PR DESCRIPTION
 Otherwise, ipp_GaussianBlur will fail if the user doesn't specify a kernel size. Not sure if this is the best fix though.