### PR TITLE
Make <array> #ifdef true for MSVC

### DIFF
--- a/modules/core/include/opencv2/core/cvdef.h
+++ b/modules/core/include/opencv2/core/cvdef.h
@@ -442,7 +442,7 @@ Cv64suf;
 \****************************************************************************************/
 
 #ifndef CV_CXX_STD_ARRAY
-#  if __cplusplus >= 201103L
+#  if __cplusplus >= 201103L || (defined(_MSC_VER) && _MSC_VER >= 1900/*MSVS 2015*/)
 #    define CV_CXX_STD_ARRAY 1
 #    include <array>
 #  endif

--- a/modules/core/test/test_mat.cpp
+++ b/modules/core/test/test_mat.cpp
@@ -1672,9 +1672,9 @@ TEST(Core_Mat_array, copyTo_roi_row)
 TEST(Core_Mat_array, SplitMerge)
 {
     std::array<cv::Mat, 3> src;
-    for(size_t i=0; i<src.size(); ++i) {
-        src[i].create(10, 10, CV_8U);
-        src[i] = 127 * i;
+    for (size_t i = 0; i < src.size(); ++i)
+    {
+        src[i] = Mat(10, 10, CV_8U, Scalar((double)(16 * (i + 1))));
     }
 
     Mat merged;
@@ -1683,10 +1683,9 @@ TEST(Core_Mat_array, SplitMerge)
     std::array<cv::Mat, 3> dst;
     split(merged, dst);
 
-    Mat diff;
-    for(size_t i=0; i<dst.size(); ++i) {
-        absdiff(src[i], dst[i], diff);
-        EXPECT_EQ(0, countNonZero(diff));
+    for (size_t i = 0; i < dst.size(); ++i)
+    {
+        EXPECT_EQ(0, cvtest::norm(src[i], dst[i], NORM_INF));
     }
 }
 #endif


### PR DESCRIPTION
I think MSVC had `std::array` for quite a while (possibly going back as far as VS 2012, but it's definitely there in 2015 and 2017. So I think `_MSC_VER` `1900` is a safe bet. Probably `1800` and maybe even `1700` could work as well but I can't test that locally.