### PR TITLE
Fix mapping RelWithDebInfo/MinSizeRel to Release

### DIFF
--- a/cmake/templates/OpenCVConfig.cmake.in
+++ b/cmake/templates/OpenCVConfig.cmake.in
@@ -134,7 +134,7 @@ if(NOT DEFINED OPENCV_MAP_IMPORTED_CONFIG)
     # By default CMake maps these configuration on the first available (Debug) which is wrong.
     # Non-Debug build of Application can't be used with OpenCV Debug build (ABI mismatch problem)
     # Add mapping of RelWithDebInfo and MinSizeRel to Release here
-    set(OPENCV_MAP_IMPORTED_CONFIG "RELWITHDEBINFO=!Release;MINSIZEREL=!Release")
+    set(OPENCV_MAP_IMPORTED_CONFIG "RelWithDebInfo=!Release;MinSizeRel=!Release")
   endif()
 endif()
 set(__remap_warnings "")


### PR DESCRIPTION
### This pullrequest changes

When building in RelWithDebInfo mode, the build completes successfully but any other library trying to link with OpenCV will fail with the same errors as described in #10321. The cause seems to be that the configs to map stored in `OPENCV_MAP_IMPORTED_CONFIG` are written in all caps. I suspect this is a mistake, as the variable is matched against a regex, and the captured match in then converted to capitals. (`string(TOUPPER "${__remap_config}" __remap_config_upper)`).

In any case, this PR fixes the problem for me.

I'm on Windows + VS2017 (using VS2015 toolset). I only fixed this for my setup, and looking at the code, I think other setups (e.g. Linux/OS X) would encounter the same issue. I'll get someone to try it out so that I can push fixes for the other platforms if it turns out they need it, so please don't merge this until I had the time to do that :)