### PR TITLE
OCL: core: fix deadlock in UMatDataAutoLock

### DIFF
--- a/modules/core/include/opencv2/core/mat.hpp
+++ b/modules/core/include/opencv2/core/mat.hpp
@@ -545,14 +545,6 @@ struct CV_EXPORTS UMatData
 };
 
 
-struct CV_EXPORTS UMatDataAutoLock
-{
-    explicit UMatDataAutoLock(UMatData* u);
-    ~UMatDataAutoLock();
-    UMatData* u;
-};
-
-
 struct CV_EXPORTS MatSize
 {
     explicit MatSize(int* _p);

--- a/modules/core/include/opencv2/core/mat.inl.hpp
+++ b/modules/core/include/opencv2/core/mat.inl.hpp
@@ -3911,9 +3911,6 @@ inline void UMatData::markDeviceCopyObsolete(bool flag)
         flags &= ~DEVICE_COPY_OBSOLETE;
 }
 
-inline UMatDataAutoLock::UMatDataAutoLock(UMatData* _u) : u(_u) { u->lock(); }
-inline UMatDataAutoLock::~UMatDataAutoLock() { u->unlock(); }
-
 //! @endcond
 
 } //cv

--- a/modules/core/src/ocl.cpp
+++ b/modules/core/src/ocl.cpp
@@ -123,6 +123,8 @@
 #include "opencv2/core/opencl/opencl_svm.hpp"
 #endif
 
+#include "umatrix.hpp"
+
 namespace cv { namespace ocl {
 
 #define IMPLEMENT_REFCOUNTABLE() \
@@ -5424,8 +5426,7 @@ public:
                                             srcrawofs, new_srcofs, new_srcstep,
                                             dstrawofs, new_dstofs, new_dststep);
 
-        UMatDataAutoLock src_autolock(src);
-        UMatDataAutoLock dst_autolock(dst);
+        UMatDataAutoLock src_autolock(src, dst);
 
         if( !src->handle || (src->data && src->hostCopyObsolete() < src->deviceCopyObsolete()) )
         {

--- a/modules/core/src/umatrix.hpp
+++ b/modules/core/src/umatrix.hpp
@@ -1,0 +1,20 @@
+// This file is part of OpenCV project.
+// It is subject to the license terms in the LICENSE file found in the top-level directory
+// of this distribution and at http://opencv.org/license.html.
+#ifndef OPENCV_CORE_SRC_UMATRIX_HPP
+#define OPENCV_CORE_SRC_UMATRIX_HPP
+
+namespace cv {
+
+struct CV_EXPORTS UMatDataAutoLock
+{
+    explicit UMatDataAutoLock(UMatData* u);
+    UMatDataAutoLock(UMatData* u1, UMatData* u2);
+    ~UMatDataAutoLock();
+    UMatData* u1;
+    UMatData* u2;
+};
+
+}
+
+#endif // OPENCV_CORE_SRC_UMATRIX_HPP


### PR DESCRIPTION
UMatData locks are not mapped on real locks (they are mapped to some "pre-initialized" pool).

Concurrent execution of these statements may lead to deadlock:
- a.copyTo(b) from thread 1
- c.copyTo(d) from thread 2

where:
- 'a' and 'd' are mapped to single lock "A".
- 'b' and 'c' are mapped to single lock "B".

Workaround is to process locks with strict order.


resolves http://answers.opencv.org/question/182280/opencv-opencl-thread-saftey-deadlock-changing-cvmat-to-umat/


<details>

<summary>Problem reproducer</summary>

```
{
    size_t N = 64;
    UMat umats[N];
    for (size_t i = 0; i < N; i++)
    {
        umats[i].create(Size(100, 100), CV_8UC1);
        umats[i].setTo(Scalar::all(i));
        std::cout << i << ": " << (void*)umats[i].u << std::endl;
    }
    auto fn = ([&] () -> void
    {
        int t = cv::utils::getThreadID();
        cv::RNG r(t);
        for (int i = 0; i < 1000; i++)
        {
            int a = r(N);
            int b = r(N);
            std::stringstream ss; ss << t << ": " << a << " => " << b << std::endl;
            std::string s = ss.str();
            std::cout << s;
            umats[a].copyTo(umats[b]);
        }
    });
    size_t num_threads = 4;
    std::vector<std::thread> threads(num_threads);
    for (auto& t: threads) t = std::thread(fn);
    for (auto& t: threads) t.join();
    std::cout << "Done" << std::endl;
}
```

</details>