### PR TITLE
Re-apply protobuf fix for JavaScript builds

### DIFF
--- a/3rdparty/protobuf/src/google/protobuf/stubs/port.h
+++ b/3rdparty/protobuf/src/google/protobuf/stubs/port.h
@@ -239,8 +239,7 @@ static const uint64 kuint64max = GOOGLE_ULONGLONG(0xFFFFFFFFFFFFFFFF);
 
 #if defined(__clang__) && defined(__has_cpp_attribute) \
     && !defined(GOOGLE_PROTOBUF_OS_APPLE)
-# if defined(GOOGLE_PROTOBUF_OS_NACL) || defined(EMSCRIPTEN) || \
-     __has_cpp_attribute(clang::fallthrough)
+# if defined(GOOGLE_PROTOBUF_OS_NACL) || __has_cpp_attribute(clang::fallthrough)
 #  define GOOGLE_FALLTHROUGH_INTENDED [[clang::fallthrough]]
 # endif
 #elif defined(__GNUC__) && __GNUC__ > 6


### PR DESCRIPTION
original commit: f5035150824c49d3a2d7cb7ce69ac1ffbdf8c63d
JavaScript bindings for dnn module

Fixes nightly builds: [1](http://pullrequest.opencv.org/buildbot/builders/master_docs-lin64/builds/10343) [2](http://pullrequest.opencv.org/buildbot/builders/master_javascript-emscripten-lin64/builds/63)

Related #10595

```
docker_image:Docs=docs-js
docker_image:Custom=javascript
force_builders=Custom
```