### PR TITLE
added cap field for VideoWriter (constructor, open, C interface) for …

### DIFF
--- a/modules/videoio/include/opencv2/videoio.hpp
+++ b/modules/videoio/include/opencv2/videoio.hpp
@@ -172,10 +172,13 @@ enum VideoCaptureProperties {
 @note Currently, these are supported through the libv4l backend only.
 */
 enum VideoCaptureModes {
+       CAP_MODE_AUTO = -1, 
        CAP_MODE_BGR  = 0, //!< BGR24 (default)
        CAP_MODE_RGB  = 1, //!< RGB24
        CAP_MODE_GRAY = 2, //!< Y8
-       CAP_MODE_YUYV = 3  //!< YUYV
+       CAP_MODE_YUYV = 3,  //!< YUYV
+       CAP_MODE_RGBA = 4, //!< RGBA
+       CAP_MODE_GRAY16 = 5, //!< Y16
      };
 
 /** @brief %VideoWriter generic properties identifier.

--- a/modules/videoio/include/opencv2/videoio/videoio_c.h
+++ b/modules/videoio/include/opencv2/videoio/videoio_c.h
@@ -456,10 +456,13 @@ enum
 // Currently, these are supported through the libv4l interface only.
 enum
 {
+    CV_CAP_MODE_AUTO = -1, 
     CV_CAP_MODE_BGR  = 0, // BGR24 (default)
     CV_CAP_MODE_RGB  = 1, // RGB24
     CV_CAP_MODE_GRAY = 2, // Y8
-    CV_CAP_MODE_YUYV = 3  // YUYV
+    CV_CAP_MODE_YUYV = 3, // YUYV
+    CV_CAP_MODE_RGBA = 4, // RGBA
+    CV_CAP_MODE_GRAY16 = 5, // Y16
 };
 
 enum

--- a/modules/videoio/src/cap_ffmpeg.cpp
+++ b/modules/videoio/src/cap_ffmpeg.cpp
@@ -276,13 +276,13 @@ public:
         return icvWriteFrame_FFMPEG_p(ffmpegWriter, (const uchar*)image->imageData,
              image->widthStep, image->width, image->height, image->nChannels, image->origin) !=0;
     }
-    virtual bool open( const char* filename, int fourcc, double fps, CvSize frameSize, bool isColor )
+    virtual bool open( const char* filename, int fourcc, double fps, CvSize frameSize, bool isColor, int cap)
     {
         icvInitFFMPEG::Init();
         close();
         if( !icvCreateVideoWriter_FFMPEG_p )
             return false;
-        ffmpegWriter = icvCreateVideoWriter_FFMPEG_p( filename, fourcc, fps, frameSize.width, frameSize.height, isColor );
+        ffmpegWriter = icvCreateVideoWriter_FFMPEG_p( filename, fourcc, fps, frameSize.width, frameSize.height, isColor, (cv::VideoCaptureModes)cap);
         return ffmpegWriter != 0;
     }
 
@@ -300,11 +300,11 @@ protected:
 
 
 CvVideoWriter* cvCreateVideoWriter_FFMPEG_proxy( const char* filename, int fourcc,
-                                          double fps, CvSize frameSize, int isColor )
+                                          double fps, CvSize frameSize, int isColor, cv::VideoCaptureModes cap)
 {
     CvVideoWriter_FFMPEG_proxy* result = new CvVideoWriter_FFMPEG_proxy;
 
-    if( result->open( filename, fourcc, fps, frameSize, isColor != 0 ))
+    if( result->open( filename, fourcc, fps, frameSize, isColor != 0, cap ))
         return result;
     delete result;
     return 0;

--- a/modules/videoio/src/cap_ffmpeg_api.hpp
+++ b/modules/videoio/src/cap_ffmpeg_api.hpp
@@ -46,9 +46,9 @@ OPENCV_FFMPEG_API int cvRetrieveFrame_FFMPEG_2(struct CvCapture_FFMPEG_2* captur
 OPENCV_FFMPEG_API void cvReleaseCapture_FFMPEG(struct CvCapture_FFMPEG** cap);
 OPENCV_FFMPEG_API void cvReleaseCapture_FFMPEG_2(struct CvCapture_FFMPEG_2** cap);
 OPENCV_FFMPEG_API struct CvVideoWriter_FFMPEG* cvCreateVideoWriter_FFMPEG(const char* filename,
-            int fourcc, double fps, int width, int height, int isColor );
+            int fourcc, double fps, int width, int height, int isColor, cv::VideoCaptureModes cap);
 OPENCV_FFMPEG_API struct CvVideoWriter_FFMPEG_2* cvCreateVideoWriter_FFMPEG_2(const char* filename,
-            int fourcc, double fps, int width, int height, int isColor );
+            int fourcc, double fps, int width, int height, int isColor, cv::VideoCaptureModes cap );
 
 OPENCV_FFMPEG_API int cvWriteFrame_FFMPEG(struct CvVideoWriter_FFMPEG* writer, const unsigned char* data,
                                           int step, int width, int height, int cn, int origin);
@@ -64,7 +64,7 @@ typedef int (*CvSetCaptureProperty_Plugin)( void* capture_handle, int prop_id, d
 typedef double (*CvGetCaptureProperty_Plugin)( void* capture_handle, int prop_id );
 typedef void (*CvReleaseCapture_Plugin)( void** capture_handle );
 typedef void* (*CvCreateVideoWriter_Plugin)( const char* filename, int fourcc,
-                                             double fps, int width, int height, int iscolor );
+                                             double fps, int width, int height, int iscolor, cv::VideoCaptureModes cap);
 typedef int (*CvWriteFrame_Plugin)( void* writer_handle, const unsigned char* data, int step,
                                     int width, int height, int cn, int origin);
 typedef void (*CvReleaseVideoWriter_Plugin)( void** writer );

--- a/modules/videoio/src/cap_gstreamer.cpp
+++ b/modules/videoio/src/cap_gstreamer.cpp
@@ -1418,7 +1418,7 @@ const char* CvVideoWriter_GStreamer::filenameToMimetype(const char *filename)
  *
  */
 bool CvVideoWriter_GStreamer::open( const char * filename, int fourcc,
-                                    double fps, CvSize frameSize, bool is_color )
+                                    double fps, CvSize frameSize, bool is_color)
 {
     CV_FUNCNAME("CvVideoWriter_GStreamer::open");
 
@@ -1429,6 +1429,9 @@ bool CvVideoWriter_GStreamer::open( const char * filename, int fourcc,
 
     // init gstreamer
     gst_initializer::init();
+
+    if(cap != CAP_MODE_AUTO)
+        return false;
 
     // init vars
     bool manualpipeline = true;

--- a/modules/videoio/src/cap_mfx_writer.cpp
+++ b/modules/videoio/src/cap_mfx_writer.cpp
@@ -29,7 +29,7 @@ inline mfxU32 codecIdByFourCC(int fourcc)
         return (mfxU32)-1;
 }
 
-VideoWriter_IntelMFX::VideoWriter_IntelMFX(const String &filename, int _fourcc, double fps, Size frameSize_, bool)
+VideoWriter_IntelMFX::VideoWriter_IntelMFX(const String &filename, int _fourcc, double fps, Size frameSize_, bool , VideoCaptureMode cap)
     : session(0), plugin(0), deviceHandler(0), bs(0), encoder(0), pool(0), frameSize(frameSize_), good(false)
 {
     mfxStatus res = MFX_ERR_NONE;
@@ -244,11 +244,11 @@ bool VideoWriter_IntelMFX::write_one(cv::InputArray bgr)
     }
 }
 
-Ptr<VideoWriter_IntelMFX> VideoWriter_IntelMFX::create(const String &filename, int _fourcc, double fps, Size frameSize, bool isColor)
+Ptr<VideoWriter_IntelMFX> VideoWriter_IntelMFX::create(const String &filename, int _fourcc, double fps, Size frameSize, bool isColor , VideoCaptureMode cap)
 {
     if (codecIdByFourCC(_fourcc) > 0)
     {
-        Ptr<VideoWriter_IntelMFX> a = makePtr<VideoWriter_IntelMFX>(filename, _fourcc, fps, frameSize, isColor);
+        Ptr<VideoWriter_IntelMFX> a = makePtr<VideoWriter_IntelMFX>(filename, _fourcc, fps, frameSize, isColor, cap);
         if (a->isOpened())
             return a;
     }

--- a/modules/videoio/src/cap_mfx_writer.hpp
+++ b/modules/videoio/src/cap_mfx_writer.hpp
@@ -18,13 +18,13 @@ class MFXVideoENCODE;
 class VideoWriter_IntelMFX : public cv::IVideoWriter
 {
 public:
-    VideoWriter_IntelMFX(const cv::String &filename, int _fourcc, double fps, cv::Size frameSize, bool isColor);
+    VideoWriter_IntelMFX(const cv::String &filename, int _fourcc, double fps, cv::Size frameSize, bool isColor, VideoCaptureMode cap = CAP_MODE_AUTO);
     virtual ~VideoWriter_IntelMFX();
     virtual double getProperty(int) const;
     virtual bool setProperty(int, double);
     virtual bool isOpened() const;
     virtual void write(cv::InputArray input);
-    static cv::Ptr<VideoWriter_IntelMFX> create(const cv::String& filename, int _fourcc, double fps, cv::Size frameSize, bool isColor);
+    static cv::Ptr<VideoWriter_IntelMFX> create(const cv::String& filename, int _fourcc, double fps, cv::Size frameSize, bool isColor, VideoCaptureMode cap = CAP_MODE_AUTO);
 
 protected:
     bool write_one(cv::InputArray bgr);

--- a/modules/videoio/src/cap_mjpeg_encoder.cpp
+++ b/modules/videoio/src/cap_mjpeg_encoder.cpp
@@ -1893,7 +1893,7 @@ void MotionJpegWriter::writeFrameData( const uchar* data, int step, int colorspa
 
 }
 
-Ptr<IVideoWriter> createMotionJpegWriter( const String& filename, double fps, Size frameSize, bool iscolor )
+Ptr<IVideoWriter> createMotionJpegWriter( const String& filename, double fps, Size frameSize, bool iscolor)
 {
     Ptr<IVideoWriter> iwriter = makePtr<mjpeg::MotionJpegWriter>(filename, fps, frameSize, iscolor);
     if( !iwriter->isOpened() )

--- a/modules/videoio/src/precomp.hpp
+++ b/modules/videoio/src/precomp.hpp
@@ -146,7 +146,7 @@ CvCapture* cvCreateFileCapture_FFMPEG_proxy(const char* filename);
 
 
 CvVideoWriter* cvCreateVideoWriter_FFMPEG_proxy( const char* filename, int fourcc,
-                                            double fps, CvSize frameSize, int is_color );
+                                            double fps, CvSize frameSize, int is_color, cv::VideoCaptureModes cap );
 
 CvCapture * cvCreateFileCapture_QT (const char  * filename);
 CvCapture * cvCreateCameraCapture_QT  (const int     index);
@@ -191,7 +191,7 @@ namespace cv
     };
 
     Ptr<IVideoCapture> createMotionJpegCapture(const String& filename);
-    Ptr<IVideoWriter> createMotionJpegWriter( const String& filename, double fps, Size frameSize, bool iscolor );
+    Ptr<IVideoWriter> createMotionJpegWriter( const String& filename, double fps, Size frameSize, bool iscolor);
 
     Ptr<IVideoCapture> createGPhoto2Capture(int index);
     Ptr<IVideoCapture> createGPhoto2Capture(const String& deviceName);


### PR DESCRIPTION

(partially) resolves #10623 

If useful it can be completed by removing the assert in CvVideoWriter_FFMPEG_proxy plus creating some tests.

### This pullrequest changes
videoio module

VideoWriter interface adding cap field AFTER is_color. Cap field uses VideoCaptureModes.
