### PR TITLE
persistence: replace arbitrary limit of cn to 4 by CV_CN_MAX

### DIFF
--- a/modules/core/src/persistence.cpp
+++ b/modules/core/src/persistence.cpp
@@ -4781,7 +4781,7 @@ icvDecodeSimpleFormat( const char* dt )
     int fmt_pairs[CV_FS_MAX_FMT_PAIRS], fmt_pair_count;
 
     fmt_pair_count = icvDecodeFormat( dt, fmt_pairs, CV_FS_MAX_FMT_PAIRS );
-    if( fmt_pair_count != 1 || fmt_pairs[0] > 4 )
+    if( fmt_pair_count != 1 || fmt_pairs[0] >= CV_CN_MAX)
         CV_Error( CV_StsError, "Too complex format for the matrix" );
 
     elem_type = CV_MAKETYPE( fmt_pairs[1], fmt_pairs[0] );

--- a/modules/python/test/test_algorithm_rw.py
+++ b/modules/python/test/test_algorithm_rw.py
@@ -1,19 +1,19 @@
 #!/usr/bin/env python
-
-'''
-Algorithm serializaion test
-'''
+"""Algorithm serializaion test."""
+from tempfile import NamedTemporaryFile
 import cv2 as cv
-
 from tests_common import NewOpenCVTests
+
 
 class algorithm_rw_test(NewOpenCVTests):
     def test_algorithm_rw(self):
+        f = NamedTemporaryFile(prefix="opencv_python_algorithm_", suffix=".yml")
+
         # some arbitrary non-default parameters
         gold = cv.AKAZE_create(descriptor_size=1, descriptor_channels=2, nOctaves=3, threshold=4.0)
-        gold.write(cv.FileStorage("params.yml", 1), "AKAZE")
+        gold.write(cv.FileStorage(f.name, cv.FILE_STORAGE_WRITE), "AKAZE")
 
-        fs = cv.FileStorage("params.yml", 0)
+        fs = cv.FileStorage(f.name, cv.FILE_STORAGE_READ)
         algorithm = cv.AKAZE_create()
         algorithm.read(fs.getNode("AKAZE"))
 
@@ -21,3 +21,5 @@ class algorithm_rw_test(NewOpenCVTests):
         self.assertEqual(algorithm.getDescriptorChannels(), 2)
         self.assertEqual(algorithm.getNOctaves(), 3)
         self.assertEqual(algorithm.getThreshold(), 4.0)
+
+        f.close()

--- a/modules/python/test/test_algorithm_rw.py
+++ b/modules/python/test/test_algorithm_rw.py
@@ -1,19 +1,21 @@
 #!/usr/bin/env python
 """Algorithm serializaion test."""
-from tempfile import NamedTemporaryFile
+import tempfile
+import os
 import cv2 as cv
 from tests_common import NewOpenCVTests
 
 
 class algorithm_rw_test(NewOpenCVTests):
     def test_algorithm_rw(self):
-        f = NamedTemporaryFile(prefix="opencv_python_algorithm_", suffix=".yml")
+        fd, fname = tempfile.mkstemp(prefix="opencv_python_algorithm_", suffix=".yml")
+        os.close(fd)
 
         # some arbitrary non-default parameters
         gold = cv.AKAZE_create(descriptor_size=1, descriptor_channels=2, nOctaves=3, threshold=4.0)
-        gold.write(cv.FileStorage(f.name, cv.FILE_STORAGE_WRITE), "AKAZE")
+        gold.write(cv.FileStorage(fname, cv.FILE_STORAGE_WRITE), "AKAZE")
 
-        fs = cv.FileStorage(f.name, cv.FILE_STORAGE_READ)
+        fs = cv.FileStorage(fname, cv.FILE_STORAGE_READ)
         algorithm = cv.AKAZE_create()
         algorithm.read(fs.getNode("AKAZE"))
 
@@ -22,4 +24,4 @@ class algorithm_rw_test(NewOpenCVTests):
         self.assertEqual(algorithm.getNOctaves(), 3)
         self.assertEqual(algorithm.getThreshold(), 4.0)
 
-        f.close()
+        os.remove(fname)

--- a/modules/python/test/test_persistence.py
+++ b/modules/python/test/test_persistence.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 """"Core serializaion tests."""
-from tempfile import NamedTemporaryFile
+import tempfile
+import os
 import cv2 as cv
 import numpy as np
 from tests_common import NewOpenCVTests
@@ -8,16 +9,17 @@ from tests_common import NewOpenCVTests
 
 class persistence_test(NewOpenCVTests):
     def test_basic(self):
-        f = NamedTemporaryFile(prefix="opencv_python_persistence_", suffix=".yml")
+        fd, fname = tempfile.mkstemp(prefix="opencv_python_persistence_", suffix=".yml")
+        os.close(fd)
 
         # Writing ...
         expected = np.array([[[0, 1, 2, 3, 4]]])
-        fs = cv.FileStorage(f.name, cv.FILE_STORAGE_WRITE)
+        fs = cv.FileStorage(fname, cv.FILE_STORAGE_WRITE)
         fs.write("test", expected)
         fs.release()
 
         # Reading ...
-        fs = cv.FileStorage(f.name, cv.FILE_STORAGE_READ)
+        fs = cv.FileStorage(fname, cv.FILE_STORAGE_READ)
         root = fs.getFirstTopLevelNode()
         self.assertEqual(root.name(), "test")
         test = fs.getNode("test")
@@ -30,4 +32,4 @@ class persistence_test(NewOpenCVTests):
         self.assertEqual(np.array_equal(expected, actual), True)
         fs.release()
 
-        f.close()
+        os.remove(fname)

--- a/modules/python/test/test_persistence.py
+++ b/modules/python/test/test_persistence.py
@@ -8,7 +8,7 @@ from tests_common import NewOpenCVTests
 
 
 class persistence_test(NewOpenCVTests):
-    def test_basic(self):
+    def test_yml_rw(self):
         fd, fname = tempfile.mkstemp(prefix="opencv_python_persistence_", suffix=".yml")
         os.close(fd)
 

--- a/modules/python/test/test_persistence.py
+++ b/modules/python/test/test_persistence.py
@@ -1,0 +1,33 @@
+#!/usr/bin/env python
+""""Core serializaion tests."""
+from tempfile import NamedTemporaryFile
+import cv2 as cv
+import numpy as np
+from tests_common import NewOpenCVTests
+
+
+class persistence_test(NewOpenCVTests):
+    def test_basic(self):
+        f = NamedTemporaryFile(prefix="opencv_python_persistence_", suffix=".yml")
+
+        # Writing ...
+        expected = np.array([[[0, 1, 2, 3, 4]]])
+        fs = cv.FileStorage(f.name, cv.FILE_STORAGE_WRITE)
+        fs.write("test", expected)
+        fs.release()
+
+        # Reading ...
+        fs = cv.FileStorage(f.name, cv.FILE_STORAGE_READ)
+        root = fs.getFirstTopLevelNode()
+        self.assertEqual(root.name(), "test")
+        test = fs.getNode("test")
+        self.assertEqual(test.empty(), False)
+        self.assertEqual(test.name(), "test")
+        self.assertEqual(test.type(), cv.FILE_NODE_MAP)
+        self.assertEqual(test.isMap(), True)
+        actual = test.mat()
+        self.assertEqual(actual.shape, expected.shape)
+        self.assertEqual(np.array_equal(expected, actual), True)
+        fs.release()
+
+        f.close()


### PR DESCRIPTION
without the change you could do
```py
fs.write("test", np.array([[[0,1,2,3,4]]]))
```
but reading would trigger the assertion. With this change all 5 channels are read as expected.