### PR TITLE
Fix perf build with CUDA 9

### DIFF
--- a/modules/cudaarithm/perf/perf_core.cpp
+++ b/modules/cudaarithm/perf/perf_core.cpp
@@ -51,6 +51,8 @@ using namespace perf;
 //////////////////////////////////////////////////////////////////////
 // Merge
 
+DEF_PARAM_TEST(Sz_Depth_Cn, cv::Size, MatDepth, MatCn);
+
 PERF_TEST_P(Sz_Depth_Cn, Merge,
             Combine(CUDA_TYPICAL_MAT_SIZES,
                     ARITHM_MAT_DEPTH,

--- a/modules/cudaarithm/perf/perf_element_operations.cpp
+++ b/modules/cudaarithm/perf/perf_element_operations.cpp
@@ -51,6 +51,8 @@ using namespace perf;
 //////////////////////////////////////////////////////////////////////
 // AddMat
 
+DEF_PARAM_TEST(Sz_Depth, cv::Size, MatDepth);
+
 PERF_TEST_P(Sz_Depth, AddMat,
             Combine(CUDA_TYPICAL_MAT_SIZES,
                     ARITHM_MAT_DEPTH))
@@ -775,6 +777,8 @@ PERF_TEST_P(Sz_Depth, BitwiseAndMat,
 
 //////////////////////////////////////////////////////////////////////
 // BitwiseAndScalar
+
+DEF_PARAM_TEST(Sz_Depth_Cn, cv::Size, MatDepth, MatCn);
 
 PERF_TEST_P(Sz_Depth_Cn, BitwiseAndScalar,
             Combine(CUDA_TYPICAL_MAT_SIZES,

--- a/modules/cudaarithm/perf/perf_reductions.cpp
+++ b/modules/cudaarithm/perf/perf_reductions.cpp
@@ -128,6 +128,8 @@ PERF_TEST_P(Sz_Norm, NormDiff,
 //////////////////////////////////////////////////////////////////////
 // Sum
 
+DEF_PARAM_TEST(Sz_Depth_Cn, cv::Size, MatDepth, MatCn);
+
 PERF_TEST_P(Sz_Depth_Cn, Sum,
             Combine(CUDA_TYPICAL_MAT_SIZES,
                     Values(CV_8U, CV_16U, CV_32F),
@@ -227,6 +229,8 @@ PERF_TEST_P(Sz_Depth_Cn, SumSqr,
 
 //////////////////////////////////////////////////////////////////////
 // MinMax
+
+DEF_PARAM_TEST(Sz_Depth, cv::Size, MatDepth);
 
 PERF_TEST_P(Sz_Depth, MinMax,
             Combine(CUDA_TYPICAL_MAT_SIZES,

--- a/modules/cudaimgproc/perf/perf_blend.cpp
+++ b/modules/cudaimgproc/perf/perf_blend.cpp
@@ -49,6 +49,8 @@ using namespace perf;
 //////////////////////////////////////////////////////////////////////
 // BlendLinear
 
+DEF_PARAM_TEST(Sz_Depth_Cn, cv::Size, MatDepth, MatCn);
+
 PERF_TEST_P(Sz_Depth_Cn, BlendLinear,
             Combine(CUDA_TYPICAL_MAT_SIZES,
                     Values(CV_8U, CV_32F),

--- a/modules/cudaimgproc/perf/perf_histogram.cpp
+++ b/modules/cudaimgproc/perf/perf_histogram.cpp
@@ -49,6 +49,8 @@ using namespace perf;
 //////////////////////////////////////////////////////////////////////
 // HistEvenC1
 
+DEF_PARAM_TEST(Sz_Depth, cv::Size, MatDepth);
+
 PERF_TEST_P(Sz_Depth, HistEvenC1,
             Combine(CUDA_TYPICAL_MAT_SIZES,
                     Values(CV_8U, CV_16U, CV_16S)))

--- a/modules/cudastereo/perf/perf_stereo.cpp
+++ b/modules/cudastereo/perf/perf_stereo.cpp
@@ -192,6 +192,8 @@ PERF_TEST_P(ImagePair, DisparityBilateralFilter,
 //////////////////////////////////////////////////////////////////////
 // ReprojectImageTo3D
 
+DEF_PARAM_TEST(Sz_Depth, cv::Size, MatDepth);
+
 PERF_TEST_P(Sz_Depth, ReprojectImageTo3D,
             Combine(CUDA_TYPICAL_MAT_SIZES,
                     Values(CV_8U, CV_16S)))

--- a/modules/cudawarping/perf/perf_warping.cpp
+++ b/modules/cudawarping/perf/perf_warping.cpp
@@ -364,6 +364,8 @@ PERF_TEST_P(Sz_Depth_Cn_Inter, Rotate,
 //////////////////////////////////////////////////////////////////////
 // PyrDown
 
+DEF_PARAM_TEST(Sz_Depth_Cn, cv::Size, MatDepth, MatCn);
+
 PERF_TEST_P(Sz_Depth_Cn, PyrDown,
             Combine(CUDA_TYPICAL_MAT_SIZES,
                     Values(CV_8U, CV_16U, CV_32F),


### PR DESCRIPTION
This should fix build errors similar to this:

```
Error C2610 'std::tuple\<cv::Size,perf::\`anonymous-namespace'::MatDepth>::tuple(const std::tuple\<cv::Size,perf::\`anonymous-namespace'::MatDepth> &)': is not a special member function which can be defaulted (compiling source file modules\cudaarithm\perf\perf_element_operations.cpp)
```

Tested with:

- Microsoft Visual Studio Community 2017 Version 15.4.5

- Cuda compilation tools, release 9.1, V9.1.85

Related #6716 #10355 

```
force_builders=Custom
docker_image:Custom=ubuntu-cuda:16.04
```