### PR TITLE
cv::cuda::cvtColor bug fix

### DIFF
--- a/modules/cudev/include/opencv2/cudev/functional/detail/color_cvt.hpp
+++ b/modules/cudev/include/opencv2/cudev/functional/detail/color_cvt.hpp
@@ -343,14 +343,14 @@ namespace color_cvt_detail
             const int delta = ColorChannel<T>::half() * (1 << yuv_shift);
 
             const int Y = CV_CUDEV_DESCALE(b * c_RGB2YUVCoeffs_i[0] + g * c_RGB2YUVCoeffs_i[1] + r * c_RGB2YUVCoeffs_i[2], yuv_shift);
-            const int Cr = CV_CUDEV_DESCALE((b - Y) * c_RGB2YUVCoeffs_i[3] + delta, yuv_shift);
-            const int Cb = CV_CUDEV_DESCALE((r - Y) * c_RGB2YUVCoeffs_i[4] + delta, yuv_shift);
+            const int Cb = CV_CUDEV_DESCALE((b - Y) * c_RGB2YUVCoeffs_i[3] + delta, yuv_shift);
+            const int Cr = CV_CUDEV_DESCALE((r - Y) * c_RGB2YUVCoeffs_i[4] + delta, yuv_shift);
 
             typename MakeVec<T, dcn>::type dst;
 
             dst.x = saturate_cast<T>(Y);
-            dst.y = saturate_cast<T>(Cr);
-            dst.z = saturate_cast<T>(Cb);
+            dst.y = saturate_cast<T>(Cb);
+            dst.z = saturate_cast<T>(Cr);
 
             return dst;
         }

--- a/modules/cudev/include/opencv2/cudev/functional/detail/color_cvt.hpp
+++ b/modules/cudev/include/opencv2/cudev/functional/detail/color_cvt.hpp
@@ -342,9 +342,9 @@ namespace color_cvt_detail
 
             const int delta = ColorChannel<T>::half() * (1 << yuv_shift);
 
-            const int Y = CV_CUDEV_DESCALE(b * c_RGB2YUVCoeffs_i[2] + g * c_RGB2YUVCoeffs_i[1] + r * c_RGB2YUVCoeffs_i[0], yuv_shift);
-            const int Cr = CV_CUDEV_DESCALE((r - Y) * c_RGB2YUVCoeffs_i[3] + delta, yuv_shift);
-            const int Cb = CV_CUDEV_DESCALE((b - Y) * c_RGB2YUVCoeffs_i[4] + delta, yuv_shift);
+            const int Y = CV_CUDEV_DESCALE(b * c_RGB2YUVCoeffs_i[0] + g * c_RGB2YUVCoeffs_i[1] + r * c_RGB2YUVCoeffs_i[2], yuv_shift);
+            const int Cr = CV_CUDEV_DESCALE((b - Y) * c_RGB2YUVCoeffs_i[3] + delta, yuv_shift);
+            const int Cb = CV_CUDEV_DESCALE((r - Y) * c_RGB2YUVCoeffs_i[4] + delta, yuv_shift);
 
             typename MakeVec<T, dcn>::type dst;
 
@@ -367,9 +367,9 @@ namespace color_cvt_detail
 
             typename MakeVec<float, dcn>::type dst;
 
-            dst.x = b * c_RGB2YUVCoeffs_f[2] + g * c_RGB2YUVCoeffs_f[1] + r * c_RGB2YUVCoeffs_f[0];
-            dst.y = (r - dst.x) * c_RGB2YUVCoeffs_f[3] + ColorChannel<float>::half();
-            dst.z = (b - dst.x) * c_RGB2YUVCoeffs_f[4] + ColorChannel<float>::half();
+            dst.x = b * c_RGB2YUVCoeffs_f[0] + g * c_RGB2YUVCoeffs_f[1] + r * c_RGB2YUVCoeffs_f[2];
+            dst.y = (b - dst.x) * c_RGB2YUVCoeffs_f[3] + ColorChannel<float>::half();
+            dst.z = (r - dst.x) * c_RGB2YUVCoeffs_f[4] + ColorChannel<float>::half();
 
             return dst;
         }
@@ -385,9 +385,9 @@ namespace color_cvt_detail
     {
         __device__ typename MakeVec<T, dcn>::type operator ()(const typename MakeVec<T, scn>::type& src) const
         {
-            const int b = src.x + CV_CUDEV_DESCALE((src.z - ColorChannel<T>::half()) * c_YUV2RGBCoeffs_i[3], yuv_shift);
+            const int r = src.x + CV_CUDEV_DESCALE((src.z - ColorChannel<T>::half()) * c_YUV2RGBCoeffs_i[3], yuv_shift);
             const int g = src.x + CV_CUDEV_DESCALE((src.z - ColorChannel<T>::half()) * c_YUV2RGBCoeffs_i[2] + (src.y - ColorChannel<T>::half()) * c_YUV2RGBCoeffs_i[1], yuv_shift);
-            const int r = src.x + CV_CUDEV_DESCALE((src.y - ColorChannel<T>::half()) * c_YUV2RGBCoeffs_i[0], yuv_shift);
+            const int b = src.x + CV_CUDEV_DESCALE((src.y - ColorChannel<T>::half()) * c_YUV2RGBCoeffs_i[0], yuv_shift);
 
             typename MakeVec<T, dcn>::type dst;
 
@@ -405,9 +405,9 @@ namespace color_cvt_detail
     {
         __device__ typename MakeVec<float, dcn>::type operator ()(const typename MakeVec<float, scn>::type& src) const
         {
-            const float b = src.x + (src.z - ColorChannel<float>::half()) * c_YUV2RGBCoeffs_f[3];
+            const float r = src.x + (src.z - ColorChannel<float>::half()) * c_YUV2RGBCoeffs_f[3];
             const float g = src.x + (src.z - ColorChannel<float>::half()) * c_YUV2RGBCoeffs_f[2] + (src.y - ColorChannel<float>::half()) * c_YUV2RGBCoeffs_f[1];
-            const float r = src.x + (src.y - ColorChannel<float>::half()) * c_YUV2RGBCoeffs_f[0];
+            const float b = src.x + (src.y - ColorChannel<float>::half()) * c_YUV2RGBCoeffs_f[0];
 
             typename MakeVec<float, dcn>::type dst;
 


### PR DESCRIPTION
Fixed bug in conversion formula between RGB space and YUV space.
Testing with opencv_test_cudaimgproc.exe, this commit reduces the number
of failed tests from 191 to 95. (96 more tests pass)

Following are the list of categories of the tests that failed before this commit
but are solved now. Each category contains 12 tests, summing up to 96 total.

CUDA_ImgProc/CvtColor.BGR2YUV
CUDA_ImgProc/CvtColor.RGB2YUV
CUDA_ImgProc/CvtColor.YUV2BGR
CUDA_ImgProc/CvtColor.YUV42BGR
CUDA_ImgProc/CvtColor.YUV42BGRA
CUDA_ImgProc/CvtColor.YUV2RGB
CUDA_ImgProc/CvtColor.BGR2YUV4
CUDA_ImgProc/CvtColor.RGBA2YUV4

```
force_builders=Custom
docker_image:Custom=ubuntu-cuda:16.04
```

**alalek**: related #7481