### PR TITLE
Avoid unnecessary MOG2 opencl initializing when non-UMat parameters are used

### DIFF
--- a/modules/video/src/bgfg_gaussmix2.cpp
+++ b/modules/video/src/bgfg_gaussmix2.cpp
@@ -770,6 +770,11 @@ public:
 
 bool BackgroundSubtractorMOG2Impl::ocl_apply(InputArray _image, OutputArray _fgmask, double learningRate)
 {
+    bool needToInitialize = nframes == 0 || learningRate >= 1 || _image.size() != frameSize || _image.type() != frameType;
+
+    if( needToInitialize )
+        initialize(_image.size(), _image.type());
+
     ++nframes;
     learningRate = learningRate >= 0 && nframes > 1 ? learningRate : 1./std::min( 2*nframes, history );
     CV_Assert(learningRate >= 0);
@@ -841,20 +846,20 @@ void BackgroundSubtractorMOG2Impl::apply(InputArray _image, OutputArray _fgmask,
 {
     CV_INSTRUMENT_REGION()
 
-    bool needToInitialize = nframes == 0 || learningRate >= 1 || _image.size() != frameSize || _image.type() != frameType;
-
-    if( needToInitialize )
-        initialize(_image.size(), _image.type());
-
 #ifdef HAVE_OPENCL
     if (opencl_ON)
     {
         CV_OCL_RUN(_fgmask.isUMat(), ocl_apply(_image, _fgmask, learningRate))
 
         opencl_ON = false;
-        initialize(_image.size(), _image.type());
+        nframes = 0;
     }
 #endif
+
+    bool needToInitialize = nframes == 0 || learningRate >= 1 || _image.size() != frameSize || _image.type() != frameType;
+
+    if( needToInitialize )
+        initialize(_image.size(), _image.type());
 
     Mat image = _image.getMat();
     _fgmask.create( image.size(), CV_8U );


### PR DESCRIPTION
<!-- Please use this line to close one or multiple issues when this pullrequest gets merged
You can add another line right under the first one:
resolves #1234
resolves #1235
-->

### This pullrequest changes

<!-- Please describe what your pullrequest is changing -->
If OpenCL is enabled but non-UMat parameters are used, it shouldn't initialize twice.