### PR TITLE
PriorBox layer with explicit normalized sizes

### DIFF
--- a/modules/dnn/src/layers/prior_box_layer.cpp
+++ b/modules/dnn/src/layers/prior_box_layer.cpp
@@ -416,6 +416,11 @@ public:
                 {
                     _boxWidth = _widths[0] * _scales[0];
                     _boxHeight = _heights[0] * _scales[0];
+                    if (_bboxesNormalized)
+                    {
+                        _boxWidth *= _imageWidth;
+                        _boxHeight *= _imageHeight;
+                    }
                 }
                 else
                     _boxWidth = _boxHeight = _minSize * _scales[0];
@@ -463,6 +468,11 @@ public:
                 {
                     _boxWidth = _widths[i] * _scales[i];
                     _boxHeight = _heights[i] * _scales[i];
+                    if (_bboxesNormalized)
+                    {
+                        _boxWidth *= _imageWidth;
+                        _boxHeight *= _imageHeight;
+                    }
                     for (int j = 0; j < _offsetsX.size(); ++j)
                     {
                         float center_x = (w + _offsetsX[j]) * stepX;

--- a/modules/dnn/src/tensorflow/tf_importer.cpp
+++ b/modules/dnn/src/tensorflow/tf_importer.cpp
@@ -1411,23 +1411,17 @@ void TFImporter::populateNet(Net dstNet)
                 layerParams.set("clip", getLayerAttr(layer, "clip").b());
             if (hasLayerAttr(layer, "offset"))
                 layerParams.set("offset", getLayerAttr(layer, "offset").f());
-            if (hasLayerAttr(layer, "variance"))
+
+            const std::string paramNames[] = {"variance", "aspect_ratio", "scales",
+                                              "width", "height"};
+            for (int i = 0; i < 5; ++i)
             {
-                Mat variance = getTensorContent(getLayerAttr(layer, "variance").tensor());
-                layerParams.set("variance",
-                                DictValue::arrayReal<float*>((float*)variance.data, variance.total()));
-            }
-            if (hasLayerAttr(layer, "aspect_ratio"))
-            {
-                Mat aspectRatios = getTensorContent(getLayerAttr(layer, "aspect_ratio").tensor());
-                layerParams.set("aspect_ratio",
-                               DictValue::arrayReal<float*>((float*)aspectRatios.data, aspectRatios.total()));
-            }
-            if (hasLayerAttr(layer, "scales"))
-            {
-                Mat scales = getTensorContent(getLayerAttr(layer, "scales").tensor());
-                layerParams.set("scales",
-                               DictValue::arrayReal<float*>((float*)scales.data, scales.total()));
+                if (hasLayerAttr(layer, paramNames[i]))
+                {
+                    Mat values = getTensorContent(getLayerAttr(layer, paramNames[i]).tensor());
+                    layerParams.set(paramNames[i],
+                                    DictValue::arrayReal<float*>((float*)values.data, values.total()));
+                }
             }
             int id = dstNet.addLayer(name, "PriorBox", layerParams);
             layer_id[name] = id;


### PR DESCRIPTION
<!-- Please use this line to close one or multiple issues when this pullrequest gets merged
You can add another line right under the first one:
resolves #1234
resolves #1235
-->

### This pullrequest changes

Allow to specify explicit relative prior boxes' sizes.

related:
http://answers.opencv.org/question/180105/tensorflow-custom-model-in-opencv/
https://github.com/opencv/opencv/issues/10601
https://github.com/opencv/opencv/issues/10431

**Merge with extra**: https://github.com/opencv/opencv_extra/pull/431
