### PR TITLE
Exported a high level stitcher for Scans to the DLL

### DIFF
--- a/modules/stitching/include/opencv2/stitching.hpp
+++ b/modules/stitching/include/opencv2/stitching.hpp
@@ -312,6 +312,7 @@ private:
 };
 
 CV_EXPORTS_W Ptr<Stitcher> createStitcher(bool try_use_gpu = false);
+CV_EXPORTS_W Ptr<Stitcher> createStitcherScans(bool try_use_gpu = false);
 
 //! @} stitching
 

--- a/modules/stitching/src/stitcher.cpp
+++ b/modules/stitching/src/stitcher.cpp
@@ -606,42 +606,13 @@ Ptr<Stitcher> createStitcher(bool try_use_gpu)
 {
     CV_INSTRUMENT_REGION()
 
-    Ptr<Stitcher> stitcher = makePtr<Stitcher>();
-    stitcher->setRegistrationResol(0.6);
-    stitcher->setSeamEstimationResol(0.1);
-    stitcher->setCompositingResol(Stitcher::ORIG_RESOL);
-    stitcher->setPanoConfidenceThresh(1);
-    stitcher->setWaveCorrection(true);
-    stitcher->setWaveCorrectKind(detail::WAVE_CORRECT_HORIZ);
-    stitcher->setFeaturesMatcher(makePtr<detail::BestOf2NearestMatcher>(try_use_gpu));
-    stitcher->setBundleAdjuster(makePtr<detail::BundleAdjusterRay>());
+    return Stitcher::create(Stitcher::PANORAMA, try_use_gpu);
+}
 
-    #ifdef HAVE_OPENCV_CUDALEGACY
-    if (try_use_gpu && cuda::getCudaEnabledDeviceCount() > 0)
-    {
-        #ifdef HAVE_OPENCV_NONFREE
-        stitcher->setFeaturesFinder(makePtr<detail::SurfFeaturesFinderGpu>());
-        #else
-        stitcher->setFeaturesFinder(makePtr<detail::OrbFeaturesFinder>());
-        #endif
-        stitcher->setWarper(makePtr<SphericalWarperGpu>());
-        stitcher->setSeamFinder(makePtr<detail::GraphCutSeamFinderGpu>());
-    }
-    else
-    #endif
-    {
-        #ifdef HAVE_OPENCV_NONFREE
-        stitcher->setFeaturesFinder(makePtr<detail::SurfFeaturesFinder>());
-        #else
-        stitcher->setFeaturesFinder(makePtr<detail::OrbFeaturesFinder>());
-        #endif
-        stitcher->setWarper(makePtr<SphericalWarper>());
-        stitcher->setSeamFinder(makePtr<detail::GraphCutSeamFinder>(detail::GraphCutSeamFinderBase::COST_COLOR));
-    }
+Ptr<Stitcher> createStitcherScans(bool try_use_gpu)
+{
+    CV_INSTRUMENT_REGION()
 
-    stitcher->setExposureCompensator(makePtr<detail::BlocksGainCompensator>());
-    stitcher->setBlender(makePtr<detail::MultiBandBlender>(try_use_gpu));
-
-    return stitcher;
+    return Stitcher::create(Stitcher::SCANS, try_use_gpu);
 }
 } // namespace cv


### PR DESCRIPTION
allows Stitcher to be used for scans from within python.
I had to use very strange notation because I couldn't export the `enum`
`Mode` making the Cpython generated code unable to compile.

```c++
class Stitcher {
public:
enum Mode
    {
        PANORAMA = 0,
        SCANS = 1,
    };
...
```

Also removed duplicate code from the `createStitcher` function making
use of the `Stitcher::create` function

<!-- Please use this line to close one or multiple issues when this pullrequest gets merged
You can add another line right under the first one:
resolves #1234
resolves #1235
-->

### This pullrequest changes

<!-- Please describe what your pullrequest is changing -->
