### PR TITLE
perf reports: remove units from table cells

### DIFF
--- a/modules/ts/misc/chart.py
+++ b/modules/ts/misc/chart.py
@@ -108,7 +108,7 @@ def getTest(stests, x, y, row, col):
 if __name__ == "__main__":
     parser = OptionParser()
     parser.add_option("-o", "--output", dest="format", help="output results in text format (can be 'txt', 'html' or 'auto' - default)", metavar="FMT", default="auto")
-    parser.add_option("-u", "--units", dest="units", help="units for output values (s, ms (default), mks, ns or ticks)", metavar="UNITS", default="ms")
+    parser.add_option("-u", "--units", dest="units", help="units for output values (s, ms (default), us, ns or ticks)", metavar="UNITS", default="ms")
     parser.add_option("-m", "--metric", dest="metric", help="output metric", metavar="NAME", default="gmean")
     parser.add_option("-x", "", dest="x", help="argument number for rows", metavar="ROW", default=1)
     parser.add_option("-y", "", dest="y", help="argument number for columns", metavar="COL", default=0)

--- a/modules/ts/misc/report.py
+++ b/modules/ts/misc/report.py
@@ -7,7 +7,7 @@ from optparse import OptionParser
 if __name__ == "__main__":
     parser = OptionParser()
     parser.add_option("-o", "--output", dest="format", help="output results in text format (can be 'txt', 'html' or 'auto' - default)", metavar="FMT", default="auto")
-    parser.add_option("-u", "--units", dest="units", help="units for output values (s, ms (default), mks, ns or ticks)", metavar="UNITS", default="ms")
+    parser.add_option("-u", "--units", dest="units", help="units for output values (s, ms (default), us, ns or ticks)", metavar="UNITS", default="ms")
     parser.add_option("-c", "--columns", dest="columns", help="comma-separated list of columns to show", metavar="COLS", default="")
     parser.add_option("-f", "--filter", dest="filter", help="regex to filter tests", metavar="REGEX", default=None)
     parser.add_option("", "--show-all", action="store_true", dest="showall", default=False, help="also include empty and \"notrun\" lines")

--- a/modules/ts/misc/table_formatter.py
+++ b/modules/ts/misc/table_formatter.py
@@ -716,7 +716,10 @@ def formatValue(val, metric, units = None):
         if val > 0:
             return "slower"
         #return "%.4f" % val
-    return "%.3f %s" % (val, units)
+    if units:
+        return "%.3f %s" % (val, units)
+    else:
+        return "%.3f" % val
 
 if __name__ == "__main__":
     if len(sys.argv) < 2:
@@ -726,7 +729,7 @@ if __name__ == "__main__":
     parser = OptionParser()
     parser.add_option("-o", "--output", dest="format", help="output results in text format (can be 'txt', 'html', 'markdown' or 'auto' - default)", metavar="FMT", default="auto")
     parser.add_option("-m", "--metric", dest="metric", help="output metric", metavar="NAME", default="gmean")
-    parser.add_option("-u", "--units", dest="units", help="units for output values (s, ms (default), mks, ns or ticks)", metavar="UNITS", default="ms")
+    parser.add_option("-u", "--units", dest="units", help="units for output values (s, ms (default), us, ns or ticks)", metavar="UNITS", default="ms")
     (options, args) = parser.parse_args()
 
     options.generateHtml = detectHtmlOutputType(options.format)

--- a/modules/ts/misc/testlog_parser.py
+++ b/modules/ts/misc/testlog_parser.py
@@ -96,7 +96,7 @@ class TestInfo(object):
             frequency = self.metrix.get("frequency", 1.0) or 1.0
             if units == "ms":
                 scale = 1000.0
-            if units == "mks":
+            if units == "us" or units == "mks":  # mks is typo error for microsecond (<= OpenCV 3.4)
                 scale = 1000000.0
             if units == "ns":
                 scale = 1000000000.0


### PR DESCRIPTION
- moved to table title
- can be restored via '--show_units' option
- fix microseconds: mks -> us