### PR TITLE
Fix cv::CommandLineParser::check() documentation

### DIFF
--- a/modules/core/include/opencv2/core/utility.hpp
+++ b/modules/core/include/opencv2/core/utility.hpp
@@ -909,7 +909,7 @@ public:
 
     /** @brief Check for parsing errors
 
-    Returns true if error occurred while accessing the parameters (bad conversion, missing arguments,
+    Returns false if error occurred while accessing the parameters (bad conversion, missing arguments,
     etc.). Call @ref printErrors to print error messages list.
      */
     bool check() const;


### PR DESCRIPTION
### This pullrequest changes

Fix this small error, it's even pointed out in the docs that one should use 

```cpp
if (!parser.check())
{
    parser.printErrors();
    return 0;
}
```
But the docs says check returns true on error so I fixed it.
Had a hard time finding why my parser was always throwing errors.
