### PR TITLE
cuda_stream: do not allocate GPU memory by default (fixes #8725)

### DIFF
--- a/modules/core/src/cuda_stream.cpp
+++ b/modules/core/src/cuda_stream.cpp
@@ -552,7 +552,7 @@ Stream cv::cuda::StreamAccessor::wrapStream(cudaStream_t stream)
 
 namespace
 {
-    bool enableMemoryPool = true;
+    bool enableMemoryPool = false;
 
     class StackAllocator : public GpuMat::Allocator
     {


### PR DESCRIPTION
Current implementation allocates some GPU memory when a `Stream` object is defined for the first time for a GPU device. The amount of memory allocated is 10MB times the number of GPU devices by default. The allocated amount can be configured beforehand via `setBufferPoolConfig`.

Usage of this allocated memory is described at OpenCV doc for `BufferPool`, which says:
> `BufferPool` utilizes `cuda::Stream`'s allocator to create new buffers. It is particularly useful when BufferPoolUsage is set to true, or a custom allocator is specified for the `cuda::Stream`, and you want to implement your own stream based functions utilizing the same underlying GPU memory management.

IMHO, however, users won't expect some additional memories to be allocated when they just use `Stream` objects for asynchronous API calls.

Also, deallocation of this memory is carried out by the destructor of a global object `DefaultDeviceInitializer`. Since it is global, the destructor might be called after CUDA context is destroyed. In such cases, issues like #8725 may arise.

```
force_builders=Custom
docker_image:Custom=ubuntu-cuda:16.04
```