### PR TITLE
build: eliminate calls of removed functionality from C++17

### DIFF
--- a/modules/calib3d/test/test_affine3d_estimator.cpp
+++ b/modules/calib3d/test/test_affine3d_estimator.cpp
@@ -138,8 +138,13 @@ bool CV_Affine3D_EstTest::testNPoints()
     std::transform(fpts.ptr<Point3f>(), fpts.ptr<Point3f>() + n, tpts.ptr<Point3f>(), WrapAff(aff));
 
     /* adding noise*/
+#ifdef CV_CXX11
+    std::transform(tpts.ptr<Point3f>() + m, tpts.ptr<Point3f>() + n, tpts.ptr<Point3f>() + m,
+        [=] (const Point3f& pt) -> Point3f { return Noise(noise_level)(pt + shift_outl); });
+#else
     std::transform(tpts.ptr<Point3f>() + m, tpts.ptr<Point3f>() + n, tpts.ptr<Point3f>() + m, std::bind2nd(std::plus<Point3f>(), shift_outl));
     std::transform(tpts.ptr<Point3f>() + m, tpts.ptr<Point3f>() + n, tpts.ptr<Point3f>() + m, Noise(noise_level));
+#endif
 
     Mat aff_est;
     vector<uchar> outl;

--- a/modules/core/include/opencv2/core/cuda/functional.hpp
+++ b/modules/core/include/opencv2/core/cuda/functional.hpp
@@ -58,8 +58,22 @@
 namespace cv { namespace cuda { namespace device
 {
     // Function Objects
+#ifdef CV_CXX11
+    template<typename Argument, typename Result> struct unary_function
+    {
+        typedef Argument argument_type;
+        typedef Result result_type;
+    };
+    template<typename Argument1, typename Argument2, typename Result> struct binary_function
+    {
+        typedef Argument1 first_argument_type;
+        typedef Argument2 second_argument_type;
+        typedef Result result_type;
+    };
+#else
     template<typename Argument, typename Result> struct unary_function : public std::unary_function<Argument, Result> {};
     template<typename Argument1, typename Argument2, typename Result> struct binary_function : public std::binary_function<Argument1, Argument2, Result> {};
+#endif
 
     // Arithmetic Operations
     template <typename T> struct plus : binary_function<T, T, T>

--- a/modules/cudafeatures2d/src/brute_force_matcher.cpp
+++ b/modules/cudafeatures2d/src/brute_force_matcher.cpp
@@ -564,7 +564,12 @@ namespace
 
             if (compactResult)
             {
+#ifdef CV_CXX11
+                std::vector< std::vector<DMatch> >::iterator new_end = std::remove_if(matches.begin(), matches.end(),
+                    [](const std::vector<DMatch>& e)->bool { return e.empty(); });
+#else
                 std::vector< std::vector<DMatch> >::iterator new_end = std::remove_if(matches.begin(), matches.end(), std::mem_fun_ref(&std::vector<DMatch>::empty));
+#endif
                 matches.erase(new_end, matches.end());
             }
         }

--- a/modules/imgproc/src/featureselect.cpp
+++ b/modules/imgproc/src/featureselect.cpp
@@ -52,8 +52,11 @@
 namespace cv
 {
 
-struct greaterThanPtr :
-        public std::binary_function<const float *, const float *, bool>
+#ifdef CV_CXX11
+struct greaterThanPtr
+#else
+struct greaterThanPtr : public std::binary_function<const float *, const float *, bool>
+#endif
 {
     bool operator () (const float * a, const float * b) const
     // Ensure a fully deterministic result of the sort

--- a/modules/imgproc/src/generalized_hough.cpp
+++ b/modules/imgproc/src/generalized_hough.cpp
@@ -385,7 +385,11 @@ namespace
         const double thetaScale = levels_ / 360.0;
 
         r_table_.resize(levels_ + 1);
+#ifdef CV_CXX11
+        std::for_each(r_table_.begin(), r_table_.end(), [](std::vector<Point>& e)->void { e.clear(); });
+#else
         std::for_each(r_table_.begin(), r_table_.end(), std::mem_fun_ref(&std::vector<Point>::clear));
+#endif
 
         for (int y = 0; y < templSize_.height; ++y)
         {
@@ -692,8 +696,12 @@ namespace
         getContourPoints(edges, dx, dy, points);
 
         features.resize(levels_ + 1);
+#ifdef CV_CXX11
+        std::for_each(features.begin(), features.end(), [=](std::vector<Feature>& e) { e.clear(); e.reserve(maxBufferSize_); });
+#else
         std::for_each(features.begin(), features.end(), std::mem_fun_ref(&std::vector<Feature>::clear));
         std::for_each(features.begin(), features.end(), std::bind2nd(std::mem_fun_ref(&std::vector<Feature>::reserve), maxBufferSize_));
+#endif
 
         for (size_t i = 0; i < points.size(); ++i)
         {

--- a/modules/imgproc/test/test_goodfeaturetotrack.cpp
+++ b/modules/imgproc/test/test_goodfeaturetotrack.cpp
@@ -56,8 +56,11 @@ enum { MINEIGENVAL=0, HARRIS=1, EIGENVALSVECS=2 };
 
 /////////////////////ref//////////////////////
 
-struct greaterThanPtr :
-        public std::binary_function<const float *, const float *, bool>
+#ifdef CV_CXX11
+struct greaterThanPtr
+#else
+struct greaterThanPtr : public std::binary_function<const float *, const float *, bool>
+#endif
 {
     bool operator () (const float * a, const float * b) const
     { return *a > *b; }

--- a/modules/objdetect/perf/opencl/perf_hogdetect.cpp
+++ b/modules/objdetect/perf/opencl/perf_hogdetect.cpp
@@ -53,8 +53,11 @@ namespace opencv_test {
 namespace ocl {
 ///////////// HOG////////////////////////
 
-struct RectLess :
-        public std::binary_function<cv::Rect, cv::Rect, bool>
+#ifdef CV_CXX11
+struct RectLess
+#else
+struct RectLess : public std::binary_function<cv::Rect, cv::Rect, bool>
+#endif
 {
     bool operator()(const cv::Rect& a,
         const cv::Rect& b) const

--- a/modules/shape/test/test_shape.cpp
+++ b/modules/shape/test/test_shape.cpp
@@ -105,7 +105,7 @@ protected:
         }
 
         // Uniformly sampling
-        random_shuffle(contoursQuery.begin(), contoursQuery.end());
+        cv::randShuffle(contoursQuery);
         int nStart=NP;
         vector<PointType> cont;
         for (int i=0; i<nStart; i++)

--- a/modules/ts/include/opencv2/ts/ts_perf.hpp
+++ b/modules/ts/include/opencv2/ts/ts_perf.hpp
@@ -707,8 +707,11 @@ namespace comparators
 {
 
 template<typename T>
-struct RectLess_ :
-        public std::binary_function<cv::Rect_<T>, cv::Rect_<T>, bool>
+#ifdef CV_CXX11
+struct RectLess_
+#else
+struct RectLess_ : public std::binary_function<cv::Rect_<T>, cv::Rect_<T>, bool>
+#endif
 {
   bool operator()(const cv::Rect_<T>& r1, const cv::Rect_<T>& r2) const
   {
@@ -721,8 +724,11 @@ struct RectLess_ :
 
 typedef RectLess_<int> RectLess;
 
-struct KeypointGreater :
-        public std::binary_function<cv::KeyPoint, cv::KeyPoint, bool>
+#ifdef CV_CXX11
+struct KeypointGreater
+#else
+struct KeypointGreater : public std::binary_function<cv::KeyPoint, cv::KeyPoint, bool>
+#endif
 {
     bool operator()(const cv::KeyPoint& kp1, const cv::KeyPoint& kp2) const
     {

--- a/modules/ts/src/cuda_test.cpp
+++ b/modules/ts/src/cuda_test.cpp
@@ -462,7 +462,11 @@ namespace cvtest
             return false;
         }
 
+#ifdef CV_CXX11
+        struct KeyPointLess
+#else
         struct KeyPointLess : std::binary_function<cv::KeyPoint, cv::KeyPoint, bool>
+#endif
         {
             bool operator()(const cv::KeyPoint& kp1, const cv::KeyPoint& kp2) const
             {

--- a/samples/cpp/shape_example.cpp
+++ b/samples/cpp/shape_example.cpp
@@ -43,7 +43,7 @@ static vector<Point> simpleContour( const Mat& currentQuery, int n=300 )
     }
 
     // Uniformly sampling
-    random_shuffle(contoursQuery.begin(), contoursQuery.end());
+    cv::randShuffle(contoursQuery);
     vector<Point> cont;
     for (int i=0; i<n; i++)
     {


### PR DESCRIPTION
Most part is deprecated since C++11

OpenEXR builtin sources are still unfixed. Need to disable them: `WITH_OPENEXR=OFF`.

MSVS flag: `/std:c++17`
GCC flag: `-std=c++17`
