### PR TITLE
Remove setBatchNorm and setScale methods

### DIFF
--- a/modules/dnn/include/opencv2/dnn/all_layers.hpp
+++ b/modules/dnn/include/opencv2/dnn/all_layers.hpp
@@ -472,7 +472,6 @@ CV__DNN_EXPERIMENTAL_NS_BEGIN
         bool hasWeights, hasBias;
         float epsilon;
 
-        virtual void getScaleShift(Mat& scale, Mat& shift) const = 0;
         static Ptr<BatchNormLayer> create(const LayerParams &params);
     };
 

--- a/modules/dnn/include/opencv2/dnn/dnn.hpp
+++ b/modules/dnn/include/opencv2/dnn/dnn.hpp
@@ -281,20 +281,26 @@ CV__DNN_EXPERIMENTAL_NS_BEGIN
         virtual bool setActivation(const Ptr<ActivationLayer>& layer);
 
         /**
-         * @brief Tries to attach to the layer the subsequent batch normalization layer, i.e. do the layer fusion in a partial case.
-         * @param[in] layer The subsequent batch normalization layer.
-         *
-         * Returns true if the batch normalization layer has been attached successfully.
+         * @brief Try to fuse current layer with a next one
+         * @param[in] top Next layer to be fused.
+         * @returns True if fusion was performed.
          */
-        virtual bool setBatchNorm(const Ptr<BatchNormLayer>& layer);
+        virtual bool tryFuse(Ptr<Layer>& top);
 
         /**
-         * @brief Tries to attach to the layer the subsequent scaling layer, i.e. do the layer fusion in a partial case.
-         * @param[in] layer The subsequent scaling layer.
+         * @brief Returns parameters of layers with channel-wise multiplication and addition.
+         * @param[out] scale Channel-wise multipliers. Total number of values should
+         *                   be equal to number of channels.
+         * @param[out] shift Channel-wise offsets. Total number of values should
+         *                   be equal to number of channels.
          *
-         * Returns true if the scaling layer has been attached successfully.
+         * Some layers can fuse their transformations with further layers.
+         * In example, convolution + batch normalization. This way base layer
+         * use weights from layer after it. Fused layer is skipped.
+         * By default, @p scale and @p shift are empty that means layer has no
+         * element-wise multiplications or additions.
          */
-        virtual bool setScale(const Ptr<ScaleLayer>& layer);
+        virtual void getScaleShift(Mat& scale, Mat& shift) const;
 
         /**
          * @brief "Deattaches" all the layers, attached to particular layer.

--- a/modules/dnn/src/layers/mvn_layer.cpp
+++ b/modules/dnn/src/layers/mvn_layer.cpp
@@ -65,16 +65,18 @@ public:
         relu_slope = 0.f;
     }
 
-    Ptr<BatchNormLayer> bnorm;
     Mat scale, shift;
-    UMat bnorm_weight, bnorm_bias;
     bool fuse_batch_norm;
 
-    bool setBatchNorm(const Ptr<BatchNormLayer>& layer )
+    virtual bool tryFuse(Ptr<Layer>& top)
     {
-        bnorm = layer;
-        fuse_batch_norm = !bnorm.empty() && (preferableTarget == DNN_TARGET_OPENCL);
-        return fuse_batch_norm;
+        if (preferableTarget == DNN_TARGET_OPENCL && !fuse_batch_norm)
+        {
+            top->getScaleShift(scale, shift);
+            fuse_batch_norm = !scale.empty() || !shift.empty();
+            return fuse_batch_norm;
+        }
+        return false;
     }
 
     Ptr<ReLULayer> activ_relu;
@@ -95,12 +97,8 @@ public:
 #ifdef HAVE_OPENCL
     bool fast_forward_ocl(std::vector<UMat> &inputs, std::vector<UMat> &outputs)
     {
-        if( fuse_batch_norm && scale.empty())
-        {
-            bnorm->getScaleShift(scale, shift);
-            bnorm_weight = scale.getUMat(ACCESS_READ);
-            bnorm_bias = shift.getUMat(ACCESS_READ);
-        }
+        UMat bnorm_weight = scale.empty() ? UMat() : scale.getUMat(ACCESS_READ);
+        UMat bnorm_bias = shift.empty() ? UMat() : shift.getUMat(ACCESS_READ);
 
         int splitDim = (acrossChannels) ? 1 : 2;
         for (size_t inpIdx = 0; inpIdx < inputs.size(); inpIdx++)
@@ -171,12 +169,8 @@ public:
             return ret;
         }
 
-        if( fuse_batch_norm && scale.empty())
-        {
-            bnorm->getScaleShift(scale, shift);
-            bnorm_weight = scale.getUMat(ACCESS_READ);
-            bnorm_bias = shift.getUMat(ACCESS_READ);
-        }
+        UMat bnorm_weight = scale.empty() ? UMat() : scale.getUMat(ACCESS_READ);
+        UMat bnorm_bias = shift.empty() ? UMat() : shift.getUMat(ACCESS_READ);
 
         for (size_t inpIdx = 0; inpIdx < inputs.size(); inpIdx++)
         {

--- a/modules/dnn/src/layers/scale_layer.cpp
+++ b/modules/dnn/src/layers/scale_layer.cpp
@@ -201,6 +201,12 @@ public:
         return Ptr<BackendNode>();
     }
 
+    void getScaleShift(Mat& scale, Mat& shift) const
+    {
+        scale = !blobs.empty() ? blobs[0] : Mat();
+        shift = hasBias ? blobs[1] : Mat();
+    }
+
     virtual int64 getFLOPS(const std::vector<MatShape> &inputs,
                            const std::vector<MatShape> &outputs) const
     {

--- a/modules/dnn/src/layers/shift_layer.cpp
+++ b/modules/dnn/src/layers/shift_layer.cpp
@@ -136,6 +136,12 @@ public:
         return Ptr<BackendNode>();
     }
 
+    void getScaleShift(Mat& scale, Mat& shift) const
+    {
+        scale = Mat();
+        shift = blobs[0];
+    }
+
     virtual int64 getFLOPS(const std::vector<MatShape> &inputs,
                            const std::vector<MatShape> &outputs) const
     {


### PR DESCRIPTION
<!-- Please use this line to close one or multiple issues when this pullrequest gets merged
You can add another line right under the first one:
resolves #1234
resolves #1235
-->

### This pullrequest changes

Refactored element-wise layers fusion that gives unlimited number of linear fusions.

| Name of Test|  master | refactored fusion | refactored fusion vs master (x-factor) |
|---:|---:|---:|---:|                                                                       
| AlexNet::DNNTestNetwork::(DNN_BACKEND_DEFAULT, DNN_TARGET_CPU)                                | 14.186  |   14.113    |  1.01   |
| AlexNet::DNNTestNetwork::(DNN_BACKEND_DEFAULT, DNN_TARGET_OPENCL)                             | 15.501  |   15.453    |  1.00   |
| DenseNet_121::DNNTestNetwork::(DNN_BACKEND_DEFAULT, DNN_TARGET_CPU)                           | 59.458  |   60.472    |  0.98   |
| DenseNet_121::DNNTestNetwork::(DNN_BACKEND_DEFAULT, DNN_TARGET_OPENCL)                        | 67.110  |   67.068    |  1.00   |
| ENet::DNNTestNetwork::(DNN_BACKEND_DEFAULT, DNN_TARGET_CPU)                                   | 44.348  |   44.319    |  1.00   |
| ENet::DNNTestNetwork::(DNN_BACKEND_DEFAULT, DNN_TARGET_OPENCL)                                | 27.510  |   27.586    |  1.00   |
| GoogLeNet::DNNTestNetwork::(DNN_BACKEND_DEFAULT, DNN_TARGET_CPU)                              | 14.560  |   14.574    |  1.00   |
| GoogLeNet::DNNTestNetwork::(DNN_BACKEND_DEFAULT, DNN_TARGET_OPENCL)                           | 19.296  |   19.841    |  0.97   |
| Inception_5h::DNNTestNetwork::(DNN_BACKEND_DEFAULT, DNN_TARGET_CPU)                           | 15.986  |   16.006    |  1.00   |
| Inception_5h::DNNTestNetwork::(DNN_BACKEND_DEFAULT, DNN_TARGET_OPENCL)                        | 21.390  |   21.504    |  0.99   |
| **MobileNet_SSD_2017_11_17_TensorFlow::DNNTestNetwork::(DNN_BACKEND_DEFAULT, DNN_TARGET_CPU)**    | **33.132**  |   **23.191**    |  **1.43**   |
| MobileNet_SSD_Caffe::DNNTestNetwork::(DNN_BACKEND_DEFAULT, DNN_TARGET_CPU)                    | 19.790  |   19.943    |  0.99   |
| MobileNet_SSD_Caffe::DNNTestNetwork::(DNN_BACKEND_DEFAULT, DNN_TARGET_OPENCL)                 | 18.799  |   18.775    |  1.00   |
| MobileNet_SSD_TensorFlow::DNNTestNetwork::(DNN_BACKEND_DEFAULT, DNN_TARGET_CPU)               | 23.200  |   23.370    |  0.99   |
| OpenFace::DNNTestNetwork::(DNN_BACKEND_DEFAULT, DNN_TARGET_CPU)                               |  3.896  |   3.863     |  1.01   |
| OpenFace::DNNTestNetwork::(DNN_BACKEND_DEFAULT, DNN_TARGET_OPENCL)                            |  9.584  |   9.591     |  1.00   |
| ResNet_50::DNNTestNetwork::(DNN_BACKEND_DEFAULT, DNN_TARGET_CPU)                              | 35.800  |   35.771    |  1.00   |
| ResNet_50::DNNTestNetwork::(DNN_BACKEND_DEFAULT, DNN_TARGET_OPENCL)                           | 36.491  |   36.278    |  1.01   |
| SSD::DNNTestNetwork::(DNN_BACKEND_DEFAULT, DNN_TARGET_CPU)                                    | 269.793  | 262.681    |  1.03   |
| SSD::DNNTestNetwork::(DNN_BACKEND_DEFAULT, DNN_TARGET_OPENCL)                                 | 390.969  | 387.736    |  1.01   |
| SqueezeNet_v1_1::DNNTestNetwork::(DNN_BACKEND_DEFAULT, DNN_TARGET_CPU)                        |  3.752  |   3.741     |  1.00   |
| SqueezeNet_v1_1::DNNTestNetwork::(DNN_BACKEND_DEFAULT, DNN_TARGET_OPENCL)                     |  5.968  |   5.943     |  1.00   |
| opencv_face_detector::DNNTestNetwork::(DNN_BACKEND_DEFAULT, DNN_TARGET_CPU)                   | 14.975  |   14.973    |  1.00   |

