### PR TITLE
OCL: disable Laplacian5 and sepFilter2D_SinglePass kernels for AMD OpenCL

### DIFF
--- a/modules/imgproc/src/deriv.cpp
+++ b/modules/imgproc/src/deriv.cpp
@@ -558,6 +558,7 @@ static bool ocl_Laplacian5(InputArray _src, OutputArray _dst,
         ) &&
         (tileSizeX * tileSizeYmin <= wgs) &&
         (LAPLACIAN_LOCAL_MEM(tileSizeX, tileSizeYmin, kernelX.cols, loc_mem_cn * 4) <= lmsz)
+        && OCL_PERFORMANCE_CHECK(!dev.isAMD())  // TODO FIXIT 2018: Problem with AMDGPU on Linux (2482.3)
        )
     {
         Size size = _src.size(), wholeSize;

--- a/modules/imgproc/src/filter.cpp
+++ b/modules/imgproc/src/filter.cpp
@@ -4391,7 +4391,7 @@ bool ocl_sepFilter2D( InputArray _src, OutputArray _dst, int ddepth,
                 imgSize.height > optimizedSepFilterLocalHeight + anchor.y &&
                 (!(borderType & BORDER_ISOLATED) || _src.offset() == 0) &&
                 anchor == Point(kernelX.cols >> 1, kernelY.cols >> 1) &&
-                (d.isIntel() || (d.isAMD() && !d.hostUnifiedMemory())),
+                OCL_PERFORMANCE_CHECK(d.isIntel()),  // TODO FIXIT
                 ocl_sepFilter2D_SinglePass(_src, _dst, kernelX, kernelY, delta,
                                            borderType & ~BORDER_ISOLATED, ddepth, bdepth, int_arithm), true)
 


### PR DESCRIPTION
[Failed tests](http://pullrequest.opencv.org/buildbot/builders/master-skx-lin64/builds/24)
[Validation build](http://pullrequest.opencv.org/buildbot/builders/master-skx-lin64/builds/34)