### PR TITLE
Fix for CUDA_Arithm/Dft.Algorithm/0 test

### DIFF
--- a/modules/cudaarithm/test/test_arithm.cpp
+++ b/modules/cudaarithm/test/test_arithm.cpp
@@ -253,7 +253,7 @@ CUDA_TEST_P(Dft, Algorithm)
     int cols = randomInt(2, 100);
     int rows = randomInt(2, 100);
 
-    int flags = 0;
+    int flags = 0 | DFT_COMPLEX_INPUT;
     cv::Ptr<cv::cuda::DFT> dft = cv::cuda::createDFT(cv::Size(cols, rows), flags);
 
     for (int i = 0; i < 5; ++i)


### PR DESCRIPTION
The previously failed test CUDA_Arithm/Dft.Algorithm/0 had an issue with setting flags for the DFT algorithm. After this fix, the test passes. This fix reduces the number of failed tests from 11 to 10.

Tested on GTX1080, Driver version 376.51.