### PR TITLE
try to detect PythonLibs every time CMake is executed if it is not found yet

### DIFF
--- a/cmake/OpenCVDetectPython.cmake
+++ b/cmake/OpenCVDetectPython.cmake
@@ -26,7 +26,7 @@ function(find_python preferred_version min_version library_env include_dir_env
          libs_found libs_version_string libraries library debug_libraries
          debug_library include_path include_dir include_dir2 packages_path
          numpy_include_dirs numpy_version)
-if(NOT ${found})
+if(NOT ${found} OR NOT ${libs_found})
   ocv_check_environment_variables(${executable})
   if(${executable})
     set(PYTHON_EXECUTABLE "${${executable}}")


### PR DESCRIPTION
When the python interpreter is found but the libraries are not, reconfiguring CMake will not search for them again, since PYTHONINTERP_FOUND is already true.

### This pullrequest changes

Also checking whether the libraries were found enables users to correct the cause for CMake not finding the libraries and reconfigure without having to delete or modify CMakeCache.txt by hand.
