### PR TITLE
Use only absolute prior boxes explicit sizes. Remove scales attributes.

### DIFF
--- a/samples/dnn/tf_text_graph_ssd.py
+++ b/samples/dnn/tf_text_graph_ssd.py
@@ -26,6 +26,8 @@ parser.add_argument('--max_scale', default=0.95, type=float, help='Hyper-paramet
 parser.add_argument('--num_layers', default=6, type=int, help='Hyper-parameter of ssd_anchor_generator from config file.')
 parser.add_argument('--aspect_ratios', default=[1.0, 2.0, 0.5, 3.0, 0.333], type=float, nargs='+',
                     help='Hyper-parameter of ssd_anchor_generator from config file.')
+parser.add_argument('--image_width', default=300, type=int, help='Training images width.')
+parser.add_argument('--image_height', default=300, type=int, help='Training images height.')
 args = parser.parse_args()
 
 # Nodes that should be kept.
@@ -192,7 +194,6 @@ for i in range(args.num_layers):
 
     text_format.Merge('b: false', priorBox.attr["flip"])
     text_format.Merge('b: false', priorBox.attr["clip"])
-    text_format.Merge('b: true', priorBox.attr["normalized_bbox"])
 
     if i == 0:
         widths = [args.min_scale * 0.5, args.min_scale * sqrt(2.0), args.min_scale * sqrt(0.5)]
@@ -203,6 +204,8 @@ for i in range(args.num_layers):
 
         widths += [sqrt(scales[i] * scales[i + 1])]
         heights += [sqrt(scales[i] * scales[i + 1])]
+    widths = [w * args.image_width for w in widths]
+    heights = [h * args.image_height for h in heights]
     text_format.Merge(tensorMsg(widths), priorBox.attr["width"])
     text_format.Merge(tensorMsg(heights), priorBox.attr["height"])
     text_format.Merge(tensorMsg([0.1, 0.1, 0.2, 0.2]), priorBox.attr["variance"])


### PR DESCRIPTION
<!-- Please use this line to close one or multiple issues when this pullrequest gets merged
You can add another line right under the first one:
resolves #1234
resolves #1235
-->

### This pullrequest changes

**Merge with extra**: https://github.com/opencv/opencv_extra/pull/441

Experimented with PriorBox layer. Original SSD model generates proposals using bounding boxes sizes in pixels. Then normalize them by input image size.

Before PR, we put relative bounding boxes' sizes to proposals generator thinking that it helps with different input sizes (only TensorFlow models). In example, both relative and absolute proposals give the same results for 300x300 images:

* 300x300 input image, relative proposals sizes
```yaml
  attr {
    key: "width"
    value {
      tensor {
        dtype: DT_FLOAT
        tensor_shape {
          dim {
            size: 3
          }
        }
        float_val: 0.1
        float_val: 0.282843
        float_val: 0.141421
      }
    }
  }
```
<img src="https://user-images.githubusercontent.com/25801568/36257009-5772c1ee-1266-11e8-8b2e-4600545f9b14.png" width="512">

* 300x300 input image, absolute proposals sizes
```yaml
  attr {
    key: "width"
    value {
      tensor {
        dtype: DT_FLOAT
        tensor_shape {
          dim {
            size: 3
          }
        }
        float_val: 30.0
        float_val: 84.8528137207
        float_val: 42.4264068604
      }
    }
  }
```
<img src="https://user-images.githubusercontent.com/25801568/36257006-5721db26-1266-11e8-86ec-a16b574e4a07.png" width="512">

However we need to keep that sizes for any input dimensions:

* 512x512 input image, relative proposals sizes
<img src="https://user-images.githubusercontent.com/25801568/36257010-579c5bbc-1266-11e8-840d-df851195c03b.png" width="512">

This PR reverts changer from https://github.com/opencv/opencv/pull/10676 and use only absolute explicit widths and heights:

* 512x512 input image, absolute proposals sizes
<img src="https://user-images.githubusercontent.com/25801568/36257007-574ab280-1266-11e8-8c6a-275dd506e7fc.png" width="512">

Also removed `scales` attribute of prior box layer.