### PR TITLE
core: remove '-' from separators list of disabled CPU flags

### DIFF
--- a/modules/core/src/system.cpp
+++ b/modules/core/src/system.cpp
@@ -514,7 +514,7 @@ struct HWFeatures
 
     static inline bool isSymbolSeparator(char c)
     {
-        return c == ',' || c == ';' || c == '-';
+        return c == ',' || c == ';';
     }
 
     void readSettings(const int* baseline_features, int baseline_count)


### PR DESCRIPTION
To allow runtime disabling of AVX512-SKX via 'OPENCV_CPU_DISABLE' parameter

```
docker_image:Linux x64 Debug=gstreamer:16.04
```