### PR TITLE
videoio: read in gray scale mode when writing a gray scale video

### DIFF
--- a/modules/videoio/perf/perf_output.cpp
+++ b/modules/videoio/perf/perf_output.cpp
@@ -28,7 +28,7 @@ PERF_TEST_P(VideoWriter_Writing, WriteFrame,
 {
   const string filename = getDataPath(get<0>(GetParam()));
   const bool isColor = get<1>(GetParam());
-  Mat image = imread(filename, 1);
+  Mat image = imread(filename, isColor ? IMREAD_COLOR : IMREAD_GRAYSCALE );
 #if defined(HAVE_MSMF) && !defined(HAVE_VFW) && !defined(HAVE_FFMPEG) // VFW has greater priority
   const string outfile = cv::tempfile(".wmv");
   const int fourcc = VideoWriter::fourcc('W', 'M', 'V', '3');


### PR DESCRIPTION
resolves #10899 

```
docker_image:Linux x64 Debug=gstreamer:16.04
```