### PR TITLE
(2.4 backport #10912) imgcodecs: fix RBaseStream hang on truncated inputs

### DIFF
--- a/modules/highgui/src/bitstrm.cpp
+++ b/modules/highgui/src/bitstrm.cpp
@@ -104,7 +104,6 @@ void  RBaseStream::readBlock()
     fseek( m_file, m_block_pos, SEEK_SET );
     size_t readed = fread( m_start, 1, m_block_size, m_file );
     m_end = m_start + readed;
-    m_current = m_start;
 
     if( readed == 0 || m_current >= m_end )
         throw RBS_THROW_EOS;


### PR DESCRIPTION
Backport #10912

<!--
buildworker:Linux x64=linux-1
-->