### PR TITLE
Fixed dynamic build script for iOS

### DIFF
--- a/platforms/ios/Info.Dynamic.plist.in
+++ b/platforms/ios/Info.Dynamic.plist.in
@@ -24,5 +24,10 @@
     </array>
     <key>MinimumOSVersion</key>
     <string>8.0</string>
+    <key>UIDeviceFamily</key>
+    <array>
+        <integer>1</integer>
+        <integer>2</integer>
+    </array>
 </dict>
 </plist>

--- a/platforms/ios/build_framework.py
+++ b/platforms/ios/build_framework.py
@@ -150,6 +150,7 @@ class Builder:
             buildcmd += [
                 "IPHONEOS_DEPLOYMENT_TARGET=8.0",
                 "ONLY_ACTIVE_ARCH=NO",
+                "BITCODE_GENERATION_MODE=bitcode"
             ]
 
             for arch in archs:

--- a/platforms/ios/build_framework.py
+++ b/platforms/ios/build_framework.py
@@ -149,9 +149,11 @@ class Builder:
         if self.dynamic:
             buildcmd += [
                 "IPHONEOS_DEPLOYMENT_TARGET=8.0",
-                "ONLY_ACTIVE_ARCH=NO",
-                "BITCODE_GENERATION_MODE=bitcode"
+                "ONLY_ACTIVE_ARCH=NO"
             ]
+
+            if self.bitcodedisabled == False:
+                buildcmd.append("BITCODE_GENERATION_MODE=bitcode")
 
             for arch in archs:
                 buildcmd.append("-arch")

--- a/platforms/ios/build_framework.py
+++ b/platforms/ios/build_framework.py
@@ -149,10 +149,10 @@ class Builder:
         if self.dynamic:
             buildcmd += [
                 "IPHONEOS_DEPLOYMENT_TARGET=8.0",
-                "ONLY_ACTIVE_ARCH=NO"
+                "ONLY_ACTIVE_ARCH=NO",
             ]
 
-            if self.bitcodedisabled == False:
+            if not self.bitcodedisabled:
                 buildcmd.append("BITCODE_GENERATION_MODE=bitcode")
 
             for arch in archs:


### PR DESCRIPTION
### Used environment
```
cmake version 3.10.2
opencv HEAD (5caf624), 3.3.0 and 3.4.0
```

### Encountered problems

1. App could not be uploaded via ItunesConnect as `UIDeviceFamily` was missing in the dynamic framework of opencv:

As described in #8009, there was a warning:

> warning: User supplied UIDeviceFamily key in the Info.plist will be overwritten. Please use the build setting TARGETED_DEVICE_FAMILY and remove UIDeviceFamily from your Info.plist.

Nonetheless, in the final `Info.plist` the entries regarding `UIDeviceFamily` were missing. Was reproducible on every Mac we tested that on.

2. The dynamic framework was built without bitcode being enabled:

It seems that at the current point of time we need to use `BITCODE_GENERATION_MODE=bitcode`. The only resource I found is https://stackoverflow.com/a/34965178. Sadly, no official documentation by Apple.

### This pullrequest changes

1. Readded UIDeviceFamily (was removed in beec247).
2. Added `BITCODE_GENERATION_MODE=bitcode` flag.
