### PR TITLE
CPU dispatching: additional AVX-512 check for mingw-w64

### DIFF
--- a/cmake/checks/cpu_avx512.cpp
+++ b/cmake/checks/cpu_avx512.cpp
@@ -3,6 +3,9 @@
 void test()
 {
     __m512i zmm = _mm512_setzero_si512();
+#if defined __GNUC__ && defined __x86_64__
+    asm volatile ("" : : : "zmm16", "zmm17", "zmm18", "zmm19");
+#endif
 }
 #else
 #error "AVX512 is not supported"

--- a/cmake/checks/cpu_avx512skx.cpp
+++ b/cmake/checks/cpu_avx512skx.cpp
@@ -7,6 +7,9 @@ void test()
     __m256i b = _mm256_abs_epi64(a); // VL
     __m512i c = _mm512_abs_epi8(zmm); // BW
     __m512i d = _mm512_broadcast_i32x8(b); // DQ
+#if defined __GNUC__ && defined __x86_64__
+    asm volatile ("" : : : "zmm16", "zmm17", "zmm18", "zmm19");
+#endif
 }
 #else
 #error "AVX512-SKX is not supported"


### PR DESCRIPTION
### This pullrequest changes

Problem:
```
[ 58%] Building CXX object modules/dnn/CMakeFiles/opencv_dnn.dir/layers/layers_common.avx512_skx.cpp.obj
%USERPROFILE%\AppData\Local\Temp\ccBSUeSO.s: Assembler messages:
%USERPROFILE%\AppData\Local\Temp\ccBSUeSO.s:21573: Error: invalid register for .seh_savexmm
%USERPROFILE%\AppData\Local\Temp\ccBSUeSO.s:21575: Error: invalid register for .seh_savexmm
%USERPROFILE%\AppData\Local\Temp\ccBSUeSO.s:21577: Error: invalid register for .seh_savexmm
<...>
mingw32-make[2]: * [modules\dnn\CMakeFiles\opencv_dnn.dir\build.make:1742: modules/dnn/CMakeFiles/opencv_dnn.dir/layers/layers_common.avx512_skx.cpp.obj] Error 1 
mingw32-make[1]: [CMakeFiles\Makefile2:4024: modules/dnn/CMakeFiles/opencv_dnn.dir/all] Error 2 
mingw32-make: ** [Makefile:162: all] Error 2
```

Proposed patch is a workaround based on this patch in GCC: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=79127 - AVX-512 support will not be detected by cmake for mingw-w64, and will be disabled.

```
docker_image:Custom=ubuntu:17.10
```
