### PR TITLE
C API support for OpenCV 4.3.x

### DIFF
--- a/modules/core/include/opencv2/core/cvdef.h
+++ b/modules/core/include/opencv2/core/cvdef.h
@@ -480,7 +480,7 @@ using std::uint32_t;
 using std::int64_t;
 using std::uint64_t;
 }
-#else
+#elif __cplusplus
 #include <stdint.h>
 namespace cv {
 typedef ::int8_t int8_t;
@@ -492,6 +492,8 @@ typedef ::uint32_t uint32_t;
 typedef ::int64_t int64_t;
 typedef ::uint64_t uint64_t;
 }
+#else
+#include <stdint.h>
 #endif
 #endif
 

--- a/modules/core/include/opencv2/core/types_c.h
+++ b/modules/core/include/opencv2/core/types_c.h
@@ -57,6 +57,7 @@
 #endif
 
 #include "opencv2/core/cvdef.h"
+#include "opencv2/core/fast_math.hpp"
 
 #ifndef SKIP_INCLUDES
 #include <assert.h>

--- a/modules/highgui/include/opencv2/highgui/highgui_c.h
+++ b/modules/highgui/include/opencv2/highgui/highgui_c.h
@@ -136,7 +136,10 @@ CVAPI(void) cvSetWindowProperty(const char* name, int prop_id, double prop_value
 CVAPI(double) cvGetWindowProperty(const char* name, int prop_id);
 
 /* Get window image rectangle coordinates, width and height */
+#if __cplusplus
 CVAPI(cv::Rect)cvGetWindowImageRect(const char* name);
+#else
+#endif
 
 /* display image within window (highgui windows remember their content) */
 CVAPI(void) cvShowImage( const char* name, const CvArr* image );


### PR DESCRIPTION
I wrote small patches to add C API support to 4.3.1

This will solve the following issues:
#10405, #6585,  #10658

Could you please consider to merge these fixes? 
There are many legacy program that still use C APIs.