### PR TITLE
Import tf.reduce_mean operation as average pooling layer

### DIFF
--- a/modules/dnn/test/test_tf_importer.cpp
+++ b/modules/dnn/test/test_tf_importer.cpp
@@ -167,6 +167,7 @@ TEST(Test_TensorFlow, pooling)
     runTensorFlowNet("max_pool_odd_valid");
     runTensorFlowNet("max_pool_odd_same");
     runTensorFlowNet("ave_pool_same");
+    runTensorFlowNet("reduce_mean");  // an average pooling over all spatial dimensions.
 }
 
 TEST(Test_TensorFlow, deconvolution)


### PR DESCRIPTION
<!-- Please use this line to close one or multiple issues when this pullrequest gets merged
You can add another line right under the first one:
resolves #1234
resolves #1235
-->

### This pullrequest changes

A specific case of `tf.reduce_mean` layer from TensorFlow that can be interpret as an average pooling layer over all spatial dimensions (global averge pooling).

**Merge with extra**: https://github.com/opencv/opencv_extra/pull/446

**WIP**: please do not merge
