### PR TITLE
cmake: add option to enable/disable OpenCL in DNN module

### DIFF
--- a/cmake/OpenCVModule.cmake
+++ b/cmake/OpenCVModule.cmake
@@ -747,13 +747,17 @@ endmacro()
 
 # finds and sets headers and sources for the standard OpenCV module
 # Usage:
-# ocv_glob_module_sources([EXCLUDE_CUDA] <extra sources&headers in the same format as used in ocv_set_module_sources>)
+# ocv_glob_module_sources([EXCLUDE_CUDA] [EXCLUDE_OPENCL] <extra sources&headers in the same format as used in ocv_set_module_sources>)
 macro(ocv_glob_module_sources)
   ocv_debug_message("ocv_glob_module_sources(" ${ARGN} ")")
   set(_argn ${ARGN})
   list(FIND _argn "EXCLUDE_CUDA" exclude_cuda)
   if(NOT exclude_cuda EQUAL -1)
     list(REMOVE_AT _argn ${exclude_cuda})
+  endif()
+  list(FIND _argn "EXCLUDE_OPENCL" exclude_opencl)
+  if(NOT exclude_opencl EQUAL -1)
+    list(REMOVE_AT _argn ${exclude_opencl})
   endif()
 
   file(GLOB_RECURSE lib_srcs
@@ -801,7 +805,7 @@ macro(ocv_glob_module_sources)
   file(GLOB cl_kernels
        "${CMAKE_CURRENT_LIST_DIR}/src/opencl/*.cl"
   )
-  if(cl_kernels)
+  if(cl_kernels AND exclude_opencl EQUAL -1)
     set(OCL_NAME opencl_kernels_${name})
     add_custom_command(
       OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/${OCL_NAME}.cpp"  # don't add .hpp file here to optimize build process

--- a/modules/dnn/CMakeLists.txt
+++ b/modules/dnn/CMakeLists.txt
@@ -11,6 +11,14 @@ set(the_description "Deep neural network module. It allows to load models from d
 ocv_add_dispatched_file_force_all("layers/layers_common" AVX AVX2 AVX512_SKX)
 
 ocv_add_module(dnn opencv_core opencv_imgproc WRAP python matlab java js)
+
+ocv_option(OPENCV_DNN_OPENCL "Build with OpenCL support" HAVE_OPENCL)
+if(OPENCV_DNN_OPENCL AND HAVE_OPENCL)
+  add_definitions(-DCV_OCL4DNN=1)
+else()
+  ocv_cmake_hook_append(INIT_MODULE_SOURCES_opencv_dnn "${CMAKE_CURRENT_LIST_DIR}/cmake/hooks/INIT_MODULE_SOURCES_opencv_dnn.cmake")
+endif()
+
 ocv_warnings_disable(CMAKE_CXX_FLAGS -Wno-shadow -Wno-parentheses -Wmaybe-uninitialized -Wsign-promo
                                      -Wmissing-declarations -Wmissing-prototypes
 )
@@ -63,8 +71,15 @@ else()
   set(fw_inc "${CMAKE_CURRENT_LIST_DIR}/misc/caffe" "${CMAKE_CURRENT_LIST_DIR}/misc/tensorflow")
 endif()
 
-ocv_module_include_directories(${fw_inc} ${CMAKE_CURRENT_LIST_DIR}/src/ocl4dnn/include ${OPENCL_INCLUDE_DIRS})
-ocv_glob_module_sources(SOURCES ${fw_srcs})
+set(include_dirs ${fw_inc})
+set(sources_options "")
+if(OPENCV_DNN_OPENCL AND HAVE_OPENCL)
+  list(APPEND include_dirs ${OPENCL_INCLUDE_DIRS})
+else()
+  set(sources_options EXCLUDE_OPENCL)
+endif()
+ocv_module_include_directories(${include_dirs})
+ocv_glob_module_sources(${sources_options} SOURCES ${fw_srcs})
 ocv_create_module(libprotobuf ${LAPACK_LIBRARIES})
 ocv_add_samples()
 ocv_add_accuracy_tests()

--- a/modules/dnn/cmake/hooks/INIT_MODULE_SOURCES_opencv_dnn.cmake
+++ b/modules/dnn/cmake/hooks/INIT_MODULE_SOURCES_opencv_dnn.cmake
@@ -1,0 +1,3 @@
+message(STATUS "opencv_dnn: filter out ocl4dnn source code")
+ocv_list_filterout(OPENCV_MODULE_${the_module}_SOURCES "/ocl4dnn/")
+ocv_list_filterout(OPENCV_MODULE_${the_module}_HEADERS "/ocl4dnn/")

--- a/modules/dnn/src/dnn.cpp
+++ b/modules/dnn/src/dnn.cpp
@@ -53,6 +53,7 @@
 #include <opencv2/imgproc.hpp>
 
 #include <opencv2/core/utils/configuration.private.hpp>
+#include <opencv2/core/utils/logger.hpp>
 
 namespace cv {
 namespace dnn {
@@ -846,6 +847,13 @@ struct Net::Impl
 
         if (!netWasAllocated || this->blobsToKeep != blobsToKeep_)
         {
+#ifndef HAVE_OPENCL
+            if (preferableBackend == DNN_BACKEND_DEFAULT && preferableTarget == DNN_TARGET_OPENCL)
+            {
+                CV_LOG_WARNING(NULL, "DNN: OpenCL target is not available in this OpenCV build, switching to CPU.")
+                preferableTarget = DNN_TARGET_CPU;
+            }
+#endif
             clear();
 
             allocateLayers(blobsToKeep_);

--- a/modules/dnn/src/layers/batch_norm_layer.cpp
+++ b/modules/dnn/src/layers/batch_norm_layer.cpp
@@ -13,7 +13,10 @@ Implementation of Batch Normalization layer.
 #include "op_halide.hpp"
 #include "op_inf_engine.hpp"
 #include <opencv2/dnn/shape_utils.hpp>
+
+#ifdef HAVE_OPENCL
 #include "opencl_kernels_dnn.hpp"
+#endif
 
 namespace cv
 {

--- a/modules/dnn/src/layers/concat_layer.cpp
+++ b/modules/dnn/src/layers/concat_layer.cpp
@@ -44,7 +44,10 @@
 #include "layers_common.hpp"
 #include "op_halide.hpp"
 #include "op_inf_engine.hpp"
+
+#ifdef HAVE_OPENCL
 #include "opencl_kernels_dnn.hpp"
+#endif
 
 namespace cv
 {

--- a/modules/dnn/src/layers/convolution_layer.cpp
+++ b/modules/dnn/src/layers/convolution_layer.cpp
@@ -47,9 +47,9 @@
 #include "opencv2/core/hal/hal.hpp"
 #include "opencv2/core/hal/intrin.hpp"
 #include <iostream>
-#include "opencl_kernels_dnn.hpp"
 
 #ifdef HAVE_OPENCL
+#include "opencl_kernels_dnn.hpp"
 using namespace cv::dnn::ocl4dnn;
 #endif
 

--- a/modules/dnn/src/layers/detection_output_layer.cpp
+++ b/modules/dnn/src/layers/detection_output_layer.cpp
@@ -46,7 +46,10 @@
 #include <float.h>
 #include <string>
 #include "../nms.inl.hpp"
+
+#ifdef HAVE_OPENCL
 #include "opencl_kernels_dnn.hpp"
+#endif
 
 namespace cv
 {

--- a/modules/dnn/src/layers/elementwise_layers.cpp
+++ b/modules/dnn/src/layers/elementwise_layers.cpp
@@ -46,8 +46,11 @@
 #include "op_inf_engine.hpp"
 #include "opencv2/imgproc.hpp"
 #include <opencv2/dnn/shape_utils.hpp>
-#include "opencl_kernels_dnn.hpp"
 #include <iostream>
+
+#ifdef HAVE_OPENCL
+#include "opencl_kernels_dnn.hpp"
+#endif
 
 namespace cv
 {

--- a/modules/dnn/src/layers/eltwise_layer.cpp
+++ b/modules/dnn/src/layers/eltwise_layer.cpp
@@ -44,7 +44,10 @@
 #include "layers_common.hpp"
 #include "op_halide.hpp"
 #include "op_inf_engine.hpp"
+
+#ifdef HAVE_OPENCL
 #include "opencl_kernels_dnn.hpp"
+#endif
 
 namespace cv
 {

--- a/modules/dnn/src/layers/fully_connected_layer.cpp
+++ b/modules/dnn/src/layers/fully_connected_layer.cpp
@@ -44,10 +44,10 @@
 #include "layers_common.hpp"
 #include "op_halide.hpp"
 #include "op_inf_engine.hpp"
-#include "opencl_kernels_dnn.hpp"
 #include <opencv2/dnn/shape_utils.hpp>
 
 #ifdef HAVE_OPENCL
+#include "opencl_kernels_dnn.hpp"
 using namespace cv::dnn::ocl4dnn;
 #endif
 

--- a/modules/dnn/src/layers/layers_common.cpp
+++ b/modules/dnn/src/layers/layers_common.cpp
@@ -40,6 +40,7 @@
 //
 //M*/
 
+#include "../precomp.hpp"
 #include "layers_common.hpp"
 
 namespace cv

--- a/modules/dnn/src/layers/layers_common.hpp
+++ b/modules/dnn/src/layers/layers_common.hpp
@@ -52,7 +52,7 @@
 #undef CV_CPU_OPTIMIZATION_DECLARATIONS_ONLY
 
 #ifdef HAVE_OPENCL
-#include "ocl4dnn.hpp"
+#include "../ocl4dnn/include/ocl4dnn.hpp"
 #endif
 
 namespace cv

--- a/modules/dnn/src/layers/lrn_layer.cpp
+++ b/modules/dnn/src/layers/lrn_layer.cpp
@@ -47,10 +47,10 @@
 #include "opencv2/imgproc.hpp"
 #include "opencv2/dnn/shape_utils.hpp"
 #include "opencv2/core/hal/hal.hpp"
-#include "opencl_kernels_dnn.hpp"
 #include <algorithm>
 
 #ifdef HAVE_OPENCL
+#include "opencl_kernels_dnn.hpp"
 using namespace cv::dnn::ocl4dnn;
 #endif
 

--- a/modules/dnn/src/layers/mvn_layer.cpp
+++ b/modules/dnn/src/layers/mvn_layer.cpp
@@ -43,8 +43,11 @@
 #include "../precomp.hpp"
 #include "layers_common.hpp"
 #include <opencv2/dnn/shape_utils.hpp>
-#include "math_functions.hpp"
+
+#ifdef HAVE_OPENCL
+#include "../ocl4dnn/include/math_functions.hpp"
 #include "opencl_kernels_dnn.hpp"
+#endif
 
 namespace cv
 {

--- a/modules/dnn/src/layers/permute_layer.cpp
+++ b/modules/dnn/src/layers/permute_layer.cpp
@@ -45,7 +45,10 @@
 #include "op_inf_engine.hpp"
 #include <float.h>
 #include <algorithm>
+
+#ifdef HAVE_OPENCL
 #include "opencl_kernels_dnn.hpp"
+#endif
 
 namespace cv
 {

--- a/modules/dnn/src/layers/pooling_layer.cpp
+++ b/modules/dnn/src/layers/pooling_layer.cpp
@@ -45,12 +45,13 @@
 #include "opencv2/core/hal/intrin.hpp"
 #include "op_halide.hpp"
 #include "op_inf_engine.hpp"
-#include "opencl_kernels_dnn.hpp"
 #include <float.h>
 #include <algorithm>
 using std::max;
 using std::min;
+
 #ifdef HAVE_OPENCL
+#include "opencl_kernels_dnn.hpp"
 using namespace cv::dnn::ocl4dnn;
 #endif
 

--- a/modules/dnn/src/layers/prior_box_layer.cpp
+++ b/modules/dnn/src/layers/prior_box_layer.cpp
@@ -46,7 +46,10 @@
 #include <float.h>
 #include <algorithm>
 #include <cmath>
+
+#ifdef HAVE_OPENCL
 #include "opencl_kernels_dnn.hpp"
+#endif
 
 namespace cv
 {

--- a/modules/dnn/src/layers/region_layer.cpp
+++ b/modules/dnn/src/layers/region_layer.cpp
@@ -44,7 +44,10 @@
 #include <opencv2/dnn/shape_utils.hpp>
 #include <opencv2/dnn/all_layers.hpp>
 #include "nms.inl.hpp"
+
+#ifdef HAVE_OPENCL
 #include "opencl_kernels_dnn.hpp"
+#endif
 
 namespace cv
 {

--- a/modules/dnn/src/layers/reorg_layer.cpp
+++ b/modules/dnn/src/layers/reorg_layer.cpp
@@ -44,7 +44,10 @@
 #include <opencv2/dnn/shape_utils.hpp>
 #include <opencv2/dnn/all_layers.hpp>
 #include <iostream>
+
+#ifdef HAVE_OPENCL
 #include "opencl_kernels_dnn.hpp"
+#endif
 
 namespace cv
 {

--- a/modules/dnn/src/layers/slice_layer.cpp
+++ b/modules/dnn/src/layers/slice_layer.cpp
@@ -43,7 +43,10 @@
 #include "../precomp.hpp"
 #include "layers_common.hpp"
 #include <opencv2/dnn/shape_utils.hpp>
+
+#ifdef HAVE_OPENCL
 #include "opencl_kernels_dnn.hpp"
+#endif
 
 namespace cv
 {

--- a/modules/dnn/src/layers/softmax_layer.cpp
+++ b/modules/dnn/src/layers/softmax_layer.cpp
@@ -44,11 +44,12 @@
 #include "layers_common.hpp"
 #include "op_halide.hpp"
 #include "op_inf_engine.hpp"
-#include "opencl_kernels_dnn.hpp"
 #include <algorithm>
 #include <stdlib.h>
 using std::max;
+
 #ifdef HAVE_OPENCL
+#include "opencl_kernels_dnn.hpp"
 using namespace cv::dnn::ocl4dnn;
 #endif
 

--- a/modules/dnn/src/ocl4dnn/include/common.hpp
+++ b/modules/dnn/src/ocl4dnn/include/common.hpp
@@ -45,8 +45,6 @@
 #include "../../caffe/glog_emulator.hpp"
 #include <opencv2/core/opencl/runtime/opencl_core.hpp>
 
-#ifdef HAVE_OPENCL
-
 // Macro to select the single (_float) or double (_double) precision kernel
 #define CL_KERNEL_SELECT(kernel) kernel "_float"
 
@@ -58,5 +56,4 @@
 
 bool clOptionSupport(cv::String option);
 
-#endif // HAVE_OPENCL
 #endif

--- a/modules/dnn/src/ocl4dnn/include/math_functions.hpp
+++ b/modules/dnn/src/ocl4dnn/include/math_functions.hpp
@@ -52,7 +52,6 @@ namespace dnn
 namespace ocl4dnn
 {
 
-#ifdef HAVE_OPENCL
 enum CBLAS_TRANSPOSE {CblasNoTrans=111, CblasTrans=112, CblasConjTrans=113};
 
 template<typename Dtype>
@@ -80,8 +79,6 @@ template<typename Dtype>
 bool ocl4dnnAXPY(const int32_t N, const Dtype alpha,
                  const UMat x, const int32_t offx, UMat y,
                  const int32_t offy);
-
-#endif  // HAVE_OPENCL
 
 } // namespace ocl4dnn
 } // namespace dnn

--- a/modules/dnn/src/ocl4dnn/include/ocl4dnn.hpp
+++ b/modules/dnn/src/ocl4dnn/include/ocl4dnn.hpp
@@ -51,7 +51,6 @@
 #include "common.hpp"
 
 namespace cv { namespace dnn { namespace ocl4dnn {
-#ifdef HAVE_OPENCL
 
 struct OCL4DNNConvConfig
 {
@@ -507,8 +506,7 @@ class OCL4DNNSoftmax
         bool log_softmax_;
         UMat scale_data_;
 };
-#endif // HAVE_OPENCL
-} // namespace ocl4dnn
-} // namespace dnn
-} // namespce cv
+
+}}} // namespace cv::dnn::ocl4dnn
+
 #endif

--- a/modules/dnn/src/ocl4dnn/src/common.cpp
+++ b/modules/dnn/src/ocl4dnn/src/common.cpp
@@ -41,17 +41,14 @@
 //M*/
 
 #include "../../precomp.hpp"
-#include "common.hpp"
+#include "../include/common.hpp"
 #include "opencl_kernels_dnn.hpp"
 
 using namespace cv;
 
-#ifdef HAVE_OPENCL
 bool clOptionSupport(cv::String option)
 {
     cv::String errmsg;
     ocl::Program program = ocl::Context::getDefault().getProg(ocl::dnn::dummy_oclsrc, option, errmsg);
     return program.ptr() ? true : false;
 }
-
-#endif // HAVE_OPENCL

--- a/modules/dnn/src/ocl4dnn/src/math_functions.cpp
+++ b/modules/dnn/src/ocl4dnn/src/math_functions.cpp
@@ -41,19 +41,13 @@
 //M*/
 
 #include "../../precomp.hpp"
-#include "common.hpp"
-#include "math_functions.hpp"
+#include "../include/common.hpp"
+#include "../include/math_functions.hpp"
 #include <vector>
 #include "opencl_kernels_dnn.hpp"
 
-namespace cv
-{
-namespace dnn
-{
-namespace ocl4dnn
-{
+namespace cv { namespace dnn { namespace ocl4dnn {
 
-#ifdef HAVE_OPENCL
 // Create and copy buffer to image for GEMM's matrix A and B.
 // Will return image to caller if the input image is NULL. Otherwise,
 // will use the image directly. It's caller's responsibility to
@@ -527,8 +521,4 @@ template bool ocl4dnnAXPY<float>(const int32_t N, const float alpha,
                                  const UMat X, const int32_t offX,
                                  UMat Y, const int32_t offY);
 
-#endif  // HAVE_OPENCL
-
-} // namespace ocl4dnn
-} // namespace dnn
-} // namespce cv
+}}} // namespace cv::dnn::ocl4dnn

--- a/modules/dnn/src/ocl4dnn/src/ocl4dnn_conv_spatial.cpp
+++ b/modules/dnn/src/ocl4dnn/src/ocl4dnn_conv_spatial.cpp
@@ -49,18 +49,17 @@
 #include <fstream>
 #include <sys/stat.h>
 #include <assert.h>
-#include "common.hpp"
-#include "ocl4dnn.hpp"
+#include "../include/common.hpp"
+#include "../include/ocl4dnn.hpp"
 #include "opencl_kernels_dnn.hpp"
-#include "math_functions.hpp"
-#include "default_kernel_config.hpp"
+#include "../include/math_functions.hpp"
+#include "../include/default_kernel_config.hpp"
 
 #if defined WIN32 || defined _WIN32
 #include <windows.h>
 #include <direct.h>
 #endif
 
-#ifdef HAVE_OPENCL
 namespace cv { namespace dnn { namespace ocl4dnn {
 static cv::Mutex kernelConfigMutex;
 typedef std::map<std::string, std::string> kernel_hash_t;
@@ -1855,7 +1854,5 @@ bool OCL4DNNConvSpatial<Dtype>::loadTunedConfig()
 }
 
 template class OCL4DNNConvSpatial<float>;
-} // namespace ocl4dnn
-}
-}
-#endif // HAVE_OPENCL
+
+}}} // namespace cv::dnn::ocl4dnn

--- a/modules/dnn/src/ocl4dnn/src/ocl4dnn_inner_product.cpp
+++ b/modules/dnn/src/ocl4dnn/src/ocl4dnn_inner_product.cpp
@@ -41,11 +41,10 @@
 //M*/
 
 #include "../../precomp.hpp"
-#include "common.hpp"
-#include "ocl4dnn.hpp"
-#include "math_functions.hpp"
+#include "../include/common.hpp"
+#include "../include/ocl4dnn.hpp"
+#include "../include/math_functions.hpp"
 
-#ifdef HAVE_OPENCL
 namespace cv { namespace dnn { namespace ocl4dnn {
 template<typename Dtype>
 OCL4DNNInnerProduct<Dtype>::OCL4DNNInnerProduct(OCL4DNNInnerProductConfig config)
@@ -102,7 +101,5 @@ bool OCL4DNNInnerProduct<Dtype>::Forward(const UMat& bottom,
 }
 
 template class OCL4DNNInnerProduct<float>;
-} // namespace ocl4dnn
-}
-}
-#endif // HAVE_OPENCL
+
+}}} // namespace cv::dnn::ocl4dnn

--- a/modules/dnn/src/ocl4dnn/src/ocl4dnn_lrn.cpp
+++ b/modules/dnn/src/ocl4dnn/src/ocl4dnn_lrn.cpp
@@ -41,11 +41,10 @@
 //M*/
 
 #include "../../precomp.hpp"
-#include "common.hpp"
-#include "ocl4dnn.hpp"
+#include "../include/common.hpp"
+#include "../include/ocl4dnn.hpp"
 #include "opencl_kernels_dnn.hpp"
 
-#ifdef HAVE_OPENCL
 namespace cv { namespace dnn { namespace ocl4dnn {
 template<typename Dtype>
 OCL4DNNLRN<Dtype>::OCL4DNNLRN(OCL4DNNLRNConfig config)
@@ -119,7 +118,5 @@ bool OCL4DNNLRN<Dtype>::crossChannelForward(const UMat& bottom, UMat& top)
 }
 
 template class OCL4DNNLRN<float>;
-} // namespace ocl4dnn
-}
-}
-#endif // HAVE_OPENCL
+
+}}} // namespace cv::dnn::ocl4dnn

--- a/modules/dnn/src/ocl4dnn/src/ocl4dnn_pool.cpp
+++ b/modules/dnn/src/ocl4dnn/src/ocl4dnn_pool.cpp
@@ -42,11 +42,10 @@
 #include "../../precomp.hpp"
 #include <string>
 #include <vector>
-#include "common.hpp"
-#include "ocl4dnn.hpp"
+#include "../include/common.hpp"
+#include "../include/ocl4dnn.hpp"
 #include "opencl_kernels_dnn.hpp"
 
-#ifdef HAVE_OPENCL
 namespace cv { namespace dnn { namespace ocl4dnn {
 template<typename Dtype>
 OCL4DNNPool<Dtype>::OCL4DNNPool(OCL4DNNPoolConfig config)
@@ -208,7 +207,5 @@ bool OCL4DNNPool<Dtype>::Forward(const UMat& bottom,
 }
 
 template class OCL4DNNPool<float>;
-} // namespace ocl4dnn
-}
-}
-#endif // HAVE_OPENCL
+
+}}} // namespace cv::dnn::ocl4dnn

--- a/modules/dnn/src/ocl4dnn/src/ocl4dnn_softmax.cpp
+++ b/modules/dnn/src/ocl4dnn/src/ocl4dnn_softmax.cpp
@@ -41,11 +41,10 @@
 
 #include "../../precomp.hpp"
 #include <vector>
-#include "common.hpp"
-#include "ocl4dnn.hpp"
+#include "../include/common.hpp"
+#include "../include/ocl4dnn.hpp"
 #include "opencl_kernels_dnn.hpp"
 
-#ifdef HAVE_OPENCL
 namespace cv { namespace dnn { namespace ocl4dnn {
 template<typename Dtype>
 OCL4DNNSoftmax<Dtype>::OCL4DNNSoftmax(OCL4DNNSoftmaxConfig config)
@@ -130,7 +129,5 @@ bool OCL4DNNSoftmax<Dtype>::Forward(const UMat& bottom, UMat& top)
 }
 
 template class OCL4DNNSoftmax<float>;
-} // namespace ocl4dnn
-}
-}
-#endif // HAVE_OPENCL
+
+}}} // namespace cv::dnn::ocl4dnn

--- a/modules/dnn/src/precomp.hpp
+++ b/modules/dnn/src/precomp.hpp
@@ -40,12 +40,27 @@
 //M*/
 
 #include <opencv2/core.hpp>
+#include "cvconfig.h"
+
+#ifndef CV_OCL4DNN
+#define CV_OCL4DNN 0
+#endif
+
+#if CV_OCL4DNN
+#ifndef HAVE_OPENCL
+#error "Configuration error: re-run CMake from clean build directory"
+#endif
+#else
+#undef HAVE_OPENCL
+#endif
 #include <opencv2/core/ocl.hpp>
 #include <opencv2/core/opencl/ocl_defs.hpp>
+
+
 #include <opencv2/core/utils/trace.hpp>
-#include "cvconfig.h"
 #include <opencv2/dnn.hpp>
 #include <opencv2/dnn/all_layers.hpp>
+
 
 namespace cv { namespace dnn {
 CV__DNN_EXPERIMENTAL_NS_BEGIN


### PR DESCRIPTION
- OpenCL is turned ON by default
- can be turned off via `cmake -DOPENCV_DNN_OPENCL=OFF <...>`

[Validated](http://pullrequest.opencv.org/buildbot/builders/precommit_opencl_linux/builds/14869/steps/test_dnn-ippicv-opencl/logs/stdio).

```
allow_multiple_commits=1
```