### PR TITLE
features2d: add verbose messages into tests

### DIFF
--- a/modules/features2d/test/test_nearestneighbors.cpp
+++ b/modules/features2d/test/test_nearestneighbors.cpp
@@ -112,11 +112,7 @@ int NearestNeighborTest::checkFind( const Mat& data )
         }
 
         double correctPerc = correctMatches / (double)pointsCount;
-        if (correctPerc < .75)
-        {
-            ts->printf( cvtest::TS::LOG, "correct_perc = %d\n", correctPerc );
-            code = cvtest::TS::FAIL_BAD_ACCURACY;
-        }
+        EXPECT_GE(correctPerc, .75) << "correctMatches=" << correctMatches << " pointsCount=" << pointsCount;
     }
 
     return code;
@@ -152,6 +148,7 @@ void NearestNeighborTest::run( int /*start_from*/ ) {
 
     releaseModel();
 
+    if (::testing::Test::HasFailure()) code = cvtest::TS::FAIL_BAD_ACCURACY;
     ts->set_failed_test_info( code );
 }
 
@@ -201,10 +198,9 @@ int CV_FlannTest::knnSearch( Mat& points, Mat& neighbors )
     }
 
     // compare results
-    if( cvtest::norm( neighbors, neighbors1, NORM_L1 ) != 0 )
-        return cvtest::TS::FAIL_BAD_ACCURACY;
+    EXPECT_LE(cvtest::norm(neighbors, neighbors1, NORM_L1), 0);
 
-    return cvtest::TS::OK;
+    return ::testing::Test::HasFailure() ? cvtest::TS::FAIL_BAD_ACCURACY : cvtest::TS::OK;
 }
 
 int CV_FlannTest::radiusSearch( Mat& points, Mat& neighbors )
@@ -232,11 +228,11 @@ int CV_FlannTest::radiusSearch( Mat& points, Mat& neighbors )
         for( j = 0; it != indices.end(); ++it, j++ )
             neighbors1.at<int>(i,j) = *it;
     }
-    // compare results
-    if( cvtest::norm( neighbors, neighbors1, NORM_L1 ) != 0 )
-        return cvtest::TS::FAIL_BAD_ACCURACY;
 
-    return cvtest::TS::OK;
+    // compare results
+    EXPECT_LE(cvtest::norm(neighbors, neighbors1, NORM_L1), 0);
+
+    return ::testing::Test::HasFailure() ? cvtest::TS::FAIL_BAD_ACCURACY : cvtest::TS::OK;
 }
 
 void CV_FlannTest::releaseModel()


### PR DESCRIPTION
To investigate sporadic failures of Features2d_FLANN_Auto.regression test.

Using double value for '%d' specifier is wrong and doesn't provide useful message.