### PR TITLE
SSE2 : use _mm_cvtpd_epi32 when converting from CV_64F to CV_32S

### DIFF
--- a/modules/core/include/opencv2/core/hal/intrin_sse.hpp
+++ b/modules/core/include/opencv2/core/hal/intrin_sse.hpp
@@ -1860,11 +1860,6 @@ OPENCV_HAL_IMPL_SSE_LOADSTORE_INTERLEAVE(v_int16x8, short, s16, v_uint16x8, usho
 OPENCV_HAL_IMPL_SSE_LOADSTORE_INTERLEAVE(v_int32x4, int, s32, v_uint32x4, unsigned, u32)
 OPENCV_HAL_IMPL_SSE_LOADSTORE_INTERLEAVE(v_float32x4, float, f32, v_uint32x4, unsigned, u32)
 
-inline v_int32x4 v_cvt_s32(const v_float64x2& a)
-{
-    return v_int32x4(_mm_cvtpd_epi32(a.val));
-}
-
 inline v_float32x4 v_cvt_f32(const v_int32x4& a)
 {
     return v_float32x4(_mm_cvtepi32_ps(a.val));

--- a/modules/core/include/opencv2/core/hal/intrin_sse.hpp
+++ b/modules/core/include/opencv2/core/hal/intrin_sse.hpp
@@ -1860,6 +1860,11 @@ OPENCV_HAL_IMPL_SSE_LOADSTORE_INTERLEAVE(v_int16x8, short, s16, v_uint16x8, usho
 OPENCV_HAL_IMPL_SSE_LOADSTORE_INTERLEAVE(v_int32x4, int, s32, v_uint32x4, unsigned, u32)
 OPENCV_HAL_IMPL_SSE_LOADSTORE_INTERLEAVE(v_float32x4, float, f32, v_uint32x4, unsigned, u32)
 
+inline v_int32x4 v_cvt_s32(const v_float64x2& a)
+{
+    return v_int32x4(_mm_cvtpd_epi32(a.val));
+}
+
 inline v_float32x4 v_cvt_f32(const v_int32x4& a)
 {
     return v_float32x4(_mm_cvtepi32_ps(a.val));

--- a/modules/core/src/convert.cpp
+++ b/modules/core/src/convert.cpp
@@ -770,8 +770,8 @@ struct Cvt_SIMD<double, int>
             int cWidth = v_float64x2::nlanes;
             for (; x <= width - cWidth * 2; x += cWidth * 2)
             {
-                v_int32x4 v_src0 = v_cvt_s32(v_load(src + x));
-                v_int32x4 v_src1 = v_cvt_s32(v_load(src + x + cWidth));
+                v_int32x4 v_src0 = v_round(v_load(src + x));
+                v_int32x4 v_src1 = v_round(v_load(src + x + cWidth));
 
                 v_store(dst + x, v_combine_low(v_src0, v_src1));
             }

--- a/modules/core/src/convert.cpp
+++ b/modules/core/src/convert.cpp
@@ -770,10 +770,10 @@ struct Cvt_SIMD<double, int>
             int cWidth = v_float64x2::nlanes;
             for (; x <= width - cWidth * 2; x += cWidth * 2)
             {
-                v_float32x4 v_src0 = v_cvt_f32(v_load(src + x));
-                v_float32x4 v_src1 = v_cvt_f32(v_load(src + x + cWidth));
+                v_int32x4 v_src0 = v_cvt_s32(v_load(src + x));
+                v_int32x4 v_src1 = v_cvt_s32(v_load(src + x + cWidth));
 
-                v_store(dst + x, v_round(v_combine_low(v_src0, v_src1)));
+                v_store(dst + x, v_combine_low(v_src0, v_src1));
             }
         }
         return x;


### PR DESCRIPTION
Previously, `Cvt_SIMD<double, int>` used `_mm_cvtpd_ps` with `_mm_cvtps_epi32` to convert CV_64F value to CV_32S, when SSE2 is available. But using `_mm_cvtpd_ps` results in some loss of precision, and some tests in `opencv_test_cudaarithm` fail because of this loss. This PR fixes this by using `_mm_cvtpd_epi32`.

Without this fix, following 6 tests fail.
CUDA_Arithm/Bitwise_Scalar.Or/8, where GetParam() = (GeForce GTX 1080, 128x128, CV_32S, Channels(4))
CUDA_Arithm/Bitwise_Scalar.Or/17, where GetParam() = (GeForce GTX 1080, 113x113, CV_32S, Channels(4))
CUDA_Arithm/Bitwise_Scalar.And/8, where GetParam() = (GeForce GTX 1080, 128x128, CV_32S, Channels(4))
CUDA_Arithm/Bitwise_Scalar.And/17, where GetParam() = (GeForce GTX 1080, 113x113, CV_32S, Channels(4))
CUDA_Arithm/Bitwise_Scalar.Xor/8, where GetParam() = (GeForce GTX 1080, 128x128, CV_32S, Channels(4))
CUDA_Arithm/Bitwise_Scalar.Xor/17, where GetParam() = (GeForce GTX 1080, 113x113, CV_32S, Channels(4)) 

Tested on i7-7700K with SSE2 enabled build.