### PR TITLE
videoio: add workaround of old gstreamer

### DIFF
--- a/modules/videoio/test/test_video_io.cpp
+++ b/modules/videoio/test/test_video_io.cpp
@@ -112,6 +112,13 @@ public:
 
         {
             SCOPED_TRACE("consecutive read");
+            if (apiPref == CAP_GSTREAMER)
+            {
+                // This workaround is for GStreamer 1.3.1.1 and older.
+                // Old Gstreamer has a bug which handles the total duration 1 frame shorter
+                // Old Gstreamer are used in Ubuntu 14.04, so the following code could be removed after it's EOL
+                n_frames--;
+            }
             for (int k = 0; k < n_frames; ++k)
             {
                 checkFrameRead(k, cap);


### PR DESCRIPTION
resolves #10932 

```
docker_image:Custom=gstreamer:16.04
```