### PR TITLE
[tutorial_py_contours_more_function] Fixes python3 error int object is not iterable

### DIFF
--- a/doc/py_tutorials/py_imgproc/py_contours/py_contours_more_functions/py_contours_more_functions.markdown
+++ b/doc/py_tutorials/py_imgproc/py_contours/py_contours_more_functions/py_contours_more_functions.markdown
@@ -47,9 +47,9 @@ defects = cv.convexityDefects(cnt,hull)
 
 for i in range(defects.shape[0]):
     s,e,f,d = defects[i,0]
-    start = tuple(cnt[s][0])
-    end = tuple(cnt[e][0])
-    far = tuple(cnt[f][0])
+    start = tuple(cnt[s])
+    end = tuple(cnt[e])
+    far = tuple(cnt[f])
     cv.line(img,start,end,[0,255,0],2)
     cv.circle(img,far,5,[0,0,255],-1)
 


### PR DESCRIPTION
AFAIK cnt[s] returns x,y  when cnt[s][0] is only x of contours , we need the tuple of cnt[s] and tuple (x) retur an error: 

    'int' object is not iterable

<!-- Please use this line to close one or multiple issues when this pullrequest gets merged
You can add another line right under the first one:
resolves #1234
resolves #1235
-->

### This pullrequest changes

<!-- Please describe what your pullrequest is changing -->
