### PR TITLE
imgproc: let the performance tests of WarpPerspective pass

### DIFF
--- a/modules/imgproc/src/imgwarp.cpp
+++ b/modules/imgproc/src/imgwarp.cpp
@@ -2793,6 +2793,11 @@ public:
         ParallelLoopBody(), src(_src), dst(_dst), M(_M), interpolation(_interpolation),
         borderType(_borderType), borderValue(_borderValue)
     {
+#if defined(_MSC_VER) && _MSC_VER == 1800 /* MSVS 2013 */ && CV_AVX
+        // details: https://github.com/opencv/opencv/issues/11026
+        borderValue.val[2] = _borderValue.val[2];
+        borderValue.val[3] = _borderValue.val[3];
+#endif
     }
 
     virtual void operator() (const Range& range) const


### PR DESCRIPTION
  * avoid misuse of vzeroupper on Visual Studio 2013 Update 5
  * add ifdef to avoid unattended optimization

<!-- Please use this line to close one or multiple issues when this pullrequest gets merged
You can add another line right under the first one:
resolves #1234
resolves #1235
-->

### This pullrequest changes
resolves #11026

<!-- Please describe what your pullrequest is changing -->
