### PR TITLE
Update OpenCVDownload.cmake to fix log crash

### DIFF
--- a/cmake/OpenCVDownload.cmake
+++ b/cmake/OpenCVDownload.cmake
@@ -34,9 +34,9 @@ file(WRITE "${OPENCV_DOWNLOAD_LOG}" "use_cache \"${OPENCV_DOWNLOAD_PATH}\"\n")
 function(ocv_download)
   cmake_parse_arguments(DL "UNPACK;RELATIVE_URL" "FILENAME;HASH;DESTINATION_DIR;ID;STATUS" "URL" ${ARGN})
 
-  macro(ocv_download_log)
+  function(ocv_download_log)
     file(APPEND "${OPENCV_DOWNLOAD_LOG}" "${ARGN}\n")
-  endmacro()
+  endfunction()
 
   ocv_assert(DL_FILENAME)
   ocv_assert(DL_HASH)


### PR DESCRIPTION
<!-- Please use this line to close one or multiple issues when this pullrequest gets merged
You can add another line right under the first one:
resolves #1234
resolves #1235
-->


### This pullrequest changes

<!-- Please describe what your pullrequest is changing -->
This PR changes the file `opencv-3.4.1/cmake/OpenCVDownload.cmake`. 
It suppresses the interpretation of string literals by switching `ocv_download_log` from a macro to a function.

This avoid the interpretation of string literals, which is one of the root causes for build errors in opencv_contrib because the output of libcurl (used to download extra files) can contain characters like `\,`which get interpreted and produce errors.

More information about the difference between cmake macros and functions is available here:

- https://stackoverflow.com/questions/14112279/cmake-parse-error-invalid-escape-sequence-o/14113153#14113153
- https://cmake.org/cmake/help/v2.8.10/cmake.html#command%3amacro
- https://cmake.org/cmake/help/v2.8.10/cmake.html#command%3afunction

More details about the problem this PR fixes are available at:

- https://github.com/opencv/opencv_contrib/issues/1131
