### PR TITLE
Enabling build of stitching when CUDA is available

### DIFF
--- a/modules/stitching/CMakeLists.txt
+++ b/modules/stitching/CMakeLists.txt
@@ -9,5 +9,5 @@ if(BUILD_SHARED_LIBS AND BUILD_opencv_world AND OPENCV_WORLD_EXCLUDE_EXTRA_MODUL
   set(STITCHING_CONTRIB_DEPS "")
 endif()
 ocv_define_module(stitching opencv_imgproc opencv_features2d opencv_calib3d opencv_flann
-                  OPTIONAL opencv_cudaarithm opencv_cudawarping opencv_cudafeatures2d opencv_cudalegacy ${STITCHING_CONTRIB_DEPS}
+                  OPTIONAL opencv_cudaarithm opencv_cudawarping opencv_cudafeatures2d opencv_cudalegacy opencv_cudaimgproc ${STITCHING_CONTRIB_DEPS}
                   WRAP python)


### PR DESCRIPTION
<!-- Please use this line to close one or multiple issues when this pullrequest gets merged
You can add another line right under the first one:
resolves #1234
resolves #1235
-->

### This pullrequest changes
CMake for stitching module is updated to include optional opencv_cudaimgproc dependency
<!-- Please describe what your pullrequest is changing -->
### Description
Without proposed change, module throws build error regarding missing `opencv2/cudaimgproc.hpp`