### PR TITLE
Resolves #10948 again

### DIFF
--- a/modules/core/src/lda.cpp
+++ b/modules/core/src/lda.cpp
@@ -350,6 +350,9 @@ private:
             // Look for single small sub-diagonal element
             int l = n1;
             while (l > low) {
+                if (norm < FLT_EPSILON) {
+                    break;
+                }
                 s = std::abs(H[l - 1][l - 1]) + std::abs(H[l][l]);
                 if (s == 0.0) {
                     s = norm;
@@ -594,7 +597,7 @@ private:
 
         // Backsubstitute to find vectors of upper triangular form
 
-        if (norm == 0.0) {
+        if (norm < FLT_EPSILON) {
             return;
         }
 

--- a/modules/core/test/test_eigen.cpp
+++ b/modules/core/test/test_eigen.cpp
@@ -451,13 +451,19 @@ static void testEigenSymmetric3x3()
             -1, 2, -1,
             0, -1, 2
     };
+
     Mat_<T> src(3, 3, values_);
+    Mat_<T> srcZero(3, 3, 0.0);
 
     /*const*/ T expected_eigenvalues_[] = { 3.414213562373095f, 2, 0.585786437626905f };
+    T expected_eigenvaluesZero_[] = { 0.000000000000000f, 0.000000000000000f, 0.000000000000000f };
     Mat_<T> expected_eigenvalues(3, 1, expected_eigenvalues_);
+    Mat_<T> expected_eigenvalueZero(3, 1, expected_eigenvaluesZero_);
 
     testEigen(src, expected_eigenvalues);
     testEigen(src, expected_eigenvalues, true);
+    testEigen(srcZero, expected_eigenvalueZero);
+    testEigen(srcZero, expected_eigenvalueZero, true);
 }
 TEST(Core_EigenSymmetric, float3x3) { testEigenSymmetric3x3<float>(); }
 TEST(Core_EigenSymmetric, double3x3) { testEigenSymmetric3x3<double>(); }
@@ -473,12 +479,17 @@ static void testEigenSymmetric5x5()
             1, 0, -1, 0, 1
     };
     Mat_<T> src(5, 5, values_);
+    Mat_<T> srcZero(5, 5, 0.0);
 
     /*const*/ T expected_eigenvalues_[] = { 7.028919644935684f, 4.406130784616501f, 3.73626552682258f, 1.438067799899037f, 0.390616243726198f };
+    T expected_eigenvaluesZero_[] = { 0.000000000000000f, 0.000000000000000f, 0.000000000000000f, 0.000000000000000f, 0.000000000000000f };
     Mat_<T> expected_eigenvalues(5, 1, expected_eigenvalues_);
+    Mat_<T> expected_eigenvalueZero(5, 1, expected_eigenvaluesZero_);
 
     testEigen(src, expected_eigenvalues);
     testEigen(src, expected_eigenvalues, true);
+    testEigen(srcZero, expected_eigenvalueZero);
+    testEigen(srcZero, expected_eigenvalueZero, true);
 }
 TEST(Core_EigenSymmetric, float5x5) { testEigenSymmetric5x5<float>(); }
 TEST(Core_EigenSymmetric, double5x5) { testEigenSymmetric5x5<double>(); }
@@ -489,11 +500,15 @@ static void testEigen2x2()
 {
     /*const*/ T values_[] = { 4, 1, 6, 3 };
     Mat_<T> src(2, 2, values_);
+    Mat_<T> srcZero(2, 2, 0.0);
 
     /*const*/ T expected_eigenvalues_[] = { 6, 1 };
+    T expected_eigenvaluesZero_[] = { 0.000000000000000f, 0.000000000000000f };
     Mat_<T> expected_eigenvalues(2, 1, expected_eigenvalues_);
+    Mat_<T> expected_eigenvalueZero(2, 1, expected_eigenvaluesZero_);
 
     testEigen(src, expected_eigenvalues);
+    testEigen(srcZero, expected_eigenvalueZero);
 }
 TEST(Core_EigenNonSymmetric, float2x2) { testEigen2x2<float>(); }
 TEST(Core_EigenNonSymmetric, double2x2) { testEigen2x2<double>(); }
@@ -507,11 +522,15 @@ static void testEigen3x3()
             0,0,3
     };
     Mat_<T> src(3, 3, values_);
+    Mat_<T> srcZero(2, 2, 0.0);
 
     /*const*/ T expected_eigenvalues_[] = { 3, 3, 3 };
+    T expected_eigenvaluesZero_[] = { 0.000000000000000f, 0.000000000000000f, 0.000000000000000f };
     Mat_<T> expected_eigenvalues(3, 1, expected_eigenvalues_);
+    Mat_<T> expected_eigenvalueZero(3, 1, expected_eigenvaluesZero_);
 
     testEigen(src, expected_eigenvalues);
+    testEigen(srcZero, expected_eigenvalueZero);
 }
 TEST(Core_EigenNonSymmetric, float3x3) { testEigen3x3<float>(); }
 TEST(Core_EigenNonSymmetric, double3x3) { testEigen3x3<double>(); }

--- a/modules/core/test/test_eigen.cpp
+++ b/modules/core/test/test_eigen.cpp
@@ -451,9 +451,14 @@ static void testEigenSymmetric3x3()
             -1, 2, -1,
             0, -1, 2
     };
+    T valuesZero_[] = {
+        0, 0, 0,
+        0, 0, 0,
+        0, 0, 0
+    };
 
     Mat_<T> src(3, 3, values_);
-    Mat_<T> srcZero(3, 3, 0.0);
+    Mat_<T> srcZero(3, 3, valuesZero_);
 
     /*const*/ T expected_eigenvalues_[] = { 3.414213562373095f, 2, 0.585786437626905f };
     T expected_eigenvaluesZero_[] = { 0.000000000000000f, 0.000000000000000f, 0.000000000000000f };
@@ -478,8 +483,16 @@ static void testEigenSymmetric5x5()
             2, 0, 1, 4, 0,
             1, 0, -1, 0, 1
     };
+
+    T valuesZero_[5*5] = {
+        0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0,
+    };
     Mat_<T> src(5, 5, values_);
-    Mat_<T> srcZero(5, 5, 0.0);
+    Mat_<T> srcZero(5, 5, valuesZero_);
 
     /*const*/ T expected_eigenvalues_[] = { 7.028919644935684f, 4.406130784616501f, 3.73626552682258f, 1.438067799899037f, 0.390616243726198f };
     T expected_eigenvaluesZero_[] = { 0.000000000000000f, 0.000000000000000f, 0.000000000000000f, 0.000000000000000f, 0.000000000000000f };
@@ -499,11 +512,12 @@ template<typename T>
 static void testEigen2x2()
 {
     /*const*/ T values_[] = { 4, 1, 6, 3 };
+    T valuesZero_[] = { 0, 0, 0, 0 };
     Mat_<T> src(2, 2, values_);
-    Mat_<T> srcZero(2, 2, 0.0);
+    Mat_<T> srcZero(2, 2, valuesZero_);
 
     /*const*/ T expected_eigenvalues_[] = { 6, 1 };
-    T expected_eigenvaluesZero_[] = { 0.000000000000000f, 0.000000000000000f };
+    T expected_eigenvaluesZero_[] = { 0, 0 };
     Mat_<T> expected_eigenvalues(2, 1, expected_eigenvalues_);
     Mat_<T> expected_eigenvalueZero(2, 1, expected_eigenvaluesZero_);
 
@@ -521,11 +535,16 @@ static void testEigen3x3()
             0,3,1,
             0,0,3
     };
+    T valuesZero_[3*3] = {
+        0,0,0,
+        0,0,0,
+        0,0,0
+    };
     Mat_<T> src(3, 3, values_);
-    Mat_<T> srcZero(3, 3, 0.0);
+    Mat_<T> srcZero(3, 3, valuesZero_);
 
     /*const*/ T expected_eigenvalues_[] = { 3, 3, 3 };
-    T expected_eigenvaluesZero_[] = { 0.000000000000000f, 0.000000000000000f, 0.000000000000000f };
+    T expected_eigenvaluesZero_[] = { 0, 0, 0 };
     Mat_<T> expected_eigenvalues(3, 1, expected_eigenvalues_);
     Mat_<T> expected_eigenvalueZero(3, 1, expected_eigenvaluesZero_);
 

--- a/modules/core/test/test_eigen.cpp
+++ b/modules/core/test/test_eigen.cpp
@@ -522,7 +522,7 @@ static void testEigen3x3()
             0,0,3
     };
     Mat_<T> src(3, 3, values_);
-    Mat_<T> srcZero(2, 2, 0.0);
+    Mat_<T> srcZero(3, 3, 0.0);
 
     /*const*/ T expected_eigenvalues_[] = { 3, 3, 3 };
     T expected_eigenvaluesZero_[] = { 0.000000000000000f, 0.000000000000000f, 0.000000000000000f };

--- a/modules/core/test/test_eigen.cpp
+++ b/modules/core/test/test_eigen.cpp
@@ -451,24 +451,13 @@ static void testEigenSymmetric3x3()
             -1, 2, -1,
             0, -1, 2
     };
-    T valuesZero_[] = {
-        0, 0, 0,
-        0, 0, 0,
-        0, 0, 0
-    };
-
     Mat_<T> src(3, 3, values_);
-    Mat_<T> srcZero(3, 3, valuesZero_);
 
     /*const*/ T expected_eigenvalues_[] = { 3.414213562373095f, 2, 0.585786437626905f };
-    T expected_eigenvaluesZero_[] = { 0.000000000000000f, 0.000000000000000f, 0.000000000000000f };
     Mat_<T> expected_eigenvalues(3, 1, expected_eigenvalues_);
-    Mat_<T> expected_eigenvalueZero(3, 1, expected_eigenvaluesZero_);
 
     testEigen(src, expected_eigenvalues);
     testEigen(src, expected_eigenvalues, true);
-    testEigen(srcZero, expected_eigenvalueZero);
-    testEigen(srcZero, expected_eigenvalueZero, true);
 }
 TEST(Core_EigenSymmetric, float3x3) { testEigenSymmetric3x3<float>(); }
 TEST(Core_EigenSymmetric, double3x3) { testEigenSymmetric3x3<double>(); }
@@ -483,26 +472,13 @@ static void testEigenSymmetric5x5()
             2, 0, 1, 4, 0,
             1, 0, -1, 0, 1
     };
-
-    T valuesZero_[5*5] = {
-        0, 0, 0, 0, 0,
-        0, 0, 0, 0, 0,
-        0, 0, 0, 0, 0,
-        0, 0, 0, 0, 0,
-        0, 0, 0, 0, 0,
-    };
     Mat_<T> src(5, 5, values_);
-    Mat_<T> srcZero(5, 5, valuesZero_);
 
     /*const*/ T expected_eigenvalues_[] = { 7.028919644935684f, 4.406130784616501f, 3.73626552682258f, 1.438067799899037f, 0.390616243726198f };
-    T expected_eigenvaluesZero_[] = { 0.000000000000000f, 0.000000000000000f, 0.000000000000000f, 0.000000000000000f, 0.000000000000000f };
     Mat_<T> expected_eigenvalues(5, 1, expected_eigenvalues_);
-    Mat_<T> expected_eigenvalueZero(5, 1, expected_eigenvaluesZero_);
 
     testEigen(src, expected_eigenvalues);
     testEigen(src, expected_eigenvalues, true);
-    testEigen(srcZero, expected_eigenvalueZero);
-    testEigen(srcZero, expected_eigenvalueZero, true);
 }
 TEST(Core_EigenSymmetric, float5x5) { testEigenSymmetric5x5<float>(); }
 TEST(Core_EigenSymmetric, double5x5) { testEigenSymmetric5x5<double>(); }
@@ -512,17 +488,12 @@ template<typename T>
 static void testEigen2x2()
 {
     /*const*/ T values_[] = { 4, 1, 6, 3 };
-    T valuesZero_[] = { 0, 0, 0, 0 };
     Mat_<T> src(2, 2, values_);
-    Mat_<T> srcZero(2, 2, valuesZero_);
 
     /*const*/ T expected_eigenvalues_[] = { 6, 1 };
-    T expected_eigenvaluesZero_[] = { 0, 0 };
     Mat_<T> expected_eigenvalues(2, 1, expected_eigenvalues_);
-    Mat_<T> expected_eigenvalueZero(2, 1, expected_eigenvaluesZero_);
 
     testEigen(src, expected_eigenvalues);
-    testEigen(srcZero, expected_eigenvalueZero);
 }
 TEST(Core_EigenNonSymmetric, float2x2) { testEigen2x2<float>(); }
 TEST(Core_EigenNonSymmetric, double2x2) { testEigen2x2<double>(); }
@@ -535,23 +506,25 @@ static void testEigen3x3()
             0,3,1,
             0,0,3
     };
-    T valuesZero_[3*3] = {
-        0,0,0,
-        0,0,0,
-        0,0,0
-    };
     Mat_<T> src(3, 3, values_);
-    Mat_<T> srcZero(3, 3, valuesZero_);
 
     /*const*/ T expected_eigenvalues_[] = { 3, 3, 3 };
-    T expected_eigenvaluesZero_[] = { 0, 0, 0 };
     Mat_<T> expected_eigenvalues(3, 1, expected_eigenvalues_);
-    Mat_<T> expected_eigenvalueZero(3, 1, expected_eigenvaluesZero_);
 
     testEigen(src, expected_eigenvalues);
-    testEigen(srcZero, expected_eigenvalueZero);
 }
 TEST(Core_EigenNonSymmetric, float3x3) { testEigen3x3<float>(); }
 TEST(Core_EigenNonSymmetric, double3x3) { testEigen3x3<double>(); }
+
+typedef testing::TestWithParam<int> Core_EigenZero;
+TEST_P(Core_EigenZero, double)
+{
+    int N = GetParam();
+    Mat_<double> srcZero = Mat_<double>::zeros(N, N);
+    Mat_<double> expected_eigenvalueZero = Mat_<double>::zeros(N, 1);  // 1D Mat
+    testEigen(srcZero, expected_eigenvalueZero);
+    testEigen(srcZero, expected_eigenvalueZero, true);
+}
+INSTANTIATE_TEST_CASE_P(/**/, Core_EigenZero, testing::Values(2, 3, 5));
 
 }} // namespace


### PR DESCRIPTION
resolves #10948 


Fixed a bug that caused an infinite loop if norm value was zero.

I made a mistake in my operation, I deleted the pull request.
>alalek 
>if (norm == 0.0)
>This condition may not work in some cases (like norm=1e-100). 
>Perhaps we should use if (fabs(norm) < FLT_EPSILON) instead.
-> I think so, too. Since norm is an absolute value, I think that it is not necessary to perform abs conversion again.