### PR TITLE
core: added checks and "fixit" items for persistence parsers

### DIFF
--- a/modules/core/src/persistence.cpp
+++ b/modules/core/src/persistence.cpp
@@ -59,16 +59,33 @@ char* icvGets( CvFileStorage* fs, char* str, int maxCount )
         }
         str[j++] = '\0';
         fs->strbufpos = i;
+        if (maxCount > 256)
+            CV_Assert(j < maxCount - 1 && "OpenCV persistence doesn't support very long lines");
         return j > 1 ? str : 0;
     }
     if( fs->file )
-        return fgets( str, maxCount, fs->file );
+    {
+        char* ptr = fgets( str, maxCount, fs->file );
+        if (ptr && maxCount > 256)
+        {
+            size_t sz = strnlen(ptr, maxCount);
+            CV_Assert(sz < (size_t)(maxCount - 1) && "OpenCV persistence doesn't support very long lines");
+        }
+        return ptr;
+    }
 #if USE_ZLIB
     if( fs->gzfile )
-        return gzgets( fs->gzfile, str, maxCount );
+    {
+        char* ptr = gzgets( fs->gzfile, str, maxCount );
+        if (ptr && maxCount > 256)
+        {
+            size_t sz = strnlen(ptr, maxCount);
+            CV_Assert(sz < (size_t)(maxCount - 1) && "OpenCV persistence doesn't support very long lines");
+        }
+        return ptr;
+    }
 #endif
-    CV_Error( CV_StsError, "The storage is not opened" );
-    return 0;
+    CV_ErrorNoReturn(CV_StsError, "The storage is not opened");
 }
 
 int icvEof( CvFileStorage* fs )

--- a/modules/core/src/persistence.cpp
+++ b/modules/core/src/persistence.cpp
@@ -59,14 +59,14 @@ char* icvGets( CvFileStorage* fs, char* str, int maxCount )
         }
         str[j++] = '\0';
         fs->strbufpos = i;
-        if (maxCount > 256)
+        if (maxCount > 256 && !(fs->flags & cv::FileStorage::BASE64))
             CV_Assert(j < maxCount - 1 && "OpenCV persistence doesn't support very long lines");
         return j > 1 ? str : 0;
     }
     if( fs->file )
     {
         char* ptr = fgets( str, maxCount, fs->file );
-        if (ptr && maxCount > 256)
+        if (ptr && maxCount > 256 && !(fs->flags & cv::FileStorage::BASE64))
         {
             size_t sz = strnlen(ptr, maxCount);
             CV_Assert(sz < (size_t)(maxCount - 1) && "OpenCV persistence doesn't support very long lines");
@@ -77,7 +77,7 @@ char* icvGets( CvFileStorage* fs, char* str, int maxCount )
     if( fs->gzfile )
     {
         char* ptr = gzgets( fs->gzfile, str, maxCount );
-        if (ptr && maxCount > 256)
+        if (ptr && maxCount > 256 && !(fs->flags & cv::FileStorage::BASE64))
         {
             size_t sz = strnlen(ptr, maxCount);
             CV_Assert(sz < (size_t)(maxCount - 1) && "OpenCV persistence doesn't support very long lines");

--- a/modules/core/src/persistence.hpp
+++ b/modules/core/src/persistence.hpp
@@ -321,4 +321,8 @@ void icvJSONWriteReal( CvFileStorage* fs, const char* key, double value );
 void icvJSONWriteString( CvFileStorage* fs, const char* key, const char* str, int quote CV_DEFAULT(0));
 void icvJSONWriteComment( CvFileStorage* fs, const char* comment, int eol_comment );
 
+// Adding icvGets is not enough - we need to merge buffer contents (see #11061)
+#define CV_PERSISTENCE_CHECK_END_OF_BUFFER_BUG() \
+    CV_Assert((ptr[0] != 0 || ptr != fs->buffer_end - 1) && "OpenCV persistence doesn't support very long lines")
+
 #endif // SRC_PERSISTENCE_HPP

--- a/modules/core/src/persistence_json.cpp
+++ b/modules/core/src/persistence_json.cpp
@@ -125,8 +125,10 @@ static char* icvJSONParseKey( CvFileStorage* fs, char* ptr, CvFileNode* map, CvF
     char * beg = ptr + 1;
     char * end = beg;
 
-    do ++ptr;
-    while( cv_isprint(*ptr) && *ptr != '"' );
+    do {
+        ++ptr;
+        CV_PERSISTENCE_CHECK_END_OF_BUFFER_BUG();
+    } while( cv_isprint(*ptr) && *ptr != '"' );
 
     if( *ptr != '"' )
         CV_PARSE_ERROR( "Key must end with \'\"\'" );
@@ -367,17 +369,25 @@ static char* icvJSONParseValue( CvFileStorage* fs, char* ptr, CvFileNode* node )
     {    /**************** number ****************/
         char * beg = ptr;
         if ( *ptr == '+' || *ptr == '-' )
+        {
             ptr++;
+            CV_PERSISTENCE_CHECK_END_OF_BUFFER_BUG();
+        }
         while( cv_isdigit(*ptr) )
+        {
             ptr++;
+            CV_PERSISTENCE_CHECK_END_OF_BUFFER_BUG();
+        }
         if (*ptr == '.' || *ptr == 'e')
         {
             node->data.f = icv_strtod( fs, beg, &ptr );
+            CV_PERSISTENCE_CHECK_END_OF_BUFFER_BUG();
             node->tag = CV_NODE_REAL;
         }
         else
         {
             node->data.i = static_cast<int>(strtol( beg, &ptr, 0 ));
+            CV_PERSISTENCE_CHECK_END_OF_BUFFER_BUG();
             node->tag = CV_NODE_INT;
         }
 
@@ -388,8 +398,12 @@ static char* icvJSONParseValue( CvFileStorage* fs, char* ptr, CvFileNode* node )
     {    /**************** other data ****************/
         const char * beg = ptr;
         size_t len = 0u;
-        for ( ; cv_isalpha(*ptr) && len <= 6u; ptr++ )
+        for ( ; cv_isalpha(*ptr) && len <= 6u; )
+        {
             len++;
+            ptr++;
+            CV_PERSISTENCE_CHECK_END_OF_BUFFER_BUG();
+        }
 
         if ( len >= 4u && memcmp( beg, "null", 4u ) == 0 )
         {

--- a/modules/core/src/persistence_yml.cpp
+++ b/modules/core/src/persistence_yml.cpp
@@ -51,7 +51,7 @@ static char* icvYMLSkipSpaces( CvFileStorage* fs, char* ptr, int min_indent, int
                     CV_PARSE_ERROR( "Too long string or a last string w/o newline" );
             }
 
-            fs->lineno++;
+            fs->lineno++;  // FIXIT doesn't really work with long lines. It must be counted via '\n' or '\r' symbols, not the number of icvGets() calls.
         }
         else
             CV_PARSE_ERROR( *ptr == '\t' ? "Tabs are prohibited in YAML!" : "Invalid character" );
@@ -331,6 +331,7 @@ force_int:
             CV_PARSE_ERROR( "Invalid numeric value (inconsistent explicit type specification?)" );
 
         ptr = endptr;
+        CV_PERSISTENCE_CHECK_END_OF_BUFFER_BUG();
     }
     else if( c == '\'' || c == '\"' ) // an explicit string
     {


### PR DESCRIPTION
To raise errors with proper messages of the problems.

related #11061 

```
allow_multiple_commits=1
```