### PR TITLE
core: use explicit for cv::AutoBuffer

### DIFF
--- a/modules/core/include/opencv2/core/private.hpp
+++ b/modules/core/include/opencv2/core/private.hpp
@@ -472,7 +472,7 @@ class IppAutoBuffer
 {
 public:
     IppAutoBuffer() { m_size = 0; m_pBuffer = NULL; }
-    IppAutoBuffer(size_t size) { m_size = 0; m_pBuffer = NULL; allocate(size); }
+    explicit IppAutoBuffer(size_t size) { m_size = 0; m_pBuffer = NULL; allocate(size); }
     ~IppAutoBuffer() { deallocate(); }
     T* allocate(size_t size)   { if(m_size < size) { deallocate(); m_pBuffer = (T*)CV_IPP_MALLOC(size); m_size = size; } return m_pBuffer; }
     void deallocate() { if(m_pBuffer) { ippFree(m_pBuffer); m_pBuffer = NULL; } m_size = 0; }

--- a/modules/core/include/opencv2/core/utility.hpp
+++ b/modules/core/include/opencv2/core/utility.hpp
@@ -124,7 +124,7 @@ public:
     //! the default constructor
     AutoBuffer();
     //! constructor taking the real buffer size
-    AutoBuffer(size_t _size);
+    explicit AutoBuffer(size_t _size);
 
     //! the copy constructor
     AutoBuffer(const AutoBuffer<_Tp, fixed_size>& buf);


### PR DESCRIPTION
To avoid compilation of this code:
- `buf = 0;`

This code can be received after refactoring of 1D `cv::Mat` to `cv::AutoBuffer`.
- `cv_mat = 0` calls `setTo()`.
- `cv::AutoBuffer` calls `allocate(0)`, - this is wrong.