### PR TITLE
Better text contrast of pixel brightness values in Qt window

### DIFF
--- a/modules/highgui/src/window_QT.cpp
+++ b/modules/highgui/src/window_QT.cpp
@@ -3094,6 +3094,11 @@ void DefaultViewPort::drawImgRegion(QPainter *painter)
             if (nbChannelOriginImage==CV_8UC1)
             {
                 QString val = tr("%1").arg(qRed(rgbValue));
+                int pixel_brightness_value = qRed(rgbValue);
+                int text_brightness_value = 0;
+
+                text_brightness_value = pixel_brightness_value > 127 ? pixel_brightness_value - 127 : 127 + pixel_brightness_value;
+                painter->setPen(QPen(QColor(text_brightness_value, text_brightness_value, text_brightness_value)));
                 painter->drawText(QRect(pos_in_view.x(),pos_in_view.y(),pixel_width,pixel_height),
                     Qt::AlignCenter, val);
             }


### PR DESCRIPTION
This offsets text brightness of pixel brightness values
by offsetting it by 127 to the curent pixel value.
The text is now readable even if pixels are black.

### This pullrequest changes

This PR changes the way pixel brightness values are displayed in the Qt window.
At this point, brightness values are printed using black font, so values are unreadable for black/dark
pixels. This patch offsets text brightness by 127 to the current pixel value, so it's always readable.

Screenshots of before and after states:

![before](https://user-images.githubusercontent.com/263425/37469397-748c891c-2865-11e8-833a-59f1b68fbe5e.png)

![after](https://user-images.githubusercontent.com/263425/37469395-74664bf8-2865-11e8-85f9-4d0f0444fd4b.png)