### PR TITLE
Fix crash on exit in opencv_annotation

### DIFF
--- a/apps/annotation/opencv_annotation.cpp
+++ b/apps/annotation/opencv_annotation.cpp
@@ -140,7 +140,6 @@ vector<Rect> get_annotations(Mat input_image)
         switch( key_pressed )
         {
         case 27:
-                destroyWindow(window_name);
                 stop = true;
                 break;
         case 99:


### PR DESCRIPTION
destroyWindow was called twice during completion of the
annotation procedure, resulting in a crash, and failure to write
an output file


### This pullrequest changes

This pull request drops extra call to destroyWindow in the opencv_annotate
