### PR TITLE
fixed samples/dnn/openpose.py

### DIFF
--- a/samples/dnn/openpose.py
+++ b/samples/dnn/openpose.py
@@ -82,7 +82,7 @@ while cv.waitKey(1) < 0:
         y = (frameHeight * point[1]) / out.shape[2]
 
         # Add a point if it's confidence is higher than threshold.
-        points.append((x, y) if conf > args.thr else None)
+        points.append((int(x), int(y)) if conf > args.thr else None)
 
     for pair in POSE_PAIRS:
         partFrom = pair[0]


### PR DESCRIPTION
resolves #11077

### This pullrequest changes
I converted the coordinate values used by drawing function from `float` to `int`.

#### input
![coco_val2014_000000000589](https://user-images.githubusercontent.com/2630323/37429041-7de98216-2811-11e8-99bb-75b7793a072a.jpg)

#### output
![openpose](https://user-images.githubusercontent.com/2630323/37429047-824644e8-2811-11e8-82be-44cf12b6e761.png)