### PR TITLE
Help CMake find OpenNI2 include path

### DIFF
--- a/cmake/OpenCVFindOpenNI2.cmake
+++ b/cmake/OpenCVFindOpenNI2.cmake
@@ -14,7 +14,7 @@ endif()
 
 if(WIN32)
     if(NOT (MSVC64 OR MINGW64))
-        find_file(OPENNI2_INCLUDES "OpenNI.h" PATHS "$ENV{OPEN_NI_INSTALL_PATH}Include" DOC "OpenNI2 c++ interface header")
+        find_file(OPENNI2_INCLUDES "OpenNI.h" PATHS $ENV{OPENNI2_INCLUDE} "$ENV{OPEN_NI_INSTALL_PATH}Include" DOC "OpenNI2 c++ interface header")
         find_library(OPENNI2_LIBRARY "OpenNI2" PATHS $ENV{OPENNI2_LIB} DOC "OpenNI2 library")
     else()
         find_file(OPENNI2_INCLUDES "OpenNI.h" PATHS $ENV{OPENNI2_INCLUDE64} "$ENV{OPEN_NI_INSTALL_PATH64}Include" DOC "OpenNI2 c++ interface header")


### PR DESCRIPTION
When compiling with OpenNI2 flag active for 32 bit windows, CMake will not be able to find OpenNI.h due to the environment path not set in OpenCVFindOpenNI2.cmake. This PR rectifies this issue.


### This pullrequest changes

Added the environment variable for OpenNI2 include folder so CMake can find OpenNI.h when compiling for 32 bit Windows.
