### PR TITLE
Reading Darknet from cv::FileStorage

### DIFF
--- a/modules/dnn/include/opencv2/dnn/dnn.hpp
+++ b/modules/dnn/include/opencv2/dnn/dnn.hpp
@@ -644,6 +644,14 @@ CV__DNN_EXPERIMENTAL_NS_BEGIN
     */
     CV_EXPORTS_W Net readNetFromDarknet(const String &cfgFile, const String &darknetModel = String());
 
+   /** @brief Reads a network model stored in <a href="https://pjreddie.com/darknet/">Darknet</a> model files.
+    *  @param cfgFile      file node to the .cfg file with text description of the network architecture.
+    *  @param darknetModel file node to the .weights file with learned network.
+    *  @returns Network object that ready to do forward, throw an exception in failure cases.
+    *  @returns Net object.
+    */
+    CV_EXPORTS_W Net readNetFromDarknet(const FileNode &cfgFile, const FileNode &darknetModel = FileNode());
+
     /** @brief Reads a network model stored in <a href="http://caffe.berkeleyvision.org">Caffe</a> framework's format.
       * @param prototxt   path to the .prototxt file with text description of the network architecture.
       * @param caffeModel path to the .caffemodel file with learned network.

--- a/modules/dnn/include/opencv2/dnn/dnn.hpp
+++ b/modules/dnn/include/opencv2/dnn/dnn.hpp
@@ -649,8 +649,8 @@ CV__DNN_EXPERIMENTAL_NS_BEGIN
      *  @param bufferModel A buffer contains a content of .weights file with learned network.
      *  @returns Net object.
      */
-    CV_EXPORTS_W Net readNetFromDarknet(const std::vector<char>& bufferCfg,
-                                        const std::vector<char>& bufferModel = std::vector<char>());
+    CV_EXPORTS_W Net readNetFromDarknet(const std::vector<uchar>& bufferCfg,
+                                        const std::vector<uchar>& bufferModel = std::vector<uchar>());
 
     /** @brief Reads a network model stored in <a href="https://pjreddie.com/darknet/">Darknet</a> model files.
      *  @param bufferCfg   A buffer contains a content of .cfg file with text description of the network architecture.
@@ -674,8 +674,8 @@ CV__DNN_EXPERIMENTAL_NS_BEGIN
       * @param bufferModel buffer containing the content of the .caffemodel file
       * @returns Net object.
       */
-    CV_EXPORTS_W Net readNetFromCaffe(const std::vector<char>& bufferProto,
-                                      const std::vector<char>& bufferModel = std::vector<char>());
+    CV_EXPORTS_W Net readNetFromCaffe(const std::vector<uchar>& bufferProto,
+                                      const std::vector<uchar>& bufferModel = std::vector<uchar>());
 
     /** @brief Reads a network model stored in Caffe model in memory.
       * @details This is an overloaded member function, provided for convenience.
@@ -703,8 +703,8 @@ CV__DNN_EXPERIMENTAL_NS_BEGIN
       * @param bufferConfig buffer containing the content of the pbtxt file
       * @returns Net object.
       */
-    CV_EXPORTS_W Net readNetFromTensorflow(const std::vector<char>& bufferModel,
-                                           const std::vector<char>& bufferConfig = std::vector<char>());
+    CV_EXPORTS_W Net readNetFromTensorflow(const std::vector<uchar>& bufferModel,
+                                           const std::vector<uchar>& bufferConfig = std::vector<uchar>());
 
     /** @brief Reads a network model stored in <a href="https://www.tensorflow.org/">TensorFlow</a> framework's format.
       * @details This is an overloaded member function, provided for convenience.
@@ -778,8 +778,8 @@ CV__DNN_EXPERIMENTAL_NS_BEGIN
       * @param[in] bufferConfig A buffer with a content of text file contains network configuration.
       * @returns Net object.
       */
-     CV_EXPORTS_W Net readNet(const String& framework, const std::vector<char>& bufferModel,
-                              const std::vector<char>& bufferConfig = std::vector<char>());
+     CV_EXPORTS_W Net readNet(const String& framework, const std::vector<uchar>& bufferModel,
+                              const std::vector<uchar>& bufferConfig = std::vector<uchar>());
 
     /** @brief Loads blob which was serialized as torch.Tensor object of Torch7 framework.
      *  @warning This function has the same limitations as readNetFromTorch().

--- a/modules/dnn/include/opencv2/dnn/dnn.hpp
+++ b/modules/dnn/include/opencv2/dnn/dnn.hpp
@@ -644,13 +644,23 @@ CV__DNN_EXPERIMENTAL_NS_BEGIN
     */
     CV_EXPORTS_W Net readNetFromDarknet(const String &cfgFile, const String &darknetModel = String());
 
-   /** @brief Reads a network model stored in <a href="https://pjreddie.com/darknet/">Darknet</a> model files.
-    *  @param cfgFile      file node to the .cfg file with text description of the network architecture.
-    *  @param darknetModel file node to the .weights file with learned network.
-    *  @returns Network object that ready to do forward, throw an exception in failure cases.
-    *  @returns Net object.
-    */
-    CV_EXPORTS_W Net readNetFromDarknet(const FileNode &cfgFile, const FileNode &darknetModel = FileNode());
+    /** @brief Reads a network model stored in <a href="https://pjreddie.com/darknet/">Darknet</a> model files.
+     *  @param bufferCfg   A buffer contains a content of .cfg file with text description of the network architecture.
+     *  @param bufferModel A buffer contains a content of .weights file with learned network.
+     *  @returns Net object.
+     */
+    CV_EXPORTS_W Net readNetFromDarknet(const std::vector<char>& bufferCfg,
+                                        const std::vector<char>& bufferModel = std::vector<char>());
+
+    /** @brief Reads a network model stored in <a href="https://pjreddie.com/darknet/">Darknet</a> model files.
+     *  @param bufferCfg   A buffer contains a content of .cfg file with text description of the network architecture.
+     *  @param lenCfg      Number of bytes to read from bufferCfg
+     *  @param bufferModel A buffer contains a content of .weights file with learned network.
+     *  @param lenModel    Number of bytes to read from bufferModel
+     *  @returns Net object.
+     */
+    CV_EXPORTS Net readNetFromDarknet(const char *bufferCfg, size_t lenCfg,
+                                      const char *bufferModel = NULL, size_t lenModel = 0);
 
     /** @brief Reads a network model stored in <a href="http://caffe.berkeleyvision.org">Caffe</a> framework's format.
       * @param prototxt   path to the .prototxt file with text description of the network architecture.
@@ -658,6 +668,14 @@ CV__DNN_EXPERIMENTAL_NS_BEGIN
       * @returns Net object.
       */
     CV_EXPORTS_W Net readNetFromCaffe(const String &prototxt, const String &caffeModel = String());
+
+    /** @brief Reads a network model stored in Caffe model in memory.
+      * @param bufferProto buffer containing the content of the .prototxt file
+      * @param bufferModel buffer containing the content of the .caffemodel file
+      * @returns Net object.
+      */
+    CV_EXPORTS_W Net readNetFromCaffe(const std::vector<char>& bufferProto,
+                                      const std::vector<char>& bufferModel = std::vector<char>());
 
     /** @brief Reads a network model stored in Caffe model in memory.
       * @details This is an overloaded member function, provided for convenience.
@@ -679,6 +697,14 @@ CV__DNN_EXPERIMENTAL_NS_BEGIN
       * @returns Net object.
       */
     CV_EXPORTS_W Net readNetFromTensorflow(const String &model, const String &config = String());
+
+    /** @brief Reads a network model stored in <a href="https://www.tensorflow.org/">TensorFlow</a> framework's format.
+      * @param bufferModel buffer containing the content of the pb file
+      * @param bufferConfig buffer containing the content of the pbtxt file
+      * @returns Net object.
+      */
+    CV_EXPORTS_W Net readNetFromTensorflow(const std::vector<char>& bufferModel,
+                                           const std::vector<char>& bufferConfig = std::vector<char>());
 
     /** @brief Reads a network model stored in <a href="https://www.tensorflow.org/">TensorFlow</a> framework's format.
       * @details This is an overloaded member function, provided for convenience.
@@ -742,6 +768,18 @@ CV__DNN_EXPERIMENTAL_NS_BEGIN
       * arguments does not matter.
       */
      CV_EXPORTS_W Net readNet(const String& model, const String& config = "", const String& framework = "");
+
+     /**
+      * @brief Read deep learning network represented in one of the supported formats.
+      * @details This is an overloaded member function, provided for convenience.
+      *          It differs from the above function only in what argument(s) it accepts.
+      * @param[in] framework    Name of origin framework.
+      * @param[in] bufferModel  A buffer with a content of binary file with weights
+      * @param[in] bufferConfig A buffer with a content of text file contains network configuration.
+      * @returns Net object.
+      */
+     CV_EXPORTS_W Net readNet(const String& framework, const std::vector<char>& bufferModel,
+                              const std::vector<char>& bufferConfig = std::vector<char>());
 
     /** @brief Loads blob which was serialized as torch.Tensor object of Torch7 framework.
      *  @warning This function has the same limitations as readNetFromTorch().

--- a/modules/dnn/misc/java/test/DnnTensorFlowTest.java
+++ b/modules/dnn/misc/java/test/DnnTensorFlowTest.java
@@ -1,10 +1,14 @@
 package org.opencv.test.dnn;
 
 import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import org.opencv.core.Core;
 import org.opencv.core.Mat;
+import org.opencv.core.MatOfFloat;
+import org.opencv.core.MatOfByte;
 import org.opencv.core.Scalar;
 import org.opencv.core.Size;
 import org.opencv.dnn.DictValue;
@@ -26,6 +30,15 @@ public class DnnTensorFlowTest extends OpenCVTestCase {
 
     Net net;
 
+    private static void normAssert(Mat ref, Mat test) {
+        final double l1 = 1e-5;
+        final double lInf = 1e-4;
+        double normL1 = Core.norm(ref, test, Core.NORM_L1) / ref.total();
+        double normLInf = Core.norm(ref, test, Core.NORM_INF) / ref.total();
+        assertTrue(normL1 < l1);
+        assertTrue(normLInf < lInf);
+    }
+
     @Override
     protected void setUp() throws Exception {
         super.setUp();
@@ -46,7 +59,7 @@ public class DnnTensorFlowTest extends OpenCVTestCase {
 
         File testDataPath = new File(envTestDataPath);
 
-        File f = new File(testDataPath, "dnn/space_shuttle.jpg");
+        File f = new File(testDataPath, "dnn/grace_hopper_227.png");
         sourceImageFile = f.toString();
         if(!f.exists()) throw new Exception("Test image is missing: " + sourceImageFile);
 
@@ -77,31 +90,55 @@ public class DnnTensorFlowTest extends OpenCVTestCase {
 
     }
 
-    public void testTestNetForward() {
-        Mat rawImage = Imgcodecs.imread(sourceImageFile);
+    public void checkInceptionNet(Net net)
+    {
+        Mat image = Imgcodecs.imread(sourceImageFile);
+        assertNotNull("Loading image from file failed!", image);
 
-        assertNotNull("Loading image from file failed!", rawImage);
-
-        Mat image = new Mat();
-        Imgproc.resize(rawImage, image, new Size(224,224));
-
-        Mat inputBlob = Dnn.blobFromImage(image);
+        Mat inputBlob = Dnn.blobFromImage(image, 1.0, new Size(224, 224), new Scalar(0), true, true);
         assertNotNull("Converting image to blob failed!", inputBlob);
 
-        Mat inputBlobP = new Mat();
-        Core.subtract(inputBlob, new Scalar(117.0), inputBlobP);
+        net.setInput(inputBlob, "input");
 
-        net.setInput(inputBlobP, "input" );
-
-        Mat result = net.forward();
-
+        Mat result = new Mat();
+        try {
+            net.setPreferableBackend(Dnn.DNN_BACKEND_OPENCV);
+            result = net.forward("softmax2");
+        }
+        catch (Exception e) {
+            fail("DNN forward failed: " + e.getMessage());
+        }
         assertNotNull("Net returned no result!", result);
 
-        Core.MinMaxLocResult minmax = Core.minMaxLoc(result.reshape(1, 1));
+        result = result.reshape(1, 1);
+        Core.MinMaxLocResult minmax = Core.minMaxLoc(result);
+        assertEquals("Wrong prediction", (int)minmax.maxLoc.x, 866);
 
-        assertTrue("No image recognized!", minmax.maxVal > 0.9);
+        Mat top5RefScores = new MatOfFloat(new float[] {
+            0.63032645f, 0.2561979f, 0.032181446f, 0.015721032f, 0.014785315f
+        }).reshape(1, 1);
 
+        Core.sort(result, result, Core.SORT_DESCENDING);
 
+        normAssert(result.colRange(0, 5), top5RefScores);
     }
 
+    public void testTestNetForward() {
+        checkInceptionNet(net);
+    }
+
+    public void testReadFromBuffer() {
+        File modelFile = new File(modelFileName);
+        byte[] modelBuffer = new byte[ (int)modelFile.length() ];
+
+        try {
+            FileInputStream fis = new FileInputStream(modelFile);
+            fis.read(modelBuffer);
+            fis.close();
+        } catch (IOException e) {
+            fail("Failed to read a model: " + e.getMessage());
+        }
+        net = Dnn.readNetFromTensorflow(new MatOfByte(modelBuffer));
+        checkInceptionNet(net);
+    }
 }

--- a/modules/dnn/src/caffe/caffe_importer.cpp
+++ b/modules/dnn/src/caffe/caffe_importer.cpp
@@ -453,10 +453,13 @@ Net readNetFromCaffe(const char *bufferProto, size_t lenProto,
     return net;
 }
 
-Net readNetFromCaffe(const std::vector<char>& bufferProto, const std::vector<char>& bufferModel)
+Net readNetFromCaffe(const std::vector<uchar>& bufferProto, const std::vector<uchar>& bufferModel)
 {
-    return readNetFromCaffe(&bufferProto[0], bufferProto.size(),
-                            bufferModel.empty() ? NULL : &bufferModel[0], bufferModel.size());
+    const char* bufferProtoPtr = reinterpret_cast<const char*>(&bufferProto[0]);
+    const char* bufferModelPtr = bufferModel.empty() ? NULL :
+                                 reinterpret_cast<const char*>(&bufferModel[0]);
+    return readNetFromCaffe(bufferProtoPtr, bufferProto.size(),
+                            bufferModelPtr, bufferModel.size());
 }
 
 #endif //HAVE_PROTOBUF

--- a/modules/dnn/src/caffe/caffe_importer.cpp
+++ b/modules/dnn/src/caffe/caffe_importer.cpp
@@ -453,6 +453,12 @@ Net readNetFromCaffe(const char *bufferProto, size_t lenProto,
     return net;
 }
 
+Net readNetFromCaffe(const std::vector<char>& bufferProto, const std::vector<char>& bufferModel)
+{
+    return readNetFromCaffe(&bufferProto[0], bufferProto.size(),
+                            bufferModel.empty() ? NULL : &bufferModel[0], bufferModel.size());
+}
+
 #endif //HAVE_PROTOBUF
 
 CV__DNN_EXPERIMENTAL_NS_END

--- a/modules/dnn/src/darknet/darknet_importer.cpp
+++ b/modules/dnn/src/darknet/darknet_importer.cpp
@@ -44,6 +44,7 @@
 #include "../precomp.hpp"
 
 #include <iostream>
+#include <fstream>
 #include <algorithm>
 #include <vector>
 #include <map>
@@ -66,14 +67,19 @@ public:
 
     DarknetImporter() {}
 
-    DarknetImporter(const char *cfgFile, const char *darknetModel)
+    DarknetImporter(std::istream &cfgStream, std::istream &darknetModelStream)
     {
         CV_TRACE_FUNCTION();
 
-        ReadNetParamsFromCfgFileOrDie(cfgFile, &net);
+        ReadNetParamsFromCfgStreamOrDie(cfgStream, &net);
+        ReadNetParamsFromBinaryStreamOrDie(darknetModelStream, &net);
+    }
 
-        if (darknetModel && darknetModel[0])
-            ReadNetParamsFromBinaryFileOrDie(darknetModel, &net);
+    DarknetImporter(std::istream &cfgStream)
+    {
+        CV_TRACE_FUNCTION();
+
+        ReadNetParamsFromCfgStreamOrDie(cfgStream, &net);
     }
 
     struct BlobNote
@@ -179,7 +185,38 @@ public:
 
 Net readNetFromDarknet(const String &cfgFile, const String &darknetModel /*= String()*/)
 {
-    DarknetImporter darknetImporter(cfgFile.c_str(), darknetModel.c_str());
+    Net net;
+    std::ifstream cfgStream(cfgFile.c_str());
+    if(!cfgStream.is_open()) {
+        CV_Error(cv::Error::StsParseError, "Failed to parse NetParameter file: " + std::string(cfgFile));
+        return net;
+    }
+    DarknetImporter darknetImporter;
+    if (darknetModel != String()) {
+        std::ifstream darknetModelStream(darknetModel.c_str());
+        if(!darknetModelStream.is_open()){
+            CV_Error(cv::Error::StsParseError, "Failed to parse NetParameter file: " + std::string(darknetModel));
+            return net;
+        }
+        darknetImporter = DarknetImporter(cfgStream, darknetModelStream);
+    } else {
+        darknetImporter = DarknetImporter(cfgStream);
+    }
+    darknetImporter.populateNet(net);
+    return net;
+}
+
+Net readNetFromDarknet(const FileNode &cfgFile, const FileNode &darknetModel /*= FileNode()*/)
+{
+    DarknetImporter darknetImporter;
+    if(darknetModel.empty()){
+        std::istringstream cfgStream((std::string)cfgFile);
+        darknetImporter = DarknetImporter(cfgStream);
+    }else{
+        std::istringstream cfgStream((std::string)cfgFile);
+        std::istringstream darknetModelStream((std::string)darknetModel);
+        darknetImporter = DarknetImporter(cfgStream, darknetModelStream);
+    }
     Net net;
     darknetImporter.populateNet(net);
     return net;

--- a/modules/dnn/src/darknet/darknet_importer.cpp
+++ b/modules/dnn/src/darknet/darknet_importer.cpp
@@ -242,10 +242,13 @@ Net readNetFromDarknet(const char *bufferCfg, size_t lenCfg, const char *bufferM
         return readNetFromDarknet(cfgStream);
 }
 
-Net readNetFromDarknet(const std::vector<char>& bufferCfg, const std::vector<char>& bufferModel)
+Net readNetFromDarknet(const std::vector<uchar>& bufferCfg, const std::vector<uchar>& bufferModel)
 {
-    return readNetFromDarknet(&bufferCfg[0], bufferCfg.size(),
-                              bufferModel.empty() ? NULL : &bufferModel[0], bufferModel.size());
+    const char* bufferCfgPtr = reinterpret_cast<const char*>(&bufferCfg[0]);
+    const char* bufferModelPtr = bufferModel.empty() ? NULL :
+                                 reinterpret_cast<const char*>(&bufferModel[0]);
+    return readNetFromDarknet(bufferCfgPtr, bufferCfg.size(),
+                              bufferModelPtr, bufferModel.size());
 }
 
 CV__DNN_EXPERIMENTAL_NS_END

--- a/modules/dnn/src/darknet/darknet_io.cpp
+++ b/modules/dnn/src/darknet/darknet_io.cpp
@@ -476,68 +476,61 @@ namespace cv {
                 return dst;
             }
 
-            bool ReadDarknetFromCfgFile(const char *cfgFile, NetParameter *net)
+            bool ReadDarknetFromCfgStream(std::istream &ifile, NetParameter *net)
             {
-                std::ifstream ifile;
-                ifile.open(cfgFile);
-                if (ifile.is_open())
-                {
-                    bool read_net = false;
-                    int layers_counter = -1;
-                    for (std::string line; std::getline(ifile, line);) {
-                        line = escapeString(line);
-                        if (line.empty()) continue;
-                        switch (line[0]) {
-                        case '\0': break;
-                        case '#': break;
-                        case ';': break;
-                        case '[':
-                            if (line == "[net]") {
-                                read_net = true;
-                            }
-                            else {
-                                // read section
-                                read_net = false;
-                                ++layers_counter;
-                                const size_t layer_type_size = line.find("]") - 1;
-                                CV_Assert(layer_type_size < line.size());
-                                std::string layer_type = line.substr(1, layer_type_size);
-                                net->layers_cfg[layers_counter]["type"] = layer_type;
-                            }
-                            break;
-                        default:
-                            // read entry
-                            const size_t separator_index = line.find('=');
-                            CV_Assert(separator_index < line.size());
-                            if (separator_index != std::string::npos) {
-                                std::string name = line.substr(0, separator_index);
-                                std::string value = line.substr(separator_index + 1, line.size() - (separator_index + 1));
-                                name = escapeString(name);
-                                value = escapeString(value);
-                                if (name.empty() || value.empty()) continue;
-                                if (read_net)
-                                    net->net_cfg[name] = value;
-                                else
-                                    net->layers_cfg[layers_counter][name] = value;
-                            }
+                bool read_net = false;
+                int layers_counter = -1;
+                for (std::string line; std::getline(ifile, line);) {
+                    line = escapeString(line);
+                    if (line.empty()) continue;
+                    switch (line[0]) {
+                    case '\0': break;
+                    case '#': break;
+                    case ';': break;
+                    case '[':
+                        if (line == "[net]") {
+                            read_net = true;
+                        }
+                        else {
+                            // read section
+                            read_net = false;
+                            ++layers_counter;
+                            const size_t layer_type_size = line.find("]") - 1;
+                            CV_Assert(layer_type_size < line.size());
+                            std::string layer_type = line.substr(1, layer_type_size);
+                            net->layers_cfg[layers_counter]["type"] = layer_type;
+                        }
+                        break;
+                    default:
+                        // read entry
+                        const size_t separator_index = line.find('=');
+                        CV_Assert(separator_index < line.size());
+                        if (separator_index != std::string::npos) {
+                            std::string name = line.substr(0, separator_index);
+                            std::string value = line.substr(separator_index + 1, line.size() - (separator_index + 1));
+                            name = escapeString(name);
+                            value = escapeString(value);
+                            if (name.empty() || value.empty()) continue;
+                            if (read_net)
+                                net->net_cfg[name] = value;
+                            else
+                                net->layers_cfg[layers_counter][name] = value;
                         }
                     }
-
-                    std::string anchors = net->layers_cfg[net->layers_cfg.size() - 1]["anchors"];
-                    std::vector<float> vec = getNumbers<float>(anchors);
-                    std::map<std::string, std::string> &net_params = net->net_cfg;
-                    net->width = getParam(net_params, "width", 416);
-                    net->height = getParam(net_params, "height", 416);
-                    net->channels = getParam(net_params, "channels", 3);
-                    CV_Assert(net->width > 0 && net->height > 0 && net->channels > 0);
                 }
-                else
-                    return false;
+
+                std::string anchors = net->layers_cfg[net->layers_cfg.size() - 1]["anchors"];
+                std::vector<float> vec = getNumbers<float>(anchors);
+                std::map<std::string, std::string> &net_params = net->net_cfg;
+                net->width = getParam(net_params, "width", 416);
+                net->height = getParam(net_params, "height", 416);
+                net->channels = getParam(net_params, "channels", 3);
+                CV_Assert(net->width > 0 && net->height > 0 && net->channels > 0);
 
                 int current_channels = net->channels;
                 net->out_channels_vec.resize(net->layers_cfg.size());
 
-                int layers_counter = -1;
+                layers_counter = -1;
 
                 setLayersParams setParams(net);
 
@@ -676,13 +669,8 @@ namespace cv {
                 return true;
             }
 
-
-            bool ReadDarknetFromWeightsFile(const char *darknetModel, NetParameter *net)
+            bool ReadDarknetFromWeightsStream(std::istream &ifile, NetParameter *net)
             {
-                std::ifstream ifile;
-                ifile.open(darknetModel, std::ios::binary);
-                CV_Assert(ifile.is_open());
-
                 int32_t major_ver, minor_ver, revision;
                 ifile.read(reinterpret_cast<char *>(&major_ver), sizeof(int32_t));
                 ifile.read(reinterpret_cast<char *>(&minor_ver), sizeof(int32_t));
@@ -778,19 +766,18 @@ namespace cv {
         }
 
 
-        void ReadNetParamsFromCfgFileOrDie(const char *cfgFile, darknet::NetParameter *net)
+        void ReadNetParamsFromCfgStreamOrDie(std::istream &ifile, darknet::NetParameter *net)
         {
-            if (!darknet::ReadDarknetFromCfgFile(cfgFile, net)) {
-                CV_Error(cv::Error::StsParseError, "Failed to parse NetParameter file: " + std::string(cfgFile));
+            if (!darknet::ReadDarknetFromCfgStream(ifile, net)) {
+                CV_Error(cv::Error::StsParseError, "Failed to parse NetParameter stream");
             }
         }
 
-        void ReadNetParamsFromBinaryFileOrDie(const char *darknetModel, darknet::NetParameter *net)
+        void ReadNetParamsFromBinaryStreamOrDie(std::istream &ifile, darknet::NetParameter *net)
         {
-            if (!darknet::ReadDarknetFromWeightsFile(darknetModel, net)) {
-                CV_Error(cv::Error::StsParseError, "Failed to parse NetParameter file: " + std::string(darknetModel));
+            if (!darknet::ReadDarknetFromWeightsStream(ifile, net)) {
+                CV_Error(cv::Error::StsParseError, "Failed to parse NetParameter stream");
             }
         }
-
     }
 }

--- a/modules/dnn/src/darknet/darknet_io.hpp
+++ b/modules/dnn/src/darknet/darknet_io.hpp
@@ -109,10 +109,9 @@ namespace cv {
             };
         }
 
-        // Read parameters from a file into a NetParameter message.
-        void ReadNetParamsFromCfgFileOrDie(const char *cfgFile, darknet::NetParameter *net);
-        void ReadNetParamsFromBinaryFileOrDie(const char *darknetModel, darknet::NetParameter *net);
-
+        // Read parameters from a stream into a NetParameter message.
+        void ReadNetParamsFromCfgStreamOrDie(std::istream &ifile, darknet::NetParameter *net);
+        void ReadNetParamsFromBinaryStreamOrDie(std::istream &ifile, darknet::NetParameter *net);
     }
 }
 #endif

--- a/modules/dnn/src/dnn.cpp
+++ b/modules/dnn/src/dnn.cpp
@@ -3047,6 +3047,23 @@ Net readNet(const String& _model, const String& _config, const String& _framewor
                                       model + (config.empty() ? "" : ", " + config));
 }
 
+Net readNet(const String& _framework, const std::vector<char>& bufferModel,
+            const std::vector<char>& bufferConfig)
+{
+    String framework = _framework.toLowerCase();
+    if (framework == "caffe")
+        return readNetFromCaffe(bufferConfig, bufferModel);
+    else if (framework == "tensorflow")
+        return readNetFromTensorflow(bufferModel, bufferConfig);
+    else if (framework == "darknet")
+        return readNetFromDarknet(bufferConfig, bufferModel);
+    else if (framework == "torch")
+        CV_Error(Error::StsNotImplemented, "Reading Torch models from buffers");
+    else if (framework == "dldt")
+        CV_Error(Error::StsNotImplemented, "Reading Intel's Model Optimizer models from buffers");
+    CV_Error(Error::StsError, "Cannot determine an origin framework with a name " + framework);
+}
+
 Net readNetFromModelOptimizer(const String &xml, const String &bin)
 {
     return Net::readFromModelOptimizer(xml, bin);

--- a/modules/dnn/src/dnn.cpp
+++ b/modules/dnn/src/dnn.cpp
@@ -3047,8 +3047,8 @@ Net readNet(const String& _model, const String& _config, const String& _framewor
                                       model + (config.empty() ? "" : ", " + config));
 }
 
-Net readNet(const String& _framework, const std::vector<char>& bufferModel,
-            const std::vector<char>& bufferConfig)
+Net readNet(const String& _framework, const std::vector<uchar>& bufferModel,
+            const std::vector<uchar>& bufferConfig)
 {
     String framework = _framework.toLowerCase();
     if (framework == "caffe")

--- a/modules/dnn/src/tensorflow/tf_importer.cpp
+++ b/modules/dnn/src/tensorflow/tf_importer.cpp
@@ -1856,10 +1856,13 @@ Net readNetFromTensorflow(const char* bufferModel, size_t lenModel,
     return net;
 }
 
-Net readNetFromTensorflow(const std::vector<char>& bufferModel, const std::vector<char>& bufferConfig)
+Net readNetFromTensorflow(const std::vector<uchar>& bufferModel, const std::vector<uchar>& bufferConfig)
 {
-    return readNetFromCaffe(&bufferModel[0], bufferModel.size(),
-                            bufferConfig.empty() ? NULL : &bufferConfig[0], bufferConfig.size());
+    const char* bufferModelPtr = reinterpret_cast<const char*>(&bufferModel[0]);
+    const char* bufferConfigPtr = bufferConfig.empty() ? NULL :
+                                  reinterpret_cast<const char*>(&bufferConfig[0]);
+    return readNetFromTensorflow(bufferModelPtr, bufferModel.size(),
+                                 bufferConfigPtr, bufferConfig.size());
 }
 
 CV__DNN_EXPERIMENTAL_NS_END

--- a/modules/dnn/src/tensorflow/tf_importer.cpp
+++ b/modules/dnn/src/tensorflow/tf_importer.cpp
@@ -1856,5 +1856,11 @@ Net readNetFromTensorflow(const char* bufferModel, size_t lenModel,
     return net;
 }
 
+Net readNetFromTensorflow(const std::vector<char>& bufferModel, const std::vector<char>& bufferConfig)
+{
+    return readNetFromCaffe(&bufferModel[0], bufferModel.size(),
+                            bufferConfig.empty() ? NULL : &bufferConfig[0], bufferConfig.size());
+}
+
 CV__DNN_EXPERIMENTAL_NS_END
 }} // namespace

--- a/modules/dnn/test/test_darknet_importer.cpp
+++ b/modules/dnn/test/test_darknet_importer.cpp
@@ -65,6 +65,18 @@ TEST(Test_Darknet, read_yolo_voc)
     ASSERT_FALSE(net.empty());
 }
 
+TEST(Test_Darknet, read_filestorage_yolo_voc)
+{
+    std::ifstream ifile(_tf("yolo-voc.cfg").c_str());
+    std::stringstream buffer;
+    buffer << " " << ifile.rdbuf(); // FIXME: FileStorage drops first character.
+    FileStorage ofs(".xml", FileStorage::WRITE | FileStorage::MEMORY);
+    ofs.write("cfgFile", buffer.str());
+    FileStorage ifs(ofs.releaseAndGetString(), FileStorage::READ | FileStorage::MEMORY | FileStorage::FORMAT_XML);
+    Net net = readNetFromDarknet(ifs["cfgFile"]);
+    ASSERT_FALSE(net.empty());
+}
+
 class Test_Darknet_layers : public DNNTestLayer
 {
 public:


### PR DESCRIPTION
### This pullrequest changes
I added new constructor for DarknetImporter to load from std::istream.
Current constructor gets to two pathnames which are raw strings. Without std::filesystem of C++17, some pathname has problem for cross-platform development. This changes makes abstractly to load files.

<cut/>

```c++
std::ifstream cfg("path/to/cfg");
std::ifstream model("path/to/model");
Net net = readNetFromDarknet(cfg, model);
```
And more, by this changes we will be able to include resources into binary, like followings.

```c++
std::istringstream cfg("some configuration text");
std::ifstream model("path/to/model");
Net net = readNetFromDarknet(cfg, model);
```

```
allow_multiple_commits=1
```