### PR TITLE
test_buffer_pool: synchronize after async copy

### DIFF
--- a/modules/cudaarithm/test/test_buffer_pool.cpp
+++ b/modules/cudaarithm/test/test_buffer_pool.cpp
@@ -93,6 +93,8 @@ CUDA_TEST_P(BufferPoolTest, FromNullStream)
 
     RunSimpleTest(Stream::Null(), dst_1, dst_2);
 
+    cudaSafeCall(cudaDeviceSynchronize());
+
     CheckSimpleTest(dst_1, dst_2);
 }
 


### PR DESCRIPTION
`RunSimpleTest` has non-blocking memory copy. It would be preferred to synchronize before comparing the copied value at `CheckSimpleTest`.

```
force_builders=Custom
docker_image:Custom=ubuntu-cuda:16.04
```