### PR TITLE
cmake: don't add include <module>/src directory to avoid conflicts

### DIFF
--- a/cmake/OpenCVCompilerOptimizations.cmake
+++ b/cmake/OpenCVCompilerOptimizations.cmake
@@ -743,11 +743,11 @@ endmacro()
 macro(ocv_add_dispatched_file filename)
   if(NOT OPENCV_INITIAL_PASS)
     set(__codestr "
-#include \"precomp.hpp\"
-#include \"${filename}.simd.hpp\"
+#include \"${CMAKE_CURRENT_LIST_DIR}/src/precomp.hpp\"
+#include \"${CMAKE_CURRENT_LIST_DIR}/src/${filename}.simd.hpp\"
 ")
 
-    set(__declarations_str "#define CV_CPU_SIMD_FILENAME \"${filename}.simd.hpp\"")
+    set(__declarations_str "#define CV_CPU_SIMD_FILENAME \"${CMAKE_CURRENT_LIST_DIR}/src/${filename}.simd.hpp\"")
     set(__dispatch_modes "BASELINE")
 
     set(__optimizations "${ARGN}")

--- a/cmake/OpenCVModule.cmake
+++ b/cmake/OpenCVModule.cmake
@@ -700,7 +700,6 @@ endmacro()
 macro(ocv_module_include_directories)
   ocv_target_include_directories(${the_module}
       "${OPENCV_MODULE_${the_module}_LOCATION}/include"
-      "${OPENCV_MODULE_${the_module}_LOCATION}/src"
       "${CMAKE_CURRENT_BINARY_DIR}" # for precompiled headers
       )
   ocv_target_include_modules(${the_module} ${OPENCV_MODULE_${the_module}_DEPS} ${ARGN})

--- a/cmake/cl2cpp.cmake
+++ b/cmake/cl2cpp.cmake
@@ -17,7 +17,7 @@ set(nested_namespace_end "}")
 
 set(STR_CPP "// This file is auto-generated. Do not edit!
 
-#include \"precomp.hpp\"
+#include \"opencv2/core.hpp\"
 #include \"cvconfig.h\"
 #include \"${OUTPUT_HPP_NAME}\"
 

--- a/modules/core/src/logger.cpp
+++ b/modules/core/src/logger.cpp
@@ -2,7 +2,7 @@
 // It is subject to the license terms in the LICENSE file found in the top-level directory
 // of this distribution and at http://opencv.org/license.html.
 
-#include <precomp.hpp>
+#include "precomp.hpp"
 
 #include <opencv2/core/utils/configuration.private.hpp>
 #include <opencv2/core/utils/logger.hpp>

--- a/modules/core/src/trace.cpp
+++ b/modules/core/src/trace.cpp
@@ -2,7 +2,7 @@
 // It is subject to the license terms in the LICENSE file found in the top-level directory
 // of this distribution and at http://opencv.org/license.html.
 
-#include <precomp.hpp>
+#include "precomp.hpp"
 
 #include <opencv2/core/utils/trace.hpp>
 #include <opencv2/core/utils/trace.private.hpp>

--- a/modules/core/src/utils/filesystem.cpp
+++ b/modules/core/src/utils/filesystem.cpp
@@ -2,7 +2,7 @@
 // It is subject to the license terms in the LICENSE file found in the top-level directory
 // of this distribution and at http://opencv.org/license.html.
 
-#include "precomp.hpp"
+#include "../precomp.hpp"
 
 #include <opencv2/core/utils/configuration.private.hpp>
 

--- a/modules/dnn/src/layers/batch_norm_layer.cpp
+++ b/modules/dnn/src/layers/batch_norm_layer.cpp
@@ -10,8 +10,8 @@ Implementation of Batch Normalization layer.
 */
 
 #include "../precomp.hpp"
-#include "op_halide.hpp"
-#include "op_inf_engine.hpp"
+#include "../op_halide.hpp"
+#include "../op_inf_engine.hpp"
 #include <opencv2/dnn/shape_utils.hpp>
 
 #ifdef HAVE_OPENCL

--- a/modules/dnn/src/layers/concat_layer.cpp
+++ b/modules/dnn/src/layers/concat_layer.cpp
@@ -42,8 +42,8 @@
 
 #include "../precomp.hpp"
 #include "layers_common.hpp"
-#include "op_halide.hpp"
-#include "op_inf_engine.hpp"
+#include "../op_halide.hpp"
+#include "../op_inf_engine.hpp"
 
 #ifdef HAVE_OPENCL
 #include "opencl_kernels_dnn.hpp"

--- a/modules/dnn/src/layers/convolution_layer.cpp
+++ b/modules/dnn/src/layers/convolution_layer.cpp
@@ -42,8 +42,8 @@
 
 #include "../precomp.hpp"
 #include "layers_common.hpp"
-#include "op_halide.hpp"
-#include "op_inf_engine.hpp"
+#include "../op_halide.hpp"
+#include "../op_inf_engine.hpp"
 #include "opencv2/core/hal/hal.hpp"
 #include "opencv2/core/hal/intrin.hpp"
 #include <iostream>

--- a/modules/dnn/src/layers/detection_output_layer.cpp
+++ b/modules/dnn/src/layers/detection_output_layer.cpp
@@ -42,7 +42,7 @@
 
 #include "../precomp.hpp"
 #include "layers_common.hpp"
-#include "op_inf_engine.hpp"
+#include "../op_inf_engine.hpp"
 #include <float.h>
 #include <string>
 #include "../nms.inl.hpp"

--- a/modules/dnn/src/layers/elementwise_layers.cpp
+++ b/modules/dnn/src/layers/elementwise_layers.cpp
@@ -42,8 +42,8 @@
 
 #include "../precomp.hpp"
 #include "layers_common.hpp"
-#include "op_halide.hpp"
-#include "op_inf_engine.hpp"
+#include "../op_halide.hpp"
+#include "../op_inf_engine.hpp"
 #include "opencv2/imgproc.hpp"
 #include <opencv2/dnn/shape_utils.hpp>
 #include <iostream>

--- a/modules/dnn/src/layers/eltwise_layer.cpp
+++ b/modules/dnn/src/layers/eltwise_layer.cpp
@@ -42,8 +42,8 @@
 
 #include "../precomp.hpp"
 #include "layers_common.hpp"
-#include "op_halide.hpp"
-#include "op_inf_engine.hpp"
+#include "../op_halide.hpp"
+#include "../op_inf_engine.hpp"
 
 #ifdef HAVE_OPENCL
 #include "opencl_kernels_dnn.hpp"

--- a/modules/dnn/src/layers/flatten_layer.cpp
+++ b/modules/dnn/src/layers/flatten_layer.cpp
@@ -42,7 +42,7 @@
 
 #include "../precomp.hpp"
 #include "layers_common.hpp"
-#include "op_inf_engine.hpp"
+#include "../op_inf_engine.hpp"
 #include <float.h>
 #include <algorithm>
 #include <opencv2/dnn/shape_utils.hpp>

--- a/modules/dnn/src/layers/fully_connected_layer.cpp
+++ b/modules/dnn/src/layers/fully_connected_layer.cpp
@@ -42,8 +42,8 @@
 
 #include "../precomp.hpp"
 #include "layers_common.hpp"
-#include "op_halide.hpp"
-#include "op_inf_engine.hpp"
+#include "../op_halide.hpp"
+#include "../op_inf_engine.hpp"
 #include <opencv2/dnn/shape_utils.hpp>
 
 #ifdef HAVE_OPENCL

--- a/modules/dnn/src/layers/layers_common.hpp
+++ b/modules/dnn/src/layers/layers_common.hpp
@@ -47,7 +47,7 @@
 
 #define CV_CPU_OPTIMIZATION_DECLARATIONS_ONLY
 // dispatched AVX/AVX2 optimizations
-#include "layers/layers_common.simd.hpp"
+#include "./layers_common.simd.hpp"
 #include "layers/layers_common.simd_declarations.hpp"
 #undef CV_CPU_OPTIMIZATION_DECLARATIONS_ONLY
 

--- a/modules/dnn/src/layers/lrn_layer.cpp
+++ b/modules/dnn/src/layers/lrn_layer.cpp
@@ -42,8 +42,8 @@
 
 #include "../precomp.hpp"
 #include "layers_common.hpp"
-#include "op_halide.hpp"
-#include "op_inf_engine.hpp"
+#include "../op_halide.hpp"
+#include "../op_inf_engine.hpp"
 #include "opencv2/imgproc.hpp"
 #include "opencv2/dnn/shape_utils.hpp"
 #include "opencv2/core/hal/hal.hpp"

--- a/modules/dnn/src/layers/max_unpooling_layer.cpp
+++ b/modules/dnn/src/layers/max_unpooling_layer.cpp
@@ -11,7 +11,7 @@ Implementation of Batch Normalization layer.
 
 #include "../precomp.hpp"
 #include "layers_common.hpp"
-#include "op_halide.hpp"
+#include "../op_halide.hpp"
 #include <opencv2/dnn/shape_utils.hpp>
 
 #include <iostream>

--- a/modules/dnn/src/layers/padding_layer.cpp
+++ b/modules/dnn/src/layers/padding_layer.cpp
@@ -11,7 +11,7 @@ Implementation of padding layer, which adds paddings to input blob.
 
 #include "../precomp.hpp"
 #include "layers_common.hpp"
-#include "op_halide.hpp"
+#include "../op_halide.hpp"
 #include <vector>
 
 namespace cv

--- a/modules/dnn/src/layers/permute_layer.cpp
+++ b/modules/dnn/src/layers/permute_layer.cpp
@@ -42,7 +42,7 @@
 
 #include "../precomp.hpp"
 #include "layers_common.hpp"
-#include "op_inf_engine.hpp"
+#include "../op_inf_engine.hpp"
 #include <float.h>
 #include <algorithm>
 

--- a/modules/dnn/src/layers/pooling_layer.cpp
+++ b/modules/dnn/src/layers/pooling_layer.cpp
@@ -43,8 +43,8 @@
 #include "../precomp.hpp"
 #include "layers_common.hpp"
 #include "opencv2/core/hal/intrin.hpp"
-#include "op_halide.hpp"
-#include "op_inf_engine.hpp"
+#include "../op_halide.hpp"
+#include "../op_inf_engine.hpp"
 #include <float.h>
 #include <algorithm>
 using std::max;

--- a/modules/dnn/src/layers/prior_box_layer.cpp
+++ b/modules/dnn/src/layers/prior_box_layer.cpp
@@ -42,7 +42,7 @@
 
 #include "../precomp.hpp"
 #include "layers_common.hpp"
-#include "op_inf_engine.hpp"
+#include "../op_inf_engine.hpp"
 #include <float.h>
 #include <algorithm>
 #include <cmath>

--- a/modules/dnn/src/layers/region_layer.cpp
+++ b/modules/dnn/src/layers/region_layer.cpp
@@ -43,7 +43,7 @@
 #include "../precomp.hpp"
 #include <opencv2/dnn/shape_utils.hpp>
 #include <opencv2/dnn/all_layers.hpp>
-#include "nms.inl.hpp"
+#include "../nms.inl.hpp"
 
 #ifdef HAVE_OPENCL
 #include "opencl_kernels_dnn.hpp"

--- a/modules/dnn/src/layers/reshape_layer.cpp
+++ b/modules/dnn/src/layers/reshape_layer.cpp
@@ -42,7 +42,7 @@
 
 #include "../precomp.hpp"
 #include "layers_common.hpp"
-#include "op_inf_engine.hpp"
+#include "../op_inf_engine.hpp"
 #include <opencv2/dnn/shape_utils.hpp>
 
 namespace cv

--- a/modules/dnn/src/layers/scale_layer.cpp
+++ b/modules/dnn/src/layers/scale_layer.cpp
@@ -11,8 +11,8 @@ Implementation of Scale layer.
 
 #include "../precomp.hpp"
 #include "layers_common.hpp"
-#include "op_halide.hpp"
-#include "op_inf_engine.hpp"
+#include "../op_halide.hpp"
+#include "../op_inf_engine.hpp"
 #include <opencv2/dnn/shape_utils.hpp>
 
 namespace cv

--- a/modules/dnn/src/layers/shift_layer.cpp
+++ b/modules/dnn/src/layers/shift_layer.cpp
@@ -10,7 +10,7 @@ Implementation of shift layer, which adds up const values to blob.
 */
 
 #include "../precomp.hpp"
-#include "op_inf_engine.hpp"
+#include "../op_inf_engine.hpp"
 #include <opencv2/dnn/shape_utils.hpp>
 
 namespace cv

--- a/modules/dnn/src/layers/softmax_layer.cpp
+++ b/modules/dnn/src/layers/softmax_layer.cpp
@@ -42,8 +42,8 @@
 
 #include "../precomp.hpp"
 #include "layers_common.hpp"
-#include "op_halide.hpp"
-#include "op_inf_engine.hpp"
+#include "../op_halide.hpp"
+#include "../op_inf_engine.hpp"
 #include <algorithm>
 #include <stdlib.h>
 using std::max;

--- a/modules/dnn/src/nms.cpp
+++ b/modules/dnn/src/nms.cpp
@@ -6,7 +6,7 @@
 // Third party copyrights are property of their respective owners.
 
 #include "precomp.hpp"
-#include <nms.inl.hpp>
+#include "nms.inl.hpp"
 
 namespace cv
 {

--- a/modules/viz/src/precomp.hpp
+++ b/modules/viz/src/precomp.hpp
@@ -140,13 +140,13 @@
 # include <io.h> /* unlink */
 #endif
 
-#include <vtk/vtkOBJWriter.h>
-#include <vtk/vtkXYZWriter.h>
-#include <vtk/vtkXYZReader.h>
-#include <vtk/vtkCloudMatSink.h>
-#include <vtk/vtkCloudMatSource.h>
-#include <vtk/vtkTrajectorySource.h>
-#include <vtk/vtkImageMatSource.h>
+#include "vtk/vtkOBJWriter.h"
+#include "vtk/vtkXYZWriter.h"
+#include "vtk/vtkXYZReader.h"
+#include "vtk/vtkCloudMatSink.h"
+#include "vtk/vtkCloudMatSource.h"
+#include "vtk/vtkTrajectorySource.h"
+#include "vtk/vtkImageMatSource.h"
 
 
 #include <opencv2/core.hpp>


### PR DESCRIPTION
**Merge with contrib**: https://github.com/opencv/opencv_contrib/pull/1585

during opencv_world builds:
- opencv_world is target which includes all cpp files into project
- headers from "/src" can have similar names (especialy precomp.hpp or "utils.hpp", etc)
- including header files from "/src" should be done via relative path