### PR TITLE
Sets a higher limit on videoio's AVI container's maximum chunk size, …

### DIFF
--- a/modules/videoio/src/container_avi.cpp
+++ b/modules/videoio/src/container_avi.cpp
@@ -511,7 +511,12 @@ std::vector<char> AVIReadContainer::readFrame(frame_iterator it)
 
     RiffChunk chunk;
     *(m_file_stream) >> chunk;
-    CV_Assert(chunk.m_size <= 0xFFFF);
+
+    // Assertion added to prevent complaints from static analysis tools
+    // as the chunk size is read from a file then used to allocate
+    // memory. 64MB was chosen arbitrarily as an upper bound but it may
+    // be useful to make it configurable.
+    CV_Assert(chunk.m_size <= 67108864);
 
     std::vector<char> result;
 


### PR DESCRIPTION
…and adds an explanation of the assertion.

resolves #11126

### This pullrequest changes

The upper limit for the chunk size in the AVI video container implementation in `videoio` has been increased from 64KB (too small for practical applications) to 64MB. Also, an explanation of the assertion's function is included.