### PR TITLE
#include <math.h> in cv2.cpp

### DIFF
--- a/modules/python/src2/cv2.cpp
+++ b/modules/python/src2/cv2.cpp
@@ -4,6 +4,7 @@
 #pragma warning(push)
 #pragma warning(disable:5033)  // 'register' is no longer a supported storage class
 #endif
+#include <math.h>
 #include <Python.h>
 #if defined(_MSC_VER) && (_MSC_VER >= 1800)
 #pragma warning(pop)


### PR DESCRIPTION
My build fails with the error:
`C:/PROGRA~1/MINGW-~1/X86_64~1.0-P/mingw64/lib/gcc/x86_64-w64-mingw32/7.2.0/include/c++/cmath:1136:11: error: '::hypot' has not been declared`.
I have tried to fix it by adding `#include <cmath>` before the line `#include <Python.h>` but then the build has failed with the error:
`C:/PROGRA~1/MINGW-~1/X86_64~1.0-P/mingw64/lib/gcc/x86_64-w64-mingw32/7.2.0/include/c++/math.h:91:12:: error: 'std::_hypot' has not been declared`.
Adding `#include <math.h>` allowed me to build opencv.

OS: Windows 10 (x64)
Compiler: MINGW C++ 7.2.0
Flags: ENABLE_CXX11 = ON

<!-- Please use this line to close one or multiple issues when this pullrequest gets merged
You can add another line right under the first one:
resolves #1234
resolves #1235
-->

### This pullrequest changes

<!-- Please describe what your pullrequest is changing -->
