### PR TITLE
Minor improvement to SSE code in HOGDescriptor, issue #11161

### DIFF
--- a/modules/objdetect/src/hog.cpp
+++ b/modules/objdetect/src/hog.cpp
@@ -323,14 +323,10 @@ void HOGDescriptor::computeGradient(const Mat& img, Mat& grad, Mat& qangle,
         int end = gradsize.width + 2;
         xmap -= 1, x = 0;
 #if CV_SSE2
-        __m128i ithree = _mm_set1_epi32(3);
         for ( ; x <= end - 4; x += 4)
         {
-            //emulation of _mm_mullo_epi32
             __m128i mul_res = _mm_loadu_si128((const __m128i*)(xmap + x));
-            __m128i tmp1 = _mm_mul_epu32(ithree, mul_res);
-            __m128i tmp2 = _mm_mul_epu32( _mm_srli_si128(ithree,4), _mm_srli_si128(mul_res,4));
-            mul_res = _mm_unpacklo_epi32(_mm_shuffle_epi32(tmp1, _MM_SHUFFLE (0,0,2,0)), _mm_shuffle_epi32(tmp2, _MM_SHUFFLE (0,0,2,0)));
+            mul_res = _mm_add_epi32(_mm_add_epi32(mul_res, mul_res), mul_res); // multiply by 3
             _mm_storeu_si128((__m128i*)(xmap + x), mul_res);
         }
 #elif CV_NEON


### PR DESCRIPTION
### This pullrequest changes 

objdetect module, hog.cpp, minor SSE code improvement, near line 325

Minor improvement to SSE code in HOGDescriptor::computeGradient, replace emulation of _mm_mullo_epi32 with constant multiplicand 3 with two _mm_add_epi32. My PR does not use universal intrinsics, as I found out the code currently does not include the universal intrinsics headers, and I don't want to change that without having a discussion first. If universal intrinsics is needed, the entire file will need SIMD cleanup (e.g. the use of multi-indirection LUT).

resolves #11161 