### PR TITLE
Fix build issue in stiching module when CUDA Toolkit is enabled

### DIFF
--- a/modules/stitching/CMakeLists.txt
+++ b/modules/stitching/CMakeLists.txt
@@ -9,5 +9,5 @@ if(BUILD_SHARED_LIBS AND BUILD_opencv_world AND OPENCV_WORLD_EXCLUDE_EXTRA_MODUL
   set(STITCHING_CONTRIB_DEPS "")
 endif()
 ocv_define_module(stitching opencv_imgproc opencv_features2d opencv_calib3d opencv_flann
-                  OPTIONAL opencv_cudaarithm opencv_cudawarping opencv_cudafeatures2d opencv_cudalegacy ${STITCHING_CONTRIB_DEPS}
+                  OPTIONAL opencv_cudaarithm opencv_cudawarping opencv_cudafeatures2d opencv_cudalegacy opencv_cudaimgproc ${STITCHING_CONTRIB_DEPS}
                   WRAP python)


### PR DESCRIPTION
### This pullrequest changes

The patch changes CMakeLists.txt file to include 'opencv_cudaimgproc' module as a dependency of 'stiching' module. It resolves building issues when CUDA Toolkit is enabled for it. Without the patch, 'stiching' module is not built.