### PR TITLE
#11143 [FIX] Normalize node risk with sample weight sum

### DIFF
--- a/modules/ml/src/tree.cpp
+++ b/modules/ml/src/tree.cpp
@@ -632,6 +632,7 @@ void DTreesImpl::calcValue( int nidx, const vector<int>& _sidx )
         }
 
         node->node_risk = sum2 - (sum/sumw)*sum;
+        node->node_risk /= sumw;
         node->value = sum/sumw;
     }
 }


### PR DESCRIPTION
### This pullrequest changes

This pullrequest resolves #11143. 

In case of regression trees, node risk is computed as sum of squared error. To get a meaningful value to compare with it needs to be normalized to the number of samples in the node (or more generally to the sum of sample weights in this node). Otherwise the sum of squared error is highly depended on the number of samples in the node and comparison with `regressionAccuracy` parameter is not very meaningful.

After normalization `node_risk` means in fact sample variance for all samples in the node, which makes much more sense and seams to be what was originally intended by the code given that node risk is later used as a split termination criteria by
```
sqrt(node.node_risk) < params.getRegressionAccuracy()
```

<!-- Please use this line to close one or multiple issues when this pullrequest gets merged
You can add another line right under the first one:
resolves #11143 
-->




