### PR TITLE
Fix link to Hershey fonts in opencv2/core.hpp

### DIFF
--- a/modules/core/include/opencv2/core.hpp
+++ b/modules/core/include/opencv2/core.hpp
@@ -219,8 +219,7 @@ enum LineTypes {
     LINE_AA = 16 //!< antialiased line
 };
 
-//! Only a subset of Hershey fonts
-//! <http://sources.isc.org/utils/misc/hershey-font.txt> are supported
+//! Only a subset of Hershey fonts <https://en.wikipedia.org/wiki/Hershey_fonts> are supported
 enum HersheyFonts {
     FONT_HERSHEY_SIMPLEX        = 0, //!< normal size sans-serif font
     FONT_HERSHEY_PLAIN          = 1, //!< small size sans-serif font


### PR DESCRIPTION
resolves #11054

### This pullrequest changes

The [current link](https://sources.isc.org/utils/misc/hershey-font.txt) to the `hershey` fonts in `opencv2/core.hpp` at `sources.isc.org` is broken (404) and `isc.org` has been unresponsive after two weeks regarding alternative hosting where we might find the `hershey` font documentation. 

Documentation is also not available via the [web archive](https://www.web.archive.org/web/19981202040357/http://sources.isc.org/utils/misc/hershey-font.txt).

@alalek suggested we use [Wikipedia](https://en.wikipedia.org/wiki/Hershey_fonts) as an alternative.
