### PR TITLE
Fix minimal size proposals for SSDs from TensorFlow

### DIFF
--- a/samples/dnn/tf_text_graph_ssd.py
+++ b/samples/dnn/tf_text_graph_ssd.py
@@ -196,8 +196,8 @@ for i in range(args.num_layers):
     text_format.Merge('b: false', priorBox.attr["clip"])
 
     if i == 0:
-        widths = [args.min_scale * 0.5, args.min_scale * sqrt(2.0), args.min_scale * sqrt(0.5)]
-        heights = [args.min_scale * 0.5, args.min_scale / sqrt(2.0), args.min_scale / sqrt(0.5)]
+        widths = [0.1, args.min_scale * sqrt(2.0), args.min_scale * sqrt(0.5)]
+        heights = [0.1, args.min_scale / sqrt(2.0), args.min_scale / sqrt(0.5)]
     else:
         widths = [scales[i] * sqrt(ar) for ar in args.aspect_ratios]
         heights = [scales[i] / sqrt(ar) for ar in args.aspect_ratios]


### PR DESCRIPTION
<!-- Please use this line to close one or multiple issues when this pullrequest gets merged
You can add another line right under the first one:
resolves #1234
resolves #1235
-->

### This pullrequest changes

By default, `min_scale` equals to `0.2` so the smallest proposal's size computed by `0.2 * 0.5 = 0.1`. However that must be invariant to `min_scale` according to https://github.com/tensorflow/models/blob/78d5f8f89cd2f29d8f5cce6e4da34272298362d7/research/object_detection/anchor_generators/multiple_grid_anchor_generator.py#L322-L323.

related discussion: http://answers.opencv.org/question/186532/opencv-dnn-precision-loss-when-using-tensorflow-object-detection-model/#186710 (user got a problem with `min_size = 0.02`)
