### PR TITLE
Fix #10557

### DIFF
--- a/modules/core/src/opencl/cvtclr_dx.cl
+++ b/modules/core/src/opencl/cvtclr_dx.cl
@@ -92,9 +92,9 @@ void YUV2BGR_NV12_8u(
     int x = get_global_id(0);
     int y = get_global_id(1);
 
-    if (x < cols)
+    if (x + 1 < cols)
     {
-        if (y < rows)
+        if (y + 1 < rows)
         {
             __global uchar* pDstRow1 = pBGR + mad24(y, bgrStep, mad24(x, NCHANNELS, 0));
             __global uchar* pDstRow2 = pDstRow1 + bgrStep;


### PR DESCRIPTION
Fix overflow bugs in conversion from NV12 VA-surface/D3D11texture2D to OpenCL UMat

resolves #10557 

### This pullrequest changes

Fix bugs in x, y coordinate checks
