### PR TITLE
Add Python support for error message handlers.

### DIFF
--- a/modules/python/src2/cv2.cpp
+++ b/modules/python/src2/cv2.cpp
@@ -1733,7 +1733,7 @@ static int convert_to_char(PyObject *o, char *dst, const char *name = "no_name")
 #include "pyopencv_generated_funcs.h"
 
 static PyMethodDef special_methods[] = {
-  {"redirectError", (PyCFunction)pycvRedirectError, METH_VARARGS | METH_KEYWORDS, "redirectError(onError [, param]) -> None"},
+  {"redirectError", (PyCFunction)pycvRedirectError, METH_VARARGS | METH_KEYWORDS, "redirectError(onError) -> None"},
 #ifdef HAVE_OPENCV_HIGHGUI
   {"createTrackbar", pycvCreateTrackbar, METH_VARARGS, "createTrackbar(trackbarName, windowName, value, count, onChange) -> None"},
   {"createButton", (PyCFunction)pycvCreateButton, METH_VARARGS | METH_KEYWORDS, "createButton(buttonName, onChange [, userData, buttonType, initialButtonState]) -> None"},

--- a/modules/python/src2/cv2.cpp
+++ b/modules/python/src2/cv2.cpp
@@ -1556,9 +1556,6 @@ static int OnError(int status, const char *func_name, const char *err_msg, const
     return 0; // The return value isn't used
 }
 
-// Keep track of the previous handler parameter, so we can decref it when no longer used
-static PyObject* last_on_error_param = NULL;
-
 static PyObject *pycvRedirectError(PyObject*, PyObject *args, PyObject *kw)
 {
     const char *keywords[] = { "on_error", "param", NULL };
@@ -1576,6 +1573,8 @@ static PyObject *pycvRedirectError(PyObject*, PyObject *args, PyObject *kw)
         param = Py_None;
     }
 
+    // Keep track of the previous handler parameter, so we can decref it when no longer used
+    static PyObject* last_on_error_param = NULL;
     if (last_on_error_param) {
         Py_DECREF(last_on_error_param);
         last_on_error_param = NULL;

--- a/modules/python/test/test_misc.py
+++ b/modules/python/test/test_misc.py
@@ -18,5 +18,33 @@ class Bindings(NewOpenCVTests):
         boost.getMaxDepth() # from ml::DTrees
         boost.isClassifier() # from ml::StatModel
 
+
+    def test_redirectError(self):
+        try:
+            cv.imshow("", None) # This causes an assert
+            self.assertEqual("Dead code", 0)
+        except cv.error as e:
+            pass
+
+        handler_called = [False]
+        def test_error_handler(status, func_name, err_msg, file_name, line):
+            handler_called[0] = True
+
+        cv.redirectError(test_error_handler)
+        try:
+            cv.imshow("", None) # This causes an assert
+            self.assertEqual("Dead code", 0)
+        except cv.error as e:
+            self.assertEqual(handler_called[0], True)
+            pass
+
+        cv.redirectError(None)
+        try:
+            cv.imshow("", None) # This causes an assert
+            self.assertEqual("Dead code", 0)
+        except cv.error as e:
+            pass
+
+
 if __name__ == '__main__':
     NewOpenCVTests.bootstrap()


### PR DESCRIPTION
Based on [this StackOverflow question](https://stackoverflow.com/questions/49602465/how-to-stop-opencv-error-message-from-printing-in-python) I took an inspiration in the current `highgui` callback wrappers, and implemented a wrapper for `cv::redirectError`.

I attempted to address the concerns I've raised in issues #11205 and #11206, and also added support for resetting to a default handler.