### PR TITLE
Set translation in Viz3d::setViewerPose

### DIFF
--- a/modules/viz/src/vizimpl.cpp
+++ b/modules/viz/src/vizimpl.cpp
@@ -506,7 +506,6 @@ void cv::viz::Viz3d::VizImpl::setViewerPose(const Affine3d &pose)
     camera.SetViewUp(up_vec.val);
 
     renderer_->ResetCameraClippingRange();
-    renderer_->ResetCamera();
 }
 
 /////////////////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
### This pullrequest changes

`ResetCamera` was being called unnecessarily in `Viz3d::setViewerPose`. Removing the call makes `Viz3d::setViewPose` correctly set the translation of the viewer. This partially assesses #10944.

resolves #10944