### PR TITLE
Support for setting TIFF DPI info in imwrite

### DIFF
--- a/modules/imgcodecs/include/opencv2/imgcodecs.hpp
+++ b/modules/imgcodecs/include/opencv2/imgcodecs.hpp
@@ -92,6 +92,9 @@ enum ImwriteFlags {
        IMWRITE_EXR_TYPE            = (3 << 4) + 0, /* 48 */ //!< override EXR storage type (FLOAT (FP32) is default)
        IMWRITE_WEBP_QUALITY        = 64, //!< For WEBP, it can be a quality from 1 to 100 (the higher is the better). By default (without any parameter) and for quality above 100 the lossless compression is used.
        IMWRITE_PAM_TUPLETYPE       = 128,//!< For PAM, sets the TUPLETYPE field to the corresponding string value that is defined for the format
+       IMWRITE_TIFF_RESUNIT = 256,//!< For TIFF, use to specify which DPI resolution unit to set; see libtiff documentation for valid values
+       IMWRITE_TIFF_XDPI = 257,//!< For TIFF, use to specify the X direction DPI
+       IMWRITE_TIFF_YDPI = 258 //!< For TIFF, use to specify the Y direction DPI
      };
 
 enum ImwriteEXRTypeFlags {

--- a/modules/imgcodecs/src/grfmt_tiff.cpp
+++ b/modules/imgcodecs/src/grfmt_tiff.cpp
@@ -748,9 +748,13 @@ bool TiffEncoder::writeLibTiff( const std::vector<Mat>& img_vec, const std::vect
     // defaults for now, maybe base them on params in the future
     int compression = COMPRESSION_LZW;
     int predictor = PREDICTOR_HORIZONTAL;
+    int resUnit = -1, dpiX = -1, dpiY = -1;
 
     readParam(params, TIFFTAG_COMPRESSION, compression);
     readParam(params, TIFFTAG_PREDICTOR, predictor);
+    readParam(params, IMWRITE_TIFF_RESUNIT, resUnit);
+    readParam(params, IMWRITE_TIFF_XDPI, dpiX);
+    readParam(params, IMWRITE_TIFF_YDPI, dpiY);
 
     //Iterate through each image in the vector and write them out as Tiff directories
     for (size_t page = 0; page < img_vec.size(); page++)
@@ -816,6 +820,16 @@ bool TiffEncoder::writeLibTiff( const std::vector<Mat>& img_vec, const std::vect
             TIFFClose(pTiffHandle);
             return false;
         }
+
+        if (((resUnit >= RESUNIT_NONE && resUnit <= RESUNIT_CENTIMETER) && !TIFFSetField(pTiffHandle, TIFFTAG_RESOLUTIONUNIT, resUnit))
+            || (dpiX >= 0 && !TIFFSetField(pTiffHandle, TIFFTAG_XRESOLUTION, (float)dpiX))
+            || (dpiY >= 0 && !TIFFSetField(pTiffHandle, TIFFTAG_YRESOLUTION, (float)dpiY))
+            )
+        {
+            TIFFClose(pTiffHandle);
+            return false;
+        }
+
 
         // row buffer, because TIFFWriteScanline modifies the original data!
         size_t scanlineSize = TIFFScanlineSize(pTiffHandle);


### PR DESCRIPTION
<!-- Please use this line to close one or multiple issues when this pullrequest gets merged
You can add another line right under the first one:
resolves #1234
resolves #1235
-->

### This pullrequest completes PR #10669, a feature request initiated by user chrisestesaa01
Verified to be working locally with a variety of settings used on a sample image. Written image was loaded into an external TIFF Tag viewer utility (Aware Systems TIFF Tag viewer) to verify that PR does indeed write out DPI related tags correctly.

<!-- Please describe what your pullrequest is changing -->
