### PR TITLE
cuda: refactor MemoryPool

### DIFF
--- a/modules/core/src/cuda_stream.cpp
+++ b/modules/core/src/cuda_stream.cpp
@@ -117,6 +117,7 @@ namespace
     {
     public:
         MemoryPool();
+        ~MemoryPool() { release(); }
 
         void initialize(size_t stackSize, int stackCount);
         void release();
@@ -136,6 +137,8 @@ namespace
         uchar* mem_;
 
         std::vector<MemoryStack> stacks_;
+
+        MemoryPool(const MemoryPool&); //= delete;
     };
 
     MemoryPool::MemoryPool() : initialized_(false), mem_(0)
@@ -336,7 +339,7 @@ namespace cv { namespace cuda
         ~DefaultDeviceInitializer();
 
         Stream& getNullStream(int deviceId);
-        MemoryPool* getMemoryPool(int deviceId);
+        MemoryPool& getMemoryPool(int deviceId);
 
     private:
         void initStreams();
@@ -345,7 +348,7 @@ namespace cv { namespace cuda
         std::vector<Ptr<Stream> > streams_;
         Mutex streams_mtx_;
 
-        std::vector<MemoryPool> pools_;
+        std::vector<Ptr<MemoryPool> > pools_;
         Mutex pools_mtx_;
     };
 
@@ -360,7 +363,7 @@ namespace cv { namespace cuda
         for (size_t i = 0; i < pools_.size(); ++i)
         {
             cudaSetDevice(static_cast<int>(i));
-            pools_[i].release();
+            pools_[i]->release();
         }
 
         pools_.clear();
@@ -390,7 +393,7 @@ namespace cv { namespace cuda
         return *streams_[deviceId];
     }
 
-    MemoryPool* DefaultDeviceInitializer::getMemoryPool(int deviceId)
+    MemoryPool& DefaultDeviceInitializer::getMemoryPool(int deviceId)
     {
         AutoLock lock(pools_mtx_);
 
@@ -399,12 +402,21 @@ namespace cv { namespace cuda
             int deviceCount = getCudaEnabledDeviceCount();
 
             if (deviceCount > 0)
+            {
                 pools_.resize(deviceCount);
+                for (size_t i = 0; i < pools_.size(); ++i)
+                {
+                    cudaSetDevice(static_cast<int>(i));
+                    pools_[i] = makePtr<MemoryPool>();
+                }
+            }
         }
 
         CV_DbgAssert( deviceId >= 0 && deviceId < static_cast<int>(pools_.size()) );
 
-        return &pools_[deviceId];
+        MemoryPool* p = pools_[deviceId];
+        CV_Assert(p);
+        return *p;
     }
 
     DefaultDeviceInitializer initializer;
@@ -577,7 +589,7 @@ namespace
         if (enableMemoryPool)
         {
             const int deviceId = getDevice();
-            memStack_ = initializer.getMemoryPool(deviceId)->getFreeMemStack();
+            memStack_ = initializer.getMemoryPool(deviceId).getFreeMemStack();
             DeviceInfo devInfo(deviceId);
             alignment_ = devInfo.textureAlignment();
         }
@@ -668,7 +680,7 @@ void cv::cuda::setBufferPoolConfig(int deviceId, size_t stackSize, int stackCoun
     if (deviceId >= 0)
     {
         setDevice(deviceId);
-        initializer.getMemoryPool(deviceId)->initialize(stackSize, stackCount);
+        initializer.getMemoryPool(deviceId).initialize(stackSize, stackCount);
     }
     else
     {
@@ -677,7 +689,7 @@ void cv::cuda::setBufferPoolConfig(int deviceId, size_t stackSize, int stackCoun
         for (deviceId = 0; deviceId < deviceCount; ++deviceId)
         {
             setDevice(deviceId);
-            initializer.getMemoryPool(deviceId)->initialize(stackSize, stackCount);
+            initializer.getMemoryPool(deviceId).initialize(stackSize, stackCount);
         }
     }
 


### PR DESCRIPTION
- make non-copyable (aligns inner mutex semantic to `std::mutex`)
- getMemoryPool() returns reference instead of pointer (NULL is not expected here)

```
force_builders=Custom
docker_image:Custom=ubuntu-cuda:16.04
```