### PR TITLE
Solves issue #10506

### DIFF
--- a/modules/core/include/opencv2/core/persistence.hpp
+++ b/modules/core/include/opencv2/core/persistence.hpp
@@ -438,6 +438,8 @@ public:
      * @param name Name of the written object
      * @param val Value of the written object
      */
+    CV_WRAP void write(const String& name, int val);
+    /// @overload
     CV_WRAP void write(const String& name, double val);
     /// @overload
     CV_WRAP void write(const String& name, const String& val);

--- a/modules/core/src/persistence_cpp.cpp
+++ b/modules/core/src/persistence_cpp.cpp
@@ -178,6 +178,12 @@ void FileStorage::writeObj( const String& name, const void* obj )
     cvWrite( fs, name.size() > 0 ? name.c_str() : 0, obj );
 }
 
+
+void FileStorage::write( const String& name, int val )
+{
+    *this << name << val;
+}
+
 void FileStorage::write( const String& name, double val )
 {
     *this << name << val;


### PR DESCRIPTION
resolves #10506

possibly also [this](https://github.com/opencv/opencv_contrib/issues/1504)

### This pullrequest changes
New overload method **write**.

Now, there is no cast to double.
