### PR TITLE
Correct a mistake in {js,py}_table_of_contents_histograms.markdown

### DIFF
--- a/doc/js_tutorials/js_imgproc/js_histograms/js_table_of_contents_histograms.markdown
+++ b/doc/js_tutorials/js_imgproc/js_histograms/js_table_of_contents_histograms.markdown
@@ -3,7 +3,7 @@ Histograms in OpenCV.js {#tutorial_js_table_of_contents_histograms}
 
 -   @subpage tutorial_js_histogram_begins
 
-    Learn to find and draw Contours
+    Learn the basics of histograms
 
 -   @subpage tutorial_js_histogram_equalization
 

--- a/doc/py_tutorials/py_imgproc/py_histograms/py_table_of_contents_histograms.markdown
+++ b/doc/py_tutorials/py_imgproc/py_histograms/py_table_of_contents_histograms.markdown
@@ -3,7 +3,7 @@ Histograms in OpenCV {#tutorial_py_table_of_contents_histograms}
 
 -   @subpage tutorial_py_histogram_begins
 
-    Learn to find and draw Contours
+    Learn the basics of histograms
 
 -   @subpage tutorial_py_histogram_equalization
 


### PR DESCRIPTION
Nobody has mentioned this documention mistake in issues.

### This pullrequest changes
Corrected a seemlingly wronged line of copy in the python documention py_table_of_contents_histograms.markdown

"Learn to find and draw Contours" => "Learn the basics of histograms"

Similarly, corrected a seemlingly wronged line of copy in the js documention js_table_of_contents_histograms.markdown

"Learn to find and draw Contours" => "Learn the basics of histograms"
