### PR TITLE
imgproc: don't call .unlock() on non-holded mutex in houghCircles()

### DIFF
--- a/modules/imgproc/src/hough.cpp
+++ b/modules/imgproc/src/hough.cpp
@@ -1329,7 +1329,7 @@ public:
         CV_Assert(nzSz > 0);
     }
 
-    ~HoughCircleEstimateRadiusInvoker() {_lock.unlock();}
+    ~HoughCircleEstimateRadiusInvoker() {}
 
 protected:
     inline int filterCircles(const Point2f& curCenter, float* ddata) const;


### PR DESCRIPTION
Related message:
```
Assertion failed: (e == 0), function unlock, file /BuildRoot/Library/Caches/com.apple.xbs/Sources/libcxx/libcxx-307.5/src/mutex.cpp, line 102.
```
