### PR TITLE
Avoiding Divide By Zero Error

### DIFF
--- a/samples/cpp/train_HOG.cpp
+++ b/samples/cpp/train_HOG.cpp
@@ -101,7 +101,7 @@ void sample_neg( const vector< Mat > & full_neg_lst, vector< Mat > & neg_lst, co
     srand( (unsigned int)time( NULL ) );
 
     for ( size_t i = 0; i < full_neg_lst.size(); i++ )
-        if ( full_neg_lst[i].cols >= box.width && full_neg_lst[i].rows >= box.height )
+        if ( full_neg_lst[i].cols > box.width && full_neg_lst[i].rows > box.height )
         {
             box.x = rand() % ( full_neg_lst[i].cols - size_x );
             box.y = rand() % ( full_neg_lst[i].rows - size_y );


### PR DESCRIPTION
### This pullrequest changes

**Avoids Possible Divide By Zero Error.**

In line 104 `if ( full_neg_lst[i].cols >= box.width && full_neg_lst[i].rows >= box.height )` removed '=' as it causes divide By Zero Error in line 106 and 107 `box.x = rand() % ( full_neg_lst[i].cols - size_x );` when  full_neg_lst[i].cols = size_x or full_neg_lst[i].rows = size_y