### PR TITLE
tbb: fix build warnings -Wshadow

### DIFF
--- a/modules/core/src/parallel.cpp
+++ b/modules/core/src/parallel.cpp
@@ -379,8 +379,8 @@ namespace
 
         void operator ()() const  // run parallel job
         {
-            cv::Range stripeRange = this->stripeRange();
-            tbb::parallel_for(tbb::blocked_range<int>(stripeRange.start, stripeRange.end), *this);
+            cv::Range range = this->stripeRange();
+            tbb::parallel_for(tbb::blocked_range<int>(range.start, range.end), *this);
         }
     };
 #elif defined HAVE_CSTRIPES || defined HAVE_OPENMP


### PR DESCRIPTION
Message sample:
```
modules/core/src/parallel.cpp:378:23: warning: declaration of 'stripeRange' shadows a member of 'this' [-Wshadow]
             cv::Range stripeRange = this->stripeRange();
                       ^
```