### PR TITLE
imgcodecs: exclude rle8.bmp from GDAL tests

### DIFF
--- a/modules/imgcodecs/test/test_grfmt.cpp
+++ b/modules/imgcodecs/test/test_grfmt.cpp
@@ -110,7 +110,8 @@ INSTANTIATE_TEST_CASE_P(All, Imgcodecs_FileMode,
 struct notForGDAL {
     bool operator()(const string &name) const {
         const string &ext = name.substr(name.size() - 3, 3);
-        return ext == "hdr" || ext == "dcm" || ext == "jp2";
+        return ext == "hdr" || ext == "dcm" || ext == "jp2" ||
+                name.find("rle8.bmp") != std::string::npos;
     }
 };
 


### PR DESCRIPTION
GDAL message:
- ERROR 1: The BMP file is probably corrupted or too large. Image width = 480

GDAL fails due `GDALOpen()` call, so it can't be fixed in OpenCV.
- Ubuntu 14.06 / 16.04 works fine
- Ubuntu 17.10 / upcoming 18.04 - doesn't work

resolves #10118