### PR TITLE
core: fix mm_pause() for non-SSE i386 builds

### DIFF
--- a/modules/core/src/parallel_impl.cpp
+++ b/modules/core/src/parallel_impl.cpp
@@ -49,7 +49,11 @@ DECLARE_CV_YIELD
 DECLARE_CV_PAUSE
 #endif
 #ifndef CV_PAUSE
-#if defined __GNUC__ && (defined __i386__ || defined __x86_64__)
+# if defined __GNUC__ && (defined __i386__ || defined __x86_64__)
+#   if !defined(__SSE__)
+      static inline void cv_non_sse_mm_pause() { __asm__ __volatile__ ("rep; nop"); }
+#     define _mm_pause cv_non_sse_mm_pause
+#   endif
 #   define CV_PAUSE(v) do { for (int __delay = (v); __delay > 0; --__delay) { _mm_pause(); } } while (0)
 # elif defined __GNUC__ && defined __aarch64__
 #   define CV_PAUSE(v) do { for (int __delay = (v); __delay > 0; --__delay) { asm volatile("yield" ::: "memory"); } } while (0)


### PR DESCRIPTION
replaced to safe binary compatible 'rep; nop' asm instruction

resolves #11274