### PR TITLE
imgproc: fix wrong parameter in LSD test

### DIFF
--- a/modules/imgproc/test/test_lsd.cpp
+++ b/modules/imgproc/test/test_lsd.cpp
@@ -224,7 +224,7 @@ TEST_F(Imgproc_LSD_NONE, whiteNoise)
     for (int i = 0; i < EPOCHS; ++i)
     {
         GenerateWhiteNoise(test_image);
-        Ptr<LineSegmentDetector> detector = createLineSegmentDetector(LSD_REFINE_STD);
+        Ptr<LineSegmentDetector> detector = createLineSegmentDetector(LSD_REFINE_NONE);
         detector->detect(test_image, lines);
 
         if(50u >= lines.size()) ++passedtests;


### PR DESCRIPTION
### This pullrequest changes
- A LSD test for LSD_REFINE_**NONE** detector uses LSD_REFINE_**STD**. This is a minor patch to resolve this issue.