### PR TITLE
cmake: fix Ninja generator warning about pylintrc

### DIFF
--- a/cmake/OpenCVPylint.cmake
+++ b/cmake/OpenCVPylint.cmake
@@ -97,7 +97,11 @@ function(ocv_pylint_finalize)
     return()
   endif()
 
-  file(COPY "${CMAKE_SOURCE_DIR}/platforms/scripts/pylintrc" DESTINATION "${CMAKE_BINARY_DIR}")
+  add_custom_command(
+      OUTPUT "${CMAKE_BINARY_DIR}/pylintrc"
+      COMMAND ${CMAKE_COMMAND} -E copy_if_different "${CMAKE_SOURCE_DIR}/platforms/scripts/pylintrc" "${CMAKE_BINARY_DIR}/pylintrc"
+      DEPENDS "${CMAKE_SOURCE_DIR}/platforms/scripts/pylintrc"
+  )
 
   set(PYLINT_CONFIG_SCRIPT "")
   ocv_cmake_script_append_var(PYLINT_CONFIG_SCRIPT


### PR DESCRIPTION
CMake generated files is a part of target depends list.
Details: `cmake --help-policy CMP0058`
