### PR TITLE
Fix issue #11242 (universal intrinsics v_rotate, v_extract type restriction and SSSE3 optimization)

### DIFF
--- a/modules/core/include/opencv2/core/hal/intrin_cpp.hpp
+++ b/modules/core/include/opencv2/core/hal/intrin_cpp.hpp
@@ -202,6 +202,7 @@ Regular integers:
 |pack_u             | x |   | x |   |   |   |
 |unpack             | x | x | x | x | x | x |
 |extract            | x | x | x | x | x | x |
+|rotate (lanes)     | x | x | x | x | x | x |
 |cvt_flt32          |   |   |   |   |   | x |
 |cvt_flt64          |   |   |   |   |   | x |
 |transpose4x4       |   |   |   |   | x | x |
@@ -215,6 +216,7 @@ Big integers:
 |shift              | x | x |
 |logical            | x | x |
 |extract            | x | x |
+|rotate (lanes)     | x | x |
 
 Floating point:
 
@@ -236,7 +238,8 @@ Floating point:
 |sqrt, abs          | x | x |
 |float math         | x | x |
 |transpose4x4       | x |   |
-
+|extract            | x | x |
+|rotate (lanes)     | x | x |
 
  @{ */
 
@@ -1476,7 +1479,8 @@ Usage:
 v_int32x4 a, b, c;
 c = v_extract<2>(a, b);
 @endcode
-For integer types only. */
+
+For all type. */
 template<int s, typename _Tp, int n>
 inline v_reg<_Tp, n> v_extract(const v_reg<_Tp, n>& a, const v_reg<_Tp, n>& b)
 {

--- a/modules/core/include/opencv2/core/hal/intrin_sse.hpp
+++ b/modules/core/include/opencv2/core/hal/intrin_sse.hpp
@@ -1125,7 +1125,7 @@ namespace hal_sse_internal
     template <int imm>
     inline __m128i v_sse_palignr_u8(const __m128i& a, const __m128i& b)
     {
-        static_assert((imm >= 0) && (imm <= 16), "invalid value for (imm) calling intrinsic (v_sse_palignr_u8)");
+        CV_StaticAssert((imm >= 0) && (imm <= 16), "Invalid imm for v_sse_palignr_u8.");
         return v_sse_palignr_u8_class<imm>()(a, b);
     }
 }

--- a/modules/core/include/opencv2/core/hal/intrin_sse.hpp
+++ b/modules/core/include/opencv2/core/hal/intrin_sse.hpp
@@ -61,6 +61,7 @@ CV_CPU_OPTIMIZATION_HAL_NAMESPACE_BEGIN
 struct v_uint8x16
 {
     typedef uchar lane_type;
+    typedef __m128i vector_type;
     enum { nlanes = 16 };
 
     v_uint8x16() : val(_mm_setzero_si128()) {}
@@ -84,6 +85,7 @@ struct v_uint8x16
 struct v_int8x16
 {
     typedef schar lane_type;
+    typedef __m128i vector_type;
     enum { nlanes = 16 };
 
     v_int8x16() : val(_mm_setzero_si128()) {}
@@ -107,6 +109,7 @@ struct v_int8x16
 struct v_uint16x8
 {
     typedef ushort lane_type;
+    typedef __m128i vector_type;
     enum { nlanes = 8 };
 
     v_uint16x8() : val(_mm_setzero_si128()) {}
@@ -127,6 +130,7 @@ struct v_uint16x8
 struct v_int16x8
 {
     typedef short lane_type;
+    typedef __m128i vector_type;
     enum { nlanes = 8 };
 
     v_int16x8() : val(_mm_setzero_si128()) {}
@@ -146,6 +150,7 @@ struct v_int16x8
 struct v_uint32x4
 {
     typedef unsigned lane_type;
+    typedef __m128i vector_type;
     enum { nlanes = 4 };
 
     v_uint32x4() : val(_mm_setzero_si128()) {}
@@ -164,6 +169,7 @@ struct v_uint32x4
 struct v_int32x4
 {
     typedef int lane_type;
+    typedef __m128i vector_type;
     enum { nlanes = 4 };
 
     v_int32x4() : val(_mm_setzero_si128()) {}
@@ -182,6 +188,7 @@ struct v_int32x4
 struct v_float32x4
 {
     typedef float lane_type;
+    typedef __m128 vector_type;
     enum { nlanes = 4 };
 
     v_float32x4() : val(_mm_setzero_ps()) {}
@@ -200,6 +207,7 @@ struct v_float32x4
 struct v_uint64x2
 {
     typedef uint64 lane_type;
+    typedef __m128i vector_type;
     enum { nlanes = 2 };
 
     v_uint64x2() : val(_mm_setzero_si128()) {}
@@ -220,6 +228,7 @@ struct v_uint64x2
 struct v_int64x2
 {
     typedef int64 lane_type;
+    typedef __m128i vector_type;
     enum { nlanes = 2 };
 
     v_int64x2() : val(_mm_setzero_si128()) {}
@@ -240,6 +249,7 @@ struct v_int64x2
 struct v_float64x2
 {
     typedef double lane_type;
+    typedef __m128d vector_type;
     enum { nlanes = 2 };
 
     v_float64x2() : val(_mm_setzero_pd()) {}
@@ -259,6 +269,7 @@ struct v_float64x2
 struct v_float16x4
 {
     typedef short lane_type;
+    typedef __m128i vector_type;
     enum { nlanes = 4 };
 
     v_float16x4() : val(_mm_setzero_si128()) {}

--- a/modules/core/include/opencv2/core/hal/intrin_sse.hpp
+++ b/modules/core/include/opencv2/core/hal/intrin_sse.hpp
@@ -286,6 +286,27 @@ struct v_float16x4
 };
 #endif
 
+namespace hal_sse_internal
+{
+    template <typename to_sse_type, typename from_sse_type>
+    to_sse_type v_sse_reinterpret_as(const from_sse_type& val);
+
+#define OPENCV_HAL_IMPL_SSE_REINTERPRET_RAW(to_sse_type, from_sse_type, sse_cast_intrin) \
+    template<> inline \
+    to_sse_type v_sse_reinterpret_as(const from_sse_type& a) \
+    { return sse_cast_intrin(a); }
+
+    OPENCV_HAL_IMPL_SSE_REINTERPRET_RAW(__m128i, __m128i, OPENCV_HAL_NOP);
+    OPENCV_HAL_IMPL_SSE_REINTERPRET_RAW(__m128i, __m128, _mm_castps_si128);
+    OPENCV_HAL_IMPL_SSE_REINTERPRET_RAW(__m128i, __m128d, _mm_castpd_si128);
+    OPENCV_HAL_IMPL_SSE_REINTERPRET_RAW(__m128, __m128i, _mm_castsi128_ps);
+    OPENCV_HAL_IMPL_SSE_REINTERPRET_RAW(__m128, __m128, OPENCV_HAL_NOP);
+    OPENCV_HAL_IMPL_SSE_REINTERPRET_RAW(__m128, __m128d, _mm_castpd_ps);
+    OPENCV_HAL_IMPL_SSE_REINTERPRET_RAW(__m128d, __m128i, _mm_castsi128_pd);
+    OPENCV_HAL_IMPL_SSE_REINTERPRET_RAW(__m128d, __m128, _mm_castps_pd);
+    OPENCV_HAL_IMPL_SSE_REINTERPRET_RAW(__m128d, __m128d, OPENCV_HAL_NOP);
+}
+
 #define OPENCV_HAL_IMPL_SSE_INITVEC(_Tpvec, _Tp, suffix, zsuffix, ssuffix, _Tps, cast) \
 inline _Tpvec v_setzero_##suffix() { return _Tpvec(_mm_setzero_##zsuffix()); } \
 inline _Tpvec v_setall_##suffix(_Tp v) { return _Tpvec(_mm_set1_##ssuffix((_Tps)v)); } \

--- a/modules/core/include/opencv2/core/hal/intrin_sse.hpp
+++ b/modules/core/include/opencv2/core/hal/intrin_sse.hpp
@@ -1133,15 +1133,21 @@ namespace hal_sse_internal
 template<int imm, typename _Tpvec>
 inline _Tpvec v_rotate_right(const _Tpvec &a)
 {
-    enum { CV_SHIFT = imm*(sizeof(typename _Tpvec::lane_type)) };
-    return _Tpvec(_mm_srli_si128(a.val, CV_SHIFT));
+    using namespace hal_sse_internal;
+    enum { imm2 = (imm * sizeof(typename _Tpvec::lane_type)) };
+    return _Tpvec(v_sse_reinterpret_as<typename _Tpvec::vector_type>(
+        _mm_srli_si128(
+            v_sse_reinterpret_as<__m128i>(a.val), imm2)));
 }
 
 template<int imm, typename _Tpvec>
 inline _Tpvec v_rotate_left(const _Tpvec &a)
 {
-    enum { CV_SHIFT = imm*(sizeof(typename _Tpvec::lane_type)) };
-    return _Tpvec(_mm_slli_si128(a.val, CV_SHIFT));
+    using namespace hal_sse_internal;
+    enum { imm2 = (imm * sizeof(typename _Tpvec::lane_type)) };
+    return _Tpvec(v_sse_reinterpret_as<typename _Tpvec::vector_type>(
+        _mm_slli_si128(
+            v_sse_reinterpret_as<__m128i>(a.val), imm2)));
 }
 
 template<int imm, typename _Tpvec>

--- a/modules/core/include/opencv2/core/hal/intrin_sse.hpp
+++ b/modules/core/include/opencv2/core/hal/intrin_sse.hpp
@@ -1053,31 +1053,117 @@ OPENCV_HAL_IMPL_SSE_SHIFT_OP(v_uint16x8, v_int16x8, epi16, _mm_srai_epi16)
 OPENCV_HAL_IMPL_SSE_SHIFT_OP(v_uint32x4, v_int32x4, epi32, _mm_srai_epi32)
 OPENCV_HAL_IMPL_SSE_SHIFT_OP(v_uint64x2, v_int64x2, epi64, v_srai_epi64)
 
+namespace hal_sse_internal
+{
+    // note, "half = 2" is reserved for future implementation.
+    enum class v_sse_palignr_u8_mode
+    {
+        invalid = 0,
+        first = 1,
+        second = 3,
+        other = 4
+    };
+
+    constexpr v_sse_palignr_u8_mode v_sse_get_palignr_u8_mode(int imm)
+    {
+        return (imm < 0) ? v_sse_palignr_u8_mode::invalid
+            : (imm == 0) ? v_sse_palignr_u8_mode::first
+            : (imm < 16) ? v_sse_palignr_u8_mode::other
+            : (imm == 16) ? v_sse_palignr_u8_mode::second
+            : v_sse_palignr_u8_mode::invalid;
+    }
+
+    template <int imm, v_sse_palignr_u8_mode mode = v_sse_get_palignr_u8_mode(imm)>
+    class v_sse_palignr_u8_class;
+
+    template <int imm>
+    class v_sse_palignr_u8_class<imm, v_sse_palignr_u8_mode::invalid>
+    {
+    public:
+        __m128i operator()(const __m128i&, const __m128i&) const = delete;
+    };
+
+    template <int imm>
+    class v_sse_palignr_u8_class<imm, v_sse_palignr_u8_mode::first>
+    {
+    public:
+        inline __m128i operator()(const __m128i& a, const __m128i&) const
+        {
+            return a;
+        }
+    };
+
+    template <int imm>
+    class v_sse_palignr_u8_class<imm, v_sse_palignr_u8_mode::second>
+    {
+    public:
+        inline __m128i operator()(const __m128i&, const __m128i& b) const
+        {
+            return b;
+        }
+    };
+
+    template <int imm>
+    class v_sse_palignr_u8_class<imm, v_sse_palignr_u8_mode::other>
+    {
+#if CV_SSSE3
+    public:
+        inline __m128i operator()(const __m128i& a, const __m128i& b) const
+        {
+            return _mm_alignr_epi8(b, a, imm);
+        }
+#else
+    public:
+        inline __m128i operator()(const __m128i& a, const __m128i& b) const
+        {
+            enum { imm2 = (sizeof(__m128i) - imm) };
+            return _mm_or_si128(_mm_srli_si128(a, imm), _mm_slli_si128(b, imm2));
+        }
+#endif
+    };
+
+    template <int imm>
+    inline __m128i v_sse_palignr_u8(const __m128i& a, const __m128i& b)
+    {
+        static_assert((imm >= 0) && (imm <= 16), "invalid value for (imm) calling intrinsic (v_sse_palignr_u8)");
+        return v_sse_palignr_u8_class<imm>()(a, b);
+    }
+}
+
 template<int imm, typename _Tpvec>
 inline _Tpvec v_rotate_right(const _Tpvec &a)
 {
     enum { CV_SHIFT = imm*(sizeof(typename _Tpvec::lane_type)) };
     return _Tpvec(_mm_srli_si128(a.val, CV_SHIFT));
 }
+
 template<int imm, typename _Tpvec>
 inline _Tpvec v_rotate_left(const _Tpvec &a)
 {
     enum { CV_SHIFT = imm*(sizeof(typename _Tpvec::lane_type)) };
     return _Tpvec(_mm_slli_si128(a.val, CV_SHIFT));
 }
+
 template<int imm, typename _Tpvec>
 inline _Tpvec v_rotate_right(const _Tpvec &a, const _Tpvec &b)
 {
-    enum { CV_SHIFT1 = imm*(sizeof(typename _Tpvec::lane_type)) };
-    enum { CV_SHIFT2 = 16 - imm*(sizeof(typename _Tpvec::lane_type)) };
-    return _Tpvec(_mm_or_si128(_mm_srli_si128(a.val, CV_SHIFT1), _mm_slli_si128(b.val, CV_SHIFT2)));
+    using namespace hal_sse_internal;
+    enum { imm2 = (imm * sizeof(typename _Tpvec::lane_type)) };
+    return _Tpvec(v_sse_reinterpret_as<typename _Tpvec::vector_type>(
+        v_sse_palignr_u8<imm2>(
+            v_sse_reinterpret_as<__m128i>(a.val),
+            v_sse_reinterpret_as<__m128i>(b.val))));
 }
+
 template<int imm, typename _Tpvec>
 inline _Tpvec v_rotate_left(const _Tpvec &a, const _Tpvec &b)
 {
-    enum { CV_SHIFT1 = imm*(sizeof(typename _Tpvec::lane_type)) };
-    enum { CV_SHIFT2 = 16 - imm*(sizeof(typename _Tpvec::lane_type)) };
-    return _Tpvec(_mm_or_si128(_mm_slli_si128(a.val, CV_SHIFT1), _mm_srli_si128(b.val, CV_SHIFT2)));
+    using namespace hal_sse_internal;
+    enum { imm2 = ((_Tpvec::nlanes - imm) * sizeof(typename _Tpvec::lane_type)) };
+    return _Tpvec(v_sse_reinterpret_as<typename _Tpvec::vector_type>(
+        v_sse_palignr_u8<imm2>(
+            v_sse_reinterpret_as<__m128i>(b.val),
+            v_sse_reinterpret_as<__m128i>(a.val))));
 }
 
 #define OPENCV_HAL_IMPL_SSE_LOADSTORE_INT_OP(_Tpvec, _Tp) \
@@ -1394,12 +1480,7 @@ OPENCV_HAL_IMPL_SSE_UNPACKS(v_float64x2, pd, _mm_castpd_si128, _mm_castsi128_pd)
 template<int s, typename _Tpvec>
 inline _Tpvec v_extract(const _Tpvec& a, const _Tpvec& b)
 {
-    const int w = sizeof(typename _Tpvec::lane_type);
-    const int n = _Tpvec::nlanes;
-    __m128i ra, rb;
-    ra = _mm_srli_si128(a.val, s*w);
-    rb = _mm_slli_si128(b.val, (n-s)*w);
-    return _Tpvec(_mm_or_si128(ra, rb));
+    return v_rotate_right<s>(a, b);
 }
 
 inline v_int32x4 v_round(const v_float32x4& a)

--- a/modules/core/test/test_intrin.cpp
+++ b/modules/core/test/test_intrin.cpp
@@ -215,6 +215,8 @@ TEST(hal_intrin, float32x4) {
         .test_matmul()
         .test_transpose()
         .test_reduce_sum4()
+        .test_extract<0>().test_extract<1>().test_extract<2>().test_extract<3>()
+        .test_rotate<0>().test_rotate<1>().test_rotate<2>().test_rotate<3>()
         ;
 }
 
@@ -233,6 +235,8 @@ TEST(hal_intrin, float64x2) {
         .test_unpack()
         .test_float_math()
         .test_float_cvt32()
+        .test_extract<0>().test_extract<1>()
+        .test_rotate<0>().test_rotate<1>()
         ;
 }
 #endif


### PR DESCRIPTION
WIP resolve #11242 

Please review. 
Requires C++11.
PR to (master == 4.0). Do not merge to 3.4
Please run buildbot (master == 4.0), if resource permits.

***This PR.***
 - [x] v_rotate_left, right (reg a), (reg a, reg b)
 - [x] v_extract (reg a, reg b)

***Not done, open to discussion.***
 - [ ] design uniformity in CPP, NEON, AVX, VSX
 - [ ] Before/after performance comparison, with and without SSSE3
   - core "matmul", (note: it uses ```v_rotate_left, right```)
   - calib3d "stereo sgbm", 
   - contrib optflow "dis_flow", 
   - contrib optflow "variational_refinement") 
 - [ ] Uncertainty about latency impacts on using PALIGNR ("integer-centric instructions") or PUNPCKH(L)DQ in between floating-point intensive algorithms. Such latency may come from CPU execution units. ***Suggestions welcome.***

***Not in this issue, not in this PR.***
 - [ ] v_insert (out reg a, out reg b, in const ref c)
 - [ ] v_rotate_left, right (array of regs) 
 - [ ] v_extract (array of regs)

### This pullrequest changes

 * ```typedef``` ```v_int32x4::vector_type``` etc
 * ```namespace hal_sse_internal``` ```v_sse_reinterpret_as``` such as ```__m128i```
 * ```namespace hal_sse_internal``` ```v_sse_palignr_u8```
 * ```v_rotate_left```, ```v_rotate_right```, ```v_extract``` enhancement
   * Remove type restriction, should work for 8, 16, 32, 64 integers and 32, 64 floats
   * Enhancement using PALIGNR when preprocessor (```CV_SSSE3```) equals 1
 * Updated test case in ```test_intrin.cpp```
 * Updated doxygen docs in ```intrin_cpp.hpp```

### Attachments

#### Test and performance outputs

My machine isn't set up for performance testing (it has thermal throttling, so execution time can vary a lot depending on random reasons.) Would appreciate any help from anybody.

[opencv_perf_optflow.after_modify.txt](https://github.com/opencv/opencv/files/1897804/opencv_perf_optflow.after_modify.txt)
[opencv_test_calib3d.after_modify.txt](https://github.com/opencv/opencv/files/1897805/opencv_test_calib3d.after_modify.txt)
[opencv_test_core.after_modify.txt](https://github.com/opencv/opencv/files/1897806/opencv_test_core.after_modify.txt)
[opencv_test_optflow.after_modify.txt](https://github.com/opencv/opencv/files/1897807/opencv_test_optflow.after_modify.txt)
[opencv_perf_calib3d.after_modify.txt](https://github.com/opencv/opencv/files/1897808/opencv_perf_calib3d.after_modify.txt)
[opencv_perf_core.after_modify.txt](https://github.com/opencv/opencv/files/1897809/opencv_perf_core.after_modify.txt)


```
buildworker:Linux x64=linux-1
buildworker:Win64 OpenCL=windows-2
force_builders=Custom
docker_image:Custom=powerpc64le
```