### PR TITLE
Parse repeated values of ConvolutionParameter

### DIFF
--- a/modules/dnn/src/layers/layers_common.cpp
+++ b/modules/dnn/src/layers/layers_common.cpp
@@ -77,7 +77,20 @@ bool getParameter(const LayerParams &params, const std::string& nameBase, const 
     {
         if (params.has(nameAll_))
         {
-            parameterH = parameterW = params.get<int>(nameAll_);
+            DictValue param = params.get(nameAll_);
+            parameterH = param.get<int>(0);
+            if (param.size() == 1)
+            {
+                parameterW = parameterH;
+            }
+            else if (param.size() == 2)
+            {
+                parameterW = param.get<int>(1);
+            }
+            else
+            {
+                return false;
+            }
             return true;
         }
         else


### PR DESCRIPTION
Fix hyper-parameters parsing in case of repeated `kernel_size` or `pad` or `stride` from Caffe's `convolution_param`.

https://github.com/opencv/opencv/blob/10ba6a93a6fee952fb7812b28989eb209d4f49a1/modules/dnn/src/caffe/opencv-caffe.proto#L727-L731

**Merge with extra**: https://github.com/opencv/opencv_extra/pull/457

related: http://answers.opencv.org/question/187725/when-loading-caffe-vgg-16-i-get-error-215-idx-1-size-1-idx-0-idx-size-in-function-get/

```
buildworker:Win64 OpenCL=windows-2
```