### PR TITLE
core: fix FP16 conversion with CV_DISABLE_OPTIMIZATION option

### DIFF
--- a/cmake/OpenCVCompilerOptimizations.cmake
+++ b/cmake/OpenCVCompilerOptimizations.cmake
@@ -703,16 +703,19 @@ macro(ocv_compiler_optimization_fill_cpu_config)
       set(OPENCV_CPU_CONTROL_DEFINITIONS_CONFIGMAKE "${OPENCV_CPU_CONTROL_DEFINITIONS_CONFIGMAKE}
 #if !defined CV_DISABLE_OPTIMIZATION && defined CV_ENABLE_INTRINSICS && defined CV_CPU_COMPILE_${OPT}
 #  define CV_TRY_${OPT} 1
+#  define CV_CPU_FORCE_${OPT} 1
 #  define CV_CPU_HAS_SUPPORT_${OPT} 1
 #  define CV_CPU_CALL_${OPT}(fn, args) return (cpu_baseline::fn args)
 #  define CV_CPU_CALL_${OPT}_(fn, args) return (opt_${OPT}::fn args)
 #elif !defined CV_DISABLE_OPTIMIZATION && defined CV_ENABLE_INTRINSICS && defined CV_CPU_DISPATCH_COMPILE_${OPT}
 #  define CV_TRY_${OPT} 1
+#  define CV_CPU_FORCE_${OPT} 0
 #  define CV_CPU_HAS_SUPPORT_${OPT} (cv::checkHardwareSupport(CV_CPU_${OPT}))
 #  define CV_CPU_CALL_${OPT}(fn, args) if (CV_CPU_HAS_SUPPORT_${OPT}) return (opt_${OPT}::fn args)
 #  define CV_CPU_CALL_${OPT}_(fn, args) if (CV_CPU_HAS_SUPPORT_${OPT}) return (opt_${OPT}::fn args)
 #else
 #  define CV_TRY_${OPT} 0
+#  define CV_CPU_FORCE_${OPT} 0
 #  define CV_CPU_HAS_SUPPORT_${OPT} 0
 #  define CV_CPU_CALL_${OPT}(fn, args)
 #  define CV_CPU_CALL_${OPT}_(fn, args)

--- a/modules/core/include/opencv2/core/cv_cpu_helper.h
+++ b/modules/core/include/opencv2/core/cv_cpu_helper.h
@@ -2,16 +2,19 @@
 
 #if !defined CV_DISABLE_OPTIMIZATION && defined CV_ENABLE_INTRINSICS && defined CV_CPU_COMPILE_SSE
 #  define CV_TRY_SSE 1
+#  define CV_CPU_FORCE_SSE 1
 #  define CV_CPU_HAS_SUPPORT_SSE 1
 #  define CV_CPU_CALL_SSE(fn, args) return (cpu_baseline::fn args)
 #  define CV_CPU_CALL_SSE_(fn, args) return (opt_SSE::fn args)
 #elif !defined CV_DISABLE_OPTIMIZATION && defined CV_ENABLE_INTRINSICS && defined CV_CPU_DISPATCH_COMPILE_SSE
 #  define CV_TRY_SSE 1
+#  define CV_CPU_FORCE_SSE 0
 #  define CV_CPU_HAS_SUPPORT_SSE (cv::checkHardwareSupport(CV_CPU_SSE))
 #  define CV_CPU_CALL_SSE(fn, args) if (CV_CPU_HAS_SUPPORT_SSE) return (opt_SSE::fn args)
 #  define CV_CPU_CALL_SSE_(fn, args) if (CV_CPU_HAS_SUPPORT_SSE) return (opt_SSE::fn args)
 #else
 #  define CV_TRY_SSE 0
+#  define CV_CPU_FORCE_SSE 0
 #  define CV_CPU_HAS_SUPPORT_SSE 0
 #  define CV_CPU_CALL_SSE(fn, args)
 #  define CV_CPU_CALL_SSE_(fn, args)
@@ -20,16 +23,19 @@
 
 #if !defined CV_DISABLE_OPTIMIZATION && defined CV_ENABLE_INTRINSICS && defined CV_CPU_COMPILE_SSE2
 #  define CV_TRY_SSE2 1
+#  define CV_CPU_FORCE_SSE2 1
 #  define CV_CPU_HAS_SUPPORT_SSE2 1
 #  define CV_CPU_CALL_SSE2(fn, args) return (cpu_baseline::fn args)
 #  define CV_CPU_CALL_SSE2_(fn, args) return (opt_SSE2::fn args)
 #elif !defined CV_DISABLE_OPTIMIZATION && defined CV_ENABLE_INTRINSICS && defined CV_CPU_DISPATCH_COMPILE_SSE2
 #  define CV_TRY_SSE2 1
+#  define CV_CPU_FORCE_SSE2 0
 #  define CV_CPU_HAS_SUPPORT_SSE2 (cv::checkHardwareSupport(CV_CPU_SSE2))
 #  define CV_CPU_CALL_SSE2(fn, args) if (CV_CPU_HAS_SUPPORT_SSE2) return (opt_SSE2::fn args)
 #  define CV_CPU_CALL_SSE2_(fn, args) if (CV_CPU_HAS_SUPPORT_SSE2) return (opt_SSE2::fn args)
 #else
 #  define CV_TRY_SSE2 0
+#  define CV_CPU_FORCE_SSE2 0
 #  define CV_CPU_HAS_SUPPORT_SSE2 0
 #  define CV_CPU_CALL_SSE2(fn, args)
 #  define CV_CPU_CALL_SSE2_(fn, args)
@@ -38,16 +44,19 @@
 
 #if !defined CV_DISABLE_OPTIMIZATION && defined CV_ENABLE_INTRINSICS && defined CV_CPU_COMPILE_SSE3
 #  define CV_TRY_SSE3 1
+#  define CV_CPU_FORCE_SSE3 1
 #  define CV_CPU_HAS_SUPPORT_SSE3 1
 #  define CV_CPU_CALL_SSE3(fn, args) return (cpu_baseline::fn args)
 #  define CV_CPU_CALL_SSE3_(fn, args) return (opt_SSE3::fn args)
 #elif !defined CV_DISABLE_OPTIMIZATION && defined CV_ENABLE_INTRINSICS && defined CV_CPU_DISPATCH_COMPILE_SSE3
 #  define CV_TRY_SSE3 1
+#  define CV_CPU_FORCE_SSE3 0
 #  define CV_CPU_HAS_SUPPORT_SSE3 (cv::checkHardwareSupport(CV_CPU_SSE3))
 #  define CV_CPU_CALL_SSE3(fn, args) if (CV_CPU_HAS_SUPPORT_SSE3) return (opt_SSE3::fn args)
 #  define CV_CPU_CALL_SSE3_(fn, args) if (CV_CPU_HAS_SUPPORT_SSE3) return (opt_SSE3::fn args)
 #else
 #  define CV_TRY_SSE3 0
+#  define CV_CPU_FORCE_SSE3 0
 #  define CV_CPU_HAS_SUPPORT_SSE3 0
 #  define CV_CPU_CALL_SSE3(fn, args)
 #  define CV_CPU_CALL_SSE3_(fn, args)
@@ -56,16 +65,19 @@
 
 #if !defined CV_DISABLE_OPTIMIZATION && defined CV_ENABLE_INTRINSICS && defined CV_CPU_COMPILE_SSSE3
 #  define CV_TRY_SSSE3 1
+#  define CV_CPU_FORCE_SSSE3 1
 #  define CV_CPU_HAS_SUPPORT_SSSE3 1
 #  define CV_CPU_CALL_SSSE3(fn, args) return (cpu_baseline::fn args)
 #  define CV_CPU_CALL_SSSE3_(fn, args) return (opt_SSSE3::fn args)
 #elif !defined CV_DISABLE_OPTIMIZATION && defined CV_ENABLE_INTRINSICS && defined CV_CPU_DISPATCH_COMPILE_SSSE3
 #  define CV_TRY_SSSE3 1
+#  define CV_CPU_FORCE_SSSE3 0
 #  define CV_CPU_HAS_SUPPORT_SSSE3 (cv::checkHardwareSupport(CV_CPU_SSSE3))
 #  define CV_CPU_CALL_SSSE3(fn, args) if (CV_CPU_HAS_SUPPORT_SSSE3) return (opt_SSSE3::fn args)
 #  define CV_CPU_CALL_SSSE3_(fn, args) if (CV_CPU_HAS_SUPPORT_SSSE3) return (opt_SSSE3::fn args)
 #else
 #  define CV_TRY_SSSE3 0
+#  define CV_CPU_FORCE_SSSE3 0
 #  define CV_CPU_HAS_SUPPORT_SSSE3 0
 #  define CV_CPU_CALL_SSSE3(fn, args)
 #  define CV_CPU_CALL_SSSE3_(fn, args)
@@ -74,16 +86,19 @@
 
 #if !defined CV_DISABLE_OPTIMIZATION && defined CV_ENABLE_INTRINSICS && defined CV_CPU_COMPILE_SSE4_1
 #  define CV_TRY_SSE4_1 1
+#  define CV_CPU_FORCE_SSE4_1 1
 #  define CV_CPU_HAS_SUPPORT_SSE4_1 1
 #  define CV_CPU_CALL_SSE4_1(fn, args) return (cpu_baseline::fn args)
 #  define CV_CPU_CALL_SSE4_1_(fn, args) return (opt_SSE4_1::fn args)
 #elif !defined CV_DISABLE_OPTIMIZATION && defined CV_ENABLE_INTRINSICS && defined CV_CPU_DISPATCH_COMPILE_SSE4_1
 #  define CV_TRY_SSE4_1 1
+#  define CV_CPU_FORCE_SSE4_1 0
 #  define CV_CPU_HAS_SUPPORT_SSE4_1 (cv::checkHardwareSupport(CV_CPU_SSE4_1))
 #  define CV_CPU_CALL_SSE4_1(fn, args) if (CV_CPU_HAS_SUPPORT_SSE4_1) return (opt_SSE4_1::fn args)
 #  define CV_CPU_CALL_SSE4_1_(fn, args) if (CV_CPU_HAS_SUPPORT_SSE4_1) return (opt_SSE4_1::fn args)
 #else
 #  define CV_TRY_SSE4_1 0
+#  define CV_CPU_FORCE_SSE4_1 0
 #  define CV_CPU_HAS_SUPPORT_SSE4_1 0
 #  define CV_CPU_CALL_SSE4_1(fn, args)
 #  define CV_CPU_CALL_SSE4_1_(fn, args)
@@ -92,16 +107,19 @@
 
 #if !defined CV_DISABLE_OPTIMIZATION && defined CV_ENABLE_INTRINSICS && defined CV_CPU_COMPILE_SSE4_2
 #  define CV_TRY_SSE4_2 1
+#  define CV_CPU_FORCE_SSE4_2 1
 #  define CV_CPU_HAS_SUPPORT_SSE4_2 1
 #  define CV_CPU_CALL_SSE4_2(fn, args) return (cpu_baseline::fn args)
 #  define CV_CPU_CALL_SSE4_2_(fn, args) return (opt_SSE4_2::fn args)
 #elif !defined CV_DISABLE_OPTIMIZATION && defined CV_ENABLE_INTRINSICS && defined CV_CPU_DISPATCH_COMPILE_SSE4_2
 #  define CV_TRY_SSE4_2 1
+#  define CV_CPU_FORCE_SSE4_2 0
 #  define CV_CPU_HAS_SUPPORT_SSE4_2 (cv::checkHardwareSupport(CV_CPU_SSE4_2))
 #  define CV_CPU_CALL_SSE4_2(fn, args) if (CV_CPU_HAS_SUPPORT_SSE4_2) return (opt_SSE4_2::fn args)
 #  define CV_CPU_CALL_SSE4_2_(fn, args) if (CV_CPU_HAS_SUPPORT_SSE4_2) return (opt_SSE4_2::fn args)
 #else
 #  define CV_TRY_SSE4_2 0
+#  define CV_CPU_FORCE_SSE4_2 0
 #  define CV_CPU_HAS_SUPPORT_SSE4_2 0
 #  define CV_CPU_CALL_SSE4_2(fn, args)
 #  define CV_CPU_CALL_SSE4_2_(fn, args)
@@ -110,16 +128,19 @@
 
 #if !defined CV_DISABLE_OPTIMIZATION && defined CV_ENABLE_INTRINSICS && defined CV_CPU_COMPILE_POPCNT
 #  define CV_TRY_POPCNT 1
+#  define CV_CPU_FORCE_POPCNT 1
 #  define CV_CPU_HAS_SUPPORT_POPCNT 1
 #  define CV_CPU_CALL_POPCNT(fn, args) return (cpu_baseline::fn args)
 #  define CV_CPU_CALL_POPCNT_(fn, args) return (opt_POPCNT::fn args)
 #elif !defined CV_DISABLE_OPTIMIZATION && defined CV_ENABLE_INTRINSICS && defined CV_CPU_DISPATCH_COMPILE_POPCNT
 #  define CV_TRY_POPCNT 1
+#  define CV_CPU_FORCE_POPCNT 0
 #  define CV_CPU_HAS_SUPPORT_POPCNT (cv::checkHardwareSupport(CV_CPU_POPCNT))
 #  define CV_CPU_CALL_POPCNT(fn, args) if (CV_CPU_HAS_SUPPORT_POPCNT) return (opt_POPCNT::fn args)
 #  define CV_CPU_CALL_POPCNT_(fn, args) if (CV_CPU_HAS_SUPPORT_POPCNT) return (opt_POPCNT::fn args)
 #else
 #  define CV_TRY_POPCNT 0
+#  define CV_CPU_FORCE_POPCNT 0
 #  define CV_CPU_HAS_SUPPORT_POPCNT 0
 #  define CV_CPU_CALL_POPCNT(fn, args)
 #  define CV_CPU_CALL_POPCNT_(fn, args)
@@ -128,16 +149,19 @@
 
 #if !defined CV_DISABLE_OPTIMIZATION && defined CV_ENABLE_INTRINSICS && defined CV_CPU_COMPILE_AVX
 #  define CV_TRY_AVX 1
+#  define CV_CPU_FORCE_AVX 1
 #  define CV_CPU_HAS_SUPPORT_AVX 1
 #  define CV_CPU_CALL_AVX(fn, args) return (cpu_baseline::fn args)
 #  define CV_CPU_CALL_AVX_(fn, args) return (opt_AVX::fn args)
 #elif !defined CV_DISABLE_OPTIMIZATION && defined CV_ENABLE_INTRINSICS && defined CV_CPU_DISPATCH_COMPILE_AVX
 #  define CV_TRY_AVX 1
+#  define CV_CPU_FORCE_AVX 0
 #  define CV_CPU_HAS_SUPPORT_AVX (cv::checkHardwareSupport(CV_CPU_AVX))
 #  define CV_CPU_CALL_AVX(fn, args) if (CV_CPU_HAS_SUPPORT_AVX) return (opt_AVX::fn args)
 #  define CV_CPU_CALL_AVX_(fn, args) if (CV_CPU_HAS_SUPPORT_AVX) return (opt_AVX::fn args)
 #else
 #  define CV_TRY_AVX 0
+#  define CV_CPU_FORCE_AVX 0
 #  define CV_CPU_HAS_SUPPORT_AVX 0
 #  define CV_CPU_CALL_AVX(fn, args)
 #  define CV_CPU_CALL_AVX_(fn, args)
@@ -146,16 +170,19 @@
 
 #if !defined CV_DISABLE_OPTIMIZATION && defined CV_ENABLE_INTRINSICS && defined CV_CPU_COMPILE_FP16
 #  define CV_TRY_FP16 1
+#  define CV_CPU_FORCE_FP16 1
 #  define CV_CPU_HAS_SUPPORT_FP16 1
 #  define CV_CPU_CALL_FP16(fn, args) return (cpu_baseline::fn args)
 #  define CV_CPU_CALL_FP16_(fn, args) return (opt_FP16::fn args)
 #elif !defined CV_DISABLE_OPTIMIZATION && defined CV_ENABLE_INTRINSICS && defined CV_CPU_DISPATCH_COMPILE_FP16
 #  define CV_TRY_FP16 1
+#  define CV_CPU_FORCE_FP16 0
 #  define CV_CPU_HAS_SUPPORT_FP16 (cv::checkHardwareSupport(CV_CPU_FP16))
 #  define CV_CPU_CALL_FP16(fn, args) if (CV_CPU_HAS_SUPPORT_FP16) return (opt_FP16::fn args)
 #  define CV_CPU_CALL_FP16_(fn, args) if (CV_CPU_HAS_SUPPORT_FP16) return (opt_FP16::fn args)
 #else
 #  define CV_TRY_FP16 0
+#  define CV_CPU_FORCE_FP16 0
 #  define CV_CPU_HAS_SUPPORT_FP16 0
 #  define CV_CPU_CALL_FP16(fn, args)
 #  define CV_CPU_CALL_FP16_(fn, args)
@@ -164,16 +191,19 @@
 
 #if !defined CV_DISABLE_OPTIMIZATION && defined CV_ENABLE_INTRINSICS && defined CV_CPU_COMPILE_AVX2
 #  define CV_TRY_AVX2 1
+#  define CV_CPU_FORCE_AVX2 1
 #  define CV_CPU_HAS_SUPPORT_AVX2 1
 #  define CV_CPU_CALL_AVX2(fn, args) return (cpu_baseline::fn args)
 #  define CV_CPU_CALL_AVX2_(fn, args) return (opt_AVX2::fn args)
 #elif !defined CV_DISABLE_OPTIMIZATION && defined CV_ENABLE_INTRINSICS && defined CV_CPU_DISPATCH_COMPILE_AVX2
 #  define CV_TRY_AVX2 1
+#  define CV_CPU_FORCE_AVX2 0
 #  define CV_CPU_HAS_SUPPORT_AVX2 (cv::checkHardwareSupport(CV_CPU_AVX2))
 #  define CV_CPU_CALL_AVX2(fn, args) if (CV_CPU_HAS_SUPPORT_AVX2) return (opt_AVX2::fn args)
 #  define CV_CPU_CALL_AVX2_(fn, args) if (CV_CPU_HAS_SUPPORT_AVX2) return (opt_AVX2::fn args)
 #else
 #  define CV_TRY_AVX2 0
+#  define CV_CPU_FORCE_AVX2 0
 #  define CV_CPU_HAS_SUPPORT_AVX2 0
 #  define CV_CPU_CALL_AVX2(fn, args)
 #  define CV_CPU_CALL_AVX2_(fn, args)
@@ -182,16 +212,19 @@
 
 #if !defined CV_DISABLE_OPTIMIZATION && defined CV_ENABLE_INTRINSICS && defined CV_CPU_COMPILE_FMA3
 #  define CV_TRY_FMA3 1
+#  define CV_CPU_FORCE_FMA3 1
 #  define CV_CPU_HAS_SUPPORT_FMA3 1
 #  define CV_CPU_CALL_FMA3(fn, args) return (cpu_baseline::fn args)
 #  define CV_CPU_CALL_FMA3_(fn, args) return (opt_FMA3::fn args)
 #elif !defined CV_DISABLE_OPTIMIZATION && defined CV_ENABLE_INTRINSICS && defined CV_CPU_DISPATCH_COMPILE_FMA3
 #  define CV_TRY_FMA3 1
+#  define CV_CPU_FORCE_FMA3 0
 #  define CV_CPU_HAS_SUPPORT_FMA3 (cv::checkHardwareSupport(CV_CPU_FMA3))
 #  define CV_CPU_CALL_FMA3(fn, args) if (CV_CPU_HAS_SUPPORT_FMA3) return (opt_FMA3::fn args)
 #  define CV_CPU_CALL_FMA3_(fn, args) if (CV_CPU_HAS_SUPPORT_FMA3) return (opt_FMA3::fn args)
 #else
 #  define CV_TRY_FMA3 0
+#  define CV_CPU_FORCE_FMA3 0
 #  define CV_CPU_HAS_SUPPORT_FMA3 0
 #  define CV_CPU_CALL_FMA3(fn, args)
 #  define CV_CPU_CALL_FMA3_(fn, args)
@@ -200,16 +233,19 @@
 
 #if !defined CV_DISABLE_OPTIMIZATION && defined CV_ENABLE_INTRINSICS && defined CV_CPU_COMPILE_AVX_512F
 #  define CV_TRY_AVX_512F 1
+#  define CV_CPU_FORCE_AVX_512F 1
 #  define CV_CPU_HAS_SUPPORT_AVX_512F 1
 #  define CV_CPU_CALL_AVX_512F(fn, args) return (cpu_baseline::fn args)
 #  define CV_CPU_CALL_AVX_512F_(fn, args) return (opt_AVX_512F::fn args)
 #elif !defined CV_DISABLE_OPTIMIZATION && defined CV_ENABLE_INTRINSICS && defined CV_CPU_DISPATCH_COMPILE_AVX_512F
 #  define CV_TRY_AVX_512F 1
+#  define CV_CPU_FORCE_AVX_512F 0
 #  define CV_CPU_HAS_SUPPORT_AVX_512F (cv::checkHardwareSupport(CV_CPU_AVX_512F))
 #  define CV_CPU_CALL_AVX_512F(fn, args) if (CV_CPU_HAS_SUPPORT_AVX_512F) return (opt_AVX_512F::fn args)
 #  define CV_CPU_CALL_AVX_512F_(fn, args) if (CV_CPU_HAS_SUPPORT_AVX_512F) return (opt_AVX_512F::fn args)
 #else
 #  define CV_TRY_AVX_512F 0
+#  define CV_CPU_FORCE_AVX_512F 0
 #  define CV_CPU_HAS_SUPPORT_AVX_512F 0
 #  define CV_CPU_CALL_AVX_512F(fn, args)
 #  define CV_CPU_CALL_AVX_512F_(fn, args)
@@ -218,16 +254,19 @@
 
 #if !defined CV_DISABLE_OPTIMIZATION && defined CV_ENABLE_INTRINSICS && defined CV_CPU_COMPILE_AVX512_SKX
 #  define CV_TRY_AVX512_SKX 1
+#  define CV_CPU_FORCE_AVX512_SKX 1
 #  define CV_CPU_HAS_SUPPORT_AVX512_SKX 1
 #  define CV_CPU_CALL_AVX512_SKX(fn, args) return (cpu_baseline::fn args)
 #  define CV_CPU_CALL_AVX512_SKX_(fn, args) return (opt_AVX512_SKX::fn args)
 #elif !defined CV_DISABLE_OPTIMIZATION && defined CV_ENABLE_INTRINSICS && defined CV_CPU_DISPATCH_COMPILE_AVX512_SKX
 #  define CV_TRY_AVX512_SKX 1
+#  define CV_CPU_FORCE_AVX512_SKX 0
 #  define CV_CPU_HAS_SUPPORT_AVX512_SKX (cv::checkHardwareSupport(CV_CPU_AVX512_SKX))
 #  define CV_CPU_CALL_AVX512_SKX(fn, args) if (CV_CPU_HAS_SUPPORT_AVX512_SKX) return (opt_AVX512_SKX::fn args)
 #  define CV_CPU_CALL_AVX512_SKX_(fn, args) if (CV_CPU_HAS_SUPPORT_AVX512_SKX) return (opt_AVX512_SKX::fn args)
 #else
 #  define CV_TRY_AVX512_SKX 0
+#  define CV_CPU_FORCE_AVX512_SKX 0
 #  define CV_CPU_HAS_SUPPORT_AVX512_SKX 0
 #  define CV_CPU_CALL_AVX512_SKX(fn, args)
 #  define CV_CPU_CALL_AVX512_SKX_(fn, args)
@@ -236,16 +275,19 @@
 
 #if !defined CV_DISABLE_OPTIMIZATION && defined CV_ENABLE_INTRINSICS && defined CV_CPU_COMPILE_NEON
 #  define CV_TRY_NEON 1
+#  define CV_CPU_FORCE_NEON 1
 #  define CV_CPU_HAS_SUPPORT_NEON 1
 #  define CV_CPU_CALL_NEON(fn, args) return (cpu_baseline::fn args)
 #  define CV_CPU_CALL_NEON_(fn, args) return (opt_NEON::fn args)
 #elif !defined CV_DISABLE_OPTIMIZATION && defined CV_ENABLE_INTRINSICS && defined CV_CPU_DISPATCH_COMPILE_NEON
 #  define CV_TRY_NEON 1
+#  define CV_CPU_FORCE_NEON 0
 #  define CV_CPU_HAS_SUPPORT_NEON (cv::checkHardwareSupport(CV_CPU_NEON))
 #  define CV_CPU_CALL_NEON(fn, args) if (CV_CPU_HAS_SUPPORT_NEON) return (opt_NEON::fn args)
 #  define CV_CPU_CALL_NEON_(fn, args) if (CV_CPU_HAS_SUPPORT_NEON) return (opt_NEON::fn args)
 #else
 #  define CV_TRY_NEON 0
+#  define CV_CPU_FORCE_NEON 0
 #  define CV_CPU_HAS_SUPPORT_NEON 0
 #  define CV_CPU_CALL_NEON(fn, args)
 #  define CV_CPU_CALL_NEON_(fn, args)
@@ -254,16 +296,19 @@
 
 #if !defined CV_DISABLE_OPTIMIZATION && defined CV_ENABLE_INTRINSICS && defined CV_CPU_COMPILE_VSX
 #  define CV_TRY_VSX 1
+#  define CV_CPU_FORCE_VSX 1
 #  define CV_CPU_HAS_SUPPORT_VSX 1
 #  define CV_CPU_CALL_VSX(fn, args) return (cpu_baseline::fn args)
 #  define CV_CPU_CALL_VSX_(fn, args) return (opt_VSX::fn args)
 #elif !defined CV_DISABLE_OPTIMIZATION && defined CV_ENABLE_INTRINSICS && defined CV_CPU_DISPATCH_COMPILE_VSX
 #  define CV_TRY_VSX 1
+#  define CV_CPU_FORCE_VSX 0
 #  define CV_CPU_HAS_SUPPORT_VSX (cv::checkHardwareSupport(CV_CPU_VSX))
 #  define CV_CPU_CALL_VSX(fn, args) if (CV_CPU_HAS_SUPPORT_VSX) return (opt_VSX::fn args)
 #  define CV_CPU_CALL_VSX_(fn, args) if (CV_CPU_HAS_SUPPORT_VSX) return (opt_VSX::fn args)
 #else
 #  define CV_TRY_VSX 0
+#  define CV_CPU_FORCE_VSX 0
 #  define CV_CPU_HAS_SUPPORT_VSX 0
 #  define CV_CPU_CALL_VSX(fn, args)
 #  define CV_CPU_CALL_VSX_(fn, args)

--- a/modules/core/src/convert.cpp
+++ b/modules/core/src/convert.cpp
@@ -1363,7 +1363,7 @@ cvtScaleHalf_<float, short>( const float* src, size_t sstep, short* dst, size_t 
 {
     CV_CPU_CALL_FP16_(cvtScaleHalf_SIMD32f16f, (src, sstep, dst, dstep, size));
 
-#if !defined(CV_CPU_COMPILE_FP16)
+#if !CV_CPU_FORCE_FP16
     sstep /= sizeof(src[0]);
     dstep /= sizeof(dst[0]);
 
@@ -1382,7 +1382,7 @@ cvtScaleHalf_<short, float>( const short* src, size_t sstep, float* dst, size_t 
 {
     CV_CPU_CALL_FP16_(cvtScaleHalf_SIMD16f32f, (src, sstep, dst, dstep, size));
 
-#if !defined(CV_CPU_COMPILE_FP16)
+#if !CV_CPU_FORCE_FP16
     sstep /= sizeof(src[0]);
     dstep /= sizeof(dst[0]);
 


### PR DESCRIPTION
Reproducer:
```
cmake -DCPU_BASELINE=AVX2 -DCV_DISABLE_OPTIMIZATION=ON ...
```

This build configuration is used to measure "compiler" optimizations on C++ code without manual intrinsic/vectorized code.

Related: #8899

```
buildworker:Linux x64=linux-2
```