### PR TITLE
 Fix some C++ compiler warnings (case fallthrough, negation of string)

### DIFF
--- a/modules/core/include/opencv2/core/affine.hpp
+++ b/modules/core/include/opencv2/core/affine.hpp
@@ -445,7 +445,7 @@ void cv::Affine3<T>::rotation(const cv::Mat& data)
         rotation(_rvec);
     }
     else
-        CV_Assert(!"Input matrix can only be 3x3, 1x3 or 3x1");
+        CV_Error(Error::StsError, "Input matrix can only be 3x3, 1x3 or 3x1");
 }
 
 template<typename T> inline

--- a/modules/core/src/persistence_base64.cpp
+++ b/modules/core/src/persistence_base64.cpp
@@ -640,7 +640,9 @@ private:
                     pack.func = to_binary<double>;
                     break;
                 case 'r':
-                default: { CV_Assert(!"type not support"); break; }
+                default:
+                    CV_Error(cv::Error::StsError, "type is not supported");
+                    break;
                 };
 
                 offset = static_cast<size_t>(cvAlign(static_cast<int>(offset), static_cast<int>(size)));
@@ -799,7 +801,9 @@ private:
                     pack.func = binary_to<double>;
                     break;
                 case 'r':
-                default:  { CV_Assert(!"type not support"); break; }
+                default:
+                    CV_Error(cv::Error::StsError, "type is not supported");
+                    break;
                 }; // need a better way for outputting error.
 
                 offset = static_cast<size_t>(cvAlign(static_cast<int>(offset), static_cast<int>(size)));
@@ -817,7 +821,9 @@ private:
                 case 'f': { pack.cv_type = CV_32F; break; }
                 case 'd': { pack.cv_type = CV_64F; break; }
                 case 'r':
-                default:  { CV_Assert(!"type is not support"); break; }
+                default:
+                    CV_Error(cv::Error::StsError, "type is not supported");
+                    break;
                 } // need a better way for outputting error.
 
                 binary_to_funcs.push_back(pack);

--- a/modules/core/src/persistence_base64.cpp
+++ b/modules/core/src/persistence_base64.cpp
@@ -83,11 +83,15 @@ size_t base64_encode(uint8_t const * src, uint8_t * dst, size_t off, size_t cnt)
     /* padding */
     switch (rst)
     {
-    case 1U: *dst_cur++ = base64_padding;
-    case 2U: *dst_cur++ = base64_padding;
-    default: *dst_cur   = 0;
+    case 1U:
+        *dst_cur++ = base64_padding;
+        *dst_cur++ = base64_padding;
+        break;
+    case 2U:
+        *dst_cur++ = base64_padding;
         break;
     }
+    *dst_cur = 0;
 
     return static_cast<size_t>(dst_cur - dst_beg);
 }

--- a/modules/core/src/persistence_json.cpp
+++ b/modules/core/src/persistence_json.cpp
@@ -311,7 +311,7 @@ static char* icvJSONParseValue( CvFileStorage* fs, char* ptr, CvFileNode* node )
                     case 't' : { string_buffer.append( 1u, '\t' ); break; }
                     case 'b' : { string_buffer.append( 1u, '\b' ); break; }
                     case 'f' : { string_buffer.append( 1u, '\f' ); break; }
-                    case 'u' : { CV_PARSE_ERROR( "'\\uXXXX' currently not supported" ); }
+                    case 'u' : { CV_PARSE_ERROR( "'\\uXXXX' currently not supported" ); break; }
                     default  : { CV_PARSE_ERROR( "Invalid escape character" ); }
                         break;
                     }

--- a/modules/videoio/src/cap_gstreamer.cpp
+++ b/modules/videoio/src/cap_gstreamer.cpp
@@ -1614,7 +1614,8 @@ bool CvVideoWriter_GStreamer::open( const char * filename, int fourcc,
         caps = gst_caps_fixate(caps);
 #endif
 #else
-        CV_Assert(!"Gstreamer 0.10.29 or newer is required for grayscale input");
+        CV_Error(Error::StsError,
+                 "Gstreamer 0.10.29 or newer is required for grayscale input");
 #endif
     }
 

--- a/modules/viz/src/types.cpp
+++ b/modules/viz/src/types.cpp
@@ -63,7 +63,7 @@ cv::viz::Mesh cv::viz::Mesh::load(const String& file, int type)
     switch (type) {
       case LOAD_AUTO:
       {
-        CV_Assert(!"cv::viz::Mesh::LOAD_AUTO: Not implemented yet");
+        CV_Error(Error::StsError, "cv::viz::Mesh::LOAD_AUTO: Not implemented yet");
         break;
       }
       case LOAD_PLY:
@@ -83,7 +83,7 @@ cv::viz::Mesh cv::viz::Mesh::load(const String& file, int type)
         break;
       }
       default:
-        CV_Assert(!"cv::viz::Mesh::load: Unknown file type");
+        CV_Error(Error::StsError, "cv::viz::Mesh::load: Unknown file type");
         break;
     }
 

--- a/modules/viz/src/vizcore.cpp
+++ b/modules/viz/src/vizcore.cpp
@@ -194,7 +194,7 @@ void cv::viz::writeCloud(const String& file, InputArray cloud, InputArray colors
         vtkOBJWriter::SafeDownCast(writer)->SetFileName(file.c_str());
     }
     else
-        CV_Assert(!"Unsupported format");
+        CV_Error(Error::StsError, "Unsupported format");
 
     writer->SetInputConnection(source->GetOutputPort());
     writer->Write();
@@ -228,7 +228,7 @@ cv::Mat cv::viz::readCloud(const String& file, OutputArray colors, OutputArray n
         vtkSTLReader::SafeDownCast(reader)->SetFileName(file.c_str());
     }
     else
-        CV_Assert(!"Unsupported format");
+        CV_Error(Error::StsError, "Unsupported format");
 
     cv::Mat cloud;
 
@@ -325,7 +325,7 @@ void cv::viz::writeTrajectory(InputArray _traj, const String& files_format, int 
         return;
     }
 
-    CV_Assert(!"Unsupported array kind");
+    CV_Error(Error::StsError, "Unsupported array kind");
 }
 
 ///////////////////////////////////////////////////////////////////////////////////////////////

--- a/modules/viz/src/vtk/vtkCloudMatSource.cpp
+++ b/modules/viz/src/vtk/vtkCloudMatSource.cpp
@@ -128,7 +128,7 @@ int cv::viz::vtkCloudMatSource::SetColorCloudNormals(InputArray _cloud, InputArr
     else if (n.depth() == CV_64F && c.depth() == CV_64F)
         filterNanNormalsCopy<double, double>(n, c, total);
     else
-        CV_Assert(!"Unsupported normals/cloud type");
+        CV_Error(Error::StsError, "Unsupported normals/cloud type");
 
     return total;
 }
@@ -155,7 +155,7 @@ int cv::viz::vtkCloudMatSource::SetColorCloudNormalsTCoords(InputArray _cloud, I
     else if (tc.depth() == CV_64F && cl.depth() == CV_64F)
         filterNanTCoordsCopy<double, double>(tc, cl, total);
     else
-        CV_Assert(!"Unsupported tcoords/cloud type");
+        CV_Error(Error::StsError, "Unsupported tcoords/cloud type");
 
     return total;
 }


### PR DESCRIPTION
### This pullrequest changes

Replace {!"string"} with {false && "string"}
Replace case statement fallthroughs with break statements

The warnings appear in gcc 7.3.0 with -Wimplicit-fallthrough

