### PR TITLE
Allow using more types with LUT, findNonZero, and PSNR.

### DIFF
--- a/modules/core/include/opencv2/core.hpp
+++ b/modules/core/include/opencv2/core.hpp
@@ -1079,7 +1079,7 @@ and the rows and cols are switched for ROTATE_90_CLOCKWISE and ROTATE_90_COUNTER
 @param rotateCode an enum to specify how to rotate the array; see the enum #RotateFlags
 @sa transpose , repeat , completeSymm, flip, RotateFlags
 */
-CV_EXPORTS_W void rotate(InputArray src, OutputArray dst, RotateFlags rotateCode);
+CV_EXPORTS_W void rotate(InputArray src, OutputArray dst, int rotateCode);
 
 /** @brief Fills the output array with repeated copies of the input array.
 

--- a/modules/core/include/opencv2/core.hpp
+++ b/modules/core/include/opencv2/core.hpp
@@ -548,8 +548,9 @@ are taken from the input array. That is, the function processes each element of 
 \f[\texttt{dst} (I)  \leftarrow \texttt{lut(src(I) + d)}\f]
 where
 \f[d =  \fork{0}{if \(\texttt{src}\) has depth \(\texttt{CV_8U}\)}{128}{if \(\texttt{src}\) has depth \(\texttt{CV_8S}\)}\f]
-@param src input array of 8-bit elements.
-@param lut look-up table of 256 elements; in case of multi-channel input array, the table should
+\f[d =  \fork{0}{if \(\texttt{src}\) has depth \(\texttt{CV_16U}\)}{131072}{if \(\texttt{src}\) has depth \(\texttt{CV_16S}\)}\f]
+@param src input array of 8 or 16-bit elements.
+@param lut look-up table of 256 or 65536 elements; in case of multi-channel input array, the table should
 either have a single channel (in this case the same table is used for all channels) or the same
 number of channels as in the input array.
 @param dst output array of the same size and number of channels as src, and the same depth as lut.
@@ -598,7 +599,7 @@ or
     // access pixel coordinates
     Point pnt = locations[i];
 @endcode
-@param src single-channel array (type CV_8UC1)
+@param src single-channel array
 @param idx the output array, type of cv::Mat or std::vector<Point>, corresponding to non-zero indices in the input
 */
 CV_EXPORTS_W void findNonZero( InputArray src, OutputArray idx );
@@ -706,13 +707,14 @@ The PSNR is calculated as follows:
 \texttt{PSNR} = 10 \cdot \log_{10}{\left( \frac{R^2}{MSE} \right) }
 \f]
 
-where R is the maximum integer value of depth CV_8U (255) and MSE is the mean squared error between the two arrays.
+where R is the maximum possible difference (for CV_8U R = 255) and MSE is the mean squared error between the two arrays.
 
 @param src1 first input array.
 @param src2 second input array of the same size as src1.
+@param R is the maximum possible difference between images, default = 255
 
   */
-CV_EXPORTS_W double PSNR(InputArray src1, InputArray src2);
+CV_EXPORTS_W double PSNR(InputArray src1, InputArray src2, double R = 255.);
 
 /** @brief naive nearest neighbor finder
 
@@ -1077,7 +1079,7 @@ and the rows and cols are switched for ROTATE_90_CLOCKWISE and ROTATE_90_COUNTER
 @param rotateCode an enum to specify how to rotate the array; see the enum #RotateFlags
 @sa transpose , repeat , completeSymm, flip, RotateFlags
 */
-CV_EXPORTS_W void rotate(InputArray src, OutputArray dst, int rotateCode);
+CV_EXPORTS_W void rotate(InputArray src, OutputArray dst, RotateFlags rotateCode);
 
 /** @brief Fills the output array with repeated copies of the input array.
 

--- a/modules/core/src/copy.cpp
+++ b/modules/core/src/copy.cpp
@@ -807,7 +807,7 @@ static bool ocl_rotate(InputArray _src, OutputArray _dst, int rotateMode)
 }
 #endif
 
-void rotate(InputArray _src, OutputArray _dst, int rotateMode)
+void rotate(InputArray _src, OutputArray _dst, RotateFlags rotateMode)
 {
     CV_Assert(_src.dims() <= 2);
 

--- a/modules/core/src/copy.cpp
+++ b/modules/core/src/copy.cpp
@@ -807,7 +807,7 @@ static bool ocl_rotate(InputArray _src, OutputArray _dst, int rotateMode)
 }
 #endif
 
-void rotate(InputArray _src, OutputArray _dst, RotateFlags rotateMode)
+void rotate(InputArray _src, OutputArray _dst, int rotateMode)
 {
     CV_Assert(_src.dims() <= 2);
 

--- a/modules/core/src/count_non_zero.cpp
+++ b/modules/core/src/count_non_zero.cpp
@@ -388,12 +388,24 @@ int cv::countNonZero( InputArray _src )
     return nz;
 }
 
+template<typename T>
+void nonZero(const cv::Mat& src, cv::Point* idx_ptr)
+{
+    for( int i = 0; i < src.rows; i++ )
+    {
+        const T* bin_ptr = src.ptr<T>(i);
+        for( int j = 0; j < src.cols; j++ )
+            if( bin_ptr[j] != (T)0)
+                *idx_ptr++ = cv::Point(j, i);
+    }
+}
+
 void cv::findNonZero( InputArray _src, OutputArray _idx )
 {
     CV_INSTRUMENT_REGION()
 
     Mat src = _src.getMat();
-    CV_Assert( src.type() == CV_8UC1 );
+    CV_Assert( src.channels() == 1 );
     int n = countNonZero(src);
     if( n == 0 )
     {
@@ -407,11 +419,30 @@ void cv::findNonZero( InputArray _src, OutputArray _idx )
     CV_Assert(idx.isContinuous());
     Point* idx_ptr = idx.ptr<Point>();
 
-    for( int i = 0; i < src.rows; i++ )
+    switch(src.depth())
     {
-        const uchar* bin_ptr = src.ptr(i);
-        for( int j = 0; j < src.cols; j++ )
-            if( bin_ptr[j] )
-                *idx_ptr++ = Point(j, i);
+    case CV_8U:
+        nonZero<uchar>(src, idx_ptr);
+        break;
+    case CV_8S:
+        nonZero<char>(src, idx_ptr);
+        break;
+    case CV_16U:
+        nonZero<ushort>(src, idx_ptr);
+        break;
+    case CV_16S:
+        nonZero<short>(src, idx_ptr);
+        break;
+    case CV_32S:
+        nonZero<int>(src, idx_ptr);
+        break;
+    case CV_32F:
+        nonZero<float>(src, idx_ptr);
+        break;
+    case CV_64F:
+        nonZero<double>(src, idx_ptr);
+        break;
+    default:
+        CV_Assert("Invalid Input Type");
     }
 }

--- a/modules/core/src/lut.cpp
+++ b/modules/core/src/lut.cpp
@@ -15,63 +15,225 @@
 namespace cv
 {
 
-template<typename T> static void
-LUT8u_( const uchar* src, const T* lut, T* dst, int len, int cn, int lutcn )
+template<typename S, typename T> static void
+LUT_S_T( const S* src, const T* lut, T* dst, int len, int cn, int lutcn, uint offset = 0)
 {
     if( lutcn == 1 )
     {
         for( int i = 0; i < len*cn; i++ )
-            dst[i] = lut[src[i]];
+            dst[i] = lut[src[i]+offset];
     }
     else
     {
         for( int i = 0; i < len*cn; i += cn )
             for( int k = 0; k < cn; k++ )
-                dst[i+k] = lut[src[i+k]*cn+k];
+                dst[i+k] = lut[(src[i+k]+offset)*cn+k];
     }
 }
 
 static void LUT8u_8u( const uchar* src, const uchar* lut, uchar* dst, int len, int cn, int lutcn )
 {
-    LUT8u_( src, lut, dst, len, cn, lutcn );
+    LUT_S_T( src, lut, dst, len, cn, lutcn );
 }
 
 static void LUT8u_8s( const uchar* src, const schar* lut, schar* dst, int len, int cn, int lutcn )
 {
-    LUT8u_( src, lut, dst, len, cn, lutcn );
+    LUT_S_T( src, lut, dst, len, cn, lutcn );
 }
 
 static void LUT8u_16u( const uchar* src, const ushort* lut, ushort* dst, int len, int cn, int lutcn )
 {
-    LUT8u_( src, lut, dst, len, cn, lutcn );
+    LUT_S_T( src, lut, dst, len, cn, lutcn );
 }
 
 static void LUT8u_16s( const uchar* src, const short* lut, short* dst, int len, int cn, int lutcn )
 {
-    LUT8u_( src, lut, dst, len, cn, lutcn );
+    LUT_S_T( src, lut, dst, len, cn, lutcn );
 }
 
 static void LUT8u_32s( const uchar* src, const int* lut, int* dst, int len, int cn, int lutcn )
 {
-    LUT8u_( src, lut, dst, len, cn, lutcn );
+    LUT_S_T( src, lut, dst, len, cn, lutcn );
 }
 
 static void LUT8u_32f( const uchar* src, const float* lut, float* dst, int len, int cn, int lutcn )
 {
-    LUT8u_( src, lut, dst, len, cn, lutcn );
+    LUT_S_T( src, lut, dst, len, cn, lutcn );
 }
 
 static void LUT8u_64f( const uchar* src, const double* lut, double* dst, int len, int cn, int lutcn )
 {
-    LUT8u_( src, lut, dst, len, cn, lutcn );
+    LUT_S_T( src, lut, dst, len, cn, lutcn );
+}
+
+static void LUT8s_8u( const uchar* src, const uchar* lut, uchar* dst, int len, int cn, int lutcn )
+{
+    LUT_S_T( src, lut, dst, len, cn, lutcn, std::numeric_limits<char>::max()+1 );
+}
+
+static void LUT8s_8s( const uchar* src, const schar* lut, schar* dst, int len, int cn, int lutcn )
+{
+    LUT_S_T( src, lut, dst, len, cn, lutcn, std::numeric_limits<char>::max()+1 );
+}
+
+static void LUT8s_16u( const uchar* src, const ushort* lut, ushort* dst, int len, int cn, int lutcn )
+{
+    LUT_S_T( src, lut, dst, len, cn, lutcn, std::numeric_limits<char>::max()+1 );
+}
+
+static void LUT8s_16s( const uchar* src, const short* lut, short* dst, int len, int cn, int lutcn )
+{
+    LUT_S_T( src, lut, dst, len, cn, lutcn, std::numeric_limits<char>::max()+1 );
+}
+
+static void LUT8s_32s( const uchar* src, const int* lut, int* dst, int len, int cn, int lutcn )
+{
+    LUT_S_T( src, lut, dst, len, cn, lutcn, std::numeric_limits<char>::max()+1 );
+}
+
+static void LUT8s_32f( const uchar* src, const float* lut, float* dst, int len, int cn, int lutcn )
+{
+    LUT_S_T( src, lut, dst, len, cn, lutcn, std::numeric_limits<char>::max()+1 );
+}
+
+static void LUT8s_64f( const uchar* src, const double* lut, double* dst, int len, int cn, int lutcn )
+{
+    LUT_S_T( src, lut, dst, len, cn, lutcn, std::numeric_limits<char>::max()+1 );
+}
+
+//16 bit
+static void LUT16u_8u( const uchar* src, const uchar* lut, uchar* dst, int len, int cn, int lutcn )
+{
+    LUT_S_T( (ushort*)src, lut, dst, len, cn, lutcn );
+}
+
+static void LUT16u_8s( const uchar* src, const schar* lut, schar* dst, int len, int cn, int lutcn )
+{
+    LUT_S_T( (ushort*)src, lut, dst, len, cn, lutcn );
+}
+
+static void LUT16u_16u( const uchar* src, const ushort* lut, ushort* dst, int len, int cn, int lutcn )
+{
+    LUT_S_T( (ushort*)src, lut, dst, len, cn, lutcn );
+}
+
+static void LUT16u_16s( const uchar* src, const short* lut, short* dst, int len, int cn, int lutcn )
+{
+    LUT_S_T( (ushort*)src, lut, dst, len, cn, lutcn );
+}
+
+static void LUT16u_32s( const uchar* src, const int* lut, int* dst, int len, int cn, int lutcn )
+{
+    LUT_S_T( (ushort*)src, lut, dst, len, cn, lutcn );
+}
+
+static void LUT16u_32f( const uchar* src, const float* lut, float* dst, int len, int cn, int lutcn )
+{
+    LUT_S_T( (ushort*)src, lut, dst, len, cn, lutcn );
+}
+
+static void LUT16u_64f( const uchar* src, const double* lut, double* dst, int len, int cn, int lutcn )
+{
+    LUT_S_T( (ushort*)src, lut, dst, len, cn, lutcn );
+}
+
+static void LUT16s_8u( const uchar* src, const uchar* lut, uchar* dst, int len, int cn, int lutcn )
+{
+    LUT_S_T( (ushort*)src, lut, dst, len, cn, lutcn, std::numeric_limits<short>::max()+1 );
+}
+
+static void LUT16s_8s( const uchar* src, const schar* lut, schar* dst, int len, int cn, int lutcn )
+{
+    LUT_S_T( (ushort*)src, lut, dst, len, cn, lutcn, std::numeric_limits<short>::max()+1 );
+}
+
+static void LUT16s_16u( const uchar* src, const ushort* lut, ushort* dst, int len, int cn, int lutcn )
+{
+    LUT_S_T( (ushort*)src, lut, dst, len, cn, lutcn, std::numeric_limits<short>::max()+1 );
+}
+
+static void LUT16s_16s( const uchar* src, const short* lut, short* dst, int len, int cn, int lutcn )
+{
+    LUT_S_T( (ushort*)src, lut, dst, len, cn, lutcn, std::numeric_limits<short>::max()+1 );
+}
+
+static void LUT16s_32s( const uchar* src, const int* lut, int* dst, int len, int cn, int lutcn )
+{
+    LUT_S_T( (ushort*)src, lut, dst, len, cn, lutcn, std::numeric_limits<short>::max()+1 );
+}
+
+static void LUT16s_32f( const uchar* src, const float* lut, float* dst, int len, int cn, int lutcn )
+{
+    LUT_S_T( (ushort*)src, lut, dst, len, cn, lutcn, std::numeric_limits<short>::max()+1 );
+}
+
+static void LUT16s_64f( const uchar* src, const double* lut, double* dst, int len, int cn, int lutcn )
+{
+    LUT_S_T( (ushort*)src, lut, dst, len, cn, lutcn, std::numeric_limits<short>::max()+1 );
+}
+
+//32 bit
+static void LUT32s_8u( const uchar* src, const uchar* lut, uchar* dst, int len, int cn, int lutcn )
+{
+    LUT_S_T( (uint*)src, lut, dst, len, cn, lutcn, std::numeric_limits<int>::max()+1 );
+}
+
+static void LUT32s_8s( const uchar* src, const schar* lut, schar* dst, int len, int cn, int lutcn )
+{
+    LUT_S_T( (uint*)src, lut, dst, len, cn, lutcn, std::numeric_limits<int>::max()+1 );
+}
+
+static void LUT32s_16u( const uchar* src, const ushort* lut, ushort* dst, int len, int cn, int lutcn )
+{
+    LUT_S_T( (uint*)src, lut, dst, len, cn, lutcn, std::numeric_limits<int>::max()+1 );
+}
+
+static void LUT32s_16s( const uchar* src, const short* lut, short* dst, int len, int cn, int lutcn )
+{
+    LUT_S_T( (uint*)src, lut, dst, len, cn, lutcn, std::numeric_limits<int>::max()+1 );
+}
+
+static void LUT32s_32s( const uchar* src, const int* lut, int* dst, int len, int cn, int lutcn )
+{
+    LUT_S_T( (uint*)src, lut, dst, len, cn, lutcn, std::numeric_limits<int>::max()+1 );
+}
+
+static void LUT32s_32f( const uchar* src, const float* lut, float* dst, int len, int cn, int lutcn )
+{
+    LUT_S_T( (uint*)src, lut, dst, len, cn, lutcn, std::numeric_limits<int>::max()+1 );
+}
+
+static void LUT32s_64f( const uchar* src, const double* lut, double* dst, int len, int cn, int lutcn )
+{
+    LUT_S_T( (uint*)src, lut, dst, len, cn, lutcn, std::numeric_limits<int>::max()+1 );
 }
 
 typedef void (*LUTFunc)( const uchar* src, const uchar* lut, uchar* dst, int len, int cn, int lutcn );
 
-static LUTFunc lutTab[] =
+static LUTFunc lutTab[][8] =
+{
 {
     (LUTFunc)LUT8u_8u, (LUTFunc)LUT8u_8s, (LUTFunc)LUT8u_16u, (LUTFunc)LUT8u_16s,
     (LUTFunc)LUT8u_32s, (LUTFunc)LUT8u_32f, (LUTFunc)LUT8u_64f, 0
+},
+{
+    (LUTFunc)LUT8s_8u, (LUTFunc)LUT8s_8s, (LUTFunc)LUT8s_16u, (LUTFunc)LUT8s_16s,
+    (LUTFunc)LUT8s_32s, (LUTFunc)LUT8s_32f, (LUTFunc)LUT8s_64f, 0
+},
+{
+    (LUTFunc)LUT16u_8u, (LUTFunc)LUT16u_8s, (LUTFunc)LUT16u_16u, (LUTFunc)LUT16u_16s,
+    (LUTFunc)LUT16u_32s, (LUTFunc)LUT16u_32f, (LUTFunc)LUT16u_64f, 0
+},
+{
+    (LUTFunc)LUT16s_8u, (LUTFunc)LUT16s_8s, (LUTFunc)LUT16s_16u, (LUTFunc)LUT16s_16s,
+    (LUTFunc)LUT16s_32s, (LUTFunc)LUT16s_32f, (LUTFunc)LUT16s_64f, 0
+},
+{
+    (LUTFunc)LUT32s_8u, (LUTFunc)LUT32s_8s, (LUTFunc)LUT32s_16u, (LUTFunc)LUT32s_16s,
+    (LUTFunc)LUT32s_32s, (LUTFunc)LUT32s_32f, (LUTFunc)LUT32s_64f, 0
+},
+{ 0, 0, 0, 0, 0, 0, 0, 0},//32f
+{ 0, 0, 0, 0, 0, 0, 0, 0},//64f
 };
 
 #ifdef HAVE_OPENCL
@@ -84,10 +246,22 @@ static bool ocl_LUT(InputArray _src, InputArray _lut, OutputArray _dst)
     _dst.create(src.size(), CV_MAKETYPE(ddepth, dcn));
     UMat dst = _dst.getUMat();
     int kercn = lcn == 1 ? std::min(4, ocl::predictOptimalVectorWidth(_src, _dst)) : dcn;
+    unsigned int offset = 0;
+    switch(_src.depth())
+    {
+    case CV_8S:
+        offset = std::numeric_limits<char>::max()+1;
+        break;
+    case CV_16S:
+        offset = std::numeric_limits<short>::max()+1;
+        break;
+    default:
+        offset = 0;
+    }
 
     ocl::Kernel k("LUT", ocl::core::lut_oclsrc,
-                  format("-D dcn=%d -D lcn=%d -D srcT=%s -D dstT=%s", kercn, lcn,
-                         ocl::typeToStr(src.depth()), ocl::memopTypeToStr(ddepth)));
+                  format("-D dcn=%d -D lcn=%d -D srcT=%s -D dstT=%s -D lutLEN=%d -D lutOFF=%d", kercn, lcn,
+                         ocl::typeToStr(src.depth()), ocl::memopTypeToStr(ddepth), _lut.total(), offset));
     if (k.empty())
         return false;
 
@@ -324,11 +498,11 @@ public:
     LUTParallelBody(const Mat& src, const Mat& lut, Mat& dst, bool* _ok)
         : ok(_ok), src_(src), lut_(lut), dst_(dst)
     {
-        func = lutTab[lut.depth()];
+        func = lutTab[src.depth()][lut.depth()];
         *ok = (func != NULL);
     }
 
-    void operator()( const cv::Range& range ) const CV_OVERRIDE
+    void operator()( const cv::Range& range ) const
     {
         CV_DbgAssert(*ok);
 
@@ -354,7 +528,7 @@ private:
     LUTParallelBody& operator=(const LUTParallelBody&);
 };
 
-} // cv::
+}
 
 void cv::LUT( InputArray _src, InputArray _lut, OutputArray _dst )
 {
@@ -363,23 +537,37 @@ void cv::LUT( InputArray _src, InputArray _lut, OutputArray _dst )
     int cn = _src.channels(), depth = _src.depth();
     int lutcn = _lut.channels();
 
-    CV_Assert( (lutcn == cn || lutcn == 1) &&
-        _lut.total() == 256 && _lut.isContinuous() &&
-        (depth == CV_8U || depth == CV_8S) );
-
+    CV_Assert( (lutcn == cn || lutcn == 1) && _lut.isContinuous() );
+    switch(depth)
+    {
+    case CV_8U:
+    case CV_8S:
+        CV_Assert((depth == CV_8U || depth == CV_8S) && _lut.total() == 256);
+        break;
+    case CV_16U:
+    case CV_16S:
+        CV_Assert((depth == CV_16U || depth == CV_16S) && _lut.total() == 65536);
+        break;
+    default:
+        CV_Assert(false && "Input depth is not a supported type.");
+    }
+    
     CV_OCL_RUN(_dst.isUMat() && _src.dims() <= 2,
-               ocl_LUT(_src, _lut, _dst))
+                ocl_LUT(_src, _lut, _dst))
 
     Mat src = _src.getMat(), lut = _lut.getMat();
     _dst.create(src.dims, src.size, CV_MAKETYPE(_lut.depth(), cn));
     Mat dst = _dst.getMat();
 
-    CV_OVX_RUN(!ovx::skipSmallImages<VX_KERNEL_TABLE_LOOKUP>(src.cols, src.rows),
-               openvx_LUT(src, dst, lut))
+    if(depth == CV_8U || depth == CV_8S)
+    {
+        CV_OVX_RUN(!ovx::skipSmallImages<VX_KERNEL_TABLE_LOOKUP>(src.cols, src.rows),
+                   openvx_LUT(src, dst, lut))
 
 #if !IPP_DISABLE_PERF_LUT
-    CV_IPP_RUN(_src.dims() <= 2, ipp_lut(src, lut, dst));
+        CV_IPP_RUN(_src.dims() <= 2, ipp_lut(src, lut, dst));
 #endif
+    }
 
     if (_src.dims() <= 2)
     {
@@ -404,7 +592,7 @@ void cv::LUT( InputArray _src, InputArray _lut, OutputArray _dst )
         }
     }
 
-    LUTFunc func = lutTab[lut.depth()];
+    LUTFunc func = lutTab[src.depth()][lut.depth()];
     CV_Assert( func != 0 );
 
     const Mat* arrays[] = {&src, &dst, 0};

--- a/modules/core/src/lut.cpp
+++ b/modules/core/src/lut.cpp
@@ -552,7 +552,7 @@ void cv::LUT( InputArray _src, InputArray _lut, OutputArray _dst )
     default:
         CV_Assert(false && "Input depth is not a supported type.");
     }
-    
+
     CV_OCL_RUN(_dst.isUMat() && _src.dims() <= 2,
                 ocl_LUT(_src, _lut, _dst))
 

--- a/modules/core/src/lut.cpp
+++ b/modules/core/src/lut.cpp
@@ -246,6 +246,7 @@ static bool ocl_LUT(InputArray _src, InputArray _lut, OutputArray _dst)
     _dst.create(src.size(), CV_MAKETYPE(ddepth, dcn));
     UMat dst = _dst.getUMat();
     int kercn = lcn == 1 ? std::min(4, ocl::predictOptimalVectorWidth(_src, _dst)) : dcn;
+
     unsigned int offset = 0;
     switch(_src.depth())
     {

--- a/modules/core/src/norm.cpp
+++ b/modules/core/src/norm.cpp
@@ -1241,13 +1241,14 @@ cv::Hamming::ResultType cv::Hamming::operator()( const unsigned char* a, const u
     return cv::hal::normHamming(a, b, size);
 }
 
-double cv::PSNR(InputArray _src1, InputArray _src2)
+double cv::PSNR(InputArray _src1, InputArray _src2, double R)
 {
     CV_INSTRUMENT_REGION()
 
-    //Input arrays must have depth CV_8U
-    CV_Assert( _src1.depth() == CV_8U && _src2.depth() == CV_8U );
+    //Input arrays must have same depth
+    CV_Assert( _src1.depth() == _src2.depth() );
 
     double diff = std::sqrt(norm(_src1, _src2, NORM_L2SQR)/(_src1.total()*_src1.channels()));
-    return 20*log10(255./(diff+DBL_EPSILON));
+
+    return 20*log10(R/(diff+DBL_EPSILON));
 }

--- a/modules/core/src/opencl/lut.cl
+++ b/modules/core/src/opencl/lut.cl
@@ -33,78 +33,18 @@
 // the use of this software, even if advised of the possibility of such damage.
 //
 //
-
 #if lcn == 1
-    #if dcn == 4
-        #define LUT_OP  \
-            int idx = *(__global const int *)(srcptr + src_index); \
-            dst = (__global dstT *)(dstptr + dst_index); \
-            dst[0] = lut_l[idx & 0xff]; \
-            dst[1] = lut_l[(idx >> 8) & 0xff]; \
-            dst[2] = lut_l[(idx >> 16) & 0xff]; \
-            dst[3] = lut_l[(idx >> 24) & 0xff];
-    #elif dcn == 3
-        #define LUT_OP  \
-            uchar3 idx = vload3(0, srcptr + src_index); \
-            dst = (__global dstT *)(dstptr + dst_index); \
-            dst[0] = lut_l[idx.x]; \
-            dst[1] = lut_l[idx.y]; \
-            dst[2] = lut_l[idx.z];
-    #elif dcn == 2
-        #define LUT_OP \
-            short idx = *(__global const short *)(srcptr + src_index); \
-            dst = (__global dstT *)(dstptr + dst_index); \
-            dst[0] = lut_l[idx & 0xff]; \
-            dst[1] = lut_l[(idx >> 8) & 0xff];
-    #elif dcn == 1
-        #define LUT_OP \
-            uchar idx = (srcptr + src_index)[0]; \
-            dst = (__global dstT *)(dstptr + dst_index); \
-            dst[0] = lut_l[idx];
-    #else
-        #define LUT_OP \
-            __global const srcT * src = (__global const srcT *)(srcptr + src_index); \
-            dst = (__global dstT *)(dstptr + dst_index); \
-            for (int cn = 0; cn < dcn; ++cn) \
-                dst[cn] = lut_l[src[cn]];
-    #endif
+#define LUT_OP \
+    __global const srcT * src = (__global const srcT *)(srcptr + src_index); \
+    dst = (__global dstT *)(dstptr + dst_index); \
+    for (int cn = 0; cn < dcn; ++cn) \
+        dst[cn] = lut_l[src[cn]+lutOFF];
 #else
-    #if dcn == 4
-        #define LUT_OP \
-            __global const uchar4 * src_pixel = (__global const uchar4 *)(srcptr + src_index); \
-            int4 idx = mad24(convert_int4(src_pixel[0]), (int4)(lcn), (int4)(0, 1, 2, 3)); \
-            dst = (__global dstT *)(dstptr + dst_index); \
-            dst[0] = lut_l[idx.x]; \
-            dst[1] = lut_l[idx.y]; \
-            dst[2] = lut_l[idx.z]; \
-            dst[3] = lut_l[idx.w];
-    #elif dcn == 3
-        #define LUT_OP \
-            uchar3 src_pixel = vload3(0, srcptr + src_index); \
-            int3 idx = mad24(convert_int3(src_pixel), (int3)(lcn), (int3)(0, 1, 2)); \
-            dst = (__global dstT *)(dstptr + dst_index); \
-            dst[0] = lut_l[idx.x]; \
-            dst[1] = lut_l[idx.y]; \
-            dst[2] = lut_l[idx.z];
-    #elif dcn == 2
-        #define LUT_OP \
-            __global const uchar2 * src_pixel = (__global const uchar2 *)(srcptr + src_index); \
-            int2 idx = mad24(convert_int2(src_pixel[0]), lcn, (int2)(0, 1)); \
-            dst = (__global dstT *)(dstptr + dst_index); \
-            dst[0] = lut_l[idx.x]; \
-            dst[1] = lut_l[idx.y];
-    #elif dcn == 1 //error case (1 < lcn) ==> lcn == scn == dcn
-        #define LUT_OP \
-            uchar idx = (srcptr + src_index)[0]; \
-            dst = (__global dstT *)(dstptr + dst_index); \
-            dst[0] = lut_l[idx];
-    #else
-        #define LUT_OP \
-            __global const srcT * src = (__global const srcT *)(srcptr + src_index); \
-            dst = (__global dstT *)(dstptr + dst_index); \
-            for (int cn = 0; cn < dcn; ++cn) \
-                dst[cn] = lut_l[mad24(src[cn], lcn, cn)];
-    #endif
+#define LUT_OP \
+    __global const srcT * src = (__global const srcT *)(srcptr + src_index); \
+    dst = (__global dstT *)(dstptr + dst_index); \
+    for (int cn = 0; cn < dcn; ++cn) \
+        dst[cn] = lut_l[mad24(src[cn]+lutOFF, lcn, cn)];
 #endif
 
 __kernel void LUT(__global const uchar * srcptr, int src_step, int src_offset,
@@ -114,11 +54,11 @@ __kernel void LUT(__global const uchar * srcptr, int src_step, int src_offset,
     int x = get_global_id(0);
     int y = get_global_id(1) << 2;
 
-    __local dstT lut_l[256 * lcn];
+    __local dstT lut_l[lutLEN * lcn];
     __global const dstT * lut = (__global const dstT *)(lutptr + lut_offset);
 
     for (int i = mad24((int)get_local_id(1), (int)get_local_size(0), (int)get_local_id(0)),
-             step = get_local_size(0) * get_local_size(1); i < 256 * lcn; i += step)
+             step = get_local_size(0) * get_local_size(1); i < lutLEN * lcn; i += step)
         lut_l[i] = lut[i];
     barrier(CLK_LOCAL_MEM_FENCE);
 

--- a/modules/core/src/opencl/lut.cl
+++ b/modules/core/src/opencl/lut.cl
@@ -38,13 +38,13 @@
     __global const srcT * src = (__global const srcT *)(srcptr + src_index); \
     dst = (__global dstT *)(dstptr + dst_index); \
     for (int cn = 0; cn < dcn; ++cn) \
-        dst[cn] = lut_l[src[cn]+lutOFF];
+        dst[cn] = lut[src[cn]+lutOFF];
 #else
 #define LUT_OP \
     __global const srcT * src = (__global const srcT *)(srcptr + src_index); \
     dst = (__global dstT *)(dstptr + dst_index); \
     for (int cn = 0; cn < dcn; ++cn) \
-        dst[cn] = lut_l[mad24(src[cn]+lutOFF, lcn, cn)];
+        dst[cn] = lut[mad24(src[cn]+lutOFF, lcn, cn)];
 #endif
 
 __kernel void LUT(__global const uchar * srcptr, int src_step, int src_offset,
@@ -54,13 +54,13 @@ __kernel void LUT(__global const uchar * srcptr, int src_step, int src_offset,
     int x = get_global_id(0);
     int y = get_global_id(1) << 2;
 
-    __local dstT lut_l[lutLEN * lcn];
+    //__local dstT lut_l[lutLEN * lcn];
     __global const dstT * lut = (__global const dstT *)(lutptr + lut_offset);
 
-    for (int i = mad24((int)get_local_id(1), (int)get_local_size(0), (int)get_local_id(0)),
-             step = get_local_size(0) * get_local_size(1); i < lutLEN * lcn; i += step)
-        lut_l[i] = lut[i];
-    barrier(CLK_LOCAL_MEM_FENCE);
+    //for (int i = mad24((int)get_local_id(1), (int)get_local_size(0), (int)get_local_id(0)),
+    //         step = get_local_size(0) * get_local_size(1); i < lutLEN * lcn; i += step)
+    //    lut_l[i] = lut[i];
+    //barrier(CLK_LOCAL_MEM_FENCE);
 
     if (x < cols && y < rows)
     {

--- a/modules/core/src/opencl/lut.cl
+++ b/modules/core/src/opencl/lut.cl
@@ -34,17 +34,73 @@
 //
 //
 #if lcn == 1
-#define LUT_OP \
-    __global const srcT * src = (__global const srcT *)(srcptr + src_index); \
-    dst = (__global dstT *)(dstptr + dst_index); \
-    for (int cn = 0; cn < dcn; ++cn) \
-        dst[cn] = lut[src[cn]+lutOFF];
+    //#if dcn == 4
+    //    #define LUT_OP \
+    //        __global const srcT * src = (__global const srcT *)(srcptr + src_index); \
+    //        dst = (__global dstT *)(dstptr + dst_index); \
+    //        dst[0] = lut[src[0]+lutOFF]; \
+    //        dst[1] = lut[src[1]+lutOFF]; \
+    //        dst[2] = lut[src[2]+lutOFF]; \
+    //        dst[3] = lut[src[3]+lutOFF];
+    //#elif dcn == 3
+    //    #define LUT_OP \
+    //        __global const srcT * src = (__global const srcT *)(srcptr + src_index); \
+    //        dst = (__global dstT *)(dstptr + dst_index); \
+    //        dst[0] = lut[src[0]+lutOFF]; \
+    //        dst[1] = lut[src[1]+lutOFF]; \
+    //        dst[2] = lut[src[2]+lutOFF];
+    //#elif dcn == 2
+    //    #define LUT_OP \
+    //        __global const srcT * src = (__global const srcT *)(srcptr + src_index); \
+    //        dst = (__global dstT *)(dstptr + dst_index); \
+    //        dst[0] = lut[src[0]+lutOFF]; \
+    //        dst[1] = lut[src[1]+lutOFF];
+    //#elif dcn == 1
+    //    #define LUT_OP \
+    //        __global const srcT * src = (__global const srcT *)(srcptr + src_index); \
+    //        dst = (__global dstT *)(dstptr + dst_index); \
+    //        dst[0] = lut[src[0]+lutOFF];
+    //#else
+        #define LUT_OP \
+            __global const srcT * src = (__global const srcT *)(srcptr + src_index); \
+            dst = (__global dstT *)(dstptr + dst_index); \
+            for (int cn = 0; cn < dcn; ++cn) \
+                dst[cn] = lut[src[cn]+lutOFF];
+    //#endif
 #else
-#define LUT_OP \
-    __global const srcT * src = (__global const srcT *)(srcptr + src_index); \
-    dst = (__global dstT *)(dstptr + dst_index); \
-    for (int cn = 0; cn < dcn; ++cn) \
-        dst[cn] = lut[mad24(src[cn]+lutOFF, lcn, cn)];
+    //#if dcn == 4
+    //    #define LUT_OP \
+    //        __global const srcT * src = (__global const srcT *)(srcptr + src_index); \
+    //        dst = (__global dstT *)(dstptr + dst_index); \
+    //        dst[0] = lut[mad24(src[0]+lutOFF, lcn, 0)]; \
+    //        dst[1] = lut[mad24(src[1]+lutOFF, lcn, 1)]; \
+    //        dst[2] = lut[mad24(src[2]+lutOFF, lcn, 2)]; \
+    //        dst[3] = lut[mad24(src[3]+lutOFF, lcn, 3)];
+    //#elif dcn == 3
+    //    #define LUT_OP \
+    //        __global const srcT * src = (__global const srcT *)(srcptr + src_index); \
+    //        dst = (__global dstT *)(dstptr + dst_index); \
+    //        dst[0] = lut[mad24(src[0]+lutOFF, lcn, 0)]; \
+    //        dst[1] = lut[mad24(src[1]+lutOFF, lcn, 1)]; \
+    //        dst[2] = lut[mad24(src[2]+lutOFF, lcn, 2)];
+    //#elif dcn == 2
+    //    #define LUT_OP \
+    //        __global const srcT * src = (__global const srcT *)(srcptr + src_index); \
+    //        dst = (__global dstT *)(dstptr + dst_index); \
+    //        dst[0] = lut[mad24(src[0]+lutOFF, lcn, 0)]; \
+    //        dst[1] = lut[mad24(src[1]+lutOFF, lcn, 1)];
+    //#elif dcn == 1
+    //    #define LUT_OP \
+    //        __global const srcT * src = (__global const srcT *)(srcptr + src_index); \
+    //        dst = (__global dstT *)(dstptr + dst_index); \
+    //        dst[0] = lut[mad24(src[0]+lutOFF, lcn, 0)];
+    //#else
+        #define LUT_OP \
+            __global const srcT * src = (__global const srcT *)(srcptr + src_index); \
+            dst = (__global dstT *)(dstptr + dst_index); \
+            for (int cn = 0; cn < dcn; ++cn) \
+                dst[cn] = lut[mad24(src[cn]+lutOFF, lcn, cn)];
+    //#endif
 #endif
 
 __kernel void LUT(__global const uchar * srcptr, int src_step, int src_offset,

--- a/modules/core/test/ocl/test_arithm.cpp
+++ b/modules/core/test/ocl/test_arithm.cpp
@@ -78,7 +78,11 @@ PARAM_TEST_CASE(Lut, MatDepth, MatDepth, Channels, bool, bool)
         Border srcBorder = randomBorder(0, use_roi ? MAX_VALUE : 0);
         randomSubMat(src, src_roi, roiSize, srcBorder, src_type, 0, 256);
 
-        Size lutRoiSize = Size(256, 1);
+        Size lutRoiSize;
+        if(src_depth == CV_8U || src_depth == CV_8S)
+            lutRoiSize = Size(256, 1);
+        else if(src_depth == CV_16U || src_depth == CV_16S)
+            lutRoiSize = Size(65536, 1);
         Border lutBorder = randomBorder(0, use_roi ? MAX_VALUE : 0);
         randomSubMat(lut, lut_roi, lutRoiSize, lutBorder, lut_type, 5, 16);
 
@@ -1875,7 +1879,7 @@ OCL_TEST_P(ReduceAvg, Mat)
 
 //////////////////////////////////////// Instantiation /////////////////////////////////////////
 
-OCL_INSTANTIATE_TEST_CASE_P(Arithm, Lut, Combine(::testing::Values(CV_8U, CV_8S), OCL_ALL_DEPTHS, OCL_ALL_CHANNELS, Bool(), Bool()));
+OCL_INSTANTIATE_TEST_CASE_P(Arithm, Lut, Combine(::testing::Values(CV_8U, CV_8S, CV_16U, CV_16S), OCL_ALL_DEPTHS, OCL_ALL_CHANNELS, Bool(), Bool()));
 OCL_INSTANTIATE_TEST_CASE_P(Arithm, Add, Combine(OCL_ALL_DEPTHS, OCL_ALL_CHANNELS, Bool()));
 OCL_INSTANTIATE_TEST_CASE_P(Arithm, Subtract, Combine(OCL_ALL_DEPTHS, OCL_ALL_CHANNELS, Bool()));
 OCL_INSTANTIATE_TEST_CASE_P(Arithm, Mul, Combine(OCL_ALL_DEPTHS, OCL_ALL_CHANNELS, Bool()));
@@ -1913,7 +1917,7 @@ OCL_INSTANTIATE_TEST_CASE_P(Arithm, ConvertScaleAbs, Combine(OCL_ALL_DEPTHS, OCL
 OCL_INSTANTIATE_TEST_CASE_P(Arithm, ConvertFp16, Combine(OCL_ALL_CHANNELS, Bool()));
 OCL_INSTANTIATE_TEST_CASE_P(Arithm, ScaleAdd, Combine(OCL_ALL_DEPTHS, OCL_ALL_CHANNELS, Bool()));
 OCL_INSTANTIATE_TEST_CASE_P(Arithm, PatchNaNs, Combine(OCL_ALL_CHANNELS, Bool()));
-OCL_INSTANTIATE_TEST_CASE_P(Arithm, Psnr, Combine(::testing::Values((MatDepth)CV_8U), OCL_ALL_CHANNELS, Bool()));
+OCL_INSTANTIATE_TEST_CASE_P(Arithm, Psnr, Combine(::testing::Values((MatDepth)CV_8U, CV_8S, CV_16U, CV_16S, CV_32F, CV_64F), OCL_ALL_CHANNELS, Bool()));
 OCL_INSTANTIATE_TEST_CASE_P(Arithm, UMatDot, Combine(OCL_ALL_DEPTHS, OCL_ALL_CHANNELS, Bool()));
 
 OCL_INSTANTIATE_TEST_CASE_P(Arithm, ReduceSum, Combine(testing::Values(std::make_pair<MatDepth, MatDepth>(CV_8U, CV_32S),

--- a/modules/core/test/test_arithm.cpp
+++ b/modules/core/test/test_arithm.cpp
@@ -1854,6 +1854,36 @@ TEST(Core_FindNonZero, singular)
     findNonZero(img, pts);
     findNonZero(img, pts2);
     ASSERT_TRUE(pts.empty() && pts2.empty());
+
+    img.convertTo( img, CV_8S );
+    findNonZero(img, pts);
+    findNonZero(img, pts2);
+    ASSERT_TRUE(pts.empty() && pts2.empty());
+
+    img.convertTo( img, CV_16U );
+    findNonZero(img, pts);
+    findNonZero(img, pts2);
+    ASSERT_TRUE(pts.empty() && pts2.empty());
+
+    img.convertTo( img, CV_16S );
+    findNonZero(img, pts);
+    findNonZero(img, pts2);
+    ASSERT_TRUE(pts.empty() && pts2.empty());
+
+    img.convertTo( img, CV_32S );
+    findNonZero(img, pts);
+    findNonZero(img, pts2);
+    ASSERT_TRUE(pts.empty() && pts2.empty());
+
+    img.convertTo( img, CV_32F );
+    findNonZero(img, pts);
+    findNonZero(img, pts2);
+    ASSERT_TRUE(pts.empty() && pts2.empty());
+
+    img.convertTo( img, CV_64F );
+    findNonZero(img, pts);
+    findNonZero(img, pts2);
+    ASSERT_TRUE(pts.empty() && pts2.empty());
 }
 
 TEST(Core_BoolVector, support)


### PR DESCRIPTION
Allow using more types with LUT, findNonZero, and PSNR. 
Fix comment error in Rotate.

This is the first step in making sure all (or as many as I can get done) functions work with all the datatypes the can possibly accept.  This takes the functions in [core/operations on arrays](https://docs.opencv.org/3.4.1/d2/de8/group__core__array.html#gad327659ac03e5fd6894b90025e6900a7) and updates them. I believe that this is everything in core that needs to be updated, though if someone finds something else, just let me know.

```
buildworker:Linux x64=linux-1
buildworker:Win64 OpenCL=windows-2
```