### PR TITLE
core: add a check for empty input in inRange()

### DIFF
--- a/modules/core/src/arithm.cpp
+++ b/modules/core/src/arithm.cpp
@@ -1752,6 +1752,8 @@ void cv::inRange(InputArray _src, InputArray _lowerb,
 {
     CV_INSTRUMENT_REGION()
 
+    CV_Assert(! _src.empty());
+
     CV_OCL_RUN(_src.dims() <= 2 && _lowerb.dims() <= 2 &&
                _upperb.dims() <= 2 && OCL_PERFORMANCE_CHECK(_dst.isUMat()),
                ocl_inRange(_src, _lowerb, _upperb, _dst))


### PR DESCRIPTION
resolves #11345
