### PR TITLE
IPP morphology with big images hotfix.

### DIFF
--- a/modules/imgproc/src/morph.cpp
+++ b/modules/imgproc/src/morph.cpp
@@ -1148,6 +1148,11 @@ static bool ippMorph(int op, int src_type, int dst_type,
     // Different mask flipping
     if(op == MORPH_GRADIENT)
         return false;
+
+    // Integer overflow bug
+    if(src_step >= IPP_MAX_32S ||
+       src_step*height >= IPP_MAX_32S)
+        return false;
 #endif
 
 #if IPP_VERSION_X100 < 201801


### PR DESCRIPTION
resolves #11296

Hotfix for IPP morphology crash on big images. 
Cause: internal error with integer overflow. IPP >= 2018 should work fine.
