### PR TITLE
protobuf build documenting: move the WITH_PROTOBUF option to the top …

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -279,6 +279,7 @@ OCV_OPTION(WITH_GDAL           "Include GDAL Support"                        OFF
 OCV_OPTION(WITH_GPHOTO2        "Include gPhoto2 library support"             ON   IF (UNIX AND NOT ANDROID AND NOT IOS) )
 OCV_OPTION(WITH_LAPACK         "Include Lapack library support"              (NOT CV_DISABLE_OPTIMIZATION)  IF (NOT ANDROID AND NOT IOS) )
 OCV_OPTION(WITH_ITT            "Include Intel ITT support"                   ON   IF (NOT APPLE_FRAMEWORK) )
+OCV_OPTION(WITH_PROTOBUF       "Enable libprotobuf"                          ON )
 
 # OpenCV build components
 # ===================================================

--- a/cmake/OpenCVFindProtobuf.cmake
+++ b/cmake/OpenCVFindProtobuf.cmake
@@ -1,14 +1,13 @@
 # If protobuf is found - libprotobuf target is available
 
-ocv_option(WITH_PROTOBUF "Enable libprotobuf" ON)
-ocv_option(BUILD_PROTOBUF "Force to build libprotobuf from sources" ON)
-ocv_option(PROTOBUF_UPDATE_FILES "Force rebuilding .proto files (protoc should be available)" OFF)
-
 set(HAVE_PROTOBUF FALSE)
 
 if(NOT WITH_PROTOBUF)
   return()
 endif()
+
+ocv_option(BUILD_PROTOBUF "Force to build libprotobuf from sources" ON)
+ocv_option(PROTOBUF_UPDATE_FILES "Force rebuilding .proto files (protoc should be available)" OFF)
 
 function(get_protobuf_version version include)
   file(STRINGS "${include}/google/protobuf/stubs/common.h" ver REGEX "#define GOOGLE_PROTOBUF_VERSION [0-9]+")


### PR DESCRIPTION
It seems somewhat unobvious that a user can configure protobuf within it's finder - my proposal is to move it to the top level.

P.S. IMHO may ease troubles like #10950 .

