### PR TITLE
cmake: change CPU_BASELINE=DETECT for MacOSX

### DIFF
--- a/cmake/OpenCVCompilerOptimizations.cmake
+++ b/cmake/OpenCVCompilerOptimizations.cmake
@@ -258,7 +258,10 @@ if(X86 OR X86_64)
   endif()
 
   if(NOT DEFINED CPU_BASELINE)
-    if(X86_64)
+    if(APPLE)
+      # MacOS X has limited set of possible supported H/W, so compiler is configured well
+      set(CPU_BASELINE "DETECT" CACHE STRING "${HELP_CPU_BASELINE}")
+    elseif(X86_64)
       set(CPU_BASELINE "SSE3" CACHE STRING "${HELP_CPU_BASELINE}")
     else()
       set(CPU_BASELINE "SSE2" CACHE STRING "${HELP_CPU_BASELINE}")

--- a/cmake/checks/cpu_popcnt.cpp
+++ b/cmake/checks/cpu_popcnt.cpp
@@ -4,12 +4,14 @@
 #    define CV_POPCNT_U64 _mm_popcnt_u64
 #  endif
 #  define CV_POPCNT_U32 _mm_popcnt_u32
-#else
+#elif defined(__POPCNT__)
 #  include <popcntintrin.h>
 #  if defined(__x86_64__)
 #    define CV_POPCNT_U64 __builtin_popcountll
 #  endif
 #  define CV_POPCNT_U32 __builtin_popcount
+#else
+#  error "__POPCNT__ is not defined by compiler"
 #endif
 
 int main()


### PR DESCRIPTION
Compiler suggests SSE4.1 instructions on Mac mini (Late 2014 + macOS 10.13.3):

```
$ echo | clang -dM -E - | grep SSE
#define __SSE2_MATH__ 1
#define __SSE2__ 1
#define __SSE3__ 1
#define __SSE4_1__ 1
#define __SSE_MATH__ 1
#define __SSE__ 1
#define __SSSE3__ 1
```

```
allow_multiple_commits=1
```