### PR TITLE
core: fix Intel Compiler std::exception_ptr detection

### DIFF
--- a/modules/core/src/parallel.cpp
+++ b/modules/core/src/parallel.cpp
@@ -135,8 +135,6 @@
 #    define CV__EXCEPTION_PTR 0  // Not supported, details: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=58938
 #  elif defined(CV_CXX11)
 #    define CV__EXCEPTION_PTR 1
-#  elif defined(CV_ICC)
-#    define CV__EXCEPTION_PTR 1
 #  elif defined(_MSC_VER)
 #    define CV__EXCEPTION_PTR (_MSC_VER >= 1600)
 #  elif defined(__clang__)


### PR DESCRIPTION
std::exception_ptr requires enabled C++11 mode

resolves #11393 (part 2)