### PR TITLE
core: added MatSize::dims() method

### DIFF
--- a/modules/core/include/opencv2/core/cvstd.inl.hpp
+++ b/modules/core/include/opencv2/core/cvstd.inl.hpp
@@ -265,10 +265,10 @@ std::ostream& operator << (std::ostream& out, const Rect_<_Tp>& rect)
 
 static inline std::ostream& operator << (std::ostream& out, const MatSize& msize)
 {
-    int i, dims = msize.p[-1];
+    int i, dims = msize.dims();
     for( i = 0; i < dims; i++ )
     {
-        out << msize.p[i];
+        out << msize[i];
         if( i < dims-1 )
             out << " x ";
     }

--- a/modules/core/include/opencv2/core/mat.hpp
+++ b/modules/core/include/opencv2/core/mat.hpp
@@ -548,10 +548,11 @@ struct CV_EXPORTS UMatData
 struct CV_EXPORTS MatSize
 {
     explicit MatSize(int* _p);
+    int dims() const;
     Size operator()() const;
     const int& operator[](int i) const;
     int& operator[](int i);
-    operator const int*() const;
+    operator const int*() const;  // TODO OpenCV 4.0: drop this
     bool operator == (const MatSize& sz) const;
     bool operator != (const MatSize& sz) const;
 

--- a/modules/core/include/opencv2/core/mat.inl.hpp
+++ b/modules/core/include/opencv2/core/mat.inl.hpp
@@ -1412,21 +1412,35 @@ MatSize::MatSize(int* _p)
     : p(_p) {}
 
 inline
+int MatSize::dims() const
+{
+    return (p - 1)[0];
+}
+
+inline
 Size MatSize::operator()() const
 {
-    CV_DbgAssert(p[-1] <= 2);
+    CV_DbgAssert(dims() <= 2);
     return Size(p[1], p[0]);
 }
 
 inline
 const int& MatSize::operator[](int i) const
 {
+    CV_DbgAssert(i < dims());
+#ifdef __OPENCV_BUILD
+    CV_DbgAssert(i >= 0);
+#endif
     return p[i];
 }
 
 inline
 int& MatSize::operator[](int i)
 {
+    CV_DbgAssert(i < dims());
+#ifdef __OPENCV_BUILD
+    CV_DbgAssert(i >= 0);
+#endif
     return p[i];
 }
 
@@ -1439,8 +1453,8 @@ MatSize::operator const int*() const
 inline
 bool MatSize::operator == (const MatSize& sz) const
 {
-    int d = p[-1];
-    int dsz = sz.p[-1];
+    int d = dims();
+    int dsz = sz.dims();
     if( d != dsz )
         return false;
     if( d == 2 )

--- a/modules/dnn/include/opencv2/dnn/shape_utils.hpp
+++ b/modules/dnn/include/opencv2/dnn/shape_utils.hpp
@@ -134,7 +134,7 @@ static inline MatShape shape(const Mat& mat)
 
 static inline MatShape shape(const MatSize& sz)
 {
-    return shape(sz.p, sz[-1]);
+    return shape(sz.p, sz.dims());
 }
 
 static inline MatShape shape(const UMat& mat)

--- a/modules/dnn/src/layers/slice_layer.cpp
+++ b/modules/dnn/src/layers/slice_layer.cpp
@@ -161,14 +161,14 @@ public:
 
         for (int i = 0; i < outputs.size(); ++i)
         {
-            CV_Assert(sliceRanges[i].size() <= inpShape[-1]);
+            CV_Assert(sliceRanges[i].size() <= inpShape.dims());
             // Clamp.
             for (int j = 0; j < sliceRanges[i].size(); ++j)
             {
                 sliceRanges[i][j] = clamp(sliceRanges[i][j], inpShape[j]);
             }
             // Fill the rest of ranges.
-            for (int j = sliceRanges[i].size(); j < inpShape[-1]; ++j)
+            for (int j = sliceRanges[i].size(); j < inpShape.dims(); ++j)
             {
                 sliceRanges[i].push_back(Range::all());
             }

--- a/modules/dnn/src/op_halide.cpp
+++ b/modules/dnn/src/op_halide.cpp
@@ -6,6 +6,7 @@
 // Third party copyrights are property of their respective owners.
 
 #include "precomp.hpp"
+#include <opencv2/dnn/shape_utils.hpp>
 #include "op_halide.hpp"
 
 #ifdef HAVE_HALIDE
@@ -36,7 +37,7 @@ static MatShape getBufferShape(const MatShape& shape)
 
 static MatShape getBufferShape(const MatSize& size)
 {
-    return getBufferShape(MatShape(size.p, size.p + size[-1]));
+    return getBufferShape(shape(size));
 }
 
 Halide::Buffer<float> wrapToHalideBuffer(const Mat& mat)
@@ -160,7 +161,7 @@ void HalideBackendWrapper::setHostDirty()
 
 void getCanonicalSize(const MatSize& size, int* w, int* h, int* c, int* n)
 {
-    getCanonicalSize(MatShape(size.p, size.p + size[-1]), w, h, c, n);
+    getCanonicalSize(shape(size), w, h, c, n);
 }
 
 void getCanonicalSize(const MatShape& shape, int* width, int* height,


### PR DESCRIPTION
to avoid accessing of 'p[-1]' (static code analysers dislike this)