### PR TITLE
imgcodecs iface: add imquery() to get image size & decoder_type from the header

### DIFF
--- a/modules/imgcodecs/include/opencv2/imgcodecs.hpp
+++ b/modules/imgcodecs/include/opencv2/imgcodecs.hpp
@@ -175,6 +175,36 @@ Currently, the following file formats are supported:
 */
 CV_EXPORTS_W Mat imread( const String& filename, int flags = IMREAD_COLOR );
 
+enum ImageDecoderType
+{
+	IMAGE_DECODER_BMP = 0,
+	IMAGE_DECODER_DICOM,
+	IMAGE_DECODER_EXR,
+	IMAGE_DECODER_GDAL,
+	IMAGE_DECODER_HDR,
+	IMAGE_DECODER_JPEG,
+	IMAGE_DECODER_JPEG2000,
+	IMAGE_DECODER_PAM,
+	IMAGE_DECODER_PNG,
+	IMAGE_DECODER_PXM,
+	IMAGE_DECODER_SUNRASTER,
+	IMAGE_DECODER_TIFF,
+	IMAGE_DECODER_WEBP
+};
+
+/** Query image parameters
+
+@sa cv::imread
+
+Throws exception if image is not supported.
+
+@param filename Name of file to be loaded
+@param flags Flag that can take values of cv::ImreadModes
+@param[out] decoderType (optional) type of used image decoder for cv::imread . decoderType can take values of cv::ImageDecoderType
+@returns size of image
+*/
+CV_EXPORTS_W Size imquery(const cv::String& filename, CV_OUT int* decoderType = NULL, int flags = IMREAD_COLOR);
+
 /** @brief Loads a multi-page image from a file.
 
 The function imreadmulti loads a multi-page image from the specified file into a vector of Mat objects.

--- a/modules/imgcodecs/src/grfmt_base.hpp
+++ b/modules/imgcodecs/src/grfmt_base.hpp
@@ -64,6 +64,7 @@ public:
     int width() const { return m_width; }
     int height() const { return m_height; }
     virtual int type() const { return m_type; }
+	virtual int decoderType() const = 0;
 
     virtual bool setSource( const String& filename );
     virtual bool setSource( const Mat& buf );

--- a/modules/imgcodecs/src/grfmt_bmp.cpp
+++ b/modules/imgcodecs/src/grfmt_bmp.cpp
@@ -71,6 +71,11 @@ void  BmpDecoder::close()
     m_strm.close();
 }
 
+int BmpDecoder::decoderType() const
+{
+	return ImageDecoderType::IMAGE_DECODER_BMP;
+}
+
 ImageDecoder BmpDecoder::newDecoder() const
 {
     return makePtr<BmpDecoder>();

--- a/modules/imgcodecs/src/grfmt_bmp.hpp
+++ b/modules/imgcodecs/src/grfmt_bmp.hpp
@@ -65,6 +65,7 @@ public:
     BmpDecoder();
     ~BmpDecoder() CV_OVERRIDE;
 
+	int	  decoderType() const CV_OVERRIDE;
     bool  readData( Mat& img ) CV_OVERRIDE;
     bool  readHeader() CV_OVERRIDE;
     void  close();

--- a/modules/imgcodecs/src/grfmt_exr.cpp
+++ b/modules/imgcodecs/src/grfmt_exr.cpp
@@ -110,6 +110,10 @@ void  ExrDecoder::close()
     }
 }
 
+int ExrDecoder::decoderType() const
+{
+	return ImageDecoderType::IMAGE_DECODER_EXR;
+}
 
 int  ExrDecoder::type() const
 {

--- a/modules/imgcodecs/src/grfmt_exr.hpp
+++ b/modules/imgcodecs/src/grfmt_exr.hpp
@@ -71,6 +71,7 @@ public:
     ~ExrDecoder() CV_OVERRIDE;
 
     int   type() const CV_OVERRIDE;
+	int	  decoderType() const CV_OVERRIDE;
     bool  readData( Mat& img ) CV_OVERRIDE;
     bool  readHeader() CV_OVERRIDE;
     void  close();

--- a/modules/imgcodecs/src/grfmt_gdal.cpp
+++ b/modules/imgcodecs/src/grfmt_gdal.cpp
@@ -160,6 +160,11 @@ GdalDecoder::~GdalDecoder(){
     }
 }
 
+int GdalDecoder::decoderType() const
+{
+	return ImageDecoderType::IMAGE_DECODER_GDAL;
+}
+
 /**
  * Convert data range
 */

--- a/modules/imgcodecs/src/grfmt_gdal.hpp
+++ b/modules/imgcodecs/src/grfmt_gdal.hpp
@@ -117,6 +117,8 @@ class GdalDecoder CV_FINAL : public BaseImageDecoder{
         */
         ~GdalDecoder() CV_OVERRIDE;
 
+		int	  decoderType() const CV_OVERRIDE;
+
         /**
          * Read image data
         */

--- a/modules/imgcodecs/src/grfmt_gdcm.cpp
+++ b/modules/imgcodecs/src/grfmt_gdcm.cpp
@@ -83,6 +83,11 @@ bool DICOMDecoder::checkSignature( const String& signature ) const
     return false;
 }
 
+int DICOMDecoder::decoderType() const
+{
+	return ImageDecoderType::IMAGE_DECODER_DICOM;
+}
+
 ImageDecoder DICOMDecoder::newDecoder() const
 {
     return makePtr<DICOMDecoder>();

--- a/modules/imgcodecs/src/grfmt_gdcm.hpp
+++ b/modules/imgcodecs/src/grfmt_gdcm.hpp
@@ -57,6 +57,7 @@ class DICOMDecoder CV_FINAL : public BaseImageDecoder
 {
 public:
     DICOMDecoder();
+	int	  decoderType() const CV_OVERRIDE;
     bool  readData( Mat& img ) CV_OVERRIDE;
     bool  readHeader() CV_OVERRIDE;
     ImageDecoder newDecoder() const CV_OVERRIDE;

--- a/modules/imgcodecs/src/grfmt_hdr.cpp
+++ b/modules/imgcodecs/src/grfmt_hdr.cpp
@@ -59,6 +59,11 @@ HdrDecoder::~HdrDecoder()
 {
 }
 
+int HdrDecoder::decoderType() const
+{
+	return ImageDecoderType::IMAGE_DECODER_HDR;
+}
+
 size_t HdrDecoder::signatureLength() const
 {
     return m_signature.size() > m_signature_alt.size() ?

--- a/modules/imgcodecs/src/grfmt_hdr.hpp
+++ b/modules/imgcodecs/src/grfmt_hdr.hpp
@@ -60,6 +60,7 @@ class HdrDecoder CV_FINAL : public BaseImageDecoder
 public:
     HdrDecoder();
     ~HdrDecoder() CV_OVERRIDE;
+	int	  decoderType() const CV_OVERRIDE;
     bool readHeader() CV_OVERRIDE;
     bool readData( Mat& img ) CV_OVERRIDE;
     bool checkSignature( const String& signature ) const CV_OVERRIDE;

--- a/modules/imgcodecs/src/grfmt_jpeg.cpp
+++ b/modules/imgcodecs/src/grfmt_jpeg.cpp
@@ -199,6 +199,11 @@ void  JpegDecoder::close()
     m_type = -1;
 }
 
+int JpegDecoder::decoderType() const
+{
+	return ImageDecoderType::IMAGE_DECODER_JPEG;
+}
+
 ImageDecoder JpegDecoder::newDecoder() const
 {
     return makePtr<JpegDecoder>();

--- a/modules/imgcodecs/src/grfmt_jpeg.hpp
+++ b/modules/imgcodecs/src/grfmt_jpeg.hpp
@@ -60,6 +60,7 @@ public:
     JpegDecoder();
     virtual ~JpegDecoder();
 
+	int	  decoderType() const CV_OVERRIDE;
     bool  readData( Mat& img ) CV_OVERRIDE;
     bool  readHeader() CV_OVERRIDE;
     void  close();

--- a/modules/imgcodecs/src/grfmt_jpeg2000.cpp
+++ b/modules/imgcodecs/src/grfmt_jpeg2000.cpp
@@ -88,6 +88,11 @@ Jpeg2KDecoder::~Jpeg2KDecoder()
 {
 }
 
+int Jpeg2KDecoder::decoderType() const
+{
+	return ImageDecoderType::IMAGE_DECODER_JPEG2000;
+}
+
 ImageDecoder Jpeg2KDecoder::newDecoder() const
 {
     return makePtr<Jpeg2KDecoder>();

--- a/modules/imgcodecs/src/grfmt_jpeg2000.hpp
+++ b/modules/imgcodecs/src/grfmt_jpeg2000.hpp
@@ -57,6 +57,7 @@ public:
     Jpeg2KDecoder();
     virtual ~Jpeg2KDecoder();
 
+	int	  decoderType() const CV_OVERRIDE;
     bool  readData( Mat& img ) CV_OVERRIDE;
     bool  readHeader() CV_OVERRIDE;
     void  close();

--- a/modules/imgcodecs/src/grfmt_pam.cpp
+++ b/modules/imgcodecs/src/grfmt_pam.cpp
@@ -337,6 +337,11 @@ PAMDecoder::~PAMDecoder()
     m_strm.close();
 }
 
+int PAMDecoder::decoderType() const
+{
+	return ImageDecoderType::IMAGE_DECODER_PAM;
+}
+
 size_t PAMDecoder::signatureLength() const
 {
     return 3;

--- a/modules/imgcodecs/src/grfmt_pam.hpp
+++ b/modules/imgcodecs/src/grfmt_pam.hpp
@@ -66,6 +66,7 @@ public:
     PAMDecoder();
     virtual ~PAMDecoder() CV_OVERRIDE;
 
+	int	  decoderType() const CV_OVERRIDE;
     bool  readData( Mat& img ) CV_OVERRIDE;
     bool  readHeader() CV_OVERRIDE;
 

--- a/modules/imgcodecs/src/grfmt_png.cpp
+++ b/modules/imgcodecs/src/grfmt_png.cpp
@@ -100,6 +100,11 @@ PngDecoder::~PngDecoder()
     close();
 }
 
+int PngDecoder::decoderType() const
+{
+	return ImageDecoderType::IMAGE_DECODER_PNG;
+}
+
 ImageDecoder PngDecoder::newDecoder() const
 {
     return makePtr<PngDecoder>();

--- a/modules/imgcodecs/src/grfmt_png.hpp
+++ b/modules/imgcodecs/src/grfmt_png.hpp
@@ -58,6 +58,7 @@ public:
     PngDecoder();
     virtual ~PngDecoder();
 
+	int	  decoderType() const CV_OVERRIDE;
     bool  readData( Mat& img ) CV_OVERRIDE;
     bool  readHeader() CV_OVERRIDE;
     void  close();

--- a/modules/imgcodecs/src/grfmt_pxm.cpp
+++ b/modules/imgcodecs/src/grfmt_pxm.cpp
@@ -113,6 +113,11 @@ PxMDecoder::~PxMDecoder()
     close();
 }
 
+int PxMDecoder::decoderType() const
+{
+	return ImageDecoderType::IMAGE_DECODER_PXM;
+}
+
 size_t PxMDecoder::signatureLength() const
 {
     return 3;

--- a/modules/imgcodecs/src/grfmt_pxm.hpp
+++ b/modules/imgcodecs/src/grfmt_pxm.hpp
@@ -64,6 +64,7 @@ public:
     PxMDecoder();
     virtual ~PxMDecoder() CV_OVERRIDE;
 
+	int	  decoderType() const CV_OVERRIDE;
     bool  readData( Mat& img ) CV_OVERRIDE;
     bool  readHeader() CV_OVERRIDE;
     void  close();

--- a/modules/imgcodecs/src/grfmt_sunras.cpp
+++ b/modules/imgcodecs/src/grfmt_sunras.cpp
@@ -75,6 +75,10 @@ void  SunRasterDecoder::close()
     m_strm.close();
 }
 
+int SunRasterDecoder::decoderType() const
+{
+	return ImageDecoderType::IMAGE_DECODER_SUNRASTER;
+}
 
 bool  SunRasterDecoder::readHeader()
 {

--- a/modules/imgcodecs/src/grfmt_sunras.hpp
+++ b/modules/imgcodecs/src/grfmt_sunras.hpp
@@ -71,6 +71,7 @@ public:
     SunRasterDecoder();
     virtual ~SunRasterDecoder() CV_OVERRIDE;
 
+	int	  decoderType() const CV_OVERRIDE;
     bool  readData( Mat& img ) CV_OVERRIDE;
     bool  readHeader() CV_OVERRIDE;
     void  close();

--- a/modules/imgcodecs/src/grfmt_tiff.cpp
+++ b/modules/imgcodecs/src/grfmt_tiff.cpp
@@ -99,6 +99,11 @@ TiffDecoder::~TiffDecoder()
     close();
 }
 
+int TiffDecoder::decoderType() const
+{
+	return ImageDecoderType::IMAGE_DECODER_TIFF;
+}
+
 size_t TiffDecoder::signatureLength() const
 {
     return 4;

--- a/modules/imgcodecs/src/grfmt_tiff.hpp
+++ b/modules/imgcodecs/src/grfmt_tiff.hpp
@@ -96,6 +96,7 @@ public:
     TiffDecoder();
     virtual ~TiffDecoder() CV_OVERRIDE;
 
+	int	  decoderType() const CV_OVERRIDE;
     bool  readHeader() CV_OVERRIDE;
     bool  readData( Mat& img ) CV_OVERRIDE;
     void  close();

--- a/modules/imgcodecs/src/grfmt_webp.cpp
+++ b/modules/imgcodecs/src/grfmt_webp.cpp
@@ -67,6 +67,11 @@ WebPDecoder::WebPDecoder()
 
 WebPDecoder::~WebPDecoder() {}
 
+int WebPDecoder::decoderType() const
+{
+	return ImageDecoderType::IMAGE_DECODER_WEBP;
+}
+
 size_t WebPDecoder::signatureLength() const
 {
     return WEBP_HEADER_SIZE;

--- a/modules/imgcodecs/src/grfmt_webp.hpp
+++ b/modules/imgcodecs/src/grfmt_webp.hpp
@@ -59,6 +59,7 @@ public:
     WebPDecoder();
     ~WebPDecoder() CV_OVERRIDE;
 
+	int	  decoderType() const CV_OVERRIDE;
     bool readData( Mat& img ) CV_OVERRIDE;
     bool readHeader() CV_OVERRIDE;
     void close();

--- a/modules/imgcodecs/test/test_jpeg.cpp
+++ b/modules/imgcodecs/test/test_jpeg.cpp
@@ -118,6 +118,13 @@ TEST(Imgcodecs_Jpeg, encode_decode_progressive_jpeg)
     EXPECT_NO_THROW(cv::imwrite(output_progressive, img, params));
     cv::Mat img_jpg_progressive = cv::imread(output_progressive);
 
+	int decoderType;
+	Size imageSize = imquery(output_progressive, &decoderType);
+	EXPECT_EQ(512, imageSize.width);
+	EXPECT_EQ(512, imageSize.height);
+	EXPECT_EQ((int)cv::ImageDecoderType::IMAGE_DECODER_JPEG, decoderType);
+	
+
     string output_normal = cv::tempfile(".jpg");
     EXPECT_NO_THROW(cv::imwrite(output_normal, img));
     cv::Mat img_jpg_normal = cv::imread(output_normal);

--- a/modules/imgcodecs/test/test_read_write.cpp
+++ b/modules/imgcodecs/test/test_read_write.cpp
@@ -63,6 +63,12 @@ TEST_P(Imgcodecs_Image, read_write)
     const string _name = TS::ptr()->get_data_path() + "../cv/shared/baboon.png";
     const double thresDbell = 32;
 
+	int decoderType;
+	Size imageSize = imquery(_name, &decoderType);
+	EXPECT_EQ(512, imageSize.width);
+	EXPECT_EQ(512, imageSize.height);
+	EXPECT_EQ((int)cv::ImageDecoderType::IMAGE_DECODER_PNG, decoderType);
+
     Mat image = imread(_name);
     image.convertTo(image, CV_8UC3);
     ASSERT_FALSE(image.empty());

--- a/modules/imgcodecs/test/test_webp.cpp
+++ b/modules/imgcodecs/test/test_webp.cpp
@@ -17,6 +17,12 @@ TEST(Imgcodecs_WebP, encode_decode_lossless_webp)
     string output = cv::tempfile(".webp");
     EXPECT_NO_THROW(cv::imwrite(output, img)); // lossless
 
+	int decoderType;
+	Size imageSize = imquery(output, &decoderType);
+	EXPECT_EQ(512, imageSize.width);
+	EXPECT_EQ(512, imageSize.height);
+	EXPECT_EQ((int)cv::ImageDecoderType::IMAGE_DECODER_WEBP, decoderType);
+
     cv::Mat img_webp = cv::imread(output);
 
     std::vector<unsigned char> buf;


### PR DESCRIPTION
As a possible follow-up due to #8511 
