### PR TITLE
MSVS2017: eliminate build warning

### DIFF
--- a/modules/dnn/src/layers/prior_box_layer.cpp
+++ b/modules/dnn/src/layers/prior_box_layer.cpp
@@ -205,7 +205,9 @@ public:
 
         if (_explicitSizes)
         {
-            CV_Assert(_aspectRatios.empty(), !params.has("min_size"), !params.has("max_size"));
+            CV_Assert(_aspectRatios.empty());
+            CV_Assert(!params.has("min_size"));
+            CV_Assert(!params.has("max_size"));
             _boxWidths = widths;
             _boxHeights = heights;
         }


### PR DESCRIPTION
> modules\dnn\src\layers\prior_box_layer.cpp(208): warning C4834: discarding return value of function with 'nodiscard' attribute
