### PR TITLE
Fix Python string formatting

### DIFF
--- a/platforms/android/build_sdk.py
+++ b/platforms/android/build_sdk.py
@@ -18,7 +18,7 @@ def execute(cmd, shell=False):
         log.info('Executing: ' + ' '.join(cmd))
         retcode = subprocess.call(cmd, shell=shell)
         if retcode < 0:
-            raise Fail("Child was terminated by signal:" %s -retcode)
+            raise Fail("Child was terminated by signal: %s" % -retcode)
         elif retcode > 0:
             raise Fail("Child returned: %s" % retcode)
     except OSError as e:

--- a/platforms/js/build_js.py
+++ b/platforms/js/build_js.py
@@ -14,7 +14,7 @@ def execute(cmd, shell=False):
         log.info("Executing: %s" % cmd)
         retcode = subprocess.call(cmd, shell=shell)
         if retcode < 0:
-            raise Fail("Child was terminated by signal:" %s -retcode)
+            raise Fail("Child was terminated by signal: %s" % -retcode)
         elif retcode > 0:
             raise Fail("Child returned: %s" % retcode)
     except OSError as e:
@@ -159,7 +159,7 @@ class Builder:
         if flags:
             cmd += ["-DCMAKE_C_FLAGS='%s'" % flags,
                     "-DCMAKE_CXX_FLAGS='%s'" % flags]
-        return cmd;
+        return cmd
 
     def get_build_flags(self):
         flags = ""
@@ -235,7 +235,7 @@ if __name__ == "__main__":
         builder.config()
 
     if args.config_only:
-        sys.exit(0);
+        sys.exit(0)
 
     log.info("=====")
     log.info("===== Building OpenCV.js in %s", "asm.js" if not args.build_wasm else "wasm")


### PR DESCRIPTION
<!-- Please use this line to close one or multiple issues when this pullrequest gets merged
You can add another line right under the first one:
resolves #1234
resolves #1235
-->

### This pullrequest changes
Invalid Python string formatting into valid Python string formatting.  The current lines will raise [NameError](https://docs.python.org/3/library/exceptions.html#NameError) on 's' instead of raising the expected __Fail()__.

Also removed a couple of superfluous trailing semicolons.  (Python != JavaScript)

Discovered via flake8 testing of https://github.com/opencv/opencv

$ __flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics__
```
./platforms/android/build_sdk.py:21:59: F821 undefined name 's'
            raise Fail("Child was terminated by signal:" %s -retcode)
                                                          ^
./platforms/js/build_js.py:17:59: F821 undefined name 's'
            raise Fail("Child was terminated by signal:" %s -retcode)
                                                          ^
```