### PR TITLE
Don't forget self in table_formatter.py

### DIFF
--- a/modules/ts/misc/table_formatter.py
+++ b/modules/ts/misc/table_formatter.py
@@ -47,7 +47,7 @@ class table(object):
         if len(self.rows) - 1 == self.ridx:
             self.rows.append(tblRow(len(self.columns), properties))
         else:
-            self.rows[ridx + 1].props = properties
+            self.rows[self.ridx + 1].props = properties
         self.ridx += 1
         return self.rows[self.ridx]
 


### PR DESCRIPTION
__ridx__ is an _undefined name_ in this context but __self.ridx__ is used three other times in this method and nine times in this class.  Undefined names may raise [NameError](https://docs.python.org/3/library/exceptions.html#NameError) at runtime.

flake8 testing of https://github.com/opencv/opencv

$ __flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics__
```
./modules/ts/misc/table_formatter.py:50:23: F821 undefined name 'ridx'
            self.rows[ridx + 1].props = properties
                      ^
```