### PR TITLE
Define execfile, file, long, raw_input, xrange for Python 3

### DIFF
--- a/doc/pattern_tools/svgfig.py
+++ b/doc/pattern_tools/svgfig.py
@@ -29,6 +29,12 @@ try:
 except NameError:
     unicode = lambda s: str(s)
 
+try:
+    xrange          # Python 2
+except NameError:
+    xrange = range  # Python 3
+
+
 if re.search("windows", platform.system(), re.I):
     try:
         import _winreg
@@ -600,7 +606,7 @@ def template(fileName, svg, replaceme="REPLACEME"):
 
 def load(fileName):
     """Loads an SVG image from a file."""
-    return load_stream(file(fileName))
+    return load_stream(open(fileName))
 
 def load_stream(stream):
     """Loads an SVG image from a stream (can be a string or a file object)."""

--- a/modules/dnn/test/imagenet_cls_test_alexnet.py
+++ b/modules/dnn/test/imagenet_cls_test_alexnet.py
@@ -16,6 +16,11 @@ except ImportError:
     raise ImportError('Can\'t find OpenCV Python module. If you\'ve built it from sources without installation, '
                       'configure environment variable PYTHONPATH to "opencv_build_dir/lib" directory (with "python3" subdirectory if required)')
 
+try:
+    xrange          # Python 2
+except NameError:
+    xrange = range  # Python 3
+
 
 class DataFetch(object):
     imgs_dir = ''

--- a/modules/ts/misc/trace_profiler.py
+++ b/modules/ts/misc/trace_profiler.py
@@ -6,10 +6,15 @@ import csv
 from pprint import pprint
 from collections import deque
 
+try:
+    long        # Python 2
+except NameError:
+    long = int  # Python 3
+
 # trace.hpp
-REGION_FLAG_IMPL_MASK = 15 << 16;
-REGION_FLAG_IMPL_IPP = 1 << 16;
-REGION_FLAG_IMPL_OPENCL = 2 << 16;
+REGION_FLAG_IMPL_MASK = 15 << 16
+REGION_FLAG_IMPL_IPP = 1 << 16
+REGION_FLAG_IMPL_OPENCL = 2 << 16
 
 DEBUG = False
 

--- a/samples/python/_doc.py
+++ b/samples/python/_doc.py
@@ -7,8 +7,6 @@ ones with missing __doc__ string.
 
 # Python 2/3 compatibility
 from __future__ import print_function
-import sys
-PY3 = sys.version_info[0] == 3
 
 from glob import glob
 
@@ -17,11 +15,11 @@ if __name__ == '__main__':
     for fn in glob('*.py'):
         loc = {}
         try:
-            if PY3:
-                exec(open(fn).read(), loc)
-            else:
-                execfile(fn, loc)
-        except:
+            try:
+                execfile(fn, loc)           # Python 2
+            except NameError:
+                exec(open(fn).read(), loc)  # Python 3
+        except Exception:
             pass
         if '__doc__' not in loc:
             print(fn)

--- a/samples/python/demo.py
+++ b/samples/python/demo.py
@@ -7,7 +7,6 @@ Sample-launcher application.
 # Python 2/3 compatibility
 from __future__ import print_function
 import sys
-PY3 = sys.version_info[0] == 3
 
 # local modules
 from common import splitfn
@@ -17,11 +16,11 @@ import webbrowser
 from glob import glob
 from subprocess import Popen
 
-if PY3:
-    import tkinter as tk
+try:
+    import tkinter as tk  # Python 3
     from tkinter.scrolledtext import ScrolledText
-else:
-    import Tkinter as tk
+except ImportError:
+    import Tkinter as tk  # Python 2
     from ScrolledText import ScrolledText
 
 
@@ -116,10 +115,10 @@ class App:
         name = self.demos_lb.get( self.demos_lb.curselection()[0] )
         fn = self.samples[name]
         loc = {}
-        if PY3:
-            exec(open(fn).read(), loc)
-        else:
-            execfile(fn, loc)
+        try:
+            execfile(fn, loc)           # Python 2
+        except NameError:
+            exec(open(fn).read(), loc)  # Python 3
         descr = loc.get('__doc__', 'no-description')
 
         self.linker.reset()

--- a/samples/python/tutorial_code/core/AddingImages/adding_images.py
+++ b/samples/python/tutorial_code/core/AddingImages/adding_images.py
@@ -1,35 +1,36 @@
 from __future__ import print_function
-import sys
 
 import cv2 as cv
 
 alpha = 0.5
 
+try:
+    raw_input          # Python 2
+except NameError:
+    raw_input = input  # Python 3
+
 print(''' Simple Linear Blender
 -----------------------
 * Enter alpha [0.0-1.0]: ''')
-if sys.version_info >= (3, 0): # If Python 3.x
-    input_alpha = float(input())
-else:
-    input_alpha = float(raw_input())
+input_alpha = float(raw_input().strip())
 if 0 <= alpha <= 1:
     alpha = input_alpha
-## [load]
+# [load]
 src1 = cv.imread('../../../../data/LinuxLogo.jpg')
 src2 = cv.imread('../../../../data/WindowsLogo.jpg')
-## [load]
+# [load]
 if src1 is None:
-    print ("Error loading src1")
+    print("Error loading src1")
     exit(-1)
 elif src2 is None:
-    print ("Error loading src2")
+    print("Error loading src2")
     exit(-1)
-## [blend_images]
+# [blend_images]
 beta = (1.0 - alpha)
 dst = cv.addWeighted(src1, alpha, src2, beta, 0.0)
-## [blend_images]
-## [display]
+# [blend_images]
+# [display]
 cv.imshow('dst', dst)
 cv.waitKey(0)
-## [display]
+# [display]
 cv.destroyAllWindows()


### PR DESCRIPTION
__execfile, file, long, raw_input, xrange__ were all removed in Python 3 so this PR defines them using the Python porting best practice [use feature detection instead of version detection](https://docs.python.org/3/howto/pyporting.html#use-feature-detection-instead-of-version-detection) which saves on imports and placates linters like PyLint and flake8.

flake8 testing of https://github.com/opencv/opencv on Python 3.6.3
$ __flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics__
```
./doc/pattern_tools/svgfig.py:603:24: F821 undefined name 'file'
    return load_stream(file(fileName))
                       ^
./doc/pattern_tools/svgfig.py:1914:22: F821 undefined name 'xrange'
            for i in xrange(len(self.d)):
                     ^
./doc/pattern_tools/svgfig.py:2861:22: F821 undefined name 'xrange'
            for i in xrange(N):
                     ^
./doc/pattern_tools/svgfig.py:2943:18: F821 undefined name 'xrange'
        for i in xrange(N):
                 ^
./doc/pattern_tools/svgfig.py:2995:22: F821 undefined name 'xrange'
            for i in xrange(N):
                     ^
./modules/dnn/test/imagenet_cls_test_alexnet.py:180:18: F821 undefined name 'xrange'
        for x in xrange(0, len(sorted_imgs_names), self.batch_size):
                 ^
./modules/ts/misc/trace_profiler.py:37:20: F821 undefined name 'long'
            return long(s)
                   ^
./samples/python/_doc.py:23:17: F821 undefined name 'execfile'
                execfile(fn, loc)
                ^
./samples/python/demo.py:122:13: F821 undefined name 'execfile'
            execfile(fn, loc)
            ^
./samples/python/tutorial_code/core/AddingImages/adding_images.py:14:25: F821 undefined name 'raw_input'
    input_alpha = float(raw_input())
                        ^
```