### PR TITLE
Load CascasdeClassifier from cv::FileStorage.

### DIFF
--- a/modules/core/include/opencv2/core/persistence.hpp
+++ b/modules/core/include/opencv2/core/persistence.hpp
@@ -95,6 +95,7 @@ the extension of the opened file, ".xml" for XML files, ".yml" or ".yaml" for YA
 JSON.
  */
 typedef struct CvFileStorage CvFileStorage;
+typedef struct CvMemStorage CvMemStorage;
 typedef struct CvFileNode CvFileNode;
 typedef struct CvMat CvMat;
 typedef struct CvMatND CvMatND;
@@ -1344,6 +1345,19 @@ inline FileNode FileNodeIterator::operator ->() const { return FileNode(fs, (con
 inline String::String(const FileNode& fn): cstr_(0), len_(0) { read(fn, *this, *this); }
 
 //! @endcond
+
+/** @brief Loads an object from a filestorage.
+
+This performs the same functionality as @cvLoad, but does it directly from a FileStorage object.
+@param filename File storage object
+@param memstorage Memory storage for dynamic structures, such as CvSeq or CvGraph . It is not used
+for matrices or images.
+@param name Optional object name. If it is NULL, the first top-level object in the storage will be
+loaded.
+@param real_name Optional output parameter that will contain the name of the loaded object
+(useful if name=NULL )
+ */
+CV_EXPORTS void* cvLoadFileStorage(FileStorage& filestorage, CvMemStorage* memstorage, const char* name, const char** real_name);
 
 
 CV_EXPORTS void cvStartWriteRawData_Base64(::CvFileStorage * fs, const char* name, int len, const char* dt);

--- a/modules/core/src/persistence_c.cpp
+++ b/modules/core/src/persistence_c.cpp
@@ -494,81 +494,8 @@ CV_IMPL void*
 cvLoad( const char* filename, CvMemStorage* memstorage,
         const char* name, const char** _real_name )
 {
-    void* ptr = 0;
-    const char* real_name = 0;
     cv::FileStorage fs(cvOpenFileStorage(filename, memstorage, CV_STORAGE_READ));
-
-    CvFileNode* node = 0;
-
-    if( !fs.isOpened() )
-        return 0;
-
-    if( name )
-    {
-        node = cvGetFileNodeByName( *fs, 0, name );
-    }
-    else
-    {
-        int i, k;
-        for( k = 0; k < (*fs)->roots->total; k++ )
-        {
-            CvSeq* seq;
-            CvSeqReader reader;
-
-            node = (CvFileNode*)cvGetSeqElem( (*fs)->roots, k );
-            CV_Assert(node != NULL);
-            if( !CV_NODE_IS_MAP( node->tag ))
-                return 0;
-            seq = node->data.seq;
-            node = 0;
-
-            cvStartReadSeq( seq, &reader, 0 );
-
-            // find the first element in the map
-            for( i = 0; i < seq->total; i++ )
-            {
-                if( CV_IS_SET_ELEM( reader.ptr ))
-                {
-                    node = (CvFileNode*)reader.ptr;
-                    goto stop_search;
-                }
-                CV_NEXT_SEQ_ELEM( seq->elem_size, reader );
-            }
-        }
-
-stop_search:
-        ;
-    }
-
-    if( !node )
-        CV_Error( CV_StsObjectNotFound, "Could not find the/an object in file storage" );
-
-    real_name = cvGetFileNodeName( node );
-    ptr = cvRead( *fs, node, 0 );
-
-    // sanity check
-    if( !memstorage && (CV_IS_SEQ( ptr ) || CV_IS_SET( ptr )) )
-        CV_Error( CV_StsNullPtr,
-        "NULL memory storage is passed - the loaded dynamic structure can not be stored" );
-
-    if( cvGetErrStatus() < 0 )
-    {
-        cvRelease( (void**)&ptr );
-        real_name = 0;
-    }
-
-    if( _real_name)
-    {
-    if (real_name)
-    {
-        *_real_name = (const char*)cvAlloc(strlen(real_name));
-            memcpy((void*)*_real_name, real_name, strlen(real_name));
-    } else {
-        *_real_name = 0;
-    }
-    }
-
-    return ptr;
+    return cv::cvLoadFileStorage(fs, memstorage, name, _real_name);
 }
 
 CV_IMPL const char*

--- a/modules/core/src/persistence_cpp.cpp
+++ b/modules/core/src/persistence_cpp.cpp
@@ -11,6 +11,89 @@
 namespace cv
 {
 
+
+void*
+cvLoadFileStorage(cv::FileStorage& fs, CvMemStorage* memstorage,
+        const char* name, const char** _real_name )
+{
+    void* ptr = 0;
+    const char* real_name = 0;
+
+    CvFileNode* node = 0;
+
+    if( !fs.isOpened() )
+        return 0;
+
+    if( name )
+    {
+        node = cvGetFileNodeByName( *fs, 0, name );
+    }
+    else
+    {
+        int i, k;
+        for( k = 0; k < (*fs)->roots->total; k++ )
+        {
+            CvSeq* seq;
+            CvSeqReader reader;
+
+            node = (CvFileNode*)cvGetSeqElem( (*fs)->roots, k );
+            CV_Assert(node != NULL);
+            if( !CV_NODE_IS_MAP( node->tag ))
+                return 0;
+            seq = node->data.seq;
+            node = 0;
+
+            cvStartReadSeq( seq, &reader, 0 );
+
+            // find the first element in the map
+            for( i = 0; i < seq->total; i++ )
+            {
+                if( CV_IS_SET_ELEM( reader.ptr ))
+                {
+                    node = (CvFileNode*)reader.ptr;
+                    goto stop_search;
+                }
+                CV_NEXT_SEQ_ELEM( seq->elem_size, reader );
+            }
+        }
+
+stop_search:
+        ;
+    }
+
+    if( !node )
+        CV_Error( CV_StsObjectNotFound, "Could not find the/an object in file storage" );
+
+    real_name = cvGetFileNodeName( node );
+    ptr = cvRead( *fs, node, 0 );
+
+    // sanity check
+    if( !memstorage && (CV_IS_SEQ( ptr ) || CV_IS_SET( ptr )) )
+        CV_Error( CV_StsNullPtr,
+        "NULL memory storage is passed - the loaded dynamic structure can not be stored" );
+
+    if( cvGetErrStatus() < 0 )
+    {
+        cvRelease( (void**)&ptr );
+        real_name = 0;
+    }
+
+    if( _real_name)
+    {
+    if (real_name)
+    {
+        *_real_name = (const char*)cvAlloc(strlen(real_name));
+            memcpy((void*)*_real_name, real_name, strlen(real_name));
+    } else {
+        *_real_name = 0;
+    }
+    }
+
+    return ptr;
+}
+
+
+
 static void getElemSize( const String& fmt, size_t& elemSize, size_t& cn )
 {
     const char* dt = fmt.c_str();

--- a/modules/objdetect/include/opencv2/objdetect.hpp
+++ b/modules/objdetect/include/opencv2/objdetect.hpp
@@ -177,6 +177,7 @@ public:
     virtual ~BaseCascadeClassifier();
     virtual bool empty() const CV_OVERRIDE = 0;
     virtual bool load( const String& filename ) = 0;
+    virtual bool load( FileStorage& filestorage) = 0;
     virtual void detectMultiScale( InputArray image,
                            CV_OUT std::vector<Rect>& objects,
                            double scaleFactor,
@@ -241,6 +242,7 @@ public:
     traincascade application.
      */
     CV_WRAP bool load( const String& filename );
+    CV_WRAP bool load( FileStorage& filename );
     /** @brief Reads a classifier from a FileStorage node.
 
     @note The file may contain a new cascade classifier (trained traincascade application) only.

--- a/modules/objdetect/include/opencv2/objdetect.hpp
+++ b/modules/objdetect/include/opencv2/objdetect.hpp
@@ -242,7 +242,7 @@ public:
     traincascade application.
      */
     CV_WRAP bool load( const String& filename );
-    CV_WRAP bool load( FileStorage& filename );
+    bool load( FileStorage& filename );
     /** @brief Reads a classifier from a FileStorage node.
 
     @note The file may contain a new cascade classifier (trained traincascade application) only.

--- a/modules/objdetect/src/cascadedetect.cpp
+++ b/modules/objdetect/src/cascadedetect.cpp
@@ -905,20 +905,23 @@ bool CascadeClassifierImpl::empty() const
 
 bool CascadeClassifierImpl::load(const String& filename)
 {
+    FileStorage file(filename, FileStorage::READ);
+    return load(file);
+}
+
+bool CascadeClassifierImpl::load(FileStorage& fs)
+{
     oldCascade.release();
     data = Data();
     featureEvaluator.release();
 
-    FileStorage fs(filename, FileStorage::READ);
     if( !fs.isOpened() )
         return false;
 
     if( read_(fs.getFirstTopLevelNode()) )
         return true;
 
-    fs.release();
-
-    oldCascade.reset((CvHaarClassifierCascade*)cvLoad(filename.c_str(), 0, 0, 0));
+    oldCascade.reset((CvHaarClassifierCascade*)cvLoadFileStorage(fs, 0, 0, 0));
     return !oldCascade.empty();
 }
 
@@ -1624,6 +1627,14 @@ CascadeClassifier::~CascadeClassifier()
 bool CascadeClassifier::empty() const
 {
     return cc.empty() || cc->empty();
+}
+
+bool CascadeClassifier::load( FileStorage& filestorage )
+{
+    cc = makePtr<CascadeClassifierImpl>();
+    if(!cc->load(filestorage))
+        cc.release();
+    return !empty();
 }
 
 bool CascadeClassifier::load( const String& filename )

--- a/modules/objdetect/src/cascadedetect.hpp
+++ b/modules/objdetect/src/cascadedetect.hpp
@@ -82,6 +82,7 @@ public:
 
     bool empty() const CV_OVERRIDE;
     bool load( const String& filename ) CV_OVERRIDE;
+    bool load( FileStorage& filename ) CV_OVERRIDE;
     void read( const FileNode& node ) CV_OVERRIDE;
     bool read_( const FileNode& node );
     void detectMultiScale( InputArray image,


### PR DESCRIPTION
### This pullrequest changes

CascadeClassifier currently allows loading from files using the load method. Internally this opens a FileStorage object and loads from that. This PR exposes that functionality to the public interface. The purpose is to allow the load() to work on all sources supported by FileStorage, for example in memory storage.




