### PR TITLE
core: fix ARM intrinsincs (v_rotate_left<0>)

### DIFF
--- a/modules/core/include/opencv2/core/hal/intrin_neon.hpp
+++ b/modules/core/include/opencv2/core/hal/intrin_neon.hpp
@@ -786,10 +786,14 @@ template<int n> inline _Tpvec v_rotate_right(const _Tpvec& a) \
 { return _Tpvec(vextq_##suffix(a.val, vdupq_n_##suffix(0), n)); } \
 template<int n> inline _Tpvec v_rotate_left(const _Tpvec& a) \
 { return _Tpvec(vextq_##suffix(vdupq_n_##suffix(0), a.val, _Tpvec::nlanes - n)); } \
+template<> inline _Tpvec v_rotate_left<0>(const _Tpvec& a) \
+{ return a; } \
 template<int n> inline _Tpvec v_rotate_right(const _Tpvec& a, const _Tpvec& b) \
 { return _Tpvec(vextq_##suffix(a.val, b.val, n)); } \
 template<int n> inline _Tpvec v_rotate_left(const _Tpvec& a, const _Tpvec& b) \
-{ return _Tpvec(vextq_##suffix(b.val, a.val, _Tpvec::nlanes - n)); }
+{ return _Tpvec(vextq_##suffix(b.val, a.val, _Tpvec::nlanes - n)); } \
+template<> inline _Tpvec v_rotate_left<0>(const _Tpvec& a, const _Tpvec& b) \
+{ CV_UNUSED(b); return a; }
 
 OPENCV_HAL_IMPL_NEON_ROTATE_OP(v_uint8x16, u8)
 OPENCV_HAL_IMPL_NEON_ROTATE_OP(v_int8x16, s8)

--- a/modules/core/test/test_intrin.cpp
+++ b/modules/core/test/test_intrin.cpp
@@ -35,7 +35,7 @@ TEST(hal_intrin, uint8x16) {
         .test_pack_u<1>().test_pack_u<2>().test_pack_u<3>().test_pack_u<8>()
         .test_unpack()
         .test_extract<0>().test_extract<1>().test_extract<8>().test_extract<15>()
-        .test_rotate<1>().test_rotate<8>().test_rotate<15>()
+        .test_rotate<0>().test_rotate<1>().test_rotate<8>().test_rotate<15>()
         ;
 }
 
@@ -57,7 +57,7 @@ TEST(hal_intrin, int8x16) {
         .test_pack<1>().test_pack<2>().test_pack<3>().test_pack<8>()
         .test_unpack()
         .test_extract<0>().test_extract<1>().test_extract<8>().test_extract<15>()
-        .test_rotate<1>().test_rotate<8>().test_rotate<15>()
+        .test_rotate<0>().test_rotate<1>().test_rotate<8>().test_rotate<15>()
         ;
 }
 
@@ -85,7 +85,7 @@ TEST(hal_intrin, uint16x8) {
         .test_pack_u<1>().test_pack_u<2>().test_pack_u<7>().test_pack_u<16>()
         .test_unpack()
         .test_extract<0>().test_extract<1>().test_extract<4>().test_extract<7>()
-        .test_rotate<1>().test_rotate<4>().test_rotate<7>()
+        .test_rotate<0>().test_rotate<1>().test_rotate<4>().test_rotate<7>()
         ;
 }
 
@@ -112,7 +112,7 @@ TEST(hal_intrin, int16x8) {
         .test_pack<1>().test_pack<2>().test_pack<7>().test_pack<16>()
         .test_unpack()
         .test_extract<0>().test_extract<1>().test_extract<4>().test_extract<7>()
-        .test_rotate<1>().test_rotate<4>().test_rotate<7>()
+        .test_rotate<0>().test_rotate<1>().test_rotate<4>().test_rotate<7>()
         ;
 }
 
@@ -138,7 +138,7 @@ TEST(hal_intrin, uint32x4) {
         .test_pack<1>().test_pack<2>().test_pack<15>().test_pack<32>()
         .test_unpack()
         .test_extract<0>().test_extract<1>().test_extract<2>().test_extract<3>()
-        .test_rotate<1>().test_rotate<2>().test_rotate<3>()
+        .test_rotate<0>().test_rotate<1>().test_rotate<2>().test_rotate<3>()
         .test_transpose()
         ;
 }
@@ -162,7 +162,7 @@ TEST(hal_intrin, int32x4) {
         .test_pack<1>().test_pack<2>().test_pack<15>().test_pack<32>()
         .test_unpack()
         .test_extract<0>().test_extract<1>().test_extract<2>().test_extract<3>()
-        .test_rotate<1>().test_rotate<2>().test_rotate<3>()
+        .test_rotate<0>().test_rotate<1>().test_rotate<2>().test_rotate<3>()
         .test_float_cvt32()
         .test_float_cvt64()
         .test_transpose()
@@ -178,7 +178,7 @@ TEST(hal_intrin, uint64x2) {
         .test_shift<1>().test_shift<8>()
         .test_logic()
         .test_extract<0>().test_extract<1>()
-        .test_rotate<1>()
+        .test_rotate<0>().test_rotate<1>()
         ;
 }
 
@@ -189,7 +189,7 @@ TEST(hal_intrin, int64x2) {
         .test_shift<1>().test_shift<8>()
         .test_logic()
         .test_extract<0>().test_extract<1>()
-        .test_rotate<1>()
+        .test_rotate<0>().test_rotate<1>()
         ;
 }
 
@@ -216,7 +216,7 @@ TEST(hal_intrin, float32x4) {
         .test_transpose()
         .test_reduce_sum4()
         .test_extract<0>().test_extract<1>().test_extract<2>().test_extract<3>()
-        .test_rotate<1>().test_rotate<2>().test_rotate<3>()
+        .test_rotate<0>().test_rotate<1>().test_rotate<2>().test_rotate<3>()
         ;
 }
 
@@ -236,7 +236,7 @@ TEST(hal_intrin, float64x2) {
         .test_float_math()
         .test_float_cvt32()
         .test_extract<0>().test_extract<1>()
-        .test_rotate<1>()
+        .test_rotate<0>().test_rotate<1>()
         ;
 }
 #endif


### PR DESCRIPTION
'0' is specific case (make no sence as a standalone operation),
but it can be useful in template-based programming.

reverts commit: a58c9d4d630926ed81beda1a8f7f8ec52165949e
related #11474