### PR TITLE
Add assertion for GaussianBlur

### DIFF
--- a/modules/imgproc/src/smooth.cpp
+++ b/modules/imgproc/src/smooth.cpp
@@ -4118,6 +4118,9 @@ void cv::GaussianBlur( InputArray _src, OutputArray _dst, Size ksize,
     CV_INSTRUMENT_REGION()
 
     int type = _src.type();
+    int sdepth = CV_MAT_DEPTH(type), cn = CV_MAT_CN(type);
+    CV_Assert(!(sdepth == CV_8S || sdepth == CV_32S));
+
     Size size = _src.size();
     _dst.create( size, type );
 
@@ -4141,8 +4144,6 @@ void cv::GaussianBlur( InputArray _src, OutputArray _dst, Size ksize,
                (ksize.width == 5 && ksize.height == 5)) &&
                _src.rows() > ksize.height && _src.cols() > ksize.width);
     (void)useOpenCL;
-
-    int sdepth = CV_MAT_DEPTH(type), cn = CV_MAT_CN(type);
 
     if(sdepth == CV_8U && ((borderType & BORDER_ISOLATED) || !_src.getMat().isSubmatrix()))
     {

--- a/modules/imgproc/test/test_filter.cpp
+++ b/modules/imgproc/test/test_filter.cpp
@@ -2002,6 +2002,23 @@ TEST(Imgproc_GaussianBlur, borderTypes)
     EXPECT_EQ(27, dst.at<uchar>(0, 0));
 }
 
+TEST(Imgproc_GaussianBlur, depth)
+{
+    Mat src, dst;
+    for(int depth = 0; depth < 7; depth++)
+        for(int c = 1; c < 5; c++)
+        {
+            int type = CV_MAKE_TYPE(depth, c);
+            src.create(256, 256, type);
+            if(depth == CV_32S || depth == CV_8S)
+                ASSERT_ANY_THROW(cv::GaussianBlur(src, dst, cv::Size(), 2.0, 2.0));
+            else
+                ASSERT_NO_THROW(cv::GaussianBlur(src, dst, cv::Size(), 2.0, 2.0));
+            src.release();
+            dst.release();
+        }
+}
+
 TEST(Imgproc_Morphology, iterated)
 {
     RNG& rng = theRNG();


### PR DESCRIPTION
Using CV_32S, CV_8S as input for GaussianBlur, an error occurs in sepFilter2D. In using GaussianBlur, I think that we need to add assertions to explicitly prohibit the use of these types.
