### PR TITLE
ml: fix internal state when changing the impl in KNearest

### DIFF
--- a/modules/ml/src/knearest.cpp
+++ b/modules/ml/src/knearest.cpp
@@ -437,7 +437,16 @@ public:
     {
         if (val != BRUTE_FORCE && val != KDTREE)
             val = BRUTE_FORCE;
+
+        int k = getDefaultK();
+        int e = getEmax();
+        bool c = getIsClassifier();
+
         initImpl(val);
+
+        setDefaultK(k);
+        setEmax(e);
+        setIsClassifier(c);
     }
 
 public:


### PR DESCRIPTION

resolves #11450

### This pullrequest changes

cache previous impl state vars, like defaultK, Emax, isClassifier, and set them again after creating a new impl object