### PR TITLE
tests: "Big data" tests category

### DIFF
--- a/modules/core/test/test_io.cpp
+++ b/modules/core/test/test_io.cpp
@@ -522,33 +522,23 @@ protected:
 
 TEST(Core_InputOutput, misc) { CV_MiscIOTest test; test.safe_run(); }
 
-/*class CV_BigMatrixIOTest : public cvtest::BaseTest
+#if 0 // 4+ GB of data, 40+ GB of estimated result size, it is very slow
+BIGDATA_TEST(Core_InputOutput, huge)
 {
-public:
-    CV_BigMatrixIOTest() {}
-    ~CV_BigMatrixIOTest() {}
-protected:
-    void run(int)
+    RNG& rng = theRNG();
+    int N = 1000, M = 1200000;
+    std::cout << "Allocating..." << std::endl;
+    Mat mat(M, N, CV_32F);
+    std::cout << "Initializing..." << std::endl;
+    rng.fill(mat, RNG::UNIFORM, 0, 1);
+    std::cout << "Writing..." << std::endl;
     {
-        try
-        {
-            RNG& rng = theRNG();
-            int N = 1000, M = 1200000;
-            Mat mat(M, N, CV_32F);
-            rng.fill(mat, RNG::UNIFORM, 0, 1);
-            FileStorage fs(cv::tempfile(".xml"), FileStorage::WRITE);
-            fs << "mat" << mat;
-            fs.release();
-        }
-        catch(...)
-        {
-            ts->set_failed_test_info(cvtest::TS::FAIL_MISMATCH);
-        }
+        FileStorage fs(cv::tempfile(".xml"), FileStorage::WRITE);
+        fs << "mat" << mat;
+        fs.release();
     }
-};
-
-TEST(Core_InputOutput, huge) { CV_BigMatrixIOTest test; test.safe_run(); }
-*/
+}
+#endif
 
 TEST(Core_globbing, accuracy)
 {

--- a/modules/core/test/test_mat.cpp
+++ b/modules/core/test/test_mat.cpp
@@ -1776,4 +1776,26 @@ TEST(Mat_, template_based_ptr)
 
 #endif
 
+
+BIGDATA_TEST(Mat, push_back_regression_4158)  // memory usage: ~10.6 Gb
+{
+    Mat result;
+
+    Mat tail(100, 500000, CV_32FC2, Scalar(1, 2));
+
+    tail.copyTo(result);
+    for (int i = 1; i < 15; i++)
+    {
+        result.push_back(tail);
+        std::cout << "i = " << i << "  result = " << result.size() << "   used = " << (uint64)result.total()*result.elemSize()*(1.0 / (1 << 20)) << " Mb"
+            << "   allocated=" << (uint64)(result.datalimit - result.datastart)*(1.0 / (1 << 20)) << " Mb" << std::endl;
+    }
+    for (int i = 0; i < 15; i++)
+    {
+        Rect roi(0, tail.rows * i, tail.cols, tail.rows);
+        int nz = countNonZero(result(roi).reshape(1) == 2);
+        EXPECT_EQ(tail.total(), (size_t)nz) << "i=" << i;
+    }
+}
+
 }} // namespace

--- a/modules/ts/include/opencv2/ts/ts_ext.hpp
+++ b/modules/ts/include/opencv2/ts/ts_ext.hpp
@@ -11,6 +11,7 @@
 namespace cvtest {
 void checkIppStatus();
 extern bool skipUnstableTests;
+extern bool runBigDataTests;
 extern int testThreads;
 }
 
@@ -43,7 +44,7 @@ extern int testThreads;
 
 
 #undef TEST
-#define TEST(test_case_name, test_name) \
+#define TEST_(test_case_name, test_name, BODY_IMPL) \
     class GTEST_TEST_CLASS_NAME_(test_case_name, test_name) : public ::testing::Test {\
      public:\
       GTEST_TEST_CLASS_NAME_(test_case_name, test_name)() {}\
@@ -65,8 +66,36 @@ extern int testThreads;
             ::testing::Test::TearDownTestCase, \
             new ::testing::internal::TestFactoryImpl<\
                 GTEST_TEST_CLASS_NAME_(test_case_name, test_name)>);\
-    void GTEST_TEST_CLASS_NAME_(test_case_name, test_name)::TestBody() CV__TEST_BODY_IMPL( #test_case_name "_" #test_name ) \
+    void GTEST_TEST_CLASS_NAME_(test_case_name, test_name)::TestBody() BODY_IMPL( #test_case_name "_" #test_name ) \
     void GTEST_TEST_CLASS_NAME_(test_case_name, test_name)::Body()
+
+#define TEST(test_case_name, test_name) TEST_(test_case_name, test_name, CV__TEST_BODY_IMPL)
+
+#define CV__TEST_BIGDATA_BODY_IMPL(name) \
+    { \
+       if (!cvtest::runBigDataTests) \
+       { \
+           printf("[     SKIP ] BigData tests are disabled\n"); \
+           return; \
+       } \
+       CV__TRACE_APP_FUNCTION_NAME(name); \
+       try { \
+          CV__TEST_INIT \
+          Body(); \
+          CV__TEST_CLEANUP \
+       } \
+       catch (cvtest::SkipTestException& e) \
+       { \
+          printf("[     SKIP ] %s\n", e.what()); \
+       } \
+    } \
+
+// Special type of tests which require / use or validate processing of huge amount of data (>= 2Gb)
+#if defined(_M_X64) || defined(__x86_64__) || defined(__aarch64__)
+#define BIGDATA_TEST(test_case_name, test_name) TEST_(BigData_ ## test_case_name, test_name, CV__TEST_BIGDATA_BODY_IMPL)
+#else
+#define BIGDATA_TEST(test_case_name, test_name) TEST_(BigData_ ## test_case_name, DISABLED_ ## test_name, CV__TEST_BIGDATA_BODY_IMPL)
+#endif
 
 #undef TEST_F
 #define TEST_F(test_fixture, test_name)\

--- a/modules/ts/src/ts.cpp
+++ b/modules/ts/src/ts.cpp
@@ -699,6 +699,7 @@ void checkIppStatus()
 }
 
 bool skipUnstableTests = false;
+bool runBigDataTests = false;
 int testThreads = 0;
 
 void parseCustomOptions(int argc, char **argv)
@@ -708,6 +709,7 @@ void parseCustomOptions(int argc, char **argv)
         "{ test_seed          |809564   |seed for random numbers generator }"
         "{ test_threads       |-1       |the number of worker threads, if parallel execution is enabled}"
         "{ skip_unstable      |false    |skip unstable tests }"
+        "{ test_bigdata       |false    |run BigData tests (>=2Gb) }"
         "{ h   help           |false    |print help info                          }";
 
     cv::CommandLineParser parser(argc, argv, command_line_keys);
@@ -730,6 +732,7 @@ void parseCustomOptions(int argc, char **argv)
     testThreads = parser.get<int>("test_threads");
 
     skipUnstableTests = parser.get<bool>("skip_unstable");
+    runBigDataTests = parser.get<bool>("test_bigdata");
 }
 
 


### PR DESCRIPTION
Tests which use a large amount of memory 2+Gb (up to 14Gb).

- skipped by default
- Use `--test_bigdata` to allow launching of "BigData" tests.

related #11505

**Note**: Do not perform massive port of existed accuracy tests with different input types / multiple sizes.
Only simple, quite fast (up to 5-20 seconds), non-parametric (exact single flow), "regression" tests from fixed issues are allowed here.

```
allow_multiple_commits=1
```