### PR TITLE
cuda_meanStdDev : bug fix

### DIFF
--- a/modules/cudaarithm/src/reductions.cpp
+++ b/modules/cudaarithm/src/reductions.cpp
@@ -137,12 +137,11 @@ void cv::cuda::meanStdDev(InputArray _src, OutputArray _dst, Stream& stream)
     if (!deviceSupports(FEATURE_SET_COMPUTE_13))
         CV_Error(cv::Error::StsNotImplemented, "Not sufficient compute capebility");
 
-    GpuMat src = getInputMat(_src, stream);
+    const GpuMat src = getInputMat(_src, stream);
 
     CV_Assert( src.type() == CV_8UC1 );
 
-    _dst.create(1, 2, CV_64FC1);
-    GpuMat dst = _dst.getGpuMat();
+    GpuMat dst = getOutputMat(_dst, 1, 2, CV_64FC1, stream);
 
     NppiSize sz;
     sz.width  = src.cols;


### PR DESCRIPTION
Without this fix, following tests in opencv_test_cudaarithm will fail.

CUDA_Arithm/MeanStdDev.Accuracy
CUDA_Arithm/MeanStdDev.Async

`_dst.getGpuMat()` gives error when `_dst` is a `HostMem` whose `alloc_type` is not `SHARED`. More general approach is needed that covers various types of `_dst`.

This PR reverts a small part of f4e5d77.

```
force_builders=Custom
docker_image:Custom=ubuntu-cuda:16.04
```