### PR TITLE
Add InputArray::isExpr() and allow as input to imwrite()

### DIFF
--- a/modules/core/include/opencv2/core/mat.hpp
+++ b/modules/core/include/opencv2/core/mat.hpp
@@ -236,6 +236,7 @@ public:
     bool isUMatVector() const;
     bool isMatx() const;
     bool isVector() const;
+    bool isExpr() const;
     bool isGpuMat() const;
     bool isGpuMatVector() const;
     ~_InputArray();

--- a/modules/core/include/opencv2/core/mat.inl.hpp
+++ b/modules/core/include/opencv2/core/mat.inl.hpp
@@ -155,6 +155,7 @@ inline bool _InputArray::isMatx() const { return kind() == _InputArray::MATX; }
 inline bool _InputArray::isVector() const { return kind() == _InputArray::STD_VECTOR ||
                                                    kind() == _InputArray::STD_BOOL_VECTOR ||
                                                    kind() == _InputArray::STD_ARRAY; }
+inline bool _InputArray::isExpr() const { return kind() == _InputArray::EXPR; }
 inline bool _InputArray::isGpuMat() const { return kind() == _InputArray::CUDA_GPU_MAT; }
 inline bool _InputArray::isGpuMatVector() const { return kind() == _InputArray::STD_VECTOR_CUDA_GPU_MAT; }
 

--- a/modules/imgcodecs/src/loadsave.cpp
+++ b/modules/imgcodecs/src/loadsave.cpp
@@ -717,7 +717,7 @@ bool imwrite( const String& filename, InputArray _img,
     CV_TRACE_FUNCTION();
     std::vector<Mat> img_vec;
     //Did we get a Mat or a vector of Mats?
-    if (_img.isMat() || _img.isUMat())
+    if (_img.isMat() || _img.isUMat() || _img.isExpr())
         img_vec.push_back(_img.getMat());
     else if (_img.isMatVector() || _img.isUMatVector())
         _img.getMatVector(img_vec);


### PR DESCRIPTION
resolves #11545 

### This pullrequest changes
Allows expressions to be used as arguments to imwrite, which is broken in 3.4.1 and was supported up through 3.4.0