### PR TITLE
cuda: fix the test failure of CUDA_Arithm/MeanStdDev

### DIFF
--- a/modules/core/include/opencv2/core/private.cuda.hpp
+++ b/modules/core/include/opencv2/core/private.cuda.hpp
@@ -152,7 +152,7 @@ namespace cv { namespace cuda
 
         inline ~NppStreamHandler()
         {
-            nppSetStream(oldStream);
+            cudaStreamSynchronize(oldStream);
         }
 
     private:


### PR DESCRIPTION
<!-- Please use this line to close one or multiple issues when this pullrequest gets merged
You can add another line right under the first one:
resolves #1234
resolves #1235
-->

### This pullrequest changes
related to #11063 #11064 
At last I got rid of unknown test failure of ```opencv_test_cudaarithm``` on each Jetson.

<!-- Please describe what your pullrequest is changing -->
