### PR TITLE
dnn: relax intel only ocl4 dnn

### DIFF
--- a/modules/dnn/src/layers/convolution_layer.cpp
+++ b/modules/dnn/src/layers/convolution_layer.cpp
@@ -966,8 +966,7 @@ public:
         CV_TRACE_FUNCTION();
         CV_TRACE_ARG_VALUE(name, "name", name.c_str());
 
-        CV_OCL_RUN(IS_DNN_OPENCL_TARGET(preferableTarget) &&
-                   OCL_PERFORMANCE_CHECK(ocl::Device::getDefault().isIntel()),
+        CV_OCL_RUN(IS_DNN_OPENCL_TARGET(preferableTarget),
                    forward_ocl(inputs_arr, outputs_arr, internals_arr))
 
         Layer::forward_fallback(inputs_arr, outputs_arr, internals_arr);

--- a/modules/dnn/src/layers/elementwise_layers.cpp
+++ b/modules/dnn/src/layers/elementwise_layers.cpp
@@ -176,8 +176,7 @@ public:
     {
         CV_TRACE_FUNCTION();
 
-        CV_OCL_RUN(IS_DNN_OPENCL_TARGET(this->preferableTarget) &&
-                   OCL_PERFORMANCE_CHECK(ocl::Device::getDefault().isIntel()),
+        CV_OCL_RUN(IS_DNN_OPENCL_TARGET(this->preferableTarget),
                    func.applyOCL(inputs_arr, outputs_arr, internals_arr))
 
         Layer::forward_fallback(inputs_arr, outputs_arr, internals_arr);

--- a/modules/dnn/src/layers/pooling_layer.cpp
+++ b/modules/dnn/src/layers/pooling_layer.cpp
@@ -191,8 +191,7 @@ public:
         CV_TRACE_FUNCTION();
         CV_TRACE_ARG_VALUE(name, "name", name.c_str());
 
-        CV_OCL_RUN(IS_DNN_OPENCL_TARGET(preferableTarget) &&
-                   OCL_PERFORMANCE_CHECK(ocl::Device::getDefault().isIntel()),
+        CV_OCL_RUN(IS_DNN_OPENCL_TARGET(preferableTarget),
                    forward_ocl(inputs_arr, outputs_arr, internals_arr))
 
         Layer::forward_fallback(inputs_arr, outputs_arr, internals_arr);

--- a/modules/dnn/src/opencl/mvn.cl
+++ b/modules/dnn/src/opencl/mvn.cl
@@ -89,7 +89,8 @@ __kernel void CALC_MEAN(__global const Dtype* src,
 
     Dtype mean_val = mean[x];
     vec_type src_vec = load(src, index);
-    vec_type dst_vec = native_powr(src_vec - (vec_type)mean_val, 2);
+    vec_type dst_vec = src_vec - (vec_type)mean_val;
+    dst_vec = dst_vec * dst_vec;
     store(dst_vec, dst, index);
 }
 
@@ -197,10 +198,14 @@ __kernel void MEAN_FUSE(__global const T * A,
         const T4 a2 = vload4(i, src0_read + 2 * A_col_size);
         const T4 a3 = vload4(i, src0_read + 3 * A_col_size);
 
-        dot0 = native_powr(convert_float4(a0) - (Dtype4)sum.x, 2);
-        dot1 = native_powr(convert_float4(a1) - (Dtype4)sum.y, 2);
-        dot2 = native_powr(convert_float4(a2) - (Dtype4)sum.z, 2);
-        dot3 = native_powr(convert_float4(a3) - (Dtype4)sum.w, 2);
+        dot0 = convert_float4(a0) - (Dtype4)sum.x;
+        dot1 = convert_float4(a1) - (Dtype4)sum.y;
+        dot2 = convert_float4(a2) - (Dtype4)sum.z;
+        dot3 = convert_float4(a3) - (Dtype4)sum.w;
+        dot0 = dot0 * dot0;
+        dot1 = dot1 * dot1;
+        dot2 = dot2 * dot2;
+        dot3 = dot3 * dot3;
 
         vstore4(dot0, i, dst0_read);
         vstore4(dot1, i, dst0_read + A_col_size);

--- a/modules/dnn/test/test_tf_importer.cpp
+++ b/modules/dnn/test/test_tf_importer.cpp
@@ -160,10 +160,12 @@ TEST_P(Test_TensorFlow_layers, batch_norm)
 TEST_P(Test_TensorFlow_layers, pooling)
 {
     int targetId = GetParam();
+    cv::ocl::Device d = cv::ocl::Device::getDefault();
+    bool loosenFlag = targetId == DNN_TARGET_OPENCL && d.isIntel() && d.type() == cv::ocl::Device::TYPE_CPU;
     runTensorFlowNet("max_pool_even", targetId);
     runTensorFlowNet("max_pool_odd_valid", targetId);
     runTensorFlowNet("ave_pool_same", targetId);
-    runTensorFlowNet("max_pool_odd_same", targetId);
+    runTensorFlowNet("max_pool_odd_same", targetId, false, loosenFlag ? 3e-5 : 1e-5, loosenFlag ? 3e-4 : 1e-4);
     runTensorFlowNet("reduce_mean", targetId);  // an average pooling over all spatial dimensions.
 }
 


### PR DESCRIPTION
related #11494 #11397 #10639 #10717

I realized that ocl4dnn kernel only works on Intel GPU.
I wrote a workaround in #11494 but the root of the cause was two points.
1. The kernel was using platform dependent behaviour of ```native_powr```
2. The fallback process when OpenCL failed on runtime, was doing wrong normalization



### Platform specific ```native_powr```
 * I confirmed that ```Test_TensorFlow_layers.batch_norm``` and ```Test_TensorFlow_layers.pooling``` passes only on Intel GPU
   * PASS : Intel GPU
   * FAILURE: Intel CPU, NVIDIA Geforce, Arm Mali
 * I digged in for a while and realized that after calculating the mean using OpenCL kernel, some of the elements became ```NaN```
 * I googled a lot and realized that [this line](https://github.com/opencv/opencv/blob/6aec71d7ee02955d781ef57126693ec674976076/modules/dnn/src/opencl/mvn.cl#L88) seems wrong

https://github.com/opencv/opencv/blob/6aec71d7ee02955d781ef57126693ec674976076/modules/dnn/src/opencl/mvn.cl#L88

 * This line is computing the square diff between the average value, but ```native_powr``` is showing a different behaviour based on platform
   * According to the references[1][2][3], it seems that ```native_powr``` requires the first parameter to be **greather than or equal to 0**
   * In this case, the first parameter can be a negative value, and thus, in some situation the computation value resulted in ```NaN```

> native_powr Computes x to the power of y, where x is ? 0. The range of x and y are implementation-defined. The maximum error is implementation-defined.

   * So probably, ```pown``` is the function we should use here.

> pown Computes x to the power of y, where y is an integer. 


### fallback process of normalization
 * Still, the test was failing on Arm Mali (Tinkerboard, ODROID-XU4, Firefly RK3399)
   * It seems that memory was not enough for running the kernel and it was falling back to the CPU version call
   * The fall back is inevidable, but I guess that fall back implementation was not verified correctly, and the normalization result was different from the others
   * I modified the code a bit, and now the test passes, but it's involves removing the following 0 fill from mvn_layer.cpp

https://github.com/opencv/opencv/blob/1060c0f439cbb8de44ff258d2ad3ab9c6b429331/modules/dnn/src/layers/mvn_layer.cpp#L274-L279

   * I'd like to confirm @pengli about this point, just in case if I'm going the wrong way.

### other topics
 * This PR isn't packed as a single commit, becasue there are other points to discuss
 * other ```native_powr```
   * in [mvn.cl](https://github.com/opencv/opencv/blob/master/modules/dnn/src/opencl/mvn.cl), there [are other call of ```native_powr```](https://github.com/opencv/opencv/blob/6aec71d7ee02955d781ef57126693ec674976076/modules/dnn/src/opencl/mvn.cl#L196-L199) which seems ```pown``` looks suitable

https://github.com/opencv/opencv/blob/6aec71d7ee02955d781ef57126693ec674976076/modules/dnn/src/opencl/mvn.cl#L196-L199

   * For this, I could make a separate PR
 * Also, I removed all the ```isIntel()``` call from the dnn module
   * If I understand correctly, these call were added because the kernel doesn't work on other platform than Intel GPU
   * Now all the test pass on 
     * Intel GPU (HD Graphics)
     * Intel CPU (Core i7)
     * NVIDIA GPU (Geforce GTX 1060)
     * Arm GPU (Mali T628, 760, T860)
   * So I guess ```isIntel``` is no more needed in this module
 


[1] https://www.khronos.org/registry/OpenCL/sdk/1.0/docs/man/xhtml/pow.html
[2] https://www.khronos.org/registry/OpenCL/sdk/1.2/docs/man/xhtml/pow.html
[3] https://www.khronos.org/registry/OpenCL/sdk/2.0/docs/man/xhtml/pow.html

