### PR TITLE
cmake: filter NVCC compiler flags

### DIFF
--- a/cmake/OpenCVDetectCUDA.cmake
+++ b/cmake/OpenCVDetectCUDA.cmake
@@ -203,6 +203,16 @@ if(CUDA_FOUND)
 
       # cc1: warning: command line option '-Wsuggest-override' is valid for C++/ObjC++ but not for C
       string(REPLACE "-Wsuggest-override" "" ${var} "${${var}}")
+
+      # issue: #11552 (from OpenCVCompilerOptions.cmake)
+      string(REGEX REPLACE "-Wimplicit-fallthrough(=[0-9]+)? " "" ${var} "${${var}}")
+
+      # removal of custom specified options
+      if(OPENCV_CUDA_NVCC_FILTEROUT_OPTIONS)
+        foreach(__flag ${OPENCV_CUDA_NVCC_FILTEROUT_OPTIONS})
+          string(REPLACE "${__flag}" "" ${var} "${${var}}")
+        endforeach()
+      endif()
     endforeach()
   endmacro()
 


### PR DESCRIPTION
resolves #11552

- remove `-Wimplicit-fallthrough`
- remove custom options, specified via `OPENCV_CUDA_NVCC_FILTEROUT_OPTIONS` variable

```
force_builders=Custom
docker_image:Custom=ubuntu-cuda:16.04
```