### PR TITLE
 imgcodecs: fix imwrite handling of different OutputArray types

### DIFF
--- a/modules/imgcodecs/src/loadsave.cpp
+++ b/modules/imgcodecs/src/loadsave.cpp
@@ -716,13 +716,10 @@ bool imwrite( const String& filename, InputArray _img,
 {
     CV_TRACE_FUNCTION();
     std::vector<Mat> img_vec;
-    //Did we get a Mat or a vector of Mats?
-    if (_img.isMat() || _img.isUMat())
-        img_vec.push_back(_img.getMat());
-    else if (_img.isMatVector() || _img.isUMatVector())
+    if (_img.isMatVector() || _img.isUMatVector())
         _img.getMatVector(img_vec);
     else
-        CV_Error(Error::StsBadArg, "Unknown/unsupported input encountered");
+        img_vec.push_back(_img.getMat());
 
     CV_Assert(!img_vec.empty());
     return imwrite_(filename, img_vec, params, false);

--- a/modules/imgcodecs/test/test_grfmt.cpp
+++ b/modules/imgcodecs/test/test_grfmt.cpp
@@ -327,4 +327,18 @@ TEST(Imgcodecs_Pam, read_write)
     remove(writefile_no_param.c_str());
 }
 
+TEST(Imgcodecs, write_parameter_type)
+{
+    cv::Mat m(10, 10, CV_8UC1, cv::Scalar::all(0));
+    cv::Mat1b m_type = cv::Mat1b::zeros(10, 10);
+    string tmp_file = cv::tempfile(".bmp");
+    EXPECT_NO_THROW(cv::imwrite(tmp_file, cv::Mat(m * 2))) << "* Failed with cv::Mat";
+    EXPECT_NO_THROW(cv::imwrite(tmp_file, m * 2)) << "* Failed with cv::MatExpr";
+    EXPECT_NO_THROW(cv::imwrite(tmp_file, m_type)) << "* Failed with cv::Mat_";
+    EXPECT_NO_THROW(cv::imwrite(tmp_file, m_type * 2)) << "* Failed with cv::MatExpr(Mat_)";
+    cv::Matx<uchar, 10, 10> matx;
+    EXPECT_NO_THROW(cv::imwrite(tmp_file, matx)) << "* Failed with cv::Matx";
+    EXPECT_EQ(0, remove(tmp_file.c_str()));
+}
+
 }} // namespace


### PR DESCRIPTION
resolves #11545
related #11548

```
allow_multiple_commits=1
```