### PR TITLE
Allow setting IE paths via cmake

### DIFF
--- a/cmake/OpenCVDetectInferenceEngine.cmake
+++ b/cmake/OpenCVDetectInferenceEngine.cmake
@@ -30,7 +30,7 @@ if(NOT INF_ENGINE_ROOT_DIR OR NOT EXISTS "${INF_ENGINE_ROOT_DIR}/include/inferen
         list(APPEND ie_root_paths "${INTEL_CVSDK_DIR}/inference_engine")
     endif()
 
-    if(WITH_INF_ENGINE AND NOT ie_root_paths)
+    if(NOT ie_root_paths)
         list(APPEND ie_root_paths "/opt/intel/deeplearning_deploymenttoolkit/deployment_tools/inference_engine")
     endif()
 

--- a/modules/dnn/CMakeLists.txt
+++ b/modules/dnn/CMakeLists.txt
@@ -80,7 +80,7 @@ else()
   set(sources_options EXCLUDE_OPENCL)
 endif()
 
-if(WITH_INF_ENGINE AND HAVE_INF_ENGINE)
+if(HAVE_INF_ENGINE)
   add_definitions(-DHAVE_INF_ENGINE=1)
   list(APPEND include_dirs ${INF_ENGINE_INCLUDE_DIRS})
   list(APPEND libs ${INF_ENGINE_LIBRARIES})

--- a/modules/dnn/src/op_inf_engine.cpp
+++ b/modules/dnn/src/op_inf_engine.cpp
@@ -192,6 +192,10 @@ void InfEngineBackendNet::getName(char*, size_t) noexcept
 {
 }
 
+void InfEngineBackendNet::getName(char*, size_t) const noexcept
+{
+}
+
 size_t InfEngineBackendNet::layerCount() noexcept
 {
     return layers.size();

--- a/modules/dnn/src/op_inf_engine.hpp
+++ b/modules/dnn/src/op_inf_engine.hpp
@@ -46,7 +46,9 @@ public:
 
     virtual InferenceEngine::InputInfo::Ptr getInput(const std::string &inputName) noexcept CV_OVERRIDE;
 
-    virtual void getName(char *pName, size_t len) noexcept CV_OVERRIDE;
+    virtual void getName(char *pName, size_t len) noexcept;
+
+    virtual void getName(char *pName, size_t len) const noexcept;
 
     virtual size_t layerCount() noexcept CV_OVERRIDE;
 


### PR DESCRIPTION
<!-- Please use this line to close one or multiple issues when this pullrequest gets merged
You can add another line right under the first one:
resolves #1234
resolves #1235
-->

### This pullrequest changes

* allow forcing IE paths bypassing auto detector: `-DWITH_INF_ENGINE=OFF -DHAVE_INF_ENGINE=ON -DINF_ENGINE_INCLUDE_DIRS=... -DINF_ENGINE_LIBRARIES=...`
* fixed compatibility with recent versions
