### PR TITLE
NPP : NppStreamHandler fix

### DIFF
--- a/modules/core/include/opencv2/core/private.cuda.hpp
+++ b/modules/core/include/opencv2/core/private.cuda.hpp
@@ -152,7 +152,7 @@ namespace cv { namespace cuda
 
         inline ~NppStreamHandler()
         {
-            cudaStreamSynchronize(oldStream);
+            nppSafeSetStream(nppGetStream(), oldStream);
         }
 
     private:


### PR DESCRIPTION
The destructor of NppStreamHandler should rollback NPP stream.

Without this fix, following tests in opencv_test_cudaimgproc fail.

CUDA_ImgProc/EqualizeHist.Async/1
CUDA_ImgProc/EqualizeHist.Accuracy/0
CUDA_ImgProc/EqualizeHist.Accuracy/1

Test environment:
* Branch: 3.4
* OS/Platform: Windows10/CUDA8.0
* GPU: GTX1080