### PR TITLE
GStreamer backend: fixed memory leak and version check

### DIFF
--- a/modules/videoio/src/cap_gstreamer.cpp
+++ b/modules/videoio/src/cap_gstreamer.cpp
@@ -125,7 +125,7 @@ private:
         gst_init(NULL, NULL);
         guint major, minor, micro, nano;
         gst_version(&major, &minor, &micro, &nano);
-        if (GST_VERSION_MAJOR == major)
+        if (GST_VERSION_MAJOR != major)
         {
             CV_WARN("incompatible gstreamer version");
         }
@@ -268,7 +268,6 @@ bool GStreamerCapture::grabFrame()
     sample = gst_app_sink_pull_sample(GST_APP_SINK(sink));
     if(!sample)
         return false;
-    gst_sample_ref(sample);
 #endif
 
     if (isPosFramesEmulated)


### PR DESCRIPTION
### This pullrequest changes

Looks like that `gst_sample_ref` was not needed.

See #5715 for details.

```
docker_image:Linux x64 Debug=gstreamer:16.04
docker_image:Custom=gstreamer:14.04
```