### PR TITLE
avoid copyTo(outputarray.getMat()) coding pattern

### DIFF
--- a/modules/photo/src/merge.cpp
+++ b/modules/photo/src/merge.cpp
@@ -259,7 +259,7 @@ public:
             res_pyr[lvl - 1] += up;
         }
         dst.create(size, CV_32FCC);
-        res_pyr[0].copyTo(dst.getMat());
+        res_pyr[0].copyTo(dst);
     }
 
     float getContrastWeight() const CV_OVERRIDE { return wcon; }


### PR DESCRIPTION
- leads to errors due 'const' modifier of getMat() method
- may be non-optimal with non-CPU data storage
