### PR TITLE
Update Intel's Inference Engine deep learning backend

### DIFF
--- a/cmake/OpenCVDetectInferenceEngine.cmake
+++ b/cmake/OpenCVDetectInferenceEngine.cmake
@@ -37,9 +37,7 @@ if(NOT INF_ENGINE_ROOT_DIR OR NOT EXISTS "${INF_ENGINE_ROOT_DIR}/include/inferen
     find_path(INF_ENGINE_ROOT_DIR include/inference_engine.hpp PATHS ${ie_root_paths})
 endif()
 
-set(INF_ENGINE_INCLUDE_DIRS "${INF_ENGINE_ROOT_DIR}/include"
-                            "${INF_ENGINE_ROOT_DIR}/samples/extension"
-                            CACHE PATH "Path to Inference Engine include directories")
+set(INF_ENGINE_INCLUDE_DIRS "${INF_ENGINE_ROOT_DIR}/include" CACHE PATH "Path to Inference Engine include directory")
 
 if(NOT INF_ENGINE_ROOT_DIR
     OR NOT EXISTS "${INF_ENGINE_ROOT_DIR}"
@@ -50,13 +48,10 @@ endif()
 
 set(INF_ENGINE_LIBRARIES "")
 
-set(ie_lib_list inference_engine cpu_extension)
+set(ie_lib_list inference_engine)
 
 link_directories(
-  ${INTEL_CVSDK_DIR}/external/mklml_lnx/lib
-  ${INTEL_CVSDK_DIR}/inference_engine/external/mklml_lnx/lib
   ${INTEL_CVSDK_DIR}/inference_engine/external/mkltiny_lnx/lib
-  ${INTEL_CVSDK_DIR}/external/cldnn/lib
   ${INTEL_CVSDK_DIR}/inference_engine/external/cldnn/lib
 )
 

--- a/cmake/OpenCVDetectInferenceEngine.cmake
+++ b/cmake/OpenCVDetectInferenceEngine.cmake
@@ -37,19 +37,20 @@ if(NOT INF_ENGINE_ROOT_DIR OR NOT EXISTS "${INF_ENGINE_ROOT_DIR}/include/inferen
     find_path(INF_ENGINE_ROOT_DIR include/inference_engine.hpp PATHS ${ie_root_paths})
 endif()
 
-set(INF_ENGINE_INCLUDE_DIRS "${INF_ENGINE_ROOT_DIR}/include" CACHE PATH "Path to Inference Engine include directory")
+set(INF_ENGINE_INCLUDE_DIRS "${INF_ENGINE_ROOT_DIR}/include"
+                            "${INF_ENGINE_ROOT_DIR}/samples/extension"
+                            CACHE PATH "Path to Inference Engine include directories")
 
 if(NOT INF_ENGINE_ROOT_DIR
     OR NOT EXISTS "${INF_ENGINE_ROOT_DIR}"
-    OR NOT EXISTS "${INF_ENGINE_INCLUDE_DIRS}"
-    OR NOT EXISTS "${INF_ENGINE_INCLUDE_DIRS}/inference_engine.hpp"
+    OR NOT EXISTS "${INF_ENGINE_ROOT_DIR}/include/inference_engine.hpp"
 )
     ie_fail()
 endif()
 
 set(INF_ENGINE_LIBRARIES "")
 
-set(ie_lib_list inference_engine)
+set(ie_lib_list inference_engine cpu_extension)
 
 link_directories(
   ${INTEL_CVSDK_DIR}/external/mklml_lnx/lib

--- a/modules/dnn/include/opencv2/dnn/dnn.hpp
+++ b/modules/dnn/include/opencv2/dnn/dnn.hpp
@@ -81,7 +81,8 @@ CV__DNN_EXPERIMENTAL_NS_BEGIN
     {
         DNN_TARGET_CPU,
         DNN_TARGET_OPENCL,
-        DNN_TARGET_OPENCL_FP16
+        DNN_TARGET_OPENCL_FP16,
+        DNN_TARGET_MYRIAD
     };
 
     /** @brief This class provides all data needed to initialize layer.
@@ -700,13 +701,13 @@ CV__DNN_EXPERIMENTAL_NS_BEGIN
       *                  * `*.pb` (TensorFlow, https://www.tensorflow.org/)
       *                  * `*.t7` | `*.net` (Torch, http://torch.ch/)
       *                  * `*.weights` (Darknet, https://pjreddie.com/darknet/)
-      *                  * `*.bin` (DLDT, https://software.seek.intel.com/deep-learning-deployment)
+      *                  * `*.bin` (DLDT, https://software.intel.com/openvino-toolkit)
       * @param[in] config Text file contains network configuration. It could be a
       *                   file with the following extensions:
       *                  * `*.prototxt` (Caffe, http://caffe.berkeleyvision.org/)
       *                  * `*.pbtxt` (TensorFlow, https://www.tensorflow.org/)
       *                  * `*.cfg` (Darknet, https://pjreddie.com/darknet/)
-      *                  * `*.xml` (DLDT, https://software.seek.intel.com/deep-learning-deployment)
+      *                  * `*.xml` (DLDT, https://software.intel.com/openvino-toolkit)
       * @param[in] framework Explicit framework name tag to determine a format.
       * @returns Net object.
       *

--- a/modules/dnn/perf/perf_net.cpp
+++ b/modules/dnn/perf/perf_net.cpp
@@ -13,7 +13,7 @@
 namespace opencv_test {
 
 CV_ENUM(DNNBackend, DNN_BACKEND_DEFAULT, DNN_BACKEND_HALIDE, DNN_BACKEND_INFERENCE_ENGINE)
-CV_ENUM(DNNTarget, DNN_TARGET_CPU, DNN_TARGET_OPENCL, DNN_TARGET_OPENCL_FP16)
+CV_ENUM(DNNTarget, DNN_TARGET_CPU, DNN_TARGET_OPENCL, DNN_TARGET_OPENCL_FP16, DNN_TARGET_MYRIAD)
 
 class DNNTestNetwork : public ::perf::TestBaseWithParam< tuple<DNNBackend, DNNTarget> >
 {
@@ -87,8 +87,6 @@ public:
 
 PERF_TEST_P_(DNNTestNetwork, AlexNet)
 {
-    if (backend == DNN_BACKEND_INFERENCE_ENGINE && target != DNN_TARGET_CPU)
-        throw SkipTestException("");
     processNet("dnn/bvlc_alexnet.caffemodel", "dnn/bvlc_alexnet.prototxt",
             "alexnet.yml", Mat(cv::Size(227, 227), CV_32FC3));
 }
@@ -130,7 +128,6 @@ PERF_TEST_P_(DNNTestNetwork, ENet)
 
 PERF_TEST_P_(DNNTestNetwork, SSD)
 {
-    if (backend == DNN_BACKEND_INFERENCE_ENGINE) throw SkipTestException("");
     processNet("dnn/VGG_ILSVRC2016_SSD_300x300_iter_440000.caffemodel", "dnn/ssd_vgg16.prototxt", "disabled",
             Mat(cv::Size(300, 300), CV_32FC3));
 }
@@ -146,8 +143,7 @@ PERF_TEST_P_(DNNTestNetwork, OpenFace)
 
 PERF_TEST_P_(DNNTestNetwork, MobileNet_SSD_Caffe)
 {
-    if (backend == DNN_BACKEND_HALIDE ||
-        backend == DNN_BACKEND_INFERENCE_ENGINE && target != DNN_TARGET_CPU)
+    if (backend == DNN_BACKEND_HALIDE)
         throw SkipTestException("");
     processNet("dnn/MobileNetSSD_deploy.caffemodel", "dnn/MobileNetSSD_deploy.prototxt", "",
             Mat(cv::Size(300, 300), CV_32FC3));
@@ -155,8 +151,7 @@ PERF_TEST_P_(DNNTestNetwork, MobileNet_SSD_Caffe)
 
 PERF_TEST_P_(DNNTestNetwork, MobileNet_SSD_TensorFlow)
 {
-    if (backend == DNN_BACKEND_DEFAULT && target == DNN_TARGET_OPENCL ||
-        backend == DNN_BACKEND_HALIDE ||
+    if (backend == DNN_BACKEND_HALIDE ||
         backend == DNN_BACKEND_INFERENCE_ENGINE && target != DNN_TARGET_CPU)
         throw SkipTestException("");
     processNet("dnn/ssd_mobilenet_v1_coco.pb", "ssd_mobilenet_v1_coco.pbtxt", "",
@@ -166,7 +161,8 @@ PERF_TEST_P_(DNNTestNetwork, MobileNet_SSD_TensorFlow)
 PERF_TEST_P_(DNNTestNetwork, DenseNet_121)
 {
     if (backend == DNN_BACKEND_HALIDE ||
-        backend == DNN_BACKEND_INFERENCE_ENGINE && target == DNN_TARGET_OPENCL_FP16)
+        backend == DNN_BACKEND_INFERENCE_ENGINE && (target == DNN_TARGET_OPENCL_FP16 ||
+                                                    target == DNN_TARGET_MYRIAD))
         throw SkipTestException("");
     processNet("dnn/DenseNet_121.caffemodel", "dnn/DenseNet_121.prototxt", "",
                Mat(cv::Size(224, 224), CV_32FC3));
@@ -174,21 +170,27 @@ PERF_TEST_P_(DNNTestNetwork, DenseNet_121)
 
 PERF_TEST_P_(DNNTestNetwork, OpenPose_pose_coco)
 {
-    if (backend == DNN_BACKEND_HALIDE) throw SkipTestException("");
+    if (backend == DNN_BACKEND_HALIDE ||
+        backend == DNN_BACKEND_INFERENCE_ENGINE && target == DNN_TARGET_MYRIAD)
+        throw SkipTestException("");
     processNet("dnn/openpose_pose_coco.caffemodel", "dnn/openpose_pose_coco.prototxt", "",
                Mat(cv::Size(368, 368), CV_32FC3));
 }
 
 PERF_TEST_P_(DNNTestNetwork, OpenPose_pose_mpi)
 {
-    if (backend == DNN_BACKEND_HALIDE) throw SkipTestException("");
+    if (backend == DNN_BACKEND_HALIDE ||
+        backend == DNN_BACKEND_INFERENCE_ENGINE && target == DNN_TARGET_MYRIAD)
+        throw SkipTestException("");
     processNet("dnn/openpose_pose_mpi.caffemodel", "dnn/openpose_pose_mpi.prototxt", "",
                Mat(cv::Size(368, 368), CV_32FC3));
 }
 
 PERF_TEST_P_(DNNTestNetwork, OpenPose_pose_mpi_faster_4_stages)
 {
-    if (backend == DNN_BACKEND_HALIDE) throw SkipTestException("");
+    if (backend == DNN_BACKEND_HALIDE ||
+        backend == DNN_BACKEND_INFERENCE_ENGINE && target == DNN_TARGET_MYRIAD)
+        throw SkipTestException("");
     // The same .caffemodel but modified .prototxt
     // See https://github.com/CMU-Perceptual-Computing-Lab/openpose/blob/master/src/openpose/pose/poseParameters.cpp
     processNet("dnn/openpose_pose_mpi.caffemodel", "dnn/openpose_pose_mpi_faster_4_stages.prototxt", "",
@@ -197,8 +199,7 @@ PERF_TEST_P_(DNNTestNetwork, OpenPose_pose_mpi_faster_4_stages)
 
 PERF_TEST_P_(DNNTestNetwork, opencv_face_detector)
 {
-    if (backend == DNN_BACKEND_HALIDE ||
-        backend == DNN_BACKEND_INFERENCE_ENGINE && target != DNN_TARGET_CPU)
+    if (backend == DNN_BACKEND_HALIDE)
         throw SkipTestException("");
     processNet("dnn/opencv_face_detector.caffemodel", "dnn/opencv_face_detector.prototxt", "",
                Mat(cv::Size(300, 300), CV_32FC3));
@@ -207,7 +208,8 @@ PERF_TEST_P_(DNNTestNetwork, opencv_face_detector)
 PERF_TEST_P_(DNNTestNetwork, Inception_v2_SSD_TensorFlow)
 {
     if (backend == DNN_BACKEND_HALIDE ||
-        backend == DNN_BACKEND_INFERENCE_ENGINE && target != DNN_TARGET_CPU)
+        (backend == DNN_BACKEND_INFERENCE_ENGINE && target == DNN_TARGET_OPENCL) ||
+        (backend == DNN_BACKEND_INFERENCE_ENGINE && target == DNN_TARGET_OPENCL_FP16))
         throw SkipTestException("");
     processNet("dnn/ssd_inception_v2_coco_2017_11_17.pb", "ssd_inception_v2_coco_2017_11_17.pbtxt", "",
             Mat(cv::Size(300, 300), CV_32FC3));
@@ -215,7 +217,8 @@ PERF_TEST_P_(DNNTestNetwork, Inception_v2_SSD_TensorFlow)
 
 PERF_TEST_P_(DNNTestNetwork, YOLOv3)
 {
-    if (backend != DNN_BACKEND_DEFAULT)
+    if (backend == DNN_BACKEND_HALIDE ||
+        backend == DNN_BACKEND_INFERENCE_ENGINE && target != DNN_TARGET_CPU)
         throw SkipTestException("");
     Mat sample = imread(findDataFile("dnn/dog416.png", false));
     Mat inp;
@@ -232,6 +235,7 @@ const tuple<DNNBackend, DNNTarget> testCases[] = {
     tuple<DNNBackend, DNNTarget>(DNN_BACKEND_INFERENCE_ENGINE, DNN_TARGET_CPU),
     tuple<DNNBackend, DNNTarget>(DNN_BACKEND_INFERENCE_ENGINE, DNN_TARGET_OPENCL),
     tuple<DNNBackend, DNNTarget>(DNN_BACKEND_INFERENCE_ENGINE, DNN_TARGET_OPENCL_FP16),
+    tuple<DNNBackend, DNNTarget>(DNN_BACKEND_INFERENCE_ENGINE, DNN_TARGET_MYRIAD),
 #endif
     tuple<DNNBackend, DNNTarget>(DNN_BACKEND_DEFAULT, DNN_TARGET_CPU),
     tuple<DNNBackend, DNNTarget>(DNN_BACKEND_DEFAULT, DNN_TARGET_OPENCL),

--- a/modules/dnn/perf/perf_net.cpp
+++ b/modules/dnn/perf/perf_net.cpp
@@ -149,10 +149,11 @@ PERF_TEST_P_(DNNTestNetwork, MobileNet_SSD_Caffe)
             Mat(cv::Size(300, 300), CV_32FC3));
 }
 
+// TODO: update MobileNet model.
 PERF_TEST_P_(DNNTestNetwork, MobileNet_SSD_TensorFlow)
 {
     if (backend == DNN_BACKEND_HALIDE ||
-        backend == DNN_BACKEND_INFERENCE_ENGINE && target != DNN_TARGET_CPU)
+        backend == DNN_BACKEND_INFERENCE_ENGINE)
         throw SkipTestException("");
     processNet("dnn/ssd_mobilenet_v1_coco.pb", "ssd_mobilenet_v1_coco.pbtxt", "",
             Mat(cv::Size(300, 300), CV_32FC3));

--- a/modules/dnn/src/darknet/darknet_io.cpp
+++ b/modules/dnn/src/darknet/darknet_io.cpp
@@ -288,7 +288,7 @@ namespace cv {
                     permute_params.set("order", paramOrder);
 
                     darknet::LayerParameter lp;
-                    std::string layer_name = cv::format("premute_%d", layer_id);
+                    std::string layer_name = cv::format("permute_%d", layer_id);
                     lp.layer_name = layer_name;
                     lp.layer_type = permute_params.type;
                     lp.layerParams = permute_params;

--- a/modules/dnn/src/layers/elementwise_layers.cpp
+++ b/modules/dnn/src/layers/elementwise_layers.cpp
@@ -117,7 +117,7 @@ public:
     {
         return backendId == DNN_BACKEND_DEFAULT ||
                backendId == DNN_BACKEND_HALIDE && haveHalide() ||
-               backendId == DNN_BACKEND_INFERENCE_ENGINE && haveInfEngine() && this->type != "Sigmoid";
+               backendId == DNN_BACKEND_INFERENCE_ENGINE && haveInfEngine();
     }
 
     virtual Ptr<BackendNode> tryAttach(const Ptr<BackendNode>& node) CV_OVERRIDE
@@ -335,6 +335,7 @@ struct ReLUFunctor
         lp.type = "ReLU";
         std::shared_ptr<InferenceEngine::ReLULayer> ieLayer(new InferenceEngine::ReLULayer(lp));
         ieLayer->negative_slope = slope;
+        ieLayer->params["negative_slope"] = format("%f", slope);
         return ieLayer;
     }
 #endif  // HAVE_INF_ENGINE
@@ -432,6 +433,8 @@ struct ReLU6Functor
         std::shared_ptr<InferenceEngine::ClampLayer> ieLayer(new InferenceEngine::ClampLayer(lp));
         ieLayer->min_value = minValue;
         ieLayer->max_value = maxValue;
+        ieLayer->params["min"] = format("%f", minValue);
+        ieLayer->params["max"] = format("%f", maxValue);
         return ieLayer;
     }
 #endif  // HAVE_INF_ENGINE
@@ -557,8 +560,9 @@ struct SigmoidFunctor
 #ifdef HAVE_INF_ENGINE
     InferenceEngine::CNNLayerPtr initInfEngine(InferenceEngine::LayerParams& lp)
     {
-        CV_Error(Error::StsNotImplemented, "Sigmoid");
-        return InferenceEngine::CNNLayerPtr();
+        lp.type = "Sigmoid";
+        std::shared_ptr<InferenceEngine::CNNLayer> ieLayer(new InferenceEngine::CNNLayer(lp));
+        return ieLayer;
     }
 #endif  // HAVE_INF_ENGINE
 

--- a/modules/dnn/src/layers/region_layer.cpp
+++ b/modules/dnn/src/layers/region_layer.cpp
@@ -95,11 +95,6 @@ public:
         return false;
     }
 
-    virtual bool supportBackend(int backendId) CV_OVERRIDE
-    {
-        return backendId == DNN_BACKEND_DEFAULT;
-    }
-
     float logistic_activate(float x) { return 1.F / (1.F + exp(-x)); }
 
     void softmax_activate(const float* input, const int n, const float temp, float* output)

--- a/modules/dnn/src/op_inf_engine.cpp
+++ b/modules/dnn/src/op_inf_engine.cpp
@@ -18,11 +18,6 @@ namespace cv { namespace dnn {
 
 #ifdef HAVE_INF_ENGINE
 
-static int infEngineVersion()
-{
-    return std::atoi(InferenceEngine::GetInferenceEngineVersion()->buildNumber);
-}
-
 InfEngineBackendNode::InfEngineBackendNode(const InferenceEngine::CNNLayerPtr& _layer)
     : BackendNode(DNN_BACKEND_INFERENCE_ENGINE), layer(_layer) {}
 
@@ -59,27 +54,23 @@ infEngineWrappers(const std::vector<Ptr<BackendWrapper> >& ptrs)
     return wrappers;
 }
 
+static InferenceEngine::Layout estimateLayout(const Mat& m)
+{
+    if (m.dims == 4)
+        return InferenceEngine::Layout::NCHW;
+    else if (m.dims == 2)
+        return InferenceEngine::Layout::NC;
+    else
+        return InferenceEngine::Layout::ANY;
+}
+
 static InferenceEngine::DataPtr wrapToInfEngineDataNode(const Mat& m, const std::string& name = "")
 {
     std::vector<size_t> reversedShape(&m.size[0], &m.size[0] + m.dims);
     std::reverse(reversedShape.begin(), reversedShape.end());
-    if (infEngineVersion() > 5855)
-    {
-        InferenceEngine::Layout l = InferenceEngine::Layout::ANY;
-        if (m.dims == 4)
-            l = InferenceEngine::Layout::NCHW;
-        else if (m.dims == 2)
-            l = InferenceEngine::Layout::NC;
-        return InferenceEngine::DataPtr(
-            new InferenceEngine::Data(name, reversedShape, InferenceEngine::Precision::FP32, l)
-        );
-    }
-    else
-    {
-        return InferenceEngine::DataPtr(
-            new InferenceEngine::Data(name, reversedShape, InferenceEngine::Precision::FP32)
-        );
-    }
+    return InferenceEngine::DataPtr(
+        new InferenceEngine::Data(name, reversedShape, InferenceEngine::Precision::FP32, estimateLayout(m))
+    );
 }
 
 InferenceEngine::TBlob<float>::Ptr wrapToInfEngineBlob(const Mat& m, const std::vector<size_t>& shape,
@@ -108,7 +99,7 @@ InfEngineBackendWrapper::InfEngineBackendWrapper(int targetId, const cv::Mat& m)
     : BackendWrapper(DNN_BACKEND_INFERENCE_ENGINE, targetId)
 {
     dataPtr = wrapToInfEngineDataNode(m);
-    blob = wrapToInfEngineBlob(m);
+    blob = wrapToInfEngineBlob(m, estimateLayout(m));
 }
 
 InfEngineBackendWrapper::~InfEngineBackendWrapper()
@@ -252,7 +243,8 @@ InfEngineBackendNet::getLayerByName(const char *layerName, InferenceEngine::CNNL
 void InfEngineBackendNet::setTargetDevice(InferenceEngine::TargetDevice device) noexcept
 {
     if (device != InferenceEngine::TargetDevice::eCPU &&
-        device != InferenceEngine::TargetDevice::eGPU)
+        device != InferenceEngine::TargetDevice::eGPU &&
+        device != InferenceEngine::TargetDevice::eMYRIAD)
         CV_Error(Error::StsNotImplemented, "");
     targetDevice = device;
 }
@@ -352,6 +344,11 @@ void InfEngineBackendNet::init(int targetId)
     case DNN_TARGET_CPU: setTargetDevice(InferenceEngine::TargetDevice::eCPU); break;
     case DNN_TARGET_OPENCL_FP16: setPrecision(InferenceEngine::Precision::FP16);  // Fallback to the next.
     case DNN_TARGET_OPENCL: setTargetDevice(InferenceEngine::TargetDevice::eGPU); break;
+    case DNN_TARGET_MYRIAD:
+    {
+        setPrecision(InferenceEngine::Precision::FP16);
+        setTargetDevice(InferenceEngine::TargetDevice::eMYRIAD); break;
+    }
     default:
         CV_Error(Error::StsError, format("Unknown target identifier: %d", targetId));
     }
@@ -368,7 +365,7 @@ void InfEngineBackendNet::initPlugin(InferenceEngine::ICNNNetwork& net)
     InferenceEngine::ResponseDesc resp;
 
     plugin = InferenceEngine::PluginDispatcher({""}).getSuitablePlugin(targetDevice);
-    if (infEngineVersion() > 5855 && targetDevice == InferenceEngine::TargetDevice::eCPU)
+    if (targetDevice == InferenceEngine::TargetDevice::eCPU)
     {
 #ifdef _WIN32
         InferenceEngine::IExtensionPtr extension =
@@ -415,6 +412,15 @@ Mat infEngineBlobToMat(const InferenceEngine::Blob::Ptr& blob)
     std::vector<int> size(dims.begin(), dims.end());
     std::reverse(size.begin(), size.end());
     return Mat(size, CV_32F, (void*)blob->buffer());
+}
+
+void infEngineBlobsToMats(const std::vector<InferenceEngine::Blob::Ptr>& blobs,
+                          std::vector<Mat>& mats)
+{
+    const size_t num = blobs.size();
+    mats.resize(num);
+    for (size_t i = 0; i < num; ++i)
+        mats[i] = infEngineBlobToMat(blobs[i]);
 }
 
 InfEngineBackendLayer::InfEngineBackendLayer(const InferenceEngine::DataPtr& output_)

--- a/modules/dnn/src/op_inf_engine.cpp
+++ b/modules/dnn/src/op_inf_engine.cpp
@@ -414,15 +414,6 @@ Mat infEngineBlobToMat(const InferenceEngine::Blob::Ptr& blob)
     return Mat(size, CV_32F, (void*)blob->buffer());
 }
 
-void infEngineBlobsToMats(const std::vector<InferenceEngine::Blob::Ptr>& blobs,
-                          std::vector<Mat>& mats)
-{
-    const size_t num = blobs.size();
-    mats.resize(num);
-    for (size_t i = 0; i < num; ++i)
-        mats[i] = infEngineBlobToMat(blobs[i]);
-}
-
 InfEngineBackendLayer::InfEngineBackendLayer(const InferenceEngine::DataPtr& output_)
 {
     output = output_;

--- a/modules/dnn/src/op_inf_engine.hpp
+++ b/modules/dnn/src/op_inf_engine.hpp
@@ -14,6 +14,9 @@
 #pragma GCC diagnostic ignored "-Wsuggest-override"
 #endif
 #include <inference_engine.hpp>
+#include <ext_base.hpp>
+#include <ext_list.hpp>
+#include <ie_extension.h>
 #if defined(__GNUC__) && __GNUC__ >= 5
 //#pragma GCC diagnostic pop
 #endif
@@ -129,6 +132,9 @@ InferenceEngine::TBlob<float>::Ptr wrapToInfEngineBlob(const Mat& m, const std::
 InferenceEngine::DataPtr infEngineDataNode(const Ptr<BackendWrapper>& ptr);
 
 Mat infEngineBlobToMat(const InferenceEngine::Blob::Ptr& blob);
+
+void infEngineBlobsToMats(const std::vector<InferenceEngine::Blob::Ptr>& blobs,
+                          std::vector<Mat>& mats);
 
 // Convert Inference Engine blob with FP32 precision to FP16 precision.
 // Allocates memory for a new blob.

--- a/modules/dnn/src/op_inf_engine.hpp
+++ b/modules/dnn/src/op_inf_engine.hpp
@@ -14,9 +14,6 @@
 #pragma GCC diagnostic ignored "-Wsuggest-override"
 #endif
 #include <inference_engine.hpp>
-#include <ext_base.hpp>
-#include <ext_list.hpp>
-#include <ie_extension.h>
 #if defined(__GNUC__) && __GNUC__ >= 5
 //#pragma GCC diagnostic pop
 #endif
@@ -132,9 +129,6 @@ InferenceEngine::TBlob<float>::Ptr wrapToInfEngineBlob(const Mat& m, const std::
 InferenceEngine::DataPtr infEngineDataNode(const Ptr<BackendWrapper>& ptr);
 
 Mat infEngineBlobToMat(const InferenceEngine::Blob::Ptr& blob);
-
-void infEngineBlobsToMats(const std::vector<InferenceEngine::Blob::Ptr>& blobs,
-                          std::vector<Mat>& mats);
 
 // Convert Inference Engine blob with FP32 precision to FP16 precision.
 // Allocates memory for a new blob.

--- a/modules/dnn/test/test_backends.cpp
+++ b/modules/dnn/test/test_backends.cpp
@@ -105,6 +105,7 @@ public:
             {
                 out = out.reshape(1, out.total() / 7);
                 int numDetections = 0;
+                // DNN_TARGET_MYRIAD produces detections terminated by a row which starts from -1.
                 while (numDetections < out.rows && out.at<float>(numDetections, 0) != -1)
                 {
                     numDetections += 1;
@@ -180,10 +181,11 @@ TEST_P(DNNTestNetwork, MobileNet_SSD_Caffe)
                inp, "detection_out", "", l1, lInf);
 }
 
+// TODO: update MobileNet model.
 TEST_P(DNNTestNetwork, MobileNet_SSD_TensorFlow)
 {
     if (backend == DNN_BACKEND_HALIDE ||
-        backend == DNN_BACKEND_INFERENCE_ENGINE && target != DNN_TARGET_CPU)
+        backend == DNN_BACKEND_INFERENCE_ENGINE)
         throw SkipTestException("");
     Mat sample = imread(findDataFile("dnn/street.png", false));
     Mat inp = blobFromImage(sample, 1.0f / 127.5, Size(300, 300), Scalar(127.5, 127.5, 127.5), false);

--- a/modules/dnn/test/test_backends.cpp
+++ b/modules/dnn/test/test_backends.cpp
@@ -49,7 +49,7 @@ public:
                 throw SkipTestException("OpenCL is not available/disabled in OpenCV");
             }
         }
-        if (target == DNN_TARGET_OPENCL_FP16)
+        if (target == DNN_TARGET_OPENCL_FP16 || target == DNN_TARGET_MYRIAD)
         {
             l1 = l1 == 0.0 ? 4e-3 : l1;
             lInf = lInf == 0.0 ? 2e-2 : lInf;
@@ -80,10 +80,7 @@ public:
         }
         Mat out = net.forward(outputLayer).clone();
 
-        if (outputLayer == "detection_out")
-            normAssertDetections(outDefault, out, "First run", 0.2, l1, lInf);
-        else
-            normAssert(outDefault, out, "First run", l1, lInf);
+        check(outDefault, out, outputLayer, l1, lInf, "First run");
 
         // Test 2: change input.
         float* inpData = (float*)inp.data;
@@ -97,18 +94,32 @@ public:
         net.setInput(inp);
         outDefault = netDefault.forward(outputLayer).clone();
         out = net.forward(outputLayer).clone();
+        check(outDefault, out, outputLayer, l1, lInf, "Second run");
+    }
 
+    void check(Mat& ref, Mat& out, const std::string& outputLayer, double l1, double lInf, const char* msg)
+    {
         if (outputLayer == "detection_out")
-            normAssertDetections(outDefault, out, "Second run", 0.2, l1, lInf);
+        {
+            if (backend == DNN_BACKEND_INFERENCE_ENGINE)
+            {
+                out = out.reshape(1, out.total() / 7);
+                int numDetections = 0;
+                while (numDetections < out.rows && out.at<float>(numDetections, 0) != -1)
+                {
+                    numDetections += 1;
+                }
+                out = out.rowRange(0, numDetections);
+            }
+            normAssertDetections(ref, out, msg, 0.2, l1, lInf);
+        }
         else
-            normAssert(outDefault, out, "Second run", l1, lInf);
+            normAssert(ref, out, msg, l1, lInf);
     }
 };
 
 TEST_P(DNNTestNetwork, AlexNet)
 {
-    if (backend == DNN_BACKEND_INFERENCE_ENGINE && target != DNN_TARGET_CPU)
-        throw SkipTestException("");
     processNet("dnn/bvlc_alexnet.caffemodel", "dnn/bvlc_alexnet.prototxt",
                Size(227, 227), "prob",
                target == DNN_TARGET_OPENCL ? "dnn/halide_scheduler_opencl_alexnet.yml" :
@@ -158,8 +169,7 @@ TEST_P(DNNTestNetwork, ENet)
 
 TEST_P(DNNTestNetwork, MobileNet_SSD_Caffe)
 {
-    if (backend == DNN_BACKEND_HALIDE ||
-        backend == DNN_BACKEND_INFERENCE_ENGINE && target != DNN_TARGET_CPU)
+    if (backend == DNN_BACKEND_HALIDE)
         throw SkipTestException("");
     Mat sample = imread(findDataFile("dnn/street.png", false));
     Mat inp = blobFromImage(sample, 1.0f / 127.5, Size(300, 300), Scalar(127.5, 127.5, 127.5), false);
@@ -185,31 +195,38 @@ TEST_P(DNNTestNetwork, MobileNet_SSD_TensorFlow)
 
 TEST_P(DNNTestNetwork, SSD_VGG16)
 {
-    if ((backend == DNN_BACKEND_DEFAULT && target == DNN_TARGET_OPENCL_FP16) ||
-        (backend == DNN_BACKEND_HALIDE && target == DNN_TARGET_CPU) ||
-        (backend == DNN_BACKEND_INFERENCE_ENGINE && target != DNN_TARGET_CPU))
+    if (backend == DNN_BACKEND_HALIDE && target == DNN_TARGET_CPU)
         throw SkipTestException("");
+    double scoreThreshold = (target == DNN_TARGET_OPENCL_FP16 || target == DNN_TARGET_MYRIAD) ? 0.0252 : 0.0;
+    Mat sample = imread(findDataFile("dnn/street.png", false));
+    Mat inp = blobFromImage(sample, 1.0f, Size(300, 300), Scalar(), false);
     processNet("dnn/VGG_ILSVRC2016_SSD_300x300_iter_440000.caffemodel",
-               "dnn/ssd_vgg16.prototxt", Size(300, 300), "detection_out");
+               "dnn/ssd_vgg16.prototxt", inp, "detection_out", "", scoreThreshold);
 }
 
 TEST_P(DNNTestNetwork, OpenPose_pose_coco)
 {
-    if (backend == DNN_BACKEND_HALIDE) throw SkipTestException("");
+    if (backend == DNN_BACKEND_HALIDE ||
+        backend == DNN_BACKEND_INFERENCE_ENGINE && target == DNN_TARGET_MYRIAD)
+        throw SkipTestException("");
     processNet("dnn/openpose_pose_coco.caffemodel", "dnn/openpose_pose_coco.prototxt",
                Size(368, 368));
 }
 
 TEST_P(DNNTestNetwork, OpenPose_pose_mpi)
 {
-    if (backend == DNN_BACKEND_HALIDE) throw SkipTestException("");
+    if (backend == DNN_BACKEND_HALIDE ||
+        backend == DNN_BACKEND_INFERENCE_ENGINE && target == DNN_TARGET_MYRIAD)
+        throw SkipTestException("");
     processNet("dnn/openpose_pose_mpi.caffemodel", "dnn/openpose_pose_mpi.prototxt",
                Size(368, 368));
 }
 
 TEST_P(DNNTestNetwork, OpenPose_pose_mpi_faster_4_stages)
 {
-    if (backend == DNN_BACKEND_HALIDE) throw SkipTestException("");
+    if (backend == DNN_BACKEND_HALIDE ||
+        backend == DNN_BACKEND_INFERENCE_ENGINE && target == DNN_TARGET_MYRIAD)
+        throw SkipTestException("");
     // The same .caffemodel but modified .prototxt
     // See https://github.com/CMU-Perceptual-Computing-Lab/openpose/blob/master/src/openpose/pose/poseParameters.cpp
     processNet("dnn/openpose_pose_mpi.caffemodel", "dnn/openpose_pose_mpi_faster_4_stages.prototxt",
@@ -226,11 +243,13 @@ TEST_P(DNNTestNetwork, OpenFace)
 
 TEST_P(DNNTestNetwork, opencv_face_detector)
 {
-    if (backend == DNN_BACKEND_HALIDE ||
-        backend == DNN_BACKEND_INFERENCE_ENGINE && target != DNN_TARGET_CPU)
+    if (backend == DNN_BACKEND_HALIDE)
         throw SkipTestException("");
+    Size inpSize;
+    if (backend == DNN_BACKEND_INFERENCE_ENGINE && target == DNN_TARGET_MYRIAD)
+        inpSize = Size(300, 300);
     Mat img = imread(findDataFile("gpu/lbpcascade/er.png", false));
-    Mat inp = blobFromImage(img, 1.0, Size(), Scalar(104.0, 177.0, 123.0), false, false);
+    Mat inp = blobFromImage(img, 1.0, inpSize, Scalar(104.0, 177.0, 123.0), false, false);
     processNet("dnn/opencv_face_detector.caffemodel", "dnn/opencv_face_detector.prototxt",
                inp, "detection_out");
 }
@@ -238,12 +257,13 @@ TEST_P(DNNTestNetwork, opencv_face_detector)
 TEST_P(DNNTestNetwork, Inception_v2_SSD_TensorFlow)
 {
     if (backend == DNN_BACKEND_HALIDE ||
-        backend == DNN_BACKEND_INFERENCE_ENGINE && target != DNN_TARGET_CPU)
+        (backend == DNN_BACKEND_INFERENCE_ENGINE && target == DNN_TARGET_OPENCL) ||
+        (backend == DNN_BACKEND_INFERENCE_ENGINE && target == DNN_TARGET_OPENCL_FP16))
         throw SkipTestException("");
     Mat sample = imread(findDataFile("dnn/street.png", false));
     Mat inp = blobFromImage(sample, 1.0f / 127.5, Size(300, 300), Scalar(127.5, 127.5, 127.5), false);
-    float l1 = (backend == DNN_BACKEND_DEFAULT && target == DNN_TARGET_OPENCL_FP16) ? 0.008 : 0.0;
-    float lInf = (backend == DNN_BACKEND_DEFAULT && target == DNN_TARGET_OPENCL_FP16) ? 0.07 : 0.0;
+    float l1 = (target == DNN_TARGET_OPENCL_FP16 || target == DNN_TARGET_MYRIAD) ? 0.008 : 0.0;
+    float lInf = (target == DNN_TARGET_OPENCL_FP16 || target == DNN_TARGET_MYRIAD) ? 0.07 : 0.0;
     processNet("dnn/ssd_inception_v2_coco_2017_11_17.pb", "dnn/ssd_inception_v2_coco_2017_11_17.pbtxt",
                inp, "detection_out", "", l1, lInf);
 }
@@ -252,9 +272,20 @@ TEST_P(DNNTestNetwork, DenseNet_121)
 {
     if ((backend == DNN_BACKEND_HALIDE) ||
         (backend == DNN_BACKEND_DEFAULT && target == DNN_TARGET_OPENCL_FP16) ||
-        (backend == DNN_BACKEND_INFERENCE_ENGINE && target == DNN_TARGET_OPENCL_FP16))
+        (backend == DNN_BACKEND_INFERENCE_ENGINE && (target == DNN_TARGET_OPENCL_FP16 ||
+                                                     target == DNN_TARGET_MYRIAD)))
         throw SkipTestException("");
     processNet("dnn/DenseNet_121.caffemodel", "dnn/DenseNet_121.prototxt", Size(224, 224), "", "caffe");
+}
+
+TEST_P(DNNTestNetwork, YOLOv3)
+{
+    if (backend == DNN_BACKEND_HALIDE ||
+        backend == DNN_BACKEND_INFERENCE_ENGINE && target != DNN_TARGET_CPU)
+        throw SkipTestException("");
+    Mat img = imread(findDataFile("dnn/dog416.png", false));
+    Mat inp = blobFromImage(img, 1.0/255, Size(416, 416), Scalar(), true, false);
+    processNet("dnn/yolov3.weights", "dnn/yolov3.cfg", inp, "");
 }
 
 const tuple<DNNBackend, DNNTarget> testCases[] = {
@@ -266,6 +297,7 @@ const tuple<DNNBackend, DNNTarget> testCases[] = {
     tuple<DNNBackend, DNNTarget>(DNN_BACKEND_INFERENCE_ENGINE, DNN_TARGET_CPU),
     tuple<DNNBackend, DNNTarget>(DNN_BACKEND_INFERENCE_ENGINE, DNN_TARGET_OPENCL),
     tuple<DNNBackend, DNNTarget>(DNN_BACKEND_INFERENCE_ENGINE, DNN_TARGET_OPENCL_FP16),
+    tuple<DNNBackend, DNNTarget>(DNN_BACKEND_INFERENCE_ENGINE, DNN_TARGET_MYRIAD),
 #endif
     tuple<DNNBackend, DNNTarget>(DNN_BACKEND_DEFAULT, DNN_TARGET_OPENCL),
     tuple<DNNBackend, DNNTarget>(DNN_BACKEND_DEFAULT, DNN_TARGET_OPENCL_FP16)

--- a/modules/dnn/test/test_backends.cpp
+++ b/modules/dnn/test/test_backends.cpp
@@ -49,6 +49,13 @@ public:
                 throw SkipTestException("OpenCL is not available/disabled in OpenCV");
             }
         }
+        if (backend == DNN_BACKEND_INFERENCE_ENGINE && target == DNN_TARGET_MYRIAD)
+        {
+            if (!checkMyriadTarget())
+            {
+                throw SkipTestException("Myriad is not available/disabled in OpenCV");
+            }
+        }
         if (target == DNN_TARGET_OPENCL_FP16 || target == DNN_TARGET_MYRIAD)
         {
             l1 = l1 == 0.0 ? 4e-3 : l1;
@@ -103,9 +110,9 @@ public:
         {
             if (backend == DNN_BACKEND_INFERENCE_ENGINE)
             {
+                // Inference Engine produces detections terminated by a row which starts from -1.
                 out = out.reshape(1, out.total() / 7);
                 int numDetections = 0;
-                // DNN_TARGET_MYRIAD produces detections terminated by a row which starts from -1.
                 while (numDetections < out.rows && out.at<float>(numDetections, 0) != -1)
                 {
                     numDetections += 1;
@@ -278,16 +285,6 @@ TEST_P(DNNTestNetwork, DenseNet_121)
                                                      target == DNN_TARGET_MYRIAD)))
         throw SkipTestException("");
     processNet("dnn/DenseNet_121.caffemodel", "dnn/DenseNet_121.prototxt", Size(224, 224), "", "caffe");
-}
-
-TEST_P(DNNTestNetwork, YOLOv3)
-{
-    if (backend == DNN_BACKEND_HALIDE ||
-        backend == DNN_BACKEND_INFERENCE_ENGINE && target != DNN_TARGET_CPU)
-        throw SkipTestException("");
-    Mat img = imread(findDataFile("dnn/dog416.png", false));
-    Mat inp = blobFromImage(img, 1.0/255, Size(416, 416), Scalar(), true, false);
-    processNet("dnn/yolov3.weights", "dnn/yolov3.cfg", inp, "");
 }
 
 const tuple<DNNBackend, DNNTarget> testCases[] = {

--- a/modules/dnn/test/test_common.hpp
+++ b/modules/dnn/test/test_common.hpp
@@ -147,6 +147,28 @@ inline void normAssertDetections(cv::Mat ref, cv::Mat out, const char *comment =
                          testBoxes, comment, confThreshold, scores_diff, boxes_iou_diff);
 }
 
+inline bool checkMyriadTarget()
+{
+#ifndef HAVE_INF_ENGINE
+    return false;
+#endif
+    cv::dnn::Net net;
+    cv::dnn::LayerParams lp;
+    net.addLayerToPrev("testLayer", "Identity", lp);
+    net.setPreferableBackend(cv::dnn::DNN_BACKEND_INFERENCE_ENGINE);
+    net.setPreferableTarget(cv::dnn::DNN_TARGET_MYRIAD);
+    net.setInput(cv::Mat::zeros(1, 1, CV_32FC1));
+    try
+    {
+        net.forward();
+    }
+    catch(...)
+    {
+        return false;
+    }
+    return true;
+}
+
 inline bool readFileInMemory(const std::string& filename, std::string& content)
 {
     std::ios::openmode mode = std::ios::in | std::ios::binary;

--- a/modules/dnn/test/test_darknet_importer.cpp
+++ b/modules/dnn/test/test_darknet_importer.cpp
@@ -71,13 +71,31 @@ static void testDarknetModel(const std::string& cfg, const std::string& weights,
                              const std::vector<int>& refClassIds,
                              const std::vector<float>& refConfidences,
                              const std::vector<Rect2d>& refBoxes,
-                             int targetId, float confThreshold = 0.24)
+                             int backendId, int targetId, float scoreDiff = 0.0,
+                             float iouDiff = 0.0, float confThreshold = 0.24)
 {
+    if (backendId == DNN_BACKEND_DEFAULT && targetId == DNN_TARGET_OPENCL)
+    {
+  #ifdef HAVE_OPENCL
+        if (!cv::ocl::useOpenCL())
+  #endif
+        {
+            throw SkipTestException("OpenCL is not available/disabled in OpenCV");
+        }
+    }
+    if (backendId == DNN_BACKEND_INFERENCE_ENGINE && targetId == DNN_TARGET_MYRIAD)
+    {
+        if (!checkMyriadTarget())
+        {
+            throw SkipTestException("Myriad is not available/disabled in OpenCV");
+        }
+    }
     Mat sample = imread(_tf("dog416.png"));
     Mat inp = blobFromImage(sample, 1.0/255, Size(416, 416), Scalar(), true, false);
 
     Net net = readNet(findDataFile("dnn/" + cfg, false),
                       findDataFile("dnn/" + weights, false));
+    net.setPreferableBackend(backendId);
     net.setPreferableTarget(targetId);
     net.setInput(inp);
     std::vector<Mat> outs;
@@ -108,14 +126,17 @@ static void testDarknetModel(const std::string& cfg, const std::string& weights,
         }
     }
     normAssertDetections(refClassIds, refConfidences, refBoxes, classIds,
-                         confidences, boxes, "", confThreshold, 8e-5, 3e-5);
+                         confidences, boxes, "", confThreshold, scoreDiff, iouDiff);
 }
 
-typedef testing::TestWithParam<DNNTarget> Test_Darknet_nets;
+typedef testing::TestWithParam<tuple<DNNBackend, DNNTarget> > Test_Darknet_nets;
 
 TEST_P(Test_Darknet_nets, YoloVoc)
 {
-    int targetId = GetParam();
+    int backendId = get<0>(GetParam());
+    int targetId = get<1>(GetParam());
+    if (backendId == DNN_BACKEND_INFERENCE_ENGINE && targetId == DNN_TARGET_MYRIAD)
+        throw SkipTestException("");
     std::vector<cv::String> outNames(1, "detection_out");
 
     std::vector<int> classIds(3);
@@ -124,26 +145,34 @@ TEST_P(Test_Darknet_nets, YoloVoc)
     classIds[0] = 6;  confidences[0] = 0.750469f; boxes[0] = Rect2d(0.577374, 0.127391, 0.325575, 0.173418);  // a car
     classIds[1] = 1;  confidences[1] = 0.780879f; boxes[1] = Rect2d(0.270762, 0.264102, 0.461713, 0.48131); // a bycicle
     classIds[2] = 11; confidences[2] = 0.901615f; boxes[2] = Rect2d(0.1386, 0.338509, 0.282737, 0.60028);  // a dog
+    double scoreDiff = (targetId == DNN_TARGET_OPENCL_FP16 || targetId == DNN_TARGET_MYRIAD) ? 7e-3 : 8e-5;
+    double iouDiff = (targetId == DNN_TARGET_OPENCL_FP16 || targetId == DNN_TARGET_MYRIAD) ? 0.013 : 3e-5;
     testDarknetModel("yolo-voc.cfg", "yolo-voc.weights", outNames,
-                     classIds, confidences, boxes, targetId);
+                     classIds, confidences, boxes, backendId, targetId, scoreDiff, iouDiff);
 }
 
 TEST_P(Test_Darknet_nets, TinyYoloVoc)
 {
-    int targetId = GetParam();
+    int backendId = get<0>(GetParam());
+    int targetId = get<1>(GetParam());
     std::vector<cv::String> outNames(1, "detection_out");
     std::vector<int> classIds(2);
     std::vector<float> confidences(2);
     std::vector<Rect2d> boxes(2);
     classIds[0] = 6;  confidences[0] = 0.761967f; boxes[0] = Rect2d(0.579042, 0.159161, 0.31544, 0.160779);  // a car
     classIds[1] = 11; confidences[1] = 0.780595f; boxes[1] = Rect2d(0.129696, 0.386467, 0.315579, 0.534527);  // a dog
+    double scoreDiff = (targetId == DNN_TARGET_OPENCL_FP16 || targetId == DNN_TARGET_MYRIAD) ? 8e-3 : 8e-5;
+    double iouDiff = (targetId == DNN_TARGET_OPENCL_FP16 || targetId == DNN_TARGET_MYRIAD) ? 8e-3 : 3e-5;
     testDarknetModel("tiny-yolo-voc.cfg", "tiny-yolo-voc.weights", outNames,
-                     classIds, confidences, boxes, targetId);
+                     classIds, confidences, boxes, backendId, targetId, scoreDiff, iouDiff);
 }
 
 TEST_P(Test_Darknet_nets, YOLOv3)
 {
-    int targetId = GetParam();
+    int backendId = get<0>(GetParam());
+    int targetId = get<1>(GetParam());
+    if (backendId == DNN_BACKEND_INFERENCE_ENGINE && targetId == DNN_TARGET_MYRIAD)
+        throw SkipTestException("");
     std::vector<cv::String> outNames(3);
     outNames[0] = "yolo_82";
     outNames[1] = "yolo_94";
@@ -155,11 +184,25 @@ TEST_P(Test_Darknet_nets, YOLOv3)
     classIds[0] = 7;  confidences[0] = 0.952983f; boxes[0] = Rect2d(0.614622, 0.150257, 0.286747, 0.138994);  // a truck
     classIds[1] = 1; confidences[1] = 0.987908f; boxes[1] = Rect2d(0.150913, 0.221933, 0.591342, 0.524327);  // a bycicle
     classIds[2] = 16; confidences[2] = 0.998836f; boxes[2] = Rect2d(0.160024, 0.389964, 0.257861, 0.553752);  // a dog (COCO)
+    double scoreDiff = (targetId == DNN_TARGET_OPENCL_FP16 || targetId == DNN_TARGET_MYRIAD) ? 4e-3 : 8e-5;
+    double iouDiff = (targetId == DNN_TARGET_OPENCL_FP16 || targetId == DNN_TARGET_MYRIAD) ? 0.011 : 3e-5;
     testDarknetModel("yolov3.cfg", "yolov3.weights", outNames,
-                     classIds, confidences, boxes, targetId);
+                     classIds, confidences, boxes, backendId, targetId, scoreDiff, iouDiff);
 }
 
-INSTANTIATE_TEST_CASE_P(/**/, Test_Darknet_nets, availableDnnTargets());
+const tuple<DNNBackend, DNNTarget> testCases[] = {
+#ifdef HAVE_INF_ENGINE
+    tuple<DNNBackend, DNNTarget>(DNN_BACKEND_INFERENCE_ENGINE, DNN_TARGET_CPU),
+    tuple<DNNBackend, DNNTarget>(DNN_BACKEND_INFERENCE_ENGINE, DNN_TARGET_OPENCL),
+    tuple<DNNBackend, DNNTarget>(DNN_BACKEND_INFERENCE_ENGINE, DNN_TARGET_OPENCL_FP16),
+    tuple<DNNBackend, DNNTarget>(DNN_BACKEND_INFERENCE_ENGINE, DNN_TARGET_MYRIAD),
+#endif
+    tuple<DNNBackend, DNNTarget>(DNN_BACKEND_DEFAULT, DNN_TARGET_CPU),
+    tuple<DNNBackend, DNNTarget>(DNN_BACKEND_DEFAULT, DNN_TARGET_OPENCL),
+    tuple<DNNBackend, DNNTarget>(DNN_BACKEND_DEFAULT, DNN_TARGET_OPENCL_FP16)
+};
+
+INSTANTIATE_TEST_CASE_P(/**/, Test_Darknet_nets, testing::ValuesIn(testCases));
 
 static void testDarknetLayer(const std::string& name, bool hasWeights = false)
 {

--- a/modules/dnn/test/test_precomp.hpp
+++ b/modules/dnn/test/test_precomp.hpp
@@ -53,7 +53,7 @@ namespace opencv_test {
 using namespace cv::dnn;
 
 CV_ENUM(DNNBackend, DNN_BACKEND_DEFAULT, DNN_BACKEND_HALIDE, DNN_BACKEND_INFERENCE_ENGINE)
-CV_ENUM(DNNTarget, DNN_TARGET_CPU, DNN_TARGET_OPENCL, DNN_TARGET_OPENCL_FP16)
+CV_ENUM(DNNTarget, DNN_TARGET_CPU, DNN_TARGET_OPENCL, DNN_TARGET_OPENCL_FP16, DNN_TARGET_MYRIAD)
 
 static testing::internal::ParamGenerator<DNNTarget> availableDnnTargets()
 {

--- a/samples/dnn/classification.cpp
+++ b/samples/dnn/classification.cpp
@@ -23,7 +23,7 @@ const char* keys =
     "{ backend     | 0 | Choose one of computation backends: "
                         "0: default C++ backend, "
                         "1: Halide language (http://halide-lang.org/), "
-                        "2: Intel's Deep Learning Inference Engine (https://software.seek.intel.com/deep-learning-deployment)}"
+                        "2: Intel's Deep Learning Inference Engine (https://software.intel.com/openvino-toolkit)}"
     "{ target      | 0 | Choose one of target computation devices: "
                         "0: CPU target (by default),"
                         "1: OpenCL }";

--- a/samples/dnn/classification.py
+++ b/samples/dnn/classification.py
@@ -34,7 +34,7 @@ parser.add_argument('--backend', choices=backends, default=cv.dnn.DNN_BACKEND_DE
                     help="Choose one of computation backends: "
                          "%d: default C++ backend, "
                          "%d: Halide language (http://halide-lang.org/), "
-                         "%d: Intel's Deep Learning Inference Engine (https://software.seek.intel.com/deep-learning-deployment)" % backends)
+                         "%d: Intel's Deep Learning Inference Engine (https://software.intel.com/openvino-toolkit)" % backends)
 parser.add_argument('--target', choices=targets, default=cv.dnn.DNN_TARGET_CPU, type=int,
                     help='Choose one of target computation devices: '
                          '%d: CPU target (by default), '

--- a/samples/dnn/object_detection.cpp
+++ b/samples/dnn/object_detection.cpp
@@ -25,7 +25,7 @@ const char* keys =
     "{ backend     |  0 | Choose one of computation backends: "
                          "0: default C++ backend, "
                          "1: Halide language (http://halide-lang.org/), "
-                         "2: Intel's Deep Learning Inference Engine (https://software.seek.intel.com/deep-learning-deployment)}"
+                         "2: Intel's Deep Learning Inference Engine (https://software.intel.com/openvino-toolkit)}"
     "{ target      |  0 | Choose one of target computation devices: "
                          "0: CPU target (by default),"
                          "1: OpenCL }";

--- a/samples/dnn/object_detection.py
+++ b/samples/dnn/object_detection.py
@@ -35,7 +35,7 @@ parser.add_argument('--backend', choices=backends, default=cv.dnn.DNN_BACKEND_DE
                     help="Choose one of computation backends: "
                          "%d: default C++ backend, "
                          "%d: Halide language (http://halide-lang.org/), "
-                         "%d: Intel's Deep Learning Inference Engine (https://software.seek.intel.com/deep-learning-deployment)" % backends)
+                         "%d: Intel's Deep Learning Inference Engine (https://software.intel.com/openvino-toolkit)" % backends)
 parser.add_argument('--target', choices=targets, default=cv.dnn.DNN_TARGET_CPU, type=int,
                     help='Choose one of target computation devices: '
                          '%d: CPU target (by default), '

--- a/samples/dnn/segmentation.cpp
+++ b/samples/dnn/segmentation.cpp
@@ -26,7 +26,7 @@ const char* keys =
     "{ backend     | 0 | Choose one of computation backends: "
                         "0: default C++ backend, "
                         "1: Halide language (http://halide-lang.org/), "
-                        "2: Intel's Deep Learning Inference Engine (https://software.seek.intel.com/deep-learning-deployment)}"
+                        "2: Intel's Deep Learning Inference Engine (https://software.intel.com/openvino-toolkit)}"
     "{ target      | 0 | Choose one of target computation devices: "
                         "0: CPU target (by default),"
                         "1: OpenCL }";

--- a/samples/dnn/segmentation.py
+++ b/samples/dnn/segmentation.py
@@ -36,7 +36,7 @@ parser.add_argument('--backend', choices=backends, default=cv.dnn.DNN_BACKEND_DE
                     help="Choose one of computation backends: "
                          "%d: default C++ backend, "
                          "%d: Halide language (http://halide-lang.org/), "
-                         "%d: Intel's Deep Learning Inference Engine (https://software.seek.intel.com/deep-learning-deployment)" % backends)
+                         "%d: Intel's Deep Learning Inference Engine (https://software.intel.com/openvino-toolkit)" % backends)
 parser.add_argument('--target', choices=targets, default=cv.dnn.DNN_TARGET_CPU, type=int,
                     help='Choose one of target computation devices: '
                          '%d: CPU target (by default), '


### PR DESCRIPTION
<!-- Please use this line to close one or multiple issues when this pullrequest gets merged
You can add another line right under the first one:
resolves #1234
resolves #1235
-->

### This pullrequest changes

* Update Intel's Inference Engine backend support ([OpenVINO](https://software.intel.com/openvino-toolkit)). (This PR is not compatible with beta releases of Inference Engine).
* Intel&reg; Movidius&trade; Neural Compute Stick computational target (`DNN_TARGET_MYRIAD`)

Measured efficiency in milliseconds (median times):

Model name | CV CPU | CV GPU, fp32 | CV GPU, fp16 | IE CPU | IE GPU, fp32 | IE GPU, fp16 | IE NCS | 
---|---|---|---|---|---|---|---
AlexNet                           | 13.896  |   17.253 |   11.999 |  11.784 |  12.074 |   8.554 | 82.426 |
DenseNet_121                      | 53.407  |   92.322 |  114.797 |  27.770 |  60.182 |   ---- | --- |
ENet                              | 43.899  |   45.791 |     ---  |     ---  |     --- |  ---- | --- |
GoogLeNet                         | 14.436  |   26.842 |   27.057 |   8.635 |  20.407 |  15.927 | 105.209 |
Inception_5h                      | 15.595  |   32.168 |   31.484 |     --- |     --- |  ---- | --- |
Inception_v2_SSD_TensorFlow       | 42.287  |   79.025 |   89.259 |  33.557 |     --- |  ---- | 336.046 |
MobileNet_SSD_Caffe               | 18.972  |   22.117 |   26.790 |   7.960 |  25.772 |  20.071 | 94.525 |
MobileNet_v1_SSD_TensorFlow       | 22.11 |  24.26  | 28.49   |  14.95 |     --- |  ---- |  114.91 |
MobileNet_v2_SSD_TensorFlow       | 30.50 | 49.98 | 56.03  | 21.51  |     --- |  ---- |  243.43 |
OpenFace                          |  3.524  |   12.573 |   14.801 |   3.019 |     --- |  ---- |  --- |
OpenPose_pose_coco                | 874.148  |  1056.600 |  1160.916 |  536.416 |  762.814 |  437.578 | --- |
OpenPose_pose_mpi                 | 855.136  |  1037.866 |  1146.179 |  530.876 |  753.180 |  431.936 | --- |
OpenPose_pose_mpi_faster_4_stages | 585.762  |  746.806 |  805.990 |  376.030 |  528.614 |  291.959 | --- |
ResNet_50                         | 34.316  |   37.396 |   41.666 |  19.430 |  45.441 |  30.939 | 210.283 |
SSD, VGG16                        | 259.178  |  393.397 |  358.791 |  193.240 |  242.875 |  135.590 | 1739.619 |
SqueezeNet_v1_1                   |  3.672  |   9.470 |   10.894 |   2.512 |   7.865 |   6.924 | 45.237 |
YOLOv3                            | 207.946  |  361.693 |  366.220 |  180.727 |     --- |     ---- | --- |
opencv_face_detector              | 13.784  |   33.526 |   39.373 |   7.631 |  18.165 |  14.665 | 106.338 |

**CV CPU**: `DNN_BACKEND_DEFAULT`, `DNN_TARGET_CPU`
**CV GPU, fp32**: `DNN_BACKEND_DEFAULT`, `DNN_TARGET_OPENCL`
**CV GPU, fp16**: `DNN_BACKEND_DEFAULT`, `DNN_TARGET_OPENCL_FP16`
**IE CPU**: `DNN_BACKEND_INFERENCE_ENGINE`, `DNN_TARGET_CPU`
**IE GPU, fp32**: `DNN_BACKEND_INFERENCE_ENGINE`, `DNN_TARGET_OPENCL`
**IE GPU, fp16**: `DNN_BACKEND_INFERENCE_ENGINE`, `DNN_TARGET_OPENCL_FP16`
**IE NCS**: `DNN_BACKEND_INFERENCE_ENGINE`, `DNN_TARGET_MYRIAD`

CPU: Intel&reg; Core&trade; i7-6700K CPU @ 4.00GHz x 8
GPU: Intel&reg; HD Graphics 530 (Skylake GT2)
NCS: Intel&reg; Movidius&trade; Neural Compute Stick