### PR TITLE
Remove custom toBufferedImage Java code in Java tutorials

### DIFF
--- a/samples/java/tutorial_code/ImgProc/erosion_dilatation/MorphologyDemo1.java
+++ b/samples/java/tutorial_code/ImgProc/erosion_dilatation/MorphologyDemo1.java
@@ -1,9 +1,8 @@
 import java.awt.BorderLayout;
 import java.awt.Container;
+import java.awt.Image;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
-import java.awt.image.BufferedImage;
-import java.awt.image.DataBufferByte;
 
 import javax.swing.BoxLayout;
 import javax.swing.ImageIcon;
@@ -19,6 +18,7 @@ import org.opencv.core.Core;
 import org.opencv.core.Mat;
 import org.opencv.core.Point;
 import org.opencv.core.Size;
+import org.opencv.highgui.HighGui;
 import org.opencv.imgcodecs.Imgcodecs;
 import org.opencv.imgproc.Imgproc;
 
@@ -46,7 +46,7 @@ public class MorphologyDemo1 {
         frame = new JFrame("Erosion and dilatation demo");
         frame.setDefaultCloseOperation(JFrame.EXIT_ON_CLOSE);
         // Set up the content pane.
-        BufferedImage img = toBufferedImage(matImgSrc);
+        Image img = HighGui.toBufferedImage(matImgSrc);
         addComponentsToPane(frame.getContentPane(), img);
         // Use the content pane's default BorderLayout. No need for
         // setLayout(new BorderLayout());
@@ -55,7 +55,7 @@ public class MorphologyDemo1 {
         frame.setVisible(true);
     }
 
-    private void addComponentsToPane(Container pane, BufferedImage img) {
+    private void addComponentsToPane(Container pane, Image img) {
         if (!(pane.getLayout() instanceof BorderLayout)) {
             pane.add(new JLabel("Container doesn't use BorderLayout!"));
             return;
@@ -115,20 +115,6 @@ public class MorphologyDemo1 {
         pane.add(imgLabel, BorderLayout.CENTER);
     }
 
-    private BufferedImage toBufferedImage(Mat matrix) {
-        int type = BufferedImage.TYPE_BYTE_GRAY;
-        if (matrix.channels() > 1) {
-            type = BufferedImage.TYPE_3BYTE_BGR;
-        }
-        int bufferSize = matrix.channels() * matrix.cols() * matrix.rows();
-        byte[] buffer = new byte[bufferSize];
-        matrix.get(0, 0, buffer); // get all the pixels
-        BufferedImage image = new BufferedImage(matrix.cols(), matrix.rows(), type);
-        final byte[] targetPixels = ((DataBufferByte) image.getRaster().getDataBuffer()).getData();
-        System.arraycopy(buffer, 0, targetPixels, 0, buffer.length);
-        return image;
-    }
-
     private void update() {
         Mat element = Imgproc.getStructuringElement(elementType, new Size(2 * kernelSize + 1, 2 * kernelSize + 1),
                 new Point(kernelSize, kernelSize));
@@ -138,7 +124,7 @@ public class MorphologyDemo1 {
         } else {
             Imgproc.dilate(matImgSrc, matImgDst, element);
         }
-        BufferedImage img = toBufferedImage(matImgDst);
+        Image img = HighGui.toBufferedImage(matImgDst);
         imgLabel.setIcon(new ImageIcon(img));
         frame.repaint();
     }

--- a/samples/java/tutorial_code/ImgProc/opening_closing_hats/MorphologyDemo2.java
+++ b/samples/java/tutorial_code/ImgProc/opening_closing_hats/MorphologyDemo2.java
@@ -1,9 +1,8 @@
 import java.awt.BorderLayout;
 import java.awt.Container;
+import java.awt.Image;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
-import java.awt.image.BufferedImage;
-import java.awt.image.DataBufferByte;
 
 import javax.swing.BoxLayout;
 import javax.swing.ImageIcon;
@@ -19,6 +18,7 @@ import org.opencv.core.Core;
 import org.opencv.core.Mat;
 import org.opencv.core.Point;
 import org.opencv.core.Size;
+import org.opencv.highgui.HighGui;
 import org.opencv.imgcodecs.Imgcodecs;
 import org.opencv.imgproc.Imgproc;
 
@@ -48,7 +48,7 @@ public class MorphologyDemo2 {
         frame = new JFrame("Morphology Transformations demo");
         frame.setDefaultCloseOperation(JFrame.EXIT_ON_CLOSE);
         // Set up the content pane.
-        BufferedImage img = toBufferedImage(matImgSrc);
+        Image img = HighGui.toBufferedImage(matImgSrc);
         addComponentsToPane(frame.getContentPane(), img);
         // Use the content pane's default BorderLayout. No need for
         // setLayout(new BorderLayout());
@@ -57,7 +57,7 @@ public class MorphologyDemo2 {
         frame.setVisible(true);
     }
 
-    private void addComponentsToPane(Container pane, BufferedImage img) {
+    private void addComponentsToPane(Container pane, Image img) {
         if (!(pane.getLayout() instanceof BorderLayout)) {
             pane.add(new JLabel("Container doesn't use BorderLayout!"));
             return;
@@ -117,26 +117,12 @@ public class MorphologyDemo2 {
         pane.add(imgLabel, BorderLayout.CENTER);
     }
 
-    private BufferedImage toBufferedImage(Mat matrix) {
-        int type = BufferedImage.TYPE_BYTE_GRAY;
-        if (matrix.channels() > 1) {
-            type = BufferedImage.TYPE_3BYTE_BGR;
-        }
-        int bufferSize = matrix.channels() * matrix.cols() * matrix.rows();
-        byte[] buffer = new byte[bufferSize];
-        matrix.get(0, 0, buffer); // get all the pixels
-        BufferedImage image = new BufferedImage(matrix.cols(), matrix.rows(), type);
-        final byte[] targetPixels = ((DataBufferByte) image.getRaster().getDataBuffer()).getData();
-        System.arraycopy(buffer, 0, targetPixels, 0, buffer.length);
-        return image;
-    }
-
     private void update() {
         Mat element = Imgproc.getStructuringElement(elementType, new Size(2 * kernelSize + 1, 2 * kernelSize + 1),
                 new Point(kernelSize, kernelSize));
 
         Imgproc.morphologyEx(matImgSrc, matImgDst, morphOpType, element);
-        BufferedImage img = toBufferedImage(matImgDst);
+        Image img = HighGui.toBufferedImage(matImgDst);
         imgLabel.setIcon(new ImageIcon(img));
         frame.repaint();
     }

--- a/samples/java/tutorial_code/ImgProc/tutorial_template_matching/MatchTemplateDemo.java
+++ b/samples/java/tutorial_code/ImgProc/tutorial_template_matching/MatchTemplateDemo.java
@@ -1,18 +1,24 @@
-import org.opencv.core.*;
+import java.awt.GridLayout;
+import java.awt.Image;
+import java.util.Hashtable;
+
+import javax.swing.ImageIcon;
+import javax.swing.JFrame;
+import javax.swing.JLabel;
+import javax.swing.JSlider;
+import javax.swing.event.ChangeEvent;
+import javax.swing.event.ChangeListener;
+
+import org.opencv.core.Core;
+import org.opencv.core.CvType;
+import org.opencv.core.Mat;
 import org.opencv.core.Point;
+import org.opencv.core.Scalar;
+import org.opencv.highgui.HighGui;
 import org.opencv.imgcodecs.Imgcodecs;
 import org.opencv.imgproc.Imgproc;
 
-import javax.swing.*;
-import javax.swing.event.ChangeEvent;
-import javax.swing.event.ChangeListener;
-import java.awt.*;
-import java.awt.image.BufferedImage;
-import java.awt.image.DataBufferByte;
-
-import java.util.*;
-
-class MatchTemplateDemoRun implements ChangeListener{
+class MatchTemplateDemoRun implements ChangeListener {
 
     //! [declare]
     /// Global Variables
@@ -26,9 +32,7 @@ class MatchTemplateDemoRun implements ChangeListener{
     //! [declare]
 
     public void run(String[] args) {
-
-        if (args.length < 2)
-        {
+        if (args.length < 2) {
             System.out.println("Not enough parameters");
             System.out.println("Program arguments:\n<image_name> <template_name> [<mask_name>]");
             System.exit(-1);
@@ -36,117 +40,100 @@ class MatchTemplateDemoRun implements ChangeListener{
 
         //! [load_image]
         /// Load image and template
-        img = Imgcodecs.imread( args[0], Imgcodecs.IMREAD_COLOR );
-        templ = Imgcodecs.imread( args[1], Imgcodecs.IMREAD_COLOR );
+        img = Imgcodecs.imread(args[0], Imgcodecs.IMREAD_COLOR);
+        templ = Imgcodecs.imread(args[1], Imgcodecs.IMREAD_COLOR);
         //! [load_image]
 
-        if(args.length > 2) {
+        if (args.length > 2) {
             use_mask = true;
-            mask = Imgcodecs.imread( args[2], Imgcodecs.IMREAD_COLOR );
+            mask = Imgcodecs.imread(args[2], Imgcodecs.IMREAD_COLOR);
         }
 
-        if(img.empty() || templ.empty() || (use_mask && mask.empty()))
-        {
+        if (img.empty() || templ.empty() || (use_mask && mask.empty())) {
             System.out.println("Can't read one of the images");
             System.exit(-1);
         }
 
         matchingMethod();
         createJFrame();
-
     }
 
     private void matchingMethod() {
-
         Mat result = new Mat();
 
         //! [copy_source]
         /// Source image to display
         Mat img_display = new Mat();
-        img.copyTo( img_display );
+        img.copyTo(img_display);
         //! [copy_source]
 
         //! [create_result_matrix]
         /// Create the result matrix
-        int result_cols =  img.cols() - templ.cols() + 1;
+        int result_cols = img.cols() - templ.cols() + 1;
         int result_rows = img.rows() - templ.rows() + 1;
 
-        result.create( result_rows, result_cols, CvType.CV_32FC1 );
+        result.create(result_rows, result_cols, CvType.CV_32FC1);
         //! [create_result_matrix]
 
         //! [match_template]
         /// Do the Matching and Normalize
-        Boolean method_accepts_mask = (Imgproc.TM_SQDIFF == match_method ||
-                match_method == Imgproc.TM_CCORR_NORMED);
-        if (use_mask && method_accepts_mask)
-        { Imgproc.matchTemplate( img, templ, result, match_method, mask); }
-        else
-        { Imgproc.matchTemplate( img, templ, result, match_method); }
+        Boolean method_accepts_mask = (Imgproc.TM_SQDIFF == match_method || match_method == Imgproc.TM_CCORR_NORMED);
+        if (use_mask && method_accepts_mask) {
+            Imgproc.matchTemplate(img, templ, result, match_method, mask);
+        } else {
+            Imgproc.matchTemplate(img, templ, result, match_method);
+        }
         //! [match_template]
 
         //! [normalize]
-        Core.normalize( result, result, 0, 1, Core.NORM_MINMAX, -1, new Mat() );
+        Core.normalize(result, result, 0, 1, Core.NORM_MINMAX, -1, new Mat());
         //! [normalize]
 
         //! [best_match]
         /// Localizing the best match with minMaxLoc
-        double minVal; double maxVal;
         Point matchLoc;
 
-        Core.MinMaxLocResult mmr = Core.minMaxLoc( result );
+        Core.MinMaxLocResult mmr = Core.minMaxLoc(result);
         //! [best_match]
 
         //! [match_loc]
         /// For SQDIFF and SQDIFF_NORMED, the best matches are lower values.
-        //  For all the other methods, the higher the better
-        if( match_method  == Imgproc.TM_SQDIFF || match_method == Imgproc.TM_SQDIFF_NORMED )
-        { matchLoc = mmr.minLoc; }
-        else
-        { matchLoc = mmr.maxLoc; }
+        /// For all the other methods, the higher the better
+        if (match_method == Imgproc.TM_SQDIFF || match_method == Imgproc.TM_SQDIFF_NORMED) {
+            matchLoc = mmr.minLoc;
+        } else {
+            matchLoc = mmr.maxLoc;
+        }
         //! [match_loc]
 
         //! [imshow]
         /// Show me what you got
-        Imgproc.rectangle(img_display, matchLoc, new Point(matchLoc.x + templ.cols(),
-                matchLoc.y + templ.rows()), new Scalar(0, 0, 0), 2, 8, 0);
-        Imgproc.rectangle(result, matchLoc, new Point(matchLoc.x + templ.cols(),
-                matchLoc.y + templ.rows()), new Scalar(0, 0, 0), 2, 8, 0);
+        Imgproc.rectangle(img_display, matchLoc, new Point(matchLoc.x + templ.cols(), matchLoc.y + templ.rows()),
+                new Scalar(0, 0, 0), 2, 8, 0);
+        Imgproc.rectangle(result, matchLoc, new Point(matchLoc.x + templ.cols(), matchLoc.y + templ.rows()),
+                new Scalar(0, 0, 0), 2, 8, 0);
 
-        Image tmpImg = toBufferedImage(img_display);
+        Image tmpImg = HighGui.toBufferedImage(img_display);
         ImageIcon icon = new ImageIcon(tmpImg);
         imgDisplay.setIcon(icon);
 
         result.convertTo(result, CvType.CV_8UC1, 255.0);
-        tmpImg = toBufferedImage(result);
+        tmpImg = HighGui.toBufferedImage(result);
         icon = new ImageIcon(tmpImg);
         resultDisplay.setIcon(icon);
         //! [imshow]
     }
 
+    @Override
     public void stateChanged(ChangeEvent e) {
         JSlider source = (JSlider) e.getSource();
         if (!source.getValueIsAdjusting()) {
-            match_method = (int)source.getValue();
+            match_method = source.getValue();
             matchingMethod();
         }
     }
 
-    public Image toBufferedImage(Mat m) {
-        int type = BufferedImage.TYPE_BYTE_GRAY;
-        if ( m.channels() > 1 ) {
-            type = BufferedImage.TYPE_3BYTE_BGR;
-        }
-        int bufferSize = m.channels()*m.cols()*m.rows();
-        byte [] b = new byte[bufferSize];
-        m.get(0,0,b); // get all the pixels
-        BufferedImage image = new BufferedImage(m.cols(),m.rows(), type);
-        final byte[] targetPixels = ((DataBufferByte) image.getRaster().getDataBuffer()).getData();
-        System.arraycopy(b, 0, targetPixels, 0, b.length);
-        return image;
-    }
-
     private void createJFrame() {
-
         String title = "Source image; Control; Result image";
         JFrame frame = new JFrame(title);
         frame.setLayout(new GridLayout(2, 2));
@@ -164,14 +151,14 @@ class MatchTemplateDemoRun implements ChangeListener{
         slider.setMinorTickSpacing(1);
 
         // Customizing the labels
-        Hashtable labelTable = new Hashtable();
-        labelTable.put( new Integer( 0 ), new JLabel("0 - SQDIFF") );
-        labelTable.put( new Integer( 1 ), new JLabel("1 - SQDIFF NORMED") );
-        labelTable.put( new Integer( 2 ), new JLabel("2 - TM CCORR") );
-        labelTable.put( new Integer( 3 ), new JLabel("3 - TM CCORR NORMED") );
-        labelTable.put( new Integer( 4 ), new JLabel("4 - TM COEFF") );
-        labelTable.put( new Integer( 5 ), new JLabel("5 - TM COEFF NORMED : (Method)") );
-        slider.setLabelTable( labelTable );
+        Hashtable<Integer, JLabel> labelTable = new Hashtable<>();
+        labelTable.put(new Integer(0), new JLabel("0 - SQDIFF"));
+        labelTable.put(new Integer(1), new JLabel("1 - SQDIFF NORMED"));
+        labelTable.put(new Integer(2), new JLabel("2 - TM CCORR"));
+        labelTable.put(new Integer(3), new JLabel("3 - TM CCORR NORMED"));
+        labelTable.put(new Integer(4), new JLabel("4 - TM COEFF"));
+        labelTable.put(new Integer(5), new JLabel("5 - TM COEFF NORMED : (Method)"));
+        slider.setLabelTable(labelTable);
 
         slider.addChangeListener(this);
 
@@ -184,8 +171,7 @@ class MatchTemplateDemoRun implements ChangeListener{
     }
 }
 
-public class MatchTemplateDemo
-{
+public class MatchTemplateDemo {
     public static void main(String[] args) {
         // load the native OpenCV library
         System.loadLibrary(Core.NATIVE_LIBRARY_NAME);


### PR DESCRIPTION
<!-- Please use this line to close one or multiple issues when this pullrequest gets merged
You can add another line right under the first one:
resolves #1234
resolves #1235
-->

### This pullrequest changes

<!-- Please describe what your pullrequest is changing -->
Use `HighGui.toBufferedImage()` instead.
Auto-format `MatchTemplateDemo.java` with Eclipse.