### PR TITLE
Disable ffmpeg proxy for VideoWriter when MJPEG AVI output

### DIFF
--- a/modules/videoio/src/cap.cpp
+++ b/modules/videoio/src/cap.cpp
@@ -525,7 +525,7 @@ static Ptr<IVideoCapture> IVideoCapture_create(const String& filename, int apiPr
 {
     bool useAny = (apiPreference == CAP_ANY);
     Ptr<IVideoCapture> capture;
-#ifdef HAVE_FFMPEG
+#if 0 //#ifdef HAVE_FFMPEG
     if (useAny || apiPreference == CAP_FFMPEG)
     {
         capture = cvCreateFileCapture_FFMPEG_proxy(filename);
@@ -579,7 +579,7 @@ static Ptr<IVideoCapture> IVideoCapture_create(const String& filename, int apiPr
 static Ptr<IVideoWriter> IVideoWriter_create(const String& filename, int apiPreference, int _fourcc, double fps, Size frameSize, bool isColor)
 {
     Ptr<IVideoWriter> iwriter;
-#ifdef HAVE_FFMPEG
+#if 0 //#ifdef HAVE_FFMPEG
     if (apiPreference == CAP_FFMPEG || apiPreference == CAP_ANY)
     {
         iwriter = cvCreateVideoWriter_FFMPEG_proxy(filename, _fourcc, fps, frameSize, isColor);

--- a/modules/videoio/src/cap.cpp
+++ b/modules/videoio/src/cap.cpp
@@ -525,8 +525,8 @@ static Ptr<IVideoCapture> IVideoCapture_create(const String& filename, int apiPr
 {
     bool useAny = (apiPreference == CAP_ANY);
     Ptr<IVideoCapture> capture;
-#if 0 //#ifdef HAVE_FFMPEG
-    if (useAny || apiPreference == CAP_FFMPEG)
+#ifdef HAVE_FFMPEG
+    if (apiPreference == CAP_FFMPEG) // removed useAny to continue previous behaviour
     {
         capture = cvCreateFileCapture_FFMPEG_proxy(filename);
         if (capture && capture->isOpened())
@@ -579,8 +579,8 @@ static Ptr<IVideoCapture> IVideoCapture_create(const String& filename, int apiPr
 static Ptr<IVideoWriter> IVideoWriter_create(const String& filename, int apiPreference, int _fourcc, double fps, Size frameSize, bool isColor)
 {
     Ptr<IVideoWriter> iwriter;
-#if 0 //#ifdef HAVE_FFMPEG
-    if (apiPreference == CAP_FFMPEG || apiPreference == CAP_ANY)
+#ifdef HAVE_FFMPEG
+    if (apiPreference == CAP_FFMPEG) // removed CAP_ANY to continue previous behaviour
     {
         iwriter = cvCreateVideoWriter_FFMPEG_proxy(filename, _fourcc, fps, frameSize, isColor);
         if (!iwriter.empty())


### PR DESCRIPTION
resolves #11602

### This pullrequest changes

Updated previous pull request #11603 to make FFMPEG proxy bypass specifically for MJPEG encoded AVI output, when apiPreference is not CAP_FFMPEG. Still intended as temporary measure due to incorrect output for this type of file by FFMPEG proxy function, and restores previous use of fallback OpenCV `createMotionJpegWriter`.