### PR TITLE
build: workaround issues with C compilation mode

### DIFF
--- a/modules/core/include/opencv2/core/cvdef.h
+++ b/modules/core/include/opencv2/core/cvdef.h
@@ -480,7 +480,7 @@ Cv64suf;
 // Integer types portatibility
 #ifdef OPENCV_STDINT_HEADER
 #include OPENCV_STDINT_HEADER
-#else
+#elif defined(__cplusplus)
 #if defined(_MSC_VER) && _MSC_VER < 1600 /* MSVS 2010 */
 namespace cv {
 typedef signed char int8_t;
@@ -517,9 +517,15 @@ typedef ::int64_t int64_t;
 typedef ::uint64_t uint64_t;
 }
 #endif
+#else // pure C
+#include <stdint.h>
 #endif
 
 
 //! @}
+
+#ifndef __cplusplus
+#include "opencv2/core/fast_math.hpp" // define cvRound(double)
+#endif
 
 #endif // OPENCV_CORE_CVDEF_H

--- a/modules/highgui/include/opencv2/highgui/highgui_c.h
+++ b/modules/highgui/include/opencv2/highgui/highgui_c.h
@@ -135,8 +135,10 @@ CVAPI(int) cvNamedWindow( const char* name, int flags CV_DEFAULT(CV_WINDOW_AUTOS
 CVAPI(void) cvSetWindowProperty(const char* name, int prop_id, double prop_value);
 CVAPI(double) cvGetWindowProperty(const char* name, int prop_id);
 
+#ifdef __cplusplus  // FIXIT remove in OpenCV 4.0
 /* Get window image rectangle coordinates, width and height */
 CVAPI(cv::Rect)cvGetWindowImageRect(const char* name);
+#endif
 
 /* display image within window (highgui windows remember their content) */
 CVAPI(void) cvShowImage( const char* name, const CvArr* image );


### PR DESCRIPTION
- cvdef.h + cvRound (double only)
- highgui_c.h

fixes build: #10963

**Note**: There is no official support for C compilation mode (no automatic builds, no tests). This API just "keep" names for old programs which should be compiled with C++ compiler.
Since OpenCV 2.4.x (>5 years).