### PR TITLE
StereoBM: fixed SIMD processing for fixed-type output arrays

### DIFF
--- a/modules/calib3d/src/stereobm.cpp
+++ b/modules/calib3d/src/stereobm.cpp
@@ -284,6 +284,37 @@ prefilterXSobel( const Mat& src, Mat& dst, int ftzero )
 static const int DISPARITY_SHIFT_16S = 4;
 static const int DISPARITY_SHIFT_32S = 8;
 
+template <typename T>
+struct dispShiftTemplate
+{ };
+
+template<>
+struct dispShiftTemplate<short>
+{
+    enum { value = DISPARITY_SHIFT_16S };
+};
+
+template<>
+struct dispShiftTemplate<int>
+{
+    enum { value = DISPARITY_SHIFT_32S };
+};
+
+template <typename T>
+inline T dispDescale(int /*v1*/, int /*v2*/, int /*d*/);
+
+template<>
+inline short dispDescale(int v1, int v2, int d)
+{
+    return (short)((v1*256 + (d != 0 ? v2*256/d : 0) + 15) >> 4);
+}
+
+template <>
+inline int dispDescale(int v1, int v2, int d)
+{
+    return (int)(v1*256 + (d != 0 ? v2*256/d : 0)); // no need to add 127, this will be converted to float
+}
+
 #if CV_SIMD128
 template <typename dType>
 static void findStereoCorrespondenceBM_SIMD( const Mat& left, const Mat& right,
@@ -303,7 +334,8 @@ static void findStereoCorrespondenceBM_SIMD( const Mat& left, const Mat& right,
     int ftzero = state.preFilterCap;
     int textureThreshold = state.textureThreshold;
     int uniquenessRatio = state.uniquenessRatio;
-    dType FILTERED = (dType)((mindisp - 1) << DISPARITY_SHIFT_16S);
+    const int disp_shift = dispShiftTemplate<dType>::value;
+    dType FILTERED = (dType)((mindisp - 1) << disp_shift);
 
     ushort *sad, *hsad0, *hsad, *hsad_sub;
     int *htext;
@@ -528,10 +560,10 @@ static void findStereoCorrespondenceBM_SIMD( const Mat& left, const Mat& right,
             {
                 int p = sad[mind+1], n = sad[mind-1];
                 d = p + n - 2*sad[mind] + std::abs(p - n);
-                dptr[y*dstep] = (dType)(((ndisp - mind - 1 + mindisp)*256 + (d != 0 ? (p-n)*256/d : 0) + 15) >> 4);
+                dptr[y*dstep] = dispDescale<dType>(ndisp - mind - 1 + mindisp, p-n, d);
             }
             else
-                dptr[y*dstep] = (dType)((ndisp - mind - 1 + mindisp)*16);
+                dptr[y*dstep] = dispDescale<dType>(ndisp - mind - 1 + mindisp, 0, 0);
             costptr[y*coststep] = sad[mind];
         }
     }
@@ -541,8 +573,8 @@ static void findStereoCorrespondenceBM_SIMD( const Mat& left, const Mat& right,
 template <typename mType>
 static void
 findStereoCorrespondenceBM( const Mat& left, const Mat& right,
-                           Mat& disp, Mat& cost, const StereoBMParams& state,
-                           uchar* buf, int _dy0, int _dy1, const int disp_shift )
+                            Mat& disp, Mat& cost, const StereoBMParams& state,
+                            uchar* buf, int _dy0, int _dy1 )
 {
 
     const int ALIGN = 16;
@@ -558,6 +590,7 @@ findStereoCorrespondenceBM( const Mat& left, const Mat& right,
     int ftzero = state.preFilterCap;
     int textureThreshold = state.textureThreshold;
     int uniquenessRatio = state.uniquenessRatio;
+    const int disp_shift = dispShiftTemplate<mType>::value;
     mType FILTERED = (mType)((mindisp - 1) << disp_shift);
 
 #if CV_SIMD128
@@ -850,8 +883,8 @@ findStereoCorrespondenceBM( const Mat& left, const Mat& right,
                 sad[ndisp] = sad[ndisp-2];
                 int p = sad[mind+1], n = sad[mind-1];
                 d = p + n - 2*sad[mind] + std::abs(p - n);
-                dptr[y*dstep] = (mType)(((ndisp - mind - 1 + mindisp)*256 + (d != 0 ? (p-n)*256/d : 0) + 15)
-                                 >> (DISPARITY_SHIFT_32S - disp_shift));
+                dptr[y*dstep] = dispDescale<mType>(ndisp - mind - 1 + mindisp, p-n, d);
+
                 costptr[y*coststep] = sad[mind];
             }
         }
@@ -981,7 +1014,10 @@ struct FindStereoCorrespInvoker : public ParallelLoopBody
         int _row0 = std::min(cvRound(range.start * rows / nstripes), rows);
         int _row1 = std::min(cvRound(range.end * rows / nstripes), rows);
         uchar *ptr = slidingSumBuf->ptr() + range.start * stripeBufSize;
-        int FILTERED = (state->minDisparity - 1)*16;
+
+        int dispShift = disp->type() == CV_16S ? DISPARITY_SHIFT_16S :
+                                                 DISPARITY_SHIFT_32S;
+        int FILTERED = (state->minDisparity - 1) << dispShift;
 
         Rect roi = validDisparityRect & Rect(0, _row0, cols, _row1 - _row0);
         if( roi.height == 0 )
@@ -1006,23 +1042,21 @@ struct FindStereoCorrespInvoker : public ParallelLoopBody
         Mat disp_i = disp->rowRange(row0, row1);
         Mat cost_i = state->disp12MaxDiff >= 0 ? cost->rowRange(row0, row1) : Mat();
 
-        CV_Assert(disp_i.type() == CV_16S || disp_i.type() == CV_32S);
-
 #if CV_SIMD128
         if( useSIMD && useShorts )
         {
             if( disp_i.type() == CV_16S)
                 findStereoCorrespondenceBM_SIMD<short>( left_i, right_i, disp_i, cost_i, *state, ptr, row0, rows - row1 );
             else
-                findStereoCorrespondenceBM_SIMD<int>( left_i, right_i, disp_i, cost_i, *state, ptr, row0, rows - row1 );
+                findStereoCorrespondenceBM_SIMD<int>( left_i, right_i, disp_i, cost_i, *state, ptr, row0, rows - row1);
         }
         else
 #endif
         {
             if( disp_i.type() == CV_16S )
-                findStereoCorrespondenceBM<short>( left_i, right_i, disp_i, cost_i, *state, ptr, row0, rows - row1, DISPARITY_SHIFT_16S );
+                findStereoCorrespondenceBM<short>( left_i, right_i, disp_i, cost_i, *state, ptr, row0, rows - row1 );
             else
-                findStereoCorrespondenceBM<int>( left_i, right_i, disp_i, cost_i, *state, ptr, row0, rows - row1, DISPARITY_SHIFT_32S );
+                findStereoCorrespondenceBM<int>( left_i, right_i, disp_i, cost_i, *state, ptr, row0, rows - row1 );
         }
 
         if( state->disp12MaxDiff >= 0 )
@@ -1110,7 +1144,6 @@ public:
         else
             disp_shift = DISPARITY_SHIFT_32S;
 
-
         int FILTERED = (params.minDisparity - 1) << disp_shift;
 
 #ifdef HAVE_OPENCL
@@ -1121,6 +1154,9 @@ public:
             {
                 if(ocl_stereobm(left, right, disparr, &params))
                 {
+                    disp_shift = DISPARITY_SHIFT_16S;
+                    FILTERED = (params.minDisparity - 1) << disp_shift;
+
                     if( params.speckleRange >= 0 && params.speckleWindowSize > 0 )
                         filterSpeckles(disparr.getMat(), FILTERED, params.speckleWindowSize, params.speckleRange, slidingSumBuf);
                     if (dtype == CV_32F)

--- a/modules/calib3d/src/stereobm.cpp
+++ b/modules/calib3d/src/stereobm.cpp
@@ -1006,6 +1006,8 @@ struct FindStereoCorrespInvoker : public ParallelLoopBody
         Mat disp_i = disp->rowRange(row0, row1);
         Mat cost_i = state->disp12MaxDiff >= 0 ? cost->rowRange(row0, row1) : Mat();
 
+        CV_Assert(disp_i.type() == CV_16S || disp_i.type() == CV_32S);
+
 #if CV_SIMD128
         if( useSIMD && useShorts )
         {

--- a/modules/calib3d/test/test_stereomatching.cpp
+++ b/modules/calib3d/test/test_stereomatching.cpp
@@ -794,7 +794,8 @@ protected:
         //check for fixed-type disparity data type
         Mat_<float> fixedFloatDisp;
         bm->compute( leftImg, rightImg, fixedFloatDisp );
-        EXPECT_TRUE(cvtest::norm(fixedFloatDisp, leftDisp, cv::NORM_L2) < (double)(leftDisp.total()));
+        EXPECT_LT(cvtest::norm(fixedFloatDisp, leftDisp, cv::NORM_L2 | cv::NORM_RELATIVE),
+                  0.9375 + DBL_EPSILON);
 
         if (params.mindisp != 0)
             for (int y = 0; y < leftDisp.rows; y++)

--- a/modules/calib3d/test/test_stereomatching.cpp
+++ b/modules/calib3d/test/test_stereomatching.cpp
@@ -795,7 +795,7 @@ protected:
         Mat_<float> fixedFloatDisp;
         bm->compute( leftImg, rightImg, fixedFloatDisp );
         EXPECT_LT(cvtest::norm(fixedFloatDisp, leftDisp, cv::NORM_L2 | cv::NORM_RELATIVE),
-                  0.9375 + DBL_EPSILON);
+                  0.005 + DBL_EPSILON);
 
         if (params.mindisp != 0)
             for (int y = 0; y < leftDisp.rows; y++)

--- a/modules/calib3d/test/test_stereomatching.cpp
+++ b/modules/calib3d/test/test_stereomatching.cpp
@@ -791,6 +791,11 @@ protected:
         bm->compute( leftImg, rightImg, tempDisp );
         tempDisp.convertTo(leftDisp, CV_32F, 1./StereoMatcher::DISP_SCALE);
 
+        //check for fixed-type disparity data type
+        Mat_<float> fixedFloatDisp;
+        bm->compute( leftImg, rightImg, fixedFloatDisp );
+        EXPECT_TRUE(cvtest::norm(fixedFloatDisp, leftDisp, cv::NORM_L2) < (double)(leftDisp.total()));
+
         if (params.mindisp != 0)
             for (int y = 0; y < leftDisp.rows; y++)
                 for (int x = 0; x < leftDisp.cols; x++)


### PR DESCRIPTION
A check is not done before `findStereoCorrespondenceBM_SIMD` call whether outputting array should contain shorts or ints.

### This pullrequest changes

* A type of output disparity array is passed now through template parameter.
* Test modified to cover the case
