### PR TITLE
videoio(ffmpeg): specify stream->time_base

### DIFF
--- a/modules/videoio/src/cap_ffmpeg_impl.hpp
+++ b/modules/videoio/src/cap_ffmpeg_impl.hpp
@@ -1587,6 +1587,9 @@ static AVStream *icv_add_video_stream_FFMPEG(AVFormatContext *oc,
 #if LIBAVCODEC_BUILD >= CALC_FFMPEG_VERSION(52, 42, 0)
     st->avg_frame_rate = (AVRational){frame_rate, frame_rate_base};
 #endif
+#if LIBAVFORMAT_BUILD >= CALC_FFMPEG_VERSION(55, 20, 0)
+    st->time_base = c->time_base;
+#endif
 
     return st;
 }

--- a/modules/videoio/test/test_ffmpeg.cpp
+++ b/modules/videoio/test/test_ffmpeg.cpp
@@ -357,6 +357,8 @@ public:
 
             for (unsigned int i = 0; i < frameCount && next; ++i)
             {
+                SCOPED_TRACE(cv::format("frame=%d", (int)frameCount));
+
                 Mat actual;
                 (*capture) >> actual;
 


### PR DESCRIPTION
Using `codec->time_base` is deprecated to specify muxer settings.
Resolves issue with FPS value for AVI files with FFmpeg 4.0.

resolves #11602

Related FFmpeg commits:
- https://github.com/FFmpeg/FFmpeg/commit/194be1f43ea391eb986732707435176e579265aa
- https://github.com/FFmpeg/FFmpeg/commit/91736025b2807995e29bd0661807c1c84f515fef

```
docker_image:Custom=ffmpeg-master
#docker_image:Custom=fedora:28
```

Probably related to #6905