### PR TITLE
videoio(ffmpeg): add option to enable debug logs

### DIFF
--- a/modules/videoio/src/cap_ffmpeg_impl.hpp
+++ b/modules/videoio/src/cap_ffmpeg_impl.hpp
@@ -754,6 +754,17 @@ private:
     AutoLock& operator = (const AutoLock&); // disabled
 };
 
+static void ffmpeg_log_callback(void *ptr, int level, const char *fmt, va_list vargs)
+{
+    static bool skip_header = false;
+    static int prev_level = -1;
+    (void)ptr;
+    if (!skip_header || level != prev_level) printf("[OPENCV:FFMPEG:%02d] ", level);
+    vprintf(fmt, vargs);
+    size_t fmt_len = strlen(fmt);
+    skip_header = fmt_len > 0 && fmt[fmt_len - 1] != '\n';
+    prev_level = level;
+}
 
 class InternalFFMpegRegister
 {
@@ -773,7 +784,18 @@ public:
             /* register a callback function for synchronization */
             av_lockmgr_register(&LockCallBack);
 
-            av_log_set_level(AV_LOG_ERROR);
+#ifndef NO_GETENV
+            char* debug_option = getenv("OPENCV_FFMPEG_DEBUG");
+            if (debug_option != NULL)
+            {
+                av_log_set_level(AV_LOG_VERBOSE);
+                av_log_set_callback(ffmpeg_log_callback);
+            }
+            else
+#endif
+            {
+                av_log_set_level(AV_LOG_ERROR);
+            }
 
             _initialized = true;
         }


### PR DESCRIPTION
via `OPENCV_FFMPEG_DEBUG` environment variable.

<cut>
<details>

<summary>Output example</summary>

```
OpenCV: FFMPEG: tag 0x34363248/'H264' is not supported with codec id 27 and format 'mp4 / MP4 (MPEG-4 Part 14)'
OpenCV: FFMPEG: fallback to use tag 0x31637661/'avc1'
[OPENCV:FFMPEG:48] using mv_range_thread = 184
[OPENCV:FFMPEG:32] using cpu capabilities: MMX2 SSE2Fast SSSE3 SSE4.2 AVX FMA3 BMI2 AVX2
[OPENCV:FFMPEG:32] profile High, level 5.1
[OPENCV:FFMPEG:32] 264 - core 152 r2854 e9a5903 - H.264/MPEG-4 AVC codec - Copyleft 2003-2017 - http://www.videolan.org/x264.html - options: cabac=1 ref=3 deblock=1:0:0 analyse=0x3:0x113 me=hex subme=7 psy=1 psy_rd=1.00:0.00 mixed_ref=1 me_range=16 chroma_me=1 trellis=1 8x8dct=1 cqm=0 deadzone=21,11 fast_pskip=1 chroma_qp_offset=-2 threads=6 lookahead_threads=1 sliced_threads=0 nr=0 decimate=1 interlaced=0 bluray_compat=0 constrained_intra=0 bframes=3 b_pyramid=2 b_adapt=1 b_bias=0 direct=1 weightb=1 open_gop=0 weightp=2 keyint=250 keyint_min=15 scenecut=40 intra_refresh=0 rc_lookahead=40 rc=crf mbtree=1 crf=23.0 qcomp=0.60 qpmin=0 qpmax=69 qpstep=4 ip_ratio=1.40 aq=1:1.00
[OPENCV:FFMPEG:48] Setting default whitelist 'file,crypto'
[OPENCV:FFMPEG:24] Using AVStream.codec to pass codec parameters to muxers is deprecated, use AVStream.codecpar instead.
[OPENCV:FFMPEG:48] frame=   0 QP=6.96 NAL=3 Slice:I Poc:0   I:34560 P:0    SKIP:0    size=1745 bytes
[OPENCV:FFMPEG:48] frame=   1 QP=21.23 NAL=2 Slice:P Poc:8   I:394  P:5    SKIP:34161 size=568 bytes
[OPENCV:FFMPEG:48] frame=   2 QP=24.39 NAL=2 Slice:B Poc:4   I:0    P:113  SKIP:34447 size=305 bytes
[OPENCV:FFMPEG:48] frame=   3 QP=25.86 NAL=0 Slice:B Poc:2   I:0    P:55   SKIP:34505 size=290 bytes
[OPENCV:FFMPEG:48] frame=   4 QP=22.98 NAL=0 Slice:B Poc:6   I:1    P:60   SKIP:34499 size=294 bytes
[OPENCV:FFMPEG:48] frame=   5 QP=16.02 NAL=2 Slice:P Poc:16  I:394  P:4    SKIP:34162 size=525 bytes
[OPENCV:FFMPEG:48] frame=   6 QP=19.04 NAL=2 Slice:B Poc:12  I:0    P:119  SKIP:34441 size=307 bytes
[OPENCV:FFMPEG:48] frame=   7 QP=20.98 NAL=0 Slice:B Poc:10  I:0    P:61   SKIP:34499 size=289 bytes
[OPENCV:FFMPEG:48] frame=   8 QP=18.97 NAL=0 Slice:B Poc:14  I:1    P:64   SKIP:34495 size=292 bytes
[OPENCV:FFMPEG:48] frame=   9 QP=13.05 NAL=2 Slice:P Poc:24  I:396  P:1    SKIP:34163 size=528 bytes
[OPENCV:FFMPEG:48] frame=  10 QP=14.48 NAL=2 Slice:B Poc:20  I:1    P:125  SKIP:34434 size=311 bytes
[OPENCV:FFMPEG:48] frame=  11 QP=16.96 NAL=0 Slice:B Poc:18  I:1    P:62   SKIP:34497 size=287 bytes
[OPENCV:FFMPEG:48] frame=  12 QP=14.76 NAL=0 Slice:B Poc:22  I:1    P:69   SKIP:34490 size=293 bytes
[OPENCV:FFMPEG:48] frame=  13 QP=12.26 NAL=2 Slice:P Poc:28  I:189  P:1    SKIP:34370 size=378 bytes
[OPENCV:FFMPEG:48] frame=  14 QP=12.88 NAL=0 Slice:B Poc:26  I:1    P:72   SKIP:34487 size=297 bytes
[OPENCV:FFMPEG:32] frame I:1     Avg QP: 6.96  size:  1745
[OPENCV:FFMPEG:32] frame P:4     Avg QP:15.64  size:   500
[OPENCV:FFMPEG:32] frame B:10    Avg QP:19.13  size:   296
[OPENCV:FFMPEG:32] consecutive B-frames:  6.7% 13.3%  0.0% 80.0%
[OPENCV:FFMPEG:32] mb I  I16..4: 100.0%  0.0%  0.0%
[OPENCV:FFMPEG:32] mb P  I16..4:  1.0%  0.0%  0.0%  P16..4:  0.0%  0.0%  0.0%  0.0%  0.0%    skip:99.0%
[OPENCV:FFMPEG:32] mb B  I16..4:  0.0%  0.0%  0.0%  B16..8:  0.2%  0.0%  0.0%  direct: 0.0%  skip:99.8%  L0:54.3% L1:45.7% BI: 0.0%
[OPENCV:FFMPEG:32] 8x8 transform intra:0.0% inter:41.7%
[OPENCV:FFMPEG:32] coded y,uvDC,uvAC intra: 0.0% 0.0% 0.0% inter: 0.0% 0.0% 0.0%
[OPENCV:FFMPEG:32] i16 v,h,dc,p: 99%  1%  1%  0%
[OPENCV:FFMPEG:32] i4 v,h,dc,ddl,ddr,vr,hd,vl,hu: 38% 27% 33%  0%  0%  0%  0%  1%  0%
[OPENCV:FFMPEG:32] i8c dc,h,v,p: 99%  0%  0%  0%
[OPENCV:FFMPEG:32] Weighted P-Frames: Y:0.0% UV:0.0%
[OPENCV:FFMPEG:32] ref P L0: 54.5% 36.4%  9.1%
[OPENCV:FFMPEG:32] ref B L0: 92.4%  7.6%
[OPENCV:FFMPEG:32] kb/s:53.67
[OPENCV:FFMPEG:48] Statistics: 2 seeks, 4 writeouts
```

</details>