### PR TITLE
Fix for morphologyEx MORPH_HITMISS mode

### DIFF
--- a/modules/imgproc/src/morph.cpp
+++ b/modules/imgproc/src/morph.cpp
@@ -2115,16 +2115,18 @@ void cv::morphologyEx( InputArray _src, OutputArray _dst, int op,
             k2 = (kernel == -1);
 
             if (countNonZero(k1) <= 0)
-                e1 = src;
+                e1 = Mat(src.size(), src.type(), Scalar(255));
             else
                 erode(src, e1, k1, anchor, iterations, borderType, borderValue);
 
-            Mat src_complement;
-            bitwise_not(src, src_complement);
             if (countNonZero(k2) <= 0)
-                e2 = src_complement;
+                e2 = Mat(src.size(), src.type(), Scalar(255));
             else
+            {
+                Mat src_complement;
+                bitwise_not(src, src_complement);
                 erode(src_complement, e2, k2, anchor, iterations, borderType, borderValue);
+            }
             dst = e1 & e2;
         }
         break;

--- a/modules/imgproc/test/test_filter.cpp
+++ b/modules/imgproc/test/test_filter.cpp
@@ -2102,6 +2102,12 @@ TEST(Imgproc_MorphEx, hitmiss_regression_8957)
     ref.at<uchar>(1, 1) = 255;
 
     ASSERT_DOUBLE_EQ(cvtest::norm(dst, ref, NORM_INF), 0.);
+
+    src.at<uchar>(1, 1) = 255;
+    ref.at<uchar>(0, 1) = 255;
+    ref.at<uchar>(2, 1) = 255;
+    cv::morphologyEx(src, dst, MORPH_HITMISS, kernel);
+    ASSERT_DOUBLE_EQ(cvtest::norm(dst, ref, NORM_INF), 0.);
 }
 
 TEST(Imgproc_MorphEx, hitmiss_zero_kernel)


### PR DESCRIPTION
resolves #11612

### This pullrequest changes
Fixed erosion processing in MORPH_HITMISS in case one of provided subkernels is zero
