### PR TITLE
ts: support parameters with types from anonymous namespace

### DIFF
--- a/modules/dnn/test/test_precomp.hpp
+++ b/modules/dnn/test/test_precomp.hpp
@@ -49,7 +49,7 @@
 #include "opencv2/dnn.hpp"
 #include "test_common.hpp"
 
-namespace opencv_test {
+namespace opencv_test { namespace {
 using namespace cv::dnn;
 
 CV_ENUM(DNNBackend, DNN_BACKEND_DEFAULT, DNN_BACKEND_HALIDE, DNN_BACKEND_INFERENCE_ENGINE)
@@ -69,6 +69,6 @@ static testing::internal::ParamGenerator<DNNTarget> availableDnnTargets()
     return testing::ValuesIn(targets);
 }
 
-}
+}}
 
 #endif

--- a/modules/ts/include/opencv2/ts/ts_gtest.h
+++ b/modules/ts/include/opencv2/ts/ts_gtest.h
@@ -11539,12 +11539,15 @@ typename ParamNameGenFunc<ParamType>::Type *GetParamNameGen() {
   return DefaultParamName;
 }
 
+} // namespace internal::  // fixes MacOS X issue with "friend class internal/*::anon*/::ParameterizedTestFactory;"
+namespace { // wrap into anynomous namespace to avoid build warnings like GCC's -Wsubobject-linkage
+
 // INTERNAL IMPLEMENTATION - DO NOT USE IN USER CODE.
 //
 // Stores a parameter value and later creates tests parameterized with that
 // value.
 template <class TestClass>
-class ParameterizedTestFactory : public TestFactoryBase {
+class ParameterizedTestFactory : public internal::TestFactoryBase {
  public:
   typedef typename TestClass::ParamType ParamType;
   explicit ParameterizedTestFactory(ParamType parameter) :
@@ -11559,6 +11562,8 @@ class ParameterizedTestFactory : public TestFactoryBase {
 
   GTEST_DISALLOW_COPY_AND_ASSIGN_(ParameterizedTestFactory);
 };
+} // namespace
+namespace internal {
 
 // INTERNAL IMPLEMENTATION - DO NOT USE IN USER CODE.
 //
@@ -20405,6 +20410,12 @@ class GTEST_API_ AssertHelper {
 }  // namespace internal
 
 #if GTEST_HAS_PARAM_TEST
+
+namespace internal {
+// Static value used for accessing test parameter during a test lifetime.
+extern void* g_parameter_;
+} // namespace internal
+
 // The pure interface class that all value-parameterized tests inherit from.
 // A value-parameterized class must inherit from both ::testing::Test and
 // ::testing::WithParamInterface. In most cases that just means inheriting
@@ -20451,28 +20462,27 @@ class WithParamInterface {
   // like writing 'WithParamInterface<bool>::GetParam()' for a test that
   // uses a fixture whose parameter type is int.
   const ParamType& GetParam() const {
-    GTEST_CHECK_(parameter_ != NULL)
+    GTEST_CHECK_(GetParameterPtrRef_() != NULL)
         << "GetParam() can only be called inside a value-parameterized test "
         << "-- did you intend to write TEST_P instead of TEST_F?";
-    return *parameter_;
+    return *GetParameterPtrRef_();
   }
 
  private:
   // Sets parameter value. The caller is responsible for making sure the value
   // remains alive and unchanged throughout the current test.
   static void SetParam(const ParamType* parameter) {
-    parameter_ = parameter;
+      GetParameterPtrRef_() = parameter;
   }
 
-  // Static value used for accessing parameter during a test lifetime.
-  static const ParamType* parameter_;
+  static const ParamType*& GetParameterPtrRef_()
+  {
+      return (const ParamType*&)internal::g_parameter_;
+  }
 
   // TestClass must be a subclass of WithParamInterface<T> and Test.
-  template <class TestClass> friend class internal::ParameterizedTestFactory;
+  template <class TestClass> friend class /*internal::*/ParameterizedTestFactory;
 };
-
-template <typename T>
-const T* WithParamInterface<T>::parameter_ = NULL;
 
 // Most value-parameterized classes can ignore the existence of
 // WithParamInterface, and can just inherit from ::testing::TestWithParam.

--- a/modules/ts/src/ts_gtest.cpp
+++ b/modules/ts/src/ts_gtest.cpp
@@ -10441,5 +10441,7 @@ const char* TypedTestCasePState::VerifyRegisteredTestNames(
 
 #endif  // GTEST_HAS_TYPED_TEST_P
 
+void* g_parameter_ = NULL;
+
 }  // namespace internal
 }  // namespace testing


### PR DESCRIPTION
related #11626

<cut>

Eliminates warnings like these:

> modules/ts/include/opencv2/ts/ts_gtest.h:11547:7: warning: 'testing::internal::ParameterizedTestFactory<opencv_test::ocl::OCL_ThreshFixture_Threshold_Threshold_Test>' has a field 'testing::internal::ParameterizedTestFactory<opencv_test::ocl::OCL_ThreshFixture_Threshold_Threshold_Test>::parameter_' whose type uses the anonymous namespace [-Wsubobject-linkage]

Make global variable for `WithParamInterface<T>::parameter_` due issues with using of anonymous namespace in `T`.

```
docker_image:Custom=fedora:28
```