### PR TITLE
calib3d: Refactored out a dead code path.

### DIFF
--- a/modules/calib3d/src/ptsetreg.cpp
+++ b/modules/calib3d/src/ptsetreg.cpp
@@ -78,10 +78,7 @@ class RANSACPointSetRegistrator : public PointSetRegistrator
 public:
     RANSACPointSetRegistrator(const Ptr<PointSetRegistrator::Callback>& _cb=Ptr<PointSetRegistrator::Callback>(),
                               int _modelPoints=0, double _threshold=0, double _confidence=0.99, int _maxIters=1000)
-    : cb(_cb), modelPoints(_modelPoints), threshold(_threshold), confidence(_confidence), maxIters(_maxIters)
-    {
-        checkPartialSubsets = false;
-    }
+      : cb(_cb), modelPoints(_modelPoints), threshold(_threshold), confidence(_confidence), maxIters(_maxIters) {}
 
     int findInliers( const Mat& m1, const Mat& m2, const Mat& model, Mat& err, Mat& mask, double thresh ) const
     {
@@ -143,17 +140,9 @@ public:
                     ms1ptr[i*esz1 + k] = m1ptr[idx_i*esz1 + k];
                 for( k = 0; k < esz2; k++ )
                     ms2ptr[i*esz2 + k] = m2ptr[idx_i*esz2 + k];
-                if( checkPartialSubsets && !cb->checkSubset( ms1, ms2, i+1 ))
-                {
-                    // we may have selected some bad points;
-                    // so, let's remove some of them randomly
-                    i = rng.uniform(0, i+1);
-                    iters++;
-                    continue;
-                }
                 i++;
             }
-            if( !checkPartialSubsets && i == modelPoints && !cb->checkSubset(ms1, ms2, i))
+            if( i == modelPoints && !cb->checkSubset(ms1, ms2, i) )
                 continue;
             break;
         }
@@ -261,7 +250,6 @@ public:
 
     Ptr<PointSetRegistrator::Callback> cb;
     int modelPoints;
-    bool checkPartialSubsets;
     double threshold;
     double confidence;
     int maxIters;


### PR DESCRIPTION
<!-- Please use this line to close one or multiple issues when this pullrequest gets merged
You can add another line right under the first one:
resolves #1234
resolves #1235
-->

I refactored out a dead code path in the RANSAC code. `checkPartialSubsets` was being set to `false` in the constructor and then never changed.