### PR TITLE
convertFp16: documentation edit

### DIFF
--- a/modules/core/include/opencv2/core.hpp
+++ b/modules/core/include/opencv2/core.hpp
@@ -532,7 +532,7 @@ CV_EXPORTS_W void convertScaleAbs(InputArray src, OutputArray dst,
 
 /** @brief Converts an array to half precision floating number.
 
-This function converts FP32 (single precision floating point) from/to FP16 (half precision floating point).  The input array has to have type of CV_32F or
+This function converts FP32 (single precision floating point) to FP16 (half precision floating point).  The input array has to have type of CV_32F or
 CV_16S to represent the bit depth.  If the input array is neither of them, the function will raise an error.
 The format of half precision floating point is defined in IEEE 754-2008.
 


### PR DESCRIPTION
convertFp16 doesn't convert from FP16: 

> input array has to have type of CV_32F or CV_16S.

