### PR TITLE
core:ppc Fix java CoreTest/testMahalanobis

### DIFF
--- a/modules/core/misc/java/test/CoreTest.java
+++ b/modules/core/misc/java/test/CoreTest.java
@@ -947,12 +947,16 @@ public class CoreTest extends OpenCVTestCase {
     }
 
     public void testMahalanobis() {
+        Mat src = new Mat(matSize, matSize, CvType.CV_32F);
+        Core.randu(src, -128, 128);
+
         Mat covar = new Mat(matSize, matSize, CvType.CV_32F);
         Mat mean = new Mat(1, matSize, CvType.CV_32F);
-        Core.calcCovarMatrix(grayRnd_32f, covar, mean, Core.COVAR_ROWS | Core.COVAR_NORMAL, CvType.CV_32F);
+        Core.calcCovarMatrix(src, covar, mean, Core.COVAR_ROWS | Core.COVAR_NORMAL, CvType.CV_32F);
         covar = covar.inv();
-        Mat line1 = grayRnd_32f.row(0);
-        Mat line2 = grayRnd_32f.row(1);
+
+        Mat line1 = src.row(0);
+        Mat line2 = src.row(1);
 
         double d = Core.Mahalanobis(line1, line1, covar);
 

--- a/modules/core/src/system.cpp
+++ b/modules/core/src/system.cpp
@@ -739,7 +739,6 @@ int64 getCPUTickCount(void)
 
 int64 getCPUTickCount(void)
 {
-    int64 result = 0;
     unsigned upper, lower, tmp;
     __asm__ volatile(
                      "0:                  \n"


### PR DESCRIPTION
resolves #11676 

````
force_builders=Custom
docker_image:Custom=powerpc64le
allow_multiple_commits=1
````


options for alternative buildbot for powerpc
https://ocv-power.imavr.com/#/opencv_pullrequests
````
pw_compilers=gcc-4.9, gcc-5, gcc-6, clang-4
# by default java test disabled due this issue
pw_disable_tests=rgbd, shape
#pw_cmake_definitions=OPENCV_EXTRA_MODULES_PATH:OFF
###
#pw_disable_perf_tests=*
#pw_filter_tests=core:*Mahalanobis*, java
````