### PR TITLE
core: set default logger level to 'warning'

### DIFF
--- a/modules/core/src/logger.cpp
+++ b/modules/core/src/logger.cpp
@@ -21,7 +21,13 @@ namespace logging {
 
 static LogLevel parseLogLevelConfiguration()
 {
-    static cv::String param_log_level = utils::getConfigurationParameterString("OPENCV_LOG_LEVEL", "INFO");
+    static cv::String param_log_level = utils::getConfigurationParameterString("OPENCV_LOG_LEVEL",
+#if defined NDEBUG
+            "WARNING"
+#else
+            "INFO"
+#endif
+    );
     if (param_log_level == "DISABLED" || param_log_level == "disabled" ||
         param_log_level == "0" || param_log_level == "OFF" || param_log_level == "off")
         return LOG_LEVEL_SILENT;


### PR DESCRIPTION
should hide unnecessary 'info' messages