### PR TITLE
apps: catch() with "const reference"

### DIFF
--- a/apps/interactive-calibration/main.cpp
+++ b/apps/interactive-calibration/main.cpp
@@ -217,7 +217,7 @@ int main(int argc, char** argv)
                 (*it)->resetState();
         }
     }
-    catch (std::runtime_error exp) {
+    catch (const std::runtime_error& exp) {
         std::cout << exp.what() << std::endl;
     }
 


### PR DESCRIPTION
related #11626 

> apps/interactive-calibration/main.cpp:220:31: warning: catching polymorphic type 'class std::runtime_error' by value [-Wcatch-value=]

```
docker_image:Custom=fedora:28
```
