### PR TITLE
samples: fix callback function type

### DIFF
--- a/samples/tapi/clahe.cpp
+++ b/samples/tapi/clahe.cpp
@@ -14,7 +14,7 @@ Ptr<CLAHE> pFilter;
 int tilesize;
 int cliplimit;
 
-static void TSize_Callback(int pos)
+static void TSize_Callback(int pos, void* /*data*/)
 {
     if(pos==0)
         pFilter->setTilesGridSize(Size(1,1));
@@ -22,7 +22,7 @@ static void TSize_Callback(int pos)
         pFilter->setTilesGridSize(Size(tilesize,tilesize));
 }
 
-static void Clip_Callback(int)
+static void Clip_Callback(int, void* /*data*/)
 {
     pFilter->setClipLimit(cliplimit);
 }


### PR DESCRIPTION
related #11626 

> samples/tapi/clahe.cpp:52:75: warning: cast between incompatible function types from 'void (*)(int)' to 'cv::TrackbarCallback' {aka 'void (*)(int, void*)'} [-Wcast-function-type]
> samples/tapi/clahe.cpp:53:77: warning: cast between incompatible function types from 'void (*)(int)' to 'cv::TrackbarCallback' {aka 'void (*)(int, void*)'} [-Wcast-function-type]

```
docker_image:Custom=fedora:28
```