### PR TITLE
SSDs from TenorFlow with OpenCL plugin of Inference Engine

### DIFF
--- a/modules/dnn/perf/perf_net.cpp
+++ b/modules/dnn/perf/perf_net.cpp
@@ -158,13 +158,19 @@ PERF_TEST_P_(DNNTestNetwork, MobileNet_SSD_Caffe)
             Mat(cv::Size(300, 300), CV_32FC3));
 }
 
-// TODO: update MobileNet model.
-PERF_TEST_P_(DNNTestNetwork, MobileNet_SSD_TensorFlow)
+PERF_TEST_P_(DNNTestNetwork, MobileNet_SSD_v1_TensorFlow)
 {
-    if (backend == DNN_BACKEND_HALIDE ||
-        backend == DNN_BACKEND_INFERENCE_ENGINE)
+    if (backend == DNN_BACKEND_HALIDE)
         throw SkipTestException("");
-    processNet("dnn/ssd_mobilenet_v1_coco.pb", "ssd_mobilenet_v1_coco.pbtxt", "",
+    processNet("dnn/ssd_mobilenet_v1_coco_2017_11_17.pb", "ssd_mobilenet_v1_coco_2017_11_17.pbtxt", "",
+            Mat(cv::Size(300, 300), CV_32FC3));
+}
+
+PERF_TEST_P_(DNNTestNetwork, MobileNet_SSD_v2_TensorFlow)
+{
+    if (backend == DNN_BACKEND_HALIDE)
+        throw SkipTestException("");
+    processNet("dnn/ssd_mobilenet_v2_coco_2018_03_29.pb", "ssd_mobilenet_v2_coco_2018_03_29.pbtxt", "",
             Mat(cv::Size(300, 300), CV_32FC3));
 }
 
@@ -217,9 +223,7 @@ PERF_TEST_P_(DNNTestNetwork, opencv_face_detector)
 
 PERF_TEST_P_(DNNTestNetwork, Inception_v2_SSD_TensorFlow)
 {
-    if (backend == DNN_BACKEND_HALIDE ||
-        (backend == DNN_BACKEND_INFERENCE_ENGINE && target == DNN_TARGET_OPENCL) ||
-        (backend == DNN_BACKEND_INFERENCE_ENGINE && target == DNN_TARGET_OPENCL_FP16))
+    if (backend == DNN_BACKEND_HALIDE)
         throw SkipTestException("");
     processNet("dnn/ssd_inception_v2_coco_2017_11_17.pb", "ssd_inception_v2_coco_2017_11_17.pbtxt", "",
             Mat(cv::Size(300, 300), CV_32FC3));

--- a/modules/dnn/test/test_layers.cpp
+++ b/modules/dnn/test/test_layers.cpp
@@ -877,6 +877,7 @@ TEST_P(Layer_Test_DWconv_Prelu, Accuracy)
     int shape[] = {1, num_input, 16, 16};
     Mat in_blob(4, &shape[0], CV_32FC1, Scalar(1));
 
+    net.setPreferableBackend(DNN_BACKEND_OPENCV);
     net.setInput(in_blob);
     Mat out = net.forward();
 


### PR DESCRIPTION
<!-- Please use this line to close one or multiple issues when this pullrequest gets merged
You can add another line right under the first one:
resolves #1234
resolves #1235
-->

### This pullrequest changes

* Enable OpenCL targets for SSD-based models from TensorFlow using Inference Engine backend.
OpenCV rebuild is not required. Just rerun a text graph generation script tf_text_graph_ssd.py
As result, extra reshape layers after prior box layers are added to final model.
* Add tests for new  MobileNet-SSD models from TensorFlow

Median time performance tests with previously generated graphs / new graphs: ~0.4ms slower in average.

|                  | MobileNet-SSD v1 | MobileNet-SSD v2 | Inception-SSD v2 |
|------------------|------------------|------------------|------------------|
| OCV, CPU         | 22.211 / 22.457  |  30.795 / 31.208 |  43.059 / 42.606  |
| OCV, GPU FP32 | 20.357 / 20.417  |  45.109 / 45.380 |  63.649 / 64.083  |
| OCV, GPU FP16 | 25.034 / 25.095  |  51.012 / 51.401 |  75.030 / 74.757  |
| IE, CPU          | 20.025 / 19.939  |  30.031 / 30.457 |  33.905 / 34.036  |
| IE, GPU FP32  |    --------- / 25.436  |    --------- / 31.985  |  --------- / 50.744  |
| IE, GPU FP16  |   --------- / 19.043  |    --------- / 25.907  |    --------- / 35.693  |
| IE, VPU          | 111.01 / 111.76  | 239.484 / 240.169 | 333.039 / 333.289 |

CPU: Intel&reg; Core&trade; i7-6700K CPU @ 4.00GHz x 8
GPU: Intel&reg; HD Graphics 530 (Skylake GT2)
NCS: Intel&reg; Movidius&trade; Neural Compute Stick

**Merge with extra**: https://github.com/opencv/opencv_extra/pull/474