### PR TITLE
videoio: update librealsense to API 2.0

### DIFF
--- a/cmake/OpenCVFindLibRealsense.cmake
+++ b/cmake/OpenCVFindLibRealsense.cmake
@@ -2,8 +2,8 @@
 # LIBREALSENSE_LIBRARIES and LIBREALSENSE_INCLUDE to link Intel librealsense modules
 # HAVE_LIBREALSENSE for conditional compilation OpenCV with/without librealsense
 
-find_path(LIBREALSENSE_INCLUDE_DIR "librealsense/rs.hpp" PATHS "$ENV{LIBREALSENSE_INCLUDE}" DOC "Path to librealsense interface headers")
-find_library(LIBREALSENSE_LIBRARIES "realsense" PATHS "$ENV{LIBREALSENSE_LIB}" DOC "Path to librealsense interface libraries")
+find_path(LIBREALSENSE_INCLUDE_DIR "librealsense2/rs.hpp" PATHS "$ENV{LIBREALSENSE_INCLUDE}" DOC "Path to librealsense interface headers")
+find_library(LIBREALSENSE_LIBRARIES "realsense2" PATHS "$ENV{LIBREALSENSE_LIB}" DOC "Path to librealsense interface libraries")
 
 if(LIBREALSENSE_INCLUDE_DIR AND LIBREALSENSE_LIBRARIES)
     set(HAVE_LIBREALSENSE TRUE)

--- a/modules/videoio/src/cap_librealsense.hpp
+++ b/modules/videoio/src/cap_librealsense.hpp
@@ -7,7 +7,7 @@
 
 #ifdef HAVE_LIBREALSENSE
 
-#include <librealsense/rs.hpp>
+#include <librealsense2/rs.hpp>
 
 namespace cv
 {
@@ -26,8 +26,9 @@ public:
     virtual int getCaptureDomain() CV_OVERRIDE;
     virtual bool isOpened() const CV_OVERRIDE;
 protected:
-    rs::context mContext;
-    rs::device* mDev = nullptr;
+    rs2::pipeline mPipe;
+    rs2::frameset mData;
+    rs2::align    mAlign;
 };
 
 }


### PR DESCRIPTION
this enables the usage of current sensors, while dropping support for
legacy devices, see:
https://github.com/IntelRealSense/librealsense#overview

Given limited resources, and that the legacy sensors where not that
great, I think we should focus on v2.
