### PR TITLE
samples: don't call twice of VideoCapture::open()

### DIFF
--- a/samples/cpp/videocapture_basic.cpp
+++ b/samples/cpp/videocapture_basic.cpp
@@ -20,7 +20,7 @@ int main(int, char**)
     //--- INITIALIZE VIDEOCAPTURE
     VideoCapture cap;
     // open the default camera using default API
-    cap.open(0);
+    // cap.open(0);
     // OR advance usage: select any API backend
     int deviceID = 0;             // 0 = open default camera
     int apiID = cv::CAP_ANY;      // 0 = autodetect default API


### PR DESCRIPTION
To avoid `EBUSY` errors in samples (some cameras/backends may require delay after `release()` call)