### PR TITLE
Added Size_::aspectRatio

### DIFF
--- a/modules/core/include/opencv2/core/types.hpp
+++ b/modules/core/include/opencv2/core/types.hpp
@@ -322,6 +322,8 @@ public:
     Size_& operator = (const Size_& sz);
     //! the area (width*height)
     _Tp area() const;
+    //! aspect ratio (width/height)
+    double aspectRatio() const;
     //! true if empty
     bool empty() const;
 
@@ -1668,6 +1670,12 @@ _Tp Size_<_Tp>::area() const
     CV_DbgAssert(!std::numeric_limits<_Tp>::is_integer
         || width == 0 || result / width == height); // make sure the result fits in the return value
     return result;
+}
+
+template<typename _Tp> inline
+double Size_<_Tp>::aspectRatio() const
+{
+    return width / static_cast<double>(height);
 }
 
 template<typename _Tp> inline


### PR DESCRIPTION
### This pullrequest changes
Aspect ratio computation is often needed when working with images. This is a convenience function to reduce the amount of code needed

## Things open for discussion:

1. Do we actually want to extend core type functionality like this?
2. Should we handle ``height == 0``, e.g. by returning -1 ?
3. Which (other) assertions do we want to impose (cf. ``area()``)
4. Should we handle larger types ``_TP`` where ``static_cast<double>(height)`` will fail?
