### PR TITLE
dnn: add a coco labels file for yolov3

### DIFF
--- a/samples/data/dnn/object_detection_classes_yolov3.txt
+++ b/samples/data/dnn/object_detection_classes_yolov3.txt
@@ -9,7 +9,6 @@ truck
 boat
 traffic light
 fire hydrant
-street sign
 stop sign
 parking meter
 bench
@@ -23,11 +22,8 @@ elephant
 bear
 zebra
 giraffe
-hat
 backpack
 umbrella
-shoe
-eye glasses
 handbag
 tie
 suitcase
@@ -42,7 +38,6 @@ skateboard
 surfboard
 tennis racket
 bottle
-plate
 wine glass
 cup
 fork
@@ -63,12 +58,8 @@ chair
 couch
 potted plant
 bed
-mirror
 dining table
-window
-desk
 toilet
-door
 tv
 laptop
 mouse
@@ -80,7 +71,6 @@ oven
 toaster
 sink
 refrigerator
-blender
 book
 clock
 vase


### PR DESCRIPTION
11 classes were dropped from the coco dataset, see arXiv:1405.0312v3 (Table2), so yolov3 has 80 classes, but [rcnn](https://github.com/opencv/opencv_extra/blob/master/testdata/dnn/faster_rcnn_inception_v2_coco_2018_01_28.pbtxt) still has the original 90, also fill blank names in object_detection_classes_coco.txt [from here](https://github.com/nightrome/cocostuff/blob/master/labels.md)
