### PR TITLE
Kinect2 support added to OpenNI2 backend

### DIFF
--- a/modules/videoio/src/cap_openni2.cpp
+++ b/modules/videoio/src/cap_openni2.cpp
@@ -175,9 +175,9 @@ protected:
     // Cameras settings:
     // TODO find in OpenNI function to convert z->disparity and remove fields "baseline" and depthFocalLength_VGA
     // Distance between IR projector and IR camera (in meters)
-    mutable double baseline;
+    double baseline;
     // Focal length for the IR camera in VGA resolution (in pixels)
-    mutable int depthFocalLength_VGA;
+    int depthFocalLength_VGA;
 
     // The value for shadow (occluded pixels)
     int shadowValue;

--- a/modules/videoio/src/cap_openni2.cpp
+++ b/modules/videoio/src/cap_openni2.cpp
@@ -365,7 +365,7 @@ void CvCapture_OpenNI2::toggleStream(int stream, bool toggle)
             if (status != openni::STATUS_OK)
             {
                 streams[stream].destroy();
-                CV_Error(CV_StsError, std::string("CvCapture_OpenNI2::CvCapture_OpenNI2 : Couldn't start ") + 
+                CV_Error(CV_StsError, std::string("CvCapture_OpenNI2::CvCapture_OpenNI2 : Couldn't start ") +
                          stream_names[stream] + std::string(" stream: ") +
                          std::string(openni::OpenNI::getExtendedError()));
             }
@@ -602,7 +602,7 @@ bool CvCapture_OpenNI2::setDepthGeneratorProperty( int propIdx, double propValue
         {
             toggleStream(CV_DEPTH_STREAM, propValue > 0.0);
             isSet = true;
-        }            
+        }
         break;
     case CV_CAP_PROP_OPENNI_REGISTRATION:
         {

--- a/modules/videoio/src/cap_openni2.cpp
+++ b/modules/videoio/src/cap_openni2.cpp
@@ -148,7 +148,7 @@ protected:
     IplImage* retrieveIrImage();
 
     void toggleStream(int stream, bool toggle);
-    void readCamerasParams() const;
+    void readCamerasParams();
 
     double getDepthGeneratorProperty(int propIdx) const;
     bool setDepthGeneratorProperty(int propIdx, double propVal);
@@ -388,7 +388,7 @@ void CvCapture_OpenNI2::toggleStream(int stream, bool toggle)
 }
 
 
-void CvCapture_OpenNI2::readCamerasParams() const
+void CvCapture_OpenNI2::readCamerasParams()
 {
     double pixelSize = 0;
     if (streams[CV_DEPTH_STREAM].getProperty<double>(XN_STREAM_PROPERTY_ZERO_PLANE_PIXEL_SIZE, &pixelSize) != openni::STATUS_OK)
@@ -577,12 +577,12 @@ double CvCapture_OpenNI2::getDepthGeneratorProperty( int propIdx ) const
         break;
     case CV_CAP_PROP_OPENNI_BASELINE :
         if(baseline <= 0)
-            readCamerasParams();
+            const_cast<CvCapture_OpenNI2*>(this)->readCamerasParams();
         propValue = baseline;
         break;
     case CV_CAP_PROP_OPENNI_FOCAL_LENGTH :
         if(depthFocalLength_VGA <= 0)
-            readCamerasParams();
+            const_cast<CvCapture_OpenNI2*>(this)->readCamerasParams();
         propValue = (double)depthFocalLength_VGA;
         break;
     case CV_CAP_PROP_OPENNI_REGISTRATION :


### PR DESCRIPTION
### This pullrequest changes
* added support for Kinect 2 drivers (`libfreenect2` and `kinect2` branch of OpenNI2)
* IR sensor support added
* checking available video modes added (before setting pre-defined one)
* less exceptions in case of unsupported options (for example getting baseline and focal length is used in case of disparity map generation only, there's no need to throw exception in other cases)
* a little refactoring
