### PR TITLE
Remove undocumented feature of dnn's forward

### DIFF
--- a/modules/dnn/test/test_torch_importer.cpp
+++ b/modules/dnn/test/test_torch_importer.cpp
@@ -87,7 +87,7 @@ static void runTorchNet(String prefix, int targetId = DNN_TARGET_CPU, String out
     if (outLayerName.empty())
         outLayerName = net.getLayerNames().back();
 
-    net.setInput(inp, "0");
+    net.setInput(inp);
     std::vector<Mat> outBlobs;
     net.forward(outBlobs, outLayerName);
     normAssert(outRef, outBlobs[0]);


### PR DESCRIPTION
<!-- Please use this line to close one or multiple issues when this pullrequest gets merged
You can add another line right under the first one:
resolves #1234
resolves #1235
-->

### This pullrequest changes

If layer has several outputs (like a max pooling layer) - retrieve all of them by 
```cpp
        /** @brief Runs forward pass to compute output of layer with name @p outputName.
         *  @param outputBlobs contains all output blobs for specified layer.
         *  @param outputName name for layer which output is needed to get
         *  @details If @p outputName is empty, runs forward pass for the whole network.
         */
        CV_WRAP void forward(OutputArrayOfArrays outputBlobs, const String& outputName = String());
```
but not by 
```cpp
        /** @brief Runs forward pass to compute output of layer with name @p outputName.
         *  @param outputName name for layer which output is needed to get
         *  @return blob for first output of specified layer.
         *  @details By default runs forward pass for the whole network.
         */
        CV_WRAP Mat forward(const String& outputName = String());
```
adding an index after layer's name (looks like it was undocumented). 

This way we can import networks with layers' names contain dot characters. There was an assertion otherwise.