### PR TITLE
Arm: suppress warning on Arm platform

### DIFF
--- a/3rdparty/carotene/hal/tegra_hal.hpp
+++ b/3rdparty/carotene/hal/tegra_hal.hpp
@@ -1531,7 +1531,7 @@ class TegraCvtColor_##name##_Invoker : public cv::ParallelLoopBody \
 public: \
     TegraCvtColor_##name##_Invoker(const uchar * src_data_, size_t src_step_, uchar * dst_data_, size_t dst_step_, int width_, int height_) : \
         cv::ParallelLoopBody(), src_data(src_data_), src_step(src_step_), dst_data(dst_data_), dst_step(dst_step_), width(width_), height(height_) {} \
-    virtual void operator()(const cv::Range& range) const \
+    virtual void operator()(const cv::Range& range) const CV_OVERRIDE \
     { \
         CAROTENE_NS::func(CAROTENE_NS::Size2D(width, range.end-range.start), __VA_ARGS__); \
     } \


### PR DESCRIPTION
<!-- Please use this line to close one or multiple issues when this pullrequest gets merged
You can add another line right under the first one:
resolves #1234
resolves #1235
-->

### This pullrequest changes

When building OpenCV on Arm, there are too many warnings about override

```
/home/linaro/opencv-fork/build/carotene/tegra_hal.hpp:1534:18: warning: ‘virtual void TegraCvtColor_rgb2bgr_Invoker::operator()(const cv::Range&) const’ can be marked override [-Wsuggest-override]
     virtual void operator()(const cv::Range& range) const \
                  ^
/home/linaro/opencv-fork/build/carotene/tegra_hal.hpp:1547:1: note: in expansion of macro ‘TegraCvtColor_Invoker’
 TegraCvtColor_Invoker(rgb2bgr, rgb2bgr, src_data + static_cast<size_t>(range.start) * src_step, src_step, \
 ^~~~~~~~~~~~~~~~~~~~~
```

I guess this PR should fix this.


I pasted my local build log [here](https://gist.github.com/tomoaki0705/7a88f856f4da9cc8cf4c531b13b36e59)
The diff is too large to show in the gist but the lines of the log has reduced **SO MUCH**.

```
$ wc -l override_*.log
   3205 override_current.log
  13009 override_previous.log
```


<!-- Please describe what your pullrequest is changing -->

