### PR TITLE
temporarily disabled OpenCL use in DNN module on Mac

### DIFF
--- a/modules/dnn/CMakeLists.txt
+++ b/modules/dnn/CMakeLists.txt
@@ -12,7 +12,8 @@ ocv_add_dispatched_file_force_all("layers/layers_common" AVX AVX2 AVX512_SKX)
 
 ocv_add_module(dnn opencv_core opencv_imgproc WRAP python matlab java js)
 
-ocv_option(OPENCV_DNN_OPENCL "Build with OpenCL support" HAVE_OPENCL)
+ocv_option(OPENCV_DNN_OPENCL "Build with OpenCL support" HAVE_OPENCL AND NOT APPLE)
+
 if(OPENCV_DNN_OPENCL AND HAVE_OPENCL)
   add_definitions(-DCV_OCL4DNN=1)
 else()

--- a/modules/dnn/src/dnn.cpp
+++ b/modules/dnn/src/dnn.cpp
@@ -877,7 +877,7 @@ struct Net::Impl
         if (!netWasAllocated || this->blobsToKeep != blobsToKeep_)
         {
             if (preferableBackend == DNN_BACKEND_OPENCV && IS_DNN_OPENCL_TARGET(preferableTarget))
-#if !defined HAVE_OPENCL || defined __APPLE__
+#ifndef HAVE_OPENCL
             {
                 CV_LOG_WARNING(NULL, "DNN: OpenCL target is not available in this OpenCV build, switching to CPU.");
                 preferableTarget = DNN_TARGET_CPU;

--- a/modules/dnn/src/dnn.cpp
+++ b/modules/dnn/src/dnn.cpp
@@ -877,7 +877,7 @@ struct Net::Impl
         if (!netWasAllocated || this->blobsToKeep != blobsToKeep_)
         {
             if (preferableBackend == DNN_BACKEND_OPENCV && IS_DNN_OPENCL_TARGET(preferableTarget))
-#ifndef HAVE_OPENCL
+#if !defined HAVE_OPENCL || defined __APPLE__
             {
                 CV_LOG_WARNING(NULL, "DNN: OpenCL target is not available in this OpenCV build, switching to CPU.");
                 preferableTarget = DNN_TARGET_CPU;


### PR DESCRIPTION
Did that since some of the tests fail. At some point, OpenCV DNN OpenCL branch will be expanded to support more generic OpenCL implementations; since OpenCL on Mac is a bit old and, e.g. does not support all the vendors extensions, like Intel extensions, some less sophisticated variant of kernels should be used there