### PR TITLE
Disable MSMF VideoCapture fallback to existing camera

### DIFF
--- a/modules/videoio/src/cap_msmf.cpp
+++ b/modules/videoio/src/cap_msmf.cpp
@@ -854,7 +854,8 @@ bool CvCapture_MSMF::configureOutput(UINT32 width, UINT32 height, double prefFra
 bool CvCapture_MSMF::open(int _index)
 {
     close();
-
+    if (_index < 0)
+        return false;
     _ComPtr<IMFAttributes> msAttr = NULL;
     if (SUCCEEDED(MFCreateAttributes(&msAttr, 1)) &&
         SUCCEEDED(msAttr->SetGUID(
@@ -868,7 +869,6 @@ bool CvCapture_MSMF::open(int _index)
         {
             if (count > 0)
             {
-                _index = std::min(std::max(0, _index), (int)count - 1);
                 for (int ind = 0; ind < (int)count; ind++)
                 {
                     if (ind == _index && ppDevices[ind])


### PR DESCRIPTION
resolves #11780

### This pullrequest changes
Removed fallback to existing camera in case provided index is out of camera id range
