### PR TITLE
Update Inference Engine tests

### DIFF
--- a/modules/dnn/test/test_backends.cpp
+++ b/modules/dnn/test/test_backends.cpp
@@ -182,11 +182,9 @@ TEST_P(DNNTestNetwork, MobileNet_SSD_Caffe)
         throw SkipTestException("");
     Mat sample = imread(findDataFile("dnn/street.png", false));
     Mat inp = blobFromImage(sample, 1.0f / 127.5, Size(300, 300), Scalar(127.5, 127.5, 127.5), false);
-    float l1 = (backend == DNN_BACKEND_OPENCV && target == DNN_TARGET_OPENCL_FP16) ? 0.0007 : 0.0;
-    float lInf = (backend == DNN_BACKEND_OPENCV && target == DNN_TARGET_OPENCL_FP16) ? 0.011 : 0.0;
-
+    float diffScores = (target == DNN_TARGET_OPENCL_FP16) ? 6e-3 : 0.0;
     processNet("dnn/MobileNetSSD_deploy.caffemodel", "dnn/MobileNetSSD_deploy.prototxt",
-               inp, "detection_out", "", l1, lInf);
+               inp, "detection_out", "", diffScores);
 }
 
 TEST_P(DNNTestNetwork, MobileNet_SSD_v1_TensorFlow)

--- a/modules/dnn/test/test_common.hpp
+++ b/modules/dnn/test/test_common.hpp
@@ -157,7 +157,8 @@ static inline bool checkMyriadTarget()
     net.addLayerToPrev("testLayer", "Identity", lp);
     net.setPreferableBackend(cv::dnn::DNN_BACKEND_INFERENCE_ENGINE);
     net.setPreferableTarget(cv::dnn::DNN_TARGET_MYRIAD);
-    net.setInput(cv::Mat::zeros(1, 1, CV_32FC1));
+    static int inpDims[] = {1, 2, 3, 4};
+    net.setInput(cv::Mat(4, &inpDims[0], CV_32FC1, cv::Scalar(0)));
     try
     {
         net.forward();

--- a/modules/dnn/test/test_darknet_importer.cpp
+++ b/modules/dnn/test/test_darknet_importer.cpp
@@ -143,7 +143,7 @@ TEST_P(Test_Darknet_nets, YoloVoc)
     classIds[0] = 6;  confidences[0] = 0.750469f; boxes[0] = Rect2d(0.577374, 0.127391, 0.325575, 0.173418);  // a car
     classIds[1] = 1;  confidences[1] = 0.780879f; boxes[1] = Rect2d(0.270762, 0.264102, 0.461713, 0.48131); // a bicycle
     classIds[2] = 11; confidences[2] = 0.901615f; boxes[2] = Rect2d(0.1386, 0.338509, 0.282737, 0.60028);  // a dog
-    double scoreDiff = (targetId == DNN_TARGET_OPENCL_FP16 || targetId == DNN_TARGET_MYRIAD) ? 7e-3 : 8e-5;
+    double scoreDiff = (targetId == DNN_TARGET_OPENCL_FP16 || targetId == DNN_TARGET_MYRIAD) ? 1e-2 : 8e-5;
     double iouDiff = (targetId == DNN_TARGET_OPENCL_FP16 || targetId == DNN_TARGET_MYRIAD) ? 0.013 : 3e-5;
     testDarknetModel("yolo-voc.cfg", "yolo-voc.weights", outNames,
                      classIds, confidences, boxes, backendId, targetId, scoreDiff, iouDiff);

--- a/modules/dnn/test/test_layers.cpp
+++ b/modules/dnn/test/test_layers.cpp
@@ -1183,6 +1183,7 @@ TEST(Layer_Test_PoolingIndices, Accuracy)
             }
         }
     }
+    net.setPreferableBackend(DNN_BACKEND_OPENCV);
     net.setInput(blobFromImage(inp));
 
     std::vector<Mat> outputs;


### PR DESCRIPTION
<!-- Please use this line to close one or multiple issues when this pullrequest gets merged
You can add another line right under the first one:
resolves #1234
resolves #1235
-->

### This pullrequest changes

* Modify thresholds for some of OpenCL fp16 tests.
* Change Myriad plugin checker.

The following tests are failed with prebuilt **cpu_extension** library using MKL-DNN CPU plugin:
```
[  FAILED  ] 3 tests, listed below:
[  FAILED  ] DNNTestNetwork.MobileNet_SSD_v1_TensorFlow/0, where GetParam() = (DNN_BACKEND_INFERENCE_ENGINE, DNN_TARGET_CPU)
[  FAILED  ] DNNTestNetwork.MobileNet_SSD_v2_TensorFlow/0, where GetParam() = (DNN_BACKEND_INFERENCE_ENGINE, DNN_TARGET_CPU)
[  FAILED  ] DNNTestNetwork.Inception_v2_SSD_TensorFlow/0, where GetParam() = (DNN_BACKEND_INFERENCE_ENGINE, DNN_TARGET_CPU)
```
read https://github.com/opencv/opencv/wiki/Intel's-Deep-Learning-Inference-Engine-backend#troubleshooting for a workaround.