### PR TITLE
WIP: HPX backend for OpenCV

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -252,6 +252,8 @@ OCV_OPTION(WITH_WIN32UI        "Build with Win32 UI Backend support"         ON 
 OCV_OPTION(WITH_QUICKTIME      "Use QuickTime for Video I/O"                 OFF  IF APPLE )
 OCV_OPTION(WITH_QTKIT          "Use QTKit Video I/O backend"                 OFF  IF APPLE )
 OCV_OPTION(WITH_TBB            "Include Intel TBB support"                   OFF  IF (NOT IOS AND NOT WINRT) )
+OCV_OPTION(WITH_HPX            "Include Ste||ar Group HPX support"           OFF)
+OCV_OPTION(WITH_HPX_STARTSTOP  "Start-Stop HPX runtime for each backend call" OFF)
 OCV_OPTION(WITH_OPENMP         "Include OpenMP support"                      OFF)
 OCV_OPTION(WITH_PTHREADS_PF    "Use pthreads-based parallel_for"             ON   IF (NOT WIN32 OR MINGW) )
 OCV_OPTION(WITH_TIFF           "Include TIFF support"                        ON   IF (NOT IOS) )
@@ -1348,6 +1350,7 @@ endif()
 # Order is similar to CV_PARALLEL_FRAMEWORK in core/src/parallel.cpp
 ocv_build_features_string(parallel_status EXCLUSIVE
   IF HAVE_TBB THEN "TBB (ver ${TBB_VERSION_MAJOR}.${TBB_VERSION_MINOR} interface ${TBB_INTERFACE_VERSION})"
+  IF HAVE_HPX THEN "HPX (WITH_HPX_STARTSTOP=${WITH_HPX_STARTSTOP})"
   IF HAVE_OPENMP THEN "OpenMP"
   IF HAVE_GCD THEN "GCD"
   IF WINRT OR HAVE_CONCURRENCY THEN "Concurrency"

--- a/cmake/OpenCVFindLibsPerf.cmake
+++ b/cmake/OpenCVFindLibsPerf.cmake
@@ -7,6 +7,17 @@ if(WITH_TBB)
   include("${OpenCV_SOURCE_DIR}/cmake/OpenCVDetectTBB.cmake")
 endif(WITH_TBB)
 
+# --- HPX ---
+if(WITH_HPX)
+  find_package(HPX REQUIRED)
+  ocv_include_directories(${HPX_INCLUDE_DIRS})
+  set(HAVE_HPX TRUE)
+endif(WITH_HPX)
+
+if(WITH_HPX_STARTSTOP)
+  set(HPX_STARTSTOP TRUE)
+endif(WITH_HPX_STARTSTOP)
+
 # --- IPP ---
 if(WITH_IPP)
   include("${OpenCV_SOURCE_DIR}/cmake/OpenCVFindIPP.cmake")

--- a/cmake/OpenCVModule.cmake
+++ b/cmake/OpenCVModule.cmake
@@ -1135,6 +1135,11 @@ function(ocv_add_perf_tests)
       ocv_target_link_libraries(${the_target} LINK_PRIVATE ${perf_deps} ${OPENCV_MODULE_${the_module}_DEPS} ${OPENCV_LINKER_LIBS})
       add_dependencies(opencv_perf_tests ${the_target})
 
+      if(HAVE_HPX AND NOT HPX_STARTSTOP)
+        message("Linking HPX to Perf test of module ${name}")
+        ocv_target_link_libraries(${the_target} LINK_PRIVATE "${HPX_LIBRARIES}")
+      endif()
+
       set_target_properties(${the_target} PROPERTIES LABELS "${OPENCV_MODULE_${the_module}_LABEL};PerfTest")
       set_source_files_properties(${OPENCV_PERF_${the_module}_SOURCES} ${${the_target}_pch}
         PROPERTIES LABELS "${OPENCV_MODULE_${the_module}_LABEL};PerfTest")
@@ -1213,6 +1218,11 @@ function(ocv_add_accuracy_tests)
       ocv_target_include_modules(${the_target} ${test_deps} "${test_path}")
       ocv_target_link_libraries(${the_target} LINK_PRIVATE ${test_deps} ${OPENCV_MODULE_${the_module}_DEPS} ${OPENCV_LINKER_LIBS})
       add_dependencies(opencv_tests ${the_target})
+
+      if(HAVE_HPX AND NOT HPX_STARTSTOP)
+        message("Linking HPX to Perf test of module ${name}")
+        ocv_target_link_libraries(${the_target} LINK_PRIVATE "${HPX_LIBRARIES}")
+      endif()
 
       set_target_properties(${the_target} PROPERTIES LABELS "${OPENCV_MODULE_${the_module}_LABEL};AccuracyTest")
       set_source_files_properties(${OPENCV_TEST_${the_module}_SOURCES} ${${the_target}_pch}

--- a/cmake/templates/cvconfig.h.in
+++ b/cmake/templates/cvconfig.h.in
@@ -174,6 +174,10 @@
 /* Intel Threading Building Blocks */
 #cmakedefine HAVE_TBB
 
+/* Ste||ar Group High Performance ParallelX */
+#cmakedefine HAVE_HPX
+#cmakedefine HPX_STARTSTOP
+
 /* TIFF codec */
 #cmakedefine HAVE_TIFF
 

--- a/modules/core/CMakeLists.txt
+++ b/modules/core/CMakeLists.txt
@@ -68,6 +68,10 @@ ocv_target_link_libraries(${the_module} LINK_PRIVATE
     "${OPENCV_HAL_LINKER_LIBS}"
 )
 
+if(HAVE_HPX)
+  ocv_target_link_libraries(${the_module} LINK_PRIVATE "${HPX_LIBRARIES}")
+endif()
+
 if(HAVE_CUDA)
   ocv_target_compile_definitions(${the_module} PUBLIC OPENCV_TRAITS_ENABLE_DEPRECATED)
 endif()

--- a/modules/core/perf/perf_main.cpp
+++ b/modules/core/perf/perf_main.cpp
@@ -5,4 +5,8 @@
 # endif
 #endif
 
+#if defined(HAVE_HPX) && !defined(HPX_STARTSTOP)
+    #include <hpx/hpx_main.hpp>
+#endif
+
 CV_PERF_TEST_MAIN(core)

--- a/modules/core/test/test_main.cpp
+++ b/modules/core/test/test_main.cpp
@@ -3,4 +3,8 @@
 // of this distribution and at http://opencv.org/license.html.
 #include "test_precomp.hpp"
 
+#if defined(HAVE_HPX) && !defined(HPX_STARTSTOP)
+    #include <hpx/hpx_main.hpp>
+#endif
+
 CV_TEST_MAIN("cv")


### PR DESCRIPTION
### Introduction

My name is Jakub Golinowski and I am a student enrolled for Google Summer of Code 2018. I am working for Ste||ar Group on developing [HPX](https://github.com/STEllAR-GROUP/hpx) backend for parallelism in OpenCV. Here is the link to the GSoC project: https://summerofcode.withgoogle.com/projects/#5375652711104512. The main goal of the project is to allow better interoperability of HPX applications, which are using OpenCV. The primary use-case we have in mind is an application that is already using the HPX runtime environment and also performs computer vision operations using OpenCV. Including the HPX backend within the OpenCV will make such an application easier to implement and to control its parallelization behaviour using standard HPX approach.

So far there are 2 versions of HPX backend:

- HPX - primary version, described above, which assumes that user’s application starts the runtime before making calls to OpenCV functions that use cv::parallel_for_(). As mentioned in the introduction, this would be the preferred and hopefully only way to use the backend.
- HPX_STARTSTOP - back-up version of backend in which HPX runtime is started and stopped for each cv::parallel_for_() call. 

The backend was tested locally using small applications (they can be found here: https://github.com/Jakub-Golinowski/opencv_hpx_backend). The applications were behaving as expected.

### This pullrequest changes

- In the first commit (e2699a9) there are all source code changes required for backend functionality and proposition of cmake changes for HPX library inclusion.

- In the second commit (d4746dd) there is a proposition of changes required for OpenCV with HPX backend to enable the primary version of backend to pass the tests, however in this configuration there were linking errors encountered in the release mode build, which are not present in the debug mode build.

### Summary

This is still work in progress, but I would like to ask for feedback early especially on the CMake config. After that I will be able to run tests locally and make necessary fixes to backend if any will be required. 

Also, I would like to ask what would be required to have the HPX backend tested using OpenCV's CI? For now I added the cmake option WITH_HPX to choose HPX as the parallel backend and WITH_HPX_STARTSTOP to choose its back-up version (described above).