### PR TITLE
imgcodecs(sunras): avoid buffer overrun

### DIFF
--- a/modules/imgcodecs/src/grfmt_sunras.cpp
+++ b/modules/imgcodecs/src/grfmt_sunras.cpp
@@ -175,8 +175,6 @@ bool  SunRasterDecoder::readData( Mat& img )
 
     AutoBuffer<uchar> _src(src_pitch + 32);
     uchar* src = _src;
-    AutoBuffer<uchar> _bgr(m_width*3 + 32);
-    uchar* bgr = _bgr;
 
     if( !color && m_maptype == RMT_EQUAL_RGB )
         CvtPaletteToGray( m_palette, gray_palette, 1 << m_bpp );
@@ -340,16 +338,18 @@ bad_decoding_end:
         case 24:
             for( y = 0; y < m_height; y++, data += step )
             {
-                m_strm.getBytes( color ? data : bgr, src_pitch );
+                m_strm.getBytes(src, src_pitch );
 
                 if( color )
                 {
                     if( m_type == RAS_FORMAT_RGB )
-                        icvCvt_RGB2BGR_8u_C3R( data, 0, data, 0, cvSize(m_width,1) );
+                        icvCvt_RGB2BGR_8u_C3R(src, 0, data, 0, cvSize(m_width,1) );
+                    else
+                        memcpy(data, src, std::min(step, (size_t)src_pitch));
                 }
                 else
                 {
-                    icvCvt_BGR2Gray_8u_C3C1R( bgr, 0, data, 0, cvSize(m_width,1),
+                    icvCvt_BGR2Gray_8u_C3C1R(src, 0, data, 0, cvSize(m_width,1),
                                               m_type == RAS_FORMAT_RGB ? 2 : 0 );
                 }
             }


### PR DESCRIPTION
`src_pitch` may be large than data `step`

resolves #11827