### PR TITLE
Python 3.7 compatability

### DIFF
--- a/modules/python/src2/cv2.cpp
+++ b/modules/python/src2/cv2.cpp
@@ -916,7 +916,7 @@ bool pyopencv_to(PyObject* obj, String& value, const char* name)
     (void)name;
     if(!obj || obj == Py_None)
         return true;
-    char* str = PyString_AsString(obj);
+    const char* str = PyString_AsString(obj);
     if(!str)
         return false;
     value = String(str);


### PR DESCRIPTION
The result of PyUnicode_AsUTF8() is now of type const char * rather of 
char *.

See
https://docs.python.org/3/whatsnew/3.7.html
https://bugs.python.org/issue28769