### PR TITLE
RFC: merge fisheye camera into default camera calibration API

### DIFF
--- a/modules/calib3d/include/opencv2/calib3d.hpp
+++ b/modules/calib3d/include/opencv2/calib3d.hpp
@@ -277,7 +277,17 @@ enum { CALIB_USE_INTRINSIC_GUESS = 0x00001,
        CALIB_ZERO_DISPARITY      = 0x00400,
        CALIB_USE_LU              = (1 << 17), //!< use LU instead of SVD decomposition for solving. much faster but potentially less precise
        CALIB_USE_EXTRINSIC_GUESS = (1 << 22), //!< for stereoCalibrate
+       // only for fisheye camera model
+       CALIB_FIX_SKEW              = 1 << 23,
+       CALIB_RECOMPUTE_EXTRINSIC   = 1 << 24,
+       CALIB_CHECK_COND            = 1 << 25
      };
+
+//! the mathematical camera model to assume for calibration
+enum {
+    CAMERA_MODEL_DEFAULT = 0,
+    CAMERA_MODEL_FISHEYE
+};
 
 //! the algorithm for finding fundamental matrix
 enum { FM_7POINT = 1, //!< 7-point algorithm
@@ -524,7 +534,8 @@ CV_EXPORTS_W void projectPoints( InputArray objectPoints,
                                  InputArray cameraMatrix, InputArray distCoeffs,
                                  OutputArray imagePoints,
                                  OutputArray jacobian = noArray(),
-                                 double aspectRatio = 0 );
+                                 double aspectRatio = 0,
+                                 int cameraModel = CAMERA_MODEL_DEFAULT);
 
 /** @example homography_from_camera_displacement.cpp
   An example program about homography from the camera displacement
@@ -689,10 +700,10 @@ a 3D point expressed in the world frame into the camera frame:
        are sufficient to compute a pose but there are up to 4 solutions). The initial solution should be close to the
        global solution to converge.
  */
-CV_EXPORTS_W bool solvePnP( InputArray objectPoints, InputArray imagePoints,
-                            InputArray cameraMatrix, InputArray distCoeffs,
-                            OutputArray rvec, OutputArray tvec,
-                            bool useExtrinsicGuess = false, int flags = SOLVEPNP_ITERATIVE );
+CV_EXPORTS_W bool solvePnP(InputArray objectPoints, InputArray imagePoints, InputArray cameraMatrix,
+                           InputArray distCoeffs, OutputArray rvec, OutputArray tvec,
+                           bool useExtrinsicGuess = false, int flags = SOLVEPNP_ITERATIVE,
+                           int cameraModel = CAMERA_MODEL_DEFAULT);
 
 /** @brief Finds an object pose from 3D-2D point correspondences using the RANSAC scheme.
 
@@ -736,12 +747,12 @@ makes the function resistant to outliers.
        flags parameters unless it is equal to #SOLVEPNP_P3P or #SOLVEPNP_AP3P. In this case,
        the method #SOLVEPNP_EPNP will be used instead.
  */
-CV_EXPORTS_W bool solvePnPRansac( InputArray objectPoints, InputArray imagePoints,
-                                  InputArray cameraMatrix, InputArray distCoeffs,
-                                  OutputArray rvec, OutputArray tvec,
-                                  bool useExtrinsicGuess = false, int iterationsCount = 100,
-                                  float reprojectionError = 8.0, double confidence = 0.99,
-                                  OutputArray inliers = noArray(), int flags = SOLVEPNP_ITERATIVE );
+CV_EXPORTS_W bool solvePnPRansac(InputArray objectPoints, InputArray imagePoints, InputArray cameraMatrix,
+                                 InputArray distCoeffs, OutputArray rvec, OutputArray tvec,
+                                 bool useExtrinsicGuess = false, int iterationsCount = 100,
+                                 float reprojectionError = 8.0, double confidence = 0.99,
+                                 OutputArray inliers = noArray(), int flags = SOLVEPNP_ITERATIVE,
+                                 int cameraModel = CAMERA_MODEL_DEFAULT);
 /** @brief Finds an object pose from 3 3D-2D point correspondences.
 
 @param objectPoints Array of object points in the object coordinate space, 3x3 1-channel or
@@ -765,10 +776,9 @@ the model coordinate system to the camera coordinate system. A P3P problem has u
 The function estimates the object pose given 3 object points, their corresponding image
 projections, as well as the camera matrix and the distortion coefficients.
  */
-CV_EXPORTS_W int solveP3P( InputArray objectPoints, InputArray imagePoints,
-                           InputArray cameraMatrix, InputArray distCoeffs,
-                           OutputArrayOfArrays rvecs, OutputArrayOfArrays tvecs,
-                           int flags );
+CV_EXPORTS_W int solveP3P(InputArray objectPoints, InputArray imagePoints, InputArray cameraMatrix,
+                          InputArray distCoeffs, OutputArrayOfArrays rvecs, OutputArrayOfArrays tvecs,
+                          int flags, int cameraModel = CAMERA_MODEL_DEFAULT);
 
 /** @brief Finds an initial camera matrix from 3D-2D point correspondences.
 
@@ -971,6 +981,7 @@ space, that is, a real position of the calibration pattern in the k-th pattern v
  Order of deviations values: \f$(R_1, T_1, \dotsc , R_M, T_M)\f$ where M is number of pattern views,
  \f$R_i, T_i\f$ are concatenated 1x3 vectors.
  @param perViewErrors Output vector of the RMS re-projection error estimated for each pattern view.
+ @param cameraModel
 @param flags Different flags that may be zero or a combination of the following values:
 -   **CALIB_USE_INTRINSIC_GUESS** cameraMatrix contains valid initial values of
 fx, fy, cx, cy that are optimized further. Otherwise, (cx, cy) is initially set to the image
@@ -1053,7 +1064,8 @@ CV_EXPORTS_AS(calibrateCameraExtended) double calibrateCamera( InputArrayOfArray
                                      OutputArray stdDeviationsExtrinsics,
                                      OutputArray perViewErrors,
                                      int flags = 0, TermCriteria criteria = TermCriteria(
-                                        TermCriteria::COUNT + TermCriteria::EPS, 30, DBL_EPSILON) );
+                                        TermCriteria::COUNT + TermCriteria::EPS, 30, DBL_EPSILON),
+                                     int cameraModel = CAMERA_MODEL_DEFAULT );
 
 /** @overload double calibrateCamera( InputArrayOfArrays objectPoints,
                                      InputArrayOfArrays imagePoints, Size imageSize,
@@ -1061,14 +1073,16 @@ CV_EXPORTS_AS(calibrateCameraExtended) double calibrateCamera( InputArrayOfArray
                                      OutputArrayOfArrays rvecs, OutputArrayOfArrays tvecs,
                                      OutputArray stdDeviations, OutputArray perViewErrors,
                                      int flags = 0, TermCriteria criteria = TermCriteria(
-                                        TermCriteria::COUNT + TermCriteria::EPS, 30, DBL_EPSILON) )
+                                        TermCriteria::COUNT + TermCriteria::EPS, 30, DBL_EPSILON),
+                                     int cameraModel = CAMERA_MODEL_DEFAULT  )
  */
 CV_EXPORTS_W double calibrateCamera( InputArrayOfArrays objectPoints,
                                      InputArrayOfArrays imagePoints, Size imageSize,
                                      InputOutputArray cameraMatrix, InputOutputArray distCoeffs,
                                      OutputArrayOfArrays rvecs, OutputArrayOfArrays tvecs,
                                      int flags = 0, TermCriteria criteria = TermCriteria(
-                                        TermCriteria::COUNT + TermCriteria::EPS, 30, DBL_EPSILON) );
+                                        TermCriteria::COUNT + TermCriteria::EPS, 30, DBL_EPSILON),
+                                     int cameraModel = CAMERA_MODEL_DEFAULT );
 
 /** @brief Computes useful camera characteristics from the camera matrix.
 
@@ -1197,7 +1211,8 @@ CV_EXPORTS_AS(stereoCalibrateExtended) double stereoCalibrate( InputArrayOfArray
                                      InputOutputArray cameraMatrix2, InputOutputArray distCoeffs2,
                                      Size imageSize, InputOutputArray R,InputOutputArray T, OutputArray E, OutputArray F,
                                      OutputArray perViewErrors, int flags = CALIB_FIX_INTRINSIC,
-                                     TermCriteria criteria = TermCriteria(TermCriteria::COUNT+TermCriteria::EPS, 30, 1e-6) );
+                                     TermCriteria criteria = TermCriteria(TermCriteria::COUNT+TermCriteria::EPS, 30, 1e-6),
+                                     int cameraModel = CAMERA_MODEL_DEFAULT);
 
 /// @overload
 CV_EXPORTS_W double stereoCalibrate( InputArrayOfArrays objectPoints,
@@ -1206,7 +1221,8 @@ CV_EXPORTS_W double stereoCalibrate( InputArrayOfArrays objectPoints,
                                      InputOutputArray cameraMatrix2, InputOutputArray distCoeffs2,
                                      Size imageSize, OutputArray R,OutputArray T, OutputArray E, OutputArray F,
                                      int flags = CALIB_FIX_INTRINSIC,
-                                     TermCriteria criteria = TermCriteria(TermCriteria::COUNT+TermCriteria::EPS, 30, 1e-6) );
+                                     TermCriteria criteria = TermCriteria(TermCriteria::COUNT+TermCriteria::EPS, 30, 1e-6),
+                                     int cameraModel = CAMERA_MODEL_DEFAULT);
 
 /** @brief Computes rectification transforms for each head of a calibrated stereo camera.
 
@@ -1294,7 +1310,8 @@ CV_EXPORTS_W void stereoRectify( InputArray cameraMatrix1, InputArray distCoeffs
                                  OutputArray P1, OutputArray P2,
                                  OutputArray Q, int flags = CALIB_ZERO_DISPARITY,
                                  double alpha = -1, Size newImageSize = Size(),
-                                 CV_OUT Rect* validPixROI1 = 0, CV_OUT Rect* validPixROI2 = 0 );
+                                 CV_OUT Rect* validPixROI1 = 0, CV_OUT Rect* validPixROI2 = 0,
+                                 int cameraModel = CAMERA_MODEL_DEFAULT);
 
 /** @brief Computes a rectification transform for an uncalibrated stereo camera.
 
@@ -1372,7 +1389,8 @@ initUndistortRectifyMap to produce the maps for remap .
 CV_EXPORTS_W Mat getOptimalNewCameraMatrix( InputArray cameraMatrix, InputArray distCoeffs,
                                             Size imageSize, double alpha, Size newImgSize = Size(),
                                             CV_OUT Rect* validPixROI = 0,
-                                            bool centerPrincipalPoint = false);
+                                            bool centerPrincipalPoint = false,
+                                            int cameraModel = CAMERA_MODEL_DEFAULT);
 
 /** @brief Converts points from Euclidean to homogeneous space.
 
@@ -2174,16 +2192,16 @@ namespace fisheye
 //! @{
 
     enum{
-        CALIB_USE_INTRINSIC_GUESS   = 1 << 0,
-        CALIB_RECOMPUTE_EXTRINSIC   = 1 << 1,
-        CALIB_CHECK_COND            = 1 << 2,
-        CALIB_FIX_SKEW              = 1 << 3,
-        CALIB_FIX_K1                = 1 << 4,
-        CALIB_FIX_K2                = 1 << 5,
-        CALIB_FIX_K3                = 1 << 6,
-        CALIB_FIX_K4                = 1 << 7,
-        CALIB_FIX_INTRINSIC         = 1 << 8,
-        CALIB_FIX_PRINCIPAL_POINT   = 1 << 9
+        CALIB_USE_INTRINSIC_GUESS   = cv::CALIB_USE_INTRINSIC_GUESS,
+        CALIB_FIX_K1                = cv::CALIB_FIX_K1,
+        CALIB_FIX_K2                = cv::CALIB_FIX_K2,
+        CALIB_FIX_K3                = cv::CALIB_FIX_K3,
+        CALIB_FIX_K4                = cv::CALIB_FIX_K4,
+        CALIB_FIX_INTRINSIC         = cv::CALIB_FIX_INTRINSIC,
+        CALIB_FIX_PRINCIPAL_POINT   = cv::CALIB_FIX_PRINCIPAL_POINT,
+        CALIB_FIX_SKEW              = cv::CALIB_FIX_SKEW,
+        CALIB_RECOMPUTE_EXTRINSIC   = cv::CALIB_RECOMPUTE_EXTRINSIC,
+        CALIB_CHECK_COND            = cv::CALIB_CHECK_COND
     };
 
     /** @brief Projects points using fisheye model

--- a/modules/calib3d/src/calibration.cpp
+++ b/modules/calib3d/src/calibration.cpp
@@ -3289,8 +3289,16 @@ void cv::projectPoints( InputArray _opoints,
                         InputArray _distCoeffs,
                         OutputArray _ipoints,
                         OutputArray _jacobian,
-                        double aspectRatio )
+                        double aspectRatio,
+                        int cameraModel)
 {
+    if (cameraModel == CAMERA_MODEL_FISHEYE) {
+        CV_Assert(aspectRatio == 0);
+        cv::fisheye::projectPoints(_opoints, _ipoints, _rvec, _tvec, _cameraMatrix, _distCoeffs, 0,
+                                   _jacobian);
+        return;
+    }
+
     Mat opoints = _opoints.getMat();
     int npoints = opoints.checkVector(3), depth = opoints.depth();
     CV_Assert(npoints >= 0 && (depth == CV_32F || depth == CV_64F));
@@ -3351,9 +3359,14 @@ cv::Mat cv::initCameraMatrix2D( InputArrayOfArrays objectPoints,
 double cv::calibrateCamera( InputArrayOfArrays _objectPoints,
                             InputArrayOfArrays _imagePoints,
                             Size imageSize, InputOutputArray _cameraMatrix, InputOutputArray _distCoeffs,
-                            OutputArrayOfArrays _rvecs, OutputArrayOfArrays _tvecs, int flags, TermCriteria criteria )
+                            OutputArrayOfArrays _rvecs, OutputArrayOfArrays _tvecs, int flags, TermCriteria criteria, int cameraModel)
 {
     CV_INSTRUMENT_REGION()
+
+    if (cameraModel == CAMERA_MODEL_FISHEYE) {
+        return cv::fisheye::calibrate(_objectPoints, _imagePoints, imageSize, _cameraMatrix, _distCoeffs,
+                                      _rvecs, _tvecs, flags, criteria);
+    }
 
     return calibrateCamera(_objectPoints, _imagePoints, imageSize, _cameraMatrix, _distCoeffs,
                                          _rvecs, _tvecs, noArray(), noArray(), noArray(), flags, criteria);
@@ -3365,9 +3378,11 @@ double cv::calibrateCamera(InputArrayOfArrays _objectPoints,
                             OutputArrayOfArrays _rvecs, OutputArrayOfArrays _tvecs,
                             OutputArray stdDeviationsIntrinsics,
                             OutputArray stdDeviationsExtrinsics,
-                            OutputArray _perViewErrors, int flags, TermCriteria criteria )
+                            OutputArray _perViewErrors, int flags, TermCriteria criteria, int cameraModel )
 {
     CV_INSTRUMENT_REGION()
+
+    CV_Assert(cameraModel == CAMERA_MODEL_DEFAULT);
 
     int rtype = CV_64F;
     Mat cameraMatrix = _cameraMatrix.getMat();
@@ -3523,8 +3538,15 @@ double cv::stereoCalibrate( InputArrayOfArrays _objectPoints,
                           InputOutputArray _cameraMatrix2, InputOutputArray _distCoeffs2,
                           Size imageSize, OutputArray _Rmat, OutputArray _Tmat,
                           OutputArray _Emat, OutputArray _Fmat, int flags,
-                          TermCriteria criteria)
+                          TermCriteria criteria, int cameraModel)
 {
+    if (cameraModel == CAMERA_MODEL_FISHEYE) {
+        CV_Assert(!_Emat.needed() && !_Fmat.needed());
+        return cv::fisheye::stereoCalibrate(_objectPoints, _imagePoints1, _imagePoints2, _cameraMatrix1,
+                                            _distCoeffs1, _cameraMatrix2, _distCoeffs2, imageSize, _Rmat,
+                                            _Tmat, flags, criteria);
+    }
+
     Mat Rmat, Tmat;
     double ret = stereoCalibrate(_objectPoints, _imagePoints1, _imagePoints2, _cameraMatrix1, _distCoeffs1,
                                  _cameraMatrix2, _distCoeffs2, imageSize, Rmat, Tmat, _Emat, _Fmat,
@@ -3542,8 +3564,10 @@ double cv::stereoCalibrate( InputArrayOfArrays _objectPoints,
                           Size imageSize, InputOutputArray _Rmat, InputOutputArray _Tmat,
                           OutputArray _Emat, OutputArray _Fmat,
                           OutputArray _perViewErrors, int flags ,
-                          TermCriteria criteria)
+                          TermCriteria criteria, int cameraModel)
 {
+    CV_Assert(cameraModel == CAMERA_MODEL_DEFAULT);
+
     int rtype = CV_64F;
     Mat cameraMatrix1 = _cameraMatrix1.getMat();
     Mat cameraMatrix2 = _cameraMatrix2.getMat();
@@ -3618,8 +3642,16 @@ void cv::stereoRectify( InputArray _cameraMatrix1, InputArray _distCoeffs1,
                         OutputArray _Pmat1, OutputArray _Pmat2,
                         OutputArray _Qmat, int flags,
                         double alpha, Size newImageSize,
-                        Rect* validPixROI1, Rect* validPixROI2 )
+                        Rect* validPixROI1, Rect* validPixROI2, int cameraModel )
 {
+    if (cameraModel == CAMERA_MODEL_FISHEYE) {
+        CV_Assert(alpha >= 0 && !validPixROI1 && !validPixROI2);
+        cv::fisheye::stereoRectify(_cameraMatrix1, _distCoeffs1, _cameraMatrix2, _distCoeffs2, imageSize,
+                                   _Rmat, _Tmat, _Rmat1, _Rmat2, _Pmat1, _Pmat2, _Qmat, flags, newImageSize,
+                                   alpha, 1);
+        return;
+    }
+
     Mat cameraMatrix1 = _cameraMatrix1.getMat(), cameraMatrix2 = _cameraMatrix2.getMat();
     Mat distCoeffs1 = _distCoeffs1.getMat(), distCoeffs2 = _distCoeffs2.getMat();
     Mat Rmat = _Rmat.getMat(), Tmat = _Tmat.getMat();
@@ -3671,9 +3703,17 @@ bool cv::stereoRectifyUncalibrated( InputArray _points1, InputArray _points2,
 cv::Mat cv::getOptimalNewCameraMatrix( InputArray _cameraMatrix,
                                        InputArray _distCoeffs,
                                        Size imgSize, double alpha, Size newImgSize,
-                                       Rect* validPixROI, bool centerPrincipalPoint )
+                                       Rect* validPixROI, bool centerPrincipalPoint, int cameraModel )
 {
     CV_INSTRUMENT_REGION()
+
+    if (cameraModel == CAMERA_MODEL_FISHEYE) {
+        CV_Assert(centerPrincipalPoint == false, !validPixROI);
+        Mat newCameraMatrix;
+        cv::fisheye::estimateNewCameraMatrixForUndistortRectify(
+            _cameraMatrix, _distCoeffs, imgSize, Matx33d::eye(), newCameraMatrix, alpha, newImgSize, 1);
+        return newCameraMatrix;
+    }
 
     Mat cameraMatrix = _cameraMatrix.getMat(), distCoeffs = _distCoeffs.getMat();
     CvMat c_cameraMatrix = cameraMatrix, c_distCoeffs = distCoeffs;

--- a/modules/calib3d/src/solvepnp.cpp
+++ b/modules/calib3d/src/solvepnp.cpp
@@ -55,7 +55,7 @@ namespace cv
 
 bool solvePnP( InputArray _opoints, InputArray _ipoints,
                InputArray _cameraMatrix, InputArray _distCoeffs,
-               OutputArray _rvec, OutputArray _tvec, bool useExtrinsicGuess, int flags )
+               OutputArray _rvec, OutputArray _tvec, bool useExtrinsicGuess, int flags, int cameraModel )
 {
     CV_INSTRUMENT_REGION()
 
@@ -100,7 +100,7 @@ bool solvePnP( InputArray _opoints, InputArray _ipoints,
     if (flags == SOLVEPNP_EPNP || flags == SOLVEPNP_DLS || flags == SOLVEPNP_UPNP)
     {
         Mat undistortedPoints;
-        undistortPoints(ipoints, undistortedPoints, cameraMatrix, distCoeffs);
+        undistortPoints(ipoints, undistortedPoints, cameraMatrix, distCoeffs, cameraModel);
         epnp PnP(cameraMatrix, opoints, undistortedPoints);
 
         Mat R;
@@ -112,7 +112,7 @@ bool solvePnP( InputArray _opoints, InputArray _ipoints,
     {
         CV_Assert( npoints == 4);
         Mat undistortedPoints;
-        undistortPoints(ipoints, undistortedPoints, cameraMatrix, distCoeffs);
+        undistortPoints(ipoints, undistortedPoints, cameraMatrix, distCoeffs, cameraModel);
         p3p P3Psolver(cameraMatrix);
 
         Mat R;
@@ -124,7 +124,7 @@ bool solvePnP( InputArray _opoints, InputArray _ipoints,
     {
         CV_Assert( npoints == 4);
         Mat undistortedPoints;
-        undistortPoints(ipoints, undistortedPoints, cameraMatrix, distCoeffs);
+        undistortPoints(ipoints, undistortedPoints, cameraMatrix, distCoeffs, cameraModel);
         ap3p P3Psolver(cameraMatrix);
 
         Mat R;
@@ -134,6 +134,7 @@ bool solvePnP( InputArray _opoints, InputArray _ipoints,
     }
     else if (flags == SOLVEPNP_ITERATIVE)
     {
+        CV_Assert(cameraModel == CAMERA_MODEL_DEFAULT);
         CvMat c_objectPoints = opoints, c_imagePoints = ipoints;
         CvMat c_cameraMatrix = cameraMatrix, c_distCoeffs = distCoeffs;
         CvMat c_rvec = rvec, c_tvec = tvec;
@@ -234,7 +235,7 @@ bool solvePnPRansac(InputArray _opoints, InputArray _ipoints,
                         InputArray _cameraMatrix, InputArray _distCoeffs,
                         OutputArray _rvec, OutputArray _tvec, bool useExtrinsicGuess,
                         int iterationsCount, float reprojectionError, double confidence,
-                        OutputArray _inliers, int flags)
+                        OutputArray _inliers, int flags, int cameraModel)
 {
     CV_INSTRUMENT_REGION()
 
@@ -282,7 +283,7 @@ bool solvePnPRansac(InputArray _opoints, InputArray _ipoints,
 
     if( model_points == npoints )
     {
-        bool result = solvePnP(opoints, ipoints, cameraMatrix, distCoeffs, _rvec, _tvec, useExtrinsicGuess, ransac_kernel_method);
+        bool result = solvePnP(opoints, ipoints, cameraMatrix, distCoeffs, _rvec, _tvec, useExtrinsicGuess, ransac_kernel_method, cameraModel);
 
         if(!result)
         {
@@ -304,6 +305,8 @@ bool solvePnPRansac(InputArray _opoints, InputArray _ipoints,
 
         return true;
     }
+
+    CV_Assert(cameraModel == CAMERA_MODEL_DEFAULT);
 
     Ptr<PointSetRegistrator::Callback> cb; // pointer to callback
     cb = makePtr<PnPRansacCallback>( cameraMatrix, distCoeffs, ransac_kernel_method, useExtrinsicGuess, rvec, tvec);
@@ -378,7 +381,7 @@ bool solvePnPRansac(InputArray _opoints, InputArray _ipoints,
 
 int solveP3P( InputArray _opoints, InputArray _ipoints,
               InputArray _cameraMatrix, InputArray _distCoeffs,
-              OutputArrayOfArrays _rvecs, OutputArrayOfArrays _tvecs, int flags) {
+              OutputArrayOfArrays _rvecs, OutputArrayOfArrays _tvecs, int flags, int cameraModel) {
     CV_INSTRUMENT_REGION()
 
     Mat opoints = _opoints.getMat(), ipoints = _ipoints.getMat();
@@ -392,7 +395,7 @@ int solveP3P( InputArray _opoints, InputArray _ipoints,
     Mat distCoeffs = Mat_<double>(distCoeffs0);
 
     Mat undistortedPoints;
-    undistortPoints(ipoints, undistortedPoints, cameraMatrix, distCoeffs);
+    undistortPoints(ipoints, undistortedPoints, cameraMatrix, distCoeffs, cameraModel);
     std::vector<Mat> Rs, ts;
 
     int solutions = 0;

--- a/modules/imgproc/include/opencv2/imgproc.hpp
+++ b/modules/imgproc/include/opencv2/imgproc.hpp
@@ -3106,14 +3106,14 @@ of 4, 5, 8, 12 or 14 elements. If the vector is NULL/empty, the zero distortion 
  */
 CV_EXPORTS_W void undistortPoints( InputArray src, OutputArray dst,
                                    InputArray cameraMatrix, InputArray distCoeffs,
-                                   InputArray R = noArray(), InputArray P = noArray());
+                                   InputArray R = noArray(), InputArray P = noArray(), int cameraModel = 0);
 /** @overload
     @note Default version of #undistortPoints does 5 iterations to compute undistorted points.
 
  */
 CV_EXPORTS_AS(undistortPointsIter) void undistortPoints( InputArray src, OutputArray dst,
                                    InputArray cameraMatrix, InputArray distCoeffs,
-                                   InputArray R, InputArray P, TermCriteria criteria);
+                                   InputArray R, InputArray P, TermCriteria criteria, int cameraModel = 0);
 
 //! @} imgproc_transform
 

--- a/modules/imgproc/src/undistort.cpp
+++ b/modules/imgproc/src/undistort.cpp
@@ -545,9 +545,10 @@ void cv::undistortPoints( InputArray _src, OutputArray _dst,
                           InputArray _cameraMatrix,
                           InputArray _distCoeffs,
                           InputArray _Rmat,
-                          InputArray _Pmat )
+                          InputArray _Pmat,
+                          int cameraModel)
 {
-    undistortPoints(_src, _dst, _cameraMatrix, _distCoeffs, _Rmat, _Pmat, TermCriteria(TermCriteria::MAX_ITER, 5, 0.01));
+    undistortPoints(_src, _dst, _cameraMatrix, _distCoeffs, _Rmat, _Pmat, TermCriteria(TermCriteria::MAX_ITER, 5, 0.01), cameraModel);
 }
 
 void cv::undistortPoints( InputArray _src, OutputArray _dst,
@@ -555,8 +556,11 @@ void cv::undistortPoints( InputArray _src, OutputArray _dst,
                           InputArray _distCoeffs,
                           InputArray _Rmat,
                           InputArray _Pmat,
-                          TermCriteria criteria)
+                          TermCriteria criteria,
+                          int cameraModel)
 {
+    CV_Assert(cameraModel == 0);
+
     Mat src = _src.getMat(), cameraMatrix = _cameraMatrix.getMat();
     Mat distCoeffs = _distCoeffs.getMat(), R = _Rmat.getMat(), P = _Pmat.getMat();
 


### PR DESCRIPTION
for #11015

- allow using default calib flags for fisheye functions
- forwarded the cameraModel flag where possible
- solvePnP will still fail with fisheye model in undistort points
  - as undistortPoints is in imgproc, while the fisheye version is in calib3d there is no forwarding
- the ccalib versions could be similarly integrated 