### PR TITLE
cuda: fix build

### DIFF
--- a/modules/cudaimgproc/src/hough_circles.cpp
+++ b/modules/cudaimgproc/src/hough_circles.cpp
@@ -215,8 +215,8 @@ namespace
             AutoBuffer<ushort2> newBuf_(centersCount);
             int newCount = 0;
 
-            ushort2* oldBuf = oldBuf_;
-            ushort2* newBuf = newBuf_;
+            ushort2* oldBuf = oldBuf_.data();
+            ushort2* newBuf = newBuf_.data();
 
             cudaSafeCall( cudaMemcpy(oldBuf, centers, centersCount * sizeof(ushort2), cudaMemcpyDeviceToHost) );
 

--- a/modules/cudastereo/src/stereocsbp.cpp
+++ b/modules/cudastereo/src/stereocsbp.cpp
@@ -172,7 +172,7 @@ namespace
 
         // compute sizes
         AutoBuffer<int> buf(levels_ * 3);
-        int* cols_pyr = buf;
+        int* cols_pyr = buf.data();
         int* rows_pyr = cols_pyr + levels_;
         int* nr_plane_pyr = rows_pyr + levels_;
 


### PR DESCRIPTION
use cv::AutoBuffer::data() to get data pointer

related #11719 

```
docker_image:Custom=ubuntu-cuda:16.04
```