### PR TITLE
Make TextFormat::Parse calls consistent.

### DIFF
--- a/modules/dnn/src/caffe/caffe_io.cpp
+++ b/modules/dnn/src/caffe/caffe_io.cpp
@@ -1120,7 +1120,7 @@ bool ReadProtoFromTextFile(const char* filename, Message* proto) {
     std::ifstream fs(filename, std::ifstream::in);
     CHECK(fs.is_open()) << "Can't open \"" << filename << "\"";
     IstreamInputStream input(&fs);
-    return google::protobuf::TextFormat::Parse(&input, proto);
+    return google::protobuf::TextFormat::Parser().Parse(&input, proto);
 }
 
 bool ReadProtoFromBinaryFile(const char* filename, Message* proto) {


### PR DESCRIPTION
Google pb does not have (or removed in 3.x series) Parser::Parser(bool) constructor, so the current code fails to compile.
This PR replaces it with static Parse call like in line 1136 of that file.