### PR TITLE
dnn(ocl4dnn): fix args for 'max_pool_forward' kernel

### DIFF
--- a/modules/dnn/src/ocl4dnn/src/ocl4dnn_pool.cpp
+++ b/modules/dnn/src/ocl4dnn/src/ocl4dnn_pool.cpp
@@ -132,9 +132,10 @@ bool OCL4DNNPool<Dtype>::Forward(const UMat& bottom,
                 width_,
                 pooled_height_,
                 pooled_width_,
-                ocl::KernelArg::PtrWriteOnly(top),
-                ocl::KernelArg::PtrWriteOnly(top_mask)
+                ocl::KernelArg::PtrWriteOnly(top)
             );
+            if (computeMaxIdx)
+                oclk_max_pool_forward.set(8, ocl::KernelArg::PtrWriteOnly(top_mask));  // TODO remove magic number. Extend cv::ocl::Kernel API
 
             ret = oclk_max_pool_forward.run(1, global, local, false);
         }


### PR DESCRIPTION
Fix messages like this:
> C++ exception with description "OpenCV(3.4.2-dev) modules/core/src/ocl.cpp:2995: error: (-220:Unknown error code -220) OpenCL error CL_INVALID_ARG_INDEX (-49) during call: clSetKernelArg('max_pool_forward_float', arg_index=8, cl_mem=0x524d2d0) in function 'set'