### PR TITLE
Support for Matx read/write by FileStorage

### DIFF
--- a/modules/core/include/opencv2/core/persistence.hpp
+++ b/modules/core/include/opencv2/core/persistence.hpp
@@ -777,7 +777,7 @@ template<typename _Tp, int m, int n> static inline void read(const FileNode& nod
     Mat temp;
     read(node, temp); // read as a Mat class
 
-    if ( !temp.data || temp.dims > 2 || temp.rows != m || temp.cols != n || temp.channels() != 1 )
+    if (temp.empty())
         value = default_matx;
     else
         value = Matx<_Tp, m, n>(temp);

--- a/modules/core/include/opencv2/core/persistence.hpp
+++ b/modules/core/include/opencv2/core/persistence.hpp
@@ -772,6 +772,17 @@ template<typename _Tp, int cn> static inline void read(const FileNode& node, Vec
     value = temp.size() != cn ? default_value : Vec<_Tp, cn>(&temp[0]);
 }
 
+template<typename _Tp, int m, int n> static inline void read(const FileNode& node, Matx<_Tp, m, n>& value, const Matx<_Tp, m, n>& default_matx = Matx<_Tp, m, n>())
+{
+    Mat temp;
+    read(node, temp); // read as a Mat class
+
+    if ( !temp.data || temp.dims > 2 || temp.rows != m || temp.cols != n || temp.channels() != 1 )
+        value = default_matx;
+    else
+        value = Matx<_Tp, m, n>(temp);
+}
+
 template<typename _Tp> static inline void read(const FileNode& node, Scalar_<_Tp>& value, const Scalar_<_Tp>& default_value)
 {
     std::vector<_Tp> temp; FileNodeIterator it = node.begin(); it >> temp;
@@ -952,6 +963,12 @@ void write(FileStorage& fs, const Vec<_Tp, cn>& v )
         write(fs, v.val[i]);
 }
 
+template<typename _Tp, int m, int n> static inline
+void write(FileStorage& fs, const Matx<_Tp, m, n>& x )
+{
+    write(fs, Mat(x)); // write as a Mat class
+}
+
 template<typename _Tp> static inline
 void write(FileStorage& fs, const Scalar_<_Tp>& s )
 {
@@ -1015,6 +1032,12 @@ void write(FileStorage& fs, const String& name, const Vec<_Tp, cn>& v )
 {
     cv::internal::WriteStructContext ws(fs, name, FileNode::SEQ+FileNode::FLOW);
     write(fs, v);
+}
+
+template<typename _Tp, int m, int n> static inline
+void write(FileStorage& fs, const String& name, const Matx<_Tp, m, n>& x )
+{
+    write(fs, name, Mat(x)); // write as a Mat class
 }
 
 template<typename _Tp> static inline

--- a/modules/core/test/test_io.cpp
+++ b/modules/core/test/test_io.cpp
@@ -1092,6 +1092,38 @@ TEST(Core_InputOutput, filestorage_yaml_advanvced_type_heading)
     ASSERT_EQ(cv::norm(inputMatrix, actualMatrix, NORM_INF), 0.);
 }
 
+TEST(Core_InputOutput, filestorage_matx_io)
+{
+    Matx33d matxTest(1.234, 2, 3, 4, 5, 6, 7, 8, 9.876);
+    Matx32d matxTestWrongSize(1, 2, 3, 4, 5, 6);
+    Mat normalMat = Mat::eye(3, 3, CV_64F);
+
+    std::vector<FileStorage::Mode> formats;
+    formats.push_back(FileStorage::Mode::FORMAT_JSON);
+    formats.push_back(FileStorage::Mode::FORMAT_XML);
+    formats.push_back(FileStorage::Mode::FORMAT_YAML);
+
+    for(size_t i = 0; i < formats.size(); i++)
+    {
+        FileStorage writer("", FileStorage::WRITE | FileStorage::MEMORY | formats[i]);
+        writer << "matxTest" << matxTest;
+        writer << "matxTestWrongSize" << matxTestWrongSize;
+        writer << "normalMat" << normalMat;
+        String content = writer.releaseAndGetString();
+
+        FileStorage reader(content, FileStorage::READ | FileStorage::MEMORY);
+        Matx33d matxTestRead;
+        reader["matxTest"] >> matxTestRead;
+        ASSERT_TRUE( cv::norm(matxTest, matxTestRead, NORM_INF) == 0 );
+        reader["matxTestWrongSize"] >> matxTestRead;
+        ASSERT_TRUE( cv::norm(Matx33d(), matxTestRead, NORM_INF) == 0 );
+        reader["normalMat"] >> matxTestRead;
+        ASSERT_TRUE( cv::norm(Mat::eye(3, 3, CV_64F), matxTestRead, NORM_INF) == 0 );
+
+        reader.release();
+    }
+}
+
 TEST(Core_InputOutput, filestorage_keypoints_vec_vec_io)
 {
     vector<vector<KeyPoint> > kptsVec;


### PR DESCRIPTION
resolves #11934
resolves #8148

### This pullrequest changes

Adds direct read and write support for the Matx class to FileStorage. Internally calls the read and write functions for the Mat class, so output format is identical and can be used interchangeably with Mat data types (so there will be no change to previous FileStorage output). If the read is empty, the default Matx (all zeros) is returned (similar to Vec), otherwise the data is passed to the Matx constructor. This may then throw an exception if the format or size are not correct.