### PR TITLE
dnn: preserve name, type strings for ShuffleChannelLayer

### DIFF
--- a/modules/dnn/src/layers/shuffle_channel_layer.cpp
+++ b/modules/dnn/src/layers/shuffle_channel_layer.cpp
@@ -14,6 +14,7 @@ public:
     ShuffleChannelLayerImpl(const LayerParams& params)
     {
         group = params.get<int>("group", 1);
+        setParamsFrom(params);
     }
 
     bool getMemoryShapes(const std::vector<MatShape> &inputs,


### PR DESCRIPTION
### This pullrequest changes
call setParamsFrom, so name & type get properly copied from the importer params