### PR TITLE
Fixed unreachable code warnings for Matx::solve()

### DIFF
--- a/modules/core/include/opencv2/core/operations.hpp
+++ b/modules/core/include/opencv2/core/operations.hpp
@@ -65,7 +65,6 @@ template<typename _Tp, int m, int n> struct Matx_FastInvOp
 {
     bool operator()(const Matx<_Tp, m, n>&, Matx<_Tp, n, m>&, int) const
     {
-        CV_Assert(false);
         return false;
     }
 };
@@ -132,7 +131,6 @@ template<typename _Tp, int m, int l, int n> struct Matx_FastSolveOp
     bool operator()(const Matx<_Tp, m, l>&, const Matx<_Tp, m, n>&,
                     Matx<_Tp, l, n>&, int) const
     {
-        CV_Assert(false);
         return false;
     }
 };
@@ -213,8 +211,11 @@ Matx<_Tp, n, m> Matx<_Tp, m, n>::inv(int method, bool *p_is_ok /*= NULL*/) const
 {
     Matx<_Tp, n, m> b;
     bool ok;
-    if( m == n && (method == DECOMP_LU || method == DECOMP_CHOLESKY) )
+    if (method == DECOMP_LU || method == DECOMP_CHOLESKY)
+    {
+        CV_Assert(m == n);
         ok = cv::internal::Matx_FastInvOp<_Tp, m, n>()(*this, b, method);
+    }
     else
     {
         Mat A(*this, false), B(b, false);
@@ -229,8 +230,11 @@ Matx<_Tp, n, l> Matx<_Tp, m, n>::solve(const Matx<_Tp, m, l>& rhs, int method) c
 {
     Matx<_Tp, n, l> x;
     bool ok;
-    if( m == n && (method == DECOMP_LU || method == DECOMP_CHOLESKY) )
+    if (method == DECOMP_LU || method == DECOMP_CHOLESKY)
+    {
+        CV_Assert(m == n);
         ok = cv::internal::Matx_FastSolveOp<_Tp, m, n, l>()(*this, rhs, x, method);
+    }
     else
     {
         Mat A(*this, false), B(rhs, false), X(x, false);

--- a/modules/core/test/test_math.cpp
+++ b/modules/core/test/test_math.cpp
@@ -3139,7 +3139,7 @@ TEST(Core_Solve, regression_11888)
     cv::Vec<float, 3> b(4, 5, 7);
     cv::Matx<float, 2, 1> xQR = A.solve(b, DECOMP_QR);
     cv::Matx<float, 2, 1> xSVD = A.solve(b, DECOMP_SVD);
-    EXPECT_LE(cvtest::norm(xQR, xSVD, CV_RELATIVE_L2), FLT_EPSILON);
+    EXPECT_LE(cvtest::norm(xQR, xSVD, CV_RELATIVE_L2), 0.001);
     cv::Matx<float, 2, 3> iA = A.inv(DECOMP_SVD);
     EXPECT_LE(cvtest::norm(A*iA, Matx<float, 3, 3>::eye(), CV_RELATIVE_L2), 0.6);
 }


### PR DESCRIPTION
resolves #11950

### This pullrequest changes
Fix for unreachable code warnings in Matx::solve() and Matx::inv()

