### PR TITLE
Fix fully-connected layer in case of number of rows less than 4

### DIFF
--- a/modules/dnn/src/ocl4dnn/src/math_functions.cpp
+++ b/modules/dnn/src/ocl4dnn/src/math_functions.cpp
@@ -612,7 +612,7 @@ bool ocl4dnnGEMV<float>(const CBLAS_TRANSPOSE TransA,
             ret = k.run(1, globalsize, localsize, false);
         }
 
-        if ((row_size % 4) != 0 && ret)
+        if (row_size < 4 || ((row_size % 4) != 0 && ret))
         {
             String kname = format("matvec_mul1_%s", use_half ? "half" : "float");
             ocl::Kernel k_1(kname.c_str(), cv::ocl::dnn::matvec_mul_oclsrc, opts);

--- a/modules/dnn/test/test_halide_layers.cpp
+++ b/modules/dnn/test/test_halide_layers.cpp
@@ -104,8 +104,14 @@ TEST_P(Convolution, Accuracy)
     int backendId = get<0>(get<7>(GetParam()));
     int targetId = get<1>(get<7>(GetParam()));
 
-    if ((backendId == DNN_BACKEND_INFERENCE_ENGINE && targetId == DNN_TARGET_MYRIAD) ||
-        (backendId == DNN_BACKEND_OPENCV && targetId == DNN_TARGET_OPENCL_FP16))
+    if (backendId == DNN_BACKEND_INFERENCE_ENGINE && targetId == DNN_TARGET_MYRIAD)
+        throw SkipTestException("");
+
+    // TODO: unstable test cases
+    if (backendId == DNN_BACKEND_OPENCV && (targetId == DNN_TARGET_OPENCL || targetId == DNN_TARGET_OPENCL_FP16) &&
+        inChannels == 6 && outChannels == 9 && group == 1 && inSize == Size(5, 6) &&
+        kernel == Size(3, 1) && stride == Size(1, 1) && pad == Size(0, 1) && dilation == Size(1, 1) &&
+        hasBias)
         throw SkipTestException("");
 
     int sz[] = {outChannels, inChannels / group, kernel.height, kernel.width};
@@ -353,8 +359,7 @@ TEST_P(FullyConnected, Accuracy)
     bool hasBias = get<3>(GetParam());
     int backendId = get<0>(get<4>(GetParam()));
     int targetId = get<1>(get<4>(GetParam()));
-    if (backendId == DNN_BACKEND_INFERENCE_ENGINE ||
-        (backendId == DNN_BACKEND_OPENCV && targetId == DNN_TARGET_OPENCL_FP16))
+    if (backendId == DNN_BACKEND_INFERENCE_ENGINE)
         throw SkipTestException("");
 
     Mat weights(outChannels, inChannels * inSize.height * inSize.width, CV_32F);
@@ -691,10 +696,6 @@ TEST_P(Eltwise, Accuracy)
     bool weighted = get<3>(GetParam());
     int backendId = get<0>(get<4>(GetParam()));
     int targetId = get<1>(get<4>(GetParam()));
-
-    if (backendId == DNN_BACKEND_OPENCV &&
-        (targetId == DNN_TARGET_OPENCL || targetId == DNN_TARGET_OPENCL_FP16))
-        throw SkipTestException("");
 
     Net net;
 


### PR DESCRIPTION
### This pullrequest changes

Fixes OpenCL test cases (see https://github.com/opencv/opencv/issues/11866)

```
force_builders=Custom
docker_image:Custom=ubuntu-openvino:16.04
buildworker:Custom=linux-2
test_opencl=ON
```