### PR TITLE
imgproc(getPerspectiveTransform): change solve() 'method' parameter

### DIFF
--- a/modules/imgproc/perf/perf_warp.cpp
+++ b/modules/imgproc/perf/perf_warp.cpp
@@ -271,7 +271,7 @@ void update_map(const Mat& src, Mat& map_x, Mat& map_y, const int remapMode )
     }
 }
 
-PERF_TEST(Transform, getPerspectiveTransform)
+PERF_TEST(Transform, getPerspectiveTransform_1000)
 {
     unsigned int size = 8;
     Mat source(1, size/2, CV_32FC2);
@@ -280,12 +280,14 @@ PERF_TEST(Transform, getPerspectiveTransform)
 
     declare.in(source, destination, WARMUP_RNG);
 
-    TEST_CYCLE()
+    PERF_SAMPLE_BEGIN()
+    for (int i = 0; i < 1000; i++)
     {
         transformCoefficient = getPerspectiveTransform(source, destination);
     }
+    PERF_SAMPLE_END()
 
-    SANITY_CHECK(transformCoefficient, 1e-5);
+    SANITY_CHECK_NOTHING();
 }
 
 } // namespace

--- a/modules/imgproc/src/imgwarp.cpp
+++ b/modules/imgproc/src/imgwarp.cpp
@@ -3061,7 +3061,7 @@ cv::Mat cv::getPerspectiveTransform( const Point2f src[], const Point2f dst[] )
         b[i+4] = dst[i].y;
     }
 
-    solve( A, B, X, DECOMP_SVD );
+    solve(A, B, X, DECOMP_LU);
     M.ptr<double>()[8] = 1.;
 
     return M;

--- a/modules/imgproc/src/imgwarp.cpp
+++ b/modules/imgproc/src/imgwarp.cpp
@@ -50,6 +50,7 @@
 #include "precomp.hpp"
 #include "opencl_kernels_imgproc.hpp"
 #include "hal_replacement.hpp"
+#include <opencv2/core/utils/configuration.private.hpp>
 #include "opencv2/core/hal/intrin.hpp"
 #include "opencv2/core/openvx/ovx_defs.hpp"
 #include "opencv2/core/softfloat.hpp"
@@ -3061,7 +3062,9 @@ cv::Mat cv::getPerspectiveTransform( const Point2f src[], const Point2f dst[] )
         b[i+4] = dst[i].y;
     }
 
-    solve(A, B, X, DECOMP_LU);
+    static int param_IMGPROC_GETPERSPECTIVETRANSFORM_SOLVE_METHOD =
+        (int)utils::getConfigurationParameterSizeT("OPENCV_IMGPROC_GETPERSPECTIVETRANSFORM_SOLVE_METHOD", (size_t)DECOMP_LU);
+    solve(A, B, X, param_IMGPROC_GETPERSPECTIVETRANSFORM_SOLVE_METHOD);
     M.ptr<double>()[8] = 1.;
 
     return M;


### PR DESCRIPTION
`DECOMP_SVD` -> `DECOMP_LU`

`getPerspectiveTransform()` requires to solve 8x8 linear system.

Performance is improved from 27.6 ms to 2.6 ms (1000 calls, i7-6700)

resolves #11944

```
allow_multiple_commits=1
```