### PR TITLE
3.4 - avx512 - optimize fastConv

### DIFF
--- a/modules/dnn/src/layers/layers_common.simd.hpp
+++ b/modules/dnn/src/layers/layers_common.simd.hpp
@@ -147,20 +147,20 @@ void fastConv( const float* weights, size_t wstep, const float* bias,
                     vs10_5 = _mm512_fmadd_ps(w1, r0, vs10_5);
                     vs20_5 = _mm512_fmadd_ps(w2, r0, vs20_5);
 
-                    r0 = _mm512_loadu_ps(rptr + vecsize_aligned);
-                    vs01_5 = _mm512_fmadd_ps(w0, r0, vs01_5);
-                    vs11_5 = _mm512_fmadd_ps(w1, r0, vs11_5);
-                    vs21_5 = _mm512_fmadd_ps(w2, r0, vs21_5);
+                    __m512 r1 = _mm512_loadu_ps(rptr + vecsize_aligned);
+                    vs01_5 = _mm512_fmadd_ps(w0, r1, vs01_5);
+                    vs11_5 = _mm512_fmadd_ps(w1, r1, vs11_5);
+                    vs21_5 = _mm512_fmadd_ps(w2, r1, vs21_5);
 
-                    r0 = _mm512_loadu_ps(rptr + vecsize_aligned*2);
-                    vs02_5 = _mm512_fmadd_ps(w0, r0, vs02_5);
-                    vs12_5 = _mm512_fmadd_ps(w1, r0, vs12_5);
-                    vs22_5 = _mm512_fmadd_ps(w2, r0, vs22_5);
+                    __m512 r2 = _mm512_loadu_ps(rptr + vecsize_aligned*2);
+                    vs02_5 = _mm512_fmadd_ps(w0, r2, vs02_5);
+                    vs12_5 = _mm512_fmadd_ps(w1, r2, vs12_5);
+                    vs22_5 = _mm512_fmadd_ps(w2, r2, vs22_5);
 
-                    r0 = _mm512_loadu_ps(rptr + vecsize_aligned*3);
-                    vs03_5 = _mm512_fmadd_ps(w0, r0, vs03_5);
-                    vs13_5 = _mm512_fmadd_ps(w1, r0, vs13_5);
-                    vs23_5 = _mm512_fmadd_ps(w2, r0, vs23_5);
+                    __m512 r3 = _mm512_loadu_ps(rptr + vecsize_aligned*3);
+                    vs03_5 = _mm512_fmadd_ps(w0, r3, vs03_5);
+                    vs13_5 = _mm512_fmadd_ps(w1, r3, vs13_5);
+                    vs23_5 = _mm512_fmadd_ps(w2, r3, vs23_5);
                 }
                 /*
                  * now fold the 512 bit accumulator vectors into 256 bit vectors so that the AVX2 code can finish

--- a/modules/dnn/src/layers/layers_common.simd.hpp
+++ b/modules/dnn/src/layers/layers_common.simd.hpp
@@ -129,6 +129,11 @@ void fastConv( const float* weights, size_t wstep, const float* bias,
 #if CV_AVX512_SKX // AVX512VL is necessary to avoid register spilling
             if (vecsize >= 32)
             {
+                __m512 r0 = _mm512_loadu_ps(rptr);
+                __m512 r1 = _mm512_loadu_ps(rptr + vecsize_aligned);
+                __m512 r2 = _mm512_loadu_ps(rptr + vecsize_aligned*2);
+                __m512 r3 = _mm512_loadu_ps(rptr + vecsize_aligned*3);
+
                 __m512 vs00_5 = _mm512_setzero_ps(), vs01_5 = _mm512_setzero_ps(),
                        vs02_5 = _mm512_setzero_ps(), vs03_5 = _mm512_setzero_ps(),
                        vs10_5 = _mm512_setzero_ps(), vs11_5 = _mm512_setzero_ps(),
@@ -136,28 +141,25 @@ void fastConv( const float* weights, size_t wstep, const float* bias,
                        vs20_5 = _mm512_setzero_ps(), vs21_5 = _mm512_setzero_ps(),
                        vs22_5 = _mm512_setzero_ps(), vs23_5 = _mm512_setzero_ps();
 
+
                 for (; k <= vecsize - 16; k += 16, rptr += 16)
                 {
                     __m512 w0 = _mm512_loadu_ps(wptr0 + k);
                     __m512 w1 = _mm512_loadu_ps(wptr1 + k);
                     __m512 w2 = _mm512_loadu_ps(wptr2 + k);
-                    __m512 r0 = _mm512_loadu_ps(rptr);
 
                     vs00_5 = _mm512_fmadd_ps(w0, r0, vs00_5);
                     vs10_5 = _mm512_fmadd_ps(w1, r0, vs10_5);
                     vs20_5 = _mm512_fmadd_ps(w2, r0, vs20_5);
 
-                    __m512 r1 = _mm512_loadu_ps(rptr + vecsize_aligned);
                     vs01_5 = _mm512_fmadd_ps(w0, r1, vs01_5);
                     vs11_5 = _mm512_fmadd_ps(w1, r1, vs11_5);
                     vs21_5 = _mm512_fmadd_ps(w2, r1, vs21_5);
 
-                    __m512 r2 = _mm512_loadu_ps(rptr + vecsize_aligned*2);
                     vs02_5 = _mm512_fmadd_ps(w0, r2, vs02_5);
                     vs12_5 = _mm512_fmadd_ps(w1, r2, vs12_5);
                     vs22_5 = _mm512_fmadd_ps(w2, r2, vs22_5);
 
-                    __m512 r3 = _mm512_loadu_ps(rptr + vecsize_aligned*3);
                     vs03_5 = _mm512_fmadd_ps(w0, r3, vs03_5);
                     vs13_5 = _mm512_fmadd_ps(w1, r3, vs13_5);
                     vs23_5 = _mm512_fmadd_ps(w2, r3, vs23_5);


### PR DESCRIPTION
### This pullrequest changes the avx512 fastConv DNN code

This pullrequest optimizes the inner loop of the avx512 fastConv DNN code, to pull
loop invariant data loads out of the main loop for performance.

<cut>

python2 ../modules/ts/misc/summary.py -o markdown base.xml optimized.xml

Geometric mean (ms)

|Name of Test|base|optimized|optimized vs base (x-factor)|
|---|:-:|:-:|:-:|
|AlexNet::DNNTestNetwork::(DNN_BACKEND_OPENCV, DNN_TARGET_CPU)|7.956|7.030|1.13|
|DenseNet_121::DNNTestNetwork::(DNN_BACKEND_OPENCV, DNN_TARGET_CPU)|32.999|30.922|1.07|
|EAST_text_detection::DNNTestNetwork::(DNN_BACKEND_OPENCV, DNN_TARGET_CPU)|49.023|44.758|1.10|
|ENet::DNNTestNetwork::(DNN_BACKEND_OPENCV, DNN_TARGET_CPU)|23.690|32.484|0.73|
|FastNeuralStyle_eccv16::DNNTestNetwork::(DNN_BACKEND_OPENCV, DNN_TARGET_CPU)|55.618|42.228|1.32|
|GoogLeNet::DNNTestNetwork::(DNN_BACKEND_OPENCV, DNN_TARGET_CPU)|11.968|10.533|1.14|
|Inception_5h::DNNTestNetwork::(DNN_BACKEND_OPENCV, DNN_TARGET_CPU)|12.918|11.492|1.12|
|Inception_v2_SSD_TensorFlow::DNNTestNetwork::(DNN_BACKEND_OPENCV, DNN_TARGET_CPU)|33.063|30.217|1.09|
|MobileNet_SSD_Caffe::DNNTestNetwork::(DNN_BACKEND_OPENCV, DNN_TARGET_CPU)|15.328|19.743|0.78|
|MobileNet_SSD_v1_TensorFlow::DNNTestNetwork::(DNN_BACKEND_OPENCV, DNN_TARGET_CPU)|17.951|18.468|0.97|
|MobileNet_SSD_v2_TensorFlow::DNNTestNetwork::(DNN_BACKEND_OPENCV, DNN_TARGET_CPU)|23.783|22.258|1.07|
|OpenFace::DNNTestNetwork::(DNN_BACKEND_OPENCV, DNN_TARGET_CPU)|4.302|4.183|1.03|
|OpenPose_pose_coco::DNNTestNetwork::(DNN_BACKEND_OPENCV, DNN_TARGET_CPU)|417.555|234.509|1.78|
|OpenPose_pose_mpi::DNNTestNetwork::(DNN_BACKEND_OPENCV, DNN_TARGET_CPU)|414.717|233.179|1.78|
|OpenPose_pose_mpi_faster_4_stages::DNNTestNetwork::(DNN_BACKEND_OPENCV, DNN_TARGET_CPU)|287.774|164.816|1.75|
|ResNet_50::DNNTestNetwork::(DNN_BACKEND_OPENCV, DNN_TARGET_CPU)|32.728|29.508|1.11|
|SSD::DNNTestNetwork::(DNN_BACKEND_OPENCV, DNN_TARGET_CPU)|166.672|123.101|1.35|
|SqueezeNet_v1_1::DNNTestNetwork::(DNN_BACKEND_OPENCV, DNN_TARGET_CPU)|2.992|2.771|1.08|
|YOLOv3::DNNTestNetwork::(DNN_BACKEND_OPENCV, DNN_TARGET_CPU)|133.227|96.852|1.38|
|opencv_face_detector::DNNTestNetwork::(DNN_BACKEND_OPENCV, DNN_TARGET_CPU)|11.318|9.530|1.19|
|perf::ConvolutionPerfTest::(1x1, ({ 1, 4, 224, 224 }, 64), GROUP_2, STRIDE_OFF)|0.291|0.287|1.02|
|perf::ConvolutionPerfTest::(1x1, ({ 1, 4, 224, 224 }, 64), GROUP_2, STRIDE_ON)|0.090|0.087|1.04|
|perf::ConvolutionPerfTest::(1x1, ({ 1, 4, 224, 224 }, 64), GROUP_OFF, STRIDE_OFF)|0.315|0.275|1.15|
|perf::ConvolutionPerfTest::(1x1, ({ 1, 4, 224, 224 }, 64), GROUP_OFF, STRIDE_ON)|0.085|0.084|1.01|
|perf::ConvolutionPerfTest::(1x1, ({ 1, 64, 112, 122 }, 128), GROUP_2, STRIDE_OFF)|0.334|0.319|1.05|
|perf::ConvolutionPerfTest::(1x1, ({ 1, 64, 112, 122 }, 128), GROUP_2, STRIDE_ON)|0.098|0.094|1.03|
|perf::ConvolutionPerfTest::(1x1, ({ 1, 64, 112, 122 }, 128), GROUP_OFF, STRIDE_OFF)|0.356|0.357|1.00|
|perf::ConvolutionPerfTest::(1x1, ({ 1, 64, 112, 122 }, 128), GROUP_OFF, STRIDE_ON)|0.111|0.105|1.06|
|perf::ConvolutionPerfTest::(1x1, ({ 1, 256, 28, 28 }, 512), GROUP_2, STRIDE_OFF)|0.159|0.148|1.08|
|perf::ConvolutionPerfTest::(1x1, ({ 1, 256, 28, 28 }, 512), GROUP_2, STRIDE_ON)|0.070|0.066|1.07|
|perf::ConvolutionPerfTest::(1x1, ({ 1, 256, 28, 28 }, 512), GROUP_OFF, STRIDE_OFF)|0.418|0.396|1.05|
|perf::ConvolutionPerfTest::(1x1, ({ 1, 256, 28, 28 }, 512), GROUP_OFF, STRIDE_ON)|0.190|0.189|1.01|
|perf::ConvolutionPerfTest::(3x3, ({ 1, 4, 224, 224 }, 64), GROUP_2, STRIDE_OFF)|0.499|0.491|1.02|
|perf::ConvolutionPerfTest::(3x3, ({ 1, 4, 224, 224 }, 64), GROUP_2, STRIDE_ON)|0.149|0.141|1.05|
|perf::ConvolutionPerfTest::(3x3, ({ 1, 4, 224, 224 }, 64), GROUP_OFF, STRIDE_OFF)|0.583|0.603|0.97|
|perf::ConvolutionPerfTest::(3x3, ({ 1, 4, 224, 224 }, 64), GROUP_OFF, STRIDE_ON)|0.185|0.180|1.03|
|perf::ConvolutionPerfTest::(3x3, ({ 1, 64, 112, 122 }, 128), GROUP_2, STRIDE_OFF)|1.562|1.092|1.43|
|perf::ConvolutionPerfTest::(3x3, ({ 1, 64, 112, 122 }, 128), GROUP_2, STRIDE_ON)|0.407|0.270|1.51|
|perf::ConvolutionPerfTest::(3x3, ({ 1, 64, 112, 122 }, 128), GROUP_OFF, STRIDE_OFF)|2.696|1.587|1.70|
|perf::ConvolutionPerfTest::(3x3, ({ 1, 64, 112, 122 }, 128), GROUP_OFF, STRIDE_ON)|0.714|0.419|1.70|
|perf::ConvolutionPerfTest::(3x3, ({ 1, 256, 28, 28 }, 512), GROUP_2, STRIDE_OFF)|1.237|0.797|1.55|
|perf::ConvolutionPerfTest::(3x3, ({ 1, 256, 28, 28 }, 512), GROUP_2, STRIDE_ON)|0.441|0.287|1.53|
|perf::ConvolutionPerfTest::(3x3, ({ 1, 256, 28, 28 }, 512), GROUP_OFF, STRIDE_OFF)|2.467|1.616|1.53|
|perf::ConvolutionPerfTest::(3x3, ({ 1, 256, 28, 28 }, 512), GROUP_OFF, STRIDE_ON)|1.018|0.717|1.42|
|perf::ConvolutionPerfTest::(5x5, ({ 1, 4, 224, 224 }, 64), GROUP_2, STRIDE_OFF)|0.786|0.782|1.01|
|perf::ConvolutionPerfTest::(5x5, ({ 1, 4, 224, 224 }, 64), GROUP_2, STRIDE_ON)|0.246|0.218|1.13|
|perf::ConvolutionPerfTest::(5x5, ({ 1, 4, 224, 224 }, 64), GROUP_OFF, STRIDE_OFF)|1.096|0.988|1.11|
|perf::ConvolutionPerfTest::(5x5, ({ 1, 4, 224, 224 }, 64), GROUP_OFF, STRIDE_ON)|0.300|0.255|1.17|
|perf::ConvolutionPerfTest::(5x5, ({ 1, 64, 112, 122 }, 128), GROUP_2, STRIDE_OFF)|4.370|2.506|1.74|
|perf::ConvolutionPerfTest::(5x5, ({ 1, 64, 112, 122 }, 128), GROUP_2, STRIDE_ON)|1.135|0.668|1.70|
|perf::ConvolutionPerfTest::(5x5, ({ 1, 64, 112, 122 }, 128), GROUP_OFF, STRIDE_OFF)|7.909|4.178|1.89|
|perf::ConvolutionPerfTest::(5x5, ({ 1, 64, 112, 122 }, 128), GROUP_OFF, STRIDE_ON)|2.050|1.083|1.89|
|perf::ConvolutionPerfTest::(5x5, ({ 1, 256, 28, 28 }, 512), GROUP_2, STRIDE_OFF)|2.944|1.685|1.75|
|perf::ConvolutionPerfTest::(5x5, ({ 1, 256, 28, 28 }, 512), GROUP_2, STRIDE_ON)|0.798|0.534|1.49|
|perf::ConvolutionPerfTest::(5x5, ({ 1, 256, 28, 28 }, 512), GROUP_OFF, STRIDE_OFF)|5.306|3.006|1.77|
|perf::ConvolutionPerfTest::(5x5, ({ 1, 256, 28, 28 }, 512), GROUP_OFF, STRIDE_ON)|1.503|1.106|1.36|
|perf::ConvolutionPerfTest::(11x11, ({ 1, 4, 224, 224 }, 64), GROUP_2, STRIDE_OFF)|0.308|0.299|1.03|
|perf::ConvolutionPerfTest::(11x11, ({ 1, 4, 224, 224 }, 64), GROUP_2, STRIDE_ON)|0.326|0.288|1.13|
|perf::ConvolutionPerfTest::(11x11, ({ 1, 4, 224, 224 }, 64), GROUP_OFF, STRIDE_OFF)|0.497|0.414|1.20|
|perf::ConvolutionPerfTest::(11x11, ({ 1, 4, 224, 224 }, 64), GROUP_OFF, STRIDE_ON)|0.483|0.396|1.22|
|perf::ConvolutionPerfTest::(11x11, ({ 1, 64, 112, 122 }, 128), GROUP_2, STRIDE_OFF)|2.351|1.215|1.93|
|perf::ConvolutionPerfTest::(11x11, ({ 1, 64, 112, 122 }, 128), GROUP_2, STRIDE_ON)|2.333|1.214|1.92|
|perf::ConvolutionPerfTest::(11x11, ({ 1, 64, 112, 122 }, 128), GROUP_OFF, STRIDE_OFF)|7.386|1.966|3.76|
|perf::ConvolutionPerfTest::(11x11, ({ 1, 64, 112, 122 }, 128), GROUP_OFF, STRIDE_ON)|7.436|1.958|3.80|
|perf::ConvolutionPerfTest::(11x11, ({ 1, 256, 28, 28 }, 512), GROUP_2, STRIDE_OFF)|2.696|2.131|1.27|
|perf::ConvolutionPerfTest::(11x11, ({ 1, 256, 28, 28 }, 512), GROUP_2, STRIDE_ON)|2.669|2.121|1.26|
|perf::ConvolutionPerfTest::(11x11, ({ 1, 256, 28, 28 }, 512), GROUP_OFF, STRIDE_OFF)|7.391|6.138|1.20|
|perf::ConvolutionPerfTest::(11x11, ({ 1, 256, 28, 28 }, 512), GROUP_OFF, STRIDE_ON)|7.665|5.855|1.31|
|perf::OCL_ConvolutionPerfTest::(1x1, ({ 1, 4, 224, 224 }, 64), GROUP_2, STRIDE_OFF)|0.337|0.285|1.19|
|perf::OCL_ConvolutionPerfTest::(1x1, ({ 1, 4, 224, 224 }, 64), GROUP_2, STRIDE_ON)|0.096|0.088|1.09|
|perf::OCL_ConvolutionPerfTest::(1x1, ({ 1, 4, 224, 224 }, 64), GROUP_OFF, STRIDE_OFF)|0.277|0.276|1.00|
|perf::OCL_ConvolutionPerfTest::(1x1, ({ 1, 4, 224, 224 }, 64), GROUP_OFF, STRIDE_ON)|0.094|0.088|1.07|
|perf::OCL_ConvolutionPerfTest::(1x1, ({ 1, 64, 112, 122 }, 128), GROUP_2, STRIDE_OFF)|0.295|0.318|0.93|
|perf::OCL_ConvolutionPerfTest::(1x1, ({ 1, 64, 112, 122 }, 128), GROUP_2, STRIDE_ON)|0.099|0.089|1.11|
|perf::OCL_ConvolutionPerfTest::(1x1, ({ 1, 64, 112, 122 }, 128), GROUP_OFF, STRIDE_OFF)|0.344|0.336|1.02|
|perf::OCL_ConvolutionPerfTest::(1x1, ({ 1, 64, 112, 122 }, 128), GROUP_OFF, STRIDE_ON)|0.118|0.107|1.10|
|perf::OCL_ConvolutionPerfTest::(1x1, ({ 1, 256, 28, 28 }, 512), GROUP_2, STRIDE_OFF)|0.158|0.160|0.99|
|perf::OCL_ConvolutionPerfTest::(1x1, ({ 1, 256, 28, 28 }, 512), GROUP_2, STRIDE_ON)|0.068|0.065|1.04|
|perf::OCL_ConvolutionPerfTest::(1x1, ({ 1, 256, 28, 28 }, 512), GROUP_OFF, STRIDE_OFF)|0.429|0.390|1.10|
|perf::OCL_ConvolutionPerfTest::(1x1, ({ 1, 256, 28, 28 }, 512), GROUP_OFF, STRIDE_ON)|0.193|0.191|1.01|
|perf::OCL_ConvolutionPerfTest::(3x3, ({ 1, 4, 224, 224 }, 64), GROUP_2, STRIDE_OFF)|0.569|0.481|1.18|
|perf::OCL_ConvolutionPerfTest::(3x3, ({ 1, 4, 224, 224 }, 64), GROUP_2, STRIDE_ON)|0.157|0.148|1.06|
|perf::OCL_ConvolutionPerfTest::(3x3, ({ 1, 4, 224, 224 }, 64), GROUP_OFF, STRIDE_OFF)|0.680|0.586|1.16|
|perf::OCL_ConvolutionPerfTest::(3x3, ({ 1, 4, 224, 224 }, 64), GROUP_OFF, STRIDE_ON)|0.176|0.185|0.95|
|perf::OCL_ConvolutionPerfTest::(3x3, ({ 1, 64, 112, 122 }, 128), GROUP_2, STRIDE_OFF)|1.571|1.083|1.45|
|perf::OCL_ConvolutionPerfTest::(3x3, ({ 1, 64, 112, 122 }, 128), GROUP_2, STRIDE_ON)|0.410|0.278|1.47|
|perf::OCL_ConvolutionPerfTest::(3x3, ({ 1, 64, 112, 122 }, 128), GROUP_OFF, STRIDE_OFF)|2.711|1.554|1.74|
|perf::OCL_ConvolutionPerfTest::(3x3, ({ 1, 64, 112, 122 }, 128), GROUP_OFF, STRIDE_ON)|0.713|0.422|1.69|
|perf::OCL_ConvolutionPerfTest::(3x3, ({ 1, 256, 28, 28 }, 512), GROUP_2, STRIDE_OFF)|1.238|0.796|1.56|
|perf::OCL_ConvolutionPerfTest::(3x3, ({ 1, 256, 28, 28 }, 512), GROUP_2, STRIDE_ON)|0.428|0.281|1.52|
|perf::OCL_ConvolutionPerfTest::(3x3, ({ 1, 256, 28, 28 }, 512), GROUP_OFF, STRIDE_OFF)|2.482|1.617|1.53|
|perf::OCL_ConvolutionPerfTest::(3x3, ({ 1, 256, 28, 28 }, 512), GROUP_OFF, STRIDE_ON)|1.029|0.704|1.46|
|perf::OCL_ConvolutionPerfTest::(5x5, ({ 1, 4, 224, 224 }, 64), GROUP_2, STRIDE_OFF)|0.789|0.829|0.95|
|perf::OCL_ConvolutionPerfTest::(5x5, ({ 1, 4, 224, 224 }, 64), GROUP_2, STRIDE_ON)|0.221|0.222|1.00|
|perf::OCL_ConvolutionPerfTest::(5x5, ({ 1, 4, 224, 224 }, 64), GROUP_OFF, STRIDE_OFF)|0.986|1.000|0.99|
|perf::OCL_ConvolutionPerfTest::(5x5, ({ 1, 4, 224, 224 }, 64), GROUP_OFF, STRIDE_ON)|0.273|0.274|1.00|
|perf::OCL_ConvolutionPerfTest::(5x5, ({ 1, 64, 112, 122 }, 128), GROUP_2, STRIDE_OFF)|4.373|2.518|1.74|
|perf::OCL_ConvolutionPerfTest::(5x5, ({ 1, 64, 112, 122 }, 128), GROUP_2, STRIDE_ON)|1.130|0.670|1.69|
|perf::OCL_ConvolutionPerfTest::(5x5, ({ 1, 64, 112, 122 }, 128), GROUP_OFF, STRIDE_OFF)|7.803|4.150|1.88|
|perf::OCL_ConvolutionPerfTest::(5x5, ({ 1, 64, 112, 122 }, 128), GROUP_OFF, STRIDE_ON)|2.035|1.105|1.84|
|perf::OCL_ConvolutionPerfTest::(5x5, ({ 1, 256, 28, 28 }, 512), GROUP_2, STRIDE_OFF)|2.975|1.671|1.78|
|perf::OCL_ConvolutionPerfTest::(5x5, ({ 1, 256, 28, 28 }, 512), GROUP_2, STRIDE_ON)|0.798|0.537|1.49|
|perf::OCL_ConvolutionPerfTest::(5x5, ({ 1, 256, 28, 28 }, 512), GROUP_OFF, STRIDE_OFF)|5.378|3.001|1.79|
|perf::OCL_ConvolutionPerfTest::(5x5, ({ 1, 256, 28, 28 }, 512), GROUP_OFF, STRIDE_ON)|1.493|1.208|1.24|
|perf::OCL_ConvolutionPerfTest::(11x11, ({ 1, 4, 224, 224 }, 64), GROUP_2, STRIDE_OFF)|0.305|0.286|1.06|
|perf::OCL_ConvolutionPerfTest::(11x11, ({ 1, 4, 224, 224 }, 64), GROUP_2, STRIDE_ON)|0.311|0.281|1.11|
|perf::OCL_ConvolutionPerfTest::(11x11, ({ 1, 4, 224, 224 }, 64), GROUP_OFF, STRIDE_OFF)|0.502|0.404|1.24|
|perf::OCL_ConvolutionPerfTest::(11x11, ({ 1, 4, 224, 224 }, 64), GROUP_OFF, STRIDE_ON)|0.499|0.406|1.23|
|perf::OCL_ConvolutionPerfTest::(11x11, ({ 1, 64, 112, 122 }, 128), GROUP_2, STRIDE_OFF)|2.347|1.238|1.90|
|perf::OCL_ConvolutionPerfTest::(11x11, ({ 1, 64, 112, 122 }, 128), GROUP_2, STRIDE_ON)|2.412|1.238|1.95|
|perf::OCL_ConvolutionPerfTest::(11x11, ({ 1, 64, 112, 122 }, 128), GROUP_OFF, STRIDE_OFF)|7.476|1.979|3.78|
|perf::OCL_ConvolutionPerfTest::(11x11, ({ 1, 64, 112, 122 }, 128), GROUP_OFF, STRIDE_ON)|7.494|1.924|3.90|
|perf::OCL_ConvolutionPerfTest::(11x11, ({ 1, 256, 28, 28 }, 512), GROUP_2, STRIDE_OFF)|2.676|2.140|1.25|
|perf::OCL_ConvolutionPerfTest::(11x11, ({ 1, 256, 28, 28 }, 512), GROUP_2, STRIDE_ON)|2.708|2.122|1.28|
|perf::OCL_ConvolutionPerfTest::(11x11, ({ 1, 256, 28, 28 }, 512), GROUP_OFF, STRIDE_OFF)|7.726|6.040|1.28|
|perf::OCL_ConvolutionPerfTest::(11x11, ({ 1, 256, 28, 28 }, 512), GROUP_OFF, STRIDE_ON)|7.853|6.199|1.27|


```
force_builders=Docs,linux,ocllinux,windows,ocl,macosx,oclmacosx,linuxNoOpt
buildworker:Custom=linux-3
docker_image:Custom=ubuntu:18.04
```