### PR TITLE
cmake: update DL IE detection to align with OpenVINO 2018 R2

### DIFF
--- a/cmake/OpenCVDetectInferenceEngine.cmake
+++ b/cmake/OpenCVDetectInferenceEngine.cmake
@@ -16,25 +16,27 @@ macro(ie_fail)
 endmacro()
 
 if(NOT HAVE_CXX11)
+    message(WARNING "DL Inference engine requires C++11. You can turn it on via ENABLE_CXX11=ON CMake flag.")
     ie_fail()
 endif()
 
+ocv_check_environment_variables(INTEL_CVSDK_DIR INF_ENGINE_ROOT_DIR IE_PLUGINS_PATH)
+
 if(NOT INF_ENGINE_ROOT_DIR OR NOT EXISTS "${INF_ENGINE_ROOT_DIR}/include/inference_engine.hpp")
     set(ie_root_paths "${INF_ENGINE_ROOT_DIR}")
-    if(DEFINED ENV{INTEL_CVSDK_DIR})
-        list(APPEND ie_root_paths "$ENV{INTEL_CVSDK_DIR}")
-        list(APPEND ie_root_paths "$ENV{INTEL_CVSDK_DIR}/inference_engine")
-    endif()
     if(DEFINED INTEL_CVSDK_DIR)
-        list(APPEND ie_root_paths "${INTEL_CVSDK_DIR}")
-        list(APPEND ie_root_paths "${INTEL_CVSDK_DIR}/inference_engine")
+        list(APPEND ie_root_paths "${INTEL_CVSDK_DIR}/")
+        list(APPEND ie_root_paths "${INTEL_CVSDK_DIR}/deployment_tools/inference_engine")
     endif()
 
     if(NOT ie_root_paths)
-        list(APPEND ie_root_paths "/opt/intel/deeplearning_deploymenttoolkit/deployment_tools/inference_engine")
+        list(APPEND ie_root_paths "/opt/intel/computer_vision_sdk/deployment_tools/inference_engine/")
     endif()
 
     find_path(INF_ENGINE_ROOT_DIR include/inference_engine.hpp PATHS ${ie_root_paths})
+    if(INF_ENGINE_ROOT_DIR MATCHES "-NOTFOUND$")
+      unset(INF_ENGINE_ROOT_DIR CACHE)
+    endif()
 endif()
 
 set(INF_ENGINE_INCLUDE_DIRS "${INF_ENGINE_ROOT_DIR}/include" CACHE PATH "Path to Inference Engine include directory")
@@ -43,6 +45,7 @@ if(NOT INF_ENGINE_ROOT_DIR
     OR NOT EXISTS "${INF_ENGINE_ROOT_DIR}"
     OR NOT EXISTS "${INF_ENGINE_ROOT_DIR}/include/inference_engine.hpp"
 )
+    message(WARNING "DL IE: Can't detect INF_ENGINE_ROOT_DIR location.")
     ie_fail()
 endif()
 
@@ -50,19 +53,19 @@ set(INF_ENGINE_LIBRARIES "")
 
 set(ie_lib_list inference_engine)
 
+if(NOT IS_ABSOLUTE "${IE_PLUGINS_PATH}")
+  set(IE_PLUGINS_PATH "${INF_ENGINE_ROOT_DIR}/${IE_PLUGINS_PATH}")
+endif()
+
 link_directories(
-  ${INTEL_CVSDK_DIR}/inference_engine/external/mkltiny_lnx/lib
-  ${INTEL_CVSDK_DIR}/inference_engine/external/cldnn/lib
+  ${INF_ENGINE_ROOT_DIR}/external/mkltiny_lnx/lib
+  ${INF_ENGINE_ROOT_DIR}/external/cldnn/lib
 )
 
 foreach(lib ${ie_lib_list})
-    find_library(${lib}
-        NAMES ${lib}
-        # For inference_engine
-        HINTS ${IE_PLUGINS_PATH}
-        HINTS "$ENV{IE_PLUGINS_PATH}"
-    )
+    find_library(${lib} NAMES ${lib} HINTS ${IE_PLUGINS_PATH})
     if(NOT ${lib})
+        message(WARNING "DL IE: Can't find library: '${lib}'")
         ie_fail()
     endif()
     list(APPEND INF_ENGINE_LIBRARIES ${${lib}})


### PR DESCRIPTION
These CMake options are enough:
- `-DWITH_INF_ENGINE=ON`
- `-DIE_PLUGINS_PATH=lib/ubuntu_16.04/intel64`
- `-DENABLE_CXX11=ON` (OpenCV 3.4 only)

```
force_builders=Custom
docker_image:Custom=ubuntu-openvino:16.04
buildworker:Custom=linux-1
test_opencl:Custom=ON
```