### PR TITLE
core: CV_NODISCARD macro with semantic of [[nodiscard]] attr

### DIFF
--- a/modules/core/include/opencv2/core/cvdef.h
+++ b/modules/core/include/opencv2/core/cvdef.h
@@ -407,6 +407,24 @@ Cv64suf;
 
 
 /****************************************************************************************\
+*                                  CV_NODISCARD attribute                                *
+* encourages the compiler to issue a warning if the return value is discarded (C++17)    *
+\****************************************************************************************/
+#ifndef CV_NODISCARD
+#  if defined(__GNUC__)
+#    define CV_NODISCARD __attribute__((__warn_unused_result__)) // at least available with GCC 3.4
+#  elif defined(__clang__) && defined(__has_attribute)
+#    if __has_attribute(__warn_unused_result__)
+#      define CV_NODISCARD __attribute__((__warn_unused_result__))
+#    endif
+#  endif
+#endif
+#ifndef CV_NODISCARD
+#  define CV_NODISCARD /* nothing by default */
+#endif
+
+
+/****************************************************************************************\
 *                                    C++ 11                                              *
 \****************************************************************************************/
 #ifndef CV_CXX11

--- a/modules/core/include/opencv2/core/mat.hpp
+++ b/modules/core/include/opencv2/core/mat.hpp
@@ -1171,7 +1171,7 @@ public:
     The method creates a full copy of the array. The original step[] is not taken into account. So, the
     array copy is a continuous array occupying total()*elemSize() bytes.
      */
-    Mat clone() const;
+    Mat clone() const CV_NODISCARD;
 
     /** @brief Copies the matrix to another one.
 
@@ -2262,7 +2262,7 @@ public:
     Mat_ row(int y) const;
     Mat_ col(int x) const;
     Mat_ diag(int d=0) const;
-    Mat_ clone() const;
+    Mat_ clone() const CV_NODISCARD;
 
     //! overridden forms of Mat::elemSize() etc.
     size_t elemSize() const;
@@ -2441,7 +2441,7 @@ public:
     static UMat diag(const UMat& d);
 
     //! returns deep copy of the matrix, i.e. the data is copied
-    UMat clone() const;
+    UMat clone() const CV_NODISCARD;
     //! copies the matrix content to "m".
     // It calls m.create(this->size(), this->type()).
     void copyTo( OutputArray m ) const;
@@ -2736,7 +2736,7 @@ public:
     SparseMat& operator = (const Mat& m);
 
     //! creates full copy of the matrix
-    SparseMat clone() const;
+    SparseMat clone() const CV_NODISCARD;
 
     //! copies all the data to the destination matrix. All the previous content of m is erased
     void copyTo( SparseMat& m ) const;
@@ -2973,7 +2973,7 @@ public:
     SparseMat_& operator = (const Mat& m);
 
     //! makes full copy of the matrix. All the elements are duplicated
-    SparseMat_ clone() const;
+    SparseMat_ clone() const CV_NODISCARD;
     //! equivalent to cv::SparseMat::create(dims, _sizes, DataType<_Tp>::type)
     void create(int dims, const int* _sizes);
     //! converts sparse matrix to the old-style CvSparseMat. All the elements are copied

--- a/modules/core/perf/perf_mat.cpp
+++ b/modules/core/perf/perf_mat.cpp
@@ -61,7 +61,8 @@ PERF_TEST_P(Size_MatType, Mat_Clone,
 
     TEST_CYCLE()
     {
-        source.clone();
+        Mat tmp = source.clone();
+        (void)tmp;
     }
     destination = source.clone();
 
@@ -88,7 +89,8 @@ PERF_TEST_P(Size_MatType, Mat_Clone_Roi,
 
     TEST_CYCLE()
     {
-        roi.clone();
+        Mat tmp = roi.clone();
+        (void)tmp;
     }
     destination = roi.clone();
 


### PR DESCRIPTION
`[[nodiscard]]` is defined in C++17.
There is fallback alias for modern GCC / Clang compilers.

Merge after #11989.


<cut/>

[Validated](http://pullrequest.opencv.org/buildbot/builders/precommit_macosx/builds/16098).

```
/build/precommit_macosx/3.4/opencv/modules/calib3d/src/calibinit.cpp:518:9: warning: ignoring return value of function declared with 'warn_unused_result' attribute [-Wunused-result]
        img.clone();
```


```
docker_image:Custom=fedora:28
```