### PR TITLE
ts: fix PERF_TEST() macro to allow test_case name reusing

### DIFF
--- a/modules/ts/include/opencv2/ts/ts_ext.hpp
+++ b/modules/ts/include/opencv2/ts/ts_ext.hpp
@@ -44,13 +44,13 @@ extern int testThreads;
 
 
 #undef TEST
-#define TEST_(test_case_name, test_name, BODY_IMPL) \
-    class GTEST_TEST_CLASS_NAME_(test_case_name, test_name) : public ::testing::Test {\
+#define TEST_(test_case_name, test_name, parent_class, bodyMethodName, BODY_IMPL) \
+    class GTEST_TEST_CLASS_NAME_(test_case_name, test_name) : public parent_class {\
      public:\
       GTEST_TEST_CLASS_NAME_(test_case_name, test_name)() {}\
      private:\
       virtual void TestBody() CV_OVERRIDE;\
-      virtual void Body();\
+      virtual void bodyMethodName();\
       static ::testing::TestInfo* const test_info_ GTEST_ATTRIBUTE_UNUSED_;\
       GTEST_DISALLOW_COPY_AND_ASSIGN_(\
           GTEST_TEST_CLASS_NAME_(test_case_name, test_name));\
@@ -62,14 +62,14 @@ extern int testThreads;
             #test_case_name, #test_name, NULL, NULL, \
             ::testing::internal::CodeLocation(__FILE__, __LINE__), \
             (::testing::internal::GetTestTypeId()), \
-            ::testing::Test::SetUpTestCase, \
-            ::testing::Test::TearDownTestCase, \
+            parent_class::SetUpTestCase, \
+            parent_class::TearDownTestCase, \
             new ::testing::internal::TestFactoryImpl<\
                 GTEST_TEST_CLASS_NAME_(test_case_name, test_name)>);\
     void GTEST_TEST_CLASS_NAME_(test_case_name, test_name)::TestBody() BODY_IMPL( #test_case_name "_" #test_name ) \
-    void GTEST_TEST_CLASS_NAME_(test_case_name, test_name)::Body()
+    void GTEST_TEST_CLASS_NAME_(test_case_name, test_name)::bodyMethodName()
 
-#define TEST(test_case_name, test_name) TEST_(test_case_name, test_name, CV__TEST_BODY_IMPL)
+#define TEST(test_case_name, test_name) TEST_(test_case_name, test_name, ::testing::Test, Body, CV__TEST_BODY_IMPL)
 
 #define CV__TEST_BIGDATA_BODY_IMPL(name) \
     { \
@@ -92,9 +92,9 @@ extern int testThreads;
 
 // Special type of tests which require / use or validate processing of huge amount of data (>= 2Gb)
 #if defined(_M_X64) || defined(__x86_64__) || defined(__aarch64__)
-#define BIGDATA_TEST(test_case_name, test_name) TEST_(BigData_ ## test_case_name, test_name, CV__TEST_BIGDATA_BODY_IMPL)
+#define BIGDATA_TEST(test_case_name, test_name) TEST_(BigData_ ## test_case_name, test_name, ::testing::Test, Body, CV__TEST_BIGDATA_BODY_IMPL)
 #else
-#define BIGDATA_TEST(test_case_name, test_name) TEST_(BigData_ ## test_case_name, DISABLED_ ## test_name, CV__TEST_BIGDATA_BODY_IMPL)
+#define BIGDATA_TEST(test_case_name, test_name) TEST_(BigData_ ## test_case_name, DISABLED_ ## test_name, ::testing::Test, Body, CV__TEST_BIGDATA_BODY_IMPL)
 #endif
 
 #undef TEST_F

--- a/modules/ts/include/opencv2/ts/ts_perf.hpp
+++ b/modules/ts/include/opencv2/ts/ts_perf.hpp
@@ -546,17 +546,7 @@ void PrintTo(const Size& sz, ::std::ostream* os);
 //     EXPECT_TRUE(foo.StatusIsOK());
 //   }
 #define PERF_TEST(test_case_name, test_name)\
-    namespace PERF_PROXY_NAMESPACE_NAME_(test_case_name, test_name) {\
-     class TestBase {/*compile error for this class means that you are trying to use perf::TestBase as a fixture*/};\
-     class test_case_name : public ::perf::TestBase {\
-      public:\
-       test_case_name() {}\
-      protected:\
-       virtual void PerfTestBody();\
-     };\
-     TEST_F(test_case_name, test_name){ CV__PERF_TEST_BODY_IMPL(#test_case_name "_" #test_name); }\
-    }\
-    void PERF_PROXY_NAMESPACE_NAME_(test_case_name, test_name)::test_case_name::PerfTestBody()
+    TEST_(test_case_name, test_name, ::perf::TestBase, PerfTestBody, CV__PERF_TEST_BODY_IMPL)
 
 // Defines a performance test that uses a test fixture.
 //


### PR DESCRIPTION
Example (reuse 'Transform' test case):
```
PERF_TEST(Transform, getPerspectiveTransform_1000) { ... }
PERF_TEST(Transform, getPerspectiveTransform_QR_1000) { ... }
```

```
buildworker:Linux OpenCL=linux-1
buildworker:Win64 OpenCL=windows-2
```