### PR TITLE
Run entire SSDs from TensorFlow using Intel's Inference Engine

### DIFF
--- a/modules/dnn/test/test_tf_importer.cpp
+++ b/modules/dnn/test/test_tf_importer.cpp
@@ -309,7 +309,7 @@ TEST_P(Test_TensorFlow_nets, Inception_v2_SSD)
                                     0, 10, 0.95932811, 0.38349164, 0.32528657, 0.40387636, 0.39165527,
                                     0, 10, 0.93973452, 0.66561931, 0.37841269, 0.68074018, 0.42907384);
     double scoreDiff = (target == DNN_TARGET_OPENCL_FP16 || target == DNN_TARGET_MYRIAD) ? 5e-3 : default_l1;
-    double iouDiff = (target == DNN_TARGET_OPENCL_FP16 || target == DNN_TARGET_MYRIAD) ? 0.025 : default_lInf;
+    double iouDiff = (target == DNN_TARGET_OPENCL_FP16 || target == DNN_TARGET_MYRIAD) ? 0.09 : default_lInf;
     normAssertDetections(ref, out, "", 0.5, scoreDiff, iouDiff);
 }
 


### PR DESCRIPTION
### This pullrequest changes

**Merge with extra**: https://github.com/opencv/opencv_extra/pull/492

SSD networks produce base bounding boxes (anchors, priors, proposals) and predict deltas for it's coordinates. For now SSDs from TensorFlow predict values in `ymin, xmin, ymax, xmax` order but PriorBox layer and DetectionOutput layer produce outputs in `xmin, ymin, xmax, ymax` coordinates order. There is `loc_pred_transposed` flag which indicates layout of predictions at `DetectionOutput` layer (to distinguish between Caffe's SSDs and TensorFlow's ones). However this mode doesn't supported in Intel's Inference Engine so all the graphs have three output layers and OpenCV runs a local `DetectionOutput`.

https://github.com/opencv/opencv/blob/51074b9743a36996af60bb5f8dbcddb71efe73b2/modules/dnn/src/layers/detection_output_layer.cpp#L833-L846

This PR adds the same flag to final convolution layers which let us to swap weights so these layers get predictions in `xmin, ymin, xmax, ymax` order. It's useful for the future support of Faster-RCNN model using IE (see https://github.com/opencv/opencv/issues/11983) that has an intermediate DetectionOuput layer.

There is an out-of-date MobileNet-SSD (ssd_mobilenet_v1_coco.pb) with old version of graph.

Additionally, removed 3d->4d reshapes because clDNN plugin of IE didn't support 3d outputs.

Observed up to 10% efficiency improvement for SSDs from TensorFlow.

Model name       |   Backend, Target                                    | 3.4     | PR       | x-factor|
---|---|---|---|---
Inception_v2_SSD | DNN_BACKEND_INFERENCE_ENGINE, DNN_TARGET_CPU         | 26.730  | 25.937   |  1.03   |
Inception_v2_SSD | DNN_BACKEND_INFERENCE_ENGINE, DNN_TARGET_MYRIAD      | 335.945 | 334.882  |  1.00   |
Inception_v2_SSD | DNN_BACKEND_INFERENCE_ENGINE, DNN_TARGET_OPENCL      | 50.922  | 50.328   |  1.01   |
Inception_v2_SSD | DNN_BACKEND_INFERENCE_ENGINE, DNN_TARGET_OPENCL_FP16 | 36.242  | 35.453   |  1.02   |
Inception_v2_SSD | DNN_BACKEND_OPENCV, DNN_TARGET_CPU                   | 42.982  | 42.694   |  1.01   |
Inception_v2_SSD | DNN_BACKEND_OPENCV, DNN_TARGET_OPENCL                | 50.886  | 51.038   |  1.00   |
Inception_v2_SSD | DNN_BACKEND_OPENCV, DNN_TARGET_OPENCL_FP16           | 61.116  | 61.438   |  0.99   |
MobileNet_SSD_v1 | DNN_BACKEND_INFERENCE_ENGINE, DNN_TARGET_CPU         |  8.692  |  7.896   |**1.10** |
MobileNet_SSD_v1 | DNN_BACKEND_INFERENCE_ENGINE, DNN_TARGET_MYRIAD      | 99.988  | 99.320   |  1.01   |
MobileNet_SSD_v1 | DNN_BACKEND_INFERENCE_ENGINE, DNN_TARGET_OPENCL      | 25.392  | 24.713   |  1.03   |
MobileNet_SSD_v1 | DNN_BACKEND_INFERENCE_ENGINE, DNN_TARGET_OPENCL_FP16 | 19.035  | 18.259   |  1.04   |
MobileNet_SSD_v1 | DNN_BACKEND_OPENCV, DNN_TARGET_CPU                   | 23.166  | 22.138   |  1.05   |
MobileNet_SSD_v1 | DNN_BACKEND_OPENCV, DNN_TARGET_OPENCL                | 19.366  | 19.440   |  1.00   |
MobileNet_SSD_v1 | DNN_BACKEND_OPENCV, DNN_TARGET_OPENCL_FP16           | 24.692  | 24.854   |  0.99   |
MobileNet_SSD_v2 | DNN_BACKEND_INFERENCE_ENGINE, DNN_TARGET_CPU         | 13.709  | 12.590   |**1.09** |
MobileNet_SSD_v2 | DNN_BACKEND_INFERENCE_ENGINE, DNN_TARGET_MYRIAD      | 162.614 | 160.938  |  1.01   |
MobileNet_SSD_v2 | DNN_BACKEND_INFERENCE_ENGINE, DNN_TARGET_OPENCL      | 31.778  | 31.173   |  1.02   |
MobileNet_SSD_v2 | DNN_BACKEND_INFERENCE_ENGINE, DNN_TARGET_OPENCL_FP16 | 25.696  | 24.917   |  1.03   |
MobileNet_SSD_v2 | DNN_BACKEND_OPENCV, DNN_TARGET_CPU                   | 30.943  | 30.827   |  1.00   |
MobileNet_SSD_v2 | DNN_BACKEND_OPENCV, DNN_TARGET_OPENCL                | 30.145  | 30.167   |  1.00   |
MobileNet_SSD_v2 | DNN_BACKEND_OPENCV, DNN_TARGET_OPENCL_FP16           | 34.930  | 34.913   |  1.00   |

```
force_builders=Custom
docker_image:Custom=ubuntu-openvino:16.04
buildworker:Custom=linux-1
test_opencl:Custom=ON
```
