### PR TITLE
TF import : Allow a different input order for Mul+Maximum (ReLU)

### DIFF
--- a/modules/dnn/src/tensorflow/tf_importer.cpp
+++ b/modules/dnn/src/tensorflow/tf_importer.cpp
@@ -1260,7 +1260,13 @@ void TFImporter::populateNet(Net dstNet)
                     if (!next_layers.empty())
                     {
                         int maximumLayerIdx = next_layers[0].second;
-                        ExcludeLayer(net, maximumLayerIdx, 0, false);
+
+                        CV_Assert(net.node(maximumLayerIdx).input_size() == 2);
+
+                        // The input from the Mul layer can also be at index 1.
+                        int mulInputIdx = (net.node(maximumLayerIdx).input(0) == name) ? 0 : 1;
+
+                        ExcludeLayer(net, maximumLayerIdx, mulInputIdx, false);
                         layers_to_ignore.insert(next_layers[0].first);
 
                         layerParams.set("negative_slope", scaleMat.at<float>(0));

--- a/modules/dnn/test/test_tf_importer.cpp
+++ b/modules/dnn/test/test_tf_importer.cpp
@@ -230,6 +230,13 @@ TEST_P(Test_TensorFlow_layers, flatten)
     runTensorFlowNet("unfused_flatten_unknown_batch");
 }
 
+TEST_P(Test_TensorFlow_layers, leaky_relu)
+{
+    runTensorFlowNet("leaky_relu_order1");
+    runTensorFlowNet("leaky_relu_order2");
+    runTensorFlowNet("leaky_relu_order3");
+}
+
 TEST_P(Test_TensorFlow_layers, l2_normalize)
 {
     runTensorFlowNet("l2_normalize");


### PR DESCRIPTION
<!-- Please use this line to close one or multiple issues when this pullrequest gets merged
You can add another line right under the first one:
resolves #1234
resolves #1235
-->
resolves #12024

This pullrequest adds a simple check for the input index of the Mul node in the Maximum node to solve the issue.

<!-- Please describe what your pullrequest is changing -->
