### PR TITLE
Do not copy cv_cpu_helper.h to parent if OpenCV is a submodule

### DIFF
--- a/cmake/OpenCVCompilerOptimizations.cmake
+++ b/cmake/OpenCVCompilerOptimizations.cmake
@@ -740,7 +740,7 @@ macro(ocv_compiler_optimization_fill_cpu_config)
 ")
 
 
-  set(__file "${CMAKE_SOURCE_DIR}/modules/core/include/opencv2/core/cv_cpu_helper.h")
+  set(__file "${OpenCV_SOURCE_DIR}/modules/core/include/opencv2/core/cv_cpu_helper.h")
   if(EXISTS "${__file}")
     file(READ "${__file}" __content)
   endif()


### PR DESCRIPTION
<!-- Please use this line to close one or multiple issues when this pullrequest gets merged
You can add another line right under the first one:
resolves #1234
resolves #1235
-->

### This pullrequest changes

```
|-- test_cv
    |-- 3rdparty
        |-- opencv
    |-- build
    CMakeLists.txt
```

```
mkdir test_cv && cd test_cv
mkdir build

git init
mkdir 3rdparty && cd 3rdparty
git submodule add https://github.com/opencv/opencv.git

mkdir ../build
cmake ..
```

corresponding CMakeLists.txt:
```cmake
cmake_minimum_required(VERSION 2.8)
project(test_cv)
add_subdirectory(3rdparty/opencv)
```

cmake copies cv_cpu_helper.h to a parent project:

```
|-- test_cv
    |-- 3rdparty
        |-- opencv
    |-- build
    |-- modules
        |-- core
            |-- include
                |-- opencv2
                    |-- core
                        cv_cpu_helper.h
    CMakeLists.txt
```