### PR TITLE
Increase the performance

### DIFF
--- a/modules/calib3d/src/stereobm.cpp
+++ b/modules/calib3d/src/stereobm.cpp
@@ -1089,15 +1089,9 @@ protected:
 class StereoBMImpl CV_FINAL : public StereoBM
 {
 public:
-    StereoBMImpl()
-    {
-        params = StereoBMParams();
-    }
+    StereoBMImpl() : params(StereoBMParams()) {}
 
-    StereoBMImpl( int _numDisparities, int _SADWindowSize )
-    {
-        params = StereoBMParams(_numDisparities, _SADWindowSize);
-    }
+    StereoBMImpl( int _numDisparities, int _SADWindowSize ) : params(StereoBMParams(_numDisparities, _SADWindowSize)) {}
 
     void compute( InputArray leftarr, InputArray rightarr, OutputArray disparr ) CV_OVERRIDE
     {


### PR DESCRIPTION
Increase the performance by removing the assignment to the params variable in the constructor (which is very bad) and using the implementation through the default parameters