### PR TITLE
core:avx2 fix unaligned store for v_store_interleave v_uint32x8-3ch

### DIFF
--- a/modules/core/include/opencv2/core/hal/intrin_avx.hpp
+++ b/modules/core/include/opencv2/core/hal/intrin_avx.hpp
@@ -2156,9 +2156,9 @@ inline void v_store_interleave( unsigned* ptr, const v_uint32x8& b, const v_uint
     }
     else
     {
-        _mm256_stream_si256((__m256i*)ptr, bgr0);
-        _mm256_stream_si256((__m256i*)(ptr + 8), p2);
-        _mm256_stream_si256((__m256i*)(ptr + 16), bgr2);
+        _mm256_storeu_si256((__m256i*)ptr, bgr0);
+        _mm256_storeu_si256((__m256i*)(ptr + 8), p2);
+        _mm256_storeu_si256((__m256i*)(ptr + 16), bgr2);
     }
 }
 


### PR DESCRIPTION
maybe related to #12086, #12085, #12084 discovered by #12056

resolves #12086
resolves #12085 
resolves #12084