### PR TITLE
Support WITH_CUDA with clang compiler.

### DIFF
--- a/cmake/OpenCVDetectCUDA.cmake
+++ b/cmake/OpenCVDetectCUDA.cmake
@@ -3,7 +3,7 @@ if(WIN32 AND NOT MSVC)
   return()
 endif()
 
-if(NOT APPLE AND CV_CLANG)
+if(NOT UNIX AND CV_CLANG)
   message(STATUS "CUDA compilation is disabled (due to Clang unsupported on your platform).")
   return()
 endif()
@@ -187,6 +187,13 @@ if(CUDA_FOUND)
   macro(ocv_cuda_filter_options)
     foreach(var CMAKE_CXX_FLAGS CMAKE_CXX_FLAGS_RELEASE CMAKE_CXX_FLAGS_DEBUG)
       set(${var}_backup_in_cuda_compile_ "${${var}}")
+
+      if (CV_CLANG)
+        # we remove -Winconsistent-missing-override and -Qunused-arguments
+        # just in case we are compiling CUDA with gcc but OpenCV with clang
+        string(REPLACE "-Winconsistent-missing-override" "" ${var} "${${var}}")
+        string(REPLACE "-Qunused-arguments" "" ${var} "${${var}}")
+      endif()
 
       # we remove /EHa as it generates warnings under windows
       string(REPLACE "/EHa" "" ${var} "${${var}}")


### PR DESCRIPTION
resolves #11354
### This pullrequest changes
Allows compiling CUDA OpenCV with a clang compiler (which is a valid scenario supported by CUDA).
Allows compiling CUDA OpenCV with a clang compiler but using gcc for the cuda compiler (CUDA_HOST_COMPILER=/usr/bin/gcc). This is also an extremely common scenario as the latest versions of gcc and clang are not supported by Clang, so you often need to specify an older (usually gcc) compiler. Arch-based distros install gcc-5 with cuda.

Note: CUDA still throws warnings about -Wmissing-prototypes and -Wstrict-prototypes when compiling CUDA with gcc but OpenCV with clang. This is because they share CXX flags and there is no checks done to see what the cuda compiler is. Crucially, it compiles


```
force_builders=Custom
docker_image:Custom=ubuntu-cuda:16.04
```