### PR TITLE
feat(stitching): Add Sift support for the FeaturesFinder

### DIFF
--- a/modules/stitching/include/opencv2/stitching/detail/matchers.hpp
+++ b/modules/stitching/include/opencv2/stitching/detail/matchers.hpp
@@ -137,6 +137,21 @@ private:
     Ptr<Feature2D> surf;
 };
 
+
+/** @brief SIFT features finder.
+
+@sa detail::FeaturesFinder, SIFT
+*/
+class CV_EXPORTS SiftFeaturesFinder : public FeaturesFinder
+{
+public:
+    SiftFeaturesFinder();
+
+private:
+    void find(InputArray image, ImageFeatures &features) CV_OVERRIDE;
+    Ptr<Feature2D> sift;
+};
+
 /** @brief ORB features finder. :
 
 @sa detail::FeaturesFinder, ORB

--- a/modules/stitching/src/matchers.cpp
+++ b/modules/stitching/src/matchers.cpp
@@ -51,6 +51,7 @@ using namespace cv::cuda;
 #ifdef HAVE_OPENCV_XFEATURES2D
 #include "opencv2/xfeatures2d.hpp"
 using xfeatures2d::SURF;
+using xfeatures2d::SIFT;
 #endif
 
 #ifdef HAVE_OPENCV_CUDAIMGPROC
@@ -478,6 +479,35 @@ void SurfFeaturesFinder::find(InputArray image, ImageFeatures &features)
         surf->detectAndCompute(gray_image, Mat(), features.keypoints, descriptors);
         features.descriptors = descriptors.reshape(1, (int)features.keypoints.size());
     }
+}
+
+SiftFeaturesFinder::SiftFeaturesFinder()
+{
+#ifdef HAVE_OPENCV_XFEATURES2D
+    Ptr<SIFT> sift_ = SIFT::create();
+    if( !sift_ )
+        CV_Error( Error::StsNotImplemented, "OpenCV was built without SIFT support" );
+    sift = sift_;
+#else
+    CV_Error( Error::StsNotImplemented, "OpenCV was built without SIFT support" );
+#endif
+}
+
+void SiftFeaturesFinder::find(InputArray image, ImageFeatures &features)
+{
+    UMat gray_image;
+    CV_Assert((image.type() == CV_8UC3) || (image.type() == CV_8UC1));
+    if(image.type() == CV_8UC3)
+    {
+        cvtColor(image, gray_image, COLOR_BGR2GRAY);
+    }
+    else
+    {
+        gray_image = image.getUMat();
+    }
+    UMat descriptors;
+    sift->detectAndCompute(gray_image, Mat(), features.keypoints, descriptors);
+    features.descriptors = descriptors.reshape(1, (int)features.keypoints.size());
 }
 
 OrbFeaturesFinder::OrbFeaturesFinder(Size _grid_size, int n_features, float scaleFactor, int nlevels)

--- a/samples/cpp/stitching_detailed.cpp
+++ b/samples/cpp/stitching_detailed.cpp
@@ -82,7 +82,7 @@ static void printUsage()
         "\nMotion Estimation Flags:\n"
         "  --work_megapix <float>\n"
         "      Resolution for image registration step. The default is 0.6 Mpx.\n"
-        "  --features (surf|orb)\n"
+        "  --features (surf|orb|sift)\n"
         "      Type of features used for images matching. The default is surf.\n"
         "  --matcher (homography|affine)\n"
         "      Matcher used for pairwise image matching.\n"
@@ -429,6 +429,9 @@ int main(int argc, char* argv[])
     else if (features_type == "orb")
     {
         finder = makePtr<OrbFeaturesFinder>();
+    }
+    else if (features_type == "sift") {
+        finder = makePtr<SiftFeaturesFinder>();
     }
     else
     {


### PR DESCRIPTION
Allow the use of SIFT FeaturesFinder for the `stitching_detailed` example.