### PR TITLE
Update cap_gstreamer.cpp

### DIFF
--- a/modules/videoio/src/cap_gstreamer.cpp
+++ b/modules/videoio/src/cap_gstreamer.cpp
@@ -613,10 +613,12 @@ int GStreamerCapture::getCaptureDomain() { return CAP_GSTREAMER; }
  */
 bool GStreamerCapture::open(int id)
 {
+    gst_initializer::init();
+
     if (!is_gst_element_exists("v4l2src"))
         return false;
     std::ostringstream desc;
-    desc << "v4l2src device-name=/dev/video" << id
+    desc << "v4l2src device=/dev/video" << id
              << " ! " << COLOR_ELEM
              << " ! appsink";
     return open(desc.str());


### PR DESCRIPTION
fixed call VideoCapturer::open(int id, cv::CAP_GSTREAMER) failed, 
because gst_init() never be called

### This pullrequest changes

call gst_init(), use use v4l2src "device" property instead of "device-name"

```
force_builders=Custom,docs,linux
#docker_image:Custom=gstreamer:14.04
docker_image:Custom=gstreamer:16.04
```