### PR TITLE
core: dump neighbour cache directories (from old OpenCV versions)

### DIFF
--- a/modules/core/src/utils/filesystem.cpp
+++ b/modules/core/src/utils/filesystem.cpp
@@ -469,7 +469,32 @@ cv::String getCacheDirectory(const char* sub_directory_name, const char* configu
         {
             if (utils::fs::isDirectory(default_cache_path))
             {
-                default_cache_path = utils::fs::join(default_cache_path, utils::fs::join("opencv", CV_VERSION));
+                cv::String default_cache_path_base = utils::fs::join(default_cache_path, "opencv");
+                default_cache_path = utils::fs::join(default_cache_path_base, "3.4.x" CV_VERSION_STATUS);
+                if (utils::getConfigurationParameterBool("OPENCV_CACHE_SHOW_CLEANUP_MESSAGE", true)
+                    && !utils::fs::isDirectory(default_cache_path))
+                {
+                    std::vector<cv::String> existedCacheDirs;
+                    try
+                    {
+                        utils::fs::glob_relative(default_cache_path_base, "*", existedCacheDirs, false, true);
+                    }
+                    catch (...)
+                    {
+                        // ignore
+                    }
+                    if (!existedCacheDirs.empty())
+                    {
+                        CV_LOG_WARNING(NULL, "Creating new OpenCV cache directory: " << default_cache_path);
+                        CV_LOG_WARNING(NULL, "There are several neighbour directories, probably created by old OpenCV versions.");
+                        CV_LOG_WARNING(NULL, "Feel free to cleanup these unused directories:");
+                        for (size_t i = 0; i < existedCacheDirs.size(); i++)
+                        {
+                            CV_LOG_WARNING(NULL, "  - " << existedCacheDirs[i]);
+                        }
+                        CV_LOG_WARNING(NULL, "Note: This message is showed only once.");
+                    }
+                }
                 if (sub_directory_name && sub_directory_name[0] != '\0')
                     default_cache_path = utils::fs::join(default_cache_path, cv::String(sub_directory_name) + native_separator);
                 if (!utils::fs::createDirectories(default_cache_path))


### PR DESCRIPTION
- use '3.4.x' cache name for current maintenance series (there are no serious changes between them)
- message is shown only once during creation of new cache directory
- use `OPENCV_CACHE_SHOW_CLEANUP_MESSAGE=0` to hide this warning

<cut/>

Example:
```
[ WARN:0] Creating new OpenCV cache directory: /home/alalek/.cache/opencv/3.4.x-dev
[ WARN:0] There are several neighbor directories, probably created by old OpenCV versions.
[ WARN:0] Feel free to cleanup these unused directories:
[ WARN:0]   - 3.3.1-dev
[ WARN:0]   - 3.4.2
[ WARN:0]   - 3.4.2-dev
[ WARN:0]   - 4.0.0-pre
[ WARN:0] Note: This message is showed only once.
```