### PR TITLE
videoio: check iterator in mjpeg_encoder.cpp

### DIFF
--- a/modules/videoio/src/cap_mjpeg_decoder.cpp
+++ b/modules/videoio/src/cap_mjpeg_decoder.cpp
@@ -146,6 +146,9 @@ bool MotionJpegCapture::grabFrame()
         }
         else
         {
+            if (m_frame_iterator == m_mjpeg_frames.end())
+                return false;
+
             ++m_frame_iterator;
         }
     }


### PR DESCRIPTION
resolves #12164

check for `m_mjpeg_frames.end()` before iterating