### PR TITLE
photo: avoid resizing a const Mat in decolor()

### DIFF
--- a/modules/photo/src/contrast_preserve.hpp
+++ b/modules/photo/src/contrast_preserve.hpp
@@ -204,14 +204,19 @@ void Decolor::add_to_vector_poly(vector < vector <double> > &polyGrad, const vec
     idx1++;
 }
 
-void Decolor::weak_order(const Mat &img, vector <double> &alf) const
+void Decolor::weak_order(const Mat &im, vector <double> &alf) const
 {
-    const int h = img.size().height;
-    const int w = img.size().width;
+    Mat img;
+    const int h = im.size().height;
+    const int w = im.size().width;
     if((h + w) > 800)
     {
         const double sizefactor = double(800)/(h+w);
-        resize(img, img, Size(cvRound(h*sizefactor), cvRound(w*sizefactor)));
+        resize(im, img, Size(cvRound(h*sizefactor), cvRound(w*sizefactor)));
+    }
+    else
+    {
+        img = im;
     }
 
     Mat curIm = Mat(img.size(),CV_32FC1);
@@ -246,16 +251,20 @@ void Decolor::weak_order(const Mat &img, vector <double> &alf) const
         alf[i] -= tmp1[i] * tmp2[i] * tmp3[i];
 }
 
-void Decolor::grad_system(const Mat &img, vector < vector < double > > &polyGrad,
+void Decolor::grad_system(const Mat &im, vector < vector < double > > &polyGrad,
         vector < double > &Cg, vector <Vec3i>& comb) const
 {
-    int h = img.size().height;
-    int w = img.size().width;
-
+    Mat img;
+    int h = im.size().height;
+    int w = im.size().width;
     if((h + w) > 800)
     {
         const double sizefactor = double(800)/(h+w);
-        resize(img, img, Size(cvRound(h*sizefactor), cvRound(w*sizefactor)));
+        resize(im, img, Size(cvRound(h*sizefactor), cvRound(w*sizefactor)));
+    }
+    else
+    {
+        img = im;
     }
 
     h = img.size().height;


### PR DESCRIPTION
resolves: #12167

use a new Mat header for the resize() result.