### PR TITLE
apps: fix interactive calibration

### DIFF
--- a/apps/interactive-calibration/calibController.cpp
+++ b/apps/interactive-calibration/calibController.cpp
@@ -224,8 +224,10 @@ void calib::calibDataController::filterFrames()
         cv::Mat newErrorsVec = cv::Mat((int)numberOfFrames - 1, 1, CV_64F);
         std::copy(mCalibData->perViewErrors.ptr<double>(0),
                   mCalibData->perViewErrors.ptr<double>((int)worstElemIndex), newErrorsVec.ptr<double>(0));
-        std::copy(mCalibData->perViewErrors.ptr<double>((int)worstElemIndex + 1), mCalibData->perViewErrors.ptr<double>((int)numberOfFrames),
+        if((int)worstElemIndex < (int)numberOfFrames-1) {
+            std::copy(mCalibData->perViewErrors.ptr<double>((int)worstElemIndex + 1), mCalibData->perViewErrors.ptr<double>((int)numberOfFrames),
                     newErrorsVec.ptr<double>((int)worstElemIndex));
+        }
         mCalibData->perViewErrors = newErrorsVec;
     }
 }


### PR DESCRIPTION
resolves #12202

only copy the 2nd part if `worstElemIndex < (int)numberOfFrames-1`