### PR TITLE
core: repair CV_Assert() messages

### DIFF
--- a/modules/core/include/opencv2/core/cvdef.h
+++ b/modules/core/include/opencv2/core/cvdef.h
@@ -79,6 +79,8 @@ namespace cv { namespace debug_build_guard { } using namespace debug_build_guard
 #define __CV_CAT(x, y) __CV_CAT_(x, y)
 #endif
 
+#define __CV_VA_NUM_ARGS_HELPER(_1, _2, _3, _4, _5, _6, _7, _8, _9, _10, N, ...) N
+#define __CV_VA_NUM_ARGS(...) __CV_VA_NUM_ARGS_HELPER(__VA_ARGS__, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0)
 
 // undef problematic defines sometimes defined by system headers (windows.h in particular)
 #undef small

--- a/modules/core/src/matmul.cpp
+++ b/modules/core/src/matmul.cpp
@@ -796,7 +796,7 @@ static bool ocl_gemm( InputArray matA, InputArray matB, double alpha,
     int depth = matA.depth(), cn = matA.channels();
     int type = CV_MAKETYPE(depth, cn);
 
-    CV_Assert( type == matB.type(), (type == CV_32FC1 || type == CV_64FC1 || type == CV_32FC2 || type == CV_64FC2) );
+    CV_Assert_N( type == matB.type(), (type == CV_32FC1 || type == CV_64FC1 || type == CV_32FC2 || type == CV_64FC2) );
 
     const ocl::Device & dev = ocl::Device::getDefault();
     bool doubleSupport = dev.doubleFPConfig() > 0;
@@ -1555,7 +1555,7 @@ void cv::gemm( InputArray matA, InputArray matB, double alpha,
     Size a_size = A.size(), d_size;
     int len = 0, type = A.type();
 
-    CV_Assert( type == B.type(), (type == CV_32FC1 || type == CV_64FC1 || type == CV_32FC2 || type == CV_64FC2) );
+    CV_Assert_N( type == B.type(), (type == CV_32FC1 || type == CV_64FC1 || type == CV_32FC2 || type == CV_64FC2) );
 
     switch( flags & (GEMM_1_T|GEMM_2_T) )
     {
@@ -1583,7 +1583,7 @@ void cv::gemm( InputArray matA, InputArray matB, double alpha,
 
     if( !C.empty() )
     {
-        CV_Assert( C.type() == type,
+        CV_Assert_N( C.type() == type,
             (((flags&GEMM_3_T) == 0 && C.rows == d_size.height && C.cols == d_size.width) ||
              ((flags&GEMM_3_T) != 0 && C.rows == d_size.width && C.cols == d_size.height)));
     }
@@ -2457,7 +2457,7 @@ void cv::calcCovarMatrix( const Mat* data, int nsamples, Mat& covar, Mat& _mean,
 {
     CV_INSTRUMENT_REGION()
 
-    CV_Assert( data, nsamples > 0 );
+    CV_Assert_N( data, nsamples > 0 );
     Size size = data[0].size();
     int sz = size.width * size.height, esz = (int)data[0].elemSize();
     int type = data[0].type();
@@ -2480,7 +2480,7 @@ void cv::calcCovarMatrix( const Mat* data, int nsamples, Mat& covar, Mat& _mean,
 
     for( int i = 0; i < nsamples; i++ )
     {
-        CV_Assert( data[i].size() == size, data[i].type() == type );
+        CV_Assert_N( data[i].size() == size, data[i].type() == type );
         if( data[i].isContinuous() )
             memcpy( _data.ptr(i), data[i].ptr(), sz*esz );
         else
@@ -2516,7 +2516,7 @@ void cv::calcCovarMatrix( InputArray _src, OutputArray _covar, InputOutputArray 
         int i = 0;
         for(std::vector<cv::Mat>::iterator each = src.begin(); each != src.end(); ++each, ++i )
         {
-            CV_Assert( (*each).size() == size, (*each).type() == type );
+            CV_Assert_N( (*each).size() == size, (*each).type() == type );
             Mat dataRow(size.height, size.width, type, _data.ptr(i));
             (*each).copyTo(dataRow);
         }
@@ -2595,7 +2595,7 @@ double cv::Mahalanobis( InputArray _v1, InputArray _v2, InputArray _icovar )
     AutoBuffer<double> buf(len);
     double result = 0;
 
-    CV_Assert( type == v2.type(), type == icovar.type(),
+    CV_Assert_N( type == v2.type(), type == icovar.type(),
         sz == v2.size(), len == icovar.rows && len == icovar.cols );
 
     sz.width *= v1.channels();
@@ -2888,7 +2888,7 @@ void cv::mulTransposed( InputArray _src, OutputArray _dst, bool ata,
 
     if( !delta.empty() )
     {
-        CV_Assert( delta.channels() == 1,
+        CV_Assert_N( delta.channels() == 1,
             (delta.rows == src.rows || delta.rows == 1),
             (delta.cols == src.cols || delta.cols == 1));
         if( delta.type() != dtype )
@@ -3291,7 +3291,7 @@ double Mat::dot(InputArray _mat) const
     Mat mat = _mat.getMat();
     int cn = channels();
     DotProdFunc func = getDotProdFunc(depth());
-    CV_Assert( mat.type() == type(), mat.size == size, func != 0 );
+    CV_Assert_N( mat.type() == type(), mat.size == size, func != 0 );
 
     if( isContinuous() && mat.isContinuous() )
     {
@@ -3327,7 +3327,7 @@ CV_IMPL void cvGEMM( const CvArr* Aarr, const CvArr* Barr, double alpha,
     if( Carr )
         C = cv::cvarrToMat(Carr);
 
-    CV_Assert( (D.rows == ((flags & CV_GEMM_A_T) == 0 ? A.rows : A.cols)),
+    CV_Assert_N( (D.rows == ((flags & CV_GEMM_A_T) == 0 ? A.rows : A.cols)),
                (D.cols == ((flags & CV_GEMM_B_T) == 0 ? B.cols : B.rows)),
                D.type() == A.type() );
 
@@ -3350,7 +3350,7 @@ cvTransform( const CvArr* srcarr, CvArr* dstarr,
         m = _m;
     }
 
-    CV_Assert( dst.depth() == src.depth(), dst.channels() == m.rows );
+    CV_Assert_N( dst.depth() == src.depth(), dst.channels() == m.rows );
     cv::transform( src, dst, m );
 }
 
@@ -3360,7 +3360,7 @@ cvPerspectiveTransform( const CvArr* srcarr, CvArr* dstarr, const CvMat* mat )
 {
     cv::Mat m = cv::cvarrToMat(mat), src = cv::cvarrToMat(srcarr), dst = cv::cvarrToMat(dstarr);
 
-    CV_Assert( dst.type() == src.type(), dst.channels() == m.rows-1 );
+    CV_Assert_N( dst.type() == src.type(), dst.channels() == m.rows-1 );
     cv::perspectiveTransform( src, dst, m );
 }
 
@@ -3370,7 +3370,7 @@ CV_IMPL void cvScaleAdd( const CvArr* srcarr1, CvScalar scale,
 {
     cv::Mat src1 = cv::cvarrToMat(srcarr1), dst = cv::cvarrToMat(dstarr);
 
-    CV_Assert( src1.size == dst.size, src1.type() == dst.type() );
+    CV_Assert_N( src1.size == dst.size, src1.type() == dst.type() );
     cv::scaleAdd( src1, scale.val[0], cv::cvarrToMat(srcarr2), dst );
 }
 
@@ -3380,7 +3380,7 @@ cvCalcCovarMatrix( const CvArr** vecarr, int count,
                    CvArr* covarr, CvArr* avgarr, int flags )
 {
     cv::Mat cov0 = cv::cvarrToMat(covarr), cov = cov0, mean0, mean;
-    CV_Assert( vecarr != 0, count >= 1 );
+    CV_Assert_N( vecarr != 0, count >= 1 );
 
     if( avgarr )
         mean = mean0 = cv::cvarrToMat(avgarr);
@@ -3460,7 +3460,7 @@ cvCalcPCA( const CvArr* data_arr, CvArr* avg_arr, CvArr* eigenvals, CvArr* eigen
     int ecount0 = evals0.cols + evals0.rows - 1;
     int ecount = evals.cols + evals.rows - 1;
 
-    CV_Assert( (evals0.cols == 1 || evals0.rows == 1),
+    CV_Assert_N( (evals0.cols == 1 || evals0.rows == 1),
                 ecount0 <= ecount,
                 evects0.cols == evects.cols,
                 evects0.rows == ecount0 );
@@ -3491,12 +3491,12 @@ cvProjectPCA( const CvArr* data_arr, const CvArr* avg_arr,
     int n;
     if( mean.rows == 1 )
     {
-        CV_Assert(dst.cols <= evects.rows, dst.rows == data.rows);
+        CV_Assert_N(dst.cols <= evects.rows, dst.rows == data.rows);
         n = dst.cols;
     }
     else
     {
-        CV_Assert(dst.rows <= evects.rows, dst.cols == data.cols);
+        CV_Assert_N(dst.rows <= evects.rows, dst.cols == data.cols);
         n = dst.rows;
     }
     pca.eigenvectors = evects.rowRange(0, n);
@@ -3522,12 +3522,12 @@ cvBackProjectPCA( const CvArr* proj_arr, const CvArr* avg_arr,
     int n;
     if( mean.rows == 1 )
     {
-        CV_Assert(data.cols <= evects.rows, dst.rows == data.rows);
+        CV_Assert_N(data.cols <= evects.rows, dst.rows == data.rows);
         n = data.cols;
     }
     else
     {
-        CV_Assert(data.rows <= evects.rows, dst.cols == data.cols);
+        CV_Assert_N(data.rows <= evects.rows, dst.cols == data.cols);
         n = data.rows;
     }
     pca.eigenvectors = evects.rowRange(0, n);

--- a/modules/dnn/include/opencv2/dnn/shape_utils.hpp
+++ b/modules/dnn/include/opencv2/dnn/shape_utils.hpp
@@ -209,7 +209,7 @@ inline Range clamp(const Range& r, int axisSize)
 {
     Range clamped(std::max(r.start, 0),
                   r.end > 0 ? std::min(r.end, axisSize) : axisSize + r.end + 1);
-    CV_Assert(clamped.start < clamped.end, clamped.end <= axisSize);
+    CV_Assert_N(clamped.start < clamped.end, clamped.end <= axisSize);
     return clamped;
 }
 

--- a/modules/dnn/src/caffe/caffe_importer.cpp
+++ b/modules/dnn/src/caffe/caffe_importer.cpp
@@ -359,7 +359,7 @@ public:
             {
                 if (!layerParams.get<bool>("use_global_stats", true))
                 {
-                    CV_Assert(layer.bottom_size() == 1, layer.top_size() == 1);
+                    CV_Assert_N(layer.bottom_size() == 1, layer.top_size() == 1);
 
                     LayerParams mvnParams;
                     mvnParams.set("eps", layerParams.get<float>("eps", 1e-5));

--- a/modules/dnn/src/dnn.cpp
+++ b/modules/dnn/src/dnn.cpp
@@ -134,7 +134,7 @@ void blobFromImages(InputArrayOfArrays images_, OutputArray blob_, double scalef
     if (ddepth == CV_8U)
     {
         CV_CheckEQ(scalefactor, 1.0, "Scaling is not supported for CV_8U blob depth");
-        CV_Assert(mean_ == Scalar(), "Mean subtraction is not supported for CV_8U blob depth");
+        CV_Assert(mean_ == Scalar() && "Mean subtraction is not supported for CV_8U blob depth");
     }
 
     std::vector<Mat> images;
@@ -451,8 +451,8 @@ struct DataLayer : public Layer
         {
             double scale = scaleFactors[i];
             Scalar& mean = means[i];
-            CV_Assert(mean == Scalar() || inputsData[i].size[1] <= 4,
-                      outputs[i].type() == CV_32F);
+            CV_Assert(mean == Scalar() || inputsData[i].size[1] <= 4);
+            CV_CheckTypeEQ(outputs[i].type(), CV_32FC1, "");
 
             bool singleMean = true;
             for (int j = 1; j < std::min(4, inputsData[i].size[1]) && singleMean; ++j)
@@ -569,7 +569,7 @@ struct DataLayer : public Layer
 
     void finalize(const std::vector<Mat*>&, std::vector<Mat>& outputs) CV_OVERRIDE
     {
-        CV_Assert(outputs.size() == scaleFactors.size(), outputs.size() == means.size(),
+        CV_Assert_N(outputs.size() == scaleFactors.size(), outputs.size() == means.size(),
                   inputsData.size() == outputs.size());
         skip = true;
         for (int i = 0; skip && i < inputsData.size(); ++i)
@@ -1237,7 +1237,7 @@ struct Net::Impl
     void initHalideBackend()
     {
         CV_TRACE_FUNCTION();
-        CV_Assert(preferableBackend == DNN_BACKEND_HALIDE, haveHalide());
+        CV_Assert_N(preferableBackend == DNN_BACKEND_HALIDE, haveHalide());
 
         // Iterator to current layer.
         MapIdToLayerData::iterator it = layers.begin();
@@ -1330,7 +1330,7 @@ struct Net::Impl
     void initInfEngineBackend()
     {
         CV_TRACE_FUNCTION();
-        CV_Assert(preferableBackend == DNN_BACKEND_INFERENCE_ENGINE, haveInfEngine());
+        CV_Assert_N(preferableBackend == DNN_BACKEND_INFERENCE_ENGINE, haveInfEngine());
 #ifdef HAVE_INF_ENGINE
         MapIdToLayerData::iterator it;
         Ptr<InfEngineBackendNet> net;
@@ -1827,7 +1827,7 @@ struct Net::Impl
                                         // To prevent memory collisions (i.e. when input of
                                         // [conv] and output of [eltwise] is the same blob)
                                         // we allocate a new blob.
-                                        CV_Assert(ld.outputBlobs.size() == 1, ld.outputBlobsWrappers.size() == 1);
+                                        CV_Assert_N(ld.outputBlobs.size() == 1, ld.outputBlobsWrappers.size() == 1);
                                         ld.outputBlobs[0] = ld.outputBlobs[0].clone();
                                         ld.outputBlobsWrappers[0] = wrap(ld.outputBlobs[0]);
 
@@ -1984,7 +1984,7 @@ struct Net::Impl
                             }
                             // Layers that refer old input Mat will refer to the
                             // new data but the same Mat object.
-                            CV_Assert(curr_output.data == output_slice.data, oldPtr == &curr_output);
+                            CV_Assert_N(curr_output.data == output_slice.data, oldPtr == &curr_output);
                         }
                         ld.skip = true;
                         printf_(("\toptimized out Concat layer %s\n", concatLayer->name.c_str()));

--- a/modules/dnn/src/layers/batch_norm_layer.cpp
+++ b/modules/dnn/src/layers/batch_norm_layer.cpp
@@ -48,7 +48,7 @@ public:
 
         float varMeanScale = 1.f;
         if (!hasWeights && !hasBias && blobs.size() > 2 && useGlobalStats) {
-            CV_Assert(blobs.size() == 3, blobs[2].type() == CV_32F);
+            CV_Assert(blobs.size() == 3); CV_CheckTypeEQ(blobs[2].type(), CV_32FC1, "");
             varMeanScale = blobs[2].at<float>(0);
             if (varMeanScale != 0)
                 varMeanScale = 1/varMeanScale;

--- a/modules/dnn/src/layers/convolution_layer.cpp
+++ b/modules/dnn/src/layers/convolution_layer.cpp
@@ -349,8 +349,8 @@ public:
         // (conv(I) + b1 ) * w + b2
         // means to replace convolution's weights to [w*conv(I)] and bias to [b1 * w + b2]
         const int outCn = weightsMat.size[0];
-        CV_Assert(!weightsMat.empty(), biasvec.size() == outCn + 2,
-                  w.empty() || outCn == w.total(), b.empty() || outCn == b.total());
+        CV_Assert_N(!weightsMat.empty(), biasvec.size() == outCn + 2,
+                    w.empty() || outCn == w.total(), b.empty() || outCn == b.total());
 
         if (!w.empty())
         {
@@ -512,13 +512,14 @@ public:
                          Size kernel, Size pad, Size stride, Size dilation,
                          const ActivationLayer* activ, int ngroups, int nstripes )
         {
-            CV_Assert( input.dims == 4 && output.dims == 4,
+            CV_Assert_N(
+                       input.dims == 4 && output.dims == 4,
                        input.size[0] == output.size[0],
                        weights.rows == output.size[1],
                        weights.cols == (input.size[1]/ngroups)*kernel.width*kernel.height,
                        input.type() == output.type(),
                        input.type() == weights.type(),
-                       input.type() == CV_32F,
+                       input.type() == CV_32FC1,
                        input.isContinuous(),
                        output.isContinuous(),
                        biasvec.size() == (size_t)output.size[1]+2);
@@ -1009,8 +1010,8 @@ public:
                name.c_str(), inputs[0]->size[0], inputs[0]->size[1], inputs[0]->size[2], inputs[0]->size[3],
                kernel.width, kernel.height, pad.width, pad.height,
                stride.width, stride.height, dilation.width, dilation.height);*/
-        CV_Assert(inputs.size() == (size_t)1, inputs[0]->size[1] % blobs[0].size[1] == 0,
-                  outputs.size() == 1, inputs[0]->data != outputs[0].data);
+        CV_Assert_N(inputs.size() == (size_t)1, inputs[0]->size[1] % blobs[0].size[1] == 0,
+                    outputs.size() == 1, inputs[0]->data != outputs[0].data);
 
         int ngroups = inputs[0]->size[1]/blobs[0].size[1];
         CV_Assert(outputs[0].size[1] % ngroups == 0);

--- a/modules/dnn/src/layers/crop_and_resize_layer.cpp
+++ b/modules/dnn/src/layers/crop_and_resize_layer.cpp
@@ -14,7 +14,7 @@ class CropAndResizeLayerImpl CV_FINAL : public CropAndResizeLayer
 public:
     CropAndResizeLayerImpl(const LayerParams& params)
     {
-        CV_Assert(params.has("width"), params.has("height"));
+        CV_Assert_N(params.has("width"), params.has("height"));
         outWidth = params.get<float>("width");
         outHeight = params.get<float>("height");
     }
@@ -24,7 +24,7 @@ public:
                          std::vector<MatShape> &outputs,
                          std::vector<MatShape> &internals) const CV_OVERRIDE
     {
-        CV_Assert(inputs.size() == 2, inputs[0].size() == 4);
+        CV_Assert_N(inputs.size() == 2, inputs[0].size() == 4);
         if (inputs[0][0] != 1)
             CV_Error(Error::StsNotImplemented, "");
         outputs.resize(1, MatShape(4));
@@ -56,7 +56,7 @@ public:
         const int inpWidth = inp.size[3];
         const int inpSpatialSize = inpHeight * inpWidth;
         const int outSpatialSize = outHeight * outWidth;
-        CV_Assert(inp.isContinuous(), out.isContinuous());
+        CV_Assert_N(inp.isContinuous(), out.isContinuous());
 
         for (int b = 0; b < boxes.rows; ++b)
         {

--- a/modules/dnn/src/layers/eltwise_layer.cpp
+++ b/modules/dnn/src/layers/eltwise_layer.cpp
@@ -139,7 +139,7 @@ public:
                         const std::vector<float>& coeffs, EltwiseOp op,
                         const ActivationLayer* activ, int nstripes)
         {
-            CV_Assert(1 < dst.dims && dst.dims <= 4, dst.type() == CV_32F, dst.isContinuous());
+            CV_Check(dst.dims, 1 < dst.dims && dst.dims <= 4, ""); CV_CheckTypeEQ(dst.type(), CV_32FC1, ""); CV_Assert(dst.isContinuous());
             CV_Assert(coeffs.empty() || coeffs.size() == (size_t)nsrcs);
 
             for( int i = 0; i > nsrcs; i++ )

--- a/modules/dnn/src/layers/padding_layer.cpp
+++ b/modules/dnn/src/layers/padding_layer.cpp
@@ -38,7 +38,7 @@ public:
         {
             paddings[i].first = paddingsParam.get<int>(i * 2);  // Pad before.
             paddings[i].second = paddingsParam.get<int>(i * 2 + 1);  // Pad after.
-            CV_Assert(paddings[i].first >= 0, paddings[i].second >= 0);
+            CV_Assert_N(paddings[i].first >= 0, paddings[i].second >= 0);
         }
     }
 
@@ -127,8 +127,8 @@ public:
             const int padBottom = outHeight - dstRanges[2].end;
             const int padLeft = dstRanges[3].start;
             const int padRight = outWidth - dstRanges[3].end;
-            CV_Assert(padTop < inpHeight, padBottom < inpHeight,
-                      padLeft < inpWidth, padRight < inpWidth);
+            CV_CheckLT(padTop, inpHeight, ""); CV_CheckLT(padBottom, inpHeight, "");
+            CV_CheckLT(padLeft, inpWidth, ""); CV_CheckLT(padRight, inpWidth, "");
 
             for (size_t n = 0; n < inputs[0]->size[0]; ++n)
             {

--- a/modules/dnn/src/layers/pooling_layer.cpp
+++ b/modules/dnn/src/layers/pooling_layer.cpp
@@ -216,15 +216,15 @@ public:
         switch (type)
         {
             case MAX:
-                CV_Assert(inputs.size() == 1, outputs.size() == 2);
+                CV_Assert_N(inputs.size() == 1, outputs.size() == 2);
                 maxPooling(*inputs[0], outputs[0], outputs[1]);
                 break;
             case AVE:
-                CV_Assert(inputs.size() == 1, outputs.size() == 1);
+                CV_Assert_N(inputs.size() == 1, outputs.size() == 1);
                 avePooling(*inputs[0], outputs[0]);
                 break;
             case ROI: case PSROI:
-                CV_Assert(inputs.size() == 2, outputs.size() == 1);
+                CV_Assert_N(inputs.size() == 2, outputs.size() == 1);
                 roiPooling(*inputs[0], *inputs[1], outputs[0]);
                 break;
             default:
@@ -311,7 +311,8 @@ public:
                         Size stride, Size pad, bool avePoolPaddedArea, int poolingType, float spatialScale,
                         bool computeMaxIdx, int nstripes)
         {
-            CV_Assert(src.isContinuous(), dst.isContinuous(),
+            CV_Assert_N(
+                      src.isContinuous(), dst.isContinuous(),
                       src.type() == CV_32F, src.type() == dst.type(),
                       src.dims == 4, dst.dims == 4,
                       ((poolingType == ROI || poolingType == PSROI) && dst.size[0] ==rois.size[0] || src.size[0] == dst.size[0]),

--- a/modules/dnn/src/layers/prior_box_layer.cpp
+++ b/modules/dnn/src/layers/prior_box_layer.cpp
@@ -254,7 +254,7 @@ public:
         }
         if (params.has("offset_h") || params.has("offset_w"))
         {
-            CV_Assert(!params.has("offset"), params.has("offset_h"), params.has("offset_w"));
+            CV_Assert_N(!params.has("offset"), params.has("offset_h"), params.has("offset_w"));
             getParams("offset_h", params, &_offsetsY);
             getParams("offset_w", params, &_offsetsX);
             CV_Assert(_offsetsX.size() == _offsetsY.size());
@@ -299,7 +299,8 @@ public:
 
     void finalize(const std::vector<Mat*> &inputs, std::vector<Mat> &outputs) CV_OVERRIDE
     {
-        CV_Assert(inputs.size() > 1, inputs[0]->dims == 4, inputs[1]->dims == 4);
+        CV_CheckGT(inputs.size(), (size_t)1, "");
+        CV_CheckEQ(inputs[0]->dims, 4, ""); CV_CheckEQ(inputs[1]->dims, 4, "");
         int layerWidth = inputs[0]->size[3];
         int layerHeight = inputs[0]->size[2];
 

--- a/modules/dnn/src/layers/reshape_layer.cpp
+++ b/modules/dnn/src/layers/reshape_layer.cpp
@@ -197,7 +197,7 @@ public:
         }
         else
         {
-            CV_Assert(inputs.size() == 2, total(inputs[0]) == total(inputs[1]));
+            CV_Assert_N(inputs.size() == 2, total(inputs[0]) == total(inputs[1]));
             outputs.assign(1, inputs[1]);
         }
         return true;

--- a/modules/dnn/src/layers/resize_layer.cpp
+++ b/modules/dnn/src/layers/resize_layer.cpp
@@ -43,7 +43,7 @@ public:
                          std::vector<MatShape> &outputs,
                          std::vector<MatShape> &internals) const CV_OVERRIDE
     {
-        CV_Assert(inputs.size() == 1, inputs[0].size() == 4);
+        CV_Assert_N(inputs.size() == 1, inputs[0].size() == 4);
         outputs.resize(1, inputs[0]);
         outputs[0][2] = outHeight > 0 ? outHeight : (outputs[0][2] * zoomFactorHeight);
         outputs[0][3] = outWidth > 0 ? outWidth : (outputs[0][3] * zoomFactorWidth);
@@ -106,7 +106,7 @@ public:
             const int inpSpatialSize = inpHeight * inpWidth;
             const int outSpatialSize = outHeight * outWidth;
             const int numPlanes = inp.size[0] * inp.size[1];
-            CV_Assert(inp.isContinuous(), out.isContinuous());
+            CV_Assert_N(inp.isContinuous(), out.isContinuous());
 
             Mat inpPlanes = inp.reshape(1, numPlanes * inpHeight);
             Mat outPlanes = out.reshape(1, numPlanes * outHeight);
@@ -184,7 +184,7 @@ public:
                          std::vector<MatShape> &outputs,
                          std::vector<MatShape> &internals) const CV_OVERRIDE
     {
-        CV_Assert(inputs.size() == 1, inputs[0].size() == 4);
+        CV_Assert_N(inputs.size() == 1, inputs[0].size() == 4);
         outputs.resize(1, inputs[0]);
         outputs[0][2] = outHeight > 0 ? outHeight : (1 + zoomFactorHeight * (outputs[0][2] - 1));
         outputs[0][3] = outWidth > 0 ? outWidth : (1 + zoomFactorWidth * (outputs[0][3] - 1));

--- a/modules/dnn/src/layers/scale_layer.cpp
+++ b/modules/dnn/src/layers/scale_layer.cpp
@@ -64,7 +64,7 @@ public:
     {
         CV_TRACE_FUNCTION();
         CV_TRACE_ARG_VALUE(name, "name", name.c_str());
-        CV_Assert(outputs.size() == 1, !blobs.empty() || inputs.size() == 2);
+        CV_Assert_N(outputs.size() == 1, !blobs.empty() || inputs.size() == 2);
 
         Mat &inpBlob = *inputs[0];
         Mat &outBlob = outputs[0];
@@ -76,7 +76,9 @@ public:
             weights = weights.reshape(1, 1);
         MatShape inpShape = shape(inpBlob);
         const int numWeights = !weights.empty() ? weights.total() : bias.total();
-        CV_Assert(numWeights != 0, !hasWeights || !hasBias || weights.total() == bias.total());
+        CV_Assert(numWeights != 0);
+        if (hasWeights && hasBias)
+            CV_CheckEQ(weights.total(), bias.total(), "Incompatible weights/bias blobs");
 
         int endAxis;
         for (endAxis = axis + 1; endAxis <= inpBlob.dims; ++endAxis)
@@ -84,9 +86,9 @@ public:
             if (total(inpShape, axis, endAxis) == numWeights)
                 break;
         }
-        CV_Assert(total(inpShape, axis, endAxis) == numWeights,
-                  !hasBias || numWeights == bias.total(),
-                  inpBlob.type() == CV_32F && outBlob.type() == CV_32F);
+        CV_Assert(total(inpShape, axis, endAxis) == numWeights);
+        CV_Assert(!hasBias || numWeights == bias.total());
+        CV_CheckTypeEQ(inpBlob.type(), CV_32FC1, ""); CV_CheckTypeEQ(outBlob.type(), CV_32FC1, "");
 
         int numSlices = total(inpShape, 0, axis);
         float* inpData = (float*)inpBlob.data;

--- a/modules/dnn/src/nms.cpp
+++ b/modules/dnn/src/nms.cpp
@@ -25,7 +25,7 @@ void NMSBoxes(const std::vector<Rect>& bboxes, const std::vector<float>& scores,
                           const float score_threshold, const float nms_threshold,
                           std::vector<int>& indices, const float eta, const int top_k)
 {
-    CV_Assert(bboxes.size() == scores.size(), score_threshold >= 0,
+    CV_Assert_N(bboxes.size() == scores.size(), score_threshold >= 0,
         nms_threshold >= 0, eta > 0);
     NMSFast_(bboxes, scores, score_threshold, nms_threshold, eta, top_k, indices, rectOverlap);
 }
@@ -46,7 +46,7 @@ void NMSBoxes(const std::vector<RotatedRect>& bboxes, const std::vector<float>& 
               const float score_threshold, const float nms_threshold,
               std::vector<int>& indices, const float eta, const int top_k)
 {
-    CV_Assert(bboxes.size() == scores.size(), score_threshold >= 0,
+    CV_Assert_N(bboxes.size() == scores.size(), score_threshold >= 0,
         nms_threshold >= 0, eta > 0);
     NMSFast_(bboxes, scores, score_threshold, nms_threshold, eta, top_k, indices, rotatedRectIOU);
 }

--- a/modules/dnn/src/tensorflow/tf_graph_simplifier.cpp
+++ b/modules/dnn/src/tensorflow/tf_graph_simplifier.cpp
@@ -221,7 +221,7 @@ public:
                           std::vector<tensorflow::NodeDef*>& inputNodes) CV_OVERRIDE
     {
         Mat epsMat = getTensorContent(inputNodes.back()->attr().at("value").tensor());
-        CV_Assert(epsMat.total() == 1, epsMat.type() == CV_32FC1);
+        CV_CheckEQ(epsMat.total(), (size_t)1, ""); CV_CheckTypeEQ(epsMat.type(), CV_32FC1, "");
 
         fusedNode->mutable_input()->RemoveLast();
         fusedNode->clear_attr();
@@ -256,7 +256,7 @@ public:
                           std::vector<tensorflow::NodeDef*>& inputNodes) CV_OVERRIDE
     {
         Mat epsMat = getTensorContent(inputNodes.back()->attr().at("value").tensor());
-        CV_Assert(epsMat.total() == 1, epsMat.type() == CV_32FC1);
+        CV_CheckEQ(epsMat.total(), (size_t)1, ""); CV_CheckTypeEQ(epsMat.type(), CV_32FC1, "");
 
         fusedNode->mutable_input()->RemoveLast();
         fusedNode->clear_attr();
@@ -593,7 +593,7 @@ public:
                           std::vector<tensorflow::NodeDef*>& inputNodes) CV_OVERRIDE
     {
         Mat factorsMat = getTensorContent(inputNodes[1]->attr().at("value").tensor());
-        CV_Assert(factorsMat.total() == 2, factorsMat.type() == CV_32SC1);
+        CV_CheckEQ(factorsMat.total(), (size_t)2, ""); CV_CheckTypeEQ(factorsMat.type(), CV_32SC1, "");
 
         // Height scale factor
         tensorflow::TensorProto* factorY = inputNodes[1]->mutable_attr()->at("value").mutable_tensor();

--- a/modules/dnn/src/tensorflow/tf_importer.cpp
+++ b/modules/dnn/src/tensorflow/tf_importer.cpp
@@ -545,8 +545,8 @@ const tensorflow::TensorProto& TFImporter::getConstBlob(const tensorflow::NodeDe
     }
     else
     {
-        CV_Assert(nodeIdx < netTxt.node_size(),
-                  netTxt.node(nodeIdx).name() == kernel_inp.name);
+        CV_Assert_N(nodeIdx < netTxt.node_size(),
+                    netTxt.node(nodeIdx).name() == kernel_inp.name);
         return netTxt.node(nodeIdx).attr().at("value").tensor();
     }
 }
@@ -587,8 +587,8 @@ static void addConstNodes(tensorflow::GraphDef& net, std::map<String, int>& cons
 
             Mat qMin = getTensorContent(net.node(minId).attr().at("value").tensor());
             Mat qMax = getTensorContent(net.node(maxId).attr().at("value").tensor());
-            CV_Assert(qMin.total() == 1, qMin.type() == CV_32FC1,
-                      qMax.total() == 1, qMax.type() == CV_32FC1);
+            CV_Assert_N(qMin.total() == 1, qMin.type() == CV_32FC1,
+                        qMax.total() == 1, qMax.type() == CV_32FC1);
 
             Mat content = getTensorContent(*tensor);
 
@@ -1295,8 +1295,9 @@ void TFImporter::populateNet(Net dstNet)
             CV_Assert(layer.input_size() == 3);
             Mat begins = getTensorContent(getConstBlob(layer, value_id, 1));
             Mat sizes = getTensorContent(getConstBlob(layer, value_id, 2));
-            CV_Assert(!begins.empty(), !sizes.empty(), begins.type() == CV_32SC1,
-                      sizes.type() == CV_32SC1);
+            CV_Assert_N(!begins.empty(), !sizes.empty());
+            CV_CheckTypeEQ(begins.type(), CV_32SC1, "");
+            CV_CheckTypeEQ(sizes.type(), CV_32SC1, "");
 
             if (begins.total() == 4 && getDataLayout(name, data_layouts) == DATA_LAYOUT_NHWC)
             {
@@ -1665,7 +1666,7 @@ void TFImporter::populateNet(Net dstNet)
             if (layer.input_size() == 2)
             {
                 Mat outSize = getTensorContent(getConstBlob(layer, value_id, 1));
-                CV_Assert(outSize.type() == CV_32SC1, outSize.total() == 2);
+                CV_CheckTypeEQ(outSize.type(), CV_32SC1, ""); CV_CheckEQ(outSize.total(), (size_t)2, "");
                 layerParams.set("height", outSize.at<int>(0, 0));
                 layerParams.set("width", outSize.at<int>(0, 1));
             }
@@ -1673,8 +1674,8 @@ void TFImporter::populateNet(Net dstNet)
             {
                 Mat factorHeight = getTensorContent(getConstBlob(layer, value_id, 1));
                 Mat factorWidth = getTensorContent(getConstBlob(layer, value_id, 2));
-                CV_Assert(factorHeight.type() == CV_32SC1, factorHeight.total() == 1,
-                          factorWidth.type() == CV_32SC1, factorWidth.total() == 1);
+                CV_CheckTypeEQ(factorHeight.type(), CV_32SC1, ""); CV_CheckEQ(factorHeight.total(), (size_t)1, "");
+                CV_CheckTypeEQ(factorWidth.type(), CV_32SC1, ""); CV_CheckEQ(factorWidth.total(), (size_t)1, "");
                 layerParams.set("zoom_factor_x", factorWidth.at<int>(0));
                 layerParams.set("zoom_factor_y", factorHeight.at<int>(0));
             }
@@ -1772,7 +1773,7 @@ void TFImporter::populateNet(Net dstNet)
             CV_Assert(layer.input_size() == 3);
 
             Mat cropSize = getTensorContent(getConstBlob(layer, value_id, 2));
-            CV_Assert(cropSize.type() == CV_32SC1, cropSize.total() == 2);
+            CV_CheckTypeEQ(cropSize.type(), CV_32SC1, ""); CV_CheckEQ(cropSize.total(), (size_t)2, "");
 
             layerParams.set("height", cropSize.at<int>(0));
             layerParams.set("width", cropSize.at<int>(1));
@@ -1826,8 +1827,8 @@ void TFImporter::populateNet(Net dstNet)
 
             Mat minValue = getTensorContent(getConstBlob(layer, value_id, 1));
             Mat maxValue = getTensorContent(getConstBlob(layer, value_id, 2));
-            CV_Assert(minValue.total() == 1, minValue.type() == CV_32F,
-                      maxValue.total() == 1, maxValue.type() == CV_32F);
+            CV_CheckEQ(minValue.total(), (size_t)1, ""); CV_CheckTypeEQ(minValue.type(), CV_32FC1, "");
+            CV_CheckEQ(maxValue.total(), (size_t)1, ""); CV_CheckTypeEQ(maxValue.type(), CV_32FC1, "");
 
             layerParams.set("min_value", minValue.at<float>(0));
             layerParams.set("max_value", maxValue.at<float>(0));

--- a/modules/dnn/src/torch/torch_importer.cpp
+++ b/modules/dnn/src/torch/torch_importer.cpp
@@ -896,8 +896,8 @@ struct TorchImporter
             else if (nnName == "SpatialZeroPadding" || nnName == "SpatialReflectionPadding")
             {
                 readTorchTable(scalarParams, tensorParams);
-                CV_Assert(scalarParams.has("pad_l"), scalarParams.has("pad_r"),
-                          scalarParams.has("pad_t"), scalarParams.has("pad_b"));
+                CV_Assert_N(scalarParams.has("pad_l"), scalarParams.has("pad_r"),
+                            scalarParams.has("pad_t"), scalarParams.has("pad_b"));
                 int padTop = scalarParams.get<int>("pad_t");
                 int padLeft = scalarParams.get<int>("pad_l");
                 int padRight = scalarParams.get<int>("pad_r");

--- a/modules/dnn/test/test_layers.cpp
+++ b/modules/dnn/test/test_layers.cpp
@@ -814,7 +814,7 @@ TEST_P(Layer_Test_DWconv_Prelu, Accuracy)
     const int group = 3;                        //outChannels=group when group>1
     const int num_output = get<1>(GetParam());
     const int kernel_depth = num_input/group;
-    CV_Assert(num_output >= group, num_output % group == 0, num_input % group == 0);
+    CV_Assert_N(num_output >= group, num_output % group == 0, num_input % group == 0);
 
     Net net;
     //layer 1: dwconv

--- a/modules/highgui/src/window_w32.cpp
+++ b/modules/highgui/src/window_w32.cpp
@@ -1500,7 +1500,7 @@ MainWindowProc( HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam )
             rgn = CreateRectRgn(0, 0, wrc.right, wrc.bottom);
             rgn1 = CreateRectRgn(cr.left, cr.top, cr.right, cr.bottom);
             rgn2 = CreateRectRgn(tr.left, tr.top, tr.right, tr.bottom);
-            CV_Assert(rgn != 0, rgn1 != 0, rgn2 != 0);
+            CV_Assert_N(rgn != 0, rgn1 != 0, rgn2 != 0);
 
             ret = CombineRgn(rgn, rgn, rgn1, RGN_DIFF);
             ret = CombineRgn(rgn, rgn, rgn2, RGN_DIFF);

--- a/samples/dnn/classification.cpp
+++ b/samples/dnn/classification.cpp
@@ -49,7 +49,6 @@ int main(int argc, char** argv)
     float scale = parser.get<float>("scale");
     Scalar mean = parser.get<Scalar>("mean");
     bool swapRB = parser.get<bool>("rgb");
-    CV_Assert(parser.has("width"), parser.has("height"));
     int inpWidth = parser.get<int>("width");
     int inpHeight = parser.get<int>("height");
     String model = parser.get<String>("model");
@@ -72,7 +71,13 @@ int main(int argc, char** argv)
         }
     }
 
-    CV_Assert(parser.has("model"));
+    if (!parser.check())
+    {
+        parser.printErrors();
+        return 1;
+    }
+    CV_Assert(!model.empty());
+
     //! [Read and initialize network]
     Net net = readNet(model, config, framework);
     net.setPreferableBackend(backendId);

--- a/samples/dnn/custom_layers.hpp
+++ b/samples/dnn/custom_layers.hpp
@@ -108,7 +108,7 @@ public:
         }
         else
         {
-            CV_Assert(blobs.size() == 2, blobs[0].total() == 1, blobs[1].total() == 1);
+            CV_Assert(blobs.size() == 2); CV_Assert(blobs[0].total() == 1); CV_Assert(blobs[1].total() == 1);
             factorHeight = blobs[0].at<int>(0, 0);
             factorWidth = blobs[1].at<int>(0, 0);
             outHeight = outWidth = 0;

--- a/samples/dnn/segmentation.cpp
+++ b/samples/dnn/segmentation.cpp
@@ -57,7 +57,6 @@ int main(int argc, char** argv)
     float scale = parser.get<float>("scale");
     Scalar mean = parser.get<Scalar>("mean");
     bool swapRB = parser.get<bool>("rgb");
-    CV_Assert(parser.has("width"), parser.has("height"));
     int inpWidth = parser.get<int>("width");
     int inpHeight = parser.get<int>("height");
     String model = parser.get<String>("model");
@@ -99,7 +98,13 @@ int main(int argc, char** argv)
         }
     }
 
-    CV_Assert(parser.has("model"));
+    if (!parser.check())
+    {
+        parser.printErrors();
+        return 1;
+    }
+
+    CV_Assert(!model.empty());
     //! [Read and initialize network]
     Net net = readNet(model, config, framework);
     net.setPreferableBackend(backendId);

--- a/samples/dnn/text_detection.cpp
+++ b/samples/dnn/text_detection.cpp
@@ -33,8 +33,15 @@ int main(int argc, char** argv)
     float nmsThreshold = parser.get<float>("nms");
     int inpWidth = parser.get<int>("width");
     int inpHeight = parser.get<int>("height");
-    CV_Assert(parser.has("model"));
     String model = parser.get<String>("model");
+
+    if (!parser.check())
+    {
+        parser.printErrors();
+        return 1;
+    }
+
+    CV_Assert(!model.empty());
 
     // Load network.
     Net net = readNet(model);
@@ -113,9 +120,9 @@ void decode(const Mat& scores, const Mat& geometry, float scoreThresh,
             std::vector<RotatedRect>& detections, std::vector<float>& confidences)
 {
     detections.clear();
-    CV_Assert(scores.dims == 4, geometry.dims == 4, scores.size[0] == 1,
-              geometry.size[0] == 1, scores.size[1] == 1, geometry.size[1] == 5,
-              scores.size[2] == geometry.size[2], scores.size[3] == geometry.size[3]);
+    CV_Assert(scores.dims == 4); CV_Assert(geometry.dims == 4); CV_Assert(scores.size[0] == 1);
+    CV_Assert(geometry.size[0] == 1); CV_Assert(scores.size[1] == 1); CV_Assert(geometry.size[1] == 5);
+    CV_Assert(scores.size[2] == geometry.size[2]); CV_Assert(scores.size[3] == geometry.size[3]);
 
     const int height = scores.size[2];
     const int width = scores.size[3];


### PR DESCRIPTION
**Merge with contrib**: https://github.com/opencv/opencv_contrib/pull/1722

Multi-argument CV_Assert() is accessible via CV_Assert_N() (with malformed messages).
Or use `OPENCV_FORCE_MULTIARG_ASSERT_CHECK` definition (before any of OpenCV headers) to force previous behavior.

Fix: avoid expanding of assertion inner macro

Sample code:
`CV_Assert(type == CV_8UC3);`

Message before:
"type == (((0) & ((1 << 3) - 1)) + (((3)-1) << 3))"

Message after:
"type == CV_8UC3"

<cut/>

There are many other cases which are much [worse](https://github.com/opencv/opencv/issues/12012#issue-342551071).

related #9293

```
docker_image:Custom=ubuntu-cuda:16.04
#docker_image:Custom=halide:16.04
#buildworker:Custom=linux-1
test_opencl:Custom=ON
```