### PR TITLE
Fixed core headers installation in world builds

### DIFF
--- a/modules/core/CMakeLists.txt
+++ b/modules/core/CMakeLists.txt
@@ -33,9 +33,14 @@ if(CV_TRACE AND HAVE_ITT AND BUILD_ITT)
   add_definitions(-DOPENCV_WITH_ITT=1)
 endif()
 
-file(GLOB lib_cuda_hdrs        "include/opencv2/${name}/cuda/*.hpp"        "include/opencv2/${name}/cuda/*.h")
-file(GLOB lib_cuda_hdrs_detail "include/opencv2/${name}/cuda/detail/*.hpp" "include/opencv2/${name}/cuda/detail/*.h")
-file(GLOB_RECURSE module_opencl_hdrs "include/opencv2/${name}/opencl/*")
+file(GLOB lib_cuda_hdrs
+    "${CMAKE_CURRENT_LIST_DIR}/include/opencv2/${name}/cuda/*.hpp"
+    "${CMAKE_CURRENT_LIST_DIR}/include/opencv2/${name}/cuda/*.h")
+file(GLOB lib_cuda_hdrs_detail
+    "${CMAKE_CURRENT_LIST_DIR}/include/opencv2/${name}/cuda/detail/*.hpp"
+    "${CMAKE_CURRENT_LIST_DIR}/include/opencv2/${name}/cuda/detail/*.h")
+file(GLOB_RECURSE module_opencl_hdrs
+    "${CMAKE_CURRENT_LIST_DIR}/include/opencv2/${name}/opencl/*")
 
 source_group("Include\\Cuda Headers"         FILES ${lib_cuda_hdrs})
 source_group("Include\\Cuda Headers\\Detail" FILES ${lib_cuda_hdrs_detail})


### PR DESCRIPTION
### This pullrequest changes

Builds with opencv_world enabled did not find some headers in _cuda_ and _opencl_ subdirectories.
