### PR TITLE
core(perf): fix addScalar test

### DIFF
--- a/modules/core/perf/perf_arithm.cpp
+++ b/modules/core/perf/perf_arithm.cpp
@@ -4,11 +4,9 @@ namespace opencv_test
 {
 using namespace perf;
 
-#define TYPICAL_MAT_SIZES_CORE_ARITHM   szVGA, sz720p, sz1080p
-#define TYPICAL_MAT_TYPES_CORE_ARITHM   CV_8UC1, CV_8SC1, CV_16SC1, CV_16SC2, CV_16SC3, CV_16SC4, CV_8UC4, CV_32SC1, CV_32FC1
-#define TYPICAL_MATS_CORE_ARITHM        testing::Combine( testing::Values( TYPICAL_MAT_SIZES_CORE_ARITHM ), testing::Values( TYPICAL_MAT_TYPES_CORE_ARITHM ) )
+typedef Size_MatType BinaryOpTest;
 
-PERF_TEST_P(Size_MatType, min, TYPICAL_MATS_CORE_ARITHM)
+PERF_TEST_P_(BinaryOpTest, min)
 {
     Size sz = get<0>(GetParam());
     int type = get<1>(GetParam());
@@ -20,10 +18,10 @@ PERF_TEST_P(Size_MatType, min, TYPICAL_MATS_CORE_ARITHM)
 
     TEST_CYCLE() cv::min(a, b, c);
 
-    SANITY_CHECK(c);
+    SANITY_CHECK_NOTHING();
 }
 
-PERF_TEST_P(Size_MatType, minScalar, TYPICAL_MATS_CORE_ARITHM)
+PERF_TEST_P_(BinaryOpTest, minScalarDouble)
 {
     Size sz = get<0>(GetParam());
     int type = get<1>(GetParam());
@@ -35,10 +33,34 @@ PERF_TEST_P(Size_MatType, minScalar, TYPICAL_MATS_CORE_ARITHM)
 
     TEST_CYCLE() cv::min(a, b, c);
 
-    SANITY_CHECK(c);
+    SANITY_CHECK_NOTHING();
 }
 
-PERF_TEST_P(Size_MatType, max, TYPICAL_MATS_CORE_ARITHM)
+PERF_TEST_P_(BinaryOpTest, minScalarSameType)
+{
+    Size sz = get<0>(GetParam());
+    int type = get<1>(GetParam());
+    cv::Mat a = Mat(sz, type);
+    cv::Scalar b;
+    cv::Mat c = Mat(sz, type);
+
+    declare.in(a, b, WARMUP_RNG).out(c);
+
+    if (CV_MAT_DEPTH(type) < CV_32S)
+    {
+        b = Scalar(1, 0, 3, 4); // don't pass non-integer values for 8U/8S/16U/16S processing
+    }
+    else if (CV_MAT_DEPTH(type) == CV_32S)
+    {
+        b = Scalar(1, 0, -3, 4); // don't pass non-integer values for 32S processing
+    }
+
+    TEST_CYCLE() cv::min(a, b, c);
+
+    SANITY_CHECK_NOTHING();
+}
+
+PERF_TEST_P_(BinaryOpTest, max)
 {
     Size sz = get<0>(GetParam());
     int type = get<1>(GetParam());
@@ -50,10 +72,10 @@ PERF_TEST_P(Size_MatType, max, TYPICAL_MATS_CORE_ARITHM)
 
     TEST_CYCLE() cv::max(a, b, c);
 
-    SANITY_CHECK(c);
+    SANITY_CHECK_NOTHING();
 }
 
-PERF_TEST_P(Size_MatType, maxScalar, TYPICAL_MATS_CORE_ARITHM)
+PERF_TEST_P_(BinaryOpTest, maxScalarDouble)
 {
     Size sz = get<0>(GetParam());
     int type = get<1>(GetParam());
@@ -65,34 +87,10 @@ PERF_TEST_P(Size_MatType, maxScalar, TYPICAL_MATS_CORE_ARITHM)
 
     TEST_CYCLE() cv::max(a, b, c);
 
-    SANITY_CHECK(c);
+    SANITY_CHECK_NOTHING();
 }
 
-PERF_TEST_P(Size_MatType, absdiff, TYPICAL_MATS_CORE_ARITHM)
-{
-    Size sz = get<0>(GetParam());
-    int type = get<1>(GetParam());
-    cv::Mat a = Mat(sz, type);
-    cv::Mat b = Mat(sz, type);
-    cv::Mat c = Mat(sz, type);
-
-    declare.in(a, b, WARMUP_RNG).out(c);
-
-    double eps = 1e-8;
-    if (CV_MAT_DEPTH(type) == CV_32S)
-    {
-        //see ticket 1529: absdiff can be without saturation on 32S
-        a /= 2;
-        b /= 2;
-        eps = 1;
-    }
-
-    TEST_CYCLE() cv::absdiff(a, b, c);
-
-    SANITY_CHECK(c, eps);
-}
-
-PERF_TEST_P(Size_MatType, absdiffScalar, TYPICAL_MATS_CORE_ARITHM)
+PERF_TEST_P_(BinaryOpTest, maxScalarSameType)
 {
     Size sz = get<0>(GetParam());
     int type = get<1>(GetParam());
@@ -102,21 +100,91 @@ PERF_TEST_P(Size_MatType, absdiffScalar, TYPICAL_MATS_CORE_ARITHM)
 
     declare.in(a, b, WARMUP_RNG).out(c);
 
-    double eps = 1e-8;
+    if (CV_MAT_DEPTH(type) < CV_32S)
+    {
+        b = Scalar(1, 0, 3, 4); // don't pass non-integer values for 8U/8S/16U/16S processing
+    }
+    else if (CV_MAT_DEPTH(type) == CV_32S)
+    {
+        b = Scalar(1, 0, -3, 4); // don't pass non-integer values for 32S processing
+    }
+
+    TEST_CYCLE() cv::max(a, b, c);
+
+    SANITY_CHECK_NOTHING();
+}
+
+PERF_TEST_P_(BinaryOpTest, absdiff)
+{
+    Size sz = get<0>(GetParam());
+    int type = get<1>(GetParam());
+    cv::Mat a = Mat(sz, type);
+    cv::Mat b = Mat(sz, type);
+    cv::Mat c = Mat(sz, type);
+
+    declare.in(a, b, WARMUP_RNG).out(c);
+
     if (CV_MAT_DEPTH(type) == CV_32S)
     {
         //see ticket 1529: absdiff can be without saturation on 32S
         a /= 2;
         b /= 2;
-        eps = 1;
     }
 
     TEST_CYCLE() cv::absdiff(a, b, c);
 
-    SANITY_CHECK(c, eps);
+    SANITY_CHECK_NOTHING();
 }
 
-PERF_TEST_P(Size_MatType, add, TYPICAL_MATS_CORE_ARITHM)
+PERF_TEST_P_(BinaryOpTest, absdiffScalarDouble)
+{
+    Size sz = get<0>(GetParam());
+    int type = get<1>(GetParam());
+    cv::Mat a = Mat(sz, type);
+    cv::Scalar b;
+    cv::Mat c = Mat(sz, type);
+
+    declare.in(a, b, WARMUP_RNG).out(c);
+
+    if (CV_MAT_DEPTH(type) == CV_32S)
+    {
+        //see ticket 1529: absdiff can be without saturation on 32S
+        a /= 2;
+        b /= 2;
+    }
+
+    TEST_CYCLE() cv::absdiff(a, b, c);
+
+    SANITY_CHECK_NOTHING();
+}
+
+PERF_TEST_P_(BinaryOpTest, absdiffScalarSameType)
+{
+    Size sz = get<0>(GetParam());
+    int type = get<1>(GetParam());
+    cv::Mat a = Mat(sz, type);
+    cv::Scalar b;
+    cv::Mat c = Mat(sz, type);
+
+    declare.in(a, b, WARMUP_RNG).out(c);
+
+    if (CV_MAT_DEPTH(type) < CV_32S)
+    {
+        b = Scalar(1, 0, 3, 4); // don't pass non-integer values for 8U/8S/16U/16S processing
+    }
+    else if (CV_MAT_DEPTH(type) == CV_32S)
+    {
+        //see ticket 1529: absdiff can be without saturation on 32S
+        a /= 2;
+        b = Scalar(1, 0, -3, 4); // don't pass non-integer values for 32S processing
+    }
+
+    TEST_CYCLE() cv::absdiff(a, b, c);
+
+    SANITY_CHECK_NOTHING();
+}
+
+PERF_TEST_P_(BinaryOpTest, add)
 {
     Size sz = get<0>(GetParam());
     int type = get<1>(GetParam());
@@ -127,21 +195,19 @@ PERF_TEST_P(Size_MatType, add, TYPICAL_MATS_CORE_ARITHM)
     declare.in(a, b, WARMUP_RNG).out(c);
     declare.time(50);
 
-    double eps = 1e-8;
     if (CV_MAT_DEPTH(type) == CV_32S)
     {
         //see ticket 1529: add can be without saturation on 32S
         a /= 2;
         b /= 2;
-        eps = 1;
     }
 
     TEST_CYCLE() cv::add(a, b, c);
 
-    SANITY_CHECK(c, eps);
+    SANITY_CHECK_NOTHING();
 }
 
-PERF_TEST_P(Size_MatType, addScalar, TYPICAL_MATS_CORE_ARITHM)
+PERF_TEST_P_(BinaryOpTest, addScalarDouble)
 {
     Size sz = get<0>(GetParam());
     int type = get<1>(GetParam());
@@ -151,21 +217,45 @@ PERF_TEST_P(Size_MatType, addScalar, TYPICAL_MATS_CORE_ARITHM)
 
     declare.in(a, b, WARMUP_RNG).out(c);
 
-    double eps = 1e-8;
     if (CV_MAT_DEPTH(type) == CV_32S)
     {
         //see ticket 1529: add can be without saturation on 32S
         a /= 2;
         b /= 2;
-        eps = 1;
     }
 
     TEST_CYCLE() cv::add(a, b, c);
 
-    SANITY_CHECK(c, eps);
+    SANITY_CHECK_NOTHING();
 }
 
-PERF_TEST_P(Size_MatType, subtract, TYPICAL_MATS_CORE_ARITHM)
+PERF_TEST_P_(BinaryOpTest, addScalarSameType)
+{
+    Size sz = get<0>(GetParam());
+    int type = get<1>(GetParam());
+    cv::Mat a = Mat(sz, type);
+    cv::Scalar b;
+    cv::Mat c = Mat(sz, type);
+
+    declare.in(a, b, WARMUP_RNG).out(c);
+
+    if (CV_MAT_DEPTH(type) < CV_32S)
+    {
+        b = Scalar(1, 0, 3, 4); // don't pass non-integer values for 8U/8S/16U/16S processing
+    }
+    else if (CV_MAT_DEPTH(type) == CV_32S)
+    {
+        //see ticket 1529: add can be without saturation on 32S
+        a /= 2;
+        b = Scalar(1, 0, -3, 4); // don't pass non-integer values for 32S processing
+    }
+
+    TEST_CYCLE() cv::add(a, b, c, noArray(), type);
+
+    SANITY_CHECK_NOTHING();
+}
+
+PERF_TEST_P_(BinaryOpTest, subtract)
 {
     Size sz = get<0>(GetParam());
     int type = get<1>(GetParam());
@@ -175,21 +265,19 @@ PERF_TEST_P(Size_MatType, subtract, TYPICAL_MATS_CORE_ARITHM)
 
     declare.in(a, b, WARMUP_RNG).out(c);
 
-    double eps = 1e-8;
     if (CV_MAT_DEPTH(type) == CV_32S)
     {
         //see ticket 1529: subtract can be without saturation on 32S
         a /= 2;
         b /= 2;
-        eps = 1;
     }
 
     TEST_CYCLE() cv::subtract(a, b, c);
 
-    SANITY_CHECK(c, eps);
+    SANITY_CHECK_NOTHING();
 }
 
-PERF_TEST_P(Size_MatType, subtractScalar, TYPICAL_MATS_CORE_ARITHM)
+PERF_TEST_P_(BinaryOpTest, subtractScalarDouble)
 {
     Size sz = get<0>(GetParam());
     int type = get<1>(GetParam());
@@ -199,21 +287,45 @@ PERF_TEST_P(Size_MatType, subtractScalar, TYPICAL_MATS_CORE_ARITHM)
 
     declare.in(a, b, WARMUP_RNG).out(c);
 
-    double eps = 1e-8;
     if (CV_MAT_DEPTH(type) == CV_32S)
     {
         //see ticket 1529: subtract can be without saturation on 32S
         a /= 2;
         b /= 2;
-        eps = 1;
     }
 
     TEST_CYCLE() cv::subtract(a, b, c);
 
-    SANITY_CHECK(c, eps);
+    SANITY_CHECK_NOTHING();
 }
 
-PERF_TEST_P(Size_MatType, multiply, TYPICAL_MATS_CORE_ARITHM)
+PERF_TEST_P_(BinaryOpTest, subtractScalarSameType)
+{
+    Size sz = get<0>(GetParam());
+    int type = get<1>(GetParam());
+    cv::Mat a = Mat(sz, type);
+    cv::Scalar b;
+    cv::Mat c = Mat(sz, type);
+
+    declare.in(a, b, WARMUP_RNG).out(c);
+
+    if (CV_MAT_DEPTH(type) < CV_32S)
+    {
+        b = Scalar(1, 0, 3, 4); // don't pass non-integer values for 8U/8S/16U/16S processing
+    }
+    else if (CV_MAT_DEPTH(type) == CV_32S)
+    {
+        //see ticket 1529: subtract can be without saturation on 32S
+        a /= 2;
+        b = Scalar(1, 0, -3, 4); // don't pass non-integer values for 32S processing
+    }
+
+    TEST_CYCLE() cv::subtract(a, b, c, noArray(), type);
+
+    SANITY_CHECK_NOTHING();
+}
+
+PERF_TEST_P_(BinaryOpTest, multiply)
 {
     Size sz = get<0>(GetParam());
     int type = get<1>(GetParam());
@@ -229,10 +341,10 @@ PERF_TEST_P(Size_MatType, multiply, TYPICAL_MATS_CORE_ARITHM)
 
     TEST_CYCLE() cv::multiply(a, b, c);
 
-    SANITY_CHECK(c, 1e-8);
+    SANITY_CHECK_NOTHING();
 }
 
-PERF_TEST_P(Size_MatType, multiplyScale, TYPICAL_MATS_CORE_ARITHM)
+PERF_TEST_P_(BinaryOpTest, multiplyScale)
 {
     Size sz = get<0>(GetParam());
     int type = get<1>(GetParam());
@@ -250,10 +362,10 @@ PERF_TEST_P(Size_MatType, multiplyScale, TYPICAL_MATS_CORE_ARITHM)
 
     TEST_CYCLE() cv::multiply(a, b, c, scale);
 
-    SANITY_CHECK(c, 1e-8);
+    SANITY_CHECK_NOTHING();
 }
 
-PERF_TEST_P(Size_MatType, divide, TYPICAL_MATS_CORE_ARITHM)
+PERF_TEST_P_(BinaryOpTest, divide)
 {
     Size sz = get<0>(GetParam());
     int type = get<1>(GetParam());
@@ -267,7 +379,7 @@ PERF_TEST_P(Size_MatType, divide, TYPICAL_MATS_CORE_ARITHM)
     SANITY_CHECK_NOTHING();
 }
 
-PERF_TEST_P(Size_MatType, reciprocal, TYPICAL_MATS_CORE_ARITHM)
+PERF_TEST_P_(BinaryOpTest, reciprocal)
 {
     Size sz = get<0>(GetParam());
     int type = get<1>(GetParam());
@@ -280,5 +392,12 @@ PERF_TEST_P(Size_MatType, reciprocal, TYPICAL_MATS_CORE_ARITHM)
 
     SANITY_CHECK_NOTHING();
 }
+
+INSTANTIATE_TEST_CASE_P(/*nothing*/ , BinaryOpTest,
+    testing::Combine(
+        testing::Values(szVGA, sz720p, sz1080p),
+        testing::Values(CV_8UC1, CV_8UC3, CV_8UC4, CV_8SC1, CV_16SC1, CV_16SC2, CV_16SC3, CV_16SC4, CV_32SC1, CV_32FC1)
+    )
+);
 
 } // namespace


### PR DESCRIPTION
Keep the same type for passed `Scalar` values.

There is no sense to pass values like 3506.3 for 8U tests.

<cut/>

1920x1080 CV_8UC1 results:

|Name of Test|ms|
|---|:-:|
|absdiff::BinaryOpTest::(1920x1080, 8UC1)|0.144|
|absdiffScalarDouble::BinaryOpTest::(1920x1080, 8UC1)|0.730|
|absdiffScalarSameType::BinaryOpTest::(1920x1080, 8UC1)|0.111|
|add::BinaryOpTest::(1920x1080, 8UC1)|0.150|
|addScalarDouble::BinaryOpTest::(1920x1080, 8UC1)|0.680|
|addScalarSameType::BinaryOpTest::(1920x1080, 8UC1)|0.111|
|divide::BinaryOpTest::(1920x1080, 8UC1)|0.994|
|max::BinaryOpTest::(1920x1080, 8UC1)|0.120|
|maxScalarDouble::BinaryOpTest::(1920x1080, 8UC1)|0.119|
|maxScalarSameType::BinaryOpTest::(1920x1080, 8UC1)|0.117|
|min::BinaryOpTest::(1920x1080, 8UC1)|0.152|
|minScalarDouble::BinaryOpTest::(1920x1080, 8UC1)|0.110|
|minScalarSameType::BinaryOpTest::(1920x1080, 8UC1)|0.119|
|multiply::BinaryOpTest::(1920x1080, 8UC1)|0.918|
|multiplyScale::BinaryOpTest::(1920x1080, 8UC1)|3.856|
|reciprocal::BinaryOpTest::(1920x1080, 8UC1)|0.809|
|subtract::BinaryOpTest::(1920x1080, 8UC1)|0.122|
|subtractScalarDouble::BinaryOpTest::(1920x1080, 8UC1)|0.638|
|subtractScalarSameType::BinaryOpTest::(1920x1080, 8UC1)|0.115|