### PR TITLE
Split fix

### DIFF
--- a/modules/ml/src/data.cpp
+++ b/modules/ml/src/data.cpp
@@ -79,7 +79,7 @@ Mat TrainData::getSubVector(const Mat& vec, const Mat& idx)
 
     Mat subvec;
 
-    if( vec.cols == m )
+    if( (dims == 1) && (vec.cols == m) )
         subvec.create(dims, n, type);
     else
         subvec.create(n, dims, type);


### PR DESCRIPTION
resolves #12236 

Hopefully I correctly understood what original condition in line 82 means - it was used only in case when we're retrieving responses and they're organized by COL_SAMPLE.