### PR TITLE
fixed 64-float pfm auto conversion

### DIFF
--- a/modules/imgcodecs/src/grfmt_pfm.cpp
+++ b/modules/imgcodecs/src/grfmt_pfm.cpp
@@ -187,7 +187,7 @@ bool PFMEncoder::isFormatSupported(int depth) const
 {
   // any depth will be converted into 32-bit float.
   (void) depth;
-  return true;         
+  return true;
 }
 
 bool PFMEncoder::write(const Mat& img, const std::vector<int>& params)

--- a/modules/imgcodecs/src/grfmt_pfm.cpp
+++ b/modules/imgcodecs/src/grfmt_pfm.cpp
@@ -185,7 +185,9 @@ PFMEncoder::~PFMEncoder()
 
 bool PFMEncoder::isFormatSupported(int depth) const
 {
-  return CV_MAT_DEPTH(depth) == CV_32F || CV_MAT_DEPTH(depth) == CV_8U;
+  // any depth will be converted into 32-bit float.
+  (void) depth;
+  return true;         
 }
 
 bool PFMEncoder::write(const Mat& img, const std::vector<int>& params)
@@ -246,8 +248,8 @@ bool PFMEncoder::write(const Mat& img, const std::vector<int>& params)
         rgb_row[x*3+1] = bgr_row[x*3+1];
         rgb_row[x*3+2] = bgr_row[x*3+0];
       }
-      strm.putBytes(  reinterpret_cast<const uchar*>(rgb_row.data()),
-                      static_cast<int>(sizeof(float) * row_size));
+      strm.putBytes( reinterpret_cast<const uchar*>(rgb_row.data()),
+                     static_cast<int>(sizeof(float) * row_size) );
     } else if (float_img.channels() == 1) {
       strm.putBytes(float_img.ptr(y), sizeof(float) * float_img.cols);
     }


### PR DESCRIPTION
resolves  #12239

This pullrequest changes the encoding of non-float32-images when encoded to `pfm` format.
Formerly, anything other than float32 was converted to uint8 in order to encode it into the `pfm`-format, which is counter-intuitive and drops a lot of data unnecessarily.

With this fix, all three- or single-channel image types are converted to the corresponsing float32-type directly.
