### PR TITLE
cap-v4l: remove unwanted loop in V4L2 mainloop

### DIFF
--- a/modules/videoio/src/cap_v4l.cpp
+++ b/modules/videoio/src/cap_v4l.cpp
@@ -857,45 +857,39 @@ static int read_frame_v4l2(CvCaptureCAM_V4L* capture) {
 }
 
 static int mainloop_v4l2(CvCaptureCAM_V4L* capture) {
-    unsigned int count;
+    for (;;) {
+        fd_set fds;
+        struct timeval tv;
+        int r;
 
-    count = 1;
+        FD_ZERO (&fds);
+        FD_SET (capture->deviceHandle, &fds);
 
-    while (count-- > 0) {
-        for (;;) {
-            fd_set fds;
-            struct timeval tv;
-            int r;
+        /* Timeout. */
+        tv.tv_sec = 10;
+        tv.tv_usec = 0;
 
-            FD_ZERO (&fds);
-            FD_SET (capture->deviceHandle, &fds);
+        r = select (capture->deviceHandle+1, &fds, NULL, NULL, &tv);
 
-            /* Timeout. */
-            tv.tv_sec = 10;
-            tv.tv_usec = 0;
+        if (-1 == r) {
+            if (EINTR == errno)
+                continue;
 
-            r = select (capture->deviceHandle+1, &fds, NULL, NULL, &tv);
-
-            if (-1 == r) {
-                if (EINTR == errno)
-                    continue;
-
-                perror ("select");
-            }
-
-            if (0 == r) {
-                fprintf (stderr, "select timeout\n");
-
-                /* end the infinite loop */
-                break;
-            }
-
-            int returnCode = read_frame_v4l2 (capture);
-            if(returnCode == -1)
-                return -1;
-            if(returnCode == 1)
-                return 1;
+            perror ("select");
         }
+
+        if (0 == r) {
+            fprintf (stderr, "select timeout\n");
+
+            /* end the infinite loop */
+            break;
+        }
+
+        int returnCode = read_frame_v4l2 (capture);
+        if(returnCode == -1)
+            return -1;
+        if(returnCode == 1)
+            return 1;
     }
     return 0;
 }


### PR DESCRIPTION
### This pullrequest changes

Removes an unwanted while loop in cap_v4l.cpp

The while loop would run only once making it useless and leading
to confusion.

So, remove the unwanted while loop and just keep an infinite for
loop.

Note: Change better seen with ignoring whitespace changes.