### PR TITLE
Add export macro for ios conversion functions

### DIFF
--- a/modules/imgcodecs/include/opencv2/imgcodecs/ios.h
+++ b/modules/imgcodecs/include/opencv2/imgcodecs/ios.h
@@ -50,8 +50,8 @@
 //! @addtogroup imgcodecs_ios
 //! @{
 
-UIImage* MatToUIImage(const cv::Mat& image);
-void UIImageToMat(const UIImage* image,
-                         cv::Mat& m, bool alphaExist = false);
+CV_EXPORTS UIImage* MatToUIImage(const cv::Mat& image);
+CV_EXPORTS void UIImageToMat(const UIImage* image,
+                             cv::Mat& m, bool alphaExist = false);
 
 //! @}

--- a/modules/imgcodecs/src/ios_conversions.mm
+++ b/modules/imgcodecs/src/ios_conversions.mm
@@ -47,8 +47,8 @@
 #include "opencv2/core.hpp"
 #include "precomp.hpp"
 
-UIImage* MatToUIImage(const cv::Mat& image);
-void UIImageToMat(const UIImage* image, cv::Mat& m, bool alphaExist);
+CV_EXPORTS UIImage* MatToUIImage(const cv::Mat& image);
+CV_EXPORTS void UIImageToMat(const UIImage* image, cv::Mat& m, bool alphaExist);
 
 UIImage* MatToUIImage(const cv::Mat& image) {
 


### PR DESCRIPTION
This adds the export macros to the iOS UIImage conversion functions. Without the macro, the functions are not available when building OpenCV as a dynamic framework.

(This is a resubmission of a previous PR #12245 so that it can properly go to the 3.4 branch instead of master)