### PR TITLE
Fixed windows build with InferenceEngine

### DIFF
--- a/modules/dnn/src/layers/normalize_bbox_layer.cpp
+++ b/modules/dnn/src/layers/normalize_bbox_layer.cpp
@@ -276,7 +276,7 @@ public:
             {
                 auto weights = InferenceEngine::make_shared_blob<float>(InferenceEngine::Precision::FP32,
                                                                         InferenceEngine::Layout::C,
-                                                                        {numChannels});
+                                                                        {(size_t)numChannels});
                 weights->allocate();
                 std::vector<float> ones(numChannels, 1);
                 weights->set(ones);
@@ -286,7 +286,7 @@ public:
             else
             {
                 CV_Assert(numChannels == blobs[0].total());
-                ieLayer->blobs["weights"] = wrapToInfEngineBlob(blobs[0], {numChannels}, InferenceEngine::Layout::C);
+                ieLayer->blobs["weights"] = wrapToInfEngineBlob(blobs[0], {(size_t)numChannels}, InferenceEngine::Layout::C);
                 ieLayer->params["channel_shared"] = blobs[0].total() == 1 ? "1" : "0";
             }
             ieLayer->params["eps"] = format("%f", epsilon);


### PR DESCRIPTION
<!-- Please use this line to close one or multiple issues when this pullrequest gets merged
You can add another line right under the first one:
resolves #1234
resolves #1235
-->

### This pullrequest changes

VS 2015 compilation failed: 
```
normalize_bbox_layer.cpp(279): error C2398: Element '1': conversion from 'const int' to 'unsigned __int64' requires a narrowing conversion
```
