### PR TITLE
dnn(test): mark unstable OpenCL tests

### DIFF
--- a/modules/dnn/test/test_halide_layers.cpp
+++ b/modules/dnn/test/test_halide_layers.cpp
@@ -113,7 +113,11 @@ TEST_P(Convolution, Accuracy)
     bool skipCheck = false;
     if (cvtest::skipUnstableTests && backendId == DNN_BACKEND_OPENCV &&
         (targetId == DNN_TARGET_OPENCL || targetId == DNN_TARGET_OPENCL_FP16) &&
-        kernel == Size(3, 1) && stride == Size(1, 1) && pad == Size(0, 1))
+        (
+            (kernel == Size(3, 1) && stride == Size(1, 1) && pad == Size(0, 1)) ||
+            (stride.area() > 1 && !(pad.width == 0 && pad.height == 0))
+        )
+    )
         skipCheck = true;
 
     int sz[] = {outChannels, inChannels / group, kernel.height, kernel.width};


### PR DESCRIPTION

```
buildworker:Win64 OpenCL=windows-2
```