### PR TITLE
java: add a MatOfRotatedRect class

### DIFF
--- a/modules/core/misc/java/src/java/core+MatOfRotatedRect.java
+++ b/modules/core/misc/java/src/java/core+MatOfRotatedRect.java
@@ -1,0 +1,86 @@
+package org.opencv.core;
+
+import java.util.Arrays;
+import java.util.List;
+
+import org.opencv.core.RotatedRect;
+
+
+
+public class MatOfRotatedRect extends Mat {
+    // 64FC5
+    private static final int _depth = CvType.CV_64F;
+    private static final int _channels = 5;
+
+    public MatOfRotatedRect() {
+        super();
+    }
+
+    protected MatOfRotatedRect(long addr) {
+        super(addr);
+        if( !empty() && checkVector(_channels, _depth) < 0 )
+            throw new IllegalArgumentException("Incompatible Mat");
+        //FIXME: do we need release() here?
+    }
+
+    public static MatOfRotatedRect fromNativeAddr(long addr) {
+        return new MatOfRotatedRect(addr);
+    }
+
+    public MatOfRotatedRect(Mat m) {
+        super(m, Range.all());
+        if( !empty() && checkVector(_channels, _depth) < 0 )
+            throw new IllegalArgumentException("Incompatible Mat");
+        //FIXME: do we need release() here?
+    }
+
+    public MatOfRotatedRect(RotatedRect...a) {
+        super();
+        fromArray(a);
+    }
+
+    public void alloc(int elemNumber) {
+        if(elemNumber>0)
+            super.create(elemNumber, 1, CvType.makeType(_depth, _channels));
+    }
+
+    public void fromArray(RotatedRect...a) {
+        if(a==null || a.length==0)
+            return;
+        int num = a.length;
+        alloc(num);
+        double buff[] = new double[num * _channels];
+        for(int i=0; i<num; i++) {
+            RotatedRect r = a[i];
+            buff[_channels*i+0] = (double) r.center.x;
+            buff[_channels*i+1] = (double) r.center.y;
+            buff[_channels*i+2] = (double) r.size.width;
+            buff[_channels*i+3] = (double) r.size.height;
+            buff[_channels*i+4] = (double) r.angle;
+        }
+        put(0, 0, buff); //TODO: check ret val!
+    }
+
+    public RotatedRect[] toArray() {
+        int num = (int) total();
+        RotatedRect[] a = new RotatedRect[num];
+        if(num == 0)
+            return a;
+        double buff[] = new double[_channels];
+        for(int i=0; i<num; i++) {
+            get(i, 0, buff); //TODO: check ret val!
+            a[i] = new RotatedRect(buff);
+        }
+        return a;
+    }
+
+    public void fromList(List<RotatedRect> lr) {
+        RotatedRect ap[] = lr.toArray(new RotatedRect[0]);
+        fromArray(ap);
+    }
+
+    public List<RotatedRect> toList() {
+        RotatedRect[] ar = toArray();
+        return Arrays.asList(ar);
+    }
+}

--- a/modules/core/misc/java/test/RotatedRectTest.java
+++ b/modules/core/misc/java/test/RotatedRectTest.java
@@ -1,10 +1,15 @@
 package org.opencv.test.core;
 
+import org.opencv.core.CvType;
 import org.opencv.core.Point;
 import org.opencv.core.Rect;
 import org.opencv.core.RotatedRect;
+import org.opencv.core.MatOfRotatedRect;
 import org.opencv.core.Size;
 import org.opencv.test.OpenCVTestCase;
+
+import java.util.Arrays;
+import java.util.List;
 
 public class RotatedRectTest extends OpenCVTestCase {
 
@@ -188,4 +193,21 @@ public class RotatedRectTest extends OpenCVTestCase {
         assertEquals(expected, actual);
     }
 
+    public void testMatOfRotatedRect() {
+        RotatedRect a = new RotatedRect(new Point(1,2),new Size(3,4),5.678);
+        RotatedRect b = new RotatedRect(new Point(9,8),new Size(7,6),5.432);
+        MatOfRotatedRect m = new MatOfRotatedRect(a,b,a,b,a,b,a,b);
+        assertEquals(m.rows(), 8);
+        assertEquals(m.cols(), 1);
+        assertEquals(m.type(), CvType.CV_64FC(5));
+        RotatedRect[] arr = m.toArray();
+        assertTrue(arr[2].angle == 5.678);
+        assertTrue(arr[3].center.x == 9);
+        assertTrue(arr[3].size.width == 7);
+        List<RotatedRect> li = m.toList();
+        assertTrue(li.size() == 8);
+        RotatedRect rr = li.get(7);
+        assertTrue(rr.angle == 5.432);
+        assertTrue(rr.center.y == 8);
+    }
 }


### PR DESCRIPTION
related: #12226 , #11800

add a MatOfRotatedRect class (and a small test) to the java wrappers.

this is needed for the dnn wrappers, (EAST and YOLOv3 models).