### PR TITLE
java: change MatOfRotatedRect to CV_32FC5

### DIFF
--- a/modules/core/misc/java/src/java/core+MatOfRotatedRect.java
+++ b/modules/core/misc/java/src/java/core+MatOfRotatedRect.java
@@ -8,8 +8,8 @@ import org.opencv.core.RotatedRect;
 
 
 public class MatOfRotatedRect extends Mat {
-    // 64FC5
-    private static final int _depth = CvType.CV_64F;
+    // 32FC5
+    private static final int _depth = CvType.CV_32F;
     private static final int _channels = 5;
 
     public MatOfRotatedRect() {
@@ -49,14 +49,14 @@ public class MatOfRotatedRect extends Mat {
             return;
         int num = a.length;
         alloc(num);
-        double buff[] = new double[num * _channels];
+        float buff[] = new float[num * _channels];
         for(int i=0; i<num; i++) {
             RotatedRect r = a[i];
-            buff[_channels*i+0] = (double) r.center.x;
-            buff[_channels*i+1] = (double) r.center.y;
-            buff[_channels*i+2] = (double) r.size.width;
-            buff[_channels*i+3] = (double) r.size.height;
-            buff[_channels*i+4] = (double) r.angle;
+            buff[_channels*i+0] = (float) r.center.x;
+            buff[_channels*i+1] = (float) r.center.y;
+            buff[_channels*i+2] = (float) r.size.width;
+            buff[_channels*i+3] = (float) r.size.height;
+            buff[_channels*i+4] = (float) r.angle;
         }
         put(0, 0, buff); //TODO: check ret val!
     }
@@ -66,10 +66,10 @@ public class MatOfRotatedRect extends Mat {
         RotatedRect[] a = new RotatedRect[num];
         if(num == 0)
             return a;
-        double buff[] = new double[_channels];
+        float buff[] = new float[_channels];
         for(int i=0; i<num; i++) {
             get(i, 0, buff); //TODO: check ret val!
-            a[i] = new RotatedRect(buff);
+            a[i] = new RotatedRect(new Point(buff[0],buff[1]),new Size(buff[2],buff[3]),buff[4]);
         }
         return a;
     }

--- a/modules/core/misc/java/test/RotatedRectTest.java
+++ b/modules/core/misc/java/test/RotatedRectTest.java
@@ -199,15 +199,15 @@ public class RotatedRectTest extends OpenCVTestCase {
         MatOfRotatedRect m = new MatOfRotatedRect(a,b,a,b,a,b,a,b);
         assertEquals(m.rows(), 8);
         assertEquals(m.cols(), 1);
-        assertEquals(m.type(), CvType.CV_64FC(5));
+        assertEquals(m.type(), CvType.CV_32FC(5));
         RotatedRect[] arr = m.toArray();
-        assertTrue(arr[2].angle == 5.678);
-        assertTrue(arr[3].center.x == 9);
-        assertTrue(arr[3].size.width == 7);
+        assertEquals(arr[2].angle, a.angle, EPS);
+        assertEquals(arr[3].center.x, b.center.x);
+        assertEquals(arr[3].size.width, b.size.width);
         List<RotatedRect> li = m.toList();
-        assertTrue(li.size() == 8);
+        assertEquals(li.size(), 8);
         RotatedRect rr = li.get(7);
-        assertTrue(rr.angle == 5.432);
-        assertTrue(rr.center.y == 8);
+        assertEquals(rr.angle, b.angle, EPS);
+        assertEquals(rr.center.y, b.center.y);
     }
 }


### PR DESCRIPTION
my bad (sorry for the extra work).
but it must be float, not double, to be binary compatible to the c++ object.

related #12287