### PR TITLE
android: NDK17 support

### DIFF
--- a/platforms/android/build_sdk.py
+++ b/platforms/android/build_sdk.py
@@ -106,9 +106,13 @@ class ABI:
         self.cmake_vars = dict(
             ANDROID_STL="gnustl_static",
             ANDROID_ABI=self.name,
-            ANDROID_TOOLCHAIN_NAME=toolchain,
             ANDROID_PLATFORM_ID=platform_id,
         )
+        if toolchain is not None:
+            self.cmake_vars['ANDROID_TOOLCHAIN_NAME'] = toolchain
+        else:
+            self.cmake_vars['ANDROID_TOOLCHAIN'] = 'clang'
+            self.cmake_vars['ANDROID_STL'] = 'c++_static'
         if ndk_api_level:
             self.cmake_vars['ANDROID_NATIVE_API_LEVEL'] = ndk_api_level
         self.cmake_vars.update(cmake_vars)

--- a/platforms/android/ndk-17.config.py
+++ b/platforms/android/ndk-17.config.py
@@ -1,0 +1,6 @@
+ABIs = [
+    ABI("2", "armeabi-v7a", None, cmake_vars=dict(ANDROID_ABI='armeabi-v7a with NEON')),
+    ABI("3", "arm64-v8a",   None),
+    ABI("5", "x86_64",      None),
+    ABI("4", "x86",         None),
+]


### PR DESCRIPTION
GCC toolchain is deprecated and emits verbose messages.
Switched to Clang.