### PR TITLE
Added option to fail on missing testdata

### DIFF
--- a/modules/ts/src/ts.cpp
+++ b/modules/ts/src/ts.cpp
@@ -721,6 +721,7 @@ void checkIppStatus()
     }
 }
 
+static bool checkTestData = false;
 bool skipUnstableTests = false;
 bool runBigDataTests = false;
 int testThreads = 0;
@@ -733,6 +734,7 @@ void parseCustomOptions(int argc, char **argv)
         "{ test_threads       |-1       |the number of worker threads, if parallel execution is enabled}"
         "{ skip_unstable      |false    |skip unstable tests }"
         "{ test_bigdata       |false    |run BigData tests (>=2Gb) }"
+        "{ test_require_data  |false    |fail on missing non-required test data instead of skip}"
         "{ h   help           |false    |print help info                          }";
 
     cv::CommandLineParser parser(argc, argv, command_line_keys);
@@ -756,6 +758,7 @@ void parseCustomOptions(int argc, char **argv)
 
     skipUnstableTests = parser.get<bool>("skip_unstable");
     runBigDataTests = parser.get<bool>("test_bigdata");
+    checkTestData = parser.get<bool>("test_require_data");
 }
 
 
@@ -870,7 +873,7 @@ static std::string findData(const std::string& relative_path, bool required, boo
 #endif
 #endif
     const char* type = findDirectory ? "directory" : "data file";
-    if (required)
+    if (required || checkTestData)
         CV_Error(cv::Error::StsError, cv::format("OpenCV tests: Can't find required %s: %s", type, relative_path.c_str()));
     throw SkipTestException(cv::format("OpenCV tests: Can't find %s: %s", type, relative_path.c_str()));
 }


### PR DESCRIPTION
<!-- Please use this line to close one or multiple issues when this pullrequest gets merged
You can add another line right under the first one:
resolves #1234
resolves #1235
-->

### This pullrequest changes

Option `test_data_check` can be used to verify that no test cases have been skipped due to missing test data.

Example run without downloaded DL models:
```.sh
$ ./bin/opencv_test_dnn
...
[  PASSED  ] 1703 tests.
```
Same but with the new option enabled:
```.sh
$ ./bin/opencv_test_dnn  --test_require_data=true
...
[  PASSED  ] 1590 tests.                                                                                                  
[  FAILED  ] 113 tests, listed below: 
...
113 FAILED TESTS
```

