### PR TITLE
build: fix js build (make video->calib3d dependency optional)

### DIFF
--- a/modules/js/src/embindgen.py
+++ b/modules/js/src/embindgen.py
@@ -120,7 +120,7 @@ objdetect = {'': ['groupRectangles'],
              'HOGDescriptor': ['load', 'HOGDescriptor', 'getDefaultPeopleDetector', 'getDaimlerPeopleDetector', 'setSVMDetector', 'detectMultiScale'],
              'CascadeClassifier': ['load', 'detectMultiScale2', 'CascadeClassifier', 'detectMultiScale3', 'empty', 'detectMultiScale']}
 
-video = {'': ['CamShift', 'calcOpticalFlowFarneback', 'calcOpticalFlowPyrLK', 'createBackgroundSubtractorMOG2', 'estimateRigidTransform',\
+video = {'': ['CamShift', 'calcOpticalFlowFarneback', 'calcOpticalFlowPyrLK', 'createBackgroundSubtractorMOG2', \
              'findTransformECC', 'meanShift'],
          'BackgroundSubtractorMOG2': ['BackgroundSubtractorMOG2', 'apply'],
          'BackgroundSubtractor': ['apply', 'getBackgroundImage']}

--- a/modules/video/CMakeLists.txt
+++ b/modules/video/CMakeLists.txt
@@ -1,2 +1,2 @@
 set(the_description "Video Analysis")
-ocv_define_module(video opencv_imgproc opencv_calib3d WRAP java python js)
+ocv_define_module(video opencv_imgproc OPTIONAL opencv_calib3d WRAP java python js)

--- a/modules/video/src/lkpyramid.cpp
+++ b/modules/video/src/lkpyramid.cpp
@@ -45,7 +45,9 @@
 #include "lkpyramid.hpp"
 #include "opencl_kernels_video.hpp"
 #include "opencv2/core/hal/intrin.hpp"
+#ifdef HAVE_OPENCV_CALIB3D
 #include "opencv2/calib3d.hpp"
+#endif
 
 #include "opencv2/core/openvx/ovx_defs.hpp"
 
@@ -1402,7 +1404,10 @@ void cv::calcOpticalFlowPyrLK( InputArray _prevImg, InputArray _nextImg,
 cv::Mat cv::estimateRigidTransform( InputArray src1, InputArray src2, bool fullAffine )
 {
     CV_INSTRUMENT_REGION()
-
+#ifndef HAVE_OPENCV_CALIB3D
+    CV_UNUSED(src1); CV_UNUSED(src2); CV_UNUSED(fullAffine);
+    CV_Error(Error::StsError, "estimateRigidTransform requires calib3d module");
+#else
     Mat A = src1.getMat(), B = src2.getMat();
 
     const int COUNT = 15;
@@ -1505,8 +1510,10 @@ cv::Mat cv::estimateRigidTransform( InputArray src1, InputArray src2, bool fullA
     if (fullAffine)
     {
         return estimateAffine2D(pA, pB);
-    } else
+    }
+    else
     {
         return estimateAffinePartial2D(pA, pB);
     }
+#endif
 }

--- a/platforms/js/build_js.py
+++ b/platforms/js/build_js.py
@@ -129,7 +129,7 @@ class Builder:
                "-DWITH_ITT=OFF",
                "-DBUILD_ZLIB=ON",
                "-DBUILD_opencv_apps=OFF",
-               "-DBUILD_opencv_calib3d=OFF",
+               "-DBUILD_opencv_calib3d=ON",
                "-DBUILD_opencv_dnn=ON",
                "-DBUILD_opencv_features2d=OFF",
                "-DBUILD_opencv_flann=OFF",


### PR DESCRIPTION
resolves #12359

- `estimateRigidTransform()` is excluded from JS bindings

related #12248

```
**WIP**
force_builders=Custom
docker_image:Custom=javascript
docker_image:Docs=docs-js
```