### PR TITLE
imgcodecs(webp): use safe cast to size_t on Win32

### DIFF
--- a/modules/imgcodecs/src/grfmt_webp.cpp
+++ b/modules/imgcodecs/src/grfmt_webp.cpp
@@ -107,7 +107,7 @@ bool WebPDecoder::readHeader()
     {
         fs.open(m_filename.c_str(), std::ios::binary);
         fs.seekg(0, std::ios::end);
-        fs_size = fs.tellg();
+        fs_size = safeCastToSizeT(fs.tellg(), "File is too large");
         fs.seekg(0, std::ios::beg);
         CV_Assert(fs && "File stream error");
         CV_CheckGE(fs_size, WEBP_HEADER_SIZE, "File is too small");

--- a/modules/imgcodecs/src/utils.hpp
+++ b/modules/imgcodecs/src/utils.hpp
@@ -44,6 +44,15 @@
 
 int validateToInt(size_t step);
 
+template <typename _Tp> static inline
+size_t safeCastToSizeT(const _Tp v_origin, const char* msg)
+{
+    const size_t value_cast = (size_t)v_origin;
+    if ((_Tp)value_cast != v_origin)
+        CV_Error(cv::Error::StsError, msg ? msg : "Can't cast value into size_t");
+    return value_cast;
+}
+
 struct PaletteEntry
 {
     unsigned char b, g, r, a;


### PR DESCRIPTION
related #12353

```
force_builders=win32
```