### PR TITLE
cmake: update install paths (Linux)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -373,8 +373,6 @@ endif()
 
 if(ANDROID OR WIN32)
   ocv_update(OPENCV_DOC_INSTALL_PATH doc)
-else()
-  ocv_update(OPENCV_DOC_INSTALL_PATH share/OpenCV/doc)
 endif()
 
 if(WIN32 AND CMAKE_HOST_SYSTEM_NAME MATCHES Windows)
@@ -414,8 +412,6 @@ if(ANDROID)
   ocv_update(OPENCV_TEST_DATA_INSTALL_PATH "sdk/etc/testdata")
 elseif(WIN32)
   ocv_update(OPENCV_TEST_DATA_INSTALL_PATH "testdata")
-else()
-  ocv_update(OPENCV_TEST_DATA_INSTALL_PATH "share/OpenCV/testdata")
 endif()
 
 if(ANDROID)
@@ -428,6 +424,7 @@ if(ANDROID)
   ocv_update(OPENCV_INCLUDE_INSTALL_PATH sdk/native/jni/include)
   ocv_update(OPENCV_SAMPLES_SRC_INSTALL_PATH samples/native)
   ocv_update(OPENCV_OTHER_INSTALL_PATH   sdk/etc)
+  ocv_update(OPENCV_LICENSES_INSTALL_PATH "${OPENCV_OTHER_INSTALL_PATH}/licenses")
 else()
   set(LIBRARY_OUTPUT_PATH                "${OpenCV_BINARY_DIR}/lib")
   ocv_update(3P_LIBRARY_OUTPUT_PATH      "${OpenCV_BINARY_DIR}/3rdparty/lib${LIB_SUFFIX}")
@@ -443,42 +440,40 @@ else()
     ocv_update(OPENCV_JAR_INSTALL_PATH java)
     ocv_update(OPENCV_OTHER_INSTALL_PATH   etc)
     ocv_update(OPENCV_CONFIG_INSTALL_PATH  ".")
+    ocv_update(OPENCV_INCLUDE_INSTALL_PATH "include")
+    ocv_update(OPENCV_LICENSES_INSTALL_PATH "${OPENCV_OTHER_INSTALL_PATH}/licenses")
   else()
+    # Note: layout differs from OpenCV 3.4
     include(GNUInstallDirs)
-    ocv_update(OPENCV_LIB_INSTALL_PATH     ${CMAKE_INSTALL_LIBDIR}${LIB_SUFFIX})
-    ocv_update(OPENCV_3P_LIB_INSTALL_PATH  share/OpenCV/3rdparty/${OPENCV_LIB_INSTALL_PATH})
-    ocv_update(OPENCV_SAMPLES_SRC_INSTALL_PATH    share/OpenCV/samples)
-    ocv_update(OPENCV_JAR_INSTALL_PATH share/OpenCV/java)
-    ocv_update(OPENCV_OTHER_INSTALL_PATH   share/OpenCV)
-
-    if(NOT DEFINED OPENCV_CONFIG_INSTALL_PATH)
-      math(EXPR SIZEOF_VOID_P_BITS "8 * ${CMAKE_SIZEOF_VOID_P}")
-      if(LIB_SUFFIX AND NOT SIZEOF_VOID_P_BITS EQUAL LIB_SUFFIX)
-        ocv_update(OPENCV_CONFIG_INSTALL_PATH ${CMAKE_INSTALL_LIBDIR}${LIB_SUFFIX}/cmake/opencv)
-      else()
-        ocv_update(OPENCV_CONFIG_INSTALL_PATH share/OpenCV)
-      endif()
-    endif()
+    ocv_update(OPENCV_INCLUDE_INSTALL_PATH       "${CMAKE_INSTALL_INCLUDEDIR}/opencv4")
+    ocv_update(OPENCV_LIB_INSTALL_PATH           "${CMAKE_INSTALL_LIBDIR}${LIB_SUFFIX}")
+    ocv_update(OPENCV_CONFIG_INSTALL_PATH        "${OPENCV_LIB_INSTALL_PATH}/cmake/opencv4")
+    ocv_update(OPENCV_3P_LIB_INSTALL_PATH        "${OPENCV_LIB_INSTALL_PATH}/opencv4/3rdparty")
+    ocv_update(OPENCV_SAMPLES_SRC_INSTALL_PATH   "${CMAKE_INSTALL_DATAROOTDIR}/opencv4/samples")
+    ocv_update(OPENCV_DOC_INSTALL_PATH           "${CMAKE_INSTALL_DATAROOTDIR}/doc/opencv4")
+    ocv_update(OPENCV_JAR_INSTALL_PATH           "${CMAKE_INSTALL_DATAROOTDIR}/java/opencv4")
+    ocv_update(OPENCV_TEST_DATA_INSTALL_PATH     "${CMAKE_INSTALL_DATAROOTDIR}/opencv4/testdata")
+    ocv_update(OPENCV_OTHER_INSTALL_PATH         "${CMAKE_INSTALL_DATAROOTDIR}/opencv4")
+    ocv_update(OPENCV_LICENSES_INSTALL_PATH      "${CMAKE_INSTALL_DATAROOTDIR}/licenses/opencv4")
   endif()
-  ocv_update(OPENCV_INCLUDE_INSTALL_PATH "include")
 endif()
 
 ocv_update(CMAKE_INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/${OPENCV_LIB_INSTALL_PATH}")
 set(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
 
 if(INSTALL_TO_MANGLED_PATHS)
-  set(OPENCV_INCLUDE_INSTALL_PATH ${OPENCV_INCLUDE_INSTALL_PATH}/opencv-${OPENCV_VERSION})
   foreach(v
+      OPENCV_INCLUDE_INSTALL_PATH
+      # file names include version (.so/.dll): OPENCV_LIB_INSTALL_PATH
+      OPENCV_CONFIG_INSTALL_PATH
       OPENCV_3P_LIB_INSTALL_PATH
       OPENCV_SAMPLES_SRC_INSTALL_PATH
-      OPENCV_CONFIG_INSTALL_PATH
       OPENCV_DOC_INSTALL_PATH
-      OPENCV_JAR_INSTALL_PATH
+      # JAR file name includes version: OPENCV_JAR_INSTALL_PATH
       OPENCV_TEST_DATA_INSTALL_PATH
       OPENCV_OTHER_INSTALL_PATH
     )
-    string(REPLACE "OpenCV" "OpenCV-${OPENCV_VERSION}" ${v} "${${v}}")
-    string(REPLACE "opencv" "opencv-${OPENCV_VERSION}" ${v} "${${v}}")
+    string(REGEX REPLACE "opencv[0-9]*" "opencv-${OPENCV_VERSION}" ${v} "${${v}}")
   endforeach()
 endif()
 

--- a/cmake/OpenCVGenPkgconfig.cmake
+++ b/cmake/OpenCVGenPkgconfig.cmake
@@ -43,9 +43,9 @@ endmacro()
 if(NOT DEFINED CMAKE_HELPER_SCRIPT)
 
 if(INSTALL_TO_MANGLED_PATHS)
-  set(OPENCV_PC_FILE_NAME "opencv-${OPENCV_VERSION}.pc")
+  ocv_update(OPENCV_PC_FILE_NAME "opencv-${OPENCV_VERSION}.pc")
 else()
-  set(OPENCV_PC_FILE_NAME opencv.pc)
+  ocv_update(OPENCV_PC_FILE_NAME opencv4.pc)
 endif()
 
 # build the list of opencv libs and dependencies for all modules

--- a/cmake/OpenCVUtils.cmake
+++ b/cmake/OpenCVUtils.cmake
@@ -1089,7 +1089,7 @@ function(ocv_install_3rdparty_licenses library)
     get_filename_component(name "${filename}" NAME)
     install(
       FILES "${filename}"
-      DESTINATION "${OPENCV_OTHER_INSTALL_PATH}/licenses"
+      DESTINATION "${OPENCV_LICENSES_INSTALL_PATH}"
       COMPONENT licenses
       RENAME "${library}-${name}"
       OPTIONAL)

--- a/platforms/ios/build_framework.py
+++ b/platforms/ios/build_framework.py
@@ -128,6 +128,8 @@ class Builder:
             "-DAPPLE_FRAMEWORK=ON",
             "-DCMAKE_INSTALL_PREFIX=install",
             "-DCMAKE_BUILD_TYPE=Release",
+            "-DOPENCV_INCLUDE_INSTALL_PATH=include",
+            "-DOPENCV_3P_LIB_INSTALL_PATH=lib/3rdparty"
         ] + ([
             "-DBUILD_SHARED_LIBS=ON",
             "-DCMAKE_MACOSX_BUNDLE=ON",
@@ -199,7 +201,7 @@ class Builder:
     def mergeLibs(self, builddir):
         res = os.path.join(builddir, "lib", "Release", "libopencv_merged.a")
         libs = glob.glob(os.path.join(builddir, "install", "lib", "*.a"))
-        libs3 = glob.glob(os.path.join(builddir, "install", "share", "OpenCV", "3rdparty", "lib", "*.a"))
+        libs3 = glob.glob(os.path.join(builddir, "install", "lib", "3rdparty", "*.a"))
         print("Merging libraries:\n\t%s" % "\n\t".join(libs + libs3), file=sys.stderr)
         execute(["libtool", "-static", "-o", res] + libs + libs3)
 

--- a/samples/cpp/example_cmake/CMakeLists.txt
+++ b/samples/cpp/example_cmake/CMakeLists.txt
@@ -18,6 +18,7 @@ find_package(OpenCV REQUIRED)
 # in the OpenCVConfig.cmake file.
 # Print some message showing some of them
 message(STATUS "OpenCV library status:")
+message(STATUS "    config: ${OpenCV_DIR}")
 message(STATUS "    version: ${OpenCV_VERSION}")
 message(STATUS "    libraries: ${OpenCV_LIBS}")
 message(STATUS "    include path: ${OpenCV_INCLUDE_DIRS}")


### PR DESCRIPTION
Improve support for side-by-side installations (multiple major versions).
Improve conformance with Linux/GNU installation layout.

Details:
- includes have one extra level: `/usr/include/opencv4/` (no changes in applications are required if CMake is used).
- CMake config is moved into "lib". It is incorrect to place it in "share" directory due direct paths to binaries.
- changed paths for "doc", "licenses", "java"
- use "opencv4" by default (except "lib" - no "opencv" in path)
- pkg-config file is renamed to `opencv4.pc`
- use lower-case "opencv" in paths

All paths are still configurable.

```
**WIP**
force_builders=linux,docs
test_modules=core
build_contrib:iOS=ON
```