### PR TITLE
cap_v4l: Fix private control enumeration end condition

### DIFF
--- a/modules/videoio/src/cap_v4l.cpp
+++ b/modules/videoio/src/cap_v4l.cpp
@@ -512,9 +512,11 @@ static void v4l2_scan_controls(CvCaptureCAM_V4L* capture)
 
     for (ctrl_id = V4L2_CID_PRIVATE_BASE;;ctrl_id++)
     {
+        errno = 0;
+
         v4l2_control_range(capture, ctrl_id);
 
-        if (errno == EINVAL)
+        if (errno)
             break;
     }
 


### PR DESCRIPTION
Currently the private control enumeration will be stopped when QUERYCTRL
returns -EINVAL only. It is possible however that other errors occur.

One particular case is when the v4l2 device doesn't support any controls
and doesn't implement the QUERYCTRL ioctl. In that case the v4l2
framework returns -ENOTTY. In that case the current control enumeration
will go in an endless loop.

To fix this change the control enumeration stop condition. If any errors
occur, end the control enumeration.

Signed-off-by: Todor Tomov <todor.tomov@linaro.org>

<!-- Please use this line to close one or multiple issues when this pullrequest gets merged
You can add another line right under the first one:
resolves #1234
resolves #1235
-->

### This pullrequest changes

<!-- Please describe what your pullrequest is changing -->
