### PR TITLE
(3.4) backport fixes for static analyzer warnings

### DIFF
--- a/modules/core/include/opencv2/core/mat.inl.hpp
+++ b/modules/core/include/opencv2/core/mat.inl.hpp
@@ -1026,7 +1026,7 @@ _Tp* Mat::ptr(int y)
 template<typename _Tp> inline
 const _Tp* Mat::ptr(int y) const
 {
-    CV_DbgAssert( y == 0 || (data && dims >= 1 && data && (unsigned)y < (unsigned)size.p[0]) );
+    CV_DbgAssert( y == 0 || (data && dims >= 1 && (unsigned)y < (unsigned)size.p[0]) );
     return (const _Tp*)(data + step.p[0] * y);
 }
 

--- a/modules/core/src/arithm.cpp
+++ b/modules/core/src/arithm.cpp
@@ -270,7 +270,7 @@ static void binary_op( InputArray _src1, InputArray _src2, OutputArray _dst,
     if( !haveScalar )
     {
         const Mat* arrays[] = { &src1, &src2, &dst, &mask, 0 };
-        uchar* ptrs[4];
+        uchar* ptrs[4] = {};
 
         NAryMatIterator it(arrays, ptrs);
         size_t total = it.size, blocksize = total;
@@ -306,7 +306,7 @@ static void binary_op( InputArray _src1, InputArray _src2, OutputArray _dst,
     else
     {
         const Mat* arrays[] = { &src1, &dst, &mask, 0 };
-        uchar* ptrs[3];
+        uchar* ptrs[3] = {};
 
         NAryMatIterator it(arrays, ptrs);
         size_t total = it.size, blocksize = std::min(total, blocksize0);
@@ -745,7 +745,7 @@ static void arithm_op(InputArray _src1, InputArray _src2, OutputArray _dst,
     if( !haveScalar )
     {
         const Mat* arrays[] = { &src1, &src2, &dst, &mask, 0 };
-        uchar* ptrs[4];
+        uchar* ptrs[4] = {};
 
         NAryMatIterator it(arrays, ptrs);
         size_t total = it.size, blocksize = total;
@@ -812,7 +812,7 @@ static void arithm_op(InputArray _src1, InputArray _src2, OutputArray _dst,
     else
     {
         const Mat* arrays[] = { &src1, &dst, &mask, 0 };
-        uchar* ptrs[3];
+        uchar* ptrs[3] = {};
 
         NAryMatIterator it(arrays, ptrs);
         size_t total = it.size, blocksize = std::min(total, blocksize0);
@@ -1293,7 +1293,7 @@ void cv::compare(InputArray _src1, InputArray _src2, OutputArray _dst, int op)
     if( !haveScalar )
     {
         const Mat* arrays[] = { &src1, &src2, &dst, 0 };
-        uchar* ptrs[3];
+        uchar* ptrs[3] = {};
 
         NAryMatIterator it(arrays, ptrs);
         size_t total = it.size;
@@ -1304,7 +1304,7 @@ void cv::compare(InputArray _src1, InputArray _src2, OutputArray _dst, int op)
     else
     {
         const Mat* arrays[] = { &src1, &dst, 0 };
-        uchar* ptrs[2];
+        uchar* ptrs[2] = {};
 
         NAryMatIterator it(arrays, ptrs);
         size_t total = it.size, blocksize = std::min(total, blocksize0);
@@ -1801,7 +1801,7 @@ void cv::inRange(InputArray _src, InputArray _lowerb,
 
     const Mat* arrays_sc[] = { &src, &dst, 0 };
     const Mat* arrays_nosc[] = { &src, &dst, &lb, &ub, 0 };
-    uchar* ptrs[4];
+    uchar* ptrs[4] = {};
 
     NAryMatIterator it(lbScalar && ubScalar ? arrays_sc : arrays_nosc, ptrs);
     size_t total = it.size, blocksize = std::min(total, blocksize0);

--- a/modules/core/src/convert.cpp
+++ b/modules/core/src/convert.cpp
@@ -1347,7 +1347,7 @@ void cv::Mat::convertTo(OutputArray _dst, int _type, double alpha, double beta) 
     else
     {
         const Mat* arrays[] = {&src, &dst, 0};
-        uchar* ptrs[2];
+        uchar* ptrs[2] = {};
         NAryMatIterator it(arrays, ptrs);
         Size sz((int)(it.size*cn), 1);
 
@@ -1496,7 +1496,7 @@ void cv::convertFp16( InputArray _src, OutputArray _dst)
     else
     {
         const Mat* arrays[] = {&src, &dst, 0};
-        uchar* ptrs[2];
+        uchar* ptrs[2] = {};
         NAryMatIterator it(arrays, ptrs);
         Size sz((int)(it.size*cn), 1);
 

--- a/modules/core/src/convert_scale.cpp
+++ b/modules/core/src/convert_scale.cpp
@@ -1775,7 +1775,7 @@ void cv::convertScaleAbs( InputArray _src, OutputArray _dst, double alpha, doubl
     else
     {
         const Mat* arrays[] = {&src, &dst, 0};
-        uchar* ptrs[2];
+        uchar* ptrs[2] = {};
         NAryMatIterator it(arrays, ptrs);
         Size sz((int)it.size*cn, 1);
 

--- a/modules/core/src/copy.cpp
+++ b/modules/core/src/copy.cpp
@@ -306,7 +306,7 @@ void Mat::copyTo( OutputArray _dst ) const
     if( total() != 0 )
     {
         const Mat* arrays[] = { this, &dst };
-        uchar* ptrs[2];
+        uchar* ptrs[2] = {};
         NAryMatIterator it(arrays, ptrs, 2);
         size_t sz = it.size*elemSize();
 
@@ -399,7 +399,7 @@ void Mat::copyTo( OutputArray _dst, InputArray _mask ) const
     }
 
     const Mat* arrays[] = { this, &dst, &mask, 0 };
-    uchar* ptrs[3];
+    uchar* ptrs[3] = {};
     NAryMatIterator it(arrays, ptrs);
     Size sz((int)(it.size*mcn), 1);
 

--- a/modules/core/src/count_non_zero.cpp
+++ b/modules/core/src/count_non_zero.cpp
@@ -314,7 +314,7 @@ int cv::countNonZero( InputArray _src )
     CV_Assert( func != 0 );
 
     const Mat* arrays[] = {&src, 0};
-    uchar* ptrs[1];
+    uchar* ptrs[1] = {};
     NAryMatIterator it(arrays, ptrs);
     int total = (int)it.size, nz = 0;
 

--- a/modules/core/src/lut.cpp
+++ b/modules/core/src/lut.cpp
@@ -342,7 +342,7 @@ public:
         int lutcn = lut_.channels();
 
         const Mat* arrays[] = {&src, &dst, 0};
-        uchar* ptrs[2];
+        uchar* ptrs[2] = {};
         NAryMatIterator it(arrays, ptrs);
         int len = (int)it.size;
 
@@ -408,7 +408,7 @@ void cv::LUT( InputArray _src, InputArray _lut, OutputArray _dst )
     CV_Assert( func != 0 );
 
     const Mat* arrays[] = {&src, &dst, 0};
-    uchar* ptrs[2];
+    uchar* ptrs[2] = {};
     NAryMatIterator it(arrays, ptrs);
     int len = (int)it.size;
 

--- a/modules/core/src/mathfuncs.cpp
+++ b/modules/core/src/mathfuncs.cpp
@@ -158,7 +158,7 @@ void magnitude( InputArray src1, InputArray src2, OutputArray dst )
     Mat Mag = dst.getMat();
 
     const Mat* arrays[] = {&X, &Y, &Mag, 0};
-    uchar* ptrs[3];
+    uchar* ptrs[3] = {};
     NAryMatIterator it(arrays, ptrs);
     int len = (int)it.size*cn;
 
@@ -194,7 +194,7 @@ void phase( InputArray src1, InputArray src2, OutputArray dst, bool angleInDegre
     Mat Angle = dst.getMat();
 
     const Mat* arrays[] = {&X, &Y, &Angle, 0};
-    uchar* ptrs[3];
+    uchar* ptrs[3] = {};
     NAryMatIterator it(arrays, ptrs);
     int j, total = (int)(it.size*cn), blockSize = total;
     size_t esz1 = X.elemSize1();
@@ -280,7 +280,7 @@ void cartToPolar( InputArray src1, InputArray src2,
     Mat Mag = dst1.getMat(), Angle = dst2.getMat();
 
     const Mat* arrays[] = {&X, &Y, &Mag, &Angle, 0};
-    uchar* ptrs[4];
+    uchar* ptrs[4] = {};
     NAryMatIterator it(arrays, ptrs);
     int j, total = (int)(it.size*cn), blockSize = std::min(total, ((BLOCK_SIZE+cn-1)/cn)*cn);
     size_t esz1 = X.elemSize1();
@@ -577,7 +577,7 @@ void polarToCart( InputArray src1, InputArray src2,
     CV_IPP_RUN(!angleInDegrees, ipp_polarToCart(Mag, Angle, X, Y));
 
     const Mat* arrays[] = {&Mag, &Angle, &X, &Y, 0};
-    uchar* ptrs[4];
+    uchar* ptrs[4] = {};
     NAryMatIterator it(arrays, ptrs);
     cv::AutoBuffer<float> _buf;
     float* buf[2] = {0, 0};
@@ -676,7 +676,7 @@ void exp( InputArray _src, OutputArray _dst )
     Mat dst = _dst.getMat();
 
     const Mat* arrays[] = {&src, &dst, 0};
-    uchar* ptrs[2];
+    uchar* ptrs[2] = {};
     NAryMatIterator it(arrays, ptrs);
     int len = (int)(it.size*cn);
 
@@ -709,7 +709,7 @@ void log( InputArray _src, OutputArray _dst )
     Mat dst = _dst.getMat();
 
     const Mat* arrays[] = {&src, &dst, 0};
-    uchar* ptrs[2];
+    uchar* ptrs[2] = {};
     NAryMatIterator it(arrays, ptrs);
     int len = (int)(it.size*cn);
 
@@ -1241,7 +1241,7 @@ void pow( InputArray _src, double power, OutputArray _dst )
     Mat dst = _dst.getMat();
 
     const Mat* arrays[] = {&src, &dst, 0};
-    uchar* ptrs[2];
+    uchar* ptrs[2] = {};
     NAryMatIterator it(arrays, ptrs);
     int len = (int)(it.size*cn);
 
@@ -1588,7 +1588,7 @@ void patchNaNs( InputOutputArray _a, double _val )
 
     Mat a = _a.getMat();
     const Mat* arrays[] = {&a, 0};
-    int* ptrs[1];
+    int* ptrs[1] = {};
     NAryMatIterator it(arrays, (uchar**)ptrs);
     size_t len = it.size*a.channels();
     Cv32suf val;

--- a/modules/core/src/matmul.cpp
+++ b/modules/core/src/matmul.cpp
@@ -2144,7 +2144,7 @@ void cv::transform( InputArray _src, OutputArray _dst, InputArray _mtx )
     CV_Assert( func != 0 );
 
     const Mat* arrays[] = {&src, &dst, 0};
-    uchar* ptrs[2];
+    uchar* ptrs[2] = {};
     NAryMatIterator it(arrays, ptrs);
     size_t i, total = it.size;
 
@@ -2290,7 +2290,7 @@ void cv::perspectiveTransform( InputArray _src, OutputArray _dst, InputArray _mt
     CV_Assert( func != 0 );
 
     const Mat* arrays[] = {&src, &dst, 0};
-    uchar* ptrs[2];
+    uchar* ptrs[2] = {};
     NAryMatIterator it(arrays, ptrs);
     size_t i, total = it.size;
 
@@ -2441,7 +2441,7 @@ void cv::scaleAdd( InputArray _src1, double alpha, InputArray _src2, OutputArray
     }
 
     const Mat* arrays[] = {&src1, &src2, &dst, 0};
-    uchar* ptrs[3];
+    uchar* ptrs[3] = {};
     NAryMatIterator it(arrays, ptrs);
     size_t i, len = it.size*cn;
 
@@ -3301,7 +3301,7 @@ double Mat::dot(InputArray _mat) const
     }
 
     const Mat* arrays[] = {this, &mat, 0};
-    uchar* ptrs[2];
+    uchar* ptrs[2] = {};
     NAryMatIterator it(arrays, ptrs);
     int len = (int)(it.size*cn);
     double r = 0;

--- a/modules/core/src/matrix_wrap.cpp
+++ b/modules/core/src/matrix_wrap.cpp
@@ -939,7 +939,7 @@ bool _InputArray::isContinuous(int i) const
     if( k == STD_VECTOR_MAT )
     {
         const std::vector<Mat>& vv = *(const std::vector<Mat>*)obj;
-        CV_Assert((size_t)i < vv.size());
+        CV_Assert(i >= 0 && (size_t)i < vv.size());
         return vv[i].isContinuous();
     }
 
@@ -953,7 +953,7 @@ bool _InputArray::isContinuous(int i) const
     if( k == STD_VECTOR_UMAT )
     {
         const std::vector<UMat>& vv = *(const std::vector<UMat>*)obj;
-        CV_Assert((size_t)i < vv.size());
+        CV_Assert(i >= 0 && (size_t)i < vv.size());
         return vv[i].isContinuous();
     }
 

--- a/modules/core/src/mean.cpp
+++ b/modules/core/src/mean.cpp
@@ -121,7 +121,7 @@ cv::Scalar cv::mean( InputArray _src, InputArray _mask )
     CV_Assert( cn <= 4 && func != 0 );
 
     const Mat* arrays[] = {&src, &mask, 0};
-    uchar* ptrs[2];
+    uchar* ptrs[2] = {};
     NAryMatIterator it(arrays, ptrs);
     int total = (int)it.size, blockSize = total, intSumBlockSize = 0;
     int j, count = 0;
@@ -786,7 +786,7 @@ void cv::meanStdDev( InputArray _src, OutputArray _mean, OutputArray _sdv, Input
     CV_Assert( func != 0 );
 
     const Mat* arrays[] = {&src, &mask, 0};
-    uchar* ptrs[2];
+    uchar* ptrs[2] = {};
     NAryMatIterator it(arrays, ptrs);
     int total = (int)it.size, blockSize = total, intSumBlockSize = 0;
     int j, count = 0, nz0 = 0;

--- a/modules/core/src/minmax.cpp
+++ b/modules/core/src/minmax.cpp
@@ -770,7 +770,7 @@ void cv::minMaxIdx(InputArray _src, double* minVal,
     CV_Assert( func != 0 );
 
     const Mat* arrays[] = {&src, &mask, 0};
-    uchar* ptrs[2];
+    uchar* ptrs[2] = {};
     NAryMatIterator it(arrays, ptrs);
 
     size_t minidx = 0, maxidx = 0;

--- a/modules/core/src/norm.cpp
+++ b/modules/core/src/norm.cpp
@@ -710,7 +710,7 @@ double cv::norm( InputArray _src, int normType, InputArray _mask )
         int cellSize = normType == NORM_HAMMING ? 1 : 2;
 
         const Mat* arrays[] = {&src, 0};
-        uchar* ptrs[1];
+        uchar* ptrs[1] = {};
         NAryMatIterator it(arrays, ptrs);
         int total = (int)it.size;
         int result = 0;
@@ -727,7 +727,7 @@ double cv::norm( InputArray _src, int normType, InputArray _mask )
     CV_Assert( func != 0 );
 
     const Mat* arrays[] = {&src, &mask, 0};
-    uchar* ptrs[2];
+    uchar* ptrs[2] = {};
     union
     {
         double d;
@@ -1168,7 +1168,7 @@ double cv::norm( InputArray _src1, InputArray _src2, int normType, InputArray _m
         int cellSize = normType == NORM_HAMMING ? 1 : 2;
 
         const Mat* arrays[] = {&src1, &src2, 0};
-        uchar* ptrs[2];
+        uchar* ptrs[2] = {};
         NAryMatIterator it(arrays, ptrs);
         int total = (int)it.size;
         int result = 0;
@@ -1185,7 +1185,7 @@ double cv::norm( InputArray _src1, InputArray _src2, int normType, InputArray _m
     CV_Assert( func != 0 );
 
     const Mat* arrays[] = {&src1, &src2, &mask, 0};
-    uchar* ptrs[3];
+    uchar* ptrs[3] = {};
     union
     {
         double d;

--- a/modules/core/src/persistence_json.cpp
+++ b/modules/core/src/persistence_json.cpp
@@ -238,11 +238,11 @@ static char* icvJSONParseValue( CvFileStorage* fs, char* ptr, CvFileNode* node )
                         CV_PARSE_ERROR("Invalid `dt` in Base64 header");
                 }
 
-                /* set base64_beg to beginning of base64 data */
-                base64_beg = &base64_buffer.at( base64::ENCODED_HEADER_SIZE );
 
                 if ( base64_buffer.size() > base64::ENCODED_HEADER_SIZE )
                 {
+                    /* set base64_beg to beginning of base64 data */
+                    base64_beg = &base64_buffer.at( base64::ENCODED_HEADER_SIZE );
                     if ( !base64::base64_valid( base64_beg, 0U, base64_end - base64_beg ) )
                         CV_PARSE_ERROR( "Invalid Base64 data." );
 

--- a/modules/core/src/sum.cpp
+++ b/modules/core/src/sum.cpp
@@ -602,7 +602,7 @@ cv::Scalar cv::sum( InputArray _src )
     CV_Assert( cn <= 4 && func != 0 );
 
     const Mat* arrays[] = {&src, 0};
-    uchar* ptrs[1];
+    uchar* ptrs[1] = {};
     NAryMatIterator it(arrays, ptrs);
     Scalar s;
     int total = (int)it.size, blockSize = total, intSumBlockSize = 0;

--- a/modules/cudaarithm/src/arithm.cpp
+++ b/modules/cudaarithm/src/arithm.cpp
@@ -451,7 +451,6 @@ namespace
         Size block_size;
         Size user_block_size;
         Size dft_size;
-        int spect_len;
 
         GpuMat image_spect, templ_spect, result_spect;
         GpuMat image_block, templ_block, result_data;
@@ -484,7 +483,7 @@ namespace
         createContinuous(dft_size, CV_32F, templ_block);
         createContinuous(dft_size, CV_32F, result_data);
 
-        spect_len = dft_size.height * (dft_size.width / 2 + 1);
+        int spect_len = dft_size.height * (dft_size.width / 2 + 1);
         createContinuous(1, spect_len, CV_32FC2, image_spect);
         createContinuous(1, spect_len, CV_32FC2, templ_spect);
         createContinuous(1, spect_len, CV_32FC2, result_spect);

--- a/modules/cudaimgproc/src/canny.cpp
+++ b/modules/cudaimgproc/src/canny.cpp
@@ -74,6 +74,7 @@ namespace
             low_thresh_(low_thresh), high_thresh_(high_thresh), apperture_size_(apperture_size), L2gradient_(L2gradient)
         {
             old_apperture_size_ = -1;
+            d_counter = nullptr;
         }
 
         void detect(InputArray image, OutputArray edges, Stream& stream);

--- a/modules/imgcodecs/src/grfmt_jpeg2000.cpp
+++ b/modules/imgcodecs/src/grfmt_jpeg2000.cpp
@@ -179,7 +179,7 @@ bool  Jpeg2KDecoder::readData( Mat& img )
 {
     Ptr<Jpeg2KDecoder> close_this(this, Jpeg2KDecoder_close);
     bool result = false;
-    int color = img.channels() > 1;
+    bool color = img.channels() > 1;
     uchar* data = img.ptr();
     size_t step = img.step;
     jas_stream_t* stream = (jas_stream_t*)m_stream;

--- a/modules/imgcodecs/src/grfmt_png.cpp
+++ b/modules/imgcodecs/src/grfmt_png.cpp
@@ -226,7 +226,7 @@ bool  PngDecoder::readData( Mat& img )
     volatile bool result = false;
     AutoBuffer<uchar*> _buffer(m_height);
     uchar** buffer = _buffer.data();
-    int color = img.channels() > 1;
+    bool color = img.channels() > 1;
 
     png_structp png_ptr = (png_structp)m_png_ptr;
     png_infop info_ptr = (png_infop)m_info_ptr;

--- a/modules/imgcodecs/src/grfmt_pxm.cpp
+++ b/modules/imgcodecs/src/grfmt_pxm.cpp
@@ -208,7 +208,7 @@ bool PxMDecoder::readHeader()
 
 bool PxMDecoder::readData( Mat& img )
 {
-    int color = img.channels() > 1;
+    bool color = img.channels() > 1;
     uchar* data = img.ptr();
     PaletteEntry palette[256];
     bool   result = false;
@@ -225,7 +225,7 @@ bool PxMDecoder::readData( Mat& img )
     // create LUT for converting colors
     if( bit_depth == 8 )
     {
-        CV_Assert(m_maxval < 256);
+        CV_Assert(m_maxval < 256 && m_maxval > 0);
 
         for (int i = 0; i <= m_maxval; i++)
             gray_palette[i] = (uchar)((i*255/m_maxval)^(m_bpp == 1 ? 255 : 0));

--- a/modules/imgcodecs/src/grfmt_sunras.cpp
+++ b/modules/imgcodecs/src/grfmt_sunras.cpp
@@ -160,7 +160,7 @@ bool  SunRasterDecoder::readHeader()
 
 bool  SunRasterDecoder::readData( Mat& img )
 {
-    int color = img.channels() > 1;
+    bool color = img.channels() > 1;
     uchar* data = img.ptr();
     size_t step = img.step;
     uchar  gray_palette[256] = {0};

--- a/modules/imgproc/src/accum.cpp
+++ b/modules/imgproc/src/accum.cpp
@@ -332,7 +332,7 @@ void cv::accumulate( InputArray _src, InputOutputArray _dst, InputArray _mask )
     CV_Assert( func != 0 );
 
     const Mat* arrays[] = {&src, &dst, &mask, 0};
-    uchar* ptrs[3];
+    uchar* ptrs[3] = {};
     NAryMatIterator it(arrays, ptrs);
     int len = (int)it.size;
 
@@ -430,7 +430,7 @@ void cv::accumulateSquare( InputArray _src, InputOutputArray _dst, InputArray _m
     CV_Assert( func != 0 );
 
     const Mat* arrays[] = {&src, &dst, &mask, 0};
-    uchar* ptrs[3];
+    uchar* ptrs[3] = {};
     NAryMatIterator it(arrays, ptrs);
     int len = (int)it.size;
 
@@ -533,7 +533,7 @@ void cv::accumulateProduct( InputArray _src1, InputArray _src2,
     CV_Assert( func != 0 );
 
     const Mat* arrays[] = {&src1, &src2, &dst, &mask, 0};
-    uchar* ptrs[4];
+    uchar* ptrs[4] = {};
     NAryMatIterator it(arrays, ptrs);
     int len = (int)it.size;
 
@@ -635,7 +635,7 @@ void cv::accumulateWeighted( InputArray _src, InputOutputArray _dst,
     CV_Assert( func != 0 );
 
     const Mat* arrays[] = {&src, &dst, &mask, 0};
-    uchar* ptrs[3];
+    uchar* ptrs[3] = {};
     NAryMatIterator it(arrays, ptrs);
     int len = (int)it.size;
 

--- a/modules/imgproc/src/linefit.cpp
+++ b/modules/imgproc/src/linefit.cpp
@@ -321,7 +321,7 @@ static void fitLine2D( const Point2f * points, int count, int dist,
     void (*calc_weights) (float *, int, float *) = 0;
     void (*calc_weights_param) (float *, int, float *, float) = 0;
     int i, j, k;
-    float _line[6], _lineprev[6];
+    float _line[4], _lineprev[4];
     float rdelta = reps != 0 ? reps : 1.0f;
     float adelta = aeps != 0 ? aeps : 0.01f;
     double min_err = DBL_MAX, err = 0;


### PR DESCRIPTION
Commits:
- 09837928d934d104b3f327ce42122b7b8f35fff3
- 10fb88d02791b33d83a3756c62e21aa1c5a1e68d

Excluded changes with std::atomic (C++98 requirement)

related #12357 #12391
