### PR TITLE
Workaround for GTest v1.8.1 + Visual Studio 2013 (vc12)

### DIFF
--- a/modules/ts/include/opencv2/ts/ts_gtest.h
+++ b/modules/ts/include/opencv2/ts/ts_gtest.h
@@ -11397,7 +11397,7 @@ struct TuplePolicy {
 
   template <size_t I>
   static typename AddReference<const typename ::std::tr1::tuple_element<
-      static_cast<int>(I), Tuple>::type>::type
+      I, Tuple>::type>::type
   get(const Tuple& tuple) {
     return ::std::tr1::get<I>(tuple);
   }


### PR DESCRIPTION
### This pullrequest changes
OpenCV tests no longer compiles with vc12.
This fix enables it to compile again.