### PR TITLE
build: don't use nullptr without C++11 guard

### DIFF
--- a/modules/cudaimgproc/src/canny.cpp
+++ b/modules/cudaimgproc/src/canny.cpp
@@ -74,7 +74,7 @@ namespace
             low_thresh_(low_thresh), high_thresh_(high_thresh), apperture_size_(apperture_size), L2gradient_(L2gradient)
         {
             old_apperture_size_ = -1;
-            d_counter = nullptr;
+            d_counter = NULL;
         }
 
         void detect(InputArray image, OutputArray edges, Stream& stream);

--- a/modules/videoio/src/cap_openni2.cpp
+++ b/modules/videoio/src/cap_openni2.cpp
@@ -223,7 +223,7 @@ openni::VideoMode CvCapture_OpenNI2::defaultStreamOutputMode(int stream)
 
 
 CvCapture_OpenNI2::CvCapture_OpenNI2(int index) :
-    CvCapture_OpenNI2(index, nullptr)
+    CvCapture_OpenNI2(index, NULL)
 { }
 
 CvCapture_OpenNI2::CvCapture_OpenNI2(const char * filename) :


### PR DESCRIPTION
C++98 is used in OpenCV 3.x.


```
docker_image:Custom=ubuntu-cuda:16.04
```