### PR TITLE
Utilize CV_UNUSED macro

### DIFF
--- a/apps/interactive-calibration/frameProcessor.cpp
+++ b/apps/interactive-calibration/frameProcessor.cpp
@@ -103,7 +103,7 @@ bool CalibProcessor::detectAndParseChAruco(const cv::Mat &frame)
         return true;
     }
 #else
-    (void)frame;
+    CV_UNUSED(frame);
 #endif
     return false;
 }

--- a/modules/calib3d/src/circlesgrid.cpp
+++ b/modules/calib3d/src/circlesgrid.cpp
@@ -394,9 +394,9 @@ void CirclesGridClusterFinder::rectifyPatternPoints(const std::vector<cv::Point2
 void CirclesGridClusterFinder::parsePatternPoints(const std::vector<cv::Point2f> &patternPoints, const std::vector<cv::Point2f> &rectifiedPatternPoints, std::vector<cv::Point2f> &centers)
 {
 #ifndef HAVE_OPENCV_FLANN
-  (void)patternPoints;
-  (void)rectifiedPatternPoints;
-  (void)centers;
+  CV_UNUSED(patternPoints);
+  CV_UNUSED(rectifiedPatternPoints);
+  CV_UNUSED(centers);
   CV_Error(Error::StsNotImplemented, "The desired functionality requires flann module, which was disabled.");
 #else
   flann::LinearIndexParams flannIndexParams;

--- a/modules/calib3d/src/rho.cpp
+++ b/modules/calib3d/src/rho.cpp
@@ -127,8 +127,8 @@ struct RHO_HEST{
      */
 
     virtual inline int    ensureCapacity(unsigned N, double beta){
-        (void)N;
-        (void)beta;
+        CV_UNUSED(N);
+        CV_UNUSED(beta);
 
         return 1;
     }

--- a/modules/core/include/opencv2/core.hpp
+++ b/modules/core/include/opencv2/core.hpp
@@ -3081,7 +3081,7 @@ public:
 
     /** @brief Stores algorithm parameters in a file storage
     */
-    virtual void write(FileStorage& fs) const { (void)fs; }
+    virtual void write(FileStorage& fs) const { CV_UNUSED(fs); }
 
     /** @brief simplified API for language bindings
     * @overload
@@ -3090,7 +3090,7 @@ public:
 
     /** @brief Reads algorithm parameters from a file storage
     */
-    CV_WRAP virtual void read(const FileNode& fn) { (void)fn; }
+    CV_WRAP virtual void read(const FileNode& fn) { CV_UNUSED(fn); }
 
     /** @brief Returns true if the Algorithm is empty (e.g. in the very beginning or after unsuccessful read
     */

--- a/modules/core/include/opencv2/core/cuda/detail/reduce.hpp
+++ b/modules/core/include/opencv2/core/cuda/detail/reduce.hpp
@@ -276,8 +276,8 @@ namespace cv { namespace cuda { namespace device
             static __device__ void reduce(Pointer smem, Reference val, unsigned int tid, Op op)
             {
             #if defined __CUDA_ARCH__ && __CUDA_ARCH__ >= 300
-                (void) smem;
-                (void) tid;
+                CV_UNUSED(smem);
+                CV_UNUSED(tid);
 
                 Unroll<N / 2, Pointer, Reference, Op>::loopShfl(val, op, N);
             #else

--- a/modules/core/include/opencv2/core/cuda/detail/reduce_key_val.hpp
+++ b/modules/core/include/opencv2/core/cuda/detail/reduce_key_val.hpp
@@ -402,9 +402,9 @@ namespace cv { namespace cuda { namespace device
             static __device__ void reduce(KP skeys, KR key, VP svals, VR val, unsigned int tid, Cmp cmp)
             {
             #if 0 // __CUDA_ARCH__ >= 300
-                (void) skeys;
-                (void) svals;
-                (void) tid;
+                CV_UNUSED(skeys);
+                CV_UNUSED(svals);
+                CV_UNUSED(tid);
 
                 Unroll<N / 2, KP, KR, VP, VR, Cmp>::loopShfl(key, val, cmp, N);
             #else

--- a/modules/core/include/opencv2/core/cuda/emulation.hpp
+++ b/modules/core/include/opencv2/core/cuda/emulation.hpp
@@ -177,8 +177,8 @@ namespace cv { namespace cuda { namespace device
                 } while (assumed != old);
                 return __longlong_as_double(old);
             #else
-                (void) address;
-                (void) val;
+                CV_UNUSED(address);
+                CV_UNUSED(val);
                 return 0.0;
             #endif
             }
@@ -199,8 +199,8 @@ namespace cv { namespace cuda { namespace device
                 } while (assumed != old);
                 return __int_as_float(old);
             #else
-                (void) address;
-                (void) val;
+                CV_UNUSED(address);
+                CV_UNUSED(val);
                 return 0.0f;
             #endif
             }
@@ -216,8 +216,8 @@ namespace cv { namespace cuda { namespace device
                 } while (assumed != old);
                 return __longlong_as_double(old);
             #else
-                (void) address;
-                (void) val;
+                CV_UNUSED(address);
+                CV_UNUSED(val);
                 return 0.0;
             #endif
             }
@@ -238,8 +238,8 @@ namespace cv { namespace cuda { namespace device
                 } while (assumed != old);
                 return __int_as_float(old);
             #else
-                (void) address;
-                (void) val;
+                CV_UNUSED(address);
+                CV_UNUSED(val);
                 return 0.0f;
             #endif
             }
@@ -255,8 +255,8 @@ namespace cv { namespace cuda { namespace device
                 } while (assumed != old);
                 return __longlong_as_double(old);
             #else
-                (void) address;
-                (void) val;
+                CV_UNUSED(address);
+                CV_UNUSED(val);
                 return 0.0;
             #endif
             }

--- a/modules/core/include/opencv2/core/cuda/filters.hpp
+++ b/modules/core/include/opencv2/core/cuda/filters.hpp
@@ -64,8 +64,8 @@ namespace cv { namespace cuda { namespace device
         explicit __host__ __device__ __forceinline__ PointFilter(const Ptr2D& src_, float fx = 0.f, float fy = 0.f)
         : src(src_)
         {
-            (void)fx;
-            (void)fy;
+            CV_UNUSED(fx);
+            CV_UNUSED(fy);
         }
 
         __device__ __forceinline__ elem_type operator ()(float y, float x) const
@@ -84,8 +84,8 @@ namespace cv { namespace cuda { namespace device
         explicit __host__ __device__ __forceinline__ LinearFilter(const Ptr2D& src_, float fx = 0.f, float fy = 0.f)
         : src(src_)
         {
-            (void)fx;
-            (void)fy;
+            CV_UNUSED(fx);
+            CV_UNUSED(fy);
         }
         __device__ __forceinline__ elem_type operator ()(float y, float x) const
         {
@@ -125,8 +125,8 @@ namespace cv { namespace cuda { namespace device
         explicit __host__ __device__ __forceinline__ CubicFilter(const Ptr2D& src_, float fx = 0.f, float fy = 0.f)
         : src(src_)
         {
-            (void)fx;
-            (void)fy;
+            CV_UNUSED(fx);
+            CV_UNUSED(fy);
         }
 
         static __device__ __forceinline__ float bicubicCoeff(float x_)

--- a/modules/core/include/opencv2/core/cuda/functional.hpp
+++ b/modules/core/include/opencv2/core/cuda/functional.hpp
@@ -597,7 +597,7 @@ namespace cv { namespace cuda { namespace device
 
     template <typename T> struct thresh_trunc_func : unary_function<T, T>
     {
-        explicit __host__ __device__ __forceinline__ thresh_trunc_func(T thresh_, T maxVal_ = 0) : thresh(thresh_) {(void)maxVal_;}
+        explicit __host__ __device__ __forceinline__ thresh_trunc_func(T thresh_, T maxVal_ = 0) : thresh(thresh_) {CV_UNUSED(maxVal_);}
 
         __device__ __forceinline__ T operator()(typename TypeTraits<T>::ParameterType src) const
         {
@@ -613,7 +613,7 @@ namespace cv { namespace cuda { namespace device
 
     template <typename T> struct thresh_to_zero_func : unary_function<T, T>
     {
-        explicit __host__ __device__ __forceinline__ thresh_to_zero_func(T thresh_, T maxVal_ = 0) : thresh(thresh_) {(void)maxVal_;}
+        explicit __host__ __device__ __forceinline__ thresh_to_zero_func(T thresh_, T maxVal_ = 0) : thresh(thresh_) {CV_UNUSED(maxVal_);}
 
         __device__ __forceinline__ T operator()(typename TypeTraits<T>::ParameterType src) const
         {
@@ -629,7 +629,7 @@ namespace cv { namespace cuda { namespace device
 
     template <typename T> struct thresh_to_zero_inv_func : unary_function<T, T>
     {
-        explicit __host__ __device__ __forceinline__ thresh_to_zero_inv_func(T thresh_, T maxVal_ = 0) : thresh(thresh_) {(void)maxVal_;}
+        explicit __host__ __device__ __forceinline__ thresh_to_zero_inv_func(T thresh_, T maxVal_ = 0) : thresh(thresh_) {CV_UNUSED(maxVal_);}
 
         __device__ __forceinline__ T operator()(typename TypeTraits<T>::ParameterType src) const
         {

--- a/modules/core/include/opencv2/core/cuda/scan.hpp
+++ b/modules/core/include/opencv2/core/cuda/scan.hpp
@@ -61,7 +61,7 @@ namespace cv { namespace cuda { namespace device
     template <ScanKind Kind, typename T, typename F> struct WarpScan
     {
         __device__ __forceinline__ WarpScan() {}
-        __device__ __forceinline__ WarpScan(const WarpScan& other) { (void)other; }
+        __device__ __forceinline__ WarpScan(const WarpScan& other) { CV_UNUSED(other); }
 
         __device__ __forceinline__ T operator()( volatile T *ptr , const unsigned int idx)
         {
@@ -95,7 +95,7 @@ namespace cv { namespace cuda { namespace device
     template <ScanKind Kind , typename T, typename F> struct WarpScanNoComp
     {
         __device__ __forceinline__ WarpScanNoComp() {}
-        __device__ __forceinline__ WarpScanNoComp(const WarpScanNoComp& other) { (void)other; }
+        __device__ __forceinline__ WarpScanNoComp(const WarpScanNoComp& other) { CV_UNUSED(other); }
 
         __device__ __forceinline__ T operator()( volatile T *ptr , const unsigned int idx)
         {
@@ -135,7 +135,7 @@ namespace cv { namespace cuda { namespace device
     template <ScanKind Kind , typename T, typename Sc, typename F> struct BlockScan
     {
         __device__ __forceinline__ BlockScan() {}
-        __device__ __forceinline__ BlockScan(const BlockScan& other) { (void)other; }
+        __device__ __forceinline__ BlockScan(const BlockScan& other) { CV_UNUSED(other); }
 
         __device__ __forceinline__ T operator()(volatile T *ptr)
         {

--- a/modules/core/include/opencv2/core/cv_cpu_dispatch.h
+++ b/modules/core/include/opencv2/core/cv_cpu_dispatch.h
@@ -124,7 +124,7 @@ struct VZeroUpperGuard {
 #endif
     inline ~VZeroUpperGuard() { _mm256_zeroupper(); }
 };
-#define __CV_AVX_GUARD VZeroUpperGuard __vzeroupper_guard; (void)__vzeroupper_guard;
+#define __CV_AVX_GUARD VZeroUpperGuard __vzeroupper_guard; CV_UNUSED(__vzeroupper_guard);
 #endif
 
 #ifdef __CV_AVX_GUARD

--- a/modules/core/include/opencv2/core/fast_math.hpp
+++ b/modules/core/include/opencv2/core/fast_math.hpp
@@ -79,7 +79,7 @@
     #define ARM_ROUND(_value, _asm_string) \
         int res; \
         float temp; \
-        (void)temp; \
+        CV_UNUSED(temp); \
         __asm__(_asm_string : [res] "=r" (res), [temp] "=w" (temp) : [value] "w" (_value)); \
         return res
     // 2. version for double

--- a/modules/core/include/opencv2/core/vsx_utils.hpp
+++ b/modules/core/include/opencv2/core/vsx_utils.hpp
@@ -466,7 +466,7 @@ VSX_IMPL_CONV_EVEN_2_4(vec_uint4,  vec_double2, vec_ctu, vec_ctuo)
     VSX_FINLINE(rt) fnm(const rg& a, int only_truncate) \
     {                                                   \
         assert(only_truncate == 0);                     \
-        (void)only_truncate;                            \
+        CV_UNUSED(only_truncate);                            \
         return fn2(a);                                  \
     }
     VSX_IMPL_CONV_2VARIANT(vec_int4,   vec_float4,  vec_cts, vec_cts)

--- a/modules/core/perf/perf_mat.cpp
+++ b/modules/core/perf/perf_mat.cpp
@@ -62,7 +62,7 @@ PERF_TEST_P(Size_MatType, Mat_Clone,
     TEST_CYCLE()
     {
         Mat tmp = source.clone();
-        (void)tmp;
+        CV_UNUSED(tmp);
     }
     destination = source.clone();
 
@@ -90,7 +90,7 @@ PERF_TEST_P(Size_MatType, Mat_Clone_Roi,
     TEST_CYCLE()
     {
         Mat tmp = roi.clone();
-        (void)tmp;
+        CV_UNUSED(tmp);
     }
     destination = roi.clone();
 

--- a/modules/core/perf/perf_norm.cpp
+++ b/modules/core/perf/perf_norm.cpp
@@ -126,7 +126,7 @@ PERF_TEST_P(PerfHamming, norm,
 
     TEST_CYCLE() n = cv::norm(src, normType);
 
-    (void)n;
+    CV_UNUSED(n);
     SANITY_CHECK_NOTHING();
 }
 
@@ -150,7 +150,7 @@ PERF_TEST_P(PerfHamming, norm2,
 
     TEST_CYCLE() n = cv::norm(src1, src2, normType);
 
-    (void)n;
+    CV_UNUSED(n);
     SANITY_CHECK_NOTHING();
 }
 

--- a/modules/core/src/arithm.cpp
+++ b/modules/core/src/arithm.cpp
@@ -2555,7 +2555,7 @@ void absdiff64f( const double* src1, size_t step1,
 #define CALL_IPP_UN(fun) \
     CV_IPP_CHECK() \
     { \
-        fixSteps(width, height, sizeof(dst[0]), step1, step2, step); (void)src2; \
+        fixSteps(width, height, sizeof(dst[0]), step1, step2, step); CV_UNUSED(src2); \
         if (0 <= CV_INSTRUMENT_FUN_IPP(fun, src1, (int)step1, dst, (int)step, ippiSize(width, height))) \
         { \
             CV_IMPL_ADD(CV_IMPL_IPP); \

--- a/modules/core/src/bufferpool.impl.hpp
+++ b/modules/core/src/bufferpool.impl.hpp
@@ -19,7 +19,7 @@ public:
 
     virtual size_t getReservedSize() const CV_OVERRIDE { return (size_t)-1; }
     virtual size_t getMaxReservedSize() const CV_OVERRIDE { return (size_t)-1; }
-    virtual void setMaxReservedSize(size_t size) CV_OVERRIDE { (void)size; }
+    virtual void setMaxReservedSize(size_t size) CV_OVERRIDE { CV_UNUSED(size); }
     virtual void freeAllReservedBuffers() CV_OVERRIDE { }
 };
 

--- a/modules/core/src/cuda/gpu_mat.cu
+++ b/modules/core/src/cuda/gpu_mat.cu
@@ -76,7 +76,7 @@ namespace
         }
         __device__ __host__ void deallocate(uchar* ptr, size_t numBytes) CV_OVERRIDE
         {
-            (void)numBytes;
+            CV_UNUSED(numBytes);
 #ifndef __CUDA_ARCH__
             CV_CUDEV_SAFE_CALL(cudaFree(ptr));
 #endif

--- a/modules/core/src/cuda_gpu_mat.cpp
+++ b/modules/core/src/cuda_gpu_mat.cpp
@@ -345,8 +345,8 @@ void cv::cuda::ensureSizeIsEnough(int rows, int cols, int type, OutputArray arr)
 GpuMat cv::cuda::getInputMat(InputArray _src, Stream& stream)
 {
 #ifndef HAVE_CUDA
-    (void) _src;
-    (void) stream;
+    CV_UNUSED(_src);
+    CV_UNUSED(stream);
     throw_no_cuda();
 #else
     GpuMat src;
@@ -367,11 +367,11 @@ GpuMat cv::cuda::getInputMat(InputArray _src, Stream& stream)
 GpuMat cv::cuda::getOutputMat(OutputArray _dst, int rows, int cols, int type, Stream& stream)
 {
 #ifndef HAVE_CUDA
-    (void) _dst;
-    (void) rows;
-    (void) cols;
-    (void) type;
-    (void) stream;
+    CV_UNUSED(_dst);
+    CV_UNUSED(rows);
+    CV_UNUSED(cols);
+    CV_UNUSED(type);
+    CV_UNUSED(stream);
     throw_no_cuda();
 #else
     GpuMat dst;
@@ -392,9 +392,9 @@ GpuMat cv::cuda::getOutputMat(OutputArray _dst, int rows, int cols, int type, St
 void cv::cuda::syncOutput(const GpuMat& dst, OutputArray _dst, Stream& stream)
 {
 #ifndef HAVE_CUDA
-    (void) dst;
-    (void) _dst;
-    (void) stream;
+    CV_UNUSED(dst);
+    CV_UNUSED(_dst);
+    CV_UNUSED(stream);
     throw_no_cuda();
 #else
     if (_dst.kind() != _InputArray::CUDA_GPU_MAT)
@@ -416,15 +416,15 @@ GpuMat::Allocator* cv::cuda::GpuMat::defaultAllocator()
 
 void cv::cuda::GpuMat::setDefaultAllocator(Allocator* allocator)
 {
-    (void) allocator;
+    CV_UNUSED(allocator);
     throw_no_cuda();
 }
 
 void cv::cuda::GpuMat::create(int _rows, int _cols, int _type)
 {
-    (void) _rows;
-    (void) _cols;
-    (void) _type;
+    CV_UNUSED(_rows);
+    CV_UNUSED(_cols);
+    CV_UNUSED(_type);
     throw_no_cuda();
 }
 
@@ -434,81 +434,81 @@ void cv::cuda::GpuMat::release()
 
 void cv::cuda::GpuMat::upload(InputArray arr)
 {
-    (void) arr;
+    CV_UNUSED(arr);
     throw_no_cuda();
 }
 
 void cv::cuda::GpuMat::upload(InputArray arr, Stream& _stream)
 {
-    (void) arr;
-    (void) _stream;
+    CV_UNUSED(arr);
+    CV_UNUSED(_stream);
     throw_no_cuda();
 }
 
 void cv::cuda::GpuMat::download(OutputArray _dst) const
 {
-    (void) _dst;
+    CV_UNUSED(_dst);
     throw_no_cuda();
 }
 
 void cv::cuda::GpuMat::download(OutputArray _dst, Stream& _stream) const
 {
-    (void) _dst;
-    (void) _stream;
+    CV_UNUSED(_dst);
+    CV_UNUSED(_stream);
     throw_no_cuda();
 }
 
 void cv::cuda::GpuMat::copyTo(OutputArray _dst) const
 {
-    (void) _dst;
+    CV_UNUSED(_dst);
     throw_no_cuda();
 }
 
 void cv::cuda::GpuMat::copyTo(OutputArray _dst, Stream& _stream) const
 {
-    (void) _dst;
-    (void) _stream;
+    CV_UNUSED(_dst);
+    CV_UNUSED(_stream);
     throw_no_cuda();
 }
 
 void cv::cuda::GpuMat::copyTo(OutputArray _dst, InputArray _mask, Stream& _stream) const
 {
-    (void) _dst;
-    (void) _mask;
-    (void) _stream;
+    CV_UNUSED(_dst);
+    CV_UNUSED(_mask);
+    CV_UNUSED(_stream);
     throw_no_cuda();
 }
 
 GpuMat& cv::cuda::GpuMat::setTo(Scalar s, Stream& _stream)
 {
-    (void) s;
-    (void) _stream;
+    CV_UNUSED(s);
+    CV_UNUSED(_stream);
     throw_no_cuda();
 }
 
 GpuMat& cv::cuda::GpuMat::setTo(Scalar s, InputArray _mask, Stream& _stream)
 {
-    (void) s;
-    (void) _mask;
-    (void) _stream;
+    CV_UNUSED(s);
+    CV_UNUSED(_mask);
+    CV_UNUSED(_stream);
     throw_no_cuda();
 }
 
 void cv::cuda::GpuMat::convertTo(OutputArray _dst, int rtype, Stream& _stream) const
 {
-    (void) _dst;
-    (void) rtype;
-    (void) _stream;
+    CV_UNUSED(_dst);
+    CV_UNUSED(rtype);
+    CV_UNUSED(_stream);
     throw_no_cuda();
 }
 
 void cv::cuda::GpuMat::convertTo(OutputArray _dst, int rtype, double alpha, double beta, Stream& _stream) const
 {
-    (void) _dst;
-    (void) rtype;
-    (void) alpha;
-    (void) beta;
-    (void) _stream;
+    CV_UNUSED(_dst);
+    CV_UNUSED(rtype);
+    CV_UNUSED(alpha);
+    CV_UNUSED(beta);
+    CV_UNUSED(_stream);
     throw_no_cuda();
 }
 

--- a/modules/core/src/cuda_host_mem.cpp
+++ b/modules/core/src/cuda_host_mem.cpp
@@ -136,7 +136,7 @@ private:
 MatAllocator* cv::cuda::HostMem::getAllocator(AllocType alloc_type)
 {
 #ifndef HAVE_CUDA
-    (void) alloc_type;
+    CV_UNUSED(alloc_type);
     throw_no_cuda();
 #else
     static std::map<unsigned int, Ptr<MatAllocator> > allocators;
@@ -178,9 +178,9 @@ namespace
 void cv::cuda::HostMem::create(int rows_, int cols_, int type_)
 {
 #ifndef HAVE_CUDA
-    (void) rows_;
-    (void) cols_;
-    (void) type_;
+    CV_UNUSED(rows_);
+    CV_UNUSED(cols_);
+    CV_UNUSED(type_);
     throw_no_cuda();
 #else
     if (alloc_type == SHARED)
@@ -317,7 +317,7 @@ GpuMat cv::cuda::HostMem::createGpuMatHeader() const
 void cv::cuda::registerPageLocked(Mat& m)
 {
 #ifndef HAVE_CUDA
-    (void) m;
+    CV_UNUSED(m);
     throw_no_cuda();
 #else
     CV_Assert( m.isContinuous() );
@@ -328,7 +328,7 @@ void cv::cuda::registerPageLocked(Mat& m)
 void cv::cuda::unregisterPageLocked(Mat& m)
 {
 #ifndef HAVE_CUDA
-    (void) m;
+    CV_UNUSED(m);
 #else
     cudaSafeCall( cudaHostUnregister(m.data) );
 #endif

--- a/modules/core/src/cuda_info.cpp
+++ b/modules/core/src/cuda_info.cpp
@@ -67,7 +67,7 @@ int cv::cuda::getCudaEnabledDeviceCount()
 void cv::cuda::setDevice(int device)
 {
 #ifndef HAVE_CUDA
-    (void) device;
+    CV_UNUSED(device);
     throw_no_cuda();
 #else
     cudaSafeCall( cudaSetDevice(device) );
@@ -98,7 +98,7 @@ void cv::cuda::resetDevice()
 bool cv::cuda::deviceSupports(FeatureSet feature_set)
 {
 #ifndef HAVE_CUDA
-    (void) feature_set;
+    CV_UNUSED(feature_set);
     throw_no_cuda();
 #else
     static int versions[] =
@@ -227,7 +227,7 @@ namespace
 bool cv::cuda::TargetArchs::builtWith(cv::cuda::FeatureSet feature_set)
 {
 #ifndef HAVE_CUDA
-    (void) feature_set;
+    CV_UNUSED(feature_set);
     throw_no_cuda();
 #else
     return cudaArch.builtWith(feature_set);
@@ -237,8 +237,8 @@ bool cv::cuda::TargetArchs::builtWith(cv::cuda::FeatureSet feature_set)
 bool cv::cuda::TargetArchs::hasPtx(int major, int minor)
 {
 #ifndef HAVE_CUDA
-    (void) major;
-    (void) minor;
+    CV_UNUSED(major);
+    CV_UNUSED(minor);
     throw_no_cuda();
 #else
     return cudaArch.hasPtx(major, minor);
@@ -248,8 +248,8 @@ bool cv::cuda::TargetArchs::hasPtx(int major, int minor)
 bool cv::cuda::TargetArchs::hasBin(int major, int minor)
 {
 #ifndef HAVE_CUDA
-    (void) major;
-    (void) minor;
+    CV_UNUSED(major);
+    CV_UNUSED(minor);
     throw_no_cuda();
 #else
     return cudaArch.hasBin(major, minor);
@@ -259,8 +259,8 @@ bool cv::cuda::TargetArchs::hasBin(int major, int minor)
 bool cv::cuda::TargetArchs::hasEqualOrLessPtx(int major, int minor)
 {
 #ifndef HAVE_CUDA
-    (void) major;
-    (void) minor;
+    CV_UNUSED(major);
+    CV_UNUSED(minor);
     throw_no_cuda();
 #else
     return cudaArch.hasEqualOrLessPtx(major, minor);
@@ -270,8 +270,8 @@ bool cv::cuda::TargetArchs::hasEqualOrLessPtx(int major, int minor)
 bool cv::cuda::TargetArchs::hasEqualOrGreaterPtx(int major, int minor)
 {
 #ifndef HAVE_CUDA
-    (void) major;
-    (void) minor;
+    CV_UNUSED(major);
+    CV_UNUSED(minor);
     throw_no_cuda();
 #else
     return cudaArch.hasEqualOrGreaterPtx(major, minor);
@@ -281,8 +281,8 @@ bool cv::cuda::TargetArchs::hasEqualOrGreaterPtx(int major, int minor)
 bool cv::cuda::TargetArchs::hasEqualOrGreaterBin(int major, int minor)
 {
 #ifndef HAVE_CUDA
-    (void) major;
-    (void) minor;
+    CV_UNUSED(major);
+    CV_UNUSED(minor);
     throw_no_cuda();
 #else
     return cudaArch.hasEqualOrGreaterBin(major, minor);
@@ -827,8 +827,8 @@ int cv::cuda::DeviceInfo::maxThreadsPerMultiProcessor() const
 void cv::cuda::DeviceInfo::queryMemory(size_t& _totalMemory, size_t& _freeMemory) const
 {
 #ifndef HAVE_CUDA
-    (void) _totalMemory;
-    (void) _freeMemory;
+    CV_UNUSED(_totalMemory);
+    CV_UNUSED(_freeMemory);
     throw_no_cuda();
 #else
     int prevDeviceID = getDevice();
@@ -894,7 +894,7 @@ namespace
 void cv::cuda::printCudaDeviceInfo(int device)
 {
 #ifndef HAVE_CUDA
-    (void) device;
+    CV_UNUSED(device);
     throw_no_cuda();
 #else
     int count = getCudaEnabledDeviceCount();
@@ -980,7 +980,7 @@ void cv::cuda::printCudaDeviceInfo(int device)
 void cv::cuda::printShortCudaDeviceInfo(int device)
 {
 #ifndef HAVE_CUDA
-    (void) device;
+    CV_UNUSED(device);
     throw_no_cuda();
 #else
     int count = getCudaEnabledDeviceCount();
@@ -1194,7 +1194,7 @@ namespace
 String cv::cuda::getNppErrorMessage(int code)
 {
 #ifndef HAVE_CUDA
-    (void) code;
+    CV_UNUSED(code);
     return String();
 #else
     return getErrorString(code, npp_errors, npp_error_num);
@@ -1204,7 +1204,7 @@ String cv::cuda::getNppErrorMessage(int code)
 String cv::cuda::getCudaDriverApiErrorMessage(int code)
 {
 #ifndef HAVE_CUDA
-    (void) code;
+    CV_UNUSED(code);
     return String();
 #else
     return getErrorString(code, cu_errors, cu_errors_num);

--- a/modules/core/src/cuda_stream.cpp
+++ b/modules/core/src/cuda_stream.cpp
@@ -267,7 +267,7 @@ class cv::cuda::Stream::Impl
 public:
     Impl(void* ptr = 0)
     {
-        (void) ptr;
+        CV_UNUSED(ptr);
         throw_no_cuda();
     }
 };
@@ -439,7 +439,7 @@ cv::cuda::Stream::Stream()
 cv::cuda::Stream::Stream(const Ptr<GpuMat::Allocator>& allocator)
 {
 #ifndef HAVE_CUDA
-    (void) allocator;
+    CV_UNUSED(allocator);
     throw_no_cuda();
 #else
     impl_ = makePtr<Impl>(allocator);
@@ -473,7 +473,7 @@ void cv::cuda::Stream::waitForCompletion()
 void cv::cuda::Stream::waitEvent(const Event& event)
 {
 #ifndef HAVE_CUDA
-    (void) event;
+    CV_UNUSED(event);
     throw_no_cuda();
 #else
     cudaSafeCall( cudaStreamWaitEvent(impl_->stream, EventAccessor::getEvent(event), 0) );
@@ -505,13 +505,13 @@ namespace
 void cv::cuda::Stream::enqueueHostCallback(StreamCallback callback, void* userData)
 {
 #ifndef HAVE_CUDA
-    (void) callback;
-    (void) userData;
+    CV_UNUSED(callback);
+    CV_UNUSED(userData);
     throw_no_cuda();
 #else
     #if CUDART_VERSION < 5000
-        (void) callback;
-        (void) userData;
+        CV_UNUSED(callback);
+        CV_UNUSED(userData);
         CV_Error(cv::Error::StsNotImplemented, "This function requires CUDA >= 5.0");
     #else
         CallbackData* data = new CallbackData(callback, userData);
@@ -658,7 +658,7 @@ namespace
 void cv::cuda::setBufferPoolUsage(bool on)
 {
 #ifndef HAVE_CUDA
-    (void)on;
+    CV_UNUSED(on);
     throw_no_cuda();
 #else
     enableMemoryPool = on;
@@ -668,9 +668,9 @@ void cv::cuda::setBufferPoolUsage(bool on)
 void cv::cuda::setBufferPoolConfig(int deviceId, size_t stackSize, int stackCount)
 {
 #ifndef HAVE_CUDA
-    (void)deviceId;
-    (void)stackSize;
-    (void)stackCount;
+    CV_UNUSED(deviceId);
+    CV_UNUSED(stackSize);
+    CV_UNUSED(stackCount);
     throw_no_cuda();
 #else
     const int currentDevice = getDevice();
@@ -698,7 +698,7 @@ void cv::cuda::setBufferPoolConfig(int deviceId, size_t stackSize, int stackCoun
 #ifndef HAVE_CUDA
 cv::cuda::BufferPool::BufferPool(Stream& stream)
 {
-    (void) stream;
+    CV_UNUSED(stream);
     throw_no_cuda();
 }
 #else
@@ -710,9 +710,9 @@ cv::cuda::BufferPool::BufferPool(Stream& stream) : allocator_(stream.impl_->allo
 GpuMat cv::cuda::BufferPool::getBuffer(int rows, int cols, int type)
 {
 #ifndef HAVE_CUDA
-    (void) rows;
-    (void) cols;
-    (void) type;
+    CV_UNUSED(rows);
+    CV_UNUSED(cols);
+    CV_UNUSED(type);
     throw_no_cuda();
 #else
     GpuMat buf(allocator_);
@@ -782,7 +782,7 @@ Event cv::cuda::EventAccessor::wrapEvent(cudaEvent_t event)
 cv::cuda::Event::Event(CreateFlags flags)
 {
 #ifndef HAVE_CUDA
-    (void) flags;
+    CV_UNUSED(flags);
     throw_no_cuda();
 #else
     impl_ = makePtr<Impl>(flags);
@@ -792,7 +792,7 @@ cv::cuda::Event::Event(CreateFlags flags)
 void cv::cuda::Event::record(Stream& stream)
 {
 #ifndef HAVE_CUDA
-    (void) stream;
+    CV_UNUSED(stream);
     throw_no_cuda();
 #else
     cudaSafeCall( cudaEventRecord(impl_->event, StreamAccessor::getStream(stream)) );
@@ -826,8 +826,8 @@ void cv::cuda::Event::waitForCompletion()
 float cv::cuda::Event::elapsedTime(const Event& start, const Event& end)
 {
 #ifndef HAVE_CUDA
-    (void) start;
-    (void) end;
+    CV_UNUSED(start);
+    CV_UNUSED(end);
     throw_no_cuda();
 #else
     float ms;

--- a/modules/core/src/directx.cpp
+++ b/modules/core/src/directx.cpp
@@ -61,7 +61,7 @@ namespace cv { namespace directx {
 
 int getTypeFromDXGI_FORMAT(const int iDXGI_FORMAT)
 {
-    (void)iDXGI_FORMAT;
+    CV_UNUSED(iDXGI_FORMAT);
 #if !defined(HAVE_DIRECTX)
     NO_DIRECTX_SUPPORT_ERROR;
 #else
@@ -179,7 +179,7 @@ int getTypeFromDXGI_FORMAT(const int iDXGI_FORMAT)
 
 int getTypeFromD3DFORMAT(const int iD3DFORMAT)
 {
-    (void)iD3DFORMAT;
+    CV_UNUSED(iD3DFORMAT);
 #if !defined(HAVE_DIRECTX)
     NO_DIRECTX_SUPPORT_ERROR;
 #else
@@ -242,7 +242,7 @@ static bool g_isDirect3DDevice9Ex = false; // Direct3DDevice9Ex or Direct3DDevic
 
 Context& initializeContextFromD3D11Device(ID3D11Device* pD3D11Device)
 {
-    (void)pD3D11Device;
+    CV_UNUSED(pD3D11Device);
 #if !defined(HAVE_DIRECTX)
     NO_DIRECTX_SUPPORT_ERROR;
 #elif !defined(HAVE_OPENCL)
@@ -350,7 +350,7 @@ Context& initializeContextFromD3D11Device(ID3D11Device* pD3D11Device)
 
 Context& initializeContextFromD3D10Device(ID3D10Device* pD3D10Device)
 {
-    (void)pD3D10Device;
+    CV_UNUSED(pD3D10Device);
 #if !defined(HAVE_DIRECTX)
     NO_DIRECTX_SUPPORT_ERROR;
 #elif !defined(HAVE_OPENCL)
@@ -458,7 +458,7 @@ Context& initializeContextFromD3D10Device(ID3D10Device* pD3D10Device)
 
 Context& initializeContextFromDirect3DDevice9Ex(IDirect3DDevice9Ex* pDirect3DDevice9Ex)
 {
-    (void)pDirect3DDevice9Ex;
+    CV_UNUSED(pDirect3DDevice9Ex);
 #if !defined(HAVE_DIRECTX)
     NO_DIRECTX_SUPPORT_ERROR;
 #elif !defined(HAVE_OPENCL)
@@ -568,7 +568,7 @@ Context& initializeContextFromDirect3DDevice9Ex(IDirect3DDevice9Ex* pDirect3DDev
 
 Context& initializeContextFromDirect3DDevice9(IDirect3DDevice9* pDirect3DDevice9)
 {
-    (void)pDirect3DDevice9;
+    CV_UNUSED(pDirect3DDevice9);
 #if !defined(HAVE_DIRECTX)
     NO_DIRECTX_SUPPORT_ERROR;
 #elif !defined(HAVE_OPENCL)
@@ -764,7 +764,7 @@ namespace directx {
 
 void convertToD3D11Texture2D(InputArray src, ID3D11Texture2D* pD3D11Texture2D)
 {
-    (void)src; (void)pD3D11Texture2D;
+    CV_UNUSED(src); CV_UNUSED(pD3D11Texture2D);
 #if !defined(HAVE_DIRECTX)
     NO_DIRECTX_SUPPORT_ERROR;
 #elif defined(HAVE_OPENCL)
@@ -873,7 +873,7 @@ void convertToD3D11Texture2D(InputArray src, ID3D11Texture2D* pD3D11Texture2D)
 
 void convertFromD3D11Texture2D(ID3D11Texture2D* pD3D11Texture2D, OutputArray dst)
 {
-    (void)pD3D11Texture2D; (void)dst;
+    CV_UNUSED(pD3D11Texture2D); CV_UNUSED(dst);
 #if !defined(HAVE_DIRECTX)
     NO_DIRECTX_SUPPORT_ERROR;
 #elif defined(HAVE_OPENCL)
@@ -1004,7 +1004,7 @@ static void __OpenCLinitializeD3D10()
 
 void convertToD3D10Texture2D(InputArray src, ID3D10Texture2D* pD3D10Texture2D)
 {
-    (void)src; (void)pD3D10Texture2D;
+    CV_UNUSED(src); CV_UNUSED(pD3D10Texture2D);
 #if !defined(HAVE_DIRECTX)
     NO_DIRECTX_SUPPORT_ERROR;
 #elif defined(HAVE_OPENCL)
@@ -1065,7 +1065,7 @@ void convertToD3D10Texture2D(InputArray src, ID3D10Texture2D* pD3D10Texture2D)
 }
 void convertFromD3D10Texture2D(ID3D10Texture2D* pD3D10Texture2D, OutputArray dst)
 {
-    (void)pD3D10Texture2D; (void)dst;
+    CV_UNUSED(pD3D10Texture2D); CV_UNUSED(dst);
 #if !defined(HAVE_DIRECTX)
     NO_DIRECTX_SUPPORT_ERROR;
 #elif defined(HAVE_OPENCL)
@@ -1152,7 +1152,7 @@ static void __OpenCLinitializeD3D9()
 
 void convertToDirect3DSurface9(InputArray src, IDirect3DSurface9* pDirect3DSurface9, void* surfaceSharedHandle)
 {
-    (void)src; (void)pDirect3DSurface9; (void)surfaceSharedHandle;
+    CV_UNUSED(src); CV_UNUSED(pDirect3DSurface9); CV_UNUSED(surfaceSharedHandle);
 #if !defined(HAVE_DIRECTX)
     NO_DIRECTX_SUPPORT_ERROR;
 #elif defined(HAVE_OPENCL)
@@ -1220,7 +1220,7 @@ void convertToDirect3DSurface9(InputArray src, IDirect3DSurface9* pDirect3DSurfa
 
 void convertFromDirect3DSurface9(IDirect3DSurface9* pDirect3DSurface9, OutputArray dst, void* surfaceSharedHandle)
 {
-    (void)pDirect3DSurface9; (void)dst; (void)surfaceSharedHandle;
+    CV_UNUSED(pDirect3DSurface9); CV_UNUSED(dst); CV_UNUSED(surfaceSharedHandle);
 #if !defined(HAVE_DIRECTX)
     NO_DIRECTX_SUPPORT_ERROR;
 #elif defined(HAVE_OPENCL)

--- a/modules/core/src/glob.cpp
+++ b/modules/core/src/glob.cpp
@@ -160,7 +160,7 @@ static bool isDir(const cv::String& path, DIR* dir)
 
     return status && ((attributes & FILE_ATTRIBUTE_DIRECTORY) != 0);
 #else
-    (void)dir;
+    CV_UNUSED(dir);
     struct stat stat_buf;
     if (0 != stat( path.c_str(), &stat_buf))
         return false;

--- a/modules/core/src/matrix.cpp
+++ b/modules/core/src/matrix.cpp
@@ -118,7 +118,7 @@ void MatAllocator::copy(UMatData* usrc, UMatData* udst, int dims, const size_t s
 
 BufferPoolController* MatAllocator::getBufferPoolController(const char* id) const
 {
-    (void)id;
+    CV_UNUSED(id);
     static DummyBufferPoolController dummy;
     return &dummy;
 }

--- a/modules/core/src/ocl.cpp
+++ b/modules/core/src/ocl.cpp
@@ -190,7 +190,7 @@ void traceOpenCLCheck(cl_int status, const char* message)
         CV_OCL_TRACE_CHECK_RESULT(check_result, msg); \
         if (check_result != CL_SUCCESS) \
         { \
-            if (0) { const char* msg_ = (msg); (void)msg_; /* ensure const char* type (cv::String without c_str()) */ } \
+            if (0) { const char* msg_ = (msg); CV_UNUSED(msg_); /* ensure const char* type (cv::String without c_str()) */ } \
             cv::String error_msg = CV_OCL_API_ERROR_MSG(check_result, msg); \
             CV_Error(Error::OpenCLApiCallError, error_msg); \
         } \
@@ -210,7 +210,7 @@ void traceOpenCLCheck(cl_int status, const char* message)
         CV_OCL_TRACE_CHECK_RESULT(check_result, msg); \
         if (check_result != CL_SUCCESS && isRaiseError()) \
         { \
-            if (0) { const char* msg_ = (msg); (void)msg_; /* ensure const char* type (cv::String without c_str()) */ } \
+            if (0) { const char* msg_ = (msg); CV_UNUSED(msg_); /* ensure const char* type (cv::String without c_str()) */ } \
             cv::String error_msg = CV_OCL_API_ERROR_MSG(check_result, msg); \
             CV_Error(Error::OpenCLApiCallError, error_msg); \
         } \

--- a/modules/core/src/opengl.cpp
+++ b/modules/core/src/opengl.cpp
@@ -104,11 +104,11 @@ namespace
 void cv::cuda::setGlDevice(int device)
 {
 #ifndef HAVE_OPENGL
-    (void) device;
+    CV_UNUSED(device);
     throw_no_ogl();
 #else
     #ifndef HAVE_CUDA
-        (void) device;
+        CV_UNUSED(device);
         throw_no_cuda();
     #else
         cudaSafeCall( cudaGLSetGLDevice(device) );
@@ -214,7 +214,7 @@ namespace
         CV_DbgAssert( resource_ != 0 );
 
         GraphicsMapHolder h(&resource_, stream);
-        (void) h;
+        CV_UNUSED(h);
 
         void* dst;
         size_t size;
@@ -233,7 +233,7 @@ namespace
         CV_DbgAssert( resource_ != 0 );
 
         GraphicsMapHolder h(&resource_, stream);
-        (void) h;
+        CV_UNUSED(h);
 
         void* src;
         size_t size;
@@ -456,11 +456,11 @@ cv::ogl::Buffer::Buffer() : rows_(0), cols_(0), type_(0)
 cv::ogl::Buffer::Buffer(int arows, int acols, int atype, unsigned int abufId, bool autoRelease) : rows_(0), cols_(0), type_(0)
 {
 #ifndef HAVE_OPENGL
-    (void) arows;
-    (void) acols;
-    (void) atype;
-    (void) abufId;
-    (void) autoRelease;
+    CV_UNUSED(arows);
+    CV_UNUSED(acols);
+    CV_UNUSED(atype);
+    CV_UNUSED(abufId);
+    CV_UNUSED(autoRelease);
     throw_no_ogl();
 #else
     impl_.reset(new Impl(abufId, autoRelease));
@@ -473,10 +473,10 @@ cv::ogl::Buffer::Buffer(int arows, int acols, int atype, unsigned int abufId, bo
 cv::ogl::Buffer::Buffer(Size asize, int atype, unsigned int abufId, bool autoRelease) : rows_(0), cols_(0), type_(0)
 {
 #ifndef HAVE_OPENGL
-    (void) asize;
-    (void) atype;
-    (void) abufId;
-    (void) autoRelease;
+    CV_UNUSED(asize);
+    CV_UNUSED(atype);
+    CV_UNUSED(abufId);
+    CV_UNUSED(autoRelease);
     throw_no_ogl();
 #else
     impl_.reset(new Impl(abufId, autoRelease));
@@ -489,9 +489,9 @@ cv::ogl::Buffer::Buffer(Size asize, int atype, unsigned int abufId, bool autoRel
 cv::ogl::Buffer::Buffer(InputArray arr, Target target, bool autoRelease) : rows_(0), cols_(0), type_(0)
 {
 #ifndef HAVE_OPENGL
-    (void) arr;
-    (void) target;
-    (void) autoRelease;
+    CV_UNUSED(arr);
+    CV_UNUSED(target);
+    CV_UNUSED(autoRelease);
     throw_no_ogl();
 #else
     const int kind = arr.kind();
@@ -521,11 +521,11 @@ cv::ogl::Buffer::Buffer(InputArray arr, Target target, bool autoRelease) : rows_
 void cv::ogl::Buffer::create(int arows, int acols, int atype, Target target, bool autoRelease)
 {
 #ifndef HAVE_OPENGL
-    (void) arows;
-    (void) acols;
-    (void) atype;
-    (void) target;
-    (void) autoRelease;
+    CV_UNUSED(arows);
+    CV_UNUSED(acols);
+    CV_UNUSED(atype);
+    CV_UNUSED(target);
+    CV_UNUSED(autoRelease);
     throw_no_ogl();
 #else
     if (rows_ != arows || cols_ != acols || type_ != atype)
@@ -554,7 +554,7 @@ void cv::ogl::Buffer::release()
 void cv::ogl::Buffer::setAutoRelease(bool flag)
 {
 #ifndef HAVE_OPENGL
-    (void) flag;
+    CV_UNUSED(flag);
     throw_no_ogl();
 #else
     impl_->setAutoRelease(flag);
@@ -564,9 +564,9 @@ void cv::ogl::Buffer::setAutoRelease(bool flag)
 void cv::ogl::Buffer::copyFrom(InputArray arr, Target target, bool autoRelease)
 {
 #ifndef HAVE_OPENGL
-    (void) arr;
-    (void) target;
-    (void) autoRelease;
+    CV_UNUSED(arr);
+    CV_UNUSED(target);
+    CV_UNUSED(autoRelease);
     throw_no_ogl();
 #else
     const int kind = arr.kind();
@@ -609,17 +609,17 @@ void cv::ogl::Buffer::copyFrom(InputArray arr, Target target, bool autoRelease)
 void cv::ogl::Buffer::copyFrom(InputArray arr, cuda::Stream& stream, Target target, bool autoRelease)
 {
 #ifndef HAVE_OPENGL
-    (void) arr;
-    (void) stream;
-    (void) target;
-    (void) autoRelease;
+    CV_UNUSED(arr);
+    CV_UNUSED(stream);
+    CV_UNUSED(target);
+    CV_UNUSED(autoRelease);
     throw_no_ogl();
 #else
     #ifndef HAVE_CUDA
-        (void) arr;
-        (void) stream;
-        (void) target;
-        (void) autoRelease;
+        CV_UNUSED(arr);
+        CV_UNUSED(stream);
+        CV_UNUSED(target);
+        CV_UNUSED(autoRelease);
         throw_no_cuda();
     #else
         GpuMat dmat = arr.getGpuMat();
@@ -634,7 +634,7 @@ void cv::ogl::Buffer::copyFrom(InputArray arr, cuda::Stream& stream, Target targ
 void cv::ogl::Buffer::copyTo(OutputArray arr) const
 {
 #ifndef HAVE_OPENGL
-    (void) arr;
+    CV_UNUSED(arr);
     throw_no_ogl();
 #else
     const int kind = arr.kind();
@@ -674,13 +674,13 @@ void cv::ogl::Buffer::copyTo(OutputArray arr) const
 void cv::ogl::Buffer::copyTo(OutputArray arr, cuda::Stream& stream) const
 {
 #ifndef HAVE_OPENGL
-    (void) arr;
-    (void) stream;
+    CV_UNUSED(arr);
+    CV_UNUSED(stream);
     throw_no_ogl();
 #else
     #ifndef HAVE_CUDA
-        (void) arr;
-        (void) stream;
+        CV_UNUSED(arr);
+        CV_UNUSED(stream);
         throw_no_cuda();
     #else
         arr.create(rows_, cols_, type_);
@@ -693,8 +693,8 @@ void cv::ogl::Buffer::copyTo(OutputArray arr, cuda::Stream& stream) const
 cv::ogl::Buffer cv::ogl::Buffer::clone(Target target, bool autoRelease) const
 {
 #ifndef HAVE_OPENGL
-    (void) target;
-    (void) autoRelease;
+    CV_UNUSED(target);
+    CV_UNUSED(autoRelease);
     throw_no_ogl();
 #else
     ogl::Buffer buf;
@@ -706,7 +706,7 @@ cv::ogl::Buffer cv::ogl::Buffer::clone(Target target, bool autoRelease) const
 void cv::ogl::Buffer::bind(Target target) const
 {
 #ifndef HAVE_OPENGL
-    (void) target;
+    CV_UNUSED(target);
     throw_no_ogl();
 #else
     impl_->bind(target);
@@ -716,7 +716,7 @@ void cv::ogl::Buffer::bind(Target target) const
 void cv::ogl::Buffer::unbind(Target target)
 {
 #ifndef HAVE_OPENGL
-    (void) target;
+    CV_UNUSED(target);
     throw_no_ogl();
 #else
     gl::BindBuffer(target, 0);
@@ -727,7 +727,7 @@ void cv::ogl::Buffer::unbind(Target target)
 Mat cv::ogl::Buffer::mapHost(Access access)
 {
 #ifndef HAVE_OPENGL
-    (void) access;
+    CV_UNUSED(access);
     throw_no_ogl();
 #else
     return Mat(rows_, cols_, type_, impl_->mapHost(access));
@@ -772,11 +772,11 @@ void cv::ogl::Buffer::unmapDevice()
 cuda::GpuMat cv::ogl::Buffer::mapDevice(cuda::Stream& stream)
 {
 #ifndef HAVE_OPENGL
-    (void) stream;
+    CV_UNUSED(stream);
     throw_no_ogl();
 #else
     #ifndef HAVE_CUDA
-        (void) stream;
+        CV_UNUSED(stream);
         throw_no_cuda();
     #else
         return GpuMat(rows_, cols_, type_, impl_->mapDevice(cuda::StreamAccessor::getStream(stream)));
@@ -787,11 +787,11 @@ cuda::GpuMat cv::ogl::Buffer::mapDevice(cuda::Stream& stream)
 void cv::ogl::Buffer::unmapDevice(cuda::Stream& stream)
 {
 #ifndef HAVE_OPENGL
-    (void) stream;
+    CV_UNUSED(stream);
     throw_no_ogl();
 #else
     #ifndef HAVE_CUDA
-        (void) stream;
+        CV_UNUSED(stream);
         throw_no_cuda();
     #else
         impl_->unmapDevice(cuda::StreamAccessor::getStream(stream));
@@ -933,11 +933,11 @@ cv::ogl::Texture2D::Texture2D() : rows_(0), cols_(0), format_(NONE)
 cv::ogl::Texture2D::Texture2D(int arows, int acols, Format aformat, unsigned int atexId, bool autoRelease) : rows_(0), cols_(0), format_(NONE)
 {
 #ifndef HAVE_OPENGL
-    (void) arows;
-    (void) acols;
-    (void) aformat;
-    (void) atexId;
-    (void) autoRelease;
+    CV_UNUSED(arows);
+    CV_UNUSED(acols);
+    CV_UNUSED(aformat);
+    CV_UNUSED(atexId);
+    CV_UNUSED(autoRelease);
     throw_no_ogl();
 #else
     impl_.reset(new Impl(atexId, autoRelease));
@@ -950,10 +950,10 @@ cv::ogl::Texture2D::Texture2D(int arows, int acols, Format aformat, unsigned int
 cv::ogl::Texture2D::Texture2D(Size asize, Format aformat, unsigned int atexId, bool autoRelease) : rows_(0), cols_(0), format_(NONE)
 {
 #ifndef HAVE_OPENGL
-    (void) asize;
-    (void) aformat;
-    (void) atexId;
-    (void) autoRelease;
+    CV_UNUSED(asize);
+    CV_UNUSED(aformat);
+    CV_UNUSED(atexId);
+    CV_UNUSED(autoRelease);
     throw_no_ogl();
 #else
     impl_.reset(new Impl(atexId, autoRelease));
@@ -966,8 +966,8 @@ cv::ogl::Texture2D::Texture2D(Size asize, Format aformat, unsigned int atexId, b
 cv::ogl::Texture2D::Texture2D(InputArray arr, bool autoRelease) : rows_(0), cols_(0), format_(NONE)
 {
 #ifndef HAVE_OPENGL
-    (void) arr;
-    (void) autoRelease;
+    CV_UNUSED(arr);
+    CV_UNUSED(autoRelease);
     throw_no_ogl();
 #else
     const int kind = arr.kind();
@@ -1036,10 +1036,10 @@ cv::ogl::Texture2D::Texture2D(InputArray arr, bool autoRelease) : rows_(0), cols
 void cv::ogl::Texture2D::create(int arows, int acols, Format aformat, bool autoRelease)
 {
 #ifndef HAVE_OPENGL
-    (void) arows;
-    (void) acols;
-    (void) aformat;
-    (void) autoRelease;
+    CV_UNUSED(arows);
+    CV_UNUSED(acols);
+    CV_UNUSED(aformat);
+    CV_UNUSED(autoRelease);
     throw_no_ogl();
 #else
     if (rows_ != arows || cols_ != acols || format_ != aformat)
@@ -1068,7 +1068,7 @@ void cv::ogl::Texture2D::release()
 void cv::ogl::Texture2D::setAutoRelease(bool flag)
 {
 #ifndef HAVE_OPENGL
-    (void) flag;
+    CV_UNUSED(flag);
     throw_no_ogl();
 #else
     impl_->setAutoRelease(flag);
@@ -1078,8 +1078,8 @@ void cv::ogl::Texture2D::setAutoRelease(bool flag)
 void cv::ogl::Texture2D::copyFrom(InputArray arr, bool autoRelease)
 {
 #ifndef HAVE_OPENGL
-    (void) arr;
-    (void) autoRelease;
+    CV_UNUSED(arr);
+    CV_UNUSED(autoRelease);
     throw_no_ogl();
 #else
     const int kind = arr.kind();
@@ -1145,9 +1145,9 @@ void cv::ogl::Texture2D::copyFrom(InputArray arr, bool autoRelease)
 void cv::ogl::Texture2D::copyTo(OutputArray arr, int ddepth, bool autoRelease) const
 {
 #ifndef HAVE_OPENGL
-    (void) arr;
-    (void) ddepth;
-    (void) autoRelease;
+    CV_UNUSED(arr);
+    CV_UNUSED(ddepth);
+    CV_UNUSED(autoRelease);
     throw_no_ogl();
 #else
     const int kind = arr.kind();
@@ -1400,9 +1400,9 @@ void cv::ogl::Arrays::bind() const
 void cv::ogl::render(const ogl::Texture2D& tex, Rect_<double> wndRect, Rect_<double> texRect)
 {
 #ifndef HAVE_OPENGL
-    (void) tex;
-    (void) wndRect;
-    (void) texRect;
+    CV_UNUSED(tex);
+    CV_UNUSED(wndRect);
+    CV_UNUSED(texRect);
     throw_no_ogl();
 #else
     if (!tex.empty())
@@ -1472,9 +1472,9 @@ void cv::ogl::render(const ogl::Texture2D& tex, Rect_<double> wndRect, Rect_<dou
 void cv::ogl::render(const ogl::Arrays& arr, int mode, Scalar color)
 {
 #ifndef HAVE_OPENGL
-    (void) arr;
-    (void) mode;
-    (void) color;
+    CV_UNUSED(arr);
+    CV_UNUSED(mode);
+    CV_UNUSED(color);
     throw_no_ogl();
 #else
     if (!arr.empty())
@@ -1491,10 +1491,10 @@ void cv::ogl::render(const ogl::Arrays& arr, int mode, Scalar color)
 void cv::ogl::render(const ogl::Arrays& arr, InputArray indices, int mode, Scalar color)
 {
 #ifndef HAVE_OPENGL
-    (void) arr;
-    (void) indices;
-    (void) mode;
-    (void) color;
+    CV_UNUSED(arr);
+    CV_UNUSED(indices);
+    CV_UNUSED(mode);
+    CV_UNUSED(color);
     throw_no_ogl();
 #else
     if (!arr.empty() && !indices.empty())
@@ -1688,7 +1688,7 @@ Context& initializeContextFromGL()
 
 void convertToGLTexture2D(InputArray src, Texture2D& texture)
 {
-    (void)src; (void)texture;
+    CV_UNUSED(src); CV_UNUSED(texture);
 #if !defined(HAVE_OPENGL)
     NO_OPENGL_SUPPORT_ERROR;
 #elif !defined(HAVE_OPENCL)
@@ -1742,7 +1742,7 @@ void convertToGLTexture2D(InputArray src, Texture2D& texture)
 
 void convertFromGLTexture2D(const Texture2D& texture, OutputArray dst)
 {
-    (void)texture; (void)dst;
+    CV_UNUSED(texture); CV_UNUSED(dst);
 #if !defined(HAVE_OPENGL)
     NO_OPENGL_SUPPORT_ERROR;
 #elif !defined(HAVE_OPENCL)
@@ -1803,7 +1803,7 @@ void convertFromGLTexture2D(const Texture2D& texture, OutputArray dst)
 //void mapGLBuffer(const Buffer& buffer, UMat& dst, int accessFlags)
 UMat mapGLBuffer(const Buffer& buffer, int accessFlags)
 {
-    (void)buffer; (void)accessFlags;
+    CV_UNUSED(buffer); CV_UNUSED(accessFlags);
 #if !defined(HAVE_OPENGL)
     NO_OPENGL_SUPPORT_ERROR;
 #elif !defined(HAVE_OPENCL)
@@ -1855,7 +1855,7 @@ UMat mapGLBuffer(const Buffer& buffer, int accessFlags)
 
 void unmapGLBuffer(UMat& u)
 {
-    (void)u;
+    CV_UNUSED(u);
 #if !defined(HAVE_OPENGL)
     NO_OPENGL_SUPPORT_ERROR;
 #elif !defined(HAVE_OPENCL)

--- a/modules/core/src/parallel.cpp
+++ b/modules/core/src/parallel.cpp
@@ -491,7 +491,7 @@ void cv::parallel_for_(const cv::Range& range, const cv::ParallelLoopBody& body,
     else // nested parallel_for_() calls are not parallelized
 #endif // CV_PARALLEL_FRAMEWORK
     {
-        (void)nstripes;
+        CV_UNUSED(nstripes);
         body(range);
     }
 }
@@ -664,7 +664,7 @@ unsigned defaultNumberOfThreads()
 
 void cv::setNumThreads( int threads_ )
 {
-    (void)threads_;
+    CV_UNUSED(threads_);
 #ifdef CV_PARALLEL_FRAMEWORK
     int threads = (threads_ < 0) ? defaultNumberOfThreads() : (unsigned)threads_;
     numThreads = threads;

--- a/modules/core/src/system.cpp
+++ b/modules/core/src/system.cpp
@@ -2215,7 +2215,7 @@ void setUseIPP(bool flag)
 #ifdef HAVE_IPP
     data->useIPP = (getIPPSingleton().useIPP)?flag:false;
 #else
-    (void)flag;
+    CV_UNUSED(flag);
     data->useIPP = false;
 #endif
 }
@@ -2240,7 +2240,7 @@ void setUseIPP_NE(bool flag)
 #ifdef HAVE_IPP
     data->useIPP_NE = (getIPPSingleton().useIPP_NE)?flag:false;
 #else
-    (void)flag;
+    CV_UNUSED(flag);
     data->useIPP_NE = false;
 #endif
 }

--- a/modules/core/src/trace.cpp
+++ b/modules/core/src/trace.cpp
@@ -892,7 +892,7 @@ bool TraceManager::isActivated()
     if (!isInitialized)
     {
         TraceManager& m = getTraceManager();
-        (void)m; // TODO
+        CV_UNUSED(m); // TODO
     }
 
     return activated;

--- a/modules/core/src/umatrix.cpp
+++ b/modules/core/src/umatrix.cpp
@@ -122,7 +122,7 @@ UMatData::~UMatData()
             }
         }
 #else
-        (void)showWarn;
+        CV_UNUSED(showWarn);
 #endif
         originalUMatData = NULL;
     }

--- a/modules/core/src/va_intel.cpp
+++ b/modules/core/src/va_intel.cpp
@@ -46,7 +46,7 @@ namespace ocl {
 
 Context& initializeContextFromVA(VADisplay display, bool tryInterop)
 {
-    (void)display; (void)tryInterop;
+    CV_UNUSED(display); CV_UNUSED(tryInterop);
 #if !defined(HAVE_VA)
     NO_VA_SUPPORT_ERROR;
 #else  // !HAVE_VA
@@ -485,7 +485,7 @@ static void copy_convert_bgr_to_yv12(const VAImage& image, const Mat& bgr, unsig
 
 void convertToVASurface(VADisplay display, InputArray src, VASurfaceID surface, Size size)
 {
-    (void)display; (void)src; (void)surface; (void)size;
+    CV_UNUSED(display); CV_UNUSED(src); CV_UNUSED(surface); CV_UNUSED(size);
 #if !defined(HAVE_VA)
     NO_VA_SUPPORT_ERROR;
 #else  // !HAVE_VA
@@ -589,7 +589,7 @@ void convertToVASurface(VADisplay display, InputArray src, VASurfaceID surface, 
 
 void convertFromVASurface(VADisplay display, VASurfaceID surface, Size size, OutputArray dst)
 {
-    (void)display; (void)surface; (void)dst; (void)size;
+    CV_UNUSED(display); CV_UNUSED(surface); CV_UNUSED(dst); CV_UNUSED(size);
 #if !defined(HAVE_VA)
     NO_VA_SUPPORT_ERROR;
 #else  // !HAVE_VA

--- a/modules/core/test/test_dxt.cpp
+++ b/modules/core/test/test_dxt.cpp
@@ -793,7 +793,7 @@ CxCore_MulSpectrumsTest::CxCore_MulSpectrumsTest() : CxCore_DXTBaseTest( true, t
 
 double CxCore_MulSpectrumsTest::get_success_error_level( int test_case_idx, int i, int j )
 {
-    (void)test_case_idx;
+    CV_UNUSED(test_case_idx);
     CV_Assert(i == OUTPUT);
     CV_Assert(j == 0);
     int elem_depth = CV_MAT_DEPTH(cvGetElemType(test_array[i][j]));

--- a/modules/cudaarithm/src/arithm.cpp
+++ b/modules/cudaarithm/src/arithm.cpp
@@ -157,14 +157,14 @@ namespace
 void cv::cuda::gemm(InputArray _src1, InputArray _src2, double alpha, InputArray _src3, double beta, OutputArray _dst, int flags, Stream& stream)
 {
 #ifndef HAVE_CUBLAS
-    (void) _src1;
-    (void) _src2;
-    (void) alpha;
-    (void) _src3;
-    (void) beta;
-    (void) _dst;
-    (void) flags;
-    (void) stream;
+    CV_UNUSED(_src1);
+    CV_UNUSED(_src2);
+    CV_UNUSED(alpha);
+    CV_UNUSED(_src3);
+    CV_UNUSED(beta);
+    CV_UNUSED(_dst);
+    CV_UNUSED(flags);
+    CV_UNUSED(stream);
     CV_Error(Error::StsNotImplemented, "The library was build without CUBLAS");
 #else
     // CUBLAS works with column-major matrices
@@ -420,8 +420,8 @@ namespace
 Ptr<DFT> cv::cuda::createDFT(Size dft_size, int flags)
 {
 #ifndef HAVE_CUFFT
-    (void) dft_size;
-    (void) flags;
+    CV_UNUSED(dft_size);
+    CV_UNUSED(flags);
     CV_Error(Error::StsNotImplemented, "The library was build without CUFFT");
     return Ptr<DFT>();
 #else
@@ -571,7 +571,7 @@ namespace
 Ptr<Convolution> cv::cuda::createConvolution(Size user_block_size)
 {
 #ifndef HAVE_CUFFT
-    (void) user_block_size;
+    CV_UNUSED(user_block_size);
     CV_Error(Error::StsNotImplemented, "The library was build without CUFFT");
     return Ptr<Convolution>();
 #else

--- a/modules/cudaarithm/src/cuda/bitwise_scalar.cu
+++ b/modules/cudaarithm/src/cuda/bitwise_scalar.cu
@@ -126,7 +126,7 @@ namespace
 
 void bitScalar(const GpuMat& src, cv::Scalar value, bool, GpuMat& dst, const GpuMat& mask, double, Stream& stream, int op)
 {
-    (void) mask;
+    CV_UNUSED(mask);
 
     typedef void (*func_t)(const GpuMat& src, cv::Scalar value, GpuMat& dst, Stream& stream);
     static const func_t funcs[3][6][4] =

--- a/modules/cudaarithm/src/cuda/mul_spectrums.cu
+++ b/modules/cudaarithm/src/cuda/mul_spectrums.cu
@@ -121,7 +121,7 @@ namespace
 
 void cv::cuda::mulSpectrums(InputArray _src1, InputArray _src2, OutputArray _dst, int flags, bool conjB, Stream& stream)
 {
-    (void) flags;
+    CV_UNUSED(flags);
 
     GpuMat src1 = getInputMat(_src1, stream);
     GpuMat src2 = getInputMat(_src2, stream);
@@ -141,7 +141,7 @@ void cv::cuda::mulSpectrums(InputArray _src1, InputArray _src2, OutputArray _dst
 
 void cv::cuda::mulAndScaleSpectrums(InputArray _src1, InputArray _src2, OutputArray _dst, int flags, float scale, bool conjB, Stream& stream)
 {
-    (void) flags;
+    CV_UNUSED(flags);
 
     GpuMat src1 = getInputMat(_src1, stream);
     GpuMat src2 = getInputMat(_src2, stream);

--- a/modules/cudacodec/src/video_writer.cpp
+++ b/modules/cudacodec/src/video_writer.cpp
@@ -794,14 +794,14 @@ namespace
 
     void EncoderCallBackFFMPEG::onBeginFrame(int frameNumber, PicType picType)
     {
-        (void) frameNumber;
+        CV_UNUSED(frameNumber);
         isKeyFrame_ = (picType == IFRAME);
     }
 
     void EncoderCallBackFFMPEG::onEndFrame(int frameNumber, PicType picType)
     {
-        (void) frameNumber;
-        (void) picType;
+        CV_UNUSED(frameNumber);
+        CV_UNUSED(picType);
     }
 }
 

--- a/modules/cudafeatures2d/src/cuda/bf_knnmatch.cu
+++ b/modules/cudafeatures2d/src/cuda/bf_knnmatch.cu
@@ -63,8 +63,8 @@ namespace cv { namespace cuda { namespace device
                                       float* s_distance, int* s_trainIdx)
         {
         #if __CUDA_ARCH__ >= 300
-            (void) s_distance;
-            (void) s_trainIdx;
+            CV_UNUSED(s_distance);
+            CV_UNUSED(s_trainIdx);
 
             float d1, d2;
             int i1, i2;
@@ -174,9 +174,9 @@ namespace cv { namespace cuda { namespace device
                                        float* s_distance, int* s_trainIdx, int* s_imgIdx)
         {
         #if __CUDA_ARCH__ >= 300
-            (void) s_distance;
-            (void) s_trainIdx;
-            (void) s_imgIdx;
+            CV_UNUSED(s_distance);
+            CV_UNUSED(s_trainIdx);
+            CV_UNUSED(s_imgIdx);
 
             float d1, d2;
             int i1, i2;

--- a/modules/cudaimgproc/src/color.cpp
+++ b/modules/cudaimgproc/src/color.cpp
@@ -1812,9 +1812,9 @@ namespace
     void RGBA_to_mBGRA(InputArray _src, OutputArray _dst, int, Stream& _stream)
     {
     #if (CUDA_VERSION < 5000)
-        (void) _src;
-        (void) _dst;
-        (void) _stream;
+        CV_UNUSED(_src);
+        CV_UNUSED(_dst);
+        CV_UNUSED(_stream);
         CV_Error( Error::StsBadFlag, "Unknown/unsupported color conversion code" );
     #else
         GpuMat src = _src.getGpuMat();
@@ -2212,10 +2212,10 @@ void cv::cuda::swapChannels(InputOutputArray _image, const int dstOrder[4], Stre
 void cv::cuda::gammaCorrection(InputArray _src, OutputArray _dst, bool forward, Stream& stream)
 {
 #if (CUDA_VERSION < 5000)
-    (void) _src;
-    (void) _dst;
-    (void) forward;
-    (void) stream;
+    CV_UNUSED(_src);
+    CV_UNUSED(_dst);
+    CV_UNUSED(forward);
+    CV_UNUSED(stream);
     CV_Error(Error::StsNotImplemented, "This function works only with CUDA 5.0 or higher");
 #else
     typedef NppStatus (*func_t)(const Npp8u* pSrc, int nSrcStep, Npp8u* pDst, int nDstStep, NppiSize oSizeROI);

--- a/modules/cudaimgproc/src/generalized_hough.cpp
+++ b/modules/cudaimgproc/src/generalized_hough.cpp
@@ -201,8 +201,8 @@ namespace
     void GeneralizedHoughBase::setTemplateImpl(InputArray templ, Point templCenter)
     {
 #ifndef HAVE_OPENCV_CUDAFILTERS
-        (void) templ;
-        (void) templCenter;
+        CV_UNUSED(templ);
+        CV_UNUSED(templCenter);
         throw_no_cuda();
 #else
         calcEdges(templ, templEdges_, templDx_, templDy_);
@@ -239,9 +239,9 @@ namespace
     void GeneralizedHoughBase::detectImpl(InputArray image, OutputArray positions, OutputArray votes)
     {
 #ifndef HAVE_OPENCV_CUDAFILTERS
-        (void) image;
-        (void) positions;
-        (void) votes;
+        CV_UNUSED(image);
+        CV_UNUSED(positions);
+        CV_UNUSED(votes);
         throw_no_cuda();
 #else
         calcEdges(image, imageEdges_, imageDx_, imageDy_);

--- a/modules/cudaimgproc/src/hough_circles.cpp
+++ b/modules/cudaimgproc/src/hough_circles.cpp
@@ -158,7 +158,7 @@ namespace
     void HoughCirclesDetectorImpl::detect(InputArray _src, OutputArray circles, Stream& stream)
     {
         // TODO : implement async version
-        (void) stream;
+        CV_UNUSED(stream);
 
         using namespace cv::cuda::device::hough;
         using namespace cv::cuda::device::hough_circles;

--- a/modules/cudaimgproc/src/hough_lines.cpp
+++ b/modules/cudaimgproc/src/hough_lines.cpp
@@ -129,7 +129,7 @@ namespace
     void HoughLinesDetectorImpl::detect(InputArray _src, OutputArray lines, Stream& stream)
     {
         // TODO : implement async version
-        (void) stream;
+        CV_UNUSED(stream);
 
         using namespace cv::cuda::device::hough;
         using namespace cv::cuda::device::hough_lines;

--- a/modules/cudaimgproc/src/hough_segments.cpp
+++ b/modules/cudaimgproc/src/hough_segments.cpp
@@ -132,7 +132,7 @@ namespace
     void HoughSegmentDetectorImpl::detect(InputArray _src, OutputArray lines, Stream& stream)
     {
         // TODO : implement async version
-        (void) stream;
+        CV_UNUSED(stream);
 
         using namespace cv::cuda::device::hough;
         using namespace cv::cuda::device::hough_lines;

--- a/modules/cudalegacy/include/opencv2/cudalegacy/NCV.hpp
+++ b/modules/cudalegacy/include/opencv2/cudalegacy/NCV.hpp
@@ -494,12 +494,12 @@ public:
     virtual NCVStatus alloc(NCVMemSegment &seg, size_t size);
     virtual NCVStatus dealloc(NCVMemSegment &seg);
 
-    virtual NcvBool isInitialized(void) const;
-    virtual NcvBool isCounting(void) const;
+    virtual NcvBool isInitialized() const;
+    virtual NcvBool isCounting() const;
 
-    virtual NCVMemoryType memType(void) const;
-    virtual Ncv32u alignment(void) const;
-    virtual size_t maxSize(void) const;
+    virtual NCVMemoryType memType() const;
+    virtual Ncv32u alignment() const;
+    virtual size_t maxSize() const;
 
 private:
 
@@ -527,12 +527,12 @@ public:
     virtual NCVStatus alloc(NCVMemSegment &seg, size_t size);
     virtual NCVStatus dealloc(NCVMemSegment &seg);
 
-    virtual NcvBool isInitialized(void) const;
-    virtual NcvBool isCounting(void) const;
+    virtual NcvBool isInitialized() const;
+    virtual NcvBool isCounting() const;
 
-    virtual NCVMemoryType memType(void) const;
-    virtual Ncv32u alignment(void) const;
-    virtual size_t maxSize(void) const;
+    virtual NCVMemoryType memType() const;
+    virtual Ncv32u alignment() const;
+    virtual size_t maxSize() const;
 
 private:
 

--- a/modules/cudalegacy/src/NCV.cpp
+++ b/modules/cudalegacy/src/NCV.cpp
@@ -738,10 +738,10 @@ struct RectConvert
 static void groupRectangles(std::vector<NcvRect32u> &hypotheses, int groupThreshold, double eps, std::vector<Ncv32u> *weights)
 {
 #ifndef HAVE_OPENCV_OBJDETECT
-    (void) hypotheses;
-    (void) groupThreshold;
-    (void) eps;
-    (void) weights;
+    CV_UNUSED(hypotheses);
+    CV_UNUSED(groupThreshold);
+    CV_UNUSED(eps);
+    CV_UNUSED(weights);
     CV_Error(cv::Error::StsNotImplemented, "This functionality requires objdetect module");
 #else
     std::vector<cv::Rect> rects(hypotheses.size());

--- a/modules/cudalegacy/src/calib3d.cpp
+++ b/modules/cudalegacy/src/calib3d.cpp
@@ -213,7 +213,7 @@ void cv::cuda::solvePnPRansac(const Mat& object, const Mat& image, const Mat& ca
                              int num_iters, float max_dist, int min_inlier_count,
                              std::vector<int>* inliers)
 {
-    (void)min_inlier_count;
+    CV_UNUSED(min_inlier_count);
     CV_Assert(object.rows == 1 && object.cols > 0 && object.type() == CV_32FC3);
     CV_Assert(image.rows == 1 && image.cols > 0 && image.type() == CV_32FC2);
     CV_Assert(object.cols == image.cols);

--- a/modules/cudalegacy/src/cuda/NCV.cu
+++ b/modules/cudalegacy/src/cuda/NCV.cu
@@ -127,7 +127,7 @@ static NCVStatus drawRectsWrapperDevice(T *d_dst,
                                         T color,
                                         cudaStream_t cuStream)
 {
-    (void)cuStream;
+    CV_UNUSED(cuStream);
     ncvAssertReturn(d_dst != NULL && d_rects != NULL, NCV_NULL_PTR);
     ncvAssertReturn(dstWidth > 0 && dstHeight > 0, NCV_DIMENSIONS_INVALID);
     ncvAssertReturn(dstStride >= dstWidth, NCV_INVALID_STEP);

--- a/modules/cudalegacy/src/cuda/NCVHaarObjectDetection.cu
+++ b/modules/cudalegacy/src/cuda/NCVHaarObjectDetection.cu
@@ -714,7 +714,7 @@ struct applyHaarClassifierAnchorParallelFunctor
     template<class TList>
     void call(TList tl)
     {
-        (void)tl;
+        CV_UNUSED(tl);
         applyHaarClassifierAnchorParallel <
             Loki::TL::TypeAt<TList, 0>::Result::value,
             Loki::TL::TypeAt<TList, 1>::Result::value,
@@ -824,7 +824,7 @@ struct applyHaarClassifierClassifierParallelFunctor
     template<class TList>
     void call(TList tl)
     {
-        (void)tl;
+        CV_UNUSED(tl);
         applyHaarClassifierClassifierParallel <
             Loki::TL::TypeAt<TList, 0>::Result::value,
             Loki::TL::TypeAt<TList, 1>::Result::value,
@@ -905,7 +905,7 @@ struct initializeMaskVectorFunctor
     template<class TList>
     void call(TList tl)
     {
-        (void)tl;
+        CV_UNUSED(tl);
         initializeMaskVector <
             Loki::TL::TypeAt<TList, 0>::Result::value,
             Loki::TL::TypeAt<TList, 1>::Result::value >
@@ -2113,11 +2113,11 @@ static NCVStatus loadFromXML(const cv::String &filename,
                       std::vector<HaarFeature64> &haarFeatures)
 {
 #ifndef HAVE_OPENCV_OBJDETECT
-    (void) filename;
-    (void) haar;
-    (void) haarStages;
-    (void) haarClassifierNodes;
-    (void) haarFeatures;
+    CV_UNUSED(filename);
+    CV_UNUSED(haar);
+    CV_UNUSED(haarStages);
+    CV_UNUSED(haarClassifierNodes);
+    CV_UNUSED(haarFeatures);
     CV_Error(cv::Error::StsNotImplemented, "This functionality requires objdetect module");
     return NCV_HAAR_XML_LOADING_EXCEPTION;
 #else

--- a/modules/cudalegacy/src/cuda/NCVRuntimeTemplates.hpp
+++ b/modules/cudalegacy/src/cuda/NCVRuntimeTemplates.hpp
@@ -212,7 +212,7 @@ namespace NCVRuntimeTemplateBool
 
         static void call(Func &functor, std::vector<int> &templateParams)
         {
-            (void)templateParams;
+            CV_UNUSED(templateParams);
             functor.call(TList());
         }
     };

--- a/modules/cudalegacy/src/cuda/ccomponetns.cu
+++ b/modules/cudalegacy/src/cuda/ccomponetns.cu
@@ -498,7 +498,7 @@ namespace cv { namespace cuda { namespace device
 
         void labelComponents(const PtrStepSzb& edges, PtrStepSzi comps, int flags, cudaStream_t stream)
         {
-            (void) flags;
+            CV_UNUSED(flags);
             dim3 block(CTA_SIZE_X, CTA_SIZE_Y);
             dim3 grid(divUp(edges.cols, TILE_COLS), divUp(edges.rows, TILE_ROWS));
 

--- a/modules/cudalegacy/src/gmg.cpp
+++ b/modules/cudalegacy/src/gmg.cpp
@@ -231,7 +231,7 @@ namespace
 
     void GMGImpl::getBackgroundImage(OutputArray backgroundImage) const
     {
-        (void) backgroundImage;
+        CV_UNUSED(backgroundImage);
         CV_Error(Error::StsNotImplemented, "Not implemented");
     }
 

--- a/modules/cudalegacy/test/TestHaarCascadeApplication.cpp
+++ b/modules/cudalegacy/test/TestHaarCascadeApplication.cpp
@@ -265,7 +265,7 @@ bool TestHaarCascadeApplication::process()
     {
         // calculations here
         FpuControl fpu;
-        (void) fpu;
+        CV_UNUSED(fpu);
 
         ncvStat = ncvApplyHaarClassifierCascade_host(
             h_integralImage, h_rectStdDev, h_pixelMask,

--- a/modules/cudalegacy/test/main_nvidia.cpp
+++ b/modules/cudalegacy/test/main_nvidia.cpp
@@ -271,7 +271,7 @@ void generateHaarLoaderTests(NCVAutoTestLister &testLister)
 void generateHaarApplicationTests(NCVAutoTestLister &testLister, NCVTestSourceProvider<Ncv8u> &src,
                                   Ncv32u maxWidth, Ncv32u maxHeight)
 {
-    (void)maxHeight;
+    CV_UNUSED(maxHeight);
     for (Ncv32u i=100; i<512; i+=41)
     {
         for (Ncv32u j=100; j<128; j+=25)
@@ -292,7 +292,7 @@ void generateHaarApplicationTests(NCVAutoTestLister &testLister, NCVTestSourcePr
 
 static void devNullOutput(const cv::String& msg)
 {
-    (void)msg;
+    CV_UNUSED(msg);
 }
 
 }

--- a/modules/cudaobjdetect/src/cuda/hog.cu
+++ b/modules/cudaobjdetect/src/cuda/hog.cu
@@ -731,7 +731,7 @@ namespace cv { namespace cuda { namespace device
                                     bool correct_gamma,
                                     const cudaStream_t& stream)
         {
-            (void)nbins;
+            CV_UNUSED(nbins);
             const int nthreads = 256;
 
             dim3 bdim(nthreads, 1);
@@ -806,7 +806,7 @@ namespace cv { namespace cuda { namespace device
                                     bool correct_gamma,
                                     const cudaStream_t& stream)
         {
-            (void)nbins;
+            CV_UNUSED(nbins);
             const int nthreads = 256;
 
             dim3 bdim(nthreads, 1);

--- a/modules/cudaoptflow/src/cuda/pyrlk.cu
+++ b/modules/cudaoptflow/src/cuda/pyrlk.cu
@@ -89,7 +89,7 @@ namespace pyrlk
     {
         static __host__ __forceinline__ void bindTexture_(PtrStepSz<typename TypeVec<T, cn>::vec_type> I)
         {
-            (void)I;
+            CV_UNUSED(I);
         }
     };
 
@@ -112,7 +112,7 @@ namespace pyrlk
         }
         static __host__ __forceinline__ void bindTexture_(PtrStepSz<ushort>& I)
         {
-            (void)I;
+            CV_UNUSED(I);
         }
     };
     template <> struct Tex_I<1, int>
@@ -123,7 +123,7 @@ namespace pyrlk
         }
         static __host__ __forceinline__ void bindTexture_(PtrStepSz<int>& I)
         {
-            (void)I;
+            CV_UNUSED(I);
         }
     };
     template <> struct Tex_I<1, float>
@@ -146,7 +146,7 @@ namespace pyrlk
         }
         static __host__ __forceinline__ void bindTexture_(PtrStepSz<uchar3> I)
         {
-            (void)I;
+            CV_UNUSED(I);
         }
     };
     template <> struct Tex_I<3, ushort>
@@ -157,7 +157,7 @@ namespace pyrlk
         }
         static __host__ __forceinline__ void bindTexture_(PtrStepSz<ushort3> I)
         {
-            (void)I;
+            CV_UNUSED(I);
         }
     };
     template <> struct Tex_I<3, int>
@@ -168,7 +168,7 @@ namespace pyrlk
         }
         static __host__ __forceinline__ void bindTexture_(PtrStepSz<int3> I)
         {
-            (void)I;
+            CV_UNUSED(I);
         }
     };
     template <> struct Tex_I<3, float>
@@ -179,7 +179,7 @@ namespace pyrlk
         }
         static __host__ __forceinline__ void bindTexture_(PtrStepSz<float3> I)
         {
-            (void)I;
+            CV_UNUSED(I);
         }
     };
     // ****************** 4 channel specializations ************************
@@ -222,7 +222,7 @@ namespace pyrlk
     {
         static __host__ __forceinline__ void bindTexture_(PtrStepSz<typename TypeVec<T,cn>::vec_type>& J)
         {
-            (void)J;
+            CV_UNUSED(J);
         }
     };
     template <> struct Tex_J<1, uchar>
@@ -757,8 +757,8 @@ namespace pyrlk
             int level, dim3 block, cudaStream_t stream)
         {
             dim3 grid(ptcount);
-            (void)I;
-            (void)J;
+            CV_UNUSED(I);
+            CV_UNUSED(J);
             if (level == 0 && err)
                 sparseKernel<cn, PATCH_X, PATCH_Y, true, T> <<<grid, block, 0, stream >>>(prevPts, nextPts, status, err, level, rows, cols);
             else

--- a/modules/cudawarping/src/cuda/remap.cu
+++ b/modules/cudawarping/src/cuda/remap.cu
@@ -89,9 +89,9 @@ namespace cv { namespace cuda { namespace device
         {
             static void call(PtrStepSz<T> src, PtrStepSz<T> srcWhole, int xoff, int yoff, PtrStepSzf mapx, PtrStepSzf mapy, PtrStepSz<T> dst, const float* borderValue, bool)
             {
-                (void)srcWhole;
-                (void)xoff;
-                (void)yoff;
+                CV_UNUSED(srcWhole);
+                CV_UNUSED(xoff);
+                CV_UNUSED(yoff);
                 typedef typename TypeVec<float, VecTraits<T>::cn>::vec_type work_type;
 
                 dim3 block(32, 8);

--- a/modules/cudawarping/src/cuda/warp.cu
+++ b/modules/cudawarping/src/cuda/warp.cu
@@ -160,9 +160,9 @@ namespace cv { namespace cuda { namespace device
         {
             static void call(PtrStepSz<T> src, PtrStepSz<T> srcWhole, int xoff, int yoff, PtrStepSz<T> dst, const float* borderValue, bool)
             {
-                (void)xoff;
-                (void)yoff;
-                (void)srcWhole;
+                CV_UNUSED(xoff);
+                CV_UNUSED(yoff);
+                CV_UNUSED(srcWhole);
 
                 typedef typename TypeVec<float, VecTraits<T>::cn>::vec_type work_type;
 

--- a/modules/cudawarping/src/warp.cpp
+++ b/modules/cudawarping/src/warp.cpp
@@ -478,7 +478,7 @@ namespace
 
         static void call(const GpuMat& src, GpuMat& dst, Size dsize, double angle, double xShift, double yShift, int interpolation, cudaStream_t stream)
         {
-            (void)dsize;
+            CV_UNUSED(dsize);
             static const int npp_inter[] = {NPPI_INTER_NN, NPPI_INTER_LINEAR, NPPI_INTER_CUBIC};
 
             NppStreamHandler h(stream);

--- a/modules/cudev/include/opencv2/cudev/block/detail/reduce.hpp
+++ b/modules/cudev/include/opencv2/cudev/block/detail/reduce.hpp
@@ -317,8 +317,8 @@ namespace block_reduce_detail
         __device__ static void reduce(Pointer smem, Reference val, uint tid, Op op)
         {
         #if CV_CUDEV_ARCH >= 300
-            (void) smem;
-            (void) tid;
+            CV_UNUSED(smem);
+            CV_UNUSED(tid);
 
             Unroll<N / 2, Pointer, Reference, Op>::loopShfl(val, op, N);
         #else

--- a/modules/cudev/include/opencv2/cudev/ptr2d/texture.hpp
+++ b/modules/cudev/include/opencv2/cudev/ptr2d/texture.hpp
@@ -195,8 +195,8 @@ template <typename T> struct TexturePtr
         // Use the texture object
         return tex2D<T>(texObj, x, y);
     #else
-        (void) y;
-        (void) x;
+        CV_UNUSED(y);
+        CV_UNUSED(x);
         return T();
     #endif
     }

--- a/modules/cudev/include/opencv2/cudev/util/atomic.hpp
+++ b/modules/cudev/include/opencv2/cudev/util/atomic.hpp
@@ -93,8 +93,8 @@ __device__ static double atomicAdd(double* address, double val)
     } while (assumed != old);
     return __longlong_as_double(old);
 #else
-    (void) address;
-    (void) val;
+    CV_UNUSED(address);
+    CV_UNUSED(val);
     return 0.0;
 #endif
 }
@@ -123,8 +123,8 @@ __device__ static float atomicMin(float* address, float val)
     } while (assumed != old);
     return __int_as_float(old);
 #else
-    (void) address;
-    (void) val;
+    CV_UNUSED(address);
+    CV_UNUSED(val);
     return 0.0f;
 #endif
 }
@@ -141,8 +141,8 @@ __device__ static double atomicMin(double* address, double val)
     } while (assumed != old);
     return __longlong_as_double(old);
 #else
-    (void) address;
-    (void) val;
+    CV_UNUSED(address);
+    CV_UNUSED(val);
     return 0.0;
 #endif
 }
@@ -171,8 +171,8 @@ __device__ static float atomicMax(float* address, float val)
     } while (assumed != old);
     return __int_as_float(old);
 #else
-    (void) address;
-    (void) val;
+    CV_UNUSED(address);
+    CV_UNUSED(val);
     return 0.0f;
 #endif
 }
@@ -189,8 +189,8 @@ __device__ static double atomicMax(double* address, double val)
     } while (assumed != old);
     return __longlong_as_double(old);
 #else
-    (void) address;
-    (void) val;
+    CV_UNUSED(address);
+    CV_UNUSED(val);
     return 0.0;
 #endif
 }

--- a/modules/cudev/include/opencv2/cudev/warp/detail/reduce.hpp
+++ b/modules/cudev/include/opencv2/cudev/warp/detail/reduce.hpp
@@ -193,8 +193,8 @@ namespace warp_reduce_detail
         __device__ static void reduce(Pointer smem, Reference val, uint tid, Op op)
         {
         #if CV_CUDEV_ARCH >= 300
-            (void) smem;
-            (void) tid;
+            CV_UNUSED(smem);
+            CV_UNUSED(tid);
 
             mergeShfl(val, 16, 32, op);
             mergeShfl(val, 8, 32, op);

--- a/modules/cudev/include/opencv2/cudev/warp/scan.hpp
+++ b/modules/cudev/include/opencv2/cudev/warp/scan.hpp
@@ -59,8 +59,8 @@ template <typename T>
 __device__ T warpScanInclusive(T data, volatile T* smem, uint tid)
 {
 #if CV_CUDEV_ARCH >= 300
-    (void) smem;
-    (void) tid;
+    CV_UNUSED(smem);
+    CV_UNUSED(tid);
 
     const uint laneId = Warp::laneId();
 

--- a/modules/dnn/include/opencv2/dnn/dnn.hpp
+++ b/modules/dnn/include/opencv2/dnn/dnn.hpp
@@ -337,7 +337,7 @@ CV__DNN_EXPERIMENTAL_NS_BEGIN
                                      std::vector<MatShape> &outputs,
                                      std::vector<MatShape> &internals) const;
         virtual int64 getFLOPS(const std::vector<MatShape> &inputs,
-                               const std::vector<MatShape> &outputs) const {(void)inputs; (void)outputs; return 0;}
+                               const std::vector<MatShape> &outputs) const {CV_UNUSED(inputs); CV_UNUSED(outputs); return 0;}
 
         CV_PROP String name; //!< Name of the layer instance, can be used for logging or other internal purposes.
         CV_PROP String type; //!< Type name which was used for creating layer by layer factory.

--- a/modules/dnn/misc/python/pyopencv_dnn.hpp
+++ b/modules/dnn/misc/python/pyopencv_dnn.hpp
@@ -7,7 +7,7 @@ typedef std::vector<std::vector<dnn::MatShape> > vector_vector_MatShape;
 template<>
 bool pyopencv_to(PyObject *o, dnn::DictValue &dv, const char *name)
 {
-    (void)name;
+    CV_UNUSED(name);
     if (!o || o == Py_None)
         return true; //Current state will be used
     else if (PyLong_Check(o))

--- a/modules/dnn/src/dnn.cpp
+++ b/modules/dnn/src/dnn.cpp
@@ -3191,7 +3191,7 @@ void Layer::finalize(const std::vector<Mat> &inputs, std::vector<Mat> &outputs)
 
 void Layer::finalize(const std::vector<Mat*> &input, std::vector<Mat> &output)
 {
-    (void)input;(void)output;
+    CV_UNUSED(input);CV_UNUSED(output);
 }
 
 void Layer::finalize(InputArrayOfArrays inputs_arr, OutputArrayOfArrays outputs_arr)

--- a/modules/dnn/src/init.cpp
+++ b/modules/dnn/src/init.cpp
@@ -76,7 +76,7 @@ void initializeLayerFactory()
 {
     CV_TRACE_FUNCTION();
 
-    static ProtobufShutdown protobufShutdown; (void)protobufShutdown;
+    static ProtobufShutdown protobufShutdown; CV_UNUSED(protobufShutdown);
 
     CV_DNN_REGISTER_LAYER_CLASS(Slice,          SliceLayer);
     CV_DNN_REGISTER_LAYER_CLASS(Split,          SplitLayer);

--- a/modules/dnn/src/layers/batch_norm_layer.cpp
+++ b/modules/dnn/src/layers/batch_norm_layer.cpp
@@ -367,7 +367,7 @@ public:
     virtual int64 getFLOPS(const std::vector<MatShape> &inputs,
                            const std::vector<MatShape> &outputs) const CV_OVERRIDE
     {
-        (void)outputs; // suppress unused variable warning
+        CV_UNUSED(outputs); // suppress unused variable warning
 
         int64 flops = 0;
         for(int i = 0; i < inputs.size(); i++)

--- a/modules/dnn/src/layers/eltwise_layer.cpp
+++ b/modules/dnn/src/layers/eltwise_layer.cpp
@@ -444,7 +444,7 @@ public:
     virtual int64 getFLOPS(const std::vector<MatShape> &inputs,
                            const std::vector<MatShape> &outputs) const CV_OVERRIDE
     {
-        (void)outputs; // suppress unused variable warning
+        CV_UNUSED(outputs); // suppress unused variable warning
         CV_Assert(inputs.size());
 
         long flops = inputs.size() * total(inputs[0]);

--- a/modules/dnn/src/layers/fully_connected_layer.cpp
+++ b/modules/dnn/src/layers/fully_connected_layer.cpp
@@ -461,7 +461,7 @@ public:
     virtual int64 getFLOPS(const std::vector<MatShape> &inputs,
                            const std::vector<MatShape> &outputs) const CV_OVERRIDE
     {
-        (void)inputs; // suppress unused variable warning
+        CV_UNUSED(inputs); // suppress unused variable warning
         long flops = 0;
 
         int innerSize = blobs[0].size[1];

--- a/modules/dnn/src/layers/lrn_layer.cpp
+++ b/modules/dnn/src/layers/lrn_layer.cpp
@@ -402,7 +402,7 @@ public:
     virtual int64 getFLOPS(const std::vector<MatShape> &inputs,
                            const std::vector<MatShape> &outputs) const CV_OVERRIDE
     {
-        (void)outputs; // suppress unused variable warning
+        CV_UNUSED(outputs); // suppress unused variable warning
         CV_Assert(inputs.size() > 0);
         long flops = 0;
 

--- a/modules/dnn/src/layers/mvn_layer.cpp
+++ b/modules/dnn/src/layers/mvn_layer.cpp
@@ -364,7 +364,7 @@ public:
     virtual int64 getFLOPS(const std::vector<MatShape> &inputs,
                            const std::vector<MatShape> &outputs) const CV_OVERRIDE
     {
-        (void)outputs; // suppress unused variable warning
+        CV_UNUSED(outputs); // suppress unused variable warning
         long flops = 0;
         for(int i = 0; i < inputs.size(); i++)
         {

--- a/modules/dnn/src/layers/pooling_layer.cpp
+++ b/modules/dnn/src/layers/pooling_layer.cpp
@@ -897,7 +897,7 @@ public:
     virtual int64 getFLOPS(const std::vector<MatShape> &inputs,
                            const std::vector<MatShape> &outputs) const CV_OVERRIDE
     {
-        (void)inputs; // suppress unused variable warning
+        CV_UNUSED(inputs); // suppress unused variable warning
         long flops = 0;
 
         for(int i = 0; i < outputs.size(); i++)

--- a/modules/dnn/src/layers/prior_box_layer.cpp
+++ b/modules/dnn/src/layers/prior_box_layer.cpp
@@ -546,7 +546,7 @@ public:
     virtual int64 getFLOPS(const std::vector<MatShape> &inputs,
                            const std::vector<MatShape> &outputs) const CV_OVERRIDE
     {
-        (void)outputs; // suppress unused variable warning
+        CV_UNUSED(outputs); // suppress unused variable warning
         long flops = 0;
 
         for (int i = 0; i < inputs.size(); i++)

--- a/modules/dnn/src/layers/region_layer.cpp
+++ b/modules/dnn/src/layers/region_layer.cpp
@@ -315,7 +315,7 @@ public:
     virtual int64 getFLOPS(const std::vector<MatShape> &inputs,
                            const std::vector<MatShape> &outputs) const CV_OVERRIDE
     {
-        (void)outputs; // suppress unused variable warning
+        CV_UNUSED(outputs); // suppress unused variable warning
 
         int64 flops = 0;
         for(int i = 0; i < inputs.size(); i++)

--- a/modules/dnn/src/layers/reorg_layer.cpp
+++ b/modules/dnn/src/layers/reorg_layer.cpp
@@ -193,7 +193,7 @@ public:
     virtual int64 getFLOPS(const std::vector<MatShape> &inputs,
                            const std::vector<MatShape> &outputs) const CV_OVERRIDE
     {
-        (void)outputs; // suppress unused variable warning
+        CV_UNUSED(outputs); // suppress unused variable warning
 
         int64 flops = 0;
         for(int i = 0; i < inputs.size(); i++)

--- a/modules/dnn/src/layers/scale_layer.cpp
+++ b/modules/dnn/src/layers/scale_layer.cpp
@@ -236,7 +236,7 @@ public:
     virtual int64 getFLOPS(const std::vector<MatShape> &inputs,
                            const std::vector<MatShape> &outputs) const CV_OVERRIDE
     {
-        (void)outputs; // suppress unused variable warning
+        CV_UNUSED(outputs); // suppress unused variable warning
         long flops = 0;
         for(int i = 0; i < inputs.size(); i++)
         {

--- a/modules/dnn/src/layers/softmax_layer.cpp
+++ b/modules/dnn/src/layers/softmax_layer.cpp
@@ -329,7 +329,7 @@ public:
     int64 getFLOPS(const std::vector<MatShape> &inputs,
                   const std::vector<MatShape> &outputs) const CV_OVERRIDE
     {
-        (void)outputs; // suppress unused variable warning
+        CV_UNUSED(outputs); // suppress unused variable warning
         int64 flops = 0;
 
         for (int i = 0; i < inputs.size(); i++)

--- a/modules/features2d/src/blobdetector.cpp
+++ b/modules/features2d/src/blobdetector.cpp
@@ -193,7 +193,7 @@ void SimpleBlobDetectorImpl::findBlobs(InputArray _image, InputArray _binaryImag
     CV_INSTRUMENT_REGION()
 
     Mat image = _image.getMat(), binaryImage = _binaryImage.getMat();
-    (void)image;
+    CV_UNUSED(image);
     centers.clear();
 
     std::vector < std::vector<Point> > contours;

--- a/modules/features2d/src/orb.cpp
+++ b/modules/features2d/src/orb.cpp
@@ -779,7 +779,7 @@ static void computeKeyPoints(const Mat& imagePyramid,
                              bool useOCL, int fastThreshold  )
 {
 #ifndef HAVE_OPENCL
-    (void)uimagePyramid;(void)ulayerInfo;(void)useOCL;
+    CV_UNUSED(uimagePyramid);CV_UNUSED(ulayerInfo);CV_UNUSED(useOCL);
 #endif
 
     int i, nkeypoints, level, nlevels = (int)layerInfo.size();

--- a/modules/flann/include/opencv2/flann/lsh_table.h
+++ b/modules/flann/include/opencv2/flann/lsh_table.h
@@ -159,7 +159,7 @@ public:
     LshTable(unsigned int feature_size, unsigned int key_size)
     {
         feature_size_ = feature_size;
-        (void)key_size;
+        CV_UNUSED(key_size);
         std::cerr << "LSH is not implemented for that type" << std::endl;
         assert(0);
     }

--- a/modules/flann/misc/python/pyopencv_flann.hpp
+++ b/modules/flann/misc/python/pyopencv_flann.hpp
@@ -17,7 +17,7 @@ PyObject* pyopencv_from(const cvflann_flann_distance_t& value)
 template<>
 bool pyopencv_to(PyObject *o, cv::flann::IndexParams& p, const char *name)
 {
-    (void)name;
+    CV_UNUSED(name);
     bool ok = true;
     PyObject* key = NULL;
     PyObject* item = NULL;

--- a/modules/highgui/src/window.cpp
+++ b/modules/highgui/src/window.cpp
@@ -409,8 +409,8 @@ void cv::imshow(const String& winname, const ogl::Texture2D& _tex)
 {
     CV_TRACE_FUNCTION();
 #ifndef HAVE_OPENGL
-    (void) winname;
-    (void) _tex;
+    CV_UNUSED(winname);
+    CV_UNUSED(_tex);
     CV_Error(cv::Error::OpenGlNotSupported, "The library is compiled without OpenGL support");
 #else
     const double useGl = getWindowProperty(winname, WND_PROP_OPENGL);
@@ -728,7 +728,7 @@ CV_IMPL void cvDisplayOverlay(const char* , const char* , int )
 
 CV_IMPL int cvStartLoop(int (*)(int argc, char *argv[]), int , char* argv[])
 {
-    (void)argv;
+    CV_UNUSED(argv);
     CV_NO_GUI_ERROR("cvStartLoop");
 }
 

--- a/modules/highgui/src/window_w32.cpp
+++ b/modules/highgui/src/window_w32.cpp
@@ -624,7 +624,7 @@ double cvGetOpenGlProp_W32(const char* name)
 
     __END__;
 #endif
-    (void)name;
+    CV_UNUSED(name);
 
     return result;
 }

--- a/modules/imgproc/src/connectedcomponents.cpp
+++ b/modules/imgproc/src/connectedcomponents.cpp
@@ -65,9 +65,9 @@ namespace cv{
 
         inline
         void operator()(int r, int c, int l){
-            (void)r;
-            (void)c;
-            (void)l;
+            CV_UNUSED(r);
+            CV_UNUSED(c);
+            CV_UNUSED(l);
         }
 
         void finish(){

--- a/modules/imgproc/src/resize.cpp
+++ b/modules/imgproc/src/resize.cpp
@@ -3451,7 +3451,7 @@ static bool ocl_resize( InputArray _src, OutputArray _dst, Size dsize,
     // in case of scale_x && scale_y is equal to 2
     // INTER_AREA (fast) also is equal to INTER_LINEAR
     if( interpolation == INTER_LINEAR && is_area_fast && iscale_x == 2 && iscale_y == 2 )
-        /*interpolation = INTER_AREA*/(void)0; // INTER_AREA is slower
+        /*interpolation = INTER_AREA*/CV_UNUSED(0); // INTER_AREA is slower
 
     if( !(cn <= 4 &&
            (interpolation == INTER_NEAREST || interpolation == INTER_LINEAR ||

--- a/modules/imgproc/src/smooth.cpp
+++ b/modules/imgproc/src/smooth.cpp
@@ -4102,7 +4102,7 @@ void cv::GaussianBlur( InputArray _src, OutputArray _dst, Size ksize,
                ((ksize.width == 3 && ksize.height == 3) ||
                (ksize.width == 5 && ksize.height == 5)) &&
                _src.rows() > ksize.height && _src.cols() > ksize.width);
-    (void)useOpenCL;
+    CV_UNUSED(useOpenCL);
 
     int sdepth = CV_MAT_DEPTH(type), cn = CV_MAT_CN(type);
 

--- a/modules/java/generator/src/cpp/Mat.cpp
+++ b/modules/java/generator/src/cpp/Mat.cpp
@@ -29,7 +29,7 @@ static void throwJavaException(JNIEnv *env, const std::exception *e, const char 
   env->ThrowNew(je, what.c_str());
 
   LOGE("%s caught %s", method, what.c_str());
-  (void)method;        // avoid "unused" warning
+  CV_UNUSED(method);        // avoid "unused" warning
 }
 
 extern "C" {

--- a/modules/ml/misc/python/pyopencv_ml.hpp
+++ b/modules/ml/misc/python/pyopencv_ml.hpp
@@ -1,7 +1,7 @@
 template<>
 bool pyopencv_to(PyObject *obj, CvTermCriteria& dst, const char *name)
 {
-    (void)name;
+    CV_UNUSED(name);
     if(!obj)
         return true;
     return PyArg_ParseTuple(obj, "iid", &dst.type, &dst.max_iter, &dst.epsilon) > 0;
@@ -10,7 +10,7 @@ bool pyopencv_to(PyObject *obj, CvTermCriteria& dst, const char *name)
 template<>
 bool pyopencv_to(PyObject* obj, CvSlice& r, const char* name)
 {
-    (void)name;
+    CV_UNUSED(name);
     if(!obj || obj == Py_None)
         return true;
     if(PyObject_Size(obj) == 0)

--- a/modules/ml/src/knearest.cpp
+++ b/modules/ml/src/knearest.cpp
@@ -98,7 +98,7 @@ public:
         return true;
     }
 
-    virtual void doTrain(InputArray points) { (void)points; }
+    virtual void doTrain(InputArray points) { CV_UNUSED(points); }
 
     void clear()
     {

--- a/modules/python/src2/cv2.cpp
+++ b/modules/python/src2/cv2.cpp
@@ -797,7 +797,7 @@ PyObject* pyopencv_from(const bool& value)
 template<>
 bool pyopencv_to(PyObject* obj, bool& value, const char* name)
 {
-    (void)name;
+    CV_UNUSED(name);
     if(!obj || obj == Py_None)
         return true;
     int _val = PyObject_IsTrue(obj);
@@ -816,7 +816,7 @@ PyObject* pyopencv_from(const size_t& value)
 template<>
 bool pyopencv_to(PyObject* obj, size_t& value, const char* name)
 {
-    (void)name;
+    CV_UNUSED(name);
     if(!obj || obj == Py_None)
         return true;
     value = (int)PyLong_AsUnsignedLong(obj);
@@ -832,7 +832,7 @@ PyObject* pyopencv_from(const int& value)
 template<>
 bool pyopencv_to(PyObject* obj, int& value, const char* name)
 {
-    (void)name;
+    CV_UNUSED(name);
     if(!obj || obj == Py_None)
         return true;
     if(PyInt_Check(obj))
@@ -853,7 +853,7 @@ PyObject* pyopencv_from(const uchar& value)
 template<>
 bool pyopencv_to(PyObject* obj, uchar& value, const char* name)
 {
-    (void)name;
+    CV_UNUSED(name);
     if(!obj || obj == Py_None)
         return true;
     int ivalue = (int)PyInt_AsLong(obj);
@@ -870,7 +870,7 @@ PyObject* pyopencv_from(const double& value)
 template<>
 bool pyopencv_to(PyObject* obj, double& value, const char* name)
 {
-    (void)name;
+    CV_UNUSED(name);
     if(!obj || obj == Py_None)
         return true;
     if(!!PyInt_CheckExact(obj))
@@ -889,7 +889,7 @@ PyObject* pyopencv_from(const float& value)
 template<>
 bool pyopencv_to(PyObject* obj, float& value, const char* name)
 {
-    (void)name;
+    CV_UNUSED(name);
     if(!obj || obj == Py_None)
         return true;
     if(!!PyInt_CheckExact(obj))
@@ -914,7 +914,7 @@ PyObject* pyopencv_from(const String& value)
 template<>
 bool pyopencv_to(PyObject* obj, String& value, const char* name)
 {
-    (void)name;
+    CV_UNUSED(name);
     if(!obj || obj == Py_None)
         return true;
     const char* str = PyString_AsString(obj);
@@ -927,7 +927,7 @@ bool pyopencv_to(PyObject* obj, String& value, const char* name)
 template<>
 bool pyopencv_to(PyObject* obj, Size& sz, const char* name)
 {
-    (void)name;
+    CV_UNUSED(name);
     if(!obj || obj == Py_None)
         return true;
     return PyArg_ParseTuple(obj, "ii", &sz.width, &sz.height) > 0;
@@ -942,7 +942,7 @@ PyObject* pyopencv_from(const Size& sz)
 template<>
 bool pyopencv_to(PyObject* obj, Size_<float>& sz, const char* name)
 {
-    (void)name;
+    CV_UNUSED(name);
     if(!obj || obj == Py_None)
         return true;
     return PyArg_ParseTuple(obj, "ff", &sz.width, &sz.height) > 0;
@@ -957,7 +957,7 @@ PyObject* pyopencv_from(const Size_<float>& sz)
 template<>
 bool pyopencv_to(PyObject* obj, Rect& r, const char* name)
 {
-    (void)name;
+    CV_UNUSED(name);
     if(!obj || obj == Py_None)
         return true;
     return PyArg_ParseTuple(obj, "iiii", &r.x, &r.y, &r.width, &r.height) > 0;
@@ -972,7 +972,7 @@ PyObject* pyopencv_from(const Rect& r)
 template<>
 bool pyopencv_to(PyObject* obj, Rect2d& r, const char* name)
 {
-    (void)name;
+    CV_UNUSED(name);
     if(!obj || obj == Py_None)
         return true;
     return PyArg_ParseTuple(obj, "dddd", &r.x, &r.y, &r.width, &r.height) > 0;
@@ -987,7 +987,7 @@ PyObject* pyopencv_from(const Rect2d& r)
 template<>
 bool pyopencv_to(PyObject* obj, Range& r, const char* name)
 {
-    (void)name;
+    CV_UNUSED(name);
     if(!obj || obj == Py_None)
         return true;
     if(PyObject_Size(obj) == 0)
@@ -1007,7 +1007,7 @@ PyObject* pyopencv_from(const Range& r)
 template<>
 bool pyopencv_to(PyObject* obj, Point& p, const char* name)
 {
-    (void)name;
+    CV_UNUSED(name);
     if(!obj || obj == Py_None)
         return true;
     if(!!PyComplex_CheckExact(obj))
@@ -1023,7 +1023,7 @@ bool pyopencv_to(PyObject* obj, Point& p, const char* name)
 template<>
 bool pyopencv_to(PyObject* obj, Point2f& p, const char* name)
 {
-    (void)name;
+    CV_UNUSED(name);
     if(!obj || obj == Py_None)
         return true;
     if(!!PyComplex_CheckExact(obj))
@@ -1039,7 +1039,7 @@ bool pyopencv_to(PyObject* obj, Point2f& p, const char* name)
 template<>
 bool pyopencv_to(PyObject* obj, Point2d& p, const char* name)
 {
-    (void)name;
+    CV_UNUSED(name);
     if(!obj || obj == Py_None)
         return true;
     if(!!PyComplex_CheckExact(obj))
@@ -1055,7 +1055,7 @@ bool pyopencv_to(PyObject* obj, Point2d& p, const char* name)
 template<>
 bool pyopencv_to(PyObject* obj, Point3f& p, const char* name)
 {
-    (void)name;
+    CV_UNUSED(name);
     if(!obj || obj == Py_None)
         return true;
     return PyArg_ParseTuple(obj, "fff", &p.x, &p.y, &p.z) > 0;
@@ -1064,7 +1064,7 @@ bool pyopencv_to(PyObject* obj, Point3f& p, const char* name)
 template<>
 bool pyopencv_to(PyObject* obj, Point3d& p, const char* name)
 {
-    (void)name;
+    CV_UNUSED(name);
     if(!obj || obj == Py_None)
         return true;
     return PyArg_ParseTuple(obj, "ddd", &p.x, &p.y, &p.z) > 0;
@@ -1090,7 +1090,7 @@ PyObject* pyopencv_from(const Point3f& p)
 
 static bool pyopencv_to(PyObject* obj, Vec4d& v, ArgInfo info)
 {
-    (void)info;
+    CV_UNUSED(info);
     if (!obj)
         return true;
     return PyArg_ParseTuple(obj, "dddd", &v[0], &v[1], &v[2], &v[3]) > 0;
@@ -1103,7 +1103,7 @@ bool pyopencv_to(PyObject* obj, Vec4d& v, const char* name)
 
 static bool pyopencv_to(PyObject* obj, Vec4f& v, ArgInfo info)
 {
-    (void)info;
+    CV_UNUSED(info);
     if (!obj)
         return true;
     return PyArg_ParseTuple(obj, "ffff", &v[0], &v[1], &v[2], &v[3]) > 0;
@@ -1116,7 +1116,7 @@ bool pyopencv_to(PyObject* obj, Vec4f& v, const char* name)
 
 static bool pyopencv_to(PyObject* obj, Vec4i& v, ArgInfo info)
 {
-    (void)info;
+    CV_UNUSED(info);
     if (!obj)
         return true;
     return PyArg_ParseTuple(obj, "iiii", &v[0], &v[1], &v[2], &v[3]) > 0;
@@ -1129,7 +1129,7 @@ bool pyopencv_to(PyObject* obj, Vec4i& v, const char* name)
 
 static bool pyopencv_to(PyObject* obj, Vec3d& v, ArgInfo info)
 {
-    (void)info;
+    CV_UNUSED(info);
     if (!obj)
         return true;
     return PyArg_ParseTuple(obj, "ddd", &v[0], &v[1], &v[2]) > 0;
@@ -1142,7 +1142,7 @@ bool pyopencv_to(PyObject* obj, Vec3d& v, const char* name)
 
 static bool pyopencv_to(PyObject* obj, Vec3f& v, ArgInfo info)
 {
-    (void)info;
+    CV_UNUSED(info);
     if (!obj)
         return true;
     return PyArg_ParseTuple(obj, "fff", &v[0], &v[1], &v[2]) > 0;
@@ -1155,7 +1155,7 @@ bool pyopencv_to(PyObject* obj, Vec3f& v, const char* name)
 
 static bool pyopencv_to(PyObject* obj, Vec3i& v, ArgInfo info)
 {
-    (void)info;
+    CV_UNUSED(info);
     if (!obj)
         return true;
     return PyArg_ParseTuple(obj, "iii", &v[0], &v[1], &v[2]) > 0;
@@ -1168,7 +1168,7 @@ bool pyopencv_to(PyObject* obj, Vec3i& v, const char* name)
 
 static bool pyopencv_to(PyObject* obj, Vec2d& v, ArgInfo info)
 {
-    (void)info;
+    CV_UNUSED(info);
     if (!obj)
         return true;
     return PyArg_ParseTuple(obj, "dd", &v[0], &v[1]) > 0;
@@ -1181,7 +1181,7 @@ bool pyopencv_to(PyObject* obj, Vec2d& v, const char* name)
 
 static bool pyopencv_to(PyObject* obj, Vec2f& v, ArgInfo info)
 {
-    (void)info;
+    CV_UNUSED(info);
     if (!obj)
         return true;
     return PyArg_ParseTuple(obj, "ff", &v[0], &v[1]) > 0;
@@ -1194,7 +1194,7 @@ bool pyopencv_to(PyObject* obj, Vec2f& v, const char* name)
 
 static bool pyopencv_to(PyObject* obj, Vec2i& v, ArgInfo info)
 {
-    (void)info;
+    CV_UNUSED(info);
     if (!obj)
         return true;
     return PyArg_ParseTuple(obj, "ii", &v[0], &v[1]) > 0;
@@ -1536,7 +1536,7 @@ template<> struct pyopencvVecConverter<RotatedRect>
 template<>
 bool pyopencv_to(PyObject *obj, TermCriteria& dst, const char *name)
 {
-    (void)name;
+    CV_UNUSED(name);
     if(!obj)
         return true;
     return PyArg_ParseTuple(obj, "iid", &dst.type, &dst.maxCount, &dst.epsilon) > 0;
@@ -1551,7 +1551,7 @@ PyObject* pyopencv_from(const TermCriteria& src)
 template<>
 bool pyopencv_to(PyObject *obj, RotatedRect& dst, const char *name)
 {
-    (void)name;
+    CV_UNUSED(name);
     if(!obj)
         return true;
     return PyArg_ParseTuple(obj, "(ff)(ff)f", &dst.center.x, &dst.center.y, &dst.size.width, &dst.size.height, &dst.angle) > 0;

--- a/modules/stitching/src/blenders.cpp
+++ b/modules/stitching/src/blenders.cpp
@@ -223,7 +223,7 @@ MultiBandBlender::MultiBandBlender(int try_gpu, int num_bands, int weight_type)
     can_use_gpu_ = try_gpu && cuda::getCudaEnabledDeviceCount();
     gpu_feed_idx_ = 0;
 #else
-    (void) try_gpu;
+    CV_UNUSED(try_gpu);
     can_use_gpu_ = false;
 #endif
 
@@ -868,9 +868,9 @@ void createLaplacePyrGpu(InputArray img, int num_levels, std::vector<UMat> &pyr)
 
     gpu_pyr[num_levels].download(pyr[num_levels]);
 #else
-    (void)img;
-    (void)num_levels;
-    (void)pyr;
+    CV_UNUSED(img);
+    CV_UNUSED(num_levels);
+    CV_UNUSED(pyr);
     CV_Error(Error::StsNotImplemented, "CUDA optimization is unavailable");
 #endif
 }
@@ -908,7 +908,7 @@ void restoreImageFromLaplacePyrGpu(std::vector<UMat> &pyr)
 
     gpu_pyr[0].download(pyr[0]);
 #else
-    (void)pyr;
+    CV_UNUSED(pyr);
     CV_Error(Error::StsNotImplemented, "CUDA optimization is unavailable");
 #endif
 }

--- a/modules/stitching/src/matchers.cpp
+++ b/modules/stitching/src/matchers.cpp
@@ -447,11 +447,11 @@ SurfFeaturesFinder::SurfFeaturesFinder(double hess_thresh, int num_octaves, int 
         extractor_ = sextractor_;
     }
 #else
-    (void)hess_thresh;
-    (void)num_octaves;
-    (void)num_layers;
-    (void)num_octaves_descr;
-    (void)num_layers_descr;
+    CV_UNUSED(hess_thresh);
+    CV_UNUSED(num_octaves);
+    CV_UNUSED(num_layers);
+    CV_UNUSED(num_octaves_descr);
+    CV_UNUSED(num_layers_descr);
     CV_Error( Error::StsNotImplemented, "OpenCV was built without SURF support" );
 #endif
 }
@@ -705,7 +705,7 @@ void FeaturesMatcher::operator ()(const std::vector<ImageFeatures> &features, st
 
 BestOf2NearestMatcher::BestOf2NearestMatcher(bool try_use_gpu, float match_conf, int num_matches_thresh1, int num_matches_thresh2)
 {
-    (void)try_use_gpu;
+    CV_UNUSED(try_use_gpu);
 
 #ifdef HAVE_OPENCV_CUDAFEATURES2D
     if (try_use_gpu && getCudaEnabledDeviceCount() > 0)

--- a/modules/stitching/src/warpers_cuda.cpp
+++ b/modules/stitching/src/warpers_cuda.cpp
@@ -69,7 +69,7 @@ namespace cv { namespace cuda { namespace device
 static void buildWarpPlaneMaps(Size src_size, Rect dst_roi, InputArray _K, InputArray _R, InputArray _T,
                                float scale, OutputArray _map_x, OutputArray _map_y, Stream& stream = Stream::Null())
 {
-    (void) src_size;
+    CV_UNUSED(src_size);
 
     Mat K = _K.getMat();
     Mat R = _R.getMat();
@@ -97,7 +97,7 @@ static void buildWarpPlaneMaps(Size src_size, Rect dst_roi, InputArray _K, Input
 static void buildWarpSphericalMaps(Size src_size, Rect dst_roi, InputArray _K, InputArray _R, float scale,
                                    OutputArray _map_x, OutputArray _map_y, Stream& stream = Stream::Null())
 {
-    (void) src_size;
+    CV_UNUSED(src_size);
 
     Mat K = _K.getMat();
     Mat R = _R.getMat();
@@ -122,7 +122,7 @@ static void buildWarpSphericalMaps(Size src_size, Rect dst_roi, InputArray _K, I
 static void buildWarpCylindricalMaps(Size src_size, Rect dst_roi, InputArray _K, InputArray _R, float scale,
                                      OutputArray _map_x, OutputArray _map_y, Stream& stream = Stream::Null())
 {
-    (void) src_size;
+    CV_UNUSED(src_size);
 
     Mat K = _K.getMat();
     Mat R = _R.getMat();
@@ -156,12 +156,12 @@ Rect cv::detail::PlaneWarperGpu::buildMaps(Size src_size, InputArray K, InputArr
                                            cuda::GpuMat & xmap, cuda::GpuMat & ymap)
 {
 #ifndef HAVE_CUDA
-    (void)src_size;
-    (void)K;
-    (void)R;
-    (void)T;
-    (void)xmap;
-    (void)ymap;
+    CV_UNUSED(src_size);
+    CV_UNUSED(K);
+    CV_UNUSED(R);
+    CV_UNUSED(T);
+    CV_UNUSED(xmap);
+    CV_UNUSED(ymap);
     throw_no_cuda();
 #else
     projector_.setCameraParams(K, R, T);
@@ -189,13 +189,13 @@ Point cv::detail::PlaneWarperGpu::warp(const cuda::GpuMat & src, InputArray K, I
                                        cuda::GpuMat & dst)
 {
 #ifndef HAVE_OPENCV_CUDAWARPING
-    (void)src;
-    (void)K;
-    (void)R;
-    (void)T;
-    (void)interp_mode;
-    (void)border_mode;
-    (void)dst;
+    CV_UNUSED(src);
+    CV_UNUSED(K);
+    CV_UNUSED(R);
+    CV_UNUSED(T);
+    CV_UNUSED(interp_mode);
+    CV_UNUSED(border_mode);
+    CV_UNUSED(dst);
     throw_no_cuda();
 #else
     Rect dst_roi = buildMaps(src.size(), K, R, T, d_xmap_, d_ymap_);
@@ -208,11 +208,11 @@ Point cv::detail::PlaneWarperGpu::warp(const cuda::GpuMat & src, InputArray K, I
 Rect cv::detail::SphericalWarperGpu::buildMaps(Size src_size, InputArray K, InputArray R, cuda::GpuMat & xmap, cuda::GpuMat & ymap)
 {
 #ifndef HAVE_CUDA
-    (void)src_size;
-    (void)K;
-    (void)R;
-    (void)xmap;
-    (void)ymap;
+    CV_UNUSED(src_size);
+    CV_UNUSED(K);
+    CV_UNUSED(R);
+    CV_UNUSED(xmap);
+    CV_UNUSED(ymap);
     throw_no_cuda();
 #else
     projector_.setCameraParams(K, R);
@@ -232,12 +232,12 @@ Point cv::detail::SphericalWarperGpu::warp(const cuda::GpuMat & src, InputArray 
                                            cuda::GpuMat & dst)
 {
 #ifndef HAVE_OPENCV_CUDAWARPING
-    (void)src;
-    (void)K;
-    (void)R;
-    (void)interp_mode;
-    (void)border_mode;
-    (void)dst;
+    CV_UNUSED(src);
+    CV_UNUSED(K);
+    CV_UNUSED(R);
+    CV_UNUSED(interp_mode);
+    CV_UNUSED(border_mode);
+    CV_UNUSED(dst);
     throw_no_cuda();
 #else
     Rect dst_roi = buildMaps(src.size(), K, R, d_xmap_, d_ymap_);
@@ -252,11 +252,11 @@ Rect cv::detail::CylindricalWarperGpu::buildMaps(Size src_size, InputArray K, In
                                                  cuda::GpuMat & xmap, cuda::GpuMat & ymap)
 {
 #ifndef HAVE_CUDA
-    (void)src_size;
-    (void)K;
-    (void)R;
-    (void)xmap;
-    (void)ymap;
+    CV_UNUSED(src_size);
+    CV_UNUSED(K);
+    CV_UNUSED(R);
+    CV_UNUSED(xmap);
+    CV_UNUSED(ymap);
     throw_no_cuda();
 #else
     projector_.setCameraParams(K, R);
@@ -276,12 +276,12 @@ Point cv::detail::CylindricalWarperGpu::warp(const cuda::GpuMat & src, InputArra
                                              cuda::GpuMat & dst)
 {
 #ifndef HAVE_OPENCV_CUDAWARPING
-    (void)src;
-    (void)K;
-    (void)R;
-    (void)interp_mode;
-    (void)border_mode;
-    (void)dst;
+    CV_UNUSED(src);
+    CV_UNUSED(K);
+    CV_UNUSED(R);
+    CV_UNUSED(interp_mode);
+    CV_UNUSED(border_mode);
+    CV_UNUSED(dst);
     throw_no_cuda();
 #else
     Rect dst_roi = buildMaps(src.size(), K, R, d_xmap_, d_ymap_);

--- a/modules/superres/src/frame_source.cpp
+++ b/modules/superres/src/frame_source.cpp
@@ -84,14 +84,14 @@ Ptr<FrameSource> cv::superres::createFrameSource_Empty()
 
 Ptr<FrameSource> cv::superres::createFrameSource_Video(const String& fileName)
 {
-    (void) fileName;
+    CV_UNUSED(fileName);
     CV_Error(cv::Error::StsNotImplemented, "The called functionality is disabled for current build or platform");
     return Ptr<FrameSource>();
 }
 
 Ptr<FrameSource> cv::superres::createFrameSource_Camera(int deviceId)
 {
-    (void) deviceId;
+    CV_UNUSED(deviceId);
     CV_Error(cv::Error::StsNotImplemented, "The called functionality is disabled for current build or platform");
     return Ptr<FrameSource>();
 }

--- a/modules/ts/src/ts_gtest.cpp
+++ b/modules/ts/src/ts_gtest.cpp
@@ -3913,7 +3913,7 @@ Result HandleSehExceptionsInMethodIfSupported(
     return static_cast<Result>(0);
   }
 #else
-  (void)location;
+  CV_UNUSED(location);
   return (object->*method)();
 #endif  // GTEST_HAS_SEH
 }

--- a/modules/videoio/include/opencv2/videoio/cap_ios.h
+++ b/modules/videoio/include/opencv2/videoio/cap_ios.h
@@ -64,22 +64,22 @@ CV_EXPORTS @interface CvAbstractCamera : NSObject
 
 @property (nonatomic, strong) UIView* parentView;
 
-- (void)start;
-- (void)stop;
-- (void)switchCameras;
+- CV_UNUSED(start);
+- CV_UNUSED(stop);
+- CV_UNUSED(switchCameras);
 
 - (id)initWithParentView:(UIView*)parent;
 
-- (void)createCaptureOutput;
-- (void)createVideoPreviewLayer;
-- (void)updateOrientation;
+- CV_UNUSED(createCaptureOutput);
+- CV_UNUSED(createVideoPreviewLayer);
+- CV_UNUSED(updateOrientation);
 
-- (void)lockFocus;
-- (void)unlockFocus;
-- (void)lockExposure;
-- (void)unlockExposure;
-- (void)lockBalance;
-- (void)unlockBalance;
+- CV_UNUSED(lockFocus);
+- CV_UNUSED(unlockFocus);
+- CV_UNUSED(lockExposure);
+- CV_UNUSED(unlockExposure);
+- CV_UNUSED(lockBalance);
+- CV_UNUSED(unlockBalance);
 
 @end
 
@@ -117,8 +117,8 @@ CV_EXPORTS @interface CvVideoCamera : CvAbstractCamera<AVCaptureVideoDataOutputS
 @property (nonatomic, strong) AVAssetWriter* recordAssetWriter;
 
 - (void)adjustLayoutToInterfaceOrientation:(UIInterfaceOrientation)interfaceOrientation;
-- (void)layoutPreviewLayer;
-- (void)saveVideo;
+- CV_UNUSED(layoutPreviewLayer);
+- CV_UNUSED(saveVideo);
 - (NSURL *)videoFileURL;
 - (NSString *)videoFileString;
 
@@ -143,7 +143,7 @@ CV_EXPORTS @interface CvPhotoCamera : CvAbstractCamera
 
 @property (nonatomic, weak) id<CvPhotoCameraDelegate> delegate;
 
-- (void)takePicture;
+- CV_UNUSED(takePicture);
 
 @end
 

--- a/modules/videoio/src/cap_ffmpeg_impl.hpp
+++ b/modules/videoio/src/cap_ffmpeg_impl.hpp
@@ -758,7 +758,7 @@ static void ffmpeg_log_callback(void *ptr, int level, const char *fmt, va_list v
 {
     static bool skip_header = false;
     static int prev_level = -1;
-    (void)ptr;
+    CV_UNUSED(ptr);
     if (!skip_header || level != prev_level) printf("[OPENCV:FFMPEG:%02d] ", level);
     vprintf(fmt, vargs);
     size_t fmt_len = strlen(fmt);


### PR DESCRIPTION
Preferably merge with opencv/opencv_contrib#1756

Minor change for coding style unification

### This pullrequest changes
- Utilized `CV_UNUSED(x);` instead of `(void)x;`
