### PR TITLE
Select the correct depth for bayer2rgb and bayer2rgba

### DIFF
--- a/modules/imgproc/src/demosaicing.cpp
+++ b/modules/imgproc/src/demosaicing.cpp
@@ -1686,8 +1686,11 @@ void cv::demosaicing(InputArray _src, OutputArray _dst, int code, int dcn)
             CV_Error(CV_StsUnsupportedFormat, "Bayer->Gray demosaicing only supports 8u and 16u types");
         break;
 
-    case CV_BayerBG2BGR: case CV_BayerGB2BGR: case CV_BayerRG2BGR: case CV_BayerGR2BGR:
     case CV_BayerBG2BGRA: case CV_BayerGB2BGRA: case CV_BayerRG2BGRA: case CV_BayerGR2BGRA:
+        if (dcn <= 0)
+          dcn = 4;
+        /* fallthrough */
+    case CV_BayerBG2BGR: case CV_BayerGB2BGR: case CV_BayerRG2BGR: case CV_BayerGR2BGR:
     case CV_BayerBG2BGR_VNG: case CV_BayerGB2BGR_VNG: case CV_BayerRG2BGR_VNG: case CV_BayerGR2BGR_VNG:
         {
             if (dcn <= 0)


### PR DESCRIPTION
### This pull request changes
`bayer_XX2rgba` was returning a [NxMx3] array. I guess it was falling back on `bayer_xx2rgb` (no `a`)

I added the appropriate lines to tell it the depth of each image.

Let me know if you need anything else.

```
docker_image:Custom=fedora:28
```