### PR TITLE
opencv_js: Support Python3 and MSVC

### DIFF
--- a/modules/js/CMakeLists.txt
+++ b/modules/js/CMakeLists.txt
@@ -66,9 +66,14 @@ link_libraries(${OPENCV_MODULE_${the_module}_DEPS})
 
 ocv_add_executable(${the_module} ${bindings_cpp})
 
-set_target_properties(${the_module} PROPERTIES COMPILE_FLAGS "-Wno-missing-prototypes")
-
-set_target_properties(${the_module} PROPERTIES LINK_FLAGS "--memory-init-file 0 -s TOTAL_MEMORY=134217728 -s ALLOW_MEMORY_GROWTH=1 -s MODULARIZE=1 -s EXPORT_NAME=\"'cv'\" -s DEMANGLE_SUPPORT=1 -s FORCE_FILESYSTEM=1 --use-preload-plugins --bind --post-js ${JS_HELPER} -Wno-missing-prototypes")
+set(COMPILE_FLAGS "")
+if(NOT CMAKE_CXX_COMPILER_ID MATCHES "MSVC")
+    set(COMPILE_FLAGS "${COMPILE_FLAGS} -Wno-missing-prototypes")
+endif()
+if(COMPILE_FLAGS)
+    set_target_properties(${the_module} PROPERTIES COMPILE_FLAGS ${COMPILE_FLAGS})
+endif()
+set_target_properties(${the_module} PROPERTIES LINK_FLAGS "--memory-init-file 0 -s TOTAL_MEMORY=134217728 -s ALLOW_MEMORY_GROWTH=1 -s MODULARIZE=1 -s EXPORT_NAME=\"'cv'\" -s DEMANGLE_SUPPORT=1 -s FORCE_FILESYSTEM=1 --use-preload-plugins --bind --post-js ${JS_HELPER} ${COMPILE_FLAGS}")
 
 # add UMD wrapper
 set(MODULE_JS_PATH "${OpenCV_BINARY_DIR}/bin/${the_module}.js")

--- a/modules/js/src/embindgen.py
+++ b/modules/js/src/embindgen.py
@@ -369,7 +369,7 @@ class JSWrapperGenerator(object):
         return namespace, classes, chunks[-1]
 
     def add_enum(self, decl):
-        name = decl[1]
+        name = decl[0].rsplit(" ", 1)[1]
         namespace, classes, val = self.split_decl_name(name)
         namespace = '.'.join(namespace)
         val = '_'.join(classes + [name])
@@ -383,6 +383,12 @@ class JSWrapperGenerator(object):
             ns.enums[name] = []
         for item in decl[3]:
             ns.enums[name].append(item)
+
+        const_decls = decl[3]
+
+        for decl in const_decls:
+            name = decl[0]
+            self.add_const(name.replace("const ", "").strip(), decl)
 
     def add_const(self, name, decl):
         cname = name.replace('.','::')

--- a/modules/js/src/embindgen.py
+++ b/modules/js/src/embindgen.py
@@ -70,7 +70,6 @@
 from __future__ import print_function
 import sys, re, os
 from templates import *
-from sets import Set
 
 if sys.version_info[0] >= 3:
     from io import StringIO
@@ -185,7 +184,7 @@ class ClassInfo(object):
         self.consts = {}
         customname = False
         self.jsfuncs = {}
-        self.constructor_arg_num = Set()
+        self.constructor_arg_num = set()
 
         self.has_smart_ptr = False
 
@@ -372,11 +371,20 @@ class JSWrapperGenerator(object):
         name = decl[0].rsplit(" ", 1)[1]
         namespace, classes, val = self.split_decl_name(name)
         namespace = '.'.join(namespace)
+        ns = self.namespaces.setdefault(namespace, Namespace())
+        if len(name) == 0: name = "<unnamed>"
+        if name.endswith("<unnamed>"):
+            i = 0
+            while True:
+                i += 1
+                candidate_name = name.replace("<unnamed>", "unnamed_%u" % i)
+                if candidate_name not in ns.enums:
+                    name = candidate_name
+                    break;
         val = '_'.join(classes + [name])
         cname = name.replace('.', '::')
-        ns = self.namespaces.setdefault(namespace, Namespace())
         if name in ns.enums:
-            print("Generator warning: constant %s (cname=%s) already exists" \
+            print("Generator warning: enum %s (cname=%s) already exists" \
                   % (name, cname))
             # sys.exit(-1)
         else:
@@ -809,7 +817,7 @@ class JSWrapperGenerator(object):
                 continue
 
             # Generate bindings for methods
-            for method_name, method in class_info.methods.iteritems():
+            for method_name, method in class_info.methods.items():
                 if method.cname in ignore_list:
                     continue
                 if not method.name in white_list[method.class_name]:
@@ -839,7 +847,7 @@ class JSWrapperGenerator(object):
                 class_bindings.append(smart_ptr_reg_template.substitute(cname=class_info.cname, name=class_info.name))
 
             # Attach external constructors
-            # for method_name, method in class_info.ext_constructors.iteritems():
+            # for method_name, method in class_info.ext_constructors.items():
                 # print("ext constructor", method_name)
             #if class_info.ext_constructors:
 


### PR DESCRIPTION
Although Emscripten currently utilized Python2 and Clang for Windows, there is no harm to maintain highly compatible code with all platforms

### This pullrequest changes
- Resolves #12436
- Cleanup some deprecated Python code
- Handle unnamed enums
- Support MSVC


```
allow_multiple_commits=1
force_builders=Custom
docker_image:Custom=javascript
docker_image:Docs=docs-js
```