### PR TITLE
CMAKE: Improve python detection

### DIFF
--- a/cmake/OpenCVDetectPython.cmake
+++ b/cmake/OpenCVDetectPython.cmake
@@ -254,10 +254,12 @@ find_python(3.4 "${MIN_VER_PYTHON3}" PYTHON3_LIBRARY PYTHON3_INCLUDE_DIR
 
 if(PYTHON_DEFAULT_EXECUTABLE)
     set(PYTHON_DEFAULT_AVAILABLE "TRUE")
-elseif(PYTHON2INTERP_FOUND) # Use Python 2 as default Python interpreter
+elseif(PYTHON2_EXECUTABLE AND PYTHON2INTERP_FOUND)
+    # Use Python 2 as default Python interpreter
     set(PYTHON_DEFAULT_AVAILABLE "TRUE")
     set(PYTHON_DEFAULT_EXECUTABLE "${PYTHON2_EXECUTABLE}")
-elseif(PYTHON3INTERP_FOUND) # Use Python 3 as fallback Python interpreter (if there is no Python 2)
+elseif(PYTHON3_EXECUTABLE AND PYTHON3INTERP_FOUND)
+    # Use Python 3 as fallback Python interpreter (if there is no Python 2)
     set(PYTHON_DEFAULT_AVAILABLE "TRUE")
     set(PYTHON_DEFAULT_EXECUTABLE "${PYTHON3_EXECUTABLE}")
 endif()


### PR DESCRIPTION
I am not sure if the issue I went through is reproducible, but this change makes things more straightforward.

Basically I was experimenting with Emscripten on Windows, which affected my environment varibles heavily, and as a result `PYTHON2INTERP_FOUND` became set, while `PYTHON2_EXECUTABLE` is empty, thus broke building all python-based modules!
Anyway, what matters to us is that `PYTHON*_EXECUTABLE` is set, not `PYTHON*INTERP_FOUND`

### This pullrequest changes
- Improve detection of Python executable by checking for `PYTHON*_EXECUTABLE` rather than for `PYTHON*INTERP_FOUND`