### PR TITLE
Fix include paths when building with external protobuf

### DIFF
--- a/cmake/OpenCVFindProtobuf.cmake
+++ b/cmake/OpenCVFindProtobuf.cmake
@@ -50,7 +50,8 @@ else()
       add_library(libprotobuf UNKNOWN IMPORTED)
       set_target_properties(libprotobuf PROPERTIES
         IMPORTED_LOCATION "${Protobuf_LIBRARY}"
-        INTERFACE_INCLUDE_SYSTEM_DIRECTORIES "${Protobuf_INCLUDE_DIR}"
+        INTERFACE_INCLUDE_DIRECTORIES "${Protobuf_INCLUDE_DIR}"
+        INTERFACE_SYSTEM_INCLUDE_DIRECTORIES "${Protobuf_INCLUDE_DIR}"
       )
       get_protobuf_version(Protobuf_VERSION "${Protobuf_INCLUDE_DIR}")
     endif()


### PR DESCRIPTION
Typo I believe. No such property as `INTERFACE_INCLUDE_SYSTEM_DIRECTORIES` in cmake
