### PR TITLE
Check for clang before using -isystem

### DIFF
--- a/cmake/OpenCVUtils.cmake
+++ b/cmake/OpenCVUtils.cmake
@@ -259,7 +259,7 @@ function(ocv_include_directories)
     ocv_is_opencv_directory(__is_opencv_dir "${dir}")
     if(__is_opencv_dir)
       list(APPEND __add_before "${dir}")
-    elseif(CV_GCC AND NOT CMAKE_CXX_COMPILER_VERSION VERSION_LESS "6.0" AND
+    elseif(((CV_GCC AND NOT CMAKE_CXX_COMPILER_VERSION VERSION_LESS "6.0") OR CV_CLANG) AND
            dir MATCHES "/usr/include$")
       # workaround for GCC 6.x bug
     else()


### PR DESCRIPTION
When cross compiling with clang, the internal C++ headers are not found
when adding sysroot to -isystem, that is redundant anyway because it
will look for headers insider --sysroot path with same quality as it
would do with -isystem otherwise

Signed-off-by: Khem Raj <raj.khem@gmail.com>

<!-- Please use this line to close one or multiple issues when this pullrequest gets merged
You can add another line right under the first one:
resolves #1234
resolves #1235
-->

### This pullrequest changes

```
FAILED: 3rdparty/openexr/CMakeFiles/IlmImf.dir/Iex/IexBaseExc.cpp.o
....
In file included from
TOPDIR/build/tmp/work/cortexa7t2hf-neon-vfpv4-bec-linux-musleabi/opencv/3.4.3+gitAUTOINC+b38c50b3d0_1f6d6f0626_bdb7bb85f3_34e4206aef_fccf7cd6a4-r0/git/3rdparty/openexr/Iex/IexBaseExc.cpp:43:
In file included from
TOPDIR/build/tmp/work/cortexa7t2hf-neon-vfpv4-bec-linux-musleabi/opencv/3.4.3+gitAUTOINC+b38c50b3d0_1f6d6f0626_bdb7bb85f3_34e4206aef_fccf7cd6a4-r0/git/3rdparty/openexr/Iex/IexBaseExc.h:48:
In file included from
TOPDIR/build/tmp/work/cortexa7t2hf-neon-vfpv4-bec-linux-musleabi/opencv/3.4.3+gitAUTOINC+b38c50b3d0_1f6d6f0626_bdb7bb85f3_34e4206aef_fccf7cd6a4-r0/recipe-sysroot/usr/lib//arm-bec-linux-musleabi/8.2.0/../../../include/c++/8.2.0/string:52:
In file included from
TOPDIR/build/tmp/work/cortexa7t2hf-neon-vfpv4-bec-linux-musleabi/opencv/3.4.3+gitAUTOINC+b38c50b3d0_1f6d6f0626_bdb7bb85f3_34e4206aef_fccf7cd6a4-r0/recipe-sysroot/usr/lib//arm-bec-linux-musleabi/8.2.0/../../../include/c++/8.2.0/bits/basic_string.h:6391:
In file included from
TOPDIR/build/tmp/work/cortexa7t2hf-neon-vfpv4-bec-linux-musleabi/opencv/3.4.3+gitAUTOINC+b38c50b3d0_1f6d6f0626_bdb7bb85f3_34e4206aef_fccf7cd6a4-r0/recipe-sysroot/usr/lib//arm-bec-linux-musleabi/8.2.0/../../../include/c++/8.2.0/ext/string_conversions.h:41:
TOPDIR/build/tmp/work/cortexa7t2hf-neon-vfpv4-bec-linux-musleabi/opencv/3.4.3+gitAUTOINC+b38c50b3d0_1f6d6f0626_bdb7bb85f3_34e4206aef_fccf7cd6a4-r0/recipe-sysroot/usr/lib//arm-bec-linux-musleabi/8.2.0/../../../include/c++/8.2.0/cstdlib:75:15:
fatal error: 'stdlib.h' file not found
              ^~~~~~~~~~
1 error generated.
```