### PR TITLE
MSVC: Slience external/meaningless warnings

### DIFF
--- a/modules/calib3d/src/dls.cpp
+++ b/modules/calib3d/src/dls.cpp
@@ -7,8 +7,17 @@
 #  if defined __GNUC__ && defined __APPLE__
 #    pragma GCC diagnostic ignored "-Wshadow"
 #  endif
+#  if defined(_MSC_VER)
+#    pragma warning(push)
+#    pragma warning(disable:4701)  // potentially uninitialized local variable
+#    pragma warning(disable:4702)  // unreachable code
+#    pragma warning(disable:4714)  // const marked as __forceinline not inlined
+#  endif
 #  include <Eigen/Core>
 #  include <Eigen/Eigenvalues>
+#  if defined(_MSC_VER)
+#    pragma warning(pop)
+#  endif
 #  include "opencv2/core/eigen.hpp"
 #endif
 

--- a/modules/core/include/opencv2/core/private.hpp
+++ b/modules/core/include/opencv2/core/private.hpp
@@ -57,7 +57,16 @@
 #  if defined __GNUC__ && defined __APPLE__
 #    pragma GCC diagnostic ignored "-Wshadow"
 #  endif
+#  if defined(_MSC_VER)
+#    pragma warning(push)
+#    pragma warning(disable:4701)  // potentially uninitialized local variable
+#    pragma warning(disable:4702)  // unreachable code
+#    pragma warning(disable:4714)  // const marked as __forceinline not inlined
+#  endif
 #  include <Eigen/Core>
+#  if defined(_MSC_VER)
+#    pragma warning(pop)
+#  endif
 #  include "opencv2/core/eigen.hpp"
 #endif
 

--- a/modules/core/src/cuda_stream.cpp
+++ b/modules/core/src/cuda_stream.cpp
@@ -45,6 +45,10 @@
 using namespace cv;
 using namespace cv::cuda;
 
+#if defined(_MSC_VER)
+#pragma warning(disable : 4702)  // unreachable code
+#endif
+
 /////////////////////////////////////////////////////////////
 /// MemoryStack
 

--- a/modules/core/src/lapack.cpp
+++ b/modules/core/src/lapack.cpp
@@ -44,9 +44,18 @@
 #include <limits>
 
 #ifdef HAVE_EIGEN
-#include <Eigen/Core>
-#include <Eigen/Eigenvalues>
-#include "opencv2/core/eigen.hpp"
+#  if defined(_MSC_VER)
+#    pragma warning(push)
+#    pragma warning(disable:4701)  // potentially uninitialized local variable
+#    pragma warning(disable:4702)  // unreachable code
+#    pragma warning(disable:4714)  // const marked as __forceinline not inlined
+#  endif
+#  include <Eigen/Core>
+#  include <Eigen/Eigenvalues>
+#  if defined(_MSC_VER)
+#    pragma warning(pop)
+#  endif
+#  include "opencv2/core/eigen.hpp"
 #endif
 
 #if defined _M_IX86 && defined _MSC_VER && _MSC_VER < 1700

--- a/modules/core/src/opengl.cpp
+++ b/modules/core/src/opengl.cpp
@@ -54,6 +54,10 @@
 using namespace cv;
 using namespace cv::cuda;
 
+#if defined(_MSC_VER)
+#pragma warning(disable : 4702)  // unreachable code
+#endif
+
 namespace
 {
 #ifndef HAVE_OPENGL

--- a/modules/features2d/src/matchers.cpp
+++ b/modules/features2d/src/matchers.cpp
@@ -44,7 +44,16 @@
 #include "opencl_kernels_features2d.hpp"
 
 #if defined(HAVE_EIGEN) && EIGEN_WORLD_VERSION == 2
-#include <Eigen/Array>
+#  if defined(_MSC_VER)
+#    pragma warning(push)
+#    pragma warning(disable:4701)  // potentially uninitialized local variable
+#    pragma warning(disable:4702)  // unreachable code
+#    pragma warning(disable:4714)  // const marked as __forceinline not inlined
+#  endif
+#  include <Eigen/Array>
+#  if defined(_MSC_VER)
+#    pragma warning(pop)
+#  endif
 #endif
 
 namespace cv

--- a/modules/python/src2/cv2.cpp
+++ b/modules/python/src2/cv2.cpp
@@ -1,4 +1,5 @@
-#if defined(_MSC_VER) && (_MSC_VER >= 1800)
+//warning number '5033' not a valid compiler warning in vc12
+#if defined(_MSC_VER) && (_MSC_VER > 1800)
 // eliminating duplicated round() declaration
 #define HAVE_ROUND 1
 #pragma warning(push)
@@ -6,7 +7,7 @@
 #endif
 #include <math.h>
 #include <Python.h>
-#if defined(_MSC_VER) && (_MSC_VER >= 1800)
+#if defined(_MSC_VER) && (_MSC_VER > 1800)
 #pragma warning(pop)
 #endif
 


### PR DESCRIPTION
### This pullrequest changes
- Suppress some meaningless warnings that originate from external libraries
- Fix a warning specific for MSVC2013, in which warning code 5033 does not exists yet
