### PR TITLE
Rename tensorflow namespace

### DIFF
--- a/modules/dnn/misc/tensorflow/attr_value.pb.cc
+++ b/modules/dnn/misc/tensorflow/attr_value.pb.cc
@@ -19,7 +19,7 @@
 #include "third_party/protobuf/version.h"
 #endif
 // @@protoc_insertion_point(includes)
-namespace tensorflow {
+namespace opencv_tensorflow {
 class AttrValue_ListValueDefaultTypeInternal {
  public:
   ::google::protobuf::internal::ExplicitlyConstructed<AttrValue_ListValue>
@@ -34,10 +34,10 @@ class AttrValueDefaultTypeInternal {
   float f_;
   bool b_;
   int type_;
-  const ::tensorflow::TensorShapeProto* shape_;
-  const ::tensorflow::TensorProto* tensor_;
-  const ::tensorflow::AttrValue_ListValue* list_;
-  const ::tensorflow::NameAttrList* func_;
+  const ::opencv_tensorflow::TensorShapeProto* shape_;
+  const ::opencv_tensorflow::TensorProto* tensor_;
+  const ::opencv_tensorflow::AttrValue_ListValue* list_;
+  const ::opencv_tensorflow::NameAttrList* func_;
   ::google::protobuf::internal::ArenaStringPtr placeholder_;
 } _AttrValue_default_instance_;
 class NameAttrList_AttrEntry_DoNotUseDefaultTypeInternal {
@@ -50,7 +50,7 @@ class NameAttrListDefaultTypeInternal {
   ::google::protobuf::internal::ExplicitlyConstructed<NameAttrList>
       _instance;
 } _NameAttrList_default_instance_;
-}  // namespace tensorflow
+}  // namespace opencv_tensorflow
 namespace protobuf_attr_5fvalue_2eproto {
 void InitDefaultsAttrValue_ListValueImpl() {
   GOOGLE_PROTOBUF_VERIFY_VERSION;
@@ -63,11 +63,11 @@ void InitDefaultsAttrValue_ListValueImpl() {
   protobuf_tensor_5fshape_2eproto::InitDefaultsTensorShapeProto();
   protobuf_tensor_2eproto::InitDefaultsTensorProto();
   {
-    void* ptr = &::tensorflow::_AttrValue_ListValue_default_instance_;
-    new (ptr) ::tensorflow::AttrValue_ListValue();
+    void* ptr = &::opencv_tensorflow::_AttrValue_ListValue_default_instance_;
+    new (ptr) ::opencv_tensorflow::AttrValue_ListValue();
     ::google::protobuf::internal::OnShutdownDestroyMessage(ptr);
   }
-  ::tensorflow::AttrValue_ListValue::InitAsDefaultInstance();
+  ::opencv_tensorflow::AttrValue_ListValue::InitAsDefaultInstance();
 }
 
 void InitDefaultsAttrValue_ListValue() {
@@ -87,22 +87,22 @@ void InitDefaultsAttrValueImpl() {
   protobuf_tensor_2eproto::InitDefaultsTensorProto();
   protobuf_attr_5fvalue_2eproto::InitDefaultsAttrValue_ListValue();
   {
-    void* ptr = &::tensorflow::_AttrValue_default_instance_;
-    new (ptr) ::tensorflow::AttrValue();
+    void* ptr = &::opencv_tensorflow::_AttrValue_default_instance_;
+    new (ptr) ::opencv_tensorflow::AttrValue();
     ::google::protobuf::internal::OnShutdownDestroyMessage(ptr);
   }
   {
-    void* ptr = &::tensorflow::_NameAttrList_AttrEntry_DoNotUse_default_instance_;
-    new (ptr) ::tensorflow::NameAttrList_AttrEntry_DoNotUse();
+    void* ptr = &::opencv_tensorflow::_NameAttrList_AttrEntry_DoNotUse_default_instance_;
+    new (ptr) ::opencv_tensorflow::NameAttrList_AttrEntry_DoNotUse();
   }
   {
-    void* ptr = &::tensorflow::_NameAttrList_default_instance_;
-    new (ptr) ::tensorflow::NameAttrList();
+    void* ptr = &::opencv_tensorflow::_NameAttrList_default_instance_;
+    new (ptr) ::opencv_tensorflow::NameAttrList();
     ::google::protobuf::internal::OnShutdownDestroyMessage(ptr);
   }
-  ::tensorflow::AttrValue::InitAsDefaultInstance();
-  ::tensorflow::NameAttrList_AttrEntry_DoNotUse::InitAsDefaultInstance();
-  ::tensorflow::NameAttrList::InitAsDefaultInstance();
+  ::opencv_tensorflow::AttrValue::InitAsDefaultInstance();
+  ::opencv_tensorflow::NameAttrList_AttrEntry_DoNotUse::InitAsDefaultInstance();
+  ::opencv_tensorflow::NameAttrList::InitAsDefaultInstance();
 }
 
 void InitDefaultsAttrValue() {
@@ -114,62 +114,62 @@ void InitDefaultsAttrValue() {
 
 const ::google::protobuf::uint32 TableStruct::offsets[] GOOGLE_PROTOBUF_ATTRIBUTE_SECTION_VARIABLE(protodesc_cold) = {
   ~0u,  // no _has_bits_
-  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::tensorflow::AttrValue_ListValue, _internal_metadata_),
+  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::opencv_tensorflow::AttrValue_ListValue, _internal_metadata_),
   ~0u,  // no _extensions_
   ~0u,  // no _oneof_case_
   ~0u,  // no _weak_field_map_
-  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::tensorflow::AttrValue_ListValue, s_),
-  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::tensorflow::AttrValue_ListValue, i_),
-  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::tensorflow::AttrValue_ListValue, f_),
-  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::tensorflow::AttrValue_ListValue, b_),
-  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::tensorflow::AttrValue_ListValue, type_),
-  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::tensorflow::AttrValue_ListValue, shape_),
-  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::tensorflow::AttrValue_ListValue, tensor_),
+  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::opencv_tensorflow::AttrValue_ListValue, s_),
+  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::opencv_tensorflow::AttrValue_ListValue, i_),
+  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::opencv_tensorflow::AttrValue_ListValue, f_),
+  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::opencv_tensorflow::AttrValue_ListValue, b_),
+  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::opencv_tensorflow::AttrValue_ListValue, type_),
+  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::opencv_tensorflow::AttrValue_ListValue, shape_),
+  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::opencv_tensorflow::AttrValue_ListValue, tensor_),
   ~0u,  // no _has_bits_
-  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::tensorflow::AttrValue, _internal_metadata_),
+  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::opencv_tensorflow::AttrValue, _internal_metadata_),
   ~0u,  // no _extensions_
-  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::tensorflow::AttrValue, _oneof_case_[0]),
+  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::opencv_tensorflow::AttrValue, _oneof_case_[0]),
   ~0u,  // no _weak_field_map_
-  offsetof(::tensorflow::AttrValueDefaultTypeInternal, s_),
-  offsetof(::tensorflow::AttrValueDefaultTypeInternal, i_),
-  offsetof(::tensorflow::AttrValueDefaultTypeInternal, f_),
-  offsetof(::tensorflow::AttrValueDefaultTypeInternal, b_),
-  offsetof(::tensorflow::AttrValueDefaultTypeInternal, type_),
-  offsetof(::tensorflow::AttrValueDefaultTypeInternal, shape_),
-  offsetof(::tensorflow::AttrValueDefaultTypeInternal, tensor_),
-  offsetof(::tensorflow::AttrValueDefaultTypeInternal, list_),
-  offsetof(::tensorflow::AttrValueDefaultTypeInternal, func_),
-  offsetof(::tensorflow::AttrValueDefaultTypeInternal, placeholder_),
-  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::tensorflow::AttrValue, value_),
-  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::tensorflow::NameAttrList_AttrEntry_DoNotUse, _has_bits_),
-  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::tensorflow::NameAttrList_AttrEntry_DoNotUse, _internal_metadata_),
+  offsetof(::opencv_tensorflow::AttrValueDefaultTypeInternal, s_),
+  offsetof(::opencv_tensorflow::AttrValueDefaultTypeInternal, i_),
+  offsetof(::opencv_tensorflow::AttrValueDefaultTypeInternal, f_),
+  offsetof(::opencv_tensorflow::AttrValueDefaultTypeInternal, b_),
+  offsetof(::opencv_tensorflow::AttrValueDefaultTypeInternal, type_),
+  offsetof(::opencv_tensorflow::AttrValueDefaultTypeInternal, shape_),
+  offsetof(::opencv_tensorflow::AttrValueDefaultTypeInternal, tensor_),
+  offsetof(::opencv_tensorflow::AttrValueDefaultTypeInternal, list_),
+  offsetof(::opencv_tensorflow::AttrValueDefaultTypeInternal, func_),
+  offsetof(::opencv_tensorflow::AttrValueDefaultTypeInternal, placeholder_),
+  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::opencv_tensorflow::AttrValue, value_),
+  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::opencv_tensorflow::NameAttrList_AttrEntry_DoNotUse, _has_bits_),
+  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::opencv_tensorflow::NameAttrList_AttrEntry_DoNotUse, _internal_metadata_),
   ~0u,  // no _extensions_
   ~0u,  // no _oneof_case_
   ~0u,  // no _weak_field_map_
-  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::tensorflow::NameAttrList_AttrEntry_DoNotUse, key_),
-  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::tensorflow::NameAttrList_AttrEntry_DoNotUse, value_),
+  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::opencv_tensorflow::NameAttrList_AttrEntry_DoNotUse, key_),
+  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::opencv_tensorflow::NameAttrList_AttrEntry_DoNotUse, value_),
   0,
   1,
   ~0u,  // no _has_bits_
-  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::tensorflow::NameAttrList, _internal_metadata_),
+  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::opencv_tensorflow::NameAttrList, _internal_metadata_),
   ~0u,  // no _extensions_
   ~0u,  // no _oneof_case_
   ~0u,  // no _weak_field_map_
-  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::tensorflow::NameAttrList, name_),
-  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::tensorflow::NameAttrList, attr_),
+  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::opencv_tensorflow::NameAttrList, name_),
+  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::opencv_tensorflow::NameAttrList, attr_),
 };
 static const ::google::protobuf::internal::MigrationSchema schemas[] GOOGLE_PROTOBUF_ATTRIBUTE_SECTION_VARIABLE(protodesc_cold) = {
-  { 0, -1, sizeof(::tensorflow::AttrValue_ListValue)},
-  { 12, -1, sizeof(::tensorflow::AttrValue)},
-  { 28, 35, sizeof(::tensorflow::NameAttrList_AttrEntry_DoNotUse)},
-  { 37, -1, sizeof(::tensorflow::NameAttrList)},
+  { 0, -1, sizeof(::opencv_tensorflow::AttrValue_ListValue)},
+  { 12, -1, sizeof(::opencv_tensorflow::AttrValue)},
+  { 28, 35, sizeof(::opencv_tensorflow::NameAttrList_AttrEntry_DoNotUse)},
+  { 37, -1, sizeof(::opencv_tensorflow::NameAttrList)},
 };
 
 static ::google::protobuf::Message const * const file_default_instances[] = {
-  reinterpret_cast<const ::google::protobuf::Message*>(&::tensorflow::_AttrValue_ListValue_default_instance_),
-  reinterpret_cast<const ::google::protobuf::Message*>(&::tensorflow::_AttrValue_default_instance_),
-  reinterpret_cast<const ::google::protobuf::Message*>(&::tensorflow::_NameAttrList_AttrEntry_DoNotUse_default_instance_),
-  reinterpret_cast<const ::google::protobuf::Message*>(&::tensorflow::_NameAttrList_default_instance_),
+  reinterpret_cast<const ::google::protobuf::Message*>(&::opencv_tensorflow::_AttrValue_ListValue_default_instance_),
+  reinterpret_cast<const ::google::protobuf::Message*>(&::opencv_tensorflow::_AttrValue_default_instance_),
+  reinterpret_cast<const ::google::protobuf::Message*>(&::opencv_tensorflow::_NameAttrList_AttrEntry_DoNotUse_default_instance_),
+  reinterpret_cast<const ::google::protobuf::Message*>(&::opencv_tensorflow::_NameAttrList_default_instance_),
 };
 
 void protobuf_AssignDescriptors() {
@@ -194,29 +194,31 @@ void protobuf_RegisterTypes(const ::std::string&) {
 void AddDescriptorsImpl() {
   InitDefaults();
   static const char descriptor[] GOOGLE_PROTOBUF_ATTRIBUTE_SECTION_VARIABLE(protodesc_cold) = {
-      "\n\020attr_value.proto\022\ntensorflow\032\014tensor.p"
-      "roto\032\022tensor_shape.proto\032\013types.proto\"\376\003"
-      "\n\tAttrValue\022\013\n\001s\030\002 \001(\014H\000\022\013\n\001i\030\003 \001(\003H\000\022\013\n"
-      "\001f\030\004 \001(\002H\000\022\013\n\001b\030\005 \001(\010H\000\022$\n\004type\030\006 \001(\0162\024."
-      "tensorflow.DataTypeH\000\022-\n\005shape\030\007 \001(\0132\034.t"
-      "ensorflow.TensorShapeProtoH\000\022)\n\006tensor\030\010"
-      " \001(\0132\027.tensorflow.TensorProtoH\000\022/\n\004list\030"
-      "\001 \001(\0132\037.tensorflow.AttrValue.ListValueH\000"
-      "\022(\n\004func\030\n \001(\0132\030.tensorflow.NameAttrList"
-      "H\000\022\025\n\013placeholder\030\t \001(\tH\000\032\301\001\n\tListValue\022"
-      "\t\n\001s\030\002 \003(\014\022\r\n\001i\030\003 \003(\003B\002\020\001\022\r\n\001f\030\004 \003(\002B\002\020\001"
-      "\022\r\n\001b\030\005 \003(\010B\002\020\001\022&\n\004type\030\006 \003(\0162\024.tensorfl"
-      "ow.DataTypeB\002\020\001\022+\n\005shape\030\007 \003(\0132\034.tensorf"
-      "low.TensorShapeProto\022\'\n\006tensor\030\010 \003(\0132\027.t"
-      "ensorflow.TensorProtoB\007\n\005value\"\222\001\n\014NameA"
-      "ttrList\022\014\n\004name\030\001 \001(\t\0220\n\004attr\030\002 \003(\0132\".te"
-      "nsorflow.NameAttrList.AttrEntry\032B\n\tAttrE"
-      "ntry\022\013\n\003key\030\001 \001(\t\022$\n\005value\030\002 \001(\0132\025.tenso"
-      "rflow.AttrValue:\0028\001B0\n\030org.tensorflow.fr"
-      "ameworkB\017AttrValueProtosP\001\370\001\001b\006proto3"
+      "\n\020attr_value.proto\022\021opencv_tensorflow\032\014t"
+      "ensor.proto\032\022tensor_shape.proto\032\013types.p"
+      "roto\"\266\004\n\tAttrValue\022\013\n\001s\030\002 \001(\014H\000\022\013\n\001i\030\003 \001"
+      "(\003H\000\022\013\n\001f\030\004 \001(\002H\000\022\013\n\001b\030\005 \001(\010H\000\022+\n\004type\030\006"
+      " \001(\0162\033.opencv_tensorflow.DataTypeH\000\0224\n\005s"
+      "hape\030\007 \001(\0132#.opencv_tensorflow.TensorSha"
+      "peProtoH\000\0220\n\006tensor\030\010 \001(\0132\036.opencv_tenso"
+      "rflow.TensorProtoH\000\0226\n\004list\030\001 \001(\0132&.open"
+      "cv_tensorflow.AttrValue.ListValueH\000\022/\n\004f"
+      "unc\030\n \001(\0132\037.opencv_tensorflow.NameAttrLi"
+      "stH\000\022\025\n\013placeholder\030\t \001(\tH\000\032\326\001\n\tListValu"
+      "e\022\t\n\001s\030\002 \003(\014\022\r\n\001i\030\003 \003(\003B\002\020\001\022\r\n\001f\030\004 \003(\002B\002"
+      "\020\001\022\r\n\001b\030\005 \003(\010B\002\020\001\022-\n\004type\030\006 \003(\0162\033.opencv"
+      "_tensorflow.DataTypeB\002\020\001\0222\n\005shape\030\007 \003(\0132"
+      "#.opencv_tensorflow.TensorShapeProto\022.\n\006"
+      "tensor\030\010 \003(\0132\036.opencv_tensorflow.TensorP"
+      "rotoB\007\n\005value\"\240\001\n\014NameAttrList\022\014\n\004name\030\001"
+      " \001(\t\0227\n\004attr\030\002 \003(\0132).opencv_tensorflow.N"
+      "ameAttrList.AttrEntry\032I\n\tAttrEntry\022\013\n\003ke"
+      "y\030\001 \001(\t\022+\n\005value\030\002 \001(\0132\034.opencv_tensorfl"
+      "ow.AttrValue:\0028\001B0\n\030org.tensorflow.frame"
+      "workB\017AttrValueProtosP\001\370\001\001b\006proto3"
   };
   ::google::protobuf::DescriptorPool::InternalAddGeneratedFile(
-      descriptor, 797);
+      descriptor, 874);
   ::google::protobuf::MessageFactory::InternalRegisterGeneratedFile(
     "attr_value.proto", &protobuf_RegisterTypes);
   ::protobuf_tensor_2eproto::AddDescriptors();
@@ -235,7 +237,7 @@ struct StaticDescriptorInitializer {
   }
 } static_descriptor_initializer;
 }  // namespace protobuf_attr_5fvalue_2eproto
-namespace tensorflow {
+namespace opencv_tensorflow {
 
 // ===================================================================
 
@@ -263,7 +265,7 @@ AttrValue_ListValue::AttrValue_ListValue()
     ::protobuf_attr_5fvalue_2eproto::InitDefaultsAttrValue_ListValue();
   }
   SharedCtor();
-  // @@protoc_insertion_point(constructor:tensorflow.AttrValue.ListValue)
+  // @@protoc_insertion_point(constructor:opencv_tensorflow.AttrValue.ListValue)
 }
 AttrValue_ListValue::AttrValue_ListValue(::google::protobuf::Arena* arena)
   : ::google::protobuf::Message(),
@@ -278,7 +280,7 @@ AttrValue_ListValue::AttrValue_ListValue(::google::protobuf::Arena* arena)
   ::protobuf_attr_5fvalue_2eproto::InitDefaultsAttrValue_ListValue();
   SharedCtor();
   RegisterArenaDtor(arena);
-  // @@protoc_insertion_point(arena_constructor:tensorflow.AttrValue.ListValue)
+  // @@protoc_insertion_point(arena_constructor:opencv_tensorflow.AttrValue.ListValue)
 }
 AttrValue_ListValue::AttrValue_ListValue(const AttrValue_ListValue& from)
   : ::google::protobuf::Message(),
@@ -292,7 +294,7 @@ AttrValue_ListValue::AttrValue_ListValue(const AttrValue_ListValue& from)
       tensor_(from.tensor_),
       _cached_size_(0) {
   _internal_metadata_.MergeFrom(from._internal_metadata_);
-  // @@protoc_insertion_point(copy_constructor:tensorflow.AttrValue.ListValue)
+  // @@protoc_insertion_point(copy_constructor:opencv_tensorflow.AttrValue.ListValue)
 }
 
 void AttrValue_ListValue::SharedCtor() {
@@ -300,7 +302,7 @@ void AttrValue_ListValue::SharedCtor() {
 }
 
 AttrValue_ListValue::~AttrValue_ListValue() {
-  // @@protoc_insertion_point(destructor:tensorflow.AttrValue.ListValue)
+  // @@protoc_insertion_point(destructor:opencv_tensorflow.AttrValue.ListValue)
   SharedDtor();
 }
 
@@ -334,7 +336,7 @@ AttrValue_ListValue* AttrValue_ListValue::New(::google::protobuf::Arena* arena) 
 }
 
 void AttrValue_ListValue::Clear() {
-// @@protoc_insertion_point(message_clear_start:tensorflow.AttrValue.ListValue)
+// @@protoc_insertion_point(message_clear_start:opencv_tensorflow.AttrValue.ListValue)
   ::google::protobuf::uint32 cached_has_bits = 0;
   // Prevent compiler warnings about cached_has_bits being unused
   (void) cached_has_bits;
@@ -353,7 +355,7 @@ bool AttrValue_ListValue::MergePartialFromCodedStream(
     ::google::protobuf::io::CodedInputStream* input) {
 #define DO_(EXPRESSION) if (!GOOGLE_PREDICT_TRUE(EXPRESSION)) goto failure
   ::google::protobuf::uint32 tag;
-  // @@protoc_insertion_point(parse_start:tensorflow.AttrValue.ListValue)
+  // @@protoc_insertion_point(parse_start:opencv_tensorflow.AttrValue.ListValue)
   for (;;) {
     ::std::pair< ::google::protobuf::uint32, bool> p = input->ReadTagWithCutoffNoLastTag(127u);
     tag = p.first;
@@ -428,7 +430,7 @@ bool AttrValue_ListValue::MergePartialFromCodedStream(
         break;
       }
 
-      // repeated .tensorflow.DataType type = 6 [packed = true];
+      // repeated .opencv_tensorflow.DataType type = 6 [packed = true];
       case 6: {
         if (static_cast< ::google::protobuf::uint8>(tag) ==
             static_cast< ::google::protobuf::uint8>(50u /* 50 & 0xFF */)) {
@@ -440,7 +442,7 @@ bool AttrValue_ListValue::MergePartialFromCodedStream(
             DO_((::google::protobuf::internal::WireFormatLite::ReadPrimitive<
                    int, ::google::protobuf::internal::WireFormatLite::TYPE_ENUM>(
                  input, &value)));
-            add_type(static_cast< ::tensorflow::DataType >(value));
+            add_type(static_cast< ::opencv_tensorflow::DataType >(value));
           }
           input->PopLimit(limit);
         } else if (
@@ -450,14 +452,14 @@ bool AttrValue_ListValue::MergePartialFromCodedStream(
           DO_((::google::protobuf::internal::WireFormatLite::ReadPrimitive<
                    int, ::google::protobuf::internal::WireFormatLite::TYPE_ENUM>(
                  input, &value)));
-          add_type(static_cast< ::tensorflow::DataType >(value));
+          add_type(static_cast< ::opencv_tensorflow::DataType >(value));
         } else {
           goto handle_unusual;
         }
         break;
       }
 
-      // repeated .tensorflow.TensorShapeProto shape = 7;
+      // repeated .opencv_tensorflow.TensorShapeProto shape = 7;
       case 7: {
         if (static_cast< ::google::protobuf::uint8>(tag) ==
             static_cast< ::google::protobuf::uint8>(58u /* 58 & 0xFF */)) {
@@ -468,7 +470,7 @@ bool AttrValue_ListValue::MergePartialFromCodedStream(
         break;
       }
 
-      // repeated .tensorflow.TensorProto tensor = 8;
+      // repeated .opencv_tensorflow.TensorProto tensor = 8;
       case 8: {
         if (static_cast< ::google::protobuf::uint8>(tag) ==
             static_cast< ::google::protobuf::uint8>(66u /* 66 & 0xFF */)) {
@@ -491,17 +493,17 @@ bool AttrValue_ListValue::MergePartialFromCodedStream(
     }
   }
 success:
-  // @@protoc_insertion_point(parse_success:tensorflow.AttrValue.ListValue)
+  // @@protoc_insertion_point(parse_success:opencv_tensorflow.AttrValue.ListValue)
   return true;
 failure:
-  // @@protoc_insertion_point(parse_failure:tensorflow.AttrValue.ListValue)
+  // @@protoc_insertion_point(parse_failure:opencv_tensorflow.AttrValue.ListValue)
   return false;
 #undef DO_
 }
 
 void AttrValue_ListValue::SerializeWithCachedSizes(
     ::google::protobuf::io::CodedOutputStream* output) const {
-  // @@protoc_insertion_point(serialize_start:tensorflow.AttrValue.ListValue)
+  // @@protoc_insertion_point(serialize_start:opencv_tensorflow.AttrValue.ListValue)
   ::google::protobuf::uint32 cached_has_bits = 0;
   (void) cached_has_bits;
 
@@ -540,7 +542,7 @@ void AttrValue_ListValue::SerializeWithCachedSizes(
       this->b().data(), this->b_size(), output);
   }
 
-  // repeated .tensorflow.DataType type = 6 [packed = true];
+  // repeated .opencv_tensorflow.DataType type = 6 [packed = true];
   if (this->type_size() > 0) {
     ::google::protobuf::internal::WireFormatLite::WriteTag(
       6,
@@ -554,14 +556,14 @@ void AttrValue_ListValue::SerializeWithCachedSizes(
       this->type(i), output);
   }
 
-  // repeated .tensorflow.TensorShapeProto shape = 7;
+  // repeated .opencv_tensorflow.TensorShapeProto shape = 7;
   for (unsigned int i = 0,
       n = static_cast<unsigned int>(this->shape_size()); i < n; i++) {
     ::google::protobuf::internal::WireFormatLite::WriteMessageMaybeToArray(
       7, this->shape(static_cast<int>(i)), output);
   }
 
-  // repeated .tensorflow.TensorProto tensor = 8;
+  // repeated .opencv_tensorflow.TensorProto tensor = 8;
   for (unsigned int i = 0,
       n = static_cast<unsigned int>(this->tensor_size()); i < n; i++) {
     ::google::protobuf::internal::WireFormatLite::WriteMessageMaybeToArray(
@@ -572,13 +574,13 @@ void AttrValue_ListValue::SerializeWithCachedSizes(
     ::google::protobuf::internal::WireFormat::SerializeUnknownFields(
         (::google::protobuf::internal::GetProto3PreserveUnknownsDefault()   ? _internal_metadata_.unknown_fields()   : _internal_metadata_.default_instance()), output);
   }
-  // @@protoc_insertion_point(serialize_end:tensorflow.AttrValue.ListValue)
+  // @@protoc_insertion_point(serialize_end:opencv_tensorflow.AttrValue.ListValue)
 }
 
 ::google::protobuf::uint8* AttrValue_ListValue::InternalSerializeWithCachedSizesToArray(
     bool deterministic, ::google::protobuf::uint8* target) const {
   (void)deterministic; // Unused
-  // @@protoc_insertion_point(serialize_to_array_start:tensorflow.AttrValue.ListValue)
+  // @@protoc_insertion_point(serialize_to_array_start:opencv_tensorflow.AttrValue.ListValue)
   ::google::protobuf::uint32 cached_has_bits = 0;
   (void) cached_has_bits;
 
@@ -627,7 +629,7 @@ void AttrValue_ListValue::SerializeWithCachedSizes(
       WriteBoolNoTagToArray(this->b_, target);
   }
 
-  // repeated .tensorflow.DataType type = 6 [packed = true];
+  // repeated .opencv_tensorflow.DataType type = 6 [packed = true];
   if (this->type_size() > 0) {
     target = ::google::protobuf::internal::WireFormatLite::WriteTagToArray(
       6,
@@ -639,7 +641,7 @@ void AttrValue_ListValue::SerializeWithCachedSizes(
       this->type_, target);
   }
 
-  // repeated .tensorflow.TensorShapeProto shape = 7;
+  // repeated .opencv_tensorflow.TensorShapeProto shape = 7;
   for (unsigned int i = 0,
       n = static_cast<unsigned int>(this->shape_size()); i < n; i++) {
     target = ::google::protobuf::internal::WireFormatLite::
@@ -647,7 +649,7 @@ void AttrValue_ListValue::SerializeWithCachedSizes(
         7, this->shape(static_cast<int>(i)), deterministic, target);
   }
 
-  // repeated .tensorflow.TensorProto tensor = 8;
+  // repeated .opencv_tensorflow.TensorProto tensor = 8;
   for (unsigned int i = 0,
       n = static_cast<unsigned int>(this->tensor_size()); i < n; i++) {
     target = ::google::protobuf::internal::WireFormatLite::
@@ -659,12 +661,12 @@ void AttrValue_ListValue::SerializeWithCachedSizes(
     target = ::google::protobuf::internal::WireFormat::SerializeUnknownFieldsToArray(
         (::google::protobuf::internal::GetProto3PreserveUnknownsDefault()   ? _internal_metadata_.unknown_fields()   : _internal_metadata_.default_instance()), target);
   }
-  // @@protoc_insertion_point(serialize_to_array_end:tensorflow.AttrValue.ListValue)
+  // @@protoc_insertion_point(serialize_to_array_end:opencv_tensorflow.AttrValue.ListValue)
   return target;
 }
 
 size_t AttrValue_ListValue::ByteSizeLong() const {
-// @@protoc_insertion_point(message_byte_size_start:tensorflow.AttrValue.ListValue)
+// @@protoc_insertion_point(message_byte_size_start:opencv_tensorflow.AttrValue.ListValue)
   size_t total_size = 0;
 
   if ((_internal_metadata_.have_unknown_fields() &&  ::google::protobuf::internal::GetProto3PreserveUnknownsDefault())) {
@@ -728,7 +730,7 @@ size_t AttrValue_ListValue::ByteSizeLong() const {
     total_size += data_size;
   }
 
-  // repeated .tensorflow.DataType type = 6 [packed = true];
+  // repeated .opencv_tensorflow.DataType type = 6 [packed = true];
   {
     size_t data_size = 0;
     unsigned int count = static_cast<unsigned int>(this->type_size());for (unsigned int i = 0; i < count; i++) {
@@ -747,7 +749,7 @@ size_t AttrValue_ListValue::ByteSizeLong() const {
     total_size += data_size;
   }
 
-  // repeated .tensorflow.TensorShapeProto shape = 7;
+  // repeated .opencv_tensorflow.TensorShapeProto shape = 7;
   {
     unsigned int count = static_cast<unsigned int>(this->shape_size());
     total_size += 1UL * count;
@@ -758,7 +760,7 @@ size_t AttrValue_ListValue::ByteSizeLong() const {
     }
   }
 
-  // repeated .tensorflow.TensorProto tensor = 8;
+  // repeated .opencv_tensorflow.TensorProto tensor = 8;
   {
     unsigned int count = static_cast<unsigned int>(this->tensor_size());
     total_size += 1UL * count;
@@ -777,22 +779,22 @@ size_t AttrValue_ListValue::ByteSizeLong() const {
 }
 
 void AttrValue_ListValue::MergeFrom(const ::google::protobuf::Message& from) {
-// @@protoc_insertion_point(generalized_merge_from_start:tensorflow.AttrValue.ListValue)
+// @@protoc_insertion_point(generalized_merge_from_start:opencv_tensorflow.AttrValue.ListValue)
   GOOGLE_DCHECK_NE(&from, this);
   const AttrValue_ListValue* source =
       ::google::protobuf::internal::DynamicCastToGenerated<const AttrValue_ListValue>(
           &from);
   if (source == NULL) {
-  // @@protoc_insertion_point(generalized_merge_from_cast_fail:tensorflow.AttrValue.ListValue)
+  // @@protoc_insertion_point(generalized_merge_from_cast_fail:opencv_tensorflow.AttrValue.ListValue)
     ::google::protobuf::internal::ReflectionOps::Merge(from, this);
   } else {
-  // @@protoc_insertion_point(generalized_merge_from_cast_success:tensorflow.AttrValue.ListValue)
+  // @@protoc_insertion_point(generalized_merge_from_cast_success:opencv_tensorflow.AttrValue.ListValue)
     MergeFrom(*source);
   }
 }
 
 void AttrValue_ListValue::MergeFrom(const AttrValue_ListValue& from) {
-// @@protoc_insertion_point(class_specific_merge_from_start:tensorflow.AttrValue.ListValue)
+// @@protoc_insertion_point(class_specific_merge_from_start:opencv_tensorflow.AttrValue.ListValue)
   GOOGLE_DCHECK_NE(&from, this);
   _internal_metadata_.MergeFrom(from._internal_metadata_);
   ::google::protobuf::uint32 cached_has_bits = 0;
@@ -808,14 +810,14 @@ void AttrValue_ListValue::MergeFrom(const AttrValue_ListValue& from) {
 }
 
 void AttrValue_ListValue::CopyFrom(const ::google::protobuf::Message& from) {
-// @@protoc_insertion_point(generalized_copy_from_start:tensorflow.AttrValue.ListValue)
+// @@protoc_insertion_point(generalized_copy_from_start:opencv_tensorflow.AttrValue.ListValue)
   if (&from == this) return;
   Clear();
   MergeFrom(from);
 }
 
 void AttrValue_ListValue::CopyFrom(const AttrValue_ListValue& from) {
-// @@protoc_insertion_point(class_specific_copy_from_start:tensorflow.AttrValue.ListValue)
+// @@protoc_insertion_point(class_specific_copy_from_start:opencv_tensorflow.AttrValue.ListValue)
   if (&from == this) return;
   Clear();
   MergeFrom(from);
@@ -866,24 +868,24 @@ void AttrValue_ListValue::InternalSwap(AttrValue_ListValue* other) {
 // ===================================================================
 
 void AttrValue::InitAsDefaultInstance() {
-  ::tensorflow::_AttrValue_default_instance_.s_.UnsafeSetDefault(
+  ::opencv_tensorflow::_AttrValue_default_instance_.s_.UnsafeSetDefault(
       &::google::protobuf::internal::GetEmptyStringAlreadyInited());
-  ::tensorflow::_AttrValue_default_instance_.i_ = GOOGLE_LONGLONG(0);
-  ::tensorflow::_AttrValue_default_instance_.f_ = 0;
-  ::tensorflow::_AttrValue_default_instance_.b_ = false;
-  ::tensorflow::_AttrValue_default_instance_.type_ = 0;
-  ::tensorflow::_AttrValue_default_instance_.shape_ = const_cast< ::tensorflow::TensorShapeProto*>(
-      ::tensorflow::TensorShapeProto::internal_default_instance());
-  ::tensorflow::_AttrValue_default_instance_.tensor_ = const_cast< ::tensorflow::TensorProto*>(
-      ::tensorflow::TensorProto::internal_default_instance());
-  ::tensorflow::_AttrValue_default_instance_.list_ = const_cast< ::tensorflow::AttrValue_ListValue*>(
-      ::tensorflow::AttrValue_ListValue::internal_default_instance());
-  ::tensorflow::_AttrValue_default_instance_.func_ = const_cast< ::tensorflow::NameAttrList*>(
-      ::tensorflow::NameAttrList::internal_default_instance());
-  ::tensorflow::_AttrValue_default_instance_.placeholder_.UnsafeSetDefault(
+  ::opencv_tensorflow::_AttrValue_default_instance_.i_ = GOOGLE_LONGLONG(0);
+  ::opencv_tensorflow::_AttrValue_default_instance_.f_ = 0;
+  ::opencv_tensorflow::_AttrValue_default_instance_.b_ = false;
+  ::opencv_tensorflow::_AttrValue_default_instance_.type_ = 0;
+  ::opencv_tensorflow::_AttrValue_default_instance_.shape_ = const_cast< ::opencv_tensorflow::TensorShapeProto*>(
+      ::opencv_tensorflow::TensorShapeProto::internal_default_instance());
+  ::opencv_tensorflow::_AttrValue_default_instance_.tensor_ = const_cast< ::opencv_tensorflow::TensorProto*>(
+      ::opencv_tensorflow::TensorProto::internal_default_instance());
+  ::opencv_tensorflow::_AttrValue_default_instance_.list_ = const_cast< ::opencv_tensorflow::AttrValue_ListValue*>(
+      ::opencv_tensorflow::AttrValue_ListValue::internal_default_instance());
+  ::opencv_tensorflow::_AttrValue_default_instance_.func_ = const_cast< ::opencv_tensorflow::NameAttrList*>(
+      ::opencv_tensorflow::NameAttrList::internal_default_instance());
+  ::opencv_tensorflow::_AttrValue_default_instance_.placeholder_.UnsafeSetDefault(
       &::google::protobuf::internal::GetEmptyStringAlreadyInited());
 }
-void AttrValue::set_allocated_shape(::tensorflow::TensorShapeProto* shape) {
+void AttrValue::set_allocated_shape(::opencv_tensorflow::TensorShapeProto* shape) {
   ::google::protobuf::Arena* message_arena = GetArenaNoVirtual();
   clear_value();
   if (shape) {
@@ -896,7 +898,7 @@ void AttrValue::set_allocated_shape(::tensorflow::TensorShapeProto* shape) {
     set_has_shape();
     value_.shape_ = shape;
   }
-  // @@protoc_insertion_point(field_set_allocated:tensorflow.AttrValue.shape)
+  // @@protoc_insertion_point(field_set_allocated:opencv_tensorflow.AttrValue.shape)
 }
 void AttrValue::clear_shape() {
   if (has_shape()) {
@@ -906,7 +908,7 @@ void AttrValue::clear_shape() {
     clear_has_value();
   }
 }
-void AttrValue::set_allocated_tensor(::tensorflow::TensorProto* tensor) {
+void AttrValue::set_allocated_tensor(::opencv_tensorflow::TensorProto* tensor) {
   ::google::protobuf::Arena* message_arena = GetArenaNoVirtual();
   clear_value();
   if (tensor) {
@@ -919,7 +921,7 @@ void AttrValue::set_allocated_tensor(::tensorflow::TensorProto* tensor) {
     set_has_tensor();
     value_.tensor_ = tensor;
   }
-  // @@protoc_insertion_point(field_set_allocated:tensorflow.AttrValue.tensor)
+  // @@protoc_insertion_point(field_set_allocated:opencv_tensorflow.AttrValue.tensor)
 }
 void AttrValue::clear_tensor() {
   if (has_tensor()) {
@@ -929,7 +931,7 @@ void AttrValue::clear_tensor() {
     clear_has_value();
   }
 }
-void AttrValue::set_allocated_list(::tensorflow::AttrValue_ListValue* list) {
+void AttrValue::set_allocated_list(::opencv_tensorflow::AttrValue_ListValue* list) {
   ::google::protobuf::Arena* message_arena = GetArenaNoVirtual();
   clear_value();
   if (list) {
@@ -942,9 +944,9 @@ void AttrValue::set_allocated_list(::tensorflow::AttrValue_ListValue* list) {
     set_has_list();
     value_.list_ = list;
   }
-  // @@protoc_insertion_point(field_set_allocated:tensorflow.AttrValue.list)
+  // @@protoc_insertion_point(field_set_allocated:opencv_tensorflow.AttrValue.list)
 }
-void AttrValue::set_allocated_func(::tensorflow::NameAttrList* func) {
+void AttrValue::set_allocated_func(::opencv_tensorflow::NameAttrList* func) {
   ::google::protobuf::Arena* message_arena = GetArenaNoVirtual();
   clear_value();
   if (func) {
@@ -957,7 +959,7 @@ void AttrValue::set_allocated_func(::tensorflow::NameAttrList* func) {
     set_has_func();
     value_.func_ = func;
   }
-  // @@protoc_insertion_point(field_set_allocated:tensorflow.AttrValue.func)
+  // @@protoc_insertion_point(field_set_allocated:opencv_tensorflow.AttrValue.func)
 }
 #if !defined(_MSC_VER) || _MSC_VER >= 1900
 const int AttrValue::kSFieldNumber;
@@ -978,7 +980,7 @@ AttrValue::AttrValue()
     ::protobuf_attr_5fvalue_2eproto::InitDefaultsAttrValue();
   }
   SharedCtor();
-  // @@protoc_insertion_point(constructor:tensorflow.AttrValue)
+  // @@protoc_insertion_point(constructor:opencv_tensorflow.AttrValue)
 }
 AttrValue::AttrValue(::google::protobuf::Arena* arena)
   : ::google::protobuf::Message(),
@@ -986,7 +988,7 @@ AttrValue::AttrValue(::google::protobuf::Arena* arena)
   ::protobuf_attr_5fvalue_2eproto::InitDefaultsAttrValue();
   SharedCtor();
   RegisterArenaDtor(arena);
-  // @@protoc_insertion_point(arena_constructor:tensorflow.AttrValue)
+  // @@protoc_insertion_point(arena_constructor:opencv_tensorflow.AttrValue)
 }
 AttrValue::AttrValue(const AttrValue& from)
   : ::google::protobuf::Message(),
@@ -1016,19 +1018,19 @@ AttrValue::AttrValue(const AttrValue& from)
       break;
     }
     case kShape: {
-      mutable_shape()->::tensorflow::TensorShapeProto::MergeFrom(from.shape());
+      mutable_shape()->::opencv_tensorflow::TensorShapeProto::MergeFrom(from.shape());
       break;
     }
     case kTensor: {
-      mutable_tensor()->::tensorflow::TensorProto::MergeFrom(from.tensor());
+      mutable_tensor()->::opencv_tensorflow::TensorProto::MergeFrom(from.tensor());
       break;
     }
     case kList: {
-      mutable_list()->::tensorflow::AttrValue_ListValue::MergeFrom(from.list());
+      mutable_list()->::opencv_tensorflow::AttrValue_ListValue::MergeFrom(from.list());
       break;
     }
     case kFunc: {
-      mutable_func()->::tensorflow::NameAttrList::MergeFrom(from.func());
+      mutable_func()->::opencv_tensorflow::NameAttrList::MergeFrom(from.func());
       break;
     }
     case kPlaceholder: {
@@ -1039,7 +1041,7 @@ AttrValue::AttrValue(const AttrValue& from)
       break;
     }
   }
-  // @@protoc_insertion_point(copy_constructor:tensorflow.AttrValue)
+  // @@protoc_insertion_point(copy_constructor:opencv_tensorflow.AttrValue)
 }
 
 void AttrValue::SharedCtor() {
@@ -1048,7 +1050,7 @@ void AttrValue::SharedCtor() {
 }
 
 AttrValue::~AttrValue() {
-  // @@protoc_insertion_point(destructor:tensorflow.AttrValue)
+  // @@protoc_insertion_point(destructor:opencv_tensorflow.AttrValue)
   SharedDtor();
 }
 
@@ -1085,7 +1087,7 @@ AttrValue* AttrValue::New(::google::protobuf::Arena* arena) const {
 }
 
 void AttrValue::clear_value() {
-// @@protoc_insertion_point(one_of_clear_start:tensorflow.AttrValue)
+// @@protoc_insertion_point(one_of_clear_start:opencv_tensorflow.AttrValue)
   switch (value_case()) {
     case kS: {
       value_.s_.Destroy(&::google::protobuf::internal::GetEmptyStringAlreadyInited(),
@@ -1146,7 +1148,7 @@ void AttrValue::clear_value() {
 
 
 void AttrValue::Clear() {
-// @@protoc_insertion_point(message_clear_start:tensorflow.AttrValue)
+// @@protoc_insertion_point(message_clear_start:opencv_tensorflow.AttrValue)
   ::google::protobuf::uint32 cached_has_bits = 0;
   // Prevent compiler warnings about cached_has_bits being unused
   (void) cached_has_bits;
@@ -1159,13 +1161,13 @@ bool AttrValue::MergePartialFromCodedStream(
     ::google::protobuf::io::CodedInputStream* input) {
 #define DO_(EXPRESSION) if (!GOOGLE_PREDICT_TRUE(EXPRESSION)) goto failure
   ::google::protobuf::uint32 tag;
-  // @@protoc_insertion_point(parse_start:tensorflow.AttrValue)
+  // @@protoc_insertion_point(parse_start:opencv_tensorflow.AttrValue)
   for (;;) {
     ::std::pair< ::google::protobuf::uint32, bool> p = input->ReadTagWithCutoffNoLastTag(127u);
     tag = p.first;
     if (!p.second) goto handle_unusual;
     switch (::google::protobuf::internal::WireFormatLite::GetTagFieldNumber(tag)) {
-      // .tensorflow.AttrValue.ListValue list = 1;
+      // .opencv_tensorflow.AttrValue.ListValue list = 1;
       case 1: {
         if (static_cast< ::google::protobuf::uint8>(tag) ==
             static_cast< ::google::protobuf::uint8>(10u /* 10 & 0xFF */)) {
@@ -1234,7 +1236,7 @@ bool AttrValue::MergePartialFromCodedStream(
         break;
       }
 
-      // .tensorflow.DataType type = 6;
+      // .opencv_tensorflow.DataType type = 6;
       case 6: {
         if (static_cast< ::google::protobuf::uint8>(tag) ==
             static_cast< ::google::protobuf::uint8>(48u /* 48 & 0xFF */)) {
@@ -1242,14 +1244,14 @@ bool AttrValue::MergePartialFromCodedStream(
           DO_((::google::protobuf::internal::WireFormatLite::ReadPrimitive<
                    int, ::google::protobuf::internal::WireFormatLite::TYPE_ENUM>(
                  input, &value)));
-          set_type(static_cast< ::tensorflow::DataType >(value));
+          set_type(static_cast< ::opencv_tensorflow::DataType >(value));
         } else {
           goto handle_unusual;
         }
         break;
       }
 
-      // .tensorflow.TensorShapeProto shape = 7;
+      // .opencv_tensorflow.TensorShapeProto shape = 7;
       case 7: {
         if (static_cast< ::google::protobuf::uint8>(tag) ==
             static_cast< ::google::protobuf::uint8>(58u /* 58 & 0xFF */)) {
@@ -1261,7 +1263,7 @@ bool AttrValue::MergePartialFromCodedStream(
         break;
       }
 
-      // .tensorflow.TensorProto tensor = 8;
+      // .opencv_tensorflow.TensorProto tensor = 8;
       case 8: {
         if (static_cast< ::google::protobuf::uint8>(tag) ==
             static_cast< ::google::protobuf::uint8>(66u /* 66 & 0xFF */)) {
@@ -1282,14 +1284,14 @@ bool AttrValue::MergePartialFromCodedStream(
           DO_(::google::protobuf::internal::WireFormatLite::VerifyUtf8String(
             this->placeholder().data(), static_cast<int>(this->placeholder().length()),
             ::google::protobuf::internal::WireFormatLite::PARSE,
-            "tensorflow.AttrValue.placeholder"));
+            "opencv_tensorflow.AttrValue.placeholder"));
         } else {
           goto handle_unusual;
         }
         break;
       }
 
-      // .tensorflow.NameAttrList func = 10;
+      // .opencv_tensorflow.NameAttrList func = 10;
       case 10: {
         if (static_cast< ::google::protobuf::uint8>(tag) ==
             static_cast< ::google::protobuf::uint8>(82u /* 82 & 0xFF */)) {
@@ -1313,21 +1315,21 @@ bool AttrValue::MergePartialFromCodedStream(
     }
   }
 success:
-  // @@protoc_insertion_point(parse_success:tensorflow.AttrValue)
+  // @@protoc_insertion_point(parse_success:opencv_tensorflow.AttrValue)
   return true;
 failure:
-  // @@protoc_insertion_point(parse_failure:tensorflow.AttrValue)
+  // @@protoc_insertion_point(parse_failure:opencv_tensorflow.AttrValue)
   return false;
 #undef DO_
 }
 
 void AttrValue::SerializeWithCachedSizes(
     ::google::protobuf::io::CodedOutputStream* output) const {
-  // @@protoc_insertion_point(serialize_start:tensorflow.AttrValue)
+  // @@protoc_insertion_point(serialize_start:opencv_tensorflow.AttrValue)
   ::google::protobuf::uint32 cached_has_bits = 0;
   (void) cached_has_bits;
 
-  // .tensorflow.AttrValue.ListValue list = 1;
+  // .opencv_tensorflow.AttrValue.ListValue list = 1;
   if (has_list()) {
     ::google::protobuf::internal::WireFormatLite::WriteMessageMaybeToArray(
       1, *value_.list_, output);
@@ -1354,19 +1356,19 @@ void AttrValue::SerializeWithCachedSizes(
     ::google::protobuf::internal::WireFormatLite::WriteBool(5, this->b(), output);
   }
 
-  // .tensorflow.DataType type = 6;
+  // .opencv_tensorflow.DataType type = 6;
   if (has_type()) {
     ::google::protobuf::internal::WireFormatLite::WriteEnum(
       6, this->type(), output);
   }
 
-  // .tensorflow.TensorShapeProto shape = 7;
+  // .opencv_tensorflow.TensorShapeProto shape = 7;
   if (has_shape()) {
     ::google::protobuf::internal::WireFormatLite::WriteMessageMaybeToArray(
       7, *value_.shape_, output);
   }
 
-  // .tensorflow.TensorProto tensor = 8;
+  // .opencv_tensorflow.TensorProto tensor = 8;
   if (has_tensor()) {
     ::google::protobuf::internal::WireFormatLite::WriteMessageMaybeToArray(
       8, *value_.tensor_, output);
@@ -1377,12 +1379,12 @@ void AttrValue::SerializeWithCachedSizes(
     ::google::protobuf::internal::WireFormatLite::VerifyUtf8String(
       this->placeholder().data(), static_cast<int>(this->placeholder().length()),
       ::google::protobuf::internal::WireFormatLite::SERIALIZE,
-      "tensorflow.AttrValue.placeholder");
+      "opencv_tensorflow.AttrValue.placeholder");
     ::google::protobuf::internal::WireFormatLite::WriteStringMaybeAliased(
       9, this->placeholder(), output);
   }
 
-  // .tensorflow.NameAttrList func = 10;
+  // .opencv_tensorflow.NameAttrList func = 10;
   if (has_func()) {
     ::google::protobuf::internal::WireFormatLite::WriteMessageMaybeToArray(
       10, *value_.func_, output);
@@ -1392,17 +1394,17 @@ void AttrValue::SerializeWithCachedSizes(
     ::google::protobuf::internal::WireFormat::SerializeUnknownFields(
         (::google::protobuf::internal::GetProto3PreserveUnknownsDefault()   ? _internal_metadata_.unknown_fields()   : _internal_metadata_.default_instance()), output);
   }
-  // @@protoc_insertion_point(serialize_end:tensorflow.AttrValue)
+  // @@protoc_insertion_point(serialize_end:opencv_tensorflow.AttrValue)
 }
 
 ::google::protobuf::uint8* AttrValue::InternalSerializeWithCachedSizesToArray(
     bool deterministic, ::google::protobuf::uint8* target) const {
   (void)deterministic; // Unused
-  // @@protoc_insertion_point(serialize_to_array_start:tensorflow.AttrValue)
+  // @@protoc_insertion_point(serialize_to_array_start:opencv_tensorflow.AttrValue)
   ::google::protobuf::uint32 cached_has_bits = 0;
   (void) cached_has_bits;
 
-  // .tensorflow.AttrValue.ListValue list = 1;
+  // .opencv_tensorflow.AttrValue.ListValue list = 1;
   if (has_list()) {
     target = ::google::protobuf::internal::WireFormatLite::
       InternalWriteMessageToArray(
@@ -1431,20 +1433,20 @@ void AttrValue::SerializeWithCachedSizes(
     target = ::google::protobuf::internal::WireFormatLite::WriteBoolToArray(5, this->b(), target);
   }
 
-  // .tensorflow.DataType type = 6;
+  // .opencv_tensorflow.DataType type = 6;
   if (has_type()) {
     target = ::google::protobuf::internal::WireFormatLite::WriteEnumToArray(
       6, this->type(), target);
   }
 
-  // .tensorflow.TensorShapeProto shape = 7;
+  // .opencv_tensorflow.TensorShapeProto shape = 7;
   if (has_shape()) {
     target = ::google::protobuf::internal::WireFormatLite::
       InternalWriteMessageToArray(
         7, *value_.shape_, deterministic, target);
   }
 
-  // .tensorflow.TensorProto tensor = 8;
+  // .opencv_tensorflow.TensorProto tensor = 8;
   if (has_tensor()) {
     target = ::google::protobuf::internal::WireFormatLite::
       InternalWriteMessageToArray(
@@ -1456,13 +1458,13 @@ void AttrValue::SerializeWithCachedSizes(
     ::google::protobuf::internal::WireFormatLite::VerifyUtf8String(
       this->placeholder().data(), static_cast<int>(this->placeholder().length()),
       ::google::protobuf::internal::WireFormatLite::SERIALIZE,
-      "tensorflow.AttrValue.placeholder");
+      "opencv_tensorflow.AttrValue.placeholder");
     target =
       ::google::protobuf::internal::WireFormatLite::WriteStringToArray(
         9, this->placeholder(), target);
   }
 
-  // .tensorflow.NameAttrList func = 10;
+  // .opencv_tensorflow.NameAttrList func = 10;
   if (has_func()) {
     target = ::google::protobuf::internal::WireFormatLite::
       InternalWriteMessageToArray(
@@ -1473,12 +1475,12 @@ void AttrValue::SerializeWithCachedSizes(
     target = ::google::protobuf::internal::WireFormat::SerializeUnknownFieldsToArray(
         (::google::protobuf::internal::GetProto3PreserveUnknownsDefault()   ? _internal_metadata_.unknown_fields()   : _internal_metadata_.default_instance()), target);
   }
-  // @@protoc_insertion_point(serialize_to_array_end:tensorflow.AttrValue)
+  // @@protoc_insertion_point(serialize_to_array_end:opencv_tensorflow.AttrValue)
   return target;
 }
 
 size_t AttrValue::ByteSizeLong() const {
-// @@protoc_insertion_point(message_byte_size_start:tensorflow.AttrValue)
+// @@protoc_insertion_point(message_byte_size_start:opencv_tensorflow.AttrValue)
   size_t total_size = 0;
 
   if ((_internal_metadata_.have_unknown_fields() &&  ::google::protobuf::internal::GetProto3PreserveUnknownsDefault())) {
@@ -1511,34 +1513,34 @@ size_t AttrValue::ByteSizeLong() const {
       total_size += 1 + 1;
       break;
     }
-    // .tensorflow.DataType type = 6;
+    // .opencv_tensorflow.DataType type = 6;
     case kType: {
       total_size += 1 +
         ::google::protobuf::internal::WireFormatLite::EnumSize(this->type());
       break;
     }
-    // .tensorflow.TensorShapeProto shape = 7;
+    // .opencv_tensorflow.TensorShapeProto shape = 7;
     case kShape: {
       total_size += 1 +
         ::google::protobuf::internal::WireFormatLite::MessageSize(
           *value_.shape_);
       break;
     }
-    // .tensorflow.TensorProto tensor = 8;
+    // .opencv_tensorflow.TensorProto tensor = 8;
     case kTensor: {
       total_size += 1 +
         ::google::protobuf::internal::WireFormatLite::MessageSize(
           *value_.tensor_);
       break;
     }
-    // .tensorflow.AttrValue.ListValue list = 1;
+    // .opencv_tensorflow.AttrValue.ListValue list = 1;
     case kList: {
       total_size += 1 +
         ::google::protobuf::internal::WireFormatLite::MessageSize(
           *value_.list_);
       break;
     }
-    // .tensorflow.NameAttrList func = 10;
+    // .opencv_tensorflow.NameAttrList func = 10;
     case kFunc: {
       total_size += 1 +
         ::google::protobuf::internal::WireFormatLite::MessageSize(
@@ -1564,22 +1566,22 @@ size_t AttrValue::ByteSizeLong() const {
 }
 
 void AttrValue::MergeFrom(const ::google::protobuf::Message& from) {
-// @@protoc_insertion_point(generalized_merge_from_start:tensorflow.AttrValue)
+// @@protoc_insertion_point(generalized_merge_from_start:opencv_tensorflow.AttrValue)
   GOOGLE_DCHECK_NE(&from, this);
   const AttrValue* source =
       ::google::protobuf::internal::DynamicCastToGenerated<const AttrValue>(
           &from);
   if (source == NULL) {
-  // @@protoc_insertion_point(generalized_merge_from_cast_fail:tensorflow.AttrValue)
+  // @@protoc_insertion_point(generalized_merge_from_cast_fail:opencv_tensorflow.AttrValue)
     ::google::protobuf::internal::ReflectionOps::Merge(from, this);
   } else {
-  // @@protoc_insertion_point(generalized_merge_from_cast_success:tensorflow.AttrValue)
+  // @@protoc_insertion_point(generalized_merge_from_cast_success:opencv_tensorflow.AttrValue)
     MergeFrom(*source);
   }
 }
 
 void AttrValue::MergeFrom(const AttrValue& from) {
-// @@protoc_insertion_point(class_specific_merge_from_start:tensorflow.AttrValue)
+// @@protoc_insertion_point(class_specific_merge_from_start:opencv_tensorflow.AttrValue)
   GOOGLE_DCHECK_NE(&from, this);
   _internal_metadata_.MergeFrom(from._internal_metadata_);
   ::google::protobuf::uint32 cached_has_bits = 0;
@@ -1607,19 +1609,19 @@ void AttrValue::MergeFrom(const AttrValue& from) {
       break;
     }
     case kShape: {
-      mutable_shape()->::tensorflow::TensorShapeProto::MergeFrom(from.shape());
+      mutable_shape()->::opencv_tensorflow::TensorShapeProto::MergeFrom(from.shape());
       break;
     }
     case kTensor: {
-      mutable_tensor()->::tensorflow::TensorProto::MergeFrom(from.tensor());
+      mutable_tensor()->::opencv_tensorflow::TensorProto::MergeFrom(from.tensor());
       break;
     }
     case kList: {
-      mutable_list()->::tensorflow::AttrValue_ListValue::MergeFrom(from.list());
+      mutable_list()->::opencv_tensorflow::AttrValue_ListValue::MergeFrom(from.list());
       break;
     }
     case kFunc: {
-      mutable_func()->::tensorflow::NameAttrList::MergeFrom(from.func());
+      mutable_func()->::opencv_tensorflow::NameAttrList::MergeFrom(from.func());
       break;
     }
     case kPlaceholder: {
@@ -1633,14 +1635,14 @@ void AttrValue::MergeFrom(const AttrValue& from) {
 }
 
 void AttrValue::CopyFrom(const ::google::protobuf::Message& from) {
-// @@protoc_insertion_point(generalized_copy_from_start:tensorflow.AttrValue)
+// @@protoc_insertion_point(generalized_copy_from_start:opencv_tensorflow.AttrValue)
   if (&from == this) return;
   Clear();
   MergeFrom(from);
 }
 
 void AttrValue::CopyFrom(const AttrValue& from) {
-// @@protoc_insertion_point(class_specific_copy_from_start:tensorflow.AttrValue)
+// @@protoc_insertion_point(class_specific_copy_from_start:opencv_tensorflow.AttrValue)
   if (&from == this) return;
   Clear();
   MergeFrom(from);
@@ -1715,7 +1717,7 @@ NameAttrList::NameAttrList()
     ::protobuf_attr_5fvalue_2eproto::InitDefaultsAttrValue();
   }
   SharedCtor();
-  // @@protoc_insertion_point(constructor:tensorflow.NameAttrList)
+  // @@protoc_insertion_point(constructor:opencv_tensorflow.NameAttrList)
 }
 NameAttrList::NameAttrList(::google::protobuf::Arena* arena)
   : ::google::protobuf::Message(),
@@ -1724,7 +1726,7 @@ NameAttrList::NameAttrList(::google::protobuf::Arena* arena)
   ::protobuf_attr_5fvalue_2eproto::InitDefaultsAttrValue();
   SharedCtor();
   RegisterArenaDtor(arena);
-  // @@protoc_insertion_point(arena_constructor:tensorflow.NameAttrList)
+  // @@protoc_insertion_point(arena_constructor:opencv_tensorflow.NameAttrList)
 }
 NameAttrList::NameAttrList(const NameAttrList& from)
   : ::google::protobuf::Message(),
@@ -1737,7 +1739,7 @@ NameAttrList::NameAttrList(const NameAttrList& from)
     name_.Set(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), from.name(),
       GetArenaNoVirtual());
   }
-  // @@protoc_insertion_point(copy_constructor:tensorflow.NameAttrList)
+  // @@protoc_insertion_point(copy_constructor:opencv_tensorflow.NameAttrList)
 }
 
 void NameAttrList::SharedCtor() {
@@ -1746,7 +1748,7 @@ void NameAttrList::SharedCtor() {
 }
 
 NameAttrList::~NameAttrList() {
-  // @@protoc_insertion_point(destructor:tensorflow.NameAttrList)
+  // @@protoc_insertion_point(destructor:opencv_tensorflow.NameAttrList)
   SharedDtor();
 }
 
@@ -1781,7 +1783,7 @@ NameAttrList* NameAttrList::New(::google::protobuf::Arena* arena) const {
 }
 
 void NameAttrList::Clear() {
-// @@protoc_insertion_point(message_clear_start:tensorflow.NameAttrList)
+// @@protoc_insertion_point(message_clear_start:opencv_tensorflow.NameAttrList)
   ::google::protobuf::uint32 cached_has_bits = 0;
   // Prevent compiler warnings about cached_has_bits being unused
   (void) cached_has_bits;
@@ -1795,7 +1797,7 @@ bool NameAttrList::MergePartialFromCodedStream(
     ::google::protobuf::io::CodedInputStream* input) {
 #define DO_(EXPRESSION) if (!GOOGLE_PREDICT_TRUE(EXPRESSION)) goto failure
   ::google::protobuf::uint32 tag;
-  // @@protoc_insertion_point(parse_start:tensorflow.NameAttrList)
+  // @@protoc_insertion_point(parse_start:opencv_tensorflow.NameAttrList)
   for (;;) {
     ::std::pair< ::google::protobuf::uint32, bool> p = input->ReadTagWithCutoffNoLastTag(127u);
     tag = p.first;
@@ -1810,30 +1812,30 @@ bool NameAttrList::MergePartialFromCodedStream(
           DO_(::google::protobuf::internal::WireFormatLite::VerifyUtf8String(
             this->name().data(), static_cast<int>(this->name().length()),
             ::google::protobuf::internal::WireFormatLite::PARSE,
-            "tensorflow.NameAttrList.name"));
+            "opencv_tensorflow.NameAttrList.name"));
         } else {
           goto handle_unusual;
         }
         break;
       }
 
-      // map<string, .tensorflow.AttrValue> attr = 2;
+      // map<string, .opencv_tensorflow.AttrValue> attr = 2;
       case 2: {
         if (static_cast< ::google::protobuf::uint8>(tag) ==
             static_cast< ::google::protobuf::uint8>(18u /* 18 & 0xFF */)) {
           NameAttrList_AttrEntry_DoNotUse::Parser< ::google::protobuf::internal::MapField<
               NameAttrList_AttrEntry_DoNotUse,
-              ::std::string, ::tensorflow::AttrValue,
+              ::std::string, ::opencv_tensorflow::AttrValue,
               ::google::protobuf::internal::WireFormatLite::TYPE_STRING,
               ::google::protobuf::internal::WireFormatLite::TYPE_MESSAGE,
               0 >,
-            ::google::protobuf::Map< ::std::string, ::tensorflow::AttrValue > > parser(&attr_);
+            ::google::protobuf::Map< ::std::string, ::opencv_tensorflow::AttrValue > > parser(&attr_);
           DO_(::google::protobuf::internal::WireFormatLite::ReadMessageNoVirtual(
               input, &parser));
           DO_(::google::protobuf::internal::WireFormatLite::VerifyUtf8String(
             parser.key().data(), static_cast<int>(parser.key().length()),
             ::google::protobuf::internal::WireFormatLite::PARSE,
-            "tensorflow.NameAttrList.AttrEntry.key"));
+            "opencv_tensorflow.NameAttrList.AttrEntry.key"));
         } else {
           goto handle_unusual;
         }
@@ -1852,17 +1854,17 @@ bool NameAttrList::MergePartialFromCodedStream(
     }
   }
 success:
-  // @@protoc_insertion_point(parse_success:tensorflow.NameAttrList)
+  // @@protoc_insertion_point(parse_success:opencv_tensorflow.NameAttrList)
   return true;
 failure:
-  // @@protoc_insertion_point(parse_failure:tensorflow.NameAttrList)
+  // @@protoc_insertion_point(parse_failure:opencv_tensorflow.NameAttrList)
   return false;
 #undef DO_
 }
 
 void NameAttrList::SerializeWithCachedSizes(
     ::google::protobuf::io::CodedOutputStream* output) const {
-  // @@protoc_insertion_point(serialize_start:tensorflow.NameAttrList)
+  // @@protoc_insertion_point(serialize_start:opencv_tensorflow.NameAttrList)
   ::google::protobuf::uint32 cached_has_bits = 0;
   (void) cached_has_bits;
 
@@ -1871,14 +1873,14 @@ void NameAttrList::SerializeWithCachedSizes(
     ::google::protobuf::internal::WireFormatLite::VerifyUtf8String(
       this->name().data(), static_cast<int>(this->name().length()),
       ::google::protobuf::internal::WireFormatLite::SERIALIZE,
-      "tensorflow.NameAttrList.name");
+      "opencv_tensorflow.NameAttrList.name");
     ::google::protobuf::internal::WireFormatLite::WriteStringMaybeAliased(
       1, this->name(), output);
   }
 
-  // map<string, .tensorflow.AttrValue> attr = 2;
+  // map<string, .opencv_tensorflow.AttrValue> attr = 2;
   if (!this->attr().empty()) {
-    typedef ::google::protobuf::Map< ::std::string, ::tensorflow::AttrValue >::const_pointer
+    typedef ::google::protobuf::Map< ::std::string, ::opencv_tensorflow::AttrValue >::const_pointer
         ConstPtr;
     typedef ConstPtr SortItem;
     typedef ::google::protobuf::internal::CompareByDerefFirst<SortItem> Less;
@@ -1887,7 +1889,7 @@ void NameAttrList::SerializeWithCachedSizes(
         ::google::protobuf::internal::WireFormatLite::VerifyUtf8String(
           p->first.data(), static_cast<int>(p->first.length()),
           ::google::protobuf::internal::WireFormatLite::SERIALIZE,
-          "tensorflow.NameAttrList.AttrEntry.key");
+          "opencv_tensorflow.NameAttrList.AttrEntry.key");
       }
     };
 
@@ -1895,9 +1897,9 @@ void NameAttrList::SerializeWithCachedSizes(
         this->attr().size() > 1) {
       ::google::protobuf::scoped_array<SortItem> items(
           new SortItem[this->attr().size()]);
-      typedef ::google::protobuf::Map< ::std::string, ::tensorflow::AttrValue >::size_type size_type;
+      typedef ::google::protobuf::Map< ::std::string, ::opencv_tensorflow::AttrValue >::size_type size_type;
       size_type n = 0;
-      for (::google::protobuf::Map< ::std::string, ::tensorflow::AttrValue >::const_iterator
+      for (::google::protobuf::Map< ::std::string, ::opencv_tensorflow::AttrValue >::const_iterator
           it = this->attr().begin();
           it != this->attr().end(); ++it, ++n) {
         items[static_cast<ptrdiff_t>(n)] = SortItem(&*it);
@@ -1916,7 +1918,7 @@ void NameAttrList::SerializeWithCachedSizes(
       }
     } else {
       ::google::protobuf::scoped_ptr<NameAttrList_AttrEntry_DoNotUse> entry;
-      for (::google::protobuf::Map< ::std::string, ::tensorflow::AttrValue >::const_iterator
+      for (::google::protobuf::Map< ::std::string, ::opencv_tensorflow::AttrValue >::const_iterator
           it = this->attr().begin();
           it != this->attr().end(); ++it) {
         entry.reset(attr_.NewEntryWrapper(
@@ -1935,13 +1937,13 @@ void NameAttrList::SerializeWithCachedSizes(
     ::google::protobuf::internal::WireFormat::SerializeUnknownFields(
         (::google::protobuf::internal::GetProto3PreserveUnknownsDefault()   ? _internal_metadata_.unknown_fields()   : _internal_metadata_.default_instance()), output);
   }
-  // @@protoc_insertion_point(serialize_end:tensorflow.NameAttrList)
+  // @@protoc_insertion_point(serialize_end:opencv_tensorflow.NameAttrList)
 }
 
 ::google::protobuf::uint8* NameAttrList::InternalSerializeWithCachedSizesToArray(
     bool deterministic, ::google::protobuf::uint8* target) const {
   (void)deterministic; // Unused
-  // @@protoc_insertion_point(serialize_to_array_start:tensorflow.NameAttrList)
+  // @@protoc_insertion_point(serialize_to_array_start:opencv_tensorflow.NameAttrList)
   ::google::protobuf::uint32 cached_has_bits = 0;
   (void) cached_has_bits;
 
@@ -1950,15 +1952,15 @@ void NameAttrList::SerializeWithCachedSizes(
     ::google::protobuf::internal::WireFormatLite::VerifyUtf8String(
       this->name().data(), static_cast<int>(this->name().length()),
       ::google::protobuf::internal::WireFormatLite::SERIALIZE,
-      "tensorflow.NameAttrList.name");
+      "opencv_tensorflow.NameAttrList.name");
     target =
       ::google::protobuf::internal::WireFormatLite::WriteStringToArray(
         1, this->name(), target);
   }
 
-  // map<string, .tensorflow.AttrValue> attr = 2;
+  // map<string, .opencv_tensorflow.AttrValue> attr = 2;
   if (!this->attr().empty()) {
-    typedef ::google::protobuf::Map< ::std::string, ::tensorflow::AttrValue >::const_pointer
+    typedef ::google::protobuf::Map< ::std::string, ::opencv_tensorflow::AttrValue >::const_pointer
         ConstPtr;
     typedef ConstPtr SortItem;
     typedef ::google::protobuf::internal::CompareByDerefFirst<SortItem> Less;
@@ -1967,7 +1969,7 @@ void NameAttrList::SerializeWithCachedSizes(
         ::google::protobuf::internal::WireFormatLite::VerifyUtf8String(
           p->first.data(), static_cast<int>(p->first.length()),
           ::google::protobuf::internal::WireFormatLite::SERIALIZE,
-          "tensorflow.NameAttrList.AttrEntry.key");
+          "opencv_tensorflow.NameAttrList.AttrEntry.key");
       }
     };
 
@@ -1975,9 +1977,9 @@ void NameAttrList::SerializeWithCachedSizes(
         this->attr().size() > 1) {
       ::google::protobuf::scoped_array<SortItem> items(
           new SortItem[this->attr().size()]);
-      typedef ::google::protobuf::Map< ::std::string, ::tensorflow::AttrValue >::size_type size_type;
+      typedef ::google::protobuf::Map< ::std::string, ::opencv_tensorflow::AttrValue >::size_type size_type;
       size_type n = 0;
-      for (::google::protobuf::Map< ::std::string, ::tensorflow::AttrValue >::const_iterator
+      for (::google::protobuf::Map< ::std::string, ::opencv_tensorflow::AttrValue >::const_iterator
           it = this->attr().begin();
           it != this->attr().end(); ++it, ++n) {
         items[static_cast<ptrdiff_t>(n)] = SortItem(&*it);
@@ -1998,7 +2000,7 @@ void NameAttrList::SerializeWithCachedSizes(
       }
     } else {
       ::google::protobuf::scoped_ptr<NameAttrList_AttrEntry_DoNotUse> entry;
-      for (::google::protobuf::Map< ::std::string, ::tensorflow::AttrValue >::const_iterator
+      for (::google::protobuf::Map< ::std::string, ::opencv_tensorflow::AttrValue >::const_iterator
           it = this->attr().begin();
           it != this->attr().end(); ++it) {
         entry.reset(attr_.NewEntryWrapper(
@@ -2019,12 +2021,12 @@ void NameAttrList::SerializeWithCachedSizes(
     target = ::google::protobuf::internal::WireFormat::SerializeUnknownFieldsToArray(
         (::google::protobuf::internal::GetProto3PreserveUnknownsDefault()   ? _internal_metadata_.unknown_fields()   : _internal_metadata_.default_instance()), target);
   }
-  // @@protoc_insertion_point(serialize_to_array_end:tensorflow.NameAttrList)
+  // @@protoc_insertion_point(serialize_to_array_end:opencv_tensorflow.NameAttrList)
   return target;
 }
 
 size_t NameAttrList::ByteSizeLong() const {
-// @@protoc_insertion_point(message_byte_size_start:tensorflow.NameAttrList)
+// @@protoc_insertion_point(message_byte_size_start:opencv_tensorflow.NameAttrList)
   size_t total_size = 0;
 
   if ((_internal_metadata_.have_unknown_fields() &&  ::google::protobuf::internal::GetProto3PreserveUnknownsDefault())) {
@@ -2032,12 +2034,12 @@ size_t NameAttrList::ByteSizeLong() const {
       ::google::protobuf::internal::WireFormat::ComputeUnknownFieldsSize(
         (::google::protobuf::internal::GetProto3PreserveUnknownsDefault()   ? _internal_metadata_.unknown_fields()   : _internal_metadata_.default_instance()));
   }
-  // map<string, .tensorflow.AttrValue> attr = 2;
+  // map<string, .opencv_tensorflow.AttrValue> attr = 2;
   total_size += 1 *
       ::google::protobuf::internal::FromIntSize(this->attr_size());
   {
     ::google::protobuf::scoped_ptr<NameAttrList_AttrEntry_DoNotUse> entry;
-    for (::google::protobuf::Map< ::std::string, ::tensorflow::AttrValue >::const_iterator
+    for (::google::protobuf::Map< ::std::string, ::opencv_tensorflow::AttrValue >::const_iterator
         it = this->attr().begin();
         it != this->attr().end(); ++it) {
       if (entry.get() != NULL && entry->GetArena() != NULL) {
@@ -2067,22 +2069,22 @@ size_t NameAttrList::ByteSizeLong() const {
 }
 
 void NameAttrList::MergeFrom(const ::google::protobuf::Message& from) {
-// @@protoc_insertion_point(generalized_merge_from_start:tensorflow.NameAttrList)
+// @@protoc_insertion_point(generalized_merge_from_start:opencv_tensorflow.NameAttrList)
   GOOGLE_DCHECK_NE(&from, this);
   const NameAttrList* source =
       ::google::protobuf::internal::DynamicCastToGenerated<const NameAttrList>(
           &from);
   if (source == NULL) {
-  // @@protoc_insertion_point(generalized_merge_from_cast_fail:tensorflow.NameAttrList)
+  // @@protoc_insertion_point(generalized_merge_from_cast_fail:opencv_tensorflow.NameAttrList)
     ::google::protobuf::internal::ReflectionOps::Merge(from, this);
   } else {
-  // @@protoc_insertion_point(generalized_merge_from_cast_success:tensorflow.NameAttrList)
+  // @@protoc_insertion_point(generalized_merge_from_cast_success:opencv_tensorflow.NameAttrList)
     MergeFrom(*source);
   }
 }
 
 void NameAttrList::MergeFrom(const NameAttrList& from) {
-// @@protoc_insertion_point(class_specific_merge_from_start:tensorflow.NameAttrList)
+// @@protoc_insertion_point(class_specific_merge_from_start:opencv_tensorflow.NameAttrList)
   GOOGLE_DCHECK_NE(&from, this);
   _internal_metadata_.MergeFrom(from._internal_metadata_);
   ::google::protobuf::uint32 cached_has_bits = 0;
@@ -2095,14 +2097,14 @@ void NameAttrList::MergeFrom(const NameAttrList& from) {
 }
 
 void NameAttrList::CopyFrom(const ::google::protobuf::Message& from) {
-// @@protoc_insertion_point(generalized_copy_from_start:tensorflow.NameAttrList)
+// @@protoc_insertion_point(generalized_copy_from_start:opencv_tensorflow.NameAttrList)
   if (&from == this) return;
   Clear();
   MergeFrom(from);
 }
 
 void NameAttrList::CopyFrom(const NameAttrList& from) {
-// @@protoc_insertion_point(class_specific_copy_from_start:tensorflow.NameAttrList)
+// @@protoc_insertion_point(class_specific_copy_from_start:opencv_tensorflow.NameAttrList)
   if (&from == this) return;
   Clear();
   MergeFrom(from);
@@ -2146,6 +2148,6 @@ void NameAttrList::InternalSwap(NameAttrList* other) {
 
 
 // @@protoc_insertion_point(namespace_scope)
-}  // namespace tensorflow
+}  // namespace opencv_tensorflow
 
 // @@protoc_insertion_point(global_scope)

--- a/modules/dnn/misc/tensorflow/attr_value.pb.h
+++ b/modules/dnn/misc/tensorflow/attr_value.pb.h
@@ -57,7 +57,7 @@ inline void InitDefaults() {
   InitDefaultsAttrValue();
 }
 }  // namespace protobuf_attr_5fvalue_2eproto
-namespace tensorflow {
+namespace opencv_tensorflow {
 class AttrValue;
 class AttrValueDefaultTypeInternal;
 extern AttrValueDefaultTypeInternal _AttrValue_default_instance_;
@@ -70,12 +70,12 @@ extern NameAttrListDefaultTypeInternal _NameAttrList_default_instance_;
 class NameAttrList_AttrEntry_DoNotUse;
 class NameAttrList_AttrEntry_DoNotUseDefaultTypeInternal;
 extern NameAttrList_AttrEntry_DoNotUseDefaultTypeInternal _NameAttrList_AttrEntry_DoNotUse_default_instance_;
-}  // namespace tensorflow
-namespace tensorflow {
+}  // namespace opencv_tensorflow
+namespace opencv_tensorflow {
 
 // ===================================================================
 
-class AttrValue_ListValue : public ::google::protobuf::Message /* @@protoc_insertion_point(class_definition:tensorflow.AttrValue.ListValue) */ {
+class AttrValue_ListValue : public ::google::protobuf::Message /* @@protoc_insertion_point(class_definition:opencv_tensorflow.AttrValue.ListValue) */ {
  public:
   AttrValue_ListValue();
   virtual ~AttrValue_ListValue();
@@ -227,41 +227,41 @@ class AttrValue_ListValue : public ::google::protobuf::Message /* @@protoc_inser
   ::google::protobuf::RepeatedField< bool >*
       mutable_b();
 
-  // repeated .tensorflow.DataType type = 6 [packed = true];
+  // repeated .opencv_tensorflow.DataType type = 6 [packed = true];
   int type_size() const;
   void clear_type();
   static const int kTypeFieldNumber = 6;
-  ::tensorflow::DataType type(int index) const;
-  void set_type(int index, ::tensorflow::DataType value);
-  void add_type(::tensorflow::DataType value);
+  ::opencv_tensorflow::DataType type(int index) const;
+  void set_type(int index, ::opencv_tensorflow::DataType value);
+  void add_type(::opencv_tensorflow::DataType value);
   const ::google::protobuf::RepeatedField<int>& type() const;
   ::google::protobuf::RepeatedField<int>* mutable_type();
 
-  // repeated .tensorflow.TensorShapeProto shape = 7;
+  // repeated .opencv_tensorflow.TensorShapeProto shape = 7;
   int shape_size() const;
   void clear_shape();
   static const int kShapeFieldNumber = 7;
-  const ::tensorflow::TensorShapeProto& shape(int index) const;
-  ::tensorflow::TensorShapeProto* mutable_shape(int index);
-  ::tensorflow::TensorShapeProto* add_shape();
-  ::google::protobuf::RepeatedPtrField< ::tensorflow::TensorShapeProto >*
+  const ::opencv_tensorflow::TensorShapeProto& shape(int index) const;
+  ::opencv_tensorflow::TensorShapeProto* mutable_shape(int index);
+  ::opencv_tensorflow::TensorShapeProto* add_shape();
+  ::google::protobuf::RepeatedPtrField< ::opencv_tensorflow::TensorShapeProto >*
       mutable_shape();
-  const ::google::protobuf::RepeatedPtrField< ::tensorflow::TensorShapeProto >&
+  const ::google::protobuf::RepeatedPtrField< ::opencv_tensorflow::TensorShapeProto >&
       shape() const;
 
-  // repeated .tensorflow.TensorProto tensor = 8;
+  // repeated .opencv_tensorflow.TensorProto tensor = 8;
   int tensor_size() const;
   void clear_tensor();
   static const int kTensorFieldNumber = 8;
-  const ::tensorflow::TensorProto& tensor(int index) const;
-  ::tensorflow::TensorProto* mutable_tensor(int index);
-  ::tensorflow::TensorProto* add_tensor();
-  ::google::protobuf::RepeatedPtrField< ::tensorflow::TensorProto >*
+  const ::opencv_tensorflow::TensorProto& tensor(int index) const;
+  ::opencv_tensorflow::TensorProto* mutable_tensor(int index);
+  ::opencv_tensorflow::TensorProto* add_tensor();
+  ::google::protobuf::RepeatedPtrField< ::opencv_tensorflow::TensorProto >*
       mutable_tensor();
-  const ::google::protobuf::RepeatedPtrField< ::tensorflow::TensorProto >&
+  const ::google::protobuf::RepeatedPtrField< ::opencv_tensorflow::TensorProto >&
       tensor() const;
 
-  // @@protoc_insertion_point(class_scope:tensorflow.AttrValue.ListValue)
+  // @@protoc_insertion_point(class_scope:opencv_tensorflow.AttrValue.ListValue)
  private:
 
   ::google::protobuf::internal::InternalMetadataWithArena _internal_metadata_;
@@ -277,15 +277,15 @@ class AttrValue_ListValue : public ::google::protobuf::Message /* @@protoc_inser
   mutable int _b_cached_byte_size_;
   ::google::protobuf::RepeatedField<int> type_;
   mutable int _type_cached_byte_size_;
-  ::google::protobuf::RepeatedPtrField< ::tensorflow::TensorShapeProto > shape_;
-  ::google::protobuf::RepeatedPtrField< ::tensorflow::TensorProto > tensor_;
+  ::google::protobuf::RepeatedPtrField< ::opencv_tensorflow::TensorShapeProto > shape_;
+  ::google::protobuf::RepeatedPtrField< ::opencv_tensorflow::TensorProto > tensor_;
   mutable int _cached_size_;
   friend struct ::protobuf_attr_5fvalue_2eproto::TableStruct;
   friend void ::protobuf_attr_5fvalue_2eproto::InitDefaultsAttrValue_ListValueImpl();
 };
 // -------------------------------------------------------------------
 
-class AttrValue : public ::google::protobuf::Message /* @@protoc_insertion_point(class_definition:tensorflow.AttrValue) */ {
+class AttrValue : public ::google::protobuf::Message /* @@protoc_insertion_point(class_definition:opencv_tensorflow.AttrValue) */ {
  public:
   AttrValue();
   virtual ~AttrValue();
@@ -448,74 +448,74 @@ class AttrValue : public ::google::protobuf::Message /* @@protoc_insertion_point
   bool b() const;
   void set_b(bool value);
 
-  // .tensorflow.DataType type = 6;
+  // .opencv_tensorflow.DataType type = 6;
   private:
   bool has_type() const;
   public:
   void clear_type();
   static const int kTypeFieldNumber = 6;
-  ::tensorflow::DataType type() const;
-  void set_type(::tensorflow::DataType value);
+  ::opencv_tensorflow::DataType type() const;
+  void set_type(::opencv_tensorflow::DataType value);
 
-  // .tensorflow.TensorShapeProto shape = 7;
+  // .opencv_tensorflow.TensorShapeProto shape = 7;
   bool has_shape() const;
   void clear_shape();
   static const int kShapeFieldNumber = 7;
   private:
   void _slow_mutable_shape();
   public:
-  const ::tensorflow::TensorShapeProto& shape() const;
-  ::tensorflow::TensorShapeProto* release_shape();
-  ::tensorflow::TensorShapeProto* mutable_shape();
-  void set_allocated_shape(::tensorflow::TensorShapeProto* shape);
+  const ::opencv_tensorflow::TensorShapeProto& shape() const;
+  ::opencv_tensorflow::TensorShapeProto* release_shape();
+  ::opencv_tensorflow::TensorShapeProto* mutable_shape();
+  void set_allocated_shape(::opencv_tensorflow::TensorShapeProto* shape);
   void unsafe_arena_set_allocated_shape(
-      ::tensorflow::TensorShapeProto* shape);
-  ::tensorflow::TensorShapeProto* unsafe_arena_release_shape();
+      ::opencv_tensorflow::TensorShapeProto* shape);
+  ::opencv_tensorflow::TensorShapeProto* unsafe_arena_release_shape();
 
-  // .tensorflow.TensorProto tensor = 8;
+  // .opencv_tensorflow.TensorProto tensor = 8;
   bool has_tensor() const;
   void clear_tensor();
   static const int kTensorFieldNumber = 8;
   private:
   void _slow_mutable_tensor();
   public:
-  const ::tensorflow::TensorProto& tensor() const;
-  ::tensorflow::TensorProto* release_tensor();
-  ::tensorflow::TensorProto* mutable_tensor();
-  void set_allocated_tensor(::tensorflow::TensorProto* tensor);
+  const ::opencv_tensorflow::TensorProto& tensor() const;
+  ::opencv_tensorflow::TensorProto* release_tensor();
+  ::opencv_tensorflow::TensorProto* mutable_tensor();
+  void set_allocated_tensor(::opencv_tensorflow::TensorProto* tensor);
   void unsafe_arena_set_allocated_tensor(
-      ::tensorflow::TensorProto* tensor);
-  ::tensorflow::TensorProto* unsafe_arena_release_tensor();
+      ::opencv_tensorflow::TensorProto* tensor);
+  ::opencv_tensorflow::TensorProto* unsafe_arena_release_tensor();
 
-  // .tensorflow.AttrValue.ListValue list = 1;
+  // .opencv_tensorflow.AttrValue.ListValue list = 1;
   bool has_list() const;
   void clear_list();
   static const int kListFieldNumber = 1;
   private:
   void _slow_mutable_list();
   public:
-  const ::tensorflow::AttrValue_ListValue& list() const;
-  ::tensorflow::AttrValue_ListValue* release_list();
-  ::tensorflow::AttrValue_ListValue* mutable_list();
-  void set_allocated_list(::tensorflow::AttrValue_ListValue* list);
+  const ::opencv_tensorflow::AttrValue_ListValue& list() const;
+  ::opencv_tensorflow::AttrValue_ListValue* release_list();
+  ::opencv_tensorflow::AttrValue_ListValue* mutable_list();
+  void set_allocated_list(::opencv_tensorflow::AttrValue_ListValue* list);
   void unsafe_arena_set_allocated_list(
-      ::tensorflow::AttrValue_ListValue* list);
-  ::tensorflow::AttrValue_ListValue* unsafe_arena_release_list();
+      ::opencv_tensorflow::AttrValue_ListValue* list);
+  ::opencv_tensorflow::AttrValue_ListValue* unsafe_arena_release_list();
 
-  // .tensorflow.NameAttrList func = 10;
+  // .opencv_tensorflow.NameAttrList func = 10;
   bool has_func() const;
   void clear_func();
   static const int kFuncFieldNumber = 10;
   private:
   void _slow_mutable_func();
   public:
-  const ::tensorflow::NameAttrList& func() const;
-  ::tensorflow::NameAttrList* release_func();
-  ::tensorflow::NameAttrList* mutable_func();
-  void set_allocated_func(::tensorflow::NameAttrList* func);
+  const ::opencv_tensorflow::NameAttrList& func() const;
+  ::opencv_tensorflow::NameAttrList* release_func();
+  ::opencv_tensorflow::NameAttrList* mutable_func();
+  void set_allocated_func(::opencv_tensorflow::NameAttrList* func);
   void unsafe_arena_set_allocated_func(
-      ::tensorflow::NameAttrList* func);
-  ::tensorflow::NameAttrList* unsafe_arena_release_func();
+      ::opencv_tensorflow::NameAttrList* func);
+  ::opencv_tensorflow::NameAttrList* unsafe_arena_release_func();
 
   // string placeholder = 9;
   private:
@@ -544,7 +544,7 @@ class AttrValue : public ::google::protobuf::Message /* @@protoc_insertion_point
       ::std::string* placeholder);
 
   ValueCase value_case() const;
-  // @@protoc_insertion_point(class_scope:tensorflow.AttrValue)
+  // @@protoc_insertion_point(class_scope:opencv_tensorflow.AttrValue)
  private:
   void set_has_s();
   void set_has_i();
@@ -572,10 +572,10 @@ class AttrValue : public ::google::protobuf::Message /* @@protoc_insertion_point
     float f_;
     bool b_;
     int type_;
-    ::tensorflow::TensorShapeProto* shape_;
-    ::tensorflow::TensorProto* tensor_;
-    ::tensorflow::AttrValue_ListValue* list_;
-    ::tensorflow::NameAttrList* func_;
+    ::opencv_tensorflow::TensorShapeProto* shape_;
+    ::opencv_tensorflow::TensorProto* tensor_;
+    ::opencv_tensorflow::AttrValue_ListValue* list_;
+    ::opencv_tensorflow::NameAttrList* func_;
     ::google::protobuf::internal::ArenaStringPtr placeholder_;
   } value_;
   mutable int _cached_size_;
@@ -587,13 +587,13 @@ class AttrValue : public ::google::protobuf::Message /* @@protoc_insertion_point
 // -------------------------------------------------------------------
 
 class NameAttrList_AttrEntry_DoNotUse : public ::google::protobuf::internal::MapEntry<NameAttrList_AttrEntry_DoNotUse,
-    ::std::string, ::tensorflow::AttrValue,
+    ::std::string, ::opencv_tensorflow::AttrValue,
     ::google::protobuf::internal::WireFormatLite::TYPE_STRING,
     ::google::protobuf::internal::WireFormatLite::TYPE_MESSAGE,
     0 > {
 public:
   typedef ::google::protobuf::internal::MapEntry<NameAttrList_AttrEntry_DoNotUse,
-    ::std::string, ::tensorflow::AttrValue,
+    ::std::string, ::opencv_tensorflow::AttrValue,
     ::google::protobuf::internal::WireFormatLite::TYPE_STRING,
     ::google::protobuf::internal::WireFormatLite::TYPE_MESSAGE,
     0 > SuperType;
@@ -607,7 +607,7 @@ public:
 
 // -------------------------------------------------------------------
 
-class NameAttrList : public ::google::protobuf::Message /* @@protoc_insertion_point(class_definition:tensorflow.NameAttrList) */ {
+class NameAttrList : public ::google::protobuf::Message /* @@protoc_insertion_point(class_definition:opencv_tensorflow.NameAttrList) */ {
  public:
   NameAttrList();
   virtual ~NameAttrList();
@@ -702,13 +702,13 @@ class NameAttrList : public ::google::protobuf::Message /* @@protoc_insertion_po
 
   // accessors -------------------------------------------------------
 
-  // map<string, .tensorflow.AttrValue> attr = 2;
+  // map<string, .opencv_tensorflow.AttrValue> attr = 2;
   int attr_size() const;
   void clear_attr();
   static const int kAttrFieldNumber = 2;
-  const ::google::protobuf::Map< ::std::string, ::tensorflow::AttrValue >&
+  const ::google::protobuf::Map< ::std::string, ::opencv_tensorflow::AttrValue >&
       attr() const;
-  ::google::protobuf::Map< ::std::string, ::tensorflow::AttrValue >*
+  ::google::protobuf::Map< ::std::string, ::opencv_tensorflow::AttrValue >*
       mutable_attr();
 
   // string name = 1;
@@ -734,7 +734,7 @@ class NameAttrList : public ::google::protobuf::Message /* @@protoc_insertion_po
   void unsafe_arena_set_allocated_name(
       ::std::string* name);
 
-  // @@protoc_insertion_point(class_scope:tensorflow.NameAttrList)
+  // @@protoc_insertion_point(class_scope:opencv_tensorflow.NameAttrList)
  private:
 
   ::google::protobuf::internal::InternalMetadataWithArena _internal_metadata_;
@@ -743,7 +743,7 @@ class NameAttrList : public ::google::protobuf::Message /* @@protoc_insertion_po
   typedef void DestructorSkippable_;
   ::google::protobuf::internal::MapField<
       NameAttrList_AttrEntry_DoNotUse,
-      ::std::string, ::tensorflow::AttrValue,
+      ::std::string, ::opencv_tensorflow::AttrValue,
       ::google::protobuf::internal::WireFormatLite::TYPE_STRING,
       ::google::protobuf::internal::WireFormatLite::TYPE_MESSAGE,
       0 > attr_;
@@ -771,64 +771,64 @@ inline void AttrValue_ListValue::clear_s() {
   s_.Clear();
 }
 inline const ::std::string& AttrValue_ListValue::s(int index) const {
-  // @@protoc_insertion_point(field_get:tensorflow.AttrValue.ListValue.s)
+  // @@protoc_insertion_point(field_get:opencv_tensorflow.AttrValue.ListValue.s)
   return s_.Get(index);
 }
 inline ::std::string* AttrValue_ListValue::mutable_s(int index) {
-  // @@protoc_insertion_point(field_mutable:tensorflow.AttrValue.ListValue.s)
+  // @@protoc_insertion_point(field_mutable:opencv_tensorflow.AttrValue.ListValue.s)
   return s_.Mutable(index);
 }
 inline void AttrValue_ListValue::set_s(int index, const ::std::string& value) {
-  // @@protoc_insertion_point(field_set:tensorflow.AttrValue.ListValue.s)
+  // @@protoc_insertion_point(field_set:opencv_tensorflow.AttrValue.ListValue.s)
   s_.Mutable(index)->assign(value);
 }
 #if LANG_CXX11
 inline void AttrValue_ListValue::set_s(int index, ::std::string&& value) {
-  // @@protoc_insertion_point(field_set:tensorflow.AttrValue.ListValue.s)
+  // @@protoc_insertion_point(field_set:opencv_tensorflow.AttrValue.ListValue.s)
   s_.Mutable(index)->assign(std::move(value));
 }
 #endif
 inline void AttrValue_ListValue::set_s(int index, const char* value) {
   GOOGLE_DCHECK(value != NULL);
   s_.Mutable(index)->assign(value);
-  // @@protoc_insertion_point(field_set_char:tensorflow.AttrValue.ListValue.s)
+  // @@protoc_insertion_point(field_set_char:opencv_tensorflow.AttrValue.ListValue.s)
 }
 inline void AttrValue_ListValue::set_s(int index, const void* value, size_t size) {
   s_.Mutable(index)->assign(
     reinterpret_cast<const char*>(value), size);
-  // @@protoc_insertion_point(field_set_pointer:tensorflow.AttrValue.ListValue.s)
+  // @@protoc_insertion_point(field_set_pointer:opencv_tensorflow.AttrValue.ListValue.s)
 }
 inline ::std::string* AttrValue_ListValue::add_s() {
-  // @@protoc_insertion_point(field_add_mutable:tensorflow.AttrValue.ListValue.s)
+  // @@protoc_insertion_point(field_add_mutable:opencv_tensorflow.AttrValue.ListValue.s)
   return s_.Add();
 }
 inline void AttrValue_ListValue::add_s(const ::std::string& value) {
   s_.Add()->assign(value);
-  // @@protoc_insertion_point(field_add:tensorflow.AttrValue.ListValue.s)
+  // @@protoc_insertion_point(field_add:opencv_tensorflow.AttrValue.ListValue.s)
 }
 #if LANG_CXX11
 inline void AttrValue_ListValue::add_s(::std::string&& value) {
   s_.Add(std::move(value));
-  // @@protoc_insertion_point(field_add:tensorflow.AttrValue.ListValue.s)
+  // @@protoc_insertion_point(field_add:opencv_tensorflow.AttrValue.ListValue.s)
 }
 #endif
 inline void AttrValue_ListValue::add_s(const char* value) {
   GOOGLE_DCHECK(value != NULL);
   s_.Add()->assign(value);
-  // @@protoc_insertion_point(field_add_char:tensorflow.AttrValue.ListValue.s)
+  // @@protoc_insertion_point(field_add_char:opencv_tensorflow.AttrValue.ListValue.s)
 }
 inline void AttrValue_ListValue::add_s(const void* value, size_t size) {
   s_.Add()->assign(reinterpret_cast<const char*>(value), size);
-  // @@protoc_insertion_point(field_add_pointer:tensorflow.AttrValue.ListValue.s)
+  // @@protoc_insertion_point(field_add_pointer:opencv_tensorflow.AttrValue.ListValue.s)
 }
 inline const ::google::protobuf::RepeatedPtrField< ::std::string>&
 AttrValue_ListValue::s() const {
-  // @@protoc_insertion_point(field_list:tensorflow.AttrValue.ListValue.s)
+  // @@protoc_insertion_point(field_list:opencv_tensorflow.AttrValue.ListValue.s)
   return s_;
 }
 inline ::google::protobuf::RepeatedPtrField< ::std::string>*
 AttrValue_ListValue::mutable_s() {
-  // @@protoc_insertion_point(field_mutable_list:tensorflow.AttrValue.ListValue.s)
+  // @@protoc_insertion_point(field_mutable_list:opencv_tensorflow.AttrValue.ListValue.s)
   return &s_;
 }
 
@@ -840,25 +840,25 @@ inline void AttrValue_ListValue::clear_i() {
   i_.Clear();
 }
 inline ::google::protobuf::int64 AttrValue_ListValue::i(int index) const {
-  // @@protoc_insertion_point(field_get:tensorflow.AttrValue.ListValue.i)
+  // @@protoc_insertion_point(field_get:opencv_tensorflow.AttrValue.ListValue.i)
   return i_.Get(index);
 }
 inline void AttrValue_ListValue::set_i(int index, ::google::protobuf::int64 value) {
   i_.Set(index, value);
-  // @@protoc_insertion_point(field_set:tensorflow.AttrValue.ListValue.i)
+  // @@protoc_insertion_point(field_set:opencv_tensorflow.AttrValue.ListValue.i)
 }
 inline void AttrValue_ListValue::add_i(::google::protobuf::int64 value) {
   i_.Add(value);
-  // @@protoc_insertion_point(field_add:tensorflow.AttrValue.ListValue.i)
+  // @@protoc_insertion_point(field_add:opencv_tensorflow.AttrValue.ListValue.i)
 }
 inline const ::google::protobuf::RepeatedField< ::google::protobuf::int64 >&
 AttrValue_ListValue::i() const {
-  // @@protoc_insertion_point(field_list:tensorflow.AttrValue.ListValue.i)
+  // @@protoc_insertion_point(field_list:opencv_tensorflow.AttrValue.ListValue.i)
   return i_;
 }
 inline ::google::protobuf::RepeatedField< ::google::protobuf::int64 >*
 AttrValue_ListValue::mutable_i() {
-  // @@protoc_insertion_point(field_mutable_list:tensorflow.AttrValue.ListValue.i)
+  // @@protoc_insertion_point(field_mutable_list:opencv_tensorflow.AttrValue.ListValue.i)
   return &i_;
 }
 
@@ -870,25 +870,25 @@ inline void AttrValue_ListValue::clear_f() {
   f_.Clear();
 }
 inline float AttrValue_ListValue::f(int index) const {
-  // @@protoc_insertion_point(field_get:tensorflow.AttrValue.ListValue.f)
+  // @@protoc_insertion_point(field_get:opencv_tensorflow.AttrValue.ListValue.f)
   return f_.Get(index);
 }
 inline void AttrValue_ListValue::set_f(int index, float value) {
   f_.Set(index, value);
-  // @@protoc_insertion_point(field_set:tensorflow.AttrValue.ListValue.f)
+  // @@protoc_insertion_point(field_set:opencv_tensorflow.AttrValue.ListValue.f)
 }
 inline void AttrValue_ListValue::add_f(float value) {
   f_.Add(value);
-  // @@protoc_insertion_point(field_add:tensorflow.AttrValue.ListValue.f)
+  // @@protoc_insertion_point(field_add:opencv_tensorflow.AttrValue.ListValue.f)
 }
 inline const ::google::protobuf::RepeatedField< float >&
 AttrValue_ListValue::f() const {
-  // @@protoc_insertion_point(field_list:tensorflow.AttrValue.ListValue.f)
+  // @@protoc_insertion_point(field_list:opencv_tensorflow.AttrValue.ListValue.f)
   return f_;
 }
 inline ::google::protobuf::RepeatedField< float >*
 AttrValue_ListValue::mutable_f() {
-  // @@protoc_insertion_point(field_mutable_list:tensorflow.AttrValue.ListValue.f)
+  // @@protoc_insertion_point(field_mutable_list:opencv_tensorflow.AttrValue.ListValue.f)
   return &f_;
 }
 
@@ -900,109 +900,109 @@ inline void AttrValue_ListValue::clear_b() {
   b_.Clear();
 }
 inline bool AttrValue_ListValue::b(int index) const {
-  // @@protoc_insertion_point(field_get:tensorflow.AttrValue.ListValue.b)
+  // @@protoc_insertion_point(field_get:opencv_tensorflow.AttrValue.ListValue.b)
   return b_.Get(index);
 }
 inline void AttrValue_ListValue::set_b(int index, bool value) {
   b_.Set(index, value);
-  // @@protoc_insertion_point(field_set:tensorflow.AttrValue.ListValue.b)
+  // @@protoc_insertion_point(field_set:opencv_tensorflow.AttrValue.ListValue.b)
 }
 inline void AttrValue_ListValue::add_b(bool value) {
   b_.Add(value);
-  // @@protoc_insertion_point(field_add:tensorflow.AttrValue.ListValue.b)
+  // @@protoc_insertion_point(field_add:opencv_tensorflow.AttrValue.ListValue.b)
 }
 inline const ::google::protobuf::RepeatedField< bool >&
 AttrValue_ListValue::b() const {
-  // @@protoc_insertion_point(field_list:tensorflow.AttrValue.ListValue.b)
+  // @@protoc_insertion_point(field_list:opencv_tensorflow.AttrValue.ListValue.b)
   return b_;
 }
 inline ::google::protobuf::RepeatedField< bool >*
 AttrValue_ListValue::mutable_b() {
-  // @@protoc_insertion_point(field_mutable_list:tensorflow.AttrValue.ListValue.b)
+  // @@protoc_insertion_point(field_mutable_list:opencv_tensorflow.AttrValue.ListValue.b)
   return &b_;
 }
 
-// repeated .tensorflow.DataType type = 6 [packed = true];
+// repeated .opencv_tensorflow.DataType type = 6 [packed = true];
 inline int AttrValue_ListValue::type_size() const {
   return type_.size();
 }
 inline void AttrValue_ListValue::clear_type() {
   type_.Clear();
 }
-inline ::tensorflow::DataType AttrValue_ListValue::type(int index) const {
-  // @@protoc_insertion_point(field_get:tensorflow.AttrValue.ListValue.type)
-  return static_cast< ::tensorflow::DataType >(type_.Get(index));
+inline ::opencv_tensorflow::DataType AttrValue_ListValue::type(int index) const {
+  // @@protoc_insertion_point(field_get:opencv_tensorflow.AttrValue.ListValue.type)
+  return static_cast< ::opencv_tensorflow::DataType >(type_.Get(index));
 }
-inline void AttrValue_ListValue::set_type(int index, ::tensorflow::DataType value) {
+inline void AttrValue_ListValue::set_type(int index, ::opencv_tensorflow::DataType value) {
   type_.Set(index, value);
-  // @@protoc_insertion_point(field_set:tensorflow.AttrValue.ListValue.type)
+  // @@protoc_insertion_point(field_set:opencv_tensorflow.AttrValue.ListValue.type)
 }
-inline void AttrValue_ListValue::add_type(::tensorflow::DataType value) {
+inline void AttrValue_ListValue::add_type(::opencv_tensorflow::DataType value) {
   type_.Add(value);
-  // @@protoc_insertion_point(field_add:tensorflow.AttrValue.ListValue.type)
+  // @@protoc_insertion_point(field_add:opencv_tensorflow.AttrValue.ListValue.type)
 }
 inline const ::google::protobuf::RepeatedField<int>&
 AttrValue_ListValue::type() const {
-  // @@protoc_insertion_point(field_list:tensorflow.AttrValue.ListValue.type)
+  // @@protoc_insertion_point(field_list:opencv_tensorflow.AttrValue.ListValue.type)
   return type_;
 }
 inline ::google::protobuf::RepeatedField<int>*
 AttrValue_ListValue::mutable_type() {
-  // @@protoc_insertion_point(field_mutable_list:tensorflow.AttrValue.ListValue.type)
+  // @@protoc_insertion_point(field_mutable_list:opencv_tensorflow.AttrValue.ListValue.type)
   return &type_;
 }
 
-// repeated .tensorflow.TensorShapeProto shape = 7;
+// repeated .opencv_tensorflow.TensorShapeProto shape = 7;
 inline int AttrValue_ListValue::shape_size() const {
   return shape_.size();
 }
-inline const ::tensorflow::TensorShapeProto& AttrValue_ListValue::shape(int index) const {
-  // @@protoc_insertion_point(field_get:tensorflow.AttrValue.ListValue.shape)
+inline const ::opencv_tensorflow::TensorShapeProto& AttrValue_ListValue::shape(int index) const {
+  // @@protoc_insertion_point(field_get:opencv_tensorflow.AttrValue.ListValue.shape)
   return shape_.Get(index);
 }
-inline ::tensorflow::TensorShapeProto* AttrValue_ListValue::mutable_shape(int index) {
-  // @@protoc_insertion_point(field_mutable:tensorflow.AttrValue.ListValue.shape)
+inline ::opencv_tensorflow::TensorShapeProto* AttrValue_ListValue::mutable_shape(int index) {
+  // @@protoc_insertion_point(field_mutable:opencv_tensorflow.AttrValue.ListValue.shape)
   return shape_.Mutable(index);
 }
-inline ::tensorflow::TensorShapeProto* AttrValue_ListValue::add_shape() {
-  // @@protoc_insertion_point(field_add:tensorflow.AttrValue.ListValue.shape)
+inline ::opencv_tensorflow::TensorShapeProto* AttrValue_ListValue::add_shape() {
+  // @@protoc_insertion_point(field_add:opencv_tensorflow.AttrValue.ListValue.shape)
   return shape_.Add();
 }
-inline ::google::protobuf::RepeatedPtrField< ::tensorflow::TensorShapeProto >*
+inline ::google::protobuf::RepeatedPtrField< ::opencv_tensorflow::TensorShapeProto >*
 AttrValue_ListValue::mutable_shape() {
-  // @@protoc_insertion_point(field_mutable_list:tensorflow.AttrValue.ListValue.shape)
+  // @@protoc_insertion_point(field_mutable_list:opencv_tensorflow.AttrValue.ListValue.shape)
   return &shape_;
 }
-inline const ::google::protobuf::RepeatedPtrField< ::tensorflow::TensorShapeProto >&
+inline const ::google::protobuf::RepeatedPtrField< ::opencv_tensorflow::TensorShapeProto >&
 AttrValue_ListValue::shape() const {
-  // @@protoc_insertion_point(field_list:tensorflow.AttrValue.ListValue.shape)
+  // @@protoc_insertion_point(field_list:opencv_tensorflow.AttrValue.ListValue.shape)
   return shape_;
 }
 
-// repeated .tensorflow.TensorProto tensor = 8;
+// repeated .opencv_tensorflow.TensorProto tensor = 8;
 inline int AttrValue_ListValue::tensor_size() const {
   return tensor_.size();
 }
-inline const ::tensorflow::TensorProto& AttrValue_ListValue::tensor(int index) const {
-  // @@protoc_insertion_point(field_get:tensorflow.AttrValue.ListValue.tensor)
+inline const ::opencv_tensorflow::TensorProto& AttrValue_ListValue::tensor(int index) const {
+  // @@protoc_insertion_point(field_get:opencv_tensorflow.AttrValue.ListValue.tensor)
   return tensor_.Get(index);
 }
-inline ::tensorflow::TensorProto* AttrValue_ListValue::mutable_tensor(int index) {
-  // @@protoc_insertion_point(field_mutable:tensorflow.AttrValue.ListValue.tensor)
+inline ::opencv_tensorflow::TensorProto* AttrValue_ListValue::mutable_tensor(int index) {
+  // @@protoc_insertion_point(field_mutable:opencv_tensorflow.AttrValue.ListValue.tensor)
   return tensor_.Mutable(index);
 }
-inline ::tensorflow::TensorProto* AttrValue_ListValue::add_tensor() {
-  // @@protoc_insertion_point(field_add:tensorflow.AttrValue.ListValue.tensor)
+inline ::opencv_tensorflow::TensorProto* AttrValue_ListValue::add_tensor() {
+  // @@protoc_insertion_point(field_add:opencv_tensorflow.AttrValue.ListValue.tensor)
   return tensor_.Add();
 }
-inline ::google::protobuf::RepeatedPtrField< ::tensorflow::TensorProto >*
+inline ::google::protobuf::RepeatedPtrField< ::opencv_tensorflow::TensorProto >*
 AttrValue_ListValue::mutable_tensor() {
-  // @@protoc_insertion_point(field_mutable_list:tensorflow.AttrValue.ListValue.tensor)
+  // @@protoc_insertion_point(field_mutable_list:opencv_tensorflow.AttrValue.ListValue.tensor)
   return &tensor_;
 }
-inline const ::google::protobuf::RepeatedPtrField< ::tensorflow::TensorProto >&
+inline const ::google::protobuf::RepeatedPtrField< ::opencv_tensorflow::TensorProto >&
 AttrValue_ListValue::tensor() const {
-  // @@protoc_insertion_point(field_list:tensorflow.AttrValue.ListValue.tensor)
+  // @@protoc_insertion_point(field_list:opencv_tensorflow.AttrValue.ListValue.tensor)
   return tensor_;
 }
 
@@ -1025,7 +1025,7 @@ inline void AttrValue::clear_s() {
   }
 }
 inline const ::std::string& AttrValue::s() const {
-  // @@protoc_insertion_point(field_get:tensorflow.AttrValue.s)
+  // @@protoc_insertion_point(field_get:opencv_tensorflow.AttrValue.s)
   if (has_s()) {
     return value_.s_.Get();
   }
@@ -1039,11 +1039,11 @@ inline void AttrValue::set_s(const ::std::string& value) {
   }
   value_.s_.Set(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), value,
       GetArenaNoVirtual());
-  // @@protoc_insertion_point(field_set:tensorflow.AttrValue.s)
+  // @@protoc_insertion_point(field_set:opencv_tensorflow.AttrValue.s)
 }
 #if LANG_CXX11
 inline void AttrValue::set_s(::std::string&& value) {
-  // @@protoc_insertion_point(field_set:tensorflow.AttrValue.s)
+  // @@protoc_insertion_point(field_set:opencv_tensorflow.AttrValue.s)
   if (!has_s()) {
     clear_value();
     set_has_s();
@@ -1051,7 +1051,7 @@ inline void AttrValue::set_s(::std::string&& value) {
   }
   value_.s_.Set(
     &::google::protobuf::internal::GetEmptyStringAlreadyInited(), ::std::move(value), GetArenaNoVirtual());
-  // @@protoc_insertion_point(field_set_rvalue:tensorflow.AttrValue.s)
+  // @@protoc_insertion_point(field_set_rvalue:opencv_tensorflow.AttrValue.s)
 }
 #endif
 inline void AttrValue::set_s(const char* value) {
@@ -1063,7 +1063,7 @@ inline void AttrValue::set_s(const char* value) {
   }
   value_.s_.Set(&::google::protobuf::internal::GetEmptyStringAlreadyInited(),
       ::std::string(value), GetArenaNoVirtual());
-  // @@protoc_insertion_point(field_set_char:tensorflow.AttrValue.s)
+  // @@protoc_insertion_point(field_set_char:opencv_tensorflow.AttrValue.s)
 }
 inline void AttrValue::set_s(const void* value,
                              size_t size) {
@@ -1076,7 +1076,7 @@ inline void AttrValue::set_s(const void* value,
       &::google::protobuf::internal::GetEmptyStringAlreadyInited(), ::std::string(
       reinterpret_cast<const char*>(value), size),
       GetArenaNoVirtual());
-  // @@protoc_insertion_point(field_set_pointer:tensorflow.AttrValue.s)
+  // @@protoc_insertion_point(field_set_pointer:opencv_tensorflow.AttrValue.s)
 }
 inline ::std::string* AttrValue::mutable_s() {
   if (!has_s()) {
@@ -1086,10 +1086,10 @@ inline ::std::string* AttrValue::mutable_s() {
   }
   return value_.s_.Mutable(&::google::protobuf::internal::GetEmptyStringAlreadyInited(),
       GetArenaNoVirtual());
-  // @@protoc_insertion_point(field_mutable:tensorflow.AttrValue.s)
+  // @@protoc_insertion_point(field_mutable:opencv_tensorflow.AttrValue.s)
 }
 inline ::std::string* AttrValue::release_s() {
-  // @@protoc_insertion_point(field_release:tensorflow.AttrValue.s)
+  // @@protoc_insertion_point(field_release:opencv_tensorflow.AttrValue.s)
   if (has_s()) {
     clear_has_value();
     return value_.s_.Release(&::google::protobuf::internal::GetEmptyStringAlreadyInited(),
@@ -1108,10 +1108,10 @@ inline void AttrValue::set_allocated_s(::std::string* s) {
     value_.s_.SetAllocated(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), s,
         GetArenaNoVirtual());
   }
-  // @@protoc_insertion_point(field_set_allocated:tensorflow.AttrValue.s)
+  // @@protoc_insertion_point(field_set_allocated:opencv_tensorflow.AttrValue.s)
 }
 inline ::std::string* AttrValue::unsafe_arena_release_s() {
-  // @@protoc_insertion_point(field_unsafe_arena_release:tensorflow.AttrValue.s)
+  // @@protoc_insertion_point(field_unsafe_arena_release:opencv_tensorflow.AttrValue.s)
   GOOGLE_DCHECK(GetArenaNoVirtual() != NULL);
   if (has_s()) {
     clear_has_value();
@@ -1131,7 +1131,7 @@ inline void AttrValue::unsafe_arena_set_allocated_s(::std::string* s) {
     set_has_s();
     value_.s_.UnsafeArenaSetAllocated(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), s, GetArenaNoVirtual());
   }
-  // @@protoc_insertion_point(field_unsafe_arena_set_allocated:tensorflow.AttrValue.s)
+  // @@protoc_insertion_point(field_unsafe_arena_set_allocated:opencv_tensorflow.AttrValue.s)
 }
 
 // int64 i = 3;
@@ -1148,7 +1148,7 @@ inline void AttrValue::clear_i() {
   }
 }
 inline ::google::protobuf::int64 AttrValue::i() const {
-  // @@protoc_insertion_point(field_get:tensorflow.AttrValue.i)
+  // @@protoc_insertion_point(field_get:opencv_tensorflow.AttrValue.i)
   if (has_i()) {
     return value_.i_;
   }
@@ -1160,7 +1160,7 @@ inline void AttrValue::set_i(::google::protobuf::int64 value) {
     set_has_i();
   }
   value_.i_ = value;
-  // @@protoc_insertion_point(field_set:tensorflow.AttrValue.i)
+  // @@protoc_insertion_point(field_set:opencv_tensorflow.AttrValue.i)
 }
 
 // float f = 4;
@@ -1177,7 +1177,7 @@ inline void AttrValue::clear_f() {
   }
 }
 inline float AttrValue::f() const {
-  // @@protoc_insertion_point(field_get:tensorflow.AttrValue.f)
+  // @@protoc_insertion_point(field_get:opencv_tensorflow.AttrValue.f)
   if (has_f()) {
     return value_.f_;
   }
@@ -1189,7 +1189,7 @@ inline void AttrValue::set_f(float value) {
     set_has_f();
   }
   value_.f_ = value;
-  // @@protoc_insertion_point(field_set:tensorflow.AttrValue.f)
+  // @@protoc_insertion_point(field_set:opencv_tensorflow.AttrValue.f)
 }
 
 // bool b = 5;
@@ -1206,7 +1206,7 @@ inline void AttrValue::clear_b() {
   }
 }
 inline bool AttrValue::b() const {
-  // @@protoc_insertion_point(field_get:tensorflow.AttrValue.b)
+  // @@protoc_insertion_point(field_get:opencv_tensorflow.AttrValue.b)
   if (has_b()) {
     return value_.b_;
   }
@@ -1218,10 +1218,10 @@ inline void AttrValue::set_b(bool value) {
     set_has_b();
   }
   value_.b_ = value;
-  // @@protoc_insertion_point(field_set:tensorflow.AttrValue.b)
+  // @@protoc_insertion_point(field_set:opencv_tensorflow.AttrValue.b)
 }
 
-// .tensorflow.DataType type = 6;
+// .opencv_tensorflow.DataType type = 6;
 inline bool AttrValue::has_type() const {
   return value_case() == kType;
 }
@@ -1234,34 +1234,34 @@ inline void AttrValue::clear_type() {
     clear_has_value();
   }
 }
-inline ::tensorflow::DataType AttrValue::type() const {
-  // @@protoc_insertion_point(field_get:tensorflow.AttrValue.type)
+inline ::opencv_tensorflow::DataType AttrValue::type() const {
+  // @@protoc_insertion_point(field_get:opencv_tensorflow.AttrValue.type)
   if (has_type()) {
-    return static_cast< ::tensorflow::DataType >(value_.type_);
+    return static_cast< ::opencv_tensorflow::DataType >(value_.type_);
   }
-  return static_cast< ::tensorflow::DataType >(0);
+  return static_cast< ::opencv_tensorflow::DataType >(0);
 }
-inline void AttrValue::set_type(::tensorflow::DataType value) {
+inline void AttrValue::set_type(::opencv_tensorflow::DataType value) {
   if (!has_type()) {
     clear_value();
     set_has_type();
   }
   value_.type_ = value;
-  // @@protoc_insertion_point(field_set:tensorflow.AttrValue.type)
+  // @@protoc_insertion_point(field_set:opencv_tensorflow.AttrValue.type)
 }
 
-// .tensorflow.TensorShapeProto shape = 7;
+// .opencv_tensorflow.TensorShapeProto shape = 7;
 inline bool AttrValue::has_shape() const {
   return value_case() == kShape;
 }
 inline void AttrValue::set_has_shape() {
   _oneof_case_[0] = kShape;
 }
-inline ::tensorflow::TensorShapeProto* AttrValue::release_shape() {
-  // @@protoc_insertion_point(field_release:tensorflow.AttrValue.shape)
+inline ::opencv_tensorflow::TensorShapeProto* AttrValue::release_shape() {
+  // @@protoc_insertion_point(field_release:opencv_tensorflow.AttrValue.shape)
   if (has_shape()) {
     clear_has_value();
-      ::tensorflow::TensorShapeProto* temp = value_.shape_;
+      ::opencv_tensorflow::TensorShapeProto* temp = value_.shape_;
     if (GetArenaNoVirtual() != NULL) {
       temp = ::google::protobuf::internal::DuplicateIfNonNull(temp, NULL);
     }
@@ -1271,55 +1271,55 @@ inline ::tensorflow::TensorShapeProto* AttrValue::release_shape() {
     return NULL;
   }
 }
-inline const ::tensorflow::TensorShapeProto& AttrValue::shape() const {
-  // @@protoc_insertion_point(field_get:tensorflow.AttrValue.shape)
+inline const ::opencv_tensorflow::TensorShapeProto& AttrValue::shape() const {
+  // @@protoc_insertion_point(field_get:opencv_tensorflow.AttrValue.shape)
   return has_shape()
       ? *value_.shape_
-      : *reinterpret_cast< ::tensorflow::TensorShapeProto*>(&::tensorflow::_TensorShapeProto_default_instance_);
+      : *reinterpret_cast< ::opencv_tensorflow::TensorShapeProto*>(&::opencv_tensorflow::_TensorShapeProto_default_instance_);
 }
-inline ::tensorflow::TensorShapeProto* AttrValue::unsafe_arena_release_shape() {
-  // @@protoc_insertion_point(field_unsafe_arena_release:tensorflow.AttrValue.shape)
+inline ::opencv_tensorflow::TensorShapeProto* AttrValue::unsafe_arena_release_shape() {
+  // @@protoc_insertion_point(field_unsafe_arena_release:opencv_tensorflow.AttrValue.shape)
   if (has_shape()) {
     clear_has_value();
-    ::tensorflow::TensorShapeProto* temp = value_.shape_;
+    ::opencv_tensorflow::TensorShapeProto* temp = value_.shape_;
     value_.shape_ = NULL;
     return temp;
   } else {
     return NULL;
   }
 }
-inline void AttrValue::unsafe_arena_set_allocated_shape(::tensorflow::TensorShapeProto* shape) {
+inline void AttrValue::unsafe_arena_set_allocated_shape(::opencv_tensorflow::TensorShapeProto* shape) {
   clear_value();
   if (shape) {
     set_has_shape();
     value_.shape_ = shape;
   }
-  // @@protoc_insertion_point(field_unsafe_arena_set_allocated:tensorflow.AttrValue.shape)
+  // @@protoc_insertion_point(field_unsafe_arena_set_allocated:opencv_tensorflow.AttrValue.shape)
 }
-inline ::tensorflow::TensorShapeProto* AttrValue::mutable_shape() {
+inline ::opencv_tensorflow::TensorShapeProto* AttrValue::mutable_shape() {
   if (!has_shape()) {
     clear_value();
     set_has_shape();
     value_.shape_ =
-      ::google::protobuf::Arena::CreateMessage< ::tensorflow::TensorShapeProto >(
+      ::google::protobuf::Arena::CreateMessage< ::opencv_tensorflow::TensorShapeProto >(
       GetArenaNoVirtual());
   }
-  // @@protoc_insertion_point(field_mutable:tensorflow.AttrValue.shape)
+  // @@protoc_insertion_point(field_mutable:opencv_tensorflow.AttrValue.shape)
   return value_.shape_;
 }
 
-// .tensorflow.TensorProto tensor = 8;
+// .opencv_tensorflow.TensorProto tensor = 8;
 inline bool AttrValue::has_tensor() const {
   return value_case() == kTensor;
 }
 inline void AttrValue::set_has_tensor() {
   _oneof_case_[0] = kTensor;
 }
-inline ::tensorflow::TensorProto* AttrValue::release_tensor() {
-  // @@protoc_insertion_point(field_release:tensorflow.AttrValue.tensor)
+inline ::opencv_tensorflow::TensorProto* AttrValue::release_tensor() {
+  // @@protoc_insertion_point(field_release:opencv_tensorflow.AttrValue.tensor)
   if (has_tensor()) {
     clear_has_value();
-      ::tensorflow::TensorProto* temp = value_.tensor_;
+      ::opencv_tensorflow::TensorProto* temp = value_.tensor_;
     if (GetArenaNoVirtual() != NULL) {
       temp = ::google::protobuf::internal::DuplicateIfNonNull(temp, NULL);
     }
@@ -1329,44 +1329,44 @@ inline ::tensorflow::TensorProto* AttrValue::release_tensor() {
     return NULL;
   }
 }
-inline const ::tensorflow::TensorProto& AttrValue::tensor() const {
-  // @@protoc_insertion_point(field_get:tensorflow.AttrValue.tensor)
+inline const ::opencv_tensorflow::TensorProto& AttrValue::tensor() const {
+  // @@protoc_insertion_point(field_get:opencv_tensorflow.AttrValue.tensor)
   return has_tensor()
       ? *value_.tensor_
-      : *reinterpret_cast< ::tensorflow::TensorProto*>(&::tensorflow::_TensorProto_default_instance_);
+      : *reinterpret_cast< ::opencv_tensorflow::TensorProto*>(&::opencv_tensorflow::_TensorProto_default_instance_);
 }
-inline ::tensorflow::TensorProto* AttrValue::unsafe_arena_release_tensor() {
-  // @@protoc_insertion_point(field_unsafe_arena_release:tensorflow.AttrValue.tensor)
+inline ::opencv_tensorflow::TensorProto* AttrValue::unsafe_arena_release_tensor() {
+  // @@protoc_insertion_point(field_unsafe_arena_release:opencv_tensorflow.AttrValue.tensor)
   if (has_tensor()) {
     clear_has_value();
-    ::tensorflow::TensorProto* temp = value_.tensor_;
+    ::opencv_tensorflow::TensorProto* temp = value_.tensor_;
     value_.tensor_ = NULL;
     return temp;
   } else {
     return NULL;
   }
 }
-inline void AttrValue::unsafe_arena_set_allocated_tensor(::tensorflow::TensorProto* tensor) {
+inline void AttrValue::unsafe_arena_set_allocated_tensor(::opencv_tensorflow::TensorProto* tensor) {
   clear_value();
   if (tensor) {
     set_has_tensor();
     value_.tensor_ = tensor;
   }
-  // @@protoc_insertion_point(field_unsafe_arena_set_allocated:tensorflow.AttrValue.tensor)
+  // @@protoc_insertion_point(field_unsafe_arena_set_allocated:opencv_tensorflow.AttrValue.tensor)
 }
-inline ::tensorflow::TensorProto* AttrValue::mutable_tensor() {
+inline ::opencv_tensorflow::TensorProto* AttrValue::mutable_tensor() {
   if (!has_tensor()) {
     clear_value();
     set_has_tensor();
     value_.tensor_ =
-      ::google::protobuf::Arena::CreateMessage< ::tensorflow::TensorProto >(
+      ::google::protobuf::Arena::CreateMessage< ::opencv_tensorflow::TensorProto >(
       GetArenaNoVirtual());
   }
-  // @@protoc_insertion_point(field_mutable:tensorflow.AttrValue.tensor)
+  // @@protoc_insertion_point(field_mutable:opencv_tensorflow.AttrValue.tensor)
   return value_.tensor_;
 }
 
-// .tensorflow.AttrValue.ListValue list = 1;
+// .opencv_tensorflow.AttrValue.ListValue list = 1;
 inline bool AttrValue::has_list() const {
   return value_case() == kList;
 }
@@ -1381,11 +1381,11 @@ inline void AttrValue::clear_list() {
     clear_has_value();
   }
 }
-inline ::tensorflow::AttrValue_ListValue* AttrValue::release_list() {
-  // @@protoc_insertion_point(field_release:tensorflow.AttrValue.list)
+inline ::opencv_tensorflow::AttrValue_ListValue* AttrValue::release_list() {
+  // @@protoc_insertion_point(field_release:opencv_tensorflow.AttrValue.list)
   if (has_list()) {
     clear_has_value();
-      ::tensorflow::AttrValue_ListValue* temp = value_.list_;
+      ::opencv_tensorflow::AttrValue_ListValue* temp = value_.list_;
     if (GetArenaNoVirtual() != NULL) {
       temp = ::google::protobuf::internal::DuplicateIfNonNull(temp, NULL);
     }
@@ -1395,44 +1395,44 @@ inline ::tensorflow::AttrValue_ListValue* AttrValue::release_list() {
     return NULL;
   }
 }
-inline const ::tensorflow::AttrValue_ListValue& AttrValue::list() const {
-  // @@protoc_insertion_point(field_get:tensorflow.AttrValue.list)
+inline const ::opencv_tensorflow::AttrValue_ListValue& AttrValue::list() const {
+  // @@protoc_insertion_point(field_get:opencv_tensorflow.AttrValue.list)
   return has_list()
       ? *value_.list_
-      : *reinterpret_cast< ::tensorflow::AttrValue_ListValue*>(&::tensorflow::_AttrValue_ListValue_default_instance_);
+      : *reinterpret_cast< ::opencv_tensorflow::AttrValue_ListValue*>(&::opencv_tensorflow::_AttrValue_ListValue_default_instance_);
 }
-inline ::tensorflow::AttrValue_ListValue* AttrValue::unsafe_arena_release_list() {
-  // @@protoc_insertion_point(field_unsafe_arena_release:tensorflow.AttrValue.list)
+inline ::opencv_tensorflow::AttrValue_ListValue* AttrValue::unsafe_arena_release_list() {
+  // @@protoc_insertion_point(field_unsafe_arena_release:opencv_tensorflow.AttrValue.list)
   if (has_list()) {
     clear_has_value();
-    ::tensorflow::AttrValue_ListValue* temp = value_.list_;
+    ::opencv_tensorflow::AttrValue_ListValue* temp = value_.list_;
     value_.list_ = NULL;
     return temp;
   } else {
     return NULL;
   }
 }
-inline void AttrValue::unsafe_arena_set_allocated_list(::tensorflow::AttrValue_ListValue* list) {
+inline void AttrValue::unsafe_arena_set_allocated_list(::opencv_tensorflow::AttrValue_ListValue* list) {
   clear_value();
   if (list) {
     set_has_list();
     value_.list_ = list;
   }
-  // @@protoc_insertion_point(field_unsafe_arena_set_allocated:tensorflow.AttrValue.list)
+  // @@protoc_insertion_point(field_unsafe_arena_set_allocated:opencv_tensorflow.AttrValue.list)
 }
-inline ::tensorflow::AttrValue_ListValue* AttrValue::mutable_list() {
+inline ::opencv_tensorflow::AttrValue_ListValue* AttrValue::mutable_list() {
   if (!has_list()) {
     clear_value();
     set_has_list();
     value_.list_ =
-      ::google::protobuf::Arena::CreateMessage< ::tensorflow::AttrValue_ListValue >(
+      ::google::protobuf::Arena::CreateMessage< ::opencv_tensorflow::AttrValue_ListValue >(
       GetArenaNoVirtual());
   }
-  // @@protoc_insertion_point(field_mutable:tensorflow.AttrValue.list)
+  // @@protoc_insertion_point(field_mutable:opencv_tensorflow.AttrValue.list)
   return value_.list_;
 }
 
-// .tensorflow.NameAttrList func = 10;
+// .opencv_tensorflow.NameAttrList func = 10;
 inline bool AttrValue::has_func() const {
   return value_case() == kFunc;
 }
@@ -1447,11 +1447,11 @@ inline void AttrValue::clear_func() {
     clear_has_value();
   }
 }
-inline ::tensorflow::NameAttrList* AttrValue::release_func() {
-  // @@protoc_insertion_point(field_release:tensorflow.AttrValue.func)
+inline ::opencv_tensorflow::NameAttrList* AttrValue::release_func() {
+  // @@protoc_insertion_point(field_release:opencv_tensorflow.AttrValue.func)
   if (has_func()) {
     clear_has_value();
-      ::tensorflow::NameAttrList* temp = value_.func_;
+      ::opencv_tensorflow::NameAttrList* temp = value_.func_;
     if (GetArenaNoVirtual() != NULL) {
       temp = ::google::protobuf::internal::DuplicateIfNonNull(temp, NULL);
     }
@@ -1461,40 +1461,40 @@ inline ::tensorflow::NameAttrList* AttrValue::release_func() {
     return NULL;
   }
 }
-inline const ::tensorflow::NameAttrList& AttrValue::func() const {
-  // @@protoc_insertion_point(field_get:tensorflow.AttrValue.func)
+inline const ::opencv_tensorflow::NameAttrList& AttrValue::func() const {
+  // @@protoc_insertion_point(field_get:opencv_tensorflow.AttrValue.func)
   return has_func()
       ? *value_.func_
-      : *reinterpret_cast< ::tensorflow::NameAttrList*>(&::tensorflow::_NameAttrList_default_instance_);
+      : *reinterpret_cast< ::opencv_tensorflow::NameAttrList*>(&::opencv_tensorflow::_NameAttrList_default_instance_);
 }
-inline ::tensorflow::NameAttrList* AttrValue::unsafe_arena_release_func() {
-  // @@protoc_insertion_point(field_unsafe_arena_release:tensorflow.AttrValue.func)
+inline ::opencv_tensorflow::NameAttrList* AttrValue::unsafe_arena_release_func() {
+  // @@protoc_insertion_point(field_unsafe_arena_release:opencv_tensorflow.AttrValue.func)
   if (has_func()) {
     clear_has_value();
-    ::tensorflow::NameAttrList* temp = value_.func_;
+    ::opencv_tensorflow::NameAttrList* temp = value_.func_;
     value_.func_ = NULL;
     return temp;
   } else {
     return NULL;
   }
 }
-inline void AttrValue::unsafe_arena_set_allocated_func(::tensorflow::NameAttrList* func) {
+inline void AttrValue::unsafe_arena_set_allocated_func(::opencv_tensorflow::NameAttrList* func) {
   clear_value();
   if (func) {
     set_has_func();
     value_.func_ = func;
   }
-  // @@protoc_insertion_point(field_unsafe_arena_set_allocated:tensorflow.AttrValue.func)
+  // @@protoc_insertion_point(field_unsafe_arena_set_allocated:opencv_tensorflow.AttrValue.func)
 }
-inline ::tensorflow::NameAttrList* AttrValue::mutable_func() {
+inline ::opencv_tensorflow::NameAttrList* AttrValue::mutable_func() {
   if (!has_func()) {
     clear_value();
     set_has_func();
     value_.func_ =
-      ::google::protobuf::Arena::CreateMessage< ::tensorflow::NameAttrList >(
+      ::google::protobuf::Arena::CreateMessage< ::opencv_tensorflow::NameAttrList >(
       GetArenaNoVirtual());
   }
-  // @@protoc_insertion_point(field_mutable:tensorflow.AttrValue.func)
+  // @@protoc_insertion_point(field_mutable:opencv_tensorflow.AttrValue.func)
   return value_.func_;
 }
 
@@ -1513,7 +1513,7 @@ inline void AttrValue::clear_placeholder() {
   }
 }
 inline const ::std::string& AttrValue::placeholder() const {
-  // @@protoc_insertion_point(field_get:tensorflow.AttrValue.placeholder)
+  // @@protoc_insertion_point(field_get:opencv_tensorflow.AttrValue.placeholder)
   if (has_placeholder()) {
     return value_.placeholder_.Get();
   }
@@ -1527,11 +1527,11 @@ inline void AttrValue::set_placeholder(const ::std::string& value) {
   }
   value_.placeholder_.Set(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), value,
       GetArenaNoVirtual());
-  // @@protoc_insertion_point(field_set:tensorflow.AttrValue.placeholder)
+  // @@protoc_insertion_point(field_set:opencv_tensorflow.AttrValue.placeholder)
 }
 #if LANG_CXX11
 inline void AttrValue::set_placeholder(::std::string&& value) {
-  // @@protoc_insertion_point(field_set:tensorflow.AttrValue.placeholder)
+  // @@protoc_insertion_point(field_set:opencv_tensorflow.AttrValue.placeholder)
   if (!has_placeholder()) {
     clear_value();
     set_has_placeholder();
@@ -1539,7 +1539,7 @@ inline void AttrValue::set_placeholder(::std::string&& value) {
   }
   value_.placeholder_.Set(
     &::google::protobuf::internal::GetEmptyStringAlreadyInited(), ::std::move(value), GetArenaNoVirtual());
-  // @@protoc_insertion_point(field_set_rvalue:tensorflow.AttrValue.placeholder)
+  // @@protoc_insertion_point(field_set_rvalue:opencv_tensorflow.AttrValue.placeholder)
 }
 #endif
 inline void AttrValue::set_placeholder(const char* value) {
@@ -1551,7 +1551,7 @@ inline void AttrValue::set_placeholder(const char* value) {
   }
   value_.placeholder_.Set(&::google::protobuf::internal::GetEmptyStringAlreadyInited(),
       ::std::string(value), GetArenaNoVirtual());
-  // @@protoc_insertion_point(field_set_char:tensorflow.AttrValue.placeholder)
+  // @@protoc_insertion_point(field_set_char:opencv_tensorflow.AttrValue.placeholder)
 }
 inline void AttrValue::set_placeholder(const char* value,
                              size_t size) {
@@ -1564,7 +1564,7 @@ inline void AttrValue::set_placeholder(const char* value,
       &::google::protobuf::internal::GetEmptyStringAlreadyInited(), ::std::string(
       reinterpret_cast<const char*>(value), size),
       GetArenaNoVirtual());
-  // @@protoc_insertion_point(field_set_pointer:tensorflow.AttrValue.placeholder)
+  // @@protoc_insertion_point(field_set_pointer:opencv_tensorflow.AttrValue.placeholder)
 }
 inline ::std::string* AttrValue::mutable_placeholder() {
   if (!has_placeholder()) {
@@ -1574,10 +1574,10 @@ inline ::std::string* AttrValue::mutable_placeholder() {
   }
   return value_.placeholder_.Mutable(&::google::protobuf::internal::GetEmptyStringAlreadyInited(),
       GetArenaNoVirtual());
-  // @@protoc_insertion_point(field_mutable:tensorflow.AttrValue.placeholder)
+  // @@protoc_insertion_point(field_mutable:opencv_tensorflow.AttrValue.placeholder)
 }
 inline ::std::string* AttrValue::release_placeholder() {
-  // @@protoc_insertion_point(field_release:tensorflow.AttrValue.placeholder)
+  // @@protoc_insertion_point(field_release:opencv_tensorflow.AttrValue.placeholder)
   if (has_placeholder()) {
     clear_has_value();
     return value_.placeholder_.Release(&::google::protobuf::internal::GetEmptyStringAlreadyInited(),
@@ -1596,10 +1596,10 @@ inline void AttrValue::set_allocated_placeholder(::std::string* placeholder) {
     value_.placeholder_.SetAllocated(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), placeholder,
         GetArenaNoVirtual());
   }
-  // @@protoc_insertion_point(field_set_allocated:tensorflow.AttrValue.placeholder)
+  // @@protoc_insertion_point(field_set_allocated:opencv_tensorflow.AttrValue.placeholder)
 }
 inline ::std::string* AttrValue::unsafe_arena_release_placeholder() {
-  // @@protoc_insertion_point(field_unsafe_arena_release:tensorflow.AttrValue.placeholder)
+  // @@protoc_insertion_point(field_unsafe_arena_release:opencv_tensorflow.AttrValue.placeholder)
   GOOGLE_DCHECK(GetArenaNoVirtual() != NULL);
   if (has_placeholder()) {
     clear_has_value();
@@ -1619,7 +1619,7 @@ inline void AttrValue::unsafe_arena_set_allocated_placeholder(::std::string* pla
     set_has_placeholder();
     value_.placeholder_.UnsafeArenaSetAllocated(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), placeholder, GetArenaNoVirtual());
   }
-  // @@protoc_insertion_point(field_unsafe_arena_set_allocated:tensorflow.AttrValue.placeholder)
+  // @@protoc_insertion_point(field_unsafe_arena_set_allocated:opencv_tensorflow.AttrValue.placeholder)
 }
 
 inline bool AttrValue::has_value() const {
@@ -1642,20 +1642,20 @@ inline void NameAttrList::clear_name() {
   name_.ClearToEmpty(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), GetArenaNoVirtual());
 }
 inline const ::std::string& NameAttrList::name() const {
-  // @@protoc_insertion_point(field_get:tensorflow.NameAttrList.name)
+  // @@protoc_insertion_point(field_get:opencv_tensorflow.NameAttrList.name)
   return name_.Get();
 }
 inline void NameAttrList::set_name(const ::std::string& value) {
 
   name_.Set(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), value, GetArenaNoVirtual());
-  // @@protoc_insertion_point(field_set:tensorflow.NameAttrList.name)
+  // @@protoc_insertion_point(field_set:opencv_tensorflow.NameAttrList.name)
 }
 #if LANG_CXX11
 inline void NameAttrList::set_name(::std::string&& value) {
 
   name_.Set(
     &::google::protobuf::internal::GetEmptyStringAlreadyInited(), ::std::move(value), GetArenaNoVirtual());
-  // @@protoc_insertion_point(field_set_rvalue:tensorflow.NameAttrList.name)
+  // @@protoc_insertion_point(field_set_rvalue:opencv_tensorflow.NameAttrList.name)
 }
 #endif
 inline void NameAttrList::set_name(const char* value) {
@@ -1663,22 +1663,22 @@ inline void NameAttrList::set_name(const char* value) {
 
   name_.Set(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), ::std::string(value),
               GetArenaNoVirtual());
-  // @@protoc_insertion_point(field_set_char:tensorflow.NameAttrList.name)
+  // @@protoc_insertion_point(field_set_char:opencv_tensorflow.NameAttrList.name)
 }
 inline void NameAttrList::set_name(const char* value,
     size_t size) {
 
   name_.Set(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), ::std::string(
       reinterpret_cast<const char*>(value), size), GetArenaNoVirtual());
-  // @@protoc_insertion_point(field_set_pointer:tensorflow.NameAttrList.name)
+  // @@protoc_insertion_point(field_set_pointer:opencv_tensorflow.NameAttrList.name)
 }
 inline ::std::string* NameAttrList::mutable_name() {
 
-  // @@protoc_insertion_point(field_mutable:tensorflow.NameAttrList.name)
+  // @@protoc_insertion_point(field_mutable:opencv_tensorflow.NameAttrList.name)
   return name_.Mutable(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), GetArenaNoVirtual());
 }
 inline ::std::string* NameAttrList::release_name() {
-  // @@protoc_insertion_point(field_release:tensorflow.NameAttrList.name)
+  // @@protoc_insertion_point(field_release:opencv_tensorflow.NameAttrList.name)
 
   return name_.Release(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), GetArenaNoVirtual());
 }
@@ -1690,10 +1690,10 @@ inline void NameAttrList::set_allocated_name(::std::string* name) {
   }
   name_.SetAllocated(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), name,
       GetArenaNoVirtual());
-  // @@protoc_insertion_point(field_set_allocated:tensorflow.NameAttrList.name)
+  // @@protoc_insertion_point(field_set_allocated:opencv_tensorflow.NameAttrList.name)
 }
 inline ::std::string* NameAttrList::unsafe_arena_release_name() {
-  // @@protoc_insertion_point(field_unsafe_arena_release:tensorflow.NameAttrList.name)
+  // @@protoc_insertion_point(field_unsafe_arena_release:opencv_tensorflow.NameAttrList.name)
   GOOGLE_DCHECK(GetArenaNoVirtual() != NULL);
 
   return name_.UnsafeArenaRelease(&::google::protobuf::internal::GetEmptyStringAlreadyInited(),
@@ -1709,24 +1709,24 @@ inline void NameAttrList::unsafe_arena_set_allocated_name(
   }
   name_.UnsafeArenaSetAllocated(&::google::protobuf::internal::GetEmptyStringAlreadyInited(),
       name, GetArenaNoVirtual());
-  // @@protoc_insertion_point(field_unsafe_arena_set_allocated:tensorflow.NameAttrList.name)
+  // @@protoc_insertion_point(field_unsafe_arena_set_allocated:opencv_tensorflow.NameAttrList.name)
 }
 
-// map<string, .tensorflow.AttrValue> attr = 2;
+// map<string, .opencv_tensorflow.AttrValue> attr = 2;
 inline int NameAttrList::attr_size() const {
   return attr_.size();
 }
 inline void NameAttrList::clear_attr() {
   attr_.Clear();
 }
-inline const ::google::protobuf::Map< ::std::string, ::tensorflow::AttrValue >&
+inline const ::google::protobuf::Map< ::std::string, ::opencv_tensorflow::AttrValue >&
 NameAttrList::attr() const {
-  // @@protoc_insertion_point(field_map:tensorflow.NameAttrList.attr)
+  // @@protoc_insertion_point(field_map:opencv_tensorflow.NameAttrList.attr)
   return attr_.GetMap();
 }
-inline ::google::protobuf::Map< ::std::string, ::tensorflow::AttrValue >*
+inline ::google::protobuf::Map< ::std::string, ::opencv_tensorflow::AttrValue >*
 NameAttrList::mutable_attr() {
-  // @@protoc_insertion_point(field_mutable_map:tensorflow.NameAttrList.attr)
+  // @@protoc_insertion_point(field_mutable_map:opencv_tensorflow.NameAttrList.attr)
   return attr_.MutableMap();
 }
 
@@ -1742,7 +1742,7 @@ NameAttrList::mutable_attr() {
 
 // @@protoc_insertion_point(namespace_scope)
 
-}  // namespace tensorflow
+}  // namespace opencv_tensorflow
 
 // @@protoc_insertion_point(global_scope)
 

--- a/modules/dnn/misc/tensorflow/function.pb.cc
+++ b/modules/dnn/misc/tensorflow/function.pb.cc
@@ -19,7 +19,7 @@
 #include "third_party/protobuf/version.h"
 #endif
 // @@protoc_insertion_point(includes)
-namespace tensorflow {
+namespace opencv_tensorflow {
 class FunctionDefLibraryDefaultTypeInternal {
  public:
   ::google::protobuf::internal::ExplicitlyConstructed<FunctionDefLibrary>
@@ -45,7 +45,7 @@ class GradientDefDefaultTypeInternal {
   ::google::protobuf::internal::ExplicitlyConstructed<GradientDef>
       _instance;
 } _GradientDef_default_instance_;
-}  // namespace tensorflow
+}  // namespace opencv_tensorflow
 namespace protobuf_function_2eproto {
 void InitDefaultsFunctionDefLibraryImpl() {
   GOOGLE_PROTOBUF_VERIFY_VERSION;
@@ -58,11 +58,11 @@ void InitDefaultsFunctionDefLibraryImpl() {
   protobuf_function_2eproto::InitDefaultsFunctionDef();
   protobuf_function_2eproto::InitDefaultsGradientDef();
   {
-    void* ptr = &::tensorflow::_FunctionDefLibrary_default_instance_;
-    new (ptr) ::tensorflow::FunctionDefLibrary();
+    void* ptr = &::opencv_tensorflow::_FunctionDefLibrary_default_instance_;
+    new (ptr) ::opencv_tensorflow::FunctionDefLibrary();
     ::google::protobuf::internal::OnShutdownDestroyMessage(ptr);
   }
-  ::tensorflow::FunctionDefLibrary::InitAsDefaultInstance();
+  ::opencv_tensorflow::FunctionDefLibrary::InitAsDefaultInstance();
 }
 
 void InitDefaultsFunctionDefLibrary() {
@@ -80,10 +80,10 @@ void InitDefaultsFunctionDef_Node_AttrEntry_DoNotUseImpl() {
 #endif  // GOOGLE_PROTOBUF_ENFORCE_UNIQUENESS
   protobuf_attr_5fvalue_2eproto::InitDefaultsAttrValue();
   {
-    void* ptr = &::tensorflow::_FunctionDef_Node_AttrEntry_DoNotUse_default_instance_;
-    new (ptr) ::tensorflow::FunctionDef_Node_AttrEntry_DoNotUse();
+    void* ptr = &::opencv_tensorflow::_FunctionDef_Node_AttrEntry_DoNotUse_default_instance_;
+    new (ptr) ::opencv_tensorflow::FunctionDef_Node_AttrEntry_DoNotUse();
   }
-  ::tensorflow::FunctionDef_Node_AttrEntry_DoNotUse::InitAsDefaultInstance();
+  ::opencv_tensorflow::FunctionDef_Node_AttrEntry_DoNotUse::InitAsDefaultInstance();
 }
 
 void InitDefaultsFunctionDef_Node_AttrEntry_DoNotUse() {
@@ -101,11 +101,11 @@ void InitDefaultsFunctionDef_NodeImpl() {
 #endif  // GOOGLE_PROTOBUF_ENFORCE_UNIQUENESS
   protobuf_function_2eproto::InitDefaultsFunctionDef_Node_AttrEntry_DoNotUse();
   {
-    void* ptr = &::tensorflow::_FunctionDef_Node_default_instance_;
-    new (ptr) ::tensorflow::FunctionDef_Node();
+    void* ptr = &::opencv_tensorflow::_FunctionDef_Node_default_instance_;
+    new (ptr) ::opencv_tensorflow::FunctionDef_Node();
     ::google::protobuf::internal::OnShutdownDestroyMessage(ptr);
   }
-  ::tensorflow::FunctionDef_Node::InitAsDefaultInstance();
+  ::opencv_tensorflow::FunctionDef_Node::InitAsDefaultInstance();
 }
 
 void InitDefaultsFunctionDef_Node() {
@@ -124,11 +124,11 @@ void InitDefaultsFunctionDefImpl() {
   protobuf_op_5fdef_2eproto::InitDefaultsOpDef();
   protobuf_function_2eproto::InitDefaultsFunctionDef_Node();
   {
-    void* ptr = &::tensorflow::_FunctionDef_default_instance_;
-    new (ptr) ::tensorflow::FunctionDef();
+    void* ptr = &::opencv_tensorflow::_FunctionDef_default_instance_;
+    new (ptr) ::opencv_tensorflow::FunctionDef();
     ::google::protobuf::internal::OnShutdownDestroyMessage(ptr);
   }
-  ::tensorflow::FunctionDef::InitAsDefaultInstance();
+  ::opencv_tensorflow::FunctionDef::InitAsDefaultInstance();
 }
 
 void InitDefaultsFunctionDef() {
@@ -145,11 +145,11 @@ void InitDefaultsGradientDefImpl() {
   ::google::protobuf::internal::InitProtobufDefaults();
 #endif  // GOOGLE_PROTOBUF_ENFORCE_UNIQUENESS
   {
-    void* ptr = &::tensorflow::_GradientDef_default_instance_;
-    new (ptr) ::tensorflow::GradientDef();
+    void* ptr = &::opencv_tensorflow::_GradientDef_default_instance_;
+    new (ptr) ::opencv_tensorflow::GradientDef();
     ::google::protobuf::internal::OnShutdownDestroyMessage(ptr);
   }
-  ::tensorflow::GradientDef::InitAsDefaultInstance();
+  ::opencv_tensorflow::GradientDef::InitAsDefaultInstance();
 }
 
 void InitDefaultsGradientDef() {
@@ -161,60 +161,60 @@ void InitDefaultsGradientDef() {
 
 const ::google::protobuf::uint32 TableStruct::offsets[] GOOGLE_PROTOBUF_ATTRIBUTE_SECTION_VARIABLE(protodesc_cold) = {
   ~0u,  // no _has_bits_
-  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::tensorflow::FunctionDefLibrary, _internal_metadata_),
+  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::opencv_tensorflow::FunctionDefLibrary, _internal_metadata_),
   ~0u,  // no _extensions_
   ~0u,  // no _oneof_case_
   ~0u,  // no _weak_field_map_
-  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::tensorflow::FunctionDefLibrary, function_),
-  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::tensorflow::FunctionDefLibrary, gradient_),
-  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::tensorflow::FunctionDef_Node_AttrEntry_DoNotUse, _has_bits_),
-  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::tensorflow::FunctionDef_Node_AttrEntry_DoNotUse, _internal_metadata_),
+  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::opencv_tensorflow::FunctionDefLibrary, function_),
+  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::opencv_tensorflow::FunctionDefLibrary, gradient_),
+  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::opencv_tensorflow::FunctionDef_Node_AttrEntry_DoNotUse, _has_bits_),
+  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::opencv_tensorflow::FunctionDef_Node_AttrEntry_DoNotUse, _internal_metadata_),
   ~0u,  // no _extensions_
   ~0u,  // no _oneof_case_
   ~0u,  // no _weak_field_map_
-  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::tensorflow::FunctionDef_Node_AttrEntry_DoNotUse, key_),
-  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::tensorflow::FunctionDef_Node_AttrEntry_DoNotUse, value_),
+  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::opencv_tensorflow::FunctionDef_Node_AttrEntry_DoNotUse, key_),
+  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::opencv_tensorflow::FunctionDef_Node_AttrEntry_DoNotUse, value_),
   0,
   1,
   ~0u,  // no _has_bits_
-  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::tensorflow::FunctionDef_Node, _internal_metadata_),
+  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::opencv_tensorflow::FunctionDef_Node, _internal_metadata_),
   ~0u,  // no _extensions_
   ~0u,  // no _oneof_case_
   ~0u,  // no _weak_field_map_
-  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::tensorflow::FunctionDef_Node, ret_),
-  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::tensorflow::FunctionDef_Node, op_),
-  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::tensorflow::FunctionDef_Node, arg_),
-  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::tensorflow::FunctionDef_Node, dep_),
-  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::tensorflow::FunctionDef_Node, attr_),
+  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::opencv_tensorflow::FunctionDef_Node, ret_),
+  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::opencv_tensorflow::FunctionDef_Node, op_),
+  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::opencv_tensorflow::FunctionDef_Node, arg_),
+  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::opencv_tensorflow::FunctionDef_Node, dep_),
+  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::opencv_tensorflow::FunctionDef_Node, attr_),
   ~0u,  // no _has_bits_
-  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::tensorflow::FunctionDef, _internal_metadata_),
+  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::opencv_tensorflow::FunctionDef, _internal_metadata_),
   ~0u,  // no _extensions_
   ~0u,  // no _oneof_case_
   ~0u,  // no _weak_field_map_
-  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::tensorflow::FunctionDef, signature_),
-  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::tensorflow::FunctionDef, node_),
+  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::opencv_tensorflow::FunctionDef, signature_),
+  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::opencv_tensorflow::FunctionDef, node_),
   ~0u,  // no _has_bits_
-  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::tensorflow::GradientDef, _internal_metadata_),
+  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::opencv_tensorflow::GradientDef, _internal_metadata_),
   ~0u,  // no _extensions_
   ~0u,  // no _oneof_case_
   ~0u,  // no _weak_field_map_
-  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::tensorflow::GradientDef, function_name_),
-  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::tensorflow::GradientDef, gradient_func_),
+  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::opencv_tensorflow::GradientDef, function_name_),
+  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::opencv_tensorflow::GradientDef, gradient_func_),
 };
 static const ::google::protobuf::internal::MigrationSchema schemas[] GOOGLE_PROTOBUF_ATTRIBUTE_SECTION_VARIABLE(protodesc_cold) = {
-  { 0, -1, sizeof(::tensorflow::FunctionDefLibrary)},
-  { 7, 14, sizeof(::tensorflow::FunctionDef_Node_AttrEntry_DoNotUse)},
-  { 16, -1, sizeof(::tensorflow::FunctionDef_Node)},
-  { 26, -1, sizeof(::tensorflow::FunctionDef)},
-  { 33, -1, sizeof(::tensorflow::GradientDef)},
+  { 0, -1, sizeof(::opencv_tensorflow::FunctionDefLibrary)},
+  { 7, 14, sizeof(::opencv_tensorflow::FunctionDef_Node_AttrEntry_DoNotUse)},
+  { 16, -1, sizeof(::opencv_tensorflow::FunctionDef_Node)},
+  { 26, -1, sizeof(::opencv_tensorflow::FunctionDef)},
+  { 33, -1, sizeof(::opencv_tensorflow::GradientDef)},
 };
 
 static ::google::protobuf::Message const * const file_default_instances[] = {
-  reinterpret_cast<const ::google::protobuf::Message*>(&::tensorflow::_FunctionDefLibrary_default_instance_),
-  reinterpret_cast<const ::google::protobuf::Message*>(&::tensorflow::_FunctionDef_Node_AttrEntry_DoNotUse_default_instance_),
-  reinterpret_cast<const ::google::protobuf::Message*>(&::tensorflow::_FunctionDef_Node_default_instance_),
-  reinterpret_cast<const ::google::protobuf::Message*>(&::tensorflow::_FunctionDef_default_instance_),
-  reinterpret_cast<const ::google::protobuf::Message*>(&::tensorflow::_GradientDef_default_instance_),
+  reinterpret_cast<const ::google::protobuf::Message*>(&::opencv_tensorflow::_FunctionDefLibrary_default_instance_),
+  reinterpret_cast<const ::google::protobuf::Message*>(&::opencv_tensorflow::_FunctionDef_Node_AttrEntry_DoNotUse_default_instance_),
+  reinterpret_cast<const ::google::protobuf::Message*>(&::opencv_tensorflow::_FunctionDef_Node_default_instance_),
+  reinterpret_cast<const ::google::protobuf::Message*>(&::opencv_tensorflow::_FunctionDef_default_instance_),
+  reinterpret_cast<const ::google::protobuf::Message*>(&::opencv_tensorflow::_GradientDef_default_instance_),
 };
 
 void protobuf_AssignDescriptors() {
@@ -239,24 +239,25 @@ void protobuf_RegisterTypes(const ::std::string&) {
 void AddDescriptorsImpl() {
   InitDefaults();
   static const char descriptor[] GOOGLE_PROTOBUF_ATTRIBUTE_SECTION_VARIABLE(protodesc_cold) = {
-      "\n\016function.proto\022\ntensorflow\032\020attr_value"
-      ".proto\032\014op_def.proto\"j\n\022FunctionDefLibra"
-      "ry\022)\n\010function\030\001 \003(\0132\027.tensorflow.Functi"
-      "onDef\022)\n\010gradient\030\002 \003(\0132\027.tensorflow.Gra"
-      "dientDef\"\225\002\n\013FunctionDef\022$\n\tsignature\030\001 "
-      "\001(\0132\021.tensorflow.OpDef\022*\n\004node\030\002 \003(\0132\034.t"
-      "ensorflow.FunctionDef.Node\032\263\001\n\004Node\022\013\n\003r"
-      "et\030\001 \003(\t\022\n\n\002op\030\002 \001(\t\022\013\n\003arg\030\003 \003(\t\022\013\n\003dep"
-      "\030\004 \003(\t\0224\n\004attr\030\005 \003(\0132&.tensorflow.Functi"
-      "onDef.Node.AttrEntry\032B\n\tAttrEntry\022\013\n\003key"
-      "\030\001 \001(\t\022$\n\005value\030\002 \001(\0132\025.tensorflow.AttrV"
-      "alue:\0028\001\";\n\013GradientDef\022\025\n\rfunction_name"
-      "\030\001 \001(\t\022\025\n\rgradient_func\030\002 \001(\tB/\n\030org.ten"
-      "sorflow.frameworkB\016FunctionProtosP\001\370\001\001b\006"
-      "proto3"
+      "\n\016function.proto\022\021opencv_tensorflow\032\020att"
+      "r_value.proto\032\014op_def.proto\"x\n\022FunctionD"
+      "efLibrary\0220\n\010function\030\001 \003(\0132\036.opencv_ten"
+      "sorflow.FunctionDef\0220\n\010gradient\030\002 \003(\0132\036."
+      "opencv_tensorflow.GradientDef\"\261\002\n\013Functi"
+      "onDef\022+\n\tsignature\030\001 \001(\0132\030.opencv_tensor"
+      "flow.OpDef\0221\n\004node\030\002 \003(\0132#.opencv_tensor"
+      "flow.FunctionDef.Node\032\301\001\n\004Node\022\013\n\003ret\030\001 "
+      "\003(\t\022\n\n\002op\030\002 \001(\t\022\013\n\003arg\030\003 \003(\t\022\013\n\003dep\030\004 \003("
+      "\t\022;\n\004attr\030\005 \003(\0132-.opencv_tensorflow.Func"
+      "tionDef.Node.AttrEntry\032I\n\tAttrEntry\022\013\n\003k"
+      "ey\030\001 \001(\t\022+\n\005value\030\002 \001(\0132\034.opencv_tensorf"
+      "low.AttrValue:\0028\001\";\n\013GradientDef\022\025\n\rfunc"
+      "tion_name\030\001 \001(\t\022\025\n\rgradient_func\030\002 \001(\tB/"
+      "\n\030org.tensorflow.frameworkB\016FunctionProt"
+      "osP\001\370\001\001b\006proto3"
   };
   ::google::protobuf::DescriptorPool::InternalAddGeneratedFile(
-      descriptor, 566);
+      descriptor, 615);
   ::google::protobuf::MessageFactory::InternalRegisterGeneratedFile(
     "function.proto", &protobuf_RegisterTypes);
   ::protobuf_attr_5fvalue_2eproto::AddDescriptors();
@@ -274,7 +275,7 @@ struct StaticDescriptorInitializer {
   }
 } static_descriptor_initializer;
 }  // namespace protobuf_function_2eproto
-namespace tensorflow {
+namespace opencv_tensorflow {
 
 // ===================================================================
 
@@ -291,7 +292,7 @@ FunctionDefLibrary::FunctionDefLibrary()
     ::protobuf_function_2eproto::InitDefaultsFunctionDefLibrary();
   }
   SharedCtor();
-  // @@protoc_insertion_point(constructor:tensorflow.FunctionDefLibrary)
+  // @@protoc_insertion_point(constructor:opencv_tensorflow.FunctionDefLibrary)
 }
 FunctionDefLibrary::FunctionDefLibrary(::google::protobuf::Arena* arena)
   : ::google::protobuf::Message(),
@@ -301,7 +302,7 @@ FunctionDefLibrary::FunctionDefLibrary(::google::protobuf::Arena* arena)
   ::protobuf_function_2eproto::InitDefaultsFunctionDefLibrary();
   SharedCtor();
   RegisterArenaDtor(arena);
-  // @@protoc_insertion_point(arena_constructor:tensorflow.FunctionDefLibrary)
+  // @@protoc_insertion_point(arena_constructor:opencv_tensorflow.FunctionDefLibrary)
 }
 FunctionDefLibrary::FunctionDefLibrary(const FunctionDefLibrary& from)
   : ::google::protobuf::Message(),
@@ -310,7 +311,7 @@ FunctionDefLibrary::FunctionDefLibrary(const FunctionDefLibrary& from)
       gradient_(from.gradient_),
       _cached_size_(0) {
   _internal_metadata_.MergeFrom(from._internal_metadata_);
-  // @@protoc_insertion_point(copy_constructor:tensorflow.FunctionDefLibrary)
+  // @@protoc_insertion_point(copy_constructor:opencv_tensorflow.FunctionDefLibrary)
 }
 
 void FunctionDefLibrary::SharedCtor() {
@@ -318,7 +319,7 @@ void FunctionDefLibrary::SharedCtor() {
 }
 
 FunctionDefLibrary::~FunctionDefLibrary() {
-  // @@protoc_insertion_point(destructor:tensorflow.FunctionDefLibrary)
+  // @@protoc_insertion_point(destructor:opencv_tensorflow.FunctionDefLibrary)
   SharedDtor();
 }
 
@@ -352,7 +353,7 @@ FunctionDefLibrary* FunctionDefLibrary::New(::google::protobuf::Arena* arena) co
 }
 
 void FunctionDefLibrary::Clear() {
-// @@protoc_insertion_point(message_clear_start:tensorflow.FunctionDefLibrary)
+// @@protoc_insertion_point(message_clear_start:opencv_tensorflow.FunctionDefLibrary)
   ::google::protobuf::uint32 cached_has_bits = 0;
   // Prevent compiler warnings about cached_has_bits being unused
   (void) cached_has_bits;
@@ -366,13 +367,13 @@ bool FunctionDefLibrary::MergePartialFromCodedStream(
     ::google::protobuf::io::CodedInputStream* input) {
 #define DO_(EXPRESSION) if (!GOOGLE_PREDICT_TRUE(EXPRESSION)) goto failure
   ::google::protobuf::uint32 tag;
-  // @@protoc_insertion_point(parse_start:tensorflow.FunctionDefLibrary)
+  // @@protoc_insertion_point(parse_start:opencv_tensorflow.FunctionDefLibrary)
   for (;;) {
     ::std::pair< ::google::protobuf::uint32, bool> p = input->ReadTagWithCutoffNoLastTag(127u);
     tag = p.first;
     if (!p.second) goto handle_unusual;
     switch (::google::protobuf::internal::WireFormatLite::GetTagFieldNumber(tag)) {
-      // repeated .tensorflow.FunctionDef function = 1;
+      // repeated .opencv_tensorflow.FunctionDef function = 1;
       case 1: {
         if (static_cast< ::google::protobuf::uint8>(tag) ==
             static_cast< ::google::protobuf::uint8>(10u /* 10 & 0xFF */)) {
@@ -383,7 +384,7 @@ bool FunctionDefLibrary::MergePartialFromCodedStream(
         break;
       }
 
-      // repeated .tensorflow.GradientDef gradient = 2;
+      // repeated .opencv_tensorflow.GradientDef gradient = 2;
       case 2: {
         if (static_cast< ::google::protobuf::uint8>(tag) ==
             static_cast< ::google::protobuf::uint8>(18u /* 18 & 0xFF */)) {
@@ -406,28 +407,28 @@ bool FunctionDefLibrary::MergePartialFromCodedStream(
     }
   }
 success:
-  // @@protoc_insertion_point(parse_success:tensorflow.FunctionDefLibrary)
+  // @@protoc_insertion_point(parse_success:opencv_tensorflow.FunctionDefLibrary)
   return true;
 failure:
-  // @@protoc_insertion_point(parse_failure:tensorflow.FunctionDefLibrary)
+  // @@protoc_insertion_point(parse_failure:opencv_tensorflow.FunctionDefLibrary)
   return false;
 #undef DO_
 }
 
 void FunctionDefLibrary::SerializeWithCachedSizes(
     ::google::protobuf::io::CodedOutputStream* output) const {
-  // @@protoc_insertion_point(serialize_start:tensorflow.FunctionDefLibrary)
+  // @@protoc_insertion_point(serialize_start:opencv_tensorflow.FunctionDefLibrary)
   ::google::protobuf::uint32 cached_has_bits = 0;
   (void) cached_has_bits;
 
-  // repeated .tensorflow.FunctionDef function = 1;
+  // repeated .opencv_tensorflow.FunctionDef function = 1;
   for (unsigned int i = 0,
       n = static_cast<unsigned int>(this->function_size()); i < n; i++) {
     ::google::protobuf::internal::WireFormatLite::WriteMessageMaybeToArray(
       1, this->function(static_cast<int>(i)), output);
   }
 
-  // repeated .tensorflow.GradientDef gradient = 2;
+  // repeated .opencv_tensorflow.GradientDef gradient = 2;
   for (unsigned int i = 0,
       n = static_cast<unsigned int>(this->gradient_size()); i < n; i++) {
     ::google::protobuf::internal::WireFormatLite::WriteMessageMaybeToArray(
@@ -438,17 +439,17 @@ void FunctionDefLibrary::SerializeWithCachedSizes(
     ::google::protobuf::internal::WireFormat::SerializeUnknownFields(
         (::google::protobuf::internal::GetProto3PreserveUnknownsDefault()   ? _internal_metadata_.unknown_fields()   : _internal_metadata_.default_instance()), output);
   }
-  // @@protoc_insertion_point(serialize_end:tensorflow.FunctionDefLibrary)
+  // @@protoc_insertion_point(serialize_end:opencv_tensorflow.FunctionDefLibrary)
 }
 
 ::google::protobuf::uint8* FunctionDefLibrary::InternalSerializeWithCachedSizesToArray(
     bool deterministic, ::google::protobuf::uint8* target) const {
   (void)deterministic; // Unused
-  // @@protoc_insertion_point(serialize_to_array_start:tensorflow.FunctionDefLibrary)
+  // @@protoc_insertion_point(serialize_to_array_start:opencv_tensorflow.FunctionDefLibrary)
   ::google::protobuf::uint32 cached_has_bits = 0;
   (void) cached_has_bits;
 
-  // repeated .tensorflow.FunctionDef function = 1;
+  // repeated .opencv_tensorflow.FunctionDef function = 1;
   for (unsigned int i = 0,
       n = static_cast<unsigned int>(this->function_size()); i < n; i++) {
     target = ::google::protobuf::internal::WireFormatLite::
@@ -456,7 +457,7 @@ void FunctionDefLibrary::SerializeWithCachedSizes(
         1, this->function(static_cast<int>(i)), deterministic, target);
   }
 
-  // repeated .tensorflow.GradientDef gradient = 2;
+  // repeated .opencv_tensorflow.GradientDef gradient = 2;
   for (unsigned int i = 0,
       n = static_cast<unsigned int>(this->gradient_size()); i < n; i++) {
     target = ::google::protobuf::internal::WireFormatLite::
@@ -468,12 +469,12 @@ void FunctionDefLibrary::SerializeWithCachedSizes(
     target = ::google::protobuf::internal::WireFormat::SerializeUnknownFieldsToArray(
         (::google::protobuf::internal::GetProto3PreserveUnknownsDefault()   ? _internal_metadata_.unknown_fields()   : _internal_metadata_.default_instance()), target);
   }
-  // @@protoc_insertion_point(serialize_to_array_end:tensorflow.FunctionDefLibrary)
+  // @@protoc_insertion_point(serialize_to_array_end:opencv_tensorflow.FunctionDefLibrary)
   return target;
 }
 
 size_t FunctionDefLibrary::ByteSizeLong() const {
-// @@protoc_insertion_point(message_byte_size_start:tensorflow.FunctionDefLibrary)
+// @@protoc_insertion_point(message_byte_size_start:opencv_tensorflow.FunctionDefLibrary)
   size_t total_size = 0;
 
   if ((_internal_metadata_.have_unknown_fields() &&  ::google::protobuf::internal::GetProto3PreserveUnknownsDefault())) {
@@ -481,7 +482,7 @@ size_t FunctionDefLibrary::ByteSizeLong() const {
       ::google::protobuf::internal::WireFormat::ComputeUnknownFieldsSize(
         (::google::protobuf::internal::GetProto3PreserveUnknownsDefault()   ? _internal_metadata_.unknown_fields()   : _internal_metadata_.default_instance()));
   }
-  // repeated .tensorflow.FunctionDef function = 1;
+  // repeated .opencv_tensorflow.FunctionDef function = 1;
   {
     unsigned int count = static_cast<unsigned int>(this->function_size());
     total_size += 1UL * count;
@@ -492,7 +493,7 @@ size_t FunctionDefLibrary::ByteSizeLong() const {
     }
   }
 
-  // repeated .tensorflow.GradientDef gradient = 2;
+  // repeated .opencv_tensorflow.GradientDef gradient = 2;
   {
     unsigned int count = static_cast<unsigned int>(this->gradient_size());
     total_size += 1UL * count;
@@ -511,22 +512,22 @@ size_t FunctionDefLibrary::ByteSizeLong() const {
 }
 
 void FunctionDefLibrary::MergeFrom(const ::google::protobuf::Message& from) {
-// @@protoc_insertion_point(generalized_merge_from_start:tensorflow.FunctionDefLibrary)
+// @@protoc_insertion_point(generalized_merge_from_start:opencv_tensorflow.FunctionDefLibrary)
   GOOGLE_DCHECK_NE(&from, this);
   const FunctionDefLibrary* source =
       ::google::protobuf::internal::DynamicCastToGenerated<const FunctionDefLibrary>(
           &from);
   if (source == NULL) {
-  // @@protoc_insertion_point(generalized_merge_from_cast_fail:tensorflow.FunctionDefLibrary)
+  // @@protoc_insertion_point(generalized_merge_from_cast_fail:opencv_tensorflow.FunctionDefLibrary)
     ::google::protobuf::internal::ReflectionOps::Merge(from, this);
   } else {
-  // @@protoc_insertion_point(generalized_merge_from_cast_success:tensorflow.FunctionDefLibrary)
+  // @@protoc_insertion_point(generalized_merge_from_cast_success:opencv_tensorflow.FunctionDefLibrary)
     MergeFrom(*source);
   }
 }
 
 void FunctionDefLibrary::MergeFrom(const FunctionDefLibrary& from) {
-// @@protoc_insertion_point(class_specific_merge_from_start:tensorflow.FunctionDefLibrary)
+// @@protoc_insertion_point(class_specific_merge_from_start:opencv_tensorflow.FunctionDefLibrary)
   GOOGLE_DCHECK_NE(&from, this);
   _internal_metadata_.MergeFrom(from._internal_metadata_);
   ::google::protobuf::uint32 cached_has_bits = 0;
@@ -537,14 +538,14 @@ void FunctionDefLibrary::MergeFrom(const FunctionDefLibrary& from) {
 }
 
 void FunctionDefLibrary::CopyFrom(const ::google::protobuf::Message& from) {
-// @@protoc_insertion_point(generalized_copy_from_start:tensorflow.FunctionDefLibrary)
+// @@protoc_insertion_point(generalized_copy_from_start:opencv_tensorflow.FunctionDefLibrary)
   if (&from == this) return;
   Clear();
   MergeFrom(from);
 }
 
 void FunctionDefLibrary::CopyFrom(const FunctionDefLibrary& from) {
-// @@protoc_insertion_point(class_specific_copy_from_start:tensorflow.FunctionDefLibrary)
+// @@protoc_insertion_point(class_specific_copy_from_start:opencv_tensorflow.FunctionDefLibrary)
   if (&from == this) return;
   Clear();
   MergeFrom(from);
@@ -625,7 +626,7 @@ FunctionDef_Node::FunctionDef_Node()
     ::protobuf_function_2eproto::InitDefaultsFunctionDef_Node();
   }
   SharedCtor();
-  // @@protoc_insertion_point(constructor:tensorflow.FunctionDef.Node)
+  // @@protoc_insertion_point(constructor:opencv_tensorflow.FunctionDef.Node)
 }
 FunctionDef_Node::FunctionDef_Node(::google::protobuf::Arena* arena)
   : ::google::protobuf::Message(),
@@ -637,7 +638,7 @@ FunctionDef_Node::FunctionDef_Node(::google::protobuf::Arena* arena)
   ::protobuf_function_2eproto::InitDefaultsFunctionDef_Node();
   SharedCtor();
   RegisterArenaDtor(arena);
-  // @@protoc_insertion_point(arena_constructor:tensorflow.FunctionDef.Node)
+  // @@protoc_insertion_point(arena_constructor:opencv_tensorflow.FunctionDef.Node)
 }
 FunctionDef_Node::FunctionDef_Node(const FunctionDef_Node& from)
   : ::google::protobuf::Message(),
@@ -653,7 +654,7 @@ FunctionDef_Node::FunctionDef_Node(const FunctionDef_Node& from)
     op_.Set(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), from.op(),
       GetArenaNoVirtual());
   }
-  // @@protoc_insertion_point(copy_constructor:tensorflow.FunctionDef.Node)
+  // @@protoc_insertion_point(copy_constructor:opencv_tensorflow.FunctionDef.Node)
 }
 
 void FunctionDef_Node::SharedCtor() {
@@ -662,7 +663,7 @@ void FunctionDef_Node::SharedCtor() {
 }
 
 FunctionDef_Node::~FunctionDef_Node() {
-  // @@protoc_insertion_point(destructor:tensorflow.FunctionDef.Node)
+  // @@protoc_insertion_point(destructor:opencv_tensorflow.FunctionDef.Node)
   SharedDtor();
 }
 
@@ -697,7 +698,7 @@ FunctionDef_Node* FunctionDef_Node::New(::google::protobuf::Arena* arena) const 
 }
 
 void FunctionDef_Node::Clear() {
-// @@protoc_insertion_point(message_clear_start:tensorflow.FunctionDef.Node)
+// @@protoc_insertion_point(message_clear_start:opencv_tensorflow.FunctionDef.Node)
   ::google::protobuf::uint32 cached_has_bits = 0;
   // Prevent compiler warnings about cached_has_bits being unused
   (void) cached_has_bits;
@@ -714,7 +715,7 @@ bool FunctionDef_Node::MergePartialFromCodedStream(
     ::google::protobuf::io::CodedInputStream* input) {
 #define DO_(EXPRESSION) if (!GOOGLE_PREDICT_TRUE(EXPRESSION)) goto failure
   ::google::protobuf::uint32 tag;
-  // @@protoc_insertion_point(parse_start:tensorflow.FunctionDef.Node)
+  // @@protoc_insertion_point(parse_start:opencv_tensorflow.FunctionDef.Node)
   for (;;) {
     ::std::pair< ::google::protobuf::uint32, bool> p = input->ReadTagWithCutoffNoLastTag(127u);
     tag = p.first;
@@ -730,7 +731,7 @@ bool FunctionDef_Node::MergePartialFromCodedStream(
             this->ret(this->ret_size() - 1).data(),
             static_cast<int>(this->ret(this->ret_size() - 1).length()),
             ::google::protobuf::internal::WireFormatLite::PARSE,
-            "tensorflow.FunctionDef.Node.ret"));
+            "opencv_tensorflow.FunctionDef.Node.ret"));
         } else {
           goto handle_unusual;
         }
@@ -746,7 +747,7 @@ bool FunctionDef_Node::MergePartialFromCodedStream(
           DO_(::google::protobuf::internal::WireFormatLite::VerifyUtf8String(
             this->op().data(), static_cast<int>(this->op().length()),
             ::google::protobuf::internal::WireFormatLite::PARSE,
-            "tensorflow.FunctionDef.Node.op"));
+            "opencv_tensorflow.FunctionDef.Node.op"));
         } else {
           goto handle_unusual;
         }
@@ -763,7 +764,7 @@ bool FunctionDef_Node::MergePartialFromCodedStream(
             this->arg(this->arg_size() - 1).data(),
             static_cast<int>(this->arg(this->arg_size() - 1).length()),
             ::google::protobuf::internal::WireFormatLite::PARSE,
-            "tensorflow.FunctionDef.Node.arg"));
+            "opencv_tensorflow.FunctionDef.Node.arg"));
         } else {
           goto handle_unusual;
         }
@@ -780,30 +781,30 @@ bool FunctionDef_Node::MergePartialFromCodedStream(
             this->dep(this->dep_size() - 1).data(),
             static_cast<int>(this->dep(this->dep_size() - 1).length()),
             ::google::protobuf::internal::WireFormatLite::PARSE,
-            "tensorflow.FunctionDef.Node.dep"));
+            "opencv_tensorflow.FunctionDef.Node.dep"));
         } else {
           goto handle_unusual;
         }
         break;
       }
 
-      // map<string, .tensorflow.AttrValue> attr = 5;
+      // map<string, .opencv_tensorflow.AttrValue> attr = 5;
       case 5: {
         if (static_cast< ::google::protobuf::uint8>(tag) ==
             static_cast< ::google::protobuf::uint8>(42u /* 42 & 0xFF */)) {
           FunctionDef_Node_AttrEntry_DoNotUse::Parser< ::google::protobuf::internal::MapField<
               FunctionDef_Node_AttrEntry_DoNotUse,
-              ::std::string, ::tensorflow::AttrValue,
+              ::std::string, ::opencv_tensorflow::AttrValue,
               ::google::protobuf::internal::WireFormatLite::TYPE_STRING,
               ::google::protobuf::internal::WireFormatLite::TYPE_MESSAGE,
               0 >,
-            ::google::protobuf::Map< ::std::string, ::tensorflow::AttrValue > > parser(&attr_);
+            ::google::protobuf::Map< ::std::string, ::opencv_tensorflow::AttrValue > > parser(&attr_);
           DO_(::google::protobuf::internal::WireFormatLite::ReadMessageNoVirtual(
               input, &parser));
           DO_(::google::protobuf::internal::WireFormatLite::VerifyUtf8String(
             parser.key().data(), static_cast<int>(parser.key().length()),
             ::google::protobuf::internal::WireFormatLite::PARSE,
-            "tensorflow.FunctionDef.Node.AttrEntry.key"));
+            "opencv_tensorflow.FunctionDef.Node.AttrEntry.key"));
         } else {
           goto handle_unusual;
         }
@@ -822,17 +823,17 @@ bool FunctionDef_Node::MergePartialFromCodedStream(
     }
   }
 success:
-  // @@protoc_insertion_point(parse_success:tensorflow.FunctionDef.Node)
+  // @@protoc_insertion_point(parse_success:opencv_tensorflow.FunctionDef.Node)
   return true;
 failure:
-  // @@protoc_insertion_point(parse_failure:tensorflow.FunctionDef.Node)
+  // @@protoc_insertion_point(parse_failure:opencv_tensorflow.FunctionDef.Node)
   return false;
 #undef DO_
 }
 
 void FunctionDef_Node::SerializeWithCachedSizes(
     ::google::protobuf::io::CodedOutputStream* output) const {
-  // @@protoc_insertion_point(serialize_start:tensorflow.FunctionDef.Node)
+  // @@protoc_insertion_point(serialize_start:opencv_tensorflow.FunctionDef.Node)
   ::google::protobuf::uint32 cached_has_bits = 0;
   (void) cached_has_bits;
 
@@ -841,7 +842,7 @@ void FunctionDef_Node::SerializeWithCachedSizes(
     ::google::protobuf::internal::WireFormatLite::VerifyUtf8String(
       this->ret(i).data(), static_cast<int>(this->ret(i).length()),
       ::google::protobuf::internal::WireFormatLite::SERIALIZE,
-      "tensorflow.FunctionDef.Node.ret");
+      "opencv_tensorflow.FunctionDef.Node.ret");
     ::google::protobuf::internal::WireFormatLite::WriteString(
       1, this->ret(i), output);
   }
@@ -851,7 +852,7 @@ void FunctionDef_Node::SerializeWithCachedSizes(
     ::google::protobuf::internal::WireFormatLite::VerifyUtf8String(
       this->op().data(), static_cast<int>(this->op().length()),
       ::google::protobuf::internal::WireFormatLite::SERIALIZE,
-      "tensorflow.FunctionDef.Node.op");
+      "opencv_tensorflow.FunctionDef.Node.op");
     ::google::protobuf::internal::WireFormatLite::WriteStringMaybeAliased(
       2, this->op(), output);
   }
@@ -861,7 +862,7 @@ void FunctionDef_Node::SerializeWithCachedSizes(
     ::google::protobuf::internal::WireFormatLite::VerifyUtf8String(
       this->arg(i).data(), static_cast<int>(this->arg(i).length()),
       ::google::protobuf::internal::WireFormatLite::SERIALIZE,
-      "tensorflow.FunctionDef.Node.arg");
+      "opencv_tensorflow.FunctionDef.Node.arg");
     ::google::protobuf::internal::WireFormatLite::WriteString(
       3, this->arg(i), output);
   }
@@ -871,14 +872,14 @@ void FunctionDef_Node::SerializeWithCachedSizes(
     ::google::protobuf::internal::WireFormatLite::VerifyUtf8String(
       this->dep(i).data(), static_cast<int>(this->dep(i).length()),
       ::google::protobuf::internal::WireFormatLite::SERIALIZE,
-      "tensorflow.FunctionDef.Node.dep");
+      "opencv_tensorflow.FunctionDef.Node.dep");
     ::google::protobuf::internal::WireFormatLite::WriteString(
       4, this->dep(i), output);
   }
 
-  // map<string, .tensorflow.AttrValue> attr = 5;
+  // map<string, .opencv_tensorflow.AttrValue> attr = 5;
   if (!this->attr().empty()) {
-    typedef ::google::protobuf::Map< ::std::string, ::tensorflow::AttrValue >::const_pointer
+    typedef ::google::protobuf::Map< ::std::string, ::opencv_tensorflow::AttrValue >::const_pointer
         ConstPtr;
     typedef ConstPtr SortItem;
     typedef ::google::protobuf::internal::CompareByDerefFirst<SortItem> Less;
@@ -887,7 +888,7 @@ void FunctionDef_Node::SerializeWithCachedSizes(
         ::google::protobuf::internal::WireFormatLite::VerifyUtf8String(
           p->first.data(), static_cast<int>(p->first.length()),
           ::google::protobuf::internal::WireFormatLite::SERIALIZE,
-          "tensorflow.FunctionDef.Node.AttrEntry.key");
+          "opencv_tensorflow.FunctionDef.Node.AttrEntry.key");
       }
     };
 
@@ -895,9 +896,9 @@ void FunctionDef_Node::SerializeWithCachedSizes(
         this->attr().size() > 1) {
       ::google::protobuf::scoped_array<SortItem> items(
           new SortItem[this->attr().size()]);
-      typedef ::google::protobuf::Map< ::std::string, ::tensorflow::AttrValue >::size_type size_type;
+      typedef ::google::protobuf::Map< ::std::string, ::opencv_tensorflow::AttrValue >::size_type size_type;
       size_type n = 0;
-      for (::google::protobuf::Map< ::std::string, ::tensorflow::AttrValue >::const_iterator
+      for (::google::protobuf::Map< ::std::string, ::opencv_tensorflow::AttrValue >::const_iterator
           it = this->attr().begin();
           it != this->attr().end(); ++it, ++n) {
         items[static_cast<ptrdiff_t>(n)] = SortItem(&*it);
@@ -916,7 +917,7 @@ void FunctionDef_Node::SerializeWithCachedSizes(
       }
     } else {
       ::google::protobuf::scoped_ptr<FunctionDef_Node_AttrEntry_DoNotUse> entry;
-      for (::google::protobuf::Map< ::std::string, ::tensorflow::AttrValue >::const_iterator
+      for (::google::protobuf::Map< ::std::string, ::opencv_tensorflow::AttrValue >::const_iterator
           it = this->attr().begin();
           it != this->attr().end(); ++it) {
         entry.reset(attr_.NewEntryWrapper(
@@ -935,13 +936,13 @@ void FunctionDef_Node::SerializeWithCachedSizes(
     ::google::protobuf::internal::WireFormat::SerializeUnknownFields(
         (::google::protobuf::internal::GetProto3PreserveUnknownsDefault()   ? _internal_metadata_.unknown_fields()   : _internal_metadata_.default_instance()), output);
   }
-  // @@protoc_insertion_point(serialize_end:tensorflow.FunctionDef.Node)
+  // @@protoc_insertion_point(serialize_end:opencv_tensorflow.FunctionDef.Node)
 }
 
 ::google::protobuf::uint8* FunctionDef_Node::InternalSerializeWithCachedSizesToArray(
     bool deterministic, ::google::protobuf::uint8* target) const {
   (void)deterministic; // Unused
-  // @@protoc_insertion_point(serialize_to_array_start:tensorflow.FunctionDef.Node)
+  // @@protoc_insertion_point(serialize_to_array_start:opencv_tensorflow.FunctionDef.Node)
   ::google::protobuf::uint32 cached_has_bits = 0;
   (void) cached_has_bits;
 
@@ -950,7 +951,7 @@ void FunctionDef_Node::SerializeWithCachedSizes(
     ::google::protobuf::internal::WireFormatLite::VerifyUtf8String(
       this->ret(i).data(), static_cast<int>(this->ret(i).length()),
       ::google::protobuf::internal::WireFormatLite::SERIALIZE,
-      "tensorflow.FunctionDef.Node.ret");
+      "opencv_tensorflow.FunctionDef.Node.ret");
     target = ::google::protobuf::internal::WireFormatLite::
       WriteStringToArray(1, this->ret(i), target);
   }
@@ -960,7 +961,7 @@ void FunctionDef_Node::SerializeWithCachedSizes(
     ::google::protobuf::internal::WireFormatLite::VerifyUtf8String(
       this->op().data(), static_cast<int>(this->op().length()),
       ::google::protobuf::internal::WireFormatLite::SERIALIZE,
-      "tensorflow.FunctionDef.Node.op");
+      "opencv_tensorflow.FunctionDef.Node.op");
     target =
       ::google::protobuf::internal::WireFormatLite::WriteStringToArray(
         2, this->op(), target);
@@ -971,7 +972,7 @@ void FunctionDef_Node::SerializeWithCachedSizes(
     ::google::protobuf::internal::WireFormatLite::VerifyUtf8String(
       this->arg(i).data(), static_cast<int>(this->arg(i).length()),
       ::google::protobuf::internal::WireFormatLite::SERIALIZE,
-      "tensorflow.FunctionDef.Node.arg");
+      "opencv_tensorflow.FunctionDef.Node.arg");
     target = ::google::protobuf::internal::WireFormatLite::
       WriteStringToArray(3, this->arg(i), target);
   }
@@ -981,14 +982,14 @@ void FunctionDef_Node::SerializeWithCachedSizes(
     ::google::protobuf::internal::WireFormatLite::VerifyUtf8String(
       this->dep(i).data(), static_cast<int>(this->dep(i).length()),
       ::google::protobuf::internal::WireFormatLite::SERIALIZE,
-      "tensorflow.FunctionDef.Node.dep");
+      "opencv_tensorflow.FunctionDef.Node.dep");
     target = ::google::protobuf::internal::WireFormatLite::
       WriteStringToArray(4, this->dep(i), target);
   }
 
-  // map<string, .tensorflow.AttrValue> attr = 5;
+  // map<string, .opencv_tensorflow.AttrValue> attr = 5;
   if (!this->attr().empty()) {
-    typedef ::google::protobuf::Map< ::std::string, ::tensorflow::AttrValue >::const_pointer
+    typedef ::google::protobuf::Map< ::std::string, ::opencv_tensorflow::AttrValue >::const_pointer
         ConstPtr;
     typedef ConstPtr SortItem;
     typedef ::google::protobuf::internal::CompareByDerefFirst<SortItem> Less;
@@ -997,7 +998,7 @@ void FunctionDef_Node::SerializeWithCachedSizes(
         ::google::protobuf::internal::WireFormatLite::VerifyUtf8String(
           p->first.data(), static_cast<int>(p->first.length()),
           ::google::protobuf::internal::WireFormatLite::SERIALIZE,
-          "tensorflow.FunctionDef.Node.AttrEntry.key");
+          "opencv_tensorflow.FunctionDef.Node.AttrEntry.key");
       }
     };
 
@@ -1005,9 +1006,9 @@ void FunctionDef_Node::SerializeWithCachedSizes(
         this->attr().size() > 1) {
       ::google::protobuf::scoped_array<SortItem> items(
           new SortItem[this->attr().size()]);
-      typedef ::google::protobuf::Map< ::std::string, ::tensorflow::AttrValue >::size_type size_type;
+      typedef ::google::protobuf::Map< ::std::string, ::opencv_tensorflow::AttrValue >::size_type size_type;
       size_type n = 0;
-      for (::google::protobuf::Map< ::std::string, ::tensorflow::AttrValue >::const_iterator
+      for (::google::protobuf::Map< ::std::string, ::opencv_tensorflow::AttrValue >::const_iterator
           it = this->attr().begin();
           it != this->attr().end(); ++it, ++n) {
         items[static_cast<ptrdiff_t>(n)] = SortItem(&*it);
@@ -1028,7 +1029,7 @@ void FunctionDef_Node::SerializeWithCachedSizes(
       }
     } else {
       ::google::protobuf::scoped_ptr<FunctionDef_Node_AttrEntry_DoNotUse> entry;
-      for (::google::protobuf::Map< ::std::string, ::tensorflow::AttrValue >::const_iterator
+      for (::google::protobuf::Map< ::std::string, ::opencv_tensorflow::AttrValue >::const_iterator
           it = this->attr().begin();
           it != this->attr().end(); ++it) {
         entry.reset(attr_.NewEntryWrapper(
@@ -1049,12 +1050,12 @@ void FunctionDef_Node::SerializeWithCachedSizes(
     target = ::google::protobuf::internal::WireFormat::SerializeUnknownFieldsToArray(
         (::google::protobuf::internal::GetProto3PreserveUnknownsDefault()   ? _internal_metadata_.unknown_fields()   : _internal_metadata_.default_instance()), target);
   }
-  // @@protoc_insertion_point(serialize_to_array_end:tensorflow.FunctionDef.Node)
+  // @@protoc_insertion_point(serialize_to_array_end:opencv_tensorflow.FunctionDef.Node)
   return target;
 }
 
 size_t FunctionDef_Node::ByteSizeLong() const {
-// @@protoc_insertion_point(message_byte_size_start:tensorflow.FunctionDef.Node)
+// @@protoc_insertion_point(message_byte_size_start:opencv_tensorflow.FunctionDef.Node)
   size_t total_size = 0;
 
   if ((_internal_metadata_.have_unknown_fields() &&  ::google::protobuf::internal::GetProto3PreserveUnknownsDefault())) {
@@ -1086,12 +1087,12 @@ size_t FunctionDef_Node::ByteSizeLong() const {
       this->dep(i));
   }
 
-  // map<string, .tensorflow.AttrValue> attr = 5;
+  // map<string, .opencv_tensorflow.AttrValue> attr = 5;
   total_size += 1 *
       ::google::protobuf::internal::FromIntSize(this->attr_size());
   {
     ::google::protobuf::scoped_ptr<FunctionDef_Node_AttrEntry_DoNotUse> entry;
-    for (::google::protobuf::Map< ::std::string, ::tensorflow::AttrValue >::const_iterator
+    for (::google::protobuf::Map< ::std::string, ::opencv_tensorflow::AttrValue >::const_iterator
         it = this->attr().begin();
         it != this->attr().end(); ++it) {
       if (entry.get() != NULL && entry->GetArena() != NULL) {
@@ -1121,22 +1122,22 @@ size_t FunctionDef_Node::ByteSizeLong() const {
 }
 
 void FunctionDef_Node::MergeFrom(const ::google::protobuf::Message& from) {
-// @@protoc_insertion_point(generalized_merge_from_start:tensorflow.FunctionDef.Node)
+// @@protoc_insertion_point(generalized_merge_from_start:opencv_tensorflow.FunctionDef.Node)
   GOOGLE_DCHECK_NE(&from, this);
   const FunctionDef_Node* source =
       ::google::protobuf::internal::DynamicCastToGenerated<const FunctionDef_Node>(
           &from);
   if (source == NULL) {
-  // @@protoc_insertion_point(generalized_merge_from_cast_fail:tensorflow.FunctionDef.Node)
+  // @@protoc_insertion_point(generalized_merge_from_cast_fail:opencv_tensorflow.FunctionDef.Node)
     ::google::protobuf::internal::ReflectionOps::Merge(from, this);
   } else {
-  // @@protoc_insertion_point(generalized_merge_from_cast_success:tensorflow.FunctionDef.Node)
+  // @@protoc_insertion_point(generalized_merge_from_cast_success:opencv_tensorflow.FunctionDef.Node)
     MergeFrom(*source);
   }
 }
 
 void FunctionDef_Node::MergeFrom(const FunctionDef_Node& from) {
-// @@protoc_insertion_point(class_specific_merge_from_start:tensorflow.FunctionDef.Node)
+// @@protoc_insertion_point(class_specific_merge_from_start:opencv_tensorflow.FunctionDef.Node)
   GOOGLE_DCHECK_NE(&from, this);
   _internal_metadata_.MergeFrom(from._internal_metadata_);
   ::google::protobuf::uint32 cached_has_bits = 0;
@@ -1152,14 +1153,14 @@ void FunctionDef_Node::MergeFrom(const FunctionDef_Node& from) {
 }
 
 void FunctionDef_Node::CopyFrom(const ::google::protobuf::Message& from) {
-// @@protoc_insertion_point(generalized_copy_from_start:tensorflow.FunctionDef.Node)
+// @@protoc_insertion_point(generalized_copy_from_start:opencv_tensorflow.FunctionDef.Node)
   if (&from == this) return;
   Clear();
   MergeFrom(from);
 }
 
 void FunctionDef_Node::CopyFrom(const FunctionDef_Node& from) {
-// @@protoc_insertion_point(class_specific_copy_from_start:tensorflow.FunctionDef.Node)
+// @@protoc_insertion_point(class_specific_copy_from_start:opencv_tensorflow.FunctionDef.Node)
   if (&from == this) return;
   Clear();
   MergeFrom(from);
@@ -1208,15 +1209,15 @@ void FunctionDef_Node::InternalSwap(FunctionDef_Node* other) {
 // ===================================================================
 
 void FunctionDef::InitAsDefaultInstance() {
-  ::tensorflow::_FunctionDef_default_instance_._instance.get_mutable()->signature_ = const_cast< ::tensorflow::OpDef*>(
-      ::tensorflow::OpDef::internal_default_instance());
+  ::opencv_tensorflow::_FunctionDef_default_instance_._instance.get_mutable()->signature_ = const_cast< ::opencv_tensorflow::OpDef*>(
+      ::opencv_tensorflow::OpDef::internal_default_instance());
 }
 void FunctionDef::_slow_mutable_signature() {
-  signature_ = ::google::protobuf::Arena::CreateMessage< ::tensorflow::OpDef >(
+  signature_ = ::google::protobuf::Arena::CreateMessage< ::opencv_tensorflow::OpDef >(
       GetArenaNoVirtual());
 }
 void FunctionDef::unsafe_arena_set_allocated_signature(
-    ::tensorflow::OpDef* signature) {
+    ::opencv_tensorflow::OpDef* signature) {
   if (GetArenaNoVirtual() == NULL) {
     delete signature_;
   }
@@ -1226,7 +1227,7 @@ void FunctionDef::unsafe_arena_set_allocated_signature(
   } else {
 
   }
-  // @@protoc_insertion_point(field_unsafe_arena_set_allocated:tensorflow.FunctionDef.signature)
+  // @@protoc_insertion_point(field_unsafe_arena_set_allocated:opencv_tensorflow.FunctionDef.signature)
 }
 void FunctionDef::clear_signature() {
   if (GetArenaNoVirtual() == NULL && signature_ != NULL) {
@@ -1245,7 +1246,7 @@ FunctionDef::FunctionDef()
     ::protobuf_function_2eproto::InitDefaultsFunctionDef();
   }
   SharedCtor();
-  // @@protoc_insertion_point(constructor:tensorflow.FunctionDef)
+  // @@protoc_insertion_point(constructor:opencv_tensorflow.FunctionDef)
 }
 FunctionDef::FunctionDef(::google::protobuf::Arena* arena)
   : ::google::protobuf::Message(),
@@ -1254,7 +1255,7 @@ FunctionDef::FunctionDef(::google::protobuf::Arena* arena)
   ::protobuf_function_2eproto::InitDefaultsFunctionDef();
   SharedCtor();
   RegisterArenaDtor(arena);
-  // @@protoc_insertion_point(arena_constructor:tensorflow.FunctionDef)
+  // @@protoc_insertion_point(arena_constructor:opencv_tensorflow.FunctionDef)
 }
 FunctionDef::FunctionDef(const FunctionDef& from)
   : ::google::protobuf::Message(),
@@ -1263,11 +1264,11 @@ FunctionDef::FunctionDef(const FunctionDef& from)
       _cached_size_(0) {
   _internal_metadata_.MergeFrom(from._internal_metadata_);
   if (from.has_signature()) {
-    signature_ = new ::tensorflow::OpDef(*from.signature_);
+    signature_ = new ::opencv_tensorflow::OpDef(*from.signature_);
   } else {
     signature_ = NULL;
   }
-  // @@protoc_insertion_point(copy_constructor:tensorflow.FunctionDef)
+  // @@protoc_insertion_point(copy_constructor:opencv_tensorflow.FunctionDef)
 }
 
 void FunctionDef::SharedCtor() {
@@ -1276,7 +1277,7 @@ void FunctionDef::SharedCtor() {
 }
 
 FunctionDef::~FunctionDef() {
-  // @@protoc_insertion_point(destructor:tensorflow.FunctionDef)
+  // @@protoc_insertion_point(destructor:opencv_tensorflow.FunctionDef)
   SharedDtor();
 }
 
@@ -1311,7 +1312,7 @@ FunctionDef* FunctionDef::New(::google::protobuf::Arena* arena) const {
 }
 
 void FunctionDef::Clear() {
-// @@protoc_insertion_point(message_clear_start:tensorflow.FunctionDef)
+// @@protoc_insertion_point(message_clear_start:opencv_tensorflow.FunctionDef)
   ::google::protobuf::uint32 cached_has_bits = 0;
   // Prevent compiler warnings about cached_has_bits being unused
   (void) cached_has_bits;
@@ -1328,13 +1329,13 @@ bool FunctionDef::MergePartialFromCodedStream(
     ::google::protobuf::io::CodedInputStream* input) {
 #define DO_(EXPRESSION) if (!GOOGLE_PREDICT_TRUE(EXPRESSION)) goto failure
   ::google::protobuf::uint32 tag;
-  // @@protoc_insertion_point(parse_start:tensorflow.FunctionDef)
+  // @@protoc_insertion_point(parse_start:opencv_tensorflow.FunctionDef)
   for (;;) {
     ::std::pair< ::google::protobuf::uint32, bool> p = input->ReadTagWithCutoffNoLastTag(127u);
     tag = p.first;
     if (!p.second) goto handle_unusual;
     switch (::google::protobuf::internal::WireFormatLite::GetTagFieldNumber(tag)) {
-      // .tensorflow.OpDef signature = 1;
+      // .opencv_tensorflow.OpDef signature = 1;
       case 1: {
         if (static_cast< ::google::protobuf::uint8>(tag) ==
             static_cast< ::google::protobuf::uint8>(10u /* 10 & 0xFF */)) {
@@ -1346,7 +1347,7 @@ bool FunctionDef::MergePartialFromCodedStream(
         break;
       }
 
-      // repeated .tensorflow.FunctionDef.Node node = 2;
+      // repeated .opencv_tensorflow.FunctionDef.Node node = 2;
       case 2: {
         if (static_cast< ::google::protobuf::uint8>(tag) ==
             static_cast< ::google::protobuf::uint8>(18u /* 18 & 0xFF */)) {
@@ -1369,27 +1370,27 @@ bool FunctionDef::MergePartialFromCodedStream(
     }
   }
 success:
-  // @@protoc_insertion_point(parse_success:tensorflow.FunctionDef)
+  // @@protoc_insertion_point(parse_success:opencv_tensorflow.FunctionDef)
   return true;
 failure:
-  // @@protoc_insertion_point(parse_failure:tensorflow.FunctionDef)
+  // @@protoc_insertion_point(parse_failure:opencv_tensorflow.FunctionDef)
   return false;
 #undef DO_
 }
 
 void FunctionDef::SerializeWithCachedSizes(
     ::google::protobuf::io::CodedOutputStream* output) const {
-  // @@protoc_insertion_point(serialize_start:tensorflow.FunctionDef)
+  // @@protoc_insertion_point(serialize_start:opencv_tensorflow.FunctionDef)
   ::google::protobuf::uint32 cached_has_bits = 0;
   (void) cached_has_bits;
 
-  // .tensorflow.OpDef signature = 1;
+  // .opencv_tensorflow.OpDef signature = 1;
   if (this->has_signature()) {
     ::google::protobuf::internal::WireFormatLite::WriteMessageMaybeToArray(
       1, *this->signature_, output);
   }
 
-  // repeated .tensorflow.FunctionDef.Node node = 2;
+  // repeated .opencv_tensorflow.FunctionDef.Node node = 2;
   for (unsigned int i = 0,
       n = static_cast<unsigned int>(this->node_size()); i < n; i++) {
     ::google::protobuf::internal::WireFormatLite::WriteMessageMaybeToArray(
@@ -1400,24 +1401,24 @@ void FunctionDef::SerializeWithCachedSizes(
     ::google::protobuf::internal::WireFormat::SerializeUnknownFields(
         (::google::protobuf::internal::GetProto3PreserveUnknownsDefault()   ? _internal_metadata_.unknown_fields()   : _internal_metadata_.default_instance()), output);
   }
-  // @@protoc_insertion_point(serialize_end:tensorflow.FunctionDef)
+  // @@protoc_insertion_point(serialize_end:opencv_tensorflow.FunctionDef)
 }
 
 ::google::protobuf::uint8* FunctionDef::InternalSerializeWithCachedSizesToArray(
     bool deterministic, ::google::protobuf::uint8* target) const {
   (void)deterministic; // Unused
-  // @@protoc_insertion_point(serialize_to_array_start:tensorflow.FunctionDef)
+  // @@protoc_insertion_point(serialize_to_array_start:opencv_tensorflow.FunctionDef)
   ::google::protobuf::uint32 cached_has_bits = 0;
   (void) cached_has_bits;
 
-  // .tensorflow.OpDef signature = 1;
+  // .opencv_tensorflow.OpDef signature = 1;
   if (this->has_signature()) {
     target = ::google::protobuf::internal::WireFormatLite::
       InternalWriteMessageToArray(
         1, *this->signature_, deterministic, target);
   }
 
-  // repeated .tensorflow.FunctionDef.Node node = 2;
+  // repeated .opencv_tensorflow.FunctionDef.Node node = 2;
   for (unsigned int i = 0,
       n = static_cast<unsigned int>(this->node_size()); i < n; i++) {
     target = ::google::protobuf::internal::WireFormatLite::
@@ -1429,12 +1430,12 @@ void FunctionDef::SerializeWithCachedSizes(
     target = ::google::protobuf::internal::WireFormat::SerializeUnknownFieldsToArray(
         (::google::protobuf::internal::GetProto3PreserveUnknownsDefault()   ? _internal_metadata_.unknown_fields()   : _internal_metadata_.default_instance()), target);
   }
-  // @@protoc_insertion_point(serialize_to_array_end:tensorflow.FunctionDef)
+  // @@protoc_insertion_point(serialize_to_array_end:opencv_tensorflow.FunctionDef)
   return target;
 }
 
 size_t FunctionDef::ByteSizeLong() const {
-// @@protoc_insertion_point(message_byte_size_start:tensorflow.FunctionDef)
+// @@protoc_insertion_point(message_byte_size_start:opencv_tensorflow.FunctionDef)
   size_t total_size = 0;
 
   if ((_internal_metadata_.have_unknown_fields() &&  ::google::protobuf::internal::GetProto3PreserveUnknownsDefault())) {
@@ -1442,7 +1443,7 @@ size_t FunctionDef::ByteSizeLong() const {
       ::google::protobuf::internal::WireFormat::ComputeUnknownFieldsSize(
         (::google::protobuf::internal::GetProto3PreserveUnknownsDefault()   ? _internal_metadata_.unknown_fields()   : _internal_metadata_.default_instance()));
   }
-  // repeated .tensorflow.FunctionDef.Node node = 2;
+  // repeated .opencv_tensorflow.FunctionDef.Node node = 2;
   {
     unsigned int count = static_cast<unsigned int>(this->node_size());
     total_size += 1UL * count;
@@ -1453,7 +1454,7 @@ size_t FunctionDef::ByteSizeLong() const {
     }
   }
 
-  // .tensorflow.OpDef signature = 1;
+  // .opencv_tensorflow.OpDef signature = 1;
   if (this->has_signature()) {
     total_size += 1 +
       ::google::protobuf::internal::WireFormatLite::MessageSize(
@@ -1468,22 +1469,22 @@ size_t FunctionDef::ByteSizeLong() const {
 }
 
 void FunctionDef::MergeFrom(const ::google::protobuf::Message& from) {
-// @@protoc_insertion_point(generalized_merge_from_start:tensorflow.FunctionDef)
+// @@protoc_insertion_point(generalized_merge_from_start:opencv_tensorflow.FunctionDef)
   GOOGLE_DCHECK_NE(&from, this);
   const FunctionDef* source =
       ::google::protobuf::internal::DynamicCastToGenerated<const FunctionDef>(
           &from);
   if (source == NULL) {
-  // @@protoc_insertion_point(generalized_merge_from_cast_fail:tensorflow.FunctionDef)
+  // @@protoc_insertion_point(generalized_merge_from_cast_fail:opencv_tensorflow.FunctionDef)
     ::google::protobuf::internal::ReflectionOps::Merge(from, this);
   } else {
-  // @@protoc_insertion_point(generalized_merge_from_cast_success:tensorflow.FunctionDef)
+  // @@protoc_insertion_point(generalized_merge_from_cast_success:opencv_tensorflow.FunctionDef)
     MergeFrom(*source);
   }
 }
 
 void FunctionDef::MergeFrom(const FunctionDef& from) {
-// @@protoc_insertion_point(class_specific_merge_from_start:tensorflow.FunctionDef)
+// @@protoc_insertion_point(class_specific_merge_from_start:opencv_tensorflow.FunctionDef)
   GOOGLE_DCHECK_NE(&from, this);
   _internal_metadata_.MergeFrom(from._internal_metadata_);
   ::google::protobuf::uint32 cached_has_bits = 0;
@@ -1491,19 +1492,19 @@ void FunctionDef::MergeFrom(const FunctionDef& from) {
 
   node_.MergeFrom(from.node_);
   if (from.has_signature()) {
-    mutable_signature()->::tensorflow::OpDef::MergeFrom(from.signature());
+    mutable_signature()->::opencv_tensorflow::OpDef::MergeFrom(from.signature());
   }
 }
 
 void FunctionDef::CopyFrom(const ::google::protobuf::Message& from) {
-// @@protoc_insertion_point(generalized_copy_from_start:tensorflow.FunctionDef)
+// @@protoc_insertion_point(generalized_copy_from_start:opencv_tensorflow.FunctionDef)
   if (&from == this) return;
   Clear();
   MergeFrom(from);
 }
 
 void FunctionDef::CopyFrom(const FunctionDef& from) {
-// @@protoc_insertion_point(class_specific_copy_from_start:tensorflow.FunctionDef)
+// @@protoc_insertion_point(class_specific_copy_from_start:opencv_tensorflow.FunctionDef)
   if (&from == this) return;
   Clear();
   MergeFrom(from);
@@ -1561,7 +1562,7 @@ GradientDef::GradientDef()
     ::protobuf_function_2eproto::InitDefaultsGradientDef();
   }
   SharedCtor();
-  // @@protoc_insertion_point(constructor:tensorflow.GradientDef)
+  // @@protoc_insertion_point(constructor:opencv_tensorflow.GradientDef)
 }
 GradientDef::GradientDef(::google::protobuf::Arena* arena)
   : ::google::protobuf::Message(),
@@ -1569,7 +1570,7 @@ GradientDef::GradientDef(::google::protobuf::Arena* arena)
   ::protobuf_function_2eproto::InitDefaultsGradientDef();
   SharedCtor();
   RegisterArenaDtor(arena);
-  // @@protoc_insertion_point(arena_constructor:tensorflow.GradientDef)
+  // @@protoc_insertion_point(arena_constructor:opencv_tensorflow.GradientDef)
 }
 GradientDef::GradientDef(const GradientDef& from)
   : ::google::protobuf::Message(),
@@ -1586,7 +1587,7 @@ GradientDef::GradientDef(const GradientDef& from)
     gradient_func_.Set(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), from.gradient_func(),
       GetArenaNoVirtual());
   }
-  // @@protoc_insertion_point(copy_constructor:tensorflow.GradientDef)
+  // @@protoc_insertion_point(copy_constructor:opencv_tensorflow.GradientDef)
 }
 
 void GradientDef::SharedCtor() {
@@ -1596,7 +1597,7 @@ void GradientDef::SharedCtor() {
 }
 
 GradientDef::~GradientDef() {
-  // @@protoc_insertion_point(destructor:tensorflow.GradientDef)
+  // @@protoc_insertion_point(destructor:opencv_tensorflow.GradientDef)
   SharedDtor();
 }
 
@@ -1632,7 +1633,7 @@ GradientDef* GradientDef::New(::google::protobuf::Arena* arena) const {
 }
 
 void GradientDef::Clear() {
-// @@protoc_insertion_point(message_clear_start:tensorflow.GradientDef)
+// @@protoc_insertion_point(message_clear_start:opencv_tensorflow.GradientDef)
   ::google::protobuf::uint32 cached_has_bits = 0;
   // Prevent compiler warnings about cached_has_bits being unused
   (void) cached_has_bits;
@@ -1646,7 +1647,7 @@ bool GradientDef::MergePartialFromCodedStream(
     ::google::protobuf::io::CodedInputStream* input) {
 #define DO_(EXPRESSION) if (!GOOGLE_PREDICT_TRUE(EXPRESSION)) goto failure
   ::google::protobuf::uint32 tag;
-  // @@protoc_insertion_point(parse_start:tensorflow.GradientDef)
+  // @@protoc_insertion_point(parse_start:opencv_tensorflow.GradientDef)
   for (;;) {
     ::std::pair< ::google::protobuf::uint32, bool> p = input->ReadTagWithCutoffNoLastTag(127u);
     tag = p.first;
@@ -1661,7 +1662,7 @@ bool GradientDef::MergePartialFromCodedStream(
           DO_(::google::protobuf::internal::WireFormatLite::VerifyUtf8String(
             this->function_name().data(), static_cast<int>(this->function_name().length()),
             ::google::protobuf::internal::WireFormatLite::PARSE,
-            "tensorflow.GradientDef.function_name"));
+            "opencv_tensorflow.GradientDef.function_name"));
         } else {
           goto handle_unusual;
         }
@@ -1677,7 +1678,7 @@ bool GradientDef::MergePartialFromCodedStream(
           DO_(::google::protobuf::internal::WireFormatLite::VerifyUtf8String(
             this->gradient_func().data(), static_cast<int>(this->gradient_func().length()),
             ::google::protobuf::internal::WireFormatLite::PARSE,
-            "tensorflow.GradientDef.gradient_func"));
+            "opencv_tensorflow.GradientDef.gradient_func"));
         } else {
           goto handle_unusual;
         }
@@ -1696,17 +1697,17 @@ bool GradientDef::MergePartialFromCodedStream(
     }
   }
 success:
-  // @@protoc_insertion_point(parse_success:tensorflow.GradientDef)
+  // @@protoc_insertion_point(parse_success:opencv_tensorflow.GradientDef)
   return true;
 failure:
-  // @@protoc_insertion_point(parse_failure:tensorflow.GradientDef)
+  // @@protoc_insertion_point(parse_failure:opencv_tensorflow.GradientDef)
   return false;
 #undef DO_
 }
 
 void GradientDef::SerializeWithCachedSizes(
     ::google::protobuf::io::CodedOutputStream* output) const {
-  // @@protoc_insertion_point(serialize_start:tensorflow.GradientDef)
+  // @@protoc_insertion_point(serialize_start:opencv_tensorflow.GradientDef)
   ::google::protobuf::uint32 cached_has_bits = 0;
   (void) cached_has_bits;
 
@@ -1715,7 +1716,7 @@ void GradientDef::SerializeWithCachedSizes(
     ::google::protobuf::internal::WireFormatLite::VerifyUtf8String(
       this->function_name().data(), static_cast<int>(this->function_name().length()),
       ::google::protobuf::internal::WireFormatLite::SERIALIZE,
-      "tensorflow.GradientDef.function_name");
+      "opencv_tensorflow.GradientDef.function_name");
     ::google::protobuf::internal::WireFormatLite::WriteStringMaybeAliased(
       1, this->function_name(), output);
   }
@@ -1725,7 +1726,7 @@ void GradientDef::SerializeWithCachedSizes(
     ::google::protobuf::internal::WireFormatLite::VerifyUtf8String(
       this->gradient_func().data(), static_cast<int>(this->gradient_func().length()),
       ::google::protobuf::internal::WireFormatLite::SERIALIZE,
-      "tensorflow.GradientDef.gradient_func");
+      "opencv_tensorflow.GradientDef.gradient_func");
     ::google::protobuf::internal::WireFormatLite::WriteStringMaybeAliased(
       2, this->gradient_func(), output);
   }
@@ -1734,13 +1735,13 @@ void GradientDef::SerializeWithCachedSizes(
     ::google::protobuf::internal::WireFormat::SerializeUnknownFields(
         (::google::protobuf::internal::GetProto3PreserveUnknownsDefault()   ? _internal_metadata_.unknown_fields()   : _internal_metadata_.default_instance()), output);
   }
-  // @@protoc_insertion_point(serialize_end:tensorflow.GradientDef)
+  // @@protoc_insertion_point(serialize_end:opencv_tensorflow.GradientDef)
 }
 
 ::google::protobuf::uint8* GradientDef::InternalSerializeWithCachedSizesToArray(
     bool deterministic, ::google::protobuf::uint8* target) const {
   (void)deterministic; // Unused
-  // @@protoc_insertion_point(serialize_to_array_start:tensorflow.GradientDef)
+  // @@protoc_insertion_point(serialize_to_array_start:opencv_tensorflow.GradientDef)
   ::google::protobuf::uint32 cached_has_bits = 0;
   (void) cached_has_bits;
 
@@ -1749,7 +1750,7 @@ void GradientDef::SerializeWithCachedSizes(
     ::google::protobuf::internal::WireFormatLite::VerifyUtf8String(
       this->function_name().data(), static_cast<int>(this->function_name().length()),
       ::google::protobuf::internal::WireFormatLite::SERIALIZE,
-      "tensorflow.GradientDef.function_name");
+      "opencv_tensorflow.GradientDef.function_name");
     target =
       ::google::protobuf::internal::WireFormatLite::WriteStringToArray(
         1, this->function_name(), target);
@@ -1760,7 +1761,7 @@ void GradientDef::SerializeWithCachedSizes(
     ::google::protobuf::internal::WireFormatLite::VerifyUtf8String(
       this->gradient_func().data(), static_cast<int>(this->gradient_func().length()),
       ::google::protobuf::internal::WireFormatLite::SERIALIZE,
-      "tensorflow.GradientDef.gradient_func");
+      "opencv_tensorflow.GradientDef.gradient_func");
     target =
       ::google::protobuf::internal::WireFormatLite::WriteStringToArray(
         2, this->gradient_func(), target);
@@ -1770,12 +1771,12 @@ void GradientDef::SerializeWithCachedSizes(
     target = ::google::protobuf::internal::WireFormat::SerializeUnknownFieldsToArray(
         (::google::protobuf::internal::GetProto3PreserveUnknownsDefault()   ? _internal_metadata_.unknown_fields()   : _internal_metadata_.default_instance()), target);
   }
-  // @@protoc_insertion_point(serialize_to_array_end:tensorflow.GradientDef)
+  // @@protoc_insertion_point(serialize_to_array_end:opencv_tensorflow.GradientDef)
   return target;
 }
 
 size_t GradientDef::ByteSizeLong() const {
-// @@protoc_insertion_point(message_byte_size_start:tensorflow.GradientDef)
+// @@protoc_insertion_point(message_byte_size_start:opencv_tensorflow.GradientDef)
   size_t total_size = 0;
 
   if ((_internal_metadata_.have_unknown_fields() &&  ::google::protobuf::internal::GetProto3PreserveUnknownsDefault())) {
@@ -1805,22 +1806,22 @@ size_t GradientDef::ByteSizeLong() const {
 }
 
 void GradientDef::MergeFrom(const ::google::protobuf::Message& from) {
-// @@protoc_insertion_point(generalized_merge_from_start:tensorflow.GradientDef)
+// @@protoc_insertion_point(generalized_merge_from_start:opencv_tensorflow.GradientDef)
   GOOGLE_DCHECK_NE(&from, this);
   const GradientDef* source =
       ::google::protobuf::internal::DynamicCastToGenerated<const GradientDef>(
           &from);
   if (source == NULL) {
-  // @@protoc_insertion_point(generalized_merge_from_cast_fail:tensorflow.GradientDef)
+  // @@protoc_insertion_point(generalized_merge_from_cast_fail:opencv_tensorflow.GradientDef)
     ::google::protobuf::internal::ReflectionOps::Merge(from, this);
   } else {
-  // @@protoc_insertion_point(generalized_merge_from_cast_success:tensorflow.GradientDef)
+  // @@protoc_insertion_point(generalized_merge_from_cast_success:opencv_tensorflow.GradientDef)
     MergeFrom(*source);
   }
 }
 
 void GradientDef::MergeFrom(const GradientDef& from) {
-// @@protoc_insertion_point(class_specific_merge_from_start:tensorflow.GradientDef)
+// @@protoc_insertion_point(class_specific_merge_from_start:opencv_tensorflow.GradientDef)
   GOOGLE_DCHECK_NE(&from, this);
   _internal_metadata_.MergeFrom(from._internal_metadata_);
   ::google::protobuf::uint32 cached_has_bits = 0;
@@ -1835,14 +1836,14 @@ void GradientDef::MergeFrom(const GradientDef& from) {
 }
 
 void GradientDef::CopyFrom(const ::google::protobuf::Message& from) {
-// @@protoc_insertion_point(generalized_copy_from_start:tensorflow.GradientDef)
+// @@protoc_insertion_point(generalized_copy_from_start:opencv_tensorflow.GradientDef)
   if (&from == this) return;
   Clear();
   MergeFrom(from);
 }
 
 void GradientDef::CopyFrom(const GradientDef& from) {
-// @@protoc_insertion_point(class_specific_copy_from_start:tensorflow.GradientDef)
+// @@protoc_insertion_point(class_specific_copy_from_start:opencv_tensorflow.GradientDef)
   if (&from == this) return;
   Clear();
   MergeFrom(from);
@@ -1886,6 +1887,6 @@ void GradientDef::InternalSwap(GradientDef* other) {
 
 
 // @@protoc_insertion_point(namespace_scope)
-}  // namespace tensorflow
+}  // namespace opencv_tensorflow
 
 // @@protoc_insertion_point(global_scope)

--- a/modules/dnn/misc/tensorflow/function.pb.h
+++ b/modules/dnn/misc/tensorflow/function.pb.h
@@ -65,7 +65,7 @@ inline void InitDefaults() {
   InitDefaultsGradientDef();
 }
 }  // namespace protobuf_function_2eproto
-namespace tensorflow {
+namespace opencv_tensorflow {
 class FunctionDef;
 class FunctionDefDefaultTypeInternal;
 extern FunctionDefDefaultTypeInternal _FunctionDef_default_instance_;
@@ -81,12 +81,12 @@ extern FunctionDef_Node_AttrEntry_DoNotUseDefaultTypeInternal _FunctionDef_Node_
 class GradientDef;
 class GradientDefDefaultTypeInternal;
 extern GradientDefDefaultTypeInternal _GradientDef_default_instance_;
-}  // namespace tensorflow
-namespace tensorflow {
+}  // namespace opencv_tensorflow
+namespace opencv_tensorflow {
 
 // ===================================================================
 
-class FunctionDefLibrary : public ::google::protobuf::Message /* @@protoc_insertion_point(class_definition:tensorflow.FunctionDefLibrary) */ {
+class FunctionDefLibrary : public ::google::protobuf::Message /* @@protoc_insertion_point(class_definition:opencv_tensorflow.FunctionDefLibrary) */ {
  public:
   FunctionDefLibrary();
   virtual ~FunctionDefLibrary();
@@ -180,39 +180,39 @@ class FunctionDefLibrary : public ::google::protobuf::Message /* @@protoc_insert
 
   // accessors -------------------------------------------------------
 
-  // repeated .tensorflow.FunctionDef function = 1;
+  // repeated .opencv_tensorflow.FunctionDef function = 1;
   int function_size() const;
   void clear_function();
   static const int kFunctionFieldNumber = 1;
-  const ::tensorflow::FunctionDef& function(int index) const;
-  ::tensorflow::FunctionDef* mutable_function(int index);
-  ::tensorflow::FunctionDef* add_function();
-  ::google::protobuf::RepeatedPtrField< ::tensorflow::FunctionDef >*
+  const ::opencv_tensorflow::FunctionDef& function(int index) const;
+  ::opencv_tensorflow::FunctionDef* mutable_function(int index);
+  ::opencv_tensorflow::FunctionDef* add_function();
+  ::google::protobuf::RepeatedPtrField< ::opencv_tensorflow::FunctionDef >*
       mutable_function();
-  const ::google::protobuf::RepeatedPtrField< ::tensorflow::FunctionDef >&
+  const ::google::protobuf::RepeatedPtrField< ::opencv_tensorflow::FunctionDef >&
       function() const;
 
-  // repeated .tensorflow.GradientDef gradient = 2;
+  // repeated .opencv_tensorflow.GradientDef gradient = 2;
   int gradient_size() const;
   void clear_gradient();
   static const int kGradientFieldNumber = 2;
-  const ::tensorflow::GradientDef& gradient(int index) const;
-  ::tensorflow::GradientDef* mutable_gradient(int index);
-  ::tensorflow::GradientDef* add_gradient();
-  ::google::protobuf::RepeatedPtrField< ::tensorflow::GradientDef >*
+  const ::opencv_tensorflow::GradientDef& gradient(int index) const;
+  ::opencv_tensorflow::GradientDef* mutable_gradient(int index);
+  ::opencv_tensorflow::GradientDef* add_gradient();
+  ::google::protobuf::RepeatedPtrField< ::opencv_tensorflow::GradientDef >*
       mutable_gradient();
-  const ::google::protobuf::RepeatedPtrField< ::tensorflow::GradientDef >&
+  const ::google::protobuf::RepeatedPtrField< ::opencv_tensorflow::GradientDef >&
       gradient() const;
 
-  // @@protoc_insertion_point(class_scope:tensorflow.FunctionDefLibrary)
+  // @@protoc_insertion_point(class_scope:opencv_tensorflow.FunctionDefLibrary)
  private:
 
   ::google::protobuf::internal::InternalMetadataWithArena _internal_metadata_;
   template <typename T> friend class ::google::protobuf::Arena::InternalHelper;
   typedef void InternalArenaConstructable_;
   typedef void DestructorSkippable_;
-  ::google::protobuf::RepeatedPtrField< ::tensorflow::FunctionDef > function_;
-  ::google::protobuf::RepeatedPtrField< ::tensorflow::GradientDef > gradient_;
+  ::google::protobuf::RepeatedPtrField< ::opencv_tensorflow::FunctionDef > function_;
+  ::google::protobuf::RepeatedPtrField< ::opencv_tensorflow::GradientDef > gradient_;
   mutable int _cached_size_;
   friend struct ::protobuf_function_2eproto::TableStruct;
   friend void ::protobuf_function_2eproto::InitDefaultsFunctionDefLibraryImpl();
@@ -220,13 +220,13 @@ class FunctionDefLibrary : public ::google::protobuf::Message /* @@protoc_insert
 // -------------------------------------------------------------------
 
 class FunctionDef_Node_AttrEntry_DoNotUse : public ::google::protobuf::internal::MapEntry<FunctionDef_Node_AttrEntry_DoNotUse,
-    ::std::string, ::tensorflow::AttrValue,
+    ::std::string, ::opencv_tensorflow::AttrValue,
     ::google::protobuf::internal::WireFormatLite::TYPE_STRING,
     ::google::protobuf::internal::WireFormatLite::TYPE_MESSAGE,
     0 > {
 public:
   typedef ::google::protobuf::internal::MapEntry<FunctionDef_Node_AttrEntry_DoNotUse,
-    ::std::string, ::tensorflow::AttrValue,
+    ::std::string, ::opencv_tensorflow::AttrValue,
     ::google::protobuf::internal::WireFormatLite::TYPE_STRING,
     ::google::protobuf::internal::WireFormatLite::TYPE_MESSAGE,
     0 > SuperType;
@@ -240,7 +240,7 @@ public:
 
 // -------------------------------------------------------------------
 
-class FunctionDef_Node : public ::google::protobuf::Message /* @@protoc_insertion_point(class_definition:tensorflow.FunctionDef.Node) */ {
+class FunctionDef_Node : public ::google::protobuf::Message /* @@protoc_insertion_point(class_definition:opencv_tensorflow.FunctionDef.Node) */ {
  public:
   FunctionDef_Node();
   virtual ~FunctionDef_Node();
@@ -401,13 +401,13 @@ class FunctionDef_Node : public ::google::protobuf::Message /* @@protoc_insertio
   const ::google::protobuf::RepeatedPtrField< ::std::string>& dep() const;
   ::google::protobuf::RepeatedPtrField< ::std::string>* mutable_dep();
 
-  // map<string, .tensorflow.AttrValue> attr = 5;
+  // map<string, .opencv_tensorflow.AttrValue> attr = 5;
   int attr_size() const;
   void clear_attr();
   static const int kAttrFieldNumber = 5;
-  const ::google::protobuf::Map< ::std::string, ::tensorflow::AttrValue >&
+  const ::google::protobuf::Map< ::std::string, ::opencv_tensorflow::AttrValue >&
       attr() const;
-  ::google::protobuf::Map< ::std::string, ::tensorflow::AttrValue >*
+  ::google::protobuf::Map< ::std::string, ::opencv_tensorflow::AttrValue >*
       mutable_attr();
 
   // string op = 2;
@@ -433,7 +433,7 @@ class FunctionDef_Node : public ::google::protobuf::Message /* @@protoc_insertio
   void unsafe_arena_set_allocated_op(
       ::std::string* op);
 
-  // @@protoc_insertion_point(class_scope:tensorflow.FunctionDef.Node)
+  // @@protoc_insertion_point(class_scope:opencv_tensorflow.FunctionDef.Node)
  private:
 
   ::google::protobuf::internal::InternalMetadataWithArena _internal_metadata_;
@@ -445,7 +445,7 @@ class FunctionDef_Node : public ::google::protobuf::Message /* @@protoc_insertio
   ::google::protobuf::RepeatedPtrField< ::std::string> dep_;
   ::google::protobuf::internal::MapField<
       FunctionDef_Node_AttrEntry_DoNotUse,
-      ::std::string, ::tensorflow::AttrValue,
+      ::std::string, ::opencv_tensorflow::AttrValue,
       ::google::protobuf::internal::WireFormatLite::TYPE_STRING,
       ::google::protobuf::internal::WireFormatLite::TYPE_MESSAGE,
       0 > attr_;
@@ -456,7 +456,7 @@ class FunctionDef_Node : public ::google::protobuf::Message /* @@protoc_insertio
 };
 // -------------------------------------------------------------------
 
-class FunctionDef : public ::google::protobuf::Message /* @@protoc_insertion_point(class_definition:tensorflow.FunctionDef) */ {
+class FunctionDef : public ::google::protobuf::Message /* @@protoc_insertion_point(class_definition:opencv_tensorflow.FunctionDef) */ {
  public:
   FunctionDef();
   virtual ~FunctionDef();
@@ -552,49 +552,49 @@ class FunctionDef : public ::google::protobuf::Message /* @@protoc_insertion_poi
 
   // accessors -------------------------------------------------------
 
-  // repeated .tensorflow.FunctionDef.Node node = 2;
+  // repeated .opencv_tensorflow.FunctionDef.Node node = 2;
   int node_size() const;
   void clear_node();
   static const int kNodeFieldNumber = 2;
-  const ::tensorflow::FunctionDef_Node& node(int index) const;
-  ::tensorflow::FunctionDef_Node* mutable_node(int index);
-  ::tensorflow::FunctionDef_Node* add_node();
-  ::google::protobuf::RepeatedPtrField< ::tensorflow::FunctionDef_Node >*
+  const ::opencv_tensorflow::FunctionDef_Node& node(int index) const;
+  ::opencv_tensorflow::FunctionDef_Node* mutable_node(int index);
+  ::opencv_tensorflow::FunctionDef_Node* add_node();
+  ::google::protobuf::RepeatedPtrField< ::opencv_tensorflow::FunctionDef_Node >*
       mutable_node();
-  const ::google::protobuf::RepeatedPtrField< ::tensorflow::FunctionDef_Node >&
+  const ::google::protobuf::RepeatedPtrField< ::opencv_tensorflow::FunctionDef_Node >&
       node() const;
 
-  // .tensorflow.OpDef signature = 1;
+  // .opencv_tensorflow.OpDef signature = 1;
   bool has_signature() const;
   void clear_signature();
   static const int kSignatureFieldNumber = 1;
   private:
   void _slow_mutable_signature();
   public:
-  const ::tensorflow::OpDef& signature() const;
-  ::tensorflow::OpDef* release_signature();
-  ::tensorflow::OpDef* mutable_signature();
-  void set_allocated_signature(::tensorflow::OpDef* signature);
+  const ::opencv_tensorflow::OpDef& signature() const;
+  ::opencv_tensorflow::OpDef* release_signature();
+  ::opencv_tensorflow::OpDef* mutable_signature();
+  void set_allocated_signature(::opencv_tensorflow::OpDef* signature);
   void unsafe_arena_set_allocated_signature(
-      ::tensorflow::OpDef* signature);
-  ::tensorflow::OpDef* unsafe_arena_release_signature();
+      ::opencv_tensorflow::OpDef* signature);
+  ::opencv_tensorflow::OpDef* unsafe_arena_release_signature();
 
-  // @@protoc_insertion_point(class_scope:tensorflow.FunctionDef)
+  // @@protoc_insertion_point(class_scope:opencv_tensorflow.FunctionDef)
  private:
 
   ::google::protobuf::internal::InternalMetadataWithArena _internal_metadata_;
   template <typename T> friend class ::google::protobuf::Arena::InternalHelper;
   typedef void InternalArenaConstructable_;
   typedef void DestructorSkippable_;
-  ::google::protobuf::RepeatedPtrField< ::tensorflow::FunctionDef_Node > node_;
-  ::tensorflow::OpDef* signature_;
+  ::google::protobuf::RepeatedPtrField< ::opencv_tensorflow::FunctionDef_Node > node_;
+  ::opencv_tensorflow::OpDef* signature_;
   mutable int _cached_size_;
   friend struct ::protobuf_function_2eproto::TableStruct;
   friend void ::protobuf_function_2eproto::InitDefaultsFunctionDefImpl();
 };
 // -------------------------------------------------------------------
 
-class GradientDef : public ::google::protobuf::Message /* @@protoc_insertion_point(class_definition:tensorflow.GradientDef) */ {
+class GradientDef : public ::google::protobuf::Message /* @@protoc_insertion_point(class_definition:opencv_tensorflow.GradientDef) */ {
  public:
   GradientDef();
   virtual ~GradientDef();
@@ -734,7 +734,7 @@ class GradientDef : public ::google::protobuf::Message /* @@protoc_insertion_poi
   void unsafe_arena_set_allocated_gradient_func(
       ::std::string* gradient_func);
 
-  // @@protoc_insertion_point(class_scope:tensorflow.GradientDef)
+  // @@protoc_insertion_point(class_scope:opencv_tensorflow.GradientDef)
  private:
 
   ::google::protobuf::internal::InternalMetadataWithArena _internal_metadata_;
@@ -758,63 +758,63 @@ class GradientDef : public ::google::protobuf::Message /* @@protoc_insertion_poi
 #endif  // __GNUC__
 // FunctionDefLibrary
 
-// repeated .tensorflow.FunctionDef function = 1;
+// repeated .opencv_tensorflow.FunctionDef function = 1;
 inline int FunctionDefLibrary::function_size() const {
   return function_.size();
 }
 inline void FunctionDefLibrary::clear_function() {
   function_.Clear();
 }
-inline const ::tensorflow::FunctionDef& FunctionDefLibrary::function(int index) const {
-  // @@protoc_insertion_point(field_get:tensorflow.FunctionDefLibrary.function)
+inline const ::opencv_tensorflow::FunctionDef& FunctionDefLibrary::function(int index) const {
+  // @@protoc_insertion_point(field_get:opencv_tensorflow.FunctionDefLibrary.function)
   return function_.Get(index);
 }
-inline ::tensorflow::FunctionDef* FunctionDefLibrary::mutable_function(int index) {
-  // @@protoc_insertion_point(field_mutable:tensorflow.FunctionDefLibrary.function)
+inline ::opencv_tensorflow::FunctionDef* FunctionDefLibrary::mutable_function(int index) {
+  // @@protoc_insertion_point(field_mutable:opencv_tensorflow.FunctionDefLibrary.function)
   return function_.Mutable(index);
 }
-inline ::tensorflow::FunctionDef* FunctionDefLibrary::add_function() {
-  // @@protoc_insertion_point(field_add:tensorflow.FunctionDefLibrary.function)
+inline ::opencv_tensorflow::FunctionDef* FunctionDefLibrary::add_function() {
+  // @@protoc_insertion_point(field_add:opencv_tensorflow.FunctionDefLibrary.function)
   return function_.Add();
 }
-inline ::google::protobuf::RepeatedPtrField< ::tensorflow::FunctionDef >*
+inline ::google::protobuf::RepeatedPtrField< ::opencv_tensorflow::FunctionDef >*
 FunctionDefLibrary::mutable_function() {
-  // @@protoc_insertion_point(field_mutable_list:tensorflow.FunctionDefLibrary.function)
+  // @@protoc_insertion_point(field_mutable_list:opencv_tensorflow.FunctionDefLibrary.function)
   return &function_;
 }
-inline const ::google::protobuf::RepeatedPtrField< ::tensorflow::FunctionDef >&
+inline const ::google::protobuf::RepeatedPtrField< ::opencv_tensorflow::FunctionDef >&
 FunctionDefLibrary::function() const {
-  // @@protoc_insertion_point(field_list:tensorflow.FunctionDefLibrary.function)
+  // @@protoc_insertion_point(field_list:opencv_tensorflow.FunctionDefLibrary.function)
   return function_;
 }
 
-// repeated .tensorflow.GradientDef gradient = 2;
+// repeated .opencv_tensorflow.GradientDef gradient = 2;
 inline int FunctionDefLibrary::gradient_size() const {
   return gradient_.size();
 }
 inline void FunctionDefLibrary::clear_gradient() {
   gradient_.Clear();
 }
-inline const ::tensorflow::GradientDef& FunctionDefLibrary::gradient(int index) const {
-  // @@protoc_insertion_point(field_get:tensorflow.FunctionDefLibrary.gradient)
+inline const ::opencv_tensorflow::GradientDef& FunctionDefLibrary::gradient(int index) const {
+  // @@protoc_insertion_point(field_get:opencv_tensorflow.FunctionDefLibrary.gradient)
   return gradient_.Get(index);
 }
-inline ::tensorflow::GradientDef* FunctionDefLibrary::mutable_gradient(int index) {
-  // @@protoc_insertion_point(field_mutable:tensorflow.FunctionDefLibrary.gradient)
+inline ::opencv_tensorflow::GradientDef* FunctionDefLibrary::mutable_gradient(int index) {
+  // @@protoc_insertion_point(field_mutable:opencv_tensorflow.FunctionDefLibrary.gradient)
   return gradient_.Mutable(index);
 }
-inline ::tensorflow::GradientDef* FunctionDefLibrary::add_gradient() {
-  // @@protoc_insertion_point(field_add:tensorflow.FunctionDefLibrary.gradient)
+inline ::opencv_tensorflow::GradientDef* FunctionDefLibrary::add_gradient() {
+  // @@protoc_insertion_point(field_add:opencv_tensorflow.FunctionDefLibrary.gradient)
   return gradient_.Add();
 }
-inline ::google::protobuf::RepeatedPtrField< ::tensorflow::GradientDef >*
+inline ::google::protobuf::RepeatedPtrField< ::opencv_tensorflow::GradientDef >*
 FunctionDefLibrary::mutable_gradient() {
-  // @@protoc_insertion_point(field_mutable_list:tensorflow.FunctionDefLibrary.gradient)
+  // @@protoc_insertion_point(field_mutable_list:opencv_tensorflow.FunctionDefLibrary.gradient)
   return &gradient_;
 }
-inline const ::google::protobuf::RepeatedPtrField< ::tensorflow::GradientDef >&
+inline const ::google::protobuf::RepeatedPtrField< ::opencv_tensorflow::GradientDef >&
 FunctionDefLibrary::gradient() const {
-  // @@protoc_insertion_point(field_list:tensorflow.FunctionDefLibrary.gradient)
+  // @@protoc_insertion_point(field_list:opencv_tensorflow.FunctionDefLibrary.gradient)
   return gradient_;
 }
 
@@ -832,64 +832,64 @@ inline void FunctionDef_Node::clear_ret() {
   ret_.Clear();
 }
 inline const ::std::string& FunctionDef_Node::ret(int index) const {
-  // @@protoc_insertion_point(field_get:tensorflow.FunctionDef.Node.ret)
+  // @@protoc_insertion_point(field_get:opencv_tensorflow.FunctionDef.Node.ret)
   return ret_.Get(index);
 }
 inline ::std::string* FunctionDef_Node::mutable_ret(int index) {
-  // @@protoc_insertion_point(field_mutable:tensorflow.FunctionDef.Node.ret)
+  // @@protoc_insertion_point(field_mutable:opencv_tensorflow.FunctionDef.Node.ret)
   return ret_.Mutable(index);
 }
 inline void FunctionDef_Node::set_ret(int index, const ::std::string& value) {
-  // @@protoc_insertion_point(field_set:tensorflow.FunctionDef.Node.ret)
+  // @@protoc_insertion_point(field_set:opencv_tensorflow.FunctionDef.Node.ret)
   ret_.Mutable(index)->assign(value);
 }
 #if LANG_CXX11
 inline void FunctionDef_Node::set_ret(int index, ::std::string&& value) {
-  // @@protoc_insertion_point(field_set:tensorflow.FunctionDef.Node.ret)
+  // @@protoc_insertion_point(field_set:opencv_tensorflow.FunctionDef.Node.ret)
   ret_.Mutable(index)->assign(std::move(value));
 }
 #endif
 inline void FunctionDef_Node::set_ret(int index, const char* value) {
   GOOGLE_DCHECK(value != NULL);
   ret_.Mutable(index)->assign(value);
-  // @@protoc_insertion_point(field_set_char:tensorflow.FunctionDef.Node.ret)
+  // @@protoc_insertion_point(field_set_char:opencv_tensorflow.FunctionDef.Node.ret)
 }
 inline void FunctionDef_Node::set_ret(int index, const char* value, size_t size) {
   ret_.Mutable(index)->assign(
     reinterpret_cast<const char*>(value), size);
-  // @@protoc_insertion_point(field_set_pointer:tensorflow.FunctionDef.Node.ret)
+  // @@protoc_insertion_point(field_set_pointer:opencv_tensorflow.FunctionDef.Node.ret)
 }
 inline ::std::string* FunctionDef_Node::add_ret() {
-  // @@protoc_insertion_point(field_add_mutable:tensorflow.FunctionDef.Node.ret)
+  // @@protoc_insertion_point(field_add_mutable:opencv_tensorflow.FunctionDef.Node.ret)
   return ret_.Add();
 }
 inline void FunctionDef_Node::add_ret(const ::std::string& value) {
   ret_.Add()->assign(value);
-  // @@protoc_insertion_point(field_add:tensorflow.FunctionDef.Node.ret)
+  // @@protoc_insertion_point(field_add:opencv_tensorflow.FunctionDef.Node.ret)
 }
 #if LANG_CXX11
 inline void FunctionDef_Node::add_ret(::std::string&& value) {
   ret_.Add(std::move(value));
-  // @@protoc_insertion_point(field_add:tensorflow.FunctionDef.Node.ret)
+  // @@protoc_insertion_point(field_add:opencv_tensorflow.FunctionDef.Node.ret)
 }
 #endif
 inline void FunctionDef_Node::add_ret(const char* value) {
   GOOGLE_DCHECK(value != NULL);
   ret_.Add()->assign(value);
-  // @@protoc_insertion_point(field_add_char:tensorflow.FunctionDef.Node.ret)
+  // @@protoc_insertion_point(field_add_char:opencv_tensorflow.FunctionDef.Node.ret)
 }
 inline void FunctionDef_Node::add_ret(const char* value, size_t size) {
   ret_.Add()->assign(reinterpret_cast<const char*>(value), size);
-  // @@protoc_insertion_point(field_add_pointer:tensorflow.FunctionDef.Node.ret)
+  // @@protoc_insertion_point(field_add_pointer:opencv_tensorflow.FunctionDef.Node.ret)
 }
 inline const ::google::protobuf::RepeatedPtrField< ::std::string>&
 FunctionDef_Node::ret() const {
-  // @@protoc_insertion_point(field_list:tensorflow.FunctionDef.Node.ret)
+  // @@protoc_insertion_point(field_list:opencv_tensorflow.FunctionDef.Node.ret)
   return ret_;
 }
 inline ::google::protobuf::RepeatedPtrField< ::std::string>*
 FunctionDef_Node::mutable_ret() {
-  // @@protoc_insertion_point(field_mutable_list:tensorflow.FunctionDef.Node.ret)
+  // @@protoc_insertion_point(field_mutable_list:opencv_tensorflow.FunctionDef.Node.ret)
   return &ret_;
 }
 
@@ -898,20 +898,20 @@ inline void FunctionDef_Node::clear_op() {
   op_.ClearToEmpty(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), GetArenaNoVirtual());
 }
 inline const ::std::string& FunctionDef_Node::op() const {
-  // @@protoc_insertion_point(field_get:tensorflow.FunctionDef.Node.op)
+  // @@protoc_insertion_point(field_get:opencv_tensorflow.FunctionDef.Node.op)
   return op_.Get();
 }
 inline void FunctionDef_Node::set_op(const ::std::string& value) {
 
   op_.Set(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), value, GetArenaNoVirtual());
-  // @@protoc_insertion_point(field_set:tensorflow.FunctionDef.Node.op)
+  // @@protoc_insertion_point(field_set:opencv_tensorflow.FunctionDef.Node.op)
 }
 #if LANG_CXX11
 inline void FunctionDef_Node::set_op(::std::string&& value) {
 
   op_.Set(
     &::google::protobuf::internal::GetEmptyStringAlreadyInited(), ::std::move(value), GetArenaNoVirtual());
-  // @@protoc_insertion_point(field_set_rvalue:tensorflow.FunctionDef.Node.op)
+  // @@protoc_insertion_point(field_set_rvalue:opencv_tensorflow.FunctionDef.Node.op)
 }
 #endif
 inline void FunctionDef_Node::set_op(const char* value) {
@@ -919,22 +919,22 @@ inline void FunctionDef_Node::set_op(const char* value) {
 
   op_.Set(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), ::std::string(value),
               GetArenaNoVirtual());
-  // @@protoc_insertion_point(field_set_char:tensorflow.FunctionDef.Node.op)
+  // @@protoc_insertion_point(field_set_char:opencv_tensorflow.FunctionDef.Node.op)
 }
 inline void FunctionDef_Node::set_op(const char* value,
     size_t size) {
 
   op_.Set(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), ::std::string(
       reinterpret_cast<const char*>(value), size), GetArenaNoVirtual());
-  // @@protoc_insertion_point(field_set_pointer:tensorflow.FunctionDef.Node.op)
+  // @@protoc_insertion_point(field_set_pointer:opencv_tensorflow.FunctionDef.Node.op)
 }
 inline ::std::string* FunctionDef_Node::mutable_op() {
 
-  // @@protoc_insertion_point(field_mutable:tensorflow.FunctionDef.Node.op)
+  // @@protoc_insertion_point(field_mutable:opencv_tensorflow.FunctionDef.Node.op)
   return op_.Mutable(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), GetArenaNoVirtual());
 }
 inline ::std::string* FunctionDef_Node::release_op() {
-  // @@protoc_insertion_point(field_release:tensorflow.FunctionDef.Node.op)
+  // @@protoc_insertion_point(field_release:opencv_tensorflow.FunctionDef.Node.op)
 
   return op_.Release(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), GetArenaNoVirtual());
 }
@@ -946,10 +946,10 @@ inline void FunctionDef_Node::set_allocated_op(::std::string* op) {
   }
   op_.SetAllocated(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), op,
       GetArenaNoVirtual());
-  // @@protoc_insertion_point(field_set_allocated:tensorflow.FunctionDef.Node.op)
+  // @@protoc_insertion_point(field_set_allocated:opencv_tensorflow.FunctionDef.Node.op)
 }
 inline ::std::string* FunctionDef_Node::unsafe_arena_release_op() {
-  // @@protoc_insertion_point(field_unsafe_arena_release:tensorflow.FunctionDef.Node.op)
+  // @@protoc_insertion_point(field_unsafe_arena_release:opencv_tensorflow.FunctionDef.Node.op)
   GOOGLE_DCHECK(GetArenaNoVirtual() != NULL);
 
   return op_.UnsafeArenaRelease(&::google::protobuf::internal::GetEmptyStringAlreadyInited(),
@@ -965,7 +965,7 @@ inline void FunctionDef_Node::unsafe_arena_set_allocated_op(
   }
   op_.UnsafeArenaSetAllocated(&::google::protobuf::internal::GetEmptyStringAlreadyInited(),
       op, GetArenaNoVirtual());
-  // @@protoc_insertion_point(field_unsafe_arena_set_allocated:tensorflow.FunctionDef.Node.op)
+  // @@protoc_insertion_point(field_unsafe_arena_set_allocated:opencv_tensorflow.FunctionDef.Node.op)
 }
 
 // repeated string arg = 3;
@@ -976,64 +976,64 @@ inline void FunctionDef_Node::clear_arg() {
   arg_.Clear();
 }
 inline const ::std::string& FunctionDef_Node::arg(int index) const {
-  // @@protoc_insertion_point(field_get:tensorflow.FunctionDef.Node.arg)
+  // @@protoc_insertion_point(field_get:opencv_tensorflow.FunctionDef.Node.arg)
   return arg_.Get(index);
 }
 inline ::std::string* FunctionDef_Node::mutable_arg(int index) {
-  // @@protoc_insertion_point(field_mutable:tensorflow.FunctionDef.Node.arg)
+  // @@protoc_insertion_point(field_mutable:opencv_tensorflow.FunctionDef.Node.arg)
   return arg_.Mutable(index);
 }
 inline void FunctionDef_Node::set_arg(int index, const ::std::string& value) {
-  // @@protoc_insertion_point(field_set:tensorflow.FunctionDef.Node.arg)
+  // @@protoc_insertion_point(field_set:opencv_tensorflow.FunctionDef.Node.arg)
   arg_.Mutable(index)->assign(value);
 }
 #if LANG_CXX11
 inline void FunctionDef_Node::set_arg(int index, ::std::string&& value) {
-  // @@protoc_insertion_point(field_set:tensorflow.FunctionDef.Node.arg)
+  // @@protoc_insertion_point(field_set:opencv_tensorflow.FunctionDef.Node.arg)
   arg_.Mutable(index)->assign(std::move(value));
 }
 #endif
 inline void FunctionDef_Node::set_arg(int index, const char* value) {
   GOOGLE_DCHECK(value != NULL);
   arg_.Mutable(index)->assign(value);
-  // @@protoc_insertion_point(field_set_char:tensorflow.FunctionDef.Node.arg)
+  // @@protoc_insertion_point(field_set_char:opencv_tensorflow.FunctionDef.Node.arg)
 }
 inline void FunctionDef_Node::set_arg(int index, const char* value, size_t size) {
   arg_.Mutable(index)->assign(
     reinterpret_cast<const char*>(value), size);
-  // @@protoc_insertion_point(field_set_pointer:tensorflow.FunctionDef.Node.arg)
+  // @@protoc_insertion_point(field_set_pointer:opencv_tensorflow.FunctionDef.Node.arg)
 }
 inline ::std::string* FunctionDef_Node::add_arg() {
-  // @@protoc_insertion_point(field_add_mutable:tensorflow.FunctionDef.Node.arg)
+  // @@protoc_insertion_point(field_add_mutable:opencv_tensorflow.FunctionDef.Node.arg)
   return arg_.Add();
 }
 inline void FunctionDef_Node::add_arg(const ::std::string& value) {
   arg_.Add()->assign(value);
-  // @@protoc_insertion_point(field_add:tensorflow.FunctionDef.Node.arg)
+  // @@protoc_insertion_point(field_add:opencv_tensorflow.FunctionDef.Node.arg)
 }
 #if LANG_CXX11
 inline void FunctionDef_Node::add_arg(::std::string&& value) {
   arg_.Add(std::move(value));
-  // @@protoc_insertion_point(field_add:tensorflow.FunctionDef.Node.arg)
+  // @@protoc_insertion_point(field_add:opencv_tensorflow.FunctionDef.Node.arg)
 }
 #endif
 inline void FunctionDef_Node::add_arg(const char* value) {
   GOOGLE_DCHECK(value != NULL);
   arg_.Add()->assign(value);
-  // @@protoc_insertion_point(field_add_char:tensorflow.FunctionDef.Node.arg)
+  // @@protoc_insertion_point(field_add_char:opencv_tensorflow.FunctionDef.Node.arg)
 }
 inline void FunctionDef_Node::add_arg(const char* value, size_t size) {
   arg_.Add()->assign(reinterpret_cast<const char*>(value), size);
-  // @@protoc_insertion_point(field_add_pointer:tensorflow.FunctionDef.Node.arg)
+  // @@protoc_insertion_point(field_add_pointer:opencv_tensorflow.FunctionDef.Node.arg)
 }
 inline const ::google::protobuf::RepeatedPtrField< ::std::string>&
 FunctionDef_Node::arg() const {
-  // @@protoc_insertion_point(field_list:tensorflow.FunctionDef.Node.arg)
+  // @@protoc_insertion_point(field_list:opencv_tensorflow.FunctionDef.Node.arg)
   return arg_;
 }
 inline ::google::protobuf::RepeatedPtrField< ::std::string>*
 FunctionDef_Node::mutable_arg() {
-  // @@protoc_insertion_point(field_mutable_list:tensorflow.FunctionDef.Node.arg)
+  // @@protoc_insertion_point(field_mutable_list:opencv_tensorflow.FunctionDef.Node.arg)
   return &arg_;
 }
 
@@ -1045,79 +1045,79 @@ inline void FunctionDef_Node::clear_dep() {
   dep_.Clear();
 }
 inline const ::std::string& FunctionDef_Node::dep(int index) const {
-  // @@protoc_insertion_point(field_get:tensorflow.FunctionDef.Node.dep)
+  // @@protoc_insertion_point(field_get:opencv_tensorflow.FunctionDef.Node.dep)
   return dep_.Get(index);
 }
 inline ::std::string* FunctionDef_Node::mutable_dep(int index) {
-  // @@protoc_insertion_point(field_mutable:tensorflow.FunctionDef.Node.dep)
+  // @@protoc_insertion_point(field_mutable:opencv_tensorflow.FunctionDef.Node.dep)
   return dep_.Mutable(index);
 }
 inline void FunctionDef_Node::set_dep(int index, const ::std::string& value) {
-  // @@protoc_insertion_point(field_set:tensorflow.FunctionDef.Node.dep)
+  // @@protoc_insertion_point(field_set:opencv_tensorflow.FunctionDef.Node.dep)
   dep_.Mutable(index)->assign(value);
 }
 #if LANG_CXX11
 inline void FunctionDef_Node::set_dep(int index, ::std::string&& value) {
-  // @@protoc_insertion_point(field_set:tensorflow.FunctionDef.Node.dep)
+  // @@protoc_insertion_point(field_set:opencv_tensorflow.FunctionDef.Node.dep)
   dep_.Mutable(index)->assign(std::move(value));
 }
 #endif
 inline void FunctionDef_Node::set_dep(int index, const char* value) {
   GOOGLE_DCHECK(value != NULL);
   dep_.Mutable(index)->assign(value);
-  // @@protoc_insertion_point(field_set_char:tensorflow.FunctionDef.Node.dep)
+  // @@protoc_insertion_point(field_set_char:opencv_tensorflow.FunctionDef.Node.dep)
 }
 inline void FunctionDef_Node::set_dep(int index, const char* value, size_t size) {
   dep_.Mutable(index)->assign(
     reinterpret_cast<const char*>(value), size);
-  // @@protoc_insertion_point(field_set_pointer:tensorflow.FunctionDef.Node.dep)
+  // @@protoc_insertion_point(field_set_pointer:opencv_tensorflow.FunctionDef.Node.dep)
 }
 inline ::std::string* FunctionDef_Node::add_dep() {
-  // @@protoc_insertion_point(field_add_mutable:tensorflow.FunctionDef.Node.dep)
+  // @@protoc_insertion_point(field_add_mutable:opencv_tensorflow.FunctionDef.Node.dep)
   return dep_.Add();
 }
 inline void FunctionDef_Node::add_dep(const ::std::string& value) {
   dep_.Add()->assign(value);
-  // @@protoc_insertion_point(field_add:tensorflow.FunctionDef.Node.dep)
+  // @@protoc_insertion_point(field_add:opencv_tensorflow.FunctionDef.Node.dep)
 }
 #if LANG_CXX11
 inline void FunctionDef_Node::add_dep(::std::string&& value) {
   dep_.Add(std::move(value));
-  // @@protoc_insertion_point(field_add:tensorflow.FunctionDef.Node.dep)
+  // @@protoc_insertion_point(field_add:opencv_tensorflow.FunctionDef.Node.dep)
 }
 #endif
 inline void FunctionDef_Node::add_dep(const char* value) {
   GOOGLE_DCHECK(value != NULL);
   dep_.Add()->assign(value);
-  // @@protoc_insertion_point(field_add_char:tensorflow.FunctionDef.Node.dep)
+  // @@protoc_insertion_point(field_add_char:opencv_tensorflow.FunctionDef.Node.dep)
 }
 inline void FunctionDef_Node::add_dep(const char* value, size_t size) {
   dep_.Add()->assign(reinterpret_cast<const char*>(value), size);
-  // @@protoc_insertion_point(field_add_pointer:tensorflow.FunctionDef.Node.dep)
+  // @@protoc_insertion_point(field_add_pointer:opencv_tensorflow.FunctionDef.Node.dep)
 }
 inline const ::google::protobuf::RepeatedPtrField< ::std::string>&
 FunctionDef_Node::dep() const {
-  // @@protoc_insertion_point(field_list:tensorflow.FunctionDef.Node.dep)
+  // @@protoc_insertion_point(field_list:opencv_tensorflow.FunctionDef.Node.dep)
   return dep_;
 }
 inline ::google::protobuf::RepeatedPtrField< ::std::string>*
 FunctionDef_Node::mutable_dep() {
-  // @@protoc_insertion_point(field_mutable_list:tensorflow.FunctionDef.Node.dep)
+  // @@protoc_insertion_point(field_mutable_list:opencv_tensorflow.FunctionDef.Node.dep)
   return &dep_;
 }
 
-// map<string, .tensorflow.AttrValue> attr = 5;
+// map<string, .opencv_tensorflow.AttrValue> attr = 5;
 inline int FunctionDef_Node::attr_size() const {
   return attr_.size();
 }
-inline const ::google::protobuf::Map< ::std::string, ::tensorflow::AttrValue >&
+inline const ::google::protobuf::Map< ::std::string, ::opencv_tensorflow::AttrValue >&
 FunctionDef_Node::attr() const {
-  // @@protoc_insertion_point(field_map:tensorflow.FunctionDef.Node.attr)
+  // @@protoc_insertion_point(field_map:opencv_tensorflow.FunctionDef.Node.attr)
   return attr_.GetMap();
 }
-inline ::google::protobuf::Map< ::std::string, ::tensorflow::AttrValue >*
+inline ::google::protobuf::Map< ::std::string, ::opencv_tensorflow::AttrValue >*
 FunctionDef_Node::mutable_attr() {
-  // @@protoc_insertion_point(field_mutable_map:tensorflow.FunctionDef.Node.attr)
+  // @@protoc_insertion_point(field_mutable_map:opencv_tensorflow.FunctionDef.Node.attr)
   return attr_.MutableMap();
 }
 
@@ -1125,42 +1125,42 @@ FunctionDef_Node::mutable_attr() {
 
 // FunctionDef
 
-// .tensorflow.OpDef signature = 1;
+// .opencv_tensorflow.OpDef signature = 1;
 inline bool FunctionDef::has_signature() const {
   return this != internal_default_instance() && signature_ != NULL;
 }
-inline const ::tensorflow::OpDef& FunctionDef::signature() const {
-  const ::tensorflow::OpDef* p = signature_;
-  // @@protoc_insertion_point(field_get:tensorflow.FunctionDef.signature)
-  return p != NULL ? *p : *reinterpret_cast<const ::tensorflow::OpDef*>(
-      &::tensorflow::_OpDef_default_instance_);
+inline const ::opencv_tensorflow::OpDef& FunctionDef::signature() const {
+  const ::opencv_tensorflow::OpDef* p = signature_;
+  // @@protoc_insertion_point(field_get:opencv_tensorflow.FunctionDef.signature)
+  return p != NULL ? *p : *reinterpret_cast<const ::opencv_tensorflow::OpDef*>(
+      &::opencv_tensorflow::_OpDef_default_instance_);
 }
-inline ::tensorflow::OpDef* FunctionDef::release_signature() {
-  // @@protoc_insertion_point(field_release:tensorflow.FunctionDef.signature)
+inline ::opencv_tensorflow::OpDef* FunctionDef::release_signature() {
+  // @@protoc_insertion_point(field_release:opencv_tensorflow.FunctionDef.signature)
 
-  ::tensorflow::OpDef* temp = signature_;
+  ::opencv_tensorflow::OpDef* temp = signature_;
   if (GetArenaNoVirtual() != NULL) {
     temp = ::google::protobuf::internal::DuplicateIfNonNull(temp, NULL);
   }
   signature_ = NULL;
   return temp;
 }
-inline ::tensorflow::OpDef* FunctionDef::unsafe_arena_release_signature() {
-  // @@protoc_insertion_point(field_unsafe_arena_release:tensorflow.FunctionDef.signature)
+inline ::opencv_tensorflow::OpDef* FunctionDef::unsafe_arena_release_signature() {
+  // @@protoc_insertion_point(field_unsafe_arena_release:opencv_tensorflow.FunctionDef.signature)
 
-  ::tensorflow::OpDef* temp = signature_;
+  ::opencv_tensorflow::OpDef* temp = signature_;
   signature_ = NULL;
   return temp;
 }
-inline ::tensorflow::OpDef* FunctionDef::mutable_signature() {
+inline ::opencv_tensorflow::OpDef* FunctionDef::mutable_signature() {
 
   if (signature_ == NULL) {
     _slow_mutable_signature();
   }
-  // @@protoc_insertion_point(field_mutable:tensorflow.FunctionDef.signature)
+  // @@protoc_insertion_point(field_mutable:opencv_tensorflow.FunctionDef.signature)
   return signature_;
 }
-inline void FunctionDef::set_allocated_signature(::tensorflow::OpDef* signature) {
+inline void FunctionDef::set_allocated_signature(::opencv_tensorflow::OpDef* signature) {
   ::google::protobuf::Arena* message_arena = GetArenaNoVirtual();
   if (message_arena == NULL) {
     delete reinterpret_cast< ::google::protobuf::MessageLite*>(signature_);
@@ -1177,36 +1177,36 @@ inline void FunctionDef::set_allocated_signature(::tensorflow::OpDef* signature)
 
   }
   signature_ = signature;
-  // @@protoc_insertion_point(field_set_allocated:tensorflow.FunctionDef.signature)
+  // @@protoc_insertion_point(field_set_allocated:opencv_tensorflow.FunctionDef.signature)
 }
 
-// repeated .tensorflow.FunctionDef.Node node = 2;
+// repeated .opencv_tensorflow.FunctionDef.Node node = 2;
 inline int FunctionDef::node_size() const {
   return node_.size();
 }
 inline void FunctionDef::clear_node() {
   node_.Clear();
 }
-inline const ::tensorflow::FunctionDef_Node& FunctionDef::node(int index) const {
-  // @@protoc_insertion_point(field_get:tensorflow.FunctionDef.node)
+inline const ::opencv_tensorflow::FunctionDef_Node& FunctionDef::node(int index) const {
+  // @@protoc_insertion_point(field_get:opencv_tensorflow.FunctionDef.node)
   return node_.Get(index);
 }
-inline ::tensorflow::FunctionDef_Node* FunctionDef::mutable_node(int index) {
-  // @@protoc_insertion_point(field_mutable:tensorflow.FunctionDef.node)
+inline ::opencv_tensorflow::FunctionDef_Node* FunctionDef::mutable_node(int index) {
+  // @@protoc_insertion_point(field_mutable:opencv_tensorflow.FunctionDef.node)
   return node_.Mutable(index);
 }
-inline ::tensorflow::FunctionDef_Node* FunctionDef::add_node() {
-  // @@protoc_insertion_point(field_add:tensorflow.FunctionDef.node)
+inline ::opencv_tensorflow::FunctionDef_Node* FunctionDef::add_node() {
+  // @@protoc_insertion_point(field_add:opencv_tensorflow.FunctionDef.node)
   return node_.Add();
 }
-inline ::google::protobuf::RepeatedPtrField< ::tensorflow::FunctionDef_Node >*
+inline ::google::protobuf::RepeatedPtrField< ::opencv_tensorflow::FunctionDef_Node >*
 FunctionDef::mutable_node() {
-  // @@protoc_insertion_point(field_mutable_list:tensorflow.FunctionDef.node)
+  // @@protoc_insertion_point(field_mutable_list:opencv_tensorflow.FunctionDef.node)
   return &node_;
 }
-inline const ::google::protobuf::RepeatedPtrField< ::tensorflow::FunctionDef_Node >&
+inline const ::google::protobuf::RepeatedPtrField< ::opencv_tensorflow::FunctionDef_Node >&
 FunctionDef::node() const {
-  // @@protoc_insertion_point(field_list:tensorflow.FunctionDef.node)
+  // @@protoc_insertion_point(field_list:opencv_tensorflow.FunctionDef.node)
   return node_;
 }
 
@@ -1219,20 +1219,20 @@ inline void GradientDef::clear_function_name() {
   function_name_.ClearToEmpty(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), GetArenaNoVirtual());
 }
 inline const ::std::string& GradientDef::function_name() const {
-  // @@protoc_insertion_point(field_get:tensorflow.GradientDef.function_name)
+  // @@protoc_insertion_point(field_get:opencv_tensorflow.GradientDef.function_name)
   return function_name_.Get();
 }
 inline void GradientDef::set_function_name(const ::std::string& value) {
 
   function_name_.Set(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), value, GetArenaNoVirtual());
-  // @@protoc_insertion_point(field_set:tensorflow.GradientDef.function_name)
+  // @@protoc_insertion_point(field_set:opencv_tensorflow.GradientDef.function_name)
 }
 #if LANG_CXX11
 inline void GradientDef::set_function_name(::std::string&& value) {
 
   function_name_.Set(
     &::google::protobuf::internal::GetEmptyStringAlreadyInited(), ::std::move(value), GetArenaNoVirtual());
-  // @@protoc_insertion_point(field_set_rvalue:tensorflow.GradientDef.function_name)
+  // @@protoc_insertion_point(field_set_rvalue:opencv_tensorflow.GradientDef.function_name)
 }
 #endif
 inline void GradientDef::set_function_name(const char* value) {
@@ -1240,22 +1240,22 @@ inline void GradientDef::set_function_name(const char* value) {
 
   function_name_.Set(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), ::std::string(value),
               GetArenaNoVirtual());
-  // @@protoc_insertion_point(field_set_char:tensorflow.GradientDef.function_name)
+  // @@protoc_insertion_point(field_set_char:opencv_tensorflow.GradientDef.function_name)
 }
 inline void GradientDef::set_function_name(const char* value,
     size_t size) {
 
   function_name_.Set(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), ::std::string(
       reinterpret_cast<const char*>(value), size), GetArenaNoVirtual());
-  // @@protoc_insertion_point(field_set_pointer:tensorflow.GradientDef.function_name)
+  // @@protoc_insertion_point(field_set_pointer:opencv_tensorflow.GradientDef.function_name)
 }
 inline ::std::string* GradientDef::mutable_function_name() {
 
-  // @@protoc_insertion_point(field_mutable:tensorflow.GradientDef.function_name)
+  // @@protoc_insertion_point(field_mutable:opencv_tensorflow.GradientDef.function_name)
   return function_name_.Mutable(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), GetArenaNoVirtual());
 }
 inline ::std::string* GradientDef::release_function_name() {
-  // @@protoc_insertion_point(field_release:tensorflow.GradientDef.function_name)
+  // @@protoc_insertion_point(field_release:opencv_tensorflow.GradientDef.function_name)
 
   return function_name_.Release(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), GetArenaNoVirtual());
 }
@@ -1267,10 +1267,10 @@ inline void GradientDef::set_allocated_function_name(::std::string* function_nam
   }
   function_name_.SetAllocated(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), function_name,
       GetArenaNoVirtual());
-  // @@protoc_insertion_point(field_set_allocated:tensorflow.GradientDef.function_name)
+  // @@protoc_insertion_point(field_set_allocated:opencv_tensorflow.GradientDef.function_name)
 }
 inline ::std::string* GradientDef::unsafe_arena_release_function_name() {
-  // @@protoc_insertion_point(field_unsafe_arena_release:tensorflow.GradientDef.function_name)
+  // @@protoc_insertion_point(field_unsafe_arena_release:opencv_tensorflow.GradientDef.function_name)
   GOOGLE_DCHECK(GetArenaNoVirtual() != NULL);
 
   return function_name_.UnsafeArenaRelease(&::google::protobuf::internal::GetEmptyStringAlreadyInited(),
@@ -1286,7 +1286,7 @@ inline void GradientDef::unsafe_arena_set_allocated_function_name(
   }
   function_name_.UnsafeArenaSetAllocated(&::google::protobuf::internal::GetEmptyStringAlreadyInited(),
       function_name, GetArenaNoVirtual());
-  // @@protoc_insertion_point(field_unsafe_arena_set_allocated:tensorflow.GradientDef.function_name)
+  // @@protoc_insertion_point(field_unsafe_arena_set_allocated:opencv_tensorflow.GradientDef.function_name)
 }
 
 // string gradient_func = 2;
@@ -1294,20 +1294,20 @@ inline void GradientDef::clear_gradient_func() {
   gradient_func_.ClearToEmpty(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), GetArenaNoVirtual());
 }
 inline const ::std::string& GradientDef::gradient_func() const {
-  // @@protoc_insertion_point(field_get:tensorflow.GradientDef.gradient_func)
+  // @@protoc_insertion_point(field_get:opencv_tensorflow.GradientDef.gradient_func)
   return gradient_func_.Get();
 }
 inline void GradientDef::set_gradient_func(const ::std::string& value) {
 
   gradient_func_.Set(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), value, GetArenaNoVirtual());
-  // @@protoc_insertion_point(field_set:tensorflow.GradientDef.gradient_func)
+  // @@protoc_insertion_point(field_set:opencv_tensorflow.GradientDef.gradient_func)
 }
 #if LANG_CXX11
 inline void GradientDef::set_gradient_func(::std::string&& value) {
 
   gradient_func_.Set(
     &::google::protobuf::internal::GetEmptyStringAlreadyInited(), ::std::move(value), GetArenaNoVirtual());
-  // @@protoc_insertion_point(field_set_rvalue:tensorflow.GradientDef.gradient_func)
+  // @@protoc_insertion_point(field_set_rvalue:opencv_tensorflow.GradientDef.gradient_func)
 }
 #endif
 inline void GradientDef::set_gradient_func(const char* value) {
@@ -1315,22 +1315,22 @@ inline void GradientDef::set_gradient_func(const char* value) {
 
   gradient_func_.Set(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), ::std::string(value),
               GetArenaNoVirtual());
-  // @@protoc_insertion_point(field_set_char:tensorflow.GradientDef.gradient_func)
+  // @@protoc_insertion_point(field_set_char:opencv_tensorflow.GradientDef.gradient_func)
 }
 inline void GradientDef::set_gradient_func(const char* value,
     size_t size) {
 
   gradient_func_.Set(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), ::std::string(
       reinterpret_cast<const char*>(value), size), GetArenaNoVirtual());
-  // @@protoc_insertion_point(field_set_pointer:tensorflow.GradientDef.gradient_func)
+  // @@protoc_insertion_point(field_set_pointer:opencv_tensorflow.GradientDef.gradient_func)
 }
 inline ::std::string* GradientDef::mutable_gradient_func() {
 
-  // @@protoc_insertion_point(field_mutable:tensorflow.GradientDef.gradient_func)
+  // @@protoc_insertion_point(field_mutable:opencv_tensorflow.GradientDef.gradient_func)
   return gradient_func_.Mutable(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), GetArenaNoVirtual());
 }
 inline ::std::string* GradientDef::release_gradient_func() {
-  // @@protoc_insertion_point(field_release:tensorflow.GradientDef.gradient_func)
+  // @@protoc_insertion_point(field_release:opencv_tensorflow.GradientDef.gradient_func)
 
   return gradient_func_.Release(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), GetArenaNoVirtual());
 }
@@ -1342,10 +1342,10 @@ inline void GradientDef::set_allocated_gradient_func(::std::string* gradient_fun
   }
   gradient_func_.SetAllocated(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), gradient_func,
       GetArenaNoVirtual());
-  // @@protoc_insertion_point(field_set_allocated:tensorflow.GradientDef.gradient_func)
+  // @@protoc_insertion_point(field_set_allocated:opencv_tensorflow.GradientDef.gradient_func)
 }
 inline ::std::string* GradientDef::unsafe_arena_release_gradient_func() {
-  // @@protoc_insertion_point(field_unsafe_arena_release:tensorflow.GradientDef.gradient_func)
+  // @@protoc_insertion_point(field_unsafe_arena_release:opencv_tensorflow.GradientDef.gradient_func)
   GOOGLE_DCHECK(GetArenaNoVirtual() != NULL);
 
   return gradient_func_.UnsafeArenaRelease(&::google::protobuf::internal::GetEmptyStringAlreadyInited(),
@@ -1361,7 +1361,7 @@ inline void GradientDef::unsafe_arena_set_allocated_gradient_func(
   }
   gradient_func_.UnsafeArenaSetAllocated(&::google::protobuf::internal::GetEmptyStringAlreadyInited(),
       gradient_func, GetArenaNoVirtual());
-  // @@protoc_insertion_point(field_unsafe_arena_set_allocated:tensorflow.GradientDef.gradient_func)
+  // @@protoc_insertion_point(field_unsafe_arena_set_allocated:opencv_tensorflow.GradientDef.gradient_func)
 }
 
 #ifdef __GNUC__
@@ -1378,7 +1378,7 @@ inline void GradientDef::unsafe_arena_set_allocated_gradient_func(
 
 // @@protoc_insertion_point(namespace_scope)
 
-}  // namespace tensorflow
+}  // namespace opencv_tensorflow
 
 // @@protoc_insertion_point(global_scope)
 

--- a/modules/dnn/misc/tensorflow/graph.pb.cc
+++ b/modules/dnn/misc/tensorflow/graph.pb.cc
@@ -19,7 +19,7 @@
 #include "third_party/protobuf/version.h"
 #endif
 // @@protoc_insertion_point(includes)
-namespace tensorflow {
+namespace opencv_tensorflow {
 class GraphDefDefaultTypeInternal {
  public:
   ::google::protobuf::internal::ExplicitlyConstructed<GraphDef>
@@ -35,7 +35,7 @@ class NodeDefDefaultTypeInternal {
   ::google::protobuf::internal::ExplicitlyConstructed<NodeDef>
       _instance;
 } _NodeDef_default_instance_;
-}  // namespace tensorflow
+}  // namespace opencv_tensorflow
 namespace protobuf_graph_2eproto {
 void InitDefaultsGraphDefImpl() {
   GOOGLE_PROTOBUF_VERIFY_VERSION;
@@ -49,11 +49,11 @@ void InitDefaultsGraphDefImpl() {
   protobuf_versions_2eproto::InitDefaultsVersionDef();
   protobuf_function_2eproto::InitDefaultsFunctionDefLibrary();
   {
-    void* ptr = &::tensorflow::_GraphDef_default_instance_;
-    new (ptr) ::tensorflow::GraphDef();
+    void* ptr = &::opencv_tensorflow::_GraphDef_default_instance_;
+    new (ptr) ::opencv_tensorflow::GraphDef();
     ::google::protobuf::internal::OnShutdownDestroyMessage(ptr);
   }
-  ::tensorflow::GraphDef::InitAsDefaultInstance();
+  ::opencv_tensorflow::GraphDef::InitAsDefaultInstance();
 }
 
 void InitDefaultsGraphDef() {
@@ -71,10 +71,10 @@ void InitDefaultsNodeDef_AttrEntry_DoNotUseImpl() {
 #endif  // GOOGLE_PROTOBUF_ENFORCE_UNIQUENESS
   protobuf_attr_5fvalue_2eproto::InitDefaultsAttrValue();
   {
-    void* ptr = &::tensorflow::_NodeDef_AttrEntry_DoNotUse_default_instance_;
-    new (ptr) ::tensorflow::NodeDef_AttrEntry_DoNotUse();
+    void* ptr = &::opencv_tensorflow::_NodeDef_AttrEntry_DoNotUse_default_instance_;
+    new (ptr) ::opencv_tensorflow::NodeDef_AttrEntry_DoNotUse();
   }
-  ::tensorflow::NodeDef_AttrEntry_DoNotUse::InitAsDefaultInstance();
+  ::opencv_tensorflow::NodeDef_AttrEntry_DoNotUse::InitAsDefaultInstance();
 }
 
 void InitDefaultsNodeDef_AttrEntry_DoNotUse() {
@@ -92,11 +92,11 @@ void InitDefaultsNodeDefImpl() {
 #endif  // GOOGLE_PROTOBUF_ENFORCE_UNIQUENESS
   protobuf_graph_2eproto::InitDefaultsNodeDef_AttrEntry_DoNotUse();
   {
-    void* ptr = &::tensorflow::_NodeDef_default_instance_;
-    new (ptr) ::tensorflow::NodeDef();
+    void* ptr = &::opencv_tensorflow::_NodeDef_default_instance_;
+    new (ptr) ::opencv_tensorflow::NodeDef();
     ::google::protobuf::internal::OnShutdownDestroyMessage(ptr);
   }
-  ::tensorflow::NodeDef::InitAsDefaultInstance();
+  ::opencv_tensorflow::NodeDef::InitAsDefaultInstance();
 }
 
 void InitDefaultsNodeDef() {
@@ -108,44 +108,44 @@ void InitDefaultsNodeDef() {
 
 const ::google::protobuf::uint32 TableStruct::offsets[] GOOGLE_PROTOBUF_ATTRIBUTE_SECTION_VARIABLE(protodesc_cold) = {
   ~0u,  // no _has_bits_
-  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::tensorflow::GraphDef, _internal_metadata_),
+  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::opencv_tensorflow::GraphDef, _internal_metadata_),
   ~0u,  // no _extensions_
   ~0u,  // no _oneof_case_
   ~0u,  // no _weak_field_map_
-  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::tensorflow::GraphDef, node_),
-  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::tensorflow::GraphDef, versions_),
-  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::tensorflow::GraphDef, version_),
-  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::tensorflow::GraphDef, library_),
-  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::tensorflow::NodeDef_AttrEntry_DoNotUse, _has_bits_),
-  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::tensorflow::NodeDef_AttrEntry_DoNotUse, _internal_metadata_),
+  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::opencv_tensorflow::GraphDef, node_),
+  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::opencv_tensorflow::GraphDef, versions_),
+  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::opencv_tensorflow::GraphDef, version_),
+  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::opencv_tensorflow::GraphDef, library_),
+  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::opencv_tensorflow::NodeDef_AttrEntry_DoNotUse, _has_bits_),
+  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::opencv_tensorflow::NodeDef_AttrEntry_DoNotUse, _internal_metadata_),
   ~0u,  // no _extensions_
   ~0u,  // no _oneof_case_
   ~0u,  // no _weak_field_map_
-  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::tensorflow::NodeDef_AttrEntry_DoNotUse, key_),
-  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::tensorflow::NodeDef_AttrEntry_DoNotUse, value_),
+  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::opencv_tensorflow::NodeDef_AttrEntry_DoNotUse, key_),
+  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::opencv_tensorflow::NodeDef_AttrEntry_DoNotUse, value_),
   0,
   1,
   ~0u,  // no _has_bits_
-  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::tensorflow::NodeDef, _internal_metadata_),
+  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::opencv_tensorflow::NodeDef, _internal_metadata_),
   ~0u,  // no _extensions_
   ~0u,  // no _oneof_case_
   ~0u,  // no _weak_field_map_
-  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::tensorflow::NodeDef, name_),
-  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::tensorflow::NodeDef, op_),
-  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::tensorflow::NodeDef, input_),
-  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::tensorflow::NodeDef, device_),
-  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::tensorflow::NodeDef, attr_),
+  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::opencv_tensorflow::NodeDef, name_),
+  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::opencv_tensorflow::NodeDef, op_),
+  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::opencv_tensorflow::NodeDef, input_),
+  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::opencv_tensorflow::NodeDef, device_),
+  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::opencv_tensorflow::NodeDef, attr_),
 };
 static const ::google::protobuf::internal::MigrationSchema schemas[] GOOGLE_PROTOBUF_ATTRIBUTE_SECTION_VARIABLE(protodesc_cold) = {
-  { 0, -1, sizeof(::tensorflow::GraphDef)},
-  { 9, 16, sizeof(::tensorflow::NodeDef_AttrEntry_DoNotUse)},
-  { 18, -1, sizeof(::tensorflow::NodeDef)},
+  { 0, -1, sizeof(::opencv_tensorflow::GraphDef)},
+  { 9, 16, sizeof(::opencv_tensorflow::NodeDef_AttrEntry_DoNotUse)},
+  { 18, -1, sizeof(::opencv_tensorflow::NodeDef)},
 };
 
 static ::google::protobuf::Message const * const file_default_instances[] = {
-  reinterpret_cast<const ::google::protobuf::Message*>(&::tensorflow::_GraphDef_default_instance_),
-  reinterpret_cast<const ::google::protobuf::Message*>(&::tensorflow::_NodeDef_AttrEntry_DoNotUse_default_instance_),
-  reinterpret_cast<const ::google::protobuf::Message*>(&::tensorflow::_NodeDef_default_instance_),
+  reinterpret_cast<const ::google::protobuf::Message*>(&::opencv_tensorflow::_GraphDef_default_instance_),
+  reinterpret_cast<const ::google::protobuf::Message*>(&::opencv_tensorflow::_NodeDef_AttrEntry_DoNotUse_default_instance_),
+  reinterpret_cast<const ::google::protobuf::Message*>(&::opencv_tensorflow::_NodeDef_default_instance_),
 };
 
 void protobuf_AssignDescriptors() {
@@ -170,21 +170,22 @@ void protobuf_RegisterTypes(const ::std::string&) {
 void AddDescriptorsImpl() {
   InitDefaults();
   static const char descriptor[] GOOGLE_PROTOBUF_ATTRIBUTE_SECTION_VARIABLE(protodesc_cold) = {
-      "\n\013graph.proto\022\ntensorflow\032\020attr_value.pr"
-      "oto\032\016function.proto\032\016versions.proto\"\235\001\n\010"
-      "GraphDef\022!\n\004node\030\001 \003(\0132\023.tensorflow.Node"
-      "Def\022(\n\010versions\030\004 \001(\0132\026.tensorflow.Versi"
-      "onDef\022\023\n\007version\030\003 \001(\005B\002\030\001\022/\n\007library\030\002 "
-      "\001(\0132\036.tensorflow.FunctionDefLibrary\"\263\001\n\007"
-      "NodeDef\022\014\n\004name\030\001 \001(\t\022\n\n\002op\030\002 \001(\t\022\r\n\005inp"
-      "ut\030\003 \003(\t\022\016\n\006device\030\004 \001(\t\022+\n\004attr\030\005 \003(\0132\035"
-      ".tensorflow.NodeDef.AttrEntry\032B\n\tAttrEnt"
-      "ry\022\013\n\003key\030\001 \001(\t\022$\n\005value\030\002 \001(\0132\025.tensorf"
-      "low.AttrValue:\0028\001B,\n\030org.tensorflow.fram"
-      "eworkB\013GraphProtosP\001\370\001\001b\006proto3"
+      "\n\013graph.proto\022\021opencv_tensorflow\032\020attr_v"
+      "alue.proto\032\016function.proto\032\016versions.pro"
+      "to\"\262\001\n\010GraphDef\022(\n\004node\030\001 \003(\0132\032.opencv_t"
+      "ensorflow.NodeDef\022/\n\010versions\030\004 \001(\0132\035.op"
+      "encv_tensorflow.VersionDef\022\023\n\007version\030\003 "
+      "\001(\005B\002\030\001\0226\n\007library\030\002 \001(\0132%.opencv_tensor"
+      "flow.FunctionDefLibrary\"\301\001\n\007NodeDef\022\014\n\004n"
+      "ame\030\001 \001(\t\022\n\n\002op\030\002 \001(\t\022\r\n\005input\030\003 \003(\t\022\016\n\006"
+      "device\030\004 \001(\t\0222\n\004attr\030\005 \003(\0132$.opencv_tens"
+      "orflow.NodeDef.AttrEntry\032I\n\tAttrEntry\022\013\n"
+      "\003key\030\001 \001(\t\022+\n\005value\030\002 \001(\0132\034.opencv_tenso"
+      "rflow.AttrValue:\0028\001B,\n\030org.tensorflow.fr"
+      "ameworkB\013GraphProtosP\001\370\001\001b\006proto3"
   };
   ::google::protobuf::DescriptorPool::InternalAddGeneratedFile(
-      descriptor, 471);
+      descriptor, 513);
   ::google::protobuf::MessageFactory::InternalRegisterGeneratedFile(
     "graph.proto", &protobuf_RegisterTypes);
   ::protobuf_attr_5fvalue_2eproto::AddDescriptors();
@@ -203,22 +204,22 @@ struct StaticDescriptorInitializer {
   }
 } static_descriptor_initializer;
 }  // namespace protobuf_graph_2eproto
-namespace tensorflow {
+namespace opencv_tensorflow {
 
 // ===================================================================
 
 void GraphDef::InitAsDefaultInstance() {
-  ::tensorflow::_GraphDef_default_instance_._instance.get_mutable()->versions_ = const_cast< ::tensorflow::VersionDef*>(
-      ::tensorflow::VersionDef::internal_default_instance());
-  ::tensorflow::_GraphDef_default_instance_._instance.get_mutable()->library_ = const_cast< ::tensorflow::FunctionDefLibrary*>(
-      ::tensorflow::FunctionDefLibrary::internal_default_instance());
+  ::opencv_tensorflow::_GraphDef_default_instance_._instance.get_mutable()->versions_ = const_cast< ::opencv_tensorflow::VersionDef*>(
+      ::opencv_tensorflow::VersionDef::internal_default_instance());
+  ::opencv_tensorflow::_GraphDef_default_instance_._instance.get_mutable()->library_ = const_cast< ::opencv_tensorflow::FunctionDefLibrary*>(
+      ::opencv_tensorflow::FunctionDefLibrary::internal_default_instance());
 }
 void GraphDef::_slow_mutable_versions() {
-  versions_ = ::google::protobuf::Arena::CreateMessage< ::tensorflow::VersionDef >(
+  versions_ = ::google::protobuf::Arena::CreateMessage< ::opencv_tensorflow::VersionDef >(
       GetArenaNoVirtual());
 }
 void GraphDef::unsafe_arena_set_allocated_versions(
-    ::tensorflow::VersionDef* versions) {
+    ::opencv_tensorflow::VersionDef* versions) {
   if (GetArenaNoVirtual() == NULL) {
     delete versions_;
   }
@@ -228,7 +229,7 @@ void GraphDef::unsafe_arena_set_allocated_versions(
   } else {
 
   }
-  // @@protoc_insertion_point(field_unsafe_arena_set_allocated:tensorflow.GraphDef.versions)
+  // @@protoc_insertion_point(field_unsafe_arena_set_allocated:opencv_tensorflow.GraphDef.versions)
 }
 void GraphDef::clear_versions() {
   if (GetArenaNoVirtual() == NULL && versions_ != NULL) {
@@ -237,11 +238,11 @@ void GraphDef::clear_versions() {
   versions_ = NULL;
 }
 void GraphDef::_slow_mutable_library() {
-  library_ = ::google::protobuf::Arena::CreateMessage< ::tensorflow::FunctionDefLibrary >(
+  library_ = ::google::protobuf::Arena::CreateMessage< ::opencv_tensorflow::FunctionDefLibrary >(
       GetArenaNoVirtual());
 }
 void GraphDef::unsafe_arena_set_allocated_library(
-    ::tensorflow::FunctionDefLibrary* library) {
+    ::opencv_tensorflow::FunctionDefLibrary* library) {
   if (GetArenaNoVirtual() == NULL) {
     delete library_;
   }
@@ -251,7 +252,7 @@ void GraphDef::unsafe_arena_set_allocated_library(
   } else {
 
   }
-  // @@protoc_insertion_point(field_unsafe_arena_set_allocated:tensorflow.GraphDef.library)
+  // @@protoc_insertion_point(field_unsafe_arena_set_allocated:opencv_tensorflow.GraphDef.library)
 }
 void GraphDef::clear_library() {
   if (GetArenaNoVirtual() == NULL && library_ != NULL) {
@@ -272,7 +273,7 @@ GraphDef::GraphDef()
     ::protobuf_graph_2eproto::InitDefaultsGraphDef();
   }
   SharedCtor();
-  // @@protoc_insertion_point(constructor:tensorflow.GraphDef)
+  // @@protoc_insertion_point(constructor:opencv_tensorflow.GraphDef)
 }
 GraphDef::GraphDef(::google::protobuf::Arena* arena)
   : ::google::protobuf::Message(),
@@ -281,7 +282,7 @@ GraphDef::GraphDef(::google::protobuf::Arena* arena)
   ::protobuf_graph_2eproto::InitDefaultsGraphDef();
   SharedCtor();
   RegisterArenaDtor(arena);
-  // @@protoc_insertion_point(arena_constructor:tensorflow.GraphDef)
+  // @@protoc_insertion_point(arena_constructor:opencv_tensorflow.GraphDef)
 }
 GraphDef::GraphDef(const GraphDef& from)
   : ::google::protobuf::Message(),
@@ -290,17 +291,17 @@ GraphDef::GraphDef(const GraphDef& from)
       _cached_size_(0) {
   _internal_metadata_.MergeFrom(from._internal_metadata_);
   if (from.has_library()) {
-    library_ = new ::tensorflow::FunctionDefLibrary(*from.library_);
+    library_ = new ::opencv_tensorflow::FunctionDefLibrary(*from.library_);
   } else {
     library_ = NULL;
   }
   if (from.has_versions()) {
-    versions_ = new ::tensorflow::VersionDef(*from.versions_);
+    versions_ = new ::opencv_tensorflow::VersionDef(*from.versions_);
   } else {
     versions_ = NULL;
   }
   version_ = from.version_;
-  // @@protoc_insertion_point(copy_constructor:tensorflow.GraphDef)
+  // @@protoc_insertion_point(copy_constructor:opencv_tensorflow.GraphDef)
 }
 
 void GraphDef::SharedCtor() {
@@ -311,7 +312,7 @@ void GraphDef::SharedCtor() {
 }
 
 GraphDef::~GraphDef() {
-  // @@protoc_insertion_point(destructor:tensorflow.GraphDef)
+  // @@protoc_insertion_point(destructor:opencv_tensorflow.GraphDef)
   SharedDtor();
 }
 
@@ -347,7 +348,7 @@ GraphDef* GraphDef::New(::google::protobuf::Arena* arena) const {
 }
 
 void GraphDef::Clear() {
-// @@protoc_insertion_point(message_clear_start:tensorflow.GraphDef)
+// @@protoc_insertion_point(message_clear_start:opencv_tensorflow.GraphDef)
   ::google::protobuf::uint32 cached_has_bits = 0;
   // Prevent compiler warnings about cached_has_bits being unused
   (void) cached_has_bits;
@@ -369,13 +370,13 @@ bool GraphDef::MergePartialFromCodedStream(
     ::google::protobuf::io::CodedInputStream* input) {
 #define DO_(EXPRESSION) if (!GOOGLE_PREDICT_TRUE(EXPRESSION)) goto failure
   ::google::protobuf::uint32 tag;
-  // @@protoc_insertion_point(parse_start:tensorflow.GraphDef)
+  // @@protoc_insertion_point(parse_start:opencv_tensorflow.GraphDef)
   for (;;) {
     ::std::pair< ::google::protobuf::uint32, bool> p = input->ReadTagWithCutoffNoLastTag(127u);
     tag = p.first;
     if (!p.second) goto handle_unusual;
     switch (::google::protobuf::internal::WireFormatLite::GetTagFieldNumber(tag)) {
-      // repeated .tensorflow.NodeDef node = 1;
+      // repeated .opencv_tensorflow.NodeDef node = 1;
       case 1: {
         if (static_cast< ::google::protobuf::uint8>(tag) ==
             static_cast< ::google::protobuf::uint8>(10u /* 10 & 0xFF */)) {
@@ -386,7 +387,7 @@ bool GraphDef::MergePartialFromCodedStream(
         break;
       }
 
-      // .tensorflow.FunctionDefLibrary library = 2;
+      // .opencv_tensorflow.FunctionDefLibrary library = 2;
       case 2: {
         if (static_cast< ::google::protobuf::uint8>(tag) ==
             static_cast< ::google::protobuf::uint8>(18u /* 18 & 0xFF */)) {
@@ -412,7 +413,7 @@ bool GraphDef::MergePartialFromCodedStream(
         break;
       }
 
-      // .tensorflow.VersionDef versions = 4;
+      // .opencv_tensorflow.VersionDef versions = 4;
       case 4: {
         if (static_cast< ::google::protobuf::uint8>(tag) ==
             static_cast< ::google::protobuf::uint8>(34u /* 34 & 0xFF */)) {
@@ -436,28 +437,28 @@ bool GraphDef::MergePartialFromCodedStream(
     }
   }
 success:
-  // @@protoc_insertion_point(parse_success:tensorflow.GraphDef)
+  // @@protoc_insertion_point(parse_success:opencv_tensorflow.GraphDef)
   return true;
 failure:
-  // @@protoc_insertion_point(parse_failure:tensorflow.GraphDef)
+  // @@protoc_insertion_point(parse_failure:opencv_tensorflow.GraphDef)
   return false;
 #undef DO_
 }
 
 void GraphDef::SerializeWithCachedSizes(
     ::google::protobuf::io::CodedOutputStream* output) const {
-  // @@protoc_insertion_point(serialize_start:tensorflow.GraphDef)
+  // @@protoc_insertion_point(serialize_start:opencv_tensorflow.GraphDef)
   ::google::protobuf::uint32 cached_has_bits = 0;
   (void) cached_has_bits;
 
-  // repeated .tensorflow.NodeDef node = 1;
+  // repeated .opencv_tensorflow.NodeDef node = 1;
   for (unsigned int i = 0,
       n = static_cast<unsigned int>(this->node_size()); i < n; i++) {
     ::google::protobuf::internal::WireFormatLite::WriteMessageMaybeToArray(
       1, this->node(static_cast<int>(i)), output);
   }
 
-  // .tensorflow.FunctionDefLibrary library = 2;
+  // .opencv_tensorflow.FunctionDefLibrary library = 2;
   if (this->has_library()) {
     ::google::protobuf::internal::WireFormatLite::WriteMessageMaybeToArray(
       2, *this->library_, output);
@@ -468,7 +469,7 @@ void GraphDef::SerializeWithCachedSizes(
     ::google::protobuf::internal::WireFormatLite::WriteInt32(3, this->version(), output);
   }
 
-  // .tensorflow.VersionDef versions = 4;
+  // .opencv_tensorflow.VersionDef versions = 4;
   if (this->has_versions()) {
     ::google::protobuf::internal::WireFormatLite::WriteMessageMaybeToArray(
       4, *this->versions_, output);
@@ -478,17 +479,17 @@ void GraphDef::SerializeWithCachedSizes(
     ::google::protobuf::internal::WireFormat::SerializeUnknownFields(
         (::google::protobuf::internal::GetProto3PreserveUnknownsDefault()   ? _internal_metadata_.unknown_fields()   : _internal_metadata_.default_instance()), output);
   }
-  // @@protoc_insertion_point(serialize_end:tensorflow.GraphDef)
+  // @@protoc_insertion_point(serialize_end:opencv_tensorflow.GraphDef)
 }
 
 ::google::protobuf::uint8* GraphDef::InternalSerializeWithCachedSizesToArray(
     bool deterministic, ::google::protobuf::uint8* target) const {
   (void)deterministic; // Unused
-  // @@protoc_insertion_point(serialize_to_array_start:tensorflow.GraphDef)
+  // @@protoc_insertion_point(serialize_to_array_start:opencv_tensorflow.GraphDef)
   ::google::protobuf::uint32 cached_has_bits = 0;
   (void) cached_has_bits;
 
-  // repeated .tensorflow.NodeDef node = 1;
+  // repeated .opencv_tensorflow.NodeDef node = 1;
   for (unsigned int i = 0,
       n = static_cast<unsigned int>(this->node_size()); i < n; i++) {
     target = ::google::protobuf::internal::WireFormatLite::
@@ -496,7 +497,7 @@ void GraphDef::SerializeWithCachedSizes(
         1, this->node(static_cast<int>(i)), deterministic, target);
   }
 
-  // .tensorflow.FunctionDefLibrary library = 2;
+  // .opencv_tensorflow.FunctionDefLibrary library = 2;
   if (this->has_library()) {
     target = ::google::protobuf::internal::WireFormatLite::
       InternalWriteMessageToArray(
@@ -508,7 +509,7 @@ void GraphDef::SerializeWithCachedSizes(
     target = ::google::protobuf::internal::WireFormatLite::WriteInt32ToArray(3, this->version(), target);
   }
 
-  // .tensorflow.VersionDef versions = 4;
+  // .opencv_tensorflow.VersionDef versions = 4;
   if (this->has_versions()) {
     target = ::google::protobuf::internal::WireFormatLite::
       InternalWriteMessageToArray(
@@ -519,12 +520,12 @@ void GraphDef::SerializeWithCachedSizes(
     target = ::google::protobuf::internal::WireFormat::SerializeUnknownFieldsToArray(
         (::google::protobuf::internal::GetProto3PreserveUnknownsDefault()   ? _internal_metadata_.unknown_fields()   : _internal_metadata_.default_instance()), target);
   }
-  // @@protoc_insertion_point(serialize_to_array_end:tensorflow.GraphDef)
+  // @@protoc_insertion_point(serialize_to_array_end:opencv_tensorflow.GraphDef)
   return target;
 }
 
 size_t GraphDef::ByteSizeLong() const {
-// @@protoc_insertion_point(message_byte_size_start:tensorflow.GraphDef)
+// @@protoc_insertion_point(message_byte_size_start:opencv_tensorflow.GraphDef)
   size_t total_size = 0;
 
   if ((_internal_metadata_.have_unknown_fields() &&  ::google::protobuf::internal::GetProto3PreserveUnknownsDefault())) {
@@ -532,7 +533,7 @@ size_t GraphDef::ByteSizeLong() const {
       ::google::protobuf::internal::WireFormat::ComputeUnknownFieldsSize(
         (::google::protobuf::internal::GetProto3PreserveUnknownsDefault()   ? _internal_metadata_.unknown_fields()   : _internal_metadata_.default_instance()));
   }
-  // repeated .tensorflow.NodeDef node = 1;
+  // repeated .opencv_tensorflow.NodeDef node = 1;
   {
     unsigned int count = static_cast<unsigned int>(this->node_size());
     total_size += 1UL * count;
@@ -543,14 +544,14 @@ size_t GraphDef::ByteSizeLong() const {
     }
   }
 
-  // .tensorflow.FunctionDefLibrary library = 2;
+  // .opencv_tensorflow.FunctionDefLibrary library = 2;
   if (this->has_library()) {
     total_size += 1 +
       ::google::protobuf::internal::WireFormatLite::MessageSize(
         *this->library_);
   }
 
-  // .tensorflow.VersionDef versions = 4;
+  // .opencv_tensorflow.VersionDef versions = 4;
   if (this->has_versions()) {
     total_size += 1 +
       ::google::protobuf::internal::WireFormatLite::MessageSize(
@@ -572,22 +573,22 @@ size_t GraphDef::ByteSizeLong() const {
 }
 
 void GraphDef::MergeFrom(const ::google::protobuf::Message& from) {
-// @@protoc_insertion_point(generalized_merge_from_start:tensorflow.GraphDef)
+// @@protoc_insertion_point(generalized_merge_from_start:opencv_tensorflow.GraphDef)
   GOOGLE_DCHECK_NE(&from, this);
   const GraphDef* source =
       ::google::protobuf::internal::DynamicCastToGenerated<const GraphDef>(
           &from);
   if (source == NULL) {
-  // @@protoc_insertion_point(generalized_merge_from_cast_fail:tensorflow.GraphDef)
+  // @@protoc_insertion_point(generalized_merge_from_cast_fail:opencv_tensorflow.GraphDef)
     ::google::protobuf::internal::ReflectionOps::Merge(from, this);
   } else {
-  // @@protoc_insertion_point(generalized_merge_from_cast_success:tensorflow.GraphDef)
+  // @@protoc_insertion_point(generalized_merge_from_cast_success:opencv_tensorflow.GraphDef)
     MergeFrom(*source);
   }
 }
 
 void GraphDef::MergeFrom(const GraphDef& from) {
-// @@protoc_insertion_point(class_specific_merge_from_start:tensorflow.GraphDef)
+// @@protoc_insertion_point(class_specific_merge_from_start:opencv_tensorflow.GraphDef)
   GOOGLE_DCHECK_NE(&from, this);
   _internal_metadata_.MergeFrom(from._internal_metadata_);
   ::google::protobuf::uint32 cached_has_bits = 0;
@@ -595,10 +596,10 @@ void GraphDef::MergeFrom(const GraphDef& from) {
 
   node_.MergeFrom(from.node_);
   if (from.has_library()) {
-    mutable_library()->::tensorflow::FunctionDefLibrary::MergeFrom(from.library());
+    mutable_library()->::opencv_tensorflow::FunctionDefLibrary::MergeFrom(from.library());
   }
   if (from.has_versions()) {
-    mutable_versions()->::tensorflow::VersionDef::MergeFrom(from.versions());
+    mutable_versions()->::opencv_tensorflow::VersionDef::MergeFrom(from.versions());
   }
   if (from.version() != 0) {
     set_version(from.version());
@@ -606,14 +607,14 @@ void GraphDef::MergeFrom(const GraphDef& from) {
 }
 
 void GraphDef::CopyFrom(const ::google::protobuf::Message& from) {
-// @@protoc_insertion_point(generalized_copy_from_start:tensorflow.GraphDef)
+// @@protoc_insertion_point(generalized_copy_from_start:opencv_tensorflow.GraphDef)
   if (&from == this) return;
   Clear();
   MergeFrom(from);
 }
 
 void GraphDef::CopyFrom(const GraphDef& from) {
-// @@protoc_insertion_point(class_specific_copy_from_start:tensorflow.GraphDef)
+// @@protoc_insertion_point(class_specific_copy_from_start:opencv_tensorflow.GraphDef)
   if (&from == this) return;
   Clear();
   MergeFrom(from);
@@ -696,7 +697,7 @@ NodeDef::NodeDef()
     ::protobuf_graph_2eproto::InitDefaultsNodeDef();
   }
   SharedCtor();
-  // @@protoc_insertion_point(constructor:tensorflow.NodeDef)
+  // @@protoc_insertion_point(constructor:opencv_tensorflow.NodeDef)
 }
 NodeDef::NodeDef(::google::protobuf::Arena* arena)
   : ::google::protobuf::Message(),
@@ -706,7 +707,7 @@ NodeDef::NodeDef(::google::protobuf::Arena* arena)
   ::protobuf_graph_2eproto::InitDefaultsNodeDef();
   SharedCtor();
   RegisterArenaDtor(arena);
-  // @@protoc_insertion_point(arena_constructor:tensorflow.NodeDef)
+  // @@protoc_insertion_point(arena_constructor:opencv_tensorflow.NodeDef)
 }
 NodeDef::NodeDef(const NodeDef& from)
   : ::google::protobuf::Message(),
@@ -730,7 +731,7 @@ NodeDef::NodeDef(const NodeDef& from)
     device_.Set(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), from.device(),
       GetArenaNoVirtual());
   }
-  // @@protoc_insertion_point(copy_constructor:tensorflow.NodeDef)
+  // @@protoc_insertion_point(copy_constructor:opencv_tensorflow.NodeDef)
 }
 
 void NodeDef::SharedCtor() {
@@ -741,7 +742,7 @@ void NodeDef::SharedCtor() {
 }
 
 NodeDef::~NodeDef() {
-  // @@protoc_insertion_point(destructor:tensorflow.NodeDef)
+  // @@protoc_insertion_point(destructor:opencv_tensorflow.NodeDef)
   SharedDtor();
 }
 
@@ -778,7 +779,7 @@ NodeDef* NodeDef::New(::google::protobuf::Arena* arena) const {
 }
 
 void NodeDef::Clear() {
-// @@protoc_insertion_point(message_clear_start:tensorflow.NodeDef)
+// @@protoc_insertion_point(message_clear_start:opencv_tensorflow.NodeDef)
   ::google::protobuf::uint32 cached_has_bits = 0;
   // Prevent compiler warnings about cached_has_bits being unused
   (void) cached_has_bits;
@@ -795,7 +796,7 @@ bool NodeDef::MergePartialFromCodedStream(
     ::google::protobuf::io::CodedInputStream* input) {
 #define DO_(EXPRESSION) if (!GOOGLE_PREDICT_TRUE(EXPRESSION)) goto failure
   ::google::protobuf::uint32 tag;
-  // @@protoc_insertion_point(parse_start:tensorflow.NodeDef)
+  // @@protoc_insertion_point(parse_start:opencv_tensorflow.NodeDef)
   for (;;) {
     ::std::pair< ::google::protobuf::uint32, bool> p = input->ReadTagWithCutoffNoLastTag(127u);
     tag = p.first;
@@ -810,7 +811,7 @@ bool NodeDef::MergePartialFromCodedStream(
           DO_(::google::protobuf::internal::WireFormatLite::VerifyUtf8String(
             this->name().data(), static_cast<int>(this->name().length()),
             ::google::protobuf::internal::WireFormatLite::PARSE,
-            "tensorflow.NodeDef.name"));
+            "opencv_tensorflow.NodeDef.name"));
         } else {
           goto handle_unusual;
         }
@@ -826,7 +827,7 @@ bool NodeDef::MergePartialFromCodedStream(
           DO_(::google::protobuf::internal::WireFormatLite::VerifyUtf8String(
             this->op().data(), static_cast<int>(this->op().length()),
             ::google::protobuf::internal::WireFormatLite::PARSE,
-            "tensorflow.NodeDef.op"));
+            "opencv_tensorflow.NodeDef.op"));
         } else {
           goto handle_unusual;
         }
@@ -843,7 +844,7 @@ bool NodeDef::MergePartialFromCodedStream(
             this->input(this->input_size() - 1).data(),
             static_cast<int>(this->input(this->input_size() - 1).length()),
             ::google::protobuf::internal::WireFormatLite::PARSE,
-            "tensorflow.NodeDef.input"));
+            "opencv_tensorflow.NodeDef.input"));
         } else {
           goto handle_unusual;
         }
@@ -859,30 +860,30 @@ bool NodeDef::MergePartialFromCodedStream(
           DO_(::google::protobuf::internal::WireFormatLite::VerifyUtf8String(
             this->device().data(), static_cast<int>(this->device().length()),
             ::google::protobuf::internal::WireFormatLite::PARSE,
-            "tensorflow.NodeDef.device"));
+            "opencv_tensorflow.NodeDef.device"));
         } else {
           goto handle_unusual;
         }
         break;
       }
 
-      // map<string, .tensorflow.AttrValue> attr = 5;
+      // map<string, .opencv_tensorflow.AttrValue> attr = 5;
       case 5: {
         if (static_cast< ::google::protobuf::uint8>(tag) ==
             static_cast< ::google::protobuf::uint8>(42u /* 42 & 0xFF */)) {
           NodeDef_AttrEntry_DoNotUse::Parser< ::google::protobuf::internal::MapField<
               NodeDef_AttrEntry_DoNotUse,
-              ::std::string, ::tensorflow::AttrValue,
+              ::std::string, ::opencv_tensorflow::AttrValue,
               ::google::protobuf::internal::WireFormatLite::TYPE_STRING,
               ::google::protobuf::internal::WireFormatLite::TYPE_MESSAGE,
               0 >,
-            ::google::protobuf::Map< ::std::string, ::tensorflow::AttrValue > > parser(&attr_);
+            ::google::protobuf::Map< ::std::string, ::opencv_tensorflow::AttrValue > > parser(&attr_);
           DO_(::google::protobuf::internal::WireFormatLite::ReadMessageNoVirtual(
               input, &parser));
           DO_(::google::protobuf::internal::WireFormatLite::VerifyUtf8String(
             parser.key().data(), static_cast<int>(parser.key().length()),
             ::google::protobuf::internal::WireFormatLite::PARSE,
-            "tensorflow.NodeDef.AttrEntry.key"));
+            "opencv_tensorflow.NodeDef.AttrEntry.key"));
         } else {
           goto handle_unusual;
         }
@@ -901,17 +902,17 @@ bool NodeDef::MergePartialFromCodedStream(
     }
   }
 success:
-  // @@protoc_insertion_point(parse_success:tensorflow.NodeDef)
+  // @@protoc_insertion_point(parse_success:opencv_tensorflow.NodeDef)
   return true;
 failure:
-  // @@protoc_insertion_point(parse_failure:tensorflow.NodeDef)
+  // @@protoc_insertion_point(parse_failure:opencv_tensorflow.NodeDef)
   return false;
 #undef DO_
 }
 
 void NodeDef::SerializeWithCachedSizes(
     ::google::protobuf::io::CodedOutputStream* output) const {
-  // @@protoc_insertion_point(serialize_start:tensorflow.NodeDef)
+  // @@protoc_insertion_point(serialize_start:opencv_tensorflow.NodeDef)
   ::google::protobuf::uint32 cached_has_bits = 0;
   (void) cached_has_bits;
 
@@ -920,7 +921,7 @@ void NodeDef::SerializeWithCachedSizes(
     ::google::protobuf::internal::WireFormatLite::VerifyUtf8String(
       this->name().data(), static_cast<int>(this->name().length()),
       ::google::protobuf::internal::WireFormatLite::SERIALIZE,
-      "tensorflow.NodeDef.name");
+      "opencv_tensorflow.NodeDef.name");
     ::google::protobuf::internal::WireFormatLite::WriteStringMaybeAliased(
       1, this->name(), output);
   }
@@ -930,7 +931,7 @@ void NodeDef::SerializeWithCachedSizes(
     ::google::protobuf::internal::WireFormatLite::VerifyUtf8String(
       this->op().data(), static_cast<int>(this->op().length()),
       ::google::protobuf::internal::WireFormatLite::SERIALIZE,
-      "tensorflow.NodeDef.op");
+      "opencv_tensorflow.NodeDef.op");
     ::google::protobuf::internal::WireFormatLite::WriteStringMaybeAliased(
       2, this->op(), output);
   }
@@ -940,7 +941,7 @@ void NodeDef::SerializeWithCachedSizes(
     ::google::protobuf::internal::WireFormatLite::VerifyUtf8String(
       this->input(i).data(), static_cast<int>(this->input(i).length()),
       ::google::protobuf::internal::WireFormatLite::SERIALIZE,
-      "tensorflow.NodeDef.input");
+      "opencv_tensorflow.NodeDef.input");
     ::google::protobuf::internal::WireFormatLite::WriteString(
       3, this->input(i), output);
   }
@@ -950,14 +951,14 @@ void NodeDef::SerializeWithCachedSizes(
     ::google::protobuf::internal::WireFormatLite::VerifyUtf8String(
       this->device().data(), static_cast<int>(this->device().length()),
       ::google::protobuf::internal::WireFormatLite::SERIALIZE,
-      "tensorflow.NodeDef.device");
+      "opencv_tensorflow.NodeDef.device");
     ::google::protobuf::internal::WireFormatLite::WriteStringMaybeAliased(
       4, this->device(), output);
   }
 
-  // map<string, .tensorflow.AttrValue> attr = 5;
+  // map<string, .opencv_tensorflow.AttrValue> attr = 5;
   if (!this->attr().empty()) {
-    typedef ::google::protobuf::Map< ::std::string, ::tensorflow::AttrValue >::const_pointer
+    typedef ::google::protobuf::Map< ::std::string, ::opencv_tensorflow::AttrValue >::const_pointer
         ConstPtr;
     typedef ConstPtr SortItem;
     typedef ::google::protobuf::internal::CompareByDerefFirst<SortItem> Less;
@@ -966,7 +967,7 @@ void NodeDef::SerializeWithCachedSizes(
         ::google::protobuf::internal::WireFormatLite::VerifyUtf8String(
           p->first.data(), static_cast<int>(p->first.length()),
           ::google::protobuf::internal::WireFormatLite::SERIALIZE,
-          "tensorflow.NodeDef.AttrEntry.key");
+          "opencv_tensorflow.NodeDef.AttrEntry.key");
       }
     };
 
@@ -974,9 +975,9 @@ void NodeDef::SerializeWithCachedSizes(
         this->attr().size() > 1) {
       ::google::protobuf::scoped_array<SortItem> items(
           new SortItem[this->attr().size()]);
-      typedef ::google::protobuf::Map< ::std::string, ::tensorflow::AttrValue >::size_type size_type;
+      typedef ::google::protobuf::Map< ::std::string, ::opencv_tensorflow::AttrValue >::size_type size_type;
       size_type n = 0;
-      for (::google::protobuf::Map< ::std::string, ::tensorflow::AttrValue >::const_iterator
+      for (::google::protobuf::Map< ::std::string, ::opencv_tensorflow::AttrValue >::const_iterator
           it = this->attr().begin();
           it != this->attr().end(); ++it, ++n) {
         items[static_cast<ptrdiff_t>(n)] = SortItem(&*it);
@@ -995,7 +996,7 @@ void NodeDef::SerializeWithCachedSizes(
       }
     } else {
       ::google::protobuf::scoped_ptr<NodeDef_AttrEntry_DoNotUse> entry;
-      for (::google::protobuf::Map< ::std::string, ::tensorflow::AttrValue >::const_iterator
+      for (::google::protobuf::Map< ::std::string, ::opencv_tensorflow::AttrValue >::const_iterator
           it = this->attr().begin();
           it != this->attr().end(); ++it) {
         entry.reset(attr_.NewEntryWrapper(
@@ -1014,13 +1015,13 @@ void NodeDef::SerializeWithCachedSizes(
     ::google::protobuf::internal::WireFormat::SerializeUnknownFields(
         (::google::protobuf::internal::GetProto3PreserveUnknownsDefault()   ? _internal_metadata_.unknown_fields()   : _internal_metadata_.default_instance()), output);
   }
-  // @@protoc_insertion_point(serialize_end:tensorflow.NodeDef)
+  // @@protoc_insertion_point(serialize_end:opencv_tensorflow.NodeDef)
 }
 
 ::google::protobuf::uint8* NodeDef::InternalSerializeWithCachedSizesToArray(
     bool deterministic, ::google::protobuf::uint8* target) const {
   (void)deterministic; // Unused
-  // @@protoc_insertion_point(serialize_to_array_start:tensorflow.NodeDef)
+  // @@protoc_insertion_point(serialize_to_array_start:opencv_tensorflow.NodeDef)
   ::google::protobuf::uint32 cached_has_bits = 0;
   (void) cached_has_bits;
 
@@ -1029,7 +1030,7 @@ void NodeDef::SerializeWithCachedSizes(
     ::google::protobuf::internal::WireFormatLite::VerifyUtf8String(
       this->name().data(), static_cast<int>(this->name().length()),
       ::google::protobuf::internal::WireFormatLite::SERIALIZE,
-      "tensorflow.NodeDef.name");
+      "opencv_tensorflow.NodeDef.name");
     target =
       ::google::protobuf::internal::WireFormatLite::WriteStringToArray(
         1, this->name(), target);
@@ -1040,7 +1041,7 @@ void NodeDef::SerializeWithCachedSizes(
     ::google::protobuf::internal::WireFormatLite::VerifyUtf8String(
       this->op().data(), static_cast<int>(this->op().length()),
       ::google::protobuf::internal::WireFormatLite::SERIALIZE,
-      "tensorflow.NodeDef.op");
+      "opencv_tensorflow.NodeDef.op");
     target =
       ::google::protobuf::internal::WireFormatLite::WriteStringToArray(
         2, this->op(), target);
@@ -1051,7 +1052,7 @@ void NodeDef::SerializeWithCachedSizes(
     ::google::protobuf::internal::WireFormatLite::VerifyUtf8String(
       this->input(i).data(), static_cast<int>(this->input(i).length()),
       ::google::protobuf::internal::WireFormatLite::SERIALIZE,
-      "tensorflow.NodeDef.input");
+      "opencv_tensorflow.NodeDef.input");
     target = ::google::protobuf::internal::WireFormatLite::
       WriteStringToArray(3, this->input(i), target);
   }
@@ -1061,15 +1062,15 @@ void NodeDef::SerializeWithCachedSizes(
     ::google::protobuf::internal::WireFormatLite::VerifyUtf8String(
       this->device().data(), static_cast<int>(this->device().length()),
       ::google::protobuf::internal::WireFormatLite::SERIALIZE,
-      "tensorflow.NodeDef.device");
+      "opencv_tensorflow.NodeDef.device");
     target =
       ::google::protobuf::internal::WireFormatLite::WriteStringToArray(
         4, this->device(), target);
   }
 
-  // map<string, .tensorflow.AttrValue> attr = 5;
+  // map<string, .opencv_tensorflow.AttrValue> attr = 5;
   if (!this->attr().empty()) {
-    typedef ::google::protobuf::Map< ::std::string, ::tensorflow::AttrValue >::const_pointer
+    typedef ::google::protobuf::Map< ::std::string, ::opencv_tensorflow::AttrValue >::const_pointer
         ConstPtr;
     typedef ConstPtr SortItem;
     typedef ::google::protobuf::internal::CompareByDerefFirst<SortItem> Less;
@@ -1078,7 +1079,7 @@ void NodeDef::SerializeWithCachedSizes(
         ::google::protobuf::internal::WireFormatLite::VerifyUtf8String(
           p->first.data(), static_cast<int>(p->first.length()),
           ::google::protobuf::internal::WireFormatLite::SERIALIZE,
-          "tensorflow.NodeDef.AttrEntry.key");
+          "opencv_tensorflow.NodeDef.AttrEntry.key");
       }
     };
 
@@ -1086,9 +1087,9 @@ void NodeDef::SerializeWithCachedSizes(
         this->attr().size() > 1) {
       ::google::protobuf::scoped_array<SortItem> items(
           new SortItem[this->attr().size()]);
-      typedef ::google::protobuf::Map< ::std::string, ::tensorflow::AttrValue >::size_type size_type;
+      typedef ::google::protobuf::Map< ::std::string, ::opencv_tensorflow::AttrValue >::size_type size_type;
       size_type n = 0;
-      for (::google::protobuf::Map< ::std::string, ::tensorflow::AttrValue >::const_iterator
+      for (::google::protobuf::Map< ::std::string, ::opencv_tensorflow::AttrValue >::const_iterator
           it = this->attr().begin();
           it != this->attr().end(); ++it, ++n) {
         items[static_cast<ptrdiff_t>(n)] = SortItem(&*it);
@@ -1109,7 +1110,7 @@ void NodeDef::SerializeWithCachedSizes(
       }
     } else {
       ::google::protobuf::scoped_ptr<NodeDef_AttrEntry_DoNotUse> entry;
-      for (::google::protobuf::Map< ::std::string, ::tensorflow::AttrValue >::const_iterator
+      for (::google::protobuf::Map< ::std::string, ::opencv_tensorflow::AttrValue >::const_iterator
           it = this->attr().begin();
           it != this->attr().end(); ++it) {
         entry.reset(attr_.NewEntryWrapper(
@@ -1130,12 +1131,12 @@ void NodeDef::SerializeWithCachedSizes(
     target = ::google::protobuf::internal::WireFormat::SerializeUnknownFieldsToArray(
         (::google::protobuf::internal::GetProto3PreserveUnknownsDefault()   ? _internal_metadata_.unknown_fields()   : _internal_metadata_.default_instance()), target);
   }
-  // @@protoc_insertion_point(serialize_to_array_end:tensorflow.NodeDef)
+  // @@protoc_insertion_point(serialize_to_array_end:opencv_tensorflow.NodeDef)
   return target;
 }
 
 size_t NodeDef::ByteSizeLong() const {
-// @@protoc_insertion_point(message_byte_size_start:tensorflow.NodeDef)
+// @@protoc_insertion_point(message_byte_size_start:opencv_tensorflow.NodeDef)
   size_t total_size = 0;
 
   if ((_internal_metadata_.have_unknown_fields() &&  ::google::protobuf::internal::GetProto3PreserveUnknownsDefault())) {
@@ -1151,12 +1152,12 @@ size_t NodeDef::ByteSizeLong() const {
       this->input(i));
   }
 
-  // map<string, .tensorflow.AttrValue> attr = 5;
+  // map<string, .opencv_tensorflow.AttrValue> attr = 5;
   total_size += 1 *
       ::google::protobuf::internal::FromIntSize(this->attr_size());
   {
     ::google::protobuf::scoped_ptr<NodeDef_AttrEntry_DoNotUse> entry;
-    for (::google::protobuf::Map< ::std::string, ::tensorflow::AttrValue >::const_iterator
+    for (::google::protobuf::Map< ::std::string, ::opencv_tensorflow::AttrValue >::const_iterator
         it = this->attr().begin();
         it != this->attr().end(); ++it) {
       if (entry.get() != NULL && entry->GetArena() != NULL) {
@@ -1200,22 +1201,22 @@ size_t NodeDef::ByteSizeLong() const {
 }
 
 void NodeDef::MergeFrom(const ::google::protobuf::Message& from) {
-// @@protoc_insertion_point(generalized_merge_from_start:tensorflow.NodeDef)
+// @@protoc_insertion_point(generalized_merge_from_start:opencv_tensorflow.NodeDef)
   GOOGLE_DCHECK_NE(&from, this);
   const NodeDef* source =
       ::google::protobuf::internal::DynamicCastToGenerated<const NodeDef>(
           &from);
   if (source == NULL) {
-  // @@protoc_insertion_point(generalized_merge_from_cast_fail:tensorflow.NodeDef)
+  // @@protoc_insertion_point(generalized_merge_from_cast_fail:opencv_tensorflow.NodeDef)
     ::google::protobuf::internal::ReflectionOps::Merge(from, this);
   } else {
-  // @@protoc_insertion_point(generalized_merge_from_cast_success:tensorflow.NodeDef)
+  // @@protoc_insertion_point(generalized_merge_from_cast_success:opencv_tensorflow.NodeDef)
     MergeFrom(*source);
   }
 }
 
 void NodeDef::MergeFrom(const NodeDef& from) {
-// @@protoc_insertion_point(class_specific_merge_from_start:tensorflow.NodeDef)
+// @@protoc_insertion_point(class_specific_merge_from_start:opencv_tensorflow.NodeDef)
   GOOGLE_DCHECK_NE(&from, this);
   _internal_metadata_.MergeFrom(from._internal_metadata_);
   ::google::protobuf::uint32 cached_has_bits = 0;
@@ -1235,14 +1236,14 @@ void NodeDef::MergeFrom(const NodeDef& from) {
 }
 
 void NodeDef::CopyFrom(const ::google::protobuf::Message& from) {
-// @@protoc_insertion_point(generalized_copy_from_start:tensorflow.NodeDef)
+// @@protoc_insertion_point(generalized_copy_from_start:opencv_tensorflow.NodeDef)
   if (&from == this) return;
   Clear();
   MergeFrom(from);
 }
 
 void NodeDef::CopyFrom(const NodeDef& from) {
-// @@protoc_insertion_point(class_specific_copy_from_start:tensorflow.NodeDef)
+// @@protoc_insertion_point(class_specific_copy_from_start:opencv_tensorflow.NodeDef)
   if (&from == this) return;
   Clear();
   MergeFrom(from);
@@ -1289,6 +1290,6 @@ void NodeDef::InternalSwap(NodeDef* other) {
 
 
 // @@protoc_insertion_point(namespace_scope)
-}  // namespace tensorflow
+}  // namespace opencv_tensorflow
 
 // @@protoc_insertion_point(global_scope)

--- a/modules/dnn/misc/tensorflow/graph.pb.h
+++ b/modules/dnn/misc/tensorflow/graph.pb.h
@@ -60,7 +60,7 @@ inline void InitDefaults() {
   InitDefaultsNodeDef();
 }
 }  // namespace protobuf_graph_2eproto
-namespace tensorflow {
+namespace opencv_tensorflow {
 class GraphDef;
 class GraphDefDefaultTypeInternal;
 extern GraphDefDefaultTypeInternal _GraphDef_default_instance_;
@@ -70,12 +70,12 @@ extern NodeDefDefaultTypeInternal _NodeDef_default_instance_;
 class NodeDef_AttrEntry_DoNotUse;
 class NodeDef_AttrEntry_DoNotUseDefaultTypeInternal;
 extern NodeDef_AttrEntry_DoNotUseDefaultTypeInternal _NodeDef_AttrEntry_DoNotUse_default_instance_;
-}  // namespace tensorflow
-namespace tensorflow {
+}  // namespace opencv_tensorflow
+namespace opencv_tensorflow {
 
 // ===================================================================
 
-class GraphDef : public ::google::protobuf::Message /* @@protoc_insertion_point(class_definition:tensorflow.GraphDef) */ {
+class GraphDef : public ::google::protobuf::Message /* @@protoc_insertion_point(class_definition:opencv_tensorflow.GraphDef) */ {
  public:
   GraphDef();
   virtual ~GraphDef();
@@ -169,47 +169,47 @@ class GraphDef : public ::google::protobuf::Message /* @@protoc_insertion_point(
 
   // accessors -------------------------------------------------------
 
-  // repeated .tensorflow.NodeDef node = 1;
+  // repeated .opencv_tensorflow.NodeDef node = 1;
   int node_size() const;
   void clear_node();
   static const int kNodeFieldNumber = 1;
-  const ::tensorflow::NodeDef& node(int index) const;
-  ::tensorflow::NodeDef* mutable_node(int index);
-  ::tensorflow::NodeDef* add_node();
-  ::google::protobuf::RepeatedPtrField< ::tensorflow::NodeDef >*
+  const ::opencv_tensorflow::NodeDef& node(int index) const;
+  ::opencv_tensorflow::NodeDef* mutable_node(int index);
+  ::opencv_tensorflow::NodeDef* add_node();
+  ::google::protobuf::RepeatedPtrField< ::opencv_tensorflow::NodeDef >*
       mutable_node();
-  const ::google::protobuf::RepeatedPtrField< ::tensorflow::NodeDef >&
+  const ::google::protobuf::RepeatedPtrField< ::opencv_tensorflow::NodeDef >&
       node() const;
 
-  // .tensorflow.FunctionDefLibrary library = 2;
+  // .opencv_tensorflow.FunctionDefLibrary library = 2;
   bool has_library() const;
   void clear_library();
   static const int kLibraryFieldNumber = 2;
   private:
   void _slow_mutable_library();
   public:
-  const ::tensorflow::FunctionDefLibrary& library() const;
-  ::tensorflow::FunctionDefLibrary* release_library();
-  ::tensorflow::FunctionDefLibrary* mutable_library();
-  void set_allocated_library(::tensorflow::FunctionDefLibrary* library);
+  const ::opencv_tensorflow::FunctionDefLibrary& library() const;
+  ::opencv_tensorflow::FunctionDefLibrary* release_library();
+  ::opencv_tensorflow::FunctionDefLibrary* mutable_library();
+  void set_allocated_library(::opencv_tensorflow::FunctionDefLibrary* library);
   void unsafe_arena_set_allocated_library(
-      ::tensorflow::FunctionDefLibrary* library);
-  ::tensorflow::FunctionDefLibrary* unsafe_arena_release_library();
+      ::opencv_tensorflow::FunctionDefLibrary* library);
+  ::opencv_tensorflow::FunctionDefLibrary* unsafe_arena_release_library();
 
-  // .tensorflow.VersionDef versions = 4;
+  // .opencv_tensorflow.VersionDef versions = 4;
   bool has_versions() const;
   void clear_versions();
   static const int kVersionsFieldNumber = 4;
   private:
   void _slow_mutable_versions();
   public:
-  const ::tensorflow::VersionDef& versions() const;
-  ::tensorflow::VersionDef* release_versions();
-  ::tensorflow::VersionDef* mutable_versions();
-  void set_allocated_versions(::tensorflow::VersionDef* versions);
+  const ::opencv_tensorflow::VersionDef& versions() const;
+  ::opencv_tensorflow::VersionDef* release_versions();
+  ::opencv_tensorflow::VersionDef* mutable_versions();
+  void set_allocated_versions(::opencv_tensorflow::VersionDef* versions);
   void unsafe_arena_set_allocated_versions(
-      ::tensorflow::VersionDef* versions);
-  ::tensorflow::VersionDef* unsafe_arena_release_versions();
+      ::opencv_tensorflow::VersionDef* versions);
+  ::opencv_tensorflow::VersionDef* unsafe_arena_release_versions();
 
   // int32 version = 3 [deprecated = true];
   GOOGLE_PROTOBUF_DEPRECATED_ATTR void clear_version();
@@ -217,16 +217,16 @@ class GraphDef : public ::google::protobuf::Message /* @@protoc_insertion_point(
   GOOGLE_PROTOBUF_DEPRECATED_ATTR ::google::protobuf::int32 version() const;
   GOOGLE_PROTOBUF_DEPRECATED_ATTR void set_version(::google::protobuf::int32 value);
 
-  // @@protoc_insertion_point(class_scope:tensorflow.GraphDef)
+  // @@protoc_insertion_point(class_scope:opencv_tensorflow.GraphDef)
  private:
 
   ::google::protobuf::internal::InternalMetadataWithArena _internal_metadata_;
   template <typename T> friend class ::google::protobuf::Arena::InternalHelper;
   typedef void InternalArenaConstructable_;
   typedef void DestructorSkippable_;
-  ::google::protobuf::RepeatedPtrField< ::tensorflow::NodeDef > node_;
-  ::tensorflow::FunctionDefLibrary* library_;
-  ::tensorflow::VersionDef* versions_;
+  ::google::protobuf::RepeatedPtrField< ::opencv_tensorflow::NodeDef > node_;
+  ::opencv_tensorflow::FunctionDefLibrary* library_;
+  ::opencv_tensorflow::VersionDef* versions_;
   ::google::protobuf::int32 version_;
   mutable int _cached_size_;
   friend struct ::protobuf_graph_2eproto::TableStruct;
@@ -235,13 +235,13 @@ class GraphDef : public ::google::protobuf::Message /* @@protoc_insertion_point(
 // -------------------------------------------------------------------
 
 class NodeDef_AttrEntry_DoNotUse : public ::google::protobuf::internal::MapEntry<NodeDef_AttrEntry_DoNotUse,
-    ::std::string, ::tensorflow::AttrValue,
+    ::std::string, ::opencv_tensorflow::AttrValue,
     ::google::protobuf::internal::WireFormatLite::TYPE_STRING,
     ::google::protobuf::internal::WireFormatLite::TYPE_MESSAGE,
     0 > {
 public:
   typedef ::google::protobuf::internal::MapEntry<NodeDef_AttrEntry_DoNotUse,
-    ::std::string, ::tensorflow::AttrValue,
+    ::std::string, ::opencv_tensorflow::AttrValue,
     ::google::protobuf::internal::WireFormatLite::TYPE_STRING,
     ::google::protobuf::internal::WireFormatLite::TYPE_MESSAGE,
     0 > SuperType;
@@ -255,7 +255,7 @@ public:
 
 // -------------------------------------------------------------------
 
-class NodeDef : public ::google::protobuf::Message /* @@protoc_insertion_point(class_definition:tensorflow.NodeDef) */ {
+class NodeDef : public ::google::protobuf::Message /* @@protoc_insertion_point(class_definition:opencv_tensorflow.NodeDef) */ {
  public:
   NodeDef();
   virtual ~NodeDef();
@@ -372,13 +372,13 @@ class NodeDef : public ::google::protobuf::Message /* @@protoc_insertion_point(c
   const ::google::protobuf::RepeatedPtrField< ::std::string>& input() const;
   ::google::protobuf::RepeatedPtrField< ::std::string>* mutable_input();
 
-  // map<string, .tensorflow.AttrValue> attr = 5;
+  // map<string, .opencv_tensorflow.AttrValue> attr = 5;
   int attr_size() const;
   void clear_attr();
   static const int kAttrFieldNumber = 5;
-  const ::google::protobuf::Map< ::std::string, ::tensorflow::AttrValue >&
+  const ::google::protobuf::Map< ::std::string, ::opencv_tensorflow::AttrValue >&
       attr() const;
-  ::google::protobuf::Map< ::std::string, ::tensorflow::AttrValue >*
+  ::google::protobuf::Map< ::std::string, ::opencv_tensorflow::AttrValue >*
       mutable_attr();
 
   // string name = 1;
@@ -450,7 +450,7 @@ class NodeDef : public ::google::protobuf::Message /* @@protoc_insertion_point(c
   void unsafe_arena_set_allocated_device(
       ::std::string* device);
 
-  // @@protoc_insertion_point(class_scope:tensorflow.NodeDef)
+  // @@protoc_insertion_point(class_scope:opencv_tensorflow.NodeDef)
  private:
 
   ::google::protobuf::internal::InternalMetadataWithArena _internal_metadata_;
@@ -460,7 +460,7 @@ class NodeDef : public ::google::protobuf::Message /* @@protoc_insertion_point(c
   ::google::protobuf::RepeatedPtrField< ::std::string> input_;
   ::google::protobuf::internal::MapField<
       NodeDef_AttrEntry_DoNotUse,
-      ::std::string, ::tensorflow::AttrValue,
+      ::std::string, ::opencv_tensorflow::AttrValue,
       ::google::protobuf::internal::WireFormatLite::TYPE_STRING,
       ::google::protobuf::internal::WireFormatLite::TYPE_MESSAGE,
       0 > attr_;
@@ -482,72 +482,72 @@ class NodeDef : public ::google::protobuf::Message /* @@protoc_insertion_point(c
 #endif  // __GNUC__
 // GraphDef
 
-// repeated .tensorflow.NodeDef node = 1;
+// repeated .opencv_tensorflow.NodeDef node = 1;
 inline int GraphDef::node_size() const {
   return node_.size();
 }
 inline void GraphDef::clear_node() {
   node_.Clear();
 }
-inline const ::tensorflow::NodeDef& GraphDef::node(int index) const {
-  // @@protoc_insertion_point(field_get:tensorflow.GraphDef.node)
+inline const ::opencv_tensorflow::NodeDef& GraphDef::node(int index) const {
+  // @@protoc_insertion_point(field_get:opencv_tensorflow.GraphDef.node)
   return node_.Get(index);
 }
-inline ::tensorflow::NodeDef* GraphDef::mutable_node(int index) {
-  // @@protoc_insertion_point(field_mutable:tensorflow.GraphDef.node)
+inline ::opencv_tensorflow::NodeDef* GraphDef::mutable_node(int index) {
+  // @@protoc_insertion_point(field_mutable:opencv_tensorflow.GraphDef.node)
   return node_.Mutable(index);
 }
-inline ::tensorflow::NodeDef* GraphDef::add_node() {
-  // @@protoc_insertion_point(field_add:tensorflow.GraphDef.node)
+inline ::opencv_tensorflow::NodeDef* GraphDef::add_node() {
+  // @@protoc_insertion_point(field_add:opencv_tensorflow.GraphDef.node)
   return node_.Add();
 }
-inline ::google::protobuf::RepeatedPtrField< ::tensorflow::NodeDef >*
+inline ::google::protobuf::RepeatedPtrField< ::opencv_tensorflow::NodeDef >*
 GraphDef::mutable_node() {
-  // @@protoc_insertion_point(field_mutable_list:tensorflow.GraphDef.node)
+  // @@protoc_insertion_point(field_mutable_list:opencv_tensorflow.GraphDef.node)
   return &node_;
 }
-inline const ::google::protobuf::RepeatedPtrField< ::tensorflow::NodeDef >&
+inline const ::google::protobuf::RepeatedPtrField< ::opencv_tensorflow::NodeDef >&
 GraphDef::node() const {
-  // @@protoc_insertion_point(field_list:tensorflow.GraphDef.node)
+  // @@protoc_insertion_point(field_list:opencv_tensorflow.GraphDef.node)
   return node_;
 }
 
-// .tensorflow.VersionDef versions = 4;
+// .opencv_tensorflow.VersionDef versions = 4;
 inline bool GraphDef::has_versions() const {
   return this != internal_default_instance() && versions_ != NULL;
 }
-inline const ::tensorflow::VersionDef& GraphDef::versions() const {
-  const ::tensorflow::VersionDef* p = versions_;
-  // @@protoc_insertion_point(field_get:tensorflow.GraphDef.versions)
-  return p != NULL ? *p : *reinterpret_cast<const ::tensorflow::VersionDef*>(
-      &::tensorflow::_VersionDef_default_instance_);
+inline const ::opencv_tensorflow::VersionDef& GraphDef::versions() const {
+  const ::opencv_tensorflow::VersionDef* p = versions_;
+  // @@protoc_insertion_point(field_get:opencv_tensorflow.GraphDef.versions)
+  return p != NULL ? *p : *reinterpret_cast<const ::opencv_tensorflow::VersionDef*>(
+      &::opencv_tensorflow::_VersionDef_default_instance_);
 }
-inline ::tensorflow::VersionDef* GraphDef::release_versions() {
-  // @@protoc_insertion_point(field_release:tensorflow.GraphDef.versions)
+inline ::opencv_tensorflow::VersionDef* GraphDef::release_versions() {
+  // @@protoc_insertion_point(field_release:opencv_tensorflow.GraphDef.versions)
 
-  ::tensorflow::VersionDef* temp = versions_;
+  ::opencv_tensorflow::VersionDef* temp = versions_;
   if (GetArenaNoVirtual() != NULL) {
     temp = ::google::protobuf::internal::DuplicateIfNonNull(temp, NULL);
   }
   versions_ = NULL;
   return temp;
 }
-inline ::tensorflow::VersionDef* GraphDef::unsafe_arena_release_versions() {
-  // @@protoc_insertion_point(field_unsafe_arena_release:tensorflow.GraphDef.versions)
+inline ::opencv_tensorflow::VersionDef* GraphDef::unsafe_arena_release_versions() {
+  // @@protoc_insertion_point(field_unsafe_arena_release:opencv_tensorflow.GraphDef.versions)
 
-  ::tensorflow::VersionDef* temp = versions_;
+  ::opencv_tensorflow::VersionDef* temp = versions_;
   versions_ = NULL;
   return temp;
 }
-inline ::tensorflow::VersionDef* GraphDef::mutable_versions() {
+inline ::opencv_tensorflow::VersionDef* GraphDef::mutable_versions() {
 
   if (versions_ == NULL) {
     _slow_mutable_versions();
   }
-  // @@protoc_insertion_point(field_mutable:tensorflow.GraphDef.versions)
+  // @@protoc_insertion_point(field_mutable:opencv_tensorflow.GraphDef.versions)
   return versions_;
 }
-inline void GraphDef::set_allocated_versions(::tensorflow::VersionDef* versions) {
+inline void GraphDef::set_allocated_versions(::opencv_tensorflow::VersionDef* versions) {
   ::google::protobuf::Arena* message_arena = GetArenaNoVirtual();
   if (message_arena == NULL) {
     delete reinterpret_cast< ::google::protobuf::MessageLite*>(versions_);
@@ -564,7 +564,7 @@ inline void GraphDef::set_allocated_versions(::tensorflow::VersionDef* versions)
 
   }
   versions_ = versions;
-  // @@protoc_insertion_point(field_set_allocated:tensorflow.GraphDef.versions)
+  // @@protoc_insertion_point(field_set_allocated:opencv_tensorflow.GraphDef.versions)
 }
 
 // int32 version = 3 [deprecated = true];
@@ -572,51 +572,51 @@ inline void GraphDef::clear_version() {
   version_ = 0;
 }
 inline ::google::protobuf::int32 GraphDef::version() const {
-  // @@protoc_insertion_point(field_get:tensorflow.GraphDef.version)
+  // @@protoc_insertion_point(field_get:opencv_tensorflow.GraphDef.version)
   return version_;
 }
 inline void GraphDef::set_version(::google::protobuf::int32 value) {
 
   version_ = value;
-  // @@protoc_insertion_point(field_set:tensorflow.GraphDef.version)
+  // @@protoc_insertion_point(field_set:opencv_tensorflow.GraphDef.version)
 }
 
-// .tensorflow.FunctionDefLibrary library = 2;
+// .opencv_tensorflow.FunctionDefLibrary library = 2;
 inline bool GraphDef::has_library() const {
   return this != internal_default_instance() && library_ != NULL;
 }
-inline const ::tensorflow::FunctionDefLibrary& GraphDef::library() const {
-  const ::tensorflow::FunctionDefLibrary* p = library_;
-  // @@protoc_insertion_point(field_get:tensorflow.GraphDef.library)
-  return p != NULL ? *p : *reinterpret_cast<const ::tensorflow::FunctionDefLibrary*>(
-      &::tensorflow::_FunctionDefLibrary_default_instance_);
+inline const ::opencv_tensorflow::FunctionDefLibrary& GraphDef::library() const {
+  const ::opencv_tensorflow::FunctionDefLibrary* p = library_;
+  // @@protoc_insertion_point(field_get:opencv_tensorflow.GraphDef.library)
+  return p != NULL ? *p : *reinterpret_cast<const ::opencv_tensorflow::FunctionDefLibrary*>(
+      &::opencv_tensorflow::_FunctionDefLibrary_default_instance_);
 }
-inline ::tensorflow::FunctionDefLibrary* GraphDef::release_library() {
-  // @@protoc_insertion_point(field_release:tensorflow.GraphDef.library)
+inline ::opencv_tensorflow::FunctionDefLibrary* GraphDef::release_library() {
+  // @@protoc_insertion_point(field_release:opencv_tensorflow.GraphDef.library)
 
-  ::tensorflow::FunctionDefLibrary* temp = library_;
+  ::opencv_tensorflow::FunctionDefLibrary* temp = library_;
   if (GetArenaNoVirtual() != NULL) {
     temp = ::google::protobuf::internal::DuplicateIfNonNull(temp, NULL);
   }
   library_ = NULL;
   return temp;
 }
-inline ::tensorflow::FunctionDefLibrary* GraphDef::unsafe_arena_release_library() {
-  // @@protoc_insertion_point(field_unsafe_arena_release:tensorflow.GraphDef.library)
+inline ::opencv_tensorflow::FunctionDefLibrary* GraphDef::unsafe_arena_release_library() {
+  // @@protoc_insertion_point(field_unsafe_arena_release:opencv_tensorflow.GraphDef.library)
 
-  ::tensorflow::FunctionDefLibrary* temp = library_;
+  ::opencv_tensorflow::FunctionDefLibrary* temp = library_;
   library_ = NULL;
   return temp;
 }
-inline ::tensorflow::FunctionDefLibrary* GraphDef::mutable_library() {
+inline ::opencv_tensorflow::FunctionDefLibrary* GraphDef::mutable_library() {
 
   if (library_ == NULL) {
     _slow_mutable_library();
   }
-  // @@protoc_insertion_point(field_mutable:tensorflow.GraphDef.library)
+  // @@protoc_insertion_point(field_mutable:opencv_tensorflow.GraphDef.library)
   return library_;
 }
-inline void GraphDef::set_allocated_library(::tensorflow::FunctionDefLibrary* library) {
+inline void GraphDef::set_allocated_library(::opencv_tensorflow::FunctionDefLibrary* library) {
   ::google::protobuf::Arena* message_arena = GetArenaNoVirtual();
   if (message_arena == NULL) {
     delete reinterpret_cast< ::google::protobuf::MessageLite*>(library_);
@@ -633,7 +633,7 @@ inline void GraphDef::set_allocated_library(::tensorflow::FunctionDefLibrary* li
 
   }
   library_ = library;
-  // @@protoc_insertion_point(field_set_allocated:tensorflow.GraphDef.library)
+  // @@protoc_insertion_point(field_set_allocated:opencv_tensorflow.GraphDef.library)
 }
 
 // -------------------------------------------------------------------
@@ -647,20 +647,20 @@ inline void NodeDef::clear_name() {
   name_.ClearToEmpty(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), GetArenaNoVirtual());
 }
 inline const ::std::string& NodeDef::name() const {
-  // @@protoc_insertion_point(field_get:tensorflow.NodeDef.name)
+  // @@protoc_insertion_point(field_get:opencv_tensorflow.NodeDef.name)
   return name_.Get();
 }
 inline void NodeDef::set_name(const ::std::string& value) {
 
   name_.Set(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), value, GetArenaNoVirtual());
-  // @@protoc_insertion_point(field_set:tensorflow.NodeDef.name)
+  // @@protoc_insertion_point(field_set:opencv_tensorflow.NodeDef.name)
 }
 #if LANG_CXX11
 inline void NodeDef::set_name(::std::string&& value) {
 
   name_.Set(
     &::google::protobuf::internal::GetEmptyStringAlreadyInited(), ::std::move(value), GetArenaNoVirtual());
-  // @@protoc_insertion_point(field_set_rvalue:tensorflow.NodeDef.name)
+  // @@protoc_insertion_point(field_set_rvalue:opencv_tensorflow.NodeDef.name)
 }
 #endif
 inline void NodeDef::set_name(const char* value) {
@@ -668,22 +668,22 @@ inline void NodeDef::set_name(const char* value) {
 
   name_.Set(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), ::std::string(value),
               GetArenaNoVirtual());
-  // @@protoc_insertion_point(field_set_char:tensorflow.NodeDef.name)
+  // @@protoc_insertion_point(field_set_char:opencv_tensorflow.NodeDef.name)
 }
 inline void NodeDef::set_name(const char* value,
     size_t size) {
 
   name_.Set(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), ::std::string(
       reinterpret_cast<const char*>(value), size), GetArenaNoVirtual());
-  // @@protoc_insertion_point(field_set_pointer:tensorflow.NodeDef.name)
+  // @@protoc_insertion_point(field_set_pointer:opencv_tensorflow.NodeDef.name)
 }
 inline ::std::string* NodeDef::mutable_name() {
 
-  // @@protoc_insertion_point(field_mutable:tensorflow.NodeDef.name)
+  // @@protoc_insertion_point(field_mutable:opencv_tensorflow.NodeDef.name)
   return name_.Mutable(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), GetArenaNoVirtual());
 }
 inline ::std::string* NodeDef::release_name() {
-  // @@protoc_insertion_point(field_release:tensorflow.NodeDef.name)
+  // @@protoc_insertion_point(field_release:opencv_tensorflow.NodeDef.name)
 
   return name_.Release(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), GetArenaNoVirtual());
 }
@@ -695,10 +695,10 @@ inline void NodeDef::set_allocated_name(::std::string* name) {
   }
   name_.SetAllocated(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), name,
       GetArenaNoVirtual());
-  // @@protoc_insertion_point(field_set_allocated:tensorflow.NodeDef.name)
+  // @@protoc_insertion_point(field_set_allocated:opencv_tensorflow.NodeDef.name)
 }
 inline ::std::string* NodeDef::unsafe_arena_release_name() {
-  // @@protoc_insertion_point(field_unsafe_arena_release:tensorflow.NodeDef.name)
+  // @@protoc_insertion_point(field_unsafe_arena_release:opencv_tensorflow.NodeDef.name)
   GOOGLE_DCHECK(GetArenaNoVirtual() != NULL);
 
   return name_.UnsafeArenaRelease(&::google::protobuf::internal::GetEmptyStringAlreadyInited(),
@@ -714,7 +714,7 @@ inline void NodeDef::unsafe_arena_set_allocated_name(
   }
   name_.UnsafeArenaSetAllocated(&::google::protobuf::internal::GetEmptyStringAlreadyInited(),
       name, GetArenaNoVirtual());
-  // @@protoc_insertion_point(field_unsafe_arena_set_allocated:tensorflow.NodeDef.name)
+  // @@protoc_insertion_point(field_unsafe_arena_set_allocated:opencv_tensorflow.NodeDef.name)
 }
 
 // string op = 2;
@@ -722,20 +722,20 @@ inline void NodeDef::clear_op() {
   op_.ClearToEmpty(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), GetArenaNoVirtual());
 }
 inline const ::std::string& NodeDef::op() const {
-  // @@protoc_insertion_point(field_get:tensorflow.NodeDef.op)
+  // @@protoc_insertion_point(field_get:opencv_tensorflow.NodeDef.op)
   return op_.Get();
 }
 inline void NodeDef::set_op(const ::std::string& value) {
 
   op_.Set(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), value, GetArenaNoVirtual());
-  // @@protoc_insertion_point(field_set:tensorflow.NodeDef.op)
+  // @@protoc_insertion_point(field_set:opencv_tensorflow.NodeDef.op)
 }
 #if LANG_CXX11
 inline void NodeDef::set_op(::std::string&& value) {
 
   op_.Set(
     &::google::protobuf::internal::GetEmptyStringAlreadyInited(), ::std::move(value), GetArenaNoVirtual());
-  // @@protoc_insertion_point(field_set_rvalue:tensorflow.NodeDef.op)
+  // @@protoc_insertion_point(field_set_rvalue:opencv_tensorflow.NodeDef.op)
 }
 #endif
 inline void NodeDef::set_op(const char* value) {
@@ -743,22 +743,22 @@ inline void NodeDef::set_op(const char* value) {
 
   op_.Set(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), ::std::string(value),
               GetArenaNoVirtual());
-  // @@protoc_insertion_point(field_set_char:tensorflow.NodeDef.op)
+  // @@protoc_insertion_point(field_set_char:opencv_tensorflow.NodeDef.op)
 }
 inline void NodeDef::set_op(const char* value,
     size_t size) {
 
   op_.Set(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), ::std::string(
       reinterpret_cast<const char*>(value), size), GetArenaNoVirtual());
-  // @@protoc_insertion_point(field_set_pointer:tensorflow.NodeDef.op)
+  // @@protoc_insertion_point(field_set_pointer:opencv_tensorflow.NodeDef.op)
 }
 inline ::std::string* NodeDef::mutable_op() {
 
-  // @@protoc_insertion_point(field_mutable:tensorflow.NodeDef.op)
+  // @@protoc_insertion_point(field_mutable:opencv_tensorflow.NodeDef.op)
   return op_.Mutable(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), GetArenaNoVirtual());
 }
 inline ::std::string* NodeDef::release_op() {
-  // @@protoc_insertion_point(field_release:tensorflow.NodeDef.op)
+  // @@protoc_insertion_point(field_release:opencv_tensorflow.NodeDef.op)
 
   return op_.Release(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), GetArenaNoVirtual());
 }
@@ -770,10 +770,10 @@ inline void NodeDef::set_allocated_op(::std::string* op) {
   }
   op_.SetAllocated(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), op,
       GetArenaNoVirtual());
-  // @@protoc_insertion_point(field_set_allocated:tensorflow.NodeDef.op)
+  // @@protoc_insertion_point(field_set_allocated:opencv_tensorflow.NodeDef.op)
 }
 inline ::std::string* NodeDef::unsafe_arena_release_op() {
-  // @@protoc_insertion_point(field_unsafe_arena_release:tensorflow.NodeDef.op)
+  // @@protoc_insertion_point(field_unsafe_arena_release:opencv_tensorflow.NodeDef.op)
   GOOGLE_DCHECK(GetArenaNoVirtual() != NULL);
 
   return op_.UnsafeArenaRelease(&::google::protobuf::internal::GetEmptyStringAlreadyInited(),
@@ -789,7 +789,7 @@ inline void NodeDef::unsafe_arena_set_allocated_op(
   }
   op_.UnsafeArenaSetAllocated(&::google::protobuf::internal::GetEmptyStringAlreadyInited(),
       op, GetArenaNoVirtual());
-  // @@protoc_insertion_point(field_unsafe_arena_set_allocated:tensorflow.NodeDef.op)
+  // @@protoc_insertion_point(field_unsafe_arena_set_allocated:opencv_tensorflow.NodeDef.op)
 }
 
 // repeated string input = 3;
@@ -800,64 +800,64 @@ inline void NodeDef::clear_input() {
   input_.Clear();
 }
 inline const ::std::string& NodeDef::input(int index) const {
-  // @@protoc_insertion_point(field_get:tensorflow.NodeDef.input)
+  // @@protoc_insertion_point(field_get:opencv_tensorflow.NodeDef.input)
   return input_.Get(index);
 }
 inline ::std::string* NodeDef::mutable_input(int index) {
-  // @@protoc_insertion_point(field_mutable:tensorflow.NodeDef.input)
+  // @@protoc_insertion_point(field_mutable:opencv_tensorflow.NodeDef.input)
   return input_.Mutable(index);
 }
 inline void NodeDef::set_input(int index, const ::std::string& value) {
-  // @@protoc_insertion_point(field_set:tensorflow.NodeDef.input)
+  // @@protoc_insertion_point(field_set:opencv_tensorflow.NodeDef.input)
   input_.Mutable(index)->assign(value);
 }
 #if LANG_CXX11
 inline void NodeDef::set_input(int index, ::std::string&& value) {
-  // @@protoc_insertion_point(field_set:tensorflow.NodeDef.input)
+  // @@protoc_insertion_point(field_set:opencv_tensorflow.NodeDef.input)
   input_.Mutable(index)->assign(std::move(value));
 }
 #endif
 inline void NodeDef::set_input(int index, const char* value) {
   GOOGLE_DCHECK(value != NULL);
   input_.Mutable(index)->assign(value);
-  // @@protoc_insertion_point(field_set_char:tensorflow.NodeDef.input)
+  // @@protoc_insertion_point(field_set_char:opencv_tensorflow.NodeDef.input)
 }
 inline void NodeDef::set_input(int index, const char* value, size_t size) {
   input_.Mutable(index)->assign(
     reinterpret_cast<const char*>(value), size);
-  // @@protoc_insertion_point(field_set_pointer:tensorflow.NodeDef.input)
+  // @@protoc_insertion_point(field_set_pointer:opencv_tensorflow.NodeDef.input)
 }
 inline ::std::string* NodeDef::add_input() {
-  // @@protoc_insertion_point(field_add_mutable:tensorflow.NodeDef.input)
+  // @@protoc_insertion_point(field_add_mutable:opencv_tensorflow.NodeDef.input)
   return input_.Add();
 }
 inline void NodeDef::add_input(const ::std::string& value) {
   input_.Add()->assign(value);
-  // @@protoc_insertion_point(field_add:tensorflow.NodeDef.input)
+  // @@protoc_insertion_point(field_add:opencv_tensorflow.NodeDef.input)
 }
 #if LANG_CXX11
 inline void NodeDef::add_input(::std::string&& value) {
   input_.Add(std::move(value));
-  // @@protoc_insertion_point(field_add:tensorflow.NodeDef.input)
+  // @@protoc_insertion_point(field_add:opencv_tensorflow.NodeDef.input)
 }
 #endif
 inline void NodeDef::add_input(const char* value) {
   GOOGLE_DCHECK(value != NULL);
   input_.Add()->assign(value);
-  // @@protoc_insertion_point(field_add_char:tensorflow.NodeDef.input)
+  // @@protoc_insertion_point(field_add_char:opencv_tensorflow.NodeDef.input)
 }
 inline void NodeDef::add_input(const char* value, size_t size) {
   input_.Add()->assign(reinterpret_cast<const char*>(value), size);
-  // @@protoc_insertion_point(field_add_pointer:tensorflow.NodeDef.input)
+  // @@protoc_insertion_point(field_add_pointer:opencv_tensorflow.NodeDef.input)
 }
 inline const ::google::protobuf::RepeatedPtrField< ::std::string>&
 NodeDef::input() const {
-  // @@protoc_insertion_point(field_list:tensorflow.NodeDef.input)
+  // @@protoc_insertion_point(field_list:opencv_tensorflow.NodeDef.input)
   return input_;
 }
 inline ::google::protobuf::RepeatedPtrField< ::std::string>*
 NodeDef::mutable_input() {
-  // @@protoc_insertion_point(field_mutable_list:tensorflow.NodeDef.input)
+  // @@protoc_insertion_point(field_mutable_list:opencv_tensorflow.NodeDef.input)
   return &input_;
 }
 
@@ -866,20 +866,20 @@ inline void NodeDef::clear_device() {
   device_.ClearToEmpty(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), GetArenaNoVirtual());
 }
 inline const ::std::string& NodeDef::device() const {
-  // @@protoc_insertion_point(field_get:tensorflow.NodeDef.device)
+  // @@protoc_insertion_point(field_get:opencv_tensorflow.NodeDef.device)
   return device_.Get();
 }
 inline void NodeDef::set_device(const ::std::string& value) {
 
   device_.Set(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), value, GetArenaNoVirtual());
-  // @@protoc_insertion_point(field_set:tensorflow.NodeDef.device)
+  // @@protoc_insertion_point(field_set:opencv_tensorflow.NodeDef.device)
 }
 #if LANG_CXX11
 inline void NodeDef::set_device(::std::string&& value) {
 
   device_.Set(
     &::google::protobuf::internal::GetEmptyStringAlreadyInited(), ::std::move(value), GetArenaNoVirtual());
-  // @@protoc_insertion_point(field_set_rvalue:tensorflow.NodeDef.device)
+  // @@protoc_insertion_point(field_set_rvalue:opencv_tensorflow.NodeDef.device)
 }
 #endif
 inline void NodeDef::set_device(const char* value) {
@@ -887,22 +887,22 @@ inline void NodeDef::set_device(const char* value) {
 
   device_.Set(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), ::std::string(value),
               GetArenaNoVirtual());
-  // @@protoc_insertion_point(field_set_char:tensorflow.NodeDef.device)
+  // @@protoc_insertion_point(field_set_char:opencv_tensorflow.NodeDef.device)
 }
 inline void NodeDef::set_device(const char* value,
     size_t size) {
 
   device_.Set(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), ::std::string(
       reinterpret_cast<const char*>(value), size), GetArenaNoVirtual());
-  // @@protoc_insertion_point(field_set_pointer:tensorflow.NodeDef.device)
+  // @@protoc_insertion_point(field_set_pointer:opencv_tensorflow.NodeDef.device)
 }
 inline ::std::string* NodeDef::mutable_device() {
 
-  // @@protoc_insertion_point(field_mutable:tensorflow.NodeDef.device)
+  // @@protoc_insertion_point(field_mutable:opencv_tensorflow.NodeDef.device)
   return device_.Mutable(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), GetArenaNoVirtual());
 }
 inline ::std::string* NodeDef::release_device() {
-  // @@protoc_insertion_point(field_release:tensorflow.NodeDef.device)
+  // @@protoc_insertion_point(field_release:opencv_tensorflow.NodeDef.device)
 
   return device_.Release(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), GetArenaNoVirtual());
 }
@@ -914,10 +914,10 @@ inline void NodeDef::set_allocated_device(::std::string* device) {
   }
   device_.SetAllocated(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), device,
       GetArenaNoVirtual());
-  // @@protoc_insertion_point(field_set_allocated:tensorflow.NodeDef.device)
+  // @@protoc_insertion_point(field_set_allocated:opencv_tensorflow.NodeDef.device)
 }
 inline ::std::string* NodeDef::unsafe_arena_release_device() {
-  // @@protoc_insertion_point(field_unsafe_arena_release:tensorflow.NodeDef.device)
+  // @@protoc_insertion_point(field_unsafe_arena_release:opencv_tensorflow.NodeDef.device)
   GOOGLE_DCHECK(GetArenaNoVirtual() != NULL);
 
   return device_.UnsafeArenaRelease(&::google::protobuf::internal::GetEmptyStringAlreadyInited(),
@@ -933,21 +933,21 @@ inline void NodeDef::unsafe_arena_set_allocated_device(
   }
   device_.UnsafeArenaSetAllocated(&::google::protobuf::internal::GetEmptyStringAlreadyInited(),
       device, GetArenaNoVirtual());
-  // @@protoc_insertion_point(field_unsafe_arena_set_allocated:tensorflow.NodeDef.device)
+  // @@protoc_insertion_point(field_unsafe_arena_set_allocated:opencv_tensorflow.NodeDef.device)
 }
 
-// map<string, .tensorflow.AttrValue> attr = 5;
+// map<string, .opencv_tensorflow.AttrValue> attr = 5;
 inline int NodeDef::attr_size() const {
   return attr_.size();
 }
-inline const ::google::protobuf::Map< ::std::string, ::tensorflow::AttrValue >&
+inline const ::google::protobuf::Map< ::std::string, ::opencv_tensorflow::AttrValue >&
 NodeDef::attr() const {
-  // @@protoc_insertion_point(field_map:tensorflow.NodeDef.attr)
+  // @@protoc_insertion_point(field_map:opencv_tensorflow.NodeDef.attr)
   return attr_.GetMap();
 }
-inline ::google::protobuf::Map< ::std::string, ::tensorflow::AttrValue >*
+inline ::google::protobuf::Map< ::std::string, ::opencv_tensorflow::AttrValue >*
 NodeDef::mutable_attr() {
-  // @@protoc_insertion_point(field_mutable_map:tensorflow.NodeDef.attr)
+  // @@protoc_insertion_point(field_mutable_map:opencv_tensorflow.NodeDef.attr)
   return attr_.MutableMap();
 }
 
@@ -961,7 +961,7 @@ NodeDef::mutable_attr() {
 
 // @@protoc_insertion_point(namespace_scope)
 
-}  // namespace tensorflow
+}  // namespace opencv_tensorflow
 
 // @@protoc_insertion_point(global_scope)
 

--- a/modules/dnn/misc/tensorflow/op_def.pb.cc
+++ b/modules/dnn/misc/tensorflow/op_def.pb.cc
@@ -19,7 +19,7 @@
 #include "third_party/protobuf/version.h"
 #endif
 // @@protoc_insertion_point(includes)
-namespace tensorflow {
+namespace opencv_tensorflow {
 class OpDef_ArgDefDefaultTypeInternal {
  public:
   ::google::protobuf::internal::ExplicitlyConstructed<OpDef_ArgDef>
@@ -45,7 +45,7 @@ class OpListDefaultTypeInternal {
   ::google::protobuf::internal::ExplicitlyConstructed<OpList>
       _instance;
 } _OpList_default_instance_;
-}  // namespace tensorflow
+}  // namespace opencv_tensorflow
 namespace protobuf_op_5fdef_2eproto {
 void InitDefaultsOpDef_ArgDefImpl() {
   GOOGLE_PROTOBUF_VERIFY_VERSION;
@@ -56,11 +56,11 @@ void InitDefaultsOpDef_ArgDefImpl() {
   ::google::protobuf::internal::InitProtobufDefaults();
 #endif  // GOOGLE_PROTOBUF_ENFORCE_UNIQUENESS
   {
-    void* ptr = &::tensorflow::_OpDef_ArgDef_default_instance_;
-    new (ptr) ::tensorflow::OpDef_ArgDef();
+    void* ptr = &::opencv_tensorflow::_OpDef_ArgDef_default_instance_;
+    new (ptr) ::opencv_tensorflow::OpDef_ArgDef();
     ::google::protobuf::internal::OnShutdownDestroyMessage(ptr);
   }
-  ::tensorflow::OpDef_ArgDef::InitAsDefaultInstance();
+  ::opencv_tensorflow::OpDef_ArgDef::InitAsDefaultInstance();
 }
 
 void InitDefaultsOpDef_ArgDef() {
@@ -78,11 +78,11 @@ void InitDefaultsOpDef_AttrDefImpl() {
 #endif  // GOOGLE_PROTOBUF_ENFORCE_UNIQUENESS
   protobuf_attr_5fvalue_2eproto::InitDefaultsAttrValue();
   {
-    void* ptr = &::tensorflow::_OpDef_AttrDef_default_instance_;
-    new (ptr) ::tensorflow::OpDef_AttrDef();
+    void* ptr = &::opencv_tensorflow::_OpDef_AttrDef_default_instance_;
+    new (ptr) ::opencv_tensorflow::OpDef_AttrDef();
     ::google::protobuf::internal::OnShutdownDestroyMessage(ptr);
   }
-  ::tensorflow::OpDef_AttrDef::InitAsDefaultInstance();
+  ::opencv_tensorflow::OpDef_AttrDef::InitAsDefaultInstance();
 }
 
 void InitDefaultsOpDef_AttrDef() {
@@ -102,11 +102,11 @@ void InitDefaultsOpDefImpl() {
   protobuf_op_5fdef_2eproto::InitDefaultsOpDef_AttrDef();
   protobuf_op_5fdef_2eproto::InitDefaultsOpDeprecation();
   {
-    void* ptr = &::tensorflow::_OpDef_default_instance_;
-    new (ptr) ::tensorflow::OpDef();
+    void* ptr = &::opencv_tensorflow::_OpDef_default_instance_;
+    new (ptr) ::opencv_tensorflow::OpDef();
     ::google::protobuf::internal::OnShutdownDestroyMessage(ptr);
   }
-  ::tensorflow::OpDef::InitAsDefaultInstance();
+  ::opencv_tensorflow::OpDef::InitAsDefaultInstance();
 }
 
 void InitDefaultsOpDef() {
@@ -123,11 +123,11 @@ void InitDefaultsOpDeprecationImpl() {
   ::google::protobuf::internal::InitProtobufDefaults();
 #endif  // GOOGLE_PROTOBUF_ENFORCE_UNIQUENESS
   {
-    void* ptr = &::tensorflow::_OpDeprecation_default_instance_;
-    new (ptr) ::tensorflow::OpDeprecation();
+    void* ptr = &::opencv_tensorflow::_OpDeprecation_default_instance_;
+    new (ptr) ::opencv_tensorflow::OpDeprecation();
     ::google::protobuf::internal::OnShutdownDestroyMessage(ptr);
   }
-  ::tensorflow::OpDeprecation::InitAsDefaultInstance();
+  ::opencv_tensorflow::OpDeprecation::InitAsDefaultInstance();
 }
 
 void InitDefaultsOpDeprecation() {
@@ -145,11 +145,11 @@ void InitDefaultsOpListImpl() {
 #endif  // GOOGLE_PROTOBUF_ENFORCE_UNIQUENESS
   protobuf_op_5fdef_2eproto::InitDefaultsOpDef();
   {
-    void* ptr = &::tensorflow::_OpList_default_instance_;
-    new (ptr) ::tensorflow::OpList();
+    void* ptr = &::opencv_tensorflow::_OpList_default_instance_;
+    new (ptr) ::opencv_tensorflow::OpList();
     ::google::protobuf::internal::OnShutdownDestroyMessage(ptr);
   }
-  ::tensorflow::OpList::InitAsDefaultInstance();
+  ::opencv_tensorflow::OpList::InitAsDefaultInstance();
 }
 
 void InitDefaultsOpList() {
@@ -161,73 +161,73 @@ void InitDefaultsOpList() {
 
 const ::google::protobuf::uint32 TableStruct::offsets[] GOOGLE_PROTOBUF_ATTRIBUTE_SECTION_VARIABLE(protodesc_cold) = {
   ~0u,  // no _has_bits_
-  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::tensorflow::OpDef_ArgDef, _internal_metadata_),
+  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::opencv_tensorflow::OpDef_ArgDef, _internal_metadata_),
   ~0u,  // no _extensions_
   ~0u,  // no _oneof_case_
   ~0u,  // no _weak_field_map_
-  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::tensorflow::OpDef_ArgDef, name_),
-  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::tensorflow::OpDef_ArgDef, description_),
-  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::tensorflow::OpDef_ArgDef, type_),
-  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::tensorflow::OpDef_ArgDef, type_attr_),
-  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::tensorflow::OpDef_ArgDef, number_attr_),
-  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::tensorflow::OpDef_ArgDef, type_list_attr_),
-  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::tensorflow::OpDef_ArgDef, is_ref_),
+  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::opencv_tensorflow::OpDef_ArgDef, name_),
+  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::opencv_tensorflow::OpDef_ArgDef, description_),
+  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::opencv_tensorflow::OpDef_ArgDef, type_),
+  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::opencv_tensorflow::OpDef_ArgDef, type_attr_),
+  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::opencv_tensorflow::OpDef_ArgDef, number_attr_),
+  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::opencv_tensorflow::OpDef_ArgDef, type_list_attr_),
+  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::opencv_tensorflow::OpDef_ArgDef, is_ref_),
   ~0u,  // no _has_bits_
-  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::tensorflow::OpDef_AttrDef, _internal_metadata_),
+  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::opencv_tensorflow::OpDef_AttrDef, _internal_metadata_),
   ~0u,  // no _extensions_
   ~0u,  // no _oneof_case_
   ~0u,  // no _weak_field_map_
-  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::tensorflow::OpDef_AttrDef, name_),
-  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::tensorflow::OpDef_AttrDef, type_),
-  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::tensorflow::OpDef_AttrDef, default_value_),
-  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::tensorflow::OpDef_AttrDef, description_),
-  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::tensorflow::OpDef_AttrDef, has_minimum_),
-  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::tensorflow::OpDef_AttrDef, minimum_),
-  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::tensorflow::OpDef_AttrDef, allowed_values_),
+  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::opencv_tensorflow::OpDef_AttrDef, name_),
+  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::opencv_tensorflow::OpDef_AttrDef, type_),
+  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::opencv_tensorflow::OpDef_AttrDef, default_value_),
+  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::opencv_tensorflow::OpDef_AttrDef, description_),
+  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::opencv_tensorflow::OpDef_AttrDef, has_minimum_),
+  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::opencv_tensorflow::OpDef_AttrDef, minimum_),
+  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::opencv_tensorflow::OpDef_AttrDef, allowed_values_),
   ~0u,  // no _has_bits_
-  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::tensorflow::OpDef, _internal_metadata_),
+  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::opencv_tensorflow::OpDef, _internal_metadata_),
   ~0u,  // no _extensions_
   ~0u,  // no _oneof_case_
   ~0u,  // no _weak_field_map_
-  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::tensorflow::OpDef, name_),
-  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::tensorflow::OpDef, input_arg_),
-  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::tensorflow::OpDef, output_arg_),
-  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::tensorflow::OpDef, attr_),
-  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::tensorflow::OpDef, deprecation_),
-  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::tensorflow::OpDef, summary_),
-  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::tensorflow::OpDef, description_),
-  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::tensorflow::OpDef, is_commutative_),
-  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::tensorflow::OpDef, is_aggregate_),
-  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::tensorflow::OpDef, is_stateful_),
-  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::tensorflow::OpDef, allows_uninitialized_input_),
+  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::opencv_tensorflow::OpDef, name_),
+  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::opencv_tensorflow::OpDef, input_arg_),
+  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::opencv_tensorflow::OpDef, output_arg_),
+  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::opencv_tensorflow::OpDef, attr_),
+  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::opencv_tensorflow::OpDef, deprecation_),
+  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::opencv_tensorflow::OpDef, summary_),
+  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::opencv_tensorflow::OpDef, description_),
+  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::opencv_tensorflow::OpDef, is_commutative_),
+  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::opencv_tensorflow::OpDef, is_aggregate_),
+  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::opencv_tensorflow::OpDef, is_stateful_),
+  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::opencv_tensorflow::OpDef, allows_uninitialized_input_),
   ~0u,  // no _has_bits_
-  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::tensorflow::OpDeprecation, _internal_metadata_),
+  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::opencv_tensorflow::OpDeprecation, _internal_metadata_),
   ~0u,  // no _extensions_
   ~0u,  // no _oneof_case_
   ~0u,  // no _weak_field_map_
-  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::tensorflow::OpDeprecation, version_),
-  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::tensorflow::OpDeprecation, explanation_),
+  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::opencv_tensorflow::OpDeprecation, version_),
+  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::opencv_tensorflow::OpDeprecation, explanation_),
   ~0u,  // no _has_bits_
-  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::tensorflow::OpList, _internal_metadata_),
+  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::opencv_tensorflow::OpList, _internal_metadata_),
   ~0u,  // no _extensions_
   ~0u,  // no _oneof_case_
   ~0u,  // no _weak_field_map_
-  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::tensorflow::OpList, op_),
+  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::opencv_tensorflow::OpList, op_),
 };
 static const ::google::protobuf::internal::MigrationSchema schemas[] GOOGLE_PROTOBUF_ATTRIBUTE_SECTION_VARIABLE(protodesc_cold) = {
-  { 0, -1, sizeof(::tensorflow::OpDef_ArgDef)},
-  { 12, -1, sizeof(::tensorflow::OpDef_AttrDef)},
-  { 24, -1, sizeof(::tensorflow::OpDef)},
-  { 40, -1, sizeof(::tensorflow::OpDeprecation)},
-  { 47, -1, sizeof(::tensorflow::OpList)},
+  { 0, -1, sizeof(::opencv_tensorflow::OpDef_ArgDef)},
+  { 12, -1, sizeof(::opencv_tensorflow::OpDef_AttrDef)},
+  { 24, -1, sizeof(::opencv_tensorflow::OpDef)},
+  { 40, -1, sizeof(::opencv_tensorflow::OpDeprecation)},
+  { 47, -1, sizeof(::opencv_tensorflow::OpList)},
 };
 
 static ::google::protobuf::Message const * const file_default_instances[] = {
-  reinterpret_cast<const ::google::protobuf::Message*>(&::tensorflow::_OpDef_ArgDef_default_instance_),
-  reinterpret_cast<const ::google::protobuf::Message*>(&::tensorflow::_OpDef_AttrDef_default_instance_),
-  reinterpret_cast<const ::google::protobuf::Message*>(&::tensorflow::_OpDef_default_instance_),
-  reinterpret_cast<const ::google::protobuf::Message*>(&::tensorflow::_OpDeprecation_default_instance_),
-  reinterpret_cast<const ::google::protobuf::Message*>(&::tensorflow::_OpList_default_instance_),
+  reinterpret_cast<const ::google::protobuf::Message*>(&::opencv_tensorflow::_OpDef_ArgDef_default_instance_),
+  reinterpret_cast<const ::google::protobuf::Message*>(&::opencv_tensorflow::_OpDef_AttrDef_default_instance_),
+  reinterpret_cast<const ::google::protobuf::Message*>(&::opencv_tensorflow::_OpDef_default_instance_),
+  reinterpret_cast<const ::google::protobuf::Message*>(&::opencv_tensorflow::_OpDeprecation_default_instance_),
+  reinterpret_cast<const ::google::protobuf::Message*>(&::opencv_tensorflow::_OpList_default_instance_),
 };
 
 void protobuf_AssignDescriptors() {
@@ -252,32 +252,34 @@ void protobuf_RegisterTypes(const ::std::string&) {
 void AddDescriptorsImpl() {
   InitDefaults();
   static const char descriptor[] GOOGLE_PROTOBUF_ATTRIBUTE_SECTION_VARIABLE(protodesc_cold) = {
-      "\n\014op_def.proto\022\ntensorflow\032\020attr_value.p"
-      "roto\032\013types.proto\"\270\005\n\005OpDef\022\014\n\004name\030\001 \001("
-      "\t\022+\n\tinput_arg\030\002 \003(\0132\030.tensorflow.OpDef."
-      "ArgDef\022,\n\noutput_arg\030\003 \003(\0132\030.tensorflow."
-      "OpDef.ArgDef\022\'\n\004attr\030\004 \003(\0132\031.tensorflow."
-      "OpDef.AttrDef\022.\n\013deprecation\030\010 \001(\0132\031.ten"
-      "sorflow.OpDeprecation\022\017\n\007summary\030\005 \001(\t\022\023"
-      "\n\013description\030\006 \001(\t\022\026\n\016is_commutative\030\022 "
-      "\001(\010\022\024\n\014is_aggregate\030\020 \001(\010\022\023\n\013is_stateful"
-      "\030\021 \001(\010\022\"\n\032allows_uninitialized_input\030\023 \001"
-      "(\010\032\237\001\n\006ArgDef\022\014\n\004name\030\001 \001(\t\022\023\n\013descripti"
-      "on\030\002 \001(\t\022\"\n\004type\030\003 \001(\0162\024.tensorflow.Data"
-      "Type\022\021\n\ttype_attr\030\004 \001(\t\022\023\n\013number_attr\030\005"
-      " \001(\t\022\026\n\016type_list_attr\030\006 \001(\t\022\016\n\006is_ref\030\020"
-      " \001(\010\032\275\001\n\007AttrDef\022\014\n\004name\030\001 \001(\t\022\014\n\004type\030\002"
-      " \001(\t\022,\n\rdefault_value\030\003 \001(\0132\025.tensorflow"
-      ".AttrValue\022\023\n\013description\030\004 \001(\t\022\023\n\013has_m"
-      "inimum\030\005 \001(\010\022\017\n\007minimum\030\006 \001(\003\022-\n\016allowed"
-      "_values\030\007 \001(\0132\025.tensorflow.AttrValue\"5\n\r"
-      "OpDeprecation\022\017\n\007version\030\001 \001(\005\022\023\n\013explan"
-      "ation\030\002 \001(\t\"\'\n\006OpList\022\035\n\002op\030\001 \003(\0132\021.tens"
-      "orflow.OpDefB,\n\030org.tensorflow.framework"
-      "B\013OpDefProtosP\001\370\001\001b\006proto3"
+      "\n\014op_def.proto\022\021opencv_tensorflow\032\020attr_"
+      "value.proto\032\013types.proto\"\351\005\n\005OpDef\022\014\n\004na"
+      "me\030\001 \001(\t\0222\n\tinput_arg\030\002 \003(\0132\037.opencv_ten"
+      "sorflow.OpDef.ArgDef\0223\n\noutput_arg\030\003 \003(\013"
+      "2\037.opencv_tensorflow.OpDef.ArgDef\022.\n\004att"
+      "r\030\004 \003(\0132 .opencv_tensorflow.OpDef.AttrDe"
+      "f\0225\n\013deprecation\030\010 \001(\0132 .opencv_tensorfl"
+      "ow.OpDeprecation\022\017\n\007summary\030\005 \001(\t\022\023\n\013des"
+      "cription\030\006 \001(\t\022\026\n\016is_commutative\030\022 \001(\010\022\024"
+      "\n\014is_aggregate\030\020 \001(\010\022\023\n\013is_stateful\030\021 \001("
+      "\010\022\"\n\032allows_uninitialized_input\030\023 \001(\010\032\246\001"
+      "\n\006ArgDef\022\014\n\004name\030\001 \001(\t\022\023\n\013description\030\002 "
+      "\001(\t\022)\n\004type\030\003 \001(\0162\033.opencv_tensorflow.Da"
+      "taType\022\021\n\ttype_attr\030\004 \001(\t\022\023\n\013number_attr"
+      "\030\005 \001(\t\022\026\n\016type_list_attr\030\006 \001(\t\022\016\n\006is_ref"
+      "\030\020 \001(\010\032\313\001\n\007AttrDef\022\014\n\004name\030\001 \001(\t\022\014\n\004type"
+      "\030\002 \001(\t\0223\n\rdefault_value\030\003 \001(\0132\034.opencv_t"
+      "ensorflow.AttrValue\022\023\n\013description\030\004 \001(\t"
+      "\022\023\n\013has_minimum\030\005 \001(\010\022\017\n\007minimum\030\006 \001(\003\0224"
+      "\n\016allowed_values\030\007 \001(\0132\034.opencv_tensorfl"
+      "ow.AttrValue\"5\n\rOpDeprecation\022\017\n\007version"
+      "\030\001 \001(\005\022\023\n\013explanation\030\002 \001(\t\".\n\006OpList\022$\n"
+      "\002op\030\001 \003(\0132\030.opencv_tensorflow.OpDefB,\n\030o"
+      "rg.tensorflow.frameworkB\013OpDefProtosP\001\370\001"
+      "\001b\006proto3"
   };
   ::google::protobuf::DescriptorPool::InternalAddGeneratedFile(
-      descriptor, 906);
+      descriptor, 969);
   ::google::protobuf::MessageFactory::InternalRegisterGeneratedFile(
     "op_def.proto", &protobuf_RegisterTypes);
   ::protobuf_attr_5fvalue_2eproto::AddDescriptors();
@@ -295,7 +297,7 @@ struct StaticDescriptorInitializer {
   }
 } static_descriptor_initializer;
 }  // namespace protobuf_op_5fdef_2eproto
-namespace tensorflow {
+namespace opencv_tensorflow {
 
 // ===================================================================
 
@@ -317,7 +319,7 @@ OpDef_ArgDef::OpDef_ArgDef()
     ::protobuf_op_5fdef_2eproto::InitDefaultsOpDef_ArgDef();
   }
   SharedCtor();
-  // @@protoc_insertion_point(constructor:tensorflow.OpDef.ArgDef)
+  // @@protoc_insertion_point(constructor:opencv_tensorflow.OpDef.ArgDef)
 }
 OpDef_ArgDef::OpDef_ArgDef(::google::protobuf::Arena* arena)
   : ::google::protobuf::Message(),
@@ -325,7 +327,7 @@ OpDef_ArgDef::OpDef_ArgDef(::google::protobuf::Arena* arena)
   ::protobuf_op_5fdef_2eproto::InitDefaultsOpDef_ArgDef();
   SharedCtor();
   RegisterArenaDtor(arena);
-  // @@protoc_insertion_point(arena_constructor:tensorflow.OpDef.ArgDef)
+  // @@protoc_insertion_point(arena_constructor:opencv_tensorflow.OpDef.ArgDef)
 }
 OpDef_ArgDef::OpDef_ArgDef(const OpDef_ArgDef& from)
   : ::google::protobuf::Message(),
@@ -360,7 +362,7 @@ OpDef_ArgDef::OpDef_ArgDef(const OpDef_ArgDef& from)
   ::memcpy(&type_, &from.type_,
     static_cast<size_t>(reinterpret_cast<char*>(&is_ref_) -
     reinterpret_cast<char*>(&type_)) + sizeof(is_ref_));
-  // @@protoc_insertion_point(copy_constructor:tensorflow.OpDef.ArgDef)
+  // @@protoc_insertion_point(copy_constructor:opencv_tensorflow.OpDef.ArgDef)
 }
 
 void OpDef_ArgDef::SharedCtor() {
@@ -376,7 +378,7 @@ void OpDef_ArgDef::SharedCtor() {
 }
 
 OpDef_ArgDef::~OpDef_ArgDef() {
-  // @@protoc_insertion_point(destructor:tensorflow.OpDef.ArgDef)
+  // @@protoc_insertion_point(destructor:opencv_tensorflow.OpDef.ArgDef)
   SharedDtor();
 }
 
@@ -415,7 +417,7 @@ OpDef_ArgDef* OpDef_ArgDef::New(::google::protobuf::Arena* arena) const {
 }
 
 void OpDef_ArgDef::Clear() {
-// @@protoc_insertion_point(message_clear_start:tensorflow.OpDef.ArgDef)
+// @@protoc_insertion_point(message_clear_start:opencv_tensorflow.OpDef.ArgDef)
   ::google::protobuf::uint32 cached_has_bits = 0;
   // Prevent compiler warnings about cached_has_bits being unused
   (void) cached_has_bits;
@@ -435,7 +437,7 @@ bool OpDef_ArgDef::MergePartialFromCodedStream(
     ::google::protobuf::io::CodedInputStream* input) {
 #define DO_(EXPRESSION) if (!GOOGLE_PREDICT_TRUE(EXPRESSION)) goto failure
   ::google::protobuf::uint32 tag;
-  // @@protoc_insertion_point(parse_start:tensorflow.OpDef.ArgDef)
+  // @@protoc_insertion_point(parse_start:opencv_tensorflow.OpDef.ArgDef)
   for (;;) {
     ::std::pair< ::google::protobuf::uint32, bool> p = input->ReadTagWithCutoffNoLastTag(16383u);
     tag = p.first;
@@ -450,7 +452,7 @@ bool OpDef_ArgDef::MergePartialFromCodedStream(
           DO_(::google::protobuf::internal::WireFormatLite::VerifyUtf8String(
             this->name().data(), static_cast<int>(this->name().length()),
             ::google::protobuf::internal::WireFormatLite::PARSE,
-            "tensorflow.OpDef.ArgDef.name"));
+            "opencv_tensorflow.OpDef.ArgDef.name"));
         } else {
           goto handle_unusual;
         }
@@ -466,14 +468,14 @@ bool OpDef_ArgDef::MergePartialFromCodedStream(
           DO_(::google::protobuf::internal::WireFormatLite::VerifyUtf8String(
             this->description().data(), static_cast<int>(this->description().length()),
             ::google::protobuf::internal::WireFormatLite::PARSE,
-            "tensorflow.OpDef.ArgDef.description"));
+            "opencv_tensorflow.OpDef.ArgDef.description"));
         } else {
           goto handle_unusual;
         }
         break;
       }
 
-      // .tensorflow.DataType type = 3;
+      // .opencv_tensorflow.DataType type = 3;
       case 3: {
         if (static_cast< ::google::protobuf::uint8>(tag) ==
             static_cast< ::google::protobuf::uint8>(24u /* 24 & 0xFF */)) {
@@ -481,7 +483,7 @@ bool OpDef_ArgDef::MergePartialFromCodedStream(
           DO_((::google::protobuf::internal::WireFormatLite::ReadPrimitive<
                    int, ::google::protobuf::internal::WireFormatLite::TYPE_ENUM>(
                  input, &value)));
-          set_type(static_cast< ::tensorflow::DataType >(value));
+          set_type(static_cast< ::opencv_tensorflow::DataType >(value));
         } else {
           goto handle_unusual;
         }
@@ -497,7 +499,7 @@ bool OpDef_ArgDef::MergePartialFromCodedStream(
           DO_(::google::protobuf::internal::WireFormatLite::VerifyUtf8String(
             this->type_attr().data(), static_cast<int>(this->type_attr().length()),
             ::google::protobuf::internal::WireFormatLite::PARSE,
-            "tensorflow.OpDef.ArgDef.type_attr"));
+            "opencv_tensorflow.OpDef.ArgDef.type_attr"));
         } else {
           goto handle_unusual;
         }
@@ -513,7 +515,7 @@ bool OpDef_ArgDef::MergePartialFromCodedStream(
           DO_(::google::protobuf::internal::WireFormatLite::VerifyUtf8String(
             this->number_attr().data(), static_cast<int>(this->number_attr().length()),
             ::google::protobuf::internal::WireFormatLite::PARSE,
-            "tensorflow.OpDef.ArgDef.number_attr"));
+            "opencv_tensorflow.OpDef.ArgDef.number_attr"));
         } else {
           goto handle_unusual;
         }
@@ -529,7 +531,7 @@ bool OpDef_ArgDef::MergePartialFromCodedStream(
           DO_(::google::protobuf::internal::WireFormatLite::VerifyUtf8String(
             this->type_list_attr().data(), static_cast<int>(this->type_list_attr().length()),
             ::google::protobuf::internal::WireFormatLite::PARSE,
-            "tensorflow.OpDef.ArgDef.type_list_attr"));
+            "opencv_tensorflow.OpDef.ArgDef.type_list_attr"));
         } else {
           goto handle_unusual;
         }
@@ -562,17 +564,17 @@ bool OpDef_ArgDef::MergePartialFromCodedStream(
     }
   }
 success:
-  // @@protoc_insertion_point(parse_success:tensorflow.OpDef.ArgDef)
+  // @@protoc_insertion_point(parse_success:opencv_tensorflow.OpDef.ArgDef)
   return true;
 failure:
-  // @@protoc_insertion_point(parse_failure:tensorflow.OpDef.ArgDef)
+  // @@protoc_insertion_point(parse_failure:opencv_tensorflow.OpDef.ArgDef)
   return false;
 #undef DO_
 }
 
 void OpDef_ArgDef::SerializeWithCachedSizes(
     ::google::protobuf::io::CodedOutputStream* output) const {
-  // @@protoc_insertion_point(serialize_start:tensorflow.OpDef.ArgDef)
+  // @@protoc_insertion_point(serialize_start:opencv_tensorflow.OpDef.ArgDef)
   ::google::protobuf::uint32 cached_has_bits = 0;
   (void) cached_has_bits;
 
@@ -581,7 +583,7 @@ void OpDef_ArgDef::SerializeWithCachedSizes(
     ::google::protobuf::internal::WireFormatLite::VerifyUtf8String(
       this->name().data(), static_cast<int>(this->name().length()),
       ::google::protobuf::internal::WireFormatLite::SERIALIZE,
-      "tensorflow.OpDef.ArgDef.name");
+      "opencv_tensorflow.OpDef.ArgDef.name");
     ::google::protobuf::internal::WireFormatLite::WriteStringMaybeAliased(
       1, this->name(), output);
   }
@@ -591,12 +593,12 @@ void OpDef_ArgDef::SerializeWithCachedSizes(
     ::google::protobuf::internal::WireFormatLite::VerifyUtf8String(
       this->description().data(), static_cast<int>(this->description().length()),
       ::google::protobuf::internal::WireFormatLite::SERIALIZE,
-      "tensorflow.OpDef.ArgDef.description");
+      "opencv_tensorflow.OpDef.ArgDef.description");
     ::google::protobuf::internal::WireFormatLite::WriteStringMaybeAliased(
       2, this->description(), output);
   }
 
-  // .tensorflow.DataType type = 3;
+  // .opencv_tensorflow.DataType type = 3;
   if (this->type() != 0) {
     ::google::protobuf::internal::WireFormatLite::WriteEnum(
       3, this->type(), output);
@@ -607,7 +609,7 @@ void OpDef_ArgDef::SerializeWithCachedSizes(
     ::google::protobuf::internal::WireFormatLite::VerifyUtf8String(
       this->type_attr().data(), static_cast<int>(this->type_attr().length()),
       ::google::protobuf::internal::WireFormatLite::SERIALIZE,
-      "tensorflow.OpDef.ArgDef.type_attr");
+      "opencv_tensorflow.OpDef.ArgDef.type_attr");
     ::google::protobuf::internal::WireFormatLite::WriteStringMaybeAliased(
       4, this->type_attr(), output);
   }
@@ -617,7 +619,7 @@ void OpDef_ArgDef::SerializeWithCachedSizes(
     ::google::protobuf::internal::WireFormatLite::VerifyUtf8String(
       this->number_attr().data(), static_cast<int>(this->number_attr().length()),
       ::google::protobuf::internal::WireFormatLite::SERIALIZE,
-      "tensorflow.OpDef.ArgDef.number_attr");
+      "opencv_tensorflow.OpDef.ArgDef.number_attr");
     ::google::protobuf::internal::WireFormatLite::WriteStringMaybeAliased(
       5, this->number_attr(), output);
   }
@@ -627,7 +629,7 @@ void OpDef_ArgDef::SerializeWithCachedSizes(
     ::google::protobuf::internal::WireFormatLite::VerifyUtf8String(
       this->type_list_attr().data(), static_cast<int>(this->type_list_attr().length()),
       ::google::protobuf::internal::WireFormatLite::SERIALIZE,
-      "tensorflow.OpDef.ArgDef.type_list_attr");
+      "opencv_tensorflow.OpDef.ArgDef.type_list_attr");
     ::google::protobuf::internal::WireFormatLite::WriteStringMaybeAliased(
       6, this->type_list_attr(), output);
   }
@@ -641,13 +643,13 @@ void OpDef_ArgDef::SerializeWithCachedSizes(
     ::google::protobuf::internal::WireFormat::SerializeUnknownFields(
         (::google::protobuf::internal::GetProto3PreserveUnknownsDefault()   ? _internal_metadata_.unknown_fields()   : _internal_metadata_.default_instance()), output);
   }
-  // @@protoc_insertion_point(serialize_end:tensorflow.OpDef.ArgDef)
+  // @@protoc_insertion_point(serialize_end:opencv_tensorflow.OpDef.ArgDef)
 }
 
 ::google::protobuf::uint8* OpDef_ArgDef::InternalSerializeWithCachedSizesToArray(
     bool deterministic, ::google::protobuf::uint8* target) const {
   (void)deterministic; // Unused
-  // @@protoc_insertion_point(serialize_to_array_start:tensorflow.OpDef.ArgDef)
+  // @@protoc_insertion_point(serialize_to_array_start:opencv_tensorflow.OpDef.ArgDef)
   ::google::protobuf::uint32 cached_has_bits = 0;
   (void) cached_has_bits;
 
@@ -656,7 +658,7 @@ void OpDef_ArgDef::SerializeWithCachedSizes(
     ::google::protobuf::internal::WireFormatLite::VerifyUtf8String(
       this->name().data(), static_cast<int>(this->name().length()),
       ::google::protobuf::internal::WireFormatLite::SERIALIZE,
-      "tensorflow.OpDef.ArgDef.name");
+      "opencv_tensorflow.OpDef.ArgDef.name");
     target =
       ::google::protobuf::internal::WireFormatLite::WriteStringToArray(
         1, this->name(), target);
@@ -667,13 +669,13 @@ void OpDef_ArgDef::SerializeWithCachedSizes(
     ::google::protobuf::internal::WireFormatLite::VerifyUtf8String(
       this->description().data(), static_cast<int>(this->description().length()),
       ::google::protobuf::internal::WireFormatLite::SERIALIZE,
-      "tensorflow.OpDef.ArgDef.description");
+      "opencv_tensorflow.OpDef.ArgDef.description");
     target =
       ::google::protobuf::internal::WireFormatLite::WriteStringToArray(
         2, this->description(), target);
   }
 
-  // .tensorflow.DataType type = 3;
+  // .opencv_tensorflow.DataType type = 3;
   if (this->type() != 0) {
     target = ::google::protobuf::internal::WireFormatLite::WriteEnumToArray(
       3, this->type(), target);
@@ -684,7 +686,7 @@ void OpDef_ArgDef::SerializeWithCachedSizes(
     ::google::protobuf::internal::WireFormatLite::VerifyUtf8String(
       this->type_attr().data(), static_cast<int>(this->type_attr().length()),
       ::google::protobuf::internal::WireFormatLite::SERIALIZE,
-      "tensorflow.OpDef.ArgDef.type_attr");
+      "opencv_tensorflow.OpDef.ArgDef.type_attr");
     target =
       ::google::protobuf::internal::WireFormatLite::WriteStringToArray(
         4, this->type_attr(), target);
@@ -695,7 +697,7 @@ void OpDef_ArgDef::SerializeWithCachedSizes(
     ::google::protobuf::internal::WireFormatLite::VerifyUtf8String(
       this->number_attr().data(), static_cast<int>(this->number_attr().length()),
       ::google::protobuf::internal::WireFormatLite::SERIALIZE,
-      "tensorflow.OpDef.ArgDef.number_attr");
+      "opencv_tensorflow.OpDef.ArgDef.number_attr");
     target =
       ::google::protobuf::internal::WireFormatLite::WriteStringToArray(
         5, this->number_attr(), target);
@@ -706,7 +708,7 @@ void OpDef_ArgDef::SerializeWithCachedSizes(
     ::google::protobuf::internal::WireFormatLite::VerifyUtf8String(
       this->type_list_attr().data(), static_cast<int>(this->type_list_attr().length()),
       ::google::protobuf::internal::WireFormatLite::SERIALIZE,
-      "tensorflow.OpDef.ArgDef.type_list_attr");
+      "opencv_tensorflow.OpDef.ArgDef.type_list_attr");
     target =
       ::google::protobuf::internal::WireFormatLite::WriteStringToArray(
         6, this->type_list_attr(), target);
@@ -721,12 +723,12 @@ void OpDef_ArgDef::SerializeWithCachedSizes(
     target = ::google::protobuf::internal::WireFormat::SerializeUnknownFieldsToArray(
         (::google::protobuf::internal::GetProto3PreserveUnknownsDefault()   ? _internal_metadata_.unknown_fields()   : _internal_metadata_.default_instance()), target);
   }
-  // @@protoc_insertion_point(serialize_to_array_end:tensorflow.OpDef.ArgDef)
+  // @@protoc_insertion_point(serialize_to_array_end:opencv_tensorflow.OpDef.ArgDef)
   return target;
 }
 
 size_t OpDef_ArgDef::ByteSizeLong() const {
-// @@protoc_insertion_point(message_byte_size_start:tensorflow.OpDef.ArgDef)
+// @@protoc_insertion_point(message_byte_size_start:opencv_tensorflow.OpDef.ArgDef)
   size_t total_size = 0;
 
   if ((_internal_metadata_.have_unknown_fields() &&  ::google::protobuf::internal::GetProto3PreserveUnknownsDefault())) {
@@ -769,7 +771,7 @@ size_t OpDef_ArgDef::ByteSizeLong() const {
         this->type_list_attr());
   }
 
-  // .tensorflow.DataType type = 3;
+  // .opencv_tensorflow.DataType type = 3;
   if (this->type() != 0) {
     total_size += 1 +
       ::google::protobuf::internal::WireFormatLite::EnumSize(this->type());
@@ -788,22 +790,22 @@ size_t OpDef_ArgDef::ByteSizeLong() const {
 }
 
 void OpDef_ArgDef::MergeFrom(const ::google::protobuf::Message& from) {
-// @@protoc_insertion_point(generalized_merge_from_start:tensorflow.OpDef.ArgDef)
+// @@protoc_insertion_point(generalized_merge_from_start:opencv_tensorflow.OpDef.ArgDef)
   GOOGLE_DCHECK_NE(&from, this);
   const OpDef_ArgDef* source =
       ::google::protobuf::internal::DynamicCastToGenerated<const OpDef_ArgDef>(
           &from);
   if (source == NULL) {
-  // @@protoc_insertion_point(generalized_merge_from_cast_fail:tensorflow.OpDef.ArgDef)
+  // @@protoc_insertion_point(generalized_merge_from_cast_fail:opencv_tensorflow.OpDef.ArgDef)
     ::google::protobuf::internal::ReflectionOps::Merge(from, this);
   } else {
-  // @@protoc_insertion_point(generalized_merge_from_cast_success:tensorflow.OpDef.ArgDef)
+  // @@protoc_insertion_point(generalized_merge_from_cast_success:opencv_tensorflow.OpDef.ArgDef)
     MergeFrom(*source);
   }
 }
 
 void OpDef_ArgDef::MergeFrom(const OpDef_ArgDef& from) {
-// @@protoc_insertion_point(class_specific_merge_from_start:tensorflow.OpDef.ArgDef)
+// @@protoc_insertion_point(class_specific_merge_from_start:opencv_tensorflow.OpDef.ArgDef)
   GOOGLE_DCHECK_NE(&from, this);
   _internal_metadata_.MergeFrom(from._internal_metadata_);
   ::google::protobuf::uint32 cached_has_bits = 0;
@@ -833,14 +835,14 @@ void OpDef_ArgDef::MergeFrom(const OpDef_ArgDef& from) {
 }
 
 void OpDef_ArgDef::CopyFrom(const ::google::protobuf::Message& from) {
-// @@protoc_insertion_point(generalized_copy_from_start:tensorflow.OpDef.ArgDef)
+// @@protoc_insertion_point(generalized_copy_from_start:opencv_tensorflow.OpDef.ArgDef)
   if (&from == this) return;
   Clear();
   MergeFrom(from);
 }
 
 void OpDef_ArgDef::CopyFrom(const OpDef_ArgDef& from) {
-// @@protoc_insertion_point(class_specific_copy_from_start:tensorflow.OpDef.ArgDef)
+// @@protoc_insertion_point(class_specific_copy_from_start:opencv_tensorflow.OpDef.ArgDef)
   if (&from == this) return;
   Clear();
   MergeFrom(from);
@@ -891,17 +893,17 @@ void OpDef_ArgDef::InternalSwap(OpDef_ArgDef* other) {
 // ===================================================================
 
 void OpDef_AttrDef::InitAsDefaultInstance() {
-  ::tensorflow::_OpDef_AttrDef_default_instance_._instance.get_mutable()->default_value_ = const_cast< ::tensorflow::AttrValue*>(
-      ::tensorflow::AttrValue::internal_default_instance());
-  ::tensorflow::_OpDef_AttrDef_default_instance_._instance.get_mutable()->allowed_values_ = const_cast< ::tensorflow::AttrValue*>(
-      ::tensorflow::AttrValue::internal_default_instance());
+  ::opencv_tensorflow::_OpDef_AttrDef_default_instance_._instance.get_mutable()->default_value_ = const_cast< ::opencv_tensorflow::AttrValue*>(
+      ::opencv_tensorflow::AttrValue::internal_default_instance());
+  ::opencv_tensorflow::_OpDef_AttrDef_default_instance_._instance.get_mutable()->allowed_values_ = const_cast< ::opencv_tensorflow::AttrValue*>(
+      ::opencv_tensorflow::AttrValue::internal_default_instance());
 }
 void OpDef_AttrDef::_slow_mutable_default_value() {
-  default_value_ = ::google::protobuf::Arena::CreateMessage< ::tensorflow::AttrValue >(
+  default_value_ = ::google::protobuf::Arena::CreateMessage< ::opencv_tensorflow::AttrValue >(
       GetArenaNoVirtual());
 }
 void OpDef_AttrDef::unsafe_arena_set_allocated_default_value(
-    ::tensorflow::AttrValue* default_value) {
+    ::opencv_tensorflow::AttrValue* default_value) {
   if (GetArenaNoVirtual() == NULL) {
     delete default_value_;
   }
@@ -911,7 +913,7 @@ void OpDef_AttrDef::unsafe_arena_set_allocated_default_value(
   } else {
 
   }
-  // @@protoc_insertion_point(field_unsafe_arena_set_allocated:tensorflow.OpDef.AttrDef.default_value)
+  // @@protoc_insertion_point(field_unsafe_arena_set_allocated:opencv_tensorflow.OpDef.AttrDef.default_value)
 }
 void OpDef_AttrDef::clear_default_value() {
   if (GetArenaNoVirtual() == NULL && default_value_ != NULL) {
@@ -920,11 +922,11 @@ void OpDef_AttrDef::clear_default_value() {
   default_value_ = NULL;
 }
 void OpDef_AttrDef::_slow_mutable_allowed_values() {
-  allowed_values_ = ::google::protobuf::Arena::CreateMessage< ::tensorflow::AttrValue >(
+  allowed_values_ = ::google::protobuf::Arena::CreateMessage< ::opencv_tensorflow::AttrValue >(
       GetArenaNoVirtual());
 }
 void OpDef_AttrDef::unsafe_arena_set_allocated_allowed_values(
-    ::tensorflow::AttrValue* allowed_values) {
+    ::opencv_tensorflow::AttrValue* allowed_values) {
   if (GetArenaNoVirtual() == NULL) {
     delete allowed_values_;
   }
@@ -934,7 +936,7 @@ void OpDef_AttrDef::unsafe_arena_set_allocated_allowed_values(
   } else {
 
   }
-  // @@protoc_insertion_point(field_unsafe_arena_set_allocated:tensorflow.OpDef.AttrDef.allowed_values)
+  // @@protoc_insertion_point(field_unsafe_arena_set_allocated:opencv_tensorflow.OpDef.AttrDef.allowed_values)
 }
 void OpDef_AttrDef::clear_allowed_values() {
   if (GetArenaNoVirtual() == NULL && allowed_values_ != NULL) {
@@ -958,7 +960,7 @@ OpDef_AttrDef::OpDef_AttrDef()
     ::protobuf_op_5fdef_2eproto::InitDefaultsOpDef_AttrDef();
   }
   SharedCtor();
-  // @@protoc_insertion_point(constructor:tensorflow.OpDef.AttrDef)
+  // @@protoc_insertion_point(constructor:opencv_tensorflow.OpDef.AttrDef)
 }
 OpDef_AttrDef::OpDef_AttrDef(::google::protobuf::Arena* arena)
   : ::google::protobuf::Message(),
@@ -966,7 +968,7 @@ OpDef_AttrDef::OpDef_AttrDef(::google::protobuf::Arena* arena)
   ::protobuf_op_5fdef_2eproto::InitDefaultsOpDef_AttrDef();
   SharedCtor();
   RegisterArenaDtor(arena);
-  // @@protoc_insertion_point(arena_constructor:tensorflow.OpDef.AttrDef)
+  // @@protoc_insertion_point(arena_constructor:opencv_tensorflow.OpDef.AttrDef)
 }
 OpDef_AttrDef::OpDef_AttrDef(const OpDef_AttrDef& from)
   : ::google::protobuf::Message(),
@@ -989,19 +991,19 @@ OpDef_AttrDef::OpDef_AttrDef(const OpDef_AttrDef& from)
       GetArenaNoVirtual());
   }
   if (from.has_default_value()) {
-    default_value_ = new ::tensorflow::AttrValue(*from.default_value_);
+    default_value_ = new ::opencv_tensorflow::AttrValue(*from.default_value_);
   } else {
     default_value_ = NULL;
   }
   if (from.has_allowed_values()) {
-    allowed_values_ = new ::tensorflow::AttrValue(*from.allowed_values_);
+    allowed_values_ = new ::opencv_tensorflow::AttrValue(*from.allowed_values_);
   } else {
     allowed_values_ = NULL;
   }
   ::memcpy(&minimum_, &from.minimum_,
     static_cast<size_t>(reinterpret_cast<char*>(&has_minimum_) -
     reinterpret_cast<char*>(&minimum_)) + sizeof(has_minimum_));
-  // @@protoc_insertion_point(copy_constructor:tensorflow.OpDef.AttrDef)
+  // @@protoc_insertion_point(copy_constructor:opencv_tensorflow.OpDef.AttrDef)
 }
 
 void OpDef_AttrDef::SharedCtor() {
@@ -1015,7 +1017,7 @@ void OpDef_AttrDef::SharedCtor() {
 }
 
 OpDef_AttrDef::~OpDef_AttrDef() {
-  // @@protoc_insertion_point(destructor:tensorflow.OpDef.AttrDef)
+  // @@protoc_insertion_point(destructor:opencv_tensorflow.OpDef.AttrDef)
   SharedDtor();
 }
 
@@ -1054,7 +1056,7 @@ OpDef_AttrDef* OpDef_AttrDef::New(::google::protobuf::Arena* arena) const {
 }
 
 void OpDef_AttrDef::Clear() {
-// @@protoc_insertion_point(message_clear_start:tensorflow.OpDef.AttrDef)
+// @@protoc_insertion_point(message_clear_start:opencv_tensorflow.OpDef.AttrDef)
   ::google::protobuf::uint32 cached_has_bits = 0;
   // Prevent compiler warnings about cached_has_bits being unused
   (void) cached_has_bits;
@@ -1080,7 +1082,7 @@ bool OpDef_AttrDef::MergePartialFromCodedStream(
     ::google::protobuf::io::CodedInputStream* input) {
 #define DO_(EXPRESSION) if (!GOOGLE_PREDICT_TRUE(EXPRESSION)) goto failure
   ::google::protobuf::uint32 tag;
-  // @@protoc_insertion_point(parse_start:tensorflow.OpDef.AttrDef)
+  // @@protoc_insertion_point(parse_start:opencv_tensorflow.OpDef.AttrDef)
   for (;;) {
     ::std::pair< ::google::protobuf::uint32, bool> p = input->ReadTagWithCutoffNoLastTag(127u);
     tag = p.first;
@@ -1095,7 +1097,7 @@ bool OpDef_AttrDef::MergePartialFromCodedStream(
           DO_(::google::protobuf::internal::WireFormatLite::VerifyUtf8String(
             this->name().data(), static_cast<int>(this->name().length()),
             ::google::protobuf::internal::WireFormatLite::PARSE,
-            "tensorflow.OpDef.AttrDef.name"));
+            "opencv_tensorflow.OpDef.AttrDef.name"));
         } else {
           goto handle_unusual;
         }
@@ -1111,14 +1113,14 @@ bool OpDef_AttrDef::MergePartialFromCodedStream(
           DO_(::google::protobuf::internal::WireFormatLite::VerifyUtf8String(
             this->type().data(), static_cast<int>(this->type().length()),
             ::google::protobuf::internal::WireFormatLite::PARSE,
-            "tensorflow.OpDef.AttrDef.type"));
+            "opencv_tensorflow.OpDef.AttrDef.type"));
         } else {
           goto handle_unusual;
         }
         break;
       }
 
-      // .tensorflow.AttrValue default_value = 3;
+      // .opencv_tensorflow.AttrValue default_value = 3;
       case 3: {
         if (static_cast< ::google::protobuf::uint8>(tag) ==
             static_cast< ::google::protobuf::uint8>(26u /* 26 & 0xFF */)) {
@@ -1139,7 +1141,7 @@ bool OpDef_AttrDef::MergePartialFromCodedStream(
           DO_(::google::protobuf::internal::WireFormatLite::VerifyUtf8String(
             this->description().data(), static_cast<int>(this->description().length()),
             ::google::protobuf::internal::WireFormatLite::PARSE,
-            "tensorflow.OpDef.AttrDef.description"));
+            "opencv_tensorflow.OpDef.AttrDef.description"));
         } else {
           goto handle_unusual;
         }
@@ -1174,7 +1176,7 @@ bool OpDef_AttrDef::MergePartialFromCodedStream(
         break;
       }
 
-      // .tensorflow.AttrValue allowed_values = 7;
+      // .opencv_tensorflow.AttrValue allowed_values = 7;
       case 7: {
         if (static_cast< ::google::protobuf::uint8>(tag) ==
             static_cast< ::google::protobuf::uint8>(58u /* 58 & 0xFF */)) {
@@ -1198,17 +1200,17 @@ bool OpDef_AttrDef::MergePartialFromCodedStream(
     }
   }
 success:
-  // @@protoc_insertion_point(parse_success:tensorflow.OpDef.AttrDef)
+  // @@protoc_insertion_point(parse_success:opencv_tensorflow.OpDef.AttrDef)
   return true;
 failure:
-  // @@protoc_insertion_point(parse_failure:tensorflow.OpDef.AttrDef)
+  // @@protoc_insertion_point(parse_failure:opencv_tensorflow.OpDef.AttrDef)
   return false;
 #undef DO_
 }
 
 void OpDef_AttrDef::SerializeWithCachedSizes(
     ::google::protobuf::io::CodedOutputStream* output) const {
-  // @@protoc_insertion_point(serialize_start:tensorflow.OpDef.AttrDef)
+  // @@protoc_insertion_point(serialize_start:opencv_tensorflow.OpDef.AttrDef)
   ::google::protobuf::uint32 cached_has_bits = 0;
   (void) cached_has_bits;
 
@@ -1217,7 +1219,7 @@ void OpDef_AttrDef::SerializeWithCachedSizes(
     ::google::protobuf::internal::WireFormatLite::VerifyUtf8String(
       this->name().data(), static_cast<int>(this->name().length()),
       ::google::protobuf::internal::WireFormatLite::SERIALIZE,
-      "tensorflow.OpDef.AttrDef.name");
+      "opencv_tensorflow.OpDef.AttrDef.name");
     ::google::protobuf::internal::WireFormatLite::WriteStringMaybeAliased(
       1, this->name(), output);
   }
@@ -1227,12 +1229,12 @@ void OpDef_AttrDef::SerializeWithCachedSizes(
     ::google::protobuf::internal::WireFormatLite::VerifyUtf8String(
       this->type().data(), static_cast<int>(this->type().length()),
       ::google::protobuf::internal::WireFormatLite::SERIALIZE,
-      "tensorflow.OpDef.AttrDef.type");
+      "opencv_tensorflow.OpDef.AttrDef.type");
     ::google::protobuf::internal::WireFormatLite::WriteStringMaybeAliased(
       2, this->type(), output);
   }
 
-  // .tensorflow.AttrValue default_value = 3;
+  // .opencv_tensorflow.AttrValue default_value = 3;
   if (this->has_default_value()) {
     ::google::protobuf::internal::WireFormatLite::WriteMessageMaybeToArray(
       3, *this->default_value_, output);
@@ -1243,7 +1245,7 @@ void OpDef_AttrDef::SerializeWithCachedSizes(
     ::google::protobuf::internal::WireFormatLite::VerifyUtf8String(
       this->description().data(), static_cast<int>(this->description().length()),
       ::google::protobuf::internal::WireFormatLite::SERIALIZE,
-      "tensorflow.OpDef.AttrDef.description");
+      "opencv_tensorflow.OpDef.AttrDef.description");
     ::google::protobuf::internal::WireFormatLite::WriteStringMaybeAliased(
       4, this->description(), output);
   }
@@ -1258,7 +1260,7 @@ void OpDef_AttrDef::SerializeWithCachedSizes(
     ::google::protobuf::internal::WireFormatLite::WriteInt64(6, this->minimum(), output);
   }
 
-  // .tensorflow.AttrValue allowed_values = 7;
+  // .opencv_tensorflow.AttrValue allowed_values = 7;
   if (this->has_allowed_values()) {
     ::google::protobuf::internal::WireFormatLite::WriteMessageMaybeToArray(
       7, *this->allowed_values_, output);
@@ -1268,13 +1270,13 @@ void OpDef_AttrDef::SerializeWithCachedSizes(
     ::google::protobuf::internal::WireFormat::SerializeUnknownFields(
         (::google::protobuf::internal::GetProto3PreserveUnknownsDefault()   ? _internal_metadata_.unknown_fields()   : _internal_metadata_.default_instance()), output);
   }
-  // @@protoc_insertion_point(serialize_end:tensorflow.OpDef.AttrDef)
+  // @@protoc_insertion_point(serialize_end:opencv_tensorflow.OpDef.AttrDef)
 }
 
 ::google::protobuf::uint8* OpDef_AttrDef::InternalSerializeWithCachedSizesToArray(
     bool deterministic, ::google::protobuf::uint8* target) const {
   (void)deterministic; // Unused
-  // @@protoc_insertion_point(serialize_to_array_start:tensorflow.OpDef.AttrDef)
+  // @@protoc_insertion_point(serialize_to_array_start:opencv_tensorflow.OpDef.AttrDef)
   ::google::protobuf::uint32 cached_has_bits = 0;
   (void) cached_has_bits;
 
@@ -1283,7 +1285,7 @@ void OpDef_AttrDef::SerializeWithCachedSizes(
     ::google::protobuf::internal::WireFormatLite::VerifyUtf8String(
       this->name().data(), static_cast<int>(this->name().length()),
       ::google::protobuf::internal::WireFormatLite::SERIALIZE,
-      "tensorflow.OpDef.AttrDef.name");
+      "opencv_tensorflow.OpDef.AttrDef.name");
     target =
       ::google::protobuf::internal::WireFormatLite::WriteStringToArray(
         1, this->name(), target);
@@ -1294,13 +1296,13 @@ void OpDef_AttrDef::SerializeWithCachedSizes(
     ::google::protobuf::internal::WireFormatLite::VerifyUtf8String(
       this->type().data(), static_cast<int>(this->type().length()),
       ::google::protobuf::internal::WireFormatLite::SERIALIZE,
-      "tensorflow.OpDef.AttrDef.type");
+      "opencv_tensorflow.OpDef.AttrDef.type");
     target =
       ::google::protobuf::internal::WireFormatLite::WriteStringToArray(
         2, this->type(), target);
   }
 
-  // .tensorflow.AttrValue default_value = 3;
+  // .opencv_tensorflow.AttrValue default_value = 3;
   if (this->has_default_value()) {
     target = ::google::protobuf::internal::WireFormatLite::
       InternalWriteMessageToArray(
@@ -1312,7 +1314,7 @@ void OpDef_AttrDef::SerializeWithCachedSizes(
     ::google::protobuf::internal::WireFormatLite::VerifyUtf8String(
       this->description().data(), static_cast<int>(this->description().length()),
       ::google::protobuf::internal::WireFormatLite::SERIALIZE,
-      "tensorflow.OpDef.AttrDef.description");
+      "opencv_tensorflow.OpDef.AttrDef.description");
     target =
       ::google::protobuf::internal::WireFormatLite::WriteStringToArray(
         4, this->description(), target);
@@ -1328,7 +1330,7 @@ void OpDef_AttrDef::SerializeWithCachedSizes(
     target = ::google::protobuf::internal::WireFormatLite::WriteInt64ToArray(6, this->minimum(), target);
   }
 
-  // .tensorflow.AttrValue allowed_values = 7;
+  // .opencv_tensorflow.AttrValue allowed_values = 7;
   if (this->has_allowed_values()) {
     target = ::google::protobuf::internal::WireFormatLite::
       InternalWriteMessageToArray(
@@ -1339,12 +1341,12 @@ void OpDef_AttrDef::SerializeWithCachedSizes(
     target = ::google::protobuf::internal::WireFormat::SerializeUnknownFieldsToArray(
         (::google::protobuf::internal::GetProto3PreserveUnknownsDefault()   ? _internal_metadata_.unknown_fields()   : _internal_metadata_.default_instance()), target);
   }
-  // @@protoc_insertion_point(serialize_to_array_end:tensorflow.OpDef.AttrDef)
+  // @@protoc_insertion_point(serialize_to_array_end:opencv_tensorflow.OpDef.AttrDef)
   return target;
 }
 
 size_t OpDef_AttrDef::ByteSizeLong() const {
-// @@protoc_insertion_point(message_byte_size_start:tensorflow.OpDef.AttrDef)
+// @@protoc_insertion_point(message_byte_size_start:opencv_tensorflow.OpDef.AttrDef)
   size_t total_size = 0;
 
   if ((_internal_metadata_.have_unknown_fields() &&  ::google::protobuf::internal::GetProto3PreserveUnknownsDefault())) {
@@ -1373,14 +1375,14 @@ size_t OpDef_AttrDef::ByteSizeLong() const {
         this->description());
   }
 
-  // .tensorflow.AttrValue default_value = 3;
+  // .opencv_tensorflow.AttrValue default_value = 3;
   if (this->has_default_value()) {
     total_size += 1 +
       ::google::protobuf::internal::WireFormatLite::MessageSize(
         *this->default_value_);
   }
 
-  // .tensorflow.AttrValue allowed_values = 7;
+  // .opencv_tensorflow.AttrValue allowed_values = 7;
   if (this->has_allowed_values()) {
     total_size += 1 +
       ::google::protobuf::internal::WireFormatLite::MessageSize(
@@ -1407,22 +1409,22 @@ size_t OpDef_AttrDef::ByteSizeLong() const {
 }
 
 void OpDef_AttrDef::MergeFrom(const ::google::protobuf::Message& from) {
-// @@protoc_insertion_point(generalized_merge_from_start:tensorflow.OpDef.AttrDef)
+// @@protoc_insertion_point(generalized_merge_from_start:opencv_tensorflow.OpDef.AttrDef)
   GOOGLE_DCHECK_NE(&from, this);
   const OpDef_AttrDef* source =
       ::google::protobuf::internal::DynamicCastToGenerated<const OpDef_AttrDef>(
           &from);
   if (source == NULL) {
-  // @@protoc_insertion_point(generalized_merge_from_cast_fail:tensorflow.OpDef.AttrDef)
+  // @@protoc_insertion_point(generalized_merge_from_cast_fail:opencv_tensorflow.OpDef.AttrDef)
     ::google::protobuf::internal::ReflectionOps::Merge(from, this);
   } else {
-  // @@protoc_insertion_point(generalized_merge_from_cast_success:tensorflow.OpDef.AttrDef)
+  // @@protoc_insertion_point(generalized_merge_from_cast_success:opencv_tensorflow.OpDef.AttrDef)
     MergeFrom(*source);
   }
 }
 
 void OpDef_AttrDef::MergeFrom(const OpDef_AttrDef& from) {
-// @@protoc_insertion_point(class_specific_merge_from_start:tensorflow.OpDef.AttrDef)
+// @@protoc_insertion_point(class_specific_merge_from_start:opencv_tensorflow.OpDef.AttrDef)
   GOOGLE_DCHECK_NE(&from, this);
   _internal_metadata_.MergeFrom(from._internal_metadata_);
   ::google::protobuf::uint32 cached_has_bits = 0;
@@ -1438,10 +1440,10 @@ void OpDef_AttrDef::MergeFrom(const OpDef_AttrDef& from) {
     set_description(from.description());
   }
   if (from.has_default_value()) {
-    mutable_default_value()->::tensorflow::AttrValue::MergeFrom(from.default_value());
+    mutable_default_value()->::opencv_tensorflow::AttrValue::MergeFrom(from.default_value());
   }
   if (from.has_allowed_values()) {
-    mutable_allowed_values()->::tensorflow::AttrValue::MergeFrom(from.allowed_values());
+    mutable_allowed_values()->::opencv_tensorflow::AttrValue::MergeFrom(from.allowed_values());
   }
   if (from.minimum() != 0) {
     set_minimum(from.minimum());
@@ -1452,14 +1454,14 @@ void OpDef_AttrDef::MergeFrom(const OpDef_AttrDef& from) {
 }
 
 void OpDef_AttrDef::CopyFrom(const ::google::protobuf::Message& from) {
-// @@protoc_insertion_point(generalized_copy_from_start:tensorflow.OpDef.AttrDef)
+// @@protoc_insertion_point(generalized_copy_from_start:opencv_tensorflow.OpDef.AttrDef)
   if (&from == this) return;
   Clear();
   MergeFrom(from);
 }
 
 void OpDef_AttrDef::CopyFrom(const OpDef_AttrDef& from) {
-// @@protoc_insertion_point(class_specific_copy_from_start:tensorflow.OpDef.AttrDef)
+// @@protoc_insertion_point(class_specific_copy_from_start:opencv_tensorflow.OpDef.AttrDef)
   if (&from == this) return;
   Clear();
   MergeFrom(from);
@@ -1510,15 +1512,15 @@ void OpDef_AttrDef::InternalSwap(OpDef_AttrDef* other) {
 // ===================================================================
 
 void OpDef::InitAsDefaultInstance() {
-  ::tensorflow::_OpDef_default_instance_._instance.get_mutable()->deprecation_ = const_cast< ::tensorflow::OpDeprecation*>(
-      ::tensorflow::OpDeprecation::internal_default_instance());
+  ::opencv_tensorflow::_OpDef_default_instance_._instance.get_mutable()->deprecation_ = const_cast< ::opencv_tensorflow::OpDeprecation*>(
+      ::opencv_tensorflow::OpDeprecation::internal_default_instance());
 }
 void OpDef::_slow_mutable_deprecation() {
-  deprecation_ = ::google::protobuf::Arena::CreateMessage< ::tensorflow::OpDeprecation >(
+  deprecation_ = ::google::protobuf::Arena::CreateMessage< ::opencv_tensorflow::OpDeprecation >(
       GetArenaNoVirtual());
 }
 void OpDef::unsafe_arena_set_allocated_deprecation(
-    ::tensorflow::OpDeprecation* deprecation) {
+    ::opencv_tensorflow::OpDeprecation* deprecation) {
   if (GetArenaNoVirtual() == NULL) {
     delete deprecation_;
   }
@@ -1528,7 +1530,7 @@ void OpDef::unsafe_arena_set_allocated_deprecation(
   } else {
 
   }
-  // @@protoc_insertion_point(field_unsafe_arena_set_allocated:tensorflow.OpDef.deprecation)
+  // @@protoc_insertion_point(field_unsafe_arena_set_allocated:opencv_tensorflow.OpDef.deprecation)
 }
 #if !defined(_MSC_VER) || _MSC_VER >= 1900
 const int OpDef::kNameFieldNumber;
@@ -1550,7 +1552,7 @@ OpDef::OpDef()
     ::protobuf_op_5fdef_2eproto::InitDefaultsOpDef();
   }
   SharedCtor();
-  // @@protoc_insertion_point(constructor:tensorflow.OpDef)
+  // @@protoc_insertion_point(constructor:opencv_tensorflow.OpDef)
 }
 OpDef::OpDef(::google::protobuf::Arena* arena)
   : ::google::protobuf::Message(),
@@ -1561,7 +1563,7 @@ OpDef::OpDef(::google::protobuf::Arena* arena)
   ::protobuf_op_5fdef_2eproto::InitDefaultsOpDef();
   SharedCtor();
   RegisterArenaDtor(arena);
-  // @@protoc_insertion_point(arena_constructor:tensorflow.OpDef)
+  // @@protoc_insertion_point(arena_constructor:opencv_tensorflow.OpDef)
 }
 OpDef::OpDef(const OpDef& from)
   : ::google::protobuf::Message(),
@@ -1587,14 +1589,14 @@ OpDef::OpDef(const OpDef& from)
       GetArenaNoVirtual());
   }
   if (from.has_deprecation()) {
-    deprecation_ = new ::tensorflow::OpDeprecation(*from.deprecation_);
+    deprecation_ = new ::opencv_tensorflow::OpDeprecation(*from.deprecation_);
   } else {
     deprecation_ = NULL;
   }
   ::memcpy(&is_commutative_, &from.is_commutative_,
     static_cast<size_t>(reinterpret_cast<char*>(&allows_uninitialized_input_) -
     reinterpret_cast<char*>(&is_commutative_)) + sizeof(allows_uninitialized_input_));
-  // @@protoc_insertion_point(copy_constructor:tensorflow.OpDef)
+  // @@protoc_insertion_point(copy_constructor:opencv_tensorflow.OpDef)
 }
 
 void OpDef::SharedCtor() {
@@ -1608,7 +1610,7 @@ void OpDef::SharedCtor() {
 }
 
 OpDef::~OpDef() {
-  // @@protoc_insertion_point(destructor:tensorflow.OpDef)
+  // @@protoc_insertion_point(destructor:opencv_tensorflow.OpDef)
   SharedDtor();
 }
 
@@ -1646,7 +1648,7 @@ OpDef* OpDef::New(::google::protobuf::Arena* arena) const {
 }
 
 void OpDef::Clear() {
-// @@protoc_insertion_point(message_clear_start:tensorflow.OpDef)
+// @@protoc_insertion_point(message_clear_start:opencv_tensorflow.OpDef)
   ::google::protobuf::uint32 cached_has_bits = 0;
   // Prevent compiler warnings about cached_has_bits being unused
   (void) cached_has_bits;
@@ -1671,7 +1673,7 @@ bool OpDef::MergePartialFromCodedStream(
     ::google::protobuf::io::CodedInputStream* input) {
 #define DO_(EXPRESSION) if (!GOOGLE_PREDICT_TRUE(EXPRESSION)) goto failure
   ::google::protobuf::uint32 tag;
-  // @@protoc_insertion_point(parse_start:tensorflow.OpDef)
+  // @@protoc_insertion_point(parse_start:opencv_tensorflow.OpDef)
   for (;;) {
     ::std::pair< ::google::protobuf::uint32, bool> p = input->ReadTagWithCutoffNoLastTag(16383u);
     tag = p.first;
@@ -1686,14 +1688,14 @@ bool OpDef::MergePartialFromCodedStream(
           DO_(::google::protobuf::internal::WireFormatLite::VerifyUtf8String(
             this->name().data(), static_cast<int>(this->name().length()),
             ::google::protobuf::internal::WireFormatLite::PARSE,
-            "tensorflow.OpDef.name"));
+            "opencv_tensorflow.OpDef.name"));
         } else {
           goto handle_unusual;
         }
         break;
       }
 
-      // repeated .tensorflow.OpDef.ArgDef input_arg = 2;
+      // repeated .opencv_tensorflow.OpDef.ArgDef input_arg = 2;
       case 2: {
         if (static_cast< ::google::protobuf::uint8>(tag) ==
             static_cast< ::google::protobuf::uint8>(18u /* 18 & 0xFF */)) {
@@ -1704,7 +1706,7 @@ bool OpDef::MergePartialFromCodedStream(
         break;
       }
 
-      // repeated .tensorflow.OpDef.ArgDef output_arg = 3;
+      // repeated .opencv_tensorflow.OpDef.ArgDef output_arg = 3;
       case 3: {
         if (static_cast< ::google::protobuf::uint8>(tag) ==
             static_cast< ::google::protobuf::uint8>(26u /* 26 & 0xFF */)) {
@@ -1715,7 +1717,7 @@ bool OpDef::MergePartialFromCodedStream(
         break;
       }
 
-      // repeated .tensorflow.OpDef.AttrDef attr = 4;
+      // repeated .opencv_tensorflow.OpDef.AttrDef attr = 4;
       case 4: {
         if (static_cast< ::google::protobuf::uint8>(tag) ==
             static_cast< ::google::protobuf::uint8>(34u /* 34 & 0xFF */)) {
@@ -1735,7 +1737,7 @@ bool OpDef::MergePartialFromCodedStream(
           DO_(::google::protobuf::internal::WireFormatLite::VerifyUtf8String(
             this->summary().data(), static_cast<int>(this->summary().length()),
             ::google::protobuf::internal::WireFormatLite::PARSE,
-            "tensorflow.OpDef.summary"));
+            "opencv_tensorflow.OpDef.summary"));
         } else {
           goto handle_unusual;
         }
@@ -1751,14 +1753,14 @@ bool OpDef::MergePartialFromCodedStream(
           DO_(::google::protobuf::internal::WireFormatLite::VerifyUtf8String(
             this->description().data(), static_cast<int>(this->description().length()),
             ::google::protobuf::internal::WireFormatLite::PARSE,
-            "tensorflow.OpDef.description"));
+            "opencv_tensorflow.OpDef.description"));
         } else {
           goto handle_unusual;
         }
         break;
       }
 
-      // .tensorflow.OpDeprecation deprecation = 8;
+      // .opencv_tensorflow.OpDeprecation deprecation = 8;
       case 8: {
         if (static_cast< ::google::protobuf::uint8>(tag) ==
             static_cast< ::google::protobuf::uint8>(66u /* 66 & 0xFF */)) {
@@ -1838,17 +1840,17 @@ bool OpDef::MergePartialFromCodedStream(
     }
   }
 success:
-  // @@protoc_insertion_point(parse_success:tensorflow.OpDef)
+  // @@protoc_insertion_point(parse_success:opencv_tensorflow.OpDef)
   return true;
 failure:
-  // @@protoc_insertion_point(parse_failure:tensorflow.OpDef)
+  // @@protoc_insertion_point(parse_failure:opencv_tensorflow.OpDef)
   return false;
 #undef DO_
 }
 
 void OpDef::SerializeWithCachedSizes(
     ::google::protobuf::io::CodedOutputStream* output) const {
-  // @@protoc_insertion_point(serialize_start:tensorflow.OpDef)
+  // @@protoc_insertion_point(serialize_start:opencv_tensorflow.OpDef)
   ::google::protobuf::uint32 cached_has_bits = 0;
   (void) cached_has_bits;
 
@@ -1857,26 +1859,26 @@ void OpDef::SerializeWithCachedSizes(
     ::google::protobuf::internal::WireFormatLite::VerifyUtf8String(
       this->name().data(), static_cast<int>(this->name().length()),
       ::google::protobuf::internal::WireFormatLite::SERIALIZE,
-      "tensorflow.OpDef.name");
+      "opencv_tensorflow.OpDef.name");
     ::google::protobuf::internal::WireFormatLite::WriteStringMaybeAliased(
       1, this->name(), output);
   }
 
-  // repeated .tensorflow.OpDef.ArgDef input_arg = 2;
+  // repeated .opencv_tensorflow.OpDef.ArgDef input_arg = 2;
   for (unsigned int i = 0,
       n = static_cast<unsigned int>(this->input_arg_size()); i < n; i++) {
     ::google::protobuf::internal::WireFormatLite::WriteMessageMaybeToArray(
       2, this->input_arg(static_cast<int>(i)), output);
   }
 
-  // repeated .tensorflow.OpDef.ArgDef output_arg = 3;
+  // repeated .opencv_tensorflow.OpDef.ArgDef output_arg = 3;
   for (unsigned int i = 0,
       n = static_cast<unsigned int>(this->output_arg_size()); i < n; i++) {
     ::google::protobuf::internal::WireFormatLite::WriteMessageMaybeToArray(
       3, this->output_arg(static_cast<int>(i)), output);
   }
 
-  // repeated .tensorflow.OpDef.AttrDef attr = 4;
+  // repeated .opencv_tensorflow.OpDef.AttrDef attr = 4;
   for (unsigned int i = 0,
       n = static_cast<unsigned int>(this->attr_size()); i < n; i++) {
     ::google::protobuf::internal::WireFormatLite::WriteMessageMaybeToArray(
@@ -1888,7 +1890,7 @@ void OpDef::SerializeWithCachedSizes(
     ::google::protobuf::internal::WireFormatLite::VerifyUtf8String(
       this->summary().data(), static_cast<int>(this->summary().length()),
       ::google::protobuf::internal::WireFormatLite::SERIALIZE,
-      "tensorflow.OpDef.summary");
+      "opencv_tensorflow.OpDef.summary");
     ::google::protobuf::internal::WireFormatLite::WriteStringMaybeAliased(
       5, this->summary(), output);
   }
@@ -1898,12 +1900,12 @@ void OpDef::SerializeWithCachedSizes(
     ::google::protobuf::internal::WireFormatLite::VerifyUtf8String(
       this->description().data(), static_cast<int>(this->description().length()),
       ::google::protobuf::internal::WireFormatLite::SERIALIZE,
-      "tensorflow.OpDef.description");
+      "opencv_tensorflow.OpDef.description");
     ::google::protobuf::internal::WireFormatLite::WriteStringMaybeAliased(
       6, this->description(), output);
   }
 
-  // .tensorflow.OpDeprecation deprecation = 8;
+  // .opencv_tensorflow.OpDeprecation deprecation = 8;
   if (this->has_deprecation()) {
     ::google::protobuf::internal::WireFormatLite::WriteMessageMaybeToArray(
       8, *this->deprecation_, output);
@@ -1933,13 +1935,13 @@ void OpDef::SerializeWithCachedSizes(
     ::google::protobuf::internal::WireFormat::SerializeUnknownFields(
         (::google::protobuf::internal::GetProto3PreserveUnknownsDefault()   ? _internal_metadata_.unknown_fields()   : _internal_metadata_.default_instance()), output);
   }
-  // @@protoc_insertion_point(serialize_end:tensorflow.OpDef)
+  // @@protoc_insertion_point(serialize_end:opencv_tensorflow.OpDef)
 }
 
 ::google::protobuf::uint8* OpDef::InternalSerializeWithCachedSizesToArray(
     bool deterministic, ::google::protobuf::uint8* target) const {
   (void)deterministic; // Unused
-  // @@protoc_insertion_point(serialize_to_array_start:tensorflow.OpDef)
+  // @@protoc_insertion_point(serialize_to_array_start:opencv_tensorflow.OpDef)
   ::google::protobuf::uint32 cached_has_bits = 0;
   (void) cached_has_bits;
 
@@ -1948,13 +1950,13 @@ void OpDef::SerializeWithCachedSizes(
     ::google::protobuf::internal::WireFormatLite::VerifyUtf8String(
       this->name().data(), static_cast<int>(this->name().length()),
       ::google::protobuf::internal::WireFormatLite::SERIALIZE,
-      "tensorflow.OpDef.name");
+      "opencv_tensorflow.OpDef.name");
     target =
       ::google::protobuf::internal::WireFormatLite::WriteStringToArray(
         1, this->name(), target);
   }
 
-  // repeated .tensorflow.OpDef.ArgDef input_arg = 2;
+  // repeated .opencv_tensorflow.OpDef.ArgDef input_arg = 2;
   for (unsigned int i = 0,
       n = static_cast<unsigned int>(this->input_arg_size()); i < n; i++) {
     target = ::google::protobuf::internal::WireFormatLite::
@@ -1962,7 +1964,7 @@ void OpDef::SerializeWithCachedSizes(
         2, this->input_arg(static_cast<int>(i)), deterministic, target);
   }
 
-  // repeated .tensorflow.OpDef.ArgDef output_arg = 3;
+  // repeated .opencv_tensorflow.OpDef.ArgDef output_arg = 3;
   for (unsigned int i = 0,
       n = static_cast<unsigned int>(this->output_arg_size()); i < n; i++) {
     target = ::google::protobuf::internal::WireFormatLite::
@@ -1970,7 +1972,7 @@ void OpDef::SerializeWithCachedSizes(
         3, this->output_arg(static_cast<int>(i)), deterministic, target);
   }
 
-  // repeated .tensorflow.OpDef.AttrDef attr = 4;
+  // repeated .opencv_tensorflow.OpDef.AttrDef attr = 4;
   for (unsigned int i = 0,
       n = static_cast<unsigned int>(this->attr_size()); i < n; i++) {
     target = ::google::protobuf::internal::WireFormatLite::
@@ -1983,7 +1985,7 @@ void OpDef::SerializeWithCachedSizes(
     ::google::protobuf::internal::WireFormatLite::VerifyUtf8String(
       this->summary().data(), static_cast<int>(this->summary().length()),
       ::google::protobuf::internal::WireFormatLite::SERIALIZE,
-      "tensorflow.OpDef.summary");
+      "opencv_tensorflow.OpDef.summary");
     target =
       ::google::protobuf::internal::WireFormatLite::WriteStringToArray(
         5, this->summary(), target);
@@ -1994,13 +1996,13 @@ void OpDef::SerializeWithCachedSizes(
     ::google::protobuf::internal::WireFormatLite::VerifyUtf8String(
       this->description().data(), static_cast<int>(this->description().length()),
       ::google::protobuf::internal::WireFormatLite::SERIALIZE,
-      "tensorflow.OpDef.description");
+      "opencv_tensorflow.OpDef.description");
     target =
       ::google::protobuf::internal::WireFormatLite::WriteStringToArray(
         6, this->description(), target);
   }
 
-  // .tensorflow.OpDeprecation deprecation = 8;
+  // .opencv_tensorflow.OpDeprecation deprecation = 8;
   if (this->has_deprecation()) {
     target = ::google::protobuf::internal::WireFormatLite::
       InternalWriteMessageToArray(
@@ -2031,12 +2033,12 @@ void OpDef::SerializeWithCachedSizes(
     target = ::google::protobuf::internal::WireFormat::SerializeUnknownFieldsToArray(
         (::google::protobuf::internal::GetProto3PreserveUnknownsDefault()   ? _internal_metadata_.unknown_fields()   : _internal_metadata_.default_instance()), target);
   }
-  // @@protoc_insertion_point(serialize_to_array_end:tensorflow.OpDef)
+  // @@protoc_insertion_point(serialize_to_array_end:opencv_tensorflow.OpDef)
   return target;
 }
 
 size_t OpDef::ByteSizeLong() const {
-// @@protoc_insertion_point(message_byte_size_start:tensorflow.OpDef)
+// @@protoc_insertion_point(message_byte_size_start:opencv_tensorflow.OpDef)
   size_t total_size = 0;
 
   if ((_internal_metadata_.have_unknown_fields() &&  ::google::protobuf::internal::GetProto3PreserveUnknownsDefault())) {
@@ -2044,7 +2046,7 @@ size_t OpDef::ByteSizeLong() const {
       ::google::protobuf::internal::WireFormat::ComputeUnknownFieldsSize(
         (::google::protobuf::internal::GetProto3PreserveUnknownsDefault()   ? _internal_metadata_.unknown_fields()   : _internal_metadata_.default_instance()));
   }
-  // repeated .tensorflow.OpDef.ArgDef input_arg = 2;
+  // repeated .opencv_tensorflow.OpDef.ArgDef input_arg = 2;
   {
     unsigned int count = static_cast<unsigned int>(this->input_arg_size());
     total_size += 1UL * count;
@@ -2055,7 +2057,7 @@ size_t OpDef::ByteSizeLong() const {
     }
   }
 
-  // repeated .tensorflow.OpDef.ArgDef output_arg = 3;
+  // repeated .opencv_tensorflow.OpDef.ArgDef output_arg = 3;
   {
     unsigned int count = static_cast<unsigned int>(this->output_arg_size());
     total_size += 1UL * count;
@@ -2066,7 +2068,7 @@ size_t OpDef::ByteSizeLong() const {
     }
   }
 
-  // repeated .tensorflow.OpDef.AttrDef attr = 4;
+  // repeated .opencv_tensorflow.OpDef.AttrDef attr = 4;
   {
     unsigned int count = static_cast<unsigned int>(this->attr_size());
     total_size += 1UL * count;
@@ -2098,7 +2100,7 @@ size_t OpDef::ByteSizeLong() const {
         this->description());
   }
 
-  // .tensorflow.OpDeprecation deprecation = 8;
+  // .opencv_tensorflow.OpDeprecation deprecation = 8;
   if (this->has_deprecation()) {
     total_size += 1 +
       ::google::protobuf::internal::WireFormatLite::MessageSize(
@@ -2133,22 +2135,22 @@ size_t OpDef::ByteSizeLong() const {
 }
 
 void OpDef::MergeFrom(const ::google::protobuf::Message& from) {
-// @@protoc_insertion_point(generalized_merge_from_start:tensorflow.OpDef)
+// @@protoc_insertion_point(generalized_merge_from_start:opencv_tensorflow.OpDef)
   GOOGLE_DCHECK_NE(&from, this);
   const OpDef* source =
       ::google::protobuf::internal::DynamicCastToGenerated<const OpDef>(
           &from);
   if (source == NULL) {
-  // @@protoc_insertion_point(generalized_merge_from_cast_fail:tensorflow.OpDef)
+  // @@protoc_insertion_point(generalized_merge_from_cast_fail:opencv_tensorflow.OpDef)
     ::google::protobuf::internal::ReflectionOps::Merge(from, this);
   } else {
-  // @@protoc_insertion_point(generalized_merge_from_cast_success:tensorflow.OpDef)
+  // @@protoc_insertion_point(generalized_merge_from_cast_success:opencv_tensorflow.OpDef)
     MergeFrom(*source);
   }
 }
 
 void OpDef::MergeFrom(const OpDef& from) {
-// @@protoc_insertion_point(class_specific_merge_from_start:tensorflow.OpDef)
+// @@protoc_insertion_point(class_specific_merge_from_start:opencv_tensorflow.OpDef)
   GOOGLE_DCHECK_NE(&from, this);
   _internal_metadata_.MergeFrom(from._internal_metadata_);
   ::google::protobuf::uint32 cached_has_bits = 0;
@@ -2167,7 +2169,7 @@ void OpDef::MergeFrom(const OpDef& from) {
     set_description(from.description());
   }
   if (from.has_deprecation()) {
-    mutable_deprecation()->::tensorflow::OpDeprecation::MergeFrom(from.deprecation());
+    mutable_deprecation()->::opencv_tensorflow::OpDeprecation::MergeFrom(from.deprecation());
   }
   if (from.is_commutative() != 0) {
     set_is_commutative(from.is_commutative());
@@ -2184,14 +2186,14 @@ void OpDef::MergeFrom(const OpDef& from) {
 }
 
 void OpDef::CopyFrom(const ::google::protobuf::Message& from) {
-// @@protoc_insertion_point(generalized_copy_from_start:tensorflow.OpDef)
+// @@protoc_insertion_point(generalized_copy_from_start:opencv_tensorflow.OpDef)
   if (&from == this) return;
   Clear();
   MergeFrom(from);
 }
 
 void OpDef::CopyFrom(const OpDef& from) {
-// @@protoc_insertion_point(class_specific_copy_from_start:tensorflow.OpDef)
+// @@protoc_insertion_point(class_specific_copy_from_start:opencv_tensorflow.OpDef)
   if (&from == this) return;
   Clear();
   MergeFrom(from);
@@ -2258,7 +2260,7 @@ OpDeprecation::OpDeprecation()
     ::protobuf_op_5fdef_2eproto::InitDefaultsOpDeprecation();
   }
   SharedCtor();
-  // @@protoc_insertion_point(constructor:tensorflow.OpDeprecation)
+  // @@protoc_insertion_point(constructor:opencv_tensorflow.OpDeprecation)
 }
 OpDeprecation::OpDeprecation(::google::protobuf::Arena* arena)
   : ::google::protobuf::Message(),
@@ -2266,7 +2268,7 @@ OpDeprecation::OpDeprecation(::google::protobuf::Arena* arena)
   ::protobuf_op_5fdef_2eproto::InitDefaultsOpDeprecation();
   SharedCtor();
   RegisterArenaDtor(arena);
-  // @@protoc_insertion_point(arena_constructor:tensorflow.OpDeprecation)
+  // @@protoc_insertion_point(arena_constructor:opencv_tensorflow.OpDeprecation)
 }
 OpDeprecation::OpDeprecation(const OpDeprecation& from)
   : ::google::protobuf::Message(),
@@ -2279,7 +2281,7 @@ OpDeprecation::OpDeprecation(const OpDeprecation& from)
       GetArenaNoVirtual());
   }
   version_ = from.version_;
-  // @@protoc_insertion_point(copy_constructor:tensorflow.OpDeprecation)
+  // @@protoc_insertion_point(copy_constructor:opencv_tensorflow.OpDeprecation)
 }
 
 void OpDeprecation::SharedCtor() {
@@ -2289,7 +2291,7 @@ void OpDeprecation::SharedCtor() {
 }
 
 OpDeprecation::~OpDeprecation() {
-  // @@protoc_insertion_point(destructor:tensorflow.OpDeprecation)
+  // @@protoc_insertion_point(destructor:opencv_tensorflow.OpDeprecation)
   SharedDtor();
 }
 
@@ -2324,7 +2326,7 @@ OpDeprecation* OpDeprecation::New(::google::protobuf::Arena* arena) const {
 }
 
 void OpDeprecation::Clear() {
-// @@protoc_insertion_point(message_clear_start:tensorflow.OpDeprecation)
+// @@protoc_insertion_point(message_clear_start:opencv_tensorflow.OpDeprecation)
   ::google::protobuf::uint32 cached_has_bits = 0;
   // Prevent compiler warnings about cached_has_bits being unused
   (void) cached_has_bits;
@@ -2338,7 +2340,7 @@ bool OpDeprecation::MergePartialFromCodedStream(
     ::google::protobuf::io::CodedInputStream* input) {
 #define DO_(EXPRESSION) if (!GOOGLE_PREDICT_TRUE(EXPRESSION)) goto failure
   ::google::protobuf::uint32 tag;
-  // @@protoc_insertion_point(parse_start:tensorflow.OpDeprecation)
+  // @@protoc_insertion_point(parse_start:opencv_tensorflow.OpDeprecation)
   for (;;) {
     ::std::pair< ::google::protobuf::uint32, bool> p = input->ReadTagWithCutoffNoLastTag(127u);
     tag = p.first;
@@ -2367,7 +2369,7 @@ bool OpDeprecation::MergePartialFromCodedStream(
           DO_(::google::protobuf::internal::WireFormatLite::VerifyUtf8String(
             this->explanation().data(), static_cast<int>(this->explanation().length()),
             ::google::protobuf::internal::WireFormatLite::PARSE,
-            "tensorflow.OpDeprecation.explanation"));
+            "opencv_tensorflow.OpDeprecation.explanation"));
         } else {
           goto handle_unusual;
         }
@@ -2386,17 +2388,17 @@ bool OpDeprecation::MergePartialFromCodedStream(
     }
   }
 success:
-  // @@protoc_insertion_point(parse_success:tensorflow.OpDeprecation)
+  // @@protoc_insertion_point(parse_success:opencv_tensorflow.OpDeprecation)
   return true;
 failure:
-  // @@protoc_insertion_point(parse_failure:tensorflow.OpDeprecation)
+  // @@protoc_insertion_point(parse_failure:opencv_tensorflow.OpDeprecation)
   return false;
 #undef DO_
 }
 
 void OpDeprecation::SerializeWithCachedSizes(
     ::google::protobuf::io::CodedOutputStream* output) const {
-  // @@protoc_insertion_point(serialize_start:tensorflow.OpDeprecation)
+  // @@protoc_insertion_point(serialize_start:opencv_tensorflow.OpDeprecation)
   ::google::protobuf::uint32 cached_has_bits = 0;
   (void) cached_has_bits;
 
@@ -2410,7 +2412,7 @@ void OpDeprecation::SerializeWithCachedSizes(
     ::google::protobuf::internal::WireFormatLite::VerifyUtf8String(
       this->explanation().data(), static_cast<int>(this->explanation().length()),
       ::google::protobuf::internal::WireFormatLite::SERIALIZE,
-      "tensorflow.OpDeprecation.explanation");
+      "opencv_tensorflow.OpDeprecation.explanation");
     ::google::protobuf::internal::WireFormatLite::WriteStringMaybeAliased(
       2, this->explanation(), output);
   }
@@ -2419,13 +2421,13 @@ void OpDeprecation::SerializeWithCachedSizes(
     ::google::protobuf::internal::WireFormat::SerializeUnknownFields(
         (::google::protobuf::internal::GetProto3PreserveUnknownsDefault()   ? _internal_metadata_.unknown_fields()   : _internal_metadata_.default_instance()), output);
   }
-  // @@protoc_insertion_point(serialize_end:tensorflow.OpDeprecation)
+  // @@protoc_insertion_point(serialize_end:opencv_tensorflow.OpDeprecation)
 }
 
 ::google::protobuf::uint8* OpDeprecation::InternalSerializeWithCachedSizesToArray(
     bool deterministic, ::google::protobuf::uint8* target) const {
   (void)deterministic; // Unused
-  // @@protoc_insertion_point(serialize_to_array_start:tensorflow.OpDeprecation)
+  // @@protoc_insertion_point(serialize_to_array_start:opencv_tensorflow.OpDeprecation)
   ::google::protobuf::uint32 cached_has_bits = 0;
   (void) cached_has_bits;
 
@@ -2439,7 +2441,7 @@ void OpDeprecation::SerializeWithCachedSizes(
     ::google::protobuf::internal::WireFormatLite::VerifyUtf8String(
       this->explanation().data(), static_cast<int>(this->explanation().length()),
       ::google::protobuf::internal::WireFormatLite::SERIALIZE,
-      "tensorflow.OpDeprecation.explanation");
+      "opencv_tensorflow.OpDeprecation.explanation");
     target =
       ::google::protobuf::internal::WireFormatLite::WriteStringToArray(
         2, this->explanation(), target);
@@ -2449,12 +2451,12 @@ void OpDeprecation::SerializeWithCachedSizes(
     target = ::google::protobuf::internal::WireFormat::SerializeUnknownFieldsToArray(
         (::google::protobuf::internal::GetProto3PreserveUnknownsDefault()   ? _internal_metadata_.unknown_fields()   : _internal_metadata_.default_instance()), target);
   }
-  // @@protoc_insertion_point(serialize_to_array_end:tensorflow.OpDeprecation)
+  // @@protoc_insertion_point(serialize_to_array_end:opencv_tensorflow.OpDeprecation)
   return target;
 }
 
 size_t OpDeprecation::ByteSizeLong() const {
-// @@protoc_insertion_point(message_byte_size_start:tensorflow.OpDeprecation)
+// @@protoc_insertion_point(message_byte_size_start:opencv_tensorflow.OpDeprecation)
   size_t total_size = 0;
 
   if ((_internal_metadata_.have_unknown_fields() &&  ::google::protobuf::internal::GetProto3PreserveUnknownsDefault())) {
@@ -2484,22 +2486,22 @@ size_t OpDeprecation::ByteSizeLong() const {
 }
 
 void OpDeprecation::MergeFrom(const ::google::protobuf::Message& from) {
-// @@protoc_insertion_point(generalized_merge_from_start:tensorflow.OpDeprecation)
+// @@protoc_insertion_point(generalized_merge_from_start:opencv_tensorflow.OpDeprecation)
   GOOGLE_DCHECK_NE(&from, this);
   const OpDeprecation* source =
       ::google::protobuf::internal::DynamicCastToGenerated<const OpDeprecation>(
           &from);
   if (source == NULL) {
-  // @@protoc_insertion_point(generalized_merge_from_cast_fail:tensorflow.OpDeprecation)
+  // @@protoc_insertion_point(generalized_merge_from_cast_fail:opencv_tensorflow.OpDeprecation)
     ::google::protobuf::internal::ReflectionOps::Merge(from, this);
   } else {
-  // @@protoc_insertion_point(generalized_merge_from_cast_success:tensorflow.OpDeprecation)
+  // @@protoc_insertion_point(generalized_merge_from_cast_success:opencv_tensorflow.OpDeprecation)
     MergeFrom(*source);
   }
 }
 
 void OpDeprecation::MergeFrom(const OpDeprecation& from) {
-// @@protoc_insertion_point(class_specific_merge_from_start:tensorflow.OpDeprecation)
+// @@protoc_insertion_point(class_specific_merge_from_start:opencv_tensorflow.OpDeprecation)
   GOOGLE_DCHECK_NE(&from, this);
   _internal_metadata_.MergeFrom(from._internal_metadata_);
   ::google::protobuf::uint32 cached_has_bits = 0;
@@ -2514,14 +2516,14 @@ void OpDeprecation::MergeFrom(const OpDeprecation& from) {
 }
 
 void OpDeprecation::CopyFrom(const ::google::protobuf::Message& from) {
-// @@protoc_insertion_point(generalized_copy_from_start:tensorflow.OpDeprecation)
+// @@protoc_insertion_point(generalized_copy_from_start:opencv_tensorflow.OpDeprecation)
   if (&from == this) return;
   Clear();
   MergeFrom(from);
 }
 
 void OpDeprecation::CopyFrom(const OpDeprecation& from) {
-// @@protoc_insertion_point(class_specific_copy_from_start:tensorflow.OpDeprecation)
+// @@protoc_insertion_point(class_specific_copy_from_start:opencv_tensorflow.OpDeprecation)
   if (&from == this) return;
   Clear();
   MergeFrom(from);
@@ -2578,7 +2580,7 @@ OpList::OpList()
     ::protobuf_op_5fdef_2eproto::InitDefaultsOpList();
   }
   SharedCtor();
-  // @@protoc_insertion_point(constructor:tensorflow.OpList)
+  // @@protoc_insertion_point(constructor:opencv_tensorflow.OpList)
 }
 OpList::OpList(::google::protobuf::Arena* arena)
   : ::google::protobuf::Message(),
@@ -2587,7 +2589,7 @@ OpList::OpList(::google::protobuf::Arena* arena)
   ::protobuf_op_5fdef_2eproto::InitDefaultsOpList();
   SharedCtor();
   RegisterArenaDtor(arena);
-  // @@protoc_insertion_point(arena_constructor:tensorflow.OpList)
+  // @@protoc_insertion_point(arena_constructor:opencv_tensorflow.OpList)
 }
 OpList::OpList(const OpList& from)
   : ::google::protobuf::Message(),
@@ -2595,7 +2597,7 @@ OpList::OpList(const OpList& from)
       op_(from.op_),
       _cached_size_(0) {
   _internal_metadata_.MergeFrom(from._internal_metadata_);
-  // @@protoc_insertion_point(copy_constructor:tensorflow.OpList)
+  // @@protoc_insertion_point(copy_constructor:opencv_tensorflow.OpList)
 }
 
 void OpList::SharedCtor() {
@@ -2603,7 +2605,7 @@ void OpList::SharedCtor() {
 }
 
 OpList::~OpList() {
-  // @@protoc_insertion_point(destructor:tensorflow.OpList)
+  // @@protoc_insertion_point(destructor:opencv_tensorflow.OpList)
   SharedDtor();
 }
 
@@ -2637,7 +2639,7 @@ OpList* OpList::New(::google::protobuf::Arena* arena) const {
 }
 
 void OpList::Clear() {
-// @@protoc_insertion_point(message_clear_start:tensorflow.OpList)
+// @@protoc_insertion_point(message_clear_start:opencv_tensorflow.OpList)
   ::google::protobuf::uint32 cached_has_bits = 0;
   // Prevent compiler warnings about cached_has_bits being unused
   (void) cached_has_bits;
@@ -2650,13 +2652,13 @@ bool OpList::MergePartialFromCodedStream(
     ::google::protobuf::io::CodedInputStream* input) {
 #define DO_(EXPRESSION) if (!GOOGLE_PREDICT_TRUE(EXPRESSION)) goto failure
   ::google::protobuf::uint32 tag;
-  // @@protoc_insertion_point(parse_start:tensorflow.OpList)
+  // @@protoc_insertion_point(parse_start:opencv_tensorflow.OpList)
   for (;;) {
     ::std::pair< ::google::protobuf::uint32, bool> p = input->ReadTagWithCutoffNoLastTag(127u);
     tag = p.first;
     if (!p.second) goto handle_unusual;
     switch (::google::protobuf::internal::WireFormatLite::GetTagFieldNumber(tag)) {
-      // repeated .tensorflow.OpDef op = 1;
+      // repeated .opencv_tensorflow.OpDef op = 1;
       case 1: {
         if (static_cast< ::google::protobuf::uint8>(tag) ==
             static_cast< ::google::protobuf::uint8>(10u /* 10 & 0xFF */)) {
@@ -2679,21 +2681,21 @@ bool OpList::MergePartialFromCodedStream(
     }
   }
 success:
-  // @@protoc_insertion_point(parse_success:tensorflow.OpList)
+  // @@protoc_insertion_point(parse_success:opencv_tensorflow.OpList)
   return true;
 failure:
-  // @@protoc_insertion_point(parse_failure:tensorflow.OpList)
+  // @@protoc_insertion_point(parse_failure:opencv_tensorflow.OpList)
   return false;
 #undef DO_
 }
 
 void OpList::SerializeWithCachedSizes(
     ::google::protobuf::io::CodedOutputStream* output) const {
-  // @@protoc_insertion_point(serialize_start:tensorflow.OpList)
+  // @@protoc_insertion_point(serialize_start:opencv_tensorflow.OpList)
   ::google::protobuf::uint32 cached_has_bits = 0;
   (void) cached_has_bits;
 
-  // repeated .tensorflow.OpDef op = 1;
+  // repeated .opencv_tensorflow.OpDef op = 1;
   for (unsigned int i = 0,
       n = static_cast<unsigned int>(this->op_size()); i < n; i++) {
     ::google::protobuf::internal::WireFormatLite::WriteMessageMaybeToArray(
@@ -2704,17 +2706,17 @@ void OpList::SerializeWithCachedSizes(
     ::google::protobuf::internal::WireFormat::SerializeUnknownFields(
         (::google::protobuf::internal::GetProto3PreserveUnknownsDefault()   ? _internal_metadata_.unknown_fields()   : _internal_metadata_.default_instance()), output);
   }
-  // @@protoc_insertion_point(serialize_end:tensorflow.OpList)
+  // @@protoc_insertion_point(serialize_end:opencv_tensorflow.OpList)
 }
 
 ::google::protobuf::uint8* OpList::InternalSerializeWithCachedSizesToArray(
     bool deterministic, ::google::protobuf::uint8* target) const {
   (void)deterministic; // Unused
-  // @@protoc_insertion_point(serialize_to_array_start:tensorflow.OpList)
+  // @@protoc_insertion_point(serialize_to_array_start:opencv_tensorflow.OpList)
   ::google::protobuf::uint32 cached_has_bits = 0;
   (void) cached_has_bits;
 
-  // repeated .tensorflow.OpDef op = 1;
+  // repeated .opencv_tensorflow.OpDef op = 1;
   for (unsigned int i = 0,
       n = static_cast<unsigned int>(this->op_size()); i < n; i++) {
     target = ::google::protobuf::internal::WireFormatLite::
@@ -2726,12 +2728,12 @@ void OpList::SerializeWithCachedSizes(
     target = ::google::protobuf::internal::WireFormat::SerializeUnknownFieldsToArray(
         (::google::protobuf::internal::GetProto3PreserveUnknownsDefault()   ? _internal_metadata_.unknown_fields()   : _internal_metadata_.default_instance()), target);
   }
-  // @@protoc_insertion_point(serialize_to_array_end:tensorflow.OpList)
+  // @@protoc_insertion_point(serialize_to_array_end:opencv_tensorflow.OpList)
   return target;
 }
 
 size_t OpList::ByteSizeLong() const {
-// @@protoc_insertion_point(message_byte_size_start:tensorflow.OpList)
+// @@protoc_insertion_point(message_byte_size_start:opencv_tensorflow.OpList)
   size_t total_size = 0;
 
   if ((_internal_metadata_.have_unknown_fields() &&  ::google::protobuf::internal::GetProto3PreserveUnknownsDefault())) {
@@ -2739,7 +2741,7 @@ size_t OpList::ByteSizeLong() const {
       ::google::protobuf::internal::WireFormat::ComputeUnknownFieldsSize(
         (::google::protobuf::internal::GetProto3PreserveUnknownsDefault()   ? _internal_metadata_.unknown_fields()   : _internal_metadata_.default_instance()));
   }
-  // repeated .tensorflow.OpDef op = 1;
+  // repeated .opencv_tensorflow.OpDef op = 1;
   {
     unsigned int count = static_cast<unsigned int>(this->op_size());
     total_size += 1UL * count;
@@ -2758,22 +2760,22 @@ size_t OpList::ByteSizeLong() const {
 }
 
 void OpList::MergeFrom(const ::google::protobuf::Message& from) {
-// @@protoc_insertion_point(generalized_merge_from_start:tensorflow.OpList)
+// @@protoc_insertion_point(generalized_merge_from_start:opencv_tensorflow.OpList)
   GOOGLE_DCHECK_NE(&from, this);
   const OpList* source =
       ::google::protobuf::internal::DynamicCastToGenerated<const OpList>(
           &from);
   if (source == NULL) {
-  // @@protoc_insertion_point(generalized_merge_from_cast_fail:tensorflow.OpList)
+  // @@protoc_insertion_point(generalized_merge_from_cast_fail:opencv_tensorflow.OpList)
     ::google::protobuf::internal::ReflectionOps::Merge(from, this);
   } else {
-  // @@protoc_insertion_point(generalized_merge_from_cast_success:tensorflow.OpList)
+  // @@protoc_insertion_point(generalized_merge_from_cast_success:opencv_tensorflow.OpList)
     MergeFrom(*source);
   }
 }
 
 void OpList::MergeFrom(const OpList& from) {
-// @@protoc_insertion_point(class_specific_merge_from_start:tensorflow.OpList)
+// @@protoc_insertion_point(class_specific_merge_from_start:opencv_tensorflow.OpList)
   GOOGLE_DCHECK_NE(&from, this);
   _internal_metadata_.MergeFrom(from._internal_metadata_);
   ::google::protobuf::uint32 cached_has_bits = 0;
@@ -2783,14 +2785,14 @@ void OpList::MergeFrom(const OpList& from) {
 }
 
 void OpList::CopyFrom(const ::google::protobuf::Message& from) {
-// @@protoc_insertion_point(generalized_copy_from_start:tensorflow.OpList)
+// @@protoc_insertion_point(generalized_copy_from_start:opencv_tensorflow.OpList)
   if (&from == this) return;
   Clear();
   MergeFrom(from);
 }
 
 void OpList::CopyFrom(const OpList& from) {
-// @@protoc_insertion_point(class_specific_copy_from_start:tensorflow.OpList)
+// @@protoc_insertion_point(class_specific_copy_from_start:opencv_tensorflow.OpList)
   if (&from == this) return;
   Clear();
   MergeFrom(from);
@@ -2833,6 +2835,6 @@ void OpList::InternalSwap(OpList* other) {
 
 
 // @@protoc_insertion_point(namespace_scope)
-}  // namespace tensorflow
+}  // namespace opencv_tensorflow
 
 // @@protoc_insertion_point(global_scope)

--- a/modules/dnn/misc/tensorflow/op_def.pb.h
+++ b/modules/dnn/misc/tensorflow/op_def.pb.h
@@ -62,7 +62,7 @@ inline void InitDefaults() {
   InitDefaultsOpList();
 }
 }  // namespace protobuf_op_5fdef_2eproto
-namespace tensorflow {
+namespace opencv_tensorflow {
 class OpDef;
 class OpDefDefaultTypeInternal;
 extern OpDefDefaultTypeInternal _OpDef_default_instance_;
@@ -78,12 +78,12 @@ extern OpDeprecationDefaultTypeInternal _OpDeprecation_default_instance_;
 class OpList;
 class OpListDefaultTypeInternal;
 extern OpListDefaultTypeInternal _OpList_default_instance_;
-}  // namespace tensorflow
-namespace tensorflow {
+}  // namespace opencv_tensorflow
+namespace opencv_tensorflow {
 
 // ===================================================================
 
-class OpDef_ArgDef : public ::google::protobuf::Message /* @@protoc_insertion_point(class_definition:tensorflow.OpDef.ArgDef) */ {
+class OpDef_ArgDef : public ::google::protobuf::Message /* @@protoc_insertion_point(class_definition:opencv_tensorflow.OpDef.ArgDef) */ {
  public:
   OpDef_ArgDef();
   virtual ~OpDef_ArgDef();
@@ -292,11 +292,11 @@ class OpDef_ArgDef : public ::google::protobuf::Message /* @@protoc_insertion_po
   void unsafe_arena_set_allocated_type_list_attr(
       ::std::string* type_list_attr);
 
-  // .tensorflow.DataType type = 3;
+  // .opencv_tensorflow.DataType type = 3;
   void clear_type();
   static const int kTypeFieldNumber = 3;
-  ::tensorflow::DataType type() const;
-  void set_type(::tensorflow::DataType value);
+  ::opencv_tensorflow::DataType type() const;
+  void set_type(::opencv_tensorflow::DataType value);
 
   // bool is_ref = 16;
   void clear_is_ref();
@@ -304,7 +304,7 @@ class OpDef_ArgDef : public ::google::protobuf::Message /* @@protoc_insertion_po
   bool is_ref() const;
   void set_is_ref(bool value);
 
-  // @@protoc_insertion_point(class_scope:tensorflow.OpDef.ArgDef)
+  // @@protoc_insertion_point(class_scope:opencv_tensorflow.OpDef.ArgDef)
  private:
 
   ::google::protobuf::internal::InternalMetadataWithArena _internal_metadata_;
@@ -324,7 +324,7 @@ class OpDef_ArgDef : public ::google::protobuf::Message /* @@protoc_insertion_po
 };
 // -------------------------------------------------------------------
 
-class OpDef_AttrDef : public ::google::protobuf::Message /* @@protoc_insertion_point(class_definition:tensorflow.OpDef.AttrDef) */ {
+class OpDef_AttrDef : public ::google::protobuf::Message /* @@protoc_insertion_point(class_definition:opencv_tensorflow.OpDef.AttrDef) */ {
  public:
   OpDef_AttrDef();
   virtual ~OpDef_AttrDef();
@@ -487,35 +487,35 @@ class OpDef_AttrDef : public ::google::protobuf::Message /* @@protoc_insertion_p
   void unsafe_arena_set_allocated_description(
       ::std::string* description);
 
-  // .tensorflow.AttrValue default_value = 3;
+  // .opencv_tensorflow.AttrValue default_value = 3;
   bool has_default_value() const;
   void clear_default_value();
   static const int kDefaultValueFieldNumber = 3;
   private:
   void _slow_mutable_default_value();
   public:
-  const ::tensorflow::AttrValue& default_value() const;
-  ::tensorflow::AttrValue* release_default_value();
-  ::tensorflow::AttrValue* mutable_default_value();
-  void set_allocated_default_value(::tensorflow::AttrValue* default_value);
+  const ::opencv_tensorflow::AttrValue& default_value() const;
+  ::opencv_tensorflow::AttrValue* release_default_value();
+  ::opencv_tensorflow::AttrValue* mutable_default_value();
+  void set_allocated_default_value(::opencv_tensorflow::AttrValue* default_value);
   void unsafe_arena_set_allocated_default_value(
-      ::tensorflow::AttrValue* default_value);
-  ::tensorflow::AttrValue* unsafe_arena_release_default_value();
+      ::opencv_tensorflow::AttrValue* default_value);
+  ::opencv_tensorflow::AttrValue* unsafe_arena_release_default_value();
 
-  // .tensorflow.AttrValue allowed_values = 7;
+  // .opencv_tensorflow.AttrValue allowed_values = 7;
   bool has_allowed_values() const;
   void clear_allowed_values();
   static const int kAllowedValuesFieldNumber = 7;
   private:
   void _slow_mutable_allowed_values();
   public:
-  const ::tensorflow::AttrValue& allowed_values() const;
-  ::tensorflow::AttrValue* release_allowed_values();
-  ::tensorflow::AttrValue* mutable_allowed_values();
-  void set_allocated_allowed_values(::tensorflow::AttrValue* allowed_values);
+  const ::opencv_tensorflow::AttrValue& allowed_values() const;
+  ::opencv_tensorflow::AttrValue* release_allowed_values();
+  ::opencv_tensorflow::AttrValue* mutable_allowed_values();
+  void set_allocated_allowed_values(::opencv_tensorflow::AttrValue* allowed_values);
   void unsafe_arena_set_allocated_allowed_values(
-      ::tensorflow::AttrValue* allowed_values);
-  ::tensorflow::AttrValue* unsafe_arena_release_allowed_values();
+      ::opencv_tensorflow::AttrValue* allowed_values);
+  ::opencv_tensorflow::AttrValue* unsafe_arena_release_allowed_values();
 
   // int64 minimum = 6;
   void clear_minimum();
@@ -529,7 +529,7 @@ class OpDef_AttrDef : public ::google::protobuf::Message /* @@protoc_insertion_p
   bool has_minimum() const;
   void set_has_minimum(bool value);
 
-  // @@protoc_insertion_point(class_scope:tensorflow.OpDef.AttrDef)
+  // @@protoc_insertion_point(class_scope:opencv_tensorflow.OpDef.AttrDef)
  private:
 
   ::google::protobuf::internal::InternalMetadataWithArena _internal_metadata_;
@@ -539,8 +539,8 @@ class OpDef_AttrDef : public ::google::protobuf::Message /* @@protoc_insertion_p
   ::google::protobuf::internal::ArenaStringPtr name_;
   ::google::protobuf::internal::ArenaStringPtr type_;
   ::google::protobuf::internal::ArenaStringPtr description_;
-  ::tensorflow::AttrValue* default_value_;
-  ::tensorflow::AttrValue* allowed_values_;
+  ::opencv_tensorflow::AttrValue* default_value_;
+  ::opencv_tensorflow::AttrValue* allowed_values_;
   ::google::protobuf::int64 minimum_;
   bool has_minimum_;
   mutable int _cached_size_;
@@ -549,7 +549,7 @@ class OpDef_AttrDef : public ::google::protobuf::Message /* @@protoc_insertion_p
 };
 // -------------------------------------------------------------------
 
-class OpDef : public ::google::protobuf::Message /* @@protoc_insertion_point(class_definition:tensorflow.OpDef) */ {
+class OpDef : public ::google::protobuf::Message /* @@protoc_insertion_point(class_definition:opencv_tensorflow.OpDef) */ {
  public:
   OpDef();
   virtual ~OpDef();
@@ -646,40 +646,40 @@ class OpDef : public ::google::protobuf::Message /* @@protoc_insertion_point(cla
 
   // accessors -------------------------------------------------------
 
-  // repeated .tensorflow.OpDef.ArgDef input_arg = 2;
+  // repeated .opencv_tensorflow.OpDef.ArgDef input_arg = 2;
   int input_arg_size() const;
   void clear_input_arg();
   static const int kInputArgFieldNumber = 2;
-  const ::tensorflow::OpDef_ArgDef& input_arg(int index) const;
-  ::tensorflow::OpDef_ArgDef* mutable_input_arg(int index);
-  ::tensorflow::OpDef_ArgDef* add_input_arg();
-  ::google::protobuf::RepeatedPtrField< ::tensorflow::OpDef_ArgDef >*
+  const ::opencv_tensorflow::OpDef_ArgDef& input_arg(int index) const;
+  ::opencv_tensorflow::OpDef_ArgDef* mutable_input_arg(int index);
+  ::opencv_tensorflow::OpDef_ArgDef* add_input_arg();
+  ::google::protobuf::RepeatedPtrField< ::opencv_tensorflow::OpDef_ArgDef >*
       mutable_input_arg();
-  const ::google::protobuf::RepeatedPtrField< ::tensorflow::OpDef_ArgDef >&
+  const ::google::protobuf::RepeatedPtrField< ::opencv_tensorflow::OpDef_ArgDef >&
       input_arg() const;
 
-  // repeated .tensorflow.OpDef.ArgDef output_arg = 3;
+  // repeated .opencv_tensorflow.OpDef.ArgDef output_arg = 3;
   int output_arg_size() const;
   void clear_output_arg();
   static const int kOutputArgFieldNumber = 3;
-  const ::tensorflow::OpDef_ArgDef& output_arg(int index) const;
-  ::tensorflow::OpDef_ArgDef* mutable_output_arg(int index);
-  ::tensorflow::OpDef_ArgDef* add_output_arg();
-  ::google::protobuf::RepeatedPtrField< ::tensorflow::OpDef_ArgDef >*
+  const ::opencv_tensorflow::OpDef_ArgDef& output_arg(int index) const;
+  ::opencv_tensorflow::OpDef_ArgDef* mutable_output_arg(int index);
+  ::opencv_tensorflow::OpDef_ArgDef* add_output_arg();
+  ::google::protobuf::RepeatedPtrField< ::opencv_tensorflow::OpDef_ArgDef >*
       mutable_output_arg();
-  const ::google::protobuf::RepeatedPtrField< ::tensorflow::OpDef_ArgDef >&
+  const ::google::protobuf::RepeatedPtrField< ::opencv_tensorflow::OpDef_ArgDef >&
       output_arg() const;
 
-  // repeated .tensorflow.OpDef.AttrDef attr = 4;
+  // repeated .opencv_tensorflow.OpDef.AttrDef attr = 4;
   int attr_size() const;
   void clear_attr();
   static const int kAttrFieldNumber = 4;
-  const ::tensorflow::OpDef_AttrDef& attr(int index) const;
-  ::tensorflow::OpDef_AttrDef* mutable_attr(int index);
-  ::tensorflow::OpDef_AttrDef* add_attr();
-  ::google::protobuf::RepeatedPtrField< ::tensorflow::OpDef_AttrDef >*
+  const ::opencv_tensorflow::OpDef_AttrDef& attr(int index) const;
+  ::opencv_tensorflow::OpDef_AttrDef* mutable_attr(int index);
+  ::opencv_tensorflow::OpDef_AttrDef* add_attr();
+  ::google::protobuf::RepeatedPtrField< ::opencv_tensorflow::OpDef_AttrDef >*
       mutable_attr();
-  const ::google::protobuf::RepeatedPtrField< ::tensorflow::OpDef_AttrDef >&
+  const ::google::protobuf::RepeatedPtrField< ::opencv_tensorflow::OpDef_AttrDef >&
       attr() const;
 
   // string name = 1;
@@ -751,20 +751,20 @@ class OpDef : public ::google::protobuf::Message /* @@protoc_insertion_point(cla
   void unsafe_arena_set_allocated_description(
       ::std::string* description);
 
-  // .tensorflow.OpDeprecation deprecation = 8;
+  // .opencv_tensorflow.OpDeprecation deprecation = 8;
   bool has_deprecation() const;
   void clear_deprecation();
   static const int kDeprecationFieldNumber = 8;
   private:
   void _slow_mutable_deprecation();
   public:
-  const ::tensorflow::OpDeprecation& deprecation() const;
-  ::tensorflow::OpDeprecation* release_deprecation();
-  ::tensorflow::OpDeprecation* mutable_deprecation();
-  void set_allocated_deprecation(::tensorflow::OpDeprecation* deprecation);
+  const ::opencv_tensorflow::OpDeprecation& deprecation() const;
+  ::opencv_tensorflow::OpDeprecation* release_deprecation();
+  ::opencv_tensorflow::OpDeprecation* mutable_deprecation();
+  void set_allocated_deprecation(::opencv_tensorflow::OpDeprecation* deprecation);
   void unsafe_arena_set_allocated_deprecation(
-      ::tensorflow::OpDeprecation* deprecation);
-  ::tensorflow::OpDeprecation* unsafe_arena_release_deprecation();
+      ::opencv_tensorflow::OpDeprecation* deprecation);
+  ::opencv_tensorflow::OpDeprecation* unsafe_arena_release_deprecation();
 
   // bool is_commutative = 18;
   void clear_is_commutative();
@@ -790,20 +790,20 @@ class OpDef : public ::google::protobuf::Message /* @@protoc_insertion_point(cla
   bool allows_uninitialized_input() const;
   void set_allows_uninitialized_input(bool value);
 
-  // @@protoc_insertion_point(class_scope:tensorflow.OpDef)
+  // @@protoc_insertion_point(class_scope:opencv_tensorflow.OpDef)
  private:
 
   ::google::protobuf::internal::InternalMetadataWithArena _internal_metadata_;
   template <typename T> friend class ::google::protobuf::Arena::InternalHelper;
   typedef void InternalArenaConstructable_;
   typedef void DestructorSkippable_;
-  ::google::protobuf::RepeatedPtrField< ::tensorflow::OpDef_ArgDef > input_arg_;
-  ::google::protobuf::RepeatedPtrField< ::tensorflow::OpDef_ArgDef > output_arg_;
-  ::google::protobuf::RepeatedPtrField< ::tensorflow::OpDef_AttrDef > attr_;
+  ::google::protobuf::RepeatedPtrField< ::opencv_tensorflow::OpDef_ArgDef > input_arg_;
+  ::google::protobuf::RepeatedPtrField< ::opencv_tensorflow::OpDef_ArgDef > output_arg_;
+  ::google::protobuf::RepeatedPtrField< ::opencv_tensorflow::OpDef_AttrDef > attr_;
   ::google::protobuf::internal::ArenaStringPtr name_;
   ::google::protobuf::internal::ArenaStringPtr summary_;
   ::google::protobuf::internal::ArenaStringPtr description_;
-  ::tensorflow::OpDeprecation* deprecation_;
+  ::opencv_tensorflow::OpDeprecation* deprecation_;
   bool is_commutative_;
   bool is_aggregate_;
   bool is_stateful_;
@@ -814,7 +814,7 @@ class OpDef : public ::google::protobuf::Message /* @@protoc_insertion_point(cla
 };
 // -------------------------------------------------------------------
 
-class OpDeprecation : public ::google::protobuf::Message /* @@protoc_insertion_point(class_definition:tensorflow.OpDeprecation) */ {
+class OpDeprecation : public ::google::protobuf::Message /* @@protoc_insertion_point(class_definition:opencv_tensorflow.OpDeprecation) */ {
  public:
   OpDeprecation();
   virtual ~OpDeprecation();
@@ -937,7 +937,7 @@ class OpDeprecation : public ::google::protobuf::Message /* @@protoc_insertion_p
   ::google::protobuf::int32 version() const;
   void set_version(::google::protobuf::int32 value);
 
-  // @@protoc_insertion_point(class_scope:tensorflow.OpDeprecation)
+  // @@protoc_insertion_point(class_scope:opencv_tensorflow.OpDeprecation)
  private:
 
   ::google::protobuf::internal::InternalMetadataWithArena _internal_metadata_;
@@ -952,7 +952,7 @@ class OpDeprecation : public ::google::protobuf::Message /* @@protoc_insertion_p
 };
 // -------------------------------------------------------------------
 
-class OpList : public ::google::protobuf::Message /* @@protoc_insertion_point(class_definition:tensorflow.OpList) */ {
+class OpList : public ::google::protobuf::Message /* @@protoc_insertion_point(class_definition:opencv_tensorflow.OpList) */ {
  public:
   OpList();
   virtual ~OpList();
@@ -1046,26 +1046,26 @@ class OpList : public ::google::protobuf::Message /* @@protoc_insertion_point(cl
 
   // accessors -------------------------------------------------------
 
-  // repeated .tensorflow.OpDef op = 1;
+  // repeated .opencv_tensorflow.OpDef op = 1;
   int op_size() const;
   void clear_op();
   static const int kOpFieldNumber = 1;
-  const ::tensorflow::OpDef& op(int index) const;
-  ::tensorflow::OpDef* mutable_op(int index);
-  ::tensorflow::OpDef* add_op();
-  ::google::protobuf::RepeatedPtrField< ::tensorflow::OpDef >*
+  const ::opencv_tensorflow::OpDef& op(int index) const;
+  ::opencv_tensorflow::OpDef* mutable_op(int index);
+  ::opencv_tensorflow::OpDef* add_op();
+  ::google::protobuf::RepeatedPtrField< ::opencv_tensorflow::OpDef >*
       mutable_op();
-  const ::google::protobuf::RepeatedPtrField< ::tensorflow::OpDef >&
+  const ::google::protobuf::RepeatedPtrField< ::opencv_tensorflow::OpDef >&
       op() const;
 
-  // @@protoc_insertion_point(class_scope:tensorflow.OpList)
+  // @@protoc_insertion_point(class_scope:opencv_tensorflow.OpList)
  private:
 
   ::google::protobuf::internal::InternalMetadataWithArena _internal_metadata_;
   template <typename T> friend class ::google::protobuf::Arena::InternalHelper;
   typedef void InternalArenaConstructable_;
   typedef void DestructorSkippable_;
-  ::google::protobuf::RepeatedPtrField< ::tensorflow::OpDef > op_;
+  ::google::protobuf::RepeatedPtrField< ::opencv_tensorflow::OpDef > op_;
   mutable int _cached_size_;
   friend struct ::protobuf_op_5fdef_2eproto::TableStruct;
   friend void ::protobuf_op_5fdef_2eproto::InitDefaultsOpListImpl();
@@ -1086,20 +1086,20 @@ inline void OpDef_ArgDef::clear_name() {
   name_.ClearToEmpty(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), GetArenaNoVirtual());
 }
 inline const ::std::string& OpDef_ArgDef::name() const {
-  // @@protoc_insertion_point(field_get:tensorflow.OpDef.ArgDef.name)
+  // @@protoc_insertion_point(field_get:opencv_tensorflow.OpDef.ArgDef.name)
   return name_.Get();
 }
 inline void OpDef_ArgDef::set_name(const ::std::string& value) {
 
   name_.Set(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), value, GetArenaNoVirtual());
-  // @@protoc_insertion_point(field_set:tensorflow.OpDef.ArgDef.name)
+  // @@protoc_insertion_point(field_set:opencv_tensorflow.OpDef.ArgDef.name)
 }
 #if LANG_CXX11
 inline void OpDef_ArgDef::set_name(::std::string&& value) {
 
   name_.Set(
     &::google::protobuf::internal::GetEmptyStringAlreadyInited(), ::std::move(value), GetArenaNoVirtual());
-  // @@protoc_insertion_point(field_set_rvalue:tensorflow.OpDef.ArgDef.name)
+  // @@protoc_insertion_point(field_set_rvalue:opencv_tensorflow.OpDef.ArgDef.name)
 }
 #endif
 inline void OpDef_ArgDef::set_name(const char* value) {
@@ -1107,22 +1107,22 @@ inline void OpDef_ArgDef::set_name(const char* value) {
 
   name_.Set(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), ::std::string(value),
               GetArenaNoVirtual());
-  // @@protoc_insertion_point(field_set_char:tensorflow.OpDef.ArgDef.name)
+  // @@protoc_insertion_point(field_set_char:opencv_tensorflow.OpDef.ArgDef.name)
 }
 inline void OpDef_ArgDef::set_name(const char* value,
     size_t size) {
 
   name_.Set(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), ::std::string(
       reinterpret_cast<const char*>(value), size), GetArenaNoVirtual());
-  // @@protoc_insertion_point(field_set_pointer:tensorflow.OpDef.ArgDef.name)
+  // @@protoc_insertion_point(field_set_pointer:opencv_tensorflow.OpDef.ArgDef.name)
 }
 inline ::std::string* OpDef_ArgDef::mutable_name() {
 
-  // @@protoc_insertion_point(field_mutable:tensorflow.OpDef.ArgDef.name)
+  // @@protoc_insertion_point(field_mutable:opencv_tensorflow.OpDef.ArgDef.name)
   return name_.Mutable(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), GetArenaNoVirtual());
 }
 inline ::std::string* OpDef_ArgDef::release_name() {
-  // @@protoc_insertion_point(field_release:tensorflow.OpDef.ArgDef.name)
+  // @@protoc_insertion_point(field_release:opencv_tensorflow.OpDef.ArgDef.name)
 
   return name_.Release(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), GetArenaNoVirtual());
 }
@@ -1134,10 +1134,10 @@ inline void OpDef_ArgDef::set_allocated_name(::std::string* name) {
   }
   name_.SetAllocated(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), name,
       GetArenaNoVirtual());
-  // @@protoc_insertion_point(field_set_allocated:tensorflow.OpDef.ArgDef.name)
+  // @@protoc_insertion_point(field_set_allocated:opencv_tensorflow.OpDef.ArgDef.name)
 }
 inline ::std::string* OpDef_ArgDef::unsafe_arena_release_name() {
-  // @@protoc_insertion_point(field_unsafe_arena_release:tensorflow.OpDef.ArgDef.name)
+  // @@protoc_insertion_point(field_unsafe_arena_release:opencv_tensorflow.OpDef.ArgDef.name)
   GOOGLE_DCHECK(GetArenaNoVirtual() != NULL);
 
   return name_.UnsafeArenaRelease(&::google::protobuf::internal::GetEmptyStringAlreadyInited(),
@@ -1153,7 +1153,7 @@ inline void OpDef_ArgDef::unsafe_arena_set_allocated_name(
   }
   name_.UnsafeArenaSetAllocated(&::google::protobuf::internal::GetEmptyStringAlreadyInited(),
       name, GetArenaNoVirtual());
-  // @@protoc_insertion_point(field_unsafe_arena_set_allocated:tensorflow.OpDef.ArgDef.name)
+  // @@protoc_insertion_point(field_unsafe_arena_set_allocated:opencv_tensorflow.OpDef.ArgDef.name)
 }
 
 // string description = 2;
@@ -1161,20 +1161,20 @@ inline void OpDef_ArgDef::clear_description() {
   description_.ClearToEmpty(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), GetArenaNoVirtual());
 }
 inline const ::std::string& OpDef_ArgDef::description() const {
-  // @@protoc_insertion_point(field_get:tensorflow.OpDef.ArgDef.description)
+  // @@protoc_insertion_point(field_get:opencv_tensorflow.OpDef.ArgDef.description)
   return description_.Get();
 }
 inline void OpDef_ArgDef::set_description(const ::std::string& value) {
 
   description_.Set(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), value, GetArenaNoVirtual());
-  // @@protoc_insertion_point(field_set:tensorflow.OpDef.ArgDef.description)
+  // @@protoc_insertion_point(field_set:opencv_tensorflow.OpDef.ArgDef.description)
 }
 #if LANG_CXX11
 inline void OpDef_ArgDef::set_description(::std::string&& value) {
 
   description_.Set(
     &::google::protobuf::internal::GetEmptyStringAlreadyInited(), ::std::move(value), GetArenaNoVirtual());
-  // @@protoc_insertion_point(field_set_rvalue:tensorflow.OpDef.ArgDef.description)
+  // @@protoc_insertion_point(field_set_rvalue:opencv_tensorflow.OpDef.ArgDef.description)
 }
 #endif
 inline void OpDef_ArgDef::set_description(const char* value) {
@@ -1182,22 +1182,22 @@ inline void OpDef_ArgDef::set_description(const char* value) {
 
   description_.Set(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), ::std::string(value),
               GetArenaNoVirtual());
-  // @@protoc_insertion_point(field_set_char:tensorflow.OpDef.ArgDef.description)
+  // @@protoc_insertion_point(field_set_char:opencv_tensorflow.OpDef.ArgDef.description)
 }
 inline void OpDef_ArgDef::set_description(const char* value,
     size_t size) {
 
   description_.Set(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), ::std::string(
       reinterpret_cast<const char*>(value), size), GetArenaNoVirtual());
-  // @@protoc_insertion_point(field_set_pointer:tensorflow.OpDef.ArgDef.description)
+  // @@protoc_insertion_point(field_set_pointer:opencv_tensorflow.OpDef.ArgDef.description)
 }
 inline ::std::string* OpDef_ArgDef::mutable_description() {
 
-  // @@protoc_insertion_point(field_mutable:tensorflow.OpDef.ArgDef.description)
+  // @@protoc_insertion_point(field_mutable:opencv_tensorflow.OpDef.ArgDef.description)
   return description_.Mutable(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), GetArenaNoVirtual());
 }
 inline ::std::string* OpDef_ArgDef::release_description() {
-  // @@protoc_insertion_point(field_release:tensorflow.OpDef.ArgDef.description)
+  // @@protoc_insertion_point(field_release:opencv_tensorflow.OpDef.ArgDef.description)
 
   return description_.Release(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), GetArenaNoVirtual());
 }
@@ -1209,10 +1209,10 @@ inline void OpDef_ArgDef::set_allocated_description(::std::string* description) 
   }
   description_.SetAllocated(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), description,
       GetArenaNoVirtual());
-  // @@protoc_insertion_point(field_set_allocated:tensorflow.OpDef.ArgDef.description)
+  // @@protoc_insertion_point(field_set_allocated:opencv_tensorflow.OpDef.ArgDef.description)
 }
 inline ::std::string* OpDef_ArgDef::unsafe_arena_release_description() {
-  // @@protoc_insertion_point(field_unsafe_arena_release:tensorflow.OpDef.ArgDef.description)
+  // @@protoc_insertion_point(field_unsafe_arena_release:opencv_tensorflow.OpDef.ArgDef.description)
   GOOGLE_DCHECK(GetArenaNoVirtual() != NULL);
 
   return description_.UnsafeArenaRelease(&::google::protobuf::internal::GetEmptyStringAlreadyInited(),
@@ -1228,21 +1228,21 @@ inline void OpDef_ArgDef::unsafe_arena_set_allocated_description(
   }
   description_.UnsafeArenaSetAllocated(&::google::protobuf::internal::GetEmptyStringAlreadyInited(),
       description, GetArenaNoVirtual());
-  // @@protoc_insertion_point(field_unsafe_arena_set_allocated:tensorflow.OpDef.ArgDef.description)
+  // @@protoc_insertion_point(field_unsafe_arena_set_allocated:opencv_tensorflow.OpDef.ArgDef.description)
 }
 
-// .tensorflow.DataType type = 3;
+// .opencv_tensorflow.DataType type = 3;
 inline void OpDef_ArgDef::clear_type() {
   type_ = 0;
 }
-inline ::tensorflow::DataType OpDef_ArgDef::type() const {
-  // @@protoc_insertion_point(field_get:tensorflow.OpDef.ArgDef.type)
-  return static_cast< ::tensorflow::DataType >(type_);
+inline ::opencv_tensorflow::DataType OpDef_ArgDef::type() const {
+  // @@protoc_insertion_point(field_get:opencv_tensorflow.OpDef.ArgDef.type)
+  return static_cast< ::opencv_tensorflow::DataType >(type_);
 }
-inline void OpDef_ArgDef::set_type(::tensorflow::DataType value) {
+inline void OpDef_ArgDef::set_type(::opencv_tensorflow::DataType value) {
 
   type_ = value;
-  // @@protoc_insertion_point(field_set:tensorflow.OpDef.ArgDef.type)
+  // @@protoc_insertion_point(field_set:opencv_tensorflow.OpDef.ArgDef.type)
 }
 
 // string type_attr = 4;
@@ -1250,20 +1250,20 @@ inline void OpDef_ArgDef::clear_type_attr() {
   type_attr_.ClearToEmpty(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), GetArenaNoVirtual());
 }
 inline const ::std::string& OpDef_ArgDef::type_attr() const {
-  // @@protoc_insertion_point(field_get:tensorflow.OpDef.ArgDef.type_attr)
+  // @@protoc_insertion_point(field_get:opencv_tensorflow.OpDef.ArgDef.type_attr)
   return type_attr_.Get();
 }
 inline void OpDef_ArgDef::set_type_attr(const ::std::string& value) {
 
   type_attr_.Set(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), value, GetArenaNoVirtual());
-  // @@protoc_insertion_point(field_set:tensorflow.OpDef.ArgDef.type_attr)
+  // @@protoc_insertion_point(field_set:opencv_tensorflow.OpDef.ArgDef.type_attr)
 }
 #if LANG_CXX11
 inline void OpDef_ArgDef::set_type_attr(::std::string&& value) {
 
   type_attr_.Set(
     &::google::protobuf::internal::GetEmptyStringAlreadyInited(), ::std::move(value), GetArenaNoVirtual());
-  // @@protoc_insertion_point(field_set_rvalue:tensorflow.OpDef.ArgDef.type_attr)
+  // @@protoc_insertion_point(field_set_rvalue:opencv_tensorflow.OpDef.ArgDef.type_attr)
 }
 #endif
 inline void OpDef_ArgDef::set_type_attr(const char* value) {
@@ -1271,22 +1271,22 @@ inline void OpDef_ArgDef::set_type_attr(const char* value) {
 
   type_attr_.Set(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), ::std::string(value),
               GetArenaNoVirtual());
-  // @@protoc_insertion_point(field_set_char:tensorflow.OpDef.ArgDef.type_attr)
+  // @@protoc_insertion_point(field_set_char:opencv_tensorflow.OpDef.ArgDef.type_attr)
 }
 inline void OpDef_ArgDef::set_type_attr(const char* value,
     size_t size) {
 
   type_attr_.Set(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), ::std::string(
       reinterpret_cast<const char*>(value), size), GetArenaNoVirtual());
-  // @@protoc_insertion_point(field_set_pointer:tensorflow.OpDef.ArgDef.type_attr)
+  // @@protoc_insertion_point(field_set_pointer:opencv_tensorflow.OpDef.ArgDef.type_attr)
 }
 inline ::std::string* OpDef_ArgDef::mutable_type_attr() {
 
-  // @@protoc_insertion_point(field_mutable:tensorflow.OpDef.ArgDef.type_attr)
+  // @@protoc_insertion_point(field_mutable:opencv_tensorflow.OpDef.ArgDef.type_attr)
   return type_attr_.Mutable(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), GetArenaNoVirtual());
 }
 inline ::std::string* OpDef_ArgDef::release_type_attr() {
-  // @@protoc_insertion_point(field_release:tensorflow.OpDef.ArgDef.type_attr)
+  // @@protoc_insertion_point(field_release:opencv_tensorflow.OpDef.ArgDef.type_attr)
 
   return type_attr_.Release(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), GetArenaNoVirtual());
 }
@@ -1298,10 +1298,10 @@ inline void OpDef_ArgDef::set_allocated_type_attr(::std::string* type_attr) {
   }
   type_attr_.SetAllocated(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), type_attr,
       GetArenaNoVirtual());
-  // @@protoc_insertion_point(field_set_allocated:tensorflow.OpDef.ArgDef.type_attr)
+  // @@protoc_insertion_point(field_set_allocated:opencv_tensorflow.OpDef.ArgDef.type_attr)
 }
 inline ::std::string* OpDef_ArgDef::unsafe_arena_release_type_attr() {
-  // @@protoc_insertion_point(field_unsafe_arena_release:tensorflow.OpDef.ArgDef.type_attr)
+  // @@protoc_insertion_point(field_unsafe_arena_release:opencv_tensorflow.OpDef.ArgDef.type_attr)
   GOOGLE_DCHECK(GetArenaNoVirtual() != NULL);
 
   return type_attr_.UnsafeArenaRelease(&::google::protobuf::internal::GetEmptyStringAlreadyInited(),
@@ -1317,7 +1317,7 @@ inline void OpDef_ArgDef::unsafe_arena_set_allocated_type_attr(
   }
   type_attr_.UnsafeArenaSetAllocated(&::google::protobuf::internal::GetEmptyStringAlreadyInited(),
       type_attr, GetArenaNoVirtual());
-  // @@protoc_insertion_point(field_unsafe_arena_set_allocated:tensorflow.OpDef.ArgDef.type_attr)
+  // @@protoc_insertion_point(field_unsafe_arena_set_allocated:opencv_tensorflow.OpDef.ArgDef.type_attr)
 }
 
 // string number_attr = 5;
@@ -1325,20 +1325,20 @@ inline void OpDef_ArgDef::clear_number_attr() {
   number_attr_.ClearToEmpty(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), GetArenaNoVirtual());
 }
 inline const ::std::string& OpDef_ArgDef::number_attr() const {
-  // @@protoc_insertion_point(field_get:tensorflow.OpDef.ArgDef.number_attr)
+  // @@protoc_insertion_point(field_get:opencv_tensorflow.OpDef.ArgDef.number_attr)
   return number_attr_.Get();
 }
 inline void OpDef_ArgDef::set_number_attr(const ::std::string& value) {
 
   number_attr_.Set(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), value, GetArenaNoVirtual());
-  // @@protoc_insertion_point(field_set:tensorflow.OpDef.ArgDef.number_attr)
+  // @@protoc_insertion_point(field_set:opencv_tensorflow.OpDef.ArgDef.number_attr)
 }
 #if LANG_CXX11
 inline void OpDef_ArgDef::set_number_attr(::std::string&& value) {
 
   number_attr_.Set(
     &::google::protobuf::internal::GetEmptyStringAlreadyInited(), ::std::move(value), GetArenaNoVirtual());
-  // @@protoc_insertion_point(field_set_rvalue:tensorflow.OpDef.ArgDef.number_attr)
+  // @@protoc_insertion_point(field_set_rvalue:opencv_tensorflow.OpDef.ArgDef.number_attr)
 }
 #endif
 inline void OpDef_ArgDef::set_number_attr(const char* value) {
@@ -1346,22 +1346,22 @@ inline void OpDef_ArgDef::set_number_attr(const char* value) {
 
   number_attr_.Set(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), ::std::string(value),
               GetArenaNoVirtual());
-  // @@protoc_insertion_point(field_set_char:tensorflow.OpDef.ArgDef.number_attr)
+  // @@protoc_insertion_point(field_set_char:opencv_tensorflow.OpDef.ArgDef.number_attr)
 }
 inline void OpDef_ArgDef::set_number_attr(const char* value,
     size_t size) {
 
   number_attr_.Set(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), ::std::string(
       reinterpret_cast<const char*>(value), size), GetArenaNoVirtual());
-  // @@protoc_insertion_point(field_set_pointer:tensorflow.OpDef.ArgDef.number_attr)
+  // @@protoc_insertion_point(field_set_pointer:opencv_tensorflow.OpDef.ArgDef.number_attr)
 }
 inline ::std::string* OpDef_ArgDef::mutable_number_attr() {
 
-  // @@protoc_insertion_point(field_mutable:tensorflow.OpDef.ArgDef.number_attr)
+  // @@protoc_insertion_point(field_mutable:opencv_tensorflow.OpDef.ArgDef.number_attr)
   return number_attr_.Mutable(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), GetArenaNoVirtual());
 }
 inline ::std::string* OpDef_ArgDef::release_number_attr() {
-  // @@protoc_insertion_point(field_release:tensorflow.OpDef.ArgDef.number_attr)
+  // @@protoc_insertion_point(field_release:opencv_tensorflow.OpDef.ArgDef.number_attr)
 
   return number_attr_.Release(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), GetArenaNoVirtual());
 }
@@ -1373,10 +1373,10 @@ inline void OpDef_ArgDef::set_allocated_number_attr(::std::string* number_attr) 
   }
   number_attr_.SetAllocated(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), number_attr,
       GetArenaNoVirtual());
-  // @@protoc_insertion_point(field_set_allocated:tensorflow.OpDef.ArgDef.number_attr)
+  // @@protoc_insertion_point(field_set_allocated:opencv_tensorflow.OpDef.ArgDef.number_attr)
 }
 inline ::std::string* OpDef_ArgDef::unsafe_arena_release_number_attr() {
-  // @@protoc_insertion_point(field_unsafe_arena_release:tensorflow.OpDef.ArgDef.number_attr)
+  // @@protoc_insertion_point(field_unsafe_arena_release:opencv_tensorflow.OpDef.ArgDef.number_attr)
   GOOGLE_DCHECK(GetArenaNoVirtual() != NULL);
 
   return number_attr_.UnsafeArenaRelease(&::google::protobuf::internal::GetEmptyStringAlreadyInited(),
@@ -1392,7 +1392,7 @@ inline void OpDef_ArgDef::unsafe_arena_set_allocated_number_attr(
   }
   number_attr_.UnsafeArenaSetAllocated(&::google::protobuf::internal::GetEmptyStringAlreadyInited(),
       number_attr, GetArenaNoVirtual());
-  // @@protoc_insertion_point(field_unsafe_arena_set_allocated:tensorflow.OpDef.ArgDef.number_attr)
+  // @@protoc_insertion_point(field_unsafe_arena_set_allocated:opencv_tensorflow.OpDef.ArgDef.number_attr)
 }
 
 // string type_list_attr = 6;
@@ -1400,20 +1400,20 @@ inline void OpDef_ArgDef::clear_type_list_attr() {
   type_list_attr_.ClearToEmpty(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), GetArenaNoVirtual());
 }
 inline const ::std::string& OpDef_ArgDef::type_list_attr() const {
-  // @@protoc_insertion_point(field_get:tensorflow.OpDef.ArgDef.type_list_attr)
+  // @@protoc_insertion_point(field_get:opencv_tensorflow.OpDef.ArgDef.type_list_attr)
   return type_list_attr_.Get();
 }
 inline void OpDef_ArgDef::set_type_list_attr(const ::std::string& value) {
 
   type_list_attr_.Set(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), value, GetArenaNoVirtual());
-  // @@protoc_insertion_point(field_set:tensorflow.OpDef.ArgDef.type_list_attr)
+  // @@protoc_insertion_point(field_set:opencv_tensorflow.OpDef.ArgDef.type_list_attr)
 }
 #if LANG_CXX11
 inline void OpDef_ArgDef::set_type_list_attr(::std::string&& value) {
 
   type_list_attr_.Set(
     &::google::protobuf::internal::GetEmptyStringAlreadyInited(), ::std::move(value), GetArenaNoVirtual());
-  // @@protoc_insertion_point(field_set_rvalue:tensorflow.OpDef.ArgDef.type_list_attr)
+  // @@protoc_insertion_point(field_set_rvalue:opencv_tensorflow.OpDef.ArgDef.type_list_attr)
 }
 #endif
 inline void OpDef_ArgDef::set_type_list_attr(const char* value) {
@@ -1421,22 +1421,22 @@ inline void OpDef_ArgDef::set_type_list_attr(const char* value) {
 
   type_list_attr_.Set(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), ::std::string(value),
               GetArenaNoVirtual());
-  // @@protoc_insertion_point(field_set_char:tensorflow.OpDef.ArgDef.type_list_attr)
+  // @@protoc_insertion_point(field_set_char:opencv_tensorflow.OpDef.ArgDef.type_list_attr)
 }
 inline void OpDef_ArgDef::set_type_list_attr(const char* value,
     size_t size) {
 
   type_list_attr_.Set(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), ::std::string(
       reinterpret_cast<const char*>(value), size), GetArenaNoVirtual());
-  // @@protoc_insertion_point(field_set_pointer:tensorflow.OpDef.ArgDef.type_list_attr)
+  // @@protoc_insertion_point(field_set_pointer:opencv_tensorflow.OpDef.ArgDef.type_list_attr)
 }
 inline ::std::string* OpDef_ArgDef::mutable_type_list_attr() {
 
-  // @@protoc_insertion_point(field_mutable:tensorflow.OpDef.ArgDef.type_list_attr)
+  // @@protoc_insertion_point(field_mutable:opencv_tensorflow.OpDef.ArgDef.type_list_attr)
   return type_list_attr_.Mutable(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), GetArenaNoVirtual());
 }
 inline ::std::string* OpDef_ArgDef::release_type_list_attr() {
-  // @@protoc_insertion_point(field_release:tensorflow.OpDef.ArgDef.type_list_attr)
+  // @@protoc_insertion_point(field_release:opencv_tensorflow.OpDef.ArgDef.type_list_attr)
 
   return type_list_attr_.Release(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), GetArenaNoVirtual());
 }
@@ -1448,10 +1448,10 @@ inline void OpDef_ArgDef::set_allocated_type_list_attr(::std::string* type_list_
   }
   type_list_attr_.SetAllocated(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), type_list_attr,
       GetArenaNoVirtual());
-  // @@protoc_insertion_point(field_set_allocated:tensorflow.OpDef.ArgDef.type_list_attr)
+  // @@protoc_insertion_point(field_set_allocated:opencv_tensorflow.OpDef.ArgDef.type_list_attr)
 }
 inline ::std::string* OpDef_ArgDef::unsafe_arena_release_type_list_attr() {
-  // @@protoc_insertion_point(field_unsafe_arena_release:tensorflow.OpDef.ArgDef.type_list_attr)
+  // @@protoc_insertion_point(field_unsafe_arena_release:opencv_tensorflow.OpDef.ArgDef.type_list_attr)
   GOOGLE_DCHECK(GetArenaNoVirtual() != NULL);
 
   return type_list_attr_.UnsafeArenaRelease(&::google::protobuf::internal::GetEmptyStringAlreadyInited(),
@@ -1467,7 +1467,7 @@ inline void OpDef_ArgDef::unsafe_arena_set_allocated_type_list_attr(
   }
   type_list_attr_.UnsafeArenaSetAllocated(&::google::protobuf::internal::GetEmptyStringAlreadyInited(),
       type_list_attr, GetArenaNoVirtual());
-  // @@protoc_insertion_point(field_unsafe_arena_set_allocated:tensorflow.OpDef.ArgDef.type_list_attr)
+  // @@protoc_insertion_point(field_unsafe_arena_set_allocated:opencv_tensorflow.OpDef.ArgDef.type_list_attr)
 }
 
 // bool is_ref = 16;
@@ -1475,13 +1475,13 @@ inline void OpDef_ArgDef::clear_is_ref() {
   is_ref_ = false;
 }
 inline bool OpDef_ArgDef::is_ref() const {
-  // @@protoc_insertion_point(field_get:tensorflow.OpDef.ArgDef.is_ref)
+  // @@protoc_insertion_point(field_get:opencv_tensorflow.OpDef.ArgDef.is_ref)
   return is_ref_;
 }
 inline void OpDef_ArgDef::set_is_ref(bool value) {
 
   is_ref_ = value;
-  // @@protoc_insertion_point(field_set:tensorflow.OpDef.ArgDef.is_ref)
+  // @@protoc_insertion_point(field_set:opencv_tensorflow.OpDef.ArgDef.is_ref)
 }
 
 // -------------------------------------------------------------------
@@ -1493,20 +1493,20 @@ inline void OpDef_AttrDef::clear_name() {
   name_.ClearToEmpty(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), GetArenaNoVirtual());
 }
 inline const ::std::string& OpDef_AttrDef::name() const {
-  // @@protoc_insertion_point(field_get:tensorflow.OpDef.AttrDef.name)
+  // @@protoc_insertion_point(field_get:opencv_tensorflow.OpDef.AttrDef.name)
   return name_.Get();
 }
 inline void OpDef_AttrDef::set_name(const ::std::string& value) {
 
   name_.Set(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), value, GetArenaNoVirtual());
-  // @@protoc_insertion_point(field_set:tensorflow.OpDef.AttrDef.name)
+  // @@protoc_insertion_point(field_set:opencv_tensorflow.OpDef.AttrDef.name)
 }
 #if LANG_CXX11
 inline void OpDef_AttrDef::set_name(::std::string&& value) {
 
   name_.Set(
     &::google::protobuf::internal::GetEmptyStringAlreadyInited(), ::std::move(value), GetArenaNoVirtual());
-  // @@protoc_insertion_point(field_set_rvalue:tensorflow.OpDef.AttrDef.name)
+  // @@protoc_insertion_point(field_set_rvalue:opencv_tensorflow.OpDef.AttrDef.name)
 }
 #endif
 inline void OpDef_AttrDef::set_name(const char* value) {
@@ -1514,22 +1514,22 @@ inline void OpDef_AttrDef::set_name(const char* value) {
 
   name_.Set(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), ::std::string(value),
               GetArenaNoVirtual());
-  // @@protoc_insertion_point(field_set_char:tensorflow.OpDef.AttrDef.name)
+  // @@protoc_insertion_point(field_set_char:opencv_tensorflow.OpDef.AttrDef.name)
 }
 inline void OpDef_AttrDef::set_name(const char* value,
     size_t size) {
 
   name_.Set(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), ::std::string(
       reinterpret_cast<const char*>(value), size), GetArenaNoVirtual());
-  // @@protoc_insertion_point(field_set_pointer:tensorflow.OpDef.AttrDef.name)
+  // @@protoc_insertion_point(field_set_pointer:opencv_tensorflow.OpDef.AttrDef.name)
 }
 inline ::std::string* OpDef_AttrDef::mutable_name() {
 
-  // @@protoc_insertion_point(field_mutable:tensorflow.OpDef.AttrDef.name)
+  // @@protoc_insertion_point(field_mutable:opencv_tensorflow.OpDef.AttrDef.name)
   return name_.Mutable(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), GetArenaNoVirtual());
 }
 inline ::std::string* OpDef_AttrDef::release_name() {
-  // @@protoc_insertion_point(field_release:tensorflow.OpDef.AttrDef.name)
+  // @@protoc_insertion_point(field_release:opencv_tensorflow.OpDef.AttrDef.name)
 
   return name_.Release(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), GetArenaNoVirtual());
 }
@@ -1541,10 +1541,10 @@ inline void OpDef_AttrDef::set_allocated_name(::std::string* name) {
   }
   name_.SetAllocated(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), name,
       GetArenaNoVirtual());
-  // @@protoc_insertion_point(field_set_allocated:tensorflow.OpDef.AttrDef.name)
+  // @@protoc_insertion_point(field_set_allocated:opencv_tensorflow.OpDef.AttrDef.name)
 }
 inline ::std::string* OpDef_AttrDef::unsafe_arena_release_name() {
-  // @@protoc_insertion_point(field_unsafe_arena_release:tensorflow.OpDef.AttrDef.name)
+  // @@protoc_insertion_point(field_unsafe_arena_release:opencv_tensorflow.OpDef.AttrDef.name)
   GOOGLE_DCHECK(GetArenaNoVirtual() != NULL);
 
   return name_.UnsafeArenaRelease(&::google::protobuf::internal::GetEmptyStringAlreadyInited(),
@@ -1560,7 +1560,7 @@ inline void OpDef_AttrDef::unsafe_arena_set_allocated_name(
   }
   name_.UnsafeArenaSetAllocated(&::google::protobuf::internal::GetEmptyStringAlreadyInited(),
       name, GetArenaNoVirtual());
-  // @@protoc_insertion_point(field_unsafe_arena_set_allocated:tensorflow.OpDef.AttrDef.name)
+  // @@protoc_insertion_point(field_unsafe_arena_set_allocated:opencv_tensorflow.OpDef.AttrDef.name)
 }
 
 // string type = 2;
@@ -1568,20 +1568,20 @@ inline void OpDef_AttrDef::clear_type() {
   type_.ClearToEmpty(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), GetArenaNoVirtual());
 }
 inline const ::std::string& OpDef_AttrDef::type() const {
-  // @@protoc_insertion_point(field_get:tensorflow.OpDef.AttrDef.type)
+  // @@protoc_insertion_point(field_get:opencv_tensorflow.OpDef.AttrDef.type)
   return type_.Get();
 }
 inline void OpDef_AttrDef::set_type(const ::std::string& value) {
 
   type_.Set(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), value, GetArenaNoVirtual());
-  // @@protoc_insertion_point(field_set:tensorflow.OpDef.AttrDef.type)
+  // @@protoc_insertion_point(field_set:opencv_tensorflow.OpDef.AttrDef.type)
 }
 #if LANG_CXX11
 inline void OpDef_AttrDef::set_type(::std::string&& value) {
 
   type_.Set(
     &::google::protobuf::internal::GetEmptyStringAlreadyInited(), ::std::move(value), GetArenaNoVirtual());
-  // @@protoc_insertion_point(field_set_rvalue:tensorflow.OpDef.AttrDef.type)
+  // @@protoc_insertion_point(field_set_rvalue:opencv_tensorflow.OpDef.AttrDef.type)
 }
 #endif
 inline void OpDef_AttrDef::set_type(const char* value) {
@@ -1589,22 +1589,22 @@ inline void OpDef_AttrDef::set_type(const char* value) {
 
   type_.Set(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), ::std::string(value),
               GetArenaNoVirtual());
-  // @@protoc_insertion_point(field_set_char:tensorflow.OpDef.AttrDef.type)
+  // @@protoc_insertion_point(field_set_char:opencv_tensorflow.OpDef.AttrDef.type)
 }
 inline void OpDef_AttrDef::set_type(const char* value,
     size_t size) {
 
   type_.Set(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), ::std::string(
       reinterpret_cast<const char*>(value), size), GetArenaNoVirtual());
-  // @@protoc_insertion_point(field_set_pointer:tensorflow.OpDef.AttrDef.type)
+  // @@protoc_insertion_point(field_set_pointer:opencv_tensorflow.OpDef.AttrDef.type)
 }
 inline ::std::string* OpDef_AttrDef::mutable_type() {
 
-  // @@protoc_insertion_point(field_mutable:tensorflow.OpDef.AttrDef.type)
+  // @@protoc_insertion_point(field_mutable:opencv_tensorflow.OpDef.AttrDef.type)
   return type_.Mutable(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), GetArenaNoVirtual());
 }
 inline ::std::string* OpDef_AttrDef::release_type() {
-  // @@protoc_insertion_point(field_release:tensorflow.OpDef.AttrDef.type)
+  // @@protoc_insertion_point(field_release:opencv_tensorflow.OpDef.AttrDef.type)
 
   return type_.Release(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), GetArenaNoVirtual());
 }
@@ -1616,10 +1616,10 @@ inline void OpDef_AttrDef::set_allocated_type(::std::string* type) {
   }
   type_.SetAllocated(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), type,
       GetArenaNoVirtual());
-  // @@protoc_insertion_point(field_set_allocated:tensorflow.OpDef.AttrDef.type)
+  // @@protoc_insertion_point(field_set_allocated:opencv_tensorflow.OpDef.AttrDef.type)
 }
 inline ::std::string* OpDef_AttrDef::unsafe_arena_release_type() {
-  // @@protoc_insertion_point(field_unsafe_arena_release:tensorflow.OpDef.AttrDef.type)
+  // @@protoc_insertion_point(field_unsafe_arena_release:opencv_tensorflow.OpDef.AttrDef.type)
   GOOGLE_DCHECK(GetArenaNoVirtual() != NULL);
 
   return type_.UnsafeArenaRelease(&::google::protobuf::internal::GetEmptyStringAlreadyInited(),
@@ -1635,45 +1635,45 @@ inline void OpDef_AttrDef::unsafe_arena_set_allocated_type(
   }
   type_.UnsafeArenaSetAllocated(&::google::protobuf::internal::GetEmptyStringAlreadyInited(),
       type, GetArenaNoVirtual());
-  // @@protoc_insertion_point(field_unsafe_arena_set_allocated:tensorflow.OpDef.AttrDef.type)
+  // @@protoc_insertion_point(field_unsafe_arena_set_allocated:opencv_tensorflow.OpDef.AttrDef.type)
 }
 
-// .tensorflow.AttrValue default_value = 3;
+// .opencv_tensorflow.AttrValue default_value = 3;
 inline bool OpDef_AttrDef::has_default_value() const {
   return this != internal_default_instance() && default_value_ != NULL;
 }
-inline const ::tensorflow::AttrValue& OpDef_AttrDef::default_value() const {
-  const ::tensorflow::AttrValue* p = default_value_;
-  // @@protoc_insertion_point(field_get:tensorflow.OpDef.AttrDef.default_value)
-  return p != NULL ? *p : *reinterpret_cast<const ::tensorflow::AttrValue*>(
-      &::tensorflow::_AttrValue_default_instance_);
+inline const ::opencv_tensorflow::AttrValue& OpDef_AttrDef::default_value() const {
+  const ::opencv_tensorflow::AttrValue* p = default_value_;
+  // @@protoc_insertion_point(field_get:opencv_tensorflow.OpDef.AttrDef.default_value)
+  return p != NULL ? *p : *reinterpret_cast<const ::opencv_tensorflow::AttrValue*>(
+      &::opencv_tensorflow::_AttrValue_default_instance_);
 }
-inline ::tensorflow::AttrValue* OpDef_AttrDef::release_default_value() {
-  // @@protoc_insertion_point(field_release:tensorflow.OpDef.AttrDef.default_value)
+inline ::opencv_tensorflow::AttrValue* OpDef_AttrDef::release_default_value() {
+  // @@protoc_insertion_point(field_release:opencv_tensorflow.OpDef.AttrDef.default_value)
 
-  ::tensorflow::AttrValue* temp = default_value_;
+  ::opencv_tensorflow::AttrValue* temp = default_value_;
   if (GetArenaNoVirtual() != NULL) {
     temp = ::google::protobuf::internal::DuplicateIfNonNull(temp, NULL);
   }
   default_value_ = NULL;
   return temp;
 }
-inline ::tensorflow::AttrValue* OpDef_AttrDef::unsafe_arena_release_default_value() {
-  // @@protoc_insertion_point(field_unsafe_arena_release:tensorflow.OpDef.AttrDef.default_value)
+inline ::opencv_tensorflow::AttrValue* OpDef_AttrDef::unsafe_arena_release_default_value() {
+  // @@protoc_insertion_point(field_unsafe_arena_release:opencv_tensorflow.OpDef.AttrDef.default_value)
 
-  ::tensorflow::AttrValue* temp = default_value_;
+  ::opencv_tensorflow::AttrValue* temp = default_value_;
   default_value_ = NULL;
   return temp;
 }
-inline ::tensorflow::AttrValue* OpDef_AttrDef::mutable_default_value() {
+inline ::opencv_tensorflow::AttrValue* OpDef_AttrDef::mutable_default_value() {
 
   if (default_value_ == NULL) {
     _slow_mutable_default_value();
   }
-  // @@protoc_insertion_point(field_mutable:tensorflow.OpDef.AttrDef.default_value)
+  // @@protoc_insertion_point(field_mutable:opencv_tensorflow.OpDef.AttrDef.default_value)
   return default_value_;
 }
-inline void OpDef_AttrDef::set_allocated_default_value(::tensorflow::AttrValue* default_value) {
+inline void OpDef_AttrDef::set_allocated_default_value(::opencv_tensorflow::AttrValue* default_value) {
   ::google::protobuf::Arena* message_arena = GetArenaNoVirtual();
   if (message_arena == NULL) {
     delete reinterpret_cast< ::google::protobuf::MessageLite*>(default_value_);
@@ -1690,7 +1690,7 @@ inline void OpDef_AttrDef::set_allocated_default_value(::tensorflow::AttrValue* 
 
   }
   default_value_ = default_value;
-  // @@protoc_insertion_point(field_set_allocated:tensorflow.OpDef.AttrDef.default_value)
+  // @@protoc_insertion_point(field_set_allocated:opencv_tensorflow.OpDef.AttrDef.default_value)
 }
 
 // string description = 4;
@@ -1698,20 +1698,20 @@ inline void OpDef_AttrDef::clear_description() {
   description_.ClearToEmpty(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), GetArenaNoVirtual());
 }
 inline const ::std::string& OpDef_AttrDef::description() const {
-  // @@protoc_insertion_point(field_get:tensorflow.OpDef.AttrDef.description)
+  // @@protoc_insertion_point(field_get:opencv_tensorflow.OpDef.AttrDef.description)
   return description_.Get();
 }
 inline void OpDef_AttrDef::set_description(const ::std::string& value) {
 
   description_.Set(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), value, GetArenaNoVirtual());
-  // @@protoc_insertion_point(field_set:tensorflow.OpDef.AttrDef.description)
+  // @@protoc_insertion_point(field_set:opencv_tensorflow.OpDef.AttrDef.description)
 }
 #if LANG_CXX11
 inline void OpDef_AttrDef::set_description(::std::string&& value) {
 
   description_.Set(
     &::google::protobuf::internal::GetEmptyStringAlreadyInited(), ::std::move(value), GetArenaNoVirtual());
-  // @@protoc_insertion_point(field_set_rvalue:tensorflow.OpDef.AttrDef.description)
+  // @@protoc_insertion_point(field_set_rvalue:opencv_tensorflow.OpDef.AttrDef.description)
 }
 #endif
 inline void OpDef_AttrDef::set_description(const char* value) {
@@ -1719,22 +1719,22 @@ inline void OpDef_AttrDef::set_description(const char* value) {
 
   description_.Set(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), ::std::string(value),
               GetArenaNoVirtual());
-  // @@protoc_insertion_point(field_set_char:tensorflow.OpDef.AttrDef.description)
+  // @@protoc_insertion_point(field_set_char:opencv_tensorflow.OpDef.AttrDef.description)
 }
 inline void OpDef_AttrDef::set_description(const char* value,
     size_t size) {
 
   description_.Set(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), ::std::string(
       reinterpret_cast<const char*>(value), size), GetArenaNoVirtual());
-  // @@protoc_insertion_point(field_set_pointer:tensorflow.OpDef.AttrDef.description)
+  // @@protoc_insertion_point(field_set_pointer:opencv_tensorflow.OpDef.AttrDef.description)
 }
 inline ::std::string* OpDef_AttrDef::mutable_description() {
 
-  // @@protoc_insertion_point(field_mutable:tensorflow.OpDef.AttrDef.description)
+  // @@protoc_insertion_point(field_mutable:opencv_tensorflow.OpDef.AttrDef.description)
   return description_.Mutable(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), GetArenaNoVirtual());
 }
 inline ::std::string* OpDef_AttrDef::release_description() {
-  // @@protoc_insertion_point(field_release:tensorflow.OpDef.AttrDef.description)
+  // @@protoc_insertion_point(field_release:opencv_tensorflow.OpDef.AttrDef.description)
 
   return description_.Release(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), GetArenaNoVirtual());
 }
@@ -1746,10 +1746,10 @@ inline void OpDef_AttrDef::set_allocated_description(::std::string* description)
   }
   description_.SetAllocated(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), description,
       GetArenaNoVirtual());
-  // @@protoc_insertion_point(field_set_allocated:tensorflow.OpDef.AttrDef.description)
+  // @@protoc_insertion_point(field_set_allocated:opencv_tensorflow.OpDef.AttrDef.description)
 }
 inline ::std::string* OpDef_AttrDef::unsafe_arena_release_description() {
-  // @@protoc_insertion_point(field_unsafe_arena_release:tensorflow.OpDef.AttrDef.description)
+  // @@protoc_insertion_point(field_unsafe_arena_release:opencv_tensorflow.OpDef.AttrDef.description)
   GOOGLE_DCHECK(GetArenaNoVirtual() != NULL);
 
   return description_.UnsafeArenaRelease(&::google::protobuf::internal::GetEmptyStringAlreadyInited(),
@@ -1765,7 +1765,7 @@ inline void OpDef_AttrDef::unsafe_arena_set_allocated_description(
   }
   description_.UnsafeArenaSetAllocated(&::google::protobuf::internal::GetEmptyStringAlreadyInited(),
       description, GetArenaNoVirtual());
-  // @@protoc_insertion_point(field_unsafe_arena_set_allocated:tensorflow.OpDef.AttrDef.description)
+  // @@protoc_insertion_point(field_unsafe_arena_set_allocated:opencv_tensorflow.OpDef.AttrDef.description)
 }
 
 // bool has_minimum = 5;
@@ -1773,13 +1773,13 @@ inline void OpDef_AttrDef::clear_has_minimum() {
   has_minimum_ = false;
 }
 inline bool OpDef_AttrDef::has_minimum() const {
-  // @@protoc_insertion_point(field_get:tensorflow.OpDef.AttrDef.has_minimum)
+  // @@protoc_insertion_point(field_get:opencv_tensorflow.OpDef.AttrDef.has_minimum)
   return has_minimum_;
 }
 inline void OpDef_AttrDef::set_has_minimum(bool value) {
 
   has_minimum_ = value;
-  // @@protoc_insertion_point(field_set:tensorflow.OpDef.AttrDef.has_minimum)
+  // @@protoc_insertion_point(field_set:opencv_tensorflow.OpDef.AttrDef.has_minimum)
 }
 
 // int64 minimum = 6;
@@ -1787,51 +1787,51 @@ inline void OpDef_AttrDef::clear_minimum() {
   minimum_ = GOOGLE_LONGLONG(0);
 }
 inline ::google::protobuf::int64 OpDef_AttrDef::minimum() const {
-  // @@protoc_insertion_point(field_get:tensorflow.OpDef.AttrDef.minimum)
+  // @@protoc_insertion_point(field_get:opencv_tensorflow.OpDef.AttrDef.minimum)
   return minimum_;
 }
 inline void OpDef_AttrDef::set_minimum(::google::protobuf::int64 value) {
 
   minimum_ = value;
-  // @@protoc_insertion_point(field_set:tensorflow.OpDef.AttrDef.minimum)
+  // @@protoc_insertion_point(field_set:opencv_tensorflow.OpDef.AttrDef.minimum)
 }
 
-// .tensorflow.AttrValue allowed_values = 7;
+// .opencv_tensorflow.AttrValue allowed_values = 7;
 inline bool OpDef_AttrDef::has_allowed_values() const {
   return this != internal_default_instance() && allowed_values_ != NULL;
 }
-inline const ::tensorflow::AttrValue& OpDef_AttrDef::allowed_values() const {
-  const ::tensorflow::AttrValue* p = allowed_values_;
-  // @@protoc_insertion_point(field_get:tensorflow.OpDef.AttrDef.allowed_values)
-  return p != NULL ? *p : *reinterpret_cast<const ::tensorflow::AttrValue*>(
-      &::tensorflow::_AttrValue_default_instance_);
+inline const ::opencv_tensorflow::AttrValue& OpDef_AttrDef::allowed_values() const {
+  const ::opencv_tensorflow::AttrValue* p = allowed_values_;
+  // @@protoc_insertion_point(field_get:opencv_tensorflow.OpDef.AttrDef.allowed_values)
+  return p != NULL ? *p : *reinterpret_cast<const ::opencv_tensorflow::AttrValue*>(
+      &::opencv_tensorflow::_AttrValue_default_instance_);
 }
-inline ::tensorflow::AttrValue* OpDef_AttrDef::release_allowed_values() {
-  // @@protoc_insertion_point(field_release:tensorflow.OpDef.AttrDef.allowed_values)
+inline ::opencv_tensorflow::AttrValue* OpDef_AttrDef::release_allowed_values() {
+  // @@protoc_insertion_point(field_release:opencv_tensorflow.OpDef.AttrDef.allowed_values)
 
-  ::tensorflow::AttrValue* temp = allowed_values_;
+  ::opencv_tensorflow::AttrValue* temp = allowed_values_;
   if (GetArenaNoVirtual() != NULL) {
     temp = ::google::protobuf::internal::DuplicateIfNonNull(temp, NULL);
   }
   allowed_values_ = NULL;
   return temp;
 }
-inline ::tensorflow::AttrValue* OpDef_AttrDef::unsafe_arena_release_allowed_values() {
-  // @@protoc_insertion_point(field_unsafe_arena_release:tensorflow.OpDef.AttrDef.allowed_values)
+inline ::opencv_tensorflow::AttrValue* OpDef_AttrDef::unsafe_arena_release_allowed_values() {
+  // @@protoc_insertion_point(field_unsafe_arena_release:opencv_tensorflow.OpDef.AttrDef.allowed_values)
 
-  ::tensorflow::AttrValue* temp = allowed_values_;
+  ::opencv_tensorflow::AttrValue* temp = allowed_values_;
   allowed_values_ = NULL;
   return temp;
 }
-inline ::tensorflow::AttrValue* OpDef_AttrDef::mutable_allowed_values() {
+inline ::opencv_tensorflow::AttrValue* OpDef_AttrDef::mutable_allowed_values() {
 
   if (allowed_values_ == NULL) {
     _slow_mutable_allowed_values();
   }
-  // @@protoc_insertion_point(field_mutable:tensorflow.OpDef.AttrDef.allowed_values)
+  // @@protoc_insertion_point(field_mutable:opencv_tensorflow.OpDef.AttrDef.allowed_values)
   return allowed_values_;
 }
-inline void OpDef_AttrDef::set_allocated_allowed_values(::tensorflow::AttrValue* allowed_values) {
+inline void OpDef_AttrDef::set_allocated_allowed_values(::opencv_tensorflow::AttrValue* allowed_values) {
   ::google::protobuf::Arena* message_arena = GetArenaNoVirtual();
   if (message_arena == NULL) {
     delete reinterpret_cast< ::google::protobuf::MessageLite*>(allowed_values_);
@@ -1848,7 +1848,7 @@ inline void OpDef_AttrDef::set_allocated_allowed_values(::tensorflow::AttrValue*
 
   }
   allowed_values_ = allowed_values;
-  // @@protoc_insertion_point(field_set_allocated:tensorflow.OpDef.AttrDef.allowed_values)
+  // @@protoc_insertion_point(field_set_allocated:opencv_tensorflow.OpDef.AttrDef.allowed_values)
 }
 
 // -------------------------------------------------------------------
@@ -1860,20 +1860,20 @@ inline void OpDef::clear_name() {
   name_.ClearToEmpty(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), GetArenaNoVirtual());
 }
 inline const ::std::string& OpDef::name() const {
-  // @@protoc_insertion_point(field_get:tensorflow.OpDef.name)
+  // @@protoc_insertion_point(field_get:opencv_tensorflow.OpDef.name)
   return name_.Get();
 }
 inline void OpDef::set_name(const ::std::string& value) {
 
   name_.Set(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), value, GetArenaNoVirtual());
-  // @@protoc_insertion_point(field_set:tensorflow.OpDef.name)
+  // @@protoc_insertion_point(field_set:opencv_tensorflow.OpDef.name)
 }
 #if LANG_CXX11
 inline void OpDef::set_name(::std::string&& value) {
 
   name_.Set(
     &::google::protobuf::internal::GetEmptyStringAlreadyInited(), ::std::move(value), GetArenaNoVirtual());
-  // @@protoc_insertion_point(field_set_rvalue:tensorflow.OpDef.name)
+  // @@protoc_insertion_point(field_set_rvalue:opencv_tensorflow.OpDef.name)
 }
 #endif
 inline void OpDef::set_name(const char* value) {
@@ -1881,22 +1881,22 @@ inline void OpDef::set_name(const char* value) {
 
   name_.Set(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), ::std::string(value),
               GetArenaNoVirtual());
-  // @@protoc_insertion_point(field_set_char:tensorflow.OpDef.name)
+  // @@protoc_insertion_point(field_set_char:opencv_tensorflow.OpDef.name)
 }
 inline void OpDef::set_name(const char* value,
     size_t size) {
 
   name_.Set(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), ::std::string(
       reinterpret_cast<const char*>(value), size), GetArenaNoVirtual());
-  // @@protoc_insertion_point(field_set_pointer:tensorflow.OpDef.name)
+  // @@protoc_insertion_point(field_set_pointer:opencv_tensorflow.OpDef.name)
 }
 inline ::std::string* OpDef::mutable_name() {
 
-  // @@protoc_insertion_point(field_mutable:tensorflow.OpDef.name)
+  // @@protoc_insertion_point(field_mutable:opencv_tensorflow.OpDef.name)
   return name_.Mutable(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), GetArenaNoVirtual());
 }
 inline ::std::string* OpDef::release_name() {
-  // @@protoc_insertion_point(field_release:tensorflow.OpDef.name)
+  // @@protoc_insertion_point(field_release:opencv_tensorflow.OpDef.name)
 
   return name_.Release(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), GetArenaNoVirtual());
 }
@@ -1908,10 +1908,10 @@ inline void OpDef::set_allocated_name(::std::string* name) {
   }
   name_.SetAllocated(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), name,
       GetArenaNoVirtual());
-  // @@protoc_insertion_point(field_set_allocated:tensorflow.OpDef.name)
+  // @@protoc_insertion_point(field_set_allocated:opencv_tensorflow.OpDef.name)
 }
 inline ::std::string* OpDef::unsafe_arena_release_name() {
-  // @@protoc_insertion_point(field_unsafe_arena_release:tensorflow.OpDef.name)
+  // @@protoc_insertion_point(field_unsafe_arena_release:opencv_tensorflow.OpDef.name)
   GOOGLE_DCHECK(GetArenaNoVirtual() != NULL);
 
   return name_.UnsafeArenaRelease(&::google::protobuf::internal::GetEmptyStringAlreadyInited(),
@@ -1927,100 +1927,100 @@ inline void OpDef::unsafe_arena_set_allocated_name(
   }
   name_.UnsafeArenaSetAllocated(&::google::protobuf::internal::GetEmptyStringAlreadyInited(),
       name, GetArenaNoVirtual());
-  // @@protoc_insertion_point(field_unsafe_arena_set_allocated:tensorflow.OpDef.name)
+  // @@protoc_insertion_point(field_unsafe_arena_set_allocated:opencv_tensorflow.OpDef.name)
 }
 
-// repeated .tensorflow.OpDef.ArgDef input_arg = 2;
+// repeated .opencv_tensorflow.OpDef.ArgDef input_arg = 2;
 inline int OpDef::input_arg_size() const {
   return input_arg_.size();
 }
 inline void OpDef::clear_input_arg() {
   input_arg_.Clear();
 }
-inline const ::tensorflow::OpDef_ArgDef& OpDef::input_arg(int index) const {
-  // @@protoc_insertion_point(field_get:tensorflow.OpDef.input_arg)
+inline const ::opencv_tensorflow::OpDef_ArgDef& OpDef::input_arg(int index) const {
+  // @@protoc_insertion_point(field_get:opencv_tensorflow.OpDef.input_arg)
   return input_arg_.Get(index);
 }
-inline ::tensorflow::OpDef_ArgDef* OpDef::mutable_input_arg(int index) {
-  // @@protoc_insertion_point(field_mutable:tensorflow.OpDef.input_arg)
+inline ::opencv_tensorflow::OpDef_ArgDef* OpDef::mutable_input_arg(int index) {
+  // @@protoc_insertion_point(field_mutable:opencv_tensorflow.OpDef.input_arg)
   return input_arg_.Mutable(index);
 }
-inline ::tensorflow::OpDef_ArgDef* OpDef::add_input_arg() {
-  // @@protoc_insertion_point(field_add:tensorflow.OpDef.input_arg)
+inline ::opencv_tensorflow::OpDef_ArgDef* OpDef::add_input_arg() {
+  // @@protoc_insertion_point(field_add:opencv_tensorflow.OpDef.input_arg)
   return input_arg_.Add();
 }
-inline ::google::protobuf::RepeatedPtrField< ::tensorflow::OpDef_ArgDef >*
+inline ::google::protobuf::RepeatedPtrField< ::opencv_tensorflow::OpDef_ArgDef >*
 OpDef::mutable_input_arg() {
-  // @@protoc_insertion_point(field_mutable_list:tensorflow.OpDef.input_arg)
+  // @@protoc_insertion_point(field_mutable_list:opencv_tensorflow.OpDef.input_arg)
   return &input_arg_;
 }
-inline const ::google::protobuf::RepeatedPtrField< ::tensorflow::OpDef_ArgDef >&
+inline const ::google::protobuf::RepeatedPtrField< ::opencv_tensorflow::OpDef_ArgDef >&
 OpDef::input_arg() const {
-  // @@protoc_insertion_point(field_list:tensorflow.OpDef.input_arg)
+  // @@protoc_insertion_point(field_list:opencv_tensorflow.OpDef.input_arg)
   return input_arg_;
 }
 
-// repeated .tensorflow.OpDef.ArgDef output_arg = 3;
+// repeated .opencv_tensorflow.OpDef.ArgDef output_arg = 3;
 inline int OpDef::output_arg_size() const {
   return output_arg_.size();
 }
 inline void OpDef::clear_output_arg() {
   output_arg_.Clear();
 }
-inline const ::tensorflow::OpDef_ArgDef& OpDef::output_arg(int index) const {
-  // @@protoc_insertion_point(field_get:tensorflow.OpDef.output_arg)
+inline const ::opencv_tensorflow::OpDef_ArgDef& OpDef::output_arg(int index) const {
+  // @@protoc_insertion_point(field_get:opencv_tensorflow.OpDef.output_arg)
   return output_arg_.Get(index);
 }
-inline ::tensorflow::OpDef_ArgDef* OpDef::mutable_output_arg(int index) {
-  // @@protoc_insertion_point(field_mutable:tensorflow.OpDef.output_arg)
+inline ::opencv_tensorflow::OpDef_ArgDef* OpDef::mutable_output_arg(int index) {
+  // @@protoc_insertion_point(field_mutable:opencv_tensorflow.OpDef.output_arg)
   return output_arg_.Mutable(index);
 }
-inline ::tensorflow::OpDef_ArgDef* OpDef::add_output_arg() {
-  // @@protoc_insertion_point(field_add:tensorflow.OpDef.output_arg)
+inline ::opencv_tensorflow::OpDef_ArgDef* OpDef::add_output_arg() {
+  // @@protoc_insertion_point(field_add:opencv_tensorflow.OpDef.output_arg)
   return output_arg_.Add();
 }
-inline ::google::protobuf::RepeatedPtrField< ::tensorflow::OpDef_ArgDef >*
+inline ::google::protobuf::RepeatedPtrField< ::opencv_tensorflow::OpDef_ArgDef >*
 OpDef::mutable_output_arg() {
-  // @@protoc_insertion_point(field_mutable_list:tensorflow.OpDef.output_arg)
+  // @@protoc_insertion_point(field_mutable_list:opencv_tensorflow.OpDef.output_arg)
   return &output_arg_;
 }
-inline const ::google::protobuf::RepeatedPtrField< ::tensorflow::OpDef_ArgDef >&
+inline const ::google::protobuf::RepeatedPtrField< ::opencv_tensorflow::OpDef_ArgDef >&
 OpDef::output_arg() const {
-  // @@protoc_insertion_point(field_list:tensorflow.OpDef.output_arg)
+  // @@protoc_insertion_point(field_list:opencv_tensorflow.OpDef.output_arg)
   return output_arg_;
 }
 
-// repeated .tensorflow.OpDef.AttrDef attr = 4;
+// repeated .opencv_tensorflow.OpDef.AttrDef attr = 4;
 inline int OpDef::attr_size() const {
   return attr_.size();
 }
 inline void OpDef::clear_attr() {
   attr_.Clear();
 }
-inline const ::tensorflow::OpDef_AttrDef& OpDef::attr(int index) const {
-  // @@protoc_insertion_point(field_get:tensorflow.OpDef.attr)
+inline const ::opencv_tensorflow::OpDef_AttrDef& OpDef::attr(int index) const {
+  // @@protoc_insertion_point(field_get:opencv_tensorflow.OpDef.attr)
   return attr_.Get(index);
 }
-inline ::tensorflow::OpDef_AttrDef* OpDef::mutable_attr(int index) {
-  // @@protoc_insertion_point(field_mutable:tensorflow.OpDef.attr)
+inline ::opencv_tensorflow::OpDef_AttrDef* OpDef::mutable_attr(int index) {
+  // @@protoc_insertion_point(field_mutable:opencv_tensorflow.OpDef.attr)
   return attr_.Mutable(index);
 }
-inline ::tensorflow::OpDef_AttrDef* OpDef::add_attr() {
-  // @@protoc_insertion_point(field_add:tensorflow.OpDef.attr)
+inline ::opencv_tensorflow::OpDef_AttrDef* OpDef::add_attr() {
+  // @@protoc_insertion_point(field_add:opencv_tensorflow.OpDef.attr)
   return attr_.Add();
 }
-inline ::google::protobuf::RepeatedPtrField< ::tensorflow::OpDef_AttrDef >*
+inline ::google::protobuf::RepeatedPtrField< ::opencv_tensorflow::OpDef_AttrDef >*
 OpDef::mutable_attr() {
-  // @@protoc_insertion_point(field_mutable_list:tensorflow.OpDef.attr)
+  // @@protoc_insertion_point(field_mutable_list:opencv_tensorflow.OpDef.attr)
   return &attr_;
 }
-inline const ::google::protobuf::RepeatedPtrField< ::tensorflow::OpDef_AttrDef >&
+inline const ::google::protobuf::RepeatedPtrField< ::opencv_tensorflow::OpDef_AttrDef >&
 OpDef::attr() const {
-  // @@protoc_insertion_point(field_list:tensorflow.OpDef.attr)
+  // @@protoc_insertion_point(field_list:opencv_tensorflow.OpDef.attr)
   return attr_;
 }
 
-// .tensorflow.OpDeprecation deprecation = 8;
+// .opencv_tensorflow.OpDeprecation deprecation = 8;
 inline bool OpDef::has_deprecation() const {
   return this != internal_default_instance() && deprecation_ != NULL;
 }
@@ -2030,38 +2030,38 @@ inline void OpDef::clear_deprecation() {
   }
   deprecation_ = NULL;
 }
-inline const ::tensorflow::OpDeprecation& OpDef::deprecation() const {
-  const ::tensorflow::OpDeprecation* p = deprecation_;
-  // @@protoc_insertion_point(field_get:tensorflow.OpDef.deprecation)
-  return p != NULL ? *p : *reinterpret_cast<const ::tensorflow::OpDeprecation*>(
-      &::tensorflow::_OpDeprecation_default_instance_);
+inline const ::opencv_tensorflow::OpDeprecation& OpDef::deprecation() const {
+  const ::opencv_tensorflow::OpDeprecation* p = deprecation_;
+  // @@protoc_insertion_point(field_get:opencv_tensorflow.OpDef.deprecation)
+  return p != NULL ? *p : *reinterpret_cast<const ::opencv_tensorflow::OpDeprecation*>(
+      &::opencv_tensorflow::_OpDeprecation_default_instance_);
 }
-inline ::tensorflow::OpDeprecation* OpDef::release_deprecation() {
-  // @@protoc_insertion_point(field_release:tensorflow.OpDef.deprecation)
+inline ::opencv_tensorflow::OpDeprecation* OpDef::release_deprecation() {
+  // @@protoc_insertion_point(field_release:opencv_tensorflow.OpDef.deprecation)
 
-  ::tensorflow::OpDeprecation* temp = deprecation_;
+  ::opencv_tensorflow::OpDeprecation* temp = deprecation_;
   if (GetArenaNoVirtual() != NULL) {
     temp = ::google::protobuf::internal::DuplicateIfNonNull(temp, NULL);
   }
   deprecation_ = NULL;
   return temp;
 }
-inline ::tensorflow::OpDeprecation* OpDef::unsafe_arena_release_deprecation() {
-  // @@protoc_insertion_point(field_unsafe_arena_release:tensorflow.OpDef.deprecation)
+inline ::opencv_tensorflow::OpDeprecation* OpDef::unsafe_arena_release_deprecation() {
+  // @@protoc_insertion_point(field_unsafe_arena_release:opencv_tensorflow.OpDef.deprecation)
 
-  ::tensorflow::OpDeprecation* temp = deprecation_;
+  ::opencv_tensorflow::OpDeprecation* temp = deprecation_;
   deprecation_ = NULL;
   return temp;
 }
-inline ::tensorflow::OpDeprecation* OpDef::mutable_deprecation() {
+inline ::opencv_tensorflow::OpDeprecation* OpDef::mutable_deprecation() {
 
   if (deprecation_ == NULL) {
     _slow_mutable_deprecation();
   }
-  // @@protoc_insertion_point(field_mutable:tensorflow.OpDef.deprecation)
+  // @@protoc_insertion_point(field_mutable:opencv_tensorflow.OpDef.deprecation)
   return deprecation_;
 }
-inline void OpDef::set_allocated_deprecation(::tensorflow::OpDeprecation* deprecation) {
+inline void OpDef::set_allocated_deprecation(::opencv_tensorflow::OpDeprecation* deprecation) {
   ::google::protobuf::Arena* message_arena = GetArenaNoVirtual();
   if (message_arena == NULL) {
     delete deprecation_;
@@ -2078,7 +2078,7 @@ inline void OpDef::set_allocated_deprecation(::tensorflow::OpDeprecation* deprec
 
   }
   deprecation_ = deprecation;
-  // @@protoc_insertion_point(field_set_allocated:tensorflow.OpDef.deprecation)
+  // @@protoc_insertion_point(field_set_allocated:opencv_tensorflow.OpDef.deprecation)
 }
 
 // string summary = 5;
@@ -2086,20 +2086,20 @@ inline void OpDef::clear_summary() {
   summary_.ClearToEmpty(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), GetArenaNoVirtual());
 }
 inline const ::std::string& OpDef::summary() const {
-  // @@protoc_insertion_point(field_get:tensorflow.OpDef.summary)
+  // @@protoc_insertion_point(field_get:opencv_tensorflow.OpDef.summary)
   return summary_.Get();
 }
 inline void OpDef::set_summary(const ::std::string& value) {
 
   summary_.Set(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), value, GetArenaNoVirtual());
-  // @@protoc_insertion_point(field_set:tensorflow.OpDef.summary)
+  // @@protoc_insertion_point(field_set:opencv_tensorflow.OpDef.summary)
 }
 #if LANG_CXX11
 inline void OpDef::set_summary(::std::string&& value) {
 
   summary_.Set(
     &::google::protobuf::internal::GetEmptyStringAlreadyInited(), ::std::move(value), GetArenaNoVirtual());
-  // @@protoc_insertion_point(field_set_rvalue:tensorflow.OpDef.summary)
+  // @@protoc_insertion_point(field_set_rvalue:opencv_tensorflow.OpDef.summary)
 }
 #endif
 inline void OpDef::set_summary(const char* value) {
@@ -2107,22 +2107,22 @@ inline void OpDef::set_summary(const char* value) {
 
   summary_.Set(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), ::std::string(value),
               GetArenaNoVirtual());
-  // @@protoc_insertion_point(field_set_char:tensorflow.OpDef.summary)
+  // @@protoc_insertion_point(field_set_char:opencv_tensorflow.OpDef.summary)
 }
 inline void OpDef::set_summary(const char* value,
     size_t size) {
 
   summary_.Set(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), ::std::string(
       reinterpret_cast<const char*>(value), size), GetArenaNoVirtual());
-  // @@protoc_insertion_point(field_set_pointer:tensorflow.OpDef.summary)
+  // @@protoc_insertion_point(field_set_pointer:opencv_tensorflow.OpDef.summary)
 }
 inline ::std::string* OpDef::mutable_summary() {
 
-  // @@protoc_insertion_point(field_mutable:tensorflow.OpDef.summary)
+  // @@protoc_insertion_point(field_mutable:opencv_tensorflow.OpDef.summary)
   return summary_.Mutable(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), GetArenaNoVirtual());
 }
 inline ::std::string* OpDef::release_summary() {
-  // @@protoc_insertion_point(field_release:tensorflow.OpDef.summary)
+  // @@protoc_insertion_point(field_release:opencv_tensorflow.OpDef.summary)
 
   return summary_.Release(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), GetArenaNoVirtual());
 }
@@ -2134,10 +2134,10 @@ inline void OpDef::set_allocated_summary(::std::string* summary) {
   }
   summary_.SetAllocated(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), summary,
       GetArenaNoVirtual());
-  // @@protoc_insertion_point(field_set_allocated:tensorflow.OpDef.summary)
+  // @@protoc_insertion_point(field_set_allocated:opencv_tensorflow.OpDef.summary)
 }
 inline ::std::string* OpDef::unsafe_arena_release_summary() {
-  // @@protoc_insertion_point(field_unsafe_arena_release:tensorflow.OpDef.summary)
+  // @@protoc_insertion_point(field_unsafe_arena_release:opencv_tensorflow.OpDef.summary)
   GOOGLE_DCHECK(GetArenaNoVirtual() != NULL);
 
   return summary_.UnsafeArenaRelease(&::google::protobuf::internal::GetEmptyStringAlreadyInited(),
@@ -2153,7 +2153,7 @@ inline void OpDef::unsafe_arena_set_allocated_summary(
   }
   summary_.UnsafeArenaSetAllocated(&::google::protobuf::internal::GetEmptyStringAlreadyInited(),
       summary, GetArenaNoVirtual());
-  // @@protoc_insertion_point(field_unsafe_arena_set_allocated:tensorflow.OpDef.summary)
+  // @@protoc_insertion_point(field_unsafe_arena_set_allocated:opencv_tensorflow.OpDef.summary)
 }
 
 // string description = 6;
@@ -2161,20 +2161,20 @@ inline void OpDef::clear_description() {
   description_.ClearToEmpty(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), GetArenaNoVirtual());
 }
 inline const ::std::string& OpDef::description() const {
-  // @@protoc_insertion_point(field_get:tensorflow.OpDef.description)
+  // @@protoc_insertion_point(field_get:opencv_tensorflow.OpDef.description)
   return description_.Get();
 }
 inline void OpDef::set_description(const ::std::string& value) {
 
   description_.Set(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), value, GetArenaNoVirtual());
-  // @@protoc_insertion_point(field_set:tensorflow.OpDef.description)
+  // @@protoc_insertion_point(field_set:opencv_tensorflow.OpDef.description)
 }
 #if LANG_CXX11
 inline void OpDef::set_description(::std::string&& value) {
 
   description_.Set(
     &::google::protobuf::internal::GetEmptyStringAlreadyInited(), ::std::move(value), GetArenaNoVirtual());
-  // @@protoc_insertion_point(field_set_rvalue:tensorflow.OpDef.description)
+  // @@protoc_insertion_point(field_set_rvalue:opencv_tensorflow.OpDef.description)
 }
 #endif
 inline void OpDef::set_description(const char* value) {
@@ -2182,22 +2182,22 @@ inline void OpDef::set_description(const char* value) {
 
   description_.Set(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), ::std::string(value),
               GetArenaNoVirtual());
-  // @@protoc_insertion_point(field_set_char:tensorflow.OpDef.description)
+  // @@protoc_insertion_point(field_set_char:opencv_tensorflow.OpDef.description)
 }
 inline void OpDef::set_description(const char* value,
     size_t size) {
 
   description_.Set(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), ::std::string(
       reinterpret_cast<const char*>(value), size), GetArenaNoVirtual());
-  // @@protoc_insertion_point(field_set_pointer:tensorflow.OpDef.description)
+  // @@protoc_insertion_point(field_set_pointer:opencv_tensorflow.OpDef.description)
 }
 inline ::std::string* OpDef::mutable_description() {
 
-  // @@protoc_insertion_point(field_mutable:tensorflow.OpDef.description)
+  // @@protoc_insertion_point(field_mutable:opencv_tensorflow.OpDef.description)
   return description_.Mutable(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), GetArenaNoVirtual());
 }
 inline ::std::string* OpDef::release_description() {
-  // @@protoc_insertion_point(field_release:tensorflow.OpDef.description)
+  // @@protoc_insertion_point(field_release:opencv_tensorflow.OpDef.description)
 
   return description_.Release(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), GetArenaNoVirtual());
 }
@@ -2209,10 +2209,10 @@ inline void OpDef::set_allocated_description(::std::string* description) {
   }
   description_.SetAllocated(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), description,
       GetArenaNoVirtual());
-  // @@protoc_insertion_point(field_set_allocated:tensorflow.OpDef.description)
+  // @@protoc_insertion_point(field_set_allocated:opencv_tensorflow.OpDef.description)
 }
 inline ::std::string* OpDef::unsafe_arena_release_description() {
-  // @@protoc_insertion_point(field_unsafe_arena_release:tensorflow.OpDef.description)
+  // @@protoc_insertion_point(field_unsafe_arena_release:opencv_tensorflow.OpDef.description)
   GOOGLE_DCHECK(GetArenaNoVirtual() != NULL);
 
   return description_.UnsafeArenaRelease(&::google::protobuf::internal::GetEmptyStringAlreadyInited(),
@@ -2228,7 +2228,7 @@ inline void OpDef::unsafe_arena_set_allocated_description(
   }
   description_.UnsafeArenaSetAllocated(&::google::protobuf::internal::GetEmptyStringAlreadyInited(),
       description, GetArenaNoVirtual());
-  // @@protoc_insertion_point(field_unsafe_arena_set_allocated:tensorflow.OpDef.description)
+  // @@protoc_insertion_point(field_unsafe_arena_set_allocated:opencv_tensorflow.OpDef.description)
 }
 
 // bool is_commutative = 18;
@@ -2236,13 +2236,13 @@ inline void OpDef::clear_is_commutative() {
   is_commutative_ = false;
 }
 inline bool OpDef::is_commutative() const {
-  // @@protoc_insertion_point(field_get:tensorflow.OpDef.is_commutative)
+  // @@protoc_insertion_point(field_get:opencv_tensorflow.OpDef.is_commutative)
   return is_commutative_;
 }
 inline void OpDef::set_is_commutative(bool value) {
 
   is_commutative_ = value;
-  // @@protoc_insertion_point(field_set:tensorflow.OpDef.is_commutative)
+  // @@protoc_insertion_point(field_set:opencv_tensorflow.OpDef.is_commutative)
 }
 
 // bool is_aggregate = 16;
@@ -2250,13 +2250,13 @@ inline void OpDef::clear_is_aggregate() {
   is_aggregate_ = false;
 }
 inline bool OpDef::is_aggregate() const {
-  // @@protoc_insertion_point(field_get:tensorflow.OpDef.is_aggregate)
+  // @@protoc_insertion_point(field_get:opencv_tensorflow.OpDef.is_aggregate)
   return is_aggregate_;
 }
 inline void OpDef::set_is_aggregate(bool value) {
 
   is_aggregate_ = value;
-  // @@protoc_insertion_point(field_set:tensorflow.OpDef.is_aggregate)
+  // @@protoc_insertion_point(field_set:opencv_tensorflow.OpDef.is_aggregate)
 }
 
 // bool is_stateful = 17;
@@ -2264,13 +2264,13 @@ inline void OpDef::clear_is_stateful() {
   is_stateful_ = false;
 }
 inline bool OpDef::is_stateful() const {
-  // @@protoc_insertion_point(field_get:tensorflow.OpDef.is_stateful)
+  // @@protoc_insertion_point(field_get:opencv_tensorflow.OpDef.is_stateful)
   return is_stateful_;
 }
 inline void OpDef::set_is_stateful(bool value) {
 
   is_stateful_ = value;
-  // @@protoc_insertion_point(field_set:tensorflow.OpDef.is_stateful)
+  // @@protoc_insertion_point(field_set:opencv_tensorflow.OpDef.is_stateful)
 }
 
 // bool allows_uninitialized_input = 19;
@@ -2278,13 +2278,13 @@ inline void OpDef::clear_allows_uninitialized_input() {
   allows_uninitialized_input_ = false;
 }
 inline bool OpDef::allows_uninitialized_input() const {
-  // @@protoc_insertion_point(field_get:tensorflow.OpDef.allows_uninitialized_input)
+  // @@protoc_insertion_point(field_get:opencv_tensorflow.OpDef.allows_uninitialized_input)
   return allows_uninitialized_input_;
 }
 inline void OpDef::set_allows_uninitialized_input(bool value) {
 
   allows_uninitialized_input_ = value;
-  // @@protoc_insertion_point(field_set:tensorflow.OpDef.allows_uninitialized_input)
+  // @@protoc_insertion_point(field_set:opencv_tensorflow.OpDef.allows_uninitialized_input)
 }
 
 // -------------------------------------------------------------------
@@ -2296,13 +2296,13 @@ inline void OpDeprecation::clear_version() {
   version_ = 0;
 }
 inline ::google::protobuf::int32 OpDeprecation::version() const {
-  // @@protoc_insertion_point(field_get:tensorflow.OpDeprecation.version)
+  // @@protoc_insertion_point(field_get:opencv_tensorflow.OpDeprecation.version)
   return version_;
 }
 inline void OpDeprecation::set_version(::google::protobuf::int32 value) {
 
   version_ = value;
-  // @@protoc_insertion_point(field_set:tensorflow.OpDeprecation.version)
+  // @@protoc_insertion_point(field_set:opencv_tensorflow.OpDeprecation.version)
 }
 
 // string explanation = 2;
@@ -2310,20 +2310,20 @@ inline void OpDeprecation::clear_explanation() {
   explanation_.ClearToEmpty(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), GetArenaNoVirtual());
 }
 inline const ::std::string& OpDeprecation::explanation() const {
-  // @@protoc_insertion_point(field_get:tensorflow.OpDeprecation.explanation)
+  // @@protoc_insertion_point(field_get:opencv_tensorflow.OpDeprecation.explanation)
   return explanation_.Get();
 }
 inline void OpDeprecation::set_explanation(const ::std::string& value) {
 
   explanation_.Set(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), value, GetArenaNoVirtual());
-  // @@protoc_insertion_point(field_set:tensorflow.OpDeprecation.explanation)
+  // @@protoc_insertion_point(field_set:opencv_tensorflow.OpDeprecation.explanation)
 }
 #if LANG_CXX11
 inline void OpDeprecation::set_explanation(::std::string&& value) {
 
   explanation_.Set(
     &::google::protobuf::internal::GetEmptyStringAlreadyInited(), ::std::move(value), GetArenaNoVirtual());
-  // @@protoc_insertion_point(field_set_rvalue:tensorflow.OpDeprecation.explanation)
+  // @@protoc_insertion_point(field_set_rvalue:opencv_tensorflow.OpDeprecation.explanation)
 }
 #endif
 inline void OpDeprecation::set_explanation(const char* value) {
@@ -2331,22 +2331,22 @@ inline void OpDeprecation::set_explanation(const char* value) {
 
   explanation_.Set(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), ::std::string(value),
               GetArenaNoVirtual());
-  // @@protoc_insertion_point(field_set_char:tensorflow.OpDeprecation.explanation)
+  // @@protoc_insertion_point(field_set_char:opencv_tensorflow.OpDeprecation.explanation)
 }
 inline void OpDeprecation::set_explanation(const char* value,
     size_t size) {
 
   explanation_.Set(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), ::std::string(
       reinterpret_cast<const char*>(value), size), GetArenaNoVirtual());
-  // @@protoc_insertion_point(field_set_pointer:tensorflow.OpDeprecation.explanation)
+  // @@protoc_insertion_point(field_set_pointer:opencv_tensorflow.OpDeprecation.explanation)
 }
 inline ::std::string* OpDeprecation::mutable_explanation() {
 
-  // @@protoc_insertion_point(field_mutable:tensorflow.OpDeprecation.explanation)
+  // @@protoc_insertion_point(field_mutable:opencv_tensorflow.OpDeprecation.explanation)
   return explanation_.Mutable(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), GetArenaNoVirtual());
 }
 inline ::std::string* OpDeprecation::release_explanation() {
-  // @@protoc_insertion_point(field_release:tensorflow.OpDeprecation.explanation)
+  // @@protoc_insertion_point(field_release:opencv_tensorflow.OpDeprecation.explanation)
 
   return explanation_.Release(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), GetArenaNoVirtual());
 }
@@ -2358,10 +2358,10 @@ inline void OpDeprecation::set_allocated_explanation(::std::string* explanation)
   }
   explanation_.SetAllocated(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), explanation,
       GetArenaNoVirtual());
-  // @@protoc_insertion_point(field_set_allocated:tensorflow.OpDeprecation.explanation)
+  // @@protoc_insertion_point(field_set_allocated:opencv_tensorflow.OpDeprecation.explanation)
 }
 inline ::std::string* OpDeprecation::unsafe_arena_release_explanation() {
-  // @@protoc_insertion_point(field_unsafe_arena_release:tensorflow.OpDeprecation.explanation)
+  // @@protoc_insertion_point(field_unsafe_arena_release:opencv_tensorflow.OpDeprecation.explanation)
   GOOGLE_DCHECK(GetArenaNoVirtual() != NULL);
 
   return explanation_.UnsafeArenaRelease(&::google::protobuf::internal::GetEmptyStringAlreadyInited(),
@@ -2377,40 +2377,40 @@ inline void OpDeprecation::unsafe_arena_set_allocated_explanation(
   }
   explanation_.UnsafeArenaSetAllocated(&::google::protobuf::internal::GetEmptyStringAlreadyInited(),
       explanation, GetArenaNoVirtual());
-  // @@protoc_insertion_point(field_unsafe_arena_set_allocated:tensorflow.OpDeprecation.explanation)
+  // @@protoc_insertion_point(field_unsafe_arena_set_allocated:opencv_tensorflow.OpDeprecation.explanation)
 }
 
 // -------------------------------------------------------------------
 
 // OpList
 
-// repeated .tensorflow.OpDef op = 1;
+// repeated .opencv_tensorflow.OpDef op = 1;
 inline int OpList::op_size() const {
   return op_.size();
 }
 inline void OpList::clear_op() {
   op_.Clear();
 }
-inline const ::tensorflow::OpDef& OpList::op(int index) const {
-  // @@protoc_insertion_point(field_get:tensorflow.OpList.op)
+inline const ::opencv_tensorflow::OpDef& OpList::op(int index) const {
+  // @@protoc_insertion_point(field_get:opencv_tensorflow.OpList.op)
   return op_.Get(index);
 }
-inline ::tensorflow::OpDef* OpList::mutable_op(int index) {
-  // @@protoc_insertion_point(field_mutable:tensorflow.OpList.op)
+inline ::opencv_tensorflow::OpDef* OpList::mutable_op(int index) {
+  // @@protoc_insertion_point(field_mutable:opencv_tensorflow.OpList.op)
   return op_.Mutable(index);
 }
-inline ::tensorflow::OpDef* OpList::add_op() {
-  // @@protoc_insertion_point(field_add:tensorflow.OpList.op)
+inline ::opencv_tensorflow::OpDef* OpList::add_op() {
+  // @@protoc_insertion_point(field_add:opencv_tensorflow.OpList.op)
   return op_.Add();
 }
-inline ::google::protobuf::RepeatedPtrField< ::tensorflow::OpDef >*
+inline ::google::protobuf::RepeatedPtrField< ::opencv_tensorflow::OpDef >*
 OpList::mutable_op() {
-  // @@protoc_insertion_point(field_mutable_list:tensorflow.OpList.op)
+  // @@protoc_insertion_point(field_mutable_list:opencv_tensorflow.OpList.op)
   return &op_;
 }
-inline const ::google::protobuf::RepeatedPtrField< ::tensorflow::OpDef >&
+inline const ::google::protobuf::RepeatedPtrField< ::opencv_tensorflow::OpDef >&
 OpList::op() const {
-  // @@protoc_insertion_point(field_list:tensorflow.OpList.op)
+  // @@protoc_insertion_point(field_list:opencv_tensorflow.OpList.op)
   return op_;
 }
 
@@ -2428,7 +2428,7 @@ OpList::op() const {
 
 // @@protoc_insertion_point(namespace_scope)
 
-}  // namespace tensorflow
+}  // namespace opencv_tensorflow
 
 // @@protoc_insertion_point(global_scope)
 

--- a/modules/dnn/misc/tensorflow/tensor.pb.cc
+++ b/modules/dnn/misc/tensorflow/tensor.pb.cc
@@ -19,13 +19,13 @@
 #include "third_party/protobuf/version.h"
 #endif
 // @@protoc_insertion_point(includes)
-namespace tensorflow {
+namespace opencv_tensorflow {
 class TensorProtoDefaultTypeInternal {
  public:
   ::google::protobuf::internal::ExplicitlyConstructed<TensorProto>
       _instance;
 } _TensorProto_default_instance_;
-}  // namespace tensorflow
+}  // namespace opencv_tensorflow
 namespace protobuf_tensor_2eproto {
 void InitDefaultsTensorProtoImpl() {
   GOOGLE_PROTOBUF_VERIFY_VERSION;
@@ -37,11 +37,11 @@ void InitDefaultsTensorProtoImpl() {
 #endif  // GOOGLE_PROTOBUF_ENFORCE_UNIQUENESS
   protobuf_tensor_5fshape_2eproto::InitDefaultsTensorShapeProto();
   {
-    void* ptr = &::tensorflow::_TensorProto_default_instance_;
-    new (ptr) ::tensorflow::TensorProto();
+    void* ptr = &::opencv_tensorflow::_TensorProto_default_instance_;
+    new (ptr) ::opencv_tensorflow::TensorProto();
     ::google::protobuf::internal::OnShutdownDestroyMessage(ptr);
   }
-  ::tensorflow::TensorProto::InitAsDefaultInstance();
+  ::opencv_tensorflow::TensorProto::InitAsDefaultInstance();
 }
 
 void InitDefaultsTensorProto() {
@@ -53,30 +53,30 @@ void InitDefaultsTensorProto() {
 
 const ::google::protobuf::uint32 TableStruct::offsets[] GOOGLE_PROTOBUF_ATTRIBUTE_SECTION_VARIABLE(protodesc_cold) = {
   ~0u,  // no _has_bits_
-  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::tensorflow::TensorProto, _internal_metadata_),
+  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::opencv_tensorflow::TensorProto, _internal_metadata_),
   ~0u,  // no _extensions_
   ~0u,  // no _oneof_case_
   ~0u,  // no _weak_field_map_
-  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::tensorflow::TensorProto, dtype_),
-  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::tensorflow::TensorProto, tensor_shape_),
-  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::tensorflow::TensorProto, version_number_),
-  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::tensorflow::TensorProto, tensor_content_),
-  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::tensorflow::TensorProto, half_val_),
-  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::tensorflow::TensorProto, float_val_),
-  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::tensorflow::TensorProto, double_val_),
-  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::tensorflow::TensorProto, int_val_),
-  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::tensorflow::TensorProto, string_val_),
-  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::tensorflow::TensorProto, scomplex_val_),
-  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::tensorflow::TensorProto, int64_val_),
-  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::tensorflow::TensorProto, bool_val_),
-  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::tensorflow::TensorProto, dcomplex_val_),
+  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::opencv_tensorflow::TensorProto, dtype_),
+  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::opencv_tensorflow::TensorProto, tensor_shape_),
+  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::opencv_tensorflow::TensorProto, version_number_),
+  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::opencv_tensorflow::TensorProto, tensor_content_),
+  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::opencv_tensorflow::TensorProto, half_val_),
+  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::opencv_tensorflow::TensorProto, float_val_),
+  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::opencv_tensorflow::TensorProto, double_val_),
+  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::opencv_tensorflow::TensorProto, int_val_),
+  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::opencv_tensorflow::TensorProto, string_val_),
+  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::opencv_tensorflow::TensorProto, scomplex_val_),
+  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::opencv_tensorflow::TensorProto, int64_val_),
+  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::opencv_tensorflow::TensorProto, bool_val_),
+  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::opencv_tensorflow::TensorProto, dcomplex_val_),
 };
 static const ::google::protobuf::internal::MigrationSchema schemas[] GOOGLE_PROTOBUF_ATTRIBUTE_SECTION_VARIABLE(protodesc_cold) = {
-  { 0, -1, sizeof(::tensorflow::TensorProto)},
+  { 0, -1, sizeof(::opencv_tensorflow::TensorProto)},
 };
 
 static ::google::protobuf::Message const * const file_default_instances[] = {
-  reinterpret_cast<const ::google::protobuf::Message*>(&::tensorflow::_TensorProto_default_instance_),
+  reinterpret_cast<const ::google::protobuf::Message*>(&::opencv_tensorflow::_TensorProto_default_instance_),
 };
 
 void protobuf_AssignDescriptors() {
@@ -101,21 +101,22 @@ void protobuf_RegisterTypes(const ::std::string&) {
 void AddDescriptorsImpl() {
   InitDefaults();
   static const char descriptor[] GOOGLE_PROTOBUF_ATTRIBUTE_SECTION_VARIABLE(protodesc_cold) = {
-      "\n\014tensor.proto\022\ntensorflow\032\022tensor_shape"
-      ".proto\032\013types.proto\"\345\002\n\013TensorProto\022#\n\005d"
-      "type\030\001 \001(\0162\024.tensorflow.DataType\0222\n\014tens"
-      "or_shape\030\002 \001(\0132\034.tensorflow.TensorShapeP"
-      "roto\022\026\n\016version_number\030\003 \001(\005\022\026\n\016tensor_c"
-      "ontent\030\004 \001(\014\022\024\n\010half_val\030\r \003(\005B\002\020\001\022\025\n\tfl"
-      "oat_val\030\005 \003(\002B\002\020\001\022\026\n\ndouble_val\030\006 \003(\001B\002\020"
-      "\001\022\023\n\007int_val\030\007 \003(\005B\002\020\001\022\022\n\nstring_val\030\010 \003"
-      "(\014\022\030\n\014scomplex_val\030\t \003(\002B\002\020\001\022\025\n\tint64_va"
-      "l\030\n \003(\003B\002\020\001\022\024\n\010bool_val\030\013 \003(\010B\002\020\001\022\030\n\014dco"
-      "mplex_val\030\014 \003(\001B\002\020\001B-\n\030org.tensorflow.fr"
-      "ameworkB\014TensorProtosP\001\370\001\001b\006proto3"
+      "\n\014tensor.proto\022\021opencv_tensorflow\032\022tenso"
+      "r_shape.proto\032\013types.proto\"\363\002\n\013TensorPro"
+      "to\022*\n\005dtype\030\001 \001(\0162\033.opencv_tensorflow.Da"
+      "taType\0229\n\014tensor_shape\030\002 \001(\0132#.opencv_te"
+      "nsorflow.TensorShapeProto\022\026\n\016version_num"
+      "ber\030\003 \001(\005\022\026\n\016tensor_content\030\004 \001(\014\022\024\n\010hal"
+      "f_val\030\r \003(\005B\002\020\001\022\025\n\tfloat_val\030\005 \003(\002B\002\020\001\022\026"
+      "\n\ndouble_val\030\006 \003(\001B\002\020\001\022\023\n\007int_val\030\007 \003(\005B"
+      "\002\020\001\022\022\n\nstring_val\030\010 \003(\014\022\030\n\014scomplex_val\030"
+      "\t \003(\002B\002\020\001\022\025\n\tint64_val\030\n \003(\003B\002\020\001\022\024\n\010bool"
+      "_val\030\013 \003(\010B\002\020\001\022\030\n\014dcomplex_val\030\014 \003(\001B\002\020\001"
+      "B-\n\030org.tensorflow.frameworkB\014TensorProt"
+      "osP\001\370\001\001b\006proto3"
   };
   ::google::protobuf::DescriptorPool::InternalAddGeneratedFile(
-      descriptor, 474);
+      descriptor, 495);
   ::google::protobuf::MessageFactory::InternalRegisterGeneratedFile(
     "tensor.proto", &protobuf_RegisterTypes);
   ::protobuf_tensor_5fshape_2eproto::AddDescriptors();
@@ -133,20 +134,20 @@ struct StaticDescriptorInitializer {
   }
 } static_descriptor_initializer;
 }  // namespace protobuf_tensor_2eproto
-namespace tensorflow {
+namespace opencv_tensorflow {
 
 // ===================================================================
 
 void TensorProto::InitAsDefaultInstance() {
-  ::tensorflow::_TensorProto_default_instance_._instance.get_mutable()->tensor_shape_ = const_cast< ::tensorflow::TensorShapeProto*>(
-      ::tensorflow::TensorShapeProto::internal_default_instance());
+  ::opencv_tensorflow::_TensorProto_default_instance_._instance.get_mutable()->tensor_shape_ = const_cast< ::opencv_tensorflow::TensorShapeProto*>(
+      ::opencv_tensorflow::TensorShapeProto::internal_default_instance());
 }
 void TensorProto::_slow_mutable_tensor_shape() {
-  tensor_shape_ = ::google::protobuf::Arena::CreateMessage< ::tensorflow::TensorShapeProto >(
+  tensor_shape_ = ::google::protobuf::Arena::CreateMessage< ::opencv_tensorflow::TensorShapeProto >(
       GetArenaNoVirtual());
 }
 void TensorProto::unsafe_arena_set_allocated_tensor_shape(
-    ::tensorflow::TensorShapeProto* tensor_shape) {
+    ::opencv_tensorflow::TensorShapeProto* tensor_shape) {
   if (GetArenaNoVirtual() == NULL) {
     delete tensor_shape_;
   }
@@ -156,7 +157,7 @@ void TensorProto::unsafe_arena_set_allocated_tensor_shape(
   } else {
 
   }
-  // @@protoc_insertion_point(field_unsafe_arena_set_allocated:tensorflow.TensorProto.tensor_shape)
+  // @@protoc_insertion_point(field_unsafe_arena_set_allocated:opencv_tensorflow.TensorProto.tensor_shape)
 }
 void TensorProto::clear_tensor_shape() {
   if (GetArenaNoVirtual() == NULL && tensor_shape_ != NULL) {
@@ -186,7 +187,7 @@ TensorProto::TensorProto()
     ::protobuf_tensor_2eproto::InitDefaultsTensorProto();
   }
   SharedCtor();
-  // @@protoc_insertion_point(constructor:tensorflow.TensorProto)
+  // @@protoc_insertion_point(constructor:opencv_tensorflow.TensorProto)
 }
 TensorProto::TensorProto(::google::protobuf::Arena* arena)
   : ::google::protobuf::Message(),
@@ -203,7 +204,7 @@ TensorProto::TensorProto(::google::protobuf::Arena* arena)
   ::protobuf_tensor_2eproto::InitDefaultsTensorProto();
   SharedCtor();
   RegisterArenaDtor(arena);
-  // @@protoc_insertion_point(arena_constructor:tensorflow.TensorProto)
+  // @@protoc_insertion_point(arena_constructor:opencv_tensorflow.TensorProto)
 }
 TensorProto::TensorProto(const TensorProto& from)
   : ::google::protobuf::Message(),
@@ -225,14 +226,14 @@ TensorProto::TensorProto(const TensorProto& from)
       GetArenaNoVirtual());
   }
   if (from.has_tensor_shape()) {
-    tensor_shape_ = new ::tensorflow::TensorShapeProto(*from.tensor_shape_);
+    tensor_shape_ = new ::opencv_tensorflow::TensorShapeProto(*from.tensor_shape_);
   } else {
     tensor_shape_ = NULL;
   }
   ::memcpy(&dtype_, &from.dtype_,
     static_cast<size_t>(reinterpret_cast<char*>(&version_number_) -
     reinterpret_cast<char*>(&dtype_)) + sizeof(version_number_));
-  // @@protoc_insertion_point(copy_constructor:tensorflow.TensorProto)
+  // @@protoc_insertion_point(copy_constructor:opencv_tensorflow.TensorProto)
 }
 
 void TensorProto::SharedCtor() {
@@ -244,7 +245,7 @@ void TensorProto::SharedCtor() {
 }
 
 TensorProto::~TensorProto() {
-  // @@protoc_insertion_point(destructor:tensorflow.TensorProto)
+  // @@protoc_insertion_point(destructor:opencv_tensorflow.TensorProto)
   SharedDtor();
 }
 
@@ -280,7 +281,7 @@ TensorProto* TensorProto::New(::google::protobuf::Arena* arena) const {
 }
 
 void TensorProto::Clear() {
-// @@protoc_insertion_point(message_clear_start:tensorflow.TensorProto)
+// @@protoc_insertion_point(message_clear_start:opencv_tensorflow.TensorProto)
   ::google::protobuf::uint32 cached_has_bits = 0;
   // Prevent compiler warnings about cached_has_bits being unused
   (void) cached_has_bits;
@@ -309,13 +310,13 @@ bool TensorProto::MergePartialFromCodedStream(
     ::google::protobuf::io::CodedInputStream* input) {
 #define DO_(EXPRESSION) if (!GOOGLE_PREDICT_TRUE(EXPRESSION)) goto failure
   ::google::protobuf::uint32 tag;
-  // @@protoc_insertion_point(parse_start:tensorflow.TensorProto)
+  // @@protoc_insertion_point(parse_start:opencv_tensorflow.TensorProto)
   for (;;) {
     ::std::pair< ::google::protobuf::uint32, bool> p = input->ReadTagWithCutoffNoLastTag(127u);
     tag = p.first;
     if (!p.second) goto handle_unusual;
     switch (::google::protobuf::internal::WireFormatLite::GetTagFieldNumber(tag)) {
-      // .tensorflow.DataType dtype = 1;
+      // .opencv_tensorflow.DataType dtype = 1;
       case 1: {
         if (static_cast< ::google::protobuf::uint8>(tag) ==
             static_cast< ::google::protobuf::uint8>(8u /* 8 & 0xFF */)) {
@@ -323,14 +324,14 @@ bool TensorProto::MergePartialFromCodedStream(
           DO_((::google::protobuf::internal::WireFormatLite::ReadPrimitive<
                    int, ::google::protobuf::internal::WireFormatLite::TYPE_ENUM>(
                  input, &value)));
-          set_dtype(static_cast< ::tensorflow::DataType >(value));
+          set_dtype(static_cast< ::opencv_tensorflow::DataType >(value));
         } else {
           goto handle_unusual;
         }
         break;
       }
 
-      // .tensorflow.TensorShapeProto tensor_shape = 2;
+      // .opencv_tensorflow.TensorShapeProto tensor_shape = 2;
       case 2: {
         if (static_cast< ::google::protobuf::uint8>(tag) ==
             static_cast< ::google::protobuf::uint8>(18u /* 18 & 0xFF */)) {
@@ -544,27 +545,27 @@ bool TensorProto::MergePartialFromCodedStream(
     }
   }
 success:
-  // @@protoc_insertion_point(parse_success:tensorflow.TensorProto)
+  // @@protoc_insertion_point(parse_success:opencv_tensorflow.TensorProto)
   return true;
 failure:
-  // @@protoc_insertion_point(parse_failure:tensorflow.TensorProto)
+  // @@protoc_insertion_point(parse_failure:opencv_tensorflow.TensorProto)
   return false;
 #undef DO_
 }
 
 void TensorProto::SerializeWithCachedSizes(
     ::google::protobuf::io::CodedOutputStream* output) const {
-  // @@protoc_insertion_point(serialize_start:tensorflow.TensorProto)
+  // @@protoc_insertion_point(serialize_start:opencv_tensorflow.TensorProto)
   ::google::protobuf::uint32 cached_has_bits = 0;
   (void) cached_has_bits;
 
-  // .tensorflow.DataType dtype = 1;
+  // .opencv_tensorflow.DataType dtype = 1;
   if (this->dtype() != 0) {
     ::google::protobuf::internal::WireFormatLite::WriteEnum(
       1, this->dtype(), output);
   }
 
-  // .tensorflow.TensorShapeProto tensor_shape = 2;
+  // .opencv_tensorflow.TensorShapeProto tensor_shape = 2;
   if (this->has_tensor_shape()) {
     ::google::protobuf::internal::WireFormatLite::WriteMessageMaybeToArray(
       2, *this->tensor_shape_, output);
@@ -669,23 +670,23 @@ void TensorProto::SerializeWithCachedSizes(
     ::google::protobuf::internal::WireFormat::SerializeUnknownFields(
         (::google::protobuf::internal::GetProto3PreserveUnknownsDefault()   ? _internal_metadata_.unknown_fields()   : _internal_metadata_.default_instance()), output);
   }
-  // @@protoc_insertion_point(serialize_end:tensorflow.TensorProto)
+  // @@protoc_insertion_point(serialize_end:opencv_tensorflow.TensorProto)
 }
 
 ::google::protobuf::uint8* TensorProto::InternalSerializeWithCachedSizesToArray(
     bool deterministic, ::google::protobuf::uint8* target) const {
   (void)deterministic; // Unused
-  // @@protoc_insertion_point(serialize_to_array_start:tensorflow.TensorProto)
+  // @@protoc_insertion_point(serialize_to_array_start:opencv_tensorflow.TensorProto)
   ::google::protobuf::uint32 cached_has_bits = 0;
   (void) cached_has_bits;
 
-  // .tensorflow.DataType dtype = 1;
+  // .opencv_tensorflow.DataType dtype = 1;
   if (this->dtype() != 0) {
     target = ::google::protobuf::internal::WireFormatLite::WriteEnumToArray(
       1, this->dtype(), target);
   }
 
-  // .tensorflow.TensorShapeProto tensor_shape = 2;
+  // .opencv_tensorflow.TensorShapeProto tensor_shape = 2;
   if (this->has_tensor_shape()) {
     target = ::google::protobuf::internal::WireFormatLite::
       InternalWriteMessageToArray(
@@ -818,12 +819,12 @@ void TensorProto::SerializeWithCachedSizes(
     target = ::google::protobuf::internal::WireFormat::SerializeUnknownFieldsToArray(
         (::google::protobuf::internal::GetProto3PreserveUnknownsDefault()   ? _internal_metadata_.unknown_fields()   : _internal_metadata_.default_instance()), target);
   }
-  // @@protoc_insertion_point(serialize_to_array_end:tensorflow.TensorProto)
+  // @@protoc_insertion_point(serialize_to_array_end:opencv_tensorflow.TensorProto)
   return target;
 }
 
 size_t TensorProto::ByteSizeLong() const {
-// @@protoc_insertion_point(message_byte_size_start:tensorflow.TensorProto)
+// @@protoc_insertion_point(message_byte_size_start:opencv_tensorflow.TensorProto)
   size_t total_size = 0;
 
   if ((_internal_metadata_.have_unknown_fields() &&  ::google::protobuf::internal::GetProto3PreserveUnknownsDefault())) {
@@ -974,14 +975,14 @@ size_t TensorProto::ByteSizeLong() const {
         this->tensor_content());
   }
 
-  // .tensorflow.TensorShapeProto tensor_shape = 2;
+  // .opencv_tensorflow.TensorShapeProto tensor_shape = 2;
   if (this->has_tensor_shape()) {
     total_size += 1 +
       ::google::protobuf::internal::WireFormatLite::MessageSize(
         *this->tensor_shape_);
   }
 
-  // .tensorflow.DataType dtype = 1;
+  // .opencv_tensorflow.DataType dtype = 1;
   if (this->dtype() != 0) {
     total_size += 1 +
       ::google::protobuf::internal::WireFormatLite::EnumSize(this->dtype());
@@ -1002,22 +1003,22 @@ size_t TensorProto::ByteSizeLong() const {
 }
 
 void TensorProto::MergeFrom(const ::google::protobuf::Message& from) {
-// @@protoc_insertion_point(generalized_merge_from_start:tensorflow.TensorProto)
+// @@protoc_insertion_point(generalized_merge_from_start:opencv_tensorflow.TensorProto)
   GOOGLE_DCHECK_NE(&from, this);
   const TensorProto* source =
       ::google::protobuf::internal::DynamicCastToGenerated<const TensorProto>(
           &from);
   if (source == NULL) {
-  // @@protoc_insertion_point(generalized_merge_from_cast_fail:tensorflow.TensorProto)
+  // @@protoc_insertion_point(generalized_merge_from_cast_fail:opencv_tensorflow.TensorProto)
     ::google::protobuf::internal::ReflectionOps::Merge(from, this);
   } else {
-  // @@protoc_insertion_point(generalized_merge_from_cast_success:tensorflow.TensorProto)
+  // @@protoc_insertion_point(generalized_merge_from_cast_success:opencv_tensorflow.TensorProto)
     MergeFrom(*source);
   }
 }
 
 void TensorProto::MergeFrom(const TensorProto& from) {
-// @@protoc_insertion_point(class_specific_merge_from_start:tensorflow.TensorProto)
+// @@protoc_insertion_point(class_specific_merge_from_start:opencv_tensorflow.TensorProto)
   GOOGLE_DCHECK_NE(&from, this);
   _internal_metadata_.MergeFrom(from._internal_metadata_);
   ::google::protobuf::uint32 cached_has_bits = 0;
@@ -1036,7 +1037,7 @@ void TensorProto::MergeFrom(const TensorProto& from) {
     set_tensor_content(from.tensor_content());
   }
   if (from.has_tensor_shape()) {
-    mutable_tensor_shape()->::tensorflow::TensorShapeProto::MergeFrom(from.tensor_shape());
+    mutable_tensor_shape()->::opencv_tensorflow::TensorShapeProto::MergeFrom(from.tensor_shape());
   }
   if (from.dtype() != 0) {
     set_dtype(from.dtype());
@@ -1047,14 +1048,14 @@ void TensorProto::MergeFrom(const TensorProto& from) {
 }
 
 void TensorProto::CopyFrom(const ::google::protobuf::Message& from) {
-// @@protoc_insertion_point(generalized_copy_from_start:tensorflow.TensorProto)
+// @@protoc_insertion_point(generalized_copy_from_start:opencv_tensorflow.TensorProto)
   if (&from == this) return;
   Clear();
   MergeFrom(from);
 }
 
 void TensorProto::CopyFrom(const TensorProto& from) {
-// @@protoc_insertion_point(class_specific_copy_from_start:tensorflow.TensorProto)
+// @@protoc_insertion_point(class_specific_copy_from_start:opencv_tensorflow.TensorProto)
   if (&from == this) return;
   Clear();
   MergeFrom(from);
@@ -1109,6 +1110,6 @@ void TensorProto::InternalSwap(TensorProto* other) {
 
 
 // @@protoc_insertion_point(namespace_scope)
-}  // namespace tensorflow
+}  // namespace opencv_tensorflow
 
 // @@protoc_insertion_point(global_scope)

--- a/modules/dnn/misc/tensorflow/tensor.pb.h
+++ b/modules/dnn/misc/tensorflow/tensor.pb.h
@@ -50,16 +50,16 @@ inline void InitDefaults() {
   InitDefaultsTensorProto();
 }
 }  // namespace protobuf_tensor_2eproto
-namespace tensorflow {
+namespace opencv_tensorflow {
 class TensorProto;
 class TensorProtoDefaultTypeInternal;
 extern TensorProtoDefaultTypeInternal _TensorProto_default_instance_;
-}  // namespace tensorflow
-namespace tensorflow {
+}  // namespace opencv_tensorflow
+namespace opencv_tensorflow {
 
 // ===================================================================
 
-class TensorProto : public ::google::protobuf::Message /* @@protoc_insertion_point(class_definition:tensorflow.TensorProto) */ {
+class TensorProto : public ::google::protobuf::Message /* @@protoc_insertion_point(class_definition:opencv_tensorflow.TensorProto) */ {
  public:
   TensorProto();
   virtual ~TensorProto();
@@ -294,26 +294,26 @@ class TensorProto : public ::google::protobuf::Message /* @@protoc_insertion_poi
   void unsafe_arena_set_allocated_tensor_content(
       ::std::string* tensor_content);
 
-  // .tensorflow.TensorShapeProto tensor_shape = 2;
+  // .opencv_tensorflow.TensorShapeProto tensor_shape = 2;
   bool has_tensor_shape() const;
   void clear_tensor_shape();
   static const int kTensorShapeFieldNumber = 2;
   private:
   void _slow_mutable_tensor_shape();
   public:
-  const ::tensorflow::TensorShapeProto& tensor_shape() const;
-  ::tensorflow::TensorShapeProto* release_tensor_shape();
-  ::tensorflow::TensorShapeProto* mutable_tensor_shape();
-  void set_allocated_tensor_shape(::tensorflow::TensorShapeProto* tensor_shape);
+  const ::opencv_tensorflow::TensorShapeProto& tensor_shape() const;
+  ::opencv_tensorflow::TensorShapeProto* release_tensor_shape();
+  ::opencv_tensorflow::TensorShapeProto* mutable_tensor_shape();
+  void set_allocated_tensor_shape(::opencv_tensorflow::TensorShapeProto* tensor_shape);
   void unsafe_arena_set_allocated_tensor_shape(
-      ::tensorflow::TensorShapeProto* tensor_shape);
-  ::tensorflow::TensorShapeProto* unsafe_arena_release_tensor_shape();
+      ::opencv_tensorflow::TensorShapeProto* tensor_shape);
+  ::opencv_tensorflow::TensorShapeProto* unsafe_arena_release_tensor_shape();
 
-  // .tensorflow.DataType dtype = 1;
+  // .opencv_tensorflow.DataType dtype = 1;
   void clear_dtype();
   static const int kDtypeFieldNumber = 1;
-  ::tensorflow::DataType dtype() const;
-  void set_dtype(::tensorflow::DataType value);
+  ::opencv_tensorflow::DataType dtype() const;
+  void set_dtype(::opencv_tensorflow::DataType value);
 
   // int32 version_number = 3;
   void clear_version_number();
@@ -321,7 +321,7 @@ class TensorProto : public ::google::protobuf::Message /* @@protoc_insertion_poi
   ::google::protobuf::int32 version_number() const;
   void set_version_number(::google::protobuf::int32 value);
 
-  // @@protoc_insertion_point(class_scope:tensorflow.TensorProto)
+  // @@protoc_insertion_point(class_scope:opencv_tensorflow.TensorProto)
  private:
 
   ::google::protobuf::internal::InternalMetadataWithArena _internal_metadata_;
@@ -346,7 +346,7 @@ class TensorProto : public ::google::protobuf::Message /* @@protoc_insertion_poi
   ::google::protobuf::RepeatedField< ::google::protobuf::int32 > half_val_;
   mutable int _half_val_cached_byte_size_;
   ::google::protobuf::internal::ArenaStringPtr tensor_content_;
-  ::tensorflow::TensorShapeProto* tensor_shape_;
+  ::opencv_tensorflow::TensorShapeProto* tensor_shape_;
   int dtype_;
   ::google::protobuf::int32 version_number_;
   mutable int _cached_size_;
@@ -364,56 +364,56 @@ class TensorProto : public ::google::protobuf::Message /* @@protoc_insertion_poi
 #endif  // __GNUC__
 // TensorProto
 
-// .tensorflow.DataType dtype = 1;
+// .opencv_tensorflow.DataType dtype = 1;
 inline void TensorProto::clear_dtype() {
   dtype_ = 0;
 }
-inline ::tensorflow::DataType TensorProto::dtype() const {
-  // @@protoc_insertion_point(field_get:tensorflow.TensorProto.dtype)
-  return static_cast< ::tensorflow::DataType >(dtype_);
+inline ::opencv_tensorflow::DataType TensorProto::dtype() const {
+  // @@protoc_insertion_point(field_get:opencv_tensorflow.TensorProto.dtype)
+  return static_cast< ::opencv_tensorflow::DataType >(dtype_);
 }
-inline void TensorProto::set_dtype(::tensorflow::DataType value) {
+inline void TensorProto::set_dtype(::opencv_tensorflow::DataType value) {
 
   dtype_ = value;
-  // @@protoc_insertion_point(field_set:tensorflow.TensorProto.dtype)
+  // @@protoc_insertion_point(field_set:opencv_tensorflow.TensorProto.dtype)
 }
 
-// .tensorflow.TensorShapeProto tensor_shape = 2;
+// .opencv_tensorflow.TensorShapeProto tensor_shape = 2;
 inline bool TensorProto::has_tensor_shape() const {
   return this != internal_default_instance() && tensor_shape_ != NULL;
 }
-inline const ::tensorflow::TensorShapeProto& TensorProto::tensor_shape() const {
-  const ::tensorflow::TensorShapeProto* p = tensor_shape_;
-  // @@protoc_insertion_point(field_get:tensorflow.TensorProto.tensor_shape)
-  return p != NULL ? *p : *reinterpret_cast<const ::tensorflow::TensorShapeProto*>(
-      &::tensorflow::_TensorShapeProto_default_instance_);
+inline const ::opencv_tensorflow::TensorShapeProto& TensorProto::tensor_shape() const {
+  const ::opencv_tensorflow::TensorShapeProto* p = tensor_shape_;
+  // @@protoc_insertion_point(field_get:opencv_tensorflow.TensorProto.tensor_shape)
+  return p != NULL ? *p : *reinterpret_cast<const ::opencv_tensorflow::TensorShapeProto*>(
+      &::opencv_tensorflow::_TensorShapeProto_default_instance_);
 }
-inline ::tensorflow::TensorShapeProto* TensorProto::release_tensor_shape() {
-  // @@protoc_insertion_point(field_release:tensorflow.TensorProto.tensor_shape)
+inline ::opencv_tensorflow::TensorShapeProto* TensorProto::release_tensor_shape() {
+  // @@protoc_insertion_point(field_release:opencv_tensorflow.TensorProto.tensor_shape)
 
-  ::tensorflow::TensorShapeProto* temp = tensor_shape_;
+  ::opencv_tensorflow::TensorShapeProto* temp = tensor_shape_;
   if (GetArenaNoVirtual() != NULL) {
     temp = ::google::protobuf::internal::DuplicateIfNonNull(temp, NULL);
   }
   tensor_shape_ = NULL;
   return temp;
 }
-inline ::tensorflow::TensorShapeProto* TensorProto::unsafe_arena_release_tensor_shape() {
-  // @@protoc_insertion_point(field_unsafe_arena_release:tensorflow.TensorProto.tensor_shape)
+inline ::opencv_tensorflow::TensorShapeProto* TensorProto::unsafe_arena_release_tensor_shape() {
+  // @@protoc_insertion_point(field_unsafe_arena_release:opencv_tensorflow.TensorProto.tensor_shape)
 
-  ::tensorflow::TensorShapeProto* temp = tensor_shape_;
+  ::opencv_tensorflow::TensorShapeProto* temp = tensor_shape_;
   tensor_shape_ = NULL;
   return temp;
 }
-inline ::tensorflow::TensorShapeProto* TensorProto::mutable_tensor_shape() {
+inline ::opencv_tensorflow::TensorShapeProto* TensorProto::mutable_tensor_shape() {
 
   if (tensor_shape_ == NULL) {
     _slow_mutable_tensor_shape();
   }
-  // @@protoc_insertion_point(field_mutable:tensorflow.TensorProto.tensor_shape)
+  // @@protoc_insertion_point(field_mutable:opencv_tensorflow.TensorProto.tensor_shape)
   return tensor_shape_;
 }
-inline void TensorProto::set_allocated_tensor_shape(::tensorflow::TensorShapeProto* tensor_shape) {
+inline void TensorProto::set_allocated_tensor_shape(::opencv_tensorflow::TensorShapeProto* tensor_shape) {
   ::google::protobuf::Arena* message_arena = GetArenaNoVirtual();
   if (message_arena == NULL) {
     delete reinterpret_cast< ::google::protobuf::MessageLite*>(tensor_shape_);
@@ -430,7 +430,7 @@ inline void TensorProto::set_allocated_tensor_shape(::tensorflow::TensorShapePro
 
   }
   tensor_shape_ = tensor_shape;
-  // @@protoc_insertion_point(field_set_allocated:tensorflow.TensorProto.tensor_shape)
+  // @@protoc_insertion_point(field_set_allocated:opencv_tensorflow.TensorProto.tensor_shape)
 }
 
 // int32 version_number = 3;
@@ -438,13 +438,13 @@ inline void TensorProto::clear_version_number() {
   version_number_ = 0;
 }
 inline ::google::protobuf::int32 TensorProto::version_number() const {
-  // @@protoc_insertion_point(field_get:tensorflow.TensorProto.version_number)
+  // @@protoc_insertion_point(field_get:opencv_tensorflow.TensorProto.version_number)
   return version_number_;
 }
 inline void TensorProto::set_version_number(::google::protobuf::int32 value) {
 
   version_number_ = value;
-  // @@protoc_insertion_point(field_set:tensorflow.TensorProto.version_number)
+  // @@protoc_insertion_point(field_set:opencv_tensorflow.TensorProto.version_number)
 }
 
 // bytes tensor_content = 4;
@@ -452,20 +452,20 @@ inline void TensorProto::clear_tensor_content() {
   tensor_content_.ClearToEmpty(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), GetArenaNoVirtual());
 }
 inline const ::std::string& TensorProto::tensor_content() const {
-  // @@protoc_insertion_point(field_get:tensorflow.TensorProto.tensor_content)
+  // @@protoc_insertion_point(field_get:opencv_tensorflow.TensorProto.tensor_content)
   return tensor_content_.Get();
 }
 inline void TensorProto::set_tensor_content(const ::std::string& value) {
 
   tensor_content_.Set(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), value, GetArenaNoVirtual());
-  // @@protoc_insertion_point(field_set:tensorflow.TensorProto.tensor_content)
+  // @@protoc_insertion_point(field_set:opencv_tensorflow.TensorProto.tensor_content)
 }
 #if LANG_CXX11
 inline void TensorProto::set_tensor_content(::std::string&& value) {
 
   tensor_content_.Set(
     &::google::protobuf::internal::GetEmptyStringAlreadyInited(), ::std::move(value), GetArenaNoVirtual());
-  // @@protoc_insertion_point(field_set_rvalue:tensorflow.TensorProto.tensor_content)
+  // @@protoc_insertion_point(field_set_rvalue:opencv_tensorflow.TensorProto.tensor_content)
 }
 #endif
 inline void TensorProto::set_tensor_content(const char* value) {
@@ -473,22 +473,22 @@ inline void TensorProto::set_tensor_content(const char* value) {
 
   tensor_content_.Set(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), ::std::string(value),
               GetArenaNoVirtual());
-  // @@protoc_insertion_point(field_set_char:tensorflow.TensorProto.tensor_content)
+  // @@protoc_insertion_point(field_set_char:opencv_tensorflow.TensorProto.tensor_content)
 }
 inline void TensorProto::set_tensor_content(const void* value,
     size_t size) {
 
   tensor_content_.Set(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), ::std::string(
       reinterpret_cast<const char*>(value), size), GetArenaNoVirtual());
-  // @@protoc_insertion_point(field_set_pointer:tensorflow.TensorProto.tensor_content)
+  // @@protoc_insertion_point(field_set_pointer:opencv_tensorflow.TensorProto.tensor_content)
 }
 inline ::std::string* TensorProto::mutable_tensor_content() {
 
-  // @@protoc_insertion_point(field_mutable:tensorflow.TensorProto.tensor_content)
+  // @@protoc_insertion_point(field_mutable:opencv_tensorflow.TensorProto.tensor_content)
   return tensor_content_.Mutable(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), GetArenaNoVirtual());
 }
 inline ::std::string* TensorProto::release_tensor_content() {
-  // @@protoc_insertion_point(field_release:tensorflow.TensorProto.tensor_content)
+  // @@protoc_insertion_point(field_release:opencv_tensorflow.TensorProto.tensor_content)
 
   return tensor_content_.Release(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), GetArenaNoVirtual());
 }
@@ -500,10 +500,10 @@ inline void TensorProto::set_allocated_tensor_content(::std::string* tensor_cont
   }
   tensor_content_.SetAllocated(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), tensor_content,
       GetArenaNoVirtual());
-  // @@protoc_insertion_point(field_set_allocated:tensorflow.TensorProto.tensor_content)
+  // @@protoc_insertion_point(field_set_allocated:opencv_tensorflow.TensorProto.tensor_content)
 }
 inline ::std::string* TensorProto::unsafe_arena_release_tensor_content() {
-  // @@protoc_insertion_point(field_unsafe_arena_release:tensorflow.TensorProto.tensor_content)
+  // @@protoc_insertion_point(field_unsafe_arena_release:opencv_tensorflow.TensorProto.tensor_content)
   GOOGLE_DCHECK(GetArenaNoVirtual() != NULL);
 
   return tensor_content_.UnsafeArenaRelease(&::google::protobuf::internal::GetEmptyStringAlreadyInited(),
@@ -519,7 +519,7 @@ inline void TensorProto::unsafe_arena_set_allocated_tensor_content(
   }
   tensor_content_.UnsafeArenaSetAllocated(&::google::protobuf::internal::GetEmptyStringAlreadyInited(),
       tensor_content, GetArenaNoVirtual());
-  // @@protoc_insertion_point(field_unsafe_arena_set_allocated:tensorflow.TensorProto.tensor_content)
+  // @@protoc_insertion_point(field_unsafe_arena_set_allocated:opencv_tensorflow.TensorProto.tensor_content)
 }
 
 // repeated int32 half_val = 13 [packed = true];
@@ -530,25 +530,25 @@ inline void TensorProto::clear_half_val() {
   half_val_.Clear();
 }
 inline ::google::protobuf::int32 TensorProto::half_val(int index) const {
-  // @@protoc_insertion_point(field_get:tensorflow.TensorProto.half_val)
+  // @@protoc_insertion_point(field_get:opencv_tensorflow.TensorProto.half_val)
   return half_val_.Get(index);
 }
 inline void TensorProto::set_half_val(int index, ::google::protobuf::int32 value) {
   half_val_.Set(index, value);
-  // @@protoc_insertion_point(field_set:tensorflow.TensorProto.half_val)
+  // @@protoc_insertion_point(field_set:opencv_tensorflow.TensorProto.half_val)
 }
 inline void TensorProto::add_half_val(::google::protobuf::int32 value) {
   half_val_.Add(value);
-  // @@protoc_insertion_point(field_add:tensorflow.TensorProto.half_val)
+  // @@protoc_insertion_point(field_add:opencv_tensorflow.TensorProto.half_val)
 }
 inline const ::google::protobuf::RepeatedField< ::google::protobuf::int32 >&
 TensorProto::half_val() const {
-  // @@protoc_insertion_point(field_list:tensorflow.TensorProto.half_val)
+  // @@protoc_insertion_point(field_list:opencv_tensorflow.TensorProto.half_val)
   return half_val_;
 }
 inline ::google::protobuf::RepeatedField< ::google::protobuf::int32 >*
 TensorProto::mutable_half_val() {
-  // @@protoc_insertion_point(field_mutable_list:tensorflow.TensorProto.half_val)
+  // @@protoc_insertion_point(field_mutable_list:opencv_tensorflow.TensorProto.half_val)
   return &half_val_;
 }
 
@@ -560,25 +560,25 @@ inline void TensorProto::clear_float_val() {
   float_val_.Clear();
 }
 inline float TensorProto::float_val(int index) const {
-  // @@protoc_insertion_point(field_get:tensorflow.TensorProto.float_val)
+  // @@protoc_insertion_point(field_get:opencv_tensorflow.TensorProto.float_val)
   return float_val_.Get(index);
 }
 inline void TensorProto::set_float_val(int index, float value) {
   float_val_.Set(index, value);
-  // @@protoc_insertion_point(field_set:tensorflow.TensorProto.float_val)
+  // @@protoc_insertion_point(field_set:opencv_tensorflow.TensorProto.float_val)
 }
 inline void TensorProto::add_float_val(float value) {
   float_val_.Add(value);
-  // @@protoc_insertion_point(field_add:tensorflow.TensorProto.float_val)
+  // @@protoc_insertion_point(field_add:opencv_tensorflow.TensorProto.float_val)
 }
 inline const ::google::protobuf::RepeatedField< float >&
 TensorProto::float_val() const {
-  // @@protoc_insertion_point(field_list:tensorflow.TensorProto.float_val)
+  // @@protoc_insertion_point(field_list:opencv_tensorflow.TensorProto.float_val)
   return float_val_;
 }
 inline ::google::protobuf::RepeatedField< float >*
 TensorProto::mutable_float_val() {
-  // @@protoc_insertion_point(field_mutable_list:tensorflow.TensorProto.float_val)
+  // @@protoc_insertion_point(field_mutable_list:opencv_tensorflow.TensorProto.float_val)
   return &float_val_;
 }
 
@@ -590,25 +590,25 @@ inline void TensorProto::clear_double_val() {
   double_val_.Clear();
 }
 inline double TensorProto::double_val(int index) const {
-  // @@protoc_insertion_point(field_get:tensorflow.TensorProto.double_val)
+  // @@protoc_insertion_point(field_get:opencv_tensorflow.TensorProto.double_val)
   return double_val_.Get(index);
 }
 inline void TensorProto::set_double_val(int index, double value) {
   double_val_.Set(index, value);
-  // @@protoc_insertion_point(field_set:tensorflow.TensorProto.double_val)
+  // @@protoc_insertion_point(field_set:opencv_tensorflow.TensorProto.double_val)
 }
 inline void TensorProto::add_double_val(double value) {
   double_val_.Add(value);
-  // @@protoc_insertion_point(field_add:tensorflow.TensorProto.double_val)
+  // @@protoc_insertion_point(field_add:opencv_tensorflow.TensorProto.double_val)
 }
 inline const ::google::protobuf::RepeatedField< double >&
 TensorProto::double_val() const {
-  // @@protoc_insertion_point(field_list:tensorflow.TensorProto.double_val)
+  // @@protoc_insertion_point(field_list:opencv_tensorflow.TensorProto.double_val)
   return double_val_;
 }
 inline ::google::protobuf::RepeatedField< double >*
 TensorProto::mutable_double_val() {
-  // @@protoc_insertion_point(field_mutable_list:tensorflow.TensorProto.double_val)
+  // @@protoc_insertion_point(field_mutable_list:opencv_tensorflow.TensorProto.double_val)
   return &double_val_;
 }
 
@@ -620,25 +620,25 @@ inline void TensorProto::clear_int_val() {
   int_val_.Clear();
 }
 inline ::google::protobuf::int32 TensorProto::int_val(int index) const {
-  // @@protoc_insertion_point(field_get:tensorflow.TensorProto.int_val)
+  // @@protoc_insertion_point(field_get:opencv_tensorflow.TensorProto.int_val)
   return int_val_.Get(index);
 }
 inline void TensorProto::set_int_val(int index, ::google::protobuf::int32 value) {
   int_val_.Set(index, value);
-  // @@protoc_insertion_point(field_set:tensorflow.TensorProto.int_val)
+  // @@protoc_insertion_point(field_set:opencv_tensorflow.TensorProto.int_val)
 }
 inline void TensorProto::add_int_val(::google::protobuf::int32 value) {
   int_val_.Add(value);
-  // @@protoc_insertion_point(field_add:tensorflow.TensorProto.int_val)
+  // @@protoc_insertion_point(field_add:opencv_tensorflow.TensorProto.int_val)
 }
 inline const ::google::protobuf::RepeatedField< ::google::protobuf::int32 >&
 TensorProto::int_val() const {
-  // @@protoc_insertion_point(field_list:tensorflow.TensorProto.int_val)
+  // @@protoc_insertion_point(field_list:opencv_tensorflow.TensorProto.int_val)
   return int_val_;
 }
 inline ::google::protobuf::RepeatedField< ::google::protobuf::int32 >*
 TensorProto::mutable_int_val() {
-  // @@protoc_insertion_point(field_mutable_list:tensorflow.TensorProto.int_val)
+  // @@protoc_insertion_point(field_mutable_list:opencv_tensorflow.TensorProto.int_val)
   return &int_val_;
 }
 
@@ -650,64 +650,64 @@ inline void TensorProto::clear_string_val() {
   string_val_.Clear();
 }
 inline const ::std::string& TensorProto::string_val(int index) const {
-  // @@protoc_insertion_point(field_get:tensorflow.TensorProto.string_val)
+  // @@protoc_insertion_point(field_get:opencv_tensorflow.TensorProto.string_val)
   return string_val_.Get(index);
 }
 inline ::std::string* TensorProto::mutable_string_val(int index) {
-  // @@protoc_insertion_point(field_mutable:tensorflow.TensorProto.string_val)
+  // @@protoc_insertion_point(field_mutable:opencv_tensorflow.TensorProto.string_val)
   return string_val_.Mutable(index);
 }
 inline void TensorProto::set_string_val(int index, const ::std::string& value) {
-  // @@protoc_insertion_point(field_set:tensorflow.TensorProto.string_val)
+  // @@protoc_insertion_point(field_set:opencv_tensorflow.TensorProto.string_val)
   string_val_.Mutable(index)->assign(value);
 }
 #if LANG_CXX11
 inline void TensorProto::set_string_val(int index, ::std::string&& value) {
-  // @@protoc_insertion_point(field_set:tensorflow.TensorProto.string_val)
+  // @@protoc_insertion_point(field_set:opencv_tensorflow.TensorProto.string_val)
   string_val_.Mutable(index)->assign(std::move(value));
 }
 #endif
 inline void TensorProto::set_string_val(int index, const char* value) {
   GOOGLE_DCHECK(value != NULL);
   string_val_.Mutable(index)->assign(value);
-  // @@protoc_insertion_point(field_set_char:tensorflow.TensorProto.string_val)
+  // @@protoc_insertion_point(field_set_char:opencv_tensorflow.TensorProto.string_val)
 }
 inline void TensorProto::set_string_val(int index, const void* value, size_t size) {
   string_val_.Mutable(index)->assign(
     reinterpret_cast<const char*>(value), size);
-  // @@protoc_insertion_point(field_set_pointer:tensorflow.TensorProto.string_val)
+  // @@protoc_insertion_point(field_set_pointer:opencv_tensorflow.TensorProto.string_val)
 }
 inline ::std::string* TensorProto::add_string_val() {
-  // @@protoc_insertion_point(field_add_mutable:tensorflow.TensorProto.string_val)
+  // @@protoc_insertion_point(field_add_mutable:opencv_tensorflow.TensorProto.string_val)
   return string_val_.Add();
 }
 inline void TensorProto::add_string_val(const ::std::string& value) {
   string_val_.Add()->assign(value);
-  // @@protoc_insertion_point(field_add:tensorflow.TensorProto.string_val)
+  // @@protoc_insertion_point(field_add:opencv_tensorflow.TensorProto.string_val)
 }
 #if LANG_CXX11
 inline void TensorProto::add_string_val(::std::string&& value) {
   string_val_.Add(std::move(value));
-  // @@protoc_insertion_point(field_add:tensorflow.TensorProto.string_val)
+  // @@protoc_insertion_point(field_add:opencv_tensorflow.TensorProto.string_val)
 }
 #endif
 inline void TensorProto::add_string_val(const char* value) {
   GOOGLE_DCHECK(value != NULL);
   string_val_.Add()->assign(value);
-  // @@protoc_insertion_point(field_add_char:tensorflow.TensorProto.string_val)
+  // @@protoc_insertion_point(field_add_char:opencv_tensorflow.TensorProto.string_val)
 }
 inline void TensorProto::add_string_val(const void* value, size_t size) {
   string_val_.Add()->assign(reinterpret_cast<const char*>(value), size);
-  // @@protoc_insertion_point(field_add_pointer:tensorflow.TensorProto.string_val)
+  // @@protoc_insertion_point(field_add_pointer:opencv_tensorflow.TensorProto.string_val)
 }
 inline const ::google::protobuf::RepeatedPtrField< ::std::string>&
 TensorProto::string_val() const {
-  // @@protoc_insertion_point(field_list:tensorflow.TensorProto.string_val)
+  // @@protoc_insertion_point(field_list:opencv_tensorflow.TensorProto.string_val)
   return string_val_;
 }
 inline ::google::protobuf::RepeatedPtrField< ::std::string>*
 TensorProto::mutable_string_val() {
-  // @@protoc_insertion_point(field_mutable_list:tensorflow.TensorProto.string_val)
+  // @@protoc_insertion_point(field_mutable_list:opencv_tensorflow.TensorProto.string_val)
   return &string_val_;
 }
 
@@ -719,25 +719,25 @@ inline void TensorProto::clear_scomplex_val() {
   scomplex_val_.Clear();
 }
 inline float TensorProto::scomplex_val(int index) const {
-  // @@protoc_insertion_point(field_get:tensorflow.TensorProto.scomplex_val)
+  // @@protoc_insertion_point(field_get:opencv_tensorflow.TensorProto.scomplex_val)
   return scomplex_val_.Get(index);
 }
 inline void TensorProto::set_scomplex_val(int index, float value) {
   scomplex_val_.Set(index, value);
-  // @@protoc_insertion_point(field_set:tensorflow.TensorProto.scomplex_val)
+  // @@protoc_insertion_point(field_set:opencv_tensorflow.TensorProto.scomplex_val)
 }
 inline void TensorProto::add_scomplex_val(float value) {
   scomplex_val_.Add(value);
-  // @@protoc_insertion_point(field_add:tensorflow.TensorProto.scomplex_val)
+  // @@protoc_insertion_point(field_add:opencv_tensorflow.TensorProto.scomplex_val)
 }
 inline const ::google::protobuf::RepeatedField< float >&
 TensorProto::scomplex_val() const {
-  // @@protoc_insertion_point(field_list:tensorflow.TensorProto.scomplex_val)
+  // @@protoc_insertion_point(field_list:opencv_tensorflow.TensorProto.scomplex_val)
   return scomplex_val_;
 }
 inline ::google::protobuf::RepeatedField< float >*
 TensorProto::mutable_scomplex_val() {
-  // @@protoc_insertion_point(field_mutable_list:tensorflow.TensorProto.scomplex_val)
+  // @@protoc_insertion_point(field_mutable_list:opencv_tensorflow.TensorProto.scomplex_val)
   return &scomplex_val_;
 }
 
@@ -749,25 +749,25 @@ inline void TensorProto::clear_int64_val() {
   int64_val_.Clear();
 }
 inline ::google::protobuf::int64 TensorProto::int64_val(int index) const {
-  // @@protoc_insertion_point(field_get:tensorflow.TensorProto.int64_val)
+  // @@protoc_insertion_point(field_get:opencv_tensorflow.TensorProto.int64_val)
   return int64_val_.Get(index);
 }
 inline void TensorProto::set_int64_val(int index, ::google::protobuf::int64 value) {
   int64_val_.Set(index, value);
-  // @@protoc_insertion_point(field_set:tensorflow.TensorProto.int64_val)
+  // @@protoc_insertion_point(field_set:opencv_tensorflow.TensorProto.int64_val)
 }
 inline void TensorProto::add_int64_val(::google::protobuf::int64 value) {
   int64_val_.Add(value);
-  // @@protoc_insertion_point(field_add:tensorflow.TensorProto.int64_val)
+  // @@protoc_insertion_point(field_add:opencv_tensorflow.TensorProto.int64_val)
 }
 inline const ::google::protobuf::RepeatedField< ::google::protobuf::int64 >&
 TensorProto::int64_val() const {
-  // @@protoc_insertion_point(field_list:tensorflow.TensorProto.int64_val)
+  // @@protoc_insertion_point(field_list:opencv_tensorflow.TensorProto.int64_val)
   return int64_val_;
 }
 inline ::google::protobuf::RepeatedField< ::google::protobuf::int64 >*
 TensorProto::mutable_int64_val() {
-  // @@protoc_insertion_point(field_mutable_list:tensorflow.TensorProto.int64_val)
+  // @@protoc_insertion_point(field_mutable_list:opencv_tensorflow.TensorProto.int64_val)
   return &int64_val_;
 }
 
@@ -779,25 +779,25 @@ inline void TensorProto::clear_bool_val() {
   bool_val_.Clear();
 }
 inline bool TensorProto::bool_val(int index) const {
-  // @@protoc_insertion_point(field_get:tensorflow.TensorProto.bool_val)
+  // @@protoc_insertion_point(field_get:opencv_tensorflow.TensorProto.bool_val)
   return bool_val_.Get(index);
 }
 inline void TensorProto::set_bool_val(int index, bool value) {
   bool_val_.Set(index, value);
-  // @@protoc_insertion_point(field_set:tensorflow.TensorProto.bool_val)
+  // @@protoc_insertion_point(field_set:opencv_tensorflow.TensorProto.bool_val)
 }
 inline void TensorProto::add_bool_val(bool value) {
   bool_val_.Add(value);
-  // @@protoc_insertion_point(field_add:tensorflow.TensorProto.bool_val)
+  // @@protoc_insertion_point(field_add:opencv_tensorflow.TensorProto.bool_val)
 }
 inline const ::google::protobuf::RepeatedField< bool >&
 TensorProto::bool_val() const {
-  // @@protoc_insertion_point(field_list:tensorflow.TensorProto.bool_val)
+  // @@protoc_insertion_point(field_list:opencv_tensorflow.TensorProto.bool_val)
   return bool_val_;
 }
 inline ::google::protobuf::RepeatedField< bool >*
 TensorProto::mutable_bool_val() {
-  // @@protoc_insertion_point(field_mutable_list:tensorflow.TensorProto.bool_val)
+  // @@protoc_insertion_point(field_mutable_list:opencv_tensorflow.TensorProto.bool_val)
   return &bool_val_;
 }
 
@@ -809,25 +809,25 @@ inline void TensorProto::clear_dcomplex_val() {
   dcomplex_val_.Clear();
 }
 inline double TensorProto::dcomplex_val(int index) const {
-  // @@protoc_insertion_point(field_get:tensorflow.TensorProto.dcomplex_val)
+  // @@protoc_insertion_point(field_get:opencv_tensorflow.TensorProto.dcomplex_val)
   return dcomplex_val_.Get(index);
 }
 inline void TensorProto::set_dcomplex_val(int index, double value) {
   dcomplex_val_.Set(index, value);
-  // @@protoc_insertion_point(field_set:tensorflow.TensorProto.dcomplex_val)
+  // @@protoc_insertion_point(field_set:opencv_tensorflow.TensorProto.dcomplex_val)
 }
 inline void TensorProto::add_dcomplex_val(double value) {
   dcomplex_val_.Add(value);
-  // @@protoc_insertion_point(field_add:tensorflow.TensorProto.dcomplex_val)
+  // @@protoc_insertion_point(field_add:opencv_tensorflow.TensorProto.dcomplex_val)
 }
 inline const ::google::protobuf::RepeatedField< double >&
 TensorProto::dcomplex_val() const {
-  // @@protoc_insertion_point(field_list:tensorflow.TensorProto.dcomplex_val)
+  // @@protoc_insertion_point(field_list:opencv_tensorflow.TensorProto.dcomplex_val)
   return dcomplex_val_;
 }
 inline ::google::protobuf::RepeatedField< double >*
 TensorProto::mutable_dcomplex_val() {
-  // @@protoc_insertion_point(field_mutable_list:tensorflow.TensorProto.dcomplex_val)
+  // @@protoc_insertion_point(field_mutable_list:opencv_tensorflow.TensorProto.dcomplex_val)
   return &dcomplex_val_;
 }
 
@@ -837,7 +837,7 @@ TensorProto::mutable_dcomplex_val() {
 
 // @@protoc_insertion_point(namespace_scope)
 
-}  // namespace tensorflow
+}  // namespace opencv_tensorflow
 
 // @@protoc_insertion_point(global_scope)
 

--- a/modules/dnn/misc/tensorflow/tensor_shape.pb.cc
+++ b/modules/dnn/misc/tensorflow/tensor_shape.pb.cc
@@ -19,7 +19,7 @@
 #include "third_party/protobuf/version.h"
 #endif
 // @@protoc_insertion_point(includes)
-namespace tensorflow {
+namespace opencv_tensorflow {
 class TensorShapeProto_DimDefaultTypeInternal {
  public:
   ::google::protobuf::internal::ExplicitlyConstructed<TensorShapeProto_Dim>
@@ -30,7 +30,7 @@ class TensorShapeProtoDefaultTypeInternal {
   ::google::protobuf::internal::ExplicitlyConstructed<TensorShapeProto>
       _instance;
 } _TensorShapeProto_default_instance_;
-}  // namespace tensorflow
+}  // namespace opencv_tensorflow
 namespace protobuf_tensor_5fshape_2eproto {
 void InitDefaultsTensorShapeProto_DimImpl() {
   GOOGLE_PROTOBUF_VERIFY_VERSION;
@@ -41,11 +41,11 @@ void InitDefaultsTensorShapeProto_DimImpl() {
   ::google::protobuf::internal::InitProtobufDefaults();
 #endif  // GOOGLE_PROTOBUF_ENFORCE_UNIQUENESS
   {
-    void* ptr = &::tensorflow::_TensorShapeProto_Dim_default_instance_;
-    new (ptr) ::tensorflow::TensorShapeProto_Dim();
+    void* ptr = &::opencv_tensorflow::_TensorShapeProto_Dim_default_instance_;
+    new (ptr) ::opencv_tensorflow::TensorShapeProto_Dim();
     ::google::protobuf::internal::OnShutdownDestroyMessage(ptr);
   }
-  ::tensorflow::TensorShapeProto_Dim::InitAsDefaultInstance();
+  ::opencv_tensorflow::TensorShapeProto_Dim::InitAsDefaultInstance();
 }
 
 void InitDefaultsTensorShapeProto_Dim() {
@@ -63,11 +63,11 @@ void InitDefaultsTensorShapeProtoImpl() {
 #endif  // GOOGLE_PROTOBUF_ENFORCE_UNIQUENESS
   protobuf_tensor_5fshape_2eproto::InitDefaultsTensorShapeProto_Dim();
   {
-    void* ptr = &::tensorflow::_TensorShapeProto_default_instance_;
-    new (ptr) ::tensorflow::TensorShapeProto();
+    void* ptr = &::opencv_tensorflow::_TensorShapeProto_default_instance_;
+    new (ptr) ::opencv_tensorflow::TensorShapeProto();
     ::google::protobuf::internal::OnShutdownDestroyMessage(ptr);
   }
-  ::tensorflow::TensorShapeProto::InitAsDefaultInstance();
+  ::opencv_tensorflow::TensorShapeProto::InitAsDefaultInstance();
 }
 
 void InitDefaultsTensorShapeProto() {
@@ -79,28 +79,28 @@ void InitDefaultsTensorShapeProto() {
 
 const ::google::protobuf::uint32 TableStruct::offsets[] GOOGLE_PROTOBUF_ATTRIBUTE_SECTION_VARIABLE(protodesc_cold) = {
   ~0u,  // no _has_bits_
-  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::tensorflow::TensorShapeProto_Dim, _internal_metadata_),
+  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::opencv_tensorflow::TensorShapeProto_Dim, _internal_metadata_),
   ~0u,  // no _extensions_
   ~0u,  // no _oneof_case_
   ~0u,  // no _weak_field_map_
-  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::tensorflow::TensorShapeProto_Dim, size_),
-  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::tensorflow::TensorShapeProto_Dim, name_),
+  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::opencv_tensorflow::TensorShapeProto_Dim, size_),
+  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::opencv_tensorflow::TensorShapeProto_Dim, name_),
   ~0u,  // no _has_bits_
-  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::tensorflow::TensorShapeProto, _internal_metadata_),
+  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::opencv_tensorflow::TensorShapeProto, _internal_metadata_),
   ~0u,  // no _extensions_
   ~0u,  // no _oneof_case_
   ~0u,  // no _weak_field_map_
-  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::tensorflow::TensorShapeProto, dim_),
-  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::tensorflow::TensorShapeProto, unknown_rank_),
+  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::opencv_tensorflow::TensorShapeProto, dim_),
+  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::opencv_tensorflow::TensorShapeProto, unknown_rank_),
 };
 static const ::google::protobuf::internal::MigrationSchema schemas[] GOOGLE_PROTOBUF_ATTRIBUTE_SECTION_VARIABLE(protodesc_cold) = {
-  { 0, -1, sizeof(::tensorflow::TensorShapeProto_Dim)},
-  { 7, -1, sizeof(::tensorflow::TensorShapeProto)},
+  { 0, -1, sizeof(::opencv_tensorflow::TensorShapeProto_Dim)},
+  { 7, -1, sizeof(::opencv_tensorflow::TensorShapeProto)},
 };
 
 static ::google::protobuf::Message const * const file_default_instances[] = {
-  reinterpret_cast<const ::google::protobuf::Message*>(&::tensorflow::_TensorShapeProto_Dim_default_instance_),
-  reinterpret_cast<const ::google::protobuf::Message*>(&::tensorflow::_TensorShapeProto_default_instance_),
+  reinterpret_cast<const ::google::protobuf::Message*>(&::opencv_tensorflow::_TensorShapeProto_Dim_default_instance_),
+  reinterpret_cast<const ::google::protobuf::Message*>(&::opencv_tensorflow::_TensorShapeProto_default_instance_),
 };
 
 void protobuf_AssignDescriptors() {
@@ -125,15 +125,15 @@ void protobuf_RegisterTypes(const ::std::string&) {
 void AddDescriptorsImpl() {
   InitDefaults();
   static const char descriptor[] GOOGLE_PROTOBUF_ATTRIBUTE_SECTION_VARIABLE(protodesc_cold) = {
-      "\n\022tensor_shape.proto\022\ntensorflow\"z\n\020Tens"
-      "orShapeProto\022-\n\003dim\030\002 \003(\0132 .tensorflow.T"
-      "ensorShapeProto.Dim\022\024\n\014unknown_rank\030\003 \001("
-      "\010\032!\n\003Dim\022\014\n\004size\030\001 \001(\003\022\014\n\004name\030\002 \001(\tB2\n\030"
-      "org.tensorflow.frameworkB\021TensorShapePro"
-      "tosP\001\370\001\001b\006proto3"
+      "\n\022tensor_shape.proto\022\021opencv_tensorflow\""
+      "\201\001\n\020TensorShapeProto\0224\n\003dim\030\002 \003(\0132\'.open"
+      "cv_tensorflow.TensorShapeProto.Dim\022\024\n\014un"
+      "known_rank\030\003 \001(\010\032!\n\003Dim\022\014\n\004size\030\001 \001(\003\022\014\n"
+      "\004name\030\002 \001(\tB2\n\030org.tensorflow.frameworkB"
+      "\021TensorShapeProtosP\001\370\001\001b\006proto3"
   };
   ::google::protobuf::DescriptorPool::InternalAddGeneratedFile(
-      descriptor, 216);
+      descriptor, 231);
   ::google::protobuf::MessageFactory::InternalRegisterGeneratedFile(
     "tensor_shape.proto", &protobuf_RegisterTypes);
 }
@@ -149,7 +149,7 @@ struct StaticDescriptorInitializer {
   }
 } static_descriptor_initializer;
 }  // namespace protobuf_tensor_5fshape_2eproto
-namespace tensorflow {
+namespace opencv_tensorflow {
 
 // ===================================================================
 
@@ -166,7 +166,7 @@ TensorShapeProto_Dim::TensorShapeProto_Dim()
     ::protobuf_tensor_5fshape_2eproto::InitDefaultsTensorShapeProto_Dim();
   }
   SharedCtor();
-  // @@protoc_insertion_point(constructor:tensorflow.TensorShapeProto.Dim)
+  // @@protoc_insertion_point(constructor:opencv_tensorflow.TensorShapeProto.Dim)
 }
 TensorShapeProto_Dim::TensorShapeProto_Dim(::google::protobuf::Arena* arena)
   : ::google::protobuf::Message(),
@@ -174,7 +174,7 @@ TensorShapeProto_Dim::TensorShapeProto_Dim(::google::protobuf::Arena* arena)
   ::protobuf_tensor_5fshape_2eproto::InitDefaultsTensorShapeProto_Dim();
   SharedCtor();
   RegisterArenaDtor(arena);
-  // @@protoc_insertion_point(arena_constructor:tensorflow.TensorShapeProto.Dim)
+  // @@protoc_insertion_point(arena_constructor:opencv_tensorflow.TensorShapeProto.Dim)
 }
 TensorShapeProto_Dim::TensorShapeProto_Dim(const TensorShapeProto_Dim& from)
   : ::google::protobuf::Message(),
@@ -187,7 +187,7 @@ TensorShapeProto_Dim::TensorShapeProto_Dim(const TensorShapeProto_Dim& from)
       GetArenaNoVirtual());
   }
   size_ = from.size_;
-  // @@protoc_insertion_point(copy_constructor:tensorflow.TensorShapeProto.Dim)
+  // @@protoc_insertion_point(copy_constructor:opencv_tensorflow.TensorShapeProto.Dim)
 }
 
 void TensorShapeProto_Dim::SharedCtor() {
@@ -197,7 +197,7 @@ void TensorShapeProto_Dim::SharedCtor() {
 }
 
 TensorShapeProto_Dim::~TensorShapeProto_Dim() {
-  // @@protoc_insertion_point(destructor:tensorflow.TensorShapeProto.Dim)
+  // @@protoc_insertion_point(destructor:opencv_tensorflow.TensorShapeProto.Dim)
   SharedDtor();
 }
 
@@ -232,7 +232,7 @@ TensorShapeProto_Dim* TensorShapeProto_Dim::New(::google::protobuf::Arena* arena
 }
 
 void TensorShapeProto_Dim::Clear() {
-// @@protoc_insertion_point(message_clear_start:tensorflow.TensorShapeProto.Dim)
+// @@protoc_insertion_point(message_clear_start:opencv_tensorflow.TensorShapeProto.Dim)
   ::google::protobuf::uint32 cached_has_bits = 0;
   // Prevent compiler warnings about cached_has_bits being unused
   (void) cached_has_bits;
@@ -246,7 +246,7 @@ bool TensorShapeProto_Dim::MergePartialFromCodedStream(
     ::google::protobuf::io::CodedInputStream* input) {
 #define DO_(EXPRESSION) if (!GOOGLE_PREDICT_TRUE(EXPRESSION)) goto failure
   ::google::protobuf::uint32 tag;
-  // @@protoc_insertion_point(parse_start:tensorflow.TensorShapeProto.Dim)
+  // @@protoc_insertion_point(parse_start:opencv_tensorflow.TensorShapeProto.Dim)
   for (;;) {
     ::std::pair< ::google::protobuf::uint32, bool> p = input->ReadTagWithCutoffNoLastTag(127u);
     tag = p.first;
@@ -275,7 +275,7 @@ bool TensorShapeProto_Dim::MergePartialFromCodedStream(
           DO_(::google::protobuf::internal::WireFormatLite::VerifyUtf8String(
             this->name().data(), static_cast<int>(this->name().length()),
             ::google::protobuf::internal::WireFormatLite::PARSE,
-            "tensorflow.TensorShapeProto.Dim.name"));
+            "opencv_tensorflow.TensorShapeProto.Dim.name"));
         } else {
           goto handle_unusual;
         }
@@ -294,17 +294,17 @@ bool TensorShapeProto_Dim::MergePartialFromCodedStream(
     }
   }
 success:
-  // @@protoc_insertion_point(parse_success:tensorflow.TensorShapeProto.Dim)
+  // @@protoc_insertion_point(parse_success:opencv_tensorflow.TensorShapeProto.Dim)
   return true;
 failure:
-  // @@protoc_insertion_point(parse_failure:tensorflow.TensorShapeProto.Dim)
+  // @@protoc_insertion_point(parse_failure:opencv_tensorflow.TensorShapeProto.Dim)
   return false;
 #undef DO_
 }
 
 void TensorShapeProto_Dim::SerializeWithCachedSizes(
     ::google::protobuf::io::CodedOutputStream* output) const {
-  // @@protoc_insertion_point(serialize_start:tensorflow.TensorShapeProto.Dim)
+  // @@protoc_insertion_point(serialize_start:opencv_tensorflow.TensorShapeProto.Dim)
   ::google::protobuf::uint32 cached_has_bits = 0;
   (void) cached_has_bits;
 
@@ -318,7 +318,7 @@ void TensorShapeProto_Dim::SerializeWithCachedSizes(
     ::google::protobuf::internal::WireFormatLite::VerifyUtf8String(
       this->name().data(), static_cast<int>(this->name().length()),
       ::google::protobuf::internal::WireFormatLite::SERIALIZE,
-      "tensorflow.TensorShapeProto.Dim.name");
+      "opencv_tensorflow.TensorShapeProto.Dim.name");
     ::google::protobuf::internal::WireFormatLite::WriteStringMaybeAliased(
       2, this->name(), output);
   }
@@ -327,13 +327,13 @@ void TensorShapeProto_Dim::SerializeWithCachedSizes(
     ::google::protobuf::internal::WireFormat::SerializeUnknownFields(
         (::google::protobuf::internal::GetProto3PreserveUnknownsDefault()   ? _internal_metadata_.unknown_fields()   : _internal_metadata_.default_instance()), output);
   }
-  // @@protoc_insertion_point(serialize_end:tensorflow.TensorShapeProto.Dim)
+  // @@protoc_insertion_point(serialize_end:opencv_tensorflow.TensorShapeProto.Dim)
 }
 
 ::google::protobuf::uint8* TensorShapeProto_Dim::InternalSerializeWithCachedSizesToArray(
     bool deterministic, ::google::protobuf::uint8* target) const {
   (void)deterministic; // Unused
-  // @@protoc_insertion_point(serialize_to_array_start:tensorflow.TensorShapeProto.Dim)
+  // @@protoc_insertion_point(serialize_to_array_start:opencv_tensorflow.TensorShapeProto.Dim)
   ::google::protobuf::uint32 cached_has_bits = 0;
   (void) cached_has_bits;
 
@@ -347,7 +347,7 @@ void TensorShapeProto_Dim::SerializeWithCachedSizes(
     ::google::protobuf::internal::WireFormatLite::VerifyUtf8String(
       this->name().data(), static_cast<int>(this->name().length()),
       ::google::protobuf::internal::WireFormatLite::SERIALIZE,
-      "tensorflow.TensorShapeProto.Dim.name");
+      "opencv_tensorflow.TensorShapeProto.Dim.name");
     target =
       ::google::protobuf::internal::WireFormatLite::WriteStringToArray(
         2, this->name(), target);
@@ -357,12 +357,12 @@ void TensorShapeProto_Dim::SerializeWithCachedSizes(
     target = ::google::protobuf::internal::WireFormat::SerializeUnknownFieldsToArray(
         (::google::protobuf::internal::GetProto3PreserveUnknownsDefault()   ? _internal_metadata_.unknown_fields()   : _internal_metadata_.default_instance()), target);
   }
-  // @@protoc_insertion_point(serialize_to_array_end:tensorflow.TensorShapeProto.Dim)
+  // @@protoc_insertion_point(serialize_to_array_end:opencv_tensorflow.TensorShapeProto.Dim)
   return target;
 }
 
 size_t TensorShapeProto_Dim::ByteSizeLong() const {
-// @@protoc_insertion_point(message_byte_size_start:tensorflow.TensorShapeProto.Dim)
+// @@protoc_insertion_point(message_byte_size_start:opencv_tensorflow.TensorShapeProto.Dim)
   size_t total_size = 0;
 
   if ((_internal_metadata_.have_unknown_fields() &&  ::google::protobuf::internal::GetProto3PreserveUnknownsDefault())) {
@@ -392,22 +392,22 @@ size_t TensorShapeProto_Dim::ByteSizeLong() const {
 }
 
 void TensorShapeProto_Dim::MergeFrom(const ::google::protobuf::Message& from) {
-// @@protoc_insertion_point(generalized_merge_from_start:tensorflow.TensorShapeProto.Dim)
+// @@protoc_insertion_point(generalized_merge_from_start:opencv_tensorflow.TensorShapeProto.Dim)
   GOOGLE_DCHECK_NE(&from, this);
   const TensorShapeProto_Dim* source =
       ::google::protobuf::internal::DynamicCastToGenerated<const TensorShapeProto_Dim>(
           &from);
   if (source == NULL) {
-  // @@protoc_insertion_point(generalized_merge_from_cast_fail:tensorflow.TensorShapeProto.Dim)
+  // @@protoc_insertion_point(generalized_merge_from_cast_fail:opencv_tensorflow.TensorShapeProto.Dim)
     ::google::protobuf::internal::ReflectionOps::Merge(from, this);
   } else {
-  // @@protoc_insertion_point(generalized_merge_from_cast_success:tensorflow.TensorShapeProto.Dim)
+  // @@protoc_insertion_point(generalized_merge_from_cast_success:opencv_tensorflow.TensorShapeProto.Dim)
     MergeFrom(*source);
   }
 }
 
 void TensorShapeProto_Dim::MergeFrom(const TensorShapeProto_Dim& from) {
-// @@protoc_insertion_point(class_specific_merge_from_start:tensorflow.TensorShapeProto.Dim)
+// @@protoc_insertion_point(class_specific_merge_from_start:opencv_tensorflow.TensorShapeProto.Dim)
   GOOGLE_DCHECK_NE(&from, this);
   _internal_metadata_.MergeFrom(from._internal_metadata_);
   ::google::protobuf::uint32 cached_has_bits = 0;
@@ -422,14 +422,14 @@ void TensorShapeProto_Dim::MergeFrom(const TensorShapeProto_Dim& from) {
 }
 
 void TensorShapeProto_Dim::CopyFrom(const ::google::protobuf::Message& from) {
-// @@protoc_insertion_point(generalized_copy_from_start:tensorflow.TensorShapeProto.Dim)
+// @@protoc_insertion_point(generalized_copy_from_start:opencv_tensorflow.TensorShapeProto.Dim)
   if (&from == this) return;
   Clear();
   MergeFrom(from);
 }
 
 void TensorShapeProto_Dim::CopyFrom(const TensorShapeProto_Dim& from) {
-// @@protoc_insertion_point(class_specific_copy_from_start:tensorflow.TensorShapeProto.Dim)
+// @@protoc_insertion_point(class_specific_copy_from_start:opencv_tensorflow.TensorShapeProto.Dim)
   if (&from == this) return;
   Clear();
   MergeFrom(from);
@@ -487,7 +487,7 @@ TensorShapeProto::TensorShapeProto()
     ::protobuf_tensor_5fshape_2eproto::InitDefaultsTensorShapeProto();
   }
   SharedCtor();
-  // @@protoc_insertion_point(constructor:tensorflow.TensorShapeProto)
+  // @@protoc_insertion_point(constructor:opencv_tensorflow.TensorShapeProto)
 }
 TensorShapeProto::TensorShapeProto(::google::protobuf::Arena* arena)
   : ::google::protobuf::Message(),
@@ -496,7 +496,7 @@ TensorShapeProto::TensorShapeProto(::google::protobuf::Arena* arena)
   ::protobuf_tensor_5fshape_2eproto::InitDefaultsTensorShapeProto();
   SharedCtor();
   RegisterArenaDtor(arena);
-  // @@protoc_insertion_point(arena_constructor:tensorflow.TensorShapeProto)
+  // @@protoc_insertion_point(arena_constructor:opencv_tensorflow.TensorShapeProto)
 }
 TensorShapeProto::TensorShapeProto(const TensorShapeProto& from)
   : ::google::protobuf::Message(),
@@ -505,7 +505,7 @@ TensorShapeProto::TensorShapeProto(const TensorShapeProto& from)
       _cached_size_(0) {
   _internal_metadata_.MergeFrom(from._internal_metadata_);
   unknown_rank_ = from.unknown_rank_;
-  // @@protoc_insertion_point(copy_constructor:tensorflow.TensorShapeProto)
+  // @@protoc_insertion_point(copy_constructor:opencv_tensorflow.TensorShapeProto)
 }
 
 void TensorShapeProto::SharedCtor() {
@@ -514,7 +514,7 @@ void TensorShapeProto::SharedCtor() {
 }
 
 TensorShapeProto::~TensorShapeProto() {
-  // @@protoc_insertion_point(destructor:tensorflow.TensorShapeProto)
+  // @@protoc_insertion_point(destructor:opencv_tensorflow.TensorShapeProto)
   SharedDtor();
 }
 
@@ -548,7 +548,7 @@ TensorShapeProto* TensorShapeProto::New(::google::protobuf::Arena* arena) const 
 }
 
 void TensorShapeProto::Clear() {
-// @@protoc_insertion_point(message_clear_start:tensorflow.TensorShapeProto)
+// @@protoc_insertion_point(message_clear_start:opencv_tensorflow.TensorShapeProto)
   ::google::protobuf::uint32 cached_has_bits = 0;
   // Prevent compiler warnings about cached_has_bits being unused
   (void) cached_has_bits;
@@ -562,13 +562,13 @@ bool TensorShapeProto::MergePartialFromCodedStream(
     ::google::protobuf::io::CodedInputStream* input) {
 #define DO_(EXPRESSION) if (!GOOGLE_PREDICT_TRUE(EXPRESSION)) goto failure
   ::google::protobuf::uint32 tag;
-  // @@protoc_insertion_point(parse_start:tensorflow.TensorShapeProto)
+  // @@protoc_insertion_point(parse_start:opencv_tensorflow.TensorShapeProto)
   for (;;) {
     ::std::pair< ::google::protobuf::uint32, bool> p = input->ReadTagWithCutoffNoLastTag(127u);
     tag = p.first;
     if (!p.second) goto handle_unusual;
     switch (::google::protobuf::internal::WireFormatLite::GetTagFieldNumber(tag)) {
-      // repeated .tensorflow.TensorShapeProto.Dim dim = 2;
+      // repeated .opencv_tensorflow.TensorShapeProto.Dim dim = 2;
       case 2: {
         if (static_cast< ::google::protobuf::uint8>(tag) ==
             static_cast< ::google::protobuf::uint8>(18u /* 18 & 0xFF */)) {
@@ -605,21 +605,21 @@ bool TensorShapeProto::MergePartialFromCodedStream(
     }
   }
 success:
-  // @@protoc_insertion_point(parse_success:tensorflow.TensorShapeProto)
+  // @@protoc_insertion_point(parse_success:opencv_tensorflow.TensorShapeProto)
   return true;
 failure:
-  // @@protoc_insertion_point(parse_failure:tensorflow.TensorShapeProto)
+  // @@protoc_insertion_point(parse_failure:opencv_tensorflow.TensorShapeProto)
   return false;
 #undef DO_
 }
 
 void TensorShapeProto::SerializeWithCachedSizes(
     ::google::protobuf::io::CodedOutputStream* output) const {
-  // @@protoc_insertion_point(serialize_start:tensorflow.TensorShapeProto)
+  // @@protoc_insertion_point(serialize_start:opencv_tensorflow.TensorShapeProto)
   ::google::protobuf::uint32 cached_has_bits = 0;
   (void) cached_has_bits;
 
-  // repeated .tensorflow.TensorShapeProto.Dim dim = 2;
+  // repeated .opencv_tensorflow.TensorShapeProto.Dim dim = 2;
   for (unsigned int i = 0,
       n = static_cast<unsigned int>(this->dim_size()); i < n; i++) {
     ::google::protobuf::internal::WireFormatLite::WriteMessageMaybeToArray(
@@ -635,17 +635,17 @@ void TensorShapeProto::SerializeWithCachedSizes(
     ::google::protobuf::internal::WireFormat::SerializeUnknownFields(
         (::google::protobuf::internal::GetProto3PreserveUnknownsDefault()   ? _internal_metadata_.unknown_fields()   : _internal_metadata_.default_instance()), output);
   }
-  // @@protoc_insertion_point(serialize_end:tensorflow.TensorShapeProto)
+  // @@protoc_insertion_point(serialize_end:opencv_tensorflow.TensorShapeProto)
 }
 
 ::google::protobuf::uint8* TensorShapeProto::InternalSerializeWithCachedSizesToArray(
     bool deterministic, ::google::protobuf::uint8* target) const {
   (void)deterministic; // Unused
-  // @@protoc_insertion_point(serialize_to_array_start:tensorflow.TensorShapeProto)
+  // @@protoc_insertion_point(serialize_to_array_start:opencv_tensorflow.TensorShapeProto)
   ::google::protobuf::uint32 cached_has_bits = 0;
   (void) cached_has_bits;
 
-  // repeated .tensorflow.TensorShapeProto.Dim dim = 2;
+  // repeated .opencv_tensorflow.TensorShapeProto.Dim dim = 2;
   for (unsigned int i = 0,
       n = static_cast<unsigned int>(this->dim_size()); i < n; i++) {
     target = ::google::protobuf::internal::WireFormatLite::
@@ -662,12 +662,12 @@ void TensorShapeProto::SerializeWithCachedSizes(
     target = ::google::protobuf::internal::WireFormat::SerializeUnknownFieldsToArray(
         (::google::protobuf::internal::GetProto3PreserveUnknownsDefault()   ? _internal_metadata_.unknown_fields()   : _internal_metadata_.default_instance()), target);
   }
-  // @@protoc_insertion_point(serialize_to_array_end:tensorflow.TensorShapeProto)
+  // @@protoc_insertion_point(serialize_to_array_end:opencv_tensorflow.TensorShapeProto)
   return target;
 }
 
 size_t TensorShapeProto::ByteSizeLong() const {
-// @@protoc_insertion_point(message_byte_size_start:tensorflow.TensorShapeProto)
+// @@protoc_insertion_point(message_byte_size_start:opencv_tensorflow.TensorShapeProto)
   size_t total_size = 0;
 
   if ((_internal_metadata_.have_unknown_fields() &&  ::google::protobuf::internal::GetProto3PreserveUnknownsDefault())) {
@@ -675,7 +675,7 @@ size_t TensorShapeProto::ByteSizeLong() const {
       ::google::protobuf::internal::WireFormat::ComputeUnknownFieldsSize(
         (::google::protobuf::internal::GetProto3PreserveUnknownsDefault()   ? _internal_metadata_.unknown_fields()   : _internal_metadata_.default_instance()));
   }
-  // repeated .tensorflow.TensorShapeProto.Dim dim = 2;
+  // repeated .opencv_tensorflow.TensorShapeProto.Dim dim = 2;
   {
     unsigned int count = static_cast<unsigned int>(this->dim_size());
     total_size += 1UL * count;
@@ -699,22 +699,22 @@ size_t TensorShapeProto::ByteSizeLong() const {
 }
 
 void TensorShapeProto::MergeFrom(const ::google::protobuf::Message& from) {
-// @@protoc_insertion_point(generalized_merge_from_start:tensorflow.TensorShapeProto)
+// @@protoc_insertion_point(generalized_merge_from_start:opencv_tensorflow.TensorShapeProto)
   GOOGLE_DCHECK_NE(&from, this);
   const TensorShapeProto* source =
       ::google::protobuf::internal::DynamicCastToGenerated<const TensorShapeProto>(
           &from);
   if (source == NULL) {
-  // @@protoc_insertion_point(generalized_merge_from_cast_fail:tensorflow.TensorShapeProto)
+  // @@protoc_insertion_point(generalized_merge_from_cast_fail:opencv_tensorflow.TensorShapeProto)
     ::google::protobuf::internal::ReflectionOps::Merge(from, this);
   } else {
-  // @@protoc_insertion_point(generalized_merge_from_cast_success:tensorflow.TensorShapeProto)
+  // @@protoc_insertion_point(generalized_merge_from_cast_success:opencv_tensorflow.TensorShapeProto)
     MergeFrom(*source);
   }
 }
 
 void TensorShapeProto::MergeFrom(const TensorShapeProto& from) {
-// @@protoc_insertion_point(class_specific_merge_from_start:tensorflow.TensorShapeProto)
+// @@protoc_insertion_point(class_specific_merge_from_start:opencv_tensorflow.TensorShapeProto)
   GOOGLE_DCHECK_NE(&from, this);
   _internal_metadata_.MergeFrom(from._internal_metadata_);
   ::google::protobuf::uint32 cached_has_bits = 0;
@@ -727,14 +727,14 @@ void TensorShapeProto::MergeFrom(const TensorShapeProto& from) {
 }
 
 void TensorShapeProto::CopyFrom(const ::google::protobuf::Message& from) {
-// @@protoc_insertion_point(generalized_copy_from_start:tensorflow.TensorShapeProto)
+// @@protoc_insertion_point(generalized_copy_from_start:opencv_tensorflow.TensorShapeProto)
   if (&from == this) return;
   Clear();
   MergeFrom(from);
 }
 
 void TensorShapeProto::CopyFrom(const TensorShapeProto& from) {
-// @@protoc_insertion_point(class_specific_copy_from_start:tensorflow.TensorShapeProto)
+// @@protoc_insertion_point(class_specific_copy_from_start:opencv_tensorflow.TensorShapeProto)
   if (&from == this) return;
   Clear();
   MergeFrom(from);
@@ -778,6 +778,6 @@ void TensorShapeProto::InternalSwap(TensorShapeProto* other) {
 
 
 // @@protoc_insertion_point(namespace_scope)
-}  // namespace tensorflow
+}  // namespace opencv_tensorflow
 
 // @@protoc_insertion_point(global_scope)

--- a/modules/dnn/misc/tensorflow/tensor_shape.pb.h
+++ b/modules/dnn/misc/tensorflow/tensor_shape.pb.h
@@ -51,19 +51,19 @@ inline void InitDefaults() {
   InitDefaultsTensorShapeProto();
 }
 }  // namespace protobuf_tensor_5fshape_2eproto
-namespace tensorflow {
+namespace opencv_tensorflow {
 class TensorShapeProto;
 class TensorShapeProtoDefaultTypeInternal;
 extern TensorShapeProtoDefaultTypeInternal _TensorShapeProto_default_instance_;
 class TensorShapeProto_Dim;
 class TensorShapeProto_DimDefaultTypeInternal;
 extern TensorShapeProto_DimDefaultTypeInternal _TensorShapeProto_Dim_default_instance_;
-}  // namespace tensorflow
-namespace tensorflow {
+}  // namespace opencv_tensorflow
+namespace opencv_tensorflow {
 
 // ===================================================================
 
-class TensorShapeProto_Dim : public ::google::protobuf::Message /* @@protoc_insertion_point(class_definition:tensorflow.TensorShapeProto.Dim) */ {
+class TensorShapeProto_Dim : public ::google::protobuf::Message /* @@protoc_insertion_point(class_definition:opencv_tensorflow.TensorShapeProto.Dim) */ {
  public:
   TensorShapeProto_Dim();
   virtual ~TensorShapeProto_Dim();
@@ -186,7 +186,7 @@ class TensorShapeProto_Dim : public ::google::protobuf::Message /* @@protoc_inse
   ::google::protobuf::int64 size() const;
   void set_size(::google::protobuf::int64 value);
 
-  // @@protoc_insertion_point(class_scope:tensorflow.TensorShapeProto.Dim)
+  // @@protoc_insertion_point(class_scope:opencv_tensorflow.TensorShapeProto.Dim)
  private:
 
   ::google::protobuf::internal::InternalMetadataWithArena _internal_metadata_;
@@ -201,7 +201,7 @@ class TensorShapeProto_Dim : public ::google::protobuf::Message /* @@protoc_inse
 };
 // -------------------------------------------------------------------
 
-class TensorShapeProto : public ::google::protobuf::Message /* @@protoc_insertion_point(class_definition:tensorflow.TensorShapeProto) */ {
+class TensorShapeProto : public ::google::protobuf::Message /* @@protoc_insertion_point(class_definition:opencv_tensorflow.TensorShapeProto) */ {
  public:
   TensorShapeProto();
   virtual ~TensorShapeProto();
@@ -297,16 +297,16 @@ class TensorShapeProto : public ::google::protobuf::Message /* @@protoc_insertio
 
   // accessors -------------------------------------------------------
 
-  // repeated .tensorflow.TensorShapeProto.Dim dim = 2;
+  // repeated .opencv_tensorflow.TensorShapeProto.Dim dim = 2;
   int dim_size() const;
   void clear_dim();
   static const int kDimFieldNumber = 2;
-  const ::tensorflow::TensorShapeProto_Dim& dim(int index) const;
-  ::tensorflow::TensorShapeProto_Dim* mutable_dim(int index);
-  ::tensorflow::TensorShapeProto_Dim* add_dim();
-  ::google::protobuf::RepeatedPtrField< ::tensorflow::TensorShapeProto_Dim >*
+  const ::opencv_tensorflow::TensorShapeProto_Dim& dim(int index) const;
+  ::opencv_tensorflow::TensorShapeProto_Dim* mutable_dim(int index);
+  ::opencv_tensorflow::TensorShapeProto_Dim* add_dim();
+  ::google::protobuf::RepeatedPtrField< ::opencv_tensorflow::TensorShapeProto_Dim >*
       mutable_dim();
-  const ::google::protobuf::RepeatedPtrField< ::tensorflow::TensorShapeProto_Dim >&
+  const ::google::protobuf::RepeatedPtrField< ::opencv_tensorflow::TensorShapeProto_Dim >&
       dim() const;
 
   // bool unknown_rank = 3;
@@ -315,14 +315,14 @@ class TensorShapeProto : public ::google::protobuf::Message /* @@protoc_insertio
   bool unknown_rank() const;
   void set_unknown_rank(bool value);
 
-  // @@protoc_insertion_point(class_scope:tensorflow.TensorShapeProto)
+  // @@protoc_insertion_point(class_scope:opencv_tensorflow.TensorShapeProto)
  private:
 
   ::google::protobuf::internal::InternalMetadataWithArena _internal_metadata_;
   template <typename T> friend class ::google::protobuf::Arena::InternalHelper;
   typedef void InternalArenaConstructable_;
   typedef void DestructorSkippable_;
-  ::google::protobuf::RepeatedPtrField< ::tensorflow::TensorShapeProto_Dim > dim_;
+  ::google::protobuf::RepeatedPtrField< ::opencv_tensorflow::TensorShapeProto_Dim > dim_;
   bool unknown_rank_;
   mutable int _cached_size_;
   friend struct ::protobuf_tensor_5fshape_2eproto::TableStruct;
@@ -344,13 +344,13 @@ inline void TensorShapeProto_Dim::clear_size() {
   size_ = GOOGLE_LONGLONG(0);
 }
 inline ::google::protobuf::int64 TensorShapeProto_Dim::size() const {
-  // @@protoc_insertion_point(field_get:tensorflow.TensorShapeProto.Dim.size)
+  // @@protoc_insertion_point(field_get:opencv_tensorflow.TensorShapeProto.Dim.size)
   return size_;
 }
 inline void TensorShapeProto_Dim::set_size(::google::protobuf::int64 value) {
 
   size_ = value;
-  // @@protoc_insertion_point(field_set:tensorflow.TensorShapeProto.Dim.size)
+  // @@protoc_insertion_point(field_set:opencv_tensorflow.TensorShapeProto.Dim.size)
 }
 
 // string name = 2;
@@ -358,20 +358,20 @@ inline void TensorShapeProto_Dim::clear_name() {
   name_.ClearToEmpty(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), GetArenaNoVirtual());
 }
 inline const ::std::string& TensorShapeProto_Dim::name() const {
-  // @@protoc_insertion_point(field_get:tensorflow.TensorShapeProto.Dim.name)
+  // @@protoc_insertion_point(field_get:opencv_tensorflow.TensorShapeProto.Dim.name)
   return name_.Get();
 }
 inline void TensorShapeProto_Dim::set_name(const ::std::string& value) {
 
   name_.Set(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), value, GetArenaNoVirtual());
-  // @@protoc_insertion_point(field_set:tensorflow.TensorShapeProto.Dim.name)
+  // @@protoc_insertion_point(field_set:opencv_tensorflow.TensorShapeProto.Dim.name)
 }
 #if LANG_CXX11
 inline void TensorShapeProto_Dim::set_name(::std::string&& value) {
 
   name_.Set(
     &::google::protobuf::internal::GetEmptyStringAlreadyInited(), ::std::move(value), GetArenaNoVirtual());
-  // @@protoc_insertion_point(field_set_rvalue:tensorflow.TensorShapeProto.Dim.name)
+  // @@protoc_insertion_point(field_set_rvalue:opencv_tensorflow.TensorShapeProto.Dim.name)
 }
 #endif
 inline void TensorShapeProto_Dim::set_name(const char* value) {
@@ -379,22 +379,22 @@ inline void TensorShapeProto_Dim::set_name(const char* value) {
 
   name_.Set(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), ::std::string(value),
               GetArenaNoVirtual());
-  // @@protoc_insertion_point(field_set_char:tensorflow.TensorShapeProto.Dim.name)
+  // @@protoc_insertion_point(field_set_char:opencv_tensorflow.TensorShapeProto.Dim.name)
 }
 inline void TensorShapeProto_Dim::set_name(const char* value,
     size_t size) {
 
   name_.Set(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), ::std::string(
       reinterpret_cast<const char*>(value), size), GetArenaNoVirtual());
-  // @@protoc_insertion_point(field_set_pointer:tensorflow.TensorShapeProto.Dim.name)
+  // @@protoc_insertion_point(field_set_pointer:opencv_tensorflow.TensorShapeProto.Dim.name)
 }
 inline ::std::string* TensorShapeProto_Dim::mutable_name() {
 
-  // @@protoc_insertion_point(field_mutable:tensorflow.TensorShapeProto.Dim.name)
+  // @@protoc_insertion_point(field_mutable:opencv_tensorflow.TensorShapeProto.Dim.name)
   return name_.Mutable(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), GetArenaNoVirtual());
 }
 inline ::std::string* TensorShapeProto_Dim::release_name() {
-  // @@protoc_insertion_point(field_release:tensorflow.TensorShapeProto.Dim.name)
+  // @@protoc_insertion_point(field_release:opencv_tensorflow.TensorShapeProto.Dim.name)
 
   return name_.Release(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), GetArenaNoVirtual());
 }
@@ -406,10 +406,10 @@ inline void TensorShapeProto_Dim::set_allocated_name(::std::string* name) {
   }
   name_.SetAllocated(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), name,
       GetArenaNoVirtual());
-  // @@protoc_insertion_point(field_set_allocated:tensorflow.TensorShapeProto.Dim.name)
+  // @@protoc_insertion_point(field_set_allocated:opencv_tensorflow.TensorShapeProto.Dim.name)
 }
 inline ::std::string* TensorShapeProto_Dim::unsafe_arena_release_name() {
-  // @@protoc_insertion_point(field_unsafe_arena_release:tensorflow.TensorShapeProto.Dim.name)
+  // @@protoc_insertion_point(field_unsafe_arena_release:opencv_tensorflow.TensorShapeProto.Dim.name)
   GOOGLE_DCHECK(GetArenaNoVirtual() != NULL);
 
   return name_.UnsafeArenaRelease(&::google::protobuf::internal::GetEmptyStringAlreadyInited(),
@@ -425,40 +425,40 @@ inline void TensorShapeProto_Dim::unsafe_arena_set_allocated_name(
   }
   name_.UnsafeArenaSetAllocated(&::google::protobuf::internal::GetEmptyStringAlreadyInited(),
       name, GetArenaNoVirtual());
-  // @@protoc_insertion_point(field_unsafe_arena_set_allocated:tensorflow.TensorShapeProto.Dim.name)
+  // @@protoc_insertion_point(field_unsafe_arena_set_allocated:opencv_tensorflow.TensorShapeProto.Dim.name)
 }
 
 // -------------------------------------------------------------------
 
 // TensorShapeProto
 
-// repeated .tensorflow.TensorShapeProto.Dim dim = 2;
+// repeated .opencv_tensorflow.TensorShapeProto.Dim dim = 2;
 inline int TensorShapeProto::dim_size() const {
   return dim_.size();
 }
 inline void TensorShapeProto::clear_dim() {
   dim_.Clear();
 }
-inline const ::tensorflow::TensorShapeProto_Dim& TensorShapeProto::dim(int index) const {
-  // @@protoc_insertion_point(field_get:tensorflow.TensorShapeProto.dim)
+inline const ::opencv_tensorflow::TensorShapeProto_Dim& TensorShapeProto::dim(int index) const {
+  // @@protoc_insertion_point(field_get:opencv_tensorflow.TensorShapeProto.dim)
   return dim_.Get(index);
 }
-inline ::tensorflow::TensorShapeProto_Dim* TensorShapeProto::mutable_dim(int index) {
-  // @@protoc_insertion_point(field_mutable:tensorflow.TensorShapeProto.dim)
+inline ::opencv_tensorflow::TensorShapeProto_Dim* TensorShapeProto::mutable_dim(int index) {
+  // @@protoc_insertion_point(field_mutable:opencv_tensorflow.TensorShapeProto.dim)
   return dim_.Mutable(index);
 }
-inline ::tensorflow::TensorShapeProto_Dim* TensorShapeProto::add_dim() {
-  // @@protoc_insertion_point(field_add:tensorflow.TensorShapeProto.dim)
+inline ::opencv_tensorflow::TensorShapeProto_Dim* TensorShapeProto::add_dim() {
+  // @@protoc_insertion_point(field_add:opencv_tensorflow.TensorShapeProto.dim)
   return dim_.Add();
 }
-inline ::google::protobuf::RepeatedPtrField< ::tensorflow::TensorShapeProto_Dim >*
+inline ::google::protobuf::RepeatedPtrField< ::opencv_tensorflow::TensorShapeProto_Dim >*
 TensorShapeProto::mutable_dim() {
-  // @@protoc_insertion_point(field_mutable_list:tensorflow.TensorShapeProto.dim)
+  // @@protoc_insertion_point(field_mutable_list:opencv_tensorflow.TensorShapeProto.dim)
   return &dim_;
 }
-inline const ::google::protobuf::RepeatedPtrField< ::tensorflow::TensorShapeProto_Dim >&
+inline const ::google::protobuf::RepeatedPtrField< ::opencv_tensorflow::TensorShapeProto_Dim >&
 TensorShapeProto::dim() const {
-  // @@protoc_insertion_point(field_list:tensorflow.TensorShapeProto.dim)
+  // @@protoc_insertion_point(field_list:opencv_tensorflow.TensorShapeProto.dim)
   return dim_;
 }
 
@@ -467,13 +467,13 @@ inline void TensorShapeProto::clear_unknown_rank() {
   unknown_rank_ = false;
 }
 inline bool TensorShapeProto::unknown_rank() const {
-  // @@protoc_insertion_point(field_get:tensorflow.TensorShapeProto.unknown_rank)
+  // @@protoc_insertion_point(field_get:opencv_tensorflow.TensorShapeProto.unknown_rank)
   return unknown_rank_;
 }
 inline void TensorShapeProto::set_unknown_rank(bool value) {
 
   unknown_rank_ = value;
-  // @@protoc_insertion_point(field_set:tensorflow.TensorShapeProto.unknown_rank)
+  // @@protoc_insertion_point(field_set:opencv_tensorflow.TensorShapeProto.unknown_rank)
 }
 
 #ifdef __GNUC__
@@ -484,7 +484,7 @@ inline void TensorShapeProto::set_unknown_rank(bool value) {
 
 // @@protoc_insertion_point(namespace_scope)
 
-}  // namespace tensorflow
+}  // namespace opencv_tensorflow
 
 // @@protoc_insertion_point(global_scope)
 

--- a/modules/dnn/misc/tensorflow/types.pb.cc
+++ b/modules/dnn/misc/tensorflow/types.pb.cc
@@ -19,8 +19,8 @@
 #include "third_party/protobuf/version.h"
 #endif
 // @@protoc_insertion_point(includes)
-namespace tensorflow {
-}  // namespace tensorflow
+namespace opencv_tensorflow {
+}  // namespace opencv_tensorflow
 namespace protobuf_types_2eproto {
 const ::google::protobuf::EnumDescriptor* file_level_enum_descriptors[1];
 const ::google::protobuf::uint32 TableStruct::offsets[1] = {};
@@ -48,28 +48,28 @@ void protobuf_RegisterTypes(const ::std::string&) {
 void AddDescriptorsImpl() {
   InitDefaults();
   static const char descriptor[] GOOGLE_PROTOBUF_ATTRIBUTE_SECTION_VARIABLE(protodesc_cold) = {
-      "\n\013types.proto\022\ntensorflow*\234\005\n\010DataType\022\016"
-      "\n\nDT_INVALID\020\000\022\014\n\010DT_FLOAT\020\001\022\r\n\tDT_DOUBL"
-      "E\020\002\022\014\n\010DT_INT32\020\003\022\014\n\010DT_UINT8\020\004\022\014\n\010DT_IN"
-      "T16\020\005\022\013\n\007DT_INT8\020\006\022\r\n\tDT_STRING\020\007\022\020\n\014DT_"
-      "COMPLEX64\020\010\022\014\n\010DT_INT64\020\t\022\013\n\007DT_BOOL\020\n\022\014"
-      "\n\010DT_QINT8\020\013\022\r\n\tDT_QUINT8\020\014\022\r\n\tDT_QINT32"
-      "\020\r\022\017\n\013DT_BFLOAT16\020\016\022\r\n\tDT_QINT16\020\017\022\016\n\nDT"
-      "_QUINT16\020\020\022\r\n\tDT_UINT16\020\021\022\021\n\rDT_COMPLEX1"
-      "28\020\022\022\013\n\007DT_HALF\020\023\022\020\n\014DT_FLOAT_REF\020e\022\021\n\rD"
-      "T_DOUBLE_REF\020f\022\020\n\014DT_INT32_REF\020g\022\020\n\014DT_U"
-      "INT8_REF\020h\022\020\n\014DT_INT16_REF\020i\022\017\n\013DT_INT8_"
-      "REF\020j\022\021\n\rDT_STRING_REF\020k\022\024\n\020DT_COMPLEX64"
-      "_REF\020l\022\020\n\014DT_INT64_REF\020m\022\017\n\013DT_BOOL_REF\020"
-      "n\022\020\n\014DT_QINT8_REF\020o\022\021\n\rDT_QUINT8_REF\020p\022\021"
-      "\n\rDT_QINT32_REF\020q\022\023\n\017DT_BFLOAT16_REF\020r\022\021"
-      "\n\rDT_QINT16_REF\020s\022\022\n\016DT_QUINT16_REF\020t\022\021\n"
-      "\rDT_UINT16_REF\020u\022\025\n\021DT_COMPLEX128_REF\020v\022"
-      "\017\n\013DT_HALF_REF\020wB,\n\030org.tensorflow.frame"
-      "workB\013TypesProtosP\001\370\001\001b\006proto3"
+      "\n\013types.proto\022\021opencv_tensorflow*\234\005\n\010Dat"
+      "aType\022\016\n\nDT_INVALID\020\000\022\014\n\010DT_FLOAT\020\001\022\r\n\tD"
+      "T_DOUBLE\020\002\022\014\n\010DT_INT32\020\003\022\014\n\010DT_UINT8\020\004\022\014"
+      "\n\010DT_INT16\020\005\022\013\n\007DT_INT8\020\006\022\r\n\tDT_STRING\020\007"
+      "\022\020\n\014DT_COMPLEX64\020\010\022\014\n\010DT_INT64\020\t\022\013\n\007DT_B"
+      "OOL\020\n\022\014\n\010DT_QINT8\020\013\022\r\n\tDT_QUINT8\020\014\022\r\n\tDT"
+      "_QINT32\020\r\022\017\n\013DT_BFLOAT16\020\016\022\r\n\tDT_QINT16\020"
+      "\017\022\016\n\nDT_QUINT16\020\020\022\r\n\tDT_UINT16\020\021\022\021\n\rDT_C"
+      "OMPLEX128\020\022\022\013\n\007DT_HALF\020\023\022\020\n\014DT_FLOAT_REF"
+      "\020e\022\021\n\rDT_DOUBLE_REF\020f\022\020\n\014DT_INT32_REF\020g\022"
+      "\020\n\014DT_UINT8_REF\020h\022\020\n\014DT_INT16_REF\020i\022\017\n\013D"
+      "T_INT8_REF\020j\022\021\n\rDT_STRING_REF\020k\022\024\n\020DT_CO"
+      "MPLEX64_REF\020l\022\020\n\014DT_INT64_REF\020m\022\017\n\013DT_BO"
+      "OL_REF\020n\022\020\n\014DT_QINT8_REF\020o\022\021\n\rDT_QUINT8_"
+      "REF\020p\022\021\n\rDT_QINT32_REF\020q\022\023\n\017DT_BFLOAT16_"
+      "REF\020r\022\021\n\rDT_QINT16_REF\020s\022\022\n\016DT_QUINT16_R"
+      "EF\020t\022\021\n\rDT_UINT16_REF\020u\022\025\n\021DT_COMPLEX128"
+      "_REF\020v\022\017\n\013DT_HALF_REF\020wB,\n\030org.tensorflo"
+      "w.frameworkB\013TypesProtosP\001\370\001\001b\006proto3"
   };
   ::google::protobuf::DescriptorPool::InternalAddGeneratedFile(
-      descriptor, 750);
+      descriptor, 757);
   ::google::protobuf::MessageFactory::InternalRegisterGeneratedFile(
     "types.proto", &protobuf_RegisterTypes);
 }
@@ -85,7 +85,7 @@ struct StaticDescriptorInitializer {
   }
 } static_descriptor_initializer;
 }  // namespace protobuf_types_2eproto
-namespace tensorflow {
+namespace opencv_tensorflow {
 const ::google::protobuf::EnumDescriptor* DataType_descriptor() {
   protobuf_types_2eproto::protobuf_AssignDescriptorsOnce();
   return protobuf_types_2eproto::file_level_enum_descriptors[0];
@@ -139,6 +139,6 @@ bool DataType_IsValid(int value) {
 
 
 // @@protoc_insertion_point(namespace_scope)
-}  // namespace tensorflow
+}  // namespace opencv_tensorflow
 
 // @@protoc_insertion_point(global_scope)

--- a/modules/dnn/misc/tensorflow/types.pb.h
+++ b/modules/dnn/misc/tensorflow/types.pb.h
@@ -44,9 +44,9 @@ void AddDescriptors();
 inline void InitDefaults() {
 }
 }  // namespace protobuf_types_2eproto
-namespace tensorflow {
-}  // namespace tensorflow
-namespace tensorflow {
+namespace opencv_tensorflow {
+}  // namespace opencv_tensorflow
+namespace opencv_tensorflow {
 
 enum DataType {
   DT_INVALID = 0,
@@ -124,15 +124,15 @@ inline bool DataType_Parse(
 
 // @@protoc_insertion_point(namespace_scope)
 
-}  // namespace tensorflow
+}  // namespace opencv_tensorflow
 
 namespace google {
 namespace protobuf {
 
-template <> struct is_proto_enum< ::tensorflow::DataType> : ::google::protobuf::internal::true_type {};
+template <> struct is_proto_enum< ::opencv_tensorflow::DataType> : ::google::protobuf::internal::true_type {};
 template <>
-inline const EnumDescriptor* GetEnumDescriptor< ::tensorflow::DataType>() {
-  return ::tensorflow::DataType_descriptor();
+inline const EnumDescriptor* GetEnumDescriptor< ::opencv_tensorflow::DataType>() {
+  return ::opencv_tensorflow::DataType_descriptor();
 }
 
 }  // namespace protobuf

--- a/modules/dnn/misc/tensorflow/versions.pb.cc
+++ b/modules/dnn/misc/tensorflow/versions.pb.cc
@@ -19,13 +19,13 @@
 #include "third_party/protobuf/version.h"
 #endif
 // @@protoc_insertion_point(includes)
-namespace tensorflow {
+namespace opencv_tensorflow {
 class VersionDefDefaultTypeInternal {
  public:
   ::google::protobuf::internal::ExplicitlyConstructed<VersionDef>
       _instance;
 } _VersionDef_default_instance_;
-}  // namespace tensorflow
+}  // namespace opencv_tensorflow
 namespace protobuf_versions_2eproto {
 void InitDefaultsVersionDefImpl() {
   GOOGLE_PROTOBUF_VERIFY_VERSION;
@@ -36,11 +36,11 @@ void InitDefaultsVersionDefImpl() {
   ::google::protobuf::internal::InitProtobufDefaults();
 #endif  // GOOGLE_PROTOBUF_ENFORCE_UNIQUENESS
   {
-    void* ptr = &::tensorflow::_VersionDef_default_instance_;
-    new (ptr) ::tensorflow::VersionDef();
+    void* ptr = &::opencv_tensorflow::_VersionDef_default_instance_;
+    new (ptr) ::opencv_tensorflow::VersionDef();
     ::google::protobuf::internal::OnShutdownDestroyMessage(ptr);
   }
-  ::tensorflow::VersionDef::InitAsDefaultInstance();
+  ::opencv_tensorflow::VersionDef::InitAsDefaultInstance();
 }
 
 void InitDefaultsVersionDef() {
@@ -52,20 +52,20 @@ void InitDefaultsVersionDef() {
 
 const ::google::protobuf::uint32 TableStruct::offsets[] GOOGLE_PROTOBUF_ATTRIBUTE_SECTION_VARIABLE(protodesc_cold) = {
   ~0u,  // no _has_bits_
-  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::tensorflow::VersionDef, _internal_metadata_),
+  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::opencv_tensorflow::VersionDef, _internal_metadata_),
   ~0u,  // no _extensions_
   ~0u,  // no _oneof_case_
   ~0u,  // no _weak_field_map_
-  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::tensorflow::VersionDef, producer_),
-  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::tensorflow::VersionDef, min_consumer_),
-  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::tensorflow::VersionDef, bad_consumers_),
+  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::opencv_tensorflow::VersionDef, producer_),
+  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::opencv_tensorflow::VersionDef, min_consumer_),
+  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::opencv_tensorflow::VersionDef, bad_consumers_),
 };
 static const ::google::protobuf::internal::MigrationSchema schemas[] GOOGLE_PROTOBUF_ATTRIBUTE_SECTION_VARIABLE(protodesc_cold) = {
-  { 0, -1, sizeof(::tensorflow::VersionDef)},
+  { 0, -1, sizeof(::opencv_tensorflow::VersionDef)},
 };
 
 static ::google::protobuf::Message const * const file_default_instances[] = {
-  reinterpret_cast<const ::google::protobuf::Message*>(&::tensorflow::_VersionDef_default_instance_),
+  reinterpret_cast<const ::google::protobuf::Message*>(&::opencv_tensorflow::_VersionDef_default_instance_),
 };
 
 void protobuf_AssignDescriptors() {
@@ -90,14 +90,14 @@ void protobuf_RegisterTypes(const ::std::string&) {
 void AddDescriptorsImpl() {
   InitDefaults();
   static const char descriptor[] GOOGLE_PROTOBUF_ATTRIBUTE_SECTION_VARIABLE(protodesc_cold) = {
-      "\n\016versions.proto\022\ntensorflow\"K\n\nVersionD"
-      "ef\022\020\n\010producer\030\001 \001(\005\022\024\n\014min_consumer\030\002 \001"
-      "(\005\022\025\n\rbad_consumers\030\003 \003(\005B/\n\030org.tensorf"
-      "low.frameworkB\016VersionsProtosP\001\370\001\001b\006prot"
-      "o3"
+      "\n\016versions.proto\022\021opencv_tensorflow\"K\n\nV"
+      "ersionDef\022\020\n\010producer\030\001 \001(\005\022\024\n\014min_consu"
+      "mer\030\002 \001(\005\022\025\n\rbad_consumers\030\003 \003(\005B/\n\030org."
+      "tensorflow.frameworkB\016VersionsProtosP\001\370\001"
+      "\001b\006proto3"
   };
   ::google::protobuf::DescriptorPool::InternalAddGeneratedFile(
-      descriptor, 162);
+      descriptor, 169);
   ::google::protobuf::MessageFactory::InternalRegisterGeneratedFile(
     "versions.proto", &protobuf_RegisterTypes);
 }
@@ -113,7 +113,7 @@ struct StaticDescriptorInitializer {
   }
 } static_descriptor_initializer;
 }  // namespace protobuf_versions_2eproto
-namespace tensorflow {
+namespace opencv_tensorflow {
 
 // ===================================================================
 
@@ -131,7 +131,7 @@ VersionDef::VersionDef()
     ::protobuf_versions_2eproto::InitDefaultsVersionDef();
   }
   SharedCtor();
-  // @@protoc_insertion_point(constructor:tensorflow.VersionDef)
+  // @@protoc_insertion_point(constructor:opencv_tensorflow.VersionDef)
 }
 VersionDef::VersionDef(::google::protobuf::Arena* arena)
   : ::google::protobuf::Message(),
@@ -140,7 +140,7 @@ VersionDef::VersionDef(::google::protobuf::Arena* arena)
   ::protobuf_versions_2eproto::InitDefaultsVersionDef();
   SharedCtor();
   RegisterArenaDtor(arena);
-  // @@protoc_insertion_point(arena_constructor:tensorflow.VersionDef)
+  // @@protoc_insertion_point(arena_constructor:opencv_tensorflow.VersionDef)
 }
 VersionDef::VersionDef(const VersionDef& from)
   : ::google::protobuf::Message(),
@@ -151,7 +151,7 @@ VersionDef::VersionDef(const VersionDef& from)
   ::memcpy(&producer_, &from.producer_,
     static_cast<size_t>(reinterpret_cast<char*>(&min_consumer_) -
     reinterpret_cast<char*>(&producer_)) + sizeof(min_consumer_));
-  // @@protoc_insertion_point(copy_constructor:tensorflow.VersionDef)
+  // @@protoc_insertion_point(copy_constructor:opencv_tensorflow.VersionDef)
 }
 
 void VersionDef::SharedCtor() {
@@ -162,7 +162,7 @@ void VersionDef::SharedCtor() {
 }
 
 VersionDef::~VersionDef() {
-  // @@protoc_insertion_point(destructor:tensorflow.VersionDef)
+  // @@protoc_insertion_point(destructor:opencv_tensorflow.VersionDef)
   SharedDtor();
 }
 
@@ -196,7 +196,7 @@ VersionDef* VersionDef::New(::google::protobuf::Arena* arena) const {
 }
 
 void VersionDef::Clear() {
-// @@protoc_insertion_point(message_clear_start:tensorflow.VersionDef)
+// @@protoc_insertion_point(message_clear_start:opencv_tensorflow.VersionDef)
   ::google::protobuf::uint32 cached_has_bits = 0;
   // Prevent compiler warnings about cached_has_bits being unused
   (void) cached_has_bits;
@@ -212,7 +212,7 @@ bool VersionDef::MergePartialFromCodedStream(
     ::google::protobuf::io::CodedInputStream* input) {
 #define DO_(EXPRESSION) if (!GOOGLE_PREDICT_TRUE(EXPRESSION)) goto failure
   ::google::protobuf::uint32 tag;
-  // @@protoc_insertion_point(parse_start:tensorflow.VersionDef)
+  // @@protoc_insertion_point(parse_start:opencv_tensorflow.VersionDef)
   for (;;) {
     ::std::pair< ::google::protobuf::uint32, bool> p = input->ReadTagWithCutoffNoLastTag(127u);
     tag = p.first;
@@ -277,17 +277,17 @@ bool VersionDef::MergePartialFromCodedStream(
     }
   }
 success:
-  // @@protoc_insertion_point(parse_success:tensorflow.VersionDef)
+  // @@protoc_insertion_point(parse_success:opencv_tensorflow.VersionDef)
   return true;
 failure:
-  // @@protoc_insertion_point(parse_failure:tensorflow.VersionDef)
+  // @@protoc_insertion_point(parse_failure:opencv_tensorflow.VersionDef)
   return false;
 #undef DO_
 }
 
 void VersionDef::SerializeWithCachedSizes(
     ::google::protobuf::io::CodedOutputStream* output) const {
-  // @@protoc_insertion_point(serialize_start:tensorflow.VersionDef)
+  // @@protoc_insertion_point(serialize_start:opencv_tensorflow.VersionDef)
   ::google::protobuf::uint32 cached_has_bits = 0;
   (void) cached_has_bits;
 
@@ -316,13 +316,13 @@ void VersionDef::SerializeWithCachedSizes(
     ::google::protobuf::internal::WireFormat::SerializeUnknownFields(
         (::google::protobuf::internal::GetProto3PreserveUnknownsDefault()   ? _internal_metadata_.unknown_fields()   : _internal_metadata_.default_instance()), output);
   }
-  // @@protoc_insertion_point(serialize_end:tensorflow.VersionDef)
+  // @@protoc_insertion_point(serialize_end:opencv_tensorflow.VersionDef)
 }
 
 ::google::protobuf::uint8* VersionDef::InternalSerializeWithCachedSizesToArray(
     bool deterministic, ::google::protobuf::uint8* target) const {
   (void)deterministic; // Unused
-  // @@protoc_insertion_point(serialize_to_array_start:tensorflow.VersionDef)
+  // @@protoc_insertion_point(serialize_to_array_start:opencv_tensorflow.VersionDef)
   ::google::protobuf::uint32 cached_has_bits = 0;
   (void) cached_has_bits;
 
@@ -353,12 +353,12 @@ void VersionDef::SerializeWithCachedSizes(
     target = ::google::protobuf::internal::WireFormat::SerializeUnknownFieldsToArray(
         (::google::protobuf::internal::GetProto3PreserveUnknownsDefault()   ? _internal_metadata_.unknown_fields()   : _internal_metadata_.default_instance()), target);
   }
-  // @@protoc_insertion_point(serialize_to_array_end:tensorflow.VersionDef)
+  // @@protoc_insertion_point(serialize_to_array_end:opencv_tensorflow.VersionDef)
   return target;
 }
 
 size_t VersionDef::ByteSizeLong() const {
-// @@protoc_insertion_point(message_byte_size_start:tensorflow.VersionDef)
+// @@protoc_insertion_point(message_byte_size_start:opencv_tensorflow.VersionDef)
   size_t total_size = 0;
 
   if ((_internal_metadata_.have_unknown_fields() &&  ::google::protobuf::internal::GetProto3PreserveUnknownsDefault())) {
@@ -404,22 +404,22 @@ size_t VersionDef::ByteSizeLong() const {
 }
 
 void VersionDef::MergeFrom(const ::google::protobuf::Message& from) {
-// @@protoc_insertion_point(generalized_merge_from_start:tensorflow.VersionDef)
+// @@protoc_insertion_point(generalized_merge_from_start:opencv_tensorflow.VersionDef)
   GOOGLE_DCHECK_NE(&from, this);
   const VersionDef* source =
       ::google::protobuf::internal::DynamicCastToGenerated<const VersionDef>(
           &from);
   if (source == NULL) {
-  // @@protoc_insertion_point(generalized_merge_from_cast_fail:tensorflow.VersionDef)
+  // @@protoc_insertion_point(generalized_merge_from_cast_fail:opencv_tensorflow.VersionDef)
     ::google::protobuf::internal::ReflectionOps::Merge(from, this);
   } else {
-  // @@protoc_insertion_point(generalized_merge_from_cast_success:tensorflow.VersionDef)
+  // @@protoc_insertion_point(generalized_merge_from_cast_success:opencv_tensorflow.VersionDef)
     MergeFrom(*source);
   }
 }
 
 void VersionDef::MergeFrom(const VersionDef& from) {
-// @@protoc_insertion_point(class_specific_merge_from_start:tensorflow.VersionDef)
+// @@protoc_insertion_point(class_specific_merge_from_start:opencv_tensorflow.VersionDef)
   GOOGLE_DCHECK_NE(&from, this);
   _internal_metadata_.MergeFrom(from._internal_metadata_);
   ::google::protobuf::uint32 cached_has_bits = 0;
@@ -435,14 +435,14 @@ void VersionDef::MergeFrom(const VersionDef& from) {
 }
 
 void VersionDef::CopyFrom(const ::google::protobuf::Message& from) {
-// @@protoc_insertion_point(generalized_copy_from_start:tensorflow.VersionDef)
+// @@protoc_insertion_point(generalized_copy_from_start:opencv_tensorflow.VersionDef)
   if (&from == this) return;
   Clear();
   MergeFrom(from);
 }
 
 void VersionDef::CopyFrom(const VersionDef& from) {
-// @@protoc_insertion_point(class_specific_copy_from_start:tensorflow.VersionDef)
+// @@protoc_insertion_point(class_specific_copy_from_start:opencv_tensorflow.VersionDef)
   if (&from == this) return;
   Clear();
   MergeFrom(from);
@@ -487,6 +487,6 @@ void VersionDef::InternalSwap(VersionDef* other) {
 
 
 // @@protoc_insertion_point(namespace_scope)
-}  // namespace tensorflow
+}  // namespace opencv_tensorflow
 
 // @@protoc_insertion_point(global_scope)

--- a/modules/dnn/misc/tensorflow/versions.pb.h
+++ b/modules/dnn/misc/tensorflow/versions.pb.h
@@ -48,16 +48,16 @@ inline void InitDefaults() {
   InitDefaultsVersionDef();
 }
 }  // namespace protobuf_versions_2eproto
-namespace tensorflow {
+namespace opencv_tensorflow {
 class VersionDef;
 class VersionDefDefaultTypeInternal;
 extern VersionDefDefaultTypeInternal _VersionDef_default_instance_;
-}  // namespace tensorflow
-namespace tensorflow {
+}  // namespace opencv_tensorflow
+namespace opencv_tensorflow {
 
 // ===================================================================
 
-class VersionDef : public ::google::protobuf::Message /* @@protoc_insertion_point(class_definition:tensorflow.VersionDef) */ {
+class VersionDef : public ::google::protobuf::Message /* @@protoc_insertion_point(class_definition:opencv_tensorflow.VersionDef) */ {
  public:
   VersionDef();
   virtual ~VersionDef();
@@ -175,7 +175,7 @@ class VersionDef : public ::google::protobuf::Message /* @@protoc_insertion_poin
   ::google::protobuf::int32 min_consumer() const;
   void set_min_consumer(::google::protobuf::int32 value);
 
-  // @@protoc_insertion_point(class_scope:tensorflow.VersionDef)
+  // @@protoc_insertion_point(class_scope:opencv_tensorflow.VersionDef)
  private:
 
   ::google::protobuf::internal::InternalMetadataWithArena _internal_metadata_;
@@ -206,13 +206,13 @@ inline void VersionDef::clear_producer() {
   producer_ = 0;
 }
 inline ::google::protobuf::int32 VersionDef::producer() const {
-  // @@protoc_insertion_point(field_get:tensorflow.VersionDef.producer)
+  // @@protoc_insertion_point(field_get:opencv_tensorflow.VersionDef.producer)
   return producer_;
 }
 inline void VersionDef::set_producer(::google::protobuf::int32 value) {
 
   producer_ = value;
-  // @@protoc_insertion_point(field_set:tensorflow.VersionDef.producer)
+  // @@protoc_insertion_point(field_set:opencv_tensorflow.VersionDef.producer)
 }
 
 // int32 min_consumer = 2;
@@ -220,13 +220,13 @@ inline void VersionDef::clear_min_consumer() {
   min_consumer_ = 0;
 }
 inline ::google::protobuf::int32 VersionDef::min_consumer() const {
-  // @@protoc_insertion_point(field_get:tensorflow.VersionDef.min_consumer)
+  // @@protoc_insertion_point(field_get:opencv_tensorflow.VersionDef.min_consumer)
   return min_consumer_;
 }
 inline void VersionDef::set_min_consumer(::google::protobuf::int32 value) {
 
   min_consumer_ = value;
-  // @@protoc_insertion_point(field_set:tensorflow.VersionDef.min_consumer)
+  // @@protoc_insertion_point(field_set:opencv_tensorflow.VersionDef.min_consumer)
 }
 
 // repeated int32 bad_consumers = 3;
@@ -237,25 +237,25 @@ inline void VersionDef::clear_bad_consumers() {
   bad_consumers_.Clear();
 }
 inline ::google::protobuf::int32 VersionDef::bad_consumers(int index) const {
-  // @@protoc_insertion_point(field_get:tensorflow.VersionDef.bad_consumers)
+  // @@protoc_insertion_point(field_get:opencv_tensorflow.VersionDef.bad_consumers)
   return bad_consumers_.Get(index);
 }
 inline void VersionDef::set_bad_consumers(int index, ::google::protobuf::int32 value) {
   bad_consumers_.Set(index, value);
-  // @@protoc_insertion_point(field_set:tensorflow.VersionDef.bad_consumers)
+  // @@protoc_insertion_point(field_set:opencv_tensorflow.VersionDef.bad_consumers)
 }
 inline void VersionDef::add_bad_consumers(::google::protobuf::int32 value) {
   bad_consumers_.Add(value);
-  // @@protoc_insertion_point(field_add:tensorflow.VersionDef.bad_consumers)
+  // @@protoc_insertion_point(field_add:opencv_tensorflow.VersionDef.bad_consumers)
 }
 inline const ::google::protobuf::RepeatedField< ::google::protobuf::int32 >&
 VersionDef::bad_consumers() const {
-  // @@protoc_insertion_point(field_list:tensorflow.VersionDef.bad_consumers)
+  // @@protoc_insertion_point(field_list:opencv_tensorflow.VersionDef.bad_consumers)
   return bad_consumers_;
 }
 inline ::google::protobuf::RepeatedField< ::google::protobuf::int32 >*
 VersionDef::mutable_bad_consumers() {
-  // @@protoc_insertion_point(field_mutable_list:tensorflow.VersionDef.bad_consumers)
+  // @@protoc_insertion_point(field_mutable_list:opencv_tensorflow.VersionDef.bad_consumers)
   return &bad_consumers_;
 }
 
@@ -265,7 +265,7 @@ VersionDef::mutable_bad_consumers() {
 
 // @@protoc_insertion_point(namespace_scope)
 
-}  // namespace tensorflow
+}  // namespace opencv_tensorflow
 
 // @@protoc_insertion_point(global_scope)
 

--- a/modules/dnn/src/tensorflow/attr_value.proto
+++ b/modules/dnn/src/tensorflow/attr_value.proto
@@ -1,6 +1,6 @@
 syntax = "proto3";
 
-package tensorflow;
+package opencv_tensorflow;
 option cc_enable_arenas = true;
 option java_outer_classname = "AttrValueProtos";
 option java_multiple_files = true;

--- a/modules/dnn/src/tensorflow/function.proto
+++ b/modules/dnn/src/tensorflow/function.proto
@@ -1,6 +1,6 @@
 syntax = "proto3";
 
-package tensorflow;
+package opencv_tensorflow;
 option cc_enable_arenas = true;
 option java_outer_classname = "FunctionProtos";
 option java_multiple_files = true;

--- a/modules/dnn/src/tensorflow/graph.proto
+++ b/modules/dnn/src/tensorflow/graph.proto
@@ -1,6 +1,6 @@
 syntax = "proto3";
 
-package tensorflow;
+package opencv_tensorflow;
 option cc_enable_arenas = true;
 option java_outer_classname = "GraphProtos";
 option java_multiple_files = true;

--- a/modules/dnn/src/tensorflow/op_def.proto
+++ b/modules/dnn/src/tensorflow/op_def.proto
@@ -1,6 +1,6 @@
 syntax = "proto3";
 
-package tensorflow;
+package opencv_tensorflow;
 option cc_enable_arenas = true;
 option java_outer_classname = "OpDefProtos";
 option java_multiple_files = true;

--- a/modules/dnn/src/tensorflow/tensor.proto
+++ b/modules/dnn/src/tensorflow/tensor.proto
@@ -1,6 +1,6 @@
 syntax = "proto3";
 
-package tensorflow;
+package opencv_tensorflow;
 option cc_enable_arenas = true;
 option java_outer_classname = "TensorProtos";
 option java_multiple_files = true;

--- a/modules/dnn/src/tensorflow/tensor_shape.proto
+++ b/modules/dnn/src/tensorflow/tensor_shape.proto
@@ -6,7 +6,7 @@ option java_outer_classname = "TensorShapeProtos";
 option java_multiple_files = true;
 option java_package = "org.tensorflow.framework";
 
-package tensorflow;
+package opencv_tensorflow;
 
 // Dimensions of a tensor.
 message TensorShapeProto {

--- a/modules/dnn/src/tensorflow/tf_io.hpp
+++ b/modules/dnn/src/tensorflow/tf_io.hpp
@@ -26,6 +26,7 @@ Declaration of various functions which are related to Tensorflow models reading.
 #pragma GCC diagnostic pop
 #endif
 
+namespace tensorflow { using namespace opencv_tensorflow; }
 
 namespace cv {
 namespace dnn {

--- a/modules/dnn/src/tensorflow/types.proto
+++ b/modules/dnn/src/tensorflow/types.proto
@@ -1,6 +1,6 @@
 syntax = "proto3";
 
-package tensorflow;
+package opencv_tensorflow;
 option cc_enable_arenas = true;
 option java_outer_classname = "TypesProtos";
 option java_multiple_files = true;

--- a/modules/dnn/src/tensorflow/versions.proto
+++ b/modules/dnn/src/tensorflow/versions.proto
@@ -1,6 +1,6 @@
 syntax = "proto3";
 
-package tensorflow;
+package opencv_tensorflow;
 option cc_enable_arenas = true;
 option java_outer_classname = "VersionsProtos";
 option java_multiple_files = true;


### PR DESCRIPTION
Preventing conflicts when linking both `opencv-dnn` and `tensorflow`. Same stuff as for Caffe

related #10139

```
allow_multiple_commits=1
```