### PR TITLE
Update seamless_cloning.cpp

### DIFF
--- a/modules/photo/src/seamless_cloning.cpp
+++ b/modules/photo/src/seamless_cloning.cpp
@@ -54,20 +54,27 @@ void cv::seamlessClone(InputArray _src, InputArray _dst, InputArray _mask, Point
     const Mat src  = _src.getMat();
     const Mat dest = _dst.getMat();
     const Mat mask = _mask.getMat();
-    _blend.create(dest.size(), CV_8UC3);
+    dest.copyTo(_blend);
     Mat blend = _blend.getMat();
-    dest.copyTo(blend);
-
-    int minx = INT_MAX, miny = INT_MAX, maxx = INT_MIN, maxy = INT_MIN;
-    int h = mask.size().height;
-    int w = mask.size().width;
 
     Mat gray;
 
     if(mask.channels() == 3)
         cvtColor(mask, gray, COLOR_BGR2GRAY );
     else
-        mask.copyTo(gray);
+    {
+        if (mask.empty())
+            gray = Mat(src.rows, src.cols, CV_8UC1, Scalar(255));
+        else
+            mask.copyTo(gray);
+    }
+
+    Mat gray_inner = gray(Rect(1, 1, gray.cols - 2, gray.rows - 2));
+    copyMakeBorder(gray_inner, gray, 1, 1, 1, 1, BORDER_ISOLATED | BORDER_CONSTANT, Scalar(0));
+
+    int minx = INT_MAX, miny = INT_MAX, maxx = INT_MIN, maxy = INT_MIN;
+    int h = gray.size().height;
+    int w = gray.size().width;
 
     for(int i=0;i<h;i++)
     {
@@ -102,7 +109,6 @@ void cv::seamlessClone(InputArray _src, InputArray _dst, InputArray _mask, Point
 
     Cloning obj;
     obj.normalClone(destinationROI,sourceROI,maskROI,recoveredROI,flags);
-
 }
 
 void cv::colorChange(InputArray _src, InputArray _mask, OutputArray _dst, float red, float green, float blue)


### PR DESCRIPTION
### This pullrequest changes
resolves #12496 

proposed solution guarantees that mask will have at least one pixel black border. This seems solving the actual problem. 

P.S. : actual code is broken without error message when the mask is empty. So i will edit other cloning types later if the proposed patch is acceptable.