### PR TITLE
Fix BayerXX2RGBA when blue is on the first line.

### DIFF
--- a/modules/imgproc/src/demosaicing.cpp
+++ b/modules/imgproc/src/demosaicing.cpp
@@ -923,8 +923,10 @@ static void Bayer2RGB_( const Mat& srcmat, Mat& dstmat, int code )
 {
     int dst_step = (int)(dstmat.step/sizeof(T));
     Size size = srcmat.size();
-    int blue = code == CV_BayerBG2BGR || code == CV_BayerGB2BGR ? -1 : 1;
-    int start_with_green = code == CV_BayerGB2BGR || code == CV_BayerGR2BGR;
+    int blue = (code == CV_BayerBG2BGR || code == CV_BayerGB2BGR ||
+                code == CV_BayerBG2BGRA || code == CV_BayerGB2BGRA ) ? -1 : 1;
+    int start_with_green = (code == CV_BayerGB2BGR || code == CV_BayerGR2BGR ||
+                            code == CV_BayerGB2BGRA || code == CV_BayerGR2BGRA);
 
     int dcn = dstmat.channels();
     size.height -= 2;


### PR DESCRIPTION
**Merge with extra**: https://github.com/opencv/opencv_extra/pull/519

Relates to #12465 

I had a typo in my tests which meant that I wasn't testing these cases.

Without this, when converting to bayer2rgba, the provided bayer pattern was ignored and assumed to be `rggb`.

related #8178