### PR TITLE
Removed unnecessary build-time MediaSDK detection

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1396,7 +1396,7 @@ if(WITH_VA OR HAVE_VA)
 endif()
 
 if(WITH_VA_INTEL OR HAVE_VA_INTEL)
-  status("    Intel VA-API/OpenCL:"  HAVE_VA_INTEL       THEN "YES (MSDK: ${VA_INTEL_MSDK_ROOT}  OpenCL: ${VA_INTEL_IOCL_ROOT})" ELSE NO)
+  status("    Intel VA-API/OpenCL:"  HAVE_VA_INTEL       THEN "YES (OpenCL: ${VA_INTEL_IOCL_ROOT})" ELSE NO)
 endif()
 
 if(WITH_LAPACK OR HAVE_LAPACK)

--- a/cmake/OpenCVFindVA_INTEL.cmake
+++ b/cmake/OpenCVFindVA_INTEL.cmake
@@ -1,29 +1,15 @@
 # Main variables:
-# VA_INTEL_MSDK_INCLUDE_DIR and VA_INTEL_IOCL_INCLUDE_DIR to use VA_INTEL
+# VA_INTEL_IOCL_INCLUDE_DIR to use VA_INTEL
 # HAVE_VA_INTEL for conditional compilation OpenCV with/without VA_INTEL
 
-# VA_INTEL_MSDK_ROOT - root of Intel MSDK installation
 # VA_INTEL_IOCL_ROOT - root of Intel OCL installation
 
 if(UNIX AND NOT ANDROID)
-    if($ENV{VA_INTEL_MSDK_ROOT})
-        set(VA_INTEL_MSDK_ROOT $ENV{VA_INTEL_MSDK_ROOT})
-    else()
-        set(VA_INTEL_MSDK_ROOT "/opt/intel/mediasdk")
-    endif()
-
     if($ENV{VA_INTEL_IOCL_ROOT})
         set(VA_INTEL_IOCL_ROOT $ENV{VA_INTEL_IOCL_ROOT})
     else()
         set(VA_INTEL_IOCL_ROOT "/opt/intel/opencl")
     endif()
-
-    find_path(
-    VA_INTEL_MSDK_INCLUDE_DIR
-    NAMES mfxdefs.h
-    PATHS ${VA_INTEL_MSDK_ROOT}
-    PATH_SUFFIXES include
-    DOC "Path to Intel MSDK headers")
 
     find_path(
     VA_INTEL_IOCL_INCLUDE_DIR
@@ -33,12 +19,14 @@ if(UNIX AND NOT ANDROID)
     DOC "Path to Intel OpenCL headers")
 endif()
 
-if(VA_INTEL_MSDK_INCLUDE_DIR AND VA_INTEL_IOCL_INCLUDE_DIR)
+if(VA_INTEL_IOCL_INCLUDE_DIR)
     set(HAVE_VA_INTEL TRUE)
-    set(VA_INTEL_LIBRARIES "-lva" "-lva-drm")
+    if(NOT DEFINED VA_INTEL_LIBRARIES)
+      set(VA_INTEL_LIBRARIES "va" "va-drm")
+    endif()
 else()
     set(HAVE_VA_INTEL FALSE)
-    message(WARNING "Intel MSDK & OpenCL installation is not found.")
+    message(WARNING "Intel OpenCL installation is not found.")
 endif()
 
-mark_as_advanced(FORCE VA_INTEL_MSDK_INCLUDE_DIR VA_INTEL_IOCL_INCLUDE_DIR)
+mark_as_advanced(FORCE VA_INTEL_IOCL_INCLUDE_DIR)

--- a/modules/core/include/opencv2/core/va_intel.hpp
+++ b/modules/core/include/opencv2/core/va_intel.hpp
@@ -31,8 +31,9 @@ This section describes Intel VA-API/OpenCL (CL-VA) interoperability.
 
 To enable CL-VA interoperability support, configure OpenCV using CMake with WITH_VA_INTEL=ON . Currently VA-API is
 supported on Linux only. You should also install Intel Media Server Studio (MSS) to use this feature. You may
-have to specify the path(s) to MSS components for cmake in environment variables: VA_INTEL_MSDK_ROOT for Media SDK
-(default is "/opt/intel/mediasdk"), and VA_INTEL_IOCL_ROOT for Intel OpenCL (default is "/opt/intel/opencl").
+have to specify the path(s) to MSS components for cmake in environment variables:
+
+- VA_INTEL_IOCL_ROOT for Intel OpenCL (default is "/opt/intel/opencl").
 
 To use CL-VA interoperability you should first create VADisplay (libva), and then call initializeContextFromVA()
 function to create OpenCL context and set up interoperability.


### PR DESCRIPTION
<!-- Please use this line to close one or multiple issues when this pullrequest gets merged
You can add another line right under the first one:
resolves #1234
resolves #1235
-->

### This pullrequest changes

MediaSDK is not actually needed to build VA-API/OpenCL interoperability feature. Detected `VA_INTEL_MSDK_INCLUDE_DIR` is not used.
