### PR TITLE
Minor changes in docs (Python Tutorials)

### DIFF
--- a/doc/py_tutorials/py_core/py_basic_ops/py_basic_ops.markdown
+++ b/doc/py_tutorials/py_core/py_basic_ops/py_basic_ops.markdown
@@ -153,15 +153,15 @@ padding etc. This function takes following arguments:
 
 -   **borderType** - Flag defining what kind of border to be added. It can be following types:
     -   **cv.BORDER_CONSTANT** - Adds a constant colored border. The value should be given
-            as next argument.
-        -   **cv.BORDER_REFLECT** - Border will be mirror reflection of the border elements,
-            like this : *fedcba|abcdefgh|hgfedcb*
-        -   **cv.BORDER_REFLECT_101** or **cv.BORDER_DEFAULT** - Same as above, but with a
-            slight change, like this : *gfedcb|abcdefgh|gfedcba*
-        -   **cv.BORDER_REPLICATE** - Last element is replicated throughout, like this:
-            *aaaaaa|abcdefgh|hhhhhhh*
-        -   **cv.BORDER_WRAP** - Can't explain, it will look like this :
-            *cdefgh|abcdefgh|abcdefg*
+        as next argument.
+    -   **cv.BORDER_REFLECT** - Border will be mirror reflection of the border elements,
+        like this : *fedcba|abcdefgh|hgfedcb*
+    -   **cv.BORDER_REFLECT_101** or **cv.BORDER_DEFAULT** - Same as above, but with a
+        slight change, like this : *gfedcb|abcdefgh|gfedcba*
+    -   **cv.BORDER_REPLICATE** - Last element is replicated throughout, like this:
+        *aaaaaa|abcdefgh|hhhhhhh*
+    -   **cv.BORDER_WRAP** - Can't explain, it will look like this :
+        *cdefgh|abcdefgh|abcdefg*
 
 -   **value** - Color of border if border type is cv.BORDER_CONSTANT
 

--- a/doc/py_tutorials/py_gui/py_trackbar/py_trackbar.markdown
+++ b/doc/py_tutorials/py_gui/py_trackbar/py_trackbar.markdown
@@ -37,6 +37,7 @@ cv.namedWindow('image')
 
 # create trackbars for color change
 cv.createTrackbar('R','image',0,255,nothing)
+
 cv.createTrackbar('G','image',0,255,nothing)
 cv.createTrackbar('B','image',0,255,nothing)
 


### PR DESCRIPTION
For some mysterious (for me) reason, two lines of the code appears in my browser (Chrome) in the same line.
I've added an "enter" (just pressed enter), but don't know if it's the best solution.


```
force_builders=Docs
```