### PR TITLE
Refactor test units & ts module for type-safety

### DIFF
--- a/modules/calib3d/perf/perf_affine2d.cpp
+++ b/modules/calib3d/perf/perf_affine2d.cpp
@@ -61,7 +61,7 @@ static Mat rngPartialAffMat() {
     double ty = rngIn(-2, 2);
     double aff[2*3] = { std::cos(theta) * scale, -std::sin(theta) * scale, tx,
                         std::sin(theta) * scale,  std::cos(theta) * scale, ty };
-    return Mat(2, 3, CV_64F, aff).clone();
+    return Mat(2, 3, CV_64FC1, aff).clone();
 }
 
 PERF_TEST_P( EstimateAffine, EstimateAffine2D, ESTIMATE_PARAMS )
@@ -72,7 +72,7 @@ PERF_TEST_P( EstimateAffine, EstimateAffine2D, ESTIMATE_PARAMS )
     const int method = get<2>(params);
     const size_t refining = get<3>(params);
 
-    Mat aff(2, 3, CV_64F);
+    Mat aff(2, 3, CV_64FC1);
     cv::randu(aff, -2., 2.);
 
     // LMEDS can't handle more than 50% outliers (by design)

--- a/modules/calib3d/perf/perf_pnp.cpp
+++ b/modules/calib3d/perf/perf_pnp.cpp
@@ -85,7 +85,7 @@ PERF_TEST_P(PointsNum_Algo, solvePnPSmallPoints,
     warmup(tvec, WARMUP_RNG);
 
     // normalize Rodrigues vector
-    Mat rvec_tmp = Mat::eye(3, 3, CV_32F);
+    Mat rvec_tmp = Mat::eye(3, 3, CV_32FC1);
     cv::Rodrigues(rvec, rvec_tmp);
     cv::Rodrigues(rvec_tmp, rvec);
 
@@ -122,7 +122,7 @@ PERF_TEST_P(PointsNum, DISABLED_SolvePnPRansac, testing::Values(5, 3*9, 7*13))
     camera_mat.at<float>(2, 0) = 0.f;
     camera_mat.at<float>(2, 1) = 0.f;
 
-    Mat dist_coef(1, 8, CV_32F, cv::Scalar::all(0));
+    Mat dist_coef(1, 8, CV_32FC1, cv::Scalar::all(0));
 
     vector<cv::Point2f> image_vec;
 

--- a/modules/calib3d/perf/perf_stereosgbm.cpp
+++ b/modules/calib3d/perf/perf_stereosgbm.cpp
@@ -63,7 +63,7 @@ PERF_TEST_P( TestStereoCorresp, DISABLED_TooLongInDebug_SGBM, Combine(Values(Siz
 
     Mat src_left(sz, CV_8UC3);
     Mat src_right(sz, CV_8UC3);
-    Mat dst(sz, CV_16S);
+    Mat dst(sz, CV_16SC1);
 
     MakeArtificialExample(rng,src_left,src_right);
 

--- a/modules/calib3d/test/test_affine2d_estimator.cpp
+++ b/modules/calib3d/test/test_affine2d_estimator.cpp
@@ -53,7 +53,7 @@ TEST_P(EstimateAffine2D, test3Points)
     // try more transformations
     for (size_t i = 0; i < 500; ++i)
     {
-        Mat aff(2, 3, CV_64F);
+        Mat aff(2, 3, CV_64FC1);
         cv::randu(aff, 1., 3.);
 
         Mat fpts(1, 3, CV_32FC2);
@@ -81,7 +81,7 @@ TEST_P(EstimateAffine2D, testNPoints)
     // try more transformations
     for (size_t i = 0; i < 500; ++i)
     {
-        Mat aff(2, 3, CV_64F);
+        Mat aff(2, 3, CV_64FC1);
         cv::randu(aff, -2., 2.);
         const int method = GetParam();
         const int n = 100;
@@ -125,7 +125,7 @@ TEST_P(EstimateAffine2D, testNPoints)
 // test conversion from other datatypes than float
 TEST_P(EstimateAffine2D, testConversion)
 {
-    Mat aff(2, 3, CV_32S);
+    Mat aff(2, 3, CV_32SC1);
     cv::randu(aff, 1., 3.);
 
     std::vector<Point> fpts(3);

--- a/modules/calib3d/test/test_affine3d_estimator.cpp
+++ b/modules/calib3d/test/test_affine3d_estimator.cpp
@@ -79,7 +79,7 @@ struct WrapAff
 
 bool CV_Affine3D_EstTest::test4Points()
 {
-    Mat aff(3, 4, CV_64F);
+    Mat aff(3, 4, CV_64FC1);
     cv::randu(aff, Scalar(1), Scalar(3));
 
     // setting points that are no in the same line
@@ -121,7 +121,7 @@ struct Noise
 
 bool CV_Affine3D_EstTest::testNPoints()
 {
-    Mat aff(3, 4, CV_64F);
+    Mat aff(3, 4, CV_64FC1);
     cv::randu(aff, Scalar(-2), Scalar(2));
 
     // setting points that are no in the same line

--- a/modules/calib3d/test/test_affine_partial2d_estimator.cpp
+++ b/modules/calib3d/test/test_affine_partial2d_estimator.cpp
@@ -57,7 +57,7 @@ static Mat rngPartialAffMat() {
     double ty = rngIn(-2, 2);
     double aff[2*3] = { std::cos(theta) * scale, -std::sin(theta) * scale, tx,
                         std::sin(theta) * scale,  std::cos(theta) * scale, ty };
-    return Mat(2, 3, CV_64F, aff).clone();
+    return Mat(2, 3, CV_64FC1, aff).clone();
 }
 
 TEST_P(EstimateAffinePartial2D, test2Points)

--- a/modules/calib3d/test/test_cameracalibration_artificial.cpp
+++ b/modules/calib3d/test/test_cameracalibration_artificial.cpp
@@ -63,7 +63,7 @@ Mat calcRvec(const vector<Point3f>& points, const Size& cornerSize)
     Vec3d ey(p01.x - p00.x, p01.y - p00.y, p01.z - p00.z);
     Vec3d ez = ex.cross(ey);
 
-    Mat rot(3, 3, CV_64F);
+    Mat rot(3, 3, CV_64FC1);
     *rot.ptr<Vec3d>(0) = ex;
     *rot.ptr<Vec3d>(1) = ey;
     *rot.ptr<Vec3d>(2) = ez * (1.0/cv::norm(ez)); // TODO cvtest
@@ -219,8 +219,8 @@ protected:
     double reprojectErrorWithoutIntrinsics(const vector<Point3f>& cb3d, const vector<Mat>& _rvecs_exp, const vector<Mat>& _tvecs_exp,
         const vector<Mat>& rvecs_est, const vector<Mat>& tvecs_est)
     {
-        const static Mat eye33 = Mat::eye(3, 3, CV_64F);
-        const static Mat zero15 = Mat::zeros(1, 5, CV_64F);
+        const static Mat eye33 = Mat::eye(3, 3, CV_64FC1);
+        const static Mat zero15 = Mat::zeros(1, 5, CV_64FC1);
         Mat _chessboard3D(cb3d);
         vector<Point2f> uv_exp, uv_est;
         double res = 0;
@@ -277,7 +277,7 @@ protected:
             imagePoints_art.push_back(corners_art);
             imagePoints_findCb.push_back(corners_fcb);
 
-            tvecs_exp[i].create(1, 3, CV_64F);
+            tvecs_exp[i].create(1, 3, CV_64FC1);
             *tvecs_exp[i].ptr<Point3d>() = cbg.corners3d[0];
             rvecs_exp[i] = calcRvec(cbg.corners3d, cbg.cornersSize());
         }
@@ -319,7 +319,7 @@ protected:
             throw std::exception();
         }
 
-        Mat camMat_est = Mat::eye(3, 3, CV_64F), distCoeffs_est = Mat::zeros(1, 5, CV_64F);
+        Mat camMat_est = Mat::eye(3, 3, CV_64FC1), distCoeffs_est = Mat::zeros(1, 5, CV_64FC1);
         vector<Mat> rvecs_est, tvecs_est;
 
         int flags = /*CALIB_FIX_K3|*/CALIB_FIX_K4|CALIB_FIX_K5|CALIB_FIX_K6; //CALIB_FIX_K3; //CALIB_FIX_ASPECT_RATIO |  | CALIB_ZERO_TANGENT_DIST;

--- a/modules/calib3d/test/test_cameracalibration_badarg.cpp
+++ b/modules/calib3d/test/test_cameracalibration_badarg.cpp
@@ -93,11 +93,11 @@ void CV_CameraCalibrationBadArgTest::run( int /* start_from */ )
     ChessBoardGenerator cbg(Size(8,6));
     corSize = cbg.cornersSize();
     vector<Point2f> exp_corn;
-    chessBoard = cbg(Mat(imgSize, CV_8U, Scalar(0)), camMat, distCoeffs0, exp_corn);
+    chessBoard = cbg(Mat(imgSize, CV_8UC1, Scalar(0)), camMat, distCoeffs0, exp_corn);
     Mat_<Point2f>(corSize.height, corSize.width, (Point2f*)&exp_corn[0]).copyTo(corners);
 
     CvMat objPts, imgPts, npoints, cameraMatrix, distCoeffs, rvecs, tvecs;
-    Mat zeros(1, sizeof(CvMat), CV_8U, Scalar(0));
+    Mat zeros(1, sizeof(CvMat), CV_8UC1, Scalar(0));
 
     C_Caller caller, bad_caller;
     caller.imageSize = imgSize;
@@ -126,8 +126,8 @@ void CV_CameraCalibrationBadArgTest::run( int /* start_from */ )
 
     imgPts_cpp = corners.clone().reshape(2, 1);
     npoints_cpp = Mat_<int>(M, 1, corSize.width * corSize.height);
-    cameraMatrix_cpp.create(3, 3, CV_32F);
-    distCoeffs_cpp.create(5, 1, CV_32F);
+    cameraMatrix_cpp.create(3, 3, CV_32FC1);
+    distCoeffs_cpp.create(5, 1, CV_32FC1);
     rvecs_cpp.create(M, 1, CV_32FC3);
     tvecs_cpp.create(M, 1, CV_32FC3);
 
@@ -221,9 +221,9 @@ void CV_CameraCalibrationBadArgTest::run( int /* start_from */ )
     bad_caller.tvecs = &bad_tvecs_c2;
     errors += run_test_case( CV_StsBadArg, "Bad tvecs header", bad_caller );
 
-    Mat bad_cameraMatrix_cpp1(3, 3, CV_32S); CvMat bad_cameraMatrix_c1 = cvMat(bad_cameraMatrix_cpp1);
-    Mat bad_cameraMatrix_cpp2(2, 3, CV_32F); CvMat bad_cameraMatrix_c2 = cvMat(bad_cameraMatrix_cpp2);
-    Mat bad_cameraMatrix_cpp3(3, 2, CV_64F); CvMat bad_cameraMatrix_c3 = cvMat(bad_cameraMatrix_cpp3);
+    Mat bad_cameraMatrix_cpp1(3, 3, CV_32SC1); CvMat bad_cameraMatrix_c1 = cvMat(bad_cameraMatrix_cpp1);
+    Mat bad_cameraMatrix_cpp2(2, 3, CV_32FC1); CvMat bad_cameraMatrix_c2 = cvMat(bad_cameraMatrix_cpp2);
+    Mat bad_cameraMatrix_cpp3(3, 2, CV_64FC1); CvMat bad_cameraMatrix_c3 = cvMat(bad_cameraMatrix_cpp3);
 
 
 
@@ -239,9 +239,9 @@ void CV_CameraCalibrationBadArgTest::run( int /* start_from */ )
     bad_caller.cameraMatrix = &bad_cameraMatrix_c3;
     errors += run_test_case( CV_StsBadArg, "Bad camearaMatrix header", bad_caller );
 
-    Mat bad_distCoeffs_cpp1(1, 5, CV_32S); CvMat bad_distCoeffs_c1 = cvMat(bad_distCoeffs_cpp1);
-    Mat bad_distCoeffs_cpp2(2, 2, CV_64F); CvMat bad_distCoeffs_c2 = cvMat(bad_distCoeffs_cpp2);
-    Mat bad_distCoeffs_cpp3(1, 6, CV_64F); CvMat bad_distCoeffs_c3 = cvMat(bad_distCoeffs_cpp3);
+    Mat bad_distCoeffs_cpp1(1, 5, CV_32SC1); CvMat bad_distCoeffs_c1 = cvMat(bad_distCoeffs_cpp1);
+    Mat bad_distCoeffs_cpp2(2, 2, CV_64FC1); CvMat bad_distCoeffs_c2 = cvMat(bad_distCoeffs_cpp2);
+    Mat bad_distCoeffs_cpp3(1, 6, CV_64FC1); CvMat bad_distCoeffs_c3 = cvMat(bad_distCoeffs_cpp3);
 
 
 
@@ -259,7 +259,7 @@ void CV_CameraCalibrationBadArgTest::run( int /* start_from */ )
     errors += run_test_case( CV_StsBadArg, "Bad distCoeffs header", bad_caller );
 
     double CM[] = {0, 0, 0, /**/0, 0, 0, /**/0, 0, 0};
-    Mat bad_cameraMatrix_cpp4(3, 3, CV_64F, CM); CvMat bad_cameraMatrix_c4 = cvMat(bad_cameraMatrix_cpp4);
+    Mat bad_cameraMatrix_cpp4(3, 3, CV_64FC1, CM); CvMat bad_cameraMatrix_c4 = cvMat(bad_cameraMatrix_cpp4);
 
     bad_caller = caller;
     bad_caller.flags |= CV_CALIB_USE_INTRINSIC_GUESS;
@@ -344,12 +344,12 @@ protected:
 
     void run(int /* start_from */ )
     {
-        Mat zeros(1, sizeof(CvMat), CV_8U, Scalar(0));
+        Mat zeros(1, sizeof(CvMat), CV_8UC1, Scalar(0));
         CvMat src_c, dst_c, jacobian_c;
 
-        Mat src_cpp(3, 1, CV_32F); src_c = cvMat(src_cpp);
-        Mat dst_cpp(3, 3, CV_32F); dst_c = cvMat(dst_cpp);
-        Mat jacobian_cpp(3, 9, CV_32F); jacobian_c = cvMat(jacobian_cpp);
+        Mat src_cpp(3, 1, CV_32FC1); src_c = cvMat(src_cpp);
+        Mat dst_cpp(3, 3, CV_32FC1); dst_c = cvMat(dst_cpp);
+        Mat jacobian_cpp(3, 9, CV_32FC1); jacobian_c = cvMat(jacobian_cpp);
 
         C_Caller caller, bad_caller;
         caller.src = &src_c;
@@ -373,11 +373,11 @@ protected:
         bad_caller.dst = 0;
         errors += run_test_case( CV_StsNullPtr, "Dst is zero pointer", bad_caller );
 
-        Mat bad_src_cpp1(3, 1, CV_8U); CvMat bad_src_c1 = cvMat(bad_src_cpp1);
-        Mat bad_dst_cpp1(3, 1, CV_8U); CvMat bad_dst_c1 = cvMat(bad_dst_cpp1);
-        Mat bad_jac_cpp1(3, 1, CV_8U); CvMat bad_jac_c1 = cvMat(bad_jac_cpp1);
+        Mat bad_src_cpp1(3, 1, CV_8UC1); CvMat bad_src_c1 = cvMat(bad_src_cpp1);
+        Mat bad_dst_cpp1(3, 1, CV_8UC1); CvMat bad_dst_c1 = cvMat(bad_dst_cpp1);
+        Mat bad_jac_cpp1(3, 1, CV_8UC1); CvMat bad_jac_c1 = cvMat(bad_jac_cpp1);
         Mat bad_jac_cpp2(3, 1, CV_32FC2); CvMat bad_jac_c2 = cvMat(bad_jac_cpp2);
-        Mat bad_jac_cpp3(3, 1, CV_32F); CvMat bad_jac_c3 = cvMat(bad_jac_cpp3);
+        Mat bad_jac_cpp3(3, 1, CV_32FC1); CvMat bad_jac_c3 = cvMat(bad_jac_cpp3);
 
         bad_caller = caller;
         bad_caller.src = &bad_src_c1;
@@ -403,14 +403,14 @@ protected:
         bad_caller.jacobian = &bad_jac_c3;
         errors += run_test_case( CV_StsBadSize, "Bad jacobian format", bad_caller );
 
-        Mat bad_src_cpp2(1, 1, CV_32F); CvMat bad_src_c2 = cvMat(bad_src_cpp2);
+        Mat bad_src_cpp2(1, 1, CV_32FC1); CvMat bad_src_c2 = cvMat(bad_src_cpp2);
 
         bad_caller = caller;
         bad_caller.src = &bad_src_c2;
         errors += run_test_case( CV_StsBadSize, "Bad src format", bad_caller );
 
-        Mat bad_dst_cpp2(2, 1, CV_32F); CvMat bad_dst_c2 = cvMat(bad_dst_cpp2);
-        Mat bad_dst_cpp3(3, 2, CV_32F); CvMat bad_dst_c3 = cvMat(bad_dst_cpp3);
+        Mat bad_dst_cpp2(2, 1, CV_32FC1); CvMat bad_dst_c2 = cvMat(bad_dst_cpp2);
+        Mat bad_dst_cpp3(3, 2, CV_32FC1); CvMat bad_dst_c3 = cvMat(bad_dst_cpp3);
         Mat bad_dst_cpp4(3, 3, CV_32FC2); CvMat bad_dst_c4 = cvMat(bad_dst_cpp4);
 
         bad_caller = caller;
@@ -427,11 +427,11 @@ protected:
 
 
         /********/
-        src_cpp.create(3, 3, CV_32F); src_c = cvMat(src_cpp);
-        dst_cpp.create(3, 1, CV_32F); dst_c = cvMat(dst_cpp);
+        src_cpp.create(3, 3, CV_32FC1); src_c = cvMat(src_cpp);
+        dst_cpp.create(3, 1, CV_32FC1); dst_c = cvMat(dst_cpp);
 
 
-        Mat bad_dst_cpp5(5, 5, CV_32F); CvMat bad_dst_c5 = cvMat(bad_dst_cpp5);
+        Mat bad_dst_cpp5(5, 5, CV_32FC1); CvMat bad_dst_c5 = cvMat(bad_dst_cpp5);
 
         bad_caller = caller;
         bad_caller.dst = &bad_dst_c5;
@@ -502,18 +502,18 @@ protected:
         randu(objectPoints_cpp, Scalar::all(1), Scalar::all(10));
         objectPoints_c = cvMat(objectPoints_cpp);
 
-        Mat t_vec_cpp(Mat::zeros(1, 3, CV_32F)); t_vec_c = cvMat(t_vec_cpp);
-        Mat r_vec_cpp(3, 1, CV_32F);
-        cvtest::Rodrigues(Mat::eye(3, 3, CV_32F), r_vec_cpp); r_vec_c = cvMat(r_vec_cpp);
+        Mat t_vec_cpp(Mat::zeros(1, 3, CV_32FC1)); t_vec_c = cvMat(t_vec_cpp);
+        Mat r_vec_cpp(3, 1, CV_32FC1);
+        cvtest::Rodrigues(Mat::eye(3, 3, CV_32FC1), r_vec_cpp); r_vec_c = cvMat(r_vec_cpp);
 
         Mat A_cpp = camMat.clone(); A_c = cvMat(A_cpp);
         Mat distCoeffs_cpp = distCoeffs.clone(); distCoeffs_c = cvMat(distCoeffs_cpp);
 
-        Mat dpdr_cpp(2*n, 3, CV_32F); dpdr_c = cvMat(dpdr_cpp);
-        Mat dpdt_cpp(2*n, 3, CV_32F); dpdt_c = cvMat(dpdt_cpp);
-        Mat dpdf_cpp(2*n, 2, CV_32F); dpdf_c = cvMat(dpdf_cpp);
-        Mat dpdc_cpp(2*n, 2, CV_32F); dpdc_c = cvMat(dpdc_cpp);
-        Mat dpdk_cpp(2*n, 4, CV_32F); dpdk_c = cvMat(dpdk_cpp);
+        Mat dpdr_cpp(2 * n, 3, CV_32FC1); dpdr_c = cvMat(dpdr_cpp);
+        Mat dpdt_cpp(2 * n, 3, CV_32FC1); dpdt_c = cvMat(dpdt_cpp);
+        Mat dpdf_cpp(2 * n, 2, CV_32FC1); dpdf_c = cvMat(dpdf_cpp);
+        Mat dpdc_cpp(2 * n, 2, CV_32FC1); dpdc_c = cvMat(dpdc_cpp);
+        Mat dpdk_cpp(2 * n, 4, CV_32FC1); dpdk_c = cvMat(dpdk_cpp);
 
         caller.aspectRatio = 1.0;
         caller.objectPoints = &objectPoints_c;
@@ -553,8 +553,8 @@ protected:
         errors += run_test_case( CV_StsBadArg, "Zero imagePoints", bad_caller );
 
         /****************************/
-        Mat bad_r_vec_cpp1(r_vec_cpp.size(), CV_32S); CvMat bad_r_vec_c1 = cvMat(bad_r_vec_cpp1);
-        Mat bad_r_vec_cpp2(2, 2, CV_32F); CvMat bad_r_vec_c2 = cvMat(bad_r_vec_cpp2);
+        Mat bad_r_vec_cpp1(r_vec_cpp.size(), CV_32SC1); CvMat bad_r_vec_c1 = cvMat(bad_r_vec_cpp1);
+        Mat bad_r_vec_cpp2(2, 2, CV_32FC1); CvMat bad_r_vec_c2 = cvMat(bad_r_vec_cpp2);
         Mat bad_r_vec_cpp3(r_vec_cpp.size(), CV_32FC2); CvMat bad_r_vec_c3 = cvMat(bad_r_vec_cpp3);
 
         bad_caller = caller;
@@ -570,8 +570,8 @@ protected:
         errors += run_test_case( CV_StsBadArg, "Bad rvec format", bad_caller );
 
         /****************************/
-        Mat bad_t_vec_cpp1(t_vec_cpp.size(), CV_32S); CvMat bad_t_vec_c1 = cvMat(bad_t_vec_cpp1);
-        Mat bad_t_vec_cpp2(2, 2, CV_32F); CvMat bad_t_vec_c2 = cvMat(bad_t_vec_cpp2);
+        Mat bad_t_vec_cpp1(t_vec_cpp.size(), CV_32SC1); CvMat bad_t_vec_c1 = cvMat(bad_t_vec_cpp1);
+        Mat bad_t_vec_cpp2(2, 2, CV_32FC1); CvMat bad_t_vec_c2 = cvMat(bad_t_vec_cpp2);
         Mat bad_t_vec_cpp3(1, 1, CV_32FC2); CvMat bad_t_vec_c3 = cvMat(bad_t_vec_cpp3);
 
         bad_caller = caller;
@@ -587,8 +587,8 @@ protected:
         errors += run_test_case( CV_StsBadArg, "Bad tvec format", bad_caller );
 
         /****************************/
-        Mat bad_A_cpp1(A_cpp.size(), CV_32S); CvMat bad_A_c1 = cvMat(bad_A_cpp1);
-        Mat bad_A_cpp2(2, 2, CV_32F); CvMat bad_A_c2 = cvMat(bad_A_cpp2);
+        Mat bad_A_cpp1(A_cpp.size(), CV_32SC1); CvMat bad_A_c1 = cvMat(bad_A_cpp1);
+        Mat bad_A_cpp2(2, 2, CV_32FC1); CvMat bad_A_c2 = cvMat(bad_A_cpp2);
 
         bad_caller = caller;
         bad_caller.A = &bad_A_c1;
@@ -599,9 +599,9 @@ protected:
         errors += run_test_case( CV_StsBadArg, "Bad A format", bad_caller );
 
         /****************************/
-        Mat bad_distCoeffs_cpp1(distCoeffs_cpp.size(), CV_32S); CvMat bad_distCoeffs_c1 = cvMat(bad_distCoeffs_cpp1);
-        Mat bad_distCoeffs_cpp2(2, 2, CV_32F); CvMat bad_distCoeffs_c2 = cvMat(bad_distCoeffs_cpp2);
-        Mat bad_distCoeffs_cpp3(1, 7, CV_32F); CvMat bad_distCoeffs_c3 = cvMat(bad_distCoeffs_cpp3);
+        Mat bad_distCoeffs_cpp1(distCoeffs_cpp.size(), CV_32SC1); CvMat bad_distCoeffs_c1 = cvMat(bad_distCoeffs_cpp1);
+        Mat bad_distCoeffs_cpp2(2, 2, CV_32FC1); CvMat bad_distCoeffs_c2 = cvMat(bad_distCoeffs_cpp2);
+        Mat bad_distCoeffs_cpp3(1, 7, CV_32FC1); CvMat bad_distCoeffs_c3 = cvMat(bad_distCoeffs_cpp3);
 
         bad_caller = caller;
         bad_caller.distCoeffs = &zeros;
@@ -621,9 +621,9 @@ protected:
 
 
         /****************************/
-        Mat bad_dpdr_cpp1(dpdr_cpp.size(), CV_32S); CvMat bad_dpdr_c1 = cvMat(bad_dpdr_cpp1);
-        Mat bad_dpdr_cpp2(dpdr_cpp.cols+1, 3, CV_32F); CvMat bad_dpdr_c2 = cvMat(bad_dpdr_cpp2);
-        Mat bad_dpdr_cpp3(dpdr_cpp.cols, 7, CV_32F); CvMat bad_dpdr_c3 = cvMat(bad_dpdr_cpp3);
+        Mat bad_dpdr_cpp1(dpdr_cpp.size(), CV_32SC1); CvMat bad_dpdr_c1 = cvMat(bad_dpdr_cpp1);
+        Mat bad_dpdr_cpp2(dpdr_cpp.cols + 1, 3, CV_32FC1); CvMat bad_dpdr_c2 = cvMat(bad_dpdr_cpp2);
+        Mat bad_dpdr_cpp3(dpdr_cpp.cols, 7, CV_32FC1); CvMat bad_dpdr_c3 = cvMat(bad_dpdr_cpp3);
 
         bad_caller = caller;
         bad_caller.dpdr = &zeros;
@@ -661,7 +661,7 @@ protected:
 
         /****************************/
 
-        Mat bad_dpdf_cpp2(dpdr_cpp.cols+1, 2, CV_32F); CvMat bad_dpdf_c2 = cvMat(bad_dpdf_cpp2);
+        Mat bad_dpdf_cpp2(dpdr_cpp.cols + 1, 2, CV_32FC1); CvMat bad_dpdf_c2 = cvMat(bad_dpdf_cpp2);
 
         bad_caller = caller;
         bad_caller.dpdf = &zeros;

--- a/modules/calib3d/test/test_cameracalibration_tilt.cpp
+++ b/modules/calib3d/test/test_cameracalibration_tilt.cpp
@@ -616,7 +616,7 @@ TEST_F(cameraCalibrationTiltTest, calibrateCamera)
 
         // Output
         std::vector<cv::Mat> outRvecs, outTvecs;
-        cv::Mat outCameraMatrix(3, 3, CV_64F, cv::Scalar::all(1)), outDistCoeff;
+        cv::Mat outCameraMatrix(3, 3, CV_64FC1, cv::Scalar::all(1)), outDistCoeff;
 
         // Stopping criteria
         cv::TermCriteria stop(

--- a/modules/calib3d/test/test_chessboardgenerator.cpp
+++ b/modules/calib3d/test/test_chessboardgenerator.cpp
@@ -47,10 +47,10 @@ namespace cv {
 
 ChessBoardGenerator::ChessBoardGenerator(const Size& _patternSize) : sensorWidth(32), sensorHeight(24),
     squareEdgePointsNum(200), min_cos(std::sqrt(3.f)*0.5f), cov(0.5),
-    patternSize(_patternSize), rendererResolutionMultiplier(4), tvec(Mat::zeros(1, 3, CV_32F))
+    patternSize(_patternSize), rendererResolutionMultiplier(4), tvec(Mat::zeros(1, 3, CV_32FC1))
 {
-    rvec.create(3, 1, CV_32F);
-    cvtest::Rodrigues(Mat::eye(3, 3, CV_32F), rvec);
+    rvec.create(3, 1, CV_32FC1);
+    cvtest::Rodrigues(Mat::eye(3, 3, CV_32FC1), rvec);
 }
 
 void ChessBoardGenerator::generateEdge(const Point3f& p1, const Point3f& p2, vector<Point3f>& out) const

--- a/modules/calib3d/test/test_chesscorners_badarg.cpp
+++ b/modules/calib3d/test/test_chesscorners_badarg.cpp
@@ -98,7 +98,7 @@ CV_ChessboardDetectorBadArgTest::CV_ChessboardDetectorBadArgTest()
 /* ///////////////////// chess_corner_test ///////////////////////// */
 void CV_ChessboardDetectorBadArgTest::run( int /*start_from */)
 {
-    Mat bg(800, 600, CV_8U, Scalar(0));
+    Mat bg(800, 600, CV_8UC1, Scalar(0));
     Mat_<float> camMat(3, 3);
     camMat << 300.f, 0.f, bg.cols/2.f, 0, 300.f, bg.rows/2.f, 0.f, 0.f, 1.f;
     Mat_<float> distCoeffs(1, 5);

--- a/modules/calib3d/test/test_filter_homography_decomp.cpp
+++ b/modules/calib3d/test/test_filter_homography_decomp.cpp
@@ -556,7 +556,7 @@ private:
         _rotations.swap(rotations);
         _normals.swap(normals);
 
-        _mask = Mat(514, 1, CV_8U, maskArray).clone();
+        _mask = Mat(514, 1, CV_8UC1, maskArray).clone();
     }
 
     bool isValidResult(const vector<int>& solutions)

--- a/modules/calib3d/test/test_fisheye.cpp
+++ b/modules/calib3d/test/test_fisheye.cpp
@@ -145,9 +145,9 @@ TEST_F(fisheyeTest, jacobians)
 {
     int n = 10;
     cv::Mat X(1, n, CV_64FC3);
-    cv::Mat om(3, 1, CV_64F), theT(3, 1, CV_64F);
-    cv::Mat f(2, 1, CV_64F), c(2, 1, CV_64F);
-    cv::Mat k(4, 1, CV_64F);
+    cv::Mat om(3, 1, CV_64FC1), theT(3, 1, CV_64FC1);
+    cv::Mat f(2, 1, CV_64FC1), c(2, 1, CV_64FC1);
+    cv::Mat k(4, 1, CV_64FC1);
     double alpha;
 
     cv::RNG r;
@@ -452,8 +452,8 @@ TEST_F(fisheyeTest, stereoRectify)
 #if 1 // Debug code
     cv::Mat lmapx, lmapy, rmapx, rmapy;
     //rewrite for fisheye
-    cv::fisheye::initUndistortRectifyMap(K1, D1, R1, P1, requested_size, CV_32F, lmapx, lmapy);
-    cv::fisheye::initUndistortRectifyMap(K2, D2, R2, P2, requested_size, CV_32F, rmapx, rmapy);
+    cv::fisheye::initUndistortRectifyMap(K1, D1, R1, P1, requested_size, CV_32FC1, lmapx, lmapy);
+    cv::fisheye::initUndistortRectifyMap(K2, D2, R2, P2, requested_size, CV_32FC1, rmapx, rmapy);
 
     cv::Mat l, r, lundist, rundist;
     for (int i = 0; i < 34; ++i)
@@ -691,7 +691,7 @@ std::string fisheyeTest::combine(const std::string& _item1, const std::string& _
 
 void fisheyeTest::merge4(const cv::Mat& tl, const cv::Mat& tr, const cv::Mat& bl, const cv::Mat& br, cv::Mat& merged)
 {
-    int type = tl.type();
+    ElemType type = tl.type();
     cv::Size sz = tl.size();
     ASSERT_EQ(type, tr.type()); ASSERT_EQ(type, bl.type()); ASSERT_EQ(type, br.type());
     ASSERT_EQ(sz.width, tr.cols); ASSERT_EQ(sz.width, bl.cols); ASSERT_EQ(sz.width, br.cols);

--- a/modules/calib3d/test/test_fundam.cpp
+++ b/modules/calib3d/test/test_fundam.cpp
@@ -102,9 +102,9 @@ static int cvTsRodrigues( const CvMat* src, CvMat* dst, CvMat* jacobian )
                 w3*w1, w3*w2, w3*w3
             };
             double R[9];
-            CvMat _omegav = cvMat(3, 3, CV_64F, omegav);
-            CvMat matA = cvMat(3, 3, CV_64F, A);
-            CvMat matR = cvMat(3, 3, CV_64F, R);
+            CvMat _omegav = cvMat(3, 3, CV_64FC1, omegav);
+            CvMat matA = cvMat(3, 3, CV_64FC1, A);
+            CvMat matR = cvMat(3, 3, CV_64FC1, R);
 
             cvSetIdentity( &matR, cvRealScalar(alpha) );
             cvScaleAdd( &_omegav, cvRealScalar(beta), &matR, &matR );
@@ -474,7 +474,7 @@ test_projectPoints( const Mat& _3d, const Mat& Rt, const Mat& A, Mat& _2d, RNG* 
     CV_Assert( _3d.isContinuous() );
 
     double p[12];
-    Mat P( 3, 4, CV_64F, p );
+    Mat P(3, 4, CV_64FC1, p);
     gemm(A, Rt, 1, Mat(), 0, P);
 
     int i, count = _3d.cols;
@@ -525,13 +525,13 @@ public:
     CV_RodriguesTest();
 
 protected:
-    int read_params( CvFileStorage* fs );
-    void fill_array( int test_case_idx, int i, int j, Mat& arr );
-    int prepare_test_case( int test_case_idx );
-    void get_test_array_types_and_sizes( int test_case_idx, vector<vector<Size> >& sizes, vector<vector<int> >& types );
-    double get_success_error_level( int test_case_idx, int i, int j );
-    void run_func();
-    void prepare_to_validation( int );
+    int read_params(CvFileStorage* fs) CV_OVERRIDE;
+    void fill_array(int test_case_idx, int i, int j, Mat& arr) CV_OVERRIDE;
+    int prepare_test_case(int test_case_idx) CV_OVERRIDE;
+    void get_test_array_types_and_sizes(int test_case_idx, vector<vector<Size> >& sizes, vector<vector<ElemType> >& types) CV_OVERRIDE;
+    double get_success_error_level(int test_case_idx, int i, int j) CV_OVERRIDE;
+    void run_func() CV_OVERRIDE;
+    void prepare_to_validation(int) CV_OVERRIDE;
 
     bool calc_jacobians;
     bool test_cpp;
@@ -567,7 +567,7 @@ int CV_RodriguesTest::read_params( CvFileStorage* fs )
 
 
 void CV_RodriguesTest::get_test_array_types_and_sizes(
-    int /*test_case_idx*/, vector<vector<Size> >& sizes, vector<vector<int> >& types )
+    int /*test_case_idx*/, vector<vector<Size> >& sizes, vector<vector<ElemType> >& types)
 {
     RNG& rng = ts->get_rng();
     int depth = cvtest::randInt(rng) % 2 == 0 ? CV_32F : CV_64F;
@@ -647,7 +647,7 @@ void CV_RodriguesTest::fill_array( int test_case_idx, int i, int j, Mat& arr )
         r[1] *= f;
         r[2] *= f;
 
-        cvtest::convert( _r, arr, arr.type() );
+        cvtest::convert( _r, arr, arr.depth() );
     }
     else
         cvtest::ArrayTest::fill_array( test_case_idx, i, j, arr );
@@ -696,19 +696,19 @@ void CV_RodriguesTest::run_func()
             {
                 if( J1.size() != J1_0.size() )
                     J1 = J1.t();
-                J1.convertTo(J1_0, J1_0.type());
+                J1.convertTo(J1_0, J1_0.depth());
             }
             if( J2.data != J2_0.data )
             {
                 if( J2.size() != J2_0.size() )
                     J2 = J2.t();
-                J2.convertTo(J2_0, J2_0.type());
+                J2.convertTo(J2_0, J2_0.depth());
             }
         }
         if( M.data != M0.data )
-            M.reshape(M0.channels(), M0.rows).convertTo(M0, M0.type());
+            M.reshape(M0.channels(), M0.rows).convertTo(M0, M0.depth());
         if( v2.data != v2_0.data )
-            v2.reshape(v2_0.channels(), v2_0.rows).convertTo(v2_0, v2_0.type());
+            v2.reshape(v2_0.channels(), v2_0.rows).convertTo(v2_0, v2_0.depth());
     }
 }
 
@@ -767,13 +767,13 @@ public:
     CV_FundamentalMatTest();
 
 protected:
-    int read_params( CvFileStorage* fs );
-    void fill_array( int test_case_idx, int i, int j, Mat& arr );
-    int prepare_test_case( int test_case_idx );
-    void get_test_array_types_and_sizes( int test_case_idx, vector<vector<Size> >& sizes, vector<vector<int> >& types );
-    double get_success_error_level( int test_case_idx, int i, int j );
-    void run_func();
-    void prepare_to_validation( int );
+    int read_params(CvFileStorage* fs) CV_OVERRIDE;
+    void fill_array(int test_case_idx, int i, int j, Mat& arr) CV_OVERRIDE;
+    int prepare_test_case(int test_case_idx) CV_OVERRIDE;
+    void get_test_array_types_and_sizes(int test_case_idx, vector<vector<Size> >& sizes, vector<vector<ElemType> >& types) CV_OVERRIDE;
+    double get_success_error_level(int test_case_idx, int i, int j) CV_OVERRIDE;
+    void run_func() CV_OVERRIDE;
+    void prepare_to_validation(int) CV_OVERRIDE;
 
     int method;
     int img_size;
@@ -830,7 +830,7 @@ int CV_FundamentalMatTest::read_params( CvFileStorage* fs )
 
 
 void CV_FundamentalMatTest::get_test_array_types_and_sizes( int /*test_case_idx*/,
-                                                vector<vector<Size> >& sizes, vector<vector<int> >& types )
+                                                vector<vector<Size> >& sizes, vector<vector<ElemType> >& types )
 {
     RNG& rng = ts->get_rng();
     int pt_depth = cvtest::randInt(rng) % 2 == 0 ? CV_32F : CV_64F;
@@ -928,8 +928,8 @@ void CV_FundamentalMatTest::fill_array( int test_case_idx, int i, int j, Mat& ar
     case 3:
         {
         double r[3];
-        Mat rot_vec( 3, 1, CV_64F, r );
-        Mat rot_mat( 3, 3, CV_64F, t, 4*sizeof(t[0]) );
+        Mat rot_vec(3, 1, CV_64FC1, r);
+        Mat rot_mat(3, 3, CV_64FC1, t, 4 * sizeof(t[0]));
         r[0] = cvtest::randReal(rng)*CV_PI*2;
         r[1] = cvtest::randReal(rng)*CV_PI*2;
         r[2] = cvtest::randReal(rng)*CV_PI*2;
@@ -938,7 +938,7 @@ void CV_FundamentalMatTest::fill_array( int test_case_idx, int i, int j, Mat& ar
         t[3] = cvtest::randReal(rng)*cube_size;
         t[7] = cvtest::randReal(rng)*cube_size;
         t[11] = cvtest::randReal(rng)*cube_size;
-        Mat( 3, 4, CV_64F, t ).convertTo(arr, arr.type());
+        Mat(3, 4, CV_64FC1, t).convertTo(arr, arr.depth());
         }
         break;
     case 4:
@@ -947,7 +947,7 @@ void CV_FundamentalMatTest::fill_array( int test_case_idx, int i, int j, Mat& ar
         t[2] = (img_size*0.5 + cvtest::randReal(rng)*4. - 2.)*t[0];
         t[5] = (img_size*0.5 + cvtest::randReal(rng)*4. - 2.)*t[4];
         t[8] = 1.;
-        Mat( 3, 3, CV_64F, t ).convertTo( arr, arr.type() );
+        Mat(3, 3, CV_64FC1, t).convertTo(arr, arr.depth());
         break;
     }
 }
@@ -961,7 +961,7 @@ int CV_FundamentalMatTest::prepare_test_case( int test_case_idx )
         const Mat& _3d = test_mat[INPUT][2];
         RNG& rng = ts->get_rng();
         double Idata[] = { 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0 };
-        Mat I( 3, 4, CV_64F, Idata );
+        Mat I(3, 4, CV_64FC1, Idata);
         int k;
 
         for( k = 0; k < 2; k++ )
@@ -992,7 +992,7 @@ void CV_FundamentalMatTest::prepare_to_validation( int test_case_idx )
     const Mat& A1 = test_mat[INPUT][4];
     const Mat& A2 = test_mat[INPUT][5];
     double f0[9], f[9];
-    Mat F0(3, 3, CV_64FC1, f0), F(3, 3, CV_64F, f);
+    Mat F0(3, 3, CV_64FC1, f0), F(3, 3, CV_64FC1, f);
 
     Mat invA1, invA2, R=Rt.colRange(0, 3), T;
 
@@ -1006,7 +1006,7 @@ void CV_FundamentalMatTest::prepare_to_validation( int test_case_idx )
     double _t_x[] = { 0, -tz, ty, tz, 0, -tx, -ty, tx, 0 };
 
     // F = (A2^-T)*[t]_x*R*(A1^-1)
-    cv::gemm( invA2, Mat( 3, 3, CV_64F, _t_x ), 1, Mat(), 0, T, CV_GEMM_A_T );
+    cv::gemm(invA2, Mat(3, 3, CV_64FC1, _t_x), 1, Mat(), 0, T, CV_GEMM_A_T);
     cv::gemm( R, invA1, 1, Mat(), 0, invA2 );
     cv::gemm( T, invA2, 1, Mat(), 0, F0 );
     F0 *= 1./f0[8];
@@ -1025,7 +1025,7 @@ void CV_FundamentalMatTest::prepare_to_validation( int test_case_idx )
     test_convertHomogeneous( test_mat[INPUT][0], p1 );
     test_convertHomogeneous( test_mat[INPUT][1], p2 );
 
-    cvtest::convert(test_mat[TEMP][0], F, F.type());
+    cvtest::convert(test_mat[TEMP][0], F, F.depth());
 
     if( method <= CV_FM_8POINT )
         memset( status, 1, pt_count );
@@ -1063,13 +1063,13 @@ public:
     CV_EssentialMatTest();
 
 protected:
-    int read_params( CvFileStorage* fs );
-    void fill_array( int test_case_idx, int i, int j, Mat& arr );
-    int prepare_test_case( int test_case_idx );
-    void get_test_array_types_and_sizes( int test_case_idx, vector<vector<Size> >& sizes, vector<vector<int> >& types );
-    double get_success_error_level( int test_case_idx, int i, int j );
-    void run_func();
-    void prepare_to_validation( int );
+    int read_params( CvFileStorage* fs ) CV_OVERRIDE;
+    void fill_array(int test_case_idx, int i, int j, Mat& arr) CV_OVERRIDE;
+    int prepare_test_case(int test_case_idx) CV_OVERRIDE;
+    void get_test_array_types_and_sizes(int test_case_idx, vector<vector<Size> >& sizes, vector<vector<ElemType> >& types) CV_OVERRIDE;
+    double get_success_error_level(int test_case_idx, int i, int j) CV_OVERRIDE;
+    void run_func() CV_OVERRIDE;
+    void prepare_to_validation(int) CV_OVERRIDE;
 
 #if 0
     double sampson_error(const double* f, double x1, double y1, double x2, double y2);
@@ -1131,7 +1131,7 @@ int CV_EssentialMatTest::read_params( CvFileStorage* fs )
 
 
 void CV_EssentialMatTest::get_test_array_types_and_sizes( int /*test_case_idx*/,
-                                                vector<vector<Size> >& sizes, vector<vector<int> >& types )
+                                                vector<vector<Size> >& sizes, vector<vector<ElemType> >& types )
 {
     RNG& rng = ts->get_rng();
     int pt_depth = cvtest::randInt(rng) % 2 == 0 ? CV_32F : CV_64F;
@@ -1230,8 +1230,8 @@ void CV_EssentialMatTest::fill_array( int test_case_idx, int i, int j, Mat& arr 
     case 3:
         {
         double r[3];
-        Mat rot_vec( 3, 1, CV_64F, r );
-        Mat rot_mat( 3, 3, CV_64F, t, 4*sizeof(t[0]) );
+        Mat rot_vec(3, 1, CV_64FC1, r);
+        Mat rot_mat(3, 3, CV_64FC1, t, 4 * sizeof(t[0]));
         r[0] = cvtest::randReal(rng)*CV_PI*2;
         r[1] = cvtest::randReal(rng)*CV_PI*2;
         r[2] = cvtest::randReal(rng)*CV_PI*2;
@@ -1240,7 +1240,7 @@ void CV_EssentialMatTest::fill_array( int test_case_idx, int i, int j, Mat& arr 
         t[3] = cvtest::randReal(rng)*cube_size;
         t[7] = cvtest::randReal(rng)*cube_size;
         t[11] = cvtest::randReal(rng)*cube_size;
-        Mat( 3, 4, CV_64F, t ).convertTo(arr, arr.type());
+        Mat(3, 4, CV_64FC1, t).convertTo(arr, arr.depth());
         }
         break;
     case 4:
@@ -1248,7 +1248,7 @@ void CV_EssentialMatTest::fill_array( int test_case_idx, int i, int j, Mat& arr 
         t[2] = (img_size*0.5 + cvtest::randReal(rng)*4. - 2.)*t[0];
         t[5] = (img_size*0.5 + cvtest::randReal(rng)*4. - 2.)*t[4];
         t[8] = 1.;
-        Mat( 3, 3, CV_64F, t ).convertTo( arr, arr.type() );
+        Mat(3, 3, CV_64FC1, t).convertTo(arr, arr.depth());
         break;
     }
 }
@@ -1262,7 +1262,7 @@ int CV_EssentialMatTest::prepare_test_case( int test_case_idx )
         const Mat& _3d = test_mat[INPUT][2];
         RNG& rng = ts->get_rng();
         double Idata[] = { 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0 };
-        Mat I( 3, 4, CV_64F, Idata );
+        Mat I(3, 4, CV_64FC1, Idata);
         int k;
 
         for( k = 0; k < 2; k++ )
@@ -1331,8 +1331,8 @@ void CV_EssentialMatTest::prepare_to_validation( int test_case_idx )
     const Mat& Rt0 = test_mat[INPUT][3];
     const Mat& A = test_mat[INPUT][4];
     double f0[9], f[9], e[9];
-    Mat F0(3, 3, CV_64FC1, f0), F(3, 3, CV_64F, f);
-    Mat E(3, 3, CV_64F, e);
+    Mat F0(3, 3, CV_64FC1, f0), F(3, 3, CV_64FC1, f);
+    Mat E(3, 3, CV_64FC1, e);
 
     Mat invA, R=Rt0.colRange(0, 3), T1, T2;
 
@@ -1345,7 +1345,7 @@ void CV_EssentialMatTest::prepare_to_validation( int test_case_idx )
     double _t_x[] = { 0, -tz, ty, tz, 0, -tx, -ty, tx, 0 };
 
     // F = (A2^-T)*[t]_x*R*(A1^-1)
-    cv::gemm( invA, Mat( 3, 3, CV_64F, _t_x ), 1, Mat(), 0, T1, CV_GEMM_A_T );
+    cv::gemm(invA, Mat(3, 3, CV_64FC1, _t_x), 1, Mat(), 0, T1, CV_GEMM_A_T);
     cv::gemm( R, invA, 1, Mat(), 0, T2 );
     cv::gemm( T1, T2, 1, Mat(), 0, F0 );
     F0 *= 1./f0[8];
@@ -1356,7 +1356,7 @@ void CV_EssentialMatTest::prepare_to_validation( int test_case_idx )
     uchar* mtfm2 = test_mat[OUTPUT][1].ptr();
     double* e_prop1 = test_mat[REF_OUTPUT][0].ptr<double>();
     double* e_prop2 = test_mat[OUTPUT][0].ptr<double>();
-    Mat E_prop2 = Mat(3, 1, CV_64F, e_prop2);
+    Mat E_prop2 = Mat(3, 1, CV_64FC1, e_prop2);
 
     int i, pt_count = test_mat[INPUT][2].cols;
     Mat p1( 1, pt_count, CV_64FC2 );
@@ -1365,7 +1365,7 @@ void CV_EssentialMatTest::prepare_to_validation( int test_case_idx )
     test_convertHomogeneous( test_mat[INPUT][0], p1 );
     test_convertHomogeneous( test_mat[INPUT][1], p2 );
 
-    cvtest::convert(test_mat[TEMP][0], E, E.type());
+    cvtest::convert(test_mat[TEMP][0], E, E.depth());
     cv::gemm( invA, E, 1, Mat(), 0, T1, CV_GEMM_A_T );
     cv::gemm( T1, invA, 1, Mat(), 0, F );
 
@@ -1404,7 +1404,7 @@ void CV_EssentialMatTest::prepare_to_validation( int test_case_idx )
     double* pose_prop2 = test_mat[OUTPUT][2].ptr<double>();
     double terr1 = cvtest::norm(Rt0.col(3) / cvtest::norm(Rt0.col(3), NORM_L2) + test_mat[TEMP][3], NORM_L2);
     double terr2 = cvtest::norm(Rt0.col(3) / cvtest::norm(Rt0.col(3), NORM_L2) - test_mat[TEMP][3], NORM_L2);
-    Mat rvec(3, 1, CV_32F);
+    Mat rvec(3, 1, CV_32FC1);
     cvtest::Rodrigues(Rt0.colRange(0, 3), rvec);
     pose_prop1[0] = 0;
     // No check for CV_LMeDS on translation. Since it
@@ -1429,12 +1429,12 @@ public:
     CV_ConvertHomogeneousTest();
 
 protected:
-    int read_params( CvFileStorage* fs );
-    void get_test_array_types_and_sizes( int test_case_idx, vector<vector<Size> >& sizes, vector<vector<int> >& types );
-    void fill_array( int test_case_idx, int i, int j, Mat& arr );
-    double get_success_error_level( int test_case_idx, int i, int j );
-    void run_func();
-    void prepare_to_validation( int );
+    int read_params(CvFileStorage* fs) CV_OVERRIDE;
+    void get_test_array_types_and_sizes(int test_case_idx, vector<vector<Size> >& sizes, vector<vector<ElemType> >& types) CV_OVERRIDE;
+    void fill_array(int test_case_idx, int i, int j, Mat& arr) CV_OVERRIDE;
+    double get_success_error_level(int test_case_idx, int i, int j) CV_OVERRIDE;
+    void run_func() CV_OVERRIDE;
+    void prepare_to_validation(int) CV_OVERRIDE;
 
     int dims1, dims2;
     int pt_count;
@@ -1460,7 +1460,7 @@ int CV_ConvertHomogeneousTest::read_params( CvFileStorage* fs )
 
 
 void CV_ConvertHomogeneousTest::get_test_array_types_and_sizes( int /*test_case_idx*/,
-                                                vector<vector<Size> >& sizes, vector<vector<int> >& types )
+                                                vector<vector<Size> >& sizes, vector<vector<ElemType> >& types )
 {
     RNG& rng = ts->get_rng();
     int pt_depth1 = cvtest::randInt(rng) % 2 == 0 ? CV_32F : CV_64F;
@@ -1562,12 +1562,12 @@ public:
     CV_ComputeEpilinesTest();
 
 protected:
-    int read_params( CvFileStorage* fs );
-    void get_test_array_types_and_sizes( int test_case_idx, vector<vector<Size> >& sizes, vector<vector<int> >& types );
-    void fill_array( int test_case_idx, int i, int j, Mat& arr );
-    double get_success_error_level( int test_case_idx, int i, int j );
-    void run_func();
-    void prepare_to_validation( int );
+    int read_params(CvFileStorage* fs) CV_OVERRIDE;
+    void get_test_array_types_and_sizes(int test_case_idx, vector<vector<Size> >& sizes, vector<vector<ElemType> >& types) CV_OVERRIDE;
+    void fill_array(int test_case_idx, int i, int j, Mat& arr) CV_OVERRIDE;
+    double get_success_error_level(int test_case_idx, int i, int j) CV_OVERRIDE;
+    void run_func() CV_OVERRIDE;
+    void prepare_to_validation(int) CV_OVERRIDE;
 
     int which_image;
     int dims;
@@ -1595,7 +1595,7 @@ int CV_ComputeEpilinesTest::read_params( CvFileStorage* fs )
 
 
 void CV_ComputeEpilinesTest::get_test_array_types_and_sizes( int /*test_case_idx*/,
-                                                vector<vector<Size> >& sizes, vector<vector<int> >& types )
+                                                vector<vector<Size> >& sizes, vector<vector<ElemType> >& types )
 {
     RNG& rng = ts->get_rng();
     int fm_depth = cvtest::randInt(rng) % 2 == 0 ? CV_32F : CV_64F;
@@ -1688,7 +1688,7 @@ void CV_ComputeEpilinesTest::prepare_to_validation( int /*test_case_idx*/ )
     Mat pt( 1, pt_count, CV_MAKETYPE(CV_64F, 3) );
     Mat lines( 1, pt_count, CV_MAKETYPE(CV_64F, 3) );
     double f[9];
-    Mat F( 3, 3, CV_64F, f );
+    Mat F(3, 3, CV_64FC1, f);
 
     test_convertHomogeneous( test_mat[INPUT][0], pt );
     test_mat[INPUT][1].convertTo(F, CV_64F);
@@ -1722,7 +1722,7 @@ TEST(Calib3d_FindFundamentalMat, correctMatches)
     double p1data[] = {200, 0, 1};
     double p2data[] = {170, 0, 1};
 
-    Mat F(3, 3, CV_64F, fdata);
+    Mat F(3, 3, CV_64FC1, fdata);
     Mat p1(1, 1, CV_64FC2, p1data);
     Mat p2(1, 1, CV_64FC2, p2data);
     Mat np1, np2;

--- a/modules/calib3d/test/test_homography.cpp
+++ b/modules/calib3d/test/test_homography.cpp
@@ -262,8 +262,8 @@ void CV_HomographyTest::run(int)
         }
 
         cv::Mat src_mat_2f(1, N, CV_32FC2, src_data),
-        src_mat_2d(2, N, CV_32F, src_data),
-        src_mat_3d(3, N, CV_32F);
+                src_mat_2d(2, N, CV_32FC1, src_data),
+                src_mat_3d(3, N, CV_32FC1);
         cv::Mat dst_mat_2f, dst_mat_2d, dst_mat_3d;
 
         vector <Point2f> src_vec, dst_vec;
@@ -287,13 +287,13 @@ void CV_HomographyTest::run(int)
                             sin(fi),  cos(fi), t_y,
                             0.0f,     0.0f, 1.0f };
 
-        cv::Mat H_64(3, 3, CV_64F, Hdata), H_32;
+        cv::Mat H_64(3, 3, CV_64FC1, Hdata), H_32;
 
         H_64.convertTo(H_32, CV_32F);
 
         dst_mat_3d = H_32*src_mat_3d;
 
-        dst_mat_2d.create(2, N, CV_32F); dst_mat_2f.create(1, N, CV_32FC2);
+        dst_mat_2d.create(2, N, CV_32FC1); dst_mat_2f.create(1, N, CV_32FC2);
 
         for (int i = 0; i < N; ++i)
         {
@@ -433,7 +433,7 @@ void CV_HomographyTest::run(int)
 
                         Mat H_res_32; H_res_64[j].convertTo(H_res_32, CV_32F);
 
-                        cv::Mat dst_res_3d(3, N, CV_32F), noise_2d(2, N, CV_32F);
+                        cv::Mat dst_res_3d(3, N, CV_32FC1), noise_2d(2, N, CV_32FC1);
 
                         for (int k = 0; k < N; ++k)
                         {
@@ -542,7 +542,7 @@ void CV_HomographyTest::run(int)
                                 dst_mat_3d.at<float>(0, k) -= a[0];
                                 dst_mat_3d.at<float>(1, k) -= a[1];
 
-                                cv::Mat noise_2d(2, 1, CV_32F);
+                                cv::Mat noise_2d(2, 1, CV_32FC1);
                                 noise_2d.at<float>(0, 0) = a[0]; noise_2d.at<float>(1, 0) = a[1];
 
                                 for (int l = 0; l < COUNT_NORM_TYPES; ++l)

--- a/modules/calib3d/test/test_modelest.cpp
+++ b/modules/calib3d/test/test_modelest.cpp
@@ -86,11 +86,11 @@ public:
     CV_ModelEstimator2_Test();
 
 protected:
-    void get_test_array_types_and_sizes( int test_case_idx, vector<vector<Size> >& sizes, vector<vector<int> >& types );
-    void fill_array( int test_case_idx, int i, int j, Mat& arr );
-    double get_success_error_level( int test_case_idx, int i, int j );
+    void get_test_array_types_and_sizes( int test_case_idx, vector<vector<Size> >& sizes, vector<vector<ElemType> >& types ) CV_OVERRIDE;
+    void fill_array( int test_case_idx, int i, int j, Mat& arr ) CV_OVERRIDE;
+    double get_success_error_level( int test_case_idx, int i, int j ) CV_OVERRIDE;
     void run_func();
-    void prepare_to_validation( int test_case_idx );
+    void prepare_to_validation( int test_case_idx ) CV_OVERRIDE;
 
     bool checkPartialSubsets;
     int usedPointsCount;
@@ -111,7 +111,7 @@ CV_ModelEstimator2_Test::CV_ModelEstimator2_Test()
 }
 
 void CV_ModelEstimator2_Test::get_test_array_types_and_sizes( int /*test_case_idx*/,
-                                                              vector<vector<Size> > &sizes, vector<vector<int> > &types )
+                                                              vector<vector<Size> > &sizes, vector<vector<ElemType> > &types )
 {
     RNG &rng = ts->get_rng();
     checkPartialSubsets = (cvtest::randInt(rng) % 2 == 0);

--- a/modules/calib3d/test/test_solvepnp_ransac.cpp
+++ b/modules/calib3d/test/test_solvepnp_ransac.cpp
@@ -368,7 +368,7 @@ TEST(Calib3d_SolvePnPRansac, concurrency)
     camera_mat.at<float>(2, 0) = 0.f;
     camera_mat.at<float>(2, 1) = 0.f;
 
-    Mat dist_coef(1, 8, CV_32F, cv::Scalar::all(0));
+    Mat dist_coef(1, 8, CV_32FC1, cv::Scalar::all(0));
 
     vector<cv::Point2f> image_vec;
     Mat rvec_gold(1, 3, CV_32FC1);

--- a/modules/calib3d/test/test_stereomatching.cpp
+++ b/modules/calib3d/test/test_stereomatching.cpp
@@ -78,9 +78,9 @@ void computeTextureBasedMasks( const Mat& _img, Mat* texturelessMask, Mat* textu
     {
         Mat tmp; cvtColor( _img, tmp, COLOR_BGR2GRAY ); img = tmp;
     }
-    Mat dxI; Sobel( img, dxI, CV_32FC1, 1, 0, 3 );
+    Mat dxI; Sobel( img, dxI, CV_32F, 1, 0, 3 );
     Mat dxI2; pow( dxI / 8.f/*normalize*/, 2, dxI2 );
-    Mat avgDxI2; boxFilter( dxI2, avgDxI2, CV_32FC1, Size(texturelessWidth,texturelessWidth) );
+    Mat avgDxI2; boxFilter( dxI2, avgDxI2, CV_32F, Size(texturelessWidth,texturelessWidth) );
 
     if( texturelessMask )
         *texturelessMask = avgDxI2 < texturelessThresh;
@@ -469,13 +469,13 @@ void CV_StereoMatchingTest::run(int)
         int dispScaleFactor = datasetsParams[datasetName].dispScaleFactor;
         Mat tmp;
 
-        trueLeftDisp.convertTo( tmp, CV_32FC1, 1.f/dispScaleFactor );
+        trueLeftDisp.convertTo( tmp, CV_32F, 1.f/dispScaleFactor );
         trueLeftDisp = tmp;
         tmp.release();
 
         if( !trueRightDisp.empty() )
         {
-            trueRightDisp.convertTo( tmp, CV_32FC1, 1.f/dispScaleFactor );
+            trueRightDisp.convertTo( tmp, CV_32F, 1.f/dispScaleFactor );
             trueRightDisp = tmp;
             tmp.release();
         }
@@ -483,11 +483,11 @@ void CV_StereoMatchingTest::run(int)
         Mat leftDisp, rightDisp;
         int ignBorder = max(runStereoMatchingAlgorithm(leftImg, rightImg, calcROI, leftDisp, rightDisp, ci), EVAL_IGNORE_BORDER);
 
-        leftDisp.convertTo( tmp, CV_32FC1 );
+        leftDisp.convertTo( tmp, CV_32F );
         leftDisp = tmp;
         tmp.release();
 
-        rightDisp.convertTo( tmp, CV_32FC1 );
+        rightDisp.convertTo( tmp, CV_32F );
         rightDisp = tmp;
         tmp.release();
 
@@ -888,7 +888,7 @@ TEST(Calib3d_StereoSGBM_HH4, regression)
         Ptr<StereoSGBM> sgbm = StereoSGBM::create( 0, 48, 3, 90, 360, 1, 63, 10, 100, 32, StereoSGBM::MODE_HH4);
         sgbm->compute( leftImg, rightImg, leftDisp);
         CV_Assert( leftDisp.type() == CV_16SC1 );
-        leftDisp.convertTo(toCheck, CV_16UC1,1,16);
+        leftDisp.convertTo(toCheck, CV_16U,1,16);
     }
     Mat diff;
     absdiff(toCheck, testData,diff);

--- a/modules/calib3d/test/test_undistort.cpp
+++ b/modules/calib3d/test/test_undistort.cpp
@@ -50,9 +50,9 @@ class CV_DefaultNewCameraMatrixTest : public cvtest::ArrayTest
 public:
     CV_DefaultNewCameraMatrixTest();
 protected:
-    int prepare_test_case (int test_case_idx);
-    void prepare_to_validation( int test_case_idx );
-    void get_test_array_types_and_sizes( int test_case_idx, vector<vector<Size> >& sizes, vector<vector<int> >& types );
+    int prepare_test_case (int test_case_idx) CV_OVERRIDE;
+    void prepare_to_validation( int test_case_idx ) CV_OVERRIDE;
+    void get_test_array_types_and_sizes(int test_case_idx, vector<vector<Size> >& sizes, vector<vector<ElemType> >& types) CV_OVERRIDE;
     void run_func();
 
 private:
@@ -79,11 +79,11 @@ CV_DefaultNewCameraMatrixTest::CV_DefaultNewCameraMatrixTest()
     center_principal_point = false;
 }
 
-void CV_DefaultNewCameraMatrixTest::get_test_array_types_and_sizes( int test_case_idx, vector<vector<Size> >& sizes, vector<vector<int> >& types )
+void CV_DefaultNewCameraMatrixTest::get_test_array_types_and_sizes(int test_case_idx, vector<vector<Size> >& sizes, vector<vector<ElemType> >& types)
 {
     cvtest::ArrayTest::get_test_array_types_and_sizes(test_case_idx,sizes,types);
     RNG& rng = ts->get_rng();
-    matrix_type = types[INPUT][0] = types[OUTPUT][0]= types[REF_OUTPUT][0] = cvtest::randInt(rng)%2 ? CV_64F : CV_32F;
+    matrix_type = types[INPUT][0] = types[OUTPUT][0] = types[REF_OUTPUT][0] = cvtest::randInt(rng) % 2 ? CV_64FC1 : CV_32FC1;
     sizes[INPUT][0] = sizes[OUTPUT][0] = sizes[REF_OUTPUT][0] = cvSize(3,3);
 }
 
@@ -105,14 +105,14 @@ int CV_DefaultNewCameraMatrixTest::prepare_test_case(int test_case_idx)
     double sz = MAX(img_size.width, img_size.height);
     double aspect_ratio = cvtest::randReal(rng)*0.6 + 0.7;
     double a[9] = {0,0,0,0,0,0,0,0,1};
-    Mat _a(3,3,CV_64F,a);
+    Mat _a(3,3,CV_64FC1,a);
     a[2] = (img_size.width - 1)*0.5 + cvtest::randReal(rng)*10 - 5;
     a[5] = (img_size.height - 1)*0.5 + cvtest::randReal(rng)*10 - 5;
     a[0] = sz/(0.9 - cvtest::randReal(rng)*0.6);
     a[4] = aspect_ratio*a[0];
 
     Mat& _a0 = test_mat[INPUT][0];
-    cvtest::convert(_a, _a0, _a0.type());
+    cvtest::convert(_a, _a0, _a0.depth());
     camera_mat = _a0;
 
     return code;
@@ -130,7 +130,7 @@ void CV_DefaultNewCameraMatrixTest::prepare_to_validation( int /*test_case_idx*/
     Mat& dst = test_mat[REF_OUTPUT][0];
     Mat& test_output = test_mat[OUTPUT][0];
     Mat& output = new_camera_mat;
-    cvtest::convert( output, test_output, test_output.type() );
+    cvtest::convert(output, test_output, test_output.depth());
     if (!center_principal_point)
     {
         cvtest::copy(src, dst);
@@ -138,7 +138,7 @@ void CV_DefaultNewCameraMatrixTest::prepare_to_validation( int /*test_case_idx*/
     else
     {
         double a[9] = {0,0,0,0,0,0,0,0,1};
-        Mat _a(3,3,CV_64F,a);
+        Mat _a(3,3,CV_64FC1,a);
         if (matrix_type == CV_64F)
         {
             a[0] = src.at<double>(0,0);
@@ -151,7 +151,7 @@ void CV_DefaultNewCameraMatrixTest::prepare_to_validation( int /*test_case_idx*/
         }
         a[2] = (img_size.width - 1)*0.5;
         a[5] = (img_size.height - 1)*0.5;
-        cvtest::convert( _a, dst, dst.type() );
+        cvtest::convert(_a, dst, dst.depth());
     }
 }
 
@@ -162,10 +162,10 @@ class CV_UndistortPointsTest : public cvtest::ArrayTest
 public:
     CV_UndistortPointsTest();
 protected:
-    int prepare_test_case (int test_case_idx);
-    void prepare_to_validation( int test_case_idx );
-    void get_test_array_types_and_sizes( int test_case_idx, vector<vector<Size> >& sizes, vector<vector<int> >& types );
-    double get_success_error_level( int test_case_idx, int i, int j );
+    int prepare_test_case (int test_case_idx) CV_OVERRIDE;
+    void prepare_to_validation( int test_case_idx ) CV_OVERRIDE;
+    void get_test_array_types_and_sizes(int test_case_idx, vector<vector<Size> >& sizes, vector<vector<ElemType> >& types) CV_OVERRIDE;
+    double get_success_error_level( int test_case_idx, int i, int j ) CV_OVERRIDE;
     void run_func();
     void distortPoints(const CvMat* _src, CvMat* _dst, const CvMat* _cameraMatrix,
                        const CvMat* _distCoeffs, const CvMat* matR, const CvMat* matP);
@@ -207,7 +207,7 @@ CV_UndistortPointsTest::CV_UndistortPointsTest()
     zero_new_cam = zero_distortion = zero_R = false;
 }
 
-void CV_UndistortPointsTest::get_test_array_types_and_sizes( int test_case_idx, vector<vector<Size> >& sizes, vector<vector<int> >& types )
+void CV_UndistortPointsTest::get_test_array_types_and_sizes(int test_case_idx, vector<vector<Size> >& sizes, vector<vector<ElemType> >& types)
 {
     cvtest::ArrayTest::get_test_array_types_and_sizes(test_case_idx,sizes,types);
     RNG& rng = ts->get_rng();
@@ -221,10 +221,10 @@ void CV_UndistortPointsTest::get_test_array_types_and_sizes( int test_case_idx, 
     {
         types[INPUT][0] = types[OUTPUT][0] = types[REF_OUTPUT][0] = types[TEMP][0]= cvtest::randInt(rng)%2 ? CV_64FC2 : CV_32FC2;
     }
-    types[INPUT][1] = cvtest::randInt(rng)%2 ? CV_64F : CV_32F;
-    types[INPUT][2] = cvtest::randInt(rng)%2 ? CV_64F : CV_32F;
-    types[INPUT][3] = cvtest::randInt(rng)%2 ? CV_64F : CV_32F;
-    types[INPUT][4] = cvtest::randInt(rng)%2 ? CV_64F : CV_32F;
+    types[INPUT][1] = cvtest::randInt(rng) % 2 ? CV_64FC1 : CV_32FC1;
+    types[INPUT][2] = cvtest::randInt(rng) % 2 ? CV_64FC1 : CV_32FC1;
+    types[INPUT][3] = cvtest::randInt(rng) % 2 ? CV_64FC1 : CV_32FC1;
+    types[INPUT][4] = cvtest::randInt(rng) % 2 ? CV_64FC1 : CV_32FC1;
 
     sizes[INPUT][0] = sizes[OUTPUT][0] = sizes[REF_OUTPUT][0] = sizes[TEMP][0]= cvtest::randInt(rng)%2 ? cvSize(1,N_POINTS) : cvSize(N_POINTS,1);
     sizes[INPUT][1] = sizes[INPUT][3] = cvSize(3,3);
@@ -272,9 +272,9 @@ int CV_UndistortPointsTest::prepare_test_case(int test_case_idx)
     vector<double> proj(test_mat[INPUT][4].cols * test_mat[INPUT][4].rows);
     vector<Point2d> points(N_POINTS);
 
-    Mat _camera(3,3,CV_64F,cam);
-    Mat _distort(test_mat[INPUT][2].rows,test_mat[INPUT][2].cols,CV_64F,&dist[0]);
-    Mat _proj(test_mat[INPUT][4].size(), CV_64F, &proj[0]);
+    Mat _camera(3,3,CV_64FC1,cam);
+    Mat _distort(test_mat[INPUT][2].rows, test_mat[INPUT][2].cols, CV_64FC1, &dist[0]);
+    Mat _proj(test_mat[INPUT][4].size(), CV_64FC1, &proj[0]);
     Mat _points(test_mat[INPUT][0].size(), CV_64FC2, &points[0]);
 
     _proj = Scalar::all(0);
@@ -344,8 +344,8 @@ int CV_UndistortPointsTest::prepare_test_case(int test_case_idx)
     }
 
     //Generating R matrix
-    Mat _rot(3,3,CV_64F);
-    Mat rotation(1,3,CV_64F);
+    Mat _rot(3,3,CV_64FC1);
+    Mat rotation(1,3,CV_64FC1);
     rotation.at<double>(0) = CV_PI*(cvtest::randReal(rng) - (double)0.5); // phi
     rotation.at<double>(1) = CV_PI*(cvtest::randReal(rng) - (double)0.5); // ksi
     rotation.at<double>(2) = CV_PI*(cvtest::randReal(rng) - (double)0.5); //khi
@@ -353,11 +353,11 @@ int CV_UndistortPointsTest::prepare_test_case(int test_case_idx)
 
     //copying data
     //src_points = &_points;
-    _points.convertTo(test_mat[INPUT][0], test_mat[INPUT][0].type());
-    _camera.convertTo(test_mat[INPUT][1], test_mat[INPUT][1].type());
-    _distort.convertTo(test_mat[INPUT][2], test_mat[INPUT][2].type());
-    _rot.convertTo(test_mat[INPUT][3], test_mat[INPUT][3].type());
-    _proj.convertTo(test_mat[INPUT][4], test_mat[INPUT][4].type());
+    _points.convertTo(test_mat[INPUT][0], test_mat[INPUT][0].depth());
+    _camera.convertTo(test_mat[INPUT][1], test_mat[INPUT][1].depth());
+    _distort.convertTo(test_mat[INPUT][2], test_mat[INPUT][2].depth());
+    _rot.convertTo(test_mat[INPUT][3], test_mat[INPUT][3].depth());
+    _proj.convertTo(test_mat[INPUT][4], test_mat[INPUT][4].depth());
 
     zero_distortion = (cvtest::randInt(rng)%2) == 0 ? false : true;
     zero_new_cam = (cvtest::randInt(rng)%2) == 0 ? false : true;
@@ -388,8 +388,8 @@ void CV_UndistortPointsTest::prepare_to_validation(int /*test_case_idx*/)
     double* r_points = new double[N_POINTS*2];
     //Run reference calculations
     CvMat ref_points= cvMat(test_mat[INPUT][0].rows,test_mat[INPUT][0].cols,CV_64FC2,r_points);
-    CvMat _camera = cvMat(3,3,CV_64F,cam);
-    CvMat _rot = cvMat(3,3,CV_64F,rot);
+    CvMat _camera = cvMat(3,3,CV_64FC1,cam);
+    CvMat _rot = cvMat(3,3,CV_64FC1,rot);
     CvMat _distort = cvMat(test_mat[INPUT][2].rows,test_mat[INPUT][2].cols,CV_64F,dist);
     CvMat _proj = cvMat(test_mat[INPUT][4].rows,test_mat[INPUT][4].cols,CV_64F,proj);
     CvMat _points= cvMat(test_mat[TEMP][0].rows,test_mat[TEMP][0].cols,CV_64FC2,points);
@@ -401,10 +401,10 @@ void CV_UndistortPointsTest::prepare_to_validation(int /*test_case_idx*/)
     Mat __points = cvarrToMat(&_points);
     Mat _ref_points = cvarrToMat(&ref_points);
 
-    cvtest::convert(test_mat[INPUT][1], __camera, __camera.type());
-    cvtest::convert(test_mat[INPUT][2], __distort, __distort.type());
-    cvtest::convert(test_mat[INPUT][3], __rot, __rot.type());
-    cvtest::convert(test_mat[INPUT][4], __proj, __proj.type());
+    cvtest::convert(test_mat[INPUT][1], __camera, __camera.depth());
+    cvtest::convert(test_mat[INPUT][2], __distort, __distort.depth());
+    cvtest::convert(test_mat[INPUT][3], __rot, __rot.depth());
+    cvtest::convert(test_mat[INPUT][4], __proj, __proj.depth());
 
     if (useCPlus)
     {
@@ -427,7 +427,7 @@ void CV_UndistortPointsTest::prepare_to_validation(int /*test_case_idx*/)
     }
     else
     {
-        cvtest::convert(test_mat[TEMP][0],__points, __points.type());
+        cvtest::convert(test_mat[TEMP][0], __points, __points.depth());
     }
 
     CvMat* input2 = zero_distortion ? 0 : &_distort;
@@ -436,7 +436,7 @@ void CV_UndistortPointsTest::prepare_to_validation(int /*test_case_idx*/)
     distortPoints(&_points,&ref_points,&_camera,input2,input3,input4);
 
     Mat& dst = test_mat[REF_OUTPUT][0];
-    cvtest::convert(_ref_points, dst, dst.type());
+    cvtest::convert(_ref_points, dst, dst.depth());
 
     cvtest::copy(test_mat[INPUT][0], test_mat[OUTPUT][0]);
 
@@ -492,12 +492,12 @@ void CV_UndistortPointsTest::distortPoints(const CvMat* _src, CvMat* _dst, const
 
     CvMat* __P;
     if ((!matP)||(matP->cols == 3))
-        __P = cvCreateMat(3,3,CV_64F);
+        __P = cvCreateMat(3,3,CV_64FC1);
     else
-        __P = cvCreateMat(3,4,CV_64F);
+        __P = cvCreateMat(3,4,CV_64FC1);
     if (matP)
     {
-        cvtest::convert(cvarrToMat(matP), cvarrToMat(__P), -1);
+        cvtest::convert(cvarrToMat(matP), cvarrToMat(__P), CV_DEPTH_AUTO);
     }
     else
     {
@@ -506,7 +506,7 @@ void CV_UndistortPointsTest::distortPoints(const CvMat* _src, CvMat* _dst, const
         __P->data.db[4] = 1;
         __P->data.db[8] = 1;
     }
-    CvMat* __R = cvCreateMat(3,3,CV_64F);
+    CvMat* __R = cvCreateMat(3,3,CV_64FC1);
     if (matR)
     {
         cvCopy(matR,__R);
@@ -523,7 +523,7 @@ void CV_UndistortPointsTest::distortPoints(const CvMat* _src, CvMat* _dst, const
         int movement = __P->cols > 3 ? 1 : 0;
         double x = (_src->data.db[2*i]-__P->data.db[2])/__P->data.db[0];
         double y = (_src->data.db[2*i+1]-__P->data.db[5+movement])/__P->data.db[4+movement];
-        CvMat inverse = cvMat(3,3,CV_64F,a);
+        CvMat inverse = cvMat(3,3,CV_64FC1,a);
         cvInvert(__R,&inverse);
         double w1 = x*inverse.data.db[6]+y*inverse.data.db[7]+inverse.data.db[8];
         double _x = (x*inverse.data.db[0]+y*inverse.data.db[1]+inverse.data.db[2])/w1;
@@ -572,10 +572,10 @@ class CV_InitUndistortRectifyMapTest : public cvtest::ArrayTest
 public:
     CV_InitUndistortRectifyMapTest();
 protected:
-    int prepare_test_case (int test_case_idx);
-    void prepare_to_validation( int test_case_idx );
-    void get_test_array_types_and_sizes( int test_case_idx, vector<vector<Size> >& sizes, vector<vector<int> >& types );
-    double get_success_error_level( int test_case_idx, int i, int j );
+    int prepare_test_case (int test_case_idx) CV_OVERRIDE;
+    void prepare_to_validation( int test_case_idx ) CV_OVERRIDE;
+    void get_test_array_types_and_sizes(int test_case_idx, vector<vector<Size> >& sizes, vector<vector<ElemType> >& types) CV_OVERRIDE;
+    double get_success_error_level( int test_case_idx, int i, int j ) CV_OVERRIDE;
     void run_func();
 
 private:
@@ -598,7 +598,7 @@ private:
     cv::Mat mapy;
     CvMat* _mapx;
     CvMat* _mapy;
-    int mat_type;
+    ElemType mat_type;
 };
 
 CV_InitUndistortRectifyMapTest::CV_InitUndistortRectifyMapTest()
@@ -614,10 +614,10 @@ CV_InitUndistortRectifyMapTest::CV_InitUndistortRectifyMapTest()
     useCPlus = false;
     zero_distortion = zero_new_cam = zero_R = false;
     _mapx = _mapy = NULL;
-    mat_type = 0;
+    mat_type = CV_8UC1;
 }
 
-void CV_InitUndistortRectifyMapTest::get_test_array_types_and_sizes( int test_case_idx, vector<vector<Size> >& sizes, vector<vector<int> >& types )
+void CV_InitUndistortRectifyMapTest::get_test_array_types_and_sizes(int test_case_idx, vector<vector<Size> >& sizes, vector<vector<ElemType> >& types)
 {
     cvtest::ArrayTest::get_test_array_types_and_sizes(test_case_idx,sizes,types);
     RNG& rng = ts->get_rng();
@@ -625,10 +625,10 @@ void CV_InitUndistortRectifyMapTest::get_test_array_types_and_sizes( int test_ca
     //useCPlus = 0;
     types[INPUT][0] = types[OUTPUT][0] = types[REF_OUTPUT][0] = CV_64FC2;
 
-    types[INPUT][1] = cvtest::randInt(rng)%2 ? CV_64F : CV_32F;
-    types[INPUT][2] = cvtest::randInt(rng)%2 ? CV_64F : CV_32F;
-    types[INPUT][3] = cvtest::randInt(rng)%2 ? CV_64F : CV_32F;
-    types[INPUT][4] = cvtest::randInt(rng)%2 ? CV_64F : CV_32F;
+    types[INPUT][1] = cvtest::randInt(rng) % 2 ? CV_64FC1 : CV_32FC1;
+    types[INPUT][2] = cvtest::randInt(rng) % 2 ? CV_64FC1 : CV_32FC1;
+    types[INPUT][3] = cvtest::randInt(rng) % 2 ? CV_64FC1 : CV_32FC1;
+    types[INPUT][4] = cvtest::randInt(rng) % 2 ? CV_64FC1 : CV_32FC1;
 
     sizes[INPUT][0] = sizes[OUTPUT][0] = sizes[REF_OUTPUT][0] = cvSize(N_POINTS,1);
     sizes[INPUT][1] = sizes[INPUT][3] = cvSize(3,3);
@@ -674,7 +674,7 @@ int CV_InitUndistortRectifyMapTest::prepare_test_case(int test_case_idx)
     {
         mat_type = (cvtest::randInt(rng) % 2) == 0 ? CV_32FC1 : CV_16SC2;
         if ((cvtest::randInt(rng) % 4) == 0)
-            mat_type = -1;
+            mat_type = CV_TYPE_AUTO;
         if ((cvtest::randInt(rng) % 4) == 0)
             mat_type = CV_32FC2;
         _mapx = 0;
@@ -698,10 +698,10 @@ int CV_InitUndistortRectifyMapTest::prepare_test_case(int test_case_idx)
     vector<double> new_cam(test_mat[INPUT][4].cols * test_mat[INPUT][4].rows);
     vector<Point2d> points(N_POINTS);
 
-    Mat _camera(3,3,CV_64F,cam);
-    Mat _distort(test_mat[INPUT][2].size(),CV_64F,&dist[0]);
-    Mat _new_cam(test_mat[INPUT][4].size(),CV_64F,&new_cam[0]);
-    Mat _points(test_mat[INPUT][0].size(),CV_64FC2, &points[0]);
+    Mat _camera(3, 3, CV_64FC1, cam);
+    Mat _distort(test_mat[INPUT][2].size(), CV_64FC1, &dist[0]);
+    Mat _new_cam(test_mat[INPUT][4].size(), CV_64FC1, &new_cam[0]);
+    Mat _points(test_mat[INPUT][0].size(), CV_64FC2, &points[0]);
 
     //Generating points
     for (int i=0;i<N_POINTS;i++)
@@ -753,8 +753,8 @@ int CV_InitUndistortRectifyMapTest::prepare_test_case(int test_case_idx)
 
 
     //Generating R matrix
-    Mat _rot(3,3,CV_64F);
-    Mat rotation(1,3,CV_64F);
+    Mat _rot(3,3,CV_64FC1);
+    Mat rotation(1,3,CV_64FC1);
     rotation.at<double>(0) = CV_PI/8*(cvtest::randReal(rng) - (double)0.5); // phi
     rotation.at<double>(1) = CV_PI/8*(cvtest::randReal(rng) - (double)0.5); // ksi
     rotation.at<double>(2) = CV_PI/3*(cvtest::randReal(rng) - (double)0.5); //khi
@@ -762,11 +762,11 @@ int CV_InitUndistortRectifyMapTest::prepare_test_case(int test_case_idx)
 
     //cvSetIdentity(_rot);
     //copying data
-    cvtest::convert( _points, test_mat[INPUT][0], test_mat[INPUT][0].type());
-    cvtest::convert( _camera, test_mat[INPUT][1], test_mat[INPUT][1].type());
-    cvtest::convert( _distort, test_mat[INPUT][2], test_mat[INPUT][2].type());
-    cvtest::convert( _rot, test_mat[INPUT][3], test_mat[INPUT][3].type());
-    cvtest::convert( _new_cam, test_mat[INPUT][4], test_mat[INPUT][4].type());
+    cvtest::convert(_points, test_mat[INPUT][0], test_mat[INPUT][0].depth());
+    cvtest::convert(_camera, test_mat[INPUT][1], test_mat[INPUT][1].depth());
+    cvtest::convert(_distort, test_mat[INPUT][2], test_mat[INPUT][2].depth());
+    cvtest::convert(_rot, test_mat[INPUT][3], test_mat[INPUT][3].depth());
+    cvtest::convert(_new_cam, test_mat[INPUT][4], test_mat[INPUT][4].depth());
 
     zero_distortion = (cvtest::randInt(rng)%2) == 0 ? false : true;
     zero_new_cam = (cvtest::randInt(rng)%2) == 0 ? false : true;
@@ -795,8 +795,8 @@ void CV_InitUndistortRectifyMapTest::prepare_to_validation(int/* test_case_idx*/
     vector<Point2d> r_points(N_POINTS);
     //Run reference calculations
     Mat ref_points(test_mat[INPUT][0].size(),CV_64FC2,&r_points[0]);
-    Mat _camera(3,3,CV_64F,cam);
-    Mat _rot(3,3,CV_64F,rot);
+    Mat _camera(3,3,CV_64FC1,cam);
+    Mat _rot(3,3,CV_64FC1,rot);
     Mat _distort(test_mat[INPUT][2].size(),CV_64F,&dist[0]);
     Mat _new_cam(test_mat[INPUT][4].size(),CV_64F,&new_cam[0]);
     Mat _points(test_mat[INPUT][0].size(),CV_64FC2,&points[0]);
@@ -847,8 +847,8 @@ void CV_InitUndistortRectifyMapTest::prepare_to_validation(int/* test_case_idx*/
     double* r_points = new double[N_POINTS*2];
     //Run reference calculations
     CvMat ref_points= cvMat(test_mat[INPUT][0].rows,test_mat[INPUT][0].cols,CV_64FC2,r_points);
-    CvMat _camera = cvMat(3,3,CV_64F,cam);
-    CvMat _rot = cvMat(3,3,CV_64F,rot);
+    CvMat _camera = cvMat(3,3,CV_64FC1,cam);
+    CvMat _rot = cvMat(3,3,CV_64FC1,rot);
     CvMat _distort = cvMat(test_mat[INPUT][2].rows,test_mat[INPUT][2].cols,CV_64F,dist);
     CvMat _new_cam = cvMat(test_mat[INPUT][4].rows,test_mat[INPUT][4].cols,CV_64F,new_cam);
     CvMat _points= cvMat(test_mat[INPUT][0].rows,test_mat[INPUT][0].cols,CV_64FC2,points);
@@ -858,10 +858,10 @@ void CV_InitUndistortRectifyMapTest::prepare_to_validation(int/* test_case_idx*/
     CvMat _input3 = cvMat(test_mat[INPUT][3]);
     CvMat _input4 = cvMat(test_mat[INPUT][4]);
 
-    cvtest::convert(cvarrToMat(&_input1), cvarrToMat(&_camera), -1);
-    cvtest::convert(cvarrToMat(&_input2), cvarrToMat(&_distort), -1);
-    cvtest::convert(cvarrToMat(&_input3), cvarrToMat(&_rot), -1);
-    cvtest::convert(cvarrToMat(&_input4), cvarrToMat(&_new_cam), -1);
+    cvtest::convert(cvarrToMat(&_input1), cvarrToMat(&_camera), CV_DEPTH_AUTO);
+    cvtest::convert(cvarrToMat(&_input2), cvarrToMat(&_distort), CV_DEPTH_AUTO);
+    cvtest::convert(cvarrToMat(&_input3), cvarrToMat(&_rot), CV_DEPTH_AUTO);
+    cvtest::convert(cvarrToMat(&_input4), cvarrToMat(&_new_cam), CV_DEPTH_AUTO);
 
     //Applying precalculated undistort rectify map
     if (!useCPlus)
@@ -887,7 +887,7 @@ void CV_InitUndistortRectifyMapTest::prepare_to_validation(int/* test_case_idx*/
                       zero_distortion ? 0 : &_distort, zero_R ? 0 : &_rot, zero_new_cam ? &_camera : &_new_cam);
     //cvTsDistortPoints(&_points,&ref_points,&_camera,&_distort,&_rot,&_new_cam);
     CvMat dst = cvMat(test_mat[REF_OUTPUT][0]);
-    cvtest::convert(cvarrToMat(&ref_points), cvarrToMat(&dst), -1);
+    cvtest::convert(cvarrToMat(&ref_points), cvarrToMat(&dst), CV_DEPTH_AUTO);
 
     cvtest::copy(test_mat[INPUT][0],test_mat[OUTPUT][0]);
 

--- a/modules/calib3d/test/test_undistort_badarg.cpp
+++ b/modules/calib3d/test/test_undistort_badarg.cpp
@@ -114,10 +114,10 @@ void CV_UndistortPointsBadArgTest::run(int)
     double p[9] = {155.f, 0.f, img_size.width/2.f+img_size.width/50.f, 0, 310.f, img_size.height/2.f+img_size.height/50.f, 0.f, 0.f, 1.f};
     double r[9] = {1,0,0,0,1,0,0,0,1};
 
-    CvMat _camera_mat_orig = cvMat(3,3,CV_64F,cam);
-    CvMat _distortion_coeffs_orig = cvMat(1,4,CV_64F,dist);
-    CvMat _P_orig = cvMat(3,3,CV_64F,p);
-    CvMat _R_orig = cvMat(3,3,CV_64F,r);
+    CvMat _camera_mat_orig = cvMat(3,3,CV_64FC1,cam);
+    CvMat _distortion_coeffs_orig = cvMat(1,4,CV_64FC1,dist);
+    CvMat _P_orig = cvMat(3,3,CV_64FC1,p);
+    CvMat _R_orig = cvMat(3,3,CV_64FC1,r);
     CvMat _src_points_orig = cvMat(1,4,CV_64FC2,s_points);
     CvMat _dst_points_orig = cvMat(1,4,CV_64FC2,d_points);
 
@@ -144,20 +144,20 @@ void CV_UndistortPointsBadArgTest::run(int)
     errcount += run_test_case( CV_StsAssert, "Output data is not CvMat*" );
     _dst_points = &_dst_points_orig;
 
-    temp = cvCreateMat(2,3,CV_64F);
+    temp = cvCreateMat(2,3,CV_64FC1);
     _src_points = temp;
     errcount += run_test_case( CV_StsAssert, "Invalid input data matrix size" );
     _src_points = &_src_points_orig;
     cvReleaseMat(&temp);
 
-    temp = cvCreateMat(2,3,CV_64F);
+    temp = cvCreateMat(2,3,CV_64FC1);
     _dst_points = temp;
     errcount += run_test_case(CV_StsAssert, "Invalid output data matrix size" );
     _dst_points = &_dst_points_orig;
     cvReleaseMat(&temp);
 
-    temp = cvCreateMat(1,3,CV_64F);
-    temp1 = cvCreateMat(4,1,CV_64F);
+    temp = cvCreateMat(1,3,CV_64FC1);
+    temp1 = cvCreateMat(4,1,CV_64FC1);
     _dst_points = temp;
     _src_points = temp1;
     errcount += run_test_case(CV_StsAssert, "Output and input data sizes mismatch" );
@@ -166,25 +166,25 @@ void CV_UndistortPointsBadArgTest::run(int)
     cvReleaseMat(&temp);
     cvReleaseMat(&temp1);
 
-    temp = cvCreateMat(1,3,CV_32S);
+    temp = cvCreateMat(1,3,CV_32SC1);
     _dst_points = temp;
     errcount += run_test_case(CV_StsAssert, "Invalid output data matrix type" );
     _dst_points = &_dst_points_orig;
     cvReleaseMat(&temp);
 
-    temp = cvCreateMat(1,3,CV_32S);
+    temp = cvCreateMat(1,3,CV_32SC1);
     _src_points = temp;
     errcount += run_test_case(CV_StsAssert, "Invalid input data matrix type" );
     _src_points = &_src_points_orig;
     cvReleaseMat(&temp);
 //------------
-    temp = cvCreateMat(2,3,CV_64F);
+    temp = cvCreateMat(2,3,CV_64FC1);
     _camera_mat = temp;
     errcount += run_test_case( CV_StsAssert, "Invalid camera data matrix size" );
     _camera_mat = &_camera_mat_orig;
     cvReleaseMat(&temp);
 
-    temp = cvCreateMat(3,4,CV_64F);
+    temp = cvCreateMat(3,4,CV_64FC1);
     _camera_mat = temp;
     errcount += run_test_case( CV_StsAssert, "Invalid camera data matrix size" );
     _camera_mat = &_camera_mat_orig;
@@ -201,13 +201,13 @@ void CV_UndistortPointsBadArgTest::run(int)
     errcount += run_test_case( CV_StsAssert, "Distortion coefficients data is not CvMat*" );
     _distortion_coeffs = &_distortion_coeffs_orig;
 
-    temp = cvCreateMat(1,6,CV_64F);
+    temp = cvCreateMat(1,6,CV_64FC1);
     _distortion_coeffs = temp;
     errcount += run_test_case( CV_StsAssert, "Invalid distortion coefficients data matrix size" );
     _distortion_coeffs = &_distortion_coeffs_orig;
     cvReleaseMat(&temp);
 
-    temp = cvCreateMat(3,3,CV_64F);
+    temp = cvCreateMat(3,3,CV_64FC1);
     _distortion_coeffs = temp;
     errcount += run_test_case( CV_StsAssert, "Invalid distortion coefficients data matrix size" );
     _distortion_coeffs = &_distortion_coeffs_orig;
@@ -218,13 +218,13 @@ void CV_UndistortPointsBadArgTest::run(int)
     errcount += run_test_case( CV_StsAssert, "R data is not CvMat*" );
     matR = &_R_orig;
 
-    temp = cvCreateMat(4,3,CV_64F);
+    temp = cvCreateMat(4,3,CV_64FC1);
     matR = temp;
     errcount += run_test_case( CV_StsAssert, "Invalid R data matrix size" );
     matR = &_R_orig;
     cvReleaseMat(&temp);
 
-    temp = cvCreateMat(3,2,CV_64F);
+    temp = cvCreateMat(3,2,CV_64FC1);
     matR = temp;
     errcount += run_test_case( CV_StsAssert, "Invalid R data matrix size" );
     matR = &_R_orig;
@@ -236,13 +236,13 @@ void CV_UndistortPointsBadArgTest::run(int)
     errcount += run_test_case( CV_StsAssert, "P data is not CvMat*" );
     matP = &_P_orig;
 
-    temp = cvCreateMat(4,3,CV_64F);
+    temp = cvCreateMat(4,3,CV_64FC1);
     matP = temp;
     errcount += run_test_case( CV_StsAssert, "Invalid P data matrix size" );
     matP = &_P_orig;
     cvReleaseMat(&temp);
 
-    temp = cvCreateMat(3,2,CV_64F);
+    temp = cvCreateMat(3,2,CV_64FC1);
     matP = temp;
     errcount += run_test_case( CV_StsAssert, "Invalid P data matrix size" );
     matP = &_P_orig;
@@ -312,7 +312,7 @@ private:
     cv::Mat distortion_coeffs;
     cv::Mat mapx;
     cv::Mat mapy;
-    int mat_type;
+    ElemType mat_type;
 
 };
 
@@ -347,13 +347,13 @@ void CV_InitUndistortRectifyMapBadArgTest::run(int)
     double arr_new_camera_mat[9] = {155.f, 0.f, img_size.width/2.f+img_size.width/50.f, 0, 310.f, img_size.height/2.f+img_size.height/50.f, 0.f, 0.f, 1.f};
     double r[9] = {1,0,0,0,1,0,0,0,1};
 
-    CvMat _camera_mat_orig = cvMat(3,3,CV_64F,cam);
-    CvMat _distortion_coeffs_orig = cvMat(1,4,CV_64F,dist);
-    CvMat _new_camera_mat_orig = cvMat(3,3,CV_64F,arr_new_camera_mat);
-    CvMat _R_orig = cvMat(3,3,CV_64F,r);
+    CvMat _camera_mat_orig = cvMat(3,3,CV_64FC1,cam);
+    CvMat _distortion_coeffs_orig = cvMat(1,4,CV_64FC1,dist);
+    CvMat _new_camera_mat_orig = cvMat(3,3,CV_64FC1,arr_new_camera_mat);
+    CvMat _R_orig = cvMat(3,3,CV_64FC1,r);
     CvMat _mapx_orig = cvMat(img_size.height,img_size.width,CV_32FC1,arr_mapx);
     CvMat _mapy_orig = cvMat(img_size.height,img_size.width,CV_32FC1,arr_mapy);
-    int mat_type_orig = CV_32FC1;
+    ElemType mat_type_orig = CV_32FC1;
 
     _camera_mat = &_camera_mat_orig;
     _distortion_coeffs = &_distortion_coeffs_orig;
@@ -378,7 +378,7 @@ void CV_InitUndistortRectifyMapBadArgTest::run(int)
     mapy = cv::cvarrToMat(&_mapy_orig);
 
 
-    mat_type = CV_64F;
+    mat_type = CV_64FC1;
     errcount += run_test_case( CV_StsAssert, "Invalid map matrix type" );
     mat_type = mat_type_orig;
 
@@ -468,9 +468,9 @@ void CV_UndistortBadArgTest::run(int)
     float* arr_dst = new float[img_size.width*img_size.height];
     double arr_new_camera_mat[9] = {155.f, 0.f, img_size.width/2.f+img_size.width/50.f, 0, 310.f, img_size.height/2.f+img_size.height/50.f, 0.f, 0.f, 1.f};
 
-    CvMat _camera_mat_orig = cvMat(3,3,CV_64F,cam);
-    CvMat _distortion_coeffs_orig = cvMat(1,4,CV_64F,dist);
-    CvMat _new_camera_mat_orig = cvMat(3,3,CV_64F,arr_new_camera_mat);
+    CvMat _camera_mat_orig = cvMat(3,3,CV_64FC1,cam);
+    CvMat _distortion_coeffs_orig = cvMat(1,4,CV_64FC1,dist);
+    CvMat _new_camera_mat_orig = cvMat(3,3,CV_64FC1,arr_new_camera_mat);
     CvMat _src_orig = cvMat(img_size.height,img_size.width,CV_32FC1,arr_src);
     CvMat _dst_orig = cvMat(img_size.height,img_size.width,CV_32FC1,arr_dst);
 
@@ -488,8 +488,8 @@ void CV_UndistortBadArgTest::run(int)
 //C tests
     useCPlus = false;
 
-    temp = cvCreateMat(800,600,CV_32F);
-    temp1 = cvCreateMat(800,601,CV_32F);
+    temp = cvCreateMat(800,600,CV_32FC1);
+    temp1 = cvCreateMat(800,601,CV_32FC1);
     _src = temp;
     _dst = temp1;
     errcount += run_test_case( CV_StsAssert, "Input and output data matrix sizes mismatch" );
@@ -498,8 +498,8 @@ void CV_UndistortBadArgTest::run(int)
     cvReleaseMat(&temp);
     cvReleaseMat(&temp1);
 
-    temp = cvCreateMat(800,600,CV_32F);
-    temp1 = cvCreateMat(800,600,CV_64F);
+    temp = cvCreateMat(800,600,CV_32FC1);
+    temp1 = cvCreateMat(800,600,CV_64FC1);
     _src = temp;
     _dst = temp1;
     errcount += run_test_case( CV_StsAssert, "Input and output data matrix types mismatch" );

--- a/modules/calib3d/test/test_undistort_points.cpp
+++ b/modules/calib3d/test/test_undistort_points.cpp
@@ -113,7 +113,7 @@ TEST(Calib3d_Undistort, stop_criteria)
     std::vector<Point2d> pt_redistorted_vec;
     std::vector<Point3d> pt_undist_vec_homogeneous;
     pt_undist_vec_homogeneous.push_back( Point3d(pt_undist_vec[0].x, pt_undist_vec[0].y, 1.0) );
-    projectPoints(pt_undist_vec_homogeneous, Mat::zeros(3,1,CV_64F), Mat::zeros(3,1,CV_64F), cameraMatrix, distCoeffs, pt_redistorted_vec);
+    projectPoints(pt_undist_vec_homogeneous, Mat::zeros(3, 1, CV_64FC1), Mat::zeros(3, 1, CV_64FC1), cameraMatrix, distCoeffs, pt_redistorted_vec);
     const double obtainedError = sqrt( pow(pt_distorted.x - pt_redistorted_vec[0].x, 2) + pow(pt_distorted.y - pt_redistorted_vec[0].y, 2) );
 
     ASSERT_LE(obtainedError, maxError);

--- a/modules/core/include/opencv2/core/base.hpp
+++ b/modules/core/include/opencv2/core/base.hpp
@@ -450,7 +450,7 @@ configurations while CV_DbgAssert is only retained in the Debug configuration.
 #define CV_Assert_9( expr1, expr2, expr3, expr4, expr5, expr6, expr7, expr8, expr9 ) CV_Assert_8(expr1, expr2, expr3, expr4, expr5, expr6, expr7, expr8 ); CV_Assert_1(expr9)
 #define CV_Assert_10( expr1, expr2, expr3, expr4, expr5, expr6, expr7, expr8, expr9, expr10 ) CV_Assert_9(expr1, expr2, expr3, expr4, expr5, expr6, expr7, expr8, expr9 ); CV_Assert_1(expr10)
 
-#define CV_Assert_N(...) do { __CV_CAT(CV_Assert_, __CV_VA_NUM_ARGS(__VA_ARGS__)) (__VA_ARGS__); } while(0)
+#define CV_Assert_N(...) do { __CV_EXPAND(__CV_CAT(CV_Assert_, __CV_VA_NUM_ARGS(__VA_ARGS__)) (__VA_ARGS__)); } while(0)
 
 //! @endcond
 

--- a/modules/core/include/opencv2/core/cvdef.h
+++ b/modules/core/include/opencv2/core/cvdef.h
@@ -80,7 +80,7 @@ namespace cv { namespace debug_build_guard { } using namespace debug_build_guard
 #endif
 
 #define __CV_VA_NUM_ARGS_HELPER(_1, _2, _3, _4, _5, _6, _7, _8, _9, _10, N, ...) N
-#define __CV_VA_NUM_ARGS(...) __CV_VA_NUM_ARGS_HELPER(__VA_ARGS__, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0)
+#define __CV_VA_NUM_ARGS(...) __CV_EXPAND(__CV_VA_NUM_ARGS_HELPER(__VA_ARGS__, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0))
 
 // undef problematic defines sometimes defined by system headers (windows.h in particular)
 #undef small

--- a/modules/core/include/opencv2/core/hal/interface.h
+++ b/modules/core/include/opencv2/core/hal/interface.h
@@ -66,6 +66,28 @@ typedef signed char schar;
 
 #define CV_USRTYPE1 (void)"CV_USRTYPE1 support has been dropped in OpenCV 4.0"
 
+//! test: Simplify the reviewer life
+//Reduced version of PR #12487
+//TODO: Remove these before merege
+#define ElemType                  int
+#define ElemDepth                 int
+#define MagicFlag                 int
+#define CV_DEPTH_AUTO             -1
+#define CV_TYPE_AUTO              -1
+#define __CV_MAX_DEPTH_0(m, n)    (m != 7 || n <= 3 ? m : n) /* CV_16F workaround */
+#define __CV_MAX_DEPTH_1(d1, d2)  __CV_MAX_DEPTH_0(std::max(d1, d2), std::min(d1, d2))
+#define __CV_MAX_DEPTH_2(d1, d2)  __CV_MAX_DEPTH_1(static_cast<int>(d1), static_cast<int>(d2))
+#define __CV_MAX_DEPTH_3(d, ...)  __CV_EXPAND(__CV_MAX_DEPTH_2(d, __CV_MAX_DEPTH_2(__VA_ARGS__)))
+#define __CV_MAX_DEPTH_4(d, ...)  __CV_EXPAND(__CV_MAX_DEPTH_2(d, __CV_MAX_DEPTH_3(__VA_ARGS__)))
+#define CV_MAX_DEPTH(...)         __CV_EXPAND(static_cast<ElemDepth>(__CV_CAT(__CV_MAX_DEPTH_, __CV_VA_NUM_ARGS(__VA_ARGS__)) (__VA_ARGS__)))
+#define __CV_MIN_DEPTH_0(m, n)    (m == 7 && n >= 4 ? m : n) /* CV_16F workaround */
+#define __CV_MIN_DEPTH_1(d1, d2)  __CV_MIN_DEPTH_0(std::max(d1, d2), std::min(d1, d2))
+#define __CV_MIN_DEPTH_2(d1, d2)  __CV_MIN_DEPTH_1(static_cast<int>(d1), static_cast<int>(d2))
+#define __CV_MIN_DEPTH_3(d, ...)  __CV_EXPAND(__CV_MIN_DEPTH_2(d, __CV_MIN_DEPTH_2(__VA_ARGS__)))
+#define __CV_MIN_DEPTH_4(d, ...)  __CV_EXPAND(__CV_MIN_DEPTH_2(d, __CV_MIN_DEPTH_3(__VA_ARGS__)))
+#define CV_MIN_DEPTH(...)         __CV_EXPAND(static_cast<ElemDepth>(__CV_CAT(__CV_MIN_DEPTH_, __CV_VA_NUM_ARGS(__VA_ARGS__)) (__VA_ARGS__)))
+//end of ! test
+
 #define CV_CN_MAX     512
 #define CV_CN_SHIFT   3
 #define CV_DEPTH_MAX  (1 << CV_CN_SHIFT)

--- a/modules/core/include/opencv2/core/mat.hpp
+++ b/modules/core/include/opencv2/core/mat.hpp
@@ -287,6 +287,7 @@ generators:
 class CV_EXPORTS _OutputArray : public _InputArray
 {
 public:
+    typedef int DepthMask; //TODO: Remove me
     enum
     {
         DEPTH_MASK_8U = 1 << CV_8U,

--- a/modules/core/perf/cuda/perf_gpumat.cpp
+++ b/modules/core/perf/cuda/perf_gpumat.cpp
@@ -60,10 +60,10 @@ PERF_TEST_P(Sz_Depth_Cn, CUDA_GpuMat_SetTo,
                     CUDA_CHANNELS_1_3_4))
 {
     const cv::Size size = GET_PARAM(0);
-    const int depth = GET_PARAM(1);
+    const ElemDepth depth = GET_PARAM(1);
     const int channels = GET_PARAM(2);
 
-    const int type = CV_MAKE_TYPE(depth, channels);
+    const ElemType type = CV_MAKE_TYPE(depth, channels);
 
     const cv::Scalar val(1, 2, 3, 4);
 
@@ -92,10 +92,10 @@ PERF_TEST_P(Sz_Depth_Cn, CUDA_GpuMat_SetToMasked,
                     CUDA_CHANNELS_1_3_4))
 {
     const cv::Size size = GET_PARAM(0);
-    const int depth = GET_PARAM(1);
+    const ElemDepth depth = GET_PARAM(1);
     const int channels = GET_PARAM(2);
 
-    const int type = CV_MAKE_TYPE(depth, channels);
+    const ElemType type = CV_MAKE_TYPE(depth, channels);
 
     cv::Mat src(size, type);
     cv::Mat mask(size, CV_8UC1);
@@ -129,10 +129,10 @@ PERF_TEST_P(Sz_Depth_Cn, CUDA_GpuMat_CopyToMasked,
                     CUDA_CHANNELS_1_3_4))
 {
     const cv::Size size = GET_PARAM(0);
-    const int depth = GET_PARAM(1);
+    const ElemDepth depth = GET_PARAM(1);
     const int channels = GET_PARAM(2);
 
-    const int type = CV_MAKE_TYPE(depth, channels);
+    const ElemType type = CV_MAKE_TYPE(depth, channels);
 
     cv::Mat src(size, type);
     cv::Mat mask(size, CV_8UC1);
@@ -167,10 +167,10 @@ PERF_TEST_P(Sz_2Depth, CUDA_GpuMat_ConvertTo,
                     Values(CV_8U, CV_16U, CV_32F, CV_64F)))
 {
     const cv::Size size = GET_PARAM(0);
-    const int depth1 = GET_PARAM(1);
-    const int depth2 = GET_PARAM(2);
+    const ElemDepth depth1 = GET_PARAM(1);
+    const ElemDepth depth2 = GET_PARAM(2);
 
-    cv::Mat src(size, depth1);
+    cv::Mat src(size, CV_MAKETYPE(depth1, 1));
     declare.in(src, WARMUP_RNG);
 
     const double a = 0.5;

--- a/modules/core/perf/opencl/perf_arithm.cpp
+++ b/modules/core/perf/opencl/perf_arithm.cpp
@@ -57,12 +57,13 @@ OCL_PERF_TEST_P(LUTFixture, LUT,
 {
     const Size_MatType_t params = GetParam();
     const Size srcSize = get<0>(params);
-    const int type = get<1>(params), cn = CV_MAT_CN(type);
+    const ElemType type = get<1>(params);
+    const int cn = CV_MAT_CN(type);
 
     checkDeviceMaxMemoryAllocSize(srcSize, type);
 
     UMat src(srcSize, CV_8UC(cn)), lut(1, 256, type);
-    int dstType = CV_MAKETYPE(lut.depth(), src.channels());
+    ElemType dstType = CV_MAKETYPE(lut.depth(), src.channels());
     UMat dst(srcSize, dstType);
 
     declare.in(src, lut, WARMUP_RNG).out(dst);
@@ -81,7 +82,7 @@ OCL_PERF_TEST_P(ExpFixture, Exp, ::testing::Combine(
 {
     const Size_MatType_t params = GetParam();
     const Size srcSize = get<0>(params);
-    const int type = get<1>(params);
+    const ElemType type = get<1>(params);
 
     checkDeviceMaxMemoryAllocSize(srcSize, type);
 
@@ -106,7 +107,7 @@ OCL_PERF_TEST_P(LogFixture, Log, ::testing::Combine(
 {
     const Size_MatType_t params = GetParam();
     const Size srcSize = get<0>(params);
-    const int type = get<1>(params);
+    const ElemType type = get<1>(params);
 
     checkDeviceMaxMemoryAllocSize(srcSize, type);
 
@@ -130,7 +131,7 @@ OCL_PERF_TEST_P(AddFixture, Add,
                 ::testing::Combine(OCL_TEST_SIZES, OCL_TEST_TYPES_134))
 {
     const Size srcSize = GET_PARAM(0);
-    const int type = GET_PARAM(1);
+    const ElemType type = GET_PARAM(1);
 
     checkDeviceMaxMemoryAllocSize(srcSize, type);
 
@@ -151,7 +152,7 @@ OCL_PERF_TEST_P(SubtractFixture, Subtract,
 {
     const Size_MatType_t params = GetParam();
     const Size srcSize = get<0>(params);
-    const int type = get<1>(params);
+    const ElemType type = get<1>(params);
 
     checkDeviceMaxMemoryAllocSize(srcSize, type);
 
@@ -171,7 +172,7 @@ OCL_PERF_TEST_P(MulFixture, Multiply, ::testing::Combine(OCL_TEST_SIZES, OCL_TES
 {
     const Size_MatType_t params = GetParam();
     const Size srcSize = get<0>(params);
-    const int type = get<1>(params);
+    const ElemType type = get<1>(params);
 
     checkDeviceMaxMemoryAllocSize(srcSize, type);
 
@@ -192,7 +193,7 @@ OCL_PERF_TEST_P(DivFixture, Divide,
 {
     const Size_MatType_t params = GetParam();
     const Size srcSize = get<0>(params);
-    const int type = get<1>(params);
+    const ElemType type = get<1>(params);
 
     checkDeviceMaxMemoryAllocSize(srcSize, type);
 
@@ -204,7 +205,7 @@ OCL_PERF_TEST_P(DivFixture, Divide,
         Mat m2 = src2.getMat(ACCESS_RW);
         Mat zero_mask = m2 == 0;
         Mat fix;
-        zero_mask.convertTo(fix, type); // 0 or 255
+        zero_mask.convertTo(fix, CV_MAT_DEPTH(type)); // 0 or 255
         cv::add(m2, fix, m2);
     }
 
@@ -225,7 +226,7 @@ OCL_PERF_TEST_P(AbsDiffFixture, Absdiff,
 {
     const Size_MatType_t params = GetParam();
     const Size srcSize = get<0>(params);
-    const int type = get<1>(params);
+    const ElemType type = get<1>(params);
 
     checkDeviceMaxMemoryAllocSize(srcSize, type);
 
@@ -246,7 +247,7 @@ OCL_PERF_TEST_P(CartToPolarFixture, CartToPolar, ::testing::Combine(
 {
     const Size_MatType_t params = GetParam();
     const Size srcSize = get<0>(params);
-    const int type = get<1>(params);
+    const ElemType type = get<1>(params);
 
     checkDeviceMaxMemoryAllocSize(srcSize, type);
 
@@ -269,7 +270,7 @@ OCL_PERF_TEST_P(PolarToCartFixture, PolarToCart, ::testing::Combine(
 {
     const Size_MatType_t params = GetParam();
     const Size srcSize = get<0>(params);
-    const int type = get<1>(params);
+    const ElemType type = get<1>(params);
 
     checkDeviceMaxMemoryAllocSize(srcSize, type);
 
@@ -292,7 +293,7 @@ OCL_PERF_TEST_P(MagnitudeFixture, Magnitude, ::testing::Combine(
 {
     const Size_MatType_t params = GetParam();
     const Size srcSize = get<0>(params);
-    const int type = get<1>(params);
+    const ElemType type = get<1>(params);
 
     checkDeviceMaxMemoryAllocSize(srcSize, type);
 
@@ -314,7 +315,7 @@ OCL_PERF_TEST_P(TransposeFixture, Transpose, ::testing::Combine(
 {
     const Size_MatType_t params = GetParam();
     const Size srcSize = get<0>(params);
-    const int type = get<1>(params);
+    const ElemType type = get<1>(params);
 
     checkDeviceMaxMemoryAllocSize(srcSize, type);
 
@@ -331,7 +332,7 @@ OCL_PERF_TEST_P(TransposeFixture, TransposeInplace, ::testing::Combine(
 {
     const Size_MatType_t params = GetParam();
     const Size srcSize = get<0>(params);
-    const int type = get<1>(params);
+    const ElemType type = get<1>(params);
 
     checkDeviceMaxMemoryAllocSize(srcSize, type);
 
@@ -361,7 +362,7 @@ OCL_PERF_TEST_P(FlipFixture, Flip,
 {
     const FlipParams params = GetParam();
     const Size srcSize = get<0>(params);
-    const int type = get<1>(params);
+    const ElemType type = get<1>(params);
     const int flipType = get<2>(params);
 
     checkDeviceMaxMemoryAllocSize(srcSize, type);
@@ -383,7 +384,7 @@ OCL_PERF_TEST_P(MinMaxLocFixture, MinMaxLoc,
 {
     const Size_MatType_t params = GetParam();
     const Size srcSize = get<0>(params);
-    const int type = get<1>(params);
+    const ElemType type = get<1>(params);
     bool onecn = CV_MAT_CN(type) == 1;
 
     checkDeviceMaxMemoryAllocSize(srcSize, type);
@@ -419,7 +420,8 @@ OCL_PERF_TEST_P(SumFixture, Sum,
 {
     const Size_MatType_t params = GetParam();
     const Size srcSize = get<0>(params);
-    const int type = get<1>(params), depth = CV_MAT_DEPTH(type);
+    const ElemType type = get<1>(params);
+    const ElemDepth depth = CV_MAT_DEPTH(type);
 
     checkDeviceMaxMemoryAllocSize(srcSize, type);
 
@@ -446,7 +448,7 @@ OCL_PERF_TEST_P(CountNonZeroFixture, CountNonZero,
 {
     const Size_MatType_t params = GetParam();
     const Size srcSize = get<0>(params);
-    const int type = get<1>(params);
+    const ElemType type = get<1>(params);
 
     checkDeviceMaxMemoryAllocSize(srcSize, type);
 
@@ -469,7 +471,7 @@ OCL_PERF_TEST_P(PhaseFixture, Phase, ::testing::Combine(
 {
     const Size_MatType_t params = GetParam();
     const Size srcSize = get<0>(params);
-    const int type = get<1>(params);
+    const ElemType type = get<1>(params);
 
     checkDeviceMaxMemoryAllocSize(srcSize, type);
 
@@ -491,7 +493,7 @@ OCL_PERF_TEST_P(BitwiseAndFixture, Bitwise_and,
 {
     const Size_MatType_t params = GetParam();
     const Size srcSize = get<0>(params);
-    const int type = get<1>(params);
+    const ElemType type = get<1>(params);
 
     checkDeviceMaxMemoryAllocSize(srcSize, type);
 
@@ -512,7 +514,7 @@ OCL_PERF_TEST_P(BitwiseXorFixture, Bitwise_xor,
 {
     const Size_MatType_t params = GetParam();
     const Size srcSize = get<0>(params);
-    const int type = get<1>(params);
+    const ElemType type = get<1>(params);
 
     checkDeviceMaxMemoryAllocSize(srcSize, type);
 
@@ -533,7 +535,7 @@ OCL_PERF_TEST_P(BitwiseOrFixture, Bitwise_or,
 {
     const Size_MatType_t params = GetParam();
     const Size srcSize = get<0>(params);
-    const int type = get<1>(params);
+    const ElemType type = get<1>(params);
 
     checkDeviceMaxMemoryAllocSize(srcSize, type);
 
@@ -554,7 +556,7 @@ OCL_PERF_TEST_P(BitwiseNotFixture, Bitwise_not,
 {
     const Size_MatType_t params = GetParam();
     const Size srcSize = get<0>(params);
-    const int type = get<1>(params);
+    const ElemType type = get<1>(params);
 
     checkDeviceMaxMemoryAllocSize(srcSize, type);
 
@@ -579,7 +581,7 @@ OCL_PERF_TEST_P(CompareFixture, Compare,
 {
     const CompareParams params = GetParam();
     const Size srcSize = get<0>(params);
-    const int type = get<1>(params);
+    const ElemType type = get<1>(params);
     const int cmpCode = get<2>(params);
 
     checkDeviceMaxMemoryAllocSize(srcSize, type);
@@ -594,12 +596,12 @@ OCL_PERF_TEST_P(CompareFixture, Compare,
 
 OCL_PERF_TEST_P(CompareFixture, CompareScalar,
             ::testing::Combine(OCL_TEST_SIZES,
-                               OCL_PERF_ENUM((MatType)CV_32FC1), // TODO: OCL_TEST_TYPES_134
+                               OCL_PERF_ENUM(CV_32FC1), // TODO: OCL_TEST_TYPES_134
                                CmpCode::all()))
 {
     const CompareParams params = GetParam();
     const Size srcSize = get<0>(params);
-    const int type = get<1>(params);
+    const ElemType type = get<1>(params);
     const int cmpCode = get<2>(params);
 
     checkDeviceMaxMemoryAllocSize(srcSize, type);
@@ -621,7 +623,7 @@ OCL_PERF_TEST_P(PowFixture, Pow, ::testing::Combine(
 {
     const Size_MatType_t params = GetParam();
     const Size srcSize = get<0>(params);
-    const int type = get<1>(params);
+    const ElemType type = get<1>(params);
 
     checkDeviceMaxMemoryAllocSize(srcSize, type);
 
@@ -643,7 +645,8 @@ OCL_PERF_TEST_P(AddWeightedFixture, AddWeighted,
 {
     const Size_MatType_t params = GetParam();
     const Size srcSize = get<0>(params);
-    const int type = get<1>(params), depth = CV_MAT_DEPTH(type);
+    const ElemType type = get<1>(params);
+    const ElemDepth depth = CV_MAT_DEPTH(type);
 
     checkDeviceMaxMemoryAllocSize(srcSize, type);
 
@@ -668,7 +671,7 @@ OCL_PERF_TEST_P(SqrtFixture, Sqrt, ::testing::Combine(
 {
     const Size_MatType_t params = GetParam();
     const Size srcSize = get<0>(params);
-    const int type = get<1>(params);
+    const ElemType type = get<1>(params);
 
     checkDeviceMaxMemoryAllocSize(srcSize, type);
 
@@ -693,7 +696,7 @@ OCL_PERF_TEST_P(SetIdentityFixture, SetIdentity,
 {
     const Size_MatType_t params = GetParam();
     const Size srcSize = get<0>(params);
-    const int type = get<1>(params);
+    const ElemType type = get<1>(params);
 
     checkDeviceMaxMemoryAllocSize(srcSize, type);
 
@@ -715,7 +718,7 @@ OCL_PERF_TEST_P(MeanStdDevFixture, MeanStdDev,
 {
     const Size_MatType_t params = GetParam();
     const Size srcSize = get<0>(params);
-    const int type = get<1>(params);
+    const ElemType type = get<1>(params);
     const double eps = 2e-5;
 
     checkDeviceMaxMemoryAllocSize(srcSize, type);
@@ -745,7 +748,7 @@ OCL_PERF_TEST_P(MeanStdDevFixture, MeanStdDevWithMask,
 {
     const Size_MatType_t params = GetParam();
     const Size srcSize = get<0>(params);
-    const int type = get<1>(params);
+    const ElemType type = get<1>(params);
     const double eps = 2e-5;
 
     checkDeviceMaxMemoryAllocSize(srcSize, type);
@@ -782,7 +785,7 @@ OCL_PERF_TEST_P(NormFixture, Norm1Arg,
 {
     const NormParams params = GetParam();
     const Size srcSize = get<0>(params);
-    const int type = get<1>(params);
+    const ElemType type = get<1>(params);
     const int normType = get<2>(params);
 
     checkDeviceMaxMemoryAllocSize(srcSize, type);
@@ -802,7 +805,7 @@ OCL_PERF_TEST_P(NormFixture, Norm,
 {
     const NormParams params = GetParam();
     const Size srcSize = get<0>(params);
-    const int type = get<1>(params);
+    const ElemType type = get<1>(params);
     const int normType = get<2>(params);
 
     checkDeviceMaxMemoryAllocSize(srcSize, type);
@@ -822,7 +825,7 @@ OCL_PERF_TEST_P(NormFixture, NormRel,
 {
     const NormParams params = GetParam();
     const Size srcSize = get<0>(params);
-    const int type = get<1>(params);
+    const ElemType type = get<1>(params);
     const int normType = get<2>(params);
 
     checkDeviceMaxMemoryAllocSize(srcSize, type);
@@ -846,7 +849,7 @@ OCL_PERF_TEST_P(UMatDotFixture, UMatDot,
 {
     const Size_MatType_t params = GetParam();
     const Size srcSize = get<0>(params);
-    const int type = get<1>(params);
+    const ElemType type = get<1>(params);
     double r = 0.0;
 
     checkDeviceMaxMemoryAllocSize(srcSize, type);
@@ -868,7 +871,8 @@ OCL_PERF_TEST_P(RepeatFixture, Repeat,
 {
     const Size_MatType_t params = GetParam();
     const Size srcSize = get<0>(params);
-    const int type = get<1>(params), nx = 2, ny = 2;
+    const ElemType type = get<1>(params);
+    const int nx = 2, ny = 2;
 
     checkDeviceMaxMemoryAllocSize(srcSize, type);
 
@@ -889,7 +893,7 @@ OCL_PERF_TEST_P(MinFixture, Min,
 {
     const Size_MatType_t params = GetParam();
     const Size srcSize = get<0>(params);
-    const int type = get<1>(params);
+    const ElemType type = get<1>(params);
 
     checkDeviceMaxMemoryAllocSize(srcSize, type);
 
@@ -910,7 +914,7 @@ OCL_PERF_TEST_P(MaxFixture, Max,
 {
     const Size_MatType_t params = GetParam();
     const Size srcSize = get<0>(params);
-    const int type = get<1>(params);
+    const ElemType type = get<1>(params);
 
     checkDeviceMaxMemoryAllocSize(srcSize, type);
 
@@ -931,7 +935,7 @@ OCL_PERF_TEST_P(InRangeFixture, InRange,
 {
     const Size_MatType_t params = GetParam();
     const Size srcSize = get<0>(params);
-    const int type = get<1>(params);
+    const ElemType type = get<1>(params);
 
     checkDeviceMaxMemoryAllocSize(srcSize, type);
 
@@ -956,7 +960,8 @@ OCL_PERF_TEST_P(NormalizeFixture, Normalize,
 {
     const NormalizeParams params = GetParam();
     const Size srcSize = get<0>(params);
-    const int type = get<1>(params), mode = get<2>(params);
+    const ElemType type = get<1>(params);
+    const int mode = get<2>(params);
 
     checkDeviceMaxMemoryAllocSize(srcSize, type);
 
@@ -974,14 +979,15 @@ OCL_PERF_TEST_P(NormalizeFixture, NormalizeWithMask,
 {
     const NormalizeParams params = GetParam();
     const Size srcSize = get<0>(params);
-    const int type = get<1>(params), mode = get<2>(params);
+    const ElemType type = get<1>(params);
+    const int mode = get<2>(params);
 
     checkDeviceMaxMemoryAllocSize(srcSize, type);
 
     UMat src(srcSize, type), mask(srcSize, CV_8UC1), dst(srcSize, type);
     declare.in(src, mask, WARMUP_RNG).out(dst);
 
-    OCL_TEST_CYCLE() cv::normalize(src, dst, 10, 110, mode, -1, mask);
+    OCL_TEST_CYCLE() cv::normalize(src, dst, 10, 110, mode, CV_DEPTH_AUTO, mask);
 
     SANITY_CHECK(dst, 5e-2);
 }
@@ -995,7 +1001,8 @@ OCL_PERF_TEST_P(ConvertScaleAbsFixture, ConvertScaleAbs,
 {
     const Size_MatType_t params = GetParam();
     const Size srcSize = get<0>(params);
-    const int type = get<1>(params), cn = CV_MAT_CN(type);
+    const ElemType type = get<1>(params);
+    const int cn = CV_MAT_CN(type);
 
     checkDeviceMaxMemoryAllocSize(srcSize, type);
 
@@ -1016,7 +1023,8 @@ OCL_PERF_TEST_P(PatchNaNsFixture, PatchNaNs,
 {
     const Size_MatType_t params = GetParam();
     Size srcSize = get<0>(params);
-    const int type = get<1>(params), cn = CV_MAT_CN(type);
+    const ElemType type = get<1>(params);
+    const int cn = CV_MAT_CN(type);
 
     checkDeviceMaxMemoryAllocSize(srcSize, type);
 
@@ -1050,7 +1058,7 @@ OCL_PERF_TEST_P(ScaleAddFixture, ScaleAdd,
 {
     const Size_MatType_t params = GetParam();
     const Size srcSize = get<0>(params);
-    const int type = get<1>(params);
+    const ElemType type = get<1>(params);
 
     checkDeviceMaxMemoryAllocSize(srcSize, type);
 
@@ -1072,7 +1080,7 @@ OCL_PERF_TEST_P(TransformFixture, Transform,
 {
     const Size_MatType_t params = GetParam();
     const Size srcSize = get<0>(params);
-    const int type = get<1>(params);
+    const ElemType type = get<1>(params);
 
     checkDeviceMaxMemoryAllocSize(srcSize, type);
 
@@ -1099,7 +1107,7 @@ OCL_PERF_TEST_P(PSNRFixture, PSNR,
 {
     const Size_MatType_t params = GetParam();
     const Size srcSize = get<0>(params);
-    const int type = get<1>(params);
+    const ElemType type = get<1>(params);
 
     checkDeviceMaxMemoryAllocSize(srcSize, type);
 
@@ -1128,8 +1136,8 @@ OCL_PERF_TEST_P(ReduceMinMaxFixture, Reduce,
 {
     const ReduceMinMaxParams params = GetParam();
     const std::pair<MatType, MatType> types = get<1>(params);
-    const int stype = types.first, dtype = types.second,
-            dim = get<2>(params), op = get<3>(params);
+    const ElemType stype = types.first, dtype = types.second;
+    const int dim = get<2>(params), op = get<3>(params);
     const Size srcSize = get<0>(params),
             dstSize(dim == 0 ? srcSize.width : 1, dim == 0 ? 1 : srcSize.height);
     const double eps = CV_MAT_DEPTH(dtype) <= CV_32S ? 1 : 1e-5;
@@ -1140,7 +1148,7 @@ OCL_PERF_TEST_P(ReduceMinMaxFixture, Reduce,
     UMat src(srcSize, stype), dst(dstSize, dtype);
     declare.in(src, WARMUP_RNG).out(dst);
 
-    OCL_TEST_CYCLE() cv::reduce(src, dst, dim, op, dtype);
+    OCL_TEST_CYCLE() cv::reduce(src, dst, dim, op, CV_MAT_DEPTH(dtype));
 
     SANITY_CHECK(dst, eps);
 }
@@ -1159,8 +1167,8 @@ OCL_PERF_TEST_P(ReduceAccFixture, Reduce,
 {
     const ReduceAccParams params = GetParam();
     const std::pair<MatType, MatType> types = get<1>(params);
-    const int stype = types.first, dtype = types.second,
-            dim = get<2>(params), op = get<3>(params);
+    const ElemType stype = types.first, dtype = types.second;
+    const int dim = get<2>(params), op = get<3>(params);
     const Size srcSize = get<0>(params),
             dstSize(dim == 0 ? srcSize.width : 1, dim == 0 ? 1 : srcSize.height);
     const double eps = CV_MAT_DEPTH(dtype) <= CV_32S ? 1 : 3e-4;
@@ -1171,7 +1179,7 @@ OCL_PERF_TEST_P(ReduceAccFixture, Reduce,
     UMat src(srcSize, stype), dst(dstSize, dtype);
     declare.in(src, WARMUP_RNG).out(dst);
 
-    OCL_TEST_CYCLE() cv::reduce(src, dst, dim, op, dtype);
+    OCL_TEST_CYCLE() cv::reduce(src, dst, dim, op, CV_MAT_DEPTH(dtype));
 
     SANITY_CHECK(dst, eps);
 }

--- a/modules/core/perf/opencl/perf_channels.cpp
+++ b/modules/core/perf/opencl/perf_channels.cpp
@@ -62,7 +62,9 @@ OCL_PERF_TEST_P(MergeFixture, Merge,
 {
     const MergeParams params = GetParam();
     const Size srcSize = get<0>(params);
-    const int depth = get<1>(params), cn = get<2>(params), dtype = CV_MAKE_TYPE(depth, cn);
+    const ElemDepth depth = get<1>(params);
+    const int cn = get<2>(params);
+    const ElemType dtype = CV_MAKE_TYPE(depth, cn);
 
     checkDeviceMaxMemoryAllocSize(srcSize, dtype);
 
@@ -90,7 +92,9 @@ OCL_PERF_TEST_P(SplitFixture, Split,
 {
     const SplitParams params = GetParam();
     const Size srcSize = get<0>(params);
-    const int depth = get<1>(params), cn = get<2>(params), type = CV_MAKE_TYPE(depth, cn);
+    const ElemDepth depth = get<1>(params);
+    const int cn = get<2>(params);
+    const ElemType type = CV_MAKE_TYPE(depth, cn);
 
     ASSERT_TRUE(cn == 3 || cn == 2);
 
@@ -133,7 +137,9 @@ OCL_PERF_TEST_P(MixChannelsFixture, MixChannels,
 {
     const MixChannelsParams params = GetParam();
     const Size srcSize = get<0>(params);
-    const int depth = get<1>(params), type = CV_MAKE_TYPE(depth, 2), n = 2;
+    const ElemDepth depth = get<1>(params);
+    const ElemType type = CV_MAKE_TYPE(depth, 2);
+    int n = 2;
 
     checkDeviceMaxMemoryAllocSize(srcSize, type);
 
@@ -167,11 +173,12 @@ OCL_PERF_TEST_P(InsertChannelFixture, InsertChannel,
 {
     const Size_MatDepth_t params = GetParam();
     const Size srcSize = get<0>(params);
-    const int depth = get<1>(params), type = CV_MAKE_TYPE(depth, 3);
+    const ElemDepth depth = get<1>(params);
+    const ElemType type = CV_MAKE_TYPE(depth, 3);
 
     checkDeviceMaxMemoryAllocSize(srcSize, type);
 
-    UMat src(srcSize, depth), dst(srcSize, type, Scalar::all(17));
+    UMat src(srcSize, CV_MAKETYPE(depth, 1)), dst(srcSize, type, Scalar::all(17));
     declare.in(src, WARMUP_RNG).out(dst);
 
     OCL_TEST_CYCLE() cv::insertChannel(src, dst, 1);
@@ -189,11 +196,12 @@ OCL_PERF_TEST_P(ExtractChannelFixture, ExtractChannel,
 {
     const Size_MatDepth_t params = GetParam();
     const Size srcSize = get<0>(params);
-    const int depth = get<1>(params), type = CV_MAKE_TYPE(depth, 3);
+    const ElemDepth depth = get<1>(params);
+    const ElemType type = CV_MAKE_TYPE(depth, 3);
 
     checkDeviceMaxMemoryAllocSize(srcSize, type);
 
-    UMat src(srcSize, type), dst(srcSize, depth);
+    UMat src(srcSize, type), dst(srcSize, CV_MAKETYPE(depth, 1));
     declare.in(src, WARMUP_RNG).out(dst);
 
     OCL_TEST_CYCLE() cv::extractChannel(src, dst, 1);

--- a/modules/core/perf/opencl/perf_gemm.cpp
+++ b/modules/core/perf/opencl/perf_gemm.cpp
@@ -66,7 +66,7 @@ OCL_PERF_TEST_P(GemmFixture, Gemm, ::testing::Combine(
     GemmParams params = GetParam();
     const Size srcSize = get<0>(params);
     const int flags = get<1>(params);
-    const int type = get<2>(params);
+    const ElemType type = get<2>(params);
 
     UMat src1(srcSize, type), src2(srcSize, type), src3(srcSize, type), dst(srcSize, type);
     declare.in(src1, src2, src3).out(dst);

--- a/modules/core/perf/opencl/perf_matop.cpp
+++ b/modules/core/perf/opencl/perf_matop.cpp
@@ -22,7 +22,7 @@ OCL_PERF_TEST_P(SetToFixture, SetTo,
 {
     const Size_MatType_t params = GetParam();
     const Size srcSize = get<0>(params);
-    const int type = get<1>(params);
+    const ElemType type = get<1>(params);
     const Scalar s = Scalar::all(17);
 
     checkDeviceMaxMemoryAllocSize(srcSize, type);
@@ -44,7 +44,7 @@ OCL_PERF_TEST_P(SetToFixture, SetToWithMask,
 {
     const Size_MatType_t params = GetParam();
     const Size srcSize = get<0>(params);
-    const int type = get<1>(params);
+    const ElemType type = get<1>(params);
     const Scalar s = Scalar::all(17);
 
     checkDeviceMaxMemoryAllocSize(srcSize, type);
@@ -66,8 +66,10 @@ OCL_PERF_TEST_P(ConvertToFixture, ConvertTo,
 {
     const Size_MatType_t params = GetParam();
     const Size srcSize = get<0>(params);
-    const int type = get<1>(params), ddepth = CV_MAT_DEPTH(type) == CV_8U ? CV_32F : CV_8U,
-        cn = CV_MAT_CN(type), dtype = CV_MAKE_TYPE(ddepth, cn);
+    const ElemType type = get<1>(params);
+    const ElemDepth ddepth = CV_MAT_DEPTH(type) == CV_8U ? CV_32F : CV_8U;
+    const int cn = CV_MAT_CN(type);
+    const ElemType dtype = CV_MAKE_TYPE(ddepth, cn);
 
     checkDeviceMaxMemoryAllocSize(srcSize, type);
     checkDeviceMaxMemoryAllocSize(srcSize, dtype);
@@ -75,7 +77,7 @@ OCL_PERF_TEST_P(ConvertToFixture, ConvertTo,
     UMat src(srcSize, type), dst(srcSize, dtype);
     declare.in(src, WARMUP_RNG).out(dst);
 
-    OCL_TEST_CYCLE() src.convertTo(dst, dtype);
+    OCL_TEST_CYCLE() src.convertTo(dst, ddepth);
 
     SANITY_CHECK(dst);
 }
@@ -89,7 +91,7 @@ OCL_PERF_TEST_P(CopyToFixture, CopyTo,
 {
     const Size_MatType_t params = GetParam();
     const Size srcSize = get<0>(params);
-    const int type = get<1>(params);
+    const ElemType type = get<1>(params);
 
     checkDeviceMaxMemoryAllocSize(srcSize, type);
 
@@ -110,7 +112,7 @@ OCL_PERF_TEST_P(CopyToFixture, CopyToWithMask,
 {
     const Size_MatType_t params = GetParam();
     const Size srcSize = get<0>(params);
-    const int type = get<1>(params);
+    const ElemType type = get<1>(params);
 
     checkDeviceMaxMemoryAllocSize(srcSize, type);
 
@@ -127,7 +129,7 @@ OCL_PERF_TEST_P(CopyToFixture, CopyToWithMaskUninit,
 {
     const Size_MatType_t params = GetParam();
     const Size srcSize = get<0>(params);
-    const int type = get<1>(params);
+    const ElemType type = get<1>(params);
 
     checkDeviceMaxMemoryAllocSize(srcSize, type);
 

--- a/modules/core/perf/perf_abs.cpp
+++ b/modules/core/perf/perf_abs.cpp
@@ -11,7 +11,7 @@ using namespace perf;
 PERF_TEST_P(Size_MatType, abs, TYPICAL_MATS_ABS)
 {
     Size sz = get<0>(GetParam());
-    int type = get<1>(GetParam());
+    ElemType type = get<1>(GetParam());
 
     cv::Mat a = Mat(sz, type);
     cv::Mat c = Mat(sz, type);

--- a/modules/core/perf/perf_addWeighted.cpp
+++ b/modules/core/perf/perf_addWeighted.cpp
@@ -10,7 +10,7 @@ using namespace perf;
 PERF_TEST_P(Size_MatType, addWeighted, TYPICAL_MATS_ADWEIGHTED)
 {
     Size size = get<0>(GetParam());
-    int type = get<1>(GetParam());
+    ElemType type = get<1>(GetParam());
     int depth = CV_MAT_DEPTH(type);
     Mat src1(size, type);
     Mat src2(size, type);
@@ -29,7 +29,7 @@ PERF_TEST_P(Size_MatType, addWeighted, TYPICAL_MATS_ADWEIGHTED)
         src2 /= 2048;
     }
 
-    TEST_CYCLE() cv::addWeighted( src1, alpha, src2, beta, gamma, dst, dst.type() );
+    TEST_CYCLE() cv::addWeighted( src1, alpha, src2, beta, gamma, dst, dst.depth() );
 
     SANITY_CHECK(dst, depth == CV_32S ? 4 : 1);
 }

--- a/modules/core/perf/perf_arithm.cpp
+++ b/modules/core/perf/perf_arithm.cpp
@@ -9,7 +9,7 @@ typedef Size_MatType BinaryOpTest;
 PERF_TEST_P_(BinaryOpTest, min)
 {
     Size sz = get<0>(GetParam());
-    int type = get<1>(GetParam());
+    ElemType type = get<1>(GetParam());
     cv::Mat a = Mat(sz, type);
     cv::Mat b = Mat(sz, type);
     cv::Mat c = Mat(sz, type);
@@ -24,7 +24,7 @@ PERF_TEST_P_(BinaryOpTest, min)
 PERF_TEST_P_(BinaryOpTest, minScalarDouble)
 {
     Size sz = get<0>(GetParam());
-    int type = get<1>(GetParam());
+    ElemType type = get<1>(GetParam());
     cv::Mat a = Mat(sz, type);
     cv::Scalar b;
     cv::Mat c = Mat(sz, type);
@@ -39,7 +39,7 @@ PERF_TEST_P_(BinaryOpTest, minScalarDouble)
 PERF_TEST_P_(BinaryOpTest, minScalarSameType)
 {
     Size sz = get<0>(GetParam());
-    int type = get<1>(GetParam());
+    ElemType type = get<1>(GetParam());
     cv::Mat a = Mat(sz, type);
     cv::Scalar b;
     cv::Mat c = Mat(sz, type);
@@ -63,7 +63,7 @@ PERF_TEST_P_(BinaryOpTest, minScalarSameType)
 PERF_TEST_P_(BinaryOpTest, max)
 {
     Size sz = get<0>(GetParam());
-    int type = get<1>(GetParam());
+    ElemType type = get<1>(GetParam());
     cv::Mat a = Mat(sz, type);
     cv::Mat b = Mat(sz, type);
     cv::Mat c = Mat(sz, type);
@@ -78,7 +78,7 @@ PERF_TEST_P_(BinaryOpTest, max)
 PERF_TEST_P_(BinaryOpTest, maxScalarDouble)
 {
     Size sz = get<0>(GetParam());
-    int type = get<1>(GetParam());
+    ElemType type = get<1>(GetParam());
     cv::Mat a = Mat(sz, type);
     cv::Scalar b;
     cv::Mat c = Mat(sz, type);
@@ -93,7 +93,7 @@ PERF_TEST_P_(BinaryOpTest, maxScalarDouble)
 PERF_TEST_P_(BinaryOpTest, maxScalarSameType)
 {
     Size sz = get<0>(GetParam());
-    int type = get<1>(GetParam());
+    ElemType type = get<1>(GetParam());
     cv::Mat a = Mat(sz, type);
     cv::Scalar b;
     cv::Mat c = Mat(sz, type);
@@ -117,7 +117,7 @@ PERF_TEST_P_(BinaryOpTest, maxScalarSameType)
 PERF_TEST_P_(BinaryOpTest, absdiff)
 {
     Size sz = get<0>(GetParam());
-    int type = get<1>(GetParam());
+    ElemType type = get<1>(GetParam());
     cv::Mat a = Mat(sz, type);
     cv::Mat b = Mat(sz, type);
     cv::Mat c = Mat(sz, type);
@@ -139,7 +139,7 @@ PERF_TEST_P_(BinaryOpTest, absdiff)
 PERF_TEST_P_(BinaryOpTest, absdiffScalarDouble)
 {
     Size sz = get<0>(GetParam());
-    int type = get<1>(GetParam());
+    ElemType type = get<1>(GetParam());
     cv::Mat a = Mat(sz, type);
     cv::Scalar b;
     cv::Mat c = Mat(sz, type);
@@ -161,7 +161,7 @@ PERF_TEST_P_(BinaryOpTest, absdiffScalarDouble)
 PERF_TEST_P_(BinaryOpTest, absdiffScalarSameType)
 {
     Size sz = get<0>(GetParam());
-    int type = get<1>(GetParam());
+    ElemType type = get<1>(GetParam());
     cv::Mat a = Mat(sz, type);
     cv::Scalar b;
     cv::Mat c = Mat(sz, type);
@@ -187,7 +187,7 @@ PERF_TEST_P_(BinaryOpTest, absdiffScalarSameType)
 PERF_TEST_P_(BinaryOpTest, add)
 {
     Size sz = get<0>(GetParam());
-    int type = get<1>(GetParam());
+    ElemType type = get<1>(GetParam());
     cv::Mat a = Mat(sz, type);
     cv::Mat b = Mat(sz, type);
     cv::Mat c = Mat(sz, type);
@@ -210,7 +210,7 @@ PERF_TEST_P_(BinaryOpTest, add)
 PERF_TEST_P_(BinaryOpTest, addScalarDouble)
 {
     Size sz = get<0>(GetParam());
-    int type = get<1>(GetParam());
+    ElemType type = get<1>(GetParam());
     cv::Mat a = Mat(sz, type);
     cv::Scalar b;
     cv::Mat c = Mat(sz, type);
@@ -232,25 +232,26 @@ PERF_TEST_P_(BinaryOpTest, addScalarDouble)
 PERF_TEST_P_(BinaryOpTest, addScalarSameType)
 {
     Size sz = get<0>(GetParam());
-    int type = get<1>(GetParam());
+    ElemType type = get<1>(GetParam());
+    ElemDepth depth = CV_MAT_DEPTH(type);
     cv::Mat a = Mat(sz, type);
     cv::Scalar b;
     cv::Mat c = Mat(sz, type);
 
     declare.in(a, b, WARMUP_RNG).out(c);
 
-    if (CV_MAT_DEPTH(type) < CV_32S)
+    if (depth < CV_32S)
     {
         b = Scalar(1, 0, 3, 4); // don't pass non-integer values for 8U/8S/16U/16S processing
     }
-    else if (CV_MAT_DEPTH(type) == CV_32S)
+    else if (depth == CV_32S)
     {
         //see ticket 1529: add can be without saturation on 32S
         a /= 2;
         b = Scalar(1, 0, -3, 4); // don't pass non-integer values for 32S processing
     }
 
-    TEST_CYCLE() cv::add(a, b, c, noArray(), type);
+    TEST_CYCLE() cv::add(a, b, c, noArray(), depth);
 
     SANITY_CHECK_NOTHING();
 }
@@ -258,7 +259,7 @@ PERF_TEST_P_(BinaryOpTest, addScalarSameType)
 PERF_TEST_P_(BinaryOpTest, subtract)
 {
     Size sz = get<0>(GetParam());
-    int type = get<1>(GetParam());
+    ElemType type = get<1>(GetParam());
     cv::Mat a = Mat(sz, type);
     cv::Mat b = Mat(sz, type);
     cv::Mat c = Mat(sz, type);
@@ -280,7 +281,7 @@ PERF_TEST_P_(BinaryOpTest, subtract)
 PERF_TEST_P_(BinaryOpTest, subtractScalarDouble)
 {
     Size sz = get<0>(GetParam());
-    int type = get<1>(GetParam());
+    ElemType type = get<1>(GetParam());
     cv::Mat a = Mat(sz, type);
     cv::Scalar b;
     cv::Mat c = Mat(sz, type);
@@ -302,25 +303,26 @@ PERF_TEST_P_(BinaryOpTest, subtractScalarDouble)
 PERF_TEST_P_(BinaryOpTest, subtractScalarSameType)
 {
     Size sz = get<0>(GetParam());
-    int type = get<1>(GetParam());
+    ElemType type = get<1>(GetParam());
+    ElemDepth depth = CV_MAT_DEPTH(type);
     cv::Mat a = Mat(sz, type);
     cv::Scalar b;
     cv::Mat c = Mat(sz, type);
 
     declare.in(a, b, WARMUP_RNG).out(c);
 
-    if (CV_MAT_DEPTH(type) < CV_32S)
+    if (depth < CV_32S)
     {
         b = Scalar(1, 0, 3, 4); // don't pass non-integer values for 8U/8S/16U/16S processing
     }
-    else if (CV_MAT_DEPTH(type) == CV_32S)
+    else if (depth == CV_32S)
     {
         //see ticket 1529: subtract can be without saturation on 32S
         a /= 2;
         b = Scalar(1, 0, -3, 4); // don't pass non-integer values for 32S processing
     }
 
-    TEST_CYCLE() cv::subtract(a, b, c, noArray(), type);
+    TEST_CYCLE() cv::subtract(a, b, c, noArray(), depth);
 
     SANITY_CHECK_NOTHING();
 }
@@ -328,7 +330,7 @@ PERF_TEST_P_(BinaryOpTest, subtractScalarSameType)
 PERF_TEST_P_(BinaryOpTest, multiply)
 {
     Size sz = get<0>(GetParam());
-    int type = get<1>(GetParam());
+    ElemType type = get<1>(GetParam());
     cv::Mat a(sz, type), b(sz, type), c(sz, type);
 
     declare.in(a, b, WARMUP_RNG).out(c);
@@ -347,7 +349,7 @@ PERF_TEST_P_(BinaryOpTest, multiply)
 PERF_TEST_P_(BinaryOpTest, multiplyScale)
 {
     Size sz = get<0>(GetParam());
-    int type = get<1>(GetParam());
+    ElemType type = get<1>(GetParam());
     cv::Mat a(sz, type), b(sz, type), c(sz, type);
     double scale = 0.5;
 
@@ -368,7 +370,7 @@ PERF_TEST_P_(BinaryOpTest, multiplyScale)
 PERF_TEST_P_(BinaryOpTest, divide)
 {
     Size sz = get<0>(GetParam());
-    int type = get<1>(GetParam());
+    ElemType type = get<1>(GetParam());
     cv::Mat a(sz, type), b(sz, type), c(sz, type);
     double scale = 0.5;
 
@@ -382,7 +384,7 @@ PERF_TEST_P_(BinaryOpTest, divide)
 PERF_TEST_P_(BinaryOpTest, reciprocal)
 {
     Size sz = get<0>(GetParam());
-    int type = get<1>(GetParam());
+    ElemType type = get<1>(GetParam());
     cv::Mat b(sz, type), c(sz, type);
     double scale = 0.5;
 

--- a/modules/core/perf/perf_bitwise.cpp
+++ b/modules/core/perf/perf_bitwise.cpp
@@ -11,7 +11,7 @@ using namespace perf;
 PERF_TEST_P(Size_MatType, bitwise_not, TYPICAL_MATS_BITW_ARITHM)
 {
     Size sz = get<0>(GetParam());
-    int type = get<1>(GetParam());
+    ElemType type = get<1>(GetParam());
 
     cv::Mat a = Mat(sz, type);
     cv::Mat c = Mat(sz, type);
@@ -27,7 +27,7 @@ PERF_TEST_P(Size_MatType, bitwise_not, TYPICAL_MATS_BITW_ARITHM)
 PERF_TEST_P(Size_MatType, bitwise_and, TYPICAL_MATS_BITW_ARITHM)
 {
     Size sz = get<0>(GetParam());
-    int type = get<1>(GetParam());
+    ElemType type = get<1>(GetParam());
     cv::Mat a = Mat(sz, type);
     cv::Mat b = Mat(sz, type);
     cv::Mat c = Mat(sz, type);
@@ -43,7 +43,7 @@ PERF_TEST_P(Size_MatType, bitwise_and, TYPICAL_MATS_BITW_ARITHM)
 PERF_TEST_P(Size_MatType, bitwise_or, TYPICAL_MATS_BITW_ARITHM)
 {
     Size sz = get<0>(GetParam());
-    int type = get<1>(GetParam());
+    ElemType type = get<1>(GetParam());
     cv::Mat a = Mat(sz, type);
     cv::Mat b = Mat(sz, type);
     cv::Mat c = Mat(sz, type);
@@ -59,7 +59,7 @@ PERF_TEST_P(Size_MatType, bitwise_or, TYPICAL_MATS_BITW_ARITHM)
 PERF_TEST_P(Size_MatType, bitwise_xor, TYPICAL_MATS_BITW_ARITHM)
 {
     Size sz = get<0>(GetParam());
-    int type = get<1>(GetParam());
+    ElemType type = get<1>(GetParam());
     cv::Mat a = Mat(sz, type);
     cv::Mat b = Mat(sz, type);
     cv::Mat c = Mat(sz, type);

--- a/modules/core/perf/perf_compare.cpp
+++ b/modules/core/perf/perf_compare.cpp
@@ -18,7 +18,7 @@ PERF_TEST_P( Size_MatType_CmpType, compare,
              )
 {
     Size sz = get<0>(GetParam());
-    int matType1 = get<1>(GetParam());
+    ElemType matType1 = get<1>(GetParam());
     CmpType cmpType = get<2>(GetParam());
 
     Mat src1(sz, matType1);
@@ -41,7 +41,7 @@ PERF_TEST_P( Size_MatType_CmpType, compareScalar,
              )
 {
     Size sz = get<0>(GetParam());
-    int matType = get<1>(GetParam());
+    ElemType matType = get<1>(GetParam());
     CmpType cmpType = get<2>(GetParam());
 
     Mat src1(sz, matType);

--- a/modules/core/perf/perf_convertTo.cpp
+++ b/modules/core/perf/perf_convertTo.cpp
@@ -4,7 +4,7 @@ namespace opencv_test
 {
 using namespace perf;
 
-typedef tuple<Size, MatType, MatType, int, double> Size_DepthSrc_DepthDst_Channels_alpha_t;
+typedef tuple<Size, MatDepth, MatDepth, int, double> Size_DepthSrc_DepthDst_Channels_alpha_t;
 typedef perf::TestBaseWithParam<Size_DepthSrc_DepthDst_Channels_alpha_t> Size_DepthSrc_DepthDst_Channels_alpha;
 
 PERF_TEST_P( Size_DepthSrc_DepthDst_Channels_alpha, convertTo,
@@ -19,8 +19,8 @@ PERF_TEST_P( Size_DepthSrc_DepthDst_Channels_alpha, convertTo,
            )
 {
     Size sz = get<0>(GetParam());
-    int depthSrc = get<1>(GetParam());
-    int depthDst = get<2>(GetParam());
+    ElemDepth depthSrc = get<1>(GetParam());
+    ElemDepth depthDst = get<2>(GetParam());
     int channels = get<3>(GetParam());
     double alpha = get<4>(GetParam());
 

--- a/modules/core/perf/perf_cvround.cpp
+++ b/modules/core/perf/perf_cvround.cpp
@@ -22,7 +22,8 @@ PERF_TEST_P(Size_MatType, CvRound_Float,
                              testing::Values(CV_32FC1, CV_64FC1)))
 {
     Size size = get<0>(GetParam());
-    int type = get<1>(GetParam()), depth = CV_MAT_DEPTH(type);
+    ElemType type = get<1>(GetParam());
+    ElemDepth depth = CV_MAT_DEPTH(type);
 
     cv::Mat src(size, type), dst(size, CV_32SC1);
 

--- a/modules/core/perf/perf_dft.cpp
+++ b/modules/core/perf/perf_dft.cpp
@@ -17,7 +17,7 @@ typedef perf::TestBaseWithParam<Size_MatType_FlagsType_NzeroRows_t> Size_MatType
 PERF_TEST_P(Size_MatType_FlagsType_NzeroRows, dft, TEST_MATS_DFT)
 {
     Size sz = get<0>(GetParam());
-    int type = get<1>(GetParam());
+    ElemType type = get<1>(GetParam());
     int flags = get<2>(GetParam());
     bool isNzeroRows = get<3>(GetParam());
 
@@ -50,7 +50,7 @@ PERF_TEST_P(Size_MatType_Flag, dct, testing::Combine(
                                     testing::Values(CV_32FC1, CV_64FC1), DCT_FlagsType::all()))
 {
     Size sz = get<0>(GetParam());
-    int type = get<1>(GetParam());
+    ElemType type = get<1>(GetParam());
     int flags = get<2>(GetParam());
 
     Mat src(sz, type);

--- a/modules/core/perf/perf_dot.cpp
+++ b/modules/core/perf/perf_dot.cpp
@@ -13,7 +13,7 @@ PERF_TEST_P( MatType_Length, dot,
                  testing::Values( 32, 64, 128, 256, 512, 1024 )
                  ))
 {
-    int type = get<0>(GetParam());
+    ElemType type = get<0>(GetParam());
     int size = get<1>(GetParam());
     Mat a(size, size, type);
     Mat b(size, size, type);

--- a/modules/core/perf/perf_inRange.cpp
+++ b/modules/core/perf/perf_inRange.cpp
@@ -10,7 +10,7 @@ using namespace perf;
 PERF_TEST_P(Size_MatType, inRange, TYPICAL_MATS_INRANGE)
 {
     Size size = get<0>(GetParam());
-    int type = get<1>(GetParam());
+    ElemType type = get<1>(GetParam());
     Mat src1(size, type);
     Mat src2(size, type);
     Mat src3(size, type);

--- a/modules/core/perf/perf_io_base64.cpp
+++ b/modules/core/perf/perf_io_base64.cpp
@@ -19,7 +19,7 @@ PERF_TEST_P(Size_Mat_StrType, fs_text,
              )
 {
     Size   size = get<0>(GetParam());
-    int    type = get<1>(GetParam());
+    ElemType type = get<1>(GetParam());
     String ext  = get<2>(GetParam());
 
     Mat src(size.height, size.width, type);
@@ -55,7 +55,7 @@ PERF_TEST_P(Size_Mat_StrType, fs_base64,
              )
 {
     Size   size = get<0>(GetParam());
-    int    type = get<1>(GetParam());
+    ElemType type = get<1>(GetParam());
     String ext  = get<2>(GetParam());
 
     Mat src(size.height, size.width, type);

--- a/modules/core/perf/perf_mat.cpp
+++ b/modules/core/perf/perf_mat.cpp
@@ -11,7 +11,7 @@ PERF_TEST_P(Size_MatType, Mat_Eye,
              )
 {
     Size size = get<0>(GetParam());
-    int type = get<1>(GetParam());
+    ElemType type = get<1>(GetParam());
     Mat diagonalMatrix(size.height, size.width, type);
 
     declare.out(diagonalMatrix);
@@ -32,7 +32,7 @@ PERF_TEST_P(Size_MatType, Mat_Zeros,
              )
 {
     Size size = get<0>(GetParam());
-    int type = get<1>(GetParam());
+    ElemType type = get<1>(GetParam());
     Mat zeroMatrix(size.height, size.width, type);
 
     declare.out(zeroMatrix);
@@ -53,7 +53,7 @@ PERF_TEST_P(Size_MatType, Mat_Clone,
              )
 {
     Size size = get<0>(GetParam());
-    int type = get<1>(GetParam());
+    ElemType type = get<1>(GetParam());
     Mat source(size.height, size.width, type);
     Mat destination(size.height, size.width, type);
 
@@ -76,7 +76,7 @@ PERF_TEST_P(Size_MatType, Mat_Clone_Roi,
              )
 {
     Size size = get<0>(GetParam());
-    int type = get<1>(GetParam());
+    ElemType type = get<1>(GetParam());
 
     unsigned int width = size.width;
     unsigned int height = size.height;
@@ -104,7 +104,7 @@ PERF_TEST_P(Size_MatType, Mat_CopyToWithMask,
 {
     const Size_MatType_t params = GetParam();
     const Size size = get<0>(params);
-    const int type = get<1>(params);
+    const ElemType type = get<1>(params);
 
     Mat src(size, type), dst(size, type), mask(size, CV_8UC1);
     declare.in(src, mask, WARMUP_RNG).out(dst);
@@ -124,7 +124,7 @@ PERF_TEST_P(Size_MatType, Mat_SetToWithMask,
 {
     const Size_MatType_t params = GetParam();
     const Size size = get<0>(params);
-    const int type = get<1>(params);
+    const ElemType type = get<1>(params);
     const Scalar sc = Scalar::all(27);
 
     Mat src(size, type), mask(size, CV_8UC1);
@@ -148,7 +148,7 @@ PERF_TEST_P(Size_MatType, Mat_Transform,
     const Size_MatType_t params = GetParam();
     const Size srcSize0 = get<0>(params);
     const Size srcSize = Size(1, srcSize0.width*srcSize0.height);
-    const int type = get<1>(params);
+    const ElemType type = get<1>(params);
     const float transform[] = { 0.5f,           0.f, 0.86602540378f, 128,
                                 0.f,            1.f, 0.f,            -64,
                                 0.86602540378f, 0.f, 0.5f,            32,};

--- a/modules/core/perf/perf_math.cpp
+++ b/modules/core/perf/perf_math.cpp
@@ -46,11 +46,11 @@ PERF_TEST_P_(KMeans, single_iter)
     const int N = testing::get<2>(GetParam());
     const int attempts = 5;
 
-    Mat data(N, dims, CV_32F);
+    Mat data(N, dims, CV_32FC1);
     rng.fill(data, RNG::UNIFORM, -0.1, 0.1);
 
     const int N0 = K;
-    Mat data0(N0, dims, CV_32F);
+    Mat data0(N0, dims, CV_32FC1);
     rng.fill(data0, RNG::UNIFORM, -1, 1);
 
     for (int i = 0; i < N; i++)
@@ -80,11 +80,11 @@ PERF_TEST_P_(KMeans, good)
     const int N = testing::get<2>(GetParam());
     const int attempts = 5;
 
-    Mat data(N, dims, CV_32F);
+    Mat data(N, dims, CV_32FC1);
     rng.fill(data, RNG::UNIFORM, -0.1, 0.1);
 
     const int N0 = K;
-    Mat data0(N0, dims, CV_32F);
+    Mat data0(N0, dims, CV_32FC1);
     rng.fill(data0, RNG::UNIFORM, -1, 1);
 
     for (int i = 0; i < N; i++)
@@ -114,10 +114,10 @@ PERF_TEST_P_(KMeans, with_duplicates)
     const int N = testing::get<2>(GetParam());
     const int attempts = 5;
 
-    Mat data(N, dims, CV_32F, Scalar::all(0));
+    Mat data(N, dims, CV_32FC1, Scalar::all(0));
 
     const int N0 = std::max(2, K * 2 / 3);
-    Mat data0(N0, dims, CV_32F);
+    Mat data0(N0, dims, CV_32FC1);
     rng.fill(data0, RNG::UNIFORM, -1, 1);
 
     for (int i = 0; i < N; i++)

--- a/modules/core/perf/perf_merge.cpp
+++ b/modules/core/perf/perf_merge.cpp
@@ -4,7 +4,7 @@ namespace opencv_test
 {
 using namespace perf;
 
-typedef tuple<Size, MatType, int> Size_SrcDepth_DstChannels_t;
+typedef tuple<Size, MatDepth, int> Size_SrcDepth_DstChannels_t;
 typedef perf::TestBaseWithParam<Size_SrcDepth_DstChannels_t> Size_SrcDepth_DstChannels;
 
 PERF_TEST_P( Size_SrcDepth_DstChannels, merge,
@@ -17,7 +17,7 @@ PERF_TEST_P( Size_SrcDepth_DstChannels, merge,
            )
 {
     Size sz = get<0>(GetParam());
-    int srcDepth = get<1>(GetParam());
+    ElemDepth srcDepth = get<1>(GetParam());
     int dstChannels = get<2>(GetParam());
 
     int maxValue = 255;

--- a/modules/core/perf/perf_minmaxloc.cpp
+++ b/modules/core/perf/perf_minmaxloc.cpp
@@ -11,15 +11,15 @@ PERF_TEST_P(Size_MatType, minMaxLoc, testing::Combine(
              )
 {
     Size sz = get<0>(GetParam());
-    int matType = get<1>(GetParam());
+    ElemType matType = get<1>(GetParam());
 
     Mat src(sz, matType);
     double minVal, maxVal;
     Point minLoc, maxLoc;
 
-    if (matType == CV_8U)
+    if (matType == CV_8UC1)
         randu(src, 1, 254 /*do not include 0 and 255 to avoid early exit on 1 byte data*/);
-    else if (matType == CV_8S)
+    else if (matType == CV_8SC1)
         randu(src, -127, 126);
     else
         warmup(src, WARMUP_RNG);

--- a/modules/core/perf/perf_norm.cpp
+++ b/modules/core/perf/perf_norm.cpp
@@ -20,7 +20,7 @@ PERF_TEST_P(Size_MatType_NormType, norm,
             )
 {
     Size sz = get<0>(GetParam());
-    int matType = get<1>(GetParam());
+    ElemType matType = get<1>(GetParam());
     int normType = get<2>(GetParam());
 
     Mat src(sz, matType);
@@ -42,11 +42,11 @@ PERF_TEST_P(Size_MatType_NormType, norm_mask,
             )
 {
     Size sz = get<0>(GetParam());
-    int matType = get<1>(GetParam());
+    ElemType matType = get<1>(GetParam());
     int normType = get<2>(GetParam());
 
     Mat src(sz, matType);
-    Mat mask = Mat::ones(sz, CV_8U);
+    Mat mask = Mat::ones(sz, CV_8UC1);
     double n;
 
     declare.in(src, WARMUP_RNG).in(mask);
@@ -65,7 +65,7 @@ PERF_TEST_P(Size_MatType_NormType, norm2,
             )
 {
     Size sz = get<0>(GetParam());
-    int matType = get<1>(GetParam());
+    ElemType matType = get<1>(GetParam());
     int normType = get<2>(GetParam());
 
     Mat src1(sz, matType);
@@ -88,12 +88,12 @@ PERF_TEST_P(Size_MatType_NormType, norm2_mask,
             )
 {
     Size sz = get<0>(GetParam());
-    int matType = get<1>(GetParam());
+    ElemType matType = get<1>(GetParam());
     int normType = get<2>(GetParam());
 
     Mat src1(sz, matType);
     Mat src2(sz, matType);
-    Mat mask = Mat::ones(sz, CV_8U);
+    Mat mask = Mat::ones(sz, CV_8UC1);
     double n;
 
     declare.in(src1, src2, WARMUP_RNG).in(mask);
@@ -116,7 +116,7 @@ PERF_TEST_P(PerfHamming, norm,
             )
 {
     Size sz = get<2>(GetParam());
-    int matType = get<1>(GetParam());
+    ElemType matType = get<1>(GetParam());
     int normType = get<0>(GetParam());
 
     Mat src(sz, matType);
@@ -139,7 +139,7 @@ PERF_TEST_P(PerfHamming, norm2,
             )
 {
     Size sz = get<2>(GetParam());
-    int matType = get<1>(GetParam());
+    ElemType matType = get<1>(GetParam());
     int normType = get<0>(GetParam());
 
     Mat src1(sz, matType);
@@ -166,7 +166,7 @@ PERF_TEST_P(Size_MatType_NormType, normalize,
             )
 {
     Size sz = get<0>(GetParam());
-    int matType = get<1>(GetParam());
+    ElemType matType = get<1>(GetParam());
     int normType = get<2>(GetParam());
 
     Mat src(sz, matType);
@@ -192,12 +192,12 @@ PERF_TEST_P(Size_MatType_NormType, normalize_mask,
             )
 {
     Size sz = get<0>(GetParam());
-    int matType = get<1>(GetParam());
+    ElemType matType = get<1>(GetParam());
     int normType = get<2>(GetParam());
 
     Mat src(sz, matType);
     Mat dst(sz, matType);
-    Mat mask = Mat::ones(sz, CV_8U);
+    Mat mask = Mat::ones(sz, CV_8UC1);
 
     double alpha = 100.;
     if(normType==NORM_L1) alpha = (double)src.total() * src.channels();
@@ -206,7 +206,7 @@ PERF_TEST_P(Size_MatType_NormType, normalize_mask,
     declare.in(src, WARMUP_RNG).in(mask).out(dst);
     declare.time(100);
 
-    TEST_CYCLE() cv::normalize(src, dst, alpha, 0., normType, -1, mask);
+    TEST_CYCLE() cv::normalize(src, dst, alpha, 0., normType, CV_DEPTH_AUTO, mask);
 
     SANITY_CHECK(dst, 1e-6);
 }
@@ -220,11 +220,11 @@ PERF_TEST_P(Size_MatType_NormType, normalize_32f,
             )
 {
     Size sz = get<0>(GetParam());
-    int matType = get<1>(GetParam());
+    ElemType matType = get<1>(GetParam());
     int normType = get<2>(GetParam());
 
     Mat src(sz, matType);
-    Mat dst(sz, CV_32F);
+    Mat dst(sz, CV_32FC1);
 
     double alpha = 100.;
     if(normType==NORM_L1) alpha = (double)src.total() * src.channels();
@@ -240,7 +240,7 @@ PERF_TEST_P(Size_MatType_NormType, normalize_32f,
 PERF_TEST_P( Size_MatType, normalize_minmax, TYPICAL_MATS )
 {
     Size sz = get<0>(GetParam());
-    int matType = get<1>(GetParam());
+    ElemType matType = get<1>(GetParam());
 
     Mat src(sz, matType);
     Mat dst(sz, matType);

--- a/modules/core/perf/perf_reduce.cpp
+++ b/modules/core/perf/perf_reduce.cpp
@@ -19,15 +19,15 @@ PERF_TEST_P(Size_MatType_ROp, reduceR,
             )
 {
     Size sz = get<0>(GetParam());
-    int matType = get<1>(GetParam());
+    ElemType matType = get<1>(GetParam());
     int reduceOp = get<2>(GetParam());
 
-    int ddepth = -1;
+    ElemDepth ddepth = CV_DEPTH_AUTO;
     if( CV_MAT_DEPTH(matType) < CV_32S && (reduceOp == CV_REDUCE_SUM || reduceOp == CV_REDUCE_AVG) )
         ddepth = CV_32S;
 
     Mat src(sz, matType);
-    Mat vec(1, sz.width, ddepth < 0 ? matType : ddepth);
+    Mat vec(1, sz.width, ddepth == CV_DEPTH_AUTO ? matType : CV_MAKETYPE(ddepth, 1));
 
     declare.in(src, WARMUP_RNG).out(vec);
     declare.time(100);
@@ -47,15 +47,15 @@ PERF_TEST_P(Size_MatType_ROp, reduceC,
             )
 {
     Size sz = get<0>(GetParam());
-    int matType = get<1>(GetParam());
+    ElemType matType = get<1>(GetParam());
     int reduceOp = get<2>(GetParam());
 
-    int ddepth = -1;
+    ElemDepth ddepth = CV_DEPTH_AUTO;
     if( CV_MAT_DEPTH(matType)< CV_32S && (reduceOp == CV_REDUCE_SUM || reduceOp == CV_REDUCE_AVG) )
         ddepth = CV_32S;
 
     Mat src(sz, matType);
-    Mat vec(sz.height, 1, ddepth < 0 ? matType : ddepth);
+    Mat vec(sz.height, 1, ddepth == CV_DEPTH_AUTO ? matType : CV_MAKETYPE(ddepth, 1));
 
     declare.in(src, WARMUP_RNG).out(vec);
     declare.time(100);

--- a/modules/core/perf/perf_sort.cpp
+++ b/modules/core/perf/perf_sort.cpp
@@ -16,7 +16,8 @@ PERF_TEST_P(sortFixture, sort, TYPICAL_MATS_SORT)
 {
     const sortParams params = GetParam();
     const Size sz = get<0>(params);
-    const int type = get<1>(params), flags = get<2>(params);
+    const ElemType type = get<1>(params);
+    const int flags = get<2>(params);
 
     cv::Mat a(sz, type), b(sz, type);
 
@@ -36,7 +37,8 @@ PERF_TEST_P(sortIdxFixture, sorIdx, TYPICAL_MATS_SORT)
 {
     const sortParams params = GetParam();
     const Size sz = get<0>(params);
-    const int type = get<1>(params), flags = get<2>(params);
+    const ElemType type = get<1>(params);
+    int flags = get<2>(params);
 
     cv::Mat a(sz, type), b(sz, type);
 

--- a/modules/core/perf/perf_split.cpp
+++ b/modules/core/perf/perf_split.cpp
@@ -4,7 +4,7 @@ namespace opencv_test
 {
 using namespace perf;
 
-typedef tuple<Size, MatType, int> Size_Depth_Channels_t;
+typedef tuple<Size, MatDepth, int> Size_Depth_Channels_t;
 typedef perf::TestBaseWithParam<Size_Depth_Channels_t> Size_Depth_Channels;
 
 PERF_TEST_P( Size_Depth_Channels, split,
@@ -17,7 +17,7 @@ PERF_TEST_P( Size_Depth_Channels, split,
            )
 {
     Size sz = get<0>(GetParam());
-    int depth = get<1>(GetParam());
+    ElemDepth depth = get<1>(GetParam());
     int channels = get<2>(GetParam());
 
     Mat m(sz, CV_MAKETYPE(depth, channels));

--- a/modules/core/perf/perf_stat.cpp
+++ b/modules/core/perf/perf_stat.cpp
@@ -7,7 +7,7 @@ using namespace perf;
 PERF_TEST_P(Size_MatType, sum, TYPICAL_MATS)
 {
     Size sz = get<0>(GetParam());
-    int type = get<1>(GetParam());
+    ElemType type = get<1>(GetParam());
 
     Mat arr(sz, type);
     Scalar s;
@@ -22,7 +22,7 @@ PERF_TEST_P(Size_MatType, sum, TYPICAL_MATS)
 PERF_TEST_P(Size_MatType, mean, TYPICAL_MATS)
 {
     Size sz = get<0>(GetParam());
-    int type = get<1>(GetParam());
+    ElemType type = get<1>(GetParam());
 
     Mat src(sz, type);
     Scalar s;
@@ -37,10 +37,10 @@ PERF_TEST_P(Size_MatType, mean, TYPICAL_MATS)
 PERF_TEST_P(Size_MatType, mean_mask, TYPICAL_MATS)
 {
     Size sz = get<0>(GetParam());
-    int type = get<1>(GetParam());
+    ElemType type = get<1>(GetParam());
 
     Mat src(sz, type);
-    Mat mask = Mat::ones(src.size(), CV_8U);
+    Mat mask = Mat::ones(src.size(), CV_8UC1);
     Scalar s;
 
     declare.in(src, WARMUP_RNG).in(mask).out(s);
@@ -53,7 +53,7 @@ PERF_TEST_P(Size_MatType, mean_mask, TYPICAL_MATS)
 PERF_TEST_P(Size_MatType, meanStdDev, TYPICAL_MATS)
 {
     Size sz = get<0>(GetParam());
-    int matType = get<1>(GetParam());
+    ElemType matType = get<1>(GetParam());
 
     Mat src(sz, matType);
     Scalar mean;
@@ -70,10 +70,10 @@ PERF_TEST_P(Size_MatType, meanStdDev, TYPICAL_MATS)
 PERF_TEST_P(Size_MatType, meanStdDev_mask, TYPICAL_MATS)
 {
     Size sz = get<0>(GetParam());
-    int matType = get<1>(GetParam());
+    ElemType matType = get<1>(GetParam());
 
     Mat src(sz, matType);
-    Mat mask = Mat::ones(sz, CV_8U);
+    Mat mask = Mat::ones(sz, CV_8UC1);
     Scalar mean;
     Scalar dev;
 
@@ -88,7 +88,7 @@ PERF_TEST_P(Size_MatType, meanStdDev_mask, TYPICAL_MATS)
 PERF_TEST_P(Size_MatType, countNonZero, testing::Combine( testing::Values( TYPICAL_MAT_SIZES ), testing::Values( CV_8UC1, CV_8SC1, CV_16UC1, CV_16SC1, CV_32SC1, CV_32FC1, CV_64FC1 ) ))
 {
     Size sz = get<0>(GetParam());
-    int matType = get<1>(GetParam());
+    ElemType matType = get<1>(GetParam());
 
     Mat src(sz, matType);
     int cnt = 0;

--- a/modules/core/perf/perf_umat.cpp
+++ b/modules/core/perf/perf_umat.cpp
@@ -34,7 +34,7 @@ OCL_PERF_TEST_P(UMatTest, CustomPtr, Combine(Values(sz1080p, sz2160p), Bool(), :
 {
     OpenCLState s(get<1>(GetParam()));
 
-    int type = CV_8UC1;
+    ElemType type = CV_8UC1;
     cv::Size size = get<0>(GetParam());
     size_t align_base = 4096;
     const int align_offset = get<2>(GetParam());

--- a/modules/core/test/ocl/test_arithm.cpp
+++ b/modules/core/test/ocl/test_arithm.cpp
@@ -70,9 +70,9 @@ PARAM_TEST_CASE(Lut, MatDepth, MatDepth, Channels, bool, bool)
 
     void generateTestData()
     {
-        const int src_type = CV_MAKE_TYPE(src_depth, cn);
-        const int lut_type = CV_MAKE_TYPE(lut_depth, same_cn ? cn : 1);
-        const int dst_type = CV_MAKE_TYPE(lut_depth, cn);
+        const ElemType src_type = CV_MAKE_TYPE(src_depth, cn);
+        const ElemType lut_type = CV_MAKE_TYPE(lut_depth, same_cn ? cn : 1);
+        const ElemType dst_type = CV_MAKE_TYPE(lut_depth, cn);
 
         Size roiSize = randomSize(1, MAX_VALUE);
         Border srcBorder = randomBorder(0, use_roi ? MAX_VALUE : 0);
@@ -113,7 +113,7 @@ OCL_TEST_P(Lut, Mat)
 
 PARAM_TEST_CASE(ArithmTestBase, MatDepth, Channels, bool)
 {
-    int depth;
+    ElemDepth depth;
     int cn;
     bool use_roi;
     cv::Scalar val;
@@ -134,10 +134,10 @@ PARAM_TEST_CASE(ArithmTestBase, MatDepth, Channels, bool)
 
     void generateTestData(bool with_val_in_range = false)
     {
-        const int type = CV_MAKE_TYPE(depth, cn);
+        const ElemType type = CV_MAKE_TYPE(depth, cn);
 
-        double minV = cvtest::getMinVal(type);
-        double maxV = cvtest::getMaxVal(type);
+        double minV = cvtest::getMinVal(depth);
+        double maxV = cvtest::getMaxVal(depth);
 
         Size roiSize = randomSize(1, MAX_VALUE);
         Border src1Border = randomBorder(0, use_roi ? MAX_VALUE : 0);
@@ -583,7 +583,7 @@ OCL_TEST_P(Transpose, Mat)
 
 OCL_TEST_P(Transpose, SquareInplace)
 {
-    const int type = CV_MAKE_TYPE(depth, cn);
+    const ElemType type = CV_MAKE_TYPE(depth, cn);
 
     for (int j = 0; j < test_loop_times; j++)
     {
@@ -903,7 +903,7 @@ struct RepeatTestCase :
 
     void generateTestData()
     {
-        const int type = CV_MAKE_TYPE(depth, cn);
+        const ElemType type = CV_MAKE_TYPE(depth, cn);
 
         nx = randomInt(1, 4);
         ny = randomInt(1, 4);
@@ -1469,8 +1469,8 @@ OCL_TEST_P(Normalize, Mat)
 
         for (int i = 0, size = sizeof(modes) / sizeof(modes[0]); i < size; ++i)
         {
-            OCL_OFF(cv::normalize(src1_roi, dst1_roi, 10, 110, modes[i], src1_roi.type(), mask_roi));
-            OCL_ON(cv::normalize(usrc1_roi, udst1_roi, 10, 110, modes[i], src1_roi.type(), umask_roi));
+            OCL_OFF(cv::normalize(src1_roi, dst1_roi, 10, 110, modes[i], src1_roi.depth(), mask_roi));
+            OCL_ON(cv::normalize(usrc1_roi, udst1_roi, 10, 110, modes[i], src1_roi.depth(), umask_roi));
 
             Near(1);
         }
@@ -1501,7 +1501,7 @@ PARAM_TEST_CASE(InRange, MatDepth, Channels, bool /*Scalar or not*/, bool /*Roi*
 
     void generateTestData()
     {
-        const int type = CV_MAKE_TYPE(depth, cn);
+        const ElemType type = CV_MAKE_TYPE(depth, cn);
 
         Size roiSize = randomSize(1, MAX_VALUE);
         Border src1Border = randomBorder(0, use_roi ? MAX_VALUE : 0);
@@ -1580,8 +1580,8 @@ PARAM_TEST_CASE(ConvertScaleAbs, MatDepth, Channels, bool)
 
     void generateTestData()
     {
-        const int stype = CV_MAKE_TYPE(depth, cn);
-        const int dtype = CV_MAKE_TYPE(CV_8U, cn);
+        const ElemType stype = CV_MAKE_TYPE(depth, cn);
+        const ElemType dtype = CV_MAKE_TYPE(CV_8U, cn);
 
         Size roiSize = randomSize(1, MAX_VALUE);
         Border srcBorder = randomBorder(0, use_roi ? MAX_VALUE : 0);
@@ -1637,8 +1637,8 @@ PARAM_TEST_CASE(ConvertFp16, Channels, bool)
 
     void generateTestData()
     {
-        const int stype = CV_MAKE_TYPE(fromHalf ? CV_32F : CV_16S, cn);
-        const int dtype = CV_MAKE_TYPE(fromHalf ? CV_16S : CV_32F, cn);
+        const ElemType stype = CV_MAKE_TYPE(fromHalf ? CV_32F : CV_16S, cn);
+        const ElemType dtype = CV_MAKE_TYPE(fromHalf ? CV_16S : CV_32F, cn);
 
         Size roiSize = randomSize(1, MAX_VALUE);
         Border srcBorder = randomBorder(0, 0);
@@ -1649,7 +1649,7 @@ PARAM_TEST_CASE(ConvertFp16, Channels, bool)
             Mat src_i32 = cvtest::randomMat(dataRng, roiSize, CV_MAKE_TYPE(CV_32S, cn), 0, 0x7c00, false);
             Mat shift_i32 = cvtest::randomMat(dataRng, roiSize, src_i32.type(), -1, 1, false); // values: -1, 0
             src_i32 = src_i32 + (shift_i32 * 0x8000);
-            src_i32.convertTo(src_roi, stype);
+            src_i32.convertTo(src_roi, CV_MAT_DEPTH(stype));
         }
 
         Border dstBorder = randomBorder(0, 0);
@@ -1715,7 +1715,7 @@ PARAM_TEST_CASE(PatchNaNs, Channels, bool)
 
     void generateTestData()
     {
-        const int type = CV_MAKE_TYPE(CV_32F, cn);
+        const ElemType type = CV_MAKE_TYPE(CV_32F, cn);
 
         Size roiSize = randomSize(1, 10);
         Border srcBorder = randomBorder(0, use_roi ? MAX_VALUE : 0);
@@ -1777,7 +1777,9 @@ OCL_TEST_P(Psnr, Mat)
 
 PARAM_TEST_CASE(Reduce, std::pair<MatDepth, MatDepth>, Channels, int, bool)
 {
-    int sdepth, ddepth, cn, dim, dtype;
+    ElemDepth sdepth, ddepth;
+    int cn, dim;
+    ElemType dtype;
     bool use_roi;
 
     TEST_DECLARE_INPUT_PARAMETER(src);
@@ -1795,7 +1797,7 @@ PARAM_TEST_CASE(Reduce, std::pair<MatDepth, MatDepth>, Channels, int, bool)
 
     void generateTestData()
     {
-        const int stype = CV_MAKE_TYPE(sdepth, cn);
+        const ElemType stype = CV_MAKE_TYPE(sdepth, cn);
         dtype = CV_MAKE_TYPE(ddepth, cn);
 
         Size roiSize = randomSize(1, MAX_VALUE);
@@ -1819,8 +1821,8 @@ OCL_TEST_P(ReduceSum, Mat)
     {
         generateTestData();
 
-        OCL_OFF(cv::reduce(src_roi, dst_roi, dim, CV_REDUCE_SUM, dtype));
-        OCL_ON(cv::reduce(usrc_roi, udst_roi, dim, CV_REDUCE_SUM, dtype));
+        OCL_OFF(cv::reduce(src_roi, dst_roi, dim, CV_REDUCE_SUM, CV_MAT_DEPTH(dtype)));
+        OCL_ON(cv::reduce(usrc_roi, udst_roi, dim, CV_REDUCE_SUM, CV_MAT_DEPTH(dtype)));
 
         double eps = ddepth <= CV_32S ? 1 : 7e-4;
         OCL_EXPECT_MATS_NEAR(dst, eps);
@@ -1835,8 +1837,8 @@ OCL_TEST_P(ReduceMax, Mat)
     {
         generateTestData();
 
-        OCL_OFF(cv::reduce(src_roi, dst_roi, dim, CV_REDUCE_MAX, dtype));
-        OCL_ON(cv::reduce(usrc_roi, udst_roi, dim, CV_REDUCE_MAX, dtype));
+        OCL_OFF(cv::reduce(src_roi, dst_roi, dim, CV_REDUCE_MAX, CV_MAT_DEPTH(dtype)));
+        OCL_ON(cv::reduce(usrc_roi, udst_roi, dim, CV_REDUCE_MAX, CV_MAT_DEPTH(dtype)));
 
         OCL_EXPECT_MATS_NEAR(dst, 0);
     }
@@ -1850,8 +1852,8 @@ OCL_TEST_P(ReduceMin, Mat)
     {
         generateTestData();
 
-        OCL_OFF(cv::reduce(src_roi, dst_roi, dim, CV_REDUCE_MIN, dtype));
-        OCL_ON(cv::reduce(usrc_roi, udst_roi, dim, CV_REDUCE_MIN, dtype));
+        OCL_OFF(cv::reduce(src_roi, dst_roi, dim, CV_REDUCE_MIN, CV_MAT_DEPTH(dtype)));
+        OCL_ON(cv::reduce(usrc_roi, udst_roi, dim, CV_REDUCE_MIN, CV_MAT_DEPTH(dtype)));
 
         OCL_EXPECT_MATS_NEAR(dst, 0);
     }
@@ -1865,8 +1867,8 @@ OCL_TEST_P(ReduceAvg, Mat)
     {
         generateTestData();
 
-        OCL_OFF(cv::reduce(src_roi, dst_roi, dim, CV_REDUCE_AVG, dtype));
-        OCL_ON(cv::reduce(usrc_roi, udst_roi, dim, CV_REDUCE_AVG, dtype));
+        OCL_OFF(cv::reduce(src_roi, dst_roi, dim, CV_REDUCE_AVG, CV_MAT_DEPTH(dtype)));
+        OCL_ON(cv::reduce(usrc_roi, udst_roi, dim, CV_REDUCE_AVG, CV_MAT_DEPTH(dtype)));
 
         double eps = ddepth <= CV_32S ? 1 : 6e-6;
         OCL_EXPECT_MATS_NEAR(dst, eps);

--- a/modules/core/test/ocl/test_channels.cpp
+++ b/modules/core/test/ocl/test_channels.cpp
@@ -77,7 +77,7 @@ PARAM_TEST_CASE(Merge, MatDepth, int, bool)
         CV_Assert(nsrc >= 1 && nsrc <= 4);
     }
 
-    int type()
+    ElemType type()
     {
         return CV_MAKE_TYPE(depth, randomInt(1, 3));
     }
@@ -176,16 +176,16 @@ PARAM_TEST_CASE(Split, MatType, Channels, bool)
 
         {
             Border dst1Border = randomBorder(0, use_roi ? MAX_VALUE : 0);
-            randomSubMat(dst1, dst1_roi, roiSize, dst1Border, depth, 2, 11);
+            randomSubMat(dst1, dst1_roi, roiSize, dst1Border, CV_MAKE_TYPE(depth, 1), 2, 11);
 
             Border dst2Border = randomBorder(0, use_roi ? MAX_VALUE : 0);
-            randomSubMat(dst2, dst2_roi, roiSize, dst2Border, depth, -1540, 1740);
+            randomSubMat(dst2, dst2_roi, roiSize, dst2Border, CV_MAKE_TYPE(depth, 1), -1540, 1740);
 
             Border dst3Border = randomBorder(0, use_roi ? MAX_VALUE : 0);
-            randomSubMat(dst3, dst3_roi, roiSize, dst3Border, depth, -1540, 1740);
+            randomSubMat(dst3, dst3_roi, roiSize, dst3Border, CV_MAKE_TYPE(depth, 1), -1540, 1740);
 
             Border dst4Border = randomBorder(0, use_roi ? MAX_VALUE : 0);
-            randomSubMat(dst4, dst4_roi, roiSize, dst4Border, depth, -1540, 1740);
+            randomSubMat(dst4, dst4_roi, roiSize, dst4Border, CV_MAKE_TYPE(depth, 1), -1540, 1740);
         }
 
         UMAT_UPLOAD_INPUT_PARAMETER(src);
@@ -252,7 +252,7 @@ PARAM_TEST_CASE(MixChannels, MatType, bool)
     }
 
     // generate number of channels and create type
-    int type()
+    ElemType type()
     {
         int cn = randomInt(1, 5);
         return CV_MAKE_TYPE(depth, cn);
@@ -368,7 +368,8 @@ OCL_TEST_P(MixChannels, Accuracy)
 
 PARAM_TEST_CASE(InsertChannel, MatDepth, Channels, bool)
 {
-    int depth, cn, coi;
+    ElemDepth depth;
+    int cn, coi;
     bool use_roi;
 
     TEST_DECLARE_INPUT_PARAMETER(src);
@@ -387,7 +388,7 @@ PARAM_TEST_CASE(InsertChannel, MatDepth, Channels, bool)
         coi = randomInt(0, cn);
 
         Border srcBorder = randomBorder(0, use_roi ? MAX_VALUE : 0);
-        randomSubMat(src, src_roi, roiSize, srcBorder, depth, 2, 11);
+        randomSubMat(src, src_roi, roiSize, srcBorder, CV_MAKETYPE(depth, 1), 2, 11);
 
         Border dstBorder = randomBorder(0, use_roi ? MAX_VALUE : 0);
         randomSubMat(dst, dst_roi, roiSize, dstBorder, CV_MAKE_TYPE(depth, cn), 5, 16);
@@ -436,7 +437,7 @@ PARAM_TEST_CASE(ExtractChannel, MatDepth, Channels, bool)
         randomSubMat(src, src_roi, roiSize, srcBorder, CV_MAKE_TYPE(depth, cn), 2, 11);
 
         Border dstBorder = randomBorder(0, use_roi ? MAX_VALUE : 0);
-        randomSubMat(dst, dst_roi, roiSize, dstBorder, depth, 5, 16);
+        randomSubMat(dst, dst_roi, roiSize, dstBorder, CV_MAKETYPE(depth, 1), 5, 16);
 
         UMAT_UPLOAD_INPUT_PARAMETER(src);
         UMAT_UPLOAD_OUTPUT_PARAMETER(dst);

--- a/modules/core/test/ocl/test_gemm.cpp
+++ b/modules/core/test/ocl/test_gemm.cpp
@@ -62,7 +62,8 @@ PARAM_TEST_CASE(Gemm,
                 )
 {
     bool use_roi;
-    int type, flags;
+    ElemType type;
+    int flags;
     bool atrans, btrans, ctrans;
 
     double alpha, beta;

--- a/modules/core/test/ocl/test_matrix_expr.cpp
+++ b/modules/core/test/ocl/test_matrix_expr.cpp
@@ -17,7 +17,7 @@ namespace ocl {
 
 PARAM_TEST_CASE(UMatExpr, MatDepth, Channels)
 {
-    int type;
+    ElemType type;
     Size size;
 
     virtual void SetUp()

--- a/modules/core/test/ocl/test_matrix_operation.cpp
+++ b/modules/core/test/ocl/test_matrix_operation.cpp
@@ -56,7 +56,9 @@ namespace ocl {
 
 PARAM_TEST_CASE(ConvertTo, MatDepth, MatDepth, Channels, bool)
 {
-    int src_depth, cn, dstType;
+    ElemDepth src_depth;
+    int cn;
+    ElemType dstType;
     bool use_roi;
 
     TEST_DECLARE_INPUT_PARAMETER(src);
@@ -93,8 +95,8 @@ OCL_TEST_P(ConvertTo, WithScale_Accuracy)
 
         double alpha = randomDouble(-4, 4), beta = randomDouble(-4, 4);
 
-        OCL_OFF(src_roi.convertTo(dst_roi, dstType, alpha, beta));
-        OCL_ON(usrc_roi.convertTo(udst_roi, dstType, alpha, beta));
+        OCL_OFF(src_roi.convertTo(dst_roi, CV_MAT_DEPTH(dstType), alpha, beta));
+        OCL_ON(usrc_roi.convertTo(udst_roi, CV_MAT_DEPTH(dstType), alpha, beta));
 
         double eps = CV_MAT_DEPTH(dstType) >= CV_32F ? 2e-4 : 1;
         OCL_EXPECT_MATS_NEAR(dst, eps);
@@ -107,8 +109,8 @@ OCL_TEST_P(ConvertTo, NoScale_Accuracy)
     {
         generateTestData();
 
-        OCL_OFF(src_roi.convertTo(dst_roi, dstType, 1, 0));
-        OCL_ON(usrc_roi.convertTo(udst_roi, dstType, 1, 0));
+        OCL_OFF(src_roi.convertTo(dst_roi, CV_MAT_DEPTH(dstType), 1, 0));
+        OCL_ON(usrc_roi.convertTo(udst_roi, CV_MAT_DEPTH(dstType), 1, 0));
 
         double eps = CV_MAT_DEPTH(dstType) >= CV_32F ? 2e-4 : 1;
         OCL_EXPECT_MATS_NEAR(dst, eps);
@@ -137,7 +139,7 @@ PARAM_TEST_CASE(CopyTo, MatDepth, Channels, bool, bool)
 
     void generateTestData(bool one_cn_mask = false)
     {
-        const int type = CV_MAKE_TYPE(depth, cn);
+        const ElemType type = CV_MAKE_TYPE(depth, cn);
 
         Size roiSize = randomSize(1, MAX_VALUE);
         Border srcBorder = randomBorder(0, use_roi ? MAX_VALUE : 0);

--- a/modules/core/test/test_concatenation.cpp
+++ b/modules/core/test/test_concatenation.cpp
@@ -45,13 +45,13 @@ namespace opencv_test { namespace {
 
 TEST(Core_Concatenation, empty)
 {
-    const Mat mat0x5(0,5, CV_8U, Scalar::all(1));
-    const Mat mat10x5(10,5, CV_8U, Scalar::all(1));
-    const Mat mat20x5(20,5, CV_8U, Scalar::all(1));
+    const Mat mat0x5(0, 5, CV_8UC1, Scalar::all(1));
+    const Mat mat10x5(10, 5, CV_8UC1, Scalar::all(1));
+    const Mat mat20x5(20, 5, CV_8UC1, Scalar::all(1));
 
-    const Mat mat5x0(5,0, CV_8U, Scalar::all(1));
-    const Mat mat5x10(5,10, CV_8U, Scalar::all(1));
-    const Mat mat5x20(5,20, CV_8U, Scalar::all(1));
+    const Mat mat5x0(5, 0, CV_8UC1, Scalar::all(1));
+    const Mat mat5x10(5, 10, CV_8UC1, Scalar::all(1));
+    const Mat mat5x20(5, 20, CV_8UC1, Scalar::all(1));
 
     Mat result;
 

--- a/modules/core/test/test_ds.cpp
+++ b/modules/core/test/test_ds.cpp
@@ -764,7 +764,7 @@ int  Core_SeqBaseTest::test_seq_ops( int iters )
                 if( sseq->count == sseq->max_count )
                     break;
 
-                elem_mat = Mat(1, elem_size, CV_8U, elem);
+                elem_mat = Mat(1, elem_size, CV_8UC1, elem);
                 cvtest::randUni( rng, elem_mat, cvScalarAll(0), cvScalarAll(255) );
 
                 whence = op - 1;
@@ -845,7 +845,7 @@ int  Core_SeqBaseTest::test_seq_ops( int iters )
                     break;
 
                 count = cvtest::randInt( rng ) % (sseq->max_count - sseq->count + 1);
-                elem_mat = Mat(1, MAX(count,1) * elem_size, CV_8U, elem);
+                elem_mat = Mat(1, MAX(count, 1) * elem_size, CV_8UC1, elem);
                 cvtest::randUni( rng, elem_mat, cvScalarAll(0), cvScalarAll(255) );
 
                 whence = op - 7;
@@ -1286,7 +1286,7 @@ int  Core_SetTest::test_set_ops( int iters )
             if( sset->free_count == 0 )
                 continue;
 
-            elem_mat = Mat(1, cvset->elem_size, CV_8U, &elem_buf[0]);
+            elem_mat = Mat(1, cvset->elem_size, CV_8UC1, &elem_buf[0]);
             cvtest::randUni( rng, elem_mat, cvScalarAll(0), cvScalarAll(255) );
             elem = (CvSetElem*)&elem_buf[0];
 
@@ -1521,7 +1521,7 @@ int  Core_GraphTest::test_graph_ops( int iters )
 
             if( pure_vtx_size )
             {
-                elem_mat = Mat(1, graph->elem_size, CV_8U, &elem_buf[0]);
+                elem_mat = Mat(1, graph->elem_size, CV_8UC1, &elem_buf[0]);
                 cvtest::randUni( rng, elem_mat, cvScalarAll(0), cvScalarAll(255) );
             }
 
@@ -1631,7 +1631,7 @@ int  Core_GraphTest::test_graph_ops( int iters )
 
             if( pure_edge_size > 0 )
             {
-                elem_mat = Mat(1, graph->edges->elem_size, CV_8U, &elem_buf[0]);
+                elem_mat = Mat(1, graph->edges->elem_size, CV_8UC1, &elem_buf[0]);
                 cvtest::randUni( rng, elem_mat, cvScalarAll(0), cvScalarAll(255) );
             }
             edge = (CvGraphEdge*)&elem_buf[0];

--- a/modules/core/test/test_eigen.cpp
+++ b/modules/core/test/test_eigen.cpp
@@ -73,7 +73,7 @@ public:
 protected:
 
     bool test_values(const cv::Mat& src);												// complex test for eigen without vectors
-    bool check_full(int type);													// compex test for symmetric matrix
+    bool check_full(ElemType type);													// compex test for symmetric matrix
     virtual void run (int) = 0;													// main testing method
 
 protected:
@@ -220,7 +220,7 @@ void Core_EigenTest::print_information(const size_t norm_idx, const cv::Mat& src
 
 bool Core_EigenTest::check_orthogonality(const cv::Mat& U)
 {
-    int type = U.type();
+    ElemType type = U.type();
     double eps_vec = type == CV_32FC1 ? eps_vec_32 : eps_vec_64;
     cv::Mat UUt; cv::mulTransposed(U, UUt, false);
 
@@ -280,7 +280,7 @@ bool Core_EigenTest::check_pairs_order(const cv::Mat& eigen_values)
 
 bool Core_EigenTest::test_pairs(const cv::Mat& src)
 {
-    int type = src.type();
+    ElemType type = src.type();
     double eps_vec = type == CV_32FC1 ? eps_vec_32 : eps_vec_64;
 
     cv::Mat eigen_values, eigen_vectors;
@@ -308,10 +308,13 @@ bool Core_EigenTest::test_pairs(const cv::Mat& src)
     for (int i = 0; i < src.cols; ++i)
     {
         double eigenval = 0;
-        switch (type)
+        if (type == CV_32FC1)
         {
-        case CV_32FC1: eigenval = eigen_values.at<float>(i, 0); break;
-        case CV_64FC1: eigenval = eigen_values.at<double>(i, 0); break;
+            eigenval = eigen_values.at<float>(i, 0);
+        }
+        else if (type == CV_64FC1)
+        {
+            eigenval = eigen_values.at<double>(i, 0);
         }
         cv::Mat rhs_v = eigenval * eigen_vectors_t.col(i);
         rhs_v.copyTo(rhs.col(i));
@@ -359,7 +362,7 @@ bool Core_EigenTest::test_values(const cv::Mat& src)
     return true;
 }
 
-bool Core_EigenTest::check_full(int type)
+bool Core_EigenTest::check_full(ElemType type)
 {
     const int MAX_DEGREE = 7;
 
@@ -393,7 +396,7 @@ static void testEigen(const Mat_<T>& src, const Mat_<T>& expected_eigenvalues, b
     SCOPED_TRACE(runSymmetric ? "cv::eigen" : "cv::eigenNonSymmetric");
 
     int type = traits::Type<T>::value;
-    const T eps = src.type() == CV_32F ? 1e-4f : 1e-6f;
+    const T eps = src.type() == CV_32FC1 ? 1e-4f : 1e-6f;
 
     Mat eigenvalues, eigenvectors, eigenvalues0;
 

--- a/modules/core/test/test_hal_core.cpp
+++ b/modules/core/test/test_hal_core.cpp
@@ -53,12 +53,12 @@ TEST(Core_HAL, mathfuncs)
 {
     for( int hcase = 0; hcase < 6; hcase++ )
     {
-        int depth = hcase % 2 == 0 ? CV_32F : CV_64F;
+        ElemDepth depth = hcase % 2 == 0 ? CV_32F : CV_64F;
         double eps = depth == CV_32F ? 1e-5 : 1e-10;
         int nfunc = hcase / 2;
         int n = 100;
 
-        Mat src(1, n, depth), dst(1, n, depth), dst0(1, n, depth);
+        Mat src(1, n, CV_MAKETYPE(depth, 1)), dst(1, n, CV_MAKETYPE(depth, 1)), dst0(1, n, CV_MAKETYPE(depth, 1));
         randu(src, 1, 10);
 
         double min_hal_t = DBL_MAX, min_ocv_t = DBL_MAX;
@@ -132,7 +132,7 @@ TEST_P(HAL, mat_decomp)
     int hcase = GetParam();
     SCOPED_TRACE(cv::format("hcase=%d", hcase));
     {
-        int depth = hcase % 2 == 0 ? CV_32F : CV_64F;
+        ElemDepth depth = hcase % 2 == 0 ? CV_32F : CV_64F;
         int size = (hcase / 2) % 4;
         size = size == 0 ? 3 : size == 1 ? 4  : size == 2 ? 6 : 15;
         int nfunc = (hcase / 8);
@@ -141,7 +141,7 @@ TEST_P(HAL, mat_decomp)
         if( size == 3 )
             return; // TODO ???
 
-        Mat a0(size, size, depth), a(size, size, depth), b(size, 1, depth), x(size, 1, depth), x0(size, 1, depth);
+        Mat a0(size, size, CV_MAKETYPE(depth, 1)), a(size, size, CV_MAKETYPE(depth, 1)), b(size, 1, CV_MAKETYPE(depth, 1)), x(size, 1, CV_MAKETYPE(depth, 1)), x0(size, 1, CV_MAKETYPE(depth, 1));
         randu(a0, -1, 1);
         a0 = a0*a0.t();
         randu(b, -1, 1);

--- a/modules/core/test/test_io.cpp
+++ b/modules/core/test/test_io.cpp
@@ -5,10 +5,10 @@
 
 namespace opencv_test { namespace {
 
-static SparseMat cvTsGetRandomSparseMat(int dims, const int* sz, int type,
+static SparseMat cvTsGetRandomSparseMat(int dims, const int* sz, ElemDepth type,
                                         int nzcount, double a, double b, RNG& rng)
 {
-    SparseMat m(dims, sz, type);
+    SparseMat m(dims, sz, CV_MAKETYPE(type, 1));
     int i, j;
     CV_Assert(CV_MAT_CN(type) == 1);
     for( i = 0; i < nzcount; i++ )
@@ -114,7 +114,7 @@ protected:
             double test_real = (cvtest::randInt(rng)%2?1:-1)*exp(cvtest::randReal(rng)*18-9);
             string test_string = "vw wv23424rt\"&amp;&lt;&gt;&amp;&apos;@#$@$%$%&%IJUKYILFD@#$@%$&*&() ";
 
-            int depth = cvtest::randInt(rng) % (CV_64F+1);
+            ElemDepth depth = static_cast<ElemDepth>(cvtest::randInt(rng) % (CV_64F + 1));
             int cn = cvtest::randInt(rng) % 4 + 1;
             Mat test_mat(cvtest::randInt(rng)%30+1, cvtest::randInt(rng)%30+1, CV_MAKETYPE(depth, cn));
 
@@ -145,7 +145,7 @@ protected:
                 edge->weight = (float)(i+1);
             }
 
-            depth = cvtest::randInt(rng) % (CV_64F+1);
+            depth = static_cast<ElemDepth>(cvtest::randInt(rng) % (CV_64F + 1));
             cn = cvtest::randInt(rng) % 4 + 1;
             int sz[] = {
                 static_cast<int>(cvtest::randInt(rng)%10+1),
@@ -169,7 +169,7 @@ protected:
                 static_cast<int>(cvtest::randInt(rng)%10+1),
                 static_cast<int>(cvtest::randInt(rng)%10+1),
             };
-            SparseMat test_sparse_mat = cvTsGetRandomSparseMat(4, ssz, cvtest::randInt(rng)%(CV_64F+1),
+            SparseMat test_sparse_mat = cvTsGetRandomSparseMat(4, ssz, static_cast<ElemDepth>(cvtest::randInt(rng)%(CV_64F+1)),
                                                                cvtest::randInt(rng) % 10000, 0, 100, rng);
 
             fs << "test_int" << test_int << "test_real" << test_real << "test_string" << test_string;
@@ -445,7 +445,7 @@ protected:
                 vector<int> mi, mi2, mi3, mi4;
                 vector<Mat> mv, mv2, mv3, mv4;
                 vector<UserDefinedType> vudt, vudt2, vudt3, vudt4;
-                Mat m(10, 9, CV_32F);
+                Mat m(10, 9, CV_32FC1);
                 Mat empty;
                 UserDefinedType udt = { 8, 3.3f };
                 randu(m, 0, 1);
@@ -1037,7 +1037,7 @@ TEST(Core_InputOutput, filestorage_vec_vec_io)
         outputMats[i].resize(i+1);
         for(size_t j = 0; j < outputMats[i].size(); j++)
         {
-            outputMats[i][j] = Mat::eye((int)i + 1, (int)i + 1, CV_8U);
+            outputMats[i][j] = Mat::eye((int)i + 1, (int)i + 1, CV_8UC1);
         }
     }
 
@@ -1086,7 +1086,7 @@ TEST(Core_InputOutput, filestorage_yaml_advanvced_type_heading)
     cv::FileStorage fs(content, cv::FileStorage::READ | cv::FileStorage::MEMORY);
 
     cv::Mat inputMatrix;
-    cv::Mat actualMatrix = cv::Mat::eye(1, 1, CV_64F);
+    cv::Mat actualMatrix = cv::Mat::eye(1, 1, CV_64FC1);
     fs["cameraMatrix"] >> inputMatrix;
 
     ASSERT_EQ(cv::norm(inputMatrix, actualMatrix, NORM_INF), 0.);

--- a/modules/core/test/test_mat.cpp
+++ b/modules/core/test/test_mat.cpp
@@ -946,7 +946,7 @@ void Core_ArrayOpTest::run( int /* start_from */)
 }
 
 
-template <class ElemType>
+template <class T>
 int calcDiffElemCountImpl(const vector<Mat>& mv, const Mat& m)
 {
     int diffElemCount = 0;
@@ -955,12 +955,12 @@ int calcDiffElemCountImpl(const vector<Mat>& mv, const Mat& m)
     {
         for(int x = 0; x < m.cols; x++)
         {
-            const ElemType* mElem = &m.at<ElemType>(y,x*mChannels);
+            const T* mElem = &m.at<T>(y, x*mChannels);
             size_t loc = 0;
             for(size_t i = 0; i < mv.size(); i++)
             {
                 const size_t mvChannel = mv[i].channels();
-                const ElemType* mvElem = &mv[i].at<ElemType>(y,x*(int)mvChannel);
+                const T* mvElem = &mv[i].at<T>(y, x*(int)mvChannel);
                 for(size_t li = 0; li < mvChannel; li++)
                     if(mElem[loc + li] != mvElem[li])
                         diffElemCount++;

--- a/modules/core/test/test_misc.cpp
+++ b/modules/core/test/test_misc.cpp
@@ -8,14 +8,14 @@ namespace opencv_test { namespace {
 TEST(Core_OutputArrayCreate, _1997)
 {
     struct local {
-        static void create(OutputArray arr, Size submatSize, int type)
+        static void create(OutputArray arr, Size submatSize, ElemType type)
         {
             int sizes[] = {submatSize.width, submatSize.height};
             arr.create(sizeof(sizes)/sizeof(sizes[0]), sizes, type);
         }
     };
 
-    Mat mat(Size(512, 512), CV_8U);
+    Mat mat(Size(512, 512), CV_8UC1);
     Size submatSize = Size(256, 256);
 
     ASSERT_NO_THROW(local::create( mat(Rect(Point(), submatSize)), submatSize, mat.type() ));
@@ -136,7 +136,7 @@ TEST(Core_OutputArrayAssign, _Matxf_UMatd)
 
 int fixedType_handler(OutputArray dst)
 {
-    int type = CV_32FC2; // return points only {x, y}
+    ElemType type = CV_32FC2; // return points only {x, y}
     if (dst.fixedType())
     {
         type = dst.type();

--- a/modules/core/test/test_operations.cpp
+++ b/modules/core/test/test_operations.cpp
@@ -122,13 +122,13 @@ bool CV_OperationsTest::TestMat()
 {
     try
     {
-        Mat one_3x1(3, 1, CV_32F, Scalar(1.0));
-        Mat shi_3x1(3, 1, CV_32F, Scalar(1.2));
-        Mat shi_2x1(2, 1, CV_32F, Scalar(-1));
+        Mat one_3x1(3, 1, CV_32FC1, Scalar(1.0));
+        Mat shi_3x1(3, 1, CV_32FC1, Scalar(1.2));
+        Mat shi_2x1(2, 1, CV_32FC1, Scalar(-1));
         Scalar shift = Scalar::all(15);
 
         float data[] = { sqrt(2.f)/2, -sqrt(2.f)/2, 1.f, sqrt(2.f)/2, sqrt(2.f)/2, 10.f };
-        Mat rot_2x3(2, 3, CV_32F, data);
+        Mat rot_2x3(2, 3, CV_32FC1, data);
 
         Mat res = one_3x1 + shi_3x1 + shi_3x1 + shi_3x1;
         res = Mat(Mat(2 * rot_2x3) * res - shi_2x1) + shift;
@@ -138,11 +138,11 @@ bool CV_OperationsTest::TestMat()
         cv::add(tmp, shi_3x1, tmp);
         cv::add(tmp, shi_3x1, tmp);
         cv::gemm(rot_2x3, tmp, 2, shi_2x1, -1, res2, 0);
-        cv::add(res2, Mat(2, 1, CV_32F, shift), res2);
+        cv::add(res2, Mat(2, 1, CV_32FC1, shift), res2);
 
         CHECK_DIFF(res, res2);
 
-        Mat mat4x4(4, 4, CV_32F);
+        Mat mat4x4(4, 4, CV_32FC1);
         cv::randu(mat4x4, Scalar(0), Scalar(10));
 
         Mat roi1 = mat4x4(Rect(Point(1, 1), Size(2, 2)));
@@ -151,9 +151,9 @@ bool CV_OperationsTest::TestMat()
         CHECK_DIFF(roi1, roi2);
         CHECK_DIFF(mat4x4, mat4x4(Rect(Point(0,0), mat4x4.size())));
 
-        Mat intMat10(3, 3, CV_32S, Scalar(10));
-        Mat intMat11(3, 3, CV_32S, Scalar(11));
-        Mat resMat(3, 3, CV_8U, Scalar(255));
+        Mat intMat10(3, 3, CV_32SC1, Scalar(10));
+        Mat intMat11(3, 3, CV_32SC1, Scalar(11));
+        Mat resMat(3, 3, CV_8UC1, Scalar(255));
 
         CHECK_DIFF(resMat, intMat10 == intMat10);
         CHECK_DIFF(resMat, intMat10 <  intMat11);
@@ -172,11 +172,11 @@ bool CV_OperationsTest::TestMat()
         CHECK_DIFF(resMat, 10.0 != intMat11);
         CHECK_DIFF(resMat, intMat11 != 10.0);
 
-        Mat eye =  Mat::eye(3, 3, CV_16S);
-        Mat maskMat4(3, 3, CV_16S, Scalar(4));
-        Mat maskMat1(3, 3, CV_16S, Scalar(1));
-        Mat maskMat5(3, 3, CV_16S, Scalar(5));
-        Mat maskMat0(3, 3, CV_16S, Scalar(0));
+        Mat eye = Mat::eye(3, 3, CV_16SC1);
+        Mat maskMat4(3, 3, CV_16SC1, Scalar(4));
+        Mat maskMat1(3, 3, CV_16SC1, Scalar(1));
+        Mat maskMat5(3, 3, CV_16SC1, Scalar(5));
+        Mat maskMat0(3, 3, CV_16SC1, Scalar(0));
 
         CHECK_DIFF(maskMat0, maskMat4 & maskMat1);
         CHECK_DIFF(maskMat0, Scalar(1) & maskMat4);
@@ -338,9 +338,9 @@ bool CV_OperationsTest::TestMat()
 
         /////////////////////////////
         float matrix_data[] = { 3, 1, -4, -5, 1, 0, 0, 1.1f, 1.5f};
-        Mat mt(3, 3, CV_32F, matrix_data);
+        Mat mt(3, 3, CV_32FC1, matrix_data);
         Mat mi = mt.inv();
-        Mat d1 = Mat::eye(3, 3, CV_32F);
+        Mat d1 = Mat::eye(3, 3, CV_32FC1);
         Mat d2 = d1 * 2;
         MatExpr mt_tr = mt.t();
         MatExpr mi_tr = mi.t();
@@ -383,7 +383,7 @@ bool CV_OperationsTest::TestMat()
         CHECK_DIFF_FLT( (mi * mt) / 2.0, d1 / 2);
 
         Mat mt_mul_2_plus_1;
-        gemm(mt, d1, 2, Mat::ones(3, 3, CV_32F), 1, mt_mul_2_plus_1);
+        gemm(mt, d1, 2, Mat::ones(3, 3, CV_32FC1), 1, mt_mul_2_plus_1);
 
         CHECK_DIFF( (mt * 2.0 + 1.0) * mi, mt_mul_2_plus_1 * mi);        // (A*alpha + beta)*B
         CHECK_DIFF( mi * (mt * 2.0 + 1.0), mi * mt_mul_2_plus_1);        // A*(B*alpha + beta)
@@ -512,7 +512,7 @@ bool CV_OperationsTest::TestTemplateMat()
         cv::add(tmp, shi_3x1, tmp);
         cv::add(tmp, shi_3x1, tmp);
         cv::gemm(rot_2x3, tmp, 2, shi_2x1, -1, res2, 0);
-        cv::add(res2, Mat(2, 1, CV_32F, shift), res2);
+        cv::add(res2, Mat(2, 1, CV_32FC1, shift), res2);
 
         cv::gemm(rot_2x3, one_3x1, 1, shi_2x1, 0, resS2, 0);
         CHECK_DIFF(res, res2);
@@ -773,10 +773,10 @@ bool CV_OperationsTest::TestTemplateMat()
                   cvtest::norm(mvf2[1], mvf[1], CV_C) == 0 );
 
         {
-        Mat a(2,2,CV_32F,1.f);
-        Mat b(1,2,CV_32F,1.f);
-        Mat c = (a*b.t()).t();
-        CV_Assert( cvtest::norm(c, CV_L1) == 4. );
+            Mat a(2, 2, CV_32FC1, 1.f);
+            Mat b(1, 2, CV_32FC1, 1.f);
+            Mat c = (a*b.t()).t();
+            CV_Assert( cvtest::norm(c, CV_L1) == 4. );
         }
 
         bool badarg_catched = false;
@@ -815,7 +815,7 @@ bool CV_OperationsTest::TestTemplateMat()
 bool CV_OperationsTest::TestMatND()
 {
     int sizes[] = { 3, 3, 3};
-    cv::MatND nd(3, sizes, CV_32F);
+    cv::MatND nd(3, sizes, CV_32FC1);
 
     return true;
 }
@@ -985,7 +985,7 @@ bool CV_OperationsTest::operations1()
                 throw test_excep();
         }
 
-        Mat A(1, 32, CV_32F), B;
+        Mat A(1, 32, CV_32FC1), B;
         for( int i = 0; i < A.cols; i++ )
             A.at<float>(i) = (float)(i <= 12 ? i : 24 - i);
         cv::transpose(A, B);
@@ -1006,13 +1006,13 @@ bool CV_OperationsTest::operations1()
 
         Matx33f b(1.f, 2.f, 3.f, 4.f, 5.f, 6.f, 7.f, 8.f, 9.f);
         Mat c;
-        cv::add(Mat::zeros(3, 3, CV_32F), b, c);
+        cv::add(Mat::zeros(3, 3, CV_32FC1), b, c);
         CV_Assert( cvtest::norm(b, c, CV_C) == 0 );
 
-        cv::add(Mat::zeros(3, 3, CV_64F), b, c, noArray(), c.type());
+        cv::add(Mat::zeros(3, 3, CV_64FC1), b, c, noArray(), c.depth());
         CV_Assert( cvtest::norm(b, c, CV_C) == 0 );
 
-        cv::add(Mat::zeros(6, 1, CV_64F), 1, c, noArray(), c.type());
+        cv::add(Mat::zeros(6, 1, CV_64FC1), 1, c, noArray(), c.depth());
         CV_Assert( cvtest::norm(Matx61f(1.f, 1.f, 1.f, 1.f, 1.f, 1.f), c, CV_C) == 0 );
 
         vector<Point2f> pt2d(3);
@@ -1085,7 +1085,7 @@ bool CV_OperationsTest::TestSVD()
         U=decomp.u;
         Vt=decomp.vt;
         W=decomp.w;
-        Mat I = Mat::eye(3, 3, CV_32F);
+        Mat I = Mat::eye(3, 3, CV_32FC1);
 
         if( cvtest::norm(U*U.t(), I, CV_C) > FLT_EPSILON ||
             cvtest::norm(Vt*Vt.t(), I, CV_C) > FLT_EPSILON ||
@@ -1236,7 +1236,7 @@ TEST(Core_SparseMat, iterations) { CV_SparseMatTest test; test.safe_run(); }
 
 TEST(MatTestRoi, adjustRoiOverflow)
 {
-    Mat m(15, 10, CV_32S);
+    Mat m(15, 10, CV_32SC1);
     Mat roi(m, cv::Range(2, 10), cv::Range(3,6));
     int rowsInROI = roi.rows;
     roi.adjustROI(1, 0, 0, 0);
@@ -1254,7 +1254,7 @@ CV_ENUM(SortOrder, SORT_ASCENDING, SORT_DESCENDING)
 
 PARAM_TEST_CASE(sortIdx, MatDepth, SortRowCol, SortOrder, Size, bool)
 {
-    int type;
+    ElemType type;
     Size size;
     int flags;
     bool use_roi;
@@ -1264,7 +1264,7 @@ PARAM_TEST_CASE(sortIdx, MatDepth, SortRowCol, SortOrder, Size, bool)
 
     virtual void SetUp()
     {
-        int depth = GET_PARAM(0);
+        ElemDepth depth = GET_PARAM(0);
         int rowFlags = GET_PARAM(1);
         int orderFlags = GET_PARAM(2);
         size = GET_PARAM(3);
@@ -1281,7 +1281,7 @@ PARAM_TEST_CASE(sortIdx, MatDepth, SortRowCol, SortOrder, Size, bool)
         randomSubMat(src, src_roi, size, srcBorder, type, -100, 100);
 
         Border dstBorder = randomBorder(0, use_roi ? MAX_VALUE : 0);
-        randomSubMat(dst, dst_roi, size, dstBorder, CV_32S, 5, 16);
+        randomSubMat(dst, dst_roi, size, dstBorder, CV_32SC1, 5, 16);
     }
 
     template<typename T>
@@ -1315,7 +1315,7 @@ PARAM_TEST_CASE(sortIdx, MatDepth, SortRowCol, SortOrder, Size, bool)
         ASSERT_EQ(size, dst_roi.size());
         bool isColumn = (flags & SORT_EVERY_COLUMN) == SORT_EVERY_COLUMN;
         size_t N = isColumn ? src_roi.cols : src_roi.rows;
-        Mat values_row((int)N, 1, type), idx_row((int)N, 1, CV_32S);
+        Mat values_row((int)N, 1, type), idx_row((int)N, 1, CV_32SC1);
         for (size_t i = 0; i < N; i++)
         {
             SCOPED_TRACE(cv::format("row/col=%d", (int)i));
@@ -1337,7 +1337,7 @@ PARAM_TEST_CASE(sortIdx, MatDepth, SortRowCol, SortOrder, Size, bool)
             case CV_32S: check_<int>(values_row, idx_row); break;
             case CV_32F: check_<float>(values_row, idx_row); break;
             case CV_64F: check_<double>(values_row, idx_row); break;
-            default: ASSERT_FALSE(true) << "Unsupported type: " << type;
+            default: ASSERT_FALSE(true) << "Unsupported type: " << static_cast<int>(type);
             }
         }
     }

--- a/modules/core/test/test_rand.cpp
+++ b/modules/core/test/test_rand.cpp
@@ -38,7 +38,7 @@ static double chi2_p95(int n)
 bool Core_RandTest::check_pdf(const Mat& hist, double scale,
                             int dist_type, double& refval, double& realval)
 {
-    Mat hist0(hist.size(), CV_32F);
+    Mat hist0(hist.size(), CV_32FC1);
     const int* H = hist.ptr<int>();
     float* H0 = hist0.ptr<float>();
     int i, hsz = hist.cols;
@@ -105,10 +105,10 @@ void Core_RandTest::run( int )
         progress = update_progress( progress, idx, test_case_count, 0 );
         ts->update_context( this, idx, false );
 
-        int depth = cvtest::randInt(rng) % (CV_64F+1);
+        ElemDepth depth = static_cast<ElemDepth>(cvtest::randInt(rng) % (CV_64F + 1));
         int c, cn = (cvtest::randInt(rng) % 4) + 1;
-        int type = CV_MAKETYPE(depth, cn);
-        int dist_type = cvtest::randInt(rng) % (CV_RAND_NORMAL+1);
+        ElemType type = CV_MAKETYPE(depth, cn);
+        ElemType dist_type = static_cast<ElemType>(cvtest::randInt(rng) % (CV_RAND_NORMAL + 1));
         int i, k, SZ = N/cn;
         Scalar A, B;
 
@@ -159,7 +159,7 @@ void Core_RandTest::run( int )
             }
             A[c] = a;
             B[c] = b;
-            hist[c].create(1, hsz, CV_32S);
+            hist[c].create(1, hsz, CV_32SC1);
         }
 
         cv::RNG saved_rng = tested_rng;
@@ -315,8 +315,8 @@ public:
 protected:
     void run(int)
     {
-        Mat a(Size(1280, 720), CV_8U, Scalar(20));
-        Mat af(Size(1280, 720), CV_32F, Scalar(20));
+        Mat a(Size(1280, 720), CV_8UC1, Scalar(20));
+        Mat af(Size(1280, 720), CV_32FC1, Scalar(20));
         theRNG().fill(a, RNG::UNIFORM, -DBL_MAX, DBL_MAX);
         theRNG().fill(af, RNG::UNIFORM, -DBL_MAX, DBL_MAX);
         int n0 = 0, n255 = 0, nx = 0;

--- a/modules/dnn/perf/perf_convolution.cpp
+++ b/modules/dnn/perf/perf_convolution.cpp
@@ -600,7 +600,7 @@ PERF_TEST_P_(Conv, conv)
     Size inSize(inputShape[3], inputShape[2]);
 
     int sz[] = {outChannels, inChannels / groups, kernel.height, kernel.width};
-    Mat weights(4, &sz[0], CV_32F);
+    Mat weights(4, &sz[0], CV_32FC1);
     randu(weights, -1.0f, 1.0f);
 
     LayerParams lp;
@@ -627,12 +627,12 @@ PERF_TEST_P_(Conv, conv)
     lp.blobs.push_back(weights);
     if (hasBias)
     {
-        Mat bias(1, outChannels, CV_32F);
+        Mat bias(1, outChannels, CV_32FC1);
         randu(bias, -1.0f, 1.0f);
         lp.blobs.push_back(bias);
     }
     int inpSz[] = {1, inChannels, inSize.height, inSize.width};
-    Mat input(4, &inpSz[0], CV_32F);
+    Mat input(4, &inpSz[0], CV_32FC1);
     randu(input, -1.0f, 1.0f);
 
     Net net;

--- a/modules/dnn/perf/perf_net.cpp
+++ b/modules/dnn/perf/perf_net.cpp
@@ -234,7 +234,7 @@ PERF_TEST_P_(DNNTestNetwork, YOLOv3)
         throw SkipTestException("");
     Mat sample = imread(findDataFile("dnn/dog416.png", false));
     Mat inp;
-    sample.convertTo(inp, CV_32FC3);
+    sample.convertTo(inp, CV_32F);
     processNet("dnn/yolov3.cfg", "dnn/yolov3.weights", "", inp / 255);
 }
 

--- a/modules/dnn/test/npy_blob.cpp
+++ b/modules/dnn/test/npy_blob.cpp
@@ -84,7 +84,7 @@ Mat blobFromNPY(const std::string& path)
     CV_Assert(getFortranOrder(header) == "False");
     std::vector<int> shape = getShape(header);
 
-    Mat blob(shape, CV_32F);
+    Mat blob(shape, CV_32FC1);
     ifs.read((char*)blob.data, blob.total() * blob.elemSize());
     CV_Assert((size_t)ifs.gcount() == blob.total() * blob.elemSize());
 

--- a/modules/dnn/test/test_backends.cpp
+++ b/modules/dnn/test/test_backends.cpp
@@ -62,7 +62,7 @@ public:
         float* inpData = (float*)inp.data;
         for (int i = 0; i < inp.size[0] * inp.size[1]; ++i)
         {
-            Mat slice(inp.size[2], inp.size[3], CV_32F, inpData);
+            Mat slice(inp.size[2], inp.size[3], CV_32FC1, inpData);
             cv::flip(slice, slice, 1);
             inpData += slice.total();
         }

--- a/modules/dnn/test/test_caffe_importer.cpp
+++ b/modules/dnn/test/test_caffe_importer.cpp
@@ -385,7 +385,7 @@ TEST_P(Test_Caffe_nets, Colorization)
     net.setPreferableTarget(target);
 
     net.getLayer(net.getLayerId("class8_ab"))->blobs.push_back(kernel);
-    net.getLayer(net.getLayerId("conv8_313_rh"))->blobs.push_back(Mat(1, 313, CV_32F, 2.606));
+    net.getLayer(net.getLayerId("conv8_313_rh"))->blobs.push_back(Mat(1, 313, CV_32FC1, 2.606));
 
     net.setInput(inp);
     Mat out = net.forward();

--- a/modules/dnn/test/test_common.hpp
+++ b/modules/dnn/test/test_common.hpp
@@ -179,8 +179,8 @@ static inline void normAssertDetections(cv::Mat ref, cv::Mat out, const char *co
     out = out.reshape(1, out.total() / 7);
 
     cv::Mat refClassIds, testClassIds;
-    ref.col(1).convertTo(refClassIds, CV_32SC1);
-    out.col(1).convertTo(testClassIds, CV_32SC1);
+    ref.col(1).convertTo(refClassIds, CV_32S);
+    out.col(1).convertTo(testClassIds, CV_32S);
     std::vector<float> refScores(ref.col(2)), testScores(out.col(2));
     std::vector<cv::Rect2d> refBoxes = matToBoxes(ref.colRange(3, 7));
     std::vector<cv::Rect2d> testBoxes = matToBoxes(out.colRange(3, 7));

--- a/modules/dnn/test/test_halide_layers.cpp
+++ b/modules/dnn/test/test_halide_layers.cpp
@@ -70,7 +70,7 @@ TEST_P(Test_Halide_layers, Padding)
         lp.name = "testLayer";
 
         int sz[] = {1 + (int)rng(10), 1 + (int)rng(10), 1 + (int)rng(10), 1 + (int)rng(10)};
-        Mat input(4, &sz[0], CV_32F);
+        Mat input(4, &sz[0], CV_32FC1);
         test(lp, input, backend, target);
     }
 }
@@ -109,7 +109,7 @@ TEST_P(Convolution, Accuracy)
         skipCheck = true;
 
     int sz[] = {outChannels, inChannels / group, kernel.height, kernel.width};
-    Mat weights(4, &sz[0], CV_32F);
+    Mat weights(4, &sz[0], CV_32FC1);
     randu(weights, -1.0f, 1.0f);
 
     LayerParams lp;
@@ -129,12 +129,12 @@ TEST_P(Convolution, Accuracy)
     lp.blobs.push_back(weights);
     if (hasBias)
     {
-        Mat bias(1, outChannels, CV_32F);
+        Mat bias(1, outChannels, CV_32FC1);
         randu(bias, -1.0f, 1.0f);
         lp.blobs.push_back(bias);
     }
     int inpSz[] = {1, inChannels, inSize.height, inSize.width};
-    Mat input(4, &inpSz[0], CV_32F);
+    Mat input(4, &inpSz[0], CV_32FC1);
     test(lp, input, backendId, targetId, skipCheck);
     if (skipCheck)
         throw SkipTestException("Skip checks in unstable test");
@@ -176,7 +176,7 @@ TEST_P(Deconvolution, Accuracy)
         throw SkipTestException("");
 
     int sz[] = {inChannels, outChannels / group, kernel.height, kernel.width};
-    Mat weights(4, &sz[0], CV_32F);
+    Mat weights(4, &sz[0], CV_32FC1);
     randu(weights, -1.0f, 1.0f);
 
     LayerParams lp;
@@ -198,12 +198,12 @@ TEST_P(Deconvolution, Accuracy)
     lp.blobs.push_back(weights);
     if (hasBias)
     {
-        Mat bias(1, outChannels, CV_32F);
+        Mat bias(1, outChannels, CV_32FC1);
         randu(bias, -1.0f, 1.0f);
         lp.blobs.push_back(bias);
     }
     int inpSz[] = {1, inChannels, inSize.height, inSize.width};
-    Mat input(4, &inpSz[0], CV_32F);
+    Mat input(4, &inpSz[0], CV_32FC1);
     test(lp, input, backendId, targetId);
 }
 
@@ -249,7 +249,7 @@ TEST_P(LRN, Accuracy)
     lp.name = "testLayer";
 
     int sz[] = {1, inChannels, inSize.height, inSize.width};
-    Mat input(4, &sz[0], CV_32F);
+    Mat input(4, &sz[0], CV_32FC1);
     test(lp, input, backendId, targetId);
 }
 
@@ -293,7 +293,7 @@ TEST_P(AvePooling, Accuracy)
     lp.name = "testLayer";
 
     int sz[] = {1, inChannels, inHeight, inWidth};
-    Mat input(4, &sz[0], CV_32F);
+    Mat input(4, &sz[0], CV_32FC1);
     test(lp, input, backendId, targetId);
 }
 
@@ -331,7 +331,7 @@ TEST_P(MaxPooling, Accuracy)
     lp.name = "testLayer";
 
     int sz[] = {1, inChannels, inSize.height, inSize.width};
-    Mat input(4, &sz[0], CV_32F);
+    Mat input(4, &sz[0], CV_32FC1);
     test(lp, input, backendId, targetId);
 }
 
@@ -359,10 +359,10 @@ TEST_P(FullyConnected, Accuracy)
     if (backendId == DNN_BACKEND_INFERENCE_ENGINE)
         throw SkipTestException("");
 
-    Mat weights(outChannels, inChannels * inSize.height * inSize.width, CV_32F);
+    Mat weights(outChannels, inChannels * inSize.height * inSize.width, CV_32FC1);
     randu(weights, -1.0f, 1.0f);
 
-    Mat bias(1, outChannels, CV_32F);
+    Mat bias(1, outChannels, CV_32FC1);
     randu(bias, -1.0f, 1.0f);
 
     LayerParams lp;
@@ -374,7 +374,7 @@ TEST_P(FullyConnected, Accuracy)
     lp.name = "testLayer";
 
     int sz[] = {1, inChannels, inSize.height, inSize.width};
-    Mat input(4, &sz[0], CV_32F);
+    Mat input(4, &sz[0], CV_32FC1);
     test(lp, input, backendId, targetId);
 }
 
@@ -400,7 +400,7 @@ TEST_P(SoftMax, Accuracy)
     lp.name = "testLayer";
 
     int sz[] = {1, inChannels, 1, 1};
-    Mat input(4, &sz[0], CV_32F);
+    Mat input(4, &sz[0], CV_32FC1);
     test(lp, input, backendId, targetId);
 }
 
@@ -447,7 +447,7 @@ TEST_P(Test_Halide_layers, MaxPoolUnpool)
     net.connect(poolId, 1, unpoolId, 1);
 
     int sz[] = {1, 1, 4, 4};
-    Mat input(4, &sz[0], CV_32F);
+    Mat input(4, &sz[0], CV_32FC1);
     test(input, net, backend, target);
 }
 
@@ -474,7 +474,7 @@ void testInPlaceActivation(LayerParams& lp, Backend backendId, Target targetId)
     net.addLayerToPrev(lp.name, lp.type, lp);
 
     int sz[] = {1, kNumChannels, 10, 10};
-    Mat input(4, &sz[0], CV_32F);
+    Mat input(4, &sz[0], CV_32FC1);
     test(input, net, backendId, targetId);
 }
 
@@ -496,9 +496,9 @@ TEST_P(BatchNorm, Accuracy)
 
     lp.blobs.reserve(4);
     for (int i = 0; i < 3; ++i)
-        lp.blobs.push_back(Mat(1, kNumChannels, CV_32F));
+        lp.blobs.push_back(Mat(1, kNumChannels, CV_32FC1));
     if (hasBias || hasWeights)
-        lp.blobs.push_back(Mat(1, kNumChannels, CV_32F));
+        lp.blobs.push_back(Mat(1, kNumChannels, CV_32FC1));
 
     for (int i = 0; i < lp.blobs.size(); ++i)
         randu(lp.blobs[i], 0.0f, 1.0f);
@@ -578,7 +578,7 @@ TEST_P(Test_Halide_layers, ChannelsPReLU)
     LayerParams lp;
     lp.type = "ChannelsPReLU";
     lp.name = "testLayer";
-    lp.blobs.push_back(Mat(1, kNumChannels, CV_32F));
+    lp.blobs.push_back(Mat(1, kNumChannels, CV_32FC1));
     randu(lp.blobs[0], -1.0f, 1.0f);
 
     testInPlaceActivation(lp, backend, target);
@@ -595,11 +595,11 @@ TEST_P(Scale, Accuracy)
     lp.set("bias_term", hasBias);
     lp.type = "Scale";
     lp.name = "testLayer";
-    lp.blobs.push_back(Mat(1, kNumChannels, CV_32F));
+    lp.blobs.push_back(Mat(1, kNumChannels, CV_32FC1));
     randu(lp.blobs[0], -1.0f, 1.0f);
     if (hasBias)
     {
-        lp.blobs.push_back(Mat(1, kNumChannels, CV_32F));
+        lp.blobs.push_back(Mat(1, kNumChannels, CV_32FC1));
         randu(lp.blobs[1], -1.0f, 1.0f);
     }
     testInPlaceActivation(lp, backendId, targetId);
@@ -636,7 +636,7 @@ TEST_P(Concat, Accuracy)
             break;
 
         int sz[] = {numChannels[i], inSize[0], 1, 1};
-        Mat weights(4, &sz[0], CV_32F);
+        Mat weights(4, &sz[0], CV_32FC1);
         randu(weights, -1.0f, 1.0f);
 
         LayerParams convParam;
@@ -666,7 +666,7 @@ TEST_P(Concat, Accuracy)
     }
 
     int sz[] = {1, inSize[0], inSize[1], inSize[2]};
-    Mat input(4, &sz[0], CV_32F);
+    Mat input(4, &sz[0], CV_32FC1);
     test(input, net, backendId, targetId);
 }
 
@@ -700,7 +700,7 @@ TEST_P(Eltwise, Accuracy)
     for (int i = 0; i < numConv; ++i)
     {
         int sz[] = {inSize[0], inSize[0], 1, 1};
-        Mat weights(4, &sz[0], CV_32F);
+        Mat weights(4, &sz[0], CV_32FC1);
         randu(weights, -1.0f, 1.0f);
 
         LayerParams convParam;
@@ -740,7 +740,7 @@ TEST_P(Eltwise, Accuracy)
     }
 
     int sz[] = {1, inSize[0], inSize[1], inSize[2]};
-    Mat input(4, &sz[0], CV_32F);
+    Mat input(4, &sz[0], CV_32FC1);
     test(input, net, backendId, targetId);
 }
 
@@ -780,7 +780,7 @@ TEST(MixedBackends_Halide_Default_Halide, Accuracy)
     net.addLayerToPrev(lrn2.name, lrn2.type, lrn2);
 
     int sz[] = {4, 3, 5, 6};
-    Mat input(4, &sz[0], CV_32F);
+    Mat input(4, &sz[0], CV_32FC1);
     randu(input, -1.0f, 1.0f);
     net.setInput(input);
     net.setPreferableBackend(DNN_BACKEND_OPENCV);

--- a/modules/dnn/test/test_ie_models.cpp
+++ b/modules/dnn/test/test_ie_models.cpp
@@ -38,7 +38,7 @@ static inline void genData(const std::vector<size_t>& dims, Mat& m, Blob::Ptr& d
     std::vector<int> reversedDims(dims.begin(), dims.end());
     std::reverse(reversedDims.begin(), reversedDims.end());
 
-    m.create(reversedDims, CV_32F);
+    m.create(reversedDims, CV_32FC1);
     randu(m, -1, 1);
 
     dataPtr = make_shared_blob<float>(Precision::FP32, dims, (float*)m.data);

--- a/modules/dnn/test/test_layers.cpp
+++ b/modules/dnn/test/test_layers.cpp
@@ -73,11 +73,11 @@ void runLayer(Ptr<Layer> layer, std::vector<Mat> &inpBlobs, std::vector<Mat> &ou
     layer->getMemoryShapes(inputs, 0, outputs, internals);
     for (size_t i = 0; i < outputs.size(); i++)
     {
-        outp.push_back(Mat(outputs[i], CV_32F));
+        outp.push_back(Mat(outputs[i], CV_32FC1));
     }
     for (size_t i = 0; i < internals.size(); i++)
     {
-        intp.push_back(Mat(internals[i], CV_32F));
+        intp.push_back(Mat(internals[i], CV_32FC1));
     }
 
     layer->finalize(inp, outp);
@@ -175,7 +175,7 @@ void testReshape(const MatShape& inputShape, const MatShape& targetShape,
         params.set("dim", DictValue::arrayInt<int*>(&mask[0], mask.size()));
     }
 
-    Mat inp(inputShape.size(), &inputShape[0], CV_32F);
+    Mat inp(inputShape.size(), &inputShape[0], CV_32FC1);
     std::vector<Mat> inpVec(1, inp);
     std::vector<Mat> outVec, intVec;
 
@@ -270,7 +270,7 @@ TEST_P(Test_Caffe_layers, Fused_Concat)
         net.connect(interLayer, 0, id, 1);
     }
     int shape[] = {1, 2, 3, 4};
-    Mat input(4, shape, CV_32F);
+    Mat input(4, shape, CV_32FC1);
     randu(input, 0.0f, 1.0f);  // [0, 1] to make AbsVal an identity transformation.
 
     net.setInput(input);
@@ -333,7 +333,7 @@ TEST_P(Test_Caffe_layers, Reshape_Split_Slice)
     net.setPreferableBackend(backend);
     net.setPreferableTarget(target);
 
-    Mat input(6, 12, CV_32F);
+    Mat input(6, 12, CV_32FC1);
     RNG rng(0);
     rng.fill(input, RNG::UNIFORM, -1, 1);
 
@@ -381,9 +381,9 @@ public:
         numInp = total(inpShape_);
         numOut = total(outShape_);
 
-        Wh = Mat::ones(4 * numOut, numOut, CV_32F);
-        Wx = Mat::ones(4 * numOut, numInp, CV_32F);
-        b  = Mat::ones(4 * numOut, 1, CV_32F);
+        Wh = Mat::ones(4 * numOut, numOut, CV_32FC1);
+        Wx = Mat::ones(4 * numOut, numInp, CV_32FC1);
+        b  = Mat::ones(4 * numOut, 1, CV_32FC1);
 
         LayerParams lp;
         lp.blobs.resize(3);
@@ -409,12 +409,12 @@ TEST_F(Layer_LSTM_Test, get_set_test)
     init(inpShape, outShape, true, false);
     layer->setOutShape(outShape);
 
-    Mat C((int)outResShape.size(), &outResShape[0], CV_32F);
+    Mat C((int)outResShape.size(), &outResShape[0], CV_32FC1);
     randu(C, -1., 1.);
     Mat H = C.clone();
     randu(H, -1., 1.);
 
-    Mat inp((int)inpResShape.size(), &inpResShape[0], CV_32F);
+    Mat inp((int)inpResShape.size(), &inpResShape[0], CV_32FC1);
     randu(inp, -1., 1.);
 
     inputs.push_back(inp);
@@ -487,11 +487,11 @@ public:
         nH = 64;
         nO = 100;
 
-        Whh = Mat::ones(nH, nH, CV_32F);
-        Wxh = Mat::ones(nH, nX, CV_32F);
-        bh  = Mat::ones(nH, 1, CV_32F);
-        Who = Mat::ones(nO, nH, CV_32F);
-        bo  = Mat::ones(nO, 1, CV_32F);
+        Whh = Mat::ones(nH, nH, CV_32FC1);
+        Wxh = Mat::ones(nH, nX, CV_32FC1);
+        bh  = Mat::ones(nH, 1, CV_32FC1);
+        Who = Mat::ones(nO, nH, CV_32FC1);
+        bo  = Mat::ones(nO, 1, CV_32FC1);
 
         layer = RNNLayer::create(LayerParams());
         layer->setProduceHiddenOutput(true);
@@ -502,7 +502,7 @@ public:
 TEST_F(Layer_RNN_Test, get_set_test)
 {
     int sz[] = { nT, nS, 1, nX };
-    Mat inp(4, sz, CV_32F);
+    Mat inp(4, sz, CV_32FC1);
     randu(inp, -1., 1.);
     inputs.push_back(inp);
     runLayer(layer, inputs, outputs);
@@ -590,7 +590,7 @@ TEST_P(Scale_untrainable, Accuracy)
         weightsShape[1] = 1;  // #inpChannels / group
         weightsShape[2] = 1;  // height
         weightsShape[3] = 1;  // width
-        Mat weights(weightsShape, CV_32F);
+        Mat weights(weightsShape, CV_32FC1);
         weights.setTo(1);
         lp.blobs.push_back(weights);
         net.addLayerToPrev(lp.name, lp.type, lp);
@@ -602,8 +602,8 @@ TEST_P(Scale_untrainable, Accuracy)
     int id = net.addLayerToPrev(lp.name, lp.type, lp);
     net.connect(0, 1, id, 1);
 
-    Mat input(4, inpShape, CV_32F);
-    Mat weights(weightsDims, &inpShape[axis], CV_32F);
+    Mat input(4, inpShape, CV_32FC1);
+    Mat weights(weightsDims, &inpShape[axis], CV_32FC1);
     randu(input, -1, 1);
     randu(weights, -1, 1);
 
@@ -616,7 +616,7 @@ TEST_P(Scale_untrainable, Accuracy)
     net.setPreferableBackend(DNN_BACKEND_OPENCV);
     Mat out = net.forward();
 
-    Mat ref(input.dims, input.size, CV_32F);
+    Mat ref(input.dims, input.size, CV_32FC1);
     float* inpData = (float*)input.data;
     float* refData = (float*)ref.data;
     float* weightsData = (float*)weights.data;
@@ -670,8 +670,8 @@ TEST_P(Crop, Accuracy)
     int id = net.addLayerToPrev(lp.name, lp.type, lp);
     net.connect(0, 1, id, 1);
 
-    Mat inpImage(4, inpShape, CV_32F);
-    Mat sizImage(4, sizShape, CV_32F);
+    Mat inpImage(4, inpShape, CV_32FC1);
+    Mat sizImage(4, sizShape, CV_32FC1);
     randu(inpImage, -1, 1);
     randu(sizImage, -1, 1);
 
@@ -711,7 +711,7 @@ TEST_P(Crop, Accuracy)
     for (int i = axis; i < 4; i++)
         crop_range[i] = Range(offsetVal, sizShape[i] + offsetVal);
 
-    Mat ref(sizImage.dims, sizImage.size, CV_32F);
+    Mat ref(sizImage.dims, sizImage.size, CV_32FC1);
     inpImage(&crop_range[0]).copyTo(ref);
     normAssert(out, ref);
 }
@@ -774,7 +774,7 @@ TEST_P(Test_Caffe_layers, PriorBox_squares)
     Net net;
     int id = net.addLayerToPrev(lp.name, lp.type, lp);
     net.connect(0, 0, id, 1);  // The second input is an input image. Shapes are used for boxes normalization.
-    Mat inp(1, 2, CV_32F);
+    Mat inp(1, 2, CV_32FC1);
     randu(inp, -1, 1);
     net.setInput(blobFromImage(inp));
     net.setPreferableBackend(backend);
@@ -829,7 +829,7 @@ TEST_P(Layer_Test_DWconv_Prelu, Accuracy)
     weightsShape[1] = kernel_depth; // #inpChannels / group
     weightsShape[2] = 3;            // height
     weightsShape[3] = 3;            // width
-    Mat weights(weightsShape, CV_32F, Scalar(1));
+    Mat weights(weightsShape, CV_32FC1, Scalar(1));
 
     //assign weights
     for (int i = 0; i < weightsShape[0]; ++i)
@@ -848,7 +848,7 @@ TEST_P(Layer_Test_DWconv_Prelu, Accuracy)
     lp.blobs.push_back(weights);
 
     //assign bias
-    Mat bias(1, num_output, CV_32F, Scalar(1));
+    Mat bias(1, num_output, CV_32FC1, Scalar(1));
     for (int i = 0; i < 1; ++i)
     {
         for (int j = 0; j < num_output; ++j)
@@ -863,7 +863,7 @@ TEST_P(Layer_Test_DWconv_Prelu, Accuracy)
     LayerParams lpr;
     lpr.name = "dw_relu";
     lpr.type = "PReLU";
-    Mat weightsp(1, num_output, CV_32F, Scalar(1));
+    Mat weightsp(1, num_output, CV_32FC1, Scalar(1));
 
     //assign weights
     for (int i = 0; i < 1; ++i)
@@ -890,7 +890,7 @@ TEST_P(Layer_Test_DWconv_Prelu, Accuracy)
     outShape[1] = num_output;       // outChannels
     outShape[2] = 14;          // height
     outShape[3] = 14;          // width
-    Mat target(outShape, CV_32F, Scalar(1));
+    Mat target(outShape, CV_32FC1, Scalar(1));
     for (int i = 0; i < outShape[0]; ++i)
     {
         for (int j = 0; j < outShape[1]; ++j)
@@ -938,7 +938,7 @@ TEST(Layer_Test_Convolution_DLDT, setInput_uint8)
 {
     Mat inp = blobFromNPY(_tf("blob.npy"));
 
-    Mat inputs[] = {Mat(inp.dims, inp.size, CV_8U), Mat()};
+    Mat inputs[] = {Mat(inp.dims, inp.size, CV_8UC1), Mat()};
     randu(inputs[0], 0, 255);
     inputs[0].convertTo(inputs[1], CV_32F);
 
@@ -996,7 +996,7 @@ TEST_P(Test_DLDT_two_inputs, as_IR)
     Mat out = net.forward();
 
     Mat ref;
-    cv::add(firstInp, secondInp, ref, Mat(), CV_32F);
+    cv::add(firstInp, secondInp, ref, Mat(), CV_32FC1);
     normAssert(out, ref);
 }
 
@@ -1064,7 +1064,7 @@ TEST(Test_DLDT, fused_output)
         lp.set("bias_term", false);
         lp.type = "Convolution";
         lp.name = "testConv";
-        lp.blobs.push_back(Mat({kNumChannels, 1, 1, 1}, CV_32F, Scalar(1)));
+        lp.blobs.push_back(Mat({kNumChannels, 1, 1, 1}, CV_32FC1, Scalar(1)));
         net.addLayerToPrev(lp.name, lp.type, lp);
     }
     {
@@ -1072,7 +1072,7 @@ TEST(Test_DLDT, fused_output)
         lp.set("bias_term", false);
         lp.type = "Scale";
         lp.name = "testScale";
-        lp.blobs.push_back(Mat({kNumChannels}, CV_32F, Scalar(1)));
+        lp.blobs.push_back(Mat({kNumChannels}, CV_32FC1, Scalar(1)));
         net.addLayerToPrev(lp.name, lp.type, lp);
     }
     {
@@ -1098,7 +1098,7 @@ TEST(Test_DLDT, multiple_networks)
         lp.set("bias_term", false);
         lp.type = "Convolution";
         lp.name = format("testConv_%d", i);
-        lp.blobs.push_back(Mat({1, 1, 1, 1}, CV_32F, Scalar(1 + i)));
+        lp.blobs.push_back(Mat({1, 1, 1, 1}, CV_32FC1, Scalar(1 + i)));
         nets[i].addLayerToPrev(lp.name, lp.type, lp);
         nets[i].setPreferableBackend(DNN_BACKEND_INFERENCE_ENGINE);
         nets[i].setInput(Mat({1, 1, 1, 1}, CV_32FC1, Scalar(1)));
@@ -1261,10 +1261,10 @@ TEST(Layer_Test_PoolingIndices, Accuracy)
     lp.type = "Pooling";
     net.addLayerToPrev(lp.name, lp.type, lp);
 
-    Mat inp(10, 10, CV_8U);
+    Mat inp(10, 10, CV_8UC1);
     randu(inp, 0, 255);
 
-    Mat maxValues(5, 5, CV_32F, Scalar(-1)), indices(5, 5, CV_32F, Scalar(-1));
+    Mat maxValues(5, 5, CV_32FC1, Scalar(-1)), indices(5, 5, CV_32FC1, Scalar(-1));
     for (int y = 0; y < 10; ++y)
     {
         int dstY = y / 2;
@@ -1306,7 +1306,7 @@ TEST_P(Layer_Test_ShuffleChannel, Accuracy)
     net.addLayerToPrev(lp.name, lp.type, lp);
 
     const int inpShape[] = {inpShapeVec[0], inpShapeVec[1], inpShapeVec[2], inpShapeVec[3]};
-    Mat inp(4, inpShape, CV_32F);
+    Mat inp(4, inpShape, CV_32FC1);
     randu(inp, 0, 255);
 
     net.setInput(inp);
@@ -1344,7 +1344,7 @@ TEST(Layer_Test_Convolution, relu_fusion)
         lp.name = "testConv";
 
         int weightsShape[] = {1, 1, 1, 1};
-        Mat weights(4, &weightsShape[0], CV_32F, Scalar(1));
+        Mat weights(4, &weightsShape[0], CV_32FC1, Scalar(1));
         lp.blobs.push_back(weights);
         net.addLayerToPrev(lp.name, lp.type, lp);
     }
@@ -1355,7 +1355,7 @@ TEST(Layer_Test_Convolution, relu_fusion)
         net.addLayerToPrev(lp.name, lp.type, lp);
     }
     int sz[] = {1, 1, 2, 3};
-    Mat input(4, &sz[0], CV_32F);
+    Mat input(4, &sz[0], CV_32FC1);
     randu(input, -1.0, -0.1);
     net.setInput(input);
     net.setPreferableBackend(DNN_BACKEND_OPENCV);

--- a/modules/dnn/test/test_misc.cpp
+++ b/modules/dnn/test/test_misc.cpp
@@ -16,7 +16,7 @@ TEST(blobFromImage_4ch, Regression)
 {
     Mat ch[4];
     for(int i = 0; i < 4; i++)
-        ch[i] = Mat::ones(10, 10, CV_8U)*i;
+        ch[i] = Mat::ones(10, 10, CV_8UC1)*i;
 
     Mat img;
     merge(ch, 4, img);
@@ -24,7 +24,7 @@ TEST(blobFromImage_4ch, Regression)
 
     for(int i = 0; i < 4; i++)
     {
-        ch[i] = Mat(img.rows, img.cols, CV_32F, blob.ptr(0, i));
+        ch[i] = Mat(img.rows, img.cols, CV_32FC1, blob.ptr(0, i));
         ASSERT_DOUBLE_EQ(cvtest::norm(ch[i], cv::NORM_INF), i);
     }
 }
@@ -33,7 +33,7 @@ TEST(blobFromImage, allocated)
 {
     int size[] = {1, 3, 4, 5};
     Mat img(size[2], size[3], CV_32FC(size[1]));
-    Mat blob(4, size, CV_32F);
+    Mat blob(4, size, CV_32FC1);
     void* blobData = blob.data;
     dnn::blobFromImage(img, blob, 1.0 / 255, Size(), Scalar(), false, false);
     ASSERT_EQ(blobData, blob.data);
@@ -147,12 +147,12 @@ TEST(LayerFactory, custom_layers)
     LayerFactory::unregisterLayer("CustomType");
 }
 
-typedef testing::TestWithParam<tuple<float, Vec3f, int, tuple<Backend, Target> > > setInput;
+typedef testing::TestWithParam<tuple<float, Vec3f, ElemType, tuple<Backend, Target> > > setInput;
 TEST_P(setInput, normalization)
 {
     const float kScale = get<0>(GetParam());
     const Scalar kMean = get<1>(GetParam());
-    const int dtype    = get<2>(GetParam());
+    const ElemType dtype    = get<2>(GetParam());
     const int backend  = get<0>(get<3>(GetParam()));
     const int target   = get<1>(get<3>(GetParam()));
     const bool kSwapRB = true;
@@ -172,7 +172,7 @@ TEST_P(setInput, normalization)
     net.setPreferableBackend(backend);
     net.setPreferableTarget(target);
 
-    Mat blob = blobFromImage(inp, 1.0, Size(), Scalar(), kSwapRB, /*crop*/false, dtype);
+    Mat blob = blobFromImage(inp, 1.0, Size(), Scalar(), kSwapRB, /*crop*/false, CV_MAT_DEPTH(dtype));
     ASSERT_EQ(blob.type(), dtype);
     net.setInput(blob, "", kScale, kMean);
     Mat out = net.forward();

--- a/modules/dnn/test/test_tf_importer.cpp
+++ b/modules/dnn/test/test_tf_importer.cpp
@@ -633,7 +633,7 @@ TEST(Test_TensorFlow, Mask_RCNN)
     const int numDetections = outDetections.size[2];
 
     int masksSize[] = {1, numDetections, outMasks.size[2], outMasks.size[3]};
-    Mat masks(4, &masksSize[0], CV_32F);
+    Mat masks(4, &masksSize[0], CV_32FC1);
 
     std::vector<cv::Range> srcRanges(4, cv::Range::all());
     std::vector<cv::Range> dstRanges(4, cv::Range::all());

--- a/modules/dnn/test/test_torch_importer.cpp
+++ b/modules/dnn/test/test_torch_importer.cpp
@@ -274,7 +274,7 @@ TEST_P(Test_Torch_nets, OpenFace_accuracy)
 
     Mat sample = imread(findDataFile("cv/shared/lena.png", false));
     Mat sampleF32(sample.size(), CV_32FC3);
-    sample.convertTo(sampleF32, sampleF32.type());
+    sample.convertTo(sampleF32, sampleF32.depth());
     sampleF32 /= 255;
     resize(sampleF32, sampleF32, Size(96, 96), 0, 0, INTER_NEAREST);
 

--- a/modules/features2d/perf/opencl/perf_brute_force_matcher.cpp
+++ b/modules/features2d/perf/opencl/perf_brute_force_matcher.cpp
@@ -55,11 +55,11 @@ namespace ocl {
 
 typedef Size_MatType BruteForceMatcherFixture;
 
-OCL_PERF_TEST_P(BruteForceMatcherFixture, Match, ::testing::Combine(OCL_PERF_ENUM(OCL_SIZE_1, OCL_SIZE_2, OCL_SIZE_3), OCL_PERF_ENUM((MatType)CV_32FC1) ) )
+OCL_PERF_TEST_P(BruteForceMatcherFixture, Match, ::testing::Combine(OCL_PERF_ENUM(OCL_SIZE_1, OCL_SIZE_2, OCL_SIZE_3), OCL_PERF_ENUM(CV_32FC1) ) )
 {
     const Size_MatType_t params = GetParam();
     const Size srcSize = get<0>(params);
-    const int type = get<1>(params);
+    const ElemType type = get<1>(params);
 
     checkDeviceMaxMemoryAllocSize(srcSize, type);
 
@@ -76,11 +76,11 @@ OCL_PERF_TEST_P(BruteForceMatcherFixture, Match, ::testing::Combine(OCL_PERF_ENU
     SANITY_CHECK_MATCHES(matches, 1e-3);
 }
 
-OCL_PERF_TEST_P(BruteForceMatcherFixture, KnnMatch, ::testing::Combine(OCL_PERF_ENUM(OCL_SIZE_1, OCL_SIZE_2, OCL_SIZE_3), OCL_PERF_ENUM((MatType)CV_32FC1) ) )
+OCL_PERF_TEST_P(BruteForceMatcherFixture, KnnMatch, ::testing::Combine(OCL_PERF_ENUM(OCL_SIZE_1, OCL_SIZE_2, OCL_SIZE_3), OCL_PERF_ENUM(CV_32FC1) ) )
 {
     const Size_MatType_t params = GetParam();
     const Size srcSize = get<0>(params);
-    const int type = get<1>(params);
+    const ElemType type = get<1>(params);
 
     checkDeviceMaxMemoryAllocSize(srcSize, type);
 
@@ -100,11 +100,11 @@ OCL_PERF_TEST_P(BruteForceMatcherFixture, KnnMatch, ::testing::Combine(OCL_PERF_
 
 }
 
-OCL_PERF_TEST_P(BruteForceMatcherFixture, RadiusMatch, ::testing::Combine(OCL_PERF_ENUM(OCL_SIZE_1, OCL_SIZE_2, OCL_SIZE_3), OCL_PERF_ENUM((MatType)CV_32FC1) ) )
+OCL_PERF_TEST_P(BruteForceMatcherFixture, RadiusMatch, ::testing::Combine(OCL_PERF_ENUM(OCL_SIZE_1, OCL_SIZE_2, OCL_SIZE_3), OCL_PERF_ENUM(CV_32FC1) ) )
 {
     const Size_MatType_t params = GetParam();
     const Size srcSize = get<0>(params);
-    const int type = get<1>(params);
+    const ElemType type = get<1>(params);
 
     checkDeviceMaxMemoryAllocSize(srcSize, type);
 

--- a/modules/features2d/perf/perf_batchDistance.cpp
+++ b/modules/features2d/perf/perf_batchDistance.cpp
@@ -15,7 +15,7 @@ typedef perf::TestBaseWithParam<Norm_CrossCheck_t> Norm_CrossCheck;
 typedef tuple<MatType, bool> Source_CrossCheck_t;
 typedef perf::TestBaseWithParam<Source_CrossCheck_t> Source_CrossCheck;
 
-void generateData( Mat& query, Mat& train, const int sourceType );
+void generateData( Mat& query, Mat& train, const ElemType sourceType );
 
 PERF_TEST_P(Norm_Destination_CrossCheck, batchDistance_8U,
             testing::Combine(testing::Values((int)NORM_L1, (int)NORM_L2SQR),
@@ -25,7 +25,7 @@ PERF_TEST_P(Norm_Destination_CrossCheck, batchDistance_8U,
             )
 {
     NormType normType = get<0>(GetParam());
-    int destinationType = get<1>(GetParam());
+    ElemType destinationType = get<1>(GetParam());
     bool isCrossCheck = get<2>(GetParam());
     int knn = isCrossCheck ? 1 : 0;
 
@@ -34,7 +34,7 @@ PERF_TEST_P(Norm_Destination_CrossCheck, batchDistance_8U,
     Mat dist;
     Mat ndix;
 
-    generateData(queryDescriptors, trainDescriptors, CV_8U);
+    generateData(queryDescriptors, trainDescriptors, CV_8UC1);
 
     TEST_CYCLE()
     {
@@ -61,11 +61,11 @@ PERF_TEST_P(Norm_CrossCheck, batchDistance_Dest_32S,
     Mat dist;
     Mat ndix;
 
-    generateData(queryDescriptors, trainDescriptors, CV_8U);
+    generateData(queryDescriptors, trainDescriptors, CV_8UC1);
 
     TEST_CYCLE()
     {
-        batchDistance(queryDescriptors, trainDescriptors, dist, CV_32S, (isCrossCheck) ? ndix : noArray(),
+        batchDistance(queryDescriptors, trainDescriptors, dist, CV_32SC1, (isCrossCheck) ? ndix : noArray(),
                       normType, knn, Mat(), 0, isCrossCheck);
     }
 
@@ -79,7 +79,7 @@ PERF_TEST_P(Source_CrossCheck, batchDistance_L2,
                              )
             )
 {
-    int sourceType = get<0>(GetParam());
+    ElemType sourceType = get<0>(GetParam());
     bool isCrossCheck = get<1>(GetParam());
     int knn = isCrossCheck ? 1 : 0;
 
@@ -93,7 +93,7 @@ PERF_TEST_P(Source_CrossCheck, batchDistance_L2,
     declare.time(50);
     TEST_CYCLE()
     {
-        batchDistance(queryDescriptors, trainDescriptors, dist, CV_32F, (isCrossCheck) ? ndix : noArray(),
+        batchDistance(queryDescriptors, trainDescriptors, dist, CV_32FC1, (isCrossCheck) ? ndix : noArray(),
                       NORM_L2, knn, Mat(), 0, isCrossCheck);
     }
 
@@ -116,12 +116,12 @@ PERF_TEST_P(Norm_CrossCheck, batchDistance_32F,
     Mat dist;
     Mat ndix;
 
-    generateData(queryDescriptors, trainDescriptors, CV_32F);
+    generateData(queryDescriptors, trainDescriptors, CV_32FC1);
     declare.time(100);
 
     TEST_CYCLE()
     {
-        batchDistance(queryDescriptors, trainDescriptors, dist, CV_32F, (isCrossCheck) ? ndix : noArray(),
+        batchDistance(queryDescriptors, trainDescriptors, dist, CV_32FC1, (isCrossCheck) ? ndix : noArray(),
                       normType, knn, Mat(), 0, isCrossCheck);
     }
 
@@ -129,7 +129,7 @@ PERF_TEST_P(Norm_CrossCheck, batchDistance_32F,
     if (isCrossCheck) SANITY_CHECK(ndix);
 }
 
-void generateData( Mat& query, Mat& train, const int sourceType )
+void generateData( Mat& query, Mat& train, const ElemType sourceType )
 {
     const int dim = 500;
     const int queryDescCount = 300; // must be even number because we split train data in some cases in two
@@ -140,7 +140,7 @@ void generateData( Mat& query, Mat& train, const int sourceType )
     // Descriptor vector elements are integer values.
     Mat buf( queryDescCount, dim, CV_32SC1 );
     rng.fill( buf, RNG::UNIFORM, Scalar::all(0), Scalar(3) );
-    buf.convertTo( query, sourceType );
+    buf.convertTo( query, CV_MAT_DEPTH(sourceType) );
 
     // Generate train descriptors as follows:
     // copy each query descriptor to train set countFactor times
@@ -148,7 +148,7 @@ void generateData( Mat& query, Mat& train, const int sourceType )
     // in ascending order. General boundaries of the perturbation
     // are (0.f, 1.f).
     train.create( query.rows*countFactor, query.cols, sourceType );
-    float step = (sourceType == CV_8U ? 256.f : 1.f) / countFactor;
+    float step = (sourceType == CV_8UC1 ? 256.f : 1.f) / countFactor;
     for( int qIdx = 0; qIdx < query.rows; qIdx++ )
     {
         Mat queryDescriptor = query.row(qIdx);

--- a/modules/features2d/test/ocl/test_brute_force_matcher.cpp
+++ b/modules/features2d/test/ocl/test_brute_force_matcher.cpp
@@ -81,7 +81,7 @@ PARAM_TEST_CASE(BruteForceMatcher, int, int)
         // Descriptor vector elements are integer values.
         queryBuf.create(queryDescCount, dim, CV_32SC1);
         rng.fill(queryBuf, cv::RNG::UNIFORM, cv::Scalar::all(0), cv::Scalar::all(3));
-        queryBuf.convertTo(queryBuf, CV_32FC1);
+        queryBuf.convertTo(queryBuf, CV_32F);
 
         // Generate train descriptors as follows:
         // copy each query descriptor to train set countFactor times

--- a/modules/features2d/test/test_agast.cpp
+++ b/modules/features2d/test/test_agast.cpp
@@ -90,8 +90,8 @@ void CV_AgastTest::run( int )
         cv::circle(image2, kp.pt, cvRound(kp.size/2), Scalar(255, 0, 0));
     }
 
-    Mat kps1(1, (int)(keypoints1.size() * sizeof(KeyPoint)), CV_8U, &keypoints1[0]);
-    Mat kps2(1, (int)(keypoints2.size() * sizeof(KeyPoint)), CV_8U, &keypoints2[0]);
+    Mat kps1(1, (int)(keypoints1.size() * sizeof(KeyPoint)), CV_8UC1, &keypoints1[0]);
+    Mat kps2(1, (int)(keypoints2.size() * sizeof(KeyPoint)), CV_8UC1, &keypoints2[0]);
 
     FileStorage fs(xml, FileStorage::READ);
     if (!fs.isOpened())

--- a/modules/features2d/test/test_akaze.cpp
+++ b/modules/features2d/test/test_akaze.cpp
@@ -8,7 +8,7 @@ namespace opencv_test { namespace {
 
 TEST(Features2d_AKAZE, detect_and_compute_split)
 {
-    Mat testImg(100, 100, CV_8U);
+    Mat testImg(100, 100, CV_8UC1);
     RNG rng(101);
     rng.fill(testImg, RNG::UNIFORM, Scalar(0), Scalar(255), true);
 

--- a/modules/features2d/test/test_descriptors_regression.impl.hpp
+++ b/modules/features2d/test/test_descriptors_regression.impl.hpp
@@ -30,7 +30,8 @@ static Mat readMatFromBin( const string& filename )
     if( f )
     {
         CV_Assert(4 == sizeof(int));
-        int rows, cols, type, dataSize;
+        int rows, cols, dataSize;
+        ElemType type;
         size_t elements_read1 = fread( (void*)&rows, sizeof(int), 1, f );
         size_t elements_read2 = fread( (void*)&cols, sizeof(int), 1, f );
         size_t elements_read3 = fread( (void*)&type, sizeof(int), 1, f );

--- a/modules/features2d/test/test_fast.cpp
+++ b/modules/features2d/test/test_fast.cpp
@@ -90,8 +90,8 @@ void CV_FastTest::run( int )
         cv::circle(image2, kp.pt, cvRound(kp.size/2), Scalar(255, 0, 0));
     }
 
-    Mat kps1(1, (int)(keypoints1.size() * sizeof(KeyPoint)), CV_8U, &keypoints1[0]);
-    Mat kps2(1, (int)(keypoints2.size() * sizeof(KeyPoint)), CV_8U, &keypoints2[0]);
+    Mat kps1(1, (int)(keypoints1.size() * sizeof(KeyPoint)), CV_8UC1, &keypoints1[0]);
+    Mat kps2(1, (int)(keypoints2.size() * sizeof(KeyPoint)), CV_8UC1, &keypoints2[0]);
 
     FileStorage fs(xml, FileStorage::READ);
     if (!fs.isOpened())

--- a/modules/features2d/test/test_matchers_algorithmic.cpp
+++ b/modules/features2d/test/test_matchers_algorithmic.cpp
@@ -168,7 +168,7 @@ void CV_DescriptorMatcherTest::generateData( Mat& query, Mat& train )
     // Descriptor vector elements are integer values.
     Mat buf( queryDescCount, dim, CV_32SC1 );
     rng.fill( buf, RNG::UNIFORM, Scalar::all(0), Scalar(3) );
-    buf.convertTo( query, CV_32FC1 );
+    buf.convertTo( query, CV_32F );
 
     // Generate train descriptors as follows:
     // copy each query descriptor to train set countFactor times

--- a/modules/features2d/test/test_mser.cpp
+++ b/modules/features2d/test/test_mser.cpp
@@ -87,7 +87,7 @@ TEST(Features2d_MSER, cases)
          255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255
     };
     Mat big_image = imread(cvtest::TS::ptr()->get_data_path() + "mser/puzzle.png", 0);
-    Mat small_image(14, 26, CV_8U, buf);
+    Mat small_image(14, 26, CV_8UC1, buf);
     static const int thresharr[] = { 0, 70, 120, 180, 255 };
 
     const int kDelta = 5;

--- a/modules/highgui/test/test_gui.cpp
+++ b/modules/highgui/test/test_gui.cpp
@@ -63,7 +63,7 @@ void CV_HighGuiOnlyGuiTest::run( int /*start_from */)
     namedWindow("Win");
 
     ts->printf(ts->LOG, "GUI 2\n");
-    Mat m(256, 256, CV_8U);
+    Mat m(256, 256, CV_8UC1);
     m = Scalar(128);
 
     ts->printf(ts->LOG, "GUI 3\n");

--- a/modules/imgcodecs/test/test_grfmt.cpp
+++ b/modules/imgcodecs/test/test_grfmt.cpp
@@ -185,7 +185,7 @@ TEST_P(Imgcodecs_ExtSize, write_imageseq)
         }
         else if (ext == ".pfm")
         {
-            img_gt.convertTo(img_gt, CV_MAKETYPE(CV_32F, img.channels()));
+            img_gt.convertTo(img_gt, CV_32F);
             double n = cvtest::norm(img, img_gt, NORM_L2);
             EXPECT_LT(n, 1.);
             EXPECT_PRED_FORMAT2(cvtest::MatComparator(0, 0), img, img_gt);

--- a/modules/imgcodecs/test/test_png.cpp
+++ b/modules/imgcodecs/test/test_png.cpp
@@ -24,7 +24,7 @@ TEST(Imgcodecs_Png, write_big)
 TEST(Imgcodecs_Png, encode)
 {
     vector<uchar> buff;
-    Mat img_gt = Mat::zeros(1000, 1000, CV_8U);
+    Mat img_gt = Mat::zeros(1000, 1000, CV_8UC1);
     vector<int> param;
     param.push_back(IMWRITE_PNG_COMPRESSION);
     param.push_back(3); //default(3) 0-9.

--- a/modules/imgcodecs/test/test_read_write.cpp
+++ b/modules/imgcodecs/test/test_read_write.cpp
@@ -64,7 +64,7 @@ TEST_P(Imgcodecs_Image, read_write)
     const double thresDbell = 32;
 
     Mat image = imread(_name);
-    image.convertTo(image, CV_8UC3);
+    image.convertTo(image, CV_8U);
     ASSERT_FALSE(image.empty());
 
     imwrite(full_name, image);

--- a/modules/imgcodecs/test/test_tiff.cpp
+++ b/modules/imgcodecs/test/test_tiff.cpp
@@ -83,7 +83,7 @@ TEST(Imgcodecs_Tiff, write_read_16bit_big_little_endian)
 
         EXPECT_EQ(1, img.rows);
         EXPECT_EQ(2, img.cols);
-        EXPECT_EQ(CV_16U, img.type());
+        EXPECT_EQ(CV_16UC1, img.type());
         EXPECT_EQ(sizeof(ushort), img.elemSize());
         EXPECT_EQ(1, img.channels());
         EXPECT_EQ(0xDEAD, img.at<ushort>(0,0));
@@ -112,7 +112,7 @@ TEST(Imgcodecs_Tiff, decode_tile_remainder)
     cv::Mat tiled16 = imread(root + "readwrite/tiled_16.tif", -1);
     ASSERT_FALSE(tiled16.empty());
     ASSERT_TRUE(tiled16.elemSize() == 6);
-    tiled16.convertTo(tiled8, CV_8UC3, 1./256.);
+    tiled16.convertTo(tiled8, CV_8U, 1./256.);
     ASSERT_PRED_FORMAT2(cvtest::MatComparator(2, 0), img, tiled8);
     // What about 32, 64 bit?
 }

--- a/modules/imgproc/perf/opencl/perf_3vs4.cpp
+++ b/modules/imgproc/perf/opencl/perf_3vs4.cpp
@@ -30,7 +30,8 @@ OCL_PERF_TEST_P(_3vs4_Fixture, Resize,
 {
     _3vs4Params params = GetParam();
     const Size srcSize = get<0>(params);
-    const int type = get<1>(params), depth = CV_MAT_DEPTH(type);
+    const ElemType type = get<1>(params);
+    const ElemDepth depth = CV_MAT_DEPTH(type);
     const int mode = get<2>(params);
 
     checkDeviceMaxMemoryAllocSize(srcSize, type);
@@ -48,8 +49,8 @@ OCL_PERF_TEST_P(_3vs4_Fixture, Resize,
 
         for (int i = 0; i < 3; ++i)
         {
-            dsts[i] = UMat(srcSize, depth);
-            srcs[i] = UMat(srcSize, depth);
+            dsts[i] = UMat(srcSize, CV_MAKETYPE(depth, 1));
+            srcs[i] = UMat(srcSize, CV_MAKETYPE(depth, 1));
         }
 
         OCL_TEST_CYCLE()
@@ -64,7 +65,7 @@ OCL_PERF_TEST_P(_3vs4_Fixture, Resize,
     }
     else if (mode == Convert)
     {
-        int type4 = CV_MAKE_TYPE(depth, 4);
+        ElemType type4 = CV_MAKE_TYPE(depth, 4);
         UMat src4(srcSize, type4), dst4(srcSize, type4);
 
         OCL_TEST_CYCLE()
@@ -83,7 +84,8 @@ OCL_PERF_TEST_P(_3vs4_Fixture, Subtract,
 {
     _3vs4Params params = GetParam();
     const Size srcSize = get<0>(params);
-    const int type = get<1>(params), depth = CV_MAT_DEPTH(type);
+    const ElemType type = get<1>(params);
+    const ElemDepth depth = CV_MAT_DEPTH(type);
     const int mode = get<2>(params);
 
     checkDeviceMaxMemoryAllocSize(srcSize, type);
@@ -102,8 +104,8 @@ OCL_PERF_TEST_P(_3vs4_Fixture, Subtract,
 
         for (int i = 0; i < 3; ++i)
         {
-            dsts[i] = UMat(srcSize, depth);
-            srcs[i] = UMat(srcSize, depth);
+            dsts[i] = UMat(srcSize, CV_MAKETYPE(depth, 1));
+            srcs[i] = UMat(srcSize, CV_MAKETYPE(depth, 1));
         }
 
         OCL_TEST_CYCLE()
@@ -118,7 +120,7 @@ OCL_PERF_TEST_P(_3vs4_Fixture, Subtract,
     }
     else if (mode == Convert)
     {
-        int type4 = CV_MAKE_TYPE(depth, 4);
+        ElemType type4 = CV_MAKE_TYPE(depth, 4);
         UMat src4(srcSize, type4), dst4(srcSize, type4);
 
         OCL_TEST_CYCLE()

--- a/modules/imgproc/perf/opencl/perf_accumulate.cpp
+++ b/modules/imgproc/perf/opencl/perf_accumulate.cpp
@@ -60,7 +60,9 @@ OCL_PERF_TEST_P(AccumulateFixture, Accumulate,
 {
     Size_MatType_t params = GetParam();
     const Size srcSize = get<0>(params);
-    const int srcType = get<1>(params), cn = CV_MAT_CN(srcType), dstType = CV_32FC(cn);
+    const ElemType srcType = get<1>(params);
+    int cn = CV_MAT_CN(srcType);
+    ElemType dstType = CV_32FC(cn);
 
     checkDeviceMaxMemoryAllocSize(srcSize, dstType);
 
@@ -81,7 +83,9 @@ OCL_PERF_TEST_P(AccumulateSquareFixture, AccumulateSquare,
 {
     Size_MatType_t params = GetParam();
     const Size srcSize = get<0>(params);
-    const int srcType = get<1>(params), cn = CV_MAT_CN(srcType), dstType = CV_32FC(cn);
+    const ElemType srcType = get<1>(params);
+    int cn = CV_MAT_CN(srcType);
+    ElemType dstType = CV_32FC(cn);
 
     checkDeviceMaxMemoryAllocSize(srcSize, dstType);
 
@@ -102,7 +106,9 @@ OCL_PERF_TEST_P(AccumulateProductFixture, AccumulateProduct,
 {
     Size_MatType_t params = GetParam();
     const Size srcSize = get<0>(params);
-    const int srcType = get<1>(params), cn = CV_MAT_CN(srcType), dstType = CV_32FC(cn);
+    const ElemType srcType = get<1>(params);
+    int cn = CV_MAT_CN(srcType);
+    ElemType dstType = CV_32FC(cn);
 
     checkDeviceMaxMemoryAllocSize(srcSize, dstType);
 
@@ -123,7 +129,9 @@ OCL_PERF_TEST_P(AccumulateWeightedFixture, AccumulateWeighted,
 {
     Size_MatType_t params = GetParam();
     const Size srcSize = get<0>(params);
-    const int srcType = get<1>(params), cn = CV_MAT_CN(srcType), dstType = CV_32FC(cn);
+    const ElemType srcType = get<1>(params);
+    int cn = CV_MAT_CN(srcType);
+    ElemType dstType = CV_32FC(cn);
 
     checkDeviceMaxMemoryAllocSize(srcSize, dstType);
 

--- a/modules/imgproc/perf/opencl/perf_blend.cpp
+++ b/modules/imgproc/perf/opencl/perf_blend.cpp
@@ -60,7 +60,7 @@ OCL_PERF_TEST_P(BlendLinearFixture, BlendLinear, ::testing::Combine(OCL_TEST_SIZ
 {
     Size_MatType_t params = GetParam();
     const Size srcSize = get<0>(params);
-    const int srcType = get<1>(params);
+    const ElemType srcType = get<1>(params);
     const double eps = CV_MAT_DEPTH(srcType) <= CV_32S ? 1.0 : 0.2;
 
     checkDeviceMaxMemoryAllocSize(srcSize, srcType);

--- a/modules/imgproc/perf/opencl/perf_filters.cpp
+++ b/modules/imgproc/perf/opencl/perf_filters.cpp
@@ -64,7 +64,8 @@ OCL_PERF_TEST_P(BlurFixture, Blur,
 {
     const FilterParams params = GetParam();
     const Size srcSize = get<0>(params);
-    const int type = get<1>(params), ksize = get<2>(params), bordertype = BORDER_CONSTANT;
+    const ElemType  type = get<1>(params);
+    const int ksize = get<2>(params), bordertype = BORDER_CONSTANT;
     const double eps = CV_MAT_DEPTH(type) <= CV_32S ? 1 : 1e-5;
 
     checkDeviceMaxMemoryAllocSize(srcSize, type);
@@ -88,7 +89,8 @@ OCL_PERF_TEST_P(SqrBoxFilterFixture, SqrBoxFilter,
 {
     const SqrBoxFilterParams params = GetParam();
     const Size srcSize = get<0>(params), ksize = get<2>(params);
-    const int type = get<1>(params), depth = CV_MAT_DEPTH(type),
+    const ElemType type = get<1>(params);
+    const ElemDepth depth = CV_MAT_DEPTH(type),
             ddepth = depth == CV_8U ? CV_32S : CV_32F;
     const double eps = ddepth == CV_32S ? 0 : 5e-5;
 
@@ -111,7 +113,8 @@ OCL_PERF_TEST_P(LaplacianFixture, Laplacian,
 {
     const FilterParams params = GetParam();
     const Size srcSize = get<0>(params);
-    const int type = get<1>(params), ksize = get<2>(params);
+    const ElemType  type = get<1>(params);
+    const int ksize = get<2>(params);
     const double eps = CV_MAT_DEPTH(type) <= CV_32S ? 1 : 2e-5;
 
     checkDeviceMaxMemoryAllocSize(srcSize, type);
@@ -119,7 +122,7 @@ OCL_PERF_TEST_P(LaplacianFixture, Laplacian,
     UMat src(srcSize, type), dst(srcSize, type);
     declare.in(src, WARMUP_RNG).out(dst);
 
-    OCL_TEST_CYCLE() cv::Laplacian(src, dst, -1, ksize, 1);
+    OCL_TEST_CYCLE() cv::Laplacian(src, dst, CV_DEPTH_AUTO, ksize, 1);
 
     SANITY_CHECK(dst, eps);
 }
@@ -133,7 +136,8 @@ OCL_PERF_TEST_P(ErodeFixture, Erode,
 {
     const FilterParams params = GetParam();
     const Size srcSize = get<0>(params);
-    const int type = get<1>(params), ksize = get<2>(params);
+    const ElemType  type = get<1>(params);
+    const int ksize = get<2>(params);
     const Mat ker = getStructuringElement(MORPH_RECT, Size(ksize, ksize));
 
     checkDeviceMaxMemoryAllocSize(srcSize, type);
@@ -155,7 +159,8 @@ OCL_PERF_TEST_P(DilateFixture, Dilate,
 {
     const FilterParams params = GetParam();
     const Size srcSize = get<0>(params);
-    const int type = get<1>(params), ksize = get<2>(params);
+    const ElemType  type = get<1>(params);
+    const int ksize = get<2>(params);
     const Mat ker = getStructuringElement(MORPH_RECT, Size(ksize, ksize));
 
     checkDeviceMaxMemoryAllocSize(srcSize, type);
@@ -180,7 +185,8 @@ OCL_PERF_TEST_P(MorphologyExFixture, MorphologyEx,
 {
     const MorphologyExParams params = GetParam();
     const Size srcSize = get<0>(params);
-    const int type = get<1>(params), op = get<2>(params), ksize = get<3>(params);
+    const ElemType type = get<1>(params);
+    const int op = get<2>(params), ksize = get<3>(params);
     const Mat ker = getStructuringElement(MORPH_RECT, Size(ksize, ksize));
 
     checkDeviceMaxMemoryAllocSize(srcSize, type);
@@ -202,14 +208,15 @@ OCL_PERF_TEST_P(SobelFixture, Sobel,
 {
     const Size_MatType_t params = GetParam();
     const Size srcSize = get<0>(params);
-    const int type = get<1>(params), dx = 1, dy = 1;
+    const ElemType type = get<1>(params);
+    const int dx = 1, dy = 1;
 
     checkDeviceMaxMemoryAllocSize(srcSize, type, sizeof(float) * 2);
 
     UMat src(srcSize, type), dst(srcSize, type);
     declare.in(src, WARMUP_RNG).out(dst);
 
-    OCL_TEST_CYCLE() cv::Sobel(src, dst, -1, dx, dy);
+    OCL_TEST_CYCLE() cv::Sobel(src, dst, CV_DEPTH_AUTO, dx, dy);
 
     SANITY_CHECK(dst, 1e-6);
 }
@@ -223,7 +230,8 @@ OCL_PERF_TEST_P(ScharrFixture, Scharr,
 {
     const Size_MatType_t params = GetParam();
     const Size srcSize = get<0>(params);
-    const int type = get<1>(params), dx = 1, dy = 0;
+    const ElemType type = get<1>(params);
+    const int dx = 1, dy = 0;
     const double eps = CV_MAT_DEPTH(type) <= CV_32S ? 1 : 1e-5;
 
     checkDeviceMaxMemoryAllocSize(srcSize, type, sizeof(float) * 2);
@@ -231,7 +239,7 @@ OCL_PERF_TEST_P(ScharrFixture, Scharr,
     UMat src(srcSize, type), dst(srcSize, type);
     declare.in(src, WARMUP_RNG).out(dst);
 
-    OCL_TEST_CYCLE() cv::Scharr(src, dst, -1, dx, dy);
+    OCL_TEST_CYCLE() cv::Scharr(src, dst, CV_DEPTH_AUTO, dx, dy);
 
     SANITY_CHECK(dst, eps);
 }
@@ -245,7 +253,8 @@ OCL_PERF_TEST_P(GaussianBlurFixture, GaussianBlur,
 {
     const FilterParams params = GetParam();
     const Size srcSize = get<0>(params);
-    const int type = get<1>(params), ksize = get<2>(params);
+    const ElemType  type = get<1>(params);
+    const int ksize = get<2>(params);
     const double eps = CV_MAT_DEPTH(type) <= CV_32S ? 2 + DBL_EPSILON : 3e-4;
 
     checkDeviceMaxMemoryAllocSize(srcSize, type);
@@ -267,7 +276,8 @@ OCL_PERF_TEST_P(Filter2DFixture, Filter2D,
 {
     const FilterParams params = GetParam();
     const Size srcSize = get<0>(params);
-    const int type = get<1>(params), ksize = get<2>(params);
+    const ElemType type = get<1>(params);
+    const int ksize = get<2>(params);
     const double eps = CV_MAT_DEPTH(type) <= CV_32S ? 1 : 1e-5;
 
     checkDeviceMaxMemoryAllocSize(srcSize, type);
@@ -277,7 +287,7 @@ OCL_PERF_TEST_P(Filter2DFixture, Filter2D,
     declare.in(src, WARMUP_RNG).in(kernel).out(dst);
     randu(kernel, -3.0, 3.0);
 
-    OCL_TEST_CYCLE() cv::filter2D(src, dst, -1, kernel);
+    OCL_TEST_CYCLE() cv::filter2D(src, dst, CV_DEPTH_AUTO, kernel);
 
     SANITY_CHECK(dst, eps);
 }

--- a/modules/imgproc/perf/opencl/perf_imgproc.cpp
+++ b/modules/imgproc/perf/opencl/perf_imgproc.cpp
@@ -133,7 +133,8 @@ OCL_PERF_TEST_P(CopyMakeBorderFixture, CopyMakeBorder,
 {
     const CopyMakeBorderParamType params = GetParam();
     const Size srcSize = get<0>(params);
-    const int type = get<1>(params), borderType = get<2>(params);
+    const ElemType type = get<1>(params);
+    const int borderType = get<2>(params);
 
     checkDeviceMaxMemoryAllocSize(srcSize, type);
 
@@ -156,7 +157,8 @@ OCL_PERF_TEST_P(CornerMinEigenValFixture, CornerMinEigenVal,
 {
     const Size_MatType_t params = GetParam();
     const Size srcSize = get<0>(params);
-    const int type = get<1>(params), borderType = BORDER_REFLECT;
+    const ElemType type = get<1>(params);
+    const int borderType = BORDER_REFLECT;
     const int blockSize = 7, apertureSize = 1 + 2 * 3;
 
     checkDeviceMaxMemoryAllocSize(srcSize, type);
@@ -178,7 +180,8 @@ OCL_PERF_TEST_P(CornerHarrisFixture, CornerHarris,
 {
     const Size_MatType_t params = GetParam();
     const Size srcSize = get<0>(params);
-    const int type = get<1>(params), borderType = BORDER_REFLECT;
+    const ElemType type = get<1>(params);
+    const int borderType = BORDER_REFLECT;
 
     checkDeviceMaxMemoryAllocSize(srcSize, type);
 
@@ -199,7 +202,8 @@ OCL_PERF_TEST_P(PreCornerDetectFixture, PreCornerDetect,
 {
     const Size_MatType_t params = GetParam();
     const Size srcSize = get<0>(params);
-    const int type = get<1>(params), borderType = BORDER_REFLECT;
+    const ElemType type = get<1>(params);
+    const int borderType = BORDER_REFLECT;
 
     checkDeviceMaxMemoryAllocSize(srcSize, type);
 
@@ -220,11 +224,11 @@ OCL_PERF_TEST_P(IntegralFixture, Integral1, ::testing::Combine(OCL_TEST_SIZES, O
 {
     const IntegralParams params = GetParam();
     const Size srcSize = get<0>(params);
-    const int ddepth = get<1>(params);
+    const ElemDepth ddepth = get<1>(params);
 
     checkDeviceMaxMemoryAllocSize(srcSize, ddepth);
 
-    UMat src(srcSize, CV_8UC1), dst(srcSize + Size(1, 1), ddepth);
+    UMat src(srcSize, CV_8UC1), dst(srcSize + Size(1, 1), CV_MAKETYPE(ddepth, 1));
     declare.in(src, WARMUP_RNG).out(dst);
 
     OCL_TEST_CYCLE() cv::integral(src, dst, ddepth);
@@ -236,11 +240,11 @@ OCL_PERF_TEST_P(IntegralFixture, Integral2, ::testing::Combine(OCL_TEST_SIZES, O
 {
     const IntegralParams params = GetParam();
     const Size srcSize = get<0>(params);
-    const int ddepth = get<1>(params);
+    const ElemDepth ddepth = get<1>(params);
 
     checkDeviceMaxMemoryAllocSize(srcSize, ddepth);
 
-    UMat src(srcSize, CV_8UC1), sum(srcSize + Size(1, 1), ddepth), sqsum(srcSize + Size(1, 1), CV_32F);
+    UMat src(srcSize, CV_8UC1), sum(srcSize + Size(1, 1), CV_MAKETYPE(ddepth, 1)), sqsum(srcSize + Size(1, 1), CV_32FC1);
     declare.in(src, WARMUP_RNG).out(sum, sqsum);
 
     OCL_TEST_CYCLE() cv::integral(src, sum, sqsum, ddepth, CV_32F);
@@ -261,7 +265,7 @@ OCL_PERF_TEST_P(ThreshFixture, Threshold,
 {
     const ThreshParams params = GetParam();
     const Size srcSize = get<0>(params);
-    const int srcType = get<1>(params);
+    const ElemType srcType = get<1>(params);
     const int threshType = get<2>(params);
     const double maxValue = 220.0, threshold = 50;
 

--- a/modules/imgproc/perf/opencl/perf_imgwarp.cpp
+++ b/modules/imgproc/perf/opencl/perf_imgwarp.cpp
@@ -67,11 +67,12 @@ OCL_PERF_TEST_P(WarpAffineFixture, WarpAffine,
         { cos(CV_PI / 6), -sin(CV_PI / 6), 100.0  },
         { sin(CV_PI / 6), cos(CV_PI / 6) , -100.0 }
     };
-    Mat M(2, 3, CV_64F, (void *)coeffs);
+    Mat M(2, 3, CV_64FC1, (void *)coeffs);
 
     const WarpAffineParams params = GetParam();
     const Size srcSize = get<0>(params);
-    const int type = get<1>(params), interpolation = get<2>(params);
+    const ElemType type = get<1>(params);
+    const int interpolation = get<2>(params);
     const double eps = CV_MAT_DEPTH(type) <= CV_32S ? 1 : interpolation == INTER_CUBIC ? 2e-3 : 1e-4;
 
     checkDeviceMaxMemoryAllocSize(srcSize, type);
@@ -99,11 +100,12 @@ OCL_PERF_TEST_P(WarpPerspectiveFixture, WarpPerspective,
         {sin(CV_PI / 6), cos(CV_PI / 6), -100.0},
         {0.0, 0.0, 1.0}
     };
-    Mat M(3, 3, CV_64F, (void *)coeffs);
+    Mat M(3, 3, CV_64FC1, (void *)coeffs);
 
     const WarpPerspectiveParams params = GetParam();
     const Size srcSize = get<0>(params);
-    const int type = get<1>(params), interpolation = get<2>(params);
+    const ElemType type = get<1>(params);
+    const int interpolation = get<2>(params);
     const double eps = CV_MAT_DEPTH(type) <= CV_32S ? 1 : 1e-4;
 
     checkDeviceMaxMemoryAllocSize(srcSize, type);
@@ -128,7 +130,8 @@ OCL_PERF_TEST_P(ResizeFixture, Resize,
 {
     const ResizeParams params = GetParam();
     const Size srcSize = get<0>(params);
-    const int type = get<1>(params), interType = get<2>(params);
+    const ElemType type = get<1>(params);
+    const int interType = get<2>(params);
     double scale = get<3>(params);
     const Size dstSize(cvRound(srcSize.width * scale), cvRound(srcSize.height * scale));
     const double eps = CV_MAT_DEPTH(type) <= CV_32S ? 1 : 1e-4;
@@ -152,7 +155,7 @@ OCL_PERF_TEST_P(ResizeAreaFixture, Resize,
 {
     const ResizeAreaParams params = GetParam();
     const Size srcSize = get<0>(params);
-    const int type = get<1>(params);
+    const ElemType type = get<1>(params);
     double scale = get<2>(params);
     const Size dstSize(cvRound(srcSize.width * scale), cvRound(srcSize.height * scale));
     const double eps = CV_MAT_DEPTH(type) <= CV_32S ? 1 : 1e-4;
@@ -176,7 +179,7 @@ OCL_PERF_TEST_P(ResizeLinearExactFixture, Resize,
 {
     const ResizeAreaParams params = GetParam();
     const Size srcSize = get<0>(params);
-    const int type = get<1>(params);
+    const ElemType type = get<1>(params);
     double scale = get<2>(params);
     const Size dstSize(cvRound(srcSize.width * scale), cvRound(srcSize.height * scale));
     const double eps = 1e-4;
@@ -203,7 +206,8 @@ OCL_PERF_TEST_P(RemapFixture, Remap,
 {
     const RemapParams params = GetParam();
     const Size srcSize = get<0>(params);
-    const int type = get<1>(params), interpolation = get<2>(params), borderMode = BORDER_CONSTANT;
+    const ElemType type = get<1>(params);
+    const int interpolation = get<2>(params), borderMode = BORDER_CONSTANT;
     //const double eps = CV_MAT_DEPTH(type) <= CV_32S ? 1 : 1e-4;
 
     checkDeviceMaxMemoryAllocSize(srcSize, type);

--- a/modules/imgproc/perf/opencl/perf_matchTemplate.cpp
+++ b/modules/imgproc/perf/opencl/perf_matchTemplate.cpp
@@ -23,10 +23,10 @@ OCL_PERF_TEST_P(ImgSize_TmplSize_Method_MatType, MatchTemplate,
     const ImgSize_TmplSize_Method_MatType_t params = GetParam();
     const Size imgSz = get<0>(params), tmplSz = get<1>(params);
     const int method = get<2>(params);
-    int type = get<3>(GetParam());
+    ElemType type = get<3>(GetParam());
 
     UMat img(imgSz, type), tmpl(tmplSz, type);
-    UMat result(imgSz - tmplSz + Size(1, 1), CV_32F);
+    UMat result(imgSz - tmplSz + Size(1, 1), CV_32FC1);
 
     declare.in(img, tmpl, WARMUP_RNG).out(result);
 
@@ -52,11 +52,11 @@ OCL_PERF_TEST_P(CV_TM_CCORRFixture, matchTemplate,
 {
     const Size_MatType_t params = GetParam();
     const Size srcSize = get<0>(params), templSize(5, 5);
-    const int type = get<1>(params);
+    const ElemType type = get<1>(params);
 
     UMat src(srcSize, type), templ(templSize, type);
     const Size dstSize(src.cols - templ.cols + 1, src.rows - templ.rows + 1);
-    UMat dst(dstSize, CV_32F);
+    UMat dst(dstSize, CV_32FC1);
 
     declare.in(src, templ, WARMUP_RNG).out(dst);
 

--- a/modules/imgproc/perf/opencl/perf_pyramid.cpp
+++ b/modules/imgproc/perf/opencl/perf_pyramid.cpp
@@ -61,7 +61,7 @@ OCL_PERF_TEST_P(PyrDownFixture, PyrDown,
 {
     const Size_MatType_t params = GetParam();
     const Size srcSize = get<0>(params);
-    const int type = get<1>(params);
+    const ElemType type = get<1>(params);
     const Size dstSize((srcSize.height + 1) >> 1, (srcSize.width + 1) >> 1);
     const double eps = CV_MAT_DEPTH(type) <= CV_32S ? 1 : 1e-5;
 
@@ -85,7 +85,7 @@ OCL_PERF_TEST_P(PyrUpFixture, PyrUp,
 {
     const Size_MatType_t params = GetParam();
     const Size srcSize = get<0>(params);
-    const int type = get<1>(params);
+    const ElemType type = get<1>(params);
     const Size dstSize(srcSize.height << 1, srcSize.width << 1);
     const double eps = CV_MAT_DEPTH(type) <= CV_32S ? 1 : 1e-5;
 
@@ -109,7 +109,8 @@ OCL_PERF_TEST_P(BuildPyramidFixture, BuildPyramid,
 {
     const Size_MatType_t params = GetParam();
     const Size srcSize = get<0>(params);
-    const int type = get<1>(params), maxLevel = 5;
+    const ElemType type = get<1>(params);
+    const int maxLevel = 5;
     const double eps = CV_MAT_DEPTH(type) <= CV_32S ? 1 : 1e-5;
 
     checkDeviceMaxMemoryAllocSize(srcSize, type);

--- a/modules/imgproc/perf/perf_accumulate.cpp
+++ b/modules/imgproc/perf/perf_accumulate.cpp
@@ -22,7 +22,7 @@ PERF_TEST_P( Size_MatType, Accumulate,
 #endif
 {
     Size sz = get<0>(GetParam());
-    int dstType = get<1>(GetParam());
+    ElemType dstType = get<1>(GetParam());
 
     Mat src(sz, CV_8UC1);
     Mat dst(sz, dstType);
@@ -52,7 +52,7 @@ PERF_TEST_P( Size_MatType, AccumulateSquare,
 #endif
 {
     Size sz = get<0>(GetParam());
-    int dstType = get<1>(GetParam());
+    ElemType dstType = get<1>(GetParam());
 
     Mat src(sz, CV_8UC1);
     Mat dst(sz, dstType);
@@ -82,7 +82,7 @@ PERF_TEST_P( Size_MatType, AccumulateWeighted,
 #endif
 {
     Size sz = get<0>(GetParam());
-    int dstType = get<1>(GetParam());
+    ElemType dstType = get<1>(GetParam());
 
     Mat src(sz, CV_8UC1);
     Mat dst(sz, dstType);

--- a/modules/imgproc/perf/perf_bilateral.cpp
+++ b/modules/imgproc/perf/perf_bilateral.cpp
@@ -5,20 +5,19 @@
 
 namespace opencv_test {
 
-CV_ENUM(Mat_Type, CV_8UC1, CV_8UC3, CV_32FC1, CV_32FC3)
-
-typedef TestBaseWithParam< tuple<Size, int, Mat_Type> > TestBilateralFilter;
+typedef TestBaseWithParam< tuple<Size, int, MatType> > TestBilateralFilter;
 
 PERF_TEST_P( TestBilateralFilter, BilateralFilter,
              Combine(
                 Values( szVGA, sz1080p ), // image size
                 Values( 3, 5 ), // d
-                Mat_Type::all() // image type
+                Values(CV_8UC1, CV_8UC3, CV_32FC1, CV_32FC3) // image type
              )
 )
 {
     Size sz;
-    int d, type;
+    int d;
+    ElemType type;
     const double sigmaColor = 1., sigmaSpace = 1.;
 
     sz         = get<0>(GetParam());

--- a/modules/imgproc/perf/perf_blur.cpp
+++ b/modules/imgproc/perf/perf_blur.cpp
@@ -17,7 +17,7 @@ PERF_TEST_P(Size_MatType_kSize, medianBlur,
             )
 {
     Size size = get<0>(GetParam());
-    int type = get<1>(GetParam());
+    ElemType type = get<1>(GetParam());
     int ksize = get<2>(GetParam());
 
     Mat src(size, type);
@@ -54,7 +54,7 @@ PERF_TEST_P(Size_MatType_BorderType3x3, gaussianBlur3x3,
             )
 {
     Size size = get<0>(GetParam());
-    int type = get<1>(GetParam());
+    ElemType type = get<1>(GetParam());
     BorderType3x3 btype = get<2>(GetParam());
 
     Mat src(size, type);
@@ -76,7 +76,7 @@ PERF_TEST_P(Size_MatType_BorderType3x3, blur3x3,
             )
 {
     Size size = get<0>(GetParam());
-    int type = get<1>(GetParam());
+    ElemType type = get<1>(GetParam());
     BorderType3x3 btype = get<2>(GetParam());
 
     Mat src(size, type);
@@ -98,7 +98,7 @@ PERF_TEST_P(Size_MatType_BorderType, blur16x16,
             )
 {
     Size size = get<0>(GetParam());
-    int type = get<1>(GetParam());
+    ElemType type = get<1>(GetParam());
     BorderType btype = get<2>(GetParam());
     double eps = 1e-3;
 
@@ -123,7 +123,7 @@ PERF_TEST_P(Size_MatType_BorderType3x3, box3x3,
             )
 {
     Size size = get<0>(GetParam());
-    int type = get<1>(GetParam());
+    ElemType type = get<1>(GetParam());
     BorderType3x3 btype = get<2>(GetParam());
 
     Mat src(size, type);
@@ -131,7 +131,7 @@ PERF_TEST_P(Size_MatType_BorderType3x3, box3x3,
 
     declare.in(src, WARMUP_RNG).out(dst);
 
-    TEST_CYCLE() boxFilter(src, dst, -1, Size(3,3), Point(-1,-1), false, btype);
+    TEST_CYCLE() boxFilter(src, dst, CV_DEPTH_AUTO, Size(3, 3), Point(-1, -1), false, btype);
 
     SANITY_CHECK(dst, 1e-6, ERROR_RELATIVE);
 }
@@ -153,7 +153,7 @@ PERF_TEST_P(Size_ksize_BorderType, box_CV8U_CV16U,
 
     declare.in(src, WARMUP_RNG).out(dst);
 
-    TEST_CYCLE() boxFilter(src, dst, CV_16UC1, Size(ksize, ksize), Point(-1,-1), false, btype);
+    TEST_CYCLE() boxFilter(src, dst, CV_16U, Size(ksize, ksize), Point(-1,-1), false, btype);
 
     SANITY_CHECK(dst, 1e-6, ERROR_RELATIVE);
 }
@@ -167,7 +167,7 @@ PERF_TEST_P(Size_MatType_BorderType3x3, box3x3_inplace,
             )
 {
     Size size = get<0>(GetParam());
-    int type = get<1>(GetParam());
+    ElemType type = get<1>(GetParam());
     BorderType3x3 btype = get<2>(GetParam());
 
     Mat src(size, type);
@@ -179,7 +179,7 @@ PERF_TEST_P(Size_MatType_BorderType3x3, box3x3_inplace,
     {
         src.copyTo(dst);
         startTimer();
-        boxFilter(dst, dst, -1, Size(3,3), Point(-1,-1), false, btype);
+        boxFilter(dst, dst, CV_DEPTH_AUTO, Size(3, 3), Point(-1, -1), false, btype);
         stopTimer();
     }
 
@@ -195,7 +195,7 @@ PERF_TEST_P(Size_MatType_BorderType, gaussianBlur5x5,
             )
 {
     Size size = get<0>(GetParam());
-    int type = get<1>(GetParam());
+    ElemType type = get<1>(GetParam());
     BorderType btype = get<2>(GetParam());
 
     Mat src(size, type);
@@ -217,7 +217,7 @@ PERF_TEST_P(Size_MatType_BorderType, blur5x5,
             )
 {
     Size size = get<0>(GetParam());
-    int type = get<1>(GetParam());
+    ElemType type = get<1>(GetParam());
     BorderType btype = get<2>(GetParam());
 
     Mat src(size, type);

--- a/modules/imgproc/perf/perf_distanceTransform.cpp
+++ b/modules/imgproc/perf/perf_distanceTransform.cpp
@@ -7,10 +7,9 @@ namespace opencv_test {
 
 CV_ENUM(DistanceType, DIST_L1, DIST_L2 , DIST_C)
 CV_ENUM(MaskSize, DIST_MASK_3, DIST_MASK_5, DIST_MASK_PRECISE)
-CV_ENUM(DstType, CV_8U, CV_32F)
 CV_ENUM(LabelType, DIST_LABEL_CCOMP, DIST_LABEL_PIXEL)
 
-typedef tuple<Size, DistanceType, MaskSize, DstType> SrcSize_DistType_MaskSize_DstType;
+typedef tuple<Size, DistanceType, MaskSize, MatType> SrcSize_DistType_MaskSize_DstType;
 typedef tuple<Size, DistanceType, MaskSize, LabelType> SrcSize_DistType_MaskSize_LabelType;
 typedef perf::TestBaseWithParam<SrcSize_DistType_MaskSize_DstType> DistanceTransform_Test;
 typedef perf::TestBaseWithParam<SrcSize_DistType_MaskSize_LabelType> DistanceTransform_NeedLabels_Test;
@@ -20,16 +19,16 @@ PERF_TEST_P(DistanceTransform_Test, distanceTransform,
                 testing::Values(cv::Size(640, 480), cv::Size(800, 600), cv::Size(1024, 768), cv::Size(1280, 1024)),
                 DistanceType::all(),
                 MaskSize::all(),
-                DstType::all()
+                Values(CV_8U, CV_32F)
                 )
             )
 {
     Size srcSize = get<0>(GetParam());
     int distanceType = get<1>(GetParam());
     int maskSize = get<2>(GetParam());
-    int dstType = get<3>(GetParam());
+    ElemType dstType = get<3>(GetParam());
 
-    Mat src(srcSize, CV_8U);
+    Mat src(srcSize, CV_8UC1);
     Mat dst(srcSize, dstType);
 
     declare
@@ -58,9 +57,9 @@ PERF_TEST_P(DistanceTransform_NeedLabels_Test, distanceTransform_NeedLabels,
     int maskSize = get<2>(GetParam());
     int labelType = get<3>(GetParam());
 
-    Mat src(srcSize, CV_8U);
-    Mat label(srcSize, CV_32S);
-    Mat dst(srcSize, CV_32F);
+    Mat src(srcSize, CV_8UC1);
+    Mat label(srcSize, CV_32SC1);
+    Mat dst(srcSize, CV_32FC1);
 
     declare
         .in(src, WARMUP_RNG)

--- a/modules/imgproc/perf/perf_filter2d.cpp
+++ b/modules/imgproc/perf/perf_filter2d.cpp
@@ -34,7 +34,7 @@ PERF_TEST_P( TestFilter2d, Filter2d,
 
     declare.in(src, WARMUP_RNG).out(dst).time(20);
 
-    TEST_CYCLE() cv::filter2D(src, dst, CV_8UC4, kernel, Point(1, 1), 0., borderMode);
+    TEST_CYCLE() cv::filter2D(src, dst, CV_8U, kernel, Point(1, 1), 0., borderMode);
 
     SANITY_CHECK(dst, 1);
 }
@@ -61,7 +61,7 @@ PERF_TEST_P(TestFilter2d, Filter2d_ovx,
 
     declare.in(src, WARMUP_RNG).out(dst).time(20);
 
-    TEST_CYCLE() cv::filter2D(src, dst, CV_16SC1, kernel, Point(kSize / 2, kSize / 2), 0., borderMode);
+    TEST_CYCLE() cv::filter2D(src, dst, CV_16S, kernel, Point(kSize / 2, kSize / 2), 0., borderMode);
 
     SANITY_CHECK(dst, 1);
 }

--- a/modules/imgproc/perf/perf_floodfill.cpp
+++ b/modules/imgproc/perf/perf_floodfill.cpp
@@ -9,7 +9,7 @@
 
 namespace opencv_test {
 
-typedef tuple<string, Point, int, int, int, int> Size_Source_Fl_t;
+typedef tuple<string, Point, int, int, int, MatDepth> Size_Source_Fl_t;
 typedef perf::TestBaseWithParam<Size_Source_Fl_t> Size_Source_Fl;
 
 PERF_TEST_P(Size_Source_Fl, floodFill1, Combine(
@@ -29,7 +29,7 @@ PERF_TEST_P(Size_Source_Fl, floodFill1, Combine(
     int connectivity = get<2>(GetParam());
     int colorType = get<3>(GetParam());
     int modeType = get<4>(GetParam());
-    int imdepth = get<5>(GetParam());
+    ElemDepth imdepth = get<5>(GetParam());
 
     Mat image0 = imread(filename, colorType);
 

--- a/modules/imgproc/perf/perf_histogram.cpp
+++ b/modules/imgproc/perf/perf_histogram.cpp
@@ -103,7 +103,7 @@ PERF_TEST_P(MatSize, equalizeHist,
             )
 {
     Size size = GetParam();
-    Mat source(size.height, size.width, CV_8U);
+    Mat source(size.height, size.width, CV_8UC1);
     Mat destination;
     declare.in(source, WARMUP_RNG);
 

--- a/modules/imgproc/perf/perf_integral.cpp
+++ b/modules/imgproc/perf/perf_integral.cpp
@@ -17,11 +17,11 @@ PERF_TEST_P(Size_MatType_OutMatDepth, integral,
             )
 {
     Size sz = get<0>(GetParam());
-    int matType = get<1>(GetParam());
-    int sdepth = get<2>(GetParam());
+    ElemType matType = get<1>(GetParam());
+    ElemDepth sdepth = get<2>(GetParam());
 
     Mat src(sz, matType);
-    Mat sum(sz, sdepth);
+    Mat sum(sz, CV_MAKETYPE(sdepth, 1));
 
     declare.in(src, WARMUP_RNG).out(sum);
 
@@ -39,12 +39,12 @@ PERF_TEST_P(Size_MatType_OutMatDepth, integral_sqsum,
             )
 {
     Size sz = get<0>(GetParam());
-    int matType = get<1>(GetParam());
-    int sdepth = get<2>(GetParam());
+    ElemType matType = get<1>(GetParam());
+    ElemDepth sdepth = get<2>(GetParam());
 
     Mat src(sz, matType);
-    Mat sum(sz, sdepth);
-    Mat sqsum(sz, sdepth);
+    Mat sum(sz, CV_MAKETYPE(sdepth, 1));
+    Mat sqsum(sz, CV_MAKETYPE(sdepth, 1));
 
     declare.in(src, WARMUP_RNG).out(sum, sqsum);
     declare.time(100);
@@ -64,13 +64,13 @@ PERF_TEST_P( Size_MatType_OutMatDepth, integral_sqsum_tilted,
              )
 {
     Size sz = get<0>(GetParam());
-    int matType = get<1>(GetParam());
-    int sdepth = get<2>(GetParam());
+    ElemType matType = get<1>(GetParam());
+    ElemDepth sdepth = get<2>(GetParam());
 
     Mat src(sz, matType);
-    Mat sum(sz, sdepth);
-    Mat sqsum(sz, sdepth);
-    Mat tilted(sz, sdepth);
+    Mat sum(sz, CV_MAKETYPE(sdepth, 1));
+    Mat sqsum(sz, CV_MAKETYPE(sdepth, 1));
+    Mat tilted(sz, CV_MAKETYPE(sdepth, 1));
 
     declare.in(src, WARMUP_RNG).out(sum, sqsum, tilted);
     declare.time(100);

--- a/modules/imgproc/perf/perf_matchTemplate.cpp
+++ b/modules/imgproc/perf/perf_matchTemplate.cpp
@@ -27,7 +27,7 @@ PERF_TEST_P(ImgSize_TmplSize_Method, matchTemplateSmall,
 
     Mat img(imgSz, CV_8UC1);
     Mat tmpl(tmplSz, CV_8UC1);
-    Mat result(imgSz - tmplSz + Size(1,1), CV_32F);
+    Mat result(imgSz - tmplSz + Size(1,1), CV_32FC1);
 
     declare
         .in(img, WARMUP_RNG)
@@ -61,7 +61,7 @@ PERF_TEST_P(ImgSize_TmplSize_Method, matchTemplateBig,
 
     Mat img(imgSz, CV_8UC1);
     Mat tmpl(tmplSz, CV_8UC1);
-    Mat result(imgSz - tmplSz + Size(1,1), CV_32F);
+    Mat result(imgSz - tmplSz + Size(1,1), CV_32FC1);
 
     declare
         .in(img, WARMUP_RNG)

--- a/modules/imgproc/perf/perf_moments.cpp
+++ b/modules/imgproc/perf/perf_moments.cpp
@@ -24,13 +24,13 @@ PERF_TEST_P(MomentsFixture_val, Moments1,
     const bool binaryImage = get<2>(params);
 
     cv::Moments m;
-    Mat src(srcSize, srcDepth);
+    Mat src(srcSize, CV_MAKETYPE(srcDepth, 1));
     declare.in(src, WARMUP_RNG);
 
     TEST_CYCLE() m = cv::moments(src, binaryImage);
 
     int len = (int)sizeof(cv::Moments) / sizeof(double);
-    cv::Mat mat(1, len, CV_64F, (void*)&m);
+    cv::Mat mat(1, len, CV_64FC1, (void*)&m);
     //adding 1 to moments to avoid accidental tests fail on values close to 0
     mat += 1;
 

--- a/modules/imgproc/perf/perf_morph.cpp
+++ b/modules/imgproc/perf/perf_morph.cpp
@@ -11,7 +11,7 @@ namespace opencv_test {
 PERF_TEST_P(Size_MatType, erode, TYPICAL_MATS_MORPH)
 {
     Size sz = get<0>(GetParam());
-    int type = get<1>(GetParam());
+    ElemType type = get<1>(GetParam());
 
     Mat src(sz, type);
     Mat dst(sz, type);
@@ -27,7 +27,7 @@ PERF_TEST_P(Size_MatType, erode, TYPICAL_MATS_MORPH)
 PERF_TEST_P(Size_MatType, dilate, TYPICAL_MATS_MORPH)
 {
     Size sz = get<0>(GetParam());
-    int type = get<1>(GetParam());
+    ElemType type = get<1>(GetParam());
 
     Mat src(sz, type);
     Mat dst(sz, type);

--- a/modules/imgproc/perf/perf_pyramids.cpp
+++ b/modules/imgproc/perf/perf_pyramids.cpp
@@ -12,7 +12,7 @@ PERF_TEST_P(Size_MatType, pyrDown, testing::Combine(
             )
 {
     Size sz = get<0>(GetParam());
-    int matType = get<1>(GetParam());
+    ElemType matType = get<1>(GetParam());
     const double eps = CV_MAT_DEPTH(matType) <= CV_32S ? 1 : 1e-5;
     perf::ERROR_TYPE error_type = CV_MAT_DEPTH(matType) <= CV_32S ? ERROR_ABSOLUTE : ERROR_RELATIVE;
 
@@ -33,7 +33,7 @@ PERF_TEST_P(Size_MatType, pyrDown_ovx, testing::Combine(
 )
 {
     Size sz = get<0>(GetParam());
-    int matType = get<1>(GetParam());
+    ElemType matType = get<1>(GetParam());
     const double eps = CV_MAT_DEPTH(matType) <= CV_32S ? 1 : 1e-5;
     perf::ERROR_TYPE error_type = CV_MAT_DEPTH(matType) <= CV_32S ? ERROR_ABSOLUTE : ERROR_RELATIVE;
 
@@ -54,7 +54,7 @@ PERF_TEST_P(Size_MatType, pyrUp, testing::Combine(
             )
 {
     Size sz = get<0>(GetParam());
-    int matType = get<1>(GetParam());
+    ElemType matType = get<1>(GetParam());
     const double eps = CV_MAT_DEPTH(matType) <= CV_32S ? 1 : 1e-5;
     perf::ERROR_TYPE error_type = CV_MAT_DEPTH(matType) <= CV_32S ? ERROR_ABSOLUTE : ERROR_RELATIVE;
 
@@ -75,7 +75,7 @@ PERF_TEST_P(Size_MatType, buildPyramid, testing::Combine(
             )
 {
     Size sz = get<0>(GetParam());
-    int matType = get<1>(GetParam());
+    ElemType matType = get<1>(GetParam());
     int maxLevel = 5;
     const double eps = CV_MAT_DEPTH(matType) <= CV_32S ? 1 : 1e-5;
     perf::ERROR_TYPE error_type = CV_MAT_DEPTH(matType) <= CV_32S ? ERROR_ABSOLUTE : ERROR_RELATIVE;

--- a/modules/imgproc/perf/perf_remap.cpp
+++ b/modules/imgproc/perf/perf_remap.cpp
@@ -19,7 +19,8 @@ PERF_TEST_P( TestRemap, Remap,
 )
 {
     Size sz;
-    int src_type, map1_type, inter_type;
+    ElemType src_type, map1_type;
+    int inter_type;
 
     sz         = get<0>(GetParam());
     src_type   = get<1>(GetParam());

--- a/modules/imgproc/perf/perf_resize.cpp
+++ b/modules/imgproc/perf/perf_resize.cpp
@@ -21,7 +21,7 @@ PERF_TEST_P(MatInfo_Size_Size, resizeUpLinear,
                 )
             )
 {
-    int matType = get<0>(GetParam());
+    ElemType matType = get<0>(GetParam());
     Size from = get<1>(GetParam());
     Size to = get<2>(GetParam());
 
@@ -63,7 +63,7 @@ PERF_TEST_P(MatInfo_Size_Size, resizeDownLinear,
                 )
             )
 {
-    int matType = get<0>(GetParam());
+    ElemType matType = get<0>(GetParam());
     Size from = get<1>(GetParam());
     Size to = get<2>(GetParam());
 
@@ -92,7 +92,7 @@ PERF_TEST_P(MatInfo_Size_Scale, ResizeAreaFast,
                 )
             )
 {
-    int matType = get<0>(GetParam());
+    ElemType matType = get<0>(GetParam());
     Size from = get<1>(GetParam());
     int scale = get<2>(GetParam());
 
@@ -122,7 +122,7 @@ PERF_TEST_P(MatInfo_Size_Scale_Area, ResizeArea,
                 )
             )
 {
-    int matType = get<0>(GetParam());
+    ElemType matType = get<0>(GetParam());
     Size from = get<1>(GetParam());
     double scale = get<2>(GetParam());
 
@@ -150,7 +150,7 @@ PERF_TEST_P(MatInfo_Size_Scale_NN, ResizeNN,
     )
 )
 {
-    int matType = get<0>(GetParam());
+    ElemType matType = get<0>(GetParam());
     Size from = get<1>(GetParam());
     double scale = get<2>(GetParam());
 

--- a/modules/imgproc/perf/perf_sepfilters.cpp
+++ b/modules/imgproc/perf/perf_sepfilters.cpp
@@ -13,22 +13,22 @@ CV_ENUM(BorderType3x3ROI, BORDER_DEFAULT, BORDER_REPLICATE|BORDER_ISOLATED, BORD
 CV_ENUM(BorderType, BORDER_REPLICATE, BORDER_CONSTANT, BORDER_REFLECT, BORDER_REFLECT101)
 CV_ENUM(BorderTypeROI, BORDER_DEFAULT, BORDER_REPLICATE|BORDER_ISOLATED, BORDER_CONSTANT|BORDER_ISOLATED, BORDER_REFLECT|BORDER_ISOLATED, BORDER_REFLECT101|BORDER_ISOLATED)
 
-typedef tuple<Size, MatType, tuple<int, int>, BorderType3x3> Size_MatType_dx_dy_Border3x3_t;
-typedef perf::TestBaseWithParam<Size_MatType_dx_dy_Border3x3_t> Size_MatType_dx_dy_Border3x3;
+typedef tuple<Size, MatDepth, tuple<int, int>, BorderType3x3> Size_MatDepth_dx_dy_Border3x3_t;
+typedef perf::TestBaseWithParam<Size_MatDepth_dx_dy_Border3x3_t> Size_MatDepth_dx_dy_Border3x3;
 
-typedef tuple<Size, MatType, tuple<int, int>, BorderType3x3ROI> Size_MatType_dx_dy_Border3x3ROI_t;
-typedef perf::TestBaseWithParam<Size_MatType_dx_dy_Border3x3ROI_t> Size_MatType_dx_dy_Border3x3ROI;
+typedef tuple<Size, MatDepth, tuple<int, int>, BorderType3x3ROI> Size_MatDepth_dx_dy_Border3x3ROI_t;
+typedef perf::TestBaseWithParam<Size_MatDepth_dx_dy_Border3x3ROI_t> Size_MatDepth_dx_dy_Border3x3ROI;
 
-typedef tuple<Size, MatType, tuple<int, int>, BorderType> Size_MatType_dx_dy_Border5x5_t;
-typedef perf::TestBaseWithParam<Size_MatType_dx_dy_Border5x5_t> Size_MatType_dx_dy_Border5x5;
+typedef tuple<Size, MatDepth, tuple<int, int>, BorderType> Size_MatDepth_dx_dy_Border5x5_t;
+typedef perf::TestBaseWithParam<Size_MatDepth_dx_dy_Border5x5_t> Size_MatDepth_dx_dy_Border5x5;
 
-typedef tuple<Size, MatType, tuple<int, int>, BorderTypeROI> Size_MatType_dx_dy_Border5x5ROI_t;
-typedef perf::TestBaseWithParam<Size_MatType_dx_dy_Border5x5ROI_t> Size_MatType_dx_dy_Border5x5ROI;
+typedef tuple<Size, MatDepth, tuple<int, int>, BorderTypeROI> Size_MatDepth_dx_dy_Border5x5ROI_t;
+typedef perf::TestBaseWithParam<Size_MatDepth_dx_dy_Border5x5ROI_t> Size_MatDepth_dx_dy_Border5x5ROI;
 
 
 /**************** Sobel ********************/
 
-PERF_TEST_P(Size_MatType_dx_dy_Border3x3, sobelFilter,
+PERF_TEST_P(Size_MatDepth_dx_dy_Border3x3, sobelFilter,
             testing::Combine(
                 testing::Values(FILTER_SRC_SIZES),
                 testing::Values(CV_16S, CV_32F),
@@ -38,13 +38,13 @@ PERF_TEST_P(Size_MatType_dx_dy_Border3x3, sobelFilter,
           )
 {
     Size size = get<0>(GetParam());
-    int ddepth = get<1>(GetParam());
+    ElemDepth ddepth = get<1>(GetParam());
     int dx = get<0>(get<2>(GetParam()));
     int dy = get<1>(get<2>(GetParam()));
     BorderType3x3 border = get<3>(GetParam());
 
-    Mat src(size, CV_8U);
-    Mat dst(size, ddepth);
+    Mat src(size, CV_8UC1);
+    Mat dst(size, CV_MAKETYPE(ddepth, 1));
 
     declare.in(src, WARMUP_RNG).out(dst);
 
@@ -53,7 +53,7 @@ PERF_TEST_P(Size_MatType_dx_dy_Border3x3, sobelFilter,
     SANITY_CHECK(dst);
 }
 
-PERF_TEST_P(Size_MatType_dx_dy_Border3x3ROI, sobelFilter,
+PERF_TEST_P(Size_MatDepth_dx_dy_Border3x3ROI, sobelFilter,
             testing::Combine(
                 testing::Values(FILTER_SRC_SIZES),
                 testing::Values(CV_16S, CV_32F),
@@ -63,13 +63,13 @@ PERF_TEST_P(Size_MatType_dx_dy_Border3x3ROI, sobelFilter,
           )
 {
     Size size = get<0>(GetParam());
-    int ddepth = get<1>(GetParam());
+    ElemDepth ddepth = get<1>(GetParam());
     int dx = get<0>(get<2>(GetParam()));
     int dy = get<1>(get<2>(GetParam()));
     BorderType3x3ROI border = get<3>(GetParam());
 
-    Mat src(size.height + 10, size.width + 10, CV_8U);
-    Mat dst(size, ddepth);
+    Mat src(size.height + 10, size.width + 10, CV_8UC1);
+    Mat dst(size, CV_MAKETYPE(ddepth, 1));
 
     warmup(src, WARMUP_RNG);
     src = src(Range(5, 5 + size.height), Range(5, 5 + size.width));
@@ -81,7 +81,7 @@ PERF_TEST_P(Size_MatType_dx_dy_Border3x3ROI, sobelFilter,
     SANITY_CHECK(dst);
 }
 
-PERF_TEST_P(Size_MatType_dx_dy_Border5x5, sobelFilter,
+PERF_TEST_P(Size_MatDepth_dx_dy_Border5x5, sobelFilter,
             testing::Combine(
                 testing::Values(FILTER_SRC_SIZES),
                 testing::Values(CV_16S, CV_32F),
@@ -91,13 +91,13 @@ PERF_TEST_P(Size_MatType_dx_dy_Border5x5, sobelFilter,
           )
 {
     Size size = get<0>(GetParam());
-    int ddepth = get<1>(GetParam());
+    ElemDepth ddepth = get<1>(GetParam());
     int dx = get<0>(get<2>(GetParam()));
     int dy = get<1>(get<2>(GetParam()));
     BorderType border = get<3>(GetParam());
 
-    Mat src(size, CV_8U);
-    Mat dst(size, ddepth);
+    Mat src(size, CV_8UC1);
+    Mat dst(size, CV_MAKETYPE(ddepth, 1));
 
     declare.in(src, WARMUP_RNG).out(dst);
 
@@ -106,7 +106,7 @@ PERF_TEST_P(Size_MatType_dx_dy_Border5x5, sobelFilter,
     SANITY_CHECK(dst);
 }
 
-PERF_TEST_P(Size_MatType_dx_dy_Border5x5ROI, sobelFilter,
+PERF_TEST_P(Size_MatDepth_dx_dy_Border5x5ROI, sobelFilter,
             testing::Combine(
                 testing::Values(FILTER_SRC_SIZES),
                 testing::Values(CV_16S, CV_32F),
@@ -116,13 +116,13 @@ PERF_TEST_P(Size_MatType_dx_dy_Border5x5ROI, sobelFilter,
           )
 {
     Size size = get<0>(GetParam());
-    int ddepth = get<1>(GetParam());
+    ElemDepth ddepth = get<1>(GetParam());
     int dx = get<0>(get<2>(GetParam()));
     int dy = get<1>(get<2>(GetParam()));
     BorderTypeROI border = get<3>(GetParam());
 
-    Mat src(size.height + 10, size.width + 10, CV_8U);
-    Mat dst(size, ddepth);
+    Mat src(size.height + 10, size.width + 10, CV_8UC1);
+    Mat dst(size, CV_MAKETYPE(ddepth, 1));
 
     warmup(src, WARMUP_RNG);
     src = src(Range(5, 5 + size.height), Range(5, 5 + size.width));
@@ -136,7 +136,7 @@ PERF_TEST_P(Size_MatType_dx_dy_Border5x5ROI, sobelFilter,
 
 /**************** Scharr ********************/
 
-PERF_TEST_P(Size_MatType_dx_dy_Border3x3, scharrFilter,
+PERF_TEST_P(Size_MatDepth_dx_dy_Border3x3, scharrFilter,
             testing::Combine(
                 testing::Values(FILTER_SRC_SIZES),
                 testing::Values(CV_16S, CV_32F),
@@ -146,13 +146,13 @@ PERF_TEST_P(Size_MatType_dx_dy_Border3x3, scharrFilter,
           )
 {
     Size size = get<0>(GetParam());
-    int ddepth = get<1>(GetParam());
+    ElemDepth ddepth = get<1>(GetParam());
     int dx = get<0>(get<2>(GetParam()));
     int dy = get<1>(get<2>(GetParam()));
     BorderType3x3 border = get<3>(GetParam());
 
-    Mat src(size, CV_8U);
-    Mat dst(size, ddepth);
+    Mat src(size, CV_8UC1);
+    Mat dst(size, CV_MAKETYPE(ddepth, 1));
 
     declare.in(src, WARMUP_RNG).out(dst);
 
@@ -161,7 +161,7 @@ PERF_TEST_P(Size_MatType_dx_dy_Border3x3, scharrFilter,
     SANITY_CHECK(dst);
 }
 
-PERF_TEST_P(Size_MatType_dx_dy_Border3x3ROI, scharrFilter,
+PERF_TEST_P(Size_MatDepth_dx_dy_Border3x3ROI, scharrFilter,
             testing::Combine(
                 testing::Values(FILTER_SRC_SIZES),
                 testing::Values(CV_16S, CV_32F),
@@ -171,13 +171,13 @@ PERF_TEST_P(Size_MatType_dx_dy_Border3x3ROI, scharrFilter,
           )
 {
     Size size = get<0>(GetParam());
-    int ddepth = get<1>(GetParam());
+    ElemDepth ddepth = get<1>(GetParam());
     int dx = get<0>(get<2>(GetParam()));
     int dy = get<1>(get<2>(GetParam()));
     BorderType3x3ROI border = get<3>(GetParam());
 
-    Mat src(size.height + 10, size.width + 10, CV_8U);
-    Mat dst(size, ddepth);
+    Mat src(size.height + 10, size.width + 10, CV_8UC1);
+    Mat dst(size, CV_MAKETYPE(ddepth, 1));
 
     warmup(src, WARMUP_RNG);
     src = src(Range(5, 5 + size.height), Range(5, 5 + size.width));
@@ -189,7 +189,7 @@ PERF_TEST_P(Size_MatType_dx_dy_Border3x3ROI, scharrFilter,
     SANITY_CHECK(dst);
 }
 
-PERF_TEST_P(Size_MatType_dx_dy_Border3x3, scharrViaSobelFilter,
+PERF_TEST_P(Size_MatDepth_dx_dy_Border3x3, scharrViaSobelFilter,
             testing::Combine(
                 testing::Values(FILTER_SRC_SIZES),
                 testing::Values(CV_16S, CV_32F),
@@ -199,13 +199,13 @@ PERF_TEST_P(Size_MatType_dx_dy_Border3x3, scharrViaSobelFilter,
           )
 {
     Size size = get<0>(GetParam());
-    int ddepth = get<1>(GetParam());
+    ElemDepth ddepth = get<1>(GetParam());
     int dx = get<0>(get<2>(GetParam()));
     int dy = get<1>(get<2>(GetParam()));
     BorderType3x3 border = get<3>(GetParam());
 
-    Mat src(size, CV_8U);
-    Mat dst(size, ddepth);
+    Mat src(size, CV_8UC1);
+    Mat dst(size, CV_MAKETYPE(ddepth, 1));
 
     declare.in(src, WARMUP_RNG).out(dst);
 
@@ -214,7 +214,7 @@ PERF_TEST_P(Size_MatType_dx_dy_Border3x3, scharrViaSobelFilter,
     SANITY_CHECK(dst);
 }
 
-PERF_TEST_P(Size_MatType_dx_dy_Border3x3ROI, scharrViaSobelFilter,
+PERF_TEST_P(Size_MatDepth_dx_dy_Border3x3ROI, scharrViaSobelFilter,
             testing::Combine(
                 testing::Values(FILTER_SRC_SIZES),
                 testing::Values(CV_16S, CV_32F),
@@ -224,13 +224,13 @@ PERF_TEST_P(Size_MatType_dx_dy_Border3x3ROI, scharrViaSobelFilter,
           )
 {
     Size size = get<0>(GetParam());
-    int ddepth = get<1>(GetParam());
+    ElemDepth ddepth = get<1>(GetParam());
     int dx = get<0>(get<2>(GetParam()));
     int dy = get<1>(get<2>(GetParam()));
     BorderType3x3ROI border = get<3>(GetParam());
 
-    Mat src(size.height + 10, size.width + 10, CV_8U);
-    Mat dst(size, ddepth);
+    Mat src(size.height + 10, size.width + 10, CV_8UC1);
+    Mat dst(size, CV_MAKETYPE(ddepth, 1));
 
     warmup(src, WARMUP_RNG);
     src = src(Range(5, 5 + size.height), Range(5, 5 + size.width));

--- a/modules/imgproc/perf/perf_threshold.cpp
+++ b/modules/imgproc/perf/perf_threshold.cpp
@@ -20,7 +20,7 @@ PERF_TEST_P(Size_MatType_ThreshType, threshold,
 {
 
     Size sz = get<0>(GetParam());
-    int type = get<1>(GetParam());
+    ElemType type = get<1>(GetParam());
     ThreshType threshType = get<2>(GetParam());
 
     Mat src(sz, type);
@@ -80,7 +80,7 @@ PERF_TEST_P(Size_AdaptThreshType_AdaptThreshMethod_BlockSize_Delta, adaptiveThre
 
     double maxValue = theRNG().uniform(1, 254);
 
-    int type = CV_8UC1;
+    ElemType type = CV_8UC1;
 
     Mat src_full(cv::Size(sz.width + 2, sz.height + 2), type);
     Mat src = src_full(cv::Rect(1, 1, sz.width, sz.height));

--- a/modules/imgproc/perf/perf_warp.cpp
+++ b/modules/imgproc/perf/perf_warp.cpp
@@ -164,7 +164,8 @@ PERF_TEST_P( TestWarpPerspectiveNear_t, WarpPerspectiveNear,
              )
 {
     Size size;
-    int borderMode, interType, type;
+    int borderMode, interType;
+    ElemType type;
     size       = get<0>(GetParam());
     interType  = get<1>(GetParam());
     borderMode = get<2>(GetParam());
@@ -210,7 +211,7 @@ PERF_TEST_P( TestRemap, remap,
                  )
              )
 {
-    int type = get<0>(GetParam());
+    ElemType type = get<0>(GetParam());
     Size size = get<1>(GetParam());
     int interpolationType = get<2>(GetParam());
     int borderMode = get<3>(GetParam());
@@ -219,8 +220,8 @@ PERF_TEST_P( TestRemap, remap,
     unsigned int width = size.width;
     Mat source(height, width, type);
     Mat destination;
-    Mat map_x(height, width, CV_32F);
-    Mat map_y(height, width, CV_32F);
+    Mat map_x(height, width, CV_32FC1);
+    Mat map_y(height, width, CV_32FC1);
 
     declare.in(source, WARMUP_RNG);
 

--- a/modules/imgproc/test/ocl/test_accumulate.cpp
+++ b/modules/imgproc/test/ocl/test_accumulate.cpp
@@ -53,7 +53,8 @@ namespace ocl {
 
 PARAM_TEST_CASE(AccumulateBase, std::pair<MatDepth, MatDepth>, Channels, bool)
 {
-    int sdepth, ddepth, channels;
+    ElemDepth sdepth, ddepth;
+    int channels;
     bool useRoi;
     double alpha;
 
@@ -72,8 +73,8 @@ PARAM_TEST_CASE(AccumulateBase, std::pair<MatDepth, MatDepth>, Channels, bool)
 
     void random_roi()
     {
-        const int stype = CV_MAKE_TYPE(sdepth, channels),
-                dtype = CV_MAKE_TYPE(ddepth, channels);
+        const ElemType stype = CV_MAKE_TYPE(sdepth, channels),
+                       dtype = CV_MAKE_TYPE(ddepth, channels);
 
         Size roiSize = randomSize(1, 10);
         Border srcBorder = randomBorder(0, useRoi ? MAX_VALUE : 0);

--- a/modules/imgproc/test/ocl/test_blend.cpp
+++ b/modules/imgproc/test/ocl/test_blend.cpp
@@ -53,7 +53,8 @@ namespace ocl {
 
 PARAM_TEST_CASE(BlendLinear, MatDepth, Channels, bool)
 {
-    int depth, channels;
+    ElemDepth depth;
+    int channels;
     bool useRoi;
 
     TEST_DECLARE_INPUT_PARAMETER(src1);
@@ -71,7 +72,7 @@ PARAM_TEST_CASE(BlendLinear, MatDepth, Channels, bool)
 
     void random_roi()
     {
-        const int type = CV_MAKE_TYPE(depth, channels);
+        const ElemType type = CV_MAKE_TYPE(depth, channels);
         const double upValue = 256;
 
         Size roiSize = randomSize(1, MAX_VALUE);

--- a/modules/imgproc/test/ocl/test_boxfilter.cpp
+++ b/modules/imgproc/test/ocl/test_boxfilter.cpp
@@ -56,7 +56,8 @@ PARAM_TEST_CASE(BoxFilterBase, MatDepth, Channels, BorderType, bool, bool)
     static const int kernelMinSize = 2;
     static const int kernelMaxSize = 10;
 
-    int depth, cn, borderType;
+    ElemDepth depth;
+    int cn, borderType;
     Size ksize, dsize;
     Point anchor;
     bool normalize, useRoi;
@@ -75,7 +76,7 @@ PARAM_TEST_CASE(BoxFilterBase, MatDepth, Channels, BorderType, bool, bool)
 
     void random_roi()
     {
-        int type = CV_MAKE_TYPE(depth, cn);
+        ElemType type = CV_MAKE_TYPE(depth, cn);
         ksize = randomSize(kernelMinSize, kernelMaxSize);
 
         Size roiSize = randomSize(ksize.width, MAX_VALUE, ksize.height, MAX_VALUE);
@@ -106,8 +107,8 @@ OCL_TEST_P(BoxFilter, Mat)
     {
         random_roi();
 
-        OCL_OFF(cv::boxFilter(src_roi, dst_roi, -1, ksize, anchor, normalize, borderType));
-        OCL_ON(cv::boxFilter(usrc_roi, udst_roi, -1, ksize, anchor, normalize, borderType));
+        OCL_OFF(cv::boxFilter(src_roi, dst_roi, CV_DEPTH_AUTO, ksize, anchor, normalize, borderType));
+        OCL_ON(cv::boxFilter(usrc_roi, udst_roi, CV_DEPTH_AUTO, ksize, anchor, normalize, borderType));
 
         Near(depth <= CV_32S ? 1 : 3e-3);
     }
@@ -121,7 +122,7 @@ OCL_TEST_P(SqrBoxFilter, Mat)
     {
         random_roi();
 
-        int ddepth = depth == CV_8U ? CV_32S : CV_64F;
+        ElemDepth ddepth = depth == CV_8U ? CV_32S : CV_64F;
 
         OCL_OFF(cv::sqrBoxFilter(src_roi, dst_roi, ddepth, ksize, anchor, normalize, borderType));
         OCL_ON(cv::sqrBoxFilter(usrc_roi, udst_roi, ddepth, ksize, anchor, normalize, borderType));
@@ -159,7 +160,8 @@ OCL_INSTANTIATE_TEST_CASE_P(ImageProc, SqrBoxFilter,
 
 PARAM_TEST_CASE(BoxFilter3x3_cols16_rows2_Base, MatDepth, Channels, BorderType, bool, bool)
 {
-    int depth, cn, borderType;
+    ElemDepth depth;
+    int cn, borderType;
     Size ksize, dsize;
     Point anchor;
     bool normalize, useRoi;
@@ -178,7 +180,7 @@ PARAM_TEST_CASE(BoxFilter3x3_cols16_rows2_Base, MatDepth, Channels, BorderType, 
 
     void random_roi()
     {
-        int type = CV_MAKE_TYPE(depth, cn);
+        ElemType type = CV_MAKE_TYPE(depth, cn);
         ksize = Size(3,3);
 
         Size roiSize = randomSize(ksize.width, MAX_VALUE, ksize.height, MAX_VALUE);
@@ -211,8 +213,8 @@ OCL_TEST_P(BoxFilter3x3_cols16_rows2, Mat)
     {
         random_roi();
 
-        OCL_OFF(cv::boxFilter(src_roi, dst_roi, -1, ksize, anchor, normalize, borderType));
-        OCL_ON(cv::boxFilter(usrc_roi, udst_roi, -1, ksize, anchor, normalize, borderType));
+        OCL_OFF(cv::boxFilter(src_roi, dst_roi, CV_DEPTH_AUTO, ksize, anchor, normalize, borderType));
+        OCL_ON(cv::boxFilter(usrc_roi, udst_roi, CV_DEPTH_AUTO, ksize, anchor, normalize, borderType));
 
         Near(depth <= CV_32S ? 1 : 3e-3);
     }
@@ -220,7 +222,7 @@ OCL_TEST_P(BoxFilter3x3_cols16_rows2, Mat)
 
 OCL_INSTANTIATE_TEST_CASE_P(ImageProc, BoxFilter3x3_cols16_rows2,
                             Combine(
-                                Values((MatDepth)CV_8U),
+                                Values(CV_8U),
                                 Values((Channels)1),
                                 Values((BorderType)BORDER_CONSTANT,
                                        (BorderType)BORDER_REPLICATE,

--- a/modules/imgproc/test/ocl/test_canny.cpp
+++ b/modules/imgproc/test/ocl/test_canny.cpp
@@ -80,7 +80,7 @@ PARAM_TEST_CASE(Canny, Channels, ApertureSize, L2gradient, UseRoi)
         ASSERT_FALSE(img.empty()) << "cann't load shared/fruits.png";
 
         Size roiSize = img.size();
-        int type = img.type();
+        ElemType type = img.type();
 
         Border srcBorder = randomBorder(0, use_roi ? MAX_VALUE : 0);
         randomSubMat(src, src_roi, roiSize, srcBorder, type, 2, 100);

--- a/modules/imgproc/test/ocl/test_color.cpp
+++ b/modules/imgproc/test/ocl/test_color.cpp
@@ -56,7 +56,7 @@ namespace ocl {
 
 PARAM_TEST_CASE(CvtColor, MatDepth, bool)
 {
-    int depth;
+    ElemDepth depth;
     bool use_roi;
 
     TEST_DECLARE_INPUT_PARAMETER(src);
@@ -70,8 +70,8 @@ PARAM_TEST_CASE(CvtColor, MatDepth, bool)
 
     virtual void generateTestData(int channelsIn, int channelsOut)
     {
-        const int srcType = CV_MAKE_TYPE(depth, channelsIn);
-        const int dstType = CV_MAKE_TYPE(depth, channelsOut);
+        const ElemType srcType = CV_MAKE_TYPE(depth, channelsIn);
+        const ElemType dstType = CV_MAKE_TYPE(depth, channelsOut);
 
         Size roiSize = randomSize(1, MAX_VALUE);
         Border srcBorder = randomBorder(0, use_roi ? MAX_VALUE : 0);
@@ -109,8 +109,8 @@ PARAM_TEST_CASE(CvtColor, MatDepth, bool)
                 ASSERT_EQ(dst_roi.type(), udst_roi.type());
                 ASSERT_EQ(dst_roi.size(), udst_roi.size());
                 Mat gold, actual;
-                dst_roi.convertTo(gold, CV_32FC3);
-                udst_roi.getMat(ACCESS_READ).convertTo(actual, CV_32FC3);
+                dst_roi.convertTo(gold, CV_32F);
+                udst_roi.getMat(ACCESS_READ).convertTo(actual, CV_32F);
                 Mat absdiff1, absdiff2, absdiff3;
                 cv::absdiff(gold, actual, absdiff1);
                 cv::absdiff(gold, actual + h_limit, absdiff2);
@@ -352,8 +352,8 @@ struct CvtColor_YUV2RGB_420 :
 {
     void generateTestData(int channelsIn, int channelsOut)
     {
-        const int srcType = CV_MAKE_TYPE(depth, channelsIn);
-        const int dstType = CV_MAKE_TYPE(depth, channelsOut);
+        const ElemType srcType = CV_MAKE_TYPE(depth, channelsIn);
+        const ElemType dstType = CV_MAKE_TYPE(depth, channelsOut);
 
         Size roiSize = randomSize(1, MAX_VALUE);
         roiSize.width *= 2;
@@ -394,8 +394,8 @@ struct CvtColor_RGB2YUV_420 :
 {
     void generateTestData(int channelsIn, int channelsOut)
     {
-        const int srcType = CV_MAKE_TYPE(depth, channelsIn);
-        const int dstType = CV_MAKE_TYPE(depth, channelsOut);
+        const ElemType srcType = CV_MAKE_TYPE(depth, channelsIn);
+        const ElemType dstType = CV_MAKE_TYPE(depth, channelsOut);
 
         Size srcRoiSize = randomSize(1, MAX_VALUE);
         srcRoiSize.width *= 2;
@@ -428,8 +428,8 @@ struct CvtColor_YUV2RGB_422 :
 {
     void generateTestData(int channelsIn, int channelsOut)
     {
-        const int srcType = CV_MAKE_TYPE(depth, channelsIn);
-        const int dstType = CV_MAKE_TYPE(depth, channelsOut);
+        const ElemType srcType = CV_MAKE_TYPE(depth, channelsIn);
+        const ElemType dstType = CV_MAKE_TYPE(depth, channelsOut);
 
         Size roiSize = randomSize(1, MAX_VALUE);
         roiSize.width *= 2;

--- a/modules/imgproc/test/ocl/test_filter2d.cpp
+++ b/modules/imgproc/test/ocl/test_filter2d.cpp
@@ -56,7 +56,7 @@ PARAM_TEST_CASE(Filter2D, MatDepth, Channels, int, int, BorderType, bool, bool)
     static const int kernelMinSize = 2;
     static const int kernelMaxSize = 10;
 
-    int type;
+    ElemType type;
     Size size;
     Point anchor;
     int borderType;
@@ -114,8 +114,8 @@ OCL_TEST_P(Filter2D, Mat)
     {
         random_roi();
 
-        OCL_OFF(cv::filter2D(src_roi, dst_roi, -1, kernel, anchor, delta, borderType));
-        OCL_ON(cv::filter2D(usrc_roi, udst_roi, -1, kernel, anchor, delta, borderType));
+        OCL_OFF(cv::filter2D(src_roi, dst_roi, CV_DEPTH_AUTO, kernel, anchor, delta, borderType));
+        OCL_ON(cv::filter2D(usrc_roi, udst_roi, CV_DEPTH_AUTO, kernel, anchor, delta, borderType));
 
         Near(1.0);
     }

--- a/modules/imgproc/test/ocl/test_filters.cpp
+++ b/modules/imgproc/test/ocl/test_filters.cpp
@@ -65,7 +65,8 @@ PARAM_TEST_CASE(FilterTestBase, MatType,
                 bool, // roi or not
                 int)  // width multiplier
 {
-    int type, borderType, ksize;
+    ElemType type;
+    int borderType, ksize;
     Size size;
     double param;
     bool useRoi;
@@ -106,7 +107,7 @@ PARAM_TEST_CASE(FilterTestBase, MatType,
 
     void Near()
     {
-        int depth = CV_MAT_DEPTH(type);
+        ElemDepth depth = CV_MAT_DEPTH(type);
         bool isFP = depth >= CV_32F;
 
         if (isFP)
@@ -158,8 +159,8 @@ OCL_TEST_P(LaplacianTest, Accuracy)
     {
         random_roi();
 
-        OCL_OFF(cv::Laplacian(src_roi, dst_roi, -1, ksize, scale, 10, borderType));
-        OCL_ON(cv::Laplacian(usrc_roi, udst_roi, -1, ksize, scale, 10, borderType));
+        OCL_OFF(cv::Laplacian(src_roi, dst_roi, CV_DEPTH_AUTO, ksize, scale, 10, borderType));
+        OCL_ON(cv::Laplacian(usrc_roi, udst_roi, CV_DEPTH_AUTO, ksize, scale, 10, borderType));
 
         Near();
     }
@@ -173,7 +174,8 @@ PARAM_TEST_CASE(Deriv3x3_cols16_rows2_Base, MatType,
                 bool, // roi or not
                 int)  // width multiplier
 {
-    int type, borderType, ksize;
+    ElemType type;
+    int borderType, ksize;
     Size size;
     double param;
     bool useRoi;
@@ -235,8 +237,8 @@ OCL_TEST_P(Laplacian3_cols16_rows2, Accuracy)
     {
         random_roi();
 
-        OCL_OFF(cv::Laplacian(src_roi, dst_roi, -1, ksize, scale, 10, borderType));
-        OCL_ON(cv::Laplacian(usrc_roi, udst_roi, -1, ksize, scale, 10, borderType));
+        OCL_OFF(cv::Laplacian(src_roi, dst_roi, CV_DEPTH_AUTO, ksize, scale, 10, borderType));
+        OCL_ON(cv::Laplacian(usrc_roi, udst_roi, CV_DEPTH_AUTO, ksize, scale, 10, borderType));
 
         Near();
     }
@@ -257,8 +259,8 @@ OCL_TEST_P(SobelTest, Mat)
     {
         random_roi();
 
-        OCL_OFF(cv::Sobel(src_roi, dst_roi, -1, dx, dy, ksize, scale, /* delta */0, borderType));
-        OCL_ON(cv::Sobel(usrc_roi, udst_roi, -1, dx, dy, ksize, scale, /* delta */0, borderType));
+        OCL_OFF(cv::Sobel(src_roi, dst_roi, CV_DEPTH_AUTO, dx, dy, ksize, scale, /* delta */0, borderType));
+        OCL_ON(cv::Sobel(usrc_roi, udst_roi, CV_DEPTH_AUTO, dx, dy, ksize, scale, /* delta */0, borderType));
 
         Near();
     }
@@ -275,8 +277,8 @@ OCL_TEST_P(Sobel3x3_cols16_rows2, Mat)
     {
         random_roi();
 
-        OCL_OFF(cv::Sobel(src_roi, dst_roi, -1, dx, dy, ksize, scale, /* delta */0, borderType));
-        OCL_ON(cv::Sobel(usrc_roi, udst_roi, -1, dx, dy, ksize, scale, /* delta */0, borderType));
+        OCL_OFF(cv::Sobel(src_roi, dst_roi, CV_DEPTH_AUTO, dx, dy, ksize, scale, /* delta */0, borderType));
+        OCL_ON(cv::Sobel(usrc_roi, udst_roi, CV_DEPTH_AUTO, dx, dy, ksize, scale, /* delta */0, borderType));
 
         Near();
     }
@@ -296,8 +298,8 @@ OCL_TEST_P(ScharrTest, Mat)
     {
         random_roi();
 
-        OCL_OFF(cv::Scharr(src_roi, dst_roi, -1, dx, dy, scale, /* delta */ 0, borderType));
-        OCL_ON(cv::Scharr(usrc_roi, udst_roi, -1, dx, dy, scale, /* delta */ 0, borderType));
+        OCL_OFF(cv::Scharr(src_roi, dst_roi, CV_DEPTH_AUTO, dx, dy, scale, /* delta */ 0, borderType));
+        OCL_ON(cv::Scharr(usrc_roi, udst_roi, CV_DEPTH_AUTO, dx, dy, scale, /* delta */ 0, borderType));
 
         Near();
     }
@@ -314,8 +316,8 @@ OCL_TEST_P(Scharr3x3_cols16_rows2, Mat)
     {
         random_roi();
 
-        OCL_OFF(cv::Scharr(src_roi, dst_roi, -1, dx, dy, scale, /* delta */ 0, borderType));
-        OCL_ON(cv::Scharr(usrc_roi, udst_roi, -1, dx, dy, scale, /* delta */ 0, borderType));
+        OCL_OFF(cv::Scharr(src_roi, dst_roi, CV_DEPTH_AUTO, dx, dy, scale, /* delta */ 0, borderType));
+        OCL_ON(cv::Scharr(usrc_roi, udst_roi, CV_DEPTH_AUTO, dx, dy, scale, /* delta */ 0, borderType));
 
         Near();
     }
@@ -350,7 +352,8 @@ PARAM_TEST_CASE(GaussianBlur_multicols_Base, MatType,
                 bool, // roi or not
                 int)  // width multiplier
 {
-    int type, borderType, ksize;
+    ElemType type;
+    int borderType, ksize;
     Size size;
     double param;
     bool useRoi;
@@ -481,7 +484,8 @@ PARAM_TEST_CASE(MorphFilter3x3_cols16_rows2_Base, MatType,
                 bool, // roi or not
                 int)  // width multiplier
 {
-    int type, borderType, ksize;
+    ElemType type;
+    int borderType, ksize;
     Size size;
     double param;
     bool useRoi;
@@ -561,7 +565,8 @@ PARAM_TEST_CASE(MorphologyEx, MatType,
                 int, // iterations
                 bool)
 {
-    int type, ksize, op, iterations;
+    ElemType type;
+    int ksize, op, iterations;
     bool useRoi;
 
     TEST_DECLARE_INPUT_PARAMETER(src);
@@ -595,7 +600,7 @@ PARAM_TEST_CASE(MorphologyEx, MatType,
 
     void Near()
     {
-        int depth = CV_MAT_DEPTH(type);
+        ElemDepth depth = CV_MAT_DEPTH(type);
         bool isFP = depth >= CV_32F;
 
         if (isFP)
@@ -664,7 +669,7 @@ OCL_INSTANTIATE_TEST_CASE_P(Filter, LaplacianTest, Combine(
                             Values(1))); // not used
 
 OCL_INSTANTIATE_TEST_CASE_P(Filter, Laplacian3_cols16_rows2, Combine(
-                            Values((MatType)CV_8UC1),
+                            Values(CV_8UC1),
                             Values(3), // kernel size
                             Values(Size(0, 0)), // not used
                             FILTER_BORDER_SET_NO_WRAP_NO_ISOLATED,
@@ -682,7 +687,7 @@ OCL_INSTANTIATE_TEST_CASE_P(Filter, SobelTest, Combine(
                             Values(1))); // not used
 
 OCL_INSTANTIATE_TEST_CASE_P(Filter, Sobel3x3_cols16_rows2, Combine(
-                            Values((MatType)CV_8UC1),
+                            Values(CV_8UC1),
                             Values(3), // kernel size
                             Values(Size(1, 0), Size(1, 1), Size(2, 0), Size(2, 1)), // dx, dy
                             FILTER_BORDER_SET_NO_WRAP_NO_ISOLATED,
@@ -718,7 +723,7 @@ OCL_INSTANTIATE_TEST_CASE_P(Filter, GaussianBlurTest, Combine(
                             Values(1))); // not used
 
 OCL_INSTANTIATE_TEST_CASE_P(Filter, GaussianBlur_multicols, Combine(
-                            Values((MatType)CV_8UC1),
+                            Values(CV_8UC1),
                             Values(3, 5), // kernel size
                             Values(Size(0, 0)), // not used
                             FILTER_BORDER_SET_NO_WRAP_NO_ISOLATED,
@@ -745,7 +750,7 @@ OCL_INSTANTIATE_TEST_CASE_P(Filter, Dilate, Combine(
                             Values(1))); // not used
 
 OCL_INSTANTIATE_TEST_CASE_P(Filter, MorphFilter3x3_cols16_rows2, Combine(
-                            Values((MatType)CV_8UC1),
+                            Values(CV_8UC1),
                             Values(0, 3), // kernel size, 0 means kernel = Mat()
                             Values(Size(0, 0)), // not used
                             Values((BorderType)BORDER_CONSTANT),

--- a/modules/imgproc/test/ocl/test_histogram.cpp
+++ b/modules/imgproc/test/ocl/test_histogram.cpp
@@ -64,7 +64,8 @@ namespace ocl {
 
 PARAM_TEST_CASE(CalcBackProject, MatDepth, int, bool)
 {
-    int depth, N;
+    ElemDepth depth;
+    int N;
     bool useRoi;
 
     std::vector<float> ranges;
@@ -162,7 +163,7 @@ PARAM_TEST_CASE(CalcBackProject, MatDepth, int, bool)
 
         //compute histogram
         calcHist(&frame1, 1, 0, Mat(), hist1, 1, &histSize, &ranges1, true, false);
-        normalize(hist1, hist1, 0, 255, NORM_MINMAX, -1, Mat());
+        normalize(hist1, hist1, 0, 255, NORM_MINMAX, CV_DEPTH_AUTO, Mat());
 
         Mat dst1;
         UMat udst1, src, uhist1;
@@ -268,7 +269,7 @@ OCL_TEST_P(CalcHist, Mat)
 
 /////////////////////////////////////////////////////////////////////////////////////
 
-OCL_INSTANTIATE_TEST_CASE_P(Imgproc, CalcBackProject, Combine(Values((MatDepth)CV_8U), Values(1, 2), Bool()));
+OCL_INSTANTIATE_TEST_CASE_P(Imgproc, CalcBackProject, Combine(Values(CV_8U), Values(1, 2), Bool()));
 OCL_INSTANTIATE_TEST_CASE_P(Imgproc, CalcHist, Values(true, false));
 
 } } // namespace opencv_test::ocl

--- a/modules/imgproc/test/ocl/test_match_template.cpp
+++ b/modules/imgproc/test/ocl/test_match_template.cpp
@@ -55,8 +55,8 @@ CV_ENUM(MatchTemplType, CV_TM_CCORR, CV_TM_CCORR_NORMED, CV_TM_SQDIFF, CV_TM_SQD
 
 PARAM_TEST_CASE(MatchTemplate, MatDepth, Channels, MatchTemplType, bool)
 {
-    int type;
-    int depth;
+    ElemType type;
+    ElemDepth depth;
     int method;
     bool use_roi;
 

--- a/modules/imgproc/test/ocl/test_medianfilter.cpp
+++ b/modules/imgproc/test/ocl/test_medianfilter.cpp
@@ -53,7 +53,7 @@ namespace ocl {
 
 PARAM_TEST_CASE(MedianFilter, MatDepth, Channels, int, bool)
 {
-    int type;
+    ElemType type;
     int ksize;
     bool use_roi;
 

--- a/modules/imgproc/test/ocl/test_pyramids.cpp
+++ b/modules/imgproc/test/ocl/test_pyramids.cpp
@@ -54,7 +54,8 @@ namespace ocl {
 
 PARAM_TEST_CASE(PyrTestBase, MatDepth, Channels, BorderType, bool)
 {
-    int depth, channels, borderType;
+    ElemDepth depth;
+    int channels, borderType;
     bool use_roi;
 
     TEST_DECLARE_INPUT_PARAMETER(src);
@@ -160,7 +161,7 @@ OCL_INSTANTIATE_TEST_CASE_P(ImgprocPyr, PyrUp, Combine(
                             ));
 
 OCL_INSTANTIATE_TEST_CASE_P(ImgprocPyr, PyrUp_cols2, Combine(
-                            Values((MatDepth)CV_8U),
+                            Values(CV_8U),
                             Values((Channels)1),
                             Values((BorderType)BORDER_REFLECT_101),
                             Bool()

--- a/modules/imgproc/test/ocl/test_sepfilter2d.cpp
+++ b/modules/imgproc/test/ocl/test_sepfilter2d.cpp
@@ -56,7 +56,7 @@ PARAM_TEST_CASE(SepFilter2D, MatDepth, Channels, BorderType, bool, bool)
     static const int kernelMinSize = 2;
     static const int kernelMaxSize = 10;
 
-    int type;
+    ElemType type;
     Point anchor;
     int borderType;
     bool useRoi;
@@ -112,8 +112,8 @@ OCL_TEST_P(SepFilter2D, Mat)
     {
         random_roi();
 
-        OCL_OFF(cv::sepFilter2D(src_roi, dst_roi, -1, kernelX, kernelY, anchor, delta, borderType));
-        OCL_ON(cv::sepFilter2D(usrc_roi, udst_roi, -1, kernelX, kernelY, anchor, delta, borderType));
+        OCL_OFF(cv::sepFilter2D(src_roi, dst_roi, CV_DEPTH_AUTO, kernelX, kernelY, anchor, delta, borderType));
+        OCL_ON(cv::sepFilter2D(usrc_roi, udst_roi, CV_DEPTH_AUTO, kernelX, kernelY, anchor, delta, borderType));
 
         Near(1.0);
     }

--- a/modules/imgproc/test/ocl/test_warp.cpp
+++ b/modules/imgproc/test/ocl/test_warp.cpp
@@ -59,20 +59,16 @@
 namespace opencv_test {
 namespace ocl {
 
-enum
-{
-    noType = -1
-};
-
 /////////////////////////////////////////////////////////////////////////////////////////////////
 // warpAffine  & warpPerspective
 
 PARAM_TEST_CASE(WarpTestBase, MatType, Interpolation, bool, bool)
 {
-    int type, interpolation;
+    ElemType type;
+    int interpolation;
     Size dsize;
     bool useRoi, mapInverse;
-    int depth;
+    ElemDepth depth;
 
     TEST_DECLARE_INPUT_PARAMETER(src);
     TEST_DECLARE_OUTPUT_PARAMETER(dst);
@@ -115,10 +111,11 @@ PARAM_TEST_CASE(WarpTestBase, MatType, Interpolation, bool, bool)
 
 PARAM_TEST_CASE(WarpTest_cols4_Base, MatType, Interpolation, bool, bool)
 {
-    int type, interpolation;
+    ElemType type;
+    int interpolation;
     Size dsize;
     bool useRoi, mapInverse;
-    int depth;
+    ElemDepth depth;
 
     TEST_DECLARE_INPUT_PARAMETER(src);
     TEST_DECLARE_OUTPUT_PARAMETER(dst);
@@ -261,7 +258,8 @@ OCL_TEST_P(WarpPerspective_cols4, Mat)
 
 PARAM_TEST_CASE(Resize, MatType, double, double, Interpolation, bool, int)
 {
-    int type, interpolation;
+    ElemType type;
+    int interpolation;
     int widthMultiple;
     double fx, fy;
     bool useRoi;
@@ -315,7 +313,7 @@ OCL_TEST_P(Resize, Mat)
 {
     for (int j = 0; j < test_loop_times; j++)
     {
-        int depth = CV_MAT_DEPTH(type);
+        ElemDepth depth = CV_MAT_DEPTH(type);
         double eps = depth <= CV_32S ? integerEps : 5e-2;
 
         random_roi();
@@ -332,7 +330,7 @@ OCL_TEST_P(Resize, Mat)
 
 PARAM_TEST_CASE(Remap, MatDepth, Channels, std::pair<MatType, MatType>, BorderType, bool)
 {
-    int srcType, map1Type, map2Type;
+    ElemType srcType, map1Type, map2Type;
     int borderType;
     bool useRoi;
 
@@ -369,7 +367,7 @@ PARAM_TEST_CASE(Remap, MatDepth, Channels, std::pair<MatType, MatType>, BorderTy
         randomSubMat(map1, map1_roi, dstROISize, map1Border, map1Type, -mapMaxValue, mapMaxValue);
 
         Border map2Border = randomBorder(0, useRoi ? MAX_VALUE + 1 : 0);
-        if (map2Type != noType)
+        if (map2Type != CV_TYPE_AUTO)
         {
             int mapMinValue = -mapMaxValue;
             if (map2Type == CV_16UC1 || map2Type == CV_16SC1)
@@ -380,7 +378,7 @@ PARAM_TEST_CASE(Remap, MatDepth, Channels, std::pair<MatType, MatType>, BorderTy
         UMAT_UPLOAD_INPUT_PARAMETER(src);
         UMAT_UPLOAD_INPUT_PARAMETER(map1);
         UMAT_UPLOAD_OUTPUT_PARAMETER(dst);
-        if (noType != map2Type)
+        if (map2Type != CV_TYPE_AUTO)
             UMAT_UPLOAD_INPUT_PARAMETER(map2);
     }
 };
@@ -433,7 +431,7 @@ OCL_INSTANTIATE_TEST_CASE_P(ImgprocWarp, WarpAffine, Combine(
                             Bool()));
 
 OCL_INSTANTIATE_TEST_CASE_P(ImgprocWarp, WarpAffine_cols4, Combine(
-                            Values((MatType)CV_8UC1),
+                            Values(CV_8UC1),
                             Values((Interpolation)INTER_NEAREST, (Interpolation)INTER_LINEAR, (Interpolation)INTER_CUBIC),
                             Bool(),
                             Bool()));
@@ -445,7 +443,7 @@ OCL_INSTANTIATE_TEST_CASE_P(ImgprocWarp, WarpPerspective, Combine(
                             Bool()));
 
 OCL_INSTANTIATE_TEST_CASE_P(ImgprocWarp, WarpPerspective_cols4, Combine(
-                            Values((MatType)CV_8UC1),
+                            Values(CV_8UC1),
                             Values((Interpolation)INTER_NEAREST, (Interpolation)INTER_LINEAR, (Interpolation)INTER_CUBIC),
                             Bool(),
                             Bool()));
@@ -467,7 +465,7 @@ OCL_INSTANTIATE_TEST_CASE_P(ImgprocWarpLinearExact, Resize, Combine(
                             Values(1, 16)));
 
 OCL_INSTANTIATE_TEST_CASE_P(ImgprocWarpResizeArea, Resize, Combine(
-                            Values((MatType)CV_8UC1, CV_8UC4, CV_32FC1, CV_32FC4),
+                            Values(CV_8UC1, CV_8UC4, CV_32FC1, CV_32FC4),
                             Values(0.7, 0.4, 0.5),
                             Values(0.3, 0.6, 0.5),
                             Values((Interpolation)INTER_AREA),
@@ -477,9 +475,9 @@ OCL_INSTANTIATE_TEST_CASE_P(ImgprocWarpResizeArea, Resize, Combine(
 OCL_INSTANTIATE_TEST_CASE_P(ImgprocWarp, Remap_INTER_LINEAR, Combine(
                             Values(CV_8U, CV_16U, CV_32F),
                             Values(1, 3, 4),
-                            Values(std::pair<MatType, MatType>((MatType)CV_32FC1, (MatType)CV_32FC1),
-                                   std::pair<MatType, MatType>((MatType)CV_16SC2, (MatType)CV_16UC1),
-                                   std::pair<MatType, MatType>((MatType)CV_32FC2, noType)),
+                            Values(std::pair<MatType, MatType>(CV_32FC1, CV_32FC1),
+                                   std::pair<MatType, MatType>(CV_16SC2, CV_16UC1),
+                                   std::pair<MatType, MatType>(CV_32FC2, CV_TYPE_AUTO)),
                             Values((BorderType)BORDER_CONSTANT,
                                    (BorderType)BORDER_REPLICATE,
                                    (BorderType)BORDER_WRAP,
@@ -490,10 +488,10 @@ OCL_INSTANTIATE_TEST_CASE_P(ImgprocWarp, Remap_INTER_LINEAR, Combine(
 OCL_INSTANTIATE_TEST_CASE_P(ImgprocWarp, Remap_INTER_NEAREST, Combine(
                             Values(CV_8U, CV_16U, CV_32F),
                             Values(1, 3, 4),
-                            Values(std::pair<MatType, MatType>((MatType)CV_32FC1, (MatType)CV_32FC1),
-                                   std::pair<MatType, MatType>((MatType)CV_32FC2, noType),
-                                   std::pair<MatType, MatType>((MatType)CV_16SC2, (MatType)CV_16UC1),
-                                   std::pair<MatType, MatType>((MatType)CV_16SC2, noType)),
+                            Values(std::pair<MatType, MatType>(CV_32FC1, CV_32FC1),
+                                   std::pair<MatType, MatType>(CV_32FC2, CV_TYPE_AUTO),
+                                   std::pair<MatType, MatType>(CV_16SC2, CV_16UC1),
+                                   std::pair<MatType, MatType>(CV_16SC2, CV_TYPE_AUTO)),
                             Values((BorderType)BORDER_CONSTANT,
                                    (BorderType)BORDER_REPLICATE,
                                    (BorderType)BORDER_WRAP,

--- a/modules/imgproc/test/test_bilateral_filter.cpp
+++ b/modules/imgproc/test/test_bilateral_filter.cpp
@@ -232,10 +232,10 @@ namespace opencv_test { namespace {
 
     int CV_BilateralFilterTest::prepare_test_case(int /* test_case_index */)
     {
-        const static int types[] = { CV_32FC1, CV_32FC3, CV_8UC1, CV_8UC3 };
+        const static ElemType types[] = { CV_32FC1, CV_32FC3, CV_8UC1, CV_8UC3 };
         RNG& rng = ts->get_rng();
         Size size(getRandInt(rng, MIN_WIDTH, MAX_WIDTH), getRandInt(rng, MIN_HEIGHT, MAX_HEIGHT));
-        int type = types[rng(sizeof(types) / sizeof(types[0]))];
+        ElemType type = types[rng(sizeof(types) / sizeof(types[0]))];
 
         _d = rng.uniform(0., 1.) > 0.5 ? 5 : 3;
 
@@ -260,10 +260,9 @@ namespace opencv_test { namespace {
         }
         else
         {
-            int type = _src.type();
             _src.convertTo(reference_src, CV_32F);
             reference_bilateral_filter(reference_src, reference_dst, _d, _sigma_color, _sigma_space);
-            reference_dst.convertTo(reference_dst, type);
+            reference_dst.convertTo(reference_dst, _src.depth());
             e = cvtest::norm(reference_dst, _parallel_dst, NORM_INF);
         }
 

--- a/modules/imgproc/test/test_canny.cpp
+++ b/modules/imgproc/test/test_canny.cpp
@@ -49,12 +49,12 @@ public:
     CV_CannyTest(bool custom_deriv = false);
 
 protected:
-    void get_test_array_types_and_sizes( int test_case_idx, vector<vector<Size> >& sizes, vector<vector<int> >& types );
-    double get_success_error_level( int test_case_idx, int i, int j );
-    int prepare_test_case( int test_case_idx );
-    void run_func();
-    void prepare_to_validation( int );
-    int validate_test_results( int /*test_case_idx*/ );
+    void get_test_array_types_and_sizes( int test_case_idx, vector<vector<Size> >& sizes, vector<vector<ElemType> >& types ) CV_OVERRIDE;
+    double get_success_error_level( int test_case_idx, int i, int j ) CV_OVERRIDE;
+    int prepare_test_case( int test_case_idx ) CV_OVERRIDE;
+    void run_func() CV_OVERRIDE;
+    void prepare_to_validation( int ) CV_OVERRIDE;
+    int validate_test_results( int /*test_case_idx*/ ) CV_OVERRIDE;
 
     int aperture_size;
     bool use_true_gradient;
@@ -86,13 +86,13 @@ CV_CannyTest::CV_CannyTest(bool custom_deriv)
 
 void CV_CannyTest::get_test_array_types_and_sizes( int test_case_idx,
                                                   vector<vector<Size> >& sizes,
-                                                  vector<vector<int> >& types )
+                                                  vector<vector<ElemType> >& types )
 {
     RNG& rng = ts->get_rng();
     double thresh_range;
 
     cvtest::ArrayTest::get_test_array_types_and_sizes( test_case_idx, sizes, types );
-    types[INPUT][0] = types[OUTPUT][0] = types[REF_OUTPUT][0] = CV_8U;
+    types[INPUT][0] = types[OUTPUT][0] = types[REF_OUTPUT][0] = CV_8UC1;
 
     aperture_size = cvtest::randInt(rng) % 2 ? 5 : 3;
     thresh_range = aperture_size == 3 ? 300 : 1000;
@@ -209,7 +209,7 @@ test_Canny( const Mat& src, Mat& dst,
 
     Mat dxkernel = cvtest::calcSobelKernel2D( 1, 0, m, 0 );
     Mat dykernel = cvtest::calcSobelKernel2D( 0, 1, m, 0 );
-    Mat dx, dy, mag(height, width, CV_32F);
+    Mat dx, dy, mag(height, width, CV_32FC1);
     cvtest::filter2D(src, dx, CV_32S, dxkernel, anchor, 0, BORDER_REPLICATE);
     cvtest::filter2D(src, dy, CV_32S, dykernel, anchor, 0, BORDER_REPLICATE);
 
@@ -385,7 +385,7 @@ TEST_P(CannyVX, Accuracy)
         // 'smart' diff check (excluding isolated pixels)
         Mat diff, diff1;
         absdiff(canny, cannyVX, diff);
-        boxFilter(diff, diff1, -1, Size(3,3));
+        boxFilter(diff, diff1, CV_DEPTH_AUTO, Size(3,3));
         const int minPixelsAroud = 3; // empirical number
         diff1 = diff1 > 255/9 * minPixelsAroud;
         erode(diff1, diff1, Mat());

--- a/modules/imgproc/test/test_contours.cpp
+++ b/modules/imgproc/test/test_contours.cpp
@@ -246,7 +246,7 @@ int CV_FindContourTest::prepare_test_case( int test_case_idx )
     storage = cvCreateMemStorage( 1 << 10 );
 
     for( i = 0; i < NUM_IMG; i++ )
-        img[i] = cvCreateImage( cvSize(img_size), 8, 1 );
+        img[i] = cvCreateImage(cvSize(img_size), IPL_DEPTH_8U, 1);
 
     cvTsGenerateBlobImage( img[0], min_blob_size, max_blob_size,
         blob_count, min_brightness, max_brightness, rng );
@@ -445,7 +445,7 @@ TEST(Imgproc_FindContours, hilbert)
 {
     int n = 64, n2 = n*n, scale = 10, w = (n + 2)*scale;
     Point ofs(scale, scale);
-    Mat img(w, w, CV_8U);
+    Mat img(w, w, CV_8UC1);
     img.setTo(Scalar::all(0));
 
     Point p(0,0);
@@ -471,12 +471,12 @@ TEST(Imgproc_FindContours, hilbert)
 TEST(Imgproc_FindContours, border)
 {
     Mat img;
-    cv::copyMakeBorder(Mat::zeros(8, 10, CV_8U), img, 1, 1, 1, 1, BORDER_CONSTANT, Scalar(1));
+    cv::copyMakeBorder(Mat::zeros(8, 10, CV_8UC1), img, 1, 1, 1, 1, BORDER_CONSTANT, Scalar(1));
 
     std::vector<std::vector<cv::Point> > contours;
     findContours(img, contours, RETR_LIST, CHAIN_APPROX_NONE);
 
-    Mat img_draw_contours = Mat::zeros(img.size(), CV_8U);
+    Mat img_draw_contours = Mat::zeros(img.size(), CV_8UC1);
     for (size_t cpt = 0; cpt < contours.size(); cpt++)
     {
       drawContours(img_draw_contours, contours, static_cast<int>(cpt), cv::Scalar(1));

--- a/modules/imgproc/test/test_distancetransform.cpp
+++ b/modules/imgproc/test/test_distancetransform.cpp
@@ -49,13 +49,13 @@ public:
     CV_DisTransTest();
 
 protected:
-    void get_test_array_types_and_sizes( int test_case_idx, vector<vector<Size> >& sizes, vector<vector<int> >& types );
-    double get_success_error_level( int test_case_idx, int i, int j );
-    void run_func();
-    void prepare_to_validation( int );
+    void get_test_array_types_and_sizes(int test_case_idx, vector<vector<Size> >& sizes, vector<vector<ElemType> >& types) CV_OVERRIDE;
+    double get_success_error_level(int test_case_idx, int i, int j) CV_OVERRIDE;
+    void run_func() CV_OVERRIDE;
+    void prepare_to_validation(int) CV_OVERRIDE;
 
-    void get_minmax_bounds( int i, int j, int type, Scalar& low, Scalar& high );
-    int prepare_test_case( int test_case_idx );
+    void get_minmax_bounds(int i, int j, ElemDepth depth, Scalar& low, Scalar& high) CV_OVERRIDE;
+    int prepare_test_case(int test_case_idx) CV_OVERRIDE;
 
     int mask_size;
     int dist_type;
@@ -77,7 +77,7 @@ CV_DisTransTest::CV_DisTransTest()
 
 
 void CV_DisTransTest::get_test_array_types_and_sizes( int test_case_idx,
-                                                vector<vector<Size> >& sizes, vector<vector<int> >& types )
+                                                vector<vector<Size> >& sizes, vector<vector<ElemType> >& types )
 {
     RNG& rng = ts->get_rng();
     cvtest::ArrayTest::get_test_array_types_and_sizes( test_case_idx, sizes, types );
@@ -113,10 +113,10 @@ double CV_DisTransTest::get_success_error_level( int /*test_case_idx*/, int /*i*
 }
 
 
-void CV_DisTransTest::get_minmax_bounds( int i, int j, int type, Scalar& low, Scalar& high )
+void CV_DisTransTest::get_minmax_bounds( int i, int j, ElemDepth depth, Scalar& low, Scalar& high )
 {
-    cvtest::ArrayTest::get_minmax_bounds( i, j, type, low, high );
-    if( i == INPUT && CV_MAT_DEPTH(type) == CV_8U )
+    cvtest::ArrayTest::get_minmax_bounds( i, j, depth, low, high );
+    if( i == INPUT && depth == CV_8U )
     {
         low = Scalar::all(0);
         high = Scalar::all(10);
@@ -188,7 +188,7 @@ cvTsDistTransform( const CvMat* _src, CvMat* _dst, int dist_type,
         mask[2] = 2.1969f;
     }
 
-    temp = cvCreateMat( height + mask_size-1, width + mask_size-1, CV_32F );
+    temp = cvCreateMat( height + mask_size-1, width + mask_size-1, CV_32FC1);
     tstep = temp->step / sizeof(float);
 
     if( mask_size == 3 )
@@ -296,7 +296,7 @@ BIGDATA_TEST(Imgproc_DistanceTransform, large_image_12218)
     distanceTransform(src, dst, labels, cv::DIST_L2, cv::DIST_MASK_3, DIST_LABEL_PIXEL);
 
     double scale = (double)lls_mincnt / (double)lls_maxcnt;
-    labels.convertTo(labels, CV_32SC1, scale);
+    labels.convertTo(labels, CV_32S, scale);
     Size size = labels.size();
     nz = cv::countNonZero(labels);
     EXPECT_EQ(nz, (size.height*size.width / 2));

--- a/modules/imgproc/test/test_drawing.cpp
+++ b/modules/imgproc/test/test_drawing.cpp
@@ -573,7 +573,7 @@ protected:
         line2.push_back(Point(10, 16));
         line2.push_back(Point(2, 16));
 
-        Mat gray0(10,10,CV_8U, Scalar(0));
+        Mat gray0(10,10,CV_8UC1, Scalar(0));
         fillConvexPoly(gray0, line1, Scalar(255), 8, 0);
         int nz1 = countNonZero(gray0);
 

--- a/modules/imgproc/test/test_emd.cpp
+++ b/modules/imgproc/test/test_emd.cpp
@@ -71,9 +71,9 @@ void CV_EMDTest::run( int )
     };
     static float  w1[] = { 50, 60, 50, 50 },
                   w2[] = { 30, 20, 70, 30, 60 };
-    Mat _w1(4, 1, CV_32F, w1);
-    Mat _w2(5, 1, CV_32F, w2);
-    Mat _cost(_w1.rows, _w2.rows, CV_32F, cost);
+    Mat _w1(4, 1, CV_32FC1, w1);
+    Mat _w2(5, 1, CV_32FC1, w2);
+    Mat _cost(_w1.rows, _w2.rows, CV_32FC1, cost);
 
     float emd = EMD( _w1, _w2, -1, _cost );
     if( fabs( emd - emd0 ) > success_error_level*emd0 )

--- a/modules/imgproc/test/test_goodfeaturetotrack.cpp
+++ b/modules/imgproc/test/test_goodfeaturetotrack.cpp
@@ -76,23 +76,23 @@ test_cornerEigenValsVecs( const Mat& src, Mat& eigenv, int block_size,
     CV_Assert( ( src.rows == eigenv.rows ) &&
               (((mode == MINEIGENVAL)||(mode == HARRIS)) && (src.cols == eigenv.cols)) );
 
-    int type = src.type();
-    int ftype = CV_32FC1;
+    ElemDepth depth = src.depth();
+    ElemDepth fdepth = CV_32F;
     double kernel_scale = 1;
 
-    Mat dx2, dy2, dxdy(src.size(), CV_32F), kernel;
+    Mat dx2, dy2, dxdy(src.size(), CV_32FC1), kernel;
 
     kernel = cvtest::calcSobelKernel2D( 1, 0, _aperture_size );
-    cvtest::filter2D( src, dx2, ftype, kernel*kernel_scale, anchor, 0, borderType, borderValue );
+    cvtest::filter2D(src, dx2, fdepth, kernel*kernel_scale, anchor, 0, borderType, borderValue);
     kernel = cvtest::calcSobelKernel2D( 0, 1, _aperture_size );
-    cvtest::filter2D( src, dy2, ftype, kernel*kernel_scale, anchor, 0, borderType,borderValue );
+    cvtest::filter2D(src, dy2, fdepth, kernel*kernel_scale, anchor, 0, borderType, borderValue);
 
     double denom = (1 << (aperture_size-1))*block_size;
     denom = denom * denom;
 
     if( _aperture_size < 0 )
         denom *= 4;
-    if(type != ftype )
+    if (depth != fdepth)
         denom *= 255.;
 
     denom = 1./denom;
@@ -112,12 +112,12 @@ test_cornerEigenValsVecs( const Mat& src, Mat& eigenv, int block_size,
         }
     }
 
-    kernel = Mat::ones(block_size, block_size, CV_32F);
+    kernel = Mat::ones(block_size, block_size, CV_32FC1);
     anchor = Point(block_size/2, block_size/2);
 
-    cvtest::filter2D( dx2, dx2, ftype, kernel, anchor, 0, borderType, borderValue );
-    cvtest::filter2D( dy2, dy2, ftype, kernel, anchor, 0, borderType, borderValue );
-    cvtest::filter2D( dxdy, dxdy, ftype, kernel, anchor, 0, borderType, borderValue );
+    cvtest::filter2D(dx2, dx2, fdepth, kernel, anchor, 0, borderType, borderValue);
+    cvtest::filter2D(dy2, dy2, fdepth, kernel, anchor, 0, borderType, borderValue);
+    cvtest::filter2D(dxdy, dxdy, fdepth, kernel, anchor, 0, borderType, borderValue);
 
     if( mode == MINEIGENVAL )
     {
@@ -173,7 +173,7 @@ test_goodFeaturesToTrack( InputArray _image, OutputArray _corners,
 
     Mat eig, tmp, tt;
 
-    eig.create( image.size(), CV_32F );
+    eig.create( image.size(), CV_32FC1 );
 
     if( useHarrisDetector )
         test_cornerEigenValsVecs( image, eig, blockSize, aperture_size, harrisK, HARRIS, borderType, 0 );
@@ -300,7 +300,7 @@ test_goodFeaturesToTrack( InputArray _image, OutputArray _corners,
         }
     }
 
-    Mat(corners).convertTo(_corners, _corners.fixedType() ? _corners.type() : CV_32F);
+    Mat(corners).convertTo(_corners, _corners.fixedType() ? _corners.depth() : CV_32F);
 
 }
 
@@ -371,7 +371,7 @@ void CV_GoodFeatureToTTest::run_func()
     int cn = src_gray.channels();
 
     CV_Assert( cn == 1 );
-    CV_Assert( ( CV_MAT_DEPTH(SrcType) == CV_32FC1 ) || ( CV_MAT_DEPTH(SrcType) == CV_8UC1 ));
+    CV_Assert( ( CV_MAT_DEPTH(SrcType) == CV_32F ) || ( CV_MAT_DEPTH(SrcType) == CV_8U ));
 
     TEST_MESSAGEL ("             maxCorners = ", maxCorners)
     if (useHarrisDetector)
@@ -383,9 +383,9 @@ void CV_GoodFeatureToTTest::run_func()
         TEST_MESSAGE ("             useHarrisDetector = false\n");
     }
 
-    if( CV_MAT_DEPTH(SrcType) == CV_32FC1)
+    if( CV_MAT_DEPTH(SrcType) == CV_32F)
     {
-        if (src_gray.depth() != CV_32FC1 ) src_gray.convertTo(src_gray32f, CV_32FC1);
+        if (src_gray.depth() != CV_32F ) src_gray.convertTo(src_gray32f, CV_32F);
         else   src_gray32f = src_gray.clone();
 
         TEST_MESSAGE ("goodFeaturesToTrack 32f\n")
@@ -403,7 +403,7 @@ void CV_GoodFeatureToTTest::run_func()
     }
     else
     {
-        if (src_gray.depth() != CV_8UC1 ) src_gray.convertTo(src_gray8U, CV_8UC1);
+        if (src_gray.depth() != CV_8U ) src_gray.convertTo(src_gray8U, CV_8U);
         else   src_gray8U = src_gray.clone();
 
         TEST_MESSAGE ("goodFeaturesToTrack 8U\n")
@@ -426,9 +426,9 @@ int CV_GoodFeatureToTTest::validate_test_results( int test_case_idx )
 {
     static const double eps = 2e-6;
 
-    if( CV_MAT_DEPTH(SrcType) == CV_32FC1 )
+    if( CV_MAT_DEPTH(SrcType) == CV_32F )
     {
-        if (src_gray.depth() != CV_32FC1 ) src_gray.convertTo(src_gray32f, CV_32FC1);
+        if (src_gray.depth() != CV_32F ) src_gray.convertTo(src_gray32f, CV_32F);
         else   src_gray32f = src_gray.clone();
 
         TEST_MESSAGE ("test_goodFeaturesToTrack 32f\n")
@@ -446,7 +446,7 @@ int CV_GoodFeatureToTTest::validate_test_results( int test_case_idx )
     }
     else
     {
-        if (src_gray.depth() != CV_8UC1 ) src_gray.convertTo(src_gray8U, CV_8UC1);
+        if (src_gray.depth() != CV_8U ) src_gray.convertTo(src_gray8U, CV_8U);
         else   src_gray8U = src_gray.clone();
 
         TEST_MESSAGE ("test_goodFeaturesToTrack 8U\n")

--- a/modules/imgproc/test/test_moments.cpp
+++ b/modules/imgproc/test/test_moments.cpp
@@ -59,12 +59,12 @@ public:
 protected:
 
     enum { MOMENT_COUNT = 25 };
-    int prepare_test_case( int test_case_idx );
-    void prepare_to_validation( int /*test_case_idx*/ );
-    void get_test_array_types_and_sizes( int test_case_idx, vector<vector<Size> >& sizes, vector<vector<int> >& types );
-    void get_minmax_bounds( int i, int j, int type, Scalar& low, Scalar& high );
-    double get_success_error_level( int test_case_idx, int i, int j );
-    void run_func();
+    int prepare_test_case(int test_case_idx) CV_OVERRIDE;
+    void prepare_to_validation(int /*test_case_idx*/) CV_OVERRIDE;
+    void get_test_array_types_and_sizes(int test_case_idx, vector<vector<Size> >& sizes, vector<vector<ElemType> >& types) CV_OVERRIDE;
+    void get_minmax_bounds(int i, int j, ElemDepth depth, Scalar& low, Scalar& high) CV_OVERRIDE;
+    double get_success_error_level(int test_case_idx, int i, int j) CV_OVERRIDE;
+    void run_func() CV_OVERRIDE;
     bool is_binary;
     bool try_umat_;
 };
@@ -82,10 +82,9 @@ CV_MomentsTest::CV_MomentsTest(bool try_umat) :
 }
 
 
-void CV_MomentsTest::get_minmax_bounds( int i, int j, int type, Scalar& low, Scalar& high )
+void CV_MomentsTest::get_minmax_bounds(int i, int j, ElemDepth depth, Scalar& low, Scalar& high)
 {
-    cvtest::ArrayTest::get_minmax_bounds( i, j, type, low, high );
-    int depth = CV_MAT_DEPTH(type);
+    cvtest::ArrayTest::get_minmax_bounds( i, j, depth, low, high );
 
     if( depth == CV_16U )
     {
@@ -105,11 +104,11 @@ void CV_MomentsTest::get_minmax_bounds( int i, int j, int type, Scalar& low, Sca
 }
 
 void CV_MomentsTest::get_test_array_types_and_sizes( int test_case_idx,
-                                                vector<vector<Size> >& sizes, vector<vector<int> >& types )
+                                                vector<vector<Size> >& sizes, vector<vector<ElemType> >& types )
 {
     RNG& rng = ts->get_rng();
     cvtest::ArrayTest::get_test_array_types_and_sizes( test_case_idx, sizes, types );
-    int depth = cvtest::randInt(rng) % 4;
+    ElemDepth depth = static_cast<ElemDepth>(cvtest::randInt(rng) % 4);
     depth = depth == 0 ? CV_8U : depth == 1 ? CV_16U : depth == 2 ? CV_16S : CV_32F;
 
     is_binary = cvtest::randInt(rng) % 2 != 0;
@@ -132,7 +131,7 @@ void CV_MomentsTest::get_test_array_types_and_sizes( int test_case_idx,
 
 double CV_MomentsTest::get_success_error_level( int /*test_case_idx*/, int /*i*/, int /*j*/ )
 {
-    int depth = test_mat[INPUT][0].depth();
+    ElemDepth depth = test_mat[INPUT][0].depth();
     return depth != CV_32F ? FLT_EPSILON*10 : FLT_EPSILON*100;
 }
 
@@ -181,7 +180,7 @@ void CV_MomentsTest::prepare_to_validation( int /*test_case_idx*/ )
     Mat& src = test_mat[INPUT][0];
     CvMoments m = cvMoments();
     double* mdata = test_mat[REF_OUTPUT][0].ptr<double>();
-    int depth = src.depth();
+    ElemDepth depth = src.depth();
     int cn = src.channels();
     int i, y, x, cols = src.cols;
     double xc = 0., yc = 0.;
@@ -311,12 +310,12 @@ protected:
 
     enum { MOMENT_COUNT = 18, HU_MOMENT_COUNT = 7 };
 
-    int prepare_test_case( int test_case_idx );
-    void prepare_to_validation( int /*test_case_idx*/ );
-    void get_test_array_types_and_sizes( int test_case_idx, vector<vector<Size> >& sizes, vector<vector<int> >& types );
-    void get_minmax_bounds( int i, int j, int type, Scalar& low, Scalar& high );
-    double get_success_error_level( int test_case_idx, int i, int j );
-    void run_func();
+    int prepare_test_case(int test_case_idx) CV_OVERRIDE;
+    void prepare_to_validation(int /*test_case_idx*/) CV_OVERRIDE;
+    void get_test_array_types_and_sizes( int test_case_idx, vector<vector<Size> >& sizes, vector<vector<ElemType> >& types ) CV_OVERRIDE;
+    void get_minmax_bounds(int i, int j, ElemDepth depth, Scalar& low, Scalar& high) CV_OVERRIDE;
+    double get_success_error_level(int test_case_idx, int i, int j) CV_OVERRIDE;
+    void run_func() CV_OVERRIDE;
 };
 
 
@@ -328,16 +327,16 @@ CV_HuMomentsTest::CV_HuMomentsTest()
 }
 
 
-void CV_HuMomentsTest::get_minmax_bounds( int i, int j, int type, Scalar& low, Scalar& high )
+void CV_HuMomentsTest::get_minmax_bounds(int i, int j, ElemDepth depth, Scalar& low, Scalar& high)
 {
-    cvtest::ArrayTest::get_minmax_bounds( i, j, type, low, high );
+    cvtest::ArrayTest::get_minmax_bounds( i, j, depth, low, high );
     low = Scalar::all(-10000);
     high = Scalar::all(10000);
 }
 
 
 void CV_HuMomentsTest::get_test_array_types_and_sizes( int test_case_idx,
-                                                vector<vector<Size> >& sizes, vector<vector<int> >& types )
+                                                vector<vector<Size> >& sizes, vector<vector<ElemType> >& types )
 {
     cvtest::ArrayTest::get_test_array_types_and_sizes( test_case_idx, sizes, types );
     types[INPUT][0] = types[OUTPUT][0] = types[REF_OUTPUT][0] = CV_64FC1;

--- a/modules/imgproc/test/test_pc.cpp
+++ b/modules/imgproc/test/test_pc.cpp
@@ -59,8 +59,8 @@ void CV_PhaseCorrelatorTest::run( int )
 {
     ts->set_failed_test_info(cvtest::TS::OK);
 
-    Mat r1 = Mat::ones(Size(129, 128), CV_64F);
-    Mat r2 = Mat::ones(Size(129, 128), CV_64F);
+    Mat r1 = Mat::ones(Size(129, 128), CV_64FC1);
+    Mat r2 = Mat::ones(Size(129, 128), CV_64FC1);
 
     double expectedShiftX = -10.0;
     double expectedShiftY = -20.0;
@@ -70,7 +70,7 @@ void CV_PhaseCorrelatorTest::run( int )
     cv::rectangle(r2, Point(90, 80), Point(100, 90), Scalar(0, 0, 0), CV_FILLED);
 
     Mat hann;
-    createHanningWindow(hann, r1.size(), CV_64F);
+    createHanningWindow(hann, r1.size(), CV_64FC1);
     Point2d phaseShift = phaseCorrelate(r1, r2, hann);
 
     // test accuracy should be less than 1 pixel...
@@ -85,7 +85,7 @@ TEST(Imgproc_PhaseCorrelatorTest, accuracy) { CV_PhaseCorrelatorTest test; test.
 TEST(Imgproc_PhaseCorrelatorTest, accuracy_real_img)
 {
     Mat img = imread(cvtest::TS::ptr()->get_data_path() + "shared/airplane.png", IMREAD_GRAYSCALE);
-    img.convertTo(img, CV_64FC1);
+    img.convertTo(img, CV_64F);
 
     const int xLen = 129;
     const int yLen = 129;
@@ -96,7 +96,7 @@ TEST(Imgproc_PhaseCorrelatorTest, accuracy_real_img)
     Mat roi2 = img(Rect(0, 0, xLen, yLen));
 
     Mat hann;
-    createHanningWindow(hann, roi1.size(), CV_64F);
+    createHanningWindow(hann, roi1.size(), CV_64FC1);
     Point2d phaseShift = phaseCorrelate(roi1, roi2, hann);
 
     ASSERT_NEAR(phaseShift.x, (double)xShift, 1.);
@@ -104,8 +104,8 @@ TEST(Imgproc_PhaseCorrelatorTest, accuracy_real_img)
 }
 
 TEST(Imgproc_PhaseCorrelatorTest, accuracy_1d_odd_fft) {
-    Mat r1 = Mat::ones(Size(129, 1), CV_64F)*255; // 129 will be completed to 135 before FFT
-    Mat r2 = Mat::ones(Size(129, 1), CV_64F)*255;
+    Mat r1 = Mat::ones(Size(129, 1), CV_64FC1)*255; // 129 will be completed to 135 before FFT
+    Mat r2 = Mat::ones(Size(129, 1), CV_64FC1)*255;
 
     const int xShift = 10;
 

--- a/modules/imgproc/test/test_resize_bitexact.cpp
+++ b/modules/imgproc/test/test_resize_bitexact.cpp
@@ -24,7 +24,7 @@ TEST(Resize_Bitexact, Linear8U)
 
     struct testmode
     {
-        int type;
+        ElemType type;
         Size sz;
     } modes[] = {
         { CV_8UC1, Size( 512, 768) }, //   1/2       1
@@ -73,7 +73,9 @@ TEST(Resize_Bitexact, Linear8U)
 
     for (int modeind = 0, _modecnt = sizeof(modes) / sizeof(modes[0]); modeind < _modecnt; ++modeind)
         {
-            int type = modes[modeind].type, depth = CV_MAT_DEPTH(type), cn = CV_MAT_CN(type);
+            ElemType type = modes[modeind].type;
+            ElemDepth depth = CV_MAT_DEPTH(type);
+            int cn = CV_MAT_CN(type);
             int dcols = modes[modeind].sz.width, drows = modes[modeind].sz.height;
             int cols = 1024, rows = 768;
 

--- a/modules/imgproc/test/test_smooth_bitexact.cpp
+++ b/modules/imgproc/test/test_smooth_bitexact.cpp
@@ -40,7 +40,7 @@ TEST(GaussianBlur_Bitexact, Linear8U)
 {
     struct testmode
     {
-        int type;
+        ElemType type;
         Size sz;
         Size kernel;
         double sigma_x;
@@ -90,7 +90,9 @@ TEST(GaussianBlur_Bitexact, Linear8U)
 
     for (int modeind = 0, _modecnt = sizeof(modes) / sizeof(modes[0]); modeind < _modecnt; ++modeind)
     {
-        int type = modes[modeind].type, depth = CV_MAT_DEPTH(type), cn = CV_MAT_CN(type);
+        ElemType type = modes[modeind].type;
+        ElemDepth depth = CV_MAT_DEPTH(type);
+        int cn = CV_MAT_CN(type);
         int dcols = modes[modeind].sz.width, drows = modes[modeind].sz.height;
         Size kernel = modes[modeind].kernel;
 

--- a/modules/imgproc/test/test_templmatch.cpp
+++ b/modules/imgproc/test/test_templmatch.cpp
@@ -49,12 +49,12 @@ public:
     CV_TemplMatchTest();
 
 protected:
-    int read_params( CvFileStorage* fs );
-    void get_test_array_types_and_sizes( int test_case_idx, vector<vector<Size> >& sizes, vector<vector<int> >& types );
-    void get_minmax_bounds( int i, int j, int type, Scalar& low, Scalar& high );
-    double get_success_error_level( int test_case_idx, int i, int j );
-    void run_func();
-    void prepare_to_validation( int );
+    int read_params(CvFileStorage* fs) CV_OVERRIDE;
+    void get_test_array_types_and_sizes(int test_case_idx, vector<vector<Size> >& sizes, vector<vector<ElemType> >& types) CV_OVERRIDE;
+    void get_minmax_bounds(int i, int j, ElemDepth depth, Scalar& low, Scalar& high) CV_OVERRIDE;
+    double get_success_error_level(int test_case_idx, int i, int j) CV_OVERRIDE;
+    void run_func() CV_OVERRIDE;
+    void prepare_to_validation(int) CV_OVERRIDE;
 
     int max_template_size;
     int method;
@@ -88,10 +88,9 @@ int CV_TemplMatchTest::read_params( CvFileStorage* fs )
 }
 
 
-void CV_TemplMatchTest::get_minmax_bounds( int i, int j, int type, Scalar& low, Scalar& high )
+void CV_TemplMatchTest::get_minmax_bounds(int i, int j, ElemDepth depth, Scalar& low, Scalar& high)
 {
-    cvtest::ArrayTest::get_minmax_bounds( i, j, type, low, high );
-    int depth = CV_MAT_DEPTH(type);
+    cvtest::ArrayTest::get_minmax_bounds( i, j, depth, low, high );
     if( depth == CV_32F )
     {
         low = Scalar::all(-10.);
@@ -101,10 +100,11 @@ void CV_TemplMatchTest::get_minmax_bounds( int i, int j, int type, Scalar& low, 
 
 
 void CV_TemplMatchTest::get_test_array_types_and_sizes( int test_case_idx,
-                                                vector<vector<Size> >& sizes, vector<vector<int> >& types )
+                                                vector<vector<Size> >& sizes, vector<vector<ElemType> >& types )
 {
     RNG& rng = ts->get_rng();
-    int depth = cvtest::randInt(rng) % 2, cn = cvtest::randInt(rng) & 1 ? 3 : 1;
+    ElemDepth depth = static_cast<ElemDepth>(cvtest::randInt(rng) % 2);
+    int cn = cvtest::randInt(rng) & 1 ? 3 : 1;
     cvtest::ArrayTest::get_test_array_types_and_sizes( test_case_idx, sizes, types );
     depth = depth == 0 ? CV_8U : CV_32F;
 
@@ -147,7 +147,8 @@ void CV_TemplMatchTest::run_func()
 static void cvTsMatchTemplate( const CvMat* img, const CvMat* templ, CvMat* result, int method )
 {
     int i, j, k, l;
-    int depth = CV_MAT_DEPTH(img->type), cn = CV_MAT_CN(img->type);
+    ElemDepth depth = CV_MAT_DEPTH(img->type);
+    int cn = CV_MAT_CN(img->type);
     int width_n = templ->cols*cn, height = templ->rows;
     int a_step = img->step / CV_ELEM_SIZE(img->type & CV_MAT_DEPTH_MASK);
     int b_step = templ->step / CV_ELEM_SIZE(templ->type & CV_MAT_DEPTH_MASK);

--- a/modules/imgproc/test/test_thresh.cpp
+++ b/modules/imgproc/test/test_thresh.cpp
@@ -49,10 +49,10 @@ public:
     CV_ThreshTest();
 
 protected:
-    void get_test_array_types_and_sizes( int test_case_idx, vector<vector<Size> >& sizes, vector<vector<int> >& types );
-    double get_success_error_level( int test_case_idx, int i, int j );
-    void run_func();
-    void prepare_to_validation( int );
+    void get_test_array_types_and_sizes( int test_case_idx, vector<vector<Size> >& sizes, vector<vector<ElemType> >& types ) CV_OVERRIDE;
+    double get_success_error_level( int test_case_idx, int i, int j ) CV_OVERRIDE;
+    void run_func() CV_OVERRIDE;
+    void prepare_to_validation( int ) CV_OVERRIDE;
 
     int thresh_type;
     double thresh_val;
@@ -71,10 +71,11 @@ CV_ThreshTest::CV_ThreshTest()
 
 
 void CV_ThreshTest::get_test_array_types_and_sizes( int test_case_idx,
-                                                vector<vector<Size> >& sizes, vector<vector<int> >& types )
+                                                vector<vector<Size> >& sizes, vector<vector<ElemType> >& types )
 {
     RNG& rng = ts->get_rng();
-    int depth = cvtest::randInt(rng) % 5, cn = cvtest::randInt(rng) % 4 + 1;
+    ElemDepth depth = static_cast<ElemDepth>(cvtest::randInt(rng) % 5);
+    int cn = cvtest::randInt(rng) % 4 + 1;
     cvtest::ArrayTest::get_test_array_types_and_sizes( test_case_idx, sizes, types );
     depth = depth == 0 ? CV_8U : depth == 1 ? CV_16S : depth == 2 ? CV_16U : depth == 3 ? CV_32F : CV_64F;
 
@@ -131,7 +132,8 @@ static void test_threshold( const Mat& _src, Mat& _dst,
                             double thresh, double maxval, int thresh_type )
 {
     int i, j;
-    int depth = _src.depth(), cn = _src.channels();
+    ElemDepth depth = _src.depth();
+    int cn = _src.channels();
     int width_n = _src.cols*cn, height = _src.rows;
     int ithresh = cvFloor(thresh);
     int imaxval, ithresh2;
@@ -422,7 +424,7 @@ TEST(Imgproc_Threshold, accuracy) { CV_ThreshTest test; test.safe_run(); }
 
 BIGDATA_TEST(Imgproc_Threshold, huge)
 {
-    Mat m(65000, 40000, CV_8U);
+    Mat m(65000, 40000, CV_8UC1);
     ASSERT_FALSE(m.isContinuous());
 
     uint64 i, n = (uint64)m.rows*m.cols;

--- a/modules/java/generator/gen_java.py
+++ b/modules/java/generator/gen_java.py
@@ -64,7 +64,9 @@ type_dict = {
     "size_t"  : { "j_type" : "long", "jn_type" : "long", "jni_type" : "jlong", "suffix" : "J" },
     "__int64" : { "j_type" : "long", "jn_type" : "long", "jni_type" : "jlong", "suffix" : "J" },
     "int64"   : { "j_type" : "long", "jn_type" : "long", "jni_type" : "jlong", "suffix" : "J" },
-    "double[]": { "j_type" : "double[]", "jn_type" : "double[]", "jni_type" : "jdoubleArray", "suffix" : "_3D" }
+    "double[]": { "j_type" : "double[]", "jn_type" : "double[]", "jni_type" : "jdoubleArray", "suffix" : "_3D" },
+    "ElemType": { "j_type" : "int", "jn_type" : "int", "jni_type" : "jint", "suffix" : "I", "cast_from" : "int", "cast_to" : "ElemType" },
+    "ElemDepth": { "j_type" : "int", "jn_type" : "int", "jni_type" : "jint", "suffix" : "I", "cast_from" : "int", "cast_to" : "ElemDepth" },
 }
 
 # Defines a rule to add extra prefixes for names from specific namespaces.

--- a/modules/ml/test/test_emknearestkmeans.cpp
+++ b/modules/ml/test/test_emknearestkmeans.cpp
@@ -47,7 +47,7 @@ using cv::ml::TrainData;
 using cv::ml::EM;
 using cv::ml::KNearest;
 
-void defaultDistribs( Mat& means, vector<Mat>& covs, int type=CV_32FC1 )
+void defaultDistribs( Mat& means, vector<Mat>& covs, ElemType type=CV_32FC1 )
 {
     CV_TRACE_FUNCTION();
     float mp0[] = {0.0f, 0.0f}, cp0[] = {0.67f, 0.0f, 0.0f, 0.67f};
@@ -60,20 +60,21 @@ void defaultDistribs( Mat& means, vector<Mat>& covs, int type=CV_32FC1 )
     means.resize(3), covs.resize(3);
 
     Mat mr0 = means.row(0);
-    m0.convertTo(mr0, type);
-    c0.convertTo(covs[0], type);
+    ElemDepth depth = CV_MAT_DEPTH(type);
+    m0.convertTo(mr0, depth);
+    c0.convertTo(covs[0], depth);
 
     Mat mr1 = means.row(1);
-    m1.convertTo(mr1, type);
-    c1.convertTo(covs[1], type);
+    m1.convertTo(mr1, depth);
+    c1.convertTo(covs[1], depth);
 
     Mat mr2 = means.row(2);
-    m2.convertTo(mr2, type);
-    c2.convertTo(covs[2], type);
+    m2.convertTo(mr2, depth);
+    c2.convertTo(covs[2], depth);
 }
 
 // generate points sets by normal distributions
-void generateData( Mat& data, Mat& labels, const vector<int>& sizes, const Mat& _means, const vector<Mat>& covs, int dataType, int labelType )
+void generateData( Mat& data, Mat& labels, const vector<int>& sizes, const Mat& _means, const vector<Mat>& covs, int dataType, ElemType labelType )
 {
     CV_TRACE_FUNCTION();
     vector<int>::const_iterator sit = sizes.begin();

--- a/modules/ml/test/test_mltests.cpp
+++ b/modules/ml/test/test_mltests.cpp
@@ -165,8 +165,8 @@ TEST(ML_NBAYES, regression_5911)
     EXPECT_EQ(sum(P1 == P2)[0], 255 * P2.total());
 
     // bulk prediction, with non-continuous memory storage
-    Mat R3_(N, 1+1, CV_32S),
-        P3_(N, 3+1, CV_32F);
+    Mat R3_(N, 1+1, CV_32SC1),
+        P3_(N, 3+1, CV_32FC1);
     nb->predictProb(X, R3_.col(0), P3_.colRange(0,3));
     Mat R3 = R3_.col(0).clone(),
         P3 = P3_.colRange(0,3).clone();
@@ -187,7 +187,7 @@ TEST(ML_RTrees, getVotes)
     Ptr<ml::RTrees> rt = cv::ml::RTrees::create();
 
     //data
-    Mat data(n, 4, CV_32F);
+    Mat data(n, 4, CV_32FC1);
     randu(data, 0, 10);
 
     //labels
@@ -196,7 +196,7 @@ TEST(ML_RTrees, getVotes)
     rt->train(data, ml::ROW_SAMPLE, labels);
 
     //run function
-    Mat test(1, 4, CV_32F);
+    Mat test(1, 4, CV_32FC1);
     Mat result;
     randu(test, 0, 10);
     rt->getVotes(test, result, 0);

--- a/modules/ml/test/test_mltests2.cpp
+++ b/modules/ml/test/test_mltests2.cpp
@@ -136,7 +136,7 @@ Mat ann_get_new_responses( Ptr<TrainData> _data, map<int, int>& cls_map )
         if( it == cls_map.end() )
             cls_map[r] = cls_count++;
     }
-    Mat new_responses = Mat::zeros( nresponses, cls_count, CV_32F );
+    Mat new_responses = Mat::zeros( nresponses, cls_count, CV_32FC1);
     for( si = 0; si < n; si++ )
     {
         int sidx = train_sidx_ptr ? train_sidx_ptr[si] : si;
@@ -560,7 +560,7 @@ int CV_MLBaseTest::train( int testCaseIdx )
         data = TrainData::create(data->getSamples(), data->getLayout(), new_responses,
                                  data->getVarIdx(), data->getTrainSampleIdx());
         int layer_sz[] = { data->getNAllVars(), 100, 100, (int)cls_map.size() };
-        Mat layer_sizes( 1, (int)(sizeof(layer_sz)/sizeof(layer_sz[0])), CV_32S, layer_sz );
+        Mat layer_sizes( 1, (int)(sizeof(layer_sz)/sizeof(layer_sz[0])), CV_32SC1, layer_sz );
         Ptr<ANN_MLP> m = ANN_MLP::create();
         m->setLayerSizes(layer_sizes);
         m->setActivationFunction(ANN_MLP::SIGMOID_SYM, 0, 0);

--- a/modules/ml/test/test_save_load.cpp
+++ b/modules/ml/test/test_save_load.cpp
@@ -208,7 +208,7 @@ protected:
         }
         else
         {
-            Mat input = Mat(isTree ? 10 : 1, model->getVarCount(), CV_32F);
+            Mat input = Mat(isTree ? 10 : 1, model->getVarCount(), CV_32FC1);
             ts->get_rng().fill(input, RNG::UNIFORM, 0, 40);
 
             if (isTree)
@@ -285,7 +285,7 @@ TEST(DISABLED_ML_SVM, linear_save_load)
     ASSERT_EQ(svm1->getVarCount(), svm3->getVarCount());
 
     int m = 10000, n = svm1->getVarCount();
-    Mat samples(m, n, CV_32F), r1, r2, r3;
+    Mat samples(m, n, CV_32FC1), r1, r2, r3;
     randu(samples, 0., 1.);
 
     svm1->predict(samples, r1);

--- a/modules/ml/test/test_svmtrainauto.cpp
+++ b/modules/ml/test/test_svmtrainauto.cpp
@@ -58,7 +58,7 @@ void CV_SVMTrainAutoTest::run( int /*start_from*/ )
 {
     int datasize = 100;
     cv::Mat samples = cv::Mat::zeros( datasize, 2, CV_32FC1 );
-    cv::Mat responses = cv::Mat::zeros( datasize, 1, CV_32S );
+    cv::Mat responses = cv::Mat::zeros( datasize, 1, CV_32SC1);
 
     RNG rng(0);
     for (int i = 0; i < datasize; ++i)
@@ -93,7 +93,7 @@ TEST(ML_SVM, trainAuto_regression_5369)
 {
     int datasize = 100;
     cv::Mat samples = cv::Mat::zeros( datasize, 2, CV_32FC1 );
-    cv::Mat responses = cv::Mat::zeros( datasize, 1, CV_32S );
+    cv::Mat responses = cv::Mat::zeros( datasize, 1, CV_32SC1);
 
     RNG rng(0); // fixed!
     for (int i = 0; i < datasize; ++i)

--- a/modules/objdetect/test/opencl/test_hogdetector.cpp
+++ b/modules/objdetect/test/opencl/test_hogdetector.cpp
@@ -115,7 +115,7 @@ OCL_TEST_P(HOG, Detect)
 
 INSTANTIATE_TEST_CASE_P(OCL_ObjDetect, HOG, testing::Combine(
                             testing::Values(Size(64, 128), Size(48, 96)),
-                            testing::Values( MatType(CV_8UC1) ) ) );
+                            testing::Values( CV_8UC1 ) ) );
 
 }} // namespace
 #endif

--- a/modules/objdetect/test/test_cascadeandhog.cpp
+++ b/modules/objdetect/test/test_cascadeandhog.cpp
@@ -1169,7 +1169,7 @@ void HOGDescriptorTester::compute(InputArray _img, vector<float>& descriptors,
 void HOGDescriptorTester::computeGradient(const Mat& img, Mat& grad, Mat& qangle,
    Size paddingTL, Size paddingBR) const
 {
-    CV_Assert( img.type() == CV_8U || img.type() == CV_8UC3 );
+    CV_Assert( img.type() == CV_8UC1 || img.type() == CV_8UC3 );
 
     Size gradsize(img.cols + paddingTL.width + paddingBR.width,
        img.rows + paddingTL.height + paddingBR.height);
@@ -1209,10 +1209,10 @@ void HOGDescriptorTester::computeGradient(const Mat& img, Mat& grad, Mat& qangle
     int width = gradsize.width;
     AutoBuffer<float> _dbuf(width*4);
     float* dbuf = _dbuf.data();
-    Mat Dx(1, width, CV_32F, dbuf);
-    Mat Dy(1, width, CV_32F, dbuf + width);
-    Mat Mag(1, width, CV_32F, dbuf + width*2);
-    Mat Angle(1, width, CV_32F, dbuf + width*3);
+    Mat Dx(1, width, CV_32FC1, dbuf);
+    Mat Dy(1, width, CV_32FC1, dbuf + width);
+    Mat Mag(1, width, CV_32FC1, dbuf + width*2);
+    Mat Angle(1, width, CV_32FC1, dbuf + width*3);
 
     int _nbins = nbins;
     float angleScale = (float)(_nbins/CV_PI);
@@ -1330,7 +1330,7 @@ TEST(Objdetect_HOGDetector_Strict, accuracy)
         // creating a matrix
         Size ssize(rng.uniform(1, 10) * actual_hog.winSize.width,
             rng.uniform(1, 10) * actual_hog.winSize.height);
-        int type = rng.uniform(0, 1) > 0 ? CV_8UC1 : CV_8UC3;
+        ElemType type = rng.uniform(0, 1) > 0 ? CV_8UC1 : CV_8UC3;
         Mat image(ssize, type);
         rng.fill(image, RNG::UNIFORM, 0, 256, true);
 
@@ -1366,7 +1366,7 @@ TEST(Objdetect_CascadeDetector, small_img)
         {
             int width = rng.uniform(1, 100);
             int height = rng.uniform(1, 100);
-            Mat img(height, width, CV_8U);
+            Mat img(height, width, CV_8UC1);
             randu(img, 0, 256);
             cascade.detectMultiScale(img, objects);
         }

--- a/modules/photo/perf/perf_cuda.cpp
+++ b/modules/photo/perf/perf_cuda.cpp
@@ -69,7 +69,7 @@ PERF_TEST_P(Sz_Depth_Cn_WinSz_BlockSz, CUDA_NonLocalMeans,
     declare.time(600.0);
 
     const cv::Size size = GET_PARAM(0);
-    const int depth = GET_PARAM(1);
+    const ElemDepth depth = GET_PARAM(1);
     const int channels = GET_PARAM(2);
     const int search_widow_size = GET_PARAM(3);
     const int block_size = GET_PARAM(4);
@@ -77,7 +77,7 @@ PERF_TEST_P(Sz_Depth_Cn_WinSz_BlockSz, CUDA_NonLocalMeans,
     const float h = 10;
     const int borderMode = cv::BORDER_REFLECT101;
 
-    const int type = CV_MAKE_TYPE(depth, channels);
+    const ElemType type = CV_MAKE_TYPE(depth, channels);
 
     cv::Mat src(size, type);
     declare.in(src, WARMUP_RNG);
@@ -113,12 +113,12 @@ PERF_TEST_P(Sz_Depth_Cn_WinSz_BlockSz, CUDA_FastNonLocalMeans,
     declare.time(60.0);
 
     const cv::Size size = GET_PARAM(0);
-    const int depth = GET_PARAM(1);
+    const ElemDepth depth = GET_PARAM(1);
     const int search_widow_size = GET_PARAM(2);
     const int block_size = GET_PARAM(3);
 
     const float h = 10;
-    const int type = CV_MAKE_TYPE(depth, 1);
+    const ElemType type = CV_MAKE_TYPE(depth, 1);
 
     cv::Mat src(size, type);
     declare.in(src, WARMUP_RNG);
@@ -156,12 +156,12 @@ PERF_TEST_P(Sz_Depth_WinSz_BlockSz, CUDA_FastNonLocalMeansColored,
     declare.time(60.0);
 
     const cv::Size size = GET_PARAM(0);
-    const int depth = GET_PARAM(1);
+    const ElemDepth depth = GET_PARAM(1);
     const int search_widow_size = GET_PARAM(2);
     const int block_size = GET_PARAM(3);
 
     const float h = 10;
-    const int type = CV_MAKE_TYPE(depth, 3);
+    const ElemType type = CV_MAKE_TYPE(depth, 3);
 
     cv::Mat src(size, type);
     declare.in(src, WARMUP_RNG);

--- a/modules/photo/test/ocl/test_denoising.cpp
+++ b/modules/photo/test/ocl/test_denoising.cpp
@@ -39,7 +39,7 @@ PARAM_TEST_CASE(FastNlMeansDenoisingTestBase, Channels, int, bool, bool)
 
     void generateTestData()
     {
-        const int type = CV_8UC(cn);
+        const ElemType type = CV_8UC(cn);
         Mat image;
 
         if (use_image) {

--- a/modules/photo/test/test_denoise_tvl1.cpp
+++ b/modules/photo/test/test_denoise_tvl1.cpp
@@ -45,7 +45,7 @@ namespace opencv_test { namespace {
 void make_noisy(const cv::Mat& img, cv::Mat& noisy, double sigma, double pepper_salt_ratio,cv::RNG& rng)
 {
     noisy.create(img.size(), img.type());
-    cv::Mat noise(img.size(), img.type()), mask(img.size(), CV_8U);
+    cv::Mat noise(img.size(), img.type()), mask(img.size(), CV_8UC1);
     rng.fill(noise,cv::RNG::NORMAL,128.0,sigma);
     cv::addWeighted(img, 1, noise, 1, -128, noisy);
     cv::randn(noise, cv::Scalar::all(0), cv::Scalar::all(2));

--- a/modules/photo/test/test_hdr.cpp
+++ b/modules/photo/test/test_hdr.cpp
@@ -96,31 +96,31 @@ TEST(Photo_Tonemap, regression)
     Ptr<Tonemap> linear = createTonemap(gamma);
     linear->process(img, result);
     loadImage(test_path + "linear.png", expected);
-    result.convertTo(result, CV_8UC3, 255);
+    result.convertTo(result, CV_8U, 255);
     checkEqual(result, expected, 3, "Simple");
 
     Ptr<TonemapDrago> drago = createTonemapDrago(gamma);
     drago->process(img, result);
     loadImage(test_path + "drago.png", expected);
-    result.convertTo(result, CV_8UC3, 255);
+    result.convertTo(result, CV_8U, 255);
     checkEqual(result, expected, 3, "Drago");
 
     Ptr<TonemapDurand> durand = createTonemapDurand(gamma);
     durand->process(img, result);
     loadImage(test_path + "durand.png", expected);
-    result.convertTo(result, CV_8UC3, 255);
+    result.convertTo(result, CV_8U, 255);
     checkEqual(result, expected, 3, "Durand");
 
     Ptr<TonemapReinhard> reinhard = createTonemapReinhard(gamma);
     reinhard->process(img, result);
     loadImage(test_path + "reinhard.png", expected);
-    result.convertTo(result, CV_8UC3, 255);
+    result.convertTo(result, CV_8U, 255);
     checkEqual(result, expected, 3, "Reinhard");
 
     Ptr<TonemapMantiuk> mantiuk = createTonemapMantiuk(gamma);
     mantiuk->process(img, result);
     loadImage(test_path + "mantiuk.png", expected);
-    result.convertTo(result, CV_8UC3, 255);
+    result.convertTo(result, CV_8U, 255);
     checkEqual(result, expected, 3, "Mantiuk");
 }
 
@@ -164,7 +164,7 @@ TEST(Photo_MergeMertens, regression)
     Mat result, expected;
     loadImage(test_path + "merge/mertens.png", expected);
     merge->process(images, result);
-    result.convertTo(result, CV_8UC3, 255);
+    result.convertTo(result, CV_8U, 255);
     checkEqual(expected, result, 3, "Mertens");
 
     Mat uniform(100, 100, CV_8UC3);
@@ -174,7 +174,7 @@ TEST(Photo_MergeMertens, regression)
     images.push_back(uniform);
 
     merge->process(images, result);
-    result.convertTo(result, CV_8UC3, 255);
+    result.convertTo(result, CV_8U, 255);
     checkEqual(uniform, result, 1e-2f, "Mertens");
 }
 

--- a/modules/photo/test/test_inpaint.cpp
+++ b/modules/photo/test/test_inpaint.cpp
@@ -73,7 +73,7 @@ void CV_InpaintTest::run( int )
     }
 
     Mat inv_mask;
-    mask.convertTo(inv_mask, CV_8UC3, -1.0, 255.0);
+    mask.convertTo(inv_mask, CV_8U, -1.0, 255.0);
 
     Mat mask1ch;
     cv::cvtColor(mask, mask1ch, COLOR_BGR2GRAY);
@@ -116,15 +116,15 @@ void CV_InpaintTest::run( int )
 
 TEST(Photo_Inpaint, regression) { CV_InpaintTest test; test.safe_run(); }
 
-typedef testing::TestWithParam<tuple<int> > formats;
+typedef testing::TestWithParam<tuple<MatType> > formats;
 
 TEST_P(formats, 1c)
 {
-    const int type = get<0>(GetParam());
+    const ElemType type = get<0>(GetParam());
     Mat src(100, 100, type);
     src.setTo(Scalar::all(128));
     Mat ref = src.clone();
-    Mat dst, mask = Mat::zeros(src.size(), CV_8U);
+    Mat dst, mask = Mat::zeros(src.size(), CV_8UC1);
 
     circle(src, Point(50, 50), 5, Scalar(200), 6);
     circle(mask, Point(50, 50), 5, Scalar(200), 6);

--- a/modules/shape/test/test_shape.cpp
+++ b/modules/shape/test/test_shape.cpp
@@ -70,7 +70,7 @@ public:
         }
         // distance matrix
         const int totalCount = (int)filenames.size();
-        distanceMat = Mat::zeros(totalCount, totalCount, CV_32F);
+        distanceMat = Mat::zeros(totalCount, totalCount, CV_32FC1);
     }
 
 protected:

--- a/modules/stitching/perf/perf_estimators.cpp
+++ b/modules/stitching/perf/perf_estimators.cpp
@@ -91,7 +91,7 @@ PERF_TEST_P(bundleAdjuster, affine, testing::Combine(TEST_DETECTORS, AFFINE_FUNC
     SANITY_CHECK(R_second, .01, ERROR_ABSOLUTE); // rotations must be more precise
     // last row should be precisely (0, 0, 1) as it is just added for representation in homogeneous
     // coordinates
-    EXPECT_TRUE(h.type() == CV_32F);
+    EXPECT_TRUE(h.type() == CV_32FC1);
     EXPECT_FLOAT_EQ(h.at<float>(0), 0.f);
     EXPECT_FLOAT_EQ(h.at<float>(1), 0.f);
     EXPECT_FLOAT_EQ(h.at<float>(2), 1.f);

--- a/modules/stitching/test/test_blenders.cpp
+++ b/modules/stitching/test/test_blenders.cpp
@@ -53,11 +53,11 @@ TEST(MultiBandBlender, CanBlendTwoImages)
     image1.convertTo(image1s, CV_16S);
     image2.convertTo(image2s, CV_16S);
 
-    Mat mask1(image1s.size(), CV_8U);
+    Mat mask1(image1s.size(), CV_8UC1);
     mask1(Rect(0, 0, mask1.cols/2, mask1.rows)).setTo(255);
     mask1(Rect(mask1.cols/2, 0, mask1.cols - mask1.cols/2, mask1.rows)).setTo(0);
 
-    Mat mask2(image2s.size(), CV_8U);
+    Mat mask2(image2s.size(), CV_8UC1);
     mask2(Rect(0, 0, mask2.cols/2, mask2.rows)).setTo(0);
     mask2(Rect(mask2.cols/2, 0, mask2.cols - mask2.cols/2, mask2.rows)).setTo(255);
 

--- a/modules/stitching/test/test_blenders.cuda.cpp
+++ b/modules/stitching/test/test_blenders.cuda.cpp
@@ -72,11 +72,11 @@ TEST(CUDA_MultiBandBlender, Accuracy)
     image1.convertTo(image1s, CV_16S);
     image2.convertTo(image2s, CV_16S);
 
-    Mat mask1(image1s.size(), CV_8U);
+    Mat mask1(image1s.size(), CV_8UC1);
     mask1(Rect(0, 0, mask1.cols/2, mask1.rows)).setTo(255);
     mask1(Rect(mask1.cols/2, 0, mask1.cols - mask1.cols/2, mask1.rows)).setTo(0);
 
-    Mat mask2(image2s.size(), CV_8U);
+    Mat mask2(image2s.size(), CV_8UC1);
     mask2(Rect(0, 0, mask2.cols/2, mask2.rows)).setTo(0);
     mask2(Rect(mask2.cols/2, 0, mask2.cols - mask2.cols/2, mask2.rows)).setTo(255);
 

--- a/modules/superres/perf/perf_superres.cpp
+++ b/modules/superres/perf/perf_superres.cpp
@@ -116,13 +116,17 @@ namespace
 } // namespace
 
 PERF_TEST_P(Size_MatType, SuperResolution_BTVL1,
-            Combine(Values(szSmall64, szSmall128),
-                    Values(MatType(CV_8UC1), MatType(CV_8UC3))))
+            Combine
+            (
+                Values(szSmall64, szSmall128),
+                Values(CV_8UC1, CV_8UC3)
+            )
+)
 {
     declare.time(5 * 60);
 
     const Size size = get<0>(GetParam());
-    const int type = get<1>(GetParam());
+    const ElemType type = get<1>(GetParam());
 
     Mat frame(size, type);
     declare.in(frame, WARMUP_RNG);
@@ -178,14 +182,14 @@ typedef Size_MatType SuperResolution_BTVL1;
 
 OCL_PERF_TEST_P(SuperResolution_BTVL1 ,BTVL1,
             Combine(Values(szSmall64, szSmall128),
-                    Values(MatType(CV_8UC1), MatType(CV_8UC3))))
+                    Values(CV_8UC1, CV_8UC3)))
 {
     Size_MatType_t params = GetParam();
     const Size size = get<0>(params);
-    const int type = get<1>(params);
+    const ElemType type = get<1>(params);
 
     Mat frame(size, type);
-    UMat dst(1, 1, 0);
+    UMat dst(1, 1, CV_8UC1);
     declare.in(frame, WARMUP_RNG);
 
     const int scale = 2;

--- a/modules/superres/test/test_superres.cpp
+++ b/modules/superres/test/test_superres.cpp
@@ -115,7 +115,9 @@ DegradeFrameSource::DegradeFrameSource(const cv::Ptr<cv::superres::FrameSource>&
 
 static void addGaussNoise(cv::OutputArray _image, double sigma)
 {
-    int type = _image.type(), depth = CV_MAT_DEPTH(type), cn = CV_MAT_CN(type);
+    ElemType type = _image.type();
+    ElemDepth depth = CV_MAT_DEPTH(type);
+    int cn = CV_MAT_CN(type);
     cv::Mat noise(_image.size(), CV_32FC(cn));
     cvtest::TS::ptr()->get_rng().fill(noise, cv::RNG::NORMAL, 0.0, sigma);
 
@@ -157,7 +159,7 @@ double MSSIM(cv::InputArray _i1, cv::InputArray _i2)
     const double C1 = 6.5025;
     const double C2 = 58.5225;
 
-    const int depth = CV_32F;
+    const ElemDepth depth = CV_32F;
 
     cv::Mat I1, I2;
     _i1.getMat().convertTo(I1, depth);

--- a/modules/ts/include/opencv2/ts.hpp
+++ b/modules/ts/include/opencv2/ts.hpp
@@ -179,20 +179,20 @@ inline int clipInt( int val, int min_val, int max_val )
     return val;
 }
 
-double getMinVal(int depth);
-double getMaxVal(int depth);
+double getMinVal(ElemDepth depth);
+double getMaxVal(ElemDepth depth);
 
 Size randomSize(RNG& rng, double maxSizeLog);
 void randomSize(RNG& rng, int minDims, int maxDims, double maxSizeLog, vector<int>& sz);
-int randomType(RNG& rng, int typeMask, int minChannels, int maxChannels);
-Mat randomMat(RNG& rng, Size size, int type, double minVal, double maxVal, bool useRoi);
-Mat randomMat(RNG& rng, const vector<int>& size, int type, double minVal, double maxVal, bool useRoi);
+ElemType randomType(RNG& rng, cv::_OutputArray::DepthMask typeMask, int minChannels, int maxChannels);
+Mat randomMat(RNG& rng, Size size, ElemType type, double minVal, double maxVal, bool useRoi);
+Mat randomMat(RNG& rng, const vector<int>& size, ElemType type, double minVal, double maxVal, bool useRoi);
 void add(const Mat& a, double alpha, const Mat& b, double beta,
-                      Scalar gamma, Mat& c, int ctype, bool calcAbs=false);
+                      Scalar gamma, Mat& c, ElemDepth cdepth, bool calcAbs=false);
 void multiply(const Mat& a, const Mat& b, Mat& c, double alpha=1);
 void divide(const Mat& a, const Mat& b, Mat& c, double alpha=1);
 
-void convert(const Mat& src, cv::OutputArray dst, int dtype, double alpha=1, double beta=0);
+void convert(const Mat& src, cv::OutputArray dst, ElemDepth ddepth, double alpha=1, double beta=0);
 void copy(const Mat& src, Mat& dst, const Mat& mask=Mat(), bool invertMask=false);
 void set(Mat& dst, const Scalar& gamma, const Mat& mask=Mat());
 
@@ -212,7 +212,7 @@ void erode(const Mat& src, Mat& dst, const Mat& _kernel, Point anchor=Point(-1,-
                       int borderType=0, const Scalar& borderValue=Scalar());
 void dilate(const Mat& src, Mat& dst, const Mat& _kernel, Point anchor=Point(-1,-1),
                        int borderType=0, const Scalar& borderValue=Scalar());
-void filter2D(const Mat& src, Mat& dst, int ddepth, const Mat& kernel,
+void filter2D(const Mat& src, Mat& dst, ElemDepth ddepth, const Mat& kernel,
                          Point anchor, double delta, int borderType,
                          const Scalar& borderValue=Scalar());
 void copyMakeBorder(const Mat& src, Mat& dst, int top, int bottom, int left, int right,
@@ -546,11 +546,11 @@ protected:
     virtual int prepare_test_case( int test_case_idx ) CV_OVERRIDE;
     virtual int validate_test_results( int test_case_idx ) CV_OVERRIDE;
 
-    virtual void prepare_to_validation( int test_case_idx );
-    virtual void get_test_array_types_and_sizes( int test_case_idx, vector<vector<Size> >& sizes, vector<vector<int> >& types );
-    virtual void fill_array( int test_case_idx, int i, int j, Mat& arr );
-    virtual void get_minmax_bounds( int i, int j, int type, Scalar& low, Scalar& high );
-    virtual double get_success_error_level( int test_case_idx, int i, int j );
+    virtual void prepare_to_validation(int test_case_idx);
+    virtual void get_test_array_types_and_sizes(int test_case_idx, vector<vector<Size> >& sizes, vector<vector<ElemType> >& types);
+    virtual void fill_array(int test_case_idx, int i, int j, Mat& arr);
+    virtual void get_minmax_bounds(int i, int j, ElemDepth depth, Scalar& low, Scalar& high);
+    virtual double get_success_error_level(int test_case_idx, int i, int j);
 
     bool cvmat_allowed;
     bool iplimage_allowed;

--- a/modules/ts/include/opencv2/ts/cuda_test.hpp
+++ b/modules/ts/include/opencv2/ts/cuda_test.hpp
@@ -57,12 +57,12 @@ namespace cvtest
     double randomDouble(double minVal, double maxVal);
     cv::Size randomSize(int minVal, int maxVal);
     cv::Scalar randomScalar(double minVal, double maxVal);
-    cv::Mat randomMat(cv::Size size, int type, double minVal = 0.0, double maxVal = 255.0);
+    cv::Mat randomMat(cv::Size size, ElemType type, double minVal = 0.0, double maxVal = 255.0);
 
     //////////////////////////////////////////////////////////////////////
     // GpuMat create
 
-    cv::cuda::GpuMat createMat(cv::Size size, int type, bool useRoi = false);
+    cv::cuda::GpuMat createMat(cv::Size size, ElemType type, bool useRoi = false);
     cv::cuda::GpuMat loadMat(const cv::Mat& m, bool useRoi = false);
 
     //////////////////////////////////////////////////////////////////////
@@ -72,7 +72,7 @@ namespace cvtest
     cv::Mat readImage(const std::string& fileName, int flags = cv::IMREAD_COLOR);
 
     //! read image from testdata folder and convert it to specified type
-    cv::Mat readImageType(const std::string& fname, int type);
+    cv::Mat readImageType(const std::string& fname, ElemType type);
 
     //////////////////////////////////////////////////////////////////////
     // Gpu devices
@@ -248,9 +248,9 @@ namespace cvtest
     using perf::MatType;
 
     //! return vector with types from specified range.
-    std::vector<MatType> types(int depth_start, int depth_end, int cn_start, int cn_end);
+    std::vector<MatType> types(ElemDepth depth_start, ElemDepth depth_end, int cn_start, int cn_end);
 
-    //! return vector with all types (depth: CV_8U-CV_64F, channels: 1-4).
+    //! return vector with all types
     const std::vector<MatType>& all_types();
 
     #define ALL_TYPES testing::ValuesIn(all_types())

--- a/modules/ts/include/opencv2/ts/cuda_test.hpp
+++ b/modules/ts/include/opencv2/ts/cuda_test.hpp
@@ -58,6 +58,16 @@ namespace cvtest
     cv::Size randomSize(int minVal, int maxVal);
     cv::Scalar randomScalar(double minVal, double maxVal);
     cv::Mat randomMat(cv::Size size, ElemType type, double minVal = 0.0, double maxVal = 255.0);
+#ifdef CV_TRANSNATIONAL_API
+    static inline cv::Mat randomMat(cv::Size size, int type, double minVal = 0.0, double maxVal = 255.0)
+    {
+        return randomMat(size, static_cast<ElemType>(type), minVal, maxVal);
+    }
+    static inline cv::Mat randomMat(cv::Size size, ElemDepth type, double minVal = 0.0, double maxVal = 255.0)
+    {
+        return randomMat(size, CV_MAKETYPE(type, 1), minVal, maxVal);
+    }
+#endif // CV_TRANSNATIONAL_API
 
     //////////////////////////////////////////////////////////////////////
     // GpuMat create

--- a/modules/ts/include/opencv2/ts/ocl_test.hpp
+++ b/modules/ts/include/opencv2/ts/ocl_test.hpp
@@ -135,7 +135,7 @@ do \
     cv::threshold(diff, binary, (double)eps, 255, cv::THRESH_BINARY); \
     EXPECT_LE(countNonZero(binary.reshape(1)), (int)(binary.cols*binary.rows*5/1000)) \
         << "Size: " << name ## _roi.size() << std::endl; \
-    binary.convertTo(binary_8, mask.type()); \
+    binary.convertTo(binary_8, mask.depth()); \
     binary_8 = binary_8 & mask; \
     EXPECT_LE(countNonZero(binary_8.reshape(1)), (int)((binary_8.cols+binary_8.rows)/100)) \
         << "Size: " << name ## _roi.size() << std::endl; \
@@ -263,7 +263,7 @@ struct TestUtils
         return Scalar(randomDouble(minVal, maxVal), randomDouble(minVal, maxVal), randomDouble(minVal, maxVal), randomDouble(minVal, maxVal));
     }
 
-    Mat randomMat(Size size, int type, double minVal, double maxVal, bool useRoi = false)
+    Mat randomMat(Size size, ElemType type, double minVal, double maxVal, bool useRoi = false)
     {
         RNG dataRng(rng.next());
         return cvtest::randomMat(dataRng, size, type, minVal, maxVal, useRoi);
@@ -285,7 +285,7 @@ struct TestUtils
         return border;
     }
 
-    void randomSubMat(Mat& whole, Mat& subMat, const Size& roiSize, const Border& border, int type, double minVal, double maxVal)
+    void randomSubMat(Mat& whole, Mat& subMat, const Size& roiSize, const Border& border, ElemType type, double minVal, double maxVal)
     {
         Size wholeSize = Size(roiSize.width + border.lef + border.rig, roiSize.height + border.top + border.bot);
         whole = randomMat(wholeSize, type, minVal, maxVal, false);

--- a/modules/ts/include/opencv2/ts/ts_perf.hpp
+++ b/modules/ts/include/opencv2/ts/ts_perf.hpp
@@ -91,12 +91,27 @@ const static cv::Size szSmall128 = cv::Size(128, 128);
 class MatType
 {
 public:
-    MatType(int val=0) : _type(val) {}
-    operator int() const {return _type;}
+    MatType(int val = 0) : _type(static_cast<ElemType>(val)) {}
+    operator ElemType() const { return _type; }
 
 private:
-    int _type;
+    ElemType _type;
 };
+
+
+/*****************************************************************************************\
+*               MatDepth - printable wrapper over integer 'depth' of Mat                  *
+\*****************************************************************************************/
+class MatDepth
+{
+public:
+    MatDepth(int val = 0) : _depth(static_cast<ElemDepth>(val)) {}
+    operator ElemDepth() const { return _depth; }
+
+private:
+    ElemDepth _depth;
+};
+
 
 /*****************************************************************************************\
 *     CV_ENUM and CV_FLAGS - macro to create printable wrappers for defines and enums     *
@@ -137,7 +152,7 @@ private:
         class_name(int val = 0) : val_(val) {}                                          \
         operator int() const { return val_; }                                           \
         void PrintTo(std::ostream* os) const {                                          \
-            using namespace cv;using namespace cv::cuda; using namespace cv::ocl;        \
+            using namespace cv; using namespace cv::cuda; using namespace cv::ocl;      \
             const int vals[] = { __VA_ARGS__ };                                         \
             const char* svals = #__VA_ARGS__;                                           \
             int value = val_;                                                           \
@@ -160,7 +175,6 @@ private:
     };                                                                                  \
     static inline void PrintTo(const class_name& t, std::ostream* os) { t.PrintTo(os); } }
 
-CV_ENUM(MatDepth, CV_8U, CV_8S, CV_16U, CV_16S, CV_32S, CV_32F, CV_64F, CV_16F)
 
 /*****************************************************************************************\
 *                 Regression control utility for performance testing                      *
@@ -506,6 +520,7 @@ typedef TestBaseWithParam<Size_MatType_t> Size_MatType;
 /*****************************************************************************************\
 *                              Print functions for googletest                             *
 \*****************************************************************************************/
+void PrintTo(const MatDepth& t, std::ostream* os);
 void PrintTo(const MatType& t, std::ostream* os);
 
 } //namespace perf
@@ -606,9 +621,9 @@ void PrintTo(const Size& sz, ::std::ostream* os);
 //   typedef ::perf::TestBaseWithParam<cv::Size> FooTest;
 //
 //   PERF_TEST_P(FooTest, DoTestingRight, ::testing::Values(::perf::szVGA, ::perf::sz720p) {
-//     cv::Mat b(GetParam(), CV_8U, cv::Scalar(10));
-//     cv::Mat a(GetParam(), CV_8U, cv::Scalar(20));
-//     cv::Mat c(GetParam(), CV_8U, cv::Scalar(0));
+//     cv::Mat b(GetParam(), CV_8UC1, cv::Scalar(10));
+//     cv::Mat a(GetParam(), CV_8UC1, cv::Scalar(20));
+//     cv::Mat c(GetParam(), CV_8UC1, cv::Scalar(0));
 //
 //     declare.in(a, b).out(c).time(0.5);
 //

--- a/modules/ts/src/cuda_test.cpp
+++ b/modules/ts/src/cuda_test.cpp
@@ -81,7 +81,7 @@ namespace cvtest
         return Scalar(randomDouble(minVal, maxVal), randomDouble(minVal, maxVal), randomDouble(minVal, maxVal), randomDouble(minVal, maxVal));
     }
 
-    Mat randomMat(Size size, int type, double minVal, double maxVal)
+    Mat randomMat(Size size, ElemType type, double minVal, double maxVal)
     {
         return randomMat(TS::ptr()->get_rng(), size, type, minVal, maxVal, false);
     }
@@ -89,7 +89,7 @@ namespace cvtest
     //////////////////////////////////////////////////////////////////////
     // GpuMat create
 
-    GpuMat createMat(Size size, int type, bool useRoi)
+    GpuMat createMat(Size size, ElemType type, bool useRoi)
     {
         Size size0 = size;
 
@@ -122,7 +122,7 @@ namespace cvtest
         return imread(TS::ptr()->get_data_path() + fileName, flags);
     }
 
-    Mat readImageType(const std::string& fname, int type)
+    Mat readImageType(const std::string& fname, ElemType type)
     {
         Mat src = readImage(fname, CV_MAT_CN(type) == 1 ? IMREAD_GRAYSCALE : IMREAD_COLOR);
         if (CV_MAT_CN(type) == 4)
@@ -370,17 +370,17 @@ namespace cvtest
     //////////////////////////////////////////////////////////////////////
     // Helper structs for value-parameterized tests
 
-    vector<MatType> types(int depth_start, int depth_end, int cn_start, int cn_end)
+    vector<MatType> types(ElemDepth depth_start, ElemDepth depth_end, int cn_start, int cn_end)
     {
         vector<MatType> v;
 
         v.reserve((depth_end - depth_start + 1) * (cn_end - cn_start + 1));
 
-        for (int depth = depth_start; depth <= depth_end; ++depth)
+        for (int depth = static_cast<int>(depth_start); depth <= static_cast<int>(depth_end); ++depth)
         {
             for (int cn = cn_start; cn <= cn_end; ++cn)
             {
-                v.push_back(MatType(CV_MAKE_TYPE(depth, cn)));
+                v.push_back(CV_MAKE_TYPE(depth, cn));
             }
         }
 
@@ -389,7 +389,9 @@ namespace cvtest
 
     const vector<MatType>& all_types()
     {
-        static vector<MatType> v = types(CV_8U, CV_64F, 1, 4);
+        // return vector with all types
+        // (depth: CV_8U - CV_64F, channels : 1 - 4)
+        static vector<MatType> v = cvtest::types(CV_8U, CV_64F, 1, 4);
 
         return v;
     }

--- a/modules/video/perf/perf_ecc.cpp
+++ b/modules/video/perf/perf_ecc.cpp
@@ -58,9 +58,9 @@ PERF_TEST_P(TransformationType, findTransformECC, /*testing::ValuesIn(MotionType
     TEST_CYCLE()
     {
         if (transform_type<3)
-            warpMat = Mat::eye(2,3, CV_32F);
+            warpMat = Mat::eye(2, 3, CV_32FC1);
         else
-            warpMat = Mat::eye(3,3, CV_32F);
+            warpMat = Mat::eye(3, 3, CV_32FC1);
 
         findTransformECC(templateImage, img, warpMat, transform_type,
             TermCriteria(TermCriteria::COUNT+TermCriteria::EPS, 5, -1));

--- a/modules/video/test/test_accum.cpp
+++ b/modules/video/test/test_accum.cpp
@@ -50,8 +50,8 @@ public:
     CV_AccumBaseTest();
 
 protected:
-    void get_test_array_types_and_sizes( int test_case_idx, vector<vector<Size> >& sizes, vector<vector<int> >& types );
-    double get_success_error_level( int test_case_idx, int i, int j );
+    void get_test_array_types_and_sizes(int test_case_idx, vector<vector<Size> >& sizes, vector<vector<ElemType> >& types) CV_OVERRIDE;
+    double get_success_error_level( int test_case_idx, int i, int j ) CV_OVERRIDE;
     double alpha;
 };
 
@@ -68,7 +68,7 @@ CV_AccumBaseTest::CV_AccumBaseTest()
 
 
 void CV_AccumBaseTest::get_test_array_types_and_sizes( int test_case_idx,
-                        vector<vector<Size> >& sizes, vector<vector<int> >& types )
+                        vector<vector<Size> >& sizes, vector<vector<ElemType> >& types )
 {
     RNG& rng = ts->get_rng();
     int depth = cvtest::randInt(rng) % 4, cn = cvtest::randInt(rng) & 1 ? 3 : 1;
@@ -102,7 +102,7 @@ public:
     CV_AccTest() { }
 protected:
     void run_func();
-    void prepare_to_validation( int );
+    void prepare_to_validation( int ) CV_OVERRIDE;
 };
 
 
@@ -118,7 +118,7 @@ void CV_AccTest::prepare_to_validation( int )
     Mat& dst = test_mat[REF_INPUT_OUTPUT][0];
     const Mat& mask = test_array[MASK][0] ? test_mat[MASK][0] : Mat();
     Mat temp;
-    cvtest::add( src, 1, dst, 1, cvScalarAll(0.), temp, dst.type() );
+    cvtest::add(src, 1, dst, 1, cvScalarAll(0.), temp, dst.depth());
     cvtest::copy( temp, dst, mask );
 }
 
@@ -130,7 +130,7 @@ public:
     CV_SquareAccTest();
 protected:
     void run_func();
-    void prepare_to_validation( int );
+    void prepare_to_validation( int ) CV_OVERRIDE;
 };
 
 
@@ -152,9 +152,9 @@ void CV_SquareAccTest::prepare_to_validation( int )
     const Mat& mask = test_array[MASK][0] ? test_mat[MASK][0] : Mat();
     Mat temp;
 
-    cvtest::convert( src, temp, dst.type() );
+    cvtest::convert( src, temp, dst.depth() );
     cvtest::multiply( temp, temp, temp, 1 );
-    cvtest::add( temp, 1, dst, 1, cvScalarAll(0.), temp, dst.depth() );
+    cvtest::add(temp, 1, dst, 1, cvScalarAll(0.), temp, dst.depth());
     cvtest::copy( temp, dst, mask );
 }
 
@@ -166,7 +166,7 @@ public:
     CV_MultiplyAccTest();
 protected:
     void run_func();
-    void prepare_to_validation( int );
+    void prepare_to_validation( int ) CV_OVERRIDE;
 };
 
 
@@ -191,11 +191,11 @@ void CV_MultiplyAccTest::prepare_to_validation( int )
     const Mat& mask = test_array[MASK][0] ? test_mat[MASK][0] : Mat();
     Mat temp1, temp2;
 
-    cvtest::convert( src1, temp1, dst.type() );
-    cvtest::convert( src2, temp2, dst.type() );
+    cvtest::convert(src1, temp1, dst.depth());
+    cvtest::convert(src2, temp2, dst.depth());
 
     cvtest::multiply( temp1, temp2, temp1, 1 );
-    cvtest::add( temp1, 1, dst, 1, cvScalarAll(0.), temp1, dst.depth() );
+    cvtest::add(temp1, 1, dst, 1, cvScalarAll(0.), temp1, dst.depth());
     cvtest::copy( temp1, dst, mask );
 }
 
@@ -207,7 +207,7 @@ public:
     CV_RunningAvgTest();
 protected:
     void run_func();
-    void prepare_to_validation( int );
+    void prepare_to_validation( int ) CV_OVERRIDE;
 };
 
 
@@ -235,7 +235,7 @@ void CV_RunningAvgTest::prepare_to_validation( int )
     cvSetReal1D( &A, 0, alpha);
     cvSetReal1D( &B, 0, 1 - cvGetReal1D(&A, 0));
 
-    cvtest::convert( src, temp, dst.type() );
+    cvtest::convert(src, temp, dst.depth());
     cvtest::add( src, cvGetReal1D(&A, 0), dst, cvGetReal1D(&B, 0), cvScalarAll(0.), temp, temp.depth() );
     cvtest::copy( temp, dst, mask );
 }

--- a/modules/video/test/test_ecc.cpp
+++ b/modules/video/test/test_ecc.cpp
@@ -364,7 +364,7 @@ bool CV_ECC_Test_Homography::testHomography(int from)
         warpPerspective(testImg, warpedImage, homoGround,
             Size(200,200), INTER_LINEAR + WARP_INVERSE_MAP);
 
-        Mat mapHomography = Mat::eye(3, 3, CV_32F);
+        Mat mapHomography = Mat::eye(3, 3, CV_32FC1);
 
         findTransformECC(warpedImage, testImg, mapHomography, 3,
             TermCriteria(TermCriteria::COUNT+TermCriteria::EPS, ECC_iterations, ECC_epsilon));
@@ -420,7 +420,7 @@ bool CV_ECC_Test_Mask::testMask(int from)
     resize(img, scaledImage, Size(216, 216), 0, 0, INTER_LINEAR_EXACT );
 
     Mat_<float> testImg;
-    scaledImage.convertTo(testImg, testImg.type());
+    scaledImage.convertTo(testImg, testImg.depth());
 
     cv::RNG rng = ts->get_rng();
 

--- a/modules/video/test/test_optflowpyrlk.cpp
+++ b/modules/video/test/test_optflowpyrlk.cpp
@@ -101,8 +101,8 @@ void CV_OptFlowPyrLKTest::run( int )
         goto _exit_;
     }
 
-    if( _u->cols != 2 || CV_MAT_TYPE(_u->type) != CV_32F ||
-        _v->cols != 2 || CV_MAT_TYPE(_v->type) != CV_32F || _v->rows != _u->rows )
+    if (_u->cols != 2 || CV_MAT_TYPE(_u->type) != CV_32FC1 ||
+        _v->cols != 2 || CV_MAT_TYPE(_v->type) != CV_32FC1 || _v->rows != _u->rows)
     {
         ts->printf( cvtest::TS::LOG, "the loaded matrices of points are not valid\n" );
         code = cvtest::TS::FAIL_MISSING_TEST_DATA;

--- a/modules/videostab/test/test_motion_estimation.cpp
+++ b/modules/videostab/test/test_motion_estimation.cpp
@@ -57,7 +57,7 @@ cv::Mat testUtil::generateTransform(const cv::videostab::MotionModel model)
     const float affineCoeff = 3.f;
     /*----------Params----------*/
 
-    cv::Mat transform = cv::Mat::eye(3, 3, CV_32F);
+    cv::Mat transform = cv::Mat::eye(3, 3, CV_32FC1);
 
     if(model != cv::videostab::MM_ROTATION)
     {
@@ -116,7 +116,7 @@ double testUtil::performTest(const cv::videostab::MotionModel model, int size)
 
         const int pointsNumber = testUtil::rng.uniform(10, 100);
 
-        cv::Mat points(3, pointsNumber, CV_32F);
+        cv::Mat points(3, pointsNumber, CV_32FC1);
 
         testUtil::generatePoints(points);
 


### PR DESCRIPTION
Merge with opencv/opencv_contrib#1775 and opencv/opencv_extra#521

### This pullrequest changes
<s>Extends</s> Applies the backward-compatible API introduced in #12487 to unit tests

```
force_builders=Custom
docker_image:Custom=ubuntu-cuda:16.04
```