### PR TITLE
Fix a bug in meanShiftSegmentation

### DIFF
--- a/modules/core/src/copy.cpp
+++ b/modules/core/src/copy.cpp
@@ -238,6 +238,14 @@ void Mat::copyTo( OutputArray _dst ) const
 {
     CV_INSTRUMENT_REGION();
 
+#ifdef HAVE_CUDA
+    if (_dst.isGpuMat())
+    {
+        _dst.getGpuMat().upload(*this);
+        return;
+    }
+#endif
+
     int dtype = _dst.type();
     if( _dst.fixedType() && dtype != type() )
     {

--- a/modules/core/src/matrix_wrap.cpp
+++ b/modules/core/src/matrix_wrap.cpp
@@ -1146,6 +1146,10 @@ void _InputArray::copyTo(const _OutputArray& arr) const
     }
     else if( k == UMAT )
         ((UMat*)obj)->copyTo(arr);
+#ifdef HAVE_CUDA
+    else if (k == CUDA_GPU_MAT)
+        ((cuda::GpuMat*)obj)->copyTo(arr);
+#endif
     else
         CV_Error(Error::StsNotImplemented, "");
 }
@@ -1163,6 +1167,10 @@ void _InputArray::copyTo(const _OutputArray& arr, const _InputArray & mask) cons
     }
     else if( k == UMAT )
         ((UMat*)obj)->copyTo(arr, mask);
+#ifdef HAVE_CUDA
+    else if (k == CUDA_GPU_MAT)
+        ((cuda::GpuMat*)obj)->copyTo(arr, mask);
+#endif
     else
         CV_Error(Error::StsNotImplemented, "");
 }

--- a/modules/core/src/umatrix.cpp
+++ b/modules/core/src/umatrix.cpp
@@ -874,6 +874,14 @@ void UMat::copyTo(OutputArray _dst) const
 {
     CV_INSTRUMENT_REGION();
 
+#ifdef HAVE_CUDA
+    if (_dst.isGpuMat())
+    {
+        _dst.getGpuMat().upload(*this);
+        return;
+    }
+#endif
+
     int dtype = _dst.type();
     if( _dst.fixedType() && dtype != type() )
     {


### PR DESCRIPTION
related: #12561, #12268

### This pullrequest changes
My previous patch at #12268 was incomplete.

> Is just dst.copyTo(_dst); (without if) not enough?

> It seems it also works with copyTo(). Judging by the function code, I do not know how it can work though...

In fact it was working initially, but I got deceived by an already compiled test results (built, but forgot to install?), and thought the modifications worked as well, but it turned out it did not 😞 

```
force_builders=Custom
docker_image:Custom=ubuntu-cuda:16.04
```