### PR TITLE
core: drop usage of CV_USRTYPE1 in OpenCV

### DIFF
--- a/modules/core/include/opencv2/core/hal/interface.h
+++ b/modules/core/include/opencv2/core/hal/interface.h
@@ -64,6 +64,8 @@ typedef signed char schar;
 #  define CV_BIG_UINT(n)  n##ULL
 #endif
 
+#define CV_USRTYPE1 (void)"CV_USRTYPE1 support has been dropped in OpenCV 4.0"
+
 #define CV_CN_MAX     512
 #define CV_CN_SHIFT   3
 #define CV_DEPTH_MAX  (1 << CV_CN_SHIFT)
@@ -75,7 +77,6 @@ typedef signed char schar;
 #define CV_32S  4
 #define CV_32F  5
 #define CV_64F  6
-#define CV_USRTYPE1 7
 #define CV_16F  7
 
 #define CV_MAT_DEPTH_MASK       (CV_DEPTH_MAX - 1)

--- a/modules/core/include/opencv2/core/types_c.h
+++ b/modules/core/include/opencv2/core/types_c.h
@@ -1705,7 +1705,7 @@ typedef CvContour CvPoint2DSeq;
 #define CV_SEQ_ELTYPE_POINT          CV_32SC2  /**< (x,y) */
 #define CV_SEQ_ELTYPE_CODE           CV_8UC1   /**< freeman code: 0..7 */
 #define CV_SEQ_ELTYPE_GENERIC        0
-#define CV_SEQ_ELTYPE_PTR            CV_USRTYPE1
+#define CV_SEQ_ELTYPE_PTR            CV_MAKE_TYPE(CV_8U, 8 /*sizeof(void*)*/)
 #define CV_SEQ_ELTYPE_PPOINT         CV_SEQ_ELTYPE_PTR  /**< &(x,y) */
 #define CV_SEQ_ELTYPE_INDEX          CV_32SC1  /**< #(x,y) */
 #define CV_SEQ_ELTYPE_GRAPH_EDGE     0  /**< &next_o, &next_d, &vtx_o, &vtx_d */

--- a/modules/core/src/datastructs.cpp
+++ b/modules/core/src/datastructs.cpp
@@ -388,7 +388,7 @@ cvCreateSeq( int seq_flags, size_t header_size, size_t elem_size, CvMemStorage* 
         int elemtype = CV_MAT_TYPE(seq_flags);
         int typesize = CV_ELEM_SIZE(elemtype);
 
-        if( elemtype != CV_SEQ_ELTYPE_GENERIC && elemtype != CV_USRTYPE1 &&
+        if( elemtype != CV_SEQ_ELTYPE_GENERIC && elemtype != CV_SEQ_ELTYPE_PTR &&
             typesize != 0 && typesize != (int)elem_size )
             CV_Error( CV_StsBadSize,
             "Specified element size doesn't match to the size of the specified element type "

--- a/modules/core/src/persistence.hpp
+++ b/modules/core/src/persistence.hpp
@@ -250,7 +250,6 @@ double icv_strtod( CvFileStorage* fs, char* ptr, char** endptr );
 char* icvFloatToString( char* buf, float value );
 char* icvDoubleToString( char* buf, double value );
 
-char icvTypeSymbol(int depth);
 void icvClose( CvFileStorage* fs, cv::String* out );
 void icvCloseFile( CvFileStorage* fs );
 void icvPuts( CvFileStorage* fs, const char* str );

--- a/modules/core/src/persistence_c.cpp
+++ b/modules/core/src/persistence_c.cpp
@@ -978,7 +978,7 @@ cvWriteRawData( CvFileStorage* fs, const void* _data, int len, const char* dt )
                     ptr = icvDoubleToString( buf, *(double*)data );
                     data += sizeof(double);
                     break;
-                case CV_USRTYPE1: /* reference */
+                case CV_SEQ_ELTYPE_PTR/*CV_USRTYPE1*/: /* reference */
                     ptr = icv_itoa( (int)*(size_t*)data, buf, 10 );
                     data += sizeof(size_t);
                     break;
@@ -1118,7 +1118,7 @@ cvReadRawDataSlice( const CvFileStorage* fs, CvSeqReader* reader,
                         *(double*)data = (double)ival;
                         data += sizeof(double);
                         break;
-                    case CV_USRTYPE1: /* reference */
+                    case CV_SEQ_ELTYPE_PTR/*CV_USRTYPE1*/: /* reference */
                         *(size_t*)data = ival;
                         data += sizeof(size_t);
                         break;
@@ -1167,7 +1167,7 @@ cvReadRawDataSlice( const CvFileStorage* fs, CvSeqReader* reader,
                         *(double*)data = fval;
                         data += sizeof(double);
                         break;
-                    case CV_USRTYPE1: /* reference */
+                    case CV_SEQ_ELTYPE_PTR/*CV_USRTYPE1*/: /* reference */
                         ival = cvRound(fval);
                         *(size_t*)data = ival;
                         data += sizeof(size_t);

--- a/modules/core/src/persistence_types.cpp
+++ b/modules/core/src/persistence_types.cpp
@@ -408,8 +408,7 @@ static void icvWriteImage( CvFileStorage* fs, const char* name, const void* stru
     }
 
     depth = IPL2CV_DEPTH(image->depth);
-    sprintf( dt_buf, "%d%c", image->nChannels, icvTypeSymbol(depth) );
-    dt = dt_buf + (dt_buf[2] == '\0' && dt_buf[0] == '1');
+    dt = icvEncodeFormat(depth, dt_buf);
     cvWriteString( fs, "dt", dt, 0 );
 
     size = cvSize(image->width, image->height);

--- a/modules/cudalegacy/src/graphcuts.cpp
+++ b/modules/cudalegacy/src/graphcuts.cpp
@@ -89,7 +89,7 @@ void cv::cuda::connectivityMask(const GpuMat& image, GpuMat& mask, const cv::Sca
         { device::ccl::computeEdges<int>,    0,  0,                                  0                                  },// CV_32S
         { device::ccl::computeEdges<float>,  0,  0,                                  0                                  },// CV_32F
         { 0,                                 0,  0,                                  0                                  },// CV_64F
-        { 0,                                 0,  0,                                  0                                  } // CV_USRTYPE1
+        { 0,                                 0,  0,                                  0                                  } // CV_16F
     };
 
     func_t f = suppotLookup[depth][ch - 1];

--- a/modules/features2d/misc/java/test/FlannBasedDescriptorMatcherTest.java
+++ b/modules/features2d/misc/java/test/FlannBasedDescriptorMatcherTest.java
@@ -26,7 +26,7 @@ public class FlannBasedDescriptorMatcherTest extends OpenCVTestCase {
             + "<indexParams>\n"
             + "  <_>\n"
             + "    <name>algorithm</name>\n"
-            + "    <type>23</type>\n"
+            + "    <type>9</type>\n"  // FLANN_INDEX_TYPE_ALGORITHM
             + "    <value>1</value></_>\n"
             + "  <_>\n"
             + "    <name>trees</name>\n"
@@ -43,7 +43,7 @@ public class FlannBasedDescriptorMatcherTest extends OpenCVTestCase {
             + "    <value>0.</value></_>\n"
             + "  <_>\n"
             + "    <name>sorted</name>\n"
-            + "    <type>15</type>\n"
+            + "    <type>8</type>\n"  // FLANN_INDEX_TYPE_BOOL
             + "    <value>1</value></_></searchParams>\n"
             + "</opencv_storage>\n";
     static final String ymlParamsDefault = "%YAML:1.0\n---\n"
@@ -51,7 +51,7 @@ public class FlannBasedDescriptorMatcherTest extends OpenCVTestCase {
             + "indexParams:\n"
             + "   -\n"
             + "      name: algorithm\n"
-            + "      type: 23\n"
+            + "      type: 9\n"  // FLANN_INDEX_TYPE_ALGORITHM
             + "      value: 1\n"
             + "   -\n"
             + "      name: trees\n"
@@ -68,14 +68,14 @@ public class FlannBasedDescriptorMatcherTest extends OpenCVTestCase {
             + "      value: 0.\n"
             + "   -\n"
             + "      name: sorted\n"
-            + "      type: 15\n"
+            + "      type: 8\n"  // FLANN_INDEX_TYPE_BOOL
             + "      value: 1\n";
     static final String ymlParamsModified = "%YAML:1.0\n---\n"
             + "format: 3\n"
             + "indexParams:\n"
             + "   -\n"
             + "      name: algorithm\n"
-            + "      type: 23\n"
+            + "      type: 9\n"  // FLANN_INDEX_TYPE_ALGORITHM
             + "      value: 6\n"// this line is changed!
             + "   -\n"
             + "      name: trees\n"
@@ -92,7 +92,7 @@ public class FlannBasedDescriptorMatcherTest extends OpenCVTestCase {
             + "      value: 4.\n"// this line is changed!
             + "   -\n"
             + "      name: sorted\n"
-            + "      type: 15\n"
+            + "      type: 8\n"    // FLANN_INDEX_TYPE_BOOL
             + "      value: 1\n";
 
     DescriptorMatcher matcher;

--- a/modules/features2d/src/matchers.cpp
+++ b/modules/features2d/src/matchers.cpp
@@ -40,6 +40,7 @@
 //M*/
 
 #include "precomp.hpp"
+#include "opencv2/flann/miniflann.hpp"
 #include <limits>
 #include "opencl_kernels_features2d.hpp"
 
@@ -1167,6 +1168,8 @@ void FlannBasedMatcher::train()
     }
 }
 
+using namespace cv::flann;
+
 void FlannBasedMatcher::read( const FileNode& fn)
 {
      if (!indexParams)
@@ -1179,32 +1182,34 @@ void FlannBasedMatcher::read( const FileNode& fn)
      {
         CV_Assert(ip[i].type() == FileNode::MAP);
         String _name =  (String)ip[i]["name"];
-        int type =  (int)ip[i]["type"];
+        FlannIndexType type = (FlannIndexType)(int)ip[i]["type"];
+        CV_CheckLE((int)type, (int)LAST_VALUE_FLANN_INDEX_TYPE, "");
 
         switch(type)
         {
-        case CV_8U:
-        case CV_8S:
-        case CV_16U:
-        case CV_16S:
-        case CV_32S:
+        case FLANN_INDEX_TYPE_8U:
+        case FLANN_INDEX_TYPE_8S:
+        case FLANN_INDEX_TYPE_16U:
+        case FLANN_INDEX_TYPE_16S:
+        case FLANN_INDEX_TYPE_32S:
             indexParams->setInt(_name, (int) ip[i]["value"]);
             break;
-        case CV_32F:
+        case FLANN_INDEX_TYPE_32F:
             indexParams->setFloat(_name, (float) ip[i]["value"]);
             break;
-        case CV_64F:
+        case FLANN_INDEX_TYPE_64F:
             indexParams->setDouble(_name, (double) ip[i]["value"]);
             break;
-        case CV_USRTYPE1:
+        case FLANN_INDEX_TYPE_STRING:
             indexParams->setString(_name, (String) ip[i]["value"]);
             break;
-        case CV_MAKETYPE(CV_USRTYPE1,2):
+        case FLANN_INDEX_TYPE_BOOL:
             indexParams->setBool(_name, (int) ip[i]["value"] != 0);
             break;
-        case CV_MAKETYPE(CV_USRTYPE1,3):
+        case FLANN_INDEX_TYPE_ALGORITHM:
             indexParams->setAlgorithm((int) ip[i]["value"]);
             break;
+        // don't default: - compiler warning is here
         };
      }
 
@@ -1218,32 +1223,34 @@ void FlannBasedMatcher::read( const FileNode& fn)
      {
         CV_Assert(sp[i].type() == FileNode::MAP);
         String _name =  (String)sp[i]["name"];
-        int type =  (int)sp[i]["type"];
+        FlannIndexType type = (FlannIndexType)(int)sp[i]["type"];
+        CV_CheckLE((int)type, (int)LAST_VALUE_FLANN_INDEX_TYPE, "");
 
         switch(type)
         {
-        case CV_8U:
-        case CV_8S:
-        case CV_16U:
-        case CV_16S:
-        case CV_32S:
+        case FLANN_INDEX_TYPE_8U:
+        case FLANN_INDEX_TYPE_8S:
+        case FLANN_INDEX_TYPE_16U:
+        case FLANN_INDEX_TYPE_16S:
+        case FLANN_INDEX_TYPE_32S:
             searchParams->setInt(_name, (int) sp[i]["value"]);
             break;
-        case CV_32F:
+        case FLANN_INDEX_TYPE_32F:
             searchParams->setFloat(_name, (float) ip[i]["value"]);
             break;
-        case CV_64F:
+        case FLANN_INDEX_TYPE_64F:
             searchParams->setDouble(_name, (double) ip[i]["value"]);
             break;
-        case CV_USRTYPE1:
+        case FLANN_INDEX_TYPE_STRING:
             searchParams->setString(_name, (String) ip[i]["value"]);
             break;
-        case CV_MAKETYPE(CV_USRTYPE1,2):
+        case FLANN_INDEX_TYPE_BOOL:
             searchParams->setBool(_name, (int) ip[i]["value"] != 0);
             break;
-        case CV_MAKETYPE(CV_USRTYPE1,3):
+        case FLANN_INDEX_TYPE_ALGORITHM:
             searchParams->setAlgorithm((int) ip[i]["value"]);
             break;
+        // don't default: - compiler warning is here
         };
      }
 
@@ -1258,7 +1265,7 @@ void FlannBasedMatcher::write( FileStorage& fs) const
      if (indexParams)
      {
          std::vector<String> names;
-         std::vector<int> types;
+         std::vector<FlannIndexType> types;
          std::vector<String> strValues;
          std::vector<double> numValues;
 
@@ -1267,38 +1274,43 @@ void FlannBasedMatcher::write( FileStorage& fs) const
          for(size_t i = 0; i < names.size(); ++i)
          {
              fs << "{" << "name" << names[i] << "type" << types[i] << "value";
-             switch(types[i])
+             FlannIndexType type = (FlannIndexType)types[i];
+             if ((int)type < 0 || type > LAST_VALUE_FLANN_INDEX_TYPE)
              {
-             case CV_8U:
-                 fs << (uchar)numValues[i];
-                 break;
-             case CV_8S:
-                 fs << (char)numValues[i];
-                 break;
-             case CV_16U:
-                 fs << (ushort)numValues[i];
-                 break;
-             case CV_16S:
-                 fs << (short)numValues[i];
-                 break;
-             case CV_32S:
-             case CV_MAKETYPE(CV_USRTYPE1,2):
-             case CV_MAKETYPE(CV_USRTYPE1,3):
-                 fs << (int)numValues[i];
-                 break;
-             case CV_32F:
-                 fs << (float)numValues[i];
-                 break;
-             case CV_64F:
-                 fs << (double)numValues[i];
-                 break;
-             case CV_USRTYPE1:
-                 fs << strValues[i];
-                 break;
-             default:
                  fs << (double)numValues[i];
                  fs << "typename" << strValues[i];
+                 fs << "}";
+                 continue;
+             }
+             switch(type)
+             {
+             case FLANN_INDEX_TYPE_8U:
+                 fs << (uchar)numValues[i];
                  break;
+             case FLANN_INDEX_TYPE_8S:
+                 fs << (char)numValues[i];
+                 break;
+             case FLANN_INDEX_TYPE_16U:
+                 fs << (ushort)numValues[i];
+                 break;
+             case FLANN_INDEX_TYPE_16S:
+                 fs << (short)numValues[i];
+                 break;
+             case FLANN_INDEX_TYPE_32S:
+             case FLANN_INDEX_TYPE_BOOL:
+             case FLANN_INDEX_TYPE_ALGORITHM:
+                 fs << (int)numValues[i];
+                 break;
+             case FLANN_INDEX_TYPE_32F:
+                 fs << (float)numValues[i];
+                 break;
+             case FLANN_INDEX_TYPE_64F:
+                 fs << (double)numValues[i];
+                 break;
+             case FLANN_INDEX_TYPE_STRING:
+                 fs << strValues[i];
+                 break;
+             // don't default: - compiler warning is here
              }
              fs << "}";
          }
@@ -1309,7 +1321,7 @@ void FlannBasedMatcher::write( FileStorage& fs) const
      if (searchParams)
      {
          std::vector<String> names;
-         std::vector<int> types;
+         std::vector<FlannIndexType> types;
          std::vector<String> strValues;
          std::vector<double> numValues;
 
@@ -1318,23 +1330,31 @@ void FlannBasedMatcher::write( FileStorage& fs) const
          for(size_t i = 0; i < names.size(); ++i)
          {
              fs << "{" << "name" << names[i] << "type" << types[i] << "value";
-             switch(types[i])
+             FlannIndexType type = (FlannIndexType)types[i];
+             if ((int)type < 0 || type > LAST_VALUE_FLANN_INDEX_TYPE)
              {
-             case CV_8U:
+                 fs << (double)numValues[i];
+                 fs << "typename" << strValues[i];
+                 fs << "}";
+                 continue;
+             }
+             switch(type)
+             {
+             case FLANN_INDEX_TYPE_8U:
                  fs << (uchar)numValues[i];
                  break;
-             case CV_8S:
+             case FLANN_INDEX_TYPE_8S:
                  fs << (char)numValues[i];
                  break;
-             case CV_16U:
+             case FLANN_INDEX_TYPE_16U:
                  fs << (ushort)numValues[i];
                  break;
-             case CV_16S:
+             case FLANN_INDEX_TYPE_16S:
                  fs << (short)numValues[i];
                  break;
-             case CV_32S:
-             case CV_MAKETYPE(CV_USRTYPE1,2):
-             case CV_MAKETYPE(CV_USRTYPE1,3):
+             case FLANN_INDEX_TYPE_32S:
+             case FLANN_INDEX_TYPE_BOOL:
+             case FLANN_INDEX_TYPE_ALGORITHM:
                  fs << (int)numValues[i];
                  break;
              case CV_32F:
@@ -1343,13 +1363,10 @@ void FlannBasedMatcher::write( FileStorage& fs) const
              case CV_64F:
                  fs << (double)numValues[i];
                  break;
-             case CV_USRTYPE1:
+             case FLANN_INDEX_TYPE_STRING:
                  fs << strValues[i];
                  break;
-             default:
-                 fs << (double)numValues[i];
-                 fs << "typename" << strValues[i];
-                 break;
+             // don't default: - compiler warning is here
              }
              fs << "}";
          }

--- a/modules/flann/include/opencv2/flann/miniflann.hpp
+++ b/modules/flann/include/opencv2/flann/miniflann.hpp
@@ -52,6 +52,20 @@ namespace cv
 namespace flann
 {
 
+enum FlannIndexType {
+    FLANN_INDEX_TYPE_8U = CV_8U,
+    FLANN_INDEX_TYPE_8S = CV_8S,
+    FLANN_INDEX_TYPE_16U = CV_16U,
+    FLANN_INDEX_TYPE_16S = CV_16S,
+    FLANN_INDEX_TYPE_32S = CV_32S,
+    FLANN_INDEX_TYPE_32F = CV_32F,
+    FLANN_INDEX_TYPE_64F = CV_64F,
+    FLANN_INDEX_TYPE_STRING,
+    FLANN_INDEX_TYPE_BOOL,
+    FLANN_INDEX_TYPE_ALGORITHM,
+    LAST_VALUE_FLANN_INDEX_TYPE = FLANN_INDEX_TYPE_ALGORITHM
+};
+
 struct CV_EXPORTS IndexParams
 {
     IndexParams();
@@ -68,8 +82,9 @@ struct CV_EXPORTS IndexParams
     void setBool(const String& key, bool value);
     void setAlgorithm(int value);
 
+    // FIXIT: replace by void write(FileStorage& fs) const + read()
     void getAll(std::vector<String>& names,
-                std::vector<int>& types,
+                std::vector<FlannIndexType>& types,
                 std::vector<String>& strValues,
                 std::vector<double>& numValues) const;
 

--- a/modules/flann/src/miniflann.cpp
+++ b/modules/flann/src/miniflann.cpp
@@ -89,7 +89,7 @@ void IndexParams::setAlgorithm(int value)
 }
 
 void IndexParams::getAll(std::vector<String>& names,
-            std::vector<int>& types,
+            std::vector<FlannIndexType>& types,
             std::vector<String>& strValues,
             std::vector<double>& numValues) const
 {
@@ -107,7 +107,7 @@ void IndexParams::getAll(std::vector<String>& names,
         try
         {
             String val = it->second.cast<String>();
-            types.push_back(CV_USRTYPE1);
+            types.push_back(FLANN_INDEX_TYPE_STRING);
             strValues.push_back(val);
             numValues.push_back(-1);
         continue;
@@ -119,7 +119,7 @@ void IndexParams::getAll(std::vector<String>& names,
         try
         {
             double val = it->second.cast<double>();
-            types.push_back( CV_64F );
+            types.push_back(FLANN_INDEX_TYPE_64F);
             numValues.push_back(val);
         continue;
         }
@@ -127,7 +127,7 @@ void IndexParams::getAll(std::vector<String>& names,
         try
         {
             float val = it->second.cast<float>();
-            types.push_back( CV_32F );
+            types.push_back(FLANN_INDEX_TYPE_32F);
             numValues.push_back(val);
         continue;
         }
@@ -135,7 +135,7 @@ void IndexParams::getAll(std::vector<String>& names,
         try
         {
             int val = it->second.cast<int>();
-            types.push_back( CV_32S );
+            types.push_back(FLANN_INDEX_TYPE_32S);
             numValues.push_back(val);
         continue;
         }
@@ -143,7 +143,7 @@ void IndexParams::getAll(std::vector<String>& names,
         try
         {
             short val = it->second.cast<short>();
-            types.push_back( CV_16S );
+            types.push_back(FLANN_INDEX_TYPE_16S);
             numValues.push_back(val);
         continue;
         }
@@ -151,7 +151,7 @@ void IndexParams::getAll(std::vector<String>& names,
         try
         {
             ushort val = it->second.cast<ushort>();
-            types.push_back( CV_16U );
+            types.push_back(FLANN_INDEX_TYPE_16U);
             numValues.push_back(val);
         continue;
         }
@@ -159,7 +159,7 @@ void IndexParams::getAll(std::vector<String>& names,
         try
         {
             char val = it->second.cast<char>();
-            types.push_back( CV_8S );
+            types.push_back(FLANN_INDEX_TYPE_8S);
             numValues.push_back(val);
         continue;
         }
@@ -167,7 +167,7 @@ void IndexParams::getAll(std::vector<String>& names,
         try
         {
             uchar val = it->second.cast<uchar>();
-            types.push_back( CV_8U );
+            types.push_back(FLANN_INDEX_TYPE_8U);
             numValues.push_back(val);
         continue;
         }
@@ -175,7 +175,7 @@ void IndexParams::getAll(std::vector<String>& names,
         try
         {
             bool val = it->second.cast<bool>();
-            types.push_back( CV_MAKETYPE(CV_USRTYPE1,2) );
+            types.push_back(FLANN_INDEX_TYPE_BOOL);
             numValues.push_back(val);
         continue;
         }
@@ -183,14 +183,14 @@ void IndexParams::getAll(std::vector<String>& names,
         try
         {
             cvflann::flann_algorithm_t val = it->second.cast<cvflann::flann_algorithm_t>();
-            types.push_back( CV_MAKETYPE(CV_USRTYPE1,3) );
+            types.push_back(FLANN_INDEX_TYPE_ALGORITHM);
             numValues.push_back(val);
         continue;
         }
         catch (...) {}
 
 
-        types.push_back(-1); // unknown type
+        types.push_back((FlannIndexType)-1); // unknown type
         numValues.push_back(-1);
     }
 }

--- a/modules/ts/src/ts_perf.cpp
+++ b/modules/ts/src/ts_perf.cpp
@@ -2198,19 +2198,11 @@ namespace perf
 
 void PrintTo(const MatType& t, ::std::ostream* os)
 {
-    switch( CV_MAT_DEPTH((int)t) )
-    {
-        case CV_8U:  *os << "8U";  break;
-        case CV_8S:  *os << "8S";  break;
-        case CV_16U: *os << "16U"; break;
-        case CV_16S: *os << "16S"; break;
-        case CV_32S: *os << "32S"; break;
-        case CV_32F: *os << "32F"; break;
-        case CV_64F: *os << "64F"; break;
-        case CV_USRTYPE1: *os << "16F"; break;
-        default: *os << "INVALID_TYPE"; break;
-    }
-    *os << 'C' << CV_MAT_CN((int)t);
+    String name = typeToString(t);
+    if (name.size() > 3 && name[0] == 'C' && name[1] == 'V' && name[2] == '_')
+        *os << name.substr(3);
+    else
+        *os << name;
 }
 
 } //namespace perf


### PR DESCRIPTION
avoid OpenCV crashes due size change `CV_ELEM_SIZE(CV_USRTYPE1)`: 8 -> 2

relates #12463
