### PR TITLE
Support double precision in cuda::polarToCart() + fix broken tests

### DIFF
--- a/modules/cudaarithm/include/opencv2/cudaarithm.hpp
+++ b/modules/cudaarithm/include/opencv2/cudaarithm.hpp
@@ -415,10 +415,10 @@ CV_EXPORTS void cartToPolar(InputArray x, InputArray y, OutputArray magnitude, O
 
 /** @brief Converts polar coordinates into Cartesian.
 
-@param magnitude Source matrix containing magnitudes ( CV_32FC1 ).
-@param angle Source matrix containing angles ( CV_32FC1 ).
-@param x Destination matrix of real components ( CV_32FC1 ).
-@param y Destination matrix of imaginary components ( CV_32FC1 ).
+@param magnitude Source matrix containing magnitudes ( CV_32FC1 or CV_64FC1 ).
+@param angle Source matrix containing angles ( same type as magnitude ).
+@param x Destination matrix of real components ( same type as magnitude ).
+@param y Destination matrix of imaginary components ( same type as magnitude ).
 @param angleInDegrees Flag that indicates angles in degrees.
 @param stream Stream for the asynchronous version.
  */

--- a/modules/cudaarithm/perf/perf_element_operations.cpp
+++ b/modules/cudaarithm/perf/perf_element_operations.cpp
@@ -1346,6 +1346,7 @@ PERF_TEST_P(Sz, MagnitudeSqr,
 // Phase
 
 DEF_PARAM_TEST(Sz_AngleInDegrees, cv::Size, bool);
+DEF_PARAM_TEST(Sz_Type_AngleInDegrees, cv::Size, MatType, bool);
 
 PERF_TEST_P(Sz_AngleInDegrees, Phase,
             Combine(CUDA_TYPICAL_MAT_SIZES,
@@ -1423,17 +1424,19 @@ PERF_TEST_P(Sz_AngleInDegrees, CartToPolar,
 //////////////////////////////////////////////////////////////////////
 // PolarToCart
 
-PERF_TEST_P(Sz_AngleInDegrees, PolarToCart,
+PERF_TEST_P(Sz_Type_AngleInDegrees, PolarToCart,
             Combine(CUDA_TYPICAL_MAT_SIZES,
+                    testing::Values(CV_32FC1, CV_64FC1),
                     Bool()))
 {
     const cv::Size size = GET_PARAM(0);
-    const bool angleInDegrees = GET_PARAM(1);
+    const int type = GET_PARAM(1);
+    const bool angleInDegrees = GET_PARAM(2);
 
-    cv::Mat magnitude(size, CV_32FC1);
+    cv::Mat magnitude(size, type);
     declare.in(magnitude, WARMUP_RNG);
 
-    cv::Mat angle(size, CV_32FC1);
+    cv::Mat angle(size, type);
     declare.in(angle, WARMUP_RNG);
 
     if (PERF_RUN_CUDA())

--- a/modules/cudaarithm/src/cuda/polar_cart.cu
+++ b/modules/cudaarithm/src/cuda/polar_cart.cu
@@ -157,8 +157,23 @@ void cv::cuda::cartToPolar(InputArray _x, InputArray _y, OutputArray _mag, Outpu
 
 namespace
 {
-    template <bool useMag>
-    __global__ void polarToCartImpl(const GlobPtr<float> mag, const GlobPtr<float> angle, GlobPtr<float> xmat, GlobPtr<float> ymat, const float scale, const int rows, const int cols)
+    template <typename T> struct sincos_op
+    {
+        __device__ __forceinline__ void operator()(T a, T *sptr, T *cptr) const
+        {
+            ::sincos(a, sptr, cptr);
+        }
+    };
+    template <> struct sincos_op<float>
+    {
+        __device__ __forceinline__ void operator()(float a, float *sptr, float *cptr) const
+        {
+            ::sincosf(a, sptr, cptr);
+        }
+    };
+
+    template <typename T, bool useMag>
+    __global__ void polarToCartImpl_(const GlobPtr<T> mag, const GlobPtr<T> angle, GlobPtr<T> xmat, GlobPtr<T> ymat, const T scale, const int rows, const int cols)
     {
         const int x = blockDim.x * blockIdx.x + threadIdx.x;
         const int y = blockDim.y * blockIdx.y + threadIdx.y;
@@ -166,45 +181,53 @@ namespace
         if (x >= cols || y >= rows)
             return;
 
-        const float mag_val = useMag ? mag(y, x) : 1.0f;
-        const float angle_val = angle(y, x);
+        const T mag_val = useMag ? mag(y, x) : static_cast<T>(1.0);
+        const T angle_val = angle(y, x);
 
-        float sin_a, cos_a;
-        ::sincosf(scale * angle_val, &sin_a, &cos_a);
+        T sin_a, cos_a;
+        sincos_op<T> op;
+        op(scale * angle_val, &sin_a, &cos_a);
 
         xmat(y, x) = mag_val * cos_a;
         ymat(y, x) = mag_val * sin_a;
+    }
+
+    template <typename T>
+    void polarToCartImpl(const GpuMat& mag, const GpuMat& angle, GpuMat& x, GpuMat& y, bool angleInDegrees, cudaStream_t& stream)
+    {
+        GpuMat_<T> xc(x.reshape(1));
+        GpuMat_<T> yc(y.reshape(1));
+        GpuMat_<T> magc(mag.reshape(1));
+        GpuMat_<T> anglec(angle.reshape(1));
+
+        const dim3 block(32, 8);
+        const dim3 grid(divUp(anglec.cols, block.x), divUp(anglec.rows, block.y));
+
+        const T scale = angleInDegrees ? static_cast<T>(CV_PI / 180.0) : static_cast<T>(1.0);
+
+        if (magc.empty())
+            polarToCartImpl_<T, false> << <grid, block, 0, stream >> >(shrinkPtr(magc), shrinkPtr(anglec), shrinkPtr(xc), shrinkPtr(yc), scale, anglec.rows, anglec.cols);
+        else
+            polarToCartImpl_<T, true> << <grid, block, 0, stream >> >(shrinkPtr(magc), shrinkPtr(anglec), shrinkPtr(xc), shrinkPtr(yc), scale, anglec.rows, anglec.cols);
     }
 }
 
 void cv::cuda::polarToCart(InputArray _mag, InputArray _angle, OutputArray _x, OutputArray _y, bool angleInDegrees, Stream& _stream)
 {
+    typedef void(*func_t)(const GpuMat& mag, const GpuMat& angle, GpuMat& x, GpuMat& y, bool angleInDegrees, cudaStream_t& stream);
+    static const func_t funcs[7] = { 0, 0, 0, 0, 0, polarToCartImpl<float>, polarToCartImpl<double> };
+
     GpuMat mag = getInputMat(_mag, _stream);
     GpuMat angle = getInputMat(_angle, _stream);
 
-    CV_Assert( angle.depth() == CV_32F );
+    CV_Assert(angle.depth() == CV_32F || angle.depth() == CV_64F);
     CV_Assert( mag.empty() || (mag.type() == angle.type() && mag.size() == angle.size()) );
 
-    GpuMat x = getOutputMat(_x, angle.size(), CV_32FC1, _stream);
-    GpuMat y = getOutputMat(_y, angle.size(), CV_32FC1, _stream);
-
-    GpuMat_<float> xc(x.reshape(1));
-    GpuMat_<float> yc(y.reshape(1));
-    GpuMat_<float> magc(mag.reshape(1));
-    GpuMat_<float> anglec(angle.reshape(1));
-
-    const dim3 block(32, 8);
-    const dim3 grid(divUp(anglec.cols, block.x), divUp(anglec.rows, block.y));
-
-    const float scale = angleInDegrees ? (CV_PI_F / 180.0f) : 1.0f;
+    GpuMat x = getOutputMat(_x, angle.size(), CV_MAKETYPE(angle.depth(), 1), _stream);
+    GpuMat y = getOutputMat(_y, angle.size(), CV_MAKETYPE(angle.depth(), 1), _stream);
 
     cudaStream_t stream = StreamAccessor::getStream(_stream);
-
-    if (magc.empty())
-        polarToCartImpl<false><<<grid, block, 0, stream>>>(shrinkPtr(magc), shrinkPtr(anglec), shrinkPtr(xc), shrinkPtr(yc), scale, anglec.rows, anglec.cols);
-    else
-        polarToCartImpl<true><<<grid, block, 0, stream>>>(shrinkPtr(magc), shrinkPtr(anglec), shrinkPtr(xc), shrinkPtr(yc), scale, anglec.rows, anglec.cols);
-
+    funcs[angle.depth()](mag, angle, x, y, angleInDegrees, stream);
     CV_CUDEV_SAFE_CALL( cudaGetLastError() );
 
     syncOutput(x, _x, _stream);


### PR DESCRIPTION
Merge with opencv/opencv_extra#522
related: #12561, #12268

Fix for `cuda::polarToCart` functionality
### This pullrequest changes
- Support double precision
- test double precision and tune tolerance

All tests are performed using
```
opencv_perf_cudaarithm --gtest_filter=*PolarToCart* --perf_min_samples=10000 --perf_force_samples=10000 
```

|       | Type  | mean | median | min  |    stddev   | total time | --gtest_param_filter     |
|-------|-------|------|--------|------|-------------|------------|--------------------------|
| Before| float | 0.20 |  0.19  | 0.18 | 0.01 (5.3%) |  2054 ms   | (1920x1080, true)        |
|       | double| N/A  |  N/A   |  N/A |  N/A        |   N/A      |  N/A                     |
| After | float | 0.19 |  0.19  | 0.18 | 0.01 (4.1%) |  1994 ms   | (1920x1080, 32FC1, true) |
|       | double| 0.45 |  0.45  | 0.39 | 0.02 (4.2%) |  4587 ms   | (1920x1080, 64FC1, true) |

```
allow_multiple_commits=1
force_builders=Custom
docker_image:Custom=ubuntu-cuda:16.04
```