### PR TITLE
Import tensorflow to create text graphs if import cv is failed

### DIFF
--- a/samples/dnn/tf_text_graph_faster_rcnn.py
+++ b/samples/dnn/tf_text_graph_faster_rcnn.py
@@ -1,6 +1,5 @@
 import argparse
 import numpy as np
-import cv2 as cv
 from tf_text_graph_common import *
 
 
@@ -42,7 +41,7 @@ def createFasterRCNNGraph(modelPath, configPath, outputPath):
     print('Features stride:   %f' % features_stride)
 
     # Read the graph.
-    cv.dnn.writeTextGraph(modelPath, outputPath)
+    writeTextGraph(modelPath, outputPath, ['num_detections', 'detection_scores', 'detection_boxes', 'detection_classes'])
     graph_def = parseTextGraph(outputPath)
 
     removeIdentity(graph_def)

--- a/samples/dnn/tf_text_graph_mask_rcnn.py
+++ b/samples/dnn/tf_text_graph_mask_rcnn.py
@@ -1,6 +1,5 @@
 import argparse
 import numpy as np
-import cv2 as cv
 from tf_text_graph_common import *
 
 parser = argparse.ArgumentParser(description='Run this script to get a text graph of '
@@ -48,7 +47,7 @@ print('Height stride:     %f' % height_stride)
 print('Features stride:   %f' % features_stride)
 
 # Read the graph.
-cv.dnn.writeTextGraph(args.input, args.output)
+writeTextGraph(args.input, args.output, ['num_detections', 'detection_scores', 'detection_boxes', 'detection_classes', 'detection_masks'])
 graph_def = parseTextGraph(args.output)
 
 removeIdentity(graph_def)

--- a/samples/dnn/tf_text_graph_ssd.py
+++ b/samples/dnn/tf_text_graph_ssd.py
@@ -11,7 +11,6 @@
 # See details and examples on the following wiki page: https://github.com/opencv/opencv/wiki/TensorFlow-Object-Detection-API
 import argparse
 from math import sqrt
-import cv2 as cv
 from tf_text_graph_common import *
 
 def createSSDGraph(modelPath, configPath, outputPath):
@@ -52,11 +51,11 @@ def createSSDGraph(modelPath, configPath, outputPath):
     print('Input image size: %dx%d' % (image_width, image_height))
 
     # Read the graph.
-    cv.dnn.writeTextGraph(modelPath, outputPath)
-    graph_def = parseTextGraph(outputPath)
-
     inpNames = ['image_tensor']
     outNames = ['num_detections', 'detection_scores', 'detection_boxes', 'detection_classes']
+
+    writeTextGraph(modelPath, outputPath, outNames)
+    graph_def = parseTextGraph(outputPath)
 
     def getUnconnectedNodes():
         unconnected = []


### PR DESCRIPTION
<!-- Please use this line to close one or multiple issues when this pullrequest gets merged
You can add another line right under the first one:
resolves #1234
resolves #1235
-->

### This pullrequest changes

resolves https://github.com/opencv/opencv/issues/12442
related http://answers.opencv.org/question/199588/attributeerror-dnn-object-has-no-attribute-writetextgraph/?comment=199598#post-id-199598

Use TensorFlow to create object detection text graphs in case of outdated OpenCV imported in corresponding scripts (with no writeTextGraph).