### PR TITLE
Add .clang-format to help to enforce code format

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -4,7 +4,7 @@ BasedOnStyle:  WebKit
 AlignAfterOpenBracket: Align
 AllowAllParametersOfDeclarationOnNextLine: false
 # AlwaysBreakTemplateDeclarations: MultiLine
-BraceWrapping:   
+BraceWrapping:
   AfterClass:      true
   AfterControlStatement: true
   AfterEnum:       false

--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,24 @@
+---
+Language:        Cpp
+BasedOnStyle:  WebKit
+AlignAfterOpenBracket: Align
+AllowAllParametersOfDeclarationOnNextLine: false
+# AlwaysBreakTemplateDeclarations: MultiLine
+BraceWrapping:   
+  AfterClass:      true
+  AfterControlStatement: true
+  AfterEnum:       false
+  AfterFunction:   true
+  AfterNamespace:  false
+  AfterStruct:     true
+  AfterUnion:      true
+  BeforeCatch:     false
+  BeforeElse:      true
+  IndentBraces:    false
+BreakBeforeBinaryOperators: NonAssignment
+BreakBeforeBraces: Custom
+ColumnLimit:     100
+KeepEmptyLinesAtTheStartOfBlocks: false
+NamespaceIndentation: None
+SpaceBeforeParens: Never
+...


### PR DESCRIPTION
This is a prototype clang-format configuration file on which further
discussions are needed. The main reason is that there is no consistent
coding style in the current source code of OpenCV.

This configuration has been tested with clang-format-3.9, and may be
slightly different to other versions.

There is already a [coding style guide](https://github.com/opencv/opencv/wiki/Coding_Style_Guide).
But code style in the repository is not as consistent as expected.
Some useful utilities exist to help to enhance coding formats, such as
[clang-tidy](http://clang.llvm.org/extra/clang-tidy/) and [clang-format](http://clang.llvm.org/docs/ClangFormat.html).

Wish a `.clang-format` file will be helpful to all developers.

To explore better code style options, I'll explain several options for
why they are chosen. Available style options are described in
[Clang-Format Style Options](https://clang.llvm.org/docs/ClangFormatStyleOptions.html).

* `Language:        Cpp`

This style file should be used for C, C++.

* `BasedOnStyle:  WebKit`

Among predefined styles, `WebKit` is the closest one to OpenCV's coding
style. See [WebKit’s style guide](https://webkit.org/code-style-guidelines/) for comparison.

This option will set most of needed options. So only several additional
options are needed to custom style based on `WebKit` style.

* `AlignAfterOpenBracket: Align`

`Align` might make the code looks better. But for long function names
and long parameter names, this might make the code worse.

* `# AlwaysBreakTemplateDeclarations: MultiLine`

`MultiLine` value is only supported by higher `clang-format` versions.
So it's commented out. For clang-format-3.9 possible values are: `false`
or `true`.

* `BraceWrapping` and `BreakBeforeBraces: Custom`

`BraceWrapping` is only used when `BreakBeforeBraces` is set to
`Custom`. Instead of using `Custom`, one of predefined style is strongly
recommended. (`Attach`, `Linux`, `Mozilla`, `Stroustrup`, `Allman`,
`GNU`, `WebKit`)

* `ColumnLimit:     100`

`100` is set according to the coding style guide of OpenCV. In my
personal view, a better value of `ColumnLimit: 78` is preferred. It's
not recommended to use a large column limit. For `git diff` in
traditional 80 column terminals, 78 is a reasonable maximum choice (80
minus -/+ sign and a space). Besides, as printing on an A4 paper size
media (PDF or hard-copy), column less than 80 will make sure nicer
format.

You can always use a column of 100 in your editors with a modern HD wide
screen, just clang-format before commit. There's no hurt to anybody's
personal developing experience.

* `NamespaceIndentation: None`

Don’t indent in namespaces.

* `SpaceBeforeParens: Never`

Never put a space before opening parentheses. This is set based on the
example in OpenCV's coding style guide. But in the source code there are
many cases using spaces after control statement keywords. So this option
would be better if changed to `SpaceBeforeParens: ControlStatements`.

* `SpacesInParentheses`

If `true`, spaces will be inserted after `(` and before `)`. OpenCV's
source code use both cases with and without these spaces. So I choose
`SpacesInParentheses: false` which set already by `BasedOnStyle: WebKit`.

* Consecutive namespace declarations

In case of consecutive namespace declarations, I have no idea on styling
this:
```cpp
namespace cv { namespace detail {
...
}}
```

Only the following style is configured.
```cpp
namespace cv {
namespace detail {
...
}
}
```

### This pull request changes

Nothing changes if no code is formatted with `clang-format`. New added
source files should be formatted using `clang-format` before commit.

```
force_builders=Docs
```