### PR TITLE
Fix failure to request stddev of non-intrinsics

### DIFF
--- a/modules/calib3d/src/calibration.cpp
+++ b/modules/calib3d/src/calibration.cpp
@@ -3426,7 +3426,8 @@ double cv::calibrateCamera(InputArrayOfArrays _objectPoints,
             tvecM = _tvecs.getMat();
     }
 
-    if( stddev_needed || stddev_ext_needed )
+    bool stddev_any_needed = stddev_needed || stddev_ext_needed;
+    if( stddev_any_needed )
     {
         stdDeviationsM.create(nimages*6 + CV_CALIB_NINTRINSIC, 1, CV_64F);
     }
@@ -3447,7 +3448,7 @@ double cv::calibrateCamera(InputArrayOfArrays _objectPoints,
                                           &c_cameraMatrix, &c_distCoeffs,
                                           rvecs_needed ? &c_rvecM : NULL,
                                           tvecs_needed ? &c_tvecM : NULL,
-                                          stddev_needed ? &c_stdDev : NULL,
+                                          stddev_any_needed ? &c_stdDev : NULL,
                                           errors_needed ? &c_errors : NULL, flags, cvTermCriteria(criteria));
 
     if( stddev_needed )


### PR DESCRIPTION
Before this fix, the code would fail if only standard deviations of
extrinsic parameters are requested. While standard deviations matrix
should be computed if any set of standard deviations is requested. A
variable is added to represent this case.

### This pull request changes

It fixes a bug when only stddev of extrinsic parameters are requested.
To reproduce this bug, try to call `calibrateCamera` with
`stdDeviationsIntrinsics` set to `noArray()`, while
`stdDeviationsExtrinsics` set to a vector of `double`. After camera
calibration, check the elements of `stdDeviationsExtrinsics`.
