### PR TITLE
Improves JS dependencies detection and status indication

### DIFF
--- a/modules/js/CMakeLists.txt
+++ b/modules/js/CMakeLists.txt
@@ -9,10 +9,29 @@ set(MODULE_NAME js)
 
 set(OPENCV_JS "opencv.js")
 
+find_path(EMSCRIPTEN_INCLUDE_DIR
+          emscripten/bind.h
+          PATHS
+            ENV EMSCRIPTEN_ROOT
+          PATH_SUFFIXES system/include include
+          DOC "Location of Emscripten SDK")
+
+if(NOT EMSCRIPTEN_INCLUDE_DIR OR NOT PYTHON_DEFAULT_AVAILABLE)
+  set(DISABLE_MSG "Module ${MODULE_NAME} disabled because the following dependencies are not found:")
+  if(NOT EMSCRIPTEN_INCLUDE_DIR)
+    message(STATUS "\${EMSCRIPTEN_INCLUDE_DIR}/emscripten/bind.h` was not detected")
+    set(DISABLE_MSG "${DISABLE_MSG} Emscripten")
+  endif()
+  if(NOT PYTHON_DEFAULT_AVAILABLE)
+    set(DISABLE_MSG "${DISABLE_MSG} Python")
+  endif()
+  message(STATUS ${DISABLE_MSG})
+  ocv_module_disable(${MODULE_NAME})
+endif()
+
 ocv_add_module(${MODULE_NAME} BINDINGS)
 
-# TODO: add emscripten path
-ocv_module_include_directories()
+ocv_module_include_directories(${EMSCRIPTEN_INCLUDE_DIR})
 
 # get list of modules to wrap
 # message(STATUS "Wrapped in ${MODULE_NAME}:")

--- a/modules/js/src/make_umd.py
+++ b/modules/js/src/make_umd.py
@@ -103,4 +103,7 @@ if __name__ == "__main__":
     if len(sys.argv) > 2:
         opencvjs = sys.argv[1]
         cvjs = sys.argv[2]
+        if not os.path.isfile(opencvjs):
+            print('opencv.js file not found! Have you compiled the opencv_js module?')
+            exit()
         make_umd(opencvjs, cvjs);


### PR DESCRIPTION
### This pullrequest changes
- Improves Emscripten <s>and other windows-specific dependencies</s> detection
- Provides meaningful message in case of compile issues

By inspecting CMake vars in the builders, we can notice the following:
```
EMSCRIPTEN_INCLUDE_DIR=/opt/emsdk-portable/emscripten/1.37.21/system/include
```

```
force_builders=Custom
docker_image:Docs=docs-js
docker_image:Custom=javascript
allow_multiple_commits=1
```