### PR TITLE
JS: Improve enums support

### DIFF
--- a/modules/js/src/embindgen.py
+++ b/modules/js/src/embindgen.py
@@ -381,8 +381,8 @@ class JSWrapperGenerator(object):
                 if candidate_name not in ns.enums:
                     name = candidate_name
                     break;
-        val = '_'.join(classes + [name])
         cname = name.replace('.', '::')
+        type_dict[normalize_class_name(name)] = cname
         if name in ns.enums:
             print("Generator warning: enum %s (cname=%s) already exists" \
                   % (name, cname))
@@ -826,7 +826,8 @@ class JSWrapperGenerator(object):
                     for variant in method.variants:
                         args = []
                         for arg in variant.args:
-                            args.append(arg.tp)
+                            arg_type = type_dict[arg.tp] if arg.tp in type_dict else arg.tp
+                            args.append(arg_type)
                         # print('Constructor: ', class_info.name, len(variant.args))
                         args_num = len(variant.args)
                         if args_num in class_info.constructor_arg_num:

--- a/modules/js/src/templates.py
+++ b/modules/js/src/templates.py
@@ -176,7 +176,7 @@ enum_template = Template("""
 """)
 
 const_template = Template("""
-    constant("$js_name", +$value);
+    constant("$js_name", static_cast<long>($value));
 """)
 
 vector_template = Template("""


### PR DESCRIPTION
Enums support in JS module was not complete! If an enum is utilized in a constructor or a const, it would fail such as in [this build](http://pullrequest.opencv.org/buildbot/builders/precommit_docs/builds/17414/)..
This PR fixes the issue

### This pullrequest changes
- Support enum types in constructors
- Cast enum consts to their numeric values

```
force_builders=Custom
docker_image:Docs=docs-js
docker_image:Custom=javascript
```