### PR TITLE
Fix #12542

### DIFF
--- a/modules/dnn/CMakeLists.txt
+++ b/modules/dnn/CMakeLists.txt
@@ -36,7 +36,6 @@ else()
                                        -Wunused-parameter -Wunused-local-typedefs -Wsign-compare -Wsign-promo
                                        -Wundef -Wtautological-undefined-compare -Wignored-qualifiers -Wextra
                                        -Wunused-function -Wunused-const-variable -Wdeprecated-declarations
-                                       -Werror=non-virtual-dtor
   )
 endif()
 

--- a/modules/dnn/src/onnx/onnx_importer.cpp
+++ b/modules/dnn/src/onnx/onnx_importer.cpp
@@ -213,7 +213,7 @@ LayerParams ONNXImporter::getLayerParams(const opencv_onnx::NodeProto& node_prot
         else if (attribute_proto.floats_size() > 0)
         {
             lp.set(attribute_name, DictValue::arrayReal(
-                (float*)attribute_proto.mutable_floats(), attribute_proto.floats_size()));
+                attribute_proto.floats().data(), attribute_proto.floats_size()));
         }
         else if (attribute_proto.ints_size() > 0)
         {

--- a/modules/dnn/src/tensorflow/tf_graph_simplifier.cpp
+++ b/modules/dnn/src/tensorflow/tf_graph_simplifier.cpp
@@ -20,6 +20,8 @@ using ::google::protobuf::MapPair;
 class Subgraph  // Interface to match and replace TensorFlow subgraphs.
 {
 public:
+    virtual ~Subgraph() {}
+
     // Add a node to be matched in the origin graph. Specify ids of nodes that
     // are expected to be inputs. Returns id of a newly added node.
     // TODO: Replace inputs to std::vector<int> in C++11


### PR DESCRIPTION
* resolves https://github.com/opencv/opencv/issues/12542
* remove `-Werror=non-virtual-dtor` suppression introduced in https://github.com/opencv/opencv/pull/10608 (related: http://answers.opencv.org/question/199796/opencv-343-compiling-with-mingw-64-810-and-cmake-for-eclipse/)

```
force_builders=Custom
docker_image:Custom=ubuntu-openvino:16.04
buildworker:Custom=linux-2
test_opencl:Custom=ON
```