### PR TITLE
Clean CV_MAKETYPE related boiler code

### DIFF
--- a/modules/core/include/opencv2/core/cvdef.h
+++ b/modules/core/include/opencv2/core/cvdef.h
@@ -304,7 +304,7 @@ Cv64suf;
 *                                  Matrix type (Mat)                                     *
 \****************************************************************************************/
 
-#define CV_MAT_CN_MASK          ((CV_CN_MAX - 1) << CV_CN_SHIFT)
+#define CV_MAT_CN_MASK          CV_MAKETYPE(CV_8U, CV_CN_MAX)
 #define CV_MAT_CN(flags)        ((((flags) & CV_MAT_CN_MASK) >> CV_CN_SHIFT) + 1)
 #define CV_MAT_TYPE_MASK        (CV_DEPTH_MAX*CV_CN_MAX - 1)
 #define CV_MAT_TYPE(flags)      ((flags) & CV_MAT_TYPE_MASK)

--- a/modules/core/include/opencv2/core/types_c.h
+++ b/modules/core/include/opencv2/core/types_c.h
@@ -525,7 +525,7 @@ CvMat;
     (CV_MAT_CN((mat1)->type) == CV_MAT_CN((mat2)->type))
 
 #define CV_ARE_DEPTHS_EQ(mat1, mat2) \
-    ((((mat1)->type ^ (mat2)->type) & CV_MAT_DEPTH_MASK) == 0)
+    (CV_MAT_DEPTH((mat1)->type) == CV_MAT_DEPTH((mat2)->type))
 
 #define CV_ARE_SIZES_EQ(mat1, mat2) \
     ((mat1)->rows == (mat2)->rows && (mat1)->cols == (mat2)->cols)

--- a/modules/core/include/opencv2/core/types_c.h
+++ b/modules/core/include/opencv2/core/types_c.h
@@ -522,7 +522,7 @@ CvMat;
     ((((mat1)->type ^ (mat2)->type) & CV_MAT_TYPE_MASK) == 0)
 
 #define CV_ARE_CNS_EQ(mat1, mat2) \
-    ((((mat1)->type ^ (mat2)->type) & CV_MAT_CN_MASK) == 0)
+    (CV_MAT_CN((mat1)->type) == CV_MAT_CN((mat2)->type))
 
 #define CV_ARE_DEPTHS_EQ(mat1, mat2) \
     ((((mat1)->type ^ (mat2)->type) & CV_MAT_DEPTH_MASK) == 0)

--- a/modules/core/src/array.cpp
+++ b/modules/core/src/array.cpp
@@ -1458,7 +1458,7 @@ cvScalarToRawData( const CvScalar* scalar, void* data, int type, int extend_to_1
 {
     type = CV_MAT_TYPE(type);
     int cn = CV_MAT_CN( type );
-    int depth = type & CV_MAT_DEPTH_MASK;
+    int depth = CV_MAT_DEPTH(type);
 
     assert( scalar && data );
     if( (unsigned)(cn - 1) >= 4 )

--- a/modules/core/src/cuda_gpu_mat.cpp
+++ b/modules/core/src/cuda_gpu_mat.cpp
@@ -200,7 +200,7 @@ GpuMat cv::cuda::GpuMat::reshape(int new_cn, int new_rows) const
         CV_Error(cv::Error::BadNumChannels, "The total width is not divisible by the new number of channels");
 
     hdr.cols = new_width;
-    hdr.flags = (hdr.flags & ~CV_MAT_CN_MASK) | ((new_cn - 1) << CV_CN_SHIFT);
+    hdr.flags = (hdr.flags & ~CV_MAT_CN_MASK) | CV_MAKETYPE(CV_8U, new_cn);
 
     return hdr;
 }

--- a/modules/core/src/cuda_gpu_mat.cpp
+++ b/modules/core/src/cuda_gpu_mat.cpp
@@ -200,7 +200,7 @@ GpuMat cv::cuda::GpuMat::reshape(int new_cn, int new_rows) const
         CV_Error(cv::Error::BadNumChannels, "The total width is not divisible by the new number of channels");
 
     hdr.cols = new_width;
-    hdr.flags = (hdr.flags & ~CV_MAT_CN_MASK) | CV_MAKETYPE(CV_8U, new_cn);
+    hdr.flags = (hdr.flags & ~Mat::TYPE_MASK) | CV_MAKETYPE(CV_MAT_DEPTH(hdr.flags), new_cn);
 
     return hdr;
 }

--- a/modules/core/src/cuda_host_mem.cpp
+++ b/modules/core/src/cuda_host_mem.cpp
@@ -280,7 +280,7 @@ HostMem cv::cuda::HostMem::reshape(int new_cn, int new_rows) const
         CV_Error(cv::Error::BadNumChannels, "The total width is not divisible by the new number of channels");
 
     hdr.cols = new_width;
-    hdr.flags = (hdr.flags & ~CV_MAT_CN_MASK) | CV_MAKETYPE(CV_8U, new_cn);
+    hdr.flags = (hdr.flags & ~Mat::TYPE_MASK) | CV_MAKETYPE(CV_MAT_DEPTH(hdr.flags), new_cn);
 
     return hdr;
 }

--- a/modules/core/src/cuda_host_mem.cpp
+++ b/modules/core/src/cuda_host_mem.cpp
@@ -280,7 +280,7 @@ HostMem cv::cuda::HostMem::reshape(int new_cn, int new_rows) const
         CV_Error(cv::Error::BadNumChannels, "The total width is not divisible by the new number of channels");
 
     hdr.cols = new_width;
-    hdr.flags = (hdr.flags & ~CV_MAT_CN_MASK) | ((new_cn - 1) << CV_CN_SHIFT);
+    hdr.flags = (hdr.flags & ~CV_MAT_CN_MASK) | CV_MAKETYPE(CV_8U, new_cn);
 
     return hdr;
 }

--- a/modules/core/src/matrix.cpp
+++ b/modules/core/src/matrix.cpp
@@ -801,7 +801,7 @@ Mat Mat::reshape(int new_cn, int new_rows) const
     {
         if( new_rows == 0 && new_cn != 0 && size[dims-1]*cn % new_cn == 0 )
         {
-            hdr.flags = (hdr.flags & ~CV_MAT_CN_MASK) | ((new_cn-1) << CV_CN_SHIFT);
+            hdr.flags = (hdr.flags & ~CV_MAT_CN_MASK) | CV_MAKETYPE(CV_8U, new_cn);
             hdr.step[dims-1] = CV_ELEM_SIZE(hdr.flags);
             hdr.size[dims-1] = hdr.size[dims-1]*cn / new_cn;
             return hdr;
@@ -850,7 +850,7 @@ Mat Mat::reshape(int new_cn, int new_rows) const
         "The total width is not divisible by the new number of channels" );
 
     hdr.cols = new_width;
-    hdr.flags = (hdr.flags & ~CV_MAT_CN_MASK) | ((new_cn-1) << CV_CN_SHIFT);
+    hdr.flags = (hdr.flags & ~CV_MAT_CN_MASK) | CV_MAKETYPE(CV_8U, new_cn);
     hdr.step[1] = CV_ELEM_SIZE(hdr.flags);
     return hdr;
 }
@@ -897,7 +897,7 @@ Mat Mat::reshape(int _cn, int _newndims, const int* _newsz) const
             CV_Error(CV_StsUnmatchedSizes, "Requested and source matrices have different count of elements");
 
         Mat hdr = *this;
-        hdr.flags = (hdr.flags & ~CV_MAT_CN_MASK) | ((_cn-1) << CV_CN_SHIFT);
+        hdr.flags = (hdr.flags & ~CV_MAT_CN_MASK) | CV_MAKETYPE(CV_8U, _cn);
         setSize(hdr, _newndims, newsz_buf.data(), NULL, true);
 
         return hdr;

--- a/modules/core/src/matrix.cpp
+++ b/modules/core/src/matrix.cpp
@@ -801,7 +801,7 @@ Mat Mat::reshape(int new_cn, int new_rows) const
     {
         if( new_rows == 0 && new_cn != 0 && size[dims-1]*cn % new_cn == 0 )
         {
-            hdr.flags = (hdr.flags & ~CV_MAT_CN_MASK) | CV_MAKETYPE(CV_8U, new_cn);
+            hdr.flags = (hdr.flags & ~TYPE_MASK) | CV_MAKETYPE(CV_MAT_DEPTH(hdr.flags), new_cn);
             hdr.step[dims-1] = CV_ELEM_SIZE(hdr.flags);
             hdr.size[dims-1] = hdr.size[dims-1]*cn / new_cn;
             return hdr;
@@ -850,7 +850,7 @@ Mat Mat::reshape(int new_cn, int new_rows) const
         "The total width is not divisible by the new number of channels" );
 
     hdr.cols = new_width;
-    hdr.flags = (hdr.flags & ~CV_MAT_CN_MASK) | CV_MAKETYPE(CV_8U, new_cn);
+    hdr.flags = (hdr.flags & ~TYPE_MASK) | CV_MAKETYPE(CV_MAT_DEPTH(hdr.flags), new_cn);
     hdr.step[1] = CV_ELEM_SIZE(hdr.flags);
     return hdr;
 }
@@ -897,7 +897,7 @@ Mat Mat::reshape(int _cn, int _newndims, const int* _newsz) const
             CV_Error(CV_StsUnmatchedSizes, "Requested and source matrices have different count of elements");
 
         Mat hdr = *this;
-        hdr.flags = (hdr.flags & ~CV_MAT_CN_MASK) | CV_MAKETYPE(CV_8U, _cn);
+        hdr.flags = (hdr.flags & ~TYPE_MASK) | CV_MAKETYPE(CV_MAT_DEPTH(hdr.flags), _cn);
         setSize(hdr, _newndims, newsz_buf.data(), NULL, true);
 
         return hdr;

--- a/modules/core/src/umatrix.cpp
+++ b/modules/core/src/umatrix.cpp
@@ -690,7 +690,7 @@ UMat UMat::reshape(int new_cn, int new_rows) const
 
     if( dims > 2 && new_rows == 0 && new_cn != 0 && size[dims-1]*cn % new_cn == 0 )
     {
-        hdr.flags = (hdr.flags & ~CV_MAT_CN_MASK) | ((new_cn-1) << CV_CN_SHIFT);
+        hdr.flags = (hdr.flags & ~CV_MAT_CN_MASK) | CV_MAKETYPE(CV_8U, new_cn);
         hdr.step[dims-1] = CV_ELEM_SIZE(hdr.flags);
         hdr.size[dims-1] = hdr.size[dims-1]*cn / new_cn;
         return hdr;
@@ -733,7 +733,7 @@ UMat UMat::reshape(int new_cn, int new_rows) const
         "The total width is not divisible by the new number of channels" );
 
     hdr.cols = new_width;
-    hdr.flags = (hdr.flags & ~CV_MAT_CN_MASK) | ((new_cn-1) << CV_CN_SHIFT);
+    hdr.flags = (hdr.flags & ~CV_MAT_CN_MASK) | CV_MAKETYPE(CV_8U, new_cn);
     hdr.step[1] = CV_ELEM_SIZE(hdr.flags);
     return hdr;
 }
@@ -804,7 +804,7 @@ UMat UMat::reshape(int _cn, int _newndims, const int* _newsz) const
             CV_Error(CV_StsUnmatchedSizes, "Requested and source matrices have different count of elements");
 
         UMat hdr = *this;
-        hdr.flags = (hdr.flags & ~CV_MAT_CN_MASK) | ((_cn-1) << CV_CN_SHIFT);
+        hdr.flags = (hdr.flags & ~CV_MAT_CN_MASK) | CV_MAKETYPE(CV_8U, _cn);
         setSize(hdr, _newndims, newsz_buf.data(), NULL, true);
 
         return hdr;

--- a/modules/core/src/umatrix.cpp
+++ b/modules/core/src/umatrix.cpp
@@ -690,7 +690,7 @@ UMat UMat::reshape(int new_cn, int new_rows) const
 
     if( dims > 2 && new_rows == 0 && new_cn != 0 && size[dims-1]*cn % new_cn == 0 )
     {
-        hdr.flags = (hdr.flags & ~CV_MAT_CN_MASK) | CV_MAKETYPE(CV_8U, new_cn);
+        hdr.flags = (hdr.flags & ~TYPE_MASK) | CV_MAKETYPE(CV_MAT_DEPTH(hdr.flags), new_cn);
         hdr.step[dims-1] = CV_ELEM_SIZE(hdr.flags);
         hdr.size[dims-1] = hdr.size[dims-1]*cn / new_cn;
         return hdr;
@@ -733,7 +733,7 @@ UMat UMat::reshape(int new_cn, int new_rows) const
         "The total width is not divisible by the new number of channels" );
 
     hdr.cols = new_width;
-    hdr.flags = (hdr.flags & ~CV_MAT_CN_MASK) | CV_MAKETYPE(CV_8U, new_cn);
+    hdr.flags = (hdr.flags & ~TYPE_MASK) | CV_MAKETYPE(CV_MAT_DEPTH(hdr.flags), new_cn);
     hdr.step[1] = CV_ELEM_SIZE(hdr.flags);
     return hdr;
 }
@@ -804,7 +804,7 @@ UMat UMat::reshape(int _cn, int _newndims, const int* _newsz) const
             CV_Error(CV_StsUnmatchedSizes, "Requested and source matrices have different count of elements");
 
         UMat hdr = *this;
-        hdr.flags = (hdr.flags & ~CV_MAT_CN_MASK) | CV_MAKETYPE(CV_8U, _cn);
+        hdr.flags = (hdr.flags & ~TYPE_MASK) | CV_MAKETYPE(CV_MAT_DEPTH(hdr.flags), _cn);
         setSize(hdr, _newndims, newsz_buf.data(), NULL, true);
 
         return hdr;

--- a/modules/core/test/test_math.cpp
+++ b/modules/core/test/test_math.cpp
@@ -635,7 +635,7 @@ void Core_GEMMTest::get_test_array_types_and_sizes( int test_case_idx, vector<ve
     Base::get_test_array_types_and_sizes( test_case_idx, sizes, types );
     sizes[INPUT][0] = sizeA;
     sizes[INPUT][2] = sizes[INPUT][3] = Size(1,1);
-    types[INPUT][2] = types[INPUT][3] &= ~CV_MAT_CN_MASK;
+    types[INPUT][2] = types[INPUT][3] = CV_MAT_DEPTH(types[INPUT][2]);
 
     tabc_flag = cvtest::randInt(rng) & 7;
 
@@ -862,7 +862,7 @@ void Core_TransformTest::get_test_array_types_and_sizes( int test_case_idx, vect
             sizes[INPUT][2] = Size(dst_cn,1);
         else
             sizes[INPUT][2] = Size(1,dst_cn);
-        types[INPUT][2] &= ~CV_MAT_CN_MASK;
+        types[INPUT][2] = CV_MAT_DEPTH(types[INPUT][2]);
     }
     diagMtx = (bits & 16) != 0;
 
@@ -955,7 +955,7 @@ void Core_TransformLargeTest::get_test_array_types_and_sizes(int test_case_idx, 
             sizes[INPUT][2] = Size(dst_cn, 1);
         else
             sizes[INPUT][2] = Size(1, dst_cn);
-        types[INPUT][2] &= ~CV_MAT_CN_MASK;
+        types[INPUT][2] = CV_MAT_DEPTH(types[INPUT][2]);
     }
     diagMtx = (bits & 16) != 0;
 

--- a/modules/core/test/test_math.cpp
+++ b/modules/core/test/test_math.cpp
@@ -1257,7 +1257,7 @@ void Core_CovarMatrixTest::get_test_array_types_and_sizes( int test_case_idx, ve
         flags = (flags & ~CV_COVAR_ROWS) | CV_COVAR_COLS;
 
     if( CV_MAT_DEPTH(types[INPUT][0]) == CV_32S )
-        types[INPUT][0] = (types[INPUT][0] & ~CV_MAT_DEPTH_MASK) | CV_32F;
+        types[INPUT][0] = CV_MAKETYPE(CV_32F, CV_MAT_CN(types[INPUT][0]));
 
     sizes[OUTPUT][0] = sizes[REF_OUTPUT][0] = flags & CV_COVAR_NORMAL ? Size(len,len) : Size(count,count);
     sizes[INPUT_OUTPUT][0] = sizes[REF_INPUT_OUTPUT][0] = !t_flag ? Size(len,1) : Size(1,len);

--- a/modules/imgcodecs/src/utils.cpp
+++ b/modules/imgcodecs/src/utils.cpp
@@ -636,7 +636,7 @@ cvConvertImage( const CvArr* srcarr, CvArr* dstarr, int flags )
         if( !CV_ARE_CNS_EQ( src, dst ))
         {
             temp = cvCreateMat( src->height, src->width,
-                (src->type & CV_MAT_CN_MASK)|(dst->type & CV_MAT_DEPTH_MASK));
+                CV_MAKETYPE(CV_MAT_DEPTH(dst->type), CV_MAT_CN(src->type)));
             cvConvertScale( src, temp, scale, shift );
             src = temp;
         }

--- a/modules/imgproc/test/test_color.cpp
+++ b/modules/imgproc/test/test_color.cpp
@@ -441,7 +441,7 @@ void CV_ColorGrayTest::get_test_array_types_and_sizes( int test_case_idx, vector
 {
     CV_ColorCvtBaseTest::get_test_array_types_and_sizes( test_case_idx, sizes, types );
     int cn = CV_MAT_CN(types[INPUT][0]);
-    types[OUTPUT][0] = types[REF_OUTPUT][0] = types[INPUT][0] & CV_MAT_DEPTH_MASK;
+    types[OUTPUT][0] = types[REF_OUTPUT][0] = CV_MAT_DEPTH(types[INPUT][0]);
     inplace = false;
 
     if( cn == 3 )

--- a/modules/imgproc/test/test_convhull.cpp
+++ b/modules/imgproc/test/test_convhull.cpp
@@ -401,7 +401,7 @@ void CV_BaseShapeDescrTest::extract_points()
     if( CV_MAT_DEPTH(points2->type) != CV_32F && enable_flt_points )
     {
         CvMat tmp = cvMat( points2->rows, points2->cols,
-            (points2->type & ~CV_MAT_DEPTH_MASK) | CV_32F, points2->data.ptr );
+            CV_MAKETYPE(CV_32F, CV_MAT_CN(points2->type)), points2->data.ptr );
         cvConvert( points2, &tmp );
     }
 }

--- a/modules/imgproc/test/test_templmatch.cpp
+++ b/modules/imgproc/test/test_templmatch.cpp
@@ -149,8 +149,8 @@ static void cvTsMatchTemplate( const CvMat* img, const CvMat* templ, CvMat* resu
     int i, j, k, l;
     int depth = CV_MAT_DEPTH(img->type), cn = CV_MAT_CN(img->type);
     int width_n = templ->cols*cn, height = templ->rows;
-    int a_step = img->step / CV_ELEM_SIZE(img->type & CV_MAT_DEPTH_MASK);
-    int b_step = templ->step / CV_ELEM_SIZE(templ->type & CV_MAT_DEPTH_MASK);
+    int a_step = img->step / CV_ELEM_SIZE(CV_MAT_DEPTH(img->type));
+    int b_step = templ->step / CV_ELEM_SIZE(CV_MAT_DEPTH(templ->type));
     CvScalar b_mean = CV_STRUCT_INITIALIZER, b_sdv = CV_STRUCT_INITIALIZER;
     double b_denom = 1., b_sum2 = 0;
     int area = templ->rows*templ->cols;


### PR DESCRIPTION
### This pullrequest changes
- Reduce dependence on low-level constants, to enhance readability and scalability
- Relax dependency between MagicFlag and ElemType