### PR TITLE
(3.4) samples: update winpack python samples launcher

### DIFF
--- a/samples/python/_run_winpack_demo_python27.cmd
+++ b/samples/python/_run_winpack_demo_python27.cmd
@@ -1,12 +1,15 @@
 @echo off
-if NOT exist %CD%\..\..\..\build (
+setlocal enableDelayedExpansion
+
+set SCRIPTDIR=%~dp0
+if NOT exist %SCRIPTDIR%\..\..\..\build (
   echo ERROR: OpenCV Winpack installation is required
   pause
   exit
 )
 
 :: Path to FFMPEG binary files
-set PATH=%PATH%;%CD%\..\..\..\build\bin\
+set PATH=%PATH%;%SCRIPTDIR%\..\..\..\build\bin\
 
 :: Detect Python binary
 python -V
@@ -43,5 +46,17 @@ if %ERRORLEVEL% EQU 32 (
   )
 )
 
-:: Launch demo
+:: Don't generate unnecessary .pyc cache files
+set PYTHONDONTWRITEBYTECODE=1
+
+if [%1]==[] goto rundemo
+%PYTHON% %*
+set result=%errorlevel%
+IF %result% NEQ 0 (pause)
+EXIT /B %result%
+
+:rundemo
 %PYTHON% demo.py
+set result=%errorlevel%
+IF %result% NEQ 0 (pause)
+EXIT /B %result%


### PR DESCRIPTION
- accepts script parameter (allows drag & drop from 'explorer')
- use script dir instead of current dir (can launch samples from 'samples/dnn')
- added 'pause' to show error messages (about missing numpy) instead of instant closing

backport #12612