### PR TITLE
OpenGL: avoid losing precision in double-to-float conversion

### DIFF
--- a/modules/core/src/opengl.cpp
+++ b/modules/core/src/opengl.cpp
@@ -1434,14 +1434,14 @@ void cv::ogl::render(const ogl::Texture2D& tex, Rect_<double> wndRect, Rect_<dou
         gl::TexParameteri(gl::TEXTURE_2D, gl::TEXTURE_MIN_FILTER, gl::LINEAR);
         CV_CheckGlError();
 
-        const float vertex[] =
+        const double vertex[] =
         {
-            wndRect.x, wndRect.y, 0.0f,
-            wndRect.x, (wndRect.y + wndRect.height), 0.0f,
-            wndRect.x + wndRect.width, (wndRect.y + wndRect.height), 0.0f,
-            wndRect.x + wndRect.width, wndRect.y, 0.0f
+            wndRect.x, wndRect.y, 0.0,
+            wndRect.x, (wndRect.y + wndRect.height), 0.0,
+            wndRect.x + wndRect.width, (wndRect.y + wndRect.height), 0.0,
+            wndRect.x + wndRect.width, wndRect.y, 0.0
         };
-        const float texCoords[] =
+        const double texCoords[] =
         {
             texRect.x, texRect.y,
             texRect.x, texRect.y + texRect.height,
@@ -1454,7 +1454,7 @@ void cv::ogl::render(const ogl::Texture2D& tex, Rect_<double> wndRect, Rect_<dou
         gl::EnableClientState(gl::TEXTURE_COORD_ARRAY);
         CV_CheckGlError();
 
-        gl::TexCoordPointer(2, gl::FLOAT, 0, texCoords);
+        gl::TexCoordPointer(2, gl::DOUBLE, 0, texCoords);
         CV_CheckGlError();
 
         gl::DisableClientState(gl::NORMAL_ARRAY);
@@ -1464,7 +1464,7 @@ void cv::ogl::render(const ogl::Texture2D& tex, Rect_<double> wndRect, Rect_<dou
         gl::EnableClientState(gl::VERTEX_ARRAY);
         CV_CheckGlError();
 
-        gl::VertexPointer(3, gl::FLOAT, 0, vertex);
+        gl::VertexPointer(3, gl::DOUBLE, 0, vertex);
         CV_CheckGlError();
 
         gl::DrawArrays(gl::QUADS, 0, 4);


### PR DESCRIPTION
### This pullrequest changes
- Eliminates some annoying warnings

```
force_builders=Custom
docker_image:Custom=qt:16.04
```