### PR TITLE
fix extra-semicolon warnings

### DIFF
--- a/modules/core/include/opencv2/core/cvdef.h
+++ b/modules/core/include/opencv2/core/cvdef.h
@@ -350,121 +350,135 @@ as well as exposing the C++11 enum class members for backwards compatibility
 static const EnumType MEMBER_CONST = EnumType::MEMBER_CONST;                                          \
 
 #define __CV_ENUM_CLASS_EXPOSE_2(EnumType, MEMBER_CONST, ...)                                         \
-__CV_ENUM_CLASS_EXPOSE_1(EnumType, MEMBER_CONST);                                                     \
-__CV_EXPAND(__CV_ENUM_CLASS_EXPOSE_1(EnumType, __VA_ARGS__));                                         \
+__CV_ENUM_CLASS_EXPOSE_1(EnumType, MEMBER_CONST)                                                      \
+__CV_EXPAND(__CV_ENUM_CLASS_EXPOSE_1(EnumType, __VA_ARGS__))                                          \
 
 #define __CV_ENUM_CLASS_EXPOSE_3(EnumType, MEMBER_CONST, ...)                                         \
-__CV_ENUM_CLASS_EXPOSE_1(EnumType, MEMBER_CONST);                                                     \
-__CV_EXPAND(__CV_ENUM_CLASS_EXPOSE_2(EnumType, __VA_ARGS__));                                         \
+__CV_ENUM_CLASS_EXPOSE_1(EnumType, MEMBER_CONST)                                                      \
+__CV_EXPAND(__CV_ENUM_CLASS_EXPOSE_2(EnumType, __VA_ARGS__))                                          \
 
 #define __CV_ENUM_CLASS_EXPOSE_4(EnumType, MEMBER_CONST, ...)                                         \
-__CV_ENUM_CLASS_EXPOSE_1(EnumType, MEMBER_CONST);                                                     \
-__CV_EXPAND(__CV_ENUM_CLASS_EXPOSE_3(EnumType, __VA_ARGS__));                                         \
+__CV_ENUM_CLASS_EXPOSE_1(EnumType, MEMBER_CONST)                                                      \
+__CV_EXPAND(__CV_ENUM_CLASS_EXPOSE_3(EnumType, __VA_ARGS__))                                          \
 
 #define __CV_ENUM_CLASS_EXPOSE_5(EnumType, MEMBER_CONST, ...)                                         \
-__CV_ENUM_CLASS_EXPOSE_1(EnumType, MEMBER_CONST);                                                     \
-__CV_EXPAND(__CV_ENUM_CLASS_EXPOSE_4(EnumType, __VA_ARGS__));                                         \
+__CV_ENUM_CLASS_EXPOSE_1(EnumType, MEMBER_CONST)                                                      \
+__CV_EXPAND(__CV_ENUM_CLASS_EXPOSE_4(EnumType, __VA_ARGS__))                                          \
 
 #define __CV_ENUM_CLASS_EXPOSE_6(EnumType, MEMBER_CONST, ...)                                         \
-__CV_ENUM_CLASS_EXPOSE_1(EnumType, MEMBER_CONST);                                                     \
-__CV_EXPAND(__CV_ENUM_CLASS_EXPOSE_5(EnumType, __VA_ARGS__));                                         \
+__CV_ENUM_CLASS_EXPOSE_1(EnumType, MEMBER_CONST)                                                      \
+__CV_EXPAND(__CV_ENUM_CLASS_EXPOSE_5(EnumType, __VA_ARGS__))                                          \
 
 #define __CV_ENUM_CLASS_EXPOSE_7(EnumType, MEMBER_CONST, ...)                                         \
-__CV_ENUM_CLASS_EXPOSE_1(EnumType, MEMBER_CONST);                                                     \
-__CV_EXPAND(__CV_ENUM_CLASS_EXPOSE_6(EnumType, __VA_ARGS__));                                         \
+__CV_ENUM_CLASS_EXPOSE_1(EnumType, MEMBER_CONST)                                                      \
+__CV_EXPAND(__CV_ENUM_CLASS_EXPOSE_6(EnumType, __VA_ARGS__))                                          \
 
 #define __CV_ENUM_CLASS_EXPOSE_8(EnumType, MEMBER_CONST, ...)                                         \
-__CV_ENUM_CLASS_EXPOSE_1(EnumType, MEMBER_CONST);                                                     \
-__CV_EXPAND(__CV_ENUM_CLASS_EXPOSE_7(EnumType, __VA_ARGS__));                                         \
+__CV_ENUM_CLASS_EXPOSE_1(EnumType, MEMBER_CONST)                                                      \
+__CV_EXPAND(__CV_ENUM_CLASS_EXPOSE_7(EnumType, __VA_ARGS__))                                          \
 
 #define __CV_ENUM_CLASS_EXPOSE_9(EnumType, MEMBER_CONST, ...)                                         \
-__CV_ENUM_CLASS_EXPOSE_1(EnumType, MEMBER_CONST);                                                     \
-__CV_EXPAND(__CV_ENUM_CLASS_EXPOSE_8(EnumType, __VA_ARGS__));                                         \
+__CV_ENUM_CLASS_EXPOSE_1(EnumType, MEMBER_CONST)                                                      \
+__CV_EXPAND(__CV_ENUM_CLASS_EXPOSE_8(EnumType, __VA_ARGS__))                                          \
 
-#define __CV_ENUM_FLAGS_LOGICAL_NOT(EnumType)                                                         \
+#define __CV_ENUM_FLAGS_LOGICAL_NOT_(EnumType)                                                        \
 static inline bool operator!(const EnumType& val)                                                     \
 {                                                                                                     \
     typedef std::underlying_type<EnumType>::type UnderlyingType;                                      \
     return !static_cast<UnderlyingType>(val);                                                         \
 }                                                                                                     \
 
-#define __CV_ENUM_FLAGS_LOGICAL_NOT_EQ(Arg1Type, Arg2Type)                                            \
+#define __CV_ENUM_FLAGS_LOGICAL_NOT_EQ_(Arg1Type, Arg2Type)                                           \
 static inline bool operator!=(const Arg1Type& a, const Arg2Type& b)                                   \
 {                                                                                                     \
     return static_cast<int>(a) != static_cast<int>(b);                                                \
 }                                                                                                     \
 
-#define __CV_ENUM_FLAGS_LOGICAL_EQ(Arg1Type, Arg2Type)                                                \
+#define __CV_ENUM_FLAGS_LOGICAL_EQ_(Arg1Type, Arg2Type)                                               \
 static inline bool operator==(const Arg1Type& a, const Arg2Type& b)                                   \
 {                                                                                                     \
     return static_cast<int>(a) == static_cast<int>(b);                                                \
 }                                                                                                     \
 
-#define __CV_ENUM_FLAGS_BITWISE_NOT(EnumType)                                                         \
+#define __CV_ENUM_FLAGS_BITWISE_NOT_(EnumType)                                                        \
 static inline EnumType operator~(const EnumType& val)                                                 \
 {                                                                                                     \
     typedef std::underlying_type<EnumType>::type UnderlyingType;                                      \
     return static_cast<EnumType>(~static_cast<UnderlyingType>(val));                                  \
 }                                                                                                     \
 
-#define __CV_ENUM_FLAGS_BITWISE_OR(EnumType, Arg1Type, Arg2Type)                                      \
+#define __CV_ENUM_FLAGS_BITWISE_OR_(EnumType, Arg1Type, Arg2Type)                                     \
 static inline EnumType operator|(const Arg1Type& a, const Arg2Type& b)                                \
 {                                                                                                     \
     typedef std::underlying_type<EnumType>::type UnderlyingType;                                      \
     return static_cast<EnumType>(static_cast<UnderlyingType>(a) | static_cast<UnderlyingType>(b));    \
 }                                                                                                     \
 
-#define __CV_ENUM_FLAGS_BITWISE_AND(EnumType, Arg1Type, Arg2Type)                                     \
+#define __CV_ENUM_FLAGS_BITWISE_AND_(EnumType, Arg1Type, Arg2Type)                                    \
 static inline EnumType operator&(const Arg1Type& a, const Arg2Type& b)                                \
 {                                                                                                     \
     typedef std::underlying_type<EnumType>::type UnderlyingType;                                      \
     return static_cast<EnumType>(static_cast<UnderlyingType>(a) & static_cast<UnderlyingType>(b));    \
 }                                                                                                     \
 
-#define __CV_ENUM_FLAGS_BITWISE_XOR(EnumType, Arg1Type, Arg2Type)                                     \
+#define __CV_ENUM_FLAGS_BITWISE_XOR_(EnumType, Arg1Type, Arg2Type)                                    \
 static inline EnumType operator^(const Arg1Type& a, const Arg2Type& b)                                \
 {                                                                                                     \
     typedef std::underlying_type<EnumType>::type UnderlyingType;                                      \
     return static_cast<EnumType>(static_cast<UnderlyingType>(a) ^ static_cast<UnderlyingType>(b));    \
 }                                                                                                     \
 
-#define __CV_ENUM_FLAGS_BITWISE_OR_EQ(EnumType, Arg1Type)                                             \
+#define __CV_ENUM_FLAGS_BITWISE_OR_EQ_(EnumType, Arg1Type)                                            \
 static inline EnumType& operator|=(EnumType& _this, const Arg1Type& val)                              \
 {                                                                                                     \
     _this = static_cast<EnumType>(static_cast<int>(_this) | static_cast<int>(val));                   \
     return _this;                                                                                     \
 }                                                                                                     \
 
-#define __CV_ENUM_FLAGS_BITWISE_AND_EQ(EnumType, Arg1Type)                                            \
+#define __CV_ENUM_FLAGS_BITWISE_AND_EQ_(EnumType, Arg1Type)                                           \
 static inline EnumType& operator&=(EnumType& _this, const Arg1Type& val)                              \
 {                                                                                                     \
     _this = static_cast<EnumType>(static_cast<int>(_this) & static_cast<int>(val));                   \
     return _this;                                                                                     \
 }                                                                                                     \
 
-#define __CV_ENUM_FLAGS_BITWISE_XOR_EQ(EnumType, Arg1Type)                                            \
+#define __CV_ENUM_FLAGS_BITWISE_XOR_EQ_(EnumType, Arg1Type)                                           \
 static inline EnumType& operator^=(EnumType& _this, const Arg1Type& val)                              \
 {                                                                                                     \
     _this = static_cast<EnumType>(static_cast<int>(_this) ^ static_cast<int>(val));                   \
     return _this;                                                                                     \
 }                                                                                                     \
 
-#define CV_ENUM_CLASS_EXPOSE(EnumType, ...)                                                           \
-__CV_EXPAND(__CV_CAT(__CV_ENUM_CLASS_EXPOSE_, __CV_VA_NUM_ARGS(__VA_ARGS__))(EnumType, __VA_ARGS__)); \
+#define CV_ENUM_CLASS_EXPOSE_(EnumType, ...)                                                          \
+__CV_EXPAND(__CV_CAT(__CV_ENUM_CLASS_EXPOSE_, __CV_VA_NUM_ARGS(__VA_ARGS__))(EnumType, __VA_ARGS__))  \
 
-#define CV_ENUM_FLAGS(EnumType)                                                                       \
-__CV_ENUM_FLAGS_LOGICAL_NOT      (EnumType);                                                          \
-__CV_ENUM_FLAGS_LOGICAL_EQ       (EnumType, int);                                                     \
-__CV_ENUM_FLAGS_LOGICAL_NOT_EQ   (EnumType, int);                                                     \
+#define CV_ENUM_FLAGS_(EnumType)                                                                      \
+__CV_ENUM_FLAGS_LOGICAL_NOT_      (EnumType)                                                          \
+__CV_ENUM_FLAGS_LOGICAL_EQ_       (EnumType, int)                                                     \
+__CV_ENUM_FLAGS_LOGICAL_NOT_EQ_   (EnumType, int)                                                     \
                                                                                                       \
-__CV_ENUM_FLAGS_BITWISE_NOT      (EnumType);                                                          \
-__CV_ENUM_FLAGS_BITWISE_OR       (EnumType, EnumType, EnumType);                                      \
-__CV_ENUM_FLAGS_BITWISE_AND      (EnumType, EnumType, EnumType);                                      \
-__CV_ENUM_FLAGS_BITWISE_XOR      (EnumType, EnumType, EnumType);                                      \
+__CV_ENUM_FLAGS_BITWISE_NOT_      (EnumType)                                                          \
+__CV_ENUM_FLAGS_BITWISE_OR_       (EnumType, EnumType, EnumType)                                      \
+__CV_ENUM_FLAGS_BITWISE_AND_      (EnumType, EnumType, EnumType)                                      \
+__CV_ENUM_FLAGS_BITWISE_XOR_      (EnumType, EnumType, EnumType)                                      \
                                                                                                       \
-__CV_ENUM_FLAGS_BITWISE_OR_EQ    (EnumType, EnumType);                                                \
-__CV_ENUM_FLAGS_BITWISE_AND_EQ   (EnumType, EnumType);                                                \
-__CV_ENUM_FLAGS_BITWISE_XOR_EQ   (EnumType, EnumType);                                                \
+__CV_ENUM_FLAGS_BITWISE_OR_EQ_    (EnumType, EnumType)                                                \
+__CV_ENUM_FLAGS_BITWISE_AND_EQ_   (EnumType, EnumType)                                                \
+__CV_ENUM_FLAGS_BITWISE_XOR_EQ_   (EnumType, EnumType)                                                \
+
+/* fix extra-semicolon warnings without disturbing linting code editors (#12631) */
+#define __CV_ENUM_FLAGS_LOGICAL_NOT(EnumType);                     __CV_ENUM_FLAGS_LOGICAL_NOT_(EnumType)
+#define __CV_ENUM_FLAGS_LOGICAL_NOT_EQ(Arg1Type, Arg2Type);        __CV_ENUM_FLAGS_LOGICAL_NOT_EQ_(Arg1Type, Arg2Type)
+#define __CV_ENUM_FLAGS_LOGICAL_EQ(Arg1Type, Arg2Type);            __CV_ENUM_FLAGS_LOGICAL_EQ_(Arg1Type, Arg2Type)
+#define __CV_ENUM_FLAGS_BITWISE_NOT(EnumType);                     __CV_ENUM_FLAGS_BITWISE_NOT_(EnumType)
+#define __CV_ENUM_FLAGS_BITWISE_OR(EnumType, Arg1Type, Arg2Type);  __CV_ENUM_FLAGS_BITWISE_OR_(EnumType, Arg1Type, Arg2Type)
+#define __CV_ENUM_FLAGS_BITWISE_AND(EnumType, Arg1Type, Arg2Type); __CV_ENUM_FLAGS_BITWISE_AND_(EnumType, Arg1Type, Arg2Type)
+#define __CV_ENUM_FLAGS_BITWISE_XOR(EnumType, Arg1Type, Arg2Type); __CV_ENUM_FLAGS_BITWISE_XOR_(EnumType, Arg1Type, Arg2Type)
+#define __CV_ENUM_FLAGS_BITWISE_OR_EQ(EnumType, Arg1Type);         __CV_ENUM_FLAGS_BITWISE_OR_EQ_(EnumType, Arg1Type)
+#define __CV_ENUM_FLAGS_BITWISE_AND_EQ(EnumType, Arg1Type);        __CV_ENUM_FLAGS_BITWISE_AND_EQ_(EnumType, Arg1Type)
+#define __CV_ENUM_FLAGS_BITWISE_XOR_EQ(EnumType, Arg1Type);        __CV_ENUM_FLAGS_BITWISE_XOR_EQ_(EnumType, Arg1Type)
+#define CV_ENUM_CLASS_EXPOSE(EnumType, ...);                       __CV_EXPAND(CV_ENUM_CLASS_EXPOSE_(EnumType, __VA_ARGS__))
+#define CV_ENUM_FLAGS(EnumType);                                   CV_ENUM_FLAGS_(EnumType)
 
 /****************************************************************************************\
 *                                    static analysys                                     *


### PR DESCRIPTION
related: #12310
Why `-Wpedantic` option is not enabled by default?

### This pullrequest changes
- Removes some extra-semicolon to avoid warnings when `-Wpedantic` is enabled

```
force_builders=Custom
docker_image:Custom=qt:16.04
```