### PR TITLE
Fixes for instrumentation of IPP and OCL

### DIFF
--- a/modules/core/include/opencv2/core/private.hpp
+++ b/modules/core/include/opencv2/core/private.hpp
@@ -713,12 +713,12 @@ CV_EXPORTS InstrNode*   getCurrentNode();
     if(::cv::instr::useInstrumentation()){\
         ::cv::instr::IntrumentationRegion __instr__(#FUN, __FILE__, __LINE__, NULL, false, TYPE, IMPL);\
         try{\
-            auto status = ((FUN)(__VA_ARGS__));\
+            auto instrStatus = ((FUN)(__VA_ARGS__));\
             if(ERROR_COND){\
                 ::cv::instr::getCurrentNode()->m_payload.m_funError = true;\
                 CV_INSTRUMENT_MARK_META(IMPL, #FUN " - BadExit");\
             }\
-            return status;\
+            return instrStatus;\
         }catch(...){\
             ::cv::instr::getCurrentNode()->m_payload.m_funError = true;\
             CV_INSTRUMENT_MARK_META(IMPL, #FUN " - BadExit");\
@@ -759,7 +759,7 @@ CV_EXPORTS InstrNode*   getCurrentNode();
 // Wrapper region instrumentation macro
 #define CV_INSTRUMENT_REGION_IPP();          CV_INSTRUMENT_REGION_META(__FUNCTION__, false, ::cv::instr::TYPE_WRAPPER, ::cv::instr::IMPL_IPP)
 // Function instrumentation macro
-#define CV_INSTRUMENT_FUN_IPP(FUN, ...)     CV_INSTRUMENT_FUN_RT_META(::cv::instr::TYPE_FUN, ::cv::instr::IMPL_IPP, status < 0, FUN, __VA_ARGS__)
+#define CV_INSTRUMENT_FUN_IPP(FUN, ...)     CV_INSTRUMENT_FUN_RT_META(::cv::instr::TYPE_FUN, ::cv::instr::IMPL_IPP, instrStatus < 0, FUN, __VA_ARGS__)
 // Diagnostic markers
 #define CV_INSTRUMENT_MARK_IPP(NAME)        CV_INSTRUMENT_MARK_META(::cv::instr::IMPL_IPP, NAME)
 

--- a/modules/core/src/ocl.cpp
+++ b/modules/core/src/ocl.cpp
@@ -3091,7 +3091,7 @@ bool Kernel::run(int dims, size_t _globalsize[], size_t _localsize[],
 bool Kernel::Impl::run(int dims, size_t globalsize[], size_t localsize[],
         bool sync, int64* timeNS, const Queue& q)
 {
-    CV_INSTRUMENT_REGION_OPENCL_RUN(name.c_str(););
+    CV_INSTRUMENT_REGION_OPENCL_RUN(name.c_str());
 
     if (!handle || isInProgress)
         return false;

--- a/modules/core/src/system.cpp
+++ b/modules/core/src/system.cpp
@@ -1836,7 +1836,7 @@ FLAGS getFlags()
 
 NodeData::NodeData(const char* funName, const char* fileName, int lineNum, void* retAddress, bool alwaysExpand, cv::instr::TYPE instrType, cv::instr::IMPL implType)
 {
-    m_funName       = funName;
+    m_funName       = funName ? cv::String(funName) : cv::String();  // std::string doesn't accept NULL
     m_instrType     = instrType;
     m_implType      = implType;
     m_fileName      = fileName;


### PR DESCRIPTION
### This pullrequest changes

 * fixed warning about variable redefinition when both IPP and instrumentation are enabled
 * fixed segfault when no `funName` provided for `NodeData` struct
 * compilation fixed when both OCL and instrumentation are enabled 
