### PR TITLE
Add a file with preprocessing parameters for deep learning samples

### DIFF
--- a/modules/core/include/opencv2/core/persistence.hpp
+++ b/modules/core/include/opencv2/core/persistence.hpp
@@ -542,6 +542,11 @@ public:
     */
     CV_WRAP_AS(at) FileNode operator[](int i) const;
 
+    /** @brief Returns keys of a mapping node.
+    @returns Keys of a mapping node.
+     */
+    CV_WRAP std::vector<String> keys() const;
+
     /** @brief Returns type of the node.
     @returns Type of the node. See FileNode::Type
      */

--- a/modules/core/src/persistence_cpp.cpp
+++ b/modules/core/src/persistence_cpp.cpp
@@ -269,6 +269,20 @@ FileNode FileNode::operator[](int i) const
         i == 0 ? *this : FileNode();
 }
 
+std::vector<String> FileNode::keys() const
+{
+    std::vector<String> res;
+    if (isMap())
+    {
+        res.reserve(size());
+        for (FileNodeIterator it = begin(); it != end(); ++it)
+        {
+            res.push_back((*it).name());
+        }
+    }
+    return res;
+}
+
 String FileNode::name() const
 {
     const char* str;

--- a/samples/dnn/classification.cpp
+++ b/samples/dnn/classification.cpp
@@ -5,21 +5,15 @@
 #include <opencv2/imgproc.hpp>
 #include <opencv2/highgui.hpp>
 
-const char* keys =
+#include "common.hpp"
+
+std::string keys =
     "{ help  h     | | Print help message. }"
+    "{ @alias      | | An alias name of model to extract preprocessing parameters from models.yml file. }"
+    "{ zoo         | models.yml | An optional path to file with preprocessing parameters }"
     "{ input i     | | Path to input image or video file. Skip this argument to capture frames from a camera.}"
-    "{ model m     | | Path to a binary file of model contains trained weights. "
-                      "It could be a file with extensions .caffemodel (Caffe), "
-                      ".pb (TensorFlow), .t7 or .net (Torch), .weights (Darknet) }"
-    "{ config c    | | Path to a text file of model contains network configuration. "
-                      "It could be a file with extensions .prototxt (Caffe), .pbtxt (TensorFlow), .cfg (Darknet) }"
     "{ framework f | | Optional name of an origin framework of the model. Detect it automatically if it does not set. }"
     "{ classes     | | Optional path to a text file with names of classes. }"
-    "{ mean        | | Preprocess input image by subtracting mean values. Mean values should be in BGR order and delimited by spaces. }"
-    "{ scale       | 1 | Preprocess input image by multiplying on a scale factor. }"
-    "{ width       |   | Preprocess input image by resizing to a specific width. }"
-    "{ height      |   | Preprocess input image by resizing to a specific height. }"
-    "{ rgb         |   | Indicate that model works with RGB input images instead BGR ones. }"
     "{ backend     | 0 | Choose one of computation backends: "
                         "0: automatically (by default), "
                         "1: Halide language (http://halide-lang.org/), "
@@ -39,6 +33,13 @@ std::vector<std::string> classes;
 int main(int argc, char** argv)
 {
     CommandLineParser parser(argc, argv, keys);
+
+    const std::string modelName = parser.get<String>("@alias");
+    const std::string zooFile = parser.get<String>("zoo");
+
+    keys += genPreprocArguments(modelName, zooFile);
+
+    parser = CommandLineParser(argc, argv, keys);
     parser.about("Use this script to run classification deep learning networks using OpenCV.");
     if (argc == 1 || parser.has("help"))
     {
@@ -51,8 +52,8 @@ int main(int argc, char** argv)
     bool swapRB = parser.get<bool>("rgb");
     int inpWidth = parser.get<int>("width");
     int inpHeight = parser.get<int>("height");
-    String model = parser.get<String>("model");
-    String config = parser.get<String>("config");
+    String model = findFile(parser.get<String>("model"));
+    String config = findFile(parser.get<String>("config"));
     String framework = parser.get<String>("framework");
     int backendId = parser.get<int>("backend");
     int targetId = parser.get<int>("target");

--- a/samples/dnn/classification.py
+++ b/samples/dnn/classification.py
@@ -1,35 +1,19 @@
 import cv2 as cv
 import argparse
 import numpy as np
-import sys
+
+from common import *
 
 backends = (cv.dnn.DNN_BACKEND_DEFAULT, cv.dnn.DNN_BACKEND_HALIDE, cv.dnn.DNN_BACKEND_INFERENCE_ENGINE, cv.dnn.DNN_BACKEND_OPENCV)
 targets = (cv.dnn.DNN_TARGET_CPU, cv.dnn.DNN_TARGET_OPENCL, cv.dnn.DNN_TARGET_OPENCL_FP16, cv.dnn.DNN_TARGET_MYRIAD)
 
-parser = argparse.ArgumentParser(description='Use this script to run classification deep learning networks using OpenCV.')
+parser = argparse.ArgumentParser(add_help=False)
+parser.add_argument('--zoo', default=os.path.join(os.path.dirname(os.path.abspath(__file__)), 'models.yml'),
+                    help='An optional path to file with preprocessing parameters.')
 parser.add_argument('--input', help='Path to input image or video file. Skip this argument to capture frames from a camera.')
-parser.add_argument('--model', required=True,
-                    help='Path to a binary file of model contains trained weights. '
-                         'It could be a file with extensions .caffemodel (Caffe), '
-                         '.pb (TensorFlow), .t7 or .net (Torch), .weights (Darknet)')
-parser.add_argument('--config',
-                    help='Path to a text file of model contains network configuration. '
-                         'It could be a file with extensions .prototxt (Caffe), .pbtxt (TensorFlow), .cfg (Darknet)')
 parser.add_argument('--framework', choices=['caffe', 'tensorflow', 'torch', 'darknet'],
                     help='Optional name of an origin framework of the model. '
                          'Detect it automatically if it does not set.')
-parser.add_argument('--classes', help='Optional path to a text file with names of classes.')
-parser.add_argument('--mean', nargs='+', type=float, default=[0, 0, 0],
-                    help='Preprocess input image by subtracting mean values. '
-                         'Mean values should be in BGR order.')
-parser.add_argument('--scale', type=float, default=1.0,
-                    help='Preprocess input image by multiplying on a scale factor.')
-parser.add_argument('--width', type=int, required=True,
-                    help='Preprocess input image by resizing to a specific width.')
-parser.add_argument('--height', type=int, required=True,
-                    help='Preprocess input image by resizing to a specific height.')
-parser.add_argument('--rgb', action='store_true',
-                    help='Indicate that model works with RGB input images instead BGR ones.')
 parser.add_argument('--backend', choices=backends, default=cv.dnn.DNN_BACKEND_DEFAULT, type=int,
                     help="Choose one of computation backends: "
                          "%d: automatically (by default), "
@@ -42,7 +26,16 @@ parser.add_argument('--target', choices=targets, default=cv.dnn.DNN_TARGET_CPU, 
                          '%d: OpenCL, '
                          '%d: OpenCL fp16 (half-float precision), '
                          '%d: VPU' % targets)
+args, _ = parser.parse_known_args()
+add_preproc_args(args.zoo, parser, 'classification')
+parser = argparse.ArgumentParser(parents=[parser],
+                                 description='Use this script to run classification deep learning networks using OpenCV.',
+                                 formatter_class=argparse.ArgumentDefaultsHelpFormatter)
 args = parser.parse_args()
+
+args.model = findFile(args.model)
+args.config = findFile(args.config)
+args.classes = findFile(args.classes)
 
 # Load names of classes
 classes = None
@@ -66,7 +59,9 @@ while cv.waitKey(1) < 0:
         break
 
     # Create a 4D blob from a frame.
-    blob = cv.dnn.blobFromImage(frame, args.scale, (args.width, args.height), args.mean, args.rgb, crop=False)
+    inpWidth = args.width if args.width else frame.shape[1]
+    inpHeight = args.height if args.height else frame.shape[0]
+    blob = cv.dnn.blobFromImage(frame, args.scale, (inpWidth, inpHeight), args.mean, args.rgb, crop=False)
 
     # Run a model
     net.setInput(blob)

--- a/samples/dnn/common.hpp
+++ b/samples/dnn/common.hpp
@@ -1,0 +1,94 @@
+#include <opencv2/core/utils/filesystem.hpp>
+
+using namespace cv;
+
+std::string genArgument(const std::string& argName, const std::string& help,
+                        const std::string& modelName, const std::string& zooFile,
+                        char key = ' ', std::string defaultVal = "");
+
+std::string genPreprocArguments(const std::string& modelName, const std::string& zooFile);
+
+std::string findFile(const std::string& filename);
+
+std::string genArgument(const std::string& argName, const std::string& help,
+                        const std::string& modelName, const std::string& zooFile,
+                        char key, std::string defaultVal)
+{
+    if (!modelName.empty())
+    {
+        FileStorage fs(zooFile, FileStorage::READ);
+        if (fs.isOpened())
+        {
+            FileNode node = fs[modelName];
+            if (!node.empty())
+            {
+                FileNode value = node[argName];
+                if (!value.empty())
+                {
+                    if (value.isReal())
+                        defaultVal = format("%f", (float)value);
+                    else if (value.isString())
+                        defaultVal = (std::string)value;
+                    else if (value.isInt())
+                        defaultVal = format("%d", (int)value);
+                    else if (value.isSeq())
+                    {
+                        for (size_t i = 0; i < value.size(); ++i)
+                        {
+                            FileNode v = value[(int)i];
+                            if (v.isInt())
+                                defaultVal += format("%d ", (int)v);
+                            else if (v.isReal())
+                                defaultVal += format("%f ", (float)v);
+                            else
+                              CV_Error(Error::StsNotImplemented, "Unexpected value format");
+                        }
+                    }
+                    else
+                        CV_Error(Error::StsNotImplemented, "Unexpected field format");
+                }
+            }
+        }
+    }
+    return "{ " + argName + " " + key + " | " + defaultVal + " | " + help + " }";
+}
+
+std::string findFile(const std::string& filename)
+{
+    if (filename.empty() || utils::fs::exists(filename))
+        return filename;
+
+    std::string extraPaths[] = {getenv("OPENCV_DNN_TEST_DATA_PATH"),
+                                getenv("OPENCV_TEST_DATA_PATH")};
+    for (int i = 0; i < 2; ++i)
+    {
+        std::string absPath = utils::fs::join(extraPaths[i], utils::fs::join("dnn", filename));
+        if (utils::fs::exists(absPath))
+            return absPath;
+    }
+    CV_Error(Error::StsObjectNotFound, "File " + filename + " not found! "
+             "Please specify a path to /opencv_extra/testdata in OPENCV_DNN_TEST_DATA_PATH "
+             "environment variable or pass a full path to model.");
+    return "";
+}
+
+std::string genPreprocArguments(const std::string& modelName, const std::string& zooFile)
+{
+    return genArgument("model", "Path to a binary file of model contains trained weights. "
+                                "It could be a file with extensions .caffemodel (Caffe), "
+                                ".pb (TensorFlow), .t7 or .net (Torch), .weights (Darknet), .bin (OpenVINO).",
+                       modelName, zooFile, 'm') +
+           genArgument("config", "Path to a text file of model contains network configuration. "
+                                 "It could be a file with extensions .prototxt (Caffe), .pbtxt (TensorFlow), .cfg (Darknet), .xml (OpenVINO).",
+                       modelName, zooFile, 'c') +
+           genArgument("mean", "Preprocess input image by subtracting mean values. Mean values should be in BGR order and delimited by spaces.",
+                       modelName, zooFile) +
+           genArgument("scale", "Preprocess input image by multiplying on a scale factor.",
+                       modelName, zooFile, ' ', "1.0") +
+           genArgument("width", "Preprocess input image by resizing to a specific width.",
+                       modelName, zooFile, ' ', "-1") +
+           genArgument("height", "Preprocess input image by resizing to a specific height.",
+                       modelName, zooFile, ' ', "-1") +
+           genArgument("rgb", "Indicate that model works with RGB input images instead BGR ones.",
+                       modelName, zooFile);
+}

--- a/samples/dnn/common.py
+++ b/samples/dnn/common.py
@@ -1,0 +1,108 @@
+import sys
+import os
+import cv2 as cv
+
+
+def add_argument(zoo, parser, name, help, required=False, default=None, type=None, action=None, nargs=None):
+    if len(sys.argv) <= 1:
+        return
+
+    modelName = sys.argv[1]
+
+    if os.path.isfile(zoo):
+        fs = cv.FileStorage(zoo, cv.FILE_STORAGE_READ)
+        node = fs.getNode(modelName)
+        if not node.empty():
+            value = node.getNode(name)
+            if not value.empty():
+                if value.isReal():
+                    default = value.real()
+                elif value.isString():
+                    default = value.string()
+                elif value.isInt():
+                    default = int(value.real())
+                elif value.isSeq():
+                    default = []
+                    for i in range(value.size()):
+                        v = value.at(i)
+                        if v.isInt():
+                            default.append(int(v.real()))
+                        elif v.isReal():
+                            default.append(v.real())
+                        else:
+                            print('Unexpected value format')
+                            exit(0)
+                else:
+                    print('Unexpected field format')
+                    exit(0)
+                required = False
+
+    if action == 'store_true':
+        default = 1 if default == 'true' else (0 if default == 'false' else default)
+        assert(default is None or default == 0 or default == 1)
+        parser.add_argument('--' + name, required=required, help=help, default=bool(default),
+                            action=action)
+    else:
+        parser.add_argument('--' + name, required=required, help=help, default=default,
+                            action=action, nargs=nargs, type=type)
+
+
+def add_preproc_args(zoo, parser, sample):
+    aliases = []
+    if os.path.isfile(zoo):
+        fs = cv.FileStorage(zoo, cv.FILE_STORAGE_READ)
+        root = fs.root()
+        for name in root.keys():
+            model = root.getNode(name)
+            if model.getNode('sample').string() == sample:
+                aliases.append(name)
+
+    parser.add_argument('alias', nargs='?', choices=aliases,
+                        help='An alias name of model to extract preprocessing parameters from models.yml file.')
+    add_argument(zoo, parser, 'model', required=True,
+                 help='Path to a binary file of model contains trained weights. '
+                      'It could be a file with extensions .caffemodel (Caffe), '
+                      '.pb (TensorFlow), .t7 or .net (Torch), .weights (Darknet), .bin (OpenVINO)')
+    add_argument(zoo, parser, 'config',
+                 help='Path to a text file of model contains network configuration. '
+                      'It could be a file with extensions .prototxt (Caffe), .pbtxt or .config (TensorFlow), .cfg (Darknet), .xml (OpenVINO)')
+    add_argument(zoo, parser, 'mean', nargs='+', type=float, default=[0, 0, 0],
+                 help='Preprocess input image by subtracting mean values. '
+                      'Mean values should be in BGR order.')
+    add_argument(zoo, parser, 'scale', type=float, default=1.0,
+                 help='Preprocess input image by multiplying on a scale factor.')
+    add_argument(zoo, parser, 'width', type=int,
+                 help='Preprocess input image by resizing to a specific width.')
+    add_argument(zoo, parser, 'height', type=int,
+                 help='Preprocess input image by resizing to a specific height.')
+    add_argument(zoo, parser, 'rgb', action='store_true',
+                 help='Indicate that model works with RGB input images instead BGR ones.')
+    add_argument(zoo, parser, 'classes',
+                 help='Optional path to a text file with names of classes to label detected objects.')
+
+
+def findFile(filename):
+    if filename:
+        if os.path.exists(filename):
+            return filename
+
+        samplesDataDir = os.path.join(os.path.dirname(os.path.abspath(__file__)),
+                                      '..',
+                                      'data',
+                                      'dnn')
+        if os.path.exists(os.path.join(samplesDataDir, filename)):
+            return os.path.join(samplesDataDir, filename)
+
+        for path in ['OPENCV_DNN_TEST_DATA_PATH', 'OPENCV_TEST_DATA_PATH']:
+            try:
+                extraPath = os.environ[path]
+                absPath = os.path.join(extraPath, 'dnn', filename)
+                if os.path.exists(absPath):
+                    return absPath
+            except KeyError:
+                pass
+
+        print('File ' + filename + ' not found! Please specify a path to '
+              '/opencv_extra/testdata in OPENCV_DNN_TEST_DATA_PATH environment '
+              'variable or pass a full path to model.')
+        exit(0)

--- a/samples/dnn/models.yml
+++ b/samples/dnn/models.yml
@@ -1,0 +1,117 @@
+%YAML:1.0
+
+################################################################################
+# Object detection models.
+################################################################################
+
+# OpenCV's face detection network
+opencv_fd:
+  model: "opencv_face_detector.caffemodel"
+  config: "opencv_face_detector.prototxt"
+  mean: [104, 177, 123]
+  scale: 1.0
+  width: 300
+  height: 300
+  rgb: false
+  sample: "object_detection"
+
+# YOLO object detection family from Darknet (https://pjreddie.com/darknet/yolo/)
+# Might be used for all YOLOv2, TinyYolov2 and YOLOv3
+yolo:
+  model: "yolov3.weights"
+  config: "yolov3.cfg"
+  mean: [0, 0, 0]
+  scale: 0.00392
+  width: 416
+  height: 416
+  rgb: true
+  classes: "object_detection_classes_yolov3.txt"
+  sample: "object_detection"
+
+tiny-yolo-voc:
+  model: "tiny-yolo-voc.weights"
+  config: "tiny-yolo-voc.cfg"
+  mean: [0, 0, 0]
+  scale: 0.00392
+  width: 416
+  height: 416
+  rgb: true
+  classes: "object_detection_classes_pascal_voc.txt"
+  sample: "object_detection"
+
+# Caffe implementation of SSD model from https://github.com/chuanqi305/MobileNet-SSD
+ssd_caffe:
+  model: "MobileNetSSD_deploy.caffemodel"
+  config: "MobileNetSSD_deploy.prototxt"
+  mean: [127.5, 127.5, 127.5]
+  scale: 0.007843
+  width: 300
+  height: 300
+  rgb: false
+  classes: "object_detection_classes_pascal_voc.txt"
+  sample: "object_detection"
+
+# TensorFlow implementation of SSD model from https://github.com/tensorflow/models/tree/master/research/object_detection
+ssd_tf:
+  model: "ssd_mobilenet_v1_coco_2017_11_17.pb"
+  config: "ssd_mobilenet_v1_coco_2017_11_17.pbtxt"
+  mean: [0, 0, 0]
+  scale: 1.0
+  width: 300
+  height: 300
+  rgb: true
+  classes: "object_detection_classes_coco.txt"
+  sample: "object_detection"
+
+# TensorFlow implementation of Faster-RCNN model from https://github.com/tensorflow/models/tree/master/research/object_detection
+faster_rcnn_tf:
+  model: "faster_rcnn_inception_v2_coco_2018_01_28.pb"
+  config: "faster_rcnn_inception_v2_coco_2018_01_28.pbtxt"
+  mean: [0, 0, 0]
+  scale: 1.0
+  width: 800
+  height: 600
+  rgb: true
+  sample: "object_detection"
+
+################################################################################
+# Image classification models.
+################################################################################
+
+# SqueezeNet v1.1 from https://github.com/DeepScale/SqueezeNet
+squeezenet:
+  model: "squeezenet_v1.1.caffemodel"
+  config: "squeezenet_v1.1.prototxt"
+  mean: [0, 0, 0]
+  scale: 1.0
+  width: 227
+  height: 227
+  rgb: false
+  classes: "classification_classes_ILSVRC2012.txt"
+  sample: "classification"
+
+################################################################################
+# Semantic segmentation models.
+################################################################################
+
+# ENet road scene segmentation network from https://github.com/e-lab/ENet-training
+# Works fine for different input sizes.
+enet:
+  model: "Enet-model-best.net"
+  mean: [0, 0, 0]
+  scale: 0.00392
+  width: 512
+  height: 256
+  rgb: true
+  classes: "enet-classes.txt"
+  sample: "segmentation"
+
+fcn8s:
+  model: "fcn8s-heavy-pascal.caffemodel"
+  config: "fcn8s-heavy-pascal.prototxt"
+  mean: [0, 0, 0]
+  scale: 1.0
+  width: 500
+  height: 500
+  rgb: false
+  sample: "segmentation"

--- a/samples/dnn/object_detection.cpp
+++ b/samples/dnn/object_detection.cpp
@@ -5,22 +5,16 @@
 #include <opencv2/imgproc.hpp>
 #include <opencv2/highgui.hpp>
 
-const char* keys =
+#include "common.hpp"
+
+std::string keys =
     "{ help  h     | | Print help message. }"
+    "{ @alias      | | An alias name of model to extract preprocessing parameters from models.yml file. }"
+    "{ zoo         | models.yml | An optional path to file with preprocessing parameters }"
     "{ device      |  0 | camera device number. }"
     "{ input i     | | Path to input image or video file. Skip this argument to capture frames from a camera. }"
-    "{ model m     | | Path to a binary file of model contains trained weights. "
-                      "It could be a file with extensions .caffemodel (Caffe), "
-                      ".pb (TensorFlow), .t7 or .net (Torch), .weights (Darknet).}"
-    "{ config c    | | Path to a text file of model contains network configuration. "
-                      "It could be a file with extensions .prototxt (Caffe), .pbtxt (TensorFlow), .cfg (Darknet).}"
     "{ framework f | | Optional name of an origin framework of the model. Detect it automatically if it does not set. }"
     "{ classes     | | Optional path to a text file with names of classes to label detected objects. }"
-    "{ mean        | | Preprocess input image by subtracting mean values. Mean values should be in BGR order and delimited by spaces. }"
-    "{ scale       |  1 | Preprocess input image by multiplying on a scale factor. }"
-    "{ width       | -1 | Preprocess input image by resizing to a specific width. }"
-    "{ height      | -1 | Preprocess input image by resizing to a specific height. }"
-    "{ rgb         |    | Indicate that model works with RGB input images instead BGR ones. }"
     "{ thr         | .5 | Confidence threshold. }"
     "{ nms         | .4 | Non-maximum suppression threshold. }"
     "{ backend     |  0 | Choose one of computation backends: "
@@ -52,6 +46,13 @@ std::vector<String> getOutputsNames(const Net& net);
 int main(int argc, char** argv)
 {
     CommandLineParser parser(argc, argv, keys);
+
+    const std::string modelName = parser.get<String>("@alias");
+    const std::string zooFile = parser.get<String>("zoo");
+
+    keys += genPreprocArguments(modelName, zooFile);
+
+    parser = CommandLineParser(argc, argv, keys);
     parser.about("Use this script to run object detection deep learning networks using OpenCV.");
     if (argc == 1 || parser.has("help"))
     {
@@ -66,6 +67,9 @@ int main(int argc, char** argv)
     bool swapRB = parser.get<bool>("rgb");
     int inpWidth = parser.get<int>("width");
     int inpHeight = parser.get<int>("height");
+    CV_Assert(parser.has("model"));
+    std::string modelPath = findFile(parser.get<String>("model"));
+    std::string configPath = findFile(parser.get<String>("config"));
 
     // Open file with classes names.
     if (parser.has("classes"))
@@ -82,8 +86,7 @@ int main(int argc, char** argv)
     }
 
     // Load a model.
-    CV_Assert(parser.has("model"));
-    Net net = readNet(parser.get<String>("model"), parser.get<String>("config"), parser.get<String>("framework"));
+    Net net = readNet(modelPath, configPath, parser.get<String>("framework"));
     net.setPreferableBackend(parser.get<int>("backend"));
     net.setPreferableTarget(parser.get<int>("target"));
 

--- a/samples/dnn/segmentation.cpp
+++ b/samples/dnn/segmentation.cpp
@@ -5,24 +5,18 @@
 #include <opencv2/imgproc.hpp>
 #include <opencv2/highgui.hpp>
 
-const char* keys =
+#include "common.hpp"
+
+std::string keys =
     "{ help  h     | | Print help message. }"
+    "{ @alias      | | An alias name of model to extract preprocessing parameters from models.yml file. }"
+    "{ zoo         | models.yml | An optional path to file with preprocessing parameters }"
     "{ device      |  0 | camera device number. }"
     "{ input i     | | Path to input image or video file. Skip this argument to capture frames from a camera. }"
-    "{ model m     | | Path to a binary file of model contains trained weights. "
-                      "It could be a file with extensions .caffemodel (Caffe), "
-                      ".pb (TensorFlow), .t7 or .net (Torch), .weights (Darknet). }"
-    "{ config c    | | Path to a text file of model contains network configuration. "
-                      "It could be a file with extensions .prototxt (Caffe), .pbtxt (TensorFlow), .cfg (Darknet). }"
     "{ framework f | | Optional name of an origin framework of the model. Detect it automatically if it does not set. }"
     "{ classes     | | Optional path to a text file with names of classes. }"
     "{ colors      | | Optional path to a text file with colors for an every class. "
                       "An every color is represented with three values from 0 to 255 in BGR channels order. }"
-    "{ mean        | | Preprocess input image by subtracting mean values. Mean values should be in BGR order and delimited by spaces. }"
-    "{ scale       | 1 | Preprocess input image by multiplying on a scale factor. }"
-    "{ width       |   | Preprocess input image by resizing to a specific width. }"
-    "{ height      |   | Preprocess input image by resizing to a specific height. }"
-    "{ rgb         |   | Indicate that model works with RGB input images instead BGR ones. }"
     "{ backend     | 0 | Choose one of computation backends: "
                         "0: automatically (by default), "
                         "1: Halide language (http://halide-lang.org/), "
@@ -47,6 +41,13 @@ void colorizeSegmentation(const Mat &score, Mat &segm);
 int main(int argc, char** argv)
 {
     CommandLineParser parser(argc, argv, keys);
+
+    const std::string modelName = parser.get<String>("@alias");
+    const std::string zooFile = parser.get<String>("zoo");
+
+    keys += genPreprocArguments(modelName, zooFile);
+
+    parser = CommandLineParser(argc, argv, keys);
     parser.about("Use this script to run semantic segmentation deep learning networks using OpenCV.");
     if (argc == 1 || parser.has("help"))
     {
@@ -59,8 +60,8 @@ int main(int argc, char** argv)
     bool swapRB = parser.get<bool>("rgb");
     int inpWidth = parser.get<int>("width");
     int inpHeight = parser.get<int>("height");
-    String model = parser.get<String>("model");
-    String config = parser.get<String>("config");
+    String model = findFile(parser.get<String>("model"));
+    String config = findFile(parser.get<String>("config"));
     String framework = parser.get<String>("framework");
     int backendId = parser.get<int>("backend");
     int targetId = parser.get<int>("target");

--- a/samples/dnn/tf_text_graph_common.py
+++ b/samples/dnn/tf_text_graph_common.py
@@ -72,6 +72,8 @@ def parseMessage(tokens, idx):
 
 
 def readTextMessage(filePath):
+    if not filePath:
+        return {}
     with open(filePath, 'rt') as f:
         content = f.read()
 


### PR DESCRIPTION
<!-- Please use this line to close one or multiple issues when this pullrequest gets merged
You can add another line right under the first one:
resolves #1234
resolves #1235
-->

### This pullrequest changes

**WIP**

related: https://github.com/opencv/opencv/pull/12354, https://github.com/opencv/opencv/pull/12186

* Add a YAML file with deep learning networks aliases to autofill preprocessing parameters for OpenCV samples.

  Before:
  ```
  python object_detection.py --model opencv_face_detector.caffemodel --config opencv_face_detector.prototxt --mean 104 177 123 --width 300 --height 300
  ```

  now:
  ```
  python object_detection.py opencv_fd
  ```

  Proposed approach just puts appropriate default values to specified arguments. User can override it manually and modify another arguments as well:

  ```
  python object_detection.py opencv_fd --width 320 --height 240 --input /path/to/image
  ```

* A help message contains filled parameters and shows possible aliases:
  ```
  $ python ../samples/dnn/object_detection.py ssd_caffe -h
  usage: object_detection.py [-h] [--zoo ZOO] [--input INPUT]
                             [--out_tf_graph OUT_TF_GRAPH]
                             [--framework {caffe,tensorflow,torch,darknet,dldt}]
                             [--thr THR] [--nms NMS] [--backend {0,1,2,3}]
                             [--target {0,1,2,3}] [--model MODEL]
                             [--config CONFIG] [--mean MEAN [MEAN ...]]
                             [--scale SCALE] [--width WIDTH] [--height HEIGHT]
                             [--rgb] [--classes CLASSES]
                             [{opencv_fd,yolo,tiny-yolo-voc,ssd_caffe,ssd_tf,faster_rcnn_tf}]

  Use this script to run object detection deep learning networks using OpenCV.

  positional arguments:
    {opencv_fd,yolo,tiny-yolo-voc,ssd_caffe,ssd_tf,faster_rcnn_tf}
                          An alias name of model to extract preprocessing
                          parameters from models.yml file. (default: None)

  optional arguments:
    -h, --help            show this help message and exit
    --zoo ZOO             An optional path to file with preprocessing
                          parameters. (default:
                          /home/dkurt/opencv/samples/dnn/models.yml)
    --input INPUT         Path to input image or video file. Skip this argument
                          to capture frames from a camera. (default: None)
    --out_tf_graph OUT_TF_GRAPH
                          For models from TensorFlow Object Detection API, you
                          may pass a .config file which was used for training
                          through --config argument. This way an additional
                          .pbtxt file with TensorFlow graph will be created.
                          (default: graph.pbtxt)
    --framework {caffe,tensorflow,torch,darknet,dldt}
                          Optional name of an origin framework of the model.
                          Detect it automatically if it does not set. (default:
                          None)
    --thr THR             Confidence threshold (default: 0.5)
    --nms NMS             Non-maximum suppression threshold (default: 0.4)
    --backend {0,1,2,3}   Choose one of computation backends: 0: automatically
                          (by default), 1: Halide language (http://halide-
                          lang.org/), 2: Intel's Deep Learning Inference Engine
                          (https://software.intel.com/openvino-toolkit), 3:
                          OpenCV implementation (default: 0)
    --target {0,1,2,3}    Choose one of target computation devices: 0: CPU
                          target (by default), 1: OpenCL, 2: OpenCL fp16 (half-
                          float precision), 3: VPU (default: 0)
    --model MODEL         Path to a binary file of model contains trained
                          weights. It could be a file with extensions
                          .caffemodel (Caffe), .pb (TensorFlow), .t7 or .net
                          (Torch), .weights (Darknet), .bin (OpenVINO) (default:
                          MobileNetSSD_deploy.caffemodel)
    --config CONFIG       Path to a text file of model contains network
                          configuration. It could be a file with extensions
                          .prototxt (Caffe), .pbtxt or .config (TensorFlow),
                          .cfg (Darknet), .xml (OpenVINO) (default:
                          MobileNetSSD_deploy.prototxt)
    --mean MEAN [MEAN ...]
                          Preprocess input image by subtracting mean values.
                          Mean values should be in BGR order. (default: [127.5,
                          127.5, 127.5])
    --scale SCALE         Preprocess input image by multiplying on a scale
                          factor. (default: 0.007843)
    --width WIDTH         Preprocess input image by resizing to a specific
                          width. (default: 300)
    --height HEIGHT       Preprocess input image by resizing to a specific
                          height. (default: 300)
    --rgb                 Indicate that model works with RGB input images
                          instead BGR ones. (default: False)
    --classes CLASSES     Optional path to a text file with names of classes to
                          label detected objects. (default:
                          object_detection_classes_pascal_voc.txt)
  ```