### PR TITLE
build: cleanup js scripts

### DIFF
--- a/modules/js/CMakeLists.txt
+++ b/modules/js/CMakeLists.txt
@@ -1,11 +1,11 @@
 # ----------------------------------------------------------------------------
 #  CMake file for js support
 # ----------------------------------------------------------------------------
-
-# message(STATUS "---------------- Start of JavaScript module ----------------------")
-
 set(the_description "The js bindings")
-set(MODULE_NAME js)
+
+if(NOT BUILD_opencv_js)  # should be enabled explicitly (by build_js.py script)
+  ocv_module_disable(js)
+endif()
 
 set(OPENCV_JS "opencv.js")
 
@@ -17,27 +17,26 @@ find_path(EMSCRIPTEN_INCLUDE_DIR
           DOC "Location of Emscripten SDK")
 
 if(NOT EMSCRIPTEN_INCLUDE_DIR OR NOT PYTHON_DEFAULT_AVAILABLE)
-  set(DISABLE_MSG "Module ${MODULE_NAME} disabled because the following dependencies are not found:")
+  set(DISABLE_MSG "Module 'js' disabled because the following dependencies are not found:")
   if(NOT EMSCRIPTEN_INCLUDE_DIR)
-    message(STATUS "\${EMSCRIPTEN_INCLUDE_DIR}/emscripten/bind.h` was not detected")
     set(DISABLE_MSG "${DISABLE_MSG} Emscripten")
   endif()
   if(NOT PYTHON_DEFAULT_AVAILABLE)
     set(DISABLE_MSG "${DISABLE_MSG} Python")
   endif()
   message(STATUS ${DISABLE_MSG})
-  ocv_module_disable(${MODULE_NAME})
+  ocv_module_disable(js)
 endif()
 
-ocv_add_module(${MODULE_NAME} BINDINGS)
+ocv_add_module(js BINDINGS)
 
 ocv_module_include_directories(${EMSCRIPTEN_INCLUDE_DIR})
 
 # get list of modules to wrap
-# message(STATUS "Wrapped in ${MODULE_NAME}:")
+# message(STATUS "Wrapped in js:")
 set(OPENCV_JS_MODULES)
 foreach(m ${OPENCV_MODULES_BUILD})
-  if (";${OPENCV_MODULE_${m}_WRAPPERS};" MATCHES ";${MODULE_NAME};" AND HAVE_${m})
+  if(";${OPENCV_MODULE_${m}_WRAPPERS};" MATCHES ";js;" AND HAVE_${m})
     list(APPEND OPENCV_JS_MODULES ${m})
     # message(STATUS "\t${m}")
   endif()
@@ -139,7 +138,3 @@ list(APPEND opencv_test_js_file_deps "${test_data_path}" "${opencv_test_js_bin_d
 
 add_custom_target(${PROJECT_NAME}_test ALL
                   DEPENDS ${OCV_JS_PATH} ${opencv_test_js_file_deps})
-
-unset(MODULE_NAME)
-
-# message(STATUS "---------------- End of JavaScript module ----------------------")

--- a/platforms/js/build_js.py
+++ b/platforms/js/build_js.py
@@ -3,6 +3,8 @@
 import os, sys, subprocess, argparse, shutil, glob, re, multiprocessing
 import logging as log
 
+SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
+
 class Fail(Exception):
     def __init__(self, text=None):
         self.t = text
@@ -58,30 +60,12 @@ def find_file(name, path):
         if name in files:
             return os.path.join(root, name)
 
-def determine_emcc_version(emscripten_dir):
-    ret = subprocess.check_output([os.path.join(emscripten_dir, "emcc"), "--version"])
-    m = re.match(r'^emcc.*(\d+\.\d+\.\d+)', ret, flags=re.IGNORECASE)
-    return m.group(1)
-
-def determine_opencv_version(version_hpp_path):
-    # version in 2.4 - CV_VERSION_EPOCH.CV_VERSION_MAJOR.CV_VERSION_MINOR.CV_VERSION_REVISION
-    # version in master - CV_VERSION_MAJOR.CV_VERSION_MINOR.CV_VERSION_REVISION-CV_VERSION_STATUS
-    with open(version_hpp_path, "rt") as f:
-        data = f.read()
-        major = re.search(r'^#define\W+CV_VERSION_MAJOR\W+(\d+)$', data, re.MULTILINE).group(1)
-        minor = re.search(r'^#define\W+CV_VERSION_MINOR\W+(\d+)$', data, re.MULTILINE).group(1)
-        revision = re.search(r'^#define\W+CV_VERSION_REVISION\W+(\d+)$', data, re.MULTILINE).group(1)
-        version_status = re.search(r'^#define\W+CV_VERSION_STATUS\W+"([^"]*)"$', data, re.MULTILINE).group(1)
-        return "%(major)s.%(minor)s.%(revision)s%(version_status)s" % locals()
-
 class Builder:
     def __init__(self, options):
         self.options = options
         self.build_dir = check_dir(options.build_dir, create=True)
         self.opencv_dir = check_dir(options.opencv_dir)
         self.emscripten_dir = check_dir(options.emscripten_dir)
-        self.opencv_version = determine_opencv_version(os.path.join(self.opencv_dir, "modules", "core", "include", "opencv2", "core", "version.hpp"))
-        self.emcc_version = determine_emcc_version(self.emscripten_dir)
 
     def get_toolchain_file(self):
         return os.path.join(self.emscripten_dir, "cmake", "Modules", "Platform", "Emscripten.cmake")
@@ -123,7 +107,6 @@ class Builder:
                "-DWITH_OPENCL_SVM=OFF",
                "-DWITH_OPENCLAMDFFT=OFF",
                "-DWITH_OPENCLAMDBLAS=OFF",
-               "-DWITH_MATLAB=OFF",
                "-DWITH_GPHOTO2=OFF",
                "-DWITH_LAPACK=OFF",
                "-DWITH_ITT=OFF",
@@ -187,7 +170,7 @@ class Builder:
 #===================================================================================================
 
 if __name__ == "__main__":
-    opencv_dir = os.path.abspath(os.path.join(os.path.dirname(sys.argv[0]), "../.."))
+    opencv_dir = os.path.abspath(os.path.join(SCRIPT_DIR, '../..'))
     emscripten_dir = None
     if "EMSCRIPTEN" in os.environ:
         emscripten_dir = os.environ["EMSCRIPTEN"]
@@ -213,9 +196,6 @@ if __name__ == "__main__":
         sys.exit(-1)
 
     builder = Builder(args)
-
-    log.info("Detected OpenCV version: %s", builder.opencv_version)
-    log.info("Detected emcc version: %s", builder.emcc_version)
 
     os.chdir(builder.build_dir)
 


### PR DESCRIPTION
- avoid unnecessary 2 messages for other build configurations
    ```
    -- ${EMSCRIPTEN_INCLUDE_DIR}/emscripten/bind.h` was not detected
    -- Module js disabled because the following dependencies are not found: Emscripten
    ```

```
force_builders=Docs,Custom
docker_image:Docs=docs-js
docker_image:Custom=javascript
```