### PR TITLE
hide use of std::mutex from /clr compilation under Visual Studio

### DIFF
--- a/modules/core/include/opencv2/core/utility.hpp
+++ b/modules/core/include/opencv2/core/utility.hpp
@@ -676,32 +676,6 @@ void Mat::forEach_impl(const Functor& operation) {
 
 /////////////////////////// Synchronization Primitives ///////////////////////////////
 
-class CV_EXPORTS CEEMutex
-{
-  public:
-    CEEMutex(void);
-    ~CEEMutex();
-    CEEMutex(const CEEMutex&) = delete;
-    CEEMutex& operator=(const CEEMutex&) = delete;
-  public:
-    void lock(void);
-    void unlock(void);
-    bool try_lock(void) noexcept;
-  private:
-    void* impl;
-};
-
-class CV_EXPORTS CEELockGuard
-{
-  public:
-    explicit CEELockGuard(CEEMutex& _Mtx);
-    ~CEELockGuard();
-    CEELockGuard(const CEELockGuard&) = delete;
-    CEELockGuard& operator=(const CEELockGuard&) = delete;
-  private:
-    void* impl;
-};
-
 #if !defined(_M_CEE)
 typedef std::recursive_mutex Mutex;
 typedef std::lock_guard<cv::Mutex> AutoLock;

--- a/modules/core/include/opencv2/core/utility.hpp
+++ b/modules/core/include/opencv2/core/utility.hpp
@@ -681,12 +681,12 @@ class CV_EXPORTS CEEMutex
   public:
     CEEMutex(void);
     ~CEEMutex();
-	  CEEMutex(const CEEMutex&) = delete;
-	  CEEMutex& operator=(const CEEMutex&) = delete;
+    CEEMutex(const CEEMutex&) = delete;
+    CEEMutex& operator=(const CEEMutex&) = delete;
   public:
     void lock(void);
     void unlock(void);
-	  bool try_lock(void) noexcept;
+    bool try_lock(void) noexcept;
   private:
     void* impl;
 };
@@ -696,8 +696,8 @@ class CV_EXPORTS CEELockGuard
   public:
     explicit CEELockGuard(CEEMutex& _Mtx);
     ~CEELockGuard();
-	  CEELockGuard(const CEELockGuard&) = delete;
-	  CEELockGuard& operator=(const CEELockGuard&) = delete;
+    CEELockGuard(const CEELockGuard&) = delete;
+    CEELockGuard& operator=(const CEELockGuard&) = delete;
   private:
     void* impl;
 };
@@ -705,9 +705,6 @@ class CV_EXPORTS CEELockGuard
 #if !defined(_M_CEE)
 typedef std::recursive_mutex Mutex;
 typedef std::lock_guard<cv::Mutex> AutoLock;
-#else
-typedef CEEMutex Mutex;
-typedef CEELockGuard AutoLock;
 #endif
 
 // TLS interface

--- a/modules/core/include/opencv2/core/utility.hpp
+++ b/modules/core/include/opencv2/core/utility.hpp
@@ -686,7 +686,7 @@ class CV_EXPORTS CEEMutex
   public:
     void lock(void);
     void unlock(void);
-	  _NODISCARD bool try_lock() noexcept;
+	  bool try_lock(void) noexcept;
   private:
     void* impl;
 };

--- a/modules/core/src/system.cpp
+++ b/modules/core/src/system.cpp
@@ -81,7 +81,7 @@ void CEEMutex::unlock(void)
   reinterpret_cast<std::recursive_mutex*>(this->impl)->unlock();
 }
 
-bool CEEMutex::try_lock() noexcept
+bool CEEMutex::try_lock(void) noexcept
 {
   return reinterpret_cast<std::recursive_mutex*>(this->impl)->try_lock();
 }

--- a/modules/core/src/system.cpp
+++ b/modules/core/src/system.cpp
@@ -61,6 +61,41 @@ Mutex& getInitializationMutex()
 // force initialization (single-threaded environment)
 Mutex* __initialization_mutex_initializer = &getInitializationMutex();
 
+CEEMutex::CEEMutex(void)
+         :impl(new std::recursive_mutex)
+{
+}
+
+CEEMutex::~CEEMutex()
+{
+  delete reinterpret_cast<std::recursive_mutex*>(this->impl);
+}
+
+void CEEMutex::lock(void)
+{
+  reinterpret_cast<std::recursive_mutex*>(this->impl)->lock();
+}
+
+void CEEMutex::unlock(void)
+{
+  reinterpret_cast<std::recursive_mutex*>(this->impl)->unlock();
+}
+
+bool CEEMutex::try_lock() noexcept
+{
+  return reinterpret_cast<std::recursive_mutex*>(this->impl)->try_lock();
+}
+
+CEELockGuard::CEELockGuard(CEEMutex& _Mtx)
+             :impl(new std::lock_guard<CEEMutex>(_Mtx))
+{
+}
+
+CEELockGuard::~CEELockGuard()
+{
+  delete reinterpret_cast<std::lock_guard<CEEMutex>*>(this->impl);
+}
+
 static bool param_dumpErrors = utils::getConfigurationParameterBool("OPENCV_DUMP_ERRORS",
 #if defined(_DEBUG) || defined(__ANDROID__)
     true

--- a/modules/core/src/system.cpp
+++ b/modules/core/src/system.cpp
@@ -61,41 +61,6 @@ Mutex& getInitializationMutex()
 // force initialization (single-threaded environment)
 Mutex* __initialization_mutex_initializer = &getInitializationMutex();
 
-CEEMutex::CEEMutex(void)
-         :impl(new std::recursive_mutex)
-{
-}
-
-CEEMutex::~CEEMutex()
-{
-  delete reinterpret_cast<std::recursive_mutex*>(this->impl);
-}
-
-void CEEMutex::lock(void)
-{
-  reinterpret_cast<std::recursive_mutex*>(this->impl)->lock();
-}
-
-void CEEMutex::unlock(void)
-{
-  reinterpret_cast<std::recursive_mutex*>(this->impl)->unlock();
-}
-
-bool CEEMutex::try_lock(void) noexcept
-{
-  return reinterpret_cast<std::recursive_mutex*>(this->impl)->try_lock();
-}
-
-CEELockGuard::CEELockGuard(CEEMutex& _Mtx)
-             :impl(new std::lock_guard<CEEMutex>(_Mtx))
-{
-}
-
-CEELockGuard::~CEELockGuard()
-{
-  delete reinterpret_cast<std::lock_guard<CEEMutex>*>(this->impl);
-}
-
 static bool param_dumpErrors = utils::getConfigurationParameterBool("OPENCV_DUMP_ERRORS",
 #if defined(_DEBUG) || defined(__ANDROID__)
     true


### PR DESCRIPTION
C++11 `<mutex>` is not available when compiling with  /clr under Visual Studio, thus opencv cannot be easily included.
It is fixed by making a CEEMutex wrapper class, around an opaque implementation using std::mutex internally

resolves #11912