### PR TITLE
Fix Xcode version parsing error (affects bitcode generation)

### DIFF
--- a/platforms/ios/build_framework.py
+++ b/platforms/ios/build_framework.py
@@ -39,10 +39,11 @@ def execute(cmd, cwd = None):
 
 def getXCodeMajor():
     ret = check_output(["xcodebuild", "-version"])
-    m = re.match(r'XCode\s+(\d)\..*', ret, flags=re.IGNORECASE)
+    m = re.match(r'Xcode\s+(\d+)\..*', ret, flags=re.IGNORECASE)
     if m:
         return int(m.group(1))
-    return 0
+    else:
+        raise Exception("Failed to parse Xcode version")
 
 class Builder:
     def __init__(self, opencv, contrib, dynamic, bitcodedisabled, exclude, targets):


### PR DESCRIPTION
The regex was only parsing for a single digit in the major version, causing Xcode 10 to be treated as version "1". Other parts of the script only turn on bitcode generation if the Xcode version is > 7.