### PR TITLE
calib3d: findChessboardCornersSB() minor updates

### DIFF
--- a/modules/calib3d/test/test_chesscorners.cpp
+++ b/modules/calib3d/test/test_chesscorners.cpp
@@ -409,6 +409,8 @@ bool CV_ChessboardDetectorTest::checkByGenerator()
     int progress = 0;
     for(int i = 0; i < test_num; ++i)
     {
+        SCOPED_TRACE(cv::format("test_num=%d", test_num));
+
         progress = update_progress( progress, i, test_num, 0 );
         ChessBoardGenerator cbg(sizes[i % sizes_num]);
 
@@ -439,13 +441,17 @@ bool CV_ChessboardDetectorTest::checkByGenerator()
         }
 
         double err = calcErrorMinError(cbg.cornersSize(), corners_found, corners_generated);
-        if( err > rough_success_error_level )
+        EXPECT_LE(err, rough_success_error_level) << "bad accuracy of corner guesses";
+#if 0
+        if (err >= rough_success_error_level)
         {
-            ts->printf( cvtest::TS::LOG, "bad accuracy of corner guesses" );
-            ts->set_failed_test_info( cvtest::TS::FAIL_BAD_ACCURACY );
-            res = false;
-            return res;
+            imshow("cb", cb);
+            Mat cb_corners = cb.clone();
+            cv::drawChessboardCorners(cb_corners, cbg.cornersSize(), Mat(corners_found), found);
+            imshow("corners", cb_corners);
+            waitKey(0);
         }
+#endif
     }
 
     /* ***** negative ***** */

--- a/modules/core/include/opencv2/core/check.hpp
+++ b/modules/core/include/opencv2/core/check.hpp
@@ -69,6 +69,7 @@ CV_EXPORTS void CV_NORETURN check_failed_auto(const int v1, const int v2, const 
 CV_EXPORTS void CV_NORETURN check_failed_auto(const size_t v1, const size_t v2, const CheckContext& ctx);
 CV_EXPORTS void CV_NORETURN check_failed_auto(const float v1, const float v2, const CheckContext& ctx);
 CV_EXPORTS void CV_NORETURN check_failed_auto(const double v1, const double v2, const CheckContext& ctx);
+CV_EXPORTS void CV_NORETURN check_failed_auto(const Size_<int> v1, const Size_<int> v2, const CheckContext& ctx);
 CV_EXPORTS void CV_NORETURN check_failed_MatDepth(const int v1, const int v2, const CheckContext& ctx);
 CV_EXPORTS void CV_NORETURN check_failed_MatType(const int v1, const int v2, const CheckContext& ctx);
 CV_EXPORTS void CV_NORETURN check_failed_MatChannels(const int v1, const int v2, const CheckContext& ctx);
@@ -77,6 +78,7 @@ CV_EXPORTS void CV_NORETURN check_failed_auto(const int v, const CheckContext& c
 CV_EXPORTS void CV_NORETURN check_failed_auto(const size_t v, const CheckContext& ctx);
 CV_EXPORTS void CV_NORETURN check_failed_auto(const float v, const CheckContext& ctx);
 CV_EXPORTS void CV_NORETURN check_failed_auto(const double v, const CheckContext& ctx);
+CV_EXPORTS void CV_NORETURN check_failed_auto(const Size_<int> v, const CheckContext& ctx);
 CV_EXPORTS void CV_NORETURN check_failed_MatDepth(const int v, const CheckContext& ctx);
 CV_EXPORTS void CV_NORETURN check_failed_MatType(const int v, const CheckContext& ctx);
 CV_EXPORTS void CV_NORETURN check_failed_MatChannels(const int v, const CheckContext& ctx);

--- a/modules/core/src/check.cpp
+++ b/modules/core/src/check.cpp
@@ -113,6 +113,10 @@ void check_failed_auto(const double v1, const double v2, const CheckContext& ctx
 {
     check_failed_auto_<double>(v1, v2, ctx);
 }
+void check_failed_auto(const Size_<int> v1, const Size_<int> v2, const CheckContext& ctx)
+{
+    check_failed_auto_< Size_<int> >(v1, v2, ctx);
+}
 
 
 template<typename T> static CV_NORETURN
@@ -162,6 +166,10 @@ void check_failed_auto(const float v, const CheckContext& ctx)
 void check_failed_auto(const double v, const CheckContext& ctx)
 {
     check_failed_auto_<double>(v, ctx);
+}
+void check_failed_auto(const Size_<int> v, const CheckContext& ctx)
+{
+    check_failed_auto_< Size_<int> >(v, ctx);
 }
 
 


### PR DESCRIPTION
- avoid updating of input image during equalizeHist() call
- avoid for() with double variable (use 'int' instead)
- more CV_Check*() macros
- use Mat_<T>, Matx
- static for local variables

<cut/>

```
docker_image:Custom=javascript
buildworker:Linux x64 Debug=linux-2
```