### PR TITLE
 imgproc: use Matx23d as result type of getRotationMatrix2D() call

### DIFF
--- a/modules/calib3d/src/chessboard.cpp
+++ b/modules/calib3d/src/chessboard.cpp
@@ -282,9 +282,9 @@ void FastX::rotate(float angle,const cv::Mat &img,cv::Size size,cv::Mat &out)con
     }
     else
     {
-        cv::Mat_<double> m = cv::getRotationMatrix2D(cv::Point2f(float(img.cols*0.5),float(img.rows*0.5)),float(angle/CV_PI*180),1);
-        m.at<double>(0,2) += 0.5*(size.width-img.cols);
-        m.at<double>(1,2) += 0.5*(size.height-img.rows);
+        cv::Matx23d m = cv::getRotationMatrix2D(cv::Point2f(float(img.cols*0.5),float(img.rows*0.5)),float(angle/CV_PI*180),1);
+        m(0,2) += 0.5*(size.width-img.cols);
+        m(1,2) += 0.5*(size.height-img.rows);
         cv::warpAffine(img,out,m,size);
     }
 }

--- a/modules/imgproc/include/opencv2/imgproc.hpp
+++ b/modules/imgproc/include/opencv2/imgproc.hpp
@@ -2414,7 +2414,16 @@ coordinate origin is assumed to be the top-left corner).
 
 @sa  getAffineTransform, warpAffine, transform
  */
-CV_EXPORTS_W Mat getRotationMatrix2D( Point2f center, double angle, double scale );
+CV_EXPORTS_W Mat getRotationMatrix2D(Point2f center, double angle, double scale);
+
+/** @sa getRotationMatrix2D */
+CV_EXPORTS Matx23d getRotationMatrix2D_(Point2f center, double angle, double scale);
+
+inline
+Mat getRotationMatrix2D(Point2f center, double angle, double scale)
+{
+    return Mat(getRotationMatrix2D_(center, angle, scale), true);
+}
 
 /** @brief Calculates an affine transform from three pairs of the corresponding points.
 

--- a/modules/imgproc/src/imgwarp.cpp
+++ b/modules/imgproc/src/imgwarp.cpp
@@ -2994,7 +2994,7 @@ void cv::warpPerspective( InputArray _src, OutputArray _dst, InputArray _M0,
 }
 
 
-cv::Mat cv::getRotationMatrix2D( Point2f center, double angle, double scale )
+cv::Matx23d cv::getRotationMatrix2D_(Point2f center, double angle, double scale)
 {
     CV_INSTRUMENT_REGION();
 
@@ -3002,16 +3002,10 @@ cv::Mat cv::getRotationMatrix2D( Point2f center, double angle, double scale )
     double alpha = std::cos(angle)*scale;
     double beta = std::sin(angle)*scale;
 
-    Mat M(2, 3, CV_64F);
-    double* m = M.ptr<double>();
-
-    m[0] = alpha;
-    m[1] = beta;
-    m[2] = (1-alpha)*center.x - beta*center.y;
-    m[3] = -beta;
-    m[4] = alpha;
-    m[5] = beta*center.x + (1-alpha)*center.y;
-
+    Matx23d M(
+        alpha, beta, (1-alpha)*center.x - beta*center.y,
+        -beta, alpha, beta*center.x + (1-alpha)*center.y
+    );
     return M;
 }
 


### PR DESCRIPTION

TODO:
- [x] validate/fix bindings