### PR TITLE
Fix typo "wit" -> "with"

### DIFF
--- a/doc/tutorials/imgproc/pyramids/pyramids.markdown
+++ b/doc/tutorials/imgproc/pyramids/pyramids.markdown
@@ -56,7 +56,7 @@ Theory
     entire pyramid.
 -   The procedure above was useful to downsample an image. What if we want to make it bigger?:
     columns filled with zeros (\f$0 \f$)
-    -   First, upsize the image to twice the original in each dimension, wit the new even rows and
+    -   First, upsize the image to twice the original in each dimension, with the new even rows and
     -   Perform a convolution with the same kernel shown above (multiplied by 4) to approximate the
         values of the "missing pixels"
 -   These two procedures (downsampling and upsampling as explained above) are implemented by the


### PR DESCRIPTION
Fixing typo in image pyramids tutorial

<!--
**WIP**
force_builders=Docs
-->