### PR TITLE
3rdparty/protobuf: fix compilation issue on s390

### DIFF
--- a/3rdparty/protobuf/src/google/protobuf/stubs/atomicops_internals_generic_gcc.h
+++ b/3rdparty/protobuf/src/google/protobuf/stubs/atomicops_internals_generic_gcc.h
@@ -146,6 +146,14 @@ inline Atomic64 NoBarrier_Load(volatile const Atomic64* ptr) {
   return __atomic_load_n(ptr, __ATOMIC_RELAXED);
 }
 
+inline Atomic64 Release_CompareAndSwap(volatile Atomic64* ptr,
+                                       Atomic64 old_value,
+                                       Atomic64 new_value) {
+  __atomic_compare_exchange_n(ptr, &old_value, new_value, false,
+                              __ATOMIC_RELEASE, __ATOMIC_ACQUIRE);
+  return old_value;
+}
+
 #endif // defined(__LP64__)
 
 }  // namespace internal


### PR DESCRIPTION
Resolves #12684 

### This pullrequest changes

This commit fixes an issue while trying to compile on s390x architecture.

This is simply a backport of a fixe already applied in official protobuf code:
- https://github.com/protocolbuffers/protobuf/pull/3955

### Test

This commit was used to compile openCV on s390x for openSUSE:
- https://build.opensuse.org/package/show/home:ldevulder:branches:devel:openQA/opencv
- https://build.opensuse.org/public/build/home:ldevulder:branches:devel:openQA/SLE_15/s390x/opencv/_log


```
buildworker:Linux x64 Debug=linux-2
```