### PR TITLE
Fix frame rate rounding in ffmpeg wrapper (#9023)

### DIFF
--- a/modules/videoio/src/cap_ffmpeg_impl.hpp
+++ b/modules/videoio/src/cap_ffmpeg_impl.hpp
@@ -1541,7 +1541,7 @@ static AVStream *icv_add_video_stream_FFMPEG(AVFormatContext *oc,
        identically 1. */
     frame_rate=(int)(fps+0.5);
     frame_rate_base=1;
-    while (fabs((double)frame_rate/frame_rate_base) - fps > 0.001){
+    while (fabs(((double)frame_rate/frame_rate_base) - fps) > 0.001){
         frame_rate_base*=10;
         frame_rate=(int)(fps*frame_rate_base + 0.5);
     }
@@ -2374,7 +2374,7 @@ AVStream* OutputMediaStream_FFMPEG::addVideoStream(AVFormatContext *oc, CV_CODEC
 
     int frame_rate = static_cast<int>(fps+0.5);
     int frame_rate_base = 1;
-    while (fabs(static_cast<double>(frame_rate)/frame_rate_base) - fps > 0.001)
+    while (fabs((static_cast<double>(frame_rate)/frame_rate_base) - fps) > 0.001)
     {
         frame_rate_base *= 10;
         frame_rate = static_cast<int>(fps*frame_rate_base + 0.5);


### PR DESCRIPTION
resolves #9023 

### This pullrequest changes

It fixes a typo in the frame rate calculation in the ffmpeg wrapper making some frame rates off. Examples: 
* 59.9 stays the same
* 59.94 is rounded to 59.9
* 59.2 is rounded to 59
* 59.15 is rounded to 59