### PR TITLE
Recognize ConvolutionDepthwise as Convolution

### DIFF
--- a/modules/dnn/src/caffe/caffe_importer.cpp
+++ b/modules/dnn/src/caffe/caffe_importer.cpp
@@ -379,6 +379,10 @@ public:
                     layerParams.blobs[1].setTo(1);  // std
                 }
             }
+            else if ("ConvolutionDepthwise" == type)
+            {
+                type = "Convolution";
+            }
 
             int id = dstNet.addLayer(name, type, layerParams);
 


### PR DESCRIPTION
Resolves #12315

### This pullrequest changes
Recognize `ConvolutionDepthwise` as `Convolution` within Caffe parser.