### PR TITLE
Fix documentation of cv::cuda::compare

### DIFF
--- a/modules/cudaarithm/include/opencv2/cudaarithm.hpp
+++ b/modules/cudaarithm/include/opencv2/cudaarithm.hpp
@@ -208,7 +208,7 @@ CV_EXPORTS void pow(InputArray src, double power, OutputArray dst, Stream& strea
 
 @param src1 First source matrix or scalar.
 @param src2 Second source matrix or scalar.
-@param dst Destination matrix that has the same size and type as the input array(s).
+@param dst Destination matrix that has the same size as the input array(s) and type CV_8U.
 @param cmpop Flag specifying the relation between the elements to be checked:
 -   **CMP_EQ:** a(.) == b(.)
 -   **CMP_GT:** a(.) \> b(.)


### PR DESCRIPTION
resolves #12015

### This pullrequest changes
Fix documentation of `cv::cuda::compare` to specify the type returned.
