### PR TITLE
dnn(ocl4dnn): calculate activation expression once

### DIFF
--- a/modules/dnn/src/opencl/conv_layer_spatial.cl
+++ b/modules/dnn/src/opencl/conv_layer_spatial.cl
@@ -69,10 +69,16 @@
 #endif
 
 #ifdef FUSED_CONV_ELTWISE
-#define ACTIVATION_FUNCTION(_dst_, _offset_, _data_, _channel_) do { (_dst_)[(_offset_)] = ACTIVATION_RELU_FUNCTION(eltwise_data[(_offset_)] + (_data_), _channel_);} while(0)
+#define ACTIVATION_FUNCTION(_dst_, _offset_, _data_, _channel_) do { \
+    const Dtype _x_ = eltwise_data[(_offset_)] + (_data_); \
+    (_dst_)[(_offset_)] = ACTIVATION_RELU_FUNCTION(_x_, _channel_); \
+} while(0)
 #define ELTWISE_DATA_ARG __global Dtype* eltwise_data,
 #else
-#define ACTIVATION_FUNCTION(_dst_, _offset_, _data_, _channel_) do { (_dst_)[(_offset_)] = ACTIVATION_RELU_FUNCTION(_data_, _channel_);} while(0)
+#define ACTIVATION_FUNCTION(_dst_, _offset_, _data_, _channel_) do { \
+    const Dtype _x_ = (_data_); \
+    (_dst_)[(_offset_)] = ACTIVATION_RELU_FUNCTION(_x_, _channel_); \
+} while(0)
 #define ELTWISE_DATA_ARG
 #endif
 


### PR DESCRIPTION
- to avoid multiple conditional calls via sub_group() functions

<cut/>

```
#define ACTIVATION_RELU_FUNCTION(x, c) ((Dtype)(x) > 0 ? (Dtype)(x) : ((Dtype)(x) * (negative_slope)))
...
#define ACTIVATION_FUNCTION(_dst_, _offset_, _data_, _channel_) do { \
    (_dst_)[(_offset_)] = ACTIVATION_RELU_FUNCTION(eltwise_data[(_offset_)] + (_data_), _channel_); \
} while(0)
...
#define SUBGROUP_GET_BIAS(k, i) intel_sub_group_shuffle(bias[k], i)
...
ACTIVATION_FUNCTION(dst, out_offset + ( 0 + i ) * out_pitch_y, blockC00[i] + SUBGROUP_GET_BIAS(0, i), group_x * TILE_N + i);
```