### PR TITLE
Redesign the ElemType register

### DIFF
--- a/3rdparty/carotene/hal/tegra_hal.hpp
+++ b/3rdparty/carotene/hal/tegra_hal.hpp
@@ -1299,7 +1299,7 @@ inline int TEGRA_MORPHINIT(cvhalFilter2D **context, int operation, int src_type,
                            int borderType, const double borderValue[4], int iterations, bool allowSubmatrix, bool allowInplace)
 {
     if(!context || !kernel_data || src_type != dst_type ||
-       CV_MAT_DEPTH(src_type) != CV_8U || src_type < 0 || (src_type >> CV_CN_SHIFT) > 3 ||
+       CV_MAT_DEPTH(src_type) != CV_8U || src_type < 0 || CV_MAT_CN(src_type) > 4 ||
 
        allowSubmatrix || allowInplace || iterations != 1 ||
        !CAROTENE_NS::isSupportedConfiguration())
@@ -1334,7 +1334,7 @@ inline int TEGRA_MORPHINIT(cvhalFilter2D **context, int operation, int src_type,
     MorphCtx* ctx = new MorphCtx;
     if(!ctx)
         return CV_HAL_ERROR_UNKNOWN;
-    ctx->channels = (src_type >> CV_CN_SHIFT) + 1;
+    ctx->channels = CV_MAT_CN(src_type);
     ctx->ksize.width = kernel_width;
     ctx->ksize.height = kernel_height;
     ctx->anchor_x = anchor_x;
@@ -1434,19 +1434,19 @@ inline int TEGRA_MORPHFREE(cvhalFilter2D *context)
 #define TEGRA_RESIZE(src_type, src_data, src_step, src_width, src_height, dst_data, dst_step, dst_width, dst_height, inv_scale_x, inv_scale_y, interpolation) \
 ( \
     interpolation == CV_HAL_INTER_LINEAR ? \
-        CV_MAT_DEPTH(src_type) == CV_8U && CAROTENE_NS::isResizeLinearOpenCVSupported(CAROTENE_NS::Size2D(src_width, src_height), CAROTENE_NS::Size2D(dst_width, dst_height), ((src_type >> CV_CN_SHIFT) + 1)) && \
+        CV_MAT_DEPTH(src_type) == CV_8U && CAROTENE_NS::isResizeLinearOpenCVSupported(CAROTENE_NS::Size2D(src_width, src_height), CAROTENE_NS::Size2D(dst_width, dst_height), CV_MAT_CN(src_type)) && \
         inv_scale_x > 0 && inv_scale_y > 0 && \
         (dst_width - 0.5)/inv_scale_x - 0.5 < src_width && (dst_height - 0.5)/inv_scale_y - 0.5 < src_height && \
         (dst_width + 0.5)/inv_scale_x + 0.5 >= src_width && (dst_height + 0.5)/inv_scale_y + 0.5 >= src_height && \
         std::abs(dst_width / inv_scale_x - src_width) < 0.1 && std::abs(dst_height / inv_scale_y - src_height) < 0.1 ? \
             CAROTENE_NS::resizeLinearOpenCV(CAROTENE_NS::Size2D(src_width, src_height), CAROTENE_NS::Size2D(dst_width, dst_height), \
-                                            src_data, src_step, dst_data, dst_step, 1.0/inv_scale_x, 1.0/inv_scale_y, ((src_type >> CV_CN_SHIFT) + 1)), \
+                                            src_data, src_step, dst_data, dst_step, 1.0/inv_scale_x, 1.0/inv_scale_y, CV_MAT_CN(src_type)), \
             CV_HAL_ERROR_OK : CV_HAL_ERROR_NOT_IMPLEMENTED : \
     interpolation == CV_HAL_INTER_AREA ? \
-        CV_MAT_DEPTH(src_type) == CV_8U && CAROTENE_NS::isResizeAreaSupported(1.0/inv_scale_x, 1.0/inv_scale_y, ((src_type >> CV_CN_SHIFT) + 1)) && \
+        CV_MAT_DEPTH(src_type) == CV_8U && CAROTENE_NS::isResizeAreaSupported(1.0/inv_scale_x, 1.0/inv_scale_y, CV_MAT_CN(src_type)) && \
         std::abs(dst_width / inv_scale_x - src_width) < 0.1 && std::abs(dst_height / inv_scale_y - src_height) < 0.1 ? \
             CAROTENE_NS::resizeAreaOpenCV(CAROTENE_NS::Size2D(src_width, src_height), CAROTENE_NS::Size2D(dst_width, dst_height), \
-                                          src_data, src_step, dst_data, dst_step, 1.0/inv_scale_x, 1.0/inv_scale_y, ((src_type >> CV_CN_SHIFT) + 1)), \
+                                          src_data, src_step, dst_data, dst_step, 1.0/inv_scale_x, 1.0/inv_scale_y, CV_MAT_CN(src_type)), \
             CV_HAL_ERROR_OK : CV_HAL_ERROR_NOT_IMPLEMENTED : \
     /*nearest neighbour interpolation disabled due to rounding accuracy issues*/ \
     /*interpolation == CV_HAL_INTER_NEAREST ? \

--- a/modules/calib3d/src/triangulate.cpp
+++ b/modules/calib3d/src/triangulate.cpp
@@ -150,13 +150,13 @@ cvCorrectMatches(CvMat *F_, CvMat *points1_, CvMat *points2_, CvMat *new_points1
         CV_Error( CV_StsUnsupportedFormat, "Input parameters must be matrices" );
     if (!( F_->cols == 3 && F_->rows == 3))
         CV_Error( CV_StsUnmatchedSizes, "The fundamental matrix must be a 3x3 matrix");
-    if (!(((F_->type & CV_MAT_TYPE_MASK) >> 3) == 0 ))
+    if (CV_MAT_CN(F_->type) != 1)
         CV_Error( CV_StsUnsupportedFormat, "The fundamental matrix must be a single-channel matrix" );
     if (!(points1_->rows == 1 && points2_->rows == 1 && points1_->cols == points2_->cols))
         CV_Error( CV_StsUnmatchedSizes, "The point-matrices must have one row, and an equal number of columns" );
-    if (((points1_->type & CV_MAT_TYPE_MASK) >> 3) != 1 )
+    if (CV_MAT_CN(points1_->type) != 2)
         CV_Error( CV_StsUnmatchedSizes, "The first set of points must contain two channels; one for x and one for y" );
-    if (((points2_->type & CV_MAT_TYPE_MASK) >> 3) != 1 )
+    if (CV_MAT_CN(points2_->type) != 2)
         CV_Error( CV_StsUnmatchedSizes, "The second set of points must contain two channels; one for x and one for y" );
     if (new_points1 != NULL) {
         CV_Assert(CV_IS_MAT(new_points1));

--- a/modules/core/include/opencv2/core/cvdef.h
+++ b/modules/core/include/opencv2/core/cvdef.h
@@ -304,10 +304,7 @@ Cv64suf;
 *                                  Matrix type (Mat)                                     *
 \****************************************************************************************/
 
-#define CV_MAT_CN_MASK          ((CV_CN_MAX - 1) << CV_CN_SHIFT)
-#define CV_MAT_CN(flags)        ((((flags) & CV_MAT_CN_MASK) >> CV_CN_SHIFT) + 1)
-#define CV_MAT_TYPE_MASK        (CV_DEPTH_MAX*CV_CN_MAX - 1)
-#define CV_MAT_TYPE(flags)      ((flags) & CV_MAT_TYPE_MASK)
+#define CV_MAGIC_MASK           0xFFFF0000
 #define CV_MAT_CONT_FLAG_SHIFT  14
 #define CV_MAT_CONT_FLAG        (1 << CV_MAT_CONT_FLAG_SHIFT)
 #define CV_IS_MAT_CONT(flags)   ((flags) & CV_MAT_CONT_FLAG)
@@ -315,12 +312,6 @@ Cv64suf;
 #define CV_SUBMAT_FLAG_SHIFT    15
 #define CV_SUBMAT_FLAG          (1 << CV_SUBMAT_FLAG_SHIFT)
 #define CV_IS_SUBMAT(flags)     ((flags) & CV_MAT_SUBMAT_FLAG)
-
-/** Size of each channel item,
-   0x28442211 = 0010 1000 0100 0100 0010 0010 0001 0001 ~ array of sizeof(arr_type_elem) */
-#define CV_ELEM_SIZE1(type) ((0x28442211 >> CV_MAT_DEPTH(type)*4) & 15)
-
-#define CV_ELEM_SIZE(type) (CV_MAT_CN(type)*CV_ELEM_SIZE1(type))
 
 #ifndef MIN
 #  define MIN(a,b)  ((a) > (b) ? (b) : (a))

--- a/modules/core/include/opencv2/core/hal/cvtype.h
+++ b/modules/core/include/opencv2/core/hal/cvtype.h
@@ -1,0 +1,224 @@
+/*M///////////////////////////////////////////////////////////////////////////////////////
+//
+//  IMPORTANT: READ BEFORE DOWNLOADING, COPYING, INSTALLING OR USING.
+//
+//  By downloading, copying, installing or using the software you agree to this license.
+//  If you do not agree to this license, do not download, install,
+//  copy or use the software.
+//
+//
+//                          License Agreement
+//                For Open Source Computer Vision Library
+//
+// Copyright (C) 2000-2018, Intel Corporation, all rights reserved.
+// Copyright (C) 2009-2011, Willow Garage Inc., all rights reserved.
+// Copyright (C) 2009-2016, NVIDIA Corporation, all rights reserved.
+// Copyright (C) 2010-2013, Advanced Micro Devices, Inc., all rights reserved.
+// Copyright (C) 2015-2016, OpenCV Foundation, all rights reserved.
+// Copyright (C) 2015-2016, Itseez Inc., all rights reserved.
+// Third party copyrights are property of their respective owners.
+//
+// @Authors
+//    Hamdi Sahloul hamdi[at]sahloul[dot]me
+//
+// Redistribution and use in source and binary forms, with or without modification,
+// are permitted provided that the following conditions are met:
+//
+//   * Redistribution's of source code must retain the above copyright notice,
+//     this list of conditions and the following disclaimer.
+//
+//   * Redistribution's in binary form must reproduce the above copyright notice,
+//     this list of conditions and the following disclaimer in the documentation
+//     and/or other materials provided with the distribution.
+//
+//   * The name of the copyright holders may not be used to endorse or promote products
+//     derived from this software without specific prior written permission.
+//
+// This software is provided by the copyright holders and contributors "as is" and
+// any express or implied warranties, including, but not limited to, the implied
+// warranties of merchantability and fitness for a particular purpose are disclaimed.
+// In no event shall the Intel Corporation or contributors be liable for any direct,
+// indirect, incidental, special, exemplary, or consequential damages
+// (including, but not limited to, procurement of substitute goods or services;
+// loss of use, data, or profits; or business interruption) however caused
+// and on any theory of liability, whether in contract, strict liability,
+// or tort (including negligence or otherwise) arising in any way out of
+// the use of this software, even if advised of the possibility of such damage.
+//
+//M*/
+
+#ifndef OPENCV_CORE_HAL_CVTYPE_H
+#define OPENCV_CORE_HAL_CVTYPE_H
+
+/*
+ * MSVC evaluates both sides of conditional expressions at compile time!
+ * Lets disable that buggy behaviour, and depend on other compilers to detect real issues.
+ */
+#ifdef _MSC_VER
+#pragma warning( disable: 4293 ) /* shift count negative or too big, undefined behavior */
+#endif
+
+//! @name OpenCV4 Data types
+//! @sa cv::Types
+//! @{
+
+//ElemType register specifications
+#define CV_DEPTH_SHIFT            0
+#define CV_CN_SHIFT               5
+#define CV_CN_LEN                 7
+#define CV_CN_EXP_LEN             3
+#define CV_CN_BASE_LEN            (CV_CN_LEN - CV_CN_EXP_LEN)
+#define CV_DEPTH_LEN              (CV_CN_SHIFT - CV_DEPTH_SHIFT)
+
+//ElemType exponent power limit (private)
+#define __CV_CN_LIMIT_EXP(n)      (1 << (CV_CN_BASE_LEN + n))
+
+//ElemType register masks (private)
+#define CV_SANITY_DEPTH_MASK      ((1 << CV_DEPTH_LEN  ) - 1)
+#define CV_SANITY_CN_MASK         ((1 << CV_CN_LEN     ) - 1)
+#define CV_SANITY_CN_EXP_MASK     ((1 << CV_CN_EXP_LEN ) - 1)
+#define CV_SANITY_CN_BASE_MASK    (__CV_CN_LIMIT_EXP(0)  - 1)
+#define CV_MAT_DEPTH_MASK         (CV_SANITY_DEPTH_MASK << CV_DEPTH_SHIFT)
+#define CV_MAT_CN_MASK            (CV_SANITY_CN_MASK    << CV_CN_SHIFT   )
+#define CV_MAT_TYPE_MASK          (CV_MAT_CN_MASK | CV_MAT_DEPTH_MASK)
+
+//ElemType register limits (public)
+#define CV_DEPTH_MAX              (1 << CV_DEPTH_LEN)
+#define CV_CN_MAX                 __CV_CN_LIMIT_EXP(CV_SANITY_CN_EXP_MASK) /*(1 << CV_CN_LEN )*/
+
+//ElemType register deflate/inflate operations (private)
+#define __CV_CN_MAKE_EXPONENT(cn) ((cn) <= __CV_CN_LIMIT_EXP(0) ? 0 :          \
+                                  ((cn) <= __CV_CN_LIMIT_EXP(1) ? 1 :          \
+                                  ((cn) <= __CV_CN_LIMIT_EXP(2) ? 2 :          \
+                                  ((cn) <= __CV_CN_LIMIT_EXP(3) ? 3 :          \
+                                  ((cn) <= __CV_CN_LIMIT_EXP(4) ? 4 :          \
+                                  ((cn) <= __CV_CN_LIMIT_EXP(5) ? 5 :          \
+                                  ((cn) <= __CV_CN_LIMIT_EXP(6) ? 6 : 7)))))))
+#define __CV_CN_EXPONENT(cn_bin)  (((cn_bin) >> CV_CN_BASE_LEN) & CV_SANITY_CN_EXP_MASK)
+#define __CV_CN_MAKE_BASE(cn)     (((cn) - 1) >> __CV_CN_MAKE_EXPONENT(cn)) /*& CV_SANITY_CN_BASE_MASK*/
+#define __CV_CN_BASE(cn_bin)      ((cn_bin) & CV_SANITY_CN_BASE_MASK)
+#define __CV_CN_DEFLATE(cn)       ((__CV_CN_MAKE_EXPONENT(cn) << CV_CN_BASE_LEN) | (__CV_CN_MAKE_BASE(cn) & CV_SANITY_CN_BASE_MASK)) /*((cn) - 1)*/
+#define __CV_CN_INFLATE__(e,b)    ((b + 1) << e)
+#define __CV_CN_INFLATE(cn_bin)   __CV_CN_INFLATE__(__CV_CN_EXPONENT(cn_bin), __CV_CN_BASE(cn_bin)) /*((cn_bin) + 1)*/
+
+//ElemType register pack/unpack operations (private)
+#define __CV_DEPTH_PACK(depth)    (((depth) & CV_SANITY_DEPTH_MASK) << CV_DEPTH_SHIFT)
+#define __CV_DEPTH_UNPACK(flags)  (((flags) & CV_MAT_DEPTH_MASK)  >> CV_DEPTH_SHIFT)
+#define __CV_CN_PACK(cn)          ((__CV_CN_DEFLATE(cn) & CV_SANITY_CN_MASK) << CV_CN_SHIFT)
+#define __CV_CN_UNPACK(flags)     __CV_CN_INFLATE(((flags) & CV_MAT_CN_MASK) >> CV_CN_SHIFT)
+/*
+TODO: static assertion on bad input channel
+TODO: static assertion on cn == cn to avoid random multiple evaluation*/
+#define __CV_TYPE_PACK(depth,cn)  (__CV_DEPTH_PACK(depth) | __CV_CN_PACK(cn))
+/*TODO: Rewite __CV_TYPE_UNPACK*/
+#define __CV_TYPE_UNPACK(flags)   __CV_TYPE_PACK(__CV_DEPTH_UNPACK(flags),__CV_CN_UNPACK(flags)) /*((flags) & CV_MAT_TYPE_MASK)*/
+
+//ElemType register - user operations (public)
+#define CV_CN_FIT(cn)             __CV_CN_INFLATE__(__CV_CN_MAKE_EXPONENT(cn), __CV_CN_MAKE_BASE(cn))
+#define CV_MAT_TYPE(flags)        __CV_TYPE_UNPACK(flags)
+#define CV_MAT_CN(flags)          __CV_CN_UNPACK(flags)
+#define CV_MAT_DEPTH(flags)       __CV_DEPTH_UNPACK(flags)
+#define CV_MAKETYPE(depth,cn)     __CV_TYPE_PACK(depth,cn)
+#define CV_MAKE_TYPE              CV_MAKETYPE
+
+//depth values (public)
+#define CV_8U        0
+#define CV_16U       2
+#define CV_32U       8
+#define CV_64U       9
+
+#define CV_8S        1
+#define CV_16S       3
+#define CV_32S       4
+#define CV_64S       11
+
+#define CV_16F       7
+#define CV_32F       5
+#define CV_64F       6
+
+#define CV_RAW       29
+#define CV_AUTO      30
+#define CV_UNDEF     31
+
+//sizeof, fraction-bits, sign-bit of depth values (public)
+//sizeof(CV_8U, CV_8S, CV_16U, CV_16S, CV_32S, CV_32F, CV_64F, CV_16F) = 1, 1, 2, 2, 4, 4, 8, 2 = 0x28442211
+#define CV_ELEM_SIZE1(type)     (CV_MAT_DEPTH(type) <  8 ? ((0x28442211 >>  CV_MAT_DEPTH(type)       * 4) & 15) :     \
+                                (CV_MAT_DEPTH(type) < 16 ? ((0x00008084 >> (CV_MAT_DEPTH(type) -  8) * 4) & 15) : 0))
+#define CV_ELEM_EXP_BITS(type)  (CV_MAT_DEPTH(type) <  8 ? ((0x5B800000 >>  CV_MAT_DEPTH(type)       * 4) & 15) : 0)
+#define CV_ELEM_SIGN_BIT(type)  (CV_MAT_DEPTH(type) <  8 ? ((0x11111010 >>  CV_MAT_DEPTH(type)       * 4) & 15) :     \
+                                (CV_MAT_DEPTH(type) < 16 ? ((0x00001000 >> (CV_MAT_DEPTH(type) -  8) * 4) & 15) : 0))
+
+#define CV_ELEM_SIZE(type)      (CV_MAT_CN(type)*CV_ELEM_SIZE1(type))
+
+#define CV_USRTYPE1 (void)"CV_USRTYPE1 support has been dropped in OpenCV 4.0"
+
+//ElemType values (public)
+#define CV_8UC1 CV_MAKETYPE(CV_8U,1)
+#define CV_8UC2 CV_MAKETYPE(CV_8U,2)
+#define CV_8UC3 CV_MAKETYPE(CV_8U,3)
+#define CV_8UC4 CV_MAKETYPE(CV_8U,4)
+#define CV_8UC(n) CV_MAKETYPE(CV_8U,(n))
+
+#define CV_16UC1 CV_MAKETYPE(CV_16U,1)
+#define CV_16UC2 CV_MAKETYPE(CV_16U,2)
+#define CV_16UC3 CV_MAKETYPE(CV_16U,3)
+#define CV_16UC4 CV_MAKETYPE(CV_16U,4)
+#define CV_16UC(n) CV_MAKETYPE(CV_16U,(n))
+
+#define CV_32UC1 CV_MAKETYPE(CV_32U,1)
+#define CV_32UC2 CV_MAKETYPE(CV_32U,2)
+#define CV_32UC3 CV_MAKETYPE(CV_32U,3)
+#define CV_32UC4 CV_MAKETYPE(CV_32U,4)
+#define CV_32UC(n) CV_MAKETYPE(CV_32U,(n))
+
+#define CV_64UC1 CV_MAKETYPE(CV_64U,1)
+#define CV_64UC2 CV_MAKETYPE(CV_64U,2)
+#define CV_64UC3 CV_MAKETYPE(CV_64U,3)
+#define CV_64UC4 CV_MAKETYPE(CV_64U,4)
+#define CV_64UC(n) CV_MAKETYPE(CV_64U,(n))
+
+#define CV_8SC1 CV_MAKETYPE(CV_8S,1)
+#define CV_8SC2 CV_MAKETYPE(CV_8S,2)
+#define CV_8SC3 CV_MAKETYPE(CV_8S,3)
+#define CV_8SC4 CV_MAKETYPE(CV_8S,4)
+#define CV_8SC(n) CV_MAKETYPE(CV_8S,(n))
+
+#define CV_16SC1 CV_MAKETYPE(CV_16S,1)
+#define CV_16SC2 CV_MAKETYPE(CV_16S,2)
+#define CV_16SC3 CV_MAKETYPE(CV_16S,3)
+#define CV_16SC4 CV_MAKETYPE(CV_16S,4)
+#define CV_16SC(n) CV_MAKETYPE(CV_16S,(n))
+
+#define CV_32SC1 CV_MAKETYPE(CV_32S,1)
+#define CV_32SC2 CV_MAKETYPE(CV_32S,2)
+#define CV_32SC3 CV_MAKETYPE(CV_32S,3)
+#define CV_32SC4 CV_MAKETYPE(CV_32S,4)
+#define CV_32SC(n) CV_MAKETYPE(CV_32S,(n))
+
+#define CV_64SC1 CV_MAKETYPE(CV_64S,1)
+#define CV_64SC2 CV_MAKETYPE(CV_64S,2)
+#define CV_64SC3 CV_MAKETYPE(CV_64S,3)
+#define CV_64SC4 CV_MAKETYPE(CV_64S,4)
+#define CV_64SC(n) CV_MAKETYPE(CV_64S,(n))
+
+#define CV_16FC1 CV_MAKETYPE(CV_16F,1)
+#define CV_16FC2 CV_MAKETYPE(CV_16F,2)
+#define CV_16FC3 CV_MAKETYPE(CV_16F,3)
+#define CV_16FC4 CV_MAKETYPE(CV_16F,4)
+#define CV_16FC(n) CV_MAKETYPE(CV_16F,(n))
+
+#define CV_32FC1 CV_MAKETYPE(CV_32F,1)
+#define CV_32FC2 CV_MAKETYPE(CV_32F,2)
+#define CV_32FC3 CV_MAKETYPE(CV_32F,3)
+#define CV_32FC4 CV_MAKETYPE(CV_32F,4)
+#define CV_32FC(n) CV_MAKETYPE(CV_32F,(n))
+
+#define CV_64FC1 CV_MAKETYPE(CV_64F,1)
+#define CV_64FC2 CV_MAKETYPE(CV_64F,2)
+#define CV_64FC3 CV_MAKETYPE(CV_64F,3)
+#define CV_64FC4 CV_MAKETYPE(CV_64F,4)
+#define CV_64FC(n) CV_MAKETYPE(CV_64F,(n))
+
+//! @}
+
+#endif

--- a/modules/core/include/opencv2/core/hal/interface.h
+++ b/modules/core/include/opencv2/core/hal/interface.h
@@ -1,6 +1,8 @@
 #ifndef OPENCV_CORE_HAL_INTERFACE_H
 #define OPENCV_CORE_HAL_INTERFACE_H
 
+#include "cvtype.h"
+
 //! @addtogroup core_hal_interface
 //! @{
 
@@ -64,74 +66,6 @@ typedef signed char schar;
 #  define CV_BIG_UINT(n)  n##ULL
 #endif
 
-#define CV_USRTYPE1 (void)"CV_USRTYPE1 support has been dropped in OpenCV 4.0"
-
-#define CV_CN_MAX     512
-#define CV_CN_SHIFT   3
-#define CV_DEPTH_MAX  (1 << CV_CN_SHIFT)
-
-#define CV_8U   0
-#define CV_8S   1
-#define CV_16U  2
-#define CV_16S  3
-#define CV_32S  4
-#define CV_32F  5
-#define CV_64F  6
-#define CV_16F  7
-
-#define CV_MAT_DEPTH_MASK       (CV_DEPTH_MAX - 1)
-#define CV_MAT_DEPTH(flags)     ((flags) & CV_MAT_DEPTH_MASK)
-
-#define CV_MAKETYPE(depth,cn) (CV_MAT_DEPTH(depth) + (((cn)-1) << CV_CN_SHIFT))
-#define CV_MAKE_TYPE CV_MAKETYPE
-
-#define CV_8UC1 CV_MAKETYPE(CV_8U,1)
-#define CV_8UC2 CV_MAKETYPE(CV_8U,2)
-#define CV_8UC3 CV_MAKETYPE(CV_8U,3)
-#define CV_8UC4 CV_MAKETYPE(CV_8U,4)
-#define CV_8UC(n) CV_MAKETYPE(CV_8U,(n))
-
-#define CV_8SC1 CV_MAKETYPE(CV_8S,1)
-#define CV_8SC2 CV_MAKETYPE(CV_8S,2)
-#define CV_8SC3 CV_MAKETYPE(CV_8S,3)
-#define CV_8SC4 CV_MAKETYPE(CV_8S,4)
-#define CV_8SC(n) CV_MAKETYPE(CV_8S,(n))
-
-#define CV_16UC1 CV_MAKETYPE(CV_16U,1)
-#define CV_16UC2 CV_MAKETYPE(CV_16U,2)
-#define CV_16UC3 CV_MAKETYPE(CV_16U,3)
-#define CV_16UC4 CV_MAKETYPE(CV_16U,4)
-#define CV_16UC(n) CV_MAKETYPE(CV_16U,(n))
-
-#define CV_16SC1 CV_MAKETYPE(CV_16S,1)
-#define CV_16SC2 CV_MAKETYPE(CV_16S,2)
-#define CV_16SC3 CV_MAKETYPE(CV_16S,3)
-#define CV_16SC4 CV_MAKETYPE(CV_16S,4)
-#define CV_16SC(n) CV_MAKETYPE(CV_16S,(n))
-
-#define CV_32SC1 CV_MAKETYPE(CV_32S,1)
-#define CV_32SC2 CV_MAKETYPE(CV_32S,2)
-#define CV_32SC3 CV_MAKETYPE(CV_32S,3)
-#define CV_32SC4 CV_MAKETYPE(CV_32S,4)
-#define CV_32SC(n) CV_MAKETYPE(CV_32S,(n))
-
-#define CV_32FC1 CV_MAKETYPE(CV_32F,1)
-#define CV_32FC2 CV_MAKETYPE(CV_32F,2)
-#define CV_32FC3 CV_MAKETYPE(CV_32F,3)
-#define CV_32FC4 CV_MAKETYPE(CV_32F,4)
-#define CV_32FC(n) CV_MAKETYPE(CV_32F,(n))
-
-#define CV_64FC1 CV_MAKETYPE(CV_64F,1)
-#define CV_64FC2 CV_MAKETYPE(CV_64F,2)
-#define CV_64FC3 CV_MAKETYPE(CV_64F,3)
-#define CV_64FC4 CV_MAKETYPE(CV_64F,4)
-#define CV_64FC(n) CV_MAKETYPE(CV_64F,(n))
-
-#define CV_16FC1 CV_MAKETYPE(CV_16F,1)
-#define CV_16FC2 CV_MAKETYPE(CV_16F,2)
-#define CV_16FC3 CV_MAKETYPE(CV_16F,3)
-#define CV_16FC4 CV_MAKETYPE(CV_16F,4)
-#define CV_16FC(n) CV_MAKETYPE(CV_16F,(n))
 //! @}
 
 //! @name Comparison operation

--- a/modules/core/include/opencv2/core/mat.hpp
+++ b/modules/core/include/opencv2/core/mat.hpp
@@ -2080,7 +2080,7 @@ public:
     Mat& operator = (Mat&& m);
 
     enum { MAGIC_VAL  = 0x42FF0000, AUTO_STEP = 0, CONTINUOUS_FLAG = CV_MAT_CONT_FLAG, SUBMATRIX_FLAG = CV_SUBMAT_FLAG };
-    enum { MAGIC_MASK = 0xFFFF0000, TYPE_MASK = 0x00000FFF, DEPTH_MASK = 7 };
+    enum { MAGIC_MASK = CV_MAGIC_MASK, TYPE_MASK = CV_MAT_TYPE_MASK, DEPTH_MASK = CV_MAT_DEPTH_MASK };
 
     /*! includes several bit-fields:
          - the magic signature
@@ -2554,7 +2554,7 @@ public:
     void ndoffset(size_t* ofs) const;
 
     enum { MAGIC_VAL  = 0x42FF0000, AUTO_STEP = 0, CONTINUOUS_FLAG = CV_MAT_CONT_FLAG, SUBMATRIX_FLAG = CV_SUBMAT_FLAG };
-    enum { MAGIC_MASK = 0xFFFF0000, TYPE_MASK = 0x00000FFF, DEPTH_MASK = 7 };
+    enum { MAGIC_MASK = CV_MAGIC_MASK, TYPE_MASK = CV_MAT_TYPE_MASK, DEPTH_MASK = CV_MAT_DEPTH_MASK };
 
     /*! includes several bit-fields:
          - the magic signature

--- a/modules/core/include/opencv2/core/mat.inl.hpp
+++ b/modules/core/include/opencv2/core/mat.inl.hpp
@@ -1142,7 +1142,7 @@ _Tp& Mat::at(int i0, int i1)
     CV_DbgAssert(data);
     CV_DbgAssert((unsigned)i0 < (unsigned)size.p[0]);
     CV_DbgAssert((unsigned)(i1 * DataType<_Tp>::channels) < (unsigned)(size.p[1] * channels()));
-    CV_DbgAssert(CV_ELEM_SIZE1(traits::Depth<_Tp>::value) == elemSize1());
+    CV_DbgAssert(CV_ELEM_SIZE1(traits::Depth<_Tp>::value) == (int)elemSize1());
     return ((_Tp*)(data + step.p[0] * i0))[i1];
 }
 
@@ -1153,7 +1153,7 @@ const _Tp& Mat::at(int i0, int i1) const
     CV_DbgAssert(data);
     CV_DbgAssert((unsigned)i0 < (unsigned)size.p[0]);
     CV_DbgAssert((unsigned)(i1 * DataType<_Tp>::channels) < (unsigned)(size.p[1] * channels()));
-    CV_DbgAssert(CV_ELEM_SIZE1(traits::Depth<_Tp>::value) == elemSize1());
+    CV_DbgAssert(CV_ELEM_SIZE1(traits::Depth<_Tp>::value) == (int)elemSize1());
     return ((const _Tp*)(data + step.p[0] * i0))[i1];
 }
 
@@ -1164,7 +1164,7 @@ _Tp& Mat::at(Point pt)
     CV_DbgAssert(data);
     CV_DbgAssert((unsigned)pt.y < (unsigned)size.p[0]);
     CV_DbgAssert((unsigned)(pt.x * DataType<_Tp>::channels) < (unsigned)(size.p[1] * channels()));
-    CV_DbgAssert(CV_ELEM_SIZE1(traits::Depth<_Tp>::value) == elemSize1());
+    CV_DbgAssert(CV_ELEM_SIZE1(traits::Depth<_Tp>::value) == (int)elemSize1());
     return ((_Tp*)(data + step.p[0] * pt.y))[pt.x];
 }
 
@@ -1175,7 +1175,7 @@ const _Tp& Mat::at(Point pt) const
     CV_DbgAssert(data);
     CV_DbgAssert((unsigned)pt.y < (unsigned)size.p[0]);
     CV_DbgAssert((unsigned)(pt.x * DataType<_Tp>::channels) < (unsigned)(size.p[1] * channels()));
-    CV_DbgAssert(CV_ELEM_SIZE1(traits::Depth<_Tp>::value) == elemSize1());
+    CV_DbgAssert(CV_ELEM_SIZE1(traits::Depth<_Tp>::value) == (int)elemSize1());
     return ((const _Tp*)(data + step.p[0] * pt.y))[pt.x];
 }
 

--- a/modules/core/include/opencv2/core/traits.hpp
+++ b/modules/core/include/opencv2/core/traits.hpp
@@ -156,6 +156,51 @@ public:
          };
 };
 
+template<> class DataType<ushort>
+{
+public:
+    typedef ushort      value_type;
+    typedef int         work_type;
+    typedef value_type  channel_type;
+    typedef value_type  vec_type;
+    enum { generic_type = 0,
+           depth        = CV_16U,
+           channels     = 1,
+           fmt          = (int)'w',
+           type         = CV_MAKETYPE(depth, channels)
+         };
+};
+
+template<> class DataType<uint>
+{
+public:
+    typedef uint        value_type;
+    typedef value_type  work_type;
+    typedef value_type  channel_type;
+    typedef value_type  vec_type;
+    enum { generic_type = 0,
+           depth        = CV_32U,
+           channels     = 1,
+           fmt          = (int)'u',
+           type         = CV_MAKETYPE(depth, channels)
+         };
+};
+
+template<> class DataType<uint64_t>
+{
+public:
+    typedef uint64_t    value_type;
+    typedef value_type  work_type;
+    typedef value_type  channel_type;
+    typedef value_type  vec_type;
+    enum { generic_type = 0,
+           depth        = CV_64U,
+           channels     = 1,
+           fmt          = (int)'l',
+           type         = CV_MAKETYPE(depth, channels)
+         };
+};
+
 template<> class DataType<schar>
 {
 public:
@@ -182,21 +227,6 @@ public:
            depth        = CV_8S,
            channels     = 1,
            fmt          = (int)'c',
-           type         = CV_MAKETYPE(depth, channels)
-         };
-};
-
-template<> class DataType<ushort>
-{
-public:
-    typedef ushort      value_type;
-    typedef int         work_type;
-    typedef value_type  channel_type;
-    typedef value_type  vec_type;
-    enum { generic_type = 0,
-           depth        = CV_16U,
-           channels     = 1,
-           fmt          = (int)'w',
            type         = CV_MAKETYPE(depth, channels)
          };
 };
@@ -231,6 +261,36 @@ public:
          };
 };
 
+template<> class DataType<int64_t>
+{
+public:
+    typedef int64_t     value_type;
+    typedef value_type  work_type;
+    typedef value_type  channel_type;
+    typedef value_type  vec_type;
+    enum { generic_type = 0,
+           depth        = CV_64S,
+           channels     = 1,
+           fmt          = (int)'l',
+           type         = CV_MAKETYPE(depth, channels)
+         };
+};
+
+template<> class DataType<float16_t>
+{
+public:
+    typedef float16_t   value_type;
+    typedef float       work_type;
+    typedef value_type  channel_type;
+    typedef value_type  vec_type;
+    enum { generic_type = 0,
+           depth        = CV_16F,
+           channels     = 1,
+           fmt          = (int)'h',
+           type         = CV_MAKETYPE(depth, channels)
+         };
+};
+
 template<> class DataType<float>
 {
 public:
@@ -257,21 +317,6 @@ public:
            depth        = CV_64F,
            channels     = 1,
            fmt          = (int)'d',
-           type         = CV_MAKETYPE(depth, channels)
-         };
-};
-
-template<> class DataType<float16_t>
-{
-public:
-    typedef float16_t   value_type;
-    typedef float       work_type;
-    typedef value_type  channel_type;
-    typedef value_type  vec_type;
-    enum { generic_type = 0,
-           depth        = CV_16F,
-           channels     = 1,
-           fmt          = (int)'h',
            type         = CV_MAKETYPE(depth, channels)
          };
 };

--- a/modules/core/include/opencv2/core/types_c.h
+++ b/modules/core/include/opencv2/core/types_c.h
@@ -439,7 +439,6 @@ IplConvKernelFP;
 #define CV_AUTO_STEP  0x7fffffff
 #define CV_WHOLE_ARR  cvSlice( 0, 0x3fffffff )
 
-#define CV_MAGIC_MASK       0xFFFF0000
 #define CV_MAT_MAGIC_VAL    0x42420000
 #define CV_TYPE_NAME_MAT    "opencv-matrix"
 
@@ -516,16 +515,16 @@ CvMat;
     (CV_IS_MAT_HDR(mat) && ((const CvMat*)(mat))->data.ptr != NULL)
 
 #define CV_IS_MASK_ARR(mat) \
-    (((mat)->type & (CV_MAT_TYPE_MASK & ~CV_8SC1)) == 0)
+    (((mat)->type & (0xFFF & ~CV_8SC1)) == 0)
 
 #define CV_ARE_TYPES_EQ(mat1, mat2) \
-    ((((mat1)->type ^ (mat2)->type) & CV_MAT_TYPE_MASK) == 0)
+    ((((mat1)->type ^ (mat2)->type) & 0xFFF) == 0)
 
 #define CV_ARE_CNS_EQ(mat1, mat2) \
-    ((((mat1)->type ^ (mat2)->type) & CV_MAT_CN_MASK) == 0)
+    ((((mat1)->type ^ (mat2)->type) & 0xFF8) == 0)
 
 #define CV_ARE_DEPTHS_EQ(mat1, mat2) \
-    ((((mat1)->type ^ (mat2)->type) & CV_MAT_DEPTH_MASK) == 0)
+    ((((mat1)->type ^ (mat2)->type) & 7) == 0)
 
 #define CV_ARE_SIZES_EQ(mat1, mat2) \
     ((mat1)->rows == (mat2)->rows && (mat1)->cols == (mat2)->cols)
@@ -546,8 +545,8 @@ CV_INLINE CvMat cvMat( int rows, int cols, int type, void* data CV_DEFAULT(NULL)
 {
     CvMat m;
 
-    assert( (unsigned)CV_MAT_DEPTH(type) <= CV_64F );
-    type = CV_MAT_TYPE(type);
+    assert( (unsigned)(type & 7) <= CV_64F );
+    type = type & 0xFFF;
     m.type = CV_MAT_MAGIC_VAL | CV_MAT_CONT_FLAG | type;
     m.cols = cols;
     m.rows = rows;
@@ -614,7 +613,7 @@ CV_INLINE  double  cvmGet( const CvMat* mat, int row, int col )
 {
     int type;
 
-    type = CV_MAT_TYPE(mat->type);
+    type = mat->type & 7;
     assert( (unsigned)row < (unsigned)mat->rows &&
             (unsigned)col < (unsigned)mat->cols );
 
@@ -640,7 +639,7 @@ type, and it checks for the row and column ranges only in debug mode.
 CV_INLINE  void  cvmSet( CvMat* mat, int row, int col, double value )
 {
     int type;
-    type = CV_MAT_TYPE(mat->type);
+    type = mat->type & 0xFFF;
     assert( (unsigned)row < (unsigned)mat->rows &&
             (unsigned)col < (unsigned)mat->cols );
 
@@ -656,7 +655,7 @@ CV_INLINE  void  cvmSet( CvMat* mat, int row, int col, double value )
 
 CV_INLINE int cvIplDepth( int type )
 {
-    int depth = CV_MAT_DEPTH(type);
+    int depth = type & 7;
     return CV_ELEM_SIZE1(depth)*8 | (depth == CV_8S || depth == CV_16S ||
            depth == CV_32S ? IPL_DEPTH_SIGN : 0);
 }

--- a/modules/core/src/array.cpp
+++ b/modules/core/src/array.cpp
@@ -1458,7 +1458,7 @@ cvScalarToRawData( const CvScalar* scalar, void* data, int type, int extend_to_1
 {
     type = CV_MAT_TYPE(type);
     int cn = CV_MAT_CN( type );
-    int depth = type & CV_MAT_DEPTH_MASK;
+    int depth = CV_MAT_DEPTH(type);
 
     assert( scalar && data );
     if( (unsigned)(cn - 1) >= 4 )
@@ -2775,7 +2775,7 @@ cvReshape( const CvArr* array, CvMat* header,
         "The total width is not divisible by the new number of channels" );
 
     header->cols = new_width;
-    header->type = (mat->type  & ~CV_MAT_TYPE_MASK) | CV_MAKETYPE(mat->type, new_cn);
+    header->type = (mat->type & ~CV_MAT_TYPE_MASK) | CV_MAKETYPE(mat->type, new_cn);
 
     result = header;
     return  result;

--- a/modules/core/src/convert.cpp
+++ b/modules/core/src/convert.cpp
@@ -236,7 +236,6 @@ static void cvt32s(const int* src, size_t sstep, uchar*, size_t, int* dst, size_
 static void cvt64s(const int64* src, size_t sstep, uchar*, size_t, int64* dst, size_t dstep, Size size, void*)
 { cvtCopy((const uchar*)src, sstep, (uchar*)dst, dstep, size, 8); }
 
-
 /* [TODO] Recover IPP calls
 #if defined(HAVE_IPP)
 #define DEF_CVT_FUNC_F(suffix, stype, dtype, ippFavor) \

--- a/modules/core/src/cuda_gpu_mat.cpp
+++ b/modules/core/src/cuda_gpu_mat.cpp
@@ -200,7 +200,7 @@ GpuMat cv::cuda::GpuMat::reshape(int new_cn, int new_rows) const
         CV_Error(cv::Error::BadNumChannels, "The total width is not divisible by the new number of channels");
 
     hdr.cols = new_width;
-    hdr.flags = (hdr.flags & ~CV_MAT_CN_MASK) | ((new_cn - 1) << CV_CN_SHIFT);
+    hdr.flags = (hdr.flags & ~CV_MAT_TYPE_MASK) | CV_MAKETYPE(CV_MAT_DEPTH(hdr.flags), new_cn);
 
     return hdr;
 }

--- a/modules/core/src/cuda_host_mem.cpp
+++ b/modules/core/src/cuda_host_mem.cpp
@@ -280,7 +280,7 @@ HostMem cv::cuda::HostMem::reshape(int new_cn, int new_rows) const
         CV_Error(cv::Error::BadNumChannels, "The total width is not divisible by the new number of channels");
 
     hdr.cols = new_width;
-    hdr.flags = (hdr.flags & ~CV_MAT_CN_MASK) | ((new_cn - 1) << CV_CN_SHIFT);
+    hdr.flags = (hdr.flags & ~CV_MAT_TYPE_MASK) | CV_MAKETYPE(CV_MAT_DEPTH(hdr.flags), new_cn);
 
     return hdr;
 }

--- a/modules/core/src/datastructs.cpp
+++ b/modules/core/src/datastructs.cpp
@@ -388,6 +388,14 @@ cvCreateSeq( int seq_flags, size_t header_size, size_t elem_size, CvMemStorage* 
         int elemtype = CV_MAT_TYPE(seq_flags);
         int typesize = CV_ELEM_SIZE(elemtype);
 
+        if (elemtype != CV_SEQ_ELTYPE_PTR && typesize != (int)elem_size)
+        {
+            /* Failover to backwards-compatibility */
+            elemtype = CV_MAKETYPE(seq_flags & 7, ((seq_flags >> 3) & 0x1FF) + 1);
+            typesize = CV_ELEM_SIZE(elemtype);
+            seq->flags = (seq->flags & ~CV_MAT_TYPE_MASK) | elemtype;
+        }
+
         if( elemtype != CV_SEQ_ELTYPE_GENERIC && elemtype != CV_SEQ_ELTYPE_PTR &&
             typesize != 0 && typesize != (int)elem_size )
             CV_Error( CV_StsBadSize,

--- a/modules/core/src/matrix.cpp
+++ b/modules/core/src/matrix.cpp
@@ -343,7 +343,7 @@ void Mat::create(int d, const int* _sizes, int _type)
     release();
     if( d == 0 )
         return;
-    flags = (_type & CV_MAT_TYPE_MASK) | MAGIC_VAL;
+    flags = MAGIC_VAL | CV_MAT_TYPE(_type);
     setSize(*this, d, _sizes, 0, true);
 
     if( total() > 0 )
@@ -801,7 +801,7 @@ Mat Mat::reshape(int new_cn, int new_rows) const
     {
         if( new_rows == 0 && new_cn != 0 && size[dims-1]*cn % new_cn == 0 )
         {
-            hdr.flags = (hdr.flags & ~CV_MAT_CN_MASK) | ((new_cn-1) << CV_CN_SHIFT);
+            hdr.flags = (hdr.flags & ~CV_MAT_TYPE_MASK) | CV_MAKETYPE(CV_MAT_DEPTH(hdr.flags), new_cn);
             hdr.step[dims-1] = CV_ELEM_SIZE(hdr.flags);
             hdr.size[dims-1] = hdr.size[dims-1]*cn / new_cn;
             return hdr;
@@ -850,7 +850,7 @@ Mat Mat::reshape(int new_cn, int new_rows) const
         "The total width is not divisible by the new number of channels" );
 
     hdr.cols = new_width;
-    hdr.flags = (hdr.flags & ~CV_MAT_CN_MASK) | ((new_cn-1) << CV_CN_SHIFT);
+    hdr.flags = (hdr.flags & ~CV_MAT_TYPE_MASK) | CV_MAKETYPE(CV_MAT_DEPTH(hdr.flags), new_cn);
     hdr.step[1] = CV_ELEM_SIZE(hdr.flags);
     return hdr;
 }
@@ -897,7 +897,7 @@ Mat Mat::reshape(int _cn, int _newndims, const int* _newsz) const
             CV_Error(CV_StsUnmatchedSizes, "Requested and source matrices have different count of elements");
 
         Mat hdr = *this;
-        hdr.flags = (hdr.flags & ~CV_MAT_CN_MASK) | ((_cn-1) << CV_CN_SHIFT);
+        hdr.flags = (hdr.flags & ~CV_MAT_TYPE_MASK) | CV_MAKETYPE(CV_MAT_DEPTH(hdr.flags), _cn);
         setSize(hdr, _newndims, newsz_buf.data(), NULL, true);
 
         return hdr;

--- a/modules/core/src/matrix_c.cpp
+++ b/modules/core/src/matrix_c.cpp
@@ -35,7 +35,7 @@ static Mat cvMatToMat(const CvMat* m, bool copyData)
 
     if( !copyData )
     {
-        thiz.flags = Mat::MAGIC_VAL + (m->type & (CV_MAT_TYPE_MASK|CV_MAT_CONT_FLAG));
+        thiz.flags = Mat::MAGIC_VAL + (m->type & (0xFFF | CV_MAT_CONT_FLAG));
         thiz.dims = 2;
         thiz.rows = m->rows;
         thiz.cols = m->cols;
@@ -63,7 +63,7 @@ static Mat cvMatNDToMat(const CvMatND* m, bool copyData)
     if( !m )
         return thiz;
     thiz.datastart = thiz.data = m->data.ptr;
-    thiz.flags |= CV_MAT_TYPE(m->type);
+    thiz.flags |= m->type & 0xFFF;
     int _sizes[CV_MAX_DIM];
     size_t _steps[CV_MAX_DIM];
 
@@ -164,7 +164,7 @@ Mat cvarrToMat(const CvArr* arr, bool copyData,
     if( CV_IS_SEQ(arr) )
     {
         CvSeq* seq = (CvSeq*)arr;
-        int total = seq->total, type = CV_MAT_TYPE(seq->flags), esz = seq->elem_size;
+        int total = seq->total, type = seq->flags & 0xFFF, esz = seq->elem_size;
         if( total == 0 )
             return Mat();
         CV_Assert(total > 0 && CV_ELEM_SIZE(seq->flags) == esz);
@@ -289,7 +289,7 @@ cvRange( CvArr* arr, double start, double end )
 
     int rows = mat->rows;
     int cols = mat->cols;
-    int type = CV_MAT_TYPE(mat->type);
+    int type = mat->type & 0xFFF;
     double delta = (end-start)/(rows*cols);
 
     if( CV_IS_MAT_CONT(mat->type) )

--- a/modules/core/src/persistence.cpp
+++ b/modules/core/src/persistence.cpp
@@ -647,7 +647,7 @@ int icvDecodeSimpleFormat( const char* dt )
     int fmt_pairs[CV_FS_MAX_FMT_PAIRS], fmt_pair_count;
 
     fmt_pair_count = icvDecodeFormat( dt, fmt_pairs, CV_FS_MAX_FMT_PAIRS );
-    if( fmt_pair_count != 1 || fmt_pairs[0] >= CV_CN_MAX)
+    if( fmt_pair_count != 1 || fmt_pairs[0] > CV_CN_MAX)
         CV_Error( CV_StsError, "Too complex format for the matrix" );
 
     elem_type = CV_MAKETYPE( fmt_pairs[1], fmt_pairs[0] );

--- a/modules/core/src/umatrix.cpp
+++ b/modules/core/src/umatrix.cpp
@@ -430,7 +430,7 @@ void UMat::create(int d, const int* _sizes, int _type, UMatUsageFlags _usageFlag
     release();
     if( d == 0 )
         return;
-    flags = (_type & CV_MAT_TYPE_MASK) | MAGIC_VAL;
+    flags = MAGIC_VAL | CV_MAT_TYPE(_type);
     setSize(*this, d, _sizes, 0, true);
     offset = 0;
 
@@ -690,7 +690,7 @@ UMat UMat::reshape(int new_cn, int new_rows) const
 
     if( dims > 2 && new_rows == 0 && new_cn != 0 && size[dims-1]*cn % new_cn == 0 )
     {
-        hdr.flags = (hdr.flags & ~CV_MAT_CN_MASK) | ((new_cn-1) << CV_CN_SHIFT);
+        hdr.flags = (hdr.flags & ~CV_MAT_TYPE_MASK) | CV_MAKETYPE(CV_MAT_DEPTH(hdr.flags), new_cn);
         hdr.step[dims-1] = CV_ELEM_SIZE(hdr.flags);
         hdr.size[dims-1] = hdr.size[dims-1]*cn / new_cn;
         return hdr;
@@ -733,7 +733,7 @@ UMat UMat::reshape(int new_cn, int new_rows) const
         "The total width is not divisible by the new number of channels" );
 
     hdr.cols = new_width;
-    hdr.flags = (hdr.flags & ~CV_MAT_CN_MASK) | ((new_cn-1) << CV_CN_SHIFT);
+    hdr.flags = (hdr.flags & ~CV_MAT_TYPE_MASK) | CV_MAKETYPE(CV_MAT_DEPTH(hdr.flags), new_cn);
     hdr.step[1] = CV_ELEM_SIZE(hdr.flags);
     return hdr;
 }
@@ -804,7 +804,7 @@ UMat UMat::reshape(int _cn, int _newndims, const int* _newsz) const
             CV_Error(CV_StsUnmatchedSizes, "Requested and source matrices have different count of elements");
 
         UMat hdr = *this;
-        hdr.flags = (hdr.flags & ~CV_MAT_CN_MASK) | ((_cn-1) << CV_CN_SHIFT);
+        hdr.flags = (hdr.flags & ~CV_MAT_TYPE_MASK) | CV_MAKETYPE(CV_MAT_DEPTH(hdr.flags), _cn);
         setSize(hdr, _newndims, newsz_buf.data(), NULL, true);
 
         return hdr;

--- a/modules/core/test/ocl/test_channels.cpp
+++ b/modules/core/test/ocl/test_channels.cpp
@@ -79,7 +79,8 @@ PARAM_TEST_CASE(Merge, MatDepth, int, bool)
 
     int type()
     {
-        return CV_MAKE_TYPE(depth, randomInt(1, 3));
+        int rnd_cn = randomInt(1, 3);
+        return CV_MAKETYPE(depth, rnd_cn);
     }
 
     void generateTestData()

--- a/modules/core/test/test_dxt.cpp
+++ b/modules/core/test/test_dxt.cpp
@@ -589,7 +589,7 @@ void CxCore_DXTBaseTest::get_test_array_types_and_sizes( int test_case_idx,
     {
         if( cn == 1 )
         {
-            types[OUTPUT][0] = depth + 8;
+            types[OUTPUT][0] = CV_MAKETYPE(depth, 2);
             sizes[TEMP][0] = size;
         }
         sizes[INPUT][0] = sizes[INPUT][1] = size;
@@ -597,7 +597,7 @@ void CxCore_DXTBaseTest::get_test_array_types_and_sizes( int test_case_idx,
     }
     else if( /*(cn == 2 && (bits&32)) ||*/ (cn == 1 && allow_complex) )
     {
-        types[TEMP][0] = depth + 8; // CV_??FC2
+        types[TEMP][0] = CV_MAKETYPE(depth, 2);
         sizes[TEMP][0] = size;
         size = cvSize(size.width/2+1, size.height);
 
@@ -614,7 +614,7 @@ void CxCore_DXTBaseTest::get_test_array_types_and_sizes( int test_case_idx,
         else
         {
             if( allow_complex )
-                types[OUTPUT][0] = depth + 8;
+                types[OUTPUT][0] = CV_MAKETYPE(depth, 2);
 
             if( cn == 2 )
             {

--- a/modules/core/test/test_math.cpp
+++ b/modules/core/test/test_math.cpp
@@ -635,7 +635,7 @@ void Core_GEMMTest::get_test_array_types_and_sizes( int test_case_idx, vector<ve
     Base::get_test_array_types_and_sizes( test_case_idx, sizes, types );
     sizes[INPUT][0] = sizeA;
     sizes[INPUT][2] = sizes[INPUT][3] = Size(1,1);
-    types[INPUT][2] = types[INPUT][3] &= ~CV_MAT_CN_MASK;
+    types[INPUT][2] = types[INPUT][3] = CV_MAT_DEPTH(types[INPUT][2]);
 
     tabc_flag = cvtest::randInt(rng) & 7;
 
@@ -862,7 +862,7 @@ void Core_TransformTest::get_test_array_types_and_sizes( int test_case_idx, vect
             sizes[INPUT][2] = Size(dst_cn,1);
         else
             sizes[INPUT][2] = Size(1,dst_cn);
-        types[INPUT][2] &= ~CV_MAT_CN_MASK;
+        types[INPUT][2] = CV_MAT_DEPTH(types[INPUT][2]);
     }
     diagMtx = (bits & 16) != 0;
 
@@ -955,7 +955,7 @@ void Core_TransformLargeTest::get_test_array_types_and_sizes(int test_case_idx, 
             sizes[INPUT][2] = Size(dst_cn, 1);
         else
             sizes[INPUT][2] = Size(1, dst_cn);
-        types[INPUT][2] &= ~CV_MAT_CN_MASK;
+        types[INPUT][2] = CV_MAT_DEPTH(types[INPUT][2]);
     }
     diagMtx = (bits & 16) != 0;
 
@@ -1257,7 +1257,7 @@ void Core_CovarMatrixTest::get_test_array_types_and_sizes( int test_case_idx, ve
         flags = (flags & ~CV_COVAR_ROWS) | CV_COVAR_COLS;
 
     if( CV_MAT_DEPTH(types[INPUT][0]) == CV_32S )
-        types[INPUT][0] = (types[INPUT][0] & ~CV_MAT_DEPTH_MASK) | CV_32F;
+        types[INPUT][0] = CV_MAKETYPE(CV_32F, CV_MAT_CN(types[INPUT][0]));
 
     sizes[OUTPUT][0] = sizes[REF_OUTPUT][0] = flags & CV_COVAR_NORMAL ? Size(len,len) : Size(count,count);
     sizes[INPUT_OUTPUT][0] = sizes[REF_INPUT_OUTPUT][0] = !t_flag ? Size(len,1) : Size(1,len);

--- a/modules/core/test/test_umat.cpp
+++ b/modules/core/test/test_umat.cpp
@@ -168,7 +168,10 @@ TEST_P(UMatBasicTests, base)
         sz[i] = randomInt(1,45);
         total *= (size_t)sz[i];
     }
-    int new_type = CV_MAKE_TYPE(randomInt(CV_8S,CV_64F),randomInt(1,4));
+    vector<int> depths {CV_8U, CV_16U, CV_32U, CV_64U, CV_8S, CV_16S, CV_32S, CV_64S, CV_32F, CV_64F};
+    int rnd_depth = depths[rng.uniform(0, (int)depths.size())];
+    int rnd_cn = randomInt(1,4);
+    int new_type = CV_MAKETYPE(rnd_depth, rnd_cn);
     ub = UMat(dims, sz, new_type);
     ASSERT_EQ(ub.total(), total);
 }

--- a/modules/imgcodecs/src/utils.cpp
+++ b/modules/imgcodecs/src/utils.cpp
@@ -636,7 +636,7 @@ cvConvertImage( const CvArr* srcarr, CvArr* dstarr, int flags )
         if( !CV_ARE_CNS_EQ( src, dst ))
         {
             temp = cvCreateMat( src->height, src->width,
-                (src->type & CV_MAT_CN_MASK)|(dst->type & CV_MAT_DEPTH_MASK));
+                CV_MAKETYPE(CV_MAT_DEPTH(dst->type), CV_MAT_CN(src->type)));
             cvConvertScale( src, temp, scale, shift );
             src = temp;
         }

--- a/modules/imgproc/misc/java/test/ImgprocTest.java
+++ b/modules/imgproc/misc/java/test/ImgprocTest.java
@@ -216,19 +216,19 @@ public class ImgprocTest extends OpenCVTestCase {
 
     public void testBoxFilterMatMatIntSize() {
         Size size = new Size(3, 3);
-        Imgproc.boxFilter(gray0, dst, 8, size);
+        Imgproc.boxFilter(gray0, dst, CvType.CV_8U, size);
         assertMatEqual(gray0, dst);
         // TODO_: write better test
     }
 
     public void testBoxFilterMatMatIntSizePointBoolean() {
-        Imgproc.boxFilter(gray255, dst, 8, size, anchorPoint, false);
+        Imgproc.boxFilter(gray255, dst, CvType.CV_8U, size, anchorPoint, false);
         assertMatEqual(gray255, dst);
         // TODO_: write better test
     }
 
     public void testBoxFilterMatMatIntSizePointBooleanInt() {
-        Imgproc.boxFilter(gray255, dst, 8, size, anchorPoint, false, Core.BORDER_REFLECT);
+        Imgproc.boxFilter(gray255, dst, CvType.CV_8U, size, anchorPoint, false, Core.BORDER_REFLECT);
         assertMatEqual(gray255, dst);
         // TODO_: write better test
     }

--- a/modules/imgproc/src/histogram.cpp
+++ b/modules/imgproc/src/histogram.cpp
@@ -889,7 +889,7 @@ void cv::calcHist( const Mat* images, int nimages, const int* channels,
         ipp_calchist(images[0], hist, histSize[0], ranges, uniform, accumulate));
 
     Mat ihist = hist;
-    ihist.flags = (ihist.flags & ~CV_MAT_TYPE_MASK)|CV_32S;
+    ihist.flags = (ihist.flags & ~CV_MAT_TYPE_MASK) | CV_32S;
 
     if(!accumulate)
         hist = Scalar(0.);

--- a/modules/imgproc/test/test_color.cpp
+++ b/modules/imgproc/test/test_color.cpp
@@ -441,7 +441,7 @@ void CV_ColorGrayTest::get_test_array_types_and_sizes( int test_case_idx, vector
 {
     CV_ColorCvtBaseTest::get_test_array_types_and_sizes( test_case_idx, sizes, types );
     int cn = CV_MAT_CN(types[INPUT][0]);
-    types[OUTPUT][0] = types[REF_OUTPUT][0] = types[INPUT][0] & CV_MAT_DEPTH_MASK;
+    types[OUTPUT][0] = types[REF_OUTPUT][0] = CV_MAT_DEPTH(types[INPUT][0]);
     inplace = false;
 
     if( cn == 3 )

--- a/modules/imgproc/test/test_convhull.cpp
+++ b/modules/imgproc/test/test_convhull.cpp
@@ -401,7 +401,7 @@ void CV_BaseShapeDescrTest::extract_points()
     if( CV_MAT_DEPTH(points2->type) != CV_32F && enable_flt_points )
     {
         CvMat tmp = cvMat( points2->rows, points2->cols,
-            (points2->type & ~CV_MAT_DEPTH_MASK) | CV_32F, points2->data.ptr );
+            CV_MAKETYPE(CV_32F, CV_MAT_CN(points2->type)), points2->data.ptr );
         cvConvert( points2, &tmp );
     }
 }

--- a/modules/imgproc/test/test_templmatch.cpp
+++ b/modules/imgproc/test/test_templmatch.cpp
@@ -149,8 +149,8 @@ static void cvTsMatchTemplate( const CvMat* img, const CvMat* templ, CvMat* resu
     int i, j, k, l;
     int depth = CV_MAT_DEPTH(img->type), cn = CV_MAT_CN(img->type);
     int width_n = templ->cols*cn, height = templ->rows;
-    int a_step = img->step / CV_ELEM_SIZE(img->type & CV_MAT_DEPTH_MASK);
-    int b_step = templ->step / CV_ELEM_SIZE(templ->type & CV_MAT_DEPTH_MASK);
+    int a_step = img->step / CV_ELEM_SIZE(CV_MAT_DEPTH(img->type));
+    int b_step = templ->step / CV_ELEM_SIZE(CV_MAT_DEPTH(templ->type));
     CvScalar b_mean = CV_STRUCT_INITIALIZER, b_sdv = CV_STRUCT_INITIALIZER;
     double b_denom = 1., b_sum2 = 0;
     int area = templ->rows*templ->cols;

--- a/modules/ts/src/ts_perf.cpp
+++ b/modules/ts/src/ts_perf.cpp
@@ -464,6 +464,9 @@ void Regression::verify(cv::FileNode node, cv::InputArray array, double eps, ERR
 {
     int expected_kind = (int)node["kind"];
     int expected_type = (int)node["type"];
+
+    if (expected_type != array.type()) /* Failover to backwards-compatibility */
+        expected_type = CV_MAKETYPE(expected_type & 7, ((expected_type >> 3) & 0x1FF) + 1);
     ASSERT_EQ(expected_kind, array.kind()) << "  Argument \"" << node.name() << "\" has unexpected kind";
     ASSERT_EQ(expected_type, array.type()) << "  Argument \"" << node.name() << "\" has unexpected type";
 


### PR DESCRIPTION
Merge with opencv/opencv_contrib#1807
replaces #12611
resolves #12584
related #12569

### This pullrequest changes
- Increase the supported depth types limit from 8 to 32
  - Introduced uint32, uint64, int64 and other special formats (i.e. raw, auto, undefined)
- Increase the supported channels limit from 512 to 2048 (still extensible with further design work)
  - Use the next available (bigger) number of channels in case of invalid channel input
  - Great impact expected on various modules (e.g. DNN and feature2D)
- Fully-backwards compatible with serialized files generated using older OpenCV versions

```
force_builders=Custom,Linux32,Win32,Win64 MSVS2017,ARMv7,ARMv8,Android pack
docker_image:Docs=docs-js
docker_image:Custom=ubuntu-cuda:16.04
```