### PR TITLE
Add check for CALIB_USE_EXTRINSIC_GUESS in stereoCalibrate

### DIFF
--- a/modules/calib3d/src/calibration.cpp
+++ b/modules/calib3d/src/calibration.cpp
@@ -3541,7 +3541,7 @@ double cv::stereoCalibrate( InputArrayOfArrays _objectPoints,
                           TermCriteria criteria)
 {
     if (flags & CALIB_USE_EXTRINSIC_GUESS)
-        CV_Error(CV_StsBadFlag, "stereoCalibrate does not support CALIB_USE_EXTRINSIC_GUESS.");
+        CV_Error(Error::StsBadFlag, "stereoCalibrate does not support CALIB_USE_EXTRINSIC_GUESS.");
 
     Mat Rmat, Tmat;
     double ret = stereoCalibrate(_objectPoints, _imagePoints1, _imagePoints2, _cameraMatrix1, _distCoeffs1,

--- a/modules/calib3d/src/calibration.cpp
+++ b/modules/calib3d/src/calibration.cpp
@@ -3540,6 +3540,9 @@ double cv::stereoCalibrate( InputArrayOfArrays _objectPoints,
                           OutputArray _Emat, OutputArray _Fmat, int flags,
                           TermCriteria criteria)
 {
+    if (flags & CALIB_USE_EXTRINSIC_GUESS)
+        CV_Error(CV_StsBadFlag, "stereoCalibrate does not support CALIB_USE_EXTRINSIC_GUESS.");
+
     Mat Rmat, Tmat;
     double ret = stereoCalibrate(_objectPoints, _imagePoints1, _imagePoints2, _cameraMatrix1, _distCoeffs1,
                                  _cameraMatrix2, _distCoeffs2, imageSize, Rmat, Tmat, _Emat, _Fmat,


### PR DESCRIPTION
resolves #12012 
related #12334 

I've added a check for CALIB_USE_EXTRINSIC_GUESS such that an error is raised if this flag is set in stereoCalibrate. This commit is created to fix issue #12012.