### PR TITLE
cudastereo: fix test failure of StereoBeliefPropagation

### DIFF
--- a/modules/cudastereo/src/cuda/stereobp.cu
+++ b/modules/cudastereo/src/cuda/stereobp.cu
@@ -255,7 +255,7 @@ namespace cv { namespace cuda { namespace device
         ///////////////////////////////////////////////////////////////
 
         template <typename T>
-        __global__ void data_step_down(int dst_cols, int dst_rows, int src_rows, const PtrStep<T> src, PtrStep<T> dst)
+        __global__ void data_step_down(int dst_cols, int dst_rows, int src_cols, int src_rows, const PtrStep<T> src, PtrStep<T> dst)
         {
             const int x = blockIdx.x * blockDim.x + threadIdx.x;
             const int y = blockIdx.y * blockDim.y + threadIdx.y;
@@ -264,10 +264,15 @@ namespace cv { namespace cuda { namespace device
             {
                 for (int d = 0; d < cndisp; ++d)
                 {
-                    float dst_reg  = src.ptr(d * src_rows + (2*y+0))[(2*x+0)];
-                          dst_reg += src.ptr(d * src_rows + (2*y+1))[(2*x+0)];
-                          dst_reg += src.ptr(d * src_rows + (2*y+0))[(2*x+1)];
-                          dst_reg += src.ptr(d * src_rows + (2*y+1))[(2*x+1)];
+                    // check the index of src
+                    const int x0 = 2 * x;
+                    const int x1 = ::min(x0 + 1, src_cols - 1);
+                    const int y0 = 2 * y;
+                    const int y1 = ::min(y0 + 1, src_rows - 1);
+                    float dst_reg  = src.ptr(d * src_rows + y0)[x0];
+                          dst_reg += src.ptr(d * src_rows + y1)[x0];
+                          dst_reg += src.ptr(d * src_rows + y0)[x1];
+                          dst_reg += src.ptr(d * src_rows + y1)[x1];
 
                     dst.ptr(d * dst_rows + y)[x] = saturate_cast<T>(dst_reg);
                 }
@@ -275,7 +280,7 @@ namespace cv { namespace cuda { namespace device
         }
 
         template<typename T>
-        void data_step_down_gpu(int dst_cols, int dst_rows, int src_rows, const PtrStepSzb& src, const PtrStepSzb& dst, cudaStream_t stream)
+        void data_step_down_gpu(int dst_cols, int dst_rows, int src_cols, int src_rows, const PtrStepSzb& src, const PtrStepSzb& dst, cudaStream_t stream)
         {
             dim3 threads(32, 8, 1);
             dim3 grid(1, 1, 1);
@@ -283,15 +288,15 @@ namespace cv { namespace cuda { namespace device
             grid.x = divUp(dst_cols, threads.x);
             grid.y = divUp(dst_rows, threads.y);
 
-            data_step_down<T><<<grid, threads, 0, stream>>>(dst_cols, dst_rows, src_rows, (PtrStepSz<T>)src, (PtrStepSz<T>)dst);
+            data_step_down<T><<<grid, threads, 0, stream>>>(dst_cols, dst_rows, src_cols, src_rows, (PtrStepSz<T>)src, (PtrStepSz<T>)dst);
             cudaSafeCall( cudaGetLastError() );
 
             if (stream == 0)
                 cudaSafeCall( cudaDeviceSynchronize() );
         }
 
-        template void data_step_down_gpu<short>(int dst_cols, int dst_rows, int src_rows, const PtrStepSzb& src, const PtrStepSzb& dst, cudaStream_t stream);
-        template void data_step_down_gpu<float>(int dst_cols, int dst_rows, int src_rows, const PtrStepSzb& src, const PtrStepSzb& dst, cudaStream_t stream);
+        template void data_step_down_gpu<short>(int dst_cols, int dst_rows, int src_cols, int src_rows, const PtrStepSzb& src, const PtrStepSzb& dst, cudaStream_t stream);
+        template void data_step_down_gpu<float>(int dst_cols, int dst_rows, int src_cols, int src_rows, const PtrStepSzb& src, const PtrStepSzb& dst, cudaStream_t stream);
 
         ///////////////////////////////////////////////////////////////
         /////////////////// level up messages  ////////////////////////

--- a/modules/cudastereo/src/stereobp.cpp
+++ b/modules/cudastereo/src/stereobp.cpp
@@ -61,7 +61,7 @@ namespace cv { namespace cuda { namespace device
         template<typename T, typename D>
         void comp_data_gpu(const PtrStepSzb& left, const PtrStepSzb& right, const PtrStepSzb& data, cudaStream_t stream);
         template<typename T>
-        void data_step_down_gpu(int dst_cols, int dst_rows, int src_rows, const PtrStepSzb& src, const PtrStepSzb& dst, cudaStream_t stream);
+        void data_step_down_gpu(int dst_cols, int dst_rows, int src_cols, int src_rows, const PtrStepSzb& src, const PtrStepSzb& dst, cudaStream_t stream);
         template <typename T>
         void level_up_messages_gpu(int dst_idx, int dst_cols, int dst_rows, int src_rows, PtrStepSzb* mus, PtrStepSzb* mds, PtrStepSzb* mls, PtrStepSzb* mrs, cudaStream_t stream);
         template <typename T>
@@ -283,7 +283,7 @@ namespace
     {
         using namespace cv::cuda::device::stereobp;
 
-        typedef void (*data_step_down_t)(int dst_cols, int dst_rows, int src_rows, const PtrStepSzb& src, const PtrStepSzb& dst, cudaStream_t stream);
+        typedef void (*data_step_down_t)(int dst_cols, int dst_rows, int src_cols, int src_rows, const PtrStepSzb& src, const PtrStepSzb& dst, cudaStream_t stream);
         static const data_step_down_t data_step_down_callers[2] =
         {
             data_step_down_gpu<short>, data_step_down_gpu<float>
@@ -318,7 +318,7 @@ namespace
 
             datas_[i].create(rows_all_[i] * ndisp_, cols_all_[i], msg_type_);
 
-            data_step_down_callers[funcIdx](cols_all_[i], rows_all_[i], rows_all_[i-1], datas_[i-1], datas_[i], stream);
+            data_step_down_callers[funcIdx](cols_all_[i], rows_all_[i], cols_all_[i-1], rows_all_[i-1], datas_[i-1], datas_[i], stream);
         }
 
         PtrStepSzb mus[] = {u_, u2_};


### PR DESCRIPTION
### This pullrequest changes
  * if the src has odd number of height, access error happens
  * check both dst and src range

<!-- Please use this line to close one or multiple issues when this pullrequest gets merged
You can add another line right under the first one:
resolves #1234
resolves #1235
-->
Before
```
Device count: 1

Device 0: "GeForce GTX 1060"
  CUDA Driver Version / Runtime Version          10.0 / 10.0
  CUDA Capability Major/Minor version number:    6.1
  Total amount of global memory:                 6144 MBytes (6442450944 bytes)
  GPU Clock Speed:                               1.57 GHz
  Max Texture Dimension Size (x,y,z)             1D=(131072), 2D=(131072,65536), 3D=(16384,16384,16384)
  Max Layered Texture Size (dim) x layers        1D=(32768) x 2048, 2D=(32768,32768) x 2048
  Total amount of constant memory:               65536 bytes
  Total amount of shared memory per block:       49152 bytes
  Total number of registers available per block: 65536
  Warp size:                                     32
  Maximum number of threads per block:           1024
  Maximum sizes of each dimension of a block:    1024 x 1024 x 64
  Maximum sizes of each dimension of a grid:     2147483647 x 65535 x 65535
  Maximum memory pitch:                          2147483647 bytes
  Texture alignment:                             512 bytes
  Concurrent copy and execution:                 Yes with 5 copy engine(s)
  Run time limit on kernels:                     Yes
  Integrated GPU sharing Host Memory:            No
  Support host page-locked memory mapping:       Yes
  Concurrent kernel execution:                   Yes
  Alignment requirement for Surfaces:            Yes
  Device has ECC support enabled:                No
  Device is using TCC driver mode:               No
  Device supports Unified Addressing (UVA):      Yes
  Device PCI Bus ID / PCI location ID:           2 / 0
  Compute Mode:
      Default (multiple host threads can use ::cudaSetDevice() with device simultaneously)

deviceQuery, CUDA Driver = CUDART, CUDA Driver Version  = 10.0, CUDA Runtime Version = 10.0, NumDevs = 1

CTEST_FULL_OUTPUT
OpenCV version: 3.4.3-dev
OpenCV VCS version: 3.4.3-249-g1ef735e48-dirty
Build type: N/A
WARNING: build value differs from runtime: Debug
Compiler: C:/Program Files (x86)/Microsoft Visual Studio 14.0/VC/bin/x86_amd64/cl.exe  (ver 19.0.24215.1)
Parallel framework: ms-concurrency
CPU features: SSE? SSE2? SSE3? *SSE4.1? *SSE4.2? *FP16? *AVX? *AVX2?
Intel(R) IPP version: disabled
[ INFO:0] Initialize OpenCL runtime...
OpenCL is disabled
Note: Google Test filter = *StereoBeliefPropagation*
[==========] Running 1 test from 1 test case.
[----------] Global test environment set-up.
[----------] 1 test from CUDA_Stereo/StereoBeliefPropagation
[ RUN      ] CUDA_Stereo/StereoBeliefPropagation.Regression/0, where GetParam() = GeForce GTX 1060
unknown file: error: C++ exception with description "OpenCV(3.4.3-dev) C:/work/opencv-fork/modules/cudastereo/src/cuda/stereobp.cu:298: error: (-217:Gpu API call) an illegal memory access was encountered in function 'cv::cuda::device::stereobp::data_step_down_gpu'
" thrown in the test body.
[  FAILED  ] CUDA_Stereo/StereoBeliefPropagation.Regression/0, where GetParam() = GeForce GTX 1060 (62009 ms)
[----------] 1 test from CUDA_Stereo/StereoBeliefPropagation (62041 ms total)

[----------] Global test environment tear-down
[==========] 1 test from 1 test case ran. (62102 ms total)
[  PASSED  ] 0 tests.
[  FAILED  ] 1 test, listed below:
[  FAILED  ] CUDA_Stereo/StereoBeliefPropagation.Regression/0, where GetParam() = GeForce GTX 1060

 1 FAILED TEST
```

after
```
Device count: 1

Device 0: "GeForce GTX 1060"
  CUDA Driver Version / Runtime Version          10.0 / 10.0
  CUDA Capability Major/Minor version number:    6.1
  Total amount of global memory:                 6144 MBytes (6442450944 bytes)
  GPU Clock Speed:                               1.57 GHz
  Max Texture Dimension Size (x,y,z)             1D=(131072), 2D=(131072,65536), 3D=(16384,16384,16384)
  Max Layered Texture Size (dim) x layers        1D=(32768) x 2048, 2D=(32768,32768) x 2048
  Total amount of constant memory:               65536 bytes
  Total amount of shared memory per block:       49152 bytes
  Total number of registers available per block: 65536
  Warp size:                                     32
  Maximum number of threads per block:           1024
  Maximum sizes of each dimension of a block:    1024 x 1024 x 64
  Maximum sizes of each dimension of a grid:     2147483647 x 65535 x 65535
  Maximum memory pitch:                          2147483647 bytes
  Texture alignment:                             512 bytes
  Concurrent copy and execution:                 Yes with 5 copy engine(s)
  Run time limit on kernels:                     Yes
  Integrated GPU sharing Host Memory:            No
  Support host page-locked memory mapping:       Yes
  Concurrent kernel execution:                   Yes
  Alignment requirement for Surfaces:            Yes
  Device has ECC support enabled:                No
  Device is using TCC driver mode:               No
  Device supports Unified Addressing (UVA):      Yes
  Device PCI Bus ID / PCI location ID:           2 / 0
  Compute Mode:
      Default (multiple host threads can use ::cudaSetDevice() with device simultaneously)

deviceQuery, CUDA Driver = CUDART, CUDA Driver Version  = 10.0, CUDA Runtime Version = 10.0, NumDevs = 1

CTEST_FULL_OUTPUT
OpenCV version: 3.4.3-dev
OpenCV VCS version: 3.4.3-249-g1ef735e48-dirty
Build type: N/A
WARNING: build value differs from runtime: Debug
Compiler: C:/Program Files (x86)/Microsoft Visual Studio 14.0/VC/bin/x86_amd64/cl.exe  (ver 19.0.24215.1)
Parallel framework: ms-concurrency
CPU features: SSE? SSE2? SSE3? *SSE4.1? *SSE4.2? *FP16? *AVX? *AVX2?
Intel(R) IPP version: disabled
[ INFO:0] Initialize OpenCL runtime...
OpenCL is disabled
Note: Google Test filter = *StereoBeliefPropagation*
[==========] Running 1 test from 1 test case.
[----------] Global test environment set-up.
[----------] 1 test from CUDA_Stereo/StereoBeliefPropagation
[ RUN      ] CUDA_Stereo/StereoBeliefPropagation.Regression/0, where GetParam() = GeForce GTX 1060
[       OK ] CUDA_Stereo/StereoBeliefPropagation.Regression/0 (338 ms)
[----------] 1 test from CUDA_Stereo/StereoBeliefPropagation (345 ms total)

[----------] Global test environment tear-down
[==========] 1 test from 1 test case ran. (363 ms total)
[  PASSED  ] 1 test.
```

#### Description
The error was caused in the ```data_step_down``` (as shown above).  This kernel reduces ```src``` to ```dst``` by half in both height and width.
https://github.com/opencv/opencv/blob/fc59498b2b3fee27d7dbcb6be7f19090a50024ed/modules/cudastereo/src/stereobp.cpp#L316-L317
```rows_all_[i]``` and ```cols_all_[i]``` stands for size of ```dst``` and the right hand adds ```1``` before making it half.
Thus, the corner case existed when the src image has height of odd number


```
force_builders=Custom
docker_image:Custom=ubuntu-cuda:16.04
```