### PR TITLE
Refactoring in CommandLineParser (use std::string and std::regex)

### DIFF
--- a/modules/core/include/opencv2/core/utility.hpp
+++ b/modules/core/include/opencv2/core/utility.hpp
@@ -821,12 +821,6 @@ public:
     */
     CommandLineParser(int argc, const char* const argv[], const String& keys);
 
-    /** @brief Copy constructor */
-    CommandLineParser(const CommandLineParser& parser);
-
-    /** @brief Assignment operator */
-    CommandLineParser& operator = (const CommandLineParser& parser);
-
     /** @brief Destructor */
     ~CommandLineParser();
 
@@ -945,6 +939,13 @@ public:
     @sa check
     */
     void printErrors() const;
+
+private:
+    /** @brief Copy constructor */
+    CommandLineParser(const CommandLineParser& parser);
+
+    /** @brief Assignment operator */
+    CommandLineParser& operator = (const CommandLineParser& parser);
 
 protected:
     void getByName(const String& name, bool space_delete, Param type, void* dst) const;

--- a/modules/core/src/command_line_parser.cpp
+++ b/modules/core/src/command_line_parser.cpp
@@ -287,7 +287,7 @@ inline bool from_str<bool>(const string& line, void* dst)
     string str;
     input >> str;
     str = cv::toLowerCase(str);
-    bool val;
+    bool val = false;
     if (str == "false" || str == "0")
         val = false;
     else if (str == "true" || str == "1")

--- a/modules/core/src/command_line_parser.cpp
+++ b/modules/core/src/command_line_parser.cpp
@@ -3,551 +3,428 @@
 // of this distribution and at http://opencv.org/license.html.
 #include "precomp.hpp"
 #include <sstream>
+#include <iostream>
+#include <regex>
+#include "opencv2/core/check.hpp"
 
-namespace cv
-{
+using std::cout;
+using std::endl;
+using std::for_each;
+using std::string;
+using std::vector;
+using namespace std::placeholders;
 
 namespace {
-static const char* noneValue = "<none>";
 
-static String cat_string(const String& str)
+static const string magic_none_value = "<none>";
+
+inline static string trim(const string& str)
 {
-    int left = 0, right = (int)str.length();
-    while( left < right && str[left] == ' ' )
-        left++;
-    while( right > left && str[right-1] == ' ' )
-        right--;
-    return left >= right ? String("") : str.substr(left, right-left);
+    const string::size_type first_nonspace = str.find_first_not_of(" \t\n\r");
+    const string::size_type last_nonspace = str.find_last_not_of(" \t\n\r");
+    if (first_nonspace == string::npos || last_nonspace == string::npos)
+        return string();
+    return str.substr(first_nonspace, last_nonspace - first_nonspace + 1);
 }
+
+inline static string trim1(const string& str)
+{
+    return str.substr(1, str.size() - 1);
 }
+
+inline static std::vector<string> split_string(string str, char symbol)
+{
+    vector<string> vec;
+    string::size_type pos = str.find_first_not_of(symbol);
+    while (pos != string::npos)
+    {
+        const string::size_type end_pos = str.find_first_of(symbol, pos);
+        if (end_pos != string::npos)
+        {
+            vec.push_back(str.substr(pos, end_pos - pos));
+            pos = str.find_first_not_of(symbol, end_pos);
+            continue;
+        }
+        vec.push_back(str.substr(pos, string::npos));
+        break;
+    }
+    return vec;
+}
+
+} // namespace
 
 struct CommandLineParserParams
 {
 public:
-    String help_message;
-    String def_value;
-    std::vector<String> keys;
+    vector<string> keys;
+    string value;
+    string help_message;
     int number;
+    bool isPositional;
+    bool isValid;
+public:
+    CommandLineParserParams() : number(-1), isPositional(false), isValid(false) {}
+    CommandLineParserParams(const vector<string>& keys_, const string& def_value_, const string& help_message_)
+        : keys(keys_), value(def_value_), help_message(trim(help_message_)),
+          number(-1), isValid(true)
+    {
+        CV_Assert(!keys.empty());
+        isPositional = keys[0].find('@') == 0;
+    }
+    inline string getPrintedKey() const
+    {
+        if (isPositional)
+            return trim1(keys[0]);
+        std::ostringstream buf;
+        for (std::vector<string>::const_iterator key = keys.begin(); key != keys.end(); ++key)
+        {
+            buf << (key->length() > 1 ? "--" : "-") << *key;
+            if (key + 1 != keys.end())
+                buf << ", ";
+        }
+        return buf.str();
+    }
+    inline string getPrintedValue() const
+    {
+        const string def = trim(value);
+        if (!def.empty())
+            return " (value:" + def + ")";
+        return string();
+    }
+    inline string getValue(bool trim_spaces = true) const
+    {
+        return trim_spaces ? trim(value) : value;
+    }
+    bool operator<(const CommandLineParserParams & other) const
+    {
+        if (isPositional == other.isPositional)
+            if (number == other.number)
+                return keys[0] < other.keys[0];
+            else
+                return number < other.number;
+        else
+            return isPositional < other.isPositional;
+    }
 };
 
+//==================================================================================================
+
+namespace cv
+{
 
 struct CommandLineParser::Impl
 {
+private:
     bool error;
-    String error_message;
-    String about_message;
-
-    String path_to_app;
-    String app_name;
-
+    std::ostringstream error_message;
+    string about_message;
+    string path_to_app;
+    string app_name;
     std::vector<CommandLineParserParams> data;
+    CommandLineParserParams invalid;
 
-    std::vector<String> split_range_string(const String& str, char fs, char ss) const;
-    std::vector<String> split_string(const String& str, char symbol = ' ', bool create_empty_item = false) const;
+    typedef vector<CommandLineParserParams>::iterator DataIterator;
+    typedef vector<CommandLineParserParams>::const_iterator ConstDataIterator;
+    typedef vector<string>::const_iterator KeysIterator;
+public:
+    Impl(const std::string & keys) : error(false)
+    {
+        // parse keys
+        const std::regex rx("\\{"
+                            "([^\\{\\}\\|]*)" "\\|"
+                            "([^\\{\\}\\|]*)" "\\|"
+                            "([^\\{\\}\\|]*)"
+                            "\\}");
+        auto match_begin = std::sregex_iterator(keys.begin(), keys.end(), rx);
+        auto match_end = std::sregex_iterator();
+        int positional_counter = 0;
+        for (std::sregex_iterator i = match_begin; i != match_end; ++i)
+        {
+            const std::smatch & pieces = *i;
+            const vector<string> parsed_keys = split_string(pieces[1], ' ');
+            CV_CheckGT(parsed_keys.size(), (size_t)0, "Field KEYS can't be empty!");
+            CommandLineParserParams p(parsed_keys, pieces[2], pieces[3]);
+            if (p.isPositional)
+                p.number = positional_counter++;
+            data.push_back(p);
+        }
+    }
+    void parse(int argc, const char * const argv[])
+    {
+        if (argc <= 0)
+            return;
+        // path to application
+        const string appName(argv[0]);
+        const string::size_type pos_s = appName.find_last_of("/\\");
+        if (pos_s == string::npos)
+        {
+            path_to_app = "";
+            app_name = appName;
+        }
+        else
+        {
+            path_to_app = appName.substr(0, pos_s);
+            app_name = appName.substr(pos_s + 1, appName.size() - pos_s);
+        }
 
-    void apply_params(const String& key, const String& value);
-    void apply_params(int i, String value);
+        // parse argv
+        const std::regex bool_rx("--?([^=]+)=?");
+        const std::regex val_rx("--?([^=]+)=(.+)");
+        int positional_counter = 0;
+        for (int i = 1; i < argc; i++)
+        {
+            const string one_arg(argv[i]);
+            std::smatch match;
+            if (std::regex_match(one_arg, match, bool_rx))
+                apply_params(match[1], "true");
+            else if (std::regex_match(one_arg, match, val_rx))
+                apply_params(match[1], match[2]);
+            else
+                apply_params(positional_counter++, one_arg);
+        }
+        sort_params();
+    }
+    CommandLineParserParams& findByName(const std::string& name)
+    {
+        for (DataIterator param = data.begin(); param != data.end(); ++param)
+            for (KeysIterator key = param->keys.begin(); key != param->keys.end(); ++key)
+                if (name == *key)
+                    return *param;
+        return invalid;
+    }
+    CommandLineParserParams& findByIndex(int index)
+    {
+        for (DataIterator param = data.begin(); param != data.end(); ++param)
+            if (param->number == index)
+                return *param;
+        return invalid;
+    }
+    void apply_params(const String& key, const String& value)
+    {
+        CommandLineParserParams& param = findByName(key);
+        if (!param.isValid)
+            return;
+        param.value = value;
+    }
+    void apply_params(int i, String value)
+    {
+        CommandLineParserParams& param = findByIndex(i);
+        if (!param.isValid)
+            return;
+        param.value = value;
+    }
+    void sort_params()
+    {
+        for (size_t i = 0; i < data.size(); i++)
+            std::sort(data[i].keys.begin(), data[i].keys.end());
+        std::sort(data.begin(), data.end());
+    }
+    std::ostream& addError()
+    {
+        error = true;
+        return error_message;
+    }
+    bool isGood() const
+    {
+        return !error;
+    }
+    string getErrorMessage() const
+    {
+        return error_message.str();
+    }
 
-    void sort_params();
-    int refcount;
+    void setAboutMessage(const std::string& msg)
+    {
+        about_message = msg;
+    }
+    string getApplicationPath() const
+    {
+        return path_to_app;
+    }
+    void printMessage(std::ostream& out) const
+    {
+        if (!about_message.empty())
+            out << about_message << endl;
+        out << "Usage: " << app_name << " [params] ";
+        for (ConstDataIterator i = data.begin(); i != data.end(); ++i)
+        {
+            if (i->isPositional)
+                out << i->getPrintedKey() << " ";
+        }
+        out << endl << endl;
+        for (ConstDataIterator i = data.begin(); i != data.end(); ++i)
+        {
+            out << '\t' << i->getPrintedKey() << i->getPrintedValue() << endl;
+            out << '\t' << '\t' << i->help_message << endl;
+        }
+    }
 };
 
+} // namespace cv
 
-static const char* get_type_name(Param type)
+//==================================================================================================
+
+namespace {
+
+template<typename T>
+inline bool from_str(const string& line, void* dst)
 {
-    if( type == Param::INT )
-        return "int";
-    if( type == Param::BOOLEAN )
-        return "bool";
-    if( type == Param::UNSIGNED_INT )
-        return "unsigned";
-    if( type == Param::UINT64 )
-        return "unsigned long long";
-    if( type == Param::FLOAT )
-        return "float";
-    if( type == Param::REAL )
-        return "double";
-    if( type == Param::STRING )
-        return "string";
-    return "unknown";
+    std::istringstream input(line);
+    input.imbue(std::locale::classic());
+    T val;
+    input >> val;
+    if (input.fail())
+        return false;
+    memcpy(dst, &val, sizeof(T));
+    return true;
 }
 
-static bool parse_bool(std::string str)
+template<>
+inline bool from_str<bool>(const string& line, void* dst)
 {
-    std::transform(str.begin(), str.end(), str.begin(), details::char_tolower);
-    std::istringstream is(str);
-    bool b;
-    is >> (str.size() > 1 ? std::boolalpha : std::noboolalpha) >> b;
-    return b;
-}
-
-static void from_str(const String& str, Param type, void* dst)
-{
-    std::stringstream ss(str.c_str());
-    if( type == Param::INT )
-        ss >> *(int*)dst;
-    else if( type == Param::BOOLEAN )
-    {
-        std::string temp;
-        ss >> temp;
-        *(bool*) dst = parse_bool(temp);
-    }
-    else if( type == Param::UNSIGNED_INT )
-        ss >> *(unsigned*)dst;
-    else if( type == Param::UINT64 )
-        ss >> *(uint64*)dst;
-    else if( type == Param::FLOAT )
-        ss >> *(float*)dst;
-    else if( type == Param::REAL )
-        ss >> *(double*)dst;
-    else if( type == Param::STRING )
-        *(String*)dst = str;
-    else if( type == Param::SCALAR)
-    {
-        Scalar& scalar = *(Scalar*)dst;
-        for (int i = 0; i < 4 && !ss.eof(); ++i)
-            ss >> scalar[i];
-    }
+    std::istringstream input(line);
+    input.imbue(std::locale::classic());
+    string str;
+    input >> str;
+    str = cv::toLowerCase(str);
+    bool val;
+    if (str == "false" || str == "0")
+        val = false;
+    else if (str == "true" || str == "1")
+        val = true;
     else
-        CV_Error(Error::StsBadArg, "unknown/unsupported parameter type");
+        input.setstate(std::istream::failbit);
+    if (input.fail())
+        return false;
+    memcpy(dst, &val, sizeof(bool));
+    return true;
+}
 
-    if (ss.fail())
+template<>
+inline bool from_str<cv::Scalar>(const string& line, void* dst)
+{
+    std::istringstream input(line);
+    input.imbue(std::locale::classic());
+    cv::Scalar res;
+    int i = 0;
+    while (!input.eof() && i < 4)
+        input >> res.val[i++];
+    if (input.fail())
+        return false;
+    memcpy(dst, &res, sizeof(cv::Scalar));
+    return true;
+}
+
+inline static bool from_str(const string& str, cv::Param type, void* dst)
+{
+    switch(type)
     {
-        CV_Error_(Error::StsBadArg, ("can not convert: [%s] to [%s]", str.c_str(), get_type_name(type)));
+    case cv::Param::INT: return from_str<int>(str, dst);
+    case cv::Param::BOOLEAN: return from_str<bool>(str, dst);
+    case cv::Param::UNSIGNED_INT: return from_str<unsigned>(str, dst);
+    case cv::Param::UINT64: return from_str<uint64>(str, dst);
+    case cv::Param::FLOAT: return from_str<float>(str, dst);
+    case cv::Param::REAL: return from_str<double>(str, dst);
+    case cv::Param::SCALAR: return from_str<cv::Scalar>(str, dst);
+    case cv::Param::STRING:
+        static_cast<string*>(dst)->assign(str);
+        return true;
+    default: return false;
     }
+}
+
+} // namespace
+
+//==================================================================================================
+
+namespace cv
+{
+
+inline static std::ostream & operator<<(std::ostream& out, cv::Param type)
+{
+    switch(type)
+    {
+    case cv::Param::INT: out << "int"; break;
+    case cv::Param::BOOLEAN: out << "bool"; break;
+    case cv::Param::UNSIGNED_INT: out << "unsigned"; break;
+    case cv::Param::UINT64: out << "unsigned long long"; break;
+    case cv::Param::FLOAT: out << "float"; break;
+    case cv::Param::REAL: out << "double"; break;
+    case cv::Param::SCALAR: out << "scalar"; break;
+    case cv::Param::STRING: out << "string"; break;
+    default: out << "unknown"; break;
+    }
+    return out;
 }
 
 void CommandLineParser::getByName(const String& name, bool space_delete, Param type, void* dst) const
 {
-    CV_TRY
-    {
-        for (size_t i = 0; i < impl->data.size(); i++)
-        {
-            for (size_t j = 0; j < impl->data[i].keys.size(); j++)
-            {
-                if (name == impl->data[i].keys[j])
-                {
-                    String v = impl->data[i].def_value;
-                    if (space_delete)
-                        v = cat_string(v);
-
-                    // the key was neither specified nor has a default value
-                    if((v.empty() && type != Param::STRING) || v == noneValue) {
-                        impl->error = true;
-                        impl->error_message = impl->error_message + "Missing parameter: '" + name + "'\n";
-                        return;
-                    }
-
-                    from_str(v, type, dst);
-                    return;
-                }
-            }
-        }
-    }
-    CV_CATCH (Exception, e)
-    {
-        impl->error = true;
-        impl->error_message = impl->error_message + "Parameter '"+ name + "': " + e.err + "\n";
-        return;
-    }
-    CV_Error_(Error::StsBadArg, ("undeclared key '%s' requested", name.c_str()));
+    const CommandLineParserParams& param = impl->findByName(name);
+    if (!param.isValid)
+        CV_Error(Error::StsBadArg, "Requested invalid parameter: '" + name + "'");
+    const string value = param.getValue(space_delete);
+    if (value == magic_none_value || (value.empty() && type != Param::STRING))
+        impl->addError() << "Missing parameter: '" << name << "'" << endl;
+    else if (!from_str(value, type, dst))
+        impl->addError() << "Can not convert parameter '" << name << "': [" << value << "] to [" << type << "]" << endl;
 }
-
 
 void CommandLineParser::getByIndex(int index, bool space_delete, Param type, void* dst) const
 {
-    CV_TRY
-    {
-        for (size_t i = 0; i < impl->data.size(); i++)
-        {
-            if (impl->data[i].number == index)
-            {
-                String v = impl->data[i].def_value;
-                if (space_delete == true) v = cat_string(v);
-
-                // the key was neither specified nor has a default value
-                if((v.empty() && type != Param::STRING) || v == noneValue) {
-                    impl->error = true;
-                    impl->error_message = impl->error_message + format("Missing parameter #%d\n", index);
-                    return;
-                }
-                from_str(v, type, dst);
-                return;
-            }
-        }
-    }
-    CV_CATCH(Exception, e)
-    {
-        impl->error = true;
-        impl->error_message = impl->error_message + format("Parameter #%d: ", index) + e.err + "\n";
-        return;
-    }
-    CV_Error_(Error::StsBadArg, ("undeclared position %d requested", index));
-}
-
-static bool cmp_params(const CommandLineParserParams & p1, const CommandLineParserParams & p2)
-{
-    if (p1.number < p2.number)
-        return true;
-
-    if (p1.number > p2.number)
-        return false;
-
-    return p1.keys[0].compare(p2.keys[0]) < 0;
+    const CommandLineParserParams& param = impl->findByIndex(index);
+    if (!param.isValid)
+        CV_Error(Error::StsBadArg, "Requested invalid parameter: '" + format("%d", index) + "'");
+    const string value = param.getValue(space_delete);
+    if (value == magic_none_value || (value.empty() && type != Param::STRING))
+        impl->addError() << "Missing parameter #" << index << endl;
+    else if (!from_str(value, type, dst))
+        impl->addError() << "Can not convert parameter #" << index << " [" << value << "] to [" << type << "]" << endl;
 }
 
 CommandLineParser::CommandLineParser(int argc, const char* const argv[], const String& keys)
 {
-    impl = new Impl;
-    impl->refcount = 1;
-
-    // path to application
-    size_t pos_s = String(argv[0]).find_last_of("/\\");
-    if (pos_s == String::npos)
-    {
-        impl->path_to_app = "";
-        impl->app_name = String(argv[0]);
-    }
-    else
-    {
-        impl->path_to_app = String(argv[0]).substr(0, pos_s);
-        impl->app_name = String(argv[0]).substr(pos_s + 1, String(argv[0]).length() - pos_s);
-    }
-
-    impl->error = false;
-    impl->error_message = "";
-
-    // parse keys
-    std::vector<String> k = impl->split_range_string(keys, '{', '}');
-
-    int jj = 0;
-    for (size_t i = 0; i < k.size(); i++)
-    {
-        std::vector<String> l = impl->split_string(k[i], '|', true);
-        CommandLineParserParams p;
-        p.keys = impl->split_string(l[0]);
-        p.def_value = l[1];
-        p.help_message = cat_string(l[2]);
-        p.number = -1;
-        if (p.keys.size() <= 0)
-        {
-            impl->error = true;
-            impl->error_message = "Field KEYS could not be empty\n";
-        }
-        else
-        {
-            if (p.keys[0][0] == '@')
-            {
-                p.number = jj;
-                jj++;
-            }
-
-            impl->data.push_back(p);
-        }
-    }
-
-    // parse argv
-    jj = 0;
-    for (int i = 1; i < argc; i++)
-    {
-        String s(argv[i]);
-        bool hasSingleDash = s.length() > 1 && s[0] == '-';
-
-        if (hasSingleDash)
-        {
-            bool hasDoubleDash = s.length() > 2 && s[1] == '-';
-            String key = s.substr(hasDoubleDash ? 2 : 1);
-            String value = "true";
-            size_t equalsPos = key.find('=');
-
-            if(equalsPos != String::npos) {
-                value = key.substr(equalsPos + 1);
-                key = key.substr(0, equalsPos);
-            }
-            impl->apply_params(key, value);
-        }
-        else
-        {
-            impl->apply_params(jj, s);
-            jj++;
-        }
-    }
-
-    impl->sort_params();
+    impl = new Impl(keys);
+    impl->parse(argc, argv);
 }
 
 CommandLineParser::~CommandLineParser()
 {
-    if (CV_XADD(&impl->refcount, -1) == 1)
-        delete impl;
-}
-
-CommandLineParser::CommandLineParser(const CommandLineParser& parser)
-{
-    impl = parser.impl;
-    CV_XADD(&impl->refcount, 1);
-}
-
-CommandLineParser& CommandLineParser::operator = (const CommandLineParser& parser)
-{
-    if( this != &parser )
-    {
-        CV_XADD(&parser.impl->refcount, 1);
-        if(CV_XADD(&impl->refcount, -1) == 1)
-            delete impl;
-        impl = parser.impl;
-    }
-    return *this;
+    delete impl;
 }
 
 void CommandLineParser::about(const String& message)
 {
-    impl->about_message = message;
-}
-
-void CommandLineParser::Impl::apply_params(const String& key, const String& value)
-{
-    for (size_t i = 0; i < data.size(); i++)
-    {
-        for (size_t k = 0; k < data[i].keys.size(); k++)
-        {
-            if (key.compare(data[i].keys[k]) == 0)
-            {
-                data[i].def_value = value;
-                break;
-            }
-        }
-    }
-}
-
-void CommandLineParser::Impl::apply_params(int i, String value)
-{
-    for (size_t j = 0; j < data.size(); j++)
-    {
-        if (data[j].number == i)
-        {
-            data[j].def_value = value;
-            break;
-        }
-    }
-}
-
-void CommandLineParser::Impl::sort_params()
-{
-    for (size_t i = 0; i < data.size(); i++)
-    {
-        std::sort(data[i].keys.begin(), data[i].keys.end());
-    }
-
-    std::sort (data.begin(), data.end(), cmp_params);
+    impl->setAboutMessage(message);
 }
 
 String CommandLineParser::getPathToApplication() const
 {
-    return impl->path_to_app;
+    return impl->getApplicationPath();
 }
 
 bool CommandLineParser::has(const String& name) const
 {
-    for (size_t i = 0; i < impl->data.size(); i++)
-    {
-        for (size_t j = 0; j < impl->data[i].keys.size(); j++)
-        {
-            if (name == impl->data[i].keys[j])
-            {
-                const String v = cat_string(impl->data[i].def_value);
-                return !v.empty() && v != noneValue;
-            }
-        }
-    }
-
-    CV_Error_(Error::StsBadArg, ("undeclared key '%s' requested", name.c_str()));
+    const CommandLineParserParams& param = impl->findByName(name);
+    if (!param.isValid)
+        CV_Error(Error::StsBadArg, "Requested invalid parameter: '" + name + "'");
+    const string value = param.getValue();
+    return value != magic_none_value && !value.empty();
 }
 
 bool CommandLineParser::check() const
 {
-    return impl->error == false;
+    return impl->isGood();
 }
 
 void CommandLineParser::printErrors() const
 {
-    if (impl->error)
-    {
-        printf("\nERRORS:\n%s\n", impl->error_message.c_str());
-        fflush(stdout);
-    }
+    if (!impl->isGood())
+        cout << endl << "ERRORS:" << endl << impl->getErrorMessage() << endl;
 }
 
 void CommandLineParser::printMessage() const
 {
-    if (impl->about_message != "")
-        printf("%s\n", impl->about_message.c_str());
-
-    printf("Usage: %s [params] ", impl->app_name.c_str());
-
-    for (size_t i = 0; i < impl->data.size(); i++)
-    {
-        if (impl->data[i].number > -1)
-        {
-            String name = impl->data[i].keys[0].substr(1, impl->data[i].keys[0].length() - 1);
-            printf("%s ", name.c_str());
-        }
-    }
-
-    printf("\n\n");
-
-    for (size_t i = 0; i < impl->data.size(); i++)
-    {
-        if (impl->data[i].number == -1)
-        {
-            printf("\t");
-            for (size_t j = 0; j < impl->data[i].keys.size(); j++)
-            {
-                String k = impl->data[i].keys[j];
-                if (k.length() > 1)
-                {
-                    printf("--");
-                }
-                else
-                {
-                    printf("-");
-                }
-                printf("%s", k.c_str());
-
-                if (j != impl->data[i].keys.size() - 1)
-                {
-                    printf(", ");
-                }
-            }
-            String dv = cat_string(impl->data[i].def_value);
-            if (dv.compare("") != 0)
-            {
-                printf(" (value:%s)", dv.c_str());
-            }
-            printf("\n\t\t%s\n", impl->data[i].help_message.c_str());
-        }
-    }
-    printf("\n");
-
-    for (size_t i = 0; i < impl->data.size(); i++)
-    {
-        if (impl->data[i].number != -1)
-        {
-            printf("\t");
-            String k = impl->data[i].keys[0];
-            k = k.substr(1, k.length() - 1);
-
-            printf("%s", k.c_str());
-
-            String dv = cat_string(impl->data[i].def_value);
-            if (dv.compare("") != 0)
-            {
-                printf(" (value:%s)", dv.c_str());
-            }
-            printf("\n\t\t%s\n", impl->data[i].help_message.c_str());
-        }
-    }
+    impl->printMessage(cout);
 }
 
-std::vector<String> CommandLineParser::Impl::split_range_string(const String& _str, char fs, char ss) const
-{
-    String str = _str;
-    std::vector<String> vec;
-    String word = "";
-    bool begin = false;
-    while (!str.empty())
-    {
-        if (str[0] == fs)
-        {
-            if (begin == true)
-            {
-                CV_THROW (cv::Exception(CV_StsParseError,
-                         String("error in split_range_string(")
-                         + str
-                         + String(", ")
-                         + String(1, fs)
-                         + String(", ")
-                         + String(1, ss)
-                         + String(")"),
-                         "", __FILE__, __LINE__
-                         ));
-            }
-            begin = true;
-            word = "";
-            str = str.substr(1, str.length() - 1);
-        }
-
-        if (str[0] == ss)
-        {
-            if (begin == false)
-            {
-                CV_THROW (cv::Exception(CV_StsParseError,
-                         String("error in split_range_string(")
-                         + str
-                         + String(", ")
-                         + String(1, fs)
-                         + String(", ")
-                         + String(1, ss)
-                         + String(")"),
-                         "", __FILE__, __LINE__
-                         ));
-            }
-            begin = false;
-            vec.push_back(word);
-        }
-
-        if (begin == true)
-        {
-            word = word + str[0];
-        }
-        str = str.substr(1, str.length() - 1);
-    }
-
-    if (begin == true)
-    {
-        CV_THROW (cv::Exception(CV_StsParseError,
-                 String("error in split_range_string(")
-                 + str
-                 + String(", ")
-                 + String(1, fs)
-                 + String(", ")
-                 + String(1, ss)
-                 + String(")"),
-                 "", __FILE__, __LINE__
-                ));
-    }
-    return vec;
-}
-
-std::vector<String> CommandLineParser::Impl::split_string(const String& _str, char symbol, bool create_empty_item) const
-{
-    String str = _str;
-    std::vector<String> vec;
-    String word = "";
-
-    while (!str.empty())
-    {
-        if (str[0] == symbol)
-        {
-            if (!word.empty() || create_empty_item)
-            {
-                vec.push_back(word);
-                word = "";
-            }
-        }
-        else
-        {
-            word = word + str[0];
-        }
-        str = str.substr(1, str.length() - 1);
-    }
-
-    if (word != "" || create_empty_item)
-    {
-        vec.push_back(word);
-    }
-
-    return vec;
-}
-
-}
+} // namespace cv

--- a/modules/core/test/test_utils.cpp
+++ b/modules/core/test/test_utils.cpp
@@ -283,4 +283,14 @@ TEST(CommandLineParser, testScalar)
     EXPECT_EQ(parser.get<Scalar>("s5"), Scalar(5, -4, 3, 2));
 }
 
+TEST(CommandLineParser, BadKeys)
+{
+    const char* argv[] = {"<bin>"};
+    const int argc = 1;
+    EXPECT_NO_THROW(CommandLineParser p(argc, argv, "{}"););
+    EXPECT_NO_THROW(CommandLineParser p(argc, argv, "{|}"););
+    EXPECT_ANY_THROW(CommandLineParser p(argc, argv, "{||}"););
+    EXPECT_NO_THROW(CommandLineParser p(0, argv, "{}"););
+}
+
 }} // namespace

--- a/samples/cpp/videostab.cpp
+++ b/samples/cpp/videostab.cpp
@@ -182,7 +182,7 @@ public:
     virtual Ptr<ImageMotionEstimatorBase> build() = 0;
 protected:
     IMotionEstimatorBuilder(CommandLineParser &command) : cmd(command) {}
-    CommandLineParser cmd;
+    CommandLineParser& cmd;
 };
 
 


### PR DESCRIPTION
### This pullrequest changes

* use std::string in CommandLineParser internals
* use std::regex for parsing
* separated `Impl` from interface object

**Note:** forbidden copy and assignment of CommandLineParser
