### PR TITLE
Fix install with external protobuf

### DIFF
--- a/cmake/OpenCVFindProtobuf.cmake
+++ b/cmake/OpenCVFindProtobuf.cmake
@@ -44,8 +44,10 @@ else()
 
   if(Protobuf_FOUND)
     if(TARGET protobuf::libprotobuf)
-      add_library(libprotobuf INTERFACE)
-      target_link_libraries(libprotobuf INTERFACE protobuf::libprotobuf)
+      add_library(libprotobuf INTERFACE IMPORTED)
+      set_target_properties(libprotobuf PROPERTIES
+        INTERFACE_LINK_LIBRARIES protobuf::libprotobuf
+      )
     else()
       add_library(libprotobuf UNKNOWN IMPORTED)
       set_target_properties(libprotobuf PROPERTIES


### PR DESCRIPTION
<!-- Please use this line to close one or multiple issues when this pullrequest gets merged
You can add another line right under the first one:
resolves #1234
resolves #1235
-->

### This pullrequest changes

Adds `IMPORTED` for the `protobuf::libprotobuf` alias target as it otherwise produces an error during `install`:

`CMake Error: install(EXPORT "OpenCVModules" ...) includes target "opencv_dnn" which requires target "libprotobuf" that is not in the export set.`

cmake version: 3.10.2

<!-- Please describe what your pullrequest is changing -->
