### PR TITLE
Removed ocl::KernelArg::Local()

### DIFF
--- a/modules/core/include/opencv2/core/ocl.hpp
+++ b/modules/core/include/opencv2/core/ocl.hpp
@@ -352,7 +352,6 @@ public:
     KernelArg(int _flags, UMat* _m, int wscale=1, int iwscale=1, const void* _obj=0, size_t _sz=0);
     KernelArg();
 
-    static KernelArg Local() { return KernelArg(LOCAL, 0); }
     static KernelArg PtrWriteOnly(const UMat& m)
     { return KernelArg(PTR_ONLY+WRITE_ONLY, (UMat*)&m); }
     static KernelArg PtrReadOnly(const UMat& m)


### PR DESCRIPTION
### This pullrequest changes

`ocl::KernelArg::Local()` has been removed since it's incorrect: it doesn't provide local mem size which makes kernel run to fail.

The desired effect of providing local memory argument can be achieved by the following constructor:
`ocl::KernelArg(ocl::KernelArg::LOCAL, nullptr, 0, 0, nullptr, localMemSize)`
