### PR TITLE
cmake: define CV_ErrorNoReturn under CV_STATIC_ANALYSIS

### DIFF
--- a/modules/core/include/opencv2/core/base.hpp
+++ b/modules/core/include/opencv2/core/base.hpp
@@ -415,6 +415,8 @@ CV_INLINE CV_NORETURN void errorNoReturn(int _code, const String& _err, const ch
 #define CV_Error(...) do { abort(); } while (0)
 #define CV_Error_( code, args ) do { cv::format args; abort(); } while (0)
 #define CV_Assert( expr ) do { if (!(expr)) abort(); } while (0)
+#define CV_ErrorNoReturn CV_Error
+#define CV_ErrorNoReturn_ CV_Error_
 
 #else // CV_STATIC_ANALYSIS
 


### PR DESCRIPTION
to avoid build break without `__OPENCV_BUILD`

resolves #12736
