### PR TITLE
Fix clang-cl _tzcnt_u32 intrinsic

### DIFF
--- a/modules/core/include/opencv2/core/hal/intrin.hpp
+++ b/modules/core/include/opencv2/core/hal/intrin.hpp
@@ -368,6 +368,9 @@ inline unsigned int trailingZeros32(unsigned int value) {
     unsigned long index = 0;
     _BitScanForward(&index, value);
     return (unsigned int)index;
+#elif defined(__clang__)
+    // clang-cl doesn't export _tzcnt_u32 for non BMI systems
+    return value ? __builtin_ctz(value) : 32;
 #else
     return _tzcnt_u32(value);
 #endif


### PR DESCRIPTION
_tzcnt_u32() is not exported by clang-cl intrin.h so check for
clang-cl and enable an alterate for _tzcnt_u32()

Some discussions:
http://lists.llvm.org/pipermail/cfe-dev/2016-October/051329.html
https://bugs.llvm.org/show_bug.cgi?id=30506

TEST=Build opencv with clang-cl (disabled WEBP and DirectX due to other failures)

### This pullrequest changes

Change the reference to _tzcnt_u32() which is not available by default on clang-cl (unlike MSVC). 

```
force_builders=Custom
docker_image:Custom=ubuntu-clang:18.04
```
