### PR TITLE
CUDA/Codec: Improve error reporting of NVCUVENC missing support

### DIFF
--- a/modules/cudacodec/src/video_writer.cpp
+++ b/modules/cudacodec/src/video_writer.cpp
@@ -49,16 +49,22 @@ using namespace cv::cudacodec;
 
 #if !defined(HAVE_NVCUVENC) || !defined(_WIN32)
 
-cv::cudacodec::EncoderParams::EncoderParams() { throw_no_cuda(); }
-cv::cudacodec::EncoderParams::EncoderParams(const String&) { throw_no_cuda(); }
-void cv::cudacodec::EncoderParams::load(const String&) { throw_no_cuda(); }
-void cv::cudacodec::EncoderParams::save(const String&) const { throw_no_cuda(); }
+#ifndef HAVE_NVCUVENC
+static inline CV_NORETURN void throw_no_nvcuvenc() { CV_Error(cv::Error::StsNotImplemented, "The library is compiled without NVCUVENC support"); }
+#else
+static inline CV_NORETURN void throw_no_nvcuvenc() { CV_Error(cv::Error::StsNotImplemented, "The called functionality is disabled for current build or platform"); }
+#endif
 
-Ptr<VideoWriter> cv::cudacodec::createVideoWriter(const String&, Size, double, SurfaceFormat) { throw_no_cuda(); return Ptr<VideoWriter>(); }
-Ptr<VideoWriter> cv::cudacodec::createVideoWriter(const String&, Size, double, const EncoderParams&, SurfaceFormat) { throw_no_cuda(); return Ptr<VideoWriter>(); }
+cv::cudacodec::EncoderParams::EncoderParams() { throw_no_nvcuvenc(); }
+cv::cudacodec::EncoderParams::EncoderParams(const String&) { throw_no_nvcuvenc(); }
+void cv::cudacodec::EncoderParams::load(const String&) { throw_no_nvcuvenc(); }
+void cv::cudacodec::EncoderParams::save(const String&) const { throw_no_nvcuvenc(); }
 
-Ptr<VideoWriter> cv::cudacodec::createVideoWriter(const Ptr<EncoderCallBack>&, Size, double, SurfaceFormat) { throw_no_cuda(); return Ptr<VideoWriter>(); }
-Ptr<VideoWriter> cv::cudacodec::createVideoWriter(const Ptr<EncoderCallBack>&, Size, double, const EncoderParams&, SurfaceFormat) { throw_no_cuda(); return Ptr<VideoWriter>(); }
+Ptr<VideoWriter> cv::cudacodec::createVideoWriter(const String&, Size, double, SurfaceFormat) { throw_no_nvcuvenc(); return Ptr<VideoWriter>(); }
+Ptr<VideoWriter> cv::cudacodec::createVideoWriter(const String&, Size, double, const EncoderParams&, SurfaceFormat) { throw_no_nvcuvenc(); return Ptr<VideoWriter>(); }
+
+Ptr<VideoWriter> cv::cudacodec::createVideoWriter(const Ptr<EncoderCallBack>&, Size, double, SurfaceFormat) { throw_no_nvcuvenc(); return Ptr<VideoWriter>(); }
+Ptr<VideoWriter> cv::cudacodec::createVideoWriter(const Ptr<EncoderCallBack>&, Size, double, const EncoderParams&, SurfaceFormat) { throw_no_nvcuvenc(); return Ptr<VideoWriter>(); }
 
 #else // !defined HAVE_NVCUVENC || !defined _WIN32
 


### PR DESCRIPTION
Fix misleading error reports that platform is not supported, or CUDA is missing, while in fact NVCUVENC  component is missing

### This pullrequest changes
- Reports explicitly that NVCUVENC  is missing

```
force_builders=Custom
docker_image:Custom=ubuntu-cuda:16.04
```