### PR TITLE
More accurate pinhole camera calibration with imperfect planar target

### DIFF
--- a/doc/tutorials/calib3d/camera_calibration/camera_calibration.markdown
+++ b/doc/tutorials/calib3d/camera_calibration/camera_calibration.markdown
@@ -197,10 +197,9 @@ parameters:
     dramatically improve the accuracies of the estimated camera intrinsic parameters. This new
     calibration method will be called if command line parameter `-d=<number>` is provided. In the
     above code snippet, `grid_width` is actually the value set by `-d=<number>`. It's the measured
-    distance between top-left and top-right corners of the pattern grid points. The value usually
-    stays in the neighborhood of `s.squareSize * (s.boardSize.width - 1)`. It should be measured
-    precisely with rulers or vernier calipers. After calibration, newObjPoints will be updated with
-    refined 3D coordinates of object points.
+    distance between top-left (0, 0, 0) and top-right (s.squareSize*(s.boardSize.width-1), 0, 0)
+    corners of the pattern grid points. It should be measured precisely with rulers or vernier calipers.
+    After calibration, newObjPoints will be updated with refined 3D coordinates of object points.
 -   The image points. This is a vector of *Point2f* vector which for each input image contains
     coordinates of the important points (corners for chessboard and centers of the circles for the
     circle pattern). We have already collected this from @ref cv::findChessboardCorners or @ref

--- a/doc/tutorials/calib3d/camera_calibration/camera_calibration.markdown
+++ b/doc/tutorials/calib3d/camera_calibration/camera_calibration.markdown
@@ -131,6 +131,8 @@ Explanation
     Similar images result in similar equations, and similar equations at the calibration step will
     form an ill-posed problem, so the calibration will fail. For square images the positions of the
     corners are only approximate. We may improve this by calling the @ref cv::cornerSubPix function.
+    (`winSize` is used to control the side length of the search window. Its default value is 11.
+    `winSzie` may be changed by command line parameter `--winSize=<number>`.)
     It will produce better calibration result. After this we add a valid inputs result to the
     *imagePoints* vector to collect all of the equations into a single container. Finally, for
     visualization feedback purposes we will draw the found points on the input image using @ref
@@ -184,8 +186,21 @@ parameters:
     @code{.cpp}
     vector<vector<Point3f> > objectPoints(1);
     calcBoardCornerPositions(s.boardSize, s.squareSize, objectPoints[0], s.calibrationPattern);
+    objectPoints[0][s.boardSize.width - 1].x = objectPoints[0][0].x + grid_width;
+    newObjPoints = objectPoints[0];
+
     objectPoints.resize(imagePoints.size(),objectPoints[0]);
     @endcode
+    @note If your calibration board is inaccurate, unmeasured, roughly planar targets (Checkerboard
+    patterns on paper using off-the-shelf printers are the most convenient calibration targets and
+    most of them are not accurate enough.), a method from @cite strobl2011iccv can be utilized to
+    dramatically improve the accuracies of the estimated camera intrinsic parameters. This new
+    calibration method will be called if command line parameter `-d=<number>` is provided. In the
+    above code snippet, `grid_width` is actually the value set by `-d=<number>`. It's the measured
+    distance between top-left and top-right corners of the pattern grid points. The value usually
+    stays in the neighborhood of `s.squareSize * (s.boardSize.width - 1)`. It should be measured
+    precisely with rulers or vernier calipers. After calibration, newObjPoints will be updated with
+    refined 3D coordinates of object points.
 -   The image points. This is a vector of *Point2f* vector which for each input image contains
     coordinates of the important points (corners for chessboard and centers of the circles for the
     circle pattern). We have already collected this from @ref cv::findChessboardCorners or @ref

--- a/doc/tutorials/calib3d/camera_calibration/camera_calibration.markdown
+++ b/doc/tutorials/calib3d/camera_calibration/camera_calibration.markdown
@@ -77,8 +77,8 @@ Source code
 
 You may also find the source code in the `samples/cpp/tutorial_code/calib3d/camera_calibration/`
 folder of the OpenCV source library or [download it from here
-](https://github.com/opencv/opencv/tree/master/samples/cpp/tutorial_code/calib3d/camera_calibration/camera_calibration.cpp). The program has a
-single argument: the name of its configuration file. If none is given then it will try to open the
+](https://github.com/opencv/opencv/tree/master/samples/cpp/tutorial_code/calib3d/camera_calibration/camera_calibration.cpp). For the usage of the program, run it with `-h` argument. The program has an
+essential argument: the name of its configuration file. If none is given then it will try to open the
 one named "default.xml". [Here's a sample configuration file
 ](https://github.com/opencv/opencv/tree/master/samples/cpp/tutorial_code/calib3d/camera_calibration/in_VID5.xml) in XML format. In the
 configuration file you may choose to use camera as an input, a video file or an image list. If you
@@ -172,7 +172,7 @@ of the calibration variables we'll create these variables here and pass on both 
 calibration and saving function. Again, I'll not show the saving part as that has little in common
 with the calibration. Explore the source file in order to find out how and what:
 @snippet samples/cpp/tutorial_code/calib3d/camera_calibration/camera_calibration.cpp run_and_save
-We do the calibration with the help of the @ref cv::calibrateCamera function. It has the following
+We do the calibration with the help of the @ref cv::calibrateCameraRO function. It has the following
 parameters:
 
 -   The object points. This is a vector of *Point3f* vector that for each input image describes how
@@ -205,6 +205,14 @@ parameters:
     circle pattern). We have already collected this from @ref cv::findChessboardCorners or @ref
     cv::findCirclesGrid function. We just need to pass it on.
 -   The size of the image acquired from the camera, video file or the images.
+-   The index of the object point to be fixed. We set it to -1 to request standard calibration method.
+    If the new object-releasing method to be used, set it to the index of the top-right corner point
+    of the calibration board grid. See cv::calibrateCameraRO for detailed explanation.
+    @code{.cpp}
+    int iFixedPoint = -1;
+    if (release_object)
+        iFixedPoint = s.boardSize.width - 1;
+    @endcode
 -   The camera matrix. If we used the fixed aspect ratio option we need to set \f$f_x\f$:
     @snippet samples/cpp/tutorial_code/calib3d/camera_calibration/camera_calibration.cpp fixed_aspect
 -   The distortion coefficient matrix. Initialize with zero.
@@ -216,11 +224,15 @@ parameters:
     coordinate space). The 7-th and 8-th parameters are the output vector of matrices containing in
     the i-th position the rotation and translation vector for the i-th object point to the i-th
     image point.
+-   The updated output vector of calibration pattern points. This parameter is ignored with standard
+    calibration method.
 -   The final argument is the flag. You need to specify here options like fix the aspect ratio for
-    the focal length, assume zero tangential distortion or to fix the principal point.
+    the focal length, assume zero tangential distortion or to fix the principal point. Here we use
+    CALIB_USE_LU to get faster calibration speed.
 @code{.cpp}
-double rms = calibrateCamera(objectPoints, imagePoints, imageSize, cameraMatrix,
-                            distCoeffs, rvecs, tvecs, s.flag|CV_CALIB_FIX_K4|CV_CALIB_FIX_K5);
+rms = calibrateCameraRO(objectPoints, imagePoints, imageSize, iFixedPoint,
+                        cameraMatrix, distCoeffs, rvecs, tvecs, newObjPoints,
+                        s.flag | CALIB_USE_LU);
 @endcode
 -   The function returns the average re-projection error. This number gives a good estimation of
     precision of the found parameters. This should be as close to zero as possible. Given the

--- a/doc/tutorials/calib3d/table_of_content_calib3d.markdown
+++ b/doc/tutorials/calib3d/table_of_content_calib3d.markdown
@@ -13,7 +13,7 @@ Although we get most of our images in a 2D format they do come from a 3D world. 
 
 -   @subpage tutorial_camera_calibration
 
-    *Compatibility:* \> OpenCV 2.0
+    *Compatibility:* \> OpenCV 4.1
 
     *Author:* Bernát Gábor
 

--- a/doc/tutorials/calib3d/table_of_content_calib3d.markdown
+++ b/doc/tutorials/calib3d/table_of_content_calib3d.markdown
@@ -13,7 +13,7 @@ Although we get most of our images in a 2D format they do come from a 3D world. 
 
 -   @subpage tutorial_camera_calibration
 
-    *Compatibility:* \> OpenCV 4.1
+    *Compatibility:* \> OpenCV 4.0
 
     *Author:* Bernát Gábor
 

--- a/modules/calib3d/doc/calib3d.bib
+++ b/modules/calib3d/doc/calib3d.bib
@@ -49,5 +49,6 @@
   year={2011},
   address={Barcelona, Spain},
   publisher={IEEE},
+  url={https://elib.dlr.de/71888/1/strobl_2011iccv.pdf},
   doi={10.1109/ICCVW.2011.6130369}
 }

--- a/modules/calib3d/doc/calib3d.bib
+++ b/modules/calib3d/doc/calib3d.bib
@@ -39,3 +39,15 @@
   year={2013},
   publisher={IEEE}
 }
+
+@inproceedings{strobl2011iccv,
+  title={More accurate pinhole camera calibration with imperfect planar target},
+  author={Strobl, Klaus H. and Hirzinger, Gerd},
+  booktitle={2011 IEEE International Conference on Computer Vision (ICCV)},
+  pages={1068-1075},
+  month={Nov},
+  year={2011},
+  address={Barcelona, Spain},
+  publisher={IEEE},
+  doi={10.1109/ICCVW.2011.6130369}
+}

--- a/modules/calib3d/include/opencv2/calib3d.hpp
+++ b/modules/calib3d/include/opencv2/calib3d.hpp
@@ -992,7 +992,7 @@ together.
 the top-right corner point of the calibration board grid. This parameter is used only if
 CALIB_RELEASE_OBJECT is set. In other cases it can be set to -1 which is just ignored internally.
 According to \cite strobl2011iccv, two other points are also fixed. In this implementation,
-objectPoints[0].front and objectPoints[0].back are used. Accurate rvecs and tvecs are only possible
+objectPoints[0].front and objectPoints[0].back.z are used. Accurate rvecs and tvecs are only possible
 if coordinates of these three fixed points are accurate enough.
 @param cameraMatrix Output 3x3 floating-point camera matrix
 \f$A = \vecthreethree{f_x}{0}{c_x}{0}{f_y}{c_y}{0}{0}{1}\f$ . If CV\_CALIB\_USE\_INTRINSIC\_GUESS

--- a/modules/calib3d/include/opencv2/calib3d.hpp
+++ b/modules/calib3d/include/opencv2/calib3d.hpp
@@ -1106,12 +1106,14 @@ camera parameters. Both the object-releasing method and standard method are supp
 function. Use the parameter **iFixedPoint** for method selection. In the internal implementation,
 calibrateCamera() is a wrapper for this function.
 
-@param objectPoints See calibrateCamera() for details. If the method of releasing object to be used,
+@param objectPoints Vector of vectors of calibration pattern points in the calibration pattern
+coordinate space. See calibrateCamera() for details. If the method of releasing object to be used,
 the identical calibration board must be used in each view and it must be fully visible, and all
 objectPoints[i] must be the same and all points should be roughly close to a plane. **The calibration
 target has to be rigid, or at least static if the camera (rather than the calibration target) is
 shifted for grabbing images.**
-@param imagePoints See calibrateCamera() for details.
+@param imagePoints Vector of vectors of the projections of calibration pattern points. See
+calibrateCamera() for details.
 @param imageSize Size of the image used only to initialize the intrinsic camera matrix.
 @param iFixedPoint The index of the 3D object point in objectPoints[0] to be fixed. It also acts as
 a switch for calibration method selection. If object-releasing method to be used, pass in the

--- a/modules/calib3d/include/opencv2/calib3d.hpp
+++ b/modules/calib3d/include/opencv2/calib3d.hpp
@@ -501,10 +501,11 @@ vector\<Point3f\> ), where N is the number of points in the view.
 4, 5, 8, 12 or 14 elements. If the vector is empty, the zero distortion coefficients are assumed.
 @param imagePoints Output array of image points, 2xN/Nx2 1-channel or 1xN/Nx1 2-channel, or
 vector\<Point2f\> .
-@param jacobian Optional output 2Nx(10+\<numDistCoeffs\>) jacobian matrix of derivatives of image
+@param jacobian Optional output 2Nx(10+\<numDistCoeffs\>+3N) jacobian matrix of derivatives of image
 points with respect to components of the rotation vector, translation vector, focal lengths,
-coordinates of the principal point and the distortion coefficients. In the old interface different
-components of the jacobian are returned via different output parameters.
+coordinates of the principal point, the distortion coefficients and coordinates of the object
+points. In the old interface different components of the jacobian are returned via different output
+parameters.
 @param aspectRatio Optional "fixed aspect ratio" parameter. If the parameter is not 0, the
 function assumes that the aspect ratio (*fx/fy*) is fixed and correspondingly adjusts the jacobian
 matrix.

--- a/modules/calib3d/include/opencv2/calib3d.hpp
+++ b/modules/calib3d/include/opencv2/calib3d.hpp
@@ -993,7 +993,8 @@ the top-right corner point of the calibration board grid. This parameter is used
 CALIB_RELEASE_OBJECT is set. In other cases it can be set to -1 which is just ignored internally.
 According to \cite strobl2011iccv, two other points are also fixed. In this implementation,
 objectPoints[0].front and objectPoints[0].back.z are used. Accurate rvecs and tvecs are only possible
-if coordinates of these three fixed points are accurate enough.
+if coordinates of these three fixed points are accurate enough. In theory, the three fixed points
+can be arbitrarily chosen as long as they are not collinear.
 @param cameraMatrix Output 3x3 floating-point camera matrix
 \f$A = \vecthreethree{f_x}{0}{c_x}{0}{f_y}{c_y}{0}{0}{1}\f$ . If CV\_CALIB\_USE\_INTRINSIC\_GUESS
 and/or CALIB_FIX_ASPECT_RATIO are specified, some or all of fx, fy, cx, cy must be
@@ -1065,14 +1066,14 @@ more accurate intrinsic camera parameters.
 @return the overall RMS re-projection error.
 
 The function estimates the intrinsic camera parameters and extrinsic parameters for each of the
-views. The algorithm is based on @cite Zhang2000 and @cite BouguetMCT . The coordinates of 3D object
-points and their corresponding 2D projections in each view must be specified. That may be achieved
-by using an object with a known geometry and easily detectable feature points. Such an object is
-called a calibration rig or calibration pattern, and OpenCV has built-in support for a chessboard as
-a calibration rig (see findChessboardCorners ). Currently, initialization of intrinsic parameters
-(when CALIB_USE_INTRINSIC_GUESS is not set) is only implemented for planar calibration
-patterns (where Z-coordinates of the object points must be all zeros). 3D calibration rigs can also
-be used as long as initial cameraMatrix is provided.
+views. The algorithm is based on @cite Zhang2000, @cite BouguetMCT and @cite strobl2011iccv. The
+coordinates of 3D object points and their corresponding 2D projections in each view must be specified.
+That may be achieved by using an object with a known geometry and easily detectable feature points.
+Such an object is called a calibration rig or calibration pattern, and OpenCV has built-in support
+for a chessboard as a calibration rig (see findChessboardCorners). Currently, initialization of
+intrinsic parameters (when CALIB_USE_INTRINSIC_GUESS is not set) is only implemented for planar
+calibration patterns (where Z-coordinates of the object points must be all zeros). 3D calibration
+rigs can also be used as long as initial cameraMatrix is provided.
 
 The algorithm performs the following steps:
 

--- a/modules/calib3d/include/opencv2/calib3d.hpp
+++ b/modules/calib3d/include/opencv2/calib3d.hpp
@@ -1132,14 +1132,7 @@ CV_EXPORTS_AS(calibrateCameraExtended) double calibrateCamera( InputArrayOfArray
                                      int flags = 0, TermCriteria criteria = TermCriteria(
                                         TermCriteria::COUNT + TermCriteria::EPS, 30, DBL_EPSILON) );
 
-/** @overload double calibrateCamera( InputArrayOfArrays objectPoints,
-                                     InputArrayOfArrays imagePoints, Size imageSize,
-                                     InputOutputArray cameraMatrix, InputOutputArray distCoeffs,
-                                     OutputArrayOfArrays rvecs, OutputArrayOfArrays tvecs,
-                                     OutputArray stdDeviations, OutputArray perViewErrors,
-                                     int flags = 0, TermCriteria criteria = TermCriteria(
-                                        TermCriteria::COUNT + TermCriteria::EPS, 30, DBL_EPSILON) )
- */
+/** @overload */
 CV_EXPORTS_W double calibrateCamera( InputArrayOfArrays objectPoints,
                                      InputArrayOfArrays imagePoints, Size imageSize,
                                      InputOutputArray cameraMatrix, InputOutputArray distCoeffs,

--- a/modules/calib3d/include/opencv2/calib3d.hpp
+++ b/modules/calib3d/include/opencv2/calib3d.hpp
@@ -1100,8 +1100,10 @@ CV_EXPORTS_W double calibrateCamera( InputArrayOfArrays objectPoints,
 /** @brief Finds the camera intrinsic and extrinsic parameters from several views of a calibration pattern.
 
 This function is an extension of calibrateCamera() with the method of releasing object which was
-proposed in @cite strobl2011iccv. When the input data are not qualified, it'll fall back to standard
-calibration method. In the internal implementation, calibrateCamera() is a wrapper for this function.
+proposed in @cite strobl2011iccv. In many common cases with inaccurate, unmeasured, roughly planar
+targets (calibration plates), this method can dramatically improve the precision of the estimated
+camera parameters. When the input data are not qualified, it'll fall back to standard calibration
+method. In the internal implementation, calibrateCamera() is a wrapper for this function.
 
 @param objectPoints See calibrateCamera() for details. If the method of releasing object to be used,
 the identical calibration board must be used in each view and it must be fully visible. All

--- a/modules/calib3d/include/opencv2/calib3d.hpp
+++ b/modules/calib3d/include/opencv2/calib3d.hpp
@@ -1107,7 +1107,9 @@ method. In the internal implementation, calibrateCamera() is a wrapper for this 
 
 @param objectPoints See calibrateCamera() for details. If the method of releasing object to be used,
 the identical calibration board must be used in each view and it must be fully visible. All
-objectPoints[i] must be the same and all points should be roughly close to a plane.
+objectPoints[i] must be the same and all points should be roughly close to a plane. **The calibration
+target has to be rigid, or at least static if the camera (rather than the calibration target) is
+shifted for grabbing images.**
 @param imagePoints See calibrateCamera() for details.
 @param imageSize Size of the image used only to initialize the intrinsic camera matrix.
 @param iFixedPoint The index of the 3D object point in objectPoints[0] to be fixed. Usually it is

--- a/modules/calib3d/include/opencv2/calib3d.hpp
+++ b/modules/calib3d/include/opencv2/calib3d.hpp
@@ -279,8 +279,6 @@ enum { CALIB_USE_INTRINSIC_GUESS = 0x00001,
        CALIB_ZERO_DISPARITY      = 0x00400,
        CALIB_USE_LU              = (1 << 17), //!< use LU instead of SVD decomposition for solving. much faster but potentially less precise
        CALIB_USE_EXTRINSIC_GUESS = (1 << 22), //!< for stereoCalibrate
-       //! Release object points while optimization. The method is described in \cite strobl2011iccv
-       CALIB_RELEASE_OBJECT      = (1 << 23),
      };
 
 //! the algorithm for finding fundamental matrix

--- a/modules/calib3d/include/opencv2/calib3d.hpp
+++ b/modules/calib3d/include/opencv2/calib3d.hpp
@@ -503,11 +503,10 @@ vector\<Point3f\> ), where N is the number of points in the view.
 4, 5, 8, 12 or 14 elements. If the vector is empty, the zero distortion coefficients are assumed.
 @param imagePoints Output array of image points, 2xN/Nx2 1-channel or 1xN/Nx1 2-channel, or
 vector\<Point2f\> .
-@param jacobian Optional output 2Nx(10+\<numDistCoeffs\>+3N) jacobian matrix of derivatives of image
+@param jacobian Optional output 2Nx(10+\<numDistCoeffs\>) jacobian matrix of derivatives of image
 points with respect to components of the rotation vector, translation vector, focal lengths,
-coordinates of the principal point, the distortion coefficients and coordinates of the object
-points. In the old interface different components of the jacobian are returned via different output
-parameters.
+coordinates of the principal point and the distortion coefficients. In the old interface different
+components of the jacobian are returned via different output parameters.
 @param aspectRatio Optional "fixed aspect ratio" parameter. If the parameter is not 0, the
 function assumes that the aspect ratio (*fx/fy*) is fixed and correspondingly adjusts the jacobian
 matrix.

--- a/modules/calib3d/include/opencv2/calib3d.hpp
+++ b/modules/calib3d/include/opencv2/calib3d.hpp
@@ -1060,7 +1060,9 @@ the optimization. If CALIB_USE_INTRINSIC_GUESS is set, the coefficient from the
 supplied distCoeffs matrix is used. Otherwise, it is set to 0.
 -   **CALIB_RELEASE_OBJECT** Release object points to calibrate more accurately with imperfect
 planar target. For inaccurate calibration boards, this method \cite strobl2011iccv will deliver
-more accurate intrinsic camera parameters.
+more accurate intrinsic camera parameters. The calibration time may be much longer if this flag
+is set. CALIB_USE_QR or CALIB_USE_LU could be used for faster calibration with potentially less
+precise and less stable in some rare cases.
 @param criteria Termination criteria for the iterative optimization algorithm.
 
 @return the overall RMS re-projection error.

--- a/modules/calib3d/include/opencv2/calib3d.hpp
+++ b/modules/calib3d/include/opencv2/calib3d.hpp
@@ -279,6 +279,8 @@ enum { CALIB_USE_INTRINSIC_GUESS = 0x00001,
        CALIB_ZERO_DISPARITY      = 0x00400,
        CALIB_USE_LU              = (1 << 17), //!< use LU instead of SVD decomposition for solving. much faster but potentially less precise
        CALIB_USE_EXTRINSIC_GUESS = (1 << 22), //!< for stereoCalibrate
+       //! Release object points while optimization. The method is described in \cite strobl2011iccv
+       CALIB_RELEASE_OBJECT      = (1 << 23),
      };
 
 //! the algorithm for finding fundamental matrix

--- a/modules/calib3d/include/opencv2/calib3d.hpp
+++ b/modules/calib3d/include/opencv2/calib3d.hpp
@@ -170,7 +170,7 @@ pattern (every view is described by several 3D-2D point correspondences).
 *rectification* transformation that makes the camera optical axes parallel.
 
 @note
-   -   A calibration sample for 3 cameras in horizontal position can be found at
+    -   A calibration sample for 3 cameras in horizontal position can be found at
         opencv_source_code/samples/cpp/3calibration.cpp
     -   A calibration sample based on a sequence of images can be found at
         opencv_source_code/samples/cpp/calibration.cpp

--- a/modules/calib3d/include/opencv2/calib3d.hpp
+++ b/modules/calib3d/include/opencv2/calib3d.hpp
@@ -1145,7 +1145,7 @@ calibrateCamera() for other detailed explanations.
 @sa
    calibrateCamera, findChessboardCorners, solvePnP, initCameraMatrix2D, stereoCalibrate, undistort
  */
-CV_EXPORTS_AS(calibrateCameraExtended) double calibrateCameraRO( InputArrayOfArrays objectPoints,
+CV_EXPORTS_AS(calibrateCameraROExtended) double calibrateCameraRO( InputArrayOfArrays objectPoints,
                                      InputArrayOfArrays imagePoints, Size imageSize, int iFixedPoint,
                                      InputOutputArray cameraMatrix, InputOutputArray distCoeffs,
                                      OutputArrayOfArrays rvecs, OutputArrayOfArrays tvecs,

--- a/modules/calib3d/include/opencv2/calib3d.hpp
+++ b/modules/calib3d/include/opencv2/calib3d.hpp
@@ -1102,22 +1102,25 @@ CV_EXPORTS_W double calibrateCamera( InputArrayOfArrays objectPoints,
 This function is an extension of calibrateCamera() with the method of releasing object which was
 proposed in @cite strobl2011iccv. In many common cases with inaccurate, unmeasured, roughly planar
 targets (calibration plates), this method can dramatically improve the precision of the estimated
-camera parameters. When the input data are not qualified, it'll fall back to standard calibration
-method. In the internal implementation, calibrateCamera() is a wrapper for this function.
+camera parameters. Both the object-releasing method and standard method are supported by this
+function. Use the parameter **iFixedPoint** for method selection. In the internal implementation,
+calibrateCamera() is a wrapper for this function.
 
 @param objectPoints See calibrateCamera() for details. If the method of releasing object to be used,
-the identical calibration board must be used in each view and it must be fully visible. All
+the identical calibration board must be used in each view and it must be fully visible, and all
 objectPoints[i] must be the same and all points should be roughly close to a plane. **The calibration
 target has to be rigid, or at least static if the camera (rather than the calibration target) is
 shifted for grabbing images.**
 @param imagePoints See calibrateCamera() for details.
 @param imageSize Size of the image used only to initialize the intrinsic camera matrix.
-@param iFixedPoint The index of the 3D object point in objectPoints[0] to be fixed. Usually it is
-the top-right corner point of the calibration board grid. If it is set to a negative value, standard
-calibration method will be used. According to \cite strobl2011iccv, two other points are also fixed.
-In this implementation, objectPoints[0].front and objectPoints[0].back.z are used. Accurate rvecs
-and tvecs are only possible if coordinates of these three fixed points are accurate enough. In
-theory, the three fixed points can be arbitrarily chosen as long as they are not collinear.
+@param iFixedPoint The index of the 3D object point in objectPoints[0] to be fixed. It also acts as
+a switch for calibration method selection. If object-releasing method to be used, pass in the
+parameter in the range of [1, objectPoints[0].size()-2], otherwise a value out of this range will
+make standard calibration method selected. Usually the top-right corner point of the calibration
+board grid is recommended to be fixed when object-releasing method being utilized. According to
+\cite strobl2011iccv, two other points are also fixed. In this implementation, objectPoints[0].front
+and objectPoints[0].back.z are used. With object-releasing method, accurate rvecs, tvecs and
+newObjPoints are only possible if coordinates of these three fixed points are accurate enough.
 @param cameraMatrix Output 3x3 floating-point camera matrix. See calibrateCamera() for details.
 @param distCoeffs Output vector of distortion coefficients. See calibrateCamera() for details.
 @param rvecs Output vector of rotation vectors estimated for each pattern view. See calibrateCamera()

--- a/modules/calib3d/include/opencv2/calib3d/calib3d_c.h
+++ b/modules/calib3d/include/opencv2/calib3d/calib3d_c.h
@@ -263,6 +263,22 @@ CVAPI(double) cvCalibrateCamera2( const CvMat* object_points,
                                 CvTermCriteria term_crit CV_DEFAULT(cvTermCriteria(
                                     CV_TERMCRIT_ITER+CV_TERMCRIT_EPS,30,DBL_EPSILON)) );
 
+/* Finds intrinsic and extrinsic camera parameters
+   from a few views of known calibration pattern */
+CVAPI(double) cvCalibrateCamera4( const CvMat* object_points,
+                                const CvMat* image_points,
+                                const CvMat* point_counts,
+                                CvSize image_size,
+                                int iFixedPoint,
+                                CvMat* camera_matrix,
+                                CvMat* distortion_coeffs,
+                                CvMat* rotation_vectors CV_DEFAULT(NULL),
+                                CvMat* translation_vectors CV_DEFAULT(NULL),
+                                CvMat* newObjPoints CV_DEFAULT(NULL),
+                                int flags CV_DEFAULT(0),
+                                CvTermCriteria term_crit CV_DEFAULT(cvTermCriteria(
+                                    CV_TERMCRIT_ITER+CV_TERMCRIT_EPS,30,DBL_EPSILON)) );
+
 /* Computes various useful characteristics of the camera from the data computed by
    cvCalibrateCamera2 */
 CVAPI(void) cvCalibrationMatrixValues( const CvMat *camera_matrix,

--- a/modules/calib3d/include/opencv2/calib3d/calib3d_c.h
+++ b/modules/calib3d/include/opencv2/calib3d/calib3d_c.h
@@ -185,6 +185,7 @@ CVAPI(void) cvProjectPoints2( const CvMat* object_points, const CvMat* rotation_
                               CvMat* dpdrot CV_DEFAULT(NULL), CvMat* dpdt CV_DEFAULT(NULL),
                               CvMat* dpdf CV_DEFAULT(NULL), CvMat* dpdc CV_DEFAULT(NULL),
                               CvMat* dpddist CV_DEFAULT(NULL),
+                              CvMat* dpdo CV_DEFAULT(NULL),
                               double aspect_ratio CV_DEFAULT(0));
 
 /* Finds extrinsic camera parameters from

--- a/modules/calib3d/include/opencv2/calib3d/calib3d_c.h
+++ b/modules/calib3d/include/opencv2/calib3d/calib3d_c.h
@@ -185,7 +185,6 @@ CVAPI(void) cvProjectPoints2( const CvMat* object_points, const CvMat* rotation_
                               CvMat* dpdrot CV_DEFAULT(NULL), CvMat* dpdt CV_DEFAULT(NULL),
                               CvMat* dpdf CV_DEFAULT(NULL), CvMat* dpdc CV_DEFAULT(NULL),
                               CvMat* dpddist CV_DEFAULT(NULL),
-                              CvMat* dpdo CV_DEFAULT(NULL),
                               double aspect_ratio CV_DEFAULT(0));
 
 /* Finds extrinsic camera parameters from

--- a/modules/calib3d/src/calibration.cpp
+++ b/modules/calib3d/src/calibration.cpp
@@ -3517,6 +3517,35 @@ double cv::calibrateCamera(InputArrayOfArrays _objectPoints,
                             OutputArray stdDeviationsExtrinsics,
                             OutputArray _perViewErrors, int flags, TermCriteria criteria )
 {
+    return calibrateCamera(_objectPoints, _imagePoints, imageSize, -1, _cameraMatrix, _distCoeffs,
+                           _rvecs, _tvecs, noArray(), stdDeviationsIntrinsics, stdDeviationsExtrinsics,
+                           noArray(), _perViewErrors, flags, criteria);
+}
+
+double cv::calibrateCamera(InputArrayOfArrays _objectPoints,
+                           InputArrayOfArrays _imagePoints,
+                           Size imageSize, int iFixedPoint, InputOutputArray _cameraMatrix,
+                           InputOutputArray _distCoeffs,
+                           OutputArrayOfArrays _rvecs, OutputArrayOfArrays _tvecs,
+                           OutputArray newObjPoints,
+                           int flags, TermCriteria criteria)
+{
+    return calibrateCamera(_objectPoints, _imagePoints, imageSize, iFixedPoint, _cameraMatrix,
+                           _distCoeffs, _rvecs, _tvecs, newObjPoints, noArray(), noArray(),
+                           noArray(), noArray(), flags, criteria);
+}
+
+double cv::calibrateCamera(InputArrayOfArrays _objectPoints,
+                            InputArrayOfArrays _imagePoints,
+                            Size imageSize, int iFixedPoint, InputOutputArray _cameraMatrix,
+                            InputOutputArray _distCoeffs,
+                            OutputArrayOfArrays _rvecs, OutputArrayOfArrays _tvecs,
+                            OutputArray newObjPoints,
+                            OutputArray stdDeviationsIntrinsics,
+                            OutputArray stdDeviationsExtrinsics,
+                            OutputArray stdDeviationsObjPoints,
+                            OutputArray _perViewErrors, int flags, TermCriteria criteria )
+{
     CV_INSTRUMENT_REGION();
 
     int rtype = CV_64F;

--- a/modules/calib3d/src/calibration.cpp
+++ b/modules/calib3d/src/calibration.cpp
@@ -3603,34 +3603,38 @@ double cv::calibrateCamera(InputArrayOfArrays _objectPoints,
                             OutputArray stdDeviationsExtrinsics,
                             OutputArray _perViewErrors, int flags, TermCriteria criteria )
 {
-    return calibrateCamera(_objectPoints, _imagePoints, imageSize, -1, _cameraMatrix, _distCoeffs,
-                           _rvecs, _tvecs, noArray(), stdDeviationsIntrinsics, stdDeviationsExtrinsics,
-                           noArray(), _perViewErrors, flags, criteria);
+    CV_INSTRUMENT_REGION();
+
+    return calibrateCameraRO(_objectPoints, _imagePoints, imageSize, -1, _cameraMatrix, _distCoeffs,
+                             _rvecs, _tvecs, noArray(), stdDeviationsIntrinsics, stdDeviationsExtrinsics,
+                             noArray(), _perViewErrors, flags, criteria);
 }
 
-double cv::calibrateCamera(InputArrayOfArrays _objectPoints,
-                           InputArrayOfArrays _imagePoints,
-                           Size imageSize, int iFixedPoint, InputOutputArray _cameraMatrix,
-                           InputOutputArray _distCoeffs,
-                           OutputArrayOfArrays _rvecs, OutputArrayOfArrays _tvecs,
-                           OutputArray newObjPoints,
-                           int flags, TermCriteria criteria)
+double cv::calibrateCameraRO(InputArrayOfArrays _objectPoints,
+                             InputArrayOfArrays _imagePoints,
+                             Size imageSize, int iFixedPoint, InputOutputArray _cameraMatrix,
+                             InputOutputArray _distCoeffs,
+                             OutputArrayOfArrays _rvecs, OutputArrayOfArrays _tvecs,
+                             OutputArray newObjPoints,
+                             int flags, TermCriteria criteria)
 {
-    return calibrateCamera(_objectPoints, _imagePoints, imageSize, iFixedPoint, _cameraMatrix,
-                           _distCoeffs, _rvecs, _tvecs, newObjPoints, noArray(), noArray(),
-                           noArray(), noArray(), flags, criteria);
+    CV_INSTRUMENT_REGION();
+
+    return calibrateCameraRO(_objectPoints, _imagePoints, imageSize, iFixedPoint, _cameraMatrix,
+                             _distCoeffs, _rvecs, _tvecs, newObjPoints, noArray(), noArray(),
+                             noArray(), noArray(), flags, criteria);
 }
 
-double cv::calibrateCamera(InputArrayOfArrays _objectPoints,
-                            InputArrayOfArrays _imagePoints,
-                            Size imageSize, int iFixedPoint, InputOutputArray _cameraMatrix,
-                            InputOutputArray _distCoeffs,
-                            OutputArrayOfArrays _rvecs, OutputArrayOfArrays _tvecs,
-                            OutputArray newObjPoints,
-                            OutputArray stdDeviationsIntrinsics,
-                            OutputArray stdDeviationsExtrinsics,
-                            OutputArray stdDeviationsObjPoints,
-                            OutputArray _perViewErrors, int flags, TermCriteria criteria )
+double cv::calibrateCameraRO(InputArrayOfArrays _objectPoints,
+                             InputArrayOfArrays _imagePoints,
+                             Size imageSize, int iFixedPoint, InputOutputArray _cameraMatrix,
+                             InputOutputArray _distCoeffs,
+                             OutputArrayOfArrays _rvecs, OutputArrayOfArrays _tvecs,
+                             OutputArray newObjPoints,
+                             OutputArray stdDeviationsIntrinsics,
+                             OutputArray stdDeviationsExtrinsics,
+                             OutputArray stdDeviationsObjPoints,
+                             OutputArray _perViewErrors, int flags, TermCriteria criteria )
 {
     CV_INSTRUMENT_REGION();
 

--- a/modules/calib3d/src/calibration.cpp
+++ b/modules/calib3d/src/calibration.cpp
@@ -762,6 +762,7 @@ CV_IMPL void cvProjectPoints2( const CvMat* objectPoints,
         }
         else
             _dpdo.reset( cvCreateMat( 2 * count, 3 * count, CV_64FC1 ) );
+        cvZero(_dpdo);
         dpdo_p = _dpdo->data.db;
         dpdo_step = _dpdo->step / sizeof( dpdo_p[0] );
     }

--- a/modules/calib3d/src/calibration.cpp
+++ b/modules/calib3d/src/calibration.cpp
@@ -3373,7 +3373,9 @@ void cv::projectPoints( InputArray _opoints,
     CV_Assert(npoints >= 0 && (depth == CV_32F || depth == CV_64F));
 
     CvMat dpdrot, dpdt, dpdf, dpdc, dpddist;
+    CvMat dpdo;
     CvMat *pdpdrot=0, *pdpdt=0, *pdpdf=0, *pdpdc=0, *pdpddist=0;
+    CvMat* pdpdo=0;
 
     _ipoints.create(npoints, 1, CV_MAKETYPE(depth, 2), -1, true);
     Mat imagePoints = _ipoints.getMat();
@@ -3396,17 +3398,18 @@ void cv::projectPoints( InputArray _opoints,
     Mat jacobian;
     if( _jacobian.needed() )
     {
-        _jacobian.create(npoints*2, 3+3+2+2+ndistCoeffs, CV_64F);
+        _jacobian.create(npoints*2, 3+3+2+2+ndistCoeffs+npoints*3, CV_64F);
         jacobian = _jacobian.getMat();
         pdpdrot = &(dpdrot = cvMat(jacobian.colRange(0, 3)));
         pdpdt = &(dpdt = cvMat(jacobian.colRange(3, 6)));
         pdpdf = &(dpdf = cvMat(jacobian.colRange(6, 8)));
         pdpdc = &(dpdc = cvMat(jacobian.colRange(8, 10)));
         pdpddist = &(dpddist = cvMat(jacobian.colRange(10, 10+ndistCoeffs)));
+        pdpdo = &(dpdo = cvMat(jacobian.colRange(10+ndistCoeffs, jacobian.cols)));
     }
 
     cvProjectPoints2( &c_objectPoints, &c_rvec, &c_tvec, &c_cameraMatrix, &c_distCoeffs,
-                      &c_imagePoints, pdpdrot, pdpdt, pdpdf, pdpdc, pdpddist, NULL, aspectRatio );
+                      &c_imagePoints, pdpdrot, pdpdt, pdpdf, pdpdc, pdpddist, pdpdo, aspectRatio );
 }
 
 cv::Mat cv::initCameraMatrix2D( InputArrayOfArrays objectPoints,

--- a/modules/calib3d/src/calibration.cpp
+++ b/modules/calib3d/src/calibration.cpp
@@ -1847,6 +1847,8 @@ CV_IMPL double cvCalibrateCamera2( const CvMat* objectPoints,
                     CvSize imageSize, CvMat* cameraMatrix, CvMat* distCoeffs,
                     CvMat* rvecs, CvMat* tvecs, int flags, CvTermCriteria termCrit )
 {
+    // Don't accept CALIB_RELEASE_OBJECT
+    flags &= ~CALIB_RELEASE_OBJECT;
     return cvCalibrateCamera2Internal(objectPoints, imagePoints, npoints, imageSize, -1, cameraMatrix,
                                       distCoeffs, rvecs, tvecs, NULL, NULL, NULL, flags, termCrit);
 }

--- a/modules/calib3d/src/calibration.cpp
+++ b/modules/calib3d/src/calibration.cpp
@@ -1871,6 +1871,9 @@ CV_IMPL double cvCalibrateCamera4( const CvMat* objectPoints,
                     CvSize imageSize, int iFixedPoint, CvMat* cameraMatrix, CvMat* distCoeffs,
                     CvMat* rvecs, CvMat* tvecs, CvMat* newObjPoints, int flags, CvTermCriteria termCrit )
 {
+    // If iFixedPoint is out of rational range, fall back to standard method
+    if( iFixedPoint < 1 || iFixedPoint > npoints->data.i[0] - 2 )
+        flags &= ~CALIB_RELEASE_OBJECT;
     // check object points. If not qualified, fall back to standard calibration.
     int nimages = npoints->rows * npoints->cols;
     int npstep = npoints->rows == 1 ? 1 : npoints->step / CV_ELEM_SIZE(npoints->type);

--- a/modules/calib3d/src/calibration.cpp
+++ b/modules/calib3d/src/calibration.cpp
@@ -3630,11 +3630,8 @@ double cv::calibrateCamera(InputArrayOfArrays _objectPoints,
     collectCalibrationData( _objectPoints, _imagePoints, noArray(), flags,
                             objPt, imgPt, 0, npoints );
     // If iFixedPoint is out of rational range, fall back to standard method
-    if( flags & CALIB_RELEASE_OBJECT )
-    {
-        if( iFixedPoint < 1 || iFixedPoint > npoints.at<int>(0) - 2 )
-            flags ^= CALIB_RELEASE_OBJECT;
-    }
+    if( iFixedPoint < 1 || iFixedPoint > npoints.at<int>(0) - 2 )
+        flags &= ~CALIB_RELEASE_OBJECT;
 
     newobj_needed = newobj_needed && (flags & CALIB_RELEASE_OBJECT);
     int np = npoints.at<int>( 0 );

--- a/modules/calib3d/test/test_cameracalibration.cpp
+++ b/modules/calib3d/test/test_cameracalibration.cpp
@@ -1080,6 +1080,7 @@ protected:
         vector<Point2f>& imagePoints,
         Mat& dpdrot, Mat& dpdt, Mat& dpdf,
         Mat& dpdc, Mat& dpddist,
+        Mat& dpdo,
         double aspectRatio=0 ) = 0;
 };
 
@@ -1136,9 +1137,10 @@ void CV_ProjectPointsTest::run(int)
     vector<vector<Point2f> > rightImgPoints;
     Mat dpdrot, dpdt, dpdf, dpdc, dpddist,
         valDpdrot, valDpdt, valDpdf, valDpdc, valDpddist;
+    Mat dpdo, valDpdo;
 
     project( objPoints, rvec, tvec, cameraMatrix, distCoeffs,
-        imgPoints, dpdrot, dpdt, dpdf, dpdc, dpddist, 0 );
+        imgPoints, dpdrot, dpdt, dpdf, dpdc, dpddist, dpdo, 0 );
 
     // calculate and check image points
     assert( (int)imgPoints.size() == pointCount );
@@ -1178,10 +1180,10 @@ void CV_ProjectPointsTest::run(int)
     {
         rvec.copyTo( leftRvec ); leftRvec(0,i) -= dEps;
         project( objPoints, leftRvec, tvec, cameraMatrix, distCoeffs,
-            leftImgPoints[i], valDpdrot, valDpdt, valDpdf, valDpdc, valDpddist, 0 );
+            leftImgPoints[i], valDpdrot, valDpdt, valDpdf, valDpdc, valDpddist, valDpdo, 0 );
         rvec.copyTo( rightRvec ); rightRvec(0,i) += dEps;
         project( objPoints, rightRvec, tvec, cameraMatrix, distCoeffs,
-            rightImgPoints[i], valDpdrot, valDpdt, valDpdf, valDpdc, valDpddist, 0 );
+            rightImgPoints[i], valDpdrot, valDpdt, valDpdf, valDpdc, valDpddist, valDpdo, 0 );
     }
     calcdfdx( leftImgPoints, rightImgPoints, dEps, valDpdrot );
     err = cvtest::norm( dpdrot, valDpdrot, NORM_INF );
@@ -1196,10 +1198,10 @@ void CV_ProjectPointsTest::run(int)
     {
         tvec.copyTo( leftTvec ); leftTvec(0,i) -= dEps;
         project( objPoints, rvec, leftTvec, cameraMatrix, distCoeffs,
-            leftImgPoints[i], valDpdrot, valDpdt, valDpdf, valDpdc, valDpddist, 0 );
+            leftImgPoints[i], valDpdrot, valDpdt, valDpdf, valDpdc, valDpddist, valDpdo, 0 );
         tvec.copyTo( rightTvec ); rightTvec(0,i) += dEps;
         project( objPoints, rvec, rightTvec, cameraMatrix, distCoeffs,
-            rightImgPoints[i], valDpdrot, valDpdt, valDpdf, valDpdc, valDpddist, 0 );
+            rightImgPoints[i], valDpdrot, valDpdt, valDpdf, valDpdc, valDpddist, valDpdo, 0 );
     }
     calcdfdx( leftImgPoints, rightImgPoints, dEps, valDpdt );
     if( cvtest::norm( dpdt, valDpdt, NORM_INF ) > 0.2 )
@@ -1214,16 +1216,16 @@ void CV_ProjectPointsTest::run(int)
     rightImgPoints.resize(2);
     cameraMatrix.copyTo( leftCameraMatrix ); leftCameraMatrix(0,0) -= dEps;
     project( objPoints, rvec, tvec, leftCameraMatrix, distCoeffs,
-        leftImgPoints[0], valDpdrot, valDpdt, valDpdf, valDpdc, valDpddist, 0 );
+        leftImgPoints[0], valDpdrot, valDpdt, valDpdf, valDpdc, valDpddist, valDpdo, 0 );
     cameraMatrix.copyTo( leftCameraMatrix ); leftCameraMatrix(1,1) -= dEps;
     project( objPoints, rvec, tvec, leftCameraMatrix, distCoeffs,
-        leftImgPoints[1], valDpdrot, valDpdt, valDpdf, valDpdc, valDpddist, 0 );
+        leftImgPoints[1], valDpdrot, valDpdt, valDpdf, valDpdc, valDpddist, valDpdo, 0 );
     cameraMatrix.copyTo( rightCameraMatrix ); rightCameraMatrix(0,0) += dEps;
     project( objPoints, rvec, tvec, rightCameraMatrix, distCoeffs,
-        rightImgPoints[0], valDpdrot, valDpdt, valDpdf, valDpdc, valDpddist, 0 );
+        rightImgPoints[0], valDpdrot, valDpdt, valDpdf, valDpdc, valDpddist, valDpdo, 0 );
     cameraMatrix.copyTo( rightCameraMatrix ); rightCameraMatrix(1,1) += dEps;
     project( objPoints, rvec, tvec, rightCameraMatrix, distCoeffs,
-        rightImgPoints[1], valDpdrot, valDpdt, valDpdf, valDpdc, valDpddist, 0 );
+        rightImgPoints[1], valDpdrot, valDpdt, valDpdf, valDpdc, valDpddist, valDpdo, 0 );
     calcdfdx( leftImgPoints, rightImgPoints, dEps, valDpdf );
     if ( cvtest::norm( dpdf, valDpdf, NORM_L2 ) > 0.2 )
     {
@@ -1235,16 +1237,16 @@ void CV_ProjectPointsTest::run(int)
     rightImgPoints.resize(2);
     cameraMatrix.copyTo( leftCameraMatrix ); leftCameraMatrix(0,2) -= dEps;
     project( objPoints, rvec, tvec, leftCameraMatrix, distCoeffs,
-        leftImgPoints[0], valDpdrot, valDpdt, valDpdf, valDpdc, valDpddist, 0 );
+        leftImgPoints[0], valDpdrot, valDpdt, valDpdf, valDpdc, valDpddist, valDpdo, 0 );
     cameraMatrix.copyTo( leftCameraMatrix ); leftCameraMatrix(1,2) -= dEps;
     project( objPoints, rvec, tvec, leftCameraMatrix, distCoeffs,
-        leftImgPoints[1], valDpdrot, valDpdt, valDpdf, valDpdc, valDpddist, 0 );
+        leftImgPoints[1], valDpdrot, valDpdt, valDpdf, valDpdc, valDpddist, valDpdo, 0 );
     cameraMatrix.copyTo( rightCameraMatrix ); rightCameraMatrix(0,2) += dEps;
     project( objPoints, rvec, tvec, rightCameraMatrix, distCoeffs,
-        rightImgPoints[0], valDpdrot, valDpdt, valDpdf, valDpdc, valDpddist, 0 );
+        rightImgPoints[0], valDpdrot, valDpdt, valDpdf, valDpdc, valDpddist, valDpdo, 0 );
     cameraMatrix.copyTo( rightCameraMatrix ); rightCameraMatrix(1,2) += dEps;
     project( objPoints, rvec, tvec, rightCameraMatrix, distCoeffs,
-        rightImgPoints[1], valDpdrot, valDpdt, valDpdf, valDpdc, valDpddist, 0 );
+        rightImgPoints[1], valDpdrot, valDpdt, valDpdf, valDpdc, valDpddist, valDpdo, 0 );
     calcdfdx( leftImgPoints, rightImgPoints, dEps, valDpdc );
     if ( cvtest::norm( dpdc, valDpdc, NORM_L2 ) > 0.2 )
     {
@@ -1259,10 +1261,10 @@ void CV_ProjectPointsTest::run(int)
     {
         distCoeffs.copyTo( leftDistCoeffs ); leftDistCoeffs(0,i) -= dEps;
         project( objPoints, rvec, tvec, cameraMatrix, leftDistCoeffs,
-            leftImgPoints[i], valDpdrot, valDpdt, valDpdf, valDpdc, valDpddist, 0 );
+            leftImgPoints[i], valDpdrot, valDpdt, valDpdf, valDpdc, valDpddist, valDpdo, 0 );
         distCoeffs.copyTo( rightDistCoeffs ); rightDistCoeffs(0,i) += dEps;
         project( objPoints, rvec, tvec, cameraMatrix, rightDistCoeffs,
-            rightImgPoints[i], valDpdrot, valDpdt, valDpdf, valDpdc, valDpddist, 0 );
+            rightImgPoints[i], valDpdrot, valDpdt, valDpdf, valDpdc, valDpddist, valDpdo, 0 );
     }
     calcdfdx( leftImgPoints, rightImgPoints, dEps, valDpddist );
     if( cvtest::norm( dpddist, valDpddist, NORM_L2 ) > 0.3 )
@@ -1290,12 +1292,14 @@ protected:
         vector<Point2f>& imagePoints,
         Mat& dpdrot, Mat& dpdt, Mat& dpdf,
         Mat& dpdc, Mat& dpddist,
+        Mat& dpdo,
         double aspectRatio=0 );
 };
 
 void CV_ProjectPointsTest_C::project( const Mat& opoints, const Mat& rvec, const Mat& tvec,
                                        const Mat& cameraMatrix, const Mat& distCoeffs, vector<Point2f>& ipoints,
-                                       Mat& dpdrot, Mat& dpdt, Mat& dpdf, Mat& dpdc, Mat& dpddist, double aspectRatio)
+                                       Mat& dpdrot, Mat& dpdt, Mat& dpdf, Mat& dpdc, Mat& dpddist,
+                                       Mat& dpdo, double aspectRatio)
 {
     int npoints = opoints.cols*opoints.rows*opoints.channels()/3;
     ipoints.resize(npoints);
@@ -1304,13 +1308,15 @@ void CV_ProjectPointsTest_C::project( const Mat& opoints, const Mat& rvec, const
     dpdf.create(npoints*2, 2, CV_64F);
     dpdc.create(npoints*2, 2, CV_64F);
     dpddist.create(npoints*2, distCoeffs.rows + distCoeffs.cols - 1, CV_64F);
+    dpdo.create(npoints*2, npoints*3, CV_64F);
     Mat imagePoints(ipoints);
     CvMat _objectPoints = cvMat(opoints), _imagePoints = cvMat(imagePoints);
     CvMat _rvec = cvMat(rvec), _tvec = cvMat(tvec), _cameraMatrix = cvMat(cameraMatrix), _distCoeffs = cvMat(distCoeffs);
     CvMat _dpdrot = cvMat(dpdrot), _dpdt = cvMat(dpdt), _dpdf = cvMat(dpdf), _dpdc = cvMat(dpdc), _dpddist = cvMat(dpddist);
+    CvMat _dpdo = cvMat(dpdo);
 
     cvProjectPoints2( &_objectPoints, &_rvec, &_tvec, &_cameraMatrix, &_distCoeffs,
-                      &_imagePoints, &_dpdrot, &_dpdt, &_dpdf, &_dpdc, &_dpddist, NULL, aspectRatio );
+                      &_imagePoints, &_dpdrot, &_dpdt, &_dpdf, &_dpdc, &_dpddist, &_dpdo, aspectRatio );
 }
 
 
@@ -1327,12 +1333,14 @@ protected:
         vector<Point2f>& imagePoints,
         Mat& dpdrot, Mat& dpdt, Mat& dpdf,
         Mat& dpdc, Mat& dpddist,
+        Mat& dpdo,
         double aspectRatio=0 );
 };
 
 void CV_ProjectPointsTest_CPP::project( const Mat& objectPoints, const Mat& rvec, const Mat& tvec,
                                        const Mat& cameraMatrix, const Mat& distCoeffs, vector<Point2f>& imagePoints,
-                                       Mat& dpdrot, Mat& dpdt, Mat& dpdf, Mat& dpdc, Mat& dpddist, double aspectRatio)
+                                       Mat& dpdrot, Mat& dpdt, Mat& dpdf, Mat& dpdc, Mat& dpddist,
+                                       Mat& dpdo, double aspectRatio)
 {
     Mat J;
     projectPoints( objectPoints, rvec, tvec, cameraMatrix, distCoeffs, imagePoints, J, aspectRatio);
@@ -1340,7 +1348,9 @@ void CV_ProjectPointsTest_CPP::project( const Mat& objectPoints, const Mat& rvec
     J.colRange(3, 6).copyTo(dpdt);
     J.colRange(6, 8).copyTo(dpdf);
     J.colRange(8, 10).copyTo(dpdc);
-    J.colRange(10, J.cols).copyTo(dpddist);
+    int ndistCoeffs = distCoeffs.rows + distCoeffs.cols - 1;
+    J.colRange(10, 10 + ndistCoeffs).copyTo(dpddist);
+    J.colRange(10 + ndistCoeffs, J.cols).copyTo(dpdo);
 }
 
 ///////////////////////////////// Stereo Calibration /////////////////////////////////////

--- a/modules/calib3d/test/test_cameracalibration.cpp
+++ b/modules/calib3d/test/test_cameracalibration.cpp
@@ -403,6 +403,10 @@ void CV_CameraCalibrationTest::run( int start_from )
             goto _exit_;
         }
 
+        /* Read calibration flags */
+        values_read = fscanf(file,"%d\n",&calibFlags);
+        CV_Assert(values_read == 1);
+
         /* Need to allocate memory */
         imagePoints     = (CvPoint2D64f*)cvAlloc( numPoints *
                                                     numImages * sizeof(CvPoint2D64f));
@@ -513,15 +517,6 @@ void CV_CameraCalibrationTest::run( int start_from )
             CV_Assert(values_read == 1);
         }
 
-        calibFlags = 0
-                     // + CV_CALIB_FIX_PRINCIPAL_POINT
-                     // + CV_CALIB_ZERO_TANGENT_DIST
-                     // + CV_CALIB_FIX_ASPECT_RATIO
-                     // + CV_CALIB_USE_INTRINSIC_GUESS
-                     + CV_CALIB_FIX_K3
-                     + CV_CALIB_FIX_K4+CV_CALIB_FIX_K5
-                     + CV_CALIB_FIX_K6
-                    ;
         memset( cameraMatrix, 0, 9*sizeof(cameraMatrix[0]) );
         cameraMatrix[0] = cameraMatrix[4] = 807.;
         cameraMatrix[2] = (imageSize.width - 1)*0.5;

--- a/modules/calib3d/test/test_cameracalibration.cpp
+++ b/modules/calib3d/test/test_cameracalibration.cpp
@@ -255,8 +255,9 @@ protected:
                 double eps, const char* paramName);
     virtual void calibrate( int imageCount, int* pointCounts,
         CvSize imageSize, CvPoint2D64f* imagePoints, CvPoint3D64f* objectPoints,
-        double* distortionCoeffs, double* cameraMatrix, double* translationVectors,
-        double* rotationMatrices, double *stdDevs, double* perViewErrors, int flags ) = 0;
+        int iFixedPoint, double* distortionCoeffs, double* cameraMatrix, double* translationVectors,
+        double* rotationMatrices, double* newObjPoints, double *stdDevs, double* perViewErrors,
+        int flags ) = 0;
     virtual void project( int pointCount, CvPoint3D64f* objectPoints,
         double* rotationMatrix, double*  translationVector,
         double* cameraMatrix, double* distortion, CvPoint2D64f* imagePoints ) = 0;
@@ -300,11 +301,13 @@ void CV_CameraCalibrationTest::run( int start_from )
 
     double*       transVects;
     double*       rotMatrs;
+    double*       newObjPoints;
     double*       stdDevs;
     double*       perViewErrors;
 
     double*       goodTransVects;
     double*       goodRotMatrs;
+    double*       goodObjPoints;
     double*       goodPerViewErrors;
     double*       goodStdDevs;
 
@@ -429,13 +432,17 @@ void CV_CameraCalibrationTest::run( int start_from )
         /* Allocate memory for translate vectors and rotmatrixs*/
         transVects     = (double*)cvAlloc(3 * 1 * numImages * sizeof(double));
         rotMatrs       = (double*)cvAlloc(3 * 3 * numImages * sizeof(double));
-        stdDevs        = (double*)cvAlloc((CV_CALIB_NINTRINSIC + 6*numImages) * sizeof(double));
+        newObjPoints   = (double*)cvAlloc(3 * numbers[0] * sizeof(double));
+        stdDevs        = (double*)cvAlloc((CV_CALIB_NINTRINSIC + 6*numImages + 3*numbers[0])
+                                          * sizeof(double));
         perViewErrors  = (double*)cvAlloc(numImages * sizeof(double));
 
         goodTransVects = (double*)cvAlloc(3 * 1 * numImages * sizeof(double));
         goodRotMatrs   = (double*)cvAlloc(3 * 3 * numImages * sizeof(double));
+        goodObjPoints  = (double*)cvAlloc(3 * numbers[0] * sizeof(double));
         goodPerViewErrors  = (double*)cvAlloc(numImages * sizeof(double));
-        goodStdDevs = (double*)cvAlloc((CV_CALIB_NINTRINSIC + 6*numImages) * sizeof(double));
+        goodStdDevs = (double*)cvAlloc((CV_CALIB_NINTRINSIC + 6*numImages + 3*numbers[0])
+                                       * sizeof(double));
 
         /* Read object points */
         i = 0;/* shift for current point */
@@ -510,11 +517,33 @@ void CV_CameraCalibrationTest::run( int start_from )
             }
         }
 
+        /* Read good refined 3D object points */
+        if( calibFlags & CALIB_RELEASE_OBJECT )
+        {
+            for( i = 0; i < numbers[0]; i++ )
+            {
+                for( j = 0; j < 3; j++ )
+                {
+                    values_read = fscanf(file, "%lf", goodObjPoints + i * 3 + j);
+                    CV_Assert(values_read == 1);
+                }
+            }
+        }
+
         /* Read good stdDeviations */
         for (i = 0; i < CV_CALIB_NINTRINSIC + numImages*6; i++)
         {
             values_read = fscanf(file, "%lf", goodStdDevs + i);
             CV_Assert(values_read == 1);
+        }
+        if( calibFlags & CALIB_RELEASE_OBJECT )
+        {
+            for( i = CV_CALIB_NINTRINSIC + numImages*6; i < CV_CALIB_NINTRINSIC + numImages*6
+                                                            + numbers[0]*3; i++ )
+            {
+                values_read = fscanf(file, "%lf", goodStdDevs + i);
+                CV_Assert(values_read == 1);
+            }
         }
 
         memset( cameraMatrix, 0, 9*sizeof(cameraMatrix[0]) );
@@ -529,10 +558,12 @@ void CV_CameraCalibrationTest::run( int start_from )
                     cvSize(imageSize),
                     imagePoints,
                     objectPoints,
+                    etalonSize.width - 1,
                     distortion,
                     cameraMatrix,
                     transVects,
                     rotMatrs,
+                    newObjPoints,
                     stdDevs,
                     perViewErrors,
                     calibFlags );
@@ -541,6 +572,11 @@ void CV_CameraCalibrationTest::run( int start_from )
         for( currImage = 0; currImage < numImages; currImage++ )
         {
             int nPoints = etalonSize.width * etalonSize.height;
+            if( calibFlags & CALIB_RELEASE_OBJECT )
+            {
+                memcpy( objectPoints + currImage * nPoints, newObjPoints,
+                        nPoints * 3 * sizeof(double) );
+            }
             project(  nPoints,
                       objectPoints + currImage * nPoints,
                       rotMatrs + currImage * 9,
@@ -634,6 +670,14 @@ void CV_CameraCalibrationTest::run( int start_from )
         if( code < 0 )
             goto _exit_;
 
+        /* ----- Compare refined 3D object points ----- */
+        if( calibFlags & CALIB_RELEASE_OBJECT )
+        {
+            code = compare(newObjPoints,goodObjPoints, 3*numbers[0],0.1,"refined 3D object points");
+            if( code < 0 )
+                goto _exit_;
+        }
+
         /* ----- Compare per view re-projection errors ----- */
         code = compare(perViewErrors,goodPerViewErrors, numImages,0.1,"per view errors vector");
         if( code < 0 )
@@ -642,12 +686,13 @@ void CV_CameraCalibrationTest::run( int start_from )
         /* ----- Compare standard deviations of parameters ----- */
         //only for c-version of test (it does not provides evaluation of stdDevs
         //and returns zeros)
-        for ( i = 0; i < CV_CALIB_NINTRINSIC + 6*numImages; i++)
+        for ( i = 0; i < CV_CALIB_NINTRINSIC + 6*numImages + 3*numbers[0]; i++)
         {
             if(stdDevs[i] == 0.0)
                 stdDevs[i] = goodStdDevs[i];
         }
-        code = compare(stdDevs,goodStdDevs, CV_CALIB_NINTRINSIC + 6*numImages,.5,"stdDevs vector");
+        code = compare(stdDevs,goodStdDevs, CV_CALIB_NINTRINSIC + 6*numImages + 3*numbers[0],.5,
+                       "stdDevs vector");
         if( code < 0 )
             goto _exit_;
 
@@ -674,10 +719,12 @@ void CV_CameraCalibrationTest::run( int start_from )
 
         cvFree(&transVects);
         cvFree(&rotMatrs);
+        cvFree(&newObjPoints);
         cvFree(&stdDevs);
         cvFree(&perViewErrors);
         cvFree(&goodTransVects);
         cvFree(&goodRotMatrs);
+        cvFree(&goodObjPoints);
         cvFree(&goodPerViewErrors);
         cvFree(&goodStdDevs);
 
@@ -716,18 +763,20 @@ public:
     CV_CameraCalibrationTest_C(){}
 protected:
     virtual void calibrate( int imageCount, int* pointCounts,
-        CvSize imageSize, CvPoint2D64f* imagePoints, CvPoint3D64f* objectPoints,
+        CvSize imageSize, CvPoint2D64f* imagePoints, CvPoint3D64f* objectPoints, int iFixedPoint,
         double* distortionCoeffs, double* cameraMatrix, double* translationVectors,
-        double* rotationMatrices, double *stdDevs, double* perViewErrors, int flags );
+        double* rotationMatrices, double* newObjPoints, double *stdDevs, double* perViewErrors,
+        int flags );
     virtual void project( int pointCount, CvPoint3D64f* objectPoints,
         double* rotationMatrix, double*  translationVector,
         double* cameraMatrix, double* distortion, CvPoint2D64f* imagePoints );
 };
 
 void CV_CameraCalibrationTest_C::calibrate(int imageCount, int* pointCounts,
-        CvSize imageSize, CvPoint2D64f* imagePoints, CvPoint3D64f* objectPoints,
+        CvSize imageSize, CvPoint2D64f* imagePoints, CvPoint3D64f* objectPoints, int iFixedPoint,
         double* distortionCoeffs, double* cameraMatrix, double* translationVectors,
-        double* rotationMatrices, double *stdDevs, double *perViewErrors, int flags )
+        double* rotationMatrices, double* newObjPoints, double *stdDevs, double *perViewErrors,
+        int flags )
 {
     int i, total = 0;
     for( i = 0; i < imageCount; i++ )
@@ -736,7 +785,7 @@ void CV_CameraCalibrationTest_C::calibrate(int imageCount, int* pointCounts,
         total += pointCounts[i];
     }
 
-    for( i = 0; i < CV_CALIB_NINTRINSIC + imageCount*6; i++)
+    for( i = 0; i < CV_CALIB_NINTRINSIC + imageCount*6 + pointCounts[0]*3; i++)
     {
         stdDevs[i] = 0.0;
     }
@@ -748,9 +797,11 @@ void CV_CameraCalibrationTest_C::calibrate(int imageCount, int* pointCounts,
     CvMat _distCoeffs = cvMat(4, 1, CV_64F, distortionCoeffs);
     CvMat _rotationMatrices = cvMat(imageCount, 9, CV_64F, rotationMatrices);
     CvMat _translationVectors = cvMat(imageCount, 3, CV_64F, translationVectors);
+    CvMat _newObjPoints = cvMat(1, pointCounts[0], CV_64FC3, newObjPoints);
 
-    cvCalibrateCamera2(&_objectPoints, &_imagePoints, &_pointCounts, imageSize,
-                       &_cameraMatrix, &_distCoeffs, &_rotationMatrices, &_translationVectors, flags);
+    cvCalibrateCamera4(&_objectPoints, &_imagePoints, &_pointCounts, imageSize, iFixedPoint,
+                       &_cameraMatrix, &_distCoeffs, &_rotationMatrices, &_translationVectors,
+                       &_newObjPoints, flags);
 }
 
 void CV_CameraCalibrationTest_C::project( int pointCount, CvPoint3D64f* objectPoints,
@@ -775,25 +826,29 @@ public:
     CV_CameraCalibrationTest_CPP(){}
 protected:
     virtual void calibrate( int imageCount, int* pointCounts,
-        CvSize imageSize, CvPoint2D64f* imagePoints, CvPoint3D64f* objectPoints,
+        CvSize imageSize, CvPoint2D64f* imagePoints, CvPoint3D64f* objectPoints, int iFixedPoint,
         double* distortionCoeffs, double* cameraMatrix, double* translationVectors,
-        double* rotationMatrices, double *stdDevs, double* perViewErrors,  int flags );
+        double* rotationMatrices, double* newObjPoints, double *stdDevs, double* perViewErrors,
+        int flags );
     virtual void project( int pointCount, CvPoint3D64f* objectPoints,
         double* rotationMatrix, double*  translationVector,
         double* cameraMatrix, double* distortion, CvPoint2D64f* imagePoints );
 };
 
 void CV_CameraCalibrationTest_CPP::calibrate(int imageCount, int* pointCounts,
-        CvSize _imageSize, CvPoint2D64f* _imagePoints, CvPoint3D64f* _objectPoints,
+        CvSize _imageSize, CvPoint2D64f* _imagePoints, CvPoint3D64f* _objectPoints, int iFixedPoint,
         double* _distortionCoeffs, double* _cameraMatrix, double* translationVectors,
-        double* rotationMatrices, double *stdDevs, double *perViewErrors, int flags )
+        double* rotationMatrices, double* newObjPoints, double *stdDevs, double *perViewErrors,
+        int flags )
 {
     vector<vector<Point3f> > objectPoints( imageCount );
     vector<vector<Point2f> > imagePoints( imageCount );
     Size imageSize = _imageSize;
     Mat cameraMatrix, distCoeffs(1,4,CV_64F,Scalar::all(0));
     vector<Mat> rvecs, tvecs;
+    Mat newObjMat;
     Mat stdDevsMatInt, stdDevsMatExt;
+    Mat stdDevsMatObj;
     Mat perViewErrorsMat;
 
     CvPoint3D64f* op = _objectPoints;
@@ -814,17 +869,33 @@ void CV_CameraCalibrationTest_CPP::calibrate(int imageCount, int* pointCounts,
         }
     }
 
+    for( int i = CV_CALIB_NINTRINSIC + imageCount*6; i < CV_CALIB_NINTRINSIC + imageCount*6
+                                                         + pointCounts[0]*3; i++)
+    {
+        stdDevs[i] = 0.0;
+    }
+
     calibrateCamera( objectPoints,
                      imagePoints,
                      imageSize,
+                     iFixedPoint,
                      cameraMatrix,
                      distCoeffs,
                      rvecs,
                      tvecs,
+                     newObjMat,
                      stdDevsMatInt,
                      stdDevsMatExt,
+                     stdDevsMatObj,
                      perViewErrorsMat,
                      flags );
+
+    if( flags & CALIB_RELEASE_OBJECT )
+    {
+        newObjMat.convertTo( newObjMat, CV_64F );
+        assert( newObjMat.total() == static_cast<size_t>(3*pointCounts[0]) );
+        memcpy( newObjPoints, newObjMat.ptr(), 3*pointCounts[0]*sizeof(double) );
+    }
 
     assert( stdDevsMatInt.type() == CV_64F );
     assert( stdDevsMatInt.total() == static_cast<size_t>(CV_CALIB_NINTRINSIC) );
@@ -833,6 +904,14 @@ void CV_CameraCalibrationTest_CPP::calibrate(int imageCount, int* pointCounts,
     assert( stdDevsMatExt.type() == CV_64F );
     assert( stdDevsMatExt.total() == static_cast<size_t>(6*imageCount) );
     memcpy( stdDevs + CV_CALIB_NINTRINSIC, stdDevsMatExt.ptr(), 6*imageCount*sizeof(double) );
+
+    if( flags & CALIB_RELEASE_OBJECT )
+    {
+        assert( stdDevsMatObj.type() == CV_64F );
+        assert( stdDevsMatObj.total() == static_cast<size_t>(3*pointCounts[0]) );
+        memcpy( stdDevs + CV_CALIB_NINTRINSIC + 6*imageCount, stdDevsMatObj.ptr(),
+                3*pointCounts[0]*sizeof(double) );
+    }
 
     assert( perViewErrorsMat.type() == CV_64F);
     assert( perViewErrorsMat.total() == static_cast<size_t>(imageCount) );

--- a/modules/calib3d/test/test_cameracalibration.cpp
+++ b/modules/calib3d/test/test_cameracalibration.cpp
@@ -1310,7 +1310,7 @@ void CV_ProjectPointsTest_C::project( const Mat& opoints, const Mat& rvec, const
     CvMat _dpdrot = cvMat(dpdrot), _dpdt = cvMat(dpdt), _dpdf = cvMat(dpdf), _dpdc = cvMat(dpdc), _dpddist = cvMat(dpddist);
 
     cvProjectPoints2( &_objectPoints, &_rvec, &_tvec, &_cameraMatrix, &_distCoeffs,
-                      &_imagePoints, &_dpdrot, &_dpdt, &_dpdf, &_dpdc, &_dpddist, aspectRatio );
+                      &_imagePoints, &_dpdrot, &_dpdt, &_dpdf, &_dpdc, &_dpddist, NULL, aspectRatio );
 }
 
 

--- a/modules/calib3d/test/test_cameracalibration.cpp
+++ b/modules/calib3d/test/test_cameracalibration.cpp
@@ -881,20 +881,20 @@ void CV_CameraCalibrationTest_CPP::calibrate(int imageCount, int* pointCounts,
         stdDevs[i] = 0.0;
     }
 
-    calibrateCamera( objectPoints,
-                     imagePoints,
-                     imageSize,
-                     iFixedPoint,
-                     cameraMatrix,
-                     distCoeffs,
-                     rvecs,
-                     tvecs,
-                     newObjMat,
-                     stdDevsMatInt,
-                     stdDevsMatExt,
-                     stdDevsMatObj,
-                     perViewErrorsMat,
-                     flags );
+    calibrateCameraRO( objectPoints,
+                       imagePoints,
+                       imageSize,
+                       iFixedPoint,
+                       cameraMatrix,
+                       distCoeffs,
+                       rvecs,
+                       tvecs,
+                       newObjMat,
+                       stdDevsMatInt,
+                       stdDevsMatExt,
+                       stdDevsMatObj,
+                       perViewErrorsMat,
+                       flags );
 
     bool releaseObject = iFixedPoint > 0 && iFixedPoint < pointCounts[0] - 1;
     if( releaseObject )

--- a/modules/calib3d/test/test_cameracalibration.cpp
+++ b/modules/calib3d/test/test_cameracalibration.cpp
@@ -1080,7 +1080,6 @@ protected:
         vector<Point2f>& imagePoints,
         Mat& dpdrot, Mat& dpdt, Mat& dpdf,
         Mat& dpdc, Mat& dpddist,
-        Mat& dpdo,
         double aspectRatio=0 ) = 0;
 };
 
@@ -1103,7 +1102,6 @@ void CV_ProjectPointsTest::run(int)
     Size imgSize( 600, 800 );
     Mat_<float> objPoints( pointCount, 3), rvec( 1, 3), rmat, tvec( 1, 3 ), cameraMatrix( 3, 3 ), distCoeffs( 1, 4 ),
       leftRvec, rightRvec, leftTvec, rightTvec, leftCameraMatrix, rightCameraMatrix, leftDistCoeffs, rightDistCoeffs;
-    Mat_<float> leftObjPoints, rightObjPoints;
 
     RNG rng = ts->get_rng();
 
@@ -1138,10 +1136,9 @@ void CV_ProjectPointsTest::run(int)
     vector<vector<Point2f> > rightImgPoints;
     Mat dpdrot, dpdt, dpdf, dpdc, dpddist,
         valDpdrot, valDpdt, valDpdf, valDpdc, valDpddist;
-    Mat dpdo, valDpdo;
 
     project( objPoints, rvec, tvec, cameraMatrix, distCoeffs,
-        imgPoints, dpdrot, dpdt, dpdf, dpdc, dpddist, dpdo, 0 );
+        imgPoints, dpdrot, dpdt, dpdf, dpdc, dpddist, 0 );
 
     // calculate and check image points
     assert( (int)imgPoints.size() == pointCount );
@@ -1181,10 +1178,10 @@ void CV_ProjectPointsTest::run(int)
     {
         rvec.copyTo( leftRvec ); leftRvec(0,i) -= dEps;
         project( objPoints, leftRvec, tvec, cameraMatrix, distCoeffs,
-            leftImgPoints[i], valDpdrot, valDpdt, valDpdf, valDpdc, valDpddist, valDpdo, 0 );
+            leftImgPoints[i], valDpdrot, valDpdt, valDpdf, valDpdc, valDpddist, 0 );
         rvec.copyTo( rightRvec ); rightRvec(0,i) += dEps;
         project( objPoints, rightRvec, tvec, cameraMatrix, distCoeffs,
-            rightImgPoints[i], valDpdrot, valDpdt, valDpdf, valDpdc, valDpddist, valDpdo, 0 );
+            rightImgPoints[i], valDpdrot, valDpdt, valDpdf, valDpdc, valDpddist, 0 );
     }
     calcdfdx( leftImgPoints, rightImgPoints, dEps, valDpdrot );
     err = cvtest::norm( dpdrot, valDpdrot, NORM_INF );
@@ -1199,10 +1196,10 @@ void CV_ProjectPointsTest::run(int)
     {
         tvec.copyTo( leftTvec ); leftTvec(0,i) -= dEps;
         project( objPoints, rvec, leftTvec, cameraMatrix, distCoeffs,
-            leftImgPoints[i], valDpdrot, valDpdt, valDpdf, valDpdc, valDpddist, valDpdo, 0 );
+            leftImgPoints[i], valDpdrot, valDpdt, valDpdf, valDpdc, valDpddist, 0 );
         tvec.copyTo( rightTvec ); rightTvec(0,i) += dEps;
         project( objPoints, rvec, rightTvec, cameraMatrix, distCoeffs,
-            rightImgPoints[i], valDpdrot, valDpdt, valDpdf, valDpdc, valDpddist, valDpdo, 0 );
+            rightImgPoints[i], valDpdrot, valDpdt, valDpdf, valDpdc, valDpddist, 0 );
     }
     calcdfdx( leftImgPoints, rightImgPoints, dEps, valDpdt );
     if( cvtest::norm( dpdt, valDpdt, NORM_INF ) > 0.2 )
@@ -1217,16 +1214,16 @@ void CV_ProjectPointsTest::run(int)
     rightImgPoints.resize(2);
     cameraMatrix.copyTo( leftCameraMatrix ); leftCameraMatrix(0,0) -= dEps;
     project( objPoints, rvec, tvec, leftCameraMatrix, distCoeffs,
-        leftImgPoints[0], valDpdrot, valDpdt, valDpdf, valDpdc, valDpddist, valDpdo, 0 );
+        leftImgPoints[0], valDpdrot, valDpdt, valDpdf, valDpdc, valDpddist, 0 );
     cameraMatrix.copyTo( leftCameraMatrix ); leftCameraMatrix(1,1) -= dEps;
     project( objPoints, rvec, tvec, leftCameraMatrix, distCoeffs,
-        leftImgPoints[1], valDpdrot, valDpdt, valDpdf, valDpdc, valDpddist, valDpdo, 0 );
+        leftImgPoints[1], valDpdrot, valDpdt, valDpdf, valDpdc, valDpddist, 0 );
     cameraMatrix.copyTo( rightCameraMatrix ); rightCameraMatrix(0,0) += dEps;
     project( objPoints, rvec, tvec, rightCameraMatrix, distCoeffs,
-        rightImgPoints[0], valDpdrot, valDpdt, valDpdf, valDpdc, valDpddist, valDpdo, 0 );
+        rightImgPoints[0], valDpdrot, valDpdt, valDpdf, valDpdc, valDpddist, 0 );
     cameraMatrix.copyTo( rightCameraMatrix ); rightCameraMatrix(1,1) += dEps;
     project( objPoints, rvec, tvec, rightCameraMatrix, distCoeffs,
-        rightImgPoints[1], valDpdrot, valDpdt, valDpdf, valDpdc, valDpddist, valDpdo, 0 );
+        rightImgPoints[1], valDpdrot, valDpdt, valDpdf, valDpdc, valDpddist, 0 );
     calcdfdx( leftImgPoints, rightImgPoints, dEps, valDpdf );
     if ( cvtest::norm( dpdf, valDpdf, NORM_L2 ) > 0.2 )
     {
@@ -1238,16 +1235,16 @@ void CV_ProjectPointsTest::run(int)
     rightImgPoints.resize(2);
     cameraMatrix.copyTo( leftCameraMatrix ); leftCameraMatrix(0,2) -= dEps;
     project( objPoints, rvec, tvec, leftCameraMatrix, distCoeffs,
-        leftImgPoints[0], valDpdrot, valDpdt, valDpdf, valDpdc, valDpddist, valDpdo, 0 );
+        leftImgPoints[0], valDpdrot, valDpdt, valDpdf, valDpdc, valDpddist, 0 );
     cameraMatrix.copyTo( leftCameraMatrix ); leftCameraMatrix(1,2) -= dEps;
     project( objPoints, rvec, tvec, leftCameraMatrix, distCoeffs,
-        leftImgPoints[1], valDpdrot, valDpdt, valDpdf, valDpdc, valDpddist, valDpdo, 0 );
+        leftImgPoints[1], valDpdrot, valDpdt, valDpdf, valDpdc, valDpddist, 0 );
     cameraMatrix.copyTo( rightCameraMatrix ); rightCameraMatrix(0,2) += dEps;
     project( objPoints, rvec, tvec, rightCameraMatrix, distCoeffs,
-        rightImgPoints[0], valDpdrot, valDpdt, valDpdf, valDpdc, valDpddist, valDpdo, 0 );
+        rightImgPoints[0], valDpdrot, valDpdt, valDpdf, valDpdc, valDpddist, 0 );
     cameraMatrix.copyTo( rightCameraMatrix ); rightCameraMatrix(1,2) += dEps;
     project( objPoints, rvec, tvec, rightCameraMatrix, distCoeffs,
-        rightImgPoints[1], valDpdrot, valDpdt, valDpdf, valDpdc, valDpddist, valDpdo, 0 );
+        rightImgPoints[1], valDpdrot, valDpdt, valDpdf, valDpdc, valDpddist, 0 );
     calcdfdx( leftImgPoints, rightImgPoints, dEps, valDpdc );
     if ( cvtest::norm( dpdc, valDpdc, NORM_L2 ) > 0.2 )
     {
@@ -1262,34 +1259,15 @@ void CV_ProjectPointsTest::run(int)
     {
         distCoeffs.copyTo( leftDistCoeffs ); leftDistCoeffs(0,i) -= dEps;
         project( objPoints, rvec, tvec, cameraMatrix, leftDistCoeffs,
-            leftImgPoints[i], valDpdrot, valDpdt, valDpdf, valDpdc, valDpddist, valDpdo, 0 );
+            leftImgPoints[i], valDpdrot, valDpdt, valDpdf, valDpdc, valDpddist, 0 );
         distCoeffs.copyTo( rightDistCoeffs ); rightDistCoeffs(0,i) += dEps;
         project( objPoints, rvec, tvec, cameraMatrix, rightDistCoeffs,
-            rightImgPoints[i], valDpdrot, valDpdt, valDpdf, valDpdc, valDpddist, valDpdo, 0 );
+            rightImgPoints[i], valDpdrot, valDpdt, valDpdf, valDpdc, valDpddist, 0 );
     }
     calcdfdx( leftImgPoints, rightImgPoints, dEps, valDpddist );
     if( cvtest::norm( dpddist, valDpddist, NORM_L2 ) > 0.3 )
     {
         ts->printf( cvtest::TS::LOG, "bad dpddist\n" );
-        code = cvtest::TS::FAIL_BAD_ACCURACY;
-    }
-
-    // 5. coordinates of object points
-    leftImgPoints.resize(dpdo.cols);
-    rightImgPoints.resize(dpdo.cols);
-    for( int i = 0; i < dpdo.cols; i++ )
-    {
-        objPoints.copyTo( leftObjPoints ); leftObjPoints(i/3,i%3) -= dEps;
-        project( leftObjPoints, rvec, tvec, cameraMatrix, distCoeffs,
-            leftImgPoints[i], valDpdrot, valDpdt, valDpdf, valDpdc, valDpddist, valDpdo, 0 );
-        objPoints.copyTo( rightObjPoints ); rightObjPoints(i/3,i%3) += dEps;
-        project( rightObjPoints, rvec, tvec, cameraMatrix, distCoeffs,
-            rightImgPoints[i], valDpdrot, valDpdt, valDpdf, valDpdc, valDpddist, valDpdo, 0 );
-    }
-    calcdfdx( leftImgPoints, rightImgPoints, dEps, valDpdo );
-    if( cvtest::norm( dpdo, valDpdo, NORM_L2 ) > 0.25 )
-    {
-        ts->printf( cvtest::TS::LOG, "bad dpdo\n" );
         code = cvtest::TS::FAIL_BAD_ACCURACY;
     }
 
@@ -1312,14 +1290,12 @@ protected:
         vector<Point2f>& imagePoints,
         Mat& dpdrot, Mat& dpdt, Mat& dpdf,
         Mat& dpdc, Mat& dpddist,
-        Mat& dpdo,
         double aspectRatio=0 );
 };
 
 void CV_ProjectPointsTest_C::project( const Mat& opoints, const Mat& rvec, const Mat& tvec,
                                        const Mat& cameraMatrix, const Mat& distCoeffs, vector<Point2f>& ipoints,
-                                       Mat& dpdrot, Mat& dpdt, Mat& dpdf, Mat& dpdc, Mat& dpddist,
-                                       Mat& dpdo, double aspectRatio)
+                                       Mat& dpdrot, Mat& dpdt, Mat& dpdf, Mat& dpdc, Mat& dpddist, double aspectRatio)
 {
     int npoints = opoints.cols*opoints.rows*opoints.channels()/3;
     ipoints.resize(npoints);
@@ -1328,15 +1304,13 @@ void CV_ProjectPointsTest_C::project( const Mat& opoints, const Mat& rvec, const
     dpdf.create(npoints*2, 2, CV_64F);
     dpdc.create(npoints*2, 2, CV_64F);
     dpddist.create(npoints*2, distCoeffs.rows + distCoeffs.cols - 1, CV_64F);
-    dpdo.create(npoints*2, npoints*3, CV_64F);
     Mat imagePoints(ipoints);
     CvMat _objectPoints = cvMat(opoints), _imagePoints = cvMat(imagePoints);
     CvMat _rvec = cvMat(rvec), _tvec = cvMat(tvec), _cameraMatrix = cvMat(cameraMatrix), _distCoeffs = cvMat(distCoeffs);
     CvMat _dpdrot = cvMat(dpdrot), _dpdt = cvMat(dpdt), _dpdf = cvMat(dpdf), _dpdc = cvMat(dpdc), _dpddist = cvMat(dpddist);
-    CvMat _dpdo = cvMat(dpdo);
 
     cvProjectPoints2( &_objectPoints, &_rvec, &_tvec, &_cameraMatrix, &_distCoeffs,
-                      &_imagePoints, &_dpdrot, &_dpdt, &_dpdf, &_dpdc, &_dpddist, &_dpdo, aspectRatio );
+                      &_imagePoints, &_dpdrot, &_dpdt, &_dpdf, &_dpdc, &_dpddist, aspectRatio );
 }
 
 
@@ -1353,14 +1327,12 @@ protected:
         vector<Point2f>& imagePoints,
         Mat& dpdrot, Mat& dpdt, Mat& dpdf,
         Mat& dpdc, Mat& dpddist,
-        Mat& dpdo,
         double aspectRatio=0 );
 };
 
 void CV_ProjectPointsTest_CPP::project( const Mat& objectPoints, const Mat& rvec, const Mat& tvec,
                                        const Mat& cameraMatrix, const Mat& distCoeffs, vector<Point2f>& imagePoints,
-                                       Mat& dpdrot, Mat& dpdt, Mat& dpdf, Mat& dpdc, Mat& dpddist,
-                                       Mat& dpdo, double aspectRatio)
+                                       Mat& dpdrot, Mat& dpdt, Mat& dpdf, Mat& dpdc, Mat& dpddist, double aspectRatio)
 {
     Mat J;
     projectPoints( objectPoints, rvec, tvec, cameraMatrix, distCoeffs, imagePoints, J, aspectRatio);
@@ -1368,9 +1340,7 @@ void CV_ProjectPointsTest_CPP::project( const Mat& objectPoints, const Mat& rvec
     J.colRange(3, 6).copyTo(dpdt);
     J.colRange(6, 8).copyTo(dpdf);
     J.colRange(8, 10).copyTo(dpdc);
-    int ndistCoeffs = distCoeffs.rows + distCoeffs.cols - 1;
-    J.colRange(10, 10 + ndistCoeffs).copyTo(dpddist);
-    J.colRange(10 + ndistCoeffs, J.cols).copyTo(dpdo);
+    J.colRange(10, J.cols).copyTo(dpddist);
 }
 
 ///////////////////////////////// Stereo Calibration /////////////////////////////////////

--- a/modules/calib3d/test/test_cameracalibration.cpp
+++ b/modules/calib3d/test/test_cameracalibration.cpp
@@ -893,7 +893,7 @@ void CV_CameraCalibrationTest_CPP::calibrate(int imageCount, int* pointCounts,
     if( flags & CALIB_RELEASE_OBJECT )
     {
         newObjMat.convertTo( newObjMat, CV_64F );
-        assert( newObjMat.total() == static_cast<size_t>(3*pointCounts[0]) );
+        assert( newObjMat.total() * newObjMat.channels() == static_cast<size_t>(3*pointCounts[0]) );
         memcpy( newObjPoints, newObjMat.ptr(), 3*pointCounts[0]*sizeof(double) );
     }
 

--- a/modules/calib3d/test/test_cameracalibration_badarg.cpp
+++ b/modules/calib3d/test/test_cameracalibration_badarg.cpp
@@ -477,13 +477,12 @@ protected:
         CvMat* dpdf;
         CvMat* dpdc;
         CvMat* dpdk;
-        CvMat* dpdo;
         double aspectRatio;
 
         void operator()()
         {
             cvProjectPoints2( objectPoints, r_vec, t_vec, A, distCoeffs, imagePoints,
-                dpdr, dpdt, dpdf, dpdc, dpdk, dpdo, aspectRatio );
+                dpdr, dpdt, dpdf, dpdc, dpdk, aspectRatio );
         }
     };
 
@@ -494,7 +493,6 @@ protected:
         C_Caller caller, bad_caller;
         CvMat objectPoints_c, r_vec_c, t_vec_c, A_c, distCoeffs_c, imagePoints_c,
             dpdr_c, dpdt_c, dpdf_c, dpdc_c, dpdk_c;
-        CvMat dpdo_c;
 
         const int n = 10;
 
@@ -516,7 +514,6 @@ protected:
         Mat dpdf_cpp(2*n, 2, CV_32F); dpdf_c = cvMat(dpdf_cpp);
         Mat dpdc_cpp(2*n, 2, CV_32F); dpdc_c = cvMat(dpdc_cpp);
         Mat dpdk_cpp(2*n, 4, CV_32F); dpdk_c = cvMat(dpdk_cpp);
-        Mat dpdo_cpp(2*n, 3*n, CV_32F); dpdo_c = cvMat(dpdo_cpp);
 
         caller.aspectRatio = 1.0;
         caller.objectPoints = &objectPoints_c;
@@ -530,7 +527,6 @@ protected:
         caller.dpdf = &dpdf_c;
         caller.dpdc = &dpdc_c;
         caller.dpdk = &dpdk_c;
-        caller.dpdo = &dpdo_c;
 
         /********************/
         int errors = 0;
@@ -723,23 +719,6 @@ protected:
         bad_caller.distCoeffs = 0;
         errors += run_test_case( CV_StsNullPtr, "distCoeffs is NULL while dpdk is not", bad_caller );
 
-        /****************************/
-
-        bad_caller = caller;
-        bad_caller.dpdo = &zeros;
-        errors += run_test_case( CV_StsBadArg, "Bad dpdo format", bad_caller );
-
-        bad_caller = caller;
-        bad_caller.dpdo = &bad_dpdr_c1;
-        errors += run_test_case( CV_StsBadArg, "Bad dpdo format", bad_caller );
-
-        bad_caller = caller;
-        bad_caller.dpdo = &bad_dpdf_c2;
-        errors += run_test_case( CV_StsBadArg, "Bad dpdo format", bad_caller );
-
-        bad_caller = caller;
-        bad_caller.dpdo = &bad_dpdr_c3;
-        errors += run_test_case( CV_StsBadArg, "Bad dpdo format", bad_caller );
 
         if (errors)
             ts->set_failed_test_info(cvtest::TS::FAIL_MISMATCH);

--- a/modules/calib3d/test/test_cameracalibration_badarg.cpp
+++ b/modules/calib3d/test/test_cameracalibration_badarg.cpp
@@ -482,7 +482,7 @@ protected:
         void operator()()
         {
             cvProjectPoints2( objectPoints, r_vec, t_vec, A, distCoeffs, imagePoints,
-                dpdr, dpdt, dpdf, dpdc, dpdk, aspectRatio );
+                dpdr, dpdt, dpdf, dpdc, dpdk, NULL, aspectRatio );
         }
     };
 

--- a/modules/calib3d/test/test_cameracalibration_badarg.cpp
+++ b/modules/calib3d/test/test_cameracalibration_badarg.cpp
@@ -477,12 +477,13 @@ protected:
         CvMat* dpdf;
         CvMat* dpdc;
         CvMat* dpdk;
+        CvMat* dpdo;
         double aspectRatio;
 
         void operator()()
         {
             cvProjectPoints2( objectPoints, r_vec, t_vec, A, distCoeffs, imagePoints,
-                dpdr, dpdt, dpdf, dpdc, dpdk, NULL, aspectRatio );
+                dpdr, dpdt, dpdf, dpdc, dpdk, dpdo, aspectRatio );
         }
     };
 
@@ -493,6 +494,7 @@ protected:
         C_Caller caller, bad_caller;
         CvMat objectPoints_c, r_vec_c, t_vec_c, A_c, distCoeffs_c, imagePoints_c,
             dpdr_c, dpdt_c, dpdf_c, dpdc_c, dpdk_c;
+        CvMat dpdo_c;
 
         const int n = 10;
 
@@ -514,6 +516,7 @@ protected:
         Mat dpdf_cpp(2*n, 2, CV_32F); dpdf_c = cvMat(dpdf_cpp);
         Mat dpdc_cpp(2*n, 2, CV_32F); dpdc_c = cvMat(dpdc_cpp);
         Mat dpdk_cpp(2*n, 4, CV_32F); dpdk_c = cvMat(dpdk_cpp);
+        Mat dpdo_cpp(2*n, 3*n, CV_32F); dpdo_c = cvMat(dpdo_cpp);
 
         caller.aspectRatio = 1.0;
         caller.objectPoints = &objectPoints_c;
@@ -527,6 +530,7 @@ protected:
         caller.dpdf = &dpdf_c;
         caller.dpdc = &dpdc_c;
         caller.dpdk = &dpdk_c;
+        caller.dpdo = &dpdo_c;
 
         /********************/
         int errors = 0;
@@ -719,6 +723,23 @@ protected:
         bad_caller.distCoeffs = 0;
         errors += run_test_case( CV_StsNullPtr, "distCoeffs is NULL while dpdk is not", bad_caller );
 
+        /****************************/
+
+        bad_caller = caller;
+        bad_caller.dpdo = &zeros;
+        errors += run_test_case( CV_StsBadArg, "Bad dpdo format", bad_caller );
+
+        bad_caller = caller;
+        bad_caller.dpdo = &bad_dpdr_c1;
+        errors += run_test_case( CV_StsBadArg, "Bad dpdo format", bad_caller );
+
+        bad_caller = caller;
+        bad_caller.dpdo = &bad_dpdf_c2;
+        errors += run_test_case( CV_StsBadArg, "Bad dpdo format", bad_caller );
+
+        bad_caller = caller;
+        bad_caller.dpdo = &bad_dpdr_c3;
+        errors += run_test_case( CV_StsBadArg, "Bad dpdo format", bad_caller );
 
         if (errors)
             ts->set_failed_test_info(cvtest::TS::FAIL_MISMATCH);

--- a/modules/calib3d/test/test_cameracalibration_badarg.cpp
+++ b/modules/calib3d/test/test_cameracalibration_badarg.cpp
@@ -207,11 +207,11 @@ void CV_CameraCalibrationBadArgTest::run( int /* start_from */ )
 
     bad_caller = caller;
     bad_caller.rvecs = &bad_rvecs_c1;
-    errors += run_test_case( CV_StsBadArg, "Bad tvecs header", bad_caller );
+    errors += run_test_case( CV_StsBadArg, "Bad rvecs header", bad_caller );
 
     bad_caller = caller;
     bad_caller.rvecs = &bad_rvecs_c2;
-    errors += run_test_case( CV_StsBadArg, "Bad tvecs header", bad_caller );
+    errors += run_test_case( CV_StsBadArg, "Bad rvecs header", bad_caller );
 
     bad_caller = caller;
     bad_caller.tvecs = &bad_tvecs_c1;

--- a/modules/calib3d/test/test_cameracalibration_badarg.cpp
+++ b/modules/calib3d/test/test_cameracalibration_badarg.cpp
@@ -54,7 +54,7 @@ protected:
     void run(int);
     void run_func(void) {}
 
-    const static int M = 1;
+    const static int M = 2;
 
     Size imgSize;
     Size corSize;
@@ -67,16 +67,18 @@ protected:
         CvMat* imgPts;
         CvMat* npoints;
         Size imageSize;
+        int iFixedPoint;
         CvMat *cameraMatrix;
         CvMat *distCoeffs;
         CvMat *rvecs;
         CvMat *tvecs;
+        CvMat *newObjPts;
         int flags;
 
         void operator()() const
         {
-            cvCalibrateCamera2(objPts, imgPts, npoints, cvSize(imageSize),
-                cameraMatrix, distCoeffs, rvecs, tvecs, flags );
+            cvCalibrateCamera4(objPts, imgPts, npoints, cvSize(imageSize), iFixedPoint,
+                cameraMatrix, distCoeffs, rvecs, tvecs, newObjPts, flags );
         }
     };
 };
@@ -97,6 +99,7 @@ void CV_CameraCalibrationBadArgTest::run( int /* start_from */ )
     Mat_<Point2f>(corSize.height, corSize.width, (Point2f*)&exp_corn[0]).copyTo(corners);
 
     CvMat objPts, imgPts, npoints, cameraMatrix, distCoeffs, rvecs, tvecs;
+    CvMat newObjPts;
     Mat zeros(1, sizeof(CvMat), CV_8U, Scalar(0));
 
     C_Caller caller, bad_caller;
@@ -108,6 +111,7 @@ void CV_CameraCalibrationBadArgTest::run( int /* start_from */ )
     caller.distCoeffs = &distCoeffs;
     caller.rvecs = &rvecs;
     caller.tvecs = &tvecs;
+    caller.newObjPts = &newObjPts;
 
     /////////////////////////////
     Mat objPts_cpp;
@@ -117,19 +121,31 @@ void CV_CameraCalibrationBadArgTest::run( int /* start_from */ )
     Mat distCoeffs_cpp;
     Mat rvecs_cpp;
     Mat tvecs_cpp;
+    Mat newObjPts_cpp;
 
     objPts_cpp.create(corSize, CV_32FC3);
     for(int j = 0; j < corSize.height; ++j)
         for(int i = 0; i < corSize.width; ++i)
             objPts_cpp.at<Point3f>(j, i) = Point3i(i, j, 0);
     objPts_cpp = objPts_cpp.reshape(3, 1);
+    Mat objPts_cpp_all(1, objPts_cpp.cols * M, CV_32FC3);
+    for(int i = 0; i < M; i++)
+        objPts_cpp.copyTo(objPts_cpp_all.colRange(objPts_cpp.cols * i, objPts_cpp.cols * (i + 1)));
+    objPts_cpp = objPts_cpp_all;
+
+    caller.iFixedPoint = -1;
 
     imgPts_cpp = corners.clone().reshape(2, 1);
+    Mat imgPts_cpp_all(1, imgPts_cpp.cols * M, CV_32FC2);
+    for(int i = 0; i < M; i++)
+        imgPts_cpp.copyTo(imgPts_cpp_all.colRange(imgPts_cpp.cols * i, imgPts_cpp.cols * (i + 1)));
+    imgPts_cpp = imgPts_cpp_all;
     npoints_cpp = Mat_<int>(M, 1, corSize.width * corSize.height);
     cameraMatrix_cpp.create(3, 3, CV_32F);
     distCoeffs_cpp.create(5, 1, CV_32F);
     rvecs_cpp.create(M, 1, CV_32FC3);
     tvecs_cpp.create(M, 1, CV_32FC3);
+    newObjPts_cpp.create(corSize.width * corSize.height, 1, CV_32FC3);
 
     caller.flags = 0;
     //CV_CALIB_USE_INTRINSIC_GUESS;    //CV_CALIB_FIX_ASPECT_RATIO
@@ -144,6 +160,7 @@ void CV_CameraCalibrationBadArgTest::run( int /* start_from */ )
     distCoeffs = cvMat(distCoeffs_cpp);
     rvecs = cvMat(rvecs_cpp);
     tvecs = cvMat(tvecs_cpp);
+    newObjPts = cvMat(newObjPts_cpp);
 
     /* /*//*/ */
     int errors = 0;
@@ -197,6 +214,10 @@ void CV_CameraCalibrationBadArgTest::run( int /* start_from */ )
     bad_caller.tvecs = (CvMat*)zeros.ptr();
     errors += run_test_case( CV_StsBadArg, "Bad tvecs header", bad_caller );
 
+    bad_caller = caller;
+    bad_caller.newObjPts = (CvMat*)zeros.ptr();
+    errors += run_test_case( CV_StsBadArg, "Bad newObjPts header", bad_caller );
+
     Mat bad_rvecs_cpp1(M+1, 1, CV_32FC3); CvMat bad_rvecs_c1 = cvMat(bad_rvecs_cpp1);
     Mat bad_tvecs_cpp1(M+1, 1, CV_32FC3); CvMat bad_tvecs_c1 = cvMat(bad_tvecs_cpp1);
 
@@ -220,6 +241,14 @@ void CV_CameraCalibrationBadArgTest::run( int /* start_from */ )
     bad_caller = caller;
     bad_caller.tvecs = &bad_tvecs_c2;
     errors += run_test_case( CV_StsBadArg, "Bad tvecs header", bad_caller );
+
+    bad_caller = caller;
+    bad_caller.newObjPts = &bad_tvecs_c1;
+    errors += run_test_case( CV_StsBadArg, "Bad newObjPts header", bad_caller );
+
+    bad_caller = caller;
+    bad_caller.newObjPts = &bad_tvecs_c2;
+    errors += run_test_case( CV_StsBadArg, "Bad newObjPts header", bad_caller );
 
     Mat bad_cameraMatrix_cpp1(3, 3, CV_32S); CvMat bad_cameraMatrix_c1 = cvMat(bad_cameraMatrix_cpp1);
     Mat bad_cameraMatrix_cpp2(2, 3, CV_32F); CvMat bad_cameraMatrix_c2 = cvMat(bad_cameraMatrix_cpp2);
@@ -306,10 +335,29 @@ void CV_CameraCalibrationBadArgTest::run( int /* start_from */ )
     bad_caller.objPts = &bad_objPts_c5;
 
     cv::RNG& rng = theRNG();
-    for(int i = 0; i < bad_objPts_cpp5.rows; ++i)
+    for(int i = 0; i < bad_objPts_cpp5.cols; ++i)
         bad_objPts_cpp5.at<Point3f>(0, i).z += ((float)rng - 0.5f);
 
     errors += run_test_case( CV_StsBadArg, "Bad objPts data", bad_caller );
+
+    bad_objPts_cpp5 = objPts_cpp.clone(); bad_objPts_c5 = cvMat(bad_objPts_cpp5);
+    bad_caller.objPts = &bad_objPts_c5;
+    bad_caller.iFixedPoint = corSize.width - 1;
+    for(int i = 0; i < bad_objPts_cpp5.cols; ++i)
+    {
+        bad_objPts_cpp5.at<Point3f>(0, i).x += (float)rng;
+        bad_objPts_cpp5.at<Point3f>(0, i).y += (float)rng;
+    }
+    errors += run_test_case( CV_StsBadArg, "Bad objPts data", bad_caller );
+
+    bad_caller = caller;
+    Mat bad_npts_cpp3 = npoints_cpp.clone();
+    CvMat bad_npts_c3 = cvMat(bad_npts_cpp3);
+    bad_caller.npoints = &bad_npts_c3;
+    bad_caller.iFixedPoint = corSize.width - 1;
+    for(int i = 0; i < M; i++)
+        bad_npts_cpp3.at<int>(i) += i;
+    errors += run_test_case( CV_StsBadArg, "Bad npoints data", bad_caller );
 
     if (errors)
         ts->set_failed_test_info(cvtest::TS::FAIL_MISMATCH);

--- a/samples/cpp/calibration.cpp
+++ b/samples/cpp/calibration.cpp
@@ -10,6 +10,7 @@
 #include <stdio.h>
 #include <string.h>
 #include <time.h>
+#include <iostream>
 
 using namespace cv;
 using namespace std;
@@ -62,6 +63,7 @@ static void help()
         "     [-o=<out_camera_params>] # the output filename for intrinsic [and extrinsic] parameters\n"
         "     [-op]                    # write detected feature points\n"
         "     [-oe]                    # write extrinsic parameters\n"
+        "     [-oo]                    # write refined 3D object points\n"
         "     [-zt]                    # assume zero tangential distortion\n"
         "     [-a=<aspectRatio>]      # fix aspect ratio (fx/fy)\n"
         "     [-p]                     # fix the principal point at the center\n"
@@ -69,6 +71,11 @@ static void help()
         "     [-V]                     # use a video file, and not an image list, uses\n"
         "                              # [input_data] string for the video file name\n"
         "     [-su]                    # show undistorted images after calibration\n"
+        "     [-ws=<number_of_pixel>]  # Half of search window for cornerSubPix (11 by default)\n"
+        "     [-dt=<distance>]         # actual distance between top-left and top-right corners of\n"
+        "                              # the calibration grid. If this parameter is specified, a more\n"
+        "                              # accurate calibration method will be used which may be better\n"
+        "                              # with inaccurate, roughly planar target.\n"
         "     [input_data]             # input data, one of the following:\n"
         "                              #  - text file with a list of the images of the board\n"
         "                              #    the text file can be generated with imagelist_creator\n"
@@ -137,9 +144,11 @@ static void calcChessboardCorners(Size boardSize, float squareSize, vector<Point
 static bool runCalibration( vector<vector<Point2f> > imagePoints,
                     Size imageSize, Size boardSize, Pattern patternType,
                     float squareSize, float aspectRatio,
+                    float grid_width, bool release_object,
                     int flags, Mat& cameraMatrix, Mat& distCoeffs,
                     vector<Mat>& rvecs, vector<Mat>& tvecs,
                     vector<float>& reprojErrs,
+                    vector<Point3f>& newObjPoints,
                     double& totalAvgErr)
 {
     cameraMatrix = Mat::eye(3, 3, CV_64F);
@@ -150,16 +159,34 @@ static bool runCalibration( vector<vector<Point2f> > imagePoints,
 
     vector<vector<Point3f> > objectPoints(1);
     calcChessboardCorners(boardSize, squareSize, objectPoints[0], patternType);
+    objectPoints[0][boardSize.width - 1].x = objectPoints[0][0].x + grid_width;
+    newObjPoints = objectPoints[0];
 
     objectPoints.resize(imagePoints.size(),objectPoints[0]);
 
-    double rms = calibrateCamera(objectPoints, imagePoints, imageSize, cameraMatrix,
-                    distCoeffs, rvecs, tvecs, flags|CALIB_FIX_K4|CALIB_FIX_K5);
-                    ///*|CALIB_FIX_K3*/|CALIB_FIX_K4|CALIB_FIX_K5);
+    double rms;
+    if (release_object)
+        rms = calibrateCamera(objectPoints, imagePoints, imageSize, boardSize.width - 1,
+                              cameraMatrix, distCoeffs, rvecs, tvecs, newObjPoints,
+                              flags | CALIB_FIX_K3 | CALIB_RELEASE_OBJECT | CALIB_USE_LU);
+    else
+        rms = calibrateCamera(objectPoints, imagePoints, imageSize, cameraMatrix,
+                        distCoeffs, rvecs, tvecs, flags|CALIB_FIX_K4|CALIB_FIX_K5);
+                        ///*|CALIB_FIX_K3*/|CALIB_FIX_K4|CALIB_FIX_K5);
     printf("RMS error reported by calibrateCamera: %g\n", rms);
 
     bool ok = checkRange(cameraMatrix) && checkRange(distCoeffs);
 
+    if (release_object) {
+        cout << "New board corners: " << endl;
+        cout << newObjPoints[0] << endl;
+        cout << newObjPoints[boardSize.width - 1] << endl;
+        cout << newObjPoints[boardSize.width * (boardSize.height - 1)] << endl;
+        cout << newObjPoints.back() << endl;
+    }
+
+    objectPoints.clear();
+    objectPoints.resize(imagePoints.size(), newObjPoints);
     totalAvgErr = computeReprojectionErrors(objectPoints, imagePoints,
                 rvecs, tvecs, cameraMatrix, distCoeffs, reprojErrs);
 
@@ -174,6 +201,7 @@ static void saveCameraParams( const string& filename,
                        const vector<Mat>& rvecs, const vector<Mat>& tvecs,
                        const vector<float>& reprojErrs,
                        const vector<vector<Point2f> >& imagePoints,
+                       const vector<Point3f>& newObjPoints,
                        double totalAvgErr )
 {
     FileStorage fs( filename, FileStorage::WRITE );
@@ -246,6 +274,11 @@ static void saveCameraParams( const string& filename,
         }
         fs << "image_points" << imagePtMat;
     }
+
+    if( !newObjPoints.empty() )
+    {
+        fs << "grid_points" << newObjPoints;
+    }
 }
 
 static bool readStringList( const string& filename, vector<string>& l )
@@ -267,17 +300,19 @@ static bool readStringList( const string& filename, vector<string>& l )
 static bool runAndSave(const string& outputFilename,
                 const vector<vector<Point2f> >& imagePoints,
                 Size imageSize, Size boardSize, Pattern patternType, float squareSize,
+                float grid_width, bool release_object,
                 float aspectRatio, int flags, Mat& cameraMatrix,
-                Mat& distCoeffs, bool writeExtrinsics, bool writePoints )
+                Mat& distCoeffs, bool writeExtrinsics, bool writePoints, bool writeGrid )
 {
     vector<Mat> rvecs, tvecs;
     vector<float> reprojErrs;
     double totalAvgErr = 0;
+    vector<Point3f> newObjPoints;
 
     bool ok = runCalibration(imagePoints, imageSize, boardSize, patternType, squareSize,
-                   aspectRatio, flags, cameraMatrix, distCoeffs,
-                   rvecs, tvecs, reprojErrs, totalAvgErr);
-    printf("%s. avg reprojection error = %.2f\n",
+                   aspectRatio, grid_width, release_object, flags, cameraMatrix, distCoeffs,
+                   rvecs, tvecs, reprojErrs, newObjPoints, totalAvgErr);
+    printf("%s. avg reprojection error = %.7f\n",
            ok ? "Calibration succeeded" : "Calibration failed",
            totalAvgErr);
 
@@ -289,6 +324,7 @@ static bool runAndSave(const string& outputFilename,
                          writeExtrinsics ? tvecs : vector<Mat>(),
                          writeExtrinsics ? reprojErrs : vector<float>(),
                          writePoints ? imagePoints : vector<vector<Point2f> >(),
+                         writeGrid ? newObjPoints : vector<Point3f>(),
                          totalAvgErr );
     return ok;
 }
@@ -297,7 +333,7 @@ static bool runAndSave(const string& outputFilename,
 int main( int argc, char** argv )
 {
     Size boardSize, imageSize;
-    float squareSize, aspectRatio;
+    float squareSize, aspectRatio = 1;
     Mat cameraMatrix, distCoeffs;
     string outputFilename;
     string inputFilename = "";
@@ -320,7 +356,8 @@ int main( int argc, char** argv )
 
     cv::CommandLineParser parser(argc, argv,
         "{help ||}{w||}{h||}{pt|chessboard|}{n|10|}{d|1000|}{s|1|}{o|out_camera_data.yml|}"
-        "{op||}{oe||}{zt||}{a|1|}{p||}{v||}{V||}{su||}"
+        "{op||}{oe||}{zt||}{a||}{p||}{v||}{V||}{su||}"
+        "{oo||}{ws|11|}{dt||}"
         "{@input_data|0|}");
     if (parser.has("help"))
     {
@@ -343,12 +380,14 @@ int main( int argc, char** argv )
     }
     squareSize = parser.get<float>("s");
     nframes = parser.get<int>("n");
-    aspectRatio = parser.get<float>("a");
     delay = parser.get<int>("d");
     writePoints = parser.has("op");
     writeExtrinsics = parser.has("oe");
-    if (parser.has("a"))
+    bool writeGrid = parser.has("oo");
+    if (parser.has("a")) {
         flags |= CALIB_FIX_ASPECT_RATIO;
+        aspectRatio = parser.get<float>("a");
+    }
     if ( parser.has("zt") )
         flags |= CALIB_ZERO_TANGENT_DIST;
     if ( parser.has("p") )
@@ -362,6 +401,13 @@ int main( int argc, char** argv )
         cameraId = parser.get<int>("@input_data");
     else
         inputFilename = parser.get<string>("@input_data");
+    int winSize = parser.get<int>("ws");
+    float grid_width = squareSize * (boardSize.width - 1);
+    bool release_object = false;
+    if (parser.has("dt")) {
+        grid_width = parser.get<float>("dt");
+        release_object = true;
+    }
     if (!parser.check())
     {
         help();
@@ -420,9 +466,9 @@ int main( int argc, char** argv )
         {
             if( imagePoints.size() > 0 )
                 runAndSave(outputFilename, imagePoints, imageSize,
-                           boardSize, pattern, squareSize, aspectRatio,
+                           boardSize, pattern, squareSize, grid_width, release_object, aspectRatio,
                            flags, cameraMatrix, distCoeffs,
-                           writeExtrinsics, writePoints);
+                           writeExtrinsics, writePoints, writeGrid);
             break;
         }
 
@@ -452,8 +498,8 @@ int main( int argc, char** argv )
         }
 
        // improve the found corners' coordinate accuracy
-        if( pattern == CHESSBOARD && found) cornerSubPix( viewGray, pointbuf, Size(11,11),
-            Size(-1,-1), TermCriteria( TermCriteria::EPS+TermCriteria::COUNT, 30, 0.1 ));
+        if( pattern == CHESSBOARD && found) cornerSubPix( viewGray, pointbuf, Size(winSize,winSize),
+            Size(-1,-1), TermCriteria( TermCriteria::EPS+TermCriteria::COUNT, 30, 0.0001 ));
 
         if( mode == CAPTURING && found &&
            (!capture.isOpened() || clock() - prevTimestamp > delay*1e-3*CLOCKS_PER_SEC) )
@@ -510,9 +556,9 @@ int main( int argc, char** argv )
         if( mode == CAPTURING && imagePoints.size() >= (unsigned)nframes )
         {
             if( runAndSave(outputFilename, imagePoints, imageSize,
-                       boardSize, pattern, squareSize, aspectRatio,
+                       boardSize, pattern, squareSize, grid_width, release_object, aspectRatio,
                        flags, cameraMatrix, distCoeffs,
-                       writeExtrinsics, writePoints))
+                       writeExtrinsics, writePoints, writeGrid))
                 mode = CALIBRATED;
             else
                 mode = DETECTION;

--- a/samples/cpp/calibration.cpp
+++ b/samples/cpp/calibration.cpp
@@ -168,9 +168,9 @@ static bool runCalibration( vector<vector<Point2f> > imagePoints,
     int iFixedPoint = -1;
     if (release_object)
         iFixedPoint = boardSize.width - 1;
-    rms = calibrateCamera(objectPoints, imagePoints, imageSize, iFixedPoint,
-                          cameraMatrix, distCoeffs, rvecs, tvecs, newObjPoints,
-                          flags | CALIB_FIX_K3 | CALIB_USE_LU);
+    rms = calibrateCameraRO(objectPoints, imagePoints, imageSize, iFixedPoint,
+                            cameraMatrix, distCoeffs, rvecs, tvecs, newObjPoints,
+                            flags | CALIB_FIX_K3 | CALIB_USE_LU);
     printf("RMS error reported by calibrateCamera: %g\n", rms);
 
     bool ok = checkRange(cameraMatrix) && checkRange(distCoeffs);

--- a/samples/cpp/calibration.cpp
+++ b/samples/cpp/calibration.cpp
@@ -165,14 +165,12 @@ static bool runCalibration( vector<vector<Point2f> > imagePoints,
     objectPoints.resize(imagePoints.size(),objectPoints[0]);
 
     double rms;
+    int iFixedPoint = -1;
     if (release_object)
-        rms = calibrateCamera(objectPoints, imagePoints, imageSize, boardSize.width - 1,
-                              cameraMatrix, distCoeffs, rvecs, tvecs, newObjPoints,
-                              flags | CALIB_FIX_K3 | CALIB_RELEASE_OBJECT | CALIB_USE_LU);
-    else
-        rms = calibrateCamera(objectPoints, imagePoints, imageSize, cameraMatrix,
-                        distCoeffs, rvecs, tvecs, flags|CALIB_FIX_K4|CALIB_FIX_K5);
-                        ///*|CALIB_FIX_K3*/|CALIB_FIX_K4|CALIB_FIX_K5);
+        iFixedPoint = boardSize.width - 1;
+    rms = calibrateCamera(objectPoints, imagePoints, imageSize, iFixedPoint,
+                          cameraMatrix, distCoeffs, rvecs, tvecs, newObjPoints,
+                          flags | CALIB_FIX_K3 | CALIB_USE_LU);
     printf("RMS error reported by calibrateCamera: %g\n", rms);
 
     bool ok = checkRange(cameraMatrix) && checkRange(distCoeffs);

--- a/samples/cpp/tutorial_code/calib3d/camera_calibration/camera_calibration.cpp
+++ b/samples/cpp/tutorial_code/calib3d/camera_calibration/camera_calibration.cpp
@@ -578,13 +578,12 @@ static bool runCalibration( Settings& s, Size& imageSize, Mat& cameraMatrix, Mat
             tvecs.push_back(_tvecs.row(i));
         }
     } else {
+        int iFixedPoint = -1;
         if (release_object)
-            rms = calibrateCamera(objectPoints, imagePoints, imageSize, s.boardSize.width - 1,
-                                  cameraMatrix, distCoeffs, rvecs, tvecs, newObjPoints,
-                                  s.flag | CALIB_RELEASE_OBJECT | CALIB_USE_LU);
-        else
-            rms = calibrateCamera(objectPoints, imagePoints, imageSize, cameraMatrix, distCoeffs,
-                                  rvecs, tvecs, s.flag);
+            iFixedPoint = s.boardSize.width - 1;
+        rms = calibrateCamera(objectPoints, imagePoints, imageSize, iFixedPoint,
+                              cameraMatrix, distCoeffs, rvecs, tvecs, newObjPoints,
+                              s.flag | CALIB_USE_LU);
     }
 
     if (release_object) {

--- a/samples/cpp/tutorial_code/calib3d/camera_calibration/camera_calibration.cpp
+++ b/samples/cpp/tutorial_code/calib3d/camera_calibration/camera_calibration.cpp
@@ -581,9 +581,9 @@ static bool runCalibration( Settings& s, Size& imageSize, Mat& cameraMatrix, Mat
         int iFixedPoint = -1;
         if (release_object)
             iFixedPoint = s.boardSize.width - 1;
-        rms = calibrateCamera(objectPoints, imagePoints, imageSize, iFixedPoint,
-                              cameraMatrix, distCoeffs, rvecs, tvecs, newObjPoints,
-                              s.flag | CALIB_USE_LU);
+        rms = calibrateCameraRO(objectPoints, imagePoints, imageSize, iFixedPoint,
+                                cameraMatrix, distCoeffs, rvecs, tvecs, newObjPoints,
+                                s.flag | CALIB_USE_LU);
     }
 
     if (release_object) {

--- a/samples/cpp/tutorial_code/calib3d/camera_calibration/camera_calibration.cpp
+++ b/samples/cpp/tutorial_code/calib3d/camera_calibration/camera_calibration.cpp
@@ -15,13 +15,6 @@
 using namespace cv;
 using namespace std;
 
-static void help()
-{
-    cout <<  "This is a camera calibration sample." << endl
-         <<  "Usage: camera_calibration [configuration_file -- default ./default.xml]"  << endl
-         <<  "Near the sample file you'll find the configuration file, which has detailed help of "
-             "how to edit it.  It may be any OpenCV supported file format XML/YAML." << endl;
-}
 class Settings
 {
 public:
@@ -43,6 +36,7 @@ public:
 
                   << "Write_DetectedFeaturePoints" << writePoints
                   << "Write_extrinsicParameters"   << writeExtrinsics
+                  << "Write_gridPoints" << writeGrid
                   << "Write_outputFileName"  << outputFileName
 
                   << "Show_UndistortedImage" << showUndistorsed
@@ -62,6 +56,7 @@ public:
         node["Calibrate_FixAspectRatio"] >> aspectRatio;
         node["Write_DetectedFeaturePoints"] >> writePoints;
         node["Write_extrinsicParameters"] >> writeExtrinsics;
+        node["Write_gridPoints"] >> writeGrid;
         node["Write_outputFileName"] >> outputFileName;
         node["Calibrate_AssumeZeroTangentialDistortion"] >> calibZeroTangentDist;
         node["Calibrate_FixPrincipalPointAtTheCenter"] >> calibFixPrincipalPoint;
@@ -210,6 +205,7 @@ public:
     int delay;                   // In case of a video input
     bool writePoints;            // Write detected feature points
     bool writeExtrinsics;        // Write extrinsic parameters
+    bool writeGrid;              // Write refined 3D target grid points
     bool calibZeroTangentDist;   // Assume zero tangential distortion
     bool calibFixPrincipalPoint; // Fix the principal point at the center
     bool flipVertical;           // Flip the captured images around the horizontal axis
@@ -248,19 +244,39 @@ static inline void read(const FileNode& node, Settings& x, const Settings& defau
 enum { DETECTION = 0, CAPTURING = 1, CALIBRATED = 2 };
 
 bool runCalibrationAndSave(Settings& s, Size imageSize, Mat&  cameraMatrix, Mat& distCoeffs,
-                           vector<vector<Point2f> > imagePoints );
+                           vector<vector<Point2f> > imagePoints, float grid_width, bool release_object);
 
 int main(int argc, char* argv[])
 {
-    help();
+    const String keys
+        = "{help h usage ? |           | print this message            }"
+          "{@settings      |default.xml| input setting file            }"
+          "{d              |           | actual distance between top-left and top-right corners of "
+          "the calibration grid }"
+          "{winSize        | 11        | Half of search window for cornerSubPix }";
+    CommandLineParser parser(argc, argv, keys);
+    parser.about("This is a camera calibration sample.\n"
+                 "Usage: camera_calibration [configuration_file -- default ./default.xml]\n"
+                 "Near the sample file you'll find the configuration file, which has detailed help of "
+                 "how to edit it. It may be any OpenCV supported file format XML/YAML.");
+    if (!parser.check()) {
+        parser.printErrors();
+        return 0;
+    }
+
+    if (parser.has("help")) {
+        parser.printMessage();
+        return 0;
+    }
 
     //! [file_read]
     Settings s;
-    const string inputSettingsFile = argc > 1 ? argv[1] : "default.xml";
+    const string inputSettingsFile = parser.get<string>(0);
     FileStorage fs(inputSettingsFile, FileStorage::READ); // Read the settings
     if (!fs.isOpened())
     {
         cout << "Could not open the configuration file: \"" << inputSettingsFile << "\"" << endl;
+        parser.printMessage();
         return -1;
     }
     fs["Settings"] >> s;
@@ -274,6 +290,15 @@ int main(int argc, char* argv[])
     {
         cout << "Invalid input detected. Application stopping. " << endl;
         return -1;
+    }
+
+    int winSize = parser.get<int>("winSize");
+
+    float grid_width = s.squareSize * (s.boardSize.width - 1);
+    bool release_object = false;
+    if (parser.has("d")) {
+        grid_width = parser.get<float>("d");
+        release_object = true;
     }
 
     vector<vector<Point2f> > imagePoints;
@@ -295,7 +320,8 @@ int main(int argc, char* argv[])
         //-----  If no more image, or got enough, then stop calibration and show result -------------
         if( mode == CAPTURING && imagePoints.size() >= (size_t)s.nrFrames )
         {
-          if( runCalibrationAndSave(s, imageSize,  cameraMatrix, distCoeffs, imagePoints))
+          if(runCalibrationAndSave(s, imageSize,  cameraMatrix, distCoeffs, imagePoints, grid_width,
+                                   release_object))
               mode = CALIBRATED;
           else
               mode = DETECTION;
@@ -304,7 +330,8 @@ int main(int argc, char* argv[])
         {
             // if calibration threshold was not reached yet, calibrate now
             if( mode != CALIBRATED && !imagePoints.empty() )
-                runCalibrationAndSave(s, imageSize,  cameraMatrix, distCoeffs, imagePoints);
+                runCalibrationAndSave(s, imageSize,  cameraMatrix, distCoeffs, imagePoints, grid_width,
+                                      release_object);
             break;
         }
         //! [get_input]
@@ -348,7 +375,7 @@ int main(int argc, char* argv[])
                 {
                     Mat viewGray;
                     cvtColor(view, viewGray, COLOR_BGR2GRAY);
-                    cornerSubPix( viewGray, pointBuf, Size(11,11),
+                    cornerSubPix( viewGray, pointBuf, Size(winSize,winSize),
                         Size(-1,-1), TermCriteria( TermCriteria::EPS+TermCriteria::COUNT, 30, 0.1 ));
                 }
 
@@ -515,7 +542,8 @@ static void calcBoardCornerPositions(Size boardSize, float squareSize, vector<Po
 //! [board_corners]
 static bool runCalibration( Settings& s, Size& imageSize, Mat& cameraMatrix, Mat& distCoeffs,
                             vector<vector<Point2f> > imagePoints, vector<Mat>& rvecs, vector<Mat>& tvecs,
-                            vector<float>& reprojErrs,  double& totalAvgErr)
+                            vector<float>& reprojErrs,  double& totalAvgErr, vector<Point3f>& newObjPoints,
+                            float grid_width, bool release_object)
 {
     //! [fixed_aspect]
     cameraMatrix = Mat::eye(3, 3, CV_64F);
@@ -530,6 +558,8 @@ static bool runCalibration( Settings& s, Size& imageSize, Mat& cameraMatrix, Mat
 
     vector<vector<Point3f> > objectPoints(1);
     calcBoardCornerPositions(s.boardSize, s.squareSize, objectPoints[0], s.calibrationPattern);
+    objectPoints[0][s.boardSize.width - 1].x = objectPoints[0][0].x + grid_width;
+    newObjPoints = objectPoints[0];
 
     objectPoints.resize(imagePoints.size(),objectPoints[0]);
 
@@ -548,14 +578,29 @@ static bool runCalibration( Settings& s, Size& imageSize, Mat& cameraMatrix, Mat
             tvecs.push_back(_tvecs.row(i));
         }
     } else {
-        rms = calibrateCamera(objectPoints, imagePoints, imageSize, cameraMatrix, distCoeffs, rvecs, tvecs,
-                              s.flag);
+        if (release_object)
+            rms = calibrateCamera(objectPoints, imagePoints, imageSize, s.boardSize.width - 1,
+                                  cameraMatrix, distCoeffs, rvecs, tvecs, newObjPoints,
+                                  s.flag | CALIB_RELEASE_OBJECT | CALIB_USE_LU);
+        else
+            rms = calibrateCamera(objectPoints, imagePoints, imageSize, cameraMatrix, distCoeffs,
+                                  rvecs, tvecs, s.flag);
+    }
+
+    if (release_object) {
+        cout << "New board corners: " << endl;
+        cout << newObjPoints[0] << endl;
+        cout << newObjPoints[s.boardSize.width - 1] << endl;
+        cout << newObjPoints[s.boardSize.width * (s.boardSize.height - 1)] << endl;
+        cout << newObjPoints.back() << endl;
     }
 
     cout << "Re-projection error reported by calibrateCamera: "<< rms << endl;
 
     bool ok = checkRange(cameraMatrix) && checkRange(distCoeffs);
 
+    objectPoints.clear();
+    objectPoints.resize(imagePoints.size(), newObjPoints);
     totalAvgErr = computeReprojectionErrors(objectPoints, imagePoints, rvecs, tvecs, cameraMatrix,
                                             distCoeffs, reprojErrs, s.useFisheye);
 
@@ -566,7 +611,7 @@ static bool runCalibration( Settings& s, Size& imageSize, Mat& cameraMatrix, Mat
 static void saveCameraParams( Settings& s, Size& imageSize, Mat& cameraMatrix, Mat& distCoeffs,
                               const vector<Mat>& rvecs, const vector<Mat>& tvecs,
                               const vector<float>& reprojErrs, const vector<vector<Point2f> >& imagePoints,
-                              double totalAvgErr )
+                              double totalAvgErr, const vector<Point3f>& newObjPoints )
 {
     FileStorage fs( s.outputFileName, FileStorage::WRITE );
 
@@ -673,24 +718,30 @@ static void saveCameraParams( Settings& s, Size& imageSize, Mat& cameraMatrix, M
         }
         fs << "image_points" << imagePtMat;
     }
+
+    if( s.writeGrid && !newObjPoints.empty() )
+    {
+        fs << "grid_points" << newObjPoints;
+    }
 }
 
 //! [run_and_save]
 bool runCalibrationAndSave(Settings& s, Size imageSize, Mat& cameraMatrix, Mat& distCoeffs,
-                           vector<vector<Point2f> > imagePoints)
+                           vector<vector<Point2f> > imagePoints, float grid_width, bool release_object)
 {
     vector<Mat> rvecs, tvecs;
     vector<float> reprojErrs;
     double totalAvgErr = 0;
+    vector<Point3f> newObjPoints;
 
     bool ok = runCalibration(s, imageSize, cameraMatrix, distCoeffs, imagePoints, rvecs, tvecs, reprojErrs,
-                             totalAvgErr);
+                             totalAvgErr, newObjPoints, grid_width, release_object);
     cout << (ok ? "Calibration succeeded" : "Calibration failed")
          << ". avg re projection error = " << totalAvgErr << endl;
 
     if (ok)
         saveCameraParams(s, imageSize, cameraMatrix, distCoeffs, rvecs, tvecs, reprojErrs, imagePoints,
-                         totalAvgErr);
+                         totalAvgErr, newObjPoints);
     return ok;
 }
 //! [run_and_save]

--- a/samples/cpp/tutorial_code/calib3d/camera_calibration/camera_calibration.cpp
+++ b/samples/cpp/tutorial_code/calib3d/camera_calibration/camera_calibration.cpp
@@ -376,7 +376,7 @@ int main(int argc, char* argv[])
                     Mat viewGray;
                     cvtColor(view, viewGray, COLOR_BGR2GRAY);
                     cornerSubPix( viewGray, pointBuf, Size(winSize,winSize),
-                        Size(-1,-1), TermCriteria( TermCriteria::EPS+TermCriteria::COUNT, 30, 0.1 ));
+                        Size(-1,-1), TermCriteria( TermCriteria::EPS+TermCriteria::COUNT, 30, 0.0001 ));
                 }
 
                 if( mode == CAPTURING &&  // For camera only take new samples after delay time

--- a/samples/cpp/tutorial_code/calib3d/camera_calibration/in_VID5.xml
+++ b/samples/cpp/tutorial_code/calib3d/camera_calibration/in_VID5.xml
@@ -39,6 +39,8 @@
   <Write_DetectedFeaturePoints>1</Write_DetectedFeaturePoints>
   <!-- If true (non-zero) we write to the output file the extrinsic camera parameters.-->
   <Write_extrinsicParameters>1</Write_extrinsicParameters>
+  <!-- If true (non-zero) we write to the output file the refined 3D target grid points.-->
+  <Write_gridPoints>1</Write_gridPoints>
   <!-- If true (non-zero) we show after calibration the undistorted images.-->
   <Show_UndistortedImage>1</Show_UndistortedImage>
   <!-- If true (non-zero) will be used fisheye camera model.-->


### PR DESCRIPTION
**Merge with extra**: opencv/opencv_extra#528
### Problem to be solved

Checkerboard patterns on paper using off-the-shelf printers are the most
convenient calibration targets. And these printed patterns stuck on
roughly planar surfaces are the mostly used calibration structure world
wide. But in most cases printed patterns are inaccurate and the sticking
surfaces are not perfectly planar.

![chessboard](https://user-images.githubusercontent.com/1014277/45674601-0a5e3200-bb60-11e8-8864-303675b15fd2.png)

For example, the square size of the above chessboard is set to 15mm
in the PDF file. The printed paper was pasted to a glass panel which was
not so perfect planar structure. We measured the distances between
combinations of p1, p2, p3 and p4 with a vernier caliper of 0.02mm
resolution (The uncertainties of the measurements are probably larger
than 0.1mm I think). The result are compared to hypothesis values. The
maximum error is around 1mm (about 3~4 pixels in our application).

distance | hypothesis | measured
---------|------------|---------
\|p1-p2\|| 225        | 224.14  
\|p1-p3\|| 135        | 135.35  
\|p1-p4\|| 262.393    | 261.85  
\|p2-p3\|| 262.393    | 262     
\|p2-p4\|| 135        | 135.13  
\|p3-p4\|| 225        | 224.73  

The inaccuracy of the checkerboard causes less precise and less stable
estimation of camera intrinsic parameters.

### New method integrated

This PR integrates an extension to the standard pinhole camera
calibration method in OpenCV. The method was proposed in the paper:
Klaus H. Strobl and Gerd Hirzinger. [More accurate pinhole camera
calibration with imperfect planar target](https://elib.dlr.de/71888/1/strobl_2011iccv.pdf). In 2011 IEEE International
Conference on Computer Vision (ICCV), pages 1068-1075, Barcelona, Spain,
Nov 2011. IEEE. And it was included in the camera calibration toolbox
[DLR CalDe and DLR CalLab](http://www.robotic.dlr.de/callab/).
In many common cases with inaccurate calibration plates, this method can
dramatically improve the precision of the estimated camera parameters.

In principle the method releases 3D coordinates of the object structure
when performing non-linear Levenberg-Marquardt optimization. The current
calibration process can be easily reinforced by adding extra
optimization parameters and extending the Jacobian matrix.

Before trying to integrate it into OpenCV, a standalone project
[calibrel](https://github.com/xoox/calibrel) was created to reimplement
and validate this method. [The results were double-checked](https://github.com/xoox/calibrel/issues/1#issuecomment-419775155) with [CalLab](http://www.robotic.dlr.de/callab/).
In addition to validating with stereo cameras in the paper, [we also
evaluated its precision using measured distances](https://github.com/xoox/calibrel/issues/2).

When preparing to add test code for this new method, [the existing data
for regression test is reordered](https://github.com/xoox/opencv_extra/blob/calib-release-object/testdata/cv/cameracalibration/calib1.dat) where the object points and image
feature points can be also used by the new calibration method (with
calibration flags changed). The results with releasing object points are
so diverse to standard methods. It may be caused by bad set of images or
inaccuracy of feature points. The comparison is shown in the following
table and further discussions are needed. Could anyone do some
comparisons between these two methods with regard to the same set of
images of an **_accurate_** checkerboard? Both cameras with larger and
smaller distortions are needed. Experiments can be conducted with
`samples/cpp/calibration.cpp` and
`samples/cpp/tutorial_code/calib3d/camera_calibration/camera_calibration.cpp`
in this PR.

parameter | standard   | release_object
----------|------------|---------------
fx        | 809.94872  | 790.93722
fy        | 806.56095  | 775.18624
cx        | 361.99611  | 331.43434
cy        | 214.39525  | 203.89052
k1        | -0.1282055 | -0.244456
k2        | -0.3944258 | 0.3578029
p1        | -0.0043549 | -0.002096
p2        | -0.0073207 | -0.001801
RMS       | 0.138892   | 0.0830433

I have no information of the camera, lens and checkerboard used in
`calib1.dat`. But after drawing its feature points on images, it seems those
images are probably not good candidates for camera calibration. Please
check the images on this PR opencv/opencv_extra#528. Also see [Dr.  Strobl](https://rmc.dlr.de/rm/en/staff/klaus.strobl/)'s
comments on good calibration images: https://github.com/xoox/calibrel/issues/1#issuecomment-419279616

If this PR is going to be squashed, it'd be better full commit messages
are kept instead of commit titles only, for that there are useful
information in the full commit messages.

In the similar fashion, this method can also be included into
`stereoCalibrate()`. But the speed is expected much slower. If the
intrinsic parameters can be estimated with high accuracy for each of the
cameras individually using `calibrateCamera()`, it is recommended to do
so and then pass CALIB_FIX_INTRINSIC flag to `stereoCalibrate()` along
with the computed intrinsic parameters. However, I'd integrate this
method into `stereoCalibrate()` if the necessity is confirmed.

### This pull request changes

#### cvCalibrateCamera4()

A new C interface is added which supports both standard calibration
method and the extended new calibration method.

#### calibrateCameraRO()

New C++ interfaces are added which support both standard calibration
method and the extended new calibration method.

#### Regression test code

The test code is modified to empower tests of both standard calibration
method and the new added one. The updated test data can be found here:
https://github.com/xoox/opencv_extra/tree/calib-release-object A PR opencv/opencv_extra#528 was
also created for the new test data.

#### Sample calibration code

Two calibration samples are updated to support both standard
calibration method and the extended new calibration method.

In conclusion, this PR is just a very straightforward extension to
current standard calibration code.
