### PR TITLE
Fix dnn caffe importer extract blobs from reused layers

### DIFF
--- a/modules/dnn/src/caffe/caffe_importer.cpp
+++ b/modules/dnn/src/caffe/caffe_importer.cpp
@@ -278,11 +278,13 @@ public:
         int li;
         for (li = 0; li != netBinary.layer_size(); li++)
         {
-            if (netBinary.layer(li).name() == name)
+            const caffe::LayerParameter& binLayer = netBinary.layer(li);
+            // Break if the layer name is the same and the blobs are not cleared
+            if (binLayer.name() == name && binLayer.blobs_size() != 0)
                 break;
         }
 
-        if (li == netBinary.layer_size() || netBinary.layer(li).blobs_size() == 0)
+        if (li == netBinary.layer_size())
             return;
 
         caffe::LayerParameter* binLayer = netBinary.mutable_layer(li);

--- a/modules/dnn/test/test_caffe_importer.cpp
+++ b/modules/dnn/test/test_caffe_importer.cpp
@@ -454,6 +454,28 @@ TEST(Test_Caffe, multiple_inputs)
     normAssert(out, first_image + second_image);
 }
 
+TEST(Test_Caffe, shared_weights)
+{
+  const string proto = findDataFile("dnn/layers/shared_weights.prototxt", false);
+  const string model = findDataFile("dnn/layers/shared_weights.caffemodel", false);
+
+  Net net = readNetFromCaffe(proto, model);
+
+  Mat input_1 = (Mat_<float>(2, 2) << 0., 2., 4., 6.);
+  Mat input_2 = (Mat_<float>(2, 2) << 1., 3., 5., 7.);
+
+  Mat blob_1 = blobFromImage(input_1);
+  Mat blob_2 = blobFromImage(input_2);
+
+  net.setInput(blob_1, "input_1");
+  net.setInput(blob_2, "input_2");
+
+  Mat sum = net.forward();
+
+  EXPECT_EQ(sum.at<float>(0,0), 12.);
+  EXPECT_EQ(sum.at<float>(0,1), 16.);
+}
+
 typedef testing::TestWithParam<tuple<std::string, Target> > opencv_face_detector;
 TEST_P(opencv_face_detector, Accuracy)
 {


### PR DESCRIPTION
### Fix bug when loading caffe network which reuses layers

We have been using OpenCV dnn module to run some of our caffe models (OpenCV version 3.4.1). After upgrading to 3.4.2 we noticed problems caused by #11461 

Our network reuses parameters from some of it's layers as described in our `deploy.prototxt` file (see the layer name in the lines highlighted by `HERE`):

```
layer {
  name: "conv1"  type: "Convolution"  bottom: "input_0"  top: "conv1_0"  <--- HERE
  param { name: "conv1_w"    lr_mult: 1    decay_mult: 1  }
  param { name: "conv1_b"   lr_mult: 2    decay_mult: 0  }
  convolution_param {    num_output: 48    kernel_size: 11    stride: 4
    weight_filler {      type: "gaussian"      std: 0.01    }
    bias_filler {      type: "constant"      value: 0    }
  }
}

...

layer {
  name: "conv1"  type: "Convolution"  bottom: "input_2"  top: "conv1_2"   <--- HERE
  param { name: "conv1_w"    lr_mult: 1    decay_mult: 1  }
  param { name: "conv1_b"   lr_mult: 2    decay_mult: 0  }
  convolution_param {    num_output: 48    kernel_size: 11    stride: 4
    weight_filler {      type: "gaussian"      std: 0.01    }
    bias_filler {      type: "constant"      value: 0    }
  }
}

```

The loop edited in `opencv/modules/dnn/src/caffe/caffe_importer.cpp` used to try to copy and clear the blob values as soon as it found matching layer name. Since our network has two layers with the same name, when trying to copy the blob values for the second `conv1` layer, the function would copy a cleared blob.

After the change the loop is searching for a layer with a matching name which does not have its blob values cleared.

Would you like me to write a separate unit test or include it into this pull request? 

Thank you very much for looking into this! Please let me know if you need any more details or if I could help somehow.


```
allow_multiple_commits=1
```