### PR TITLE
samples: add search for MSVS 2017 BuildTools

### DIFF
--- a/samples/_winpack_build_sample.cmd
+++ b/samples/_winpack_build_sample.cmd
@@ -64,19 +64,25 @@ if !ERRORLEVEL! NEQ 0 (
   PUSHD !CD!
   if exist "C:\Program Files (x86)\Microsoft Visual Studio\2017\Professional\VC\Auxiliary\Build\vcvars64.bat" (
     CALL "C:\Program Files (x86)\Microsoft Visual Studio\2017\Professional\VC\Auxiliary\Build\vcvars64.bat"
-  ) else (
-    if exist "C:\Program Files (x86)\Microsoft Visual Studio\2017\Enterprise\VC\Auxiliary\Build\vcvars64.bat" (
-      CALL "C:\Program Files (x86)\Microsoft Visual Studio\2017\Enterprise\VC\Auxiliary\Build\vcvars64.bat"
-    ) else (
-      if exist "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat" (
-        CALL "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat" amd64
-      )
-    )
+    goto check_msvc
   )
+  if exist "C:\Program Files (x86)\Microsoft Visual Studio\2017\Enterprise\VC\Auxiliary\Build\vcvars64.bat" (
+    CALL "C:\Program Files (x86)\Microsoft Visual Studio\2017\Enterprise\VC\Auxiliary\Build\vcvars64.bat"
+    goto check_msvc
+  )
+  if exist "C:\Program Files (x86)\Microsoft Visual Studio\2017\BuildTools\VC\Auxiliary\Build\vcvars64.bat" (
+    CALL "C:\Program Files (x86)\Microsoft Visual Studio\2017\BuildTools\VC\Auxiliary\Build\vcvars64.bat"
+    goto check_msvc
+  )
+  if exist "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat" (
+    CALL "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat" amd64
+    goto check_msvc
+  )
+:check_msvc
   POPD
   cl /? >NUL 2>NUL <NUL
   if !ERRORLEVEL! NEQ 0 (
-    set "MSG=ERROR: Can't detect Microsoft Visial Studio C++ compiler (cl.exe). MSVS 2015/2017 are supported only from standard locations"
+    set "MSG=Can't detect Microsoft Visial Studio C++ compiler (cl.exe). MSVS 2015/2017 are supported only from standard locations"
     goto die
   )
 )


### PR DESCRIPTION
relates #12636

Support configurations without full MSVS installations - where [BuildTools](https://visualstudio.microsoft.com/downloads/#build-tools-for-visual-studio-2017) is available only.