### PR TITLE
core: call omp_set_dynamic() for better CPU usage

### DIFF
--- a/modules/core/src/parallel.cpp
+++ b/modules/core/src/parallel.cpp
@@ -420,7 +420,16 @@ static int numThreads = -1;
 #elif defined HAVE_CSTRIPES
 // nothing for C=
 #elif defined HAVE_OPENMP
-static int numThreadsMax = omp_get_max_threads();
+static inline int _initMaxThreads()
+{
+    int maxThreads = omp_get_max_threads();
+    if (!utils::getConfigurationParameterBool("OPENCV_FOR_OPENMP_DYNAMIC_DISABLE", false))
+    {
+        omp_set_dynamic(maxThreads);
+    }
+    return numThreads;
+}
+static int numThreadsMax = _initMaxThreads();
 #elif defined HAVE_GCD
 // nothing for GCD
 #elif defined WINRT


### PR DESCRIPTION
Similar to 'OMP_DYNAMIC=TRUE'.

OpenMP is very sensitive to background jobs.

Switch to old behavior:
- set `OPENCV_FOR_OPENMP_DYNAMIC_DISABLE=1`
- or call `omp_set_dynamic(0)` from user code.

<cut/>

---

[Before](http://pullrequest.opencv.org/buildbot/builders/3_4_etc-qt-openmp-lin64/builds/24):
```
[----------] 2 tests from Core_KMeans
[ RUN      ] Core_KMeans.singular
[       OK ] Core_KMeans.singular (559692 ms)
[ RUN      ] Core_KMeans.compactness

command timed out: 600 seconds without output
```

[After](http://pullrequest.opencv.org/buildbot/builders/3_4_etc-qt-openmp-lin64/builds/25):
```
[----------] 2 tests from Core_KMeans
[ RUN      ] Core_KMeans.singular
[       OK ] Core_KMeans.singular (8336 ms)
[ RUN      ] Core_KMeans.compactness
[       OK ] Core_KMeans.compactness (22233 ms)
[----------] 2 tests from Core_KMeans (30569 ms total)
```

Ideal case - no background jobs:
```
[----------] 2 tests from Core_KMeans
[ RUN      ] Core_KMeans.singular
[       OK ] Core_KMeans.singular (215 ms)
[ RUN      ] Core_KMeans.compactness
[       OK ] Core_KMeans.compactness (252 ms)
[----------] 2 tests from Core_KMeans (467 ms total)
```