### PR TITLE
js: update build js

### DIFF
--- a/modules/core/include/opencv2/core/utils/trace.hpp
+++ b/modules/core/include/opencv2/core/utils/trace.hpp
@@ -37,6 +37,10 @@ namespace trace {
 //! @cond IGNORED
 #define CV_TRACE_NS cv::utils::trace
 
+#if !defined(OPENCV_DISABLE_TRACE) && defined(__EMSCRIPTEN__)
+#define OPENCV_DISABLE_TRACE 1
+#endif
+
 namespace details {
 
 #ifndef __OPENCV_TRACE

--- a/modules/core/src/mathfuncs.cpp
+++ b/modules/core/src/mathfuncs.cpp
@@ -1271,10 +1271,17 @@ void pow( InputArray _src, double power, OutputArray _dst )
         Cv64suf inf64, nan64;
         float* fbuf = 0;
         double* dbuf = 0;
+#ifndef __EMSCRIPTEN__
         inf32.i = 0x7f800000;
         nan32.i = 0x7fffffff;
         inf64.i = CV_BIG_INT(0x7FF0000000000000);
         nan64.i = CV_BIG_INT(0x7FFFFFFFFFFFFFFF);
+#else
+        inf32.f = std::numeric_limits<float>::infinity();
+        nan32.f = std::numeric_limits<float>::quiet_NaN();
+        inf64.f = std::numeric_limits<double>::infinity();
+        nan64.f = std::numeric_limits<double>::quiet_NaN();
+#endif
 
         if( src.ptr() == dst.ptr() )
         {

--- a/modules/core/src/mathfuncs_core.simd.hpp
+++ b/modules/core/src/mathfuncs_core.simd.hpp
@@ -27,15 +27,25 @@ float fastAtan2(float y, float x);
 #ifndef CV_CPU_OPTIMIZATION_DECLARATIONS_ONLY
 
 using namespace std;
+using namespace cv;
 
 namespace {
 
+#ifdef __EMSCRIPTEN__
+static inline float atan_f32(float y, float x)
+{
+    float a = atan2(y, x) * 180.0f / CV_PI;
+    if (a < 0.0f)
+        a += 360.0f;
+    if (a >= 360.0f)
+        a -= 360.0f;
+    return a; // range [0; 360)
+}
+#else
 static const float atan2_p1 = 0.9997878412794807f*(float)(180/CV_PI);
 static const float atan2_p3 = -0.3258083974640975f*(float)(180/CV_PI);
 static const float atan2_p5 = 0.1555786518463281f*(float)(180/CV_PI);
 static const float atan2_p7 = -0.04432655554792128f*(float)(180/CV_PI);
-
-using namespace cv;
 
 static inline float atan_f32(float y, float x)
 {
@@ -59,6 +69,7 @@ static inline float atan_f32(float y, float x)
         a = 360.f - a;
     return a;
 }
+#endif
 
 #if CV_SIMD
 
@@ -363,7 +374,7 @@ void sqrt64f(const double* src, double* dst, int len)
 // Workaround for ICE in MSVS 2015 update 3 (issue #7795)
 // CV_AVX is not used here, because generated code is faster in non-AVX mode.
 // (tested with disabled IPP on i5-6300U)
-#if (defined _MSC_VER && _MSC_VER >= 1900)
+#if (defined _MSC_VER && _MSC_VER >= 1900) || defined(__EMSCRIPTEN__)
 void exp32f(const float *src, float *dst, int n)
 {
     CV_INSTRUMENT_REGION();

--- a/modules/js/CMakeLists.txt
+++ b/modules/js/CMakeLists.txt
@@ -86,7 +86,11 @@ ocv_add_executable(${the_module} ${bindings_cpp})
 
 set_target_properties(${the_module} PROPERTIES COMPILE_FLAGS "-Wno-missing-prototypes")
 
-set_target_properties(${the_module} PROPERTIES LINK_FLAGS "--memory-init-file 0 -s TOTAL_MEMORY=134217728 -s ALLOW_MEMORY_GROWTH=1 -s MODULARIZE=1 -s EXPORT_NAME=\"'cv'\" -s DEMANGLE_SUPPORT=1 -s FORCE_FILESYSTEM=1 --use-preload-plugins --bind --post-js ${JS_HELPER} -Wno-missing-prototypes")
+set(EMSCRIPTEN_LINK_FLAGS "${EMSCRIPTEN_LINK_FLAGS} --memory-init-file 0 -s TOTAL_MEMORY=134217728 -s ALLOW_MEMORY_GROWTH=1")
+set(EMSCRIPTEN_LINK_FLAGS "${EMSCRIPTEN_LINK_FLAGS} -s MODULARIZE=1 -s SINGLE_FILE=1")
+set(EMSCRIPTEN_LINK_FLAGS "${EMSCRIPTEN_LINK_FLAGS} -s EXPORT_NAME=\"'cv'\" -s DEMANGLE_SUPPORT=1")
+set(EMSCRIPTEN_LINK_FLAGS "${EMSCRIPTEN_LINK_FLAGS} -s FORCE_FILESYSTEM=1 --use-preload-plugins --bind --post-js ${JS_HELPER} -Wno-missing-prototypes")
+set_target_properties(${the_module} PROPERTIES LINK_FLAGS "${EMSCRIPTEN_LINK_FLAGS}")
 
 # add UMD wrapper
 set(MODULE_JS_PATH "${OpenCV_BINARY_DIR}/bin/${the_module}.js")

--- a/platforms/js/build_js.py
+++ b/platforms/js/build_js.py
@@ -14,7 +14,9 @@ class Fail(Exception):
 def execute(cmd, shell=False):
     try:
         log.info("Executing: %s" % cmd)
-        retcode = subprocess.call(cmd, shell=shell)
+        env = os.environ.copy()
+        env['VERBOSE'] = '1'
+        retcode = subprocess.call(cmd, shell=shell, env=env)
         if retcode < 0:
             raise Fail("Child was terminated by signal: %s" % -retcode)
         elif retcode > 0:
@@ -148,6 +150,8 @@ class Builder:
         flags = ""
         if self.options.build_wasm:
             flags += "-s WASM=1 "
+        elif self.options.disable_wasm:
+            flags += "-s WASM=0 "
         if self.options.enable_exception:
             flags += "-s DISABLE_EXCEPTION_CATCHING=0 "
         return flags
@@ -180,6 +184,7 @@ if __name__ == "__main__":
     parser.add_argument('--opencv_dir', default=opencv_dir, help='Opencv source directory (default is "../.." relative to script location)')
     parser.add_argument('--emscripten_dir', default=emscripten_dir, help="Path to Emscripten to use for build")
     parser.add_argument('--build_wasm', action="store_true", help="Build OpenCV.js in WebAssembly format")
+    parser.add_argument('--disable_wasm', action="store_true", help="Build OpenCV.js in Asm.js format")
     parser.add_argument('--build_test', action="store_true", help="Build tests")
     parser.add_argument('--build_doc', action="store_true", help="Build tutorials")
     parser.add_argument('--clean_build_dir', action="store_true", help="Clean build dir")
@@ -206,9 +211,11 @@ if __name__ == "__main__":
         builder.clean_build_dir()
 
     if not args.skip_config:
-        target = "asm.js"
+        target = "default target"
         if args.build_wasm:
             target = "wasm"
+        elif args.disable_wasm:
+            target = "asm.js"
         log.info("=====")
         log.info("===== Config OpenCV.js build for %s" % target)
         log.info("=====")
@@ -218,7 +225,7 @@ if __name__ == "__main__":
         sys.exit(0)
 
     log.info("=====")
-    log.info("===== Building OpenCV.js in %s", "asm.js" if not args.build_wasm else "wasm")
+    log.info("===== Building OpenCV.js")
     log.info("=====")
     builder.build_opencvjs()
 


### PR DESCRIPTION
- support emscipten 1.38.12 ([wasm is ON by default](https://github.com/kripken/emscripten/blame/dc5c6841ae36cf59748de21b152176e9fdd0c2d2/src/settings.js#L735), need to disable explicitly)
- verbose build messages
- use builtin Math functions

```
force_builders=Custom
docker_image:Docs=docs-js
docker_image:Custom=javascript
```