### PR TITLE
Change "top-to-bottom" to "bottom-to-top"

### DIFF
--- a/doc/py_tutorials/py_calib3d/py_calibration/py_calibration.markdown
+++ b/doc/py_tutorials/py_calib3d/py_calibration/py_calibration.markdown
@@ -81,7 +81,7 @@ So to find pattern in chess board, we can use the function, **cv.findChessboardC
 need to pass what kind of pattern we are looking for, like 8x8 grid, 5x5 grid etc. In this example, we
 use 7x6 grid. (Normally a chess board has 8x8 squares and 7x7 internal corners). It returns the
 corner points and retval which will be True if pattern is obtained. These corners will be placed in
-an order (from left-to-right, top-to-bottom)
+an order (from left-to-right, bottom-to-top)
 
 @sa This function may not be able to find the required pattern in all the images. So, one good option
 is to write the code such that, it starts the camera and check each frame for required pattern. Once


### PR DESCRIPTION
<!-- Please use this line to close one or multiple issues when this pullrequest gets merged
You can add another line right under the first one:
resolves #4905
-->

### This pullrequest changes
the python tutorial on camera calibration. Last line of the first paragraph under "Setup" says:
> These corners will be placed in an order (from left-to-right, top-to-bottom)

However, the image further down the section shows a pattern that looks like left to right, bottom to top.

This issue is mentioned in #4905