### PR TITLE
change area() emptiness checks to empty()

### DIFF
--- a/modules/calib3d/src/fisheye.cpp
+++ b/modules/calib3d/src/fisheye.cpp
@@ -534,7 +534,7 @@ void cv::fisheye::undistortImage(InputArray distorted, OutputArray undistorted,
 {
     CV_INSTRUMENT_REGION();
 
-    Size size = new_size.area() != 0 ? new_size : distorted.size();
+    Size size = !new_size.empty() ? new_size : distorted.size();
 
     cv::Mat map1, map2;
     fisheye::initUndistortRectifyMap(K, D, cv::Matx33d::eye(), Knew, size, CV_16SC2, map1, map2 );
@@ -601,7 +601,7 @@ void cv::fisheye::estimateNewCameraMatrixForUndistortRectify(InputArray K, Input
     new_f[1] /= aspect_ratio;
     new_c[1] /= aspect_ratio;
 
-    if (new_size.area() > 0)
+    if (!new_size.empty())
     {
         double rx = new_size.width /(double)image_size.width;
         double ry = new_size.height/(double)image_size.height;

--- a/modules/calib3d/src/stereobm.cpp
+++ b/modules/calib3d/src/stereobm.cpp
@@ -1226,8 +1226,8 @@ public:
         parallel_for_(Range(0, 2), PrefilterInvoker(left0, right0, left, right, _buf, _buf + bufSize1, &params), 1);
 
         Rect validDisparityRect(0, 0, width, height), R1 = params.roi1, R2 = params.roi2;
-        validDisparityRect = getValidDisparityROI(R1.area() > 0 ? R1 : validDisparityRect,
-                                                  R2.area() > 0 ? R2 : validDisparityRect,
+        validDisparityRect = getValidDisparityROI(!R1.empty() ? R1 : validDisparityRect,
+                                                  !R2.empty() ? R2 : validDisparityRect,
                                                   params.minDisparity, params.numDisparities,
                                                   params.SADWindowSize);
 

--- a/modules/dnn/perf/perf_convolution.cpp
+++ b/modules/dnn/perf/perf_convolution.cpp
@@ -562,9 +562,9 @@ static inline void PrintTo(const ConvParamID& v, std::ostream* os)
         *os << ", S=" << ((Size)p.stride);
     if (((Size)p.dilation).area() != 1)
         *os << ", D=" << ((Size)p.dilation);
-    if (((Size)p.pad).area() != 0)
+    if (!((Size)p.pad).empty())
         *os << ", P=" << ((Size)p.pad);
-    if (((Size)p.padAdjust).area() != 0)
+    if (!((Size)p.padAdjust).empty())
         *os << ", PAdj=" << ((Size)p.padAdjust);
     if (!((std::string)p.padMode).empty())
         *os << ", PM=" << ((std::string)p.padMode);

--- a/modules/imgproc/src/drawing.cpp
+++ b/modules/imgproc/src/drawing.cpp
@@ -1876,7 +1876,7 @@ void rectangle( Mat& img, Rect rec,
     CV_INSTRUMENT_REGION();
 
     CV_Assert( 0 <= shift && shift <= XY_SHIFT );
-    if( rec.area() > 0 )
+    if( !rec.empty() )
         rectangle( img, rec.tl(), rec.br() - Point(1<<shift,1<<shift),
                    color, thickness, lineType, shift );
 }

--- a/modules/imgproc/src/imgwarp.cpp
+++ b/modules/imgproc/src/imgwarp.cpp
@@ -663,7 +663,7 @@ static void remapBilinear( const Mat& _src, Mat& _dst, const Mat& _xy,
         cval[k] = saturate_cast<T>(_borderValue[k & 3]);
 
     unsigned width1 = std::max(ssize.width-1, 0), height1 = std::max(ssize.height-1, 0);
-    CV_Assert( ssize.area() > 0 );
+    CV_Assert( !ssize.empty() );
 #if CV_SIMD128
     if( _src.type() == CV_8UC3 )
         width1 = std::max(ssize.width-2, 0);
@@ -1705,7 +1705,7 @@ void cv::remap( InputArray _src, OutputArray _dst,
         remapLanczos4<Cast<double, double>, float, 1>, 0
     };
 
-    CV_Assert( _map1.size().area() > 0 );
+    CV_Assert( !_map1.empty() );
     CV_Assert( _map2.empty() || (_map2.size() == _map1.size()));
 
     CV_OCL_RUN(_src.dims() <= 2 && _dst.isUMat(),
@@ -2410,7 +2410,7 @@ static bool ocl_warpTransform_cols4(InputArray _src, OutputArray _dst, InputArra
     scalarToRawData(borderValue, borderBuf, sctype);
 
     UMat src = _src.getUMat(), M0;
-    _dst.create( dsize.area() == 0 ? src.size() : dsize, src.type() );
+    _dst.create( dsize.empty() ? src.size() : dsize, src.type() );
     UMat dst = _dst.getUMat();
 
     float M[9] = {0};
@@ -2514,7 +2514,7 @@ static bool ocl_warpTransform(InputArray _src, OutputArray _dst, InputArray _M0,
     scalarToRawData(borderValue, borderBuf, sctype);
 
     UMat src = _src.getUMat(), M0;
-    _dst.create( dsize.area() == 0 ? src.size() : dsize, src.type() );
+    _dst.create( dsize.empty() ? src.size() : dsize, src.type() );
     UMat dst = _dst.getUMat();
 
     double M[9] = {0};
@@ -2606,7 +2606,7 @@ void cv::warpAffine( InputArray _src, OutputArray _dst,
                                  borderValue, OCL_OP_AFFINE))
 
     Mat src = _src.getMat(), M0 = _M0.getMat();
-    _dst.create( dsize.area() == 0 ? src.size() : dsize, src.type() );
+    _dst.create( dsize.empty() ? src.size() : dsize, src.type() );
     Mat dst = _dst.getMat();
     CV_Assert( src.cols > 0 && src.rows > 0 );
     if( dst.data == src.data )
@@ -2912,7 +2912,7 @@ void cv::warpPerspective( InputArray _src, OutputArray _dst, InputArray _M0,
                               OCL_OP_PERSPECTIVE))
 
     Mat src = _src.getMat(), M0 = _M0.getMat();
-    _dst.create( dsize.area() == 0 ? src.size() : dsize, src.type() );
+    _dst.create( dsize.empty() ? src.size() : dsize, src.type() );
     Mat dst = _dst.getMat();
 
     if( dst.data == src.data )

--- a/modules/imgproc/src/lsd.cpp
+++ b/modules/imgproc/src/lsd.cpp
@@ -1166,7 +1166,7 @@ int LineSegmentDetectorImpl::compareSegments(const Size& size, InputArray lines1
 
     Size sz = size;
     if (_image.needed() && _image.size() != size) sz = _image.size();
-    CV_Assert(sz.area());
+    CV_Assert(!sz.empty());
 
     Mat_<uchar> I1 = Mat_<uchar>::zeros(sz);
     Mat_<uchar> I2 = Mat_<uchar>::zeros(sz);

--- a/modules/imgproc/src/pyramids.cpp
+++ b/modules/imgproc/src/pyramids.cpp
@@ -631,7 +631,7 @@ static bool ocl_pyrDown( InputArray _src, OutputArray _dst, const Size& _dsz, in
         return false;
 
     Size ssize = _src.size();
-    Size dsize = _dsz.area() == 0 ? Size((ssize.width + 1) / 2, (ssize.height + 1) / 2) : _dsz;
+    Size dsize = _dsz.empty() ? Size((ssize.width + 1) / 2, (ssize.height + 1) / 2) : _dsz;
     if (dsize.height < 2 || dsize.width < 2)
         return false;
 
@@ -683,7 +683,7 @@ static bool ocl_pyrUp( InputArray _src, OutputArray _dst, const Size& _dsz, int 
         return false;
 
     Size ssize = _src.size();
-    if ((_dsz.area() != 0) && (_dsz != Size(ssize.width * 2, ssize.height * 2)))
+    if (!_dsz.empty() && (_dsz != Size(ssize.width * 2, ssize.height * 2)))
         return false;
 
     UMat src = _src.getUMat();
@@ -742,7 +742,7 @@ static bool ipp_pyrdown( InputArray _src, OutputArray _dst, const Size& _dsz, in
     CV_INSTRUMENT_REGION_IPP();
 
 #if IPP_VERSION_X100 >= 810 && !IPP_DISABLE_PYRAMIDS_DOWN
-    Size dsz = _dsz.area() == 0 ? Size((_src.cols() + 1)/2, (_src.rows() + 1)/2) : _dsz;
+    Size dsz = _dsz.empty() ? Size((_src.cols() + 1)/2, (_src.rows() + 1)/2) : _dsz;
     bool isolated = (borderType & BORDER_ISOLATED) != 0;
     int borderTypeNI = borderType & ~BORDER_ISOLATED;
 
@@ -817,7 +817,7 @@ static bool openvx_pyrDown( InputArray _src, OutputArray _dst, const Size& _dsz,
     // OpenVX limitations
     if((srcMat.type() != CV_8U) ||
        (borderType != BORDER_REPLICATE) ||
-       (_dsz != acceptableSize && _dsz.area() != 0))
+       (_dsz != acceptableSize && !_dsz.empty()))
         return false;
 
     // The only border mode which is supported by both cv::pyrDown() and OpenVX
@@ -889,7 +889,7 @@ void cv::pyrDown( InputArray _src, OutputArray _dst, const Size& _dsz, int borde
                openvx_pyrDown(_src, _dst, _dsz, borderType))
 
     Mat src = _src.getMat();
-    Size dsz = _dsz.area() == 0 ? Size((src.cols + 1)/2, (src.rows + 1)/2) : _dsz;
+    Size dsz = _dsz.empty() ? Size((src.cols + 1)/2, (src.rows + 1)/2) : _dsz;
     _dst.create( dsz, src.type() );
     Mat dst = _dst.getMat();
     int depth = src.depth();
@@ -936,7 +936,7 @@ static bool ipp_pyrup( InputArray _src, OutputArray _dst, const Size& _dsz, int 
 
 #if IPP_VERSION_X100 >= 810 && !IPP_DISABLE_PYRAMIDS_UP
     Size sz = _src.dims() <= 2 ? _src.size() : Size();
-    Size dsz = _dsz.area() == 0 ? Size(_src.cols()*2, _src.rows()*2) : _dsz;
+    Size dsz = _dsz.empty() ? Size(_src.cols()*2, _src.rows()*2) : _dsz;
 
     Mat src = _src.getMat();
     _dst.create( dsz, src.type() );
@@ -999,7 +999,7 @@ void cv::pyrUp( InputArray _src, OutputArray _dst, const Size& _dsz, int borderT
 
 
     Mat src = _src.getMat();
-    Size dsz = _dsz.area() == 0 ? Size(src.cols*2, src.rows*2) : _dsz;
+    Size dsz = _dsz.empty() ? Size(src.cols*2, src.rows*2) : _dsz;
     _dst.create( dsz, src.type() );
     Mat dst = _dst.getMat();
     int depth = src.depth();

--- a/modules/imgproc/test/ocl/test_pyramids.cpp
+++ b/modules/imgproc/test/ocl/test_pyramids.cpp
@@ -97,7 +97,7 @@ OCL_TEST_P(PyrDown, Mat)
         Size src_roiSize = randomSize(1, MAX_VALUE);
         Size dst_roiSize = Size(randomInt((src_roiSize.width - 1) / 2, (src_roiSize.width + 3) / 2),
                                 randomInt((src_roiSize.height - 1) / 2, (src_roiSize.height + 3) / 2));
-        dst_roiSize = dst_roiSize.area() == 0 ? Size((src_roiSize.width + 1) / 2, (src_roiSize.height + 1) / 2) : dst_roiSize;
+        dst_roiSize = dst_roiSize.empty() ? Size((src_roiSize.width + 1) / 2, (src_roiSize.height + 1) / 2) : dst_roiSize;
         generateTestData(src_roiSize, dst_roiSize);
 
         OCL_OFF(pyrDown(src_roi, dst_roi, dst_roiSize, borderType));

--- a/modules/imgproc/test/ocl/test_warp.cpp
+++ b/modules/imgproc/test/ocl/test_warp.cpp
@@ -289,7 +289,7 @@ PARAM_TEST_CASE(Resize, MatType, double, double, Interpolation, bool, int)
         dstRoiSize.width = cvRound(srcRoiSize.width * fx);
         dstRoiSize.height = cvRound(srcRoiSize.height * fy);
 
-        if (dstRoiSize.area() == 0)
+        if (dstRoiSize.empty())
         {
             random_roi();
             return;

--- a/modules/imgproc/test/test_imgwarp_strict.cpp
+++ b/modules/imgproc/test/test_imgwarp_strict.cpp
@@ -527,7 +527,7 @@ double CV_Resize_Test::getWeight(double a, double b, int x)
 void CV_Resize_Test::resize_area()
 {
     Size ssize = src.size(), dsize = reference_dst.size();
-    CV_Assert(ssize.area() > 0 && dsize.area() > 0);
+    CV_Assert(!ssize.empty() && !dsize.empty());
     int cn = src.channels();
 
     CV_Assert(scale_x >= 1.0 && scale_y >= 1.0);
@@ -654,7 +654,7 @@ void CV_Resize_Test::generate_buffer(double scale, dim& _dim)
 void CV_Resize_Test::resize_generic()
 {
     Size dsize = reference_dst.size(), ssize = src.size();
-    CV_Assert(dsize.area() > 0 && ssize.area() > 0);
+    CV_Assert(!dsize.empty() && !ssize.empty());
 
     dim dims[] = { dim(dsize.width), dim(dsize.height) };
     if (interpolation == INTER_NEAREST)
@@ -884,7 +884,7 @@ void CV_Remap_Test::remap_nearest(const Mat& _src, Mat& _dst)
     CV_Assert(mapx.type() == CV_16SC2 && mapy.empty());
 
     Size ssize = _src.size(), dsize = _dst.size();
-    CV_Assert(ssize.area() > 0 && dsize.area() > 0);
+    CV_Assert(!ssize.empty() && !dsize.empty());
     int cn = _src.channels();
 
     for (int dy = 0; dy < dsize.height; ++dy)
@@ -1106,8 +1106,8 @@ void CV_WarpAffine_Test::warpAffine(const Mat& _src, Mat& _dst)
 {
     Size dsize = _dst.size();
 
-    CV_Assert(_src.size().area() > 0);
-    CV_Assert(dsize.area() > 0);
+    CV_Assert(!_src.empty());
+    CV_Assert(!dsize.empty());
     CV_Assert(_src.type() == _dst.type());
 
     Mat tM;
@@ -1228,8 +1228,8 @@ void CV_WarpPerspective_Test::warpPerspective(const Mat& _src, Mat& _dst)
 {
     Size ssize = _src.size(), dsize = _dst.size();
 
-    CV_Assert(ssize.area() > 0);
-    CV_Assert(dsize.area() > 0);
+    CV_Assert(!ssize.empty());
+    CV_Assert(!dsize.empty());
     CV_Assert(_src.type() == _dst.type());
 
     if (M.depth() != CV_64F)

--- a/modules/objdetect/src/cascadedetect.cpp
+++ b/modules/objdetect/src/cascadedetect.cpp
@@ -502,7 +502,7 @@ bool FeatureEvaluator::setImage( InputArray _image, const std::vector<float>& _s
         copyVectorToUMat(*scaleData, uscaleData);
     }
 
-    if (_image.isUMat() && localSize.area() > 0)
+    if (_image.isUMat() && !localSize.empty())
     {
         usbuf.create(sbufSize.height*nchannels, sbufSize.width, CV_32S);
         urbuf.create(sz0, CV_8U);
@@ -1076,7 +1076,7 @@ bool CascadeClassifierImpl::ocl_detectMultiScaleNoGrouping( const std::vector<fl
     std::vector<UMat> bufs;
     featureEvaluator->getUMats(bufs);
     Size localsz = featureEvaluator->getLocalSize();
-    if( localsz.area() == 0 )
+    if( localsz.empty() )
         return false;
     Size lbufSize = featureEvaluator->getLocalBufSize();
     size_t localsize[] = { (size_t)localsz.width, (size_t)localsz.height };
@@ -1112,7 +1112,7 @@ bool CascadeClassifierImpl::ocl_detectMultiScaleNoGrouping( const std::vector<fl
         if( haarKernel.empty() )
         {
             String opts;
-            if (lbufSize.area())
+            if ( !lbufSize.empty() )
                 opts = format("-D LOCAL_SIZE_X=%d -D LOCAL_SIZE_Y=%d -D SUM_BUF_SIZE=%d -D SUM_BUF_STEP=%d -D NODE_COUNT=%d -D SPLIT_STAGE=%d -D N_STAGES=%d -D MAX_FACES=%d -D HAAR",
                               localsz.width, localsz.height, lbufSize.area(), lbufSize.width, data.maxNodesPerTree, splitstage_ocl, nstages, MAX_FACES);
             else
@@ -1152,7 +1152,7 @@ bool CascadeClassifierImpl::ocl_detectMultiScaleNoGrouping( const std::vector<fl
         if( lbpKernel.empty() )
         {
             String opts;
-            if (lbufSize.area())
+            if ( !lbufSize.empty() )
                 opts = format("-D LOCAL_SIZE_X=%d -D LOCAL_SIZE_Y=%d -D SUM_BUF_SIZE=%d -D SUM_BUF_STEP=%d -D SPLIT_STAGE=%d -D N_STAGES=%d -D MAX_FACES=%d -D LBP",
                               localsz.width, localsz.height, lbufSize.area(), lbufSize.width, splitstage_ocl, nstages, MAX_FACES);
             else
@@ -1308,7 +1308,7 @@ void CascadeClassifierImpl::detectMultiScaleNoGrouping( InputArray _image, std::
 #ifdef HAVE_OPENCL
     bool use_ocl = tryOpenCL && ocl::isOpenCLActivated() &&
          OCL_FORCE_CHECK(_image.isUMat()) &&
-         featureEvaluator->getLocalSize().area() > 0 &&
+         !featureEvaluator->getLocalSize().empty() &&
          (data.minNodesPerTree == data.maxNodesPerTree) &&
          !isOldFormatCascade() &&
          maskGenerator.empty() &&

--- a/modules/objdetect/src/detection_based_tracker.cpp
+++ b/modules/objdetect/src/detection_based_tracker.cpp
@@ -661,7 +661,7 @@ void DetectionBasedTracker::process(const Mat& imageGray)
             CV_Assert(n > 0);
 
             Rect r = trackedObjects[i].lastPositions[n-1];
-            if(r.area() == 0) {
+            if(r.empty()) {
                 LOGE("DetectionBasedTracker::process: ERROR: ATTENTION: strange algorithm's behavior: trackedObjects[i].rect() is empty");
                 continue;
             }
@@ -701,7 +701,7 @@ void cv::DetectionBasedTracker::getObjects(std::vector<cv::Rect>& result) const
 
     for(size_t i=0; i < trackedObjects.size(); i++) {
         Rect r=calcTrackedObjectPositionToShow((int)i);
-        if (r.area()==0) {
+        if (r.empty()) {
             continue;
         }
         result.push_back(r);
@@ -715,7 +715,7 @@ void cv::DetectionBasedTracker::getObjects(std::vector<Object>& result) const
 
     for(size_t i=0; i < trackedObjects.size(); i++) {
         Rect r=calcTrackedObjectPositionToShow((int)i);
-        if (r.area()==0) {
+        if (r.empty()) {
             continue;
         }
         result.push_back(Object(r, trackedObjects[i].id));

--- a/modules/objdetect/src/haar.cpp
+++ b/modules/objdetect/src/haar.cpp
@@ -1427,7 +1427,7 @@ cvHaarDetectObjectsForROC( const CvArr* _img,
                             + equRect.x + equRect.width;
             }
 
-            if( scanROI.area() > 0 )
+            if( !scanROI.empty() )
             {
                 //adjust start_height and stop_height
                 startY = cvRound(scanROI.y / ystep);
@@ -1442,7 +1442,7 @@ cvHaarDetectObjectsForROC( const CvArr* _img,
                                                            ystep, sum->step, (const int**)p,
                                                            (const int**)pq, allCandidates, &mtx ));
 
-            if( findBiggestObject && !allCandidates.empty() && scanROI.area() == 0 )
+            if( findBiggestObject && !allCandidates.empty() && scanROI.empty() )
             {
                 rectList.resize(allCandidates.size());
                 std::copy(allCandidates.begin(), allCandidates.end(), rectList.begin());

--- a/samples/cpp/select3dobj.cpp
+++ b/samples/cpp/select3dobj.cpp
@@ -559,7 +559,7 @@ int main(int argc, char** argv)
             {
                 Rect r = extract3DBox(frame, shownFrame, selectedObjFrame,
                                       cameraMatrix, rvec, tvec, box, 4, true);
-                if( r.area() )
+                if( !r.empty() )
                 {
                     const int maxFrameIdx = 10000;
                     char path[1000];

--- a/samples/tapi/dense_optical_flow.cpp
+++ b/samples/tapi/dense_optical_flow.cpp
@@ -36,7 +36,7 @@ static Mat getVisibleFlow(InputArray flow)
 
 static Size fitSize(const Size & sz,  const Size & bounds)
 {
-    CV_Assert(sz.area() > 0);
+    CV_Assert(!sz.empty());
     if (sz.width > bounds.width || sz.height > bounds.height)
     {
         double scale = std::min((double)bounds.width / sz.width, (double)bounds.height / sz.height);


### PR DESCRIPTION
relates #12811 

### This pullrequest changes

changes area() emptiness checks to use empty()

cases:
 .area() == 0 to empty()
 .area() != 0 to !empty()
 .area() > 0 to  !empty()

_src.size().area() > 0 to !_src.empty() //no need to create size here

if( r.area() ) to if( !r.empty() )