### PR TITLE
G-API: Introduce LPI (multiple Lines-Per-Iteration) support for Resize

### DIFF
--- a/modules/gapi/src/backends/fluid/gfluidbackend.hpp
+++ b/modules/gapi/src/backends/fluid/gfluidbackend.hpp
@@ -82,7 +82,10 @@ public:
     bool done() const;
 
     void debug(std::ostream& os);
-
+    // FIXME:
+    // refactor (implement a more solid replacement or
+    // drop this method completely)
+    virtual void setInHeight(int h) = 0;
 private:
     // FIXME!!!
     // move to another class


### PR DESCRIPTION
Several Resize optimizations count on fetching multiple input lines at
once to do interpolation more efficiently.

At the moment, Fluid backend supports only LPI=1 for Resize kernels.

This patch introduces scheduling support for Resizes with LPI>1 and
covers these cases with new tests.

The support is initially written by Ruslan Garnov.

<!-- Please use this line to close one or multiple issues when this pullrequest gets merged
You can add another line right under the first one:
resolves #1234
resolves #1235
-->

<!-- Please describe what your pullrequest is changing -->
