### PR TITLE
Catch exceptions by const-reference

### DIFF
--- a/modules/core/src/copy.cpp
+++ b/modules/core/src/copy.cpp
@@ -729,7 +729,7 @@ static bool ipp_flip(Mat &src, Mat &dst, int flip_mode)
 
         CV_INSTRUMENT_FUN_IPP(::ipp::iwiMirror, iwSrc, iwDst, ippMode);
     }
-    catch(::ipp::IwException)
+    catch(const ::ipp::IwException &)
     {
         return false;
     }

--- a/modules/core/test/test_ds.cpp
+++ b/modules/core/test/test_ds.cpp
@@ -1032,7 +1032,7 @@ void Core_SeqBaseTest::run( int )
                 cvClearMemStorage( storage );
         }
     }
-    catch(int)
+    catch(const int &)
     {
     }
 }
@@ -1200,7 +1200,7 @@ void Core_SeqSortInvTest::run( int )
             storage.release();
         }
     }
-    catch (int)
+    catch (const int &)
     {
     }
 }
@@ -1416,7 +1416,7 @@ void Core_SetTest::run( int )
             storage.release();
         }
     }
-    catch(int)
+    catch(const int &)
     {
     }
 }
@@ -1859,7 +1859,7 @@ void Core_GraphTest::run( int )
             storage.release();
         }
     }
-    catch(int)
+    catch(const int &)
     {
     }
 }
@@ -2121,7 +2121,7 @@ void Core_GraphScanTest::run( int )
             storage.release();
         }
     }
-    catch(int)
+    catch(const int &)
     {
     }
 }

--- a/modules/imgproc/src/canny.cpp
+++ b/modules/imgproc/src/canny.cpp
@@ -93,7 +93,7 @@ static bool ipp_Canny(const Mat& src , const Mat& dx_, const Mat& dy_, Mat& dst,
 
             CV_INSTRUMENT_FUN_IPP(::ipp::iwiFilterCannyDeriv, iwSrcDx, iwSrcDy, iwDst, low, high, ::ipp::IwiFilterCannyDerivParams(norm));
         }
-        catch (::ipp::IwException ex)
+        catch (const ::ipp::IwException &)
         {
             return false;
         }
@@ -119,7 +119,7 @@ static bool ipp_Canny(const Mat& src , const Mat& dx_, const Mat& dy_, Mat& dst,
 
             CV_INSTRUMENT_FUN_IPP(::ipp::iwiFilterCanny, iwSrc, iwDst, low, high, ::ipp::IwiFilterCannyParams(ippFilterSobel, kernel, norm), ippBorderRepl);
         }
-        catch (::ipp::IwException)
+        catch (const ::ipp::IwException &)
         {
             return false;
         }

--- a/modules/imgproc/src/deriv.cpp
+++ b/modules/imgproc/src/deriv.cpp
@@ -337,7 +337,7 @@ static bool ipp_Deriv(InputArray _src, OutputArray _dst, int dx, int dy, int ksi
         if(useScale)
             CV_INSTRUMENT_FUN_IPP(::ipp::iwiScale, iwDstProc, iwDst, scale, delta, ::ipp::IwiScaleParams(ippAlgHintFast));
     }
-    catch (::ipp::IwException)
+    catch (const ::ipp::IwException &)
     {
         return false;
     }
@@ -765,7 +765,7 @@ static bool ipp_Laplacian(InputArray _src, OutputArray _dst, int ksize, double s
             CV_INSTRUMENT_FUN_IPP(::ipp::iwiScale, iwDstProc, iwDst, scale, delta);
 
     }
-    catch (::ipp::IwException ex)
+    catch (const ::ipp::IwException &)
     {
         return false;
     }

--- a/modules/imgproc/src/morph.cpp
+++ b/modules/imgproc/src/morph.cpp
@@ -1299,7 +1299,7 @@ static bool ippMorph(int op, int src_type, int dst_type,
                 CV_INSTRUMENT_FUN_IPP(::ipp::iwiFilterMorphology, iwSrc, iwDst, morphType, iwMask, ::ipp::IwDefault(), iwBorderType);
         }
     }
-    catch(::ipp::IwException ex)
+    catch(const ::ipp::IwException &)
     {
         return false;
     }

--- a/modules/imgproc/src/resize.cpp
+++ b/modules/imgproc/src/resize.cpp
@@ -3241,7 +3241,7 @@ public:
             ::ipp::IwiTile tile = ::ipp::IwiRoi(0, range.start, m_dst.m_size.width, range.end - range.start);
             CV_INSTRUMENT_FUN_IPP(iwiResize, m_src, m_dst, ippBorderRepl, tile);
         }
-        catch(::ipp::IwException)
+        catch(const ::ipp::IwException &)
         {
             m_ok = false;
             return;
@@ -3291,7 +3291,7 @@ public:
             ::ipp::IwiTile tile = ::ipp::IwiRoi(0, range.start, m_dst.m_size.width, range.end - range.start);
             CV_INSTRUMENT_FUN_IPP(iwiWarpAffine, m_src, m_dst, tile);
         }
-        catch(::ipp::IwException)
+        catch(const ::ipp::IwException &)
         {
             m_ok = false;
             return;
@@ -3387,7 +3387,7 @@ static bool ipp_resize(const uchar * src_data, size_t src_step, int src_width, i
         if(!ok)
             return false;
     }
-    catch(::ipp::IwException)
+    catch(const ::ipp::IwException &)
     {
         return false;
     }

--- a/modules/imgproc/src/smooth.cpp
+++ b/modules/imgproc/src/smooth.cpp
@@ -1510,7 +1510,7 @@ static bool ipp_boxfilter(Mat &src, Mat &dst, Size ksize, Point anchor, bool nor
 
         CV_INSTRUMENT_FUN_IPP(::ipp::iwiFilterBox, iwSrc, iwDst, iwKSize, ::ipp::IwDefault(), ippBorder);
     }
-    catch (::ipp::IwException)
+    catch (const ::ipp::IwException &)
     {
         return false;
     }
@@ -4000,7 +4000,7 @@ public:
             ::ipp::IwiTile tile = ::ipp::IwiRoi(0, range.start, m_dst.m_size.width, range.end - range.start);
             CV_INSTRUMENT_FUN_IPP(::ipp::iwiFilterGaussian, m_src, m_dst, m_kernelSize, m_sigma, ::ipp::IwDefault(), m_border, tile);
         }
-        catch(::ipp::IwException e)
+        catch(const ::ipp::IwException &)
         {
             *m_pOk = false;
             return;
@@ -4067,7 +4067,7 @@ static bool ipp_GaussianBlur(InputArray _src, OutputArray _dst, Size ksize,
             CV_INSTRUMENT_FUN_IPP(::ipp::iwiFilterGaussian, iwSrc, iwDst, ksize.width, sigma1, ::ipp::IwDefault(), ippBorder);
         }
     }
-    catch (::ipp::IwException ex)
+    catch (const ::ipp::IwException &)
     {
         return false;
     }
@@ -5878,7 +5878,7 @@ public:
             ::ipp::IwiTile tile = ::ipp::IwiRoi(0, range.start, dst.m_size.width, range.end - range.start);
             CV_INSTRUMENT_FUN_IPP(::ipp::iwiFilterBilateral, src, dst, radius, valSquareSigma, posSquareSigma, ::ipp::IwDefault(), borderType, tile);
         }
-        catch(::ipp::IwException)
+        catch(const ::ipp::IwException &)
         {
             *pOk = false;
             return;
@@ -5933,7 +5933,7 @@ static bool ipp_bilateralFilter(Mat &src, Mat &dst, int d, double sigmaColor, do
             CV_INSTRUMENT_FUN_IPP(::ipp::iwiFilterBilateral, iwSrc, iwDst, radius, valSquareSigma, posSquareSigma, ::ipp::IwDefault(), ippBorder);
         }
     }
-    catch (::ipp::IwException)
+    catch (const ::ipp::IwException &)
     {
         return false;
     }


### PR DESCRIPTION
Exceptions caught by value incur needless cost in C++, most of them can
be caught by const-reference, especially as nearly none are actually
used. This could allow compiler generate a slightly more efficient code.