### PR TITLE
Fix clashing include guards

### DIFF
--- a/apps/traincascade/old_ml.hpp
+++ b/apps/traincascade/old_ml.hpp
@@ -38,8 +38,8 @@
 //
 //M*/
 
-#ifndef OPENCV_ML_HPP
-#define OPENCV_ML_HPP
+#ifndef OPENCV_OLD_ML_HPP
+#define OPENCV_OLD_ML_HPP
 
 #ifdef __cplusplus
 #  include "opencv2/core.hpp"
@@ -2037,6 +2037,6 @@ template<> void DefaultDeleter<CvDTreeSplit>::operator ()(CvDTreeSplit* obj) con
 }
 
 #endif // __cplusplus
-#endif // OPENCV_ML_HPP
+#endif // OPENCV_OLD_ML_HPP
 
 /* End of file. */

--- a/modules/features2d/src/kaze/KAZEConfig.h
+++ b/modules/features2d/src/kaze/KAZEConfig.h
@@ -5,8 +5,8 @@
  * @author Pablo F. Alcantarilla
  */
 
-#ifndef __OPENCV_FEATURES_2D_AKAZE_CONFIG_H__
-#define __OPENCV_FEATURES_2D_AKAZE_CONFIG_H__
+#ifndef __OPENCV_FEATURES_2D_KAZE_CONFIG_H__
+#define __OPENCV_FEATURES_2D_KAZE_CONFIG_H__
 
 // OpenCV Includes
 #include "../precomp.hpp"


### PR DESCRIPTION
Relevant guards can be found in
https://github.com/opencv/opencv/blob/ef5579dc8667e5eb5e149acc4af898421eed99da/modules/features2d/src/kaze/AKAZEConfig.h#L8
and
https://github.com/opencv/opencv/blob/ef5579dc8667e5eb5e149acc4af898421eed99da/modules/ml/include/opencv2/ml.hpp#L44