### PR TITLE
resolved fatal error during initial compilation

### DIFF
--- a/modules/python/common.cmake
+++ b/modules/python/common.cmake
@@ -1,6 +1,9 @@
 # This file is included from a subdirectory
 set(PYTHON_SOURCE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../")
 
+find_package(HDF5)
+include_directories(${HDF5_INCLUDE_DIRS})
+
 ocv_add_module(${MODULE_NAME} BINDINGS PRIVATE_REQUIRED opencv_python_bindings_generator)
 
 ocv_module_include_directories(


### PR DESCRIPTION
fatal error is encountered when compiling OpenCV for Python which is 'fatal error hdf5.h no such file or directory'.

<!-- Please use this line to close one or multiple issues when this pullrequest gets merged
You can add another line right under the first one:
resolves #1234
resolves #1235
-->

### This pullrequest changes

<!-- Please describe what your pullrequest is changing -->

<!-- **WIP** -->