### PR TITLE
cmake: OPENCV_GENERATE_PKGCONFIG

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -336,6 +336,7 @@ OCV_OPTION(ENABLE_BUILD_HARDENING     "Enable hardening of the resulting binarie
 OCV_OPTION(ENABLE_LTO                 "Enable Link Time Optimization" OFF IF CV_GCC OR MSVC)
 OCV_OPTION(ENABLE_THIN_LTO            "Enable Thin LTO" OFF IF CV_CLANG)
 OCV_OPTION(GENERATE_ABI_DESCRIPTOR    "Generate XML file for abi_compliance_checker tool" OFF IF UNIX)
+OCV_OPTION(OPENCV_GENERATE_PKGCONFIG  "Generate .pc file for pkg-config build tool (deprecated)" ON IF (UNIX AND NOT MSVC AND NOT IOS AND NOT ANDROID) )
 OCV_OPTION(CV_ENABLE_INTRINSICS       "Use intrinsic-based optimized code" ON )
 OCV_OPTION(CV_DISABLE_OPTIMIZATION    "Disable explicit optimized code (dispatched code/intrinsics/loop unrolling/etc)" OFF )
 OCV_OPTION(CV_TRACE                   "Enable OpenCV code trace" ON)
@@ -850,6 +851,7 @@ include(cmake/OpenCVGenHeaders.cmake)
 
 # Generate opencv.pc for pkg-config command
 if(NOT OPENCV_SKIP_PKGCONFIG_GENERATION
+    AND OPENCV_GENERATE_PKGCONFIG
     AND NOT CMAKE_GENERATOR MATCHES "Xcode")
   include(cmake/OpenCVGenPkgconfig.cmake)
 endif()


### PR DESCRIPTION
backport #12896

Enabled by default in OpenCV 3.4 (but it is not reliable - limited set of configurations is supported)

```
buildworker:iOS=macosx-1
buildworker:Mac OpenCL=macosx-1
```