### PR TITLE
fix matchTemplate for imgproc module

### DIFF
--- a/modules/imgproc/src/templmatch.cpp
+++ b/modules/imgproc/src/templmatch.cpp
@@ -947,10 +947,11 @@ static void common_matchTemplate( Mat& img, Mat& templ, Mat& result, int method,
 
             if( isNormed )
             {
-                if (img.depth() == CV_8U && (wndSum2 - wndMean2) < invArea*0.5)
+                double diff2 = MAX(wndSum2 - wndMean2, 0);
+                if (diff2 <= std::min(0.5, 10 * FLT_EPSILON * wndSum2))
                     t = 0; // avoid rounding errors
                 else
-                    t = std::sqrt(MAX(wndSum2 - wndMean2, 0))*templNorm;
+                    t = std::sqrt(diff2)*templNorm;
 
                 if( fabs(num) < t )
                     num /= t;

--- a/modules/imgproc/src/templmatch.cpp
+++ b/modules/imgproc/src/templmatch.cpp
@@ -947,7 +947,11 @@ static void common_matchTemplate( Mat& img, Mat& templ, Mat& result, int method,
 
             if( isNormed )
             {
-                t = std::sqrt(MAX(wndSum2 - wndMean2,0))*templNorm;
+                if (img.depth() == CV_8U && (wndSum2 - wndMean2) < invArea*0.5)
+                    t = 0; // avoid rounding errors
+                else
+                    t = std::sqrt(MAX(wndSum2 - wndMean2, 0))*templNorm;
+
                 if( fabs(num) < t )
                     num /= t;
                 else if( fabs(num) < t*1.125 )


### PR DESCRIPTION
<!-- Please use this line to close one or multiple issues when this pullrequest gets merged
You can add another line right under the first one:
-->

### This pullrequest changes

<!-- Please describe what your pullrequest is changing -->

Avoid rounding errors when using CV_8U image in matchTemplate.

The result of TM_CCOEFF_NORMED is 0/0 when all pixels have the same value in matched area. However, "wndSum2 - wndMean2 == 0" may become "wndSum2 - wndMean2 > 0" because of rounding errors. If "fabs(num) < t" is true at the same time, we may get a unexpected value. Therefore, I give a proper threshold for the denominator.



**Here is my test code:**

    Mat aim = imread("../images/aim2.png", IMREAD_GRAYSCALE);
    Mat templ = imread("../images/templ0.png", IMREAD_GRAYSCALE);
    Mat result;
    matchTemplate(aim, templ, result, TemplateMatchModes::TM_CCOEFF_NORMED);
    double minVal = 0.0f;
    double maxVal = 0.0f;
    Point minLoc;
    Point maxLoc;
    minMaxLoc(result, &minVal, &maxVal, &minLoc, &maxLoc);
    cout << maxLoc << endl;

A wrong result comes with the previous code. And right result is achieved with the modification.

![aim2](https://user-images.githubusercontent.com/19570929/47419352-9510fd00-d7ae-11e8-9a8f-1dc53a384335.png)
aim2.png

![templ0](https://user-images.githubusercontent.com/19570929/47419365-99d5b100-d7ae-11e8-98fb-f019c62eb76d.png)
templ0.png

![result_wrong](https://user-images.githubusercontent.com/19570929/47419373-9f32fb80-d7ae-11e8-8327-97f5511a5c4f.png)
wrong result

![result_right](https://user-images.githubusercontent.com/19570929/47419368-9d693800-d7ae-11e8-93a5-779eec116b57.png)
right result