### PR TITLE
core: fix merge from 3.4

### DIFF
--- a/modules/core/include/opencv2/core/base.hpp
+++ b/modules/core/include/opencv2/core/base.hpp
@@ -390,8 +390,6 @@ CV_EXPORTS CV_NORETURN void error(int _code, const String& _err, const char* _fu
 #define CV_Error(...) do { abort(); } while (0)
 #define CV_Error_( code, args ) do { cv::format args; abort(); } while (0)
 #define CV_Assert( expr ) do { if (!(expr)) abort(); } while (0)
-#define CV_ErrorNoReturn CV_Error
-#define CV_ErrorNoReturn_ CV_Error_
 
 #else // CV_STATIC_ANALYSIS
 


### PR DESCRIPTION
`CV_ErrorNoReturn` should not be used in OpenCV

relates #12744
relates #12787