### PR TITLE
Update intro.markdown

### DIFF
--- a/modules/core/doc/intro.markdown
+++ b/modules/core/doc/intro.markdown
@@ -3,7 +3,7 @@ Introduction {#intro}
 
 OpenCV (Open Source Computer Vision Library: <http://opencv.org>) is an open-source BSD-licensed
 library that includes several hundreds of computer vision algorithms. The document describes the
-so-called OpenCV 2.x API, which is essentially a C++ API, as opposite to the C-based OpenCV 1.x API.
+so-called OpenCV 2.x API, which is essentially a C++ API, as opposed to the C-based OpenCV 1.x API.
 The latter is described in opencv1x.pdf.
 
 OpenCV has a modular structure, which means that the package includes several shared or static


### PR DESCRIPTION
"as opposed to" is a phrase of opposed meaning distinguished from or in contrast with. e.g., "an approach that is theoretical as opposed to practical"
synonyms: in contrast with, as against, as contrasted with, rather than, instead of, as an alternative to
example: "we use only steam, as opposed to chemical products, to clean our house"

### This pullrequest changes

<!-- Please describe what your pullrequest is changing -->
modules/core/doc/intro.markdown