### PR TITLE
core(ipp): disable SSE4.2 meanStdDev() optimization for CV_32F

### DIFF
--- a/modules/core/src/mean.cpp
+++ b/modules/core/src/mean.cpp
@@ -674,10 +674,23 @@ static bool ipp_meanStdDev(Mat& src, OutputArray _mean, OutputArray _sdv, Mat& m
     if (cn > 1)
         return false;
 #endif
-#if IPP_VERSION_X100 < 201901
+#if IPP_VERSION_X100 >= 201900 && IPP_VERSION_X100 < 201901
     // IPP_DISABLE: 32f C3C functions can read outside of allocated memory
     if (cn > 1 && src.depth() == CV_32F)
         return false;
+
+    // SSE4.2 buffer overrun
+#if defined(_WIN32) && !defined(_WIN64)
+    // IPPICV doesn't have AVX2 in 32-bit builds
+    // However cv::ipp::getIppTopFeatures() may return AVX2 value on AVX2 capable H/W
+    // details #12959
+#else
+    if (cv::ipp::getIppTopFeatures() == ippCPUID_SSE42) // Linux x64 + OPENCV_IPP=SSE42 is affected too
+#endif
+    {
+        if (src.depth() == CV_32F && src.dims > 1 && src.size[src.dims - 1] == 6)
+            return false;
+    }
 #endif
 
     size_t total_size = src.total();


### PR DESCRIPTION
6x1000 CV_32C1 valgring report with `OPENCV_IPP=SSE42`:
```
Intel(R) IPP version: ippIP SSE4.2 (y8) 2019.0.0 Gold (-) Jul 24 2018
...
==12590== Invalid read of size 16
==12590==    at 0x9AF2368: icv_y8_ownSumSq_32f_C1R_M7_Al (in lib/libopencv_core.so.3.4.3)
==12590==  Address 0x24edf180 is 0 bytes after a block of size 32,000 alloc'd
==12590==    at 0x4C30E38: memalign (vg_replace_malloc.c:857)
==12590==    by 0x4C30F40: posix_memalign (vg_replace_malloc.c:1020)
```

relates #12877