### PR TITLE
AVX v256_cleanup() fixed

### DIFF
--- a/modules/core/include/opencv2/core/hal/intrin_avx.hpp
+++ b/modules/core/include/opencv2/core/hal/intrin_avx.hpp
@@ -2505,7 +2505,7 @@ inline void v_pack_store(float16_t* ptr, const v_float32x8& a)
     _mm_storeu_si128((__m128i*)ptr, ah);
 }
 
-inline void v256_cleanup() { _mm256_zeroupper(); }
+inline void v256_cleanup() { _mm256_zeroall(); }
 
 //! @name Check SIMD256 support
 //! @{


### PR DESCRIPTION
### This pullrequest changes

`_mm256_zeroupper` is replaced by `_mm256_zeroall`

This should fix an incorrect behavior of `vx_cleanup` on AVX+ baselines on some compilers (for example GCC 7.3.0, Ubuntu 18.04).

### Details

`_mm256_zeroupper` unpredictably spoils local variables even when there's no other intrinsics used in the code.
`_mm256_zeroall` doesn't cause such errors at the same time having similar purpose and performance.