### PR TITLE
Fix signature of static function collectCalibrationData() in modules/calib3d/src/calibration.cpp

### DIFF
--- a/modules/calib3d/src/calibration.cpp
+++ b/modules/calib3d/src/calibration.cpp
@@ -3330,7 +3330,7 @@ namespace cv
 static void collectCalibrationData( InputArrayOfArrays objectPoints,
                                     InputArrayOfArrays imagePoints1,
                                     InputArrayOfArrays imagePoints2,
-                                    int& iFixedPoint,
+                                    int iFixedPoint,
                                     Mat& objPtMat, Mat& imgPtMat1, Mat* imgPtMat2,
                                     Mat& npoints )
 {
@@ -3419,8 +3419,7 @@ static void collectCalibrationData( InputArrayOfArrays objectPoints,
                                     Mat& objPtMat, Mat& imgPtMat1, Mat* imgPtMat2,
                                     Mat& npoints )
 {
-    int iFixedPoint = -1;
-    collectCalibrationData( objectPoints, imagePoints1, imagePoints2, iFixedPoint, objPtMat, imgPtMat1,
+    collectCalibrationData( objectPoints, imagePoints1, imagePoints2, -1, objPtMat, imgPtMat1,
                             imgPtMat2, npoints );
 }
 


### PR DESCRIPTION
This is a fix to the signature of static function
collectCalibrationData() and clean-up for #12772. Since fallback scheme
in calibration method selection is not used anymore. As an input
parameter, iFixedPoint should be passed by value according to the OpenCV
coding style guide.

### This pull request changes

Only the signature of the specific internal utility function is changed. No implementation logic is modified.