### PR TITLE
Python wrapper generator: Fix closing input file

### DIFF
--- a/modules/python/src2/gen2.py
+++ b/modules/python/src2/gen2.py
@@ -1091,6 +1091,7 @@ if __name__ == "__main__":
     if len(sys.argv) > 1:
         dstdir = sys.argv[1]
     if len(sys.argv) > 2:
-        srcfiles = [f.strip() for f in open(sys.argv[2], 'r').readlines()]
+        with open(sys.argv[2], 'r') as f:
+            srcfiles = [l.strip() for l in f.readlines()]
     generator = PythonWrapperGenerator()
     generator.gen(srcfiles, dstdir)


### PR DESCRIPTION
This PR closes the input file containing the list of source files during the python wrapper generation.
At the moment this generates this warning:
`modules/python/bindings/..//src2/gen2.py:1181: ResourceWarning: unclosed file <_io.TextIOWrapper name='/home/dev/trunk/MMSTP/Sources/misc/OpenCV/build/modules/python_bindings_generator/headers.txt' mode='r' encoding='UTF-8'>`

### This pullrequest changes
This PR closes the input file containing the list of source files during the python wrapper generation and thus fixes the warning listed above.
