### PR TITLE
Allow load CascadeClassifier from buffer when it fail to open FileStorage from filename

### DIFF
--- a/modules/objdetect/src/cascadedetect.cpp
+++ b/modules/objdetect/src/cascadedetect.cpp
@@ -915,7 +915,8 @@ bool CascadeClassifierImpl::load(const String& filename)
       if (!fs.isOpened()) return false;
     }
 
-    if (read_(fs.getFirstTopLevelNode())) return true;
+    if( read_(fs.getFirstTopLevelNode()) )
+        return true;
 
     fs.release();
 

--- a/modules/objdetect/src/cascadedetect.cpp
+++ b/modules/objdetect/src/cascadedetect.cpp
@@ -910,11 +910,12 @@ bool CascadeClassifierImpl::load(const String& filename)
     featureEvaluator.release();
 
     FileStorage fs(filename, FileStorage::READ);
-    if( !fs.isOpened() )
-        return false;
+    if (!fs.isOpened()) {
+      fs.open(filename, CV_STORAGE_MEMORY);
+      if (!fs.isOpened()) return false;
+    }
 
-    if( read_(fs.getFirstTopLevelNode()) )
-        return true;
+    if (read_(fs.getFirstTopLevelNode())) return true;
 
     fs.release();
 


### PR DESCRIPTION
### This pullrequest changes

<!-- Please describe what your pullrequest is changing -->
The goal of this pull request is to allow load the CascadeClassifier from a buffer instead of the filename when it try to open the FileStorage and fail