### PR TITLE
Fix reading of black-and-white (thresholded) TIFF images

### DIFF
--- a/modules/imgcodecs/src/grfmt_tiff.cpp
+++ b/modules/imgcodecs/src/grfmt_tiff.cpp
@@ -49,6 +49,7 @@
 
 #ifdef HAVE_TIFF
 #include "grfmt_tiff.hpp"
+#include <stdexcept>
 #include <limits>
 
 // TODO FIXIT Conflict declarations for common types like int64/uint64
@@ -254,8 +255,8 @@ bool TiffDecoder::readHeader()
             switch(bpp)
             {
                 case 1:
-                    result = true;
                     m_type = CV_MAKETYPE(CV_8U, photometric > 1 ? wanted_channels : 1);
+                    result = true;
                     break;
                 case 8:
                     m_type = CV_MAKETYPE(CV_8U, photometric > 1 ? wanted_channels : 1);

--- a/modules/imgcodecs/src/grfmt_tiff.cpp
+++ b/modules/imgcodecs/src/grfmt_tiff.cpp
@@ -255,6 +255,7 @@ bool TiffDecoder::readHeader()
             {
                 case 1:
                     result = true;
+                    m_type = CV_MAKETYPE(CV_8U, photometric > 1 ? wanted_channels : 1);
                     break;
                 case 8:
                     m_type = CV_MAKETYPE(CV_8U, photometric > 1 ? wanted_channels : 1);
@@ -272,6 +273,8 @@ bool TiffDecoder::readHeader()
                     m_type = CV_MAKETYPE(CV_64F, photometric > 1 ? 3 : 1);
                     result = true;
                     break;
+            default:
+                throw std::runtime_error("Invalid bitsperpixel value read from TIFF header! Must be 1, 8, 16, 32 or 64.");
             }
         }
     }

--- a/modules/imgcodecs/src/grfmt_tiff.cpp
+++ b/modules/imgcodecs/src/grfmt_tiff.cpp
@@ -253,6 +253,9 @@ bool TiffDecoder::readHeader()
             int wanted_channels = normalizeChannelsNumber(ncn);
             switch(bpp)
             {
+                case 1:
+                    result = true;
+                    break;
                 case 8:
                     m_type = CV_MAKETYPE(CV_8U, photometric > 1 ? wanted_channels : 1);
                     result = true;

--- a/modules/imgcodecs/src/grfmt_tiff.cpp
+++ b/modules/imgcodecs/src/grfmt_tiff.cpp
@@ -49,7 +49,6 @@
 
 #ifdef HAVE_TIFF
 #include "grfmt_tiff.hpp"
-#include <stdexcept>
 #include <limits>
 
 // TODO FIXIT Conflict declarations for common types like int64/uint64
@@ -275,7 +274,7 @@ bool TiffDecoder::readHeader()
                     result = true;
                     break;
             default:
-                throw std::runtime_error("Invalid bitsperpixel value read from TIFF header! Must be 1, 8, 16, 32 or 64.");
+                CV_Error(cv::Error::StsError, "Invalid bitsperpixel value read from TIFF header! Must be 1, 8, 16, 32 or 64.");
             }
         }
     }

--- a/modules/imgcodecs/test/test_tiff.cpp
+++ b/modules/imgcodecs/test/test_tiff.cpp
@@ -251,6 +251,32 @@ TEST(Imgcodecs_Tiff, imdecode_no_exception_temporary_file_removed)
     EXPECT_NO_THROW(cv::imdecode(buf, IMREAD_UNCHANGED));
 }
 
+
+TEST(Imgcodecs_Tiff, decode_black_and_write_image_pr12989)
+{
+    const string filename = cvtest::findDataFile("readwrite/bitsperpixel1.tiff");
+    cv::Mat img;
+    ASSERT_NO_THROW(img = cv::imread(filename, IMREAD_GRAYSCALE));
+    ASSERT_FALSE(img.empty());
+    EXPECT_EQ(64, img.cols);
+    EXPECT_EQ(64, img.rows);
+    EXPECT_EQ(CV_8UC1, img.type()) << cv::typeToString(img.type());
+    // Check for 0/255 values only: 267 + 3829 = 64*64
+    EXPECT_EQ(267, countNonZero(img == 0));
+    EXPECT_EQ(3829, countNonZero(img == 255));
+}
+
+TEST(Imgcodecs_Tiff, decode_black_and_write_image_pr12989_default)
+{
+    const string filename = cvtest::findDataFile("readwrite/bitsperpixel1.tiff");
+    cv::Mat img;
+    ASSERT_NO_THROW(img = cv::imread(filename));  // by default image type is CV_8UC3
+    ASSERT_FALSE(img.empty());
+    EXPECT_EQ(64, img.cols);
+    EXPECT_EQ(64, img.rows);
+    EXPECT_EQ(CV_8UC3, img.type()) << cv::typeToString(img.type());
+}
+
 #endif
 
 }} // namespace


### PR DESCRIPTION
**Merge with extra**: https://github.com/opencv/opencv_extra/pull/538

I recently updated my local OpenCV version to 3.4.3 and found out that
I could not read my TIFF images related to my project. After debugging I
found out that there has been some static analysis fixes made
that accidentally have broken reading those black-and-white TIFF images.

Commit hash in which reading of mentioned TIFF images has been broken:
cbb1e867e5141412c62ff534def7f117e28e04e8

Basically the fix is to revert back to the same functionality that has been there before.
When black-and-white images are read bpp (bitspersample) is 1.
Without the case 1: this TiffDecoder::readHeader() function always return false.

<!-- Please use this line to close one or multiple issues when this pullrequest gets merged
You can add another line right under the first one:
resolves #1234
resolves #1235
-->

### This pullrequest changes

<!-- Please describe what your pullrequest is changing -->
PR fixes reading thresholded (black-and-white) TIFF images.

```
opencv_extra=3.4
```