### PR TITLE
G-API: Introduce new `reshape()` API

### DIFF
--- a/modules/gapi/include/opencv2/gapi/fluid/gfluidbuffer.hpp
+++ b/modules/gapi/include/opencv2/gapi/fluid/gfluidbuffer.hpp
@@ -105,7 +105,7 @@ public:
 
     const GMatDesc& meta() const;
 
-    View mkView(int lineConsumption, int borderSize, BorderOpt border, bool ownStorage);
+    View mkView(int borderSize, bool ownStorage);
 
     class GAPI_EXPORTS Priv;      // internal use only
     Priv& priv();               // internal use only

--- a/modules/gapi/include/opencv2/gapi/gcompiled.hpp
+++ b/modules/gapi/include/opencv2/gapi/gcompiled.hpp
@@ -50,6 +50,9 @@ public:
     const GMetaArgs& metas() const; // Meta passed to compile()
     const GMetaArgs& outMetas() const; // Inferred output metadata
 
+    bool canReshape() const; // is reshape mechanism supported by GCompiled
+    void reshape(const GMetaArgs& inMetas, const GCompileArgs& args); // run reshape procedure
+
 protected:
     std::shared_ptr<Priv> m_priv;
 };

--- a/modules/gapi/src/api/gcomputation.cpp
+++ b/modules/gapi/src/api/gcomputation.cpp
@@ -76,7 +76,9 @@ cv::GCompiled cv::GComputation::compile(GMetaArgs &&metas, GCompileArgs &&args)
     return comp.compile();
 }
 
-static bool differInDimsOnly(const cv::GMetaArgs& metas1, const cv::GMetaArgs& metas2)
+// FIXME: Introduce similar query/test method for GMetaArgs as a building block
+// for functions like this?
+static bool formats_are_same(const cv::GMetaArgs& metas1, const cv::GMetaArgs& metas2)
 {
     return std::equal(metas1.cbegin(), metas1.cend(), metas2.cbegin(),
                       [](const cv::GMetaArg& meta1, const cv::GMetaArg& meta2) {
@@ -104,7 +106,7 @@ void cv::GComputation::apply(GRunArgs &&ins, GRunArgsP &&outs, GCompileArgs &&ar
     {
         if (m_priv->m_lastCompiled &&
             m_priv->m_lastCompiled.canReshape() &&
-            differInDimsOnly(m_priv->m_lastMetas, in_metas))
+            formats_are_same(m_priv->m_lastMetas, in_metas))
         {
             m_priv->m_lastCompiled.reshape(in_metas, args);
         }

--- a/modules/gapi/src/api/gcomputation.cpp
+++ b/modules/gapi/src/api/gcomputation.cpp
@@ -76,15 +76,44 @@ cv::GCompiled cv::GComputation::compile(GMetaArgs &&metas, GCompileArgs &&args)
     return comp.compile();
 }
 
+static bool differInDimsOnly(const cv::GMetaArgs& metas1, const cv::GMetaArgs& metas2)
+{
+    return std::equal(metas1.cbegin(), metas1.cend(), metas2.cbegin(),
+                      [](const cv::GMetaArg& meta1, const cv::GMetaArg& meta2) {
+                          if (meta1.index() == meta2.index() && meta1.index() == cv::GMetaArg::index_of<cv::GMatDesc>())
+                          {
+                              const auto& desc1 = cv::util::get<cv::GMatDesc>(meta1);
+                              const auto& desc2 = cv::util::get<cv::GMatDesc>(meta2);
+
+                              // comparison by size is omitted
+                              return (desc1.chan  == desc2.chan &&
+                                      desc1.depth == desc2.depth);
+                          }
+                          else
+                          {
+                              return meta1 == meta2;
+                          }
+                     });
+}
+
 void cv::GComputation::apply(GRunArgs &&ins, GRunArgsP &&outs, GCompileArgs &&args)
 {
     const auto in_metas = descr_of(ins);
     // FIXME Graph should be recompiled when GCompileArgs have changed
     if (m_priv->m_lastMetas != in_metas)
     {
-        // FIXME: Had to construct temporary object as compile() takes && (r-value)
-        m_priv->m_lastCompiled = compile(GMetaArgs(in_metas), std::move(args));
-        m_priv->m_lastMetas    = in_metas; // Update only here, if compile() was ok
+        if (m_priv->m_lastCompiled &&
+            m_priv->m_lastCompiled.canReshape() &&
+            differInDimsOnly(m_priv->m_lastMetas, in_metas))
+        {
+            m_priv->m_lastCompiled.reshape(in_metas, args);
+        }
+        else
+        {
+            // FIXME: Had to construct temporary object as compile() takes && (r-value)
+            m_priv->m_lastCompiled = compile(GMetaArgs(in_metas), std::move(args));
+        }
+        m_priv->m_lastMetas = in_metas;
     }
     m_priv->m_lastCompiled(std::move(ins), std::move(outs));
 }

--- a/modules/gapi/src/backends/cpu/gcpubackend.hpp
+++ b/modules/gapi/src/backends/cpu/gcpubackend.hpp
@@ -57,6 +57,9 @@ public:
     virtual inline bool canReshape() const { return false; }
     virtual inline void reshape(ade::Graph&, const GCompileArgs&)
     {
+        // FIXME: CPU plugin is in fact reshapeable (as it was initially,
+        // even before outMeta() has been introduced), so this limitation
+        // should be dropped.
         util::throw_error(std::logic_error("GCPUExecutable::reshape() should never be called"));
     }
 

--- a/modules/gapi/src/backends/cpu/gcpubackend.hpp
+++ b/modules/gapi/src/backends/cpu/gcpubackend.hpp
@@ -54,6 +54,12 @@ public:
     GCPUExecutable(const ade::Graph                   &graph,
                    const std::vector<ade::NodeHandle> &nodes);
 
+    virtual inline bool canReshape() const { return false; }
+    virtual inline void reshape(ade::Graph&, const GCompileArgs&)
+    {
+        util::throw_error(std::logic_error("GCPUExecutable::reshape() should never be called"));
+    }
+
     virtual void run(std::vector<InObj>  &&input_objs,
                      std::vector<OutObj> &&output_objs) override;
 };

--- a/modules/gapi/src/backends/cpu/gcpubackend.hpp
+++ b/modules/gapi/src/backends/cpu/gcpubackend.hpp
@@ -54,8 +54,8 @@ public:
     GCPUExecutable(const ade::Graph                   &graph,
                    const std::vector<ade::NodeHandle> &nodes);
 
-    virtual inline bool canReshape() const { return false; }
-    virtual inline void reshape(ade::Graph&, const GCompileArgs&)
+    virtual inline bool canReshape() const override { return false; }
+    virtual inline void reshape(ade::Graph&, const GCompileArgs&) override
     {
         // FIXME: CPU plugin is in fact reshapeable (as it was initially,
         // even before outMeta() has been introduced), so this limitation

--- a/modules/gapi/src/backends/fluid/gfluidbackend.cpp
+++ b/modules/gapi/src/backends/fluid/gfluidbackend.cpp
@@ -734,7 +734,8 @@ cv::gimpl::GFluidExecutable::GFluidExecutable(const ade::Graph &g,
                 auto inEdge = GModel::getInEdgeByPort(m_g, agent->op_handle, in_idx);
                 auto ownStorage = fg.metadata(inEdge).get<FluidUseOwnBorderBuffer>().use;
 
-                gapi::fluid::View view = buffer.mkView(fu.line_consumption, fu.border_size, fu.border, ownStorage);
+                gapi::fluid::View view = buffer.mkView(fu.border_size, ownStorage);
+                view.priv().allocate(fu.line_consumption, fu.border);
                 // NB: It is safe to keep ptr as view lifetime is buffer lifetime
                 agent->in_views[in_idx] = view;
                 agent->in_args[in_idx]  = GArg(view);

--- a/modules/gapi/src/backends/fluid/gfluidbackend.cpp
+++ b/modules/gapi/src/backends/fluid/gfluidbackend.cpp
@@ -1036,6 +1036,10 @@ void cv::gimpl::GFluidExecutable::makeReshape(const std::vector<gapi::own::Rect>
 
 void cv::gimpl::GFluidExecutable::reshape(ade::Graph &g, const GCompileArgs &args)
 {
+    // FIXME: Probably this needs to be integrated into common pass re-run routine
+    // Backends may want to mark with passes to re-run on reshape and framework could
+    // do it system-wide (without need in every backend handling reshape() directly).
+    // This design needs to be analyzed for implementation.
     resetFluidData(g);
     initFluidUnits(g);
     initLineConsumption(g);

--- a/modules/gapi/src/backends/fluid/gfluidbackend.hpp
+++ b/modules/gapi/src/backends/fluid/gfluidbackend.hpp
@@ -137,8 +137,8 @@ public:
                      const std::vector<ade::NodeHandle> &nodes,
                      const std::vector<cv::gapi::own::Rect> &outputRois);
 
-    virtual inline bool canReshape() const { return true; }
-    virtual void reshape(ade::Graph& g, const GCompileArgs& args);
+    virtual inline bool canReshape() const override { return true; }
+    virtual void reshape(ade::Graph& g, const GCompileArgs& args) override;
 
     virtual void run(std::vector<InObj>  &&input_objs,
                      std::vector<OutObj> &&output_objs) override;

--- a/modules/gapi/src/backends/fluid/gfluidbackend.hpp
+++ b/modules/gapi/src/backends/fluid/gfluidbackend.hpp
@@ -49,6 +49,19 @@ struct FluidData
     gapi::fluid::BorderOpt border;
 };
 
+struct FluidMapper
+{
+    FluidMapper(double ratio, int lpi) : m_ratio(ratio), m_lpi(lpi) {}
+    virtual ~FluidMapper() = default;
+    virtual int firstWindow(int outCoord, int lpi) const = 0;
+    virtual int nextWindow(int outCoord, int lpi) const = 0;
+    virtual int linesRead(int outCoord) const = 0;
+
+protected:
+    double m_ratio = 0.0;
+    int    m_lpi   = 0;
+};
+
 struct FluidAgent
 {
 public:
@@ -72,8 +85,6 @@ public:
     int m_outputLines = 0;
     int m_producedLines = 0;
 
-    double m_ratio = 0.0f;
-
     // Execution methods
     void reset();
     bool canWork() const;
@@ -83,10 +94,12 @@ public:
     bool done() const;
 
     void debug(std::ostream& os);
+
     // FIXME:
     // refactor (implement a more solid replacement or
     // drop this method completely)
-    virtual void setInHeight(int h) = 0;
+    virtual void setRatio(double ratio) = 0;
+
 private:
     // FIXME!!!
     // move to another class

--- a/modules/gapi/src/backends/fluid/gfluidbackend.hpp
+++ b/modules/gapi/src/backends/fluid/gfluidbackend.hpp
@@ -124,6 +124,9 @@ public:
                      const std::vector<ade::NodeHandle> &nodes,
                      const std::vector<cv::gapi::own::Rect> &outputRois);
 
+    virtual inline bool canReshape() const { return true; }
+    virtual void reshape(ade::Graph& g, const GCompileArgs& args);
+
     virtual void run(std::vector<InObj>  &&input_objs,
                      std::vector<OutObj> &&output_objs) override;
 };

--- a/modules/gapi/src/backends/fluid/gfluidbackend.hpp
+++ b/modules/gapi/src/backends/fluid/gfluidbackend.hpp
@@ -109,17 +109,18 @@ class GFluidExecutable final: public GIslandExecutable
 
     std::size_t m_num_int_buffers; // internal buffers counter (m_buffers - num_scratch)
     std::vector<std::size_t> m_scratch_users;
-    std::vector<cv::gapi::fluid::View> m_views;
 
     std::vector<cv::gapi::own::Rect> m_outputRois;
 
     std::unordered_map<int, std::size_t> m_id_map; // GMat id -> buffer idx map
+    std::map<std::size_t, ade::NodeHandle> m_all_gmat_ids;
 
     void bindInArg (const RcDesc &rc, const GRunArg &arg);
     void bindOutArg(const RcDesc &rc, const GRunArgP &arg);
     void packArg   (GArg &in_arg, const GArg &op_arg);
 
     void initBufferRois(std::vector<int>& readStarts, std::vector<cv::gapi::own::Rect>& rois);
+    void makeReshape();
 
 public:
     GFluidExecutable(const ade::Graph &g,

--- a/modules/gapi/src/backends/fluid/gfluidbackend.hpp
+++ b/modules/gapi/src/backends/fluid/gfluidbackend.hpp
@@ -99,7 +99,6 @@ class GFluidExecutable final: public GIslandExecutable
 {
     const ade::Graph &m_g;
     GModel::ConstGraph m_gm;
-    const std::vector<ade::NodeHandle> m_nodes;
 
     std::vector<std::unique_ptr<FluidAgent>> m_agents;
     std::vector<cv::gapi::fluid::Buffer> m_buffers;
@@ -110,8 +109,6 @@ class GFluidExecutable final: public GIslandExecutable
     std::size_t m_num_int_buffers; // internal buffers counter (m_buffers - num_scratch)
     std::vector<std::size_t> m_scratch_users;
 
-    std::vector<cv::gapi::own::Rect> m_outputRois;
-
     std::unordered_map<int, std::size_t> m_id_map; // GMat id -> buffer idx map
     std::map<std::size_t, ade::NodeHandle> m_all_gmat_ids;
 
@@ -119,8 +116,8 @@ class GFluidExecutable final: public GIslandExecutable
     void bindOutArg(const RcDesc &rc, const GRunArgP &arg);
     void packArg   (GArg &in_arg, const GArg &op_arg);
 
-    void initBufferRois(std::vector<int>& readStarts, std::vector<cv::gapi::own::Rect>& rois);
-    void makeReshape();
+    void initBufferRois(std::vector<int>& readStarts, std::vector<cv::gapi::own::Rect>& rois, const std::vector<gapi::own::Rect> &out_rois);
+    void makeReshape(const std::vector<cv::gapi::own::Rect>& out_rois);
 
 public:
     GFluidExecutable(const ade::Graph &g,

--- a/modules/gapi/src/backends/fluid/gfluidbuffer.cpp
+++ b/modules/gapi/src/backends/fluid/gfluidbuffer.cpp
@@ -522,7 +522,6 @@ void fluid::Buffer::Priv::allocate(BorderOpt border,
                                    int line_consumption,
                                    int skew)
 {
-    GAPI_Assert(!m_storage);
     GAPI_Assert(line_consumption > 0);
 
     // Init physical buffer

--- a/modules/gapi/src/backends/fluid/gfluidbuffer.cpp
+++ b/modules/gapi/src/backends/fluid/gfluidbuffer.cpp
@@ -115,10 +115,10 @@ template <int BorderType>
 fluid::BorderHandlerT<BorderType>::BorderHandlerT(int border_size, int data_type)
     : BorderHandler(border_size)
 {
-    auto getFillBorderRowFunc = [&](int border, int dataType) {
+    auto getFillBorderRowFunc = [&](int border, int depth) {
         if (border == cv::BORDER_REPLICATE)
         {
-            switch(dataType)
+            switch(depth)
             {
             case CV_8U:  return &fillBorderReplicateRow< uint8_t>; break;
             case CV_16S: return &fillBorderReplicateRow< int16_t>; break;
@@ -129,7 +129,7 @@ fluid::BorderHandlerT<BorderType>::BorderHandlerT(int border_size, int data_type
         }
         else if (border == cv::BORDER_REFLECT_101)
         {
-            switch(dataType)
+            switch(depth)
             {
             case CV_8U:  return &fillBorderReflectRow< uint8_t>; break;
             case CV_16S: return &fillBorderReflectRow< int16_t>; break;
@@ -145,7 +145,7 @@ fluid::BorderHandlerT<BorderType>::BorderHandlerT(int border_size, int data_type
         }
     };
 
-    m_fill_border_row = getFillBorderRowFunc(BorderType, data_type);
+    m_fill_border_row = getFillBorderRowFunc(BorderType, CV_MAT_DEPTH(data_type));
 }
 
 namespace {

--- a/modules/gapi/src/backends/fluid/gfluidbuffer.cpp
+++ b/modules/gapi/src/backends/fluid/gfluidbuffer.cpp
@@ -506,15 +506,15 @@ fluid::Buffer::Priv::Priv(int read_start, cv::gapi::own::Rect roi)
 {}
 
 void fluid::Buffer::Priv::init(const cv::GMatDesc &desc,
-                               int wlpi,
+                               int writer_lpi,
                                int readStartPos,
                                cv::gapi::own::Rect roi)
 {
-    m_writer_lpi = wlpi;
+    m_writer_lpi = writer_lpi;
     m_desc       = desc;
     m_readStart  = readStartPos;
-    m_roi = roi == cv::Rect{} ? cv::Rect{0, 0, desc.size.width, desc.size.height}
-                              : roi;
+    m_roi        = roi == own::Rect{} ? own::Rect{ 0, 0, desc.size.width, desc.size.height }
+                                      : roi;
 }
 
 void fluid::Buffer::Priv::allocate(BorderOpt border,

--- a/modules/gapi/src/backends/fluid/gfluidbuffer_priv.hpp
+++ b/modules/gapi/src/backends/fluid/gfluidbuffer_priv.hpp
@@ -30,7 +30,7 @@ public:
     virtual const uint8_t* inLineB(int log_idx, const BufferStorageWithBorder &data, int desc_height) const = 0;
 
     // Fills border pixels after buffer allocation (if possible (for const border))
-    inline virtual void fillCompileTimeBorder(BufferStorageWithBorder &) const { /* nothing */ }
+    inline virtual void fillCompileTimeBorder(BufferStorageWithBorder &) { /* nothing */ }
 
     // Fills required border lines
     inline virtual void updateBorderPixels(BufferStorageWithBorder& /*data*/, int /*startLine*/, int /*lpi*/) const { /* nothing */ }
@@ -56,9 +56,9 @@ class BorderHandlerT<cv::BORDER_CONSTANT> : public BorderHandler
     cv::gapi::own::Mat m_const_border;
 
 public:
-    BorderHandlerT(int border_size, cv::gapi::own::Scalar border_value, int data_type, int desc_width);
+    BorderHandlerT(int border_size, cv::gapi::own::Scalar border_value);
     virtual const uint8_t* inLineB(int log_idx, const BufferStorageWithBorder &data, int desc_height) const override;
-    virtual void fillCompileTimeBorder(BufferStorageWithBorder &) const override;
+    virtual void fillCompileTimeBorder(BufferStorageWithBorder &) override;
     virtual std::size_t size() const override;
 };
 
@@ -151,7 +151,8 @@ public:
         return m_data.ptr(physIdx(idx), borderSize());
     }
 
-    void create(int capacity, int desc_width, int type, int border_size, Border border);
+    void init(int dtype, int border_size, Border border);
+    void create(int capacity, int desc_width, int dtype);
 
     virtual const uint8_t* inLineB(int log_idx, int desc_height) const override;
 
@@ -178,6 +179,7 @@ public:
     virtual ~Priv() = default;
     // API used by actors/backend
 
+    virtual void allocate(int lineConsumption, BorderOpt border) = 0;
     virtual void prepareToRead() = 0;
 
     void readDone(int linesRead, int linesForNextIteration);
@@ -198,6 +200,7 @@ public:
     // API used by actors/backend
     ViewPrivWithoutOwnBorder(const Buffer *p, int borderSize);
 
+    inline virtual void allocate(int, BorderOpt) { /* nothing */ }
     inline virtual void prepareToRead() override { /* nothing */ }
 
     inline virtual std::size_t size() const override { return 0; }
@@ -212,8 +215,9 @@ class ViewPrivWithOwnBorder final : public View::Priv
 
 public:
     // API used by actors/backend
-    ViewPrivWithOwnBorder(const Buffer *p, int lineCapacity, int borderSize, Border border);
+    ViewPrivWithOwnBorder(const Buffer *p, int borderSize);
 
+    inline virtual void allocate(int lineConsumption, BorderOpt border);
     virtual void prepareToRead() override;
     virtual std::size_t size() const override;
 

--- a/modules/gapi/src/backends/fluid/gfluidbuffer_priv.hpp
+++ b/modules/gapi/src/backends/fluid/gfluidbuffer_priv.hpp
@@ -257,7 +257,7 @@ public:
 
     // API used by actors/backend
     void init(const cv::GMatDesc &desc,
-              int wlpi,
+              int writer_lpi,
               int readStart,
               cv::gapi::own::Rect roi);
 

--- a/modules/gapi/src/backends/fluid/gfluidbuffer_priv.hpp
+++ b/modules/gapi/src/backends/fluid/gfluidbuffer_priv.hpp
@@ -151,7 +151,7 @@ public:
         return m_data.ptr(physIdx(idx), borderSize());
     }
 
-    void init(int dtype, int border_size, Border border);
+    void init(int depth, int border_size, Border border);
     void create(int capacity, int desc_width, int dtype);
 
     virtual const uint8_t* inLineB(int log_idx, int desc_height) const override;

--- a/modules/gapi/src/backends/fluid/gfluidbuffer_priv.hpp
+++ b/modules/gapi/src/backends/fluid/gfluidbuffer_priv.hpp
@@ -200,7 +200,7 @@ public:
     // API used by actors/backend
     ViewPrivWithoutOwnBorder(const Buffer *p, int borderSize);
 
-    inline virtual void allocate(int, BorderOpt) { /* nothing */ }
+    inline virtual void allocate(int, BorderOpt) override { /* nothing */ }
     inline virtual void prepareToRead() override { /* nothing */ }
 
     inline virtual std::size_t size() const override { return 0; }
@@ -217,7 +217,7 @@ public:
     // API used by actors/backend
     ViewPrivWithOwnBorder(const Buffer *p, int borderSize);
 
-    inline virtual void allocate(int lineConsumption, BorderOpt border);
+    inline virtual void allocate(int lineConsumption, BorderOpt border) override;
     virtual void prepareToRead() override;
     virtual std::size_t size() const override;
 

--- a/modules/gapi/src/compiler/gcompiled.cpp
+++ b/modules/gapi/src/compiler/gcompiled.cpp
@@ -59,6 +59,19 @@ void cv::GCompiled::Priv::checkArgs(const cv::gimpl::GRuntimeArgs &args) const
     }
 }
 
+bool cv::GCompiled::Priv::canReshape() const
+{
+    GAPI_Assert(m_exec);
+    return m_exec->canReshape();
+}
+
+void cv::GCompiled::Priv::reshape(const GMetaArgs& inMetas, const GCompileArgs& args)
+{
+    GAPI_Assert(m_exec);
+    m_exec->reshape(inMetas, args);
+    m_metas = inMetas;
+}
+
 const cv::gimpl::GModel::Graph& cv::GCompiled::Priv::model() const
 {
     GAPI_Assert(nullptr != m_exec);
@@ -118,7 +131,6 @@ void cv::GCompiled::operator ()(const std::vector<cv::Mat> &ins,
 }
 #endif // !defined(GAPI_STANDALONE)
 
-
 const cv::GMetaArgs& cv::GCompiled::metas() const
 {
     return m_priv->metas();
@@ -129,8 +141,17 @@ const cv::GMetaArgs& cv::GCompiled::outMetas() const
     return m_priv->outMetas();
 }
 
-
 cv::GCompiled::Priv& cv::GCompiled::priv()
 {
     return *m_priv;
+}
+
+bool cv::GCompiled::canReshape() const
+{
+    return m_priv->canReshape();
+}
+
+void cv::GCompiled::reshape(const GMetaArgs& inMetas, const GCompileArgs& args)
+{
+    m_priv->reshape(inMetas, args);
 }

--- a/modules/gapi/src/compiler/gcompiled_priv.hpp
+++ b/modules/gapi/src/compiler/gcompiled_priv.hpp
@@ -46,6 +46,9 @@ public:
                std::unique_ptr<cv::gimpl::GExecutor> &&pE);
     bool isEmpty() const;
 
+    bool canReshape() const;
+    void reshape(const GMetaArgs& inMetas, const GCompileArgs &args);
+
     void run(cv::gimpl::GRuntimeArgs &&args);
     const GMetaArgs& metas() const;
     const GMetaArgs& outMetas() const;

--- a/modules/gapi/src/compiler/gcompiler.cpp
+++ b/modules/gapi/src/compiler/gcompiler.cpp
@@ -111,7 +111,7 @@ cv::gimpl::GCompiler::GCompiler(const cv::GComputation &c,
     m_e.addPass("init", "check_islands_content", passes::checkIslandsContent);
     m_e.addPassStage("meta");
     m_e.addPass("meta", "initialize",   std::bind(passes::initMeta, _1, std::ref(m_metas)));
-    m_e.addPass("meta", "propagate",    passes::inferMeta);
+    m_e.addPass("meta", "propagate",    std::bind(passes::inferMeta, _1, false));
     m_e.addPass("meta", "finalize",     passes::storeResultingMeta);
     // moved to another stage, FIXME: two dumps?
     //    m_e.addPass("meta", "dump_dot",     passes::dumpDotStdout);

--- a/modules/gapi/src/compiler/gislandmodel.hpp
+++ b/modules/gapi/src/compiler/gislandmodel.hpp
@@ -109,6 +109,9 @@ public:
     virtual void run(std::vector<InObj>  &&input_objs,
                      std::vector<OutObj> &&output_objs) = 0;
 
+    virtual bool canReshape() const = 0;
+    virtual void reshape(ade::Graph& g, const GCompileArgs& args) = 0;
+
     virtual ~GIslandExecutable() = default;
 };
 

--- a/modules/gapi/src/compiler/passes/meta.cpp
+++ b/modules/gapi/src/compiler/passes/meta.cpp
@@ -33,7 +33,7 @@ void cv::gimpl::passes::initMeta(ade::passes::PassContext &ctx, const GMetaArgs 
 
 // Iterate over all operations in the topological order, trigger kernels
 // validate() function, update output objects metadata.
-void cv::gimpl::passes::inferMeta(ade::passes::PassContext &ctx)
+void cv::gimpl::passes::inferMeta(ade::passes::PassContext &ctx, bool meta_is_initialized)
 {
     // FIXME: ADE pass dependency on topo_sort?
     // FIXME: ADE pass dependency on initMeta?
@@ -75,7 +75,7 @@ void cv::gimpl::passes::inferMeta(ade::passes::PassContext &ctx)
             // Now ask kernel for it's output meta.
             // Resulting out_args may have a larger size than op.outs, since some
             // outputs could stay unused (unconnected)
-            const GMetaArgs out_metas = op.k.outMeta(input_meta_args, op.args);
+            const auto& out_metas = op.k.outMeta(input_meta_args, op.args);
 
             // Walk through operation's outputs, update meta of output objects
             // appropriately
@@ -87,7 +87,7 @@ void cv::gimpl::passes::inferMeta(ade::passes::PassContext &ctx)
                 GAPI_Assert(gr.metadata(output_nh).get<NodeType>().t == NodeType::DATA);
 
                 auto       &output_meta = gr.metadata(output_nh).get<Data>().meta;
-                if (!util::holds_alternative<util::monostate>(output_meta))
+                if (!meta_is_initialized && !util::holds_alternative<util::monostate>(output_meta))
                 {
                     GAPI_LOG_INFO(NULL,
                                   "!!! Output object has an initialized meta - "

--- a/modules/gapi/src/compiler/passes/passes.hpp
+++ b/modules/gapi/src/compiler/passes/passes.hpp
@@ -38,7 +38,7 @@ void checkIslands(ade::passes::PassContext &ctx);
 void checkIslandsContent(ade::passes::PassContext &ctx);
 
 void initMeta(ade::passes::PassContext &ctx, const GMetaArgs &metas);
-void inferMeta(ade::passes::PassContext &ctx);
+void inferMeta(ade::passes::PassContext &ctx, bool meta_is_initialized);
 void storeResultingMeta(ade::passes::PassContext &ctx);
 
 void expandKernels(ade::passes::PassContext &ctx,

--- a/modules/gapi/src/executor/gexecutor.cpp
+++ b/modules/gapi/src/executor/gexecutor.cpp
@@ -13,6 +13,7 @@
 
 #include "opencv2/gapi/opencv_includes.hpp"
 #include "executor/gexecutor.hpp"
+#include "compiler/passes/passes.hpp"
 
 cv::gimpl::GExecutor::GExecutor(std::unique_ptr<ade::Graph> &&g_model)
     : m_orig_graph(std::move(g_model))
@@ -34,7 +35,6 @@ cv::gimpl::GExecutor::GExecutor(std::unique_ptr<ade::Graph> &&g_model)
     // 6. Run GIslandExecutable
     // 7. writeBack
 
-    m_ops.reserve(m_gim.nodes().size());
     auto sorted = m_gim.metadata().get<ade::passes::TopologicalSortData>();
     for (auto nh : sorted.nodes())
     {
@@ -59,6 +59,7 @@ cv::gimpl::GExecutor::GExecutor(std::unique_ptr<ade::Graph> &&g_model)
                 // (3)
                 for (auto in_slot_nh  : nh->inNodes())  xtract(in_slot_nh,  input_rcs);
                 for (auto out_slot_nh : nh->outNodes()) xtract(out_slot_nh, output_rcs);
+
                 m_ops.emplace_back(OpDesc{ std::move(input_rcs)
                                          , std::move(output_rcs)
                                          , m_gim.metadata(nh).get<IslandExec>().object});
@@ -223,4 +224,19 @@ void cv::gimpl::GExecutor::run(cv::gimpl::GRuntimeArgs &&args)
 const cv::gimpl::GModel::Graph& cv::gimpl::GExecutor::model() const
 {
     return m_gm;
+}
+
+bool cv::gimpl::GExecutor::canReshape() const
+{
+    return (m_ops.size() == 1) && m_ops[0].isl_exec->canReshape();
+}
+
+void cv::gimpl::GExecutor::reshape(const GMetaArgs& inMetas, const GCompileArgs& args)
+{
+    GAPI_Assert(canReshape());
+    auto& g = *m_orig_graph.get();
+    ade::passes::PassContext ctx{g};
+    passes::initMeta(ctx, inMetas);
+    passes::inferMeta(ctx, true);
+    m_ops[0].isl_exec->reshape(g, args);
 }

--- a/modules/gapi/src/executor/gexecutor.cpp
+++ b/modules/gapi/src/executor/gexecutor.cpp
@@ -228,6 +228,8 @@ const cv::gimpl::GModel::Graph& cv::gimpl::GExecutor::model() const
 
 bool cv::gimpl::GExecutor::canReshape() const
 {
+    // FIXME: Introduce proper reshaping support on GExecutor level
+    // for all cases!
     return (m_ops.size() == 1) && m_ops[0].isl_exec->canReshape();
 }
 

--- a/modules/gapi/src/executor/gexecutor.hpp
+++ b/modules/gapi/src/executor/gexecutor.hpp
@@ -85,6 +85,9 @@ public:
     explicit GExecutor(std::unique_ptr<ade::Graph> &&g_model);
     void run(cv::gimpl::GRuntimeArgs &&args);
 
+    bool canReshape() const;
+    void reshape(const GMetaArgs& inMetas, const GCompileArgs& args);
+
     const GModel::Graph& model() const; // FIXME: make it ConstGraph?
 };
 

--- a/modules/gapi/test/gapi_fluid_test.cpp
+++ b/modules/gapi/test/gapi_fluid_test.cpp
@@ -51,7 +51,7 @@ TEST(FluidBuffer, InputTest)
     cv::Mat in_mat = cv::Mat::eye(buffer_size, CV_8U);
 
     cv::gapi::fluid::Buffer buffer(to_own(in_mat), true);
-    cv::gapi::fluid::View  view = buffer.mkView(1, 0, {}, false);
+    cv::gapi::fluid::View  view = buffer.mkView(0, {});
     view.priv().reset(1);
     int this_y = 0;
 
@@ -74,7 +74,7 @@ TEST(FluidBuffer, CircularTest)
 
     cv::gapi::fluid::Buffer buffer(cv::GMatDesc{CV_8U,1,buffer_size}, 3, 1, 0, 1,
         util::make_optional(cv::gapi::fluid::Border{cv::BORDER_CONSTANT, cv::gapi::own::Scalar(255)}));
-    cv::gapi::fluid::View view = buffer.mkView(3, 1, {}, false);
+    cv::gapi::fluid::View view = buffer.mkView(1, {});
     view.priv().reset(3);
     buffer.debug(std::cout);
 

--- a/modules/gapi/test/internal/gapi_int_recompilation_test.cpp
+++ b/modules/gapi/test/internal/gapi_int_recompilation_test.cpp
@@ -8,6 +8,9 @@
 #include "test_precomp.hpp"
 #include "api/gcomputation_priv.hpp"
 
+#include <backends/fluid/gfluidcore.hpp>
+#include <backends/fluid/gfluidimgproc.hpp>
+
 namespace opencv_test
 {
 
@@ -66,6 +69,101 @@ TEST(GComputationCompile, RecompileWithDifferentMeta)
 
     // Both compiled objects are different
     EXPECT_NE(&comp1.priv(), &comp2.priv());
+}
+
+TEST(GComputationCompile, ReshapeWithDifferentDims)
+{
+    cv::GMat in;
+    cv::GComputation cc(in, in+in);
+
+    cv::Mat in_mat1 = cv::Mat::eye  (32, 32, CV_8UC1);
+    cv::Mat in_mat2 = cv::Mat::zeros(64, 64, CV_8UC1);
+    cv::Mat out_mat;
+
+    cc.apply(in_mat1, out_mat, cv::compile_args(cv::gapi::core::fluid::kernels()));
+    auto comp1 = cc.priv().m_lastCompiled;
+
+    cc.apply(in_mat2, out_mat);
+    auto comp2 = cc.priv().m_lastCompiled;
+
+    // Both compiled objects are actually the same unique executable
+    EXPECT_EQ(&comp1.priv(), &comp2.priv());
+}
+
+TEST(GComputationCompile, ReshapeResizeDownScale)
+{
+    cv::Size szOut(4, 4);
+    cv::GMat in;
+    cv::GComputation cc(in, cv::gapi::resize(in, szOut));
+
+    cv::Mat in_mat1( 8,  8, CV_8UC3);
+    cv::Mat in_mat2(16, 16, CV_8UC3);
+    cv::randu(in_mat1, cv::Scalar::all(0), cv::Scalar::all(255));
+    cv::randu(in_mat2, cv::Scalar::all(0), cv::Scalar::all(255));
+    cv::Mat out_mat1, out_mat2;
+
+    cc.apply(in_mat1, out_mat1, cv::compile_args(cv::gapi::core::fluid::kernels()));
+    auto comp1 = cc.priv().m_lastCompiled;
+
+    cc.apply(in_mat2, out_mat2);
+    auto comp2 = cc.priv().m_lastCompiled;
+
+    // Both compiled objects are actually the same unique executable
+    EXPECT_EQ(&comp1.priv(), &comp2.priv());
+
+    cv::Mat cv_out_mat1, cv_out_mat2;
+    cv::resize(in_mat1, cv_out_mat1, szOut);
+    cv::resize(in_mat2, cv_out_mat2, szOut);
+
+    EXPECT_EQ(0, cv::countNonZero(out_mat1 != cv_out_mat1));
+    EXPECT_EQ(0, cv::countNonZero(out_mat2 != cv_out_mat2));
+}
+
+TEST(GComputationCompile, ReshapeSwitchToUpscaleFromDownscale)
+{
+    cv::Size szOut(4, 4);
+    cv::GMat in;
+    cv::GComputation cc(in, cv::gapi::resize(in, szOut));
+
+    cv::Mat in_mat1(8, 8, CV_8UC3);
+    cv::Mat in_mat2(2, 2, CV_8UC3);
+    cv::randu(in_mat1, cv::Scalar::all(0), cv::Scalar::all(255));
+    cv::randu(in_mat2, cv::Scalar::all(0), cv::Scalar::all(255));
+    cv::Mat out_mat1, out_mat2;
+
+    cc.apply(in_mat1, out_mat1, cv::compile_args(cv::gapi::core::fluid::kernels()));
+
+    // Currently such switches are unsupported
+    EXPECT_ANY_THROW(cc.apply(in_mat2, out_mat2));
+}
+
+TEST(GComputationCompile, ReshapeBlur)
+{
+    cv::Size kernelSize{3, 3};
+    cv::GMat in;
+    cv::GComputation cc(in, cv::gapi::blur(in, kernelSize));
+
+    cv::Mat in_mat1( 8,  8, CV_8UC1);
+    cv::Mat in_mat2(16, 16, CV_8UC1);
+    cv::randu(in_mat1, cv::Scalar::all(0), cv::Scalar::all(255));
+    cv::randu(in_mat2, cv::Scalar::all(0), cv::Scalar::all(255));
+    cv::Mat out_mat1, out_mat2;
+
+    cc.apply(in_mat1, out_mat1, cv::compile_args(cv::gapi::imgproc::fluid::kernels()));
+    auto comp1 = cc.priv().m_lastCompiled;
+
+    cc.apply(in_mat2, out_mat2);
+    auto comp2 = cc.priv().m_lastCompiled;
+
+    // Both compiled objects are actually the same unique executable
+    EXPECT_EQ(&comp1.priv(), &comp2.priv());
+
+    cv::Mat cv_out_mat1, cv_out_mat2;
+    cv::blur(in_mat1, cv_out_mat1, kernelSize);
+    cv::blur(in_mat2, cv_out_mat2, kernelSize);
+
+    EXPECT_EQ(0, cv::countNonZero(out_mat1 != cv_out_mat1));
+    EXPECT_EQ(0, cv::countNonZero(out_mat2 != cv_out_mat2));
 }
 
 } // opencv_test


### PR DESCRIPTION
This new method allows to compile a G-API graph one and then adjust it
to new input size(s). The support is determined by the underlying backends
capabilities - if a `GCompiled` object has been produced with backends
supporting `reshape()`, adjustments are made; an exception is thrown
otherwise.

Currently only Fluid backend supports reshape capability, and CPU (OpenCV)
backend throws. OpenCV backend reshaping will be added later.