### PR TITLE
java: add support for MatOfRotatedRect

### DIFF
--- a/modules/core/misc/java/gen_dict.json
+++ b/modules/core/misc/java/gen_dict.json
@@ -765,6 +765,15 @@
             "v_type": "Mat",
             "j_import": "org.opencv.core.MatOfRect2d"
         },
+        "vector_RotatedRect": {
+            "j_type": "MatOfRotatedRect",
+            "jn_type": "long",
+            "jni_type": "jlong",
+            "jni_var": "std::vector< RotatedRect > %(n)s",
+            "suffix": "J",
+            "v_type": "Mat",
+            "j_import": "org.opencv.core.MatOfRotatedRect"
+        },
         "vector_String": {
             "j_type": "List<String>",
             "jn_type": "List<String>",

--- a/modules/java/generator/src/cpp/converters.cpp
+++ b/modules/java/generator/src/cpp/converters.cpp
@@ -107,6 +107,20 @@ void vector_Rect2d_to_Mat(std::vector<Rect2d>& v_rect, Mat& mat)
     mat = Mat(v_rect, true);
 }
 
+//vector_RotatedRect
+
+void Mat_to_vector_RotatedRect(Mat& mat, std::vector<RotatedRect>& v_rect)
+{
+    v_rect.clear();
+    CHECK_MAT(mat.type()==CV_32FC(5) && mat.cols==1);
+    v_rect = (std::vector<RotatedRect>) mat;
+}
+
+void vector_RotatedRect_to_Mat(std::vector<RotatedRect>& v_rect, Mat& mat)
+{
+    mat = Mat(v_rect, true);
+}
+
 //vector_Point
 void Mat_to_vector_Point(Mat& mat, std::vector<Point>& v_point)
 {

--- a/modules/java/generator/src/cpp/converters.h
+++ b/modules/java/generator/src/cpp/converters.h
@@ -26,6 +26,8 @@ void vector_Rect_to_Mat(std::vector<cv::Rect>& v_rect, cv::Mat& mat);
 void Mat_to_vector_Rect2d(cv::Mat& mat, std::vector<cv::Rect2d>& v_rect);
 void vector_Rect2d_to_Mat(std::vector<cv::Rect2d>& v_rect, cv::Mat& mat);
 
+void Mat_to_vector_RotatedRect(cv::Mat& mat, std::vector<cv::RotatedRect>& v_rect);
+void vector_RotatedRect_to_Mat(std::vector<cv::RotatedRect>& v_rect, cv::Mat& mat);
 
 void Mat_to_vector_Point(cv::Mat& mat, std::vector<cv::Point>& v_point);
 void Mat_to_vector_Point2f(cv::Mat& mat, std::vector<cv::Point2f>& v_point);


### PR DESCRIPTION
add rudimentary support for MatOfRotatedRect, so `Dnn.NMSBoxesRotated()` can be used with the east text detection.