### PR TITLE
Replaced strcpy_s, strcat_s for MinGW builds.

### DIFF
--- a/modules/highgui/src/window_w32.cpp
+++ b/modules/highgui/src/window_w32.cpp
@@ -99,6 +99,19 @@ static const char* trackbar_text =
     #define WM_MOUSEHWHEEL 0x020E
 #endif
 
+#if defined(__MINGW32__) || defined(__MINGW64__)
+static inline void mingw_strcpy_s(char *dest, size_t destsz, const char *src){
+    strcpy(dest, src);
+}
+
+static inline void mingw_strcat_s(char *dest, size_t destsz, const char *src){
+    strcat(dest, src);
+}
+
+#define strcpy_s mingw_strcpy_s
+#define strcat_s mingw_strcat_s
+#endif
+
 static void FillBitmapInfo( BITMAPINFO* bmi, int width, int height, int bpp, int origin )
 {
     assert( bmi && width >= 0 && height >= 0 && (bpp == 8 || bpp == 24 || bpp == 32));


### PR DESCRIPTION
Building OpenCV with MinGW-w64

<!-- Please use this line to close one or multiple issues when this pullrequest gets merged
You can add another line right under the first one:
resolves #13016
resolves #1235
-->
resolves #13016 

### This pullrequest changes

Replaced the use *strcpy_s* and *strcat_s*, which are available only on MSVC, in file *window_w32.cpp* with *strcpy* and *strcat* usage. This was wrapped in a conditional compilation and take effect only when built with MinGW.

<!-- Please describe what your pullrequest is changing -->
