### PR TITLE
highgui: fix broken waitKey() condition in window_w32

### DIFF
--- a/modules/highgui/src/window_w32.cpp
+++ b/modules/highgui/src/window_w32.cpp
@@ -1976,7 +1976,7 @@ cvWaitKey( int delay )
         MSG message;
         int is_processed = 0;
 
-        if( delay <= 0 )
+        if( (delay <= 0) && hg_windows)
             GetMessage(&message, 0, 0, 0);
         else if( PeekMessage(&message, 0, 0, 0, PM_REMOVE) == FALSE )
         {


### PR DESCRIPTION
resolves #13049
relates #11714

avoid calling GetMessage()  (which will make it stall), if we have an "inifinite" timeout, but don't have a valid window handle any more