### PR TITLE
Fix CMake find_package(OpenCV) for Windows when BUILD_SHARED_LIBS is not defined

### DIFF
--- a/cmake/OpenCVDetectCXXCompiler.cmake
+++ b/cmake/OpenCVDetectCXXCompiler.cmake
@@ -111,10 +111,10 @@ endif()
 # Similar code exists in OpenCVConfig.cmake
 if(NOT DEFINED OpenCV_STATIC)
   # look for global setting
-  if(NOT DEFINED BUILD_SHARED_LIBS OR BUILD_SHARED_LIBS)
-    set(OpenCV_STATIC OFF)
-  else()
+  if(NOT DEFINED BUILD_SHARED_LIBS OR NOT BUILD_SHARED_LIBS)
     set(OpenCV_STATIC ON)
+  else()
+    set(OpenCV_STATIC OFF)
   endif()
 endif()
 

--- a/cmake/templates/OpenCVConfig.root-WIN32.cmake.in
+++ b/cmake/templates/OpenCVConfig.root-WIN32.cmake.in
@@ -43,10 +43,10 @@ endif()
 
 if(NOT DEFINED OpenCV_STATIC)
   # look for global setting
-  if(NOT DEFINED BUILD_SHARED_LIBS OR BUILD_SHARED_LIBS)
-    set(OpenCV_STATIC OFF)
-  else()
+  if(NOT DEFINED BUILD_SHARED_LIBS OR NOT BUILD_SHARED_LIBS)
     set(OpenCV_STATIC ON)
+  else()
+    set(OpenCV_STATIC OFF)
   endif()
 endif()
 


### PR DESCRIPTION
### This pullrequest changes
Which library the find_package(OpenCV) loads when BUILD_SHARED_LIBS is not defined. This matches the standard practice as well as the library that is compiled by OpenCV when this variable is not set.

This has been broken since OpenCV 3.4.2.
Caused by https://github.com/opencv/opencv/commit/abce51fb7ba901ddf9480a127c727e514a951f90 which was matching the OpenCVDetectCXXCompiler.cmake code which has always had this incorrect logic.
