### PR TITLE
Update text graphs generator for Faster-RCNN networks from TensorFlow

### DIFF
--- a/modules/dnn/src/layers/pooling_layer.cpp
+++ b/modules/dnn/src/layers/pooling_layer.cpp
@@ -95,7 +95,6 @@ public:
         else if (params.has("pooled_w") || params.has("pooled_h"))
         {
             type = ROI;
-            computeMaxIdx = false;
             pooledSize.width = params.get<uint32_t>("pooled_w", 1);
             pooledSize.height = params.get<uint32_t>("pooled_h", 1);
         }
@@ -141,6 +140,7 @@ public:
 #ifdef HAVE_OPENCL
         poolOp.release();
 #endif
+        computeMaxIdx = type == MAX;
     }
 
     virtual bool supportBackend(int backendId) CV_OVERRIDE
@@ -190,19 +190,14 @@ public:
             poolOp = Ptr<OCL4DNNPool<float> >(new OCL4DNNPool<float>(config));
         }
 
-        for (size_t ii = 0; ii < inputs.size(); ii++)
-        {
-            UMat& inpMat = inputs[ii];
-            int out_index = (type == MAX) ? 2 : 1;
-            UMat& outMat = outputs[out_index * ii];
-            UMat maskMat = (type == MAX) ? outputs[2 * ii + 1] : UMat();
+        CV_Assert_N(inputs.size() == 1, !outputs.empty(), !computeMaxIdx || outputs.size() == 2);
+        UMat& inpMat = inputs[0];
+        UMat& outMat = outputs[0];
+        UMat maskMat = computeMaxIdx ? outputs[1] : UMat();
 
-            CV_Assert(inpMat.offset == 0 && outMat.offset == 0);
+        CV_Assert(inpMat.offset == 0 && outMat.offset == 0);
 
-            if (!poolOp->Forward(inpMat, outMat, maskMat))
-                return false;
-        }
-        return true;
+        return poolOp->Forward(inpMat, outMat, maskMat);
     }
 #endif
 
@@ -229,9 +224,12 @@ public:
         switch (type)
         {
             case MAX:
-                CV_Assert_N(inputs.size() == 1, outputs.size() == 2);
-                maxPooling(inputs[0], outputs[0], outputs[1]);
+            {
+                CV_Assert_N(inputs.size() == 1, !computeMaxIdx || outputs.size() == 2);
+                Mat mask = computeMaxIdx ? outputs[1] : Mat();
+                maxPooling(inputs[0], outputs[0], mask);
                 break;
+            }
             case AVE:
                 CV_Assert_N(inputs.size() == 1, outputs.size() == 1);
                 avePooling(inputs[0], outputs[0]);
@@ -912,7 +910,10 @@ public:
             dims[0] = inputs[1][0];  // Number of proposals;
             dims[1] = psRoiOutChannels;
         }
-        outputs.assign(type == MAX ? 2 : 1, shape(dims, 4));
+
+        int numOutputs = requiredOutputs ? requiredOutputs : (type == MAX ? 2 : 1);
+        CV_Assert(numOutputs == 1 || (numOutputs == 2 && type == MAX));
+        outputs.assign(numOutputs, shape(dims, 4));
 
         return false;
     }

--- a/modules/dnn/test/test_tf_importer.cpp
+++ b/modules/dnn/test/test_tf_importer.cpp
@@ -358,7 +358,7 @@ TEST_P(Test_TensorFlow_nets, Faster_RCNN)
         (backend == DNN_BACKEND_OPENCV && target == DNN_TARGET_OPENCL_FP16))
         throw SkipTestException("");
 
-    for (int i = 1; i < 2; ++i)
+    for (int i = 0; i < 2; ++i)
     {
         std::string proto = findDataFile("dnn/" + names[i] + ".pbtxt", false);
         std::string model = findDataFile("dnn/" + names[i] + ".pb", false);

--- a/samples/dnn/tf_text_graph_faster_rcnn.py
+++ b/samples/dnn/tf_text_graph_faster_rcnn.py
@@ -32,6 +32,8 @@ def createFasterRCNNGraph(modelPath, configPath, outputPath):
     width_stride = float(grid_anchor_generator['width_stride'][0])
     height_stride = float(grid_anchor_generator['height_stride'][0])
     features_stride = float(config['feature_extractor'][0]['first_stage_features_stride'][0])
+    first_stage_nms_iou_threshold = float(config['first_stage_nms_iou_threshold'][0])
+    first_stage_max_proposals = int(config['first_stage_max_proposals'][0])
 
     print('Number of classes: %d' % num_classes)
     print('Scales:            %s' % str(scales))
@@ -47,7 +49,8 @@ def createFasterRCNNGraph(modelPath, configPath, outputPath):
     removeIdentity(graph_def)
 
     def to_remove(name, op):
-        return name.startswith(scopesToIgnore) or not name.startswith(scopesToKeep)
+        return name.startswith(scopesToIgnore) or not name.startswith(scopesToKeep) or \
+               (name.startswith('CropAndResize') and op != 'CropAndResize')
 
     removeUnusedNodesAndAttrs(to_remove, graph_def)
 
@@ -114,10 +117,10 @@ def createFasterRCNNGraph(modelPath, configPath, outputPath):
     detectionOut.addAttr('num_classes', 2)
     detectionOut.addAttr('share_location', True)
     detectionOut.addAttr('background_label_id', 0)
-    detectionOut.addAttr('nms_threshold', 0.7)
+    detectionOut.addAttr('nms_threshold', first_stage_nms_iou_threshold)
     detectionOut.addAttr('top_k', 6000)
     detectionOut.addAttr('code_type', "CENTER_SIZE")
-    detectionOut.addAttr('keep_top_k', 100)
+    detectionOut.addAttr('keep_top_k', first_stage_max_proposals)
     detectionOut.addAttr('clip', False)
 
     graph_def.node.extend([detectionOut])
@@ -147,9 +150,11 @@ def createFasterRCNNGraph(modelPath, configPath, outputPath):
               'SecondStageBoxPredictor/Reshape_1/Reshape', [1, -1], graph_def)
 
     # Replace Flatten subgraph onto a single node.
+    cropAndResizeNodeName = ''
     for i in reversed(range(len(graph_def.node))):
         if graph_def.node[i].op == 'CropAndResize':
             graph_def.node[i].input.insert(1, 'detection_out/clip_by_value')
+            cropAndResizeNodeName = graph_def.node[i].name
 
         if graph_def.node[i].name == 'SecondStageBoxPredictor/Reshape':
             addConstNode('SecondStageBoxPredictor/Reshape/shape2', [1, -1, 4], graph_def)
@@ -159,17 +164,26 @@ def createFasterRCNNGraph(modelPath, configPath, outputPath):
 
         if graph_def.node[i].name in ['SecondStageBoxPredictor/Flatten/flatten/Shape',
                                       'SecondStageBoxPredictor/Flatten/flatten/strided_slice',
-                                      'SecondStageBoxPredictor/Flatten/flatten/Reshape/shape']:
+                                      'SecondStageBoxPredictor/Flatten/flatten/Reshape/shape',
+                                      'SecondStageBoxPredictor/Flatten_1/flatten/Shape',
+                                      'SecondStageBoxPredictor/Flatten_1/flatten/strided_slice',
+                                      'SecondStageBoxPredictor/Flatten_1/flatten/Reshape/shape']:
             del graph_def.node[i]
 
     for node in graph_def.node:
-        if node.name == 'SecondStageBoxPredictor/Flatten/flatten/Reshape':
+        if node.name == 'SecondStageBoxPredictor/Flatten/flatten/Reshape' or \
+           node.name == 'SecondStageBoxPredictor/Flatten_1/flatten/Reshape':
             node.op = 'Flatten'
             node.input.pop()
 
         if node.name in ['FirstStageBoxPredictor/BoxEncodingPredictor/Conv2D',
                          'SecondStageBoxPredictor/BoxEncodingPredictor/MatMul']:
             node.addAttr('loc_pred_transposed', True)
+
+        if node.name.startswith('MaxPool2D'):
+            assert(node.op == 'MaxPool')
+            assert(cropAndResizeNodeName)
+            node.input = [cropAndResizeNodeName]
 
     ################################################################################
     ### Postprocessing


### PR DESCRIPTION
<!-- Please use this line to close one or multiple issues when this pullrequest gets merged
You can add another line right under the first one:
resolves #1234
resolves #1235
-->

### This pullrequest changes

resolves https://github.com/opencv/opencv/issues/13050
resolves https://github.com/opencv/opencv/issues/12996

Fixed OpenCL optimization for eltwise and convolution layers fusion. Number of fused layers across all the tests before PR: 136. Number of fusions with this PR: 142 (+6).

**Merge with extra**: https://github.com/opencv/opencv_extra/pull/545

No efficiency regressions observed:
(median time for a single input forward pass)

CPU: Intel&reg; Core&trade; i7-6700K CPU @ 4.00GHz x 8
GPU: Intel&reg; HD Graphics 530 (Skylake GT2)

Test name | 3.4 branch | With a PR | x-factor
----|----|----|----
AlexNet::OCV/OCL                                 | 18.537 |   18.890    | 0.98   |
AlexNet::OCV/OCL_FP16                            | 12.725 |   12.706    | 1.00   |
DenseNet_121::OCV/OCL                           | 102.097 |  100.543    | 1.02   |
DenseNet_121::OCV/OCL_FP16                      | 104.261 |  104.472    | 1.00   |
EAST_text_detection::OCV/OCL                     | 93.894 |   93.609    | 1.00   |
EAST_text_detection::OCV/OCL_FP16                | 93.014 |   92.046    | 1.01   |
ENet::OCV/OCL                                    | 66.914 |   67.121    | 1.00   |
FastNeuralStyle_eccv16::OCV/OCL                 | 105.718 |  105.650    | 1.00   |
GoogLeNet::OCV/OCL                               | 32.514 |   32.469    | 1.00   |
GoogLeNet::OCV/OCL_FP16                          | 29.018 |   29.245    | 0.99   |
Inception_5h::OCV/OCL                            | 35.727 |   36.063    | 0.99   |
Inception_5h::OCV/OCL_FP16                       | 34.468 |   33.853    | 1.02   |
Inception_v2_Faster_RCNN::OCV/OCL               | 351.957 |  350.877    | 1.00   |
Inception_v2_SSD_TensorFlow::OCV/OCL             | 78.133 |   78.994    | 0.99   |
Inception_v2_SSD_TensorFlow::OCV/OCL_FP16        | 82.918 |   84.446    | 0.98   |
MobileNet_SSD_Caffe::OCV/OCL                     | 29.228 |   29.115    | 1.00   |
MobileNet_SSD_Caffe::OCV/OCL_FP16                | 29.965 |   30.399    | 0.99   |
MobileNet_SSD_v1_TensorFlow::OCV/OCL             | 32.191 |   32.119    | 1.00   |
MobileNet_SSD_v1_TensorFlow::OCV/OCL_FP16        | 33.897 |   33.822    | 1.00   |
MobileNet_SSD_v2_TensorFlow::OCV/OCL             | 51.679 |   52.043    | 0.99   |
MobileNet_SSD_v2_TensorFlow::OCV/OCL_FP16        | 53.841 |   51.798    | 1.04   |
OpenFace::OCV/OCL                                | 18.954 |   18.663    | 1.02   |
OpenFace::OCV/OCL_FP16                           | 21.448 |   21.082    | 1.02   |
OpenPose_pose_coco::OCV/OCL                     | 1058.803 | 1057.486   | 1.00   |
OpenPose_pose_coco::OCV/OCL_FP16                | 1188.063 | 1189.322   | 1.00   |
OpenPose_pose_mpi::OCV/OCL                      | 1044.268 | 1036.856   | 1.01   |
OpenPose_pose_mpi::OCV/OCL_FP16                 | 1173.776 | 1172.670   | 1.00   |
OpenPose_pose_mpi_faster_4_stages::OCV/OCL      | 744.265 |  742.745    | 1.00   |
OpenPose_pose_mpi_faster_4_stages::OCV/OCL_FP16 | 812.397 |  813.321    | 1.00   |
ResNet_50::OCV/OCL                               | 44.585 |   44.735    | 1.00   |
ResNet_50::OCV/OCL_FP16                          | 37.120 |   37.497    | 0.99   |
SSD::OCV/OCL                                    | 382.996 |  382.180    | 1.00   |
SSD::OCV/OCL_FP16                               | 334.588 |  335.808    | 1.00   |
SqueezeNet_v1_1::OCV/OCL                         | 11.838 |   11.806    | 1.00   |
SqueezeNet_v1_1::OCV/OCL_FP16                    | 11.747 |   11.672    | 1.01   |
YOLOv3::OCV/OCL                                 | 344.806 |  345.495    | 1.00   |
YOLOv3::OCV/OCL_FP16                            | 335.676 |  335.323    | 1.00   |
opencv_face_detector::OCV/OCL                    | 33.265 |   33.388    | 1.00   |
opencv_face_detector::OCV/OCL_FP16               | 38.702 |   36.492    | 1.06|