### PR TITLE
Fixed pendantic warning

### DIFF
--- a/modules/core/include/opencv2/core/cvdef.h
+++ b/modules/core/include/opencv2/core/cvdef.h
@@ -425,7 +425,7 @@ as well as exposing the C++11 enum class members for backwards compatibility
 
 @code
     // Provides operators required for flag enums
-    CV_ENUM_FLAGS(AccessFlag);
+    CV_ENUM_FLAGS(AccessFlag)
 
     // Exposes the listed members of the enum class AccessFlag to the current namespace
     CV_ENUM_CLASS_EXPOSE(AccessFlag, ACCESS_READ [, ACCESS_WRITE [, ...] ]);
@@ -539,18 +539,18 @@ static inline EnumType& operator^=(EnumType& _this, const Arg1Type& val)        
 __CV_EXPAND(__CV_CAT(__CV_ENUM_CLASS_EXPOSE_, __CV_VA_NUM_ARGS(__VA_ARGS__))(EnumType, __VA_ARGS__)); \
 
 #define CV_ENUM_FLAGS(EnumType)                                                                       \
-__CV_ENUM_FLAGS_LOGICAL_NOT      (EnumType);                                                          \
-__CV_ENUM_FLAGS_LOGICAL_EQ       (EnumType, int);                                                     \
-__CV_ENUM_FLAGS_LOGICAL_NOT_EQ   (EnumType, int);                                                     \
+__CV_ENUM_FLAGS_LOGICAL_NOT      (EnumType)                                                           \
+__CV_ENUM_FLAGS_LOGICAL_EQ       (EnumType, int)                                                      \
+__CV_ENUM_FLAGS_LOGICAL_NOT_EQ   (EnumType, int)                                                      \
                                                                                                       \
-__CV_ENUM_FLAGS_BITWISE_NOT      (EnumType);                                                          \
-__CV_ENUM_FLAGS_BITWISE_OR       (EnumType, EnumType, EnumType);                                      \
-__CV_ENUM_FLAGS_BITWISE_AND      (EnumType, EnumType, EnumType);                                      \
-__CV_ENUM_FLAGS_BITWISE_XOR      (EnumType, EnumType, EnumType);                                      \
+__CV_ENUM_FLAGS_BITWISE_NOT      (EnumType)                                                           \
+__CV_ENUM_FLAGS_BITWISE_OR       (EnumType, EnumType, EnumType)                                       \
+__CV_ENUM_FLAGS_BITWISE_AND      (EnumType, EnumType, EnumType)                                       \
+__CV_ENUM_FLAGS_BITWISE_XOR      (EnumType, EnumType, EnumType)                                       \
                                                                                                       \
-__CV_ENUM_FLAGS_BITWISE_OR_EQ    (EnumType, EnumType);                                                \
-__CV_ENUM_FLAGS_BITWISE_AND_EQ   (EnumType, EnumType);                                                \
-__CV_ENUM_FLAGS_BITWISE_XOR_EQ   (EnumType, EnumType);                                                \
+__CV_ENUM_FLAGS_BITWISE_OR_EQ    (EnumType, EnumType)                                                 \
+__CV_ENUM_FLAGS_BITWISE_AND_EQ   (EnumType, EnumType)                                                 \
+__CV_ENUM_FLAGS_BITWISE_XOR_EQ   (EnumType, EnumType)                                                 \
 
 /****************************************************************************************\
 *                                    static analysys                                     *

--- a/modules/core/include/opencv2/core/mat.hpp
+++ b/modules/core/include/opencv2/core/mat.hpp
@@ -63,8 +63,8 @@ namespace cv
 
 enum AccessFlag { ACCESS_READ=1<<24, ACCESS_WRITE=1<<25,
     ACCESS_RW=3<<24, ACCESS_MASK=ACCESS_RW, ACCESS_FAST=1<<26 };
-CV_ENUM_FLAGS(AccessFlag);
-__CV_ENUM_FLAGS_BITWISE_AND(AccessFlag, int, AccessFlag);
+CV_ENUM_FLAGS(AccessFlag)
+__CV_ENUM_FLAGS_BITWISE_AND(AccessFlag, int, AccessFlag)
 
 CV__DEBUG_NS_BEGIN
 
@@ -259,8 +259,8 @@ protected:
     void init(int _flags, const void* _obj);
     void init(int _flags, const void* _obj, Size _sz);
 };
-CV_ENUM_FLAGS(_InputArray::KindFlag);
-__CV_ENUM_FLAGS_BITWISE_AND(_InputArray::KindFlag, int, _InputArray::KindFlag);
+CV_ENUM_FLAGS(_InputArray::KindFlag)
+__CV_ENUM_FLAGS_BITWISE_AND(_InputArray::KindFlag, int, _InputArray::KindFlag)
 
 /** @brief This type is very similar to InputArray except that it is used for input/output and output function
 parameters.
@@ -563,7 +563,7 @@ struct CV_EXPORTS UMatData
     int mapcount;
     UMatData* originalUMatData;
 };
-CV_ENUM_FLAGS(UMatData::MemoryFlag);
+CV_ENUM_FLAGS(UMatData::MemoryFlag)
 
 
 struct CV_EXPORTS MatSize

--- a/modules/features2d/include/opencv2/features2d.hpp
+++ b/modules/features2d/include/opencv2/features2d.hpp
@@ -1199,7 +1199,7 @@ enum struct DrawMatchesFlags
   DRAW_RICH_KEYPOINTS = 4 //!< For each keypoint the circle around keypoint with keypoint size and
                           //!< orientation will be drawn.
 };
-CV_ENUM_FLAGS(DrawMatchesFlags);
+CV_ENUM_FLAGS(DrawMatchesFlags)
 
 /** @brief Draws keypoints.
 


### PR DESCRIPTION
Resolves Pedantic warning of the kind: `extra ‘;’ [-Wpedantic]` (no open issue about it that I am aware of)

### This pullrequest changes

<!-- Please describe what your pullrequest is changing -->
When enabled all warnings, it appears quite often a Pedantic warning of this kind:
```
/usr/local/include/opencv4/opencv2/features2d.hpp:1202:32: warning: extra ‘;’ [-Wpedantic]
 CV_ENUM_FLAGS(DrawMatchesFlags);
```
And analogously for every time `CV_ENUM_FLAGS` is used. This is quite annoying, so I have fixed it.

Thanks!

<!--**WIP**-->
