### PR TITLE
samples: fix digits_video.py

### DIFF
--- a/samples/python/digits_video.py
+++ b/samples/python/digits_video.py
@@ -86,7 +86,7 @@ def main():
                 frame[y:,x+w:][:SZ, :SZ] = bin_norm[...,np.newaxis]
 
             sample = preprocess_hog([bin_norm])
-            digit = model.predict(sample)[0]
+            digit = model.predict(sample)[1].ravel()
             cv.putText(frame, '%d'%digit, (x, y), cv.FONT_HERSHEY_PLAIN, 1.0, (200, 0, 0), thickness = 1)
 
 


### PR DESCRIPTION
issue [from answers.opencv.org](http://answers.opencv.org/question/202597/wrong-predictions-from-opencv-sample-digitspy/)

(the [test](https://github.com/opencv/opencv/blob/master/modules/python/test/test_digits.py#L89) has it correct)