### PR TITLE
significantly reduced OpenCV binary size by disabling IPP in some funcs

### DIFF
--- a/modules/core/src/matrix_operations.cpp
+++ b/modules/core/src/matrix_operations.cpp
@@ -8,6 +8,11 @@
 #include "opencl_kernels_core.hpp"
 #include "precomp.hpp"
 
+#undef HAVE_IPP
+#undef CV_IPP_RUN_FAST
+#define CV_IPP_RUN_FAST(f, ...)
+#undef CV_IPP_RUN
+#define CV_IPP_RUN(c, f, ...)
 
 /*************************************************************************************************\
                                         Matrix Operations

--- a/modules/core/src/mean.cpp
+++ b/modules/core/src/mean.cpp
@@ -8,6 +8,12 @@
 #include "opencv2/core/openvx/ovx_defs.hpp"
 #include "stat.hpp"
 
+#undef HAVE_IPP
+#undef CV_IPP_RUN_FAST
+#define CV_IPP_RUN_FAST(f, ...)
+#undef CV_IPP_RUN
+#define CV_IPP_RUN(c, f, ...)
+
 #if defined HAVE_IPP
 namespace cv
 {

--- a/modules/core/src/minmax.cpp
+++ b/modules/core/src/minmax.cpp
@@ -8,6 +8,12 @@
 #include "opencv2/core/openvx/ovx_defs.hpp"
 #include "stat.hpp"
 
+#undef HAVE_IPP
+#undef CV_IPP_RUN_FAST
+#define CV_IPP_RUN_FAST(f, ...)
+#undef CV_IPP_RUN
+#define CV_IPP_RUN(c, f, ...)
+
 #define IPP_DISABLE_MINMAXIDX_MANY_ROWS 1  // see Core_MinMaxIdx.rows_overflow test
 
 /****************************************************************************************\

--- a/modules/core/src/norm.cpp
+++ b/modules/core/src/norm.cpp
@@ -7,6 +7,12 @@
 #include "opencl_kernels_core.hpp"
 #include "stat.hpp"
 
+#undef HAVE_IPP
+#undef CV_IPP_RUN_FAST
+#define CV_IPP_RUN_FAST(f, ...)
+#undef CV_IPP_RUN
+#define CV_IPP_RUN(c, f, ...)
+
 /****************************************************************************************\
 *                                         norm                                           *
 \****************************************************************************************/

--- a/modules/core/src/norm.cpp
+++ b/modules/core/src/norm.cpp
@@ -7,12 +7,6 @@
 #include "opencl_kernels_core.hpp"
 #include "stat.hpp"
 
-#undef HAVE_IPP
-#undef CV_IPP_RUN_FAST
-#define CV_IPP_RUN_FAST(f, ...)
-#undef CV_IPP_RUN
-#define CV_IPP_RUN(c, f, ...)
-
 /****************************************************************************************\
 *                                         norm                                           *
 \****************************************************************************************/

--- a/modules/core/src/sum.cpp
+++ b/modules/core/src/sum.cpp
@@ -7,6 +7,12 @@
 #include "opencl_kernels_core.hpp"
 #include "stat.hpp"
 
+#undef HAVE_IPP
+#undef CV_IPP_RUN_FAST
+#define CV_IPP_RUN_FAST(f, ...)
+#undef CV_IPP_RUN
+#define CV_IPP_RUN(c, f, ...)
+
 namespace cv
 {
 

--- a/modules/imgproc/src/corner.cpp
+++ b/modules/imgproc/src/corner.cpp
@@ -483,7 +483,7 @@ static bool ocl_preCornerDetect( InputArray _src, OutputArray _dst, int ksize, i
 
 }
 
-#if defined(HAVE_IPP)
+#if 0 //defined(HAVE_IPP)
 namespace cv
 {
 static bool ipp_cornerMinEigenVal( InputArray _src, OutputArray _dst, int blockSize, int ksize, int borderType )
@@ -566,7 +566,7 @@ void cv::cornerMinEigenVal( InputArray _src, OutputArray _dst, int blockSize, in
     CV_OCL_RUN(_src.dims() <= 2 && _dst.isUMat(),
                ocl_cornerMinEigenValVecs(_src, _dst, blockSize, ksize, 0.0, borderType, MINEIGENVAL))
 
-#ifdef HAVE_IPP
+/*#ifdef HAVE_IPP
     int kerSize = (ksize < 0)?3:ksize;
     bool isolated = (borderType & BORDER_ISOLATED) != 0;
     int borderTypeNI = borderType & ~BORDER_ISOLATED;
@@ -574,7 +574,7 @@ void cv::cornerMinEigenVal( InputArray _src, OutputArray _dst, int blockSize, in
     CV_IPP_RUN(((borderTypeNI == BORDER_REPLICATE && (!_src.isSubmatrix() || isolated)) &&
             (kerSize == 3 || kerSize == 5) && (blockSize == 3 || blockSize == 5)) && IPP_VERSION_X100 >= 800,
         ipp_cornerMinEigenVal( _src, _dst, blockSize, ksize, borderType ));
-
+    */
 
     Mat src = _src.getMat();
     _dst.create( src.size(), CV_32FC1 );

--- a/modules/imgproc/src/deriv.cpp
+++ b/modules/imgproc/src/deriv.cpp
@@ -260,7 +260,7 @@ namespace cv
 }
 #endif
 
-#ifdef HAVE_IPP
+#if 0 //defined HAVE_IPP
 namespace cv
 {
 
@@ -457,7 +457,7 @@ void cv::Sobel( InputArray _src, OutputArray _dst, int ddepth, int dx, int dy,
     CV_OVX_RUN(true,
                openvx_sobel(src, dst, dx, dy, ksize, scale, delta, borderType))
 
-    CV_IPP_RUN_FAST(ipp_Deriv(src, dst, dx, dy, ksize, scale, delta, borderType));
+    //CV_IPP_RUN_FAST(ipp_Deriv(src, dst, dx, dy, ksize, scale, delta, borderType));
 
     sepFilter2D(src, dst, ddepth, kx, ky, Point(-1, -1), delta, borderType );
 }
@@ -507,7 +507,7 @@ void cv::Scharr( InputArray _src, OutputArray _dst, int ddepth, int dx, int dy,
     CALL_HAL(scharr, cv_hal_scharr, src.ptr(), src.step, dst.ptr(), dst.step, src.cols, src.rows, sdepth, ddepth, cn,
              ofs.x, ofs.y, wsz.width - src.cols - ofs.x, wsz.height - src.rows - ofs.y, dx, dy, scale, delta, borderType&~BORDER_ISOLATED);
 
-    CV_IPP_RUN_FAST(ipp_Deriv(src, dst, dx, dy, 0, scale, delta, borderType));
+    //CV_IPP_RUN_FAST(ipp_Deriv(src, dst, dx, dy, 0, scale, delta, borderType));
 
     sepFilter2D( src, dst, ddepth, kx, ky, Point(-1, -1), delta, borderType );
 }

--- a/modules/imgproc/src/filter.cpp
+++ b/modules/imgproc/src/filter.cpp
@@ -4557,7 +4557,7 @@ static bool replacementFilter2D(int stype, int dtype, int kernel_type,
     return success;
 }
 
-#ifdef HAVE_IPP
+#if 0 //defined HAVE_IPP
 static bool ippFilter2D(int stype, int dtype, int kernel_type,
               uchar * src_data, size_t src_step,
               uchar * dst_data, size_t dst_step,
@@ -4821,7 +4821,7 @@ void filter2D(int stype, int dtype, int kernel_type,
     if (res)
         return;
 
-    CV_IPP_RUN_FAST(ippFilter2D(stype, dtype, kernel_type,
+    /*CV_IPP_RUN_FAST(ippFilter2D(stype, dtype, kernel_type,
                               src_data, src_step,
                               dst_data, dst_step,
                               width, height,
@@ -4830,7 +4830,7 @@ void filter2D(int stype, int dtype, int kernel_type,
                               kernel_data, kernel_step,
                               kernel_width, kernel_height,
                               anchor_x, anchor_y,
-                              delta, borderType, isSubmatrix))
+                              delta, borderType, isSubmatrix))*/
 
     res = dftFilter2D(stype, dtype, kernel_type,
                       src_data, src_step,

--- a/modules/imgproc/src/median_blur.cpp
+++ b/modules/imgproc/src/median_blur.cpp
@@ -1081,7 +1081,7 @@ static bool openvx_medianFilter(InputArray _src, OutputArray _dst, int ksize)
 }
 #endif
 
-#ifdef HAVE_IPP
+#if 0 //defined HAVE_IPP
 static bool ipp_medianFilter(Mat &src0, Mat &dst, int ksize)
 {
     CV_INSTRUMENT_REGION_IPP();
@@ -1180,7 +1180,7 @@ void medianBlur( InputArray _src0, OutputArray _dst, int ksize )
     CV_OVX_RUN(true,
                openvx_medianFilter(_src0, _dst, ksize))
 
-    CV_IPP_RUN_FAST(ipp_medianFilter(src0, dst, ksize));
+    //CV_IPP_RUN_FAST(ipp_medianFilter(src0, dst, ksize));
 
 #ifdef HAVE_TEGRA_OPTIMIZATION
     if (tegra::useTegra() && tegra::medianBlur(src0, dst, ksize))

--- a/modules/imgproc/src/morph.cpp
+++ b/modules/imgproc/src/morph.cpp
@@ -1110,7 +1110,7 @@ static bool halMorph(int op, int src_type, int dst_type,
 }
 
 // ===== 2. IPP implementation
-#ifdef HAVE_IPP
+#if 0 //defined HAVE_IPP
 #ifdef HAVE_IPP_IW
 static inline IwiMorphologyType ippiGetMorphologyType(int morphOp)
 {
@@ -1384,12 +1384,12 @@ void morph(int op, int src_type, int dst_type,
             return;
     }
 
-    CV_IPP_RUN_FAST(ippMorph(op, src_type, dst_type, src_data, src_step, dst_data, dst_step, width, height,
+    /*CV_IPP_RUN_FAST(ippMorph(op, src_type, dst_type, src_data, src_step, dst_data, dst_step, width, height,
                             roi_width, roi_height, roi_x, roi_y,
                             roi_width2, roi_height2, roi_x2, roi_y2,
                             kernel_type, kernel_data, kernel_step,
                             kernel_width, kernel_height, anchor_x, anchor_y,
-                            borderType, borderValue, iterations, isSubmatrix));
+                            borderType, borderValue, iterations, isSubmatrix));*/
 
     ocvMorph(op, src_type, dst_type, src_data, src_step, dst_data, dst_step, width, height,
              roi_width, roi_height, roi_x, roi_y,
@@ -1967,7 +1967,7 @@ static bool ocl_morphologyEx(InputArray _src, OutputArray _dst, int op,
 #endif
 
 #define IPP_DISABLE_MORPH_ADV 1
-#ifdef HAVE_IPP
+#if 0 //defined HAVE_IPP
 #if !IPP_DISABLE_MORPH_ADV
 namespace cv {
 static bool ipp_morphologyEx(int op, InputArray _src, OutputArray _dst,
@@ -2064,7 +2064,7 @@ void cv::morphologyEx( InputArray _src, OutputArray _dst, int op,
     Mat dst = _dst.getMat();
 
 #if !IPP_DISABLE_MORPH_ADV
-    CV_IPP_RUN_FAST(ipp_morphologyEx(op, src, dst, kernel, anchor, iterations, borderType, borderValue));
+    //CV_IPP_RUN_FAST(ipp_morphologyEx(op, src, dst, kernel, anchor, iterations, borderType, borderValue));
 #endif
 
     switch( op )

--- a/modules/imgproc/src/smooth.cpp
+++ b/modules/imgproc/src/smooth.cpp
@@ -1459,7 +1459,7 @@ namespace cv
 }
 #endif
 
-#if defined(HAVE_IPP)
+#if 0 //defined(HAVE_IPP)
 namespace cv
 {
 static bool ipp_boxfilter(Mat &src, Mat &dst, Size ksize, Point anchor, bool normalize, int borderType)
@@ -1549,7 +1549,7 @@ void cv::boxFilter( InputArray _src, OutputArray _dst, int ddepth,
     CV_OVX_RUN(true,
                openvx_boxfilter(src, dst, ddepth, ksize, anchor, normalize, borderType))
 
-    CV_IPP_RUN_FAST(ipp_boxfilter(src, dst, ksize, anchor, normalize, borderType));
+    //CV_IPP_RUN_FAST(ipp_boxfilter(src, dst, ksize, anchor, normalize, borderType));
 
     borderType = (borderType&~BORDER_ISOLATED);
 
@@ -3952,7 +3952,7 @@ static bool openvx_gaussianBlur(InputArray _src, OutputArray _dst, Size ksize,
 
 #endif
 
-#ifdef HAVE_IPP
+#if 0 //defined HAVE_IPP
 // IW 2017u2 has bug which doesn't allow use of partial inMem with tiling
 #if IPP_DISABLE_GAUSSIANBLUR_PARALLEL
 #define IPP_GAUSSIANBLUR_PARALLEL 0
@@ -4123,7 +4123,7 @@ void cv::GaussianBlur( InputArray _src, OutputArray _dst, Size ksize,
     CV_OVX_RUN(true,
                openvx_gaussianBlur(src, dst, ksize, sigma1, sigma2, borderType))
 
-    CV_IPP_RUN_FAST(ipp_GaussianBlur(src, dst, ksize, sigma1, sigma2, borderType));
+    //CV_IPP_RUN_FAST(ipp_GaussianBlur(src, dst, ksize, sigma1, sigma2, borderType));
 
     if(sdepth == CV_8U && ((borderType & BORDER_ISOLATED) || !_src.getMat().isSubmatrix()))
     {


### PR DESCRIPTION
the functions where IPP was disabled: *Sobel, Scharr, medianBlur, GaussianBlur, filter2D, mean, meanStdDev, sum, minMaxIdx, sort*.

`opencv_core` size is reduced by ~2Mb (19 down to 17), `opencv_imgproc` size is reduced by ~24Mb (45 down to 21); other modules did not change, but they are much smaller than core and imgproc.

The patch should not affect OpenCV performance much, since each of those functions is either very fast as-is, or optimized with SIMD instructions, or both. `cv::filter2D` uses IPP-optimized DFT, so the performance should not drop either.