### PR TITLE
OCL: core: run "reduce" kernels in synchronous mode

### DIFF
--- a/modules/core/src/sum.cpp
+++ b/modules/core/src/sum.cpp
@@ -520,7 +520,7 @@ bool ocl_sum( InputArray _src, Scalar & res, int sum_op, InputArray _mask,
     }
 
     size_t globalsize = ngroups * wgs;
-    if (k.run(1, &globalsize, &wgs, false))
+    if (k.run(1, &globalsize, &wgs, true))
     {
         typedef Scalar (*part_sum)(Mat m);
         part_sum funcs[3] = { ocl_part_sum<int>, ocl_part_sum<float>, ocl_part_sum<double> },

--- a/modules/core/src/umatrix.cpp
+++ b/modules/core/src/umatrix.cpp
@@ -1168,7 +1168,7 @@ static bool ocl_dot( InputArray _src1, InputArray _src2, double & res )
     k.args(src1arg, src1.cols, (int)src1.total(), dbsize, dbarg, src2arg);
 
     size_t globalsize = dbsize * wgs;
-    if (k.run(1, &globalsize, &wgs, false))
+    if (k.run(1, &globalsize, &wgs, true))
     {
         res = sum(db.getMat(ACCESS_READ))[0];
         return true;


### PR DESCRIPTION
Workaround to avoid OpenCL runtime crashing due large amount of kernel events.

relates #13087

<cut />

One of possible Linux crash point:
https://github.com/intel/compute-runtime/blob/18.33.11309/runtime/os_interface/linux/drm_buffer_object.cpp#L167


```
buildworker:Linux AVX2=linux-3
```