### PR TITLE
Fix missing intrin.hpp header in dis_flow.cpp

### DIFF
--- a/modules/video/src/dis_flow.cpp
+++ b/modules/video/src/dis_flow.cpp
@@ -41,6 +41,7 @@
 //M*/
 
 #include "precomp.hpp"
+#include "opencv2/core/hal/intrin.hpp"
 #include "opencl_kernels_video.hpp"
 
 using namespace std;
@@ -517,7 +518,7 @@ inline float processPatch(float &dst_dUx, float &dst_dUy, uchar *I0_ptr, uchar *
                           int I0_stride, int I1_stride, float w00, float w01, float w10, float w11, int patch_sz)
 {
     float SSD = 0.0f;
-#ifdef CV_SIMD128
+#if CV_SIMD128
     if (patch_sz == 8)
     {
         /* Variables to accumulate the sums */
@@ -569,7 +570,7 @@ inline float processPatch(float &dst_dUx, float &dst_dUy, uchar *I0_ptr, uchar *
                 dst_dUx += diff * I0x_ptr[i * I0_stride + j];
                 dst_dUy += diff * I0y_ptr[i * I0_stride + j];
             }
-#ifdef CV_SIMD128
+#if CV_SIMD128
     }
 #endif
     return SSD;
@@ -586,7 +587,7 @@ inline float processPatchMeanNorm(float &dst_dUx, float &dst_dUy, uchar *I0_ptr,
     float sum_I0x_mul = 0.0, sum_I0y_mul = 0.0;
     float n = (float)patch_sz * patch_sz;
 
-#ifdef CV_SIMD128
+#if CV_SIMD128
     if (patch_sz == 8)
     {
         /* Variables to accumulate the sums */
@@ -641,7 +642,7 @@ inline float processPatchMeanNorm(float &dst_dUx, float &dst_dUy, uchar *I0_ptr,
                 sum_I0x_mul += diff * I0x_ptr[i * I0_stride + j];
                 sum_I0y_mul += diff * I0y_ptr[i * I0_stride + j];
             }
-#ifdef CV_SIMD128
+#if CV_SIMD128
     }
 #endif
     dst_dUx = sum_I0x_mul - sum_diff * x_grad_sum / n;
@@ -654,7 +655,7 @@ inline float computeSSD(uchar *I0_ptr, uchar *I1_ptr, int I0_stride, int I1_stri
                         float w11, int patch_sz)
 {
     float SSD = 0.0f;
-#ifdef CV_SIMD128
+#if CV_SIMD128
     if (patch_sz == 8)
     {
         v_float32x4 SSD_vec = v_setall_f32(0);
@@ -679,7 +680,7 @@ inline float computeSSD(uchar *I0_ptr, uchar *I1_ptr, int I0_stride, int I1_stri
                        I0_ptr[i * I0_stride + j];
                 SSD += diff * diff;
             }
-#ifdef CV_SIMD128
+#if CV_SIMD128
     }
 #endif
     return SSD;
@@ -691,7 +692,7 @@ inline float computeSSDMeanNorm(uchar *I0_ptr, uchar *I1_ptr, int I0_stride, int
 {
     float sum_diff = 0.0f, sum_diff_sq = 0.0f;
     float n = (float)patch_sz * patch_sz;
-#ifdef CV_SIMD128
+#if CV_SIMD128
     if (patch_sz == 8)
     {
         v_float32x4 sum_diff_vec = v_setall_f32(0);
@@ -721,7 +722,7 @@ inline float computeSSDMeanNorm(uchar *I0_ptr, uchar *I1_ptr, int I0_stride, int
                 sum_diff += diff;
                 sum_diff_sq += diff * diff;
             }
-#ifdef CV_SIMD128
+#if CV_SIMD128
     }
 #endif
     return sum_diff_sq - sum_diff * sum_diff / n;

--- a/modules/video/src/variational_refinement.cpp
+++ b/modules/video/src/variational_refinement.cpp
@@ -595,7 +595,7 @@ void VariationalRefinementImpl::ComputeDataTerm_ParBody::operator()(const Range 
 #undef INIT_ROW_POINTERS
 
         int j = 0;
-#ifdef CV_SIMD128
+#if CV_SIMD128
         v_float32x4 zeta_vec = v_setall_f32(zeta_squared);
         v_float32x4 eps_vec = v_setall_f32(epsilon_squared);
         v_float32x4 delta_vec = v_setall_f32(delta2);
@@ -801,7 +801,7 @@ void VariationalRefinementImpl::ComputeSmoothnessTermHorPass_ParBody::operator()
     pA_v_next[j] += pWeight[j];
 
         int j = 0;
-#ifdef CV_SIMD128
+#if CV_SIMD128
         v_float32x4 alpha2_vec = v_setall_f32(alpha2);
         v_float32x4 eps_vec = v_setall_f32(epsilon_squared);
         v_float32x4 cW_u_vec, cW_v_vec;
@@ -911,7 +911,7 @@ void VariationalRefinementImpl::ComputeSmoothnessTermVertPass_ParBody::operator(
 #undef INIT_ROW_POINTERS
 
         int j = 0;
-#ifdef CV_SIMD128
+#if CV_SIMD128
         v_float32x4 pWeight_vec, uy_vec, vy_vec;
         for (; j < len - 3; j += 4)
         {
@@ -1013,7 +1013,7 @@ void VariationalRefinementImpl::RedBlackSOR_ParBody::operator()(const Range &ran
 #undef INIT_ROW_POINTERS
 
         j = 0;
-#ifdef CV_SIMD128
+#if CV_SIMD128
         v_float32x4 pW_prev_vec = v_setall_f32(pW_next[-1]);
         v_float32x4 pdu_prev_vec = v_setall_f32(pdu_next[-1]);
         v_float32x4 pdv_prev_vec = v_setall_f32(pdv_next[-1]);


### PR DESCRIPTION
resolves opencv/opencv_contrib#1894

Geometric mean (ms)

|Name of Test|before|after|before vs after (x-factor)|
|---|:-:|:-:|:-:|
|perf::DenseOpticalFlow_DIS::("PRESET_FAST", 640x480)|14.602|13.442|1.09|
|perf::DenseOpticalFlow_DIS::("PRESET_FAST", 1280x720)|40.623|36.206|1.12|
|perf::DenseOpticalFlow_DIS::("PRESET_FAST", 1920x1080)|86.579|77.698|1.11|
|perf::DenseOpticalFlow_DIS::("PRESET_MEDIUM", 640x480)|53.288|41.514|1.28|
|perf::DenseOpticalFlow_DIS::("PRESET_MEDIUM", 1280x720)|177.925|137.496|1.29|
|perf::DenseOpticalFlow_DIS::("PRESET_MEDIUM", 1920x1080)|436.096|332.447|1.31|
|perf::DenseOpticalFlow_DIS::("PRESET_ULTRAFAST", 640x480)|7.564|6.485|1.17|
|perf::DenseOpticalFlow_DIS::("PRESET_ULTRAFAST", 1280x720)|23.024|19.151|1.20|
|perf::DenseOpticalFlow_DIS::("PRESET_ULTRAFAST", 1920x1080)|49.114|38.910|1.26|
|perf::OCL_DenseOpticalFlow_DIS::("PRESET_FAST", 640x480)|15.049|14.310|1.05|
|perf::OCL_DenseOpticalFlow_DIS::("PRESET_FAST", 1280x720)|40.428|36.169|1.12|
|perf::OCL_DenseOpticalFlow_DIS::("PRESET_FAST", 1920x1080)|84.386|76.711|1.10|
|perf::OCL_DenseOpticalFlow_DIS::("PRESET_MEDIUM", 640x480)|48.509|37.854|1.28|
|perf::OCL_DenseOpticalFlow_DIS::("PRESET_MEDIUM", 1280x720)|156.342|123.468|1.27|
|perf::OCL_DenseOpticalFlow_DIS::("PRESET_MEDIUM", 1920x1080)|390.009|288.881|1.35|
|perf::OCL_DenseOpticalFlow_DIS::("PRESET_ULTRAFAST", 640x480)|10.223|9.721|1.05|
|perf::OCL_DenseOpticalFlow_DIS::("PRESET_ULTRAFAST", 1280x720)|28.411|23.203|1.22|
|perf::OCL_DenseOpticalFlow_DIS::("PRESET_ULTRAFAST", 1920x1080)|58.171|48.353|1.20|
