### PR TITLE
Add a test for FileNode::keys()

### DIFF
--- a/modules/core/src/persistence_cpp.cpp
+++ b/modules/core/src/persistence_cpp.cpp
@@ -271,14 +271,13 @@ FileNode FileNode::operator[](int i) const
 
 std::vector<String> FileNode::keys() const
 {
+    CV_Assert(isMap());
+
     std::vector<String> res;
-    if (isMap())
+    res.reserve(size());
+    for (FileNodeIterator it = begin(); it != end(); ++it)
     {
-        res.reserve(size());
-        for (FileNodeIterator it = begin(); it != end(); ++it)
-        {
-            res.push_back((*it).name());
-        }
+        res.push_back((*it).name());
     }
     return res;
 }

--- a/modules/core/test/test_io.cpp
+++ b/modules/core/test/test_io.cpp
@@ -1597,6 +1597,12 @@ TEST(Core_InputOutput, FileStorage_json_bool)
     ASSERT_EQ((int)fs["map_value"]["bool_true"], 1);
     ASSERT_EQ((std::string)fs["map_value"]["str_false"], "false");
     ASSERT_EQ((int)fs["bool_false"], 0);
+
+    std::vector<String> keys = fs["map_value"].keys();
+    ASSERT_EQ((int)keys.size(), 3);
+    ASSERT_EQ(keys[0], "int_value");
+    ASSERT_EQ(keys[1], "bool_true");
+    ASSERT_EQ(keys[2], "str_false");
     fs.release();
 }
 


### PR DESCRIPTION
<!-- Please use this line to close one or multiple issues when this pullrequest gets merged
You can add another line right under the first one:
resolves #1234
resolves #1235
-->

### This pullrequest changes

To align 3.4 with https://github.com/opencv/opencv/pull/13123 considering https://github.com/opencv/opencv/pull/12641/files#r221050674