### PR TITLE
DNN: Add support for ConvTranspose when parsing ONNX

### DIFF
--- a/modules/dnn/src/onnx/onnx_importer.cpp
+++ b/modules/dnn/src/onnx/onnx_importer.cpp
@@ -508,6 +508,16 @@ void ONNXImporter::populateNet(Net dstNet)
             layerParams.set("num_output", layerParams.blobs[0].size[0]);
             layerParams.set("bias_term", node_proto.input_size() == 3);
         }
+        else if (layer_type == "ConvTranspose")
+        {
+            CV_Assert(node_proto.input_size() >= 2);
+            layerParams.type = "Deconvolution";
+            for (int j = 1; j < node_proto.input_size(); j++) {
+                layerParams.blobs.push_back(getBlob(node_proto, constBlobs, j));
+            }
+            layerParams.set("num_output", layerParams.blobs[0].size[1]);
+            layerParams.set("bias_term", node_proto.input_size() == 3);
+        }
         else if (layer_type == "Transpose")
         {
             layerParams.type = "Permute";

--- a/modules/dnn/test/test_onnx_importer.cpp
+++ b/modules/dnn/test/test_onnx_importer.cpp
@@ -68,6 +68,12 @@ TEST_P(Test_ONNX_layers, Convolution)
     testONNXModels("two_convolution");
 }
 
+TEST_P(Test_ONNX_layers, Deconvolution)
+{
+    testONNXModels("deconvolution");
+    testONNXModels("two_deconvolution");
+}
+
 TEST_P(Test_ONNX_layers, Dropout)
 {
     testONNXModels("dropout");


### PR DESCRIPTION
**Merge with extra**: https://github.com/opencv/opencv_extra/pull/551

This tiny patch adds support for parsing ONNX files containing "ConvTranspose" layer. The existing Deconvolution implementation is capable of handling those, only the mapping was missing.

```
opencv_extra=add_transposedConv_onnx
```