### PR TITLE
videoio(v4l): turn off normalization of V4L properties

### DIFF
--- a/modules/videoio/src/cap_v4l.cpp
+++ b/modules/videoio/src/cap_v4l.cpp
@@ -775,7 +775,7 @@ bool CvCaptureCAM_V4L::open(const char* _deviceName)
     frame_allocated = false;
     deviceName = _deviceName;
     returnFrame = true;
-    normalizePropRange = utils::getConfigurationParameterBool("OPENCV_VIDEOIO_V4L_RANGE_NORMALIZED", true);
+    normalizePropRange = utils::getConfigurationParameterBool("OPENCV_VIDEOIO_V4L_RANGE_NORMALIZED", false);
     channelNumber = -1;
     bufferIndex = -1;
 


### PR DESCRIPTION
relates #12893

/cc @aleksey-nikolaev @paroj 