### PR TITLE
doc(tutorial_py_fourier_transform): Correct errors in tutorial

### DIFF
--- a/doc/py_tutorials/py_imgproc/py_transforms/py_fourier_transform/py_fourier_transform.markdown
+++ b/doc/py_tutorials/py_imgproc/py_transforms/py_fourier_transform/py_fourier_transform.markdown
@@ -79,11 +79,11 @@ using **np.ifft2()** function. The result, again, will be a complex number. You 
 absolute value.
 @code{.py}
 rows, cols = img.shape
-crow,ccol = rows/2 , cols/2
-fshift[crow-30:crow+30, ccol-30:ccol+30] = 0
+crow,ccol = rows//2 , cols//2
+fshift[crow-30:crow+31, ccol-30:ccol+31] = 0
 f_ishift = np.fft.ifftshift(fshift)
 img_back = np.fft.ifft2(f_ishift)
-img_back = np.abs(img_back)
+img_back = np.real(img_back)
 
 plt.subplot(131),plt.imshow(img, cmap = 'gray')
 plt.title('Input Image'), plt.xticks([]), plt.yticks([])


### PR DESCRIPTION
for integer division and filter symmetry.

resolves #13139 

### This pullrequest changes
Changes the second snippet of example code lines 2, 3, and 6.
- Changes the calculation of `crow` and `ccol` to use integer division since they're used as indices for slicing.
- Changes the slicing on line 3 to have symmetry.
- Change call from `np.abs()` to `np.real()` as a symmetric filter from the previous change will cause a real value to be calculated in the inverse transform.


<!--**WIP**-->
```
force_builders=linux,docs
```