### PR TITLE
Fix Vulkan's max pooling in case of no output indices

### DIFF
--- a/modules/dnn/src/vkcom/src/op_pool.cpp
+++ b/modules/dnn/src/vkcom/src/op_pool.cpp
@@ -90,16 +90,10 @@ bool OpPool::forward(std::vector<Tensor>& ins,
                      std::vector<Tensor>& blobs,
                      std::vector<Tensor>& outs)
 {
-    for (size_t ii = 0; ii < ins.size(); ii++)
-    {
-        Tensor& inpMat = ins[ii];
-        int out_index = (pool_type_ == kPoolTypeMax) ? 2 : 1;
-        Tensor& outMat = outs[out_index * ii];
-        Tensor maskMat = (pool_type_ == kPoolTypeMax) ? outs[2 * ii + 1] : Tensor();
-        if (!forward(inpMat, outMat, maskMat))
-            return false;
-    }
-    return true;
+    Tensor& inpMat = ins[0];
+    Tensor& outMat = outs[0];
+    Tensor maskMat = outs.size() > 1 ? outs[1] : Tensor();
+    return forward(inpMat, outMat, maskMat);
 }
 
 bool OpPool::forward(Tensor& in, Tensor& out, Tensor& mask)


### PR DESCRIPTION
### This pullrequest changes

Fix a bug with Vulkan's max pooling considering optimization from https://github.com/opencv/opencv/pull/13065

```
docker_image:Custom=ubuntu-vulkan:16.04
buildworker:Custom=linux-4
test_bigdata:Custom=1
test_module=dnn
tests_filter=*
**WIP**
```