### PR TITLE
highgui: Qt - restore convertscale semantics

### DIFF
--- a/modules/highgui/src/window_QT.cpp
+++ b/modules/highgui/src/window_QT.cpp
@@ -2557,7 +2557,14 @@ void DefaultViewPort::updateImage(const CvArr* arr)
     nbChannelOriginImage = cvGetElemType(mat);
     CV_Assert(origin == 0);
     cv::Mat src = cv::cvarrToMat(mat), dst = cv::cvarrToMat(image2Draw_mat);
-    cv::cvtColor(src, dst, cv::COLOR_BGR2RGB, dst.channels());
+
+    cv::Mat tmp;
+    int src_depth = src.depth();
+    double scale = src_depth <= CV_8S ? 1 : src_depth <= CV_32S ? 1./256 : 255;
+    double shift = src_depth == CV_8S || src_depth == CV_16S ? 128 : 0;
+    cv::convertScaleAbs(src, tmp, scale, shift);
+
+    cv::cvtColor(tmp, dst, cv::COLOR_BGR2RGB, dst.channels());
     CV_Assert(dst.data == image2Draw_mat->data.ptr);
 
     viewport()->update();


### PR DESCRIPTION
broken in 11eafca3e2a4cbc62f1309d25db0ea3ed9a6ea8e
