### PR TITLE
core: move dims() check to the top in copyMakeBorder()

### DIFF
--- a/modules/core/src/copy.cpp
+++ b/modules/core/src/copy.cpp
@@ -1186,9 +1186,9 @@ void cv::copyMakeBorder( InputArray _src, OutputArray _dst, int top, int bottom,
 {
     CV_INSTRUMENT_REGION();
 
-    CV_Assert( top >= 0 && bottom >= 0 && left >= 0 && right >= 0 );
+    CV_Assert( top >= 0 && bottom >= 0 && left >= 0 && right >= 0 && _src.dims() <= 2);
 
-    CV_OCL_RUN(_dst.isUMat() && _src.dims() <= 2,
+    CV_OCL_RUN(_dst.isUMat(),
                ocl_copyMakeBorder(_src, _dst, top, bottom, left, right, borderType, value))
 
     Mat src = _src.getMat();


### PR DESCRIPTION
resolves #13180

since none of the implemented branches can handle more than 2 dimensions,
move the dims() check from the CV_OCL_RUN up, so it gets checked for all of them