### PR TITLE
fix numThreadsMax for OpenMP

### DIFF
--- a/modules/core/src/parallel.cpp
+++ b/modules/core/src/parallel.cpp
@@ -427,7 +427,7 @@ static inline int _initMaxThreads()
     {
         omp_set_dynamic(maxThreads);
     }
-    return numThreads;
+    return maxThreads;
 }
 static int numThreadsMax = _initMaxThreads();
 #elif defined HAVE_GCD


### PR DESCRIPTION
introduced by commit 4e629000095779ae8f544ddd4de77633680a3db9

resolves #13207

Through fixed, but I have no idea about the different behavior between running in main thread and a separate thread due to I don't familiar with OpenMP.
