### PR TITLE
highgui: restore convertscale semantics in window_w32.cpp

### DIFF
--- a/modules/highgui/src/window_w32.cpp
+++ b/modules/highgui/src/window_w32.cpp
@@ -1154,7 +1154,6 @@ cvShowImage( const char* name, const CvArr* arr )
     int channels = 0;
     void* dst_ptr = 0;
     const int channels0 = 3;
-    int origin = 0;
     CvMat stub, *image;
     bool changed_size = false; // philipg
 
@@ -1170,9 +1169,6 @@ cvShowImage( const char* name, const CvArr* arr )
 
     if( !window || !arr )
         EXIT; // keep silence here.
-
-    if( CV_IS_IMAGE_HDR( arr ))
-        origin = ((IplImage*)arr)->origin;
 
     CV_CALL( image = cvGetMat( arr, &stub ));
 
@@ -1212,21 +1208,15 @@ cvShowImage( const char* name, const CvArr* arr )
     {
         cv::Mat src = cv::cvarrToMat(image);
         cv::Mat dst(size.cy, size.cx, CV_8UC3, dst_ptr, (size.cx * channels + 3) & -4);
-        if (src.channels() == 1)
-        {
-            cv::cvtColor(src, dst, cv::COLOR_GRAY2BGR);
-            cv::flip(dst, dst, 0);
-        }
-        else if (src.channels() == 4)
-        {
-            cv::cvtColor(src, dst, cv::COLOR_BGRA2BGR);
-            cv::flip(dst, dst, 0);
-        }
-        else
-        {
-            CV_Assert(src.channels() == 3);
-            cv::flip(src, dst, 0);
-        }
+
+        cv::Mat tmp;
+        int src_depth = src.depth();
+        double scale = src_depth <= CV_8S ? 1 : src_depth <= CV_32S ? 1./256 : 255;
+        double shift = src_depth == CV_8S || src_depth == CV_16S ? 128 : 0;
+        cv::convertScaleAbs(src, tmp, scale, shift);
+        cv::cvtColor(tmp, dst, cv::COLOR_BGRA2BGR, dst.channels());
+        cv::flip(dst, dst, 0);
+
         CV_Assert(dst.data == (uchar*)dst_ptr);
     }
 


### PR DESCRIPTION
related: #13216 (it's only a partial fix)

similar to #13184

also remove the unused `origin` variable in cvShowImage (the origin is constant [here](https://github.com/opencv/opencv/pull/13184))