### PR TITLE
Fix missing check part (defined(__cplusplus)) in header types_c.h

### DIFF
--- a/modules/core/include/opencv2/core/types_c.h
+++ b/modules/core/include/opencv2/core/types_c.h
@@ -364,7 +364,7 @@ IplImage;
 
 CV_INLINE IplImage cvIplImage()
 {
-#if !defined(CV__ENABLE_C_API_CTORS)
+#if !(defined(CV__ENABLE_C_API_CTORS) && defined(__cplusplus))
     IplImage self = CV_STRUCT_INITIALIZER; self.nSize = sizeof(IplImage); return self;
 #else
     return _IplImage();


### PR DESCRIPTION
<!-- Please use this line to close one or multiple issues when this pullrequest gets merged
You can add another line right under the first one:
-->

### This pullrequest changes

<!-- Please describe what your pullrequest is changing -->
Fix a missing part of a check for the cvUplImage() function. If compiling in c, the compiler could tried to use the c++ constructer and return an error.
