### PR TITLE
cmake: allow to disable ADE build

### DIFF
--- a/modules/gapi/cmake/init.cmake
+++ b/modules/gapi/cmake/init.cmake
@@ -1,3 +1,9 @@
+OCV_OPTION(WITH_ADE "Enable ADE framework (required for Graph API module)" ON)
+
+if(NOT WITH_ADE)
+  return()
+endif()
+
 if (ade_DIR)
   # if ade_DIR is set, use ADE-supplied CMake script
   # to set up variables to the prebuilt ADE


### PR DESCRIPTION
`BUILD_opencv_gapi=OFF` is not enough.

CMake option: `WITH_ADE=OFF`.

resolves #12856
