### PR TITLE
Fix ONNX's emotion_ferplus model.

### DIFF
--- a/modules/dnn/src/onnx/onnx_importer.cpp
+++ b/modules/dnn/src/onnx/onnx_importer.cpp
@@ -358,7 +358,8 @@ void ONNXImporter::populateNet(Net dstNet)
                     layerParams.set("shift", blob.at<float>(0));
                 }
                 else {
-                    layerParams.type = "Shift";
+                    layerParams.type = "Scale";
+                    layerParams.set("bias_term", true);
                     layerParams.blobs.push_back(blob);
                 }
             }
@@ -375,8 +376,26 @@ void ONNXImporter::populateNet(Net dstNet)
                 layerParams.set("shift", blob.at<float>(0));
             }
             else {
-                layerParams.type = "Shift";
+                layerParams.type = "Scale";
+                layerParams.set("has_bias", true);
                 layerParams.blobs.push_back(blob);
+            }
+        }
+        else if (layer_type == "Div")
+        {
+            Mat blob = getBlob(node_proto, constBlobs, 1);
+            CV_Assert_N(blob.type() == CV_32F, blob.total());
+            divide(1.0, blob, blob);
+            if (blob.total() == 1)
+            {
+                layerParams.set("scale", blob.at<float>(0));
+                layerParams.type = "Power";
+            }
+            else
+            {
+                layerParams.type = "Scale";
+                layerParams.blobs.push_back(blob);
+                layerParams.set("bias_term", false);
             }
         }
         else if (layer_type == "Constant")

--- a/modules/dnn/test/test_backends.cpp
+++ b/modules/dnn/test/test_backends.cpp
@@ -197,7 +197,7 @@ TEST_P(DNNTestNetwork, OpenPose_pose_coco)
         (backend == DNN_BACKEND_INFERENCE_ENGINE && target == DNN_TARGET_MYRIAD))
         throw SkipTestException("");
     processNet("dnn/openpose_pose_coco.caffemodel", "dnn/openpose_pose_coco.prototxt",
-               Size(368, 368));
+               Size(46, 46));
 }
 
 TEST_P(DNNTestNetwork, OpenPose_pose_mpi)
@@ -206,7 +206,7 @@ TEST_P(DNNTestNetwork, OpenPose_pose_mpi)
         (backend == DNN_BACKEND_INFERENCE_ENGINE && target == DNN_TARGET_MYRIAD))
         throw SkipTestException("");
     processNet("dnn/openpose_pose_mpi.caffemodel", "dnn/openpose_pose_mpi.prototxt",
-               Size(368, 368));
+               Size(46, 46));
 }
 
 TEST_P(DNNTestNetwork, OpenPose_pose_mpi_faster_4_stages)
@@ -217,7 +217,7 @@ TEST_P(DNNTestNetwork, OpenPose_pose_mpi_faster_4_stages)
     // The same .caffemodel but modified .prototxt
     // See https://github.com/CMU-Perceptual-Computing-Lab/openpose/blob/master/src/openpose/pose/poseParameters.cpp
     processNet("dnn/openpose_pose_mpi.caffemodel", "dnn/openpose_pose_mpi_faster_4_stages.prototxt",
-               Size(368, 368));
+               Size(46, 46));
 }
 
 TEST_P(DNNTestNetwork, OpenFace)


### PR DESCRIPTION
<!-- Please use this line to close one or multiple issues when this pullrequest gets merged
You can add another line right under the first one:
resolves #1234
resolves #1235
-->

### This pullrequest changes

* Fix updated Emotion_ferplus model in ONNX format
* Reduce inputs for OpenPose tests in 8 times to speedup tests.

```
docker_image:Custom=ubuntu-openvino:16.04
buildworker:Custom=linux-2
test_opencl:Custom=OFF
```