### PR TITLE
androidcamera: add a missing header.

### DIFF
--- a/modules/androidcamera/src/camera_activity.cpp
+++ b/modules/androidcamera/src/camera_activity.cpp
@@ -7,6 +7,7 @@
 #include <string>
 #include <vector>
 #include <algorithm>
+#include <functional>
 #include <opencv2/core/version.hpp>
 #include "camera_activity.hpp"
 #include "camera_wrapper.h"


### PR DESCRIPTION
resolves #11699 Missing std header

### This pullrequest changes
This Pull Request add `<functional>` header to fix #11699, which is a compile error when we build androidcamera module on 2.4 branch.

```
buildworker:Linux x64 Debug=linux-1
```
