### PR TITLE
dnn/Vulkan: make thread safe

### DIFF
--- a/modules/dnn/src/vkcom/src/common.hpp
+++ b/modules/dnn/src/vkcom/src/common.hpp
@@ -33,6 +33,7 @@ extern VkPhysicalDevice kPhysicalDevice;
 extern VkDevice kDevice;
 extern VkQueue kQueue;
 extern VkCommandPool kCmdPool;
+extern cv::Mutex kContextMtx;
 
 enum ShapeIdx
 {

--- a/modules/dnn/src/vkcom/src/context.cpp
+++ b/modules/dnn/src/vkcom/src/context.cpp
@@ -25,6 +25,7 @@ VkDebugReportCallbackEXT kDebugReportCallback;
 uint32_t kQueueFamilyIndex;
 std::vector<const char *> kEnabledLayers;
 std::map<std::string, std::vector<uint32_t>> kShaders;
+cv::Mutex kContextMtx;
 
 static uint32_t getComputeQueueFamilyIndex()
 {
@@ -86,7 +87,7 @@ VKAPI_ATTR VkBool32 VKAPI_CALL debugReportCallbackFn(
 // internally used
 void createContext()
 {
-    cv::AutoLock lock(getInitializationMutex());
+    cv::AutoLock lock(kContextMtx);
     if (!kCtx)
     {
         kCtx.reset(new Context());


### PR DESCRIPTION
Use a global dedicated mutex to make sure initialize once and
protect command buffer pool and queue.

Signed-off-by: Wu Zhiwen <zhiwen.wu@intel.com>

```
docker_image:Custom=ubuntu-vulkan:16.04
buildworker:Custom=linux-4
```