### PR TITLE
Fixed NEON detection in Carotene build

### DIFF
--- a/3rdparty/carotene/hal/CMakeLists.txt
+++ b/3rdparty/carotene/hal/CMakeLists.txt
@@ -53,7 +53,7 @@ endif()
 set(CAROTENE_NS "carotene_o4t" CACHE STRING "" FORCE)
 
 function(compile_carotene)
-  if(ENABLE_NEON)
+  if(";${CPU_BASELINE_FINAL};" MATCHES ";NEON;")
     set(WITH_NEON ON)
   endif()
 


### PR DESCRIPTION
resolves #13238 

### This pullrequest changes

`ENABLE_NEON` is deprecated now, but it was used in Carotene library build to detect NEON.
