### PR TITLE
Made FileNode::operator string inline

### DIFF
--- a/modules/core/include/opencv2/core/persistence.hpp
+++ b/modules/core/include/opencv2/core/persistence.hpp
@@ -565,7 +565,7 @@ public:
     //! returns the node content as double
     operator double() const;
     //! returns the node content as text string
-    operator std::string() const;
+    inline operator std::string() const { return this->string(); }
 
     static bool isMap(int flags);
     static bool isSeq(int flags);
@@ -599,7 +599,7 @@ public:
     //! Simplified reading API to use with bindings.
     CV_WRAP double real() const;
     //! Simplified reading API to use with bindings.
-    CV_WRAP String string() const;
+    CV_WRAP std::string string() const;
     //! Simplified reading API to use with bindings.
     CV_WRAP Mat mat() const;
 

--- a/modules/core/src/persistence.cpp
+++ b/modules/core/src/persistence.cpp
@@ -2197,7 +2197,8 @@ FileNode::operator double() const
         return DBL_MAX;
 }
 
-FileNode::operator std::string() const
+double FileNode::real() const  { return double(*this); }
+std::string FileNode::string() const
 {
     const uchar* p = ptr();
     if( !p || (*p & TYPE_MASK) != STRING )
@@ -2206,9 +2207,6 @@ FileNode::operator std::string() const
     size_t sz = (size_t)(unsigned)readInt(p);
     return std::string((const char*)(p + 4), sz - 1);
 }
-
-double FileNode::real() const  { return double(*this); }
-std::string FileNode::string() const { return std::string(*this); }
 Mat FileNode::mat() const { Mat value; read(*this, value, Mat()); return value; }
 
 FileNodeIterator FileNode::begin() const { return FileNodeIterator(*this, false); }


### PR DESCRIPTION
### This pullrequest changes

Fixed problem with symbol compatibility between GCC 5-6 and Clang.
`FileNode::operator string() const `  is generated differently and causes link-time errors.

https://www.gnu.org/software/gcc/gcc-7/porting_to.html - "Mangling change for conversion operators"