### PR TITLE
Fixed misleading indentation warning in intrin_cpp.hpp

### DIFF
--- a/modules/core/include/opencv2/core/hal/intrin_cpp.hpp
+++ b/modules/core/include/opencv2/core/hal/intrin_cpp.hpp
@@ -686,10 +686,10 @@ OPENCV_HAL_IMPL_CMP_OP(!=)
 template<int n>
 inline v_reg<float, n> v_not_nan(const v_reg<float, n>& a)
 {
-typedef typename V_TypeTraits<float>::int_type itype;
-v_reg<float, n> c;
-for (int i = 0; i < n; i++)
-    c.s[i] = V_TypeTraits<float>::reinterpret_from_int((itype)-(int)(a.s[i] == a.s[i]));
+    typedef typename V_TypeTraits<float>::int_type itype;
+    v_reg<float, n> c;
+    for (int i = 0; i < n; i++)
+        c.s[i] = V_TypeTraits<float>::reinterpret_from_int((itype)-(int)(a.s[i] == a.s[i]));
     return c;
 }
 template<int n>


### PR DESCRIPTION
### This pullrequest changes

```
/opencv/modules/core/include/opencv2/core/hal/intrin_cpp.hpp:691:1: 
warning: this 'for' clause does not guard... [-Wmisleading-indentation]                                                    
 for (int i = 0; i < n; i++)                                                      
 ^~~                                                                    
/opencv/modules/core/include/opencv2/core/hal/intrin_cpp.hpp:693:5: 
note: ...this statement, but the latter is misleadingly indented as if it is 
guarded by the 'for'            
     return c;                                                   
     ^~~~~~ 
```

