### PR TITLE
Fix VideoCapture_LibRealsense

### DIFF
--- a/modules/videoio/include/opencv2/videoio.hpp
+++ b/modules/videoio/include/opencv2/videoio.hpp
@@ -526,7 +526,8 @@ enum { CAP_PROP_INTELPERC_PROFILE_COUNT               = 11001,
 //! Intel Perceptual Streams
 enum { CAP_INTELPERC_DEPTH_GENERATOR = 1 << 29,
        CAP_INTELPERC_IMAGE_GENERATOR = 1 << 28,
-       CAP_INTELPERC_GENERATORS_MASK = CAP_INTELPERC_DEPTH_GENERATOR + CAP_INTELPERC_IMAGE_GENERATOR
+       CAP_INTELPERC_IR_GENERATOR    = 1 << 27,
+       CAP_INTELPERC_GENERATORS_MASK = CAP_INTELPERC_DEPTH_GENERATOR + CAP_INTELPERC_IMAGE_GENERATOR + CAP_INTELPERC_IR_GENERATOR
      };
 
 enum { CAP_INTELPERC_DEPTH_MAP              = 0, //!< Each pixel is a 16-bit integer. The value indicates the distance from an object to the camera's XY plane or the Cartesian depth.

--- a/modules/videoio/src/cap_librealsense.cpp
+++ b/modules/videoio/src/cap_librealsense.cpp
@@ -27,15 +27,147 @@ VideoCapture_LibRealsense::VideoCapture_LibRealsense(int) : mAlign(RS2_STREAM_CO
 }
 VideoCapture_LibRealsense::~VideoCapture_LibRealsense(){}
 
-double VideoCapture_LibRealsense::getProperty(int prop) const
+double VideoCapture_LibRealsense::getProperty(int propIdx) const
 {
-    double propValue = 0;
+    double propValue = 0.0;
 
-    if (prop == CAP_PROP_INTELPERC_DEPTH_SATURATION_VALUE)
-        return mPipe.get_active_profile().get_device().first<rs2::depth_sensor>().get_depth_scale();
+    const int purePropIdx = propIdx & ~CAP_INTELPERC_GENERATORS_MASK;
+    if((propIdx & CAP_INTELPERC_GENERATORS_MASK) == CAP_INTELPERC_IMAGE_GENERATOR)
+    {
+        propValue = getImageGeneratorProperty(purePropIdx);
+    }
+    else if((propIdx & CAP_INTELPERC_GENERATORS_MASK) == CAP_INTELPERC_DEPTH_GENERATOR)
+    {
+        propValue = getDepthGeneratorProperty(purePropIdx);
+    }
+    else if((propIdx & CAP_INTELPERC_GENERATORS_MASK) == CAP_INTELPERC_IR_GENERATOR)
+    {
+        propValue = getIrGeneratorProperty(purePropIdx);
+    }
+    else
+    {
+        propValue = getCommonProperty(purePropIdx);
+    }
 
     return propValue;
 }
+
+double VideoCapture_LibRealsense::getImageGeneratorProperty(int propIdx) const
+{
+    double propValue = 0.0;
+    const rs2::video_stream_profile profile = mPipe.get_active_profile().get_stream(RS2_STREAM_COLOR).as<rs2::video_stream_profile>();
+    if(!profile)
+    {
+        return propValue;
+    }
+
+    switch(propIdx)
+    {
+    case CAP_PROP_FRAME_WIDTH:
+        propValue = static_cast<double>(profile.width());
+        break;
+    case CAP_PROP_FRAME_HEIGHT:
+        propValue = static_cast<double>(profile.height());
+        break;
+    case CAP_PROP_FPS:
+        propValue = static_cast<double>(profile.fps());
+        break;
+    }
+
+    return propValue;
+}
+
+double VideoCapture_LibRealsense::getDepthGeneratorProperty(int propIdx) const
+{
+    double propValue = 0.0;
+    const rs2::video_stream_profile profile = mPipe.get_active_profile().get_stream(RS2_STREAM_DEPTH).as<rs2::video_stream_profile>();
+    const rs2::depth_sensor sensor = mPipe.get_active_profile().get_device().first<rs2::depth_sensor>();
+    if(!profile || !sensor)
+    {
+        return propValue;
+    }
+
+    switch(propIdx)
+    {
+    case CAP_PROP_FRAME_WIDTH:
+        propValue = static_cast<double>(profile.width());
+        break;
+    case CAP_PROP_FRAME_HEIGHT:
+        propValue = static_cast<double>(profile.height());
+        break;
+    case CAP_PROP_FPS:
+        propValue = static_cast<double>(profile.fps());
+        break;
+    case CAP_PROP_INTELPERC_DEPTH_SATURATION_VALUE:
+        propValue = static_cast<double>(sensor.get_depth_scale());
+        break;
+    case CAP_PROP_INTELPERC_DEPTH_FOCAL_LENGTH_HORZ:
+        propValue = static_cast<double>(profile.get_intrinsics().fx);
+        break;
+    case CAP_PROP_INTELPERC_DEPTH_FOCAL_LENGTH_VERT:
+        propValue = static_cast<double>(profile.get_intrinsics().fy);
+        break;
+    }
+
+    return propValue;
+}
+
+double VideoCapture_LibRealsense::getIrGeneratorProperty(int propIdx) const
+{
+    double propValue = 0.0;
+    const rs2::video_stream_profile profile = mPipe.get_active_profile().get_stream(RS2_STREAM_INFRARED).as<rs2::video_stream_profile>();
+    if(!profile)
+    {
+        return propValue;
+    }
+
+    switch(propIdx)
+    {
+    case CAP_PROP_FRAME_WIDTH:
+        propValue = static_cast<double>(profile.width());
+        break;
+    case CAP_PROP_FRAME_HEIGHT:
+        propValue = static_cast<double>(profile.height());
+        break;
+    case CAP_PROP_FPS:
+        propValue = static_cast<double>(profile.fps());
+        break;
+    }
+
+    return propValue;
+}
+
+double VideoCapture_LibRealsense::getCommonProperty(int propIdx) const
+{
+    double propValue = 0.0;
+    const rs2::video_stream_profile profile = mPipe.get_active_profile().get_stream(RS2_STREAM_DEPTH).as<rs2::video_stream_profile>();
+    const rs2::depth_sensor sensor = mPipe.get_active_profile().get_device().first<rs2::depth_sensor>();
+    if(!profile || !sensor)
+    {
+        return propValue;
+    }
+
+    switch(propIdx)
+    {
+    case CAP_PROP_FRAME_WIDTH:
+    case CAP_PROP_FRAME_HEIGHT:
+    case CAP_PROP_FPS:
+        propValue = getDepthGeneratorProperty(propIdx);
+        break;
+    case CAP_PROP_INTELPERC_DEPTH_SATURATION_VALUE:
+        propValue = static_cast<double>(sensor.get_depth_scale());
+        break;
+    case CAP_PROP_INTELPERC_DEPTH_FOCAL_LENGTH_HORZ:
+        propValue = static_cast<double>(profile.get_intrinsics().fx);
+        break;
+    case CAP_PROP_INTELPERC_DEPTH_FOCAL_LENGTH_VERT:
+        propValue = static_cast<double>(profile.get_intrinsics().fy);
+        break;
+    }
+
+    return propValue;
+}
+
 bool VideoCapture_LibRealsense::setProperty(int, double)
 {
     bool isSet = false;

--- a/modules/videoio/src/cap_librealsense.cpp
+++ b/modules/videoio/src/cap_librealsense.cpp
@@ -19,7 +19,7 @@ VideoCapture_LibRealsense::VideoCapture_LibRealsense(int) : mAlign(RS2_STREAM_CO
         config.enable_stream(RS2_STREAM_DEPTH, 640, 480, RS2_FORMAT_Z16);
         config.enable_stream(RS2_STREAM_COLOR, 640, 480, RS2_FORMAT_BGR8);
         config.enable_stream(RS2_STREAM_INFRARED, 640, 480, RS2_FORMAT_Y8);
-        mPipe.start();
+        mPipe.start(config);
     }
     catch (const rs2::error&)
     {

--- a/modules/videoio/src/cap_librealsense.hpp
+++ b/modules/videoio/src/cap_librealsense.hpp
@@ -29,6 +29,11 @@ protected:
     rs2::pipeline mPipe;
     rs2::frameset mData;
     rs2::align    mAlign;
+
+    double getDepthGeneratorProperty(int propIdx) const;
+    double getImageGeneratorProperty(int propIdx) const;
+    double getIrGeneratorProperty(int propIdx) const;
+    double getCommonProperty(int propIdx) const;
 };
 
 }


### PR DESCRIPTION
### This pullrequest changes
This pullrequest will fix bug and add support get properties of VideoCapture_LibRealsense.
* Fix to apply settings by passing <code>rs2::config</code> to <code>rs2::pipeline::start()</code>.
* Add support some basic properties to <code>cv::VideoCapture::get()</code>.

```cpp
cv::VideoCapture capture( cv::VideoCaptureAPIs::CAP_INTELPERC );
if( !capture.isOpened() ){
    return -1;
}

// Image
capture.get( cv::CAP_INTELPERC_IMAGE_GENERATOR + cv::CAP_PROP_FRAME_WIDTH );
capture.get( cv::CAP_INTELPERC_IMAGE_GENERATOR + cv::CAP_PROP_FRAME_HEIGHT );
capture.get( cv::CAP_INTELPERC_IMAGE_GENERATOR + cv::CAP_PROP_FPS );

// Depth
capture.get( cv::CAP_INTELPERC_DEPTH_GENERATOR + cv::CAP_PROP_FRAME_WIDTH );
capture.get( cv::CAP_INTELPERC_DEPTH_GENERATOR + cv::CAP_PROP_FRAME_HEIGHT );
capture.get( cv::CAP_INTELPERC_DEPTH_GENERATOR + cv::CAP_PROP_FPS );
capture.get( cv::CAP_PROP_INTELPERC_DEPTH_SATURATION_VALUE );
capture.get( cv::CAP_PROP_INTELPERC_DEPTH_FOCAL_LENGTH_HORZ );
capture.get( cv::CAP_PROP_INTELPERC_DEPTH_FOCAL_LENGTH_VERT );

// Infrared
capture.get( cv::CAP_INTELPERC_IR_GENERATOR + cv::CAP_PROP_FRAME_WIDTH );
capture.get( cv::CAP_INTELPERC_IR_GENERATOR + cv::CAP_PROP_FRAME_HEIGHT );
capture.get( cv::CAP_INTELPERC_IR_GENERATOR + cv::CAP_PROP_FPS );
```