### PR TITLE
 Get/Set functions for BRISK parameters, issue #11527

### DIFF
--- a/modules/features2d/include/opencv2/features2d.hpp
+++ b/modules/features2d/include/opencv2/features2d.hpp
@@ -287,7 +287,7 @@ public:
     CV_WRAP virtual String getDefaultName() const CV_OVERRIDE;
 
     /** @brief Set detection threshold.
-    @param thresh AGAST detection threshold score.
+    @param threshold AGAST detection threshold score.
     */
     CV_WRAP virtual void setThreshold(int threshold) = 0;
     CV_WRAP virtual int getThreshold() const = 0;

--- a/modules/features2d/include/opencv2/features2d.hpp
+++ b/modules/features2d/include/opencv2/features2d.hpp
@@ -289,14 +289,14 @@ public:
     /** @brief Set detection threshold.
     @param threshold AGAST detection threshold score.
     */
-    CV_WRAP virtual void setThreshold(int threshold) = 0;
-    CV_WRAP virtual int getThreshold() const = 0;
+    CV_WRAP virtual void setThreshold(int threshold) { CV_UNUSED(threshold); return; };
+    CV_WRAP virtual int getThreshold() const { return -1; };
 
     /** @brief Set detection octaves.
     @param octaves detection octaves. Use 0 to do single scale.
     */
-    CV_WRAP virtual void setOctaves(int octaves) = 0;
-    CV_WRAP virtual int getOctaves() const = 0;
+    CV_WRAP virtual void setOctaves(int octaves) { CV_UNUSED(octaves); return; };
+    CV_WRAP virtual int getOctaves() const { return -1; };
 };
 
 /** @brief Class implementing the ORB (*oriented BRIEF*) keypoint detector and descriptor extractor

--- a/modules/features2d/include/opencv2/features2d.hpp
+++ b/modules/features2d/include/opencv2/features2d.hpp
@@ -285,6 +285,18 @@ public:
         const std::vector<int> &numberList, float dMax=5.85f, float dMin=8.2f,
         const std::vector<int>& indexChange=std::vector<int>());
     CV_WRAP virtual String getDefaultName() const CV_OVERRIDE;
+
+    /** @brief Set detection threshold.
+    @param thresh AGAST detection threshold score.
+    */
+    CV_WRAP virtual void setThreshold(int threshold) = 0;
+    CV_WRAP virtual int getThreshold() const = 0;
+
+    /** @brief Set detection octaves.
+    @param octaves detection octaves. Use 0 to do single scale.
+    */
+    CV_WRAP virtual void setOctaves(int octaves) = 0;
+    CV_WRAP virtual int getOctaves() const = 0;
 };
 
 /** @brief Class implementing the ORB (*oriented BRIEF*) keypoint detector and descriptor extractor

--- a/modules/features2d/src/brisk.cpp
+++ b/modules/features2d/src/brisk.cpp
@@ -80,6 +80,26 @@ public:
         return NORM_HAMMING;
     }
 
+    virtual void setThreshold(int threshold_in) CV_OVERRIDE
+    {
+        threshold = threshold_in;
+    }
+
+    virtual int getThreshold() const CV_OVERRIDE
+    {
+        return threshold;
+    }
+
+    virtual void setOctaves(int octaves_in) CV_OVERRIDE
+    {
+        octaves = octaves_in;
+    }
+
+    virtual int getOctaves() const CV_OVERRIDE
+    {
+        return octaves;
+    }
+
     // call this to generate the kernel:
     // circle of radius r (pixels), with n points;
     // short pairings with dMax, long pairings with dMin

--- a/modules/features2d/test/test_brisk.cpp
+++ b/modules/features2d/test/test_brisk.cpp
@@ -73,6 +73,16 @@ void CV_BRISKTest::run( int )
 
   Ptr<FeatureDetector> detector = BRISK::create();
 
+  // Check parameter get/set functions.
+  BRISK* detectorTyped = dynamic_cast<BRISK*>(detector.get());
+  ASSERT_NE(nullptr, detectorTyped);
+  ASSERT_EQ(detectorTyped->getOctaves(), 4); // Default value
+  ASSERT_EQ(detectorTyped->getThreshold(), 30); // Default value
+  detectorTyped->setOctaves(3);
+  detectorTyped->setThreshold(29);
+  ASSERT_EQ(detectorTyped->getOctaves(), 3);
+  ASSERT_EQ(detectorTyped->getThreshold(), 29);
+
   vector<KeyPoint> keypoints1;
   vector<KeyPoint> keypoints2;
   detector->detect(image1, keypoints1);

--- a/modules/features2d/test/test_brisk.cpp
+++ b/modules/features2d/test/test_brisk.cpp
@@ -76,11 +76,13 @@ void CV_BRISKTest::run( int )
   // Check parameter get/set functions.
   BRISK* detectorTyped = dynamic_cast<BRISK*>(detector.get());
   ASSERT_NE(nullptr, detectorTyped);
-  ASSERT_EQ(detectorTyped->getOctaves(), 4); // Default value
-  ASSERT_EQ(detectorTyped->getThreshold(), 30); // Default value
   detectorTyped->setOctaves(3);
-  detectorTyped->setThreshold(29);
+  detectorTyped->setThreshold(30);
   ASSERT_EQ(detectorTyped->getOctaves(), 3);
+  ASSERT_EQ(detectorTyped->getThreshold(), 30);
+  detectorTyped->setOctaves(4);
+  detectorTyped->setThreshold(29);
+  ASSERT_EQ(detectorTyped->getOctaves(), 4);
   ASSERT_EQ(detectorTyped->getThreshold(), 29);
 
   vector<KeyPoint> keypoints1;


### PR DESCRIPTION
Allows setting threshold and octaves parameters after creating a brisk object. These parameters do not affect the initial pattern initialization and can be changed later without re-initialization.
I added these locally to avoid re-running the full initialization (which takes quite a long time) when changing parameters. Maybe this is useful to the rest of the community.

resolves #11527

### This pullrequest changes

Adds get/set functions for BRISK parameters.


```
force_builders=linux
```