### PR TITLE
RGB to/from Gray rewritten to wide intrinsics

### DIFF
--- a/modules/imgproc/src/color_rgb.cpp
+++ b/modules/imgproc/src/color_rgb.cpp
@@ -249,7 +249,7 @@ struct RGB2RGB5x5
         v_uint16 vn3 = vx_setall_u16((ushort)(~3));
         v_uint16 vn7 = vx_setall_u16((ushort)(~7));
         v_uint16 vz = vx_setzero_u16(), v0x8000 = vx_setall_u16(0x8000);
-        v_uint8 v7 = vx_setall_u8(~7);
+        v_uint8 v7 = vx_setall_u8((ushort)(~7));
         for(; i < n-vsize+1;
             i += vsize, src += vsize*scn, dst += vsize*sizeof(ushort))
         {

--- a/modules/imgproc/src/color_rgb.cpp
+++ b/modules/imgproc/src/color_rgb.cpp
@@ -249,7 +249,7 @@ struct RGB2RGB5x5
         v_uint16 vn3 = vx_setall_u16((ushort)(~3));
         v_uint16 vn7 = vx_setall_u16((ushort)(~7));
         v_uint16 vz = vx_setzero_u16(), v0x8000 = vx_setall_u16(0x8000);
-        v_uint8 v7 = vx_setall_u8((ushort)(~7));
+        v_uint8 v7 = vx_setall_u8((uchar)(~7));
         for(; i < n-vsize+1;
             i += vsize, src += vsize*scn, dst += vsize*sizeof(ushort))
         {

--- a/modules/imgproc/src/color_rgb.cpp
+++ b/modules/imgproc/src/color_rgb.cpp
@@ -142,7 +142,9 @@ struct RGB5x52RGB
 
 #if CV_SIMD
         const int vsize = v_uint8::nlanes;
-
+        v_uint8 vn3 = vx_setall_u8(~3), vn7 = vx_setall_u8(~7);
+        v_uint8 vz = vx_setzero_u8(), vn0 = vx_setall_u8(255);
+        v_uint16 v255 = vx_setall_u16(255);
         for(; i < n-vsize+1;
             i += vsize, src += vsize*sizeof(ushort), dst += vsize*dcn)
         {
@@ -151,15 +153,12 @@ struct RGB5x52RGB
                                                        sizeof(ushort)*v_uint16::nlanes));
 
             v_uint8 r, g, b, a;
-            v_uint16 v255 = vx_setall_u16(255);
-
             v_uint16 b0 = (t0 << 3) & v255;
             v_uint16 b1 = (t1 << 3) & v255;
             b = v_pack(b0, b1);
 
             v_uint16 g0, g1, r0, r1, a0, a1;
-            v_uint8 vn3 = vx_setall_u8(~3), vn7 = vx_setall_u8(~7);
-            v_uint8 vz = vx_setzero_u8(), vn0 = vx_setall_u8(255);
+
             if( gb == 6 )
             {
                 g0 = (t0 >> 3) & v255;
@@ -254,6 +253,9 @@ struct RGB2RGB5x5
 
 #if CV_SIMD
         const int vsize = v_uint8::nlanes;
+        v_uint16 vn3 = vx_setall_u16(~3), vn7 = vx_setall_u16(~7);
+        v_uint16 vz = vx_setzero_u16(), v0x8000 = vx_setall_u16(0x8000);
+        v_uint8 v7 = vx_setall_u8(~7);
         for(; i < n-vsize+1;
             i += vsize, src += vsize*scn, dst += vsize*sizeof(ushort))
         {
@@ -269,7 +271,7 @@ struct RGB2RGB5x5
             if(bidx == 2)
                 swap(b, r);
 
-            r = r & vx_setall_u8(~7);
+            r = r & v7;
 
             v_uint16 r0, r1, g0, g1, b0, b1, a0, a1;
             v_expand(r, r0, r1);
@@ -278,8 +280,7 @@ struct RGB2RGB5x5
             v_expand(a, a0, a1);
 
             v_uint16 d0, d1;
-            v_uint16 vn3 = vx_setall_u16(~3), vn7 = vx_setall_u16(~7);
-            v_uint16 vz = vx_setzero_u16(), v0x8000 = vx_setall_u16(0x8000);
+
             b0 = b0 >> 3;
             b1 = b1 >> 3;
             a0 = a0 != vz;

--- a/modules/imgproc/src/color_rgb.cpp
+++ b/modules/imgproc/src/color_rgb.cpp
@@ -246,7 +246,8 @@ struct RGB2RGB5x5
 
 #if CV_SIMD
         const int vsize = v_uint8::nlanes;
-        v_uint16 vn3 = vx_setall_u16(~3), vn7 = vx_setall_u16(~7);
+        v_uint16 vn3 = vx_setall_u16((ushort)(~3));
+        v_uint16 vn7 = vx_setall_u16((ushort)(~7));
         v_uint16 vz = vx_setzero_u16(), v0x8000 = vx_setall_u16(0x8000);
         v_uint8 v7 = vx_setall_u8(~7);
         for(; i < n-vsize+1;
@@ -379,7 +380,7 @@ struct Gray2RGB5x5
         int i = 0;
 #if CV_SIMD
         const int vsize = v_uint16::nlanes;
-        v_uint16 v3 = vx_setall_u16(~3);
+        v_uint16 v3 = vx_setall_u16((ushort)(~3));
         for(; i < n-vsize+1;
             i += vsize, src += vsize, dst += vsize*sizeof(ushort))
         {
@@ -611,7 +612,7 @@ struct RGB2Gray<uchar>
     {
         const int coeffs0[] = { RY, GY, BY };
         for(int i = 0; i < 3; i++)
-                coeffs[i] = _coeffs ? _coeffs[i] : coeffs0[i];
+                coeffs[i] = (short)(_coeffs ? _coeffs[i] : coeffs0[i]);
         if(blueIdx == 0)
             std::swap(coeffs[0], coeffs[2]);
 
@@ -621,7 +622,7 @@ struct RGB2Gray<uchar>
     void operator()(const uchar* src, uchar* dst, int n) const
     {
         int scn = srccn;
-        int cb = coeffs[0], cg = coeffs[1], cr = coeffs[2];
+        short cb = coeffs[0], cg = coeffs[1], cr = coeffs[2];
         int i = 0;
 
 #if CV_SIMD
@@ -685,7 +686,7 @@ struct RGB2Gray<uchar>
     }
 
     int srccn;
-    int coeffs[3];
+    short coeffs[3];
 };
 
 
@@ -705,7 +706,7 @@ struct RGB2Gray<ushort>
     {
         const int coeffs0[] = { RY, GY, BY };
         for(int i = 0; i < 3; i++)
-                coeffs[i] = _coeffs ? _coeffs[i] : coeffs0[i];
+                coeffs[i] = (short)(_coeffs ? _coeffs[i] : coeffs0[i]);
         if(blueIdx == 0)
             std::swap(coeffs[0], coeffs[2]);
 
@@ -714,7 +715,8 @@ struct RGB2Gray<ushort>
 
     void operator()(const ushort* src, ushort* dst, int n) const
     {
-        int scn = srccn, cb = coeffs[0], cg = coeffs[1], cr = coeffs[2];
+        int scn = srccn;
+        short cb = coeffs[0], cg = coeffs[1], cr = coeffs[2];
         int i = 0;
 
 #if CV_SIMD
@@ -780,7 +782,7 @@ struct RGB2Gray<ushort>
     }
 
     int srccn;
-    int coeffs[3];
+    short coeffs[3];
 };
 
 /////////////////////////// RGBA <-> mRGBA (alpha premultiplied) //////////////

--- a/modules/imgproc/src/color_rgb.cpp
+++ b/modules/imgproc/src/color_rgb.cpp
@@ -80,7 +80,7 @@ struct RGB2RGB
 #if CV_SIMD
         const int vsize = vt::nlanes;
 
-        for(; i < n-vsize+1;
+        for(; i <= n-vsize;
             i += vsize, src += vsize*scn, dst += vsize*dcn)
         {
             vt a, b, c, d;
@@ -143,7 +143,7 @@ struct RGB5x52RGB
 #if CV_SIMD
         const int vsize = v_uint8::nlanes;
         v_uint8 vz = vx_setzero_u8(), vn0 = vx_setall_u8(255);
-        for(; i < n-vsize+1;
+        for(; i <= n-vsize;
             i += vsize, src += vsize*sizeof(ushort), dst += vsize*dcn)
         {
             v_uint16 t0 = v_reinterpret_as_u16(vx_load(src));
@@ -250,7 +250,7 @@ struct RGB2RGB5x5
         v_uint16 vn7 = vx_setall_u16((ushort)(~7));
         v_uint16 vz = vx_setzero_u16(), v0x8000 = vx_setall_u16(0x8000);
         v_uint8 v7 = vx_setall_u8((uchar)(~7));
-        for(; i < n-vsize+1;
+        for(; i <= n-vsize;
             i += vsize, src += vsize*scn, dst += vsize*sizeof(ushort))
         {
             v_uint8 r, g, b, a;
@@ -339,7 +339,7 @@ struct Gray2RGB
 #if CV_SIMD
         const int vsize = vt::nlanes;
         vt valpha = v_set<_Tp>::set(alpha);
-        for(; i < n-vsize+1;
+        for(; i <= n-vsize;
             i += vsize, src += vsize, dst += vsize*dcn)
         {
             vt g = vx_load(src);
@@ -381,7 +381,7 @@ struct Gray2RGB5x5
 #if CV_SIMD
         const int vsize = v_uint16::nlanes;
         v_uint16 v3 = vx_setall_u16((ushort)(~3));
-        for(; i < n-vsize+1;
+        for(; i <= n-vsize;
             i += vsize, src += vsize, dst += vsize*sizeof(ushort))
         {
             v_uint8 t8 = vx_load_low(src);
@@ -453,7 +453,7 @@ struct RGB5x52Gray
         v_zip(vx_setall_s16(RY), vx_setall_s16( 1), r12y, dummy);
         v_int16 delta = vx_setall_s16(1 << (shift-1));
 
-        for(; i < n-vsize+1;
+        for(; i <= n-vsize;
             i += vsize, src += vsize*sizeof(ushort), dst += vsize)
         {
             v_uint16 t = vx_load((ushort*)src);
@@ -569,7 +569,7 @@ struct RGB2Gray<float>
 #if CV_SIMD
         const int vsize = v_float32::nlanes;
         v_float32 rv = vx_setall_f32(cr), gv = vx_setall_f32(cg), bv = vx_setall_f32(cb);
-        for(; i < n-vsize+1;
+        for(; i <= n-vsize;
             i += vsize, src += vsize*scn, dst += vsize)
         {
             v_float32 r, g, b, a;
@@ -634,7 +634,7 @@ struct RGB2Gray<uchar>
         v_zip(vx_setall_s16(cr), vx_setall_s16( 1), r12y, dummy);
         v_int16 delta = vx_setall_s16(1 << (shift-1));
 
-        for( ; i < n-vsize+1;
+        for( ; i <= n-vsize;
              i += vsize, src += scn*vsize, dst += vsize)
         {
             v_uint8 r, g, b, a;
@@ -735,7 +735,7 @@ struct RGB2Gray<ushort>
 
         v_int16 delta = vx_setall_s16(1 << (shift-1));
 
-        for( ; i < n-vsize+1;
+        for( ; i <= n-vsize;
              i += vsize, src += scn*vsize, dst += vsize)
         {
             v_uint16 r, g, b, a;

--- a/modules/imgproc/src/color_rgb.cpp
+++ b/modules/imgproc/src/color_rgb.cpp
@@ -257,6 +257,7 @@ struct RGB2RGB5x5
             if(scn == 3)
             {
                 v_load_deinterleave(src, b, g, r);
+                a = vx_setzero_u8();
             }
             else
             {

--- a/modules/imgproc/src/color_rgb.cpp
+++ b/modules/imgproc/src/color_rgb.cpp
@@ -248,7 +248,7 @@ struct RGB2RGB5x5
         const int vsize = v_uint8::nlanes;
         v_uint16 vn3 = vx_setall_u16((ushort)(~3));
         v_uint16 vn7 = vx_setall_u16((ushort)(~7));
-        v_uint16 vz = vx_setzero_u16(), v0x8000 = vx_setall_u16(0x8000);
+        v_uint16 vz = vx_setzero_u16();
         v_uint8 v7 = vx_setall_u8((uchar)(~7));
         for(; i <= n-vsize;
             i += vsize, src += vsize*scn, dst += vsize*sizeof(ushort))
@@ -278,8 +278,8 @@ struct RGB2RGB5x5
 
             b0 = b0 >> 3;
             b1 = b1 >> 3;
-            a0 = a0 != vz;
-            a1 = a1 != vz;
+            a0 = (a0 != vz) << 15;
+            a1 = (a1 != vz) << 15;
 
             if(gb == 6)
             {
@@ -288,8 +288,8 @@ struct RGB2RGB5x5
             }
             else
             {
-                d0 = b0 | ((g0 & vn7) << 2) | (r0 << 7) | (v_select(a0, v0x8000, vz));
-                d1 = b1 | ((g1 & vn7) << 2) | (r1 << 7) | (v_select(a1, v0x8000, vz));
+                d0 = b0 | ((g0 & vn7) << 2) | (r0 << 7) | a0;
+                d1 = b1 | ((g1 & vn7) << 2) | (r1 << 7) | a1;
             }
 
             v_store((ushort*)dst, d0);

--- a/modules/imgproc/src/opencl/color_rgb.cl
+++ b/modules/imgproc/src/opencl/color_rgb.cl
@@ -439,9 +439,10 @@ __kernel void mRGBA2RGBA(__global const uchar* src, int src_step, int src_offset
                     *(__global uchar4 *)(dst + dst_index) = (uchar4)(0, 0, 0, 0);
                 else
                     *(__global uchar4 *)(dst + dst_index) =
-                        (uchar4)(mad24(src_pix.x, MAX_NUM, v3_half) / v3,
-                                 mad24(src_pix.y, MAX_NUM, v3_half) / v3,
-                                 mad24(src_pix.z, MAX_NUM, v3_half) / v3, v3);
+                        (uchar4)(SAT_CAST(mad24(src_pix.x, MAX_NUM, v3_half) / v3),
+                                 SAT_CAST(mad24(src_pix.y, MAX_NUM, v3_half) / v3),
+                                 SAT_CAST(mad24(src_pix.z, MAX_NUM, v3_half) / v3),
+                                 SAT_CAST(v3));
 
                 ++y;
                 dst_index += dst_step;


### PR DESCRIPTION
**Merge with extra**: https://github.com/opencv/opencv_extra/pull/560

### This pullrequest changes

* All conversions in `color_rgb.cpp` rewritten to wide universal intrinsics
* Platform-specific code removed
* `mRGBA2RGBA`: saturation added

master branch has different RGB2Gray coefficients so there will be separate PR

<cut/>

### Performance

<details>
<summary>Baseline AVX2</summary>

|Name of Test|rgb initial avx2|rgb wide avx2|rgb wide avx2 vs rgb initial avx2 (x-factor)|
|---|:-:|:-:|:-:|
|cvtColor8u::Size_CvtMode::(127x61, COLOR_BGR2BGR555)|0.011|0.004|3.09|
|cvtColor8u::Size_CvtMode::(127x61, COLOR_BGR2BGR565)|0.011|0.003|3.19|
|cvtColor8u::Size_CvtMode::(127x61, COLOR_BGR2GRAY)|0.006|0.004|1.55|
|cvtColor8u::Size_CvtMode::(127x61, COLOR_BGR5552BGR)|0.007|0.003|2.20|
|cvtColor8u::Size_CvtMode::(127x61, COLOR_BGR5552BGRA)|0.008|0.003|2.48|
|cvtColor8u::Size_CvtMode::(127x61, COLOR_BGR5552GRAY)|0.003|0.003|0.86|
|cvtColor8u::Size_CvtMode::(127x61, COLOR_BGR5552RGB)|0.007|0.003|2.11|
|cvtColor8u::Size_CvtMode::(127x61, COLOR_BGR5552RGBA)|0.008|0.003|2.41|
|cvtColor8u::Size_CvtMode::(127x61, COLOR_BGR5652BGR)|0.007|0.003|2.31|
|cvtColor8u::Size_CvtMode::(127x61, COLOR_BGR5652BGRA)|0.008|0.003|2.63|
|cvtColor8u::Size_CvtMode::(127x61, COLOR_BGR5652GRAY)|0.003|0.003|0.84|
|cvtColor8u::Size_CvtMode::(127x61, COLOR_BGR5652RGB)|0.007|0.003|2.24|
|cvtColor8u::Size_CvtMode::(127x61, COLOR_BGR5652RGBA)|0.008|0.003|2.40|
|cvtColor8u::Size_CvtMode::(127x61, COLOR_BGRA2BGR555)|0.005|0.004|1.05|
|cvtColor8u::Size_CvtMode::(127x61, COLOR_BGRA2BGR565)|0.004|0.004|1.10|
|cvtColor8u::Size_CvtMode::(127x61, COLOR_BGRA2GRAY)|0.006|0.004|1.55|
|cvtColor8u::Size_CvtMode::(127x61, COLOR_GRAY2BGR555)|0.002|0.001|1.37|
|cvtColor8u::Size_CvtMode::(127x61, COLOR_GRAY2BGR565)|0.002|0.001|1.17|
|cvtColor8u::Size_CvtMode::(127x61, COLOR_GRAY2BGR)|0.002|0.002|0.93|
|cvtColor8u::Size_CvtMode::(127x61, COLOR_GRAY2BGRA)|0.003|0.003|1.05|
|cvtColor8u::Size_CvtMode::(127x61, COLOR_RGB2BGR555)|0.011|0.003|3.11|
|cvtColor8u::Size_CvtMode::(127x61, COLOR_RGB2BGR565)|0.011|0.004|2.94|
|cvtColor8u::Size_CvtMode::(127x61, COLOR_RGB2GRAY)|0.006|0.004|1.50|
|cvtColor8u::Size_CvtMode::(127x61, COLOR_RGBA2BGR555)|0.004|0.004|1.10|
|cvtColor8u::Size_CvtMode::(127x61, COLOR_RGBA2BGR565)|0.004|0.004|1.15|
|cvtColor8u::Size_CvtMode::(127x61, COLOR_RGBA2GRAY)|0.006|0.004|1.51|
|cvtColor8u::Size_CvtMode::(640x480, COLOR_BGR2BGR555)|0.452|0.067|6.76|
|cvtColor8u::Size_CvtMode::(640x480, COLOR_BGR2BGR565)|0.453|0.058|7.87|
|cvtColor8u::Size_CvtMode::(640x480, COLOR_BGR2GRAY)|0.229|0.094|2.42|
|cvtColor8u::Size_CvtMode::(640x480, COLOR_BGR5552BGR)|0.259|0.068|3.83|
|cvtColor8u::Size_CvtMode::(640x480, COLOR_BGR5552BGRA)|0.327|0.068|4.80|
|cvtColor8u::Size_CvtMode::(640x480, COLOR_BGR5552GRAY)|0.079|0.074|1.06|
|cvtColor8u::Size_CvtMode::(640x480, COLOR_BGR5552RGB)|0.285|0.066|4.29|
|cvtColor8u::Size_CvtMode::(640x480, COLOR_BGR5552RGBA)|0.329|0.068|4.81|
|cvtColor8u::Size_CvtMode::(640x480, COLOR_BGR5652BGR)|0.259|0.061|4.26|
|cvtColor8u::Size_CvtMode::(640x480, COLOR_BGR5652BGRA)|0.328|0.069|4.78|
|cvtColor8u::Size_CvtMode::(640x480, COLOR_BGR5652GRAY)|0.074|0.071|1.05|
|cvtColor8u::Size_CvtMode::(640x480, COLOR_BGR5652RGB)|0.288|0.059|4.87|
|cvtColor8u::Size_CvtMode::(640x480, COLOR_BGR5652RGBA)|0.324|0.067|4.84|
|cvtColor8u::Size_CvtMode::(640x480, COLOR_BGRA2BGR555)|0.116|0.079|1.47|
|cvtColor8u::Size_CvtMode::(640x480, COLOR_BGRA2BGR565)|0.104|0.074|1.41|
|cvtColor8u::Size_CvtMode::(640x480, COLOR_BGRA2GRAY)|0.227|0.100|2.27|
|cvtColor8u::Size_CvtMode::(640x480, COLOR_GRAY2BGR555)|0.049|0.021|2.39|
|cvtColor8u::Size_CvtMode::(640x480, COLOR_GRAY2BGR565)|0.032|0.019|1.65|
|cvtColor8u::Size_CvtMode::(640x480, COLOR_GRAY2BGR)|0.039|0.037|1.05|
|cvtColor8u::Size_CvtMode::(640x480, COLOR_GRAY2BGRA)|0.053|0.052|1.03|
|cvtColor8u::Size_CvtMode::(640x480, COLOR_RGB2BGR555)|0.453|0.062|7.36|
|cvtColor8u::Size_CvtMode::(640x480, COLOR_RGB2BGR565)|0.455|0.061|7.47|
|cvtColor8u::Size_CvtMode::(640x480, COLOR_RGB2GRAY)|0.229|0.096|2.39|
|cvtColor8u::Size_CvtMode::(640x480, COLOR_RGBA2BGR555)|0.119|0.077|1.53|
|cvtColor8u::Size_CvtMode::(640x480, COLOR_RGBA2BGR565)|0.109|0.076|1.42|
|cvtColor8u::Size_CvtMode::(640x480, COLOR_RGBA2GRAY)|0.229|0.106|2.16|
|cvtColor8u::Size_CvtMode::(1920x1080, COLOR_BGR2BGR555)|3.027|0.491|6.16|
|cvtColor8u::Size_CvtMode::(1920x1080, COLOR_BGR2BGR565)|3.029|0.473|6.40|
|cvtColor8u::Size_CvtMode::(1920x1080, COLOR_BGR2GRAY)|1.561|0.633|2.47|
|cvtColor8u::Size_CvtMode::(1920x1080, COLOR_BGR5552BGR)|1.777|0.486|3.66|
|cvtColor8u::Size_CvtMode::(1920x1080, COLOR_BGR5552BGRA)|2.219|0.577|3.84|
|cvtColor8u::Size_CvtMode::(1920x1080, COLOR_BGR5552GRAY)|0.531|0.520|1.02|
|cvtColor8u::Size_CvtMode::(1920x1080, COLOR_BGR5552RGB)|1.906|0.476|4.00|
|cvtColor8u::Size_CvtMode::(1920x1080, COLOR_BGR5552RGBA)|2.218|0.542|4.10|
|cvtColor8u::Size_CvtMode::(1920x1080, COLOR_BGR5652BGR)|1.752|0.446|3.93|
|cvtColor8u::Size_CvtMode::(1920x1080, COLOR_BGR5652BGRA)|2.215|0.541|4.09|
|cvtColor8u::Size_CvtMode::(1920x1080, COLOR_BGR5652GRAY)|0.492|0.486|1.01|
|cvtColor8u::Size_CvtMode::(1920x1080, COLOR_BGR5652RGB)|1.914|0.454|4.22|
|cvtColor8u::Size_CvtMode::(1920x1080, COLOR_BGR5652RGBA)|2.215|0.521|4.25|
|cvtColor8u::Size_CvtMode::(1920x1080, COLOR_BGRA2BGR555)|0.864|0.616|1.40|
|cvtColor8u::Size_CvtMode::(1920x1080, COLOR_BGRA2BGR565)|0.747|0.597|1.25|
|cvtColor8u::Size_CvtMode::(1920x1080, COLOR_BGRA2GRAY)|1.572|0.752|2.09|
|cvtColor8u::Size_CvtMode::(1920x1080, COLOR_GRAY2BGR555)|0.323|0.231|1.40|
|cvtColor8u::Size_CvtMode::(1920x1080, COLOR_GRAY2BGR565)|0.249|0.232|1.07|
|cvtColor8u::Size_CvtMode::(1920x1080, COLOR_GRAY2BGR)|0.322|0.322|1.00|
|cvtColor8u::Size_CvtMode::(1920x1080, COLOR_GRAY2BGRA)|0.424|0.405|1.05|
|cvtColor8u::Size_CvtMode::(1920x1080, COLOR_RGB2BGR555)|3.050|0.464|6.58|
|cvtColor8u::Size_CvtMode::(1920x1080, COLOR_RGB2BGR565)|3.059|0.467|6.55|
|cvtColor8u::Size_CvtMode::(1920x1080, COLOR_RGB2GRAY)|1.530|0.622|2.46|
|cvtColor8u::Size_CvtMode::(1920x1080, COLOR_RGBA2BGR555)|0.876|0.644|1.36|
|cvtColor8u::Size_CvtMode::(1920x1080, COLOR_RGBA2BGR565)|0.797|0.600|1.33|
|cvtColor8u::Size_CvtMode::(1920x1080, COLOR_RGBA2GRAY)|1.572|0.746|2.11|

</details>

<details>
<summary>Baseline AVX512SKX</summary>

|Name of Test|rgb initial avx512skx|rgb wide avx512skx|rgb wide avx512skx vs rgb initial avx512skx (x-factor)|
|---|:-:|:-:|:-:|
|cvtColor8u::Size_CvtMode::(127x61, COLOR_BGR2BGR555)|0.011|0.004|2.93|
|cvtColor8u::Size_CvtMode::(127x61, COLOR_BGR2BGR565)|0.011|0.003|3.17|
|cvtColor8u::Size_CvtMode::(127x61, COLOR_BGR2GRAY)|0.007|0.004|1.58|
|cvtColor8u::Size_CvtMode::(127x61, COLOR_BGR5552BGR)|0.008|0.004|2.04|
|cvtColor8u::Size_CvtMode::(127x61, COLOR_BGR5552BGRA)|0.009|0.004|2.27|
|cvtColor8u::Size_CvtMode::(127x61, COLOR_BGR5552GRAY)|0.003|0.004|0.88|
|cvtColor8u::Size_CvtMode::(127x61, COLOR_BGR5552RGB)|0.008|0.004|2.21|
|cvtColor8u::Size_CvtMode::(127x61, COLOR_BGR5552RGBA)|0.009|0.004|2.17|
|cvtColor8u::Size_CvtMode::(127x61, COLOR_BGR5652BGR)|0.008|0.003|2.30|
|cvtColor8u::Size_CvtMode::(127x61, COLOR_BGR5652BGRA)|0.009|0.004|2.62|
|cvtColor8u::Size_CvtMode::(127x61, COLOR_BGR5652GRAY)|0.003|0.004|0.86|
|cvtColor8u::Size_CvtMode::(127x61, COLOR_BGR5652RGB)|0.008|0.003|2.36|
|cvtColor8u::Size_CvtMode::(127x61, COLOR_BGR5652RGBA)|0.009|0.004|2.67|
|cvtColor8u::Size_CvtMode::(127x61, COLOR_BGRA2BGR555)|0.006|0.004|1.38|
|cvtColor8u::Size_CvtMode::(127x61, COLOR_BGRA2BGR565)|0.005|0.004|1.33|
|cvtColor8u::Size_CvtMode::(127x61, COLOR_BGRA2GRAY)|0.007|0.005|1.50|
|cvtColor8u::Size_CvtMode::(127x61, COLOR_GRAY2BGR555)|0.002|0.002|1.37|
|cvtColor8u::Size_CvtMode::(127x61, COLOR_GRAY2BGR565)|0.002|0.002|1.10|
|cvtColor8u::Size_CvtMode::(127x61, COLOR_GRAY2BGR)|0.004|0.003|1.58|
|cvtColor8u::Size_CvtMode::(127x61, COLOR_GRAY2BGRA)|0.005|0.003|1.69|
|cvtColor8u::Size_CvtMode::(127x61, COLOR_RGB2BGR555)|0.011|0.004|2.88|
|cvtColor8u::Size_CvtMode::(127x61, COLOR_RGB2BGR565)|0.011|0.004|2.90|
|cvtColor8u::Size_CvtMode::(127x61, COLOR_RGB2GRAY)|0.007|0.004|1.54|
|cvtColor8u::Size_CvtMode::(127x61, COLOR_RGBA2BGR555)|0.006|0.004|1.40|
|cvtColor8u::Size_CvtMode::(127x61, COLOR_RGBA2BGR565)|0.005|0.004|1.30|
|cvtColor8u::Size_CvtMode::(127x61, COLOR_RGBA2GRAY)|0.007|0.005|1.47|
|cvtColor8u::Size_CvtMode::(640x480, COLOR_BGR2BGR555)|0.493|0.074|6.69|
|cvtColor8u::Size_CvtMode::(640x480, COLOR_BGR2BGR565)|0.491|0.065|7.53|
|cvtColor8u::Size_CvtMode::(640x480, COLOR_BGR2GRAY)|0.256|0.108|2.37|
|cvtColor8u::Size_CvtMode::(640x480, COLOR_BGR5552BGR)|0.275|0.075|3.68|
|cvtColor8u::Size_CvtMode::(640x480, COLOR_BGR5552BGRA)|0.344|0.080|4.28|
|cvtColor8u::Size_CvtMode::(640x480, COLOR_BGR5552GRAY)|0.092|0.087|1.06|
|cvtColor8u::Size_CvtMode::(640x480, COLOR_BGR5552RGB)|0.286|0.074|3.86|
|cvtColor8u::Size_CvtMode::(640x480, COLOR_BGR5552RGBA)|0.342|0.079|4.31|
|cvtColor8u::Size_CvtMode::(640x480, COLOR_BGR5652BGR)|0.259|0.070|3.71|
|cvtColor8u::Size_CvtMode::(640x480, COLOR_BGR5652BGRA)|0.342|0.076|4.48|
|cvtColor8u::Size_CvtMode::(640x480, COLOR_BGR5652GRAY)|0.088|0.083|1.05|
|cvtColor8u::Size_CvtMode::(640x480, COLOR_BGR5652RGB)|0.285|0.066|4.30|
|cvtColor8u::Size_CvtMode::(640x480, COLOR_BGR5652RGBA)|0.331|0.076|4.37|
|cvtColor8u::Size_CvtMode::(640x480, COLOR_BGRA2BGR555)|0.114|0.084|1.35|
|cvtColor8u::Size_CvtMode::(640x480, COLOR_BGRA2BGR565)|0.096|0.084|1.15|
|cvtColor8u::Size_CvtMode::(640x480, COLOR_BGRA2GRAY)|0.257|0.116|2.21|
|cvtColor8u::Size_CvtMode::(640x480, COLOR_GRAY2BGR555)|0.056|0.022|2.49|
|cvtColor8u::Size_CvtMode::(640x480, COLOR_GRAY2BGR565)|0.035|0.025|1.38|
|cvtColor8u::Size_CvtMode::(640x480, COLOR_GRAY2BGR)|0.050|0.039|1.27|
|cvtColor8u::Size_CvtMode::(640x480, COLOR_GRAY2BGRA)|0.065|0.054|1.20|
|cvtColor8u::Size_CvtMode::(640x480, COLOR_RGB2BGR555)|0.496|0.072|6.89|
|cvtColor8u::Size_CvtMode::(640x480, COLOR_RGB2BGR565)|0.493|0.065|7.55|
|cvtColor8u::Size_CvtMode::(640x480, COLOR_RGB2GRAY)|0.255|0.109|2.34|
|cvtColor8u::Size_CvtMode::(640x480, COLOR_RGBA2BGR555)|0.113|0.087|1.30|
|cvtColor8u::Size_CvtMode::(640x480, COLOR_RGBA2BGR565)|0.098|0.081|1.22|
|cvtColor8u::Size_CvtMode::(640x480, COLOR_RGBA2GRAY)|0.256|0.117|2.19|
|cvtColor8u::Size_CvtMode::(1920x1080, COLOR_BGR2BGR555)|3.316|0.552|6.01|
|cvtColor8u::Size_CvtMode::(1920x1080, COLOR_BGR2BGR565)|3.318|0.509|6.52|
|cvtColor8u::Size_CvtMode::(1920x1080, COLOR_BGR2GRAY)|1.638|0.659|2.49|
|cvtColor8u::Size_CvtMode::(1920x1080, COLOR_BGR5552BGR)|1.821|0.533|3.41|
|cvtColor8u::Size_CvtMode::(1920x1080, COLOR_BGR5552BGRA)|2.234|0.612|3.65|
|cvtColor8u::Size_CvtMode::(1920x1080, COLOR_BGR5552GRAY)|0.615|0.600|1.03|
|cvtColor8u::Size_CvtMode::(1920x1080, COLOR_BGR5552RGB)|1.942|0.550|3.53|
|cvtColor8u::Size_CvtMode::(1920x1080, COLOR_BGR5552RGBA)|2.265|0.614|3.69|
|cvtColor8u::Size_CvtMode::(1920x1080, COLOR_BGR5652BGR)|1.765|0.516|3.42|
|cvtColor8u::Size_CvtMode::(1920x1080, COLOR_BGR5652BGRA)|2.233|0.584|3.82|
|cvtColor8u::Size_CvtMode::(1920x1080, COLOR_BGR5652GRAY)|0.587|0.582|1.01|
|cvtColor8u::Size_CvtMode::(1920x1080, COLOR_BGR5652RGB)|1.933|0.509|3.80|
|cvtColor8u::Size_CvtMode::(1920x1080, COLOR_BGR5652RGBA)|2.259|0.598|3.78|
|cvtColor8u::Size_CvtMode::(1920x1080, COLOR_BGRA2BGR555)|0.746|0.709|1.05|
|cvtColor8u::Size_CvtMode::(1920x1080, COLOR_BGRA2BGR565)|0.670|0.691|0.97|
|cvtColor8u::Size_CvtMode::(1920x1080, COLOR_BGRA2GRAY)|1.650|0.762|2.17|
|cvtColor8u::Size_CvtMode::(1920x1080, COLOR_GRAY2BGR555)|0.357|0.241|1.48|
|cvtColor8u::Size_CvtMode::(1920x1080, COLOR_GRAY2BGR565)|0.265|0.242|1.10|
|cvtColor8u::Size_CvtMode::(1920x1080, COLOR_GRAY2BGR)|0.370|0.333|1.11|
|cvtColor8u::Size_CvtMode::(1920x1080, COLOR_GRAY2BGRA)|0.483|0.435|1.11|
|cvtColor8u::Size_CvtMode::(1920x1080, COLOR_RGB2BGR555)|3.332|0.550|6.06|
|cvtColor8u::Size_CvtMode::(1920x1080, COLOR_RGB2BGR565)|3.329|0.512|6.51|
|cvtColor8u::Size_CvtMode::(1920x1080, COLOR_RGB2GRAY)|1.624|0.680|2.39|
|cvtColor8u::Size_CvtMode::(1920x1080, COLOR_RGBA2BGR555)|0.751|0.715|1.05|
|cvtColor8u::Size_CvtMode::(1920x1080, COLOR_RGBA2BGR565)|0.678|0.706|0.96|
|cvtColor8u::Size_CvtMode::(1920x1080, COLOR_RGBA2GRAY)|1.647|0.785|2.10|
</details>

<details>
<summary>Baseline SSE2</summary>

|Name of Test|rgb initial sse2|rgb wide sse2|rgb wide sse2 vs rgb initial sse2 (x-factor)|
|---|:-:|:-:|:-:|
|cvtColor8u::Size_CvtMode::(127x61, COLOR_BGR2BGR555)|0.011|0.004|2.60|
|cvtColor8u::Size_CvtMode::(127x61, COLOR_BGR2BGR565)|0.011|0.004|2.69|
|cvtColor8u::Size_CvtMode::(127x61, COLOR_BGR2GRAY)|0.006|0.006|1.01|
|cvtColor8u::Size_CvtMode::(127x61, COLOR_BGR5552BGR)|0.007|0.005|1.51|
|cvtColor8u::Size_CvtMode::(127x61, COLOR_BGR5552BGRA)|0.008|0.003|2.34|
|cvtColor8u::Size_CvtMode::(127x61, COLOR_BGR5552GRAY)|0.003|0.004|0.69|
|cvtColor8u::Size_CvtMode::(127x61, COLOR_BGR5552RGB)|0.007|0.005|1.53|
|cvtColor8u::Size_CvtMode::(127x61, COLOR_BGR5552RGBA)|0.008|0.003|2.41|
|cvtColor8u::Size_CvtMode::(127x61, COLOR_BGR5652BGR)|0.007|0.004|1.62|
|cvtColor8u::Size_CvtMode::(127x61, COLOR_BGR5652BGRA)|0.008|0.003|2.97|
|cvtColor8u::Size_CvtMode::(127x61, COLOR_BGR5652GRAY)|0.003|0.004|0.67|
|cvtColor8u::Size_CvtMode::(127x61, COLOR_BGR5652RGB)|0.007|0.004|1.59|
|cvtColor8u::Size_CvtMode::(127x61, COLOR_BGR5652RGBA)|0.008|0.003|2.88|
|cvtColor8u::Size_CvtMode::(127x61, COLOR_BGRA2BGR555)|0.004|0.004|1.20|
|cvtColor8u::Size_CvtMode::(127x61, COLOR_BGRA2BGR565)|0.003|0.004|0.88|
|cvtColor8u::Size_CvtMode::(127x61, COLOR_BGRA2GRAY)|0.006|0.005|1.13|
|cvtColor8u::Size_CvtMode::(127x61, COLOR_GRAY2BGR555)|0.002|0.001|1.79|
|cvtColor8u::Size_CvtMode::(127x61, COLOR_GRAY2BGR565)|0.003|0.001|2.04|
|cvtColor8u::Size_CvtMode::(127x61, COLOR_GRAY2BGR)|0.007|0.004|1.85|
|cvtColor8u::Size_CvtMode::(127x61, COLOR_GRAY2BGRA)|0.002|0.002|1.09|
|cvtColor8u::Size_CvtMode::(127x61, COLOR_RGB2BGR555)|0.011|0.004|2.71|
|cvtColor8u::Size_CvtMode::(127x61, COLOR_RGB2BGR565)|0.012|0.004|2.88|
|cvtColor8u::Size_CvtMode::(127x61, COLOR_RGB2GRAY)|0.006|0.006|1.03|
|cvtColor8u::Size_CvtMode::(127x61, COLOR_RGBA2BGR555)|0.004|0.004|1.20|
|cvtColor8u::Size_CvtMode::(127x61, COLOR_RGBA2BGR565)|0.003|0.004|0.92|
|cvtColor8u::Size_CvtMode::(127x61, COLOR_RGBA2GRAY)|0.006|0.006|1.13|
|cvtColor8u::Size_CvtMode::(640x480, COLOR_BGR2BGR555)|0.468|0.141|3.32|
|cvtColor8u::Size_CvtMode::(640x480, COLOR_BGR2BGR565)|0.466|0.143|3.25|
|cvtColor8u::Size_CvtMode::(640x480, COLOR_BGR2GRAY)|0.236|0.208|1.13|
|cvtColor8u::Size_CvtMode::(640x480, COLOR_BGR5552BGR)|0.271|0.165|1.64|
|cvtColor8u::Size_CvtMode::(640x480, COLOR_BGR5552BGRA)|0.332|0.101|3.29|
|cvtColor8u::Size_CvtMode::(640x480, COLOR_BGR5552GRAY)|0.088|0.150|0.58|
|cvtColor8u::Size_CvtMode::(640x480, COLOR_BGR5552RGB)|0.281|0.166|1.69|
|cvtColor8u::Size_CvtMode::(640x480, COLOR_BGR5552RGBA)|0.331|0.105|3.16|
|cvtColor8u::Size_CvtMode::(640x480, COLOR_BGR5652BGR)|0.260|0.171|1.52|
|cvtColor8u::Size_CvtMode::(640x480, COLOR_BGR5652BGRA)|0.329|0.090|3.65|
|cvtColor8u::Size_CvtMode::(640x480, COLOR_BGR5652GRAY)|0.085|0.153|0.56|
|cvtColor8u::Size_CvtMode::(640x480, COLOR_BGR5652RGB)|0.284|0.172|1.65|
|cvtColor8u::Size_CvtMode::(640x480, COLOR_BGR5652RGBA)|0.330|0.089|3.72|
|cvtColor8u::Size_CvtMode::(640x480, COLOR_BGRA2BGR555)|0.141|0.112|1.25|
|cvtColor8u::Size_CvtMode::(640x480, COLOR_BGRA2BGR565)|0.107|0.113|0.94|
|cvtColor8u::Size_CvtMode::(640x480, COLOR_BGRA2GRAY)|0.232|0.190|1.22|
|cvtColor8u::Size_CvtMode::(640x480, COLOR_GRAY2BGR555)|0.059|0.037|1.60|
|cvtColor8u::Size_CvtMode::(640x480, COLOR_GRAY2BGR565)|0.038|0.037|1.03|
|cvtColor8u::Size_CvtMode::(640x480, COLOR_GRAY2BGR)|0.279|0.152|1.84|
|cvtColor8u::Size_CvtMode::(640x480, COLOR_GRAY2BGRA)|0.051|0.049|1.05|
|cvtColor8u::Size_CvtMode::(640x480, COLOR_RGB2BGR555)|0.454|0.150|3.02|
|cvtColor8u::Size_CvtMode::(640x480, COLOR_RGB2BGR565)|0.458|0.148|3.09|
|cvtColor8u::Size_CvtMode::(640x480, COLOR_RGB2GRAY)|0.227|0.226|1.00|
|cvtColor8u::Size_CvtMode::(640x480, COLOR_RGBA2BGR555)|0.148|0.120|1.24|
|cvtColor8u::Size_CvtMode::(640x480, COLOR_RGBA2BGR565)|0.113|0.114|0.99|
|cvtColor8u::Size_CvtMode::(640x480, COLOR_RGBA2GRAY)|0.229|0.195|1.17|
|cvtColor8u::Size_CvtMode::(1920x1080, COLOR_BGR2BGR555)|3.046|1.055|2.89|
|cvtColor8u::Size_CvtMode::(1920x1080, COLOR_BGR2BGR565)|3.076|1.034|2.97|
|cvtColor8u::Size_CvtMode::(1920x1080, COLOR_BGR2GRAY)|1.561|1.458|1.07|
|cvtColor8u::Size_CvtMode::(1920x1080, COLOR_BGR5552BGR)|1.784|1.153|1.55|
|cvtColor8u::Size_CvtMode::(1920x1080, COLOR_BGR5552BGRA)|2.282|0.741|3.08|
|cvtColor8u::Size_CvtMode::(1920x1080, COLOR_BGR5552GRAY)|0.607|1.033|0.59|
|cvtColor8u::Size_CvtMode::(1920x1080, COLOR_BGR5552RGB)|1.960|1.167|1.68|
|cvtColor8u::Size_CvtMode::(1920x1080, COLOR_BGR5552RGBA)|2.283|0.748|3.05|
|cvtColor8u::Size_CvtMode::(1920x1080, COLOR_BGR5652BGR)|1.807|1.122|1.61|
|cvtColor8u::Size_CvtMode::(1920x1080, COLOR_BGR5652BGRA)|2.318|0.632|3.67|
|cvtColor8u::Size_CvtMode::(1920x1080, COLOR_BGR5652GRAY)|0.574|0.965|0.60|
|cvtColor8u::Size_CvtMode::(1920x1080, COLOR_BGR5652RGB)|1.907|1.070|1.78|
|cvtColor8u::Size_CvtMode::(1920x1080, COLOR_BGR5652RGBA)|2.267|0.646|3.51|
|cvtColor8u::Size_CvtMode::(1920x1080, COLOR_BGRA2BGR555)|1.064|0.827|1.29|
|cvtColor8u::Size_CvtMode::(1920x1080, COLOR_BGRA2BGR565)|0.866|0.821|1.05|
|cvtColor8u::Size_CvtMode::(1920x1080, COLOR_BGRA2GRAY)|1.564|1.295|1.21|
|cvtColor8u::Size_CvtMode::(1920x1080, COLOR_GRAY2BGR555)|0.377|0.240|1.57|
|cvtColor8u::Size_CvtMode::(1920x1080, COLOR_GRAY2BGR565)|0.255|0.249|1.02|
|cvtColor8u::Size_CvtMode::(1920x1080, COLOR_GRAY2BGR)|1.917|0.968|1.98|
|cvtColor8u::Size_CvtMode::(1920x1080, COLOR_GRAY2BGRA)|0.417|0.415|1.00|
|cvtColor8u::Size_CvtMode::(1920x1080, COLOR_RGB2BGR555)|3.061|1.002|3.05|
|cvtColor8u::Size_CvtMode::(1920x1080, COLOR_RGB2BGR565)|3.053|0.996|3.06|
|cvtColor8u::Size_CvtMode::(1920x1080, COLOR_RGB2GRAY)|1.575|1.413|1.11|
|cvtColor8u::Size_CvtMode::(1920x1080, COLOR_RGBA2BGR555)|1.110|0.830|1.34|
|cvtColor8u::Size_CvtMode::(1920x1080, COLOR_RGBA2BGR565)|0.858|0.819|1.05|
|cvtColor8u::Size_CvtMode::(1920x1080, COLOR_RGBA2GRAY)|1.593|1.341|1.19|

</details>

<details>
<summary>Baseline SSE4.1</summary>

|Name of Test|rgb initial sse41|rgb wide sse41|rgb wide sse41 vs rgb initial sse41 (x-factor)|
|---|:-:|:-:|:-:|
|cvtColor8u::Size_CvtMode::(127x61, COLOR_BGR2BGR555)|0.009|0.003|2.88|
|cvtColor8u::Size_CvtMode::(127x61, COLOR_BGR2BGR565)|0.009|0.003|3.25|
|cvtColor8u::Size_CvtMode::(127x61, COLOR_BGR2GRAY)|0.006|0.004|1.61|
|cvtColor8u::Size_CvtMode::(127x61, COLOR_BGR5552BGR)|0.007|0.003|1.92|
|cvtColor8u::Size_CvtMode::(127x61, COLOR_BGR5552BGRA)|0.008|0.003|2.33|
|cvtColor8u::Size_CvtMode::(127x61, COLOR_BGR5552GRAY)|0.003|0.004|0.75|
|cvtColor8u::Size_CvtMode::(127x61, COLOR_BGR5552RGB)|0.007|0.004|1.98|
|cvtColor8u::Size_CvtMode::(127x61, COLOR_BGR5552RGBA)|0.008|0.004|2.26|
|cvtColor8u::Size_CvtMode::(127x61, COLOR_BGR5652BGR)|0.007|0.003|2.26|
|cvtColor8u::Size_CvtMode::(127x61, COLOR_BGR5652BGRA)|0.008|0.003|2.71|
|cvtColor8u::Size_CvtMode::(127x61, COLOR_BGR5652GRAY)|0.003|0.003|0.75|
|cvtColor8u::Size_CvtMode::(127x61, COLOR_BGR5652RGB)|0.007|0.003|2.20|
|cvtColor8u::Size_CvtMode::(127x61, COLOR_BGR5652RGBA)|0.008|0.003|2.62|
|cvtColor8u::Size_CvtMode::(127x61, COLOR_BGRA2BGR555)|0.004|0.004|1.16|
|cvtColor8u::Size_CvtMode::(127x61, COLOR_BGRA2BGR565)|0.003|0.004|0.95|
|cvtColor8u::Size_CvtMode::(127x61, COLOR_BGRA2GRAY)|0.006|0.004|1.42|
|cvtColor8u::Size_CvtMode::(127x61, COLOR_GRAY2BGR555)|0.002|0.001|1.68|
|cvtColor8u::Size_CvtMode::(127x61, COLOR_GRAY2BGR565)|0.002|0.001|1.25|
|cvtColor8u::Size_CvtMode::(127x61, COLOR_GRAY2BGR)|0.001|0.001|1.00|
|cvtColor8u::Size_CvtMode::(127x61, COLOR_GRAY2BGRA)|0.002|0.002|1.22|
|cvtColor8u::Size_CvtMode::(127x61, COLOR_RGB2BGR555)|0.010|0.003|3.14|
|cvtColor8u::Size_CvtMode::(127x61, COLOR_RGB2BGR565)|0.009|0.003|3.29|
|cvtColor8u::Size_CvtMode::(127x61, COLOR_RGB2GRAY)|0.006|0.004|1.68|
|cvtColor8u::Size_CvtMode::(127x61, COLOR_RGBA2BGR555)|0.004|0.004|1.16|
|cvtColor8u::Size_CvtMode::(127x61, COLOR_RGBA2BGR565)|0.003|0.004|0.90|
|cvtColor8u::Size_CvtMode::(127x61, COLOR_RGBA2GRAY)|0.006|0.004|1.35|
|cvtColor8u::Size_CvtMode::(640x480, COLOR_BGR2BGR555)|0.353|0.092|3.82|
|cvtColor8u::Size_CvtMode::(640x480, COLOR_BGR2BGR565)|0.353|0.076|4.66|
|cvtColor8u::Size_CvtMode::(640x480, COLOR_BGR2GRAY)|0.220|0.109|2.01|
|cvtColor8u::Size_CvtMode::(640x480, COLOR_BGR5552BGR)|0.253|0.110|2.30|
|cvtColor8u::Size_CvtMode::(640x480, COLOR_BGR5552BGRA)|0.311|0.101|3.09|
|cvtColor8u::Size_CvtMode::(640x480, COLOR_BGR5552GRAY)|0.085|0.115|0.74|
|cvtColor8u::Size_CvtMode::(640x480, COLOR_BGR5552RGB)|0.272|0.116|2.34|
|cvtColor8u::Size_CvtMode::(640x480, COLOR_BGR5552RGBA)|0.311|0.102|3.04|
|cvtColor8u::Size_CvtMode::(640x480, COLOR_BGR5652BGR)|0.253|0.100|2.54|
|cvtColor8u::Size_CvtMode::(640x480, COLOR_BGR5652BGRA)|0.323|0.088|3.68|
|cvtColor8u::Size_CvtMode::(640x480, COLOR_BGR5652GRAY)|0.083|0.106|0.78|
|cvtColor8u::Size_CvtMode::(640x480, COLOR_BGR5652RGB)|0.283|0.098|2.88|
|cvtColor8u::Size_CvtMode::(640x480, COLOR_BGR5652RGBA)|0.343|0.090|3.80|
|cvtColor8u::Size_CvtMode::(640x480, COLOR_BGRA2BGR555)|0.138|0.112|1.23|
|cvtColor8u::Size_CvtMode::(640x480, COLOR_BGRA2BGR565)|0.114|0.114|1.00|
|cvtColor8u::Size_CvtMode::(640x480, COLOR_BGRA2GRAY)|0.222|0.158|1.40|
|cvtColor8u::Size_CvtMode::(640x480, COLOR_GRAY2BGR555)|0.058|0.040|1.46|
|cvtColor8u::Size_CvtMode::(640x480, COLOR_GRAY2BGR565)|0.036|0.042|0.87|
|cvtColor8u::Size_CvtMode::(640x480, COLOR_GRAY2BGR)|0.035|0.036|0.96|
|cvtColor8u::Size_CvtMode::(640x480, COLOR_GRAY2BGRA)|0.048|0.050|0.95|
|cvtColor8u::Size_CvtMode::(640x480, COLOR_RGB2BGR555)|0.351|0.092|3.83|
|cvtColor8u::Size_CvtMode::(640x480, COLOR_RGB2BGR565)|0.355|0.083|4.27|
|cvtColor8u::Size_CvtMode::(640x480, COLOR_RGB2GRAY)|0.217|0.111|1.96|
|cvtColor8u::Size_CvtMode::(640x480, COLOR_RGBA2BGR555)|0.140|0.112|1.25|
|cvtColor8u::Size_CvtMode::(640x480, COLOR_RGBA2BGR565)|0.117|0.116|1.01|
|cvtColor8u::Size_CvtMode::(640x480, COLOR_RGBA2GRAY)|0.221|0.158|1.40|
|cvtColor8u::Size_CvtMode::(1920x1080, COLOR_BGR2BGR555)|2.414|0.652|3.70|
|cvtColor8u::Size_CvtMode::(1920x1080, COLOR_BGR2BGR565)|2.428|0.576|4.21|
|cvtColor8u::Size_CvtMode::(1920x1080, COLOR_BGR2GRAY)|1.514|0.761|1.99|
|cvtColor8u::Size_CvtMode::(1920x1080, COLOR_BGR5552BGR)|1.729|0.768|2.25|
|cvtColor8u::Size_CvtMode::(1920x1080, COLOR_BGR5552BGRA)|2.202|0.734|3.00|
|cvtColor8u::Size_CvtMode::(1920x1080, COLOR_BGR5552GRAY)|0.556|0.792|0.70|
|cvtColor8u::Size_CvtMode::(1920x1080, COLOR_BGR5552RGB)|1.874|0.781|2.40|
|cvtColor8u::Size_CvtMode::(1920x1080, COLOR_BGR5552RGBA)|2.204|0.757|2.91|
|cvtColor8u::Size_CvtMode::(1920x1080, COLOR_BGR5652BGR)|1.708|0.673|2.54|
|cvtColor8u::Size_CvtMode::(1920x1080, COLOR_BGR5652BGRA)|2.164|0.648|3.34|
|cvtColor8u::Size_CvtMode::(1920x1080, COLOR_BGR5652GRAY)|0.531|0.719|0.74|
|cvtColor8u::Size_CvtMode::(1920x1080, COLOR_BGR5652RGB)|1.846|0.668|2.76|
|cvtColor8u::Size_CvtMode::(1920x1080, COLOR_BGR5652RGBA)|2.137|0.655|3.26|
|cvtColor8u::Size_CvtMode::(1920x1080, COLOR_BGRA2BGR555)|0.962|0.877|1.10|
|cvtColor8u::Size_CvtMode::(1920x1080, COLOR_BGRA2BGR565)|0.825|0.876|0.94|
|cvtColor8u::Size_CvtMode::(1920x1080, COLOR_BGRA2GRAY)|1.498|1.062|1.41|
|cvtColor8u::Size_CvtMode::(1920x1080, COLOR_GRAY2BGR555)|0.359|0.267|1.34|
|cvtColor8u::Size_CvtMode::(1920x1080, COLOR_GRAY2BGR565)|0.243|0.279|0.87|
|cvtColor8u::Size_CvtMode::(1920x1080, COLOR_GRAY2BGR)|0.318|0.317|1.00|
|cvtColor8u::Size_CvtMode::(1920x1080, COLOR_GRAY2BGRA)|0.404|0.407|0.99|
|cvtColor8u::Size_CvtMode::(1920x1080, COLOR_RGB2BGR555)|2.392|0.658|3.64|
|cvtColor8u::Size_CvtMode::(1920x1080, COLOR_RGB2BGR565)|2.395|0.563|4.25|
|cvtColor8u::Size_CvtMode::(1920x1080, COLOR_RGB2GRAY)|1.503|0.740|2.03|
|cvtColor8u::Size_CvtMode::(1920x1080, COLOR_RGBA2BGR555)|1.026|0.866|1.18|
|cvtColor8u::Size_CvtMode::(1920x1080, COLOR_RGBA2BGR565)|0.856|0.867|0.99|
|cvtColor8u::Size_CvtMode::(1920x1080, COLOR_RGBA2GRAY)|1.516|1.062|1.43|


</details>

<details>
<summary>Not covered</summary>
Several conversions are not covered by perf tests so their performance was estimated with custom test:
 random image 511x511, time measured by loop of 20000 identical calls, averaged by 5 runs.
 
Resulting improvement depends on baseline and number of channels but doesn't differ significantly:

* `RGB2Gray<float>`:
  - 1.1x to 1.2x
* `RGB5x52Gray`:
  - the same except SSE2 which is 0.7x
* `RGB2Gray<ushort>`:
  - 1.0x to 1.2x except SSE2 which is 1.3x to 1.8x
* `RGBA2mRGBA<uchar>`:
  - from 2x on AVX512SKX to 3.7x on SSE2
*`mRGBA2RGBA<uchar>`:
  - from 2.7x on SSE2 to 5.3 on AVX2
</details>

```
#disable_ipp=ON
force_builders=Linux AVX2
```