### PR TITLE
Optimize exposure compensation

### DIFF
--- a/modules/stitching/perf/perf_stich.cpp
+++ b/modules/stitching/perf/perf_stich.cpp
@@ -13,6 +13,7 @@ using namespace perf;
 #define WORK_MEGAPIX 0.6
 
 typedef TestBaseWithParam<string> stitch;
+typedef TestBaseWithParam<int> stitchExposureCompensation;
 typedef TestBaseWithParam<tuple<string, string> > stitchDatasets;
 
 #ifdef HAVE_OPENCV_XFEATURES2D
@@ -20,6 +21,7 @@ typedef TestBaseWithParam<tuple<string, string> > stitchDatasets;
 #else
 #define TEST_DETECTORS testing::Values("orb", "akaze")
 #endif
+#define TEST_EXP_COMP_BS testing::Values(32, 16, 12, 10, 8)
 #define AFFINE_DATASETS testing::Values("s", "budapest", "newspaper", "prague")
 
 PERF_TEST_P(stitch, a123, TEST_DETECTORS)
@@ -49,6 +51,38 @@ PERF_TEST_P(stitch, a123, TEST_DETECTORS)
 
         startTimer();
         stitcher.stitch(imgs, pano);
+        stopTimer();
+    }
+
+    EXPECT_NEAR(pano.size().width, 1182, 50);
+    EXPECT_NEAR(pano.size().height, 682, 30);
+
+    SANITY_CHECK_NOTHING();
+}
+
+PERF_TEST_P(stitchExposureCompensation, a123, TEST_EXP_COMP_BS)
+{
+    Mat pano;
+
+    vector<Mat> imgs;
+    imgs.push_back( imread( getDataPath("stitching/a1.png") ) );
+    imgs.push_back( imread( getDataPath("stitching/a2.png") ) );
+    imgs.push_back( imread( getDataPath("stitching/a3.png") ) );
+
+    int bs = GetParam();
+
+    declare.time(30 * 10).iterations(10);
+
+    while(next())
+    {
+        Ptr<Stitcher> stitcher = Stitcher::create();
+        stitcher->setWarper(makePtr<SphericalWarper>());
+        stitcher->setRegistrationResol(WORK_MEGAPIX);
+        stitcher->setExposureCompensator(
+            makePtr<detail::BlocksGainCompensator>(bs, bs));
+
+        startTimer();
+        stitcher->stitch(imgs, pano);
         stopTimer();
     }
 

--- a/modules/stitching/src/exposure_compensate.cpp
+++ b/modules/stitching/src/exposure_compensate.cpp
@@ -80,6 +80,7 @@ void GainCompensator::feed(const std::vector<Point> &corners, const std::vector<
     const int num_images = static_cast<int>(images.size());
     Mat_<int> N(num_images, num_images); N.setTo(0);
     Mat_<double> I(num_images, num_images); I.setTo(0);
+    Mat_<bool> skip(num_images, 1); skip.setTo(true);
 
     //Rect dst_roi = resultRoi(corners, images);
     Mat subimg1, subimg2;
@@ -99,7 +100,19 @@ void GainCompensator::feed(const std::vector<Point> &corners, const std::vector<
                 submask2 = masks[j].first(Rect(roi.tl() - corners[j], roi.br() - corners[j])).getMat(ACCESS_READ);
                 intersect = (submask1 == masks[i].second) & (submask2 == masks[j].second);
 
-                N(i, j) = N(j, i) = std::max(1, countNonZero(intersect));
+                int intersect_count = countNonZero(intersect);
+                N(i, j) = N(j, i) = std::max(1, intersect_count);
+
+                // Don't compute Isums if subimages do not intersect anyway
+                if (intersect_count == 0)
+                    continue;
+
+                // Don't skip images that intersect with at least one other image
+                if (i != j)
+                {
+                    skip(i, 0) = false;
+                    skip(j, 0) = false;
+                }
 
                 double Isum1 = 0, Isum2 = 0;
                 for (int y = 0; y < roi.height; ++y)
@@ -123,22 +136,43 @@ void GainCompensator::feed(const std::vector<Point> &corners, const std::vector<
 
     double alpha = 0.01;
     double beta = 100;
+    int num_eq = num_images - countNonZero(skip);
 
-    Mat_<double> A(num_images, num_images); A.setTo(0);
-    Mat_<double> b(num_images, 1); b.setTo(0);
-    for (int i = 0; i < num_images; ++i)
+    Mat_<double> A(num_eq, num_eq); A.setTo(0);
+    Mat_<double> b(num_eq, 1); b.setTo(0);
+    for (int i = 0, ki = 0; i < num_images; ++i)
     {
-        for (int j = 0; j < num_images; ++j)
+        if (skip(i, 0))
+            continue;
+
+        for (int j = 0, kj = 0; j < num_images; ++j)
         {
-            b(i, 0) += beta * N(i, j);
-            A(i, i) += beta * N(i, j);
-            if (j == i) continue;
-            A(i, i) += 2 * alpha * I(i, j) * I(i, j) * N(i, j);
-            A(i, j) -= 2 * alpha * I(i, j) * I(j, i) * N(i, j);
+            if (skip(j, 0))
+                continue;
+
+            b(ki, 0) += beta * N(i, j);
+            A(ki, ki) += beta * N(i, j);
+            if (j != i)
+            {
+                A(ki, ki) += 2 * alpha * I(i, j) * I(i, j) * N(i, j);
+                A(ki, kj) -= 2 * alpha * I(i, j) * I(j, i) * N(i, j);
+            }
+            ++kj;
         }
+        ++ki;
     }
 
-    solve(A, b, gains_);
+    Mat_<double> l_gains;
+    solve(A, b, l_gains);
+
+    gains_.create(num_images, 1);
+    for (int i = 0, j = 0; i < num_images; ++i)
+    {
+        if (skip(i, 0))
+            gains_.at<double>(i, 0) = 1;
+        else
+            gains_.at<double>(i, 0) = l_gains(j++, 0);
+    }
 
     LOGLN("Exposure compensation, time: " << ((getTickCount() - t) / getTickFrequency()) << " sec");
 }


### PR DESCRIPTION
**Please read issue #13399 first**

First commit adds a performance test. It showcases a panorama-type stitching, using BlocksGainCompensator with different block size. As the block size get smaller, computation time explodes, fast.

The second commit resolves the first part of issue #13399, ignoring blocks that do not overlap with any other.

The third commit leverage Eigen if available to resolve the equation system in a more optimized fashion.

Performance test results: "master" is self-explanatory, "optimized" uses the second commit, "eigen_llt" uses the second and the third.
```
Geometric mean (ms)

            Name of Test              master   optimized  eigen   optimized    eigen   
                                                           llt        vs        llt    
                                                                    master       vs    
                                                                  (x-factor)   master  
                                                                             (x-factor)
a123::stitchExposureCompensation::8  54711.384 14658.466 2953.676    3.73      18.52   
a123::stitchExposureCompensation::10 15132.388 4515.318  1388.434    3.35      10.90   
a123::stitchExposureCompensation::12 5606.788  2058.821  888.011     2.72       6.31   
a123::stitchExposureCompensation::16 1421.896   843.919  545.014     1.68       2.61   
a123::stitchExposureCompensation::32  605.013   607.440  421.698     1.00       1.43
``` 

Note: Please feel free to showcase what you deem unacceptable and I will do my best to correct it.

[results.zip](https://github.com/opencv/opencv/files/2661094/results.zip)

