### PR TITLE
Remove MinCore_Downlevel, replace with Shlwapi

### DIFF
--- a/modules/videoio/src/cap_msmf.cpp
+++ b/modules/videoio/src/cap_msmf.cpp
@@ -99,9 +99,7 @@ static void init_MFCreateDXGIDeviceManager()
     pMFCreateDXGIDeviceManager_initialized = true;
 }
 #endif
-#if (WINVER >= 0x0602) // Available since Win 8
-#pragma comment(lib, "MinCore_Downlevel")
-#endif
+#pragma comment(lib, "Shlwapi.lib")
 #endif
 
 #include <mferror.h>


### PR DESCRIPTION
On windows 7, MinCore_Downlevel does not work correctly. However, the only API used was QISearch, which can be found in Shlwapi.

resolves #12010

This is a fix that should be backported to 3.4 as well. Should that be a separate PR, or done after merging?
