### PR TITLE
Add ability to build iOS and macOS frameworks with nonfree modules

### DIFF
--- a/platforms/ios/build_framework.py
+++ b/platforms/ios/build_framework.py
@@ -49,7 +49,7 @@ def getXCodeMajor():
         raise Exception("Failed to parse Xcode version")
 
 class Builder:
-    def __init__(self, opencv, contrib, dynamic, bitcodedisabled, exclude, targets):
+    def __init__(self, opencv, contrib, dynamic, bitcodedisabled, exclude, enablenonfree, targets):
         self.opencv = os.path.abspath(opencv)
         self.contrib = None
         if contrib:
@@ -61,6 +61,7 @@ class Builder:
         self.dynamic = dynamic
         self.bitcodedisabled = bitcodedisabled
         self.exclude = exclude
+        self.enablenonfree = enablenonfree
         self.targets = targets
 
     def getBD(self, parent, t):
@@ -136,7 +137,9 @@ class Builder:
             "-DBUILD_SHARED_LIBS=ON",
             "-DCMAKE_MACOSX_BUNDLE=ON",
             "-DCMAKE_XCODE_ATTRIBUTE_CODE_SIGNING_REQUIRED=NO",
-        ] if self.dynamic else [])
+        ] if self.dynamic else []) + ([
+            "-DOPENCV_ENABLE_NONFREE=ON"
+        ] if self.enablenonfree else [])
 
         if len(self.exclude) > 0:
             args += ["-DBUILD_opencv_world=OFF"] if not self.dynamic else []
@@ -284,6 +287,7 @@ if __name__ == "__main__":
     parser.add_argument('--iphoneos_deployment_target', default=os.environ.get('IPHONEOS_DEPLOYMENT_TARGET', IPHONEOS_DEPLOYMENT_TARGET), help='specify IPHONEOS_DEPLOYMENT_TARGET')
     parser.add_argument('--iphoneos_archs', default='armv7,armv7s,arm64', help='select iPhoneOS target ARCHS')
     parser.add_argument('--iphonesimulator_archs', default='i386,x86_64', help='select iPhoneSimulator target ARCHS')
+    parser.add_argument('--enable_nonfree', default=False, dest='enablenonfree', action='store_true', help='enable non-free modules (disabled by default)')
     args = parser.parse_args()
 
     os.environ['IPHONEOS_DEPLOYMENT_TARGET'] = args.iphoneos_deployment_target
@@ -293,7 +297,7 @@ if __name__ == "__main__":
     iphonesimulator_archs = args.iphonesimulator_archs.split(',')
     print('Using iPhoneSimulator ARCHS=' + str(iphonesimulator_archs))
 
-    b = iOSBuilder(args.opencv, args.contrib, args.dynamic, args.bitcodedisabled, args.without,
+    b = iOSBuilder(args.opencv, args.contrib, args.dynamic, args.bitcodedisabled, args.without, args.enablenonfree,
         [
             (iphoneos_archs, "iPhoneOS"),
         ] if os.environ.get('BUILD_PRECOMMIT', None) else

--- a/platforms/osx/build_framework.py
+++ b/platforms/osx/build_framework.py
@@ -38,9 +38,10 @@ if __name__ == "__main__":
     parser.add_argument('--opencv', metavar='DIR', default=folder, help='folder with opencv repository (default is "../.." relative to script location)')
     parser.add_argument('--contrib', metavar='DIR', default=None, help='folder with opencv_contrib repository (default is "None" - build only main framework)')
     parser.add_argument('--without', metavar='MODULE', default=[], action='append', help='OpenCV modules to exclude from the framework')
+    parser.add_argument('--enable_nonfree', default=False, dest='enablenonfree', action='store_true', help='enable non-free modules (disabled by default)')
     args = parser.parse_args()
 
-    b = OSXBuilder(args.opencv, args.contrib, False, False, args.without,
+    b = OSXBuilder(args.opencv, args.contrib, False, False, args.without, args.enablenonfree,
         [
             (["x86_64"], "MacOSX")
         ])


### PR DESCRIPTION
This Pull Request changes `build_framework.py` script in `platforms/ios` and `osx` to allow specifying that `OpenCV.framework` should be built with nonfree modules enabled, via `--enable_nonfree` boolean flag. It's false by default, thus preserves backwards compatibility.

Resolves #13417.