### PR TITLE
Operate with shapes in ONNX models

### DIFF
--- a/modules/dnn/test/test_onnx_importer.cpp
+++ b/modules/dnn/test/test_onnx_importer.cpp
@@ -162,6 +162,10 @@ TEST_P(Test_ONNX_layers, MultyInputs)
     normAssert(ref, out, "", default_l1,  default_lInf);
 }
 
+TEST_P(Test_ONNX_layers, DynamicReshape)
+{
+    testONNXModels("dynamic_reshape");
+}
 
 INSTANTIATE_TEST_CASE_P(/*nothing*/, Test_ONNX_layers, dnnBackendsAndTargets());
 


### PR DESCRIPTION
<!-- Please use this line to close one or multiple issues when this pullrequest gets merged
You can add another line right under the first one:
resolves #1234
resolves #1235
-->

### This pullrequest changes

* Compute shapes of intermediate blobs in ONNX importer
* Perform constant operations from ONNX graphs during import.
  * Shape: returns a shape of input blob
  * Gather: slicing specific dimension
  * Concat over constants

resolves https://github.com/opencv/opencv/issues/12869
resolves https://github.com/opencv/opencv/issues/13303

**Merge with extra**: https://github.com/opencv/opencv_extra/pull/558