### PR TITLE
cmake(java): add OPENCV_JAVA_SOURCE_VERSION / OPENCV_JAVA_TARGET_VERSION

### DIFF
--- a/cmake/OpenCVDetectApacheAnt.cmake
+++ b/cmake/OpenCVDetectApacheAnt.cmake
@@ -1,3 +1,6 @@
+set(OPENCV_JAVA_SOURCE_VERSION "" CACHE STRING "Java source version (javac Ant target)")
+set(OPENCV_JAVA_TARGET_VERSION "" CACHE STRING "Java target version (javac Ant target)")
+
 file(TO_CMAKE_PATH "$ENV{ANT_DIR}" ANT_DIR_ENV_PATH)
 file(TO_CMAKE_PATH "$ENV{ProgramFiles}" ProgramFiles_ENV_PATH)
 

--- a/modules/java/jar/CMakeLists.txt
+++ b/modules/java/jar/CMakeLists.txt
@@ -18,6 +18,13 @@ set(depends gen_opencv_java_source "${OPENCV_DEPHELPER}/gen_opencv_java_source")
 ocv_copyfiles_add_target(${the_module}_jar_source_copy JAVA_SRC_COPY "Copy Java(JAR) source files" ${depends})
 set(depends ${the_module}_jar_source_copy "${OPENCV_DEPHELPER}/${the_module}_jar_source_copy")
 
+if(OPENCV_JAVA_SOURCE_VERSION)
+  set(OPENCV_ANT_JAVAC_EXTRA_ATTRS "${OPENCV_ANT_JAVAC_EXTRA_ATTRS} source=\"${OPENCV_JAVA_SOURCE_VERSION}\"")
+endif()
+if(OPENCV_JAVA_TARGET_VERSION)
+  set(OPENCV_ANT_JAVAC_EXTRA_ATTRS "${OPENCV_ANT_JAVAC_EXTRA_ATTRS} target=\"${OPENCV_JAVA_TARGET_VERSION}\"")
+endif()
+
 configure_file("${CMAKE_CURRENT_SOURCE_DIR}/build.xml.in" "${OPENCV_JAVA_DIR}/build.xml" @ONLY)
 list(APPEND depends "${OPENCV_JAVA_DIR}/build.xml")
 

--- a/modules/java/jar/build.xml.in
+++ b/modules/java/jar/build.xml.in
@@ -11,7 +11,7 @@
     <!-- This is to make a jar with a source attachment, for e.g. easy -->
     <!-- navigation in Eclipse. See this question: -->
     <!-- http://stackoverflow.com/questions/3584968/ant-how-to-compile-jar-that-includes-source-attachment -->
-    <javac sourcepath="" srcdir="java" destdir="build/classes" debug="on" includeantruntime="false" >
+    <javac sourcepath="" srcdir="java" destdir="build/classes" debug="on" includeantruntime="false" @OPENCV_ANT_JAVAC_EXTRA_ATTRS@ >
       <include name="**/*.java"/>
       <compilerarg line="-encoding utf-8"/>
     </javac>


### PR DESCRIPTION
resolves #13434

Usage:
```
cmake -DOPENCV_JAVA_SOURCE_VERSION=1.5 -DOPENCV_JAVA_TARGET_VERSION=1.8 ...
cmake --build . --target opencv_java_jar
```