### PR TITLE
videoio: fix CAP_IMAGES

### DIFF
--- a/modules/videoio/src/cap_images.cpp
+++ b/modules/videoio/src/cap_images.cpp
@@ -288,7 +288,7 @@ bool CvCapture_Images::open(const std::string& _filename)
             }
         }
 
-        if(!haveImageReader(filename))
+        if(!haveImageReader(str))
             break;
 
         length++;


### PR DESCRIPTION
broken in 11eafca3e2a4cbc62f1309d25db0ea3ed9a6ea8e

relates #13060