### PR TITLE
core:vsx fix build failure on GCC<=6

### DIFF
--- a/modules/core/include/opencv2/core/hal/intrin_vsx.hpp
+++ b/modules/core/include/opencv2/core/hal/intrin_vsx.hpp
@@ -718,7 +718,7 @@ OPENCV_HAL_IMPL_VSX_REDUCE_OP_4(v_float32x4, vec_float4, float, min, vec_min)
 
 inline double v_reduce_sum(const v_float64x2& a)
 {
-    return vec_extract(vec_add(a.val, vec_sld(a.val, a.val, 8)), 0);
+    return vec_extract(vec_add(a.val, vec_permi(a.val, a.val, 3)), 0);
 }
 
 #define OPENCV_HAL_IMPL_VSX_REDUCE_OP_8(_Tpvec, _Tpvec2, scalartype, suffix, func) \


### PR DESCRIPTION
resolves #13442

````
force_builders=Custom
docker_image:Custom=powerpc64le
pw_compilers=gcc-4.9, gcc-5, gcc-6, gcc-7, clang-4, clang-5, clang-6, power9_gcc-4.9, power9_gcc-5, power9_gcc-6, power9_gcc-7, power9_clang-4, power9_clang-6
# newest version of Eigen(3.3.5) has bug on clang, disable it for now
pw_cmake_definitions=WITH_EIGEN:OFF
````