### PR TITLE
Added Turing to the _generations list.

### DIFF
--- a/cmake/OpenCVDetectCUDA.cmake
+++ b/cmake/OpenCVDetectCUDA.cmake
@@ -52,7 +52,7 @@ if(CUDA_FOUND)
 
   message(STATUS "CUDA detected: " ${CUDA_VERSION})
 
-  set(_generations "Fermi" "Kepler" "Maxwell" "Pascal" "Volta")
+  set(_generations "Fermi" "Kepler" "Maxwell" "Pascal" "Volta" "Turing")
   if(NOT CMAKE_CROSSCOMPILING)
     list(APPEND _generations "Auto")
   endif()


### PR DESCRIPTION
resolves #13465

### This pullrequest changes

Fixed the fact the Turing option wasn't added to `_gerenations` in `cmake/OpenCVDetectCUDA.cmake`.
