### PR TITLE
Try to fix "enum struct" wrapping for Java

### DIFF
--- a/modules/features2d/misc/java/test/Features2dTest.java
+++ b/modules/features2d/misc/java/test/Features2dTest.java
@@ -7,11 +7,13 @@ import java.util.List;
 import org.opencv.calib3d.Calib3d;
 import org.opencv.core.CvType;
 import org.opencv.core.Mat;
+import org.opencv.core.MatOfInt;
 import org.opencv.core.MatOfDMatch;
 import org.opencv.core.MatOfKeyPoint;
 import org.opencv.core.MatOfPoint2f;
 import org.opencv.core.Point;
 import org.opencv.core.Range;
+import org.opencv.core.Scalar;
 import org.opencv.core.DMatch;
 import org.opencv.features2d.DescriptorMatcher;
 import org.opencv.features2d.Features2d;
@@ -140,5 +142,31 @@ public class Features2dTest extends OpenCVTestCase {
         String outputPath = OpenCVTestRunner.getOutputFileName("PTODresult.png");
         Imgcodecs.imwrite(outputPath, outimg);
         // OpenCVTestRunner.Log("Output image is saved to: " + outputPath);
+    }
+
+    public void testDrawKeypoints()
+    {
+        Mat outImg = Mat.ones(11, 11, CvType.CV_8U);
+
+        MatOfKeyPoint kps = new MatOfKeyPoint(new KeyPoint(5, 5, 1));  // x, y, size
+        Features2d.drawKeypoints(new Mat(), kps, outImg, new Scalar(255),
+                                 Features2d.DrawMatchesFlags_DRAW_OVER_OUTIMG);
+
+        Mat ref = new MatOfInt(new int[] {
+            1,   1,   1,   1,   1,   1,   1,   1,   1,   1,   1,
+            1,   1,   1,   1,  15,  54,  15,   1,   1,   1,   1,
+            1,   1,   1,  76, 217, 217, 221,  81,   1,   1,   1,
+            1,   1, 100, 224, 111,  57, 115, 225, 101,   1,   1,
+            1,  44, 215, 100,   1,   1,   1, 101, 214,  44,   1,
+            1,  54, 212,  57,   1,   1,   1,  55, 212,  55,   1,
+            1,  40, 215, 104,   1,   1,   1, 105, 215,  40,   1,
+            1,   1, 102, 221, 111,  55, 115, 222, 103,   1,   1,
+            1,   1,   1,  76, 218, 217, 220,  81,   1,   1,   1,
+            1,   1,   1,   1,  15,  55,  15,   1,   1,   1,   1,
+            1,   1,   1,   1,   1,   1,   1,   1,   1,   1,   1
+        }).reshape(1, 11);
+        ref.convertTo(ref, CvType.CV_8U);
+
+        assertMatEqual(ref, outImg);
     }
 }

--- a/modules/java/generator/gen_java.py
+++ b/modules/java/generator/gen_java.py
@@ -427,9 +427,12 @@ class JavaWrapperGenerator(object):
         constinfo = ConstInfo(decl, namespaces=self.namespaces, enumType=enumType)
         if constinfo.isIgnored():
             logging.info('ignored: %s', constinfo)
-        elif not self.isWrapped(constinfo.classname):
-            logging.info('class not found: %s', constinfo)
         else:
+            if not self.isWrapped(constinfo.classname):
+                logging.info('class not found: %s', constinfo)
+                constinfo.name = constinfo.classname + '_' + constinfo.name
+                constinfo.classname = ''
+
             ci = self.getClass(constinfo.classname)
             duplicate = ci.getConst(constinfo.name)
             if duplicate:

--- a/modules/python/src2/hdr_parser.py
+++ b/modules/python/src2/hdr_parser.py
@@ -634,6 +634,8 @@ class CppHeaderParser(object):
             block_type, block_name = b[self.BLOCK_TYPE], b[self.BLOCK_NAME]
             if block_type in ["file", "enum"]:
                 continue
+            if block_type in ["enum struct", "enum class"] and block_name == name:
+                continue
             if block_type not in ["struct", "class", "namespace", "enum struct", "enum class"]:
                 print("Error at %d: there are non-valid entries in the current block stack %s" % (self.lineno, self.block_stack))
                 sys.exit(-1)

--- a/samples/java/tutorial_code/features2D/feature_flann_matcher/SURFFLANNMatchingDemo.java
+++ b/samples/java/tutorial_code/features2D/feature_flann_matcher/SURFFLANNMatchingDemo.java
@@ -58,7 +58,7 @@ class SURFFLANNMatching {
         //-- Draw matches
         Mat imgMatches = new Mat();
         Features2d.drawMatches(img1, keypoints1, img2, keypoints2, goodMatches, imgMatches, Scalar.all(-1),
-                Scalar.all(-1), new MatOfByte(), Features2d.NOT_DRAW_SINGLE_POINTS);
+                Scalar.all(-1), new MatOfByte(), Features2d.DrawMatchesFlags_NOT_DRAW_SINGLE_POINTS);
 
         //-- Show detected matches
         HighGui.imshow("Good Matches", imgMatches);

--- a/samples/java/tutorial_code/features2D/feature_homography/SURFFLANNMatchingHomographyDemo.java
+++ b/samples/java/tutorial_code/features2D/feature_homography/SURFFLANNMatchingHomographyDemo.java
@@ -64,7 +64,7 @@ class SURFFLANNMatchingHomography {
         //-- Draw matches
         Mat imgMatches = new Mat();
         Features2d.drawMatches(imgObject, keypointsObject, imgScene, keypointsScene, goodMatches, imgMatches, Scalar.all(-1),
-                Scalar.all(-1), new MatOfByte(), Features2d.NOT_DRAW_SINGLE_POINTS);
+                Scalar.all(-1), new MatOfByte(), Features2d.DrawMatchesFlags_NOT_DRAW_SINGLE_POINTS);
 
         //-- Localize the object
         List<Point> obj = new ArrayList<>();


### PR DESCRIPTION
<!-- Please use this line to close one or multiple issues when this pullrequest gets merged
You can add another line right under the first one:
resolves #1234
resolves #1235
-->

### This pullrequest changes

resolves https://github.com/opencv/opencv/issues/12963

docs: https://pullrequest.opencv.org/buildbot/export/pr/13471/docs/javadoc/index.html

Current output for Features2d.java:

```java
    // C++: enum DrawMatchesFlags
    public static final int
            DrawMatchesFlags_DEFAULT = 0,
            DrawMatchesFlags_DRAW_OVER_OUTIMG = 1,
            DrawMatchesFlags_NOT_DRAW_SINGLE_POINTS = 2,
            DrawMatchesFlags_DRAW_RICH_KEYPOINTS = 4;

...

    //
    // C++:  void cv::drawKeypoints(Mat image, vector_KeyPoint keypoints, Mat& outImage, Scalar color = Scalar::all(-1), DrawMatchesFlags flags = DrawMatchesFlags::DEFAULT)
    //

    //javadoc: drawKeypoints(image, keypoints, outImage, color, flags)
    public static void drawKeypoints(Mat image, MatOfKeyPoint keypoints, Mat outImage, Scalar color, int flags)
    {
        Mat keypoints_mat = keypoints;
        drawKeypoints_0(image.nativeObj, keypoints_mat.nativeObj, outImage.nativeObj, color.val[0], color.val[1], color.val[2], color.val[3], flags);
        
        return;
    }

...

    //
    // C++:  void cv::drawMatches(Mat img1, vector_KeyPoint keypoints1, Mat img2, vector_KeyPoint keypoints2, vector_DMatch matches1to2, Mat& outImg, Scalar matchColor = Scalar::all(-1), Scalar singlePointColor = Scalar::all(-1), vector_char matchesMask = std::vector<char>(), DrawMatchesFlags flags = DrawMatchesFlags::DEFAULT)
    //

    //javadoc: drawMatches(img1, keypoints1, img2, keypoints2, matches1to2, outImg, matchColor, singlePointColor, matchesMask, flags)
    public static void drawMatches(Mat img1, MatOfKeyPoint keypoints1, Mat img2, MatOfKeyPoint keypoints2, MatOfDMatch matches1to2, Mat outImg, Scalar matchColor, Scalar singlePointColor, MatOfByte matchesMask, int flags)
    {
        Mat keypoints1_mat = keypoints1;
        Mat keypoints2_mat = keypoints2;
        Mat matches1to2_mat = matches1to2;
        Mat matchesMask_mat = matchesMask;
        drawMatches_0(img1.nativeObj, keypoints1_mat.nativeObj, img2.nativeObj, keypoints2_mat.nativeObj, matches1to2_mat.nativeObj, outImg.nativeObj, matchColor.val[0], matchColor.val[1], matchColor.val[2], matchColor.val[3], singlePointColor.val[0], singlePointColor.val[1], singlePointColor.val[2], singlePointColor.val[3], matchesMask_mat.nativeObj, flags);
        
        return;
    }
```