### PR TITLE
find Protobuf in OpenCVConfig.cmake when OpenCV was build as static lib

### DIFF
--- a/cmake/OpenCVGenConfig.cmake
+++ b/cmake/OpenCVGenConfig.cmake
@@ -59,6 +59,13 @@ else()
   set(USE_IPPIW FALSE)
 endif()
 
+if(TARGET libprotobuf AND NOT BUILD_SHARED_LIBS AND NOT BUILD_PROTOBUF)
+  set(USE_PROTOBUF TRUE)
+  ocv_cmake_configure("${CMAKE_CURRENT_LIST_DIR}/templates/OpenCVConfig-Protobuf.cmake.in" PROTOBUF_CONFIGCMAKE @ONLY)
+else()
+  set(USE_PROTOBUF FALSE)
+endif()
+
 ocv_cmake_hook(PRE_CMAKE_CONFIG_BUILD)
 configure_file("${OpenCV_SOURCE_DIR}/cmake/templates/OpenCVConfig.cmake.in" "${CMAKE_BINARY_DIR}/OpenCVConfig.cmake" @ONLY)
 #support for version checking when finding opencv. find_package(OpenCV 2.3.1 EXACT) should now work.
@@ -77,6 +84,9 @@ endif()
 if(USE_IPPIW)
   file(RELATIVE_PATH IPPIW_INSTALL_PATH_RELATIVE_CONFIGCMAKE "${CMAKE_INSTALL_PREFIX}" "${IPPIW_INSTALL_PATH}")
   ocv_cmake_configure("${CMAKE_CURRENT_LIST_DIR}/templates/OpenCVConfig-IPPIW.cmake.in" IPPIW_CONFIGCMAKE @ONLY)
+endif()
+if(USE_PROTOBUF)
+  ocv_cmake_configure("${CMAKE_CURRENT_LIST_DIR}/templates/OpenCVConfig-Protobuf.cmake.in" PROTOBUF_CONFIGCMAKE @ONLY)
 endif()
 
 function(ocv_gen_config TMP_DIR NESTED_PATH ROOT_NAME)

--- a/cmake/templates/OpenCVConfig-Protobuf.cmake.in
+++ b/cmake/templates/OpenCVConfig-Protobuf.cmake.in
@@ -1,0 +1,56 @@
+set(OpenCV_Protobuf_VERSION "@Protobuf_VERSION@")
+
+function(get_protobuf_version version include)
+  file(STRINGS "${include}/google/protobuf/stubs/common.h" ver REGEX "#define GOOGLE_PROTOBUF_VERSION [0-9]+")
+  string(REGEX MATCHALL "[0-9]+" ver ${ver})
+  math(EXPR major "${ver} / 1000000")
+  math(EXPR minor "${ver} / 1000 % 1000")
+  math(EXPR patch "${ver} % 1000")
+  set(${version} "${major}.${minor}.${patch}" PARENT_SCOPE)
+endfunction()
+
+if(NOT Protobuf_FOUND)
+  find_package(Protobuf CONFIG QUIET)
+endif()
+
+if(NOT Protobuf_FOUND)
+  find_package(Protobuf MODULE QUIET)
+endif()
+
+# Backwards compatibility
+# Define camel case versions of input variables
+foreach(UPPER
+    PROTOBUF_FOUND
+    PROTOBUF_LIBRARY
+    PROTOBUF_INCLUDE_DIR
+    PROTOBUF_VERSION
+    )
+    if (DEFINED ${UPPER})
+        string(REPLACE "PROTOBUF_" "Protobuf_" Camel ${UPPER})
+        if (NOT DEFINED ${Camel})
+            set(${Camel} ${${UPPER}})
+        endif()
+    endif()
+endforeach()
+# end of compatibility block
+
+if(Protobuf_FOUND)
+  if(TARGET protobuf::libprotobuf)
+    add_library(libprotobuf INTERFACE IMPORTED)
+    set_target_properties(libprotobuf PROPERTIES
+      INTERFACE_LINK_LIBRARIES protobuf::libprotobuf
+    )
+  else()
+    add_library(libprotobuf UNKNOWN IMPORTED)
+    set_target_properties(libprotobuf PROPERTIES
+      IMPORTED_LOCATION "${Protobuf_LIBRARY}"
+      INTERFACE_INCLUDE_DIRECTORIES "${Protobuf_INCLUDE_DIR}"
+      INTERFACE_SYSTEM_INCLUDE_DIRECTORIES "${Protobuf_INCLUDE_DIR}"
+    )
+    get_protobuf_version(Protobuf_VERSION "${Protobuf_INCLUDE_DIR}")
+  endif()
+endif()
+
+if(NOT Protobuf_VERSION VERSION_EQUAL OpenCV_Protobuf_VERSION)
+  message(FATAL_ERROR "OpenCV static library was compiled with Protobuf ${OpenCV_Protobuf_VERSION} support. Please, use the same version or rebuild OpenCV with Protobuf ${Protobuf_VERSION}")
+endif()

--- a/cmake/templates/OpenCVConfig.cmake.in
+++ b/cmake/templates/OpenCVConfig.cmake.in
@@ -99,6 +99,8 @@ endif()
 @IPPICV_CONFIGCMAKE@
 @IPPIW_CONFIGCMAKE@
 
+@PROTOBUF_CONFIGCMAKE@
+
 # Some additional settings are required if OpenCV is built as static libs
 set(OpenCV_SHARED @BUILD_SHARED_LIBS@)
 


### PR DESCRIPTION
When building OpenCV as static library, the target 'libprotobuf' is part of
the INTERFACE_LINK_LIBRARIES. Therefore, Protobuf should be found
by the OpenCVConfig.cmake if it was not found before and the
libprotobuf target has to be created.
