### PR TITLE
GAPI OCL backend internal UMat size fix

### DIFF
--- a/modules/gapi/src/backends/ocl/goclbackend.cpp
+++ b/modules/gapi/src/backends/ocl/goclbackend.cpp
@@ -102,7 +102,7 @@ cv::gimpl::GOCLExecutable::GOCLExecutable(const ade::Graph &g,
             {
                 const auto mat_desc = util::get<cv::GMatDesc>(desc.meta);
                 const auto type = CV_MAKETYPE(mat_desc.depth, mat_desc.chan);
-                m_res.slot<cv::UMat>()[desc.rc].create(mat_desc.size.width, mat_desc.size.height, type);
+                m_res.slot<cv::UMat>()[desc.rc].create(mat_desc.size.height, mat_desc.size.width, type);
             }
             break;
         }


### PR DESCRIPTION
<!-- Please use this line to close one or multiple issues when this pullrequest gets merged
You can add another line right under the first one:
resolves #1234
resolves #1235
-->

### This pullrequest changes
Fixes issues with multiple nodes subgraphs for OCL/GPU GAPI backend 
<!-- Please describe what your pullrequest is changing -->
