### PR TITLE
videoio: Fix new frame size applying in v4l.

### DIFF
--- a/modules/videoio/src/cap_v4l.cpp
+++ b/modules/videoio/src/cap_v4l.cpp
@@ -1757,7 +1757,7 @@ bool CvCaptureCAM_V4L::icvSetFrameSize(int _width, int _height)
     if (_width > 0)
         width_set = _width;
 
-    if (height > 0)
+    if (_height > 0)
         height_set = _height;
 
     /* two subsequent calls setting WIDTH and HEIGHT will change


### PR DESCRIPTION
videoio: v4l: Fix new frame size applying in v4l.

### This pullrequest changes
1. Fix variable name in `if` expression in CvCaptureCAM_V4L::icvSetFrameSize