### PR TITLE
Internalize protobuf symbols 

### DIFF
--- a/3rdparty/protobuf/CMakeLists.txt
+++ b/3rdparty/protobuf/CMakeLists.txt
@@ -149,6 +149,7 @@ set_target_properties(libprotobuf
     COMPILE_PDB_NAME libprotobuf
     COMPILE_PDB_NAME_DEBUG "libprotobuf${OPENCV_DEBUG_POSTFIX}"
     ARCHIVE_OUTPUT_DIRECTORY ${3P_LIBRARY_OUTPUT_PATH}
+	CXX_VISIBILITY_PRESET hidden
     )
 
 get_protobuf_version(Protobuf_VERSION "${PROTOBUF_ROOT}/src")


### PR DESCRIPTION
### This pullrequest changes

Internalizes protobuf symbols in order for opencv to be statically linked on Ubuntu 18.04 / gcc 8.2.0.