### PR TITLE
fix initial values bug for `pairwise_matches[xxx].confidence`

### DIFF
--- a/modules/stitching/src/matchers.cpp
+++ b/modules/stitching/src/matchers.cpp
@@ -543,6 +543,7 @@ void FeaturesMatcher::operator ()(const vector<ImageFeatures> &features, vector<
             if (features[i].keypoints.size() > 0 && features[j].keypoints.size() > 0 && mask_(i, j))
                 near_pairs.push_back(make_pair(i, j));
 
+    pairwise_matches.clear(); // clear history values
     pairwise_matches.resize(num_images * num_images);
     MatchPairsBody body(*this, features, pairwise_matches, near_pairs);
 


### PR DESCRIPTION
<!-- Please use this line to close one or multiple issues when this pullrequest gets merged
You can add another line right under the first one:
resolves #1234
resolves #1235
-->

This pullrequest fixes the initial values bug of `pairwise_matches[xxx].confidence` in `FeaturesMatcher::operator ()` of `modules/stitching/src/matcher.cpp` when `Stitcher::stitch()` is called multiple times for different input images and there are images that fail to compute a validate Homography matrix.

<!-- Please describe what your pullrequest is changing -->
