### PR TITLE
Channels exposure compensators

### DIFF
--- a/modules/stitching/include/opencv2/stitching/detail/exposure_compensate.hpp
+++ b/modules/stitching/include/opencv2/stitching/detail/exposure_compensate.hpp
@@ -110,6 +110,7 @@ intensities, see @cite BL07 and @cite WJ10 for details.
 class CV_EXPORTS_W GainCompensator : public ExposureCompensator
 {
 public:
+    // This Constructor only exists to make source level compatibility detector happy
     CV_WRAP GainCompensator()
             : GainCompensator(1) {}
     CV_WRAP GainCompensator(int nr_feeds)
@@ -184,6 +185,7 @@ intensities, see @cite UES01 for details.
 class CV_EXPORTS_W BlocksGainCompensator : public BlocksCompensator
 {
 public:
+    // This Constructor only exists to make source level compatibility detector happy
     CV_WRAP BlocksGainCompensator(int bl_width = 32, int bl_height = 32)
             : BlocksGainCompensator(bl_width, bl_height, 1) {}
     CV_WRAP BlocksGainCompensator(int bl_width, int bl_height, int nr_feeds)
@@ -191,6 +193,14 @@ public:
 
     void feed(const std::vector<Point> &corners, const std::vector<UMat> &images,
               const std::vector<std::pair<UMat,uchar> > &masks) CV_OVERRIDE;
+
+    // This function only exists to make source level compatibility detector happy
+    CV_WRAP void apply(int index, Point corner, InputOutputArray image, InputArray mask) CV_OVERRIDE {
+        BlocksCompensator::apply(index, corner, image, mask); }
+    // This function only exists to make source level compatibility detector happy
+    CV_WRAP void getMatGains(CV_OUT std::vector<Mat>& umv) CV_OVERRIDE { BlocksCompensator::getMatGains(umv); }
+    // This function only exists to make source level compatibility detector happy
+    CV_WRAP void setMatGains(std::vector<Mat>& umv) CV_OVERRIDE { BlocksCompensator::setMatGains(umv); }
 };
 
 /** @brief Exposure compensator which tries to remove exposure related artifacts by adjusting image block

--- a/modules/stitching/include/opencv2/stitching/detail/exposure_compensate.hpp
+++ b/modules/stitching/include/opencv2/stitching/detail/exposure_compensate.hpp
@@ -62,7 +62,7 @@ class CV_EXPORTS_W ExposureCompensator
 public:
     virtual ~ExposureCompensator() {}
 
-    enum { NO, GAIN, GAIN_BLOCKS };
+    enum { NO, GAIN, GAIN_BLOCKS, CHANNELS };
     CV_WRAP static Ptr<ExposureCompensator> createDefault(int type);
 
     /**
@@ -127,6 +127,27 @@ public:
 
 private:
     Mat_<double> gains_;
+    int nr_feeds_;
+};
+
+/** @brief Exposure compensator which tries to remove exposure related artifacts by adjusting image
+intensities on each channel independantly.
+ */
+class CV_EXPORTS_W ChannelsCompensator : public ExposureCompensator
+{
+public:
+    CV_WRAP ChannelsCompensator(int nr_feeds=1) : nr_feeds_(nr_feeds) {}
+    void feed(const std::vector<Point> &corners, const std::vector<UMat> &images,
+              const std::vector<std::pair<UMat,uchar> > &masks) CV_OVERRIDE;
+    CV_WRAP void apply(int index, Point corner, InputOutputArray image, InputArray mask) CV_OVERRIDE;
+    CV_WRAP void getMatGains(CV_OUT std::vector<Mat>& umv) CV_OVERRIDE;
+    CV_WRAP void setMatGains(std::vector<Mat>& umv) CV_OVERRIDE;
+    CV_WRAP void setNrFeeds(int nr_feeds) { nr_feeds_ = nr_feeds; }
+    CV_WRAP int getNrFeeds() { return nr_feeds_; }
+    std::vector<Scalar> gains() const { return gains_; }
+
+private:
+    std::vector<Scalar> gains_;
     int nr_feeds_;
 };
 

--- a/modules/stitching/include/opencv2/stitching/detail/exposure_compensate.hpp
+++ b/modules/stitching/include/opencv2/stitching/detail/exposure_compensate.hpp
@@ -62,7 +62,7 @@ class CV_EXPORTS_W ExposureCompensator
 public:
     virtual ~ExposureCompensator() {}
 
-    enum { NO, GAIN, GAIN_BLOCKS, CHANNELS };
+    enum { NO, GAIN, GAIN_BLOCKS, CHANNELS, CHANNELS_BLOCKS };
     CV_WRAP static Ptr<ExposureCompensator> createDefault(int type);
 
     /**
@@ -151,28 +151,59 @@ private:
     int nr_feeds_;
 };
 
-/** @brief Exposure compensator which tries to remove exposure related artifacts by adjusting image block
-intensities, see @cite UES01 for details.
+/** @brief Exposure compensator which tries to remove exposure related artifacts by adjusting image blocks.
  */
-class CV_EXPORTS_W BlocksGainCompensator : public ExposureCompensator
+class CV_EXPORTS_W BlocksCompensator : public ExposureCompensator
 {
 public:
-    CV_WRAP BlocksGainCompensator(int bl_width = 32, int bl_height = 32)
-            : BlocksGainCompensator(bl_width, bl_height, 1) {}
-    CV_WRAP BlocksGainCompensator(int bl_width, int bl_height, int nr_feeds)
-            : bl_width_(bl_width), bl_height_(bl_height), nr_feeds_(nr_feeds) {setUpdateGain(true);}
-    void feed(const std::vector<Point> &corners, const std::vector<UMat> &images,
-              const std::vector<std::pair<UMat,uchar> > &masks) CV_OVERRIDE;
+    BlocksCompensator(int bl_width=32, int bl_height=32, int nr_feeds=1)
+            : bl_width_(bl_width), bl_height_(bl_height), nr_feeds_(nr_feeds) {}
     CV_WRAP void apply(int index, Point corner, InputOutputArray image, InputArray mask) CV_OVERRIDE;
     CV_WRAP void getMatGains(CV_OUT std::vector<Mat>& umv) CV_OVERRIDE;
     CV_WRAP void setMatGains(std::vector<Mat>& umv) CV_OVERRIDE;
     CV_WRAP void setNrFeeds(int nr_feeds) { nr_feeds_ = nr_feeds; }
     CV_WRAP int getNrFeeds() { return nr_feeds_; }
 
+protected:
+    template<class Compensator>
+    void feed(const std::vector<Point> &corners, const std::vector<UMat> &images,
+              const std::vector<std::pair<UMat,uchar> > &masks);
+
 private:
+    UMat getGainMap(const GainCompensator& compensator, int bl_idx, Size bl_per_img);
+    UMat getGainMap(const ChannelsCompensator& compensator, int bl_idx, Size bl_per_img);
+
     int bl_width_, bl_height_;
     std::vector<UMat> gain_maps_;
     int nr_feeds_;
+};
+
+/** @brief Exposure compensator which tries to remove exposure related artifacts by adjusting image block
+intensities, see @cite UES01 for details.
+ */
+class CV_EXPORTS_W BlocksGainCompensator : public BlocksCompensator
+{
+public:
+    CV_WRAP BlocksGainCompensator(int bl_width = 32, int bl_height = 32)
+            : BlocksGainCompensator(bl_width, bl_height, 1) {}
+    CV_WRAP BlocksGainCompensator(int bl_width, int bl_height, int nr_feeds)
+            : BlocksCompensator(bl_width, bl_height, nr_feeds) {setUpdateGain(true);}
+
+    void feed(const std::vector<Point> &corners, const std::vector<UMat> &images,
+              const std::vector<std::pair<UMat,uchar> > &masks) CV_OVERRIDE;
+};
+
+/** @brief Exposure compensator which tries to remove exposure related artifacts by adjusting image block
+on each channel.
+ */
+class CV_EXPORTS_W BlocksChannelsCompensator : public BlocksCompensator
+{
+public:
+    CV_WRAP BlocksChannelsCompensator(int bl_width=32, int bl_height=32, int nr_feeds=1)
+            : BlocksCompensator(bl_width, bl_height, nr_feeds) {setUpdateGain(true);}
+
+    void feed(const std::vector<Point> &corners, const std::vector<UMat> &images,
+              const std::vector<std::pair<UMat,uchar> > &masks) CV_OVERRIDE;
 };
 //! @}
 

--- a/modules/stitching/perf/perf_stich.cpp
+++ b/modules/stitching/perf/perf_stich.cpp
@@ -24,7 +24,7 @@ typedef TestBaseWithParam<tuple<string, int>> stitchExposureCompMultiFeed;
 #endif
 #define TEST_EXP_COMP_BS testing::Values(32, 16, 12, 10, 8)
 #define TEST_EXP_COMP_NR_FEED testing::Values(1, 2, 3, 4, 5)
-#define TEST_EXP_COMP_MODE testing::Values("gain", "channels", "blocks_gain")
+#define TEST_EXP_COMP_MODE testing::Values("gain", "channels", "blocks_gain", "blocks_channels")
 #define AFFINE_DATASETS testing::Values("s", "budapest", "newspaper", "prague")
 
 PERF_TEST_P(stitch, a123, TEST_DETECTORS)
@@ -117,6 +117,8 @@ PERF_TEST_P(stitchExposureCompMultiFeed, a123, testing::Combine(TEST_EXP_COMP_MO
         exp_comp = makePtr<detail::ChannelsCompensator>(nr_feeds);
     else if (mode == "blocks_gain")
         exp_comp = makePtr<detail::BlocksGainCompensator>(block_size, block_size, nr_feeds);
+    else if (mode == "blocks_channels")
+        exp_comp = makePtr<detail::BlocksChannelsCompensator>(block_size, block_size, nr_feeds);
 
     while(next())
     {

--- a/modules/stitching/perf/perf_stich.cpp
+++ b/modules/stitching/perf/perf_stich.cpp
@@ -24,7 +24,7 @@ typedef TestBaseWithParam<tuple<string, int>> stitchExposureCompMultiFeed;
 #endif
 #define TEST_EXP_COMP_BS testing::Values(32, 16, 12, 10, 8)
 #define TEST_EXP_COMP_NR_FEED testing::Values(1, 2, 3, 4, 5)
-#define TEST_EXP_COMP_MODE testing::Values("gain", "blocks")
+#define TEST_EXP_COMP_MODE testing::Values("gain", "channels", "blocks_gain")
 #define AFFINE_DATASETS testing::Values("s", "budapest", "newspaper", "prague")
 
 PERF_TEST_P(stitch, a123, TEST_DETECTORS)
@@ -111,10 +111,12 @@ PERF_TEST_P(stitchExposureCompMultiFeed, a123, testing::Combine(TEST_EXP_COMP_MO
     declare.time(30 * 10).iterations(10);
 
     Ptr<detail::ExposureCompensator> exp_comp;
-    if (mode == "blocks")
-        exp_comp = makePtr<detail::BlocksGainCompensator>(block_size, block_size, nr_feeds);
-    else if (mode == "gain")
+    if (mode == "gain")
         exp_comp = makePtr<detail::GainCompensator>(nr_feeds);
+    else if (mode == "channels")
+        exp_comp = makePtr<detail::ChannelsCompensator>(nr_feeds);
+    else if (mode == "blocks_gain")
+        exp_comp = makePtr<detail::BlocksGainCompensator>(block_size, block_size, nr_feeds);
 
     while(next())
     {

--- a/modules/stitching/src/exposure_compensate.cpp
+++ b/modules/stitching/src/exposure_compensate.cpp
@@ -370,19 +370,16 @@ void BlocksGainCompensator::apply(int index, Point /*corner*/, InputOutputArray 
     else
         resize(gain_maps_[index], u_gain_map, _image.size(), 0, 0, INTER_LINEAR);
 
-    Mat_<float> gain_map = u_gain_map.getMat(ACCESS_READ);
-    Mat image = _image.getMat();
-    for (int y = 0; y < image.rows; ++y)
+    if (u_gain_map.channels() != 3)
     {
-        const float* gain_row = gain_map.ptr<float>(y);
-        Point3_<uchar>* row = image.ptr<Point3_<uchar> >(y);
-        for (int x = 0; x < image.cols; ++x)
-        {
-            row[x].x = saturate_cast<uchar>(row[x].x * gain_row[x]);
-            row[x].y = saturate_cast<uchar>(row[x].y * gain_row[x]);
-            row[x].z = saturate_cast<uchar>(row[x].z * gain_row[x]);
-        }
+        std::vector<UMat> gains_channels;
+        gains_channels.push_back(u_gain_map);
+        gains_channels.push_back(u_gain_map);
+        gains_channels.push_back(u_gain_map);
+        merge(gains_channels, u_gain_map);
     }
+
+    multiply(_image, u_gain_map, _image, 1, _image.type());
 }
 
 void BlocksGainCompensator::getMatGains(std::vector<Mat>& umv)


### PR DESCRIPTION
### This pullrequest changes

Adds ChannelsCompensator and BlocksChannelsCompensator. The idea is to compensator each channel independantly. This is necessary if the images we want to stitch together do not have the same white balance.

For instance, I used three images of the "boatN.jpg" samples from opencv_extra, and modified the white balance of each of those. I then compared the result using the 4 compensators.

[Base images](https://ibb.co/y53HG7s)
1st one is original.
2nd one is colder.
3rd one is warmer.

[Stitching result](https://ibb.co/yVXzNfH)
1st one is `GainCompensator`
2nd one is `BlocksGainCompensator`
3rd one is `ChannelsCompensator`
4th one is `BlocksChannelsCompensator`

### Patch description
Commits e03ce35, 6ae003e and 833212e are quite simple.

5eb7d8a  brings some deep changes in the `BlocksGainCompensator`. To avoid code duplication I created a `BlockCompensator` which resembles the old `BlocksGainCompensator`. The difference is that is uses a templated `feed` method. The template argument determines which compensator to use. Then the class uses an overloaded `getGainMap` function to fill its gain map vector (as the gain format depends on the compensator used).

The final clases `BlocksGainCompensator` and `BlocksChannelsCompensator` simply inherit the generic `BlocksCompensator` and calls the right templated `feed`.