### PR TITLE
Fix a bug in cv :: merge when array of 3-channel mat is input

### DIFF
--- a/modules/core/src/merge.cpp
+++ b/modules/core/src/merge.cpp
@@ -305,6 +305,8 @@ void cv::merge(const Mat* mv, size_t n, OutputArray _dst)
         return;
     }
 
+    CV_IPP_RUN(allch1, ipp_merge(mv, dst, (int)n));
+
     if( !allch1 )
     {
         AutoBuffer<int> pairs(cn*2);
@@ -322,8 +324,6 @@ void cv::merge(const Mat* mv, size_t n, OutputArray _dst)
         mixChannels( mv, n, &dst, 1, &pairs[0], cn );
         return;
     }
-
-    CV_IPP_RUN_FAST(ipp_merge(mv, dst, (int)n));
 
     MergeFunc func = getMergeFunc(depth);
     CV_Assert( func != 0 );

--- a/modules/core/src/merge.cpp
+++ b/modules/core/src/merge.cpp
@@ -305,8 +305,6 @@ void cv::merge(const Mat* mv, size_t n, OutputArray _dst)
         return;
     }
 
-    CV_IPP_RUN_FAST(ipp_merge(mv, dst, (int)n));
-
     if( !allch1 )
     {
         AutoBuffer<int> pairs(cn*2);
@@ -324,6 +322,8 @@ void cv::merge(const Mat* mv, size_t n, OutputArray _dst)
         mixChannels( mv, n, &dst, 1, &pairs[0], cn );
         return;
     }
+
+    CV_IPP_RUN_FAST(ipp_merge(mv, dst, (int)n));
 
     MergeFunc func = getMergeFunc(depth);
     CV_Assert( func != 0 );

--- a/modules/core/test/test_mat.cpp
+++ b/modules/core/test/test_mat.cpp
@@ -1896,6 +1896,7 @@ TEST(Core_Merge, bug_13544)
     Mat src_arr[] = { src1, src2, src3 };
     Mat dst;
     merge(src_arr, 3, dst);
+    ASSERT_EQ(9, dst.channels());  // Avoid memory access out of buffer
     EXPECT_EQ(3, (int)dst.ptr<uchar>(0)[6]);
     EXPECT_EQ(3, (int)dst.ptr<uchar>(0)[7]);
     EXPECT_EQ(3, (int)dst.ptr<uchar>(0)[8]);

--- a/modules/core/test/test_mat.cpp
+++ b/modules/core/test/test_mat.cpp
@@ -1888,6 +1888,28 @@ TEST(Core_Split, crash_12171)
     EXPECT_EQ(2, dst2.ptr<uchar>(1)[1]);
 }
 
+TEST(Core_Merge, bug_13544)
+{
+    Mat src1(2, 2, CV_8UC3, Scalar::all(1));
+    Mat src2(2, 2, CV_8UC3, Scalar::all(2));
+    Mat src3(2, 2, CV_8UC3, Scalar::all(3));
+    Mat src_arr[] = { src1, src2, src3 };
+    Mat dst;
+    merge(src_arr, 3, dst);
+    EXPECT_EQ(3, (int)dst.ptr<uchar>(0)[6]);
+    EXPECT_EQ(3, (int)dst.ptr<uchar>(0)[7]);
+    EXPECT_EQ(3, (int)dst.ptr<uchar>(0)[8]);
+    EXPECT_EQ(1, (int)dst.ptr<uchar>(1)[0]);
+    EXPECT_EQ(1, (int)dst.ptr<uchar>(1)[1]);
+    EXPECT_EQ(1, (int)dst.ptr<uchar>(1)[2]);
+    EXPECT_EQ(2, (int)dst.ptr<uchar>(1)[3]);
+    EXPECT_EQ(2, (int)dst.ptr<uchar>(1)[4]);
+    EXPECT_EQ(2, (int)dst.ptr<uchar>(1)[5]);
+    EXPECT_EQ(3, (int)dst.ptr<uchar>(1)[6]);
+    EXPECT_EQ(3, (int)dst.ptr<uchar>(1)[7]);
+    EXPECT_EQ(3, (int)dst.ptr<uchar>(1)[8]);
+}
+
 struct CustomType  // like cv::Keypoint
 {
     Point2f pt;


### PR DESCRIPTION
The merge of the array of 3channel mat gives the wrong result on a particular input.<br/>
When an array of mat entering as input type If each Mat is not a single channel, but array of three or four ```Mat```'s of the three channels is input, the ```ipp_merge()``` call will result in an incorrect merge.<br/>
```ipp_merge ()``` seems to have been implemented assuming that the ```Mat``` channels are all 1 channel.
Therefore, we must move the ```ipp_merge()``` call below the ```if (! Allch1)``` branch to work properly.

#### Steps to Reproduce
```cpp
Mat src1(2, 2, CV_8UC3, Scalar::all(1));
Mat src2(2, 2, CV_8UC3, Scalar::all(2));
Mat src3(2, 2, CV_8UC3, Scalar::all(3));
Mat src_arr[] = { src1, src2, src3 };
Mat dst;
merge(src_arr, 3, dst);
cout << dst << endl;
```