### PR TITLE
Stitcher: Setter/getter for number of gain filtering iterations

### DIFF
--- a/modules/stitching/include/opencv2/stitching/detail/exposure_compensate.hpp
+++ b/modules/stitching/include/opencv2/stitching/detail/exposure_compensate.hpp
@@ -158,12 +158,14 @@ class CV_EXPORTS_W BlocksCompensator : public ExposureCompensator
 {
 public:
     BlocksCompensator(int bl_width=32, int bl_height=32, int nr_feeds=1)
-            : bl_width_(bl_width), bl_height_(bl_height), nr_feeds_(nr_feeds) {}
+            : bl_width_(bl_width), bl_height_(bl_height), nr_feeds_(nr_feeds), nr_gain_filtering_iterations_(2) {}
     CV_WRAP void apply(int index, Point corner, InputOutputArray image, InputArray mask) CV_OVERRIDE;
     CV_WRAP void getMatGains(CV_OUT std::vector<Mat>& umv) CV_OVERRIDE;
     CV_WRAP void setMatGains(std::vector<Mat>& umv) CV_OVERRIDE;
     CV_WRAP void setNrFeeds(int nr_feeds) { nr_feeds_ = nr_feeds; }
     CV_WRAP int getNrFeeds() { return nr_feeds_; }
+    CV_WRAP void setNrGainsFilteringIterations(int nr_iterations) { nr_gain_filtering_iterations_ = nr_iterations; }
+    CV_WRAP int getNrGainsFilteringIterations() const { return nr_gain_filtering_iterations_; }
 
 protected:
     template<class Compensator>
@@ -177,6 +179,7 @@ private:
     int bl_width_, bl_height_;
     std::vector<UMat> gain_maps_;
     int nr_feeds_;
+    int nr_gain_filtering_iterations_;
 };
 
 /** @brief Exposure compensator which tries to remove exposure related artifacts by adjusting image block

--- a/modules/stitching/src/exposure_compensate.cpp
+++ b/modules/stitching/src/exposure_compensate.cpp
@@ -412,8 +412,8 @@ void BlocksCompensator::feed(const std::vector<Point> &corners, const std::vecto
             UMat gain_map = getGainMap(compensator, bl_idx, bl_per_img);
             bl_idx += bl_per_img.width*bl_per_img.height;
 
-            sepFilter2D(gain_map, gain_map, CV_32F, ker, ker);
-            sepFilter2D(gain_map, gain_map, CV_32F, ker, ker);
+            for (int i=0; i<nr_gain_filtering_iterations_; ++i)
+                sepFilter2D(gain_map, gain_map, CV_32F, ker, ker);
 
             gain_maps_[img_idx] = gain_map;
         }


### PR DESCRIPTION
Currently, the BlocksCompensators compute exposure gains for each block, then filter them twice by applying a separable filter (I have been able to find this number as "good value" in the literature as well).

This PR adds the ability to change the number of times the filter is applied. I mostly use this to disable the filtering operation, but there would be no point in limiting that option to a boolean.