### PR TITLE
Fixed uninitialized value 

### DIFF
--- a/modules/stitching/include/opencv2/stitching/detail/exposure_compensate.hpp
+++ b/modules/stitching/include/opencv2/stitching/detail/exposure_compensate.hpp
@@ -60,6 +60,7 @@ namespace detail {
 class CV_EXPORTS_W ExposureCompensator
 {
 public:
+    ExposureCompensator(): updateGain(true) {}
     virtual ~ExposureCompensator() {}
 
     enum { NO, GAIN, GAIN_BLOCKS, CHANNELS, CHANNELS_BLOCKS };
@@ -189,7 +190,7 @@ public:
     CV_WRAP BlocksGainCompensator(int bl_width = 32, int bl_height = 32)
             : BlocksGainCompensator(bl_width, bl_height, 1) {}
     CV_WRAP BlocksGainCompensator(int bl_width, int bl_height, int nr_feeds)
-            : BlocksCompensator(bl_width, bl_height, nr_feeds) {setUpdateGain(true);}
+            : BlocksCompensator(bl_width, bl_height, nr_feeds) {}
 
     void feed(const std::vector<Point> &corners, const std::vector<UMat> &images,
               const std::vector<std::pair<UMat,uchar> > &masks) CV_OVERRIDE;
@@ -210,7 +211,7 @@ class CV_EXPORTS_W BlocksChannelsCompensator : public BlocksCompensator
 {
 public:
     CV_WRAP BlocksChannelsCompensator(int bl_width=32, int bl_height=32, int nr_feeds=1)
-            : BlocksCompensator(bl_width, bl_height, nr_feeds) {setUpdateGain(true);}
+            : BlocksCompensator(bl_width, bl_height, nr_feeds) {}
 
     void feed(const std::vector<Point> &corners, const std::vector<UMat> &images,
               const std::vector<std::pair<UMat,uchar> > &masks) CV_OVERRIDE;

--- a/modules/stitching/src/exposure_compensate.cpp
+++ b/modules/stitching/src/exposure_compensate.cpp
@@ -62,11 +62,10 @@ Ptr<ExposureCompensator> ExposureCompensator::createDefault(int type)
         e = makePtr<ChannelsCompensator>();
     else if (type == CHANNELS_BLOCKS)
         e = makePtr<BlocksChannelsCompensator>();
+
     if (e.get() != nullptr)
-    {
-        e->setUpdateGain(true);
         return e;
-    }
+
     CV_Error(Error::StsBadArg, "unsupported exposure compensation method");
 }
 


### PR DESCRIPTION
Fix issue #13563.

Uninitialized conditional branching was due to the `updateGain` attribute that was not initialized in the constructor of the class declaring it.
I fixed the behavior by initializing the attibute, and removed all `setUpdateGain(true)` that were called in various locations as they are not needed anymore.

EDIT: I could not rename the `updateGain` attribute to keep source compatibility as this attribute is only protected