### PR TITLE
Fix bugs in arithm_op() for InputArray (src == dst) case.

### DIFF
--- a/modules/core/src/arithm.cpp
+++ b/modules/core/src/arithm.cpp
@@ -609,8 +609,7 @@ static void arithm_op(InputArray _src1, InputArray _src2, OutputArray _dst,
         {
             if (src.getObj() == dst.getObj())
             {
-                _InputArray::KindFlag k = src.kind();
-                if (k == _InputArray::KindFlag::UMAT)
+                if (src.isUMat())
                 {
                     tmp_umat = src.getUMat();
                     input_arr = _InputArray(tmp_umat);

--- a/modules/core/test/test_mat.cpp
+++ b/modules/core/test/test_mat.cpp
@@ -1969,6 +1969,29 @@ TEST(Core_InputArray, support_CustomType)
     }
 }
 
+TEST(Core_InputArray, issue_8385)
+{
+    Mat x(1, 2, CV_8UC1, Scalar::all(3)), y;
+    cv::add(x, 2.0, x);
+    cv::multiply(x, x, x, 1, CV_16UC1);
+    EXPECT_EQ(25, (int)x.ptr<ushort>()[0]);
+    EXPECT_EQ(25, (int)x.ptr<ushort>()[1]);
+}
+
+TEST(Core_InputArray, issue_9688)
+{
+    Mat x(1, 1, CV_64FC1);
+    Mat p(10, 4, CV_64FC1);
+    x.setTo(0);
+    p.setTo(Scalar::all(5));
+    for (int i = 0; i < p.rows; i++)
+        x += p.row(i);
+    ASSERT_DOUBLE_EQ(50.0, x.ptr<double>()[0]);
+    ASSERT_DOUBLE_EQ(50.0, x.ptr<double>()[1]);
+    ASSERT_DOUBLE_EQ(50.0, x.ptr<double>()[2]);
+    ASSERT_DOUBLE_EQ(50.0, x.ptr<double>()[3]);
+}
+
 TEST(Core_Vectors, issue_13078)
 {
     float floats_[] = { 1, 2, 3, 4, 5, 6, 7, 8 };


### PR DESCRIPTION
#### Fix bugs in ```arithm_op()``` for ```InputArray```  ```(src == dst)``` case.

It is a well-known issue that ```InputArray``` ```(src == dst)``` can cause problems in opencv.
So I try to fix this issue through this PR.

The cause of this problem is the recreate of ```dst``` by call ```create()```.

There are many ways to solve this problem, but most of them are difficult solutions.
Store Mat itself inside ```Input/OutputArray```, not the pointer to it, but it would noticeably increase the overhead  and also It is possible to generate a side effect bug on any code that uses ```InputArray```.

So it is difficult to solve the problem for every part that can be ```(src == dst)``` by modifying InputArray
In most cases, we can prevent the ```(src == dst)``` case with ```CV_Assert(src1.getObj() != dst.getObj())```
However, in the case of ```Mat```'s ```+=``` operations, we must allow ```src == dst```.

Change the internal state of ```InputArray``` to solve this problem is difficult and dangerous.
So I propose to make a temporary ```Mat``` for  ```src``` on the stack when ```src == dst``` at the beginning of the ```arithm_op``` function.
I think this method can avoid this problem with small overhead and the possibility of side effects being small.

**The reasons are as follows.**

Anyway, in the ```arithm_op``` function, ```src``` will be converted via ```getMat()``` or ```getUMat()``` to be used inside the operation function.
Therefore, if we create a temporary ```Mat``` (or ```UMat```) for ```src``` at the beginning of the function, the overhead would be small.

If ```src``` is ```Mat``` (or ```UMat```), it is only a ref count increment and more use of stack memory
Otherwise It may take time to convert to ```Mat```, but in the case of ```arithm_op``` function it must be converted by ```GetMat()``` (or ```GetUMat()```) function to be used inside this function anyway. 
So this is not an additional overhead.


After the above operation, even if ```dst``` is recreated in the case of ```src == dst```, ```psrc``` is safe because it refers to the temporary ```Mat```.
This temporary ```Mat``` is created on the stack and will disappear when the function ends.

The following issues can be solved with this modification.

issue https://github.com/opencv/opencv/issues/9688
```
    Mat x(1, 1, CV_64FC1);
    Mat p(10, 4, CV_64FC1);
    x.setTo(0);
    p.setTo(Scalar::all(5));
    for (int i = 0; i < p.rows; i++)
        x += p.row(i);
    ASSERT_DOUBLE_EQ(50.0, x.ptr<double>()[0]);
    ASSERT_DOUBLE_EQ(50.0, x.ptr<double>()[1]);
    ASSERT_DOUBLE_EQ(50.0, x.ptr<double>()[2]);
    ASSERT_DOUBLE_EQ(50.0, x.ptr<double>()[3]);
```

issue https://github.com/opencv/opencv/issues/8385
```
    Mat x(1, 2, CV_8UC1, Scalar::all(3)), y;
    cv::add(x, 2.0, x);
    cv::multiply(x, x, x, 1, CV_16UC1);
    EXPECT_EQ(25, (int)x.ptr<ushort>()[0]);
    EXPECT_EQ(25, (int)x.ptr<ushort>()[1]);
```

I want to solve this problem.
Please let me know if this PR has a problem or if there are other good solutions
