### PR TITLE
Improve stitching detailed

### DIFF
--- a/modules/stitching/include/opencv2/stitching/detail/exposure_compensate.hpp
+++ b/modules/stitching/include/opencv2/stitching/detail/exposure_compensate.hpp
@@ -165,6 +165,9 @@ public:
     CV_WRAP void setMatGains(std::vector<Mat>& umv) CV_OVERRIDE;
     CV_WRAP void setNrFeeds(int nr_feeds) { nr_feeds_ = nr_feeds; }
     CV_WRAP int getNrFeeds() { return nr_feeds_; }
+    CV_WRAP void setBlockSize(int width, int height) { bl_width_ = width; bl_height_ = height; }
+    CV_WRAP void setBlockSize(Size size) { setBlockSize(size.width, size.height); }
+    CV_WRAP Size getBlockSize() const { return Size(bl_width_, bl_height_); }
     CV_WRAP void setNrGainsFilteringIterations(int nr_iterations) { nr_gain_filtering_iterations_ = nr_iterations; }
     CV_WRAP int getNrGainsFilteringIterations() const { return nr_gain_filtering_iterations_; }
 

--- a/samples/cpp/stitching_detailed.cpp
+++ b/samples/cpp/stitching_detailed.cpp
@@ -45,7 +45,8 @@ static void printUsage()
         "  --work_megapix <float>\n"
         "      Resolution for image registration step. The default is 0.6 Mpx.\n"
         "  --features (surf|orb|sift)\n"
-        "      Type of features used for images matching. The default is surf.\n"
+        "      Type of features used for images matching.\n"
+        "      The default is surf if available, orb otherwise.\n"
         "  --matcher (homography|affine)\n"
         "      Matcher used for pairwise image matching.\n"
         "  --estimator (homography|affine)\n"
@@ -113,7 +114,11 @@ double work_megapix = 0.6;
 double seam_megapix = 0.1;
 double compose_megapix = -1;
 float conf_thresh = 1.f;
+#ifdef HAVE_OPENCV_XFEATURES2D
 string features_type = "surf";
+#else
+string features_type = "orb";
+#endif
 string matcher_type = "homography";
 string estimator_type = "homography";
 string ba_cost_func = "ray";

--- a/samples/cpp/stitching_detailed.cpp
+++ b/samples/cpp/stitching_detailed.cpp
@@ -44,7 +44,7 @@ static void printUsage()
         "\nMotion Estimation Flags:\n"
         "  --work_megapix <float>\n"
         "      Resolution for image registration step. The default is 0.6 Mpx.\n"
-        "  --features (surf|orb|sift)\n"
+        "  --features (surf|orb|sift|akaze)\n"
         "      Type of features used for images matching.\n"
         "      The default is surf if available, orb otherwise.\n"
         "  --matcher (homography|affine)\n"
@@ -419,6 +419,10 @@ int main(int argc, char* argv[])
     if (features_type == "orb")
     {
         finder = ORB::create();
+    }
+    else if (features_type == "akaze")
+    {
+        finder = AKAZE::create();
     }
 #ifdef HAVE_OPENCV_XFEATURES2D
     else if (features_type == "surf")

--- a/samples/cpp/stitching_detailed.cpp
+++ b/samples/cpp/stitching_detailed.cpp
@@ -707,6 +707,11 @@ int main(int argc, char* argv[])
 
     LOGLN("Warping images, time: " << ((getTickCount() - t) / getTickFrequency()) << " sec");
 
+    LOGLN("Compensating exposure...");
+#if ENABLE_LOG
+    t = getTickCount();
+#endif
+
     Ptr<ExposureCompensator> compensator = ExposureCompensator::createDefault(expos_comp_type);
     if (dynamic_cast<GainCompensator*>(compensator.get()))
     {
@@ -729,6 +734,13 @@ int main(int argc, char* argv[])
     }
 
     compensator->feed(corners, images_warped, masks_warped);
+
+    LOGLN("Compensating exposure, time: " << ((getTickCount() - t) / getTickFrequency()) << " sec");
+
+    LOGLN("Finding seams...");
+#if ENABLE_LOG
+    t = getTickCount();
+#endif
 
     Ptr<SeamFinder> seam_finder;
     if (seam_find_type == "no")
@@ -764,6 +776,8 @@ int main(int argc, char* argv[])
     }
 
     seam_finder->find(images_warped_f, corners, masks_warped);
+
+    LOGLN("Finding seams, time: " << ((getTickCount() - t) / getTickFrequency()) << " sec");
 
     // Release unused memory
     images.clear();


### PR DESCRIPTION
- Added getter and setter for block size of `BlocksCompensator`
- Added options 'channels' and 'channels_blocks' for exposure compensator methods.
- Added options for AKAZE features.
- Added options for selecting the block size of a 'gain_blocks' and 'channels_blocks' methods.
- Added options for selecting the number of image feed for exposure compensators.
- Added options for selecting the number of gain filtering iterations for 'gain_blocks' and 'channels_blocks' methods.
- Default features fallback from SURF to ORB if SURF is not available.
- Added a few logs for more details about times.