### PR TITLE
Fix build error when building with Unicode on Windows

### DIFF
--- a/modules/core/src/glob.cpp
+++ b/modules/core/src/glob.cpp
@@ -60,7 +60,7 @@ namespace
 #ifdef WINRT
         WIN32_FIND_DATAW data;
 #else
-        WIN32_FIND_DATA data;
+        WIN32_FIND_DATAA data;
 #endif
         HANDLE handle;
         dirent ent;


### PR DESCRIPTION
### This pullrequest changes

Explicitly uses WIN32_FIND_DATAA when building for Windows desktop to avoid build error when building with Unicode character set.

This is a repeat of the accidentally closed no-op PR #13579.