### PR TITLE
Remove build warning msg with CUDA 10.0

### DIFF
--- a/modules/core/include/opencv2/core/cuda/functional.hpp
+++ b/modules/core/include/opencv2/core/cuda/functional.hpp
@@ -47,7 +47,6 @@
 #include "saturate_cast.hpp"
 #include "vec_traits.hpp"
 #include "type_traits.hpp"
-#include "device_functions.h"
 
 /** @file
  * @deprecated Use @ref cudev instead.


### PR DESCRIPTION
This PR is intended to resolve #13262.

The warning message that says "`device_functions.h` should not be included directly" seems to be added in CUDA 10.0. It turns out that OpenCV compiles fine without including the header, when tested with CUDA 8.0, 9.0, 9.1, 9.2, 10.0.

