### PR TITLE
Add a text message for Convolution layer's input channels check

### DIFF
--- a/modules/dnn/src/layers/convolution_layer.cpp
+++ b/modules/dnn/src/layers/convolution_layer.cpp
@@ -259,6 +259,9 @@ public:
         }
 
         int ngroups = inpCn / blobs[0].size[1];
+        if (ngroups == 0 || ngroups * blobs[0].size[1] != inpCn)
+            CV_Error(Error::StsError, format("Number of input channels should "
+                     "be multiple of %d but got %d", blobs[0].size[1], inpCn));
         CV_Assert(ngroups > 0 && inpCn % ngroups == 0 && outCn % ngroups == 0);
 
         int dims[] = {inputs[0][0], outCn, out.height, out.width};


### PR DESCRIPTION
<!-- Please use this line to close one or multiple issues when this pullrequest gets merged
You can add another line right under the first one:
resolves #1234
resolves #1235
-->

### This pullrequest changes

Add a error message for convolutional layer in case of wrong input channels (most frequent is BGRA instead of BGR).

```python
import cv2 as cv
import numpy as np

net = cv.dnn.readNet('opencv_face_detector.caffemodel', 'opencv_face_detector.prototxt')
inp = np.random.standard_normal([1, 4, 300, 300]).astype(np.float32)
net.setInput(inp)
out = net.forward()
```
```
Traceback (most recent call last):
  File "run.py", line 8, in <module>
    out = net.forward()
cv2.error: OpenCV(3.4.5-dev) /path/to/opencv/modules/dnn/src/layers/convolution_layer.cpp:263: error: (-2:Unspecified error) Number of input channels should be multiple of 3 but got 4 in function 'getMemoryShapes'
```