### PR TITLE
dnn: remove malloc.h include

### DIFF
--- a/modules/dnn/src/torch/THGeneral.cpp
+++ b/modules/dnn/src/torch/THGeneral.cpp
@@ -1,10 +1,2 @@
 #include "../precomp.hpp"
-
-#if defined(TH_DISABLE_HEAP_TRACKING)
-#elif (defined(__unix) || defined(_WIN32))
-#include <malloc.h>
-#elif defined(__APPLE__)
-#include <malloc/malloc.h>
-#endif
-
 #include "THGeneral.h"


### PR DESCRIPTION
malloc.h should not be needed anymore, see #6270
