### PR TITLE
Fix Farneback Optical Flow Algorithm

### DIFF
--- a/modules/cudaoptflow/test/test_optflow.cpp
+++ b/modules/cudaoptflow/test/test_optflow.cpp
@@ -337,7 +337,15 @@ CUDA_TEST_P(FarnebackOpticalFlow, Accuracy)
         frame0, frame1, flow, farn->getPyrScale(), farn->getNumLevels(), farn->getWinSize(),
         farn->getNumIters(), farn->getPolyN(), farn->getPolySigma(), farn->getFlags());
 
-    EXPECT_MAT_SIMILAR(flow, d_flow, 0.1);
+    // Relax test limit when the flag is set
+    if (farn->getFlags() & cv::OPTFLOW_FARNEBACK_GAUSSIAN)
+    {
+        EXPECT_MAT_SIMILAR(flow, d_flow, 2e-2);
+    }
+    else
+    {
+        EXPECT_MAT_SIMILAR(flow, d_flow, 1e-4);
+    }
 }
 
 INSTANTIATE_TEST_CASE_P(CUDA_OptFlow, FarnebackOpticalFlow, testing::Combine(


### PR DESCRIPTION
- Before this PR, following tests failed on some platform.
  CUDA_OptFlow/FarnebackOpticalFlow.Accuracy/19
  CUDA_OptFlow/FarnebackOpticalFlow.Accuracy/23

- The algorithm now recognizes the OPTFLOW_USE_INITIAL_FLOW flag.
  Previously, when the flag was set, it did not use the flow data
  passed as input, instead used some garbage data in memory.

- More strict test limit.

- Related #12895 

```
force_builders=Custom
docker_image:Custom=ubuntu-cuda:16.04
```