### PR TITLE
fix openvx wrappers

### DIFF
--- a/3rdparty/openvx/hal/openvx_hal.cpp
+++ b/3rdparty/openvx/hal/openvx_hal.cpp
@@ -188,8 +188,8 @@ int ovx_hal_mul(const T *a, size_t astep, const T *b, size_t bstep, T *c, size_t
     refineStep(w, h, ivx::TypeToEnum<T>::imgType, astep);
     refineStep(w, h, ivx::TypeToEnum<T>::imgType, bstep);
     refineStep(w, h, ivx::TypeToEnum<T>::imgType, cstep);
-#ifdef _MSC_VER
-    const float MAGIC_SCALE = 0x0.01010102;
+#ifdef _WIN32
+    const float MAGIC_SCALE = 0x0.01010102p0;
 #else
     const float MAGIC_SCALE = 0x1.010102p-8;
 #endif

--- a/3rdparty/openvx/include/ivx.hpp
+++ b/3rdparty/openvx/include/ivx.hpp
@@ -1718,8 +1718,7 @@ static const vx_enum
     }
 
 #ifdef IVX_USE_OPENCV
-    /// Convert image format (fourcc) to cv::Mat type
-    /// \return CV_USRTYPE1 for unknown image formats
+    /// Convert image format (fourcc) to cv::Mat type, throws WrapperError if not possible
     static int formatToMatType(vx_df_image format, vx_uint32 planeIdx = 0)
     {
         switch (format)
@@ -1739,7 +1738,7 @@ static const vx_enum
         case VX_DF_IMAGE_YUYV: return CV_8UC2;
         case VX_DF_IMAGE_NV12:
         case VX_DF_IMAGE_NV21: return planeIdx == 0 ? CV_8UC1 : CV_8UC2;
-        default: return CV_USRTYPE1;
+        default: throw WrapperError(std::string(__func__)+"(): unsupported image format");
         }
     }
 

--- a/modules/imgproc/src/median_blur.cpp
+++ b/modules/imgproc/src/median_blur.cpp
@@ -990,9 +990,11 @@ static bool ocl_medianFilter(InputArray _src, OutputArray _dst, int m)
 #endif
 
 #ifdef HAVE_OPENVX
+} // close anonymous namespace #13634
 namespace ovx {
     template <> inline bool skipSmallImages<VX_KERNEL_MEDIAN_3x3>(int w, int h) { return w*h < 1280 * 720; }
 }
+namespace { // reopen it
 static bool openvx_medianFilter(InputArray _src, OutputArray _dst, int ksize)
 {
     if (_src.type() != CV_8UC1 || _dst.type() != CV_8U


### PR DESCRIPTION
resolves #13588
resolves #13634

### This pullrequest changes

* remove usage of CV_USRTYPE1 (ivx.hpp)
* resolve a namespace issue (median_blur.cpp)
* fix the  MAGIC_SCALE constant for windows compilers (including mingw) (openvx_hal.cpp)