### PR TITLE
GAPI: fix GCall misuse in unrollExpr

### DIFF
--- a/modules/gapi/src/api/gcall.cpp
+++ b/modules/gapi/src/api/gcall.cpp
@@ -28,9 +28,14 @@ cv::GCall::GCall(const cv::GKernel &k)
 
 cv::GCall::~GCall()
 {
+    // FIXME: current behavior of the destructor can cause troubles in a threaded environment. GCall
+    // is not supposed to be accessed for modification within multiple threads. There should be a
+    // way to ensure somehow that no problem occurs in future. For now, this is a reminder that
+    // GCall is not supposed to be copied inside a code block that is executed in parallel.
+
     // When a GCall object is destroyed (and GCall::Priv is likely still alive,
     // as there might be other references), reset m_node to break cycle.
-   m_priv->m_node = GNode();
+    m_priv->m_node = GNode();
 }
 
 void cv::GCall::setArgs(std::vector<GArg> &&args)

--- a/modules/gapi/src/compiler/gmodelbuilder.cpp
+++ b/modules/gapi/src/compiler/gmodelbuilder.cpp
@@ -128,7 +128,7 @@ cv::gimpl::Unrolled cv::gimpl::unrollExpr(const GProtoArgs &ins,
                 // then add its operands to stack to continue recursion.
                 ops.visit(&node.priv(), node);
 
-                const cv::GCall         call   = origin.node.call();
+                const cv::GCall&        call   = origin.node.call();
                 const cv::GCall::Priv&  call_p = call.priv();
 
                 // Put the outputs object description of the node


### PR DESCRIPTION
This pullrequest fixes GCall issue due to wrong usage in unrollExpr in case of multi-threaded environment. FIXME added to address the need to improve current code to ensure no such problem occurs in future.
