### PR TITLE
Logging revamp for 4.1.0 (#11003, OE-11)

### DIFF
--- a/modules/core/include/opencv2/core/utils/logger.defines.hpp
+++ b/modules/core/include/opencv2/core/utils/logger.defines.hpp
@@ -19,4 +19,11 @@
 
 //! @}
 
+//! @addtogroup core_logging
+//! @{
+
+#define CV_LOG_LEVEL_CHECK_PARENT 128 //!< for use in scope-based filtering
+
+//! @}
+
 #endif // OPENCV_LOGGER_DEFINES_HPP

--- a/modules/core/include/opencv2/core/utils/logger.hpp
+++ b/modules/core/include/opencv2/core/utils/logger.hpp
@@ -34,12 +34,342 @@ enum LogLevel {
 #endif
 };
 
+#if 1 // TENTATIVE
+
+// Macros that expand to default declarations of special class methods
+
+// DC: Default (argumentless) constructor
+#define DECLARE_MEMBER_DEFAULTS_DC(ClassName) ClassName() = default;
+
+// CC: Copy constructor
+#define DECLARE_MEMBER_DEFAULTS_CC(ClassName) ClassName(const ClassName&) = default;
+
+// MC: Move constructor
+#define DECLARE_MEMBER_DEFAULTS_MC(ClassName) ClassName(ClassName&&) = default;
+
+// CA: Copy assignment operator
+#define DECLARE_MEMBER_DEFAULTS_CA(ClassName) ClassName& operator = (const ClassName&) = default;
+
+// MA: Move assignment operator
+#define DECLARE_MEMBER_DEFAULTS_MA(ClassName) ClassName& operator = (ClassName&&) = default;
+
+// ALL: All of above
+#define DECLARE_MEMBER_DEFAULTS_ALL(ClassName) \
+    DECLARE_MEMBER_DEFAULTS_DC(ClassName) \
+    DECLARE_MEMBER_DEFAULTS_CC(ClassName) \
+    DECLARE_MEMBER_DEFAULTS_MC(ClassName) \
+    DECLARE_MEMBER_DEFAULTS_CA(ClassName) \
+    DECLARE_MEMBER_DEFAULTS_MA(ClassName)
+
+#endif // TENTATIVE
+
+/**
+Information about the module that generates a log message.
+*/
+class LogModuleInfo
+{
+public:
+    DECLARE_MEMBER_DEFAULTS_ALL(LogModuleInfo);
+
+public:
+    /**
+    Name of the OpenCV module or component.
+    Might be nullptr. If not nullptr, the string needs to be static lifetime or const literal.
+    */
+    const char* name;
+
+public:
+    LogModuleInfo(const char* name_)
+        : name(name_)
+    {
+    }
+};
+
+/**
+Information about the current object (the "this" pointer) collected alongside each log message.
+*/
+class LogObjInfo
+{
+public:
+    DECLARE_MEMBER_DEFAULTS_ALL(LogObjInfo);
+
+public:
+    /**
+    Name of the class, or the string obtained from C++11 "std::type_info(typeid(Class)).name()".
+    Might contain a string prefix such as "class Class" depending on compiler vendor.
+    Might be nullptr. If not nullptr, the string needs to be static lifetime or const literal.
+    */
+    const char* typeName;
+
+    /**
+    Type-erased pointer to object. Use std::addressof() to initialize.
+    */
+    const void* ptr;
+
+public:
+    LogObjInfo(const char* typeName_, const void* ptr_)
+        : typeName(typeName_)
+        , ptr(ptr_)
+    {
+    }
+
+public:
+    template <class C>
+    LogObjInfo(const C& c)
+        : typeName(typeid(C).name())
+        , ptr(std::addressof(c))
+    {
+    }
+};
+
+/**
+Information about the line of code (source file, line number, etc) collected alongside each log message
+*/
+class LogLoc
+{
+public:
+    DECLARE_MEMBER_DEFAULTS_ALL(LogLoc);
+
+public:
+    /**
+    Source file name, likely from expansion of predefined __FILE__ macro.
+    Might be nullptr. If not nullptr, the string needs to be static lifetime or const literal.
+    */
+    const char* file;
+
+    /**
+    Line number, likely from expansion of predefined __LINE__ macro.
+    Might be zero or negative, which indicates unavailability.
+    */
+    int line;
+
+    /**
+    Function name, likely from expansion of CV_Func macro, which is similar to __func__.
+    Actual formatting is compiler vendor specific and might be inconsistent.
+    Could be decorated or undecorated.
+    Might possibly contain qualifiers.
+    Might possibly contain argument list.
+    Might be utterly garbage.
+    Might be nullptr. If not nullptr, the string needs to be static lifetime or const literal.
+    */
+    const char* func;
+
+public:
+    LogLoc(const char* file_, int line_, const char* func_)
+        : file(file_)
+        , line(line_)
+        , func(func_)
+    {
+    }
+};
+
+#if 0 // TENTATIVE
+/**
+Information about parallelized work collected alongside each log message.
+
+This information is only available when executed inside a cv::ParallelLoopBody method
+invoked via cv::parallel_for_
+
+@todo Currently empty and not implemented yet.
+*/
+class LogPar
+{
+public:
+    DECLARE_MEMBER_DEFAULTS_ALL(LogPar);
+
+public:
+public:
+};
+#endif // TENTATIVE
+
+/**
+Wraps the verbosity level of a VERBOSE log message.
+
+Because OpenCV splits the VERBOSE log level into sub-levels of verbosity via the
+argument "v" in macro CV_LOG_VERBOSE(tag, v, ...) a wrapper class is needed so that
+it can be updated to LogMeta class via the stream insertion operator.
+*/
+class LogVerboseLevel
+{
+public:
+    DECLARE_MEMBER_DEFAULTS_ALL(LogVerboseLevel);
+
+public:
+    int verboseLevel;
+
+public:
+    LogVerboseLevel(int verboseLevel_)
+        : verboseLevel(verboseLevel_)
+    {
+    }
+};
+
+/**
+Attributes collected alongside each logged message.
+*/
+class LogMeta
+{
+public:
+    DECLARE_MEMBER_DEFAULTS_CC(LogMeta);
+    DECLARE_MEMBER_DEFAULTS_MC(LogMeta);
+    DECLARE_MEMBER_DEFAULTS_CA(LogMeta);
+    DECLARE_MEMBER_DEFAULTS_MA(LogMeta);
+
+public:
+    LogLevel level;
+    int verboseLevel;
+    const char* moduleName;
+    int thread;
+    LogObjInfo objInfo;
+    LogLoc loc;
+
+#if 0 // TENTATIVE
+    LogPar par;
+#endif // TENTATIVE
+
+public:
+    LogMeta(LogLevel level_, const char* moduleName_ = nullptr, int thread_ = cv::utils::getThreadID())
+        : level(level_)
+        , verboseLevel()
+        , moduleName(moduleName_)
+        , thread(thread_)
+        , objInfo()
+        , loc()
+#if 0
+        , par()
+#endif
+    {
+    }
+
+    LogMeta()
+        : LogMeta(LOG_LEVEL_VERBOSE, nullptr, cv::utils::getThreadID())
+    {
+    }
+
+public:
+    /**
+    A stream insertion operator that does nothing. This allows the use of "nullptr"
+    when invoking the CV_LOGMETA(..., metaArgs, ...) to indicate that metaArgs is empty.
+    */
+    LogMeta& operator << (std::nullptr_t)
+    {
+        return *this;
+    }
+
+    /**
+    Updates the log level of this message via the stream insertion operator.
+    */
+    LogMeta& operator << (LogLevel level_)
+    {
+        this->level = level_;
+        return *this;
+    }
+
+    /**
+    Updates the module info via the stream insertion operator.
+    */
+    LogMeta& operator << (const LogModuleInfo& moduleInfo)
+    {
+        this->moduleName = moduleInfo.name;
+        return *this;
+    }
+
+    /**
+    Updates the current class and object info via the stream insertion operator.
+    */
+    LogMeta& operator << (const LogObjInfo& objInfo_)
+    {
+        this->objInfo = objInfo_;
+        return *this;
+    }
+
+    /**
+    Updates the line of code info via the stream insertion operator.
+    */
+    LogMeta& operator << (const LogLoc& loc_)
+    {
+        this->loc = loc_;
+        return *this;
+    }
+
+#if 0 // TENTATIVE
+    /**
+    Updates the parallelized work info via the stream insertion operator.
+    */
+    LogMeta& operator << (const LogPar& par_)
+    {
+        this->par = par_;
+        return *this;
+    }
+#endif // TENTATIVE
+
+    /**
+    Updates the verbose level via the stream insertion operator.
+    @note Verbose level is only relevant when the message log level is VERBOSE.
+    */
+    LogMeta& operator << (const LogVerboseLevel& verboseLevel_)
+    {
+        this->verboseLevel = verboseLevel_.verboseLevel;
+        return *this;
+    }
+};
+
+#if 1 // TENTATIVE
+/**
+Serializes the log message metadata to a string that is inserted into an std::ostream.
+*/
+inline std::ostream& operator << (std::ostream& o, const LogMeta& meta)
+{
+    if (meta.moduleName && meta.moduleName[0])
+    {
+        o << "(module:" << meta.moduleName << ") ";
+    }
+    if (meta.loc.file && meta.loc.file[0])
+    {
+        o << "(file: " << meta.loc.file << ") ";
+    }
+    if (meta.loc.line >= 1)
+    {
+        o << "(line: " << meta.loc.line << ") ";
+    }
+    if (meta.loc.func && meta.loc.func[0])
+    {
+        o << "(func: " << meta.loc.func << ") ";
+    }
+    if (meta.objInfo.typeName && meta.objInfo.typeName[0])
+    {
+        o << "(class: " << meta.objInfo.typeName << ") ";
+    }
+    if (meta.objInfo.ptr)
+    {
+        o << "(this_ptr: " << meta.objInfo.ptr << ") ";
+    }
+    return o;
+}
+#endif // TENTATIVE
+
 /** Set global logging level
 @return previous logging level
 */
 CV_EXPORTS LogLevel setLogLevel(LogLevel logLevel);
+
 /** Get global logging level */
 CV_EXPORTS LogLevel getLogLevel();
+
+/**
+The function prototype for global log message filter based on attributes inside a LogMeta.
+*/
+typedef bool(*LogFilterFunctionType) (const ::cv::utils::logging::LogMeta&);
+
+/**
+Sets global log message filter based on attributes provided in a LogMeta.
+*/
+CV_EXPORTS LogFilterFunctionType setLogFilter(LogFilterFunctionType filter);
+
+/**
+Gets the current global log message filter.
+*/
+CV_EXPORTS LogFilterFunctionType getLogFilter();
 
 namespace internal {
 /** Write log message */
@@ -59,24 +389,56 @@ CV_EXPORTS void writeLogMessage(LogLevel logLevel, const char* message);
 # endif
 #endif
 
+/**
+@todo Decide whether we actually want to keep the "tag" argument in the new macro.
+@todo Decide whether the for(;;) { ...; break; } encasing is still needed.
+@remark Apparently the for-break encasing allows short-circuit evaluation inside the macro.
+*/
+#define CV_LOGMETA(tag, level, metaArgs, ...) \
+    for(;;) { \
+        ::cv::utils::logging::LogMeta meta_; \
+        meta_ << ::cv::utils::logging::LogLevel(level) << metaArgs; \
+        if (!((::cv::utils::logging::getLogFilter())(meta_))) break; \
+        std::stringstream ss; \
+        ss << meta_; \
+        ss << __VA_ARGS__; \
+        cv::utils::logging::internal::writeLogMessage(level, ss.str().c_str()); \
+        break; \
+    }
 
-#define CV_LOG_FATAL(tag, ...)   for(;;) { if (cv::utils::logging::getLogLevel() < cv::utils::logging::LOG_LEVEL_FATAL) break; std::stringstream ss; ss << __VA_ARGS__; cv::utils::logging::internal::writeLogMessage(cv::utils::logging::LOG_LEVEL_FATAL, ss.str().c_str()); break; }
-#define CV_LOG_ERROR(tag, ...)   for(;;) { if (cv::utils::logging::getLogLevel() < cv::utils::logging::LOG_LEVEL_ERROR) break; std::stringstream ss; ss << __VA_ARGS__; cv::utils::logging::internal::writeLogMessage(cv::utils::logging::LOG_LEVEL_ERROR, ss.str().c_str()); break; }
-#define CV_LOG_WARNING(tag, ...) for(;;) { if (cv::utils::logging::getLogLevel() < cv::utils::logging::LOG_LEVEL_WARNING) break; std::stringstream ss; ss << __VA_ARGS__; cv::utils::logging::internal::writeLogMessage(cv::utils::logging::LOG_LEVEL_WARNING, ss.str().c_str()); break; }
+/**
+Collects the line-of-code information so that it can be added to the log message metadata.
+*/
+#define CV_LOG_LOC() (::cv::utils::logging::LogLoc(__FILE__, __LINE__, CV_Func))
+
+/**
+Collects the type name and address of the current object (via "this") so that it can be added
+to the log message metadata. This macro is only valid when inside a class non-static member
+function.
+*/
+#define CV_LOG_THIS() (::cv::utils::logging::LogObjInfo(*this))
+
+#define CV_LOG_FATAL(tag, ...) CV_LOGMETA(tag, cv::utils::logging::LOG_LEVEL_FATAL, nullptr, __VA_ARGS__)
+#define CV_LOG_ERROR(tag, ...) CV_LOGMETA(tag, cv::utils::logging::LOG_LEVEL_ERROR, nullptr, __VA_ARGS__)
+#if CV_LOG_STRIP_LEVEL <= CV_LOG_LEVEL_WARN
+#define CV_LOG_WARNING(tag, ...)
+#else
+#define CV_LOG_WARNING(tag, ...) CV_LOGMETA(tag, cv::utils::logging::LOG_LEVEL_WARNING, nullptr, __VA_ARGS__)
+#endif
 #if CV_LOG_STRIP_LEVEL <= CV_LOG_LEVEL_INFO
 #define CV_LOG_INFO(tag, ...)
 #else
-#define CV_LOG_INFO(tag, ...)    for(;;) { if (cv::utils::logging::getLogLevel() < cv::utils::logging::LOG_LEVEL_INFO) break; std::stringstream ss; ss << __VA_ARGS__; cv::utils::logging::internal::writeLogMessage(cv::utils::logging::LOG_LEVEL_INFO, ss.str().c_str()); break; }
+#define CV_LOG_INFO(tag, ...) CV_LOGMETA(tag, cv::utils::logging::LOG_LEVEL_INFO, nullptr, __VA_ARGS__)
 #endif
 #if CV_LOG_STRIP_LEVEL <= CV_LOG_LEVEL_DEBUG
 #define CV_LOG_DEBUG(tag, ...)
 #else
-#define CV_LOG_DEBUG(tag, ...)   for(;;) { if (cv::utils::logging::getLogLevel() < cv::utils::logging::LOG_LEVEL_DEBUG) break; std::stringstream ss; ss << __VA_ARGS__; cv::utils::logging::internal::writeLogMessage(cv::utils::logging::LOG_LEVEL_DEBUG, ss.str().c_str()); break; }
+#define CV_LOG_DEBUG(tag, ...) CV_LOGMETA(tag, cv::utils::logging::LOG_LEVEL_DEBUG, nullptr, __VA_ARGS__)
 #endif
 #if CV_LOG_STRIP_LEVEL <= CV_LOG_LEVEL_VERBOSE
 #define CV_LOG_VERBOSE(tag, v, ...)
 #else
-#define CV_LOG_VERBOSE(tag, v, ...) for(;;) { if (cv::utils::logging::getLogLevel() < cv::utils::logging::LOG_LEVEL_VERBOSE) break; std::stringstream ss; ss << "[VERB" << v << ":" << cv::utils::getThreadID() << "] " << __VA_ARGS__; cv::utils::logging::internal::writeLogMessage(cv::utils::logging::LOG_LEVEL_VERBOSE, ss.str().c_str()); break; }
+#define CV_LOG_VERBOSE(tag, v, ...) CV_LOGMETA(tag, cv::utils::logging::LOG_LEVEL_VERBOSE, ::cv::utils::logging::LogVerboseLevel(v), __VA_ARGS__)
 #endif
 
 

--- a/modules/core/src/logger.cpp
+++ b/modules/core/src/logger.cpp
@@ -67,6 +67,45 @@ LogLevel getLogLevel()
     return getLogLevelVariable();
 }
 
+/**
+Default log filter.
+This default log filter preserves old behavior: it compares the message log level
+against the global log level. Other log message attributes are not checked.
+
+This filter must fit function prototype:
+typedef bool(*LogFilterFunctionType) (const ::cv::utils::logging::LogMeta&);
+*/
+
+static bool defaultLogFilter(const LogMeta& meta)
+{
+    // For example, compare this to original code, macro CV_LOG_FATAL
+    // ...
+    // if (cv::utils::logging::getLogLevel() < cv::utils::logging::LOG_LEVEL_FATAL) break;
+    // ...
+    // LOG_LEVEL_FATAL is the level of the message itself;
+    // getLogLevel is the global log level filter threshold.
+    //
+    return (getLogLevelVariable() >= meta.level);
+}
+
+static LogFilterFunctionType& getLogFilterVariable()
+{
+    static LogFilterFunctionType g_logFilter = defaultLogFilter;
+    return g_logFilter;
+}
+
+LogFilterFunctionType setLogFilter(LogFilterFunctionType filter)
+{
+    LogFilterFunctionType old = getLogFilterVariable();
+    getLogFilterVariable() = filter;
+    return old;
+}
+
+LogFilterFunctionType getLogFilter()
+{
+    return getLogFilterVariable();
+}
+
 namespace internal {
 
 void writeLogMessage(LogLevel logLevel, const char* message)


### PR DESCRIPTION
does_not_resolve_yet #11003

### This pullrequest changes

Added class LogMeta and others.
Added setLogFilter, getLogFilter.
Added CV_LOGMETA.
Added CV_LOG_LOC, CV_LOG_THIS.
Modified CV_LOG_FATAL, CV_LOG_ERROR and others to use CV_LOGMETA.
Added defaultLogFilter as a default implementation.

<cut/>

### Known issues

Building with CV_LOG_STRIP_LEVEL set to (CV_LOG_LEVEL_VERBOSE + 1) will cause compile errors due to syntax errors in the following files:
- modules/core/src/ocl.cpp
- modules/dnn/src/ocl4dnn/src/ocl4dnn_conv_spatial.cpp

This is due to incorrect usage of the CV_LOG_VERBOSE macro, or trying to access non-existent C++ class members.
This commit does not fix these known issues; a separate PR will be submitted independently of Issue 11003.

### Progress



Checklist for core module changes
- [x] LogMeta class, and classes for pieces of metadata, such as LogLoc, LogObjInfo, LogModuleInfo
- [x] Global filter function that accept LogMeta class, and default implementation
- [x] CV_LOGMETA macro
- [x] Updated existing CV_LOG_(INFO, WARNING, etc) macros to use CV_LOGMETA
- [ ] Change backend function prototype (cv::utils::logging::internal::writeLogMessage) 
to accept LogMeta (or its data members) so that backends that can benefit from those 
data can use them programmatically without parsing from strings.
- [ ] Implement backend switchability
- [ ] Implement backend multicast
- [ ] Implement runtime configurable module-specific log level threshold
  - [ ] Add static functions to get and set threshold for specific modules
  - [ ] Update the default filter implementation to use that module-specific threshold
- [ ] Capture parallelized work thread-relationship information in cv::ParallelLoopBody executor implementations
- [ ] Implement string formatter switchability (for example fmtlib)
- [ ] Implement large matrix logging (frontend and backend work)
- [ ] Implement binary blob logging (frontend and backend work)

Checklist for required changes in every OpenCV module
- [ ] Define a macro for module name string that is visible to all code inside that module, without leaking outside
- [ ] Override (redefine) existing CV_LOG_(...) macros in each module to pass module name into LogMeta

Checklist for long-term improvement changes in every OpenCV module
- For modules that could use logging but don't have it, add some, strategically.
- For modules that use logging badly, fix those issues
- [ ] Where applicable, include LogObjInfo (CV_LOG_THIS) into LogMeta to help identify object instances
- Replace kludge, such as in stitching module

