### PR TITLE
dnn/samples: add googlenet to model zoo

### DIFF
--- a/samples/dnn/models.yml
+++ b/samples/dnn/models.yml
@@ -90,6 +90,18 @@ squeezenet:
   classes: "classification_classes_ILSVRC2012.txt"
   sample: "classification"
 
+# Googlenet from https://github.com/BVLC/caffe/tree/master/models/bvlc_googlenet
+googlenet:
+  model: "bvlc_googlenet.caffemodel"
+  config: "bvlc_googlenet.prototxt"
+  mean: [104, 117, 123]
+  scale: 1.0
+  width: 224
+  height: 224
+  rgb: false
+  classes: "classification_classes_ILSVRC2012.txt"
+  sample: "classification"
+
 ################################################################################
 # Semantic segmentation models.
 ################################################################################


### PR DESCRIPTION
it is used in [the tutorial](https://docs.opencv.org/4.0.0/d5/de7/tutorial_dnn_googlenet.html), and the mean/size/model, etc. information should be easy to find, and used with the "zoo" option.
