### PR TITLE
GAPI: Add version of descr_of function taking vector of Mat

### DIFF
--- a/modules/gapi/include/opencv2/gapi/gmat.hpp
+++ b/modules/gapi/include/opencv2/gapi/gmat.hpp
@@ -133,6 +133,8 @@ static inline GMatDesc empty_gmat_desc() { return GMatDesc{-1,-1,{-1,-1}}; }
 class Mat;
 GAPI_EXPORTS GMatDesc descr_of(const cv::Mat &mat);
 GAPI_EXPORTS GMatDesc descr_of(const cv::UMat &mat);
+GAPI_EXPORTS std::vector<GMatDesc> descr_of(std::vector<cv::Mat> const& vec);
+GAPI_EXPORTS std::vector<GMatDesc> descr_of(std::vector<cv::UMat> const& vec);
 #endif // !defined(GAPI_STANDALONE)
 
 /** @} */

--- a/modules/gapi/include/opencv2/gapi/gmat.hpp
+++ b/modules/gapi/include/opencv2/gapi/gmat.hpp
@@ -133,8 +133,8 @@ static inline GMatDesc empty_gmat_desc() { return GMatDesc{-1,-1,{-1,-1}}; }
 class Mat;
 GAPI_EXPORTS GMatDesc descr_of(const cv::Mat &mat);
 GAPI_EXPORTS GMatDesc descr_of(const cv::UMat &mat);
-GAPI_EXPORTS std::vector<GMatDesc> descr_of(std::vector<cv::Mat> const& vec);
-GAPI_EXPORTS std::vector<GMatDesc> descr_of(std::vector<cv::UMat> const& vec);
+GAPI_EXPORTS std::vector<GMatDesc> descr_of(const std::vector<cv::Mat> &vec);
+GAPI_EXPORTS std::vector<GMatDesc> descr_of(const std::vector<cv::UMat> &vec);
 #endif // !defined(GAPI_STANDALONE)
 
 /** @} */
@@ -142,7 +142,7 @@ GAPI_EXPORTS std::vector<GMatDesc> descr_of(std::vector<cv::UMat> const& vec);
 namespace gapi { namespace own {
     class Mat;
     GAPI_EXPORTS GMatDesc descr_of(const Mat &mat);
-    GAPI_EXPORTS std::vector<GMatDesc> descr_of(std::vector<Mat> const& vec);
+    GAPI_EXPORTS std::vector<GMatDesc> descr_of(const std::vector<Mat> &vec);
 }}//gapi::own
 
 std::ostream& operator<<(std::ostream& os, const cv::GMatDesc &desc);

--- a/modules/gapi/include/opencv2/gapi/gmat.hpp
+++ b/modules/gapi/include/opencv2/gapi/gmat.hpp
@@ -140,6 +140,7 @@ GAPI_EXPORTS GMatDesc descr_of(const cv::UMat &mat);
 namespace gapi { namespace own {
     class Mat;
     GAPI_EXPORTS GMatDesc descr_of(const Mat &mat);
+    GAPI_EXPORTS std::vector<GMatDesc> descr_of(std::vector<Mat> const& vec);
 }}//gapi::own
 
 std::ostream& operator<<(std::ostream& os, const cv::GMatDesc &desc);

--- a/modules/gapi/src/api/gmat.cpp
+++ b/modules/gapi/src/api/gmat.cpp
@@ -49,6 +49,15 @@ cv::GMatDesc cv::gapi::own::descr_of(const cv::gapi::own::Mat &mat)
     return GMatDesc{mat.depth(), mat.channels(), {mat.cols, mat.rows}};
 }
 
+std::vector<cv::GMatDesc> cv::gapi::own::descr_of(std::vector<cv::gapi::own::Mat> const& vec)
+{
+    std::vector<cv::GMatDesc> vec_descr;
+    for(auto& mat : vec){
+        vec_descr.emplace_back(descr_of(mat));
+    }
+    return vec_descr;
+}
+
 namespace cv {
 std::ostream& operator<<(std::ostream& os, const cv::GMatDesc &desc)
 {

--- a/modules/gapi/src/api/gmat.cpp
+++ b/modules/gapi/src/api/gmat.cpp
@@ -33,6 +33,15 @@ const cv::GOrigin& cv::GMat::priv() const
     return *m_priv;
 }
 
+template <typename T> std::vector<cv::GMatDesc> vec_descr_of(const std::vector<T> &vec)
+{
+    std::vector<cv::GMatDesc> vec_descr;
+    for(auto& mat : vec){
+        vec_descr.emplace_back(descr_of(mat));
+    }
+    return vec_descr;
+}
+
 #if !defined(GAPI_STANDALONE)
 cv::GMatDesc cv::descr_of(const cv::Mat &mat)
 {
@@ -44,22 +53,14 @@ cv::GMatDesc cv::descr_of(const cv::UMat &mat)
     return GMatDesc{ mat.depth(), mat.channels(),{ mat.cols, mat.rows } };
 }
 
-std::vector<cv::GMatDesc> cv::descr_of(std::vector<cv::Mat> const& vec)
+std::vector<cv::GMatDesc> cv::descr_of(const std::vector<cv::Mat> &vec)
 {
-    std::vector<cv::GMatDesc> vec_descr;
-    for(auto& mat : vec){
-        vec_descr.emplace_back(descr_of(mat));
-    }
-    return vec_descr;
+    return vec_descr_of(vec);
 }
 
-std::vector<cv::GMatDesc> cv::descr_of(std::vector<cv::UMat> const& vec)
+std::vector<cv::GMatDesc> cv::descr_of(const std::vector<cv::UMat> &vec)
 {
-    std::vector<cv::GMatDesc> vec_descr;
-    for(auto& mat : vec){
-        vec_descr.emplace_back(descr_of(mat));
-    }
-    return vec_descr;
+    return vec_descr_of(vec);
 }
 #endif
 
@@ -68,13 +69,9 @@ cv::GMatDesc cv::gapi::own::descr_of(const cv::gapi::own::Mat &mat)
     return GMatDesc{mat.depth(), mat.channels(), {mat.cols, mat.rows}};
 }
 
-std::vector<cv::GMatDesc> cv::gapi::own::descr_of(std::vector<cv::gapi::own::Mat> const& vec)
+std::vector<cv::GMatDesc> cv::gapi::own::descr_of(const std::vector<cv::gapi::own::Mat> &vec)
 {
-    std::vector<cv::GMatDesc> vec_descr;
-    for(auto& mat : vec){
-        vec_descr.emplace_back(descr_of(mat));
-    }
-    return vec_descr;
+    return vec_descr_of(vec);
 }
 
 namespace cv {

--- a/modules/gapi/src/api/gmat.cpp
+++ b/modules/gapi/src/api/gmat.cpp
@@ -38,9 +38,28 @@ cv::GMatDesc cv::descr_of(const cv::Mat &mat)
 {
     return GMatDesc{mat.depth(), mat.channels(), {mat.cols, mat.rows}};
 }
+
 cv::GMatDesc cv::descr_of(const cv::UMat &mat)
 {
     return GMatDesc{ mat.depth(), mat.channels(),{ mat.cols, mat.rows } };
+}
+
+std::vector<cv::GMatDesc> cv::descr_of(std::vector<cv::Mat> const& vec)
+{
+    std::vector<cv::GMatDesc> vec_descr;
+    for(auto& mat : vec){
+        vec_descr.emplace_back(descr_of(mat));
+    }
+    return vec_descr;
+}
+
+std::vector<cv::GMatDesc> cv::descr_of(std::vector<cv::UMat> const& vec)
+{
+    std::vector<cv::GMatDesc> vec_descr;
+    for(auto& mat : vec){
+        vec_descr.emplace_back(descr_of(mat));
+    }
+    return vec_descr;
 }
 #endif
 

--- a/modules/gapi/test/gapi_desc_tests.cpp
+++ b/modules/gapi/test/gapi_desc_tests.cpp
@@ -51,8 +51,8 @@ TEST(GAPI_MetaDesc, VecMatDesc)
     EXPECT_EQ(320,     desc1[0].size.width);
     EXPECT_EQ(240,     desc1[0].size.height);
 
-    std::vector<cv::Mat> vec2 = {
-    cv::Mat(480, 640, CV_8UC3)};
+    std::vector<cv::UMat> vec2 = {
+    cv::UMat(480, 640, CV_8UC3)};
 
     const auto desc2 = cv::descr_of(vec2);
     EXPECT_EQ(CV_8U, desc2[0].depth);
@@ -63,10 +63,9 @@ TEST(GAPI_MetaDesc, VecMatDesc)
 
 TEST(GAPI_MetaDesc, VecOwnMatDesc)
 {
-    using Mat = cv::gapi::own::Mat;
-    std::vector<Mat> vec = {
-    Mat(240, 320, CV_8U, nullptr),
-    Mat(480, 640, CV_8UC3, nullptr)};
+    std::vector<cv::gapi::own::Mat> vec = {
+    cv::gapi::own::Mat(240, 320, CV_8U, nullptr),
+    cv::gapi::own::Mat(480, 640, CV_8UC3, nullptr)};
 
     const auto desc = cv::gapi::own::descr_of(vec);
     EXPECT_EQ(CV_8U, desc[0].depth);

--- a/modules/gapi/test/gapi_desc_tests.cpp
+++ b/modules/gapi/test/gapi_desc_tests.cpp
@@ -40,6 +40,25 @@ TEST(GAPI_MetaDesc, MatDesc)
     EXPECT_EQ(480,     desc2.size.height);
 }
 
+TEST(GAPI_MetaDesc, VecMatDesc)
+{
+    using Mat = cv::gapi::own::Mat;
+    std::vector<Mat> vec = {
+    Mat(240, 320, CV_8U, nullptr),
+    Mat(480, 640, CV_8UC3, nullptr)};
+
+    const auto desc = cv::gapi::own::descr_of(vec);
+    EXPECT_EQ(CV_8U, desc[0].depth);
+    EXPECT_EQ(1,       desc[0].chan);
+    EXPECT_EQ(320,     desc[0].size.width);
+    EXPECT_EQ(240,     desc[0].size.height);
+
+    EXPECT_EQ(CV_8U, desc[1].depth);
+    EXPECT_EQ(3,       desc[1].chan);
+    EXPECT_EQ(640,     desc[1].size.width);
+    EXPECT_EQ(480,     desc[1].size.height);
+}
+
 TEST(GAPI_MetaDesc, Compare_Equal_MatDesc)
 {
     const auto desc1 = cv::GMatDesc{CV_8U, 1, {64, 64}};

--- a/modules/gapi/test/gapi_desc_tests.cpp
+++ b/modules/gapi/test/gapi_desc_tests.cpp
@@ -42,6 +42,27 @@ TEST(GAPI_MetaDesc, MatDesc)
 
 TEST(GAPI_MetaDesc, VecMatDesc)
 {
+    std::vector<cv::Mat> vec1 = {
+    cv::Mat(240, 320, CV_8U)};
+
+    const auto desc1 = cv::descr_of(vec1);
+    EXPECT_EQ(CV_8U, desc1[0].depth);
+    EXPECT_EQ(1,       desc1[0].chan);
+    EXPECT_EQ(320,     desc1[0].size.width);
+    EXPECT_EQ(240,     desc1[0].size.height);
+
+    std::vector<cv::Mat> vec2 = {
+    cv::Mat(480, 640, CV_8UC3)};
+
+    const auto desc2 = cv::descr_of(vec2);
+    EXPECT_EQ(CV_8U, desc2[0].depth);
+    EXPECT_EQ(3,       desc2[0].chan);
+    EXPECT_EQ(640,     desc2[0].size.width);
+    EXPECT_EQ(480,     desc2[0].size.height);
+}
+
+TEST(GAPI_MetaDesc, VecOwnMatDesc)
+{
     using Mat = cv::gapi::own::Mat;
     std::vector<Mat> vec = {
     Mat(240, 320, CV_8U, nullptr),


### PR DESCRIPTION
This pullrequest adds descr_of function taking a vector of Mat objects


