### PR TITLE
PyrDown: Fix bug #12961

### DIFF
--- a/modules/core/include/opencv2/core/cvdef.h
+++ b/modules/core/include/opencv2/core/cvdef.h
@@ -216,7 +216,7 @@ namespace cv { namespace debug_build_guard { } using namespace debug_build_guard
 #  define CV_ENABLE_UNROLLED 1
 #endif
 
-#if defined(__GNUC__) ||  defined(__clang__)
+#ifdef __GNUC__
 #  define CV_DECL_ALIGNED(x) __attribute__ ((aligned (x)))
 #elif defined _MSC_VER
 #  define CV_DECL_ALIGNED(x) __declspec(align(x))

--- a/modules/core/include/opencv2/core/cvdef.h
+++ b/modules/core/include/opencv2/core/cvdef.h
@@ -216,7 +216,7 @@ namespace cv { namespace debug_build_guard { } using namespace debug_build_guard
 #  define CV_ENABLE_UNROLLED 1
 #endif
 
-#ifdef __GNUC__
+#if defined(__GNUC__) ||  defined(__clang__)
 #  define CV_DECL_ALIGNED(x) __attribute__ ((aligned (x)))
 #elif defined _MSC_VER
 #  define CV_DECL_ALIGNED(x) __declspec(align(x))

--- a/modules/imgproc/src/pyramids.cpp
+++ b/modules/imgproc/src/pyramids.cpp
@@ -112,7 +112,7 @@ struct PyrDownVec_32s8u
             v_rshr_pack_store<8>(dst + x, t0);
             x += v_uint16::nlanes;
         }
-        typedef int unaligned_int __attribute__((aligned(1)));
+        typedef int unaligned_int CV_DECL_ALIGNED(1);
         for ( ; x <= width - v_int32x4::nlanes; x += v_int32x4::nlanes)
         {
             v_int32x4 r0, r1, r2, r3, r4, t0;

--- a/modules/imgproc/src/pyramids.cpp
+++ b/modules/imgproc/src/pyramids.cpp
@@ -112,7 +112,7 @@ struct PyrDownVec_32s8u
             v_rshr_pack_store<8>(dst + x, t0);
             x += v_uint16::nlanes;
         }
-        typedef int unaligned_int CV_DECL_ALIGNED(1);
+        typedef int CV_DECL_ALIGNED(1) unaligned_int;
         for ( ; x <= width - v_int32x4::nlanes; x += v_int32x4::nlanes)
         {
             v_int32x4 r0, r1, r2, r3, r4, t0;

--- a/modules/imgproc/src/pyramids.cpp
+++ b/modules/imgproc/src/pyramids.cpp
@@ -112,6 +112,7 @@ struct PyrDownVec_32s8u
             v_rshr_pack_store<8>(dst + x, t0);
             x += v_uint16::nlanes;
         }
+        typedef int unaligned_int __attribute__((aligned(1)));
         for ( ; x <= width - v_int32x4::nlanes; x += v_int32x4::nlanes)
         {
             v_int32x4 r0, r1, r2, r3, r4, t0;
@@ -122,7 +123,7 @@ struct PyrDownVec_32s8u
             r4 = v_load(row4 + x);
             t0 = r0 + r4 + (r2 + r2) + ((r1 + r3 + r2) << 2);
 
-            *(int*)(dst + x) = v_reinterpret_as_s32(v_rshr_pack<8>(v_pack_u(t0, t0), v_setzero_u16())).get0();
+            *((unaligned_int*) (dst + x)) = v_reinterpret_as_s32(v_rshr_pack<8>(v_pack_u(t0, t0), v_setzero_u16())).get0();
         }
 
         return x;

--- a/modules/imgproc/test/test_filter.cpp
+++ b/modules/imgproc/test/test_filter.cpp
@@ -2235,4 +2235,13 @@ TEST(Imgproc_Sobel, s16_regression_13506)
     Sobel(src, dst, CV_16S, 0, 1, 5);
     ASSERT_EQ(0.0, cvtest::norm(dst, ref, NORM_INF));
 }
+
+TEST(Imgproc_Pyrdown, issue_12961)
+{
+    Mat src(9, 9, CV_8UC1, Scalar::all(0));
+    Mat dst;
+    cv::pyrDown(src, dst);
+    ASSERT_EQ(0.0, cv::norm(dst));
+}
+
 }} // namespace


### PR DESCRIPTION
resolves #12961 

### This pullrequest changes

Force ARM implementation to use an unaligned int pointer.