### PR TITLE
Add note about building for pkg-config

### DIFF
--- a/doc/tutorials/introduction/linux_install/linux_install.markdown
+++ b/doc/tutorials/introduction/linux_install/linux_install.markdown
@@ -96,6 +96,11 @@ Building OpenCV from Source Using CMake
     -   Unset parameter: BUILD_SHARED_LIBS
     -   It is useful also to unset BUILD_EXAMPLES, BUILD_TESTS, BUILD_PERF_TESTS - as they all
         will be statically linked with OpenCV and can take a lot of memory.
+        
+-#  [optional] Generate pkg-config info
+    -   Add this flag when running cmake: -D OPENCV_GENERATE_PKGCONFIG = YES
+    -   Will generate the .pc file for pkg-config and install it.
+    -   Useful if not using cmake in projects that use OpenCV
 
 -#  Build. From build directory execute *make*, it is recommended to do this in several threads
 

--- a/doc/tutorials/introduction/linux_install/linux_install.markdown
+++ b/doc/tutorials/introduction/linux_install/linux_install.markdown
@@ -96,11 +96,11 @@ Building OpenCV from Source Using CMake
     -   Unset parameter: BUILD_SHARED_LIBS
     -   It is useful also to unset BUILD_EXAMPLES, BUILD_TESTS, BUILD_PERF_TESTS - as they all
         will be statically linked with OpenCV and can take a lot of memory.
-        
+
 -#  [optional] Generate pkg-config info
-    -   Add this flag when running cmake: -D OPENCV_GENERATE_PKGCONFIG = YES
+    -   Add this flag when running CMake: `-DOPENCV_GENERATE_PKGCONFIG=ON`
     -   Will generate the .pc file for pkg-config and install it.
-    -   Useful if not using cmake in projects that use OpenCV
+    -   Useful if not using CMake in projects that use OpenCV
 
 -#  Build. From build directory execute *make*, it is recommended to do this in several threads
 


### PR DESCRIPTION
Should help avoid future issues about pkg-config (#13154, #13245) without changing the code, simply adding to the documentation.

### This pullrequest changes

Adds another item to the optional build parameters that explains flags needs to generate the ``pkg-config`` .pc file during build and installation.
