### PR TITLE
Return vector of MetaArg instead of MatDesc and fix test with ADL check

### DIFF
--- a/modules/gapi/include/opencv2/gapi/gmat.hpp
+++ b/modules/gapi/include/opencv2/gapi/gmat.hpp
@@ -133,8 +133,6 @@ static inline GMatDesc empty_gmat_desc() { return GMatDesc{-1,-1,{-1,-1}}; }
 class Mat;
 GAPI_EXPORTS GMatDesc descr_of(const cv::Mat &mat);
 GAPI_EXPORTS GMatDesc descr_of(const cv::UMat &mat);
-GAPI_EXPORTS std::vector<GMatDesc> descr_of(const std::vector<cv::Mat> &vec);
-GAPI_EXPORTS std::vector<GMatDesc> descr_of(const std::vector<cv::UMat> &vec);
 #endif // !defined(GAPI_STANDALONE)
 
 /** @} */
@@ -142,7 +140,6 @@ GAPI_EXPORTS std::vector<GMatDesc> descr_of(const std::vector<cv::UMat> &vec);
 namespace gapi { namespace own {
     class Mat;
     GAPI_EXPORTS GMatDesc descr_of(const Mat &mat);
-    GAPI_EXPORTS std::vector<GMatDesc> descr_of(const std::vector<Mat> &vec);
 }}//gapi::own
 
 std::ostream& operator<<(std::ostream& os, const cv::GMatDesc &desc);

--- a/modules/gapi/include/opencv2/gapi/gmetaarg.hpp
+++ b/modules/gapi/include/opencv2/gapi/gmetaarg.hpp
@@ -61,6 +61,16 @@ namespace detail
 
 } // namespace detail
 
+// Forward declaration for gmat
+class Mat;
+class UMat;
+GAPI_EXPORTS std::vector<cv::GMetaArg> descr_of(const std::vector<cv::Mat> &vec);
+GAPI_EXPORTS std::vector<cv::GMetaArg> descr_of(const std::vector<cv::UMat> &vec);
+namespace gapi { namespace own {
+    class Mat;
+    GAPI_EXPORTS std::vector<cv::GMetaArg> descr_of(const std::vector<Mat> &vec);
+}} // namespace gapi::own
+
 } // namespace cv
 
 #endif // OPENCV_GAPI_GMETAARG_HPP

--- a/modules/gapi/src/api/gmat.cpp
+++ b/modules/gapi/src/api/gmat.cpp
@@ -33,14 +33,18 @@ const cv::GOrigin& cv::GMat::priv() const
     return *m_priv;
 }
 
-template <typename T> std::vector<cv::GMatDesc> vec_descr_of(const std::vector<T> &vec)
-{
-    std::vector<cv::GMatDesc> vec_descr;
-    for(auto& mat : vec){
-        vec_descr.emplace_back(descr_of(mat));
+namespace{
+    template <typename T> std::vector<cv::GMetaArg> vec_descr_of(const std::vector<T> &vec)
+        {
+        std::vector<cv::GMetaArg> vec_descr{vec.size()};
+        vec_descr.clear();
+        for(auto& mat : vec){
+            vec_descr.emplace_back(descr_of(mat));
+        }
+        return vec_descr;
     }
-    return vec_descr;
 }
+
 
 #if !defined(GAPI_STANDALONE)
 cv::GMatDesc cv::descr_of(const cv::Mat &mat)
@@ -53,12 +57,12 @@ cv::GMatDesc cv::descr_of(const cv::UMat &mat)
     return GMatDesc{ mat.depth(), mat.channels(),{ mat.cols, mat.rows } };
 }
 
-std::vector<cv::GMatDesc> cv::descr_of(const std::vector<cv::Mat> &vec)
+std::vector<cv::GMetaArg> cv::descr_of(const std::vector<cv::Mat> &vec)
 {
     return vec_descr_of(vec);
 }
 
-std::vector<cv::GMatDesc> cv::descr_of(const std::vector<cv::UMat> &vec)
+std::vector<cv::GMetaArg> cv::descr_of(const std::vector<cv::UMat> &vec)
 {
     return vec_descr_of(vec);
 }
@@ -69,7 +73,7 @@ cv::GMatDesc cv::gapi::own::descr_of(const cv::gapi::own::Mat &mat)
     return GMatDesc{mat.depth(), mat.channels(), {mat.cols, mat.rows}};
 }
 
-std::vector<cv::GMatDesc> cv::gapi::own::descr_of(const std::vector<cv::gapi::own::Mat> &vec)
+std::vector<cv::GMetaArg> cv::gapi::own::descr_of(const std::vector<cv::gapi::own::Mat> &vec)
 {
     return vec_descr_of(vec);
 }

--- a/modules/gapi/test/gapi_desc_tests.cpp
+++ b/modules/gapi/test/gapi_desc_tests.cpp
@@ -46,19 +46,21 @@ TEST(GAPI_MetaDesc, VecMatDesc)
     cv::Mat(240, 320, CV_8U)};
 
     const auto desc1 = cv::descr_of(vec1);
-    EXPECT_EQ(CV_8U, desc1[0].depth);
-    EXPECT_EQ(1,       desc1[0].chan);
-    EXPECT_EQ(320,     desc1[0].size.width);
-    EXPECT_EQ(240,     desc1[0].size.height);
+    const auto mat1 = get<GMatDesc>(desc1[0]);
+    EXPECT_EQ(CV_8U, mat1.depth);
+    EXPECT_EQ(1,     mat1.chan);
+    EXPECT_EQ(320,   mat1.size.width);
+    EXPECT_EQ(240,   mat1.size.height);
 
     std::vector<cv::UMat> vec2 = {
     cv::UMat(480, 640, CV_8UC3)};
 
     const auto desc2 = cv::descr_of(vec2);
-    EXPECT_EQ(CV_8U, desc2[0].depth);
-    EXPECT_EQ(3,       desc2[0].chan);
-    EXPECT_EQ(640,     desc2[0].size.width);
-    EXPECT_EQ(480,     desc2[0].size.height);
+    const auto mat2 = get<GMatDesc>(desc2[0]);
+    EXPECT_EQ(CV_8U, mat2.depth);
+    EXPECT_EQ(3,     mat2.chan);
+    EXPECT_EQ(640,   mat2.size.width);
+    EXPECT_EQ(480,   mat2.size.height);
 }
 
 TEST(GAPI_MetaDesc, VecOwnMatDesc)
@@ -67,16 +69,18 @@ TEST(GAPI_MetaDesc, VecOwnMatDesc)
     cv::gapi::own::Mat(240, 320, CV_8U, nullptr),
     cv::gapi::own::Mat(480, 640, CV_8UC3, nullptr)};
 
-    const auto desc = cv::gapi::own::descr_of(vec);
-    EXPECT_EQ(CV_8U, desc[0].depth);
-    EXPECT_EQ(1,       desc[0].chan);
-    EXPECT_EQ(320,     desc[0].size.width);
-    EXPECT_EQ(240,     desc[0].size.height);
+    const auto desc = descr_of(vec);
+    const auto mat1 = get<GMatDesc>(desc[0]);
+    const auto mat2 = get<GMatDesc>(desc[1]);
+    EXPECT_EQ(CV_8U, mat1.depth);
+    EXPECT_EQ(1,     mat1.chan);
+    EXPECT_EQ(320,   mat1.size.width);
+    EXPECT_EQ(240,   mat1.size.height);
 
-    EXPECT_EQ(CV_8U, desc[1].depth);
-    EXPECT_EQ(3,       desc[1].chan);
-    EXPECT_EQ(640,     desc[1].size.width);
-    EXPECT_EQ(480,     desc[1].size.height);
+    EXPECT_EQ(CV_8U, mat2.depth);
+    EXPECT_EQ(3,     mat2.chan);
+    EXPECT_EQ(640,   mat2.size.width);
+    EXPECT_EQ(480,   mat2.size.height);
 }
 
 TEST(GAPI_MetaDesc, Compare_Equal_MatDesc)


### PR DESCRIPTION
This pullrequest changes return type of descr_of function from vector of MatDesc to vector of MetaArg
