### PR TITLE
AVFoundation on Mac: fixed frame count and unsupported format handling (3.4)

### DIFF
--- a/modules/videoio/src/cap_avfoundation_mac.mm
+++ b/modules/videoio/src/cap_avfoundation_mac.mm
@@ -793,9 +793,7 @@ bool CvCaptureFile::setupReadingAt(CMTime position) {
     mFrameTimestamp = position;
     mFrameNum = round((mFrameTimestamp.value * mAssetTrack.nominalFrameRate) / double(mFrameTimestamp.timescale));
     [mAssetReader addOutput: mTrackOutput];
-    [mAssetReader startReading];
-
-    return true;
+    return [mAssetReader startReading];
 }
 
 int CvCaptureFile::didStart() {
@@ -1013,7 +1011,7 @@ double CvCaptureFile::getProperty(int property_id) const{
         case CV_CAP_PROP_POS_MSEC:
             return mFrameTimestamp.value * 1000.0 / mFrameTimestamp.timescale;
         case CV_CAP_PROP_POS_FRAMES:
-            return  mFrameNum;
+            return mAssetTrack.nominalFrameRate > 0 ? mFrameNum : 0;
         case CV_CAP_PROP_POS_AVI_RATIO:
             t = [mAsset duration];
             return (mFrameTimestamp.value * t.timescale) / double(mFrameTimestamp.timescale * t.value);
@@ -1049,18 +1047,15 @@ bool CvCaptureFile::setProperty(int property_id, double value) {
         case CV_CAP_PROP_POS_MSEC:
             t = mAsset.duration;
             t.value = value * t.timescale / 1000;
-            setupReadingAt(t);
-            retval = true;
+            retval = setupReadingAt(t);
             break;
         case CV_CAP_PROP_POS_FRAMES:
-            setupReadingAt(CMTimeMake(value, mAssetTrack.nominalFrameRate));
-            retval = true;
+            retval = mAssetTrack.nominalFrameRate > 0 ? setupReadingAt(CMTimeMake(value, mAssetTrack.nominalFrameRate)) : false;
             break;
         case CV_CAP_PROP_POS_AVI_RATIO:
             t = mAsset.duration;
             t.value = round(t.value * value);
-            setupReadingAt(t);
-            retval = true;
+            retval = setupReadingAt(t);
             break;
         case CV_CAP_PROP_MODE:
             int mode;
@@ -1074,8 +1069,7 @@ bool CvCaptureFile::setProperty(int property_id, double value) {
                     case CV_CAP_MODE_GRAY:
                     case CV_CAP_MODE_YUYV:
                         mMode = mode;
-                        setupReadingAt(mFrameTimestamp);
-                        retval = true;
+                        retval = setupReadingAt(mFrameTimestamp);
                         break;
                     default:
                         fprintf(stderr, "VIDEOIO ERROR: AVF Mac: Unsupported mode: %d\n", mode);

--- a/modules/videoio/test/test_video_io.cpp
+++ b/modules/videoio/test/test_video_io.cpp
@@ -307,10 +307,9 @@ static const VideoCaptureAPIs backend_params[] = {
     CAP_QT,
 #endif
 
-// TODO: Broken?
-//#ifdef HAVE_AVFOUNDATION
-//    CAP_AVFOUNDATION,
-//#endif
+#ifdef HAVE_AVFOUNDATION
+   CAP_AVFOUNDATION,
+#endif
 
 #ifdef HAVE_MSMF
     CAP_MSMF,
@@ -413,18 +412,16 @@ static Ext_Fourcc_PSNR synthetic_params[] = {
     makeParam("mkv", "MJPG", 30.f, CAP_QT),
 #endif
 
-// TODO: Broken?
-//#ifdef HAVE_AVFOUNDATION
-//    makeParam("mov", "mp4v", 30.f, CAP_AVFOUNDATION),
-//    makeParam("avi", "XVID", 30.f, CAP_AVFOUNDATION),
-//    makeParam("avi", "MPEG", 30.f, CAP_AVFOUNDATION),
-//    makeParam("avi", "IYUV", 30.f, CAP_AVFOUNDATION),
-//    makeParam("avi", "MJPG", 30.f, CAP_AVFOUNDATION),
-
-//    makeParam("mkv", "XVID", 30.f, CAP_AVFOUNDATION),
-//    makeParam("mkv", "MPEG", 30.f, CAP_AVFOUNDATION),
-//    makeParam("mkv", "MJPG", 30.f, CAP_AVFOUNDATION),
-//#endif
+#ifdef HAVE_AVFOUNDATION
+   makeParam("mov", "H264", 30.f, CAP_AVFOUNDATION),
+   makeParam("mov", "MJPG", 30.f, CAP_AVFOUNDATION),
+   makeParam("mp4", "H264", 30.f, CAP_AVFOUNDATION),
+   makeParam("mp4", "MJPG", 30.f, CAP_AVFOUNDATION),
+   makeParam("m4v", "H264", 30.f, CAP_AVFOUNDATION),
+   makeParam("m4v", "MJPG", 30.f, CAP_AVFOUNDATION),
+   makeParam("3gp", "H264", 30.f, CAP_AVFOUNDATION),
+   makeParam("3gp", "MJPG", 30.f, CAP_AVFOUNDATION),
+#endif
 
 #ifdef HAVE_FFMPEG
     makeParam("avi", "XVID", 30.f, CAP_FFMPEG),


### PR DESCRIPTION
### This pullrequest changes

Fixed test failures on Mac:
* AVFoundation writer supports only "mov", "mp4"/"m4v" and "3gp" formats with H264 and MJPG codecs - enabled these combinations to synthetic read_write test
* big_buck_bunny.mjpg.avi returned FPS=0, thus frame position calculations were wrong - added proper handling
* unsupported formats were not handled correctly in some cases: `setupReadingAt` returned true even if AssetReader returned false 
