### PR TITLE
Updated opencv.js emscripten bindings for matching

### DIFF
--- a/modules/js/src/core_bindings.cpp
+++ b/modules/js/src/core_bindings.cpp
@@ -341,6 +341,8 @@ EMSCRIPTEN_BINDINGS(binding_utils)
     register_vector<cv::Mat>("MatVector");
     register_vector<cv::Rect>("RectVector");
     register_vector<cv::KeyPoint>("KeyPointVector");
+    register_vector<cv::DMatch>("DMatchVector");
+    register_vector<std::vector<cv::DMatch>>("DMatchVectorVector");
 
     emscripten::class_<cv::Mat>("Mat")
         .constructor<>()
@@ -493,6 +495,13 @@ EMSCRIPTEN_BINDINGS(binding_utils)
         .field("pt", &cv::KeyPoint::pt)
         .field("response", &cv::KeyPoint::response)
         .field("size", &cv::KeyPoint::size);
+
+    emscripten::value_object<cv::DMatch>("DMatch")
+        .field("queryIdx", &cv::DMatch::queryIdx)
+        .field("trainIdx", &cv::DMatch::trainIdx)
+        .field("imgIdx", &cv::DMatch::imgIdx)
+        .field("distance", &cv::DMatch::distance);
+
 
     emscripten::value_array<cv::Scalar_<double>> ("Scalar")
         .element(index<0>())


### PR DESCRIPTION
This PR is necessary for opencv.js to implement the C to JS bindings for Emscripten needed for advanced pattern matching.

<cut/>

In the docs:

https://docs.opencv.org/3.4.5/db/d39/classcv_1_1DescriptorMatcher.html#a378f35c9b1a5dfa4022839a45cdf0e89

`knnMatch` needs input `matches` of type `std::vector< std::vector< DMatch > > &` 
`match` needs input `matches` of type `std::vector< DMatch > &`

We have tested the matching functions with the code below and it worked as expected (new constructor `cv.DMatchVectorVector`):
```
  var orb = new cv.ORB();

  var kp1 = new cv.KeyPointVector();
  var des1 = new cv.Mat();
  orb.detectAndCompute(patternImg, new cv.Mat(), kp1, des1);

  var kp2 = new cv.KeyPointVector();
  var des2 = new cv.Mat();
  orb.detectAndCompute(fullImg, new cv.Mat(), kp2, des2);

  var matches = new cv.DMatchVectorVector();
  var bf = new cv.BFMatcher(cv.NORM_HAMMING2, false)
  var mask = new cv.Mat();
  bf.knnMatch(des1, des2, matches, 3, mask, false)
```
@alalek @huningxin


```
docker_image:Docs=docs-js
force_builders=linux,Docs,Custom
buildworker:Custom=linux-1,linux-2,linux-4
docker_image:Custom=javascript
```
