### PR TITLE
Fixed warnings produced by clang-9.0.0

### DIFF
--- a/modules/core/include/opencv2/core/persistence.hpp
+++ b/modules/core/include/opencv2/core/persistence.hpp
@@ -320,7 +320,7 @@ public:
         BASE64      = 64,     //!< flag, write rawdata in Base64 by default. (consider using WRITE_BASE64)
         WRITE_BASE64 = BASE64 | WRITE, //!< flag, enable both WRITE and BASE64
     };
-    enum
+    enum State
     {
         UNDEFINED      = 0,
         VALUE_EXPECTED = 1,

--- a/modules/core/src/persistence.cpp
+++ b/modules/core/src/persistence.cpp
@@ -342,14 +342,6 @@ static inline void writeReal(uchar* p, double fval)
 class FileStorage::Impl : public FileStorage_API
 {
 public:
-    enum State
-    {
-        UNDEFINED      = 0,
-        VALUE_EXPECTED = 1,
-        NAME_EXPECTED  = 2,
-        INSIDE_MAP     = 4
-    };
-
     void init()
     {
         flags = 0;

--- a/modules/core/test/test_ptr.cpp
+++ b/modules/core/test/test_ptr.cpp
@@ -160,7 +160,14 @@ TEST(Core_Ptr, assignment)
 
     {
         Ptr<Reporter> p1(new Reporter(&deleted1));
+#if defined(__clang__) && (__clang_major__ >= 9) && !defined(__APPLE__)
+CV_DO_PRAGMA(GCC diagnostic push)
+CV_DO_PRAGMA(GCC diagnostic ignored "-Wself-assign-overloaded")
+#endif
         p1 = p1;
+#if defined(__clang__) && (__clang_major__ >= 9) && !defined(__APPLE__)
+CV_DO_PRAGMA(GCC diagnostic pop)
+#endif
         EXPECT_FALSE(deleted1);
     }
 

--- a/modules/gapi/include/opencv2/gapi/gcompoundkernel.hpp
+++ b/modules/gapi/include/opencv2/gapi/gcompoundkernel.hpp
@@ -78,7 +78,7 @@ template<typename T> struct tuple_wrap_helper
 template<typename... Objs>
 struct tuple_wrap_helper<std::tuple<Objs...>>
 {
-    static std::tuple<Objs...> get(std::tuple<Objs...>&& objs) { return objs; }
+    static std::tuple<Objs...> get(std::tuple<Objs...>&& objs) { return std::forward<std::tuple<Objs...>>(objs); }
 };
 
 template<typename, typename, typename>

--- a/modules/stitching/src/camera.cpp
+++ b/modules/stitching/src/camera.cpp
@@ -66,7 +66,7 @@ Mat CameraParams::K() const
     Mat_<double> k = Mat::eye(3, 3, CV_64F);
     k(0,0) = focal; k(0,2) = ppx;
     k(1,1) = focal * aspect; k(1,2) = ppy;
-    return k;
+    return std::move(k);
 }
 
 } // namespace detail

--- a/modules/video/src/optical_flow_io.cpp
+++ b/modules/video/src/optical_flow_io.cpp
@@ -52,12 +52,12 @@ CV_EXPORTS_W Mat readOpticalFlow( const String& path )
     Mat_<Point2f> flow;
     std::ifstream file(path.c_str(), std::ios_base::binary);
     if ( !file.good() )
-        return flow; // no file - return empty matrix
+        return std::move(flow); // no file - return empty matrix
 
     float tag;
     file.read((char*) &tag, sizeof(float));
     if ( tag != FLOW_TAG_FLOAT )
-        return flow;
+        return std::move(flow);
 
     int width, height;
 
@@ -76,14 +76,14 @@ CV_EXPORTS_W Mat readOpticalFlow( const String& path )
             if ( !file.good() )
             {
                 flow.release();
-                return flow;
+                return std::move(flow);
             }
 
             flow(i, j) = u;
         }
     }
     file.close();
-    return flow;
+    return std::move(flow);
 }
 
 CV_EXPORTS_W bool writeOpticalFlow( const String& path, InputArray flow )


### PR DESCRIPTION
Merge with opencv/opencv_contrib#1980

### This pullrequest changes

* `warning: declaration shadows a static data member of 'cv::FileStorage' [-Wshadow]`
* `warning: local variable xxxxx will be copied despite being returned by name [-Wreturn-std-move]`
* `warning: explicitly assigning value of variable of type 'Ptr<opencv_test::(anonymous namespace)::anonymous namespace)::Reporter>' to itself [-Wself-assign-overloaded]`

```
force_builders=Custom
buildworker:Custom=linux-1,linux-2,linux-4
docker_image:Custom=ubuntu-clang:18.04
buildworker:Win64 OpenCL=windows-2
```