### PR TITLE
Add flushing to printing number of processed positive/negative samples so that user is informed of updates quicker

### DIFF
--- a/apps/traincascade/cascadeclassifier.cpp
+++ b/apps/traincascade/cascadeclassifier.cpp
@@ -340,7 +340,7 @@ int CvCascadeClassifier::fillPassedSamples( int first, int count, bool isPositiv
             if( predict( i ) == 1 )
             {
                 getcount++;
-                printf("%s current samples: %d\r", isPositive ? "POS":"NEG", getcount);
+                std::cout << (isPositive ? "POS" : "NEG") << " current samples: " << getcount << "\r" << std::flush;
                 break;
             }
         }

--- a/apps/traincascade/cascadeclassifier.cpp
+++ b/apps/traincascade/cascadeclassifier.cpp
@@ -340,7 +340,8 @@ int CvCascadeClassifier::fillPassedSamples( int first, int count, bool isPositiv
             if( predict( i ) == 1 )
             {
                 getcount++;
-                std::cout << (isPositive ? "POS" : "NEG") << " current samples: " << getcount << "\r" << std::flush;
+                printf("%s current samples: %d\r", isPositive ? "POS":"NEG", getcount);
+                fflush(stdout);
                 break;
             }
         }


### PR DESCRIPTION
### This pullrequest changes

Add flushing to printing number of processed positive/negative samples so that when running opencv_traincascade, the user is informed of updates quicker.
Without this change I got updates one per half of hour.