### PR TITLE
Clone convolution layer weights only for fusion

### DIFF
--- a/modules/dnn/src/layers/convolution_layer.cpp
+++ b/modules/dnn/src/layers/convolution_layer.cpp
@@ -278,7 +278,7 @@ public:
         const int outCn = blobs[0].size[0];
         // prepare weightsMat where each row is aligned and has enough zero padding on the right to
         // use vectorized (i.e. with intrinsics) loops without tail processing
-        Mat wm = blobs[0].reshape(1, outCn).clone();
+        Mat wm = blobs[0].reshape(1, outCn);
         if( wm.step1() % VEC_ALIGN != 0 )
         {
             int newcols = (int)alignSize(wm.step1(), VEC_ALIGN);
@@ -371,6 +371,10 @@ public:
 
         if (!w.empty())
         {
+            // Keep origin weights unchanged.
+            if (weightsMat.data == blobs[0].data)
+                weightsMat = weightsMat.clone();
+
             Mat originWeights = blobs[0].reshape(1, outCn);
             for (int i = 0; i < outCn; ++i)
             {


### PR DESCRIPTION
<!-- Please use this line to close one or multiple issues when this pullrequest gets merged
You can add another line right under the first one:
resolves #1234
resolves #1235
-->

### This pullrequest changes

Move convolution weights cloning to fusion phase to reduce top memory consumption.

| Model | w/o PR | with PR |
|---|---|---|
| AlexNet | 398 MB | 398 MB (x1.00) |
| ResNet-50 | 222 MB | 222 MB (x1.00) |
| SqueezeNet v1.1 | 35 MB | 30.5 MB (x0.86) |
| MobileNet-SSD (Caffe) | 73 MB | 50.3 MB (x0.68) |
| MobileNet-SSD v1 (TensorFlow) | 83.3 MB | 58.8 MB (x0.70) |

Sample (use `/usr/bin/time --verbose`)

```cpp
#include <opencv2/opencv.hpp>

using namespace cv;
using namespace cv::dnn;

std::string keys =
    "{ model     | |  }"
    "{ proto     | |  }"
    "{ size     | |  }";


int main(int argc, char** argv) {
  CommandLineParser parser(argc, argv, keys);

  const std::string model = parser.get<String>("model");
  const std::string proto = parser.get<String>("proto");
  const int size = parser.get<int>("size");

  int blobSize[] = {1, 3, size, size};
  Mat blob(4, &blobSize[0], CV_32F);

  Net net = readNet(model, proto);
  net.setInput(blob);
  net.forward();

  return 0;
}
```
