### PR TITLE
SVM sigmoid kernel fix (issue #13621)

### DIFF
--- a/modules/ml/src/svm.cpp
+++ b/modules/ml/src/svm.cpp
@@ -200,16 +200,16 @@ public:
     {
         int j;
         calc_non_rbf_base( vcount, var_count, vecs, another, results,
-                          -2*params.gamma, -2*params.coef0 );
+                          2*params.gamma, 2*params.coef0 );
         // TODO: speedup this
         for( j = 0; j < vcount; j++ )
         {
             Qfloat t = results[j];
-            Qfloat e = std::exp(-std::abs(t));
+            Qfloat e = std::exp(std::abs(t));
             if( t > 0 )
-                results[j] = (Qfloat)((1. - e)/(1. + e));
-            else
                 results[j] = (Qfloat)((e - 1.)/(e + 1.));
+            else
+                results[j] = (Qfloat)((1. - e)/(1. + e));
         }
     }
 

--- a/modules/ml/src/svm.cpp
+++ b/modules/ml/src/svm.cpp
@@ -213,7 +213,6 @@ public:
         }
     }
 
-
     void calc_rbf( int vcount, int var_count, const float* vecs,
                    const float* another, Qfloat* results )
     {

--- a/modules/ml/src/svm.cpp
+++ b/modules/ml/src/svm.cpp
@@ -1310,8 +1310,6 @@ public:
 
             if( kernelType != SIGMOID && kernelType != POLY )
                 params.coef0 = 0;
-            else if( params.coef0 < 0 )
-                CV_Error( CV_StsOutOfRange, "The kernel parameter <coef0> must be positive or zero" );
 
             if( kernelType != POLY )
                 params.degree = 0;

--- a/modules/ml/test/test_svmtrainauto.cpp
+++ b/modules/ml/test/test_svmtrainauto.cpp
@@ -120,7 +120,6 @@ TEST(ML_SVM, trainauto_sigmoid)
     cv::Ptr<SVM> svm = SVM::create();
     svm->setKernel(SVM::SIGMOID);
 
-    // If gamma is zero then all data will be put in the same class
     svm->setGamma(10.0);
     svm->setCoef0(-10.0);
     svm->trainAuto( data, 10 );  // 2-fold cross validation.

--- a/modules/ml/test/test_svmtrainauto.cpp
+++ b/modules/ml/test/test_svmtrainauto.cpp
@@ -100,7 +100,7 @@ TEST(ML_SVM, trainauto_sigmoid)
     // Populate samples with data that can be split into two concentric circles
     for (int i = 0; i < datasize; i+=2)
     {
-        const float pi = 3.14159;
+        const float pi = 3.14159f;
         const float angle_rads = (i/datasize) * pi;
         const float x = radius * cos(angle_rads);
         const float y = radius * cos(angle_rads);

--- a/modules/ml/test/test_svmtrainauto.cpp
+++ b/modules/ml/test/test_svmtrainauto.cpp
@@ -161,6 +161,18 @@ void CV_SVMGetSupportVectorsTest::run(int /*startFrom*/ )
     CV_Assert(sv.rows == 0);    // inapplicable for non-linear SVMs
 
 
+    // Test retrieval of SVs and compressed SVs on sigmoid SVM
+    svm->setKernel(SVM::SIGMOID);
+    svm->setGamma(0.5);
+    svm->setCoef0(1.5);
+    svm->train(trainingDataMat, cv::ml::ROW_SAMPLE, labelsMat);
+
+    sv = svm->getSupportVectors();
+    CV_Assert(sv.rows == 2);
+    sv = svm->getUncompressedSupportVectors();
+    CV_Assert(sv.rows == 0);    // inapplicable for non-linear SVMs
+
+
     ts->set_failed_test_info(code);
 }
 

--- a/modules/ml/test/test_svmtrainauto.cpp
+++ b/modules/ml/test/test_svmtrainauto.cpp
@@ -123,7 +123,6 @@ TEST(ML_SVM, trainauto_sigmoid)
     // If gamma is zero then all data will be put in the same class
     svm->setGamma(10.0);
     svm->setCoef0(10.0);
-
     svm->trainAuto( data, 10 );  // 2-fold cross validation.
 
     float test_data0[2] = {radius, radius};

--- a/modules/ml/test/test_svmtrainauto.cpp
+++ b/modules/ml/test/test_svmtrainauto.cpp
@@ -122,7 +122,7 @@ TEST(ML_SVM, trainauto_sigmoid)
 
     // If gamma is zero then all data will be put in the same class
     svm->setGamma(10.0);
-    svm->setCoef0(10.0);
+    svm->setCoef0(-10.0);
     svm->trainAuto( data, 10 );  // 2-fold cross validation.
 
     float test_data0[2] = {radius, radius};

--- a/modules/ml/test/test_svmtrainauto.cpp
+++ b/modules/ml/test/test_svmtrainauto.cpp
@@ -126,11 +126,11 @@ TEST(ML_SVM, trainauto_sigmoid)
 
     float test_data0[2] = {radius, radius};
     cv::Mat test_point0 = cv::Mat( 1, 2, CV_32FC1, test_data0 );
-    CV_Assert(0 == svm->predict( test_point0 ));
+    ASSERT_EQ(0, svm->predict( test_point0 ));
 
     float test_data1[2] = {scale_factor * radius, scale_factor * radius};
     cv::Mat test_point1 = cv::Mat( 1, 2, CV_32FC1, test_data1 );
-    CV_Assert(1 == svm->predict( test_point1 ));
+    ASSERT_EQ(1, svm->predict( test_point1 ));
 }
 
 

--- a/modules/ml/test/test_svmtrainauto.cpp
+++ b/modules/ml/test/test_svmtrainauto.cpp
@@ -88,6 +88,53 @@ void CV_SVMTrainAutoTest::run( int /*start_from*/ )
 
 TEST(ML_SVM, trainauto) { CV_SVMTrainAutoTest test; test.safe_run(); }
 
+TEST(ML_SVM, trainauto_sigmoid)
+{
+    const int datasize = 100;
+    cv::Mat samples = cv::Mat::zeros( datasize, 2, CV_32FC1 );
+    cv::Mat responses = cv::Mat::zeros( datasize, 1, CV_32S );
+
+    const float scale_factor = 0.5;
+    const float radius = 2.0;
+
+    // Populate samples with data that can be split into two concentric circles
+    for (int i = 0; i < datasize; i+=2)
+    {
+        const float pi = 3.14159;
+        const double angle_rads = (i/datasize) * pi;
+        const double x = radius * cos(angle_rads);
+        const double y = radius * cos(angle_rads);
+
+        // Larger circle
+        samples.at<float>( i, 0 ) = x;
+        samples.at<float>( i, 1 ) = y;
+        responses.at<int>( i, 0 ) = 0;
+
+        // Smaller circle
+        samples.at<float>( i + 1, 0 ) = x * scale_factor;
+        samples.at<float>( i + 1, 1 ) = y * scale_factor;
+        responses.at<int>( i + 1, 0 ) = 1;
+    }
+
+    cv::Ptr<TrainData> data = TrainData::create( samples, cv::ml::ROW_SAMPLE, responses );
+    cv::Ptr<SVM> svm = SVM::create();
+    svm->setKernel(SVM::SIGMOID);
+
+    // If gamma is zero then all data will be put in the same class
+    svm->setGamma(10.0);
+    svm->setCoef0(10.0);
+
+    svm->trainAuto( data, 10 );  // 2-fold cross validation.
+
+    float test_data0[2] = {radius, radius};
+    cv::Mat test_point0 = cv::Mat( 1, 2, CV_32FC1, test_data0 );
+    CV_Assert(0 == svm->predict( test_point0 ));
+
+    float test_data1[2] = {scale_factor * radius, scale_factor * radius};
+    cv::Mat test_point1 = cv::Mat( 1, 2, CV_32FC1, test_data1 );
+    CV_Assert(1 == svm->predict( test_point1 ));
+}
+
 
 TEST(ML_SVM, trainAuto_regression_5369)
 {

--- a/modules/ml/test/test_svmtrainauto.cpp
+++ b/modules/ml/test/test_svmtrainauto.cpp
@@ -161,18 +161,6 @@ void CV_SVMGetSupportVectorsTest::run(int /*startFrom*/ )
     CV_Assert(sv.rows == 0);    // inapplicable for non-linear SVMs
 
 
-    // Test retrieval of SVs and compressed SVs on sigmoid SVM
-    svm->setKernel(SVM::SIGMOID);
-    svm->setGamma(0.5);
-    svm->setCoef0(1.5);
-    svm->train(trainingDataMat, cv::ml::ROW_SAMPLE, labelsMat);
-
-    sv = svm->getSupportVectors();
-    CV_Assert(sv.rows == 2);
-    sv = svm->getUncompressedSupportVectors();
-    CV_Assert(sv.rows == 0);    // inapplicable for non-linear SVMs
-
-
     ts->set_failed_test_info(code);
 }
 

--- a/modules/ml/test/test_svmtrainauto.cpp
+++ b/modules/ml/test/test_svmtrainauto.cpp
@@ -101,9 +101,9 @@ TEST(ML_SVM, trainauto_sigmoid)
     for (int i = 0; i < datasize; i+=2)
     {
         const float pi = 3.14159;
-        const double angle_rads = (i/datasize) * pi;
-        const double x = radius * cos(angle_rads);
-        const double y = radius * cos(angle_rads);
+        const float angle_rads = (i/datasize) * pi;
+        const float x = radius * cos(angle_rads);
+        const float y = radius * cos(angle_rads);
 
         // Larger circle
         samples.at<float>( i, 0 ) = x;


### PR DESCRIPTION
resolves #13621

### This pullrequest changes
_tl;dr sigmoid kernel is now as it should be, removed a restriction on coef0 that I understand to be incorrect_

Normally the sigmoid kernel used in SVM is:
K(x, y) = tanh(gamma * <x, y> + coef0)

But OpenCV had implemented the negative of this:
K(x, y) = -tanh(gamma * <x, y> + coef0)

[The OpenCV documentation](https://docs.opencv.org/3.4/d1/d2d/classcv_1_1ml_1_1SVM.html#aad7f1aaccced3c33bb256640910a0e56) says that it should be the former.

I've fixed this and added a test to give some coverage.  I chose a simple dataset that seemed well suited to the sigmoid kernel, and saw that someone else had used successfully:
![image](https://user-images.githubusercontent.com/5368222/51948378-292ed800-2420-11e9-8026-536f0c28b47a.png)

When trying to replicate the gamma and coef0 values used in this example, I found that coef0 was restricted to be 0 or positive, but that isn't a necessary or sensible restriction given my understanding of the maths. Python's sci-kit learn doesn't enforce it.

I removed this restriction also.

This is my first time contributing to OpenCV and I'd appreciate feedback -- I wasn't sure if I was taking the right approach with the test, and tried to follow from what already existed.


```
buildworker:Win64 OpenCL=windows-2
```