### PR TITLE
ocl: support empty "ptr only" UMat in Kernel::set()

### DIFF
--- a/modules/core/src/ocl.cpp
+++ b/modules/core/src/ocl.cpp
@@ -2998,7 +2998,11 @@ int Kernel::set(int i, const KernelArg& arg)
     if( !p || !p->handle )
         return -1;
     if (i < 0)
+    {
+        CV_LOG_ERROR(NULL, cv::format("OpenCL: Kernel(%s)::set(arg_index=%d): negative arg_index",
+                p->name.c_str(), (int)i));
         return i;
+    }
     if( i == 0 )
         p->cleanupUMats();
     cl_int status = 0;
@@ -3007,10 +3011,19 @@ int Kernel::set(int i, const KernelArg& arg)
         int accessFlags = ((arg.flags & KernelArg::READ_ONLY) ? ACCESS_READ : 0) +
                           ((arg.flags & KernelArg::WRITE_ONLY) ? ACCESS_WRITE : 0);
         bool ptronly = (arg.flags & KernelArg::PTR_ONLY) != 0;
+        if (ptronly && arg.m->empty())
+        {
+            cl_mem h_null = (cl_mem)NULL;
+            status = clSetKernelArg(p->handle, (cl_uint)i, sizeof(h_null), &h_null);
+            CV_OCL_DBG_CHECK_RESULT(status, cv::format("clSetKernelArg('%s', arg_index=%d, cl_mem=NULL)", p->name.c_str(), (int)i).c_str());
+            return i + 1;
+        }
         cl_mem h = (cl_mem)arg.m->handle(accessFlags);
 
         if (!h)
         {
+            CV_LOG_ERROR(NULL, cv::format("OpenCL: Kernel(%s)::set(arg_index=%d, flags=%d): can't create cl_mem handle for passed UMat buffer (addr=%p)",
+                    p->name.c_str(), (int)i, (int)arg.flags, arg.m));
             p->release();
             p = 0;
             return -1;


### PR DESCRIPTION
add messages to avoid silent kernel destruction

Related: "mvn_fuse4" kernel in dnn test "Test_Torch_nets.FastNeuralStyle_accuracy/0"

<cut/>

<details>

Trace output without patch (`CV_OPENCL_TRACE_CHECK=1` `CV_OPENCL_SHOW_RUN_KERNELS=1`):

```
OpenCV(OpenCL:0): clBuildProgram(binary: dnn/mvn)
OpenCV(OpenCL:0): result = clGetProgramBuildInfo(handle, devices[0], CL_PROGRAM_BUILD_STATUS, sizeof(build_status), &build_status, &retsz)
OpenCV(OpenCL:0): clCreateKernel('mean_fuse4')
OpenCV(OpenCL:0): clSetKernelArg('mean_fuse4', arg_index=0, cl_mem=0000013AAFBD4BB0)
OpenCV(OpenCL:0): clSetKernelArg('mean_fuse4', arg_index=1, size=4, value=0000001D90F6D094)
OpenCV(OpenCL:0): clSetKernelArg('mean_fuse4', arg_index=2, size=4, value=0000001D90F6D048)
OpenCV(OpenCL:0): clSetKernelArg('mean_fuse4', arg_index=3, cl_mem=0000013AB0819A40)
OpenCV(OpenCL:0): clSetKernelArg('mean_fuse4', arg_index=4, cl_mem=0000013AB08189C0)
OpenCV(OpenCL:0): clSetKernelArg('mean_fuse4', arg_index=5, size=2048, value=0000000000000000)
OpenCV(OpenCL:0): clEnqueueNDRangeKernel('mean_fuse4', dims=1, globalsize=512x1x1, localsize=128x1x1) sync=false
OpenCV(OpenCL:0): clSetEventCallback(asyncEvent, CL_COMPLETE, oclCleanupCallback, this)
OpenCV(OpenCL:0): clReleaseEvent(asyncEvent)
OpenCV(OpenCL:0): clBuildProgram(binary: dnn/mvn)
OpenCV(OpenCL:0): result = clGetProgramBuildInfo(handle, devices[0], CL_PROGRAM_BUILD_STATUS, sizeof(build_status), &build_status, &retsz)
OpenCV(OpenCL:0): clCreateKernel('mvn_fuse4')
OpenCV(OpenCL:0): clSetKernelArg('mvn_fuse4', arg_index=0, cl_mem=0000013AB08189C0)
OpenCV(OpenCL:0): clSetKernelArg('mvn_fuse4', arg_index=1, cl_mem=0000013AAFBD4BB0)
OpenCV(OpenCL:0): clSetKernelArg('mvn_fuse4', arg_index=2, cl_mem=0000013AB0819A40)
OpenCV(OpenCL:0): clSetKernelArg('mvn_fuse4', arg_index=3, size=4, value=0000001D90F6D098)
OpenCV(OpenCL:0): clSetKernelArg('mvn_fuse4', arg_index=4, size=4, value=0000001D90F6D09C)
OpenCV(OpenCL:0): clSetKernelArg('mvn_fuse4', arg_index=5, size=4, value=0000001D90F6D0A0)
OpenCV(OpenCL:0): clSetKernelArg('mvn_fuse4', arg_index=6, size=4, value=0000001D90F6D0A4)
OpenCV(OpenCL:0): clReleaseKernel(handle)
```

Kernel has been unexpectedly released (without any calls of this kernel via `clEnqueueNDRangeKernel()`).

</details>

```
buildworker:Win64 OpenCL=windows-2
#build_contrib=OFF
#build_examples=OFF
#test_module=dnn
#tests_filter=Test_Torch_nets.FastNeuralStyle_accuracy/0
```