### PR TITLE
WIP: GAPI: Add Sobel kernel which returns both dx and dy

### DIFF
--- a/modules/gapi/include/opencv2/gapi/imgproc.hpp
+++ b/modules/gapi/include/opencv2/gapi/imgproc.hpp
@@ -84,8 +84,8 @@ namespace imgproc {
         }
     };
 
-    G_TYPED_KERNEL_M(GSobelXY, <GMat2(GMat,int,int,int,int,double,double,int,Scalar)>, "org.opencv.imgproc.filters.sobelxy") {
-        static std::tuple<GMatDesc, GMatDesc> outMeta(GMatDesc in, int ddepth, int, int, int, double, double, int, Scalar) {
+    G_TYPED_KERNEL_M(GSobelXY, <GMat2(GMat,int,int,int,double,double,int,Scalar)>, "org.opencv.imgproc.filters.sobelxy") {
+        static std::tuple<GMatDesc, GMatDesc> outMeta(GMatDesc in, int ddepth, int, int, double, double, int, Scalar) {
             return std::make_tuple(in.withDepth(ddepth), in.withDepth(ddepth));
         }
     };
@@ -532,8 +532,7 @@ The second case corresponds to a kernel of:
 @param src input image.
 @param ddepth output image depth, see @ref filter_depths "combinations"; in the case of
     8-bit input images it will result in truncated derivatives.
-@param dx order of the derivative x.
-@param dy order of the derivative y.
+@param order order of the derivatives.
 @param ksize size of the extended Sobel kernel; it must be odd.
 @param scale optional scale factor for the computed derivative values; by default, no scaling is
 applied (see cv::getDerivKernels for details).
@@ -542,7 +541,7 @@ applied (see cv::getDerivKernels for details).
 @param borderValue border value in case of constant border type
 @sa filter2D, gaussianBlur, cartToPolar
  */
-GAPI_EXPORTS std::tuple<GMat, GMat> SobelXY(const GMat& src, int ddepth, int dx, int dy, int ksize = 3,
+GAPI_EXPORTS std::tuple<GMat, GMat> SobelXY(const GMat& src, int ddepth, int order, int ksize = 3,
                         double scale = 1, double delta = 0,
                         int borderType = BORDER_DEFAULT,
                         const Scalar& borderValue = Scalar(0));

--- a/modules/gapi/include/opencv2/gapi/imgproc.hpp
+++ b/modules/gapi/include/opencv2/gapi/imgproc.hpp
@@ -27,6 +27,7 @@
 namespace cv { namespace gapi {
 
 namespace imgproc {
+    using GMat2 = std::tuple<GMat,GMat>;
     using GMat3 = std::tuple<GMat,GMat,GMat>; // FIXME: how to avoid this?
 
     G_TYPED_KERNEL(GFilter2D, <GMat(GMat,int,Mat,Point,Scalar,int,Scalar)>,"org.opencv.imgproc.filters.filter2D") {
@@ -80,6 +81,12 @@ namespace imgproc {
     G_TYPED_KERNEL(GSobel, <GMat(GMat,int,int,int,int,double,double,int,Scalar)>, "org.opencv.imgproc.filters.sobel") {
         static GMatDesc outMeta(GMatDesc in, int ddepth, int, int, int, double, double, int, Scalar) {
             return in.withDepth(ddepth);
+        }
+    };
+
+    G_TYPED_KERNEL_M(GSobelXY, <GMat2(GMat,int,int,int,int,double,double,int,Scalar)>, "org.opencv.imgproc.filters.sobelxy") {
+        static std::tuple<GMatDesc, GMatDesc> outMeta(GMatDesc in, int ddepth, int, int, int, double, double, int, Scalar) {
+            return std::make_tuple(in.withDepth(ddepth), in.withDepth(ddepth));
         }
     };
 
@@ -483,6 +490,59 @@ applied (see cv::getDerivKernels for details).
 @sa filter2D, gaussianBlur, cartToPolar
  */
 GAPI_EXPORTS GMat Sobel(const GMat& src, int ddepth, int dx, int dy, int ksize = 3,
+                        double scale = 1, double delta = 0,
+                        int borderType = BORDER_DEFAULT,
+                        const Scalar& borderValue = Scalar(0));
+
+/** @brief Calculates the first, second, third, or mixed image derivatives using an extended Sobel operator.
+
+In all cases except one, the \f$\texttt{ksize} \times \texttt{ksize}\f$ separable kernel is used to
+calculate the derivative. When \f$\texttt{ksize = 1}\f$, the \f$3 \times 1\f$ or \f$1 \times 3\f$
+kernel is used (that is, no Gaussian smoothing is done). `ksize = 1` can only be used for the first
+or the second x- or y- derivatives.
+
+There is also the special value `ksize = FILTER_SCHARR (-1)` that corresponds to the \f$3\times3\f$ Scharr
+filter that may give more accurate results than the \f$3\times3\f$ Sobel. The Scharr aperture is
+
+\f[\vecthreethree{-3}{0}{3}{-10}{0}{10}{-3}{0}{3}\f]
+
+for the x-derivative, or transposed for the y-derivative.
+
+The function calculates an image derivative by convolving the image with the appropriate kernel:
+
+\f[\texttt{dst} =  \frac{\partial^{xorder+yorder} \texttt{src}}{\partial x^{xorder} \partial y^{yorder}}\f]
+
+The Sobel operators combine Gaussian smoothing and differentiation, so the result is more or less
+resistant to the noise. Most often, the function is called with ( xorder = 1, yorder = 0, ksize = 3)
+or ( xorder = 0, yorder = 1, ksize = 3) to calculate the first x- or y- image derivative. The first
+case corresponds to a kernel of:
+
+\f[\vecthreethree{-1}{0}{1}{-2}{0}{2}{-1}{0}{1}\f]
+
+The second case corresponds to a kernel of:
+
+\f[\vecthreethree{-1}{-2}{-1}{0}{0}{0}{1}{2}{1}\f]
+
+@note First returned matrix correspons to dx derivative while the second one to dy.
+
+@note Rounding to nearest even is procedeed if hardware supports it, if not - to nearest.
+
+@note Function textual ID is "org.opencv.imgproc.filters.sobelxy"
+
+@param src input image.
+@param ddepth output image depth, see @ref filter_depths "combinations"; in the case of
+    8-bit input images it will result in truncated derivatives.
+@param dx order of the derivative x.
+@param dy order of the derivative y.
+@param ksize size of the extended Sobel kernel; it must be odd.
+@param scale optional scale factor for the computed derivative values; by default, no scaling is
+applied (see cv::getDerivKernels for details).
+@param delta optional delta value that is added to the results prior to storing them in dst.
+@param borderType pixel extrapolation method, see cv::BorderTypes
+@param borderValue border value in case of constant border type
+@sa filter2D, gaussianBlur, cartToPolar
+ */
+GAPI_EXPORTS std::tuple<GMat, GMat> SobelXY(const GMat& src, int ddepth, int dx, int dy, int ksize = 3,
                         double scale = 1, double delta = 0,
                         int borderType = BORDER_DEFAULT,
                         const Scalar& borderValue = Scalar(0));

--- a/modules/gapi/perf/common/gapi_imgproc_perf_tests.hpp
+++ b/modules/gapi/perf/common/gapi_imgproc_perf_tests.hpp
@@ -31,6 +31,7 @@ class Erode3x3PerfTest : public TestPerfParams<tuple<compare_f, MatType, cv::Siz
 class DilatePerfTest : public TestPerfParams<tuple<compare_f, MatType,int,cv::Size,int, cv::GCompileArgs>> {};
 class Dilate3x3PerfTest : public TestPerfParams<tuple<compare_f, MatType,cv::Size,int, cv::GCompileArgs>> {};
 class SobelPerfTest : public TestPerfParams<tuple<compare_f, MatType,int,cv::Size,int,int,int, cv::GCompileArgs>> {};
+class SobelXYPerfTest : public TestPerfParams<tuple<compare_f, MatType,int,cv::Size,int,int, cv::GCompileArgs>> {};
 class CannyPerfTest : public TestPerfParams<tuple<compare_f, MatType,cv::Size,double,double,int,bool, cv::GCompileArgs>> {};
 class EqHistPerfTest : public TestPerfParams<tuple<compare_f, cv::Size, cv::GCompileArgs >> {};
 class RGB2GrayPerfTest : public TestPerfParams<tuple<compare_f, cv::Size, cv::GCompileArgs >> {};

--- a/modules/gapi/perf/common/gapi_imgproc_perf_tests_inl.hpp
+++ b/modules/gapi/perf/common/gapi_imgproc_perf_tests_inl.hpp
@@ -498,6 +498,52 @@ PERF_TEST_P_(SobelPerfTest, TestPerformance)
 
 //------------------------------------------------------------------------------
 
+PERF_TEST_P_(SobelXYPerfTest, TestPerformance)
+{
+    compare_f cmpF;
+    MatType type = 0;
+    int kernSize = 0, dtype = 0, order = 0;
+    cv::Size sz;
+    cv::GCompileArgs compile_args;
+    std::tie(cmpF, type, kernSize, sz, dtype, order, compile_args) = GetParam();
+
+    cv::Mat out_mat_ocv2 = cv::Mat(sz, dtype);
+    cv::Mat out_mat_gapi2 = cv::Mat(sz, dtype);
+
+    initMatsRandN(type, sz, dtype, false);
+
+    // OpenCV code /////////////////////////////////////////////////////////////
+    {
+        cv::Sobel(in_mat1, out_mat_ocv, dtype, order, 0, kernSize);
+        cv::Sobel(in_mat1, out_mat_ocv2, dtype, 0, order, kernSize);
+    }
+
+    // G-API code //////////////////////////////////////////////////////////////
+    cv::GMat in;
+    auto out = cv::gapi::SobelXY(in, dtype, order, kernSize);
+    cv::GComputation c(cv::GIn(in), cv::GOut(std::get<0>(out), std::get<1>(out)));
+
+    // Warm-up graph engine:
+    c.apply(cv::gin(in_mat1), cv::gout(out_mat_gapi, out_mat_gapi2), std::move(compile_args));
+
+    TEST_CYCLE()
+    {
+        c.apply(cv::gin(in_mat1), cv::gout(out_mat_gapi, out_mat_gapi2));
+    }
+
+    // Comparison //////////////////////////////////////////////////////////////
+    {
+        EXPECT_TRUE(cmpF(out_mat_gapi, out_mat_ocv));
+        EXPECT_TRUE(cmpF(out_mat_gapi2, out_mat_ocv2));
+        EXPECT_EQ(out_mat_gapi.size(), sz);
+        EXPECT_EQ(out_mat_gapi2.size(), sz);
+    }
+
+    SANITY_CHECK_NOTHING();
+}
+
+//------------------------------------------------------------------------------
+
 PERF_TEST_P_(CannyPerfTest, TestPerformance)
 {
     compare_f cmpF;

--- a/modules/gapi/perf/cpu/gapi_imgproc_perf_tests_fluid.cpp
+++ b/modules/gapi/perf/cpu/gapi_imgproc_perf_tests_fluid.cpp
@@ -125,6 +125,24 @@ INSTANTIATE_TEST_CASE_P(SobelPerfTestFluid32F, SobelPerfTest,
             Values(1, 2),
             Values(cv::compile_args(IMGPROC_FLUID))));
 
+INSTANTIATE_TEST_CASE_P(SobelXYPerfTestFluid, SobelXYPerfTest,
+    Combine(Values(AbsExact().to_compare_f()),
+            Values(CV_8UC1, CV_8UC3, CV_16UC1, CV_16SC1),
+            Values(3),                                     // add 5x5 once supported
+            Values(szVGA, sz720p, sz1080p),
+            Values(-1, CV_16S, CV_32F),
+            Values(1, 2),
+            Values(cv::compile_args(IMGPROC_FLUID))));
+
+INSTANTIATE_TEST_CASE_P(SobelXYPerfTestFluid32F, SobelXYPerfTest,
+    Combine(Values(ToleranceFilter(1e-3f, 0.0).to_compare_f()),
+            Values(CV_32FC1),
+            Values(3),                                     // add 5x5 once supported
+            Values(szVGA, sz720p, sz1080p),
+            Values(CV_32F),
+            Values(1, 2),
+            Values(cv::compile_args(IMGPROC_FLUID))));
+
 INSTANTIATE_TEST_CASE_P(RGB2GrayPerfTestFluid, RGB2GrayPerfTest,
     Combine(Values(ToleranceColor(1e-3).to_compare_f()),
             Values(szVGA, sz720p, sz1080p),

--- a/modules/gapi/perf/cpu/gapi_imgproc_perf_tests_fluid.cpp
+++ b/modules/gapi/perf/cpu/gapi_imgproc_perf_tests_fluid.cpp
@@ -32,7 +32,7 @@ INSTANTIATE_TEST_CASE_P(SepFilterPerfTestFluid_other, SepFilterPerfTest,
 INSTANTIATE_TEST_CASE_P(Filter2DPerfTestFluid, Filter2DPerfTest,
     Combine(Values(ToleranceFilter(1e-4f, 0.01).to_compare_f()),
             Values(CV_8UC1, CV_8UC3, CV_16UC1, CV_16SC1, CV_32FC1),
-            Values(3),                                     // add 4, 5, 7 when kernel is ready
+            Values(3),                                     // TODO: add 4, 5, 7 when kernel is ready
             Values(szVGA, sz720p, sz1080p),
             Values(cv::BORDER_DEFAULT),
             Values(-1, CV_32F),
@@ -41,7 +41,7 @@ INSTANTIATE_TEST_CASE_P(Filter2DPerfTestFluid, Filter2DPerfTest,
 INSTANTIATE_TEST_CASE_P(BoxFilterPerfTestFluid, BoxFilterPerfTest,
     Combine(Values(ToleranceFilter(1e-4f, 0.01).to_compare_f()),
             Values(CV_8UC1, CV_8UC3, CV_16UC1, CV_16SC1, CV_32FC1),
-            Values(3),                                     // add size=5, when kernel is ready
+            Values(3),                                     // TODO: add size=5, when kernel is ready
             Values(szVGA, sz720p, sz1080p),
             Values(cv::BORDER_DEFAULT),
             Values(-1, CV_32F),
@@ -50,7 +50,7 @@ INSTANTIATE_TEST_CASE_P(BoxFilterPerfTestFluid, BoxFilterPerfTest,
 INSTANTIATE_TEST_CASE_P(BlurPerfTestFluid, BlurPerfTest,
     Combine(Values(ToleranceFilter(1e-4f, 0.01).to_compare_f()),
             Values(CV_8UC1, CV_8UC3, CV_16UC1, CV_16SC1, CV_32FC1),
-            Values(3),                                     // add size=5, when kernel is ready
+            Values(3),                                     // TODO: add size=5, when kernel is ready
             Values(szVGA, sz720p, sz1080p),
             Values(cv::BORDER_DEFAULT),
             Values(cv::compile_args(IMGPROC_FLUID))));
@@ -58,21 +58,21 @@ INSTANTIATE_TEST_CASE_P(BlurPerfTestFluid, BlurPerfTest,
 INSTANTIATE_TEST_CASE_P(GaussianBlurPerfTestFluid, GaussianBlurPerfTest,
     Combine(Values(ToleranceFilter(1e-3f, 0.01).to_compare_f()),
             Values(CV_8UC1, CV_8UC3, CV_16UC1, CV_16SC1, CV_32FC1),
-            Values(3),                                     // add size=5, when kernel is ready
+            Values(3),                                     // TODO: add size=5, when kernel is ready
             Values(szVGA, sz720p, sz1080p),
             Values(cv::compile_args(IMGPROC_FLUID))));
 
 INSTANTIATE_TEST_CASE_P(MedianBlurPerfTestFluid, MedianBlurPerfTest,
     Combine(Values(AbsExact().to_compare_f()),
             Values(CV_8UC1, CV_8UC3, CV_16UC1, CV_16SC1, CV_32FC1),
-            Values(3),                                     // add size=5, when kernel is ready
+            Values(3),                                     // TODO: add size=5, when kernel is ready
             Values(szVGA, sz720p, sz1080p),
             Values(cv::compile_args(IMGPROC_FLUID))));
 
 INSTANTIATE_TEST_CASE_P(ErodePerfTestFluid, ErodePerfTest,
     Combine(Values(AbsExact().to_compare_f()),
             Values(CV_8UC1, CV_8UC3, CV_16UC1, CV_16SC1, CV_32FC1),
-            Values(3),                                     // add size=5, when kernel is ready
+            Values(3),                                     // TODO: add size=5, when kernel is ready
             Values(szVGA, sz720p, sz1080p),
             Values(cv::MorphShapes::MORPH_RECT,
                    cv::MorphShapes::MORPH_CROSS,
@@ -90,7 +90,7 @@ INSTANTIATE_TEST_CASE_P(DISABLED_Erode3x3PerfTestFluid, Erode3x3PerfTest,
 INSTANTIATE_TEST_CASE_P(DilatePerfTestFluid, DilatePerfTest,
     Combine(Values(AbsExact().to_compare_f()),
             Values(CV_8UC1, CV_8UC3, CV_16UC1, CV_16SC1, CV_32FC1),
-            Values(3),                                     // add size=5, when kernel is ready
+            Values(3),                                     // TODO: add size=5, when kernel is ready
             Values(szVGA, sz720p, sz1080p),
             Values(cv::MorphShapes::MORPH_RECT,
                    cv::MorphShapes::MORPH_CROSS,
@@ -108,7 +108,7 @@ INSTANTIATE_TEST_CASE_P(DISABLED_Dilate3x3PerfTestFluid, Dilate3x3PerfTest,
 INSTANTIATE_TEST_CASE_P(SobelPerfTestFluid, SobelPerfTest,
     Combine(Values(AbsExact().to_compare_f()),
             Values(CV_8UC1, CV_8UC3, CV_16UC1, CV_16SC1),
-            Values(3),                                     // add 5x5 once supported
+            Values(3),                                     // TODO: add 5x5 once supported
             Values(szVGA, sz720p, sz1080p),
             Values(-1, CV_16S, CV_32F),
             Values(0, 1),
@@ -118,7 +118,7 @@ INSTANTIATE_TEST_CASE_P(SobelPerfTestFluid, SobelPerfTest,
 INSTANTIATE_TEST_CASE_P(SobelPerfTestFluid32F, SobelPerfTest,
     Combine(Values(ToleranceFilter(1e-3f, 0.0).to_compare_f()),
             Values(CV_32FC1),
-            Values(3),                                     // add 5x5 once supported
+            Values(3),                                     // TODO: add 5x5 once supported
             Values(szVGA, sz720p, sz1080p),
             Values(CV_32F),
             Values(0, 1),
@@ -128,7 +128,7 @@ INSTANTIATE_TEST_CASE_P(SobelPerfTestFluid32F, SobelPerfTest,
 INSTANTIATE_TEST_CASE_P(SobelXYPerfTestFluid, SobelXYPerfTest,
     Combine(Values(AbsExact().to_compare_f()),
             Values(CV_8UC1, CV_8UC3, CV_16UC1, CV_16SC1),
-            Values(3),                                     // add 5x5 once supported
+            Values(3),                                     // TODO: add 5x5 once supported
             Values(szVGA, sz720p, sz1080p),
             Values(-1, CV_16S, CV_32F),
             Values(1, 2),
@@ -137,7 +137,7 @@ INSTANTIATE_TEST_CASE_P(SobelXYPerfTestFluid, SobelXYPerfTest,
 INSTANTIATE_TEST_CASE_P(SobelXYPerfTestFluid32F, SobelXYPerfTest,
     Combine(Values(ToleranceFilter(1e-3f, 0.0).to_compare_f()),
             Values(CV_32FC1),
-            Values(3),                                     // add 5x5 once supported
+            Values(3),                                     // TODO: add 5x5 once supported
             Values(szVGA, sz720p, sz1080p),
             Values(CV_32F),
             Values(1, 2),

--- a/modules/gapi/src/api/kernels_imgproc.cpp
+++ b/modules/gapi/src/api/kernels_imgproc.cpp
@@ -80,6 +80,13 @@ GMat Sobel(const GMat& src, int ddepth, int dx, int dy, int ksize,
     return imgproc::GSobel::on(src, ddepth, dx, dy, ksize, scale, delta, borderType, bordVal);
 }
 
+std::tuple<GMat, GMat> SobelXY(const GMat& src, int ddepth, int dx, int dy, int ksize,
+           double scale, double delta,
+           int borderType, const Scalar& bordVal)
+{
+    return imgproc::GSobelXY::on(src, ddepth, dx, dy, ksize, scale, delta, borderType, bordVal);
+}
+
 GMat equalizeHist(const GMat& src)
 {
     return imgproc::GEqHist::on(src);

--- a/modules/gapi/src/api/kernels_imgproc.cpp
+++ b/modules/gapi/src/api/kernels_imgproc.cpp
@@ -80,11 +80,11 @@ GMat Sobel(const GMat& src, int ddepth, int dx, int dy, int ksize,
     return imgproc::GSobel::on(src, ddepth, dx, dy, ksize, scale, delta, borderType, bordVal);
 }
 
-std::tuple<GMat, GMat> SobelXY(const GMat& src, int ddepth, int dx, int dy, int ksize,
+std::tuple<GMat, GMat> SobelXY(const GMat& src, int ddepth, int order, int ksize,
            double scale, double delta,
            int borderType, const Scalar& bordVal)
 {
-    return imgproc::GSobelXY::on(src, ddepth, dx, dy, ksize, scale, delta, borderType, bordVal);
+    return imgproc::GSobelXY::on(src, ddepth, order, ksize, scale, delta, borderType, bordVal);
 }
 
 GMat equalizeHist(const GMat& src)

--- a/modules/gapi/test/common/gapi_imgproc_tests.hpp
+++ b/modules/gapi/test/common/gapi_imgproc_tests.hpp
@@ -26,7 +26,7 @@ struct Erode3x3Test : public TestParams <std::tuple<compare_f,MatType,cv::Size,b
 struct DilateTest : public TestParams <std::tuple<compare_f,MatType,int,cv::Size,int,bool,cv::GCompileArgs>> {};
 struct Dilate3x3Test : public TestParams <std::tuple<compare_f,MatType,cv::Size,bool,int,cv::GCompileArgs>> {};
 struct SobelTest : public TestParams <std::tuple<compare_f,MatType,int,cv::Size,int,int,int,bool,cv::GCompileArgs>> {};
-struct SobelXYTest : public TestParams <std::tuple<compare_f,MatType,int,cv::Size,int,int,int,bool,cv::GCompileArgs>> {};
+struct SobelXYTest : public TestParams <std::tuple<compare_f,MatType,int,cv::Size,int,int,int,cv::GCompileArgs>> {};
 struct EqHistTest : public TestParams <std::tuple<compare_f,cv::Size,bool,cv::GCompileArgs>> {};
 struct CannyTest : public TestParams <std::tuple<compare_f,MatType,cv::Size,double,double,int,bool,bool,cv::GCompileArgs>> {};
 struct RGB2GrayTest : public  TestParams<std::tuple<compare_f,cv::Size,bool,cv::GCompileArgs>> {};

--- a/modules/gapi/test/common/gapi_imgproc_tests.hpp
+++ b/modules/gapi/test/common/gapi_imgproc_tests.hpp
@@ -26,6 +26,7 @@ struct Erode3x3Test : public TestParams <std::tuple<compare_f,MatType,cv::Size,b
 struct DilateTest : public TestParams <std::tuple<compare_f,MatType,int,cv::Size,int,bool,cv::GCompileArgs>> {};
 struct Dilate3x3Test : public TestParams <std::tuple<compare_f,MatType,cv::Size,bool,int,cv::GCompileArgs>> {};
 struct SobelTest : public TestParams <std::tuple<compare_f,MatType,int,cv::Size,int,int,int,bool,cv::GCompileArgs>> {};
+struct SobelXYTest : public TestParams <std::tuple<compare_f,MatType,int,cv::Size,int,int,int,bool,cv::GCompileArgs>> {};
 struct EqHistTest : public TestParams <std::tuple<compare_f,cv::Size,bool,cv::GCompileArgs>> {};
 struct CannyTest : public TestParams <std::tuple<compare_f,MatType,cv::Size,double,double,int,bool,bool,cv::GCompileArgs>> {};
 struct RGB2GrayTest : public  TestParams<std::tuple<compare_f,cv::Size,bool,cv::GCompileArgs>> {};

--- a/modules/gapi/test/common/gapi_imgproc_tests.hpp
+++ b/modules/gapi/test/common/gapi_imgproc_tests.hpp
@@ -26,7 +26,7 @@ struct Erode3x3Test : public TestParams <std::tuple<compare_f,MatType,cv::Size,b
 struct DilateTest : public TestParams <std::tuple<compare_f,MatType,int,cv::Size,int,bool,cv::GCompileArgs>> {};
 struct Dilate3x3Test : public TestParams <std::tuple<compare_f,MatType,cv::Size,bool,int,cv::GCompileArgs>> {};
 struct SobelTest : public TestParams <std::tuple<compare_f,MatType,int,cv::Size,int,int,int,bool,cv::GCompileArgs>> {};
-struct SobelXYTest : public TestParams <std::tuple<compare_f,MatType,int,cv::Size,int,int,int,cv::GCompileArgs>> {};
+struct SobelXYTest : public TestParams <std::tuple<compare_f,MatType,int,cv::Size,int,int,int,int,cv::GCompileArgs>> {};
 struct EqHistTest : public TestParams <std::tuple<compare_f,cv::Size,bool,cv::GCompileArgs>> {};
 struct CannyTest : public TestParams <std::tuple<compare_f,MatType,cv::Size,double,double,int,bool,bool,cv::GCompileArgs>> {};
 struct RGB2GrayTest : public  TestParams<std::tuple<compare_f,cv::Size,bool,cv::GCompileArgs>> {};

--- a/modules/gapi/test/common/gapi_imgproc_tests_inl.hpp
+++ b/modules/gapi/test/common/gapi_imgproc_tests_inl.hpp
@@ -357,22 +357,30 @@ TEST_P(SobelXYTest, AccuracyTest)
 {
     compare_f cmpF;
     MatType type = 0;
-    int kernSize = 0, dtype = 0, order = 0, border_type = 0;
+    int kernSize = 0, dtype = 0, order = 0, border_type = 0, border_val = 0;
     cv::Size sz;
     cv::GCompileArgs compile_args;
-    std::tie(cmpF, type, kernSize, sz, dtype, order, border_type, compile_args) = GetParam();
+    std::tie(cmpF, type, kernSize, sz, dtype, order, border_type, border_val, compile_args) = GetParam();
     initMatsRandN(type, sz, dtype);
     cv::Mat out_mat_ocv2 = cv::Mat(sz, dtype);
     cv::Mat out_mat_gapi2 = cv::Mat(sz, dtype);
 
     // G-API code //////////////////////////////////////////////////////////////
     cv::GMat in;
-    auto out = cv::gapi::SobelXY(in, dtype, order, kernSize, 1, 0, border_type);
+    auto out = cv::gapi::SobelXY(in, dtype, order, kernSize, 1, 0, border_type, border_val);
 
     cv::GComputation c(cv::GIn(in), cv::GOut(std::get<0>(out), std::get<1>(out)));
     c.apply(cv::gin(in_mat1), cv::gout(out_mat_gapi, out_mat_gapi2), std::move(compile_args));
     // OpenCV code /////////////////////////////////////////////////////////////
     {
+        // workaround for cv::Sobel
+        cv::Mat temp_in;
+        if(border_type == cv::BORDER_CONSTANT)
+        {
+            int add = (kernSize - 1) / 2;
+            cv::copyMakeBorder(in_mat1, temp_in, add, add, add, add, border_type, border_val);
+            in_mat1 = temp_in(cv::Rect(add, add, in_mat1.cols, in_mat1.rows));
+        }
         cv::Sobel(in_mat1, out_mat_ocv, dtype, order, 0, kernSize, 1, 0, border_type);
         cv::Sobel(in_mat1, out_mat_ocv2, dtype, 0, order, kernSize, 1, 0, border_type);
     }

--- a/modules/gapi/test/common/gapi_imgproc_tests_inl.hpp
+++ b/modules/gapi/test/common/gapi_imgproc_tests_inl.hpp
@@ -357,25 +357,24 @@ TEST_P(SobelXYTest, AccuracyTest)
 {
     compare_f cmpF;
     MatType type = 0;
-    int kernSize = 0, dtype = 0, dx = 0, dy = 0;
+    int kernSize = 0, dtype = 0, order = 0, border_type = 0;
     cv::Size sz;
-    bool initOut = false;
     cv::GCompileArgs compile_args;
-    std::tie(cmpF, type, kernSize, sz, dtype, dx, dy, initOut, compile_args) = GetParam();
-    initMatsRandN(type, sz, dtype, initOut);
+    std::tie(cmpF, type, kernSize, sz, dtype, order, border_type, compile_args) = GetParam();
+    initMatsRandN(type, sz, dtype);
     cv::Mat out_mat_ocv2 = cv::Mat(sz, dtype);
     cv::Mat out_mat_gapi2 = cv::Mat(sz, dtype);
 
     // G-API code //////////////////////////////////////////////////////////////
     cv::GMat in;
-    auto out = cv::gapi::SobelXY(in, dtype, dx, dy, kernSize );
+    auto out = cv::gapi::SobelXY(in, dtype, order, kernSize, 1, 0, border_type);
 
     cv::GComputation c(cv::GIn(in), cv::GOut(std::get<0>(out), std::get<1>(out)));
     c.apply(cv::gin(in_mat1), cv::gout(out_mat_gapi, out_mat_gapi2), std::move(compile_args));
     // OpenCV code /////////////////////////////////////////////////////////////
     {
-        cv::Sobel(in_mat1, out_mat_ocv, dtype, dx, 0, kernSize);
-        cv::Sobel(in_mat1, out_mat_ocv2, dtype, 0, dy, kernSize);
+        cv::Sobel(in_mat1, out_mat_ocv, dtype, order, 0, kernSize, 1, 0, border_type);
+        cv::Sobel(in_mat1, out_mat_ocv2, dtype, 0, order, kernSize, 1, 0, border_type);
     }
     // Comparison //////////////////////////////////////////////////////////////
     {

--- a/modules/gapi/test/common/gapi_imgproc_tests_inl.hpp
+++ b/modules/gapi/test/common/gapi_imgproc_tests_inl.hpp
@@ -353,6 +353,39 @@ TEST_P(SobelTest, AccuracyTest)
     }
 }
 
+TEST_P(SobelXYTest, AccuracyTest)
+{
+    compare_f cmpF;
+    MatType type = 0;
+    int kernSize = 0, dtype = 0, dx = 0, dy = 0;
+    cv::Size sz;
+    bool initOut = false;
+    cv::GCompileArgs compile_args;
+    std::tie(cmpF, type, kernSize, sz, dtype, dx, dy, initOut, compile_args) = GetParam();
+    initMatsRandN(type, sz, dtype, initOut);
+    cv::Mat out_mat_ocv2 = cv::Mat(sz, dtype);
+    cv::Mat out_mat_gapi2 = cv::Mat(sz, dtype);
+
+    // G-API code //////////////////////////////////////////////////////////////
+    cv::GMat in;
+    auto out = cv::gapi::SobelXY(in, dtype, dx, dy, kernSize );
+
+    cv::GComputation c(cv::GIn(in), cv::GOut(std::get<0>(out), std::get<1>(out)));
+    c.apply(cv::gin(in_mat1), cv::gout(out_mat_gapi, out_mat_gapi2), std::move(compile_args));
+    // OpenCV code /////////////////////////////////////////////////////////////
+    {
+        cv::Sobel(in_mat1, out_mat_ocv, dtype, dx, 0, kernSize);
+        cv::Sobel(in_mat1, out_mat_ocv2, dtype, 0, dy, kernSize);
+    }
+    // Comparison //////////////////////////////////////////////////////////////
+    {
+        EXPECT_TRUE(cmpF(out_mat_gapi, out_mat_ocv));
+        EXPECT_TRUE(cmpF(out_mat_gapi2, out_mat_ocv2));
+        EXPECT_EQ(out_mat_gapi.size(), sz);
+        EXPECT_EQ(out_mat_gapi2.size(), sz);
+    }
+}
+
 TEST_P(EqHistTest, AccuracyTest)
 {
     compare_f cmpF;

--- a/modules/gapi/test/common/gapi_imgproc_tests_inl.hpp
+++ b/modules/gapi/test/common/gapi_imgproc_tests_inl.hpp
@@ -377,9 +377,9 @@ TEST_P(SobelXYTest, AccuracyTest)
         cv::Mat temp_in;
         if(border_type == cv::BORDER_CONSTANT)
         {
-            int add = (kernSize - 1) / 2;
-            cv::copyMakeBorder(in_mat1, temp_in, add, add, add, add, border_type, border_val);
-            in_mat1 = temp_in(cv::Rect(add, add, in_mat1.cols, in_mat1.rows));
+            int n_pixels = (kernSize - 1) / 2;
+            cv::copyMakeBorder(in_mat1, temp_in, n_pixels, n_pixels, n_pixels, n_pixels, border_type, border_val);
+            in_mat1 = temp_in(cv::Rect(n_pixels, n_pixels, in_mat1.cols, in_mat1.rows));
         }
         cv::Sobel(in_mat1, out_mat_ocv, dtype, order, 0, kernSize, 1, 0, border_type);
         cv::Sobel(in_mat1, out_mat_ocv2, dtype, 0, order, kernSize, 1, 0, border_type);

--- a/modules/gapi/test/cpu/gapi_imgproc_tests_cpu.cpp
+++ b/modules/gapi/test/cpu/gapi_imgproc_tests_cpu.cpp
@@ -162,6 +162,7 @@ INSTANTIATE_TEST_CASE_P(SobelXYTestCPU, SobelXYTest,
                                 Values(-1, CV_16S, CV_32F),
                                 Values(1, 2),
                                 Values(BORDER_CONSTANT, BORDER_REPLICATE, BORDER_REFLECT),
+                                Values(0, 1, 255),
                                 Values(cv::compile_args(IMGPROC_CPU))));
 
 INSTANTIATE_TEST_CASE_P(SobelXYTestCPU32F, SobelXYTest,
@@ -173,6 +174,7 @@ INSTANTIATE_TEST_CASE_P(SobelXYTestCPU32F, SobelXYTest,
                                 Values(CV_32F),
                                 Values(1, 2),
                                 Values(BORDER_CONSTANT, BORDER_REPLICATE, BORDER_REFLECT),
+                                Values(0, 1, 255),
                                 Values(cv::compile_args(IMGPROC_CPU))));
 
 INSTANTIATE_TEST_CASE_P(EqHistTestCPU, EqHistTest,

--- a/modules/gapi/test/cpu/gapi_imgproc_tests_cpu.cpp
+++ b/modules/gapi/test/cpu/gapi_imgproc_tests_cpu.cpp
@@ -153,6 +153,30 @@ INSTANTIATE_TEST_CASE_P(SobelTestCPU32F, SobelTest,
 /*init output matrices or not*/ testing::Bool(),
                                 Values(cv::compile_args(IMGPROC_CPU))));
 
+INSTANTIATE_TEST_CASE_P(SobelXYTestCPU, SobelXYTest,
+                        Combine(Values(AbsExact().to_compare_f()),
+                                Values(CV_8UC1, CV_8UC3, CV_16UC1, CV_16SC1),
+                                Values(3, 5),
+                                Values(cv::Size(1280, 720),
+                                       cv::Size(640, 480)),
+                                Values(-1, CV_16S, CV_32F),
+                                Values(1, 2),
+                                Values(1, 2),
+/*init output matrices or not*/ testing::Bool(),
+                                Values(cv::compile_args(IMGPROC_CPU))));
+
+INSTANTIATE_TEST_CASE_P(SobelXYTestCPU32F, SobelXYTest,
+                        Combine(Values(AbsExact().to_compare_f()),
+                                Values(CV_32FC1),
+                                Values(3, 5),
+                                Values(cv::Size(1280, 720),
+                                       cv::Size(640, 480)),
+                                Values(CV_32F),
+                                Values(1, 2),
+                                Values(1, 2),
+/*init output matrices or not*/ testing::Bool(),
+                                Values(cv::compile_args(IMGPROC_CPU))));
+
 INSTANTIATE_TEST_CASE_P(EqHistTestCPU, EqHistTest,
                         Combine(Values(AbsExact().to_compare_f()),
                                 Values(cv::Size(1280, 720),

--- a/modules/gapi/test/cpu/gapi_imgproc_tests_cpu.cpp
+++ b/modules/gapi/test/cpu/gapi_imgproc_tests_cpu.cpp
@@ -161,8 +161,7 @@ INSTANTIATE_TEST_CASE_P(SobelXYTestCPU, SobelXYTest,
                                        cv::Size(640, 480)),
                                 Values(-1, CV_16S, CV_32F),
                                 Values(1, 2),
-                                Values(1, 2),
-/*init output matrices or not*/ testing::Bool(),
+                                Values(BORDER_CONSTANT, BORDER_REPLICATE, BORDER_REFLECT),
                                 Values(cv::compile_args(IMGPROC_CPU))));
 
 INSTANTIATE_TEST_CASE_P(SobelXYTestCPU32F, SobelXYTest,
@@ -173,8 +172,7 @@ INSTANTIATE_TEST_CASE_P(SobelXYTestCPU32F, SobelXYTest,
                                        cv::Size(640, 480)),
                                 Values(CV_32F),
                                 Values(1, 2),
-                                Values(1, 2),
-/*init output matrices or not*/ testing::Bool(),
+                                Values(BORDER_CONSTANT, BORDER_REPLICATE, BORDER_REFLECT),
                                 Values(cv::compile_args(IMGPROC_CPU))));
 
 INSTANTIATE_TEST_CASE_P(EqHistTestCPU, EqHistTest,

--- a/modules/gapi/test/cpu/gapi_imgproc_tests_fluid.cpp
+++ b/modules/gapi/test/cpu/gapi_imgproc_tests_fluid.cpp
@@ -132,6 +132,30 @@ INSTANTIATE_TEST_CASE_P(SobelTestFluid32F, SobelTest,
                                 Values(true, false),
                                 Values(cv::compile_args(IMGPROC_FLUID))));
 
+INSTANTIATE_TEST_CASE_P(SobelXYTestFluid, SobelXYTest,
+                        Combine(Values(AbsExact().to_compare_f()),
+                                Values(CV_8UC1, CV_8UC3, CV_16UC1, CV_16SC1),
+                                Values(3),
+                                Values(cv::Size(1280, 720),
+                                       cv::Size(640, 480)),
+                                Values(-1, CV_16S, CV_32F),
+                                Values(1, 2),
+                                Values(BORDER_CONSTANT, BORDER_REPLICATE, BORDER_REFLECT_101),
+                                Values(0, 1, 255),
+                                Values(cv::compile_args(IMGPROC_FLUID))));
+
+INSTANTIATE_TEST_CASE_P(SobelXYTestFluid32F, SobelXYTest,
+                        Combine(Values(ToleranceFilter(1e-4f, 0.01).to_compare_f()),
+                                Values(CV_32FC1),
+                                Values(3),
+                                Values(cv::Size(1280, 720),
+                                       cv::Size(640, 480)),
+                                Values(CV_32F),
+                                Values(1, 2),
+                                Values(BORDER_CONSTANT, BORDER_REPLICATE, BORDER_REFLECT_101),
+                                Values(0, 1, 255),
+                                Values(cv::compile_args(IMGPROC_FLUID))));
+
 INSTANTIATE_TEST_CASE_P(boxFilterTestFluid32, BoxFilterTest,
                         Combine(Values(ToleranceFilter(1e-4f, 0.01).to_compare_f()),
                                 Values(CV_8UC1, CV_16UC1, CV_16SC1),


### PR DESCRIPTION
This pullrequest adds overloading of Sobel kernel which returns both x- and y- derivatives.

```
buildworker:Win64 OpenCL=windows-2
```