### PR TITLE
Align TensorFlow and OpenCV paths to create a text graph

### DIFF
--- a/samples/dnn/tf_text_graph_common.py
+++ b/samples/dnn/tf_text_graph_common.py
@@ -323,7 +323,7 @@ def writeTextGraph(modelPath, outputPath, outNodes):
 
             for node in graph_def.node:
                 if node.op == 'Const':
-                    if 'value' in node.attr:
-                        del node.attr['value']
+                    if 'value' in node.attr and node.attr['value'].tensor.tensor_content:
+                        node.attr['value'].tensor.tensor_content = ''
 
         tf.train.write_graph(graph_def, "", outputPath, as_text=True)


### PR DESCRIPTION
<!-- Please use this line to close one or multiple issues when this pullrequest gets merged
You can add another line right under the first one:
resolves #1234
resolves #1235
-->

### This pullrequest changes

resolves https://github.com/opencv/opencv/issues/13725

This fix aligns TensorFlow's and OpenCV's paths for text graphs creation:

https://github.com/opencv/opencv/blob/631b246881f04021dfcdb2f6be03c6c108f82163/modules/dnn/src/tensorflow/tf_importer.cpp#L1963-L1969
