### PR TITLE
fixed incorrect formulas in the algorithm camshift

### DIFF
--- a/modules/video/src/camshift.cpp
+++ b/modules/video/src/camshift.cpp
@@ -167,6 +167,8 @@ cv::RotatedRect cv::CamShift( InputArray _probImage, Rect& window,
 
     double rotate_a = cs * cs * mu20 + 2 * cs * sn * mu11 + sn * sn * mu02;
     double rotate_c = sn * sn * mu20 - 2 * cs * sn * mu11 + cs * cs * mu02;
+    rotate_a = std::max(0.0, rotate_a);  // avoid negative result due calculation numeric errors
+    rotate_c = std::max(0.0, rotate_c);  // avoid negative result due calculation numeric errors
     double length = std::sqrt( rotate_a * inv_m00 ) * 4;
     double width = std::sqrt( rotate_c * inv_m00 ) * 4;
 


### PR DESCRIPTION
Issue #9152
In the example of the post #9152 the calculated value of the variable "rotate_c" are negative. It can not be, because the formula by which it was calculated is the sum of squares. 
<img width="342" alt="screenshot_1" src="https://user-images.githubusercontent.com/22386452/52420876-f497dc00-2b03-11e9-992c-b27e5c5e1c6b.png">

In the counterexample, the variable is negative and very close to zero (due to inaccurate calculations), i think,  reasonable to add to avoid such cases theshold.

