### PR TITLE
dnn(ocl): use compile-time LOCAL_SIZE parameter

### DIFF
--- a/modules/dnn/src/opencl/mvn.cl
+++ b/modules/dnn/src/opencl/mvn.cl
@@ -74,6 +74,8 @@
     #define MVN_FUSE mvn_fuse1
 #endif
 
+#ifdef KERNEL_MEAN
+
 __kernel void CALC_MEAN(__global const Dtype* src,
                         const int rows,
                         const int cols,
@@ -93,6 +95,8 @@ __kernel void CALC_MEAN(__global const Dtype* src,
     dst_vec = dst_vec * dst_vec;
     store(dst_vec, dst, index);
 }
+
+#elif defined KERNEL_MVN
 
 __kernel void MVN(__global const Dtype* src,
                   const int rows,
@@ -140,12 +144,13 @@ __kernel void MVN(__global const Dtype* src,
     store(dst_vec, dst, index);
 }
 
+#elif defined KERNEL_MEAN_FUSE
+
 __kernel void MEAN_FUSE(__global const T * A,
                         unsigned int A_col_size,
                         float alpha,
                         __global T4 * mean,
-                        __global Dtype * tmp,
-                        __local Dtype4 * work)
+                        __global Dtype * tmp)
 {
     unsigned int row_gid = get_group_id(0);
     unsigned int lid = get_local_id(0);
@@ -168,15 +173,16 @@ __kernel void MEAN_FUSE(__global const T * A,
         dot2 += convert_float4(a2);
         dot3 += convert_float4(a3);
 
-        i += get_local_size(0);
+        i += LOCAL_SIZE;
     }
 
+    __local Dtype4 work[LOCAL_SIZE];
     work[lid].s0 = dot(dot0, b0);
     work[lid].s1 = dot(dot1, b0);
     work[lid].s2 = dot(dot2, b0);
     work[lid].s3 = dot(dot3, b0);
 
-    for(unsigned int stride=get_local_size(0)/2 ; stride>0 ; stride>>=1)
+    for(unsigned int stride=LOCAL_SIZE/2 ; stride>0 ; stride>>=1)
     {
         barrier(CLK_LOCAL_MEM_FENCE);
         if(lid < stride)
@@ -212,9 +218,11 @@ __kernel void MEAN_FUSE(__global const T * A,
         vstore4(dot2, i, dst0_read + 2 * A_col_size);
         vstore4(dot3, i, dst0_read + 3 * A_col_size);
 
-        i += get_local_size(0);
+        i += LOCAL_SIZE;
     }
 }
+
+#elif defined KERNEL_MVN_FUSE
 
 __kernel void MVN_FUSE(__global const Dtype * tmp,
                        __global const T * A,
@@ -225,8 +233,7 @@ __kernel void MVN_FUSE(__global const Dtype * tmp,
                        const float relu_slope,
                        __global const Dtype4 * bnorm_weight,
                        __global const Dtype4 * bnorm_bias,
-                       __global T * B,
-                       __local Dtype4 * work)
+                       __global T * B)
 {
     unsigned int row_gid = get_group_id(0);
     unsigned int lid = get_local_id(0);
@@ -250,15 +257,16 @@ __kernel void MVN_FUSE(__global const Dtype * tmp,
         dot2 += a2;
         dot3 += a3;
 
-        i += get_local_size(0);
+        i += LOCAL_SIZE;
     }
 
+    __local Dtype4 work[LOCAL_SIZE];
     work[lid].s0 = dot(dot0, b0);
     work[lid].s1 = dot(dot1, b0);
     work[lid].s2 = dot(dot2, b0);
     work[lid].s3 = dot(dot3, b0);
 
-    for(unsigned int stride=get_local_size(0)/2 ; stride>0 ; stride>>=1)
+    for(unsigned int stride=LOCAL_SIZE/2 ; stride>0 ; stride>>=1)
     {
         barrier(CLK_LOCAL_MEM_FENCE);
         if(lid < stride)
@@ -314,6 +322,10 @@ __kernel void MVN_FUSE(__global const Dtype * tmp,
         vstore4(convert_T(dot2), i, dst0_read + 2 * A_col_size);
         vstore4(convert_T(dot3), i, dst0_read + 3 * A_col_size);
 
-        i += get_local_size(0);
+        i += LOCAL_SIZE;
     }
 }
+
+#else
+#error "Configuration error!"
+#endif


### PR DESCRIPTION
instead of `get_local_size(0)` and dynamic local memory allocation

```
buildworker:Win64 OpenCL=windows-2
```