### PR TITLE
Enable SOLVEPNP_DLS and fix InputOutputArray for rvec and tvec

### DIFF
--- a/modules/calib3d/include/opencv2/calib3d.hpp
+++ b/modules/calib3d/include/opencv2/calib3d.hpp
@@ -745,9 +745,8 @@ a 3D point expressed in the world frame into the camera frame:
         - Thus, given some data D = np.array(...) where D.shape = (N,M), in order to use a subset of
         it as, e.g., imagePoints, one must effectively copy it into a new array: imagePoints =
         np.ascontiguousarray(D[:,:2]).reshape((N,1,2))
-   -   The methods **SOLVEPNP_DLS** and **SOLVEPNP_UPNP** cannot be used as the current implementations are
-       unstable and sometimes give completely wrong results. If you pass one of these two
-       flags, **SOLVEPNP_EPNP** method will be used instead.
+   -   The method **SOLVEPNP_UPNP** cannot be used as the current implementation is
+       unstable and give completely wrong results. If you pass this flag, **SOLVEPNP_EPNP** method will be used instead.
    -   The minimum number of points is 4 in the general case. In the case of **SOLVEPNP_P3P** and **SOLVEPNP_AP3P**
        methods, it is required to use exactly 4 points (the first 3 points are used to estimate all the solutions
        of the P3P problem, the last one is used to retain the best solution that minimizes the reprojection error).
@@ -757,7 +756,7 @@ a 3D point expressed in the world frame into the camera frame:
  */
 CV_EXPORTS_W bool solvePnP( InputArray objectPoints, InputArray imagePoints,
                             InputArray cameraMatrix, InputArray distCoeffs,
-                            OutputArray rvec, OutputArray tvec,
+                            InputOutputArray rvec, InputOutputArray tvec,
                             bool useExtrinsicGuess = false, int flags = SOLVEPNP_ITERATIVE );
 
 /** @brief Finds an object pose from 3D-2D point correspondences using the RANSAC scheme.
@@ -771,10 +770,10 @@ where N is the number of points. vector\<Point2f\> can be also passed here.
 \f$(k_1, k_2, p_1, p_2[, k_3[, k_4, k_5, k_6 [, s_1, s_2, s_3, s_4[, \tau_x, \tau_y]]]])\f$ of
 4, 5, 8, 12 or 14 elements. If the vector is NULL/empty, the zero distortion coefficients are
 assumed.
-@param rvec Output rotation vector (see Rodrigues ) that, together with tvec , brings points from
+@param rvec Output rotation vector (see #Rodrigues ) that, together with tvec , brings points from
 the model coordinate system to the camera coordinate system.
 @param tvec Output translation vector.
-@param useExtrinsicGuess Parameter used for SOLVEPNP_ITERATIVE. If true (1), the function uses
+@param useExtrinsicGuess Parameter used for #SOLVEPNP_ITERATIVE. If true (1), the function uses
 the provided rvec and tvec values as initial approximations of the rotation and translation
 vectors, respectively, and further optimizes them.
 @param iterationsCount Number of iterations.
@@ -783,12 +782,12 @@ is the maximum allowed distance between the observed and computed point projecti
 an inlier.
 @param confidence The probability that the algorithm produces a useful result.
 @param inliers Output vector that contains indices of inliers in objectPoints and imagePoints .
-@param flags Method for solving a PnP problem (see solvePnP ).
+@param flags Method for solving a PnP problem (see #solvePnP ).
 
 The function estimates an object pose given a set of object points, their corresponding image
 projections, as well as the camera matrix and the distortion coefficients. This function finds such
 a pose that minimizes reprojection error, that is, the sum of squared distances between the observed
-projections imagePoints and the projected (using projectPoints ) objectPoints. The use of RANSAC
+projections imagePoints and the projected (using #projectPoints ) objectPoints. The use of RANSAC
 makes the function resistant to outliers.
 
 @note
@@ -804,7 +803,7 @@ makes the function resistant to outliers.
  */
 CV_EXPORTS_W bool solvePnPRansac( InputArray objectPoints, InputArray imagePoints,
                                   InputArray cameraMatrix, InputArray distCoeffs,
-                                  OutputArray rvec, OutputArray tvec,
+                                  InputOutputArray rvec, InputOutputArray tvec,
                                   bool useExtrinsicGuess = false, int iterationsCount = 100,
                                   float reprojectionError = 8.0, double confidence = 0.99,
                                   OutputArray inliers = noArray(), int flags = SOLVEPNP_ITERATIVE );

--- a/modules/calib3d/src/chessboard.cpp
+++ b/modules/calib3d/src/chessboard.cpp
@@ -1250,7 +1250,7 @@ void Chessboard::Board::draw(cv::InputArray m,cv::OutputArray out,cv::InputArray
     image.copyTo(out.getMat());
 }
 
-bool Chessboard::Board::estimatePose(const cv::Size2f &real_size,cv::InputArray _K,cv::OutputArray rvec,cv::OutputArray tvec)const
+bool Chessboard::Board::estimatePose(const cv::Size2f &real_size,cv::InputArray _K,cv::InputOutputArray rvec,cv::InputOutputArray tvec)const
 {
     cv::Mat K = _K.getMat();
     CV_CheckTypeEQ(K.type(), CV_64FC1, "wrong K type");

--- a/modules/calib3d/src/chessboard.hpp
+++ b/modules/calib3d/src/chessboard.hpp
@@ -319,7 +319,7 @@ class Chessboard: public cv::Feature2D
                  * \brief Estimates the pose of the chessboard
                  *
                  */
-                bool estimatePose(const cv::Size2f &real_size,cv::InputArray _K,cv::OutputArray rvec,cv::OutputArray tvec)const;
+                bool estimatePose(const cv::Size2f &real_size,cv::InputArray _K,cv::InputOutputArray rvec,cv::InputOutputArray tvec)const;
 
                 /**
                  * \brief Clears all internal data of the object

--- a/modules/calib3d/src/ptsetreg.cpp
+++ b/modules/calib3d/src/ptsetreg.cpp
@@ -89,8 +89,8 @@ public:
         const float* errptr = err.ptr<float>();
         uchar* maskptr = mask.ptr<uchar>();
         float t = (float)(thresh*thresh);
-        int i, n = (int)err.total(), nz = 0;
-        for( i = 0; i < n; i++ )
+        int n = (int)err.total(), nz = 0;
+        for( int i = 0; i < n; i++ )
         {
             int f = errptr[i] <= t;
             maskptr[i] = (uchar)f;
@@ -156,7 +156,7 @@ public:
         Mat m1 = _m1.getMat(), m2 = _m2.getMat();
         Mat err, mask, model, bestModel, ms1, ms2;
 
-        int iter, niters = MAX(maxIters, 1);
+        int niters = MAX(maxIters, 1);
         int d1 = m1.channels() > 1 ? m1.channels() : m1.cols;
         int d2 = m2.channels() > 1 ? m2.channels() : m2.cols;
         int count = m1.checkVector(d1), count2 = m2.checkVector(d2), maxGoodCount = 0;
@@ -193,9 +193,8 @@ public:
             return true;
         }
 
-        for( iter = 0; iter < niters; iter++ )
+        for( int iter = 0; iter < niters; iter++ )
         {
-            int i, nmodels;
             if( count > modelPoints )
             {
                 bool found = getSubset( m1, m2, ms1, ms2, rng, 10000 );
@@ -207,13 +206,13 @@ public:
                 }
             }
 
-            nmodels = cb->runKernel( ms1, ms2, model );
+            int nmodels = cb->runKernel( ms1, ms2, model );
             if( nmodels <= 0 )
                 continue;
             CV_Assert( model.rows % nmodels == 0 );
             Size modelSize(model.cols, model.rows/nmodels);
 
-            for( i = 0; i < nmodels; i++ )
+            for( int i = 0; i < nmodels; i++ )
             {
                 Mat model_i = model.rowRange( i*modelSize.height, (i+1)*modelSize.height );
                 int goodCount = findInliers( m1, m2, model_i, err, mask, threshold );

--- a/modules/calib3d/src/solvepnp.cpp
+++ b/modules/calib3d/src/solvepnp.cpp
@@ -118,6 +118,14 @@ bool solvePnP( InputArray _opoints, InputArray _ipoints,
     rvec = _rvec.getMat();
     tvec = _tvec.getMat();
 
+    //TODO:
+    if (useExtrinsicGuess)
+    {
+        std::cout << "useExtrinsicGuess" << std::endl;
+        std::cout << "rvec: " << rvec.t() << std::endl;
+        std::cout << "tvec: " << tvec.t() << std::endl;
+    }
+
     Mat cameraMatrix0 = _cameraMatrix.getMat();
     Mat distCoeffs0 = _distCoeffs.getMat();
     Mat cameraMatrix = Mat_<double>(cameraMatrix0);

--- a/modules/calib3d/test/test_solvepnp_ransac.cpp
+++ b/modules/calib3d/test/test_solvepnp_ransac.cpp
@@ -524,6 +524,75 @@ TEST(Calib3d_SolvePnP, translation)
     EXPECT_TRUE(checkRange(tvec));
 }
 
+TEST(Calib3d_SolvePnP, iterativeInitialGuess)
+{
+    {
+        Matx33d intrinsics(605.4, 0.0, 317.35,
+                           0.0, 601.2, 242.63,
+                           0.0, 0.0, 1.0);
+
+        double L = 0.1;
+        vector<Point3d> p3d;
+        p3d.push_back(Point3d(-L, -L, 0.0));
+        p3d.push_back(Point3d(L, -L, 0.0));
+        p3d.push_back(Point3d(L, L, 0.0));
+        p3d.push_back(Point3d(-L, L, L/2));
+        p3d.push_back(Point3d(0, 0, -L/2));
+
+        Mat rvec_ground_truth = (Mat_<double>(3,1) << 0.3, -0.2, 0.75);
+        Mat tvec_ground_truth = (Mat_<double>(3,1) << 0.15, -0.2, 1.5);
+
+        vector<Point2d> p2d;
+        projectPoints(p3d, rvec_ground_truth, tvec_ground_truth, intrinsics, noArray(), p2d);
+
+        Mat rvec_est = (Mat_<double>(3,1) << 0.1, -0.1, 0.1);
+        Mat tvec_est = (Mat_<double>(3,1) << 0.0, -0.5, 1.0);
+
+        solvePnP(p3d, p2d, intrinsics, noArray(), rvec_est, tvec_est, true, SOLVEPNP_ITERATIVE);
+
+        std::cout << "rvec_ground_truth: " << rvec_ground_truth.t() << std::endl;
+        std::cout << "rvec_est: " << rvec_est.t() << std::endl;
+        std::cout << "tvec_ground_truth: " << tvec_ground_truth.t() << std::endl;
+        std::cout << "tvec_est: " << tvec_est.t() << std::endl;
+
+        EXPECT_LE(cvtest::norm(rvec_ground_truth, rvec_est, NORM_INF), 1e-6);
+        EXPECT_LE(cvtest::norm(tvec_ground_truth, tvec_est, NORM_INF), 1e-6);
+    }
+
+    {
+        Matx33d intrinsics(605.4, 0.0, 317.35,
+                           0.0, 601.2, 242.63,
+                           0.0, 0.0, 1.0);
+
+        double L = 0.1;
+        vector<Point3d> p3d;
+        p3d.push_back(Point3d(-L, -L, 0.0));
+        p3d.push_back(Point3d(L, -L, 0.0));
+        p3d.push_back(Point3d(L, L, 0.0));
+        p3d.push_back(Point3d(-L, L, L/2));
+        p3d.push_back(Point3d(0, 0, -L/2));
+
+        Mat rvec_ground_truth = (Mat_<double>(3,1) << 0.3, -0.2, 0.75);
+        Mat tvec_ground_truth = (Mat_<double>(3,1) << 0.15, -0.2, 1.5);
+
+        vector<Point2d> p2d;
+        projectPoints(p3d, rvec_ground_truth, tvec_ground_truth, intrinsics, noArray(), p2d);
+
+        Mat rvec_est = (Mat_<double>(3,1) << 0.0, 0.0, 0.0);
+        Mat tvec_est = (Mat_<double>(3,1) << 0.0, 0.0, 0.0);
+
+        solvePnP(p3d, p2d, intrinsics, noArray(), rvec_est, tvec_est, true, SOLVEPNP_ITERATIVE);
+
+        std::cout << "rvec_ground_truth: " << rvec_ground_truth.t() << std::endl;
+        std::cout << "rvec_est: " << rvec_est.t() << std::endl;
+        std::cout << "tvec_ground_truth: " << tvec_ground_truth.t() << std::endl;
+        std::cout << "tvec_est: " << tvec_est.t() << std::endl;
+
+        EXPECT_LE(cvtest::norm(rvec_ground_truth, rvec_est, NORM_INF), 1e-6);
+        EXPECT_LE(cvtest::norm(tvec_ground_truth, tvec_est, NORM_INF), 1e-6);
+    }
+}
+
 TEST(Calib3d_SolvePnP, iterativeInitialGuess3pts)
 {
     {

--- a/modules/calib3d/test/test_solvepnp_ransac.cpp
+++ b/modules/calib3d/test/test_solvepnp_ransac.cpp
@@ -61,8 +61,8 @@ public:
     ~CV_solvePnPRansac_Test() {}
 protected:
     void generate3DPointCloud(vector<Point3f>& points,
-        Point3f pmin = Point3f(-1, -1, 5),
-        Point3f pmax = Point3f(1, 1, 10))
+                              Point3f pmin = Point3f(-1, -1, 5),
+                              Point3f pmax = Point3f(1, 1, 10))
     {
         RNG rng = cv::theRNG(); // fix the seed to use "fixed" input 3D points
 
@@ -104,7 +104,7 @@ protected:
         for (int i = 0; i < 3; i++)
         {
             rvec.at<double>(i,0) = rng.uniform(minVal, maxVal);
-            tvec.at<double>(i,0) = rng.uniform(minVal, maxVal/10);
+            tvec.at<double>(i,0) = (i == 2) ? rng.uniform(minVal*10, maxVal) : rng.uniform(-maxVal, maxVal);
         }
     }
 
@@ -177,7 +177,7 @@ protected:
                         method, totalTestsCount - successfulTestsCount, totalTestsCount, maxError, mode);
                     ts->set_failed_test_info(cvtest::TS::FAIL_BAD_ACCURACY);
                 }
-                cout << "mode: " <<printMode(mode) << ", method: " << printMethod(method) << " -> "
+                cout << "mode: " << printMode(mode) << ", method: " << printMethod(method) << " -> "
                      << ((double)successfulTestsCount / totalTestsCount) * 100 << "%"
                      << " (err < " << maxError << ")" << endl;
             }
@@ -223,7 +223,7 @@ public:
     {
         eps[SOLVEPNP_ITERATIVE] = 1.0e-6;
         eps[SOLVEPNP_EPNP] = 1.0e-6;
-        eps[SOLVEPNP_P3P] = 2.0e-4;
+        eps[SOLVEPNP_P3P] = 5.0e-4;
         eps[SOLVEPNP_AP3P] = 1.0e-4;
         eps[SOLVEPNP_DLS] = 1.0e-6;
 //        eps[SOLVEPNP_UPNP] = 1.0e-4; //UPnP is broken and is remaped to EPnP


### PR DESCRIPTION
For now, just a test to see if with:
```
CV_EXPORTS_W bool solvePnP( InputArray objectPoints, InputArray imagePoints,
                            InputArray cameraMatrix, InputArray distCoeffs,
                            OutputArray rvec, OutputArray tvec,
                            bool useExtrinsicGuess = false, int flags = SOLVEPNP_ITERATIVE );
```
and `useExtrinsicGuess = true`, provided `rvec` and `tvec` are used or not.
On my computer, they are.

Related: #13405 #13734 #12334

```
**WIP**
force_builders=linux,docs,windows,mac
```