### PR TITLE
Runing tests on IE backend 

### DIFF
--- a/modules/dnn/perf/perf_net.cpp
+++ b/modules/dnn/perf/perf_net.cpp
@@ -124,8 +124,7 @@ PERF_TEST_P_(DNNTestNetwork, SSD)
 PERF_TEST_P_(DNNTestNetwork, OpenFace)
 {
     if (backend == DNN_BACKEND_HALIDE ||
-        (backend == DNN_BACKEND_INFERENCE_ENGINE && target == DNN_TARGET_OPENCL_FP16) ||
-        (backend == DNN_BACKEND_INFERENCE_ENGINE && target == DNN_TARGET_MYRIAD))
+       (backend == DNN_BACKEND_INFERENCE_ENGINE && target == DNN_TARGET_MYRIAD))
         throw SkipTestException("");
     processNet("dnn/openface_nn4.small2.v1.t7", "", "",
             Mat(cv::Size(96, 96), CV_32FC3));

--- a/modules/dnn/src/layers/lrn_layer.cpp
+++ b/modules/dnn/src/layers/lrn_layer.cpp
@@ -92,7 +92,7 @@ public:
     {
         return backendId == DNN_BACKEND_OPENCV ||
                backendId == DNN_BACKEND_HALIDE ||
-               (backendId == DNN_BACKEND_INFERENCE_ENGINE && (preferableTarget != DNN_TARGET_MYRIAD || type == CHANNEL_NRM));
+               backendId == DNN_BACKEND_INFERENCE_ENGINE;
     }
 
 #ifdef HAVE_OPENCL

--- a/modules/dnn/src/layers/normalize_bbox_layer.cpp
+++ b/modules/dnn/src/layers/normalize_bbox_layer.cpp
@@ -65,16 +65,12 @@ public:
     {
         if (backendId == DNN_BACKEND_INFERENCE_ENGINE)
         {
-            if (pnorm != 2)
+            if (!(pnorm == 2 || pnorm == 1)) {
                 return false;
-            if (!blobs.empty())
-                return true;
-            if (preferableTarget == DNN_TARGET_MYRIAD)
-                return !acrossSpatial;
-            return startAxis == 1 && (!acrossSpatial || endAxis > 1);
+            }
+            return preferableTarget == DNN_TARGET_MYRIAD ? !acrossSpatial : startAxis == 1;
         }
-        else
-            return backendId == DNN_BACKEND_OPENCV;
+        return backendId == DNN_BACKEND_OPENCV;
     }
 
     bool getMemoryShapes(const std::vector<MatShape> &inputs,

--- a/modules/dnn/src/layers/normalize_bbox_layer.cpp
+++ b/modules/dnn/src/layers/normalize_bbox_layer.cpp
@@ -65,9 +65,9 @@ public:
     {
         if (backendId == DNN_BACKEND_INFERENCE_ENGINE)
         {
-            if (pnorm != 2) {
+            if (pnorm != 2)
                 return false;
-            }
+
             return preferableTarget == DNN_TARGET_MYRIAD ? !acrossSpatial : startAxis == 1;
         }
         return backendId == DNN_BACKEND_OPENCV;

--- a/modules/dnn/src/layers/normalize_bbox_layer.cpp
+++ b/modules/dnn/src/layers/normalize_bbox_layer.cpp
@@ -65,7 +65,7 @@ public:
     {
         if (backendId == DNN_BACKEND_INFERENCE_ENGINE)
         {
-            if (!(pnorm == 2 || pnorm == 1)) {
+            if (pnorm != 2) {
                 return false;
             }
             return preferableTarget == DNN_TARGET_MYRIAD ? !acrossSpatial : startAxis == 1;

--- a/modules/dnn/src/layers/resize_layer.cpp
+++ b/modules/dnn/src/layers/resize_layer.cpp
@@ -54,12 +54,11 @@ public:
 #ifdef HAVE_INF_ENGINE
         if (backendId == DNN_BACKEND_INFERENCE_ENGINE)
         {
-            return (interpolation == "nearest" && preferableTarget != DNN_TARGET_MYRIAD) ||
+            return (interpolation == "nearest" && scaleWidth == scaleHeight) ||
                    (interpolation == "bilinear" && INF_ENGINE_VER_MAJOR_GE(INF_ENGINE_RELEASE_2018R4));
         }
-        else
 #endif
-            return backendId == DNN_BACKEND_OPENCV;
+        return backendId == DNN_BACKEND_OPENCV;
     }
 
     virtual void finalize(InputArrayOfArrays inputs_arr, OutputArrayOfArrays outputs_arr) CV_OVERRIDE

--- a/modules/dnn/test/test_backends.cpp
+++ b/modules/dnn/test/test_backends.cpp
@@ -226,7 +226,7 @@ TEST_P(DNNTestNetwork, OpenPose_pose_mpi_faster_4_stages)
 TEST_P(DNNTestNetwork, OpenFace)
 {
 #if defined(INF_ENGINE_RELEASE)
-#if (INF_ENGINE_RELEASE < 2018030000)
+#if (INF_ENGINE_RELEASE < 2018030000 || INF_ENGINE_RELEASE == 2018050000)
     if (backend == DNN_BACKEND_INFERENCE_ENGINE && target == DNN_TARGET_MYRIAD)
         throw SkipTestException("");
 #elif INF_ENGINE_RELEASE < 2018040000

--- a/modules/dnn/test/test_backends.cpp
+++ b/modules/dnn/test/test_backends.cpp
@@ -226,7 +226,7 @@ TEST_P(DNNTestNetwork, OpenPose_pose_mpi_faster_4_stages)
 TEST_P(DNNTestNetwork, OpenFace)
 {
 #if defined(INF_ENGINE_RELEASE)
-#if (INF_ENGINE_RELEASE < 2018030000 || INF_ENGINE_RELEASE == 2018050000)
+#if (INF_ENGINE_RELEASE < 2018030000)
     if (backend == DNN_BACKEND_INFERENCE_ENGINE && target == DNN_TARGET_MYRIAD)
         throw SkipTestException("");
 #elif INF_ENGINE_RELEASE < 2018040000

--- a/modules/dnn/test/test_tf_importer.cpp
+++ b/modules/dnn/test/test_tf_importer.cpp
@@ -558,8 +558,6 @@ TEST_P(Test_TensorFlow_layers, split)
 
 TEST_P(Test_TensorFlow_layers, resize_nearest_neighbor)
 {
-    if (backend == DNN_BACKEND_INFERENCE_ENGINE && target != DNN_TARGET_MYRIAD)
-        throw SkipTestException("");
     runTensorFlowNet("resize_nearest_neighbor");
     runTensorFlowNet("keras_upsampling2d");
 }

--- a/modules/dnn/test/test_torch_importer.cpp
+++ b/modules/dnn/test/test_torch_importer.cpp
@@ -272,13 +272,11 @@ class Test_Torch_nets : public DNNTestLayer {};
 
 TEST_P(Test_Torch_nets, OpenFace_accuracy)
 {
-#if defined(INF_ENGINE_RELEASE) && (INF_ENGINE_RELEASE < 2018030000)
+#if defined(INF_ENGINE_RELEASE) && (INF_ENGINE_RELEASE < 2018030000 || INF_ENGINE_RELEASE == 2018050000)
     if (backend == DNN_BACKEND_INFERENCE_ENGINE && target == DNN_TARGET_MYRIAD)
         throw SkipTestException("");
 #endif
     checkBackend();
-    if (backend == DNN_BACKEND_INFERENCE_ENGINE && target == DNN_TARGET_OPENCL_FP16 && INF_ENGINE_RELEASE != 2018050000)
-        throw SkipTestException("");
 
     const string model = findDataFile("dnn/openface_nn4.small2.v1.t7", false);
     Net net = readNetFromTorch(model);

--- a/modules/dnn/test/test_torch_importer.cpp
+++ b/modules/dnn/test/test_torch_importer.cpp
@@ -272,12 +272,12 @@ class Test_Torch_nets : public DNNTestLayer {};
 
 TEST_P(Test_Torch_nets, OpenFace_accuracy)
 {
-#if defined(INF_ENGINE_RELEASE) && (INF_ENGINE_RELEASE < 2018030000 || INF_ENGINE_RELEASE == 2018050000)
+#if defined(INF_ENGINE_RELEASE) && (INF_ENGINE_RELEASE < 2018030000)
     if (backend == DNN_BACKEND_INFERENCE_ENGINE && target == DNN_TARGET_MYRIAD)
         throw SkipTestException("");
 #endif
     checkBackend();
-    if (backend == DNN_BACKEND_INFERENCE_ENGINE && target == DNN_TARGET_OPENCL_FP16)
+    if (backend == DNN_BACKEND_INFERENCE_ENGINE && target == DNN_TARGET_OPENCL_FP16 && INF_ENGINE_RELEASE != 2018050000)
         throw SkipTestException("");
 
     const string model = findDataFile("dnn/openface_nn4.small2.v1.t7", false);


### PR DESCRIPTION
### This pullrequest changes
The following test now use IE backend:    
Normalize layer
* Test_Torch_layers.net_normalize
* Test_Torch_nets.OpenFace_accuracy

Resize layer
* Test_Darknet_nets.YOLOv3
* Test_Darknet_layers.upsample
* Test_Torch_layers.upsampling_nearest  

LRN layer
* Test_Caffe_layers.LRN

<cut/>

### Performance test results 
Processor: Intel® Core™ i5-6500 CPU @ 3.20GHz × 4
Graphics: Intel® HD Graphics 530 (Skylake GT2)  

| Name of Test                            | Time before changes (ms) | Time after changes (ms) |  x-factor after vs before |
|-----------------------------------------|--------------------------|-------------------------|---------------------------|
| OpenFace::DNNTestNetwork::DLIE/CPU      | 18.298                   | 17.791                  | 0.97                      |
|  OpenFace::DNNTestNetwork::DLIE/OCL     | 8.375                    | 8.051                   | 0.96                      |
| OpenFace::DNNTestNetwork::DLIE/OCL_FP16 | 8.778                    | 7.491                   | 0.85                      |
| YOLOv3::DNNTestNetwork::DLIE/MYRIAD     | 1946.705                 | 1957.809                | 1.01                      |

```
force_builders=Custom
docker_image:Custom=ubuntu-openvino-2018r5:16.04
test_opencl:Custom=ON
buildworker:Custom=linux-2
#test_modules=dnn
allow_multiple_commits=1
```