### PR TITLE
Fixed out of bound reading issue in erode() and dilate()

### DIFF
--- a/modules/imgproc/src/morph.cpp
+++ b/modules/imgproc/src/morph.cpp
@@ -159,7 +159,7 @@ template<class VecUpdate> struct MorphRowVec
             i += vtype::nlanes/2;
         }
 
-        return i;
+        return i - i % cn;
     }
 
     int ksize, anchor;


### PR DESCRIPTION
resolves #13755

### This pullrequest changes
Fixed out of bound reading issue in erode() and dilate()

[Validation build](http://pullrequest.opencv.org/buildbot/builders/3_4_valgrind-lin64-debug/builds/56).