### PR TITLE
G-API: Clarify kernel package design

### DIFF
--- a/modules/gapi/include/opencv2/gapi/gkernel.hpp
+++ b/modules/gapi/include/opencv2/gapi/gkernel.hpp
@@ -368,7 +368,8 @@ namespace gapi {
         // Check if package contains ANY implementation of a kernel API
         // by API textual id.
         bool includesAPI(const std::string &id) const;
-
+        bool includes   (const GBackend& backend,
+                         const std::string& id) const;
         /// @private
         // Remove ALL implementations of the given API (identified by ID)
         void removeAPI(const std::string &id);
@@ -383,6 +384,14 @@ namespace gapi {
         std::size_t size() const;
 
         /**
+         * @brief Check that package contains conflict kernels
+         * included in this kernel package.
+         *
+         * @return names of conflicting kernels, if any.
+         */
+        std::vector<std::string> getConflictKernels(const GLookupOrder& lookup_order) const;
+
+        /**
          * @brief Test if a particular kernel _implementation_ KImpl is
          * included in this kernel package.
          *
@@ -393,10 +402,7 @@ namespace gapi {
         template<typename KImpl>
         bool includes() const
         {
-            const auto set_iter = m_backend_kernels.find(KImpl::backend());
-            return (set_iter != m_backend_kernels.end())
-                ? (set_iter->second.count(KImpl::API::id()) > 0)
-                : false;
+            return includes(KImpl::backend(), KImpl::API::id());
         }
 
         /**

--- a/modules/gapi/src/api/gbackend.cpp
+++ b/modules/gapi/src/api/gbackend.cpp
@@ -97,8 +97,6 @@ void bindInArg(Mag& mag, const RcDesc &rc, const GRunArg &arg, bool is_umat)
 #if !defined(GAPI_STANDALONE)
                 auto& mag_umat = mag.template slot<cv::UMat>()[rc.id];
                 mag_umat = to_ocv(util::get<cv::gapi::own::Mat>(arg)).getUMat(ACCESS_READ);
-//FIXME avoid delete memory in umat
-                mag_umat.addref();
 #else
                 util::throw_error(std::logic_error("UMat is not supported in stadnalone build"));
 #endif // !defined(GAPI_STANDALONE)
@@ -166,8 +164,6 @@ void bindOutArg(Mag& mag, const RcDesc &rc, const GRunArgP &arg, bool is_umat)
 #if !defined(GAPI_STANDALONE)
                 auto& mag_umat = mag.template slot<cv::UMat>()[rc.id];
                 mag_umat = to_ocv(*(util::get<cv::gapi::own::Mat*>(arg))).getUMat(ACCESS_RW);
-//FIXME avoid delete memory in umat
-                mag_umat.addref();
 #else
                 util::throw_error(std::logic_error("UMat is not supported in standalone build"));
 #endif // !defined(GAPI_STANDALONE)

--- a/modules/gapi/src/api/gbackend.cpp
+++ b/modules/gapi/src/api/gbackend.cpp
@@ -97,6 +97,8 @@ void bindInArg(Mag& mag, const RcDesc &rc, const GRunArg &arg, bool is_umat)
 #if !defined(GAPI_STANDALONE)
                 auto& mag_umat = mag.template slot<cv::UMat>()[rc.id];
                 mag_umat = to_ocv(util::get<cv::gapi::own::Mat>(arg)).getUMat(ACCESS_READ);
+//FIXME avoid delete memory in umat
+                //mag_umat.addref();
 #else
                 util::throw_error(std::logic_error("UMat is not supported in stadnalone build"));
 #endif // !defined(GAPI_STANDALONE)
@@ -164,6 +166,8 @@ void bindOutArg(Mag& mag, const RcDesc &rc, const GRunArgP &arg, bool is_umat)
 #if !defined(GAPI_STANDALONE)
                 auto& mag_umat = mag.template slot<cv::UMat>()[rc.id];
                 mag_umat = to_ocv(*(util::get<cv::gapi::own::Mat*>(arg))).getUMat(ACCESS_RW);
+//FIXME avoid delete memory in umat
+                //mag_umat.addref();
 #else
                 util::throw_error(std::logic_error("UMat is not supported in standalone build"));
 #endif // !defined(GAPI_STANDALONE)

--- a/modules/gapi/src/api/gbackend.cpp
+++ b/modules/gapi/src/api/gbackend.cpp
@@ -98,7 +98,7 @@ void bindInArg(Mag& mag, const RcDesc &rc, const GRunArg &arg, bool is_umat)
                 auto& mag_umat = mag.template slot<cv::UMat>()[rc.id];
                 mag_umat = to_ocv(util::get<cv::gapi::own::Mat>(arg)).getUMat(ACCESS_READ);
 //FIXME avoid delete memory in umat
-                //mag_umat.addref();
+                mag_umat.addref();
 #else
                 util::throw_error(std::logic_error("UMat is not supported in stadnalone build"));
 #endif // !defined(GAPI_STANDALONE)
@@ -167,7 +167,7 @@ void bindOutArg(Mag& mag, const RcDesc &rc, const GRunArgP &arg, bool is_umat)
                 auto& mag_umat = mag.template slot<cv::UMat>()[rc.id];
                 mag_umat = to_ocv(*(util::get<cv::gapi::own::Mat*>(arg))).getUMat(ACCESS_RW);
 //FIXME avoid delete memory in umat
-                //mag_umat.addref();
+                mag_umat.addref();
 #else
                 util::throw_error(std::logic_error("UMat is not supported in standalone build"));
 #endif // !defined(GAPI_STANDALONE)

--- a/modules/gapi/src/api/gkernel.cpp
+++ b/modules/gapi/src/api/gkernel.cpp
@@ -100,9 +100,8 @@ cv::gapi::GKernelPackage::getConflictKernels(const cv::gapi::GLookupOrder& looku
 bool cv::gapi::GKernelPackage::includes(const GBackend& backend, const std::string& id)  const
 {
     const auto set_iter = m_backend_kernels.find(backend);
-    return (set_iter != m_backend_kernels.end())
-        ? (ade::util::contains(set_iter->second, id))
-        : false;
+    return set_iter != m_backend_kernels.end() &&
+           ade::util::contains(set_iter->second, id);
 }
 
 cv::gapi::GKernelPackage cv::gapi::combine(const GKernelPackage  &lhs,

--- a/modules/gapi/src/backends/common/gbackend.hpp
+++ b/modules/gapi/src/backends/common/gbackend.hpp
@@ -41,11 +41,6 @@ namespace magazine {
             return std::get<ade::util::type_list_index<T, Ts...>::value>(slots);
         }
 
-        ~Class()
-        {
-            cv::UMat& umat = slot<cv::UMat>()[0];
-        }
-
     private:
         std::tuple<MapT<Ts>...> slots;
     };

--- a/modules/gapi/src/backends/common/gbackend.hpp
+++ b/modules/gapi/src/backends/common/gbackend.hpp
@@ -40,6 +40,12 @@ namespace magazine {
         {
             return std::get<ade::util::type_list_index<T, Ts...>::value>(slots);
         }
+
+        ~Class()
+        {
+            cv::UMat& umat = slot<cv::UMat>()[0];
+        }
+
     private:
         std::tuple<MapT<Ts>...> slots;
     };

--- a/modules/gapi/src/compiler/gcompiler.cpp
+++ b/modules/gapi/src/compiler/gcompiler.cpp
@@ -141,8 +141,8 @@ cv::gimpl::GCompiler::GCompiler(const cv::GComputation &c,
     m_e.addPassStage("init");
     m_e.addPass("init", "check_cycles",  ade::passes::CheckCycles());
     m_e.addPass("init", "expand_kernels",  std::bind(passes::expandKernels, _1,
-                                                     m_all_kernels,
-                                                     lookup_order)); // NB: package is copied
+                                                     m_all_kernels, // NB: package is copied
+                                                     lookup_order));
 
     m_e.addPass("init", "topo_sort",     ade::passes::TopologicalSort());
     m_e.addPass("init", "init_islands",  passes::initIslands);

--- a/modules/gapi/src/compiler/passes/kernels.cpp
+++ b/modules/gapi/src/compiler/passes/kernels.cpp
@@ -124,7 +124,9 @@ void cv::gimpl::passes::resolveKernels(ade::passes::PassContext   &ctx,
     gr.metadata().set(ActiveBackends{active_backends});
 }
 
-void cv::gimpl::passes::expandKernels(ade::passes::PassContext &ctx, const gapi::GKernelPackage &kernels)
+void cv::gimpl::passes::expandKernels(ade::passes::PassContext &ctx,
+                                      const gapi::GKernelPackage &kernels,
+                                      const gapi::GLookupOrder &lookup_order)
 {
     GModel::Graph gr(ctx.graph);
 
@@ -142,7 +144,7 @@ void cv::gimpl::passes::expandKernels(ade::passes::PassContext &ctx, const gapi:
 
                 cv::gapi::GBackend selected_backend;
                 cv::GKernelImpl    selected_impl;
-                std::tie(selected_backend, selected_impl) = kernels.lookup(op.k.name);
+                std::tie(selected_backend, selected_impl) = kernels.lookup(op.k.name, lookup_order);
 
                 if (selected_backend == cv::gapi::compound::backend())
                 {

--- a/modules/gapi/src/compiler/passes/passes.hpp
+++ b/modules/gapi/src/compiler/passes/passes.hpp
@@ -42,7 +42,8 @@ void inferMeta(ade::passes::PassContext &ctx, bool meta_is_initialized);
 void storeResultingMeta(ade::passes::PassContext &ctx);
 
 void expandKernels(ade::passes::PassContext &ctx,
-                   const gapi::GKernelPackage& kernels);
+                   const gapi::GKernelPackage& kernels,
+                   const gapi::GLookupOrder& lookup_order);
 
 void resolveKernels(ade::passes::PassContext       &ctx,
                     const gapi::GKernelPackage &kernels,

--- a/modules/gapi/test/common/gapi_compoundkernel_tests.cpp
+++ b/modules/gapi/test/common/gapi_compoundkernel_tests.cpp
@@ -229,20 +229,20 @@ namespace
 
 } // namespace
 
-// FIXME avoid cv::combine that use custom and default kernels together
 TEST(GCompoundKernel, ReplaceDefaultKernel)
 {
     cv::GMat in1, in2;
     auto out = cv::gapi::add(in1, in2);
-    const auto custom_pkg = cv::gapi::kernels<GCompoundAddImpl>();
-    const auto full_pkg   = cv::gapi::combine(cv::gapi::core::cpu::kernels(), custom_pkg, cv::unite_policy::REPLACE);
+
+    const auto pkg = cv::gapi::kernels<GCompoundAddImpl>();
+
     cv::GComputation comp(cv::GIn(in1, in2), cv::GOut(out));
     cv::Mat in_mat1 = cv::Mat::eye(3, 3, CV_8UC1),
             in_mat2 = cv::Mat::eye(3, 3, CV_8UC1),
             out_mat(3, 3, CV_8UC1),
             ref_mat(3, 3, CV_8UC1);
 
-    comp.apply(cv::gin(in_mat1, in_mat2), cv::gout(out_mat), cv::compile_args(full_pkg));
+    comp.apply(cv::gin(in_mat1, in_mat2), cv::gout(out_mat), cv::compile_args(pkg));
     ref_mat = in_mat1 - in_mat2 - in_mat2;
 
     EXPECT_EQ(0, cv::countNonZero(out_mat != ref_mat));

--- a/modules/gapi/test/gapi_kernel_tests.cpp
+++ b/modules/gapi/test/gapi_kernel_tests.cpp
@@ -570,7 +570,7 @@ TEST_F(HeteroGraph, Resolve_Default_Conflict)
         apply(cv::gin(in_mat1, in_mat2), cv::gout(out_mat), cv::compile_args(pkg, lookup_order));
 
     EXPECT_TRUE(checkCallKernel(KernelTags::CPU_CUSTOM_ADD));
-}    
+}
 
 TEST_F(HeteroGraph, Not_Resolve_Conflict)
 {

--- a/modules/gapi/test/gapi_kernel_tests.cpp
+++ b/modules/gapi/test/gapi_kernel_tests.cpp
@@ -538,9 +538,9 @@ TEST_F(HeteroGraph, Dont_Pass_Default_To_Lookup)
     // in1 --------`
 
     auto in_meta = cv::GMetaArg(cv::GMatDesc{CV_8U,1,{3, 3}});
-    auto pkg = cv::gapi::kernels<cpu::GClone, ocl::BGR2Gray, fluid::BGR2Gray>();
+    auto pkg = cv::gapi::kernels<cpu::GClone, fluid::BGR2Gray>();
 
-    // Lookup order contains only ocl backend
+    // Lookup order contains only fluid backend
     // CPU backend for GClone and gapi::GAdd pass implicitly
     cv::gapi::GLookupOrder lookup_order = { cv::gapi::fluid::backend() };
 
@@ -585,6 +585,7 @@ TEST_F(HeteroGraph, Not_Resolve_Conflict)
                          .compile({in_meta, in_meta}, cv::compile_args(pkg, lookup_order)));
 }
 
+//FIXME Impossible to build graph with ocv and ocl kernels together
 TEST_F(HeteroGraph, DISABLED_Implicit_Pass_To_Lookup)
 {
     // in0 -> ocl::GAdd -> tmp -> cpu::GClone -> fluid::BGR2Gray -> out

--- a/modules/gapi/test/gapi_kernel_tests.cpp
+++ b/modules/gapi/test/gapi_kernel_tests.cpp
@@ -24,11 +24,6 @@ namespace
         {
             static GMatDesc outMeta(GMatDesc in) { return in; }
         };
-
-        G_TYPED_KERNEL(Corge, <GMat(GMat)>, "org.opencv.test.Corge")
-        {
-            static GMatDesc outMeta(GMatDesc in) { return in; }
-        };
     }
 
     enum class KernelTags {
@@ -74,9 +69,8 @@ namespace
     namespace ocl {
         GAPI_OCL_KERNEL(GAdd, cv::gapi::core::GAdd)
         {
-            static void run(const cv::UMat& in1, const cv::UMat& in2, int dtype, cv::UMat& out)
+            static void run(const cv::UMat&, const cv::UMat&, int, cv::UMat&)
             {
-                cv::add(in1, in2, out, cv::noArray(), dtype);
                 GraphFixture::registerCallKernel(KernelTags::OCL_CUSTOM_ADD);
             }
         };
@@ -91,10 +85,9 @@ namespace
 
         GAPI_OCL_KERNEL(BGR2Gray, cv::gapi::imgproc::GBGR2Gray)
         {
-            static void run(const cv::UMat& in, cv::UMat &out)
+            static void run(const cv::UMat&, cv::UMat&)
             {
                 GraphFixture::registerCallKernel(KernelTags::OCL_CUSTOM_BGR2GRAY);
-                //cv::cvtColor(in, out, cv::COLOR_BGR2GRAY);
             }
         };
     }
@@ -103,36 +96,25 @@ namespace
     {
         GAPI_OCV_KERNEL(GAdd, cv::gapi::core::GAdd)
         {
-            static void run(const cv::Mat& in1, const cv::Mat& in2, int dtype, cv::Mat& out)
+            static void run(const cv::Mat&, const cv::Mat&, int, cv::Mat&)
             {
-                cv::add(in1, in2, out, cv::noArray(), dtype);
                 GraphFixture::registerCallKernel(KernelTags::CPU_CUSTOM_ADD);
             }
         };
 
         GAPI_OCV_KERNEL(GClone, I::GClone)
         {
-            static void run(const cv::Mat& in, cv::Mat& out)
+            static void run(const cv::Mat&, cv::Mat&)
             {
-                in.copyTo(out);
                 GraphFixture::registerCallKernel(KernelTags::CPU_CUSTOM_CLONE);
             }
         };
 
         GAPI_OCV_KERNEL(BGR2Gray, cv::gapi::imgproc::GBGR2Gray)
         {
-            static void run(const cv::Mat& in, cv::Mat& out)
+            static void run(const cv::Mat&, cv::Mat&)
             {
                 GraphFixture::registerCallKernel(KernelTags::CPU_CUSTOM_BGR2GRAY);
-                cv::cvtColor(in, out, cv::COLOR_BGR2GRAY);
-            }
-        };
-
-        GAPI_OCV_KERNEL(Not, cv::gapi::core::GNot)
-        {
-            static void run(const cv::Mat& in, cv::Mat& out)
-            {
-                cv::bitwise_not(in, out);
             }
         };
     }
@@ -678,7 +660,6 @@ TEST_F(HeteroGraph, Unused_Backend)
 
     EXPECT_NO_THROW(cv::GComputation(cv::GIn(in[0], in[1]), cv::GOut(out))
             .compile({in_meta, in_meta}, cv::compile_args(pkg, lookup_order)));
-
 }
 
 }// namespace opencv_test

--- a/modules/gapi/test/gapi_kernel_tests.cpp
+++ b/modules/gapi/test/gapi_kernel_tests.cpp
@@ -7,7 +7,6 @@
 
 #include "test_precomp.hpp"
 #include "opencv2/gapi/cpu/gcpukernel.hpp"
-#include "opencv2/gapi/fluid/gfluidkernel.hpp"
 #include "gapi_mock_kernels.hpp"
 
 #include "opencv2/gapi/ocl/goclkernel.hpp"     // ocl::backend
@@ -417,7 +416,7 @@ TEST(KernelPackage, Unite_REPLACE_Same_Backend)
 
 TEST_F(HeteroGraph, Correct_Use_Custom_Kernel)
 {
-    // in0 -> gapi::GAdd -> tmp -> U::GClone -> gapi::GResize -> out
+    // in0 -> gapi::GAdd -> tmp -> cpu::GClone -> gapi::GResize -> out
     //            ^
     //            |
     // in1 -------`
@@ -437,7 +436,7 @@ TEST_F(HeteroGraph, Correct_Use_Custom_Kernel)
 
 TEST_F(HeteroGraph, Replace_Default)
 {
-    // in0 -> U::GAdd -> tmp -> U::GClone -> gapi::GResize -> out
+    // in0 -> cpu::GAdd -> tmp -> cpu::GClone -> gapi::GResize -> out
     //            ^
     //            |
     // in1 -------`
@@ -458,7 +457,7 @@ TEST_F(HeteroGraph, Replace_Default)
 
 TEST_F(HeteroGraph, User_Kernel_Not_Found)
 {
-    // in0 -> gapi::GAdd -> tmp -> U::GClone -> gapi::GResize -> out
+    // in0 -> gapi::GAdd -> tmp -> cpu::GClone -> gapi::GResize -> out
     //            ^
     //            |
     // in1 -------`
@@ -472,7 +471,7 @@ TEST_F(HeteroGraph, User_Kernel_Not_Found)
 
 TEST_F(HeteroGraph, Replace_Default_Another_Backend)
 {
-    // in0 -> gapi::GAdd -> tmp -> U::GClone -> ocl::GResize -> out
+    // in0 -> gapi::GAdd -> tmp -> cpu::GClone -> ocl::GResize -> out
     //            ^
     //            |
     // in1 -------`
@@ -492,7 +491,7 @@ TEST_F(HeteroGraph, Replace_Default_Another_Backend)
 
 TEST_F(HeteroGraph, Conflict_Customs)
 {
-    // in0 -> gapi::GAdd -> tmp -> U::GClone -> (ocl::GResize/fluid::GResize) -> out
+    // in0 -> gapi::GAdd -> tmp -> cpu::GClone -> (ocl::GResize/fluid::GResize) -> out
     //            ^
     //            |
     // in1 -------`
@@ -534,7 +533,7 @@ TEST_F(HeteroGraph, Resolve_Custom_Conflict)
 
 TEST_F(HeteroGraph, Dont_Pass_Default_To_Lookup)
 {
-    // in0 -> gapi::GAdd -> tmp -> U::GClone -> N::GResize -> out
+    // in0 -> gapi::GAdd -> tmp -> cpu::GClone -> ocl::GResize -> out
     //            ^
     //            |
     // in1 -------`

--- a/modules/gapi/test/gapi_kernel_tests.cpp
+++ b/modules/gapi/test/gapi_kernel_tests.cpp
@@ -297,10 +297,10 @@ TEST(KernelPackage, Combine_REPLACE_Full)
     auto s_pkg = cv::gapi::kernels<S::Foo, S::Bar, S::Baz>();
     auto u_pkg = cv::gapi::combine(j_pkg, s_pkg, cv::unite_policy::REPLACE);
 
-    EXPECT_EQ(3u, u_pkg.size());
-    EXPECT_FALSE(u_pkg.includes<J::Foo>());
-    EXPECT_FALSE(u_pkg.includes<J::Bar>());
-    EXPECT_FALSE(u_pkg.includes<J::Baz>());
+    EXPECT_EQ(6u, u_pkg.size());
+    EXPECT_TRUE(u_pkg.includes<J::Foo>());
+    EXPECT_TRUE(u_pkg.includes<J::Bar>());
+    EXPECT_TRUE(u_pkg.includes<J::Baz>());
     EXPECT_TRUE (u_pkg.includes<S::Foo>());
     EXPECT_TRUE (u_pkg.includes<S::Bar>());
     EXPECT_TRUE (u_pkg.includes<S::Baz>());
@@ -314,9 +314,9 @@ TEST(KernelPackage, Combine_REPLACE_Partial)
     auto s_pkg = cv::gapi::kernels<S::Bar>();
     auto u_pkg = cv::gapi::combine(j_pkg, s_pkg, cv::unite_policy::REPLACE);
 
-    EXPECT_EQ(2u, u_pkg.size());
+    EXPECT_EQ(3u, u_pkg.size());
     EXPECT_TRUE (u_pkg.includes<J::Foo>());
-    EXPECT_FALSE(u_pkg.includes<J::Bar>());
+    EXPECT_TRUE(u_pkg.includes<J::Bar>());
     EXPECT_TRUE (u_pkg.includes<S::Bar>());
 }
 


### PR DESCRIPTION
Clarify kernel package design
<cut/>

This MR describes the mechanism for transferring user kernels to a graph and resolves conflicts between kernels  

## Cases
### 1. Kernel package can't have 2 kernels with same id and same backend. Replace happens in this case.  
 - Inside function `getKernelPackage` make kernel package via `cv::gapi::combine` between user package and default package with `cv::unite_policy::REPLACE`  
   - Create result kernel package from user package
   - Traversal the kernel from the default package, If the result kernel package in the `cpu::backend` contains a kernel named as the default kernel, this default kernel doesn't add to result kernel package.

   As a result of this `cv::gapi::combine`, custom kernels will replace the default kernels with the same name.
### 2. Kernel package have 2 kernels with same id and different backend.
* **Use case A: OCV custom resize is passed to compile args, default kernels package is OCV only => replace within backend(Custom resize is used, default is dropped)**  
  See case 1.
* **Use case B: OCL resize is passed to compile args, default kernel package is OCV only =>**
  - **Option A: Keep both kernel in resulting package, infer lookup order automatically(OCL>OCV)
Accepted as allowing to have multiple versions of the same kernel in different backends**
       - Inside `cv::gapi::combine` user kernel does't replace the default because they belong to different backends
       - Via `addBackendsTo(GLookupOrder&, const vector<GBackend>&)` added backends of the kernel package to lookup order so that the `cpu::backend` will be added in the last turn.

        As a result, the `ocl::backend` will be stored first `cpu::backend` hence will have a higher priority 

  - **Option B: ~~Drop all kernels with same id as resize, use OCL instead
rejected as can't in to heterogeneity~~**
  - **Use case C: User kernel package contains OCV LUT and fluid threshold => std LUT is replaced by custom LUT(see 1), fluid backend gets higher priority in inferred lookup order**
       - OCV LUT replaced std LUT (see 1)
       - fluid backend get higher priority (see 2.a)

  - **Use case D: User kernel package contains fluid LUT and OCL LUT => explicit lookup order is required to be passed by user, if no lookup order exception throw**
       - `GKernelPackage` has `getConflictKernels(const GLookupOrder&)` which returns a vector of the names of the conflicting kernels. How it works:
         - Traversal kernel from `kernel package`, For kernels with the same name, it is checked whether the backend vector contains at least one kernel, if not, the kernel is added to the conflicting kernel vector.
         - If the `getConflictKernels` returns a non-empty vector then throw exception (exception message contains the names of the conflicting kernels) 

