### PR TITLE
Fix typo in the tutorial

### DIFF
--- a/doc/tutorials/videoio/video-input-psnr-ssim/video_input_psnr_ssim.markdown
+++ b/doc/tutorials/videoio/video-input-psnr-ssim/video_input_psnr_ssim.markdown
@@ -77,7 +77,7 @@ by the @ref cv::VideoCapture::read or the overloaded \>\> operator:
 @code{.cpp}
 Mat frameReference, frameUnderTest;
 captRefrnc >> frameReference;
-captUndTst.open(frameUnderTest);
+captUndTst.read(frameUnderTest);
 @endcode
 The upper read operations will leave empty the *Mat* objects if no frame could be acquired (either
 cause the video stream was closed or you got to the end of the video file). We can check this with a


### PR DESCRIPTION
This pull request fixes small typo in "Video Input with OpenCV and similarity measurement" tutorial.

The tutorial says that for acquire the frame need to use `cv::VideoCapture::read` but the code example uses wrong member function `cv::VideoCapture::open`.