### PR TITLE
Update to libtiff 4.0.10

### DIFF
--- a/3rdparty/libtiff/CMakeLists.txt
+++ b/3rdparty/libtiff/CMakeLists.txt
@@ -414,10 +414,11 @@ set(lib_srcs
     tif_tile.c
     tif_version.c
     tif_warning.c
+    tif_webp.c
     tif_write.c
     tif_zip.c
+    tif_zstd.c
     tif_stream.cxx
-    snprintf.c
     t4.h
     tif_dir.h
     tif_fax3.h
@@ -432,6 +433,10 @@ set(lib_srcs
     "${CMAKE_CURRENT_BINARY_DIR}/tiffconf.h"
     )
 
+if(WIN32 AND NOT HAVE_SNPRINTF)
+  list(APPEND lib_srcs snprintf.c libport.h)
+endif()
+
 if(WIN32 AND NOT WINRT)
   list(APPEND lib_srcs tif_win32.c)
 else()
@@ -444,7 +449,7 @@ ocv_warnings_disable(CMAKE_C_FLAGS -Wno-unused-but-set-variable -Wmissing-protot
                                    -Wimplicit-fallthrough
 )
 ocv_warnings_disable(CMAKE_C_FLAGS -Wunused-parameter) # clang
-ocv_warnings_disable(CMAKE_CXX_FLAGS -Wmissing-declarations -Wunused-parameter
+ocv_warnings_disable(CMAKE_CXX_FLAGS -Wmissing-declarations -Wunused-parameter -Wmissing-prototypes
     -Wundef  # tiffiop.h: #if __clang_major__ >= 4
 )
 ocv_warnings_disable(CMAKE_CXX_FLAGS /wd4018 /wd4100 /wd4127 /wd4311 /wd4701 /wd4706) # vs2005

--- a/3rdparty/libtiff/ChangeLog
+++ b/3rdparty/libtiff/ChangeLog
@@ -1,3 +1,3018 @@
+2018-11-10  Bob Friesenhahn  <bfriesen@simple.dallas.tx.us>
+
+	* configure.ac: libtiff 4.0.10 released.
+
+	Change COMPRESSION_ZSTD to 50000 and COMPRESSION_WEBP to 50001.
+
+2018-11-04  Bob Friesenhahn  <bfriesen@simple.dallas.tx.us>
+
+	Added preliminary release notes for release 4.0.10.
+
+2018-11-03  Bob Friesenhahn  <bfriesen@simple.dallas.tx.us>
+
+	tiff2pdf: Eliminate compiler warning about snprintf output truncation when formatting pdf_datetime.
+
+2018-11-03  Olivier Paquet  <olivier.paquet@gmail.com>
+
+	Merge branch 'no_tif_platform_console' into 'master'
+	Remove builtin support for GUI warning and error message boxes
+
+	See merge request libtiff/libtiff!24
+
+2018-11-03  Bob Friesenhahn  <bfriesen@simple.dallas.tx.us>
+
+	tiffcrop.c: Eliminate compiler warning about snprintf output truncation when formatting filenum.
+
+	TWebPVGetField(): Add apparently missing break statement impacting TIFFTAG_WEBP_LOSSLESS.
+
+	Eliminate compiler warnings about duplicate definitions of streq/strneq macros.
+
+	Ignore generated files.
+
+	Remove and ignore files which are a product of autogen.sh.
+
+2018-11-02  Bob Friesenhahn  <bfriesen@simple.dallas.tx.us>
+
+	Fix TIFFErrorExt() formatting of size_t type for 32-bit compiles.
+
+2018-10-30  Even Rouault  <even.rouault@spatialys.com>
+
+	tiff2bw: avoid null pointer dereference in case of out of memory situation. Fixes http://bugzilla.maptools.org/show_bug.cgi?id=2819 / CVE-2018-18661
+
+	tiffio.h: fix comment.
+
+2018-10-26  Even Rouault  <even.rouault@spatialys.com>
+
+	Merge branch 'header2' into 'master'
+	Fix 725279bd: Standalone tif_predict.h: tiff.h should be tiffiop.h
+
+	See merge request libtiff/libtiff!41
+
+2018-10-26  Kurt Schwehr  <schwehr@google.com>
+
+	Fix 725279bd: Standalone tif_predict.h: tiff.h should be tiffiop.h.
+
+2018-10-25  Even Rouault  <even.rouault@spatialys.com>
+
+	Merge branch 'headers' into 'master'
+	Add includes to headers to allow them to stand alone.
+
+	See merge request libtiff/libtiff!40
+
+2018-10-24  Kurt Schwehr  <schwehr@google.com>
+
+	Add includes to headers to allow them to stand alone.
+	This allows compilers that can do header stand alone header parsing
+	to process libtiff.
+
+2018-10-18  Even Rouault  <even.rouault@spatialys.com>
+
+	LZMAPreEncode: emit verbose error if lzma_stream_encoder() fails (typically because not enough memory available)
+
+2018-10-17  Even Rouault  <even.rouault@spatialys.com>
+
+	tif_webp.c: fix previous commit that broke scanline decoding.
+
+	tif_webp.c: fix potential read outside libwebp buffer on corrupted images
+
+2018-10-14  Even Rouault  <even.rouault@spatialys.com>
+
+	Merge branch 'jbig_decode_overflow' into 'master'
+	JBIG: fix potential out-of-bounds write in JBIGDecode()
+
+	See merge request libtiff/libtiff!38
+
+2018-10-14  Even Rouault  <even.rouault@spatialys.com>
+
+	JBIG: fix potential out-of-bounds write in JBIGDecode()
+	JBIGDecode doesn't check if the user provided buffer is large enough
+	to store the JBIG decoded image, which can potentially cause out-of-bounds
+	write in the buffer.
+	This issue was reported and analyzed by Thomas Dullien.
+
+	Also fixes a (harmless) potential use of uninitialized memory when
+	tif->tif_rawsize > tif->tif_rawcc
+
+	And in case libtiff is compiled with CHUNKY_STRIP_READ_SUPPORT, make sure
+	that whole strip data is provided to JBIGDecode()
+
+2018-10-05  Even Rouault  <even.rouault@spatialys.com>
+
+	tif_webp.c: fix scanline reading/writing.
+
+	WEBP codec: initialize nSamples in TWebPSetupDecode() and TWebPSetupEncode()
+
+2018-10-05  Even Rouault  <even.rouault@spatialys.com>
+
+	Merge branch 'tif_webp' into 'master'
+	webp support
+
+	See merge request libtiff/libtiff!32
+
+2018-10-05  Norman Barker  <norman.barker@mapbox.com>
+
+	webp in tiff.
+
+2018-09-17  Even Rouault  <even.rouault@spatialys.com>
+
+	Merge branch 'master' into 'master'
+	fix three potential vulnerabilities.
+
+	See merge request libtiff/libtiff!33
+
+2018-09-08  Young_X  <YangX92@hotmail.com>
+
+	fix out-of-bound read on some tiled images.
+
+	avoid potential int32 overflows in multiply_ms()
+
+	only read/write TIFFTAG_GROUP3OPTIONS or TIFFTAG_GROUP4OPTIONS if compression is COMPRESSION_CCITTFAX3 or COMPRESSION_CCITTFAX4
+
+2018-08-15  Even Rouault  <even.rouault@spatialys.com>
+
+	TIFFSetupStrips(): avoid potential uint32 overflow on 32-bit systems with large number of strips. Probably relates to http://bugzilla.maptools.org/show_bug.cgi?id=2788 / CVE-2018-10779
+
+2018-08-07  Even Rouault  <even.rouault@spatialys.com>
+
+	ZSTD: fix flush issue that can cause endless loop in ZSTDEncode()
+	Fixes https://github.com/OSGeo/gdal/issues/833
+
+2018-08-07  Even Rouault  <even.rouault@spatialys.com>
+
+	Merge branch 'fix_bug_2800' into 'master'
+	Fix libtiff 4.0.8 regression when reading LZW-compressed strips with scanline API
+
+	See merge request libtiff/libtiff!31
+
+2018-08-07  Even Rouault  <even.rouault@spatialys.com>
+
+	Fix libtiff 4.0.8 regression when reading LZW-compressed strips with scanline API
+	Fixes http://bugzilla.maptools.org/show_bug.cgi?id=2800
+
+2018-07-05  Even Rouault  <even.rouault@spatialys.com>
+
+	Add tag and pseudo-tag definitions for ESRI LERC codec (out of tree codec whose source is at https://github.com/OSGeo/gdal/blob/master/gdal/frmts/gtiff/tif_lerc.c)
+
+2018-07-02  Even Rouault  <even.rouault@spatialys.com>
+
+	Fix TIFFTAG_ZSTD_LEVEL pseudo tag value to be > 65536, and the next one in the series
+
+2018-05-25  Stefan Weil  <sw@weilnetz.de>
+
+	Remove builtin support for GUI warning and error message boxes.
+	Now warnings always go to the console by default unless applications
+	define their own warning and error handlers.
+
+	GUI applications (and Windows CE) are required to define such handlers.
+
+2018-05-12  Even Rouault  <even.rouault@spatialys.com>
+
+	LZWDecodeCompat(): fix potential index-out-of-bounds write. Fixes http://bugzilla.maptools.org/show_bug.cgi?id=2780 / CVE-2018-8905
+	The fix consists in using the similar code LZWDecode() to validate we
+	don't write outside of the output buffer.
+
+	TIFFFetchNormalTag(): avoid (probably false positive) clang-tidy clang-analyzer-core.NullDereference warnings
+
+	TIFFWriteDirectorySec: avoid assertion. Fixes http://bugzilla.maptools.org/show_bug.cgi?id=2795. CVE-2018-10963
+
+2018-05-04  Even Rouault  <even.rouault@spatialys.com>
+
+	tif_color.c: fix code comment.
+
+2018-04-17  Even Rouault  <even.rouault@mines-paris.org>
+
+	Merge branch 'fuzzer-fix' into 'master'
+	remove a pointless multiplication and a variable that's not necessary
+
+	See merge request libtiff/libtiff!29
+
+2018-04-17  Paul Kehrer  <paul.l.kehrer@gmail.com>
+
+	remove a pointless multiplication and a variable that's not necessary.
+
+2018-04-17  Even Rouault  <even.rouault@mines-paris.org>
+
+	Merge branch 'ossfuzz' into 'master'
+	move oss-fuzz build script and fuzzer into libtiff tree
+
+	See merge request libtiff/libtiff!28
+
+2018-04-17  Paul Kehrer  <paul.l.kehrer@gmail.com>
+
+	move oss-fuzz build script and fuzzer into libtiff tree.
+
+2018-04-14  Even Rouault  <even.rouault@spatialys.com>
+
+	_TIFFGetMaxColorChannels: update for LOGLUV, ITULAB and ICCLAB that have 3 color channels
+
+2018-04-12  Even Rouault  <even.rouault@spatialys.com>
+
+	Fix MSVC warning.
+
+2018-04-12  Even Rouault  <even.rouault@mines-paris.org>
+
+	Merge branch 'master' into 'master'
+	Fix NULL pointer dereference in TIFFPrintDirectory (bugzilla 2778/CVE-2018-7456)
+
+	See merge request libtiff/libtiff!27
+
+2018-04-11  Hugo Lefeuvre  <hle@debian.org>
+
+	Fix NULL pointer dereference in TIFFPrintDirectory.
+	The TIFFPrintDirectory function relies on the following assumptions,
+	supposed to be guaranteed by the specification:
+
+	(a) A Transfer Function field is only present if the TIFF file has
+	    photometric type < 3.
+
+	(b) If SamplesPerPixel > Color Channels, then the ExtraSamples field
+	    has count SamplesPerPixel - (Color Channels) and contains
+	    information about supplementary channels.
+
+	While respect of (a) and (b) are essential for the well functioning of
+	TIFFPrintDirectory, no checks are realized neither by the callee nor
+	by TIFFPrintDirectory itself. Hence, following scenarios might happen
+	and trigger the NULL pointer dereference:
+
+	(1) TIFF File of photometric type 4 or more has illegal Transfer
+	    Function field.
+
+	(2) TIFF File has photometric type 3 or less and defines a
+	    SamplesPerPixel field such that SamplesPerPixel > Color Channels
+	    without defining all extra samples in the ExtraSamples fields.
+
+	In this patch, we address both issues with respect of the following
+	principles:
+
+	(A) In the case of (1), the defined transfer table should be printed
+	    safely even if it isn't 'legal'. This allows us to avoid expensive
+	    checks in TIFFPrintDirectory. Also, it is quite possible that
+	    an alternative photometric type would be developed (not part of the
+	    standard) and would allow definition of Transfer Table. We want
+	    libtiff to be able to handle this scenario out of the box.
+
+	(B) In the case of (2), the transfer table should be printed at its
+	    right size, that is if TIFF file has photometric type Palette
+	    then the transfer table should have one row and not three, even
+	    if two extra samples are declared.
+
+	In order to fulfill (A) we simply add a new 'i < 3' end condition to
+	the broken TIFFPrintDirectory loop. This makes sure that in any case
+	where (b) would be respected but not (a), everything stays fine.
+
+	(B) is fulfilled by the loop condition
+	'i < td->td_samplesperpixel - td->td_extrasamples'. This is enough as
+	long as (b) is respected.
+
+	Naturally, we also make sure (b) is respected. This is done in the
+	TIFFReadDirectory function by making sure any non-color channel is
+	counted in ExtraSamples.
+
+	This commit addresses CVE-2018-7456.
+
+2018-03-27  Even Rouault  <even.rouault@mines-paris.org>
+
+	Merge branch 'tiffset-long8' into 'master'
+	tiffset: Add support for LONG8, SLONG8 and IFD8 field types
+
+	See merge request libtiff/libtiff!25
+
+2018-03-26  Roger Leigh  <rleigh@codelibre.net>
+
+	port: Clean up NetBSD sources and headers to build standalone.
+
+2018-03-23  Roger Leigh  <rleigh@dundee.ac.uk>
+
+	port: Add strtol, strtoll and strtoull.
+	Also update strtoul.  All use the same implementation from NetBSD libc.
+
+	tiffset: Add support for LONG8, SLONG8 and IFD8 field types.
+
+2018-03-17  Even Rouault  <even.rouault@spatialys.com>
+
+	ChopUpSingleUncompressedStrip: avoid memory exhaustion (CVE-2017-11613)
+	Rework fix done in 3719385a3fac5cfb20b487619a5f08abbf967cf8 to work in more
+	cases like https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=6979.
+	Credit to OSS Fuzz
+
+	Fixes http://bugzilla.maptools.org/show_bug.cgi?id=2724
+
+2018-03-13  Even Rouault  <even.rouault@spatialys.com>
+
+	libtiff/tif_luv.c: rewrite loops in a more readable way (to avoid false positive reports like http://bugzilla.maptools.org/show_bug.cgi?id=2779)
+
+2018-03-13  Even Rouault  <even.rouault@mines-paris.org>
+
+	Merge branch 'avoid_memory_exhaustion_in_ChopUpSingleUncompressedStrip' into 'master'
+	ChopUpSingleUncompressedStrip: avoid memory exhaustion (CVE-2017-11613)
+
+	See merge request libtiff/libtiff!26
+
+2018-03-11  Even Rouault  <even.rouault@spatialys.com>
+
+	ChopUpSingleUncompressedStrip: avoid memory exhaustion (CVE-2017-11613)
+	In ChopUpSingleUncompressedStrip(), if the computed number of strips is big
+	enough and we are in read only mode, validate that the file size is consistent
+	with that number of strips to avoid useless attempts at allocating a lot of
+	memory for the td_stripbytecount and td_stripoffset arrays.
+
+	Fixes http://bugzilla.maptools.org/show_bug.cgi?id=2724
+
+2018-03-10  Even Rouault  <even.rouault@spatialys.com>
+
+	Typo fix in comment.
+
+2018-03-03  Even Rouault  <even.rouault@spatialys.com>
+
+	Avoid warning with gcc 8 (partially revert 647b0e8c11ee11896f319b92cf110775f538d75c)
+
+2018-02-25  Even Rouault  <even.rouault@mines-paris.org>
+
+	Merge branch 'typos' into 'master'
+	Fix some typos
+
+	See merge request libtiff/libtiff!23
+
+2018-02-24  Stefan Weil  <sw@weilnetz.de>
+
+	Fix some typos.
+	Most of them were found by codespell.
+
+2018-02-14  Even Rouault  <even.rouault@spatialys.com>
+
+	Typo fix in comment.
+
+	Merge branch 'zstd'
+
+	Add warning about COMPRESSION_ZSTD not being officialy registered.
+
+2018-02-14  Even Rouault  <even.rouault@mines-paris.org>
+
+	Merge branch 'bug2772' into 'master'
+	Fix for bug 2772
+
+	See merge request libtiff/libtiff!20
+
+2018-02-12  Nathan Baker  <nathanb@lenovo-chrome.com>
+
+	Fix for bug 2772.
+	It is possible to craft a TIFF document where the IFD list is circular,
+	leading to an infinite loop while traversing the chain. The libtiff
+	directory reader has a failsafe that will break out of this loop after
+	reading 65535 directory entries, but it will continue processing,
+	consuming time and resources to process what is essentially a bogus TIFF
+	document.
+
+	This change fixes the above behavior by breaking out of processing when
+	a TIFF document has >= 65535 directories and terminating with an error.
+
+2018-02-09  Even Rouault  <even.rouault@mines-paris.org>
+
+	Merge branch 'libtiff-as-subdirectory-fixes' into 'master'
+	Prefer target_include_directories
+
+	See merge request libtiff/libtiff!12
+
+2018-02-06  Even Rouault  <even.rouault@mines-paris.org>
+
+	Merge branch 'cmake-cleanups' into 'master'
+	Cmake cleanups
+
+	See merge request libtiff/libtiff!11
+
+2018-02-06  Even Rouault  <even.rouault@mines-paris.org>
+
+	Merge branch 'check-right-cxx-variable' into 'master'
+	Check right cxx variable
+
+	See merge request libtiff/libtiff!19
+
+2018-02-06  Even Rouault  <even.rouault@mines-paris.org>
+
+	Merge branch 'dont-leak-stream-open' into 'master'
+	Fix a memory leak in TIFFStreamOpen
+
+	See merge request libtiff/libtiff!17
+
+2018-02-06  Ben Boeckel  <ben.boeckel@kitware.com>
+
+	cmake: check CXX_SUPPORT.
+	This variable is set in response to the `cxx` cache variable; use it
+	instead.
+
+2018-02-04  Olivier Paquet  <olivier.paquet@gmail.com>
+
+	Merge branch 'warnings' into 'master'
+	Fix all compiler warnings for default build
+
+	See merge request libtiff/libtiff!16
+
+2018-02-04  Nathan Baker  <elitebadger@gmail.com>
+
+	Fix all compiler warnings for default build.
+
+2018-01-30  Paul Kehrer  <paul.l.kehrer@gmail.com>
+
+	tabs are hard.
+
+2018-01-29  Paul Kehrer  <paul.l.kehrer@gmail.com>
+
+	use hard tabs like the rest of the project.
+
+	Fix a memory leak in TIFFStreamOpen.
+	TIFFStreamOpen allocates a new tiff{o,i}s_data, but if TIFFClientOpen
+	fails then that struct is leaked. Delete it if the returned TIFF * is
+	null.
+
+2018-01-29  Kevin Funk  <kfunk@kde.org>
+
+	Bump minimum required CMake version to v2.8.11.
+	Because we use the BUILD_INTERFACE generator expression
+
+2018-01-27  Even Rouault  <even.rouault@mines-paris.org>
+
+	Merge branch 'patch-1' into 'master'
+	Update CMakeLists.txt for build fix on Windows
+
+	See merge request libtiff/libtiff!14
+
+2018-01-27  Even Rouault  <even.rouault@mines-paris.org>
+
+	Merge branch 'patch-2' into 'master'
+	Update tiffgt.c for build fix on Windows
+
+	See merge request libtiff/libtiff!13
+
+2018-01-25  Olivier Paquet  <olivier.paquet@gmail.com>
+
+	Merge branch 'bug2750' into 'master'
+	Add workaround to pal2rgb buffer overflow.
+
+	See merge request libtiff/libtiff!15
+
+2018-01-25  Nathan Baker  <elitebadger@gmail.com>
+
+	Add workaround to pal2rgb buffer overflow.
+
+2018-01-23  Andrea  <andrea@andreaplanet.com>
+
+	Update tiffgt.c for build fix on Windows.
+
+	Update CMakeLists.txt for build fix on Windows.
+
+2018-01-15  Even Rouault  <even.rouault@mines-paris.org>
+
+	Merge branch 'has-attribute-check' into 'master'
+	tiffiop: use __has_attribute to detect the no_sanitize attribute
+
+	See merge request libtiff/libtiff!10
+
+2018-01-15  Ben Boeckel  <ben.boeckel@kitware.com>
+
+	cmake: avoid setting hard-coded variables in the cache.
+
+	cmake: avoid an unnecessary intermediate variable.
+
+	cmake: avoid an unnecessary intermediate variable.
+
+	cmake: avoid tautological logic.
+
+	cmake: use check_symbol_exists.
+	This accounts for symbols being provided by macros.
+
+	cmake: remove unused configure checks.
+
+2018-01-12  Kevin Funk  <kfunk@kde.org>
+
+	Prefer target_include_directories.
+	When libtiff is included in a super project via a simple
+	`add_subdirectory(libtiff)`, this way the `tiff` library target has all
+	the necessary information to build against it.
+
+	Note: The BUILD_INTERFACE generator expression feature requires at least
+	CMake v2.8.11 if I'm correct.
+
+2018-01-09  Ben Boeckel  <ben.boeckel@kitware.com>
+
+	tiffiop: use __has_attribute to detect the no_sanitize attribute.
+
+2017-12-31  Even Rouault  <even.rouault@spatialys.com>
+
+	man/TIFFquery.3tiff: remove reference to non-existing TIFFReadStrip() function in TIFFIsByteSwapped() documentation. Patch by Eric Piel. Fixes http://bugzilla.maptools.org/show_bug.cgi?id=2763
+
+	libtiff/tif_dir.c: _TIFFVGetField(): fix heap out-of-bounds access when requesting TIFFTAG_NUMBEROFINKS on a EXIF directory. Fixes http://bugzilla.maptools.org/show_bug.cgi?id=2765. Reported by Google Autofuzz project
+
+	libtiff/tif_print.c: TIFFPrintDirectory(): fix null pointer dereference on corrupted file. Fixes http://bugzilla.maptools.org/show_bug.cgi?id=2770
+
+2017-12-21  Even Rouault  <even.rouault@spatialys.com>
+
+	Add libzstd to gitlab-ci.
+
+2017-12-21  Even Rouault  <even.rouault@spatialys.com>
+
+	Add ZSTD compression codec.
+	From https://github.com/facebook/zstd
+	"Zstandard, or zstd as short version, is a fast lossless compression
+	algorithm, targeting real-time compression scenarios at zlib-level
+	and better compression ratios. It's backed by a very fast entropy stage,
+	provided by Huff0 and FSE library."
+
+	We require libzstd >= 1.0.0 so as to be able to use streaming compression
+	and decompression methods.
+
+	The default compression level we have selected is 9 (range goes from 1 to 22),
+	which experimentally offers equivalent or better compression ratio than
+	the default deflate/ZIP level of 6, and much faster compression.
+
+	For example on a 6600x4400 16bit image, tiffcp -c zip runs in 10.7 seconds,
+	while tiffcp -c zstd runs in 5.3 seconds. Decompression time for zip is
+	840 ms, and for zstd 650 ms. File size is 42735936 for zip, and
+	42586822 for zstd. Similar findings on other images.
+
+	On a 25894x16701 16bit image,
+
+	                Compression time     Decompression time     File size
+
+	ZSTD                 35 s                   3.2 s          399 700 498
+	ZIP/Deflate       1m 20 s                   4.9 s          419 622 336
+
+2017-12-10  Even Rouault  <even.rouault@mines-paris.org>
+
+	Merge branch 'fix_cve-2017-9935' into 'master'
+	Fix CVE-2017-9935
+
+	See merge request libtiff/libtiff!7
+
+2017-12-10  Brian May  <brian@linuxpenguins.xyz>
+
+	tiff2pdf: Fix apparent incorrect type for transfer table.
+	The standard says the transfer table contains unsigned 16 bit values,
+	I have no idea why we refer to them as floats.
+
+2017-12-10  Brian May  <brian@linuxpenguins.xyz>
+
+	tiff2pdf: Fix CVE-2017-9935.
+	Fix for http://bugzilla.maptools.org/show_bug.cgi?id=2704
+
+	This vulnerability - at least for the supplied test case - is because we
+	assume that a tiff will only have one transfer function that is the same
+	for all pages. This is not required by the TIFF standards.
+
+	We than read the transfer function for every page.  Depending on the
+	transfer function, we allocate either 2 or 4 bytes to the XREF buffer.
+	We allocate this memory after we read in the transfer function for the
+	page.
+
+	For the first exploit - POC1, this file has 3 pages. For the first page
+	we allocate 2 extra extra XREF entries. Then for the next page 2 more
+	entries. Then for the last page the transfer function changes and we
+	allocate 4 more entries.
+
+	When we read the file into memory, we assume we have 4 bytes extra for
+	each and every page (as per the last transfer function we read). Which
+	is not correct, we only have 2 bytes extra for the first 2 pages. As a
+	result, we end up writing past the end of the buffer.
+
+	There are also some related issues that this also fixes. For example,
+	TIFFGetField can return uninitalized pointer values, and the logic to
+	detect a N=3 vs N=1 transfer function seemed rather strange.
+
+	It is also strange that we declare the transfer functions to be of type
+	float, when the standard says they are unsigned 16 bit values. This is
+	fixed in another patch.
+
+	This patch will check to ensure that the N value for every transfer
+	function is the same for every page. If this changes, we abort with an
+	error. In theory, we should perhaps check that the transfer function
+	itself is identical for every page, however we don't do that due to the
+	confusion of the type of the data in the transfer function.
+
+2017-12-10  Even Rouault  <even.rouault@mines-paris.org>
+
+	Merge branch 'undef-warn-fixes' into 'master'
+	Fix a couple of harmless but annoying -Wundef warnings
+
+	See merge request libtiff/libtiff!8
+
+2017-12-07  Vadim Zeitlin  <vadim@zeitlins.org>
+
+	Remove tests for undefined SIZEOF_VOIDP.
+	As configure never uses AC_CHECK_SIZEOF(void*), this symbol is never
+	defined and so it doesn't make sense to test it in the code, this just
+	results in -Wundef warnings if they're enabled.
+
+	Avoid harmless -Wundef warnings for __clang_major__
+	Check that we're using Clang before checking its version.
+
+2017-12-02  Even Rouault  <even.rouault@mines-paris.org>
+
+	Merge branch 'remove_autogenerated_files' into 'master'
+	Remove autogenerated files
+
+	See merge request libtiff/libtiff!5
+
+2017-12-02  Bob Friesenhahn  <bfriesen@simple.dallas.tx.us>
+
+	Merge branch 'tif_config_h_includes' into 'master'
+	'tif_config.h' or 'tiffiop.h' must be included before any system header.
+
+	See merge request libtiff/libtiff!6
+
+2017-12-02  Bob Friesenhahn  <bfriesen@simple.dallas.tx.us>
+
+	'tif_config.h' or 'tiffio.h' must be included before any system header.
+
+2017-12-01  Even Rouault  <even.rouault@spatialys.com>
+
+	.gitignore: add patterns for build from root.
+
+	Remove remaining .cvsignore files.
+
+	Remove autoconf/automake generated files, and add them to .gitignore.
+
+2017-12-01  Olivier Paquet  <olivier.paquet@gmail.com>
+
+	Merge branch 'makedistcheck' into 'master'
+	build/gitlab-ci and build/travis-ci: add a 'make dist' step in autoconf_build()…
+
+	See merge request libtiff/libtiff!4
+
+2017-12-01  Even Rouault  <even.rouault@spatialys.com>
+
+	build/gitlab-ci and build/travis-ci: add a 'make dist' step in autoconf_build() target, to check we are release-ready
+
+2017-12-01  Even Rouault  <even.rouault@mines-paris.org>
+
+	Merge branch 'git_updates' into 'master'
+	CVS to Git updates
+
+	See merge request libtiff/libtiff!2
+
+2017-12-01  Even Rouault  <even.rouault@spatialys.com>
+
+	HOWTO-RELEASE: update to use signed tags.
+
+	README.md: use markdown syntax for hyperlinks.
+
+2017-11-30  Even Rouault  <even.rouault@spatialys.com>
+
+	Add .gitignore.
+
+	Regenerate autoconf files.
+
+	Makefile.am: update to reflect removal of README.vms and README -> README.md
+
+	Remove all $Id and $Headers comments with CVS versions.
+
+	HOWTO-RELEASE: update for git.
+
+	Remove outdated .cvsignore.
+
+	Remove outdated commit script.
+
+	Remove README.vms.
+
+	Rename README as README.md, and update content.
+
+	html/index.html: reflect change from CVS to gitlab.
+
+2017-11-30  Olivier Paquet  <olivier.paquet@gmail.com>
+
+	Merge branch 'test-ci' into 'master'
+	Update CI configuration
+
+	See merge request libtiff/libtiff!1
+
+2017-11-23  Roger Leigh  <rleigh@codelibre.net>
+
+	appveyor: Correct path for git clone and skip artefact archival.
+
+2017-11-22  Roger Leigh  <rleigh@codelibre.net>
+
+	travis-ci: Remove unused matrix exclusion.
+
+	Add gitlab-ci build support.
+
+2017-11-18  Bob Friesenhahn  <bfriesen@simple.dallas.tx.us>
+
+	* configure.ac: libtiff 4.0.9 released.
+
+	* html/v4.0.9.html: Add HTML file to document changes in libtiff
+	v4.0.9.
+
+2017-11-17  Even Rouault <even.rouault at spatialys.com>
+
+	* libtiff/tif_aux.c, tif_getimage.c, tif_read.c: typo fixes in
+	comments.
+
+2017-11-02  Bob Friesenhahn  <bfriesen@simple.dallas.tx.us>
+
+	* test/Makefile.am: Add some tests for tiff2bw.
+
+2017-11-01  Bob Friesenhahn  <bfriesen@simple.dallas.tx.us>
+
+	* tools/tiff2bw.c (main): Free memory allocated in the tiff2bw
+	program.  This is in response to the report associated with
+	CVE-2017-16232 but does not solve the extremely high memory usage
+	with the associated POC file.
+
+2017-10-29  Bob Friesenhahn  <bfriesen@simple.dallas.tx.us>
+
+	* tools/tiff2pdf.c (t2p_sample_realize_palette): Fix possible
+	arithmetic overflow in bounds checking code and eliminate
+	comparison between signed and unsigned type.
+
+	* tools/fax2tiff.c (_FAX_Client_Data): Pass FAX_Client_Data as the
+	client data.  This client data is not used at all at the moment,
+	but it makes the most sense.  Issue that the value of
+	client_data.fd was passed where a pointer is expected was reported
+	via email by Gerald Schade on Sun, 29 Oct 2017.
+
+2017-10-23  Even Rouault <even.rouault at spatialys.com>
+
+	* libtiff/tif_getimage.c: avoid floating point division by zero in
+	initCIELabConversion()
+	Fixes https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=3733
+	Credit to OSS Fuzz
+
+2017-10-17  Even Rouault <even.rouault at spatialys.com>
+
+	* libtiff/tif_jpeg.c: add compatibility with libjpeg-turbo 1.5.2 that
+	honours max_memory_to_use > 0.
+	Cf https://github.com/libjpeg-turbo/libjpeg-turbo/issues/162
+
+2017-10-10  Even Rouault <even.rouault at spatialys.com>
+
+	* nmake.opt: support a DEBUG=1 option, so as to adjust OPTFLAGS and use
+	/MDd runtime in debug mode.
+
+2017-10-01  Even Rouault <even.rouault at spatialys.com>
+
+	* tools/tiffset.c: fix setting a single value for the ExtraSamples tag
+	(and other tags with variable number of values).
+	So 'tiffset -s ExtraSamples 1 X'. This only worked
+	when setting 2 or more values, but not just one.
+
+2017-09-29  Even Rouault <even.rouault at spatialys.com>
+
+	* libtiff/libtiff.def: add TIFFReadRGBAStripExt and TIFFReadRGBATileExt
+	Fixes http://bugzilla.maptools.org/show_bug.cgi?id=2735
+
+2017-09-09  Even Rouault <even.rouault at spatialys.com>
+
+	* libtiff/tif_dirread.c: add NULL check to avoid likely false positive
+	null-pointer dereference warning by CLang Static Analyzer. 
+
+2017-09-07  Even Rouault <even.rouault at spatialys.com>
+
+	* libtiff/tiffiop.h, tif_aux.c: redirect SeekOK() macro to a _TIFFSeekoK()
+	function that checks if the offset is not bigger than INT64_MAX, so as
+	to avoid a -1 error return code of TIFFSeekFile() to match a required
+	seek to UINT64_MAX/-1.
+	Fixes http://bugzilla.maptools.org/show_bug.cgi?id=2726
+	Adapted from proposal by Nicolas Ruff.
+
+2017-08-29  Even Rouault <even.rouault at spatialys.com>
+
+	* libtiff/tif_jpeg.c: accept reading the last strip of a JPEG compressed
+	file if the codestream height is larger than the truncated height of the
+	strip. Emit a warning in this situation since this is non compliant.
+
+2017-08-28  Even Rouault <even.rouault at spatialys.com>
+
+	* test/Makefile.am: add missing reference to images/quad-lzw-compat.tiff
+	to fix "make distcheck". Patch by Roger Leigh
+
+2017-08-23  Even Rouault <even.rouault at spatialys.com>
+
+	* libtiff/tif_dirwrite.c: replace assertion to tag value not fitting
+	on uint32 when selecting the value of SubIFD tag by runtime check
+	(in TIFFWriteDirectoryTagSubifd()).
+	Fixes http://bugzilla.maptools.org/show_bug.cgi?id=2728
+	Reported by team OWL337
+
+2017-08-23  Even Rouault <even.rouault at spatialys.com>
+
+	* libtiff/tif_dirwrite.c: replace assertion related to not finding the
+	SubIFD tag by runtime check (in TIFFWriteDirectorySec())
+	Fixes http://bugzilla.maptools.org/show_bug.cgi?id=2727
+	Reported by team OWL337
+
+2017-07-24  Even Rouault <even.rouault at spatialys.com>
+
+	* libtiff/tif_luv.c: further reduce memory requirements for temporary
+	buffer when RowsPerStrip >= image_length in LogLuvInitState() and
+	LogL16InitState().
+	Fixes https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=2700
+	Credit to OSS Fuzz
+
+2017-07-24  Even Rouault <even.rouault at spatialys.com>
+
+	* libtiff/tif_getimage.c: fix fromskew computation when to-be-skipped
+	pixel number is not a multiple of the horizontal subsampling, and
+	also in some other cases. Impact putcontig8bitYCbCr44tile,
+	putcontig8bitYCbCr42tile, putcontig8bitYCbCr41tile,
+	putcontig8bitYCbCr21tile and putcontig8bitYCbCr12tile
+	Fixes http://bugzilla.maptools.org/show_bug.cgi?id=2637 (discovered
+	by Agostino Sarubbo)
+	and https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=2691 (credit
+	to OSS Fuzz)
+
+2017-07-24  Even Rouault <even.rouault at spatialys.com>
+
+	* libtiff/tif_getimage.c: gtTileContig() and gtTileSeparate():
+	properly break from loops on error when stoponerr is set, instead
+	of going on iterating on row based loop.
+
+2017-07-18  Even Rouault <even.rouault at spatialys.com>
+
+	* libtiff/tif_luv.c: LogLuvInitState(): avoid excessive memory
+	allocation when RowsPerStrip tag is missing.
+	Fixes https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=2683
+	Credit to OSS-Fuzz
+
+2017-07-15  Even Rouault <even.rouault at spatialys.com>
+
+	* libtiff/tif_read.c: add protection against excessive memory
+	allocation attempts in TIFFReadDirEntryArray() on short files.
+	Effective for mmap'ed case. And non-mmap'ed case, but restricted
+	to 64bit builds.
+	Fixes http://bugzilla.maptools.org/show_bug.cgi?id=2675
+
+2017-07-15  Even Rouault <even.rouault at spatialys.com>
+
+	* libtiff/tif_read.c: in TIFFFetchStripThing(), only grow the
+	arrays that hold StripOffsets/StripByteCounts, when they are smaller
+	than the expected number of striles, up to 1 million striles, and
+	error out beyond. Can be tweaked by setting the environment variable
+	LIBTIFF_STRILE_ARRAY_MAX_RESIZE_COUNT.
+	This partially goes against a change added on 2002-12-17 to accept
+	those arrays of wrong sizes, but is needed to avoid denial of services.
+	Fixes https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=2350
+	Credit to OSS Fuzz
+
+2017-07-15  Even Rouault <even.rouault at spatialys.com>
+
+	* libtiff/tif_read.c: TIFFFillStrip() / TIFFFillTile().
+	Complementary fix for http://bugzilla.maptools.org/show_bug.cgi?id=2708
+	in the isMapped() case, so as to avoid excessive memory allocation
+	when we need a temporary buffer but the file is truncated.
+
+2017-07-15  Even Rouault <even.rouault at spatialys.com>
+
+	* tools/tiff2pdf.c: prevent heap buffer overflow write in "Raw"
+	mode on PlanarConfig=Contig input images.
+	Fixes http://bugzilla.maptools.org/show_bug.cgi?id=2715
+	Reported by team OWL337
+
+2017-07-11  Even Rouault <even.rouault at spatialys.com>
+
+	* libtiff/tif_dir.c: avoid potential null pointer dereference in
+	_TIFFVGetField() on corrupted TIFFTAG_NUMBEROFINKS tag instance.
+	Fixes http://bugzilla.maptools.org/show_bug.cgi?id=2713
+
+2017-07-11  Even Rouault <even.rouault at spatialys.com>
+
+	* libtiff/tif_lzw.c: fix potential out-of-buffer read on 1-byte LZW
+	strips. Crashing issue only on memory mapped files, where the strip
+	offset is the last byte of the file, and the file size is a multiple
+	of one page size on the CPU architecture (typically 4096). Credit
+	to myself :-)
+
+2017-07-11  Even Rouault <even.rouault at spatialys.com>
+
+	* test/tiffcp-lzw-compat.sh, test/images/quad-lzw-compat.tiff: new files
+	to test old-style LZW decompression
+	* test/common.sh, Makefile.am, CMakeList.txt: updated with above
+
+2017-07-11  Even Rouault <even.rouault at spatialys.com>
+
+	* refresh autoconf/make stuff with what is on Ubuntu 16.04 (minor changes)
+
+2017-07-11  Even Rouault <even.rouault at spatialys.com>
+
+	* libtiff/tif_lzw.c: fix 4.0.8 regression in the decoding of old-style LZW
+	compressed files.
+
+2017-07-10  Even Rouault <even.rouault at spatialys.com>
+
+	* libtiff/tif_pixarlog.c: avoid excessive memory allocation on decoding
+	when RowsPerStrip tag is not defined (and thus td_rowsperstrip == UINT_MAX)
+	Fixes https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=2554
+	Credit to OSS Fuzz
+
+2017-07-04  Even Rouault <even.rouault at spatialys.com>
+
+	* libtiff/tif_read.c, tiffiop.h: add a _TIFFReadEncodedTileAndAllocBuffer()
+	and _TIFFReadTileAndAllocBuffer() variants of TIFFReadEncodedTile() and
+	TIFFReadTile() that allocates the decoded buffer only after a first
+	successful TIFFFillTile(). This avoids excessive memory allocation
+	on corrupted files.
+	* libtiff/tif_getimage.c: use _TIFFReadTileAndAllocBuffer().
+	Fixes https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=2470
+	Credit to OSS Fuzz.
+
+2017-07-04  Even Rouault <even.rouault at spatialys.com>
+
+	* libtiff/tif_error.c, tif_warning.c: correctly use va_list when both
+	an old-style and new-style warning/error handlers are installed.
+	Patch by Paavo Helde (sent on the mailing list)
+
+2017-07-02  Even Rouault <even.rouault at spatialys.com>
+
+	* libtiff/tif_read.c: TIFFStartTile(): set tif_rawcc to
+	tif_rawdataloaded when it is set. Similarly to TIFFStartStrip().
+	This issue was revealed by the change of 2017-06-30 in TIFFFileTile(),
+	limiting the number of bytes read. But it could probably have been hit
+	too in CHUNKY_STRIP_READ_SUPPORT mode previously ?
+	Fixes https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=2454
+	Credit to OSS Fuzz
+
+2017-06-30  Even Rouault <even.rouault at spatialys.com>
+
+	* man: update documentation regarding SubIFD tag and
+	TIFFSetSubDirectory() data type.
+	Patch by Eric Piel
+	Fixes http://bugzilla.maptools.org/show_bug.cgi?id=2671
+
+2017-06-30  Even Rouault <even.rouault at spatialys.com>
+
+	* libtiff/tif_dirwrite.c: in TIFFWriteDirectoryTagCheckedXXXX()
+	functions associated with LONG8/SLONG8 data type, replace assertion that
+	the file is BigTIFF, by a non-fatal error.
+	Fixes http://bugzilla.maptools.org/show_bug.cgi?id=2712
+	Reported by team OWL337
+
+2017-06-30  Even Rouault <even.rouault at spatialys.com>
+
+	* libtiff/tif_read.c, tiffiop.h: add a _TIFFReadEncodedStripAndAllocBuffer()
+	function, variant of TIFFReadEncodedStrip() that allocates the
+	decoded buffer only after a first successful TIFFFillStrip(). This avoids
+	excessive memory allocation on corrupted files.
+	* libtiff/tif_getimage.c: use _TIFFReadEncodedStripAndAllocBuffer(). 
+	Fixes http://bugzilla.maptools.org/show_bug.cgi?id=2708 and
+	https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=2433 .
+	Credit to OSS Fuzz
+
+2017-06-30  Even Rouault <even.rouault at spatialys.com>
+
+	* libtiff/tif_read.c: TIFFFillTile(): add limitation to the number
+	of bytes read in case td_stripbytecount[strip] is bigger than
+	reasonable, so as to avoid excessive memory allocation (similarly to
+	what was done for TIFFFileStrip() on 2017-05-10)
+
+2017-06-29  Even Rouault <even.rouault at spatialys.com>
+
+	* libtiff/tiffiop.h, libtiff/tif_jpeg.c, libtiff/tif_jpeg_12.c,
+	libtiff/tif_read.c: make TIFFReadScanline() works in
+	CHUNKY_STRIP_READ_SUPPORT mode with JPEG stream with multiple scans.
+	Also make configurable through a LIBTIFF_JPEG_MAX_ALLOWED_SCAN_NUMBER
+	environment variable the maximum number of scans allowed. Defaults to
+	100.
+
+2017-06-27  Even Rouault <even.rouault at spatialys.com>
+
+	* libtiff/tif_dirread.c: in TIFFReadDirEntryFloat(), check that a
+	double value can fit in a float before casting. Patch by Nicolas RUFF
+
+2017-06-26  Even Rouault <even.rouault at spatialys.com>
+
+	* libtiff/tif_jbig.c: fix memory leak in error code path of JBIGDecode()
+	Fixes http://bugzilla.maptools.org/show_bug.cgi?id=2706
+	Reported by team OWL337
+
+2017-06-24  Even Rouault <even.rouault at spatialys.com>
+
+	* libtiff/tif_jpeg.c: error out at decoding time if anticipated libjpeg
+	memory allocation is above 100 MB. libjpeg in case of multiple scans,
+	which is allowed even in baseline JPEG, if components are spread over several
+	scans and not interleavedin a single one, needs to allocate memory (or
+	backing store) for the whole strip/tile.
+	See http://www.libjpeg-turbo.org/pmwiki/uploads/About/TwoIssueswiththeJPEGStandard.pdf
+	This limitation may be overriden by setting the 
+	LIBTIFF_ALLOW_LARGE_LIBJPEG_MEM_ALLOC environment variable, or recompiling
+	libtiff with a custom value of TIFF_LIBJPEG_LARGEST_MEM_ALLOC macro.
+
+2017-06-24  Even Rouault <even.rouault at spatialys.com>
+
+	* libtiff/tif_jpeg.c: add anti-denial of service measure to avoid excessive
+	CPU consumption on progressive JPEGs with a huge number of scans.
+	See http://www.libjpeg-turbo.org/pmwiki/uploads/About/TwoIssueswiththeJPEGStandard.pdf
+	Note: only affects libtiff since 2014-12-29 where support of non-baseline JPEG
+	was added.
+
+2017-06-18  Even Rouault <even.rouault at spatialys.com>
+
+	* libtiff/tiffiop.h: add TIFF_NOSANITIZE_UNSIGNED_INT_OVERFLOW macro to
+	disable CLang warnings raised by -fsanitize=undefined,unsigned-integer-overflow
+	* libtiff/tif_predict.c: decorate legitimate functions where unsigned int
+	overflow occur with TIFF_NOSANITIZE_UNSIGNED_INT_OVERFLOW
+	* libtiff/tif_dirread.c: avoid unsigned int overflow in EstimateStripByteCounts()
+	and BYTECOUNTLOOKSBAD when file is too short.
+	* libtiff/tif_jpeg.c: avoid (harmless) unsigned int overflow on tiled images.
+	* libtiff/tif_fax3.c: avoid unsigned int overflow in Fax3Encode2DRow(). Could
+	potentially be a bug with huge rows.
+	* libtiff/tif_getimage.c: avoid many (harmless) unsigned int overflows.
+
+2017-06-12  Even Rouault <even.rouault at spatialys.com>
+
+	* libtiff/tif_dirread.c: TIFFFetchStripThing(): limit the number of items
+	read in StripOffsets/StripByteCounts tags to the number of strips to avoid
+	excessive memory allocation.
+	Fixes https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=2215
+	Credit to OSS Fuzz
+
+2017-06-12  Even Rouault <even.rouault at spatialys.com>
+
+	* libtiff/tif_dirread.c: fix regression of libtiff 4.0.8 in
+	ChopUpSingleUncompressedStrip() regarding update of newly single-strip
+	uncompressed files whose bytecount is 0. Before the change of 2016-12-03,
+	the condition bytecount==0 used to trigger an early exit/disabling of
+	strip chop. Re-introduce that in update mode. Otherwise this cause
+	later incorrect setting for the value of StripByCounts/StripOffsets.
+	( https://trac.osgeo.org/gdal/ticket/6924 )
+
+2017-06-10  Even Rouault <even.rouault at spatialys.com>
+
+	* .appveyor.yml, .travis.yml, build/travis-ci: apply patches
+	0001-ci-Travis-script-improvements.patch and
+	0002-ci-Invoke-helper-script-via-shell.patch by Roger Leigh
+	(sent to mailing list)
+
+2017-06-08  Even Rouault <even.rouault at spatialys.com>
+
+	* .travis.yml, build/travis-ci: new files from
+	0001-ci-Add-Travis-support-for-Linux-builds-with-Autoconf.patch by
+	Roger Leigh (sent to mailing list on 2017-06-08)
+	This patch adds support for the Travis-CI service.
+
+	* .appveyor.yml: new file from
+	0002-ci-Add-AppVeyor-support.patch by Roger Leigh (sent to mailing
+	list on 2017-06-08)
+	This patch adds a .appveyor.yml file to the top-level.  This allows
+	one to opt in to having a branch built on Windows with Cygwin,
+	MinGW and MSVC automatically when a branch is pushed to GitHub,
+	GitLab, BitBucket or any other supported git hosting service.
+
+	* CMakeLists.txt, test/CMakeLists.txt, test/TiffTestCommon.cmake: apply
+	patch 0001-cmake-Improve-Cygwin-and-MingGW-test-support.patch from Roger
+	Leigh (sent to mailing list on 2017-06-08)
+	This patch makes the CMake build system support running the tests
+	with MinGW or Cygwin.
+
+2017-06-08  Even Rouault <even.rouault at spatialys.com>
+
+	* libtiff/tif_swab.c: if DISABLE_CHECK_TIFFSWABMACROS is defined, do not do
+	the #ifdef TIFFSwabXXX checks. Make it easier for GDAL to rename the symbols
+	of its internal libtiff copy.
+
+2017-06-01  Even Rouault <even.rouault at spatialys.com>
+
+	* libtiff/tif_dirinfo.c, tif_dirread.c: add _TIFFCheckFieldIsValidForCodec(),
+	and use it in TIFFReadDirectory() so as to ignore fields whose tag is a
+	codec-specified tag but this codec is not enabled. This avoids TIFFGetField()
+	to behave differently depending on whether the codec is enabled or not, and
+	thus can avoid stack based buffer overflows in a number of TIFF utilities
+	such as tiffsplit, tiffcmp, thumbnail, etc.
+	Patch derived from 0063-Handle-properly-CODEC-specific-tags.patch
+	(http://bugzilla.maptools.org/show_bug.cgi?id=2580) by Raphaël Hertzog.
+	Fixes:
+	http://bugzilla.maptools.org/show_bug.cgi?id=2580
+	http://bugzilla.maptools.org/show_bug.cgi?id=2693
+	http://bugzilla.maptools.org/show_bug.cgi?id=2625 (CVE-2016-10095)
+	http://bugzilla.maptools.org/show_bug.cgi?id=2564 (CVE-2015-7554)
+	http://bugzilla.maptools.org/show_bug.cgi?id=2561 (CVE-2016-5318)
+	http://bugzilla.maptools.org/show_bug.cgi?id=2499 (CVE-2014-8128)
+	http://bugzilla.maptools.org/show_bug.cgi?id=2441
+	http://bugzilla.maptools.org/show_bug.cgi?id=2433
+
+2017-05-29  Even Rouault <even.rouault at spatialys.com>
+
+	* libtiff/tif_getimage.c: initYCbCrConversion(): stricter validation for
+	refBlackWhite coefficients values. To avoid invalid float->int32 conversion
+	(when refBlackWhite[0] == 2147483648.f)
+	Fixes https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=1907
+	Credit to OSS Fuzz
+
+2017-05-29  Even Rouault <even.rouault at spatialys.com>
+
+	* libtiff/tif_color.c: TIFFYCbCrToRGBInit(): stricter clamping to avoid
+	int32 overflow in TIFFYCbCrtoRGB().
+	Fixes https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=1844
+	Credit to OSS Fuzz
+
+2017-05-21  Bob Friesenhahn  <bfriesen@simple.dallas.tx.us>
+
+	* configure.ac: libtiff 4.0.8 released.
+
+	* html/v4.0.8.html: Add description of changes targeting the 4.0.8
+	release.
+
+2017-05-20 Even Rouault <even.rouault at spatialys.com>
+
+	* libtiff/tif_getimage.c: initYCbCrConversion(): stricter validation for
+	refBlackWhite coefficients values. To avoid invalid float->int32 conversion.
+	Fixes https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=1718
+	Credit to OSS Fuzz
+
+2017-05-18 Even Rouault <even.rouault at spatialys.com>
+
+	* libtiff/tif_getimage.c: initYCbCrConversion(): check luma[1] is not zero
+	to avoid division by zero.
+	Fixes https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=1665
+	Credit to OSS Fuzz
+
+2017-05-17 Even Rouault <even.rouault at spatialys.com>
+
+	* libtiff/tif_read.c: _TIFFVSetField(): fix outside range cast of double to
+	float.
+	Credit to Google Autofuzz project
+
+2017-05-17 Even Rouault <even.rouault at spatialys.com>
+
+	* libtiff/tif_getimage.c: initYCbCrConversion(): add basic validation of
+	luma and refBlackWhite coefficients (just check they are not NaN for now),
+	to avoid potential float to int overflows.
+	Fixes https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=1663
+	Credit to OSS Fuzz
+
+2017-05-17 Even Rouault <even.rouault at spatialys.com>
+
+	* libtiff/tif_pixarlog.c: PixarLogDecode(): resync tif_rawcp with
+	next_in and tif_rawcc with avail_in at beginning and end of function,
+	similarly to what is done in LZWDecode(). Likely needed so that it
+	works properly with latest chnges in tif_read.c in CHUNKY_STRIP_READ_SUPPORT
+	mode. But untested...
+
+2017-05-17 Even Rouault <even.rouault at spatialys.com>
+
+	* libtiff/tif_lzw.c: update dec_bitsleft at beginning of LZWDecode(),
+	and update tif_rawcc at end of LZWDecode(). This is needed to properly
+	work with the latest chnges in tif_read.c in CHUNKY_STRIP_READ_SUPPORT
+	mode.
+
+2017-05-14 Even Rouault <even.rouault at spatialys.com>
+
+	* libtiff/tif_luv.c: LogL16InitState(): avoid excessive memory
+	allocation when RowsPerStrip tag is missing.
+	Credit to OSS-Fuzz (locally run, on GDAL)
+
+2017-05-14 Even Rouault <even.rouault at spatialys.com>
+
+	* libtiff/tif_packbits.c: fix out-of-buffer read in PackBitsDecode()
+	Fixes https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=1563
+	Credit to OSS-Fuzz
+
+2017-05-13 Even Rouault <even.rouault at spatialys.com>
+
+	* libtiff/tif_pixarlog.c, tif_luv.c: avoid potential int32
+	overflows in multiply_ms() and add_ms().
+	Fixes https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=1558
+	Credit to OSS-Fuzz
+
+2017-05-13 Even Rouault <even.rouault at spatialys.com>
+
+	* libtiff/tif_color.c: avoid potential int32 overflow in
+	TIFFYCbCrToRGBInit()
+	Fixes https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=1533
+	Credit to OSS-Fuzz
+
+2017-05-13 Even Rouault <even.rouault at spatialys.com>
+
+	* libtiff/tif_read.c: update tif_rawcc in CHUNKY_STRIP_READ_SUPPORT
+	mode with tif_rawdataloaded when calling TIFFStartStrip() or
+	TIFFFillStripPartial(). This avoids reading beyond tif_rawdata
+	when bytecount > tif_rawdatasize.
+	Fixes https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=1545.
+	Credit to OSS-Fuzz
+
+2017-05-12 Even Rouault <even.rouault at spatialys.com>
+
+	* libtiff/tif_read.c: TIFFFillStripPartial():
+	avoid excessive memory allocation in case of shorten files.
+	Only effective on 64 bit builds.
+	Credit to OSS-Fuzz (locally run, on GDAL)
+
+2017-05-12 Even Rouault <even.rouault at spatialys.com>
+
+	* libtiff/tif_read.c: TIFFFillStripPartial() / TIFFSeek(),
+	avoid potential integer overflows with read_ahead in
+	CHUNKY_STRIP_READ_SUPPORT mode. Should
+	especially occur on 32 bit platforms.
+
+2017-05-10 Even Rouault <even.rouault at spatialys.com>
+
+	* libtiff/tif_read.c: TIFFFillStrip() and TIFFFillTile():
+	avoid excessive memory allocation in case of shorten files.
+	Only effective on 64 bit builds and non-mapped cases.
+	Credit to OSS-Fuzz (locally run, on GDAL)
+
+2017-05-10 Even Rouault <even.rouault at spatialys.com>
+
+	* libtiff/tif_zip.c, tif_pixarlog.c, tif_predict.c: fix memory
+	leak when the underlying codec (ZIP, PixarLog) succeeds its
+	setupdecode() method, but PredictorSetup fails.
+	Credit to OSS-Fuzz (locally run, on GDAL)
+
+2017-05-10 Even Rouault <even.rouault at spatialys.com>
+
+	* libtiff/tif_read.c: TIFFFillStrip(): add limitation to the number
+	of bytes read in case td_stripbytecount[strip] is bigger than
+	reasonable, so as to avoid excessive memory allocation.
+
+2017-04-28 Even Rouault <even.rouault at spatialys.com>
+
+	* tools/tiff2bw.c: close TIFF handle in error code path.
+	Fixes http://bugzilla.maptools.org/show_bug.cgi?id=2677
+
+2017-04-27 Even Rouault <even.rouault at spatialys.com>
+
+	* litiff/tif_fax3.c: avoid crash in Fax3Close() on empty file.
+	Patch by Alan Coopersmith  + complement by myself.
+	Fixes http://bugzilla.maptools.org/show_bug.cgi?id=2673
+	* tools/fax2tiff.c: emit appropriate message if the input file is
+	empty. Patch by Alan Coopersmith.
+	Fixes http://bugzilla.maptools.org/show_bug.cgi?id=2672
+
+2017-04-27 Even Rouault <even.rouault at spatialys.com>
+
+	* libtiff/tif_ojpeg.c: fix potential memory leak in
+	OJPEGReadHeaderInfoSecTablesQTable, OJPEGReadHeaderInfoSecTablesDcTable
+	and OJPEGReadHeaderInfoSecTablesAcTable
+	Patch by Nicolás Peña.
+	Fixes http://bugzilla.maptools.org/show_bug.cgi?id=2670
+
+2017-04-27 Even Rouault <even.rouault at spatialys.com>
+
+	* libtiff/tif_dirread.c: fix memory leak in non DEFER_STRILE_LOAD
+	mode (ie default) when there is both a StripOffsets and
+	TileOffsets tag, or a StripByteCounts and TileByteCounts
+	Fixes http://bugzilla.maptools.org/show_bug.cgi?id=2689
+	* tools/tiff2ps.c: call TIFFClose() in error code paths.
+
+2017-02-25 Even Rouault <even.rouault at spatialys.com>
+
+	* libtiff/tif_fax3.c, tif_predict.c, tif_getimage.c: fix GCC 7
+	-Wimplicit-fallthrough warnings.
+
+2017-02-18 Even Rouault <even.rouault at spatialys.com>
+
+	* libtiff/tif_pixarlog.c: fix memory leak in error code path of
+	PixarLogSetupDecode(). Patch by Nicolás Peña.
+	Fixes http://bugzilla.maptools.org/show_bug.cgi?id=2665
+
+2017-02-18 Even Rouault <even.rouault at spatialys.com>
+
+	* libtiff/tif_lzw.c: in LZWPostEncode(), increase, if necessary, the
+	code bit-width after flushing the remaining code and before emitting
+	the EOI code.
+	Fixes http://bugzilla.maptools.org/show_bug.cgi?id=1982
+
+2017-01-31 Even Rouault <even.rouault at spatialys.com>
+
+	* libtiff/tif_jpeg.c: only run JPEGFixupTagsSubsampling() if the
+	YCbCrSubsampling tag is not explicitly present. This helps a bit to reduce
+	the I/O amount when te tag is present (especially on cloud hosted files).
+
+2017-01-14 Even Rouault <even.rouault at spatialys.com>
+
+	* tools/raw2tiff.c: avoid integer division by zero.
+	Fixes http://bugzilla.maptools.org/show_bug.cgi?id=2631
+
+2017-01-12 Even Rouault <even.rouault at spatialys.com>
+
+	* libtiff/tif_ojpeg.c: fix leak in OJPEGReadHeaderInfoSecTablesQTable,
+	OJPEGReadHeaderInfoSecTablesDcTable and OJPEGReadHeaderInfoSecTablesAcTable
+	when read fails.
+	Patch by Nicolás Peña.
+	Fixes http://bugzilla.maptools.org/show_bug.cgi?id=2659
+
+2017-01-11 Even Rouault <even.rouault at spatialys.com>
+
+	* libtiff/tif_luv.c, tif_lzw.c, tif_packbits.c: return 0 in Encode
+	functions instead of -1 when TIFFFlushData1() fails.
+	Fixes http://bugzilla.maptools.org/show_bug.cgi?id=2130
+
+2017-01-11 Even Rouault <even.rouault at spatialys.com>
+
+	* tools/tiffcp.c: error out cleanly in cpContig2SeparateByRow and
+	cpSeparate2ContigByRow if BitsPerSample != 8 to avoid heap based overflow.
+	Fixes http://bugzilla.maptools.org/show_bug.cgi?id=2656 and
+	http://bugzilla.maptools.org/show_bug.cgi?id=2657
+
+2017-01-11 Even Rouault <even.rouault at spatialys.com>
+
+	* libtiff/tiffio.h, tif_unix.c, tif_win32.c, tif_vms.c: add _TIFFcalloc()
+
+	* libtiff/tif_read.c: TIFFReadBufferSetup(): use _TIFFcalloc() to zero
+	initialize tif_rawdata.
+	Fixes http://bugzilla.maptools.org/show_bug.cgi?id=2651
+
+2017-01-11 Even Rouault <even.rouault at spatialys.com>
+
+	* libtiff/tif_getimage.c: add explicit uint32 cast in putagreytile to
+	avoid UndefinedBehaviorSanitizer warning.
+	Patch by Nicolás Peña.
+	Fixes http://bugzilla.maptools.org/show_bug.cgi?id=2658
+
+2017-01-11 Even Rouault <even.rouault at spatialys.com>
+
+	* libtiff/tif_read.c: avoid potential undefined behaviour on signed integer
+	addition in TIFFReadRawStrip1() in isMapped() case.
+	Fixes http://bugzilla.maptools.org/show_bug.cgi?id=2650
+
+2017-01-11 Even Rouault <even.rouault at spatialys.com>
+
+	* libtiff/tif_jpeg.c: validate BitsPerSample in JPEGSetupEncode() to avoid
+	undefined behaviour caused by invalid shift exponent.
+	Fixes http://bugzilla.maptools.org/show_bug.cgi?id=2648
+
+2017-01-11 Even Rouault <even.rouault at spatialys.com>
+
+	* libtiff/tif_dir.c, tif_dirread.c, tif_dirwrite.c: implement various clampings
+	of double to other data types to avoid undefined behaviour if the output range
+	isn't big enough to hold the input value.
+	Fixes http://bugzilla.maptools.org/show_bug.cgi?id=2643
+	http://bugzilla.maptools.org/show_bug.cgi?id=2642
+	http://bugzilla.maptools.org/show_bug.cgi?id=2646
+	http://bugzilla.maptools.org/show_bug.cgi?id=2647
+
+2017-01-11 Even Rouault <even.rouault at spatialys.com>
+
+	* libtiff/tif_dirread.c: avoid division by floating point 0 in
+	TIFFReadDirEntryCheckedRational() and TIFFReadDirEntryCheckedSrational(),
+	and return 0 in that case (instead of infinity as before presumably)
+	Apparently some sanitizers do not like those divisions by zero.
+	Fixes http://bugzilla.maptools.org/show_bug.cgi?id=2644
+
+2017-01-11 Even Rouault <even.rouault at spatialys.com>
+
+	* libtiff/tif_dirwrite.c: in TIFFWriteDirectoryTagCheckedRational, replace
+	assertion by runtime check to error out if passed value is strictly
+	negative.
+	Fixes http://bugzilla.maptools.org/show_bug.cgi?id=2535
+
+	* tools/tiffcrop.c: remove extraneous TIFFClose() in error code path, that
+	caused double free.
+	Related to http://bugzilla.maptools.org/show_bug.cgi?id=2535
+
+2017-01-11 Even Rouault <even.rouault at spatialys.com>
+
+	* libtiff/tif_jpeg.c: avoid integer division by zero in
+	JPEGSetupEncode() when horizontal or vertical sampling is set to 0.
+	Fixes http://bugzilla.maptools.org/show_bug.cgi?id=2653
+
+2017-01-03 Even Rouault <even.rouault at spatialys.com>
+
+	* libtiff/tif_jpeg.c: increase libjpeg max memory usable to
+	10 MB instead of libjpeg 1MB default. This helps when creating files
+	with "big" tile, without using libjpeg temporary files.
+	Related to https://trac.osgeo.org/gdal/ticket/6757
+
+2016-12-20 Even Rouault <even.rouault at spatialys.com>
+
+	* tools/tiff2pdf.c: avoid potential heap-based overflow in
+	t2p_readwrite_pdf_image_tile().
+	Fixes http://bugzilla.maptools.org/show_bug.cgi?id=2640
+
+2016-12-20 Even Rouault <even.rouault at spatialys.com>
+
+	* tools/tiff2pdf.c: avoid potential invalid memory read in
+	t2p_writeproc.
+	Fixes http://bugzilla.maptools.org/show_bug.cgi?id=2639
+
+2016-12-20 Even Rouault <even.rouault at spatialys.com>
+
+	* tools/tiff2pdf.c: fix wrong usage of memcpy() that can trigger
+	unspecified behaviour.
+	Fixes http://bugzilla.maptools.org/show_bug.cgi?id=2638
+
+2016-12-18 Even Rouault <even.rouault at spatialys.com>
+
+	* libtiff/tif_getimage.c: fix potential memory leaks in error code
+	path of TIFFRGBAImageBegin().
+	Fixes http://bugzilla.maptools.org/show_bug.cgi?id=2627
+
+2016-12-18 Even Rouault <even.rouault at spatialys.com>
+
+	* tools/tiff2pdf.c: prevent heap-based buffer overflow in -j mode
+	on a paletted image. Note: this fix errors out before the overflow
+	happens. There could probably be a better fix.
+	Fixes http://bugzilla.maptools.org/show_bug.cgi?id=2635
+
+2016-12-17 Even Rouault <even.rouault at spatialys.com>
+
+	* libtiff/tiffio.h, libtiff/tif_getimage.c: add TIFFReadRGBAStripExt()
+	and TIFFReadRGBATileExt() variants of the functions without ext, with
+	an extra argument to control the stop_on_error behaviour.
+
+2016-12-17 Even Rouault <even.rouault at spatialys.com>
+
+	* tools/tiff2ps.c: fix 2 heap-based buffer overflows (in PSDataBW
+	and PSDataColorContig). Reported by Agostino Sarubbo.
+	Fixes http://bugzilla.maptools.org/show_bug.cgi?id=2633 and
+	http://bugzilla.maptools.org/show_bug.cgi?id=2634.
+
+2016-12-13 Even Rouault <even.rouault at spatialys.com>
+
+	* libtiff/tif_fax3.h: revert change done on 2016-01-09 that made
+	Param member of TIFFFaxTabEnt structure a uint16 to reduce size of
+	the binary. It happens that the Hylafax software uses the tables that
+	follow this typedef (TIFFFaxMainTable, TIFFFaxWhiteTable,
+	TIFFFaxBlackTable), although they are not in a public libtiff header.
+	Raised by Lee Howard.
+	Fixes http://bugzilla.maptools.org/show_bug.cgi?id=2636
+
+2016-12-04 Even Rouault <even.rouault at spatialys.com>
+
+	* html/man/Makefile.am: remove thumbnail.1.html and rgb2ycbcr.1.html
+	from installed pages since the corresponding utilities are no longer
+	installed. Reported by Havard Eidnes
+	Fixes http://bugzilla.maptools.org/show_bug.cgi?id=2606
+
+2016-12-03 Even Rouault <even.rouault at spatialys.com>
+
+	* libtiff/tif_write.c: fix misleading indentation as warned by GCC.
+
+2016-12-03 Even Rouault <even.rouault at spatialys.com>
+
+	* tools/tiffcp.c: replace assert( (bps % 8) == 0 ) by a non assert check.
+	Reported by Agostino Sarubbo.
+	Fixes http://bugzilla.maptools.org/show_bug.cgi?id=2605
+
+2016-12-03 Even Rouault <even.rouault at spatialys.com>
+
+	* tools/tiffcp.c: fix uint32 underflow/overflow that can cause heap-based
+	buffer overflow.
+	Reported by Agostino Sarubbo.
+	Fixes http://bugzilla.maptools.org/show_bug.cgi?id=2610
+
+2016-12-03 Even Rouault <even.rouault at spatialys.com>
+
+	* tools/tiffcp.c: avoid potential division by zero is BitsPerSamples tag is
+	missing.
+	Reported by Agostino Sarubbo.
+	Fixes http://bugzilla.maptools.org/show_bug.cgi?id=2607
+
+2016-12-03 Even Rouault <even.rouault at spatialys.com>
+
+	* man/Makefile.am: remove thumbnail.1 and rgb2ycbcr.1 from installed man
+	pages since the corresponding utilities are no longer installed.
+	Reported by Havard Eidnes 
+	Fixes http://bugzilla.maptools.org/show_bug.cgi?id=2606
+
+2016-12-03 Even Rouault <even.rouault at spatialys.com>
+
+	* tools/tif_dir.c: when TIFFGetField(, TIFFTAG_NUMBEROFINKS, ) is called,
+	limit the return number of inks to SamplesPerPixel, so that code that parses
+	ink names doesn't go past the end of the buffer.
+	Reported by Agostino Sarubbo.
+	Fixes http://bugzilla.maptools.org/show_bug.cgi?id=2599
+
+2016-12-03 Even Rouault <even.rouault at spatialys.com>
+
+	* tools/tiffcp.c: avoid potential division by zero is BitsPerSamples tag is
+	missing.
+	Reported by Agostino Sarubbo.
+	Fixes http://bugzilla.maptools.org/show_bug.cgi?id=2597
+
+2016-12-03 Even Rouault <even.rouault at spatialys.com>
+
+	* tools/tiffinfo.c: fix null pointer dereference in -r mode when the image has
+	no StripByteCount tag.
+	Reported by Agostino Sarubbo.
+	Fixes http://bugzilla.maptools.org/show_bug.cgi?id=2594
+
+2016-12-03 Even Rouault <even.rouault at spatialys.com>
+
+	* tools/tiffcrop.c: fix integer division by zero when BitsPerSample is missing.
+	Reported by Agostino Sarubbo.
+	Fixes http://bugzilla.maptools.org/show_bug.cgi?id=2619
+
+2016-12-03 Even Rouault <even.rouault at spatialys.com>
+
+	* tools/tiffcrop.c: add 3 extra bytes at end of strip buffer in
+	readSeparateStripsIntoBuffer() to avoid read outside of heap allocated buffer.
+	Reported by Agostino Sarubbo.
+	Fixes http://bugzilla.maptools.org/show_bug.cgi?id=2621
+
+2016-12-03 Even Rouault <even.rouault at spatialys.com>
+
+	* tools/tiffcrop.c: fix readContigStripsIntoBuffer() in -i (ignore) mode so
+	that the output buffer is correctly incremented to avoid write outside bounds.
+	Reported by Agostino Sarubbo.
+	Fixes http://bugzilla.maptools.org/show_bug.cgi?id=2620
+
+2016-12-03 Even Rouault <even.rouault at spatialys.com>
+
+	* libtiff/tif_ojpeg.c: make OJPEGDecode() early exit in case of failure in
+	OJPEGPreDecode(). This will avoid a divide by zero, and potential other issues.
+	Reported by Agostino Sarubbo.
+	Fixes http://bugzilla.maptools.org/show_bug.cgi?id=2611
+
+2016-12-03 Even Rouault <even.rouault at spatialys.com>
+
+	* libtiff/tif_dirread.c: modify ChopUpSingleUncompressedStrip() to
+	instanciate compute ntrips as TIFFhowmany_32(td->td_imagelength, rowsperstrip),
+	instead of a logic based on the total size of data. Which is faulty is
+	the total size of data is not sufficient to fill the whole image, and thus
+	results in reading outside of the StripByCounts/StripOffsets arrays when
+	using TIFFReadScanline().
+	Reported by Agostino Sarubbo.
+	Fixes http://bugzilla.maptools.org/show_bug.cgi?id=2608.
+
+	* libtiff/tif_strip.c: revert the change in TIFFNumberOfStrips() done
+	for http://bugzilla.maptools.org/show_bug.cgi?id=2587 / CVE-2016-9273 since
+	the above change is a better fix that makes it unnecessary.
+
+2016-12-03 Even Rouault <even.rouault at spatialys.com>
+
+	* libtiff/tif_pixarlog.c, libtiff/tif_luv.c: fix heap-based buffer
+	overflow on generation of PixarLog / LUV compressed files, with
+	ColorMap, TransferFunction attached and nasty plays with bitspersample.
+	The fix for LUV has not been tested, but suffers from the same kind
+	of issue of PixarLog.
+	Reported by Agostino Sarubbo.
+	Fixes http://bugzilla.maptools.org/show_bug.cgi?id=2604
+
+2016-12-02 Even Rouault <even.rouault at spatialys.com>
+
+	* tools/tiffcp.c: avoid uint32 underflow in cpDecodedStrips that 
+	can cause various issues, such as buffer overflows in the library.
+	Reported by Agostino Sarubbo.
+	Fixes http://bugzilla.maptools.org/show_bug.cgi?id=2598
+
+2016-12-02 Even Rouault <even.rouault at spatialys.com>
+
+	* libtiff/tif_read.c, libtiff/tiffiop.h: fix uint32 overflow in
+	TIFFReadEncodedStrip() that caused an integer division by zero.
+	Reported by Agostino Sarubbo.
+	Fixes http://bugzilla.maptools.org/show_bug.cgi?id=2596
+
+2016-11-20 Even Rouault <even.rouault at spatialys.com>
+
+	* libtiff/tif_getimage.c, libtiff/tif_open.c: add parenthesis to
+	fix cppcheck clarifyCalculation warnings
+	* libtiff/tif_predict.c, libtiff/tif_print.c: fix printf unsigned
+	vs signed formatting (cppcheck invalidPrintfArgType_uint warnings)
+
+2016-11-20  Bob Friesenhahn  <bfriesen@simple.dallas.tx.us>
+
+	* tools/fax2tiff.c (main): Applied patch by Jörg Ahrens to fix
+	passing client data for Win32 builds using tif_win32.c
+	(USE_WIN32_FILEIO defined) for file I/O.  Patch was provided via
+	email on November 20, 2016.
+
+2016-11-19  Bob Friesenhahn  <bfriesen@simple.dallas.tx.us>
+
+	* libtiff 4.0.7 released.
+
+	* configure.ac: Update for 4.0.7 release.
+
+	* tools/tiffdump.c (ReadDirectory): Remove uint32 cast to
+	_TIFFmalloc() argument which resulted in Coverity report.  Added
+	more mutiplication overflow checks.
+
+2016-11-18 Even Rouault <even.rouault at spatialys.com>
+
+	* tools/tiffcrop.c: Fix memory leak in (recent) error code path.
+	Fixes Coverity 1394415.
+
+2016-11-17  Bob Friesenhahn  <bfriesen@simple.dallas.tx.us>
+
+	* libtiff/tif_getimage.c: Fix some benign warnings which appear in
+	64-bit compilation under Microsoft Visual Studio of the form
+	"Arithmetic overflow: 32-bit value is shifted, then cast to 64-bit
+	value.  Results might not be an expected value.".  Problem was
+	reported on November 16, 2016 on the tiff mailing list.
+
+2016-11-16 Even Rouault <even.rouault at spatialys.com>
+
+	* libtiff/tif_dirread.c: in TIFFFetchNormalTag(), do not dereference
+	NULL pointer when values of tags with TIFF_SETGET_C16_ASCII / TIFF_SETGET_C32_ASCII
+	access are 0-byte arrays.
+	Fixes http://bugzilla.maptools.org/show_bug.cgi?id=2593 (regression introduced
+	by previous fix done on 2016-11-11 for CVE-2016-9297).
+	Reported by Henri Salo. Assigned as CVE-2016-9448
+
+2016-11-12  Bob Friesenhahn  <bfriesen@simple.dallas.tx.us>
+
+	* tools/tiffinfo.c (TIFFReadContigTileData): Fix signed/unsigned
+	comparison warning.
+	(TIFFReadSeparateTileData): Fix signed/unsigned comparison
+	warning.
+
+	* tools/tiffcrop.c (readContigTilesIntoBuffer): Fix
+	signed/unsigned comparison warning.
+
+	* html/v4.0.7.html: Add a file to document the pending 4.0.7
+	release.
+
+2016-11-11 Even Rouault <even.rouault at spatialys.com>
+
+	* tools/tiff2pdf.c: avoid undefined behaviour related to overlapping
+	of source and destination buffer in memcpy() call in
+	t2p_sample_rgbaa_to_rgb()
+	Fixes http://bugzilla.maptools.org/show_bug.cgi?id=2577
+
+2016-11-11 Even Rouault <even.rouault at spatialys.com>
+
+	* tools/tiff2pdf.c: fix potential integer overflows on 32 bit builds
+	in t2p_read_tiff_size()
+	Fixes http://bugzilla.maptools.org/show_bug.cgi?id=2576
+
+2016-11-11 Even Rouault <even.rouault at spatialys.com>
+
+	* libtiff/tif_aux.c: fix crash in TIFFVGetFieldDefaulted()
+	when requesting Predictor tag and that the zip/lzw codec is not
+	configured.
+	Fixes http://bugzilla.maptools.org/show_bug.cgi?id=2591
+
+2016-11-11 Even Rouault <even.rouault at spatialys.com>
+
+	* libtiff/tif_dirread.c: in TIFFFetchNormalTag(), make sure that
+	values of tags with TIFF_SETGET_C16_ASCII / TIFF_SETGET_C32_ASCII
+	access are null terminated, to avoid potential read outside buffer
+	in _TIFFPrintField().
+	Fixes http://bugzilla.maptools.org/show_bug.cgi?id=2590 (CVE-2016-9297)
+
+2016-11-11 Even Rouault <even.rouault at spatialys.com>
+
+	* libtiff/tif_dirread.c: reject images with OJPEG compression that
+	have no TileOffsets/StripOffsets tag, when OJPEG compression is
+	disabled. Prevent null pointer dereference in TIFFReadRawStrip1()
+	and other functions that expect td_stripbytecount to be non NULL.
+	Fixes http://bugzilla.maptools.org/show_bug.cgi?id=2585
+
+2016-11-11 Even Rouault <even.rouault at spatialys.com>
+
+	* tools/tiffcrop.c: fix multiple uint32 overflows in
+	writeBufferToSeparateStrips(), writeBufferToContigTiles() and
+	writeBufferToSeparateTiles() that could cause heap buffer overflows.
+	Reported by Henri Salo from Nixu Corporation.
+	Fixes http://bugzilla.maptools.org/show_bug.cgi?id=2592 (CVE-2016-9532)
+
+2016-11-10 Even Rouault <even.rouault at spatialys.com>
+
+	* libtiff/tif_strip.c: make TIFFNumberOfStrips() return the td->td_nstrips
+	value when it is non-zero, instead of recomputing it. This is needed in
+	TIFF_STRIPCHOP mode where td_nstrips is modified. Fixes a read outsize of
+	array in tiffsplit (or other utilities using TIFFNumberOfStrips()).
+	Fixes http://bugzilla.maptools.org/show_bug.cgi?id=2587 (CVE-2016-9273)
+
+2016-11-04 Even Rouault <even.rouault at spatialys.com>
+
+	* libtiff/tif_predic.c: fix memory leaks in error code paths added in
+	previous commit (fix for MSVR 35105)
+
+2016-10-31 Even Rouault <even.rouault at spatialys.com>
+
+	* libtiff/tif_predict.h, libtiff/tif_predict.c:
+	Replace assertions by runtime checks to avoid assertions in debug mode,
+	or buffer overflows in release mode. Can happen when dealing with
+	unusual tile size like YCbCr with subsampling. Reported as MSVR 35105
+	by Axel Souchet	& Vishal Chauhan from the MSRC Vulnerabilities & Mitigations
+	team.
+
+2016-10-26 Even Rouault <even.rouault at spatialys.com>
+
+	* tools/fax2tiff.c: fix segfault when specifying -r without
+	argument. Patch by Yuriy M. Kaminskiy.
+	Fixes http://bugzilla.maptools.org/show_bug.cgi?id=2572
+
+2016-10-25 Even Rouault <even.rouault at spatialys.com>
+
+	* libtiff/tif_dir.c: discard values of SMinSampleValue and
+	SMaxSampleValue when they have been read and the value of
+	SamplesPerPixel is changed afterwards (like when reading a
+	OJPEG compressed image with a missing SamplesPerPixel tag,
+	and whose photometric is RGB or YCbCr, forcing SamplesPerPixel
+	being 3). Otherwise when rewriting the directory (for example
+	with tiffset, we will expect 3 values whereas the array had been
+	allocated with just one), thus causing a out of bound read access.
+	Fixes http://bugzilla.maptools.org/show_bug.cgi?id=2500
+	(CVE-2014-8127, duplicate: CVE-2016-3658)
+	
+	* libtiff/tif_dirwrite.c: avoid null pointer dereference on td_stripoffset
+	when writing directory, if FIELD_STRIPOFFSETS was artificially set
+	for a hack case	in OJPEG case.
+	Fixes http://bugzilla.maptools.org/show_bug.cgi?id=2500
+	(CVE-2014-8127, duplicate: CVE-2016-3658)
+
+2016-10-25 Even Rouault <even.rouault at spatialys.com>
+
+	* tools/tiffinfo.c: fix out-of-bound read on some tiled images.
+	(http://bugzilla.maptools.org/show_bug.cgi?id=2517)
+
+	* libtiff/tif_compress.c: make TIFFNoDecode() return 0 to indicate an
+	error and make upper level read routines treat it accordingly.
+	(linked to the test case of http://bugzilla.maptools.org/show_bug.cgi?id=2517)
+
+2016-10-14 Even Rouault <even.rouault at spatialys.com>
+
+	* tools/tiffcrop.c: fix out-of-bound read of up to 3 bytes in
+	readContigTilesIntoBuffer(). Reported as MSVR 35092 by Axel Souchet
+	& Vishal Chauhan from the MSRC Vulnerabilities & Mitigations team.
+
+2016-10-09 Even Rouault <even.rouault at spatialys.com>
+
+	* tools/tiff2pdf.c: fix write buffer overflow of 2 bytes on JPEG
+	compressed images. Reported by Tyler Bohan of Cisco Talos as
+	TALOS-CAN-0187 / CVE-2016-5652.
+	Also prevents writing 2 extra uninitialized bytes to the file stream.
+
+2016-10-08 Even Rouault <even.rouault at spatialys.com>
+
+	* tools/tiffcp.c: fix out-of-bounds write on tiled images with odd
+	tile width vs image width. Reported as MSVR 35103
+	by Axel Souchet and Vishal Chauhan from the MSRC Vulnerabilities &
+	Mitigations team.
+
+2016-10-08 Even Rouault <even.rouault at spatialys.com>
+
+	* tools/tiff2pdf.c: fix read -largely- outsize of buffer in
+	t2p_readwrite_pdf_image_tile(), causing crash, when reading a
+	JPEG compressed image with TIFFTAG_JPEGTABLES length being one.
+	Reported as MSVR 35101 by Axel Souchet and Vishal Chauhan from
+	the MSRC Vulnerabilities & Mitigations team. CVE-2016-9453
+
+2016-10-08 Even Rouault <even.rouault at spatialys.com>
+
+	* tools/tiffcp.c: fix read of undefined variable in case of missing
+	required tags. Found on test case of MSVR 35100.
+	* tools/tiffcrop.c: fix read of undefined buffer in
+	readContigStripsIntoBuffer() due to uint16 overflow. Probably not a
+	security issue but I can be wrong. Reported as MSVR 35100 by Axel
+	Souchet from the MSRC Vulnerabilities & Mitigations team.
+
+2016-09-25  Bob Friesenhahn  <bfriesen@simple.dallas.tx.us>
+
+	* html: Change as many remotesensing.org broken links to a working
+	URL as possible.
+
+2016-09-24  Bob Friesenhahn  <bfriesen@simple.dallas.tx.us>
+
+	* libtiff/tif_getimage.c (TIFFRGBAImageOK): Reject attempts to
+	read floating point images.
+
+	* libtiff/tif_predict.c (PredictorSetup): Enforce bits-per-sample
+	requirements of floating point predictor (3).  Fixes CVE-2016-3622
+	"Divide By Zero in the tiff2rgba tool."
+
+2016-09-23 Even Rouault <even.rouault at spatialys.com>
+
+	* tools/tiffcrop.c: fix various out-of-bounds write vulnerabilities
+	in heap or stack allocated buffers. Reported as MSVR 35093,
+	MSVR 35096 and MSVR 35097. Discovered by Axel Souchet and Vishal
+	Chauhan from the MSRC Vulnerabilities & Mitigations team.
+	* tools/tiff2pdf.c: fix out-of-bounds write vulnerabilities in
+	heap allocate buffer in t2p_process_jpeg_strip(). Reported as MSVR
+	35098. Discovered by Axel Souchet and Vishal Chauhan from the MSRC
+	Vulnerabilities & Mitigations team.
+	* libtiff/tif_pixarlog.c: fix out-of-bounds write vulnerabilities
+	in heap allocated buffers. Reported as MSVR 35094. Discovered by
+	Axel Souchet and Vishal Chauhan from the MSRC Vulnerabilities &
+	Mitigations team.
+	* libtiff/tif_write.c: fix issue in error code path of TIFFFlushData1()
+	that didn't reset the tif_rawcc and tif_rawcp members. I'm not
+	completely sure if that could happen in practice outside of the odd
+	behaviour of t2p_seekproc() of tiff2pdf). The report points that a
+	better fix could be to check the return value of TIFFFlushData1() in
+	places where it isn't done currently, but it seems this patch is enough.
+	Reported as MSVR 35095. Discovered by Axel Souchet & Vishal Chauhan &
+	Suha Can from the MSRC Vulnerabilities & Mitigations team.
+
+2016-09-20  Bob Friesenhahn  <bfriesen@simple.dallas.tx.us>
+
+	* html/man/index.html: Comment out links to documentation for
+	abandoned utilities.
+
+2016-09-17 Even Rouault <even.rouault at spatialys.com>
+
+	* libtiff/tif_lzma.c: typo fix in comment
+
+2016-09-04 Even Rouault <even.rouault at spatialys.com>
+
+	* libtiff/*.c: fix warnings raised by clang 3.9 -Wcomma
+
+2016-09-03 Even Rouault <even.rouault at spatialys.com>
+
+	* libtiff/tif_dirwrite.c, libtiff/tif_color.c: fix warnings raised
+	by GCC 5 / clang -Wfloat-conversion
+
+2016-08-16 Even Rouault <even.rouault at spatialys.com>
+
+	* tools/tiffcrop.c: fix C99'ism.
+
+2016-08-15 Even Rouault <even.rouault at spatialys.com>
+
+	* tools/tiff2bw.c: fix weight computation that could result of color
+	value overflow (no security implication). Fix bugzilla #2550.
+	Patch by Frank Freudenberg.
+
+2016-08-15 Even Rouault <even.rouault at spatialys.com>
+
+	* tools/rgb2ycbcr.c: validate values of -v and -h parameters to
+	avoid potential divide by zero. Fixes CVE-2016-3623 (bugzilla #2569)
+
+2016-08-15 Even Rouault <even.rouault at spatialys.com>
+
+	* tools/tiffcrop.c: Fix out-of-bounds write in loadImage().
+	From patch libtiff-CVE-2016-3991.patch from
+	libtiff-4.0.3-25.el7_2.src.rpm by Nikola Forro (bugzilla #2543)
+
+2016-08-15 Even Rouault <even.rouault at spatialys.com>
+
+	* libtiff/tif_pixarlog.c: Fix write buffer overflow in PixarLogEncode
+	if more input samples are provided than expected by PixarLogSetupEncode.
+	Idea based on libtiff-CVE-2016-3990.patch from
+	libtiff-4.0.3-25.el7_2.src.rpm by Nikola Forro, but with different and
+	simpler check. (bugzilla #2544)
+
+2016-08-15 Even Rouault <even.rouault at spatialys.com>
+
+	* tools/tiff2rgba.c: Fix integer overflow in size of allocated
+	buffer, when -b mode is enabled, that could result in out-of-bounds
+	write. Based initially on patch tiff-CVE-2016-3945.patch from
+	libtiff-4.0.3-25.el7_2.src.rpm by Nikola Forro, with correction for
+	invalid tests that rejected valid files. (bugzilla #2545)
+
+2016-07-11 Even Rouault <even.rouault at spatialys.com>
+
+	* tools/tiffcrop.c: Avoid access outside of stack allocated array
+	on a tiled separate TIFF with more than 8 samples per pixel.
+	Reported by Kaixiang Zhang of the Cloud Security Team, Qihoo 360
+	(CVE-2016-5321 / CVE-2016-5323 , bugzilla #2558 / #2559)
+
+2016-07-10 Even Rouault <even.rouault at spatialys.com>
+
+	* libtiff/tif_read.c: Fix out-of-bounds read on
+	memory-mapped files in TIFFReadRawStrip1() and TIFFReadRawTile1()
+	when stripoffset is beyond tmsize_t max value (reported by
+	Mathias Svensson)
+
+2016-07-10 Even Rouault <even.rouault at spatialys.com>
+
+	* tools/tiffdump.c: fix a few misaligned 64-bit reads warned
+	by -fsanitize
+
+2016-07-03 Even Rouault <even.rouault at spatialys.com>
+
+	* libtiff/tif_read.c: make TIFFReadEncodedStrip() and
+	TIFFReadEncodedTile() directly use user provided buffer when
+	no compression (and other conditions) to save a memcpy().
+
+	* libtiff/tif_write.c: make TIFFWriteEncodedStrip() and
+	TIFFWriteEncodedTile() directly use user provided buffer when
+	no compression to save a memcpy().
+
+2016-07-01  Even Rouault <even.rouault at spatialys.com>
+
+	* libtiff/tif_luv.c: validate that for COMPRESSION_SGILOG and
+	PHOTOMETRIC_LOGL, there is only one sample per pixel. Avoid
+	potential invalid memory write on corrupted/unexpected images when
+	using the TIFFRGBAImageBegin() interface (reported by
+	Clay Wood)
+
+2016-06-28  Even Rouault <even.rouault at spatialys.com>
+
+	* libtiff/tif_pixarlog.c: fix potential buffer write overrun in
+	PixarLogDecode() on corrupted/unexpected images (reported by Mathias Svensson)
+	(CVE-2016-5875)
+
+2016-06-15  Bob Friesenhahn  <bfriesen@simple.dallas.tx.us>
+
+	* libtiff/libtiff.def: Added _TIFFMultiply32 and _TIFFMultiply64
+	to libtiff.def
+
+2016-06-05  Bob Friesenhahn  <bfriesen@simple.dallas.tx.us>
+
+	* tools/Makefile.am: The libtiff tools bmp2tiff, gif2tiff,
+	ras2tiff, sgi2tiff, sgisv, and ycbcr are completely removed from
+	the distribution.  The libtiff tools rgb2ycbcr and thumbnail are
+	only built in the build tree for testing.  Old files are put in
+	new 'archive' subdirectory of the source repository, but not in
+	distribution archives.  These changes are made in order to lessen
+	the maintenance burden.
+
+2016-05-10  Bob Friesenhahn  <bfriesen@simple.dallas.tx.us>
+
+	* libtiff/tif_config.vc.h (HAVE_SNPRINTF): Add a '1' to the
+	HAVE_SNPRINTF definition.'
+
+2016-05-09  Bob Friesenhahn  <bfriesen@simple.dallas.tx.us>
+
+	* libtiff/tif_config.vc.h (HAVE_SNPRINTF): Applied patch by Edward
+	Lam to define HAVE_SNPRINTF for Visual Studio 2015.
+
+2016-04-27  Even Rouault <even.rouault at spatialys.com>
+
+	* libtiff/tif_dirread.c: when compiled with DEFER_STRILE_LOAD,
+	fix regression, introduced on 2014-12-23, when reading a one-strip
+	file without a StripByteCounts tag. GDAL #6490
+
+2016-04-07  Bob Friesenhahn  <bfriesen@simple.dallas.tx.us>
+
+	* html/bugs.html: Replace Andrey Kiselev with Bob Friesenhahn for
+	purposes of security issue reporting.
+
+2016-01-23  Even Rouault <even.rouault at spatialys.com>
+
+	* libtiff/*: upstream typo fixes (mostly contributed by Kurt Schwehr)
+	coming from GDAL internal libtiff
+
+2016-01-09  Even Rouault <even.rouault at spatialys.com>
+
+	* libtiff/tif_fax3.h: make Param member of TIFFFaxTabEnt structure
+	a uint16 to reduce size of the binary.
+
+2016-01-03  Even Rouault <even.rouault at spatialys.com>
+
+	* libtiff/tif_read.c, tif_dirread.c: fix indentation issues raised
+	by GCC 6 -Wmisleading-indentation
+
+2015-12-27  Even Rouault <even.rouault at spatialys.com>
+
+	* libtiff/tif_pixarlog.c: avoid zlib error messages to pass a NULL
+	string to %s formatter, which is undefined behaviour in sprintf().
+
+2015-12-27  Even Rouault <even.rouault at spatialys.com>
+
+	* libtiff/tif_next.c: fix potential out-of-bound write in NeXTDecode()
+	triggered by http://lcamtuf.coredump.cx/afl/vulns/libtiff5.tif
+	(bugzilla #2508)
+
+2015-12-27  Even Rouault <even.rouault at spatialys.com>
+
+	* libtiff/tif_luv.c: fix potential out-of-bound writes in decode
+	functions in non debug builds by replacing assert()s by regular if
+	checks (bugzilla #2522).
+	Fix potential out-of-bound reads in case of short input data.
+
+2015-12-26  Even Rouault <even.rouault at spatialys.com>
+
+	* libtiff/tif_getimage.c: fix out-of-bound reads in TIFFRGBAImage
+	interface in case of unsupported values of SamplesPerPixel/ExtraSamples
+	for LogLUV / CIELab. Add explicit call to TIFFRGBAImageOK() in
+	TIFFRGBAImageBegin(). Fix CVE-2015-8665 reported by limingxing and
+	CVE-2015-8683 reported by zzf of Alibaba.
+
+2015-12-21  Even Rouault <even.rouault at spatialys.com>
+
+	* libtiff/tif_dirread.c: workaround false positive warning of Clang Static
+	Analyzer about null pointer dereference in TIFFCheckDirOffset().
+
+2015-12-19  Even Rouault <even.rouault at spatialys.com>
+
+	* libtiff/tif_fax3.c: remove dead assignment in Fax3PutEOLgdal(). Found
+	by Clang Static Analyzer
+
+2015-12-18  Even Rouault <even.rouault at spatialys.com>
+
+	* libtiff/tif_dirwrite.c: fix truncation to 32 bit of file offsets in
+	TIFFLinkDirectory() and TIFFWriteDirectorySec() when aligning directory
+	offsets on a even offset (affects BigTIFF). This was a regression of the
+	changeset of 2015-10-19.
+
+2015-12-12  Even Rouault <even.rouault at spatialys.com>
+
+	* libtiff/tif_write.c: TIFFWriteEncodedStrip() and TIFFWriteEncodedTile()
+	should return -1 in case of failure of tif_encodestrip() as documented
+	* libtiff/tif_dumpmode.c: DumpModeEncode() should return 0 in case of
+	failure so that the above mentionned functions detect the error.
+
+2015-12-06  Even Rouault <even.rouault at spatialys.com>
+
+	* libtiff/uvcode.h: const'ify uv_code array
+
+2015-12-06  Even Rouault <even.rouault at spatialys.com>
+
+	* libtiff/tif_dirinfo.c: const'ify tiffFields, exifFields,
+	tiffFieldArray and exifFieldArray arrays
+
+2015-12-06  Even Rouault <even.rouault at spatialys.com>
+
+	* libtiff/tif_print.c: constify photoNames and orientNames arrays
+
+2015-12-06  Even Rouault <even.rouault at spatialys.com>
+
+	* libtiff/tif_close.c, libtiff/tif_extension.c : rename link
+	variable to avoid -Wshadow warnings
+
+2015-11-22  Even Rouault <even.rouault at spatialys.com>
+
+	* libtiff/*.c: fix typos in comments (patch by Kurt Schwehr)
+ 
+2015-11-22  Even Rouault <even.rouault at spatialys.com>
+
+	* libtiff/*.c: fix MSVC warnings related to cast shortening and
+	assignment within conditional expression
+
+2015-11-18  Even Rouault <even.rouault at spatialys.com>
+
+	* libtiff/*.c: fix clang -Wshorten-64-to-32 warnings
+
+2015-11-18  Even Rouault <even.rouault at spatialys.com>
+
+	* libtiff/tif_dirread.c: initialize double* data at line 3693 to NULL
+	to please MSVC 2013
+
+2015-11-17  Even Rouault <even.rouault at spatialys.com>
+
+	* libtiff/tif_dirread.c: prevent reading ColorMap or TransferFunction
+	if BitsPerPixel > 24, so as to avoid huge memory allocation and file
+	read attempts
+
+2015-11-02  Even Rouault <even.rouault at spatialys.com>
+
+	* libtiff/tif_dirread.c: remove duplicated assignment (reported by
+	Clang static analyzer)
+
+2015-10-28  Even Rouault <even.rouault at spatialys.com>
+
+	* libtiff/tif_dir.c, libtiff/tif_dirinfo.c, libtiff/tif_compress.c,
+	libtiff/tif_jpeg_12.c: suppress warnings about 'no previous
+	declaration/prototype'
+
+2015-10-19  Even Rouault <even.rouault at spatialys.com>
+
+	* libtiff/tiffiop.h, libtiff/tif_dirwrite.c: suffix constants by U to fix 
+	'warning: negative integer implicitly converted to unsigned type' warning
+	(part of -Wconversion)
+
+2015-10-17  Even Rouault <even.rouault at spatialys.com>
+
+	* libtiff/tif_dir.c, libtiff/tif_dirread.c, libtiff/tif_getimage.c,
+	  libtiff/tif_print.c: fix -Wshadow warnings (only in libtiff/)
+
+2015-09-12  Bob Friesenhahn  <bfriesen@simple.dallas.tx.us>
+
+	* libtiff 4.0.6 released.
+
+	* html/v4.0.6.html: Added release notes for 4.0.6.
+
+2015-09-06  Bob Friesenhahn  <bfriesen@simple.dallas.tx.us>
+
+	* tools/tiffgt.c: Silence glut API deprecation warnings on MacOS
+	X.  Patch by Roger Leigh.
+
+	* Makefile.am: Added a 'coverity' rule to assist with Coverity
+	submissions.
+
+	* tools/tiff2pdf.c: Fix compiler warning about unused function
+	when JPEG is not available.
+
+	* tools/fax2ps.c (main): Detect failure to write to temporary
+	file.
+
+2015-09-05  Bob Friesenhahn  <bfriesen@simple.dallas.tx.us>
+
+	* libtiff/tif_dirread.c (TIFFReadDirEntryCheckRangeSlongSlong8):
+	Change implementation so that it does not sometimes overflow the
+	range of a 32-bit int and to avoid a signed vs unsigned compare
+	compiler warning.
+	(TIFF_INT64_MAX): Avoid use of platform-specific large constants.
+	(TIFF_UINT32_MAX): Avoid use of platform-specific large constants.
+
+2015-09-01  Bob Friesenhahn  <bfriesen@simple.dallas.tx.us>
+
+	* Makefile.am (distcheck-hook), configure.ac: Applied patches by
+	Roger Leigh (via tiff mailing list on 2015-09-01) to fix issue
+	with BSD make and to make use of cmake in 'distcheck' target
+	conditional on if cmake is available.
+
+	* CMakeLists.txt, Makefile.am, configure.ac: Applied patches by
+	Roger Leigh (via tiff mailing list on 2015-09-01).
+
+	CMake build is now included in 'distcheck' target.
+
+	Builds with CMake 2.8.9 and newer.
+
+	Tar is now resquested to use POSIX PAX format.
+
+2015-08-31  Bob Friesenhahn  <bfriesen@simple.dallas.tx.us>
+
+	* CMakeLists.txt, libtiff/test/Makefile.am: Applied patches by
+	Roger Leigh (via tiff mailing list on 2015-08-31.
+
+	CMake reads all version information directly from configure.ac to
+	avoid duplication of values.  This basically greps over the file
+	for the LIBTIFF_* variables, then translates them to the form
+	needed for cmake. This includes the release version and libtool
+	shared library version information.
+
+	Make shared/static library building configurable.  Currently it
+	always builds shared libraries, with static libs having a _static
+	suffix (copying zlib, but it means it's got a non-standard name).
+	CMake has a -DBUILD_SHARED_LIBS=ON|OFF option to select one or the
+	other, which is now used instead.  There's now a single "tiff"
+	target to build either shared or static as required, and all the
+	tests and tools are linked with this. Note: the Windows tests fail
+	when linked with a static libtiff (says: libtiff.dll not found).
+	Not really a regression since this was not tested up to this
+	point, and it's likely the unit tests haven't (ever?) been run on
+	Windows with a static libtiff, so there's some additional
+	portability issue here to address.  Works fine on UNIX systems,
+	and fine on Windows with the default to build a DLL.
+
+	Add a missing file which wasn't being distributed, causing unit
+	tests to fail.  Note that "find . -name '*.cmake'" lists all the
+	CMake files which need distributing in addition to all the
+	CMakeLists.txt files (which now are distributed).
+
+2015-08-31  Even Rouault <even.rouault at spatialys.com>
+
+	* libtiff/tif_predict.c: pedantic change to add explicit masking
+	with 0xff before casting to uchar in floating-point horizontal
+	differencing and accumulation routines.
+
+2015-08-31  Even Rouault <even.rouault at spatialys.com>
+
+	* libtiff/tif_predict.c: fix generation of output with 16 bit
+	or 32 bit integer, when byte swapping is needed, in
+	horizontal predictor (#2521). Also fixes decoding when there is
+	a single pixel to code (unlikely case...) and byte swapping is
+	involved.
+
+2015-08-30  Even Rouault <even.rouault at spatialys.com>
+
+	* libtiff/tif_lzw.c: make nextdata a unsigned type to avoid
+	undefined behaviour with shifts (gcc -fsanitize=shift)
+
+2015-08-30  Even Rouault <even.rouault at spatialys.com>
+
+	* libtiff/tif_fax3.c, libtiff/tif_lzw.c, libtiff/tif_predict.c:
+	add explicit masking with 0xff before casting
+	to unsigned char (make icc -check=conversions happy)
+
+	* libtiff/tif_predict.c: operate on unsigned datatypes when
+	computing/applying differences to avoid undefined behaviour of
+	signed types (C standard compliance)
+
+2015-08-30  Bob Friesenhahn  <bfriesen@simple.dallas.tx.us>
+
+	* configure.ac: libtiff 4.0.5 released.
+
+2015-08-29  Bob Friesenhahn  <bfriesen@simple.dallas.tx.us>
+
+	* CMakeLists.txt: Applied patch by Roger Leigh (via tiff mailing
+	list on 2015-08-29) to add ld-version-script option to cmake build
+	to match autoconf.  Note: defaults to 'on' to be ABI-compatible by
+	default with common Linux distribution builds.  Note that the
+	autoconf configure script defaults to 'off'.
+
+	* html/build.html: Applied patch by Roger Leigh (via tiff mailing
+	list on 2015-08-29) to describe how to use CMake to build libtiff.
+
+2015-08-28  Bob Friesenhahn  <bfriesen@simple.dallas.tx.us>
+
+	* html/v4.0.5.html: Added HTML file describing the changes which
+	will appear in the 4.0.5 release.
+
+2015-08-23  Bob Friesenhahn  <bfriesen@simple.dallas.tx.us>
+
+	* libtiff/tiffiop.h: For MinGW comiles, make sure that build
+	supports necessary __MSVCRT_VERSION__ (at least at least 0x800).
+	Otherwise large files can not be supported for POSIX-style I/O.
+
+	* tools/fax2tiff.c (main): Eliminate a compiler warning in 64-bit
+	builds about cast to thandle_t.
+
+	* test/rewrite_tag.c (main): Does not require any arguments.
+
+2015-08-20  Bob Friesenhahn  <bfriesen@simple.dallas.tx.us>
+
+	* tools/CMakeLists.txt, port/snprintf.c: Patch by Roger Leigh to
+	fix build issues when using Cmake due to Windows large file
+	changes.
+
+2015-08-18  Bob Friesenhahn  <bfriesen@simple.dallas.tx.us>
+
+	* libtiff/tiffiop.h: First cut at supporting large files under
+	Microsoft Windows using tif_unix.c and the libtiff tools.  This
+	only works if the Windows CDK is new enough to support the APIs
+	used (Visual C++ 2005 or later).  Support for large files is not
+	actually tested yet.
+
+2015-08-15  Bob Friesenhahn  <bfriesen@simple.dallas.tx.us>
+
+	* libtiff/tif_jpeg.c: Applied patch by Räisä Olli to assure that
+	client_data is initialized to a known value, and to report an
+	error on two memory allocation failures.
+
+2015-08-13  Bob Friesenhahn  <bfriesen@simple.dallas.tx.us>
+
+	* CMakeLists.txt: Applied patch by Roger Leigh to fix libtiffxx
+	symbol versioning.  Patch was mailed to libtiff list on Thu, 13
+	Aug 2015.
+
+2015-07-04  Bob Friesenhahn  <bfriesen@simple.dallas.tx.us>
+
+	* cmake: Add d suffix to debug libraries with MSVC.  Patch #3 of 3
+	by Roger Leigh posted to tiff list on Wed, 1 Jul 2015 15:58:20
+	+0100.
+
+	* cmake: Add extra warning flags.  Patch #2 of 3 by Roger Leigh
+	posted to tiff list on Wed, 1 Jul 2015 15:58:20 +0100.
+
+	* cmake: Correct snprintf fallback for VS2015.  Patch #1 of 3 by
+	Roger Leigh posted to tiff list on Wed, 1 Jul 2015 15:58:20 +0100.
+
+2015-06-24  Bob Friesenhahn  <bfriesen@simple.dallas.tx.us>
+
+	* CMakeLists.txt: Add CMake patchset by Roger Leigh as posted to
+	libtiff mailing list on Mon, 22 Jun 2015 21:21:01 +0100. Several
+	corrections to ensure that the autotools build still works were
+	added by me.  I have not yet tested the build using 'cmake' or
+	MSVC with 'nmake'.
+
+2015-06-21  Bob Friesenhahn  <bfriesen@simple.dallas.tx.us>
+
+	* test/Makefile.am: tiff2rgba-quad-tile.jpg.sh depends on the JPEG
+	library so only execute if JPEG is available.
+
+	* libtiff 4.0.4 released.
+
+	* configure.ac: Add a HAVE_FOO Automake conditional for each
+	add-on library.
+
+	* test/Makefile.am (JPEG_DEPENDENT_CHECK_PROG): raw_decode
+	requires JPEG support to compile.  Use Automake conditional to
+	only include it when JPEG support is available.
+
+	* html/build.html: Try to improve the nmake-based VC++ build
+	description.
+
+	* libtiff/tiffconf.vc.h: Build fixes based on testing.
+
+	* libtiff/tif_config.vc.h: Build fixes based on testing.
+
+	* libtiff/libtiff.def: TIFFRasterScanline does not exist so remove
+	export for it.
+
+2015-06-20  Bob Friesenhahn  <bfriesen@simple.dallas.tx.us>
+
+	* libtiff/tif_config.vc.h: Make adjustments to match the new
+	definitions that configure produces, including for WIN64.  Still
+	needs to be tested.
+
+	* configure.ac: For 64-bit MinGW, fix SSIZE_FORMAT formatting
+	specifier.  64-bit MinGW supports 'long long' but support for
+	'lld' is not assured by the run-time DLLs and so GCC warns.
+	Add TIFF_SIZE_T and TIFF_SIZE_FORMAT to provide a type definition
+	and printf format specifier to deal with printing values of
+	'size_t' type.  In particular, this was necessary for WIN64.
+	Added a configure test for if the system headers provide 'optarg'
+	(normal case) and block out the many explicit 'extern' statements
+	in the utilities.  This was found to be necessary under Windows
+	when getopt is in a DLL and the symbols are already imported with
+	dllimport via standard header files.
+
+	* test/raw_decode.c (XMD_H): Avoid conflicting typedefs for INT32
+	and boolean in MinGW build due to including jpeglib.h.
+
+	* test/rewrite_tag.c (main): Fix problem with location of variable
+	declaration.
+
+	* libtiff/libtiff.def: Added exports for TIFFGetConfiguredCODECs,
+	TIFFReadRGBAImageOriented, TIFFSetCompressionScheme,
+	TIFFSwabArrayOfTriples, TIFFVGetFieldDefaulted, _TIFFCheckRealloc,
+	TIFFRasterScanline, TIFFSetErrorHandlerExt,
+	TIFFSetWarningHandlerExt, TIFFNumberOfDirectories,
+	TIFFCreateCustomDirectory, TIFFCreateEXIFDirectory,
+	TIFFWriteCustomDirectory, _TIFFRewriteField as recommended by
+	Roger Leigh and justified by use in libtiff tests, documentation,
+	and changelog notes.  Also sorted symbol list and removed
+	duplicate entries.
+
+2015-06-16  Bob Friesenhahn  <bfriesen@simple.dallas.tx.us>
+
+	* libtiff/tif_getimage.c: Fix four Coverity issues related to
+	unintended sign extension.
+
+2015-06-16  Even Rouault <even.rouault at spatialys.com>
+
+	* libtiff/tif_unix.c: fix compilation with MSVC (fix by Jeff McKenna)
+
+2015-06-14  Lee Howard  <faxguy@howardsilvan.com>
+
+	* libtiff/tif_unix.c: contribution from Vadim Zeitlin on
+	Bugzilla Bug #2510 fixes several harmless but still annoying
+	warnings
+
+	* configure: contribution from Ludolf Holzheid on Bugzilla
+	Bug #2498.  Adds an option to select the file I/O style on
+	Windows hosts.
+
+	* libtiff/tif_getimage.c: contribution from Gary Cramblitt
+	on Bugzilla Bug #2409.  Correct reading of certain tiled TIFFs.
+
+	* configure, configure.ac: contribution from Marcos H. Woehrmann
+	on Bugzilla Bug #2405.  Correct shell equality operator.
+
+	* tools/tiffgt.c (raster_draw): contribution from Jay Berkenbilt
+	on Bugzilla Bug #2401.  Appropriately call glFlush().
+
+	* tools/tiff2pdf.c: change ColorTransform from "0" to "1"
+	following Bugzilla Bug #2150.
+
+2015-06-13  Lee Howard  <faxguy@howardsilvan.com>
+
+	* libtiff/tif_lzw.c: contribution from Andy Cave - decode
+	files that contain consecutive CODE_CLEAR codes.
+
+	* tools/tiff2pdf.c: contribution from Antti S. Lankila on
+	Bugzilla Bug #2078. Suppress initial output of the header.
+
+	* tools/tiff2pdf.c: contribution from Yuriy M. Kaminskiy -
+	Take care in using the return value from snprintf().
+
+	* tools/tiffcrop.c: contribution from Eduardo Robles Elvira -
+	correctly copy the compression tag from the source TIFF.
+
+	* tools/tiff2ps.c: contribution from Eduardo Robles Elvira -
+	correct sizing and scaling problems with output document.
+
+2015-06-10  Bob Friesenhahn  <bfriesen@simple.dallas.tx.us>
+
+	* libtiff/tif_jpeg.c (JPEGDecode): Split JPEGDecode() into two
+	clean implementations in order to avoid pre-processor hell.  Only
+	one of the implementations is used in a given build.
+
+2015-06-08  Even Rouault <even.rouault at spatialys.com>
+
+	* libtiff/tif_jpeg.c: Fix compilation in BITS_IN_JSAMPLE == 12
+	case
+
+2015-06-07  Bob Friesenhahn  <bfriesen@simple.dallas.tx.us>
+
+	* libtiff/tif_write.c (TIFFWriteEncodedStrip): Fix Coverity 715975
+	"Division or modulo by zero".
+	(TIFFWriteEncodedTile): Fix Coverity 715976 and 715977 "Division
+	or modulo by zero".
+	(TIFFWriteRawStrip): Fix Coverity 715978 "Division or modulo by
+	zero".
+	(TIFFWriteScanline): Fix Coverity 715979 "Division or modulo by
+	zero".
+
+	* libtiff/tif_read.c (TIFFStartTile): Fix Coverity 715973 and
+	715974 "Division or modulo by zero".
+
+2015-05-31  Bob Friesenhahn  <bfriesen@simple.dallas.tx.us>
+
+	* libtiff/tif_dir.c (TIFFNumberOfDirectories): Quiet Coverity
+	1134470 "Logically dead code" by making the roll-over check
+	explicit.
+
+	* libtiff/tif_luv.c (LogLuvDecodeTile): Fix Coverity 991227
+	"Division or modulo by zero".
+	(LogLuvDecodeStrip): Fix Coverity 991239 "Division or modulo by
+	zero".
+	(LogLuvEncodeStrip): Fix Coverity 991240 "Division or modulo by
+	zero".
+	(LogLuvEncodeTile): Fix Coverity 991241 "Division or modulo by
+	zero".
+
+	* libtiff/tif_dirread.c (TIFFReadDirEntryDoubleArray): Fix
+	Coverity 298626 "Logically dead code".
+	(TIFFReadDirEntryFloatArray): Fix Coverity 298627 "Logically dead
+	code".
+	(TIFFReadDirEntryIfd8Array): Fix Coverity 298628 "Logically dead
+	code".
+	(TIFFReadDirEntrySlong8Array): Fix Coverity 298629 "Logically dead
+	code"
+
+	* libtiff/tif_dir.c (TIFFNumberOfDirectories): Don't depend on ++
+	operator precedenc in evaluation.  Might quench Coverity 1134470
+	"Logically dead code".
+
+	* libtiff/tif_jpeg.c (JPEGDecode): Fix Coverity 602597 "Operands
+	don't affect result".  This change uses ifdefs to include
+	applicable code based on properties of libjpeg.  Still needs to be
+	re-tested with 12-bit "6b" and "MK1".
+
+2015-05-30  Bob Friesenhahn  <bfriesen@simple.dallas.tx.us>
+
+	* libtiff/tif_dirwrite.c (_TIFFRewriteField): Fix Coverity 1024310
+	"Resource leak".
+
+	* libtiff/tif_ojpeg.c (OJPEGReadHeaderInfoSecStreamDht): Fix
+	Coverity 601720 "Resource leak".
+
+	* libtiff/tif_jpeg.c (JPEGCleanup): Fix Coverity 298624
+	"Dereference before null check".
+
+	* libtiff/tif_ojpeg.c (OJPEGReadBufferFill): Fix Coverity 603400
+	"Missing break in switch".
+
+	* contrib/addtiffo/tif_overview.c (TIFF_DownSample): Check buffer
+	size calculation for overflow.
+
+	* contrib/addtiffo/addtiffo.c (main): Possibly address Coverity
+	1024226 "Untrusted value as argument".
+
+	* tools/gif2tiff.c (readgifimage): Fix Coverity 1024222 "Untrusted
+	value as argument".
+	(checksignature): Fix Coverity 1024894 "Ignoring number of bytes
+	read".
+	(readextension): Fix Coverity 1024893 "Ignoring number of bytes
+	read".
+	(readgifimage): Fix Coverity 1024890 "Ignoring number of bytes
+	read".
+	(readraster): Fix Coverity 1024891 "Ignoring number of bytes
+	read".
+	(readgifimage): Fix Coverity 1024892 "Ignoring number of bytes
+	read".
+
+	* tools/tiff2pdf.c (t2p_readwrite_pdf_image): Fix Coverity 1024181
+	"Structurally dead code".
+
+	* tools/raw2tiff.c (main): Fix Coverity 1024887 "Unchecked return
+	value from library".
+	(guessSize): Fix Coverity 1024888 "Unchecked return value from
+	library".
+	(guessSize): Fix Coverity 1214162 "Ignoring number of bytes read".
+	(guessSize): Fix Coverity 1024889 "Unchecked return value from
+	library".
+
+	* tools/tiff2pdf.c (t2p_readwrite_pdf_image): Fix Coverity 298621
+	"Resource leak".
+	(t2p_readwrite_pdf_image): Fix Coverity 1024181 "Structurally dead
+	code".
+	(t2p_write_pdf): Fix Coverity 1227690 "Unused value".
+
+2015-05-29  Bob Friesenhahn  <bfriesen@simple.dallas.tx.us>
+
+	* contrib/iptcutil/iptcutil.c (formatIPTC): Fix Coverity 1024468
+	"Infinite loop".
+	(formatIPTC): Fix Coverity 1024727 "Truncated stdio return value".
+	(formatIPTC): Fix Coverity 1214240 "Untrusted loop bound".
+
+2015-05-28  Bob Friesenhahn  <bfriesen@simple.dallas.tx.us>
+
+	* contrib/addtiffo/tif_ovrcache.c (TIFFCreateOvrCache): Fix
+	Coverity 298615 "Resource leak".
+	(TIFFGetOvrBlock): Fix Coverity 1024649 "Unintended sign
+	extension".
+
+	* tools/bmp2tiff.c (main): Fix Coverity 1024225 "Untrusted value
+	as argument".
+	(main): Fix Coverity 1024678 "Unchecked return value from
+	library".
+	(main): Fix Coverity 1024679 "Unchecked return value from
+	library".
+	(main): Fix Coverity 1214160 "Ignoring number of bytes read".
+
+	* contrib/addtiffo/tif_ovrcache.c (TIFFCreateOvrCache): Fix
+	Coverity 298615 "Resource leak".
+
+	* tools/tiffcp.c: Fix Coverity 1024306, 1024307, 1024308, 1024309
+	"Resource leak".
+
+	* tools/tiffsplit.c (cpTiles): Fix Coverity 1024304 "Resource
+	leak".
+	(cpStrips): Fix Coverity 1024305 "Resource leak".
+
+2015-05-27  Bob Friesenhahn  <bfriesen@simple.dallas.tx.us>
+
+	* tools/ras2tiff.c: Fix Sun Raster header definition to be safe
+	for 64-bit systems.  Add some header validations.  Should fix many
+	Coverity issues.
+	(main): Fix Coverity 1301206: "Integer handling issues  (BAD_SHIFT)".
+	(main): Quiet Coverity 1024223 "Untrusted value as argument".
+
+	* tools/tiffmedian.c (GetInputLine): Fix Coverity 1024795 "Nesting
+	level does not match indentation".
+	(get_histogram): Quiet Coverity 1024386 "Out-of-bounds read".
+	This was a benign mis-diagnosis but added code to enforce against
+	buffer overflow.
+
+	* tools/tiffcrop.c (ROTATE_ANY): Fix Coverity 1294542 "Logical
+	vs. bitwise operator".
+	(readContigStripsIntoBuffer): Fix Coverity 1024545 "Division or
+	modulo by zero".
+	(readContigTilesIntoBuffer): Fix Coverity 1024586 "Logically dead
+	code".
+	(writeSingleSection): Fix Coverity 1024796 "Nesting level does not
+	match indentation".
+	(writeCroppedImage): Fix Coverity 1024797 "Nesting level does not
+	match indentation".
+	(loadImage): Fix Coverity 1299741 "Dereference before null check".
+	(loadImage): Fix Coverity 1299740 "Out-of-bounds write".
+
+2015-03-02  Even Rouault  <even.rouault@spatialys.com>
+
+	* tools/tiffdither.c: check memory allocations to avoid writing to
+	NULL pointer. Also check multiplication overflow. Fixes #2501,
+	CVE-2014-8128. Derived from patch by Petr Gajdos.
+
+2015-01-26  Even Rouault  <even.rouault@spatialys.com>
+
+	* add html/v4.0.4beta.html under version control
+	* HOWTO-RELEASE: write that cvs add html/vX.X.html must be used
+
+2015-01-26  Even Rouault  <even.rouault@spatialys.com>
+
+	* libtiff 4.0.4beta released
+
+2015-01-26  Even Rouault  <even.rouault@spatialys.com>
+
+	* automake: updated to 1.15
+	* libtool: updated to 2.4.5
+
+2015-01-22  Even Rouault  <even.rouault@spatialys.com>
+
+	* tools/tiff2pdf.c: Fix two crashes (oCERT-2014-013)
+
+2015-01-05  Frank Warmerdam  <warmerdam@pobox.com>
+
+	* html/bugs.html: remove note about needing to email the tiff mailing
+	list administrator about being approved for membership, this appears
+	not to be true.
+
+2015-01-05  Olivier Paquet  <olivier.paquet@gmail.com>
+
+	* tools/tiff2pdf.c: Fixed unsigned integer addition overflow detection.
+
+2015-01-03  Even Rouault  <even.rouault@spatialys.com>
+
+	* libtiff/tif_dirread.c: in TIFFCheckDirOffset(), avoid uint16 overflow
+	when reading more than 65535 directories, and effectively error out when
+	reaching that limit.
+
+2014-12-29  Even Rouault  <even.rouault@spatialys.com>
+
+	* libtiff/tif_jpeg.c: in JPEGFixupTags(), recognize SOF2, SOF9 and SOF10
+	markers to avoid emitting a warning (even if, according to the TechNote,
+	there are admittedly unusual/not recommended or even forbidden variants, but
+	they do work well with libjpeg for SOF2, and with libjpeg-turbo for SOF2,
+	SOF9 and SOF10).
+	Define in_color_space and input_components to the right values in
+	JPEGSetupEncode(), before calling jpeg_set_defaults(), as specified by
+	libjpeg API documentation, so as to be compatible with mozjpeg library.
+	Note: the default settings of mozjpeg will produce progressive scans, which
+	is forbidden by the TechNote.
+
+2014-12-29  Even Rouault  <even.rouault@spatialys.com>
+
+	* libtiff/tif_getimage.c: move test on vertical value of YCbCr subsampling.
+	to avoid buffer leak (fix previous fix, found by Coverity scan)
+
+2014-12-29  Even Rouault  <even.rouault@spatialys.com>
+
+	* libtiff/tif_next.c: add new tests to check that we don't read outside of
+	the compressed input stream buffer.
+
+	* libtiff/tif_getimage.c: in OJPEG case, fix checks on strile width/height
+    in the putcontig8bitYCbCr42tile, putcontig8bitYCbCr41tile and
+    putcontig8bitYCbCr21tile cases.
+
+2014-12-27  Even Rouault  <even.rouault@spatialys.com>
+
+	* libtiff/tif_dir.c: in TIFFDefaultDirectory(), reset any already existing
+	extented tags installed by user code through the extender mechaninm before
+	calling the extender callback (GDAL #5054)
+
+2014-12-26  Bob Friesenhahn  <bfriesen@simple.dallas.tx.us>
+
+	* tools/tiffcrop.c: Fix warnings about variables set but not used.
+
+	* contrib/iptcutil/iptcutil.c: Fix warnings about variables set
+	but not used.
+
+	* tools/tiffgt.c: Fix warnings about unused parameters.
+
+	* libtiff/tif_stream.cxx: Fix warnings about unused parameters.
+
+2014-12-25  Even Rouault  <even.rouault@spatialys.com>
+
+	* libtiff/tif_getimage.c, libtiff/tif_ojpeg.c, libtiff/tif_zip.c: fix
+	various typos found by Debian lintian tool (GDAL #5756)
+
+2014-12-24  Even Rouault  <even.rouault@spatialys.com>
+
+	* libtiff/tif_getimage.c: avoid divide by zero on invalid YCbCr subsampling.
+	http://bugzilla.maptools.org/show_bug.cgi?id=2235
+
+2014-12-24  Even Rouault  <even.rouault@spatialys.com>
+
+	* tools/tiff2pdf.c: fix buffer overflow on some YCbCr JPEG compressed images.
+	http://bugzilla.maptools.org/show_bug.cgi?id=2445
+
+2014-12-24  Even Rouault  <even.rouault@spatialys.com>
+
+	* tools/tiff2pdf.c: fix buffer overflow on YCbCr JPEG compressed image.
+	Derived from patch by Petr Gajdos,
+	http://bugzilla.maptools.org/show_bug.cgi?id=2443
+
+2014-12-23  Even Rouault  <even.rouault@spatialys.com>
+
+	* libtiff/tif_dirread.c: In EstimateStripByteCounts(), check return code
+	of _TIFFFillStriles(). This solves crashing bug on corrupted
+	images generated by afl.
+
+2014-12-23  Even Rouault  <even.rouault@spatialys.com>
+
+	* libtiff/tif_read.c: fix several invalid comparisons of a uint64 value with
+	<= 0 by casting it to int64 first. This solves crashing bug on corrupted
+	images generated by afl.
+
+2014-12-21  Bob Friesenhahn  <bfriesen@simple.dallas.tx.us>
+
+	* tools/tiffdump.c: Guard against arithmetic overflow when
+	calculating allocation buffer sizes.
+
+2014-12-21  Even Rouault  <even.rouault@spatialys.com>
+
+	* tools/tiff2bw.c: when Photometric=RGB, the utility only works if
+	SamplesPerPixel = 3. Enforce that
+	http://bugzilla.maptools.org/show_bug.cgi?id=2485 (CVE-2014-8127)
+
+2014-12-21  Even Rouault  <even.rouault@spatialys.com>
+
+	* tools/pal2rgb.c, tools/thumbnail.c: fix crash by disabling TIFFTAG_INKNAMES
+	copying. The right fix would be to properly copy it, but not worth the burden
+	for those esoteric utilities.
+	http://bugzilla.maptools.org/show_bug.cgi?id=2484 (CVE-2014-8127)
+
+2014-12-21  Even Rouault  <even.rouault@spatialys.com>
+
+	* tools/thumbnail.c: fix out-of-buffer write
+	http://bugzilla.maptools.org/show_bug.cgi?id=2489 (CVE-2014-8128)
+
+2014-12-21  Even Rouault  <even.rouault@spatialys.com>
+
+	* tools/thumbnail.c, tools/tiffcmp.c: only read/write TIFFTAG_GROUP3OPTIONS
+	or TIFFTAG_GROUP4OPTIONS if compression is COMPRESSION_CCITTFAX3 or
+	COMPRESSION_CCITTFAX4
+	http://bugzilla.maptools.org/show_bug.cgi?id=2493 (CVE-2014-8128)
+
+2014-12-21  Even Rouault  <even.rouault@spatialys.com>
+
+	* libtiff/tif_next.c: check that BitsPerSample = 2. Fixes
+	http://bugzilla.maptools.org/show_bug.cgi?id=2487 (CVE-2014-8129)
+
+2014-12-21  Even Rouault  <even.rouault@spatialys.com>
+
+	* tools/tiff2pdf.c: check return code of TIFFGetField() when reading
+	TIFFTAG_SAMPLESPERPIXEL
+
+2014-12-21  Even Rouault  <even.rouault@spatialys.com>
+
+	* tools/tiffcp.c: fix crash when converting YCbCr JPEG-compressed to none.
+	Based on patch by Tomasz Buchert (http://bugzilla.maptools.org/show_bug.cgi?id=2480)
+	Description: fix for Debian bug #741451
+	tiffcp crashes when converting JPEG-encoded TIFF to a different
+	encoding (like none or lzw). For example this will probably fail:
+	tiffcp -c none jpeg_encoded_file.tif output.tif
+	The reason is that when the input file contains JPEG data,
+	the tiffcp code forces conversion to RGB space. However,
+	the output normally inherits YCbCr subsampling parameters
+	from the input, which leads to a smaller working buffer
+	than necessary. The buffer is subsequently overrun inside
+	cpStripToTile() (called from writeBufferToContigTiles).
+	Note that the resulting TIFF file would be scrambled even
+	if tiffcp wouldn't crash, since the output file would contain
+	RGB data intepreted as subsampled YCbCr values.
+	This patch fixes the problem by forcing RGB space on the output
+	TIF if the input is JPEG-encoded and output is *not* JPEG-encoded.
+	Author: Tomasz Buchert <tomasz.buchert@inria.fr>
+
+2014-12-21  Even Rouault  <even.rouault@spatialys.com>
+
+	Fix various crasher bugs on fuzzed images.
+	* libtiff/tif_dir.c: TIFFSetField(): refuse to set negative values for
+	TIFFTAG_XRESOLUTION and TIFFTAG_YRESOLUTION that cause asserts when writing
+	the directory
+	* libtiff/tif_dirread.c: TIFFReadDirectory(): refuse to read ColorMap or
+	TransferFunction if BitsPerSample has not yet been read, otherwise reading
+	it later will cause user code to crash if BitsPerSample > 1
+	* libtiff/tif_getimage.c: TIFFRGBAImageOK(): return FALSE if LOGLUV with
+	SamplesPerPixel != 3, or if CIELAB with SamplesPerPixel != 3 or BitsPerSample != 8
+	* libtiff/tif_next.c: in the "run mode", use tilewidth for tiled images
+	instead of imagewidth to avoid crash
+	* tools/bmp2tiff.c: fix crash due to int overflow related to input BMP dimensions
+	* tools/tiff2pdf.c: fix crash due to invalid tile count (should likely be checked by
+	libtiff too). Detect invalid settings of BitsPerSample/SamplesPerPixel for CIELAB / ITULAB
+	* tools/tiffcrop.c: fix crash due to invalid TileWidth/TileHeight
+	* tools/tiffdump.c: fix crash due to overflow of entry count.
+
+2014-12-15  Even Rouault  <even.rouault@spatialys.com>
+
+	* libtiff/tif_jpeg.c: Fix regression introduced on 2010-05-07 that caused
+	all tiles/strips to include quantization tables even when the jpegtablesmode
+	had the JPEGTABLESMODE_QUANT bit set.
+	Also add explicit removal of Huffman tables when jpegtablesmode has the
+	JPEGTABLESMODE_HUFF bit set, which avoids Huffman tables to be emitted in the
+	first tile/strip (only useful in update scenarios. create-only was
+	fine)
+
+2014-12-09  Bob Friesenhahn  <bfriesen@simple.dallas.tx.us>
+
+	* tools/tiff2pdf.c: Assure that memory size calculations for
+	_TIFFmalloc() do not overflow the range of tmsize_t.
+
+2014-12-07  Even Rouault  <even.rouault@spatialys.com>
+
+	* tools/thumbnail.c, tools/tiffcrop.c: "fix" heap read over-run found with
+	Valgrind and Address Sanitizer on test suite
+
+2014-12-07  Bob Friesenhahn  <bfriesen@simple.dallas.tx.us>
+
+	* tools/tiff2pdf.c (t2p_read_tiff_init): TIFFTAG_TRANSFERFUNCTION
+	tag can return one channel, with the other two channels set to
+	NULL.  The tiff2pdf code was expecting that other two channels
+	were duplicate pointers in the case where there is only one
+	channel.  Detect this condition in order to avoid a crash, and
+	presumably perform correctly with just one channel.
+
+2014-12-06  Bob Friesenhahn  <bfriesen@simple.dallas.tx.us>
+
+	* tools/tiffdump.c: Fix double-free bug.
+
+2014-11-27  Even Rouault  <even.rouault@spatialys.com>
+
+	* libtiff/tif_config.vc.h: no longer use "#define snprintf _snprintf" with
+	Visual Studio 2015 aka VC 14 aka MSVC 1900
+
+2014-11-20  Even Rouault  <even.rouault@spatialys.com>
+
+	* libtiff/tif_lzw.c: prevent potential null dereference of
+	sp->dec_codetab in LZWPreDecode (bug #2459)
+
+	* libtiff/tif_read.c: in TIFFReadBufferSetup(), avoid passing -1 size
+	to TIFFmalloc() if passed user buffer size is 0 (bug #2459)
+
+	* libtiff/tif_ojpeg.c: make Coverity happier (not a bug, #2459)
+
+	* libtiff/tif_dir.c: in _TIFFVGetField() and _TIFFVSetField(), make
+	Coverity happier (not a bug, #2459)
+
+	* libtiff/tif_dirread.c: in TIFFFetchNormalTag(), make Coverity happier
+	(not a bug, #2459)
+
+	* tools/tiff2pdf.c: close PDF file (bug #2479)
+
+	* tools/fax2ps.c: check malloc()/realloc() result (bug #2470)
+
+	* tools/tiffdump.c: detect cycle in TIFF directory chaining (bug #2463)
+	and avoid passing a NULL pointer to read() if seek() failed before (bug #2459)
+
+	* tools/tiffcrop.c: fix segfault if bad value passed to -Z option
+	(bug #2459) and add missing va_end in dump_info (#2459)
+
+	* tools/gif2tif.c: apply patch for CVE-2013-4243 (#2451)
+
+2014-11-20  Even Rouault  <even.rouault@spatialys.com>
+	* libtiff/tif_jpeg.c: fix segfault in JPEGFixupTagsSubsampling() on
+	corrupted image where tif->tif_dir.td_stripoffset == NULL (bug #2471)
+
+2014-11-20  Even Rouault  <even.rouault@spatialys.com>
+	* automake: updated to 1.14.1
+	* libtool: updated to 2.4.3
+	* HOWTO-RELEASE: small update about autotools building order
+
+2014-10-20  Olivier Paquet  <olivier.paquet@gmail.com>
+	* tools/tiff2pdf.c: Preserve input file directory order when pages
+	are tagged with the same page number.
+
+2014-08-31  Bob Friesenhahn  <bfriesen@simple.dallas.tx.us>
+
+	* libtiff/tif_dirread.c (TIFFReadDirEntryOutputErr): Incorrect
+	count for tag should be a warning rather than an error since
+	errors terminate processing.
+
+2014-06-07  Bob Friesenhahn  <bfriesen@simple.dallas.tx.us>
+
+	* tools/tiff2rgba.c (]): Fixed tiff2rgba usage message in that zip
+	was wrongly described.  Fix suggested by Miguel Medalha.
+
+2014-05-06  Bob Friesenhahn  <bfriesen@simple.dallas.tx.us>
+
+	* libtiff/tif_dirinfo.c (TIFFField) : Fix data type for
+	TIFFTAG_GLOBALPARAMETERSIFD tag.  Patch by Steve Underwood.
+	Reviewed and forwarded by Lee Howard.
+
+2013-11-30  Frank Warmerdam  <warmerdam@pobox.com>
+
+	* libtiff/tif_dir.c: fix last fix for TIFFNumberOfDirectories()
+
+2013-10-21  Frank Warmerdam  <warmerdam@pobox.com>
+
+	* libtiff/tif_dir.c: generate error in case of directory count
+	overflow.
+
+2013-10-01  Frank Warmerdam  <warmerdam@pobox.com>
+
+	* libtiff/tiff.h, libtiff/tif_dirinfo.c: add definitions for
+	TIFF/EP CFARepeatPatternDim and CFAPattern tags (bug #2457)
+
+2013-09-12  Bob Friesenhahn  <bfriesen@simple.dallas.tx.us>
+
+	* libtiff/tif_dir.c (TIFFAdvanceDirectory): If nextdir is found to
+	be defective, then set it to zero before returning error in order
+	to terminate processing of truncated TIFF.  Issue found and fix
+	suggested by Richard Nolde.
+
+2013-08-14  Frank Warmerdam  <warmerdam@pobox.com>
+
+	* tools/gif2tiff.c: fix possible OOB write (#2452, CVE-2013-4244)
+
+2013-08-13  Frank Warmerdam  <warmerdam@pobox.com>
+
+	* tools/gif2tiff.c: Be more careful about corrupt or
+	hostile input files (#2450, CVE-2013-4231)
+
+	* tools/tiff2pdf.c: terminate after failure of allocating
+	ycbcr buffer (bug #2449, CVE-2013-4232)
+
+2013-07-09  Frank Warmerdam  <warmerdam@google.com>
+
+	* tools/tiffinfo.c: Default various values fetched with
+	TIFFGetField() to avoid being uninitialized.
+
+2013-05-02  Tom Lane  <tgl@sss.pgh.pa.us>
+
+	* tools/tiff2pdf.c: Rewrite JPEG marker parsing in
+	t2p_process_jpeg_strip to be at least marginally competent.  The
+	approach is still fundamentally flawed, but at least now it won't
+	stomp all over memory when given bogus input.  Fixes CVE-2013-1960.
+
+2013-05-02  Tom Lane  <tgl@sss.pgh.pa.us>
+
+	* contrib/dbs/xtiff/xtiff.c, libtiff/tif_codec.c,
+ 	libtiff/tif_dirinfo.c, tools/rgb2ycbcr.c, tools/tiff2bw.c,
+ 	tools/tiff2pdf.c, tools/tiff2ps.c, tools/tiffcrop.c,
+ 	tools/tiffdither.c: Enlarge some fixed-size buffers that weren't
+ 	large enough, and eliminate substantially all uses of sprintf(buf,
+ 	...)  in favor of using snprintf(buf, sizeof(buf), ...), so as to
+ 	protect against overflow of fixed-size buffers.  This responds in
+ 	particular to CVE-2013-1961 concerning overflow in tiff2pdf.c's
+ 	t2p_write_pdf_page(), but in general it seems like a good idea to
+ 	deprecate use of sprintf().
+
+2013-03-29  Bob Friesenhahn  <bfriesen@simple.dallas.tx.us>
+
+	* configure.ac: Applied patch by Brad Smith to improve pkg-config
+	static linking by adding -lm to Libs.private when needed.
+
+2013-03-05  Tom Lane  <tgl@sss.pgh.pa.us>
+
+	* html/man/tiff2ps.1.html, html/man/tiffcp.1.html,
+ 	html/man/tiffdither.1.html, man/tiff2ps.1, man/tiffcp.1,
+ 	man/tiffdither.1, tools/tiff2ps.c, tools/tiffcp.c,
+ 	tools/tiffdither.c: Sync tool usage printouts and man pages with
+ 	reality (quite a few options had escaped being documented in one
+ 	or both places).  Per an old report from Miroslav Vadkerti.
+
+2013-01-25  Bob Friesenhahn  <bfriesen@simple.dallas.tx.us>
+
+	* tools/tiff2ps.c:Fix bug in auto rotate option code. Once a
+	rotation angle was set by the auto rotate check, it was retained
+	for all pages that followed instead ofa being retested for each
+	page.  Patch by Richard Nolde.
+
+2013-01-18  Frank Warmerdam  <warmerdam@google.com>
+
+	* libtiff/tif_write.c: tmsize_t related casting warning fixed for
+	64bit linux.
+
+	* libtiff/tif_read.c: uint64/tmsize_t change for MSVC warnings.
+	http://bugzilla.maptools.org/show_bug.cgi?id=2427
+
+2012-12-20  Tom Lane  <tgl@sss.pgh.pa.us>
+
+	* test/raw_decode.c: Relax raw_decode's pixel-value checks so that
+	it will pass with more versions of libjpeg.  (There are at least
+	three in active use now, and JPEG_LIB_VERSION doesn't tell us
+	enough to uniquely identify expected results.)
+
+2012-12-12  Tom Lane  <tgl@sss.pgh.pa.us>
+
+	* libtiff/tif_print.c: Fix TIFFPrintDirectory's handling of
+	field_passcount fields: it had the TIFF_VARIABLE and
+	TIFF_VARIABLE2 cases backwards.
+
+2012-12-10  Tom Lane  <tgl@sss.pgh.pa.us>
+
+	* tools/ppm2tiff.c: Improve previous patch for CVE-2012-4564:
+ 	check the linebytes calculation too, get the max() calculation
+ 	straight, avoid redundant error messages, check for malloc
+ 	failure.
+
+2012-12-10  Tom Lane  <tgl@sss.pgh.pa.us>
+
+	* libtiff/tif_pixarlog.c: Improve previous patch for CVE-2012-4447
+ 	(to enlarge tbuf for possible partial stride at end) so that
+ 	overflow in the integer addition is detected.  Per gripe from
+ 	Huzaifa Sidhpurwala.
+
+2012-12-03  Bob Friesenhahn  <bfriesen@simple.dallas.tx.us>
+
+	* tools/tiffset.c: tiffset now supports a -u option to unset a
+	tag.  Patch by Zach Baker. See
+	http://bugzilla.maptools.org/show_bug.cgi?id=2419
+
+2012-11-18  Bob Friesenhahn  <bfriesen@simple.dallas.tx.us>
+
+	* automake: Update Automake to 1.12.5 release.
+
+	* libtiff/tif_{unix,vms,win32}.c (_TIFFmalloc): ANSI C does not
+	require malloc() to return NULL pointer if requested allocation
+	size is zero.  Assure that _TIFFmalloc does.
+
+2012-11-01  Frank Warmerdam  <warmerdam@pobox.com>
+
+	* tools/ppm2tiff.c: avoid zero size buffer vulnerability.
+	CVE-2012-4564 - Thanks to Huzaifa Sidhpurwala of the
+	Red Hat Security Response team for the fix.
+
+2012-10-18  Frank Warmerdam  <warmerdam@google.com>
+
+	* tif_zip.c: Avoid crash on NULL error messages.
+
+2012-09-22  Bob Friesenhahn  <bfriesen@simple.dallas.tx.us>
+
+	* libtiff 4.0.3 released.
+
+2012-09-20  Bob Friesenhahn  <bfriesen@simple.dallas.tx.us>
+
+	* Makefile.am: Update to Automake 1.12.4
+
+2012-08-19  Bob Friesenhahn  <bfriesen@simple.dallas.tx.us>
+
+	* Makefile.in: Update to Automake 1.12.3
+
+	* libtiff{tiff.h, tif_print.c, tif_dirinfo.c, tif_dirread.c}: Add
+	some TIFF/FX support in libtiff.  Add the tag definitions to
+	tiff.h.  Add the related TIFF field definitions to tif_dirinfo.c,
+	and also fixes an error in a comment.  Adds the photometric values
+	to tif_print.c, and fixes a bug.  These changes are by Steve
+	Underwood.
+
+2012-08-13  Frank Warmerdam  <warmerdam@google.com>
+
+	* libtiff/tif_write.c: Fix bug rewriting image tiles in a
+	compressed file: http://trac.osgeo.org/gdal/ticket/4771
+
+2012-08-02  Frank Warmerdam  <warmerdam@google.com>
+
+	* libtiff/tif_dirread.c: report error in case of mismatch value
+	counts for tags (ie. DotRange).
+
+2012-07-26  Tom Lane  <tgl@sss.pgh.pa.us>
+
+	* libtiff/{tiffio.h, tif_dirinfo.c, libtiff.def}: Add six new
+ 	functions TIFFFieldTag(), TIFFFieldName(), TIFFFieldDataType(),
+	TIFFFieldPassCount(), TIFFFieldReadCount(), TIFFFieldWriteCount()
+	as external accessors for the opaque type TIFFField.
+
+	* tools/tiffset.c: Make tiffset use the above functions instead of
+	relying on library private headers.
+
+2012-07-19  Tom Lane  <tgl@sss.pgh.pa.us>
+
+	* tools/tiff2pdf.c: Fix two places where t2p_error didn't get set
+	after a malloc failure.  No crash risk AFAICS, but the program
+	might not report exit code 1 as desired.  h/t mancha@mac.hush.com
+
+2012-07-18  Tom Lane  <tgl@sss.pgh.pa.us>
+
+	* tools/tiff2pdf.c: Fail when TIFFSetDirectory() fails.  This
+	prevents core dumps or perhaps even arbitrary code execution when
+	processing a corrupt input file (CVE-2012-3401).
+
+2012-07-06  Bob Friesenhahn  <bfriesen@simple.dallas.tx.us>
+
+	* test/raw_decode.c (main): Test fixes to work with IJG JPEG 7+.
+	IJG JPEG 7+ uses a different upsampling algorithm which produces
+	different numeric results.
+
+	* libtiff/tif_jpeg.c (JPEGPreDecode): Patch from Even Rouault to
+	work with IJG JPEG 7+.
+
+2012-07-04  Bob Friesenhahn  <bfriesen@simple.dallas.tx.us>
+
+	* test/raw_decode.c: Add changes so that test can run with build
+	directory outside of source directory.
+
+2012-07-02  Frank Warmerdam  <warmerdam@google.com>
+
+	* libtiff/tif_jpeg.c: Fix handling when writing RGBA jpeg compressed
+	imagery (http://trac.osgeo.org/gdal/ticket/4732)
+
+2012-06-20  Frank Warmerdam  <warmerdam@google.com>
+
+	* libtiff/tif_fax3.c: fix memory initialization of runs, only
+	partly done.
+
+	* libtiff/tif_pixarlog.c: Make sure tbuf is large enough for one
+	full "stride" past the end.
+
+2012-06-19  Frank Warmerdam  <warmerdam@google.com>
+
+	* libtiff/tif_packbits.c: fix read past end of data buffer.
+
 2012-06-15  Frank Warmerdam  <warmerdam@google.com>
 
 	*  libtiff 4.0.2 released.
@@ -36,7 +3051,7 @@
 
 	* libtiff/tif_dir.c, tif_print.c : Remove FIELD_CUSTOM handling for
 	PAGENUMBER, HALFTONEHINTS, and YCBCRSUBSAMPLING.  Implement DOTRANGE
-	differently.  This is to avoid using special TIFFGetField/TIFFSetField 
+	differently.  This is to avoid using special TIFFGetField/TIFFSetField
 	rules for these fields in non-image directories (like EXIF).
 
 2012-06-04  Frank Warmerdam  <warmerdam@google.com>
@@ -112,7 +3127,7 @@
 2012-05-19  Bob Friesenhahn  <bfriesen@simple.dallas.tx.us>
 
 	* man/TIFFGetField.3tiff: Correct the 'count' field type in the
-	example for how to retreive the value of unsupported tags.
+	example for how to retrieve the value of unsupported tags.
 
 2012-03-30  Frank Warmerdam  <warmerdam@google.com>
 
@@ -132,7 +3147,7 @@
 2012-01-31  Frank Warmerdam  <warmerdam@pobox.com>
 
 	* libtiff/tif_dir.c, libtiff/tif_dirread.c: Extra caution around
-	assumption tag fetching is always successful. 
+	assumption tag fetching is always successful.
 
 	* libtiff/tif_jpeg.c: Extra caution for case where sp is NULL.
 
@@ -168,7 +3183,7 @@
 	* libtiff/tif_dirread.c: fixes to deal with invalid files where
 	_TIFFFillStriles() fails, and we try to chop up strips (gdal #4372)
 
-	* libtiff/tif_dirread.c: fix error reporting when there is no 
+	* libtiff/tif_dirread.c: fix error reporting when there is no
 	tag information struct and name (gdal #4373)
 
 2011-10-22  Bob Friesenhahn  <bfriesen@simple.dallas.tx.us>
@@ -213,11 +3228,11 @@
 
 2011-04-20  Frank Warmerdam  <warmerdam@pobox.com>
 
-	* libtiff/tif_dirinfo.c,tiffio.h: Remove the obsolete 
-	TIFFMergeFieldInfo/TIFFFindFieldInfo/TIFFFindFieldInfoByName API. 
+	* libtiff/tif_dirinfo.c,tiffio.h: Remove the obsolete
+	TIFFMergeFieldInfo/TIFFFindFieldInfo/TIFFFindFieldInfoByName API.
 	http://bugzilla.maptools.org/show_bug.cgi?id=2315
 
-	* libtiff/libtiff.def: add some missing (64bit) APIs.  
+	* libtiff/libtiff.def: add some missing (64bit) APIs.
 	http://bugzilla.maptools.org/show_bug.cgi?id=2316
 
 2011-04-09  Bob Friesenhahn  <bfriesen@simple.dallas.tx.us>
@@ -260,8 +3275,8 @@
 
 2011-03-21  Frank Warmerdam  <warmerdam@pobox.com>
 
-	* libtiff/tif_thunder.c: Correct potential buffer overflow with 
-	thunder encoded files with wrong bitspersample set.  The libtiff 
+	* libtiff/tif_thunder.c: Correct potential buffer overflow with
+	thunder encoded files with wrong bitspersample set.  The libtiff
 	development team would like to thank Marin Barbella and TippingPoint's
 	Zero Day Initiative for reporting this vulnerability (ZDI-CAN-1004,
 	CVE-2011-1167).
@@ -269,25 +3284,25 @@
 
 2011-03-10  Frank Warmerdam  <warmerdam@pobox.com>
 
-	* libtiff/tif_fax3.h: Fix to last change allowing zero length 
+	* libtiff/tif_fax3.h: Fix to last change allowing zero length
 	runs at the start of a scanline - needed for legal cases.
 
 2011-03-02  Frank Warmerdam  <warmerdam@pobox.com>
 
-	* libtiff/tif_fax3.h: Protect against a fax VL(n) codeword commanding 
-	a move left.  Without this, a malicious input file can generate an 
-	indefinitely large series of runs without a0 ever reaching the right 
+	* libtiff/tif_fax3.h: Protect against a fax VL(n) codeword commanding
+	a move left.  Without this, a malicious input file can generate an
+	indefinitely large series of runs without a0 ever reaching the right
 	margin, thus overrunning our buffer of run lengths.  Per CVE-2011-0192.
-	This is a modified version of a patch proposed by Drew Yao of Apple 
-	Product Security.  It adds an unexpected() report, and disallows the 
-	equality case, since emitting a run without increasing a0 still allows 
+	This is a modified version of a patch proposed by Drew Yao of Apple
+	Product Security.  It adds an unexpected() report, and disallows the
+	equality case, since emitting a run without increasing a0 still allows
 	buffer overrun.
 
 2011-02-23  Frank Warmerdam  <warmerdam@pobox.com>
 
 	* libtiff/tif_jpeg.c: avoid divide by zero in degenerate case (#2296)
 
-	* tools/tiff2rgba.c: close source file on error to make leak 
+	* tools/tiff2rgba.c: close source file on error to make leak
 	detection easier.
 
 	* libtiff/tif_getimage.c: avoid leaks if TIFFRGBAImageBegin() fails.
@@ -302,15 +3317,15 @@
 2011-02-18  Frank Warmerdam  <warmerdam@pobox.com>
 
 	* configure.ac, configure: Added support for --enable-chunky-strip-read
-	configure option to enable the experimental feature from a couple 
-	months ago for reading big strips in chunks. 
+	configure option to enable the experimental feature from a couple
+	months ago for reading big strips in chunks.
 
-	* configure.ac, tif_read.c, tif_readdir.c, tif_dir.h, tiffiop.h, 
+	* configure.ac, tif_read.c, tif_readdir.c, tif_dir.h, tiffiop.h,
 	tif_write.c, tif_print.c, tif_jpeg.c, tif_dirwrite.c, tif_write.c:
-	Implement optional support for deferring the load of strip/tile 
+	Implement optional support for deferring the load of strip/tile
 	offset and size tags for optimized scanning of directories.  Enabled
 	with the --enable-defer-strile-load configure option (DEFER_STRILE_LOAD
-	#define in tif_config.h). 
+	#define in tif_config.h).
 
 2011-02-11  Frank Warmerdam  <warmerdam@pobox.com>
 
@@ -319,7 +3334,7 @@
 2011-02-09  Frank Warmerdam  <warmerdam@pobox.com>
 
 	* libtiff/tif_win32.c: avoid error/warning buffer overrun problem
-	with non-console (popup message) builds on win32. 
+	with non-console (popup message) builds on win32.
 
 	http://bugzilla.maptools.org/show_bug.cgi?id=2293
 
@@ -335,18 +3350,18 @@
 
 2011-01-06  Frank Warmerdam  <warmerdam@pobox.com>
 
-	* libtiff/tif_pixarlog.c: Note that tif_rawcc/tif_rawcp are not 
-	maintained.  
+	* libtiff/tif_pixarlog.c: Note that tif_rawcc/tif_rawcp are not
+	maintained.
 
-	* libtiff/tif_zip.c: Maintain tif_rawcc/tif_rawcp when decoding 
+	* libtiff/tif_zip.c: Maintain tif_rawcc/tif_rawcp when decoding
 	for CHUNKY_STRIP_READ_SUPPORT.
 
 	* libtiff/tif_jpeg.c: ensure that rawcc and rawcp are maintained
-	during JPEGPreDecode and JPEGDecode calls.  
-	* libtiff/tif_read.c: larger read ahead for CHUNKY_STRIP_READ_SUPPORT, 
-	as compression formats like JPEG keep 16 lines interleaved in a sense 
-	and might need to touch	quite a bit of data. 
-	
+	during JPEGPreDecode and JPEGDecode calls.
+	* libtiff/tif_read.c: larger read ahead for CHUNKY_STRIP_READ_SUPPORT,
+	as compression formats like JPEG keep 16 lines interleaved in a sense
+	and might need to touch	quite a bit of data.
+
 	http://trac.osgeo.org/gdal/ticket/3894
 
 2011-01-03  Lee Howard <faxguy@howardsilvan.com>
@@ -428,7 +3443,7 @@
 
 2010-12-12  Lee Howard <faxguy@howardsilvan.com>
 
-	* tools/tiff2pdf.c: fix colors for images with RGBA 
+	* tools/tiff2pdf.c: fix colors for images with RGBA
 	interleaved data
 	http://bugzilla.maptools.org/show_bug.cgi?id=2250
 
@@ -509,7 +3524,7 @@
 2010-10-21  Frank Warmerdam  <warmerdam@pobox.com>
 
 	* tools/tiffinfo.c: avoid direct reference to _TIFFerrorHandler.
-	
+
 	* libtiff/tif_config.vc.h: define snprintf to _snprintf for tiff2pdf.
 
 	* libtiff/libtiff.def: export _TIFFCheckMalloc for tools.
@@ -610,11 +3625,11 @@
 
 	* libtiff/tif_dirinfo.c: Fix invocation of tag compare function (#2201)
 
-	* tools/tiff2pdf.c: Fix assorted bugs in tiff2pdf: missing "return" 
-	in t2p_read_tiff_size() causes t2p->tiff_datasize to be set entirely 
-	wrong for COMPRESSION_JPEG case, resulting in memory stomp if actual 
-	size is larger.  Also, there are a bunch of places that try to 
-	memset() a malloc'd buffer before checking for malloc failure, which 
+	* tools/tiff2pdf.c: Fix assorted bugs in tiff2pdf: missing "return"
+	in t2p_read_tiff_size() causes t2p->tiff_datasize to be set entirely
+	wrong for COMPRESSION_JPEG case, resulting in memory stomp if actual
+	size is larger.  Also, there are a bunch of places that try to
+	memset() a malloc'd buffer before checking for malloc failure, which
 	would result in core dump if there actually were a failure. (#2211)
 
 2010-06-11  Bob Friesenhahn  <bfriesen@simple.dallas.tx.us>
@@ -690,13 +3705,13 @@
 
 2010-05-07  Frank Warmerdam  <warmerdam@pobox.com>
 
-	* libtiff/tif_jpeg.c: Ensure that quality is always set in 
-	JPEGPreEncode(), not just when we want to output local tables.  
+	* libtiff/tif_jpeg.c: Ensure that quality is always set in
+	JPEGPreEncode(), not just when we want to output local tables.
 	Otherwise the quality used during compression may not be right and
 	might not match the tables in the tables tag.   This bug only occurs
 	when seeking between directories in the midst of writing blocks.
 	http://trac.osgeo.org/gdal/ticket/3539
-	
+
 2010-05-06  Andrey Kiselev  <dron@ak4719.spb.edu>
 
 	* html/man/TIFFGetField.3tiff.html, html/man/TIFFSetField.3tiff.html:
@@ -719,9 +3734,9 @@
 
 2010-04-21  Frank Warmerdam  <warmerdam@pobox.com>
 
-	* libtiff/tif_jpeg.c: avoid preparing jpeg tables everytime 
-	JPEGSetupEncode() is called if the tables already seem to be 
-	established.  This prevents spurious updates and rewriting of 
+	* libtiff/tif_jpeg.c: avoid preparing jpeg tables every time
+	JPEGSetupEncode() is called if the tables already seem to be
+	established.  This prevents spurious updates and rewriting of
 	directories with jpegtables when doing updates to existing images.
 	http://trac.osgeo.org/gdal/ticket/3539
 
@@ -746,7 +3761,7 @@
 
 2010-04-02  Frank Warmerdam  <warmerdam@pobox.com>
 
-	* libtiff/tif_read.c (primarily): Add support for 
+	* libtiff/tif_read.c (primarily): Add support for
 	CHUNKY_STRIP_READ_SUPPORT where large strips are
 	read in chunks for applications using TIFFReadScanline().
 	This is intended to make it more practical work with very
@@ -775,11 +3790,11 @@
 2010-02-22  Lee Howard  <faxguy@howardsilvan.com>
 
 	* libtiff/tif_jpeg.c: Do not generate a JPEGTables tag when creating
-	the JPEG TIFF as is is not required in order to prevent it from 
-	being unused and filled with invalid data.  (Leave it to be 
+	the JPEG TIFF as is is not required in order to prevent it from
+	being unused and filled with invalid data.  (Leave it to be
 	generated by later activity.)
 	http://bugzilla.maptools.org/show_bug.cgi?id=2135
-	* tools/tiff2pdf.c: Write the JPEG SOI headers into the TIFF strip 
+	* tools/tiff2pdf.c: Write the JPEG SOI headers into the TIFF strip
 	data rather than skipping them.  This fixes the ability to view in
 	Acrobat Reader, Evince, and Ghostscript.
 	http://bugzilla.maptools.org/show_bug.cgi?id=2135
@@ -790,7 +3805,7 @@
 2009-12-03  Frank Warmerdam  <warmerdam@pobox.com>
 
 	* libtiff/tif_jpeg.c: Made JPEGDecodeRaw() check for buffer overruns.
-	Made so that when working with downsampled images a stub function 
+	Made so that when working with downsampled images a stub function
 	reporting an error is used for tif_decoderow.  We cannot meaningfully
 	support reading scanlines in this situation.  (#1936)
 
@@ -800,17 +3815,17 @@
 
 2009-11-30  Frank Warmerdam  <warmerdam@pobox.com>
 
-	* contrib/dbs/tiff-grayscale.c, contrib/tif-palette.c, 
+	* contrib/dbs/tiff-grayscale.c, contrib/tif-palette.c,
 	tools/ras2tiff.c: Fix resource leaks on error.
 	http://bugzilla.maptools.org/show_bug.cgi?id=2121
 
-	* libtiff/tif_{aux.c,dir.c,dir.h,dirinfo.c}: Return to handling 
+	* libtiff/tif_{aux.c,dir.c,dir.h,dirinfo.c}: Return to handling
 	TIFFTAG_REFERENCEBLACKWHITE as a field in the TIFF directory instead
 	of as a custom(generic) field to avoid a potential reentrancy problem.
 	http://bugzilla.maptools.org/show_bug.cgi?id=2125
-	
+
 	* libtiff/tif_color.c, libtiff/tif_getimage.c, libtiff/tiffio.h,
-	man/TIFFcolor.3tiff: Make TIFFDisplay argument in TIFFCIELabToRGBInit 
+	man/TIFFcolor.3tiff: Make TIFFDisplay argument in TIFFCIELabToRGBInit
 	const, and display_sRGB static and const.
 	http://bugzilla.maptools.org/show_bug.cgi?id=2124
 
@@ -872,7 +3887,7 @@
 2009-09-03  Frank Warmerdam  <warmerdam@pobox.com>
 
 	* libtiff/tif_getimage.c: Fixed error recognition handling in RGBA
-	interface when stoponerror is set. 
+	interface when stoponerror is set.
 	http://bugzilla.maptools.org/show_bug.cgi?id=2071
 
 2009-08-30  Bob Friesenhahn  <bfriesen@simple.dallas.tx.us>
@@ -921,7 +3936,7 @@
 
 	* libtiff/tif_dirread.c (TIFFReadCustomDirectory): Apply patch
 	from Jay Berkenbilt for "Bug 1895 - logic error in tif_dirread.c:
-	segfault after setting tdir_tag = IGNORE".	
+	segfault after setting tdir_tag = IGNORE".
 	http://bugzilla.maptools.org/show_bug.cgi?id=1895
 
 2009-08-23  Bob Friesenhahn  <bfriesen@simple.dallas.tx.us>
@@ -930,7 +3945,7 @@
 	tiffcrop.sh into a collection of many specific tests.  Re-wrote
 	all of the existing tests to be based on some simple shell
 	functions.  Make distcheck works again.
-	
+
 	Export certain variables (MAKE, MAKEFLAGS, MEMCHECK) to tests and
 	added 'memcheck' and 'ptrcheck' targets to make it easy to run the
 	tests under valgrind.
@@ -964,7 +3979,7 @@
 	1 on success instead of zero.
 	http://bugzilla.maptools.org/show_bug.cgi?id=2069
 
-	* libtiff/tif_lzw.c: back out patch from #2065 and apply patch from 
+	* libtiff/tif_lzw.c: back out patch from #2065 and apply patch from
 	#1085 for a better underflow fix that errors properly.
 	http://bugzilla.maptools.org/show_bug.cgi?id=2065
 	http://bugzilla.maptools.org/show_bug.cgi?id=1985
@@ -976,13 +3991,13 @@
 
 2009-06-22  Frank Warmerdam  <warmerdam@pobox.com>
 
-	* libtiff/tif_lzw.c: Fix buffer underflow bug. 
+	* libtiff/tif_lzw.c: Fix buffer underflow bug.
 	http://bugzilla.maptools.org/show_bug.cgi?id=2065
 
 2009-06-21  Frank Warmerdam  <warmerdam@pobox.com>
 
 	* configure.ac, libtiff/tif_jpeg.c, libtiff/tif_jpeg_12.c: add support
-	for dual mode 8/12 bit jpeg support. 
+	for dual mode 8/12 bit jpeg support.
 
 2009-06-03  Frank Warmerdam  <warmerdam@pobox.com>
 
@@ -999,7 +4014,7 @@
 	* libtiff/{tif_jpeg.c,tif_ojpeg.c,tif_getimage.c}: Fixed various
 	error reports to use "%s" as format string.
 	http://trac.osgeo.org/gdal/ticket/2976
-	
+
 2009-03-12  Frank Warmerdam  <warmerdam@pobox.com>
 
 	* libtiff/{tif_fax3.c,tif_jpeg.c,tif_ojpeg.c}: Fix printdir chaining
@@ -1007,7 +4022,7 @@
 
 2009-02-12  Frank Warmerdam  <warmerdam@pobox.com>
 
-	* libtiff/tif_luv.c: Fix handling of tiled logluv images. 
+	* libtiff/tif_luv.c: Fix handling of tiled logluv images.
 	http://bugzilla.maptools.org/show_bug.cgi?id=2005
 
 2009-02-09  Frank Warmerdam  <warmerdam@pobox.com>
@@ -1023,17 +4038,17 @@
 2009-02-05  Frank Warmerdam  <warmerdam@pobox.com>
 
 	* libtiff/tif_dirread.c: Re-incorporated a sanity check on tag size,
-	but at the 2GB boundary to avoid overflow on 32bit systems. 
+	but at the 2GB boundary to avoid overflow on 32bit systems.
 	http://bugzilla.maptools.org/show_bug.cgi?id=1993
 
 	* libtiff/tif_dirread.c: Remove some assertions that blow due to
-	corrupt files rather than in response to library internal 
-	inconsistencies.  
+	corrupt files rather than in response to library internal
+	inconsistencies.
 	http://bugzilla.maptools.org/show_bug.cgi?id=1995
 	http://bugzilla.maptools.org/show_bug.cgi?id=1991
 
 	* libtiff/tif_dirread.c: Fixed testing for failed result from
-	TIFFReadDirectoryFindFieldInfo().  
+	TIFFReadDirectoryFindFieldInfo().
 	http://bugzilla.maptools.org/show_bug.cgi?id=1992
 
 2009-01-23  Frank Warmerdam  <warmerdam@pobox.com>
@@ -1042,17 +4057,17 @@
 	http://bugzilla.maptools.org/show_bug.cgi?id=1911
 
 	* libtiff/tif_dirwrite.c: Fix byte swapping of next directory offset.
-	
+
 	http://bugzilla.maptools.org/show_bug.cgi?id=1924
 
-	* tools/tiffcrop.c: initialize xres/yres values. 
+	* tools/tiffcrop.c: initialize xres/yres values.
 
 	* test/*.sh - default ${srcdir} to local directory.
 
-	* test/common.sh - start verbose mode after common settings. 
+	* test/common.sh - start verbose mode after common settings.
 
-	* libtiff/tif_dirinfo.c: Replace lfind() with local equivelent to 
-	avoid type mismatches on different platforms. 
+	* libtiff/tif_dirinfo.c: Replace lfind() with local equivalent to
+	avoid type mismatches on different platforms.
 	http://bugzilla.maptools.org/show_bug.cgi?id=1889
 
 2009-01-22  Frank Warmerdam  <warmerdam@pobox.com>
@@ -1061,7 +4076,7 @@
 	tiffsplit.c}: avoid warnings, mostly 32bit/64bit casting issues.
 
 	* port,tools: Introduce libport.h, and include in tools if NEED_LIBPORT
-	defined, primarily to reduce prototype warnings on windows. 
+	defined, primarily to reduce prototype warnings on windows.
 
 	* libtiff/tif_dirinfo.c,tif_dirread.c: Avoid warnings
 	about unused parameters, and uninitialized variables.
@@ -1109,7 +4124,7 @@
 	for TIFFError(), TIFFErrorExt(), TIFFWarning(), and
 	TIFFWarningExt() in order to reveal bugs.
 
-	* Many fixes throughout to work better as a 64-bit build. 
+	* Many fixes throughout to work better as a 64-bit build.
 
 2008-12-30  Bob Friesenhahn  <bfriesen@simple.dallas.tx.us>
 
@@ -1160,7 +4175,7 @@
 2008-10-09  Frank Warmerdam  <warmerdam@pobox.com>
 
 	* libtiff/tif_jpeg.c: Add #ifdefs for changes needed if using
-	IPP enabled version of libjpeg from Intel. 
+	IPP enabled version of libjpeg from Intel.
 	http://bugzilla.maptools.org/show_bug.cgi?id=1951
 
 2008-09-05  Andrey Kiselev  <dron@ak4719.spb.edu>
@@ -1198,12 +4213,12 @@
 
 	* tools/tiffdump.c: When compiling for Microsoft Windows, apply
 	consistent (__int64) casting when testing if _lseeki64 has
-	successfully seeked as requested.  This is necessary for large
+	successfully sought as requested.  This is necessary for large
 	file support to work since off_t is only 32-bit.
 
 2008-07-29  Frank Warmerdam  <warmerdam@pobox.com>
 
-	* tif_strip.c: Replace assertions related to samplesperpixel != 3 or 
+	* tif_strip.c: Replace assertions related to samplesperpixel != 3 or
 	the subsampling values not being 1, 2 or 4 (for jpeg compressed images)
 	with control logic to return runtime errors (c/o Even Rouault) (#1927).
 
@@ -1243,13 +4258,13 @@ btiff/tif_win32.c: Replace custom Win32 memory api with generic
 
 2008-05-24  Frank Warmerdam  <warmerdam@pobox.com>
 
-	* tif_codec.c: Avoid NULL pointer dereferencing for exotic 
+	* tif_codec.c: Avoid NULL pointer dereferencing for exotic
 	compression codec codes.
 
 	* tif_dirwrite.c: fix potential memory leak.
 
 	* tif_dirread.c: Fix unchecked malloc result.
- 
+
 2008-05-24  Bob Friesenhahn  <bfriesen@simple.dallas.tx.us>
 
 	* test {tiff2pdf.sh tiff2ps-EPS1.sh tiff2ps-PS1.sh tiff2ps-PS2.sh
@@ -1283,7 +4298,7 @@ btiff/tif_win32.c: Replace custom Win32 memory api with generic
 
 	* libtiff/tif_dirinfo.c: Use TIFF_SETGET_ASCII for PIXAR_TEXTUREFORMAT
 	and PIXAR_WRAPMODES instead of TIFF_SETGET_UNDEFINED.  Not exactly clear
-	why this is needed. 
+	why this is needed.
 
 2008-05-09  Bob Friesenhahn  <bfriesen@simple.dallas.tx.us>
 
@@ -1324,25 +4339,25 @@ btiff/tif_win32.c: Replace custom Win32 memory api with generic
 2008-03-14  Frank Warmerdam  <warmerdam@pobox.com>
 
 	* tif_dirread.c: Removed sanity checks on tags larger than 4MB in
-	TIFFReadDirEntryArray() since they are interfering with seemingly 
+	TIFFReadDirEntryArray() since they are interfering with seemingly
 	legitimate files.  http://trac.osgeo.org/gdal/ticket/2005
 
 2008-02-09  Joris Van Damme  <joris.at.lebbeke@skynet.be>
 
-	* tif_dirread.c: Added handling for the case of number of values for 
-	PageNumber tag different from 2 (previously resulted in an assert 
+	* tif_dirread.c: Added handling for the case of number of values for
+	PageNumber tag different from 2 (previously resulted in an assert
 	indicating lack of handling and was forgotten about)
 
 2008-02-01  Frank Warmerdam  <warmerdam@pobox.com>
 
-	* libtiff/tif_jpeg.c: Do not try to fixup subsampling tags based on 
+	* libtiff/tif_jpeg.c: Do not try to fixup subsampling tags based on
 	the actual jpeg data stream if the first strip/tile has zero size.
 	This is the case when GDAL creates a new file with zero sizes, closes
 	and reopens it.
 
 2008-01-07  Frank Warmerdam  <warmerdam@pobox.com>
 
-	* tools/tiff2ps.c: fix up 64bit issues (from Edward Lam). 
+	* tools/tiff2ps.c: fix up 64bit issues (from Edward Lam).
 
 2008-01-01  Frank Warmerdam  <warmerdam@pobox.com>
 
@@ -1352,14 +4367,14 @@ btiff/tif_win32.c: Replace custom Win32 memory api with generic
 	targets.
 
 	* tools/tiffinfo.c, tools/tiffcmp.c, tools/gif2tiff.c, tools/bmp2tiff.c
-	tools/tiff2pdf.c: Fix 64-bit warnings when compiling under MSVC 2005 
-	(x64). 
+	tools/tiff2pdf.c: Fix 64-bit warnings when compiling under MSVC 2005
+	(x64).
 
-	* tools/tiffset.c: Changes to reflect the fact that TIFFFieldWithTag() 
+	* tools/tiffset.c: Changes to reflect the fact that TIFFFieldWithTag()
 	and TIFFFieldWithName() now return TIFFField pointers instead of
 	TIFFFieldInfo pointers.
 
-	* tools/tiffdump.c: Added ssize_t typedef on Windows since it doesn't 
+	* tools/tiffdump.c: Added ssize_t typedef on Windows since it doesn't
 	exist. This makes it compile again on Windows
 
 	* tif_aux.c, tif_getimage.c, tif_next.c, tif_predict.c, tif_win32.c,
@@ -1370,19 +4385,19 @@ btiff/tif_win32.c: Replace custom Win32 memory api with generic
 2007-12-31  Frank Warmerdam  <warmerdam@pobox.com>
 
 	* tif_dirwrite.c: Added TIFFRewriteField().  This new function
-	rewrites one field "on disk" updating an existing directory 
+	rewrites one field "on disk" updating an existing directory
 	entry.  Lots of limitations still...
 
-	* tiffiop.h, tif_write.c, tif_dirread.c, tif_flush.c: Keep track of 
-	TIFF_DIRTYSTRIP separately from TIFF_DIRTYDIRECT to indicate that 
-	the strip offset/size values are dirty but nothing else about the 
+	* tiffiop.h, tif_write.c, tif_dirread.c, tif_flush.c: Keep track of
+	TIFF_DIRTYSTRIP separately from TIFF_DIRTYDIRECT to indicate that
+	the strip offset/size values are dirty but nothing else about the
 	directory is dirty.  In flush handle "just stripmaps dirty" as a
-	special case that just rewrites these values without otherwise 
-	modifying the directory on disk using TIFFRewriteField().  
+	special case that just rewrites these values without otherwise
+	modifying the directory on disk using TIFFRewriteField().
 
 	We also modify logic so that in update mode the directory is not
 	marked dirty on read, but only when something is changed.  This
-	means we need to keep track of updates to the stripmap stuff in 
+	means we need to keep track of updates to the stripmap stuff in
 	TIFFAppendToStrip().
 
 2007-12-10  Frank Warmerdam  <warmerdam@pobox.com>
@@ -1393,7 +4408,7 @@ btiff/tif_win32.c: Replace custom Win32 memory api with generic
 2007-11-23  Frank Warmerdam  <warmerdam@pobox.com>
 
 	* tif_dir.c, tif_dirread.c, tif_dirwrite.c, tif_read.c, tif_write.c,
-	tiffiop.h: Added TIFF_BUF4WRITE flag to indicate if contents of the 
+	tiffiop.h: Added TIFF_BUF4WRITE flag to indicate if contents of the
 	rawcp/rawcc buffer are for writing and thus may require flushing.
 	Necessary to distinguish whether they need to be written to disk when
 	in mixed read/write mode and doing a mixture of writing followed by
@@ -1406,12 +4421,12 @@ btiff/tif_win32.c: Replace custom Win32 memory api with generic
 
 2007-11-02  Frank Warmerdam  <warmerdam@pobox.com>
 
-	* tif_write.c: Rip out the fancy logic in TIFFAppendToStrip() for 
-	establishing if an existing tile can be rewritten to the same location 
-	by comparing the current size to all the other blocks in the same 
-	directory.  This is dangerous in many situations and can easily 
+	* tif_write.c: Rip out the fancy logic in TIFFAppendToStrip() for
+	establishing if an existing tile can be rewritten to the same location
+	by comparing the current size to all the other blocks in the same
+	directory.  This is dangerous in many situations and can easily
 	corrupt a file.  (observed in esoteric GDAL situation that's hard to
-	document).  This change involves leaving the stripbytecount[] values 
+	document).  This change involves leaving the stripbytecount[] values
 	unaltered till TIFFAppendToStrip().  Now we only write a block back
 	to the same location it used to be at if the new data is the same
 	size or smaller - otherwise we move it to the end of file.
@@ -1419,30 +4434,30 @@ btiff/tif_win32.c: Replace custom Win32 memory api with generic
 	* tif_dirwrite.c: Try to avoid writing out a full readbuffer of tile
 	data when writing the directory just because we have BEENWRITING at
 	some point in the past.  This was causing odd junk to be written out
-	in a tile of data when a single tile had an interleaving of reading 
-	and writing with reading last.  (highlighted by gdal 
-	autotest/gcore/tif_write.py test 7. 
+	in a tile of data when a single tile had an interleaving of reading
+	and writing with reading last.  (highlighted by gdal
+	autotest/gcore/tif_write.py test 7.
 
 	* tif_predict.c: use working buffer in PredictorEncodeTile to avoid
-	modifying callers buffer. 
+	modifying callers buffer.
 	http://trac.osgeo.org/gdal/ticket/1965
 
-	* tif_predict.c/h: more fixes related to last item, keeping a 
+	* tif_predict.c/h: more fixes related to last item, keeping a
 	distinct pfunc for encode and decode cases as these were getting
 	mixed up sometimes.
 	http://trac.osgeo.org/gdal/ticket/1948
 
 2007-11-01  Frank Warmerdam  <warmerdam@pobox.com>
 
-	* tif_predict.c/h, tif_lzw.c, tif_zip.c: Improvements so that 
+	* tif_predict.c/h, tif_lzw.c, tif_zip.c: Improvements so that
 	predictor based encoding and decoding works in read-write update
-	mode properly. 
+	mode properly.
 	http://trac.osgeo.org/gdal/ticket/1948
 
 2007-10-24  Joris Van Damme  <joris.at.lebbeke@skynet.be>
 
-	* tif_dirread.c: Fixed problem with bogus file triggering 
-	assert(td->td_planarconfig == PLANARCONFIG_CONTIG) in 
+	* tif_dirread.c: Fixed problem with bogus file triggering
+	assert(td->td_planarconfig == PLANARCONFIG_CONTIG) in
 	ChopUpSingleUncompressedStrip
 
 2007-10-22  Joris Van Damme  <joris.at.lebbeke@skynet.be>
@@ -1466,10 +4481,10 @@ btiff/tif_win32.c: Replace custom Win32 memory api with generic
 
 2007-09-29  Joris Van Damme  <joris.at.lebbeke@skynet.be>
 
-	* tif_dirread.c: Strip chopping interfered badly with uncompressed 
-	subsampled images because it tried to divide subsampled rowblocks, 
-	leading to all sorts of errors throughout the library for these 
-	images. Fixed by making strip chopping divide in row counts that 
+	* tif_dirread.c: Strip chopping interfered badly with uncompressed
+	subsampled images because it tried to divide subsampled rowblocks,
+	leading to all sorts of errors throughout the library for these
+	images. Fixed by making strip chopping divide in row counts that
 	are a multiple of vertical subsampling value.
 
 2007-09-28  Joris Van Damme  <joris.at.lebbeke@skynet.be>
@@ -1482,18 +4497,18 @@ btiff/tif_win32.c: Replace custom Win32 memory api with generic
 
 	* tif_dirread.c: Made calculation of td_maxsamplevalue more robust
 	when dealing with large bitspersample values, shutting up purification
-	tools that warn about truncation, though it remains incorrect and 
+	tools that warn about truncation, though it remains incorrect and
 	indicates a conceptual problem there.
 
-	* tif_open.c: Moved early exit in case of 'h' flag (to disable reading 
-	of first IFD) to proper place because it badly interfered with memory 
-	mapping, resulting in mapping flag even with dummy mapping functions 
-	that returned 0 whilst at the same time the mapping tif_size wasn't 
+	* tif_open.c: Moved early exit in case of 'h' flag (to disable reading
+	of first IFD) to proper place because it badly interfered with memory
+	mapping, resulting in mapping flag even with dummy mapping functions
+	that returned 0 whilst at the same time the mapping tif_size wasn't
 	set, thus resulting in continuous incorrect beyond-eof errors.
 
 2007-09-24  Joris Van Damme  <joris.at.lebbeke@skynet.be>
 
-	* tif_dirinfo.c: Fixed (MSVC) compiler reports about 
+	* tif_dirinfo.c: Fixed (MSVC) compiler reports about
 	inconsistent use of const in tiffFields and exifFields definition
 
 2007-09-20  Frank Warmerdam  <warmerdam@pobox.com>
@@ -1503,7 +4518,7 @@ btiff/tif_win32.c: Replace custom Win32 memory api with generic
 	TIFFWriteDirectoryTagLongLong8Array() function was restructured
 	accordingly.
 
-	* tif_dirread.c: Improvements to error reporting text in 
+	* tif_dirread.c: Improvements to error reporting text in
 	TIFFFetchDirectory().
 
 2007-09-19  Bob Friesenhahn  <bfriesen@simple.dallas.tx.us>
@@ -1517,27 +4532,27 @@ btiff/tif_win32.c: Replace custom Win32 memory api with generic
 2007-08-24  Frank Warmerdam  <warmerdam@pobox.com>
 
 	* tif_dirwrite.c: Write the tif_nextdiroff value instead of a fixed
-	zero when writing directory contents to preserve the ability to 
+	zero when writing directory contents to preserve the ability to
 	rewrite directories in place, even in the middle of a directory
 	chain.
 
 	* tif_dirinfo.c:  _TIFFMergeFields() now only merges in field
 	definitions that are missing.  Existing definitions are silently
-	ignored. 
+	ignored.
 
 	* tif_dirread.c: Add runtime error for fields for which no definition
-	is found (in addition to an assert for developers) in 
-	TIFFFetchNormalTag().  Not sure if this is needed, but it seems 
+	is found (in addition to an assert for developers) in
+	TIFFFetchNormalTag().  Not sure if this is needed, but it seems
 	prudent.
 
 2007-08-10  Joris Van Damme  <joris.at.lebbeke@skynet.be>
 
-	* libtiff/tif_getimage.c: removed SubsamplingHor and SubsamplingVer 
+	* libtiff/tif_getimage.c: removed SubsamplingHor and SubsamplingVer
 	from _TIFFRGBAImage structure to revert unwanted ABI change.
 
 2007-08-10  Joris Van Damme  <joris.at.lebbeke@skynet.be>
 
-	* libtiff/tif_win32.c: use SetFilePointer instead of 
+	* libtiff/tif_win32.c: use SetFilePointer instead of
 	SetFilePointerEx, as per bug
 
 	http://bugzilla.remotesensing.org/show_bug.cgi?id=1580
@@ -1559,7 +4574,7 @@ btiff/tif_win32.c: Replace custom Win32 memory api with generic
 	* libtiff/tif_dirread.c: Handle the case of MSVC 6 when using 64-bit
 	integer constants.
 
-	* libtiff/{Makefile.am, Makefile.v}: Do not distribute tiffconf.h, 
+	* libtiff/{Makefile.am, Makefile.v}: Do not distribute tiffconf.h,
 	remove tif_config.h/tiffconf.h during cleaning. As per bug
 
 	http://bugzilla.remotesensing.org/show_bug.cgi?id=1573
@@ -1629,14 +4644,14 @@ btiff/tif_win32.c: Replace custom Win32 memory api with generic
 	tif_win3.c}: Obsoleted portability stuff removed.
 
 	* tools/tiff2ps.c:  Added support 16-bit images as per bug
-	
+
 	http://bugzilla.remotesensing.org/show_bug.cgi?id=1566
 
 	Patch from William Bader.
 
 	* tools/tiff2pdf.c: Fix for TIFFTAG_JPEGTABLES tag fetching and
 	significant upgrade of the whole utility as per bug
-	
+
 	http://bugzilla.remotesensing.org/show_bug.cgi?id=1560
 
 	Now we don't need tiffiop.h in tiff2pdf anymore and will open output
@@ -1654,7 +4669,7 @@ btiff/tif_win32.c: Replace custom Win32 memory api with generic
 2007-06-25  Bob Friesenhahn  <bfriesen@simple.dallas.tx.us>
 
 	* port/strtoull.c: New porting function in case strtoull() is not
-	available on the target system.	
+	available on the target system.
 	* configure.ac: Add configure support for determining sized types
 	in a portable way and performing necessary substitutions in
 	tif_config.h and tiffconf.h.  Updated tiff.h to use the new
@@ -1671,7 +4686,7 @@ btiff/tif_win32.c: Replace custom Win32 memory api with generic
 	* libtiff/{tif_dir.h, tif_dirread.c, tif_dirinfo.c, tif_jpeg.c,
 	tif_fax3.c, tif_jbig.c, tif_luv.c, tif_ojpeg.c, tif_pixarlog.c,
 	tif_predict.c, tif_zip.c}: Finally fix bug
-	
+
 	http://bugzilla.remotesensing.org/show_bug.cgi?id=1274
 
 	by introducing _TIFFMergeFieldInfo() returning integer error status
@@ -1682,7 +4697,7 @@ btiff/tif_win32.c: Replace custom Win32 memory api with generic
 
 2007-04-07  Frank Warmerdam  <warmerdam@pobox.com>
 
-	* contrib/addtiffo/tif_overview.c: Fix problems with odd sized output 
+	* contrib/addtiffo/tif_overview.c: Fix problems with odd sized output
 	blocks in TIFF_DownSample_Subsampled() (bug 1542).
 
 2007-04-06  Frank Warmerdam  <warmerdam@pobox.com>
@@ -1690,15 +4705,15 @@ btiff/tif_win32.c: Replace custom Win32 memory api with generic
 	* libtiff/tif_jpeg.c: Changed JPEGInitializeLibJPEG() so that it
 	will convert from decompressor to compressor or compress to decompress
 	if required by the force arguments.  This works around a problem in
-	where the JPEGFixupTestSubsampling() may cause a decompressor to 
+	where the JPEGFixupTestSubsampling() may cause a decompressor to
 	be setup on a directory when later a compressor is required with the
-	force flag set.  Occurs with the addtiffo program for instance. 
+	force flag set.  Occurs with the addtiffo program for instance.
 
 2007-04-06  Andrey Kiselev  <dron@ak4719.spb.edu>
 
 	* tools/tiffcrop.c, man/tiffcrop.1: Significant update in
 	functionality from Richard Nolde. As per bug
-	
+
 	http://bugzilla.remotesensing.org/show_bug.cgi?id=1525
 
 2007-03-28  Frank Warmerdam  <warmerdam@pobox.com>
@@ -1710,15 +4725,15 @@ btiff/tif_win32.c: Replace custom Win32 memory api with generic
 	* start of BigTIFF upgrade - CVS HEAD unstable until further notice
 
 2007-03-07  Joris Van Damme  <joris.at.lebbeke@skynet.be>
-	
+
 	* libtiff/tif_getimage.c: workaround for 'Fractional scanline' error reading
 	OJPEG images with rowsperstrip that is not a multiple of vertical subsampling
 	factor. This bug is mentioned in:
 	http://bugzilla.remotesensing.org/show_bug.cgi?id=1390
-	http://www.asmail.be/msg0054766825.html 
+	http://www.asmail.be/msg0054766825.html
 
 2007-03-07  Joris Van Damme  <joris.at.lebbeke@skynet.be>
-	
+
 	* libtiff/tif_win32.c: made inclusion of windows.h unconditional
 
 	* libtiff/tif_win32.c: replaced preprocessor indication for consiously
@@ -1768,14 +4783,14 @@ btiff/tif_win32.c: Replace custom Win32 memory api with generic
 	larger than 2GB. Fixes bug
 
 	http://bugzilla.remotesensing.org/show_bug.cgi?id=890
-	
+
 	Idea submitted by Matt Hancher.
 
 2007-01-31  Andrey Kiselev  <dron@ak4719.spb.edu>
 
 	* tools/tif2rgba.c: This utility does not work properly on big-endian
 	architectures. It was fixed including the bug
-	
+
 	http://bugzilla.remotesensing.org/show_bug.cgi?id=1149
 
 2007-01-15  Mateusz Loskot <mateusz@loskot.net>
@@ -1792,15 +4807,15 @@ btiff/tif_win32.c: Replace custom Win32 memory api with generic
 
 2006-11-19  Frank Warmerdam  <warmerdam@pobox.com>
 
-	* libtiff/tif_write.c: TIFFAppendToStrip() - clear sorted flag if 
-	we move a strip. 
-	http://bugzilla.remotesensing.org/show_bug.cgi?id=1359	
+	* libtiff/tif_write.c: TIFFAppendToStrip() - clear sorted flag if
+	we move a strip.
+	http://bugzilla.remotesensing.org/show_bug.cgi?id=1359
 
 2006-10-13  Andrey Kiselev  <dron@ak4719.spb.edu>
 
 	* libtiff/tif_dir.c: More fixes for vulnerabilities, reported
 	in Gentoo bug ():
-	
+
 	http://bugs.gentoo.org/show_bug.cgi?id=142383
 
 	* libtiff/contrib/dbs/xtiff/xtiff.c: Make xtiff utility compilable.
@@ -1834,12 +4849,12 @@ btiff/tif_win32.c: Replace custom Win32 memory api with generic
 	* libtiff/tif_lzw.c, libtiff/tif_zip.c: Fixed problems with mixing
 	encoding and decoding on the same read-write TIFF handle.  The LZW
 	code can now maintain encode and decode state at the same time. The
-	ZIP code will switch back and forth as needed.  
+	ZIP code will switch back and forth as needed.
 	http://bugzilla.remotesensing.org/show_bug.cgi?id=757
 
 2006-09-20  Frank Warmerdam  <warmerdam@pobox.com>
 
-	* libtiff: Rename config.h.vc and tif_config.h.vc to config.vc.h and 
+	* libtiff: Rename config.h.vc and tif_config.h.vc to config.vc.h and
 	tif_config.vc.h for easier identification by folks using an IDE.
 
 2006-07-25  Frank Warmerdam  <warmerdam@pobox.com>
@@ -1854,7 +4869,7 @@ btiff/tif_win32.c: Replace custom Win32 memory api with generic
 
 2006-07-12  Frank Warmerdam  <warmerdam@pobox.com>
 
-	* tif_dirwrite.c: make sure to use uint32 for wordcount in 
+	* tif_dirwrite.c: make sure to use uint32 for wordcount in
 	TIFFWriteNormanTag if writecount is VARIABLE2 for ASCII fields.
 	It already seems to have been done for other field types.  Needed
 	for "tiffset" on files with geotiff ascii text.
@@ -1882,9 +4897,9 @@ btiff/tif_win32.c: Replace custom Win32 memory api with generic
 2006-06-17  Frank Warmerdam  <warmerdam@pobox.com>
 
 	* tif_readdir.c: Added case in EstimateStripByteCounts() for tiled
-	files.  Modified TIFFReadDirectory() to not invoke 
+	files.  Modified TIFFReadDirectory() to not invoke
 	EstimateStripByteCounts() for case where entry 0 and 1 are unequal
-	but one of them is zero. 
+	but one of them is zero.
 	  http://bugzilla.remotesensing.org/show_bug.cgi?id=1204
 
 2006-06-08  Andrey Kiselev  <dron@ak4719.spb.edu>
@@ -1912,7 +4927,7 @@ btiff/tif_win32.c: Replace custom Win32 memory api with generic
 	* {configure, configure.ac, libtiff/tif_jbig.c, tools/tiffcp.c}: Added
 	support for JBIG compression scheme (34661 code) contributed by Lee
 	Howard. As per bug
-	
+
 	http://bugzilla.remotesensing.org/show_bug.cgi?id=896
 
 	* configure, configure.ac: OJPEG support enabled by default.
@@ -1951,7 +4966,7 @@ btiff/tif_win32.c: Replace custom Win32 memory api with generic
 2006-04-18  Frank Warmerdam  <warmerdam@pobox.com>
 
 	* nmake.opt: use /EHsc for VS2005 compatibility.  Also define
-	_CRT_SECURE_NO_DEPRECATE to avoid noise on VS2005. 
+	_CRT_SECURE_NO_DEPRECATE to avoid noise on VS2005.
 
 2006-04-12  Joris Van Damme  <joris.at.lebbeke@skynet.be>
 
@@ -1959,7 +4974,7 @@ btiff/tif_win32.c: Replace custom Win32 memory api with generic
 	non-subsampled YCbCr (i.e. separate YCbCr with subsampling [1,1])
 
 2006-04-11  Joris Van Damme  <joris.at.lebbeke@skynet.be>
-	
+
 	* libtiff/tif_getimage.c: Revision of all RGB(A) put routines
 	- Conversion of unassociated alpha to associated alpha now done with
 	  more performant LUT, and calculation more correct
@@ -1968,21 +4983,21 @@ btiff/tif_win32.c: Replace custom Win32 memory api with generic
 	- Bugfix of handling of 16bit RGB with unassociated alpha
 
 2006-04-11  Joris Van Damme  <joris.at.lebbeke@skynet.be>
-	
-	* libtiff/tif_getimage.c: 
-	- When there is no alpha, gtTileSeparate and gtStripSeparate allocated 
-	  buffer for alpha strile and filled it, only to never read it back. 
+
+	* libtiff/tif_getimage.c:
+	- When there is no alpha, gtTileSeparate and gtStripSeparate allocated
+	  buffer for alpha strile and filled it, only to never read it back.
 	  Removed allocation and fill.
-	- Minor rename of vars in gtTileSeparate and gtStripSeparate 
+	- Minor rename of vars in gtTileSeparate and gtStripSeparate
 	  anticipating planned functionality extension
 
 2006-04-08  Joris Van Damme  <joris.at.lebbeke@skynet.be>
 
-	* libtiff/tif_getimage.c: renamed pickTileContigCase to PickContigCase 
-	and pickTileSeparateCase to PickSeparateCase as both work on strips as 
+	* libtiff/tif_getimage.c: renamed pickTileContigCase to PickContigCase
+	and pickTileSeparateCase to PickSeparateCase as both work on strips as
 	well
 
-	* libtiff/tif_getimage.c: moved img->get selection from 
+	* libtiff/tif_getimage.c: moved img->get selection from
 	TIFFRGBAImageBegin into PickContigCase and PickSeparateCase to create
 	logical hook for planned functionality extension
 
@@ -1993,10 +5008,10 @@ btiff/tif_win32.c: Replace custom Win32 memory api with generic
 
 2006-04-07  Joris Van Damme  <joris.at.lebbeke@skynet.be>
 
-	* libtiff/tif_getimage.c: replaced usage of TIFFScanlineSize in 
+	* libtiff/tif_getimage.c: replaced usage of TIFFScanlineSize in
 	gtStripContig with TIFFNewScanlineSize so as to fix buggy behaviour
-	on subsampled images - this ought to get sorted when we feel brave 
-	enough to replace TIFFScanlineSize alltogether
+	on subsampled images - this ought to get sorted when we feel brave
+	enough to replace TIFFScanlineSize altogether
 
 	* libtiff/tif_ojpeg.c: fixed bug in OJPEGReadSkip
 
@@ -2004,13 +5019,13 @@ btiff/tif_win32.c: Replace custom Win32 memory api with generic
 
 	* libtiff/tiffio.h: added new type tstrile_t
 
-	* libtiff/tif_dir.h: changed types of td_stripsperimage and td_nstrips 
-	to new tstrile_t, types of td_stripoffset and td_stripbytecount to 
+	* libtiff/tif_dir.h: changed types of td_stripsperimage and td_nstrips
+	to new tstrile_t, types of td_stripoffset and td_stripbytecount to
 	toff_t*
 
 	* libtiff/tif_ojpeg.c: totally new implementation
 
-	* libtiff/tif_dirread.c: added several hacks to suit new support of 
+	* libtiff/tif_dirread.c: added several hacks to suit new support of
 	OJPEG
 
 	* libtiff/tif_getimage.c: removed TIFFTAG_JPEGCOLORMODE handling
@@ -2050,7 +5065,7 @@ btiff/tif_win32.c: Replace custom Win32 memory api with generic
 
 	* libtiff/tif_getimage.c: added putcontig8bitYCbCr12tile
 
-	* libtiff/tif_read.c: added support for new TIFF_NOREADRAW flag to 
+	* libtiff/tif_read.c: added support for new TIFF_NOREADRAW flag to
 	prepare	the path for new tif_ojpeg.c
 
 2006-03-23  Andrey Kiselev  <dron@ak4719.spb.edu>
@@ -2166,7 +5181,7 @@ btiff/tif_win32.c: Replace custom Win32 memory api with generic
 
 	* libtiff/tif_write.c: Small code rearrangement in TIFFWriteScanline()
 	to avoid crash as per bug
-	
+
 	http://bugzilla.remotesensing.org/show_bug.cgi?id=1081.
 
 2006-02-26  Andrey Kiselev  <dron@ak4719.spb.edu>
@@ -2216,7 +5231,7 @@ btiff/tif_win32.c: Replace custom Win32 memory api with generic
 2006-02-07  Frank Warmerdam  <warmerdam@pobox.com>
 
 	* tools/tiff2pdf.c: Fixed support for non-YCbCr encoded JPEG
-	compressed TIFF files, per submission from Dan Cobra. 
+	compressed TIFF files, per submission from Dan Cobra.
 
 2006-02-07  Andrey Kiselev  <dron@ak4719.spb.edu>
 
@@ -2248,7 +5263,7 @@ btiff/tif_win32.c: Replace custom Win32 memory api with generic
 
 	* libtiff/tif_dirread.c: Use _TIFFGetExifFieldInfo() instead of
 	_TIFFGetFieldInfo() in TIFFReadEXIFDirectory() call as per bug
-	
+
 	http://bugzilla.remotesensing.org/show_bug.cgi?id=1026.
 
 2006-01-23  Andrey Kiselev  <dron@ak4719.spb.edu>
@@ -2314,7 +5329,7 @@ btiff/tif_win32.c: Replace custom Win32 memory api with generic
 
 2005-12-26  Andrey Kiselev  <dron@ak4719.spb.edu>
 
-	* libtiff/{tif_dir.c, tif_dir.h, tif_dirread.c, tif_dirinfo.c}: 
+	* libtiff/{tif_dir.c, tif_dir.h, tif_dirread.c, tif_dirinfo.c}:
 	tiffFieldInfo and exifFieldInfo arrays definitions moved back to
 	tif_dirinfo.c; added _TIFFGetFieldInfo() and _TIFFGetExifFieldInfo()
 	private functions to retrieve FieldInfo arrays.
@@ -2341,10 +5356,10 @@ btiff/tif_win32.c: Replace custom Win32 memory api with generic
 
 2005-12-23  Joris Van Damme  <joris.at.lebbeke@skynet.be>
 
-	* libtiff/tiffio.h: fixed typo that potentially resulted in 
+	* libtiff/tiffio.h: fixed typo that potentially resulted in
 	redefininition of USE_WIN32_FILEIO
 
-	* libtiff/*: Added more 'dual-mode' error handling: Done TIFFWarning 
+	* libtiff/*: Added more 'dual-mode' error handling: Done TIFFWarning
 	calls in core LibTiff.
 
 2005-12-21  Andrey Kiselev  <dron@ak4719.spb.edu>
@@ -2354,10 +5369,10 @@ btiff/tif_win32.c: Replace custom Win32 memory api with generic
 
 2005-12-21  Joris Van Damme  <joris.at.lebbeke@skynet.be>
 
-	* libtiff/*, contrib/*: Added 'dual-mode' error handling, enabling 
+	* libtiff/*, contrib/*: Added 'dual-mode' error handling, enabling
 	newer code to get context indicator in error handler and still
-	remain compatible with older code: Done TIFFError calls everywhere 
-	except in tools   
+	remain compatible with older code: Done TIFFError calls everywhere
+	except in tools
 
 2005-12-20  Andrey Kiselev  <dron@ak4719.spb.edu>
 
@@ -2430,7 +5445,7 @@ btiff/tif_win32.c: Replace custom Win32 memory api with generic
 	http://bugzilla.remotesensing.org/show_bug.cgi?id=1002
 
 	* .cvsignore: many files added, and a few update according
-	to suggestion of Brad HArds on tiff mailing list. 
+	to suggestion of Brad HArds on tiff mailing list.
 
 2005-11-03  Frank Warmerdam  <warmerdam@pobox.com>
 
@@ -2455,7 +5470,7 @@ btiff/tif_win32.c: Replace custom Win32 memory api with generic
 	http://bugzilla.remotesensing.org/show_bug.cgi?id=946
 
 	* tools/bmp2tiff.c: Fixed possible integer overflow error as per bug
-	
+
 	http://bugzilla.remotesensing.org/show_bug.cgi?id=965
 
 	* libtiff/tif_dirinfo.c: Make XResolution, YResolution and
@@ -2465,7 +5480,7 @@ btiff/tif_win32.c: Replace custom Win32 memory api with generic
 
 	* tools/tiffsplit.c: Copy fax related fields over splitted parts
 	as per bug
-	
+
 	http://bugzilla.remotesensing.org/show_bug.cgi?id=983
 
 2005-10-21  Frank Warmerdam  <warmerdam@pobox.com>
@@ -2521,7 +5536,7 @@ btiff/tif_win32.c: Replace custom Win32 memory api with generic
 
 	* libtiff/tif_dir.c: When prefreeing tv->value in TIFFSetFieldV
 	also set it to NULL to avoid double free when re-setting custom
-	string fields as per: 
+	string fields as per:
 
 	http://bugzilla.remotesensing.org/show_bug.cgi?id=922
 
@@ -2557,7 +5572,7 @@ btiff/tif_win32.c: Replace custom Win32 memory api with generic
 	http://bugzilla.remotesensing.org/show_bug.cgi?id=831
 
 	Remove TIFFFetchExtraSamples() function, use TIFFFetchNormalTag()
-	instead. 
+	instead.
 
 	* libtiff/tiffconf.h.in: One more attempt to fix the AIX bug
 
@@ -2654,7 +5669,7 @@ btiff/tif_win32.c: Replace custom Win32 memory api with generic
 
 2005-06-03  Andrey Kiselev  <dron@ak4719.spb.edu>
 
-	* libtiff/tif_open.c: Replace runtime endianess check with the compile
+	* libtiff/tif_open.c: Replace runtime endianness check with the compile
 	time one.
 
 	* libtiff/tif_predict.c: Floating point predictor now works on
@@ -2728,7 +5743,7 @@ btiff/tif_win32.c: Replace custom Win32 memory api with generic
 
 2005-05-22  Frank Warmerdam  <warmerdam@pobox.com>
 
-	* libtiff/tif_dirread.c: Changed the code that computes 
+	* libtiff/tif_dirread.c: Changed the code that computes
 	stripbytecount[0] if it appears bogus to ignore if stripoffset[0] is
 	zero. This is a common case with GDAL indicating a "null" tile/strip.
 
@@ -2738,8 +5753,8 @@ btiff/tif_win32.c: Replace custom Win32 memory api with generic
 
 2005-05-06  Frank Warmerdam  <warmerdam@pobox.com>
 
-	* libtiff/tif_dirread.c: Applied similar change to 
-	TIFFFetchPerSampleLongs and TIFFFetchPerSampleAnys. 
+	* libtiff/tif_dirread.c: Applied similar change to
+	TIFFFetchPerSampleLongs and TIFFFetchPerSampleAnys.
 
 	http://bugzilla.remotesensing.org/show_bug.cgi?id=843
 
@@ -2789,7 +5804,7 @@ btiff/tif_win32.c: Replace custom Win32 memory api with generic
 
 	* man/TIFFSetField.3tiff: Fixed definition of the TIFFTAG_INKNAMES tag
 	as per bug
-	
+
 	http://bugzilla.remotesensing.org/show_bug.cgi?id=816
 
 2005-03-30  Andrey Kiselev  <dron@ak4719.spb.edu>
@@ -2899,7 +5914,7 @@ btiff/tif_win32.c: Replace custom Win32 memory api with generic
 
 	* libtiff/tiffio.h: Move TIFFOpenW() function into the extern "C"{}
 	block as per bug
-	
+
 	http://bugzilla.remotesensing.org/show_bug.cgi?id=763
 
 2005-02-03  Bob Friesenhahn  <bfriesen@simple.dallas.tx.us>
@@ -2920,7 +5935,7 @@ btiff/tif_win32.c: Replace custom Win32 memory api with generic
 	http://bugzilla.remotesensing.org/show_bug.cgi?id=320
 
 	* tools/tiff2ps.c: Fixed problem with page sizes as per bug
-	
+
 	http://bugzilla.remotesensing.org/show_bug.cgi?id=742
 
 2005-01-31  Bob Friesenhahn  <bfriesen@simple.dallas.tx.us>
@@ -2961,7 +5976,7 @@ btiff/tif_win32.c: Replace custom Win32 memory api with generic
 	TIFFRGBAImageBegin() as per bug
 
 	http://bugzilla.remotesensing.org/show_bug.cgi?id=739
-	
+
 2005-01-12  Andrey Kiselev  <dron@ak4719.spb.edu>
 
 	* libtiff/tif_jpeg.c: Added ability to read/write the fax specific
@@ -2990,7 +6005,7 @@ btiff/tif_win32.c: Replace custom Win32 memory api with generic
 	* libtiff/tiff.h: Restore back the workaround for AIX Visual Age C
 	compiler to avoid double definition of BSD types as per bug
 
-	http://bugzilla.remotesensing.org/show_bug.cgi?id=39	
+	http://bugzilla.remotesensing.org/show_bug.cgi?id=39
 
 	* libtiff/Makefile.am: Place the C++ stream API in the separate
 	library called libtiffxx to avoid unneeded dependencies. Probably
@@ -3014,7 +6029,7 @@ btiff/tif_win32.c: Replace custom Win32 memory api with generic
 
 	* libtiff/tif_getimage.c: More fixes for multiple-alpha-channelled
 	RGB-images as per bug
-	
+
 	http://bugzilla.remotesensing.org/show_bug.cgi?id=713
 
 
@@ -3050,7 +6065,7 @@ btiff/tif_win32.c: Replace custom Win32 memory api with generic
 2004-12-15  Frank Warmerdam  <warmerdam@pobox.com>
 
 	* libtiff/tif_getimage.c: #define A1 bracketing for clean build on
-	SunPro compiler. 
+	SunPro compiler.
 
 2004-12-11  Bob Friesenhahn  <bfriesen@simple.dallas.tx.us>
 
@@ -3062,7 +6077,7 @@ btiff/tif_win32.c: Replace custom Win32 memory api with generic
 
 	* libtiff/tif_dirwrite.c: Always write TIFFTAG_SUBIFD using LONG type
 	as per bugs
-	
+
 	http://bugzilla.remotesensing.org/show_bug.cgi?id=703
 
 	and
@@ -3082,9 +6097,9 @@ btiff/tif_win32.c: Replace custom Win32 memory api with generic
 
 	* libtiff/tif_config.in.vc: Removed unneded definitions for
 	read/open/close/lseek functions to fix the
-	
+
 	http://bugzilla.remotesensing.org/show_bug.cgi?id=680
-	
+
 2004-12-03  Andrey Kiselev  <dron@ak4719.spb.edu>
 
 	* libtiff/{tif_dir.c, tif_dirread.c}: Remove TIFFReassignTagToIgnore()
@@ -3120,7 +6135,7 @@ btiff/tif_win32.c: Replace custom Win32 memory api with generic
 
 2004-11-26  Frank Warmerdam  <warmerdam@pobox.com>
 
-	* libtiff/makefile.vc: make it easier to rename the libtiff DLL. 
+	* libtiff/makefile.vc: make it easier to rename the libtiff DLL.
 
 2004-11-24  Andrey Kiselev  <dron@ak4719.spb.edu>
 
@@ -3217,7 +6232,7 @@ btiff/tif_win32.c: Replace custom Win32 memory api with generic
 	per bug
 
 	 http://bugzilla.remotesensing.org/show_bug.cgi?id=648
-	
+
 	* libtiff/{tif_jpeg.c, tif_ojpeg.c}: TIFFTAG_JPEGTABLES should have
 	uint32 count. Use this type everywhere.
 
@@ -3230,7 +6245,7 @@ btiff/tif_win32.c: Replace custom Win32 memory api with generic
 	* tools/tiff2rgba.c: removed extra newlines in usage message.
 
 2004-10-30  Andrey Kiselev  <dron@ak4719.spb.edu>
-	
+
 	* libtiff/tif_dirwrite.c: Improvements in tag writing code.
 
 	* tools/tiff2ps.c: Fixed wrong variable data type when read Position
@@ -3245,7 +6260,7 @@ btiff/tif_win32.c: Replace custom Win32 memory api with generic
 
 	* libtiff/tif_fax3.c: Fixed case with the wrong decode routines
 	choosing when the incorrect Group4Options tag set. As per bug
-	
+
 	http://bugzilla.remotesensing.org/show_bug.cgi?id=323
 
 	* libtiff/tif_dirwrite.c: Fixed problem with passing count variable of
@@ -3264,7 +6279,7 @@ btiff/tif_win32.c: Replace custom Win32 memory api with generic
 	* tools/tiff2pdf.c: added casts to avoid warnings.
 
 	* libtiff/libtiff.def: Added several more entry points required
-	to link fax2tiff.c against the DLL on windows. 
+	to link fax2tiff.c against the DLL on windows.
 
 2004-10-27  Andrey Kiselev  <dron@ak4719.spb.edu>
 
@@ -3335,7 +6350,7 @@ btiff/tif_win32.c: Replace custom Win32 memory api with generic
 2004-10-08  Frank Warmerdam  <warmerdam@pobox.com>
 
 	* libtiff/tif_dirinfo.c: Fix bug with tif_foundfield and reallocation
-	of tif_fieldinfo.  
+	of tif_fieldinfo.
 
 	http://bugzilla.remotesensing.org/show_bug.cgi?id=630
 
@@ -3367,7 +6382,7 @@ btiff/tif_win32.c: Replace custom Win32 memory api with generic
 
 2004-09-30  Frank Warmerdam  <warmerdam@pobox.com>
 
-	* libtiff/tif_dirinfo.c: changed type of XMLPacket (tag 700) to 
+	* libtiff/tif_dirinfo.c: changed type of XMLPacket (tag 700) to
 	TIFFTAG_BYTE instead of TIFFTAG_UNDEFINED to comply with the info
 	in the Adobe XMP Specification.
 
@@ -3387,7 +6402,7 @@ btiff/tif_win32.c: Replace custom Win32 memory api with generic
 2004-09-26  Andrey Kiselev  <dron@ak4719.spb.edu>
 
 	* libtiff/{tif_dir.h, tif_dir.c, tif_dirread.c, tif_write.c}:
-	Optimize checking for the strip bounds. 
+	Optimize checking for the strip bounds.
 
 	* libtiff/{tif_dirread.c, tif_strip.c}: TIFFScanlineSize() and
 	TIFFRasterScanlineSize() functions report zero in the case of integer
@@ -3538,7 +6553,7 @@ btiff/tif_win32.c: Replace custom Win32 memory api with generic
 	here
 
 	http://www.asmail.be/msg0054799560.html
-	
+
 	for details.
 
 	* tools/fax2tiff.c: Use the new functions in the code.
@@ -3666,11 +6681,11 @@ btiff/tif_win32.c: Replace custom Win32 memory api with generic
 	* tools/tiffsplit.c: Fixed problem with unproperly written multibyte
 	files. Now output files will be written using the same byte order
 	flag as	in the input image. See
-	
+
 	http://bugzilla.remotesensing.org/show_bug.cgi?id=574
-	
+
 	for details.
-	
+
 2004-05-19  Frank Warmerdam  <warmerdam@pobox.com>
 
 	* libtiff/tif_print.c: added (untested) support for printing
@@ -3682,7 +6697,7 @@ btiff/tif_win32.c: Replace custom Win32 memory api with generic
 
 	* libtiff/tif_fax3.c: Avoid reading CCITT compression options
 	if compression type mismatches. See
-	
+
 	http://bugzilla.remotesensing.org/show_bug.cgi?id=565
 
 2004-04-30  Andrey Kiselev  <dron@ak4719.spb.edu>
@@ -3727,7 +6742,7 @@ btiff/tif_win32.c: Replace custom Win32 memory api with generic
 2004-04-04  Frank Warmerdam  <warmerdam@pobox.com>
 
 	* libtiff/tif_open.c: close clientdata if TIFFClientOpen() fails
-	via bad2. 
+	via bad2.
 
 2004-03-26  Andrey Kiselev  <dron@ak4719.spb.edu>
 
@@ -3754,10 +6769,10 @@ btiff/tif_win32.c: Replace custom Win32 memory api with generic
 
 2004-02-26  Andrey Kiselev  <dron@ak4719.spb.edu>
 
-	* tools/tiffsplit.c: Copy JPEGTables tag contents for JPEG compressed 
+	* tools/tiffsplit.c: Copy JPEGTables tag contents for JPEG compressed
 	images. Reported by Artem Mirolubov.
 
-	* libtiff/tif_dirread.c: Fixed problem with handling TIFF_UNDEFINED 
+	* libtiff/tif_dirread.c: Fixed problem with handling TIFF_UNDEFINED
 	tag type in TIFFFetchNormalTag() as per bug
 
 	http://bugzilla.remotesensing.org/show_bug.cgi?id=508
@@ -3779,8 +6794,8 @@ btiff/tif_win32.c: Replace custom Win32 memory api with generic
 2004-01-30  Frank Warmerdam  <warmerdam@pobox.com>
 
 	* libtiff/libtiff.def: Added TIFFCurrentDirOffset, TIFFWriteCheck,
-	TIFFRGBAImageOK, and TIFFNumberOfDirectories as suggested by 
-	Scott Reynolds. 
+	TIFFRGBAImageOK, and TIFFNumberOfDirectories as suggested by
+	Scott Reynolds.
 
 2004-01-29  Andrey Kiselev  <dron@ak4719.spb.edu>
 
@@ -3798,7 +6813,7 @@ btiff/tif_win32.c: Replace custom Win32 memory api with generic
 	file if TIFFFdOpen() failed as per bug
 
 	http://bugzilla.remotesensing.org/show_bug.cgi?id=468
-	
+
 	* libtiff/tif_open.c: More fixes for
 
 	http://bugzilla.remotesensing.org/show_bug.cgi?id=468
@@ -3822,7 +6837,7 @@ btiff/tif_win32.c: Replace custom Win32 memory api with generic
 	* libtiff/tif_dirwrite.c: Fixed handling of writable ASCII tags that
 	are field_passcount=TRUE properly.  Arguably anonymous custom tags
 	should be declared as passcount=FALSE, but I don't want to change
-	that without a careful review. 
+	that without a careful review.
 
 2004-01-20  Andrey Kiselev  <dron@ak4719.spb.edu>
 
@@ -3985,8 +7000,8 @@ btiff/tif_win32.c: Replace custom Win32 memory api with generic
 
 2003-11-17  Frank Warmerdam  <warmerdam@pobox.com>
 
-	* tif_dirread.c: do not mark all anonymously defined tags to be 
-	IGNOREd.  
+	* tif_dirread.c: do not mark all anonymously defined tags to be
+	IGNOREd.
 
 2003-11-17  Andrey Kiselev  <dron@ak4719.spb.edu>
 
@@ -3996,7 +7011,7 @@ btiff/tif_win32.c: Replace custom Win32 memory api with generic
 2003-11-16  Andrey Kiselev  <dron@ak4719.spb.edu>
 
 	* libtiff/{tiff.h, tif_dirinfo.c}: Added support for IFD (13)
-	datatype, intruduced in "Adobe PageMaker TIFF Tech. Notes".
+	datatype, introduced in "Adobe PageMaker TIFF Tech. Notes".
 
 2003-11-15  Frank Warmerdam  <warmerdam@pobox.com>
 
@@ -4026,15 +7041,15 @@ btiff/tif_win32.c: Replace custom Win32 memory api with generic
 
 2003-11-09  Frank Warmerdam  <warmerdam@pobox.com>
 
-	* libtiff/tif_tile.c: remove spurious use of "s" (sample) in the 
+	* libtiff/tif_tile.c: remove spurious use of "s" (sample) in the
 	planarconfig_contig case in TIFFComputeTile().
 
 	http://bugzilla.remotesensing.org/show_bug.cgi?id=387
 
 2003-11-09  Andrey Kiselev  <dron@ak4719.spb.edu>
-	
+
 	* libtiff/tiffiop.h: New macros: TIFFmax, TIFFmin and TIFFrint.
-	
+
 2003-11-07  Andrey Kiselev  <dron@ak4719.spb.edu>
 
 	* libtiff/{tiffio.h, tif_strip.c}, man/{TIFFstrip.3t, libtiff.3t}:
@@ -4101,11 +7116,11 @@ btiff/tif_win32.c: Replace custom Win32 memory api with generic
 	function TIFFReadRGBAImageOriented() implemented to retrieve raster
 	array with user-specified origin position as suggested by Jason Frank.
 	See
-	
+
 	http://bugzilla.remotesensing.org/show_bug.cgi?id=322
 
 	for details.
-	
+
 	* tools/tiff2rgba.c: Switched to use TIFFReadRGBAImageOriented()
 	instead of TIFFReadRGBAImage().
 
@@ -4186,9 +7201,9 @@ btiff/tif_win32.c: Replace custom Win32 memory api with generic
 	encoded write functions use tif_postdecode() to apply byte order
 	swapping (swab) to the application passed data buffer if the same
 	would be done when reading.  This allows us to write pixel data with
-	more than 8 bits per sample to existing files of a non-native byte 
+	more than 8 bits per sample to existing files of a non-native byte
 	order.  One side effect of this change is the applications buffer
-	itself is altered in this case by the act of writing. 
+	itself is altered in this case by the act of writing.
 
 	http://bugzilla.remotesensing.org/show_bug.cgi?id=171
 
@@ -4214,9 +7229,9 @@ btiff/tif_win32.c: Replace custom Win32 memory api with generic
 2003-07-08  Frank Warmerdam  <warmerdam@pobox.com>
 
 	* tif_aux.c, tif_codec.c, tif_dir.c, tif_dirread.c, tif_extension.c,
-	tif_fax3.c, tif_getimage.c, tif_luv.c, tif_lzw.c, tif_next.c, 
+	tif_fax3.c, tif_getimage.c, tif_luv.c, tif_lzw.c, tif_next.c,
 	tif_packbits.c, tif_predict.c, tif_print.c, tif_swab.c, tif_thunder.c:
-	avoid casting warning at /W4. 
+	avoid casting warning at /W4.
 
 2003-07-03  Andrey Kiselev  <dron@ak4719.spb.edu>
 
@@ -4238,11 +7253,11 @@ btiff/tif_win32.c: Replace custom Win32 memory api with generic
 
 	* libtiff/tif_dirinfo.c: TIFFDataWidth() returns 0 in case of
 	unknown data type.
-	
+
 2003-06-19  Frank Warmerdam  <warmerdam@pobox.com>
 
 	* libtiff/tif_print.c: fixed some serious bugs when printing
-	custom tags ... almost certain to crash. 
+	custom tags ... almost certain to crash.
 
 	* libtiff/tif_dirread.c: Don't ignore custom fields that are
 	autodefined.  Not sure how this got to be like this.
@@ -4253,12 +7268,12 @@ btiff/tif_win32.c: Replace custom Win32 memory api with generic
 
 	* tools/tiffcmp.c, man/tiffcmp.1: Fixed problem with unused data
 	comparing as per bug
-	
+
 	http://bugzilla.remotesensing.org/show_bug.cgi?id=349
 
 	`-z' option now can be used to set the number of reported different
 	bytes.
-	
+
 2003-06-09  Andrey Kiselev  <dron@ak4719.spb.edu>
 
 	* tools/tiffcp.c, man/tiffcp.1: Added possibility to specify value -1
@@ -4284,7 +7299,7 @@ btiff/tif_win32.c: Replace custom Win32 memory api with generic
 2003-05-25  Andrey Kiselev  <dron@ak4719.spb.edu>
 
 	* tools/fax2tiff.c: Page numbering fixed, as per bug
-	
+
 	http://bugzilla.remotesensing.org/show_bug.cgi?id=341
 
 2003-05-20  Andrey Kiselev  <dron@ak4719.spb.edu>
@@ -4307,7 +7322,7 @@ btiff/tif_win32.c: Replace custom Win32 memory api with generic
 
 	* contrib/ojpeg/{Makefile.in, jdhuff.h, jinclude.h, ojpeg.c, README},
 	configure, Makefile.in:	Improved libtiff compilation with OJPEG
-	support. Now no need for patching IJG JPEG library, hack requred by
+	support. Now no need for patching IJG JPEG library, hack required by
 	libtiff will be compiled and used in-place. Implemented with
 	suggestion and help from Bill Allombert, Debian's libjpeg maintainer.
 
@@ -4350,7 +7365,7 @@ btiff/tif_win32.c: Replace custom Win32 memory api with generic
 
 	* tools/tiffcp.c: Fixed problem with colorspace conversion for JPEG
 	encoded images. See bug entries
-	
+
 	http://bugzilla.remotesensing.org/show_bug.cgi?id=275
 
 	and
@@ -4411,16 +7426,16 @@ btiff/tif_win32.c: Replace custom Win32 memory api with generic
 
 	* libtiff/tif_jpeg.c: Modified to defer initialization of jpeg
 	library so that we can check if there is already any tile/strip data
-	before deciding between creating a compressor or a decompressor. 
+	before deciding between creating a compressor or a decompressor.
 
 2003-01-31  Frank Warmerdam  <warmerdam@pobox.com>
 
 	* libtiff/tif_write.c: TIFFWriteCheck() now fails if the image is
-	a pre-existing compressed image.  That is, image writing to 
+	a pre-existing compressed image.  That is, image writing to
 	pre-existing compressed images is not allowed.
 
 	* libtiff/tif_open.c: Removed error if opening a compressed file
-	in update mode. 
+	in update mode.
 
 	http://bugzilla.remotesensing.org/show_bug.cgi?id=198
 
@@ -4433,16 +7448,16 @@ btiff/tif_win32.c: Replace custom Win32 memory api with generic
 	* cut 3.6.0 Beta release.
 
 2002-12-20  Andrey Kiselev  <dron@ak4719.spb.edu>
-	
+
 	* tools/fax2ps.c, man/fax2ps.1: Page size was determined
 	in wrong way as per bug
-	
+
 	http://bugzilla.remotesensing.org/show_bug.cgi?id=239
 
 2002-12-17  Frank Warmerdam  <warmerdam@pobox.com>
 
-	* libtiff/tif_dirread.c: Allow wrong sized arrays in 
-	TIFFFetchStripThing(). 
+	* libtiff/tif_dirread.c: Allow wrong sized arrays in
+	TIFFFetchStripThing().
 
 	http://bugzilla.remotesensing.org/show_bug.cgi?id=49
 
@@ -4456,7 +7471,7 @@ btiff/tif_win32.c: Replace custom Win32 memory api with generic
 	* libtiff/tif_dir.c: fixed bug with resetting an existing custom
 	field value.
 
-	* libtiff/tif_dir.c: Fixed potential problem with ascii "custom" 
+	* libtiff/tif_dir.c: Fixed potential problem with ascii "custom"
 	tags in TIFFVGetField() ... added missing break.
 
 2002-10-14  Frank Warmerdam  <warmerdam@pobox.com>
@@ -4468,11 +7483,11 @@ btiff/tif_win32.c: Replace custom Win32 memory api with generic
 	the eps by redefining the colorimage operator will get messed up.
 	Patch supplied by William Bader.
 
-	* Makefile.in: added tif_extension.c to file list as per 
+	* Makefile.in: added tif_extension.c to file list as per
 	http://bugzilla.remotesensing.org/show_bug.cgi?id=218.
 
 2002-10-11  Andrey Kiselev  <dron@ak4719.spb.edu>
-	
+
 	* configure, config.site, libtiff/{tif_unix.c, Makefile.in}: Fix for
 	large files (>2GiB) supporting. New option in the config.site:
 	LARGEFILE="yes". Should be enough for I/O of the large files.
@@ -4504,13 +7519,13 @@ btiff/tif_win32.c: Replace custom Win32 memory api with generic
 2002-10-06  Frank Warmerdam  <warmerdam@pobox.com>
 
 	* libtiff/tif_jpeg.c: fixed problem with boolean defined with wrong
-	size on windows.  Use #define boolean hack.  
+	size on windows.  Use #define boolean hack.
 
 	http://bugzilla.remotesensing.org/show_bug.cgi?id=188
 
 	* libtiff/tiff.h: Don't do special type handling in tiff.h unless
 	USING_VISUALAGE is defined.
-	
+
 	http://bugzilla.remotesensing.org/show_bug.cgi?id=39
 
 2002-10-03  Frank Warmerdam  <warmerdam@pobox.com>
@@ -4521,30 +7536,30 @@ btiff/tif_win32.c: Replace custom Win32 memory api with generic
 
 	* libtiff/tif_dirread.c: Another fix for the fetching SBYTE arrays
 	by the TIFFFetchByteArray() function. Should finally resolve
-	
+
 	http://bugzilla.remotesensing.org/show_bug.cgi?id=52
-	
+
 	* configure: Set -DPIXARLOG_SUPPORT option along with -DZIP_SUPPORT
 
 	* html/Makefile.in: New targets added: html and groffhtml for
 	producing HTML representations of the manual pages automatically.
 	html target uses man2html tool, groffhtml uses groff tool.
-	
+
 2002-09-29  Frank Warmerdam  <warmerdam@pobox.com>
 
 	* configure, libtiff/Makefile.in: Added SCO OpenServer 5.0.6 support
-	from John H. DuBois III.  
+	from John H. DuBois III.
 
 2002-09-15  Andrey Kiselev  <dron@ak4719.spb.edu>
 
 	* Makefile.in, /man/{raw2tiff.1, Makefile.in, libtiff.3}: Added
 	manual page for raw2tiff(1) tool.
-	
+
 2002-09-12  Andrey Kiselev  <dron@ak4719.spb.edu>
 
 	* /libtiff/{tiffio.h, tif_dir.h}: TIFFDataWidth() declaration moved to
 	the tiffio.h header file.
-	
+
 	* Makefile.in, /man/{TIFFDataWidth.3t, Makefile.in, libtiff.3}: Added
 	manual page for TIFFDataWidth() function
 
@@ -4554,8 +7569,8 @@ btiff/tif_win32.c: Replace custom Win32 memory api with generic
 	as per http://bugzilla.remotesensing.org/show_bug.cgi?id=196.
 
 	* tools/tiff2ps.c: Don't emit BeginData/EndData DSC comments
-	since we are unable to properly include the amount to skip. 
-	
+	since we are unable to properly include the amount to skip.
+
 	http://bugzilla.remotesensing.org/show_bug.cgi?id=80
 
 2002-09-02  Andrey Kiselev  <dron@ak4719.spb.edu>
@@ -4565,7 +7580,7 @@ btiff/tif_win32.c: Replace custom Win32 memory api with generic
 	http://bugzilla.remotesensing.org/show_bug.cgi?id=52
 
 2002-08-22  Andrey Kiselev  <dron@ak4719.spb.edu>
-	
+
 	* /libtiff/tif_dirinfo.c: Further additions to free custom fields
 	in _TIFFSetupFieldInfo() function.
 	See http://bugzilla.remotesensing.org/show_bug.cgi?id=169 for details.
@@ -4574,14 +7589,14 @@ btiff/tif_win32.c: Replace custom Win32 memory api with generic
 	LZWDecode() and LZWDecodeCompat().
 	Fixes http://bugzilla.remotesensing.org/show_bug.cgi?id=190
 	and http://bugzilla.remotesensing.org/show_bug.cgi?id=100
-	
+
 	* /libtiff/tif_lzw.c:
 	Added check for valid code lengths in LZWDecode() and
 	LZWDecodeCompat(). Fixes
 	http://bugzilla.remotesensing.org/show_bug.cgi?id=115
 
 2002-08-16  Andrey Kiselev  <dron@ak4719.spb.edu>
-	
+
 	* /libtiff/{Makefile.vc, libtiff.def}:
 	Missed declarations added.
 
@@ -4592,7 +7607,7 @@ btiff/tif_win32.c: Replace custom Win32 memory api with generic
 
 	http://bugzilla.remotesensing.org/show_bug.cgi?id=177
 
-	* tif_dir.h: changed FIELD_CODEC to 66 from 64 to avoid overlap 
+	* tif_dir.h: changed FIELD_CODEC to 66 from 64 to avoid overlap
 	with FIELD_CUSTOM as mentioned in bug 169.
 
 	* tif_close.c: added logic to free dynamically created anonymous
@@ -4601,31 +7616,31 @@ btiff/tif_win32.c: Replace custom Win32 memory api with generic
 	http://bugzilla.remotesensing.org/show_bug.cgi?id=169
 
 2002-08-10  Andrey Kiselev  <dron@ak4719.spb.edu>
-	
+
 	* /tools/{raw2tiff.c, Makefile.in, Makefile.lcc, Makefile.vc}:
 	New tool: raw2tiff --- raw images to TIFF converter. No manual page yet.
 
 2002-07-31  Frank Warmerdam  <warmerdam@pobox.com>
 
-	* libtiff/tif_jpeg.c: Fixed problem with setting of nrows in 
+	* libtiff/tif_jpeg.c: Fixed problem with setting of nrows in
 	JPEGDecode() as per bugzilla bug (issue 1):
 
 	http://bugzilla.remotesensing.org/show_bug.cgi?id=129
 
 	* libtiff/{tif_jpeg.c,tif_strip.c,tif_print.c}: Hacked tif_jpeg.c to
 	fetch TIFFTAG_YCBCRSUBSAMPLING from the jpeg data stream if it isn't
-	present in the tiff tags. 
+	present in the tiff tags.
 
 	http://bugzilla.remotesensing.org/show_bug.cgi?id=168
 
 	* libtiff/tif_read.c, libtiff/tif_write.c: TIFFReadScanline() and
 	TIFFWriteScanline() now set tif_row explicitly in case the codec has
-	fooled with the value. 
+	fooled with the value.
 
 	http://bugzilla.remotesensing.org/show_bug.cgi?id=129
 
 2002-06-22  Andrey Kiselev  <dron@ak4719.spb.edu>
-	
+
 	* /tools/tiff2ps.c: Added workaround for some software that may crash
 	when last strip of image contains fewer number of scanlines than
 	specified by the `/Height' variable. See
@@ -4641,8 +7656,8 @@ btiff/tif_win32.c: Replace custom Win32 memory api with generic
 
 2002-06-11  Frank Warmerdam  <warmerdam@pobox.com>
 
-	* libtiff/contrib/win95: renamed to contrib/win_dib.  Added new 
-	Tiffile.cpp example of converting TIFF files into a DIB on Win32.  
+	* libtiff/contrib/win95: renamed to contrib/win_dib.  Added new
+	Tiffile.cpp example of converting TIFF files into a DIB on Win32.
 	This one is described in:
 
 	http://bugzilla.remotesensing.org/show_bug.cgi?id=143
@@ -4658,21 +7673,21 @@ btiff/tif_win32.c: Replace custom Win32 memory api with generic
 	http://bugzilla.remotesensing.org/show_bug.cgi?id=131
 
 2002-04-26  Andrey Kiselev  <dron@ak4719.spb.edu>
-	
+
 	* libtiff/libtiff.def: Added missed declaration.
-	
+
 2002-04-22  Andrey Kiselev  <dron@ak4719.spb.edu>
-	
+
 	* tools/fax2tiff.c: Updated to reflect latest changes in libtiff.
 	Closes http://bugzilla.remotesensing.org/show_bug.cgi?id=125
 
 2002-04-20  Andrey Kiselev  <dron@ak4719.spb.edu>
-	
+
 	* libtiff/tif_open.c: Pointers to custom procedures
 	in TIFFClientOpen() are checked to be not NULL-pointers.
-	
+
 2002-04-18  Andrey Kiselev  <dron@ak4719.spb.edu>
-	
+
 	* libtiff/libtiff.def: Added missed declarations.
 
 	* libtiff/tif_pixarlog.c: Updated for using tif_tagmethods structure.
@@ -4682,14 +7697,14 @@ btiff/tif_win32.c: Replace custom Win32 memory api with generic
 	* libtiff/tif_lzw.c: Additional checks for data integrity introduced.
 	Should finally close
 	http://bugzilla.remotesensing.org/show_bug.cgi?id=100
-	
+
 2002-04-10  Andrey Kiselev  <dron@ak4719.spb.edu>
 
 	* tools/tiff2ps: Division by zero fixed.
 	Closes http://bugzilla.remotesensing.org/show_bug.cgi?id=88
 
 2002-04-09  Andrey Kiselev  <dron@ak4719.spb.edu>
-	
+
 	* libtiff/: tif_dirwrite.c, tif_write.c, tiffio.h:
 	TIFFCheckpointDirectory() routine added.
 	Closes http://bugzilla.remotesensing.org/show_bug.cgi?id=124
@@ -4721,7 +7736,7 @@ btiff/tif_win32.c: Replace custom Win32 memory api with generic
 	replaced by warnings. Now libtiff should read corrupted LZW-compressed
 	files by skipping bad strips.
 	Closes http://bugzilla.remotesensing.org/show_bug.cgi?id=100
-	
+
 2002-04-03  Frank Warmerdam  <warmerdam@pobox.com>
 
 	* libtiff/tif_dirwrite.c: Removed some dead code.
@@ -4743,18 +7758,18 @@ btiff/tif_win32.c: Replace custom Win32 memory api with generic
 
 	http://bugzilla.remotesensing.org/show_bug.cgi?id=111
 
-	* tif_print.c: Fixed so that ASCII FIELD_CUSTOM values with 
+	* tif_print.c: Fixed so that ASCII FIELD_CUSTOM values with
 	passcount set FALSE can be printed (such as TIFFTAG_SOFTWARE).
 
-	* libtiff/tif_dir.c,tif_dirinfo.c,tif_dir.h,tif_ojpeg.c: modified so 
+	* libtiff/tif_dir.c,tif_dirinfo.c,tif_dir.h,tif_ojpeg.c: modified so
 	that TIFFTAG_SOFTWARE uses FIELD_CUSTOM as an example.
 
 2002-03-26  Dwight Kelly  <dbmalloc@remotesensing.org>
 
 	* libtiff/: tiff.h, tif_dir.c, tif_dir.h, tif_dirinfo.c, tif_dirread.c,
 	tif_dirwrite.c: Added get/put code for new tag XMLPACKET as defined
-	in Adobe XMP Technote. Added missing INKSET tag value from TIFF 6.0 spec 
-	INKSET_MULTIINK (=2). Added missing tags from Adobe TIFF technotes: 
+	in Adobe XMP Technote. Added missing INKSET tag value from TIFF 6.0 spec
+	INKSET_MULTIINK (=2). Added missing tags from Adobe TIFF technotes:
 	CLIPPATH, XCLIPPATHUNITS, YCLIPPATHUNITS, OPIIMAGEID, OPIPROXY and
 	INDEXED. Added PHOTOMETRIC tag value from TIFF technote 4 ICCLAB (=9).
 
@@ -4813,7 +7828,7 @@ btiff/tif_win32.c: Replace custom Win32 memory api with generic
 
 	http://bugzilla.remotesensing.org/show_bug.cgi?id=94
 
-	* man/Makefile.in: Patch DESTDIR handling 
+	* man/Makefile.in: Patch DESTDIR handling
 
 	http://bugzilla.remotesensing.org/show_bug.cgi?id=95
 
@@ -4851,9 +7866,9 @@ btiff/tif_win32.c: Replace custom Win32 memory api with generic
 
 2002-01-04  Frank Warmerdam  <warmerdam@pobox.com>
 
-	* libtiff/tif_jpeg.c: fixed computation of segment_width for 
-	tiles files to avoid error about it not matching the 
-	cinfo.d.image_width values ("JPEGPreDecode: Improper JPEG strip/tile 
+	* libtiff/tif_jpeg.c: fixed computation of segment_width for
+	tiles files to avoid error about it not matching the
+	cinfo.d.image_width values ("JPEGPreDecode: Improper JPEG strip/tile
 	size.") for ITIFF files.  Apparently the problem was incorporated since
 	3.5.5, presumably during the OJPEG/JPEG work recently.
 
@@ -4863,7 +7878,7 @@ btiff/tif_win32.c: Replace custom Win32 memory api with generic
 
 	http://bugzilla.remotesensing.org/show_bug.cgi?id=94
 
-	* libtiff/tif_getimage.c: If DEFAULT_EXTRASAMPLE_AS_ALPHA is 1 
+	* libtiff/tif_getimage.c: If DEFAULT_EXTRASAMPLE_AS_ALPHA is 1
 	(defined in tiffconf.h - 1 by default) then the RGBA interface
 	will assume that a fourth extra sample is ASSOCALPHA if the
 	EXTRASAMPLE value isn't set for it.  This changes the behaviour of
@@ -4875,9 +7890,9 @@ btiff/tif_win32.c: Replace custom Win32 memory api with generic
 
 2001-12-12  Frank Warmerdam  <warmerdam@pobox.com>
 
-	* libtiff/tif_jpeg.c: allow jpeg data stream sampling values to 
-	override those from tiff directory.  This makes this work with 
-	ImageGear generated files. 
+	* libtiff/tif_jpeg.c: allow jpeg data stream sampling values to
+	override those from tiff directory.  This makes this work with
+	ImageGear generated files.
 
 2001-12-07  Frank Warmerdam  <warmerdam@pobox.com>
 
@@ -4890,7 +7905,7 @@ btiff/tif_win32.c: Replace custom Win32 memory api with generic
 	* Reissue 3.5.7 release.
 
 	* libtiff/mkversion.c: Fix output of TIFF_VERSION to be
-	YYYYMMDD so that it is increasing over time. 
+	YYYYMMDD so that it is increasing over time.
 
 	* Makefile.in: Ensure that tiffvers.h is regenerated in the
 	make release target.
@@ -4915,8 +7930,8 @@ btiff/tif_win32.c: Replace custom Win32 memory api with generic
 
 2001-10-10  Frank Warmerdam  <warmerdam@pobox.com>
 
-	* libtiff/tiff.h: I have created COMPRESSION_CCITT_T4, 
-	COMPRESSION_CCITT_T6, TIFFTAG_T4OPTIONS and TIFFTAG_T6OPTIONS aliases 
+	* libtiff/tiff.h: I have created COMPRESSION_CCITT_T4,
+	COMPRESSION_CCITT_T6, TIFFTAG_T4OPTIONS and TIFFTAG_T6OPTIONS aliases
 	in keeping with TIFF 6.0 standard in tiff.h
 
 	http://bugzilla.remotesensing.org/show_bug.cgi?id=83
@@ -4936,10 +7951,10 @@ btiff/tif_win32.c: Replace custom Win32 memory api with generic
 	error about LZW not being available.
 
 	* libtiff/tif_dir.c: propagate failure to initialize compression
-	back from TIFFSetField() as an error status, so applications can 
+	back from TIFFSetField() as an error status, so applications can
 	detect failure.
 
-	* libtiff/tif_dir.c: removed the auto replacement of 
+	* libtiff/tif_dir.c: removed the auto replacement of
 	COMPRESSION_LZW with COMPRESSION_NONE in _TIFFVSetField().
 
 	* Removed Makefile, tools/Makefile, port/install.sh, man/Makefile
@@ -4947,7 +7962,7 @@ btiff/tif_win32.c: Replace custom Win32 memory api with generic
 
 2001-09-22  Frank Warmerdam  <warmerdam@pobox.com>
 
-	* libtiff/tif_ojpeg.c: new update from Scott. 
+	* libtiff/tif_ojpeg.c: new update from Scott.
 
 2001-09-09  Frank Warmerdam  <warmerdam@pobox.com>
 
@@ -4966,7 +7981,7 @@ btiff/tif_win32.c: Replace custom Win32 memory api with generic
 
 	http://bugzilla.remotesensing.org/show_bug.cgi?id=47
 
-	* tools/tiff2ps.c: added OJPEG YCbCr to RGB support. 
+	* tools/tiff2ps.c: added OJPEG YCbCr to RGB support.
 
 	* libtiff/tif_ojpeg.c: Applied substantial patch from Scott.
 
@@ -4975,14 +7990,14 @@ btiff/tif_win32.c: Replace custom Win32 memory api with generic
 	* libtiff/tif_packbits.c: fixed memory overrun error.
 
 	http://bugzilla.remotesensing.org/show_bug.cgi?id=77
-	
+
 2001-08-31  Frank Warmerdam  <warmerdam@pobox.com>
 
 	* libtiff/tif_getimage.c: relax handling of contig case where
 	there are extra samples that are supposed to be ignored.  This
-	should now work for 8bit greyscale or palletted images.  
+	should now work for 8bit greyscale or palletted images.
 
-	http://bugzilla.remotesensing.org/show_bug.cgi?id=75	
+	http://bugzilla.remotesensing.org/show_bug.cgi?id=75
 
 2001-08-28  Frank Warmerdam  <warmerdam@pobox.com>
 
@@ -4995,15 +8010,15 @@ btiff/tif_win32.c: Replace custom Win32 memory api with generic
 
 	* libtiff/tif_getimage.c: Use memmove() instead of TIFFmemcpy()
 	in TIFFReadRGBATile() to avoid issues in cases of overlapping
-	buffers.  See Bug 69 in Bugzilla. 
+	buffers.  See Bug 69 in Bugzilla.
 
 	http://bugzilla.remotesensing.org/show_bug.cgi?id=69
-	
+
 	* tools/tiff2rgba.c: fixed getopt() call so that -b works again.
 
 2001-08-09  Frank Warmerdam  <warmerdam@pobox.com>
 
-	* libtiff/tiff.h, libtiff/tif_fax3.c: added check for __LP64__ 
+	* libtiff/tiff.h, libtiff/tif_fax3.c: added check for __LP64__
 	when checking for 64 bit architectures as per bugzilla bug 67.
 
 2001-07-27  Frank Warmerdam  <warmerdam@pobox.com>
@@ -5013,7 +8028,7 @@ btiff/tif_win32.c: Replace custom Win32 memory api with generic
 
 2001-07-20  Frank Warmerdam  <warmerdam@pobox.com>
 
-	* libtiff/tif_jpeg.c: Define HAVE_BOOLEAN on windows if RPCNDR.H 
+	* libtiff/tif_jpeg.c: Define HAVE_BOOLEAN on windows if RPCNDR.H
 	has been included.
 
 2001-07-19  Frank Warmerdam  <warmerdam@pobox.com>
@@ -5025,11 +8040,11 @@ btiff/tif_win32.c: Replace custom Win32 memory api with generic
 
 	* libtiff/tif_ojpeg.c: updates from Scott.  Handles colors
 	much better.  Now depends on having patched libjpeg as per
-	patch in contrib/ojpeg/*. 
+	patch in contrib/ojpeg/*.
 
 2001-07-17  Frank Warmerdam  <warmerdam@pobox.com>
 
-	* */Makefile.in: added DESTDIR support. 
+	* */Makefile.in: added DESTDIR support.
 
 	http://bugzilla.remotesensing.org/show_bug.cgi?id=60
 
@@ -5037,20 +8052,20 @@ btiff/tif_win32.c: Replace custom Win32 memory api with generic
 
 	* configure, libtiff/Makefile.in: applied OpenBSD patches
 	as per:
-	
+
 	http://bugzilla.remotesensing.org/show_bug.cgi?id=61
 
 2001-06-28  Frank Warmerdam  <warmerdam@pobox.com>
 
 	* libtiff/tif_getimage.c: Fixed so that failure is properly
-	reported by gtTileContig, gtStripContig, gtTileSeparate and 
+	reported by gtTileContig, gtStripContig, gtTileSeparate and
 	gtStripSeparate.
 
 	See http://bugzilla.remotesensing.org/show_bug.cgi?id=51
 
-	* tiffcmp.c: Fixed multi samples per pixel support for ContigCompare.  
+	* tiffcmp.c: Fixed multi samples per pixel support for ContigCompare.
 	Updated bug section of tiffcmp.1 to note tiled file issues.
-	
+
 	See http://bugzilla.remotesensing.org/show_bug.cgi?id=53
 
 2001-06-22  Frank Warmerdam  <warmerdam@pobox.com>
@@ -5091,10 +8106,10 @@ btiff/tif_win32.c: Replace custom Win32 memory api with generic
 
 2001-05-08  Frank Warmerdam  <warmerdam@pobox.com>
 
-	* libtiff/tif_dirinfo.c: moved pixar and copyright flags to 
+	* libtiff/tif_dirinfo.c: moved pixar and copyright flags to
 	ensure everything is in order.
 
-	* libtiff/libtiff.def: added TIFFCreateDirectory and 
+	* libtiff/libtiff.def: added TIFFCreateDirectory and
 	TIFFDefaultStripSize as per:
 
 	  http://bugzilla.remotesensing.org/show_bug.cgi?id=46
@@ -5103,10 +8118,10 @@ btiff/tif_win32.c: Replace custom Win32 memory api with generic
 
 	* libtiff/tif_dirinfo.c: Modified the TIFF_BYTE definition for
 	TIFFTAG_PHOTOSHOP to use a writecount of TIFF_VARIABLE2 (-3) to
-	force use of uint32 counts instead of short counts. 
+	force use of uint32 counts instead of short counts.
 
 	* libtiff/tif_dirwrite.c: Added support for TIFF_VARIABLE2 in the
-	case of writing TIFF_BYTE/TIFF_SBYTE fields.  
+	case of writing TIFF_BYTE/TIFF_SBYTE fields.
 
 	http://bugzilla.remotesensing.org/show_bug.cgi?id=43
 
@@ -5142,20 +8157,20 @@ btiff/tif_win32.c: Replace custom Win32 memory api with generic
 	with the inttypes.h include file on AIX.
 
 	See http://bugzilla.remotesensing.org/show_bug.cgi?id=39
-	
+
 	* VERSION: update to 3.5.7 beta in preparation for release.
 
 	* configure/config.site: modified to check if -lm is needed for
 	MACHDEPLIBS if not supplied by config.site.  Needed for Darwin.
 
-	* config.guess: updated wholesale to an FSF version apparently 
-	from 1998 (as opposed to 1994).  This is mainly inspired by 
+	* config.guess: updated wholesale to an FSF version apparently
+	from 1998 (as opposed to 1994).  This is mainly inspired by
 	providing for MacOS X support.
 
 2001-03-29  Frank Warmerdam  <warmerdam@pobox.com>
 
 	* configure, Makefile.in, etc: added support for OPTIMIZER being
-	set from config.site. 
+	set from config.site.
 
 2001-03-28  Frank Warmerdam  <warmerdam@pobox.com>
 
@@ -5165,7 +8180,7 @@ btiff/tif_win32.c: Replace custom Win32 memory api with generic
 	sizes. It fixes two problems:
 
 	Without	scaling (-S) the fax is now centered on the page size specified
-	with -H	and/or -W. Before, fax2ps was using an obscure and practially
+	with -H	and/or -W. Before, fax2ps was using an obscure and practically
 	useless algorithm to allocate the image relative to Letter sized paper
 	which sometime sled to useless whitespace on the paper, while at the
 	same time cutting of the faxes printable area at the opposite border.
@@ -5174,7 +8189,7 @@ btiff/tif_win32.c: Replace custom Win32 memory api with generic
 	(in particular short ones) print properly.
 
 	See http://bugzilla.remotesensing.org/show_bug.cgi?id=35
-	
+
 	* tiff2ps.c/tiff2ps.1: Substantial changes to tiff2ps by
 	Bruce A. Mallett.  See check message for detailed information
 	on all the changes, including a faster encoder, fixes for level
@@ -5182,7 +8197,7 @@ btiff/tif_win32.c: Replace custom Win32 memory api with generic
 
 2001-03-27  Frank Warmerdam  <warmerdam@pobox.com>
 
-	* libtiff/tiffio.h: Changed "#if LOGLUV_PUBLIC" to 
+	* libtiff/tiffio.h: Changed "#if LOGLUV_PUBLIC" to
 	"#ifdef LOGLUV_PUBLIC" so it will work with VisualAge on AIX.
 
 	http://bugzilla.remotesensing.org/show_bug.cgi?id=39
@@ -5194,7 +8209,7 @@ btiff/tif_win32.c: Replace custom Win32 memory api with generic
 
 2001-03-13  Frank Warmerdam  <warmerdam@pobox.com>
 
-	* tif_getimage.c: Added support for 16bit minisblack/miniswhite 
+	* tif_getimage.c: Added support for 16bit minisblack/miniswhite
 	images in RGBA interface.
 
 2001-03-02  Frank Warmerdam  <warmerdam@pobox.com>
@@ -5205,29 +8220,29 @@ btiff/tif_win32.c: Replace custom Win32 memory api with generic
 
 	* Brent Roman contributed updated tiffcp utility (and tiffcp.1)
 	with support for extracting subimages with the ,n syntax, and also
-	adding the -b bias removal flag. 
+	adding the -b bias removal flag.
 
 2001-02-16  Frank Warmerdam  <warmerdam@pobox.com>
 
 	* libtiff/libtiff.def: Brent Roman submitted new version adding
-	serveral missing entry points. 
+	serveral missing entry points.
 
 	* libtiff/tif_dirinfo.c: don't declare tiffFieldInfo static on VMS.
-	Some sort of weird VMS thing.  
+	Some sort of weird VMS thing.
 
 	http://bugzilla.remotesensing.org/show_bug.cgi?id=31
 
-	* tif_luv.c/tiff.h/tiffio.h: 
-	New version of TIFF LogLuv (SGILOG) modules contributed by Greg Ward 
+	* tif_luv.c/tiff.h/tiffio.h:
+	New version of TIFF LogLuv (SGILOG) modules contributed by Greg Ward
 	(greg@shutterfly.com).  He writes:
 
 	1) I improved the gamut-mapping function in tif_luv.c for imaginary
-	colors, because some images were being super-saturated on the input 
+	colors, because some images were being super-saturated on the input
 	side and this resulted in some strange color shifts in the output.
 
 	2) I added a psuedotag in tiff.h to control random dithering during
-	LogLuv encoding.  This is turned off by default for 32-bit LogLuv and 
-	on for 24-bit LogLuv output.  Dithering improves the average color 
+	LogLuv encoding.  This is turned off by default for 32-bit LogLuv and
+	on for 24-bit LogLuv output.  Dithering improves the average color
 	accuracy over the image.
 
 	3) I added a #define for LOG_LUV_PUBLIC, which is enabled by default in
@@ -5240,20 +8255,20 @@ btiff/tif_win32.c: Replace custom Win32 memory api with generic
 2001-01-23  Frank Warmerdam  <warmerdam@pobox.com>
 
 	* tif_fax3.c: keep rw_mode flag internal to fax3 state to remember
-	whether we are encoding or decoding.  This is to ensure graceful 
+	whether we are encoding or decoding.  This is to ensure graceful
 	recovery if TIFFClientOpen() discovers an attempt to open a compressed
-	file for "r+" access, and subsequently close it, as it resets the 
+	file for "r+" access, and subsequently close it, as it resets the
 	tif_mode flag to O_RDONLY in this case to avoid writes, confusing the
 	compressor's concept of whether it is in encode or decode mode.
 
-2001-01-08  Mike Welles <mike@bangstate.com> 
+2001-01-08  Mike Welles <mike@bangstate.com>
 
 	* Makefile.in:  Now cleaning up after itself after creating the .tar.gz and .zip
-	
+
 2001-01-07  Frank Warmerdam  <warmerdam@pobox.com>
 
 	* html/libtiff.html: Fixed arguments in example for TIFFRGBAImageGet()
-	as per bug report by Patrick Connor. 
+	as per bug report by Patrick Connor.
 
 2000-12-28  Frank Warmerdam  <warmerdam@pobox.com>
 
@@ -5261,12 +8276,12 @@ btiff/tif_win32.c: Replace custom Win32 memory api with generic
 
 	* Fixed libtiff/makefile.vc to make tiffvers.h not version.h.
 
-2000-12-22  Mike Welles <mike@bangstate.com> 
+2000-12-22  Mike Welles <mike@bangstate.com>
         * added link to CVS mirror from index.html
-	
-	* updated html/internals.html to note that LZW compression is 
-	  not supported by default. 
-	
+
+	* updated html/internals.html to note that LZW compression is
+	  not supported by default.
+
 2000-12-22  Frank Warmerdam  <warmerdam@pobox.com>
 
 	* updated html/libtiff.html to not point at Niles' old JPL web site
@@ -5278,19 +8293,19 @@ btiff/tif_win32.c: Replace custom Win32 memory api with generic
 	Leonard Rosenthol <leonardr@lazerware.com>.  May interfere
 	with correct building on older systems.  If so, please let me know.
 
-2000-12-19 Mike Welles <mike@bangsate.com>   
+2000-12-19 Mike Welles <mike@bangsate.com>
 
-	* Took out LZW Encoding from tif_lzw.c 
+	* Took out LZW Encoding from tif_lzw.c
 
 	* Created HOWTO-RELEASE
 
 	* Created html/v3.5.6.html
 
 	* updated index.html
-	
+
 2000-12-01  Frank Warmerdam  <warmerdam@pobox.com>
 
-	* Added patches for EOFB support in tif_fax3.c and tif_fax3.h. 
+	* Added patches for EOFB support in tif_fax3.c and tif_fax3.h.
 	Patches supplied by Frank Cringle <fdc@cliwe.ping.de>
 	Example file at: ftp://ftp.remotesensing.org/pub/libtiff/eofb_396.tif
 
@@ -5304,30 +8319,30 @@ btiff/tif_win32.c: Replace custom Win32 memory api with generic
 	targets so libtiff.so will be built with an explicit dependency
 	on libm.so.
 
-	* libtiff/Makefile.in: Use softlinks to link libtiff.so.3 to 
-	libtiff.so.3.5.5.  
+	* libtiff/Makefile.in: Use softlinks to link libtiff.so.3 to
+	libtiff.so.3.5.5.
 
-	* libtiff/Makefile.in & configure: Remove all references to the ALPHA 
-	file, or ALPHA version logic.  Added stuff about DIST_POINT in 
+	* libtiff/Makefile.in & configure: Remove all references to the ALPHA
+	file, or ALPHA version logic.  Added stuff about DIST_POINT in
 	place of DIST_TYPE and the alpha release number stuff.
 
 2000-11-22  Frank Warmerdam  <warmerdam@pobox.com>
 
 	* I have applied a patch from Steffen Moeller <moeller@ebi.ac.uk> to
-	the configure script so that it now accepts the --prefix, and 
-	--exec-prefix directives. 
+	the configure script so that it now accepts the --prefix, and
+	--exec-prefix directives.
 
 2000-11-13  Frank Warmerdam  <warmerda@cs46980-c>
 
-	* I have made a variety of modifications in an effort to ensure the 
+	* I have made a variety of modifications in an effort to ensure the
 	TIFFLIB_VERSION macro is automatically generated from the RELEASE-DATE
-	file which seems to be updated regularly.  
+	file which seems to be updated regularly.
 
-	 o mkversion.c now reads RELEASE-DATE and emits TIFFLIB_VERSION in 
-	   version include file. 
-	 o renamed version.h to tiffvers.h because we now have to install it 
-	   with the public libtiff include files.  
-	 o include tiffvers.h in tiffio.h. 
+	 o mkversion.c now reads RELEASE-DATE and emits TIFFLIB_VERSION in
+	   version include file.
+	 o renamed version.h to tiffvers.h because we now have to install it
+	   with the public libtiff include files.
+	 o include tiffvers.h in tiffio.h.
 	 o updated tif_version.c to use tiffvers.h.
 	 o Updated Makefile.in accordingly.
 
@@ -5341,13 +8356,13 @@ btiff/tif_win32.c: Replace custom Win32 memory api with generic
 	See http://bugzilla.remotesensing.org/show_bug.cgi?id=20
 	Some patches from Rick LaMont of Dot C Software.
 
-	* Modified tif_packbits.c encoder to avoid compressing more 
+	* Modified tif_packbits.c encoder to avoid compressing more
 	data than provided if rowsize doesn't factor into provided data
 	(such as occurs for YCbCr).
 
 2000-10-19  Frank Warmerdam  <warmerda@cs46980-c>
 
-	* tools/rgb2ycbcr.c: fixed output strip size to account for vertical 
+	* tools/rgb2ycbcr.c: fixed output strip size to account for vertical
 	roundup if rows_per_strip not a multiple of vertical sample size.
 
 2000-10-16  Frank Warmerdam  <warmerda@cs46980-c>
@@ -5363,8 +8378,8 @@ btiff/tif_win32.c: Replace custom Win32 memory api with generic
 2000-10-12  Frank Warmerdam  <warmerda@cs46980-c>
 
 	* Modified tiff2bw to ensure portions add to 100%, and that
-	white is properly recovered. 
-	
+	white is properly recovered.
+
 	See bug http://bugzilla.remotesensing.org/show_bug.cgi?id=15
 	Patch c/o Stanislav Brabec <utx@penguin.cz>
 
@@ -5378,26 +8393,26 @@ btiff/tif_win32.c: Replace custom Win32 memory api with generic
 
 2000-09-27  Frank Warmerdam  <warmerda@cs46980-c>
 
-	* Added GNULDdso target an`d switched linux and freebsd to use it. 
+	* Added GNULDdso target an`d switched linux and freebsd to use it.
 
 2000-09-26  Frank Warmerdam  <warmerda@cs46980-c>
 
 	* Applied patch for 0x0000 sequences in tif_fax3.h's definition
-	of EXPAND1D() as per bug 11 (from Roman). 
+	of EXPAND1D() as per bug 11 (from Roman).
 
 2000-09-25  Frank Warmerdam  <warmerda@cs46980-c>
 	* Fixed tiffcomp.h to avoid win32 stuff if unix #defined, to improve
 	cygwin compatibility.
 
 	* Applied patch from Roman Shpount to tif_fax3.c.  This seems to
-	be a proper fix to the buffer sizing problem.  See 
+	be a proper fix to the buffer sizing problem.  See
 	http://bugzilla.remotesensing.org/show_bug.cgi?id=11
 
 	* Fixed tif_getimage.c to fix overrun bug with YCbCr images without
 	downsampling.  http://bugzilla.remotesensing.org/show_bug.cgi?id=10
 	Thanks to Nick Lamb <njl98r@ecs.soton.ac.uk> for reporting the
 	bug and proving the patch.
-	
+
 2000-09-18  Frank Warmerdam  <warmerda@cs46980-c>
 
 	* Fixed tif_jpeg.c so avoid destroying the decompressor before
@@ -5427,15 +8442,15 @@ btiff/tif_win32.c: Replace custom Win32 memory api with generic
 	* Tentatively added support for SAMPLEFORMAT_COMPLEXIEEEFP, and
 	SAMPLEFORMAT_COMPLEXINT.
 
-2000-07-13  Mike Welles <mike@onshore.com> 
+2000-07-13  Mike Welles <mike@onshore.com>
 
-	* index.html, bugs.html: added bugzilla info. 
-	
+	* index.html, bugs.html: added bugzilla info.
+
 2000-07-12  Frank Warmerdam  <warmerda@rommel.atlsci.com>
 
 	* tif_read.c: fix subtle bug with determining the number of
 	rows for strips that are the last strip in a separation but
-	not the last strip of all in TIFFReadEncodedStrip().  
+	not the last strip of all in TIFFReadEncodedStrip().
 
 	* Applied 16/32 bit fix to tif_fax3.c.  Fix supplied by
 	Peter Skarpetis <peters@serendipity-software.com.au>
@@ -5457,7 +8472,7 @@ btiff/tif_win32.c: Replace custom Win32 memory api with generic
 
 	* libtiff/tif_dirread.c: Don't use estimate strip byte count for
 	one tile/strip images with an offset, and byte count of zero. These
-	could be "unpopulated" images. 
+	could be "unpopulated" images.
 
 2000-04-18  Frank Warmerdam  <warmerda@rommel.atlsci.com>
 
@@ -5472,17 +8487,17 @@ Tue Apr 18 16:18:08 2000  Frank Warmerdam  <warmerda@esabot.atlsci.com>
 2000-04-12  Mike Welles	     <mike@onshore.com>
 	* configure:  Fixed stupid mistake in libc6 test on Linux
 
-2000-04-04  Mike Welles	     <mike@onshore.com> 
+2000-04-04  Mike Welles	     <mike@onshore.com>
 	* tif_win32.c:  Applied patch to fix overreads and ovverwrites
-	  caught by BoundsChecker.  From Arvan Pritchard 
-	  <arvan.pritchard@infomatix.co.uk>  (untested). 
-	
-	* tif_getimage.c:  Applied patch to silence VC6 warnings.  From 
+	  caught by BoundsChecker.  From Arvan Pritchard
+	  <arvan.pritchard@infomatix.co.uk>  (untested).
+
+	* tif_getimage.c:  Applied patch to silence VC6 warnings.  From
 	  Arvan Pritchard <arvan.pritchard@informatix.co.uk>
-	
-	* tif_lzw.c:  Applied patch to silence VC6 warnings.  From 
+
+	* tif_lzw.c:  Applied patch to silence VC6 warnings.  From
 	  Arvan Pritchard <arvan.pritchard@informatix.co.uk>
-	
+
 2000-03-28  Frank Warmerdam  <warmerda@cs46980-c>
 
 	* Added contrib/stream (stream io) code submitted by Avi Bleiweiss.
@@ -5492,34 +8507,34 @@ Tue Apr 18 16:18:08 2000  Frank Warmerdam  <warmerda@esabot.atlsci.com>
 	* fax2ps: Fixed mixup of width and height in bounding box statement
 	as per submission by Nalin Dahyabhai <nalin@redhat.com>.
 
-2000-03-27  Mike Welles	     <mike@onshore.com> 
+2000-03-27  Mike Welles	     <mike@onshore.com>
 
-	* fax2ps:  Modified printruns to take uint32 instead of uint16.  
-	Patch courtesy of Bernt Herd <herd@herdsoft.com> 
-	
-2000-03-20  Mike Welles	     <mike@onshore.com> 
+	* fax2ps:  Modified printruns to take uint32 instead of uint16.
+	Patch courtesy of Bernt Herd <herd@herdsoft.com>
 
-	* configure: added test for libc6 for linux targets.  Bug reported by 
+2000-03-20  Mike Welles	     <mike@onshore.com>
+
+	* configure: added test for libc6 for linux targets.  Bug reported by
         Stanislav Brabec <utx@k332.feld.cvut.cz>
 
-	* Added 3.5 docs to html/Makefile.in.  
+	* Added 3.5 docs to html/Makefile.in.
 	Thanks to  Stanislav Brabec <utx@k332.feld.cvut.cz>
 
-	* configure: fixed bugs in sed scripts 
-	(applied sed script s:/@:s;@:;s:/s;;:;: to configure). 
+	* configure: fixed bugs in sed scripts
+	(applied sed script s:/@:s;@:;s:/s;;:;: to configure).
 	fix submitted to Stanislav Brabec <utx@k332.feld.cvut.cz>
 
-	* tools/iptcutil was not in files list, and wasn't being 
+	* tools/iptcutil was not in files list, and wasn't being
 	added to tar archive.  Updated Makefile.in.
 
 2000-03-17  Frank Warmerdam  <warmerda@cs46980-c>
 
 	* tif_fax3.c: Fixed serious bug introduced during the uint16->uint32
-	conversion for the run arrays.  
+	conversion for the run arrays.
 
 2000-03-03  Frank Warmerdam  <warmerda@cs46980-c.mtnk1.on.wave.home.com>
 
-	* Set td_sampleformat default to SAMPLEFORMAT_UINT instead of 
+	* Set td_sampleformat default to SAMPLEFORMAT_UINT instead of
 	SAMPLEFORMAT_VOID in TIFFDefaultDirectory() in tif_dir.c.
 
 2000-03-02  Frank Warmerdam  <warmerda@cs46980-c.mtnk1.on.wave.home.com>
@@ -5540,20 +8555,20 @@ Tue Feb 15 22:01:05 2000  Frank Warmerdam  <warmerda@gdal.velocet.ca>
 	  set to 1, and added default (off) setting in tiffconf.h.  This
 	  should eventually be set by the configure script somehow.
 
-	  The original work on all these 2-4GB changes was done by 
+	  The original work on all these 2-4GB changes was done by
 	  Peter Smith (psmith@creo.com).
 
 	* Modified tif_win32.c to support 2-4GB seeks.
 
 	* tentatively changed toff_t to be unsigned instead of signed to
-	  facilitate support for 2-4GB files. 
+	  facilitate support for 2-4GB files.
 
 	* Updated a variety of files to use toff_t.  Fixed some mixups
 	  between toff_t and tsize_t.
 
 Fri Jan 28 10:13:49 2000  Frank Warmerdam  <warmerda@gdal.velocet.ca>
 
-	* Largely reimplemented contrib/addtiffo to avoid temp files, 
+	* Largely reimplemented contrib/addtiffo to avoid temp files,
 	updating the TIFF file in place.  Fixed a few other bugs to.
 
 	* Set tif_rawdatasize to zero when freeing raw data buffer in
@@ -5562,7 +8577,7 @@ Fri Jan 28 10:13:49 2000  Frank Warmerdam  <warmerda@gdal.velocet.ca>
 	* Enabled "REWRITE_HACK" in tif_write.c by default.
 
 	* Fix bug in tif_write.c when switching between reading one directory
-	and writing to another. 
+	and writing to another.
 
 	* Made TIFFWriteCheck() public, and added TIFFCreateDirectory()
 
@@ -5574,41 +8589,41 @@ Tue Jan  4 13:39:00 2000  Frank Warmerdam  <warmerda@gdal.velocet.ca>
 
 	* Added libtiff/libtiff.def to TIFFILES distribution list.
 
-Mon Dec 27 12:13:39 EST 1999  Mike Welles <mike@onshore.com> 
+Mon Dec 27 12:13:39 EST 1999  Mike Welles <mike@onshore.com>
 
-	* Created lzw compression kit, as a new module (libtiff-lzw-compression-kit). 
+	* Created lzw compression kit, as a new module (libtiff-lzw-compression-kit).
 
 	* Altered descriptions in tools to reflect "by default" lzw not supported
 
-	* Updated index.html to note lzw compression kit. 
-	
+	* Updated index.html to note lzw compression kit.
+
 Tue Dec 21 14:01:51 1999  Frank Warmerdam  <warmerda@gdal.velocet.ca>
 
-	* Added fax3sm_winnt.c to distribution list in Makefile.in. 
+	* Added fax3sm_winnt.c to distribution list in Makefile.in.
 
 Tue Dec 21 11:04:45 EST 1999  Mike Welles <mike@onshore.com> *** 3.5.4 release ***
-	
-	* Aadded Pixar tag support.  Contributed by Phil Beffery <phil@pixar.com> 
 
-	* Made one more change to tif_dir.c for removal of LZW compression. Also added notice 
-	  when LZW compression invoked. 
+	* Aadded Pixar tag support.  Contributed by Phil Beffery <phil@pixar.com>
+
+	* Made one more change to tif_dir.c for removal of LZW compression. Also added notice
+	  when LZW compression invoked.
 
 	* Changed default compression in tools to TIFF_PACKBITS, and changed usage descriptions
 	  in tools to reflect removal of LZW compression
-	  
+
 Mon Dec 20 18:39:02 EST 1999  Mike Welles  <mike@onshore.com>
 
-        * Fixed bug that caused LZW (non) compression to segfault. Added 
-	  warning about LZW compression removed being removed, and why. 
+        * Fixed bug that caused LZW (non) compression to segfault. Added
+	  warning about LZW compression removed being removed, and why.
 
-	* Added nostrip to install in tools/Makefile.in so that debugging 
-	  symbols are kept. 
-	
+	* Added nostrip to install in tools/Makefile.in so that debugging
+	  symbols are kept.
+
 Tue Dec  7 12:04:47 EST 1999  Mike Welles  <mike@onshore.com>
 
-	* Added patch from Ivo Penzar <ivo.penzar@infolink-software.com>, 
-	  supporting Adobe ZIP deflate.  Untested. 
-	
+	* Added patch from Ivo Penzar <ivo.penzar@infolink-software.com>,
+	  supporting Adobe ZIP deflate.  Untested.
+
 Sat Dec  4 15:47:11 1999  Frank Warmerdam  <warmerda@gdal.velocet.ca>
 
 	* Made Packbits the default compression in tools/tiff2rgba.c instead
@@ -5618,12 +8633,12 @@ Tue Nov 30 14:41:43 1999  Frank Warmerdam  <warmerda@gdal.velocet.ca>    *** 3.5
 
 	* Added tif_luv to contrib/djgpp/Makefile.lib.
 
-Tue Nov 30 14:15:32 EST 1999   Mike Welles <mike@onshore.com> 
+Tue Nov 30 14:15:32 EST 1999   Mike Welles <mike@onshore.com>
 
-        * Added zip creation to relase makefile target 
+        * Added zip creation to relase makefile target
 
-	* Added html for TIFFWriteTile.3t man page. 
-	
+	* Added html for TIFFWriteTile.3t man page.
+
 Tue Nov 30 09:20:16 1999  Frank Warmerdam  <warmerda@gdal.velocet.ca>
 
 	* Added some changes to tif_write.c to support rewriting existing
@@ -5636,26 +8651,26 @@ Mon Nov 29 11:43:42 1999  Frank Warmerdam  <warmerda@gdal.velocet.ca>
 
 Sun Nov 28 20:36:18 1999  Frank Warmerdam  <warmerda@gdal.velocet.ca>
 
-	* Added notes on use of makefile.vc in build.html, and fixed 
+	* Added notes on use of makefile.vc in build.html, and fixed
 	email subscription address.
 
-199-11-28  Mike Welles <mike@onshore.com> 
+199-11-28  Mike Welles <mike@onshore.com>
 
-	*  Fixed apocalypse-inducing y2k bug in contrib/ras/ras2tiff.c 
+	*  Fixed apocalypse-inducing y2k bug in contrib/ras/ras2tiff.c
 
 	*  Did some casts cleaning up to reduce compiler warnings in tif_fax3.c,
-	   from Bruce Carmeron <cameron@petris.com> -- modifications of 
-	   changes made by Frank (sun cc still complained on cast). 
+	   from Bruce Carmeron <cameron@petris.com> -- modifications of
+	   changes made by Frank (sun cc still complained on cast).
 
 	*  Added tiffconf.h to install target per request from Bill
 	   Radcliffe <billr@corbis.com>: "We need a way for ImageMagick to
  	   know features have been compiled into the TIFF library in order to
-	   handle things properly".  
-	
+	   handle things properly".
+
 Sat Nov 27 16:49:21 1999  Frank Warmerdam  <warmerda@gdal.velocet.ca>
 
 	* fixed various VC++ warnings as suggested by Gilles Vollant
-	<info@winimage.com>.  
+	<info@winimage.com>.
 
 Wed Nov 24 12:08:16 1999  Frank Warmerdam  <warmerda@gdal.velocet.ca>
 
@@ -5664,59 +8679,59 @@ Wed Nov 24 12:08:16 1999  Frank Warmerdam  <warmerda@gdal.velocet.ca>
 
 1999-11-22  Mike Welles <mike@onshore.com>
 	*  HTML-ized the man pages, added to html/man
-	
-	*  Removed LZW Compression to comply with Unisys patent extortion. 
-	
-1999-09-29  Mike Welles		<mike@onshore.com> 
-	*  Corrected one remaining 16 -> 32 bit value in tif_fax3.c, 
-	   From Ivo Penzar <ivo.penzar@infolink-software.com. 
+
+	*  Removed LZW Compression to comply with Unisys patent extortion.
+
+1999-09-29  Mike Welles		<mike@onshore.com>
+	*  Corrected one remaining 16 -> 32 bit value in tif_fax3.c,
+	   From Ivo Penzar <ivo.penzar@infolink-software.com.
 
 	*  Added patch from Ivo Penzar to have TiffAdvanceDirectory handle
 	   memory mapped files. <ivo.penzar@infolink-software.com>
-	
+
 1999-09-26  Mike Welles 	<mike@onshore.com>  *** 3.5.2 release ***
-	* Corrected alpha versioning.  
+	* Corrected alpha versioning.
 
-	* Removed distinction between  alpha and release targets in Makefile.in. 
+	* Removed distinction between  alpha and release targets in Makefile.in.
 
-	* added release.stamp target, which tags cvs tree, and updates 
+	* added release.stamp target, which tags cvs tree, and updates
 	  "RELEASE-DATE"
 
-	* added releasediff target, which diffs tree with source as of 
+	* added releasediff target, which diffs tree with source as of
 	  date in "RELEASE-DATE"
-	  
-	* Ticked up version to 3.5.2 (alpha 01 -- but I think we'll moving 
-	  away from alpha/non-alpha distinctions). 
 
-	* updated html to reflect release 
-	
+	* Ticked up version to 3.5.2 (alpha 01 -- but I think we'll moving
+	  away from alpha/non-alpha distinctions).
+
+	* updated html to reflect release
+
 1999-09-23    <warmerda@CS46980-B>
 
 	* Set O_BINARY for tif_unix.c open() ... used on cygwin for instance.
 
 	* Added CYGWIN case in configure.
 
-Fri Sep 17 00:13:51 CEST 1999  Mike Welles <mike@onshore.com> 
+Fri Sep 17 00:13:51 CEST 1999  Mike Welles <mike@onshore.com>
 
-	* Applied Francois Dagand's patch to handle fax decompression bug. 
-	  (sizes >= 65536 were failing) 
-	
+	* Applied Francois Dagand's patch to handle fax decompression bug.
+	  (sizes >= 65536 were failing)
+
 Tue Sep 14 21:31:43 1999  Frank Warmerdam  <warmerda@gdal.velocet.ca>
 
-	* Applied "a" mode fix to tif_win32.c/TIFFOpen() as suggested 
+	* Applied "a" mode fix to tif_win32.c/TIFFOpen() as suggested
 	  by Christopher Lawton <clawton@mathworks.com>
 
 Wed Sep  8 08:19:18 1999  Frank Warmerdam  <warmerda@gdal.velocet.ca>
 
-	* Added IRIX/gcc, and OSF/1 4.x support on behalf of 
+	* Added IRIX/gcc, and OSF/1 4.x support on behalf of
 	  Albert Chin-A-Young <china@thewrittenword.com>
 
-	* Added TIFFReassignTagToIgnore() API on behalf of 
+	* Added TIFFReassignTagToIgnore() API on behalf of
 	  Bruce Cameron <cameron@petris.com>.  Man page still pending.
 
 Wed Aug 25 11:39:07 1999  Frank Warmerdam  <warmerda@gdal.velocet.ca>
 
-	* Added test target in Makefile, test_pics.sh script and pics/*.rpt 
+	* Added test target in Makefile, test_pics.sh script and pics/*.rpt
 	files to provide for a rudimentary testsuite.
 
 	* Added contrib/tags back from old distribution ... fixed up a bit.
@@ -5724,7 +8739,7 @@ Wed Aug 25 11:39:07 1999  Frank Warmerdam  <warmerda@gdal.velocet.ca>
 1999-08-16    <warmerda@CS46980-B>
 
 	* Added simple makefile.vc makefiles for building with MS VC++
-	on Windows NT/98/95 in console mode.  Stuff in contrib/win* make give 
+	on Windows NT/98/95 in console mode.  Stuff in contrib/win* make give
 	better solutions for some users.
 
 Mon Aug 16 21:52:11 1999  Frank Warmerdam  <warmerda@gdal.velocet.ca>
@@ -5734,20 +8749,20 @@ Mon Aug 16 21:52:11 1999  Frank Warmerdam  <warmerda@gdal.velocet.ca>
 
 1999-08-16  Michael L. Welles  <mike@kurtz.fake>
 
-	* Updated html/index.html with anon CVS instructions. 
+	* Updated html/index.html with anon CVS instructions.
 
 Mon Aug 16 13:18:41 1999  Frank Warmerdam  <warmerda@gdal.velocet.ca>
 
-	* pre-remove so link before softlink in LINUXdso action in 
+	* pre-remove so link before softlink in LINUXdso action in
 	libtiff/Makefile.in to avoid failure on LINUXdso builds other than
 	the first.
 
 	* Fixed problem with cvtcmap() in tif_getimage.c modifying the
 	colormaps owned by the TIFF handle itself when trying to fixup wrong
 	(eight bit) colormaps.  Corrected by maintaining a private copy of
-	the colormap. 
+	the colormap.
 
-	* Added TIFFReadRGBATile()/TIFFReadRGBAStrip() support in 
+	* Added TIFFReadRGBATile()/TIFFReadRGBAStrip() support in
 	tif_getimage.c.
 
 	* CVS Repository placed at remotesensing.org.  ChangeLog added.

--- a/3rdparty/libtiff/libport.h
+++ b/3rdparty/libtiff/libport.h
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2009 Frank Warmerdam
+ *
+ * Permission to use, copy, modify, distribute, and sell this software and 
+ * its documentation for any purpose is hereby granted without fee, provided
+ * that (i) the above copyright notices and this permission notice appear in
+ * all copies of the software and related documentation, and (ii) the names of
+ * Sam Leffler and Silicon Graphics may not be used in any advertising or
+ * publicity relating to the software without the specific, prior written
+ * permission of Sam Leffler and Silicon Graphics.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS-IS" AND WITHOUT WARRANTY OF ANY KIND, 
+ * EXPRESS, IMPLIED OR OTHERWISE, INCLUDING WITHOUT LIMITATION, ANY 
+ * WARRANTY OF MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE.  
+ * 
+ * IN NO EVENT SHALL SAM LEFFLER OR SILICON GRAPHICS BE LIABLE FOR
+ * ANY SPECIAL, INCIDENTAL, INDIRECT OR CONSEQUENTIAL DAMAGES OF ANY KIND,
+ * OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS,
+ * WHETHER OR NOT ADVISED OF THE POSSIBILITY OF DAMAGE, AND ON ANY THEORY OF
+ * LIABILITY, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE
+ * OF THIS SOFTWARE.
+ */
+
+#ifndef _LIBPORT_
+#define	_LIBPORT_
+
+int getopt(int argc, char * const argv[], const char *optstring);
+extern   char *optarg;
+extern   int opterr;
+extern   int optind;
+extern   int optopt;
+
+int strcasecmp(const char *s1, const char *s2);
+
+#ifndef HAVE_GETOPT
+#  define HAVE_GETOPT 1
+#endif
+
+#if HAVE_STRTOL
+long strtol(const char *nptr, char **endptr, int base);
+#endif
+#if HAVE_STRTOLL
+long long strtoll(const char *nptr, char **endptr, int base);
+#endif
+#if HAVE_STRTOUL
+unsigned long strtoul(const char *nptr, char **endptr, int base);
+#endif
+#if HAVE_STRTOULL
+unsigned long long strtoull(const char *nptr, char **endptr, int base);
+#endif
+
+#if 0
+void *
+lfind(const void *key, const void *base, size_t *nmemb, size_t size,
+      int(*compar)(const void *, const void *));
+#endif
+
+#if !defined(HAVE_SNPRINTF)
+#undef vsnprintf
+#define vsnprintf _TIFF_vsnprintf_f
+
+#undef snprintf
+#define snprintf _TIFF_snprintf_f
+int snprintf(char* str, size_t size, const char* format, ...);
+#endif
+
+#endif /* ndef _LIBPORT_ */

--- a/3rdparty/libtiff/snprintf.c
+++ b/3rdparty/libtiff/snprintf.c
@@ -9,6 +9,7 @@
 
 #include <stdio.h>
 #include <stdarg.h>
+#include "libport.h"
 
 int _TIFF_vsnprintf_f(char* str, size_t size, const char* format, va_list ap)
 {
@@ -35,4 +36,3 @@ int _TIFF_snprintf_f(char* str, size_t size, const char* format, ...)
 }
 
 #endif // _MSC_VER
-

--- a/3rdparty/libtiff/t4.h
+++ b/3rdparty/libtiff/t4.h
@@ -1,5 +1,3 @@
-/* $Id: t4.h,v 1.3 2010-03-10 18:56:48 bfriesen Exp $ */
-
 /*
  * Copyright (c) 1988-1997 Sam Leffler
  * Copyright (c) 1991-1997 Silicon Graphics, Inc.

--- a/3rdparty/libtiff/tif_aux.c
+++ b/3rdparty/libtiff/tif_aux.c
@@ -1,5 +1,3 @@
-/* $Id: tif_aux.c,v 1.31 2017-11-17 20:21:00 erouault Exp $ */
-
 /*
  * Copyright (c) 1991-1997 Sam Leffler
  * Copyright (c) 1991-1997 Silicon Graphics, Inc.

--- a/3rdparty/libtiff/tif_close.c
+++ b/3rdparty/libtiff/tif_close.c
@@ -1,5 +1,3 @@
-/* $Id: tif_close.c,v 1.21 2016-01-23 21:20:34 erouault Exp $ */
-
 /*
  * Copyright (c) 1988-1997 Sam Leffler
  * Copyright (c) 1991-1997 Silicon Graphics, Inc.

--- a/3rdparty/libtiff/tif_codec.c
+++ b/3rdparty/libtiff/tif_codec.c
@@ -1,5 +1,3 @@
-/* $Id: tif_codec.c,v 1.17 2015-08-19 02:31:04 bfriesen Exp $ */
-
 /*
  * Copyright (c) 1988-1997 Sam Leffler
  * Copyright (c) 1991-1997 Silicon Graphics, Inc.
@@ -72,6 +70,12 @@ static int NotConfigured(TIFF*, int);
 #ifndef LZMA_SUPPORT
 #define TIFFInitLZMA NotConfigured
 #endif
+#ifndef ZSTD_SUPPORT
+#define TIFFInitZSTD NotConfigured
+#endif
+#ifndef WEBP_SUPPORT
+#define TIFFInitWebP NotConfigured
+#endif
 
 /*
  * Compression schemes statically built into the library.
@@ -99,6 +103,8 @@ TIFFCodec _TIFFBuiltinCODECS[] = {
     { "SGILog",		COMPRESSION_SGILOG,	TIFFInitSGILog },
     { "SGILog24",	COMPRESSION_SGILOG24,	TIFFInitSGILog },
     { "LZMA",		COMPRESSION_LZMA,	TIFFInitLZMA },
+    { "ZSTD",		COMPRESSION_ZSTD,	TIFFInitZSTD },
+    { "WEBP",		COMPRESSION_WEBP,	TIFFInitWebP },
     { NULL,             0,                      NULL }
 };
 

--- a/3rdparty/libtiff/tif_color.c
+++ b/3rdparty/libtiff/tif_color.c
@@ -1,5 +1,3 @@
-/* $Id: tif_color.c,v 1.24 2017-05-29 10:12:54 erouault Exp $ */
-
 /*
  * Copyright (c) 1988-1997 Sam Leffler
  * Copyright (c) 1991-1997 Silicon Graphics, Inc.
@@ -168,7 +166,7 @@ TIFFCIELabToRGBInit(TIFFCIELabToRGB* cielab,
 }
 
 /* 
- * Convert color value from the YCbCr space to CIE XYZ.
+ * Convert color value from the YCbCr space to RGB.
  * The colorspace conversion algorithm comes from the IJG v5a code;
  * see below for more information on how it works.
  */

--- a/3rdparty/libtiff/tif_compress.c
+++ b/3rdparty/libtiff/tif_compress.c
@@ -1,5 +1,3 @@
-/* $Id: tif_compress.c,v 1.25 2016-10-25 20:04:22 erouault Exp $ */
-
 /*
  * Copyright (c) 1988-1997 Sam Leffler
  * Copyright (c) 1991-1997 Silicon Graphics, Inc.

--- a/3rdparty/libtiff/tif_config.h.cmake.in
+++ b/3rdparty/libtiff/tif_config.h.cmake.in
@@ -26,9 +26,6 @@
 /* Define to 1 if you have the <fcntl.h> header file. */
 #cmakedefine HAVE_FCNTL_H 1
 
-/* Define to 1 if you have the `floor' function. */
-#cmakedefine HAVE_FLOOR 1
-
 /* Define to 1 if you have the `getopt' function. */
 #cmakedefine HAVE_GETOPT 1
 
@@ -50,29 +47,11 @@
 /* Define to 1 if you have the <io.h> header file. */
 #cmakedefine HAVE_IO_H 1
 
-/* Define to 1 if you have the `isascii' function. */
-#cmakedefine HAVE_ISASCII 1
-
 /* Define to 1 if you have the `jbg_newlen' function. */
 #cmakedefine HAVE_JBG_NEWLEN 1
 
 /* Define to 1 if you have the `lfind' function. */
 #cmakedefine HAVE_LFIND 1
-
-/* Define to 1 if you have the <limits.h> header file. */
-#cmakedefine HAVE_LIMITS_H 1
-
-/* Define to 1 if you have the <malloc.h> header file. */
-#cmakedefine HAVE_MALLOC_H 1
-
-/* Define to 1 if you have the `memmove' function. */
-#cmakedefine HAVE_MEMMOVE 1
-
-/* Define to 1 if you have the <memory.h> header file. */
-#cmakedefine HAVE_MEMORY_H 1
-
-/* Define to 1 if you have the `memset' function. */
-#cmakedefine HAVE_MEMSET 1
 
 /* Define to 1 if you have the `mmap' function. */
 #cmakedefine HAVE_MMAP 1
@@ -83,9 +62,6 @@
 /* Define to 1 if you have the <OpenGL/gl.h> header file. */
 #cmakedefine HAVE_OPENGL_GL_H 1
 
-/* Define to 1 if you have the `pow' function. */
-#cmakedefine HAVE_POW 1
-
 /* Define to 1 if you have the <search.h> header file. */
 #cmakedefine HAVE_SEARCH_H 1
 
@@ -95,17 +71,11 @@
 /* Define to 1 if you have the `snprintf' function. */
 #cmakedefine HAVE_SNPRINTF 1
 
-/* Define to 1 if you have the `sqrt' function. */
-#cmakedefine HAVE_SQRT 1
-
 /* Define to 1 if you have the <stdint.h> header file. */
 #cmakedefine HAVE_STDINT_H 1
 
 /* Define to 1 if you have the `strcasecmp' function. */
 #cmakedefine HAVE_STRCASECMP 1
-
-/* Define to 1 if you have the `strchr' function. */
-#cmakedefine HAVE_STRCHR 1
 
 /* Define to 1 if you have the <strings.h> header file. */
 #cmakedefine HAVE_STRINGS_H 1
@@ -113,14 +83,11 @@
 /* Define to 1 if you have the <string.h> header file. */
 #cmakedefine HAVE_STRING_H 1
 
-/* Define to 1 if you have the `strrchr' function. */
-#cmakedefine HAVE_STRRCHR 1
-
-/* Define to 1 if you have the `strstr' function. */
-#cmakedefine HAVE_STRSTR 1
-
 /* Define to 1 if you have the `strtol' function. */
 #cmakedefine HAVE_STRTOL 1
+
+/* Define to 1 if you have the `strtoll' function. */
+#cmakedefine HAVE_STRTOLL 1
 
 /* Define to 1 if you have the `strtoul' function. */
 #cmakedefine HAVE_STRTOUL 1
@@ -145,6 +112,12 @@
 
 /* Support LZMA2 compression */
 #cmakedefine LZMA_SUPPORT 1
+
+/* Support ZSTD compression */
+#cmakedefine ZSTD_SUPPORT 1
+
+/* Support WEBP compression */
+#cmakedefine WEBP_SUPPORT 1
 
 /* Name of package */
 #define PACKAGE "@PACKAGE_NAME@"
@@ -175,9 +148,6 @@
 
 /* The size of `signed long long', as computed by sizeof. */
 #define SIZEOF_SIGNED_LONG_LONG @SIZEOF_SIGNED_LONG_LONG@
-
-/* The size of `signed short', as computed by sizeof. */
-#define SIZEOF_SIGNED_SHORT @SIZEOF_SIGNED_SHORT@
 
 /* The size of `unsigned char *', as computed by sizeof. */
 #define SIZEOF_UNSIGNED_CHAR_P @SIZEOF_UNSIGNED_CHAR_P@
@@ -244,6 +214,9 @@
 #  undef WORDS_BIGENDIAN
 # endif
 #endif
+
+/* Number of bits in a file offset, on hosts where this is settable. */
+#define _FILE_OFFSET_BITS @FILE_OFFSET_BITS@
 
 /* Define to `__inline__' or `__inline' if that's what the C compiler
    calls it, or to nothing if 'inline' is not supported under any name.  */

--- a/3rdparty/libtiff/tif_dir.h
+++ b/3rdparty/libtiff/tif_dir.h
@@ -1,5 +1,3 @@
-/* $Id: tif_dir.h,v 1.55 2017-06-01 12:44:04 erouault Exp $ */
-
 /*
  * Copyright (c) 1988-1997 Sam Leffler
  * Copyright (c) 1991-1997 Silicon Graphics, Inc.
@@ -26,6 +24,10 @@
 
 #ifndef _TIFFDIR_
 #define	_TIFFDIR_
+
+#include "tiff.h"
+#include "tiffio.h"
+
 /*
  * ``Library-private'' Directory-related Definitions.
  */

--- a/3rdparty/libtiff/tif_dirinfo.c
+++ b/3rdparty/libtiff/tif_dirinfo.c
@@ -1,5 +1,3 @@
-/* $Id: tif_dirinfo.c,v 1.127 2017-06-01 12:44:04 erouault Exp $ */
-
 /*
  * Copyright (c) 1988-1997 Sam Leffler
  * Copyright (c) 1991-1997 Silicon Graphics, Inc.
@@ -979,6 +977,8 @@ _TIFFCheckFieldIsValidForCodec(TIFF *tif, ttag_t tag)
 	    case TIFFTAG_CONSECUTIVEBADFAXLINES:
 	    case TIFFTAG_GROUP3OPTIONS:
 	    case TIFFTAG_GROUP4OPTIONS:
+	    /* LERC */
+	    case TIFFTAG_LERC_PARAMETERS:
 		break;
 	    default:
 		return 1;
@@ -1054,7 +1054,18 @@ _TIFFCheckFieldIsValidForCodec(TIFF *tif, ttag_t tag)
 		if (tag == TIFFTAG_PREDICTOR)
 		    return 1;
 		break;
-
+	    case COMPRESSION_ZSTD:
+		if (tag == TIFFTAG_PREDICTOR)
+		    return 1;
+		break;
+	    case COMPRESSION_LERC:
+		if (tag == TIFFTAG_LERC_PARAMETERS)
+		    return 1;
+		break;
+		  case COMPRESSION_WEBP:
+		if (tag == TIFFTAG_PREDICTOR)
+				return 1;
+		break;
 	}
 	return 0;
 }

--- a/3rdparty/libtiff/tif_dirwrite.c
+++ b/3rdparty/libtiff/tif_dirwrite.c
@@ -1,5 +1,3 @@
-/* $Id: tif_dirwrite.c,v 1.89 2017-08-23 13:33:42 erouault Exp $ */
-
 /*
  * Copyright (c) 1988-1997 Sam Leffler
  * Copyright (c) 1991-1997 Silicon Graphics, Inc.
@@ -697,8 +695,11 @@ TIFFWriteDirectorySec(TIFF* tif, int isimage, int imagedone, uint64* pdiroff)
 								}
 								break;
 							default:
-								assert(0);   /* we should never get here */
-								break;
+								TIFFErrorExt(tif->tif_clientdata,module,
+								            "Cannot write tag %d (%s)",
+								            TIFFFieldTag(o),
+                                                                            o->field_name ? o->field_name : "unknown");
+								goto bad;
 						}
 					}
 				}

--- a/3rdparty/libtiff/tif_dumpmode.c
+++ b/3rdparty/libtiff/tif_dumpmode.c
@@ -1,5 +1,3 @@
-/* $Header: /cvs/maptools/cvsroot/libtiff/libtiff/tif_dumpmode.c,v 1.15 2015-12-12 18:04:26 erouault Exp $ */
-
 /*
  * Copyright (c) 1988-1997 Sam Leffler
  * Copyright (c) 1991-1997 Silicon Graphics, Inc.

--- a/3rdparty/libtiff/tif_error.c
+++ b/3rdparty/libtiff/tif_error.c
@@ -1,5 +1,3 @@
-/* $Header: /cvs/maptools/cvsroot/libtiff/libtiff/tif_error.c,v 1.6 2017-07-04 12:54:42 erouault Exp $ */
-
 /*
  * Copyright (c) 1988-1997 Sam Leffler
  * Copyright (c) 1991-1997 Silicon Graphics, Inc.

--- a/3rdparty/libtiff/tif_extension.c
+++ b/3rdparty/libtiff/tif_extension.c
@@ -1,5 +1,3 @@
-/* $Header: /cvs/maptools/cvsroot/libtiff/libtiff/tif_extension.c,v 1.8 2015-12-06 11:13:43 erouault Exp $ */
-
 /*
  * Copyright (c) 1988-1997 Sam Leffler
  * Copyright (c) 1991-1997 Silicon Graphics, Inc.

--- a/3rdparty/libtiff/tif_fax3.c
+++ b/3rdparty/libtiff/tif_fax3.c
@@ -1,5 +1,3 @@
-/* $Id: tif_fax3.c,v 1.81 2017-06-18 10:31:50 erouault Exp $ */
-
 /*
  * Copyright (c) 1990-1997 Sam Leffler
  * Copyright (c) 1991-1997 Silicon Graphics, Inc.

--- a/3rdparty/libtiff/tif_fax3.h
+++ b/3rdparty/libtiff/tif_fax3.h
@@ -1,5 +1,3 @@
-/* $Id: tif_fax3.h,v 1.13 2016-12-14 18:36:27 faxguy Exp $ */
-
 /*
  * Copyright (c) 1990-1997 Sam Leffler
  * Copyright (c) 1991-1997 Silicon Graphics, Inc.

--- a/3rdparty/libtiff/tif_flush.c
+++ b/3rdparty/libtiff/tif_flush.c
@@ -1,5 +1,3 @@
-/* $Id: tif_flush.c,v 1.9 2010-03-31 06:40:10 fwarmerdam Exp $ */
-
 /*
  * Copyright (c) 1988-1997 Sam Leffler
  * Copyright (c) 1991-1997 Silicon Graphics, Inc.

--- a/3rdparty/libtiff/tif_getimage.c
+++ b/3rdparty/libtiff/tif_getimage.c
@@ -1,5 +1,3 @@
-/* $Id: tif_getimage.c,v 1.114 2017-11-17 20:21:00 erouault Exp $ */
-
 /*
  * Copyright (c) 1991-1997 Sam Leffler
  * Copyright (c) 1991-1997 Silicon Graphics, Inc.

--- a/3rdparty/libtiff/tif_jbig.c
+++ b/3rdparty/libtiff/tif_jbig.c
@@ -1,5 +1,3 @@
-/* $Id: tif_jbig.c,v 1.16 2017-06-26 15:20:00 erouault Exp $ */
-
 /*
  * Copyright (c) 1988-1997 Sam Leffler
  * Copyright (c) 1991-1997 Silicon Graphics, Inc.
@@ -53,17 +51,18 @@ static int JBIGDecode(TIFF* tif, uint8* buffer, tmsize_t size, uint16 s)
 	struct jbg_dec_state decoder;
 	int decodeStatus = 0;
 	unsigned char* pImage = NULL;
-	(void) size, (void) s;
+	unsigned long decodedSize;
+	(void) s;
 
 	if (isFillOrder(tif, tif->tif_dir.td_fillorder))
 	{
-		TIFFReverseBits(tif->tif_rawdata, tif->tif_rawdatasize);
+		TIFFReverseBits(tif->tif_rawcp, tif->tif_rawcc);
 	}
 
 	jbg_dec_init(&decoder);
 
 #if defined(HAVE_JBG_NEWLEN)
-	jbg_newlen(tif->tif_rawdata, (size_t)tif->tif_rawdatasize);
+	jbg_newlen(tif->tif_rawcp, (size_t)tif->tif_rawcc);
 	/*
 	 * I do not check the return status of jbg_newlen because even if this
 	 * function fails it does not necessarily mean that decoding the image
@@ -76,8 +75,8 @@ static int JBIGDecode(TIFF* tif, uint8* buffer, tmsize_t size, uint16 s)
 	 */
 #endif /* HAVE_JBG_NEWLEN */
 
-	decodeStatus = jbg_dec_in(&decoder, (unsigned char*)tif->tif_rawdata,
-				  (size_t)tif->tif_rawdatasize, NULL);
+	decodeStatus = jbg_dec_in(&decoder, (unsigned char*)tif->tif_rawcp,
+				  (size_t)tif->tif_rawcc, NULL);
 	if (JBG_EOK != decodeStatus)
 	{
 		/*
@@ -98,9 +97,28 @@ static int JBIGDecode(TIFF* tif, uint8* buffer, tmsize_t size, uint16 s)
 		return 0;
 	}
 
+	decodedSize = jbg_dec_getsize(&decoder);
+	if( (tmsize_t)decodedSize < size )
+	{
+	    TIFFWarningExt(tif->tif_clientdata, "JBIG",
+	                   "Only decoded %lu bytes, whereas %lu requested",
+	                   decodedSize, (unsigned long)size);
+	}
+	else if( (tmsize_t)decodedSize > size )
+	{
+	    TIFFErrorExt(tif->tif_clientdata, "JBIG",
+	                 "Decoded %lu bytes, whereas %lu were requested",
+	                 decodedSize, (unsigned long)size);
+	    jbg_dec_free(&decoder);
+	    return 0;
+	}
 	pImage = jbg_dec_getimage(&decoder, 0);
-	_TIFFmemcpy(buffer, pImage, jbg_dec_getsize(&decoder));
+	_TIFFmemcpy(buffer, pImage, decodedSize);
 	jbg_dec_free(&decoder);
+
+        tif->tif_rawcp += tif->tif_rawcc;
+        tif->tif_rawcc = 0;
+
 	return 1;
 }
 

--- a/3rdparty/libtiff/tif_jpeg.c
+++ b/3rdparty/libtiff/tif_jpeg.c
@@ -1,5 +1,3 @@
-/* $Id: tif_jpeg.c,v 1.134 2017-10-17 19:04:47 erouault Exp $ */
-
 /*
  * Copyright (c) 1994-1997 Sam Leffler
  * Copyright (c) 1994-1997 Silicon Graphics, Inc.
@@ -27,9 +25,9 @@
 #define WIN32_LEAN_AND_MEAN
 #define VC_EXTRALEAN
 
+#include "tiffiop.h"
 #include <stdlib.h>
 
-#include "tiffiop.h"
 #ifdef JPEG_SUPPORT
 
 /*
@@ -76,7 +74,7 @@ int TIFFJPEGIsFullStripRequired_12(TIFF* tif);
    "JPEGLib: JPEG parameter struct mismatch: library thinks size is 432,
    caller expects 464"
 
-   For such users we wil fix the problem here. See install.doc file from
+   For such users we will fix the problem here. See install.doc file from
    the JPEG library distribution for details.
 */
 

--- a/3rdparty/libtiff/tif_luv.c
+++ b/3rdparty/libtiff/tif_luv.c
@@ -1,5 +1,3 @@
-/* $Id: tif_luv.c,v 1.49 2017-07-24 12:47:30 erouault Exp $ */
-
 /*
  * Copyright (c) 1997 Greg Ward Larson
  * Copyright (c) 1997 Silicon Graphics, Inc.
@@ -215,7 +213,7 @@ LogL16Decode(TIFF* tif, uint8* op, tmsize_t occ, uint16 s)
 	bp = (unsigned char*) tif->tif_rawcp;
 	cc = tif->tif_rawcc;
 	/* get each byte string */
-	for (shft = 2*8; (shft -= 8) >= 0; ) {
+	for (shft = 8; shft >= 0; shft -=8) {
 		for (i = 0; i < npixels && cc > 0; ) {
 			if (*bp >= 128) {		/* run */
 				if( cc < 2 )
@@ -349,7 +347,7 @@ LogLuvDecode32(TIFF* tif, uint8* op, tmsize_t occ, uint16 s)
 	bp = (unsigned char*) tif->tif_rawcp;
 	cc = tif->tif_rawcc;
 	/* get each byte string */
-	for (shft = 4*8; (shft -= 8) >= 0; ) {
+	for (shft = 24; shft >= 0; shft -=8) {
 		for (i = 0; i < npixels && cc > 0; ) {
 			if (*bp >= 128) {		/* run */
 				if( cc < 2 )
@@ -467,7 +465,7 @@ LogL16Encode(TIFF* tif, uint8* bp, tmsize_t cc, uint16 s)
 	/* compress each byte string */
 	op = tif->tif_rawcp;
 	occ = tif->tif_rawdatasize - tif->tif_rawcc;
-	for (shft = 2*8; (shft -= 8) >= 0; )
+	for (shft = 8; shft >= 0; shft -=8) {
 		for (i = 0; i < npixels; i += rc) {
 			if (occ < 4) {
 				tif->tif_rawcp = op;
@@ -522,6 +520,7 @@ LogL16Encode(TIFF* tif, uint8* bp, tmsize_t cc, uint16 s)
 			} else
 				rc = 0;
 		}
+	}
 	tif->tif_rawcp = op;
 	tif->tif_rawcc = tif->tif_rawdatasize - occ;
 
@@ -618,7 +617,7 @@ LogLuvEncode32(TIFF* tif, uint8* bp, tmsize_t cc, uint16 s)
 	/* compress each byte string */
 	op = tif->tif_rawcp;
 	occ = tif->tif_rawdatasize - tif->tif_rawcc;
-	for (shft = 4*8; (shft -= 8) >= 0; )
+	for (shft = 24; shft >= 0; shft -=8) {
 		for (i = 0; i < npixels; i += rc) {
 			if (occ < 4) {
 				tif->tif_rawcp = op;
@@ -673,6 +672,7 @@ LogLuvEncode32(TIFF* tif, uint8* bp, tmsize_t cc, uint16 s)
 			} else
 				rc = 0;
 		}
+	}
 	tif->tif_rawcp = op;
 	tif->tif_rawcc = tif->tif_rawdatasize - occ;
 

--- a/3rdparty/libtiff/tif_lzma.c
+++ b/3rdparty/libtiff/tif_lzma.c
@@ -1,5 +1,3 @@
-/* $Id: tif_lzma.c,v 1.6 2016-09-17 09:18:59 erouault Exp $ */
-
 /*
  * Copyright (c) 2010, Andrey Kiselev <dron@ak4719.spb.edu>
  *
@@ -249,6 +247,7 @@ LZMAPreEncode(TIFF* tif, uint16 s)
 {
 	static const char module[] = "LZMAPreEncode";
 	LZMAState *sp = EncoderState(tif);
+	lzma_ret ret;
 
 	(void) s;
 	assert(sp != NULL);
@@ -262,7 +261,13 @@ LZMAPreEncode(TIFF* tif, uint16 s)
 			     "Liblzma cannot deal with buffers this size");
 		return 0;
 	}
-	return (lzma_stream_encoder(&sp->stream, sp->filters, sp->check) == LZMA_OK);
+	ret = lzma_stream_encoder(&sp->stream, sp->filters, sp->check);
+	if (ret != LZMA_OK) {
+		TIFFErrorExt(tif->tif_clientdata, module,
+			"Error in lzma_stream_encoder(): %s", LZMAStrerror(ret));
+		return 0;
+	}
+	return 1;
 }
 
 /*

--- a/3rdparty/libtiff/tif_lzw.c
+++ b/3rdparty/libtiff/tif_lzw.c
@@ -1,5 +1,3 @@
-/* $Id: tif_lzw.c,v 1.57 2017-07-11 10:54:29 erouault Exp $ */
-
 /*
  * Copyright (c) 1988-1997 Sam Leffler
  * Copyright (c) 1991-1997 Silicon Graphics, Inc.
@@ -135,6 +133,7 @@ typedef struct {
 	long    dec_restart;		/* restart count */
 #ifdef LZW_CHECKEOS
 	uint64  dec_bitsleft;		/* available bits in raw data */
+	tmsize_t old_tif_rawcc;         /* value of tif_rawcc at the end of the previous TIFLZWDecode() call */
 #endif
 	decodeFunc dec_decode;		/* regular or backwards compatible */
 	code_t* dec_codep;		/* current recognized code */
@@ -320,6 +319,7 @@ LZWPreDecode(TIFF* tif, uint16 s)
 	sp->dec_nbitsmask = MAXCODE(BITS_MIN);
 #ifdef LZW_CHECKEOS
 	sp->dec_bitsleft = 0;
+        sp->old_tif_rawcc = 0;
 #endif
 	sp->dec_free_entp = sp->dec_codetab + CODE_FIRST;
 	/*
@@ -427,7 +427,7 @@ LZWDecode(TIFF* tif, uint8* op0, tmsize_t occ0, uint16 s)
 
 	bp = (unsigned char *)tif->tif_rawcp;
 #ifdef LZW_CHECKEOS
-	sp->dec_bitsleft = (((uint64)tif->tif_rawcc) << 3);
+	sp->dec_bitsleft += (((uint64)tif->tif_rawcc - sp->old_tif_rawcc) << 3);
 #endif
 	nbits = sp->lzw_nbits;
 	nextdata = sp->lzw_nextdata;
@@ -555,6 +555,9 @@ LZWDecode(TIFF* tif, uint8* op0, tmsize_t occ0, uint16 s)
 
 	tif->tif_rawcc -= (tmsize_t)( (uint8*) bp - tif->tif_rawcp );
 	tif->tif_rawcp = (uint8*) bp;
+#ifdef LZW_CHECKEOS
+	sp->old_tif_rawcc = tif->tif_rawcc;
+#endif
 	sp->lzw_nbits = (unsigned short) nbits;
 	sp->lzw_nextdata = nextdata;
 	sp->lzw_nextbits = nextbits;
@@ -604,6 +607,7 @@ LZWDecodeCompat(TIFF* tif, uint8* op0, tmsize_t occ0, uint16 s)
 	char *tp;
 	unsigned char *bp;
 	int code, nbits;
+	int len;
 	long nextbits, nextdata, nbitsmask;
 	code_t *codep, *free_entp, *maxcodep, *oldcodep;
 
@@ -657,7 +661,7 @@ LZWDecodeCompat(TIFF* tif, uint8* op0, tmsize_t occ0, uint16 s)
 
 	bp = (unsigned char *)tif->tif_rawcp;
 #ifdef LZW_CHECKEOS
-	sp->dec_bitsleft = (((uint64)tif->tif_rawcc) << 3);
+	sp->dec_bitsleft += (((uint64)tif->tif_rawcc - sp->old_tif_rawcc) << 3);
 #endif
 	nbits = sp->lzw_nbits;
 	nextdata = sp->lzw_nextdata;
@@ -755,13 +759,18 @@ LZWDecodeCompat(TIFF* tif, uint8* op0, tmsize_t occ0, uint16 s)
 				}  while (--occ);
 				break;
 			}
-			assert(occ >= codep->length);
-			op += codep->length;
-			occ -= codep->length;
-			tp = op;
+			len = codep->length;
+			tp = op + len;
 			do {
-				*--tp = codep->value;
-			} while( (codep = codep->next) != NULL );
+				int t;
+				--tp;
+				t = codep->value;
+				codep = codep->next;
+				*tp = (char)t;
+			} while (codep && tp > op);
+			assert(occ >= len);
+			op += len;
+			occ -= len;
 		} else {
 			*op++ = (char)code;
 			occ--;
@@ -770,6 +779,9 @@ LZWDecodeCompat(TIFF* tif, uint8* op0, tmsize_t occ0, uint16 s)
 
 	tif->tif_rawcc -= (tmsize_t)( (uint8*) bp - tif->tif_rawcp );
 	tif->tif_rawcp = (uint8*) bp;
+#ifdef LZW_CHECKEOS
+	sp->old_tif_rawcc = tif->tif_rawcc;
+#endif
 	sp->lzw_nbits = (unsigned short)nbits;
 	sp->lzw_nextdata = nextdata;
 	sp->lzw_nextbits = nextbits;

--- a/3rdparty/libtiff/tif_next.c
+++ b/3rdparty/libtiff/tif_next.c
@@ -1,5 +1,3 @@
-/* $Id: tif_next.c,v 1.19 2016-09-04 21:32:56 erouault Exp $ */
-
 /*
  * Copyright (c) 1988-1997 Sam Leffler
  * Copyright (c) 1991-1997 Silicon Graphics, Inc.

--- a/3rdparty/libtiff/tif_ojpeg.c
+++ b/3rdparty/libtiff/tif_ojpeg.c
@@ -1,5 +1,3 @@
-/* $Id: tif_ojpeg.c,v 1.69 2017-04-27 17:29:26 erouault Exp $ */
-
 /* WARNING: The type of JPEG encapsulation defined by the TIFF Version 6.0
    specification is now totally obsolete and deprecated for new applications and
    images. This file was was created solely in order to read unconverted images

--- a/3rdparty/libtiff/tif_open.c
+++ b/3rdparty/libtiff/tif_open.c
@@ -1,5 +1,3 @@
-/* $Id: tif_open.c,v 1.48 2016-11-20 22:29:47 erouault Exp $ */
-
 /*
  * Copyright (c) 1988-1997 Sam Leffler
  * Copyright (c) 1991-1997 Silicon Graphics, Inc.

--- a/3rdparty/libtiff/tif_packbits.c
+++ b/3rdparty/libtiff/tif_packbits.c
@@ -1,5 +1,3 @@
-/* $Id: tif_packbits.c,v 1.26 2017-05-14 02:26:07 erouault Exp $ */
-
 /*
  * Copyright (c) 1988-1997 Sam Leffler
  * Copyright (c) 1991-1997 Silicon Graphics, Inc.

--- a/3rdparty/libtiff/tif_pixarlog.c
+++ b/3rdparty/libtiff/tif_pixarlog.c
@@ -1,5 +1,3 @@
-/* $Id: tif_pixarlog.c,v 1.54 2017-07-10 10:40:28 erouault Exp $ */
-
 /*
  * Copyright (c) 1996-1997 Sam Leffler
  * Copyright (c) 1996 Pixar

--- a/3rdparty/libtiff/tif_predict.c
+++ b/3rdparty/libtiff/tif_predict.c
@@ -1,5 +1,3 @@
-/* $Id: tif_predict.c,v 1.44 2017-06-18 10:31:50 erouault Exp $ */
-
 /*
  * Copyright (c) 1988-1997 Sam Leffler
  * Copyright (c) 1991-1997 Silicon Graphics, Inc.

--- a/3rdparty/libtiff/tif_predict.h
+++ b/3rdparty/libtiff/tif_predict.h
@@ -1,5 +1,3 @@
-/* $Id: tif_predict.h,v 1.9 2016-10-31 17:24:26 erouault Exp $ */
-
 /*
  * Copyright (c) 1995-1997 Sam Leffler
  * Copyright (c) 1995-1997 Silicon Graphics, Inc.
@@ -26,6 +24,10 @@
 
 #ifndef _TIFFPREDICT_
 #define	_TIFFPREDICT_
+
+#include "tiffio.h"
+#include "tiffiop.h"
+
 /*
  * ``Library-private'' Support for the Predictor Tag
  */

--- a/3rdparty/libtiff/tif_print.c
+++ b/3rdparty/libtiff/tif_print.c
@@ -1,5 +1,3 @@
-/* $Id: tif_print.c,v 1.65 2016-11-20 22:31:22 erouault Exp $ */
-
 /*
  * Copyright (c) 1988-1997 Sam Leffler
  * Copyright (c) 1991-1997 Silicon Graphics, Inc.
@@ -546,7 +544,7 @@ TIFFPrintDirectory(TIFF* tif, FILE* fd, long flags)
 				uint16 i;
 				fprintf(fd, "    %2ld: %5u",
 				    l, td->td_transferfunction[0][l]);
-				for (i = 1; i < td->td_samplesperpixel; i++)
+				for (i = 1; i < td->td_samplesperpixel - td->td_extrasamples && i < 3; i++)
 					fprintf(fd, " %5u",
 					    td->td_transferfunction[i][l]);
 				fputc('\n', fd);
@@ -667,13 +665,13 @@ TIFFPrintDirectory(TIFF* tif, FILE* fd, long flags)
 #if defined(__WIN32__) && (defined(_MSC_VER) || defined(__MINGW32__))
 			fprintf(fd, "    %3lu: [%8I64u, %8I64u]\n",
 			    (unsigned long) s,
-			    (unsigned __int64) td->td_stripoffset[s],
-			    (unsigned __int64) td->td_stripbytecount[s]);
+			    td->td_stripoffset ? (unsigned __int64) td->td_stripoffset[s] : 0,
+			    td->td_stripbytecount ? (unsigned __int64) td->td_stripbytecount[s] : 0);
 #else
 			fprintf(fd, "    %3lu: [%8llu, %8llu]\n",
 			    (unsigned long) s,
-			    (unsigned long long) td->td_stripoffset[s],
-			    (unsigned long long) td->td_stripbytecount[s]);
+			    td->td_stripoffset ? (unsigned long long) td->td_stripoffset[s] : 0,
+			    td->td_stripbytecount ? (unsigned long long) td->td_stripbytecount[s] : 0);
 #endif
 	}
 }

--- a/3rdparty/libtiff/tif_read.c
+++ b/3rdparty/libtiff/tif_read.c
@@ -1,5 +1,3 @@
-/* $Id: tif_read.c,v 1.66 2017-11-17 20:21:00 erouault Exp $ */
-
 /*
  * Copyright (c) 1988-1997 Sam Leffler
  * Copyright (c) 1991-1997 Silicon Graphics, Inc.
@@ -58,7 +56,7 @@ static int TIFFReadAndRealloc( TIFF* tif, tmsize_t size,
                                int is_strip, uint32 strip_or_tile,
                                const char* module )
 {
-#if SIZEOF_VOIDP == 8 || SIZEOF_SIZE_T == 8
+#if SIZEOF_SIZE_T == 8
         tmsize_t threshold = INITIAL_THRESHOLD;
 #endif
         tmsize_t already_read = 0;
@@ -73,7 +71,7 @@ static int TIFFReadAndRealloc( TIFF* tif, tmsize_t size,
         {
             tmsize_t bytes_read;
             tmsize_t to_read = size - already_read;
-#if SIZEOF_VOIDP == 8 || SIZEOF_SIZE_T == 8
+#if SIZEOF_SIZE_T == 8
             if( to_read >= threshold && threshold < MAX_THRESHOLD &&
                 already_read + to_read + rawdata_offset > tif->tif_rawdatasize )
             {
@@ -348,6 +346,13 @@ TIFFSeek(TIFF* tif, uint32 row, uint16 sample )
             return 0;
         whole_strip = tif->tif_dir.td_stripbytecount[strip] < 10
                 || isMapped(tif);
+        if( td->td_compression == COMPRESSION_LERC ||
+            td->td_compression == COMPRESSION_JBIG )
+        {
+            /* Ideally plugins should have a way to declare they don't support
+             * chunk strip */
+            whole_strip = 1;
+        }
 #else
         whole_strip = 1;
 #endif

--- a/3rdparty/libtiff/tif_stream.cxx
+++ b/3rdparty/libtiff/tif_stream.cxx
@@ -1,26 +1,24 @@
-/* $Id: tif_stream.cxx,v 1.11 2010-12-11 23:12:29 faxguy Exp $ */
-
 /*
  * Copyright (c) 1988-1996 Sam Leffler
  * Copyright (c) 1991-1996 Silicon Graphics, Inc.
  *
- * Permission to use, copy, modify, distribute, and sell this software and
+ * Permission to use, copy, modify, distribute, and sell this software and 
  * its documentation for any purpose is hereby granted without fee, provided
  * that (i) the above copyright notices and this permission notice appear in
  * all copies of the software and related documentation, and (ii) the names of
  * Sam Leffler and Silicon Graphics may not be used in any advertising or
  * publicity relating to the software without the specific, prior written
  * permission of Sam Leffler and Silicon Graphics.
- *
- * THE SOFTWARE IS PROVIDED "AS-IS" AND WITHOUT WARRANTY OF ANY KIND,
- * EXPRESS, IMPLIED OR OTHERWISE, INCLUDING WITHOUT LIMITATION, ANY
- * WARRANTY OF MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE.
- *
+ * 
+ * THE SOFTWARE IS PROVIDED "AS-IS" AND WITHOUT WARRANTY OF ANY KIND, 
+ * EXPRESS, IMPLIED OR OTHERWISE, INCLUDING WITHOUT LIMITATION, ANY 
+ * WARRANTY OF MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE.  
+ * 
  * IN NO EVENT SHALL SAM LEFFLER OR SILICON GRAPHICS BE LIABLE FOR
  * ANY SPECIAL, INCIDENTAL, INDIRECT OR CONSEQUENTIAL DAMAGES OF ANY KIND,
  * OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS,
- * WHETHER OR NOT ADVISED OF THE POSSIBILITY OF DAMAGE, AND ON ANY THEORY OF
- * LIABILITY, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE
+ * WHETHER OR NOT ADVISED OF THE POSSIBILITY OF DAMAGE, AND ON ANY THEORY OF 
+ * LIABILITY, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE 
  * OF THIS SOFTWARE.
  */
 
@@ -28,7 +26,6 @@
  * TIFF Library UNIX-specific Routines.
  */
 #include "tiffiop.h"
-#include "tiffio.hxx"
 #include <iostream>
 
 #ifndef __VMS
@@ -81,30 +78,30 @@ struct tiffos_data;
 
 extern "C" {
 
-    static tmsize_t _tiffosReadProc(thandle_t, void*, tmsize_t);
-    static tmsize_t _tiffisReadProc(thandle_t fd, void* buf, tmsize_t size);
-    static tmsize_t _tiffosWriteProc(thandle_t fd, void* buf, tmsize_t size);
-    static tmsize_t _tiffisWriteProc(thandle_t, void*, tmsize_t);
-    static uint64   _tiffosSeekProc(thandle_t fd, uint64 off, int whence);
-    static uint64   _tiffisSeekProc(thandle_t fd, uint64 off, int whence);
-    static uint64   _tiffosSizeProc(thandle_t fd);
-    static uint64   _tiffisSizeProc(thandle_t fd);
-    static int      _tiffosCloseProc(thandle_t fd);
-    static int      _tiffisCloseProc(thandle_t fd);
-    static int 	_tiffDummyMapProc(thandle_t , void** base, toff_t* size );
-    static void     _tiffDummyUnmapProc(thandle_t , void* base, toff_t size );
-    static TIFF*    _tiffStreamOpen(const char* name, const char* mode, void *fd);
+	static tmsize_t _tiffosReadProc(thandle_t, void*, tmsize_t);
+	static tmsize_t _tiffisReadProc(thandle_t fd, void* buf, tmsize_t size);
+	static tmsize_t _tiffosWriteProc(thandle_t fd, void* buf, tmsize_t size);
+	static tmsize_t _tiffisWriteProc(thandle_t, void*, tmsize_t);
+	static uint64   _tiffosSeekProc(thandle_t fd, uint64 off, int whence);
+	static uint64   _tiffisSeekProc(thandle_t fd, uint64 off, int whence);
+	static uint64   _tiffosSizeProc(thandle_t fd);
+	static uint64   _tiffisSizeProc(thandle_t fd);
+	static int      _tiffosCloseProc(thandle_t fd);
+	static int      _tiffisCloseProc(thandle_t fd);
+	static int 	_tiffDummyMapProc(thandle_t , void** base, toff_t* size );
+	static void     _tiffDummyUnmapProc(thandle_t , void* base, toff_t size );
+	static TIFF*    _tiffStreamOpen(const char* name, const char* mode, void *fd);
 
 struct tiffis_data
 {
-    istream	*stream;
+	istream	*stream;
         ios::pos_type start_pos;
 };
 
 struct tiffos_data
 {
-    ostream	*stream;
-    ios::pos_type start_pos;
+	ostream	*stream;
+	ios::pos_type start_pos;
 };
 
 static tmsize_t
@@ -131,222 +128,226 @@ _tiffisReadProc(thandle_t fd, void* buf, tmsize_t size)
 static tmsize_t
 _tiffosWriteProc(thandle_t fd, void* buf, tmsize_t size)
 {
-    tiffos_data	*data = reinterpret_cast<tiffos_data *>(fd);
-    ostream		*os = data->stream;
-    ios::pos_type	pos = os->tellp();
+	tiffos_data	*data = reinterpret_cast<tiffos_data *>(fd);
+	ostream		*os = data->stream;
+	ios::pos_type	pos = os->tellp();
 
         // Verify that type does not overflow.
         streamsize request_size = size;
         if (static_cast<tmsize_t>(request_size) != size)
           return static_cast<tmsize_t>(-1);
 
-    os->write(reinterpret_cast<const char *>(buf), request_size);
+	os->write(reinterpret_cast<const char *>(buf), request_size);
 
-    return static_cast<tmsize_t>(os->tellp() - pos);
+	return static_cast<tmsize_t>(os->tellp() - pos);
 }
 
 static tmsize_t
 _tiffisWriteProc(thandle_t, void*, tmsize_t)
 {
-    return 0;
+	return 0;
 }
 
 static uint64
 _tiffosSeekProc(thandle_t fd, uint64 off, int whence)
 {
-    tiffos_data	*data = reinterpret_cast<tiffos_data *>(fd);
-    ostream		*os = data->stream;
+	tiffos_data	*data = reinterpret_cast<tiffos_data *>(fd);
+	ostream		*os = data->stream;
 
-    // if the stream has already failed, don't do anything
-    if( os->fail() )
-        return static_cast<uint64>(-1);
+	// if the stream has already failed, don't do anything
+	if( os->fail() )
+		return static_cast<uint64>(-1);
 
-    switch(whence) {
-    case SEEK_SET:
-        {
-            // Compute 64-bit offset
-            uint64 new_offset = static_cast<uint64>(data->start_pos) + off;
+	switch(whence) {
+	case SEEK_SET:
+		{
+			// Compute 64-bit offset
+			uint64 new_offset = static_cast<uint64>(data->start_pos) + off;
 
-            // Verify that value does not overflow
-            ios::off_type offset = static_cast<ios::off_type>(new_offset);
-            if (static_cast<uint64>(offset) != new_offset)
-                return static_cast<uint64>(-1);
+			// Verify that value does not overflow
+			ios::off_type offset = static_cast<ios::off_type>(new_offset);
+			if (static_cast<uint64>(offset) != new_offset)
+				return static_cast<uint64>(-1);
+			
+			os->seekp(offset, ios::beg);
+		break;
+		}
+	case SEEK_CUR:
+		{
+			// Verify that value does not overflow
+			ios::off_type offset = static_cast<ios::off_type>(off);
+			if (static_cast<uint64>(offset) != off)
+				return static_cast<uint64>(-1);
 
-            os->seekp(offset, ios::beg);
-        break;
-        }
-    case SEEK_CUR:
-        {
-            // Verify that value does not overflow
-            ios::off_type offset = static_cast<ios::off_type>(off);
-            if (static_cast<uint64>(offset) != off)
-                return static_cast<uint64>(-1);
+			os->seekp(offset, ios::cur);
+			break;
+		}
+	case SEEK_END:
+		{
+			// Verify that value does not overflow
+			ios::off_type offset = static_cast<ios::off_type>(off);
+			if (static_cast<uint64>(offset) != off)
+				return static_cast<uint64>(-1);
 
-            os->seekp(offset, ios::cur);
-            break;
-        }
-    case SEEK_END:
-        {
-            // Verify that value does not overflow
-            ios::off_type offset = static_cast<ios::off_type>(off);
-            if (static_cast<uint64>(offset) != off)
-                return static_cast<uint64>(-1);
+			os->seekp(offset, ios::end);
+			break;
+		}
+	}
 
-            os->seekp(offset, ios::end);
-            break;
-        }
-    }
-
-    // Attempt to workaround problems with seeking past the end of the
-    // stream.  ofstream doesn't have a problem with this but
-    // ostrstream/ostringstream does. In that situation, add intermediate
-    // '\0' characters.
-    if( os->fail() ) {
+	// Attempt to workaround problems with seeking past the end of the
+	// stream.  ofstream doesn't have a problem with this but
+	// ostrstream/ostringstream does. In that situation, add intermediate
+	// '\0' characters.
+	if( os->fail() ) {
 #ifdef __VMS
-        int		old_state;
+		int		old_state;
 #else
-        ios::iostate	old_state;
+		ios::iostate	old_state;
 #endif
-        ios::pos_type	origin;
+		ios::pos_type	origin;
 
-        old_state = os->rdstate();
-        // reset the fail bit or else tellp() won't work below
-        os->clear(os->rdstate() & ~ios::failbit);
-        switch( whence ) {
-            case SEEK_SET:
+		old_state = os->rdstate();
+		// reset the fail bit or else tellp() won't work below
+		os->clear(os->rdstate() & ~ios::failbit);
+		switch( whence ) {
+			case SEEK_SET:
                         default:
-                origin = data->start_pos;
-                break;
-            case SEEK_CUR:
-                origin = os->tellp();
-                break;
-            case SEEK_END:
-                os->seekp(0, ios::end);
-                origin = os->tellp();
-                break;
-        }
-        // restore original stream state
-        os->clear(old_state);
+				origin = data->start_pos;
+				break;
+			case SEEK_CUR:
+				origin = os->tellp();
+				break;
+			case SEEK_END:
+				os->seekp(0, ios::end);
+				origin = os->tellp();
+				break;
+		}
+		// restore original stream state
+		os->clear(old_state);	
 
-        // only do something if desired seek position is valid
-        if( (static_cast<uint64>(origin) + off) > static_cast<uint64>(data->start_pos) ) {
-            uint64	num_fill;
+		// only do something if desired seek position is valid
+		if( (static_cast<uint64>(origin) + off) > static_cast<uint64>(data->start_pos) ) {
+			uint64	num_fill;
 
-            // clear the fail bit
-            os->clear(os->rdstate() & ~ios::failbit);
+			// clear the fail bit 
+			os->clear(os->rdstate() & ~ios::failbit);
 
-            // extend the stream to the expected size
-            os->seekp(0, ios::end);
-            num_fill = (static_cast<uint64>(origin)) + off - os->tellp();
-            for( uint64 i = 0; i < num_fill; i++ )
-                os->put('\0');
+			// extend the stream to the expected size
+			os->seekp(0, ios::end);
+			num_fill = (static_cast<uint64>(origin)) + off - os->tellp();
+			for( uint64 i = 0; i < num_fill; i++ )
+				os->put('\0');
 
-            // retry the seek
-            os->seekp(static_cast<ios::off_type>(static_cast<uint64>(origin) + off), ios::beg);
-        }
-    }
+			// retry the seek
+			os->seekp(static_cast<ios::off_type>(static_cast<uint64>(origin) + off), ios::beg);
+		}
+	}
 
-    return static_cast<uint64>(os->tellp());
+	return static_cast<uint64>(os->tellp());
 }
 
 static uint64
 _tiffisSeekProc(thandle_t fd, uint64 off, int whence)
 {
-    tiffis_data	*data = reinterpret_cast<tiffis_data *>(fd);
+	tiffis_data	*data = reinterpret_cast<tiffis_data *>(fd);
 
-    switch(whence) {
-    case SEEK_SET:
-        {
-            // Compute 64-bit offset
-            uint64 new_offset = static_cast<uint64>(data->start_pos) + off;
+	switch(whence) {
+	case SEEK_SET:
+		{
+			// Compute 64-bit offset
+			uint64 new_offset = static_cast<uint64>(data->start_pos) + off;
+			
+			// Verify that value does not overflow
+			ios::off_type offset = static_cast<ios::off_type>(new_offset);
+			if (static_cast<uint64>(offset) != new_offset)
+				return static_cast<uint64>(-1);
 
-            // Verify that value does not overflow
-            ios::off_type offset = static_cast<ios::off_type>(new_offset);
-            if (static_cast<uint64>(offset) != new_offset)
-                return static_cast<uint64>(-1);
+			data->stream->seekg(offset, ios::beg);
+			break;
+		}
+	case SEEK_CUR:
+		{
+			// Verify that value does not overflow
+			ios::off_type offset = static_cast<ios::off_type>(off);
+			if (static_cast<uint64>(offset) != off)
+				return static_cast<uint64>(-1);
 
-            data->stream->seekg(offset, ios::beg);
-            break;
-        }
-    case SEEK_CUR:
-        {
-            // Verify that value does not overflow
-            ios::off_type offset = static_cast<ios::off_type>(off);
-            if (static_cast<uint64>(offset) != off)
-                return static_cast<uint64>(-1);
+			data->stream->seekg(offset, ios::cur);
+			break;
+		}
+	case SEEK_END:
+		{
+			// Verify that value does not overflow
+			ios::off_type offset = static_cast<ios::off_type>(off);
+			if (static_cast<uint64>(offset) != off)
+				return static_cast<uint64>(-1);
 
-            data->stream->seekg(offset, ios::cur);
-            break;
-        }
-    case SEEK_END:
-        {
-            // Verify that value does not overflow
-            ios::off_type offset = static_cast<ios::off_type>(off);
-            if (static_cast<uint64>(offset) != off)
-                return static_cast<uint64>(-1);
+			data->stream->seekg(offset, ios::end);
+			break;
+		}
+	}
 
-            data->stream->seekg(offset, ios::end);
-            break;
-        }
-    }
-
-    return (uint64) (data->stream->tellg() - data->start_pos);
+	return (uint64) (data->stream->tellg() - data->start_pos);
 }
 
 static uint64
 _tiffosSizeProc(thandle_t fd)
 {
-    tiffos_data	*data = reinterpret_cast<tiffos_data *>(fd);
-    ostream		*os = data->stream;
-    ios::pos_type	pos = os->tellp();
-    ios::pos_type	len;
+	tiffos_data	*data = reinterpret_cast<tiffos_data *>(fd);
+	ostream		*os = data->stream;
+	ios::pos_type	pos = os->tellp();
+	ios::pos_type	len;
 
-    os->seekp(0, ios::end);
-    len = os->tellp();
-    os->seekp(pos);
+	os->seekp(0, ios::end);
+	len = os->tellp();
+	os->seekp(pos);
 
-    return (uint64) len;
+	return (uint64) len;
 }
 
 static uint64
 _tiffisSizeProc(thandle_t fd)
 {
-    tiffis_data	*data = reinterpret_cast<tiffis_data *>(fd);
-    ios::pos_type	pos = data->stream->tellg();
-    ios::pos_type	len;
+	tiffis_data	*data = reinterpret_cast<tiffis_data *>(fd);
+	ios::pos_type	pos = data->stream->tellg();
+	ios::pos_type	len;
 
-    data->stream->seekg(0, ios::end);
-    len = data->stream->tellg();
-    data->stream->seekg(pos);
+	data->stream->seekg(0, ios::end);
+	len = data->stream->tellg();
+	data->stream->seekg(pos);
 
-    return (uint64) len;
+	return (uint64) len;
 }
 
 static int
 _tiffosCloseProc(thandle_t fd)
 {
-    // Our stream was not allocated by us, so it shouldn't be closed by us.
-    delete reinterpret_cast<tiffos_data *>(fd);
-    return 0;
+	// Our stream was not allocated by us, so it shouldn't be closed by us.
+	delete reinterpret_cast<tiffos_data *>(fd);
+	return 0;
 }
 
 static int
 _tiffisCloseProc(thandle_t fd)
 {
-    // Our stream was not allocated by us, so it shouldn't be closed by us.
-    delete reinterpret_cast<tiffis_data *>(fd);
-    return 0;
+	// Our stream was not allocated by us, so it shouldn't be closed by us.
+	delete reinterpret_cast<tiffis_data *>(fd);
+	return 0;
 }
 
 static int
 _tiffDummyMapProc(thandle_t , void** base, toff_t* size )
 {
-    return (0);
+	(void) base;
+	(void) size;
+	return (0);
 }
 
 static void
 _tiffDummyUnmapProc(thandle_t , void* base, toff_t size )
 {
+	(void) base;
+	(void) size;
 }
 
 /*
@@ -355,40 +356,46 @@ _tiffDummyUnmapProc(thandle_t , void* base, toff_t size )
 static TIFF*
 _tiffStreamOpen(const char* name, const char* mode, void *fd)
 {
-    TIFF*	tif;
+	TIFF*	tif;
 
-    if( strchr(mode, 'w') ) {
-        tiffos_data	*data = new tiffos_data;
-        data->stream = reinterpret_cast<ostream *>(fd);
-        data->start_pos = data->stream->tellp();
+	if( strchr(mode, 'w') ) {
+		tiffos_data	*data = new tiffos_data;
+		data->stream = reinterpret_cast<ostream *>(fd);
+		data->start_pos = data->stream->tellp();
 
-        // Open for writing.
-        tif = TIFFClientOpen(name, mode,
-                reinterpret_cast<thandle_t>(data),
-                _tiffosReadProc,
+		// Open for writing.
+		tif = TIFFClientOpen(name, mode,
+				reinterpret_cast<thandle_t>(data),
+				_tiffosReadProc,
                                 _tiffosWriteProc,
-                _tiffosSeekProc,
+				_tiffosSeekProc,
                                 _tiffosCloseProc,
-                _tiffosSizeProc,
-                _tiffDummyMapProc,
+				_tiffosSizeProc,
+				_tiffDummyMapProc,
                                 _tiffDummyUnmapProc);
-    } else {
-        tiffis_data	*data = new tiffis_data;
-        data->stream = reinterpret_cast<istream *>(fd);
-        data->start_pos = data->stream->tellg();
-        // Open for reading.
-        tif = TIFFClientOpen(name, mode,
-                reinterpret_cast<thandle_t>(data),
-                _tiffisReadProc,
+		if (!tif) {
+			delete data;
+		}
+	} else {
+		tiffis_data	*data = new tiffis_data;
+		data->stream = reinterpret_cast<istream *>(fd);
+		data->start_pos = data->stream->tellg();
+		// Open for reading.
+		tif = TIFFClientOpen(name, mode,
+				reinterpret_cast<thandle_t>(data),
+				_tiffisReadProc,
                                 _tiffisWriteProc,
-                _tiffisSeekProc,
+				_tiffisSeekProc,
                                 _tiffisCloseProc,
-                _tiffisSizeProc,
-                _tiffDummyMapProc,
+				_tiffisSizeProc,
+				_tiffDummyMapProc,
                                 _tiffDummyUnmapProc);
-    }
+		if (!tif) {
+			delete data;
+		}
+	}
 
-    return (tif);
+	return (tif);
 }
 
 } /* extern "C" */
@@ -396,31 +403,32 @@ _tiffStreamOpen(const char* name, const char* mode, void *fd)
 TIFF*
 TIFFStreamOpen(const char* name, ostream *os)
 {
-    // If os is either a ostrstream or ostringstream, and has no data
-    // written to it yet, then tellp() will return -1 which will break us.
-    // We workaround this by writing out a dummy character and
-    // then seek back to the beginning.
-    if( !os->fail() && static_cast<int>(os->tellp()) < 0 ) {
-        *os << '\0';
-        os->seekp(0);
-    }
+	// If os is either a ostrstream or ostringstream, and has no data
+	// written to it yet, then tellp() will return -1 which will break us.
+	// We workaround this by writing out a dummy character and
+	// then seek back to the beginning.
+	if( !os->fail() && static_cast<int>(os->tellp()) < 0 ) {
+		*os << '\0';
+		os->seekp(0);
+	}
 
-    // NB: We don't support mapped files with streams so add 'm'
-    return _tiffStreamOpen(name, "wm", os);
+	// NB: We don't support mapped files with streams so add 'm'
+	return _tiffStreamOpen(name, "wm", os);
 }
 
 TIFF*
 TIFFStreamOpen(const char* name, istream *is)
 {
-    // NB: We don't support mapped files with streams so add 'm'
-    return _tiffStreamOpen(name, "rm", is);
+	// NB: We don't support mapped files with streams so add 'm'
+	return _tiffStreamOpen(name, "rm", is);
 }
 
 /* vim: set ts=8 sts=8 sw=8 noet: */
 /*
-  Local Variables:
-  mode: c
-  indent-tabs-mode: true
-  c-basic-offset: 8
-  End:
-*/
+ * Local Variables:
+ * mode: c
+ * c-basic-offset: 8
+ * fill-column: 78
+ * End:
+ */
+

--- a/3rdparty/libtiff/tif_strip.c
+++ b/3rdparty/libtiff/tif_strip.c
@@ -1,5 +1,3 @@
-/* $Id: tif_strip.c,v 1.38 2016-12-03 11:02:15 erouault Exp $ */
-
 /*
  * Copyright (c) 1991-1997 Sam Leffler
  * Copyright (c) 1991-1997 Silicon Graphics, Inc.

--- a/3rdparty/libtiff/tif_swab.c
+++ b/3rdparty/libtiff/tif_swab.c
@@ -1,5 +1,3 @@
-/* $Id: tif_swab.c,v 1.15 2017-06-08 16:39:50 erouault Exp $ */
-
 /*
  * Copyright (c) 1988-1997 Sam Leffler
  * Copyright (c) 1991-1997 Silicon Graphics, Inc.

--- a/3rdparty/libtiff/tif_thunder.c
+++ b/3rdparty/libtiff/tif_thunder.c
@@ -1,5 +1,3 @@
-/* $Id: tif_thunder.c,v 1.13 2016-09-04 21:32:56 erouault Exp $ */
-
 /*
  * Copyright (c) 1988-1997 Sam Leffler
  * Copyright (c) 1991-1997 Silicon Graphics, Inc.

--- a/3rdparty/libtiff/tif_tile.c
+++ b/3rdparty/libtiff/tif_tile.c
@@ -1,5 +1,3 @@
-/* $Id: tif_tile.c,v 1.24 2015-06-07 22:35:40 bfriesen Exp $ */
-
 /*
  * Copyright (c) 1991-1997 Sam Leffler
  * Copyright (c) 1991-1997 Silicon Graphics, Inc.

--- a/3rdparty/libtiff/tif_unix.c
+++ b/3rdparty/libtiff/tif_unix.c
@@ -1,5 +1,3 @@
-/* $Id: tif_unix.c,v 1.28 2017-01-11 19:02:49 erouault Exp $ */
-
 /*
  * Copyright (c) 1988-1997 Sam Leffler
  * Copyright (c) 1991-1997 Silicon Graphics, Inc.

--- a/3rdparty/libtiff/tif_version.c
+++ b/3rdparty/libtiff/tif_version.c
@@ -1,4 +1,3 @@
-/* $Header: /cvs/maptools/cvsroot/libtiff/libtiff/tif_version.c,v 1.3 2010-03-10 18:56:49 bfriesen Exp $ */
 /*
  * Copyright (c) 1992-1997 Sam Leffler
  * Copyright (c) 1992-1997 Silicon Graphics, Inc.

--- a/3rdparty/libtiff/tif_warning.c
+++ b/3rdparty/libtiff/tif_warning.c
@@ -1,5 +1,3 @@
-/* $Header: /cvs/maptools/cvsroot/libtiff/libtiff/tif_warning.c,v 1.4 2017-07-04 12:54:42 erouault Exp $ */
-
 /*
  * Copyright (c) 1988-1997 Sam Leffler
  * Copyright (c) 1991-1997 Silicon Graphics, Inc.

--- a/3rdparty/libtiff/tif_webp.c
+++ b/3rdparty/libtiff/tif_webp.c
@@ -1,0 +1,684 @@
+/*
+* Copyright (c) 2018, Mapbox
+* Author: <norman.barker at mapbox.com>
+*
+* Permission to use, copy, modify, distribute, and sell this software and
+* its documentation for any purpose is hereby granted without fee, provided
+* that (i) the above copyright notices and this permission notice appear in
+* all copies of the software and related documentation, and (ii) the names of
+* Sam Leffler and Silicon Graphics may not be used in any advertising or
+* publicity relating to the software without the specific, prior written
+* permission of Sam Leffler and Silicon Graphics.
+*
+* THE SOFTWARE IS PROVIDED "AS-IS" AND WITHOUT WARRANTY OF ANY KIND,
+* EXPRESS, IMPLIED OR OTHERWISE, INCLUDING WITHOUT LIMITATION, ANY
+* WARRANTY OF MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE.
+*
+* IN NO EVENT SHALL SAM LEFFLER OR SILICON GRAPHICS BE LIABLE FOR
+* ANY SPECIAL, INCIDENTAL, INDIRECT OR CONSEQUENTIAL DAMAGES OF ANY KIND,
+* OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS,
+* WHETHER OR NOT ADVISED OF THE POSSIBILITY OF DAMAGE, AND ON ANY THEORY OF
+* LIABILITY, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE
+* OF THIS SOFTWARE.
+*/
+
+#include "tiffiop.h"
+#ifdef WEBP_SUPPORT
+/*
+ * TIFF Library.
+ *
+ * WEBP Compression Support
+ *
+ */
+
+#include "webp/decode.h"
+#include "webp/encode.h"
+
+#include <stdio.h>
+
+#define LSTATE_INIT_DECODE 0x01
+#define LSTATE_INIT_ENCODE 0x02
+/*
+ * State block for each open TIFF
+ * file using WEBP compression/decompression.
+ */
+typedef struct {
+  uint16           nSamples;               /* number of samples per pixel */
+  
+  int              lossless;               /* lossy/lossless compression */
+  int              quality_level;          /* compression level */
+  WebPPicture      sPicture;               /* WebP Picture */
+  WebPConfig       sEncoderConfig;         /* WebP encoder config */
+  uint8*           pBuffer;                /* buffer to hold raw data on encoding */
+  unsigned int     buffer_offset;          /* current offset into the buffer */
+  unsigned int     buffer_size;
+  
+  WebPIDecoder*    psDecoder;              /* WebPIDecoder */
+  WebPDecBuffer    sDecBuffer;             /* Decoder buffer */
+  int              last_y;                 /* Last row decoded */
+  
+  int              state;                  /* state flags */
+  
+	TIFFVGetMethod   vgetparent;             /* super-class method */
+	TIFFVSetMethod   vsetparent;             /* super-class method */
+} WebPState;
+
+#define LState(tif)            ((WebPState*) (tif)->tif_data)
+#define DecoderState(tif)       LState(tif)
+#define EncoderState(tif)       LState(tif)
+
+static int TWebPEncode(TIFF* tif, uint8* bp, tmsize_t cc, uint16 s);
+static int TWebPDecode(TIFF* tif, uint8* op, tmsize_t occ, uint16 s);
+
+static
+int TWebPDatasetWriter(const uint8_t* data, size_t data_size,
+                      const WebPPicture* const picture)
+{
+  static const char module[] = "TWebPDatasetWriter";
+  TIFF* tif = (TIFF*)(picture->custom_ptr);
+  
+  if ( (tif->tif_rawcc + (tmsize_t)data_size) > tif->tif_rawdatasize ) {
+    TIFFErrorExt(tif->tif_clientdata, module,
+                 "Buffer too small by " TIFF_SIZE_FORMAT " bytes.",
+                 (size_t) (tif->tif_rawcc + data_size - tif->tif_rawdatasize));
+    return 0;
+  } else {
+    _TIFFmemcpy(tif->tif_rawcp, data, data_size);
+    tif->tif_rawcc += data_size;
+    tif->tif_rawcp += data_size;
+    return 1;    
+  }
+}
+
+/*
+ * Encode a chunk of pixels.
+ */
+static int
+TWebPEncode(TIFF* tif, uint8* bp, tmsize_t cc, uint16 s)
+{
+  static const char module[] = "TWebPEncode";
+  WebPState *sp = EncoderState(tif);
+  (void) s;
+
+  assert(sp != NULL);
+  assert(sp->state == LSTATE_INIT_ENCODE);
+    
+  if( (uint64)sp->buffer_offset +
+                            (uint64)cc > sp->buffer_size )
+  {
+      TIFFErrorExt(tif->tif_clientdata, module,
+                   "Too many bytes to be written");
+      return 0;
+  }
+
+  memcpy(sp->pBuffer + sp->buffer_offset,
+         bp, cc);
+  sp->buffer_offset += (unsigned)cc;
+
+  return 1;
+  
+}
+
+static int
+TWebPDecode(TIFF* tif, uint8* op, tmsize_t occ, uint16 s)
+{
+  static const char module[] = "WebPDecode";
+  VP8StatusCode status = VP8_STATUS_OK;
+  WebPState *sp = DecoderState(tif);
+  (void) s;  
+
+  assert(sp != NULL);
+  assert(sp->state == LSTATE_INIT_DECODE);
+  
+  if (occ % sp->sDecBuffer.u.RGBA.stride)
+  {
+    TIFFErrorExt(tif->tif_clientdata, module,
+                 "Fractional scanlines cannot be read");
+    return 0;
+  }
+
+  status = WebPIAppend(sp->psDecoder, tif->tif_rawcp, tif->tif_rawcc);
+
+  if (status != VP8_STATUS_OK && status != VP8_STATUS_SUSPENDED) {
+    if (status == VP8_STATUS_INVALID_PARAM) {
+       TIFFErrorExt(tif->tif_clientdata, module,
+         "Invalid parameter used.");      
+    } else if (status == VP8_STATUS_OUT_OF_MEMORY) {
+      TIFFErrorExt(tif->tif_clientdata, module,
+        "Out of memory.");         
+    } else {
+      TIFFErrorExt(tif->tif_clientdata, module,
+        "Unrecognized error.");   
+    }
+    return 0;
+  } else {
+    int current_y, stride;
+    uint8_t* buf;
+
+    /* Returns the RGB/A image decoded so far */
+    buf = WebPIDecGetRGB(sp->psDecoder, &current_y, NULL, NULL, &stride);
+    
+    if ((buf != NULL) &&
+        (occ <= stride * (current_y - sp->last_y))) {
+      memcpy(op,   
+         buf + (sp->last_y * stride),
+         occ);
+
+      tif->tif_rawcp += tif->tif_rawcc;
+      tif->tif_rawcc = 0;
+      sp->last_y += occ / sp->sDecBuffer.u.RGBA.stride;
+      return 1;
+    } else {
+      TIFFErrorExt(tif->tif_clientdata, module, "Unable to decode WebP data."); 
+      return 0;
+    }
+  }
+}
+
+static int
+TWebPFixupTags(TIFF* tif)
+{
+  (void) tif;
+  if (tif->tif_dir.td_planarconfig != PLANARCONFIG_CONTIG) {
+    static const char module[] = "TWebPFixupTags";
+    TIFFErrorExt(tif->tif_clientdata, module,
+      "TIFF WEBP requires data to be stored contiguously in RGB e.g. RGBRGBRGB "
+#if WEBP_ENCODER_ABI_VERSION >= 0x0100
+      "or RGBARGBARGBA"
+#endif
+    );
+    return 0;
+  }
+  return 1;
+}
+
+static int
+TWebPSetupDecode(TIFF* tif)
+{
+  static const char module[] = "WebPSetupDecode";
+  uint16 nBitsPerSample = tif->tif_dir.td_bitspersample;
+  uint16 sampleFormat = tif->tif_dir.td_sampleformat;
+
+  WebPState* sp = DecoderState(tif);
+  assert(sp != NULL);
+
+  sp->nSamples = tif->tif_dir.td_samplesperpixel;
+
+  /* check band count */
+  if ( sp->nSamples != 3
+#if WEBP_ENCODER_ABI_VERSION >= 0x0100
+    && sp->nSamples != 4
+#endif
+  )
+  {
+    TIFFErrorExt(tif->tif_clientdata, module,
+      "WEBP driver doesn't support %d bands. Must be 3 (RGB) "
+  #if WEBP_ENCODER_ABI_VERSION >= 0x0100
+      "or 4 (RGBA) "
+  #endif
+    "bands.",
+    sp->nSamples );
+    return 0;
+  }
+
+  /* check bits per sample and data type */
+  if ((nBitsPerSample != 8) && (sampleFormat != 1)) {
+    TIFFErrorExt(tif->tif_clientdata, module,
+                "WEBP driver requires 8 bit unsigned data");
+    return 0;
+  }
+  
+  /* if we were last encoding, terminate this mode */
+  if (sp->state & LSTATE_INIT_ENCODE) {
+      WebPPictureFree(&sp->sPicture);
+      if (sp->pBuffer != NULL) {
+        _TIFFfree(sp->pBuffer);
+        sp->pBuffer = NULL;
+      }
+      sp->buffer_offset = 0;
+      sp->state = 0;
+  }
+
+  sp->state |= LSTATE_INIT_DECODE;
+
+  return 1;
+}
+
+/*
+* Setup state for decoding a strip.
+*/
+static int
+TWebPPreDecode(TIFF* tif, uint16 s)
+{
+  static const char module[] = "TWebPPreDecode";
+  uint32 segment_width, segment_height;
+  WebPState* sp = DecoderState(tif);
+  TIFFDirectory* td = &tif->tif_dir;
+  (void) s;
+  assert(sp != NULL);
+  
+  if (isTiled(tif)) {
+    segment_width = td->td_tilewidth;
+    segment_height = td->td_tilelength;
+  } else {
+    segment_width = td->td_imagewidth;
+    segment_height = td->td_imagelength - tif->tif_row;
+    if (segment_height > td->td_rowsperstrip)
+      segment_height = td->td_rowsperstrip;
+  }
+
+  if( (sp->state & LSTATE_INIT_DECODE) == 0 )
+      tif->tif_setupdecode(tif);
+      
+  if (sp->psDecoder != NULL) {
+    WebPIDelete(sp->psDecoder);
+    WebPFreeDecBuffer(&sp->sDecBuffer);
+    sp->psDecoder = NULL;
+  }
+
+  sp->last_y = 0;
+  
+  WebPInitDecBuffer(&sp->sDecBuffer);
+  
+  sp->sDecBuffer.is_external_memory = 0;
+  sp->sDecBuffer.width = segment_width;
+  sp->sDecBuffer.height = segment_height;
+  sp->sDecBuffer.u.RGBA.stride = segment_width * sp->nSamples;
+  sp->sDecBuffer.u.RGBA.size = segment_width * sp->nSamples * segment_height;
+  
+  if (sp->nSamples > 3) {
+    sp->sDecBuffer.colorspace = MODE_RGBA;
+  } else {
+    sp->sDecBuffer.colorspace = MODE_RGB;
+  }
+  
+  sp->psDecoder = WebPINewDecoder(&sp->sDecBuffer);
+  
+  if (sp->psDecoder == NULL) {
+    TIFFErrorExt(tif->tif_clientdata, module,
+                "Unable to allocate WebP decoder.");
+    return 0;
+  }
+  
+  return 1;
+}
+
+static int
+TWebPSetupEncode(TIFF* tif)
+{
+  static const char module[] = "WebPSetupEncode";
+  uint16 nBitsPerSample = tif->tif_dir.td_bitspersample;
+  uint16 sampleFormat = tif->tif_dir.td_sampleformat;
+  
+  WebPState* sp = EncoderState(tif);
+  assert(sp != NULL);
+
+  sp->nSamples = tif->tif_dir.td_samplesperpixel;
+
+  /* check band count */
+  if ( sp->nSamples != 3
+#if WEBP_ENCODER_ABI_VERSION >= 0x0100
+    && sp->nSamples != 4
+#endif
+  )
+  {
+    TIFFErrorExt(tif->tif_clientdata, module,
+      "WEBP driver doesn't support %d bands. Must be 3 (RGB) "
+#if WEBP_ENCODER_ABI_VERSION >= 0x0100
+      "or 4 (RGBA) "
+#endif
+    "bands.",
+    sp->nSamples );
+    return 0;
+  }
+  
+  /* check bits per sample and data type */
+  if ((nBitsPerSample != 8) && (sampleFormat != 1)) {
+    TIFFErrorExt(tif->tif_clientdata, module,
+                "WEBP driver requires 8 bit unsigned data");
+    return 0;
+  }
+  
+  if (sp->state & LSTATE_INIT_DECODE) {
+    WebPIDelete(sp->psDecoder);
+    WebPFreeDecBuffer(&sp->sDecBuffer);
+    sp->psDecoder = NULL;
+    sp->last_y = 0;
+    sp->state = 0;
+  }
+
+  sp->state |= LSTATE_INIT_ENCODE;
+
+  if (!WebPConfigInitInternal(&sp->sEncoderConfig, WEBP_PRESET_DEFAULT,
+                              sp->quality_level,
+                              WEBP_ENCODER_ABI_VERSION)) {
+    TIFFErrorExt(tif->tif_clientdata, module,
+      "Error creating WebP encoder configuration.");
+    return 0;
+  }
+
+#if WEBP_ENCODER_ABI_VERSION >= 0x0100
+  sp->sEncoderConfig.lossless = sp->lossless;
+#endif
+
+  if (!WebPValidateConfig(&sp->sEncoderConfig)) {
+    TIFFErrorExt(tif->tif_clientdata, module,
+      "Error with WebP encoder configuration.");
+    return 0;
+  }
+
+  if (!WebPPictureInit(&sp->sPicture)) {
+    TIFFErrorExt(tif->tif_clientdata, module,
+        "Error initializing WebP picture.");
+    return 0;
+  }
+
+  return 1;
+}
+
+/*
+* Reset encoding state at the start of a strip.
+*/
+static int
+TWebPPreEncode(TIFF* tif, uint16 s)
+{
+  static const char module[] = "TWebPPreEncode";
+  uint32 segment_width, segment_height;
+  WebPState *sp = EncoderState(tif);
+  TIFFDirectory* td = &tif->tif_dir;
+
+  (void) s;
+
+  assert(sp != NULL);
+  if( sp->state != LSTATE_INIT_ENCODE )
+    tif->tif_setupencode(tif);
+
+  /*
+   * Set encoding parameters for this strip/tile.
+   */
+  if (isTiled(tif)) {
+    segment_width = td->td_tilewidth;
+    segment_height = td->td_tilelength;
+  } else {
+    segment_width = td->td_imagewidth;
+    segment_height = td->td_imagelength - tif->tif_row;
+    if (segment_height > td->td_rowsperstrip)
+      segment_height = td->td_rowsperstrip;
+  }
+
+  if( segment_width > 16383 || segment_height > 16383 ) {
+      TIFFErrorExt(tif->tif_clientdata, module, 
+                   "WEBP maximum image dimensions are 16383 x 16383.");
+      return 0;
+  }
+
+  /* set up buffer for raw data */
+  /* given above check and that nSamples <= 4, buffer_size is <= 1 GB */
+  sp->buffer_size = segment_width * segment_height * sp->nSamples;
+  sp->pBuffer = _TIFFmalloc(sp->buffer_size);
+  if( !sp->pBuffer) {
+      TIFFErrorExt(tif->tif_clientdata, module, "Cannot allocate buffer");
+      return 0;
+  }
+  sp->buffer_offset = 0;
+
+  sp->sPicture.width = segment_width;
+  sp->sPicture.height = segment_height;
+  sp->sPicture.writer = TWebPDatasetWriter;
+  sp->sPicture.custom_ptr = tif;
+
+  return 1;
+}
+
+/*
+* Finish off an encoded strip by flushing it.
+*/
+static int
+TWebPPostEncode(TIFF* tif)
+{
+  static const char module[] = "WebPPostEncode";
+  int64_t stride;
+  WebPState *sp = EncoderState(tif);
+  assert(sp != NULL);
+
+  assert(sp->state == LSTATE_INIT_ENCODE);
+
+  stride = (int64_t)sp->sPicture.width * sp->nSamples;
+
+#if WEBP_ENCODER_ABI_VERSION >= 0x0100
+  if (sp->nSamples == 4) {
+      if (!WebPPictureImportRGBA(&sp->sPicture, sp->pBuffer, (int)stride)) {
+          TIFFErrorExt(tif->tif_clientdata, module,
+                    "WebPPictureImportRGBA() failed" );
+          return 0;
+      }
+  }
+  else
+#endif
+  if (!WebPPictureImportRGB(&sp->sPicture, sp->pBuffer, (int)stride)) {
+      TIFFErrorExt(tif->tif_clientdata, module,
+                    "WebPPictureImportRGB() failed");
+      return 0;
+  }
+
+  if (!WebPEncode(&sp->sEncoderConfig, &sp->sPicture)) {
+
+#if WEBP_ENCODER_ABI_VERSION >= 0x0100
+    const char* pszErrorMsg = NULL;
+    switch(sp->sPicture.error_code) {
+    case VP8_ENC_ERROR_OUT_OF_MEMORY:
+        pszErrorMsg = "Out of memory"; break;
+    case VP8_ENC_ERROR_BITSTREAM_OUT_OF_MEMORY:
+        pszErrorMsg = "Out of memory while flushing bits"; break;
+    case VP8_ENC_ERROR_NULL_PARAMETER:
+        pszErrorMsg = "A pointer parameter is NULL"; break;
+    case VP8_ENC_ERROR_INVALID_CONFIGURATION:
+        pszErrorMsg = "Configuration is invalid"; break;
+    case VP8_ENC_ERROR_BAD_DIMENSION:
+        pszErrorMsg = "Picture has invalid width/height"; break;
+    case VP8_ENC_ERROR_PARTITION0_OVERFLOW:
+        pszErrorMsg = "Partition is bigger than 512k. Try using less "
+            "SEGMENTS, or increase PARTITION_LIMIT value";
+        break;
+    case VP8_ENC_ERROR_PARTITION_OVERFLOW:
+        pszErrorMsg = "Partition is bigger than 16M";
+        break;
+    case VP8_ENC_ERROR_BAD_WRITE:
+        pszErrorMsg = "Error while fludshing bytes"; break;
+    case VP8_ENC_ERROR_FILE_TOO_BIG:
+        pszErrorMsg = "File is bigger than 4G"; break;
+    case VP8_ENC_ERROR_USER_ABORT:
+        pszErrorMsg = "User interrupted";
+        break;
+    default:
+        TIFFErrorExt(tif->tif_clientdata, module,
+                "WebPEncode returned an unknown error code: %d",
+                sp->sPicture.error_code);
+        pszErrorMsg = "Unknown WebP error type.";
+        break;
+    }
+    TIFFErrorExt(tif->tif_clientdata, module,
+             "WebPEncode() failed : %s", pszErrorMsg);
+#else
+    TIFFErrorExt(tif->tif_clientdata, module,
+             "Error in WebPEncode()");
+#endif
+    return 0;
+  }
+
+  sp->sPicture.custom_ptr = NULL;
+
+  if (!TIFFFlushData1(tif))
+  {
+    TIFFErrorExt(tif->tif_clientdata, module,
+      "Error flushing TIFF WebP encoder.");
+    return 0;
+  }
+
+  return 1;
+}
+
+static void
+TWebPCleanup(TIFF* tif)
+{
+  WebPState* sp = LState(tif);
+
+  assert(sp != 0);
+
+  tif->tif_tagmethods.vgetfield = sp->vgetparent;
+  tif->tif_tagmethods.vsetfield = sp->vsetparent;
+
+  if (sp->state & LSTATE_INIT_ENCODE) {
+    WebPPictureFree(&sp->sPicture);
+  }
+
+  if (sp->psDecoder != NULL) {
+    WebPIDelete(sp->psDecoder);
+    WebPFreeDecBuffer(&sp->sDecBuffer);
+    sp->psDecoder = NULL;
+    sp->last_y = 0;
+  }
+  
+  if (sp->pBuffer != NULL) {
+    _TIFFfree(sp->pBuffer);
+    sp->pBuffer = NULL;
+  }
+
+  if (tif->tif_data) {
+    _TIFFfree(tif->tif_data);
+    tif->tif_data = NULL;
+  }
+  
+  _TIFFSetDefaultCompressionState(tif);
+}
+
+static int
+TWebPVSetField(TIFF* tif, uint32 tag, va_list ap)
+{
+	static const char module[] = "WebPVSetField";
+  WebPState* sp = LState(tif);
+
+  switch (tag) {
+  case TIFFTAG_WEBP_LEVEL:
+    sp->quality_level = (int) va_arg(ap, int);
+    if( sp->quality_level <= 0 ||
+        sp->quality_level > 100.0f ) {
+      TIFFWarningExt(tif->tif_clientdata, module,
+                     "WEBP_LEVEL should be between 1 and 100");
+    }
+    return 1;
+  case TIFFTAG_WEBP_LOSSLESS:
+    #if WEBP_ENCODER_ABI_VERSION >= 0x0100
+    sp->lossless = va_arg(ap, int);
+    return 1;
+    #else
+      TIFFErrorExt(tif->tif_clientdata, module,
+                  "Need to upgrade WEBP driver, this version doesn't support "
+                  "lossless compression.");
+      return 0;
+    #endif 
+  default:
+    return (*sp->vsetparent)(tif, tag, ap);
+  }
+  /*NOTREACHED*/
+}
+
+static int
+TWebPVGetField(TIFF* tif, uint32 tag, va_list ap)
+{
+  WebPState* sp = LState(tif);
+
+  switch (tag) {
+  case TIFFTAG_WEBP_LEVEL:
+    *va_arg(ap, int*) = sp->quality_level;
+    break;
+  case TIFFTAG_WEBP_LOSSLESS:
+    *va_arg(ap, int*) = sp->lossless;
+    break;
+  default:
+    return (*sp->vgetparent)(tif, tag, ap);
+  }
+  return 1;
+}
+
+static const TIFFField TWebPFields[] = {
+  { TIFFTAG_WEBP_LEVEL, 0, 0, TIFF_ANY, 0, TIFF_SETGET_INT,
+    TIFF_SETGET_UNDEFINED,
+    FIELD_PSEUDO, TRUE, FALSE, "WEBP quality", NULL },
+  { TIFFTAG_WEBP_LOSSLESS, 0, 0, TIFF_ANY, 0, TIFF_SETGET_INT,
+    TIFF_SETGET_UNDEFINED,
+    FIELD_PSEUDO, TRUE, FALSE, "WEBP lossless/lossy", NULL
+  },
+};
+
+int
+TIFFInitWebP(TIFF* tif, int scheme)
+{
+  static const char module[] = "TIFFInitWebP";
+  WebPState* sp;
+
+  assert( scheme == COMPRESSION_WEBP );
+
+  /*
+  * Merge codec-specific tag information.
+  */
+  if ( !_TIFFMergeFields(tif, TWebPFields, TIFFArrayCount(TWebPFields)) ) {
+    TIFFErrorExt(tif->tif_clientdata, module,
+                "Merging WebP codec-specific tags failed");
+    return 0;
+  }
+
+  /*
+  * Allocate state block so tag methods have storage to record values.
+  */
+  tif->tif_data = (uint8*) _TIFFmalloc(sizeof(WebPState));
+  if (tif->tif_data == NULL)
+    goto bad;
+  sp = LState(tif);
+
+  /*
+  * Override parent get/set field methods.
+  */
+  sp->vgetparent = tif->tif_tagmethods.vgetfield;
+  tif->tif_tagmethods.vgetfield = TWebPVGetField;	/* hook for codec tags */
+  sp->vsetparent = tif->tif_tagmethods.vsetfield;
+  tif->tif_tagmethods.vsetfield = TWebPVSetField;	/* hook for codec tags */
+
+  /* Default values for codec-specific fields */
+  sp->quality_level = 75.0f;		/* default comp. level */
+  sp->lossless = 0; /* default to false */
+  sp->state = 0;
+  sp->nSamples = 0;
+  sp->psDecoder = NULL;
+  sp->last_y = 0;
+  
+  sp->buffer_offset = 0;
+  sp->pBuffer = NULL;
+
+  /*
+  * Install codec methods.
+  * Notes:
+  * encoderow is not supported
+  */
+  tif->tif_fixuptags = TWebPFixupTags;
+  tif->tif_setupdecode = TWebPSetupDecode;
+  tif->tif_predecode = TWebPPreDecode;
+  tif->tif_decoderow = TWebPDecode;
+  tif->tif_decodestrip = TWebPDecode;
+  tif->tif_decodetile = TWebPDecode;
+  tif->tif_setupencode = TWebPSetupEncode;
+  tif->tif_preencode = TWebPPreEncode;
+  tif->tif_postencode = TWebPPostEncode;
+  tif->tif_encoderow = TWebPEncode;
+  tif->tif_encodestrip = TWebPEncode;
+  tif->tif_encodetile = TWebPEncode;
+  tif->tif_cleanup = TWebPCleanup;
+
+  return 1;
+bad:
+  TIFFErrorExt(tif->tif_clientdata, module,
+  	     "No space for WebP state block");
+  return 0;
+}
+
+#endif /* WEBP_SUPPORT */

--- a/3rdparty/libtiff/tif_win32.c
+++ b/3rdparty/libtiff/tif_win32.c
@@ -1,5 +1,3 @@
-/* $Id: tif_win32.c,v 1.42 2017-01-11 19:02:49 erouault Exp $ */
-
 /*
  * Copyright (c) 1988-1997 Sam Leffler
  * Copyright (c) 1991-1997 Silicon Graphics, Inc.
@@ -407,60 +405,21 @@ _TIFFmemcmp(const void* p1, const void* p2, tmsize_t c)
 static void
 Win32WarningHandler(const char* module, const char* fmt, va_list ap)
 {
-#ifndef TIF_PLATFORM_CONSOLE
-	LPTSTR szTitle;
-	LPTSTR szTmp;
-	LPCTSTR szTitleText = "%s Warning";
-	LPCTSTR szDefaultModule = "LIBTIFF";
-	LPCTSTR szTmpModule = (module == NULL) ? szDefaultModule : module;
-        SIZE_T nBufSize = (strlen(szTmpModule) +
-                        strlen(szTitleText) + strlen(fmt) + 256)*sizeof(char);
-
-	if ((szTitle = (LPTSTR)LocalAlloc(LMEM_FIXED, nBufSize)) == NULL)
-		return;
-	sprintf(szTitle, szTitleText, szTmpModule);
-	szTmp = szTitle + (strlen(szTitle)+2)*sizeof(char);
-	vsnprintf(szTmp, nBufSize-(strlen(szTitle)+2)*sizeof(char), fmt, ap);
-	MessageBoxA(GetFocus(), szTmp, szTitle, MB_OK | MB_ICONINFORMATION);
-	LocalFree(szTitle);
-
-	return;
-#else
 	if (module != NULL)
 		fprintf(stderr, "%s: ", module);
 	fprintf(stderr, "Warning, ");
 	vfprintf(stderr, fmt, ap);
 	fprintf(stderr, ".\n");
-#endif        
 }
 TIFFErrorHandler _TIFFwarningHandler = Win32WarningHandler;
 
 static void
 Win32ErrorHandler(const char* module, const char* fmt, va_list ap)
 {
-#ifndef TIF_PLATFORM_CONSOLE
-	LPTSTR szTitle;
-	LPTSTR szTmp;
-	LPCTSTR szTitleText = "%s Error";
-	LPCTSTR szDefaultModule = "LIBTIFF";
-	LPCTSTR szTmpModule = (module == NULL) ? szDefaultModule : module;
-        SIZE_T nBufSize = (strlen(szTmpModule) +
-                        strlen(szTitleText) + strlen(fmt) + 256)*sizeof(char);
-
-	if ((szTitle = (LPTSTR)LocalAlloc(LMEM_FIXED, nBufSize)) == NULL)
-		return;
-	sprintf(szTitle, szTitleText, szTmpModule);
-	szTmp = szTitle + (strlen(szTitle)+2)*sizeof(char);
-	vsnprintf(szTmp, nBufSize-(strlen(szTitle)+2)*sizeof(char), fmt, ap);
-	MessageBoxA(GetFocus(), szTmp, szTitle, MB_OK | MB_ICONEXCLAMATION);
-	LocalFree(szTitle);
-	return;
-#else
 	if (module != NULL)
 		fprintf(stderr, "%s: ", module);
 	vfprintf(stderr, fmt, ap);
 	fprintf(stderr, ".\n");
-#endif        
 }
 TIFFErrorHandler _TIFFerrorHandler = Win32ErrorHandler;
 

--- a/3rdparty/libtiff/tif_write.c
+++ b/3rdparty/libtiff/tif_write.c
@@ -1,5 +1,3 @@
-/* $Id: tif_write.c,v 1.46 2016-12-03 21:57:44 erouault Exp $ */
-
 /*
  * Copyright (c) 1988-1997 Sam Leffler
  * Copyright (c) 1991-1997 Silicon Graphics, Inc.
@@ -540,9 +538,11 @@ TIFFSetupStrips(TIFF* tif)
 	if (td->td_planarconfig == PLANARCONFIG_SEPARATE)
 		td->td_stripsperimage /= td->td_samplesperpixel;
 	td->td_stripoffset = (uint64 *)
-	    _TIFFmalloc(td->td_nstrips * sizeof (uint64));
+            _TIFFCheckMalloc(tif, td->td_nstrips, sizeof (uint64),
+                             "for \"StripOffsets\" array");
 	td->td_stripbytecount = (uint64 *)
-	    _TIFFmalloc(td->td_nstrips * sizeof (uint64));
+            _TIFFCheckMalloc(tif, td->td_nstrips, sizeof (uint64),
+                             "for \"StripByteCounts\" array");
 	if (td->td_stripoffset == NULL || td->td_stripbytecount == NULL)
 		return (0);
 	/*

--- a/3rdparty/libtiff/tif_zip.c
+++ b/3rdparty/libtiff/tif_zip.c
@@ -1,5 +1,3 @@
-/* $Id: tif_zip.c,v 1.37 2017-05-10 15:21:16 erouault Exp $ */
-
 /*
  * Copyright (c) 1995-1997 Sam Leffler
  * Copyright (c) 1995-1997 Silicon Graphics, Inc.

--- a/3rdparty/libtiff/tif_zstd.c
+++ b/3rdparty/libtiff/tif_zstd.c
@@ -1,0 +1,440 @@
+/*
+* Copyright (c) 2017, Planet Labs
+* Author: <even.rouault at spatialys.com>
+*
+* Permission to use, copy, modify, distribute, and sell this software and
+* its documentation for any purpose is hereby granted without fee, provided
+* that (i) the above copyright notices and this permission notice appear in
+* all copies of the software and related documentation, and (ii) the names of
+* Sam Leffler and Silicon Graphics may not be used in any advertising or
+* publicity relating to the software without the specific, prior written
+* permission of Sam Leffler and Silicon Graphics.
+*
+* THE SOFTWARE IS PROVIDED "AS-IS" AND WITHOUT WARRANTY OF ANY KIND,
+* EXPRESS, IMPLIED OR OTHERWISE, INCLUDING WITHOUT LIMITATION, ANY
+* WARRANTY OF MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE.
+*
+* IN NO EVENT SHALL SAM LEFFLER OR SILICON GRAPHICS BE LIABLE FOR
+* ANY SPECIAL, INCIDENTAL, INDIRECT OR CONSEQUENTIAL DAMAGES OF ANY KIND,
+* OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS,
+* WHETHER OR NOT ADVISED OF THE POSSIBILITY OF DAMAGE, AND ON ANY THEORY OF
+* LIABILITY, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE
+* OF THIS SOFTWARE.
+*/
+
+#include "tiffiop.h"
+#ifdef ZSTD_SUPPORT
+/*
+* TIFF Library.
+*
+* ZSTD Compression Support
+*
+*/
+
+#include "tif_predict.h"
+#include "zstd.h"
+
+#include <stdio.h>
+
+/*
+* State block for each open TIFF file using ZSTD compression/decompression.
+*/
+typedef struct {
+        TIFFPredictorState predict;
+        ZSTD_DStream*   dstream;
+        ZSTD_CStream*   cstream;
+        int             compression_level;      /* compression level */
+        ZSTD_outBuffer  out_buffer;
+        int             state;                  /* state flags */
+#define LSTATE_INIT_DECODE 0x01
+#define LSTATE_INIT_ENCODE 0x02
+
+        TIFFVGetMethod  vgetparent;            /* super-class method */
+        TIFFVSetMethod  vsetparent;            /* super-class method */
+} ZSTDState;
+
+#define LState(tif)             ((ZSTDState*) (tif)->tif_data)
+#define DecoderState(tif)       LState(tif)
+#define EncoderState(tif)       LState(tif)
+
+static int ZSTDEncode(TIFF* tif, uint8* bp, tmsize_t cc, uint16 s);
+static int ZSTDDecode(TIFF* tif, uint8* op, tmsize_t occ, uint16 s);
+
+static int
+ZSTDFixupTags(TIFF* tif)
+{
+        (void) tif;
+        return 1;
+}
+
+static int
+ZSTDSetupDecode(TIFF* tif)
+{
+        ZSTDState* sp = DecoderState(tif);
+
+        assert(sp != NULL);
+
+        /* if we were last encoding, terminate this mode */
+        if (sp->state & LSTATE_INIT_ENCODE) {
+            ZSTD_freeCStream(sp->cstream);
+            sp->cstream = NULL;
+            sp->state = 0;
+        }
+
+        sp->state |= LSTATE_INIT_DECODE;
+        return 1;
+}
+
+/*
+* Setup state for decoding a strip.
+*/
+static int
+ZSTDPreDecode(TIFF* tif, uint16 s)
+{
+        static const char module[] = "ZSTDPreDecode";
+        ZSTDState* sp = DecoderState(tif);
+        size_t zstd_ret;
+
+        (void) s;
+        assert(sp != NULL);
+
+        if( (sp->state & LSTATE_INIT_DECODE) == 0 )
+            tif->tif_setupdecode(tif);
+
+        if( sp->dstream )
+        {
+            ZSTD_freeDStream(sp->dstream);
+            sp->dstream = NULL;
+        }
+
+        sp->dstream = ZSTD_createDStream();
+        if( sp->dstream == NULL ) {
+            TIFFErrorExt(tif->tif_clientdata, module,
+                         "Cannot allocate decompression stream");
+            return 0;
+        }
+        zstd_ret = ZSTD_initDStream(sp->dstream);
+        if( ZSTD_isError(zstd_ret) ) {
+            TIFFErrorExt(tif->tif_clientdata, module,
+                         "Error in ZSTD_initDStream(): %s",
+                         ZSTD_getErrorName(zstd_ret));
+            return 0;
+        }
+
+        return 1;
+}
+
+static int
+ZSTDDecode(TIFF* tif, uint8* op, tmsize_t occ, uint16 s)
+{
+        static const char module[] = "ZSTDDecode";
+        ZSTDState* sp = DecoderState(tif);
+        ZSTD_inBuffer   in_buffer;
+        ZSTD_outBuffer  out_buffer;
+        size_t          zstd_ret;
+
+        (void) s;
+        assert(sp != NULL);
+        assert(sp->state == LSTATE_INIT_DECODE);
+
+        in_buffer.src = tif->tif_rawcp;
+        in_buffer.size = (size_t) tif->tif_rawcc;
+        in_buffer.pos = 0;
+
+        out_buffer.dst = op;
+        out_buffer.size = (size_t) occ;
+        out_buffer.pos = 0;
+
+        do {
+                zstd_ret = ZSTD_decompressStream(sp->dstream, &out_buffer,
+                                                 &in_buffer);
+                if( ZSTD_isError(zstd_ret) ) {
+                    TIFFErrorExt(tif->tif_clientdata, module,
+                                "Error in ZSTD_decompressStream(): %s",
+                                ZSTD_getErrorName(zstd_ret));
+                    return 0;
+                }
+        } while( zstd_ret != 0 &&
+                 in_buffer.pos < in_buffer.size &&
+                 out_buffer.pos < out_buffer.size );
+
+        if (out_buffer.pos < (size_t)occ) {
+                TIFFErrorExt(tif->tif_clientdata, module,
+                    "Not enough data at scanline %lu (short %lu bytes)",
+                    (unsigned long) tif->tif_row,
+                    (unsigned long) (size_t)occ - out_buffer.pos);
+                return 0;
+        }
+
+        tif->tif_rawcp += in_buffer.pos;
+        tif->tif_rawcc -= in_buffer.pos;
+
+        return 1;
+}
+
+static int
+ZSTDSetupEncode(TIFF* tif)
+{
+        ZSTDState* sp = EncoderState(tif);
+
+        assert(sp != NULL);
+        if (sp->state & LSTATE_INIT_DECODE) {
+                ZSTD_freeDStream(sp->dstream);
+                sp->dstream = NULL;
+                sp->state = 0;
+        }
+
+        sp->state |= LSTATE_INIT_ENCODE;
+        return 1;
+}
+
+/*
+* Reset encoding state at the start of a strip.
+*/
+static int
+ZSTDPreEncode(TIFF* tif, uint16 s)
+{
+        static const char module[] = "ZSTDPreEncode";
+        ZSTDState *sp = EncoderState(tif);
+        size_t zstd_ret;
+
+        (void) s;
+        assert(sp != NULL);
+        if( sp->state != LSTATE_INIT_ENCODE )
+            tif->tif_setupencode(tif);
+
+        if (sp->cstream) {
+            ZSTD_freeCStream(sp->cstream);
+            sp->cstream = NULL;
+        }
+        sp->cstream = ZSTD_createCStream();
+        if( sp->cstream == NULL ) {
+            TIFFErrorExt(tif->tif_clientdata, module,
+                         "Cannot allocate compression stream");
+            return 0;
+        }
+
+        zstd_ret = ZSTD_initCStream(sp->cstream, sp->compression_level);
+        if( ZSTD_isError(zstd_ret) ) {
+            TIFFErrorExt(tif->tif_clientdata, module,
+                         "Error in ZSTD_initCStream(): %s",
+                         ZSTD_getErrorName(zstd_ret));
+            return 0;
+        }
+
+        sp->out_buffer.dst = tif->tif_rawdata;
+        sp->out_buffer.size = (size_t)tif->tif_rawdatasize;
+        sp->out_buffer.pos = 0;
+
+        return 1;
+}
+
+/*
+* Encode a chunk of pixels.
+*/
+static int
+ZSTDEncode(TIFF* tif, uint8* bp, tmsize_t cc, uint16 s)
+{
+        static const char module[] = "ZSTDEncode";
+        ZSTDState *sp = EncoderState(tif);
+        ZSTD_inBuffer   in_buffer;
+        size_t          zstd_ret;
+
+        assert(sp != NULL);
+        assert(sp->state == LSTATE_INIT_ENCODE);
+
+        (void) s;
+
+        in_buffer.src = bp;
+        in_buffer.size = (size_t)cc;
+        in_buffer.pos = 0;
+
+        do {
+                zstd_ret = ZSTD_compressStream(sp->cstream, &sp->out_buffer,
+                                               &in_buffer);
+                if( ZSTD_isError(zstd_ret) ) {
+                    TIFFErrorExt(tif->tif_clientdata, module,
+                                "Error in ZSTD_compressStream(): %s",
+                                ZSTD_getErrorName(zstd_ret));
+                    return 0;
+                }
+                if( sp->out_buffer.pos == sp->out_buffer.size ) {
+                        tif->tif_rawcc = tif->tif_rawdatasize;
+                        TIFFFlushData1(tif);
+                        sp->out_buffer.dst = tif->tif_rawcp;
+                        sp->out_buffer.pos = 0;
+                }
+        } while( in_buffer.pos < in_buffer.size );
+
+        return 1;
+}
+
+/*
+* Finish off an encoded strip by flushing it.
+*/
+static int
+ZSTDPostEncode(TIFF* tif)
+{
+        static const char module[] = "ZSTDPostEncode";
+        ZSTDState *sp = EncoderState(tif);
+        size_t          zstd_ret;
+
+        do {
+                zstd_ret = ZSTD_endStream(sp->cstream, &sp->out_buffer);
+                if( ZSTD_isError(zstd_ret) ) {
+                    TIFFErrorExt(tif->tif_clientdata, module,
+                                "Error in ZSTD_endStream(): %s",
+                                ZSTD_getErrorName(zstd_ret));
+                    return 0;
+                }
+                if( sp->out_buffer.pos > 0 ) {
+                        tif->tif_rawcc = sp->out_buffer.pos;
+                        TIFFFlushData1(tif);
+                        sp->out_buffer.dst = tif->tif_rawcp;
+                        sp->out_buffer.pos = 0;
+                }
+        } while (zstd_ret != 0);
+        return 1;
+}
+
+static void
+ZSTDCleanup(TIFF* tif)
+{
+        ZSTDState* sp = LState(tif);
+
+        assert(sp != 0);
+
+        (void)TIFFPredictorCleanup(tif);
+
+        tif->tif_tagmethods.vgetfield = sp->vgetparent;
+        tif->tif_tagmethods.vsetfield = sp->vsetparent;
+
+        if (sp->dstream) {
+            ZSTD_freeDStream(sp->dstream);
+            sp->dstream = NULL;
+        }
+        if (sp->cstream) {
+            ZSTD_freeCStream(sp->cstream);
+            sp->cstream = NULL;
+        }
+        _TIFFfree(sp);
+        tif->tif_data = NULL;
+
+        _TIFFSetDefaultCompressionState(tif);
+}
+
+static int
+ZSTDVSetField(TIFF* tif, uint32 tag, va_list ap)
+{
+	static const char module[] = "ZSTDVSetField";
+        ZSTDState* sp = LState(tif);
+
+        switch (tag) {
+        case TIFFTAG_ZSTD_LEVEL:
+                sp->compression_level = (int) va_arg(ap, int);
+                if( sp->compression_level <= 0 ||
+                    sp->compression_level > ZSTD_maxCLevel() )
+                {
+                    TIFFWarningExt(tif->tif_clientdata, module,
+                                   "ZSTD_LEVEL should be between 1 and %d",
+                                   ZSTD_maxCLevel());
+                }
+                return 1;
+        default:
+                return (*sp->vsetparent)(tif, tag, ap);
+        }
+        /*NOTREACHED*/
+}
+
+static int
+ZSTDVGetField(TIFF* tif, uint32 tag, va_list ap)
+{
+        ZSTDState* sp = LState(tif);
+
+        switch (tag) {
+        case TIFFTAG_ZSTD_LEVEL:
+                *va_arg(ap, int*) = sp->compression_level;
+                break;
+        default:
+                return (*sp->vgetparent)(tif, tag, ap);
+        }
+        return 1;
+}
+
+static const TIFFField ZSTDFields[] = {
+        { TIFFTAG_ZSTD_LEVEL, 0, 0, TIFF_ANY, 0, TIFF_SETGET_INT,
+          TIFF_SETGET_UNDEFINED,
+          FIELD_PSEUDO, TRUE, FALSE, "ZSTD compression_level", NULL },
+};
+
+int
+TIFFInitZSTD(TIFF* tif, int scheme)
+{
+        static const char module[] = "TIFFInitZSTD";
+        ZSTDState* sp;
+
+        assert( scheme == COMPRESSION_ZSTD );
+
+        /*
+        * Merge codec-specific tag information.
+        */
+        if (!_TIFFMergeFields(tif, ZSTDFields, TIFFArrayCount(ZSTDFields))) {
+                TIFFErrorExt(tif->tif_clientdata, module,
+                            "Merging ZSTD codec-specific tags failed");
+                return 0;
+        }
+
+        /*
+        * Allocate state block so tag methods have storage to record values.
+        */
+        tif->tif_data = (uint8*) _TIFFmalloc(sizeof(ZSTDState));
+        if (tif->tif_data == NULL)
+                goto bad;
+        sp = LState(tif);
+
+        /*
+        * Override parent get/set field methods.
+        */
+        sp->vgetparent = tif->tif_tagmethods.vgetfield;
+        tif->tif_tagmethods.vgetfield = ZSTDVGetField;	/* hook for codec tags */
+        sp->vsetparent = tif->tif_tagmethods.vsetfield;
+        tif->tif_tagmethods.vsetfield = ZSTDVSetField;	/* hook for codec tags */
+
+        /* Default values for codec-specific fields */
+        sp->compression_level = 9;		/* default comp. level */
+        sp->state = 0;
+        sp->dstream = 0;
+        sp->cstream = 0;
+        sp->out_buffer.dst = NULL;
+        sp->out_buffer.size = 0;
+        sp->out_buffer.pos = 0;
+
+        /*
+        * Install codec methods.
+        */
+        tif->tif_fixuptags = ZSTDFixupTags;
+        tif->tif_setupdecode = ZSTDSetupDecode;
+        tif->tif_predecode = ZSTDPreDecode;
+        tif->tif_decoderow = ZSTDDecode;
+        tif->tif_decodestrip = ZSTDDecode;
+        tif->tif_decodetile = ZSTDDecode;
+        tif->tif_setupencode = ZSTDSetupEncode;
+        tif->tif_preencode = ZSTDPreEncode;
+        tif->tif_postencode = ZSTDPostEncode;
+        tif->tif_encoderow = ZSTDEncode;
+        tif->tif_encodestrip = ZSTDEncode;
+        tif->tif_encodetile = ZSTDEncode;
+        tif->tif_cleanup = ZSTDCleanup;
+        /*
+        * Setup predictor setup.
+        */
+        (void) TIFFPredictorInit(tif);
+        return 1;
+bad:
+        TIFFErrorExt(tif->tif_clientdata, module,
+                    "No space for ZSTD state block");
+        return 0;
+}
+#endif /* ZSTD_SUPPORT */
+
+/* vim: set ts=8 sts=8 sw=8 noet: */

--- a/3rdparty/libtiff/tiff.h
+++ b/3rdparty/libtiff/tiff.h
@@ -1,5 +1,3 @@
-/* $Id: tiff.h,v 1.70 2016-01-23 21:20:34 erouault Exp $ */
-
 /*
  * Copyright (c) 1988-1997 Sam Leffler
  * Copyright (c) 1991-1997 Silicon Graphics, Inc.
@@ -189,7 +187,11 @@ typedef enum {
 #define     COMPRESSION_SGILOG		34676	/* SGI Log Luminance RLE */
 #define     COMPRESSION_SGILOG24	34677	/* SGI Log 24-bit packed */
 #define     COMPRESSION_JP2000          34712   /* Leadtools JPEG2000 */
+#define     COMPRESSION_LERC            34887   /* ESRI Lerc codec: https://github.com/Esri/lerc */
+/* compression codes 34887-34889 are reserved for ESRI */
 #define	    COMPRESSION_LZMA		34925	/* LZMA2 */
+#define	    COMPRESSION_ZSTD		50000	/* ZSTD: WARNING not registered in Adobe-maintained registry */
+#define	    COMPRESSION_WEBP		50001	/* WEBP: WARNING not registered in Adobe-maintained registry */
 #define	TIFFTAG_PHOTOMETRIC		262	/* photometric interpretation */
 #define	    PHOTOMETRIC_MINISWHITE	0	/* min value is white */
 #define	    PHOTOMETRIC_MINISBLACK	1	/* min value is black */
@@ -450,6 +452,8 @@ typedef enum {
 /* tag 34929 is a private tag registered to FedEx */
 #define	TIFFTAG_FEDEX_EDR		34929	/* unknown use */
 #define TIFFTAG_INTEROPERABILITYIFD	40965	/* Pointer to Interoperability private directory */
+/* tags 50674 to 50677 are reserved for ESRI */
+#define TIFFTAG_LERC_PARAMETERS         50674   /* Stores LERC version and additional compression method */
 /* Adobe Digital Negative (DNG) format tags */
 #define TIFFTAG_DNGVERSION		50706	/* &DNG version number */
 #define TIFFTAG_DNGBACKWARDVERSION	50707	/* &DNG compatibility version */
@@ -603,6 +607,16 @@ typedef enum {
 #define TIFFTAG_PERSAMPLE       65563	/* interface for per sample tags */
 #define     PERSAMPLE_MERGED        0	/* present as a single value */
 #define     PERSAMPLE_MULTI         1	/* present as multiple values */
+#define TIFFTAG_ZSTD_LEVEL      65564    /* ZSTD compression level */
+#define TIFFTAG_LERC_VERSION            65565 /* LERC version */
+#define     LERC_VERSION_2_4            4
+#define TIFFTAG_LERC_ADD_COMPRESSION    65566 /* LERC additional compression */
+#define     LERC_ADD_COMPRESSION_NONE    0
+#define     LERC_ADD_COMPRESSION_DEFLATE 1
+#define     LERC_ADD_COMPRESSION_ZSTD    2
+#define TIFFTAG_LERC_MAXZERROR          65567    /* LERC maximum error */
+#define TIFFTAG_WEBP_LEVEL		  65568	/* WebP compression level: WARNING not registered in Adobe-maintained registry */
+#define TIFFTAG_WEBP_LOSSLESS		65569	/* WebP lossless/lossy : WARNING not registered in Adobe-maintained registry */
 
 /*
  * EXIF tags

--- a/3rdparty/libtiff/tiffconf.h.cmake.in
+++ b/3rdparty/libtiff/tiffconf.h.cmake.in
@@ -40,15 +40,6 @@
 /* Pointer difference type */
 #define TIFF_PTRDIFF_T @TIFF_PTRDIFF_T@
 
-/* Define to 1 if the system has the type `int16'. */
-#cmakedefine HAVE_INT16 1
-
-/* Define to 1 if the system has the type `int32'. */
-#cmakedefine HAVE_INT32 1
-
-/* Define to 1 if the system has the type `int8'. */
-#cmakedefine HAVE_INT8 1
-
 /* Compatibility stuff. */
 
 /* Define as 0 or 1 according to the floating point format suported by the

--- a/3rdparty/libtiff/tiffio.h
+++ b/3rdparty/libtiff/tiffio.h
@@ -1,5 +1,3 @@
-/* $Id: tiffio.h,v 1.94 2017-01-11 19:02:49 erouault Exp $ */
-
 /*
  * Copyright (c) 1988-1997 Sam Leffler
  * Copyright (c) 1991-1997 Silicon Graphics, Inc.
@@ -52,7 +50,7 @@ typedef struct tiff TIFF;
  *     promoted type (i.e. one of int, unsigned int, pointer,
  *     or double) and because we defined pseudo-tags that are
  *     outside the range of legal Aldus-assigned tags.
- * NB: tsize_t is int32 and not uint32 because some functions
+ * NB: tsize_t is signed and not unsigned because some functions
  *     return -1.
  * NB: toff_t is not off_t for many reasons; TIFFs max out at
  *     32-bit file offsets, and BigTIFF maxes out at 64-bit

--- a/3rdparty/libtiff/tiffio.hxx
+++ b/3rdparty/libtiff/tiffio.hxx
@@ -1,5 +1,3 @@
-/* $Id: tiffio.hxx,v 1.3 2010-06-08 18:55:15 bfriesen Exp $ */
-
 /*
  * Copyright (c) 1988-1997 Sam Leffler
  * Copyright (c) 1991-1997 Silicon Graphics, Inc.
@@ -33,6 +31,7 @@
 
 #include <iostream>
 #include "tiff.h"
+#include "tiffio.h"
 
 extern TIFF* TIFFStreamOpen(const char*, std::ostream *);
 extern TIFF* TIFFStreamOpen(const char*, std::istream *);

--- a/3rdparty/libtiff/tiffiop.h
+++ b/3rdparty/libtiff/tiffiop.h
@@ -1,5 +1,3 @@
-/* $Id: tiffiop.h,v 1.95 2017-09-07 14:02:52 erouault Exp $ */
-
 /*
  * Copyright (c) 1988-1997 Sam Leffler
  * Copyright (c) 1991-1997 Silicon Graphics, Inc.
@@ -72,6 +70,7 @@ extern int snprintf(char* str, size_t size, const char* format, ...);
 #endif
 
 #define    streq(a,b)      (strcmp(a,b) == 0)
+#define    strneq(a,b,n)   (strncmp(a,b,n) == 0)
 
 #ifndef TRUE
 #define	TRUE	1
@@ -314,8 +313,12 @@ typedef size_t TIFFIOSize_t;
 #define _TIFF_off_t off_t
 #endif
 
-#if __clang_major__ >= 4 || (__clang_major__ == 3 && __clang_minor__ >= 8)
+#if defined(__has_attribute) && defined(__clang__)
+#if __has_attribute(no_sanitize)
 #define TIFF_NOSANITIZE_UNSIGNED_INT_OVERFLOW __attribute__((no_sanitize("unsigned-integer-overflow")))
+#else
+#define TIFF_NOSANITIZE_UNSIGNED_INT_OVERFLOW
+#endif
 #else
 #define TIFF_NOSANITIZE_UNSIGNED_INT_OVERFLOW
 #endif
@@ -423,6 +426,12 @@ extern int TIFFInitSGILog(TIFF*, int);
 #endif
 #ifdef LZMA_SUPPORT
 extern int TIFFInitLZMA(TIFF*, int);
+#endif
+#ifdef ZSTD_SUPPORT
+extern int TIFFInitZSTD(TIFF*, int);
+#endif
+#ifdef WEBP_SUPPORT
+extern int TIFFInitWebP(TIFF*, int);
 #endif
 #ifdef VMS
 extern const TIFFCodec _TIFFBuiltinCODECS[];

--- a/3rdparty/libtiff/tiffvers.h
+++ b/3rdparty/libtiff/tiffvers.h
@@ -1,4 +1,4 @@
-#define TIFFLIB_VERSION_STR "LIBTIFF, Version 4.0.9\nCopyright (c) 1988-1996 Sam Leffler\nCopyright (c) 1991-1996 Silicon Graphics, Inc."
+#define TIFFLIB_VERSION_STR "LIBTIFF, Version 4.0.10\nCopyright (c) 1988-1996 Sam Leffler\nCopyright (c) 1991-1996 Silicon Graphics, Inc."
 /*
  * This define can be used in code that requires
  * compilation-related definitions specific to a
@@ -6,4 +6,4 @@
  * version checking should be done based on the
  * string returned by TIFFGetVersion.
  */
-#define TIFFLIB_VERSION 20171118
+#define TIFFLIB_VERSION 20181110


### PR DESCRIPTION
Sources copied from the master download mirror: https://download.osgeo.org/libtiff/tiff-4.0.10.tar.gz

4.0.10 has fixed multiple security vulnerabilities.