### PR TITLE
cudalegacy: Use safe block scan function

### DIFF
--- a/modules/cudev/include/opencv2/cudev/warp/scan.hpp
+++ b/modules/cudev/include/opencv2/cudev/warp/scan.hpp
@@ -98,7 +98,7 @@ __device__ T warpScanInclusive(T data, volatile T* smem, uint tid)
     #pragma unroll
     for (int i = 1; i <= (WARP_SIZE / 2); i *= 2)
     {
-        const T val = shfl_up(data, i);
+        const T val = __shfl_up(data, i, WARP_SIZE);
         if (laneId >= i)
               data += val;
     }


### PR DESCRIPTION
resolves #13761

Without this PR, following tests hang on 2080 Ti (and possibly on other Volta and Turing cards).

```
opencv_test_cudalegacy --gtest_filter=*NPPST.Integral*
opencv_test_cudalegacy --gtest_filter=*NPPST.SquaredIntegral*
opencv_test_cudalegacy --gtest_filter=*NPPST.RectStdDev*
opencv_test_cudalegacy --gtest_filter=*NPPST.Integral*
opencv_test_cudalegacy --gtest_filter=*NPPST.VectorOperations*
opencv_test_cudalegacy --gtest_filter=*NCV.HaarCascadeApplication*
```

The hanging behavior of the last test case (`NCV.HaarCascadeApplication`) is identical issue to #13761, which this PR resolves.

Using "safe" version of block scan function (in `cudev` module) added by #13658 fixes these hanging issues.

Verified on following test environments:

```
CUDA 10.0 on 2080 Ti
CUDA 9.2 on 1080
CUDA 8.0 on 1080
```


```
force_builders=Custom
buildworker:Custom=linux-1,linux-2,linux-4
docker_image:Custom=ubuntu-cuda:16.04
```