### PR TITLE
GAPI: Fixes an issue with valgrind and sobelxy

### DIFF
--- a/modules/gapi/perf/common/gapi_imgproc_perf_tests_inl.hpp
+++ b/modules/gapi/perf/common/gapi_imgproc_perf_tests_inl.hpp
@@ -507,8 +507,8 @@ PERF_TEST_P_(SobelXYPerfTest, TestPerformance)
     cv::GCompileArgs compile_args;
     std::tie(cmpF, type, kernSize, sz, dtype, order, compile_args) = GetParam();
 
-    cv::Mat out_mat_ocv2 = cv::Mat(sz, dtype);
-    cv::Mat out_mat_gapi2 = cv::Mat(sz, dtype);
+    cv::Mat out_mat_ocv2;
+    cv::Mat out_mat_gapi2;
 
     initMatsRandN(type, sz, dtype, false);
 

--- a/modules/gapi/test/common/gapi_imgproc_tests_inl.hpp
+++ b/modules/gapi/test/common/gapi_imgproc_tests_inl.hpp
@@ -361,9 +361,11 @@ TEST_P(SobelXYTest, AccuracyTest)
     cv::Size sz;
     cv::GCompileArgs compile_args;
     std::tie(cmpF, type, kernSize, sz, dtype, order, border_type, border_val, compile_args) = GetParam();
+
+    cv::Mat out_mat_ocv2;
+    cv::Mat out_mat_gapi2;
+
     initMatsRandN(type, sz, dtype);
-    cv::Mat out_mat_ocv2 = cv::Mat(sz, dtype);
-    cv::Mat out_mat_gapi2 = cv::Mat(sz, dtype);
 
     // G-API code //////////////////////////////////////////////////////////////
     cv::GMat in;


### PR DESCRIPTION
resolves #13787  

This pullrequest removes initialization of additional outputs for graph due to valgrind warnings

