### PR TITLE
New computeECC function, and updated findTransformECC function to make gaussian filtering optional

### DIFF
--- a/modules/video/include/opencv2/video/tracking.hpp
+++ b/modules/video/include/opencv2/video/tracking.hpp
@@ -268,8 +268,8 @@ enum
 /** @brief Computes the Enhanced Correlation Coefficient value between two images @cite EP08 .
 
 @param templateImage single-channel template image; CV_8U or CV_32F array.
-@param inputImage single-channel input image which should be warped with the final warpMatrix in
-order to provide an image similar to templateImage, same type as templateImage.
+@param inputImage single-channel input image to be warped to provide an image similar to
+ templateImage, same type as templateImage.
 @param inputMask An optional mask to indicate valid values of inputImage.
 
 @sa

--- a/modules/video/include/opencv2/video/tracking.hpp
+++ b/modules/video/include/opencv2/video/tracking.hpp
@@ -276,7 +276,7 @@ order to provide an image similar to templateImage, same type as templateImage.
 findTransformECC
  */
 
-CV_EXPORTS_W double computeECC(const Mat& templateImage, const Mat& inputImage, const Mat& inputMask);
+CV_EXPORTS_W double computeECC(InputArray templateImage, InputArray inputImage, InputArray inputMask = noArray());
 
 /** @example samples/cpp/image_alignment.cpp
 An example using the image alignment ECC algorithm
@@ -334,9 +334,16 @@ an exception if algorithm does not converges.
 computeECC, estimateAffine2D, estimateAffinePartial2D, findHomography
  */
 CV_EXPORTS_W double findTransformECC( InputArray templateImage, InputArray inputImage,
-                                      InputOutputArray warpMatrix, int motionType = MOTION_AFFINE,
-                                      TermCriteria criteria = TermCriteria(TermCriteria::COUNT+TermCriteria::EPS, 50, 0.001),
-                                      InputArray inputMask = noArray(), int gaussFiltSize = 5);
+                                      InputOutputArray warpMatrix, int motionType,
+                                      TermCriteria criteria,
+                                      InputArray inputMask, int gaussFiltSize);
+
+/** @overload */
+CV_EXPORTS
+double findTransformECC(InputArray templateImage, InputArray inputImage,
+    InputOutputArray warpMatrix, int motionType = MOTION_AFFINE,
+    TermCriteria criteria = TermCriteria(TermCriteria::COUNT+TermCriteria::EPS, 50, 0.001),
+    InputArray inputMask = noArray());
 
 /** @example samples/cpp/kalman.cpp
 An example using the standard Kalman filter

--- a/modules/video/include/opencv2/video/tracking.hpp
+++ b/modules/video/include/opencv2/video/tracking.hpp
@@ -265,6 +265,19 @@ enum
     MOTION_HOMOGRAPHY  = 3
 };
 
+/** @brief Computes the Enhanced Correlation Coefficient value between two images @cite EP08 .
+
+@param templateImage single-channel template image; CV_8U or CV_32F array.
+@param inputImage single-channel input image which should be warped with the final warpMatrix in
+order to provide an image similar to templateImage, same type as templateImage.
+@param inputMask An optional mask to indicate valid values of inputImage.
+
+@sa
+findTransformECC
+ */
+
+CV_EXPORTS_W double computeECC(const Mat& templateImage, const Mat& inputImage, const Mat& inputMask);
+
 /** @example samples/cpp/image_alignment.cpp
 An example using the image alignment ECC algorithm
 */
@@ -273,7 +286,7 @@ An example using the image alignment ECC algorithm
 
 @param templateImage single-channel template image; CV_8U or CV_32F array.
 @param inputImage single-channel input image which should be warped with the final warpMatrix in
-order to provide an image similar to templateImage, same type as temlateImage.
+order to provide an image similar to templateImage, same type as templateImage.
 @param warpMatrix floating-point \f$2\times 3\f$ or \f$3\times 3\f$ mapping matrix (warp).
 @param motionType parameter, specifying the type of motion:
  -   **MOTION_TRANSLATION** sets a translational motion model; warpMatrix is \f$2\times 3\f$ with
@@ -317,12 +330,12 @@ sample image_alignment.cpp that demonstrates the use of the function. Note that 
 an exception if algorithm does not converges.
 
 @sa
-estimateAffine2D, estimateAffinePartial2D, findHomography
+computeECC, estimateAffine2D, estimateAffinePartial2D, findHomography
  */
 CV_EXPORTS_W double findTransformECC( InputArray templateImage, InputArray inputImage,
                                       InputOutputArray warpMatrix, int motionType = MOTION_AFFINE,
                                       TermCriteria criteria = TermCriteria(TermCriteria::COUNT+TermCriteria::EPS, 50, 0.001),
-                                      InputArray inputMask = noArray());
+                                      InputArray inputMask = noArray(), int gaussFiltSize = 5);
 
 /** @example samples/cpp/kalman.cpp
 An example using the standard Kalman filter

--- a/modules/video/include/opencv2/video/tracking.hpp
+++ b/modules/video/include/opencv2/video/tracking.hpp
@@ -303,6 +303,7 @@ criteria.epsilon defines the threshold of the increment in the correlation coeff
 iterations (a negative criteria.epsilon makes criteria.maxcount the only termination criterion).
 Default values are shown in the declaration above.
 @param inputMask An optional mask to indicate valid values of inputImage.
+@param gaussFiltSize An optional value indicating size of gaussian blur filter; (DEFAULT: 5)
 
 The function estimates the optimum transformation (warpMatrix) with respect to ECC criterion
 (@cite EP08), that is

--- a/modules/video/src/ecc.cpp
+++ b/modules/video/src/ecc.cpp
@@ -309,16 +309,40 @@ static void update_warping_matrix_ECC (Mat& map_matrix, const Mat& update, const
 }
 
 
+/** Function that computes enhanced corelation coefficient from Georgios et.al. 2008 [5]
+*   See https://github.com/opencv/opencv/issues/12432
+*/
+double cv::computeECC(const Mat& templateImage, const Mat& inputImage, const Mat& inputMask)
+{
+        Scalar meanTemplate, sdTemplate;
+
+        meanStdDev(templateImage, meanTemplate, sdTemplate, inputMask);
+        Mat templateImage_zeromean = Mat::zeros(templateImage.rows, templateImage.cols, templateImage.type());
+        subtract(templateImage, meanTemplate, templateImage_zeromean, inputMask);
+        double templateImagenorm = std::sqrt(countNonZero(inputMask)*sdTemplate.val[0]*sdTemplate.val[0]);
+
+        Scalar meanInput, sdInput;
+
+        Mat inputImage_zeromean = Mat::zeros(inputImage.rows, inputImage.cols, inputImage.type());
+        meanStdDev(inputImage, meanInput, sdInput, inputMask);
+        subtract(inputImage, meanInput, inputImage_zeromean, inputMask);
+        double inputImagenorm = std::sqrt(countNonZero(inputMask)*sdInput.val[0]*sdInput.val[0]);
+
+        return templateImage_zeromean.dot(inputImage_zeromean)/(templateImagenorm*inputImagenorm);
+}
+
+
 double cv::findTransformECC(InputArray templateImage,
                             InputArray inputImage,
                             InputOutputArray warpMatrix,
                             int motionType,
                             TermCriteria criteria,
-                            InputArray inputMask)
+                            InputArray inputMask,
+                            int gaussFiltSize)
 {
 
 
-    Mat src = templateImage.getMat();//template iamge
+    Mat src = templateImage.getMat();//template image
     Mat dst = inputImage.getMat(); //input image (to be warped)
     Mat map = warpMatrix.getMat(); //warp (transformation)
 
@@ -420,7 +444,7 @@ double cv::findTransformECC(InputArray templateImage,
 
     Mat preMaskFloat;
     preMask.convertTo(preMaskFloat, CV_32F);
-    GaussianBlur(preMaskFloat, preMaskFloat, Size(5, 5), 0, 0);
+    GaussianBlur(preMaskFloat, preMaskFloat, Size(gaussFiltSize, gaussFiltSize), 0, 0);
     // Change threshold.
     preMaskFloat *= (0.5/0.95);
     // Rounding conversion.

--- a/modules/video/test/test_ecc.cpp
+++ b/modules/video/test/test_ecc.cpp
@@ -95,45 +95,6 @@ double CV_ECC_BaseTest::computeRMS(const Mat& mat1, const Mat& mat2){
     return sqrt(errorMat.dot(errorMat)/(mat1.rows*mat1.cols));
 }
 
-
-class CV_ECC_Test_Compute : public cvtest::BaseTest
-{
-public:
-    CV_ECC_Test_Compute();
-protected:
-    void run(int);
-    bool testCompute(int);
-};
-
-CV_ECC_Test_Compute::CV_ECC_Test_Compute(){
-}
-
-bool CV_ECC_Test_Compute::testCompute(int)
-{
-    Mat testImg = (Mat_<float>(3, 3) << 1, 0, 0, 1, 0, 0, 1, 0, 0);
-    Mat warpedImage = (Mat_<float>(3, 3) << 0, 1, 0, 0, 1, 0, 0, 1, 0);
-    Mat_<unsigned char> mask = Mat_<unsigned char>::ones(testImg.rows, testImg.cols);
-    double ecc = computeECC(warpedImage, testImg, mask);
-
-    if (ecc + 1/2.0 > 1e-5){
-        ts->set_failed_test_info(cvtest::TS::FAIL_BAD_ACCURACY);
-        ts->printf( ts->LOG, "ecc = %f, expected to be -0.5",
-            ecc);
-        return false;
-    }
-    return true;
-}
-
-void CV_ECC_Test_Compute::run(int from)
-{
-
-    if (!testCompute(from))
-        return;
-
-    ts->set_failed_test_info(cvtest::TS::OK);
-}
-
-
 class CV_ECC_Test_Translation : public CV_ECC_BaseTest
 {
 public:
@@ -530,7 +491,16 @@ void CV_ECC_Test_Mask::run(int from)
     ts->set_failed_test_info(cvtest::TS::OK);
 }
 
-TEST(CV_ECC_Test_Compute, accuracy) { CV_ECC_Test_Compute test; test.safe_run();}
+TEST(Video_ECC_Test_Compute, accuracy)
+{
+    Mat testImg = (Mat_<float>(3, 3) << 1, 0, 0, 1, 0, 0, 1, 0, 0);
+    Mat warpedImage = (Mat_<float>(3, 3) << 0, 1, 0, 0, 1, 0, 0, 1, 0);
+    Mat_<unsigned char> mask = Mat_<unsigned char>::ones(testImg.rows, testImg.cols);
+    double ecc = computeECC(warpedImage, testImg, mask);
+
+    EXPECT_NEAR(ecc, -0.5f, 1e-5f);
+}
+
 TEST(Video_ECC_Translation, accuracy) { CV_ECC_Test_Translation test; test.safe_run();}
 TEST(Video_ECC_Euclidean, accuracy) { CV_ECC_Test_Euclidean test; test.safe_run(); }
 TEST(Video_ECC_Affine, accuracy) { CV_ECC_Test_Affine test; test.safe_run(); }


### PR DESCRIPTION
resolves #12432

### This pullrequest changes

The issue tracked in https://github.com/opencv/opencv/issues/12432 is resolved with the changes here, by adding a new function called computeECC as suggested by the issue author, and, by adding another optional argument to findTransformECC to control the size of the Gaussian filter (set to default of 5, to maintain backward compatibility; set to 1 to do no filtering, like the issue author would like). Tests and documentation strings are included as well. 

This is my first pull request, and so pardon my tardiness.
