### PR TITLE
Making JavaCamera2View be consistent with JavaCameraView

### DIFF
--- a/modules/java/generator/android-21/java/org/opencv/android/JavaCamera2View.java
+++ b/modules/java/generator/android-21/java/org/opencv/android/JavaCamera2View.java
@@ -110,6 +110,15 @@ public class JavaCamera2View extends CameraBridgeViewBase {
             if (mCameraID != null) {
                 Log.i(LOGTAG, "Opening camera: " + mCameraID);
                 manager.openCamera(mCameraID, mStateCallback, mBackgroundHandler);
+            } else { // make JavaCamera2View behaves in the same way as JavaCameraView
+                Log.i(LOGTAG, "Trying to open camera with the value (" + mCameraIndex + ")");
+                if (mCameraIndex < camList.length) {
+                    mCameraID = camList[mCameraIndex];
+                    manager.openCamera(mCameraID, mStateCallback, mBackgroundHandler);
+                } else {
+                    // CAMERA_DISCONNECTED is used when the camera id is no longer valid
+                    throw new CameraAccessException(CameraAccessException.CAMERA_DISCONNECTED);
+                }
             }
             return true;
         } catch (CameraAccessException e) {


### PR DESCRIPTION
Bug fix of `Interrupted while setCameraPreviewSize` and `width and height must be > 0` which is related to `JavaCamera2View`

### This pullrequest changes

`org.opencv.android.JavaCamera2View` crashes on certain phones such as Samsung Galaxy S7 and Alcatel A5A. (On contrary, `JavaCameraView` works fine.) It is because `CameraBridgeViewBase.CAMERA_ID_BACK` and `CameraBridgeViewBase.CAMERA_ID_FRONT` do not match correct values. This patch introduces two new `final int` variables to correctly detect cameras.

### Bug which happens with old code
```
java.lang.RuntimeException: Interrupted while setCameraPreviewSize.
        at org.opencv.android.JavaCamera2View.connectCamera(JavaCamera2View.java:333)
        at org.opencv.android.CameraBridgeViewBase.onEnterStartedState(CameraBridgeViewBase.java:360)
        at org.opencv.android.CameraBridgeViewBase.processEnterState(CameraBridgeViewBase.java:321)
        at org.opencv.android.CameraBridgeViewBase.checkCurrentState(CameraBridgeViewBase.java:313)
        at org.opencv.android.CameraBridgeViewBase.surfaceChanged(CameraBridgeViewBase.java:198)
        at android.view.SurfaceView.updateWindow(SurfaceView.java:725)
        at android.view.SurfaceView$3.onPreDraw(SurfaceView.java:180)
        at android.view.ViewTreeObserver.dispatchOnPreDraw(ViewTreeObserver.java:944)
        at android.view.ViewRootImpl.performTraversals(ViewRootImpl.java:2553)
        at android.view.ViewRootImpl.doTraversal(ViewRootImpl.java:1462)
        at android.view.ViewRootImpl$TraversalRunnable.run(ViewRootImpl.java:6965)
        at android.view.Choreographer$CallbackRecord.run(Choreographer.java:907)
        at android.view.Choreographer.doCallbacks(Choreographer.java:709)
        at android.view.Choreographer.doFrame(Choreographer.java:644)
        at android.view.Choreographer$FrameDisplayEventReceiver.run(Choreographer.java:893)
        at android.os.Handler.handleCallback(Handler.java:836)
        at android.os.Handler.dispatchMessage(Handler.java:103)
        at android.os.Looper.loop(Looper.java:203)
        at android.app.ActivityThread.main(ActivityThread.java:6247)
        at java.lang.reflect.Method.invoke(Native Method)
        at com.android.internal.os.ZygoteInit$MethodAndArgsCaller.run(ZygoteInit.java:1063)
        at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:924)
     Caused by: java.lang.IllegalArgumentException: width and height must be > 0
        at android.graphics.Bitmap.createBitmap(Bitmap.java:877)
        at android.graphics.Bitmap.createBitmap(Bitmap.java:856)
        at android.graphics.Bitmap.createBitmap(Bitmap.java:823)
        at org.opencv.android.CameraBridgeViewBase.AllocateCache(CameraBridgeViewBase.java:457)
        at org.opencv.android.JavaCamera2View.connectCamera(JavaCamera2View.java:322)
        at org.opencv.android.CameraBridgeViewBase.onEnterStartedState(CameraBridgeViewBase.java:360) 
        at org.opencv.android.CameraBridgeViewBase.processEnterState(CameraBridgeViewBase.java:321) 
        at org.opencv.android.CameraBridgeViewBase.checkCurrentState(CameraBridgeViewBase.java:313) 
        at org.opencv.android.CameraBridgeViewBase.surfaceChanged(CameraBridgeViewBase.java:198) 
        at android.view.SurfaceView.updateWindow(SurfaceView.java:725) 
        at android.view.SurfaceView$3.onPreDraw(SurfaceView.java:180) 
        at android.view.ViewTreeObserver.dispatchOnPreDraw(ViewTreeObserver.java:944) 
        at android.view.ViewRootImpl.performTraversals(ViewRootImpl.java:2553) 
        at android.view.ViewRootImpl.doTraversal(ViewRootImpl.java:1462) 
        at android.view.ViewRootImpl$TraversalRunnable.run(ViewRootImpl.java:6965) 
        at android.view.Choreographer$CallbackRecord.run(Choreographer.java:907) 
        at android.view.Choreographer.doCallbacks(Choreographer.java:709) 
        at android.view.Choreographer.doFrame(Choreographer.java:644) 
        at android.view.Choreographer$FrameDisplayEventReceiver.run(Choreographer.java:893) 
        at android.os.Handler.handleCallback(Handler.java:836) 
        at android.os.Handler.dispatchMessage(Handler.java:103) 
        at android.os.Looper.loop(Looper.java:203) 
        at android.app.ActivityThread.main(ActivityThread.java:6247) 
        at java.lang.reflect.Method.invoke(Native Method) 
        at com.android.internal.os.ZygoteInit$MethodAndArgsCaller.run(ZygoteInit.java:1063) 
        at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:924) 

```