### PR TITLE
LineIterator witout a Mat

### DIFF
--- a/modules/imgproc/include/opencv2/imgproc.hpp
+++ b/modules/imgproc/include/opencv2/imgproc.hpp
@@ -4697,7 +4697,7 @@ public:
       init(size, type, 0, CV_ELEM_SIZE(type)*size.width, pt1, pt2, connectivity, leftToRight);
     }
     void init(const Size& size, int type, uchar* data, size_t dataStep, Point pt1, Point pt2, int connectivity = 8, bool leftToRight = false);
-  
+
     /** @brief returns pointer to the current pixel
     */
     uchar* operator *();

--- a/modules/imgproc/include/opencv2/imgproc.hpp
+++ b/modules/imgproc/include/opencv2/imgproc.hpp
@@ -4689,7 +4689,15 @@ public:
     not to depend on the ordering of pt1 and pt2 parameters
     */
     LineIterator( const Mat& img, Point pt1, Point pt2,
-                  int connectivity = 8, bool leftToRight = false );
+                  int connectivity = 8, bool leftToRight = false ) {
+      init(img.size(), img.type(), (uchar*)img.ptr(), img.step1()*img.elemSize1(), pt1, pt2, connectivity, leftToRight);
+    }
+    LineIterator( const Size& size, int type, Point pt1, Point pt2,
+                  int connectivity = 8, bool leftToRight = false ) {
+      init(size, type, 0, CV_ELEM_SIZE(type)*size.width, pt1, pt2, connectivity, leftToRight);
+    }
+    void init(const Size& size, int type, uchar* data, size_t dataStep, Point pt1, Point pt2, int connectivity = 8, bool leftToRight = false);
+  
     /** @brief returns pointer to the current pixel
     */
     uchar* operator *();
@@ -4718,7 +4726,7 @@ public:
 inline
 uchar* LineIterator::operator *()
 {
-    return ptr;
+    return !ptr0 ? 0 : ptr;//when no Mat is attached, ptr is just a dummy address and should not be dereferenced
 }
 
 inline

--- a/modules/imgproc/src/drawing.cpp
+++ b/modules/imgproc/src/drawing.cpp
@@ -160,21 +160,21 @@ bool clipLine( Rect img_rect, Point& pt1, Point& pt2 )
    Initializes line iterator.
    Returns number of points on the line or negative number if error.
 */
-LineIterator::LineIterator(const Mat& img, Point pt1, Point pt2,
-                           int connectivity, bool left_to_right)
+void LineIterator::init(const Size& size, int type, uchar* data, size_t dataStep, Point pt1, Point pt2,
+                        int connectivity, bool left_to_right)
 {
     count = -1;
 
     CV_Assert( connectivity == 8 || connectivity == 4 );
 
-    if( (unsigned)pt1.x >= (unsigned)(img.cols) ||
-        (unsigned)pt2.x >= (unsigned)(img.cols) ||
-        (unsigned)pt1.y >= (unsigned)(img.rows) ||
-        (unsigned)pt2.y >= (unsigned)(img.rows) )
+    if( (unsigned)pt1.x >= (unsigned)(size.width) ||
+        (unsigned)pt2.x >= (unsigned)(size.width) ||
+        (unsigned)pt1.y >= (unsigned)(size.height) ||
+        (unsigned)pt2.y >= (unsigned)(size.height) )
     {
-        if( !clipLine( img.size(), pt1, pt2 ) )
+        if( !clipLine( size, pt1, pt2 ) )
         {
-            ptr = img.data;
+            ptr = data;
             err = plusDelta = minusDelta = plusStep = minusStep = count = 0;
             ptr0 = 0;
             step = 0;
@@ -183,8 +183,8 @@ LineIterator::LineIterator(const Mat& img, Point pt1, Point pt2,
         }
     }
 
-    size_t bt_pix0 = img.elemSize(), bt_pix = bt_pix0;
-    size_t istep = img.step;
+    size_t bt_pix0 = CV_ELEM_SIZE(type), bt_pix = bt_pix0;
+    size_t istep = dataStep;
 
     int dx = pt2.x - pt1.x;
     int dy = pt2.y - pt1.y;
@@ -203,7 +203,7 @@ LineIterator::LineIterator(const Mat& img, Point pt1, Point pt2,
         bt_pix = (bt_pix ^ s) - s;
     }
 
-    ptr = (uchar*)(img.data + pt1.y * istep + pt1.x * bt_pix0);
+    ptr = (uchar*)(data + pt1.y * istep + pt1.x * bt_pix0);//when no Mat is attached, ptr is just a dummy address and should not be dereferenced
 
     s = dy < 0 ? -1 : 0;
     dy = (dy ^ s) - s;
@@ -243,8 +243,8 @@ LineIterator::LineIterator(const Mat& img, Point pt1, Point pt2,
         count = dx + dy + 1;
     }
 
-    this->ptr0 = img.ptr();
-    this->step = (int)img.step;
+    this->ptr0 = data;
+    this->step = dataStep;
     this->elemSize = (int)bt_pix0;
 }
 

--- a/modules/imgproc/src/drawing.cpp
+++ b/modules/imgproc/src/drawing.cpp
@@ -244,7 +244,7 @@ void LineIterator::init(const Size& size, int type, uchar* data, size_t dataStep
     }
 
     this->ptr0 = data;
-    this->step = dataStep;
+    this->step = static_cast<int>(dataStep);
     this->elemSize = (int)bt_pix0;
 }
 


### PR DESCRIPTION
cv::LineIterator can be used without being attached to any cv::Mat, it only needs the size and type of data. An alternative constructor has been defined for that.
In that case, a LineIterator can no more be dereferenced with the * operator, but pos() still returns valid pixel positions.
It can be useful when LineIterator is just used to compute positions of pixels on a line, without requiring to build a Mat just for that.
Use case : with a dataset that would represent a huge image, pixel positions can be pre-computed before querying the dataset API.
