### PR TITLE
Remove opencv_highgui as optional dependency of features2d module

### DIFF
--- a/modules/features2d/CMakeLists.txt
+++ b/modules/features2d/CMakeLists.txt
@@ -1,2 +1,2 @@
 set(the_description "2D Features Framework")
-ocv_define_module(features2d opencv_imgproc OPTIONAL opencv_flann opencv_highgui WRAP java python js)
+ocv_define_module(features2d opencv_imgproc OPTIONAL opencv_flann WRAP java python js)

--- a/modules/features2d/src/blobdetector.cpp
+++ b/modules/features2d/src/blobdetector.cpp
@@ -44,17 +44,6 @@
 #include <iterator>
 #include <limits>
 
-//#define DEBUG_BLOB_DETECTOR
-
-#ifdef DEBUG_BLOB_DETECTOR
-#  include "opencv2/opencv_modules.hpp"
-#  ifdef HAVE_OPENCV_HIGHGUI
-#    include "opencv2/highgui.hpp"
-#  else
-#    undef DEBUG_BLOB_DETECTOR
-#  endif
-#endif
-
 namespace cv
 {
 
@@ -199,16 +188,6 @@ void SimpleBlobDetectorImpl::findBlobs(InputArray _image, InputArray _binaryImag
     std::vector < std::vector<Point> > contours;
     findContours(binaryImage, contours, RETR_LIST, CHAIN_APPROX_NONE);
 
-#ifdef DEBUG_BLOB_DETECTOR
-    //  Mat keypointsImage;
-    //  cvtColor( binaryImage, keypointsImage, CV_GRAY2RGB );
-    //
-    //  Mat contoursImage;
-    //  cvtColor( binaryImage, contoursImage, CV_GRAY2RGB );
-    //  drawContours( contoursImage, contours, -1, Scalar(0,255,0) );
-    //  imshow("contours", contoursImage );
-#endif
-
     for (size_t contourIdx = 0; contourIdx < contours.size(); contourIdx++)
     {
         Center center;
@@ -293,16 +272,7 @@ void SimpleBlobDetectorImpl::findBlobs(InputArray _image, InputArray _binaryImag
         }
 
         centers.push_back(center);
-
-
-#ifdef DEBUG_BLOB_DETECTOR
-        //    circle( keypointsImage, center.location, 1, Scalar(0,0,255), 1 );
-#endif
     }
-#ifdef DEBUG_BLOB_DETECTOR
-    //  imshow("bk", keypointsImage );
-    //  waitKey();
-#endif
 }
 
 void SimpleBlobDetectorImpl::detect(InputArray image, std::vector<cv::KeyPoint>& keypoints, InputArray mask)


### PR DESCRIPTION
The highgui module is added as an optional dependency of features2d.
However, this is only used in file blobdetector.cpp for a default-disabled debug option.
This makes it simple if someone someday wants to debug the blob detector.
However, this also means that any library downstream linking to the features2d module will also need to link to highgui and its dependencies.

### This pullrequest changes

[From my understanding] the current behavior is that if `BUILD_opencv_highgui` is enabled, then the `highgui` module is added as an optional dependency for the `features2d` module.
However, the only place `highgui` elements are used are in `blobdetector.cpp`, and only if `DEBUG_BLOB_DETECTOR` is manually defined.
And even if `DEBUG_BLOB_DETECTOR` is defined, all lines of code in the `DEBUG_BLOB_DETECTOR` code blocks would need to be uncommented.
These lines of debug code have been commented out in the repository for at least 8 years.

My guess is that these lines of debug code are very rarely, if ever, used, and only in special cases.
I would further guess that users who enable this debug tool would know how to enable highgui (or to read the fairly clear compile errors saying highgui not found). 

I think it makes sense to delete the debug code entirely, however, as this is my first OpenCV PR I don't want to overstep.

### Reasoning

A codebase that I manage benefits from the OpenCV features2d library.
A "core" portion of this codebase is used on embedded systems that do not support GUI tools.
A separate portion of this codebase allows GUI tools.
We recently ran into some issues where the features2d library caused strange build errors because it silently links against highgui due to CMake's modules system.
Once we tracked down the issue and understood it we were able to fix the issue for our systems.
However, it seems like linking features2d against highgui just because its' enabled doesn't serve any larger benefit except for in a very specific and rare use case, and sometimes can lead to system integration challenges.

