### PR TITLE
Fix Flann compilation under nvcc + NEON

### DIFF
--- a/modules/flann/include/opencv2/flann/dist.h
+++ b/modules/flann/include/opencv2/flann/dist.h
@@ -47,7 +47,7 @@ typedef unsigned __int64 uint64_t;
 # include <Intrin.h>
 #endif
 
-#ifdef __ARM_NEON__
+#if defined(__ARM_NEON__) && !defined(__CUDACC__)
 # include "arm_neon.h"
 #endif
 
@@ -425,7 +425,7 @@ struct Hamming
     ResultType operator()(Iterator1 a, Iterator2 b, size_t size, ResultType /*worst_dist*/ = -1) const
     {
         ResultType result = 0;
-#ifdef __ARM_NEON__
+#if defined(__ARM_NEON__) && !defined(__CUDACC__)
         {
             uint32x4_t bits = vmovq_n_u32(0);
             for (size_t i = 0; i < size; i += 16) {


### PR DESCRIPTION
All `<arm_neon.h>` includes in `core/cv_cpu_dispatch.h` are protected by an
`ifndef __CUDACC__` to prevent attempting to use neon intrinsics when
compiling cuda kernels (.cu) -- this prevents hard errors such as
  ```error: identifier "__builtin_neon_qi" is undefined```

Add this same protection to flann/dist.h to fix compilation involving
flann.hpp.

### This pullrequest changes

Only protection around the inline neon code in flann/dist.h's Hamming distance function.

<cut/>

```
force_builders=Custom
buildworker:Custom=linux-1,linux-2,linux-4
docker_image:Custom=ubuntu-cuda:16.04
```