### PR TITLE
Add extra limitations for LRN from Inference Engine backend

### DIFF
--- a/modules/dnn/src/layers/lrn_layer.cpp
+++ b/modules/dnn/src/layers/lrn_layer.cpp
@@ -90,9 +90,9 @@ public:
 
     virtual bool supportBackend(int backendId) CV_OVERRIDE
     {
-        return backendId == DNN_BACKEND_OPENCV ||
-               backendId == DNN_BACKEND_HALIDE ||
-               backendId == DNN_BACKEND_INFERENCE_ENGINE;
+        if (backendId == DNN_BACKEND_INFERENCE_ENGINE)
+            return (bias == 1) && (preferableTarget != DNN_TARGET_MYRIAD || type == SPATIAL_NRM);
+        return backendId == DNN_BACKEND_OPENCV || backendId == DNN_BACKEND_HALIDE;
     }
 
 #ifdef HAVE_OPENCL
@@ -382,10 +382,13 @@ public:
     virtual Ptr<BackendNode> initInfEngine(const std::vector<Ptr<BackendWrapper> >&) CV_OVERRIDE
     {
 #ifdef HAVE_INF_ENGINE
+        float alphaSize = alpha;
+        if (!normBySize)
+            alphaSize *= (type == SPATIAL_NRM ? size*size : size);
 #if INF_ENGINE_VER_MAJOR_GE(INF_ENGINE_RELEASE_2018R5)
         InferenceEngine::Builder::NormLayer ieLayer(name);
         ieLayer.setSize(size);
-        ieLayer.setAlpha(alpha);
+        ieLayer.setAlpha(alphaSize);
         ieLayer.setBeta(beta);
         ieLayer.setAcrossMaps(type == CHANNEL_NRM);
 
@@ -402,7 +405,7 @@ public:
         ieLayer->_size = size;
         ieLayer->_k = (int)bias;
         ieLayer->_beta = beta;
-        ieLayer->_alpha = alpha;
+        ieLayer->_alpha = alphaSize;
         ieLayer->_isAcrossMaps = (type == CHANNEL_NRM);
         return Ptr<BackendNode>(new InfEngineBackendNode(ieLayer));
 #endif

--- a/modules/dnn/src/op_inf_engine.cpp
+++ b/modules/dnn/src/op_inf_engine.cpp
@@ -227,7 +227,7 @@ void InfEngineBackendNet::addLayer(InferenceEngine::Builder::Layer& layer)
     // By default, all the weights are connected to last ports ids.
     for (int i = 0; i < blobsIds.size(); ++i)
     {
-        netBuilder.connect((size_t)blobsIds[i], {(size_t)id, portIds[i]});
+        netBuilder.connect((size_t)blobsIds[i], {(size_t)id, (size_t)portIds[i]});
     }
 #endif
 }

--- a/modules/dnn/test/test_halide_layers.cpp
+++ b/modules/dnn/test/test_halide_layers.cpp
@@ -232,8 +232,6 @@ TEST_P(LRN, Accuracy)
     std::string nrmType = get<4>(GetParam());
     Backend backendId = get<0>(get<5>(GetParam()));
     Target targetId = get<1>(get<5>(GetParam()));
-    if (backendId == DNN_BACKEND_INFERENCE_ENGINE)
-        throw SkipTestException("");
 
     LayerParams lp;
     lp.set("norm_region", nrmType);
@@ -254,8 +252,8 @@ INSTANTIATE_TEST_CASE_P(Layer_Test_Halide, LRN, Combine(
 /*input ch,w,h*/ Values(Vec3i(6, 5, 8), Vec3i(7, 11, 6)),
 /*local size*/   Values(3, 5),
                  Values(Vec3f(0.9f, 1.0f, 1.1f), Vec3f(0.9f, 1.1f, 1.0f),
-/*alpha, beta,*/        Vec3f(1.0f, 0.9f, 1.1f), Vec3f(1.0f, 1.1f, 0.9f),
-/*bias */               Vec3f(1.1f, 0.9f, 1.0f), Vec3f(1.1f, 1.0f, 0.9f)),
+/*alpha, beta, bias*/   Vec3f(1.0f, 0.9f, 1.1f), Vec3f(1.0f, 1.1f, 0.9f),
+                        Vec3f(1.1f, 0.9f, 1.0f), Vec3f(1.1f, 1.0f, 0.9f)),
 /*norm_by_size*/ Bool(),
 /*norm_type*/    Values("ACROSS_CHANNELS", "WITHIN_CHANNEL"),
                  dnnBackendsAndTargetsWithHalide()


### PR DESCRIPTION
Inference Engine backend doesn't support LRN with bias and Myriad plugin doesn't support normalization across channels. Enabled test for all the configurations.

```
buildworker:Custom=linux-2
docker_image:Custom=ubuntu-openvino:16.04
build_parallel_tests:Custom=1
test_modules:Custom=dnn
```