### PR TITLE
cudev - Rework some code

### DIFF
--- a/modules/cudev/include/opencv2/cudev/grid/detail/integral.hpp
+++ b/modules/cudev/include/opencv2/cudev/grid/detail/integral.hpp
@@ -63,7 +63,8 @@ namespace integral_detail
         __shared__ D smem[NUM_SCAN_THREADS * 2];
         __shared__ D carryElem;
 
-        carryElem = 0;
+        if (threadIdx.x == 0)
+            carryElem = 0;
 
         __syncthreads();
 
@@ -105,7 +106,8 @@ namespace integral_detail
         __shared__ D smem[NUM_SCAN_THREADS * 2];
         __shared__ D carryElem;
 
-        carryElem = 0;
+        if (threadIdx.x == 0)
+            carryElem = 0;
 
         __syncthreads();
 

--- a/modules/cudev/include/opencv2/cudev/warp/scan.hpp
+++ b/modules/cudev/include/opencv2/cudev/warp/scan.hpp
@@ -98,7 +98,7 @@ __device__ T warpScanInclusive(T data, volatile T* smem, uint tid)
     #pragma unroll
     for (int i = 1; i <= (WARP_SIZE / 2); i *= 2)
     {
-        const T val = __shfl_up(data, i, WARP_SIZE);
+        const T val = shfl_up(data, i);
         if (laneId >= i)
               data += val;
     }

--- a/modules/cudev/include/opencv2/cudev/warp/shuffle.hpp
+++ b/modules/cudev/include/opencv2/cudev/warp/shuffle.hpp
@@ -250,6 +250,11 @@ __device__ double shfl_up(double val, uint delta, int width = warpSize)
     return __hiloint2double(hi, lo);
 }
 
+__device__ __forceinline__ unsigned long long shfl_up(unsigned long long val, uint delta, int width = warpSize)
+{
+    return __shfl_up(val, delta, width);
+}
+
 #define CV_CUDEV_SHFL_UP_VEC_INST(input_type) \
     __device__ __forceinline__ input_type ## 1 shfl_up(const input_type ## 1 & val, uint delta, int width = warpSize) \
     { \


### PR DESCRIPTION
- Use `shfl_down`, instead of `__shfl_down`, on `scan.hpp`
```
modules/cudev/include/opencv2/cudev/warp/scan.hpp
modules/cudev/include/opencv2/cudev/warp/shuffle.hpp
```
This fix is applied to make the code conform to the structure of `cudev` module. `__shfl_down` should be directly called at `shuffle.hpp` and other files in `cudev` module should call `shfl_down`, which is a wrapper for `__shfl_down`.

- Remove race conditions
```
modules/cudev/include/opencv2/cudev/block/scan.hpp
modules/cudev/include/opencv2/cudev/grid/detail/integral.hpp
```
This fix is applied to pass the following `cuda-memcheck --tool racecheck` tests:
```
cuda-memcheck --tool racecheck opencv_test_cudev
cuda-memcheck --tool racecheck opencv_test_cudaarithm --gtest_filter=*Integral*
```


```
force_builders=Custom
buildworker:Custom=linux-1,linux-2,linux-4
docker_image:Custom=ubuntu-cuda:16.04
```