### PR TITLE
fix tf_text_graph_common tensor_content type bug

### DIFF
--- a/samples/dnn/tf_text_graph_common.py
+++ b/samples/dnn/tf_text_graph_common.py
@@ -324,6 +324,6 @@ def writeTextGraph(modelPath, outputPath, outNodes):
             for node in graph_def.node:
                 if node.op == 'Const':
                     if 'value' in node.attr and node.attr['value'].tensor.tensor_content:
-                        node.attr['value'].tensor.tensor_content = ''
+                        node.attr['value'].tensor.tensor_content = b''
 
         tf.train.write_graph(graph_def, "", outputPath, as_text=True)


### PR DESCRIPTION
<!-- Please use this line to close one or multiple issues when this pullrequest gets merged
You can add another line right under the first one:
resolves #1234
resolves #1235
-->

### This pullrequest changes

```
Tensorflow version: 1.12.0
OpenCV version: 3.4.3
```

Fix the bug in creating tensorflow model's pbtxt file. 
The type of tensor.tensor_content should be `bytes` not `str` 

```
node.attr['value'].tensor.tensor_content = ""
--> 
node.attr['value'].tensor.tensor_content = bytes('', 'utf-8')
```
