### PR TITLE
OE-11 Logging revamp (#11003) for 4.2.x (draft (logging_20190220))

### DIFF
--- a/modules/core/include/opencv2/core/utils/logger.defines.hpp
+++ b/modules/core/include/opencv2/core/utils/logger.defines.hpp
@@ -17,6 +17,26 @@
 #define CV_LOG_LEVEL_DEBUG 5           //!< Debug message. Disabled in the "Release" build.
 #define CV_LOG_LEVEL_VERBOSE 6         //!< Verbose (trace) messages. Requires verbosity level. Disabled in the "Release" build.
 
+namespace cv {
+namespace utils {
+namespace logging {
+
+//! Supported logging levels and their semantic
+enum LogLevel {
+    LOG_LEVEL_SILENT = 0,              //!< for using in setLogVevel() call
+    LOG_LEVEL_FATAL = 1,               //!< Fatal (critical) error (unrecoverable internal error)
+    LOG_LEVEL_ERROR = 2,               //!< Error message
+    LOG_LEVEL_WARNING = 3,             //!< Warning message
+    LOG_LEVEL_INFO = 4,                //!< Info message
+    LOG_LEVEL_DEBUG = 5,               //!< Debug message. Disabled in the "Release" build.
+    LOG_LEVEL_VERBOSE = 6,             //!< Verbose (trace) messages. Requires verbosity level. Disabled in the "Release" build.
+#ifndef CV_DOXYGEN
+    ENUM_LOG_LEVEL_FORCE_INT = INT_MAX
+#endif
+};
+
+}}} // namespace
+
 //! @}
 
 #endif // OPENCV_LOGGER_DEFINES_HPP

--- a/modules/core/include/opencv2/core/utils/logger.hpp
+++ b/modules/core/include/opencv2/core/utils/logger.hpp
@@ -28,13 +28,23 @@ CV_EXPORTS LogLevel setLogLevel(LogLevel logLevel);
 /** Get global logging level */
 CV_EXPORTS LogLevel getLogLevel();
 
+CV_EXPORTS void registerLogTag(cv::utils::logging::LogTag* plogtag);
+
+CV_EXPORTS void setLogTagLevel(const char* tag, cv::utils::logging::LogLevel level);
+
+CV_EXPORTS cv::utils::logging::LogLevel getLogTagLevel(const char* tag);
+
+namespace internal {
+
 /** Get global log tag */
 CV_EXPORTS cv::utils::logging::LogTag* getGlobalLogTag();
 
-namespace internal {
 /** Write log message */
 CV_EXPORTS void writeLogMessage(LogLevel logLevel, const char* message);
+
+/** Write log message */
 CV_EXPORTS void writeLogMessageEx(LogLevel logLevel, const char* tag, const char* file, int line, const char* func, const char* message);
+
 } // namespace
 
 /**
@@ -60,7 +70,7 @@ CV_EXPORTS void writeLogMessageEx(LogLevel logLevel, const char* tag, const char
 // statement nor the compilation unit. The macro needs to expand into a C++
 // expression that can be static_cast into (cv::utils::logging::LogTag*). Must be
 // non-null. Do not re-define.
-#define CV_LOGTAG_GLOBAL cv::utils::logging::getGlobalLogTag()
+#define CV_LOGTAG_GLOBAL cv::utils::logging::internal::getGlobalLogTag()
 
 #define CV_LOG_WITH_TAG(tag, msgLevel, ...) \
     for(;;) { \

--- a/modules/core/include/opencv2/core/utils/logger.hpp
+++ b/modules/core/include/opencv2/core/utils/logger.hpp
@@ -47,6 +47,19 @@ CV_EXPORTS void writeLogMessageEx(LogLevel logLevel, const char* tag, const char
 
 } // namespace
 
+struct CV_EXPORTS LogTagAuto
+    : public LogTag
+{
+    const char* name;
+    LogLevel level;
+
+    LogTagAuto(const char* _name, LogLevel _level)
+        : LogTag(_name, _level)
+    {
+        registerLogTag(this);
+    }
+};
+
 /**
  * \def CV_LOG_STRIP_LEVEL
  *
@@ -60,7 +73,7 @@ CV_EXPORTS void writeLogMessageEx(LogLevel logLevel, const char* tag, const char
 # endif
 #endif
 
-#define CV_LOGTAG_PTR_CAST(expr) (const cv::utils::logging::LogTag*)(expr)
+#define CV_LOGTAG_PTR_CAST(expr) static_cast<const cv::utils::logging::LogTag*>(expr)
 
 // CV_LOGTAG_EXPAND_NAME is intended to be re-defined (undef and then define again)
 // to allows logging users to use a shorter name argument when calling

--- a/modules/core/include/opencv2/core/utils/logger.hpp
+++ b/modules/core/include/opencv2/core/utils/logger.hpp
@@ -47,13 +47,10 @@ CV_EXPORTS void writeLogMessageEx(LogLevel logLevel, const char* tag, const char
 
 } // namespace
 
-struct CV_EXPORTS LogTagAuto
+struct LogTagAuto
     : public LogTag
 {
-    const char* name;
-    LogLevel level;
-
-    LogTagAuto(const char* _name, LogLevel _level)
+    inline LogTagAuto(const char* _name, LogLevel _level)
         : LogTag(_name, _level)
     {
         registerLogTag(this);
@@ -149,27 +146,6 @@ struct CV_EXPORTS LogTagAuto
 #if CV_LOG_STRIP_LEVEL <= CV_LOG_LEVEL_VERBOSE
 # undef CV_LOG_VERBOSE
 # define CV_LOG_VERBOSE(tag, v, ...)
-#endif
-
-#if 0
-#define CV_LOG_FATAL(tag, ...)   for(;;) { if (cv::utils::logging::getLogLevel() < cv::utils::logging::LOG_LEVEL_FATAL) break; std::stringstream ss; ss << __VA_ARGS__; cv::utils::logging::internal::writeLogMessage(cv::utils::logging::LOG_LEVEL_FATAL, ss.str().c_str()); break; }
-#define CV_LOG_ERROR(tag, ...)   for(;;) { if (cv::utils::logging::getLogLevel() < cv::utils::logging::LOG_LEVEL_ERROR) break; std::stringstream ss; ss << __VA_ARGS__; cv::utils::logging::internal::writeLogMessage(cv::utils::logging::LOG_LEVEL_ERROR, ss.str().c_str()); break; }
-#define CV_LOG_WARNING(tag, ...) for(;;) { if (cv::utils::logging::getLogLevel() < cv::utils::logging::LOG_LEVEL_WARNING) break; std::stringstream ss; ss << __VA_ARGS__; cv::utils::logging::internal::writeLogMessage(cv::utils::logging::LOG_LEVEL_WARNING, ss.str().c_str()); break; }
-#if CV_LOG_STRIP_LEVEL <= CV_LOG_LEVEL_INFO
-#define CV_LOG_INFO(tag, ...)
-#else
-#define CV_LOG_INFO(tag, ...)    for(;;) { if (cv::utils::logging::getLogLevel() < cv::utils::logging::LOG_LEVEL_INFO) break; std::stringstream ss; ss << __VA_ARGS__; cv::utils::logging::internal::writeLogMessage(cv::utils::logging::LOG_LEVEL_INFO, ss.str().c_str()); break; }
-#endif
-#if CV_LOG_STRIP_LEVEL <= CV_LOG_LEVEL_DEBUG
-#define CV_LOG_DEBUG(tag, ...)
-#else
-#define CV_LOG_DEBUG(tag, ...)   for(;;) { if (cv::utils::logging::getLogLevel() < cv::utils::logging::LOG_LEVEL_DEBUG) break; std::stringstream ss; ss << __VA_ARGS__; cv::utils::logging::internal::writeLogMessage(cv::utils::logging::LOG_LEVEL_DEBUG, ss.str().c_str()); break; }
-#endif
-#if CV_LOG_STRIP_LEVEL <= CV_LOG_LEVEL_VERBOSE
-#define CV_LOG_VERBOSE(tag, v, ...)
-#else
-#define CV_LOG_VERBOSE(tag, v, ...) for(;;) { if (cv::utils::logging::getLogLevel() < cv::utils::logging::LOG_LEVEL_VERBOSE) break; std::stringstream ss; ss << "[VERB" << v << ":" << cv::utils::getThreadID() << "] " << __VA_ARGS__; cv::utils::logging::internal::writeLogMessage(cv::utils::logging::LOG_LEVEL_VERBOSE, ss.str().c_str()); break; }
-#endif
 #endif
 
 }}} // namespace

--- a/modules/core/include/opencv2/core/utils/logtag.hpp
+++ b/modules/core/include/opencv2/core/utils/logtag.hpp
@@ -5,13 +5,14 @@
 #ifndef OPENCV_CORE_LOGTAG_HPP
 #define OPENCV_CORE_LOGTAG_HPP
 
+#include "opencv2/core/cvstd.hpp"
 #include "logger.defines.hpp"
 
 namespace cv {
 namespace utils {
 namespace logging {
 
-struct LogTag
+struct CV_EXPORTS LogTag
 {
     const char* name;
     LogLevel level;

--- a/modules/core/include/opencv2/core/utils/logtag.hpp
+++ b/modules/core/include/opencv2/core/utils/logtag.hpp
@@ -1,0 +1,27 @@
+// This file is part of OpenCV project.
+// It is subject to the license terms in the LICENSE file found in the top-level directory
+// of this distribution and at http://opencv.org/license.html.
+
+#ifndef OPENCV_CORE_LOGTAG_HPP
+#define OPENCV_CORE_LOGTAG_HPP
+
+#include "logger.defines.hpp"
+
+namespace cv {
+namespace utils {
+namespace logging {
+
+struct LogTag
+{
+    const char* name;
+    LogLevel level;
+
+    constexpr LogTag(const char* _name, LogLevel _level)
+        : name(_name)
+        , level(_level)
+    {}
+};
+
+}}}
+
+#endif

--- a/modules/core/include/opencv2/core/utils/logtag.hpp
+++ b/modules/core/include/opencv2/core/utils/logtag.hpp
@@ -12,12 +12,12 @@ namespace cv {
 namespace utils {
 namespace logging {
 
-struct CV_EXPORTS LogTag
+struct LogTag
 {
     const char* name;
     LogLevel level;
 
-    constexpr LogTag(const char* _name, LogLevel _level)
+    inline constexpr LogTag(const char* _name, LogLevel _level)
         : name(_name)
         , level(_level)
     {}

--- a/modules/core/src/logger.cpp
+++ b/modules/core/src/logger.cpp
@@ -49,10 +49,15 @@ static LogLevel parseLogLevelConfiguration()
     return LOG_LEVEL_INFO;
 }
 
+cv::utils::logging::LogTag* getGlobalLogTag()
+{
+    static cv::utils::logging::LogTag g_LogTag { "global", parseLogLevelConfiguration() };
+    return &g_LogTag;
+}
+
 static LogLevel& getLogLevelVariable()
 {
-    static LogLevel g_logLevel = parseLogLevelConfiguration();
-    return g_logLevel;
+    return getGlobalLogTag()->level;
 }
 
 LogLevel setLogLevel(LogLevel logLevel)
@@ -103,6 +108,29 @@ void writeLogMessage(LogLevel logLevel, const char* message)
     (*out) << ss.str();
     if (logLevel <= LOG_LEVEL_WARNING)
         (*out) << std::flush;
+}
+
+void writeLogMessageEx(LogLevel logLevel, const char* tag, const char* file, int line, const char* func, const char* message)
+{
+    std::ostringstream strm;
+    if (tag)
+    {
+        strm << tag << " ";
+    }
+    if (file)
+    {
+        strm << file << " ";
+    }
+    if (line > 0)
+    {
+        strm << "(" << line << ") ";
+    }
+    if (func)
+    {
+        strm << func << " ";
+    }
+    strm << message;
+    writeLogMessage(logLevel, strm.str().c_str());
 }
 
 } // namespace

--- a/modules/core/src/logger.cpp
+++ b/modules/core/src/logger.cpp
@@ -21,141 +21,111 @@ namespace cv {
 namespace utils {
 namespace logging {
 
-#if 0
-static LogLevel parseLogLevelConfiguration()
-{
-    static cv::String param_log_level = utils::getConfigurationParameterString("OPENCV_LOG_LEVEL",
-#if defined NDEBUG
-            "WARNING"
-#else
-            "INFO"
-#endif
-    );
-    if (param_log_level == "DISABLED" || param_log_level == "disabled" ||
-        param_log_level == "0" || param_log_level == "OFF" || param_log_level == "off")
-        return LOG_LEVEL_SILENT;
-    if (param_log_level == "FATAL" || param_log_level == "fatal")
-        return LOG_LEVEL_FATAL;
-    if (param_log_level == "ERROR" || param_log_level == "error")
-        return LOG_LEVEL_ERROR;
-    if (param_log_level == "WARNING" || param_log_level == "warning" ||
-        param_log_level == "WARNINGS" || param_log_level == "warnings" ||
-        param_log_level == "WARN" || param_log_level == "warn")
-        return LOG_LEVEL_WARNING;
-    if (param_log_level == "INFO" || param_log_level == "info")
-        return LOG_LEVEL_INFO;
-    if (param_log_level == "DEBUG" || param_log_level == "debug")
-        return LOG_LEVEL_DEBUG;
-    if (param_log_level == "VERBOSE" || param_log_level == "verbose")
-        return LOG_LEVEL_VERBOSE;
-    std::cerr << "ERROR: Unexpected logging level value: " << param_log_level << std::endl;
-    return LOG_LEVEL_INFO;
-}
-#endif
-
 namespace internal
 {
-    // Combining several things that require static dynamic initialization in a
-    // well-defined order into a struct.
-    //
-    struct GlobalLoggingInitStruct
-    {
-    public:
+
+// Combining several things that require static dynamic initialization in a
+// well-defined order into a struct.
+//
+struct GlobalLoggingInitStruct
+{
+public:
 #if defined NDEBUG
-        static constexpr bool m_isDebugBuild = false;
+    static constexpr bool m_isDebugBuild = false;
 #else
-        static constexpr bool m_isDebugBuild = true;
+    static constexpr bool m_isDebugBuild = true;
 #endif
 
-    public:
-        static constexpr LogLevel m_defaultUnconfiguredGlobalLevel =
-            m_isDebugBuild ? LOG_LEVEL_DEBUG : LOG_LEVEL_WARNING;
+public:
+    static constexpr LogLevel m_defaultUnconfiguredGlobalLevel =
+        m_isDebugBuild ? LOG_LEVEL_DEBUG : LOG_LEVEL_WARNING;
 
-    public:
-        LogTagManager logTagManager;
+public:
+    LogTagManager logTagManager;
 
-        GlobalLoggingInitStruct()
-            : logTagManager(m_defaultUnconfiguredGlobalLevel)
+    GlobalLoggingInitStruct()
+        : logTagManager(m_defaultUnconfiguredGlobalLevel)
+    {
+        applyConfigString();
+        handleMalformed();
+    }
+
+private:
+    void applyConfigString()
+    {
+        logTagManager.setConfigString(utils::getConfigurationParameterString("OPENCV_LOG_LEVEL", ""));
+    }
+
+    void handleMalformed()
+    {
+        // need to print warning for malformed log tag config strings?
+        if (m_isDebugBuild)
         {
-            applyConfigString();
-            handleMalformed();
-        }
-
-    private:
-        void applyConfigString()
-        {
-            logTagManager.setConfigString(utils::getConfigurationParameterString("OPENCV_LOG_LEVEL", ""));
-        }
-
-        void handleMalformed()
-        {
-            // need to print warning for malformed log tag config strings?
-            if (m_isDebugBuild)
+            const auto& parser = logTagManager.getConfigParser();
+            if (parser.hasMalformed())
             {
-                const auto& parser = logTagManager.getConfigParser();
-                if (parser.hasMalformed())
+                const auto& malformedList = parser.getMalformed();
+                for (const auto& malformed : malformedList)
                 {
-                    const auto& malformedList = parser.getMalformed();
-                    for (const auto& malformed : malformedList)
-                    {
-                        std::cout << "Malformed log level config: \"" << malformed << "\"\n";
-                    }
-                    std::cout.flush();
+                    std::cout << "Malformed log level config: \"" << malformed << "\"\n";
                 }
+                std::cout.flush();
             }
         }
-    };
-
-    // Static dynamic initialization guard function for the combined struct
-    // just defined above
-    //
-    // An initialization guard function guarantees that outside code cannot
-    // accidentally see not-yet-dynamically-initialized data, by routing
-    // all outside access request to this function, so that this function
-    // has a chance to run the initialization code if necessary.
-    //
-    // An initialization guard function only guarantees initialization upon
-    // the first call to this function.
-    //
-    static GlobalLoggingInitStruct& getGlobalLoggingInitStruct()
-    {
-        static GlobalLoggingInitStruct globalLoggingInitInstance;
-        return globalLoggingInitInstance;
     }
+};
 
-    // To ensure that the combined struct defined above is initialized even
-    // if the initialization guard function wasn't called, a dummy static
-    // instance of a struct is defined below, which will call the
-    // initialization guard function.
-    //
-    struct GlobalLoggingInitCall
-    {
-        GlobalLoggingInitCall()
-        {
-            getGlobalLoggingInitStruct();
-        }
-    };
-
-    static GlobalLoggingInitCall globalLoggingInitCall;
-
-    static LogTagManager& getLogTagManager()
-    {
-        static LogTagManager& logTagManagerInstance = getGlobalLoggingInitStruct().logTagManager;
-        return logTagManagerInstance;
-    }
-
-    static LogLevel& getLogLevelVariable()
-    {
-        static LogLevel& refGlobalLogLevel = getGlobalLogTag()->level;
-        return refGlobalLogLevel;
-    }
-
-    LogTag* getGlobalLogTag()
-    {
-        static LogTag* globalLogTagPtr = getGlobalLoggingInitStruct().logTagManager.get("global");
-        return globalLogTagPtr;
-    }
+// Static dynamic initialization guard function for the combined struct
+// just defined above
+//
+// An initialization guard function guarantees that outside code cannot
+// accidentally see not-yet-dynamically-initialized data, by routing
+// all outside access request to this function, so that this function
+// has a chance to run the initialization code if necessary.
+//
+// An initialization guard function only guarantees initialization upon
+// the first call to this function.
+//
+static GlobalLoggingInitStruct& getGlobalLoggingInitStruct()
+{
+    static GlobalLoggingInitStruct globalLoggingInitInstance;
+    return globalLoggingInitInstance;
 }
+
+// To ensure that the combined struct defined above is initialized even
+// if the initialization guard function wasn't called, a dummy static
+// instance of a struct is defined below, which will call the
+// initialization guard function.
+//
+struct GlobalLoggingInitCall
+{
+    GlobalLoggingInitCall()
+    {
+        getGlobalLoggingInitStruct();
+    }
+};
+
+static GlobalLoggingInitCall globalLoggingInitCall;
+
+static LogTagManager& getLogTagManager()
+{
+    static LogTagManager& logTagManagerInstance = getGlobalLoggingInitStruct().logTagManager;
+    return logTagManagerInstance;
+}
+
+static LogLevel& getLogLevelVariable()
+{
+    static LogLevel& refGlobalLogLevel = getGlobalLogTag()->level;
+    return refGlobalLogLevel;
+}
+
+LogTag* getGlobalLogTag()
+{
+    static LogTag* globalLogTagPtr = getGlobalLoggingInitStruct().logTagManager.get("global");
+    return globalLogTagPtr;
+}
+
+} // namespace
 
 void registerLogTag(LogTag* plogtag)
 {

--- a/modules/core/src/utils/logtagconfig.hpp
+++ b/modules/core/src/utils/logtagconfig.hpp
@@ -1,0 +1,51 @@
+// This file is part of OpenCV project.
+// It is subject to the license terms in the LICENSE file found in the top-level directory
+// of this distribution and at http://opencv.org/license.html.
+
+#ifndef OPENCV_CORE_LOGTAGCONFIG_HPP
+#define OPENCV_CORE_LOGTAGCONFIG_HPP
+
+#if 1 // if not already in precompiled headers
+#include <opencv2/core/utils/logger.defines.hpp>
+#include <string>
+#endif
+
+namespace cv {
+namespace utils {
+namespace logging {
+
+struct LogTagConfig
+{
+    std::string namePart;
+    LogLevel level;
+    bool isGlobal;
+    bool hasPrefixWildcard;
+    bool hasSuffixWildcard;
+
+    explicit LogTagConfig()
+        : namePart()
+        , level()
+        , isGlobal()
+        , hasPrefixWildcard()
+        , hasSuffixWildcard()
+    {
+    }
+
+    explicit LogTagConfig(const std::string& _namePart, LogLevel _level, bool _isGlobal = false,
+        bool _hasPrefixWildcard = false, bool _hasSuffixWildcard = false)
+        : namePart(_namePart)
+        , level(_level)
+        , isGlobal(_isGlobal)
+        , hasPrefixWildcard(_hasPrefixWildcard)
+        , hasSuffixWildcard(_hasSuffixWildcard)
+    {
+    }
+
+    LogTagConfig(const LogTagConfig&) = default;
+    LogTagConfig(LogTagConfig&&) = default;
+    ~LogTagConfig() = default;
+};
+
+}}}
+
+#endif

--- a/modules/core/src/utils/logtagconfig.hpp
+++ b/modules/core/src/utils/logtagconfig.hpp
@@ -22,7 +22,7 @@ struct LogTagConfig
     bool hasPrefixWildcard;
     bool hasSuffixWildcard;
 
-    explicit LogTagConfig()
+    LogTagConfig()
         : namePart()
         , level()
         , isGlobal()
@@ -31,7 +31,7 @@ struct LogTagConfig
     {
     }
 
-    explicit LogTagConfig(const std::string& _namePart, LogLevel _level, bool _isGlobal = false,
+    LogTagConfig(const std::string& _namePart, LogLevel _level, bool _isGlobal = false,
         bool _hasPrefixWildcard = false, bool _hasSuffixWildcard = false)
         : namePart(_namePart)
         , level(_level)

--- a/modules/core/src/utils/logtagconfigparser.cpp
+++ b/modules/core/src/utils/logtagconfigparser.cpp
@@ -1,0 +1,217 @@
+// This file is part of OpenCV project.
+// It is subject to the license terms in the LICENSE file found in the top-level directory
+// of this distribution and at http://opencv.org/license.html.
+
+#include "../precomp.hpp"
+#include "logtagconfigparser.hpp"
+
+namespace cv {
+namespace utils {
+namespace logging {
+
+LogTagConfigParser::LogTagConfigParser()
+{
+}
+
+LogTagConfigParser::LogTagConfigParser(const std::string& input)
+{
+	parse(input);
+}
+
+LogTagConfigParser::~LogTagConfigParser()
+{
+}
+
+bool LogTagConfigParser::parse(const std::string& input)
+{
+	m_input = input;
+	segmentTokens();
+	return (m_malformed.empty());
+}
+
+bool LogTagConfigParser::hasMalformed() const
+{
+    return !m_malformed.empty();
+}
+
+void LogTagConfigParser::forEachParsed(std::function<void(const std::string&, LogLevel)> func) const
+{
+    for (const auto& parsed : m_parsed)
+    {
+        func(parsed.name, parsed.level);
+    }
+}
+
+void LogTagConfigParser::forEachMalformed(std::function<void(const std::string&)> func) const
+{
+    for (const auto& malformed : m_malformed)
+    {
+        func(malformed);
+    }
+}
+
+void LogTagConfigParser::segmentTokens()
+{
+	const size_t len = m_input.length();
+	std::vector<std::pair<size_t, size_t>> startStops;
+	bool wasSeparator = true;
+	for (size_t pos = 0u; pos < len; ++pos)
+	{
+		char c = m_input[pos];
+		bool isSeparator = (c == ' ' || c == '\t' || c == ';');
+		if (!isSeparator)
+		{
+			if (wasSeparator)
+			{
+				startStops.emplace_back(pos, pos + 1u);
+			}
+			else
+			{
+				startStops.back().second = pos + 1u;
+			}
+		}
+		wasSeparator = isSeparator;
+	}
+	for (const auto& startStop : startStops)
+	{
+		const auto s = m_input.substr(startStop.first, startStop.second - startStop.first);
+		parseNameLevel(s);
+	}
+}
+
+void LogTagConfigParser::parseNameLevel(const std::string& s)
+{
+	const size_t npos = std::string::npos;
+	const size_t len = s.length();
+	size_t colonIdx = s.find_first_of(":=");
+	if (colonIdx == npos)
+	{
+		// See if the whole string is a log level
+		auto parsedLevel = parseLogLevel(s);
+		if (parsedLevel.second)
+		{
+			// If it is, assume it is a catch-all
+			m_parsed.emplace_back(NameLevel{ "*", parsedLevel.first });
+            return;
+		}
+		else
+		{
+			// not sure what to do.
+			m_malformed.push_back(s);
+			return;
+		}
+	}
+	if (colonIdx == 0u || colonIdx + 1u == len)
+	{
+		// malformed (colon or equal sign at beginning or end), cannot do anything
+		m_malformed.push_back(s);
+		return;
+	}
+	size_t colonIdx2 = s.find_first_of(":=", colonIdx + 1u);
+	if (colonIdx2 != npos)
+	{
+		// malformed (more than one colon or equal sign), cannot do anything
+		m_malformed.push_back(s);
+		return;
+	}
+	auto parsedLevel = parseLogLevel(s.substr(colonIdx + 1u));
+	if (parsedLevel.second)
+	{
+		m_parsed.emplace_back(NameLevel{ s.substr(0u, colonIdx), parsedLevel.first });
+	}
+	else
+	{
+		// not sure what to do.
+		m_malformed.push_back(s);
+		return;
+	}
+}
+
+std::pair<LogLevel, bool> LogTagConfigParser::parseLogLevel(const std::string& s)
+{
+	const auto falseDontCare = std::make_pair(LOG_LEVEL_VERBOSE, false);
+	const size_t len = s.length();
+	if (len >= 1u)
+	{
+		std::pair<LogLevel, bool> result = falseDontCare;
+		// Fast classification based on first character. 
+		// Tentative; need check remaining string.
+		char c = (char)std::toupper(s[0]);
+		switch (c)
+		{
+		case 'S':
+			result.first = LOG_LEVEL_SILENT;
+			result.second = (len == 1u || len == 6u);
+			break;
+		case 'F':
+			result.first = LOG_LEVEL_FATAL;
+			result.second = (len == 1u || len == 5u);
+			break;
+		case 'E':
+			result.first = LOG_LEVEL_ERROR;
+			result.second = (len == 1u || len == 5u);
+			break;
+		case 'W':
+			result.first = LOG_LEVEL_WARNING;
+			result.second = (len == 1u || len == 4u || len == 7u);
+			break;
+		case 'I':
+			result.first = LOG_LEVEL_INFO;
+			result.second = (len == 1u || len == 4u);
+			break;
+		case 'D':
+			result.first = LOG_LEVEL_DEBUG;
+			result.second = (len == 1u || len == 5u);
+			break;
+		case 'V':
+			result.first = LOG_LEVEL_VERBOSE;
+			result.second = (len == 1u || len == 7u);
+			break;
+		default:
+			break;
+		}
+		if (len == 1u)
+		{
+			return result;
+		}
+		if (!result.second)
+		{
+			return falseDontCare;
+		}
+		std::string upper = s;
+		std::transform(upper.begin(), upper.end(), upper.begin(),
+			[](char arg) -> char { return (char)toupper(arg); });
+		if (upper == "SILENT" || upper == "FATAL" || upper == "ERROR" ||
+			upper == "WARNING" || upper == "WARN" || upper == "INFO" ||
+			upper == "DEBUG" || upper == "VERBOSE")
+		{
+			return result;
+		}
+	}
+	return falseDontCare;
+}
+
+std::string LogTagConfigParser::toString(LogLevel level)
+{
+	switch (level)
+	{
+	case LOG_LEVEL_SILENT:
+		return "SILENT";
+	case LOG_LEVEL_FATAL:
+		return "FATAL";
+	case LOG_LEVEL_ERROR:
+		return "ERROR";
+	case LOG_LEVEL_WARNING:
+		return "WARNING";
+	case LOG_LEVEL_INFO:
+		return "INFO";
+	case LOG_LEVEL_DEBUG:
+		return "DEBUG";
+	case LOG_LEVEL_VERBOSE:
+		return "VERBOSE";
+	default:
+		return std::to_string((int)level);
+	}
+}
+
+}}} //namespace

--- a/modules/core/src/utils/logtagconfigparser.cpp
+++ b/modules/core/src/utils/logtagconfigparser.cpp
@@ -11,11 +11,16 @@ namespace logging {
 
 LogTagConfigParser::LogTagConfigParser()
 {
+    m_parsedGlobal.namePart = "global";
+    m_parsedGlobal.isGlobal = true;
+    m_parsedGlobal.hasPrefixWildcard = false;
+    m_parsedGlobal.hasSuffixWildcard = false;
+    m_parsedGlobal.level = LOG_LEVEL_VERBOSE;
 }
 
 LogTagConfigParser::LogTagConfigParser(const std::string& input)
 {
-	parse(input);
+    parse(input);
 }
 
 LogTagConfigParser::~LogTagConfigParser()
@@ -24,9 +29,9 @@ LogTagConfigParser::~LogTagConfigParser()
 
 bool LogTagConfigParser::parse(const std::string& input)
 {
-	m_input = input;
-	segmentTokens();
-	return (m_malformed.empty());
+    m_input = input;
+    segmentTokens();
+    return (m_malformed.empty());
 }
 
 bool LogTagConfigParser::hasMalformed() const
@@ -34,184 +39,242 @@ bool LogTagConfigParser::hasMalformed() const
     return !m_malformed.empty();
 }
 
-void LogTagConfigParser::forEachParsed(std::function<void(const std::string&, LogLevel)> func) const
+const LogTagConfig& LogTagConfigParser::getGlobalConfig() const
 {
-    for (const auto& parsed : m_parsed)
-    {
-        func(parsed.name, parsed.level);
-    }
+    return m_parsedGlobal;
 }
 
-void LogTagConfigParser::forEachMalformed(std::function<void(const std::string&)> func) const
+const std::vector<LogTagConfig>& LogTagConfigParser::getFullNameConfigs() const
 {
-    for (const auto& malformed : m_malformed)
-    {
-        func(malformed);
-    }
+    return m_parsedFullName;
+}
+
+const std::vector<LogTagConfig>& LogTagConfigParser::getFirstPartConfigs() const
+{
+    return m_parsedFirstPart;
+}
+
+const std::vector<LogTagConfig>& LogTagConfigParser::getAnyPartConfigs() const
+{
+    return m_parsedAnyPart;
+}
+
+const std::vector<std::string>& LogTagConfigParser::getMalformed() const
+{
+    return m_malformed;
 }
 
 void LogTagConfigParser::segmentTokens()
 {
-	const size_t len = m_input.length();
-	std::vector<std::pair<size_t, size_t>> startStops;
-	bool wasSeparator = true;
-	for (size_t pos = 0u; pos < len; ++pos)
-	{
-		char c = m_input[pos];
-		bool isSeparator = (c == ' ' || c == '\t' || c == ';');
-		if (!isSeparator)
-		{
-			if (wasSeparator)
-			{
-				startStops.emplace_back(pos, pos + 1u);
-			}
-			else
-			{
-				startStops.back().second = pos + 1u;
-			}
-		}
-		wasSeparator = isSeparator;
-	}
-	for (const auto& startStop : startStops)
-	{
-		const auto s = m_input.substr(startStop.first, startStop.second - startStop.first);
-		parseNameLevel(s);
-	}
+    const size_t len = m_input.length();
+    std::vector<std::pair<size_t, size_t>> startStops;
+    bool wasSeparator = true;
+    for (size_t pos = 0u; pos < len; ++pos)
+    {
+        char c = m_input[pos];
+        bool isSeparator = (c == ' ' || c == '\t' || c == ';');
+        if (!isSeparator)
+        {
+            if (wasSeparator)
+            {
+                startStops.emplace_back(pos, pos + 1u);
+            }
+            else
+            {
+                startStops.back().second = pos + 1u;
+            }
+        }
+        wasSeparator = isSeparator;
+    }
+    for (const auto& startStop : startStops)
+    {
+        const auto s = m_input.substr(startStop.first, startStop.second - startStop.first);
+        parseNameAndLevel(s);
+    }
 }
 
-void LogTagConfigParser::parseNameLevel(const std::string& s)
+void LogTagConfigParser::parseNameAndLevel(const std::string& s)
 {
-	const size_t npos = std::string::npos;
-	const size_t len = s.length();
-	size_t colonIdx = s.find_first_of(":=");
-	if (colonIdx == npos)
-	{
-		// See if the whole string is a log level
-		auto parsedLevel = parseLogLevel(s);
-		if (parsedLevel.second)
-		{
-			// If it is, assume it is a catch-all
-			m_parsed.emplace_back(NameLevel{ "*", parsedLevel.first });
+    const size_t npos = std::string::npos;
+    const size_t len = s.length();
+    size_t colonIdx = s.find_first_of(":=");
+    if (colonIdx == npos)
+    {
+        // See if the whole string is a log level
+        auto parsedLevel = parseLogLevel(s);
+        if (parsedLevel.second)
+        {
+            // If it is, assume the log level is for global
+            parseWildcard("", parsedLevel.first);
             return;
-		}
-		else
-		{
-			// not sure what to do.
-			m_malformed.push_back(s);
-			return;
-		}
-	}
-	if (colonIdx == 0u || colonIdx + 1u == len)
-	{
-		// malformed (colon or equal sign at beginning or end), cannot do anything
-		m_malformed.push_back(s);
-		return;
-	}
-	size_t colonIdx2 = s.find_first_of(":=", colonIdx + 1u);
-	if (colonIdx2 != npos)
-	{
-		// malformed (more than one colon or equal sign), cannot do anything
-		m_malformed.push_back(s);
-		return;
-	}
-	auto parsedLevel = parseLogLevel(s.substr(colonIdx + 1u));
-	if (parsedLevel.second)
-	{
-		m_parsed.emplace_back(NameLevel{ s.substr(0u, colonIdx), parsedLevel.first });
-	}
-	else
-	{
-		// not sure what to do.
-		m_malformed.push_back(s);
-		return;
-	}
+        }
+        else
+        {
+            // not sure what to do.
+            m_malformed.push_back(s);
+            return;
+        }
+    }
+    if (colonIdx == 0u || colonIdx + 1u == len)
+    {
+        // malformed (colon or equal sign at beginning or end), cannot do anything
+        m_malformed.push_back(s);
+        return;
+    }
+    size_t colonIdx2 = s.find_first_of(":=", colonIdx + 1u);
+    if (colonIdx2 != npos)
+    {
+        // malformed (more than one colon or equal sign), cannot do anything
+        m_malformed.push_back(s);
+        return;
+    }
+    auto parsedLevel = parseLogLevel(s.substr(colonIdx + 1u));
+    if (parsedLevel.second)
+    {
+        parseWildcard(s.substr(0u, colonIdx), parsedLevel.first);
+        return;
+    }
+    else
+    {
+        // Cannot recognize the right side of the colon or equal sign.
+        // Not sure what to do.
+        m_malformed.push_back(s);
+        return;
+    }
+}
+
+void LogTagConfigParser::parseWildcard(const std::string& name, LogLevel level)
+{
+    constexpr size_t npos = std::string::npos;
+    const size_t len = name.length();
+    if (len == 0u)
+    {
+        m_parsedGlobal.level = level;
+        return;
+    }
+    const bool hasPrefixWildcard = (name[0u] == '*');
+    if (hasPrefixWildcard && len == 1u)
+    {
+        m_parsedGlobal.level = level;
+        return;
+    }
+    const size_t firstNonWildcard = name.find_first_not_of("*.");
+    if (hasPrefixWildcard && firstNonWildcard == npos)
+    {
+        m_parsedGlobal.level = level;
+        return;
+    }
+    const bool hasSuffixWildcard = (name[len - 1u] == '*');
+    const size_t lastNonWildcard = name.find_last_not_of("*.");
+    std::string trimmedNamePart = name.substr(firstNonWildcard, lastNonWildcard - firstNonWildcard + 1u);
+    // The case of a single asterisk has been handled above;
+    // here we only handle the explicit use of "global" in the log config string.
+    const bool isGlobal = (trimmedNamePart == "global");
+    if (isGlobal)
+    {
+        m_parsedGlobal.level = level;
+        return;
+    }
+    LogTagConfig result(trimmedNamePart, level, false, hasPrefixWildcard, hasSuffixWildcard);
+    if (hasPrefixWildcard)
+    {
+        m_parsedAnyPart.emplace_back(std::move(result));
+    }
+    else if (hasSuffixWildcard)
+    {
+        m_parsedFirstPart.emplace_back(std::move(result));
+    }
+    else
+    {
+        m_parsedFullName.emplace_back(std::move(result));
+    }
 }
 
 std::pair<LogLevel, bool> LogTagConfigParser::parseLogLevel(const std::string& s)
 {
-	const auto falseDontCare = std::make_pair(LOG_LEVEL_VERBOSE, false);
-	const size_t len = s.length();
-	if (len >= 1u)
-	{
-		std::pair<LogLevel, bool> result = falseDontCare;
-		// Fast classification based on first character. 
-		// Tentative; need check remaining string.
-		char c = (char)std::toupper(s[0]);
-		switch (c)
-		{
-		case 'S':
-			result.first = LOG_LEVEL_SILENT;
-			result.second = (len == 1u || len == 6u);
-			break;
-		case 'F':
-			result.first = LOG_LEVEL_FATAL;
-			result.second = (len == 1u || len == 5u);
-			break;
-		case 'E':
-			result.first = LOG_LEVEL_ERROR;
-			result.second = (len == 1u || len == 5u);
-			break;
-		case 'W':
-			result.first = LOG_LEVEL_WARNING;
-			result.second = (len == 1u || len == 4u || len == 7u);
-			break;
-		case 'I':
-			result.first = LOG_LEVEL_INFO;
-			result.second = (len == 1u || len == 4u);
-			break;
-		case 'D':
-			result.first = LOG_LEVEL_DEBUG;
-			result.second = (len == 1u || len == 5u);
-			break;
-		case 'V':
-			result.first = LOG_LEVEL_VERBOSE;
-			result.second = (len == 1u || len == 7u);
-			break;
-		default:
-			break;
-		}
-		if (len == 1u)
-		{
-			return result;
-		}
-		if (!result.second)
-		{
-			return falseDontCare;
-		}
-		std::string upper = s;
-		std::transform(upper.begin(), upper.end(), upper.begin(),
-			[](char arg) -> char { return (char)toupper(arg); });
-		if (upper == "SILENT" || upper == "FATAL" || upper == "ERROR" ||
-			upper == "WARNING" || upper == "WARN" || upper == "INFO" ||
-			upper == "DEBUG" || upper == "VERBOSE")
-		{
-			return result;
-		}
-	}
-	return falseDontCare;
+    const auto falseDontCare = std::make_pair(LOG_LEVEL_VERBOSE, false);
+    const size_t len = s.length();
+    if (len >= 1u)
+    {
+        std::pair<LogLevel, bool> result = falseDontCare;
+        // Fast classification based on first character.
+        // Tentative; need check remaining string.
+        char c = (char)std::toupper(s[0]);
+        switch (c)
+        {
+        case 'S':
+            result.first = LOG_LEVEL_SILENT;
+            result.second = (len == 1u || len == 6u);
+            break;
+        case 'F':
+            result.first = LOG_LEVEL_FATAL;
+            result.second = (len == 1u || len == 5u);
+            break;
+        case 'E':
+            result.first = LOG_LEVEL_ERROR;
+            result.second = (len == 1u || len == 5u);
+            break;
+        case 'W':
+            result.first = LOG_LEVEL_WARNING;
+            result.second = (len == 1u || len == 4u || len == 7u);
+            break;
+        case 'I':
+            result.first = LOG_LEVEL_INFO;
+            result.second = (len == 1u || len == 4u);
+            break;
+        case 'D':
+            result.first = LOG_LEVEL_DEBUG;
+            result.second = (len == 1u || len == 5u);
+            break;
+        case 'V':
+            result.first = LOG_LEVEL_VERBOSE;
+            result.second = (len == 1u || len == 7u);
+            break;
+        default:
+            break;
+        }
+        if (len == 1u)
+        {
+            return result;
+        }
+        if (!result.second)
+        {
+            return falseDontCare;
+        }
+        std::string upper = s;
+        std::transform(upper.begin(), upper.end(), upper.begin(),
+            [](char arg) -> char { return (char)toupper(arg); });
+        if (upper == "SILENT" || upper == "FATAL" || upper == "ERROR" ||
+            upper == "WARNING" || upper == "WARN" || upper == "INFO" ||
+            upper == "DEBUG" || upper == "VERBOSE")
+        {
+            return result;
+        }
+    }
+    return falseDontCare;
 }
 
 std::string LogTagConfigParser::toString(LogLevel level)
 {
-	switch (level)
-	{
-	case LOG_LEVEL_SILENT:
-		return "SILENT";
-	case LOG_LEVEL_FATAL:
-		return "FATAL";
-	case LOG_LEVEL_ERROR:
-		return "ERROR";
-	case LOG_LEVEL_WARNING:
-		return "WARNING";
-	case LOG_LEVEL_INFO:
-		return "INFO";
-	case LOG_LEVEL_DEBUG:
-		return "DEBUG";
-	case LOG_LEVEL_VERBOSE:
-		return "VERBOSE";
-	default:
-		return std::to_string((int)level);
-	}
+    switch (level)
+    {
+    case LOG_LEVEL_SILENT:
+        return "SILENT";
+    case LOG_LEVEL_FATAL:
+        return "FATAL";
+    case LOG_LEVEL_ERROR:
+        return "ERROR";
+    case LOG_LEVEL_WARNING:
+        return "WARNING";
+    case LOG_LEVEL_INFO:
+        return "INFO";
+    case LOG_LEVEL_DEBUG:
+        return "DEBUG";
+    case LOG_LEVEL_VERBOSE:
+        return "VERBOSE";
+    default:
+        return std::to_string((int)level);
+    }
 }
 
 }}} //namespace

--- a/modules/core/src/utils/logtagconfigparser.cpp
+++ b/modules/core/src/utils/logtagconfigparser.cpp
@@ -193,63 +193,88 @@ void LogTagConfigParser::parseWildcard(const std::string& name, LogLevel level)
 std::pair<LogLevel, bool> LogTagConfigParser::parseLogLevel(const std::string& s)
 {
     const auto falseDontCare = std::make_pair(LOG_LEVEL_VERBOSE, false);
+    const auto make_parsed_result = [](LogLevel lev) -> std::pair<LogLevel, bool>
+    {
+        return std::make_pair(lev, true);
+    };
     const size_t len = s.length();
     if (len >= 1u)
     {
-        std::pair<LogLevel, bool> result = falseDontCare;
-        // Fast classification based on first character.
-        // Tentative; need check remaining string.
-        char c = (char)std::toupper(s[0]);
+        const char c = (char)std::toupper(s[0]);
         switch (c)
         {
-        case 'S':
-            result.first = LOG_LEVEL_SILENT;
-            result.second = (len == 1u || len == 6u);
-            break;
-        case 'F':
-            result.first = LOG_LEVEL_FATAL;
-            result.second = (len == 1u || len == 5u);
-            break;
-        case 'E':
-            result.first = LOG_LEVEL_ERROR;
-            result.second = (len == 1u || len == 5u);
-            break;
-        case 'W':
-            result.first = LOG_LEVEL_WARNING;
-            result.second = (len == 1u || len == 4u || len == 7u);
-            break;
-        case 'I':
-            result.first = LOG_LEVEL_INFO;
-            result.second = (len == 1u || len == 4u);
+        case '0':
+            if (len == 1u)
+            {
+                return make_parsed_result(LOG_LEVEL_SILENT);
+            }
             break;
         case 'D':
-            result.first = LOG_LEVEL_DEBUG;
-            result.second = (len == 1u || len == 5u);
+            if (len == 1u ||
+                (len == 5u && cv::toUpperCase(s) == "DEBUG"))
+            {
+                return make_parsed_result(LOG_LEVEL_DEBUG);
+            }
+            if ((len == 7u && cv::toUpperCase(s) == "DISABLE") ||
+                (len == 8u && cv::toUpperCase(s) == "DISABLED"))
+            {
+                return make_parsed_result(LOG_LEVEL_SILENT);
+            }
+            break;
+        case 'E':
+            if (len == 1u ||
+                (len == 5u && cv::toUpperCase(s) == "ERROR"))
+            {
+                return make_parsed_result(LOG_LEVEL_ERROR);
+            }
+            break;
+        case 'F':
+            if (len == 1u ||
+                (len == 5u && cv::toUpperCase(s) == "FATAL"))
+            {
+                return make_parsed_result(LOG_LEVEL_FATAL);
+            }
+            break;
+        case 'I':
+            if (len == 1u ||
+                (len == 4u && cv::toUpperCase(s) == "INFO"))
+            {
+                return make_parsed_result(LOG_LEVEL_INFO);
+            }
+            break;
+        case 'O':
+            if (len == 3u && cv::toUpperCase(s) == "OFF")
+            {
+                return make_parsed_result(LOG_LEVEL_SILENT);
+            }
+            break;
+        case 'S':
+            if (len == 1u ||
+                (len == 6u && cv::toUpperCase(s) == "SILENT"))
+            {
+                return make_parsed_result(LOG_LEVEL_SILENT);
+            }
             break;
         case 'V':
-            result.first = LOG_LEVEL_VERBOSE;
-            result.second = (len == 1u || len == 7u);
+            if (len == 1u ||
+                (len == 7u && cv::toUpperCase(s) == "VERBOSE"))
+            {
+                return make_parsed_result(LOG_LEVEL_VERBOSE);
+            }
+            break;
+        case 'W':
+            if (len == 1u ||
+                (len == 4u && cv::toUpperCase(s) == "WARN") ||
+                (len == 7u && cv::toUpperCase(s) == "WARNING") ||
+                (len == 8u && cv::toUpperCase(s) == "WARNINGS"))
+            {
+                return make_parsed_result(LOG_LEVEL_WARNING);
+            }
             break;
         default:
             break;
         }
-        if (len == 1u)
-        {
-            return result;
-        }
-        if (!result.second)
-        {
-            return falseDontCare;
-        }
-        std::string upper = s;
-        std::transform(upper.begin(), upper.end(), upper.begin(),
-            [](char arg) -> char { return (char)toupper(arg); });
-        if (upper == "SILENT" || upper == "FATAL" || upper == "ERROR" ||
-            upper == "WARNING" || upper == "WARN" || upper == "INFO" ||
-            upper == "DEBUG" || upper == "VERBOSE")
-        {
-            return result;
-        }
+        // fall through
     }
     return falseDontCare;
 }

--- a/modules/core/src/utils/logtagconfigparser.hpp
+++ b/modules/core/src/utils/logtagconfigparser.hpp
@@ -12,6 +12,7 @@
 #endif
 
 #include <opencv2/core/utils/logtag.hpp>
+#include "logtagconfig.hpp"
 
 namespace cv {
 namespace utils {
@@ -20,33 +21,33 @@ namespace logging {
 class LogTagConfigParser
 {
 public:
-	struct NameLevel
-	{
-		std::string name;
-		LogLevel level;
-	};
+    LogTagConfigParser();
+    explicit LogTagConfigParser(const std::string& input);
+    ~LogTagConfigParser();
 
 public:
-	LogTagConfigParser();
-	explicit LogTagConfigParser(const std::string& input);
-	~LogTagConfigParser();
-
-public:
-	bool parse(const std::string& input);
+    bool parse(const std::string& input);
     bool hasMalformed() const;
-    void forEachParsed(std::function<void(const std::string&, LogLevel)> func) const;
-    void forEachMalformed(std::function<void(const std::string&)> func) const;
+    const LogTagConfig& getGlobalConfig() const;
+    const std::vector<LogTagConfig>& getFullNameConfigs() const;
+    const std::vector<LogTagConfig>& getFirstPartConfigs() const;
+    const std::vector<LogTagConfig>& getAnyPartConfigs() const;
+    const std::vector<std::string>& getMalformed() const;
 
 private:
-	void segmentTokens();
-	void parseNameLevel(const std::string& s);
-	static std::pair<LogLevel, bool> parseLogLevel(const std::string& s);
-	static std::string toString(LogLevel level);
+    void segmentTokens();
+    void parseNameAndLevel(const std::string& s);
+    void parseWildcard(const std::string& name, LogLevel level);
+    static std::pair<LogLevel, bool> parseLogLevel(const std::string& s);
+    static std::string toString(LogLevel level);
 
 private:
-	std::string m_input;
-	std::vector<NameLevel> m_parsed;
-	std::vector<std::string> m_malformed;
+    std::string m_input;
+    LogTagConfig m_parsedGlobal;
+    std::vector<LogTagConfig> m_parsedFullName;
+    std::vector<LogTagConfig> m_parsedFirstPart;
+    std::vector<LogTagConfig> m_parsedAnyPart;
+    std::vector<std::string> m_malformed;
 };
 
 }}} //namespace

--- a/modules/core/src/utils/logtagconfigparser.hpp
+++ b/modules/core/src/utils/logtagconfigparser.hpp
@@ -1,0 +1,54 @@
+// This file is part of OpenCV project.
+// It is subject to the license terms in the LICENSE file found in the top-level directory
+// of this distribution and at http://opencv.org/license.html.
+
+#ifndef OPENCV_CORE_LOGTAGCONFIGPARSER_HPP
+#define OPENCV_CORE_LOGTAGCONFIGPARSER_HPP
+
+#if 1 // if not already in precompiled headers
+#include <string>
+#include <vector>
+#include <functional>
+#endif
+
+#include <opencv2/core/utils/logtag.hpp>
+
+namespace cv {
+namespace utils {
+namespace logging {
+
+class LogTagConfigParser
+{
+public:
+	struct NameLevel
+	{
+		std::string name;
+		LogLevel level;
+	};
+
+public:
+	LogTagConfigParser();
+	explicit LogTagConfigParser(const std::string& input);
+	~LogTagConfigParser();
+
+public:
+	bool parse(const std::string& input);
+    bool hasMalformed() const;
+    void forEachParsed(std::function<void(const std::string&, LogLevel)> func) const;
+    void forEachMalformed(std::function<void(const std::string&)> func) const;
+
+private:
+	void segmentTokens();
+	void parseNameLevel(const std::string& s);
+	static std::pair<LogLevel, bool> parseLogLevel(const std::string& s);
+	static std::string toString(LogLevel level);
+
+private:
+	std::string m_input;
+	std::vector<NameLevel> m_parsed;
+	std::vector<std::string> m_malformed;
+};
+
+}}} //namespace
+
+#endif

--- a/modules/core/src/utils/logtagmanager.cpp
+++ b/modules/core/src/utils/logtagmanager.cpp
@@ -4,53 +4,73 @@
 
 #include "../precomp.hpp"
 #include "logtagmanager.hpp"
+#include "logtagconfigparser.hpp"
 
 namespace cv {
 namespace utils {
 namespace logging {
 
-LogTagManager::LogTagManager()
+LogTagManager::LogTagManager(LogLevel defaultUnconfiguredGlobalLevel)
     : m_mutex()
-    , m_byFullName()
-    , m_byFirstPart()
-    , m_byAnyPart()
-    , m_nextId()
+    , m_globalLogTag(new LogTag(m_globalName, defaultUnconfiguredGlobalLevel))
+    , m_fullNames()
+    , m_firstParts()
+    , m_anyParts()
+    , m_nextId(1u)
+    , m_config(std::make_shared<LogTagConfigParser>())
 {
+    assign(m_globalName, m_globalLogTag.get());
 }
 
 LogTagManager::~LogTagManager()
 {
 }
 
-void LogTagManager::assign(const std::string& name, LogTag* value)
+void LogTagManager::setConfigString(const std::string& configString, bool apply /*true*/)
+{
+    m_config->parse(configString);
+    if (m_config->hasMalformed())
+    {
+        return;
+    }
+    if (!apply)
+    {
+        return;
+    }
+    // The following code is arranged with "priority by overwriting",
+    // where when the same log tag has multiple matches, the last code
+    // block has highest priority by literally overwriting the effects
+    // from the earlier code blocks.
+    //
+    // Matching by full name has highest priority.
+    // Matching by any name part has moderate priority.
+    // Matching by first name part (prefix) has lowest priority.
+    //
+    const auto& globalConfig = m_config->getGlobalConfig();
+    m_globalLogTag->level = globalConfig.level;
+    for (const auto& config : m_config->getFirstPartConfigs())
+    {
+        setLevelByFirstPart(config.namePart, config.level);
+    }
+    for (const auto& config : m_config->getAnyPartConfigs())
+    {
+        setLevelByAnyPart(config.namePart, config.level);
+    }
+    for (const auto& config : m_config->getFullNameConfigs())
+    {
+        setLevelByFullName(config.namePart, config.level);
+    }
+}
+
+LogTagConfigParser& LogTagManager::getConfigParser() const
+{
+    return *m_config;
+}
+
+void LogTagManager::assign(const std::string& name, LogTag* ptr)
 {
     LockType lock(m_mutex);
-    auto iterByFullName = m_byFullName.find(name);
-    size_t nameId = 0u;
-    if (iterByFullName == m_byFullName.end())
-    {
-        nameId = (++m_nextId);
-        iterByFullName = m_byFullName.emplace(name, LogTagAndId{ nameId, value }).first;
-    }
-    else
-    {
-        nameId = iterByFullName->second.id;
-        iterByFullName->second.value = value;
-    }
-    bool isFirst = true;
-    auto namePartFunc = [&](const std::string& part)
-    {
-        if (isFirst)
-        {
-            // Warning, current code is not sufficient in preventing duplicated
-            // entries in unordered_multimap.
-            m_byFirstPart.emplace(part, LogTagAndId{ nameId, value });
-            isFirst = false;
-        }
-        // See same warning above.
-        m_byAnyPart.emplace(part, LogTagAndId{ nameId, value });
-    };
-    internal_forEachNamePart(name, namePartFunc);
+    assignFullName(name, ptr);
 }
 
 void LogTagManager::unassign(const std::string& name)
@@ -62,76 +82,204 @@ void LogTagManager::unassign(const std::string& name)
 LogTag* LogTagManager::get(const std::string& name) const
 {
     LockType lock(m_mutex);
-    const auto iter = m_byFullName.find(name);
-    if (iter == m_byFullName.end())
+    const auto iter = m_fullNames.find(name);
+    if (iter == m_fullNames.end())
     {
         return nullptr;
     }
-    return iter->second.value;
+    return iter->second.member.ptr;
 }
 
-void LogTagManager::invoke(const std::string& name, std::function<void(LogTag*)> func)
+void LogTagManager::setLevelByFullName(const std::string& fullName, LogLevel level)
 {
-    LockType lock(m_mutex);
-    LogTag* value = get(name);
-    if (value)
+    auto iter = m_fullNames.find(fullName);
+    if (iter == m_fullNames.end())
     {
-        func(value);
+        iter = m_fullNames.emplace(fullName, FullNameInfo{}).first;
+    }
+    auto& info = iter->second;
+    // skip additional processing if nothing changes.
+    if (info.parsedLevel.valid &&
+        info.parsedLevel.level == level)
+    {
+        return;
+    }
+    // update the cached configured value.
+    info.parsedLevel.valid = true;
+    info.parsedLevel.level = level;
+    // update the actual tag, if already registered.
+    if (info.member.ptr)
+    {
+        info.member.ptr->level = level;
     }
 }
 
-void LogTagManager::forEach_byFirstPart(const std::string& firstPart, std::function<void(LogTag*)> func)
+void LogTagManager::setLevelByFirstPart(const std::string& firstPart, LogLevel level)
 {
-    LockType lock(m_mutex);
-    const auto iterPair = m_byFirstPart.equal_range(firstPart);
-    for (auto iter = iterPair.first; iter != iterPair.second; ++iter)
+    const bool isFirst = true;
+    setLevelByWildcard(firstPart, level, isFirst);
+}
+
+void LogTagManager::setLevelByAnyPart(const std::string& anyPart, LogLevel level)
+{
+    const bool isFirst = false;
+    setLevelByWildcard(anyPart, level, isFirst);
+}
+
+void LogTagManager::setLevelByWildcard(const std::string& namePart, LogLevel level, bool isFirst)
+{
+    auto& wildcardMap = isFirst ? m_firstParts : m_anyParts;
+    auto iter = wildcardMap.find(namePart);
+    if (iter == wildcardMap.end())
     {
-        if (iter->first == firstPart) // is this check redundant?
+        iter = wildcardMap.emplace(namePart, WildcardInfo{}).first;
+    }
+    auto& info = iter->second;
+    // skip additional processing if nothing changes.
+    if (info.parsedLevel.valid &&
+        info.parsedLevel.level == level)
+    {
+        return;
+    }
+    // update the cached configured value.
+    info.parsedLevel.valid = true;
+    info.parsedLevel.level = level;
+    // update the actual tag(s), if already registered.
+    for (auto& member : info.members)
+    {
+        if (member.ptr)
         {
-            auto value = iter->second.value;
-            if (value)
-            {
-                func(value);
-            }
+            member.ptr->level = level;
         }
     }
 }
 
-void LogTagManager::forEach_byAnyPart(const std::string& anyPart, std::function<void(LogTag*)> func)
+const LogTagManager::FullNamePair& LogTagManager::assignFullName(const std::string& fullName, LogTag* ptr)
 {
-    LockType lock(m_mutex);
-    const auto iterPair = m_byAnyPart.equal_range(anyPart);
-    for (auto iter = iterPair.first; iter != iterPair.second; ++iter)
+    auto iter = m_fullNames.find(fullName);
+    if (iter == m_fullNames.end())
     {
-        if (iter->first == anyPart) // is this check redundant?
+        // full name never seen before, neither from tag registration nor from parsed config
+        const size_t newId = (m_nextId++);
+        iter = m_fullNames.emplace(fullName, FullNameInfo{}).first;
+        auto& info = iter->second;
+        info.member.id = newId;
+        info.member.ptr = ptr;
+        return *iter;
+    }
+    else
+    {
+        // full name has been seen.
+        auto& info = iter->second;
+        // skip additional processing if nothing changes.
+        if (info.member.ptr == ptr)
         {
-            auto value = iter->second.value;
-            if (value)
-            {
-                func(value);
-            }
+            return *iter;
+        }
+        info.member.ptr = ptr;
+        // if parsed config having exact full name exists, apply.
+        // (Config using exact full name has highest matching priority.)
+        if (info.member.ptr &&
+            info.parsedLevel.valid)
+        {
+            info.member.ptr->level = info.parsedLevel.level;
+            return *iter;
+        }
+        assignNameParts(*iter);
+        return *iter;
+    }
+}
+
+void LogTagManager::assignNameParts(const FullNamePair& fullNamePair)
+{
+    const auto nameParts = splitNameParts(fullNamePair.first);
+    bool isFirstNamePart = true;
+    for (const std::string& namePart : nameParts)
+    {
+        assignWildcardInfo(fullNamePair, namePart, isFirstNamePart);
+        isFirstNamePart = false;
+    }
+}
+
+void LogTagManager::assignWildcardInfo(const FullNamePair& fullNamePair, const std::string& namePart, bool isFirst)
+{
+    const auto memberIdAndPtr = fullNamePair.second.member;
+    LogTag* const ptr = memberIdAndPtr.ptr;
+    auto& wildcardMap = isFirst ? m_firstParts : m_anyParts;
+    auto wildcardIter = wildcardMap.find(namePart);
+    if (wildcardIter == wildcardMap.end())
+    {
+        wildcardIter = wildcardMap.emplace(namePart, WildcardInfo{}).first;
+        auto& members = wildcardIter->second.members;
+        members.emplace_back(memberIdAndPtr);
+    }
+    else
+    {
+        auto& members = wildcardIter->second.members;
+        auto& foundMember = addOrGetMember(members, memberIdAndPtr);
+        // skip additional processing if nothing changes.
+        if (foundMember.ptr == ptr)
+        {
+            return;
+        }
+        foundMember.ptr = ptr;
+        // if there is parsed config for wildcard but not the full name,
+        // it is applied.
+        // (If both exist, the full name config has higher priority)
+        const bool hasParsedFullNameLevel = fullNamePair.second.parsedLevel.valid;
+        const bool hasParsedWildcardLevel = wildcardIter->second.parsedLevel.valid;
+        if (ptr &&
+            !hasParsedFullNameLevel &&
+            hasParsedWildcardLevel)
+        {
+            LogLevel wildcardLevel = wildcardIter->second.parsedLevel.level;
+            ptr->level = wildcardLevel;
         }
     }
 }
 
-void LogTagManager::internal_forEachNamePart(const std::string& name, std::function<void(const std::string& namePart)> namePartFunc)
+LogTagManager::LogTagAndId& LogTagManager::addOrGetMember(std::vector<LogTagAndId>& members, const LogTagAndId& memberArg)
+{
+    const size_t npos = ~(size_t)0u;
+    const size_t memberCount = members.size();
+    size_t memberIndex = npos;
+    for (size_t k = 0u; k < memberCount; ++k)
+    {
+        auto& member = members.at(k);
+        if (member.id == memberArg.id)
+        {
+            memberIndex = k;
+            break;
+        }
+    }
+    if (memberIndex == npos)
+    {
+        memberIndex = memberCount;
+        members.emplace_back(memberArg);
+    }
+    return members.at(memberIndex);
+}
+
+std::vector<std::string> LogTagManager::splitNameParts(const std::string& fullName)
 {
     const size_t npos = std::string::npos;
-    const size_t len = name.length();
+    const size_t len = fullName.length();
+    std::vector<std::string> nameParts;
     size_t start = 0u;
     while (start < len)
     {
-        size_t nextPeriod = name.find('.', start);
+        size_t nextPeriod = fullName.find('.', start);
         if (nextPeriod == npos)
         {
             nextPeriod = len;
         }
         if (nextPeriod >= start + 1u)
         {
-            namePartFunc(name.substr(start, nextPeriod - start));
+            nameParts.emplace_back(fullName.substr(start, nextPeriod - start));
         }
         start = nextPeriod + 1u;
     }
+    return nameParts;
 }
 
 }}} //namespace

--- a/modules/core/src/utils/logtagmanager.cpp
+++ b/modules/core/src/utils/logtagmanager.cpp
@@ -1,0 +1,137 @@
+// This file is part of OpenCV project.
+// It is subject to the license terms in the LICENSE file found in the top-level directory
+// of this distribution and at http://opencv.org/license.html.
+
+#include "../precomp.hpp"
+#include "logtagmanager.hpp"
+
+namespace cv {
+namespace utils {
+namespace logging {
+
+LogTagManager::LogTagManager()
+    : m_mutex()
+    , m_byFullName()
+    , m_byFirstPart()
+    , m_byAnyPart()
+    , m_nextId()
+{
+}
+
+LogTagManager::~LogTagManager()
+{
+}
+
+void LogTagManager::assign(const std::string& name, LogTag* value)
+{
+    LockType lock(m_mutex);
+    auto iterByFullName = m_byFullName.find(name);
+    size_t nameId = 0u;
+    if (iterByFullName == m_byFullName.end())
+    {
+        nameId = (++m_nextId);
+        iterByFullName = m_byFullName.emplace(name, LogTagAndId{ nameId, value }).first;
+    }
+    else
+    {
+        nameId = iterByFullName->second.id;
+        iterByFullName->second.value = value;
+    }
+    bool isFirst = true;
+    auto namePartFunc = [&](const std::string& part)
+    {
+        if (isFirst)
+        {
+            // Warning, current code is not sufficient in preventing duplicated
+            // entries in unordered_multimap.
+            m_byFirstPart.emplace(part, LogTagAndId{ nameId, value });
+            isFirst = false;
+        }
+        // See same warning above.
+        m_byAnyPart.emplace(part, LogTagAndId{ nameId, value });
+    };
+    internal_forEachNamePart(name, namePartFunc);
+}
+
+void LogTagManager::unassign(const std::string& name)
+{
+    // Lock is inside assign() method.
+    assign(name, nullptr);
+}
+
+LogTag* LogTagManager::get(const std::string& name) const
+{
+    LockType lock(m_mutex);
+    const auto iter = m_byFullName.find(name);
+    if (iter == m_byFullName.end())
+    {
+        return nullptr;
+    }
+    return iter->second.value;
+}
+
+void LogTagManager::invoke(const std::string& name, std::function<void(LogTag*)> func)
+{
+    LockType lock(m_mutex);
+    LogTag* value = get(name);
+    if (value)
+    {
+        func(value);
+    }
+}
+
+void LogTagManager::forEach_byFirstPart(const std::string& firstPart, std::function<void(LogTag*)> func)
+{
+    LockType lock(m_mutex);
+    const auto iterPair = m_byFirstPart.equal_range(firstPart);
+    for (auto iter = iterPair.first; iter != iterPair.second; ++iter)
+    {
+        if (iter->first == firstPart) // is this check redundant?
+        {
+            auto value = iter->second.value;
+            if (value)
+            {
+                func(value);
+            }
+        }
+    }
+}
+
+void LogTagManager::forEach_byAnyPart(const std::string& anyPart, std::function<void(LogTag*)> func)
+{
+    LockType lock(m_mutex);
+    const auto iterPair = m_byAnyPart.equal_range(anyPart);
+    for (auto iter = iterPair.first; iter != iterPair.second; ++iter)
+    {
+        if (iter->first == anyPart) // is this check redundant?
+        {
+            auto value = iter->second.value;
+            if (value)
+            {
+                func(value);
+            }
+        }
+    }
+}
+
+void LogTagManager::internal_forEachNamePart(const std::string& name, std::function<void(const std::string& namePart)> namePartFunc)
+{
+    const size_t npos = std::string::npos;
+    const size_t len = name.length();
+    size_t start = 0u;
+    while (start < len)
+    {
+        size_t nextPeriod = name.find('.', start);
+        if (nextPeriod == npos)
+        {
+            nextPeriod = len;
+        }
+        if (nextPeriod >= start + 1u)
+        {
+            namePartFunc(name.substr(start, nextPeriod - start));
+        }
+        start = nextPeriod + 1u;
+    }
+}
+
+}}} //namespace

--- a/modules/core/src/utils/logtagmanager.hpp
+++ b/modules/core/src/utils/logtagmanager.hpp
@@ -44,6 +44,12 @@ private:
     {
         size_t id;
         LogTag* ptr;
+
+        LogTagAndId()
+            : id(0u)
+            , ptr(nullptr)
+        {
+        }
     };
 
     struct ParsedLevel
@@ -73,6 +79,30 @@ private:
     };
 
     using WildcardPair = std::pair<const std::string, WildcardInfo>;
+
+    struct InfoIndex
+    {
+        std::string fullNamePtr;
+        std::vector<std::string> namePartsPtr;
+        size_t id;
+        FullNameInfo* fullNameInfoPtr;
+        WildcardInfo* firstPartInfoPtr;
+        size_t firstPartMemberIndex;
+        std::vector<WildcardInfo*> anyPartInfoPtrs;
+        std::vector<size_t> anyPartMemberIndex;
+
+        InfoIndex()
+            : fullNamePtr()
+            , namePartsPtr()
+            , id(0u)
+            , fullNameInfoPtr(nullptr)
+            , firstPartInfoPtr(nullptr)
+            , firstPartMemberIndex(0u)
+            , anyPartInfoPtrs()
+            , anyPartMemberIndex()
+        {
+        }
+    };
 
 public:
     LogTagManager(LogLevel defaultUnconfiguredGlobalLevel);
@@ -105,10 +135,13 @@ public:
     void setLevelByAnyPart(const std::string& anyPart, LogLevel level);
 
 private:
-    const FullNamePair& assignFullName(const std::string& fullName, LogTag* ptr);
-    void assignNameParts(const FullNamePair& fullNamePair);
-    void assignWildcardInfo(const FullNamePair& fullNamePair, const std::string& namePart, bool isFirst);
-    LogTagAndId& addOrGetMember(std::vector<LogTagAndId>& members, const LogTagAndId& memberArg);
+    void populateIndex(InfoIndex& index, const std::string& fullName);
+    void populateIndexFullName(InfoIndex& index);
+    void populateIndexFirstPart(InfoIndex& index);
+    void populateIndexAnyPart(InfoIndex& index, size_t namePartIndex);
+    size_t addOrGetMember(InfoIndex& index, WildcardInfo* wildcardInfoPtr);
+    bool updateIndexLogTagPtr(InfoIndex& index, LogTag* ptr);
+    bool findAndApplyLevelToTag(InfoIndex& index);
     void setLevelByWildcard(const std::string& namePart, LogLevel level, bool isFirst);
 
 private:

--- a/modules/core/src/utils/logtagmanager.hpp
+++ b/modules/core/src/utils/logtagmanager.hpp
@@ -11,13 +11,18 @@
 #include <functional>
 #include <unordered_map>
 #include <mutex>
+#include <memory>
 #endif
 
 #include <opencv2/core/utils/logtag.hpp>
+#include "logtagconfig.hpp"
 
 namespace cv {
 namespace utils {
 namespace logging {
+
+// forward declaration
+class LogTagConfigParser;
 
 // A lookup table of LogTags using full name, first part of name, and any part of name.
 // The name parts of a LogTag is delimited by period.
@@ -27,34 +32,6 @@ namespace logging {
 //
 class LogTagManager
 {
-public:
-    LogTagManager();
-    ~LogTagManager();
-
-public:
-    // Add (register) the log tag.
-    // Note, passing in nullptr as value is equivalent to unassigning.
-    void assign(const std::string& name, LogTag* value);
-
-    // Unassign the log tag. This is equivalent to calling assign with nullptr value.
-    void unassign(const std::string& name);
-
-    // Retrieve the log tag by exact name.
-    LogTag* get(const std::string& name) const;
-
-    // Given full name of a log tag, invoke the function while inside the lock.
-    void invoke(const std::string& name, std::function<void(LogTag*)> func);
-
-    // For each log tag having the specified first part of prefix (up to the first period)
-    // invoke the function inside the lock.
-    void forEach_byFirstPart(const std::string& firstPart, std::function<void(LogTag*)> func);
-
-    // For each log tag having any matching part, invoke the function inside the lock.
-    void forEach_byAnyPart(const std::string& anyPart, std::function<void(LogTag*)> func);
-
-private:
-    void internal_forEachNamePart(const std::string& name, std::function<void(const std::string& namePart)> namePartFunc);
-
 private:
     // Current implementation does not seem to require recursive mutex;
     // also, extensible functions (accepting user-provided callback) are not allowed
@@ -66,15 +43,88 @@ private:
     struct LogTagAndId
     {
         size_t id;
-        LogTag* value;
+        LogTag* ptr;
     };
+
+    struct ParsedLevel
+    {
+        bool valid;
+        LogLevel level;
+
+        ParsedLevel()
+            : valid(false)
+            , level()
+        {
+        }
+    };
+
+    struct FullNameInfo
+    {
+        LogTagAndId member;
+        ParsedLevel parsedLevel;
+    };
+
+    using FullNamePair = std::pair<const std::string, FullNameInfo>;
+
+    struct WildcardInfo
+    {
+        std::vector<LogTagAndId> members;
+        ParsedLevel parsedLevel;
+    };
+
+    using WildcardPair = std::pair<const std::string, WildcardInfo>;
+
+public:
+    LogTagManager(LogLevel defaultUnconfiguredGlobalLevel);
+    ~LogTagManager();
+
+public:
+    // Parse and apply the config string.
+    void setConfigString(const std::string& configString, bool apply = true);
+
+    // Gets the config parser. This is necessary to retrieve the list of malformed strings.
+    LogTagConfigParser& getConfigParser() const;
+
+    // Add (register) the log tag.
+    // Note, passing in nullptr as value is equivalent to unassigning.
+    void assign(const std::string& name, LogTag* ptr);
+
+    // Unassign the log tag. This is equivalent to calling assign with nullptr value.
+    void unassign(const std::string& name);
+
+    // Retrieve the log tag by exact name.
+    LogTag* get(const std::string& name) const;
+
+    // Changes the log level of the tag having the exact full name.
+    void setLevelByFullName(const std::string& fullName, LogLevel level);
+
+    // Changes the log level of the tag matching the first part of the name.
+    void setLevelByFirstPart(const std::string& firstPart, LogLevel level);
+
+    // Changes the log level of the tag matching any part of the name.
+    void setLevelByAnyPart(const std::string& anyPart, LogLevel level);
+
+private:
+    const FullNamePair& assignFullName(const std::string& fullName, LogTag* ptr);
+    void assignNameParts(const FullNamePair& fullNamePair);
+    void assignWildcardInfo(const FullNamePair& fullNamePair, const std::string& namePart, bool isFirst);
+    LogTagAndId& addOrGetMember(std::vector<LogTagAndId>& members, const LogTagAndId& memberArg);
+    void setLevelByWildcard(const std::string& namePart, LogLevel level, bool isFirst);
+
+private:
+    static std::vector<std::string> splitNameParts(const std::string& fullName);
+
+private:
+    static constexpr const char* m_globalName = "global";
 
 private:
     mutable MutexType m_mutex;
-    std::unordered_map<std::string, LogTagAndId> m_byFullName;
-    std::unordered_multimap<std::string, LogTagAndId> m_byFirstPart;
-    std::unordered_multimap<std::string, LogTagAndId> m_byAnyPart;
+    std::unique_ptr<LogTag> m_globalLogTag;
+    std::unordered_map<std::string, FullNameInfo> m_fullNames;
+    std::unordered_map<std::string, WildcardInfo> m_firstParts;
+    std::unordered_map<std::string, WildcardInfo> m_anyParts;
     size_t m_nextId;
+    std::shared_ptr<LogTagConfigParser> m_config;
 };
 
 }}} //namespace

--- a/modules/core/src/utils/logtagmanager.hpp
+++ b/modules/core/src/utils/logtagmanager.hpp
@@ -1,0 +1,82 @@
+// This file is part of OpenCV project.
+// It is subject to the license terms in the LICENSE file found in the top-level directory
+// of this distribution and at http://opencv.org/license.html.
+
+#ifndef OPENCV_CORE_LOGTAGMANAGER_HPP
+#define OPENCV_CORE_LOGTAGMANAGER_HPP
+
+#if 1 // if not already in precompiled headers
+#include <string>
+#include <algorithm>
+#include <functional>
+#include <unordered_map>
+#include <mutex>
+#endif
+
+#include <opencv2/core/utils/logtag.hpp>
+
+namespace cv {
+namespace utils {
+namespace logging {
+
+// A lookup table of LogTags using full name, first part of name, and any part of name.
+// The name parts of a LogTag is delimited by period.
+//
+// This class does not handle wildcard characters. The name-matching method can only be
+// selected by calling the appropriate function.
+//
+class LogTagManager
+{
+public:
+    LogTagManager();
+    ~LogTagManager();
+
+public:
+    // Add (register) the log tag.
+    // Note, passing in nullptr as value is equivalent to unassigning.
+    void assign(const std::string& name, LogTag* value);
+
+    // Unassign the log tag. This is equivalent to calling assign with nullptr value.
+    void unassign(const std::string& name);
+
+    // Retrieve the log tag by exact name.
+    LogTag* get(const std::string& name) const;
+
+    // Given full name of a log tag, invoke the function while inside the lock.
+    void invoke(const std::string& name, std::function<void(LogTag*)> func);
+
+    // For each log tag having the specified first part of prefix (up to the first period)
+    // invoke the function inside the lock.
+    void forEach_byFirstPart(const std::string& firstPart, std::function<void(LogTag*)> func);
+
+    // For each log tag having any matching part, invoke the function inside the lock.
+    void forEach_byAnyPart(const std::string& anyPart, std::function<void(LogTag*)> func);
+
+private:
+    void internal_forEachNamePart(const std::string& name, std::function<void(const std::string& namePart)> namePartFunc);
+
+private:
+    // Current implementation does not seem to require recursive mutex;
+    // also, extensible functions (accepting user-provided callback) are not allowed
+    // to call LogTagManger (to prevent iterator invalidation), which needs enforced
+    // with a non-recursive mutex.
+    using MutexType = std::mutex;
+    using LockType = std::lock_guard<MutexType>;
+
+    struct LogTagAndId
+    {
+        size_t id;
+        LogTag* value;
+    };
+
+private:
+    mutable MutexType m_mutex;
+    std::unordered_map<std::string, LogTagAndId> m_byFullName;
+    std::unordered_multimap<std::string, LogTagAndId> m_byFirstPart;
+    std::unordered_multimap<std::string, LogTagAndId> m_byAnyPart;
+    size_t m_nextId;
+};
+
+}}} //namespace
+
+#endif //OPENCV_CORE_LOGTAGMANAGER_HPP

--- a/modules/core/src/utils/logtagmanager.hpp
+++ b/modules/core/src/utils/logtagmanager.hpp
@@ -40,68 +40,190 @@ private:
     using MutexType = std::mutex;
     using LockType = std::lock_guard<MutexType>;
 
-    struct LogTagAndId
+    enum class MatchingScope
     {
-        size_t id;
-        LogTag* ptr;
-
-        LogTagAndId()
-            : id(0u)
-            , ptr(nullptr)
-        {
-        }
+        None,
+        Full,
+        FirstNamePart,
+        AnyNamePart
     };
 
     struct ParsedLevel
     {
-        bool valid;
         LogLevel level;
+        MatchingScope scope;
 
         ParsedLevel()
-            : valid(false)
-            , level()
+            : level()
+            , scope(MatchingScope::None)
         {
         }
     };
 
     struct FullNameInfo
     {
-        LogTagAndId member;
+        LogTag* logTagPtr;
         ParsedLevel parsedLevel;
     };
 
-    using FullNamePair = std::pair<const std::string, FullNameInfo>;
-
-    struct WildcardInfo
+    struct NamePartInfo
     {
-        std::vector<LogTagAndId> members;
         ParsedLevel parsedLevel;
     };
 
-    using WildcardPair = std::pair<const std::string, WildcardInfo>;
-
-    struct InfoIndex
+    struct CrossReference
     {
-        std::string fullNamePtr;
-        std::vector<std::string> namePartsPtr;
-        size_t id;
-        FullNameInfo* fullNameInfoPtr;
-        WildcardInfo* firstPartInfoPtr;
-        size_t firstPartMemberIndex;
-        std::vector<WildcardInfo*> anyPartInfoPtrs;
-        std::vector<size_t> anyPartMemberIndex;
+        size_t m_fullNameId;
+        size_t m_namePartId;
+        size_t m_matchingPos;
+        FullNameInfo* m_fullNameInfo;
+        NamePartInfo* m_namePartInfo;
 
-        InfoIndex()
-            : fullNamePtr()
-            , namePartsPtr()
-            , id(0u)
-            , fullNameInfoPtr(nullptr)
-            , firstPartInfoPtr(nullptr)
-            , firstPartMemberIndex(0u)
-            , anyPartInfoPtrs()
-            , anyPartMemberIndex()
+        explicit CrossReference(size_t fullNameId, size_t namePartId, size_t matchingPos,
+            FullNameInfo* fullNameInfo, NamePartInfo* namePartInfo)
+            : m_fullNameId(fullNameId)
+            , m_namePartId(namePartId)
+            , m_matchingPos(matchingPos)
+            , m_fullNameInfo(fullNameInfo)
+            , m_namePartInfo(namePartInfo)
         {
         }
+    };
+
+    struct FullNameLookupResult
+    {
+        // The full name being looked up
+        std::string m_fullName;
+
+        // The full name being broken down into name parts
+        std::vector<std::string> m_nameParts;
+
+        // The full name ID that is added or looked up from the table
+        size_t m_fullNameId;
+
+        // The name part IDs that are added to or looked up from the table
+        // listed in the same order as m_nameParts
+        std::vector<size_t> m_namePartIds;
+
+        // The information struct for the full name
+        FullNameInfo* m_fullNameInfoPtr;
+
+        // Specifies whether cross references (full names that match the name part)
+        // should be computed.
+        bool m_findCrossReferences;
+
+        // List of all full names that match the given name part.
+        // This field is computed only if m_findCrossReferences is true.
+        std::vector<CrossReference> m_crossReferences;
+
+        explicit FullNameLookupResult(const std::string& fullName)
+            : m_fullName(fullName)
+            , m_nameParts()
+            , m_fullNameId()
+            , m_namePartIds()
+            , m_fullNameInfoPtr()
+            , m_findCrossReferences()
+            , m_crossReferences()
+        {
+        }
+    };
+
+    struct NamePartLookupResult
+    {
+        // The name part being looked up
+        std::string m_namePart;
+
+        // The name part ID that is added or looked up from the table
+        size_t m_namePartId;
+
+        // Information struct ptr for the name part
+        NamePartInfo* m_namePartInfoPtr;
+
+        // Specifies whether cross references (full names that match the name part) should be computed.
+        bool m_findCrossReferences;
+
+        // List of all full names that match the given name part.
+        // This field is computed only if m_findCrossReferences is true.
+        std::vector<CrossReference> m_crossReferences;
+
+        explicit NamePartLookupResult(const std::string& namePart)
+            : m_namePart(namePart)
+            , m_namePartId()
+            , m_namePartInfoPtr()
+            , m_findCrossReferences()
+            , m_crossReferences()
+        {
+        }
+    };
+
+    struct NameTable
+    {
+        // All data structures in this class are append-only. The item count
+        // is being used as an incrementing integer key.
+
+    public:
+        // Full name information struct.
+        std::vector<FullNameInfo> m_fullNameInfos;
+
+        // Name part information struct.
+        std::vector<NamePartInfo> m_namePartInfos;
+
+        // key: full name (string)
+        // value: full name ID
+        // .... (index into the vector of m_fullNameInfos)
+        // .... (key into m_fullNameToNamePartIds)
+        // .... (value.second in m_namePartToFullNameIds)
+        std::unordered_map<std::string, size_t> m_fullNameIds;
+
+        // key: name part (string)
+        // value: name part ID
+        // .... (index into the vector of m_namePartInfos)
+        // .... (key into m_namePartToFullNameIds)
+        // .... (value.second in m_fullNameToNamePartIds)
+        std::unordered_map<std::string, size_t> m_namePartIds;
+
+        // key: full name ID
+        // value.first: name part ID
+        // value.second: occurrence position of name part in the full name
+        std::unordered_multimap<size_t, std::pair<size_t, size_t>> m_fullNameToNamePartIds;
+
+        // key: name part ID
+        // value.first: full name ID
+        // value.second: occurrence position of name part in the full name
+        std::unordered_multimap<size_t, std::pair<size_t, size_t>> m_namePartToFullNameIds;
+
+    public:
+        void addOrLookupFullName(FullNameLookupResult& result);
+        void addOrLookupNamePart(NamePartLookupResult& result);
+        FullNameInfo* getFullNameInfo(const std::string& fullName);
+
+    private:
+        // Add or get full name. Does not compute name parts or access them in the table.
+        // Returns the full name ID, and a bool indicating if the full name is new.
+        std::pair<size_t, bool> internal_addOrLookupFullName(const std::string& fullName);
+
+        // Add or get multiple name parts. Saves name part IDs into a vector.
+        void internal_addOrLookupNameParts(const std::vector<std::string>& nameParts, std::vector<size_t>& namePartIds);
+
+        // Add or get name part. Returns namePartId.
+        size_t internal_addOrLookupNamePart(const std::string& namePart);
+
+        // For each name part ID, insert the tuples (full name, name part ID, name part position)
+        // into the cross reference table
+        void internal_addCrossReference(size_t fullNameId, const std::vector<size_t>& namePartIds);
+
+        // Gather pointer for full name info struct.
+        // Note: The pointer is interior to the table vector. The pointers are invalidated
+        // if the table is modified.
+        FullNameInfo* internal_getFullNameInfo(size_t fullNameId);
+
+        // Gather pointers for name part info struct.
+        // Note: The pointers are interior to the table vector. The pointers are invalidated
+        // if the table is modified.
+        NamePartInfo* internal_getNamePartInfo(size_t namePartId);
+
+        void internal_findMatchingNamePartsForFullName(FullNameLookupResult& fullNameResult);
+        void internal_findMatchingFullNamesForNamePart(NamePartLookupResult& result);
     };
 
 public:
@@ -117,35 +239,35 @@ public:
 
     // Add (register) the log tag.
     // Note, passing in nullptr as value is equivalent to unassigning.
-    void assign(const std::string& name, LogTag* ptr);
+    void assign(const std::string& fullName, LogTag* ptr);
 
     // Unassign the log tag. This is equivalent to calling assign with nullptr value.
-    void unassign(const std::string& name);
+    void unassign(const std::string& fullName);
 
     // Retrieve the log tag by exact name.
-    LogTag* get(const std::string& name) const;
+    LogTag* get(const std::string& fullName);
 
     // Changes the log level of the tag having the exact full name.
     void setLevelByFullName(const std::string& fullName, LogLevel level);
 
-    // Changes the log level of the tag matching the first part of the name.
+    // Changes the log level of the tags matching the first part of the name.
     void setLevelByFirstPart(const std::string& firstPart, LogLevel level);
 
-    // Changes the log level of the tag matching any part of the name.
+    // Changes the log level of the tags matching any part of the name.
     void setLevelByAnyPart(const std::string& anyPart, LogLevel level);
 
+    // Changes the log level of the tags with matching name part according
+    // to the specified scope.
+    void setLevelByNamePart(const std::string& namePart, LogLevel level, MatchingScope scope);
+
 private:
-    void populateIndex(InfoIndex& index, const std::string& fullName);
-    void populateIndexFullName(InfoIndex& index);
-    void populateIndexFirstPart(InfoIndex& index);
-    void populateIndexAnyPart(InfoIndex& index, size_t namePartIndex);
-    size_t addOrGetMember(InfoIndex& index, WildcardInfo* wildcardInfoPtr);
-    bool updateIndexLogTagPtr(InfoIndex& index, LogTag* ptr);
-    bool findAndApplyLevelToTag(InfoIndex& index);
-    void setLevelByWildcard(const std::string& namePart, LogLevel level, bool isFirst);
+    bool internal_applyFullNameConfigToTag(FullNameInfo& fullNameInfo);
+    bool internal_applyNamePartConfigToSpecificTag(FullNameLookupResult& fullNameResult);
+    void internal_applyNamePartConfigToMatchingTags(NamePartLookupResult& namePartResult);
 
 private:
     static std::vector<std::string> splitNameParts(const std::string& fullName);
+    static bool internal_isNamePartMatch(MatchingScope scope, size_t matchingPos);
 
 private:
     static constexpr const char* m_globalName = "global";
@@ -153,10 +275,7 @@ private:
 private:
     mutable MutexType m_mutex;
     std::unique_ptr<LogTag> m_globalLogTag;
-    std::unordered_map<std::string, FullNameInfo> m_fullNames;
-    std::unordered_map<std::string, WildcardInfo> m_firstParts;
-    std::unordered_map<std::string, WildcardInfo> m_anyParts;
-    size_t m_nextId;
+    NameTable m_nameTable;
     std::shared_ptr<LogTagConfigParser> m_config;
 };
 

--- a/modules/core/test/test_logtagconfigparser.cpp
+++ b/modules/core/test/test_logtagconfigparser.cpp
@@ -1,0 +1,281 @@
+// This file is part of OpenCV project.
+// It is subject to the license terms in the LICENSE file found in the top-level directory
+// of this distribution and at http://opencv.org/license.html.
+
+#include "test_precomp.hpp"
+#include <opencv2/core/utils/logger.hpp>
+#include "../src/utils/logtagmanager.hpp"
+#include "../src/utils/logtagconfigparser.hpp"
+
+// Because "LogTagConfigParser" isn't exported from "opencv_core", the only way
+// to perform test is to compile the source code into "opencv_test_core".
+// This workaround may cause step debugger breakpoints to work unreliably.
+#if 1
+#include "../src/utils/logtagconfigparser.cpp"
+#endif
+
+using cv::utils::logging::LogTagConfigParser;
+
+namespace opencv_test {
+namespace {
+
+typedef testing::TestWithParam<tuple<std::string, cv::utils::logging::LogLevel>> GlobalShouldSucceedTests;
+
+TEST_P(GlobalShouldSucceedTests, globalCases)
+{
+    const std::string input = get<0>(GetParam());
+    const cv::utils::logging::LogLevel expectedLevel = get<1>(GetParam());
+    LogTagConfigParser parser;
+    parser.parse(input);
+    EXPECT_FALSE(parser.hasMalformed());
+    EXPECT_EQ(parser.getMalformed().size(), 0u) << "Malformed list should be empty";
+    EXPECT_TRUE(parser.getGlobalConfig().isGlobal);
+    EXPECT_EQ(parser.getGlobalConfig().level, expectedLevel);
+    EXPECT_EQ(parser.getFullNameConfigs().size(), 0u) << "Specifying global log level should not emit full names";
+    EXPECT_EQ(parser.getFirstPartConfigs().size(), 0u) << "Specifying global log level should not emit first name part result";
+    EXPECT_EQ(parser.getAnyPartConfigs().size(), 0u) << "Specifying global log level should not emit any name part result";
+}
+
+INSTANTIATE_TEST_CASE_P(Core_LogTagConfigParser, GlobalShouldSucceedTests,
+    testing::Values(
+        // Following test cases omit the name part
+        std::make_tuple("S", cv::utils::logging::LOG_LEVEL_SILENT),
+        std::make_tuple("SILENT", cv::utils::logging::LOG_LEVEL_SILENT),
+        std::make_tuple("F", cv::utils::logging::LOG_LEVEL_FATAL),
+        std::make_tuple("FATAL", cv::utils::logging::LOG_LEVEL_FATAL),
+        std::make_tuple("E", cv::utils::logging::LOG_LEVEL_ERROR),
+        std::make_tuple("ERROR", cv::utils::logging::LOG_LEVEL_ERROR),
+        std::make_tuple("W", cv::utils::logging::LOG_LEVEL_WARNING),
+        std::make_tuple("WARN", cv::utils::logging::LOG_LEVEL_WARNING),
+        std::make_tuple("WARNING", cv::utils::logging::LOG_LEVEL_WARNING),
+        std::make_tuple("I", cv::utils::logging::LOG_LEVEL_INFO),
+        std::make_tuple("INFO", cv::utils::logging::LOG_LEVEL_INFO),
+        std::make_tuple("D", cv::utils::logging::LOG_LEVEL_DEBUG),
+        std::make_tuple("DEBUG", cv::utils::logging::LOG_LEVEL_DEBUG),
+        std::make_tuple("V", cv::utils::logging::LOG_LEVEL_VERBOSE),
+        std::make_tuple("VERBOSE", cv::utils::logging::LOG_LEVEL_VERBOSE),
+        // Following test cases uses a single asterisk as name
+        std::make_tuple("*:S", cv::utils::logging::LOG_LEVEL_SILENT),
+        std::make_tuple("*:SILENT", cv::utils::logging::LOG_LEVEL_SILENT),
+        std::make_tuple("*:V", cv::utils::logging::LOG_LEVEL_VERBOSE),
+        std::make_tuple("*:VERBOSE", cv::utils::logging::LOG_LEVEL_VERBOSE)
+    )
+);
+
+// GlobalShouldSucceedPairedTests, globalNameHandling
+//
+// The following tests use a strategy of performing two tests as a pair, and require the pair
+// to succeed, in order to avoid false negatives due to default settings.
+// The first input string is supposed to set global to SILENT, the second input string VERBOSE.
+
+typedef testing::TestWithParam<tuple<std::string, std::string>> GlobalShouldSucceedPairedTests;
+
+TEST_P(GlobalShouldSucceedPairedTests, globalNameHandling)
+{
+    const auto firstExpected = cv::utils::logging::LOG_LEVEL_SILENT;
+    const auto secondExpected = cv::utils::logging::LOG_LEVEL_VERBOSE;
+    //
+    const std::string firstInput = get<0>(GetParam());
+    LogTagConfigParser firstParser;
+    firstParser.parse(firstInput);
+    ASSERT_FALSE(firstParser.hasMalformed());
+    ASSERT_EQ(firstParser.getMalformed().size(), 0u) << "Malformed list should be empty";
+    ASSERT_TRUE(firstParser.getGlobalConfig().isGlobal);
+    ASSERT_EQ(firstParser.getFullNameConfigs().size(), 0u) << "Specifying global log level should not emit full names";
+    ASSERT_EQ(firstParser.getFirstPartConfigs().size(), 0u) << "Specifying global log level should not emit first name part result";
+    ASSERT_EQ(firstParser.getAnyPartConfigs().size(), 0u) << "Specifying global log level should not emit any name part result";
+    const cv::utils::logging::LogLevel firstActual = firstParser.getGlobalConfig().level;
+    //
+    const std::string secondInput = get<1>(GetParam());
+    LogTagConfigParser secondParser;
+    secondParser.parse(secondInput);
+    ASSERT_FALSE(secondParser.hasMalformed());
+    ASSERT_EQ(secondParser.getMalformed().size(), 0u) << "Malformed list should be empty";
+    ASSERT_TRUE(secondParser.getGlobalConfig().isGlobal);
+    ASSERT_EQ(secondParser.getFullNameConfigs().size(), 0u) << "Specifying global log level should not emit full names";
+    ASSERT_EQ(secondParser.getFirstPartConfigs().size(), 0u) << "Specifying global log level should not emit first name part result";
+    ASSERT_EQ(secondParser.getAnyPartConfigs().size(), 0u) << "Specifying global log level should not emit any name part result";
+    const cv::utils::logging::LogLevel secondActual = secondParser.getGlobalConfig().level;
+    //
+    EXPECT_EQ(firstActual, firstExpected);
+    EXPECT_EQ(secondActual, secondExpected);
+}
+
+// Following test cases uses lowercase "global" as name
+INSTANTIATE_TEST_CASE_P(Core_LogTagConfigParser, GlobalShouldSucceedPairedTests,
+    testing::Values(
+        std::make_tuple("global:S", "global:V"),
+        std::make_tuple("global:SILENT", "global:VERBOSE")
+    )
+);
+
+// In the next few smoke tests, the use of EXPECT versus ASSERT is as follows.
+// Each test will try to read the first element from one of the vector results.
+// Prior to that, the vector need to be ASSERT'ed to have at least one element.
+// All remaining assertions in the test body would use EXPECT instead.
+
+TEST(Core_LogTagConfigParser, FullNameSmokeTest)
+{
+    LogTagConfigParser parser;
+    parser.parse("something:S");
+    EXPECT_FALSE(parser.hasMalformed());
+    EXPECT_EQ(parser.getMalformed().size(), 0u);
+    ASSERT_EQ(parser.getFullNameConfigs().size(), 1u);
+    EXPECT_EQ(parser.getFirstPartConfigs().size(), 0u);
+    EXPECT_EQ(parser.getAnyPartConfigs().size(), 0u);
+    EXPECT_STREQ(parser.getFullNameConfigs().at(0u).namePart.c_str(), "something");
+}
+
+TEST(Core_LogTagConfigParser, FirstPartSmokeTest_NoPeriod)
+{
+    LogTagConfigParser parser;
+    parser.parse("something*:S");
+    EXPECT_FALSE(parser.hasMalformed());
+    EXPECT_EQ(parser.getMalformed().size(), 0u);
+    EXPECT_EQ(parser.getFullNameConfigs().size(), 0u);
+    ASSERT_EQ(parser.getFirstPartConfigs().size(), 1u);
+    EXPECT_EQ(parser.getAnyPartConfigs().size(), 0u);
+    EXPECT_STREQ(parser.getFirstPartConfigs().at(0u).namePart.c_str(), "something");
+}
+
+TEST(Core_LogTagConfigParser, FirstPartSmokeTest_WithPeriod)
+{
+    LogTagConfigParser parser;
+    parser.parse("something.*:S");
+    EXPECT_FALSE(parser.hasMalformed());
+    EXPECT_EQ(parser.getMalformed().size(), 0u);
+    EXPECT_EQ(parser.getFullNameConfigs().size(), 0u);
+    ASSERT_EQ(parser.getFirstPartConfigs().size(), 1u);
+    EXPECT_EQ(parser.getAnyPartConfigs().size(), 0u);
+    EXPECT_STREQ(parser.getFirstPartConfigs().at(0u).namePart.c_str(), "something");
+}
+
+TEST(Core_LogTagConfigParser, AnyPartSmokeTest_PrecedeAsterisk_NoPeriod)
+{
+    LogTagConfigParser parser;
+    parser.parse("*something:S");
+    EXPECT_FALSE(parser.hasMalformed());
+    EXPECT_EQ(parser.getMalformed().size(), 0u);
+    EXPECT_EQ(parser.getFullNameConfigs().size(), 0u);
+    EXPECT_EQ(parser.getFirstPartConfigs().size(), 0u);
+    ASSERT_EQ(parser.getAnyPartConfigs().size(), 1u);
+    EXPECT_STREQ(parser.getAnyPartConfigs().at(0u).namePart.c_str(), "something");
+}
+
+TEST(Core_LogTagConfigParser, AnyPartSmokeTest_PrecedeAsterisk_WithPeriod)
+{
+    LogTagConfigParser parser;
+    parser.parse("*.something:S");
+    EXPECT_FALSE(parser.hasMalformed());
+    EXPECT_EQ(parser.getMalformed().size(), 0u);
+    EXPECT_EQ(parser.getFullNameConfigs().size(), 0u);
+    EXPECT_EQ(parser.getFirstPartConfigs().size(), 0u);
+    ASSERT_EQ(parser.getAnyPartConfigs().size(), 1u);
+    EXPECT_STREQ(parser.getAnyPartConfigs().at(0u).namePart.c_str(), "something");
+}
+
+TEST(Core_LogTagConfigParser, AnyPartSmokeTest_PrecedeFollowAsterisks_NoPeriod)
+{
+    LogTagConfigParser parser;
+    parser.parse("*something*:S");
+    EXPECT_FALSE(parser.hasMalformed());
+    EXPECT_EQ(parser.getMalformed().size(), 0u);
+    EXPECT_EQ(parser.getFullNameConfigs().size(), 0u);
+    EXPECT_EQ(parser.getFirstPartConfigs().size(), 0u);
+    ASSERT_EQ(parser.getAnyPartConfigs().size(), 1u);
+    EXPECT_STREQ(parser.getAnyPartConfigs().at(0u).namePart.c_str(), "something");
+}
+
+TEST(Core_LogTagConfigParser, AnyPartSmokeTest_PrecedeFollowAsterisks_WithPeriod)
+{
+    LogTagConfigParser parser;
+    parser.parse("*.something.*:S");
+    EXPECT_FALSE(parser.hasMalformed());
+    EXPECT_EQ(parser.getMalformed().size(), 0u);
+    EXPECT_EQ(parser.getFullNameConfigs().size(), 0u);
+    EXPECT_EQ(parser.getFirstPartConfigs().size(), 0u);
+    ASSERT_EQ(parser.getAnyPartConfigs().size(), 1u);
+    EXPECT_STREQ(parser.getAnyPartConfigs().at(0u).namePart.c_str(), "something");
+}
+
+TEST(Core_LogTagConfigParser, FullName_EqualSign_ShouldSucceed)
+{
+    LogTagConfigParser parser;
+    parser.parse("something=S");
+    EXPECT_FALSE(parser.hasMalformed());
+    EXPECT_EQ(parser.getMalformed().size(), 0u);
+    ASSERT_EQ(parser.getFullNameConfigs().size(), 1u);
+    EXPECT_EQ(parser.getFirstPartConfigs().size(), 0u);
+    EXPECT_EQ(parser.getAnyPartConfigs().size(), 0u);
+    EXPECT_STREQ(parser.getFullNameConfigs().at(0u).namePart.c_str(), "something");
+}
+
+TEST(Core_LogTagConfigParser, FirstPart_EqualSign_ShouldSucceed)
+{
+    LogTagConfigParser parser;
+    parser.parse("something*=S");
+    EXPECT_FALSE(parser.hasMalformed());
+    EXPECT_EQ(parser.getMalformed().size(), 0u);
+    EXPECT_EQ(parser.getFullNameConfigs().size(), 0u);
+    ASSERT_EQ(parser.getFirstPartConfigs().size(), 1u);
+    EXPECT_EQ(parser.getAnyPartConfigs().size(), 0u);
+    EXPECT_STREQ(parser.getFirstPartConfigs().at(0u).namePart.c_str(), "something");
+}
+
+TEST(Core_LogTagConfigParser, AnyPart_EqualSign_ShouldSucceed)
+{
+    LogTagConfigParser parser;
+    parser.parse("*something*=S");
+    EXPECT_FALSE(parser.hasMalformed());
+    EXPECT_EQ(parser.getMalformed().size(), 0u);
+    EXPECT_EQ(parser.getFullNameConfigs().size(), 0u);
+    EXPECT_EQ(parser.getFirstPartConfigs().size(), 0u);
+    ASSERT_EQ(parser.getAnyPartConfigs().size(), 1u);
+    EXPECT_STREQ(parser.getAnyPartConfigs().at(0u).namePart.c_str(), "something");
+}
+
+TEST(Core_LogTagConfigParser, DuplicateColon_ShouldFail)
+{
+    LogTagConfigParser parser;
+    parser.parse("something::S");
+    EXPECT_TRUE(parser.hasMalformed());
+    EXPECT_EQ(parser.getMalformed().size(), 1u);
+    EXPECT_EQ(parser.getFullNameConfigs().size(), 0u);
+    EXPECT_EQ(parser.getFirstPartConfigs().size(), 0u);
+    EXPECT_EQ(parser.getAnyPartConfigs().size(), 0u);
+}
+
+TEST(Core_LogTagConfigParser, DuplicateEqual_ShouldFail)
+{
+    LogTagConfigParser parser;
+    parser.parse("something==S");
+    EXPECT_TRUE(parser.hasMalformed());
+    EXPECT_EQ(parser.getMalformed().size(), 1u);
+    EXPECT_EQ(parser.getFullNameConfigs().size(), 0u);
+    EXPECT_EQ(parser.getFirstPartConfigs().size(), 0u);
+    EXPECT_EQ(parser.getAnyPartConfigs().size(), 0u);
+}
+
+TEST(Core_LogTagConfigParser, DuplicateColonAndEqual_ShouldFail)
+{
+    LogTagConfigParser parser;
+    parser.parse("something:=S");
+    EXPECT_TRUE(parser.hasMalformed());
+    EXPECT_EQ(parser.getMalformed().size(), 1u);
+    EXPECT_EQ(parser.getFullNameConfigs().size(), 0u);
+    EXPECT_EQ(parser.getFirstPartConfigs().size(), 0u);
+    EXPECT_EQ(parser.getAnyPartConfigs().size(), 0u);
+}
+
+TEST(Core_LogTagConfigParser, DuplicateEqualAndColon_ShouldFail)
+{
+    LogTagConfigParser parser;
+    parser.parse("something=:S");
+    EXPECT_TRUE(parser.hasMalformed());
+    EXPECT_EQ(parser.getMalformed().size(), 1u);
+    EXPECT_EQ(parser.getFullNameConfigs().size(), 0u);
+    EXPECT_EQ(parser.getFirstPartConfigs().size(), 0u);
+    EXPECT_EQ(parser.getAnyPartConfigs().size(), 0u);
+}
+
+}} // namespace

--- a/modules/core/test/test_logtagmanager.cpp
+++ b/modules/core/test/test_logtagmanager.cpp
@@ -36,6 +36,98 @@ static constexpr const LogLevel constTestLevelAltBegin = cv::utils::logging::LOG
 // for test cases where two distinct runtime set values are needed.
 static constexpr const LogLevel constTestLevelAltChanged = cv::utils::logging::LOG_LEVEL_DEBUG;
 
+// Enums for specifying which LogTagManager method to call.
+// Used in parameterized tests.
+enum class ByWhat
+{
+    ByFullName = 0,
+    ByFirstPart = 1,
+    ByAnyPart = 2
+};
+
+std::ostream& operator<< (std::ostream& strm, ByWhat byWhat)
+{
+    switch (byWhat)
+    {
+    case ByWhat::ByFullName:
+        strm << "ByFullName";
+        break;
+    case ByWhat::ByFirstPart:
+        strm << "ByFirstPart";
+        break;
+    case ByWhat::ByAnyPart:
+        strm << "ByAnyPart";
+        break;
+    default:
+        strm << "(invalid ByWhat enum" << (int)byWhat << ")";
+        break;
+    }
+    return strm;
+}
+
+// Enums for describing relative timing.
+// Used in parameterized tests.
+enum class Timing
+{
+    Never = 0,
+    Before = 1,
+    After = 2
+};
+
+std::ostream& operator<< (std::ostream& strm, Timing timing)
+{
+    switch (timing)
+    {
+    case Timing::Never:
+        strm << "Never";
+        break;
+    case Timing::Before:
+        strm << "Before";
+        break;
+    case Timing::After:
+        strm << "After";
+        break;
+    default:
+        strm << "(invalid Timing enum" << (int)timing << ")";
+        break;
+    }
+    return strm;
+}
+
+// Enums for selecting the substrings used in substring confusion tests.
+enum class SubstringType
+{
+    Prefix = 0,
+    Midstring = 1,
+    Suffix = 2,
+    Straddle = 3
+};
+
+std::ostream& operator<< (std::ostream& strm, SubstringType substringType)
+{
+    switch (substringType)
+    {
+    case SubstringType::Prefix:
+        strm << "Prefix";
+        break;
+    case SubstringType::Midstring:
+        strm << "Midstring";
+        break;
+    case SubstringType::Suffix:
+        strm << "Suffix";
+        break;
+    case SubstringType::Straddle:
+        strm << "Straddle";
+        break;
+    default:
+        strm << "(invalid SubstringType enum: " << (int)substringType << ")";
+        break;
+    }
+    return strm;
+}
+
+// A base fixture consisting of the LogTagManager.
+// Note that an instance of LogTagManager contains its own instance of "global" log tag.
 class LogTagManagerTestFixture
     : public ::testing::Test
 {
@@ -53,6 +145,7 @@ public:
     }
 };
 
+// LogTagManagerGlobalSmokeTest verifies that the "global" log tag works as intended.
 class LogTagManagerGlobalSmokeTest
     : public LogTagManagerTestFixture
 {
@@ -114,6 +207,9 @@ TEST_F(LogTagManagerGlobalSmokeTest, DISABLED_AfterCtorCanSetGlobalByAnyPart)
 }
 #endif
 
+// LogTagManagerNonGlobalSmokeTest performs basic smoke tests to verify that
+// a log tag (that is not the "global" log tag) can be assigned, and its
+// log level can be configured.
 class LogTagManagerNonGlobalSmokeTest
     : public LogTagManagerTestFixture
 {
@@ -196,6 +292,154 @@ TEST_F(LogTagManagerNonGlobalSmokeTest, CanSetLevelByAnyPartAfterAssignTag)
     ASSERT_EQ(m_logTagManager.get(m_somethingTagName), &m_something);
     EXPECT_EQ(m_logTagManager.get(m_somethingTagName)->level, constTestLevelChanged);
     EXPECT_NE(m_logTagManager.get(m_somethingTagName)->level, constTestLevelBegin) << "Should not be left unchanged (default value)";
+}
+
+// Non-confusion tests use two or more (non-global) log tags with chosen names to verify
+// that LogTagManager does not accidentally apply log levels to log tags other than the
+// ones intended.
+
+
+// LogTagManagerSubstrNonConfusionSmokeTest are non-confusion tests that focus on
+// substrings. Keep in mind string matching in LogTagManager must be aligned to
+// the period delimiter; substrings are not considered for matching.
+class LogTagManagerSubstrNonConfusionFixture
+    : public LogTagManagerTestFixture
+    , public ::testing::WithParamInterface<std::tuple<SubstringType, bool, Timing, ByWhat>>
+{
+public:
+    struct MyTestParam
+    {
+        const SubstringType detractorNameSelector;
+        const bool initTargetTagWithCall;
+        const Timing whenToAssignDetractorTag;
+        const ByWhat howToSetDetractorLevel;
+        MyTestParam(const std::tuple<SubstringType, bool, Timing, ByWhat>& args)
+            : detractorNameSelector(std::get<0u>(args))
+            , initTargetTagWithCall(std::get<1u>(args))
+            , whenToAssignDetractorTag(std::get<2u>(args))
+            , howToSetDetractorLevel(std::get<3u>(args))
+        {
+        }
+    };
+
+    // The following substrings are all derived from "soursop".
+    // In particular, "ours" is a substring of "soursop".
+protected:
+    LogTag tagSour;
+    LogTag tagSop;
+    LogTag tagSoursop;
+    LogTag tagSourDotSop;
+    LogTag tagOurs;
+
+protected:
+    static constexpr const char* strSour = "sour";
+    static constexpr const char* strSop = "sop";
+    static constexpr const char* strSoursop = "soursop";
+    static constexpr const char* strSourDotSop = "sour.sop";
+    static constexpr const char* strOurs = "ours";
+
+public:
+    LogTagManagerSubstrNonConfusionFixture()
+        : LogTagManagerTestFixture(constTestLevelAltBegin)
+        , tagSour(strSour, constTestLevelBegin)
+        , tagSop(strSop, constTestLevelBegin)
+        , tagSoursop(strSoursop, constTestLevelBegin)
+        , tagSourDotSop(strSourDotSop, constTestLevelBegin)
+        , tagOurs(strOurs, constTestLevelBegin)
+    {
+    }
+
+    const char* selectDetractorName(const MyTestParam& myTestParam)
+    {
+        switch (myTestParam.detractorNameSelector)
+        {
+        case SubstringType::Prefix:
+            return strSour;
+        case SubstringType::Midstring:
+            return strOurs;
+        case SubstringType::Suffix:
+            return strSop;
+        case SubstringType::Straddle:
+            return strSourDotSop;
+        default:
+            throw std::logic_error("LogTagManagerSubstrNonConfusionTest::selectDetractorName");
+        }
+    }
+
+    LogTag& selectDetractorTag(const MyTestParam& myTestParam)
+    {
+        switch (myTestParam.detractorNameSelector)
+        {
+        case SubstringType::Prefix:
+            return tagSour;
+        case SubstringType::Midstring:
+            return tagOurs;
+        case SubstringType::Suffix:
+            return tagSop;
+        case SubstringType::Straddle:
+            return tagSourDotSop;
+        default:
+            throw std::logic_error("LogTagManagerSubstrNonConfusionTest::selectDetractorName");
+        }
+    }
+};
+
+INSTANTIATE_TEST_CASE_P(
+    LogTagManagerSubstrNonConfusionTest,
+    LogTagManagerSubstrNonConfusionFixture,
+    ::testing::Combine(
+        ::testing::Values(SubstringType::Prefix, SubstringType::Midstring, SubstringType::Suffix, SubstringType::Straddle),
+        ::testing::Values(false, true),
+        ::testing::Values(Timing::Never, Timing::Before, Timing::After),
+        ::testing::Values(ByWhat::ByFullName, ByWhat::ByFirstPart, ByWhat::ByAnyPart)
+    )
+);
+
+TEST_P(LogTagManagerSubstrNonConfusionFixture, ParameterizedTestFunc)
+{
+    const auto myTestParam = MyTestParam(GetParam());
+    const char* detractorName = selectDetractorName(myTestParam);
+    LogTag& detractorTag = selectDetractorTag(myTestParam);
+    // Target tag is assigned
+    m_logTagManager.assign(tagSoursop.name, &tagSoursop);
+    // If detractor tag is to be assigned "before"
+    if (myTestParam.whenToAssignDetractorTag == Timing::Before)
+    {
+        m_logTagManager.assign(detractorName, &detractorTag);
+    }
+    // Initialize target tag to constTestLevelChanged
+    if (myTestParam.initTargetTagWithCall)
+    {
+        m_logTagManager.setLevelByFullName(strSoursop, constTestLevelChanged);
+    }
+    else
+    {
+        tagSoursop.level = constTestLevelChanged;
+    }
+    // If detractor tag is to be assigned "after"
+    if (myTestParam.whenToAssignDetractorTag == Timing::After)
+    {
+        m_logTagManager.assign(detractorName, &detractorTag);
+    }
+    // Set the log level using the detractor name
+    switch (myTestParam.howToSetDetractorLevel)
+    {
+    case ByWhat::ByFullName:
+        m_logTagManager.setLevelByFullName(detractorName, constTestLevelAltChanged);
+        break;
+    case ByWhat::ByFirstPart:
+        m_logTagManager.setLevelByFirstPart(detractorName, constTestLevelAltChanged);
+        break;
+    case ByWhat::ByAnyPart:
+        m_logTagManager.setLevelByAnyPart(detractorName, constTestLevelAltChanged);
+        break;
+    default:
+        FAIL() << "Invalid parameterized test value, check test case.";
+    }
+    // Verifies that the target tag is not disturbed by changes made using detractor name
+    ASSERT_EQ(m_logTagManager.get(strSoursop), &tagSoursop);
+    EXPECT_EQ(tagSoursop.level, constTestLevelChanged);
+    EXPECT_NE(tagSoursop.level, constTestLevelAltChanged) << "Should not be changed unless confusion bug exists";
 }
 
 }} // namespace

--- a/modules/core/test/test_logtagmanager.cpp
+++ b/modules/core/test/test_logtagmanager.cpp
@@ -4,14 +4,198 @@
 
 #include "test_precomp.hpp"
 #include <opencv2/core/utils/logger.hpp>
+
 #include "../src/utils/logtagmanager.hpp"
 #include "../src/utils/logtagconfigparser.hpp"
+
+// Because "LogTagManager" isn't exported from "opencv_core", the only way
+// to perform test is to compile the source code into "opencv_test_core".
+// This workaround may cause step debugger breakpoints to work unreliably.
+#if 1
+#include "../src/utils/logtagmanager.cpp"
+#endif
 
 namespace opencv_test {
 namespace {
 
-// STUB
-// to be implemented
-// see "test_logtagconfigparser.cpp"
+using LogLevel = cv::utils::logging::LogLevel;
+using LogTag = cv::utils::logging::LogTag;
+using LogTagManager = cv::utils::logging::LogTagManager;
+
+// Value to initialize log tag constructors
+static constexpr const LogLevel constTestLevelBegin = cv::utils::logging::LOG_LEVEL_SILENT;
+
+// Value to be set as part of test (to simulate runtime changes)
+static constexpr const LogLevel constTestLevelChanged = cv::utils::logging::LOG_LEVEL_VERBOSE;
+
+// An alternate value to initialize log tag constructors,
+// for test cases where two distinct initialization values are needed.
+static constexpr const LogLevel constTestLevelAltBegin = cv::utils::logging::LOG_LEVEL_FATAL;
+
+// An alternate value to be set as part of test (to simulate runtime changes),
+// for test cases where two distinct runtime set values are needed.
+static constexpr const LogLevel constTestLevelAltChanged = cv::utils::logging::LOG_LEVEL_DEBUG;
+
+class LogTagManagerTestFixture
+    : public ::testing::Test
+{
+protected:
+    LogTagManager m_logTagManager;
+
+public:
+    LogTagManagerTestFixture(LogLevel initGlobalLogLevel)
+        : m_logTagManager(initGlobalLogLevel)
+    {
+    }
+
+    ~LogTagManagerTestFixture()
+    {
+    }
+};
+
+class LogTagManagerGlobalSmokeTest
+    : public LogTagManagerTestFixture
+{
+protected:
+    LogTag* m_actualGlobalLogTag;
+
+protected:
+    static constexpr const char* m_globalTagName = "global";
+
+public:
+    LogTagManagerGlobalSmokeTest()
+        : LogTagManagerTestFixture(constTestLevelBegin)
+        , m_actualGlobalLogTag(nullptr)
+    {
+    }
+};
+
+TEST_F(LogTagManagerGlobalSmokeTest, AfterCtorCanGetGlobalWithoutAssign)
+{
+    EXPECT_NE(m_logTagManager.get(m_globalTagName), nullptr);
+}
+
+TEST_F(LogTagManagerGlobalSmokeTest, AfterCtorGetGlobalHasDefaultLevel)
+{
+    auto globalLogTag = m_logTagManager.get(m_globalTagName);
+    ASSERT_NE(globalLogTag, nullptr);
+    EXPECT_EQ(globalLogTag->level, constTestLevelBegin);
+}
+
+TEST_F(LogTagManagerGlobalSmokeTest, AfterCtorCanSetGlobalByFullName)
+{
+    m_logTagManager.setLevelByFullName(m_globalTagName, constTestLevelChanged);
+    auto globalLogTag = m_logTagManager.get(m_globalTagName);
+    ASSERT_NE(globalLogTag, nullptr);
+    EXPECT_EQ(globalLogTag->level, constTestLevelChanged);
+}
+
+#if 0
+// "global" level is not supposed to be settable by name-parts.
+// Therefore this test code is supposed to fail.
+TEST_F(LogTagManagerGlobalSmokeTest, DISABLED_AfterCtorCanSetGlobalByFirstPart)
+{
+    m_logTagManager.setLevelByFirstPart(m_globalTagName, constTestLevelChanged);
+    auto globalLogTag = m_logTagManager.get(m_globalTagName);
+    ASSERT_NE(globalLogTag, nullptr);
+    EXPECT_EQ(globalLogTag->level, constTestLevelChanged);
+}
+#endif
+
+#if 0
+// "global" level is not supposed to be settable by name-parts.
+// Therefore this test code is supposed to fail.
+TEST_F(LogTagManagerGlobalSmokeTest, DISABLED_AfterCtorCanSetGlobalByAnyPart)
+{
+    m_logTagManager.setLevelByAnyPart(m_globalTagName, constTestLevelChanged);
+    auto globalLogTag = m_logTagManager.get(m_globalTagName);
+    ASSERT_NE(globalLogTag, nullptr);
+    EXPECT_EQ(globalLogTag->level, constTestLevelChanged);
+}
+#endif
+
+class LogTagManagerNonGlobalSmokeTest
+    : public LogTagManagerTestFixture
+{
+protected:
+    LogTag m_something;
+
+protected:
+    static constexpr const char* m_somethingTagName = "something";
+
+public:
+    LogTagManagerNonGlobalSmokeTest()
+        : LogTagManagerTestFixture(constTestLevelAltBegin)
+        , m_something(m_somethingTagName, constTestLevelBegin)
+    {
+    }
+};
+
+TEST_F(LogTagManagerNonGlobalSmokeTest, CanAssignTagAndThenGet)
+{
+    m_logTagManager.assign(m_something.name, &m_something);
+    ASSERT_EQ(m_logTagManager.get(m_somethingTagName), &m_something);
+}
+
+TEST_F(LogTagManagerNonGlobalSmokeTest, CanAssignTagAndThenGetAndShouldHaveDefaultLevel)
+{
+    m_logTagManager.assign(m_something.name, &m_something);
+    ASSERT_EQ(m_logTagManager.get(m_somethingTagName), &m_something);
+    EXPECT_EQ(m_logTagManager.get(m_somethingTagName)->level, constTestLevelBegin);
+}
+
+TEST_F(LogTagManagerNonGlobalSmokeTest, CanSetLevelByFullNameBeforeAssignTag)
+{
+    m_logTagManager.setLevelByFullName(m_somethingTagName, constTestLevelChanged);
+    m_logTagManager.assign(m_something.name, &m_something);
+    ASSERT_EQ(m_logTagManager.get(m_somethingTagName), &m_something);
+    EXPECT_EQ(m_logTagManager.get(m_somethingTagName)->level, constTestLevelChanged);
+    EXPECT_NE(m_logTagManager.get(m_somethingTagName)->level, constTestLevelBegin) << "Should not be left unchanged (default value)";
+}
+
+TEST_F(LogTagManagerNonGlobalSmokeTest, CanSetLevelByFirstPartBeforeAssignTag)
+{
+    m_logTagManager.setLevelByFirstPart(m_somethingTagName, constTestLevelChanged);
+    m_logTagManager.assign(m_something.name, &m_something);
+    ASSERT_EQ(m_logTagManager.get(m_somethingTagName), &m_something);
+    EXPECT_EQ(m_logTagManager.get(m_somethingTagName)->level, constTestLevelChanged);
+    EXPECT_NE(m_logTagManager.get(m_somethingTagName)->level, constTestLevelBegin) << "Should not be left unchanged (default value)";
+}
+
+TEST_F(LogTagManagerNonGlobalSmokeTest, CanSetLevelByAnyPartBeforeAssignTag)
+{
+    m_logTagManager.setLevelByAnyPart(m_somethingTagName, constTestLevelChanged);
+    m_logTagManager.assign(m_something.name, &m_something);
+    ASSERT_EQ(m_logTagManager.get(m_somethingTagName), &m_something);
+    EXPECT_EQ(m_logTagManager.get(m_somethingTagName)->level, constTestLevelChanged);
+    EXPECT_NE(m_logTagManager.get(m_somethingTagName)->level, constTestLevelBegin) << "Should not be left unchanged (default value)";
+}
+
+TEST_F(LogTagManagerNonGlobalSmokeTest, CanSetLevelByFullNameAfterAssignTag)
+{
+    m_logTagManager.assign(m_something.name, &m_something);
+    m_logTagManager.setLevelByFullName(m_somethingTagName, constTestLevelChanged);
+    ASSERT_EQ(m_logTagManager.get(m_somethingTagName), &m_something);
+    EXPECT_EQ(m_logTagManager.get(m_somethingTagName)->level, constTestLevelChanged);
+    EXPECT_NE(m_logTagManager.get(m_somethingTagName)->level, constTestLevelBegin) << "Should not be left unchanged (default value)";
+}
+
+TEST_F(LogTagManagerNonGlobalSmokeTest, CanSetLevelByFirstPartAfterAssignTag)
+{
+    m_logTagManager.assign(m_something.name, &m_something);
+    m_logTagManager.setLevelByFirstPart(m_somethingTagName, constTestLevelChanged);
+    ASSERT_EQ(m_logTagManager.get(m_somethingTagName), &m_something);
+    EXPECT_EQ(m_logTagManager.get(m_somethingTagName)->level, constTestLevelChanged);
+    EXPECT_NE(m_logTagManager.get(m_somethingTagName)->level, constTestLevelBegin) << "Should not be left unchanged (default value)";
+}
+
+TEST_F(LogTagManagerNonGlobalSmokeTest, CanSetLevelByAnyPartAfterAssignTag)
+{
+    m_logTagManager.assign(m_something.name, &m_something);
+    m_logTagManager.setLevelByAnyPart(m_somethingTagName, constTestLevelChanged);
+    ASSERT_EQ(m_logTagManager.get(m_somethingTagName), &m_something);
+    EXPECT_EQ(m_logTagManager.get(m_somethingTagName)->level, constTestLevelChanged);
+    EXPECT_NE(m_logTagManager.get(m_somethingTagName)->level, constTestLevelBegin) << "Should not be left unchanged (default value)";
+}
 
 }} // namespace

--- a/modules/core/test/test_logtagmanager.cpp
+++ b/modules/core/test/test_logtagmanager.cpp
@@ -1,0 +1,17 @@
+// This file is part of OpenCV project.
+// It is subject to the license terms in the LICENSE file found in the top-level directory
+// of this distribution and at http://opencv.org/license.html.
+
+#include "test_precomp.hpp"
+#include <opencv2/core/utils/logger.hpp>
+#include "../src/utils/logtagmanager.hpp"
+#include "../src/utils/logtagconfigparser.hpp"
+
+namespace opencv_test {
+namespace {
+
+// STUB
+// to be implemented
+// see "test_logtagconfigparser.cpp"
+
+}} // namespace


### PR DESCRIPTION
```
force_builders=linux,docs
```

### This pullrequest changes

Logging revamp for OpenCV 4.1.x, [OE-11](https://github.com/opencv/opencv/wiki/OE-11.-Logging), issue #11003

This PR replaces #13642 because the old PR was not salvageable.

Please keep all high-level or design-level discussions to the issue thread #11003 to keep the dialogue in one place.

Rebase and squash will happen, therefore keep in mind *code review comments might be lost*. Please put *persistent* comments (specific to the code changes in this PR and which are not high-level design issues) in this PR.

### Status

**Do not merge yet** - the PR contains numerous behavior changes that still need to be ironed out for backward compatibility. Also missing "meaningful" performance tests.

### Checklist 

- [x] Implement line-of-code information in logging output
  - **The logging output format is changed; this is an observable library behavior change.**
- [x] Implement runtime configurable tag-based log level threshold
- [ ] Improve startup-time log level configuration (parsing support for tags and levels)
  - *(startup-time refers to e.g. environment variable ```OPENCV_LOG_LEVEL```)*
- [x] Implement limited wildcard support for startup-time log level config for tags
  - [x] Fixed: should behave correctly whether environment config string is parsed and applied before or after the registration of tags.

### Regarding log config for tags at startup-time 

*(cross reference https://gist.github.com/kinchungwong/37b3eabea7cd7bef3056ca9763816db7)*

- Config string format is similar to **```logcat```**.
  - ```imgproc:D imgcodecs.*:V *:S```
- Actual tag names (in library code) can contain the period (```"."```)
  - *(Undecided)* "imgcodecs.tiff.decoder" or "imgcodecs.decoders.tiff"
- Wildcard support is limited to asterisk (```"*"```) and are **anchored to the "name parts" obtained from splitting tag names at the delimiter, the period (```"."```)**. 
- For example, if a tag name is ```"imgcodecs.tiff.decoder"```, the name parts are ```"imgcodecs"```, ```"tiff"```, and ```"decoder"```. It can be matched by:
  - its exact name, or 
  - its first name part, ```"imgcodecs*"```, by ending with an asterisk, or 
  - a name part that appears in any position, such as ```"*tiff*"``` or ```"*decoder*"```, by surrounding with a pair of asterisks.
- However, it will not match any of the following: ```"img*"```, ```"*code*"```, ```"*codecs"```, ```"*tiff.decoder*"```, ```"*coder"```, because they don't match anything aligned to the period delimiter.
- This is done because, in actual practice, unrestricted substring matching is not as useful for OpenCV.
- Users needing better tag filtering should redirect OpenCV log to a different filtering tool.
