### PR TITLE
Fix Issue_13908

### DIFF
--- a/modules/calib3d/src/calibration.cpp
+++ b/modules/calib3d/src/calibration.cpp
@@ -1585,8 +1585,10 @@ static double cvCalibrateCamera2Internal( const CvMat* objectPoints,
     
     Mat _Ji( maxPoints*2, NINTRINSIC, CV_64FC1, Scalar(0));
     Mat _Je( maxPoints*2, 6, CV_64FC1 );
-    Mat _Jo = (solver.state == CvLevMarq::CALC_J) ? Mat( maxPoints*2, maxPoints*3, CV_64FC1, Scalar(0) ) : Mat();
-    Mat _err( maxPoints*2, 1, CV_64FC1 );
+    Mat _err( maxPoints*2, 1, CV_64FC1 );    
+    
+    const bool allocJo = (solver.state == CvLevMarq::CALC_J) || stdDevs;
+    Mat _Jo = allocJo ? Mat( maxPoints*2, maxPoints*3, CV_64FC1, Scalar(0) ) : Mat();
 
     if(flags & CALIB_USE_LU) {
         solver.solveMethod = DECOMP_LU;

--- a/modules/calib3d/src/calibration.cpp
+++ b/modules/calib3d/src/calibration.cpp
@@ -1728,13 +1728,13 @@ static double cvCalibrateCamera2Internal( const CvMat* objectPoints,
 
             if( calcJ )
             {
-		        CvMat _dpdr = cvMat(_Je.colRange(0, 3));
-				CvMat _dpdt = cvMat(_Je.colRange(3, 6));
-				CvMat _dpdf = cvMat(_Ji.colRange(0, 2));
-				CvMat _dpdc = cvMat(_Ji.colRange(2, 4));
-				CvMat _dpdk = cvMat(_Ji.colRange(4, NINTRINSIC));
-				CvMat _dpdo = _Jo.empty() ? CvMat() : cvMat(_Jo.colRange(0, ni * 3));
-				
+                CvMat _dpdr = cvMat(_Je.colRange(0, 3));
+                CvMat _dpdt = cvMat(_Je.colRange(3, 6));
+                CvMat _dpdf = cvMat(_Ji.colRange(0, 2));
+                CvMat _dpdc = cvMat(_Ji.colRange(2, 4));
+                CvMat _dpdk = cvMat(_Ji.colRange(4, NINTRINSIC));
+                CvMat _dpdo = _Jo.empty() ? CvMat() : cvMat(_Jo.colRange(0, ni * 3));
+
                 cvProjectPoints2Internal( &_Mi, &_ri, &_ti, &matA, &_k, &_mp, &_dpdr, &_dpdt,
                                   (flags & CALIB_FIX_FOCAL_LENGTH) ? nullptr : &_dpdf,
                                   (flags & CALIB_FIX_PRINCIPAL_POINT) ? nullptr : &_dpdc, &_dpdk,

--- a/modules/calib3d/src/calibration.cpp
+++ b/modules/calib3d/src/calibration.cpp
@@ -1582,11 +1582,11 @@ static double cvCalibrateCamera2Internal( const CvMat* objectPoints,
     }
 
     CvLevMarq solver( nparams, 0, termCrit );
-    
+
     Mat _Ji( maxPoints*2, NINTRINSIC, CV_64FC1, Scalar(0));
     Mat _Je( maxPoints*2, 6, CV_64FC1 );
-    Mat _err( maxPoints*2, 1, CV_64FC1 );    
-    
+    Mat _err( maxPoints*2, 1, CV_64FC1 );
+
     const bool allocJo = (solver.state == CvLevMarq::CALC_J) || stdDevs;
     Mat _Jo = allocJo ? Mat( maxPoints*2, maxPoints*3, CV_64FC1, Scalar(0) ) : Mat();
 

--- a/modules/calib3d/src/calibration.cpp
+++ b/modules/calib3d/src/calibration.cpp
@@ -1723,20 +1723,22 @@ static double cvCalibrateCamera2Internal( const CvMat* objectPoints,
 
             _Je.resize(ni*2); _Ji.resize(ni*2); _err.resize(ni*2);
             _Jo.resize(ni*2);
-            CvMat _dpdr = cvMat(_Je.colRange(0, 3));
-            CvMat _dpdt = cvMat(_Je.colRange(3, 6));
-            CvMat _dpdf = cvMat(_Ji.colRange(0, 2));
-            CvMat _dpdc = cvMat(_Ji.colRange(2, 4));
-            CvMat _dpdk = cvMat(_Ji.colRange(4, NINTRINSIC));
-            CvMat _dpdo = _Jo.empty() ? CvMat() : cvMat(_Jo.colRange(0, ni * 3));
+
             CvMat _mp = cvMat(_err.reshape(2, 1));
 
             if( calcJ )
             {
-                 cvProjectPoints2Internal( &_Mi, &_ri, &_ti, &matA, &_k, &_mp, &_dpdr, &_dpdt,
-                                  (flags & CALIB_FIX_FOCAL_LENGTH) ? 0 : &_dpdf,
-                                  (flags & CALIB_FIX_PRINCIPAL_POINT) ? 0 : &_dpdc, &_dpdk,
-                                  (_Jo.empty()) ? NULL: &_dpdo,
+		        CvMat _dpdr = cvMat(_Je.colRange(0, 3));
+				CvMat _dpdt = cvMat(_Je.colRange(3, 6));
+				CvMat _dpdf = cvMat(_Ji.colRange(0, 2));
+				CvMat _dpdc = cvMat(_Ji.colRange(2, 4));
+				CvMat _dpdk = cvMat(_Ji.colRange(4, NINTRINSIC));
+				CvMat _dpdo = _Jo.empty() ? CvMat() : cvMat(_Jo.colRange(0, ni * 3));
+				
+                cvProjectPoints2Internal( &_Mi, &_ri, &_ti, &matA, &_k, &_mp, &_dpdr, &_dpdt,
+                                  (flags & CALIB_FIX_FOCAL_LENGTH) ? nullptr : &_dpdf,
+                                  (flags & CALIB_FIX_PRINCIPAL_POINT) ? nullptr : &_dpdc, &_dpdk,
+                                  (_Jo.empty()) ? nullptr: &_dpdo,
                                   (flags & CALIB_FIX_ASPECT_RATIO) ? aspectRatio : 0);
             }
             else


### PR DESCRIPTION
resolves #13908

fix the regression of cv::calibrateCamera describe in Issue#13908 by allocating the matrix _Jo only when it seems requested