### PR TITLE
G-API: Remove incorrect assert in NV12 to RGB/BGR kernels

### DIFF
--- a/modules/gapi/include/opencv2/gapi/imgproc.hpp
+++ b/modules/gapi/include/opencv2/gapi/imgproc.hpp
@@ -120,8 +120,7 @@ namespace imgproc {
             GAPI_Assert(in_uv.chan == 2);
             GAPI_Assert(in_y.depth == CV_8U);
             GAPI_Assert(in_uv.depth == CV_8U);
-            GAPI_Assert(in_uv.size.width % 2 == 0);
-            GAPI_Assert(in_uv.size.height % 2 == 0);
+            // UV size should be aligned with Y
             GAPI_Assert(in_y.size.width == 2 * in_uv.size.width);
             GAPI_Assert(in_y.size.height == 2 * in_uv.size.height);
             return in_y.withType(CV_8U, 3); // type will be CV_8UC3;
@@ -134,8 +133,7 @@ namespace imgproc {
             GAPI_Assert(in_uv.chan == 2);
             GAPI_Assert(in_y.depth == CV_8U);
             GAPI_Assert(in_uv.depth == CV_8U);
-            GAPI_Assert(in_uv.size.width % 2 == 0);
-            GAPI_Assert(in_uv.size.height % 2 == 0);
+            // UV size should be aligned with Y
             GAPI_Assert(in_y.size.width == 2 * in_uv.size.width);
             GAPI_Assert(in_y.size.height == 2 * in_uv.size.height);
             return in_y.withType(CV_8U, 3); // type will be CV_8UC3;


### PR DESCRIPTION
This pullrequest removes incorrect asserts in NV12 to RGB/BGR color conversion kernels and add a little documentation on other asserts
