### PR TITLE
Add division operators for Matx.

### DIFF
--- a/modules/core/include/opencv2/core/matx.hpp
+++ b/modules/core/include/opencv2/core/matx.hpp
@@ -1276,18 +1276,10 @@ Matx<_Tp, m, n> operator * (double alpha, const Matx<_Tp, m, n>& a)
 }
 
 template<typename _Tp, int m, int n> static inline
-Matx<_Tp, m, n>& operator /= (Matx<_Tp, m, n>& a, int alpha)
-{
-    for( int i = 0; i < m*n; i++ )
-        a.val[i] = saturate_cast<_Tp>(a.val[i] / alpha);
-    return a;
-}
-
-template<typename _Tp, int m, int n> static inline
 Matx<_Tp, m, n>& operator /= (Matx<_Tp, m, n>& a, float alpha)
 {
     for( int i = 0; i < m*n; i++ )
-        a.val[i] = saturate_cast<_Tp>(a.val[i] / alpha);
+        a.val[i] = a.val[i] / alpha;
     return a;
 }
 
@@ -1295,14 +1287,8 @@ template<typename _Tp, int m, int n> static inline
 Matx<_Tp, m, n>& operator /= (Matx<_Tp, m, n>& a, double alpha)
 {
     for( int i = 0; i < m*n; i++ )
-        a.val[i] = saturate_cast<_Tp>(a.val[i] / alpha);
+        a.val[i] = a.val[i] / alpha;
     return a;
-}
-
-template<typename _Tp, int m, int n> static inline
-Matx<_Tp, m, n> operator / (const Matx<_Tp, m, n>& a, int alpha)
-{
-    return Matx<_Tp, m, n>(a, 1./alpha, Matx_ScaleOp());
 }
 
 template<typename _Tp, int m, int n> static inline

--- a/modules/core/include/opencv2/core/matx.hpp
+++ b/modules/core/include/opencv2/core/matx.hpp
@@ -1276,6 +1276,48 @@ Matx<_Tp, m, n> operator * (double alpha, const Matx<_Tp, m, n>& a)
 }
 
 template<typename _Tp, int m, int n> static inline
+Matx<_Tp, m, n>& operator /= (Matx<_Tp, m, n>& a, int alpha)
+{
+    for( int i = 0; i < m*n; i++ )
+        a.val[i] = saturate_cast<_Tp>(a.val[i] / alpha);
+    return a;
+}
+
+template<typename _Tp, int m, int n> static inline
+Matx<_Tp, m, n>& operator /= (Matx<_Tp, m, n>& a, float alpha)
+{
+    for( int i = 0; i < m*n; i++ )
+        a.val[i] = saturate_cast<_Tp>(a.val[i] / alpha);
+    return a;
+}
+
+template<typename _Tp, int m, int n> static inline
+Matx<_Tp, m, n>& operator /= (Matx<_Tp, m, n>& a, double alpha)
+{
+    for( int i = 0; i < m*n; i++ )
+        a.val[i] = saturate_cast<_Tp>(a.val[i] / alpha);
+    return a;
+}
+
+template<typename _Tp, int m, int n> static inline
+Matx<_Tp, m, n> operator / (const Matx<_Tp, m, n>& a, int alpha)
+{
+    return Matx<_Tp, m, n>(a, 1./alpha, Matx_ScaleOp());
+}
+
+template<typename _Tp, int m, int n> static inline
+Matx<_Tp, m, n> operator / (const Matx<_Tp, m, n>& a, float alpha)
+{
+    return Matx<_Tp, m, n>(a, 1.f/alpha, Matx_ScaleOp());
+}
+
+template<typename _Tp, int m, int n> static inline
+Matx<_Tp, m, n> operator / (const Matx<_Tp, m, n>& a, double alpha)
+{
+    return Matx<_Tp, m, n>(a, 1./alpha, Matx_ScaleOp());
+}
+
+template<typename _Tp, int m, int n> static inline
 Matx<_Tp, m, n> operator - (const Matx<_Tp, m, n>& a)
 {
     return Matx<_Tp, m, n>(a, -1, Matx_ScaleOp());

--- a/modules/core/test/test_operations.cpp
+++ b/modules/core/test/test_operations.cpp
@@ -69,6 +69,8 @@ protected:
     bool TestVec();
     bool TestMatxMultiplication();
     bool TestMatxElementwiseDivison();
+    bool TestDivisionByValue();
+    bool TestInplaceDivisionByValue();
     bool TestMatMatxCastSum();
     bool TestSubMatAccess();
     bool TestExp();
@@ -976,6 +978,50 @@ bool CV_OperationsTest::TestMatxElementwiseDivison()
     return true;
 }
 
+bool CV_OperationsTest::TestDivisionByValue()
+{
+    try
+    {
+        Matx22f mat(2, 4, 6, 8);
+        float alpha = 2.f;
+
+        Matx22f res = mat / alpha;
+
+        if(res(0, 0) != 1.0) throw test_excep();
+        if(res(0, 1) != 2.0) throw test_excep();
+        if(res(1, 0) != 3.0) throw test_excep();
+        if(res(1, 1) != 4.0) throw test_excep();
+    }
+    catch(const test_excep&)
+    {
+        ts->set_failed_test_info(cvtest::TS::FAIL_INVALID_OUTPUT);
+        return false;
+    }
+    return true;
+}
+
+
+bool CV_OperationsTest::TestInplaceDivisionByValue()
+{
+    try
+    {
+        Matx22f mat(2, 4, 6, 8);
+        float alpha = 2.f;
+
+        mat /= alpha;
+
+        if(mat(0, 0) != 1.0) throw test_excep();
+        if(mat(0, 1) != 2.0) throw test_excep();
+        if(mat(1, 0) != 3.0) throw test_excep();
+        if(mat(1, 1) != 4.0) throw test_excep();
+    }
+    catch(const test_excep&)
+    {
+        ts->set_failed_test_info(cvtest::TS::FAIL_INVALID_OUTPUT);
+        return false;
+    }
+    return true;
+}
 
 bool CV_OperationsTest::TestVec()
 {
@@ -1202,6 +1248,12 @@ void CV_OperationsTest::run( int /* start_from */)
         return;
 
     if (!TestMatxElementwiseDivison())
+        return;
+
+    if (!TestDivisionByValue())
+        return;
+
+    if (!TestInplaceDivisionByValue())
         return;
 
     if (!TestMatMatxCastSum())


### PR DESCRIPTION
Add the following operations for `Matx`:

<cut/>

```
    {
        Matx31d P1(1, 2, 3);
        P1 /= 2;
        std::cout << "P1: " << P1.t() << std::endl;
    }
    {
        Matx31d P1(1, 2, 3);
        P1 /= 2.0f;
        std::cout << "P1: " << P1.t() << std::endl;
    }
    {
        Matx31d P1(1, 2, 3);
        P1 /= 2.0;
        std::cout << "P1: " << P1.t() << std::endl;
    }
    {
        Matx31d P1(1, 2, 3);
        P1 = P1 / 2;
        std::cout << "P1: " << P1.t() << std::endl;
    }
    {
        Matx31d P1(1, 2, 3);
        P1 = P1 / 2.0f;
        std::cout << "P1: " << P1.t() << std::endl;
    }
    {
        Matx31d P1(1, 2, 3);
        P1 = P1 / 2.0;
        std::cout << "P1: " << P1.t() << std::endl;
    }
    {
        Matx31d P1(1, 2, 3);
        std::cout << "P1: " << (P1 / 2).t() << std::endl;
    }
    {
        Matx31d P1(1, 2, 3);
        std::cout << "P1: " << (P1 / 2.0f).t() << std::endl;
    }
    {
        Matx31d P1(1, 2, 3);
        std::cout << "P1: " << (P1 / 2.0).t() << std::endl;
    }
```

Output:

```
P1: [0.5, 1, 1.5]
P1: [0.5, 1, 1.5]
P1: [0.5, 1, 1.5]
P1: [0.5, 1, 1.5]
P1: [0.5, 1, 1.5]
P1: [0.5, 1, 1.5]
P1: [0.5, 1, 1.5]
P1: [0.5, 1, 1.5]
P1: [0.5, 1, 1.5]
```

---

TODO:
- [ ] Add unit tests (point me to the file where I can add the corresponding tests)
