### PR TITLE
G-API: Modifies standalone G-API cmake for testing it properly

### DIFF
--- a/modules/gapi/CMakeLists.txt
+++ b/modules/gapi/CMakeLists.txt
@@ -1,6 +1,7 @@
 # FIXME: Rework standalone build in more generic maner
 # (Restructure directories, add common pass, etc)
 if (NOT DEFINED OPENCV_INITIAL_PASS)
+    cmake_minimum_required(VERSION 3.3)
     include("cmake/standalone.cmake")
     return()
 endif()

--- a/modules/gapi/cmake/standalone.cmake
+++ b/modules/gapi/cmake/standalone.cmake
@@ -1,3 +1,7 @@
+if("${CMAKE_BUILD_TYPE}" STREQUAL "")
+  set(CMAKE_BUILD_TYPE "Release")
+endif()
+
 if (NOT TARGET ade )
   find_package(ade 0.1.0 REQUIRED)
 endif()
@@ -23,12 +27,17 @@ target_include_directories(${FLUID_TARGET}
   PUBLIC          $<BUILD_INTERFACE:${FLUID_ROOT}/include>
   PRIVATE         ${FLUID_ROOT}/src)
 
-target_compile_definitions(${FLUID_TARGET} PUBLIC -DGAPI_STANDALONE
+target_compile_definitions(${FLUID_TARGET} PUBLIC GAPI_STANDALONE
 # This preprocessor definition resolves symbol clash when
 # standalone fluid meets gapi ocv module in one application
                                            PUBLIC cv=fluidcv)
 
 set_target_properties(${FLUID_TARGET} PROPERTIES POSITION_INDEPENDENT_CODE True)
 set_property(TARGET ${FLUID_TARGET} PROPERTY CXX_STANDARD 11)
+
+if(MSVC)
+  target_compile_options(${FLUID_TARGET} PUBLIC "/wd4251")
+  target_compile_definitions(${FLUID_TARGET} PRIVATE _CRT_SECURE_NO_DEPRECATE)
+endif()
 
 target_link_libraries(${FLUID_TARGET} PRIVATE ade)


### PR DESCRIPTION
This pullrequest modifies standalone G-API cmake for proper testing standalone build

If the project uses MSVC some warnings occurs:
1) _CRT_SECURE_NO_DEPRECATE suppress a warning about "unsafe" function for which Microsoft has "safe" version. In our situation that function calls correctly.
2) Also if we export G-API (which has some non-exportable STL containers) on Windows we need to suppress 4251 warning (as there is no another robust solution).

```
build_gapi_standalone:Linux x64=ade-0.1.1d
build_gapi_standalone:Win64=ade-0.1.1d
build_gapi_standalone:Mac=ade-0.1.1d
build_gapi_standalone:Linux x64 Debug=ade-0.1.1d
```
