### PR TITLE
core, stitching: revise syntax to support Visual C++ 2013

### DIFF
--- a/modules/core/src/persistence_json.cpp
+++ b/modules/core/src/persistence_json.cpp
@@ -72,7 +72,7 @@ public:
         }
 
         char* ptr = fs->bufferPtr();
-        if( ptr > fs->bufferStart() + current_struct.indent && !FileNode::FileNode::isEmptyCollection(struct_flags) )
+        if( ptr > fs->bufferStart() + current_struct.indent && !FileNode::isEmptyCollection(struct_flags) )
             *ptr++ = ' ';
         *ptr++ = FileNode::isMap(struct_flags) ? '}' : ']';
         fs->setBufferPtr(ptr);
@@ -171,7 +171,7 @@ public:
         {
             int new_offset;
             ptr = fs->bufferPtr();
-            if( !FileNode::FileNode::isEmptyCollection(struct_flags) )
+            if( !FileNode::isEmptyCollection(struct_flags) )
                 *ptr++ = ',';
             new_offset = static_cast<int>(ptr - fs->bufferStart() + key_len + data_len);
             if( new_offset > fs->wrapMargin() && new_offset - current_struct.indent > 10 )
@@ -184,7 +184,7 @@ public:
         }
         else
         {
-            if ( !FileNode::FileNode::isEmptyCollection(struct_flags) )
+            if ( !FileNode::isEmptyCollection(struct_flags) )
             {
                 ptr = fs->bufferPtr();
                 *ptr++ = ',';

--- a/modules/stitching/include/opencv2/stitching.hpp
+++ b/modules/stitching/include/opencv2/stitching.hpp
@@ -142,7 +142,11 @@ public:
      * When setting a resolution for stitching, this values is a placeholder
      * for preserving the original resolution.
      */
-    static CV_CONSTEXPR double ORIG_RESOL;
+#if __cplusplus >= 201103L || (defined(_MSC_VER) && _MSC_VER >= 1900/*MSVS 2015*/)
+    static CV_CONSTEXPR double ORIG_RESOL = -1.0;
+#else
+    static CV_CONSTEXPR double ORIG_RESOL; // Initialized in stitcher.cpp
+#endif
 
     enum Status
     {

--- a/modules/stitching/include/opencv2/stitching.hpp
+++ b/modules/stitching/include/opencv2/stitching.hpp
@@ -143,9 +143,10 @@ public:
      * for preserving the original resolution.
      */
 #if __cplusplus >= 201103L || (defined(_MSC_VER) && _MSC_VER >= 1900/*MSVS 2015*/)
-    static CV_CONSTEXPR double ORIG_RESOL = -1.0;
+    static constexpr double ORIG_RESOL = -1.0;
 #else
-    static CV_CONSTEXPR double ORIG_RESOL; // Initialized in stitcher.cpp
+    // support MSVS 2013
+    static const double ORIG_RESOL; // Initialized in stitcher.cpp
 #endif
 
     enum Status

--- a/modules/stitching/include/opencv2/stitching.hpp
+++ b/modules/stitching/include/opencv2/stitching.hpp
@@ -142,7 +142,7 @@ public:
      * When setting a resolution for stitching, this values is a placeholder
      * for preserving the original resolution.
      */
-    static constexpr const double ORIG_RESOL = -1.0;
+    static CV_CONSTEXPR double ORIG_RESOL;
 
     enum Status
     {

--- a/modules/stitching/src/stitcher.cpp
+++ b/modules/stitching/src/stitcher.cpp
@@ -44,6 +44,8 @@
 
 namespace cv {
 
+CV_CONSTEXPR double Stitcher::ORIG_RESOL = -1.0;
+
 Ptr<Stitcher> Stitcher::create(Mode mode)
 {
     Ptr<Stitcher> stitcher = makePtr<Stitcher>();

--- a/modules/stitching/src/stitcher.cpp
+++ b/modules/stitching/src/stitcher.cpp
@@ -47,7 +47,7 @@ namespace cv {
 #if __cplusplus >= 201103L || (defined(_MSC_VER) && _MSC_VER >= 1900/*MSVS 2015*/)
 // Stitcher::ORIG_RESOL is initialized in stitching.hpp.
 #else
-CV_CONSTEXPR double Stitcher::ORIG_RESOL = -1.0;
+const double Stitcher::ORIG_RESOL = -1.0;
 #endif
 
 Ptr<Stitcher> Stitcher::create(Mode mode)

--- a/modules/stitching/src/stitcher.cpp
+++ b/modules/stitching/src/stitcher.cpp
@@ -44,7 +44,11 @@
 
 namespace cv {
 
+#if __cplusplus >= 201103L || (defined(_MSC_VER) && _MSC_VER >= 1900/*MSVS 2015*/)
+// Stitcher::ORIG_RESOL is initialized in stitching.hpp.
+#else
 CV_CONSTEXPR double Stitcher::ORIG_RESOL = -1.0;
+#endif
 
 Ptr<Stitcher> Stitcher::create(Mode mode)
 {


### PR DESCRIPTION
This pull request makes minor revisions to syntax in the core and stitching modules to improve support for Visual C++ 2013.

I am testing with a configuration similar to the following:

```
CALL C:\TBB\bin\tbbvars.bat ia32 vs2013
cmake -DCMAKE_BUILD_TYPE=RELEASE ^
      -DWITH_OPENGL=ON ^
      -DWITH_TBB=ON ^
      -DOPENCV_SKIP_PYTHON_LOADER=ON ^
      -DPYTHON2_LIBRARY=C:/Python27/libs/python27.lib ^
      -DPYTHON2_INCLUDE_DIR=C:/Python27/include ^
      -DWITH_ADE=OFF ^
      -DWITH_QUIRC=OFF ^
      -G "Visual Studio 12 2013" ^
      Z:/SDKs/OpenCV/fork
```