### PR TITLE
cmake: +opencv_videoio_plugins virtual target

### DIFF
--- a/cmake/OpenCVModule.cmake
+++ b/cmake/OpenCVModule.cmake
@@ -1152,6 +1152,10 @@ function(ocv_add_perf_tests)
       ocv_target_link_libraries(${the_target} LINK_PRIVATE ${perf_deps} ${OPENCV_MODULE_${the_module}_DEPS} ${OPENCV_LINKER_LIBS} ${OPENCV_PERF_${the_module}_DEPS})
       add_dependencies(opencv_perf_tests ${the_target})
 
+      if(TARGET opencv_videoio_plugins)
+        add_dependencies(${the_target} opencv_videoio_plugins)
+      endif()
+
       if(HAVE_HPX)
         message("Linking HPX to Perf test of module ${name}")
         ocv_target_link_libraries(${the_target} LINK_PRIVATE "${HPX_LIBRARIES}")
@@ -1242,6 +1246,10 @@ function(ocv_add_accuracy_tests)
       ocv_target_link_libraries(${the_target} LINK_PRIVATE ${test_deps} ${OPENCV_MODULE_${the_module}_DEPS} ${OPENCV_LINKER_LIBS} ${OPENCV_TEST_${the_module}_DEPS})
       add_dependencies(opencv_tests ${the_target})
 
+      if(TARGET opencv_videoio_plugins)
+        add_dependencies(${the_target} opencv_videoio_plugins)
+      endif()
+
       if(HAVE_HPX)
         message("Linking HPX to Perf test of module ${name}")
         ocv_target_link_libraries(${the_target} LINK_PRIVATE "${HPX_LIBRARIES}")
@@ -1323,6 +1331,10 @@ function(ocv_add_samples)
           add_dependencies(opencv_samples ${parent_target})
         endif()
         add_dependencies(${parent_target} ${the_target})
+
+        if(TARGET opencv_videoio_plugins)
+          add_dependencies(${the_target} opencv_videoio_plugins)
+        endif()
 
         if(WIN32)
           install(TARGETS ${the_target} RUNTIME DESTINATION "samples/${module_id}" COMPONENT samples)

--- a/modules/videoio/CMakeLists.txt
+++ b/modules/videoio/CMakeLists.txt
@@ -3,6 +3,13 @@ set(VIDEOIO_ENABLE_PLUGINS "ON" CACHE BOOL "Allow building videoio plugin suppor
 set(VIDEOIO_ENABLE_STRICT_PLUGIN_CHECK "ON" CACHE BOOL "Make sure OpenCV version is the same in plugin and host code")
 mark_as_advanced(VIDEOIO_PLUGIN_LIST VIDEOIO_ENABLE_PLUGINS VIDEOIO_ENABLE_STRICT_PLUGIN_CHECK)
 
+string(REPLACE "," ";" VIDEOIO_PLUGIN_LIST "${VIDEOIO_PLUGIN_LIST}")  # support comma-separated list (,) too
+
+# Make virtual opencv_videoio_plugins target
+if(NOT TARGET opencv_videoio_plugins)
+  add_custom_target(opencv_videoio_plugins ALL)
+endif()
+
 ocv_add_module(videoio opencv_imgproc opencv_imgcodecs WRAP java python)
 
 set(videoio_hdrs ${CMAKE_CURRENT_LIST_DIR}/src/precomp.hpp)

--- a/modules/videoio/cmake/plugin.cmake
+++ b/modules/videoio/cmake/plugin.cmake
@@ -3,12 +3,16 @@
 
 function(ocv_create_builtin_videoio_plugin name target videoio_src_file)
 
+  ocv_debug_message("ocv_create_builtin_videoio_plugin(${ARGV})")
+
   if(NOT TARGET ${target})
     message(FATAL_ERROR "${target} does not exist!")
   endif()
   if(NOT OpenCV_SOURCE_DIR)
     message(FATAL_ERROR "OpenCV_SOURCE_DIR must be set to build the plugin!")
   endif()
+
+  message(STATUS "Video I/O: add builtin plugin '${name}'")
 
   add_library(${name} MODULE
     "${CMAKE_CURRENT_LIST_DIR}/src/${videoio_src_file}"
@@ -27,6 +31,8 @@ function(ocv_create_builtin_videoio_plugin name target videoio_src_file)
     CXX_VISIBILITY_PRESET hidden
   )
   install(TARGETS ${name} LIBRARY DESTINATION ${OPENCV_LIB_INSTALL_PATH} COMPONENT plugins OPTIONAL)
+
+  add_dependencies(opencv_videoio_plugins ${name})
 
 endfunction()
 


### PR DESCRIPTION
- support comma-separated list in VIDEOIO_PLUGIN_LIST
- opencv tests/samples depend on plugins virtual target