### PR TITLE
Make use of explicit output shape for the de-convolution layer.

### DIFF
--- a/modules/dnn/test/test_onnx_importer.cpp
+++ b/modules/dnn/test/test_onnx_importer.cpp
@@ -73,6 +73,7 @@ TEST_P(Test_ONNX_layers, Deconvolution)
     testONNXModels("deconvolution");
     testONNXModels("two_deconvolution");
     testONNXModels("deconvolution_group");
+    testONNXModels("deconvolution_output_shape");
 }
 
 TEST_P(Test_ONNX_layers, Dropout)


### PR DESCRIPTION
**Merge with extra**: https://github.com/opencv/opencv_extra/pull/582

This is relevant to cases where the net is loaded from an ONNX model
containing ConvTranspose layers, which may include the output_shape
attribute.

c.f. https://github.com/onnx/onnx/blob/master/docs/Operators.md#ConvTranspose

```
allow_multiple_commits=1
```