### PR TITLE
fix android lint error in BaseLoaderCallback (LongLogTag)

### DIFF
--- a/modules/java/generator/android/java/org/opencv/android/BaseLoaderCallback.java
+++ b/modules/java/generator/android/java/org/opencv/android/BaseLoaderCallback.java
@@ -137,5 +137,5 @@ public abstract class BaseLoaderCallback implements LoaderCallbackInterface {
     }
 
     protected Context mAppContext;
-    private final static String TAG = "OpenCVLoader/BaseLoaderCallback";
+    private final static String TAG = "BaseLoaderCallback";
 }

--- a/modules/java/generator/android/java/org/opencv/android/BaseLoaderCallback.java
+++ b/modules/java/generator/android/java/org/opencv/android/BaseLoaderCallback.java
@@ -137,5 +137,5 @@ public abstract class BaseLoaderCallback implements LoaderCallbackInterface {
     }
 
     protected Context mAppContext;
-    private final static String TAG = "BaseLoaderCallback";
+    private final static String TAG = "OCV/BaseLoaderCallback";
 }


### PR DESCRIPTION
### This pullrequest changes

Shortens the hard coded log tag of BaseLoaderCallback.java by a few characters to prevent this specific android lint error.

> BaseLoaderCallback.java:31: Error: The logging tag can be at most 23 characters, was 31 (OpenCVLoader/BaseLoaderCallback) [LongLogTag]
> Log.e(TAG, "Package installation failed!");
