### PR TITLE
Add Android SDK debug build flag

### DIFF
--- a/modules/dnn/misc/java/src/cpp/dnn_converters.cpp
+++ b/modules/dnn/misc/java/src/cpp/dnn_converters.cpp
@@ -6,7 +6,7 @@
 
 #include "dnn_converters.hpp"
 
-#define LOG_TAG "DNN"
+#define LOG_TAG "org.opencv.dnn"
 
 void Mat_to_MatShape(cv::Mat& mat, MatShape& matshape)
 {

--- a/modules/dnn/misc/java/src/cpp/dnn_converters.cpp
+++ b/modules/dnn/misc/java/src/cpp/dnn_converters.cpp
@@ -6,6 +6,7 @@
 
 #include "dnn_converters.hpp"
 
+#define LOG_TAG "DNN"
 
 void Mat_to_MatShape(cv::Mat& mat, MatShape& matshape)
 {

--- a/modules/java/android_sdk/android_gradle_lib/build.gradle
+++ b/modules/java/android_sdk/android_gradle_lib/build.gradle
@@ -10,6 +10,11 @@ android {
     }
 
     buildTypes {
+        debug {
+            packagingOptions{
+                doNotStrip '*.so'
+            }
+        }
         release {
             minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.txt'


### PR DESCRIPTION
<!-- Please use this line to close one or multiple issues when this pullrequest gets merged
You can add another line right under the first one:
resolves #14010
-->

### This pullrequest adds a flag "-debug" to platform/android/build_sdk.py which results in debuggable output binaries.

* add build flag "--debug"
* when flag is set then
  * set CMake build type to Debug
  * set CMake build flag BUILD_WITH_DEBUG_INFO to ON
  * invokes ninja with target "install" instead of "install/strip"
* suppresses stripping of debug information in the SDK gradle build
* fixes a bug in the DNN Java wrapper (missing LOG_TAG define)

