### PR TITLE
fix segfault when CONVERT_RGB is disabled with V4L backend

### DIFF
--- a/modules/videoio/src/cap_v4l.cpp
+++ b/modules/videoio/src/cap_v4l.cpp
@@ -1803,9 +1803,11 @@ bool CvCaptureCAM_V4L::setProperty( int property_id, double _value )
         if (bool(value)) {
             convert_rgb = convertableToRgb();
             return convert_rgb;
+        }else{
+            convert_rgb = false;
+            releaseFrame();
+            return true;
         }
-        convert_rgb = false;
-        return true;
     case cv::CAP_PROP_FOURCC:
     {
         if (palette == static_cast<__u32>(value))


### PR DESCRIPTION
resolves https://github.com/opencv/opencv/issues/13697

### This pullrequest changes

Fixes a bug where CAP_V4L would segfault after releasing a capture device. The error seemed to be caused by a frame not being released properly when CONVERT_RGB is disabled. Possibly it was marked as allocated when it wasn't, and then the segfault occurs when the destructor gets called.

I've tested switching between modes (before releasing the camera) and it works without any errors.