### PR TITLE
Fix bug in test_tiff.cpp

### DIFF
--- a/modules/imgcodecs/test/test_tiff.cpp
+++ b/modules/imgcodecs/test/test_tiff.cpp
@@ -76,7 +76,7 @@ TEST(Imgcodecs_Tiff, write_read_16bit_big_little_endian)
         // Write sample TIFF file
         FILE* fp = fopen(filename.c_str(), "wb");
         ASSERT_TRUE(fp != NULL);
-        ASSERT_EQ((size_t)1, fwrite(tiff_sample_data, 86, 1, fp));
+        ASSERT_EQ((size_t)1, fwrite(tiff_sample_data[i], 86, 1, fp));
         fclose(fp);
 
         Mat img = imread(filename, IMREAD_UNCHANGED);


### PR DESCRIPTION


<!-- Please use this line to close one or multiple issues when this pullrequest gets merged
You can add another line right under the first one:
resolves #1234
resolves #1235
-->

### This pullrequest changes

<!-- Please describe what your pullrequest is changing -->

Fixes a bug in which the big endian data in the `tiff_sample_data` array was never being tested.  This could be observed by e.g. changing the 9th byte in the big endian data from `0xde` to something that should fail the test, e.g. `0xdd`, and the test would still pass even though it should fail.
