### PR TITLE
Changed eps checking condition

### DIFF
--- a/modules/ml/src/ann_mlp.cpp
+++ b/modules/ml/src/ann_mlp.cpp
@@ -971,7 +971,7 @@ public:
         int count = inputs.rows;
 
         int iter = -1, max_iter = termCrit.maxCount*count;
-        double epsilon = termCrit.epsilon*count;
+        double epsilon = (termCrit.type & CV_TERMCRIT_EPS) ? termCrit.epsilon*count : 0;
 
         int l_count = layer_count();
         int ivcount = layer_sizes[0];


### PR DESCRIPTION
resolves #13946 

Changed the epsilon assigning condition. Initially, epsilon was taking FLOAT_MIN value in case of only COUNT condition, however according to the relevant issue, epsilon checking shouldn't happen.     
