### PR TITLE
3rdparty: fix libtiff build

### DIFF
--- a/3rdparty/libtiff/tif_config.h.cmake.in
+++ b/3rdparty/libtiff/tif_config.h.cmake.in
@@ -216,7 +216,7 @@
 #endif
 
 /* Number of bits in a file offset, on hosts where this is settable. */
-#define _FILE_OFFSET_BITS @FILE_OFFSET_BITS@
+//disabled for OpenCV CMakeLists.txt: #define _FILE_OFFSET_BITS @FILE_OFFSET_BITS@
 
 /* Define to `__inline__' or `__inline' if that's what the C compiler
    calls it, or to nothing if 'inline' is not supported under any name.  */


### PR DESCRIPTION
Keep `_FILE_OFFSET_BITS` undefined in Android builds.

relates #13808 

<cut/>

Error message:
```
In file included from /opt/android/android-ndk-r16b/sysroot/usr/include/fcntl.h:32:0,
                 from /home/alalek/projects/opencv/dev/3rdparty/libtiff/tiffiop.h:34,
                 from /home/alalek/projects/opencv/dev/3rdparty/libtiff/tif_aux.c:30:
/opt/android/android-ndk-r16b/sysroot/usr/include/sys/cdefs.h:217:75: error: operator '&&' has no right operand
 #if !defined(__LP64__) && defined(_FILE_OFFSET_BITS) && _FILE_OFFSET_BITS == 64
                                                                           ^
```