### PR TITLE
Remove fullscreen android:theme from samples where it breaks the menu

### DIFF
--- a/samples/android/15-puzzle/AndroidManifest.xml
+++ b/samples/android/15-puzzle/AndroidManifest.xml
@@ -8,8 +8,7 @@
 
     <application
         android:icon="@drawable/icon"
-        android:label="@string/app_name"
-        android:theme="@android:style/Theme.NoTitleBar.Fullscreen" >
+        android:label="@string/app_name" >
 
         <activity
             android:name=".Puzzle15Activity"

--- a/samples/android/15-puzzle/gradle/AndroidManifest.xml
+++ b/samples/android/15-puzzle/gradle/AndroidManifest.xml
@@ -5,8 +5,7 @@
 
     <application
         android:icon="@drawable/icon"
-        android:label="@string/app_name"
-        android:theme="@android:style/Theme.NoTitleBar.Fullscreen" >
+        android:label="@string/app_name">
 
         <activity
             android:name=".Puzzle15Activity"

--- a/samples/android/camera-calibration/AndroidManifest.xml
+++ b/samples/android/camera-calibration/AndroidManifest.xml
@@ -6,8 +6,7 @@
 
     <application
         android:label="@string/app_name"
-        android:icon="@drawable/icon"
-        android:theme="@android:style/Theme.NoTitleBar.Fullscreen">
+        android:icon="@drawable/icon">
 
         <activity android:name="CameraCalibrationActivity"
                   android:label="@string/app_name"

--- a/samples/android/camera-calibration/gradle/AndroidManifest.xml
+++ b/samples/android/camera-calibration/gradle/AndroidManifest.xml
@@ -5,8 +5,7 @@
 
     <application
         android:label="@string/app_name"
-        android:icon="@drawable/icon"
-        android:theme="@android:style/Theme.NoTitleBar.Fullscreen">
+        android:icon="@drawable/icon">
 
         <activity android:name="CameraCalibrationActivity"
                   android:label="@string/app_name"

--- a/samples/android/face-detection/AndroidManifest.xml
+++ b/samples/android/face-detection/AndroidManifest.xml
@@ -6,8 +6,7 @@
 
     <application
         android:label="@string/app_name"
-        android:icon="@drawable/icon"
-        android:theme="@android:style/Theme.NoTitleBar.Fullscreen" >
+        android:icon="@drawable/icon">
 
         <activity android:name="FdActivity"
                   android:label="@string/app_name"

--- a/samples/android/face-detection/gradle/AndroidManifest.xml
+++ b/samples/android/face-detection/gradle/AndroidManifest.xml
@@ -5,8 +5,7 @@
 
     <application
         android:label="@string/app_name"
-        android:icon="@drawable/icon"
-        android:theme="@android:style/Theme.NoTitleBar.Fullscreen" >
+        android:icon="@drawable/icon">
 
         <activity android:name="FdActivity"
                   android:label="@string/app_name"

--- a/samples/android/image-manipulations/AndroidManifest.xml
+++ b/samples/android/image-manipulations/AndroidManifest.xml
@@ -6,8 +6,7 @@
 
     <application
         android:label="@string/app_name"
-        android:icon="@drawable/icon"
-        android:theme="@android:style/Theme.NoTitleBar.Fullscreen" >
+        android:icon="@drawable/icon">
 
         <activity android:name="ImageManipulationsActivity"
                   android:label="@string/app_name"

--- a/samples/android/image-manipulations/gradle/AndroidManifest.xml
+++ b/samples/android/image-manipulations/gradle/AndroidManifest.xml
@@ -5,8 +5,7 @@
 
     <application
         android:label="@string/app_name"
-        android:icon="@drawable/icon"
-        android:theme="@android:style/Theme.NoTitleBar.Fullscreen" >
+        android:icon="@drawable/icon">
 
         <activity android:name="ImageManipulationsActivity"
                   android:label="@string/app_name"

--- a/samples/android/tutorial-2-mixedprocessing/AndroidManifest.xml
+++ b/samples/android/tutorial-2-mixedprocessing/AndroidManifest.xml
@@ -6,8 +6,7 @@
 
     <application
         android:label="@string/app_name"
-        android:icon="@drawable/icon"
-        android:theme="@android:style/Theme.NoTitleBar.Fullscreen" >
+        android:icon="@drawable/icon">
 
         <activity android:name="Tutorial2Activity"
                   android:label="@string/app_name"

--- a/samples/android/tutorial-2-mixedprocessing/gradle/AndroidManifest.xml
+++ b/samples/android/tutorial-2-mixedprocessing/gradle/AndroidManifest.xml
@@ -5,8 +5,7 @@
 
     <application
         android:label="@string/app_name"
-        android:icon="@drawable/icon"
-        android:theme="@android:style/Theme.NoTitleBar.Fullscreen" >
+        android:icon="@drawable/icon">
 
         <activity android:name="Tutorial2Activity"
                   android:label="@string/app_name"

--- a/samples/android/tutorial-3-cameracontrol/AndroidManifest.xml
+++ b/samples/android/tutorial-3-cameracontrol/AndroidManifest.xml
@@ -6,8 +6,7 @@
 
     <application
         android:label="@string/app_name"
-        android:icon="@drawable/icon"
-        android:theme="@android:style/Theme.NoTitleBar.Fullscreen" >
+        android:icon="@drawable/icon">
 
         <activity android:name="Tutorial3Activity"
                   android:label="@string/app_name"

--- a/samples/android/tutorial-3-cameracontrol/gradle/AndroidManifest.xml
+++ b/samples/android/tutorial-3-cameracontrol/gradle/AndroidManifest.xml
@@ -5,8 +5,7 @@
 
     <application
         android:label="@string/app_name"
-        android:icon="@drawable/icon"
-        android:theme="@android:style/Theme.NoTitleBar.Fullscreen" >
+        android:icon="@drawable/icon">
 
         <activity android:name="Tutorial3Activity"
                   android:label="@string/app_name"

--- a/samples/android/tutorial-4-opencl/AndroidManifest.xml
+++ b/samples/android/tutorial-4-opencl/AndroidManifest.xml
@@ -15,8 +15,7 @@
 
     <application
         android:allowBackup="true"
-        android:icon="@drawable/icon"
-        android:theme="@android:style/Theme.NoTitleBar.Fullscreen" >
+        android:icon="@drawable/icon">
         <activity
             android:name=".Tutorial4Activity"
             android:label="@string/app_name"

--- a/samples/android/tutorial-4-opencl/gradle/AndroidManifest.xml
+++ b/samples/android/tutorial-4-opencl/gradle/AndroidManifest.xml
@@ -15,8 +15,7 @@
 
     <application
         android:allowBackup="true"
-        android:icon="@drawable/icon"
-        android:theme="@android:style/Theme.NoTitleBar.Fullscreen" >
+        android:icon="@drawable/icon">
         <activity
             android:name=".Tutorial4Activity"
             android:label="@string/app_name"


### PR DESCRIPTION
Many of the Android samples rely on an _options menu_ (see image below) to work properly. On newer devices & Android versions (or at least on my phone), the menu was permanently hidden by the fullscreen theme and there seemed to be no way for the user to make it visible. Consequently, most of the examples were dysfunctional.

<cut/>

### This pullrequest changes

This PR simply removes the Android theme `Theme.NoTitleBar.Fullscreen` in the samples that use the options menu, which seems to fix the issue.

![image](https://user-images.githubusercontent.com/1812432/54558892-77476d00-49c7-11e9-9c98-d8511dc759c0.png)
_Figure: Options menu visible on top of the image (Android 8.0.0 on Google Pixel 2)_

I tested this by building OpenCV from source (on Debian Stretch) and installing the samples using `adb` as
```
export ANDROID_HOME=~/Android/Sdk
export ANDROID_NDK=~/Android/Sdk/ndk-bundle
export ANDROID_SDK=~/Android/Sdk

cd opencv/platforms/android
./build_sdk.py my-build

adb install my-build/o4a/opencv_android/tutorial-2-mixedprocessing/build/outputs/apk/debug/tutorial-2-mixedprocessing-arm64-v8a-debug.apk
```
