### PR TITLE
core: fix fallback CV_CONSTEXPR definition

### DIFF
--- a/modules/core/include/opencv2/core/cvdef.h
+++ b/modules/core/include/opencv2/core/cvdef.h
@@ -691,7 +691,7 @@ __CV_ENUM_FLAGS_BITWISE_XOR_EQ   (EnumType, EnumType)                           
 #  endif
 #endif
 #ifndef CV_CONSTEXPR
-#  define CV_CONSTEXPR const
+#  define CV_CONSTEXPR
 #endif
 
 // Integer types portatibility


### PR DESCRIPTION
keep it empty to avoid failures of these declarations:
```
static CV_CONSTEXPR const int var = ...;
```
