### PR TITLE
core: fix Core_EigenNonSymmetric.convergence test

### DIFF
--- a/modules/core/test/test_eigen.cpp
+++ b/modules/core/test/test_eigen.cpp
@@ -527,7 +527,19 @@ TEST(Core_EigenNonSymmetric, convergence)
         0, -1, 0);
     Mat eigenvalues, eigenvectors;
     // eigen values are complex, algorithm doesn't converge
-    EXPECT_THROW(cv::eigenNonSymmetric(m, eigenvalues, eigenvectors), cv::Exception);  // exception instead of hang
+    try
+    {
+        cv::eigenNonSymmetric(m, eigenvalues, eigenvectors);
+        std::cout << Mat(eigenvalues.t()) << std::endl;
+    }
+    catch (const cv::Exception& e)
+    {
+        EXPECT_EQ(Error::StsNoConv, e.code) << e.what();
+    }
+    catch (...)
+    {
+        FAIL() << "Unknown exception has been raised";
+    }
 }
 
 }} // namespace


### PR DESCRIPTION
relates #14089

Failed builds:
- [AVX2](http://pullrequest.opencv.org/buildbot/builders/precommit_linux64-avx2/builds/397)
- [ARMv8](http://pullrequest.opencv.org/buildbot/builders/precommit_armv8/builds/11443)

```
force_builders=Linux AVX2,ARMv8
```