### PR TITLE
Remove dead link in calib3d.hpp

### DIFF
--- a/modules/calib3d/include/opencv2/calib3d.hpp
+++ b/modules/calib3d/include/opencv2/calib3d.hpp
@@ -177,8 +177,6 @@ pattern (every view is described by several 3D-2D point correspondences).
         opencv_source_code/samples/cpp/calibration.cpp
     -   A calibration sample in order to do 3D reconstruction can be found at
         opencv_source_code/samples/cpp/build3dmodel.cpp
-    -   A calibration sample of an artificially generated camera and chessboard patterns can be
-        found at opencv_source_code/samples/cpp/calibration_artificial.cpp
     -   A calibration example on stereo calibration can be found at
         opencv_source_code/samples/cpp/stereo_calib.cpp
     -   A calibration example on stereo matching can be found at


### PR DESCRIPTION
<!-- Please use this line to close one or multiple issues when this pull request gets merged
You can add another line right under the first one:
resolves #1234
resolves #1235
-->

Fix #11754 by removing the dead link to `calibration_artificial.cpp` in calib3d.hpp [here](https://github.com/opencv/opencv/blob/6501cb93a43fe560a7fb7272b4575aa562653e92/modules/calib3d/include/opencv2/calib3d.hpp#L181)

<!-- Please describe what your pull request is changing -->
