### PR TITLE
cmake:vsx Fix compilation fail on aligned runtime test

### DIFF
--- a/cmake/checks/runtime/cpu_vsx_aligned.cpp
+++ b/cmake/checks/runtime/cpu_vsx_aligned.cpp
@@ -2,6 +2,7 @@
 // https://github.com/opencv/opencv/issues/13211
 
 #include <altivec.h>
+#undef bool
 
 #define vsx_ld vec_vsx_ld
 #define vsx_st vec_vsx_st


### PR DESCRIPTION
relates #14040, #13211 

This patch fix compilation fail on aligned/ld/st run-time test when c++11 enabled or when build opencv4 current master and that case unnecessary fallback to unaligned ld/st intrinsics, however its my bad after all :(

<cut/>

compilation errors from CMakeError file
```bash
Run Build Command:"/usr/bin/make" "cmTC_b1fdd/fast"
/usr/bin/make -f CMakeFiles/cmTC_b1fdd.dir/build.make CMakeFiles/cmTC_b1fdd.dir/build
make[1]: Entering directory '/worker/buildbot/Power9_Linux_gcc-6__opencv/build/CMakeFiles/CMakeTmp'
Building CXX object CMakeFiles/cmTC_b1fdd.dir/cpu_vsx_aligned.cpp.o
/usr/bin/g++-6    -O3 -DNDEBUG -fPIE   -mcpu=power8 -mcpu=power9 -mtune=power9 -std=c++11 -o CMakeFiles/cmTC_b1fdd.dir/cpu_vsx_aligned.cpp.o -c /worker/buildbot/Power9_Linux_gcc-6__opencv/opencv/cmake/checks/runtime/cpu_vsx_aligned.cpp
/worker/buildbot/Power9_Linux_gcc-6__opencv/opencv/cmake/checks/runtime/cpu_vsx_aligned.cpp: In function 'int main()':
/worker/buildbot/Power9_Linux_gcc-6__opencv/opencv/cmake/checks/runtime/cpu_vsx_aligned.cpp:36:9: error: could not convert '((check_data<unsigned char [16], __vector(16) unsigned char>(rbuf, a, 0, 16) == (__vector(4) __bool int){0u, 0u, 0u, 0u}) ? (__vector(4) int){-1, -1, -1, -1} : (__vector(4) int){0, 0, 0, 0})' from '__vector(4) int' to 'bool'
     if (!check_data(rbuf, a))
         ^~~~~~~~~~~~~~~~~~~~
/worker/buildbot/Power9_Linux_gcc-6__opencv/opencv/cmake/checks/runtime/cpu_vsx_aligned.cpp:39:9: error: could not convert '((check_data<unsigned char [16], __vector(16) unsigned char>(wbuf, a, 0, 16) == (__vector(4) __bool int){0u, 0u, 0u, 0u}) ? (__vector(4) int){-1, -1, -1, -1} : (__vector(4) int){0, 0, 0, 0})' from '__vector(4) int' to 'bool'
     if (!check_data(wbuf, a))
         ^~~~~~~~~~~~~~~~~~~~
/worker/buildbot/Power9_Linux_gcc-6__opencv/opencv/cmake/checks/runtime/cpu_vsx_aligned.cpp:45:9: error: could not convert '((check_data<unsigned char [16], __vector(16) unsigned char>(wbuf, a, 0, 16) == (__vector(4) __bool int){0u, 0u, 0u, 0u}) ? (__vector(4) int){-1, -1, -1, -1} : (__vector(4) int){0, 0, 0, 0})' from '__vector(4) int' to 'bool'
     if (!check_data(wbuf, a))
         ^~~~~~~~~~~~~~~~~~~~
/worker/buildbot/Power9_Linux_gcc-6__opencv/opencv/cmake/checks/runtime/cpu_vsx_aligned.cpp:51:9: error: could not convert '((check_data<unsigned char [16], __vector(16) unsigned char>(wbuf, a, 0, 16) == (__vector(4) __bool int){0u, 0u, 0u, 0u}) ? (__vector(4) int){-1, -1, -1, -1} : (__vector(4) int){0, 0, 0, 0})' from '__vector(4) int' to 'bool'
     if (!check_data(wbuf, a))
         ^~~~~~~~~~~~~~~~~~~~
/worker/buildbot/Power9_Linux_gcc-6__opencv/opencv/cmake/checks/runtime/cpu_vsx_aligned.cpp: In instantiation of 'unsigned int check_data(T&, Tvec&, int, int) [with T = unsigned char [16]; Tvec = __vector(16) unsigned char]':
/worker/buildbot/Power9_Linux_gcc-6__opencv/opencv/cmake/checks/runtime/cpu_vsx_aligned.cpp:36:28:   required from here
/worker/buildbot/Power9_Linux_gcc-6__opencv/opencv/cmake/checks/runtime/cpu_vsx_aligned.cpp:22:20: error: cannot convert 'bool' to '__vector(4) __bool int' in return
             return false;
                    ^~~~~
/worker/buildbot/Power9_Linux_gcc-6__opencv/opencv/cmake/checks/runtime/cpu_vsx_aligned.cpp:24:12: error: cannot convert 'bool' to '__vector(4) __bool int' in return
     return true;
            ^~~~
make[1]: *** [CMakeFiles/cmTC_b1fdd.dir/build.make:66: CMakeFiles/cmTC_b1fdd.dir/cpu_vsx_aligned.cpp.o] Error 1
make[1]: Leaving directory '/worker/buildbot/Power9_Linux_gcc-6__opencv/build/CMakeFiles/CMakeTmp'
make: *** [Makefile:121: cmTC_b1fdd/fast] Error 2
```` 


````
force_builders=Custom
buildworker:Custom=linux-1,linux-2,linux-4
docker_image:Custom=powerpc64le
pw_cmake_definitions=ENABLE_CXX11:ON
````