### PR TITLE
Grammatical errors for help() in detect_mser.cpp

### DIFF
--- a/samples/cpp/detect_mser.cpp
+++ b/samples/cpp/detect_mser.cpp
@@ -38,9 +38,9 @@ static void help()
 {
     cout << "\n This program demonstrates how to use MSER to detect extremal regions \n"
         "Usage: \n"
-        "  ./detect_mser <image1(without parameter a syntehtic image is used as default)>\n"
+        "  ./detect_mser <image1(without parameter a synthetic image is used as default)>\n"
         "Press esc key when image window is active to change descriptor parameter\n"
-        "Press 2, 8, 4, 6, +,- or 5 keys in openGL windows to change view or use mouse\n";
+        "Press 2, 8, 4, 6, +, -, or 5 keys in openGL windows to change view or use mouse\n";
 }
 
 struct MSERParams

--- a/samples/cpp/detect_mser.cpp
+++ b/samples/cpp/detect_mser.cpp
@@ -36,8 +36,8 @@ using namespace cv;
 
 static void help()
 {
-    cout << "\n This program demonstrates how to use MSER to detect extremal regions \n"
-        "Usage: \n"
+    cout << "\nThis program demonstrates how to use MSER to detect extremal regions\n"
+        "Usage:\n"
         "  ./detect_mser <image1(without parameter a synthetic image is used as default)>\n"
         "Press esc key when image window is active to change descriptor parameter\n"
         "Press 2, 8, 4, 6, +, -, or 5 keys in openGL windows to change view or use mouse\n";


### PR DESCRIPTION
Corrected spelling of "synthetic" and added grammatical clarification for keys to press to change view or use mouse.

<cut/>

### This pull request changes opencv/samples/cpp/detect_mser.cpp

Fix 1 (line 41):
`syntehtic` to `synthetic`
-spelling correction

Fix 2 (line 43):
`2, 8, 4, 6, +,- or 5 keys` to `2, 8, 4, 6, +, -, or 5 keys`
-grammatical clarification

