### PR TITLE
Implementing AVX512 Support for 1 channel mats for CV_64F format

### DIFF
--- a/modules/imgproc/src/sumpixels.cpp
+++ b/modules/imgproc/src/sumpixels.cpp
@@ -77,7 +77,7 @@ struct Integral_SIMD<uchar, double, double> {
 #if CV_TRY_AVX512_SKX
         CV_UNUSED(_tiltedstep);
         // TODO:  Add support for 1 channel input (WIP)
-        if (CV_CPU_HAS_SUPPORT_AVX512_SKX && !tilted && ((cn >= 2) && (cn <= 4))){
+        if (CV_CPU_HAS_SUPPORT_AVX512_SKX && !tilted && (cn <= 4)){
             opt_AVX512_SKX::calculate_integral_avx512(src, _srcstep, sum, _sumstep,
                                                       sqsum, _sqsumstep, width, height, cn);
             return true;


### PR DESCRIPTION
Implementing AVX512 Support for 1 channel mats for CV_64F format

Also made some small changes to ensure const correctness

<cut/>

|Name of Test|no avx512|avx512|avx512 vs no avx512 (x-factor)|
|---|:-:|:-:|:-:|
|integral::Size_MatType_OutMatDepth::(127x61, 8UC1, CV_64F)|0.012|0.007|1.56|
|integral::Size_MatType_OutMatDepth::(128x128, 8UC1, CV_64F)|0.025|0.014|1.77|
|integral::Size_MatType_OutMatDepth::(640x480, 8UC1, CV_64F)|0.474|0.257|1.85|
|integral::Size_MatType_OutMatDepth::(1280x720, 8UC1, CV_64F)|1.437|0.772|1.86|
|integral::Size_MatType_OutMatDepth::(1920x1080, 8UC1, CV_64F)|3.247|1.772|1.83|
|integral::Size_MatType_OutMatDepth::(3840x2160, 8UC1, CV_64F)|12.942|7.441|1.74|
|integral_sqsum::Size_MatType_OutMatDepth::(127x61, 8UC1, CV_64F)|0.013|0.012|1.08|
|integral_sqsum::Size_MatType_OutMatDepth::(128x128, 8UC1, CV_64F)|0.028|0.021|1.34|
|integral_sqsum::Size_MatType_OutMatDepth::(640x480, 8UC1, CV_64F)|0.503|0.381|1.32|
|integral_sqsum::Size_MatType_OutMatDepth::(1280x720, 8UC1, CV_64F)|1.544|1.181|1.31|
|integral_sqsum::Size_MatType_OutMatDepth::(1920x1080, 8UC1, CV_64F)|3.509|2.849|1.23|
|integral_sqsum::Size_MatType_OutMatDepth::(3840x2160, 8UC1, CV_64F)|14.927|12.542|1.19|

```
force_builders=Linux AVX2
ci_branch:Linux AVX2=no-checks
buildworker:Linux AVX2=linux-3
test_opencl:Linux AVX2=OFF
```