### PR TITLE
Fixed cvdef.h for MSVC C users

### DIFF
--- a/modules/core/include/opencv2/core/cvdef.h
+++ b/modules/core/include/opencv2/core/cvdef.h
@@ -565,7 +565,7 @@ Cv64suf;
 \****************************************************************************************/
 
 #ifndef CV_CXX_STD_ARRAY
-#  if __cplusplus >= 201103L || (defined(_MSC_VER) && _MSC_VER >= 1900/*MSVS 2015*/)
+#  if __cplusplus >= 201103L || (defined(__cplusplus) && defined(_MSC_VER) && _MSC_VER >= 1900/*MSVS 2015*/)
 #    define CV_CXX_STD_ARRAY 1
 #    include <array>
 #  endif


### PR DESCRIPTION
related #10589

### This pullrequest changes

@mwoehlke-kitware , does this patch fix your issue?

__Note:__ merge to _master_ is not needed, `std::array` is always enabled on this branch.