### PR TITLE
GAPI: fix build with Intel Compiler 2019

### DIFF
--- a/modules/gapi/include/opencv2/gapi/util/variant.hpp
+++ b/modules/gapi/include/opencv2/gapi/util/variant.hpp
@@ -328,7 +328,8 @@ namespace util
             util::type_list_index<T, Types...>::value;
 
         if (v.index() == t_index)
-            return reinterpret_cast<T&>(v.memory);
+            return *(T*)(&v.memory);  // workaround for ICC 2019
+            // original code: return reinterpret_cast<T&>(v.memory);
         else
             throw_error(bad_variant_access());
     }
@@ -340,7 +341,8 @@ namespace util
             util::type_list_index<T, Types...>::value;
 
         if (v.index() == t_index)
-            return reinterpret_cast<const T&>(v.memory);
+            return *(const T*)(&v.memory);  // workaround for ICC 2019
+            // original code: return reinterpret_cast<const T&>(v.memory);
         else
             throw_error(bad_variant_access());
     }


### PR DESCRIPTION
resolves #14143 

<cut/>

```
docker_image:Custom=ubuntu-clang:18.04
buildworker:Custom=linux-1,linux-2
```