### PR TITLE
G-API: GComputation doesn't work with output vector<cv::Mat>

### DIFF
--- a/modules/gapi/include/opencv2/gapi/gcomputation.hpp
+++ b/modules/gapi/include/opencv2/gapi/gcomputation.hpp
@@ -315,7 +315,7 @@ public:
      * inputs/outputs which were used to define this GComputation.
      */
     void apply(const std::vector<cv::Mat>& ins,         // Compatibility overload
-               const std::vector<cv::Mat>& outs,
+                     std::vector<cv::Mat>& outs,
                GCompileArgs &&args = {});
 #endif // !defined(GAPI_STANDALONE)
     // Various versions of compile(): //////////////////////////////////////////

--- a/modules/gapi/src/api/gcomputation.cpp
+++ b/modules/gapi/src/api/gcomputation.cpp
@@ -159,16 +159,14 @@ void cv::GComputation::apply(cv::Mat in1, cv::Mat in2, cv::Scalar &out, GCompile
 }
 
 void cv::GComputation::apply(const std::vector<cv::Mat> &ins,
-                             const std::vector<cv::Mat> &outs,
+                             std::vector<cv::Mat>       &outs,
                              GCompileArgs &&args)
 {
     GRunArgs call_ins;
     GRunArgsP call_outs;
 
-    // Make a temporary copy of vector outs - cv::Mats are copies anyway
-    auto tmp = outs;
-    for (const cv::Mat &m : ins) { call_ins.emplace_back(m);   }
-    for (      cv::Mat &m : tmp) { call_outs.emplace_back(&m); }
+    for (const cv::Mat &m : ins)  { call_ins.emplace_back(m);   }
+    for (      cv::Mat &m : outs) { call_outs.emplace_back(&m); }
 
     apply(std::move(call_ins), std::move(call_outs), std::move(args));
 }

--- a/modules/gapi/src/api/gcomputation.cpp
+++ b/modules/gapi/src/api/gcomputation.cpp
@@ -159,7 +159,7 @@ void cv::GComputation::apply(cv::Mat in1, cv::Mat in2, cv::Scalar &out, GCompile
 }
 
 void cv::GComputation::apply(const std::vector<cv::Mat> &ins,
-                             std::vector<cv::Mat>       &outs,
+                             std::vector<cv::Mat> &outs,
                              GCompileArgs &&args)
 {
     GRunArgs call_ins;

--- a/modules/gapi/src/api/gcomputation.cpp
+++ b/modules/gapi/src/api/gcomputation.cpp
@@ -159,7 +159,7 @@ void cv::GComputation::apply(cv::Mat in1, cv::Mat in2, cv::Scalar &out, GCompile
 }
 
 void cv::GComputation::apply(const std::vector<cv::Mat> &ins,
-                             std::vector<cv::Mat> &outs,
+                                   std::vector<cv::Mat> &outs,
                              GCompileArgs &&args)
 {
     GRunArgs call_ins;

--- a/modules/gapi/test/gapi_gcomputation_tests.cpp
+++ b/modules/gapi/test/gapi_gcomputation_tests.cpp
@@ -55,14 +55,14 @@ namespace opencv_test
 
       struct GComputationVectorMatsAsOutput: public ::testing::Test
       {
-          cv::GMat in;
-          cv::GMat out[3];
           cv::Mat  in_mat;
           cv::GComputation m_c;
           std::vector<cv::Mat> ref_mats;
 
           GComputationVectorMatsAsOutput() : in_mat(300, 300, CV_8UC3),
           m_c([&](){
+                      cv::GMat in;
+                      cv::GMat out[3];
                       std::tie(out[0], out[1], out[2]) = cv::gapi::split3(in);
                       return cv::GComputation({in}, {out[0], out[1], out[2]});
                   })


### PR DESCRIPTION
<!-- Please use this line to close one or multiple issues when this pullrequest gets merged
You can add another line right under the first one:
resolves #1234
resolves #1235
-->

### This pullrequest changes
## Problem overview
Consider the following case:
```
TEST(GComputationTest, VectorAsOutputApply)
 {
      cv::GMat in;
      cv::GMat out[3];
      std::tie(out[0], out[1], out[2]) = cv::gapi::split3(in);

      cv::Mat in_mat(3, 3, CV_8UC3);
      cv::randu(in_mat, cv::Scalar::all(0), cv::Scalar::all(255));
      std::vector<cv::Mat> out_mats(3);
      std::vector<cv::Mat> ref_mats(3);

      cv::split(in_mat, ref_mats);

      cv::GComputation({in}, {out[0], out[1], out[2]}).apply({in_mat}, out_mats);

      EXPECT_EQ(cv::Size(3, 3), out_mats[0].size());
      for (const auto& it : ade::util::zip(ref_mats, out_mats))
      {
          const auto& ref_mat = std::get<0>(it);
          const auto& out_mat = std::get<1>(it);

          EXPECT_EQ(0, cv::countNonZero(ref_mat != out_mat));
      }
}
```
This will work fine if the output matrices are preallocated
```
for (auto& out_mat : out_mats)
{
    out_mats.create(in_mat.size(), CV_8UC1)
}
```
This is due to the fact that preallocated mat simply copy a pointer to memory, when copying, but when  
the matrix is empty this does not happen and a new mat is created when copying

Therefore, the data calculated in the copy of the mat does't reach to the output mat of the user

<!-- Please describe what your pullrequest is changing -->
