### PR TITLE
Fixed #14148 Broken Documentation Link

### DIFF
--- a/doc/tutorials/dnn/dnn_googlenet/dnn_googlenet.markdown
+++ b/doc/tutorials/dnn/dnn_googlenet/dnn_googlenet.markdown
@@ -25,7 +25,7 @@ Explanation
    [bvlc_googlenet.caffemodel](http://dl.caffe.berkeleyvision.org/bvlc_googlenet.caffemodel)
 
    Also you need file with names of [ILSVRC2012](http://image-net.org/challenges/LSVRC/2012/browse-synsets) classes:
-   [classification_classes_ILSVRC2012.txt](https://github.com/opencv/opencv/tree/3.4/samples/dnn/classification_classes_ILSVRC2012.txt).
+   [classification_classes_ILSVRC2012.txt](https://github.com/opencv/opencv/blob/master/samples/data/dnn/classification_classes_ILSVRC2012.txt).
 
    Put these files into working dir of this program example.
 

--- a/doc/tutorials/dnn/dnn_googlenet/dnn_googlenet.markdown
+++ b/doc/tutorials/dnn/dnn_googlenet/dnn_googlenet.markdown
@@ -25,7 +25,7 @@ Explanation
    [bvlc_googlenet.caffemodel](http://dl.caffe.berkeleyvision.org/bvlc_googlenet.caffemodel)
 
    Also you need file with names of [ILSVRC2012](http://image-net.org/challenges/LSVRC/2012/browse-synsets) classes:
-   [classification_classes_ILSVRC2012.txt](https://github.com/opencv/opencv/blob/master/samples/data/dnn/classification_classes_ILSVRC2012.txt).
+   [classification_classes_ILSVRC2012.txt](https://github.com/opencv/opencv/blob/3.4/samples/data/dnn/classification_classes_ILSVRC2012.txt).
 
    Put these files into working dir of this program example.
 


### PR DESCRIPTION
resolves #14148 

This updates the 'classification_classes_ILSVRC2012.txt' link in the documentation to not return a 404
