### PR TITLE
OCL: define CL_SILENCE_DEPRECATION on MacOSX

### DIFF
--- a/modules/core/include/opencv2/core/opencl/runtime/autogenerated/opencl_core.hpp
+++ b/modules/core/include/opencv2/core/opencl/runtime/autogenerated/opencl_core.hpp
@@ -96,6 +96,7 @@
 #define clWaitForEvents clWaitForEvents_
 
 #if defined __APPLE__
+#define CL_SILENCE_DEPRECATION
 #include <OpenCL/cl.h>
 #else
 #include <CL/cl.h>

--- a/modules/core/src/opencl/runtime/generator/template/opencl_core.hpp.in
+++ b/modules/core/src/opencl/runtime/generator/template/opencl_core.hpp.in
@@ -5,6 +5,7 @@
 @CL_REMAP_ORIGIN@
 
 #if defined __APPLE__
+#define CL_SILENCE_DEPRECATION
 #include <OpenCL/cl.h>
 #else
 #include <CL/cl.h>

--- a/modules/core/src/opencl/runtime/opencl_core.cpp
+++ b/modules/core/src/opencl/runtime/opencl_core.cpp
@@ -47,6 +47,7 @@
 
 #if defined(HAVE_OPENCL_STATIC)
 #if defined __APPLE__
+#define CL_SILENCE_DEPRECATION
 #include <OpenCL/cl.h>
 #else
 #include <CL/cl.h>

--- a/samples/opencl/opencl-opencv-interop.cpp
+++ b/samples/opencl/opencl-opencv-interop.cpp
@@ -19,6 +19,7 @@
 #define CL_USE_DEPRECATED_OPENCL_2_0_APIS // eliminate build warning
 
 #ifdef __APPLE__
+#define CL_SILENCE_DEPRECATION
 #include <OpenCL/cl.h>
 #else
 #include <CL/cl.h>


### PR DESCRIPTION
<cut/>

Warnings (Xcode 10.1, OSX 10.14 Mojave):
> opencv/samples/opencl/opencl-opencv-interop.cpp:72:15: warning: 'clGetPlatformInfo' is deprecated: first deprecated in macOS 10.14 - (Define CL_SILENCE_DEPRECATION to hide this warning) [-Wdeprecated-declarations]


```
buildworker:Mac=macosx-1
buildworker:Mac OpenCL=macosx-1
```