### PR TITLE
videoio: added bad parameters handling to VideoWriter

### DIFF
--- a/modules/videoio/src/cap_avfoundation_mac.mm
+++ b/modules/videoio/src/cap_avfoundation_mac.mm
@@ -45,6 +45,7 @@
 #include "precomp.hpp"
 #include "opencv2/imgproc.hpp"
 #include <stdio.h>
+#include <AvailabilityMacros.h>
 #import <AVFoundation/AVFoundation.h>
 
 #define CV_CAP_MODE_BGR CV_FOURCC_MACRO('B','G','R','3')
@@ -1136,8 +1137,12 @@ CvVideoWriter_AVFoundation::CvVideoWriter_AVFoundation(const std::string &filena
         fileType = [AVFileTypeMPEG4 copy];
     }else if ([fileExt isEqualToString:@"m4v"]){
         fileType = [AVFileTypeAppleM4V copy];
+#if MAC_OS_X_VERSION_MIN_REQUIRED >= MAC_OS_X_VERSION_10_11
     }else if ([fileExt isEqualToString:@"3gp"] || [fileExt isEqualToString:@"3gpp"] || [fileExt isEqualToString:@"sdv"]  ){
         fileType = [AVFileType3GPP copy];
+    }else if ([fileExt isEqualToString:@"3g2"] || [fileExt isEqualToString:@"3gp2"]){
+        fileType = [AVFileType3GPP2 copy];
+#endif
     } else{
         is_good = false;
     }

--- a/modules/videoio/src/cap_avfoundation_mac.mm
+++ b/modules/videoio/src/cap_avfoundation_mac.mm
@@ -1136,10 +1136,8 @@ CvVideoWriter_AVFoundation::CvVideoWriter_AVFoundation(const std::string &filena
         fileType = [AVFileTypeMPEG4 copy];
     }else if ([fileExt isEqualToString:@"m4v"]){
         fileType = [AVFileTypeAppleM4V copy];
-#if TARGET_OS_IPHONE || TARGET_IPHONE_SIMULATOR
     }else if ([fileExt isEqualToString:@"3gp"] || [fileExt isEqualToString:@"3gpp"] || [fileExt isEqualToString:@"sdv"]  ){
         fileType = [AVFileType3GPP copy];
-#endif
     } else{
         is_good = false;
     }

--- a/modules/videoio/src/cap_avfoundation_mac.mm
+++ b/modules/videoio/src/cap_avfoundation_mac.mm
@@ -1137,12 +1137,6 @@ CvVideoWriter_AVFoundation::CvVideoWriter_AVFoundation(const std::string &filena
         fileType = [AVFileTypeMPEG4 copy];
     }else if ([fileExt isEqualToString:@"m4v"]){
         fileType = [AVFileTypeAppleM4V copy];
-#if MAC_OS_X_VERSION_MIN_REQUIRED >= MAC_OS_X_VERSION_10_11
-    }else if ([fileExt isEqualToString:@"3gp"] || [fileExt isEqualToString:@"3gpp"] || [fileExt isEqualToString:@"sdv"]  ){
-        fileType = [AVFileType3GPP copy];
-    }else if ([fileExt isEqualToString:@"3g2"] || [fileExt isEqualToString:@"3gp2"]){
-        fileType = [AVFileType3GPP2 copy];
-#endif
     } else{
         is_good = false;
     }

--- a/modules/videoio/src/cap_avfoundation_mac.mm
+++ b/modules/videoio/src/cap_avfoundation_mac.mm
@@ -184,12 +184,14 @@ private:
 
 class CvVideoWriter_AVFoundation : public CvVideoWriter {
     public:
-        CvVideoWriter_AVFoundation(const char* filename, int fourcc,
-                double fps, CvSize frame_size,
-                int is_color=1);
+        CvVideoWriter_AVFoundation(const std::string &filename, int fourcc, double fps, CvSize frame_size, int is_color);
         ~CvVideoWriter_AVFoundation();
         bool writeFrame(const IplImage* image) CV_OVERRIDE;
         int getCaptureDomain() const CV_OVERRIDE { return cv::CAP_AVFOUNDATION; }
+        bool isOpened() const
+        {
+            return is_good;
+        }
     private:
         IplImage* argbimage;
 
@@ -204,6 +206,7 @@ class CvVideoWriter_AVFoundation : public CvVideoWriter {
         CvSize movieSize;
         int movieColor;
         unsigned long mFrameNum;
+        bool is_good;
 };
 
 /****************** Implementation of interface functions ********************/
@@ -230,8 +233,13 @@ cv::Ptr<cv::IVideoCapture> cv::create_AVFoundation_capture_cam(int index)
 cv::Ptr<cv::IVideoWriter> cv::create_AVFoundation_writer(const std::string& filename, int fourcc, double fps, const cv::Size &frameSize, bool isColor)
 {
     CvSize sz = { frameSize.width, frameSize.height };
-    CvVideoWriter_AVFoundation* wrt = new CvVideoWriter_AVFoundation(filename.c_str(), fourcc, fps, sz, isColor);
-    return cv::makePtr<cv::LegacyWriter>(wrt);
+    CvVideoWriter_AVFoundation* wrt = new CvVideoWriter_AVFoundation(filename, fourcc, fps, sz, isColor);
+    if (wrt->isOpened())
+    {
+        return cv::makePtr<cv::LegacyWriter>(wrt);
+    }
+    delete wrt;
+    return NULL;
 }
 
 /********************** Implementation of Classes ****************************/
@@ -1106,38 +1114,22 @@ bool CvCaptureFile::setProperty(int property_id, double value) {
  *****************************************************************************/
 
 
-CvVideoWriter_AVFoundation::CvVideoWriter_AVFoundation(const char* filename, int fourcc,
-        double fps, CvSize frame_size,
-        int is_color) {
-
+CvVideoWriter_AVFoundation::CvVideoWriter_AVFoundation(const std::string &filename, int fourcc, double fps, CvSize frame_size, int is_color)
+    : is_good(true)
+{
+    if (fps <= 0 || frame_size.width <= 0 || frame_size.height <= 0)
+    {
+        is_good = false;
+        return;
+    }
     NSAutoreleasePool* localpool = [[NSAutoreleasePool alloc] init];
-
 
     mFrameNum = 0;
     mMovieFPS = fps;
     movieSize = frame_size;
     movieColor = is_color;
     argbimage = cvCreateImage(movieSize, IPL_DEPTH_8U, 4);
-    path = [[[NSString stringWithCString:filename encoding:NSASCIIStringEncoding] stringByExpandingTildeInPath] retain];
-
-
-    /*
-         AVFileTypeQuickTimeMovie
-         UTI for the QuickTime movie file format.
-         The value of this UTI is com.apple.quicktime-movie. Files are identified with the .mov and .qt extensions.
-
-         AVFileTypeMPEG4
-         UTI for the MPEG-4 file format.
-         The value of this UTI is public.mpeg-4. Files are identified with the .mp4 extension.
-
-         AVFileTypeAppleM4V
-         UTI for the iTunes video file format.
-         The value of this UTI is com.apple.mpeg-4-video. Files are identified with the .m4v extension.
-
-         AVFileType3GPP
-         UTI for the 3GPP file format.
-         The value of this UTI is public.3gpp. Files are identified with the .3gp, .3gpp, and .sdv extensions.
-     */
+    path = [[[NSString stringWithUTF8String:filename.c_str()] stringByExpandingTildeInPath] retain];
 
     NSString *fileExt =[[[path pathExtension] lowercaseString] copy];
     if ([fileExt isEqualToString:@"mov"] || [fileExt isEqualToString:@"qt"]){
@@ -1151,7 +1143,7 @@ CvVideoWriter_AVFoundation::CvVideoWriter_AVFoundation(const char* filename, int
         fileType = [AVFileType3GPP copy];
 #endif
     } else{
-        fileType = [AVFileTypeMPEG4 copy];  //default mp4
+        is_good = false;
     }
     [fileExt release];
 
@@ -1165,6 +1157,7 @@ CvVideoWriter_AVFoundation::CvVideoWriter_AVFoundation(const char* filename, int
     if (cc2!=fourcc) {
         fprintf(stderr, "OpenCV: Didn't properly encode FourCC. Expected 0x%08X but got 0x%08X.\n", fourcc, cc2);
         //exception;
+        is_good = false;
     }
 
     // Two codec supported AVVideoCodecH264 AVVideoCodecJPEG
@@ -1175,59 +1168,61 @@ CvVideoWriter_AVFoundation::CvVideoWriter_AVFoundation(const char* filename, int
     }else if(fourcc == CV_FOURCC('H','2','6','4') || fourcc == CV_FOURCC('a','v','c','1')){
             codec = [AVVideoCodecH264 copy];
     }else{
-        codec = [AVVideoCodecH264 copy]; // default canonical H264.
-
+        is_good = false;
     }
 
     //NSLog(@"Path: %@", path);
 
-    NSError *error = nil;
+    if (is_good)
+    {
+        NSError *error = nil;
 
 
-    // Make sure the file does not already exist. Necessary to overwirte??
-    /*
-    NSFileManager *fileManager = [NSFileManager defaultManager];
-    if ([fileManager fileExistsAtPath:path]){
-        [fileManager removeItemAtPath:path error:&error];
-    }
-    */
+        // Make sure the file does not already exist. Necessary to overwirte??
+        /*
+        NSFileManager *fileManager = [NSFileManager defaultManager];
+        if ([fileManager fileExistsAtPath:path]){
+            [fileManager removeItemAtPath:path error:&error];
+        }
+        */
 
-    // Wire the writer:
-    // Supported file types:
-    //      AVFileTypeQuickTimeMovie AVFileTypeMPEG4 AVFileTypeAppleM4V AVFileType3GPP
+        // Wire the writer:
+        // Supported file types:
+        //      AVFileTypeQuickTimeMovie AVFileTypeMPEG4 AVFileTypeAppleM4V AVFileType3GPP
 
-    mMovieWriter = [[AVAssetWriter alloc] initWithURL:[NSURL fileURLWithPath:path]
-        fileType:fileType
-        error:&error];
-    //NSParameterAssert(mMovieWriter);
+        mMovieWriter = [[AVAssetWriter alloc] initWithURL:[NSURL fileURLWithPath:path]
+            fileType:fileType
+            error:&error];
+        //NSParameterAssert(mMovieWriter);
 
-    NSDictionary *videoSettings = [NSDictionary dictionaryWithObjectsAndKeys:
-        codec, AVVideoCodecKey,
-        [NSNumber numberWithInt:movieSize.width], AVVideoWidthKey,
-        [NSNumber numberWithInt:movieSize.height], AVVideoHeightKey,
-        nil];
+        NSDictionary *videoSettings = [NSDictionary dictionaryWithObjectsAndKeys:
+            codec, AVVideoCodecKey,
+            [NSNumber numberWithInt:movieSize.width], AVVideoWidthKey,
+            [NSNumber numberWithInt:movieSize.height], AVVideoHeightKey,
+            nil];
 
-    mMovieWriterInput = [[AVAssetWriterInput
-        assetWriterInputWithMediaType:AVMediaTypeVideo
-        outputSettings:videoSettings] retain];
+        mMovieWriterInput = [[AVAssetWriterInput
+            assetWriterInputWithMediaType:AVMediaTypeVideo
+            outputSettings:videoSettings] retain];
 
-    //NSParameterAssert(mMovieWriterInput);
-    //NSParameterAssert([mMovieWriter canAddInput:mMovieWriterInput]);
+        //NSParameterAssert(mMovieWriterInput);
+        //NSParameterAssert([mMovieWriter canAddInput:mMovieWriterInput]);
 
-    [mMovieWriter addInput:mMovieWriterInput];
+        [mMovieWriter addInput:mMovieWriterInput];
 
-    mMovieWriterAdaptor = [[AVAssetWriterInputPixelBufferAdaptor alloc] initWithAssetWriterInput:mMovieWriterInput sourcePixelBufferAttributes:nil];
-
-
-    //Start a session:
-    [mMovieWriter startWriting];
-    [mMovieWriter startSessionAtSourceTime:kCMTimeZero];
+        mMovieWriterAdaptor = [[AVAssetWriterInputPixelBufferAdaptor alloc] initWithAssetWriterInput:mMovieWriterInput sourcePixelBufferAttributes:nil];
 
 
-    if(mMovieWriter.status == AVAssetWriterStatusFailed){
-        NSLog(@"AVF: AVAssetWriter status: %@", [mMovieWriter.error localizedDescription]);
-        // TODO: error handling, cleanup. Throw execption?
-        // return;
+        //Start a session:
+        [mMovieWriter startWriting];
+        [mMovieWriter startSessionAtSourceTime:kCMTimeZero];
+
+        if(mMovieWriter.status == AVAssetWriterStatusFailed){
+            NSLog(@"AVF: AVAssetWriter status: %@", [mMovieWriter.error localizedDescription]);
+            // TODO: error handling, cleanup. Throw execption?
+            // return;
+            is_good = false;
+        }
     }
 
     [localpool drain];

--- a/modules/videoio/src/cap_avfoundation_mac.mm
+++ b/modules/videoio/src/cap_avfoundation_mac.mm
@@ -1115,7 +1115,7 @@ bool CvCaptureFile::setProperty(int property_id, double value) {
 
 
 CvVideoWriter_AVFoundation::CvVideoWriter_AVFoundation(const std::string &filename, int fourcc, double fps, CvSize frame_size, int is_color)
-    : is_good(true)
+    : path(0), codec(0), fileType(0), mMovieFPS(0), movieColor(0), mFrameNum(0), is_good(true)
 {
     if (fps <= 0 || frame_size.width <= 0 || frame_size.height <= 0)
     {
@@ -1124,7 +1124,6 @@ CvVideoWriter_AVFoundation::CvVideoWriter_AVFoundation(const std::string &filena
     }
     NSAutoreleasePool* localpool = [[NSAutoreleasePool alloc] init];
 
-    mFrameNum = 0;
     mMovieFPS = fps;
     movieSize = frame_size;
     movieColor = is_color;
@@ -1232,14 +1231,20 @@ CvVideoWriter_AVFoundation::CvVideoWriter_AVFoundation(const std::string &filena
 CvVideoWriter_AVFoundation::~CvVideoWriter_AVFoundation() {
     NSAutoreleasePool* localpool = [[NSAutoreleasePool alloc] init];
 
-    [mMovieWriterInput markAsFinished];
-    [mMovieWriter finishWriting];
-    [mMovieWriter release];
-    [mMovieWriterInput release];
-    [mMovieWriterAdaptor release];
-    [path release];
-    [codec release];
-    [fileType release];
+    if (mMovieWriterInput && mMovieWriter && mMovieWriterAdaptor)
+    {
+        [mMovieWriterInput markAsFinished];
+        [mMovieWriter finishWriting];
+        [mMovieWriter release];
+        [mMovieWriterInput release];
+        [mMovieWriterAdaptor release];
+    }
+    if (path)
+        [path release];
+    if (codec)
+        [codec release];
+    if (fileType)
+        [fileType release];
     cvReleaseImage(&argbimage);
 
     [localpool drain];

--- a/modules/videoio/src/cap_mfx_writer.cpp
+++ b/modules/videoio/src/cap_mfx_writer.cpp
@@ -41,6 +41,12 @@ VideoWriter_IntelMFX::VideoWriter_IntelMFX(const String &filename, int _fourcc, 
         return;
     }
 
+    if (fps <= 0)
+    {
+        MSG(cerr << "MFX: Invalid FPS passed to encoder" << endl);
+        return;
+    }
+
     // Init device and session
     deviceHandler = createDeviceHandler();
     session = new MFXVideoSession();

--- a/modules/videoio/test/test_dynamic.cpp
+++ b/modules/videoio/test/test_dynamic.cpp
@@ -79,5 +79,51 @@ TEST(videoio_dynamic, basic_write)
     remove(filename.c_str());
 }
 
+TEST(videoio_dynamic, write_invalid)
+{
+    vector<VideoCaptureAPIs> backends = videoio_registry::getWriterBackends();
+    for (VideoCaptureAPIs be : backends)
+    {
+        SCOPED_TRACE(be);
+        const string filename = cv::tempfile(".mkv");
+        VideoWriter writer;
+        bool res = true;
+
+        // Bad FourCC
+        EXPECT_NO_THROW(res = writer.open(filename, be, VideoWriter::fourcc('A', 'B', 'C', 'D'), 1, Size(640, 480), true));
+        EXPECT_FALSE(res);
+        EXPECT_FALSE(writer.isOpened());
+
+        // Empty filename
+        EXPECT_NO_THROW(res = writer.open(String(), be, VideoWriter::fourcc('H', '2', '6', '4'), 1, Size(640, 480), true));
+        EXPECT_FALSE(res);
+        EXPECT_FALSE(writer.isOpened());
+        EXPECT_NO_THROW(res = writer.open(String(), be, VideoWriter::fourcc('M', 'J', 'P', 'G'), 1, Size(640, 480), true));
+        EXPECT_FALSE(res);
+        EXPECT_FALSE(writer.isOpened());
+
+        // zero FPS
+        EXPECT_NO_THROW(res = writer.open(filename, be, VideoWriter::fourcc('H', '2', '6', '4'), 0, Size(640, 480), true));
+        EXPECT_FALSE(res);
+        EXPECT_FALSE(writer.isOpened());
+
+        // cleanup
+        EXPECT_NO_THROW(writer.release());
+        remove(filename.c_str());
+    }
+
+    // Generic
+    {
+        VideoWriter writer;
+        bool res = true;
+        EXPECT_NO_THROW(res = writer.open(std::string(), VideoWriter::fourcc('H', '2', '6', '4'), 1, Size(640, 480)));
+        EXPECT_FALSE(res);
+        EXPECT_FALSE(writer.isOpened());
+        EXPECT_NO_THROW(res = writer.open(std::string(), VideoWriter::fourcc('M', 'J', 'P', 'G'), 1, Size(640, 480)));
+        EXPECT_FALSE(res);
+        EXPECT_FALSE(writer.isOpened());
+    }
+}
+
 
 }} // opencv_test::<anonymous>::

--- a/modules/videoio/test/test_mfx.cpp
+++ b/modules/videoio/test/test_mfx.cpp
@@ -35,7 +35,7 @@ TEST(videoio_mfx, write_invalid)
     ASSERT_NO_THROW(res = writer.open(String(), CAP_INTEL_MFX, VideoWriter::fourcc('H', '2', '6', '4'), 1, Size(640, 480), true));
     EXPECT_FALSE(res);
     EXPECT_FALSE(writer.isOpened());
-    ASSERT_ANY_THROW(res = writer.open(filename, CAP_INTEL_MFX, VideoWriter::fourcc('H', '2', '6', '4'), 0, Size(640, 480), true));
+    ASSERT_NO_THROW(res = writer.open(filename, CAP_INTEL_MFX, VideoWriter::fourcc('H', '2', '6', '4'), 0, Size(640, 480), true));
     EXPECT_FALSE(res);
     EXPECT_FALSE(writer.isOpened());
 

--- a/modules/videoio/test/test_video_io.cpp
+++ b/modules/videoio/test/test_video_io.cpp
@@ -381,12 +381,6 @@ static Ext_Fourcc_PSNR synthetic_params[] = {
    makeParam("mp4", "MJPG", 30.f, CAP_AVFOUNDATION),
    makeParam("m4v", "H264", 30.f, CAP_AVFOUNDATION),
    makeParam("m4v", "MJPG", 30.f, CAP_AVFOUNDATION),
-#if MAC_OS_X_VERSION_MIN_REQUIRED >= MAC_OS_X_VERSION_10_11
-   makeParam("3gp", "H264", 30.f, CAP_AVFOUNDATION),
-   makeParam("3gp", "MJPG", 30.f, CAP_AVFOUNDATION),
-   makeParam("3g2", "H264", 30.f, CAP_AVFOUNDATION),
-   makeParam("3g2", "MJPG", 30.f, CAP_AVFOUNDATION),
-#endif
 #endif
 
     makeParam("avi", "XVID", 30.f, CAP_FFMPEG),

--- a/modules/videoio/test/test_video_io.cpp
+++ b/modules/videoio/test/test_video_io.cpp
@@ -381,8 +381,12 @@ static Ext_Fourcc_PSNR synthetic_params[] = {
    makeParam("mp4", "MJPG", 30.f, CAP_AVFOUNDATION),
    makeParam("m4v", "H264", 30.f, CAP_AVFOUNDATION),
    makeParam("m4v", "MJPG", 30.f, CAP_AVFOUNDATION),
+#if MAC_OS_X_VERSION_MIN_REQUIRED >= MAC_OS_X_VERSION_10_11
    makeParam("3gp", "H264", 30.f, CAP_AVFOUNDATION),
    makeParam("3gp", "MJPG", 30.f, CAP_AVFOUNDATION),
+   makeParam("3g2", "H264", 30.f, CAP_AVFOUNDATION),
+   makeParam("3g2", "MJPG", 30.f, CAP_AVFOUNDATION),
+#endif
 #endif
 
     makeParam("avi", "XVID", 30.f, CAP_FFMPEG),


### PR DESCRIPTION
### This pullrequest changes

We expect no throw behavior for incorrect VideoWriter parameters, added test to check this.

Changes in GStreamer backend:
* replaced `abort()` calls with error handling

Changes in AVFoundation VideoWriter backend:
* added support to UTF-8 filenames (not tested)
* removed fallback to mp4/h264 codec in case when extension or FourCC are not supported (supported extensions: `mov, qt, mp4, m4v`, supported FourCC codes: `JPEG, MJPEG, jpeg, mjpeg, H264, avc1`)
* added basic error handling and cleanup

Changes in MediaSDK backend:
* added soft `fps` check and modified


```
force_builders=Linux AVX2
docker_image:Linux AVX2=ubuntu:18.04
```