### PR TITLE
Fixed broken image link

### DIFF
--- a/doc/tutorials/dnn/dnn_googlenet/dnn_googlenet.markdown
+++ b/doc/tutorials/dnn/dnn_googlenet/dnn_googlenet.markdown
@@ -8,7 +8,7 @@ In this tutorial you will learn how to use opencv_dnn module for image classific
 GoogLeNet trained network from [Caffe model zoo](http://caffe.berkeleyvision.org/model_zoo.html).
 
 We will demonstrate results of this example on the following picture.
-![Buran space shuttle](images/space_shuttle.jpg)
+![Buran space shuttle](https://github.com/opencv/opencv_extra/blob/3.4/testdata/dnn/space_shuttle.jpg)
 
 Source Code
 -----------


### PR DESCRIPTION
I happen to notice a broken link while trying to resolve #14148: https://github.com/opencv/opencv/blob/master/doc/tutorials/dnn/dnn_googlenet/dnn_googlenet.markdown

The image of  Buran space shuttle is no longer located at this location: img/space_shuttle.jpg

This image of Buran space shuttle does appear to be in the repository at this location: https://github.com/opencv/opencv_extra/blob/3.4/testdata/dnn/space_shuttle.jpg

<!-- Please use this line to close one or multiple issues when this pullrequest gets merged
You can add another line right under the first one:
resolves #1234
resolves #1235
-->

### This pullrequest changes

<!-- Please describe what your pullrequest is changing -->
