### PR TITLE
Fix Mobilenet v2 from TensorFlow slim

### DIFF
--- a/modules/dnn/src/tensorflow/tf_graph_simplifier.cpp
+++ b/modules/dnn/src/tensorflow/tf_graph_simplifier.cpp
@@ -630,6 +630,21 @@ public:
     }
 };
 
+class SoftMaxSlimSubgraph : public Subgraph
+{
+public:
+    SoftMaxSlimSubgraph()
+    {
+        int input = addNodeToMatch("");
+        int shape = addNodeToMatch("Const");
+        int shapeOp = addNodeToMatch("Shape", input);
+        int reshape = addNodeToMatch("Reshape", input, shape);
+        int softmax = addNodeToMatch("Softmax", reshape);
+        addNodeToMatch("Reshape", softmax, shapeOp);
+        setFusedNode("Softmax", input);
+    }
+};
+
 void simplifySubgraphs(tensorflow::GraphDef& net)
 {
     std::vector<Ptr<Subgraph> > subgraphs;
@@ -646,6 +661,7 @@ void simplifySubgraphs(tensorflow::GraphDef& net)
     subgraphs.push_back(Ptr<Subgraph>(new ResizeBilinearSubgraph()));
     subgraphs.push_back(Ptr<Subgraph>(new UpsamplingKerasSubgraph()));
     subgraphs.push_back(Ptr<Subgraph>(new ReshapeAsShapeSubgraph()));
+    subgraphs.push_back(Ptr<Subgraph>(new SoftMaxSlimSubgraph()));
 
     int numNodes = net.node_size();
     std::vector<int> matchedNodesIds;

--- a/modules/dnn/src/tensorflow/tf_importer.cpp
+++ b/modules/dnn/src/tensorflow/tf_importer.cpp
@@ -661,7 +661,10 @@ void TFImporter::populateNet(Net dstNet)
     RemoveIdentityOps(netTxt);
 
     if (!netTxt.ByteSize())
+    {
         simplifySubgraphs(netBin);
+        sortByExecutionOrder(netBin);
+    }
 
     std::set<String> layers_to_ignore;
 

--- a/modules/dnn/test/test_tf_importer.cpp
+++ b/modules/dnn/test/test_tf_importer.cpp
@@ -549,6 +549,7 @@ TEST_P(Test_TensorFlow_layers, slice)
 TEST_P(Test_TensorFlow_layers, softmax)
 {
     runTensorFlowNet("keras_softmax");
+    runTensorFlowNet("slim_softmax");
 }
 
 TEST_P(Test_TensorFlow_layers, relu6)


### PR DESCRIPTION
<!-- Please use this line to close one or multiple issues when this pullrequest gets merged
You can add another line right under the first one:
resolves #1234
resolves #1235
-->

### This pullrequest changes

resolves https://github.com/opencv/opencv/issues/14149

* This PR adds fusion of SoftMax subgraph from TensorFlow's slim library.
* Apply `sortByExecutionOrder` graph nodes sort function by default

**Merge with extra**: https://github.com/opencv/opencv_extra/pull/586