### PR TITLE
dnn: fix support drop for IE<2018R3

### DIFF
--- a/modules/dnn/src/op_inf_engine.cpp
+++ b/modules/dnn/src/op_inf_engine.cpp
@@ -784,7 +784,11 @@ bool InfEngineBackendLayer::getMemoryShapes(const std::vector<MatShape> &inputs,
                                             std::vector<MatShape> &outputs,
                                             std::vector<MatShape> &internals) const
 {
+#if INF_ENGINE_VER_MAJOR_EQ(INF_ENGINE_RELEASE_2018R3)
+    InferenceEngine::ICNNNetwork::InputShapes inShapes = const_cast<InferenceEngine::CNNNetwork&>(t_net).getInputShapes();
+#else
     InferenceEngine::ICNNNetwork::InputShapes inShapes = t_net.getInputShapes();
+#endif
     InferenceEngine::ICNNNetwork::InputShapes::iterator itr;
     bool equal_flag = true;
     size_t i = 0;

--- a/modules/dnn/src/op_inf_engine.hpp
+++ b/modules/dnn/src/op_inf_engine.hpp
@@ -114,10 +114,8 @@ public:
 
     virtual size_t getBatchSize() const noexcept CV_OVERRIDE;
 
-#if INF_ENGINE_VER_MAJOR_GT(INF_ENGINE_RELEASE_2018R2)
-    virtual InferenceEngine::StatusCode AddExtension(const InferenceEngine::IShapeInferExtensionPtr& extension, InferenceEngine::ResponseDesc* resp) noexcept;
-    virtual InferenceEngine::StatusCode reshape(const InputShapes& inputShapes, InferenceEngine::ResponseDesc* resp) noexcept;
-#endif
+    virtual InferenceEngine::StatusCode AddExtension(const InferenceEngine::IShapeInferExtensionPtr& extension, InferenceEngine::ResponseDesc* resp) noexcept CV_OVERRIDE;
+    virtual InferenceEngine::StatusCode reshape(const InputShapes& inputShapes, InferenceEngine::ResponseDesc* resp) noexcept CV_OVERRIDE;
 
     void init(int targetId);
 


### PR DESCRIPTION
relates #13884

<cut/>

```
force_builders=Custom
buildworker:Custom=linux-2
docker_image:Custom=ubuntu-openvino-2018r3:16.04
test_opencl:Custom=ON
test_bigdata:Custom=1
test_filter:Custom=*
test_modules:Custom=dnn

ci_branch:Linux AVX2=no-checks
docker_image:Linux AVX2=ubuntu-openvino-2018r4:16.04
test_opencl:Linux AVX2=OFF
buildworker:Linux AVX2=linux-1
build_parallel_tests:Linux AVX2=1
test_bigdata:Linux AVX2=1
test_module:Linux AVX2=dnn,python2,python3,java
tests_filter:Linux AVX2=*
```