### PR TITLE
cmake: emit error if CUDA is enabled without opencv_contrib

### DIFF
--- a/modules/core/CMakeLists.txt
+++ b/modules/core/CMakeLists.txt
@@ -35,6 +35,9 @@ if(DEFINED WINRT AND NOT DEFINED ENABLE_WINRT_MODE_NATIVE)
 endif()
 
 if(HAVE_CUDA)
+  if(NOT TARGET opencv_cudev)
+    message(FATAL_ERROR "CUDA: OpenCV requires enabled 'cudev' module from 'opencv_contrib' repository: https://github.com/opencv/opencv_contrib")
+  endif()
   ocv_warnings_disable(CMAKE_CXX_FLAGS -Wundef -Wenum-compare -Wunused-function -Wshadow)
 endif()
 


### PR DESCRIPTION
replaces #14173

[Validated](http://pullrequest.opencv.org/buildbot/builders/precommit_custom_linux/builds/1955/steps/cmake/logs/stdio).

```
buildworker:Custom=linux-1,linux-2,linux-4
docker_image:Custom=ubuntu-cuda:16.04
#build_contrib:Custom=OFF
```