### PR TITLE
imgcodecs: fix RBaseStream::setPos() outside of current block

### DIFF
--- a/modules/imgcodecs/src/bitstrm.cpp
+++ b/modules/imgcodecs/src/bitstrm.cpp
@@ -175,8 +175,11 @@ void  RBaseStream::setPos( int pos )
     }
 
     int offset = pos % m_block_size;
+    int old_block_pos = m_block_pos;
     m_block_pos = pos - offset;
     m_current = m_start + offset;
+    if (old_block_pos != m_block_pos)
+        readBlock();
 }
 
 


### PR DESCRIPTION
Seeking outside of the current block doesn't update actual data, so getByte()/etc will get wrong data from stalled buffer.