### PR TITLE
cmake: fix CUDA world build

### DIFF
--- a/modules/core/CMakeLists.txt
+++ b/modules/core/CMakeLists.txt
@@ -35,7 +35,7 @@ if(DEFINED WINRT AND NOT DEFINED ENABLE_WINRT_MODE_NATIVE)
 endif()
 
 if(HAVE_CUDA)
-  if(NOT TARGET opencv_cudev)
+  if(NOT HAVE_opencv_cudev)
     message(FATAL_ERROR "CUDA: OpenCV requires enabled 'cudev' module from 'opencv_contrib' repository: https://github.com/opencv/opencv_contrib")
   endif()
   ocv_warnings_disable(CMAKE_CXX_FLAGS -Wundef -Wenum-compare -Wunused-function -Wshadow)


### PR DESCRIPTION
resolves #14205

```
force_builders=Custom
buildworker:Custom=linux-2
build_world:Custom=ON
docker_image:Custom=ubuntu-cuda:16.04
build_contrib:Custom=ON
```