### PR TITLE
AVX512 wide universal intrinsics

### DIFF
--- a/modules/core/CMakeLists.txt
+++ b/modules/core/CMakeLists.txt
@@ -13,8 +13,9 @@ ocv_add_dispatched_file(split SSE2 AVX2)
 ocv_add_dispatched_file(sum SSE2 AVX2)
 
 # dispatching for accuracy tests
-ocv_add_dispatched_file_force_all(test_intrin128 TEST SSE2 SSE3 SSSE3 SSE4_1 SSE4_2 AVX FP16 AVX2)
-ocv_add_dispatched_file_force_all(test_intrin256 TEST AVX2)
+ocv_add_dispatched_file_force_all(test_intrin128 TEST SSE2 SSE3 SSSE3 SSE4_1 SSE4_2 AVX FP16 AVX2 AVX512_SKX)
+ocv_add_dispatched_file_force_all(test_intrin256 TEST AVX2 AVX512_SKX)
+ocv_add_dispatched_file_force_all(test_intrin512 TEST AVX512_SKX)
 
 ocv_add_module(core
                OPTIONAL opencv_cudev

--- a/modules/core/include/opencv2/core/hal/intrin.hpp
+++ b/modules/core/include/opencv2/core/hal/intrin.hpp
@@ -184,7 +184,7 @@ using namespace CV_CPU_OPTIMIZATION_HAL_NAMESPACE;
 // we define those sets of intrinsics at once.
 // For some of AVX512 intrinsics get v512_ prefix instead of v_, e.g. v512_load() vs v_load().
 // Wide intrinsics will be mapped to v512_ counterparts in this case(e.g. vx_load() => v512_load())
-#if AVX512_SKX
+#if CV_AVX512_SKX
 
 #define CV__SIMD_FORWARD 512
 #include "opencv2/core/hal/intrin_forward.hpp"

--- a/modules/core/include/opencv2/core/hal/intrin.hpp
+++ b/modules/core/include/opencv2/core/hal/intrin.hpp
@@ -180,6 +180,18 @@ using namespace CV_CPU_OPTIMIZATION_HAL_NAMESPACE;
 
 #endif
 
+// AVX512 can be used together with SSE2 and AVX2, so
+// we define those sets of intrinsics at once.
+// For some of AVX512 intrinsics get v512_ prefix instead of v_, e.g. v512_load() vs v_load().
+// Wide intrinsics will be mapped to v512_ counterparts in this case(e.g. vx_load() => v512_load())
+#if AVX512_SKX
+
+#define CV__SIMD_FORWARD 512
+#include "opencv2/core/hal/intrin_forward.hpp"
+#include "opencv2/core/hal/intrin_avx512.hpp"
+
+#endif
+
 //! @cond IGNORED
 
 namespace cv {
@@ -321,13 +333,41 @@ template<typename _Tp> struct V_RegTraits
     CV_DEF_REG_TRAITS(v256, v_float64x4, double, f64, v_float64x4, void, void, v_int64x4, v_int32x8);
 #endif
 
+#if CV_SIMD512
+    CV_DEF_REG_TRAITS(v512, v_uint8x64, uchar, u8, v_uint8x64, v_uint16x32, v_uint32x16, v_int8x64, void);
+    CV_DEF_REG_TRAITS(v512, v_int8x64, schar, s8, v_uint8x64, v_int16x32, v_int32x16, v_int8x64, void);
+    CV_DEF_REG_TRAITS(v512, v_uint16x32, ushort, u16, v_uint16x32, v_uint32x16, v_uint64x8, v_int16x32, void);
+    CV_DEF_REG_TRAITS(v512, v_int16x32, short, s16, v_uint16x32, v_int32x16, v_int64x8, v_int16x32, void);
+    CV_DEF_REG_TRAITS(v512, v_uint32x16, unsigned, u32, v_uint32x16, v_uint64x8, void, v_int32x16, void);
+    CV_DEF_REG_TRAITS(v512, v_int32x16, int, s32, v_uint32x16, v_int64x8, void, v_int32x16, void);
+    CV_DEF_REG_TRAITS(v512, v_float32x16, float, f32, v_float32x16, v_float64x8, void, v_int32x16, v_int32x16);
+    CV_DEF_REG_TRAITS(v512, v_uint64x8, uint64, u64, v_uint64x8, void, void, v_int64x8, void);
+    CV_DEF_REG_TRAITS(v512, v_int64x8, int64, s64, v_uint64x8, void, void, v_int64x8, void);
+    CV_DEF_REG_TRAITS(v512, v_float64x8, double, f64, v_float64x8, void, void, v_int64x8, v_int32x16);
+#endif
+
 #if CV_SIMD512 && (!defined(CV__SIMD_FORCE_WIDTH) || CV__SIMD_FORCE_WIDTH == 512)
 #define CV__SIMD_NAMESPACE simd512
 namespace CV__SIMD_NAMESPACE {
     #define CV_SIMD 1
     #define CV_SIMD_64F CV_SIMD512_64F
+    #define CV_SIMD_FP16 CV_SIMD512_FP16
     #define CV_SIMD_WIDTH 64
-    // TODO typedef v_uint8 / v_int32 / etc types here
+    typedef v_uint8x64    v_uint8;
+    typedef v_int8x64     v_int8;
+    typedef v_uint16x32   v_uint16;
+    typedef v_int16x32    v_int16;
+    typedef v_uint32x16   v_uint32;
+    typedef v_int32x16    v_int32;
+    typedef v_uint64x8    v_uint64;
+    typedef v_int64x8     v_int64;
+    typedef v_float32x16  v_float32;
+    CV_INTRIN_DEFINE_WIDE_INTRIN_ALL_TYPES(v512)
+#if CV_SIMD512_64F
+    typedef v_float64x8   v_float64;
+    CV_INTRIN_DEFINE_WIDE_INTRIN(double, v_float64, f64, v512, load)
+#endif
+        inline void vx_cleanup() { v512_cleanup(); }
 } // namespace
 using namespace CV__SIMD_NAMESPACE;
 #elif CV_SIMD256 && (!defined(CV__SIMD_FORCE_WIDTH) || CV__SIMD_FORCE_WIDTH == 256)

--- a/modules/core/include/opencv2/core/hal/intrin_avx512.hpp
+++ b/modules/core/include/opencv2/core/hal/intrin_avx512.hpp
@@ -1229,10 +1229,12 @@ inline v_float64x8 v_invsqrt(const v_float64x8& x)
 #if CV_USE_ERRECIP
     return v_float64x8(_mm512_rsqrt28_pd(x.val));
 #else
-    v_float64x8 half = x * v512_setall_f64(0.5);
-    v_float64x8 t = v_float64x8(_mm512_rsqrt14_pd(x.val));
-    t *= v512_setall_f64(1.5) - ((t * t) * half);
-    return t;
+    return v512_setall_f64(1.) / v_sqrt(x);
+//    v_float64x8 half = x * v512_setall_f64(0.5);
+//    v_float64x8 t = v_float64x8(_mm512_rsqrt14_pd(x.val));
+//    t *= v512_setall_f64(1.5) - ((t * t) * half);
+//    t *= v512_setall_f64(1.5) - ((t * t) * half);
+//    return t;
 #endif
 }
 

--- a/modules/core/include/opencv2/core/hal/intrin_avx512.hpp
+++ b/modules/core/include/opencv2/core/hal/intrin_avx512.hpp
@@ -1160,207 +1160,187 @@ inline v_float64x8 v_cvt_f64_high(const v_float32x16& a)
 
 ////////////// Lookup table access ////////////////////
 
-inline v_int8x32 v512_lut(const schar* tab, const int* idx)
+inline v_int8x64 v512_lut(const schar* tab, const int* idx)
 {
-    return v_int8x32(_mm256_setr_epi8(tab[idx[ 0]], tab[idx[ 1]], tab[idx[ 2]], tab[idx[ 3]], tab[idx[ 4]], tab[idx[ 5]], tab[idx[ 6]], tab[idx[ 7]],
-                                      tab[idx[ 8]], tab[idx[ 9]], tab[idx[10]], tab[idx[11]], tab[idx[12]], tab[idx[13]], tab[idx[14]], tab[idx[15]],
-                                      tab[idx[16]], tab[idx[17]], tab[idx[18]], tab[idx[19]], tab[idx[20]], tab[idx[21]], tab[idx[22]], tab[idx[23]],
-                                      tab[idx[24]], tab[idx[25]], tab[idx[26]], tab[idx[27]], tab[idx[28]], tab[idx[29]], tab[idx[30]], tab[idx[31]]));
+    m128i p0 = _mm512_cvtepi32_epi8(_mm512_i32gather_epi32(_mm512_loadu_si512((const __m512i*)idx    ), tab, 1));
+    m128i p1 = _mm512_cvtepi32_epi8(_mm512_i32gather_epi32(_mm512_loadu_si512((const __m512i*)idx + 1), tab, 1));
+    m128i p2 = _mm512_cvtepi32_epi8(_mm512_i32gather_epi32(_mm512_loadu_si512((const __m512i*)idx + 2), tab, 1));
+    m128i p3 = _mm512_cvtepi32_epi8(_mm512_i32gather_epi32(_mm512_loadu_si512((const __m512i*)idx + 3), tab, 1));
+    return v_int8x64(_mm512_inserti32x4(_mm512_inserti32x4(_mm512_inserti32x4(_mm512_castsi128_si512(p0), p1, 1), p2, 2), p3, 3));
 }
-inline v_int8x32 v512_lut_pairs(const schar* tab, const int* idx)
+inline v_int8x64 v512_lut_pairs(const schar* tab, const int* idx)
 {
-    return v_int8x32(_mm256_setr_epi16(*(const short*)(tab + idx[ 0]), *(const short*)(tab + idx[ 1]), *(const short*)(tab + idx[ 2]), *(const short*)(tab + idx[ 3]),
-                                       *(const short*)(tab + idx[ 4]), *(const short*)(tab + idx[ 5]), *(const short*)(tab + idx[ 6]), *(const short*)(tab + idx[ 7]),
-                                       *(const short*)(tab + idx[ 8]), *(const short*)(tab + idx[ 9]), *(const short*)(tab + idx[10]), *(const short*)(tab + idx[11]),
-                                       *(const short*)(tab + idx[12]), *(const short*)(tab + idx[13]), *(const short*)(tab + idx[14]), *(const short*)(tab + idx[15])));
+    m512i mask = _mm512_set1_epi32(0x0000ffff);
+    m256i p0 = _mm512_cvtepi32_epi16(_mm512_i32gather_epi32(_mm512_loadu_si512((const __m512i*)idx    ), tab, 1));
+    m256i p1 = _mm512_cvtepi32_epi16(_mm512_i32gather_epi32(_mm512_loadu_si512((const __m512i*)idx + 1), tab, 1));
+    return v_int8x64(_v512_combine(p0, p1));
 }
-inline v_int8x32 v512_lut_quads(const schar* tab, const int* idx)
+inline v_int8x64 v512_lut_quads(const schar* tab, const int* idx)
 {
-    return v_int8x32(_mm256_i32gather_epi32((const int*)tab, _mm256_loadu_si256((const __m512i*)idx), 1));
+    return v_int8x64(_mm512_i32gather_epi32(_mm512_loadu_si512((const __m512i*)idx), tab, 1));
 }
-inline v_uint8x32 v512_lut(const uchar* tab, const int* idx) { return v_reinterpret_as_u8(v512_lut((const schar *)tab, idx)); }
-inline v_uint8x32 v512_lut_pairs(const uchar* tab, const int* idx) { return v_reinterpret_as_u8(v512_lut_pairs((const schar *)tab, idx)); }
-inline v_uint8x32 v512_lut_quads(const uchar* tab, const int* idx) { return v_reinterpret_as_u8(v512_lut_quads((const schar *)tab, idx)); }
+inline v_uint8x64 v512_lut(const uchar* tab, const int* idx) { return v_reinterpret_as_u8(v512_lut((const schar *)tab, idx)); }
+inline v_uint8x64 v512_lut_pairs(const uchar* tab, const int* idx) { return v_reinterpret_as_u8(v512_lut_pairs((const schar *)tab, idx)); }
+inline v_uint8x64 v512_lut_quads(const uchar* tab, const int* idx) { return v_reinterpret_as_u8(v512_lut_quads((const schar *)tab, idx)); }
 
-inline v_int16x16 v512_lut(const short* tab, const int* idx)
+inline v_int16x32 v512_lut(const short* tab, const int* idx)
 {
-    return v_int16x16(_mm256_setr_epi16(tab[idx[0]], tab[idx[1]], tab[idx[ 2]], tab[idx[ 3]], tab[idx[ 4]], tab[idx[ 5]], tab[idx[ 6]], tab[idx[ 7]],
-                                        tab[idx[8]], tab[idx[9]], tab[idx[10]], tab[idx[11]], tab[idx[12]], tab[idx[13]], tab[idx[14]], tab[idx[15]]));
+    m256i p0 = _mm512_cvtepi32_epi16(_mm512_i32gather_epi32(_mm512_loadu_si512((const __m512i*)idx    ), tab, 2));
+    m256i p1 = _mm512_cvtepi32_epi16(_mm512_i32gather_epi32(_mm512_loadu_si512((const __m512i*)idx + 1), tab, 2));
+    return v_int16x32(_v512_combine(p0, p1));
 }
-inline v_int16x16 v512_lut_pairs(const short* tab, const int* idx)
+inline v_int16x32 v512_lut_pairs(const short* tab, const int* idx)
 {
-    return v_int16x16(_mm256_i32gather_epi32((const int*)tab, _mm256_loadu_si256((const __m512i*)idx), 2));
+    return v_int16x32(_mm512_i32gather_epi32(_mm512_loadu_si512((const __m512i*)idx), tab, 2));
 }
-inline v_int16x16 v512_lut_quads(const short* tab, const int* idx)
+inline v_int16x32 v512_lut_quads(const short* tab, const int* idx)
 {
-#if defined(__GNUC__)
-    return v_int16x16(_mm256_i32gather_epi64((const long long int*)tab, _mm_loadu_si128((const __m256i*)idx), 2));//Looks like intrinsic has wrong definition
-#else
-    return v_int16x16(_mm256_i32gather_epi64((const int64*)tab, _mm_loadu_si128((const __m256i*)idx), 2));
-#endif
+    return v_int16x32(_mm512_i32gather_epi64(_mm256_loadu_si256((const __m256i*)idx), tab, 2));
 }
-inline v_uint16x16 v512_lut(const ushort* tab, const int* idx) { return v_reinterpret_as_u16(v512_lut((const short *)tab, idx)); }
-inline v_uint16x16 v512_lut_pairs(const ushort* tab, const int* idx) { return v_reinterpret_as_u16(v512_lut_pairs((const short *)tab, idx)); }
-inline v_uint16x16 v512_lut_quads(const ushort* tab, const int* idx) { return v_reinterpret_as_u16(v512_lut_quads((const short *)tab, idx)); }
+inline v_uint16x32 v512_lut(const ushort* tab, const int* idx) { return v_reinterpret_as_u16(v512_lut((const short *)tab, idx)); }
+inline v_uint16x32 v512_lut_pairs(const ushort* tab, const int* idx) { return v_reinterpret_as_u16(v512_lut_pairs((const short *)tab, idx)); }
+inline v_uint16x32 v512_lut_quads(const ushort* tab, const int* idx) { return v_reinterpret_as_u16(v512_lut_quads((const short *)tab, idx)); }
 
-inline v_int32x8 v512_lut(const int* tab, const int* idx)
+inline v_int32x16 v512_lut(const int* tab, const int* idx)
 {
-    return v_int32x8(_mm256_i32gather_epi32(tab, _mm256_loadu_si256((const __m512i*)idx), 4));
+    return v_int32x16(_mm512_i32gather_epi32(_mm512_loadu_si512((const __m512i*)idx), tab, 4));
 }
-inline v_int32x8 v512_lut_pairs(const int* tab, const int* idx)
+inline v_int32x16 v512_lut_pairs(const int* tab, const int* idx)
 {
-#if defined(__GNUC__)
-    return v_int32x8(_mm256_i32gather_epi64((const long long int*)tab, _mm_loadu_si128((const __m256i*)idx), 4));
-#else
-    return v_int32x8(_mm256_i32gather_epi64((const int64*)tab, _mm_loadu_si128((const __m256i*)idx), 4));
-#endif
+    return v_int32x16(_mm512_i32gather_epi64(_mm256_loadu_si256((const __m256i*)idx), tab, 4));
 }
-inline v_int32x8 v512_lut_quads(const int* tab, const int* idx)
+inline v_int32x16 v512_lut_quads(const int* tab, const int* idx)
 {
-    return v_int32x8(_mm256_insertf128_si256(_mm256_castsi128_si256(_mm_loadu_si128((const __m256i*)(tab + idx[0]))), _mm_loadu_si128((const __m256i*)(tab + idx[1])), 0x1));
+    return v_int32x16(_mm512_inserti32x4(_mm512_inserti32x4(_mm512_inserti32x4(_mm512_castsi128_si512(
+                          _mm_loadu_si128((const __m128i*)(tab + idx[0]))),
+                          _mm_loadu_si128((const __m128i*)(tab + idx[1])), 1),
+                          _mm_loadu_si128((const __m128i*)(tab + idx[2])), 2),
+                          _mm_loadu_si128((const __m128i*)(tab + idx[3])), 3));
 }
-inline v_uint32x8 v512_lut(const unsigned* tab, const int* idx) { return v_reinterpret_as_u32(v512_lut((const int *)tab, idx)); }
-inline v_uint32x8 v512_lut_pairs(const unsigned* tab, const int* idx) { return v_reinterpret_as_u32(v512_lut_pairs((const int *)tab, idx)); }
-inline v_uint32x8 v512_lut_quads(const unsigned* tab, const int* idx) { return v_reinterpret_as_u32(v512_lut_quads((const int *)tab, idx)); }
+inline v_uint32x16 v512_lut(const unsigned* tab, const int* idx) { return v_reinterpret_as_u32(v512_lut((const int *)tab, idx)); }
+inline v_uint32x16 v512_lut_pairs(const unsigned* tab, const int* idx) { return v_reinterpret_as_u32(v512_lut_pairs((const int *)tab, idx)); }
+inline v_uint32x16 v512_lut_quads(const unsigned* tab, const int* idx) { return v_reinterpret_as_u32(v512_lut_quads((const int *)tab, idx)); }
 
-inline v_int64x4 v512_lut(const int64* tab, const int* idx)
+inline v_int64x8 v512_lut(const int64* tab, const int* idx)
 {
-#if defined(__GNUC__)
-    return v_int64x4(_mm256_i32gather_epi64((const long long int*)tab, _mm_loadu_si128((const __m256i*)idx), 8));
-#else
-    return v_int64x4(_mm256_i32gather_epi64(tab, _mm_loadu_si128((const __m256i*)idx), 8));
-#endif
+    return v_int64x8(_mm512_i32gather_epi64(_mm256_loadu_si256((const __m256i*)idx), tab , 8));
 }
-inline v_int64x4 v512_lut_pairs(const int64* tab, const int* idx)
+inline v_int64x8 v512_lut_pairs(const int64* tab, const int* idx)
 {
-    return v_int64x4(_mm256_insertf128_si256(_mm256_castsi128_si256(_mm_loadu_si128((const __m256i*)(tab + idx[0]))), _mm_loadu_si128((const __m256i*)(tab + idx[1])), 0x1));
+    return v_int64x8(_mm512_inserti32x4(_mm512_inserti32x4(_mm512_inserti32x4(_mm512_castsi128_si512(
+                         _mm_loadu_si128((const __m128i*)(tab + idx[0]))),
+                         _mm_loadu_si128((const __m128i*)(tab + idx[1])), 1),
+                         _mm_loadu_si128((const __m128i*)(tab + idx[2])), 2),
+                         _mm_loadu_si128((const __m128i*)(tab + idx[3])), 3));
 }
-inline v_uint64x4 v512_lut(const uint64* tab, const int* idx) { return v_reinterpret_as_u64(v512_lut((const int64 *)tab, idx)); }
-inline v_uint64x4 v512_lut_pairs(const uint64* tab, const int* idx) { return v_reinterpret_as_u64(v512_lut_pairs((const int64 *)tab, idx)); }
+inline v_uint64x8 v512_lut(const uint64* tab, const int* idx) { return v_reinterpret_as_u64(v512_lut((const int64 *)tab, idx)); }
+inline v_uint64x8 v512_lut_pairs(const uint64* tab, const int* idx) { return v_reinterpret_as_u64(v512_lut_pairs((const int64 *)tab, idx)); }
 
-inline v_float32x8 v512_lut(const float* tab, const int* idx)
+inline v_float32x16 v512_lut(const float* tab, const int* idx)
 {
-    return v_float32x8(_mm256_i32gather_ps(tab, _mm256_loadu_si256((const __m512i*)idx), 4));
+    return v_float32x16(_mm512_i32gather_ps(_mm512_loadu_si512((const __m512i*)idx), tab, 4));
 }
-inline v_float32x8 v512_lut_pairs(const float* tab, const int* idx) { return v_reinterpret_as_f32(v512_lut_pairs((const int *)tab, idx)); }
-inline v_float32x8 v512_lut_quads(const float* tab, const int* idx) { return v_reinterpret_as_f32(v512_lut_quads((const int *)tab, idx)); }
+inline v_float32x16 v512_lut_pairs(const float* tab, const int* idx) { return v_reinterpret_as_f32(v512_lut_pairs((const int *)tab, idx)); }
+inline v_float32x16 v512_lut_quads(const float* tab, const int* idx) { return v_reinterpret_as_f32(v512_lut_quads((const int *)tab, idx)); }
 
-inline v_float64x4 v512_lut(const double* tab, const int* idx)
+inline v_float64x8 v512_lut(const double* tab, const int* idx)
 {
-    return v_float64x4(_mm256_i32gather_pd(tab, _mm_loadu_si128((const __m256i*)idx), 8));
+    return v_float64x8(_mm512_i32gather_pd(_mm256_loadu_si256((const __m256i*)idx), tab, 8));
 }
-inline v_float64x4 v512_lut_pairs(const double* tab, const int* idx) { return v_float64x4(_mm256_insertf128_pd(_mm256_castpd128_pd256(_mm_loadu_pd(tab + idx[0])), _mm_loadu_pd(tab + idx[1]), 0x1)); }
-
-inline v_int32x8 v_lut(const int* tab, const v_int32x8& idxvec)
-{
-    return v_int32x8(_mm256_i32gather_epi32(tab, idxvec.val, 4));
+inline v_float64x8 v512_lut_pairs(const double* tab, const int* idx) { 
+        return v_float64x8(_mm512_insertf64x2(_mm512_insertf64x2(_mm512_insertf64x2(_mm512_castpd128_pd512(
+                               _mm_loadu_pd(tab + idx[0])),
+                               _mm_loadu_pd(tab + idx[1]), 1),
+                               _mm_loadu_pd(tab + idx[2]), 2),
+                               _mm_loadu_pd(tab + idx[3]), 3));
 }
 
-inline v_uint32x8 v_lut(const unsigned* tab, const v_int32x8& idxvec)
+inline v_int32x16 v_lut(const int* tab, const v_int32x16& idxvec)
+{
+    return v_int32x16(_mm512_i32gather_epi32(idxvec.val, tab, 4));
+}
+
+inline v_uint32x16 v_lut(const unsigned* tab, const v_int32x16& idxvec)
 {
     return v_reinterpret_as_u32(v_lut((const int *)tab, idxvec));
 }
 
-inline v_float32x8 v_lut(const float* tab, const v_int32x8& idxvec)
+inline v_float32x16 v_lut(const float* tab, const v_int32x16& idxvec)
 {
-    return v_float32x8(_mm256_i32gather_ps(tab, idxvec.val, 4));
+    return v_float32x16(_mm512_i32gather_ps(idxvec.val, tab, 4));
 }
 
-inline v_float64x4 v_lut(const double* tab, const v_int32x8& idxvec)
+inline v_float64x8 v_lut(const double* tab, const v_int32x16& idxvec)
 {
-    return v_float64x4(_mm256_i32gather_pd(tab, _mm256_castsi256_si128(idxvec.val), 8));
+    return v_float64x8(_mm512_i32gather_pd(_v512_extract_low(idxvec.val), tab, 8));
 }
 
-inline void v_lut_deinterleave(const float* tab, const v_int32x8& idxvec, v_float32x8& x, v_float32x8& y)
+inline void v_lut_deinterleave(const float* tab, const v_int32x16& idxvec, v_float32x16& x, v_float32x16& y)
 {
-    int CV_DECL_ALIGNED(32) idx[8];
-    v_store_aligned(idx, idxvec);
-    __m256 z = _mm_setzero_ps();
-    __m256 xy01, xy45, xy23, xy67;
-    xy01 = _mm_loadl_pi(z, (const __m64*)(tab + idx[0]));
-    xy01 = _mm_loadh_pi(xy01, (const __m64*)(tab + idx[1]));
-    xy45 = _mm_loadl_pi(z, (const __m64*)(tab + idx[4]));
-    xy45 = _mm_loadh_pi(xy45, (const __m64*)(tab + idx[5]));
-    __m512 xy0145 = _v512_combine(xy01, xy45);
-    xy23 = _mm_loadl_pi(z, (const __m64*)(tab + idx[2]));
-    xy23 = _mm_loadh_pi(xy23, (const __m64*)(tab + idx[3]));
-    xy67 = _mm_loadl_pi(z, (const __m64*)(tab + idx[6]));
-    xy67 = _mm_loadh_pi(xy67, (const __m64*)(tab + idx[7]));
-    __m512 xy2367 = _v512_combine(xy23, xy67);
-
-    __m512 xxyy0145 = _mm256_unpacklo_ps(xy0145, xy2367);
-    __m512 xxyy2367 = _mm256_unpackhi_ps(xy0145, xy2367);
-
-    x = v_float32x8(_mm256_unpacklo_ps(xxyy0145, xxyy2367));
-    y = v_float32x8(_mm256_unpackhi_ps(xxyy0145, xxyy2367));
+    x.val = _mm512_i32gather_ps(idxvec.val, tab, 4);
+    y.val = _mm512_i32gather_ps(idxvec.val, tab + 1, 4);
 }
 
-inline void v_lut_deinterleave(const double* tab, const v_int32x8& idxvec, v_float64x4& x, v_float64x4& y)
+inline void v_lut_deinterleave(const double* tab, const v_int32x16& idxvec, v_float64x8& x, v_float64x8& y)
 {
-    int CV_DECL_ALIGNED(32) idx[4];
-    v_store_low(idx, idxvec);
-    __m256d xy0 = _mm_loadu_pd(tab + idx[0]);
-    __m256d xy2 = _mm_loadu_pd(tab + idx[2]);
-    __m256d xy1 = _mm_loadu_pd(tab + idx[1]);
-    __m256d xy3 = _mm_loadu_pd(tab + idx[3]);
-    __m512d xy02 = _v512_combine(xy0, xy2);
-    __m512d xy13 = _v512_combine(xy1, xy3);
-
-    x = v_float64x4(_mm256_unpacklo_pd(xy02, xy13));
-    y = v_float64x4(_mm256_unpackhi_pd(xy02, xy13));
+    x.val = _mm512_i32gather_pd(_v512_extract_low(idxvec.val), tab, 8);
+    y.val = _mm512_i32gather_pd(_v512_extract_low(idxvec.val), tab + 1, 8);
 }
 
-inline v_int8x32 v_interleave_pairs(const v_int8x32& vec)
+inline v_int8x64 v_interleave_pairs(const v_int8x64& vec)
 {
-    return v_int8x32(_mm256_shuffle_epi8(vec.val, _mm256_set_epi64x(0x0f0d0e0c0b090a08, 0x0705060403010200, 0x0f0d0e0c0b090a08, 0x0705060403010200)));
+    return v_int8x64(_mm512_shuffle_epi8(vec.val, _mm512_setr4_epi32(0x0f0d0e0c, 0x0b090a08, 0x07050604, 0x03010200)));
 }
-inline v_uint8x32 v_interleave_pairs(const v_uint8x32& vec) { return v_reinterpret_as_u8(v_interleave_pairs(v_reinterpret_as_s8(vec))); }
-inline v_int8x32 v_interleave_quads(const v_int8x32& vec)
+inline v_uint8x64 v_interleave_pairs(const v_uint8x64& vec) { return v_reinterpret_as_u8(v_interleave_pairs(v_reinterpret_as_s8(vec))); }
+inline v_int8x64 v_interleave_quads(const v_int8x64& vec)
 {
-    return v_int8x32(_mm256_shuffle_epi8(vec.val, _mm256_set_epi64x(0x0f0b0e0a0d090c08, 0x0703060205010400, 0x0f0b0e0a0d090c08, 0x0703060205010400)));
+    return v_int8x64(_mm512_shuffle_epi8(vec.val, _mm512_setr4_epi32(0x0f0b0e0a, 0x0d090c08, 0x07030602, 0x05010400)));
 }
-inline v_uint8x32 v_interleave_quads(const v_uint8x32& vec) { return v_reinterpret_as_u8(v_interleave_quads(v_reinterpret_as_s8(vec))); }
+inline v_uint8x64 v_interleave_quads(const v_uint8x64& vec) { return v_reinterpret_as_u8(v_interleave_quads(v_reinterpret_as_s8(vec))); }
 
-inline v_int16x16 v_interleave_pairs(const v_int16x16& vec)
+inline v_int16x32 v_interleave_pairs(const v_int16x32& vec)
 {
-    return v_int16x16(_mm256_shuffle_epi8(vec.val, _mm256_set_epi64x(0x0f0e0b0a0d0c0908, 0x0706030205040100, 0x0f0e0b0a0d0c0908, 0x0706030205040100)));
+    return v_int16x16(_mm512_shuffle_epi8(vec.val, _mm512_setr4_epi32(0x0f0e0b0a, 0x0d0c0908, 0x07060302, 0x05040100)));
 }
-inline v_uint16x16 v_interleave_pairs(const v_uint16x16& vec) { return v_reinterpret_as_u16(v_interleave_pairs(v_reinterpret_as_s16(vec))); }
-inline v_int16x16 v_interleave_quads(const v_int16x16& vec)
+inline v_uint16x32 v_interleave_pairs(const v_uint16x32& vec) { return v_reinterpret_as_u16(v_interleave_pairs(v_reinterpret_as_s16(vec))); }
+inline v_int16x32 v_interleave_quads(const v_int16x32& vec)
 {
-    return v_int16x16(_mm256_shuffle_epi8(vec.val, _mm256_set_epi64x(0x0f0e07060d0c0504, 0x0b0a030209080100, 0x0f0e07060d0c0504, 0x0b0a030209080100)));
+    return v_int16x32(_mm512_shuffle_epi8(vec.val, _mm512_setr4_epi32(0x0f0e0706, 0x0d0c0504, 0x0b0a0302, 0x09080100)));
 }
-inline v_uint16x16 v_interleave_quads(const v_uint16x16& vec) { return v_reinterpret_as_u16(v_interleave_quads(v_reinterpret_as_s16(vec))); }
+inline v_uint16x32 v_interleave_quads(const v_uint16x32& vec) { return v_reinterpret_as_u16(v_interleave_quads(v_reinterpret_as_s16(vec))); }
 
-inline v_int32x8 v_interleave_pairs(const v_int32x8& vec)
+inline v_int32x16 v_interleave_pairs(const v_int32x16& vec)
 {
-    return v_int32x8(_mm256_shuffle_epi32(vec.val, _MM_SHUFFLE(3, 1, 2, 0)));
+    return v_int32x16(_mm512_shuffle_epi32(vec.val, _MM_SHUFFLE(3, 1, 2, 0)));
 }
-inline v_uint32x8 v_interleave_pairs(const v_uint32x8& vec) { return v_reinterpret_as_u32(v_interleave_pairs(v_reinterpret_as_s32(vec))); }
-inline v_float32x8 v_interleave_pairs(const v_float32x8& vec) { return v_reinterpret_as_f32(v_interleave_pairs(v_reinterpret_as_s32(vec))); }
+inline v_uint32x16 v_interleave_pairs(const v_uint32x16& vec) { return v_reinterpret_as_u32(v_interleave_pairs(v_reinterpret_as_s32(vec))); }
+inline v_float32x16 v_interleave_pairs(const v_float32x16& vec) { return v_reinterpret_as_f32(v_interleave_pairs(v_reinterpret_as_s32(vec))); }
 
-inline v_int8x32 v_pack_triplets(const v_int8x32& vec)
+inline v_int8x64 v_pack_triplets(const v_int8x64& vec)
 {
-    return v_int8x32(_mm256_permutevar8x32_epi32(_mm256_shuffle_epi8(vec.val, _mm256_broadcastsi128_si256(_mm_set_epi64x(0xffffff0f0e0d0c0a, 0x0908060504020100))),
-                                                 _mm256_set_epi64x(0x0000000700000007, 0x0000000600000005, 0x0000000400000002, 0x0000000100000000)));
+    return v_int8x64(_mm512_permutexvar_epi32(_mm512_set_epi64(0x0000000f0000000f, 0x0000000f0000000f, 0x0000000e0000000d, 0x0000000c0000000a,
+                                                               0x0000000900000008, 0x0000000600000005, 0x0000000400000002, 0x0000000100000000),
+                                              _mm512_shuffle_epi8(vec.val, _mm512_setr4_epi32(0xffffff0f, 0x0e0d0c0a, 0x09080605, 0x04020100))));
 }
-inline v_uint8x32 v_pack_triplets(const v_uint8x32& vec) { return v_reinterpret_as_u8(v_pack_triplets(v_reinterpret_as_s8(vec))); }
+inline v_uint8x64 v_pack_triplets(const v_uint8x64& vec) { return v_reinterpret_as_u8(v_pack_triplets(v_reinterpret_as_s8(vec))); }
 
-inline v_int16x16 v_pack_triplets(const v_int16x16& vec)
+inline v_int16x32 v_pack_triplets(const v_int16x32& vec)
 {
-    return v_int16x16(_mm256_permutevar8x32_epi32(_mm256_shuffle_epi8(vec.val, _mm256_broadcastsi128_si256(_mm_set_epi64x(0xffff0f0e0d0c0b0a, 0x0908050403020100))),
-                                                  _mm256_set_epi64x(0x0000000700000007, 0x0000000600000005, 0x0000000400000002, 0x0000000100000000)));
+    return v_int16x32(_mm512_permutexvar_epi16(_mm512_set_epi64(0x001f001f001f001f, 0x001f001f001f001f, 0x001e001d001c001a, 0x0019001800160015,
+                                                                0x0014001200110010, 0x000e000d000c000a, 0x0009000800060005, 0x0004000200010000), vec.val));
 }
-inline v_uint16x16 v_pack_triplets(const v_uint16x16& vec) { return v_reinterpret_as_u16(v_pack_triplets(v_reinterpret_as_s16(vec))); }
+inline v_uint16x32 v_pack_triplets(const v_uint16x32& vec) { return v_reinterpret_as_u16(v_pack_triplets(v_reinterpret_as_s16(vec))); }
 
-inline v_int32x8 v_pack_triplets(const v_int32x8& vec)
+inline v_int32x16 v_pack_triplets(const v_int32x16& vec)
 {
-    return v_int32x8(_mm256_permutevar8x32_epi32(vec.val, _mm256_set_epi64x(0x0000000700000007, 0x0000000600000005, 0x0000000400000002, 0x0000000100000000)));
+    return v_int32x16(_mm512_permutexvar_epi32(_mm512_set_epi64(0x0000000f0000000f, 0x0000000f0000000f, 0x0000000e0000000d, 0x0000000c0000000a,
+                                                                0x0000000900000008, 0x0000000600000005, 0x0000000400000002, 0x0000000100000000), vec.val));
 }
-inline v_uint32x8 v_pack_triplets(const v_uint32x8& vec) { return v_reinterpret_as_u32(v_pack_triplets(v_reinterpret_as_s32(vec))); }
-inline v_float32x8 v_pack_triplets(const v_float32x8& vec)
+inline v_uint32x16 v_pack_triplets(const v_uint32x16& vec) { return v_reinterpret_as_u32(v_pack_triplets(v_reinterpret_as_s32(vec))); }
+inline v_float32x16 v_pack_triplets(const v_float32x16& vec)
 {
-    return v_float32x8(_mm256_permutevar8x32_ps(vec.val, _mm256_set_epi64x(0x0000000700000007, 0x0000000600000005, 0x0000000400000002, 0x0000000100000000)));
+    return v_float32x16(_mm512_permutexvar_ps(_mm512_set_epi64(0x0000000f0000000f, 0x0000000f0000000f, 0x0000000e0000000d, 0x0000000c0000000a,
+                                                               0x0000000900000008, 0x0000000600000005, 0x0000000400000002, 0x0000000100000000), vec.val));
 }
 
 ////////// Matrix operations /////////

--- a/modules/core/include/opencv2/core/hal/intrin_avx512.hpp
+++ b/modules/core/include/opencv2/core/hal/intrin_avx512.hpp
@@ -1817,440 +1817,420 @@ inline void v_load_deinterleave( const uint64* ptr, v_uint64x8& b, v_uint64x8& g
 
 ///////////////////////////// store interleave /////////////////////////////////////
 
-inline void v_store_interleave( uchar* ptr, const v_uint8x32& x, const v_uint8x32& y,
+inline void v_store_interleave( uchar* ptr, const v_uint8x64& x, const v_uint8x64& y,
                                 hal::StoreMode mode=hal::STORE_UNALIGNED )
 {
-    __m512i xy_l = _mm256_unpacklo_epi8(x.val, y.val);
-    __m512i xy_h = _mm256_unpackhi_epi8(x.val, y.val);
-
-    __m512i xy0 = _mm256_permute2x128_si256(xy_l, xy_h, 0 + 2*16);
-    __m512i xy1 = _mm256_permute2x128_si256(xy_l, xy_h, 1 + 3*16);
+    __m512i mask0 = _mm512_set_epi8(  95,  31,  94,  30,  93,  29,  92,  28,  91,  27,  90,  26,  89,  25,  88,  24
+                                      87,  23,  86,  22,  85,  21,  84,  20,  83,  19,  82,  18,  81,  17,  80,  16
+                                      79,  15,  78,  14,  77,  13,  76,  12,  75,  11,  74,  10,  73,   9,  72,   8
+                                      71,   7,  70,   6,  69,   5,  68,   4,  67,   3,  66,   2,  65,   1,  64,   0 );
+    __m512i mask1 = _mm512_set_epi8( 127,  63, 126,  62, 125,  61, 124,  60, 123,  59, 122,  58, 121,  57, 120,  56
+                                     119,  55, 118,  54, 117,  53, 116,  52, 115,  51, 114,  50, 113,  49, 112,  48
+                                     111,  47, 110,  46, 109,  45, 108,  44, 107,  43, 106,  42, 105,  41, 104,  40
+                                     103,  39, 102,  38, 101,  37, 100,  36,  99,  35,  98,  34,  97,  33,  96,  32 );
+    __m512i xy0 = _mm512_permutex2var_epi8(x, mask0, y);
+    __m512i xy1 = _mm512_permutex2var_epi8(x, mask1, y);
 
     if( mode == hal::STORE_ALIGNED_NOCACHE )
     {
-        _mm256_stream_si256((__m512i*)ptr, xy0);
-        _mm256_stream_si256((__m512i*)(ptr + 32), xy1);
+        _mm512_stream_si512((__m512i*)ptr, xy0);
+        _mm512_stream_si512((__m512i*)(ptr + 64), xy1);
     }
     else if( mode == hal::STORE_ALIGNED )
     {
-        _mm256_store_si256((__m512i*)ptr, xy0);
-        _mm256_store_si256((__m512i*)(ptr + 32), xy1);
+        _mm512_store_si512((__m512i*)ptr, xy0);
+        _mm512_store_si512((__m512i*)(ptr + 64), xy1);
     }
     else
     {
-        _mm256_storeu_si256((__m512i*)ptr, xy0);
-        _mm256_storeu_si256((__m512i*)(ptr + 32), xy1);
+        _mm512_storeu_si512((__m512i*)ptr, xy0);
+        _mm512_storeu_si512((__m512i*)(ptr + 64), xy1);
     }
 }
 
-inline void v_store_interleave( ushort* ptr, const v_uint16x16& x, const v_uint16x16& y,
+inline void v_store_interleave( ushort* ptr, const v_uint16x32& x, const v_uint16x32& y,
                                 hal::StoreMode mode=hal::STORE_UNALIGNED )
 {
-    __m512i xy_l = _mm256_unpacklo_epi16(x.val, y.val);
-    __m512i xy_h = _mm256_unpackhi_epi16(x.val, y.val);
-
-    __m512i xy0 = _mm256_permute2x128_si256(xy_l, xy_h, 0 + 2*16);
-    __m512i xy1 = _mm256_permute2x128_si256(xy_l, xy_h, 1 + 3*16);
+    __m512i mask0 = _mm512_set_epi16( 47, 15, 46, 14, 45, 13, 44, 12, 43, 11, 42, 10, 41,  9, 40,  8
+                                      39,  7, 38,  6, 37,  5, 36,  4, 35,  3, 34,  2, 33,  1, 32,  0 );
+    __m512i mask1 = _mm512_set_epi16( 63, 31, 62, 30, 61, 29, 60, 28, 59, 27, 58, 26, 57, 25, 56, 24
+                                      55, 23, 54, 22, 53, 21, 52, 20, 51, 19, 50, 18, 49, 17, 48, 16 );
+    __m512i xy0 = _mm512_permutex2var_epi16(x, mask0, y);
+    __m512i xy1 = _mm512_permutex2var_epi16(x, mask1, y);
 
     if( mode == hal::STORE_ALIGNED_NOCACHE )
     {
-        _mm256_stream_si256((__m512i*)ptr, xy0);
-        _mm256_stream_si256((__m512i*)(ptr + 16), xy1);
+        _mm512_stream_si512((__m512i*)ptr, xy0);
+        _mm512_stream_si512((__m512i*)(ptr + 32), xy1);
     }
     else if( mode == hal::STORE_ALIGNED )
     {
-        _mm256_store_si256((__m512i*)ptr, xy0);
-        _mm256_store_si256((__m512i*)(ptr + 16), xy1);
+        _mm512_store_si512((__m512i*)ptr, xy0);
+        _mm512_store_si512((__m512i*)(ptr + 32), xy1);
     }
     else
     {
-        _mm256_storeu_si256((__m512i*)ptr, xy0);
-        _mm256_storeu_si256((__m512i*)(ptr + 16), xy1);
+        _mm512_storeu_si512((__m512i*)ptr, xy0);
+        _mm512_storeu_si512((__m512i*)(ptr + 32), xy1);
     }
 }
 
-inline void v_store_interleave( unsigned* ptr, const v_uint32x8& x, const v_uint32x8& y,
+inline void v_store_interleave( unsigned* ptr, const v_uint32x16& x, const v_uint32x16& y,
                                 hal::StoreMode mode=hal::STORE_UNALIGNED )
 {
-    __m512i xy_l = _mm256_unpacklo_epi32(x.val, y.val);
-    __m512i xy_h = _mm256_unpackhi_epi32(x.val, y.val);
-
-    __m512i xy0 = _mm256_permute2x128_si256(xy_l, xy_h, 0 + 2*16);
-    __m512i xy1 = _mm256_permute2x128_si256(xy_l, xy_h, 1 + 3*16);
+    __m512i mask0 = _mm512_set_epi32( 23,  7, 22,  6, 21,  5, 20,  4, 19,  3, 18,  2, 17, 1, 16, 0 );
+    __m512i mask1 = _mm512_set_epi32( 31, 15, 30, 14, 29, 13, 28, 12, 27, 11, 26, 10, 25, 9, 24, 8 );
+    __m512i xy0 = _mm512_permutex2var_epi32(x, mask0, y);
+    __m512i xy1 = _mm512_permutex2var_epi32(x, mask1, y);
 
     if( mode == hal::STORE_ALIGNED_NOCACHE )
     {
-        _mm256_stream_si256((__m512i*)ptr, xy0);
-        _mm256_stream_si256((__m512i*)(ptr + 8), xy1);
+        _mm512_stream_si512((__m512i*)ptr, xy0);
+        _mm512_stream_si512((__m512i*)(ptr + 16), xy1);
     }
     else if( mode == hal::STORE_ALIGNED )
     {
-        _mm256_store_si256((__m512i*)ptr, xy0);
-        _mm256_store_si256((__m512i*)(ptr + 8), xy1);
+        _mm512_store_si512((__m512i*)ptr, xy0);
+        _mm512_store_si512((__m512i*)(ptr + 16), xy1);
     }
     else
     {
-        _mm256_storeu_si256((__m512i*)ptr, xy0);
-        _mm256_storeu_si256((__m512i*)(ptr + 8), xy1);
+        _mm512_storeu_si512((__m512i*)ptr, xy0);
+        _mm512_storeu_si512((__m512i*)(ptr + 16), xy1);
     }
 }
 
-inline void v_store_interleave( uint64* ptr, const v_uint64x4& x, const v_uint64x4& y,
+inline void v_store_interleave( uint64* ptr, const v_uint64x8& x, const v_uint64x8& y,
                                 hal::StoreMode mode=hal::STORE_UNALIGNED )
 {
-    __m512i xy_l = _mm256_unpacklo_epi64(x.val, y.val);
-    __m512i xy_h = _mm256_unpackhi_epi64(x.val, y.val);
-
-    __m512i xy0 = _mm256_permute2x128_si256(xy_l, xy_h, 0 + 2*16);
-    __m512i xy1 = _mm256_permute2x128_si256(xy_l, xy_h, 1 + 3*16);
+    __m512i mask0 = _mm512_set_epi64( 11, 3, 10, 2,  9, 1,  8, 0 );
+    __m512i mask1 = _mm512_set_epi64( 15, 7, 14, 6, 13, 5, 12, 4 );
+    __m512i xy0 = _mm512_permutex2var_epi64(x, mask0, y);
+    __m512i xy1 = _mm512_permutex2var_epi64(x, mask1, y);
 
     if( mode == hal::STORE_ALIGNED_NOCACHE )
     {
-        _mm256_stream_si256((__m512i*)ptr, xy0);
-        _mm256_stream_si256((__m512i*)(ptr + 4), xy1);
+        _mm512_stream_si512((__m512i*)ptr, xy0);
+        _mm512_stream_si512((__m512i*)(ptr + 8), xy1);
     }
     else if( mode == hal::STORE_ALIGNED )
     {
-        _mm256_store_si256((__m512i*)ptr, xy0);
-        _mm256_store_si256((__m512i*)(ptr + 4), xy1);
+        _mm512_store_si512((__m512i*)ptr, xy0);
+        _mm512_store_si512((__m512i*)(ptr + 8), xy1);
     }
     else
     {
-        _mm256_storeu_si256((__m512i*)ptr, xy0);
-        _mm256_storeu_si256((__m512i*)(ptr + 4), xy1);
+        _mm512_storeu_si512((__m512i*)ptr, xy0);
+        _mm512_storeu_si512((__m512i*)(ptr + 8), xy1);
     }
 }
 
-inline void v_store_interleave( uchar* ptr, const v_uint8x32& b, const v_uint8x32& g, const v_uint8x32& r,
+inline void v_store_interleave( uchar* ptr, const v_uint8x64& b, const v_uint8x64& g, const v_uint8x64& r,
                                 hal::StoreMode mode=hal::STORE_UNALIGNED )
 {
-    const __m512i sh_b = _mm256_setr_epi8(
-            0, 11, 6, 1, 12, 7, 2, 13, 8, 3, 14, 9, 4, 15, 10, 5,
-            0, 11, 6, 1, 12, 7, 2, 13, 8, 3, 14, 9, 4, 15, 10, 5);
-    const __m512i sh_g = _mm256_setr_epi8(
-            5, 0, 11, 6, 1, 12, 7, 2, 13, 8, 3, 14, 9, 4, 15, 10,
-            5, 0, 11, 6, 1, 12, 7, 2, 13, 8, 3, 14, 9, 4, 15, 10);
-    const __m512i sh_r = _mm256_setr_epi8(
-            10, 5, 0, 11, 6, 1, 12, 7, 2, 13, 8, 3, 14, 9, 4, 15,
-            10, 5, 0, 11, 6, 1, 12, 7, 2, 13, 8, 3, 14, 9, 4, 15);
+    __m512i mask0 = _mm512_set_epi8( 106, 127,  63, 105, 126,  62, 104, 125,  61, 103, 124,  60, 102, 123,  59, 101,
+                                     122,  58, 100, 121,  57,  99, 120,  56,  98, 119,  55,  97, 118,  54,  96, 117,
+                                      53,  95, 116,  52,  94, 115,  51,  93, 114,  50,  92, 113,  49,  91, 112,  48,
+                                      90, 111,  47,  89, 110,  46,  88, 109,  45,  87, 108,  44,  86, 107,  43,  85 );
+    __m512i mask1 = _mm512_set_epi8( 127,  42, 105, 126,  41, 104, 125,  40, 103, 124,  39, 102, 123,  38, 101, 122,
+                                      37, 100, 121,  36,  99, 120,  35,  98, 119,  34,  97, 118,  33,  96, 117,  32,
+                                      95, 116,  31,  94, 115,  30,  93, 114,  29,  92, 113,  28,  91, 112,  27,  90,
+                                     111,  26,  89, 110,  25,  88, 109,  24,  87, 108,  23,  86, 107,  22,  85, 106 );
+    __m512i g1b2g2 = _mm512_permutex2var_epi8(b.val, mask0, g.val);
+    __m512i r2r1b1 = _mm512_permutex2var_epi8(b.val, mask1, r.val);
 
-    __m512i b0 = _mm256_shuffle_epi8(b.val, sh_b);
-    __m512i g0 = _mm256_shuffle_epi8(g.val, sh_g);
-    __m512i r0 = _mm256_shuffle_epi8(r.val, sh_r);
-
-    const __m512i m0 = _mm256_setr_epi8(0, -1, 0, 0, -1, 0, 0, -1, 0, 0, -1, 0, 0, -1, 0, 0,
-                                               0, -1, 0, 0, -1, 0, 0, -1, 0, 0, -1, 0, 0, -1, 0, 0);
-    const __m512i m1 = _mm256_setr_epi8(0, 0, -1, 0, 0, -1, 0, 0, -1, 0, 0, -1, 0, 0, -1, 0,
-                                               0, 0, -1, 0, 0, -1, 0, 0, -1, 0, 0, -1, 0, 0, -1, 0);
-
-    __m512i p0 = _mm256_blendv_epi8(_mm256_blendv_epi8(b0, g0, m0), r0, m1);
-    __m512i p1 = _mm256_blendv_epi8(_mm256_blendv_epi8(g0, r0, m0), b0, m1);
-    __m512i p2 = _mm256_blendv_epi8(_mm256_blendv_epi8(r0, b0, m0), g0, m1);
-
-    __m512i bgr0 = _mm256_permute2x128_si256(p0, p1, 0 + 2*16);
-    __m512i bgr1 = _mm256_permute2x128_si256(p2, p0, 0 + 3*16);
-    __m512i bgr2 = _mm256_permute2x128_si256(p1, p2, 1 + 3*16);
+    __m512i bgr0 = _mm512_mask_expand_epi8(_mm512_mask_expand_epi8(_mm512_maskz_expand_epi8(0x9249249249249249, b.val), 0x2492492492492492, g.val), 0x4924924924924924, r.val);
+    __m512i bgr1 = _mm512_mask_blend_epi8(0x00000000003fffff, r2r1b1, g1b2g2);
+    __m512i bgr2 = _mm512_mask_blend_epi8(0x00000000003fffff, g1b2g2, r2r1b1);
 
     if( mode == hal::STORE_ALIGNED_NOCACHE )
     {
-        _mm256_stream_si256((__m512i*)ptr, bgr0);
-        _mm256_stream_si256((__m512i*)(ptr + 32), bgr1);
-        _mm256_stream_si256((__m512i*)(ptr + 64), bgr2);
+        _mm512_stream_si512((__m512i*)ptr, bgr0);
+        _mm512_stream_si512((__m512i*)(ptr + 64), bgr1);
+        _mm512_stream_si512((__m512i*)(ptr + 128), bgr2);
     }
     else if( mode == hal::STORE_ALIGNED )
     {
-        _mm256_store_si256((__m512i*)ptr, bgr0);
-        _mm256_store_si256((__m512i*)(ptr + 32), bgr1);
-        _mm256_store_si256((__m512i*)(ptr + 64), bgr2);
+        _mm512_store_si512((__m512i*)ptr, bgr0);
+        _mm512_store_si512((__m512i*)(ptr + 64), bgr1);
+        _mm512_store_si512((__m512i*)(ptr + 128), bgr2);
     }
     else
     {
-        _mm256_storeu_si256((__m512i*)ptr, bgr0);
-        _mm256_storeu_si256((__m512i*)(ptr + 32), bgr1);
-        _mm256_storeu_si256((__m512i*)(ptr + 64), bgr2);
+        _mm512_storeu_si512((__m512i*)ptr, bgr0);
+        _mm512_storeu_si512((__m512i*)(ptr + 64), bgr1);
+        _mm512_storeu_si512((__m512i*)(ptr + 128), bgr2);
     }
 }
 
-inline void v_store_interleave( ushort* ptr, const v_uint16x16& b, const v_uint16x16& g, const v_uint16x16& r,
+inline void v_store_interleave( ushort* ptr, const v_uint16x32& b, const v_uint16x32& g, const v_uint16x32& r,
                                 hal::StoreMode mode=hal::STORE_UNALIGNED )
 {
-    const __m512i sh_b = _mm256_setr_epi8(
-         0, 1, 6, 7, 12, 13, 2, 3, 8, 9, 14, 15, 4, 5, 10, 11,
-         0, 1, 6, 7, 12, 13, 2, 3, 8, 9, 14, 15, 4, 5, 10, 11);
-    const __m512i sh_g = _mm256_setr_epi8(
-         10, 11, 0, 1, 6, 7, 12, 13, 2, 3, 8, 9, 14, 15, 4, 5,
-         10, 11, 0, 1, 6, 7, 12, 13, 2, 3, 8, 9, 14, 15, 4, 5);
-    const __m512i sh_r = _mm256_setr_epi8(
-         4, 5, 10, 11, 0, 1, 6, 7, 12, 13, 2, 3, 8, 9, 14, 15,
-         4, 5, 10, 11, 0, 1, 6, 7, 12, 13, 2, 3, 8, 9, 14, 15);
+    __m512i mask0 = _mm512_set_epi16( 21, 52, 31, 20, 51, 30, 19, 50, 29, 18, 49, 28, 17, 48, 27, 16,
+                                      47, 26, 15, 46, 25, 14, 45, 24, 13, 44, 23, 12, 43, 22, 11, 42 );
+    __m512i mask1 = _mm512_set_epi16( 63, 31, 20, 62, 30, 19, 61, 29, 18, 60, 28, 17, 59, 27, 16, 58,
+                                      26, 15, 57, 25, 14, 56, 24, 13, 55, 23, 12, 54, 22, 11, 53, 21 );
+    __m512i r1b1b2 = _mm512_permutex2var_epi16(b.val, mask0, r.val);
+    __m512i g2r2g1 = _mm512_permutex2var_epi16(g.val, mask0, r.val);
 
-    __m512i b0 = _mm256_shuffle_epi8(b.val, sh_b);
-    __m512i g0 = _mm256_shuffle_epi8(g.val, sh_g);
-    __m512i r0 = _mm256_shuffle_epi8(r.val, sh_r);
-
-    const __m512i m0 = _mm256_setr_epi8(0, 0, -1, -1, 0, 0, 0, 0, -1, -1, 0, 0, 0, 0, -1, -1,
-                                               0, 0, 0, 0, -1, -1, 0, 0, 0, 0, -1, -1, 0, 0, 0, 0);
-    const __m512i m1 = _mm256_setr_epi8(0, 0, 0, 0, -1, -1, 0, 0, 0, 0, -1, -1, 0, 0, 0, 0,
-                                               -1, -1, 0, 0, 0, 0, -1, -1, 0, 0, 0, 0, -1, -1, 0, 0);
-
-    __m512i p0 = _mm256_blendv_epi8(_mm256_blendv_epi8(b0, g0, m0), r0, m1);
-    __m512i p1 = _mm256_blendv_epi8(_mm256_blendv_epi8(g0, r0, m0), b0, m1);
-    __m512i p2 = _mm256_blendv_epi8(_mm256_blendv_epi8(r0, b0, m0), g0, m1);
-
-    __m512i bgr0 = _mm256_permute2x128_si256(p0, p2, 0 + 2*16);
-    //__m512i bgr1 = p1;
-    __m512i bgr2 = _mm256_permute2x128_si256(p0, p2, 1 + 3*16);
+    __m512i bgr0 = _mm512_mask_expand_epi16(_mm512_mask_expand_epi16(_mm512_maskz_expand_epi16(0x49249249, b.val), 0x92492492, g.val), 0x24924924, r.val);
+    __m512i bgr1 = _mm512_mask_blend_epi16(0x003fffff, g2r2g1, r1b1b2);
+    __m512i bgr2 = _mm512_mask_blend_epi16(0x003fffff, r1b1b2, g2r2g1);
 
     if( mode == hal::STORE_ALIGNED_NOCACHE )
     {
-        _mm256_stream_si256((__m512i*)ptr, bgr0);
-        _mm256_stream_si256((__m512i*)(ptr + 16), p1);
-        _mm256_stream_si256((__m512i*)(ptr + 32), bgr2);
+        _mm512_stream_si512((__m512i*)ptr, bgr0);
+        _mm512_stream_si512((__m512i*)(ptr + 32), bgr1);
+        _mm512_stream_si512((__m512i*)(ptr + 64), bgr2);
     }
     else if( mode == hal::STORE_ALIGNED )
     {
-        _mm256_store_si256((__m512i*)ptr, bgr0);
-        _mm256_store_si256((__m512i*)(ptr + 16), p1);
-        _mm256_store_si256((__m512i*)(ptr + 32), bgr2);
+        _mm512_store_si512((__m512i*)ptr, bgr0);
+        _mm512_store_si512((__m512i*)(ptr + 32), bgr1);
+        _mm512_store_si512((__m512i*)(ptr + 64), bgr2);
     }
     else
     {
-        _mm256_storeu_si256((__m512i*)ptr, bgr0);
-        _mm256_storeu_si256((__m512i*)(ptr + 16), p1);
-        _mm256_storeu_si256((__m512i*)(ptr + 32), bgr2);
+        _mm512_storeu_si512((__m512i*)ptr, bgr0);
+        _mm512_storeu_si512((__m512i*)(ptr + 32), bgr1);
+        _mm512_storeu_si512((__m512i*)(ptr + 64), bgr2);
     }
 }
 
-inline void v_store_interleave( unsigned* ptr, const v_uint32x8& b, const v_uint32x8& g, const v_uint32x8& r,
+inline void v_store_interleave( unsigned* ptr, const v_uint32x16& b, const v_uint32x16& g, const v_uint32x16& r,
                                 hal::StoreMode mode=hal::STORE_UNALIGNED )
 {
-    __m512i b0 = _mm256_shuffle_epi32(b.val, 0x6c);
-    __m512i g0 = _mm256_shuffle_epi32(g.val, 0xb1);
-    __m512i r0 = _mm256_shuffle_epi32(r.val, 0xc6);
+    __m512i mask0 = _mm512_set_epi32( 26, 31, 15, 25, 30, 14, 24, 29, 13, 23, 28, 12, 22, 27, 11, 21 );
+    __m512i mask1 = _mm512_set_epi32( 31, 10, 25, 30,  9, 24, 29,  8, 23, 28,  7, 22, 27,  6, 21, 26 );
+    __m512i g1b2g2 = _mm512_permutex2var_epi32(b.val, mask0, g.val);
+    __m512i r2r1b1 = _mm512_permutex2var_epi32(b.val, mask1, r.val);
 
-    __m512i p0 = _mm256_blend_epi32(_mm256_blend_epi32(b0, g0, 0x92), r0, 0x24);
-    __m512i p1 = _mm256_blend_epi32(_mm256_blend_epi32(g0, r0, 0x92), b0, 0x24);
-    __m512i p2 = _mm256_blend_epi32(_mm256_blend_epi32(r0, b0, 0x92), g0, 0x24);
-
-    __m512i bgr0 = _mm256_permute2x128_si256(p0, p1, 0 + 2*16);
-    //__m512i bgr1 = p2;
-    __m512i bgr2 = _mm256_permute2x128_si256(p0, p1, 1 + 3*16);
+    __m512i bgr0 = _mm512_mask_expand_epi32(_mm512_mask_expand_epi32(_mm512_maskz_expand_epi32(0x9249, b.val), 0x2492, g.val), 0x4924, r.val);
+    __m512i bgr1 = _mm512_mask_blend_epi32(0x003f, r2r1b1, g1b2g2);
+    __m512i bgr2 = _mm512_mask_blend_epi32(0x003f, g1b2g2, r2r1b1);
 
     if( mode == hal::STORE_ALIGNED_NOCACHE )
     {
-        _mm256_stream_si256((__m512i*)ptr, bgr0);
-        _mm256_stream_si256((__m512i*)(ptr + 8), p2);
-        _mm256_stream_si256((__m512i*)(ptr + 16), bgr2);
+        _mm512_stream_si512((__m512i*)ptr, bgr0);
+        _mm512_stream_si512((__m512i*)(ptr + 16), bgr1);
+        _mm512_stream_si512((__m512i*)(ptr + 32), bgr2);
     }
     else if( mode == hal::STORE_ALIGNED )
     {
-        _mm256_store_si256((__m512i*)ptr, bgr0);
-        _mm256_store_si256((__m512i*)(ptr + 8), p2);
-        _mm256_store_si256((__m512i*)(ptr + 16), bgr2);
+        _mm512_store_si512((__m512i*)ptr, bgr0);
+        _mm512_store_si512((__m512i*)(ptr + 16), bgr1);
+        _mm512_store_si512((__m512i*)(ptr + 32), bgr2);
     }
     else
     {
-        _mm256_storeu_si256((__m512i*)ptr, bgr0);
-        _mm256_storeu_si256((__m512i*)(ptr + 8), p2);
-        _mm256_storeu_si256((__m512i*)(ptr + 16), bgr2);
+        _mm512_storeu_si512((__m512i*)ptr, bgr0);
+        _mm512_storeu_si512((__m512i*)(ptr + 16), bgr1);
+        _mm512_storeu_si512((__m512i*)(ptr + 32), bgr2);
     }
 }
 
-inline void v_store_interleave( uint64* ptr, const v_uint64x4& b, const v_uint64x4& g, const v_uint64x4& r,
+inline void v_store_interleave( uint64* ptr, const v_uint64x8& b, const v_uint64x8& g, const v_uint64x8& r,
                                 hal::StoreMode mode=hal::STORE_UNALIGNED )
 {
-    __m512i s01 = _mm256_unpacklo_epi64(b.val, g.val);
-    __m512i s12 = _mm256_unpackhi_epi64(g.val, r.val);
-    __m512i s20 = _mm256_blend_epi32(r.val, b.val, 0xcc);
+    __m512i mask0 = _mm512_set_epi64(  5, 12,  7,  4, 11,  6,  3, 10 );
+    __m512i mask1 = _mm512_set_epi64( 15,  7,  4, 14,  6,  3, 13,  5 );
+    __m512i r1b1b2 = _mm512_permutex2var_epi64(b.val, mask0, r.val);
+    __m512i g2r2g1 = _mm512_permutex2var_epi64(g.val, mask0, r.val);
 
-    __m512i bgr0 = _mm256_permute2x128_si256(s01, s20, 0 + 2*16);
-    __m512i bgr1 = _mm256_blend_epi32(s01, s12, 0x0f);
-    __m512i bgr2 = _mm256_permute2x128_si256(s20, s12, 1 + 3*16);
+    __m512i bgr0 = _mm512_mask_expand_epi64(_mm512_mask_expand_epi64(_mm512_maskz_expand_epi64(0x49, b.val), 0x92, g.val), 0x24, r.val);
+    __m512i bgr1 = _mm512_mask_blend_epi64(0x3f, g2r2g1, r1b1b2);
+    __m512i bgr2 = _mm512_mask_blend_epi64(0x3f, r1b1b2, g2r2g1);
 
     if( mode == hal::STORE_ALIGNED_NOCACHE )
     {
-        _mm256_stream_si256((__m512i*)ptr, bgr0);
-        _mm256_stream_si256((__m512i*)(ptr + 4), bgr1);
-        _mm256_stream_si256((__m512i*)(ptr + 8), bgr2);
+        _mm512_stream_si512((__m512i*)ptr, bgr0);
+        _mm512_stream_si512((__m512i*)(ptr + 8), bgr1);
+        _mm512_stream_si512((__m512i*)(ptr + 16), bgr2);
     }
     else if( mode == hal::STORE_ALIGNED )
     {
-        _mm256_store_si256((__m512i*)ptr, bgr0);
-        _mm256_store_si256((__m512i*)(ptr + 4), bgr1);
-        _mm256_store_si256((__m512i*)(ptr + 8), bgr2);
+        _mm512_store_si512((__m512i*)ptr, bgr0);
+        _mm512_store_si512((__m512i*)(ptr + 8), bgr1);
+        _mm512_store_si512((__m512i*)(ptr + 16), bgr2);
     }
     else
     {
-        _mm256_storeu_si256((__m512i*)ptr, bgr0);
-        _mm256_storeu_si256((__m512i*)(ptr + 4), bgr1);
-        _mm256_storeu_si256((__m512i*)(ptr + 8), bgr2);
+        _mm512_storeu_si512((__m512i*)ptr, bgr0);
+        _mm512_storeu_si512((__m512i*)(ptr + 8), bgr1);
+        _mm512_storeu_si512((__m512i*)(ptr + 16), bgr2);
     }
 }
 
-inline void v_store_interleave( uchar* ptr, const v_uint8x32& b, const v_uint8x32& g,
-                                const v_uint8x32& r, const v_uint8x32& a,
+inline void v_store_interleave( uchar* ptr, const v_uint8x64& b, const v_uint8x64& g,
+                                const v_uint8x64& r, const v_uint8x64& a,
                                 hal::StoreMode mode=hal::STORE_UNALIGNED )
 {
-    __m512i bg0 = _mm256_unpacklo_epi8(b.val, g.val);
-    __m512i bg1 = _mm256_unpackhi_epi8(b.val, g.val);
-    __m512i ra0 = _mm256_unpacklo_epi8(r.val, a.val);
-    __m512i ra1 = _mm256_unpackhi_epi8(r.val, a.val);
+    __m512i mask0 = _mm512_set_epi8(  95, 31,  94, 30,  93, 29,  92, 28,  91, 27,  90, 26,  89, 25,  88, 24,
+                                      87, 23,  86, 22,  85, 21,  84, 20,  83, 19,  82, 18,  81, 17,  80, 16,
+                                      79, 15,  78, 14,  77, 13,  76, 12,  75, 11,  74, 10,  73,  9,  72,  8,
+                                      71,  7,  70,  6,  69,  5,  68,  4,  67,  3,  66,  2,  65,  1,  64,  0 );
+    __m512i mask1 = _mm512_set_epi8( 127, 63, 126, 62, 125, 61, 124, 60, 123, 59, 122, 58, 121, 57, 120, 56,
+                                     119, 55, 118, 54, 117, 53, 116, 52, 115, 51, 114, 50, 113, 49, 112, 48,
+                                     111, 47, 110, 46, 109, 45, 108, 44, 107, 43, 106, 42, 105, 41, 104, 40,
+                                     103, 39, 102, 38, 101, 37, 100, 36,  99, 35,  98, 34,  97, 33,  96, 32 );
 
-    __m512i bgra0_ = _mm256_unpacklo_epi16(bg0, ra0);
-    __m512i bgra1_ = _mm256_unpackhi_epi16(bg0, ra0);
-    __m512i bgra2_ = _mm256_unpacklo_epi16(bg1, ra1);
-    __m512i bgra3_ = _mm256_unpackhi_epi16(bg1, ra1);
+    __m512i br01 = _mm512_permutex2var_epi8(b, mask0, r);
+    __m512i br23 = _mm512_permutex2var_epi8(b, mask1, r);
+    __m512i ga01 = _mm512_permutex2var_epi8(g, mask0, a);
+    __m512i ga23 = _mm512_permutex2var_epi8(g, mask1, a);
 
-    __m512i bgra0 = _mm256_permute2x128_si256(bgra0_, bgra1_, 0 + 2*16);
-    __m512i bgra2 = _mm256_permute2x128_si256(bgra0_, bgra1_, 1 + 3*16);
-    __m512i bgra1 = _mm256_permute2x128_si256(bgra2_, bgra3_, 0 + 2*16);
-    __m512i bgra3 = _mm256_permute2x128_si256(bgra2_, bgra3_, 1 + 3*16);
+    __m512i bgra0 = _mm512_permutex2var_epi8(br01, mask0, ga01));
+    __m512i bgra1 = _mm512_permutex2var_epi8(br01, mask1, ga01));
+    __m512i bgra2 = _mm512_permutex2var_epi8(br23, mask0, ga23));
+    __m512i bgra3 = _mm512_permutex2var_epi8(br23, mask1, ga23));
 
     if( mode == hal::STORE_ALIGNED_NOCACHE )
     {
-        _mm256_stream_si256((__m512i*)ptr, bgra0);
-        _mm256_stream_si256((__m512i*)(ptr + 32), bgra1);
-        _mm256_stream_si256((__m512i*)(ptr + 64), bgra2);
-        _mm256_stream_si256((__m512i*)(ptr + 96), bgra3);
+        _mm512_stream_si512((__m512i*)ptr, bgra0);
+        _mm512_stream_si512((__m512i*)(ptr + 64), bgra1);
+        _mm512_stream_si512((__m512i*)(ptr + 128), bgra2);
+        _mm512_stream_si512((__m512i*)(ptr + 192), bgra3);
     }
     else if( mode == hal::STORE_ALIGNED )
     {
-        _mm256_store_si256((__m512i*)ptr, bgra0);
-        _mm256_store_si256((__m512i*)(ptr + 32), bgra1);
-        _mm256_store_si256((__m512i*)(ptr + 64), bgra2);
-        _mm256_store_si256((__m512i*)(ptr + 96), bgra3);
+        _mm512_store_si512((__m512i*)ptr, bgra0);
+        _mm512_store_si512((__m512i*)(ptr + 64), bgra1);
+        _mm512_store_si512((__m512i*)(ptr + 128), bgra2);
+        _mm512_store_si512((__m512i*)(ptr + 192), bgra3);
     }
     else
     {
-        _mm256_storeu_si256((__m512i*)ptr, bgra0);
-        _mm256_storeu_si256((__m512i*)(ptr + 32), bgra1);
-        _mm256_storeu_si256((__m512i*)(ptr + 64), bgra2);
-        _mm256_storeu_si256((__m512i*)(ptr + 96), bgra3);
+        _mm512_storeu_si512((__m512i*)ptr, bgra0);
+        _mm512_storeu_si512((__m512i*)(ptr + 64), bgra1);
+        _mm512_storeu_si512((__m512i*)(ptr + 128), bgra2);
+        _mm512_storeu_si512((__m512i*)(ptr + 192), bgra3);
     }
 }
 
-inline void v_store_interleave( ushort* ptr, const v_uint16x16& b, const v_uint16x16& g,
-                                const v_uint16x16& r, const v_uint16x16& a,
+inline void v_store_interleave( ushort* ptr, const v_uint16x32& b, const v_uint16x32& g,
+                                const v_uint16x32& r, const v_uint16x32& a,
                                 hal::StoreMode mode=hal::STORE_UNALIGNED )
 {
-    __m512i bg0 = _mm256_unpacklo_epi16(b.val, g.val);
-    __m512i bg1 = _mm256_unpackhi_epi16(b.val, g.val);
-    __m512i ra0 = _mm256_unpacklo_epi16(r.val, a.val);
-    __m512i ra1 = _mm256_unpackhi_epi16(r.val, a.val);
+    __m512i mask0 = _mm512_set_epi16( 47, 15, 46, 14, 45, 13, 44, 12, 43, 11, 42, 10, 41,  9, 40,  8,
+                                      39,  7, 38,  6, 37,  5, 36,  4, 35,  3, 34,  2, 33,  1, 32,  0 );
+    __m512i mask1 = _mm512_set_epi16( 63, 31, 62, 30, 61, 29, 60, 28, 59, 27, 58, 26, 57, 25, 56, 24,
+                                      55, 23, 54, 22, 53, 21, 52, 20, 51, 19, 50, 18, 49, 17, 48, 16 );
 
-    __m512i bgra0_ = _mm256_unpacklo_epi32(bg0, ra0);
-    __m512i bgra1_ = _mm256_unpackhi_epi32(bg0, ra0);
-    __m512i bgra2_ = _mm256_unpacklo_epi32(bg1, ra1);
-    __m512i bgra3_ = _mm256_unpackhi_epi32(bg1, ra1);
+    __m512i br01 = _mm512_permutex2var_epi16(b, mask0, r);
+    __m512i br23 = _mm512_permutex2var_epi16(b, mask1, r);
+    __m512i ga01 = _mm512_permutex2var_epi16(g, mask0, a);
+    __m512i ga23 = _mm512_permutex2var_epi16(g, mask1, a);
 
-    __m512i bgra0 = _mm256_permute2x128_si256(bgra0_, bgra1_, 0 + 2*16);
-    __m512i bgra2 = _mm256_permute2x128_si256(bgra0_, bgra1_, 1 + 3*16);
-    __m512i bgra1 = _mm256_permute2x128_si256(bgra2_, bgra3_, 0 + 2*16);
-    __m512i bgra3 = _mm256_permute2x128_si256(bgra2_, bgra3_, 1 + 3*16);
+    __m512i bgra0 = _mm512_permutex2var_epi16(br01, mask0, ga01));
+    __m512i bgra1 = _mm512_permutex2var_epi16(br01, mask1, ga01));
+    __m512i bgra2 = _mm512_permutex2var_epi16(br23, mask0, ga23));
+    __m512i bgra3 = _mm512_permutex2var_epi16(br23, mask1, ga23));
 
     if( mode == hal::STORE_ALIGNED_NOCACHE )
     {
-        _mm256_stream_si256((__m512i*)ptr, bgra0);
-        _mm256_stream_si256((__m512i*)(ptr + 16), bgra1);
-        _mm256_stream_si256((__m512i*)(ptr + 32), bgra2);
-        _mm256_stream_si256((__m512i*)(ptr + 48), bgra3);
+        _mm512_stream_si512((__m512i*)ptr, bgra0);
+        _mm512_stream_si512((__m512i*)(ptr + 32), bgra1);
+        _mm512_stream_si512((__m512i*)(ptr + 64), bgra2);
+        _mm512_stream_si512((__m512i*)(ptr + 96), bgra3);
     }
     else if( mode == hal::STORE_ALIGNED )
     {
-        _mm256_store_si256((__m512i*)ptr, bgra0);
-        _mm256_store_si256((__m512i*)(ptr + 16), bgra1);
-        _mm256_store_si256((__m512i*)(ptr + 32), bgra2);
-        _mm256_store_si256((__m512i*)(ptr + 48), bgra3);
+        _mm512_store_si512((__m512i*)ptr, bgra0);
+        _mm512_store_si512((__m512i*)(ptr + 32), bgra1);
+        _mm512_store_si512((__m512i*)(ptr + 64), bgra2);
+        _mm512_store_si512((__m512i*)(ptr + 96), bgra3);
     }
     else
     {
-        _mm256_storeu_si256((__m512i*)ptr, bgra0);
-        _mm256_storeu_si256((__m512i*)(ptr + 16), bgra1);
-        _mm256_storeu_si256((__m512i*)(ptr + 32), bgra2);
-        _mm256_storeu_si256((__m512i*)(ptr + 48), bgra3);
+        _mm512_storeu_si512((__m512i*)ptr, bgra0);
+        _mm512_storeu_si512((__m512i*)(ptr + 32), bgra1);
+        _mm512_storeu_si512((__m512i*)(ptr + 64), bgra2);
+        _mm512_storeu_si512((__m512i*)(ptr + 96), bgra3);
     }
 }
 
-inline void v_store_interleave( unsigned* ptr, const v_uint32x8& b, const v_uint32x8& g,
-                                const v_uint32x8& r, const v_uint32x8& a,
+inline void v_store_interleave( unsigned* ptr, const v_uint32x16& b, const v_uint32x16& g,
+                                const v_uint32x16& r, const v_uint32x16& a,
                                 hal::StoreMode mode=hal::STORE_UNALIGNED )
 {
-    __m512i bg0 = _mm256_unpacklo_epi32(b.val, g.val);
-    __m512i bg1 = _mm256_unpackhi_epi32(b.val, g.val);
-    __m512i ra0 = _mm256_unpacklo_epi32(r.val, a.val);
-    __m512i ra1 = _mm256_unpackhi_epi32(r.val, a.val);
+    __m512i mask0 = _mm512_set_epi32( 23,  7, 22,  6, 21,  5, 20,  4, 19,  3, 18,  2, 17, 1, 16, 0 );
+    __m512i mask1 = _mm512_set_epi32( 31, 15, 30, 14, 29, 13, 28, 12, 27, 11, 26, 10, 25, 9, 24, 8 );
 
-    __m512i bgra0_ = _mm256_unpacklo_epi64(bg0, ra0);
-    __m512i bgra1_ = _mm256_unpackhi_epi64(bg0, ra0);
-    __m512i bgra2_ = _mm256_unpacklo_epi64(bg1, ra1);
-    __m512i bgra3_ = _mm256_unpackhi_epi64(bg1, ra1);
+    __m512i br01 = _mm512_permutex2var_epi32(b, mask0, r);
+    __m512i br23 = _mm512_permutex2var_epi32(b, mask1, r);
+    __m512i ga01 = _mm512_permutex2var_epi32(g, mask0, a);
+    __m512i ga23 = _mm512_permutex2var_epi32(g, mask1, a);
 
-    __m512i bgra0 = _mm256_permute2x128_si256(bgra0_, bgra1_, 0 + 2*16);
-    __m512i bgra2 = _mm256_permute2x128_si256(bgra0_, bgra1_, 1 + 3*16);
-    __m512i bgra1 = _mm256_permute2x128_si256(bgra2_, bgra3_, 0 + 2*16);
-    __m512i bgra3 = _mm256_permute2x128_si256(bgra2_, bgra3_, 1 + 3*16);
+    __m512i bgra0 = _mm512_permutex2var_epi32(br01, mask0, ga01));
+    __m512i bgra1 = _mm512_permutex2var_epi32(br01, mask1, ga01));
+    __m512i bgra2 = _mm512_permutex2var_epi32(br23, mask0, ga23));
+    __m512i bgra3 = _mm512_permutex2var_epi32(br23, mask1, ga23));
 
     if( mode == hal::STORE_ALIGNED_NOCACHE )
     {
-        _mm256_stream_si256((__m512i*)ptr, bgra0);
-        _mm256_stream_si256((__m512i*)(ptr + 8), bgra1);
-        _mm256_stream_si256((__m512i*)(ptr + 16), bgra2);
-        _mm256_stream_si256((__m512i*)(ptr + 24), bgra3);
+        _mm512_stream_si512((__m512i*)ptr, bgra0);
+        _mm512_stream_si512((__m512i*)(ptr + 16), bgra1);
+        _mm512_stream_si512((__m512i*)(ptr + 32), bgra2);
+        _mm512_stream_si512((__m512i*)(ptr + 48), bgra3);
     }
     else if( mode == hal::STORE_ALIGNED )
     {
-        _mm256_store_si256((__m512i*)ptr, bgra0);
-        _mm256_store_si256((__m512i*)(ptr + 8), bgra1);
-        _mm256_store_si256((__m512i*)(ptr + 16), bgra2);
-        _mm256_store_si256((__m512i*)(ptr + 24), bgra3);
+        _mm512_store_si512((__m512i*)ptr, bgra0);
+        _mm512_store_si512((__m512i*)(ptr + 16), bgra1);
+        _mm512_store_si512((__m512i*)(ptr + 32), bgra2);
+        _mm512_store_si512((__m512i*)(ptr + 48), bgra3);
     }
     else
     {
-        _mm256_storeu_si256((__m512i*)ptr, bgra0);
-        _mm256_storeu_si256((__m512i*)(ptr + 8), bgra1);
-        _mm256_storeu_si256((__m512i*)(ptr + 16), bgra2);
-        _mm256_storeu_si256((__m512i*)(ptr + 24), bgra3);
+        _mm512_storeu_si512((__m512i*)ptr, bgra0);
+        _mm512_storeu_si512((__m512i*)(ptr + 16), bgra1);
+        _mm512_storeu_si512((__m512i*)(ptr + 32), bgra2);
+        _mm512_storeu_si512((__m512i*)(ptr + 48), bgra3);
     }
 }
 
-inline void v_store_interleave( uint64* ptr, const v_uint64x4& b, const v_uint64x4& g,
-                                const v_uint64x4& r, const v_uint64x4& a,
+inline void v_store_interleave( uint64* ptr, const v_uint64x8& b, const v_uint64x8& g,
+                                const v_uint64x8& r, const v_uint64x8& a,
                                 hal::StoreMode mode=hal::STORE_UNALIGNED )
 {
-    __m512i bg0 = _mm256_unpacklo_epi64(b.val, g.val);
-    __m512i bg1 = _mm256_unpackhi_epi64(b.val, g.val);
-    __m512i ra0 = _mm256_unpacklo_epi64(r.val, a.val);
-    __m512i ra1 = _mm256_unpackhi_epi64(r.val, a.val);
+    
+    __m512i mask0 = _mm512_set_epi64( 11, 3, 10, 2,  9, 1,  8, 0 );
+    __m512i mask1 = _mm512_set_epi64( 15, 7, 14, 6, 13, 5, 12, 4 );
 
-    __m512i bgra0 = _mm256_permute2x128_si256(bg0, ra0, 0 + 2*16);
-    __m512i bgra1 = _mm256_permute2x128_si256(bg1, ra1, 0 + 2*16);
-    __m512i bgra2 = _mm256_permute2x128_si256(bg0, ra0, 1 + 3*16);
-    __m512i bgra3 = _mm256_permute2x128_si256(bg1, ra1, 1 + 3*16);
+    __m512i br01 = _mm512_permutex2var_epi64(b, mask0, r);
+    __m512i br23 = _mm512_permutex2var_epi64(b, mask1, r);
+    __m512i ga01 = _mm512_permutex2var_epi64(g, mask0, a);
+    __m512i ga23 = _mm512_permutex2var_epi64(g, mask1, a);
+
+    __m512i bgra0 = _mm512_permutex2var_epi64(br01, mask0, ga01));
+    __m512i bgra1 = _mm512_permutex2var_epi64(br01, mask1, ga01));
+    __m512i bgra2 = _mm512_permutex2var_epi64(br23, mask0, ga23));
+    __m512i bgra3 = _mm512_permutex2var_epi64(br23, mask1, ga23));
 
     if( mode == hal::STORE_ALIGNED_NOCACHE )
     {
-        _mm256_stream_si256((__m512i*)ptr, bgra0);
-        _mm256_stream_si256((__m512i*)(ptr + 4), bgra1);
-        _mm256_stream_si256((__m512i*)(ptr + 8), bgra2);
-        _mm256_stream_si256((__m512i*)(ptr + 12), bgra3);
+        _mm512_stream_si512((__m512i*)ptr, bgra0);
+        _mm512_stream_si512((__m512i*)(ptr + 8), bgra1);
+        _mm512_stream_si512((__m512i*)(ptr + 16), bgra2);
+        _mm512_stream_si512((__m512i*)(ptr + 24), bgra3);
     }
     else if( mode == hal::STORE_ALIGNED )
     {
-        _mm256_store_si256((__m512i*)ptr, bgra0);
-        _mm256_store_si256((__m512i*)(ptr + 4), bgra1);
-        _mm256_store_si256((__m512i*)(ptr + 8), bgra2);
-        _mm256_store_si256((__m512i*)(ptr + 12), bgra3);
+        _mm512_store_si512((__m512i*)ptr, bgra0);
+        _mm512_store_si512((__m512i*)(ptr + 8), bgra1);
+        _mm512_store_si512((__m512i*)(ptr + 16), bgra2);
+        _mm512_store_si512((__m512i*)(ptr + 24), bgra3);
     }
     else
     {
-        _mm256_storeu_si256((__m512i*)ptr, bgra0);
-        _mm256_storeu_si256((__m512i*)(ptr + 4), bgra1);
-        _mm256_storeu_si256((__m512i*)(ptr + 8), bgra2);
-        _mm256_storeu_si256((__m512i*)(ptr + 12), bgra3);
+        _mm512_storeu_si512((__m512i*)ptr, bgra0);
+        _mm512_storeu_si512((__m512i*)(ptr + 8), bgra1);
+        _mm512_storeu_si512((__m512i*)(ptr + 16), bgra2);
+        _mm512_storeu_si512((__m512i*)(ptr + 24), bgra3);
     }
 }
 
-#define OPENCV_HAL_IMPL_AVX_LOADSTORE_INTERLEAVE(_Tpvec0, _Tp0, suffix0, _Tpvec1, _Tp1, suffix1) \
+#define OPENCV_HAL_IMPL_AVX512_LOADSTORE_INTERLEAVE(_Tpvec0, _Tp0, suffix0, _Tpvec1, _Tp1, suffix1) \
 inline void v_load_deinterleave( const _Tp0* ptr, _Tpvec0& a0, _Tpvec0& b0 ) \
 { \
     _Tpvec1 a1, b1; \
@@ -2301,12 +2281,12 @@ inline void v_store_interleave( _Tp0* ptr, const _Tpvec0& a0, const _Tpvec0& b0,
     v_store_interleave((_Tp1*)ptr, a1, b1, c1, d1, mode); \
 }
 
-OPENCV_HAL_IMPL_AVX_LOADSTORE_INTERLEAVE(v_int8x32, schar, s8, v_uint8x32, uchar, u8)
-OPENCV_HAL_IMPL_AVX_LOADSTORE_INTERLEAVE(v_int16x16, short, s16, v_uint16x16, ushort, u16)
-OPENCV_HAL_IMPL_AVX_LOADSTORE_INTERLEAVE(v_int32x8, int, s32, v_uint32x8, unsigned, u32)
-OPENCV_HAL_IMPL_AVX_LOADSTORE_INTERLEAVE(v_float32x8, float, f32, v_uint32x8, unsigned, u32)
-OPENCV_HAL_IMPL_AVX_LOADSTORE_INTERLEAVE(v_int64x4, int64, s64, v_uint64x4, uint64, u64)
-OPENCV_HAL_IMPL_AVX_LOADSTORE_INTERLEAVE(v_float64x4, double, f64, v_uint64x4, uint64, u64)
+OPENCV_HAL_IMPL_AVX512_LOADSTORE_INTERLEAVE(v_int8x64, schar, s8, v_uint8x64, uchar, u8)
+OPENCV_HAL_IMPL_AVX512_LOADSTORE_INTERLEAVE(v_int16x32, short, s16, v_uint16x32, ushort, u16)
+OPENCV_HAL_IMPL_AVX512_LOADSTORE_INTERLEAVE(v_int32x16, int, s32, v_uint32x16, unsigned, u32)
+OPENCV_HAL_IMPL_AVX512_LOADSTORE_INTERLEAVE(v_float32x16, float, f32, v_uint32x16, unsigned, u32)
+OPENCV_HAL_IMPL_AVX512_LOADSTORE_INTERLEAVE(v_int64x8, int64, s64, v_uint64x8, uint64, u64)
+OPENCV_HAL_IMPL_AVX512_LOADSTORE_INTERLEAVE(v_float64x8, double, f64, v_uint64x8, uint64, u64)
 
 ////////// Mask and checks /////////
 

--- a/modules/core/include/opencv2/core/hal/intrin_avx512.hpp
+++ b/modules/core/include/opencv2/core/hal/intrin_avx512.hpp
@@ -11,19 +11,26 @@
 
 #define _v512_set_epi64(a7, a6, a5, a4, a3, a2, a1, a0) _mm512_set_epi64((a7),(a6),(a5),(a4),(a3),(a2),(a1),(a0))
 #define _v512_set_epi32(a15, a14, a13, a12, a11, a10,  a9,  a8,  a7,  a6,  a5,  a4,  a3,  a2,  a1,  a0) \
-        _v512_set_epi64(((a15)<<32)|(a14), ((a13)<<32)|(a12), ((a11)<<32)|(a10), (( a9)<<32)|( a8), (( a7)<<32)|( a6), (( a5)<<32)|( a4), (( a3)<<32)|( a2), (( a1)<<32)|( a0))
+        _v512_set_epi64(((int64)(a15)<<32)|(int64)(a14), ((int64)(a13)<<32)|(int64)(a12), ((int64)(a11)<<32)|(int64)(a10), ((int64)( a9)<<32)|(int64)( a8), \
+                        ((int64)( a7)<<32)|(int64)( a6), ((int64)( a5)<<32)|(int64)( a4), ((int64)( a3)<<32)|(int64)( a2), ((int64)( a1)<<32)|(int64)( a0))
 #define _v512_set_epi16(a31, a30, a29, a28, a27, a26, a25, a24, a23, a22, a21, a20, a19, a18, a17, a16, \
                         a15, a14, a13, a12, a11, a10,  a9,  a8,  a7,  a6,  a5,  a4,  a3,  a2,  a1,  a0) \
-        _v512_set_epi32(((a31)<<16)|(a30), ((a29)<<16)|(a28), ((a27)<<16)|(a26), ((a25)<<16)|(a24), ((a23)<<16)|(a22), ((a21)<<16)|(a20), ((a19)<<16)|(a18), ((a17)<<16)|(a16), \
-                        ((a15)<<16)|(a14), ((a13)<<16)|(a12), ((a11)<<16)|(a10), (( a9)<<16)|( a8), (( a7)<<16)|( a6), (( a5)<<16)|( a4), (( a3)<<16)|( a2), (( a1)<<16)|( a0))
+        _v512_set_epi32(((int)(a31)<<16)|(int)(a30), ((int)(a29)<<16)|(int)(a28), ((int)(a27)<<16)|(int)(a26), ((int)(a25)<<16)|(int)(a24), \
+                        ((int)(a23)<<16)|(int)(a22), ((int)(a21)<<16)|(int)(a20), ((int)(a19)<<16)|(int)(a18), ((int)(a17)<<16)|(int)(a16), \
+                        ((int)(a15)<<16)|(int)(a14), ((int)(a13)<<16)|(int)(a12), ((int)(a11)<<16)|(int)(a10), ((int)( a9)<<16)|(int)( a8), \
+                        ((int)( a7)<<16)|(int)( a6), ((int)( a5)<<16)|(int)( a4), ((int)( a3)<<16)|(int)( a2), ((int)( a1)<<16)|(int)( a0))
 #define _v512_set_epi8(a63, a62, a61, a60, a59, a58, a57, a56, a55, a54, a53, a52, a51, a50, a49, a48, \
                        a47, a46, a45, a44, a43, a42, a41, a40, a39, a38, a37, a36, a35, a34, a33, a32, \
                        a31, a30, a29, a28, a27, a26, a25, a24, a23, a22, a21, a20, a19, a18, a17, a16, \
                        a15, a14, a13, a12, a11, a10,  a9,  a8,  a7,  a6,  a5,  a4,  a3,  a2,  a1,  a0) \
-        _v512_set_epi32(((a63)<<24)|((a62)<<16)|((a61)<<8)|(a60),((a59)<<24)|((a58)<<16)|((a57)<<8)|(a56),((a55)<<24)|((a54)<<16)|((a53)<<8)|(a52),((a51)<<24)|((a50)<<16)|((a49)<<8)|(a48), \
-                        ((a47)<<24)|((a46)<<16)|((a45)<<8)|(a44),((a43)<<24)|((a42)<<16)|((a41)<<8)|(a40),((a39)<<24)|((a38)<<16)|((a37)<<8)|(a36),((a35)<<24)|((a34)<<16)|((a33)<<8)|(a32), \
-                        ((a31)<<24)|((a30)<<16)|((a29)<<8)|(a28),((a27)<<24)|((a26)<<16)|((a25)<<8)|(a24),((a23)<<24)|((a22)<<16)|((a21)<<8)|(a20),((a19)<<24)|((a18)<<16)|((a17)<<8)|(a16), \
-                        ((a15)<<24)|((a14)<<16)|((a13)<<8)|(a12),((a11)<<24)|((a10)<<16)|(( a9)<<8)|( a8),(( a7)<<24)|(( a6)<<16)|(( a5)<<8)|( a4),(( a3)<<24)|(( a2)<<16)|(( a1)<<8)|( a0))
+        _v512_set_epi32(((int)(a63)<<24)|((int)(a62)<<16)|((int)(a61)<<8)|(int)(a60),((int)(a59)<<24)|((int)(a58)<<16)|((int)(a57)<<8)|(int)(a56), \
+                        ((int)(a55)<<24)|((int)(a54)<<16)|((int)(a53)<<8)|(int)(a52),((int)(a51)<<24)|((int)(a50)<<16)|((int)(a49)<<8)|(int)(a48), \
+                        ((int)(a47)<<24)|((int)(a46)<<16)|((int)(a45)<<8)|(int)(a44),((int)(a43)<<24)|((int)(a42)<<16)|((int)(a41)<<8)|(int)(a40), \
+                        ((int)(a39)<<24)|((int)(a38)<<16)|((int)(a37)<<8)|(int)(a36),((int)(a35)<<24)|((int)(a34)<<16)|((int)(a33)<<8)|(int)(a32), \
+                        ((int)(a31)<<24)|((int)(a30)<<16)|((int)(a29)<<8)|(int)(a28),((int)(a27)<<24)|((int)(a26)<<16)|((int)(a25)<<8)|(int)(a24), \
+                        ((int)(a23)<<24)|((int)(a22)<<16)|((int)(a21)<<8)|(int)(a20),((int)(a19)<<24)|((int)(a18)<<16)|((int)(a17)<<8)|(int)(a16), \
+                        ((int)(a15)<<24)|((int)(a14)<<16)|((int)(a13)<<8)|(int)(a12),((int)(a11)<<24)|((int)(a10)<<16)|((int)( a9)<<8)|(int)( a8), \
+                        ((int)( a7)<<24)|((int)( a6)<<16)|((int)( a5)<<8)|(int)( a4),((int)( a3)<<24)|((int)( a2)<<16)|((int)( a1)<<8)|(int)( a0))
 
 #ifndef _mm512_cvtpd_pslo
 #ifdef _mm512_zextsi256_si512
@@ -940,7 +947,7 @@ inline _Tpvec v_rotate_left(const _Tpvec& a, const _Tpvec& b)                   
     if (imm == 0) return a;                                                                                                              \
     if (imm == _Tpvec::nlanes) return b;                                                                                                 \
     if (imm >= 2*_Tpvec::nlanes) return _Tpvec();                                                                                        \
-    return _Tpvec(_mm512_mask_expand_##suffix(_mm512_maskz_compress_##suffix(-1 << SHIFT2, b), -1 << imm, a));                           \
+    return _Tpvec(_mm512_mask_expand_##suffix(_mm512_maskz_compress_##suffix(0xFFFF << SHIFT2, b), 0xFFFF << imm, a));                   \
 }                                                                                                                                        \
 template<int imm>                                                                                                                        \
 inline _Tpvec v_rotate_right(const _Tpvec& a, const _Tpvec& b)                                                                           \
@@ -949,7 +956,7 @@ inline _Tpvec v_rotate_right(const _Tpvec& a, const _Tpvec& b)                  
     if (imm == 0) return a;                                                                                                              \
     if (imm == _Tpvec::nlanes) return b;                                                                                                 \
     if (imm >= 2*_Tpvec::nlanes) return _Tpvec();                                                                                        \
-    return _Tpvec(_mm512_mask_expand_##suffix(_mm512_maskz_compress_##suffix(-1 << imm, a.val), -1 << SHIFT2, b.val));                   \
+    return _Tpvec(_mm512_mask_expand_##suffix(_mm512_maskz_compress_##suffix(0xFFFF << imm, a.val), 0xFFFF << SHIFT2, b.val));           \
 }                                                                                                                                        \
 template<int imm>                                                                                                                        \
 inline _Tpvec v_rotate_left(const _Tpvec& a)                                                                                             \
@@ -957,7 +964,7 @@ inline _Tpvec v_rotate_left(const _Tpvec& a)                                    
     enum { SHIFT2 = _Tpvec::nlanes - imm };                                                                                              \
     if (imm == 0) return a;                                                                                                              \
     if (imm >= _Tpvec::nlanes) return _Tpvec();                                                                                          \
-    return _Tpvec(_mm512_maskz_expand_##suffix(-1 << imm, a.val));                                                                       \
+    return _Tpvec(_mm512_maskz_expand_##suffix(0xFFFF << imm, a.val));                                                                   \
 }                                                                                                                                        \
 template<int imm>                                                                                                                        \
 inline _Tpvec v_rotate_right(const _Tpvec& a)                                                                                            \
@@ -965,7 +972,7 @@ inline _Tpvec v_rotate_right(const _Tpvec& a)                                   
     enum { SHIFT2 = _Tpvec::nlanes - imm };                                                                                              \
     if (imm == 0) return a;                                                                                                              \
     if (imm >= _Tpvec::nlanes) return _Tpvec();                                                                                          \
-    return _Tpvec(_mm512_maskz_compress_##suffix(-1 << imm, a.val));                                                                     \
+    return _Tpvec(_mm512_maskz_compress_##suffix(0xFFFF << imm, a.val));                                                                 \
 }
 
 OPENCV_HAL_IMPL_AVX512_ROTATE_PM(v_uint8x64,   u8)

--- a/modules/core/include/opencv2/core/hal/intrin_avx512.hpp
+++ b/modules/core/include/opencv2/core/hal/intrin_avx512.hpp
@@ -509,14 +509,14 @@ inline void v_zip(const v_int16x32& a, const v_int16x32& b, v_int16x32& ab0, v_i
 }
 inline void v_zip(const v_int32x16& a, const v_int32x16& b, v_int32x16& ab0, v_int32x16& ab1)
 {
-    __m512i mask0 = _v512_set_epi32(23, 7, 22, 6, 21, 5, 20, 4, 19, 3, 18, 2, 17, 1, 16, 0);
+    __m512i mask0 = _v512_set_epi32(23,  7, 22,  6, 21,  5, 20,  4, 19,  3, 18,  2, 17, 1, 16, 0);
     ab0 = v_int32x16(_mm512_permutex2var_epi32(a.val, mask0, b.val));
     __m512i mask1 = _v512_set_epi32(31, 15, 30, 14, 29, 13, 28, 12, 27, 11, 26, 10, 25, 9, 24, 8);
     ab1 = v_int32x16(_mm512_permutex2var_epi32(a.val, mask1, b.val));
 }
 inline void v_zip(const v_int64x8& a, const v_int64x8& b, v_int64x8& ab0, v_int64x8& ab1)
 {
-    __m512i mask0 = _v512_set_epi64(11, 3, 10, 2, 9, 1, 8, 0);
+    __m512i mask0 = _v512_set_epi64(11, 3, 10, 2,  9, 1,  8, 0);
     ab0 = v_int64x8(_mm512_permutex2var_epi64(a.val, mask0, b.val));
     __m512i mask1 = _v512_set_epi64(15, 7, 14, 6, 13, 5, 12, 4);
     ab1 = v_int64x8(_mm512_permutex2var_epi64(a.val, mask1, b.val));
@@ -1626,7 +1626,7 @@ OPENCV_HAL_IMPL_AVX512_EXPAND_Q(v_int32x16,  schar, _mm512_cvtepi8_epi32)
 /* pack */
 // 16
 inline v_int8x64 v_pack(const v_int16x32& a, const v_int16x32& b)
-{ return v_int8x64(_mm512_permutexvar_epi64(_v512_set_epi64(7,5,3,1,6,4,2,0), _mm512_packs_epi16(a.val, b.val))); }
+{ return v_int8x64(_mm512_permutexvar_epi64(_v512_set_epi64(7, 5, 3, 1, 6, 4, 2, 0), _mm512_packs_epi16(a.val, b.val))); }
 
 inline v_uint8x64 v_pack(const v_uint16x32& a, const v_uint16x32& b)
 {
@@ -1863,14 +1863,14 @@ inline void v_load_deinterleave( const uchar* ptr, v_uint8x64& a, v_uint8x64& b 
     __m512i ab0 = _mm512_loadu_si512((const __m512i*)ptr);
     __m512i ab1 = _mm512_loadu_si512((const __m512i*)(ptr + 64));
 #if CV_USE_VBMIPERMUTE
-    __m512i mask0 = _v512_set_epi8( 126, 124, 122, 120, 118, 116, 114, 112, 110, 108, 106, 104, 102, 100, 98, 96,
-                                     94,  92,  90,  88,  86,  84,  82,  80,  78,  76,  74,  72,  70,  68, 66, 64,
-                                     62,  60,  58,  56,  54,  52,  50,  48,  46,  44,  42,  40,  38,  36, 34, 32,
-                                     30,  28,  26,  24,  22,  20,  18,  16,  14,  12,  10,   8,   6,   4,  2,  0 );
-    __m512i mask1 = _v512_set_epi8( 127, 125, 123, 121, 119, 117, 115, 113, 111, 109, 107, 105, 103, 101, 99, 97,
-                                     95,  93,  91,  89,  87,  85,  83,  81,  79,  77,  75,  73,  71,  69, 67, 65,
-                                     63,  61,  59,  57,  55,  53,  51,  49,  47,  45,  43,  41,  39,  37, 35, 33,
-                                     31,  29,  27,  25,  23,  21,  19,  17,  15,  13,  11,   9,   7,   5,  3,  1 );
+    __m512i mask0 = _v512_set_epi8(126, 124, 122, 120, 118, 116, 114, 112, 110, 108, 106, 104, 102, 100, 98, 96,
+                                    94,  92,  90,  88,  86,  84,  82,  80,  78,  76,  74,  72,  70,  68, 66, 64,
+                                    62,  60,  58,  56,  54,  52,  50,  48,  46,  44,  42,  40,  38,  36, 34, 32,
+                                    30,  28,  26,  24,  22,  20,  18,  16,  14,  12,  10,   8,   6,   4,  2,  0);
+    __m512i mask1 = _v512_set_epi8(127, 125, 123, 121, 119, 117, 115, 113, 111, 109, 107, 105, 103, 101, 99, 97,
+                                    95,  93,  91,  89,  87,  85,  83,  81,  79,  77,  75,  73,  71,  69, 67, 65,
+                                    63,  61,  59,  57,  55,  53,  51,  49,  47,  45,  43,  41,  39,  37, 35, 33,
+                                    31,  29,  27,  25,  23,  21,  19,  17,  15,  13,  11,   9,   7,   5,  3,  1);
     a = v_uint8x64(_mm512_permutex2var_epi8(ab0, mask0, ab1));
     b = v_uint8x64(_mm512_permutex2var_epi8(ab0, mask1, ab1));
 #else
@@ -1888,10 +1888,10 @@ inline void v_load_deinterleave( const ushort* ptr, v_uint16x32& a, v_uint16x32&
 {
     __m512i ab0 = _mm512_loadu_si512((const __m512i*)ptr);
     __m512i ab1 = _mm512_loadu_si512((const __m512i*)(ptr + 32));
-    __m512i mask0 = _v512_set_epi16( 62, 60, 58, 56, 54, 52, 50, 48, 46, 44, 42, 40, 38, 36, 34, 32,
-                                     30, 28, 26, 24, 22, 20, 18, 16, 14, 12, 10,  8,  6,  4,  2,  0 );
-    __m512i mask1 = _v512_set_epi16( 63, 61, 59, 57, 55, 53, 51, 49, 47, 45, 43, 41, 39, 37, 35, 33,
-                                     31, 29, 27, 25, 23, 21, 19, 17, 15, 13, 11,  9,  7,  5,  3,  1 );
+    __m512i mask0 = _v512_set_epi16(62, 60, 58, 56, 54, 52, 50, 48, 46, 44, 42, 40, 38, 36, 34, 32,
+                                    30, 28, 26, 24, 22, 20, 18, 16, 14, 12, 10,  8,  6,  4,  2,  0);
+    __m512i mask1 = _v512_set_epi16(63, 61, 59, 57, 55, 53, 51, 49, 47, 45, 43, 41, 39, 37, 35, 33,
+                                    31, 29, 27, 25, 23, 21, 19, 17, 15, 13, 11,  9,  7,  5,  3,  1);
     a = v_uint16x32(_mm512_permutex2var_epi16(ab0, mask0, ab1));
     b = v_uint16x32(_mm512_permutex2var_epi16(ab0, mask1, ab1));
 }
@@ -1900,8 +1900,8 @@ inline void v_load_deinterleave( const unsigned* ptr, v_uint32x16& a, v_uint32x1
 {
     __m512i ab0 = _mm512_loadu_si512((const __m512i*)ptr);
     __m512i ab1 = _mm512_loadu_si512((const __m512i*)(ptr + 16));
-    __m512i mask0 = _v512_set_epi32( 30, 28, 26, 24, 22, 20, 18, 16, 14, 12, 10, 8, 6, 4, 2, 0 );
-    __m512i mask1 = _v512_set_epi32( 31, 29, 27, 25, 23, 21, 19, 17, 15, 13, 11, 9, 7, 5, 3, 1 );
+    __m512i mask0 = _v512_set_epi32(30, 28, 26, 24, 22, 20, 18, 16, 14, 12, 10, 8, 6, 4, 2, 0);
+    __m512i mask1 = _v512_set_epi32(31, 29, 27, 25, 23, 21, 19, 17, 15, 13, 11, 9, 7, 5, 3, 1);
     a = v_uint32x16(_mm512_permutex2var_epi32(ab0, mask0, ab1));
     b = v_uint32x16(_mm512_permutex2var_epi32(ab0, mask1, ab1));
 }
@@ -1910,8 +1910,8 @@ inline void v_load_deinterleave( const uint64* ptr, v_uint64x8& a, v_uint64x8& b
 {
     __m512i ab0 = _mm512_loadu_si512((const __m512i*)ptr);
     __m512i ab1 = _mm512_loadu_si512((const __m512i*)(ptr + 8));
-    __m512i mask0 = _v512_set_epi64( 14, 12, 10, 8, 6, 4, 2, 0 );
-    __m512i mask1 = _v512_set_epi64( 15, 13, 11, 9, 7, 5, 3, 1 );
+    __m512i mask0 = _v512_set_epi64(14, 12, 10, 8, 6, 4, 2, 0);
+    __m512i mask1 = _v512_set_epi64(15, 13, 11, 9, 7, 5, 3, 1);
     a = v_uint64x8(_mm512_permutex2var_epi64(ab0, mask0, ab1));
     b = v_uint64x8(_mm512_permutex2var_epi64(ab0, mask1, ab1));
 }
@@ -1923,17 +1923,17 @@ inline void v_load_deinterleave( const uchar* ptr, v_uint8x64& b, v_uint8x64& g,
     __m512i bgr2 = _mm512_loadu_si512((const __m512i*)(ptr + 128));
 
 #if defined(_mm512_mask_expand_epi8) && defined(_mm512_mask_compress_epi8)
-    __m512i mask0 = _v512_set_epi8( 126, 123, 120, 117, 114, 111, 108, 105, 102,  99,  96,  93,  90,  87,  84, 81,
-                                     78,  75,  72,  69,  66,  63,  60,  57,  54,  51,  48,  45,  42,  39,  36, 33,
-                                     30,  27,  24,  21,  18,  15,  12,   9,   6,   3,   0,  62,  59,  56,  53, 50,
-                                     47,  44,  41,  38,  35,  32,  29,  26,  23,  20,  17,  14,  11,   8,   5,  2 );
+    __m512i mask0 = _v512_set_epi8(126, 123, 120, 117, 114, 111, 108, 105, 102,  99,  96,  93,  90,  87,  84, 81,
+                                    78,  75,  72,  69,  66,  63,  60,  57,  54,  51,  48,  45,  42,  39,  36, 33,
+                                    30,  27,  24,  21,  18,  15,  12,   9,   6,   3,   0,  62,  59,  56,  53, 50,
+                                    47,  44,  41,  38,  35,  32,  29,  26,  23,  20,  17,  14,  11,   8,   5,  2);
     __m512i r0b01 = _mm512_permutex2var_epi8(bgr0, mask0, bgr1);
     __m512i b1g12 = _mm512_permutex2var_epi8(bgr1, mask0, bgr2);
     __m512i r12b2 = _mm512_permutex2var_epi8(bgr1,
-                    _v512_set_epi8( 125, 122, 119, 116, 113, 110, 107, 104, 101,  98,  95,  92,  89,  86,  83, 80,
-                                     77,  74,  71,  68,  65, 127, 124, 121, 118, 115, 112, 109, 106, 103, 100, 97,
-                                     94,  91,  88,  85,  82,  79,  76,  73,  70,  67,  64,  61,  58,  55,  52, 49,
-                                     46,  43,  40,  37,  34,  31,  28,  25,  22,  19,  16,  13,  10,   7,   4,  1 ), bgr2);
+                    _v512_set_epi8(125, 122, 119, 116, 113, 110, 107, 104, 101,  98,  95,  92,  89,  86,  83, 80,
+                                    77,  74,  71,  68,  65, 127, 124, 121, 118, 115, 112, 109, 106, 103, 100, 97,
+                                    94,  91,  88,  85,  82,  79,  76,  73,  70,  67,  64,  61,  58,  55,  52, 49,
+                                    46,  43,  40,  37,  34,  31,  28,  25,  22,  19,  16,  13,  10,   7,   4,  1), bgr2);
     b = v_uint8x64(_mm512_mask_compress_epi8(r12b2, 0xffffffffffe00000, r0b01));
     g = v_uint8x64(_mm512_mask_compress_epi8(b1g12, 0x2492492492492492, bgr0));
     r = v_uint8x64(_mm512_mask_expand_epi8(r0b01, 0xffffffffffe00000, r12b2));
@@ -1941,18 +1941,18 @@ inline void v_load_deinterleave( const uchar* ptr, v_uint8x64& b, v_uint8x64& g,
     __m512i b0g0b1 = _mm512_mask_blend_epi8(0xb6db6db6db6db6db, bgr1, bgr0);
     __m512i g1r1g2 = _mm512_mask_blend_epi8(0xb6db6db6db6db6db, bgr2, bgr1);
     __m512i r2b2r0 = _mm512_mask_blend_epi8(0xb6db6db6db6db6db, bgr0, bgr2);
-    b = v_uint8x64(_mm512_permutex2var_epi8(b0g0b1, _v512_set_epi8( 125, 122, 119, 116, 113, 110, 107, 104, 101,  98,  95,  92,  89,  86,  83,  80,
-                                                                     77,  74,  71,  68,  65,  63,  61,  60,  58,  57,  55,  54,  52,  51,  49,  48,
-                                                                     46,  45,  43,  42,  40,  39,  37,  36,  34,  33,  31,  30,  28,  27,  25,  24,
-                                                                     23,  21,  20,  18,  17,  15,  14,  12,  11,   9,   8,   6,   5,   3,   2,   0 ), bgr2));
-    g = v_uint8x64(_mm512_permutex2var_epi8(g1r1g2, _v512_set_epi8(  63,  61,  60,  58,  57,  55,  54,  52,  51,  49,  48,  46,  45,  43,  42,  40,
-                                                                     39,  37,  36,  34,  33,  31,  30,  28,  27,  25,  24,  23,  21,  20,  18,  17,
-                                                                     15,  14,  12,  11,   9,   8,   6,   5,   3,   2,   0, 126, 123, 120, 117, 114,
-                                                                    111, 108, 105, 102,  99,  96,  93,  90,  87,  84,  81,  78,  75,  72,  69,  66 ), bgr0));
-    r = v_uint8x64(_mm512_permutex2var_epi8(r2b2r0, _v512_set_epi8(  63,  60,  57,  54,  51,  48,  45,  42,  39,  36,  33,  30,  27,  24,  21,  18,
-                                                                     15,  12,   9,   6,   3,   0, 125, 122, 119, 116, 113, 110, 107, 104, 101,  98,
-                                                                     95,  92,  89,  86,  83,  80,  77,  74,  71,  68,  65,  62,  59,  56,  53,  50,
-                                                                     47,  44,  41,  38,  35,  32,  29,  26,  23,  20,  17,  14,  11,   8,   5,   2 ), bgr1));
+    b = v_uint8x64(_mm512_permutex2var_epi8(b0g0b1, _v512_set_epi8(125, 122, 119, 116, 113, 110, 107, 104, 101,  98,  95,  92,  89,  86,  83,  80,
+                                                                    77,  74,  71,  68,  65,  63,  61,  60,  58,  57,  55,  54,  52,  51,  49,  48,
+                                                                    46,  45,  43,  42,  40,  39,  37,  36,  34,  33,  31,  30,  28,  27,  25,  24,
+                                                                    23,  21,  20,  18,  17,  15,  14,  12,  11,   9,   8,   6,   5,   3,   2,   0), bgr2));
+    g = v_uint8x64(_mm512_permutex2var_epi8(g1r1g2, _v512_set_epi8( 63,  61,  60,  58,  57,  55,  54,  52,  51,  49,  48,  46,  45,  43,  42,  40,
+                                                                    39,  37,  36,  34,  33,  31,  30,  28,  27,  25,  24,  23,  21,  20,  18,  17,
+                                                                    15,  14,  12,  11,   9,   8,   6,   5,   3,   2,   0, 126, 123, 120, 117, 114,
+                                                                   111, 108, 105, 102,  99,  96,  93,  90,  87,  84,  81,  78,  75,  72,  69,  66), bgr0));
+    r = v_uint8x64(_mm512_permutex2var_epi8(r2b2r0, _v512_set_epi8( 63,  60,  57,  54,  51,  48,  45,  42,  39,  36,  33,  30,  27,  24,  21,  18,
+                                                                    15,  12,   9,   6,   3,   0, 125, 122, 119, 116, 113, 110, 107, 104, 101,  98,
+                                                                    95,  92,  89,  86,  83,  80,  77,  74,  71,  68,  65,  62,  59,  56,  53,  50,
+                                                                    47,  44,  41,  38,  35,  32,  29,  26,  23,  20,  17,  14,  11,   8,   5,   2), bgr1));
 #else
     __m512i mask0 = _v512_set_epi16(61, 58, 55, 52, 49, 46, 43, 40, 37, 34, 63, 60, 57, 54, 51, 48,
                                     45, 42, 39, 36, 33, 30, 27, 24, 21, 18, 15, 12,  9,  6,  3,  0);
@@ -1976,8 +1976,8 @@ inline void v_load_deinterleave( const ushort* ptr, v_uint16x32& b, v_uint16x32&
     __m512i bgr1 = _mm512_loadu_si512((const __m512i*)(ptr + 32));
     __m512i bgr2 = _mm512_loadu_si512((const __m512i*)(ptr + 64));
 
-    __m512i mask0 = _v512_set_epi16( 61, 58, 55, 52, 49, 46, 43, 40, 37, 34, 63, 60, 57, 54, 51, 48,
-                                     45, 42, 39, 36, 33, 30, 27, 24, 21, 18, 15, 12,  9,  6,  3,  0 );
+    __m512i mask0 = _v512_set_epi16(61, 58, 55, 52, 49, 46, 43, 40, 37, 34, 63, 60, 57, 54, 51, 48,
+                                    45, 42, 39, 36, 33, 30, 27, 24, 21, 18, 15, 12,  9,  6,  3,  0);
     __m512i b01g1 = _mm512_permutex2var_epi16(bgr0, mask0, bgr1);
     __m512i r12b2 = _mm512_permutex2var_epi16(bgr1, mask0, bgr2);
     __m512i g20r0 = _mm512_permutex2var_epi16(bgr2, mask0, bgr0);
@@ -1994,14 +1994,14 @@ inline void v_load_deinterleave( const unsigned* ptr, v_uint32x16& b, v_uint32x1
     __m512i bgr1 = _mm512_loadu_si512((const __m512i*)(ptr + 16));
     __m512i bgr2 = _mm512_loadu_si512((const __m512i*)(ptr + 32));
 
-    __m512i mask0 = _v512_set_epi32( 29, 26, 23, 20, 17, 30, 27, 24, 21, 18, 15, 12, 9, 6, 3, 0 );
+    __m512i mask0 = _v512_set_epi32(29, 26, 23, 20, 17, 30, 27, 24, 21, 18, 15, 12, 9, 6, 3, 0);
     __m512i b01r1 = _mm512_permutex2var_epi32(bgr0, mask0, bgr1);
     __m512i g12b2 = _mm512_permutex2var_epi32(bgr1, mask0, bgr2);
     __m512i r20g0 = _mm512_permutex2var_epi32(bgr2, mask0, bgr0);
 
-    b = v_uint32x16(_mm512_mask_blend_epi32(0x001f, b01r1, g12b2));
+    b = v_uint32x16(_mm512_mask_blend_epi32(0xf800, b01r1, g12b2));
     g = v_uint32x16(_mm512_alignr_epi32(g12b2, r20g0, 11));
-    r = v_uint32x16(_mm512_permutex2var_epi32(bgr1, _v512_set_epi32( 26, 25, 24, 23, 22, 13, 10, 7, 4, 1, 21, 20, 19, 18, 17, 16 ), r20g0));
+    r = v_uint32x16(_mm512_permutex2var_epi32(bgr1, _v512_set_epi32(21, 20, 19, 18, 17, 16, 13, 10, 7, 4, 1, 26, 25, 24, 23, 22), r20g0));
 }
 
 inline void v_load_deinterleave( const uint64* ptr, v_uint64x8& b, v_uint64x8& g, v_uint64x8& r )
@@ -2010,14 +2010,14 @@ inline void v_load_deinterleave( const uint64* ptr, v_uint64x8& b, v_uint64x8& g
     __m512i bgr1 = _mm512_loadu_si512((const __m512i*)(ptr + 8));
     __m512i bgr2 = _mm512_loadu_si512((const __m512i*)(ptr + 16));
 
-    __m512i mask0 = _v512_set_epi64( 13, 10, 15, 12, 9, 6, 3, 0 );
+    __m512i mask0 = _v512_set_epi64(13, 10, 15, 12, 9, 6, 3, 0);
     __m512i b01g1 = _mm512_permutex2var_epi64(bgr0, mask0, bgr1);
     __m512i r12b2 = _mm512_permutex2var_epi64(bgr1, mask0, bgr2);
     __m512i g20r0 = _mm512_permutex2var_epi64(bgr2, mask0, bgr0);
 
-    b = v_uint64x8(_mm512_mask_blend_epi64(0x03, b01g1, r12b2));
+    b = v_uint64x8(_mm512_mask_blend_epi64(0xc0, b01g1, r12b2));
     r = v_uint64x8(_mm512_alignr_epi64(r12b2, g20r0, 6));
-    g = v_uint64x8(_mm512_permutex2var_epi64(bgr1, _v512_set_epi64( 10, 9, 8, 5, 2, 13, 12, 11 ), g20r0));
+    g = v_uint64x8(_mm512_permutex2var_epi64(bgr1, _v512_set_epi64(10, 9, 8, 5, 2, 13, 12, 11), g20r0));
 }
 
 inline void v_load_deinterleave( const uchar* ptr, v_uint8x64& b, v_uint8x64& g, v_uint8x64& r, v_uint8x64& a )
@@ -2028,14 +2028,14 @@ inline void v_load_deinterleave( const uchar* ptr, v_uint8x64& b, v_uint8x64& g,
     __m512i bgra3 = _mm512_loadu_si512((const __m512i*)(ptr + 192));
 
 #if CV_USE_VBMIPERMUTE
-    __m512i mask0 = _v512_set_epi8( 126, 124, 122, 120, 118, 116, 114, 112, 110, 108, 106, 104, 102, 100, 98, 96,
-                                     94,  92,  90,  88,  86,  84,  82,  80,  78,  76,  74,  72,  70,  68, 66, 64,
-                                     62,  60,  58,  56,  54,  52,  50,  48,  46,  44,  42,  40,  38,  36, 34, 32,
-                                     30,  28,  26,  24,  22,  20,  18,  16,  14,  12,  10,   8,   6,   4,  2,  0 );
-    __m512i mask1 = _v512_set_epi8( 127, 125, 123, 121, 119, 117, 115, 113, 111, 109, 107, 105, 103, 101, 99, 97,
-                                     95,  93,  91,  89,  87,  85,  83,  81,  79,  77,  75,  73,  71,  69, 67, 65,
-                                     63,  61,  59,  57,  55,  53,  51,  49,  47,  45,  43,  41,  39,  37, 35, 33,
-                                     31,  29,  27,  25,  23,  21,  19,  17,  15,  13,  11,   9,   7,   5,  3,  1 );
+    __m512i mask0 = _v512_set_epi8(126, 124, 122, 120, 118, 116, 114, 112, 110, 108, 106, 104, 102, 100, 98, 96,
+                                    94,  92,  90,  88,  86,  84,  82,  80,  78,  76,  74,  72,  70,  68, 66, 64,
+                                    62,  60,  58,  56,  54,  52,  50,  48,  46,  44,  42,  40,  38,  36, 34, 32,
+                                    30,  28,  26,  24,  22,  20,  18,  16,  14,  12,  10,   8,   6,   4,  2,  0);
+    __m512i mask1 = _v512_set_epi8(127, 125, 123, 121, 119, 117, 115, 113, 111, 109, 107, 105, 103, 101, 99, 97,
+                                    95,  93,  91,  89,  87,  85,  83,  81,  79,  77,  75,  73,  71,  69, 67, 65,
+                                    63,  61,  59,  57,  55,  53,  51,  49,  47,  45,  43,  41,  39,  37, 35, 33,
+                                    31,  29,  27,  25,  23,  21,  19,  17,  15,  13,  11,   9,   7,   5,  3,  1);
 
     __m512i br01 = _mm512_permutex2var_epi8(bgra0, mask0, bgra1);
     __m512i ga01 = _mm512_permutex2var_epi8(bgra0, mask1, bgra1);
@@ -2075,10 +2075,10 @@ inline void v_load_deinterleave( const ushort* ptr, v_uint16x32& b, v_uint16x32&
     __m512i bgra2 = _mm512_loadu_si512((const __m512i*)(ptr + 64));
     __m512i bgra3 = _mm512_loadu_si512((const __m512i*)(ptr + 96));
 
-    __m512i mask0 = _v512_set_epi16( 62, 60, 58, 56, 54, 52, 50, 48, 46, 44, 42, 40, 38, 36, 34, 32,
-                                     30, 28, 26, 24, 22, 20, 18, 16, 14, 12, 10,  8,  6,  4,  2,  0 );
-    __m512i mask1 = _v512_set_epi16( 63, 61, 59, 57, 55, 53, 51, 49, 47, 45, 43, 41, 39, 37, 35, 33,
-                                     31, 29, 27, 25, 23, 21, 19, 17, 15, 13, 11,  9,  7,  5,  3,  1 );
+    __m512i mask0 = _v512_set_epi16(62, 60, 58, 56, 54, 52, 50, 48, 46, 44, 42, 40, 38, 36, 34, 32,
+                                    30, 28, 26, 24, 22, 20, 18, 16, 14, 12, 10,  8,  6,  4,  2,  0);
+    __m512i mask1 = _v512_set_epi16(63, 61, 59, 57, 55, 53, 51, 49, 47, 45, 43, 41, 39, 37, 35, 33,
+                                    31, 29, 27, 25, 23, 21, 19, 17, 15, 13, 11,  9,  7,  5,  3,  1);
 
     __m512i br01 = _mm512_permutex2var_epi16(bgra0, mask0, bgra1);
     __m512i ga01 = _mm512_permutex2var_epi16(bgra0, mask1, bgra1);
@@ -2098,8 +2098,8 @@ inline void v_load_deinterleave( const unsigned* ptr, v_uint32x16& b, v_uint32x1
     __m512i bgra2 = _mm512_loadu_si512((const __m512i*)(ptr + 32));
     __m512i bgra3 = _mm512_loadu_si512((const __m512i*)(ptr + 48));
 
-    __m512i mask0 = _v512_set_epi32( 30, 28, 26, 24, 22, 20, 18, 16, 14, 12, 10, 8, 6, 4, 2, 0 );
-    __m512i mask1 = _v512_set_epi32( 31, 29, 27, 25, 23, 21, 19, 17, 15, 13, 11, 9, 7, 5, 3, 1 );
+    __m512i mask0 = _v512_set_epi32(30, 28, 26, 24, 22, 20, 18, 16, 14, 12, 10, 8, 6, 4, 2, 0);
+    __m512i mask1 = _v512_set_epi32(31, 29, 27, 25, 23, 21, 19, 17, 15, 13, 11, 9, 7, 5, 3, 1);
 
     __m512i br01 = _mm512_permutex2var_epi32(bgra0, mask0, bgra1);
     __m512i ga01 = _mm512_permutex2var_epi32(bgra0, mask1, bgra1);
@@ -2119,8 +2119,8 @@ inline void v_load_deinterleave( const uint64* ptr, v_uint64x8& b, v_uint64x8& g
     __m512i bgra2 = _mm512_loadu_si512((const __m512i*)(ptr + 16));
     __m512i bgra3 = _mm512_loadu_si512((const __m512i*)(ptr + 24));
 
-    __m512i mask0 = _v512_set_epi64( 14, 12, 10, 8, 6, 4, 2, 0 );
-    __m512i mask1 = _v512_set_epi64( 15, 13, 11, 9, 7, 5, 3, 1 );
+    __m512i mask0 = _v512_set_epi64(14, 12, 10, 8, 6, 4, 2, 0);
+    __m512i mask1 = _v512_set_epi64(15, 13, 11, 9, 7, 5, 3, 1);
 
     __m512i br01 = _mm512_permutex2var_epi64(bgra0, mask0, bgra1);
     __m512i ga01 = _mm512_permutex2var_epi64(bgra0, mask1, bgra1);
@@ -2327,14 +2327,14 @@ inline void v_store_interleave( ushort* ptr, const v_uint16x32& b, const v_uint1
 inline void v_store_interleave( unsigned* ptr, const v_uint32x16& b, const v_uint32x16& g, const v_uint32x16& r,
                                 hal::StoreMode mode=hal::STORE_UNALIGNED )
 {
-    __m512i mask0 = _v512_set_epi32( 26, 31, 15, 25, 30, 14, 24, 29, 13, 23, 28, 12, 22, 27, 11, 21 );
-    __m512i mask1 = _v512_set_epi32( 31, 10, 25, 30,  9, 24, 29,  8, 23, 28,  7, 22, 27,  6, 21, 26 );
+    __m512i mask0 = _v512_set_epi32(26, 31, 15, 25, 30, 14, 24, 29, 13, 23, 28, 12, 22, 27, 11, 21);
+    __m512i mask1 = _v512_set_epi32(31, 10, 25, 30,  9, 24, 29,  8, 23, 28,  7, 22, 27,  6, 21, 26);
     __m512i g1b2g2 = _mm512_permutex2var_epi32(b.val, mask0, g.val);
     __m512i r2r1b1 = _mm512_permutex2var_epi32(b.val, mask1, r.val);
 
     __m512i bgr0 = _mm512_mask_expand_epi32(_mm512_mask_expand_epi32(_mm512_maskz_expand_epi32(0x9249, b.val), 0x2492, g.val), 0x4924, r.val);
-    __m512i bgr1 = _mm512_mask_blend_epi32(0x003f, r2r1b1, g1b2g2);
-    __m512i bgr2 = _mm512_mask_blend_epi32(0x003f, g1b2g2, r2r1b1);
+    __m512i bgr1 = _mm512_mask_blend_epi32(0x9249, r2r1b1, g1b2g2);
+    __m512i bgr2 = _mm512_mask_blend_epi32(0x9249, g1b2g2, r2r1b1);
 
     if( mode == hal::STORE_ALIGNED_NOCACHE )
     {
@@ -2359,14 +2359,14 @@ inline void v_store_interleave( unsigned* ptr, const v_uint32x16& b, const v_uin
 inline void v_store_interleave( uint64* ptr, const v_uint64x8& b, const v_uint64x8& g, const v_uint64x8& r,
                                 hal::StoreMode mode=hal::STORE_UNALIGNED )
 {
-    __m512i mask0 = _v512_set_epi64(  5, 12,  7,  4, 11,  6,  3, 10 );
-    __m512i mask1 = _v512_set_epi64( 15,  7,  4, 14,  6,  3, 13,  5 );
+    __m512i mask0 = _v512_set_epi64( 5, 12,  7,  4, 11,  6,  3, 10);
+    __m512i mask1 = _v512_set_epi64(15,  7,  4, 14,  6,  3, 13,  5);
     __m512i r1b1b2 = _mm512_permutex2var_epi64(b.val, mask0, r.val);
     __m512i g2r2g1 = _mm512_permutex2var_epi64(g.val, mask1, r.val);
 
     __m512i bgr0 = _mm512_mask_expand_epi64(_mm512_mask_expand_epi64(_mm512_maskz_expand_epi64(0x49, b.val), 0x92, g.val), 0x24, r.val);
-    __m512i bgr1 = _mm512_mask_blend_epi64(0x3f, g2r2g1, r1b1b2);
-    __m512i bgr2 = _mm512_mask_blend_epi64(0x3f, r1b1b2, g2r2g1);
+    __m512i bgr1 = _mm512_mask_blend_epi64(0xdb, g2r2g1, r1b1b2);
+    __m512i bgr2 = _mm512_mask_blend_epi64(0xdb, r1b1b2, g2r2g1);
 
     if( mode == hal::STORE_ALIGNED_NOCACHE )
     {

--- a/modules/core/include/opencv2/core/hal/intrin_avx512.hpp
+++ b/modules/core/include/opencv2/core/hal/intrin_avx512.hpp
@@ -1953,15 +1953,15 @@ inline void v_load_deinterleave( const uchar* ptr, v_uint8x64& b, v_uint8x64& g,
                                                                      47,  44,  41,  38,  35,  32,  29,  26,  23,  20,  17,  14,  11,   8,   5,   2 ), bgr1));
 #else
     __m512i mask0 = _v512_set_epi16(61, 58, 55, 52, 49, 46, 43, 40, 37, 34, 63, 60, 57, 54, 51, 48,
-        45, 42, 39, 36, 33, 30, 27, 24, 21, 18, 15, 12, 9, 6, 3, 0);
+                                    45, 42, 39, 36, 33, 30, 27, 24, 21, 18, 15, 12,  9,  6,  3,  0);
     __m512i b01g1 = _mm512_permutex2var_epi16(bgr0, mask0, bgr1);
     __m512i r12b2 = _mm512_permutex2var_epi16(bgr1, mask0, bgr2);
     __m512i g20r0 = _mm512_permutex2var_epi16(bgr2, mask0, bgr0);
 
-    __m512i b0g0 = _mm512_mask_blend_epi32(0x001f, b01g1, r12b2);
-    __m512i r0b1 = _mm512_alignr_epi32(r12b2, g20r0, 11);
-    __m512i g1r1 = _mm512_permutex2var_epi16(bgr1, _v512_set_epi16(42, 41, 40, 39, 38, 37, 36, 35, 34, 33, 32, 29, 26, 23, 20, 17,
+    __m512i b0g0 = _mm512_mask_blend_epi32(0xf800, b01g1, r12b2);
+    __m512i r0b1 = _mm512_permutex2var_epi16(bgr1, _v512_set_epi16(42, 41, 40, 39, 38, 37, 36, 35, 34, 33, 32, 29, 26, 23, 20, 17,
                                                                    14, 11,  8,  5,  2, 53, 52, 51, 50, 49, 48, 47, 46, 45, 44, 43), g20r0);
+    __m512i g1r1 = _mm512_alignr_epi32(r12b2, g20r0, 11);
     b = v_uint8x64(_mm512_mask_blend_epi8(0xAAAAAAAAAAAAAAAA, b0g0, r0b1));
     r = v_uint8x64(_mm512_mask_blend_epi8(0xAAAAAAAAAAAAAAAA, r0b1, g1r1));
     g = v_uint8x64(_mm512_shuffle_epi8(_mm512_mask_blend_epi8(0xAAAAAAAAAAAAAAAA, g1r1, b0g0), _mm512_set4_epi32(0x0e0f0c0d, 0x0a0b0809, 0x06070405, 0x02030001)));
@@ -1980,10 +1980,10 @@ inline void v_load_deinterleave( const ushort* ptr, v_uint16x32& b, v_uint16x32&
     __m512i r12b2 = _mm512_permutex2var_epi16(bgr1, mask0, bgr2);
     __m512i g20r0 = _mm512_permutex2var_epi16(bgr2, mask0, bgr0);
 
-    b = v_uint16x32(_mm512_mask_blend_epi32(0x001f, b01g1, r12b2));
-    g = v_uint16x32(_mm512_alignr_epi32(r12b2, g20r0, 11));
-    r = v_uint16x32(_mm512_permutex2var_epi16(bgr1, _v512_set_epi16( 42, 41, 40, 39, 38, 37, 36, 35, 34, 33, 32, 29, 26, 23, 20, 17,
-                                                                     14, 11,  8,  5,  2, 53, 52, 51, 50, 49, 48, 47, 46, 45, 44, 43 ), g20r0));
+    b = v_uint16x32(_mm512_mask_blend_epi32(0xf800, b01g1, r12b2));
+    g = v_uint16x32(_mm512_permutex2var_epi16(bgr1, _v512_set_epi16(42, 41, 40, 39, 38, 37, 36, 35, 34, 33, 32, 29, 26, 23, 20, 17,
+                                                                    14, 11,  8,  5,  2, 53, 52, 51, 50, 49, 48, 47, 46, 45, 44, 43), g20r0));
+    r = v_uint16x32(_mm512_alignr_epi32(r12b2, g20r0, 11));
 }
 
 inline void v_load_deinterleave( const unsigned* ptr, v_uint32x16& b, v_uint32x16& g, v_uint32x16& r )

--- a/modules/core/include/opencv2/core/hal/intrin_avx512.hpp
+++ b/modules/core/include/opencv2/core/hal/intrin_avx512.hpp
@@ -906,9 +906,9 @@ inline v_int8x64 v_rotate_left(const v_int8x64& a, const v_int8x64& b)
                           0x47 - imm,0x46 - imm,0x45 - imm,0x44 - imm,0x43 - imm,0x42 - imm,0x41 - imm,0x40 - imm), a.val));
 #else
     enum { SHIFT2 = 64 - imm };
-    __m512i pre = _mm512_alignr_epi32(b.val, a.val, SHIFT2 / 4);
+    __m512i pre = _mm512_alignr_epi32(a.val, b.val, SHIFT2 / 4);
     if (SHIFT2 % 4)
-        return v_int8x64(_mm512_or_si512(_mm512_srli_epi32(pre, SHIFT2 % 4), _mm512_slli_epi32(_mm512_alignr_epi32(b.val, a.val, SHIFT2 / 4 + 1), 4 - SHIFT2 % 4)));
+        return v_int8x64(_mm512_or_si512(_mm512_srli_epi32(pre, (SHIFT2 % 4)*8), _mm512_slli_epi32(_mm512_alignr_epi32(a.val, b.val, SHIFT2 / 4 + 1), (4 - SHIFT2 % 4)*8)));
     else
         return v_int8x64(pre);
 #endif
@@ -932,7 +932,7 @@ inline v_int8x64 v_rotate_right(const v_int8x64& a, const v_int8x64& b)
 #else
     __m512i pre = _mm512_alignr_epi32(b.val, a.val, imm / 4);
     if (imm % 4)
-        return v_int8x64(_mm512_or_si512(_mm512_srli_epi32(pre, imm % 4), _mm512_slli_epi32(_mm512_alignr_epi32(b.val, a.val, imm / 4 + 1), 4 - imm % 4)));
+        return v_int8x64(_mm512_or_si512(_mm512_srli_epi32(pre, (imm % 4)*8), _mm512_slli_epi32(_mm512_alignr_epi32(b.val, a.val, imm / 4 + 1), (4 - imm % 4)*8)));
     else
         return v_int8x64(pre);
 #endif
@@ -955,9 +955,9 @@ inline v_int8x64 v_rotate_left(const v_int8x64& a)
 #else
     enum { SHIFT2 = 64 - imm };
     __m512i zero = _mm512_setzero_si512();
-    __m512i pre = _mm512_alignr_epi32(zero, a.val, SHIFT2 / 4);
+    __m512i pre = _mm512_alignr_epi32(a.val, zero, SHIFT2 / 4);
     if (SHIFT2 % 4)
-        return v_int8x64(_mm512_or_si512(_mm512_srli_epi32(pre, SHIFT2 % 4), _mm512_slli_epi32(_mm512_alignr_epi32(zero, a.val, SHIFT2 / 4 + 1), 4 - SHIFT2 % 4)));
+        return v_int8x64(_mm512_or_si512(_mm512_srli_epi32(pre, (SHIFT2 % 4)*8), _mm512_slli_epi32(_mm512_alignr_epi32(a.val, zero, SHIFT2 / 4 + 1), (4 - SHIFT2 % 4)*8)));
     else
         return v_int8x64(pre);
 #endif
@@ -981,7 +981,7 @@ inline v_int8x64 v_rotate_right(const v_int8x64& a)
     __m512i zero = _mm512_setzero_si512();
     __m512i pre = _mm512_alignr_epi32(zero, a.val, imm / 4);
     if (imm % 4)
-        return v_int8x64(_mm512_or_si512(_mm512_srli_epi32(pre, imm % 4), _mm512_slli_epi32(_mm512_alignr_epi32(zero, a.val, imm / 4 + 1), 4 - imm % 4)));
+        return v_int8x64(_mm512_or_si512(_mm512_srli_epi32(pre, (imm % 4)*8), _mm512_slli_epi32(_mm512_alignr_epi32(zero, a.val, imm / 4 + 1), (4 - imm % 4)*8)));
     else
         return v_int8x64(pre);
 #endif

--- a/modules/core/include/opencv2/core/hal/intrin_avx512.hpp
+++ b/modules/core/include/opencv2/core/hal/intrin_avx512.hpp
@@ -10,6 +10,7 @@
 #define CV_SIMD512_FP16 0  // no native operations with FP16 type. Only load/store from float32x8 are available (if CV_FP16 == 1)
 
 #define CV_USE_VBMIPERMUTE 0
+#define CV_USE_ERRECIP 0
 
 #define _v512_set_epi64(a7, a6, a5, a4, a3, a2, a1, a0) _mm512_set_epi64((a7),(a6),(a5),(a4),(a3),(a2),(a1),(a0))
 #define _v512_set_epi32(a15, a14, a13, a12, a11, a10,  a9,  a8,  a7,  a6,  a5,  a4,  a3,  a2,  a1,  a0) \
@@ -1166,16 +1167,26 @@ inline v_int32x16 v_muladd(const v_int32x16& a, const v_int32x16& b, const v_int
 
 inline v_float32x16 v_invsqrt(const v_float32x16& x)
 {
-//    v_float32x16 half = x * v512_setall_f32(0.5);
-//    v_float32x16 t  = v_float32x16(_mm512_rsqrt14_ps(x.val));
-//    t *= v512_setall_f32(1.5) - ((t * t) * half);
-//    return t;
+#if CV_USE_ERRECIP
     return v_float32x16(_mm512_rsqrt28_ps(x.val));
+#else
+    v_float32x16 half = x * v512_setall_f32(0.5);
+    v_float32x16 t  = v_float32x16(_mm512_rsqrt14_ps(x.val));
+    t *= v512_setall_f32(1.5) - ((t * t) * half);
+    return t;
+#endif
 }
 
 inline v_float64x8 v_invsqrt(const v_float64x8& x)
 {
+#if CV_USE_ERRECIP
     return v_float64x8(_mm512_rsqrt28_pd(x.val));
+#else
+    v_float64x8 half = x * v512_setall_f64(0.5);
+    v_float64x8 t = v_float64x8(_mm512_rsqrt14_pd(x.val));
+    t *= v512_setall_f64(1.5) - ((t * t) * half);
+    return t;
+#endif
 }
 
 /** Absolute values **/

--- a/modules/core/include/opencv2/core/hal/intrin_avx512.hpp
+++ b/modules/core/include/opencv2/core/hal/intrin_avx512.hpp
@@ -2656,15 +2656,6 @@ inline bool v_check_any(const v_uint32x16& a) { return v_check_any(v_reinterpret
 
 inline void v512_cleanup() { _mm256_zeroall(); }
 
-//! @name Check SIMD256 support
-//! @{
-//! @brief Check CPU capability of SIMD operation
-static inline bool hasSIMD512()
-{
-    return (CV_CPU_HAS_SUPPORT_AVX512_SKX) ? true : false;
-}
-//! @}
-
 CV_CPU_OPTIMIZATION_HAL_NAMESPACE_END
 
 //! @endcond

--- a/modules/core/include/opencv2/core/hal/intrin_avx512.hpp
+++ b/modules/core/include/opencv2/core/hal/intrin_avx512.hpp
@@ -1,0 +1,2782 @@
+// This file is part of OpenCV project.
+// It is subject to the license terms in the LICENSE file found in the top-level directory
+// of this distribution and at http://opencv.org/license.html
+
+#ifndef OPENCV_HAL_INTRIN_AVX512_HPP
+#define OPENCV_HAL_INTRIN_AVX512_HPP
+
+#define CV_SIMD512 1
+#define CV_SIMD512_64F 1
+#define CV_SIMD512_FP16 0  // no native operations with FP16 type. Only load/store from float32x8 are available (if CV_FP16 == 1)
+
+namespace cv
+{
+
+//! @cond IGNORED
+
+CV_CPU_OPTIMIZATION_HAL_NAMESPACE_BEGIN
+
+///////// Utils ////////////
+
+inline __m512i _v512_combine(const __m256i& lo, const __m256i& hi)
+{ return _mm512_inserti32x8(_mm512_castsi256_si512(lo), hi, 1); }
+
+inline __m512 _v512_combine(const __m256& lo, const __m256& hi)
+{ return _mm512_insertf32x8(_mm512_castps256_ps512(lo), hi, 1); }
+
+inline __m512d _v512_combine(const __m256d& lo, const __m256d& hi)
+{ return _mm512_insertf64x4(_mm512_castpd256_pd512(lo), hi, 1); }
+
+inline int _v_cvtsi512_si32(const __m512i& a)
+{ return _mm_cvtsi128_si32(_mm512_castsi512_si128(a)); }
+
+inline __m512i _v512_shuffle_odd_64(const __m512i& v)
+{ return _mm512_permutex_epi64(v, _MM_SHUFFLE(3, 1, 2, 0)); }
+
+inline __m512d _v512_shuffle_odd_64(const __m512d& v)
+{ return _mm512_permutex_pd(v, _MM_SHUFFLE(3, 1, 2, 0)); }
+
+template<int imm>
+inline __m512i _v512_permute2x128(const __m512i& a, const __m512i& b)
+{ return _mm256_permute2x128_si256(a, b, imm); }
+
+template<int imm>
+inline __m512 _v512_permute2x128(const __m512& a, const __m512& b)
+{ return _mm256_permute2f128_ps(a, b, imm); }
+
+template<int imm>
+inline __m512d _v512_permute2x128(const __m512d& a, const __m512d& b)
+{ return _mm256_permute2f128_pd(a, b, imm); }
+
+template<int imm, typename _Tpvec>
+inline _Tpvec v512_permute2x128(const _Tpvec& a, const _Tpvec& b)
+{ return _Tpvec(_v512_permute2x128<imm>(a.val, b.val)); }
+
+template<int imm>
+inline __m512i _v512_permute4x64(const __m512i& a)
+{ return _mm256_permute4x64_epi64(a, imm); }
+
+template<int imm>
+inline __m512d _v512_permute4x64(const __m512d& a)
+{ return _mm256_permute4x64_pd(a, imm); }
+
+template<int imm, typename _Tpvec>
+inline _Tpvec v512_permute4x64(const _Tpvec& a)
+{ return _Tpvec(_v512_permute4x64<imm>(a.val)); }
+
+inline __m256i _v512_extract_high(const __m512i& v)
+{ return _mm256_extracti128_si256(v, 1); }
+
+inline __m256  _v512_extract_high(const __m512& v)
+{ return _mm256_extractf128_ps(v, 1); }
+
+inline __m256d _v512_extract_high(const __m512d& v)
+{ return _mm256_extractf128_pd(v, 1); }
+
+inline __m256i _v512_extract_low(const __m512i& v)
+{ return _mm256_castsi256_si128(v); }
+
+inline __m256  _v512_extract_low(const __m512& v)
+{ return _mm256_castps256_ps128(v); }
+
+inline __m256d _v512_extract_low(const __m512d& v)
+{ return _mm256_castpd256_pd128(v); }
+
+inline __m512i _v512_packs_epu32(const __m512i& a, const __m512i& b)
+{
+    const __m512i m = _mm256_set1_epi32(65535);
+    __m512i am = _mm256_min_epu32(a, m);
+    __m512i bm = _mm256_min_epu32(b, m);
+    return _mm256_packus_epi32(am, bm);
+}
+
+///////// Types ////////////
+
+struct v_uint8x64
+{
+    typedef uchar lane_type;
+    enum { nlanes = 64 };
+    __m512i val;
+
+    explicit v_uint8x64(__m512i v) : val(v) {}
+    v_uint8x64(uchar v0,  uchar v1,  uchar v2,  uchar v3,
+               uchar v4,  uchar v5,  uchar v6,  uchar v7,
+               uchar v8,  uchar v9,  uchar v10, uchar v11,
+               uchar v12, uchar v13, uchar v14, uchar v15,
+               uchar v16, uchar v17, uchar v18, uchar v19,
+               uchar v20, uchar v21, uchar v22, uchar v23,
+               uchar v24, uchar v25, uchar v26, uchar v27,
+               uchar v28, uchar v29, uchar v30, uchar v31,
+               uchar v32, uchar v33, uchar v34, uchar v35,
+               uchar v36, uchar v37, uchar v38, uchar v39,
+               uchar v40, uchar v41, uchar v42, uchar v43,
+               uchar v44, uchar v45, uchar v46, uchar v47,
+               uchar v48, uchar v49, uchar v50, uchar v51,
+               uchar v52, uchar v53, uchar v54, uchar v55,
+               uchar v56, uchar v57, uchar v58, uchar v59,
+               uchar v60, uchar v61, uchar v62, uchar v63)
+    {
+        val = _mm512_setr_epi8((char)v0,  (char)v1,  (char)v2,  (char)v3,  (char)v4,  (char)v5,  (char)v6 , (char)v7,
+                               (char)v8,  (char)v9,  (char)v10, (char)v11, (char)v12, (char)v13, (char)v14, (char)v15,
+                               (char)v16, (char)v17, (char)v18, (char)v19, (char)v20, (char)v21, (char)v22, (char)v23,
+                               (char)v24, (char)v25, (char)v26, (char)v27, (char)v28, (char)v29, (char)v30, (char)v31,
+                               (char)v32, (char)v33, (char)v34, (char)v35, (char)v36, (char)v37, (char)v38, (char)v39,
+                               (char)v40, (char)v41, (char)v42, (char)v43, (char)v44, (char)v45, (char)v46, (char)v47,
+                               (char)v48, (char)v49, (char)v50, (char)v51, (char)v52, (char)v53, (char)v54, (char)v55,
+                               (char)v56, (char)v57, (char)v58, (char)v59, (char)v60, (char)v61, (char)v62, (char)v63);
+    }
+    v_uint8x64() : val(_mm512_setzero_si512()) {}
+    uchar get0() const { return (uchar)_v_cvtsi512_si32(val); }
+};
+
+struct v_int8x32
+{
+    typedef schar lane_type;
+    enum { nlanes = 32 };
+    __m512i val;
+
+    explicit v_int8x32(__m512i v) : val(v) {}
+    v_int8x32(schar v0,  schar v1,  schar v2,  schar v3,
+              schar v4,  schar v5,  schar v6,  schar v7,
+              schar v8,  schar v9,  schar v10, schar v11,
+              schar v12, schar v13, schar v14, schar v15,
+              schar v16, schar v17, schar v18, schar v19,
+              schar v20, schar v21, schar v22, schar v23,
+              schar v24, schar v25, schar v26, schar v27,
+              schar v28, schar v29, schar v30, schar v31)
+    {
+        val = _mm256_setr_epi8(v0, v1, v2, v3, v4, v5, v6, v7, v8, v9,
+            v10, v11, v12, v13, v14, v15, v16, v17, v18, v19, v20,
+            v21, v22, v23, v24, v25, v26, v27, v28, v29, v30, v31);
+    }
+    v_int8x32() : val(_mm256_setzero_si256()) {}
+    schar get0() const { return (schar)_v_cvtsi256_si32(val); }
+};
+
+struct v_uint16x16
+{
+    typedef ushort lane_type;
+    enum { nlanes = 16 };
+    __m512i val;
+
+    explicit v_uint16x16(__m512i v) : val(v) {}
+    v_uint16x16(ushort v0,  ushort v1,  ushort v2,  ushort v3,
+                ushort v4,  ushort v5,  ushort v6,  ushort v7,
+                ushort v8,  ushort v9,  ushort v10, ushort v11,
+                ushort v12, ushort v13, ushort v14, ushort v15)
+    {
+        val = _mm256_setr_epi16((short)v0, (short)v1, (short)v2, (short)v3,
+            (short)v4,  (short)v5,  (short)v6,  (short)v7,  (short)v8,  (short)v9,
+            (short)v10, (short)v11, (short)v12, (short)v13, (short)v14, (short)v15);
+    }
+    v_uint16x16() : val(_mm256_setzero_si256()) {}
+    ushort get0() const { return (ushort)_v_cvtsi256_si32(val); }
+};
+
+struct v_int16x16
+{
+    typedef short lane_type;
+    enum { nlanes = 16 };
+    __m512i val;
+
+    explicit v_int16x16(__m512i v) : val(v) {}
+    v_int16x16(short v0,  short v1,  short v2,  short v3,
+               short v4,  short v5,  short v6,  short v7,
+               short v8,  short v9,  short v10, short v11,
+               short v12, short v13, short v14, short v15)
+    {
+        val = _mm256_setr_epi16(v0, v1, v2, v3, v4, v5, v6, v7,
+            v8, v9, v10, v11, v12, v13, v14, v15);
+    }
+    v_int16x16() : val(_mm256_setzero_si256()) {}
+    short get0() const { return (short)_v_cvtsi256_si32(val); }
+};
+
+struct v_uint32x8
+{
+    typedef unsigned lane_type;
+    enum { nlanes = 8 };
+    __m512i val;
+
+    explicit v_uint32x8(__m512i v) : val(v) {}
+    v_uint32x8(unsigned v0, unsigned v1, unsigned v2, unsigned v3,
+               unsigned v4, unsigned v5, unsigned v6, unsigned v7)
+    {
+        val = _mm256_setr_epi32((unsigned)v0, (unsigned)v1, (unsigned)v2,
+            (unsigned)v3, (unsigned)v4, (unsigned)v5, (unsigned)v6, (unsigned)v7);
+    }
+    v_uint32x8() : val(_mm256_setzero_si256()) {}
+    unsigned get0() const { return (unsigned)_v_cvtsi256_si32(val); }
+};
+
+struct v_int32x8
+{
+    typedef int lane_type;
+    enum { nlanes = 8 };
+    __m512i val;
+
+    explicit v_int32x8(__m512i v) : val(v) {}
+    v_int32x8(int v0, int v1, int v2, int v3,
+              int v4, int v5, int v6, int v7)
+    {
+        val = _mm256_setr_epi32(v0, v1, v2, v3, v4, v5, v6, v7);
+    }
+    v_int32x8() : val(_mm256_setzero_si256()) {}
+    int get0() const { return _v_cvtsi256_si32(val); }
+};
+
+struct v_float32x8
+{
+    typedef float lane_type;
+    enum { nlanes = 8 };
+    __m512 val;
+
+    explicit v_float32x8(__m512 v) : val(v) {}
+    v_float32x8(float v0, float v1, float v2, float v3,
+                float v4, float v5, float v6, float v7)
+    {
+        val = _mm256_setr_ps(v0, v1, v2, v3, v4, v5, v6, v7);
+    }
+    v_float32x8() : val(_mm256_setzero_ps()) {}
+    float get0() const { return _mm_cvtss_f32(_mm256_castps256_ps128(val)); }
+};
+
+struct v_uint64x4
+{
+    typedef uint64 lane_type;
+    enum { nlanes = 4 };
+    __m512i val;
+
+    explicit v_uint64x4(__m512i v) : val(v) {}
+    v_uint64x4(uint64 v0, uint64 v1, uint64 v2, uint64 v3)
+    { val = _mm256_setr_epi64x((int64)v0, (int64)v1, (int64)v2, (int64)v3); }
+    v_uint64x4() : val(_mm256_setzero_si256()) {}
+    uint64 get0() const
+    {
+    #if defined __x86_64__ || defined _M_X64
+        return (uint64)_mm_cvtsi128_si64(_mm256_castsi256_si128(val));
+    #else
+        int a = _mm_cvtsi128_si32(_mm256_castsi256_si128(val));
+        int b = _mm_cvtsi128_si32(_mm256_castsi256_si128(_mm256_srli_epi64(val, 32)));
+        return (unsigned)a | ((uint64)(unsigned)b << 32);
+    #endif
+    }
+};
+
+struct v_int64x4
+{
+    typedef int64 lane_type;
+    enum { nlanes = 4 };
+    __m512i val;
+
+    explicit v_int64x4(__m512i v) : val(v) {}
+    v_int64x4(int64 v0, int64 v1, int64 v2, int64 v3)
+    { val = _mm256_setr_epi64x(v0, v1, v2, v3); }
+    v_int64x4() : val(_mm256_setzero_si256()) {}
+
+    int64 get0() const
+    {
+    #if defined __x86_64__ || defined _M_X64
+        return (int64)_mm_cvtsi128_si64(_mm256_castsi256_si128(val));
+    #else
+        int a = _mm_cvtsi128_si32(_mm256_castsi256_si128(val));
+        int b = _mm_cvtsi128_si32(_mm256_castsi256_si128(_mm256_srli_epi64(val, 32)));
+        return (int64)((unsigned)a | ((uint64)(unsigned)b << 32));
+    #endif
+    }
+};
+
+struct v_float64x4
+{
+    typedef double lane_type;
+    enum { nlanes = 4 };
+    __m512d val;
+
+    explicit v_float64x4(__m512d v) : val(v) {}
+    v_float64x4(double v0, double v1, double v2, double v3)
+    { val = _mm256_setr_pd(v0, v1, v2, v3); }
+    v_float64x4() : val(_mm256_setzero_pd()) {}
+    double get0() const { return _mm_cvtsd_f64(_mm256_castpd256_pd128(val)); }
+};
+
+//////////////// Load and store operations ///////////////
+
+#define OPENCV_HAL_IMPL_AVX_LOADSTORE(_Tpvec, _Tp)                    \
+    inline _Tpvec v512_load(const _Tp* ptr)                           \
+    { return _Tpvec(_mm256_loadu_si256((const __m512i*)ptr)); }       \
+    inline _Tpvec v512_load_aligned(const _Tp* ptr)                   \
+    { return _Tpvec(_mm256_load_si256((const __m512i*)ptr)); }        \
+    inline _Tpvec v512_load_low(const _Tp* ptr)                       \
+    {                                                                 \
+        __m256i v128 = _mm_loadu_si128((const __m256i*)ptr);          \
+        return _Tpvec(_mm256_castsi128_si256(v128));                  \
+    }                                                                 \
+    inline _Tpvec v512_load_halves(const _Tp* ptr0, const _Tp* ptr1)  \
+    {                                                                 \
+        __m256i vlo = _mm_loadu_si128((const __m256i*)ptr0);          \
+        __m256i vhi = _mm_loadu_si128((const __m256i*)ptr1);          \
+        return _Tpvec(_v512_combine(vlo, vhi));                       \
+    }                                                                 \
+    inline void v_store(_Tp* ptr, const _Tpvec& a)                    \
+    { _mm256_storeu_si256((__m512i*)ptr, a.val); }                    \
+    inline void v_store_aligned(_Tp* ptr, const _Tpvec& a)            \
+    { _mm256_store_si256((__m512i*)ptr, a.val); }                     \
+    inline void v_store_aligned_nocache(_Tp* ptr, const _Tpvec& a)    \
+    { _mm256_stream_si256((__m512i*)ptr, a.val); }                    \
+    inline void v_store(_Tp* ptr, const _Tpvec& a, hal::StoreMode mode) \
+    { \
+        if( mode == hal::STORE_UNALIGNED ) \
+            _mm256_storeu_si256((__m512i*)ptr, a.val); \
+        else if( mode == hal::STORE_ALIGNED_NOCACHE )  \
+            _mm256_stream_si256((__m512i*)ptr, a.val); \
+        else \
+            _mm256_store_si256((__m512i*)ptr, a.val); \
+    } \
+    inline void v_store_low(_Tp* ptr, const _Tpvec& a)                \
+    { _mm_storeu_si128((__m256i*)ptr, _v512_extract_low(a.val)); }    \
+    inline void v_store_high(_Tp* ptr, const _Tpvec& a)               \
+    { _mm_storeu_si128((__m256i*)ptr, _v512_extract_high(a.val)); }
+
+OPENCV_HAL_IMPL_AVX_LOADSTORE(v_uint8x32,  uchar)
+OPENCV_HAL_IMPL_AVX_LOADSTORE(v_int8x32,   schar)
+OPENCV_HAL_IMPL_AVX_LOADSTORE(v_uint16x16, ushort)
+OPENCV_HAL_IMPL_AVX_LOADSTORE(v_int16x16,  short)
+OPENCV_HAL_IMPL_AVX_LOADSTORE(v_uint32x8,  unsigned)
+OPENCV_HAL_IMPL_AVX_LOADSTORE(v_int32x8,   int)
+OPENCV_HAL_IMPL_AVX_LOADSTORE(v_uint64x4,  uint64)
+OPENCV_HAL_IMPL_AVX_LOADSTORE(v_int64x4,   int64)
+
+#define OPENCV_HAL_IMPL_AVX_LOADSTORE_FLT(_Tpvec, _Tp, suffix, halfreg)   \
+    inline _Tpvec v512_load(const _Tp* ptr)                               \
+    { return _Tpvec(_mm256_loadu_##suffix(ptr)); }                        \
+    inline _Tpvec v512_load_aligned(const _Tp* ptr)                       \
+    { return _Tpvec(_mm256_load_##suffix(ptr)); }                         \
+    inline _Tpvec v512_load_low(const _Tp* ptr)                           \
+    {                                                                     \
+        return _Tpvec(_mm256_cast##suffix##128_##suffix##256              \
+                     (_mm_loadu_##suffix(ptr)));                          \
+    }                                                                     \
+    inline _Tpvec v512_load_halves(const _Tp* ptr0, const _Tp* ptr1)      \
+    {                                                                     \
+        halfreg vlo = _mm_loadu_##suffix(ptr0);                           \
+        halfreg vhi = _mm_loadu_##suffix(ptr1);                           \
+        return _Tpvec(_v512_combine(vlo, vhi));                           \
+    }                                                                     \
+    inline void v_store(_Tp* ptr, const _Tpvec& a)                        \
+    { _mm256_storeu_##suffix(ptr, a.val); }                               \
+    inline void v_store_aligned(_Tp* ptr, const _Tpvec& a)                \
+    { _mm256_store_##suffix(ptr, a.val); }                                \
+    inline void v_store_aligned_nocache(_Tp* ptr, const _Tpvec& a)        \
+    { _mm256_stream_##suffix(ptr, a.val); }                               \
+    inline void v_store(_Tp* ptr, const _Tpvec& a, hal::StoreMode mode) \
+    { \
+        if( mode == hal::STORE_UNALIGNED ) \
+            _mm256_storeu_##suffix(ptr, a.val); \
+        else if( mode == hal::STORE_ALIGNED_NOCACHE )  \
+            _mm256_stream_##suffix(ptr, a.val); \
+        else \
+            _mm256_store_##suffix(ptr, a.val); \
+    } \
+    inline void v_store_low(_Tp* ptr, const _Tpvec& a)                    \
+    { _mm_storeu_##suffix(ptr, _v512_extract_low(a.val)); }               \
+    inline void v_store_high(_Tp* ptr, const _Tpvec& a)                   \
+    { _mm_storeu_##suffix(ptr, _v512_extract_high(a.val)); }
+
+OPENCV_HAL_IMPL_AVX_LOADSTORE_FLT(v_float32x8, float,  ps, __m256)
+OPENCV_HAL_IMPL_AVX_LOADSTORE_FLT(v_float64x4, double, pd, __m256d)
+
+#define OPENCV_HAL_IMPL_AVX_CAST(_Tpvec, _Tpvecf, suffix, cast) \
+    inline _Tpvec v_reinterpret_as_##suffix(const _Tpvecf& a)   \
+    { return _Tpvec(cast(a.val)); }
+
+#define OPENCV_HAL_IMPL_AVX_INIT(_Tpvec, _Tp, suffix, ssuffix, ctype_s)          \
+    inline _Tpvec v512_setzero_##suffix()                                        \
+    { return _Tpvec(_mm256_setzero_si256()); }                                   \
+    inline _Tpvec v512_setall_##suffix(_Tp v)                                    \
+    { return _Tpvec(_mm256_set1_##ssuffix((ctype_s)v)); }                        \
+    OPENCV_HAL_IMPL_AVX_CAST(_Tpvec, v_uint8x32,  suffix, OPENCV_HAL_NOP)        \
+    OPENCV_HAL_IMPL_AVX_CAST(_Tpvec, v_int8x32,   suffix, OPENCV_HAL_NOP)        \
+    OPENCV_HAL_IMPL_AVX_CAST(_Tpvec, v_uint16x16, suffix, OPENCV_HAL_NOP)        \
+    OPENCV_HAL_IMPL_AVX_CAST(_Tpvec, v_int16x16,  suffix, OPENCV_HAL_NOP)        \
+    OPENCV_HAL_IMPL_AVX_CAST(_Tpvec, v_uint32x8,  suffix, OPENCV_HAL_NOP)        \
+    OPENCV_HAL_IMPL_AVX_CAST(_Tpvec, v_int32x8,   suffix, OPENCV_HAL_NOP)        \
+    OPENCV_HAL_IMPL_AVX_CAST(_Tpvec, v_uint64x4,  suffix, OPENCV_HAL_NOP)        \
+    OPENCV_HAL_IMPL_AVX_CAST(_Tpvec, v_int64x4,   suffix, OPENCV_HAL_NOP)        \
+    OPENCV_HAL_IMPL_AVX_CAST(_Tpvec, v_float32x8, suffix, _mm256_castps_si256)   \
+    OPENCV_HAL_IMPL_AVX_CAST(_Tpvec, v_float64x4, suffix, _mm256_castpd_si256)
+
+OPENCV_HAL_IMPL_AVX_INIT(v_uint8x32,  uchar,    u8,  epi8,   char)
+OPENCV_HAL_IMPL_AVX_INIT(v_int8x32,   schar,    s8,  epi8,   char)
+OPENCV_HAL_IMPL_AVX_INIT(v_uint16x16, ushort,   u16, epi16,  short)
+OPENCV_HAL_IMPL_AVX_INIT(v_int16x16,  short,    s16, epi16,  short)
+OPENCV_HAL_IMPL_AVX_INIT(v_uint32x8,  unsigned, u32, epi32,  int)
+OPENCV_HAL_IMPL_AVX_INIT(v_int32x8,   int,      s32, epi32,  int)
+OPENCV_HAL_IMPL_AVX_INIT(v_uint64x4,  uint64,   u64, epi64x, int64)
+OPENCV_HAL_IMPL_AVX_INIT(v_int64x4,   int64,    s64, epi64x, int64)
+
+#define OPENCV_HAL_IMPL_AVX_INIT_FLT(_Tpvec, _Tp, suffix, zsuffix, cast) \
+    inline _Tpvec v512_setzero_##suffix()                                \
+    { return _Tpvec(_mm256_setzero_##zsuffix()); }                       \
+    inline _Tpvec v512_setall_##suffix(_Tp v)                            \
+    { return _Tpvec(_mm256_set1_##zsuffix(v)); }                         \
+    OPENCV_HAL_IMPL_AVX_CAST(_Tpvec, v_uint8x32,  suffix, cast)          \
+    OPENCV_HAL_IMPL_AVX_CAST(_Tpvec, v_int8x32,   suffix, cast)          \
+    OPENCV_HAL_IMPL_AVX_CAST(_Tpvec, v_uint16x16, suffix, cast)          \
+    OPENCV_HAL_IMPL_AVX_CAST(_Tpvec, v_int16x16,  suffix, cast)          \
+    OPENCV_HAL_IMPL_AVX_CAST(_Tpvec, v_uint32x8,  suffix, cast)          \
+    OPENCV_HAL_IMPL_AVX_CAST(_Tpvec, v_int32x8,   suffix, cast)          \
+    OPENCV_HAL_IMPL_AVX_CAST(_Tpvec, v_uint64x4,  suffix, cast)          \
+    OPENCV_HAL_IMPL_AVX_CAST(_Tpvec, v_int64x4,   suffix, cast)
+
+OPENCV_HAL_IMPL_AVX_INIT_FLT(v_float32x8, float,  f32, ps, _mm256_castsi256_ps)
+OPENCV_HAL_IMPL_AVX_INIT_FLT(v_float64x4, double, f64, pd, _mm256_castsi256_pd)
+
+inline v_float32x8 v_reinterpret_as_f32(const v_float32x8& a)
+{ return a; }
+inline v_float32x8 v_reinterpret_as_f32(const v_float64x4& a)
+{ return v_float32x8(_mm256_castpd_ps(a.val)); }
+
+inline v_float64x4 v_reinterpret_as_f64(const v_float64x4& a)
+{ return a; }
+inline v_float64x4 v_reinterpret_as_f64(const v_float32x8& a)
+{ return v_float64x4(_mm256_castps_pd(a.val)); }
+
+#if CV_FP16
+inline v_float32x8 v512_load_fp16_f32(const short* ptr)
+{
+    return v_float32x8(_mm256_cvtph_ps(_mm_loadu_si128((const __m256i*)ptr)));
+}
+
+inline void v_store_fp16(short* ptr, const v_float32x8& a)
+{
+    __m256i fp16_value = _mm256_cvtps_ph(a.val, 0);
+    _mm_store_si128((__m256i*)ptr, fp16_value);
+}
+#endif
+
+/* Recombine */
+/*#define OPENCV_HAL_IMPL_AVX_COMBINE(_Tpvec, perm)                    \
+    inline _Tpvec v_combine_low(const _Tpvec& a, const _Tpvec& b)    \
+    { return _Tpvec(perm(a.val, b.val, 0x20)); }                     \
+    inline _Tpvec v_combine_high(const _Tpvec& a, const _Tpvec& b)   \
+    { return _Tpvec(perm(a.val, b.val, 0x31)); }                     \
+    inline void v_recombine(const _Tpvec& a, const _Tpvec& b,        \
+                             _Tpvec& c, _Tpvec& d)                   \
+    { c = v_combine_low(a, b); d = v_combine_high(a, b); }
+
+#define OPENCV_HAL_IMPL_AVX_UNPACKS(_Tpvec, suffix)                  \
+    OPENCV_HAL_IMPL_AVX_COMBINE(_Tpvec, _mm256_permute2x128_si256)   \
+    inline void v_zip(const _Tpvec& a0, const _Tpvec& a1,            \
+                             _Tpvec& b0, _Tpvec& b1)                 \
+    {                                                                \
+        __m512i v0 = _v512_shuffle_odd_64(a0.val);                   \
+        __m512i v1 = _v512_shuffle_odd_64(a1.val);                   \
+        b0.val = _mm256_unpacklo_##suffix(v0, v1);                   \
+        b1.val = _mm256_unpackhi_##suffix(v0, v1);                   \
+    }
+
+OPENCV_HAL_IMPL_AVX_UNPACKS(v_uint8x32,  epi8)
+OPENCV_HAL_IMPL_AVX_UNPACKS(v_int8x32,   epi8)
+OPENCV_HAL_IMPL_AVX_UNPACKS(v_uint16x16, epi16)
+OPENCV_HAL_IMPL_AVX_UNPACKS(v_int16x16,  epi16)
+OPENCV_HAL_IMPL_AVX_UNPACKS(v_uint32x8,  epi32)
+OPENCV_HAL_IMPL_AVX_UNPACKS(v_int32x8,   epi32)
+OPENCV_HAL_IMPL_AVX_UNPACKS(v_uint64x4,  epi64)
+OPENCV_HAL_IMPL_AVX_UNPACKS(v_int64x4,   epi64)
+OPENCV_HAL_IMPL_AVX_COMBINE(v_float32x8, _mm256_permute2f128_ps)
+OPENCV_HAL_IMPL_AVX_COMBINE(v_float64x4, _mm256_permute2f128_pd)
+
+inline void v_zip(const v_float32x8& a0, const v_float32x8& a1, v_float32x8& b0, v_float32x8& b1)
+{
+    __m512 v0 = _mm256_unpacklo_ps(a0.val, a1.val);
+    __m512 v1 = _mm256_unpackhi_ps(a0.val, a1.val);
+    v_recombine(v_float32x8(v0), v_float32x8(v1), b0, b1);
+}
+
+inline void v_zip(const v_float64x4& a0, const v_float64x4& a1, v_float64x4& b0, v_float64x4& b1)
+{
+    __m512d v0 = _v_shuffle_odd_64(a0.val);
+    __m512d v1 = _v_shuffle_odd_64(a1.val);
+    b0.val = _mm256_unpacklo_pd(v0, v1);
+    b1.val = _mm256_unpackhi_pd(v0, v1);
+}*/
+
+//////////////// Variant Value reordering ///////////////
+
+// unpacks
+#define OPENCV_HAL_IMPL_AVX_UNPACK(_Tpvec, suffix)                 \
+    inline _Tpvec v512_unpacklo(const _Tpvec& a, const _Tpvec& b)  \
+    { return _Tpvec(_mm256_unpacklo_##suffix(a.val, b.val)); }     \
+    inline _Tpvec v512_unpackhi(const _Tpvec& a, const _Tpvec& b)  \
+    { return _Tpvec(_mm256_unpackhi_##suffix(a.val, b.val)); }
+
+OPENCV_HAL_IMPL_AVX_UNPACK(v_uint8x32,  epi8)
+OPENCV_HAL_IMPL_AVX_UNPACK(v_int8x32,   epi8)
+OPENCV_HAL_IMPL_AVX_UNPACK(v_uint16x16, epi16)
+OPENCV_HAL_IMPL_AVX_UNPACK(v_int16x16,  epi16)
+OPENCV_HAL_IMPL_AVX_UNPACK(v_uint32x8,  epi32)
+OPENCV_HAL_IMPL_AVX_UNPACK(v_int32x8,   epi32)
+OPENCV_HAL_IMPL_AVX_UNPACK(v_uint64x4,  epi64)
+OPENCV_HAL_IMPL_AVX_UNPACK(v_int64x4,   epi64)
+OPENCV_HAL_IMPL_AVX_UNPACK(v_float32x8, ps)
+OPENCV_HAL_IMPL_AVX_UNPACK(v_float64x4, pd)
+
+// blend
+#define OPENCV_HAL_IMPL_AVX_BLEND(_Tpvec, suffix)               \
+    template<int m>                                             \
+    inline _Tpvec v512_blend(const _Tpvec& a, const _Tpvec& b)  \
+    { return _Tpvec(_mm256_blend_##suffix(a.val, b.val, m)); }
+
+OPENCV_HAL_IMPL_AVX_BLEND(v_uint16x16, epi16)
+OPENCV_HAL_IMPL_AVX_BLEND(v_int16x16,  epi16)
+OPENCV_HAL_IMPL_AVX_BLEND(v_uint32x8,  epi32)
+OPENCV_HAL_IMPL_AVX_BLEND(v_int32x8,   epi32)
+OPENCV_HAL_IMPL_AVX_BLEND(v_float32x8, ps)
+OPENCV_HAL_IMPL_AVX_BLEND(v_float64x4, pd)
+
+template<int m>
+inline v_uint64x4 v512_blend(const v_uint64x4& a, const v_uint64x4& b)
+{
+    enum {M0 = m};
+    enum {M1 = (M0 | (M0 << 2)) & 0x33};
+    enum {M2 = (M1 | (M1 << 1)) & 0x55};
+    enum {MM =  M2 | (M2 << 1)};
+    return v_uint64x4(_mm256_blend_epi32(a.val, b.val, MM));
+}
+template<int m>
+inline v_int64x4 v512_blend(const v_int64x4& a, const v_int64x4& b)
+{ return v_int64x4(v512_blend<m>(v_uint64x4(a.val), v_uint64x4(b.val)).val); }
+
+// shuffle
+// todo: emluate 64bit
+#define OPENCV_HAL_IMPL_AVX_SHUFFLE(_Tpvec, intrin)  \
+    template<int m>                                  \
+    inline _Tpvec v512_shuffle(const _Tpvec& a)      \
+    { return _Tpvec(_mm256_##intrin(a.val, m)); }
+
+OPENCV_HAL_IMPL_AVX_SHUFFLE(v_uint32x8,  shuffle_epi32)
+OPENCV_HAL_IMPL_AVX_SHUFFLE(v_int32x8,   shuffle_epi32)
+OPENCV_HAL_IMPL_AVX_SHUFFLE(v_float32x8, permute_ps)
+OPENCV_HAL_IMPL_AVX_SHUFFLE(v_float64x4, permute_pd)
+
+template<typename _Tpvec>
+inline void v512_zip(const _Tpvec& a, const _Tpvec& b, _Tpvec& ab0, _Tpvec& ab1)
+{
+    ab0 = v512_unpacklo(a, b);
+    ab1 = v512_unpackhi(a, b);
+}
+
+template<typename _Tpvec>
+inline _Tpvec v512_combine_diagonal(const _Tpvec& a, const _Tpvec& b)
+{ return _Tpvec(_mm256_blend_epi32(a.val, b.val, 0xf0)); }
+
+inline v_float32x8 v512_combine_diagonal(const v_float32x8& a, const v_float32x8& b)
+{ return v512_blend<0xf0>(a, b); }
+
+inline v_float64x4 v512_combine_diagonal(const v_float64x4& a, const v_float64x4& b)
+{ return v512_blend<0xc>(a, b); }
+
+template<typename _Tpvec>
+inline _Tpvec v512_alignr_128(const _Tpvec& a, const _Tpvec& b)
+{ return v512_permute2x128<0x21>(a, b); }
+
+template<typename _Tpvec>
+inline _Tpvec v512_alignr_64(const _Tpvec& a, const _Tpvec& b)
+{ return _Tpvec(_mm256_alignr_epi8(a.val, b.val, 8)); }
+inline v_float64x4 v512_alignr_64(const v_float64x4& a, const v_float64x4& b)
+{ return v_float64x4(_mm256_shuffle_pd(b.val, a.val, _MM_SHUFFLE(0, 0, 1, 1))); }
+// todo: emulate float32
+
+template<typename _Tpvec>
+inline _Tpvec v512_swap_halves(const _Tpvec& a)
+{ return v512_permute2x128<1>(a, a); }
+
+template<typename _Tpvec>
+inline _Tpvec v512_reverse_64(const _Tpvec& a)
+{ return v512_permute4x64<_MM_SHUFFLE(0, 1, 2, 3)>(a); }
+
+// ZIP
+#define OPENCV_HAL_IMPL_AVX_ZIP(_Tpvec)                              \
+    inline _Tpvec v_combine_low(const _Tpvec& a, const _Tpvec& b)    \
+    { return v512_permute2x128<0x20>(a, b); }                        \
+    inline _Tpvec v_combine_high(const _Tpvec& a, const _Tpvec& b)   \
+    { return v512_permute2x128<0x31>(a, b); }                        \
+    inline void v_recombine(const _Tpvec& a, const _Tpvec& b,        \
+                             _Tpvec& c, _Tpvec& d)                   \
+    {                                                                \
+        _Tpvec a1b0 = v512_alignr_128(a, b);                         \
+        c = v512_combine_diagonal(a, a1b0);                          \
+        d = v512_combine_diagonal(a1b0, b);                          \
+    }                                                                \
+    inline void v_zip(const _Tpvec& a, const _Tpvec& b,              \
+                      _Tpvec& ab0, _Tpvec& ab1)                      \
+    {                                                                \
+        _Tpvec ab0ab2, ab1ab3;                                       \
+        v512_zip(a, b, ab0ab2, ab1ab3);                              \
+        v_recombine(ab0ab2, ab1ab3, ab0, ab1);                       \
+    }
+
+OPENCV_HAL_IMPL_AVX_ZIP(v_uint8x32)
+OPENCV_HAL_IMPL_AVX_ZIP(v_int8x32)
+OPENCV_HAL_IMPL_AVX_ZIP(v_uint16x16)
+OPENCV_HAL_IMPL_AVX_ZIP(v_int16x16)
+OPENCV_HAL_IMPL_AVX_ZIP(v_uint32x8)
+OPENCV_HAL_IMPL_AVX_ZIP(v_int32x8)
+OPENCV_HAL_IMPL_AVX_ZIP(v_uint64x4)
+OPENCV_HAL_IMPL_AVX_ZIP(v_int64x4)
+OPENCV_HAL_IMPL_AVX_ZIP(v_float32x8)
+OPENCV_HAL_IMPL_AVX_ZIP(v_float64x4)
+
+////////// Arithmetic, bitwise and comparison operations /////////
+
+/* Element-wise binary and unary operations */
+
+/** Arithmetics **/
+#define OPENCV_HAL_IMPL_AVX_BIN_OP(bin_op, _Tpvec, intrin)            \
+    inline _Tpvec operator bin_op (const _Tpvec& a, const _Tpvec& b)  \
+    { return _Tpvec(intrin(a.val, b.val)); }                          \
+    inline _Tpvec& operator bin_op##= (_Tpvec& a, const _Tpvec& b)    \
+    { a.val = intrin(a.val, b.val); return a; }
+
+OPENCV_HAL_IMPL_AVX_BIN_OP(+, v_uint8x32,  _mm256_adds_epu8)
+OPENCV_HAL_IMPL_AVX_BIN_OP(-, v_uint8x32,  _mm256_subs_epu8)
+OPENCV_HAL_IMPL_AVX_BIN_OP(+, v_int8x32,   _mm256_adds_epi8)
+OPENCV_HAL_IMPL_AVX_BIN_OP(-, v_int8x32,   _mm256_subs_epi8)
+OPENCV_HAL_IMPL_AVX_BIN_OP(+, v_uint16x16, _mm256_adds_epu16)
+OPENCV_HAL_IMPL_AVX_BIN_OP(-, v_uint16x16, _mm256_subs_epu16)
+OPENCV_HAL_IMPL_AVX_BIN_OP(+, v_int16x16,  _mm256_adds_epi16)
+OPENCV_HAL_IMPL_AVX_BIN_OP(-, v_int16x16,  _mm256_subs_epi16)
+OPENCV_HAL_IMPL_AVX_BIN_OP(+, v_uint32x8,  _mm256_add_epi32)
+OPENCV_HAL_IMPL_AVX_BIN_OP(-, v_uint32x8,  _mm256_sub_epi32)
+OPENCV_HAL_IMPL_AVX_BIN_OP(*, v_uint32x8,  _mm256_mullo_epi32)
+OPENCV_HAL_IMPL_AVX_BIN_OP(+, v_int32x8,   _mm256_add_epi32)
+OPENCV_HAL_IMPL_AVX_BIN_OP(-, v_int32x8,   _mm256_sub_epi32)
+OPENCV_HAL_IMPL_AVX_BIN_OP(*, v_int32x8,   _mm256_mullo_epi32)
+OPENCV_HAL_IMPL_AVX_BIN_OP(+, v_uint64x4,  _mm256_add_epi64)
+OPENCV_HAL_IMPL_AVX_BIN_OP(-, v_uint64x4,  _mm256_sub_epi64)
+OPENCV_HAL_IMPL_AVX_BIN_OP(+, v_int64x4,   _mm256_add_epi64)
+OPENCV_HAL_IMPL_AVX_BIN_OP(-, v_int64x4,   _mm256_sub_epi64)
+
+OPENCV_HAL_IMPL_AVX_BIN_OP(+, v_float32x8, _mm256_add_ps)
+OPENCV_HAL_IMPL_AVX_BIN_OP(-, v_float32x8, _mm256_sub_ps)
+OPENCV_HAL_IMPL_AVX_BIN_OP(*, v_float32x8, _mm256_mul_ps)
+OPENCV_HAL_IMPL_AVX_BIN_OP(/, v_float32x8, _mm256_div_ps)
+OPENCV_HAL_IMPL_AVX_BIN_OP(+, v_float64x4, _mm256_add_pd)
+OPENCV_HAL_IMPL_AVX_BIN_OP(-, v_float64x4, _mm256_sub_pd)
+OPENCV_HAL_IMPL_AVX_BIN_OP(*, v_float64x4, _mm256_mul_pd)
+OPENCV_HAL_IMPL_AVX_BIN_OP(/, v_float64x4, _mm256_div_pd)
+
+// saturating multiply 8-bit, 16-bit
+inline v_uint8x32 operator * (const v_uint8x32& a, const v_uint8x32& b)
+{
+    v_uint16x16 c, d;
+    v_mul_expand(a, b, c, d);
+    return v_pack(c, d);
+}
+inline v_int8x32 operator * (const v_int8x32& a, const v_int8x32& b)
+{
+    v_int16x16 c, d;
+    v_mul_expand(a, b, c, d);
+    return v_pack(c, d);
+}
+inline v_uint16x16 operator * (const v_uint16x16& a, const v_uint16x16& b)
+{
+    __m512i pl = _mm256_mullo_epi16(a.val, b.val);
+    __m512i ph = _mm256_mulhi_epu16(a.val, b.val);
+    __m512i p0 = _mm256_unpacklo_epi16(pl, ph);
+    __m512i p1 = _mm256_unpackhi_epi16(pl, ph);
+    return v_uint16x16(_v512_packs_epu32(p0, p1));
+}
+inline v_int16x16 operator * (const v_int16x16& a, const v_int16x16& b)
+{
+    __m512i pl = _mm256_mullo_epi16(a.val, b.val);
+    __m512i ph = _mm256_mulhi_epi16(a.val, b.val);
+    __m512i p0 = _mm256_unpacklo_epi16(pl, ph);
+    __m512i p1 = _mm256_unpackhi_epi16(pl, ph);
+    return v_int16x16(_mm256_packs_epi32(p0, p1));
+}
+inline v_uint8x32& operator *= (v_uint8x32& a, const v_uint8x32& b)
+{ a = a * b; return a; }
+inline v_int8x32& operator *= (v_int8x32& a, const v_int8x32& b)
+{ a = a * b; return a; }
+inline v_uint16x16& operator *= (v_uint16x16& a, const v_uint16x16& b)
+{ a = a * b; return a; }
+inline v_int16x16& operator *= (v_int16x16& a, const v_int16x16& b)
+{ a = a * b; return a; }
+
+/** Non-saturating arithmetics **/
+#define OPENCV_HAL_IMPL_AVX_BIN_FUNC(func, _Tpvec, intrin) \
+    inline _Tpvec func(const _Tpvec& a, const _Tpvec& b)   \
+    { return _Tpvec(intrin(a.val, b.val)); }
+
+OPENCV_HAL_IMPL_AVX_BIN_FUNC(v_add_wrap, v_uint8x32,  _mm256_add_epi8)
+OPENCV_HAL_IMPL_AVX_BIN_FUNC(v_add_wrap, v_int8x32,   _mm256_add_epi8)
+OPENCV_HAL_IMPL_AVX_BIN_FUNC(v_add_wrap, v_uint16x16, _mm256_add_epi16)
+OPENCV_HAL_IMPL_AVX_BIN_FUNC(v_add_wrap, v_int16x16,  _mm256_add_epi16)
+OPENCV_HAL_IMPL_AVX_BIN_FUNC(v_sub_wrap, v_uint8x32,  _mm256_sub_epi8)
+OPENCV_HAL_IMPL_AVX_BIN_FUNC(v_sub_wrap, v_int8x32,   _mm256_sub_epi8)
+OPENCV_HAL_IMPL_AVX_BIN_FUNC(v_sub_wrap, v_uint16x16, _mm256_sub_epi16)
+OPENCV_HAL_IMPL_AVX_BIN_FUNC(v_sub_wrap, v_int16x16,  _mm256_sub_epi16)
+OPENCV_HAL_IMPL_AVX_BIN_FUNC(v_mul_wrap, v_uint16x16, _mm256_mullo_epi16)
+OPENCV_HAL_IMPL_AVX_BIN_FUNC(v_mul_wrap, v_int16x16,  _mm256_mullo_epi16)
+
+inline v_uint8x32 v_mul_wrap(const v_uint8x32& a, const v_uint8x32& b)
+{
+    __m512i ad = _mm256_srai_epi16(a.val, 8);
+    __m512i bd = _mm256_srai_epi16(b.val, 8);
+    __m512i p0 = _mm256_mullo_epi16(a.val, b.val); // even
+    __m512i p1 = _mm256_slli_epi16(_mm256_mullo_epi16(ad, bd), 8); // odd
+
+    const __m512i b01 = _mm256_set1_epi32(0xFF00FF00);
+    return v_uint8x32(_mm256_blendv_epi8(p0, p1, b01));
+}
+inline v_int8x32 v_mul_wrap(const v_int8x32& a, const v_int8x32& b)
+{
+    return v_reinterpret_as_s8(v_mul_wrap(v_reinterpret_as_u8(a), v_reinterpret_as_u8(b)));
+}
+
+//  Multiply and expand
+inline void v_mul_expand(const v_uint8x32& a, const v_uint8x32& b,
+                         v_uint16x16& c, v_uint16x16& d)
+{
+    v_uint16x16 a0, a1, b0, b1;
+    v_expand(a, a0, a1);
+    v_expand(b, b0, b1);
+    c = v_mul_wrap(a0, b0);
+    d = v_mul_wrap(a1, b1);
+}
+
+inline void v_mul_expand(const v_int8x32& a, const v_int8x32& b,
+                         v_int16x16& c, v_int16x16& d)
+{
+    v_int16x16 a0, a1, b0, b1;
+    v_expand(a, a0, a1);
+    v_expand(b, b0, b1);
+    c = v_mul_wrap(a0, b0);
+    d = v_mul_wrap(a1, b1);
+}
+
+inline void v_mul_expand(const v_int16x16& a, const v_int16x16& b,
+                         v_int32x8& c, v_int32x8& d)
+{
+    v_int16x16 vhi = v_int16x16(_mm256_mulhi_epi16(a.val, b.val));
+
+    v_int16x16 v0, v1;
+    v_zip(v_mul_wrap(a, b), vhi, v0, v1);
+
+    c = v_reinterpret_as_s32(v0);
+    d = v_reinterpret_as_s32(v1);
+}
+
+inline void v_mul_expand(const v_uint16x16& a, const v_uint16x16& b,
+                         v_uint32x8& c, v_uint32x8& d)
+{
+    v_uint16x16 vhi = v_uint16x16(_mm256_mulhi_epu16(a.val, b.val));
+
+    v_uint16x16 v0, v1;
+    v_zip(v_mul_wrap(a, b), vhi, v0, v1);
+
+    c = v_reinterpret_as_u32(v0);
+    d = v_reinterpret_as_u32(v1);
+}
+
+inline void v_mul_expand(const v_uint32x8& a, const v_uint32x8& b,
+                         v_uint64x4& c, v_uint64x4& d)
+{
+    __m512i v0 = _mm256_mul_epu32(a.val, b.val);
+    __m512i v1 = _mm256_mul_epu32(_mm256_srli_epi64(a.val, 32), _mm256_srli_epi64(b.val, 32));
+    v_zip(v_uint64x4(v0), v_uint64x4(v1), c, d);
+}
+
+inline v_int16x16 v_mul_hi(const v_int16x16& a, const v_int16x16& b) { return v_int16x16(_mm256_mulhi_epi16(a.val, b.val)); }
+inline v_uint16x16 v_mul_hi(const v_uint16x16& a, const v_uint16x16& b) { return v_uint16x16(_mm256_mulhi_epu16(a.val, b.val)); }
+
+/** Bitwise shifts **/
+#define OPENCV_HAL_IMPL_AVX_SHIFT_OP(_Tpuvec, _Tpsvec, suffix, srai)  \
+    inline _Tpuvec operator << (const _Tpuvec& a, int imm)            \
+    { return _Tpuvec(_mm256_slli_##suffix(a.val, imm)); }             \
+    inline _Tpsvec operator << (const _Tpsvec& a, int imm)            \
+    { return _Tpsvec(_mm256_slli_##suffix(a.val, imm)); }             \
+    inline _Tpuvec operator >> (const _Tpuvec& a, int imm)            \
+    { return _Tpuvec(_mm256_srli_##suffix(a.val, imm)); }             \
+    inline _Tpsvec operator >> (const _Tpsvec& a, int imm)            \
+    { return _Tpsvec(srai(a.val, imm)); }                             \
+    template<int imm>                                                 \
+    inline _Tpuvec v_shl(const _Tpuvec& a)                            \
+    { return _Tpuvec(_mm256_slli_##suffix(a.val, imm)); }             \
+    template<int imm>                                                 \
+    inline _Tpsvec v_shl(const _Tpsvec& a)                            \
+    { return _Tpsvec(_mm256_slli_##suffix(a.val, imm)); }             \
+    template<int imm>                                                 \
+    inline _Tpuvec v_shr(const _Tpuvec& a)                            \
+    { return _Tpuvec(_mm256_srli_##suffix(a.val, imm)); }             \
+    template<int imm>                                                 \
+    inline _Tpsvec v_shr(const _Tpsvec& a)                            \
+    { return _Tpsvec(srai(a.val, imm)); }
+
+OPENCV_HAL_IMPL_AVX_SHIFT_OP(v_uint16x16, v_int16x16, epi16, _mm256_srai_epi16)
+OPENCV_HAL_IMPL_AVX_SHIFT_OP(v_uint32x8,  v_int32x8,  epi32, _mm256_srai_epi32)
+
+inline __m512i _mm256_srai_epi64xx(const __m512i a, int imm)
+{
+    __m512i d = _mm256_set1_epi64x((int64)1 << 63);
+    __m512i r = _mm256_srli_epi64(_mm256_add_epi64(a, d), imm);
+    return _mm256_sub_epi64(r, _mm256_srli_epi64(d, imm));
+}
+OPENCV_HAL_IMPL_AVX_SHIFT_OP(v_uint64x4,  v_int64x4,  epi64, _mm256_srai_epi64xx)
+
+
+/** Bitwise logic **/
+#define OPENCV_HAL_IMPL_AVX_LOGIC_OP(_Tpvec, suffix, not_const)  \
+    OPENCV_HAL_IMPL_AVX_BIN_OP(&, _Tpvec, _mm256_and_##suffix)   \
+    OPENCV_HAL_IMPL_AVX_BIN_OP(|, _Tpvec, _mm256_or_##suffix)    \
+    OPENCV_HAL_IMPL_AVX_BIN_OP(^, _Tpvec, _mm256_xor_##suffix)   \
+    inline _Tpvec operator ~ (const _Tpvec& a)                   \
+    { return _Tpvec(_mm256_xor_##suffix(a.val, not_const)); }
+
+OPENCV_HAL_IMPL_AVX_LOGIC_OP(v_uint8x32,   si256, _mm256_set1_epi32(-1))
+OPENCV_HAL_IMPL_AVX_LOGIC_OP(v_int8x32,    si256, _mm256_set1_epi32(-1))
+OPENCV_HAL_IMPL_AVX_LOGIC_OP(v_uint16x16,  si256, _mm256_set1_epi32(-1))
+OPENCV_HAL_IMPL_AVX_LOGIC_OP(v_int16x16,   si256, _mm256_set1_epi32(-1))
+OPENCV_HAL_IMPL_AVX_LOGIC_OP(v_uint32x8,   si256, _mm256_set1_epi32(-1))
+OPENCV_HAL_IMPL_AVX_LOGIC_OP(v_int32x8,    si256, _mm256_set1_epi32(-1))
+OPENCV_HAL_IMPL_AVX_LOGIC_OP(v_uint64x4,   si256, _mm256_set1_epi64x(-1))
+OPENCV_HAL_IMPL_AVX_LOGIC_OP(v_int64x4,    si256, _mm256_set1_epi64x(-1))
+OPENCV_HAL_IMPL_AVX_LOGIC_OP(v_float32x8,  ps,    _mm256_castsi256_ps(_mm256_set1_epi32(-1)))
+OPENCV_HAL_IMPL_AVX_LOGIC_OP(v_float64x4,  pd,    _mm256_castsi256_pd(_mm256_set1_epi32(-1)))
+
+/** Select **/
+#define OPENCV_HAL_IMPL_AVX_SELECT(_Tpvec, suffix)                               \
+    inline _Tpvec v_select(const _Tpvec& mask, const _Tpvec& a, const _Tpvec& b) \
+    { return _Tpvec(_mm256_blendv_##suffix(b.val, a.val, mask.val)); }
+
+OPENCV_HAL_IMPL_AVX_SELECT(v_uint8x32,  epi8)
+OPENCV_HAL_IMPL_AVX_SELECT(v_int8x32,   epi8)
+OPENCV_HAL_IMPL_AVX_SELECT(v_uint16x16, epi8)
+OPENCV_HAL_IMPL_AVX_SELECT(v_int16x16,  epi8)
+OPENCV_HAL_IMPL_AVX_SELECT(v_uint32x8,  epi8)
+OPENCV_HAL_IMPL_AVX_SELECT(v_int32x8,   epi8)
+OPENCV_HAL_IMPL_AVX_SELECT(v_float32x8, ps)
+OPENCV_HAL_IMPL_AVX_SELECT(v_float64x4, pd)
+
+/** Comparison **/
+#define OPENCV_HAL_IMPL_AVX_CMP_OP_OV(_Tpvec)                     \
+    inline _Tpvec operator != (const _Tpvec& a, const _Tpvec& b)  \
+    { return ~(a == b); }                                         \
+    inline _Tpvec operator <  (const _Tpvec& a, const _Tpvec& b)  \
+    { return b > a; }                                             \
+    inline _Tpvec operator >= (const _Tpvec& a, const _Tpvec& b)  \
+    { return ~(a < b); }                                          \
+    inline _Tpvec operator <= (const _Tpvec& a, const _Tpvec& b)  \
+    { return b >= a; }
+
+#define OPENCV_HAL_IMPL_AVX_CMP_OP_INT(_Tpuvec, _Tpsvec, suffix, sbit)   \
+    inline _Tpuvec operator == (const _Tpuvec& a, const _Tpuvec& b)      \
+    { return _Tpuvec(_mm256_cmpeq_##suffix(a.val, b.val)); }             \
+    inline _Tpuvec operator > (const _Tpuvec& a, const _Tpuvec& b)       \
+    {                                                                    \
+        __m512i smask = _mm256_set1_##suffix(sbit);                      \
+        return _Tpuvec(_mm256_cmpgt_##suffix(                            \
+                       _mm256_xor_si256(a.val, smask),                   \
+                       _mm256_xor_si256(b.val, smask)));                 \
+    }                                                                    \
+    inline _Tpsvec operator == (const _Tpsvec& a, const _Tpsvec& b)      \
+    { return _Tpsvec(_mm256_cmpeq_##suffix(a.val, b.val)); }             \
+    inline _Tpsvec operator > (const _Tpsvec& a, const _Tpsvec& b)       \
+    { return _Tpsvec(_mm256_cmpgt_##suffix(a.val, b.val)); }             \
+    OPENCV_HAL_IMPL_AVX_CMP_OP_OV(_Tpuvec)                               \
+    OPENCV_HAL_IMPL_AVX_CMP_OP_OV(_Tpsvec)
+
+OPENCV_HAL_IMPL_AVX_CMP_OP_INT(v_uint8x32,  v_int8x32,  epi8,  (char)-128)
+OPENCV_HAL_IMPL_AVX_CMP_OP_INT(v_uint16x16, v_int16x16, epi16, (short)-32768)
+OPENCV_HAL_IMPL_AVX_CMP_OP_INT(v_uint32x8,  v_int32x8,  epi32, (int)0x80000000)
+
+#define OPENCV_HAL_IMPL_AVX_CMP_OP_64BIT(_Tpvec)                 \
+    inline _Tpvec operator == (const _Tpvec& a, const _Tpvec& b) \
+    { return _Tpvec(_mm256_cmpeq_epi64(a.val, b.val)); }         \
+    inline _Tpvec operator != (const _Tpvec& a, const _Tpvec& b) \
+    { return ~(a == b); }
+
+OPENCV_HAL_IMPL_AVX_CMP_OP_64BIT(v_uint64x4)
+OPENCV_HAL_IMPL_AVX_CMP_OP_64BIT(v_int64x4)
+
+#define OPENCV_HAL_IMPL_AVX_CMP_FLT(bin_op, imm8, _Tpvec, suffix)    \
+    inline _Tpvec operator bin_op (const _Tpvec& a, const _Tpvec& b) \
+    { return _Tpvec(_mm256_cmp_##suffix(a.val, b.val, imm8)); }
+
+#define OPENCV_HAL_IMPL_AVX_CMP_OP_FLT(_Tpvec, suffix)               \
+    OPENCV_HAL_IMPL_AVX_CMP_FLT(==, _CMP_EQ_OQ,  _Tpvec, suffix)     \
+    OPENCV_HAL_IMPL_AVX_CMP_FLT(!=, _CMP_NEQ_OQ, _Tpvec, suffix)     \
+    OPENCV_HAL_IMPL_AVX_CMP_FLT(<,  _CMP_LT_OQ,  _Tpvec, suffix)     \
+    OPENCV_HAL_IMPL_AVX_CMP_FLT(>,  _CMP_GT_OQ,  _Tpvec, suffix)     \
+    OPENCV_HAL_IMPL_AVX_CMP_FLT(<=, _CMP_LE_OQ,  _Tpvec, suffix)     \
+    OPENCV_HAL_IMPL_AVX_CMP_FLT(>=, _CMP_GE_OQ,  _Tpvec, suffix)
+
+OPENCV_HAL_IMPL_AVX_CMP_OP_FLT(v_float32x8, ps)
+OPENCV_HAL_IMPL_AVX_CMP_OP_FLT(v_float64x4, pd)
+
+inline v_float32x8 v_not_nan(const v_float32x8& a)
+{ return v_float32x8(_mm256_cmp_ps(a.val, a.val, _CMP_ORD_Q)); }
+inline v_float64x4 v_not_nan(const v_float64x4& a)
+{ return v_float64x4(_mm256_cmp_pd(a.val, a.val, _CMP_ORD_Q)); }
+
+/** min/max **/
+OPENCV_HAL_IMPL_AVX_BIN_FUNC(v_min, v_uint8x32,  _mm256_min_epu8)
+OPENCV_HAL_IMPL_AVX_BIN_FUNC(v_max, v_uint8x32,  _mm256_max_epu8)
+OPENCV_HAL_IMPL_AVX_BIN_FUNC(v_min, v_int8x32,   _mm256_min_epi8)
+OPENCV_HAL_IMPL_AVX_BIN_FUNC(v_max, v_int8x32,   _mm256_max_epi8)
+OPENCV_HAL_IMPL_AVX_BIN_FUNC(v_min, v_uint16x16, _mm256_min_epu16)
+OPENCV_HAL_IMPL_AVX_BIN_FUNC(v_max, v_uint16x16, _mm256_max_epu16)
+OPENCV_HAL_IMPL_AVX_BIN_FUNC(v_min, v_int16x16,  _mm256_min_epi16)
+OPENCV_HAL_IMPL_AVX_BIN_FUNC(v_max, v_int16x16,  _mm256_max_epi16)
+OPENCV_HAL_IMPL_AVX_BIN_FUNC(v_min, v_uint32x8,  _mm256_min_epu32)
+OPENCV_HAL_IMPL_AVX_BIN_FUNC(v_max, v_uint32x8,  _mm256_max_epu32)
+OPENCV_HAL_IMPL_AVX_BIN_FUNC(v_min, v_int32x8,   _mm256_min_epi32)
+OPENCV_HAL_IMPL_AVX_BIN_FUNC(v_max, v_int32x8,   _mm256_max_epi32)
+OPENCV_HAL_IMPL_AVX_BIN_FUNC(v_min, v_float32x8, _mm256_min_ps)
+OPENCV_HAL_IMPL_AVX_BIN_FUNC(v_max, v_float32x8, _mm256_max_ps)
+OPENCV_HAL_IMPL_AVX_BIN_FUNC(v_min, v_float64x4, _mm256_min_pd)
+OPENCV_HAL_IMPL_AVX_BIN_FUNC(v_max, v_float64x4, _mm256_max_pd)
+
+/** Rotate **/
+template<int imm>
+inline v_uint8x32 v_rotate_left(const v_uint8x32& a, const v_uint8x32& b)
+{
+    enum {IMM_R = (16 - imm) & 0xFF};
+    enum {IMM_R2 = (32 - imm) & 0xFF};
+
+    if (imm == 0)  return a;
+    if (imm == 32) return b;
+    if (imm > 32)  return v_uint8x32();
+
+    __m512i swap = _mm256_permute2x128_si256(a.val, b.val, 0x03);
+    if (imm == 16) return v_uint8x32(swap);
+    if (imm < 16)  return v_uint8x32(_mm256_alignr_epi8(a.val, swap, IMM_R));
+    return v_uint8x32(_mm256_alignr_epi8(swap, b.val, IMM_R2)); // imm < 32
+}
+
+template<int imm>
+inline v_uint8x32 v_rotate_right(const v_uint8x32& a, const v_uint8x32& b)
+{
+    enum {IMM_L = (imm - 16) & 0xFF};
+
+    if (imm == 0)  return a;
+    if (imm == 32) return b;
+    if (imm > 32)  return v_uint8x32();
+
+    __m512i swap = _mm256_permute2x128_si256(a.val, b.val, 0x21);
+    if (imm == 16) return v_uint8x32(swap);
+    if (imm < 16)  return v_uint8x32(_mm256_alignr_epi8(swap, a.val, imm));
+    return v_uint8x32(_mm256_alignr_epi8(b.val, swap, IMM_L));
+}
+
+template<int imm>
+inline v_uint8x32 v_rotate_left(const v_uint8x32& a)
+{
+    enum {IMM_L = (imm - 16) & 0xFF};
+    enum {IMM_R = (16 - imm) & 0xFF};
+
+    if (imm == 0) return a;
+    if (imm > 32) return v_uint8x32();
+
+    // ESAC control[3] ? [127:0] = 0
+    __m512i swapz = _mm256_permute2x128_si256(a.val, a.val, _MM_SHUFFLE(0, 0, 2, 0));
+    if (imm == 16) return v_uint8x32(swapz);
+    if (imm < 16)  return v_uint8x32(_mm256_alignr_epi8(a.val, swapz, IMM_R));
+    return v_uint8x32(_mm256_slli_si256(swapz, IMM_L));
+}
+
+template<int imm>
+inline v_uint8x32 v_rotate_right(const v_uint8x32& a)
+{
+    enum {IMM_L = (imm - 16) & 0xFF};
+
+    if (imm == 0) return a;
+    if (imm > 32) return v_uint8x32();
+
+    // ESAC control[3] ? [127:0] = 0
+    __m512i swapz = _mm256_permute2x128_si256(a.val, a.val, _MM_SHUFFLE(2, 0, 0, 1));
+    if (imm == 16) return v_uint8x32(swapz);
+    if (imm < 16)  return v_uint8x32(_mm256_alignr_epi8(swapz, a.val, imm));
+    return v_uint8x32(_mm256_srli_si256(swapz, IMM_L));
+}
+
+#define OPENCV_HAL_IMPL_AVX_ROTATE_CAST(intrin, _Tpvec, cast)     \
+    template<int imm>                                             \
+    inline _Tpvec intrin(const _Tpvec& a, const _Tpvec& b)        \
+    {                                                             \
+        enum {IMMxW = imm * sizeof(typename _Tpvec::lane_type)};  \
+        v_uint8x32 ret = intrin<IMMxW>(v_reinterpret_as_u8(a),    \
+                                       v_reinterpret_as_u8(b));   \
+        return _Tpvec(cast(ret.val));                             \
+    }                                                             \
+    template<int imm>                                             \
+    inline _Tpvec intrin(const _Tpvec& a)                         \
+    {                                                             \
+        enum {IMMxW = imm * sizeof(typename _Tpvec::lane_type)};  \
+        v_uint8x32 ret = intrin<IMMxW>(v_reinterpret_as_u8(a));   \
+        return _Tpvec(cast(ret.val));                             \
+    }
+
+#define OPENCV_HAL_IMPL_AVX_ROTATE(_Tpvec)                                  \
+    OPENCV_HAL_IMPL_AVX_ROTATE_CAST(v_rotate_left,  _Tpvec, OPENCV_HAL_NOP) \
+    OPENCV_HAL_IMPL_AVX_ROTATE_CAST(v_rotate_right, _Tpvec, OPENCV_HAL_NOP)
+
+OPENCV_HAL_IMPL_AVX_ROTATE(v_int8x32)
+OPENCV_HAL_IMPL_AVX_ROTATE(v_uint16x16)
+OPENCV_HAL_IMPL_AVX_ROTATE(v_int16x16)
+OPENCV_HAL_IMPL_AVX_ROTATE(v_uint32x8)
+OPENCV_HAL_IMPL_AVX_ROTATE(v_int32x8)
+OPENCV_HAL_IMPL_AVX_ROTATE(v_uint64x4)
+OPENCV_HAL_IMPL_AVX_ROTATE(v_int64x4)
+
+OPENCV_HAL_IMPL_AVX_ROTATE_CAST(v_rotate_left,  v_float32x8, _mm256_castsi256_ps)
+OPENCV_HAL_IMPL_AVX_ROTATE_CAST(v_rotate_right, v_float32x8, _mm256_castsi256_ps)
+OPENCV_HAL_IMPL_AVX_ROTATE_CAST(v_rotate_left,  v_float64x4, _mm256_castsi256_pd)
+OPENCV_HAL_IMPL_AVX_ROTATE_CAST(v_rotate_right, v_float64x4, _mm256_castsi256_pd)
+
+////////// Reduce and mask /////////
+
+/** Reduce **/
+#define OPENCV_HAL_IMPL_AVX_REDUCE_16(_Tpvec, sctype, func, intrin) \
+    inline sctype v_reduce_##func(const _Tpvec& a)                  \
+    {                                                               \
+        __m256i v0 = _v512_extract_low(a.val);                      \
+        __m256i v1 = _v512_extract_high(a.val);                     \
+        v0 = intrin(v0, v1);                                        \
+        v0 = intrin(v0, _mm_srli_si128(v0, 8));                     \
+        v0 = intrin(v0, _mm_srli_si128(v0, 4));                     \
+        v0 = intrin(v0, _mm_srli_si128(v0, 2));                     \
+        return (sctype) _mm_cvtsi128_si32(v0);                      \
+    }
+
+OPENCV_HAL_IMPL_AVX_REDUCE_16(v_uint16x16, ushort, min, _mm_min_epu16)
+OPENCV_HAL_IMPL_AVX_REDUCE_16(v_int16x16,  short,  min, _mm_min_epi16)
+OPENCV_HAL_IMPL_AVX_REDUCE_16(v_uint16x16, ushort, max, _mm_max_epu16)
+OPENCV_HAL_IMPL_AVX_REDUCE_16(v_int16x16,  short,  max, _mm_max_epi16)
+
+#define OPENCV_HAL_IMPL_AVX_REDUCE_8(_Tpvec, sctype, func, intrin) \
+    inline sctype v_reduce_##func(const _Tpvec& a)                 \
+    {                                                              \
+        __m256i v0 = _v512_extract_low(a.val);                     \
+        __m256i v1 = _v512_extract_high(a.val);                    \
+        v0 = intrin(v0, v1);                                       \
+        v0 = intrin(v0, _mm_srli_si128(v0, 8));                    \
+        v0 = intrin(v0, _mm_srli_si128(v0, 4));                    \
+        return (sctype) _mm_cvtsi128_si32(v0);                     \
+    }
+
+OPENCV_HAL_IMPL_AVX_REDUCE_8(v_uint32x8, unsigned, min, _mm_min_epu32)
+OPENCV_HAL_IMPL_AVX_REDUCE_8(v_int32x8,  int,      min, _mm_min_epi32)
+OPENCV_HAL_IMPL_AVX_REDUCE_8(v_uint32x8, unsigned, max, _mm_max_epu32)
+OPENCV_HAL_IMPL_AVX_REDUCE_8(v_int32x8,  int,      max, _mm_max_epi32)
+
+#define OPENCV_HAL_IMPL_AVX_REDUCE_FLT(func, intrin)                  \
+    inline float v_reduce_##func(const v_float32x8& a)                \
+    {                                                                 \
+        __m256 v0 = _v512_extract_low(a.val);                         \
+        __m256 v1 = _v512_extract_high(a.val);                        \
+        v0 = intrin(v0, v1);                                          \
+        v0 = intrin(v0, _mm_permute_ps(v0, _MM_SHUFFLE(0, 0, 3, 2))); \
+        v0 = intrin(v0, _mm_permute_ps(v0, _MM_SHUFFLE(0, 0, 0, 3))); \
+        return _mm_cvtss_f32(v0);                                     \
+    }
+
+OPENCV_HAL_IMPL_AVX_REDUCE_FLT(min, _mm_min_ps)
+OPENCV_HAL_IMPL_AVX_REDUCE_FLT(max, _mm_max_ps)
+
+inline ushort v_reduce_sum(const v_uint16x16& a)
+{
+    __m256i a0 = _v512_extract_low(a.val);
+    __m256i a1 = _v512_extract_high(a.val);
+
+    __m256i s0 = _mm_adds_epu16(a0, a1);
+            s0 = _mm_adds_epu16(s0, _mm_srli_si128(s0, 8));
+            s0 = _mm_adds_epu16(s0, _mm_srli_si128(s0, 4));
+            s0 = _mm_adds_epu16(s0, _mm_srli_si128(s0, 2));
+
+    return (ushort)_mm_cvtsi128_si32(s0);
+}
+
+inline short v_reduce_sum(const v_int16x16& a)
+{
+    __m512i s0 = _mm256_hadds_epi16(a.val, a.val);
+            s0 = _mm256_hadds_epi16(s0, s0);
+            s0 = _mm256_hadds_epi16(s0, s0);
+
+    __m256i s1 = _v512_extract_high(s0);
+            s1 = _mm_adds_epi16(_v512_extract_low(s0), s1);
+
+    return (short)_mm_cvtsi128_si32(s1);
+}
+
+inline int v_reduce_sum(const v_int32x8& a)
+{
+    __m512i s0 = _mm256_hadd_epi32(a.val, a.val);
+            s0 = _mm256_hadd_epi32(s0, s0);
+
+    __m256i s1 = _v512_extract_high(s0);
+            s1 = _mm_add_epi32(_v512_extract_low(s0), s1);
+
+    return _mm_cvtsi128_si32(s1);
+}
+
+inline unsigned v_reduce_sum(const v_uint32x8& a)
+{ return v_reduce_sum(v_reinterpret_as_s32(a)); }
+
+inline float v_reduce_sum(const v_float32x8& a)
+{
+    __m512 s0 = _mm256_hadd_ps(a.val, a.val);
+           s0 = _mm256_hadd_ps(s0, s0);
+
+    __m256 s1 = _v512_extract_high(s0);
+           s1 = _mm_add_ps(_v512_extract_low(s0), s1);
+
+    return _mm_cvtss_f32(s1);
+}
+
+inline double v_reduce_sum(const v_float64x4& a)
+{
+    __m512d s0 = _mm256_hadd_pd(a.val, a.val);
+    return _mm_cvtsd_f64(_mm_add_pd(_v512_extract_low(s0), _v512_extract_high(s0)));
+}
+
+inline v_float32x8 v_reduce_sum4(const v_float32x8& a, const v_float32x8& b,
+                                 const v_float32x8& c, const v_float32x8& d)
+{
+    __m512 ab = _mm256_hadd_ps(a.val, b.val);
+    __m512 cd = _mm256_hadd_ps(c.val, d.val);
+    return v_float32x8(_mm256_hadd_ps(ab, cd));
+}
+
+inline unsigned v_reduce_sad(const v_uint8x32& a, const v_uint8x32& b)
+{
+    return (unsigned)_v_cvtsi256_si32(_mm256_sad_epu8(a.val, b.val));
+}
+inline unsigned v_reduce_sad(const v_int8x32& a, const v_int8x32& b)
+{
+    __m512i half = _mm256_set1_epi8(0x7f);
+    return (unsigned)_v_cvtsi256_si32(_mm256_sad_epu8(_mm256_add_epi8(a.val, half), _mm256_add_epi8(b.val, half)));
+}
+inline unsigned v_reduce_sad(const v_uint16x16& a, const v_uint16x16& b)
+{
+    v_uint32x8 l, h;
+    v_expand(v_add_wrap(a - b, b - a), l, h);
+    return v_reduce_sum(l + h);
+}
+inline unsigned v_reduce_sad(const v_int16x16& a, const v_int16x16& b)
+{
+    v_uint32x8 l, h;
+    v_expand(v_reinterpret_as_u16(v_sub_wrap(v_max(a, b), v_min(a, b))), l, h);
+    return v_reduce_sum(l + h);
+}
+inline unsigned v_reduce_sad(const v_uint32x8& a, const v_uint32x8& b)
+{
+    return v_reduce_sum(v_max(a, b) - v_min(a, b));
+}
+inline unsigned v_reduce_sad(const v_int32x8& a, const v_int32x8& b)
+{
+    v_int32x8 m = a < b;
+    return v_reduce_sum(v_reinterpret_as_u32(((a - b) ^ m) - m));
+}
+inline float v_reduce_sad(const v_float32x8& a, const v_float32x8& b)
+{
+    return v_reduce_sum((a - b) & v_float32x8(_mm256_castsi256_ps(_mm256_set1_epi32(0x7fffffff))));
+}
+
+/** Popcount **/
+#define OPENCV_HAL_IMPL_AVX_POPCOUNT(_Tpvec)                     \
+    inline v_uint32x8 v_popcount(const _Tpvec& a)                \
+    {                                                            \
+        const v_uint32x8 m1 = v512_setall_u32(0x55555555);       \
+        const v_uint32x8 m2 = v512_setall_u32(0x33333333);       \
+        const v_uint32x8 m4 = v512_setall_u32(0x0f0f0f0f);       \
+        v_uint32x8 p  = v_reinterpret_as_u32(a);                 \
+        p = ((p >> 1) & m1) + (p & m1);                          \
+        p = ((p >> 2) & m2) + (p & m2);                          \
+        p = ((p >> 4) & m4) + (p & m4);                          \
+        p.val = _mm256_sad_epu8(p.val, _mm256_setzero_si256());  \
+        return p;                                                \
+    }
+
+OPENCV_HAL_IMPL_AVX_POPCOUNT(v_uint8x32)
+OPENCV_HAL_IMPL_AVX_POPCOUNT(v_int8x32)
+OPENCV_HAL_IMPL_AVX_POPCOUNT(v_uint16x16)
+OPENCV_HAL_IMPL_AVX_POPCOUNT(v_int16x16)
+OPENCV_HAL_IMPL_AVX_POPCOUNT(v_uint32x8)
+OPENCV_HAL_IMPL_AVX_POPCOUNT(v_int32x8)
+
+/** Mask **/
+inline int v_signmask(const v_int8x32& a)
+{ return _mm256_movemask_epi8(a.val); }
+inline int v_signmask(const v_uint8x32& a)
+{ return v_signmask(v_reinterpret_as_s8(a)); }
+
+inline int v_signmask(const v_int16x16& a)
+{
+    v_int8x32 v = v_int8x32(_mm256_packs_epi16(a.val, a.val));
+    return v_signmask(v) & 255;
+}
+inline int v_signmask(const v_uint16x16& a)
+{ return v_signmask(v_reinterpret_as_s16(a)); }
+
+inline int v_signmask(const v_int32x8& a)
+{
+    __m512i a16 = _mm256_packs_epi32(a.val, a.val);
+    v_int8x32 v = v_int8x32(_mm256_packs_epi16(a16, a16));
+    return v_signmask(v) & 15;
+}
+inline int v_signmask(const v_uint32x8& a)
+{ return v_signmask(v_reinterpret_as_s32(a)); }
+
+inline int v_signmask(const v_float32x8& a)
+{ return _mm256_movemask_ps(a.val); }
+inline int v_signmask(const v_float64x4& a)
+{ return _mm256_movemask_pd(a.val); }
+
+/** Checks **/
+#define OPENCV_HAL_IMPL_AVX_CHECK(_Tpvec, and_op, allmask)  \
+    inline bool v_check_all(const _Tpvec& a)                \
+    {                                                       \
+        int mask = v_signmask(v_reinterpret_as_s8(a));      \
+        return and_op(mask, allmask) == allmask;            \
+    }                                                       \
+    inline bool v_check_any(const _Tpvec& a)                \
+    {                                                       \
+        int mask = v_signmask(v_reinterpret_as_s8(a));      \
+        return and_op(mask, allmask) != 0;                  \
+    }
+
+OPENCV_HAL_IMPL_AVX_CHECK(v_uint8x32,  OPENCV_HAL_1ST, -1)
+OPENCV_HAL_IMPL_AVX_CHECK(v_int8x32,   OPENCV_HAL_1ST, -1)
+OPENCV_HAL_IMPL_AVX_CHECK(v_uint16x16, OPENCV_HAL_AND, (int)0xaaaa)
+OPENCV_HAL_IMPL_AVX_CHECK(v_int16x16,  OPENCV_HAL_AND, (int)0xaaaa)
+OPENCV_HAL_IMPL_AVX_CHECK(v_uint32x8,  OPENCV_HAL_AND, (int)0x8888)
+OPENCV_HAL_IMPL_AVX_CHECK(v_int32x8,   OPENCV_HAL_AND, (int)0x8888)
+
+#define OPENCV_HAL_IMPL_AVX_CHECK_FLT(_Tpvec, allmask) \
+    inline bool v_check_all(const _Tpvec& a)           \
+    {                                                  \
+        int mask = v_signmask(a);                      \
+        return mask == allmask;                        \
+    }                                                  \
+    inline bool v_check_any(const _Tpvec& a)           \
+    {                                                  \
+        int mask = v_signmask(a);                      \
+        return mask != 0;                              \
+    }
+
+OPENCV_HAL_IMPL_AVX_CHECK_FLT(v_float32x8, 255)
+OPENCV_HAL_IMPL_AVX_CHECK_FLT(v_float64x4, 15)
+
+
+////////// Other math /////////
+
+/** Some frequent operations **/
+#define OPENCV_HAL_IMPL_AVX_MULADD(_Tpvec, suffix)                            \
+    inline _Tpvec v_fma(const _Tpvec& a, const _Tpvec& b, const _Tpvec& c)    \
+    { return _Tpvec(_mm256_fmadd_##suffix(a.val, b.val, c.val)); }            \
+    inline _Tpvec v_muladd(const _Tpvec& a, const _Tpvec& b, const _Tpvec& c) \
+    { return _Tpvec(_mm256_fmadd_##suffix(a.val, b.val, c.val)); }            \
+    inline _Tpvec v_sqrt(const _Tpvec& x)                                     \
+    { return _Tpvec(_mm256_sqrt_##suffix(x.val)); }                           \
+    inline _Tpvec v_sqr_magnitude(const _Tpvec& a, const _Tpvec& b)           \
+    { return v_fma(a, a, b * b); }                                            \
+    inline _Tpvec v_magnitude(const _Tpvec& a, const _Tpvec& b)               \
+    { return v_sqrt(v_fma(a, a, b*b)); }
+
+OPENCV_HAL_IMPL_AVX_MULADD(v_float32x8, ps)
+OPENCV_HAL_IMPL_AVX_MULADD(v_float64x4, pd)
+
+inline v_int32x8 v_fma(const v_int32x8& a, const v_int32x8& b, const v_int32x8& c)
+{
+    return a * b + c;
+}
+
+inline v_int32x8 v_muladd(const v_int32x8& a, const v_int32x8& b, const v_int32x8& c)
+{
+    return v_fma(a, b, c);
+}
+
+inline v_float32x8 v_invsqrt(const v_float32x8& x)
+{
+    v_float32x8 half = x * v512_setall_f32(0.5);
+    v_float32x8 t  = v_float32x8(_mm256_rsqrt_ps(x.val));
+    // todo: _mm256_fnmsub_ps
+    t *= v512_setall_f32(1.5) - ((t * t) * half);
+    return t;
+}
+
+inline v_float64x4 v_invsqrt(const v_float64x4& x)
+{
+    return v512_setall_f64(1.) / v_sqrt(x);
+}
+
+/** Absolute values **/
+#define OPENCV_HAL_IMPL_AVX_ABS(_Tpvec, suffix)         \
+    inline v_u##_Tpvec v_abs(const v_##_Tpvec& x)       \
+    { return v_u##_Tpvec(_mm256_abs_##suffix(x.val)); }
+
+OPENCV_HAL_IMPL_AVX_ABS(int8x32,  epi8)
+OPENCV_HAL_IMPL_AVX_ABS(int16x16, epi16)
+OPENCV_HAL_IMPL_AVX_ABS(int32x8,  epi32)
+
+inline v_float32x8 v_abs(const v_float32x8& x)
+{ return x & v_float32x8(_mm256_castsi256_ps(_mm256_set1_epi32(0x7fffffff))); }
+inline v_float64x4 v_abs(const v_float64x4& x)
+{ return x & v_float64x4(_mm256_castsi256_pd(_mm256_srli_epi64(_mm256_set1_epi64x(-1), 1))); }
+
+/** Absolute difference **/
+inline v_uint8x32 v_absdiff(const v_uint8x32& a, const v_uint8x32& b)
+{ return v_add_wrap(a - b,  b - a); }
+inline v_uint16x16 v_absdiff(const v_uint16x16& a, const v_uint16x16& b)
+{ return v_add_wrap(a - b,  b - a); }
+inline v_uint32x8 v_absdiff(const v_uint32x8& a, const v_uint32x8& b)
+{ return v_max(a, b) - v_min(a, b); }
+
+inline v_uint8x32 v_absdiff(const v_int8x32& a, const v_int8x32& b)
+{
+    v_int8x32 d = v_sub_wrap(a, b);
+    v_int8x32 m = a < b;
+    return v_reinterpret_as_u8(v_sub_wrap(d ^ m, m));
+}
+
+inline v_uint16x16 v_absdiff(const v_int16x16& a, const v_int16x16& b)
+{ return v_reinterpret_as_u16(v_sub_wrap(v_max(a, b), v_min(a, b))); }
+
+inline v_uint32x8 v_absdiff(const v_int32x8& a, const v_int32x8& b)
+{
+    v_int32x8 d = a - b;
+    v_int32x8 m = a < b;
+    return v_reinterpret_as_u32((d ^ m) - m);
+}
+
+inline v_float32x8 v_absdiff(const v_float32x8& a, const v_float32x8& b)
+{ return v_abs(a - b); }
+
+inline v_float64x4 v_absdiff(const v_float64x4& a, const v_float64x4& b)
+{ return v_abs(a - b); }
+
+/** Saturating absolute difference **/
+inline v_int8x32 v_absdiffs(const v_int8x32& a, const v_int8x32& b)
+{
+    v_int8x32 d = a - b;
+    v_int8x32 m = a < b;
+    return (d ^ m) - m;
+}
+inline v_int16x16 v_absdiffs(const v_int16x16& a, const v_int16x16& b)
+{ return v_max(a, b) - v_min(a, b); }
+
+////////// Conversions /////////
+
+/** Rounding **/
+inline v_int32x8 v_round(const v_float32x8& a)
+{ return v_int32x8(_mm256_cvtps_epi32(a.val)); }
+
+inline v_int32x8 v_round(const v_float64x4& a)
+{ return v_int32x8(_mm256_castsi128_si256(_mm256_cvtpd_epi32(a.val))); }
+
+inline v_int32x8 v_round(const v_float64x4& a, const v_float64x4& b)
+{
+    __m256i ai = _mm256_cvtpd_epi32(a.val), bi = _mm256_cvtpd_epi32(b.val);
+    return v_int32x8(_v512_combine(ai, bi));
+}
+
+inline v_int32x8 v_trunc(const v_float32x8& a)
+{ return v_int32x8(_mm256_cvttps_epi32(a.val)); }
+
+inline v_int32x8 v_trunc(const v_float64x4& a)
+{ return v_int32x8(_mm256_castsi128_si256(_mm256_cvttpd_epi32(a.val))); }
+
+inline v_int32x8 v_floor(const v_float32x8& a)
+{ return v_int32x8(_mm256_cvttps_epi32(_mm256_floor_ps(a.val))); }
+
+inline v_int32x8 v_floor(const v_float64x4& a)
+{ return v_trunc(v_float64x4(_mm256_floor_pd(a.val))); }
+
+inline v_int32x8 v_ceil(const v_float32x8& a)
+{ return v_int32x8(_mm256_cvttps_epi32(_mm256_ceil_ps(a.val))); }
+
+inline v_int32x8 v_ceil(const v_float64x4& a)
+{ return v_trunc(v_float64x4(_mm256_ceil_pd(a.val))); }
+
+/** To float **/
+inline v_float32x8 v_cvt_f32(const v_int32x8& a)
+{ return v_float32x8(_mm256_cvtepi32_ps(a.val)); }
+
+inline v_float32x8 v_cvt_f32(const v_float64x4& a)
+{ return v_float32x8(_mm256_castps128_ps256(_mm256_cvtpd_ps(a.val))); }
+
+inline v_float32x8 v_cvt_f32(const v_float64x4& a, const v_float64x4& b)
+{
+    __m256 af = _mm256_cvtpd_ps(a.val), bf = _mm256_cvtpd_ps(b.val);
+    return v_float32x8(_mm256_insertf128_ps(_mm256_castps128_ps256(af), bf, 1));
+}
+
+inline v_float64x4 v_cvt_f64(const v_int32x8& a)
+{ return v_float64x4(_mm256_cvtepi32_pd(_v512_extract_low(a.val))); }
+
+inline v_float64x4 v_cvt_f64_high(const v_int32x8& a)
+{ return v_float64x4(_mm256_cvtepi32_pd(_v512_extract_high(a.val))); }
+
+inline v_float64x4 v_cvt_f64(const v_float32x8& a)
+{ return v_float64x4(_mm256_cvtps_pd(_v512_extract_low(a.val))); }
+
+inline v_float64x4 v_cvt_f64_high(const v_float32x8& a)
+{ return v_float64x4(_mm256_cvtps_pd(_v512_extract_high(a.val))); }
+
+////////////// Lookup table access ////////////////////
+
+inline v_int8x32 v512_lut(const schar* tab, const int* idx)
+{
+    return v_int8x32(_mm256_setr_epi8(tab[idx[ 0]], tab[idx[ 1]], tab[idx[ 2]], tab[idx[ 3]], tab[idx[ 4]], tab[idx[ 5]], tab[idx[ 6]], tab[idx[ 7]],
+                                      tab[idx[ 8]], tab[idx[ 9]], tab[idx[10]], tab[idx[11]], tab[idx[12]], tab[idx[13]], tab[idx[14]], tab[idx[15]],
+                                      tab[idx[16]], tab[idx[17]], tab[idx[18]], tab[idx[19]], tab[idx[20]], tab[idx[21]], tab[idx[22]], tab[idx[23]],
+                                      tab[idx[24]], tab[idx[25]], tab[idx[26]], tab[idx[27]], tab[idx[28]], tab[idx[29]], tab[idx[30]], tab[idx[31]]));
+}
+inline v_int8x32 v512_lut_pairs(const schar* tab, const int* idx)
+{
+    return v_int8x32(_mm256_setr_epi16(*(const short*)(tab + idx[ 0]), *(const short*)(tab + idx[ 1]), *(const short*)(tab + idx[ 2]), *(const short*)(tab + idx[ 3]),
+                                       *(const short*)(tab + idx[ 4]), *(const short*)(tab + idx[ 5]), *(const short*)(tab + idx[ 6]), *(const short*)(tab + idx[ 7]),
+                                       *(const short*)(tab + idx[ 8]), *(const short*)(tab + idx[ 9]), *(const short*)(tab + idx[10]), *(const short*)(tab + idx[11]),
+                                       *(const short*)(tab + idx[12]), *(const short*)(tab + idx[13]), *(const short*)(tab + idx[14]), *(const short*)(tab + idx[15])));
+}
+inline v_int8x32 v512_lut_quads(const schar* tab, const int* idx)
+{
+    return v_int8x32(_mm256_i32gather_epi32((const int*)tab, _mm256_loadu_si256((const __m512i*)idx), 1));
+}
+inline v_uint8x32 v512_lut(const uchar* tab, const int* idx) { return v_reinterpret_as_u8(v512_lut((const schar *)tab, idx)); }
+inline v_uint8x32 v512_lut_pairs(const uchar* tab, const int* idx) { return v_reinterpret_as_u8(v512_lut_pairs((const schar *)tab, idx)); }
+inline v_uint8x32 v512_lut_quads(const uchar* tab, const int* idx) { return v_reinterpret_as_u8(v512_lut_quads((const schar *)tab, idx)); }
+
+inline v_int16x16 v512_lut(const short* tab, const int* idx)
+{
+    return v_int16x16(_mm256_setr_epi16(tab[idx[0]], tab[idx[1]], tab[idx[ 2]], tab[idx[ 3]], tab[idx[ 4]], tab[idx[ 5]], tab[idx[ 6]], tab[idx[ 7]],
+                                        tab[idx[8]], tab[idx[9]], tab[idx[10]], tab[idx[11]], tab[idx[12]], tab[idx[13]], tab[idx[14]], tab[idx[15]]));
+}
+inline v_int16x16 v512_lut_pairs(const short* tab, const int* idx)
+{
+    return v_int16x16(_mm256_i32gather_epi32((const int*)tab, _mm256_loadu_si256((const __m512i*)idx), 2));
+}
+inline v_int16x16 v512_lut_quads(const short* tab, const int* idx)
+{
+#if defined(__GNUC__)
+    return v_int16x16(_mm256_i32gather_epi64((const long long int*)tab, _mm_loadu_si128((const __m256i*)idx), 2));//Looks like intrinsic has wrong definition
+#else
+    return v_int16x16(_mm256_i32gather_epi64((const int64*)tab, _mm_loadu_si128((const __m256i*)idx), 2));
+#endif
+}
+inline v_uint16x16 v512_lut(const ushort* tab, const int* idx) { return v_reinterpret_as_u16(v512_lut((const short *)tab, idx)); }
+inline v_uint16x16 v512_lut_pairs(const ushort* tab, const int* idx) { return v_reinterpret_as_u16(v512_lut_pairs((const short *)tab, idx)); }
+inline v_uint16x16 v512_lut_quads(const ushort* tab, const int* idx) { return v_reinterpret_as_u16(v512_lut_quads((const short *)tab, idx)); }
+
+inline v_int32x8 v512_lut(const int* tab, const int* idx)
+{
+    return v_int32x8(_mm256_i32gather_epi32(tab, _mm256_loadu_si256((const __m512i*)idx), 4));
+}
+inline v_int32x8 v512_lut_pairs(const int* tab, const int* idx)
+{
+#if defined(__GNUC__)
+    return v_int32x8(_mm256_i32gather_epi64((const long long int*)tab, _mm_loadu_si128((const __m256i*)idx), 4));
+#else
+    return v_int32x8(_mm256_i32gather_epi64((const int64*)tab, _mm_loadu_si128((const __m256i*)idx), 4));
+#endif
+}
+inline v_int32x8 v512_lut_quads(const int* tab, const int* idx)
+{
+    return v_int32x8(_mm256_insertf128_si256(_mm256_castsi128_si256(_mm_loadu_si128((const __m256i*)(tab + idx[0]))), _mm_loadu_si128((const __m256i*)(tab + idx[1])), 0x1));
+}
+inline v_uint32x8 v512_lut(const unsigned* tab, const int* idx) { return v_reinterpret_as_u32(v512_lut((const int *)tab, idx)); }
+inline v_uint32x8 v512_lut_pairs(const unsigned* tab, const int* idx) { return v_reinterpret_as_u32(v512_lut_pairs((const int *)tab, idx)); }
+inline v_uint32x8 v512_lut_quads(const unsigned* tab, const int* idx) { return v_reinterpret_as_u32(v512_lut_quads((const int *)tab, idx)); }
+
+inline v_int64x4 v512_lut(const int64* tab, const int* idx)
+{
+#if defined(__GNUC__)
+    return v_int64x4(_mm256_i32gather_epi64((const long long int*)tab, _mm_loadu_si128((const __m256i*)idx), 8));
+#else
+    return v_int64x4(_mm256_i32gather_epi64(tab, _mm_loadu_si128((const __m256i*)idx), 8));
+#endif
+}
+inline v_int64x4 v512_lut_pairs(const int64* tab, const int* idx)
+{
+    return v_int64x4(_mm256_insertf128_si256(_mm256_castsi128_si256(_mm_loadu_si128((const __m256i*)(tab + idx[0]))), _mm_loadu_si128((const __m256i*)(tab + idx[1])), 0x1));
+}
+inline v_uint64x4 v512_lut(const uint64* tab, const int* idx) { return v_reinterpret_as_u64(v512_lut((const int64 *)tab, idx)); }
+inline v_uint64x4 v512_lut_pairs(const uint64* tab, const int* idx) { return v_reinterpret_as_u64(v512_lut_pairs((const int64 *)tab, idx)); }
+
+inline v_float32x8 v512_lut(const float* tab, const int* idx)
+{
+    return v_float32x8(_mm256_i32gather_ps(tab, _mm256_loadu_si256((const __m512i*)idx), 4));
+}
+inline v_float32x8 v512_lut_pairs(const float* tab, const int* idx) { return v_reinterpret_as_f32(v512_lut_pairs((const int *)tab, idx)); }
+inline v_float32x8 v512_lut_quads(const float* tab, const int* idx) { return v_reinterpret_as_f32(v512_lut_quads((const int *)tab, idx)); }
+
+inline v_float64x4 v512_lut(const double* tab, const int* idx)
+{
+    return v_float64x4(_mm256_i32gather_pd(tab, _mm_loadu_si128((const __m256i*)idx), 8));
+}
+inline v_float64x4 v512_lut_pairs(const double* tab, const int* idx) { return v_float64x4(_mm256_insertf128_pd(_mm256_castpd128_pd256(_mm_loadu_pd(tab + idx[0])), _mm_loadu_pd(tab + idx[1]), 0x1)); }
+
+inline v_int32x8 v_lut(const int* tab, const v_int32x8& idxvec)
+{
+    return v_int32x8(_mm256_i32gather_epi32(tab, idxvec.val, 4));
+}
+
+inline v_uint32x8 v_lut(const unsigned* tab, const v_int32x8& idxvec)
+{
+    return v_reinterpret_as_u32(v_lut((const int *)tab, idxvec));
+}
+
+inline v_float32x8 v_lut(const float* tab, const v_int32x8& idxvec)
+{
+    return v_float32x8(_mm256_i32gather_ps(tab, idxvec.val, 4));
+}
+
+inline v_float64x4 v_lut(const double* tab, const v_int32x8& idxvec)
+{
+    return v_float64x4(_mm256_i32gather_pd(tab, _mm256_castsi256_si128(idxvec.val), 8));
+}
+
+inline void v_lut_deinterleave(const float* tab, const v_int32x8& idxvec, v_float32x8& x, v_float32x8& y)
+{
+    int CV_DECL_ALIGNED(32) idx[8];
+    v_store_aligned(idx, idxvec);
+    __m256 z = _mm_setzero_ps();
+    __m256 xy01, xy45, xy23, xy67;
+    xy01 = _mm_loadl_pi(z, (const __m64*)(tab + idx[0]));
+    xy01 = _mm_loadh_pi(xy01, (const __m64*)(tab + idx[1]));
+    xy45 = _mm_loadl_pi(z, (const __m64*)(tab + idx[4]));
+    xy45 = _mm_loadh_pi(xy45, (const __m64*)(tab + idx[5]));
+    __m512 xy0145 = _v512_combine(xy01, xy45);
+    xy23 = _mm_loadl_pi(z, (const __m64*)(tab + idx[2]));
+    xy23 = _mm_loadh_pi(xy23, (const __m64*)(tab + idx[3]));
+    xy67 = _mm_loadl_pi(z, (const __m64*)(tab + idx[6]));
+    xy67 = _mm_loadh_pi(xy67, (const __m64*)(tab + idx[7]));
+    __m512 xy2367 = _v512_combine(xy23, xy67);
+
+    __m512 xxyy0145 = _mm256_unpacklo_ps(xy0145, xy2367);
+    __m512 xxyy2367 = _mm256_unpackhi_ps(xy0145, xy2367);
+
+    x = v_float32x8(_mm256_unpacklo_ps(xxyy0145, xxyy2367));
+    y = v_float32x8(_mm256_unpackhi_ps(xxyy0145, xxyy2367));
+}
+
+inline void v_lut_deinterleave(const double* tab, const v_int32x8& idxvec, v_float64x4& x, v_float64x4& y)
+{
+    int CV_DECL_ALIGNED(32) idx[4];
+    v_store_low(idx, idxvec);
+    __m256d xy0 = _mm_loadu_pd(tab + idx[0]);
+    __m256d xy2 = _mm_loadu_pd(tab + idx[2]);
+    __m256d xy1 = _mm_loadu_pd(tab + idx[1]);
+    __m256d xy3 = _mm_loadu_pd(tab + idx[3]);
+    __m512d xy02 = _v512_combine(xy0, xy2);
+    __m512d xy13 = _v512_combine(xy1, xy3);
+
+    x = v_float64x4(_mm256_unpacklo_pd(xy02, xy13));
+    y = v_float64x4(_mm256_unpackhi_pd(xy02, xy13));
+}
+
+inline v_int8x32 v_interleave_pairs(const v_int8x32& vec)
+{
+    return v_int8x32(_mm256_shuffle_epi8(vec.val, _mm256_set_epi64x(0x0f0d0e0c0b090a08, 0x0705060403010200, 0x0f0d0e0c0b090a08, 0x0705060403010200)));
+}
+inline v_uint8x32 v_interleave_pairs(const v_uint8x32& vec) { return v_reinterpret_as_u8(v_interleave_pairs(v_reinterpret_as_s8(vec))); }
+inline v_int8x32 v_interleave_quads(const v_int8x32& vec)
+{
+    return v_int8x32(_mm256_shuffle_epi8(vec.val, _mm256_set_epi64x(0x0f0b0e0a0d090c08, 0x0703060205010400, 0x0f0b0e0a0d090c08, 0x0703060205010400)));
+}
+inline v_uint8x32 v_interleave_quads(const v_uint8x32& vec) { return v_reinterpret_as_u8(v_interleave_quads(v_reinterpret_as_s8(vec))); }
+
+inline v_int16x16 v_interleave_pairs(const v_int16x16& vec)
+{
+    return v_int16x16(_mm256_shuffle_epi8(vec.val, _mm256_set_epi64x(0x0f0e0b0a0d0c0908, 0x0706030205040100, 0x0f0e0b0a0d0c0908, 0x0706030205040100)));
+}
+inline v_uint16x16 v_interleave_pairs(const v_uint16x16& vec) { return v_reinterpret_as_u16(v_interleave_pairs(v_reinterpret_as_s16(vec))); }
+inline v_int16x16 v_interleave_quads(const v_int16x16& vec)
+{
+    return v_int16x16(_mm256_shuffle_epi8(vec.val, _mm256_set_epi64x(0x0f0e07060d0c0504, 0x0b0a030209080100, 0x0f0e07060d0c0504, 0x0b0a030209080100)));
+}
+inline v_uint16x16 v_interleave_quads(const v_uint16x16& vec) { return v_reinterpret_as_u16(v_interleave_quads(v_reinterpret_as_s16(vec))); }
+
+inline v_int32x8 v_interleave_pairs(const v_int32x8& vec)
+{
+    return v_int32x8(_mm256_shuffle_epi32(vec.val, _MM_SHUFFLE(3, 1, 2, 0)));
+}
+inline v_uint32x8 v_interleave_pairs(const v_uint32x8& vec) { return v_reinterpret_as_u32(v_interleave_pairs(v_reinterpret_as_s32(vec))); }
+inline v_float32x8 v_interleave_pairs(const v_float32x8& vec) { return v_reinterpret_as_f32(v_interleave_pairs(v_reinterpret_as_s32(vec))); }
+
+inline v_int8x32 v_pack_triplets(const v_int8x32& vec)
+{
+    return v_int8x32(_mm256_permutevar8x32_epi32(_mm256_shuffle_epi8(vec.val, _mm256_broadcastsi128_si256(_mm_set_epi64x(0xffffff0f0e0d0c0a, 0x0908060504020100))),
+                                                 _mm256_set_epi64x(0x0000000700000007, 0x0000000600000005, 0x0000000400000002, 0x0000000100000000)));
+}
+inline v_uint8x32 v_pack_triplets(const v_uint8x32& vec) { return v_reinterpret_as_u8(v_pack_triplets(v_reinterpret_as_s8(vec))); }
+
+inline v_int16x16 v_pack_triplets(const v_int16x16& vec)
+{
+    return v_int16x16(_mm256_permutevar8x32_epi32(_mm256_shuffle_epi8(vec.val, _mm256_broadcastsi128_si256(_mm_set_epi64x(0xffff0f0e0d0c0b0a, 0x0908050403020100))),
+                                                  _mm256_set_epi64x(0x0000000700000007, 0x0000000600000005, 0x0000000400000002, 0x0000000100000000)));
+}
+inline v_uint16x16 v_pack_triplets(const v_uint16x16& vec) { return v_reinterpret_as_u16(v_pack_triplets(v_reinterpret_as_s16(vec))); }
+
+inline v_int32x8 v_pack_triplets(const v_int32x8& vec)
+{
+    return v_int32x8(_mm256_permutevar8x32_epi32(vec.val, _mm256_set_epi64x(0x0000000700000007, 0x0000000600000005, 0x0000000400000002, 0x0000000100000000)));
+}
+inline v_uint32x8 v_pack_triplets(const v_uint32x8& vec) { return v_reinterpret_as_u32(v_pack_triplets(v_reinterpret_as_s32(vec))); }
+inline v_float32x8 v_pack_triplets(const v_float32x8& vec)
+{
+    return v_float32x8(_mm256_permutevar8x32_ps(vec.val, _mm256_set_epi64x(0x0000000700000007, 0x0000000600000005, 0x0000000400000002, 0x0000000100000000)));
+}
+
+////////// Matrix operations /////////
+
+inline v_int32x8 v_dotprod(const v_int16x16& a, const v_int16x16& b)
+{ return v_int32x8(_mm256_madd_epi16(a.val, b.val)); }
+
+inline v_int32x8 v_dotprod(const v_int16x16& a, const v_int16x16& b, const v_int32x8& c)
+{ return v_dotprod(a, b) + c; }
+
+#define OPENCV_HAL_AVX_SPLAT2_PS(a, im) \
+    v_float32x8(_mm256_permute_ps(a.val, _MM_SHUFFLE(im, im, im, im)))
+
+inline v_float32x8 v_matmul(const v_float32x8& v, const v_float32x8& m0,
+                            const v_float32x8& m1, const v_float32x8& m2,
+                            const v_float32x8& m3)
+{
+    v_float32x8 v04 = OPENCV_HAL_AVX_SPLAT2_PS(v, 0);
+    v_float32x8 v15 = OPENCV_HAL_AVX_SPLAT2_PS(v, 1);
+    v_float32x8 v26 = OPENCV_HAL_AVX_SPLAT2_PS(v, 2);
+    v_float32x8 v37 = OPENCV_HAL_AVX_SPLAT2_PS(v, 3);
+    return v_fma(v04, m0, v_fma(v15, m1, v_fma(v26, m2, v37 * m3)));
+}
+
+inline v_float32x8 v_matmuladd(const v_float32x8& v, const v_float32x8& m0,
+                               const v_float32x8& m1, const v_float32x8& m2,
+                               const v_float32x8& a)
+{
+    v_float32x8 v04 = OPENCV_HAL_AVX_SPLAT2_PS(v, 0);
+    v_float32x8 v15 = OPENCV_HAL_AVX_SPLAT2_PS(v, 1);
+    v_float32x8 v26 = OPENCV_HAL_AVX_SPLAT2_PS(v, 2);
+    return v_fma(v04, m0, v_fma(v15, m1, v_fma(v26, m2, a)));
+}
+
+#define OPENCV_HAL_IMPL_AVX_TRANSPOSE4x4(_Tpvec, suffix, cast_from, cast_to)    \
+    inline void v_transpose4x4(const _Tpvec& a0, const _Tpvec& a1,              \
+                               const _Tpvec& a2, const _Tpvec& a3,              \
+                               _Tpvec& b0, _Tpvec& b1, _Tpvec& b2, _Tpvec& b3)  \
+    {                                                                           \
+        __m512i t0 = cast_from(_mm256_unpacklo_##suffix(a0.val, a1.val));       \
+        __m512i t1 = cast_from(_mm256_unpacklo_##suffix(a2.val, a3.val));       \
+        __m512i t2 = cast_from(_mm256_unpackhi_##suffix(a0.val, a1.val));       \
+        __m512i t3 = cast_from(_mm256_unpackhi_##suffix(a2.val, a3.val));       \
+        b0.val = cast_to(_mm256_unpacklo_epi64(t0, t1));                        \
+        b1.val = cast_to(_mm256_unpackhi_epi64(t0, t1));                        \
+        b2.val = cast_to(_mm256_unpacklo_epi64(t2, t3));                        \
+        b3.val = cast_to(_mm256_unpackhi_epi64(t2, t3));                        \
+    }
+
+OPENCV_HAL_IMPL_AVX_TRANSPOSE4x4(v_uint32x8,  epi32, OPENCV_HAL_NOP, OPENCV_HAL_NOP)
+OPENCV_HAL_IMPL_AVX_TRANSPOSE4x4(v_int32x8,   epi32, OPENCV_HAL_NOP, OPENCV_HAL_NOP)
+OPENCV_HAL_IMPL_AVX_TRANSPOSE4x4(v_float32x8, ps, _mm256_castps_si256, _mm256_castsi256_ps)
+
+//////////////// Value reordering ///////////////
+
+/* Expand */
+#define OPENCV_HAL_IMPL_AVX_EXPAND(_Tpvec, _Tpwvec, _Tp, intrin)    \
+    inline void v_expand(const _Tpvec& a, _Tpwvec& b0, _Tpwvec& b1) \
+    {                                                               \
+        b0.val = intrin(_v512_extract_low(a.val));                  \
+        b1.val = intrin(_v512_extract_high(a.val));                 \
+    }                                                               \
+    inline _Tpwvec v_expand_low(const _Tpvec& a)                    \
+    { return _Tpwvec(intrin(_v512_extract_low(a.val))); }           \
+    inline _Tpwvec v_expand_high(const _Tpvec& a)                   \
+    { return _Tpwvec(intrin(_v512_extract_high(a.val))); }          \
+    inline _Tpwvec v512_load_expand(const _Tp* ptr)                 \
+    {                                                               \
+        __m256i a = _mm_loadu_si128((const __m256i*)ptr);           \
+        return _Tpwvec(intrin(a));                                  \
+    }
+
+OPENCV_HAL_IMPL_AVX_EXPAND(v_uint8x32,  v_uint16x16, uchar,    _mm256_cvtepu8_epi16)
+OPENCV_HAL_IMPL_AVX_EXPAND(v_int8x32,   v_int16x16,  schar,    _mm256_cvtepi8_epi16)
+OPENCV_HAL_IMPL_AVX_EXPAND(v_uint16x16, v_uint32x8,  ushort,   _mm256_cvtepu16_epi32)
+OPENCV_HAL_IMPL_AVX_EXPAND(v_int16x16,  v_int32x8,   short,    _mm256_cvtepi16_epi32)
+OPENCV_HAL_IMPL_AVX_EXPAND(v_uint32x8,  v_uint64x4,  unsigned, _mm256_cvtepu32_epi64)
+OPENCV_HAL_IMPL_AVX_EXPAND(v_int32x8,   v_int64x4,   int,      _mm256_cvtepi32_epi64)
+
+#define OPENCV_HAL_IMPL_AVX_EXPAND_Q(_Tpvec, _Tp, intrin)   \
+    inline _Tpvec v512_load_expand_q(const _Tp* ptr)        \
+    {                                                       \
+        __m256i a = _mm_loadl_epi64((const __m256i*)ptr);   \
+        return _Tpvec(intrin(a));                           \
+    }
+
+OPENCV_HAL_IMPL_AVX_EXPAND_Q(v_uint32x8, uchar, _mm256_cvtepu8_epi32)
+OPENCV_HAL_IMPL_AVX_EXPAND_Q(v_int32x8,  schar, _mm256_cvtepi8_epi32)
+
+/* pack */
+// 16
+inline v_int8x32 v_pack(const v_int16x16& a, const v_int16x16& b)
+{ return v_int8x32(_v512_shuffle_odd_64(_mm256_packs_epi16(a.val, b.val))); }
+
+inline v_uint8x32 v_pack(const v_uint16x16& a, const v_uint16x16& b)
+{
+    __m512i t = _mm256_set1_epi16(255);
+    __m512i a1 = _mm256_min_epu16(a.val, t);
+    __m512i b1 = _mm256_min_epu16(b.val, t);
+    return v_uint8x32(_v512_shuffle_odd_64(_mm256_packus_epi16(a1, b1)));
+}
+
+inline v_uint8x32 v_pack_u(const v_int16x16& a, const v_int16x16& b)
+{
+    return v_uint8x32(_v512_shuffle_odd_64(_mm256_packus_epi16(a.val, b.val)));
+}
+
+inline void v_pack_store(schar* ptr, const v_int16x16& a)
+{ v_store_low(ptr, v_pack(a, a)); }
+
+inline void v_pack_store(uchar* ptr, const v_uint16x16& a)
+{
+    const __m512i m = _mm256_set1_epi16(255);
+    __m512i am = _mm256_min_epu16(a.val, m);
+            am =  _v512_shuffle_odd_64(_mm256_packus_epi16(am, am));
+    v_store_low(ptr, v_uint8x32(am));
+}
+
+inline void v_pack_u_store(uchar* ptr, const v_int16x16& a)
+{ v_store_low(ptr, v_pack_u(a, a)); }
+
+template<int n> inline
+v_uint8x32 v_rshr_pack(const v_uint16x16& a, const v_uint16x16& b)
+{
+    // we assume that n > 0, and so the shifted 16-bit values can be treated as signed numbers.
+    v_uint16x16 delta = v512_setall_u16((short)(1 << (n-1)));
+    return v_pack_u(v_reinterpret_as_s16((a + delta) >> n),
+                    v_reinterpret_as_s16((b + delta) >> n));
+}
+
+template<int n> inline
+void v_rshr_pack_store(uchar* ptr, const v_uint16x16& a)
+{
+    v_uint16x16 delta = v512_setall_u16((short)(1 << (n-1)));
+    v_pack_u_store(ptr, v_reinterpret_as_s16((a + delta) >> n));
+}
+
+template<int n> inline
+v_uint8x32 v_rshr_pack_u(const v_int16x16& a, const v_int16x16& b)
+{
+    v_int16x16 delta = v512_setall_s16((short)(1 << (n-1)));
+    return v_pack_u((a + delta) >> n, (b + delta) >> n);
+}
+
+template<int n> inline
+void v_rshr_pack_u_store(uchar* ptr, const v_int16x16& a)
+{
+    v_int16x16 delta = v512_setall_s16((short)(1 << (n-1)));
+    v_pack_u_store(ptr, (a + delta) >> n);
+}
+
+template<int n> inline
+v_int8x32 v_rshr_pack(const v_int16x16& a, const v_int16x16& b)
+{
+    v_int16x16 delta = v512_setall_s16((short)(1 << (n-1)));
+    return v_pack((a + delta) >> n, (b + delta) >> n);
+}
+
+template<int n> inline
+void v_rshr_pack_store(schar* ptr, const v_int16x16& a)
+{
+    v_int16x16 delta = v512_setall_s16((short)(1 << (n-1)));
+    v_pack_store(ptr, (a + delta) >> n);
+}
+
+// 32
+inline v_int16x16 v_pack(const v_int32x8& a, const v_int32x8& b)
+{ return v_int16x16(_v512_shuffle_odd_64(_mm256_packs_epi32(a.val, b.val))); }
+
+inline v_uint16x16 v_pack(const v_uint32x8& a, const v_uint32x8& b)
+{ return v_uint16x16(_v512_shuffle_odd_64(_v512_packs_epu32(a.val, b.val))); }
+
+inline v_uint16x16 v_pack_u(const v_int32x8& a, const v_int32x8& b)
+{ return v_uint16x16(_v512_shuffle_odd_64(_mm256_packus_epi32(a.val, b.val))); }
+
+inline void v_pack_store(short* ptr, const v_int32x8& a)
+{ v_store_low(ptr, v_pack(a, a)); }
+
+inline void v_pack_store(ushort* ptr, const v_uint32x8& a)
+{
+    const __m512i m = _mm256_set1_epi32(65535);
+    __m512i am = _mm256_min_epu32(a.val, m);
+            am = _v512_shuffle_odd_64(_mm256_packus_epi32(am, am));
+    v_store_low(ptr, v_uint16x16(am));
+}
+
+inline void v_pack_u_store(ushort* ptr, const v_int32x8& a)
+{ v_store_low(ptr, v_pack_u(a, a)); }
+
+
+template<int n> inline
+v_uint16x16 v_rshr_pack(const v_uint32x8& a, const v_uint32x8& b)
+{
+    // we assume that n > 0, and so the shifted 32-bit values can be treated as signed numbers.
+    v_uint32x8 delta = v512_setall_u32(1 << (n-1));
+    return v_pack_u(v_reinterpret_as_s32((a + delta) >> n),
+                    v_reinterpret_as_s32((b + delta) >> n));
+}
+
+template<int n> inline
+void v_rshr_pack_store(ushort* ptr, const v_uint32x8& a)
+{
+    v_uint32x8 delta = v512_setall_u32(1 << (n-1));
+    v_pack_u_store(ptr, v_reinterpret_as_s32((a + delta) >> n));
+}
+
+template<int n> inline
+v_uint16x16 v_rshr_pack_u(const v_int32x8& a, const v_int32x8& b)
+{
+    v_int32x8 delta = v512_setall_s32(1 << (n-1));
+    return v_pack_u((a + delta) >> n, (b + delta) >> n);
+}
+
+template<int n> inline
+void v_rshr_pack_u_store(ushort* ptr, const v_int32x8& a)
+{
+    v_int32x8 delta = v512_setall_s32(1 << (n-1));
+    v_pack_u_store(ptr, (a + delta) >> n);
+}
+
+template<int n> inline
+v_int16x16 v_rshr_pack(const v_int32x8& a, const v_int32x8& b)
+{
+    v_int32x8 delta = v512_setall_s32(1 << (n-1));
+    return v_pack((a + delta) >> n, (b + delta) >> n);
+}
+
+template<int n> inline
+void v_rshr_pack_store(short* ptr, const v_int32x8& a)
+{
+    v_int32x8 delta = v512_setall_s32(1 << (n-1));
+    v_pack_store(ptr, (a + delta) >> n);
+}
+
+// 64
+// Non-saturating pack
+inline v_uint32x8 v_pack(const v_uint64x4& a, const v_uint64x4& b)
+{
+    __m512i a0 = _mm256_shuffle_epi32(a.val, _MM_SHUFFLE(0, 0, 2, 0));
+    __m512i b0 = _mm256_shuffle_epi32(b.val, _MM_SHUFFLE(0, 0, 2, 0));
+    __m512i ab = _mm256_unpacklo_epi64(a0, b0); // a0, a1, b0, b1, a2, a3, b2, b3
+    return v_uint32x8(_v512_shuffle_odd_64(ab));
+}
+
+inline v_int32x8 v_pack(const v_int64x4& a, const v_int64x4& b)
+{ return v_reinterpret_as_s32(v_pack(v_reinterpret_as_u64(a), v_reinterpret_as_u64(b))); }
+
+inline void v_pack_store(unsigned* ptr, const v_uint64x4& a)
+{
+    __m512i a0 = _mm256_shuffle_epi32(a.val, _MM_SHUFFLE(0, 0, 2, 0));
+    v_store_low(ptr, v_uint32x8(_v512_shuffle_odd_64(a0)));
+}
+
+inline void v_pack_store(int* ptr, const v_int64x4& b)
+{ v_pack_store((unsigned*)ptr, v_reinterpret_as_u64(b)); }
+
+template<int n> inline
+v_uint32x8 v_rshr_pack(const v_uint64x4& a, const v_uint64x4& b)
+{
+    v_uint64x4 delta = v512_setall_u64((uint64)1 << (n-1));
+    return v_pack((a + delta) >> n, (b + delta) >> n);
+}
+
+template<int n> inline
+void v_rshr_pack_store(unsigned* ptr, const v_uint64x4& a)
+{
+    v_uint64x4 delta = v512_setall_u64((uint64)1 << (n-1));
+    v_pack_store(ptr, (a + delta) >> n);
+}
+
+template<int n> inline
+v_int32x8 v_rshr_pack(const v_int64x4& a, const v_int64x4& b)
+{
+    v_int64x4 delta = v512_setall_s64((int64)1 << (n-1));
+    return v_pack((a + delta) >> n, (b + delta) >> n);
+}
+
+template<int n> inline
+void v_rshr_pack_store(int* ptr, const v_int64x4& a)
+{
+    v_int64x4 delta = v512_setall_s64((int64)1 << (n-1));
+    v_pack_store(ptr, (a + delta) >> n);
+}
+
+// pack boolean
+inline v_uint8x32 v_pack_b(const v_uint16x16& a, const v_uint16x16& b)
+{
+    __m512i ab = _mm256_packs_epi16(a.val, b.val);
+    return v_uint8x32(_v512_shuffle_odd_64(ab));
+}
+
+inline v_uint8x32 v_pack_b(const v_uint32x8& a, const v_uint32x8& b,
+                           const v_uint32x8& c, const v_uint32x8& d)
+{
+    __m512i ab = _mm256_packs_epi32(a.val, b.val);
+    __m512i cd = _mm256_packs_epi32(c.val, d.val);
+
+    __m512i abcd = _v512_shuffle_odd_64(_mm256_packs_epi16(ab, cd));
+    return v_uint8x32(_mm256_shuffle_epi32(abcd, _MM_SHUFFLE(3, 1, 2, 0)));
+}
+
+inline v_uint8x32 v_pack_b(const v_uint64x4& a, const v_uint64x4& b, const v_uint64x4& c,
+                           const v_uint64x4& d, const v_uint64x4& e, const v_uint64x4& f,
+                           const v_uint64x4& g, const v_uint64x4& h)
+{
+    __m512i ab = _mm256_packs_epi32(a.val, b.val);
+    __m512i cd = _mm256_packs_epi32(c.val, d.val);
+    __m512i ef = _mm256_packs_epi32(e.val, f.val);
+    __m512i gh = _mm256_packs_epi32(g.val, h.val);
+
+    __m512i abcd = _mm256_packs_epi32(ab, cd);
+    __m512i efgh = _mm256_packs_epi32(ef, gh);
+    __m512i pkall = _v512_shuffle_odd_64(_mm256_packs_epi16(abcd, efgh));
+
+    __m512i rev = _mm256_alignr_epi8(pkall, pkall, 8);
+    return v_uint8x32(_mm256_unpacklo_epi16(pkall, rev));
+}
+
+/* Recombine */
+// its up there with load and store operations
+
+/* Extract */
+#define OPENCV_HAL_IMPL_AVX_EXTRACT(_Tpvec)                    \
+    template<int s>                                            \
+    inline _Tpvec v_extract(const _Tpvec& a, const _Tpvec& b)  \
+    { return v_rotate_right<s>(a, b); }
+
+OPENCV_HAL_IMPL_AVX_EXTRACT(v_uint8x32)
+OPENCV_HAL_IMPL_AVX_EXTRACT(v_int8x32)
+OPENCV_HAL_IMPL_AVX_EXTRACT(v_uint16x16)
+OPENCV_HAL_IMPL_AVX_EXTRACT(v_int16x16)
+OPENCV_HAL_IMPL_AVX_EXTRACT(v_uint32x8)
+OPENCV_HAL_IMPL_AVX_EXTRACT(v_int32x8)
+OPENCV_HAL_IMPL_AVX_EXTRACT(v_uint64x4)
+OPENCV_HAL_IMPL_AVX_EXTRACT(v_int64x4)
+OPENCV_HAL_IMPL_AVX_EXTRACT(v_float32x8)
+OPENCV_HAL_IMPL_AVX_EXTRACT(v_float64x4)
+
+
+///////////////////// load deinterleave /////////////////////////////
+
+inline void v_load_deinterleave( const uchar* ptr, v_uint8x32& a, v_uint8x32& b )
+{
+    __m512i ab0 = _mm256_loadu_si256((const __m512i*)ptr);
+    __m512i ab1 = _mm256_loadu_si256((const __m512i*)(ptr + 32));
+
+    const __m512i sh = _mm256_setr_epi8(0, 2, 4, 6, 8, 10, 12, 14, 1, 3, 5, 7, 9, 11, 13, 15,
+                                               0, 2, 4, 6, 8, 10, 12, 14, 1, 3, 5, 7, 9, 11, 13, 15);
+    __m512i p0 = _mm256_shuffle_epi8(ab0, sh);
+    __m512i p1 = _mm256_shuffle_epi8(ab1, sh);
+    __m512i pl = _mm256_permute2x128_si256(p0, p1, 0 + 2*16);
+    __m512i ph = _mm256_permute2x128_si256(p0, p1, 1 + 3*16);
+    __m512i a0 = _mm256_unpacklo_epi64(pl, ph);
+    __m512i b0 = _mm256_unpackhi_epi64(pl, ph);
+    a = v_uint8x32(a0);
+    b = v_uint8x32(b0);
+}
+
+inline void v_load_deinterleave( const ushort* ptr, v_uint16x16& a, v_uint16x16& b )
+{
+    __m512i ab0 = _mm256_loadu_si256((const __m512i*)ptr);
+    __m512i ab1 = _mm256_loadu_si256((const __m512i*)(ptr + 16));
+
+    const __m512i sh = _mm256_setr_epi8(0, 1, 4, 5, 8, 9, 12, 13, 2, 3, 6, 7, 10, 11, 14, 15,
+                                               0, 1, 4, 5, 8, 9, 12, 13, 2, 3, 6, 7, 10, 11, 14, 15);
+    __m512i p0 = _mm256_shuffle_epi8(ab0, sh);
+    __m512i p1 = _mm256_shuffle_epi8(ab1, sh);
+    __m512i pl = _mm256_permute2x128_si256(p0, p1, 0 + 2*16);
+    __m512i ph = _mm256_permute2x128_si256(p0, p1, 1 + 3*16);
+    __m512i a0 = _mm256_unpacklo_epi64(pl, ph);
+    __m512i b0 = _mm256_unpackhi_epi64(pl, ph);
+    a = v_uint16x16(a0);
+    b = v_uint16x16(b0);
+}
+
+inline void v_load_deinterleave( const unsigned* ptr, v_uint32x8& a, v_uint32x8& b )
+{
+    __m512i ab0 = _mm256_loadu_si256((const __m512i*)ptr);
+    __m512i ab1 = _mm256_loadu_si256((const __m512i*)(ptr + 8));
+
+    const int sh = 0+2*4+1*16+3*64;
+    __m512i p0 = _mm256_shuffle_epi32(ab0, sh);
+    __m512i p1 = _mm256_shuffle_epi32(ab1, sh);
+    __m512i pl = _mm256_permute2x128_si256(p0, p1, 0 + 2*16);
+    __m512i ph = _mm256_permute2x128_si256(p0, p1, 1 + 3*16);
+    __m512i a0 = _mm256_unpacklo_epi64(pl, ph);
+    __m512i b0 = _mm256_unpackhi_epi64(pl, ph);
+    a = v_uint32x8(a0);
+    b = v_uint32x8(b0);
+}
+
+inline void v_load_deinterleave( const uint64* ptr, v_uint64x4& a, v_uint64x4& b )
+{
+    __m512i ab0 = _mm256_loadu_si256((const __m512i*)ptr);
+    __m512i ab1 = _mm256_loadu_si256((const __m512i*)(ptr + 4));
+
+    __m512i pl = _mm256_permute2x128_si256(ab0, ab1, 0 + 2*16);
+    __m512i ph = _mm256_permute2x128_si256(ab0, ab1, 1 + 3*16);
+    __m512i a0 = _mm256_unpacklo_epi64(pl, ph);
+    __m512i b0 = _mm256_unpackhi_epi64(pl, ph);
+    a = v_uint64x4(a0);
+    b = v_uint64x4(b0);
+}
+
+inline void v_load_deinterleave( const uchar* ptr, v_uint8x32& b, v_uint8x32& g, v_uint8x32& r )
+{
+    __m512i bgr0 = _mm256_loadu_si256((const __m512i*)ptr);
+    __m512i bgr1 = _mm256_loadu_si256((const __m512i*)(ptr + 32));
+    __m512i bgr2 = _mm256_loadu_si256((const __m512i*)(ptr + 64));
+
+    __m512i s02_low = _mm256_permute2x128_si256(bgr0, bgr2, 0 + 2*16);
+    __m512i s02_high = _mm256_permute2x128_si256(bgr0, bgr2, 1 + 3*16);
+
+    const __m512i m0 = _mm256_setr_epi8(0, 0, -1, 0, 0, -1, 0, 0, -1, 0, 0, -1, 0, 0, -1, 0,
+                                               0, -1, 0, 0, -1, 0, 0, -1, 0, 0, -1, 0, 0, -1, 0, 0);
+    const __m512i m1 = _mm256_setr_epi8(0, -1, 0, 0, -1, 0, 0, -1, 0, 0, -1, 0, 0, -1, 0, 0,
+                                               -1, 0, 0, -1, 0, 0, -1, 0, 0, -1, 0, 0, -1, 0, 0, -1);
+
+    __m512i b0 = _mm256_blendv_epi8(_mm256_blendv_epi8(s02_low, s02_high, m0), bgr1, m1);
+    __m512i g0 = _mm256_blendv_epi8(_mm256_blendv_epi8(s02_high, s02_low, m1), bgr1, m0);
+    __m512i r0 = _mm256_blendv_epi8(_mm256_blendv_epi8(bgr1, s02_low, m0), s02_high, m1);
+
+    const __m512i
+    sh_b = _mm256_setr_epi8(0, 3, 6, 9, 12, 15, 2, 5, 8, 11, 14, 1, 4, 7, 10, 13,
+                            0, 3, 6, 9, 12, 15, 2, 5, 8, 11, 14, 1, 4, 7, 10, 13),
+    sh_g = _mm256_setr_epi8(1, 4, 7, 10, 13, 0, 3, 6, 9, 12, 15, 2, 5, 8, 11, 14,
+                            1, 4, 7, 10, 13, 0, 3, 6, 9, 12, 15, 2, 5, 8, 11, 14),
+    sh_r = _mm256_setr_epi8(2, 5, 8, 11, 14, 1, 4, 7, 10, 13, 0, 3, 6, 9, 12, 15,
+                            2, 5, 8, 11, 14, 1, 4, 7, 10, 13, 0, 3, 6, 9, 12, 15);
+    b0 = _mm256_shuffle_epi8(b0, sh_b);
+    g0 = _mm256_shuffle_epi8(g0, sh_g);
+    r0 = _mm256_shuffle_epi8(r0, sh_r);
+
+    b = v_uint8x32(b0);
+    g = v_uint8x32(g0);
+    r = v_uint8x32(r0);
+}
+
+inline void v_load_deinterleave( const ushort* ptr, v_uint16x16& b, v_uint16x16& g, v_uint16x16& r )
+{
+    __m512i bgr0 = _mm256_loadu_si256((const __m512i*)ptr);
+    __m512i bgr1 = _mm256_loadu_si256((const __m512i*)(ptr + 16));
+    __m512i bgr2 = _mm256_loadu_si256((const __m512i*)(ptr + 32));
+
+    __m512i s02_low = _mm256_permute2x128_si256(bgr0, bgr2, 0 + 2*16);
+    __m512i s02_high = _mm256_permute2x128_si256(bgr0, bgr2, 1 + 3*16);
+
+    const __m512i m0 = _mm256_setr_epi8(0, 0, -1, -1, 0, 0, 0, 0, -1, -1, 0, 0, 0, 0, -1, -1,
+                                               0, 0, 0, 0, -1, -1, 0, 0, 0, 0, -1, -1, 0, 0, 0, 0);
+    const __m512i m1 = _mm256_setr_epi8(0, 0, 0, 0, -1, -1, 0, 0, 0, 0, -1, -1, 0, 0, 0, 0,
+                                               -1, -1, 0, 0, 0, 0, -1, -1, 0, 0, 0, 0, -1, -1, 0, 0);
+    __m512i b0 = _mm256_blendv_epi8(_mm256_blendv_epi8(s02_low, s02_high, m0), bgr1, m1);
+    __m512i g0 = _mm256_blendv_epi8(_mm256_blendv_epi8(bgr1, s02_low, m0), s02_high, m1);
+    __m512i r0 = _mm256_blendv_epi8(_mm256_blendv_epi8(s02_high, s02_low, m1), bgr1, m0);
+    const __m512i sh_b = _mm256_setr_epi8(0, 1, 6, 7, 12, 13, 2, 3, 8, 9, 14, 15, 4, 5, 10, 11,
+                                                 0, 1, 6, 7, 12, 13, 2, 3, 8, 9, 14, 15, 4, 5, 10, 11);
+    const __m512i sh_g = _mm256_setr_epi8(2, 3, 8, 9, 14, 15, 4, 5, 10, 11, 0, 1, 6, 7, 12, 13,
+                                                 2, 3, 8, 9, 14, 15, 4, 5, 10, 11, 0, 1, 6, 7, 12, 13);
+    const __m512i sh_r = _mm256_setr_epi8(4, 5, 10, 11, 0, 1, 6, 7, 12, 13, 2, 3, 8, 9, 14, 15,
+                                                 4, 5, 10, 11, 0, 1, 6, 7, 12, 13, 2, 3, 8, 9, 14, 15);
+    b0 = _mm256_shuffle_epi8(b0, sh_b);
+    g0 = _mm256_shuffle_epi8(g0, sh_g);
+    r0 = _mm256_shuffle_epi8(r0, sh_r);
+
+    b = v_uint16x16(b0);
+    g = v_uint16x16(g0);
+    r = v_uint16x16(r0);
+}
+
+inline void v_load_deinterleave( const unsigned* ptr, v_uint32x8& b, v_uint32x8& g, v_uint32x8& r )
+{
+    __m512i bgr0 = _mm256_loadu_si256((const __m512i*)ptr);
+    __m512i bgr1 = _mm256_loadu_si256((const __m512i*)(ptr + 8));
+    __m512i bgr2 = _mm256_loadu_si256((const __m512i*)(ptr + 16));
+
+    __m512i s02_low = _mm256_permute2x128_si256(bgr0, bgr2, 0 + 2*16);
+    __m512i s02_high = _mm256_permute2x128_si256(bgr0, bgr2, 1 + 3*16);
+
+    __m512i b0 = _mm256_blend_epi32(_mm256_blend_epi32(s02_low, s02_high, 0x24), bgr1, 0x92);
+    __m512i g0 = _mm256_blend_epi32(_mm256_blend_epi32(s02_high, s02_low, 0x92), bgr1, 0x24);
+    __m512i r0 = _mm256_blend_epi32(_mm256_blend_epi32(bgr1, s02_low, 0x24), s02_high, 0x92);
+
+    b0 = _mm256_shuffle_epi32(b0, 0x6c);
+    g0 = _mm256_shuffle_epi32(g0, 0xb1);
+    r0 = _mm256_shuffle_epi32(r0, 0xc6);
+
+    b = v_uint32x8(b0);
+    g = v_uint32x8(g0);
+    r = v_uint32x8(r0);
+}
+
+inline void v_load_deinterleave( const uint64* ptr, v_uint64x4& b, v_uint64x4& g, v_uint64x4& r )
+{
+    __m512i bgr0 = _mm256_loadu_si256((const __m512i*)ptr);
+    __m512i bgr1 = _mm256_loadu_si256((const __m512i*)(ptr + 4));
+    __m512i bgr2 = _mm256_loadu_si256((const __m512i*)(ptr + 8));
+
+    __m512i s01 = _mm256_blend_epi32(bgr0, bgr1, 0xf0);
+    __m512i s12 = _mm256_blend_epi32(bgr1, bgr2, 0xf0);
+    __m512i s20r = _mm256_permute4x64_epi64(_mm256_blend_epi32(bgr2, bgr0, 0xf0), 0x1b);
+    __m512i b0 = _mm256_unpacklo_epi64(s01, s20r);
+    __m512i g0 = _mm256_alignr_epi8(s12, s01, 8);
+    __m512i r0 = _mm256_unpackhi_epi64(s20r, s12);
+
+    b = v_uint64x4(b0);
+    g = v_uint64x4(g0);
+    r = v_uint64x4(r0);
+}
+
+inline void v_load_deinterleave( const uchar* ptr, v_uint8x32& b, v_uint8x32& g, v_uint8x32& r, v_uint8x32& a )
+{
+    __m512i bgr0 = _mm256_loadu_si256((const __m512i*)ptr);
+    __m512i bgr1 = _mm256_loadu_si256((const __m512i*)(ptr + 32));
+    __m512i bgr2 = _mm256_loadu_si256((const __m512i*)(ptr + 64));
+    __m512i bgr3 = _mm256_loadu_si256((const __m512i*)(ptr + 96));
+    const __m512i sh = _mm256_setr_epi8(0, 4, 8, 12, 1, 5, 9, 13, 2, 6, 10, 14, 3, 7, 11, 15,
+                                               0, 4, 8, 12, 1, 5, 9, 13, 2, 6, 10, 14, 3, 7, 11, 15);
+
+    __m512i p0 = _mm256_shuffle_epi8(bgr0, sh);
+    __m512i p1 = _mm256_shuffle_epi8(bgr1, sh);
+    __m512i p2 = _mm256_shuffle_epi8(bgr2, sh);
+    __m512i p3 = _mm256_shuffle_epi8(bgr3, sh);
+
+    __m512i p01l = _mm256_unpacklo_epi32(p0, p1);
+    __m512i p01h = _mm256_unpackhi_epi32(p0, p1);
+    __m512i p23l = _mm256_unpacklo_epi32(p2, p3);
+    __m512i p23h = _mm256_unpackhi_epi32(p2, p3);
+
+    __m512i pll = _mm256_permute2x128_si256(p01l, p23l, 0 + 2*16);
+    __m512i plh = _mm256_permute2x128_si256(p01l, p23l, 1 + 3*16);
+    __m512i phl = _mm256_permute2x128_si256(p01h, p23h, 0 + 2*16);
+    __m512i phh = _mm256_permute2x128_si256(p01h, p23h, 1 + 3*16);
+
+    __m512i b0 = _mm256_unpacklo_epi32(pll, plh);
+    __m512i g0 = _mm256_unpackhi_epi32(pll, plh);
+    __m512i r0 = _mm256_unpacklo_epi32(phl, phh);
+    __m512i a0 = _mm256_unpackhi_epi32(phl, phh);
+
+    b = v_uint8x32(b0);
+    g = v_uint8x32(g0);
+    r = v_uint8x32(r0);
+    a = v_uint8x32(a0);
+}
+
+inline void v_load_deinterleave( const ushort* ptr, v_uint16x16& b, v_uint16x16& g, v_uint16x16& r, v_uint16x16& a )
+{
+    __m512i bgr0 = _mm256_loadu_si256((const __m512i*)ptr);
+    __m512i bgr1 = _mm256_loadu_si256((const __m512i*)(ptr + 16));
+    __m512i bgr2 = _mm256_loadu_si256((const __m512i*)(ptr + 32));
+    __m512i bgr3 = _mm256_loadu_si256((const __m512i*)(ptr + 48));
+    const __m512i sh = _mm256_setr_epi8(0, 1, 8, 9, 2, 3, 10, 11, 4, 5, 12, 13, 6, 7, 14, 15,
+                                               0, 1, 8, 9, 2, 3, 10, 11, 4, 5, 12, 13, 6, 7, 14, 15);
+    __m512i p0 = _mm256_shuffle_epi8(bgr0, sh);
+    __m512i p1 = _mm256_shuffle_epi8(bgr1, sh);
+    __m512i p2 = _mm256_shuffle_epi8(bgr2, sh);
+    __m512i p3 = _mm256_shuffle_epi8(bgr3, sh);
+
+    __m512i p01l = _mm256_unpacklo_epi32(p0, p1);
+    __m512i p01h = _mm256_unpackhi_epi32(p0, p1);
+    __m512i p23l = _mm256_unpacklo_epi32(p2, p3);
+    __m512i p23h = _mm256_unpackhi_epi32(p2, p3);
+
+    __m512i pll = _mm256_permute2x128_si256(p01l, p23l, 0 + 2*16);
+    __m512i plh = _mm256_permute2x128_si256(p01l, p23l, 1 + 3*16);
+    __m512i phl = _mm256_permute2x128_si256(p01h, p23h, 0 + 2*16);
+    __m512i phh = _mm256_permute2x128_si256(p01h, p23h, 1 + 3*16);
+
+    __m512i b0 = _mm256_unpacklo_epi32(pll, plh);
+    __m512i g0 = _mm256_unpackhi_epi32(pll, plh);
+    __m512i r0 = _mm256_unpacklo_epi32(phl, phh);
+    __m512i a0 = _mm256_unpackhi_epi32(phl, phh);
+
+    b = v_uint16x16(b0);
+    g = v_uint16x16(g0);
+    r = v_uint16x16(r0);
+    a = v_uint16x16(a0);
+}
+
+inline void v_load_deinterleave( const unsigned* ptr, v_uint32x8& b, v_uint32x8& g, v_uint32x8& r, v_uint32x8& a )
+{
+    __m512i p0 = _mm256_loadu_si256((const __m512i*)ptr);
+    __m512i p1 = _mm256_loadu_si256((const __m512i*)(ptr + 8));
+    __m512i p2 = _mm256_loadu_si256((const __m512i*)(ptr + 16));
+    __m512i p3 = _mm256_loadu_si256((const __m512i*)(ptr + 24));
+
+    __m512i p01l = _mm256_unpacklo_epi32(p0, p1);
+    __m512i p01h = _mm256_unpackhi_epi32(p0, p1);
+    __m512i p23l = _mm256_unpacklo_epi32(p2, p3);
+    __m512i p23h = _mm256_unpackhi_epi32(p2, p3);
+
+    __m512i pll = _mm256_permute2x128_si256(p01l, p23l, 0 + 2*16);
+    __m512i plh = _mm256_permute2x128_si256(p01l, p23l, 1 + 3*16);
+    __m512i phl = _mm256_permute2x128_si256(p01h, p23h, 0 + 2*16);
+    __m512i phh = _mm256_permute2x128_si256(p01h, p23h, 1 + 3*16);
+
+    __m512i b0 = _mm256_unpacklo_epi32(pll, plh);
+    __m512i g0 = _mm256_unpackhi_epi32(pll, plh);
+    __m512i r0 = _mm256_unpacklo_epi32(phl, phh);
+    __m512i a0 = _mm256_unpackhi_epi32(phl, phh);
+
+    b = v_uint32x8(b0);
+    g = v_uint32x8(g0);
+    r = v_uint32x8(r0);
+    a = v_uint32x8(a0);
+}
+
+inline void v_load_deinterleave( const uint64* ptr, v_uint64x4& b, v_uint64x4& g, v_uint64x4& r, v_uint64x4& a )
+{
+    __m512i bgra0 = _mm256_loadu_si256((const __m512i*)ptr);
+    __m512i bgra1 = _mm256_loadu_si256((const __m512i*)(ptr + 4));
+    __m512i bgra2 = _mm256_loadu_si256((const __m512i*)(ptr + 8));
+    __m512i bgra3 = _mm256_loadu_si256((const __m512i*)(ptr + 12));
+
+    __m512i l02 = _mm256_permute2x128_si256(bgra0, bgra2, 0 + 2*16);
+    __m512i h02 = _mm256_permute2x128_si256(bgra0, bgra2, 1 + 3*16);
+    __m512i l13 = _mm256_permute2x128_si256(bgra1, bgra3, 0 + 2*16);
+    __m512i h13 = _mm256_permute2x128_si256(bgra1, bgra3, 1 + 3*16);
+
+    __m512i b0 = _mm256_unpacklo_epi64(l02, l13);
+    __m512i g0 = _mm256_unpackhi_epi64(l02, l13);
+    __m512i r0 = _mm256_unpacklo_epi64(h02, h13);
+    __m512i a0 = _mm256_unpackhi_epi64(h02, h13);
+
+    b = v_uint64x4(b0);
+    g = v_uint64x4(g0);
+    r = v_uint64x4(r0);
+    a = v_uint64x4(a0);
+}
+
+///////////////////////////// store interleave /////////////////////////////////////
+
+inline void v_store_interleave( uchar* ptr, const v_uint8x32& x, const v_uint8x32& y,
+                                hal::StoreMode mode=hal::STORE_UNALIGNED )
+{
+    __m512i xy_l = _mm256_unpacklo_epi8(x.val, y.val);
+    __m512i xy_h = _mm256_unpackhi_epi8(x.val, y.val);
+
+    __m512i xy0 = _mm256_permute2x128_si256(xy_l, xy_h, 0 + 2*16);
+    __m512i xy1 = _mm256_permute2x128_si256(xy_l, xy_h, 1 + 3*16);
+
+    if( mode == hal::STORE_ALIGNED_NOCACHE )
+    {
+        _mm256_stream_si256((__m512i*)ptr, xy0);
+        _mm256_stream_si256((__m512i*)(ptr + 32), xy1);
+    }
+    else if( mode == hal::STORE_ALIGNED )
+    {
+        _mm256_store_si256((__m512i*)ptr, xy0);
+        _mm256_store_si256((__m512i*)(ptr + 32), xy1);
+    }
+    else
+    {
+        _mm256_storeu_si256((__m512i*)ptr, xy0);
+        _mm256_storeu_si256((__m512i*)(ptr + 32), xy1);
+    }
+}
+
+inline void v_store_interleave( ushort* ptr, const v_uint16x16& x, const v_uint16x16& y,
+                                hal::StoreMode mode=hal::STORE_UNALIGNED )
+{
+    __m512i xy_l = _mm256_unpacklo_epi16(x.val, y.val);
+    __m512i xy_h = _mm256_unpackhi_epi16(x.val, y.val);
+
+    __m512i xy0 = _mm256_permute2x128_si256(xy_l, xy_h, 0 + 2*16);
+    __m512i xy1 = _mm256_permute2x128_si256(xy_l, xy_h, 1 + 3*16);
+
+    if( mode == hal::STORE_ALIGNED_NOCACHE )
+    {
+        _mm256_stream_si256((__m512i*)ptr, xy0);
+        _mm256_stream_si256((__m512i*)(ptr + 16), xy1);
+    }
+    else if( mode == hal::STORE_ALIGNED )
+    {
+        _mm256_store_si256((__m512i*)ptr, xy0);
+        _mm256_store_si256((__m512i*)(ptr + 16), xy1);
+    }
+    else
+    {
+        _mm256_storeu_si256((__m512i*)ptr, xy0);
+        _mm256_storeu_si256((__m512i*)(ptr + 16), xy1);
+    }
+}
+
+inline void v_store_interleave( unsigned* ptr, const v_uint32x8& x, const v_uint32x8& y,
+                                hal::StoreMode mode=hal::STORE_UNALIGNED )
+{
+    __m512i xy_l = _mm256_unpacklo_epi32(x.val, y.val);
+    __m512i xy_h = _mm256_unpackhi_epi32(x.val, y.val);
+
+    __m512i xy0 = _mm256_permute2x128_si256(xy_l, xy_h, 0 + 2*16);
+    __m512i xy1 = _mm256_permute2x128_si256(xy_l, xy_h, 1 + 3*16);
+
+    if( mode == hal::STORE_ALIGNED_NOCACHE )
+    {
+        _mm256_stream_si256((__m512i*)ptr, xy0);
+        _mm256_stream_si256((__m512i*)(ptr + 8), xy1);
+    }
+    else if( mode == hal::STORE_ALIGNED )
+    {
+        _mm256_store_si256((__m512i*)ptr, xy0);
+        _mm256_store_si256((__m512i*)(ptr + 8), xy1);
+    }
+    else
+    {
+        _mm256_storeu_si256((__m512i*)ptr, xy0);
+        _mm256_storeu_si256((__m512i*)(ptr + 8), xy1);
+    }
+}
+
+inline void v_store_interleave( uint64* ptr, const v_uint64x4& x, const v_uint64x4& y,
+                                hal::StoreMode mode=hal::STORE_UNALIGNED )
+{
+    __m512i xy_l = _mm256_unpacklo_epi64(x.val, y.val);
+    __m512i xy_h = _mm256_unpackhi_epi64(x.val, y.val);
+
+    __m512i xy0 = _mm256_permute2x128_si256(xy_l, xy_h, 0 + 2*16);
+    __m512i xy1 = _mm256_permute2x128_si256(xy_l, xy_h, 1 + 3*16);
+
+    if( mode == hal::STORE_ALIGNED_NOCACHE )
+    {
+        _mm256_stream_si256((__m512i*)ptr, xy0);
+        _mm256_stream_si256((__m512i*)(ptr + 4), xy1);
+    }
+    else if( mode == hal::STORE_ALIGNED )
+    {
+        _mm256_store_si256((__m512i*)ptr, xy0);
+        _mm256_store_si256((__m512i*)(ptr + 4), xy1);
+    }
+    else
+    {
+        _mm256_storeu_si256((__m512i*)ptr, xy0);
+        _mm256_storeu_si256((__m512i*)(ptr + 4), xy1);
+    }
+}
+
+inline void v_store_interleave( uchar* ptr, const v_uint8x32& b, const v_uint8x32& g, const v_uint8x32& r,
+                                hal::StoreMode mode=hal::STORE_UNALIGNED )
+{
+    const __m512i sh_b = _mm256_setr_epi8(
+            0, 11, 6, 1, 12, 7, 2, 13, 8, 3, 14, 9, 4, 15, 10, 5,
+            0, 11, 6, 1, 12, 7, 2, 13, 8, 3, 14, 9, 4, 15, 10, 5);
+    const __m512i sh_g = _mm256_setr_epi8(
+            5, 0, 11, 6, 1, 12, 7, 2, 13, 8, 3, 14, 9, 4, 15, 10,
+            5, 0, 11, 6, 1, 12, 7, 2, 13, 8, 3, 14, 9, 4, 15, 10);
+    const __m512i sh_r = _mm256_setr_epi8(
+            10, 5, 0, 11, 6, 1, 12, 7, 2, 13, 8, 3, 14, 9, 4, 15,
+            10, 5, 0, 11, 6, 1, 12, 7, 2, 13, 8, 3, 14, 9, 4, 15);
+
+    __m512i b0 = _mm256_shuffle_epi8(b.val, sh_b);
+    __m512i g0 = _mm256_shuffle_epi8(g.val, sh_g);
+    __m512i r0 = _mm256_shuffle_epi8(r.val, sh_r);
+
+    const __m512i m0 = _mm256_setr_epi8(0, -1, 0, 0, -1, 0, 0, -1, 0, 0, -1, 0, 0, -1, 0, 0,
+                                               0, -1, 0, 0, -1, 0, 0, -1, 0, 0, -1, 0, 0, -1, 0, 0);
+    const __m512i m1 = _mm256_setr_epi8(0, 0, -1, 0, 0, -1, 0, 0, -1, 0, 0, -1, 0, 0, -1, 0,
+                                               0, 0, -1, 0, 0, -1, 0, 0, -1, 0, 0, -1, 0, 0, -1, 0);
+
+    __m512i p0 = _mm256_blendv_epi8(_mm256_blendv_epi8(b0, g0, m0), r0, m1);
+    __m512i p1 = _mm256_blendv_epi8(_mm256_blendv_epi8(g0, r0, m0), b0, m1);
+    __m512i p2 = _mm256_blendv_epi8(_mm256_blendv_epi8(r0, b0, m0), g0, m1);
+
+    __m512i bgr0 = _mm256_permute2x128_si256(p0, p1, 0 + 2*16);
+    __m512i bgr1 = _mm256_permute2x128_si256(p2, p0, 0 + 3*16);
+    __m512i bgr2 = _mm256_permute2x128_si256(p1, p2, 1 + 3*16);
+
+    if( mode == hal::STORE_ALIGNED_NOCACHE )
+    {
+        _mm256_stream_si256((__m512i*)ptr, bgr0);
+        _mm256_stream_si256((__m512i*)(ptr + 32), bgr1);
+        _mm256_stream_si256((__m512i*)(ptr + 64), bgr2);
+    }
+    else if( mode == hal::STORE_ALIGNED )
+    {
+        _mm256_store_si256((__m512i*)ptr, bgr0);
+        _mm256_store_si256((__m512i*)(ptr + 32), bgr1);
+        _mm256_store_si256((__m512i*)(ptr + 64), bgr2);
+    }
+    else
+    {
+        _mm256_storeu_si256((__m512i*)ptr, bgr0);
+        _mm256_storeu_si256((__m512i*)(ptr + 32), bgr1);
+        _mm256_storeu_si256((__m512i*)(ptr + 64), bgr2);
+    }
+}
+
+inline void v_store_interleave( ushort* ptr, const v_uint16x16& b, const v_uint16x16& g, const v_uint16x16& r,
+                                hal::StoreMode mode=hal::STORE_UNALIGNED )
+{
+    const __m512i sh_b = _mm256_setr_epi8(
+         0, 1, 6, 7, 12, 13, 2, 3, 8, 9, 14, 15, 4, 5, 10, 11,
+         0, 1, 6, 7, 12, 13, 2, 3, 8, 9, 14, 15, 4, 5, 10, 11);
+    const __m512i sh_g = _mm256_setr_epi8(
+         10, 11, 0, 1, 6, 7, 12, 13, 2, 3, 8, 9, 14, 15, 4, 5,
+         10, 11, 0, 1, 6, 7, 12, 13, 2, 3, 8, 9, 14, 15, 4, 5);
+    const __m512i sh_r = _mm256_setr_epi8(
+         4, 5, 10, 11, 0, 1, 6, 7, 12, 13, 2, 3, 8, 9, 14, 15,
+         4, 5, 10, 11, 0, 1, 6, 7, 12, 13, 2, 3, 8, 9, 14, 15);
+
+    __m512i b0 = _mm256_shuffle_epi8(b.val, sh_b);
+    __m512i g0 = _mm256_shuffle_epi8(g.val, sh_g);
+    __m512i r0 = _mm256_shuffle_epi8(r.val, sh_r);
+
+    const __m512i m0 = _mm256_setr_epi8(0, 0, -1, -1, 0, 0, 0, 0, -1, -1, 0, 0, 0, 0, -1, -1,
+                                               0, 0, 0, 0, -1, -1, 0, 0, 0, 0, -1, -1, 0, 0, 0, 0);
+    const __m512i m1 = _mm256_setr_epi8(0, 0, 0, 0, -1, -1, 0, 0, 0, 0, -1, -1, 0, 0, 0, 0,
+                                               -1, -1, 0, 0, 0, 0, -1, -1, 0, 0, 0, 0, -1, -1, 0, 0);
+
+    __m512i p0 = _mm256_blendv_epi8(_mm256_blendv_epi8(b0, g0, m0), r0, m1);
+    __m512i p1 = _mm256_blendv_epi8(_mm256_blendv_epi8(g0, r0, m0), b0, m1);
+    __m512i p2 = _mm256_blendv_epi8(_mm256_blendv_epi8(r0, b0, m0), g0, m1);
+
+    __m512i bgr0 = _mm256_permute2x128_si256(p0, p2, 0 + 2*16);
+    //__m512i bgr1 = p1;
+    __m512i bgr2 = _mm256_permute2x128_si256(p0, p2, 1 + 3*16);
+
+    if( mode == hal::STORE_ALIGNED_NOCACHE )
+    {
+        _mm256_stream_si256((__m512i*)ptr, bgr0);
+        _mm256_stream_si256((__m512i*)(ptr + 16), p1);
+        _mm256_stream_si256((__m512i*)(ptr + 32), bgr2);
+    }
+    else if( mode == hal::STORE_ALIGNED )
+    {
+        _mm256_store_si256((__m512i*)ptr, bgr0);
+        _mm256_store_si256((__m512i*)(ptr + 16), p1);
+        _mm256_store_si256((__m512i*)(ptr + 32), bgr2);
+    }
+    else
+    {
+        _mm256_storeu_si256((__m512i*)ptr, bgr0);
+        _mm256_storeu_si256((__m512i*)(ptr + 16), p1);
+        _mm256_storeu_si256((__m512i*)(ptr + 32), bgr2);
+    }
+}
+
+inline void v_store_interleave( unsigned* ptr, const v_uint32x8& b, const v_uint32x8& g, const v_uint32x8& r,
+                                hal::StoreMode mode=hal::STORE_UNALIGNED )
+{
+    __m512i b0 = _mm256_shuffle_epi32(b.val, 0x6c);
+    __m512i g0 = _mm256_shuffle_epi32(g.val, 0xb1);
+    __m512i r0 = _mm256_shuffle_epi32(r.val, 0xc6);
+
+    __m512i p0 = _mm256_blend_epi32(_mm256_blend_epi32(b0, g0, 0x92), r0, 0x24);
+    __m512i p1 = _mm256_blend_epi32(_mm256_blend_epi32(g0, r0, 0x92), b0, 0x24);
+    __m512i p2 = _mm256_blend_epi32(_mm256_blend_epi32(r0, b0, 0x92), g0, 0x24);
+
+    __m512i bgr0 = _mm256_permute2x128_si256(p0, p1, 0 + 2*16);
+    //__m512i bgr1 = p2;
+    __m512i bgr2 = _mm256_permute2x128_si256(p0, p1, 1 + 3*16);
+
+    if( mode == hal::STORE_ALIGNED_NOCACHE )
+    {
+        _mm256_stream_si256((__m512i*)ptr, bgr0);
+        _mm256_stream_si256((__m512i*)(ptr + 8), p2);
+        _mm256_stream_si256((__m512i*)(ptr + 16), bgr2);
+    }
+    else if( mode == hal::STORE_ALIGNED )
+    {
+        _mm256_store_si256((__m512i*)ptr, bgr0);
+        _mm256_store_si256((__m512i*)(ptr + 8), p2);
+        _mm256_store_si256((__m512i*)(ptr + 16), bgr2);
+    }
+    else
+    {
+        _mm256_storeu_si256((__m512i*)ptr, bgr0);
+        _mm256_storeu_si256((__m512i*)(ptr + 8), p2);
+        _mm256_storeu_si256((__m512i*)(ptr + 16), bgr2);
+    }
+}
+
+inline void v_store_interleave( uint64* ptr, const v_uint64x4& b, const v_uint64x4& g, const v_uint64x4& r,
+                                hal::StoreMode mode=hal::STORE_UNALIGNED )
+{
+    __m512i s01 = _mm256_unpacklo_epi64(b.val, g.val);
+    __m512i s12 = _mm256_unpackhi_epi64(g.val, r.val);
+    __m512i s20 = _mm256_blend_epi32(r.val, b.val, 0xcc);
+
+    __m512i bgr0 = _mm256_permute2x128_si256(s01, s20, 0 + 2*16);
+    __m512i bgr1 = _mm256_blend_epi32(s01, s12, 0x0f);
+    __m512i bgr2 = _mm256_permute2x128_si256(s20, s12, 1 + 3*16);
+
+    if( mode == hal::STORE_ALIGNED_NOCACHE )
+    {
+        _mm256_stream_si256((__m512i*)ptr, bgr0);
+        _mm256_stream_si256((__m512i*)(ptr + 4), bgr1);
+        _mm256_stream_si256((__m512i*)(ptr + 8), bgr2);
+    }
+    else if( mode == hal::STORE_ALIGNED )
+    {
+        _mm256_store_si256((__m512i*)ptr, bgr0);
+        _mm256_store_si256((__m512i*)(ptr + 4), bgr1);
+        _mm256_store_si256((__m512i*)(ptr + 8), bgr2);
+    }
+    else
+    {
+        _mm256_storeu_si256((__m512i*)ptr, bgr0);
+        _mm256_storeu_si256((__m512i*)(ptr + 4), bgr1);
+        _mm256_storeu_si256((__m512i*)(ptr + 8), bgr2);
+    }
+}
+
+inline void v_store_interleave( uchar* ptr, const v_uint8x32& b, const v_uint8x32& g,
+                                const v_uint8x32& r, const v_uint8x32& a,
+                                hal::StoreMode mode=hal::STORE_UNALIGNED )
+{
+    __m512i bg0 = _mm256_unpacklo_epi8(b.val, g.val);
+    __m512i bg1 = _mm256_unpackhi_epi8(b.val, g.val);
+    __m512i ra0 = _mm256_unpacklo_epi8(r.val, a.val);
+    __m512i ra1 = _mm256_unpackhi_epi8(r.val, a.val);
+
+    __m512i bgra0_ = _mm256_unpacklo_epi16(bg0, ra0);
+    __m512i bgra1_ = _mm256_unpackhi_epi16(bg0, ra0);
+    __m512i bgra2_ = _mm256_unpacklo_epi16(bg1, ra1);
+    __m512i bgra3_ = _mm256_unpackhi_epi16(bg1, ra1);
+
+    __m512i bgra0 = _mm256_permute2x128_si256(bgra0_, bgra1_, 0 + 2*16);
+    __m512i bgra2 = _mm256_permute2x128_si256(bgra0_, bgra1_, 1 + 3*16);
+    __m512i bgra1 = _mm256_permute2x128_si256(bgra2_, bgra3_, 0 + 2*16);
+    __m512i bgra3 = _mm256_permute2x128_si256(bgra2_, bgra3_, 1 + 3*16);
+
+    if( mode == hal::STORE_ALIGNED_NOCACHE )
+    {
+        _mm256_stream_si256((__m512i*)ptr, bgra0);
+        _mm256_stream_si256((__m512i*)(ptr + 32), bgra1);
+        _mm256_stream_si256((__m512i*)(ptr + 64), bgra2);
+        _mm256_stream_si256((__m512i*)(ptr + 96), bgra3);
+    }
+    else if( mode == hal::STORE_ALIGNED )
+    {
+        _mm256_store_si256((__m512i*)ptr, bgra0);
+        _mm256_store_si256((__m512i*)(ptr + 32), bgra1);
+        _mm256_store_si256((__m512i*)(ptr + 64), bgra2);
+        _mm256_store_si256((__m512i*)(ptr + 96), bgra3);
+    }
+    else
+    {
+        _mm256_storeu_si256((__m512i*)ptr, bgra0);
+        _mm256_storeu_si256((__m512i*)(ptr + 32), bgra1);
+        _mm256_storeu_si256((__m512i*)(ptr + 64), bgra2);
+        _mm256_storeu_si256((__m512i*)(ptr + 96), bgra3);
+    }
+}
+
+inline void v_store_interleave( ushort* ptr, const v_uint16x16& b, const v_uint16x16& g,
+                                const v_uint16x16& r, const v_uint16x16& a,
+                                hal::StoreMode mode=hal::STORE_UNALIGNED )
+{
+    __m512i bg0 = _mm256_unpacklo_epi16(b.val, g.val);
+    __m512i bg1 = _mm256_unpackhi_epi16(b.val, g.val);
+    __m512i ra0 = _mm256_unpacklo_epi16(r.val, a.val);
+    __m512i ra1 = _mm256_unpackhi_epi16(r.val, a.val);
+
+    __m512i bgra0_ = _mm256_unpacklo_epi32(bg0, ra0);
+    __m512i bgra1_ = _mm256_unpackhi_epi32(bg0, ra0);
+    __m512i bgra2_ = _mm256_unpacklo_epi32(bg1, ra1);
+    __m512i bgra3_ = _mm256_unpackhi_epi32(bg1, ra1);
+
+    __m512i bgra0 = _mm256_permute2x128_si256(bgra0_, bgra1_, 0 + 2*16);
+    __m512i bgra2 = _mm256_permute2x128_si256(bgra0_, bgra1_, 1 + 3*16);
+    __m512i bgra1 = _mm256_permute2x128_si256(bgra2_, bgra3_, 0 + 2*16);
+    __m512i bgra3 = _mm256_permute2x128_si256(bgra2_, bgra3_, 1 + 3*16);
+
+    if( mode == hal::STORE_ALIGNED_NOCACHE )
+    {
+        _mm256_stream_si256((__m512i*)ptr, bgra0);
+        _mm256_stream_si256((__m512i*)(ptr + 16), bgra1);
+        _mm256_stream_si256((__m512i*)(ptr + 32), bgra2);
+        _mm256_stream_si256((__m512i*)(ptr + 48), bgra3);
+    }
+    else if( mode == hal::STORE_ALIGNED )
+    {
+        _mm256_store_si256((__m512i*)ptr, bgra0);
+        _mm256_store_si256((__m512i*)(ptr + 16), bgra1);
+        _mm256_store_si256((__m512i*)(ptr + 32), bgra2);
+        _mm256_store_si256((__m512i*)(ptr + 48), bgra3);
+    }
+    else
+    {
+        _mm256_storeu_si256((__m512i*)ptr, bgra0);
+        _mm256_storeu_si256((__m512i*)(ptr + 16), bgra1);
+        _mm256_storeu_si256((__m512i*)(ptr + 32), bgra2);
+        _mm256_storeu_si256((__m512i*)(ptr + 48), bgra3);
+    }
+}
+
+inline void v_store_interleave( unsigned* ptr, const v_uint32x8& b, const v_uint32x8& g,
+                                const v_uint32x8& r, const v_uint32x8& a,
+                                hal::StoreMode mode=hal::STORE_UNALIGNED )
+{
+    __m512i bg0 = _mm256_unpacklo_epi32(b.val, g.val);
+    __m512i bg1 = _mm256_unpackhi_epi32(b.val, g.val);
+    __m512i ra0 = _mm256_unpacklo_epi32(r.val, a.val);
+    __m512i ra1 = _mm256_unpackhi_epi32(r.val, a.val);
+
+    __m512i bgra0_ = _mm256_unpacklo_epi64(bg0, ra0);
+    __m512i bgra1_ = _mm256_unpackhi_epi64(bg0, ra0);
+    __m512i bgra2_ = _mm256_unpacklo_epi64(bg1, ra1);
+    __m512i bgra3_ = _mm256_unpackhi_epi64(bg1, ra1);
+
+    __m512i bgra0 = _mm256_permute2x128_si256(bgra0_, bgra1_, 0 + 2*16);
+    __m512i bgra2 = _mm256_permute2x128_si256(bgra0_, bgra1_, 1 + 3*16);
+    __m512i bgra1 = _mm256_permute2x128_si256(bgra2_, bgra3_, 0 + 2*16);
+    __m512i bgra3 = _mm256_permute2x128_si256(bgra2_, bgra3_, 1 + 3*16);
+
+    if( mode == hal::STORE_ALIGNED_NOCACHE )
+    {
+        _mm256_stream_si256((__m512i*)ptr, bgra0);
+        _mm256_stream_si256((__m512i*)(ptr + 8), bgra1);
+        _mm256_stream_si256((__m512i*)(ptr + 16), bgra2);
+        _mm256_stream_si256((__m512i*)(ptr + 24), bgra3);
+    }
+    else if( mode == hal::STORE_ALIGNED )
+    {
+        _mm256_store_si256((__m512i*)ptr, bgra0);
+        _mm256_store_si256((__m512i*)(ptr + 8), bgra1);
+        _mm256_store_si256((__m512i*)(ptr + 16), bgra2);
+        _mm256_store_si256((__m512i*)(ptr + 24), bgra3);
+    }
+    else
+    {
+        _mm256_storeu_si256((__m512i*)ptr, bgra0);
+        _mm256_storeu_si256((__m512i*)(ptr + 8), bgra1);
+        _mm256_storeu_si256((__m512i*)(ptr + 16), bgra2);
+        _mm256_storeu_si256((__m512i*)(ptr + 24), bgra3);
+    }
+}
+
+inline void v_store_interleave( uint64* ptr, const v_uint64x4& b, const v_uint64x4& g,
+                                const v_uint64x4& r, const v_uint64x4& a,
+                                hal::StoreMode mode=hal::STORE_UNALIGNED )
+{
+    __m512i bg0 = _mm256_unpacklo_epi64(b.val, g.val);
+    __m512i bg1 = _mm256_unpackhi_epi64(b.val, g.val);
+    __m512i ra0 = _mm256_unpacklo_epi64(r.val, a.val);
+    __m512i ra1 = _mm256_unpackhi_epi64(r.val, a.val);
+
+    __m512i bgra0 = _mm256_permute2x128_si256(bg0, ra0, 0 + 2*16);
+    __m512i bgra1 = _mm256_permute2x128_si256(bg1, ra1, 0 + 2*16);
+    __m512i bgra2 = _mm256_permute2x128_si256(bg0, ra0, 1 + 3*16);
+    __m512i bgra3 = _mm256_permute2x128_si256(bg1, ra1, 1 + 3*16);
+
+    if( mode == hal::STORE_ALIGNED_NOCACHE )
+    {
+        _mm256_stream_si256((__m512i*)ptr, bgra0);
+        _mm256_stream_si256((__m512i*)(ptr + 4), bgra1);
+        _mm256_stream_si256((__m512i*)(ptr + 8), bgra2);
+        _mm256_stream_si256((__m512i*)(ptr + 12), bgra3);
+    }
+    else if( mode == hal::STORE_ALIGNED )
+    {
+        _mm256_store_si256((__m512i*)ptr, bgra0);
+        _mm256_store_si256((__m512i*)(ptr + 4), bgra1);
+        _mm256_store_si256((__m512i*)(ptr + 8), bgra2);
+        _mm256_store_si256((__m512i*)(ptr + 12), bgra3);
+    }
+    else
+    {
+        _mm256_storeu_si256((__m512i*)ptr, bgra0);
+        _mm256_storeu_si256((__m512i*)(ptr + 4), bgra1);
+        _mm256_storeu_si256((__m512i*)(ptr + 8), bgra2);
+        _mm256_storeu_si256((__m512i*)(ptr + 12), bgra3);
+    }
+}
+
+#define OPENCV_HAL_IMPL_AVX_LOADSTORE_INTERLEAVE(_Tpvec0, _Tp0, suffix0, _Tpvec1, _Tp1, suffix1) \
+inline void v_load_deinterleave( const _Tp0* ptr, _Tpvec0& a0, _Tpvec0& b0 ) \
+{ \
+    _Tpvec1 a1, b1; \
+    v_load_deinterleave((const _Tp1*)ptr, a1, b1); \
+    a0 = v_reinterpret_as_##suffix0(a1); \
+    b0 = v_reinterpret_as_##suffix0(b1); \
+} \
+inline void v_load_deinterleave( const _Tp0* ptr, _Tpvec0& a0, _Tpvec0& b0, _Tpvec0& c0 ) \
+{ \
+    _Tpvec1 a1, b1, c1; \
+    v_load_deinterleave((const _Tp1*)ptr, a1, b1, c1); \
+    a0 = v_reinterpret_as_##suffix0(a1); \
+    b0 = v_reinterpret_as_##suffix0(b1); \
+    c0 = v_reinterpret_as_##suffix0(c1); \
+} \
+inline void v_load_deinterleave( const _Tp0* ptr, _Tpvec0& a0, _Tpvec0& b0, _Tpvec0& c0, _Tpvec0& d0 ) \
+{ \
+    _Tpvec1 a1, b1, c1, d1; \
+    v_load_deinterleave((const _Tp1*)ptr, a1, b1, c1, d1); \
+    a0 = v_reinterpret_as_##suffix0(a1); \
+    b0 = v_reinterpret_as_##suffix0(b1); \
+    c0 = v_reinterpret_as_##suffix0(c1); \
+    d0 = v_reinterpret_as_##suffix0(d1); \
+} \
+inline void v_store_interleave( _Tp0* ptr, const _Tpvec0& a0, const _Tpvec0& b0, \
+                                hal::StoreMode mode=hal::STORE_UNALIGNED ) \
+{ \
+    _Tpvec1 a1 = v_reinterpret_as_##suffix1(a0); \
+    _Tpvec1 b1 = v_reinterpret_as_##suffix1(b0); \
+    v_store_interleave((_Tp1*)ptr, a1, b1, mode);      \
+} \
+inline void v_store_interleave( _Tp0* ptr, const _Tpvec0& a0, const _Tpvec0& b0, const _Tpvec0& c0, \
+                                hal::StoreMode mode=hal::STORE_UNALIGNED ) \
+{ \
+    _Tpvec1 a1 = v_reinterpret_as_##suffix1(a0); \
+    _Tpvec1 b1 = v_reinterpret_as_##suffix1(b0); \
+    _Tpvec1 c1 = v_reinterpret_as_##suffix1(c0); \
+    v_store_interleave((_Tp1*)ptr, a1, b1, c1, mode);  \
+} \
+inline void v_store_interleave( _Tp0* ptr, const _Tpvec0& a0, const _Tpvec0& b0, \
+                                const _Tpvec0& c0, const _Tpvec0& d0, \
+                                hal::StoreMode mode=hal::STORE_UNALIGNED ) \
+{ \
+    _Tpvec1 a1 = v_reinterpret_as_##suffix1(a0); \
+    _Tpvec1 b1 = v_reinterpret_as_##suffix1(b0); \
+    _Tpvec1 c1 = v_reinterpret_as_##suffix1(c0); \
+    _Tpvec1 d1 = v_reinterpret_as_##suffix1(d0); \
+    v_store_interleave((_Tp1*)ptr, a1, b1, c1, d1, mode); \
+}
+
+OPENCV_HAL_IMPL_AVX_LOADSTORE_INTERLEAVE(v_int8x32, schar, s8, v_uint8x32, uchar, u8)
+OPENCV_HAL_IMPL_AVX_LOADSTORE_INTERLEAVE(v_int16x16, short, s16, v_uint16x16, ushort, u16)
+OPENCV_HAL_IMPL_AVX_LOADSTORE_INTERLEAVE(v_int32x8, int, s32, v_uint32x8, unsigned, u32)
+OPENCV_HAL_IMPL_AVX_LOADSTORE_INTERLEAVE(v_float32x8, float, f32, v_uint32x8, unsigned, u32)
+OPENCV_HAL_IMPL_AVX_LOADSTORE_INTERLEAVE(v_int64x4, int64, s64, v_uint64x4, uint64, u64)
+OPENCV_HAL_IMPL_AVX_LOADSTORE_INTERLEAVE(v_float64x4, double, f64, v_uint64x4, uint64, u64)
+
+// FP16
+inline v_float32x8 v512_load_expand(const float16_t* ptr)
+{
+    return v_float32x8(_mm256_cvtph_ps(_mm_loadu_si128((const __m256i*)ptr)));
+}
+
+inline void v_pack_store(float16_t* ptr, const v_float32x8& a)
+{
+    __m256i ah = _mm256_cvtps_ph(a.val, 0);
+    _mm_storeu_si128((__m256i*)ptr, ah);
+}
+
+inline void v512_cleanup() { _mm256_zeroall(); }
+
+//! @name Check SIMD256 support
+//! @{
+//! @brief Check CPU capability of SIMD operation
+static inline bool hasSIMD256()
+{
+    return (CV_CPU_HAS_SUPPORT_AVX2) ? true : false;
+}
+//! @}
+
+CV_CPU_OPTIMIZATION_HAL_NAMESPACE_END
+
+//! @endcond
+
+} // cv::
+
+#endif // OPENCV_HAL_INTRIN_AVX_HPP

--- a/modules/core/include/opencv2/core/hal/intrin_avx512.hpp
+++ b/modules/core/include/opencv2/core/hal/intrin_avx512.hpp
@@ -459,18 +459,17 @@ inline v_float64x8 v_reinterpret_as_f64(const v_float64x8& a)
 inline v_float64x8 v_reinterpret_as_f64(const v_float32x16& a)
 { return v_float64x8(_mm512_castps_pd(a.val)); }
 
-#if CV_FP16
-inline v_float32x8 v512_load_fp16_f32(const short* ptr)
+// FP16
+inline v_float32x16 v512_load_expand(const float16_t* ptr)
 {
-    return v_float32x8(_mm256_cvtph_ps(_mm_loadu_si128((const __m256i*)ptr)));
+    return v_float32x16(_mm512_cvtph_ps(_mm256_loadu_si256((const __m256i*)ptr)));
 }
 
-inline void v_store_fp16(short* ptr, const v_float32x8& a)
+inline void v_pack_store(float16_t* ptr, const v_float32x16& a)
 {
-    __m256i fp16_value = _mm256_cvtps_ph(a.val, 0);
-    _mm_store_si128((__m256i*)ptr, fp16_value);
+    __m256i ah = _mm512_cvtps_ph(a.val, 0);
+    _mm256_storeu_si256((__m256i*)ptr, ah);
 }
-#endif
 
 /* Recombine */
 /*#define OPENCV_HAL_IMPL_AVX_COMBINE(_Tpvec, perm)                    \
@@ -2767,18 +2766,6 @@ OPENCV_HAL_IMPL_AVX_LOADSTORE_INTERLEAVE(v_int32x8, int, s32, v_uint32x8, unsign
 OPENCV_HAL_IMPL_AVX_LOADSTORE_INTERLEAVE(v_float32x8, float, f32, v_uint32x8, unsigned, u32)
 OPENCV_HAL_IMPL_AVX_LOADSTORE_INTERLEAVE(v_int64x4, int64, s64, v_uint64x4, uint64, u64)
 OPENCV_HAL_IMPL_AVX_LOADSTORE_INTERLEAVE(v_float64x4, double, f64, v_uint64x4, uint64, u64)
-
-// FP16
-inline v_float32x8 v512_load_expand(const float16_t* ptr)
-{
-    return v_float32x8(_mm256_cvtph_ps(_mm_loadu_si128((const __m256i*)ptr)));
-}
-
-inline void v_pack_store(float16_t* ptr, const v_float32x8& a)
-{
-    __m256i ah = _mm256_cvtps_ph(a.val, 0);
-    _mm_storeu_si128((__m256i*)ptr, ah);
-}
 
 inline void v512_cleanup() { _mm256_zeroall(); }
 

--- a/modules/core/include/opencv2/core/hal/intrin_avx512.hpp
+++ b/modules/core/include/opencv2/core/hal/intrin_avx512.hpp
@@ -1167,7 +1167,16 @@ OPENCV_HAL_IMPL_AVX512_ABS(v_int16x32,   v_uint16x32,  epi16)
 OPENCV_HAL_IMPL_AVX512_ABS(v_int32x16,   v_uint32x16,  epi32)
 OPENCV_HAL_IMPL_AVX512_ABS(v_int64x8,    v_uint64x8,   epi64)
 OPENCV_HAL_IMPL_AVX512_ABS(v_float32x16, v_float32x16,    ps)
-OPENCV_HAL_IMPL_AVX512_ABS(v_float64x8,  v_float64x8,     pd)
+
+inline v_float64x8 v_abs(const v_float64x8& x)
+{
+#if defined __GNUC__ && (__GNUC__ < 7 || (__GNUC__ == 7 && __GNUC_MINOR__ <= 3))
+    // Workaround for https://gcc.gnu.org/bugzilla/show_bug.cgi?id=87467
+    return v_float64x8(_mm512_abs_pd(_mm512_castpd_ps(x.val)));
+#else
+    return v_float64x8(_mm512_abs_pd(x.val));
+#endif
+}
 
 /** Absolute difference **/
 inline v_uint8x64 v_absdiff(const v_uint8x64& a, const v_uint8x64& b)

--- a/modules/core/include/opencv2/core/hal/intrin_avx512.hpp
+++ b/modules/core/include/opencv2/core/hal/intrin_avx512.hpp
@@ -1607,40 +1607,48 @@ inline void v_load_deinterleave( const uchar* ptr, v_uint8x64& a, v_uint8x64& b 
 {
     __m512i ab0 = _mm512_loadu_si512((const __m512i*)ptr);
     __m512i ab1 = _mm512_loadu_si512((const __m512i*)(ptr + 64));
-    a = v_uint8x64(_v_512_combine(_v512_extract_low(_mm512_maskz_compress_epi8(0x5555555555555555, ab0)),
-                                  _v512_extract_low(_mm512_maskz_compress_epi8(0x5555555555555555, ab1))));
-    b = v_uint8x64(_v_512_combine(_v512_extract_low(_mm512_maskz_compress_epi8(0xAAAAAAAAAAAAAAAA, ab0)),
-                                  _v512_extract_low(_mm512_maskz_compress_epi8(0xAAAAAAAAAAAAAAAA, ab1))));
+    __m512i mask0 = _mm512_set_epi8( 126, 124, 122, 120, 118, 116, 114, 112, 110, 108, 106, 104, 102, 100, 98, 96,
+                                      94,  92,  90,  88,  86,  84,  82,  80,  78,  76,  74,  72,  70,  68, 66, 64,
+                                      62,  60,  58,  56,  54,  52,  50,  48,  46,  44,  42,  40,  38,  36, 34, 32,
+                                      30,  28,  26,  24,  22,  20,  18,  16,  14,  12,  10,   8,   6,   4,  2,  0 );
+    __m512i mask1 = _mm512_set_epi8( 127, 125, 123, 121, 119, 117, 115, 113, 111, 109, 107, 105, 103, 101, 99, 97,
+                                      95,  93,  91,  89,  87,  85,  83,  81,  79,  77,  75,  73,  71,  69, 67, 65,
+                                      63,  61,  59,  57,  55,  53,  51,  49,  47,  45,  43,  41,  39,  37, 35, 33,
+                                      31,  29,  27,  25,  23,  21,  19,  17,  15,  13,  11,   9,   7,   5,  3,  1 );
+    a = v_uint8x64(_mm512_permutex2var_epi8(ab0, mask0, ab1));
+    b = v_uint8x64(_mm512_permutex2var_epi8(ab0, mask1, ab1));
 }
 
 inline void v_load_deinterleave( const ushort* ptr, v_uint16x32& a, v_uint16x32& b )
 {
     __m512i ab0 = _mm512_loadu_si512((const __m512i*)ptr);
     __m512i ab1 = _mm512_loadu_si512((const __m512i*)(ptr + 32));
-    a = v_uint16x32(_v_512_combine(_v512_extract_low(_mm512_maskz_compress_epi16(0x55555555, ab0)),
-                                   _v512_extract_low(_mm512_maskz_compress_epi16(0x55555555, ab1))));
-    b = v_uint16x32(_v_512_combine(_v512_extract_low(_mm512_maskz_compress_epi16(0xAAAAAAAA, ab0)),
-                                   _v512_extract_low(_mm512_maskz_compress_epi16(0xAAAAAAAA, ab1))));
+    __m512i mask0 = _mm512_set_epi16( 62, 60, 58, 56, 54, 52, 50, 48, 46, 44, 42, 40, 38, 36, 34, 32,
+                                      30, 28, 26, 24, 22, 20, 18, 16, 14, 12, 10,  8,  6,  4,  2,  0 );
+    __m512i mask1 = _mm512_set_epi16( 63, 61, 59, 57, 55, 53, 51, 49, 47, 45, 43, 41, 39, 37, 35, 33,
+                                      31, 29, 27, 25, 23, 21, 19, 17, 15, 13, 11,  9,  7,  5,  3,  1 );
+    a = v_uint16x32(_mm512_permutex2var_epi16(ab0, mask0, ab1));
+    b = v_uint16x32(_mm512_permutex2var_epi16(ab0, mask1, ab1));
 }
 
 inline void v_load_deinterleave( const unsigned* ptr, v_uint32x16& a, v_uint32x16& b )
 {
     __m512i ab0 = _mm512_loadu_si512((const __m512i*)ptr);
     __m512i ab1 = _mm512_loadu_si512((const __m512i*)(ptr + 16));
-    a = v_uint32x16(_v_512_combine(_v512_extract_low(_mm512_maskz_compress_epi32(0x5555, ab0)),
-                                   _v512_extract_low(_mm512_maskz_compress_epi32(0x5555, ab1))));
-    b = v_uint32x16(_v_512_combine(_v512_extract_low(_mm512_maskz_compress_epi32(0xAAAA, ab0)),
-                                   _v512_extract_low(_mm512_maskz_compress_epi32(0xAAAA, ab1))));
+    __m512i mask0 = _mm512_set_epi32( 30, 28, 26, 24, 22, 20, 18, 16, 14, 12, 10, 8, 6, 4, 2, 0 );
+    __m512i mask1 = _mm512_set_epi32( 31, 29, 27, 25, 23, 21, 19, 17, 15, 13, 11, 9, 7, 5, 3, 1 );
+    a = v_uint32x16(_mm512_permutex2var_epi32(ab0, mask0, ab1));
+    b = v_uint32x16(_mm512_permutex2var_epi32(ab0, mask1, ab1));
 }
 
 inline void v_load_deinterleave( const uint64* ptr, v_uint64x8& a, v_uint64x8& b )
 {
     __m512i ab0 = _mm512_loadu_si512((const __m512i*)ptr);
     __m512i ab1 = _mm512_loadu_si512((const __m512i*)(ptr + 8));
-    a = v_uint64x8(_v_512_combine(_v512_extract_low(_mm512_maskz_compress_epi64(0x55, ab0)),
-                                  _v512_extract_low(_mm512_maskz_compress_epi64(0x55, ab1))));
-    b = v_uint64x8(_v_512_combine(_v512_extract_low(_mm512_maskz_compress_epi64(0xAA, ab0)),
-                                  _v512_extract_low(_mm512_maskz_compress_epi64(0xAA, ab1))));
+    __m512i mask0 = _mm512_set_epi64( 14, 12, 10, 8, 6, 4, 2, 0 );
+    __m512i mask1 = _mm512_set_epi64( 15, 13, 11, 9, 7, 5, 3, 1 );
+    a = v_uint64x8(_mm512_permutex2var_epi64(ab0, mask0, ab1));
+    b = v_uint64x8(_mm512_permutex2var_epi64(ab0, mask1, ab1));
 }
 
 inline void v_load_deinterleave( const uchar* ptr, v_uint8x64& b, v_uint8x64& g, v_uint8x64& r )
@@ -1649,17 +1657,17 @@ inline void v_load_deinterleave( const uchar* ptr, v_uint8x64& b, v_uint8x64& g,
     __m512i bgr1 = _mm512_loadu_si512((const __m512i*)(ptr + 64));
     __m512i bgr2 = _mm512_loadu_si512((const __m512i*)(ptr + 128));
 
-    __m512i mask0 = _mm512_set_epi16(  2,   5,   8,  11,  14,  17,  20,  23,  26,  29,  32,  35,  38,  41,  44,  47,
-                                      50,  53,  56,  59,  62,   0,   3,   6,   9,  12,  15,  18,  21,  24,  27,  30,
-                                      33,  36,  39,  42,  45,  48,  51,  54,  57,  60,  63,  66,  69,  72,  75,  78,
-                                      81,  84,  87,  90,  93,  96,  99, 102, 105, 108, 111, 114, 117, 120, 123, 126 );
-    __m512i r0b01 = _mm512_permutex2var_epi16(bgr0, mask0, bgr1);
-    __m512i b1g12 = _mm512_permutex2var_epi16(bgr1, mask0, bgr2);
-    __m512i r12b2 = _mm512_permutex2var_epi16(bgr1,
-                    _mm512_set_epi16(  1,   4,   7,  10,  13,  16,  19,  22,  25,  28,  31,  34,  37,  40,  43,  46,
-                                      49,  52,  55,  58,  61,  64,  67,  70,  73,  76,  79,  82,  85,  88,  91,  94,
-                                      97, 100, 103, 106, 109, 112, 115, 118, 121, 124, 127,  65,  68,  71,  74,  77,
-                                      80,  83,  86,  89,  92,  95,  98, 101, 104, 107, 110, 113, 116, 119, 122, 125 ), bgr2);
+    __m512i mask0 = _mm512_set_epi8( 126, 123, 120, 117, 114, 111, 108, 105, 102, 99, 96, 93, 90, 87, 84, 81
+                                      78,  75,  72,  69,  66,  63,  60,  57,  54, 51, 48, 45, 42, 39, 36, 33
+                                      30,  27,  24,  21,  18,  15,  12,   9,   6,  3,  0, 62, 59, 56, 53, 50
+                                      47,  44,  41,  38,  35,  32,  29,  26,  23, 20, 17, 14, 11,  8,  5,  2 );
+    __m512i r0b01 = _mm512_permutex2var_epi8(bgr0, mask0, bgr1);
+    __m512i b1g12 = _mm512_permutex2var_epi8(bgr1, mask0, bgr2);
+    __m512i r12b2 = _mm512_permutex2var_epi8(bgr1,
+                    _mm512_set_epi8( 125, 122, 119, 116, 113, 110, 107, 104, 101,  98,  95,  92,  89,  86,  83, 80
+                                      77,  74,  71,  68,  65, 127, 124, 121, 118, 115, 112, 109, 106, 103, 100, 97
+                                      94,  91,  88,  85,  82,  79,  76,  73,  70,  67,  64,  61,  58,  55,  52, 49
+                                      46,  43,  40,  37,  34,  31,  28,  25,  22,  19,  16,  13,  10,   7,   4,  1 ), bgr2);
     b = v_uint16x32(_mm512_mask_compress_epi8(r12b2, 0xffffffffffe00000, r0b01));
     g = v_uint16x32(_mm512_mask_compress_epi8(b1g12, 0x2492492492492492, bgr0));
     r = v_uint16x32(_mm512_mask_expand_epi8(r0b01, 0xffffffffffe00000, r12b2));
@@ -1671,15 +1679,16 @@ inline void v_load_deinterleave( const ushort* ptr, v_uint16x32& b, v_uint16x32&
     __m512i bgr1 = _mm512_loadu_si512((const __m512i*)(ptr + 32));
     __m512i bgr2 = _mm512_loadu_si512((const __m512i*)(ptr + 64));
 
-    __m512i mask0 = _mm512_set_epi16( 0,  3,  6,  9, 12, 15, 18, 21, 24, 27, 30, 33, 36, 39, 42, 45,
-                                     48, 51, 54, 57, 60, 63, 34, 37, 40, 43, 46, 49, 52, 55, 58, 61);
+    __m512i mask0 = _mm512_set_epi16( 61, 58, 55, 52, 49, 46, 43, 40, 37, 34, 63, 60, 57, 54, 51, 48,
+                                      45, 42, 39, 36, 33, 30, 27, 24, 21, 18, 15, 12,  9,  6,  3,  0 );
     __m512i b01g1 = _mm512_permutex2var_epi16(bgr0, mask0, bgr1);
     __m512i r12b2 = _mm512_permutex2var_epi16(bgr1, mask0, bgr2);
     __m512i g20r0 = _mm512_permutex2var_epi16(bgr2, mask0, bgr0);
 
     b = v_uint16x32(_mm512_mask_blend_epi32(0x001f, b01g1, r12b2));
     g = v_uint16x32(_mm512_alignr_epi32(r12b2, g20r0, 11));
-    r = v_uint16x32(_mm512_permutex2var_epi16(bgr1, _mm512_set_epi16(43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 2, 5, 8, 11, 14, 17, 20, 23, 26, 29, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42), g20r0));
+    r = v_uint16x32(_mm512_permutex2var_epi16(bgr1, _mm512_set_epi16( 42, 41, 40, 39, 38, 37, 36, 35, 34, 33, 32, 29, 26, 23, 20, 17
+                                                                      14, 11,  8,  5,  2, 53, 52, 51, 50, 49, 48, 47, 46, 45, 44, 43 ), g20r0));
 }
 
 inline void v_load_deinterleave( const unsigned* ptr, v_uint32x16& b, v_uint32x16& g, v_uint32x16& r )
@@ -1688,14 +1697,14 @@ inline void v_load_deinterleave( const unsigned* ptr, v_uint32x16& b, v_uint32x1
     __m512i bgr1 = _mm512_loadu_si512((const __m512i*)(ptr + 16));
     __m512i bgr2 = _mm512_loadu_si512((const __m512i*)(ptr + 32));
 
-    __m512i mask0 = _mm512_set_epi32(0, 3, 6,  9, 12, 15, 18, 21, 24, 27, 30,    17, 20, 23, 26, 29);
+    __m512i mask0 = _mm512_set_epi32( 29, 26, 23, 20, 17, 30, 27, 24, 21, 18, 15, 12, 9, 6, 3, 0 );
     __m512i b01r1 = _mm512_permutex2var_epi32(bgr0, mask0, bgr1);
     __m512i g12b2 = _mm512_permutex2var_epi32(bgr1, mask0, bgr2);
     __m512i r20g0 = _mm512_permutex2var_epi32(bgr2, mask0, bgr0);
 
     b = v_uint32x16(_mm512_mask_blend_epi32(0x001f, b01r1, g12b2));
     g = v_uint32x16(_mm512_alignr_epi32(g12b2, r20g0, 11));
-    r = v_uint32x16(_mm512_permutex2var_epi32(bgr1, _mm512_set_epi32(16, 17, 18, 19, 20, 21, 1, 4, 7, 10, 13, 22, 23, 24, 25, 26), r20g0));
+    r = v_uint32x16(_mm512_permutex2var_epi32(bgr1, _mm512_set_epi32( 26, 25, 24, 23, 22, 13, 10, 7, 4, 1, 21, 20, 19, 18, 17, 16 ), r20g0));
 }
 
 inline void v_load_deinterleave( const uint64* ptr, v_uint64x8& b, v_uint64x8& g, v_uint64x8& r )
@@ -1704,134 +1713,106 @@ inline void v_load_deinterleave( const uint64* ptr, v_uint64x8& b, v_uint64x8& g
     __m512i bgr1 = _mm512_loadu_si512((const __m512i*)(ptr + 8));
     __m512i bgr2 = _mm512_loadu_si512((const __m512i*)(ptr + 16));
 
-    __m512i mask0 = _mm512_set_epi64(0, 3, 6, 9, 12, 15,    10, 13);
+    __m512i mask0 = _mm512_set_epi64( 13, 10, 15, 12, 9, 6, 3, 0 );
     __m512i b01g1 = _mm512_permutex2var_epi64(bgr0, mask0, bgr1);
     __m512i r12b2 = _mm512_permutex2var_epi64(bgr1, mask0, bgr2);
     __m512i g20r0 = _mm512_permutex2var_epi64(bgr2, mask0, bgr0);
 
     b = v_uint64x8(_mm512_mask_blend_epi64(0x03, b01g1, r12b2));
     r = v_uint64x8(_mm512_alignr_epi64(r12b2, g20r0, 6));
-    g = v_uint64x8(_mm512_permutex2var_epi64(bgr1, _mm512_set_epi32(11, 12, 13, 2, 5, 8, 9, 10), g20r0));
+    g = v_uint64x8(_mm512_permutex2var_epi64(bgr1, _mm512_set_epi32( 10, 9, 8, 5, 2, 13, 12, 11 ), g20r0));
 }
 
-inline void v_load_deinterleave( const uchar* ptr, v_uint8x32& b, v_uint8x32& g, v_uint8x32& r, v_uint8x32& a )
+inline void v_load_deinterleave( const uchar* ptr, v_uint8x64& b, v_uint8x64& g, v_uint8x64& r, v_uint8x64& a )
 {
-    __m512i bgr0 = _mm256_loadu_si256((const __m512i*)ptr);
-    __m512i bgr1 = _mm256_loadu_si256((const __m512i*)(ptr + 32));
-    __m512i bgr2 = _mm256_loadu_si256((const __m512i*)(ptr + 64));
-    __m512i bgr3 = _mm256_loadu_si256((const __m512i*)(ptr + 96));
-    const __m512i sh = _mm256_setr_epi8(0, 4, 8, 12, 1, 5, 9, 13, 2, 6, 10, 14, 3, 7, 11, 15,
-                                               0, 4, 8, 12, 1, 5, 9, 13, 2, 6, 10, 14, 3, 7, 11, 15);
+    __m512i bgra0 = _mm512_loadu_si512((const __m512i*)ptr);
+    __m512i bgra1 = _mm512_loadu_si512((const __m512i*)(ptr + 64));
+    __m512i bgra2 = _mm512_loadu_si512((const __m512i*)(ptr + 128));
+    __m512i bgra3 = _mm512_loadu_si512((const __m512i*)(ptr + 192));
 
-    __m512i p0 = _mm256_shuffle_epi8(bgr0, sh);
-    __m512i p1 = _mm256_shuffle_epi8(bgr1, sh);
-    __m512i p2 = _mm256_shuffle_epi8(bgr2, sh);
-    __m512i p3 = _mm256_shuffle_epi8(bgr3, sh);
+    __m512i mask0 = _mm512_set_epi8( 126, 124, 122, 120, 118, 116, 114, 112, 110, 108, 106, 104, 102, 100, 98, 96
+                                      94,  92,  90,  88,  86,  84,  82,  80,  78,  76,  74,  72,  70,  68, 66, 64
+                                      62,  60,  58,  56,  54,  52,  50,  48,  46,  44,  42,  40,  38,  36, 34, 32
+                                      30,  28,  26,  24,  22,  20,  18,  16,  14,  12,  10,   8,   6,   4,  2,  0 );
+    __m512i mask1 = _mm512_set_epi8( 127, 125, 123, 121, 119, 117, 115, 113, 111, 109, 107, 105, 103, 101, 99, 97
+                                      95,  93,  91,  89,  87,  85,  83,  81,  79,  77,  75,  73,  71,  69, 67, 65
+                                      63,  61,  59,  57,  55,  53,  51,  49,  47,  45,  43,  41,  39,  37, 35, 33
+                                      31,  29,  27,  25,  23,  21,  19,  17,  15,  13,  11,   9,   7,   5,  3,  1 );
 
-    __m512i p01l = _mm256_unpacklo_epi32(p0, p1);
-    __m512i p01h = _mm256_unpackhi_epi32(p0, p1);
-    __m512i p23l = _mm256_unpacklo_epi32(p2, p3);
-    __m512i p23h = _mm256_unpackhi_epi32(p2, p3);
+    __m512i br01 = _mm512_permutex2var_epi8(bgra0, mask0, bgra1);
+    __m512i ga01 = _mm512_permutex2var_epi8(bgra0, mask1, bgra1);
+    __m512i br23 = _mm512_permutex2var_epi8(bgra2, mask0, bgra3);
+    __m512i ga23 = _mm512_permutex2var_epi8(bgra2, mask1, bgra3);
 
-    __m512i pll = _mm256_permute2x128_si256(p01l, p23l, 0 + 2*16);
-    __m512i plh = _mm256_permute2x128_si256(p01l, p23l, 1 + 3*16);
-    __m512i phl = _mm256_permute2x128_si256(p01h, p23h, 0 + 2*16);
-    __m512i phh = _mm256_permute2x128_si256(p01h, p23h, 1 + 3*16);
-
-    __m512i b0 = _mm256_unpacklo_epi32(pll, plh);
-    __m512i g0 = _mm256_unpackhi_epi32(pll, plh);
-    __m512i r0 = _mm256_unpacklo_epi32(phl, phh);
-    __m512i a0 = _mm256_unpackhi_epi32(phl, phh);
-
-    b = v_uint8x32(b0);
-    g = v_uint8x32(g0);
-    r = v_uint8x32(r0);
-    a = v_uint8x32(a0);
+    b = v_uint8x64(_mm512_permutex2var_epi8(br01, mask0, br23));
+    r = v_uint8x64(_mm512_permutex2var_epi8(br01, mask1, br23));
+    g = v_uint8x64(_mm512_permutex2var_epi8(ga01, mask0, ga23));
+    a = v_uint8x64(_mm512_permutex2var_epi8(ga01, mask1, ga23));
 }
 
-inline void v_load_deinterleave( const ushort* ptr, v_uint16x16& b, v_uint16x16& g, v_uint16x16& r, v_uint16x16& a )
+inline void v_load_deinterleave( const ushort* ptr, v_uint16x32& b, v_uint16x32& g, v_uint16x32& r, v_uint16x32& a )
 {
-    __m512i bgr0 = _mm256_loadu_si256((const __m512i*)ptr);
-    __m512i bgr1 = _mm256_loadu_si256((const __m512i*)(ptr + 16));
-    __m512i bgr2 = _mm256_loadu_si256((const __m512i*)(ptr + 32));
-    __m512i bgr3 = _mm256_loadu_si256((const __m512i*)(ptr + 48));
-    const __m512i sh = _mm256_setr_epi8(0, 1, 8, 9, 2, 3, 10, 11, 4, 5, 12, 13, 6, 7, 14, 15,
-                                               0, 1, 8, 9, 2, 3, 10, 11, 4, 5, 12, 13, 6, 7, 14, 15);
-    __m512i p0 = _mm256_shuffle_epi8(bgr0, sh);
-    __m512i p1 = _mm256_shuffle_epi8(bgr1, sh);
-    __m512i p2 = _mm256_shuffle_epi8(bgr2, sh);
-    __m512i p3 = _mm256_shuffle_epi8(bgr3, sh);
+    __m512i bgra0 = _mm512_loadu_si512((const __m512i*)ptr);
+    __m512i bgra1 = _mm512_loadu_si512((const __m512i*)(ptr + 32));
+    __m512i bgra2 = _mm512_loadu_si512((const __m512i*)(ptr + 64));
+    __m512i bgra3 = _mm512_loadu_si512((const __m512i*)(ptr + 96));
 
-    __m512i p01l = _mm256_unpacklo_epi32(p0, p1);
-    __m512i p01h = _mm256_unpackhi_epi32(p0, p1);
-    __m512i p23l = _mm256_unpacklo_epi32(p2, p3);
-    __m512i p23h = _mm256_unpackhi_epi32(p2, p3);
+    __m512i mask0 = _mm512_set_epi16( 62, 60, 58, 56, 54, 52, 50, 48, 46, 44, 42, 40, 38, 36, 34, 32
+                                      30, 28, 26, 24, 22, 20, 18, 16, 14, 12, 10,  8,  6,  4,  2,  0 );
+    __m512i mask1 = _mm512_set_epi16( 63, 61, 59, 57, 55, 53, 51, 49, 47, 45, 43, 41, 39, 37, 35, 33
+                                      31, 29, 27, 25, 23, 21, 19, 17, 15, 13, 11,  9,  7,  5,  3,  1 );
 
-    __m512i pll = _mm256_permute2x128_si256(p01l, p23l, 0 + 2*16);
-    __m512i plh = _mm256_permute2x128_si256(p01l, p23l, 1 + 3*16);
-    __m512i phl = _mm256_permute2x128_si256(p01h, p23h, 0 + 2*16);
-    __m512i phh = _mm256_permute2x128_si256(p01h, p23h, 1 + 3*16);
+    __m512i br01 = _mm512_permutex2var_epi16(bgra0, mask0, bgra1);
+    __m512i ga01 = _mm512_permutex2var_epi16(bgra0, mask1, bgra1);
+    __m512i br23 = _mm512_permutex2var_epi16(bgra2, mask0, bgra3);
+    __m512i ga23 = _mm512_permutex2var_epi16(bgra2, mask1, bgra3);
 
-    __m512i b0 = _mm256_unpacklo_epi32(pll, plh);
-    __m512i g0 = _mm256_unpackhi_epi32(pll, plh);
-    __m512i r0 = _mm256_unpacklo_epi32(phl, phh);
-    __m512i a0 = _mm256_unpackhi_epi32(phl, phh);
-
-    b = v_uint16x16(b0);
-    g = v_uint16x16(g0);
-    r = v_uint16x16(r0);
-    a = v_uint16x16(a0);
+    b = v_uint16x32(_mm512_permutex2var_epi16(br01, mask0, br23));
+    r = v_uint16x32(_mm512_permutex2var_epi16(br01, mask1, br23));
+    g = v_uint16x32(_mm512_permutex2var_epi16(ga01, mask0, ga23));
+    a = v_uint16x32(_mm512_permutex2var_epi16(ga01, mask1, ga23));
 }
 
-inline void v_load_deinterleave( const unsigned* ptr, v_uint32x8& b, v_uint32x8& g, v_uint32x8& r, v_uint32x8& a )
+inline void v_load_deinterleave( const unsigned* ptr, v_uint32x16& b, v_uint32x16& g, v_uint32x16& r, v_uint32x16& a )
 {
-    __m512i p0 = _mm256_loadu_si256((const __m512i*)ptr);
-    __m512i p1 = _mm256_loadu_si256((const __m512i*)(ptr + 8));
-    __m512i p2 = _mm256_loadu_si256((const __m512i*)(ptr + 16));
-    __m512i p3 = _mm256_loadu_si256((const __m512i*)(ptr + 24));
+    __m512i bgra0 = _mm512_loadu_si512((const __m512i*)ptr);
+    __m512i bgra1 = _mm512_loadu_si512((const __m512i*)(ptr + 16));
+    __m512i bgra2 = _mm512_loadu_si512((const __m512i*)(ptr + 32));
+    __m512i bgra3 = _mm512_loadu_si512((const __m512i*)(ptr + 48));
 
-    __m512i p01l = _mm256_unpacklo_epi32(p0, p1);
-    __m512i p01h = _mm256_unpackhi_epi32(p0, p1);
-    __m512i p23l = _mm256_unpacklo_epi32(p2, p3);
-    __m512i p23h = _mm256_unpackhi_epi32(p2, p3);
+    __m512i mask0 = _mm512_set_epi32( 30, 28, 26, 24, 22, 20, 18, 16, 14, 12, 10, 8, 6, 4, 2, 0 );
+    __m512i mask1 = _mm512_set_epi32( 31, 29, 27, 25, 23, 21, 19, 17, 15, 13, 11, 9, 7, 5, 3, 1 );
 
-    __m512i pll = _mm256_permute2x128_si256(p01l, p23l, 0 + 2*16);
-    __m512i plh = _mm256_permute2x128_si256(p01l, p23l, 1 + 3*16);
-    __m512i phl = _mm256_permute2x128_si256(p01h, p23h, 0 + 2*16);
-    __m512i phh = _mm256_permute2x128_si256(p01h, p23h, 1 + 3*16);
+    __m512i br01 = _mm512_permutex2var_epi32(bgra0, mask0, bgra1);
+    __m512i ga01 = _mm512_permutex2var_epi32(bgra0, mask1, bgra1);
+    __m512i br23 = _mm512_permutex2var_epi32(bgra2, mask0, bgra3);
+    __m512i ga23 = _mm512_permutex2var_epi32(bgra2, mask1, bgra3);
 
-    __m512i b0 = _mm256_unpacklo_epi32(pll, plh);
-    __m512i g0 = _mm256_unpackhi_epi32(pll, plh);
-    __m512i r0 = _mm256_unpacklo_epi32(phl, phh);
-    __m512i a0 = _mm256_unpackhi_epi32(phl, phh);
-
-    b = v_uint32x8(b0);
-    g = v_uint32x8(g0);
-    r = v_uint32x8(r0);
-    a = v_uint32x8(a0);
+    b = v_uint32x16(_mm512_permutex2var_epi32(br01, mask0, br23));
+    r = v_uint32x16(_mm512_permutex2var_epi32(br01, mask1, br23));
+    g = v_uint32x16(_mm512_permutex2var_epi32(ga01, mask0, ga23));
+    a = v_uint32x16(_mm512_permutex2var_epi32(ga01, mask1, ga23));
 }
 
-inline void v_load_deinterleave( const uint64* ptr, v_uint64x4& b, v_uint64x4& g, v_uint64x4& r, v_uint64x4& a )
+inline void v_load_deinterleave( const uint64* ptr, v_uint64x8& b, v_uint64x8& g, v_uint64x8& r, v_uint64x8& a )
 {
-    __m512i bgra0 = _mm256_loadu_si256((const __m512i*)ptr);
-    __m512i bgra1 = _mm256_loadu_si256((const __m512i*)(ptr + 4));
-    __m512i bgra2 = _mm256_loadu_si256((const __m512i*)(ptr + 8));
-    __m512i bgra3 = _mm256_loadu_si256((const __m512i*)(ptr + 12));
+    __m512i bgra0 = _mm512_loadu_si512((const __m512i*)ptr);
+    __m512i bgra1 = _mm512_loadu_si512((const __m512i*)(ptr + 8));
+    __m512i bgra2 = _mm512_loadu_si512((const __m512i*)(ptr + 16));
+    __m512i bgra3 = _mm512_loadu_si512((const __m512i*)(ptr + 24));
 
-    __m512i l02 = _mm256_permute2x128_si256(bgra0, bgra2, 0 + 2*16);
-    __m512i h02 = _mm256_permute2x128_si256(bgra0, bgra2, 1 + 3*16);
-    __m512i l13 = _mm256_permute2x128_si256(bgra1, bgra3, 0 + 2*16);
-    __m512i h13 = _mm256_permute2x128_si256(bgra1, bgra3, 1 + 3*16);
+    __m512i mask0 = _mm512_set_epi64( 14, 12, 10, 8, 6, 4, 2, 0 );
+    __m512i mask1 = _mm512_set_epi64( 15, 13, 11, 9, 7, 5, 3, 1 );
 
-    __m512i b0 = _mm256_unpacklo_epi64(l02, l13);
-    __m512i g0 = _mm256_unpackhi_epi64(l02, l13);
-    __m512i r0 = _mm256_unpacklo_epi64(h02, h13);
-    __m512i a0 = _mm256_unpackhi_epi64(h02, h13);
+    __m512i br01 = _mm512_permutex2var_epi64(bgra0, mask0, bgra1);
+    __m512i ga01 = _mm512_permutex2var_epi64(bgra0, mask1, bgra1);
+    __m512i br23 = _mm512_permutex2var_epi64(bgra2, mask0, bgra3);
+    __m512i ga23 = _mm512_permutex2var_epi64(bgra2, mask1, bgra3);
 
-    b = v_uint64x4(b0);
-    g = v_uint64x4(g0);
-    r = v_uint64x4(r0);
-    a = v_uint64x4(a0);
+    b = v_uint32x16(_mm512_permutex2var_epi64(br01, mask0, br23));
+    r = v_uint32x16(_mm512_permutex2var_epi64(br01, mask1, br23));
+    g = v_uint32x16(_mm512_permutex2var_epi64(ga01, mask0, ga23));
+    a = v_uint32x16(_mm512_permutex2var_epi64(ga01, mask1, ga23));
 }
 
 ///////////////////////////// store interleave /////////////////////////////////////

--- a/modules/core/include/opencv2/core/hal/intrin_avx512.hpp
+++ b/modules/core/include/opencv2/core/hal/intrin_avx512.hpp
@@ -1109,60 +1109,54 @@ inline v_int16x32 v_absdiffs(const v_int16x32& a, const v_int16x32& b)
 ////////// Conversions /////////
 
 /** Rounding **/
-inline v_int32x8 v_round(const v_float32x8& a)
-{ return v_int32x8(_mm256_cvtps_epi32(a.val)); }
+inline v_int32x16 v_round(const v_float32x16& a)
+{ return v_int32x16(_mm512_cvtps_epi32(a.val)); }
 
-inline v_int32x8 v_round(const v_float64x4& a)
-{ return v_int32x8(_mm256_castsi128_si256(_mm256_cvtpd_epi32(a.val))); }
+inline v_int32x16 v_round(const v_float64x8& a)
+{ return v_int32x16(_mm512_castsi256_si512(_mm512_cvtpd_epi32(a.val))); }
 
-inline v_int32x8 v_round(const v_float64x4& a, const v_float64x4& b)
-{
-    __m256i ai = _mm256_cvtpd_epi32(a.val), bi = _mm256_cvtpd_epi32(b.val);
-    return v_int32x8(_v512_combine(ai, bi));
-}
+inline v_int32x16 v_round(const v_float64x8& a, const v_float64x8& b)
+{ return v_int32x16(_v512_combine(_mm512_cvtpd_epi32(a.val), _mm512_cvtpd_epi32(b.val))); }
 
-inline v_int32x8 v_trunc(const v_float32x8& a)
-{ return v_int32x8(_mm256_cvttps_epi32(a.val)); }
+inline v_int32x16 v_trunc(const v_float32x16& a)
+{ return v_int32x16(_mm512_cvttps_epi32(a.val)); }
 
-inline v_int32x8 v_trunc(const v_float64x4& a)
-{ return v_int32x8(_mm256_castsi128_si256(_mm256_cvttpd_epi32(a.val))); }
+inline v_int32x16 v_trunc(const v_float64x8& a)
+{ return v_int32x16(_mm512_castsi256_si512(_mm512_cvttpd_epi32(a.val))); }
 
-inline v_int32x8 v_floor(const v_float32x8& a)
-{ return v_int32x8(_mm256_cvttps_epi32(_mm256_floor_ps(a.val))); }
+inline v_int32x16 v_floor(const v_float32x16& a)
+{ return v_int32x16(_mm512_cvt_roundps_epi32(a.val, _MM_FROUND_TO_NEG_INF | _MM_FROUND_NO_EXC)); }
 
-inline v_int32x8 v_floor(const v_float64x4& a)
-{ return v_trunc(v_float64x4(_mm256_floor_pd(a.val))); }
+inline v_int32x16 v_floor(const v_float64x8& a)
+{ return v_int32x16(_mm512_castsi256_si512(_mm512_cvt_roundpd_epi32(a.val))); }
 
-inline v_int32x8 v_ceil(const v_float32x8& a)
-{ return v_int32x8(_mm256_cvttps_epi32(_mm256_ceil_ps(a.val))); }
+inline v_int32x16 v_ceil(const v_float32x16& a)
+{ return v_int32x16(_mm512_cvt_roundps_epi32(a.val, _MM_FROUND_TO_POS_INF | _MM_FROUND_NO_EXC)); }
 
-inline v_int32x8 v_ceil(const v_float64x4& a)
-{ return v_trunc(v_float64x4(_mm256_ceil_pd(a.val))); }
+inline v_int32x16 v_ceil(const v_float64x8& a)
+{ return v_int32x16(_mm512_castsi256_si512(_mm512_cvt_roundpd_epi32(a.val))); }
 
 /** To float **/
-inline v_float32x8 v_cvt_f32(const v_int32x8& a)
-{ return v_float32x8(_mm256_cvtepi32_ps(a.val)); }
+inline v_float32x16 v_cvt_f32(const v_int32x16& a)
+{ return v_float32x16(_mm512_cvtepi32_ps(a.val)); }
 
-inline v_float32x8 v_cvt_f32(const v_float64x4& a)
-{ return v_float32x8(_mm256_castps128_ps256(_mm256_cvtpd_ps(a.val))); }
+inline v_float32x16 v_cvt_f32(const v_float64x8& a)
+{ return v_float32x16(_mm512_cvtpd_pslo(a.val)); }
 
-inline v_float32x8 v_cvt_f32(const v_float64x4& a, const v_float64x4& b)
-{
-    __m256 af = _mm256_cvtpd_ps(a.val), bf = _mm256_cvtpd_ps(b.val);
-    return v_float32x8(_mm256_insertf128_ps(_mm256_castps128_ps256(af), bf, 1));
-}
+inline v_float32x16 v_cvt_f32(const v_float64x8& a, const v_float64x8& b)
+{ return v_float32x8(_v512_combine(_mm512_cvtpd_ps(a.val), _mm512_cvtpd_ps(b.val))); }
 
-inline v_float64x4 v_cvt_f64(const v_int32x8& a)
-{ return v_float64x4(_mm256_cvtepi32_pd(_v512_extract_low(a.val))); }
+inline v_float64x8 v_cvt_f64(const v_int32x16& a)
+{ return v_float64x8(_mm512_cvtepi32_pd(_v512_extract_low(a.val))); }
 
-inline v_float64x4 v_cvt_f64_high(const v_int32x8& a)
-{ return v_float64x4(_mm256_cvtepi32_pd(_v512_extract_high(a.val))); }
+inline v_float64x8 v_cvt_f64_high(const v_int32x16& a)
+{ return v_float64x8(_mm512_cvtepi32_pd(_v512_extract_high(a.val))); }
 
-inline v_float64x4 v_cvt_f64(const v_float32x8& a)
-{ return v_float64x4(_mm256_cvtps_pd(_v512_extract_low(a.val))); }
+inline v_float64x8 v_cvt_f64(const v_float32x16& a)
+{ return v_float64x8(_mm512_cvtps_pd(_v512_extract_low(a.val))); }
 
-inline v_float64x4 v_cvt_f64_high(const v_float32x8& a)
-{ return v_float64x4(_mm256_cvtps_pd(_v512_extract_high(a.val))); }
+inline v_float64x8 v_cvt_f64_high(const v_float32x16& a)
+{ return v_float64x8(_mm512_cvtps_pd(_v512_extract_high(a.val))); }
 
 ////////////// Lookup table access ////////////////////
 

--- a/modules/core/include/opencv2/core/hal/intrin_avx512.hpp
+++ b/modules/core/include/opencv2/core/hal/intrin_avx512.hpp
@@ -355,7 +355,7 @@ struct v_float64x8
 
 //////////////// Load and store operations ///////////////
 
-#define OPENCV_HAL_IMPL_AVX_LOADSTORE(_Tpvec, _Tp)                    \
+#define OPENCV_HAL_IMPL_AVX512_LOADSTORE(_Tpvec, _Tp)                    \
     inline _Tpvec v512_load(const _Tp* ptr)                           \
     { return _Tpvec(_mm512_loadu_si512((const __m512i*)ptr)); }       \
     inline _Tpvec v512_load_aligned(const _Tp* ptr)                   \
@@ -391,16 +391,16 @@ struct v_float64x8
     inline void v_store_high(_Tp* ptr, const _Tpvec& a)               \
     { _mm256_storeu_si256((__m256i*)ptr, _v512_extract_high(a.val)); }
 
-OPENCV_HAL_IMPL_AVX_LOADSTORE(v_uint8x64,  uchar)
-OPENCV_HAL_IMPL_AVX_LOADSTORE(v_int8x64,   schar)
-OPENCV_HAL_IMPL_AVX_LOADSTORE(v_uint16x32, ushort)
-OPENCV_HAL_IMPL_AVX_LOADSTORE(v_int16x32,  short)
-OPENCV_HAL_IMPL_AVX_LOADSTORE(v_uint32x16,  unsigned)
-OPENCV_HAL_IMPL_AVX_LOADSTORE(v_int32x16,   int)
-OPENCV_HAL_IMPL_AVX_LOADSTORE(v_uint64x8,  uint64)
-OPENCV_HAL_IMPL_AVX_LOADSTORE(v_int64x8,   int64)
+OPENCV_HAL_IMPL_AVX512_LOADSTORE(v_uint8x64,  uchar)
+OPENCV_HAL_IMPL_AVX512_LOADSTORE(v_int8x64,   schar)
+OPENCV_HAL_IMPL_AVX512_LOADSTORE(v_uint16x32, ushort)
+OPENCV_HAL_IMPL_AVX512_LOADSTORE(v_int16x32,  short)
+OPENCV_HAL_IMPL_AVX512_LOADSTORE(v_uint32x16,  unsigned)
+OPENCV_HAL_IMPL_AVX512_LOADSTORE(v_int32x16,   int)
+OPENCV_HAL_IMPL_AVX512_LOADSTORE(v_uint64x8,  uint64)
+OPENCV_HAL_IMPL_AVX512_LOADSTORE(v_int64x8,   int64)
 
-#define OPENCV_HAL_IMPL_AVX_LOADSTORE_FLT(_Tpvec, _Tp, suffix, halfreg)   \
+#define OPENCV_HAL_IMPL_AVX512_LOADSTORE_FLT(_Tpvec, _Tp, suffix, halfreg)   \
     inline _Tpvec v512_load(const _Tp* ptr)                               \
     { return _Tpvec(_mm512_loadu_##suffix(ptr)); }                        \
     inline _Tpvec v512_load_aligned(const _Tp* ptr)                       \
@@ -436,54 +436,54 @@ OPENCV_HAL_IMPL_AVX_LOADSTORE(v_int64x8,   int64)
     inline void v_store_high(_Tp* ptr, const _Tpvec& a)                   \
     { _mm256_storeu_##suffix(ptr, _v512_extract_high(a.val)); }
 
-OPENCV_HAL_IMPL_AVX_LOADSTORE_FLT(v_float32x16, float,  ps, __m256)
-OPENCV_HAL_IMPL_AVX_LOADSTORE_FLT(v_float64x8, double, pd, __m256d)
+OPENCV_HAL_IMPL_AVX512_LOADSTORE_FLT(v_float32x16, float,  ps, __m256)
+OPENCV_HAL_IMPL_AVX512_LOADSTORE_FLT(v_float64x8, double, pd, __m256d)
 
-#define OPENCV_HAL_IMPL_AVX_CAST(_Tpvec, _Tpvecf, suffix, cast) \
+#define OPENCV_HAL_IMPL_AVX512_CAST(_Tpvec, _Tpvecf, suffix, cast) \
     inline _Tpvec v_reinterpret_as_##suffix(const _Tpvecf& a)   \
     { return _Tpvec(cast(a.val)); }
 
-#define OPENCV_HAL_IMPL_AVX_INIT(_Tpvec, _Tp, suffix, ssuffix, ctype_s)           \
-    inline _Tpvec v512_setzero_##suffix()                                         \
-    { return _Tpvec(_mm512_setzero_si512()); }                                    \
-    inline _Tpvec v512_setall_##suffix(_Tp v)                                     \
-    { return _Tpvec(_mm512_set1_##ssuffix((ctype_s)v)); }                         \
-    OPENCV_HAL_IMPL_AVX_CAST(_Tpvec, v_uint8x64,   suffix, OPENCV_HAL_NOP)        \
-    OPENCV_HAL_IMPL_AVX_CAST(_Tpvec, v_int8x64,    suffix, OPENCV_HAL_NOP)        \
-    OPENCV_HAL_IMPL_AVX_CAST(_Tpvec, v_uint16x32,  suffix, OPENCV_HAL_NOP)        \
-    OPENCV_HAL_IMPL_AVX_CAST(_Tpvec, v_int16x32,   suffix, OPENCV_HAL_NOP)        \
-    OPENCV_HAL_IMPL_AVX_CAST(_Tpvec, v_uint32x16,  suffix, OPENCV_HAL_NOP)        \
-    OPENCV_HAL_IMPL_AVX_CAST(_Tpvec, v_int32x16,   suffix, OPENCV_HAL_NOP)        \
-    OPENCV_HAL_IMPL_AVX_CAST(_Tpvec, v_uint64x8,   suffix, OPENCV_HAL_NOP)        \
-    OPENCV_HAL_IMPL_AVX_CAST(_Tpvec, v_int64x8,    suffix, OPENCV_HAL_NOP)        \
-    OPENCV_HAL_IMPL_AVX_CAST(_Tpvec, v_float32x16, suffix, _mm256_castps_si256)   \
-    OPENCV_HAL_IMPL_AVX_CAST(_Tpvec, v_float64x8,  suffix, _mm256_castpd_si256)
+#define OPENCV_HAL_IMPL_AVX512_INIT(_Tpvec, _Tp, suffix, ssuffix, ctype_s)         \
+    inline _Tpvec v512_setzero_##suffix()                                          \
+    { return _Tpvec(_mm512_setzero_si512()); }                                     \
+    inline _Tpvec v512_setall_##suffix(_Tp v)                                      \
+    { return _Tpvec(_mm512_set1_##ssuffix((ctype_s)v)); }                          \
+    OPENCV_HAL_IMPL_AVX512_CAST(_Tpvec, v_uint8x64,   suffix, OPENCV_HAL_NOP)      \
+    OPENCV_HAL_IMPL_AVX512_CAST(_Tpvec, v_int8x64,    suffix, OPENCV_HAL_NOP)      \
+    OPENCV_HAL_IMPL_AVX512_CAST(_Tpvec, v_uint16x32,  suffix, OPENCV_HAL_NOP)      \
+    OPENCV_HAL_IMPL_AVX512_CAST(_Tpvec, v_int16x32,   suffix, OPENCV_HAL_NOP)      \
+    OPENCV_HAL_IMPL_AVX512_CAST(_Tpvec, v_uint32x16,  suffix, OPENCV_HAL_NOP)      \
+    OPENCV_HAL_IMPL_AVX512_CAST(_Tpvec, v_int32x16,   suffix, OPENCV_HAL_NOP)      \
+    OPENCV_HAL_IMPL_AVX512_CAST(_Tpvec, v_uint64x8,   suffix, OPENCV_HAL_NOP)      \
+    OPENCV_HAL_IMPL_AVX512_CAST(_Tpvec, v_int64x8,    suffix, OPENCV_HAL_NOP)      \
+    OPENCV_HAL_IMPL_AVX512_CAST(_Tpvec, v_float32x16, suffix, _mm256_castps_si256) \
+    OPENCV_HAL_IMPL_AVX512_CAST(_Tpvec, v_float64x8,  suffix, _mm256_castpd_si256)
 
-OPENCV_HAL_IMPL_AVX_INIT(v_uint8x64,  uchar,    u8,  epi8,   char)
-OPENCV_HAL_IMPL_AVX_INIT(v_int8x64,   schar,    s8,  epi8,   char)
-OPENCV_HAL_IMPL_AVX_INIT(v_uint16x32, ushort,   u16, epi16,  short)
-OPENCV_HAL_IMPL_AVX_INIT(v_int16x32,  short,    s16, epi16,  short)
-OPENCV_HAL_IMPL_AVX_INIT(v_uint32x16, unsigned, u32, epi32,  int)
-OPENCV_HAL_IMPL_AVX_INIT(v_int32x16,  int,      s32, epi32,  int)
-OPENCV_HAL_IMPL_AVX_INIT(v_uint64x8,  uint64,   u64, epi64,  int64)
-OPENCV_HAL_IMPL_AVX_INIT(v_int64x8,   int64,    s64, epi64,  int64)
+OPENCV_HAL_IMPL_AVX512_INIT(v_uint8x64,  uchar,    u8,  epi8,   char)
+OPENCV_HAL_IMPL_AVX512_INIT(v_int8x64,   schar,    s8,  epi8,   char)
+OPENCV_HAL_IMPL_AVX512_INIT(v_uint16x32, ushort,   u16, epi16,  short)
+OPENCV_HAL_IMPL_AVX512_INIT(v_int16x32,  short,    s16, epi16,  short)
+OPENCV_HAL_IMPL_AVX512_INIT(v_uint32x16, unsigned, u32, epi32,  int)
+OPENCV_HAL_IMPL_AVX512_INIT(v_int32x16,  int,      s32, epi32,  int)
+OPENCV_HAL_IMPL_AVX512_INIT(v_uint64x8,  uint64,   u64, epi64,  int64)
+OPENCV_HAL_IMPL_AVX512_INIT(v_int64x8,   int64,    s64, epi64,  int64)
 
-#define OPENCV_HAL_IMPL_AVX_INIT_FLT(_Tpvec, _Tp, suffix, zsuffix, cast) \
-    inline _Tpvec v512_setzero_##suffix()                                \
-    { return _Tpvec(_mm512_setzero_##zsuffix()); }                       \
-    inline _Tpvec v512_setall_##suffix(_Tp v)                            \
-    { return _Tpvec(_mm512_set1_##zsuffix(v)); }                         \
-    OPENCV_HAL_IMPL_AVX_CAST(_Tpvec, v_uint8x64,  suffix, cast)          \
-    OPENCV_HAL_IMPL_AVX_CAST(_Tpvec, v_int8x64,   suffix, cast)          \
-    OPENCV_HAL_IMPL_AVX_CAST(_Tpvec, v_uint16x32, suffix, cast)          \
-    OPENCV_HAL_IMPL_AVX_CAST(_Tpvec, v_int16x32,  suffix, cast)          \
-    OPENCV_HAL_IMPL_AVX_CAST(_Tpvec, v_uint32x16, suffix, cast)          \
-    OPENCV_HAL_IMPL_AVX_CAST(_Tpvec, v_int32x16,  suffix, cast)          \
-    OPENCV_HAL_IMPL_AVX_CAST(_Tpvec, v_uint64x8,  suffix, cast)          \
-    OPENCV_HAL_IMPL_AVX_CAST(_Tpvec, v_int64x8,   suffix, cast)
+#define OPENCV_HAL_IMPL_AVX512_INIT_FLT(_Tpvec, _Tp, suffix, zsuffix, cast) \
+    inline _Tpvec v512_setzero_##suffix()                                   \
+    { return _Tpvec(_mm512_setzero_##zsuffix()); }                          \
+    inline _Tpvec v512_setall_##suffix(_Tp v)                               \
+    { return _Tpvec(_mm512_set1_##zsuffix(v)); }                            \
+    OPENCV_HAL_IMPL_AVX512_CAST(_Tpvec, v_uint8x64,  suffix, cast)          \
+    OPENCV_HAL_IMPL_AVX512_CAST(_Tpvec, v_int8x64,   suffix, cast)          \
+    OPENCV_HAL_IMPL_AVX512_CAST(_Tpvec, v_uint16x32, suffix, cast)          \
+    OPENCV_HAL_IMPL_AVX512_CAST(_Tpvec, v_int16x32,  suffix, cast)          \
+    OPENCV_HAL_IMPL_AVX512_CAST(_Tpvec, v_uint32x16, suffix, cast)          \
+    OPENCV_HAL_IMPL_AVX512_CAST(_Tpvec, v_int32x16,  suffix, cast)          \
+    OPENCV_HAL_IMPL_AVX512_CAST(_Tpvec, v_uint64x8,  suffix, cast)          \
+    OPENCV_HAL_IMPL_AVX512_CAST(_Tpvec, v_int64x8,   suffix, cast)
 
-OPENCV_HAL_IMPL_AVX_INIT_FLT(v_float32x16, float,  f32, ps, _mm512_castsi512_ps)
-OPENCV_HAL_IMPL_AVX_INIT_FLT(v_float64x8,  double, f64, pd, _mm512_castsi512_pd)
+OPENCV_HAL_IMPL_AVX512_INIT_FLT(v_float32x16, float,  f32, ps, _mm512_castsi512_ps)
+OPENCV_HAL_IMPL_AVX512_INIT_FLT(v_float64x8,  double, f64, pd, _mm512_castsi512_pd)
 
 inline v_float32x16 v_reinterpret_as_f32(const v_float32x16& a)
 { return a; }
@@ -508,7 +508,7 @@ inline void v_pack_store(float16_t* ptr, const v_float32x16& a)
 }
 
 /* Recombine & ZIP */
-#define OPENCV_HAL_IMPL_AVX_ZIP(_Tpvec, suffix)                                            \
+#define OPENCV_HAL_IMPL_AVX512_ZIP(_Tpvec, suffix)                                         \
     inline _Tpvec v_combine_low(const _Tpvec& a, const _Tpvec& b)                          \
     { return _v512_combine(_v512_extract_low(a.val), _v512_extract_low(b.val)); }          \
     inline _Tpvec v_combine_high(const _Tpvec& a, const _Tpvec& b)                         \
@@ -529,36 +529,36 @@ inline void v_pack_store(float16_t* ptr, const v_float32x16& a)
         ab1.val = _mm512_mask_expand_##suffix(ab1.val, 0xAAAAAAAA << _Tpvec::nlanes/2, b); \
     }
 
-OPENCV_HAL_IMPL_AVX_ZIP(v_uint8x64, epi8)
-OPENCV_HAL_IMPL_AVX_ZIP(v_int8x64, epi8)
-OPENCV_HAL_IMPL_AVX_ZIP(v_uint16x32, epi16)
-OPENCV_HAL_IMPL_AVX_ZIP(v_int16x32, epi16)
-OPENCV_HAL_IMPL_AVX_ZIP(v_uint32x16, epi32)
-OPENCV_HAL_IMPL_AVX_ZIP(v_int32x16, epi32)
-OPENCV_HAL_IMPL_AVX_ZIP(v_uint64x8, epi64)
-OPENCV_HAL_IMPL_AVX_ZIP(v_int64x8, epi64)
-OPENCV_HAL_IMPL_AVX_ZIP(v_float32x16, ps)
-OPENCV_HAL_IMPL_AVX_ZIP(v_float64x8, pd)
+OPENCV_HAL_IMPL_AVX512_ZIP(v_uint8x64, epi8)
+OPENCV_HAL_IMPL_AVX512_ZIP(v_int8x64, epi8)
+OPENCV_HAL_IMPL_AVX512_ZIP(v_uint16x32, epi16)
+OPENCV_HAL_IMPL_AVX512_ZIP(v_int16x32, epi16)
+OPENCV_HAL_IMPL_AVX512_ZIP(v_uint32x16, epi32)
+OPENCV_HAL_IMPL_AVX512_ZIP(v_int32x16, epi32)
+OPENCV_HAL_IMPL_AVX512_ZIP(v_uint64x8, epi64)
+OPENCV_HAL_IMPL_AVX512_ZIP(v_int64x8, epi64)
+OPENCV_HAL_IMPL_AVX512_ZIP(v_float32x16, ps)
+OPENCV_HAL_IMPL_AVX512_ZIP(v_float64x8, pd)
 
 ////////// Arithmetic, bitwise and comparison operations /////////
 
 /* Element-wise binary and unary operations */
 
 /** Non-saturating arithmetics **/
-#define OPENCV_HAL_IMPL_AVX_BIN_FUNC(func, _Tpvec, intrin) \
-    inline _Tpvec func(const _Tpvec& a, const _Tpvec& b)   \
+#define OPENCV_HAL_IMPL_AVX512_BIN_FUNC(func, _Tpvec, intrin) \
+    inline _Tpvec func(const _Tpvec& a, const _Tpvec& b)      \
     { return _Tpvec(intrin(a.val, b.val)); }
 
-OPENCV_HAL_IMPL_AVX_BIN_FUNC(v_add_wrap, v_uint8x64, _mm512_add_epi8)
-OPENCV_HAL_IMPL_AVX_BIN_FUNC(v_add_wrap, v_int8x64, _mm512_add_epi8)
-OPENCV_HAL_IMPL_AVX_BIN_FUNC(v_add_wrap, v_uint16x32, _mm512_add_epi16)
-OPENCV_HAL_IMPL_AVX_BIN_FUNC(v_add_wrap, v_int16x32, _mm512_add_epi16)
-OPENCV_HAL_IMPL_AVX_BIN_FUNC(v_sub_wrap, v_uint8x64, _mm512_sub_epi8)
-OPENCV_HAL_IMPL_AVX_BIN_FUNC(v_sub_wrap, v_int8x64, _mm512_sub_epi8)
-OPENCV_HAL_IMPL_AVX_BIN_FUNC(v_sub_wrap, v_uint16x32, _mm512_sub_epi16)
-OPENCV_HAL_IMPL_AVX_BIN_FUNC(v_sub_wrap, v_int16x32, _mm512_sub_epi16)
-OPENCV_HAL_IMPL_AVX_BIN_FUNC(v_mul_wrap, v_uint16x32, _mm512_mullo_epi16)
-OPENCV_HAL_IMPL_AVX_BIN_FUNC(v_mul_wrap, v_int16x32, _mm512_mullo_epi16)
+OPENCV_HAL_IMPL_AVX512_BIN_FUNC(v_add_wrap, v_uint8x64, _mm512_add_epi8)
+OPENCV_HAL_IMPL_AVX512_BIN_FUNC(v_add_wrap, v_int8x64, _mm512_add_epi8)
+OPENCV_HAL_IMPL_AVX512_BIN_FUNC(v_add_wrap, v_uint16x32, _mm512_add_epi16)
+OPENCV_HAL_IMPL_AVX512_BIN_FUNC(v_add_wrap, v_int16x32, _mm512_add_epi16)
+OPENCV_HAL_IMPL_AVX512_BIN_FUNC(v_sub_wrap, v_uint8x64, _mm512_sub_epi8)
+OPENCV_HAL_IMPL_AVX512_BIN_FUNC(v_sub_wrap, v_int8x64, _mm512_sub_epi8)
+OPENCV_HAL_IMPL_AVX512_BIN_FUNC(v_sub_wrap, v_uint16x32, _mm512_sub_epi16)
+OPENCV_HAL_IMPL_AVX512_BIN_FUNC(v_sub_wrap, v_int16x32, _mm512_sub_epi16)
+OPENCV_HAL_IMPL_AVX512_BIN_FUNC(v_mul_wrap, v_uint16x32, _mm512_mullo_epi16)
+OPENCV_HAL_IMPL_AVX512_BIN_FUNC(v_mul_wrap, v_int16x32, _mm512_mullo_epi16)
 
 inline v_uint8x64 v_mul_wrap(const v_uint8x64& a, const v_uint8x64& b)
 {
@@ -573,44 +573,44 @@ inline v_int8x64 v_mul_wrap(const v_int8x64& a, const v_int8x64& b)
     return v_reinterpret_as_s8(v_mul_wrap(v_reinterpret_as_u8(a), v_reinterpret_as_u8(b)));
 }
 
-#define OPENCV_HAL_IMPL_AVX_BIN_OP(bin_op, _Tpvec, intrin)            \
-    inline _Tpvec operator bin_op (const _Tpvec& a, const _Tpvec& b)  \
-    { return _Tpvec(intrin(a.val, b.val)); }                          \
-    inline _Tpvec& operator bin_op##= (_Tpvec& a, const _Tpvec& b)    \
+#define OPENCV_HAL_IMPL_AVX512_BIN_OP(bin_op, _Tpvec, intrin)            \
+    inline _Tpvec operator bin_op (const _Tpvec& a, const _Tpvec& b)     \
+    { return _Tpvec(intrin(a.val, b.val)); }                             \
+    inline _Tpvec& operator bin_op##= (_Tpvec& a, const _Tpvec& b)       \
     { a.val = intrin(a.val, b.val); return a; }
 
-OPENCV_HAL_IMPL_AVX_BIN_OP(+, v_uint32x16, _mm512_add_epi32)
-OPENCV_HAL_IMPL_AVX_BIN_OP(-, v_uint32x16, _mm512_sub_epi32)
-OPENCV_HAL_IMPL_AVX_BIN_OP(+, v_int32x16, _mm512_add_epi32)
-OPENCV_HAL_IMPL_AVX_BIN_OP(-, v_int32x16, _mm512_sub_epi32)
-OPENCV_HAL_IMPL_AVX_BIN_OP(+, v_uint64x8, _mm512_add_epi64)
-OPENCV_HAL_IMPL_AVX_BIN_OP(-, v_uint64x8, _mm512_sub_epi64)
-OPENCV_HAL_IMPL_AVX_BIN_OP(+, v_int64x8, _mm512_add_epi64)
-OPENCV_HAL_IMPL_AVX_BIN_OP(-, v_int64x8, _mm512_sub_epi64)
+OPENCV_HAL_IMPL_AVX512_BIN_OP(+, v_uint32x16, _mm512_add_epi32)
+OPENCV_HAL_IMPL_AVX512_BIN_OP(-, v_uint32x16, _mm512_sub_epi32)
+OPENCV_HAL_IMPL_AVX512_BIN_OP(+, v_int32x16, _mm512_add_epi32)
+OPENCV_HAL_IMPL_AVX512_BIN_OP(-, v_int32x16, _mm512_sub_epi32)
+OPENCV_HAL_IMPL_AVX512_BIN_OP(+, v_uint64x8, _mm512_add_epi64)
+OPENCV_HAL_IMPL_AVX512_BIN_OP(-, v_uint64x8, _mm512_sub_epi64)
+OPENCV_HAL_IMPL_AVX512_BIN_OP(+, v_int64x8, _mm512_add_epi64)
+OPENCV_HAL_IMPL_AVX512_BIN_OP(-, v_int64x8, _mm512_sub_epi64)
 
-OPENCV_HAL_IMPL_AVX_BIN_OP(*, v_uint32x16, _mm512_mullo_epi32)
-OPENCV_HAL_IMPL_AVX_BIN_OP(*, v_int32x16, _mm512_mullo_epi32)
-OPENCV_HAL_IMPL_AVX_BIN_OP(*, v_uint64x8, _mm512_mullo_epi64)
-OPENCV_HAL_IMPL_AVX_BIN_OP(*, v_int64x8, _mm512_mullo_epi64)
+OPENCV_HAL_IMPL_AVX512_BIN_OP(*, v_uint32x16, _mm512_mullo_epi32)
+OPENCV_HAL_IMPL_AVX512_BIN_OP(*, v_int32x16, _mm512_mullo_epi32)
+OPENCV_HAL_IMPL_AVX512_BIN_OP(*, v_uint64x8, _mm512_mullo_epi64)
+OPENCV_HAL_IMPL_AVX512_BIN_OP(*, v_int64x8, _mm512_mullo_epi64)
 
 /** Saturating arithmetics **/
-OPENCV_HAL_IMPL_AVX_BIN_OP(+, v_uint8x64,  _mm512_adds_epu8)
-OPENCV_HAL_IMPL_AVX_BIN_OP(-, v_uint8x64,  _mm512_subs_epu8)
-OPENCV_HAL_IMPL_AVX_BIN_OP(+, v_int8x64,   _mm512_adds_epi8)
-OPENCV_HAL_IMPL_AVX_BIN_OP(-, v_int8x64,   _mm512_subs_epi8)
-OPENCV_HAL_IMPL_AVX_BIN_OP(+, v_uint16x32, _mm512_adds_epu16)
-OPENCV_HAL_IMPL_AVX_BIN_OP(-, v_uint16x32, _mm512_subs_epu16)
-OPENCV_HAL_IMPL_AVX_BIN_OP(+, v_int16x32,  _mm512_adds_epi16)
-OPENCV_HAL_IMPL_AVX_BIN_OP(-, v_int16x32,  _mm512_subs_epi16)
+OPENCV_HAL_IMPL_AVX512_BIN_OP(+, v_uint8x64,  _mm512_adds_epu8)
+OPENCV_HAL_IMPL_AVX512_BIN_OP(-, v_uint8x64,  _mm512_subs_epu8)
+OPENCV_HAL_IMPL_AVX512_BIN_OP(+, v_int8x64,   _mm512_adds_epi8)
+OPENCV_HAL_IMPL_AVX512_BIN_OP(-, v_int8x64,   _mm512_subs_epi8)
+OPENCV_HAL_IMPL_AVX512_BIN_OP(+, v_uint16x32, _mm512_adds_epu16)
+OPENCV_HAL_IMPL_AVX512_BIN_OP(-, v_uint16x32, _mm512_subs_epu16)
+OPENCV_HAL_IMPL_AVX512_BIN_OP(+, v_int16x32,  _mm512_adds_epi16)
+OPENCV_HAL_IMPL_AVX512_BIN_OP(-, v_int16x32,  _mm512_subs_epi16)
 
-OPENCV_HAL_IMPL_AVX_BIN_OP(+, v_float32x16, _mm512_add_ps)
-OPENCV_HAL_IMPL_AVX_BIN_OP(-, v_float32x16, _mm512_sub_ps)
-OPENCV_HAL_IMPL_AVX_BIN_OP(*, v_float32x16, _mm512_mul_ps)
-OPENCV_HAL_IMPL_AVX_BIN_OP(/, v_float32x16, _mm512_div_ps)
-OPENCV_HAL_IMPL_AVX_BIN_OP(+, v_float64x8, _mm512_add_pd)
-OPENCV_HAL_IMPL_AVX_BIN_OP(-, v_float64x8, _mm512_sub_pd)
-OPENCV_HAL_IMPL_AVX_BIN_OP(*, v_float64x8, _mm512_mul_pd)
-OPENCV_HAL_IMPL_AVX_BIN_OP(/, v_float64x8, _mm512_div_pd)
+OPENCV_HAL_IMPL_AVX512_BIN_OP(+, v_float32x16, _mm512_add_ps)
+OPENCV_HAL_IMPL_AVX512_BIN_OP(-, v_float32x16, _mm512_sub_ps)
+OPENCV_HAL_IMPL_AVX512_BIN_OP(*, v_float32x16, _mm512_mul_ps)
+OPENCV_HAL_IMPL_AVX512_BIN_OP(/, v_float32x16, _mm512_div_ps)
+OPENCV_HAL_IMPL_AVX512_BIN_OP(+, v_float64x8, _mm512_add_pd)
+OPENCV_HAL_IMPL_AVX512_BIN_OP(-, v_float64x8, _mm512_sub_pd)
+OPENCV_HAL_IMPL_AVX512_BIN_OP(*, v_float64x8, _mm512_mul_pd)
+OPENCV_HAL_IMPL_AVX512_BIN_OP(/, v_float64x8, _mm512_div_pd)
 
 // saturating multiply
 inline v_uint8x64 operator * (const v_uint8x64& a, const v_uint8x64& b)
@@ -710,146 +710,131 @@ inline void v_mul_expand(const v_int32x16& a, const v_int32x16& b,
 }
 
 /** Bitwise shifts **/
-#define OPENCV_HAL_IMPL_AVX_SHIFT_OP(_Tpuvec, _Tpsvec, suffix)  \
-    inline _Tpuvec operator << (const _Tpuvec& a, int imm)      \
-    { return _Tpuvec(_mm512_slli_##suffix(a.val, imm)); }       \
-    inline _Tpsvec operator << (const _Tpsvec& a, int imm)      \
-    { return _Tpsvec(_mm512_slli_##suffix(a.val, imm)); }       \
-    inline _Tpuvec operator >> (const _Tpuvec& a, int imm)      \
-    { return _Tpuvec(_mm512_srli_##suffix(a.val, imm)); }       \
-    inline _Tpsvec operator >> (const _Tpsvec& a, int imm)      \
-    { return _Tpsvec(_mm512_srai_##suffix(a.val, imm)); }       \
-    template<int imm>                                           \
-    inline _Tpuvec v_shl(const _Tpuvec& a)                      \
-    { return _Tpuvec(_mm512_slli_##suffix(a.val, imm)); }       \
-    template<int imm>                                           \
-    inline _Tpsvec v_shl(const _Tpsvec& a)                      \
-    { return _Tpsvec(_mm512_slli_##suffix(a.val, imm)); }       \
-    template<int imm>                                           \
-    inline _Tpuvec v_shr(const _Tpuvec& a)                      \
-    { return _Tpuvec(_mm512_srli_##suffix(a.val, imm)); }       \
-    template<int imm>                                           \
-    inline _Tpsvec v_shr(const _Tpsvec& a)                      \
+#define OPENCV_HAL_IMPL_AVX512_SHIFT_OP(_Tpuvec, _Tpsvec, suffix) \
+    inline _Tpuvec operator << (const _Tpuvec& a, int imm)        \
+    { return _Tpuvec(_mm512_slli_##suffix(a.val, imm)); }         \
+    inline _Tpsvec operator << (const _Tpsvec& a, int imm)        \
+    { return _Tpsvec(_mm512_slli_##suffix(a.val, imm)); }         \
+    inline _Tpuvec operator >> (const _Tpuvec& a, int imm)        \
+    { return _Tpuvec(_mm512_srli_##suffix(a.val, imm)); }         \
+    inline _Tpsvec operator >> (const _Tpsvec& a, int imm)        \
+    { return _Tpsvec(_mm512_srai_##suffix(a.val, imm)); }         \
+    template<int imm>                                             \
+    inline _Tpuvec v_shl(const _Tpuvec& a)                        \
+    { return _Tpuvec(_mm512_slli_##suffix(a.val, imm)); }         \
+    template<int imm>                                             \
+    inline _Tpsvec v_shl(const _Tpsvec& a)                        \
+    { return _Tpsvec(_mm512_slli_##suffix(a.val, imm)); }         \
+    template<int imm>                                             \
+    inline _Tpuvec v_shr(const _Tpuvec& a)                        \
+    { return _Tpuvec(_mm512_srli_##suffix(a.val, imm)); }         \
+    template<int imm>                                             \
+    inline _Tpsvec v_shr(const _Tpsvec& a)                        \
     { return _Tpsvec(_mm512_srai_##suffix(a.val, imm)); }
 
-OPENCV_HAL_IMPL_AVX_SHIFT_OP(v_uint16x32, v_int16x32, epi16)
-OPENCV_HAL_IMPL_AVX_SHIFT_OP(v_uint32x16, v_int32x16, epi32)
-OPENCV_HAL_IMPL_AVX_SHIFT_OP(v_uint64x8,  v_int64x8,  epi64)
+OPENCV_HAL_IMPL_AVX512_SHIFT_OP(v_uint16x32, v_int16x32, epi16)
+OPENCV_HAL_IMPL_AVX512_SHIFT_OP(v_uint32x16, v_int32x16, epi32)
+OPENCV_HAL_IMPL_AVX512_SHIFT_OP(v_uint64x8,  v_int64x8,  epi64)
 
 
 /** Bitwise logic **/
-#define OPENCV_HAL_IMPL_AVX_LOGIC_OP(_Tpvec, suffix, not_const)  \
-    OPENCV_HAL_IMPL_AVX_BIN_OP(&, _Tpvec, _mm512_and_##suffix)   \
-    OPENCV_HAL_IMPL_AVX_BIN_OP(|, _Tpvec, _mm512_or_##suffix)    \
-    OPENCV_HAL_IMPL_AVX_BIN_OP(^, _Tpvec, _mm512_xor_##suffix)   \
-    inline _Tpvec operator ~ (const _Tpvec& a)                   \
+#define OPENCV_HAL_IMPL_AVX512_LOGIC_OP(_Tpvec, suffix, not_const) \
+    OPENCV_HAL_IMPL_AVX512_BIN_OP(&, _Tpvec, _mm512_and_##suffix)  \
+    OPENCV_HAL_IMPL_AVX512_BIN_OP(|, _Tpvec, _mm512_or_##suffix)   \
+    OPENCV_HAL_IMPL_AVX512_BIN_OP(^, _Tpvec, _mm512_xor_##suffix)  \
+    inline _Tpvec operator ~ (const _Tpvec& a)                     \
     { return _Tpvec(_mm512_xor_##suffix(a.val, not_const)); }
 
-OPENCV_HAL_IMPL_AVX_LOGIC_OP(v_uint8x64,   si512, _mm512_set1_epi32(-1))
-OPENCV_HAL_IMPL_AVX_LOGIC_OP(v_int8x64,    si512, _mm512_set1_epi32(-1))
-OPENCV_HAL_IMPL_AVX_LOGIC_OP(v_uint16x32,  si512, _mm512_set1_epi32(-1))
-OPENCV_HAL_IMPL_AVX_LOGIC_OP(v_int16x32,   si512, _mm512_set1_epi32(-1))
-OPENCV_HAL_IMPL_AVX_LOGIC_OP(v_uint32x16,  si512, _mm512_set1_epi32(-1))
-OPENCV_HAL_IMPL_AVX_LOGIC_OP(v_int32x16,   si512, _mm512_set1_epi32(-1))
-OPENCV_HAL_IMPL_AVX_LOGIC_OP(v_uint64x8,   si512, _mm512_set1_epi64(-1))
-OPENCV_HAL_IMPL_AVX_LOGIC_OP(v_int64x8,    si512, _mm512_set1_epi64(-1))
-OPENCV_HAL_IMPL_AVX_LOGIC_OP(v_float32x16, ps,    _mm512_castsi512_ps(_mm512_set1_epi32(-1)))
-OPENCV_HAL_IMPL_AVX_LOGIC_OP(v_float64x8,  pd,    _mm512_castsi512_pd(_mm512_set1_epi32(-1)))
+OPENCV_HAL_IMPL_AVX512_LOGIC_OP(v_uint8x64,   si512, _mm512_set1_epi32(-1))
+OPENCV_HAL_IMPL_AVX512_LOGIC_OP(v_int8x64,    si512, _mm512_set1_epi32(-1))
+OPENCV_HAL_IMPL_AVX512_LOGIC_OP(v_uint16x32,  si512, _mm512_set1_epi32(-1))
+OPENCV_HAL_IMPL_AVX512_LOGIC_OP(v_int16x32,   si512, _mm512_set1_epi32(-1))
+OPENCV_HAL_IMPL_AVX512_LOGIC_OP(v_uint32x16,  si512, _mm512_set1_epi32(-1))
+OPENCV_HAL_IMPL_AVX512_LOGIC_OP(v_int32x16,   si512, _mm512_set1_epi32(-1))
+OPENCV_HAL_IMPL_AVX512_LOGIC_OP(v_uint64x8,   si512, _mm512_set1_epi64(-1))
+OPENCV_HAL_IMPL_AVX512_LOGIC_OP(v_int64x8,    si512, _mm512_set1_epi64(-1))
+OPENCV_HAL_IMPL_AVX512_LOGIC_OP(v_float32x16, ps,    _mm512_castsi512_ps(_mm512_set1_epi32(-1)))
+OPENCV_HAL_IMPL_AVX512_LOGIC_OP(v_float64x8,  pd,    _mm512_castsi512_pd(_mm512_set1_epi32(-1)))
 
 /** Select **/
-#define OPENCV_HAL_IMPL_AVX_SELECT(_Tpvec, suffix)                               \
+#define OPENCV_HAL_IMPL_AVX512_SELECT(_Tpvec, suffix)                            \
     inline _Tpvec v_select(const _Tpvec& mask, const _Tpvec& a, const _Tpvec& b) \
     { return _Tpvec(_mm512_mask_blend_##suffix(_mm512_cmp_##suffix##_mask(mask.val, _mm512_setzero_si512(), _MM_CMPINT_EQ), a.val, b.val)); }
 
-OPENCV_HAL_IMPL_AVX_SELECT(v_uint8x64,   epi8)
-OPENCV_HAL_IMPL_AVX_SELECT(v_int8x64,    epi8)
-OPENCV_HAL_IMPL_AVX_SELECT(v_uint16x32, epi16)
-OPENCV_HAL_IMPL_AVX_SELECT(v_int16x32,  epi16)
-OPENCV_HAL_IMPL_AVX_SELECT(v_uint32x16, epi32)
-OPENCV_HAL_IMPL_AVX_SELECT(v_int32x16,  epi32)
-OPENCV_HAL_IMPL_AVX_SELECT(v_uint64x8,  epi64)
-OPENCV_HAL_IMPL_AVX_SELECT(v_int64x8,   epi64)
-OPENCV_HAL_IMPL_AVX_SELECT(v_float32x16,   ps)
-OPENCV_HAL_IMPL_AVX_SELECT(v_float64x8,    pd)
+OPENCV_HAL_IMPL_AVX512_SELECT(v_uint8x64,   epi8)
+OPENCV_HAL_IMPL_AVX512_SELECT(v_int8x64,    epi8)
+OPENCV_HAL_IMPL_AVX512_SELECT(v_uint16x32, epi16)
+OPENCV_HAL_IMPL_AVX512_SELECT(v_int16x32,  epi16)
+OPENCV_HAL_IMPL_AVX512_SELECT(v_uint32x16, epi32)
+OPENCV_HAL_IMPL_AVX512_SELECT(v_int32x16,  epi32)
+OPENCV_HAL_IMPL_AVX512_SELECT(v_uint64x8,  epi64)
+OPENCV_HAL_IMPL_AVX512_SELECT(v_int64x8,   epi64)
+OPENCV_HAL_IMPL_AVX512_SELECT(v_float32x16,   ps)
+OPENCV_HAL_IMPL_AVX512_SELECT(v_float64x8,    pd)
 
 /** Comparison **/
-#define OPENCV_HAL_IMPL_AVX_CMP_OP_OV(_Tpvec)                     \
-    inline _Tpvec operator != (const _Tpvec& a, const _Tpvec& b)  \
-    { return ~(a == b); }                                         \
-    inline _Tpvec operator <  (const _Tpvec& a, const _Tpvec& b)  \
-    { return b > a; }                                             \
-    inline _Tpvec operator >= (const _Tpvec& a, const _Tpvec& b)  \
-    { return ~(a < b); }                                          \
-    inline _Tpvec operator <= (const _Tpvec& a, const _Tpvec& b)  \
-    { return b >= a; }
+#define OPENCV_HAL_IMPL_AVX512_CMP_INT(bin_op, imm8, _Tpvec, sufcmp, sufset, tval) \
+    inline _Tpvec operator bin_op (const _Tpvec& a, const _Tpvec& b)               \
+    { return _Tpvec(_mm512_maskz_set1_##sufset(_mm512_cmp_##sufcmp##_mask(a.val, b.val, imm8), tval)); }
 
-#define OPENCV_HAL_IMPL_AVX_CMP_OP_INT(_Tpuvec, _Tpsvec, suffix, sbit)   \
-    inline _Tpuvec operator == (const _Tpuvec& a, const _Tpuvec& b)      \
-    { return _Tpuvec(_mm256_cmpeq_##suffix(a.val, b.val)); }             \
-    inline _Tpuvec operator > (const _Tpuvec& a, const _Tpuvec& b)       \
-    {                                                                    \
-        __m512i smask = _mm256_set1_##suffix(sbit);                      \
-        return _Tpuvec(_mm256_cmpgt_##suffix(                            \
-                       _mm256_xor_si256(a.val, smask),                   \
-                       _mm256_xor_si256(b.val, smask)));                 \
-    }                                                                    \
-    inline _Tpsvec operator == (const _Tpsvec& a, const _Tpsvec& b)      \
-    { return _Tpsvec(_mm256_cmpeq_##suffix(a.val, b.val)); }             \
-    inline _Tpsvec operator > (const _Tpsvec& a, const _Tpsvec& b)       \
-    { return _Tpsvec(_mm256_cmpgt_##suffix(a.val, b.val)); }             \
-    OPENCV_HAL_IMPL_AVX_CMP_OP_OV(_Tpuvec)                               \
-    OPENCV_HAL_IMPL_AVX_CMP_OP_OV(_Tpsvec)
+#define OPENCV_HAL_IMPL_AVX512_CMP_OP_INT(_Tpvec, sufcmp, sufset, tval)           \
+    OPENCV_HAL_IMPL_AVX_CMP_INT(==, _MM_CMPINT_EQ,  _Tpvec, sufcmp, sufset, tval) \
+    OPENCV_HAL_IMPL_AVX_CMP_INT(!=, _MM_CMPINT_NE,  _Tpvec, sufcmp, sufset, tval) \
+    OPENCV_HAL_IMPL_AVX_CMP_INT(<,  _MM_CMPINT_LT,  _Tpvec, sufcmp, sufset, tval) \
+    OPENCV_HAL_IMPL_AVX_CMP_INT(>,  _MM_CMPINT_NLE, _Tpvec, sufcmp, sufset, tval) \
+    OPENCV_HAL_IMPL_AVX_CMP_INT(<=, _MM_CMPINT_LE,  _Tpvec, sufcmp, sufset, tval) \
+    OPENCV_HAL_IMPL_AVX_CMP_INT(>=, _MM_CMPINT_NLT, _Tpvec, sufcmp, sufset, tval)
 
-OPENCV_HAL_IMPL_AVX_CMP_OP_INT(v_uint8x32,  v_int8x32,  epi8,  (char)-128)
-OPENCV_HAL_IMPL_AVX_CMP_OP_INT(v_uint16x16, v_int16x16, epi16, (short)-32768)
-OPENCV_HAL_IMPL_AVX_CMP_OP_INT(v_uint32x8,  v_int32x8,  epi32, (int)0x80000000)
+OPENCV_HAL_IMPL_AVX512_CMP_OP_INT(v_uint8x64,   epu8,  epi8, (char)-1)
+OPENCV_HAL_IMPL_AVX512_CMP_OP_INT(v_int8x64,    epi8,  epi8, (char)-1)
+OPENCV_HAL_IMPL_AVX512_CMP_OP_INT(v_uint16x32, epu16, epi16, (short)-1)
+OPENCV_HAL_IMPL_AVX512_CMP_OP_INT(v_int16x32,  epi16, epi16, (short)-1)
+OPENCV_HAL_IMPL_AVX512_CMP_OP_INT(v_uint32x16, epu32, epi32, (int)-1)
+OPENCV_HAL_IMPL_AVX512_CMP_OP_INT(v_int32x16,  epi32, epi32, (int)-1)
+OPENCV_HAL_IMPL_AVX512_CMP_OP_INT(v_uint64x8,  epu64, epi64, (int64)-1)
+OPENCV_HAL_IMPL_AVX512_CMP_OP_INT(v_int64x8,   epi64, epi64, (int64)-1)
 
-#define OPENCV_HAL_IMPL_AVX_CMP_OP_64BIT(_Tpvec)                 \
-    inline _Tpvec operator == (const _Tpvec& a, const _Tpvec& b) \
-    { return _Tpvec(_mm256_cmpeq_epi64(a.val, b.val)); }         \
-    inline _Tpvec operator != (const _Tpvec& a, const _Tpvec& b) \
-    { return ~(a == b); }
+#define OPENCV_HAL_IMPL_AVX512_CMP_FLT(bin_op, imm8, _Tpvec, sufcmp, sufset, tval) \
+    inline _Tpvec operator bin_op (const _Tpvec& a, const _Tpvec& b)               \
+    { return _Tpvec(_mm512_castsi512_##sufcmp(_mm512_maskz_set1_##sufset(_mm512_cmp_##sufcmp##_mask(a.val, b.val, imm8), tval))); }
 
-OPENCV_HAL_IMPL_AVX_CMP_OP_64BIT(v_uint64x4)
-OPENCV_HAL_IMPL_AVX_CMP_OP_64BIT(v_int64x4)
+#define OPENCV_HAL_IMPL_AVX512_CMP_OP_FLT(_Tpvec, sufcmp, sufset, tval)           \
+    OPENCV_HAL_IMPL_AVX512_CMP_FLT(==, _CMP_EQ_OQ,  _Tpvec, sufcmp, sufset, tval) \
+    OPENCV_HAL_IMPL_AVX512_CMP_FLT(!=, _CMP_NEQ_OQ, _Tpvec, sufcmp, sufset, tval) \
+    OPENCV_HAL_IMPL_AVX512_CMP_FLT(<,  _CMP_LT_OQ,  _Tpvec, sufcmp, sufset, tval) \
+    OPENCV_HAL_IMPL_AVX512_CMP_FLT(>,  _CMP_GT_OQ,  _Tpvec, sufcmp, sufset, tval) \
+    OPENCV_HAL_IMPL_AVX512_CMP_FLT(<=, _CMP_LE_OQ,  _Tpvec, sufcmp, sufset, tval) \
+    OPENCV_HAL_IMPL_AVX512_CMP_FLT(>=, _CMP_GE_OQ,  _Tpvec, sufcmp, sufset, tval)
 
-#define OPENCV_HAL_IMPL_AVX_CMP_FLT(bin_op, imm8, _Tpvec, suffix)    \
-    inline _Tpvec operator bin_op (const _Tpvec& a, const _Tpvec& b) \
-    { return _Tpvec(_mm256_cmp_##suffix(a.val, b.val, imm8)); }
+OPENCV_HAL_IMPL_AVX512_CMP_OP_FLT(v_float32x16, ps, epi32, (int)-1)
+OPENCV_HAL_IMPL_AVX512_CMP_OP_FLT(v_float64x8,  pd, epi64, (int64)-1)
 
-#define OPENCV_HAL_IMPL_AVX_CMP_OP_FLT(_Tpvec, suffix)               \
-    OPENCV_HAL_IMPL_AVX_CMP_FLT(==, _CMP_EQ_OQ,  _Tpvec, suffix)     \
-    OPENCV_HAL_IMPL_AVX_CMP_FLT(!=, _CMP_NEQ_OQ, _Tpvec, suffix)     \
-    OPENCV_HAL_IMPL_AVX_CMP_FLT(<,  _CMP_LT_OQ,  _Tpvec, suffix)     \
-    OPENCV_HAL_IMPL_AVX_CMP_FLT(>,  _CMP_GT_OQ,  _Tpvec, suffix)     \
-    OPENCV_HAL_IMPL_AVX_CMP_FLT(<=, _CMP_LE_OQ,  _Tpvec, suffix)     \
-    OPENCV_HAL_IMPL_AVX_CMP_FLT(>=, _CMP_GE_OQ,  _Tpvec, suffix)
-
-OPENCV_HAL_IMPL_AVX_CMP_OP_FLT(v_float32x8, ps)
-OPENCV_HAL_IMPL_AVX_CMP_OP_FLT(v_float64x4, pd)
-
-inline v_float32x8 v_not_nan(const v_float32x8& a)
-{ return v_float32x8(_mm256_cmp_ps(a.val, a.val, _CMP_ORD_Q)); }
-inline v_float64x4 v_not_nan(const v_float64x4& a)
-{ return v_float64x4(_mm256_cmp_pd(a.val, a.val, _CMP_ORD_Q)); }
+inline v_float32x16 v_not_nan(const v_float32x16& a)
+{ return v_float32x16(_mm512_castsi512_ps(_mm512_maskz_set1_epi32(_mm512_cmp_ps_mask(a.val, a.val, _CMP_ORD_Q), (int)-1))); }
+inline v_float64x8 v_not_nan(const v_float64x8& a)
+{ return v_float64x8(_mm512_castsi512_pd(_mm512_maskz_set1_epi64(_mm512_cmp_pd_mask(a.val, a.val, _CMP_ORD_Q), (int64)-1))); }
 
 /** min/max **/
-OPENCV_HAL_IMPL_AVX_BIN_FUNC(v_min, v_uint8x32,  _mm256_min_epu8)
-OPENCV_HAL_IMPL_AVX_BIN_FUNC(v_max, v_uint8x32,  _mm256_max_epu8)
-OPENCV_HAL_IMPL_AVX_BIN_FUNC(v_min, v_int8x32,   _mm256_min_epi8)
-OPENCV_HAL_IMPL_AVX_BIN_FUNC(v_max, v_int8x32,   _mm256_max_epi8)
-OPENCV_HAL_IMPL_AVX_BIN_FUNC(v_min, v_uint16x16, _mm256_min_epu16)
-OPENCV_HAL_IMPL_AVX_BIN_FUNC(v_max, v_uint16x16, _mm256_max_epu16)
-OPENCV_HAL_IMPL_AVX_BIN_FUNC(v_min, v_int16x16,  _mm256_min_epi16)
-OPENCV_HAL_IMPL_AVX_BIN_FUNC(v_max, v_int16x16,  _mm256_max_epi16)
-OPENCV_HAL_IMPL_AVX_BIN_FUNC(v_min, v_uint32x8,  _mm256_min_epu32)
-OPENCV_HAL_IMPL_AVX_BIN_FUNC(v_max, v_uint32x8,  _mm256_max_epu32)
-OPENCV_HAL_IMPL_AVX_BIN_FUNC(v_min, v_int32x8,   _mm256_min_epi32)
-OPENCV_HAL_IMPL_AVX_BIN_FUNC(v_max, v_int32x8,   _mm256_max_epi32)
-OPENCV_HAL_IMPL_AVX_BIN_FUNC(v_min, v_float32x8, _mm256_min_ps)
-OPENCV_HAL_IMPL_AVX_BIN_FUNC(v_max, v_float32x8, _mm256_max_ps)
-OPENCV_HAL_IMPL_AVX_BIN_FUNC(v_min, v_float64x4, _mm256_min_pd)
-OPENCV_HAL_IMPL_AVX_BIN_FUNC(v_max, v_float64x4, _mm256_max_pd)
+OPENCV_HAL_IMPL_AVX512_BIN_FUNC(v_min, v_uint8x64,   _mm512_min_epu8)
+OPENCV_HAL_IMPL_AVX512_BIN_FUNC(v_max, v_uint8x64,   _mm512_max_epu8)
+OPENCV_HAL_IMPL_AVX512_BIN_FUNC(v_min, v_int8x64,    _mm512_min_epi8)
+OPENCV_HAL_IMPL_AVX512_BIN_FUNC(v_max, v_int8x64,    _mm512_max_epi8)
+OPENCV_HAL_IMPL_AVX512_BIN_FUNC(v_min, v_uint16x32,  _mm512_min_epu16)
+OPENCV_HAL_IMPL_AVX512_BIN_FUNC(v_max, v_uint16x32,  _mm512_max_epu16)
+OPENCV_HAL_IMPL_AVX512_BIN_FUNC(v_min, v_int16x32,   _mm512_min_epi16)
+OPENCV_HAL_IMPL_AVX512_BIN_FUNC(v_max, v_int16x32,   _mm512_max_epi16)
+OPENCV_HAL_IMPL_AVX512_BIN_FUNC(v_min, v_uint32x16,  _mm512_min_epu32)
+OPENCV_HAL_IMPL_AVX512_BIN_FUNC(v_max, v_uint32x16,  _mm512_max_epu32)
+OPENCV_HAL_IMPL_AVX512_BIN_FUNC(v_min, v_int32x16,   _mm512_min_epi32)
+OPENCV_HAL_IMPL_AVX512_BIN_FUNC(v_max, v_int32x16,   _mm512_max_epi32)
+OPENCV_HAL_IMPL_AVX512_BIN_FUNC(v_min, v_uint64x8,   _mm512_min_epu64)
+OPENCV_HAL_IMPL_AVX512_BIN_FUNC(v_max, v_uint64x8,   _mm512_max_epu64)
+OPENCV_HAL_IMPL_AVX512_BIN_FUNC(v_min, v_int64x8,    _mm512_min_epi64)
+OPENCV_HAL_IMPL_AVX512_BIN_FUNC(v_max, v_int64x8,    _mm512_max_epi64)
+OPENCV_HAL_IMPL_AVX512_BIN_FUNC(v_min, v_float32x16, _mm512_min_ps)
+OPENCV_HAL_IMPL_AVX512_BIN_FUNC(v_max, v_float32x16, _mm512_max_ps)
+OPENCV_HAL_IMPL_AVX512_BIN_FUNC(v_min, v_float64x8,  _mm512_min_pd)
+OPENCV_HAL_IMPL_AVX512_BIN_FUNC(v_max, v_float64x8,  _mm512_max_pd)
 
 /** Rotate **/
 template<int imm>

--- a/modules/core/include/opencv2/core/hal/intrin_avx512.hpp
+++ b/modules/core/include/opencv2/core/hal/intrin_avx512.hpp
@@ -908,9 +908,9 @@ inline v_int8x64 v_rotate_left(const v_int8x64& a, const v_int8x64& b)
     enum { SHIFT2 = 64 - imm };
     __m512i pre = _mm512_alignr_epi32(b.val, a.val, SHIFT2 / 4);
     if (SHIFT2 % 4)
-        return v_uint8x32(_mm512_or_si512(_mm512_srli_epi32(pre, SHIFT2 % 4), _mm512_slli_epi32(_mm512_alignr_epi32(b.val, a.val, SHIFT2 / 4 + 1), 4 - SHIFT2 % 4)));
+        return v_int8x64(_mm512_or_si512(_mm512_srli_epi32(pre, SHIFT2 % 4), _mm512_slli_epi32(_mm512_alignr_epi32(b.val, a.val, SHIFT2 / 4 + 1), 4 - SHIFT2 % 4)));
     else
-        return v_uint8x32(pre);
+        return v_int8x64(pre);
 #endif
 }
 template<int imm>
@@ -932,9 +932,9 @@ inline v_int8x64 v_rotate_right(const v_int8x64& a, const v_int8x64& b)
 #else
     __m512i pre = _mm512_alignr_epi32(b.val, a.val, imm / 4);
     if (imm % 4)
-        return v_uint8x32(_mm512_or_si512(_mm512_srli_epi32(pre, imm % 4), _mm512_slli_epi32(_mm512_alignr_epi32(b.val, a.val, imm / 4 + 1), 4 - imm % 4)));
+        return v_int8x64(_mm512_or_si512(_mm512_srli_epi32(pre, imm % 4), _mm512_slli_epi32(_mm512_alignr_epi32(b.val, a.val, imm / 4 + 1), 4 - imm % 4)));
     else
-        return v_uint8x32(pre);
+        return v_int8x64(pre);
 #endif
 }
 template<int imm>
@@ -957,9 +957,9 @@ inline v_int8x64 v_rotate_left(const v_int8x64& a)
     __m512i zero = _mm512_setzero_si512();
     __m512i pre = _mm512_alignr_epi32(zero, a.val, SHIFT2 / 4);
     if (SHIFT2 % 4)
-        return v_uint8x32(_mm512_or_si512(_mm512_srli_epi32(pre, SHIFT2 % 4), _mm512_slli_epi32(_mm512_alignr_epi32(zero, a.val, SHIFT2 / 4 + 1), 4 - SHIFT2 % 4)));
+        return v_int8x64(_mm512_or_si512(_mm512_srli_epi32(pre, SHIFT2 % 4), _mm512_slli_epi32(_mm512_alignr_epi32(zero, a.val, SHIFT2 / 4 + 1), 4 - SHIFT2 % 4)));
     else
-        return v_uint8x32(pre);
+        return v_int8x64(pre);
 #endif
 }
 template<int imm>
@@ -981,9 +981,9 @@ inline v_int8x64 v_rotate_right(const v_int8x64& a)
     __m512i zero = _mm512_setzero_si512();
     __m512i pre = _mm512_alignr_epi32(zero, a.val, imm / 4);
     if (imm % 4)
-        return v_uint8x32(_mm512_or_si512(_mm512_srli_epi32(pre, imm % 4), _mm512_slli_epi32(_mm512_alignr_epi32(zero, a.val, imm / 4 + 1), 4 - imm % 4)));
+        return v_int8x64(_mm512_or_si512(_mm512_srli_epi32(pre, imm % 4), _mm512_slli_epi32(_mm512_alignr_epi32(zero, a.val, imm / 4 + 1), 4 - imm % 4)));
     else
-        return v_uint8x32(pre);
+        return v_int8x64(pre);
 #endif
 }
 

--- a/modules/core/include/opencv2/core/hal/intrin_avx512.hpp
+++ b/modules/core/include/opencv2/core/hal/intrin_avx512.hpp
@@ -1434,7 +1434,8 @@ inline v_float64x8 v512_lut(const double* tab, const int* idx)
 {
     return v_float64x8(_mm512_i32gather_pd(_mm256_loadu_si256((const __m256i*)idx), tab, 8));
 }
-inline v_float64x8 v512_lut_pairs(const double* tab, const int* idx) { 
+inline v_float64x8 v512_lut_pairs(const double* tab, const int* idx)
+{
         return v_float64x8(_mm512_insertf64x2(_mm512_insertf64x2(_mm512_insertf64x2(_mm512_castpd128_pd512(
                                _mm_loadu_pd(tab + idx[0])),
                                _mm_loadu_pd(tab + idx[1]), 1),
@@ -1694,7 +1695,7 @@ inline v_int16x32 v_pack(const v_int32x16& a, const v_int32x16& b)
 { return v_int16x32(_mm512_permutexvar_epi64(_v512_set_epi64(7, 5, 3, 1, 6, 4, 2, 0), _mm512_packs_epi32(a.val, b.val))); }
 
 inline v_uint16x32 v_pack(const v_uint32x16& a, const v_uint32x16& b)
-{ 
+{
     const __m512i m = _mm512_set1_epi32(65535);
     return v_uint16x32(_v512_combine(_mm512_cvtepi32_epi16(_mm512_min_epu16(a.val, m)), _mm512_cvtepi32_epi16(_mm512_min_epu16(b.val, m))));
 }

--- a/modules/core/include/opencv2/core/hal/intrin_avx512.hpp
+++ b/modules/core/include/opencv2/core/hal/intrin_avx512.hpp
@@ -1002,35 +1002,39 @@ template<int imm>                                                               
 inline _Tpvec v_rotate_left(const _Tpvec& a, const _Tpvec& b)                                                                            \
 {                                                                                                                                        \
     enum { SHIFT2 = _Tpvec::nlanes - imm };                                                                                              \
+    enum { MASK = (1 << _Tpvec::nlanes) - 1 };                                                                                           \
     if (imm == 0) return a;                                                                                                              \
     if (imm == _Tpvec::nlanes) return b;                                                                                                 \
     if (imm >= 2*_Tpvec::nlanes) return _Tpvec();                                                                                        \
-    return _Tpvec(_mm512_mask_expand_##suffix(_mm512_maskz_compress_##suffix(0xFFFF << SHIFT2, b), 0xFFFF << imm, a));                   \
+    return _Tpvec(_mm512_mask_expand_##suffix(_mm512_maskz_compress_##suffix((MASK << SHIFT2)&MASK, b), (MASK << imm)&MASK, a));         \
 }                                                                                                                                        \
 template<int imm>                                                                                                                        \
 inline _Tpvec v_rotate_right(const _Tpvec& a, const _Tpvec& b)                                                                           \
 {                                                                                                                                        \
     enum { SHIFT2 = _Tpvec::nlanes - imm };                                                                                              \
+    enum { MASK = (1 << _Tpvec::nlanes) - 1 };                                                                                           \
     if (imm == 0) return a;                                                                                                              \
     if (imm == _Tpvec::nlanes) return b;                                                                                                 \
     if (imm >= 2*_Tpvec::nlanes) return _Tpvec();                                                                                        \
-    return _Tpvec(_mm512_mask_expand_##suffix(_mm512_maskz_compress_##suffix(0xFFFF << imm, a.val), 0xFFFF << SHIFT2, b.val));           \
+    return _Tpvec(_mm512_mask_expand_##suffix(_mm512_maskz_compress_##suffix((MASK << imm)&MASK, a.val), (MASK << SHIFT2)&MASK, b.val)); \
 }                                                                                                                                        \
 template<int imm>                                                                                                                        \
 inline _Tpvec v_rotate_left(const _Tpvec& a)                                                                                             \
 {                                                                                                                                        \
     enum { SHIFT2 = _Tpvec::nlanes - imm };                                                                                              \
+    enum { MASK = (1 << _Tpvec::nlanes) - 1 };                                                                                           \
     if (imm == 0) return a;                                                                                                              \
     if (imm >= _Tpvec::nlanes) return _Tpvec();                                                                                          \
-    return _Tpvec(_mm512_maskz_expand_##suffix(0xFFFF << imm, a.val));                                                                   \
+    return _Tpvec(_mm512_maskz_expand_##suffix((MASK << imm)&MASK, a.val));                                                              \
 }                                                                                                                                        \
 template<int imm>                                                                                                                        \
 inline _Tpvec v_rotate_right(const _Tpvec& a)                                                                                            \
 {                                                                                                                                        \
     enum { SHIFT2 = _Tpvec::nlanes - imm };                                                                                              \
+    enum { MASK = (1 << _Tpvec::nlanes) - 1 };                                                                                           \
     if (imm == 0) return a;                                                                                                              \
     if (imm >= _Tpvec::nlanes) return _Tpvec();                                                                                          \
-    return _Tpvec(_mm512_maskz_compress_##suffix(0xFFFF << imm, a.val));                                                                 \
+    return _Tpvec(_mm512_maskz_compress_##suffix((MASK << imm)&MASK, a.val));                                                            \
 }
 
 OPENCV_HAL_IMPL_AVX512_ROTATE_PM(v_uint8x64,   u8)

--- a/modules/core/include/opencv2/core/hal/intrin_avx512.hpp
+++ b/modules/core/include/opencv2/core/hal/intrin_avx512.hpp
@@ -2697,41 +2697,40 @@ OPENCV_HAL_IMPL_AVX512_LOADSTORE_INTERLEAVE(v_float64x8, double, f64, v_uint64x8
 ////////// Mask and checks /////////
 
 /** Mask **/
-inline int64 v_signmask(const v_int8x64& a)
-{ return (int64)_mm256_movemask_epi8(_v512_extract_low(a.val)) | ((int64)_mm256_movemask_epi8(_v512_extract_high(a.val)) << 32); }
-inline int v_signmask(const v_int16x32& a)
-{ return _mm256_movemask_epi8(_v512_extract_low(v_pack(a, a).val)); }
-inline int v_signmask(const v_int32x16& a)
-{
-    __m512i a16 = _mm512_packs_epi32(a.val, a.val);
-    return _mm_movemask_epi8(_mm512_castsi512_si128(_mm512_permutexvar_epi32(_v512_set_epu32(12, 8, 4, 0, 12, 8, 4, 0, 12, 8, 4, 0, 12, 8, 4, 0), _mm512_packs_epi16(a16, a16))));
-}
+inline int64 v_signmask(const v_int8x64& a) { return (int64)_mm512_cmp_epi8_mask(a.val, _mm512_setzero_si512(), _MM_CMPINT_LT); }
+inline int v_signmask(const v_int16x32& a) { return (int)_mm512_cmp_epi16_mask(a.val, _mm512_setzero_si512(), _MM_CMPINT_LT); }
+inline int v_signmask(const v_int32x16& a) { return (int)_mm512_cmp_epi32_mask(a.val, _mm512_setzero_si512(), _MM_CMPINT_LT); }
+inline int v_signmask(const v_int64x8& a) { return (int)_mm512_cmp_epi64_mask(a.val, _mm512_setzero_si512(), _MM_CMPINT_LT); }
+
 inline int64 v_signmask(const v_uint8x64& a) { return v_signmask(v_reinterpret_as_s8(a)); }
 inline int v_signmask(const v_uint16x32& a) { return v_signmask(v_reinterpret_as_s16(a)); }
 inline int v_signmask(const v_uint32x16& a) { return v_signmask(v_reinterpret_as_s32(a)); }
-
-inline int v_signmask(const v_float32x16& a) { return _mm256_movemask_ps(_v512_extract_low(a.val)) | (_mm256_movemask_ps(_v512_extract_high(a.val)) << 8); }
-inline int v_signmask(const v_float64x8& a) { return _mm256_movemask_ps(_mm512_cvtpd_ps(a.val)); }
+inline int v_signmask(const v_uint64x8& a) { return v_signmask(v_reinterpret_as_s64(a)); }
+inline int v_signmask(const v_float32x16& a) { return v_signmask(v_reinterpret_as_s32(a)); }
+inline int v_signmask(const v_float64x8& a) { return v_signmask(v_reinterpret_as_s64(a)); }
 
 /** Checks **/
-inline bool v_check_all(const v_int8x64& a) { return (_mm256_movemask_epi8(_v512_extract_low(a.val)) & _mm256_movemask_epi8(_v512_extract_high(a.val))) == -1; }
-inline bool v_check_any(const v_int8x64& a) { return (_mm256_movemask_epi8(_v512_extract_low(a.val)) | _mm256_movemask_epi8(_v512_extract_high(a.val))) != 0; }
-inline bool v_check_all(const v_int16x32& a) { return _mm256_movemask_epi8(_v512_extract_low(_mm512_packs_epi16(a.val, a.val))) == -1; }
-inline bool v_check_any(const v_int16x32& a) { return _mm256_movemask_epi8(_v512_extract_low(_mm512_packs_epi16(a.val, a.val))) != 0; }
-inline bool v_check_all(const v_int32x16& a) { return (_mm256_movemask_epi8(_v512_extract_low(_mm512_packs_epi32(a.val, a.val))) & (int)0xaaaa) == (int)0xaaaa; }
-inline bool v_check_any(const v_int32x16& a) { return (_mm256_movemask_epi8(_v512_extract_low(_mm512_packs_epi32(a.val, a.val))) & (int)0xaaaa) != 0; }
+inline bool v_check_all(const v_int8x64& a) { return !(bool)_mm512_cmp_epi8_mask(a.val, _mm512_setzero_si512(), _MM_CMPINT_NLT); }
+inline bool v_check_any(const v_int8x64& a) { return (bool)_mm512_cmp_epi8_mask(a.val, _mm512_setzero_si512(), _MM_CMPINT_LT); }
+inline bool v_check_all(const v_int16x32& a) { return !(bool)_mm512_cmp_epi16_mask(a.val, _mm512_setzero_si512(), _MM_CMPINT_NLT); }
+inline bool v_check_any(const v_int16x32& a) { return (bool)_mm512_cmp_epi16_mask(a.val, _mm512_setzero_si512(), _MM_CMPINT_LT); }
+inline bool v_check_all(const v_int32x16& a) { return !(bool)_mm512_cmp_epi32_mask(a.val, _mm512_setzero_si512(), _MM_CMPINT_NLT); }
+inline bool v_check_any(const v_int32x16& a) { return (bool)_mm512_cmp_epi32_mask(a.val, _mm512_setzero_si512(), _MM_CMPINT_LT); }
+inline bool v_check_all(const v_int64x8& a) { return !(bool)_mm512_cmp_epi64_mask(a.val, _mm512_setzero_si512(), _MM_CMPINT_NLT); }
+inline bool v_check_any(const v_int64x8& a) { return (bool)_mm512_cmp_epi64_mask(a.val, _mm512_setzero_si512(), _MM_CMPINT_LT); }
 
-inline bool v_check_all(const v_float32x16& a) { return (_mm256_movemask_ps(_v512_extract_low(a.val)) & _mm256_movemask_ps(_v512_extract_high(a.val))) == 255; }
-inline bool v_check_any(const v_float32x16& a) { return (_mm256_movemask_ps(_v512_extract_low(a.val)) | _mm256_movemask_ps(_v512_extract_high(a.val))) != 0; }
-inline bool v_check_all(const v_float64x8& a) { return _mm256_movemask_ps(_mm512_cvtpd_ps(a.val)) == 255; }
-inline bool v_check_any(const v_float64x8& a) { return _mm256_movemask_ps(_mm512_cvtpd_ps(a.val)) != 0; }
-
+inline bool v_check_all(const v_float32x16& a) { return v_check_all(v_reinterpret_as_s32(a)); }
+inline bool v_check_any(const v_float32x16& a) { return v_check_any(v_reinterpret_as_s32(a)); }
+inline bool v_check_all(const v_float64x8& a) { return v_check_all(v_reinterpret_as_s64(a)); }
+inline bool v_check_any(const v_float64x8& a) { return v_check_any(v_reinterpret_as_s64(a)); }
 inline bool v_check_all(const v_uint8x64& a) { return v_check_all(v_reinterpret_as_s8(a)); }
 inline bool v_check_all(const v_uint16x32& a) { return v_check_all(v_reinterpret_as_s16(a)); }
-inline bool v_check_all(const v_uint32x16& a) { return v_check_all(v_reinterpret_as_f32(a)); }
+inline bool v_check_all(const v_uint32x16& a) { return v_check_all(v_reinterpret_as_s32(a)); }
+inline bool v_check_all(const v_uint64x8& a) { return v_check_all(v_reinterpret_as_s64(a)); }
 inline bool v_check_any(const v_uint8x64& a) { return v_check_any(v_reinterpret_as_s8(a)); }
 inline bool v_check_any(const v_uint16x32& a) { return v_check_any(v_reinterpret_as_s16(a)); }
-inline bool v_check_any(const v_uint32x16& a) { return v_check_any(v_reinterpret_as_f32(a)); }
+inline bool v_check_any(const v_uint32x16& a) { return v_check_any(v_reinterpret_as_s32(a)); }
+inline bool v_check_any(const v_uint64x8& a) { return v_check_any(v_reinterpret_as_s64(a)); }
 
 inline void v512_cleanup() { _mm256_zeroall(); }
 

--- a/modules/core/include/opencv2/core/hal/intrin_avx512.hpp
+++ b/modules/core/include/opencv2/core/hal/intrin_avx512.hpp
@@ -1482,23 +1482,23 @@ inline void v_lut_deinterleave(const double* tab, const v_int32x16& idxvec, v_fl
 
 inline v_int8x64 v_interleave_pairs(const v_int8x64& vec)
 {
-    return v_int8x64(_mm512_shuffle_epi8(vec.val, _mm512_setr4_epi32(0x0f0d0e0c, 0x0b090a08, 0x07050604, 0x03010200)));
+    return v_int8x64(_mm512_shuffle_epi8(vec.val, _mm512_set4_epi32(0x0f0d0e0c, 0x0b090a08, 0x07050604, 0x03010200)));
 }
 inline v_uint8x64 v_interleave_pairs(const v_uint8x64& vec) { return v_reinterpret_as_u8(v_interleave_pairs(v_reinterpret_as_s8(vec))); }
 inline v_int8x64 v_interleave_quads(const v_int8x64& vec)
 {
-    return v_int8x64(_mm512_shuffle_epi8(vec.val, _mm512_setr4_epi32(0x0f0b0e0a, 0x0d090c08, 0x07030602, 0x05010400)));
+    return v_int8x64(_mm512_shuffle_epi8(vec.val, _mm512_set4_epi32(0x0f0b0e0a, 0x0d090c08, 0x07030602, 0x05010400)));
 }
 inline v_uint8x64 v_interleave_quads(const v_uint8x64& vec) { return v_reinterpret_as_u8(v_interleave_quads(v_reinterpret_as_s8(vec))); }
 
 inline v_int16x32 v_interleave_pairs(const v_int16x32& vec)
 {
-    return v_int16x32(_mm512_shuffle_epi8(vec.val, _mm512_setr4_epi32(0x0f0e0b0a, 0x0d0c0908, 0x07060302, 0x05040100)));
+    return v_int16x32(_mm512_shuffle_epi8(vec.val, _mm512_set4_epi32(0x0f0e0b0a, 0x0d0c0908, 0x07060302, 0x05040100)));
 }
 inline v_uint16x32 v_interleave_pairs(const v_uint16x32& vec) { return v_reinterpret_as_u16(v_interleave_pairs(v_reinterpret_as_s16(vec))); }
 inline v_int16x32 v_interleave_quads(const v_int16x32& vec)
 {
-    return v_int16x32(_mm512_shuffle_epi8(vec.val, _mm512_setr4_epi32(0x0f0e0706, 0x0d0c0504, 0x0b0a0302, 0x09080100)));
+    return v_int16x32(_mm512_shuffle_epi8(vec.val, _mm512_set4_epi32(0x0f0e0706, 0x0d0c0504, 0x0b0a0302, 0x09080100)));
 }
 inline v_uint16x32 v_interleave_quads(const v_uint16x32& vec) { return v_reinterpret_as_u16(v_interleave_quads(v_reinterpret_as_s16(vec))); }
 
@@ -1513,7 +1513,7 @@ inline v_int8x64 v_pack_triplets(const v_int8x64& vec)
 {
     return v_int8x64(_mm512_permutexvar_epi32(_v512_set_epi64(0x0000000f0000000f, 0x0000000f0000000f, 0x0000000e0000000d, 0x0000000c0000000a,
                                                               0x0000000900000008, 0x0000000600000005, 0x0000000400000002, 0x0000000100000000),
-                                              _mm512_shuffle_epi8(vec.val, _mm512_setr4_epi32(0xffffff0f, 0x0e0d0c0a, 0x09080605, 0x04020100))));
+                                              _mm512_shuffle_epi8(vec.val, _mm512_set4_epi32(0xffffff0f, 0x0e0d0c0a, 0x09080605, 0x04020100))));
 }
 inline v_uint8x64 v_pack_triplets(const v_uint8x64& vec) { return v_reinterpret_as_u8(v_pack_triplets(v_reinterpret_as_s8(vec))); }
 

--- a/modules/core/include/opencv2/core/hal/intrin_avx512.hpp
+++ b/modules/core/include/opencv2/core/hal/intrin_avx512.hpp
@@ -5,32 +5,46 @@
 #ifndef OPENCV_HAL_INTRIN_AVX512_HPP
 #define OPENCV_HAL_INTRIN_AVX512_HPP
 
+#define CVT_ROUND_MODES_IMPLEMENTED 0
+
 #define CV_SIMD512 1
 #define CV_SIMD512_64F 1
 #define CV_SIMD512_FP16 0  // no native operations with FP16 type. Only load/store from float32x8 are available (if CV_FP16 == 1)
 
-#define _v512_set_epi64(a7, a6, a5, a4, a3, a2, a1, a0) _mm512_set_epi64((a7),(a6),(a5),(a4),(a3),(a2),(a1),(a0))
-#define _v512_set_epi32(a15, a14, a13, a12, a11, a10,  a9,  a8,  a7,  a6,  a5,  a4,  a3,  a2,  a1,  a0) \
-        _v512_set_epi64(((int64)(a15)<<32)|(int64)(a14), ((int64)(a13)<<32)|(int64)(a12), ((int64)(a11)<<32)|(int64)(a10), ((int64)( a9)<<32)|(int64)( a8), \
-                        ((int64)( a7)<<32)|(int64)( a6), ((int64)( a5)<<32)|(int64)( a4), ((int64)( a3)<<32)|(int64)( a2), ((int64)( a1)<<32)|(int64)( a0))
-#define _v512_set_epi16(a31, a30, a29, a28, a27, a26, a25, a24, a23, a22, a21, a20, a19, a18, a17, a16, \
+#define _v512_set_epu64(a7, a6, a5, a4, a3, a2, a1, a0) _mm512_set_epi64((int64)(a7),(int64)(a6),(int64)(a5),(int64)(a4),(int64)(a3),(int64)(a2),(int64)(a1),(int64)(a0))
+#define _v512_set_epu32(a15, a14, a13, a12, a11, a10,  a9,  a8,  a7,  a6,  a5,  a4,  a3,  a2,  a1,  a0) \
+        _mm512_set_epi64(((int64)(a15)<<32)|(int64)(a14), ((int64)(a13)<<32)|(int64)(a12), ((int64)(a11)<<32)|(int64)(a10), ((int64)( a9)<<32)|(int64)( a8), \
+                         ((int64)( a7)<<32)|(int64)( a6), ((int64)( a5)<<32)|(int64)( a4), ((int64)( a3)<<32)|(int64)( a2), ((int64)( a1)<<32)|(int64)( a0))
+#define _v512_set_epu16(a31, a30, a29, a28, a27, a26, a25, a24, a23, a22, a21, a20, a19, a18, a17, a16, \
                         a15, a14, a13, a12, a11, a10,  a9,  a8,  a7,  a6,  a5,  a4,  a3,  a2,  a1,  a0) \
-        _v512_set_epi32(((int)(a31)<<16)|(int)(a30), ((int)(a29)<<16)|(int)(a28), ((int)(a27)<<16)|(int)(a26), ((int)(a25)<<16)|(int)(a24), \
-                        ((int)(a23)<<16)|(int)(a22), ((int)(a21)<<16)|(int)(a20), ((int)(a19)<<16)|(int)(a18), ((int)(a17)<<16)|(int)(a16), \
-                        ((int)(a15)<<16)|(int)(a14), ((int)(a13)<<16)|(int)(a12), ((int)(a11)<<16)|(int)(a10), ((int)( a9)<<16)|(int)( a8), \
-                        ((int)( a7)<<16)|(int)( a6), ((int)( a5)<<16)|(int)( a4), ((int)( a3)<<16)|(int)( a2), ((int)( a1)<<16)|(int)( a0))
+        _v512_set_epu32(((unsigned)(a31)<<16)|(unsigned)(a30), ((unsigned)(a29)<<16)|(unsigned)(a28), ((unsigned)(a27)<<16)|(unsigned)(a26), ((unsigned)(a25)<<16)|(unsigned)(a24), \
+                        ((unsigned)(a23)<<16)|(unsigned)(a22), ((unsigned)(a21)<<16)|(unsigned)(a20), ((unsigned)(a19)<<16)|(unsigned)(a18), ((unsigned)(a17)<<16)|(unsigned)(a16), \
+                        ((unsigned)(a15)<<16)|(unsigned)(a14), ((unsigned)(a13)<<16)|(unsigned)(a12), ((unsigned)(a11)<<16)|(unsigned)(a10), ((unsigned)( a9)<<16)|(unsigned)( a8), \
+                        ((unsigned)( a7)<<16)|(unsigned)( a6), ((unsigned)( a5)<<16)|(unsigned)( a4), ((unsigned)( a3)<<16)|(unsigned)( a2), ((unsigned)( a1)<<16)|(unsigned)( a0))
+#define _v512_set_epu8(a63, a62, a61, a60, a59, a58, a57, a56, a55, a54, a53, a52, a51, a50, a49, a48, \
+                       a47, a46, a45, a44, a43, a42, a41, a40, a39, a38, a37, a36, a35, a34, a33, a32, \
+                       a31, a30, a29, a28, a27, a26, a25, a24, a23, a22, a21, a20, a19, a18, a17, a16, \
+                       a15, a14, a13, a12, a11, a10,  a9,  a8,  a7,  a6,  a5,  a4,  a3,  a2,  a1,  a0) \
+        _v512_set_epu32(((unsigned)(a63)<<24)|((unsigned)(a62)<<16)|((unsigned)(a61)<<8)|(unsigned)(a60),((unsigned)(a59)<<24)|((unsigned)(a58)<<16)|((unsigned)(a57)<<8)|(unsigned)(a56), \
+                        ((unsigned)(a55)<<24)|((unsigned)(a54)<<16)|((unsigned)(a53)<<8)|(unsigned)(a52),((unsigned)(a51)<<24)|((unsigned)(a50)<<16)|((unsigned)(a49)<<8)|(unsigned)(a48), \
+                        ((unsigned)(a47)<<24)|((unsigned)(a46)<<16)|((unsigned)(a45)<<8)|(unsigned)(a44),((unsigned)(a43)<<24)|((unsigned)(a42)<<16)|((unsigned)(a41)<<8)|(unsigned)(a40), \
+                        ((unsigned)(a39)<<24)|((unsigned)(a38)<<16)|((unsigned)(a37)<<8)|(unsigned)(a36),((unsigned)(a35)<<24)|((unsigned)(a34)<<16)|((unsigned)(a33)<<8)|(unsigned)(a32), \
+                        ((unsigned)(a31)<<24)|((unsigned)(a30)<<16)|((unsigned)(a29)<<8)|(unsigned)(a28),((unsigned)(a27)<<24)|((unsigned)(a26)<<16)|((unsigned)(a25)<<8)|(unsigned)(a24), \
+                        ((unsigned)(a23)<<24)|((unsigned)(a22)<<16)|((unsigned)(a21)<<8)|(unsigned)(a20),((unsigned)(a19)<<24)|((unsigned)(a18)<<16)|((unsigned)(a17)<<8)|(unsigned)(a16), \
+                        ((unsigned)(a15)<<24)|((unsigned)(a14)<<16)|((unsigned)(a13)<<8)|(unsigned)(a12),((unsigned)(a11)<<24)|((unsigned)(a10)<<16)|((unsigned)( a9)<<8)|(unsigned)( a8), \
+                        ((unsigned)( a7)<<24)|((unsigned)( a6)<<16)|((unsigned)( a5)<<8)|(unsigned)( a4),((unsigned)( a3)<<24)|((unsigned)( a2)<<16)|((unsigned)( a1)<<8)|(unsigned)( a0))
 #define _v512_set_epi8(a63, a62, a61, a60, a59, a58, a57, a56, a55, a54, a53, a52, a51, a50, a49, a48, \
                        a47, a46, a45, a44, a43, a42, a41, a40, a39, a38, a37, a36, a35, a34, a33, a32, \
                        a31, a30, a29, a28, a27, a26, a25, a24, a23, a22, a21, a20, a19, a18, a17, a16, \
                        a15, a14, a13, a12, a11, a10,  a9,  a8,  a7,  a6,  a5,  a4,  a3,  a2,  a1,  a0) \
-        _v512_set_epi32(((int)(a63)<<24)|((int)(a62)<<16)|((int)(a61)<<8)|(int)(a60),((int)(a59)<<24)|((int)(a58)<<16)|((int)(a57)<<8)|(int)(a56), \
-                        ((int)(a55)<<24)|((int)(a54)<<16)|((int)(a53)<<8)|(int)(a52),((int)(a51)<<24)|((int)(a50)<<16)|((int)(a49)<<8)|(int)(a48), \
-                        ((int)(a47)<<24)|((int)(a46)<<16)|((int)(a45)<<8)|(int)(a44),((int)(a43)<<24)|((int)(a42)<<16)|((int)(a41)<<8)|(int)(a40), \
-                        ((int)(a39)<<24)|((int)(a38)<<16)|((int)(a37)<<8)|(int)(a36),((int)(a35)<<24)|((int)(a34)<<16)|((int)(a33)<<8)|(int)(a32), \
-                        ((int)(a31)<<24)|((int)(a30)<<16)|((int)(a29)<<8)|(int)(a28),((int)(a27)<<24)|((int)(a26)<<16)|((int)(a25)<<8)|(int)(a24), \
-                        ((int)(a23)<<24)|((int)(a22)<<16)|((int)(a21)<<8)|(int)(a20),((int)(a19)<<24)|((int)(a18)<<16)|((int)(a17)<<8)|(int)(a16), \
-                        ((int)(a15)<<24)|((int)(a14)<<16)|((int)(a13)<<8)|(int)(a12),((int)(a11)<<24)|((int)(a10)<<16)|((int)( a9)<<8)|(int)( a8), \
-                        ((int)( a7)<<24)|((int)( a6)<<16)|((int)( a5)<<8)|(int)( a4),((int)( a3)<<24)|((int)( a2)<<16)|((int)( a1)<<8)|(int)( a0))
+        _v512_set_epu8((uchar)(a63), (uchar)(a62), (uchar)(a61), (uchar)(a60), (uchar)(a59), (uchar)(a58), (uchar)(a57), (uchar)(a56), \
+                       (uchar)(a55), (uchar)(a54), (uchar)(a53), (uchar)(a52), (uchar)(a51), (uchar)(a50), (uchar)(a49), (uchar)(a48), \
+                       (uchar)(a47), (uchar)(a46), (uchar)(a45), (uchar)(a44), (uchar)(a43), (uchar)(a42), (uchar)(a41), (uchar)(a40), \
+                       (uchar)(a39), (uchar)(a38), (uchar)(a37), (uchar)(a36), (uchar)(a35), (uchar)(a34), (uchar)(a33), (uchar)(a32), \
+                       (uchar)(a31), (uchar)(a30), (uchar)(a29), (uchar)(a28), (uchar)(a27), (uchar)(a26), (uchar)(a25), (uchar)(a24), \
+                       (uchar)(a23), (uchar)(a22), (uchar)(a21), (uchar)(a20), (uchar)(a19), (uchar)(a18), (uchar)(a17), (uchar)(a16), \
+                       (uchar)(a15), (uchar)(a14), (uchar)(a13), (uchar)(a12), (uchar)(a11), (uchar)(a10), (uchar)( a9), (uchar)( a8), \
+                       (uchar)( a7), (uchar)( a6), (uchar)( a5), (uchar)( a4), (uchar)( a3), (uchar)( a2), (uchar)( a1), (uchar)( a0))
 
 #ifndef _mm512_cvtpd_pslo
 #ifdef _mm512_zextsi256_si512
@@ -119,14 +133,10 @@ struct v_uint8x64
                uchar v56, uchar v57, uchar v58, uchar v59,
                uchar v60, uchar v61, uchar v62, uchar v63)
     {
-        val = _v512_set_epi8((char)v63, (char)v62, (char)v61, (char)v60, (char)v59, (char)v58, (char)v57, (char)v56,
-                             (char)v55, (char)v54, (char)v53, (char)v52, (char)v51, (char)v50, (char)v49, (char)v48,
-                             (char)v47, (char)v46, (char)v45, (char)v44, (char)v43, (char)v42, (char)v41, (char)v40,
-                             (char)v39, (char)v38, (char)v37, (char)v36, (char)v35, (char)v34, (char)v33, (char)v32,
-                             (char)v31, (char)v30, (char)v29, (char)v28, (char)v27, (char)v26, (char)v25, (char)v24,
-                             (char)v23, (char)v22, (char)v21, (char)v20, (char)v19, (char)v18, (char)v17, (char)v16,
-                             (char)v15, (char)v14, (char)v13, (char)v12, (char)v11, (char)v10, (char)v9,  (char)v8,
-                             (char)v7,  (char)v6,  (char)v5,  (char)v4,  (char)v3,  (char)v2,  (char)v1,  (char)v0);
+        val = _v512_set_epu8(v63, v62, v61, v60, v59, v58, v57, v56, v55, v54, v53, v52, v51, v50, v49, v48,
+                             v47, v46, v45, v44, v43, v42, v41, v40, v39, v38, v37, v36, v35, v34, v33, v32,
+                             v31, v30, v29, v28, v27, v26, v25, v24, v23, v22, v21, v20, v19, v18, v17, v16,
+                             v15, v14, v13, v12, v11, v10, v9,  v8,  v7,  v6,  v5,  v4,  v3,  v2,  v1,  v0);
     }
     v_uint8x64() : val(_mm512_setzero_si512()) {}
     uchar get0() const { return (uchar)_v_cvtsi512_si32(val); }
@@ -181,10 +191,8 @@ struct v_uint16x32
                 ushort v24, ushort v25, ushort v26, ushort v27,
                 ushort v28, ushort v29, ushort v30, ushort v31)
     {
-        val = _v512_set_epi16((short)v31, (short)v30, (short)v29, (short)v28, (short)v27, (short)v26, (short)v25, (short)v24,
-                              (short)v23, (short)v22, (short)v21, (short)v20, (short)v19, (short)v18, (short)v17, (short)v16,
-                              (short)v15, (short)v14, (short)v13, (short)v12, (short)v11, (short)v10, (short)v9,  (short)v8,
-                              (short)v7,  (short)v6,  (short)v5,  (short)v4,  (short)v3,  (short)v2,  (short)v1,  (short)v0);
+        val = _v512_set_epu16(v31, v30, v29, v28, v27, v26, v25, v24, v23, v22, v21, v20, v19, v18, v17, v16,
+                              v15, v14, v13, v12, v11, v10, v9,  v8,  v7,  v6,  v5,  v4,  v3,  v2,  v1,  v0);
     }
     v_uint16x32() : val(_mm512_setzero_si512()) {}
     ushort get0() const { return (ushort)_v_cvtsi512_si32(val); }
@@ -202,8 +210,10 @@ struct v_int16x32
                short v16, short v17, short v18, short v19, short v20, short v21, short v22, short v23,
                short v24, short v25, short v26, short v27, short v28, short v29, short v30, short v31)
     {
-        val = _v512_set_epi16(v31, v30, v29, v28, v27, v26, v25, v24, v23, v22, v21, v20, v19, v18, v17, v16,
-                              v15, v14, v13, v12, v11, v10, v9,  v8,  v7,  v6,  v5,  v4,  v3,  v2,  v1,  v0);
+        val = _v512_set_epu16((ushort)v31, (ushort)v30, (ushort)v29, (ushort)v28, (ushort)v27, (ushort)v26, (ushort)v25, (ushort)v24,
+                              (ushort)v23, (ushort)v22, (ushort)v21, (ushort)v20, (ushort)v19, (ushort)v18, (ushort)v17, (ushort)v16,
+                              (ushort)v15, (ushort)v14, (ushort)v13, (ushort)v12, (ushort)v11, (ushort)v10, (ushort)v9 , (ushort)v8,
+                              (ushort)v7 , (ushort)v6 , (ushort)v5 , (ushort)v4 , (ushort)v3 , (ushort)v2 , (ushort)v1 , (ushort)v0);
     }
     v_int16x32() : val(_mm512_setzero_si512()) {}
     short get0() const { return (short)_v_cvtsi512_si32(val); }
@@ -221,10 +231,8 @@ struct v_uint32x16
                 unsigned v8,  unsigned v9,  unsigned v10, unsigned v11,
                 unsigned v12, unsigned v13, unsigned v14, unsigned v15)
     {
-        val = _mm512_setr_epi32((unsigned)v0,  (unsigned)v1,  (unsigned)v2,  (unsigned)v3,
-                                (unsigned)v4,  (unsigned)v5,  (unsigned)v6,  (unsigned)v7,
-                                (unsigned)v8,  (unsigned)v9,  (unsigned)v10, (unsigned)v11,
-                                (unsigned)v12, (unsigned)v13, (unsigned)v14, (unsigned)v15);
+        val = _mm512_setr_epi32((int)v0,  (int)v1,  (int)v2,  (int)v3, (int)v4,  (int)v5,  (int)v6,  (int)v7,
+                                (int)v8,  (int)v9,  (int)v10, (int)v11, (int)v12, (int)v13, (int)v14, (int)v15);
     }
     v_uint32x16() : val(_mm512_setzero_si512()) {}
     unsigned get0() const { return (unsigned)_v_cvtsi512_si32(val); }
@@ -478,12 +486,12 @@ inline void v_pack_store(float16_t* ptr, const v_float32x16& a)
 inline void v_zip(const v_int8x64& a, const v_int8x64& b, v_int8x64& ab0, v_int8x64& ab1)
 {
 #if CV_AVX_512VBMI
-    __m512i mask0 = _v512_set_epi8( 95,  31,  94,  30,  93,  29,  92,  28,  91,  27,  90,  26,  89,  25,  88,  24,
+    __m512i mask0 = _v512_set_epu8( 95,  31,  94,  30,  93,  29,  92,  28,  91,  27,  90,  26,  89,  25,  88,  24,
                                     87,  23,  86,  22,  85,  21,  84,  20,  83,  19,  82,  18,  81,  17,  80,  16,
                                     79,  15,  78,  14,  77,  13,  76,  12,  75,  11,  74,  10,  73,   9,  72,   8,
                                     71,   7,  70,   6,  69,   5,  68,   4,  67,   3,  66,   2,  65,   1,  64,   0);
     ab0 = v_int8x64(_mm512_permutex2var_epi8(a.val, mask0, b.val));
-    __m512i mask1 = _v512_set_epi8(127,  63, 126,  62, 125,  61, 124,  60, 123,  59, 122,  58, 121,  57, 120,  56,
+    __m512i mask1 = _v512_set_epu8(127,  63, 126,  62, 125,  61, 124,  60, 123,  59, 122,  58, 121,  57, 120,  56,
                                    119,  55, 118,  54, 117,  53, 116,  52, 115,  51, 114,  50, 113,  49, 112,  48,
                                    111,  47, 110,  46, 109,  45, 108,  44, 107,  43, 106,  42, 105,  41, 104,  40,
                                    103,  39, 102,  38, 101,  37, 100,  36,  99,  35,  98,  34,  97,  33,  96,  32);
@@ -491,31 +499,31 @@ inline void v_zip(const v_int8x64& a, const v_int8x64& b, v_int8x64& ab0, v_int8
 #else
     __m512i low  = _mm512_unpacklo_epi8(a.val, b.val);
     __m512i high = _mm512_unpackhi_epi8(a.val, b.val);
-    ab0 = v_int8x64(_mm512_permutex2var_epi64(low, _v512_set_epi64(11, 10, 3, 2,  9,  8, 1, 0), high));
-    ab1 = v_int8x64(_mm512_permutex2var_epi64(low, _v512_set_epi64(15, 14, 7, 6, 13, 12, 5, 4), high));
+    ab0 = v_int8x64(_mm512_permutex2var_epi64(low, _v512_set_epu64(11, 10, 3, 2,  9,  8, 1, 0), high));
+    ab1 = v_int8x64(_mm512_permutex2var_epi64(low, _v512_set_epu64(15, 14, 7, 6, 13, 12, 5, 4), high));
 #endif
 }
 inline void v_zip(const v_int16x32& a, const v_int16x32& b, v_int16x32& ab0, v_int16x32& ab1)
 {
-    __m512i mask0 = _v512_set_epi16(47, 15, 46, 14, 45, 13, 44, 12, 43, 11, 42, 10, 41,  9, 40,  8,
+    __m512i mask0 = _v512_set_epu16(47, 15, 46, 14, 45, 13, 44, 12, 43, 11, 42, 10, 41,  9, 40,  8,
                                     39,  7, 38,  6, 37,  5, 36,  4, 35,  3, 34,  2, 33,  1, 32,  0);
     ab0 = v_int16x32(_mm512_permutex2var_epi16(a.val, mask0, b.val));
-    __m512i mask1 = _v512_set_epi16(63, 31, 62, 30, 61, 29, 60, 28, 59, 27, 58, 26, 57, 25, 56, 24,
+    __m512i mask1 = _v512_set_epu16(63, 31, 62, 30, 61, 29, 60, 28, 59, 27, 58, 26, 57, 25, 56, 24,
                                     55, 23, 54, 22, 53, 21, 52, 20, 51, 19, 50, 18, 49, 17, 48, 16);
     ab1 = v_int16x32(_mm512_permutex2var_epi16(a.val, mask1, b.val));
 }
 inline void v_zip(const v_int32x16& a, const v_int32x16& b, v_int32x16& ab0, v_int32x16& ab1)
 {
-    __m512i mask0 = _v512_set_epi32(23,  7, 22,  6, 21,  5, 20,  4, 19,  3, 18,  2, 17, 1, 16, 0);
+    __m512i mask0 = _v512_set_epu32(23,  7, 22,  6, 21,  5, 20,  4, 19,  3, 18,  2, 17, 1, 16, 0);
     ab0 = v_int32x16(_mm512_permutex2var_epi32(a.val, mask0, b.val));
-    __m512i mask1 = _v512_set_epi32(31, 15, 30, 14, 29, 13, 28, 12, 27, 11, 26, 10, 25, 9, 24, 8);
+    __m512i mask1 = _v512_set_epu32(31, 15, 30, 14, 29, 13, 28, 12, 27, 11, 26, 10, 25, 9, 24, 8);
     ab1 = v_int32x16(_mm512_permutex2var_epi32(a.val, mask1, b.val));
 }
 inline void v_zip(const v_int64x8& a, const v_int64x8& b, v_int64x8& ab0, v_int64x8& ab1)
 {
-    __m512i mask0 = _v512_set_epi64(11, 3, 10, 2,  9, 1,  8, 0);
+    __m512i mask0 = _v512_set_epu64(11, 3, 10, 2,  9, 1,  8, 0);
     ab0 = v_int64x8(_mm512_permutex2var_epi64(a.val, mask0, b.val));
-    __m512i mask1 = _v512_set_epi64(15, 7, 14, 6, 13, 5, 12, 4);
+    __m512i mask1 = _v512_set_epu64(15, 7, 14, 6, 13, 5, 12, 4);
     ab1 = v_int64x8(_mm512_permutex2var_epi64(a.val, mask1, b.val));
 }
 
@@ -612,7 +620,7 @@ inline v_uint8x64 v_mul_wrap(const v_uint8x64& a, const v_uint8x64& b)
     __m512i bd = _mm512_srai_epi16(b.val, 8);
     __m512i p0 = _mm512_mullo_epi16(a.val, b.val); // even
     __m512i p1 = _mm512_slli_epi16(_mm512_mullo_epi16(ad, bd), 8); // odd
-    return v_uint8x64(_mm512_mask_blend_epi8(0x5555555555555555, p0, p1));
+    return v_uint8x64(_mm512_mask_blend_epi8(0xAAAAAAAAAAAAAAAA, p0, p1));
 }
 inline v_int8x64 v_mul_wrap(const v_int8x64& a, const v_int8x64& b)
 {
@@ -893,7 +901,7 @@ inline v_int8x64 v_rotate_right(const v_int8x64& a, const v_int8x64& b)
     if (imm >= 128) return v_int8x64();
 #if CV_AVX_512VBMI
     return v_int8x64(_mm512_permutex2var_epi8(a.val,
-           _v512_set_epi8(0x3f + imm,0x3e + imm,0x3d + imm,0x3c + imm,0x3b + imm,0x3a + imm,0x39 + imm,0x38 + imm,
+           _v512_set_epu8(0x3f + imm,0x3e + imm,0x3d + imm,0x3c + imm,0x3b + imm,0x3a + imm,0x39 + imm,0x38 + imm,
                           0x37 + imm,0x36 + imm,0x35 + imm,0x34 + imm,0x33 + imm,0x32 + imm,0x31 + imm,0x30 + imm,
                           0x2f + imm,0x2e + imm,0x2d + imm,0x2c + imm,0x2b + imm,0x2a + imm,0x29 + imm,0x28 + imm,
                           0x27 + imm,0x26 + imm,0x25 + imm,0x24 + imm,0x23 + imm,0x22 + imm,0x21 + imm,0x20 + imm,
@@ -946,7 +954,7 @@ inline v_int8x64 v_rotate_right(const v_int8x64& a)
     if (imm >= 64) return v_int8x64();
 #if CV_AVX_512VBMI
     return v_int8x64(_mm512_maskz_permutexvar_epi8(0xFFFFFFFFFFFFFFFF >> imm,
-           _v512_set_epi8(0x3f + imm,0x3e + imm,0x3d + imm,0x3c + imm,0x3b + imm,0x3a + imm,0x39 + imm,0x38 + imm,
+           _v512_set_epu8(0x3f + imm,0x3e + imm,0x3d + imm,0x3c + imm,0x3b + imm,0x3a + imm,0x39 + imm,0x38 + imm,
                           0x37 + imm,0x36 + imm,0x35 + imm,0x34 + imm,0x33 + imm,0x32 + imm,0x31 + imm,0x30 + imm,
                           0x2f + imm,0x2e + imm,0x2d + imm,0x2c + imm,0x2b + imm,0x2a + imm,0x29 + imm,0x28 + imm,
                           0x27 + imm,0x26 + imm,0x25 + imm,0x24 + imm,0x23 + imm,0x22 + imm,0x21 + imm,0x20 + imm,
@@ -997,7 +1005,7 @@ inline _Tpvec v_rotate_left(const _Tpvec& a, const _Tpvec& b)                   
     if (imm == 0) return a;                                                                                                              \
     if (imm == _Tpvec::nlanes) return b;                                                                                                 \
     if (imm >= 2*_Tpvec::nlanes) return _Tpvec();                                                                                        \
-    return _Tpvec(_mm512_mask_expand_##suffix(_mm512_maskz_compress_##suffix((MASK << SHIFT2)&MASK, b), (MASK << imm)&MASK, a));         \
+    return _Tpvec(_mm512_mask_expand_##suffix(_mm512_maskz_compress_##suffix((MASK << SHIFT2)&MASK, b.val), (MASK << imm)&MASK, a.val)); \
 }                                                                                                                                        \
 template<int imm>                                                                                                                        \
 inline _Tpvec v_rotate_right(const _Tpvec& a, const _Tpvec& b)                                                                           \
@@ -1141,11 +1149,11 @@ inline v_uint8x64 v_popcount(const v_int8x64& a)
 #if CV_AVX_512BITALG
     return v_uint8x64(_mm512_popcnt_epi8(a.val));
 #elif CV_AVX_512VBMI
-    __m512i _popcnt_table0 = _v512_set_epi8(7, 6, 6, 5, 6, 5, 5, 4, 6, 5, 5, 4, 5, 4, 4, 3,
+    __m512i _popcnt_table0 = _v512_set_epu8(7, 6, 6, 5, 6, 5, 5, 4, 6, 5, 5, 4, 5, 4, 4, 3,
                                             5, 4, 4, 3, 4, 3, 3, 2, 4, 3, 3, 2, 3, 2, 2, 1,
                                             5, 4, 4, 3, 4, 3, 3, 2, 4, 3, 3, 2, 3, 2, 2, 1,
                                             4, 3, 3, 2, 3, 2, 2, 1, 3, 2, 2, 1, 2, 1, 1, 0);
-    __m512i _popcnt_table1 = _v512_set_epi8(7, 6, 6, 5, 6, 5, 5, 4, 6, 5, 5, 4, 5, 4, 4, 3,
+    __m512i _popcnt_table1 = _v512_set_epu8(7, 6, 6, 5, 6, 5, 5, 4, 6, 5, 5, 4, 5, 4, 4, 3,
                                             6, 5, 5, 4, 5, 4, 4, 3, 5, 4, 4, 3, 4, 3, 3, 2,
                                             6, 5, 5, 4, 5, 4, 4, 3, 5, 4, 4, 3, 4, 3, 3, 2,
                                             5, 4, 4, 3, 4, 3, 3, 2, 4, 3, 3, 2, 3, 2, 2, 1);
@@ -1328,6 +1336,7 @@ inline v_int32x16 v_trunc(const v_float32x16& a)
 inline v_int32x16 v_trunc(const v_float64x8& a)
 { return v_int32x16(_mm512_castsi256_si512(_mm512_cvttpd_epi32(a.val))); }
 
+#if CVT_ROUND_MODES_IMPLEMENTED
 inline v_int32x16 v_floor(const v_float32x16& a)
 { return v_int32x16(_mm512_cvt_roundps_epi32(a.val, _MM_FROUND_TO_NEG_INF | _MM_FROUND_NO_EXC)); }
 
@@ -1339,6 +1348,19 @@ inline v_int32x16 v_ceil(const v_float32x16& a)
 
 inline v_int32x16 v_ceil(const v_float64x8& a)
 { return v_int32x16(_mm512_castsi256_si512(_mm512_cvt_roundpd_epi32(a.val, _MM_FROUND_TO_POS_INF | _MM_FROUND_NO_EXC))); }
+#else
+inline v_int32x16 v_floor(const v_float32x16& a)
+{ return v_int32x16(_mm512_cvtps_epi32(_mm512_roundscale_ps(a.val, 1))); }
+
+inline v_int32x16 v_floor(const v_float64x8& a)
+{ return v_int32x16(_mm512_castsi256_si512(_mm512_cvtpd_epi32(_mm512_roundscale_pd(a.val, 1)))); }
+
+inline v_int32x16 v_ceil(const v_float32x16& a)
+{ return v_int32x16(_mm512_cvtps_epi32(_mm512_roundscale_ps(a.val, 2))); }
+
+inline v_int32x16 v_ceil(const v_float64x8& a)
+{ return v_int32x16(_mm512_castsi256_si512(_mm512_cvtpd_epi32(_mm512_roundscale_pd(a.val, 2)))); }
+#endif
 
 /** To float **/
 inline v_float32x16 v_cvt_f32(const v_int32x16& a)
@@ -1522,7 +1544,7 @@ inline v_float32x16 v_interleave_pairs(const v_float32x16& vec) { return v_reint
 
 inline v_int8x64 v_pack_triplets(const v_int8x64& vec)
 {
-    return v_int8x64(_mm512_permutexvar_epi32(_v512_set_epi64(0x0000000f0000000f, 0x0000000f0000000f, 0x0000000e0000000d, 0x0000000c0000000a,
+    return v_int8x64(_mm512_permutexvar_epi32(_v512_set_epu64(0x0000000f0000000f, 0x0000000f0000000f, 0x0000000e0000000d, 0x0000000c0000000a,
                                                               0x0000000900000008, 0x0000000600000005, 0x0000000400000002, 0x0000000100000000),
                                               _mm512_shuffle_epi8(vec.val, _mm512_set4_epi32(0xffffff0f, 0x0e0d0c0a, 0x09080605, 0x04020100))));
 }
@@ -1530,20 +1552,20 @@ inline v_uint8x64 v_pack_triplets(const v_uint8x64& vec) { return v_reinterpret_
 
 inline v_int16x32 v_pack_triplets(const v_int16x32& vec)
 {
-    return v_int16x32(_mm512_permutexvar_epi16(_v512_set_epi64(0x001f001f001f001f, 0x001f001f001f001f, 0x001e001d001c001a, 0x0019001800160015,
+    return v_int16x32(_mm512_permutexvar_epi16(_v512_set_epu64(0x001f001f001f001f, 0x001f001f001f001f, 0x001e001d001c001a, 0x0019001800160015,
                                                                0x0014001200110010, 0x000e000d000c000a, 0x0009000800060005, 0x0004000200010000), vec.val));
 }
 inline v_uint16x32 v_pack_triplets(const v_uint16x32& vec) { return v_reinterpret_as_u16(v_pack_triplets(v_reinterpret_as_s16(vec))); }
 
 inline v_int32x16 v_pack_triplets(const v_int32x16& vec)
 {
-    return v_int32x16(_mm512_permutexvar_epi32(_v512_set_epi64(0x0000000f0000000f, 0x0000000f0000000f, 0x0000000e0000000d, 0x0000000c0000000a,
+    return v_int32x16(_mm512_permutexvar_epi32(_v512_set_epu64(0x0000000f0000000f, 0x0000000f0000000f, 0x0000000e0000000d, 0x0000000c0000000a,
                                                                0x0000000900000008, 0x0000000600000005, 0x0000000400000002, 0x0000000100000000), vec.val));
 }
 inline v_uint32x16 v_pack_triplets(const v_uint32x16& vec) { return v_reinterpret_as_u32(v_pack_triplets(v_reinterpret_as_s32(vec))); }
 inline v_float32x16 v_pack_triplets(const v_float32x16& vec)
 {
-    return v_float32x16(_mm512_permutexvar_ps(_v512_set_epi64(0x0000000f0000000f, 0x0000000f0000000f, 0x0000000e0000000d, 0x0000000c0000000a,
+    return v_float32x16(_mm512_permutexvar_ps(_v512_set_epu64(0x0000000f0000000f, 0x0000000f0000000f, 0x0000000e0000000d, 0x0000000c0000000a,
                                                               0x0000000900000008, 0x0000000600000005, 0x0000000400000002, 0x0000000100000000), vec.val));
 }
 
@@ -1637,7 +1659,7 @@ OPENCV_HAL_IMPL_AVX512_EXPAND_Q(v_int32x16,  schar, _mm512_cvtepi8_epi32)
 /* pack */
 // 16
 inline v_int8x64 v_pack(const v_int16x32& a, const v_int16x32& b)
-{ return v_int8x64(_mm512_permutexvar_epi64(_v512_set_epi64(7, 5, 3, 1, 6, 4, 2, 0), _mm512_packs_epi16(a.val, b.val))); }
+{ return v_int8x64(_mm512_permutexvar_epi64(_v512_set_epu64(7, 5, 3, 1, 6, 4, 2, 0), _mm512_packs_epi16(a.val, b.val))); }
 
 inline v_uint8x64 v_pack(const v_uint16x32& a, const v_uint16x32& b)
 {
@@ -1647,7 +1669,7 @@ inline v_uint8x64 v_pack(const v_uint16x32& a, const v_uint16x32& b)
 
 inline v_uint8x64 v_pack_u(const v_int16x32& a, const v_int16x32& b)
 {
-    return v_uint8x64(_mm512_permutexvar_epi64(_v512_set_epi64(7, 5, 3, 1, 6, 4, 2, 0), _mm512_packus_epi16(a.val, b.val)));
+    return v_uint8x64(_mm512_permutexvar_epi64(_v512_set_epu64(7, 5, 3, 1, 6, 4, 2, 0), _mm512_packus_epi16(a.val, b.val)));
 }
 
 inline void v_pack_store(schar* ptr, const v_int16x32& a)
@@ -1708,16 +1730,16 @@ void v_rshr_pack_store(schar* ptr, const v_int16x32& a)
 
 // 32
 inline v_int16x32 v_pack(const v_int32x16& a, const v_int32x16& b)
-{ return v_int16x32(_mm512_permutexvar_epi64(_v512_set_epi64(7, 5, 3, 1, 6, 4, 2, 0), _mm512_packs_epi32(a.val, b.val))); }
+{ return v_int16x32(_mm512_permutexvar_epi64(_v512_set_epu64(7, 5, 3, 1, 6, 4, 2, 0), _mm512_packs_epi32(a.val, b.val))); }
 
 inline v_uint16x32 v_pack(const v_uint32x16& a, const v_uint32x16& b)
 {
     const __m512i m = _mm512_set1_epi32(65535);
-    return v_uint16x32(_v512_combine(_mm512_cvtepi32_epi16(_mm512_min_epu16(a.val, m)), _mm512_cvtepi32_epi16(_mm512_min_epu16(b.val, m))));
+    return v_uint16x32(_v512_combine(_mm512_cvtepi32_epi16(_mm512_min_epu32(a.val, m)), _mm512_cvtepi32_epi16(_mm512_min_epu32(b.val, m))));
 }
 
 inline v_uint16x32 v_pack_u(const v_int32x16& a, const v_int32x16& b)
-{ return v_uint16x32(_mm512_permutexvar_epi64(_v512_set_epi64(7, 5, 3, 1, 6, 4, 2, 0), _mm512_packus_epi32(a.val, b.val))); }
+{ return v_uint16x32(_mm512_permutexvar_epi64(_v512_set_epu64(7, 5, 3, 1, 6, 4, 2, 0), _mm512_packus_epi32(a.val, b.val))); }
 
 inline void v_pack_store(short* ptr, const v_int32x16& a)
 { v_store_low(ptr, v_pack(a, a)); }
@@ -1725,7 +1747,7 @@ inline void v_pack_store(short* ptr, const v_int32x16& a)
 inline void v_pack_store(ushort* ptr, const v_uint32x16& a)
 {
     const __m512i m = _mm512_set1_epi32(65535);
-    _mm256_storeu_si256((__m256i*)ptr, _mm512_cvtepi32_epi16(_mm512_min_epu16(a.val, m)));
+    _mm256_storeu_si256((__m256i*)ptr, _mm512_cvtepi32_epi16(_mm512_min_epu32(a.val, m)));
 }
 
 inline void v_pack_u_store(ushort* ptr, const v_int32x16& a)
@@ -1819,7 +1841,7 @@ void v_rshr_pack_store(int* ptr, const v_int64x8& a)
 
 // pack boolean
 inline v_uint8x64 v_pack_b(const v_uint16x32& a, const v_uint16x32& b)
-{ return v_uint8x64(_mm512_permutexvar_epi64(_v512_set_epi64(7, 5, 3, 1, 6, 4, 2, 0), _mm512_packs_epi16(a.val, b.val))); }
+{ return v_uint8x64(_mm512_permutexvar_epi64(_v512_set_epu64(7, 5, 3, 1, 6, 4, 2, 0), _mm512_packs_epi16(a.val, b.val))); }
 
 inline v_uint8x64 v_pack_b(const v_uint32x16& a, const v_uint32x16& b,
                            const v_uint32x16& c, const v_uint32x16& d)
@@ -1827,7 +1849,7 @@ inline v_uint8x64 v_pack_b(const v_uint32x16& a, const v_uint32x16& b,
     __m512i ab = _mm512_packs_epi32(a.val, b.val);
     __m512i cd = _mm512_packs_epi32(c.val, d.val);
 
-    return v_uint8x64(_mm512_permutexvar_epi32(_v512_set_epi32(15, 11, 7, 3, 14, 10, 6, 2, 13, 9, 5, 1, 12, 8, 4, 0), _mm512_packs_epi16(ab, cd)));
+    return v_uint8x64(_mm512_permutexvar_epi32(_v512_set_epu32(15, 11, 7, 3, 14, 10, 6, 2, 13, 9, 5, 1, 12, 8, 4, 0), _mm512_packs_epi16(ab, cd)));
 }
 
 inline v_uint8x64 v_pack_b(const v_uint64x8& a, const v_uint64x8& b, const v_uint64x8& c,
@@ -1842,7 +1864,7 @@ inline v_uint8x64 v_pack_b(const v_uint64x8& a, const v_uint64x8& b, const v_uin
     __m512i abcd = _mm512_packs_epi32(ab, cd);
     __m512i efgh = _mm512_packs_epi32(ef, gh);
 
-    return v_uint8x64(_mm512_permutexvar_epi16(_v512_set_epi16(31, 23, 15, 7, 30, 22, 14, 6, 29, 21, 13, 5, 28, 20, 12, 4,
+    return v_uint8x64(_mm512_permutexvar_epi16(_v512_set_epu16(31, 23, 15, 7, 30, 22, 14, 6, 29, 21, 13, 5, 28, 20, 12, 4,
                                                                27, 19, 11, 3, 26, 18, 10, 2, 25, 17,  9, 1, 24, 16,  8, 0), _mm512_packs_epi16(abcd, efgh)));
 }
 
@@ -1874,11 +1896,11 @@ inline void v_load_deinterleave( const uchar* ptr, v_uint8x64& a, v_uint8x64& b 
     __m512i ab0 = _mm512_loadu_si512((const __m512i*)ptr);
     __m512i ab1 = _mm512_loadu_si512((const __m512i*)(ptr + 64));
 #if CV_AVX_512VBMI
-    __m512i mask0 = _v512_set_epi8(126, 124, 122, 120, 118, 116, 114, 112, 110, 108, 106, 104, 102, 100, 98, 96,
+    __m512i mask0 = _v512_set_epu8(126, 124, 122, 120, 118, 116, 114, 112, 110, 108, 106, 104, 102, 100, 98, 96,
                                     94,  92,  90,  88,  86,  84,  82,  80,  78,  76,  74,  72,  70,  68, 66, 64,
                                     62,  60,  58,  56,  54,  52,  50,  48,  46,  44,  42,  40,  38,  36, 34, 32,
                                     30,  28,  26,  24,  22,  20,  18,  16,  14,  12,  10,   8,   6,   4,  2,  0);
-    __m512i mask1 = _v512_set_epi8(127, 125, 123, 121, 119, 117, 115, 113, 111, 109, 107, 105, 103, 101, 99, 97,
+    __m512i mask1 = _v512_set_epu8(127, 125, 123, 121, 119, 117, 115, 113, 111, 109, 107, 105, 103, 101, 99, 97,
                                     95,  93,  91,  89,  87,  85,  83,  81,  79,  77,  75,  73,  71,  69, 67, 65,
                                     63,  61,  59,  57,  55,  53,  51,  49,  47,  45,  43,  41,  39,  37, 35, 33,
                                     31,  29,  27,  25,  23,  21,  19,  17,  15,  13,  11,   9,   7,   5,  3,  1);
@@ -1888,8 +1910,8 @@ inline void v_load_deinterleave( const uchar* ptr, v_uint8x64& a, v_uint8x64& b 
     __m512i mask0 = _mm512_set4_epi32(0x0f0d0b09, 0x07050301, 0x0e0c0a08, 0x06040200);
     __m512i a0b0 = _mm512_shuffle_epi8(ab0, mask0);
     __m512i a1b1 = _mm512_shuffle_epi8(ab1, mask0);
-    __m512i mask1 = _v512_set_epi64(14, 12, 10, 8, 6, 4, 2, 0);
-    __m512i mask2 = _v512_set_epi64(15, 13, 11, 9, 7, 5, 3, 1);
+    __m512i mask1 = _v512_set_epu64(14, 12, 10, 8, 6, 4, 2, 0);
+    __m512i mask2 = _v512_set_epu64(15, 13, 11, 9, 7, 5, 3, 1);
     a = v_uint8x64(_mm512_permutex2var_epi64(a0b0, mask1, a1b1));
     b = v_uint8x64(_mm512_permutex2var_epi64(a0b0, mask2, a1b1));
 #endif
@@ -1899,9 +1921,9 @@ inline void v_load_deinterleave( const ushort* ptr, v_uint16x32& a, v_uint16x32&
 {
     __m512i ab0 = _mm512_loadu_si512((const __m512i*)ptr);
     __m512i ab1 = _mm512_loadu_si512((const __m512i*)(ptr + 32));
-    __m512i mask0 = _v512_set_epi16(62, 60, 58, 56, 54, 52, 50, 48, 46, 44, 42, 40, 38, 36, 34, 32,
+    __m512i mask0 = _v512_set_epu16(62, 60, 58, 56, 54, 52, 50, 48, 46, 44, 42, 40, 38, 36, 34, 32,
                                     30, 28, 26, 24, 22, 20, 18, 16, 14, 12, 10,  8,  6,  4,  2,  0);
-    __m512i mask1 = _v512_set_epi16(63, 61, 59, 57, 55, 53, 51, 49, 47, 45, 43, 41, 39, 37, 35, 33,
+    __m512i mask1 = _v512_set_epu16(63, 61, 59, 57, 55, 53, 51, 49, 47, 45, 43, 41, 39, 37, 35, 33,
                                     31, 29, 27, 25, 23, 21, 19, 17, 15, 13, 11,  9,  7,  5,  3,  1);
     a = v_uint16x32(_mm512_permutex2var_epi16(ab0, mask0, ab1));
     b = v_uint16x32(_mm512_permutex2var_epi16(ab0, mask1, ab1));
@@ -1911,8 +1933,8 @@ inline void v_load_deinterleave( const unsigned* ptr, v_uint32x16& a, v_uint32x1
 {
     __m512i ab0 = _mm512_loadu_si512((const __m512i*)ptr);
     __m512i ab1 = _mm512_loadu_si512((const __m512i*)(ptr + 16));
-    __m512i mask0 = _v512_set_epi32(30, 28, 26, 24, 22, 20, 18, 16, 14, 12, 10, 8, 6, 4, 2, 0);
-    __m512i mask1 = _v512_set_epi32(31, 29, 27, 25, 23, 21, 19, 17, 15, 13, 11, 9, 7, 5, 3, 1);
+    __m512i mask0 = _v512_set_epu32(30, 28, 26, 24, 22, 20, 18, 16, 14, 12, 10, 8, 6, 4, 2, 0);
+    __m512i mask1 = _v512_set_epu32(31, 29, 27, 25, 23, 21, 19, 17, 15, 13, 11, 9, 7, 5, 3, 1);
     a = v_uint32x16(_mm512_permutex2var_epi32(ab0, mask0, ab1));
     b = v_uint32x16(_mm512_permutex2var_epi32(ab0, mask1, ab1));
 }
@@ -1921,8 +1943,8 @@ inline void v_load_deinterleave( const uint64* ptr, v_uint64x8& a, v_uint64x8& b
 {
     __m512i ab0 = _mm512_loadu_si512((const __m512i*)ptr);
     __m512i ab1 = _mm512_loadu_si512((const __m512i*)(ptr + 8));
-    __m512i mask0 = _v512_set_epi64(14, 12, 10, 8, 6, 4, 2, 0);
-    __m512i mask1 = _v512_set_epi64(15, 13, 11, 9, 7, 5, 3, 1);
+    __m512i mask0 = _v512_set_epu64(14, 12, 10, 8, 6, 4, 2, 0);
+    __m512i mask1 = _v512_set_epu64(15, 13, 11, 9, 7, 5, 3, 1);
     a = v_uint64x8(_mm512_permutex2var_epi64(ab0, mask0, ab1));
     b = v_uint64x8(_mm512_permutex2var_epi64(ab0, mask1, ab1));
 }
@@ -1934,14 +1956,14 @@ inline void v_load_deinterleave( const uchar* ptr, v_uint8x64& b, v_uint8x64& g,
     __m512i bgr2 = _mm512_loadu_si512((const __m512i*)(ptr + 128));
 
 #if CV_AVX_512VBMI2
-    __m512i mask0 = _v512_set_epi8(126, 123, 120, 117, 114, 111, 108, 105, 102,  99,  96,  93,  90,  87,  84, 81,
+    __m512i mask0 = _v512_set_epu8(126, 123, 120, 117, 114, 111, 108, 105, 102,  99,  96,  93,  90,  87,  84, 81,
                                     78,  75,  72,  69,  66,  63,  60,  57,  54,  51,  48,  45,  42,  39,  36, 33,
                                     30,  27,  24,  21,  18,  15,  12,   9,   6,   3,   0,  62,  59,  56,  53, 50,
                                     47,  44,  41,  38,  35,  32,  29,  26,  23,  20,  17,  14,  11,   8,   5,  2);
     __m512i r0b01 = _mm512_permutex2var_epi8(bgr0, mask0, bgr1);
     __m512i b1g12 = _mm512_permutex2var_epi8(bgr1, mask0, bgr2);
     __m512i r12b2 = _mm512_permutex2var_epi8(bgr1,
-                    _v512_set_epi8(125, 122, 119, 116, 113, 110, 107, 104, 101,  98,  95,  92,  89,  86,  83, 80,
+                    _v512_set_epu8(125, 122, 119, 116, 113, 110, 107, 104, 101,  98,  95,  92,  89,  86,  83, 80,
                                     77,  74,  71,  68,  65, 127, 124, 121, 118, 115, 112, 109, 106, 103, 100, 97,
                                     94,  91,  88,  85,  82,  79,  76,  73,  70,  67,  64,  61,  58,  55,  52, 49,
                                     46,  43,  40,  37,  34,  31,  28,  25,  22,  19,  16,  13,  10,   7,   4,  1), bgr2);
@@ -1952,27 +1974,27 @@ inline void v_load_deinterleave( const uchar* ptr, v_uint8x64& b, v_uint8x64& g,
     __m512i b0g0b1 = _mm512_mask_blend_epi8(0xb6db6db6db6db6db, bgr1, bgr0);
     __m512i g1r1g2 = _mm512_mask_blend_epi8(0xb6db6db6db6db6db, bgr2, bgr1);
     __m512i r2b2r0 = _mm512_mask_blend_epi8(0xb6db6db6db6db6db, bgr0, bgr2);
-    b = v_uint8x64(_mm512_permutex2var_epi8(b0g0b1, _v512_set_epi8(125, 122, 119, 116, 113, 110, 107, 104, 101,  98,  95,  92,  89,  86,  83,  80,
+    b = v_uint8x64(_mm512_permutex2var_epi8(b0g0b1, _v512_set_epu8(125, 122, 119, 116, 113, 110, 107, 104, 101,  98,  95,  92,  89,  86,  83,  80,
                                                                     77,  74,  71,  68,  65,  63,  61,  60,  58,  57,  55,  54,  52,  51,  49,  48,
                                                                     46,  45,  43,  42,  40,  39,  37,  36,  34,  33,  31,  30,  28,  27,  25,  24,
                                                                     23,  21,  20,  18,  17,  15,  14,  12,  11,   9,   8,   6,   5,   3,   2,   0), bgr2));
-    g = v_uint8x64(_mm512_permutex2var_epi8(g1r1g2, _v512_set_epi8( 63,  61,  60,  58,  57,  55,  54,  52,  51,  49,  48,  46,  45,  43,  42,  40,
+    g = v_uint8x64(_mm512_permutex2var_epi8(g1r1g2, _v512_set_epu8( 63,  61,  60,  58,  57,  55,  54,  52,  51,  49,  48,  46,  45,  43,  42,  40,
                                                                     39,  37,  36,  34,  33,  31,  30,  28,  27,  25,  24,  23,  21,  20,  18,  17,
                                                                     15,  14,  12,  11,   9,   8,   6,   5,   3,   2,   0, 126, 123, 120, 117, 114,
                                                                    111, 108, 105, 102,  99,  96,  93,  90,  87,  84,  81,  78,  75,  72,  69,  66), bgr0));
-    r = v_uint8x64(_mm512_permutex2var_epi8(r2b2r0, _v512_set_epi8( 63,  60,  57,  54,  51,  48,  45,  42,  39,  36,  33,  30,  27,  24,  21,  18,
+    r = v_uint8x64(_mm512_permutex2var_epi8(r2b2r0, _v512_set_epu8( 63,  60,  57,  54,  51,  48,  45,  42,  39,  36,  33,  30,  27,  24,  21,  18,
                                                                     15,  12,   9,   6,   3,   0, 125, 122, 119, 116, 113, 110, 107, 104, 101,  98,
                                                                     95,  92,  89,  86,  83,  80,  77,  74,  71,  68,  65,  62,  59,  56,  53,  50,
                                                                     47,  44,  41,  38,  35,  32,  29,  26,  23,  20,  17,  14,  11,   8,   5,   2), bgr1));
 #else
-    __m512i mask0 = _v512_set_epi16(61, 58, 55, 52, 49, 46, 43, 40, 37, 34, 63, 60, 57, 54, 51, 48,
+    __m512i mask0 = _v512_set_epu16(61, 58, 55, 52, 49, 46, 43, 40, 37, 34, 63, 60, 57, 54, 51, 48,
                                     45, 42, 39, 36, 33, 30, 27, 24, 21, 18, 15, 12,  9,  6,  3,  0);
     __m512i b01g1 = _mm512_permutex2var_epi16(bgr0, mask0, bgr1);
     __m512i r12b2 = _mm512_permutex2var_epi16(bgr1, mask0, bgr2);
     __m512i g20r0 = _mm512_permutex2var_epi16(bgr2, mask0, bgr0);
 
     __m512i b0g0 = _mm512_mask_blend_epi32(0xf800, b01g1, r12b2);
-    __m512i r0b1 = _mm512_permutex2var_epi16(bgr1, _v512_set_epi16(42, 41, 40, 39, 38, 37, 36, 35, 34, 33, 32, 29, 26, 23, 20, 17,
+    __m512i r0b1 = _mm512_permutex2var_epi16(bgr1, _v512_set_epu16(42, 41, 40, 39, 38, 37, 36, 35, 34, 33, 32, 29, 26, 23, 20, 17,
                                                                    14, 11,  8,  5,  2, 53, 52, 51, 50, 49, 48, 47, 46, 45, 44, 43), g20r0);
     __m512i g1r1 = _mm512_alignr_epi32(r12b2, g20r0, 11);
     b = v_uint8x64(_mm512_mask_blend_epi8(0xAAAAAAAAAAAAAAAA, b0g0, r0b1));
@@ -1987,14 +2009,14 @@ inline void v_load_deinterleave( const ushort* ptr, v_uint16x32& b, v_uint16x32&
     __m512i bgr1 = _mm512_loadu_si512((const __m512i*)(ptr + 32));
     __m512i bgr2 = _mm512_loadu_si512((const __m512i*)(ptr + 64));
 
-    __m512i mask0 = _v512_set_epi16(61, 58, 55, 52, 49, 46, 43, 40, 37, 34, 63, 60, 57, 54, 51, 48,
+    __m512i mask0 = _v512_set_epu16(61, 58, 55, 52, 49, 46, 43, 40, 37, 34, 63, 60, 57, 54, 51, 48,
                                     45, 42, 39, 36, 33, 30, 27, 24, 21, 18, 15, 12,  9,  6,  3,  0);
     __m512i b01g1 = _mm512_permutex2var_epi16(bgr0, mask0, bgr1);
     __m512i r12b2 = _mm512_permutex2var_epi16(bgr1, mask0, bgr2);
     __m512i g20r0 = _mm512_permutex2var_epi16(bgr2, mask0, bgr0);
 
     b = v_uint16x32(_mm512_mask_blend_epi32(0xf800, b01g1, r12b2));
-    g = v_uint16x32(_mm512_permutex2var_epi16(bgr1, _v512_set_epi16(42, 41, 40, 39, 38, 37, 36, 35, 34, 33, 32, 29, 26, 23, 20, 17,
+    g = v_uint16x32(_mm512_permutex2var_epi16(bgr1, _v512_set_epu16(42, 41, 40, 39, 38, 37, 36, 35, 34, 33, 32, 29, 26, 23, 20, 17,
                                                                     14, 11,  8,  5,  2, 53, 52, 51, 50, 49, 48, 47, 46, 45, 44, 43), g20r0));
     r = v_uint16x32(_mm512_alignr_epi32(r12b2, g20r0, 11));
 }
@@ -2005,14 +2027,14 @@ inline void v_load_deinterleave( const unsigned* ptr, v_uint32x16& b, v_uint32x1
     __m512i bgr1 = _mm512_loadu_si512((const __m512i*)(ptr + 16));
     __m512i bgr2 = _mm512_loadu_si512((const __m512i*)(ptr + 32));
 
-    __m512i mask0 = _v512_set_epi32(29, 26, 23, 20, 17, 30, 27, 24, 21, 18, 15, 12, 9, 6, 3, 0);
+    __m512i mask0 = _v512_set_epu32(29, 26, 23, 20, 17, 30, 27, 24, 21, 18, 15, 12, 9, 6, 3, 0);
     __m512i b01r1 = _mm512_permutex2var_epi32(bgr0, mask0, bgr1);
     __m512i g12b2 = _mm512_permutex2var_epi32(bgr1, mask0, bgr2);
     __m512i r20g0 = _mm512_permutex2var_epi32(bgr2, mask0, bgr0);
 
     b = v_uint32x16(_mm512_mask_blend_epi32(0xf800, b01r1, g12b2));
     g = v_uint32x16(_mm512_alignr_epi32(g12b2, r20g0, 11));
-    r = v_uint32x16(_mm512_permutex2var_epi32(bgr1, _v512_set_epi32(21, 20, 19, 18, 17, 16, 13, 10, 7, 4, 1, 26, 25, 24, 23, 22), r20g0));
+    r = v_uint32x16(_mm512_permutex2var_epi32(bgr1, _v512_set_epu32(21, 20, 19, 18, 17, 16, 13, 10, 7, 4, 1, 26, 25, 24, 23, 22), r20g0));
 }
 
 inline void v_load_deinterleave( const uint64* ptr, v_uint64x8& b, v_uint64x8& g, v_uint64x8& r )
@@ -2021,14 +2043,14 @@ inline void v_load_deinterleave( const uint64* ptr, v_uint64x8& b, v_uint64x8& g
     __m512i bgr1 = _mm512_loadu_si512((const __m512i*)(ptr + 8));
     __m512i bgr2 = _mm512_loadu_si512((const __m512i*)(ptr + 16));
 
-    __m512i mask0 = _v512_set_epi64(13, 10, 15, 12, 9, 6, 3, 0);
+    __m512i mask0 = _v512_set_epu64(13, 10, 15, 12, 9, 6, 3, 0);
     __m512i b01g1 = _mm512_permutex2var_epi64(bgr0, mask0, bgr1);
     __m512i r12b2 = _mm512_permutex2var_epi64(bgr1, mask0, bgr2);
     __m512i g20r0 = _mm512_permutex2var_epi64(bgr2, mask0, bgr0);
 
     b = v_uint64x8(_mm512_mask_blend_epi64(0xc0, b01g1, r12b2));
     r = v_uint64x8(_mm512_alignr_epi64(r12b2, g20r0, 6));
-    g = v_uint64x8(_mm512_permutex2var_epi64(bgr1, _v512_set_epi64(10, 9, 8, 5, 2, 13, 12, 11), g20r0));
+    g = v_uint64x8(_mm512_permutex2var_epi64(bgr1, _v512_set_epu64(10, 9, 8, 5, 2, 13, 12, 11), g20r0));
 }
 
 inline void v_load_deinterleave( const uchar* ptr, v_uint8x64& b, v_uint8x64& g, v_uint8x64& r, v_uint8x64& a )
@@ -2039,11 +2061,11 @@ inline void v_load_deinterleave( const uchar* ptr, v_uint8x64& b, v_uint8x64& g,
     __m512i bgra3 = _mm512_loadu_si512((const __m512i*)(ptr + 192));
 
 #if CV_AVX_512VBMI
-    __m512i mask0 = _v512_set_epi8(126, 124, 122, 120, 118, 116, 114, 112, 110, 108, 106, 104, 102, 100, 98, 96,
+    __m512i mask0 = _v512_set_epu8(126, 124, 122, 120, 118, 116, 114, 112, 110, 108, 106, 104, 102, 100, 98, 96,
                                     94,  92,  90,  88,  86,  84,  82,  80,  78,  76,  74,  72,  70,  68, 66, 64,
                                     62,  60,  58,  56,  54,  52,  50,  48,  46,  44,  42,  40,  38,  36, 34, 32,
                                     30,  28,  26,  24,  22,  20,  18,  16,  14,  12,  10,   8,   6,   4,  2,  0);
-    __m512i mask1 = _v512_set_epi8(127, 125, 123, 121, 119, 117, 115, 113, 111, 109, 107, 105, 103, 101, 99, 97,
+    __m512i mask1 = _v512_set_epu8(127, 125, 123, 121, 119, 117, 115, 113, 111, 109, 107, 105, 103, 101, 99, 97,
                                     95,  93,  91,  89,  87,  85,  83,  81,  79,  77,  75,  73,  71,  69, 67, 65,
                                     63,  61,  59,  57,  55,  53,  51,  49,  47,  45,  43,  41,  39,  37, 35, 33,
                                     31,  29,  27,  25,  23,  21,  19,  17,  15,  13,  11,   9,   7,   5,  3,  1);
@@ -2064,8 +2086,8 @@ inline void v_load_deinterleave( const uchar* ptr, v_uint8x64& b, v_uint8x64& g,
     __m512i b2g2r2a2 = _mm512_shuffle_epi8(bgra2, mask);
     __m512i b3g3r3a3 = _mm512_shuffle_epi8(bgra3, mask);
 
-    __m512i mask0 = _v512_set_epi32(30, 28, 26, 24, 22, 20, 18, 16, 14, 12, 10, 8, 6, 4, 2, 0);
-    __m512i mask1 = _v512_set_epi32(31, 29, 27, 25, 23, 21, 19, 17, 15, 13, 11, 9, 7, 5, 3, 1);
+    __m512i mask0 = _v512_set_epu32(30, 28, 26, 24, 22, 20, 18, 16, 14, 12, 10, 8, 6, 4, 2, 0);
+    __m512i mask1 = _v512_set_epu32(31, 29, 27, 25, 23, 21, 19, 17, 15, 13, 11, 9, 7, 5, 3, 1);
 
     __m512i br01 = _mm512_permutex2var_epi32(b0g0r0a0, mask0, b1g1r1a1);
     __m512i ga01 = _mm512_permutex2var_epi32(b0g0r0a0, mask1, b1g1r1a1);
@@ -2086,9 +2108,9 @@ inline void v_load_deinterleave( const ushort* ptr, v_uint16x32& b, v_uint16x32&
     __m512i bgra2 = _mm512_loadu_si512((const __m512i*)(ptr + 64));
     __m512i bgra3 = _mm512_loadu_si512((const __m512i*)(ptr + 96));
 
-    __m512i mask0 = _v512_set_epi16(62, 60, 58, 56, 54, 52, 50, 48, 46, 44, 42, 40, 38, 36, 34, 32,
+    __m512i mask0 = _v512_set_epu16(62, 60, 58, 56, 54, 52, 50, 48, 46, 44, 42, 40, 38, 36, 34, 32,
                                     30, 28, 26, 24, 22, 20, 18, 16, 14, 12, 10,  8,  6,  4,  2,  0);
-    __m512i mask1 = _v512_set_epi16(63, 61, 59, 57, 55, 53, 51, 49, 47, 45, 43, 41, 39, 37, 35, 33,
+    __m512i mask1 = _v512_set_epu16(63, 61, 59, 57, 55, 53, 51, 49, 47, 45, 43, 41, 39, 37, 35, 33,
                                     31, 29, 27, 25, 23, 21, 19, 17, 15, 13, 11,  9,  7,  5,  3,  1);
 
     __m512i br01 = _mm512_permutex2var_epi16(bgra0, mask0, bgra1);
@@ -2109,8 +2131,8 @@ inline void v_load_deinterleave( const unsigned* ptr, v_uint32x16& b, v_uint32x1
     __m512i bgra2 = _mm512_loadu_si512((const __m512i*)(ptr + 32));
     __m512i bgra3 = _mm512_loadu_si512((const __m512i*)(ptr + 48));
 
-    __m512i mask0 = _v512_set_epi32(30, 28, 26, 24, 22, 20, 18, 16, 14, 12, 10, 8, 6, 4, 2, 0);
-    __m512i mask1 = _v512_set_epi32(31, 29, 27, 25, 23, 21, 19, 17, 15, 13, 11, 9, 7, 5, 3, 1);
+    __m512i mask0 = _v512_set_epu32(30, 28, 26, 24, 22, 20, 18, 16, 14, 12, 10, 8, 6, 4, 2, 0);
+    __m512i mask1 = _v512_set_epu32(31, 29, 27, 25, 23, 21, 19, 17, 15, 13, 11, 9, 7, 5, 3, 1);
 
     __m512i br01 = _mm512_permutex2var_epi32(bgra0, mask0, bgra1);
     __m512i ga01 = _mm512_permutex2var_epi32(bgra0, mask1, bgra1);
@@ -2130,8 +2152,8 @@ inline void v_load_deinterleave( const uint64* ptr, v_uint64x8& b, v_uint64x8& g
     __m512i bgra2 = _mm512_loadu_si512((const __m512i*)(ptr + 16));
     __m512i bgra3 = _mm512_loadu_si512((const __m512i*)(ptr + 24));
 
-    __m512i mask0 = _v512_set_epi64(14, 12, 10, 8, 6, 4, 2, 0);
-    __m512i mask1 = _v512_set_epi64(15, 13, 11, 9, 7, 5, 3, 1);
+    __m512i mask0 = _v512_set_epu64(14, 12, 10, 8, 6, 4, 2, 0);
+    __m512i mask1 = _v512_set_epu64(15, 13, 11, 9, 7, 5, 3, 1);
 
     __m512i br01 = _mm512_permutex2var_epi64(bgra0, mask0, bgra1);
     __m512i ga01 = _mm512_permutex2var_epi64(bgra0, mask1, bgra1);
@@ -2238,15 +2260,15 @@ inline void v_store_interleave( uchar* ptr, const v_uint8x64& b, const v_uint8x6
                                 hal::StoreMode mode=hal::STORE_UNALIGNED )
 {
 #if CV_AVX_512VBMI
-    __m512i mask0 = _v512_set_epi8(127,  84,  20, 126,  83,  19, 125,  82,  18, 124,  81,  17, 123,  80,  16, 122,
+    __m512i mask0 = _v512_set_epu8(127,  84,  20, 126,  83,  19, 125,  82,  18, 124,  81,  17, 123,  80,  16, 122,
                                     79,  15, 121,  78,  14, 120,  77,  13, 119,  76,  12, 118,  75,  11, 117,  74,
                                     10, 116,  73,   9, 115,  72,   8, 114,  71,   7, 113,  70,   6, 112,  69,   5,
                                    111,  68,   4, 110,  67,   3, 109,  66,   2, 108,  65,   1, 107,  64,   0, 106);
-    __m512i mask1 = _v512_set_epi8( 21,  42, 105,  20,  41, 104,  19,  40, 103,  18,  39, 102,  17,  38, 101,  16,
+    __m512i mask1 = _v512_set_epu8( 21,  42, 105,  20,  41, 104,  19,  40, 103,  18,  39, 102,  17,  38, 101,  16,
                                     37, 100,  15,  36,  99,  14,  35,  98,  13,  34,  97,  12,  33,  96,  11,  32,
                                     95,  10,  31,  94,   9,  30,  93,   8,  29,  92,   7,  28,  91,   6,  27,  90,
                                      5,  26,  89,   4,  25,  88,   3,  24,  87,   2,  23,  86,   1,  22,  85,   0);
-    __m512i mask2 = _v512_set_epi8(106, 127,  63, 105, 126,  62, 104, 125,  61, 103, 124,  60, 102, 123,  59, 101,
+    __m512i mask2 = _v512_set_epu8(106, 127,  63, 105, 126,  62, 104, 125,  61, 103, 124,  60, 102, 123,  59, 101,
                                    122,  58, 100, 121,  57,  99, 120,  56,  98, 119,  55,  97, 118,  54,  96, 117,
                                     53,  95, 116,  52,  94, 115,  51,  93, 114,  50,  92, 113,  49,  91, 112,  48,
                                     90, 111,  47,  89, 110,  46,  88, 109,  45,  87, 108,  44,  86, 107,  43,  85);
@@ -2263,11 +2285,11 @@ inline void v_store_interleave( uchar* ptr, const v_uint8x64& b, const v_uint8x6
     __m512i r0b1 = _mm512_mask_blend_epi8(0xAAAAAAAAAAAAAAAA, r.val, b.val);
     __m512i g1r1 = _mm512_mask_blend_epi8(0xAAAAAAAAAAAAAAAA, g1g0, r.val);
 
-    __m512i mask0 = _v512_set_epi16(42, 10, 31, 41,  9, 30, 40,  8, 29, 39,  7, 28, 38,  6, 27, 37,
+    __m512i mask0 = _v512_set_epu16(42, 10, 31, 41,  9, 30, 40,  8, 29, 39,  7, 28, 38,  6, 27, 37,
                                      5, 26, 36,  4, 25, 35,  3, 24, 34,  2, 23, 33,  1, 22, 32,  0);
-    __m512i mask1 = _v512_set_epi16(21, 52, 41, 20, 51, 40, 19, 50, 39, 18, 49, 38, 17, 48, 37, 16,
+    __m512i mask1 = _v512_set_epu16(21, 52, 41, 20, 51, 40, 19, 50, 39, 18, 49, 38, 17, 48, 37, 16,
                                     47, 36, 15, 46, 35, 14, 45, 34, 13, 44, 33, 12, 43, 32, 11, 42);
-    __m512i mask2 = _v512_set_epi16(63, 31, 20, 62, 30, 19, 61, 29, 18, 60, 28, 17, 59, 27, 16, 58,
+    __m512i mask2 = _v512_set_epu16(63, 31, 20, 62, 30, 19, 61, 29, 18, 60, 28, 17, 59, 27, 16, 58,
                                     26, 15, 57, 25, 14, 56, 24, 13, 55, 23, 12, 54, 22, 11, 53, 21);
     __m512i b0g0b2 = _mm512_permutex2var_epi16(b0g0, mask0, r0b1);
     __m512i r1b1r0 = _mm512_permutex2var_epi16(b0g0, mask1, g1r1);
@@ -2301,11 +2323,11 @@ inline void v_store_interleave( uchar* ptr, const v_uint8x64& b, const v_uint8x6
 inline void v_store_interleave( ushort* ptr, const v_uint16x32& b, const v_uint16x32& g, const v_uint16x32& r,
                                 hal::StoreMode mode=hal::STORE_UNALIGNED )
 {
-    __m512i mask0 = _v512_set_epi16(42, 10, 31, 41,  9, 30, 40,  8, 29, 39,  7, 28, 38,  6, 27, 37,
+    __m512i mask0 = _v512_set_epu16(42, 10, 31, 41,  9, 30, 40,  8, 29, 39,  7, 28, 38,  6, 27, 37,
                                      5, 26, 36,  4, 25, 35,  3, 24, 34,  2, 23, 33,  1, 22, 32,  0);
-    __m512i mask1 = _v512_set_epi16(21, 52, 41, 20, 51, 40, 19, 50, 39, 18, 49, 38, 17, 48, 37, 16,
+    __m512i mask1 = _v512_set_epu16(21, 52, 41, 20, 51, 40, 19, 50, 39, 18, 49, 38, 17, 48, 37, 16,
                                     47, 36, 15, 46, 35, 14, 45, 34, 13, 44, 33, 12, 43, 32, 11, 42);
-    __m512i mask2 = _v512_set_epi16(63, 31, 20, 62, 30, 19, 61, 29, 18, 60, 28, 17, 59, 27, 16, 58,
+    __m512i mask2 = _v512_set_epu16(63, 31, 20, 62, 30, 19, 61, 29, 18, 60, 28, 17, 59, 27, 16, 58,
                                     26, 15, 57, 25, 14, 56, 24, 13, 55, 23, 12, 54, 22, 11, 53, 21);
     __m512i b0g0b2 = _mm512_permutex2var_epi16(b.val, mask0, g.val);
     __m512i r1b1r0 = _mm512_permutex2var_epi16(b.val, mask1, r.val);
@@ -2338,8 +2360,8 @@ inline void v_store_interleave( ushort* ptr, const v_uint16x32& b, const v_uint1
 inline void v_store_interleave( unsigned* ptr, const v_uint32x16& b, const v_uint32x16& g, const v_uint32x16& r,
                                 hal::StoreMode mode=hal::STORE_UNALIGNED )
 {
-    __m512i mask0 = _v512_set_epi32(26, 31, 15, 25, 30, 14, 24, 29, 13, 23, 28, 12, 22, 27, 11, 21);
-    __m512i mask1 = _v512_set_epi32(31, 10, 25, 30,  9, 24, 29,  8, 23, 28,  7, 22, 27,  6, 21, 26);
+    __m512i mask0 = _v512_set_epu32(26, 31, 15, 25, 30, 14, 24, 29, 13, 23, 28, 12, 22, 27, 11, 21);
+    __m512i mask1 = _v512_set_epu32(31, 10, 25, 30,  9, 24, 29,  8, 23, 28,  7, 22, 27,  6, 21, 26);
     __m512i g1b2g2 = _mm512_permutex2var_epi32(b.val, mask0, g.val);
     __m512i r2r1b1 = _mm512_permutex2var_epi32(b.val, mask1, r.val);
 
@@ -2370,8 +2392,8 @@ inline void v_store_interleave( unsigned* ptr, const v_uint32x16& b, const v_uin
 inline void v_store_interleave( uint64* ptr, const v_uint64x8& b, const v_uint64x8& g, const v_uint64x8& r,
                                 hal::StoreMode mode=hal::STORE_UNALIGNED )
 {
-    __m512i mask0 = _v512_set_epi64( 5, 12,  7,  4, 11,  6,  3, 10);
-    __m512i mask1 = _v512_set_epi64(15,  7,  4, 14,  6,  3, 13,  5);
+    __m512i mask0 = _v512_set_epu64( 5, 12,  7,  4, 11,  6,  3, 10);
+    __m512i mask1 = _v512_set_epu64(15,  7,  4, 14,  6,  3, 13,  5);
     __m512i r1b1b2 = _mm512_permutex2var_epi64(b.val, mask0, r.val);
     __m512i g2r2g1 = _mm512_permutex2var_epi64(g.val, mask1, r.val);
 
@@ -2599,11 +2621,11 @@ OPENCV_HAL_IMPL_AVX512_LOADSTORE_INTERLEAVE(v_float64x8, double, f64, v_uint64x8
 inline int64 v_signmask(const v_int8x64& a)
 { return (int64)_mm256_movemask_epi8(_v512_extract_low(a.val)) | ((int64)_mm256_movemask_epi8(_v512_extract_high(a.val)) << 32); }
 inline int v_signmask(const v_int16x32& a)
-{ return _mm256_movemask_epi8(_v512_extract_low(_mm512_packs_epi16(a.val, a.val))); }
+{ return _mm256_movemask_epi8(_v512_extract_low(v_pack(a, a).val)); }
 inline int v_signmask(const v_int32x16& a)
 {
-    __m256i a16 = _v512_extract_low(_mm512_packs_epi32(a.val, a.val));
-    return _mm_movemask_epi8(_mm256_castsi256_si128(_mm256_packs_epi16(a16, a16)));
+    __m512i a16 = _mm512_packs_epi32(a.val, a.val);
+    return _mm_movemask_epi8(_mm512_castsi512_si128(_mm512_permutexvar_epi32(_v512_set_epu32(12, 8, 4, 0, 12, 8, 4, 0, 12, 8, 4, 0, 12, 8, 4, 0), _mm512_packs_epi16(a16, a16))));
 }
 inline int64 v_signmask(const v_uint8x64& a) { return v_signmask(v_reinterpret_as_s8(a)); }
 inline int v_signmask(const v_uint16x32& a) { return v_signmask(v_reinterpret_as_s16(a)); }

--- a/modules/core/include/opencv2/core/hal/intrin_avx512.hpp
+++ b/modules/core/include/opencv2/core/hal/intrin_avx512.hpp
@@ -9,22 +9,22 @@
 #define CV_SIMD512_64F 1
 #define CV_SIMD512_FP16 0  // no native operations with FP16 type. Only load/store from float32x8 are available (if CV_FP16 == 1)
 
-#ifndef  _mm512_set_epi8
-#define _mm512_set_epi8(a63, a62, a61, a60, a59, a58, a57, a56, a55, a54, a53, a52, a51, a50, a49, a48, \
-                        a47, a46, a45, a44, a43, a42, a41, a40, a39, a38, a37, a36, a35, a34, a33, a32, \
-                        a31, a30, a29, a28, a27, a26, a25, a24, a23, a22, a21, a20, a19, a18, a17, a16, \
+#define _v512_set_epi64(a7, a6, a5, a4, a3, a2, a1, a0) _mm512_set_epi64((a7),(a6),(a5),(a4),(a3),(a2),(a1),(a0))
+#define _v512_set_epi32(a15, a14, a13, a12, a11, a10,  a9,  a8,  a7,  a6,  a5,  a4,  a3,  a2,  a1,  a0) \
+        _v512_set_epi64(((a15)<<32)|(a14), ((a13)<<32)|(a12), ((a11)<<32)|(a10), (( a9)<<32)|( a8), (( a7)<<32)|( a6), (( a5)<<32)|( a4), (( a3)<<32)|( a2), (( a1)<<32)|( a0))
+#define _v512_set_epi16(a31, a30, a29, a28, a27, a26, a25, a24, a23, a22, a21, a20, a19, a18, a17, a16, \
                         a15, a14, a13, a12, a11, a10,  a9,  a8,  a7,  a6,  a5,  a4,  a3,  a2,  a1,  a0) \
-        _mm512_set_epi32(((a63)<<24)|((a62)<<16)|((a61)<<8)|(a60),((a59)<<24)|((a58)<<16)|((a57)<<8)|(a56),((a55)<<24)|((a54)<<16)|((a53)<<8)|(a52),((a51)<<24)|((a50)<<16)|((a49)<<8)|(a48), \
-                         ((a47)<<24)|((a46)<<16)|((a45)<<8)|(a44),((a43)<<24)|((a42)<<16)|((a41)<<8)|(a40),((a39)<<24)|((a38)<<16)|((a37)<<8)|(a36),((a35)<<24)|((a34)<<16)|((a33)<<8)|(a32), \
-                         ((a31)<<24)|((a30)<<16)|((a29)<<8)|(a28),((a27)<<24)|((a26)<<16)|((a25)<<8)|(a24),((a23)<<24)|((a22)<<16)|((a21)<<8)|(a20),((a19)<<24)|((a18)<<16)|((a17)<<8)|(a16), \
-                         ((a15)<<24)|((a14)<<16)|((a13)<<8)|(a12),((a11)<<24)|((a10)<<16)|(( a9)<<8)|( a8),(( a7)<<24)|(( a6)<<16)|(( a5)<<8)|( a4),(( a3)<<24)|(( a2)<<16)|(( a1)<<8)|( a0))
-#endif
-#ifndef  _mm512_set_epi16
-#define _mm512_set_epi16(a31, a30, a29, a28, a27, a26, a25, a24, a23, a22, a21, a20, a19, a18, a17, a16, \
-                         a15, a14, a13, a12, a11, a10,  a9,  a8,  a7,  a6,  a5,  a4,  a3,  a2,  a1,  a0) \
-        _mm512_set_epi32(((a31)<<16)|(a30), ((a29)<<16)|(a28), ((a27)<<16)|(a26), ((a25)<<16)|(a24), ((a23)<<16)|(a22), ((a21)<<16)|(a20), ((a19)<<16)|(a18), ((a17)<<16)|(a16), \
-                         ((a15)<<16)|(a14), ((a13)<<16)|(a12), ((a11)<<16)|(a10), (( a9)<<16)|( a8), (( a7)<<16)|( a6), (( a5)<<16)|( a4), (( a3)<<16)|( a2), (( a1)<<16)|( a0))
-#endif
+        _v512_set_epi32(((a31)<<16)|(a30), ((a29)<<16)|(a28), ((a27)<<16)|(a26), ((a25)<<16)|(a24), ((a23)<<16)|(a22), ((a21)<<16)|(a20), ((a19)<<16)|(a18), ((a17)<<16)|(a16), \
+                        ((a15)<<16)|(a14), ((a13)<<16)|(a12), ((a11)<<16)|(a10), (( a9)<<16)|( a8), (( a7)<<16)|( a6), (( a5)<<16)|( a4), (( a3)<<16)|( a2), (( a1)<<16)|( a0))
+#define _v512_set_epi8(a63, a62, a61, a60, a59, a58, a57, a56, a55, a54, a53, a52, a51, a50, a49, a48, \
+                       a47, a46, a45, a44, a43, a42, a41, a40, a39, a38, a37, a36, a35, a34, a33, a32, \
+                       a31, a30, a29, a28, a27, a26, a25, a24, a23, a22, a21, a20, a19, a18, a17, a16, \
+                       a15, a14, a13, a12, a11, a10,  a9,  a8,  a7,  a6,  a5,  a4,  a3,  a2,  a1,  a0) \
+        _v512_set_epi32(((a63)<<24)|((a62)<<16)|((a61)<<8)|(a60),((a59)<<24)|((a58)<<16)|((a57)<<8)|(a56),((a55)<<24)|((a54)<<16)|((a53)<<8)|(a52),((a51)<<24)|((a50)<<16)|((a49)<<8)|(a48), \
+                        ((a47)<<24)|((a46)<<16)|((a45)<<8)|(a44),((a43)<<24)|((a42)<<16)|((a41)<<8)|(a40),((a39)<<24)|((a38)<<16)|((a37)<<8)|(a36),((a35)<<24)|((a34)<<16)|((a33)<<8)|(a32), \
+                        ((a31)<<24)|((a30)<<16)|((a29)<<8)|(a28),((a27)<<24)|((a26)<<16)|((a25)<<8)|(a24),((a23)<<24)|((a22)<<16)|((a21)<<8)|(a20),((a19)<<24)|((a18)<<16)|((a17)<<8)|(a16), \
+                        ((a15)<<24)|((a14)<<16)|((a13)<<8)|(a12),((a11)<<24)|((a10)<<16)|(( a9)<<8)|( a8),(( a7)<<24)|(( a6)<<16)|(( a5)<<8)|( a4),(( a3)<<24)|(( a2)<<16)|(( a1)<<8)|( a0))
+
 #ifndef _mm512_cvtpd_pslo
 #ifdef _mm512_zextsi256_si512
 #define _mm512_cvtpd_pslo(a) _mm512_zextps256_ps512(_mm512_cvtpd_ps(a))
@@ -112,14 +112,14 @@ struct v_uint8x64
                uchar v56, uchar v57, uchar v58, uchar v59,
                uchar v60, uchar v61, uchar v62, uchar v63)
     {
-        val = _mm512_set_epi8((char)v63, (char)v62, (char)v61, (char)v60, (char)v59, (char)v58, (char)v57, (char)v56,
-                              (char)v55, (char)v54, (char)v53, (char)v52, (char)v51, (char)v50, (char)v49, (char)v48,
-                              (char)v47, (char)v46, (char)v45, (char)v44, (char)v43, (char)v42, (char)v41, (char)v40,
-                              (char)v39, (char)v38, (char)v37, (char)v36, (char)v35, (char)v34, (char)v33, (char)v32,
-                              (char)v31, (char)v30, (char)v29, (char)v28, (char)v27, (char)v26, (char)v25, (char)v24,
-                              (char)v23, (char)v22, (char)v21, (char)v20, (char)v19, (char)v18, (char)v17, (char)v16,
-                              (char)v15, (char)v14, (char)v13, (char)v12, (char)v11, (char)v10, (char)v9,  (char)v8,
-                              (char)v7,  (char)v6,  (char)v5,  (char)v4,  (char)v3,  (char)v2,  (char)v1,  (char)v0);
+        val = _v512_set_epi8((char)v63, (char)v62, (char)v61, (char)v60, (char)v59, (char)v58, (char)v57, (char)v56,
+                             (char)v55, (char)v54, (char)v53, (char)v52, (char)v51, (char)v50, (char)v49, (char)v48,
+                             (char)v47, (char)v46, (char)v45, (char)v44, (char)v43, (char)v42, (char)v41, (char)v40,
+                             (char)v39, (char)v38, (char)v37, (char)v36, (char)v35, (char)v34, (char)v33, (char)v32,
+                             (char)v31, (char)v30, (char)v29, (char)v28, (char)v27, (char)v26, (char)v25, (char)v24,
+                             (char)v23, (char)v22, (char)v21, (char)v20, (char)v19, (char)v18, (char)v17, (char)v16,
+                             (char)v15, (char)v14, (char)v13, (char)v12, (char)v11, (char)v10, (char)v9,  (char)v8,
+                             (char)v7,  (char)v6,  (char)v5,  (char)v4,  (char)v3,  (char)v2,  (char)v1,  (char)v0);
     }
     v_uint8x64() : val(_mm512_setzero_si512()) {}
     uchar get0() const { return (uchar)_v_cvtsi512_si32(val); }
@@ -149,10 +149,10 @@ struct v_int8x64
               schar v56, schar v57, schar v58, schar v59,
               schar v60, schar v61, schar v62, schar v63)
     {
-        val = _mm512_set_epi8(v63, v62, v61, v60, v59, v58, v57, v56, v55, v54, v53, v52, v51, v50, v49, v48,
-                              v47, v46, v45, v44, v43, v42, v41, v40, v39, v38, v37, v36, v35, v34, v33, v32,
-                              v31, v30, v29, v28, v27, v26, v25, v24, v23, v22, v21, v20, v19, v18, v17, v16,
-                              v15, v14, v13, v12, v11, v10, v9,  v8,  v7,  v6,  v5,  v4,  v3,  v2,  v1,  v0);
+        val = _v512_set_epi8(v63, v62, v61, v60, v59, v58, v57, v56, v55, v54, v53, v52, v51, v50, v49, v48,
+                             v47, v46, v45, v44, v43, v42, v41, v40, v39, v38, v37, v36, v35, v34, v33, v32,
+                             v31, v30, v29, v28, v27, v26, v25, v24, v23, v22, v21, v20, v19, v18, v17, v16,
+                             v15, v14, v13, v12, v11, v10, v9,  v8,  v7,  v6,  v5,  v4,  v3,  v2,  v1,  v0);
     }
     v_int8x64() : val(_mm512_setzero_si512()) {}
     schar get0() const { return (schar)_v_cvtsi512_si32(val); }
@@ -174,10 +174,10 @@ struct v_uint16x32
                 ushort v24, ushort v25, ushort v26, ushort v27,
                 ushort v28, ushort v29, ushort v30, ushort v31)
     {
-        val = _mm512_set_epi16((short)v31, (short)v30, (short)v29, (short)v28, (short)v27, (short)v26, (short)v25, (short)v24,
-                               (short)v23, (short)v22, (short)v21, (short)v20, (short)v19, (short)v18, (short)v17, (short)v16,
-                               (short)v15, (short)v14, (short)v13, (short)v12, (short)v11, (short)v10, (short)v9,  (short)v8,
-                               (short)v7,  (short)v6,  (short)v5,  (short)v4,  (short)v3,  (short)v2,  (short)v1,  (short)v0);
+        val = _v512_set_epi16((short)v31, (short)v30, (short)v29, (short)v28, (short)v27, (short)v26, (short)v25, (short)v24,
+                              (short)v23, (short)v22, (short)v21, (short)v20, (short)v19, (short)v18, (short)v17, (short)v16,
+                              (short)v15, (short)v14, (short)v13, (short)v12, (short)v11, (short)v10, (short)v9,  (short)v8,
+                              (short)v7,  (short)v6,  (short)v5,  (short)v4,  (short)v3,  (short)v2,  (short)v1,  (short)v0);
     }
     v_uint16x32() : val(_mm512_setzero_si512()) {}
     ushort get0() const { return (ushort)_v_cvtsi512_si32(val); }
@@ -195,8 +195,8 @@ struct v_int16x32
                short v16, short v17, short v18, short v19, short v20, short v21, short v22, short v23,
                short v24, short v25, short v26, short v27, short v28, short v29, short v30, short v31)
     {
-        val = _mm512_set_epi16(v31, v30, v29, v28, v27, v26, v25, v24, v23, v22, v21, v20, v19, v18, v17, v16,
-                               v15, v14, v13, v12, v11, v10, v9,  v8,  v7,  v6,  v5,  v4,  v3,  v2,  v1,  v0);
+        val = _v512_set_epi16(v31, v30, v29, v28, v27, v26, v25, v24, v23, v22, v21, v20, v19, v18, v17, v16,
+                              v15, v14, v13, v12, v11, v10, v9,  v8,  v7,  v6,  v5,  v4,  v3,  v2,  v1,  v0);
     }
     v_int16x32() : val(_mm512_setzero_si512()) {}
     short get0() const { return (short)_v_cvtsi512_si32(val); }
@@ -468,36 +468,97 @@ inline void v_pack_store(float16_t* ptr, const v_float32x16& a)
 }
 
 /* Recombine & ZIP */
-#define OPENCV_HAL_IMPL_AVX512_ZIP(_Tpvec, suffix)                                             \
-    inline _Tpvec v_combine_low(const _Tpvec& a, const _Tpvec& b)                              \
-    { return _Tpvec(_v512_combine(_v512_extract_low(a.val), _v512_extract_low(b.val))); }      \
-    inline _Tpvec v_combine_high(const _Tpvec& a, const _Tpvec& b)                             \
-    { return _Tpvec(_v512_insert(b.val, _v512_extract_high(a.val))); }                         \
-    inline void v_recombine(const _Tpvec& a, const _Tpvec& b,                                  \
-                                  _Tpvec& c, _Tpvec& d)                                        \
-    {                                                                                          \
-        c.val = _v512_combine(_v512_extract_low(a.val),_v512_extract_low(b.val));              \
-        d.val = _v512_insert(b.val,_v512_extract_high(a.val));                                 \
-    }                                                                                          \
-    inline void v_zip(const _Tpvec& a, const _Tpvec& b,                                        \
-                            _Tpvec& ab0, _Tpvec& ab1)                                          \
-    {                                                                                          \
-        ab0.val = _mm512_maskz_expand_##suffix(0x55555555, a.val);                             \
-        ab1.val = _mm512_maskz_expand_##suffix(0x55555555 << _Tpvec::nlanes/2, a.val);         \
-        ab0.val = _mm512_mask_expand_##suffix(ab0.val, 0xAAAAAAAA, b.val);                     \
-        ab1.val = _mm512_mask_expand_##suffix(ab1.val, 0xAAAAAAAA << _Tpvec::nlanes/2, b.val); \
+inline v_int8x64 v_zip_low(const v_int8x64& a, const v_int8x64& b)
+{
+    __m512i mask0 = _v512_set_epi8( 95,  31,  94,  30,  93,  29,  92,  28,  91,  27,  90,  26,  89,  25,  88,  24,
+                                    87,  23,  86,  22,  85,  21,  84,  20,  83,  19,  82,  18,  81,  17,  80,  16,
+                                    79,  15,  78,  14,  77,  13,  76,  12,  75,  11,  74,  10,  73,   9,  72,   8,
+                                    71,   7,  70,   6,  69,   5,  68,   4,  67,   3,  66,   2,  65,   1,  64,   0);
+    return v_int8x64(_mm512_permutex2var_epi8(a.val, mask0, b.val));
+}
+inline v_int8x64 v_zip_high(const v_int8x64& a, const v_int8x64& b)
+{
+    __m512i mask1 = _v512_set_epi8(127,  63, 126,  62, 125,  61, 124,  60, 123,  59, 122,  58, 121,  57, 120,  56,
+                                   119,  55, 118,  54, 117,  53, 116,  52, 115,  51, 114,  50, 113,  49, 112,  48,
+                                   111,  47, 110,  46, 109,  45, 108,  44, 107,  43, 106,  42, 105,  41, 104,  40,
+                                   103,  39, 102,  38, 101,  37, 100,  36,  99,  35,  98,  34,  97,  33,  96,  32);
+    return v_int8x64(_mm512_permutex2var_epi8(a.val, mask1, b.val));
+}
+inline v_int16x32 v_zip_low(const v_int16x32& a, const v_int16x32& b)
+{
+    __m512i mask0 = _v512_set_epi16(47, 15, 46, 14, 45, 13, 44, 12, 43, 11, 42, 10, 41,  9, 40,  8,
+                                    39,  7, 38,  6, 37,  5, 36,  4, 35,  3, 34,  2, 33,  1, 32,  0);
+    return v_int16x32(_mm512_permutex2var_epi16(a.val, mask0, b.val));
+}
+inline v_int16x32 v_zip_high(const v_int16x32& a, const v_int16x32& b)
+{
+    __m512i mask1 = _v512_set_epi16(63, 31, 62, 30, 61, 29, 60, 28, 59, 27, 58, 26, 57, 25, 56, 24,
+                                    55, 23, 54, 22, 53, 21, 52, 20, 51, 19, 50, 18, 49, 17, 48, 16);
+    return v_int16x32(_mm512_permutex2var_epi16(a.val, mask1, b.val));
+}
+inline v_int32x16 v_zip_low(const v_int32x16& a, const v_int32x16& b)
+{
+    __m512i mask0 = _v512_set_epi32(23, 7, 22, 6, 21, 5, 20, 4, 19, 3, 18, 2, 17, 1, 16, 0);
+    return v_int32x16(_mm512_permutex2var_epi32(a.val, mask0, b.val));
+}
+inline v_int32x16 v_zip_high(const v_int32x16& a, const v_int32x16& b)
+{
+    __m512i mask1 = _v512_set_epi32(31, 15, 30, 14, 29, 13, 28, 12, 27, 11, 26, 10, 25, 9, 24, 8);
+    return v_int32x16(_mm512_permutex2var_epi32(a.val, mask1, b.val));
+}
+inline v_int64x8 v_zip_low(const v_int64x8& a, const v_int64x8& b)
+{
+    __m512i mask0 = _v512_set_epi64(11, 3, 10, 2, 9, 1, 8, 0);
+    return v_int64x8(_mm512_permutex2var_epi64(a.val, mask0, b.val));
+}
+inline v_int64x8 v_zip_high(const v_int64x8& a, const v_int64x8& b)
+{
+    __m512i mask1 = _v512_set_epi64(15, 7, 14, 6, 13, 5, 12, 4);
+    return v_int64x8(_mm512_permutex2var_epi64(a.val, mask1, b.val));
+}
+
+inline v_uint8x64   v_zip_low (const v_uint8x64&   a, const v_uint8x64&   b) { return v_reinterpret_as_u8 (v_zip_low (v_reinterpret_as_s8(a), v_reinterpret_as_s8(b))); }
+inline v_uint8x64   v_zip_high(const v_uint8x64&   a, const v_uint8x64&   b) { return v_reinterpret_as_u8 (v_zip_high(v_reinterpret_as_s8(a), v_reinterpret_as_s8(b))); }
+inline v_uint16x32  v_zip_low (const v_uint16x32&  a, const v_uint16x32&  b) { return v_reinterpret_as_u16(v_zip_low (v_reinterpret_as_s16(a), v_reinterpret_as_s16(b))); }
+inline v_uint16x32  v_zip_high(const v_uint16x32&  a, const v_uint16x32&  b) { return v_reinterpret_as_u16(v_zip_high(v_reinterpret_as_s16(a), v_reinterpret_as_s16(b))); }
+inline v_uint32x16  v_zip_low (const v_uint32x16&  a, const v_uint32x16&  b) { return v_reinterpret_as_u32(v_zip_low (v_reinterpret_as_s32(a), v_reinterpret_as_s32(b))); }
+inline v_uint32x16  v_zip_high(const v_uint32x16&  a, const v_uint32x16&  b) { return v_reinterpret_as_u32(v_zip_high(v_reinterpret_as_s32(a), v_reinterpret_as_s32(b))); }
+inline v_uint64x8   v_zip_low (const v_uint64x8&   a, const v_uint64x8&   b) { return v_reinterpret_as_u64(v_zip_low (v_reinterpret_as_s64(a), v_reinterpret_as_s64(b))); }
+inline v_uint64x8   v_zip_high(const v_uint64x8&   a, const v_uint64x8&   b) { return v_reinterpret_as_u64(v_zip_high(v_reinterpret_as_s64(a), v_reinterpret_as_s64(b))); }
+inline v_float32x16 v_zip_low (const v_float32x16& a, const v_float32x16& b) { return v_reinterpret_as_f32(v_zip_low (v_reinterpret_as_s32(a), v_reinterpret_as_s32(b))); }
+inline v_float32x16 v_zip_high(const v_float32x16& a, const v_float32x16& b) { return v_reinterpret_as_f32(v_zip_high(v_reinterpret_as_s32(a), v_reinterpret_as_s32(b))); }
+inline v_float64x8  v_zip_low (const v_float64x8&  a, const v_float64x8&  b) { return v_reinterpret_as_f64(v_zip_low (v_reinterpret_as_s64(a), v_reinterpret_as_s64(b))); }
+inline v_float64x8  v_zip_high(const v_float64x8&  a, const v_float64x8&  b) { return v_reinterpret_as_f64(v_zip_high(v_reinterpret_as_s64(a), v_reinterpret_as_s64(b))); }
+
+#define OPENCV_HAL_IMPL_AVX512_ZIP(_Tpvec, suffix)                                        \
+    inline _Tpvec v_combine_low(const _Tpvec& a, const _Tpvec& b)                         \
+    { return _Tpvec(_v512_combine(_v512_extract_low(a.val), _v512_extract_low(b.val))); } \
+    inline _Tpvec v_combine_high(const _Tpvec& a, const _Tpvec& b)                        \
+    { return _Tpvec(_v512_insert(b.val, _v512_extract_high(a.val))); }                    \
+    inline void v_recombine(const _Tpvec& a, const _Tpvec& b,                             \
+                                  _Tpvec& c, _Tpvec& d)                                   \
+    {                                                                                     \
+        c.val = _v512_combine(_v512_extract_low(a.val),_v512_extract_low(b.val));         \
+        d.val = _v512_insert(b.val,_v512_extract_high(a.val));                            \
+    }                                                                                     \
+    inline void v_zip(const _Tpvec& a, const _Tpvec& b,                                   \
+                            _Tpvec& ab0, _Tpvec& ab1)                                     \
+    {                                                                                     \
+        ab0 = v_zip_low(a, b);                                                            \
+        ab1 = v_zip_high(a, b);                                                           \
     }
 
-OPENCV_HAL_IMPL_AVX512_ZIP(v_uint8x64, epi8)
-OPENCV_HAL_IMPL_AVX512_ZIP(v_int8x64, epi8)
-OPENCV_HAL_IMPL_AVX512_ZIP(v_uint16x32, epi16)
-OPENCV_HAL_IMPL_AVX512_ZIP(v_int16x32, epi16)
-OPENCV_HAL_IMPL_AVX512_ZIP(v_uint32x16, epi32)
-OPENCV_HAL_IMPL_AVX512_ZIP(v_int32x16, epi32)
-OPENCV_HAL_IMPL_AVX512_ZIP(v_uint64x8, epi64)
-OPENCV_HAL_IMPL_AVX512_ZIP(v_int64x8, epi64)
+
+OPENCV_HAL_IMPL_AVX512_ZIP(v_uint8x64,   epi8)
+OPENCV_HAL_IMPL_AVX512_ZIP(v_int8x64,    epi8)
+OPENCV_HAL_IMPL_AVX512_ZIP(v_uint16x32,  epi16)
+OPENCV_HAL_IMPL_AVX512_ZIP(v_int16x32,   epi16)
+OPENCV_HAL_IMPL_AVX512_ZIP(v_uint32x16,  epi32)
+OPENCV_HAL_IMPL_AVX512_ZIP(v_int32x16,   epi32)
+OPENCV_HAL_IMPL_AVX512_ZIP(v_uint64x8,   epi64)
+OPENCV_HAL_IMPL_AVX512_ZIP(v_int64x8,    epi64)
 OPENCV_HAL_IMPL_AVX512_ZIP(v_float32x16, ps)
-OPENCV_HAL_IMPL_AVX512_ZIP(v_float64x8, pd)
+OPENCV_HAL_IMPL_AVX512_ZIP(v_float64x8,  pd)
 
 ////////// Arithmetic, bitwise and comparison operations /////////
 
@@ -970,14 +1031,14 @@ inline v_uint8x64 v_popcount(const v_int8x64& a)
 #ifdef _mm512_popcnt_epi8
     return v_uint8x64(_mm512_popcnt_epi8(a.val));
 #else
-    __m512i _popcnt_table0 = _mm512_set_epi8(7, 6, 6, 5, 6, 5, 5, 4, 6, 5, 5, 4, 5, 4, 4, 3,
-                                             5, 4, 4, 3, 4, 3, 3, 2, 4, 3, 3, 2, 3, 2, 2, 1,
-                                             5, 4, 4, 3, 4, 3, 3, 2, 4, 3, 3, 2, 3, 2, 2, 1,
-                                             4, 3, 3, 2, 3, 2, 2, 1, 3, 2, 2, 1, 2, 1, 1, 0);
-    __m512i _popcnt_table1 = _mm512_set_epi8(7, 6, 6, 5, 6, 5, 5, 4, 6, 5, 5, 4, 5, 4, 4, 3,
-                                             6, 5, 5, 4, 5, 4, 4, 3, 5, 4, 4, 3, 4, 3, 3, 2,
-                                             6, 5, 5, 4, 5, 4, 4, 3, 5, 4, 4, 3, 4, 3, 3, 2,
-                                             5, 4, 4, 3, 4, 3, 3, 2, 4, 3, 3, 2, 3, 2, 2, 1);
+    __m512i _popcnt_table0 = _v512_set_epi8(7, 6, 6, 5, 6, 5, 5, 4, 6, 5, 5, 4, 5, 4, 4, 3,
+                                            5, 4, 4, 3, 4, 3, 3, 2, 4, 3, 3, 2, 3, 2, 2, 1,
+                                            5, 4, 4, 3, 4, 3, 3, 2, 4, 3, 3, 2, 3, 2, 2, 1,
+                                            4, 3, 3, 2, 3, 2, 2, 1, 3, 2, 2, 1, 2, 1, 1, 0);
+    __m512i _popcnt_table1 = _v512_set_epi8(7, 6, 6, 5, 6, 5, 5, 4, 6, 5, 5, 4, 5, 4, 4, 3,
+                                            6, 5, 5, 4, 5, 4, 4, 3, 5, 4, 4, 3, 4, 3, 3, 2,
+                                            6, 5, 5, 4, 5, 4, 4, 3, 5, 4, 4, 3, 4, 3, 3, 2,
+                                            5, 4, 4, 3, 4, 3, 3, 2, 4, 3, 3, 2, 3, 2, 2, 1);
     return v_uint8x64(_mm512_sub_epi8(_mm512_permutex2var_epi8(_popcnt_table0, a.val, _popcnt_table1), _mm512_movm_epi8(_mm512_movepi8_mask(a.val))));
 #endif
 }
@@ -1303,29 +1364,29 @@ inline v_float32x16 v_interleave_pairs(const v_float32x16& vec) { return v_reint
 
 inline v_int8x64 v_pack_triplets(const v_int8x64& vec)
 {
-    return v_int8x64(_mm512_permutexvar_epi32(_mm512_set_epi64(0x0000000f0000000f, 0x0000000f0000000f, 0x0000000e0000000d, 0x0000000c0000000a,
-                                                               0x0000000900000008, 0x0000000600000005, 0x0000000400000002, 0x0000000100000000),
+    return v_int8x64(_mm512_permutexvar_epi32(_v512_set_epi64(0x0000000f0000000f, 0x0000000f0000000f, 0x0000000e0000000d, 0x0000000c0000000a,
+                                                              0x0000000900000008, 0x0000000600000005, 0x0000000400000002, 0x0000000100000000),
                                               _mm512_shuffle_epi8(vec.val, _mm512_setr4_epi32(0xffffff0f, 0x0e0d0c0a, 0x09080605, 0x04020100))));
 }
 inline v_uint8x64 v_pack_triplets(const v_uint8x64& vec) { return v_reinterpret_as_u8(v_pack_triplets(v_reinterpret_as_s8(vec))); }
 
 inline v_int16x32 v_pack_triplets(const v_int16x32& vec)
 {
-    return v_int16x32(_mm512_permutexvar_epi16(_mm512_set_epi64(0x001f001f001f001f, 0x001f001f001f001f, 0x001e001d001c001a, 0x0019001800160015,
-                                                                0x0014001200110010, 0x000e000d000c000a, 0x0009000800060005, 0x0004000200010000), vec.val));
+    return v_int16x32(_mm512_permutexvar_epi16(_v512_set_epi64(0x001f001f001f001f, 0x001f001f001f001f, 0x001e001d001c001a, 0x0019001800160015,
+                                                               0x0014001200110010, 0x000e000d000c000a, 0x0009000800060005, 0x0004000200010000), vec.val));
 }
 inline v_uint16x32 v_pack_triplets(const v_uint16x32& vec) { return v_reinterpret_as_u16(v_pack_triplets(v_reinterpret_as_s16(vec))); }
 
 inline v_int32x16 v_pack_triplets(const v_int32x16& vec)
 {
-    return v_int32x16(_mm512_permutexvar_epi32(_mm512_set_epi64(0x0000000f0000000f, 0x0000000f0000000f, 0x0000000e0000000d, 0x0000000c0000000a,
-                                                                0x0000000900000008, 0x0000000600000005, 0x0000000400000002, 0x0000000100000000), vec.val));
+    return v_int32x16(_mm512_permutexvar_epi32(_v512_set_epi64(0x0000000f0000000f, 0x0000000f0000000f, 0x0000000e0000000d, 0x0000000c0000000a,
+                                                               0x0000000900000008, 0x0000000600000005, 0x0000000400000002, 0x0000000100000000), vec.val));
 }
 inline v_uint32x16 v_pack_triplets(const v_uint32x16& vec) { return v_reinterpret_as_u32(v_pack_triplets(v_reinterpret_as_s32(vec))); }
 inline v_float32x16 v_pack_triplets(const v_float32x16& vec)
 {
-    return v_float32x16(_mm512_permutexvar_ps(_mm512_set_epi64(0x0000000f0000000f, 0x0000000f0000000f, 0x0000000e0000000d, 0x0000000c0000000a,
-                                                               0x0000000900000008, 0x0000000600000005, 0x0000000400000002, 0x0000000100000000), vec.val));
+    return v_float32x16(_mm512_permutexvar_ps(_v512_set_epi64(0x0000000f0000000f, 0x0000000f0000000f, 0x0000000e0000000d, 0x0000000c0000000a,
+                                                              0x0000000900000008, 0x0000000600000005, 0x0000000400000002, 0x0000000100000000), vec.val));
 }
 
 ////////// Matrix operations /////////
@@ -1418,7 +1479,7 @@ OPENCV_HAL_IMPL_AVX512_EXPAND_Q(v_int32x16,  schar, _mm512_cvtepi8_epi32)
 /* pack */
 // 16
 inline v_int8x64 v_pack(const v_int16x32& a, const v_int16x32& b)
-{ return v_int8x64(_mm512_permutexvar_epi64(_mm512_set_epi64(7,5,3,1,6,4,2,0), _mm512_packs_epi16(a.val, b.val))); }
+{ return v_int8x64(_mm512_permutexvar_epi64(_v512_set_epi64(7,5,3,1,6,4,2,0), _mm512_packs_epi16(a.val, b.val))); }
 
 inline v_uint8x64 v_pack(const v_uint16x32& a, const v_uint16x32& b)
 {
@@ -1428,7 +1489,7 @@ inline v_uint8x64 v_pack(const v_uint16x32& a, const v_uint16x32& b)
 
 inline v_uint8x64 v_pack_u(const v_int16x32& a, const v_int16x32& b)
 {
-    return v_uint8x64(_mm512_permutexvar_epi64(_mm512_set_epi64(7, 5, 3, 1, 6, 4, 2, 0), _mm512_packus_epi16(a.val, b.val)));
+    return v_uint8x64(_mm512_permutexvar_epi64(_v512_set_epi64(7, 5, 3, 1, 6, 4, 2, 0), _mm512_packus_epi16(a.val, b.val)));
 }
 
 inline void v_pack_store(schar* ptr, const v_int16x32& a)
@@ -1489,7 +1550,7 @@ void v_rshr_pack_store(schar* ptr, const v_int16x32& a)
 
 // 32
 inline v_int16x32 v_pack(const v_int32x16& a, const v_int32x16& b)
-{ return v_int16x32(_mm512_permutexvar_epi64(_mm512_set_epi64(7, 5, 3, 1, 6, 4, 2, 0), _mm512_packs_epi32(a.val, b.val))); }
+{ return v_int16x32(_mm512_permutexvar_epi64(_v512_set_epi64(7, 5, 3, 1, 6, 4, 2, 0), _mm512_packs_epi32(a.val, b.val))); }
 
 inline v_uint16x32 v_pack(const v_uint32x16& a, const v_uint32x16& b)
 { 
@@ -1498,7 +1559,7 @@ inline v_uint16x32 v_pack(const v_uint32x16& a, const v_uint32x16& b)
 }
 
 inline v_uint16x32 v_pack_u(const v_int32x16& a, const v_int32x16& b)
-{ return v_uint16x32(_mm512_permutexvar_epi64(_mm512_set_epi64(7, 5, 3, 1, 6, 4, 2, 0), _mm512_packus_epi32(a.val, b.val))); }
+{ return v_uint16x32(_mm512_permutexvar_epi64(_v512_set_epi64(7, 5, 3, 1, 6, 4, 2, 0), _mm512_packus_epi32(a.val, b.val))); }
 
 inline void v_pack_store(short* ptr, const v_int32x16& a)
 { v_store_low(ptr, v_pack(a, a)); }
@@ -1600,7 +1661,7 @@ void v_rshr_pack_store(int* ptr, const v_int64x8& a)
 
 // pack boolean
 inline v_uint8x64 v_pack_b(const v_uint16x32& a, const v_uint16x32& b)
-{ return v_uint8x64(_mm512_permutexvar_epi64(_mm512_set_epi64(7, 5, 3, 1, 6, 4, 2, 0), _mm512_packs_epi16(a.val, b.val))); }
+{ return v_uint8x64(_mm512_permutexvar_epi64(_v512_set_epi64(7, 5, 3, 1, 6, 4, 2, 0), _mm512_packs_epi16(a.val, b.val))); }
 
 inline v_uint8x64 v_pack_b(const v_uint32x16& a, const v_uint32x16& b,
                            const v_uint32x16& c, const v_uint32x16& d)
@@ -1608,7 +1669,7 @@ inline v_uint8x64 v_pack_b(const v_uint32x16& a, const v_uint32x16& b,
     __m512i ab = _mm512_packs_epi32(a.val, b.val);
     __m512i cd = _mm512_packs_epi32(c.val, d.val);
 
-    return v_uint8x64(_mm512_permutexvar_epi32(_mm512_set_epi32(15, 11, 7, 3, 14, 10, 6, 2, 13, 9, 5, 1, 12, 8, 4, 0), _mm512_packs_epi16(ab, cd)));
+    return v_uint8x64(_mm512_permutexvar_epi32(_v512_set_epi32(15, 11, 7, 3, 14, 10, 6, 2, 13, 9, 5, 1, 12, 8, 4, 0), _mm512_packs_epi16(ab, cd)));
 }
 
 inline v_uint8x64 v_pack_b(const v_uint64x8& a, const v_uint64x8& b, const v_uint64x8& c,
@@ -1623,8 +1684,8 @@ inline v_uint8x64 v_pack_b(const v_uint64x8& a, const v_uint64x8& b, const v_uin
     __m512i abcd = _mm512_packs_epi32(ab, cd);
     __m512i efgh = _mm512_packs_epi32(ef, gh);
 
-    return v_uint8x64(_mm512_permutexvar_epi16(_mm512_set_epi16(31, 23, 15, 7, 30, 22, 14, 6, 29, 21, 13, 5, 28, 20, 12, 4,
-                                                                27, 19, 11, 3, 26, 18, 10, 2, 25, 17,  9, 1, 24, 16,  8, 0), _mm512_packs_epi16(abcd, efgh)));
+    return v_uint8x64(_mm512_permutexvar_epi16(_v512_set_epi16(31, 23, 15, 7, 30, 22, 14, 6, 29, 21, 13, 5, 28, 20, 12, 4,
+                                                               27, 19, 11, 3, 26, 18, 10, 2, 25, 17,  9, 1, 24, 16,  8, 0), _mm512_packs_epi16(abcd, efgh)));
 }
 
 /* Recombine */
@@ -1654,14 +1715,14 @@ inline void v_load_deinterleave( const uchar* ptr, v_uint8x64& a, v_uint8x64& b 
 {
     __m512i ab0 = _mm512_loadu_si512((const __m512i*)ptr);
     __m512i ab1 = _mm512_loadu_si512((const __m512i*)(ptr + 64));
-    __m512i mask0 = _mm512_set_epi8( 126, 124, 122, 120, 118, 116, 114, 112, 110, 108, 106, 104, 102, 100, 98, 96,
-                                      94,  92,  90,  88,  86,  84,  82,  80,  78,  76,  74,  72,  70,  68, 66, 64,
-                                      62,  60,  58,  56,  54,  52,  50,  48,  46,  44,  42,  40,  38,  36, 34, 32,
-                                      30,  28,  26,  24,  22,  20,  18,  16,  14,  12,  10,   8,   6,   4,  2,  0 );
-    __m512i mask1 = _mm512_set_epi8( 127, 125, 123, 121, 119, 117, 115, 113, 111, 109, 107, 105, 103, 101, 99, 97,
-                                      95,  93,  91,  89,  87,  85,  83,  81,  79,  77,  75,  73,  71,  69, 67, 65,
-                                      63,  61,  59,  57,  55,  53,  51,  49,  47,  45,  43,  41,  39,  37, 35, 33,
-                                      31,  29,  27,  25,  23,  21,  19,  17,  15,  13,  11,   9,   7,   5,  3,  1 );
+    __m512i mask0 = _v512_set_epi8( 126, 124, 122, 120, 118, 116, 114, 112, 110, 108, 106, 104, 102, 100, 98, 96,
+                                     94,  92,  90,  88,  86,  84,  82,  80,  78,  76,  74,  72,  70,  68, 66, 64,
+                                     62,  60,  58,  56,  54,  52,  50,  48,  46,  44,  42,  40,  38,  36, 34, 32,
+                                     30,  28,  26,  24,  22,  20,  18,  16,  14,  12,  10,   8,   6,   4,  2,  0 );
+    __m512i mask1 = _v512_set_epi8( 127, 125, 123, 121, 119, 117, 115, 113, 111, 109, 107, 105, 103, 101, 99, 97,
+                                     95,  93,  91,  89,  87,  85,  83,  81,  79,  77,  75,  73,  71,  69, 67, 65,
+                                     63,  61,  59,  57,  55,  53,  51,  49,  47,  45,  43,  41,  39,  37, 35, 33,
+                                     31,  29,  27,  25,  23,  21,  19,  17,  15,  13,  11,   9,   7,   5,  3,  1 );
     a = v_uint8x64(_mm512_permutex2var_epi8(ab0, mask0, ab1));
     b = v_uint8x64(_mm512_permutex2var_epi8(ab0, mask1, ab1));
 }
@@ -1670,10 +1731,10 @@ inline void v_load_deinterleave( const ushort* ptr, v_uint16x32& a, v_uint16x32&
 {
     __m512i ab0 = _mm512_loadu_si512((const __m512i*)ptr);
     __m512i ab1 = _mm512_loadu_si512((const __m512i*)(ptr + 32));
-    __m512i mask0 = _mm512_set_epi16( 62, 60, 58, 56, 54, 52, 50, 48, 46, 44, 42, 40, 38, 36, 34, 32,
-                                      30, 28, 26, 24, 22, 20, 18, 16, 14, 12, 10,  8,  6,  4,  2,  0 );
-    __m512i mask1 = _mm512_set_epi16( 63, 61, 59, 57, 55, 53, 51, 49, 47, 45, 43, 41, 39, 37, 35, 33,
-                                      31, 29, 27, 25, 23, 21, 19, 17, 15, 13, 11,  9,  7,  5,  3,  1 );
+    __m512i mask0 = _v512_set_epi16( 62, 60, 58, 56, 54, 52, 50, 48, 46, 44, 42, 40, 38, 36, 34, 32,
+                                     30, 28, 26, 24, 22, 20, 18, 16, 14, 12, 10,  8,  6,  4,  2,  0 );
+    __m512i mask1 = _v512_set_epi16( 63, 61, 59, 57, 55, 53, 51, 49, 47, 45, 43, 41, 39, 37, 35, 33,
+                                     31, 29, 27, 25, 23, 21, 19, 17, 15, 13, 11,  9,  7,  5,  3,  1 );
     a = v_uint16x32(_mm512_permutex2var_epi16(ab0, mask0, ab1));
     b = v_uint16x32(_mm512_permutex2var_epi16(ab0, mask1, ab1));
 }
@@ -1682,8 +1743,8 @@ inline void v_load_deinterleave( const unsigned* ptr, v_uint32x16& a, v_uint32x1
 {
     __m512i ab0 = _mm512_loadu_si512((const __m512i*)ptr);
     __m512i ab1 = _mm512_loadu_si512((const __m512i*)(ptr + 16));
-    __m512i mask0 = _mm512_set_epi32( 30, 28, 26, 24, 22, 20, 18, 16, 14, 12, 10, 8, 6, 4, 2, 0 );
-    __m512i mask1 = _mm512_set_epi32( 31, 29, 27, 25, 23, 21, 19, 17, 15, 13, 11, 9, 7, 5, 3, 1 );
+    __m512i mask0 = _v512_set_epi32( 30, 28, 26, 24, 22, 20, 18, 16, 14, 12, 10, 8, 6, 4, 2, 0 );
+    __m512i mask1 = _v512_set_epi32( 31, 29, 27, 25, 23, 21, 19, 17, 15, 13, 11, 9, 7, 5, 3, 1 );
     a = v_uint32x16(_mm512_permutex2var_epi32(ab0, mask0, ab1));
     b = v_uint32x16(_mm512_permutex2var_epi32(ab0, mask1, ab1));
 }
@@ -1692,8 +1753,8 @@ inline void v_load_deinterleave( const uint64* ptr, v_uint64x8& a, v_uint64x8& b
 {
     __m512i ab0 = _mm512_loadu_si512((const __m512i*)ptr);
     __m512i ab1 = _mm512_loadu_si512((const __m512i*)(ptr + 8));
-    __m512i mask0 = _mm512_set_epi64( 14, 12, 10, 8, 6, 4, 2, 0 );
-    __m512i mask1 = _mm512_set_epi64( 15, 13, 11, 9, 7, 5, 3, 1 );
+    __m512i mask0 = _v512_set_epi64( 14, 12, 10, 8, 6, 4, 2, 0 );
+    __m512i mask1 = _v512_set_epi64( 15, 13, 11, 9, 7, 5, 3, 1 );
     a = v_uint64x8(_mm512_permutex2var_epi64(ab0, mask0, ab1));
     b = v_uint64x8(_mm512_permutex2var_epi64(ab0, mask1, ab1));
 }
@@ -1704,17 +1765,17 @@ inline void v_load_deinterleave( const uchar* ptr, v_uint8x64& b, v_uint8x64& g,
     __m512i bgr1 = _mm512_loadu_si512((const __m512i*)(ptr + 64));
     __m512i bgr2 = _mm512_loadu_si512((const __m512i*)(ptr + 128));
 
-    __m512i mask0 = _mm512_set_epi8( 126, 123, 120, 117, 114, 111, 108, 105, 102, 99, 96, 93, 90, 87, 84, 81,
-                                      78,  75,  72,  69,  66,  63,  60,  57,  54, 51, 48, 45, 42, 39, 36, 33,
-                                      30,  27,  24,  21,  18,  15,  12,   9,   6,  3,  0, 62, 59, 56, 53, 50,
-                                      47,  44,  41,  38,  35,  32,  29,  26,  23, 20, 17, 14, 11,  8,  5,  2 );
+    __m512i mask0 = _v512_set_epi8( 126, 123, 120, 117, 114, 111, 108, 105, 102, 99, 96, 93, 90, 87, 84, 81,
+                                     78,  75,  72,  69,  66,  63,  60,  57,  54, 51, 48, 45, 42, 39, 36, 33,
+                                     30,  27,  24,  21,  18,  15,  12,   9,   6,  3,  0, 62, 59, 56, 53, 50,
+                                     47,  44,  41,  38,  35,  32,  29,  26,  23, 20, 17, 14, 11,  8,  5,  2 );
     __m512i r0b01 = _mm512_permutex2var_epi8(bgr0, mask0, bgr1);
     __m512i b1g12 = _mm512_permutex2var_epi8(bgr1, mask0, bgr2);
     __m512i r12b2 = _mm512_permutex2var_epi8(bgr1,
-                    _mm512_set_epi8( 125, 122, 119, 116, 113, 110, 107, 104, 101,  98,  95,  92,  89,  86,  83, 80,
-                                      77,  74,  71,  68,  65, 127, 124, 121, 118, 115, 112, 109, 106, 103, 100, 97,
-                                      94,  91,  88,  85,  82,  79,  76,  73,  70,  67,  64,  61,  58,  55,  52, 49,
-                                      46,  43,  40,  37,  34,  31,  28,  25,  22,  19,  16,  13,  10,   7,   4,  1 ), bgr2);
+                    _v512_set_epi8( 125, 122, 119, 116, 113, 110, 107, 104, 101,  98,  95,  92,  89,  86,  83, 80,
+                                     77,  74,  71,  68,  65, 127, 124, 121, 118, 115, 112, 109, 106, 103, 100, 97,
+                                     94,  91,  88,  85,  82,  79,  76,  73,  70,  67,  64,  61,  58,  55,  52, 49,
+                                     46,  43,  40,  37,  34,  31,  28,  25,  22,  19,  16,  13,  10,   7,   4,  1 ), bgr2);
     b = v_uint16x32(_mm512_mask_compress_epi8(r12b2, 0xffffffffffe00000, r0b01));
     g = v_uint16x32(_mm512_mask_compress_epi8(b1g12, 0x2492492492492492, bgr0));
     r = v_uint16x32(_mm512_mask_expand_epi8(r0b01, 0xffffffffffe00000, r12b2));
@@ -1726,16 +1787,16 @@ inline void v_load_deinterleave( const ushort* ptr, v_uint16x32& b, v_uint16x32&
     __m512i bgr1 = _mm512_loadu_si512((const __m512i*)(ptr + 32));
     __m512i bgr2 = _mm512_loadu_si512((const __m512i*)(ptr + 64));
 
-    __m512i mask0 = _mm512_set_epi16( 61, 58, 55, 52, 49, 46, 43, 40, 37, 34, 63, 60, 57, 54, 51, 48,
-                                      45, 42, 39, 36, 33, 30, 27, 24, 21, 18, 15, 12,  9,  6,  3,  0 );
+    __m512i mask0 = _v512_set_epi16( 61, 58, 55, 52, 49, 46, 43, 40, 37, 34, 63, 60, 57, 54, 51, 48,
+                                     45, 42, 39, 36, 33, 30, 27, 24, 21, 18, 15, 12,  9,  6,  3,  0 );
     __m512i b01g1 = _mm512_permutex2var_epi16(bgr0, mask0, bgr1);
     __m512i r12b2 = _mm512_permutex2var_epi16(bgr1, mask0, bgr2);
     __m512i g20r0 = _mm512_permutex2var_epi16(bgr2, mask0, bgr0);
 
     b = v_uint16x32(_mm512_mask_blend_epi32(0x001f, b01g1, r12b2));
     g = v_uint16x32(_mm512_alignr_epi32(r12b2, g20r0, 11));
-    r = v_uint16x32(_mm512_permutex2var_epi16(bgr1, _mm512_set_epi16( 42, 41, 40, 39, 38, 37, 36, 35, 34, 33, 32, 29, 26, 23, 20, 17,
-                                                                      14, 11,  8,  5,  2, 53, 52, 51, 50, 49, 48, 47, 46, 45, 44, 43 ), g20r0));
+    r = v_uint16x32(_mm512_permutex2var_epi16(bgr1, _v512_set_epi16( 42, 41, 40, 39, 38, 37, 36, 35, 34, 33, 32, 29, 26, 23, 20, 17,
+                                                                     14, 11,  8,  5,  2, 53, 52, 51, 50, 49, 48, 47, 46, 45, 44, 43 ), g20r0));
 }
 
 inline void v_load_deinterleave( const unsigned* ptr, v_uint32x16& b, v_uint32x16& g, v_uint32x16& r )
@@ -1744,14 +1805,14 @@ inline void v_load_deinterleave( const unsigned* ptr, v_uint32x16& b, v_uint32x1
     __m512i bgr1 = _mm512_loadu_si512((const __m512i*)(ptr + 16));
     __m512i bgr2 = _mm512_loadu_si512((const __m512i*)(ptr + 32));
 
-    __m512i mask0 = _mm512_set_epi32( 29, 26, 23, 20, 17, 30, 27, 24, 21, 18, 15, 12, 9, 6, 3, 0 );
+    __m512i mask0 = _v512_set_epi32( 29, 26, 23, 20, 17, 30, 27, 24, 21, 18, 15, 12, 9, 6, 3, 0 );
     __m512i b01r1 = _mm512_permutex2var_epi32(bgr0, mask0, bgr1);
     __m512i g12b2 = _mm512_permutex2var_epi32(bgr1, mask0, bgr2);
     __m512i r20g0 = _mm512_permutex2var_epi32(bgr2, mask0, bgr0);
 
     b = v_uint32x16(_mm512_mask_blend_epi32(0x001f, b01r1, g12b2));
     g = v_uint32x16(_mm512_alignr_epi32(g12b2, r20g0, 11));
-    r = v_uint32x16(_mm512_permutex2var_epi32(bgr1, _mm512_set_epi32( 26, 25, 24, 23, 22, 13, 10, 7, 4, 1, 21, 20, 19, 18, 17, 16 ), r20g0));
+    r = v_uint32x16(_mm512_permutex2var_epi32(bgr1, _v512_set_epi32( 26, 25, 24, 23, 22, 13, 10, 7, 4, 1, 21, 20, 19, 18, 17, 16 ), r20g0));
 }
 
 inline void v_load_deinterleave( const uint64* ptr, v_uint64x8& b, v_uint64x8& g, v_uint64x8& r )
@@ -1760,14 +1821,14 @@ inline void v_load_deinterleave( const uint64* ptr, v_uint64x8& b, v_uint64x8& g
     __m512i bgr1 = _mm512_loadu_si512((const __m512i*)(ptr + 8));
     __m512i bgr2 = _mm512_loadu_si512((const __m512i*)(ptr + 16));
 
-    __m512i mask0 = _mm512_set_epi64( 13, 10, 15, 12, 9, 6, 3, 0 );
+    __m512i mask0 = _v512_set_epi64( 13, 10, 15, 12, 9, 6, 3, 0 );
     __m512i b01g1 = _mm512_permutex2var_epi64(bgr0, mask0, bgr1);
     __m512i r12b2 = _mm512_permutex2var_epi64(bgr1, mask0, bgr2);
     __m512i g20r0 = _mm512_permutex2var_epi64(bgr2, mask0, bgr0);
 
     b = v_uint64x8(_mm512_mask_blend_epi64(0x03, b01g1, r12b2));
     r = v_uint64x8(_mm512_alignr_epi64(r12b2, g20r0, 6));
-    g = v_uint64x8(_mm512_permutex2var_epi64(bgr1, _mm512_set_epi64( 10, 9, 8, 5, 2, 13, 12, 11 ), g20r0));
+    g = v_uint64x8(_mm512_permutex2var_epi64(bgr1, _v512_set_epi64( 10, 9, 8, 5, 2, 13, 12, 11 ), g20r0));
 }
 
 inline void v_load_deinterleave( const uchar* ptr, v_uint8x64& b, v_uint8x64& g, v_uint8x64& r, v_uint8x64& a )
@@ -1777,14 +1838,14 @@ inline void v_load_deinterleave( const uchar* ptr, v_uint8x64& b, v_uint8x64& g,
     __m512i bgra2 = _mm512_loadu_si512((const __m512i*)(ptr + 128));
     __m512i bgra3 = _mm512_loadu_si512((const __m512i*)(ptr + 192));
 
-    __m512i mask0 = _mm512_set_epi8( 126, 124, 122, 120, 118, 116, 114, 112, 110, 108, 106, 104, 102, 100, 98, 96,
-                                      94,  92,  90,  88,  86,  84,  82,  80,  78,  76,  74,  72,  70,  68, 66, 64,
-                                      62,  60,  58,  56,  54,  52,  50,  48,  46,  44,  42,  40,  38,  36, 34, 32,
-                                      30,  28,  26,  24,  22,  20,  18,  16,  14,  12,  10,   8,   6,   4,  2,  0 );
-    __m512i mask1 = _mm512_set_epi8( 127, 125, 123, 121, 119, 117, 115, 113, 111, 109, 107, 105, 103, 101, 99, 97,
-                                      95,  93,  91,  89,  87,  85,  83,  81,  79,  77,  75,  73,  71,  69, 67, 65,
-                                      63,  61,  59,  57,  55,  53,  51,  49,  47,  45,  43,  41,  39,  37, 35, 33,
-                                      31,  29,  27,  25,  23,  21,  19,  17,  15,  13,  11,   9,   7,   5,  3,  1 );
+    __m512i mask0 = _v512_set_epi8( 126, 124, 122, 120, 118, 116, 114, 112, 110, 108, 106, 104, 102, 100, 98, 96,
+                                     94,  92,  90,  88,  86,  84,  82,  80,  78,  76,  74,  72,  70,  68, 66, 64,
+                                     62,  60,  58,  56,  54,  52,  50,  48,  46,  44,  42,  40,  38,  36, 34, 32,
+                                     30,  28,  26,  24,  22,  20,  18,  16,  14,  12,  10,   8,   6,   4,  2,  0 );
+    __m512i mask1 = _v512_set_epi8( 127, 125, 123, 121, 119, 117, 115, 113, 111, 109, 107, 105, 103, 101, 99, 97,
+                                     95,  93,  91,  89,  87,  85,  83,  81,  79,  77,  75,  73,  71,  69, 67, 65,
+                                     63,  61,  59,  57,  55,  53,  51,  49,  47,  45,  43,  41,  39,  37, 35, 33,
+                                     31,  29,  27,  25,  23,  21,  19,  17,  15,  13,  11,   9,   7,   5,  3,  1 );
 
     __m512i br01 = _mm512_permutex2var_epi8(bgra0, mask0, bgra1);
     __m512i ga01 = _mm512_permutex2var_epi8(bgra0, mask1, bgra1);
@@ -1804,10 +1865,10 @@ inline void v_load_deinterleave( const ushort* ptr, v_uint16x32& b, v_uint16x32&
     __m512i bgra2 = _mm512_loadu_si512((const __m512i*)(ptr + 64));
     __m512i bgra3 = _mm512_loadu_si512((const __m512i*)(ptr + 96));
 
-    __m512i mask0 = _mm512_set_epi16( 62, 60, 58, 56, 54, 52, 50, 48, 46, 44, 42, 40, 38, 36, 34, 32,
-                                      30, 28, 26, 24, 22, 20, 18, 16, 14, 12, 10,  8,  6,  4,  2,  0 );
-    __m512i mask1 = _mm512_set_epi16( 63, 61, 59, 57, 55, 53, 51, 49, 47, 45, 43, 41, 39, 37, 35, 33,
-                                      31, 29, 27, 25, 23, 21, 19, 17, 15, 13, 11,  9,  7,  5,  3,  1 );
+    __m512i mask0 = _v512_set_epi16( 62, 60, 58, 56, 54, 52, 50, 48, 46, 44, 42, 40, 38, 36, 34, 32,
+                                     30, 28, 26, 24, 22, 20, 18, 16, 14, 12, 10,  8,  6,  4,  2,  0 );
+    __m512i mask1 = _v512_set_epi16( 63, 61, 59, 57, 55, 53, 51, 49, 47, 45, 43, 41, 39, 37, 35, 33,
+                                     31, 29, 27, 25, 23, 21, 19, 17, 15, 13, 11,  9,  7,  5,  3,  1 );
 
     __m512i br01 = _mm512_permutex2var_epi16(bgra0, mask0, bgra1);
     __m512i ga01 = _mm512_permutex2var_epi16(bgra0, mask1, bgra1);
@@ -1827,8 +1888,8 @@ inline void v_load_deinterleave( const unsigned* ptr, v_uint32x16& b, v_uint32x1
     __m512i bgra2 = _mm512_loadu_si512((const __m512i*)(ptr + 32));
     __m512i bgra3 = _mm512_loadu_si512((const __m512i*)(ptr + 48));
 
-    __m512i mask0 = _mm512_set_epi32( 30, 28, 26, 24, 22, 20, 18, 16, 14, 12, 10, 8, 6, 4, 2, 0 );
-    __m512i mask1 = _mm512_set_epi32( 31, 29, 27, 25, 23, 21, 19, 17, 15, 13, 11, 9, 7, 5, 3, 1 );
+    __m512i mask0 = _v512_set_epi32( 30, 28, 26, 24, 22, 20, 18, 16, 14, 12, 10, 8, 6, 4, 2, 0 );
+    __m512i mask1 = _v512_set_epi32( 31, 29, 27, 25, 23, 21, 19, 17, 15, 13, 11, 9, 7, 5, 3, 1 );
 
     __m512i br01 = _mm512_permutex2var_epi32(bgra0, mask0, bgra1);
     __m512i ga01 = _mm512_permutex2var_epi32(bgra0, mask1, bgra1);
@@ -1848,8 +1909,8 @@ inline void v_load_deinterleave( const uint64* ptr, v_uint64x8& b, v_uint64x8& g
     __m512i bgra2 = _mm512_loadu_si512((const __m512i*)(ptr + 16));
     __m512i bgra3 = _mm512_loadu_si512((const __m512i*)(ptr + 24));
 
-    __m512i mask0 = _mm512_set_epi64( 14, 12, 10, 8, 6, 4, 2, 0 );
-    __m512i mask1 = _mm512_set_epi64( 15, 13, 11, 9, 7, 5, 3, 1 );
+    __m512i mask0 = _v512_set_epi64( 14, 12, 10, 8, 6, 4, 2, 0 );
+    __m512i mask1 = _v512_set_epi64( 15, 13, 11, 9, 7, 5, 3, 1 );
 
     __m512i br01 = _mm512_permutex2var_epi64(bgra0, mask0, bgra1);
     __m512i ga01 = _mm512_permutex2var_epi64(bgra0, mask1, bgra1);
@@ -1867,122 +1928,94 @@ inline void v_load_deinterleave( const uint64* ptr, v_uint64x8& b, v_uint64x8& g
 inline void v_store_interleave( uchar* ptr, const v_uint8x64& x, const v_uint8x64& y,
                                 hal::StoreMode mode=hal::STORE_UNALIGNED )
 {
-    __m512i mask0 = _mm512_set_epi8(  95,  31,  94,  30,  93,  29,  92,  28,  91,  27,  90,  26,  89,  25,  88,  24,
-                                      87,  23,  86,  22,  85,  21,  84,  20,  83,  19,  82,  18,  81,  17,  80,  16,
-                                      79,  15,  78,  14,  77,  13,  76,  12,  75,  11,  74,  10,  73,   9,  72,   8,
-                                      71,   7,  70,   6,  69,   5,  68,   4,  67,   3,  66,   2,  65,   1,  64,   0 );
-    __m512i mask1 = _mm512_set_epi8( 127,  63, 126,  62, 125,  61, 124,  60, 123,  59, 122,  58, 121,  57, 120,  56,
-                                     119,  55, 118,  54, 117,  53, 116,  52, 115,  51, 114,  50, 113,  49, 112,  48,
-                                     111,  47, 110,  46, 109,  45, 108,  44, 107,  43, 106,  42, 105,  41, 104,  40,
-                                     103,  39, 102,  38, 101,  37, 100,  36,  99,  35,  98,  34,  97,  33,  96,  32 );
-    __m512i xy0 = _mm512_permutex2var_epi8(x.val, mask0, y.val);
-    __m512i xy1 = _mm512_permutex2var_epi8(x.val, mask1, y.val);
-
     if( mode == hal::STORE_ALIGNED_NOCACHE )
     {
-        _mm512_stream_si512((__m512i*)ptr, xy0);
-        _mm512_stream_si512((__m512i*)(ptr + 64), xy1);
+        _mm512_stream_si512((__m512i*)ptr, v_zip_low(x, y).val);
+        _mm512_stream_si512((__m512i*)(ptr + 64), v_zip_high(x, y).val);
     }
     else if( mode == hal::STORE_ALIGNED )
     {
-        _mm512_store_si512((__m512i*)ptr, xy0);
-        _mm512_store_si512((__m512i*)(ptr + 64), xy1);
+        _mm512_store_si512((__m512i*)ptr, v_zip_low(x, y).val);
+        _mm512_store_si512((__m512i*)(ptr + 64), v_zip_high(x, y).val);
     }
     else
     {
-        _mm512_storeu_si512((__m512i*)ptr, xy0);
-        _mm512_storeu_si512((__m512i*)(ptr + 64), xy1);
+        _mm512_storeu_si512((__m512i*)ptr, v_zip_low(x, y).val);
+        _mm512_storeu_si512((__m512i*)(ptr + 64), v_zip_high(x, y).val);
     }
 }
 
 inline void v_store_interleave( ushort* ptr, const v_uint16x32& x, const v_uint16x32& y,
                                 hal::StoreMode mode=hal::STORE_UNALIGNED )
 {
-    __m512i mask0 = _mm512_set_epi16( 47, 15, 46, 14, 45, 13, 44, 12, 43, 11, 42, 10, 41,  9, 40,  8,
-                                      39,  7, 38,  6, 37,  5, 36,  4, 35,  3, 34,  2, 33,  1, 32,  0 );
-    __m512i mask1 = _mm512_set_epi16( 63, 31, 62, 30, 61, 29, 60, 28, 59, 27, 58, 26, 57, 25, 56, 24,
-                                      55, 23, 54, 22, 53, 21, 52, 20, 51, 19, 50, 18, 49, 17, 48, 16 );
-    __m512i xy0 = _mm512_permutex2var_epi16(x.val, mask0, y.val);
-    __m512i xy1 = _mm512_permutex2var_epi16(x.val, mask1, y.val);
-
     if( mode == hal::STORE_ALIGNED_NOCACHE )
     {
-        _mm512_stream_si512((__m512i*)ptr, xy0);
-        _mm512_stream_si512((__m512i*)(ptr + 32), xy1);
+        _mm512_stream_si512((__m512i*)ptr, v_zip_low(x, y).val);
+        _mm512_stream_si512((__m512i*)(ptr + 32), v_zip_high(x, y).val);
     }
     else if( mode == hal::STORE_ALIGNED )
     {
-        _mm512_store_si512((__m512i*)ptr, xy0);
-        _mm512_store_si512((__m512i*)(ptr + 32), xy1);
+        _mm512_store_si512((__m512i*)ptr, v_zip_low(x, y).val);
+        _mm512_store_si512((__m512i*)(ptr + 32), v_zip_high(x, y).val);
     }
     else
     {
-        _mm512_storeu_si512((__m512i*)ptr, xy0);
-        _mm512_storeu_si512((__m512i*)(ptr + 32), xy1);
+        _mm512_storeu_si512((__m512i*)ptr, v_zip_low(x, y).val);
+        _mm512_storeu_si512((__m512i*)(ptr + 32), v_zip_high(x, y).val);
     }
 }
 
 inline void v_store_interleave( unsigned* ptr, const v_uint32x16& x, const v_uint32x16& y,
                                 hal::StoreMode mode=hal::STORE_UNALIGNED )
 {
-    __m512i mask0 = _mm512_set_epi32( 23,  7, 22,  6, 21,  5, 20,  4, 19,  3, 18,  2, 17, 1, 16, 0 );
-    __m512i mask1 = _mm512_set_epi32( 31, 15, 30, 14, 29, 13, 28, 12, 27, 11, 26, 10, 25, 9, 24, 8 );
-    __m512i xy0 = _mm512_permutex2var_epi32(x.val, mask0, y.val);
-    __m512i xy1 = _mm512_permutex2var_epi32(x.val, mask1, y.val);
-
     if( mode == hal::STORE_ALIGNED_NOCACHE )
     {
-        _mm512_stream_si512((__m512i*)ptr, xy0);
-        _mm512_stream_si512((__m512i*)(ptr + 16), xy1);
+        _mm512_stream_si512((__m512i*)ptr, v_zip_low(x, y).val);
+        _mm512_stream_si512((__m512i*)(ptr + 16), v_zip_high(x, y).val);
     }
     else if( mode == hal::STORE_ALIGNED )
     {
-        _mm512_store_si512((__m512i*)ptr, xy0);
-        _mm512_store_si512((__m512i*)(ptr + 16), xy1);
+        _mm512_store_si512((__m512i*)ptr, v_zip_low(x, y).val);
+        _mm512_store_si512((__m512i*)(ptr + 16), v_zip_high(x, y).val);
     }
     else
     {
-        _mm512_storeu_si512((__m512i*)ptr, xy0);
-        _mm512_storeu_si512((__m512i*)(ptr + 16), xy1);
+        _mm512_storeu_si512((__m512i*)ptr, v_zip_low(x, y).val);
+        _mm512_storeu_si512((__m512i*)(ptr + 16), v_zip_high(x, y).val);
     }
 }
 
 inline void v_store_interleave( uint64* ptr, const v_uint64x8& x, const v_uint64x8& y,
                                 hal::StoreMode mode=hal::STORE_UNALIGNED )
 {
-    __m512i mask0 = _mm512_set_epi64( 11, 3, 10, 2,  9, 1,  8, 0 );
-    __m512i mask1 = _mm512_set_epi64( 15, 7, 14, 6, 13, 5, 12, 4 );
-    __m512i xy0 = _mm512_permutex2var_epi64(x.val, mask0, y.val);
-    __m512i xy1 = _mm512_permutex2var_epi64(x.val, mask1, y.val);
-
     if( mode == hal::STORE_ALIGNED_NOCACHE )
     {
-        _mm512_stream_si512((__m512i*)ptr, xy0);
-        _mm512_stream_si512((__m512i*)(ptr + 8), xy1);
+        _mm512_stream_si512((__m512i*)ptr, v_zip_low(x, y).val);
+        _mm512_stream_si512((__m512i*)(ptr + 8), v_zip_high(x, y).val);
     }
     else if( mode == hal::STORE_ALIGNED )
     {
-        _mm512_store_si512((__m512i*)ptr, xy0);
-        _mm512_store_si512((__m512i*)(ptr + 8), xy1);
+        _mm512_store_si512((__m512i*)ptr, v_zip_low(x, y).val);
+        _mm512_store_si512((__m512i*)(ptr + 8), v_zip_high(x, y).val);
     }
     else
     {
-        _mm512_storeu_si512((__m512i*)ptr, xy0);
-        _mm512_storeu_si512((__m512i*)(ptr + 8), xy1);
+        _mm512_storeu_si512((__m512i*)ptr, v_zip_low(x, y).val);
+        _mm512_storeu_si512((__m512i*)(ptr + 8), v_zip_high(x, y).val);
     }
 }
 
 inline void v_store_interleave( uchar* ptr, const v_uint8x64& b, const v_uint8x64& g, const v_uint8x64& r,
                                 hal::StoreMode mode=hal::STORE_UNALIGNED )
 {
-    __m512i mask0 = _mm512_set_epi8( 106, 127,  63, 105, 126,  62, 104, 125,  61, 103, 124,  60, 102, 123,  59, 101,
-                                     122,  58, 100, 121,  57,  99, 120,  56,  98, 119,  55,  97, 118,  54,  96, 117,
-                                      53,  95, 116,  52,  94, 115,  51,  93, 114,  50,  92, 113,  49,  91, 112,  48,
-                                      90, 111,  47,  89, 110,  46,  88, 109,  45,  87, 108,  44,  86, 107,  43,  85 );
-    __m512i mask1 = _mm512_set_epi8( 127,  42, 105, 126,  41, 104, 125,  40, 103, 124,  39, 102, 123,  38, 101, 122,
-                                      37, 100, 121,  36,  99, 120,  35,  98, 119,  34,  97, 118,  33,  96, 117,  32,
-                                      95, 116,  31,  94, 115,  30,  93, 114,  29,  92, 113,  28,  91, 112,  27,  90,
-                                     111,  26,  89, 110,  25,  88, 109,  24,  87, 108,  23,  86, 107,  22,  85, 106 );
+    __m512i mask0 = _v512_set_epi8( 106, 127,  63, 105, 126,  62, 104, 125,  61, 103, 124,  60, 102, 123,  59, 101,
+                                    122,  58, 100, 121,  57,  99, 120,  56,  98, 119,  55,  97, 118,  54,  96, 117,
+                                     53,  95, 116,  52,  94, 115,  51,  93, 114,  50,  92, 113,  49,  91, 112,  48,
+                                     90, 111,  47,  89, 110,  46,  88, 109,  45,  87, 108,  44,  86, 107,  43,  85 );
+    __m512i mask1 = _v512_set_epi8( 127,  42, 105, 126,  41, 104, 125,  40, 103, 124,  39, 102, 123,  38, 101, 122,
+                                     37, 100, 121,  36,  99, 120,  35,  98, 119,  34,  97, 118,  33,  96, 117,  32,
+                                     95, 116,  31,  94, 115,  30,  93, 114,  29,  92, 113,  28,  91, 112,  27,  90,
+                                    111,  26,  89, 110,  25,  88, 109,  24,  87, 108,  23,  86, 107,  22,  85, 106 );
     __m512i g1b2g2 = _mm512_permutex2var_epi8(b.val, mask0, g.val);
     __m512i r2r1b1 = _mm512_permutex2var_epi8(b.val, mask1, r.val);
 
@@ -2013,10 +2046,10 @@ inline void v_store_interleave( uchar* ptr, const v_uint8x64& b, const v_uint8x6
 inline void v_store_interleave( ushort* ptr, const v_uint16x32& b, const v_uint16x32& g, const v_uint16x32& r,
                                 hal::StoreMode mode=hal::STORE_UNALIGNED )
 {
-    __m512i mask0 = _mm512_set_epi16( 21, 52, 31, 20, 51, 30, 19, 50, 29, 18, 49, 28, 17, 48, 27, 16,
-                                      47, 26, 15, 46, 25, 14, 45, 24, 13, 44, 23, 12, 43, 22, 11, 42 );
-    __m512i mask1 = _mm512_set_epi16( 63, 31, 20, 62, 30, 19, 61, 29, 18, 60, 28, 17, 59, 27, 16, 58,
-                                      26, 15, 57, 25, 14, 56, 24, 13, 55, 23, 12, 54, 22, 11, 53, 21 );
+    __m512i mask0 = _v512_set_epi16( 21, 52, 31, 20, 51, 30, 19, 50, 29, 18, 49, 28, 17, 48, 27, 16,
+                                     47, 26, 15, 46, 25, 14, 45, 24, 13, 44, 23, 12, 43, 22, 11, 42 );
+    __m512i mask1 = _v512_set_epi16( 63, 31, 20, 62, 30, 19, 61, 29, 18, 60, 28, 17, 59, 27, 16, 58,
+                                     26, 15, 57, 25, 14, 56, 24, 13, 55, 23, 12, 54, 22, 11, 53, 21 );
     __m512i r1b1b2 = _mm512_permutex2var_epi16(b.val, mask0, r.val);
     __m512i g2r2g1 = _mm512_permutex2var_epi16(g.val, mask1, r.val);
 
@@ -2047,8 +2080,8 @@ inline void v_store_interleave( ushort* ptr, const v_uint16x32& b, const v_uint1
 inline void v_store_interleave( unsigned* ptr, const v_uint32x16& b, const v_uint32x16& g, const v_uint32x16& r,
                                 hal::StoreMode mode=hal::STORE_UNALIGNED )
 {
-    __m512i mask0 = _mm512_set_epi32( 26, 31, 15, 25, 30, 14, 24, 29, 13, 23, 28, 12, 22, 27, 11, 21 );
-    __m512i mask1 = _mm512_set_epi32( 31, 10, 25, 30,  9, 24, 29,  8, 23, 28,  7, 22, 27,  6, 21, 26 );
+    __m512i mask0 = _v512_set_epi32( 26, 31, 15, 25, 30, 14, 24, 29, 13, 23, 28, 12, 22, 27, 11, 21 );
+    __m512i mask1 = _v512_set_epi32( 31, 10, 25, 30,  9, 24, 29,  8, 23, 28,  7, 22, 27,  6, 21, 26 );
     __m512i g1b2g2 = _mm512_permutex2var_epi32(b.val, mask0, g.val);
     __m512i r2r1b1 = _mm512_permutex2var_epi32(b.val, mask1, r.val);
 
@@ -2079,8 +2112,8 @@ inline void v_store_interleave( unsigned* ptr, const v_uint32x16& b, const v_uin
 inline void v_store_interleave( uint64* ptr, const v_uint64x8& b, const v_uint64x8& g, const v_uint64x8& r,
                                 hal::StoreMode mode=hal::STORE_UNALIGNED )
 {
-    __m512i mask0 = _mm512_set_epi64(  5, 12,  7,  4, 11,  6,  3, 10 );
-    __m512i mask1 = _mm512_set_epi64( 15,  7,  4, 14,  6,  3, 13,  5 );
+    __m512i mask0 = _v512_set_epi64(  5, 12,  7,  4, 11,  6,  3, 10 );
+    __m512i mask1 = _v512_set_epi64( 15,  7,  4, 14,  6,  3, 13,  5 );
     __m512i r1b1b2 = _mm512_permutex2var_epi64(b.val, mask0, r.val);
     __m512i g2r2g1 = _mm512_permutex2var_epi64(g.val, mask1, r.val);
 
@@ -2112,14 +2145,14 @@ inline void v_store_interleave( uchar* ptr, const v_uint8x64& b, const v_uint8x6
                                 const v_uint8x64& r, const v_uint8x64& a,
                                 hal::StoreMode mode=hal::STORE_UNALIGNED )
 {
-    __m512i mask0 = _mm512_set_epi8(  95, 31,  94, 30,  93, 29,  92, 28,  91, 27,  90, 26,  89, 25,  88, 24,
-                                      87, 23,  86, 22,  85, 21,  84, 20,  83, 19,  82, 18,  81, 17,  80, 16,
-                                      79, 15,  78, 14,  77, 13,  76, 12,  75, 11,  74, 10,  73,  9,  72,  8,
-                                      71,  7,  70,  6,  69,  5,  68,  4,  67,  3,  66,  2,  65,  1,  64,  0 );
-    __m512i mask1 = _mm512_set_epi8( 127, 63, 126, 62, 125, 61, 124, 60, 123, 59, 122, 58, 121, 57, 120, 56,
-                                     119, 55, 118, 54, 117, 53, 116, 52, 115, 51, 114, 50, 113, 49, 112, 48,
-                                     111, 47, 110, 46, 109, 45, 108, 44, 107, 43, 106, 42, 105, 41, 104, 40,
-                                     103, 39, 102, 38, 101, 37, 100, 36,  99, 35,  98, 34,  97, 33,  96, 32 );
+    __m512i mask0 = _v512_set_epi8(  95, 31,  94, 30,  93, 29,  92, 28,  91, 27,  90, 26,  89, 25,  88, 24,
+                                     87, 23,  86, 22,  85, 21,  84, 20,  83, 19,  82, 18,  81, 17,  80, 16,
+                                     79, 15,  78, 14,  77, 13,  76, 12,  75, 11,  74, 10,  73,  9,  72,  8,
+                                     71,  7,  70,  6,  69,  5,  68,  4,  67,  3,  66,  2,  65,  1,  64,  0 );
+    __m512i mask1 = _v512_set_epi8( 127, 63, 126, 62, 125, 61, 124, 60, 123, 59, 122, 58, 121, 57, 120, 56,
+                                    119, 55, 118, 54, 117, 53, 116, 52, 115, 51, 114, 50, 113, 49, 112, 48,
+                                    111, 47, 110, 46, 109, 45, 108, 44, 107, 43, 106, 42, 105, 41, 104, 40,
+                                    103, 39, 102, 38, 101, 37, 100, 36,  99, 35,  98, 34,  97, 33,  96, 32 );
 
     __m512i br01 = _mm512_permutex2var_epi8(b.val, mask0, r.val);
     __m512i br23 = _mm512_permutex2var_epi8(b.val, mask1, r.val);
@@ -2158,10 +2191,10 @@ inline void v_store_interleave( ushort* ptr, const v_uint16x32& b, const v_uint1
                                 const v_uint16x32& r, const v_uint16x32& a,
                                 hal::StoreMode mode=hal::STORE_UNALIGNED )
 {
-    __m512i mask0 = _mm512_set_epi16( 47, 15, 46, 14, 45, 13, 44, 12, 43, 11, 42, 10, 41,  9, 40,  8,
-                                      39,  7, 38,  6, 37,  5, 36,  4, 35,  3, 34,  2, 33,  1, 32,  0 );
-    __m512i mask1 = _mm512_set_epi16( 63, 31, 62, 30, 61, 29, 60, 28, 59, 27, 58, 26, 57, 25, 56, 24,
-                                      55, 23, 54, 22, 53, 21, 52, 20, 51, 19, 50, 18, 49, 17, 48, 16 );
+    __m512i mask0 = _v512_set_epi16( 47, 15, 46, 14, 45, 13, 44, 12, 43, 11, 42, 10, 41,  9, 40,  8,
+                                     39,  7, 38,  6, 37,  5, 36,  4, 35,  3, 34,  2, 33,  1, 32,  0 );
+    __m512i mask1 = _v512_set_epi16( 63, 31, 62, 30, 61, 29, 60, 28, 59, 27, 58, 26, 57, 25, 56, 24,
+                                     55, 23, 54, 22, 53, 21, 52, 20, 51, 19, 50, 18, 49, 17, 48, 16 );
 
     __m512i br01 = _mm512_permutex2var_epi16(b.val, mask0, r.val);
     __m512i br23 = _mm512_permutex2var_epi16(b.val, mask1, r.val);
@@ -2200,8 +2233,8 @@ inline void v_store_interleave( unsigned* ptr, const v_uint32x16& b, const v_uin
                                 const v_uint32x16& r, const v_uint32x16& a,
                                 hal::StoreMode mode=hal::STORE_UNALIGNED )
 {
-    __m512i mask0 = _mm512_set_epi32( 23,  7, 22,  6, 21,  5, 20,  4, 19,  3, 18,  2, 17, 1, 16, 0 );
-    __m512i mask1 = _mm512_set_epi32( 31, 15, 30, 14, 29, 13, 28, 12, 27, 11, 26, 10, 25, 9, 24, 8 );
+    __m512i mask0 = _v512_set_epi32( 23,  7, 22,  6, 21,  5, 20,  4, 19,  3, 18,  2, 17, 1, 16, 0 );
+    __m512i mask1 = _v512_set_epi32( 31, 15, 30, 14, 29, 13, 28, 12, 27, 11, 26, 10, 25, 9, 24, 8 );
 
     __m512i br01 = _mm512_permutex2var_epi32(b.val, mask0, r.val);
     __m512i br23 = _mm512_permutex2var_epi32(b.val, mask1, r.val);
@@ -2241,8 +2274,8 @@ inline void v_store_interleave( uint64* ptr, const v_uint64x8& b, const v_uint64
                                 hal::StoreMode mode=hal::STORE_UNALIGNED )
 {
     
-    __m512i mask0 = _mm512_set_epi64( 11, 3, 10, 2,  9, 1,  8, 0 );
-    __m512i mask1 = _mm512_set_epi64( 15, 7, 14, 6, 13, 5, 12, 4 );
+    __m512i mask0 = _v512_set_epi64( 11, 3, 10, 2,  9, 1,  8, 0 );
+    __m512i mask1 = _v512_set_epi64( 15, 7, 14, 6, 13, 5, 12, 4 );
 
     __m512i br01 = _mm512_permutex2var_epi64(b.val, mask0, r.val);
     __m512i br23 = _mm512_permutex2var_epi64(b.val, mask1, r.val);

--- a/modules/core/include/opencv2/core/hal/intrin_avx512.hpp
+++ b/modules/core/include/opencv2/core/hal/intrin_avx512.hpp
@@ -30,7 +30,7 @@ inline __m512d _v512_combine(const __m256d& lo, const __m256d& hi)
 inline int _v_cvtsi512_si32(const __m512i& a)
 { return _mm_cvtsi128_si32(_mm512_castsi512_si128(a)); }
 
-inline __m512i _v512_shuffle_odd_64(const __m512i& v)
+/*inline __m512i _v512_shuffle_odd_64(const __m512i& v)
 { return _mm512_permutex_epi64(v, _MM_SHUFFLE(3, 1, 2, 0)); }
 
 inline __m512d _v512_shuffle_odd_64(const __m512d& v)
@@ -88,7 +88,7 @@ inline __m512i _v512_packs_epu32(const __m512i& a, const __m512i& b)
     __m512i am = _mm256_min_epu32(a, m);
     __m512i bm = _mm256_min_epu32(b, m);
     return _mm256_packus_epi32(am, bm);
-}
+}*/
 
 ///////// Types ////////////
 
@@ -116,187 +116,205 @@ struct v_uint8x64
                uchar v56, uchar v57, uchar v58, uchar v59,
                uchar v60, uchar v61, uchar v62, uchar v63)
     {
-        val = _mm512_setr_epi8((char)v0,  (char)v1,  (char)v2,  (char)v3,  (char)v4,  (char)v5,  (char)v6 , (char)v7,
-                               (char)v8,  (char)v9,  (char)v10, (char)v11, (char)v12, (char)v13, (char)v14, (char)v15,
-                               (char)v16, (char)v17, (char)v18, (char)v19, (char)v20, (char)v21, (char)v22, (char)v23,
-                               (char)v24, (char)v25, (char)v26, (char)v27, (char)v28, (char)v29, (char)v30, (char)v31,
-                               (char)v32, (char)v33, (char)v34, (char)v35, (char)v36, (char)v37, (char)v38, (char)v39,
-                               (char)v40, (char)v41, (char)v42, (char)v43, (char)v44, (char)v45, (char)v46, (char)v47,
-                               (char)v48, (char)v49, (char)v50, (char)v51, (char)v52, (char)v53, (char)v54, (char)v55,
-                               (char)v56, (char)v57, (char)v58, (char)v59, (char)v60, (char)v61, (char)v62, (char)v63);
+        val = _mm512_set_epi8((char)v63, (char)v62, (char)v61, (char)v60, (char)v59, (char)v58, (char)v57, (char)v56,
+                              (char)v55, (char)v54, (char)v53, (char)v52, (char)v51, (char)v50, (char)v49, (char)v48,
+                              (char)v47, (char)v46, (char)v45, (char)v44, (char)v43, (char)v42, (char)v41, (char)v40,
+                              (char)v39, (char)v38, (char)v37, (char)v36, (char)v35, (char)v34, (char)v33, (char)v32,
+                              (char)v31, (char)v30, (char)v29, (char)v28, (char)v27, (char)v26, (char)v25, (char)v24,
+                              (char)v23, (char)v22, (char)v21, (char)v20, (char)v19, (char)v18, (char)v17, (char)v16,
+                              (char)v15, (char)v14, (char)v13, (char)v12, (char)v11, (char)v10, (char)v9,  (char)v8,
+                              (char)v7,  (char)v6,  (char)v5,  (char)v4,  (char)v3,  (char)v2,  (char)v1,  (char)v0);
     }
     v_uint8x64() : val(_mm512_setzero_si512()) {}
     uchar get0() const { return (uchar)_v_cvtsi512_si32(val); }
 };
 
-struct v_int8x32
+struct v_int8x64
 {
     typedef schar lane_type;
-    enum { nlanes = 32 };
+    enum { nlanes = 64 };
     __m512i val;
 
-    explicit v_int8x32(__m512i v) : val(v) {}
-    v_int8x32(schar v0,  schar v1,  schar v2,  schar v3,
+    explicit v_int8x64(__m512i v) : val(v) {}
+    v_int8x64(schar v0,  schar v1,  schar v2,  schar v3,
               schar v4,  schar v5,  schar v6,  schar v7,
               schar v8,  schar v9,  schar v10, schar v11,
               schar v12, schar v13, schar v14, schar v15,
               schar v16, schar v17, schar v18, schar v19,
               schar v20, schar v21, schar v22, schar v23,
               schar v24, schar v25, schar v26, schar v27,
-              schar v28, schar v29, schar v30, schar v31)
+              schar v28, schar v29, schar v30, schar v31,
+              schar v32, schar v33, schar v34, schar v35,
+              schar v36, schar v37, schar v38, schar v39,
+              schar v40, schar v41, schar v42, schar v43,
+              schar v44, schar v45, schar v46, schar v47,
+              schar v48, schar v49, schar v50, schar v51,
+              schar v52, schar v53, schar v54, schar v55,
+              schar v56, schar v57, schar v58, schar v59,
+              schar v60, schar v61, schar v62, schar v63)
     {
-        val = _mm256_setr_epi8(v0, v1, v2, v3, v4, v5, v6, v7, v8, v9,
-            v10, v11, v12, v13, v14, v15, v16, v17, v18, v19, v20,
-            v21, v22, v23, v24, v25, v26, v27, v28, v29, v30, v31);
+        val = _mm512_set_epi8(v63, v62, v61, v60, v59, v58, v57, v56, v55, v54, v53, v52, v51, v50, v49, v48,
+                              v47, v46, v45, v44, v43, v42, v41, v40, v39, v38, v37, v36, v35, v34, v33, v32,
+                              v31, v30, v29, v28, v27, v26, v25, v24, v23, v22, v21, v20, v19, v18, v17, v16,
+                              v15, v14, v13, v12, v11, v10, v9,  v8,  v7,  v6,  v5,  v4,  v3,  v2,  v1,  v0);
     }
-    v_int8x32() : val(_mm256_setzero_si256()) {}
-    schar get0() const { return (schar)_v_cvtsi256_si32(val); }
+    v_int8x64() : val(_mm512_setzero_si512()) {}
+    schar get0() const { return (schar)_v_cvtsi512_si32(val); }
 };
 
-struct v_uint16x16
+struct v_uint16x32
 {
     typedef ushort lane_type;
-    enum { nlanes = 16 };
+    enum { nlanes = 32 };
     __m512i val;
 
-    explicit v_uint16x16(__m512i v) : val(v) {}
-    v_uint16x16(ushort v0,  ushort v1,  ushort v2,  ushort v3,
+    explicit v_uint16x32(__m512i v) : val(v) {}
+    v_uint16x32(ushort v0,  ushort v1,  ushort v2,  ushort v3,
                 ushort v4,  ushort v5,  ushort v6,  ushort v7,
                 ushort v8,  ushort v9,  ushort v10, ushort v11,
-                ushort v12, ushort v13, ushort v14, ushort v15)
+                ushort v12, ushort v13, ushort v14, ushort v15,
+                ushort v16, ushort v17, ushort v18, ushort v19,
+                ushort v20, ushort v21, ushort v22, ushort v23,
+                ushort v24, ushort v25, ushort v26, ushort v27,
+                ushort v28, ushort v29, ushort v30, ushort v31)
     {
-        val = _mm256_setr_epi16((short)v0, (short)v1, (short)v2, (short)v3,
-            (short)v4,  (short)v5,  (short)v6,  (short)v7,  (short)v8,  (short)v9,
-            (short)v10, (short)v11, (short)v12, (short)v13, (short)v14, (short)v15);
+        val = _mm512_set_epi16((short)v31, (short)v30, (short)v29, (short)v28, (short)v27, (short)v26, (short)v25, (short)v24,
+                               (short)v23, (short)v22, (short)v21, (short)v20, (short)v19, (short)v18, (short)v17, (short)v16,
+                               (short)v15, (short)v14, (short)v13, (short)v12, (short)v11, (short)v10, (short)v9,  (short)v8,
+                               (short)v7,  (short)v6,  (short)v5,  (short)v4,  (short)v3,  (short)v2,  (short)v1,  (short)v0);
     }
-    v_uint16x16() : val(_mm256_setzero_si256()) {}
+    v_uint16x32() : val(_mm512_setzero_si512()) {}
     ushort get0() const { return (ushort)_v_cvtsi256_si32(val); }
 };
 
-struct v_int16x16
+struct v_int16x32
 {
     typedef short lane_type;
+    enum { nlanes = 32 };
+    __m512i val;
+
+    explicit v_int16x32(__m512i v) : val(v) {}
+    v_int16x32(short v0,  short v1,  short v2,  short v3,  short v4,  short v5,  short v6,  short v7,
+               short v8,  short v9,  short v10, short v11, short v12, short v13, short v14, short v15,
+               short v16, short v17, short v18, short v19, short v20, short v21, short v22, short v23,
+               short v24, short v25, short v26, short v27, short v28, short v29, short v30, short v31)
+    {
+        val = _mm512_set_epi16(v31, v30, v29, v28, v27, v26, v25, v24, v23, v22, v21, v20, v19, v18, v17, v16,
+                               v15, v14, v13, v12, v11, v10, v9,  v8,  v7,  v6,  v5,  v4,  v3,  v2,  v1,  v0);
+    }
+    v_int16x32() : val(_mm512_setzero_si512()) {}
+    short get0() const { return (short)_v_cvtsi512_si32(val); }
+};
+
+struct v_uint32x16
+{
+    typedef unsigned lane_type;
     enum { nlanes = 16 };
     __m512i val;
 
-    explicit v_int16x16(__m512i v) : val(v) {}
-    v_int16x16(short v0,  short v1,  short v2,  short v3,
-               short v4,  short v5,  short v6,  short v7,
-               short v8,  short v9,  short v10, short v11,
-               short v12, short v13, short v14, short v15)
+    explicit v_uint32x16(__m512i v) : val(v) {}
+    v_uint32x16(unsigned v0,  unsigned v1,  unsigned v2,  unsigned v3,
+                unsigned v4,  unsigned v5,  unsigned v6,  unsigned v7,
+                unsigned v8,  unsigned v9,  unsigned v10, unsigned v11,
+                unsigned v12, unsigned v13, unsigned v14, unsigned v15)
     {
-        val = _mm256_setr_epi16(v0, v1, v2, v3, v4, v5, v6, v7,
-            v8, v9, v10, v11, v12, v13, v14, v15);
+        val = _mm512_setr_epi32((unsigned)v0,  (unsigned)v1,  (unsigned)v2,  (unsigned)v3,
+                                (unsigned)v4,  (unsigned)v5,  (unsigned)v6,  (unsigned)v7,
+                                (unsigned)v8,  (unsigned)v9,  (unsigned)v10, (unsigned)v11,
+                                (unsigned)v12, (unsigned)v13, (unsigned)v14, (unsigned)v15);
     }
-    v_int16x16() : val(_mm256_setzero_si256()) {}
-    short get0() const { return (short)_v_cvtsi256_si32(val); }
+    v_uint32x16() : val(_mm512_setzero_si512()) {}
+    unsigned get0() const { return (unsigned)_v_cvtsi512_si32(val); }
 };
 
-struct v_uint32x8
-{
-    typedef unsigned lane_type;
-    enum { nlanes = 8 };
-    __m512i val;
-
-    explicit v_uint32x8(__m512i v) : val(v) {}
-    v_uint32x8(unsigned v0, unsigned v1, unsigned v2, unsigned v3,
-               unsigned v4, unsigned v5, unsigned v6, unsigned v7)
-    {
-        val = _mm256_setr_epi32((unsigned)v0, (unsigned)v1, (unsigned)v2,
-            (unsigned)v3, (unsigned)v4, (unsigned)v5, (unsigned)v6, (unsigned)v7);
-    }
-    v_uint32x8() : val(_mm256_setzero_si256()) {}
-    unsigned get0() const { return (unsigned)_v_cvtsi256_si32(val); }
-};
-
-struct v_int32x8
+struct v_int32x16
 {
     typedef int lane_type;
-    enum { nlanes = 8 };
+    enum { nlanes = 16 };
     __m512i val;
 
-    explicit v_int32x8(__m512i v) : val(v) {}
-    v_int32x8(int v0, int v1, int v2, int v3,
-              int v4, int v5, int v6, int v7)
+    explicit v_int32x16(__m512i v) : val(v) {}
+    v_int32x16(int v0, int v1, int v2,  int v3,  int v4,  int v5,  int v6,  int v7,
+               int v8, int v9, int v10, int v11, int v12, int v13, int v14, int v15)
     {
-        val = _mm256_setr_epi32(v0, v1, v2, v3, v4, v5, v6, v7);
+        val = _mm512_setr_epi32(v0, v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12, v13, v14, v15);
     }
-    v_int32x8() : val(_mm256_setzero_si256()) {}
-    int get0() const { return _v_cvtsi256_si32(val); }
+    v_int32x16() : val(_mm512_setzero_si512()) {}
+    int get0() const { return _v_cvtsi512_si32(val); }
 };
 
-struct v_float32x8
+struct v_float32x16
 {
     typedef float lane_type;
-    enum { nlanes = 8 };
+    enum { nlanes = 16 };
     __m512 val;
 
-    explicit v_float32x8(__m512 v) : val(v) {}
-    v_float32x8(float v0, float v1, float v2, float v3,
-                float v4, float v5, float v6, float v7)
+    explicit v_float32x16(__m512 v) : val(v) {}
+    v_float32x16(float v0, float v1, float v2,  float v3,  float v4,  float v5,  float v6,  float v7,
+                 float v8, float v9, float v10, float v11, float v12, float v13, float v14, float v15)
     {
-        val = _mm256_setr_ps(v0, v1, v2, v3, v4, v5, v6, v7);
+        val = _mm512_setr_ps(v0, v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12, v13, v14, v15);
     }
-    v_float32x8() : val(_mm256_setzero_ps()) {}
-    float get0() const { return _mm_cvtss_f32(_mm256_castps256_ps128(val)); }
+    v_float32x16() : val(_mm512_setzero_ps()) {}
+    float get0() const { return _mm_cvtss_f32(_mm512_castps512_ps128(val)); }
 };
 
-struct v_uint64x4
+struct v_uint64x8
 {
     typedef uint64 lane_type;
-    enum { nlanes = 4 };
+    enum { nlanes = 8 };
     __m512i val;
 
-    explicit v_uint64x4(__m512i v) : val(v) {}
-    v_uint64x4(uint64 v0, uint64 v1, uint64 v2, uint64 v3)
-    { val = _mm256_setr_epi64x((int64)v0, (int64)v1, (int64)v2, (int64)v3); }
-    v_uint64x4() : val(_mm256_setzero_si256()) {}
+    explicit v_uint64x8(__m512i v) : val(v) {}
+    v_uint64x8(uint64 v0, uint64 v1, uint64 v2, uint64 v3, uint64 v4, uint64 v5, uint64 v6, uint64 v7)
+    { val = _mm512_setr_epi64((int64)v0, (int64)v1, (int64)v2, (int64)v3, (int64)v4, (int64)v5, (int64)v6, (int64)v7); }
+    v_uint64x8() : val(_mm512_setzero_si512()) {}
     uint64 get0() const
     {
     #if defined __x86_64__ || defined _M_X64
-        return (uint64)_mm_cvtsi128_si64(_mm256_castsi256_si128(val));
+        return (uint64)_mm_cvtsi128_si64(_mm512_castsi512_si128(val));
     #else
-        int a = _mm_cvtsi128_si32(_mm256_castsi256_si128(val));
-        int b = _mm_cvtsi128_si32(_mm256_castsi256_si128(_mm256_srli_epi64(val, 32)));
+        int a = _mm_cvtsi128_si32(_mm512_castsi512_si128(val));
+        int b = _mm_cvtsi128_si32(_mm512_castsi512_si128(_mm512_srli_epi64(val, 32)));
         return (unsigned)a | ((uint64)(unsigned)b << 32);
     #endif
     }
 };
 
-struct v_int64x4
+struct v_int64x8
 {
     typedef int64 lane_type;
-    enum { nlanes = 4 };
+    enum { nlanes = 8 };
     __m512i val;
 
-    explicit v_int64x4(__m512i v) : val(v) {}
-    v_int64x4(int64 v0, int64 v1, int64 v2, int64 v3)
-    { val = _mm256_setr_epi64x(v0, v1, v2, v3); }
-    v_int64x4() : val(_mm256_setzero_si256()) {}
+    explicit v_int64x8(__m512i v) : val(v) {}
+    v_int64x8(int64 v0, int64 v1, int64 v2, int64 v3, int64 v4, int64 v5, int64 v6, int64 v7)
+    { val = _mm512_setr_epi64(v0, v1, v2, v3, v4, v5, v6, v7); }
+    v_int64x8() : val(_mm512_setzero_si512()) {}
 
     int64 get0() const
     {
     #if defined __x86_64__ || defined _M_X64
-        return (int64)_mm_cvtsi128_si64(_mm256_castsi256_si128(val));
+        return (int64)_mm_cvtsi128_si64(_mm512_castsi512_si128(val));
     #else
-        int a = _mm_cvtsi128_si32(_mm256_castsi256_si128(val));
-        int b = _mm_cvtsi128_si32(_mm256_castsi256_si128(_mm256_srli_epi64(val, 32)));
+        int a = _mm_cvtsi128_si32(_mm512_castsi512_si128(val));
+        int b = _mm_cvtsi128_si32(_mm512_castsi512_si128(_mm512_srli_epi64(val, 32)));
         return (int64)((unsigned)a | ((uint64)(unsigned)b << 32));
     #endif
     }
 };
 
-struct v_float64x4
+struct v_float64x8
 {
     typedef double lane_type;
-    enum { nlanes = 4 };
+    enum { nlanes = 8 };
     __m512d val;
 
-    explicit v_float64x4(__m512d v) : val(v) {}
-    v_float64x4(double v0, double v1, double v2, double v3)
-    { val = _mm256_setr_pd(v0, v1, v2, v3); }
-    v_float64x4() : val(_mm256_setzero_pd()) {}
-    double get0() const { return _mm_cvtsd_f64(_mm256_castpd256_pd128(val)); }
+    explicit v_float64x8(__m512d v) : val(v) {}
+    v_float64x8(double v0, double v1, double v2, double v3, double v4, double v5, double v6, double v7)
+    { val = _mm512_setr_pd(v0, v1, v2, v3, v4, v5, v6, v7); }
+    v_float64x8() : val(_mm512_setzero_pd()) {}
+    double get0() const { return _mm_cvtsd_f64(_mm512_castpd512_pd128(val)); }
 };
 
 //////////////// Load and store operations ///////////////

--- a/modules/core/include/opencv2/core/hal/intrin_avx512.hpp
+++ b/modules/core/include/opencv2/core/hal/intrin_avx512.hpp
@@ -30,6 +30,24 @@ inline __m512d _v512_combine(const __m256d& lo, const __m256d& hi)
 inline int _v_cvtsi512_si32(const __m512i& a)
 { return _mm_cvtsi128_si32(_mm512_castsi512_si128(a)); }
 
+inline __m256i _v512_extract_high(const __m512i& v)
+{ return _mm512_extracti32x8_epi32(v, 1); }
+
+inline __m256  _v512_extract_high(const __m512& v)
+{ return _mm512_extractf32x8_ps(v, 1); }
+
+inline __m256d _v512_extract_high(const __m512d& v)
+{ return _mm512_extractf64x4_pd(v, 1); }
+
+inline __m256i _v512_extract_low(const __m512i& v)
+{ return _mm512_castsi512_si256(v); }
+
+inline __m256  _v512_extract_low(const __m512& v)
+{ return _mm512_castps512_ps256(v); }
+
+inline __m256d _v512_extract_low(const __m512d& v)
+{ return _mm512_castpd512_pd256(v); }
+
 /*inline __m512i _v512_shuffle_odd_64(const __m512i& v)
 { return _mm512_permutex_epi64(v, _MM_SHUFFLE(3, 1, 2, 0)); }
 
@@ -63,24 +81,6 @@ inline __m512d _v512_permute4x64(const __m512d& a)
 template<int imm, typename _Tpvec>
 inline _Tpvec v512_permute4x64(const _Tpvec& a)
 { return _Tpvec(_v512_permute4x64<imm>(a.val)); }
-
-inline __m256i _v512_extract_high(const __m512i& v)
-{ return _mm256_extracti128_si256(v, 1); }
-
-inline __m256  _v512_extract_high(const __m512& v)
-{ return _mm256_extractf128_ps(v, 1); }
-
-inline __m256d _v512_extract_high(const __m512d& v)
-{ return _mm256_extractf128_pd(v, 1); }
-
-inline __m256i _v512_extract_low(const __m512i& v)
-{ return _mm256_castsi256_si128(v); }
-
-inline __m256  _v512_extract_low(const __m512& v)
-{ return _mm256_castps256_ps128(v); }
-
-inline __m256d _v512_extract_low(const __m512d& v)
-{ return _mm256_castpd256_pd128(v); }
 
 inline __m512i _v512_packs_epu32(const __m512i& a, const __m512i& b)
 {
@@ -321,143 +321,143 @@ struct v_float64x8
 
 #define OPENCV_HAL_IMPL_AVX_LOADSTORE(_Tpvec, _Tp)                    \
     inline _Tpvec v512_load(const _Tp* ptr)                           \
-    { return _Tpvec(_mm256_loadu_si256((const __m512i*)ptr)); }       \
+    { return _Tpvec(_mm512_loadu_si512((const __m512i*)ptr)); }       \
     inline _Tpvec v512_load_aligned(const _Tp* ptr)                   \
-    { return _Tpvec(_mm256_load_si256((const __m512i*)ptr)); }        \
+    { return _Tpvec(_mm512_load_si512((const __m512i*)ptr)); }        \
     inline _Tpvec v512_load_low(const _Tp* ptr)                       \
     {                                                                 \
-        __m256i v128 = _mm_loadu_si128((const __m256i*)ptr);          \
-        return _Tpvec(_mm256_castsi128_si256(v128));                  \
+        __m256i v256 = _mm256_loadu_si256((const __m256i*)ptr);       \
+        return _Tpvec(_mm512_castsi256_si512(v256));                  \
     }                                                                 \
     inline _Tpvec v512_load_halves(const _Tp* ptr0, const _Tp* ptr1)  \
     {                                                                 \
-        __m256i vlo = _mm_loadu_si128((const __m256i*)ptr0);          \
-        __m256i vhi = _mm_loadu_si128((const __m256i*)ptr1);          \
+        __m256i vlo = _mm256_loadu_si256((const __m256i*)ptr0);       \
+        __m256i vhi = _mm256_loadu_si256((const __m256i*)ptr1);       \
         return _Tpvec(_v512_combine(vlo, vhi));                       \
     }                                                                 \
     inline void v_store(_Tp* ptr, const _Tpvec& a)                    \
-    { _mm256_storeu_si256((__m512i*)ptr, a.val); }                    \
+    { _mm512_storeu_si512((__m512i*)ptr, a.val); }                    \
     inline void v_store_aligned(_Tp* ptr, const _Tpvec& a)            \
-    { _mm256_store_si256((__m512i*)ptr, a.val); }                     \
+    { _mm512_store_si512((__m512i*)ptr, a.val); }                     \
     inline void v_store_aligned_nocache(_Tp* ptr, const _Tpvec& a)    \
-    { _mm256_stream_si256((__m512i*)ptr, a.val); }                    \
+    { _mm512_stream_si512((__m512i*)ptr, a.val); }                    \
     inline void v_store(_Tp* ptr, const _Tpvec& a, hal::StoreMode mode) \
     { \
         if( mode == hal::STORE_UNALIGNED ) \
-            _mm256_storeu_si256((__m512i*)ptr, a.val); \
+            _mm512_storeu_si512((__m512i*)ptr, a.val); \
         else if( mode == hal::STORE_ALIGNED_NOCACHE )  \
-            _mm256_stream_si256((__m512i*)ptr, a.val); \
+            _mm512_stream_si512((__m512i*)ptr, a.val); \
         else \
-            _mm256_store_si256((__m512i*)ptr, a.val); \
+            _mm512_store_si512((__m512i*)ptr, a.val); \
     } \
     inline void v_store_low(_Tp* ptr, const _Tpvec& a)                \
-    { _mm_storeu_si128((__m256i*)ptr, _v512_extract_low(a.val)); }    \
+    { _mm256_storeu_si256((__m256i*)ptr, _v512_extract_low(a.val)); }    \
     inline void v_store_high(_Tp* ptr, const _Tpvec& a)               \
-    { _mm_storeu_si128((__m256i*)ptr, _v512_extract_high(a.val)); }
+    { _mm256_storeu_si256((__m256i*)ptr, _v512_extract_high(a.val)); }
 
-OPENCV_HAL_IMPL_AVX_LOADSTORE(v_uint8x32,  uchar)
-OPENCV_HAL_IMPL_AVX_LOADSTORE(v_int8x32,   schar)
-OPENCV_HAL_IMPL_AVX_LOADSTORE(v_uint16x16, ushort)
-OPENCV_HAL_IMPL_AVX_LOADSTORE(v_int16x16,  short)
-OPENCV_HAL_IMPL_AVX_LOADSTORE(v_uint32x8,  unsigned)
-OPENCV_HAL_IMPL_AVX_LOADSTORE(v_int32x8,   int)
-OPENCV_HAL_IMPL_AVX_LOADSTORE(v_uint64x4,  uint64)
-OPENCV_HAL_IMPL_AVX_LOADSTORE(v_int64x4,   int64)
+OPENCV_HAL_IMPL_AVX_LOADSTORE(v_uint8x64,  uchar)
+OPENCV_HAL_IMPL_AVX_LOADSTORE(v_int8x64,   schar)
+OPENCV_HAL_IMPL_AVX_LOADSTORE(v_uint16x32, ushort)
+OPENCV_HAL_IMPL_AVX_LOADSTORE(v_int16x32,  short)
+OPENCV_HAL_IMPL_AVX_LOADSTORE(v_uint32x16,  unsigned)
+OPENCV_HAL_IMPL_AVX_LOADSTORE(v_int32x16,   int)
+OPENCV_HAL_IMPL_AVX_LOADSTORE(v_uint64x8,  uint64)
+OPENCV_HAL_IMPL_AVX_LOADSTORE(v_int64x8,   int64)
 
 #define OPENCV_HAL_IMPL_AVX_LOADSTORE_FLT(_Tpvec, _Tp, suffix, halfreg)   \
     inline _Tpvec v512_load(const _Tp* ptr)                               \
-    { return _Tpvec(_mm256_loadu_##suffix(ptr)); }                        \
+    { return _Tpvec(_mm512_loadu_##suffix(ptr)); }                        \
     inline _Tpvec v512_load_aligned(const _Tp* ptr)                       \
-    { return _Tpvec(_mm256_load_##suffix(ptr)); }                         \
+    { return _Tpvec(_mm512_load_##suffix(ptr)); }                         \
     inline _Tpvec v512_load_low(const _Tp* ptr)                           \
     {                                                                     \
-        return _Tpvec(_mm256_cast##suffix##128_##suffix##256              \
-                     (_mm_loadu_##suffix(ptr)));                          \
+        return _Tpvec(_mm512_cast##suffix##256_##suffix##512              \
+                     (_mm256_loadu_##suffix(ptr)));                       \
     }                                                                     \
     inline _Tpvec v512_load_halves(const _Tp* ptr0, const _Tp* ptr1)      \
     {                                                                     \
-        halfreg vlo = _mm_loadu_##suffix(ptr0);                           \
-        halfreg vhi = _mm_loadu_##suffix(ptr1);                           \
+        halfreg vlo = _mm256_loadu_##suffix(ptr0);                        \
+        halfreg vhi = _mm256_loadu_##suffix(ptr1);                        \
         return _Tpvec(_v512_combine(vlo, vhi));                           \
     }                                                                     \
     inline void v_store(_Tp* ptr, const _Tpvec& a)                        \
-    { _mm256_storeu_##suffix(ptr, a.val); }                               \
+    { _mm512_storeu_##suffix(ptr, a.val); }                               \
     inline void v_store_aligned(_Tp* ptr, const _Tpvec& a)                \
-    { _mm256_store_##suffix(ptr, a.val); }                                \
+    { _mm512_store_##suffix(ptr, a.val); }                                \
     inline void v_store_aligned_nocache(_Tp* ptr, const _Tpvec& a)        \
-    { _mm256_stream_##suffix(ptr, a.val); }                               \
+    { _mm512_stream_##suffix(ptr, a.val); }                               \
     inline void v_store(_Tp* ptr, const _Tpvec& a, hal::StoreMode mode) \
     { \
         if( mode == hal::STORE_UNALIGNED ) \
-            _mm256_storeu_##suffix(ptr, a.val); \
+            _mm512_storeu_##suffix(ptr, a.val); \
         else if( mode == hal::STORE_ALIGNED_NOCACHE )  \
-            _mm256_stream_##suffix(ptr, a.val); \
+            _mm512_stream_##suffix(ptr, a.val); \
         else \
-            _mm256_store_##suffix(ptr, a.val); \
+            _mm512_store_##suffix(ptr, a.val); \
     } \
     inline void v_store_low(_Tp* ptr, const _Tpvec& a)                    \
-    { _mm_storeu_##suffix(ptr, _v512_extract_low(a.val)); }               \
+    { _mm256_storeu_##suffix(ptr, _v512_extract_low(a.val)); }            \
     inline void v_store_high(_Tp* ptr, const _Tpvec& a)                   \
-    { _mm_storeu_##suffix(ptr, _v512_extract_high(a.val)); }
+    { _mm256_storeu_##suffix(ptr, _v512_extract_high(a.val)); }
 
-OPENCV_HAL_IMPL_AVX_LOADSTORE_FLT(v_float32x8, float,  ps, __m256)
-OPENCV_HAL_IMPL_AVX_LOADSTORE_FLT(v_float64x4, double, pd, __m256d)
+OPENCV_HAL_IMPL_AVX_LOADSTORE_FLT(v_float32x16, float,  ps, __m256)
+OPENCV_HAL_IMPL_AVX_LOADSTORE_FLT(v_float64x8, double, pd, __m256d)
 
 #define OPENCV_HAL_IMPL_AVX_CAST(_Tpvec, _Tpvecf, suffix, cast) \
     inline _Tpvec v_reinterpret_as_##suffix(const _Tpvecf& a)   \
     { return _Tpvec(cast(a.val)); }
 
-#define OPENCV_HAL_IMPL_AVX_INIT(_Tpvec, _Tp, suffix, ssuffix, ctype_s)          \
-    inline _Tpvec v512_setzero_##suffix()                                        \
-    { return _Tpvec(_mm256_setzero_si256()); }                                   \
-    inline _Tpvec v512_setall_##suffix(_Tp v)                                    \
-    { return _Tpvec(_mm256_set1_##ssuffix((ctype_s)v)); }                        \
-    OPENCV_HAL_IMPL_AVX_CAST(_Tpvec, v_uint8x32,  suffix, OPENCV_HAL_NOP)        \
-    OPENCV_HAL_IMPL_AVX_CAST(_Tpvec, v_int8x32,   suffix, OPENCV_HAL_NOP)        \
-    OPENCV_HAL_IMPL_AVX_CAST(_Tpvec, v_uint16x16, suffix, OPENCV_HAL_NOP)        \
-    OPENCV_HAL_IMPL_AVX_CAST(_Tpvec, v_int16x16,  suffix, OPENCV_HAL_NOP)        \
-    OPENCV_HAL_IMPL_AVX_CAST(_Tpvec, v_uint32x8,  suffix, OPENCV_HAL_NOP)        \
-    OPENCV_HAL_IMPL_AVX_CAST(_Tpvec, v_int32x8,   suffix, OPENCV_HAL_NOP)        \
-    OPENCV_HAL_IMPL_AVX_CAST(_Tpvec, v_uint64x4,  suffix, OPENCV_HAL_NOP)        \
-    OPENCV_HAL_IMPL_AVX_CAST(_Tpvec, v_int64x4,   suffix, OPENCV_HAL_NOP)        \
-    OPENCV_HAL_IMPL_AVX_CAST(_Tpvec, v_float32x8, suffix, _mm256_castps_si256)   \
-    OPENCV_HAL_IMPL_AVX_CAST(_Tpvec, v_float64x4, suffix, _mm256_castpd_si256)
+#define OPENCV_HAL_IMPL_AVX_INIT(_Tpvec, _Tp, suffix, ssuffix, ctype_s)           \
+    inline _Tpvec v512_setzero_##suffix()                                         \
+    { return _Tpvec(_mm512_setzero_si512()); }                                    \
+    inline _Tpvec v512_setall_##suffix(_Tp v)                                     \
+    { return _Tpvec(_mm512_set1_##ssuffix((ctype_s)v)); }                         \
+    OPENCV_HAL_IMPL_AVX_CAST(_Tpvec, v_uint8x64,   suffix, OPENCV_HAL_NOP)        \
+    OPENCV_HAL_IMPL_AVX_CAST(_Tpvec, v_int8x64,    suffix, OPENCV_HAL_NOP)        \
+    OPENCV_HAL_IMPL_AVX_CAST(_Tpvec, v_uint16x32,  suffix, OPENCV_HAL_NOP)        \
+    OPENCV_HAL_IMPL_AVX_CAST(_Tpvec, v_int16x32,   suffix, OPENCV_HAL_NOP)        \
+    OPENCV_HAL_IMPL_AVX_CAST(_Tpvec, v_uint32x16,  suffix, OPENCV_HAL_NOP)        \
+    OPENCV_HAL_IMPL_AVX_CAST(_Tpvec, v_int32x16,   suffix, OPENCV_HAL_NOP)        \
+    OPENCV_HAL_IMPL_AVX_CAST(_Tpvec, v_uint64x8,   suffix, OPENCV_HAL_NOP)        \
+    OPENCV_HAL_IMPL_AVX_CAST(_Tpvec, v_int64x8,    suffix, OPENCV_HAL_NOP)        \
+    OPENCV_HAL_IMPL_AVX_CAST(_Tpvec, v_float32x16, suffix, _mm256_castps_si256)   \
+    OPENCV_HAL_IMPL_AVX_CAST(_Tpvec, v_float64x8,  suffix, _mm256_castpd_si256)
 
-OPENCV_HAL_IMPL_AVX_INIT(v_uint8x32,  uchar,    u8,  epi8,   char)
-OPENCV_HAL_IMPL_AVX_INIT(v_int8x32,   schar,    s8,  epi8,   char)
-OPENCV_HAL_IMPL_AVX_INIT(v_uint16x16, ushort,   u16, epi16,  short)
-OPENCV_HAL_IMPL_AVX_INIT(v_int16x16,  short,    s16, epi16,  short)
-OPENCV_HAL_IMPL_AVX_INIT(v_uint32x8,  unsigned, u32, epi32,  int)
-OPENCV_HAL_IMPL_AVX_INIT(v_int32x8,   int,      s32, epi32,  int)
-OPENCV_HAL_IMPL_AVX_INIT(v_uint64x4,  uint64,   u64, epi64x, int64)
-OPENCV_HAL_IMPL_AVX_INIT(v_int64x4,   int64,    s64, epi64x, int64)
+OPENCV_HAL_IMPL_AVX_INIT(v_uint8x64,  uchar,    u8,  epi8,   char)
+OPENCV_HAL_IMPL_AVX_INIT(v_int8x64,   schar,    s8,  epi8,   char)
+OPENCV_HAL_IMPL_AVX_INIT(v_uint16x32, ushort,   u16, epi16,  short)
+OPENCV_HAL_IMPL_AVX_INIT(v_int16x32,  short,    s16, epi16,  short)
+OPENCV_HAL_IMPL_AVX_INIT(v_uint32x16, unsigned, u32, epi32,  int)
+OPENCV_HAL_IMPL_AVX_INIT(v_int32x16,  int,      s32, epi32,  int)
+OPENCV_HAL_IMPL_AVX_INIT(v_uint64x8,  uint64,   u64, epi64,  int64)
+OPENCV_HAL_IMPL_AVX_INIT(v_int64x8,   int64,    s64, epi64,  int64)
 
 #define OPENCV_HAL_IMPL_AVX_INIT_FLT(_Tpvec, _Tp, suffix, zsuffix, cast) \
     inline _Tpvec v512_setzero_##suffix()                                \
-    { return _Tpvec(_mm256_setzero_##zsuffix()); }                       \
+    { return _Tpvec(_mm512_setzero_##zsuffix()); }                       \
     inline _Tpvec v512_setall_##suffix(_Tp v)                            \
-    { return _Tpvec(_mm256_set1_##zsuffix(v)); }                         \
-    OPENCV_HAL_IMPL_AVX_CAST(_Tpvec, v_uint8x32,  suffix, cast)          \
-    OPENCV_HAL_IMPL_AVX_CAST(_Tpvec, v_int8x32,   suffix, cast)          \
-    OPENCV_HAL_IMPL_AVX_CAST(_Tpvec, v_uint16x16, suffix, cast)          \
-    OPENCV_HAL_IMPL_AVX_CAST(_Tpvec, v_int16x16,  suffix, cast)          \
-    OPENCV_HAL_IMPL_AVX_CAST(_Tpvec, v_uint32x8,  suffix, cast)          \
-    OPENCV_HAL_IMPL_AVX_CAST(_Tpvec, v_int32x8,   suffix, cast)          \
-    OPENCV_HAL_IMPL_AVX_CAST(_Tpvec, v_uint64x4,  suffix, cast)          \
-    OPENCV_HAL_IMPL_AVX_CAST(_Tpvec, v_int64x4,   suffix, cast)
+    { return _Tpvec(_mm512_set1_##zsuffix(v)); }                         \
+    OPENCV_HAL_IMPL_AVX_CAST(_Tpvec, v_uint8x64,  suffix, cast)          \
+    OPENCV_HAL_IMPL_AVX_CAST(_Tpvec, v_int8x64,   suffix, cast)          \
+    OPENCV_HAL_IMPL_AVX_CAST(_Tpvec, v_uint16x32, suffix, cast)          \
+    OPENCV_HAL_IMPL_AVX_CAST(_Tpvec, v_int16x32,  suffix, cast)          \
+    OPENCV_HAL_IMPL_AVX_CAST(_Tpvec, v_uint32x16, suffix, cast)          \
+    OPENCV_HAL_IMPL_AVX_CAST(_Tpvec, v_int32x16,  suffix, cast)          \
+    OPENCV_HAL_IMPL_AVX_CAST(_Tpvec, v_uint64x8,  suffix, cast)          \
+    OPENCV_HAL_IMPL_AVX_CAST(_Tpvec, v_int64x8,   suffix, cast)
 
-OPENCV_HAL_IMPL_AVX_INIT_FLT(v_float32x8, float,  f32, ps, _mm256_castsi256_ps)
-OPENCV_HAL_IMPL_AVX_INIT_FLT(v_float64x4, double, f64, pd, _mm256_castsi256_pd)
+OPENCV_HAL_IMPL_AVX_INIT_FLT(v_float32x16, float,  f32, ps, _mm512_castsi512_ps)
+OPENCV_HAL_IMPL_AVX_INIT_FLT(v_float64x8,  double, f64, pd, _mm512_castsi512_pd)
 
-inline v_float32x8 v_reinterpret_as_f32(const v_float32x8& a)
+inline v_float32x16 v_reinterpret_as_f32(const v_float32x16& a)
 { return a; }
-inline v_float32x8 v_reinterpret_as_f32(const v_float64x4& a)
-{ return v_float32x8(_mm256_castpd_ps(a.val)); }
+inline v_float32x16 v_reinterpret_as_f32(const v_float64x8& a)
+{ return v_float32x16(_mm512_castpd_ps(a.val)); }
 
-inline v_float64x4 v_reinterpret_as_f64(const v_float64x4& a)
+inline v_float64x8 v_reinterpret_as_f64(const v_float64x8& a)
 { return a; }
-inline v_float64x4 v_reinterpret_as_f64(const v_float32x8& a)
-{ return v_float64x4(_mm256_castps_pd(a.val)); }
+inline v_float64x8 v_reinterpret_as_f64(const v_float32x16& a)
+{ return v_float64x8(_mm512_castps_pd(a.val)); }
 
 #if CV_FP16
 inline v_float32x8 v512_load_fp16_f32(const short* ptr)

--- a/modules/core/include/opencv2/core/hal/intrin_avx512.hpp
+++ b/modules/core/include/opencv2/core/hal/intrin_avx512.hpp
@@ -859,7 +859,80 @@ OPENCV_HAL_IMPL_AVX512_BIN_FUNC(v_min, v_float64x8,  _mm512_min_pd)
 OPENCV_HAL_IMPL_AVX512_BIN_FUNC(v_max, v_float64x8,  _mm512_max_pd)
 
 /** Rotate **/
-#define OPENCV_HAL_IMPL_AVX512_ROTATE(_Tpvec, suffix)                                                                                    \
+template<int imm>
+inline v_int8x64 v_rotate_left(const v_int8x64& a, const v_int8x64& b)
+{
+    if (imm == 0) return a;
+    if (imm == 64) return b;
+    if (imm >= 128) return v_int8x64();
+    return v_int8x64(_mm512_permutex2var_epi8(b.val,
+           _v512_set_epi8(0x7f - imm,0x7e - imm,0x7d - imm,0x7c - imm,0x7b - imm,0x7a - imm,0x79 - imm,0x78 - imm,
+                          0x77 - imm,0x76 - imm,0x75 - imm,0x74 - imm,0x73 - imm,0x72 - imm,0x71 - imm,0x70 - imm,
+                          0x6f - imm,0x6e - imm,0x6d - imm,0x6c - imm,0x6b - imm,0x6a - imm,0x69 - imm,0x68 - imm,
+                          0x67 - imm,0x66 - imm,0x65 - imm,0x64 - imm,0x63 - imm,0x62 - imm,0x61 - imm,0x60 - imm,
+                          0x5f - imm,0x5e - imm,0x5d - imm,0x5c - imm,0x5b - imm,0x5a - imm,0x59 - imm,0x58 - imm,
+                          0x57 - imm,0x56 - imm,0x55 - imm,0x54 - imm,0x53 - imm,0x52 - imm,0x51 - imm,0x50 - imm,
+                          0x4f - imm,0x4e - imm,0x4d - imm,0x4c - imm,0x4b - imm,0x4a - imm,0x49 - imm,0x48 - imm,
+                          0x47 - imm,0x46 - imm,0x45 - imm,0x44 - imm,0x43 - imm,0x42 - imm,0x41 - imm,0x40 - imm), a.val));
+}
+template<int imm>
+inline v_int8x64 v_rotate_right(const v_int8x64& a, const v_int8x64& b)
+{
+    if (imm == 0) return a;
+    if (imm == 64) return b;
+    if (imm >= 128) return v_int8x64();
+    return v_int8x64(_mm512_permutex2var_epi8(a.val,
+           _v512_set_epi8(0x3f + imm,0x3e + imm,0x3d + imm,0x3c + imm,0x3b + imm,0x3a + imm,0x39 + imm,0x38 + imm,
+                          0x37 + imm,0x36 + imm,0x35 + imm,0x34 + imm,0x33 + imm,0x32 + imm,0x31 + imm,0x30 + imm,
+                          0x2f + imm,0x2e + imm,0x2d + imm,0x2c + imm,0x2b + imm,0x2a + imm,0x29 + imm,0x28 + imm,
+                          0x27 + imm,0x26 + imm,0x25 + imm,0x24 + imm,0x23 + imm,0x22 + imm,0x21 + imm,0x20 + imm,
+                          0x1f + imm,0x1e + imm,0x1d + imm,0x1c + imm,0x1b + imm,0x1a + imm,0x19 + imm,0x18 + imm,
+                          0x17 + imm,0x16 + imm,0x15 + imm,0x14 + imm,0x13 + imm,0x12 + imm,0x11 + imm,0x10 + imm,
+                          0x0f + imm,0x0e + imm,0x0d + imm,0x0c + imm,0x0b + imm,0x0a + imm,0x09 + imm,0x08 + imm,
+                          0x07 + imm,0x06 + imm,0x05 + imm,0x04 + imm,0x03 + imm,0x02 + imm,0x01 + imm,0x00 + imm), b.val));
+}
+template<int imm>
+inline v_int8x64 v_rotate_left(const v_int8x64& a)
+{
+    if (imm == 0) return a;
+    if (imm >= 64) return v_int8x64();
+    return v_int8x64(_mm512_maskz_permutexvar_epi8(0xFFFFFFFFFFFFFFFF << imm,
+           _v512_set_epi8(0x3f - imm,0x3e - imm,0x3d - imm,0x3c - imm,0x3b - imm,0x3a - imm,0x39 - imm,0x38 - imm,
+                          0x37 - imm,0x36 - imm,0x35 - imm,0x34 - imm,0x33 - imm,0x32 - imm,0x31 - imm,0x30 - imm,
+                          0x2f - imm,0x2e - imm,0x2d - imm,0x2c - imm,0x2b - imm,0x2a - imm,0x29 - imm,0x28 - imm,
+                          0x27 - imm,0x26 - imm,0x25 - imm,0x24 - imm,0x23 - imm,0x22 - imm,0x21 - imm,0x20 - imm,
+                          0x1f - imm,0x1e - imm,0x1d - imm,0x1c - imm,0x1b - imm,0x1a - imm,0x19 - imm,0x18 - imm,
+                          0x17 - imm,0x16 - imm,0x15 - imm,0x14 - imm,0x13 - imm,0x12 - imm,0x11 - imm,0x10 - imm,
+                          0x0f - imm,0x0e - imm,0x0d - imm,0x0c - imm,0x0b - imm,0x0a - imm,0x09 - imm,0x08 - imm,
+                          0x07 - imm,0x06 - imm,0x05 - imm,0x04 - imm,0x03 - imm,0x02 - imm,0x01 - imm,0x00 - imm), a.val));
+}
+template<int imm>
+inline v_int8x64 v_rotate_right(const v_int8x64& a)
+{
+    if (imm == 0) return a;
+    if (imm >= 64) return v_int8x64();
+    return v_int8x64(_mm512_maskz_permutexvar_epi8(0xFFFFFFFFFFFFFFFF >> imm,
+           _v512_set_epi8(0x3f + imm,0x3e + imm,0x3d + imm,0x3c + imm,0x3b + imm,0x3a + imm,0x39 + imm,0x38 + imm,
+                          0x37 + imm,0x36 + imm,0x35 + imm,0x34 + imm,0x33 + imm,0x32 + imm,0x31 + imm,0x30 + imm,
+                          0x2f + imm,0x2e + imm,0x2d + imm,0x2c + imm,0x2b + imm,0x2a + imm,0x29 + imm,0x28 + imm,
+                          0x27 + imm,0x26 + imm,0x25 + imm,0x24 + imm,0x23 + imm,0x22 + imm,0x21 + imm,0x20 + imm,
+                          0x1f + imm,0x1e + imm,0x1d + imm,0x1c + imm,0x1b + imm,0x1a + imm,0x19 + imm,0x18 + imm,
+                          0x17 + imm,0x16 + imm,0x15 + imm,0x14 + imm,0x13 + imm,0x12 + imm,0x11 + imm,0x10 + imm,
+                          0x0f + imm,0x0e + imm,0x0d + imm,0x0c + imm,0x0b + imm,0x0a + imm,0x09 + imm,0x08 + imm,
+                          0x07 + imm,0x06 + imm,0x05 + imm,0x04 + imm,0x03 + imm,0x02 + imm,0x01 + imm,0x00 + imm), a.val));
+}
+
+#define OPENCV_HAL_IMPL_AVX512_ROTATE_PM(_Tpvec, suffix)                                                                                 \
+template<int imm> inline _Tpvec v_rotate_left(const _Tpvec& a, const _Tpvec& b)                                                          \
+{ return v_reinterpret_as_##suffix(v_rotate_left<imm * sizeof(_Tpvec::lane_type)>(v_reinterpret_as_s8(a), v_reinterpret_as_s8(b))); }    \
+template<int imm> inline _Tpvec v_rotate_right(const _Tpvec& a, const _Tpvec& b)                                                         \
+{ return v_reinterpret_as_##suffix(v_rotate_right<imm * sizeof(_Tpvec::lane_type)>(v_reinterpret_as_s8(a), v_reinterpret_as_s8(b))); }   \
+template<int imm> inline _Tpvec v_rotate_left(const _Tpvec& a)                                                                           \
+{ return v_reinterpret_as_##suffix(v_rotate_left<imm * sizeof(_Tpvec::lane_type)>(v_reinterpret_as_s8(a))); }                            \
+template<int imm> inline _Tpvec v_rotate_right(const _Tpvec& a)                                                                          \
+{ return v_reinterpret_as_##suffix(v_rotate_right<imm * sizeof(_Tpvec::lane_type)>(v_reinterpret_as_s8(a))); }
+
+#define OPENCV_HAL_IMPL_AVX512_ROTATE_EC(_Tpvec, suffix)                                                                                 \
 template<int imm>                                                                                                                        \
 inline _Tpvec v_rotate_left(const _Tpvec& a, const _Tpvec& b)                                                                            \
 {                                                                                                                                        \
@@ -868,15 +941,6 @@ inline _Tpvec v_rotate_left(const _Tpvec& a, const _Tpvec& b)                   
     if (imm == _Tpvec::nlanes) return b;                                                                                                 \
     if (imm >= 2*_Tpvec::nlanes) return _Tpvec();                                                                                        \
     return _Tpvec(_mm512_mask_expand_##suffix(_mm512_maskz_compress_##suffix(-1 << SHIFT2, b), -1 << imm, a));                           \
-  /*const _Tpvec::lane_type idx[] = { 0x00+SHIFT2,0x01+SHIFT2,0x02+SHIFT2,0x03+SHIFT2,0x04+SHIFT2,0x05+SHIFT2,0x06+SHIFT2,0x07+SHIFT2,   \
-                                      0x08+SHIFT2,0x09+SHIFT2,0x0a+SHIFT2,0x0b+SHIFT2,0x0c+SHIFT2,0x0d+SHIFT2,0x0e+SHIFT2,0x0f+SHIFT2,   \
-                                      0x10+SHIFT2,0x11+SHIFT2,0x12+SHIFT2,0x13+SHIFT2,0x14+SHIFT2,0x15+SHIFT2,0x16+SHIFT2,0x17+SHIFT2,   \
-                                      0x18+SHIFT2,0x19+SHIFT2,0x1a+SHIFT2,0x1b+SHIFT2,0x1c+SHIFT2,0x1d+SHIFT2,0x1e+SHIFT2,0x1f+SHIFT2,   \
-                                      0x20+SHIFT2,0x21+SHIFT2,0x22+SHIFT2,0x23+SHIFT2,0x24+SHIFT2,0x25+SHIFT2,0x26+SHIFT2,0x27+SHIFT2,   \
-                                      0x28+SHIFT2,0x29+SHIFT2,0x2a+SHIFT2,0x2b+SHIFT2,0x2c+SHIFT2,0x2d+SHIFT2,0x2e+SHIFT2,0x2f+SHIFT2,   \
-                                      0x30+SHIFT2,0x31+SHIFT2,0x32+SHIFT2,0x33+SHIFT2,0x34+SHIFT2,0x35+SHIFT2,0x36+SHIFT2,0x37+SHIFT2,   \
-                                      0x38+SHIFT2,0x39+SHIFT2,0x3a+SHIFT2,0x3b+SHIFT2,0x3c+SHIFT2,0x3d+SHIFT2,0x3e+SHIFT2,0x3f+SHIFT2 }; \
-    return _Tpvec(_mm512_permutex2var_##suffix(b, _mm512_load_si512(idx), a));*/                                                         \
 }                                                                                                                                        \
 template<int imm>                                                                                                                        \
 inline _Tpvec v_rotate_right(const _Tpvec& a, const _Tpvec& b)                                                                           \
@@ -886,15 +950,6 @@ inline _Tpvec v_rotate_right(const _Tpvec& a, const _Tpvec& b)                  
     if (imm == _Tpvec::nlanes) return b;                                                                                                 \
     if (imm >= 2*_Tpvec::nlanes) return _Tpvec();                                                                                        \
     return _Tpvec(_mm512_mask_expand_##suffix(_mm512_maskz_compress_##suffix(-1 << imm, a.val), -1 << SHIFT2, b.val));                   \
-  /*const _Tpvec::lane_type idx[] = { 0x00+imm,0x01+imm,0x02+imm,0x03+imm,0x04+imm,0x05+imm,0x06+imm,0x07+imm,                           \
-                                      0x08+imm,0x09+imm,0x0a+imm,0x0b+imm,0x0c+imm,0x0d+imm,0x0e+imm,0x0f+imm,                           \
-                                      0x10+imm,0x11+imm,0x12+imm,0x13+imm,0x14+imm,0x15+imm,0x16+imm,0x17+imm,                           \
-                                      0x18+imm,0x19+imm,0x1a+imm,0x1b+imm,0x1c+imm,0x1d+imm,0x1e+imm,0x1f+imm,                           \
-                                      0x20+imm,0x21+imm,0x22+imm,0x23+imm,0x24+imm,0x25+imm,0x26+imm,0x27+imm,                           \
-                                      0x28+imm,0x29+imm,0x2a+imm,0x2b+imm,0x2c+imm,0x2d+imm,0x2e+imm,0x2f+imm,                           \
-                                      0x30+imm,0x31+imm,0x32+imm,0x33+imm,0x34+imm,0x35+imm,0x36+imm,0x37+imm,                           \
-                                      0x38+imm,0x39+imm,0x3a+imm,0x3b+imm,0x3c+imm,0x3d+imm,0x3e+imm,0x3f+imm };                         \
-    return _Tpvec(_mm512_permutex2var_##suffix(a, _mm512_load_si512(idx), b));*/                                                         \
 }                                                                                                                                        \
 template<int imm>                                                                                                                        \
 inline _Tpvec v_rotate_left(const _Tpvec& a)                                                                                             \
@@ -913,20 +968,15 @@ inline _Tpvec v_rotate_right(const _Tpvec& a)                                   
     return _Tpvec(_mm512_maskz_compress_##suffix(-1 << imm, a.val));                                                                     \
 }
 
-#define OPENCV_HAL_IMPL_AVX_ROTATE(_Tpvec)                                  \
-    OPENCV_HAL_IMPL_AVX_ROTATE_CAST(v_rotate_left,  _Tpvec, OPENCV_HAL_NOP) \
-    OPENCV_HAL_IMPL_AVX_ROTATE_CAST(v_rotate_right, _Tpvec, OPENCV_HAL_NOP)
-
-OPENCV_HAL_IMPL_AVX512_ROTATE(v_uint8x64,   epi8)
-OPENCV_HAL_IMPL_AVX512_ROTATE(v_int8x64,    epi8)
-OPENCV_HAL_IMPL_AVX512_ROTATE(v_uint16x32, epi16)
-OPENCV_HAL_IMPL_AVX512_ROTATE(v_int16x32,  epi16)
-OPENCV_HAL_IMPL_AVX512_ROTATE(v_uint32x16, epi32)
-OPENCV_HAL_IMPL_AVX512_ROTATE(v_int32x16,  epi32)
-OPENCV_HAL_IMPL_AVX512_ROTATE(v_uint64x8,  epi64)
-OPENCV_HAL_IMPL_AVX512_ROTATE(v_int64x8,   epi64)
-OPENCV_HAL_IMPL_AVX512_ROTATE(v_float32x16,   ps)
-OPENCV_HAL_IMPL_AVX512_ROTATE(v_float64x8,    pd)
+OPENCV_HAL_IMPL_AVX512_ROTATE_PM(v_uint8x64,   u8)
+OPENCV_HAL_IMPL_AVX512_ROTATE_PM(v_uint16x32,  u16)
+OPENCV_HAL_IMPL_AVX512_ROTATE_PM(v_int16x32,   s16)
+OPENCV_HAL_IMPL_AVX512_ROTATE_EC(v_uint32x16,  epi32)
+OPENCV_HAL_IMPL_AVX512_ROTATE_EC(v_int32x16,   epi32)
+OPENCV_HAL_IMPL_AVX512_ROTATE_EC(v_uint64x8,   epi64)
+OPENCV_HAL_IMPL_AVX512_ROTATE_EC(v_int64x8,    epi64)
+OPENCV_HAL_IMPL_AVX512_ROTATE_EC(v_float32x16, ps)
+OPENCV_HAL_IMPL_AVX512_ROTATE_EC(v_float64x8,  pd)
 
 ////////// Reduce /////////
 

--- a/modules/core/include/opencv2/core/hal/intrin_avx512.hpp
+++ b/modules/core/include/opencv2/core/hal/intrin_avx512.hpp
@@ -1603,172 +1603,115 @@ OPENCV_HAL_IMPL_AVX512_EXTRACT(v_float64x4)
 
 ///////////////////// load deinterleave /////////////////////////////
 
-inline void v_load_deinterleave( const uchar* ptr, v_uint8x32& a, v_uint8x32& b )
+inline void v_load_deinterleave( const uchar* ptr, v_uint8x64& a, v_uint8x64& b )
 {
-    __m512i ab0 = _mm256_loadu_si256((const __m512i*)ptr);
-    __m512i ab1 = _mm256_loadu_si256((const __m512i*)(ptr + 32));
-
-    const __m512i sh = _mm256_setr_epi8(0, 2, 4, 6, 8, 10, 12, 14, 1, 3, 5, 7, 9, 11, 13, 15,
-                                               0, 2, 4, 6, 8, 10, 12, 14, 1, 3, 5, 7, 9, 11, 13, 15);
-    __m512i p0 = _mm256_shuffle_epi8(ab0, sh);
-    __m512i p1 = _mm256_shuffle_epi8(ab1, sh);
-    __m512i pl = _mm256_permute2x128_si256(p0, p1, 0 + 2*16);
-    __m512i ph = _mm256_permute2x128_si256(p0, p1, 1 + 3*16);
-    __m512i a0 = _mm256_unpacklo_epi64(pl, ph);
-    __m512i b0 = _mm256_unpackhi_epi64(pl, ph);
-    a = v_uint8x32(a0);
-    b = v_uint8x32(b0);
+    __m512i ab0 = _mm512_loadu_si512((const __m512i*)ptr);
+    __m512i ab1 = _mm512_loadu_si512((const __m512i*)(ptr + 64));
+    a = v_uint8x64(_v_512_combine(_v512_extract_low(_mm512_maskz_compress_epi8(0x5555555555555555, ab0)),
+                                  _v512_extract_low(_mm512_maskz_compress_epi8(0x5555555555555555, ab1))));
+    b = v_uint8x64(_v_512_combine(_v512_extract_low(_mm512_maskz_compress_epi8(0xAAAAAAAAAAAAAAAA, ab0)),
+                                  _v512_extract_low(_mm512_maskz_compress_epi8(0xAAAAAAAAAAAAAAAA, ab1))));
 }
 
-inline void v_load_deinterleave( const ushort* ptr, v_uint16x16& a, v_uint16x16& b )
+inline void v_load_deinterleave( const ushort* ptr, v_uint16x32& a, v_uint16x32& b )
 {
-    __m512i ab0 = _mm256_loadu_si256((const __m512i*)ptr);
-    __m512i ab1 = _mm256_loadu_si256((const __m512i*)(ptr + 16));
-
-    const __m512i sh = _mm256_setr_epi8(0, 1, 4, 5, 8, 9, 12, 13, 2, 3, 6, 7, 10, 11, 14, 15,
-                                               0, 1, 4, 5, 8, 9, 12, 13, 2, 3, 6, 7, 10, 11, 14, 15);
-    __m512i p0 = _mm256_shuffle_epi8(ab0, sh);
-    __m512i p1 = _mm256_shuffle_epi8(ab1, sh);
-    __m512i pl = _mm256_permute2x128_si256(p0, p1, 0 + 2*16);
-    __m512i ph = _mm256_permute2x128_si256(p0, p1, 1 + 3*16);
-    __m512i a0 = _mm256_unpacklo_epi64(pl, ph);
-    __m512i b0 = _mm256_unpackhi_epi64(pl, ph);
-    a = v_uint16x16(a0);
-    b = v_uint16x16(b0);
+    __m512i ab0 = _mm512_loadu_si512((const __m512i*)ptr);
+    __m512i ab1 = _mm512_loadu_si512((const __m512i*)(ptr + 32));
+    a = v_uint16x32(_v_512_combine(_v512_extract_low(_mm512_maskz_compress_epi16(0x55555555, ab0)),
+                                   _v512_extract_low(_mm512_maskz_compress_epi16(0x55555555, ab1))));
+    b = v_uint16x32(_v_512_combine(_v512_extract_low(_mm512_maskz_compress_epi16(0xAAAAAAAA, ab0)),
+                                   _v512_extract_low(_mm512_maskz_compress_epi16(0xAAAAAAAA, ab1))));
 }
 
-inline void v_load_deinterleave( const unsigned* ptr, v_uint32x8& a, v_uint32x8& b )
+inline void v_load_deinterleave( const unsigned* ptr, v_uint32x16& a, v_uint32x16& b )
 {
-    __m512i ab0 = _mm256_loadu_si256((const __m512i*)ptr);
-    __m512i ab1 = _mm256_loadu_si256((const __m512i*)(ptr + 8));
-
-    const int sh = 0+2*4+1*16+3*64;
-    __m512i p0 = _mm256_shuffle_epi32(ab0, sh);
-    __m512i p1 = _mm256_shuffle_epi32(ab1, sh);
-    __m512i pl = _mm256_permute2x128_si256(p0, p1, 0 + 2*16);
-    __m512i ph = _mm256_permute2x128_si256(p0, p1, 1 + 3*16);
-    __m512i a0 = _mm256_unpacklo_epi64(pl, ph);
-    __m512i b0 = _mm256_unpackhi_epi64(pl, ph);
-    a = v_uint32x8(a0);
-    b = v_uint32x8(b0);
+    __m512i ab0 = _mm512_loadu_si512((const __m512i*)ptr);
+    __m512i ab1 = _mm512_loadu_si512((const __m512i*)(ptr + 16));
+    a = v_uint32x16(_v_512_combine(_v512_extract_low(_mm512_maskz_compress_epi32(0x5555, ab0)),
+                                   _v512_extract_low(_mm512_maskz_compress_epi32(0x5555, ab1))));
+    b = v_uint32x16(_v_512_combine(_v512_extract_low(_mm512_maskz_compress_epi32(0xAAAA, ab0)),
+                                   _v512_extract_low(_mm512_maskz_compress_epi32(0xAAAA, ab1))));
 }
 
-inline void v_load_deinterleave( const uint64* ptr, v_uint64x4& a, v_uint64x4& b )
+inline void v_load_deinterleave( const uint64* ptr, v_uint64x8& a, v_uint64x8& b )
 {
-    __m512i ab0 = _mm256_loadu_si256((const __m512i*)ptr);
-    __m512i ab1 = _mm256_loadu_si256((const __m512i*)(ptr + 4));
-
-    __m512i pl = _mm256_permute2x128_si256(ab0, ab1, 0 + 2*16);
-    __m512i ph = _mm256_permute2x128_si256(ab0, ab1, 1 + 3*16);
-    __m512i a0 = _mm256_unpacklo_epi64(pl, ph);
-    __m512i b0 = _mm256_unpackhi_epi64(pl, ph);
-    a = v_uint64x4(a0);
-    b = v_uint64x4(b0);
+    __m512i ab0 = _mm512_loadu_si512((const __m512i*)ptr);
+    __m512i ab1 = _mm512_loadu_si512((const __m512i*)(ptr + 8));
+    a = v_uint64x8(_v_512_combine(_v512_extract_low(_mm512_maskz_compress_epi64(0x55, ab0)),
+                                  _v512_extract_low(_mm512_maskz_compress_epi64(0x55, ab1))));
+    b = v_uint64x8(_v_512_combine(_v512_extract_low(_mm512_maskz_compress_epi64(0xAA, ab0)),
+                                  _v512_extract_low(_mm512_maskz_compress_epi64(0xAA, ab1))));
 }
 
-inline void v_load_deinterleave( const uchar* ptr, v_uint8x32& b, v_uint8x32& g, v_uint8x32& r )
+inline void v_load_deinterleave( const uchar* ptr, v_uint8x64& b, v_uint8x64& g, v_uint8x64& r )
 {
-    __m512i bgr0 = _mm256_loadu_si256((const __m512i*)ptr);
-    __m512i bgr1 = _mm256_loadu_si256((const __m512i*)(ptr + 32));
-    __m512i bgr2 = _mm256_loadu_si256((const __m512i*)(ptr + 64));
+    __m512i bgr0 = _mm512_loadu_si512((const __m512i*)ptr);
+    __m512i bgr1 = _mm512_loadu_si512((const __m512i*)(ptr + 64));
+    __m512i bgr2 = _mm512_loadu_si512((const __m512i*)(ptr + 128));
 
-    __m512i s02_low = _mm256_permute2x128_si256(bgr0, bgr2, 0 + 2*16);
-    __m512i s02_high = _mm256_permute2x128_si256(bgr0, bgr2, 1 + 3*16);
-
-    const __m512i m0 = _mm256_setr_epi8(0, 0, -1, 0, 0, -1, 0, 0, -1, 0, 0, -1, 0, 0, -1, 0,
-                                               0, -1, 0, 0, -1, 0, 0, -1, 0, 0, -1, 0, 0, -1, 0, 0);
-    const __m512i m1 = _mm256_setr_epi8(0, -1, 0, 0, -1, 0, 0, -1, 0, 0, -1, 0, 0, -1, 0, 0,
-                                               -1, 0, 0, -1, 0, 0, -1, 0, 0, -1, 0, 0, -1, 0, 0, -1);
-
-    __m512i b0 = _mm256_blendv_epi8(_mm256_blendv_epi8(s02_low, s02_high, m0), bgr1, m1);
-    __m512i g0 = _mm256_blendv_epi8(_mm256_blendv_epi8(s02_high, s02_low, m1), bgr1, m0);
-    __m512i r0 = _mm256_blendv_epi8(_mm256_blendv_epi8(bgr1, s02_low, m0), s02_high, m1);
-
-    const __m512i
-    sh_b = _mm256_setr_epi8(0, 3, 6, 9, 12, 15, 2, 5, 8, 11, 14, 1, 4, 7, 10, 13,
-                            0, 3, 6, 9, 12, 15, 2, 5, 8, 11, 14, 1, 4, 7, 10, 13),
-    sh_g = _mm256_setr_epi8(1, 4, 7, 10, 13, 0, 3, 6, 9, 12, 15, 2, 5, 8, 11, 14,
-                            1, 4, 7, 10, 13, 0, 3, 6, 9, 12, 15, 2, 5, 8, 11, 14),
-    sh_r = _mm256_setr_epi8(2, 5, 8, 11, 14, 1, 4, 7, 10, 13, 0, 3, 6, 9, 12, 15,
-                            2, 5, 8, 11, 14, 1, 4, 7, 10, 13, 0, 3, 6, 9, 12, 15);
-    b0 = _mm256_shuffle_epi8(b0, sh_b);
-    g0 = _mm256_shuffle_epi8(g0, sh_g);
-    r0 = _mm256_shuffle_epi8(r0, sh_r);
-
-    b = v_uint8x32(b0);
-    g = v_uint8x32(g0);
-    r = v_uint8x32(r0);
+    __m512i mask0 = _mm512_set_epi16(  2,   5,   8,  11,  14,  17,  20,  23,  26,  29,  32,  35,  38,  41,  44,  47,
+                                      50,  53,  56,  59,  62,   0,   3,   6,   9,  12,  15,  18,  21,  24,  27,  30,
+                                      33,  36,  39,  42,  45,  48,  51,  54,  57,  60,  63,  66,  69,  72,  75,  78,
+                                      81,  84,  87,  90,  93,  96,  99, 102, 105, 108, 111, 114, 117, 120, 123, 126 );
+    __m512i r0b01 = _mm512_permutex2var_epi16(bgr0, mask0, bgr1);
+    __m512i b1g12 = _mm512_permutex2var_epi16(bgr1, mask0, bgr2);
+    __m512i r12b2 = _mm512_permutex2var_epi16(bgr1,
+                    _mm512_set_epi16(  1,   4,   7,  10,  13,  16,  19,  22,  25,  28,  31,  34,  37,  40,  43,  46,
+                                      49,  52,  55,  58,  61,  64,  67,  70,  73,  76,  79,  82,  85,  88,  91,  94,
+                                      97, 100, 103, 106, 109, 112, 115, 118, 121, 124, 127,  65,  68,  71,  74,  77,
+                                      80,  83,  86,  89,  92,  95,  98, 101, 104, 107, 110, 113, 116, 119, 122, 125 ), bgr2);
+    b = v_uint16x32(_mm512_mask_compress_epi8(r12b2, 0xffffffffffe00000, r0b01));
+    g = v_uint16x32(_mm512_mask_compress_epi8(b1g12, 0x2492492492492492, bgr0));
+    r = v_uint16x32(_mm512_mask_expand_epi8(r0b01, 0xffffffffffe00000, r12b2));
 }
 
-inline void v_load_deinterleave( const ushort* ptr, v_uint16x16& b, v_uint16x16& g, v_uint16x16& r )
+inline void v_load_deinterleave( const ushort* ptr, v_uint16x32& b, v_uint16x32& g, v_uint16x32& r )
 {
-    __m512i bgr0 = _mm256_loadu_si256((const __m512i*)ptr);
-    __m512i bgr1 = _mm256_loadu_si256((const __m512i*)(ptr + 16));
-    __m512i bgr2 = _mm256_loadu_si256((const __m512i*)(ptr + 32));
+    __m512i bgr0 = _mm512_loadu_si512((const __m512i*)ptr);
+    __m512i bgr1 = _mm512_loadu_si512((const __m512i*)(ptr + 32));
+    __m512i bgr2 = _mm512_loadu_si512((const __m512i*)(ptr + 64));
 
-    __m512i s02_low = _mm256_permute2x128_si256(bgr0, bgr2, 0 + 2*16);
-    __m512i s02_high = _mm256_permute2x128_si256(bgr0, bgr2, 1 + 3*16);
+    __m512i mask0 = _mm512_set_epi16( 0,  3,  6,  9, 12, 15, 18, 21, 24, 27, 30, 33, 36, 39, 42, 45,
+                                     48, 51, 54, 57, 60, 63, 34, 37, 40, 43, 46, 49, 52, 55, 58, 61);
+    __m512i b01g1 = _mm512_permutex2var_epi16(bgr0, mask0, bgr1);
+    __m512i r12b2 = _mm512_permutex2var_epi16(bgr1, mask0, bgr2);
+    __m512i g20r0 = _mm512_permutex2var_epi16(bgr2, mask0, bgr0);
 
-    const __m512i m0 = _mm256_setr_epi8(0, 0, -1, -1, 0, 0, 0, 0, -1, -1, 0, 0, 0, 0, -1, -1,
-                                               0, 0, 0, 0, -1, -1, 0, 0, 0, 0, -1, -1, 0, 0, 0, 0);
-    const __m512i m1 = _mm256_setr_epi8(0, 0, 0, 0, -1, -1, 0, 0, 0, 0, -1, -1, 0, 0, 0, 0,
-                                               -1, -1, 0, 0, 0, 0, -1, -1, 0, 0, 0, 0, -1, -1, 0, 0);
-    __m512i b0 = _mm256_blendv_epi8(_mm256_blendv_epi8(s02_low, s02_high, m0), bgr1, m1);
-    __m512i g0 = _mm256_blendv_epi8(_mm256_blendv_epi8(bgr1, s02_low, m0), s02_high, m1);
-    __m512i r0 = _mm256_blendv_epi8(_mm256_blendv_epi8(s02_high, s02_low, m1), bgr1, m0);
-    const __m512i sh_b = _mm256_setr_epi8(0, 1, 6, 7, 12, 13, 2, 3, 8, 9, 14, 15, 4, 5, 10, 11,
-                                                 0, 1, 6, 7, 12, 13, 2, 3, 8, 9, 14, 15, 4, 5, 10, 11);
-    const __m512i sh_g = _mm256_setr_epi8(2, 3, 8, 9, 14, 15, 4, 5, 10, 11, 0, 1, 6, 7, 12, 13,
-                                                 2, 3, 8, 9, 14, 15, 4, 5, 10, 11, 0, 1, 6, 7, 12, 13);
-    const __m512i sh_r = _mm256_setr_epi8(4, 5, 10, 11, 0, 1, 6, 7, 12, 13, 2, 3, 8, 9, 14, 15,
-                                                 4, 5, 10, 11, 0, 1, 6, 7, 12, 13, 2, 3, 8, 9, 14, 15);
-    b0 = _mm256_shuffle_epi8(b0, sh_b);
-    g0 = _mm256_shuffle_epi8(g0, sh_g);
-    r0 = _mm256_shuffle_epi8(r0, sh_r);
-
-    b = v_uint16x16(b0);
-    g = v_uint16x16(g0);
-    r = v_uint16x16(r0);
+    b = v_uint16x32(_mm512_mask_blend_epi32(0x001f, b01g1, r12b2));
+    g = v_uint16x32(_mm512_alignr_epi32(r12b2, g20r0, 11));
+    r = v_uint16x32(_mm512_permutex2var_epi16(bgr1, _mm512_set_epi16(43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 2, 5, 8, 11, 14, 17, 20, 23, 26, 29, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42), g20r0));
 }
 
-inline void v_load_deinterleave( const unsigned* ptr, v_uint32x8& b, v_uint32x8& g, v_uint32x8& r )
+inline void v_load_deinterleave( const unsigned* ptr, v_uint32x16& b, v_uint32x16& g, v_uint32x16& r )
 {
-    __m512i bgr0 = _mm256_loadu_si256((const __m512i*)ptr);
-    __m512i bgr1 = _mm256_loadu_si256((const __m512i*)(ptr + 8));
-    __m512i bgr2 = _mm256_loadu_si256((const __m512i*)(ptr + 16));
+    __m512i bgr0 = _mm512_loadu_si512((const __m512i*)ptr);
+    __m512i bgr1 = _mm512_loadu_si512((const __m512i*)(ptr + 16));
+    __m512i bgr2 = _mm512_loadu_si512((const __m512i*)(ptr + 32));
 
-    __m512i s02_low = _mm256_permute2x128_si256(bgr0, bgr2, 0 + 2*16);
-    __m512i s02_high = _mm256_permute2x128_si256(bgr0, bgr2, 1 + 3*16);
+    __m512i mask0 = _mm512_set_epi32(0, 3, 6,  9, 12, 15, 18, 21, 24, 27, 30,    17, 20, 23, 26, 29);
+    __m512i b01r1 = _mm512_permutex2var_epi32(bgr0, mask0, bgr1);
+    __m512i g12b2 = _mm512_permutex2var_epi32(bgr1, mask0, bgr2);
+    __m512i r20g0 = _mm512_permutex2var_epi32(bgr2, mask0, bgr0);
 
-    __m512i b0 = _mm256_blend_epi32(_mm256_blend_epi32(s02_low, s02_high, 0x24), bgr1, 0x92);
-    __m512i g0 = _mm256_blend_epi32(_mm256_blend_epi32(s02_high, s02_low, 0x92), bgr1, 0x24);
-    __m512i r0 = _mm256_blend_epi32(_mm256_blend_epi32(bgr1, s02_low, 0x24), s02_high, 0x92);
-
-    b0 = _mm256_shuffle_epi32(b0, 0x6c);
-    g0 = _mm256_shuffle_epi32(g0, 0xb1);
-    r0 = _mm256_shuffle_epi32(r0, 0xc6);
-
-    b = v_uint32x8(b0);
-    g = v_uint32x8(g0);
-    r = v_uint32x8(r0);
+    b = v_uint32x16(_mm512_mask_blend_epi32(0x001f, b01r1, g12b2));
+    g = v_uint32x16(_mm512_alignr_epi32(g12b2, r20g0, 11));
+    r = v_uint32x16(_mm512_permutex2var_epi32(bgr1, _mm512_set_epi32(16, 17, 18, 19, 20, 21, 1, 4, 7, 10, 13, 22, 23, 24, 25, 26), r20g0));
 }
 
-inline void v_load_deinterleave( const uint64* ptr, v_uint64x4& b, v_uint64x4& g, v_uint64x4& r )
+inline void v_load_deinterleave( const uint64* ptr, v_uint64x8& b, v_uint64x8& g, v_uint64x8& r )
 {
-    __m512i bgr0 = _mm256_loadu_si256((const __m512i*)ptr);
-    __m512i bgr1 = _mm256_loadu_si256((const __m512i*)(ptr + 4));
-    __m512i bgr2 = _mm256_loadu_si256((const __m512i*)(ptr + 8));
+    __m512i bgr0 = _mm512_loadu_si512((const __m512i*)ptr);
+    __m512i bgr1 = _mm512_loadu_si512((const __m512i*)(ptr + 8));
+    __m512i bgr2 = _mm512_loadu_si512((const __m512i*)(ptr + 16));
 
-    __m512i s01 = _mm256_blend_epi32(bgr0, bgr1, 0xf0);
-    __m512i s12 = _mm256_blend_epi32(bgr1, bgr2, 0xf0);
-    __m512i s20r = _mm256_permute4x64_epi64(_mm256_blend_epi32(bgr2, bgr0, 0xf0), 0x1b);
-    __m512i b0 = _mm256_unpacklo_epi64(s01, s20r);
-    __m512i g0 = _mm256_alignr_epi8(s12, s01, 8);
-    __m512i r0 = _mm256_unpackhi_epi64(s20r, s12);
+    __m512i mask0 = _mm512_set_epi64(0, 3, 6, 9, 12, 15,    10, 13);
+    __m512i b01g1 = _mm512_permutex2var_epi64(bgr0, mask0, bgr1);
+    __m512i r12b2 = _mm512_permutex2var_epi64(bgr1, mask0, bgr2);
+    __m512i g20r0 = _mm512_permutex2var_epi64(bgr2, mask0, bgr0);
 
-    b = v_uint64x4(b0);
-    g = v_uint64x4(g0);
-    r = v_uint64x4(r0);
+    b = v_uint64x8(_mm512_mask_blend_epi64(0x03, b01g1, r12b2));
+    r = v_uint64x8(_mm512_alignr_epi64(r12b2, g20r0, 6));
+    g = v_uint64x8(_mm512_permutex2var_epi64(bgr1, _mm512_set_epi32(11, 12, 13, 2, 5, 8, 9, 10), g20r0));
 }
 
 inline void v_load_deinterleave( const uchar* ptr, v_uint8x32& b, v_uint8x32& g, v_uint8x32& r, v_uint8x32& a )

--- a/modules/core/include/opencv2/core/hal/intrin_forward.hpp
+++ b/modules/core/include/opencv2/core/hal/intrin_forward.hpp
@@ -14,9 +14,32 @@ namespace cv
 CV_CPU_OPTIMIZATION_HAL_NAMESPACE_BEGIN
 
 /** Types **/
-#if CV__SIMD_FORWARD == 512
-// [todo] 512
-#error "AVX512 Not implemented yet"
+#if CV__SIMD_FORWARD == 1024
+// [todo] 1024
+#error "1024-long ops not implemented yet"
+#elif CV__SIMD_FORWARD == 512
+// 512
+#define __CV_VX(fun)   v256_##fun
+#define __CV_V_UINT8   v_uint8x64
+#define __CV_V_INT8    v_int8x64
+#define __CV_V_UINT16  v_uint16x32
+#define __CV_V_INT16   v_int16x32
+#define __CV_V_UINT32  v_uint32x16
+#define __CV_V_INT32   v_int32x16
+#define __CV_V_UINT64  v_uint64x8
+#define __CV_V_INT64   v_int64x8
+#define __CV_V_FLOAT32 v_float32x16
+#define __CV_V_FLOAT64 v_float64x8
+struct v_uint8x64;
+struct v_int8x64;
+struct v_uint16x32;
+struct v_int16x32;
+struct v_uint32x16;
+struct v_int32x16;
+struct v_uint64x8;
+struct v_int64x8;
+struct v_float32x16;
+struct v_float64x8;
 #elif CV__SIMD_FORWARD == 256
 // 256
 #define __CV_VX(fun)   v256_##fun

--- a/modules/core/include/opencv2/core/hal/intrin_forward.hpp
+++ b/modules/core/include/opencv2/core/hal/intrin_forward.hpp
@@ -19,7 +19,7 @@ CV_CPU_OPTIMIZATION_HAL_NAMESPACE_BEGIN
 #error "1024-long ops not implemented yet"
 #elif CV__SIMD_FORWARD == 512
 // 512
-#define __CV_VX(fun)   v256_##fun
+#define __CV_VX(fun)   v512_##fun
 #define __CV_V_UINT8   v_uint8x64
 #define __CV_V_INT8    v_int8x64
 #define __CV_V_UINT16  v_uint16x32

--- a/modules/core/test/test_intrin.cpp
+++ b/modules/core/test/test_intrin.cpp
@@ -7,10 +7,14 @@
 #include "test_intrin128.simd_declarations.hpp"
 
 #undef CV_CPU_DISPATCH_MODES_ALL
-
 #include "opencv2/core/cv_cpu_dispatch.h"
 #include "test_intrin256.simd.hpp"
 #include "test_intrin256.simd_declarations.hpp"
+
+#undef CV_CPU_DISPATCH_MODES_ALL
+#include "opencv2/core/cv_cpu_dispatch.h"
+#include "test_intrin512.simd.hpp"
+#include "test_intrin512.simd_declarations.hpp"
 
 #ifdef _MSC_VER
 # pragma warning(disable:4702)  // unreachable code
@@ -28,6 +32,11 @@ namespace opencv_test { namespace hal {
 #define DISPATCH_SIMD256(fn, cpu_opt) do { \
     CV_CPU_CALL_ ## cpu_opt ## _(fn, ()); \
     throw SkipTestException("SIMD256 (" #cpu_opt ") is not available or disabled"); \
+} while(0)
+
+#define DISPATCH_SIMD512(fn, cpu_opt) do { \
+    CV_CPU_CALL_ ## cpu_opt ## _(fn, ()); \
+    throw SkipTestException("SIMD512 (" #cpu_opt ") is not available or disabled"); \
 } while(0)
 
 #define DEFINE_SIMD_TESTS(simd_size, cpu_opt) \
@@ -67,6 +76,9 @@ DEFINE_SIMD_TESTS(128, AVX)
 #if defined CV_CPU_DISPATCH_COMPILE_AVX2 || defined CV_CPU_BASELINE_COMPILE_AVX2
 DEFINE_SIMD_TESTS(128, AVX2)
 #endif
+#if defined CV_CPU_DISPATCH_COMPILE_AVX512_SKX || defined CV_CPU_BASELINE_COMPILE_AVX512_SKX
+DEFINE_SIMD_TESTS(128, AVX512_SKX)
+#endif
 
 TEST(hal_intrin128, float16x8_FP16)
 {
@@ -91,6 +103,10 @@ namespace intrin256 {
 DEFINE_SIMD_TESTS(256, AVX2)
 #endif
 
+#if defined CV_CPU_DISPATCH_COMPILE_AVX512_SKX || defined CV_CPU_BASELINE_COMPILE_AVX512_SKX
+DEFINE_SIMD_TESTS(256, AVX512_SKX)
+#endif
+
 TEST(hal_intrin256, float16x16_FP16)
 {
     //CV_CPU_CALL_FP16_(test_hal_intrin_float16, ());
@@ -100,5 +116,20 @@ TEST(hal_intrin256, float16x16_FP16)
 
 
 } // namespace intrin256
+
+namespace intrin512 {
+
+#if defined CV_CPU_DISPATCH_COMPILE_AVX512_SKX || defined CV_CPU_BASELINE_COMPILE_AVX512_SKX
+    DEFINE_SIMD_TESTS(512, AVX512_SKX)
+#endif
+
+TEST(hal_intrin512, float16x32_FP16)
+{
+    CV_CPU_CALL_AVX512_SKX_(test_hal_intrin_float16, ());
+    throw SkipTestException("Unsupported hardware: FP16 is not available");
+}
+
+
+} // namespace intrin512
 
 }} // namespace

--- a/modules/core/test/test_intrin512.simd.hpp
+++ b/modules/core/test/test_intrin512.simd.hpp
@@ -1,0 +1,23 @@
+// This file is part of OpenCV project.
+// It is subject to the license terms in the LICENSE file found in the top-level directory
+// of this distribution and at http://opencv.org/license.html.
+#if !defined CV_CPU_OPTIMIZATION_DECLARATIONS_ONLY && \
+    !defined CV_DISABLE_OPTIMIZATION && defined CV_ENABLE_INTRINSICS // TODO? C++ fallback implementation for SIMD512
+
+#define CV__SIMD_FORCE_WIDTH 512
+#include "opencv2/core/hal/intrin.hpp"
+#undef CV__SIMD_FORCE_WIDTH
+
+#if CV_SIMD_WIDTH != 64
+#error "Invalid build configuration"
+#endif
+
+#endif // CV_CPU_OPTIMIZATION_DECLARATIONS_ONLY
+
+namespace opencv_test { namespace hal { namespace intrin512 {
+CV_CPU_OPTIMIZATION_NAMESPACE_BEGIN
+
+#include "test_intrin_utils.hpp"
+
+CV_CPU_OPTIMIZATION_NAMESPACE_END
+}}} //namespace

--- a/modules/core/test/test_intrin_utils.hpp
+++ b/modules/core/test/test_intrin_utils.hpp
@@ -811,7 +811,9 @@ template<typename R> struct TheTest
         R a = dataA, b = dataB, c = dataC, d = dataD, e = dataE;
 
         EXPECT_EQ(2, v_signmask(a));
+#if CV_SIMD_WIDTH <= 32
         EXPECT_EQ(2 | (1 << (R::nlanes / 2)) | (1 << (R::nlanes - 1)), v_signmask(b));
+#endif
 
         EXPECT_EQ(false, v_check_all(a));
         EXPECT_EQ(false, v_check_all(b));

--- a/modules/imgproc/src/resize.cpp
+++ b/modules/imgproc/src/resize.cpp
@@ -2148,6 +2148,7 @@ public:
                 v_zip(t0, t3, s0, s1); v_zip(t1, t4, s2, s3); v_zip(t2, t5, s4, s5);
                 bl = s0 + s3; gl = s1 + s4; rl = s2 + s5;
 #elif CV_SIMD_WIDTH == 64
+                v_zip(t0, t3, s0, s1); v_zip(t1, t4, s2, s3); v_zip(t2, t5, s4, s5);
                 v_zip(s0, s3, t0, t1); v_zip(s1, s4, t2, t3); v_zip(s2, s5, t4, t5);
                 bl = t0 + t3; gl = t1 + t4; rl = t2 + t5;
 #endif
@@ -2167,6 +2168,7 @@ public:
                 v_zip(t0, t3, s0, s1); v_zip(t1, t4, s2, s3); v_zip(t2, t5, s4, s5);
                 bh = s0 + s3; gh = s1 + s4; rh = s2 + s5;
 #elif CV_SIMD_WIDTH == 64
+                v_zip(t0, t3, s0, s1); v_zip(t1, t4, s2, s3); v_zip(t2, t5, s4, s5);
                 v_zip(s0, s3, t0, t1); v_zip(s1, s4, t2, t3); v_zip(s2, s5, t4, t5);
                 bh = t0 + t3; gh = t1 + t4; rh = t2 + t5;
 #endif

--- a/modules/imgproc/src/sumpixels.cpp
+++ b/modules/imgproc/src/sumpixels.cpp
@@ -127,7 +127,7 @@ struct Integral_SIMD<uchar, int, double>
             {
                 v_int16 el8 = v_reinterpret_as_s16(vx_load_expand(src_row + j));
                 v_int32 el4l, el4h;
-#if CV_AVX2
+#if CV_AVX2 && CV_SIMD_WIDTH == 32
                 __m256i vsum = _mm256_add_epi16(el8.val, _mm256_slli_si256(el8.val, 2));
                 vsum = _mm256_add_epi16(vsum, _mm256_slli_si256(vsum, 4));
                 vsum = _mm256_add_epi16(vsum, _mm256_slli_si256(vsum, 8));
@@ -138,7 +138,7 @@ struct Integral_SIMD<uchar, int, double>
 #else
                 el8 += v_rotate_left<1>(el8);
                 el8 += v_rotate_left<2>(el8);
-#if CV_SIMD_WIDTH == 32
+#if CV_SIMD_WIDTH >= 32
                 el8 += v_rotate_left<4>(el8);
 #if CV_SIMD_WIDTH == 64
                 el8 += v_rotate_left<8>(el8);
@@ -194,7 +194,7 @@ struct Integral_SIMD<uchar, float, double>
             {
                 v_int16 el8 = v_reinterpret_as_s16(vx_load_expand(src_row + j));
                 v_float32 el4l, el4h;
-#if CV_AVX2
+#if CV_AVX2 && CV_SIMD_WIDTH == 32
                 __m256i vsum = _mm256_add_epi16(el8.val, _mm256_slli_si256(el8.val, 2));
                 vsum = _mm256_add_epi16(vsum, _mm256_slli_si256(vsum, 4));
                 vsum = _mm256_add_epi16(vsum, _mm256_slli_si256(vsum, 8));
@@ -205,7 +205,7 @@ struct Integral_SIMD<uchar, float, double>
 #else
                 el8 += v_rotate_left<1>(el8);
                 el8 += v_rotate_left<2>(el8);
-#if CV_SIMD_WIDTH == 32
+#if CV_SIMD_WIDTH >= 32
                 el8 += v_rotate_left<4>(el8);
 #if CV_SIMD_WIDTH == 64
                 el8 += v_rotate_left<8>(el8);


### PR DESCRIPTION
relates #13891

Implementation of 512-bit wide universal intrinsics for AVX512
https://github.com/opencv/opencv/wiki/OE-29.-Adding-AVX512-Support

<cut/>

TODO:
- [x] extend test_intrin tests

```
force_builders=docs,linux,Custom
buildworker:Custom=linux-3
build_image:Custom=ubuntu:18.04
CPU_BASELINE:Custom=AVX512_SKX
build_image:Custom Win=msvs2019
CPU_BASELINE:Custom Win=AVX512_SKX
#build_image:Custom Mac=
CPU_BASELINE:Custom Mac=AVX512_SKX
```