### PR TITLE
(3.4) imgcodecs(tiff): avoid leak of helper struct on malformed inputs

### DIFF
--- a/modules/imgcodecs/src/grfmt_tiff.cpp
+++ b/modules/imgcodecs/src/grfmt_tiff.cpp
@@ -214,6 +214,8 @@ bool TiffDecoder::readHeader()
                                   &TiffDecoderBufHelper::write, &TiffDecoderBufHelper::seek,
                                   &TiffDecoderBufHelper::close, &TiffDecoderBufHelper::size,
                                   &TiffDecoderBufHelper::map, /*unmap=*/0 );
+            if (!tif)
+                delete buf_helper;
         }
         else
         {


### PR DESCRIPTION
backport #14202