### PR TITLE
build: fix world G-API tests

### DIFF
--- a/cmake/OpenCVModule.cmake
+++ b/cmake/OpenCVModule.cmake
@@ -1148,7 +1148,7 @@ function(ocv_add_perf_tests)
 
       source_group("Src" FILES "${${the_target}_pch}")
       ocv_add_executable(${the_target} ${OPENCV_PERF_${the_module}_SOURCES} ${${the_target}_pch})
-      ocv_target_include_modules(${the_target} ${perf_deps} "${perf_path}")
+      ocv_target_include_modules(${the_target} ${perf_deps})
       ocv_target_link_libraries(${the_target} LINK_PRIVATE ${perf_deps} ${OPENCV_MODULE_${the_module}_DEPS} ${OPENCV_LINKER_LIBS} ${OPENCV_PERF_${the_module}_DEPS})
       add_dependencies(opencv_perf_tests ${the_target})
 
@@ -1239,7 +1239,7 @@ function(ocv_add_accuracy_tests)
 
       source_group("Src" FILES "${${the_target}_pch}")
       ocv_add_executable(${the_target} ${OPENCV_TEST_${the_module}_SOURCES} ${${the_target}_pch})
-      ocv_target_include_modules(${the_target} ${test_deps} "${test_path}")
+      ocv_target_include_modules(${the_target} ${test_deps})
       if(EXISTS "${CMAKE_CURRENT_BINARY_DIR}/test")
         ocv_target_include_directories(${the_target} "${CMAKE_CURRENT_BINARY_DIR}/test")
       endif()

--- a/cmake/OpenCVPCHSupport.cmake
+++ b/cmake/OpenCVPCHSupport.cmake
@@ -261,6 +261,7 @@ MACRO(ADD_PRECOMPILED_HEADER _targetName _input)
       )
 
     _PCH_GET_COMPILE_FLAGS(_compile_FLAGS)
+    list(APPEND _compile_FLAGS "${_PCH_include_prefix}\"${_path}\"")
 
     get_target_property(type ${_targetName} TYPE)
     if(type STREQUAL "SHARED_LIBRARY")

--- a/modules/gapi/perf/common/gapi_core_perf_tests.cpp
+++ b/modules/gapi/perf/common/gapi_core_perf_tests.cpp
@@ -5,5 +5,5 @@
 // Copyright (C) 2018 Intel Corporation
 
 
-#include "perf_precomp.hpp"
+#include "../perf_precomp.hpp"
 #include "gapi_core_perf_tests_inl.hpp"

--- a/modules/gapi/perf/common/gapi_imgproc_perf_tests.cpp
+++ b/modules/gapi/perf/common/gapi_imgproc_perf_tests.cpp
@@ -5,5 +5,5 @@
 // Copyright (C) 2018 Intel Corporation
 
 
-#include "perf_precomp.hpp"
+#include "../perf_precomp.hpp"
 #include "gapi_imgproc_perf_tests_inl.hpp"

--- a/modules/gapi/perf/internal/gapi_compiler_perf_tests.cpp
+++ b/modules/gapi/perf/internal/gapi_compiler_perf_tests.cpp
@@ -5,7 +5,7 @@
 // Copyright (C) 2018 Intel Corporation
 
 
-#include "perf_precomp.hpp"
+#include "../perf_precomp.hpp"
 #include "../../test/common/gapi_tests_common.hpp"
 
 namespace opencv_test

--- a/modules/gapi/test/common/gapi_compoundkernel_tests.cpp
+++ b/modules/gapi/test/common/gapi_compoundkernel_tests.cpp
@@ -7,7 +7,7 @@
 
 // FIXME: move out from Common
 
-#include "test_precomp.hpp"
+#include "../test_precomp.hpp"
 #include "opencv2/gapi/cpu/core.hpp"
 
 #include <ade/util/algorithm.hpp>

--- a/modules/gapi/test/common/gapi_core_tests.cpp
+++ b/modules/gapi/test/common/gapi_core_tests.cpp
@@ -5,5 +5,5 @@
 // Copyright (C) 2018 Intel Corporation
 
 
-#include "test_precomp.hpp"
+#include "../test_precomp.hpp"
 #include "gapi_core_tests_inl.hpp"

--- a/modules/gapi/test/common/gapi_imgproc_tests.cpp
+++ b/modules/gapi/test/common/gapi_imgproc_tests.cpp
@@ -5,5 +5,5 @@
 // Copyright (C) 2018 Intel Corporation
 
 
-#include "test_precomp.hpp"
+#include "../test_precomp.hpp"
 #include "gapi_imgproc_tests_inl.hpp"

--- a/modules/gapi/test/common/gapi_operators_tests.cpp
+++ b/modules/gapi/test/common/gapi_operators_tests.cpp
@@ -5,5 +5,5 @@
 // Copyright (C) 2018 Intel Corporation
 
 
-#include "test_precomp.hpp"
+#include "../test_precomp.hpp"
 #include "gapi_operators_tests_inl.hpp"

--- a/modules/gapi/test/cpu/gapi_operators_tests_fluid.cpp
+++ b/modules/gapi/test/cpu/gapi_operators_tests_fluid.cpp
@@ -5,7 +5,7 @@
 // Copyright (C) 2018 Intel Corporation
 
 
-#include "test_precomp.hpp"
+#include "../test_precomp.hpp"
 #include "../common/gapi_operators_tests.hpp"
 
 #define CORE_FLUID cv::gapi::core::fluid::kernels()

--- a/modules/gapi/test/internal/gapi_int_backend_tests.cpp
+++ b/modules/gapi/test/internal/gapi_int_backend_tests.cpp
@@ -5,8 +5,8 @@
 // Copyright (C) 2018 Intel Corporation
 
 
-#include "test_precomp.hpp"
-#include "gapi_mock_kernels.hpp"
+#include "../test_precomp.hpp"
+#include "../gapi_mock_kernels.hpp"
 
 #include "compiler/gmodel.hpp"
 #include "compiler/gcompiler.hpp"

--- a/modules/gapi/test/internal/gapi_int_executor_tests.cpp
+++ b/modules/gapi/test/internal/gapi_int_executor_tests.cpp
@@ -5,7 +5,7 @@
 // Copyright (C) 2018 Intel Corporation
 
 
-#include "test_precomp.hpp"
+#include "../test_precomp.hpp"
 
 namespace opencv_test
 {

--- a/modules/gapi/test/internal/gapi_int_garg_test.cpp
+++ b/modules/gapi/test/internal/gapi_int_garg_test.cpp
@@ -5,7 +5,7 @@
 // Copyright (C) 2018 Intel Corporation
 
 
-#include "test_precomp.hpp"
+#include "../test_precomp.hpp"
 
 namespace opencv_test {
 // Tests on T/Kind matching ////////////////////////////////////////////////////

--- a/modules/gapi/test/internal/gapi_int_gmetaarg_test.cpp
+++ b/modules/gapi/test/internal/gapi_int_gmetaarg_test.cpp
@@ -5,7 +5,7 @@
 // Copyright (C) 2018 Intel Corporation
 
 
-#include "test_precomp.hpp"
+#include "../test_precomp.hpp"
 
 #include "api/gcomputation_priv.hpp"
 

--- a/modules/gapi/test/internal/gapi_int_gmodel_builder_test.cpp
+++ b/modules/gapi/test/internal/gapi_int_gmodel_builder_test.cpp
@@ -5,7 +5,7 @@
 // Copyright (C) 2018 Intel Corporation
 
 
-#include "test_precomp.hpp"
+#include "../test_precomp.hpp"
 
 #include <ade/util/zip_range.hpp>   // util::indexed
 

--- a/modules/gapi/test/internal/gapi_int_island_fusion_tests.cpp
+++ b/modules/gapi/test/internal/gapi_int_island_fusion_tests.cpp
@@ -5,10 +5,10 @@
 // Copyright (C) 2018 Intel Corporation
 
 
-#include "test_precomp.hpp"
+#include "../test_precomp.hpp"
 #include "compiler/transactions.hpp"
 
-#include "gapi_mock_kernels.hpp"
+#include "../gapi_mock_kernels.hpp"
 
 #include "compiler/gmodel.hpp"
 #include "compiler/gislandmodel.hpp"

--- a/modules/gapi/test/internal/gapi_int_island_tests.cpp
+++ b/modules/gapi/test/internal/gapi_int_island_tests.cpp
@@ -5,7 +5,7 @@
 // Copyright (C) 2018 Intel Corporation
 
 
-#include "test_precomp.hpp"
+#include "../test_precomp.hpp"
 
 #include "compiler/gmodel.hpp"
 #include "compiler/gcompiled_priv.hpp"

--- a/modules/gapi/test/internal/gapi_int_recompilation_test.cpp
+++ b/modules/gapi/test/internal/gapi_int_recompilation_test.cpp
@@ -5,7 +5,7 @@
 // Copyright (C) 2018 Intel Corporation
 
 
-#include "test_precomp.hpp"
+#include "../test_precomp.hpp"
 #include "api/gcomputation_priv.hpp"
 
 #include "opencv2/gapi/fluid/gfluidkernel.hpp"

--- a/modules/gapi/test/internal/gapi_int_resolve_kernel_test.cpp
+++ b/modules/gapi/test/internal/gapi_int_resolve_kernel_test.cpp
@@ -5,9 +5,9 @@
 // Copyright (C) 2018 Intel Corporation
 
 
-#include "test_precomp.hpp"
+#include "../test_precomp.hpp"
 
-#include "gapi_mock_kernels.hpp"
+#include "../gapi_mock_kernels.hpp"
 
 namespace opencv_test
 {

--- a/modules/gapi/test/internal/gapi_int_vectorref_test.cpp
+++ b/modules/gapi/test/internal/gapi_int_vectorref_test.cpp
@@ -5,7 +5,7 @@
 // Copyright (C) 2018 Intel Corporation
 
 
-#include "test_precomp.hpp"
+#include "../test_precomp.hpp"
 
 namespace opencv_test
 {

--- a/modules/gapi/test/internal/gapi_transactions_test.cpp
+++ b/modules/gapi/test/internal/gapi_transactions_test.cpp
@@ -5,7 +5,7 @@
 // Copyright (C) 2018 Intel Corporation
 
 
-#include "test_precomp.hpp"
+#include "../test_precomp.hpp"
 #include <ade/graph.hpp>
 #include "compiler/transactions.hpp"
 

--- a/modules/gapi/test/own/gapi_types_tests.cpp
+++ b/modules/gapi/test/own/gapi_types_tests.cpp
@@ -5,7 +5,7 @@
 // Copyright (C) 2018 Intel Corporation
 
 
-#include "test_precomp.hpp"
+#include "../test_precomp.hpp"
 #include "opencv2/gapi/own/types.hpp"
 
 namespace opencv_test

--- a/modules/gapi/test/own/mat_tests.cpp
+++ b/modules/gapi/test/own/mat_tests.cpp
@@ -5,7 +5,7 @@
 // Copyright (C) 2018 Intel Corporation
 
 
-#include "test_precomp.hpp"
+#include "../test_precomp.hpp"
 #include "opencv2/gapi/own/mat.hpp"
 #include <opencv2/gapi/util/compiler_hints.hpp> //suppress_unused_warning
 

--- a/modules/gapi/test/own/scalar_tests.cpp
+++ b/modules/gapi/test/own/scalar_tests.cpp
@@ -5,7 +5,7 @@
 // Copyright (C) 2018 Intel Corporation
 
 
-#include "test_precomp.hpp"
+#include "../test_precomp.hpp"
 #include "opencv2/gapi/own/scalar.hpp"
 
 namespace opencv_test

--- a/modules/gapi/test/util/any_tests.cpp
+++ b/modules/gapi/test/util/any_tests.cpp
@@ -5,7 +5,7 @@
 // Copyright (C) 2018 Intel Corporation
 
 
-#include "test_precomp.hpp"
+#include "../test_precomp.hpp"
 #include "opencv2/gapi/util/any.hpp"
 
 namespace opencv_test

--- a/modules/gapi/test/util/optional_tests.cpp
+++ b/modules/gapi/test/util/optional_tests.cpp
@@ -5,7 +5,7 @@
 // Copyright (C) 2018 Intel Corporation
 
 
-#include "test_precomp.hpp"
+#include "../test_precomp.hpp"
 #include "opencv2/gapi/util/optional.hpp"
 #include <opencv2/gapi/util/compiler_hints.hpp> //suppress_unused_warning
 

--- a/modules/gapi/test/util/variant_tests.cpp
+++ b/modules/gapi/test/util/variant_tests.cpp
@@ -5,7 +5,7 @@
 // Copyright (C) 2018 Intel Corporation
 
 
-#include "test_precomp.hpp"
+#include "../test_precomp.hpp"
 #include "opencv2/gapi/util/variant.hpp"
 #include <cstddef> //std::max_align_t
 


### PR DESCRIPTION
Force using of relative includes to avoid mess in world builds.

```
allow_multiple_commits=1
```