### PR TITLE
(3.4) cmake: don't add tests dirs as include directories

### DIFF
--- a/cmake/OpenCVModule.cmake
+++ b/cmake/OpenCVModule.cmake
@@ -1145,7 +1145,7 @@ function(ocv_add_perf_tests)
 
       source_group("Src" FILES "${${the_target}_pch}")
       ocv_add_executable(${the_target} ${OPENCV_PERF_${the_module}_SOURCES} ${${the_target}_pch})
-      ocv_target_include_modules(${the_target} ${perf_deps} "${perf_path}")
+      ocv_target_include_modules(${the_target} ${perf_deps})
       ocv_target_link_libraries(${the_target} LINK_PRIVATE ${perf_deps} ${OPENCV_MODULE_${the_module}_DEPS} ${OPENCV_LINKER_LIBS} ${OPENCV_PERF_${the_module}_DEPS})
       add_dependencies(opencv_perf_tests ${the_target})
 
@@ -1227,7 +1227,7 @@ function(ocv_add_accuracy_tests)
 
       source_group("Src" FILES "${${the_target}_pch}")
       ocv_add_executable(${the_target} ${OPENCV_TEST_${the_module}_SOURCES} ${${the_target}_pch})
-      ocv_target_include_modules(${the_target} ${test_deps} "${test_path}")
+      ocv_target_include_modules(${the_target} ${test_deps})
       if(EXISTS "${CMAKE_CURRENT_BINARY_DIR}/test")
         ocv_target_include_directories(${the_target} "${CMAKE_CURRENT_BINARY_DIR}/test")
       endif()

--- a/cmake/OpenCVPCHSupport.cmake
+++ b/cmake/OpenCVPCHSupport.cmake
@@ -261,6 +261,7 @@ MACRO(ADD_PRECOMPILED_HEADER _targetName _input)
       )
 
     _PCH_GET_COMPILE_FLAGS(_compile_FLAGS)
+    list(APPEND _compile_FLAGS "${_PCH_include_prefix}\"${_path}\"")
 
     get_target_property(type ${_targetName} TYPE)
     if(type STREQUAL "SHARED_LIBRARY")


### PR DESCRIPTION
relates #14217

To avoid mess in "world" builds.

They are here for more than 9 years. Currently it is not needed (relative includes works well with modern compilers).
GCC-based precompiled headers issue has been fixed.

<cut/>

```
force_builders=Custom
buildworker:Custom=linux-4
docker_image:Custom=ubuntu-cuda:16.04
```
