### PR TITLE
Enable 1x1 convolution optimization

### DIFF
--- a/modules/dnn/src/layers/convolution_layer.cpp
+++ b/modules/dnn/src/layers/convolution_layer.cpp
@@ -606,7 +606,7 @@ public:
 
             int inpCnAll = input.size[1], width = input.size[3], height = input.size[2];
             int inpCn = inpCnAll / ngroups;
-            p.is1x1_ = kernel == Size(0,0) && pad == Size(0, 0);
+            p.is1x1_ = kernel == Size(1,1) && pad == Size(0, 0);
             p.useAVX = checkHardwareSupport(CPU_AVX);
             p.useAVX2 = checkHardwareSupport(CPU_AVX2);
             p.useAVX512 = CV_CPU_HAS_SUPPORT_AVX512_SKX;


### PR DESCRIPTION
<!-- Please use this line to close one or multiple issues when this pullrequest gets merged
You can add another line right under the first one:
resolves #1234
resolves #1235
-->

### This pullrequest changes

SqueezeNet which has a number of 1x1 convolutions is 5% faster.

model name | before PR | with PR | x-factor |
---|---|---|---
AlexNet                           | 14.234 |  14.220    | 1.00   |
DenseNet_121                      | 36.797 |  36.205    | 1.02   |
EAST_text_detection               | 68.035 |  67.741    | 1.00   |
ENet                              | 42.840 |  43.617    | 0.98   |
FastNeuralStyle_eccv16            | 115.886 | 115.539   | 1.00   |
GoogLeNet                         | 14.781 |  14.803    | 1.00   |
Inception_5h                      | 16.138 |  16.230    | 0.99   |
Inception_v2_Faster_RCNN          | 281.913 | 281.062   | 1.00   |
Inception_v2_SSD_TensorFlow       | 43.484 |  42.729    | 1.02   |
MobileNet_SSD_Caffe               | 19.403 |  19.465    | 1.00   |
MobileNet_SSD_v1_TensorFlow       | 22.586 |  22.991    | 0.98   |
MobileNet_SSD_v2_TensorFlow       | 31.476 |  31.237    | 1.01   |
OpenFace                          |  3.746 |   3.692    | 1.01   |
OpenPose_pose_mpi_faster_4_stages | 598.990 | 598.406   | 1.00   |
ResNet_50                         | 35.390 |  35.169    | 1.01   |
SSD                               | 266.337 | 266.195   | 1.00   |
SqueezeNet_v1_1                   |  3.857 |   3.662    | **1.05**   |
YOLOv3                            | 212.469 | 211.797   | 1.00   |
opencv_face_detector              | 13.538 |  13.382    | 1.01|

CPU: Intel® Core™ i7-6700K CPU @ 4.00GHz × 8