### PR TITLE
Added authorization request to AVFoundation camera backend (OSX 10.14+)

### DIFF
--- a/modules/videoio/src/cap_avfoundation_mac.mm
+++ b/modules/videoio/src/cap_avfoundation_mac.mm
@@ -324,7 +324,7 @@ void CvCaptureCAM::stopCaptureDevice() {
 int CvCaptureCAM::startCaptureDevice(int cameraNum) {
     NSAutoreleasePool *localpool = [[NSAutoreleasePool alloc] init];
 
-#if defined(__MAC_OS_X_VERSION_MAX_ALLOWED) && __MAC_OS_X_VERSION_MAX_ALLOWED >= 1014
+#if defined(__MAC_OS_X_VERSION_MAX_ALLOWED) && __MAC_OS_X_VERSION_MAX_ALLOWED >= 101400
     AVAuthorizationStatus status = [AVCaptureDevice authorizationStatusForMediaType:AVMediaTypeVideo];
     if (status == AVAuthorizationStatusDenied)
     {

--- a/modules/videoio/src/cap_avfoundation_mac.mm
+++ b/modules/videoio/src/cap_avfoundation_mac.mm
@@ -45,7 +45,7 @@
 #include "precomp.hpp"
 #include "opencv2/imgproc.hpp"
 #include <stdio.h>
-#include <AvailabilityMacros.h>
+#include <Availability.h>
 #import <AVFoundation/AVFoundation.h>
 
 #define CV_CAP_MODE_BGR CV_FOURCC_MACRO('B','G','R','3')
@@ -323,6 +323,28 @@ void CvCaptureCAM::stopCaptureDevice() {
 
 int CvCaptureCAM::startCaptureDevice(int cameraNum) {
     NSAutoreleasePool *localpool = [[NSAutoreleasePool alloc] init];
+
+#if defined(__MAC_OS_X_VERSION_MAX_ALLOWED) && __MAC_OS_X_VERSION_MAX_ALLOWED >= 1014
+    AVAuthorizationStatus status = [AVCaptureDevice authorizationStatusForMediaType:AVMediaTypeVideo];
+    if (status == AVAuthorizationStatusDenied)
+    {
+        fprintf(stderr, "OpenCV: camera access has been denied. Either run 'tccutil reset Camera' "
+                        "command in same terminal to reset application authorization status, "
+                        "either modify 'System Preferences -> Security & Privacy -> Camera' "
+                        "settings for your application.\n");
+        [localpool drain];
+        return 0;
+    }
+    else if (status != AVAuthorizationStatusAuthorized)
+    {
+        fprintf(stderr, "OpenCV: not authorized to capture video (status %ld), requesting...\n", status);
+        // TODO: doesn't work via ssh
+        [AVCaptureDevice requestAccessForMediaType:AVMediaTypeVideo completionHandler:^(BOOL) { /* we don't care */}];
+        // we do not wait for completion
+        [localpool drain];
+        return 0;
+    }
+#endif
 
     // get capture device
     NSArray *devices = [[AVCaptureDevice devicesWithMediaType: AVMediaTypeVideo]


### PR DESCRIPTION
resolves #14258
resolves #12763

### This pullrequest changes

Added authorization status check and authorization request to AVFoundation camera backend for OSX Mojave (10.14+).

**Note**: to be backported to 3.4 with part of #14156 


force_builders_only=Mac,iOS