### PR TITLE
OpenCV release (3.4.6)

### DIFF
--- a/modules/core/include/opencv2/core/version.hpp
+++ b/modules/core/include/opencv2/core/version.hpp
@@ -8,7 +8,7 @@
 #define CV_VERSION_MAJOR    3
 #define CV_VERSION_MINOR    4
 #define CV_VERSION_REVISION 6
-#define CV_VERSION_STATUS   "-pre"
+#define CV_VERSION_STATUS   ""
 
 #define CVAUX_STR_EXP(__A)  #__A
 #define CVAUX_STR(__A)      CVAUX_STR_EXP(__A)


### PR DESCRIPTION
OpenCV 3.4.6

relates #14038

<cut/>

<details>

<summary>VirusTotal scan results:</summary>

[opencv_world346.dll (vc14)](https://www.virustotal.com/gui/file/c811a1e64a8e4c6933cb4d57bb6464617c27b00d812700cfc82c32424b7a84ea/detection)
[opencv_world346d.dll (vc14)](https://www.virustotal.com/gui/file/ac4605bcaa0375aa2f1d971397b9bd708c98b9f42c8650e38f8b84f046d3abd9/detection) (1 detection, [considered false positive](https://stackoverflow.com/questions/54052224/virustotal-trapmine-suspicious-low-ml-score) - 2019-04-07)
[opencv_world346.dll (vc15)](https://www.virustotal.com/gui/file/30143f5f0dc9cdd046a5f4db7b503998b5fd67b6f5dc41f82ee58ac90a59bdd7/detection)
[opencv_world346d.dll (vc15)](https://www.virustotal.com/gui/file/2802b417e018cb204488368175c0673b07816d32e778e16830efe7e589693d47/detection) (1 detection, [considered false positive](https://stackoverflow.com/questions/54052224/virustotal-trapmine-suspicious-low-ml-score) - 2019-04-07)

[opencv_ffmpeg346_64.dll](https://www.virustotal.com/#/file/e6acb89dfe6f3af13afaa3ff46ca4e3e1846d868d398e0fd662da2affd515d61/detection)
[opencv_ffmpeg346.dll](https://www.virustotal.com/#/file/f27caf6c55c7c6f94bace1d29680c340cdc248e951087fd931f5c0ed96f7c20f/detection)

</details>