### PR TITLE
Do not use compound literals (fix MSVC C4576)

### DIFF
--- a/modules/videoio/src/cap_ffmpeg_impl.hpp
+++ b/modules/videoio/src/cap_ffmpeg_impl.hpp
@@ -1669,8 +1669,12 @@ static AVStream *icv_add_video_stream_FFMPEG(AVFormatContext *oc,
 #endif
 
 #if LIBAVCODEC_BUILD >= CALC_FFMPEG_VERSION(52, 42, 0)
+#if defined(_MSC_VER) && defined(__cplusplus)
     AVRational avg_frame_rate = {frame_rate, frame_rate_base};
     st->avg_frame_rate = avg_frame_rate;
+#else
+    st->avg_frame_rate = (AVRational){frame_rate, frame_rate_base};
+#endif
 #endif
 #if LIBAVFORMAT_BUILD >= CALC_FFMPEG_VERSION(55, 20, 0)
     st->time_base = c->time_base;

--- a/modules/videoio/src/cap_ffmpeg_impl.hpp
+++ b/modules/videoio/src/cap_ffmpeg_impl.hpp
@@ -1669,7 +1669,7 @@ static AVStream *icv_add_video_stream_FFMPEG(AVFormatContext *oc,
 #endif
 
 #if LIBAVCODEC_BUILD >= CALC_FFMPEG_VERSION(52, 42, 0)
-#if defined(_MSC_VER) && defined(__cplusplus)
+#if defined(_MSC_VER)
     AVRational avg_frame_rate = {frame_rate, frame_rate_base};
     st->avg_frame_rate = avg_frame_rate;
 #else

--- a/modules/videoio/src/cap_ffmpeg_impl.hpp
+++ b/modules/videoio/src/cap_ffmpeg_impl.hpp
@@ -1669,7 +1669,8 @@ static AVStream *icv_add_video_stream_FFMPEG(AVFormatContext *oc,
 #endif
 
 #if LIBAVCODEC_BUILD >= CALC_FFMPEG_VERSION(52, 42, 0)
-    st->avg_frame_rate = (AVRational){frame_rate, frame_rate_base};
+    AVRational avg_frame_rate = {frame_rate, frame_rate_base};
+    st->avg_frame_rate = avg_frame_rate;
 #endif
 #if LIBAVFORMAT_BUILD >= CALC_FFMPEG_VERSION(55, 20, 0)
     st->time_base = c->time_base;


### PR DESCRIPTION
They are not part of the C++ standard, and MSVC will error out:
```
error C4576: a parenthesized type followed by an initializer list is a non-standard explicit type conversion syntax
```
<cut/>

See [godbolt example](https://godbolt.org/#g:!((g:!((g:!((h:codeEditor,i:(j:1,lang:c%2B%2B,source:'%23include+%3Cstring%3E%0A%0Aint+main()+%7B%0A++++std::string%7B%22hello%22%7D%3B%0A++++(std::string)%7B%22hello%22%7D%3B%0A%7D%0A'),l:'5',n:'0',o:'C%2B%2B+source+%231',t:'0')),k:51.836498185407095,l:'4',m:99.99999999999999,n:'0',o:'',s:0,t:'0'),(g:!((g:!((h:compiler,i:(compiler:vcpp_v19_20_x64,filters:(b:'0',binary:'1',commentOnly:'0',demangle:'0',directives:'0',execute:'1',intel:'0',libraryCode:'1',trim:'1'),lang:c%2B%2B,libs:!(),options:'',source:1),l:'5',n:'0',o:'x64+msvc+v19.20+(Editor+%231,+Compiler+%231)+C%2B%2B',t:'0')),k:100,l:'4',m:23.30508474576271,n:'0',o:'',s:0,t:'0'),(g:!((h:output,i:(compiler:1,editor:1,wrap:'1'),l:'5',n:'0',o:'%231+with+x64+msvc+v19.20',t:'0')),header:(),l:'4',m:23.30508474576271,n:'0',o:'',s:0,t:'0'),(g:!((h:compiler,i:(compiler:gsnapshot,filters:(b:'0',binary:'1',commentOnly:'0',demangle:'0',directives:'0',execute:'1',intel:'0',libraryCode:'1',trim:'1'),lang:c%2B%2B,libs:!(),options:'-Wall+-Wextra+-Wpedantic',source:1),l:'5',n:'0',o:'x86-64+gcc+(trunk)+(Editor+%231,+Compiler+%232)+C%2B%2B',t:'0')),header:(),k:100,l:'4',m:26.69491525423729,n:'0',o:'',s:0,t:'0'),(g:!((h:output,i:(compiler:2,editor:1,wrap:'1'),l:'5',n:'0',o:'%232+with+x86-64+gcc+(trunk)',t:'0')),header:(),l:'4',m:26.69491525423729,n:'0',o:'',s:0,t:'0')),k:48.163501814592905,l:'3',n:'0',o:'',t:'0')),l:'2',n:'0',o:'',t:'0')),version:4).
