### PR TITLE
Fix a bug in FusedBatchNorm (TensorFlow) layer importer

### DIFF
--- a/modules/dnn/src/tensorflow/tf_importer.cpp
+++ b/modules/dnn/src/tensorflow/tf_importer.cpp
@@ -1509,8 +1509,8 @@ void TFImporter::populateNet(Net dstNet)
                 if (layerParams.blobs.size() == 2)
                     CV_Error(Error::StsNotImplemented, "Cannot determine number "
                              "of parameters for batch normalization layer.");
-                mean = Mat::zeros(1, layerParams.blobs[3].total(), CV_32F);
-                std = Mat::ones(1, layerParams.blobs[3].total(), CV_32F);
+                mean = Mat::zeros(1, layerParams.blobs[2].total(), CV_32F);
+                std = Mat::ones(1, layerParams.blobs[2].total(), CV_32F);
 
                 // Add an extra layer: Mean-Variance normalization
                 LayerParams mvnParams;


### PR DESCRIPTION
<!-- Please use this line to close one or multiple issues when this pullrequest gets merged
You can add another line right under the first one:
resolves #1234
resolves #1235
-->

### This pullrequest changes

Get number of channels from an initialized blob.

resolves https://github.com/opencv/opencv/issues/14236
