### PR TITLE
Add javascript bindings for calib3d module.

### DIFF
--- a/modules/calib3d/CMakeLists.txt
+++ b/modules/calib3d/CMakeLists.txt
@@ -3,4 +3,6 @@ set(debug_modules "")
 if(DEBUG_opencv_calib3d)
   list(APPEND debug_modules opencv_highgui)
 endif()
-ocv_define_module(calib3d opencv_imgproc opencv_features2d ${debug_modules} WRAP java python)
+ocv_define_module(calib3d opencv_imgproc opencv_features2d ${debug_modules}
+    WRAP java python js
+)

--- a/modules/js/src/embindgen.py
+++ b/modules/js/src/embindgen.py
@@ -142,6 +142,8 @@ features2d = {'Feature2D': ['detect', 'compute', 'detectAndCompute', 'descriptor
               'BFMatcher': ['isMaskSupported', 'create'],
               '': ['drawKeypoints', 'drawMatches']}
 
+calib3d = {'': ['findHomography']}
+
 def makeWhiteList(module_list):
     wl = {}
     for m in module_list:
@@ -152,7 +154,7 @@ def makeWhiteList(module_list):
                 wl[k] = m[k]
     return wl
 
-white_list = makeWhiteList([core, imgproc, objdetect, video, dnn, features2d])
+white_list = makeWhiteList([core, imgproc, objdetect, video, dnn, features2d, calib3d])
 
 # Features to be exported
 export_enums = False

--- a/modules/js/test/test_calib3d.js
+++ b/modules/js/test/test_calib3d.js
@@ -1,0 +1,43 @@
+// This file is part of OpenCV project.
+// It is subject to the license terms in the LICENSE file found in the top-level directory
+// of this distribution and at http://opencv.org/license.html.
+
+if (typeof module !== 'undefined' && module.exports) {
+  // The envrionment is Node.js
+  var cv = require('./opencv.js'); // eslint-disable-line no-var
+}
+
+QUnit.module('Camera Calibration and 3D Reconstruction', {});
+
+QUnit.test('constants', function(assert) {
+  assert.strictEqual(typeof cv.LMEDS, 'number');
+  assert.strictEqual(typeof cv.RANSAC, 'number');
+  assert.strictEqual(typeof cv.RHO, 'number');
+});
+
+QUnit.test('findHomography', function(assert) {
+  let srcPoints = cv.matFromArray(4, 1, cv.CV_32FC2, [
+    56,
+    65,
+    368,
+    52,
+    28,
+    387,
+    389,
+    390,
+  ]);
+  let dstPoints = cv.matFromArray(4, 1, cv.CV_32FC2, [
+    0,
+    0,
+    300,
+    0,
+    0,
+    300,
+    300,
+    300,
+  ]);
+
+  const mat = cv.findHomography(srcPoints, dstPoints);
+
+  assert.ok(mat instanceof cv.Mat);
+});

--- a/modules/js/test/tests.html
+++ b/modules/js/test/tests.html
@@ -29,6 +29,7 @@
         <script type="application/javascript" src="test_objdetect.js"></script>
         <script type="application/javascript" src="test_video.js"></script>
         <script type="application/javascript" src="test_features2d.js"></script>
+        <script type="application/javascript" src="test_calib3d.js"></script>
         <script  type='text/javascript'>
             QUnit.config.autostart = false;
 

--- a/modules/js/test/tests.js
+++ b/modules/js/test/tests.js
@@ -45,7 +45,9 @@ testrunner.run(
     {
         code: 'opencv.js',
         tests: ['test_mat.js', 'test_utils.js', 'test_imgproc.js',
-                'test_objdetect.js', 'test_video.js', 'test_features2d.js'],
+                'test_objdetect.js', 'test_video.js', 'test_features2d.js',
+                'test_calib3d.js'
+        ],
     },
     function(err, report) {
         console.log(report.failed + ' failed, ' + report.passed + ' passed');

--- a/platforms/js/build_js.py
+++ b/platforms/js/build_js.py
@@ -115,7 +115,7 @@ class Builder:
                "-DWITH_QUIRC=OFF",
                "-DBUILD_ZLIB=ON",
                "-DBUILD_opencv_apps=OFF",
-               "-DBUILD_opencv_calib3d=ON",  # No bindings provided. This module is used as a dependency for other modules.
+               "-DBUILD_opencv_calib3d=ON",
                "-DBUILD_opencv_dnn=ON",
                "-DBUILD_opencv_features2d=ON",
                "-DBUILD_opencv_flann=OFF",


### PR DESCRIPTION
resolves #14293

### This pullrequest changes

This adds javascript bindings for the calib3d module, along with tests.

Currently I have only added the `findHomography` function, but will add the rest of the module soon.

<cut/>

```
force_builders_only=Docs,Custom
build_image:Docs=docs-js
build_image:Custom=javascript
buildworker:Custom=linux-4
```