### PR TITLE
Fix compile error with external TBB and -DBUILD_SHARED_LIBS=OFF

### DIFF
--- a/cmake/OpenCVDetectTBB.cmake
+++ b/cmake/OpenCVDetectTBB.cmake
@@ -29,8 +29,10 @@ function(ocv_tbb_cmake_guess _found)
       message(STATUS "Found TBB (cmake): ${_lib}")
       get_target_property(_inc TBB::tbb INTERFACE_INCLUDE_DIRECTORIES)
       ocv_tbb_read_version("${_inc}")
-      add_library(tbb INTERFACE)
-      target_link_libraries(tbb INTERFACE TBB::tbb)
+      add_library(tbb INTERFACE IMPORTED)
+      set_target_properties(tbb PROPERTIES
+        INTERFACE_LINK_LIBRARIES TBB::tbb
+      )
       set(${_found} TRUE PARENT_SCOPE)
     endif()
 endfunction()


### PR DESCRIPTION
Adds `IMPORTED` for the `TBB::tbb` alias target as otherwise cmake produces the following error:
```
CMake Error: install(EXPORT "OpenCVModules" ...) includes target "opencv_core" which requires target "tbb" that is not in the export set.
```

This problem occurs with the defaults used by homebrew on macOS, which compiles both static and shared versions of TBB and OpenCV. The problem should also occur on other platforms when `-DBUILD_SHARED_LIBS=OFF` is set and an external TBB library is used. However, I don't have the setup to verify this in practice.

A similar fix is implemented in #12741 for another module.

```
Xbuild_tbb=ON
Xwith_tbb=ON
Xbuild_shared=OFF
```