### PR TITLE
fix integer overflow for p.x when step is large

### DIFF
--- a/modules/imgproc/include/opencv2/imgproc.hpp
+++ b/modules/imgproc/include/opencv2/imgproc.hpp
@@ -4903,7 +4903,7 @@ Point LineIterator::pos() const
 {
     Point p;
     p.y = (int)((ptr - ptr0)/step);
-    p.x = (int)(((ptr - ptr0) - p.y*step)/elemSize);
+    p.x = (int)(((ptr - ptr0) - (long)p.y*step)/elemSize);
     return p;
 }
 


### PR DESCRIPTION
<!-- Please use this line to close one or multiple issues when this pullrequest gets merged
You can add another line right under the first one:
resolves #1234
resolves #1235
-->
resolves #14326

### This pullrequest changes
Add a cast to `long` for integer arithmetric that may potentially overflow in function `pos()` of `cv::LineIterator`
<!-- Please describe what your pullrequest is changing -->
