### PR TITLE
Another sample invisibility effect

### DIFF
--- a/samples/cpp/invisibility.cpp
+++ b/samples/cpp/invisibility.cpp
@@ -1,0 +1,92 @@
+/**
+  @file invisibility.cpp
+  @author Alessandro de Oliveira Faria (A.K.A. CABELO)
+  @brief Example of the invisibility effect, using subtraction techniques and masks. This file is part of OpenCV project, It is subject to the license terms in the LICENSE file found in the top-level directory of this distribution and at http://opencv.org/license.html
+  @date Apr 10, 2019
+*/
+
+#include <opencv2/opencv.hpp>
+#include <opencv2/imgproc/imgproc.hpp>
+#include <opencv2/highgui/highgui.hpp>
+
+using namespace std;
+using namespace cv;
+
+string keys =
+    "{ help        | | Print help message. }"
+    "{ input i     | 0 | Video or camera id.  }"
+    "{ thr         | 20 | Threshold background. }";
+
+int main(int argc, char** argv)
+{
+    CommandLineParser parser(argc, argv, keys);
+    parser.about("This sample demonstrates the invisibility effect with OpenCV.");
+    if (parser.has("help"))
+    {
+        parser.printMessage();
+        return 0;
+    }
+
+    Mat backgroundImage, currentImage;
+    Mat diffImage;
+    Mat foregroundMask, mask2;
+    Mat result1, result2;
+    Mat video, element;
+
+    float threshold = parser.get<float>("thr");
+    float dist;
+
+    int camId = parser.get<int>("input");
+    int key = -1;
+
+    VideoCapture cap;
+    cap.open(camId);
+
+    while (key<0)
+    {
+        key = waitKey(1);
+        cap >> backgroundImage;
+        putText(backgroundImage, "Press any key to grab backgroud or ESC to exit.", Point(10, 15), FONT_HERSHEY_SIMPLEX, 0.5, Scalar(0, 0, 0));
+        imshow("Video", backgroundImage);
+    }
+
+    if(key ==27){
+       exit(0);
+    }
+    else{
+        cap >> backgroundImage;
+        key = -1;
+    }
+
+    while (key<0)
+    {
+        result1 = 0;
+        result2 = 0;
+        key = waitKey(1);
+        cap >> currentImage;
+        absdiff(backgroundImage, currentImage, diffImage);
+        foregroundMask = Mat::zeros(diffImage.rows, diffImage.cols, CV_8UC1);
+        for(int j=0; j<diffImage.rows; ++j)
+        {
+            for(int i=0; i<diffImage.cols; ++i)
+            {
+                Vec3b pix = diffImage.at<cv::Vec3b>(j,i);
+                dist = (pix[0]*pix[0] + pix[1]*pix[1] + pix[2]*pix[2]);
+                dist = sqrt(dist);
+                if(dist>threshold)
+                {
+                    foregroundMask.at<unsigned char>(j,i) = 255;
+                }
+            }
+        }
+        element = Mat::ones(5,5, CV_32F);
+        morphologyEx(foregroundMask,foregroundMask,cv::MORPH_OPEN, element);
+        morphologyEx(foregroundMask,foregroundMask,cv::MORPH_DILATE, element);
+        bitwise_not(foregroundMask,mask2);
+        bitwise_and(currentImage,currentImage,result1,mask2);
+        bitwise_and(backgroundImage,backgroundImage,result2,foregroundMask);
+        addWeighted(result1,1,result2,1,0,video);
+        imshow("Video",video);
+    }
+    return 0;
+}

--- a/samples/cpp/invisibility.cpp
+++ b/samples/cpp/invisibility.cpp
@@ -5,9 +5,9 @@
   @date Apr 10, 2019
 */
 
-#include "opencv4/opencv2/opencv.hpp">
-#include <opencv4/opencv2/imgproc/imgproc.hpp>
-#include <opencv4/opencv2/highgui/highgui.hpp>
+#include "opencv2/imgcodecs.hpp"
+#include "opencv2/highgui.hpp"
+#include "opencv2/imgproc.hpp"
 
 using namespace std;
 using namespace cv;

--- a/samples/cpp/invisibility.cpp
+++ b/samples/cpp/invisibility.cpp
@@ -72,7 +72,7 @@ int main(int argc, char** argv)
             {
                 Vec3b pix = diffImage.at<cv::Vec3b>(j,i);
                 dist = (pix[0]*pix[0] + pix[1]*pix[1] + pix[2]*pix[2]);
-                dist = sqrt(dist);
+                dist = (int)sqrt(dist);
                 if(dist>threshold)
                 {
                     foregroundMask.at<unsigned char>(j,i) = 255;

--- a/samples/cpp/invisibility.cpp
+++ b/samples/cpp/invisibility.cpp
@@ -5,7 +5,7 @@
   @date Apr 10, 2019
 */
 
-#include <opencv4/opencv2/opencv.hpp>
+#include "opencv4/opencv2/opencv.hpp">
 #include <opencv4/opencv2/imgproc/imgproc.hpp>
 #include <opencv4/opencv2/highgui/highgui.hpp>
 

--- a/samples/cpp/invisibility.cpp
+++ b/samples/cpp/invisibility.cpp
@@ -34,7 +34,7 @@ int main(int argc, char** argv)
     Mat video, element;
 
     float threshold = parser.get<float>("thr");
-    float dist;
+    int dist;
 
     int camId = parser.get<int>("input");
     int key = -1;

--- a/samples/cpp/invisibility.cpp
+++ b/samples/cpp/invisibility.cpp
@@ -15,7 +15,7 @@ using namespace cv;
 string keys =
     "{ help        | | Print help message. }"
     "{ input i     | 0 | Video or camera id.  }"
-    "{ thr         | 20 | Threshold background. }";
+    "{ thr         | 40 | Threshold background. }";
 
 int main(int argc, char** argv)
 {

--- a/samples/cpp/invisibility.cpp
+++ b/samples/cpp/invisibility.cpp
@@ -5,9 +5,9 @@
   @date Apr 10, 2019
 */
 
-#include <opencv2/opencv.hpp>
-#include <opencv2/imgproc/imgproc.hpp>
-#include <opencv2/highgui/highgui.hpp>
+#include <opencv4/opencv2/opencv.hpp>
+#include <opencv4/opencv2/imgproc/imgproc.hpp>
+#include <opencv4/opencv2/highgui/highgui.hpp>
 
 using namespace std;
 using namespace cv;


### PR DESCRIPTION
<!-- Please use this line to close one or multiple issues when this pullrequest gets merged
You can add another line right under the first one:
resolves #1234
resolves #1235
-->

### This pullrequest changes

@alalek this is a example  (Invisibility) with OpenCV (using morphologyEx, bitwise_not, absdiff and another funcions)

Please. Sorry for the confusion in past, i found the problem. 

I  used  this example in this work: https://www.youtube.com/watch?v=h5savmDl5G0
![opencv_01](https://user-images.githubusercontent.com/675645/56168356-5156bd80-5fb1-11e9-89dd-2233b780ea1b.png)

<!-- Please describe what your pullrequest is changing -->
