### PR TITLE
Remove preprocessing parameters from README

### DIFF
--- a/samples/dnn/README.md
+++ b/samples/dnn/README.md
@@ -2,19 +2,22 @@
 
 ## Model Zoo
 
-### Object detection
+Check [a wiki](https://github.com/opencv/opencv/wiki/Deep-Learning-in-OpenCV) for a list of tested models.
 
-|    Model | Scale |   Size WxH|   Mean subtraction | Channels order |
-|---------------|-------|-----------|--------------------|-------|
-| [MobileNet-SSD, Caffe](https://github.com/chuanqi305/MobileNet-SSD/) | `0.00784 (2/255)` | `300x300` | `127.5 127.5 127.5` | BGR |
-| [OpenCV face detector](https://github.com/opencv/opencv/tree/3.4/samples/dnn/face_detector) | `1.0` | `300x300` | `104 177 123` | BGR |
-| [SSDs from TensorFlow](https://github.com/tensorflow/models/tree/master/research/object_detection/) | `0.00784 (2/255)` | `300x300` | `127.5 127.5 127.5` | RGB |
-| [YOLO](https://pjreddie.com/darknet/yolo/) | `0.00392 (1/255)` | `416x416` | `0 0 0` | RGB |
-| [VGG16-SSD](https://github.com/weiliu89/caffe/tree/ssd) | `1.0` | `300x300` | `104 117 123` | BGR |
-| [Faster-RCNN](https://github.com/rbgirshick/py-faster-rcnn) | `1.0` | `800x600` | `102.9801 115.9465 122.7717` | BGR |
-| [R-FCN](https://github.com/YuwenXiong/py-R-FCN) | `1.0` | `800x600` | `102.9801 115.9465 122.7717` | BGR |
-| [Faster-RCNN, ResNet backbone](https://github.com/tensorflow/models/tree/master/research/object_detection/) | `1.0` | `300x300` | `103.939 116.779 123.68` | RGB |
-| [Faster-RCNN, InceptionV2 backbone](https://github.com/tensorflow/models/tree/master/research/object_detection/) | `0.00784 (2/255)` | `300x300` | `127.5 127.5 127.5` | RGB |
+If OpenCV is built with [Intel's Inference Engine support](https://github.com/opencv/opencv/wiki/Intel%27s-Deep-Learning-Inference-Engine-backend) you can use [Intel's pre-trained](https://github.com/opencv/open_model_zoo) models.
+
+There are different preprocessing parameters such mean subtraction or scale factors for different models.
+You may check the most popular models and their parameters at [models.yml](https://github.com/opencv/opencv/blob/master/samples/dnn/models.yml) configuration file. It might be also used for aliasing samples parameters. In example,
+
+```bash
+python object_detection.py opencv_fd --model /path/to/caffemodel --config /path/to/prototxt
+```
+
+Check `-h` option to know which values are used by default:
+
+```bash
+python object_detection.py opencv_fd -h
+```
 
 #### Face detection
 [An origin model](https://github.com/opencv/opencv/tree/3.4/samples/dnn/face_detector)
@@ -43,18 +46,6 @@ AR @[ IoU=0.50:0.95 | area= small | maxDets=100 ] | 0.189     | 0.193 (+0.004) |
 AR @[ IoU=0.50:0.95 | area=medium | maxDets=100 ] | 0.481     | 0.480 (-0.001) | 0.470     | 0.458 (-0.012) |
 AR @[ IoU=0.50:0.95 | area= large | maxDets=100 ] | 0.528     | 0.528          | 0.520     | 0.462 (-0.058) |
 ```
-
-### Classification
-|    Model | Scale |   Size WxH|   Mean subtraction | Channels order |
-|---------------|-------|-----------|--------------------|-------|
-| GoogLeNet | `1.0` | `224x224` | `104 117 123` | BGR |
-| [SqueezeNet](https://github.com/DeepScale/SqueezeNet) | `1.0` | `227x227` | `0 0 0` | BGR |
-
-### Semantic segmentation
-|    Model | Scale |   Size WxH|   Mean subtraction | Channels order |
-|---------------|-------|-----------|--------------------|-------|
-| [ENet](https://github.com/e-lab/ENet-training) | `0.00392 (1/255)` | `1024x512` | `0 0 0` | RGB |
-| FCN8s | `1.0` | `500x500` | `0 0 0` | BGR |
 
 ## References
 * [Models downloading script](https://github.com/opencv/opencv_extra/blob/master/testdata/dnn/download_models.py)


### PR DESCRIPTION
<!-- Please use this line to close one or multiple issues when this pullrequest gets merged
You can add another line right under the first one:
resolves #1234
resolves #1235
-->

### This pullrequest changes

Remove dnn samples arguments from README page. Some of them are outdated.

related: http://answers.opencv.org/question/211466/faster-rcnn-no-results/
