### PR TITLE
tests: workaround for DYLD_LIBRARY_PATH on Apple MacOSX

### DIFF
--- a/modules/java/test/pure_test/build.xml
+++ b/modules/java/test/pure_test/build.xml
@@ -41,6 +41,7 @@
     <junit printsummary="true" haltonfailure="false" haltonerror="false" showoutput="true" logfailedtests="true" maxmemory="256m">
       <sysproperty key="java.library.path" path="${opencv.lib.path}"/>
       <env key="PATH" path="${opencv.lib.path}:${env.PATH}:${env.Path}"/>
+      <env key="DYLD_LIBRARY_PATH" path="${env.OPENCV_SAVED_DYLD_LIBRARY_PATH}"/>  <!-- https://github.com/opencv/opencv/issues/14353 -->
       <classpath refid="master-classpath"/>
       <classpath>
         <pathelement location="build/classes"/>

--- a/modules/ts/misc/run_utils.py
+++ b/modules/ts/misc/run_utils.py
@@ -37,6 +37,13 @@ def execute(cmd, silent=False, cwd=".", env=None):
             new_env = os.environ.copy()
             new_env.update(env)
             env = new_env
+
+        if sys.platform == 'darwin':  # https://github.com/opencv/opencv/issues/14351
+            if env is None:
+                env = os.environ.copy()
+            if 'DYLD_LIBRARY_PATH' in env:
+                env['OPENCV_SAVED_DYLD_LIBRARY_PATH'] = env['DYLD_LIBRARY_PATH']
+
         if silent:
             return check_output(cmd, stderr=STDOUT, cwd=cwd, env=env).decode("latin-1")
         else:


### PR DESCRIPTION
resolves #14353

```
buildworker:Mac OpenCL=macosx-1
build_image:Mac OpenCL=openvino-2019r1
```