### PR TITLE
FIX: getting platformIDs in initializeContextFromD3D11Device

### DIFF
--- a/modules/core/src/directx.cpp
+++ b/modules/core/src/directx.cpp
@@ -256,6 +256,10 @@ Context& initializeContextFromD3D11Device(ID3D11Device* pD3D11Device)
         CV_Error(cv::Error::OpenCLInitError, "OpenCL: No available platforms");
 
     std::vector<cl_platform_id> platforms(numPlatforms);
+    status = clGetPlatformIDs(numPlatforms, &platforms[0], NULL);
+    if (status != CL_SUCCESS)
+        CV_Error(cv::Error::OpenCLInitError, "OpenCL: Can't get number of platforms");
+
     size_t exts_len;
     cv::AutoBuffer<char> extensions;
     bool is_support_cl_khr_d3d11_sharing = false;
@@ -264,9 +268,6 @@ Context& initializeContextFromD3D11Device(ID3D11Device* pD3D11Device)
 #endif
     for (int i = 0; i < (int)numPlatforms; i++)
     {
-        status = clGetPlatformIDs(numPlatforms, &platforms[i], NULL);
-        if (status != CL_SUCCESS)
-            CV_Error(cv::Error::OpenCLInitError, "OpenCL: Can't get number of platforms");
         status = clGetPlatformInfo(platforms[i], CL_PLATFORM_EXTENSIONS, 0, NULL, &exts_len);
         if (status != CL_SUCCESS)
             CV_Error(cv::Error::OpenCLInitError, "OpenCL: Can't get length of CL_PLATFORM_EXTENSIONS");


### PR DESCRIPTION
<!-- Please use this line to close one or multiple issues when this pullrequest gets merged
You can add another line right under the first one:
resolves #1234
resolves #1235
-->

### This pullrequest changes
relates #13972

<!-- Please describe what your pullrequest is changing -->
fix usage of clGetPlatformIDs in initializeContextFromD3D11Device