### PR TITLE
cmake: guard macro definitions in PCH scripts

### DIFF
--- a/cmake/OpenCVPCHSupport.cmake
+++ b/cmake/OpenCVPCHSupport.cmake
@@ -302,7 +302,7 @@ MACRO(ADD_PRECOMPILED_HEADER _targetName _input)
 if [ -n \"$VERBOSE\" ]; then
   tail -n1 \$0
 fi
-${_command} -D$<JOIN:$<TARGET_PROPERTY:${_targetName},COMPILE_DEFINITIONS>, -D>
+${_command} '-D$<JOIN:$<TARGET_PROPERTY:${_targetName},COMPILE_DEFINITIONS>,' '-D>'
 ")
     GET_FILENAME_COMPONENT(_outdir ${_output} PATH)
     ADD_CUSTOM_COMMAND(


### PR DESCRIPTION
fixes build with VTK

relates #14313

[Failed nightly build](http://pullrequest.opencv.org/buildbot/builders/3_4_noOCL_noICV_noSSE-lin64-debug/builds/364).
[Validation build](http://pullrequest.opencv.org/buildbot/builders/3_4_noOCL_noICV_noSSE-lin64-debug/builds/365) :+1:
