### PR TITLE
Fixed array indexing bugs in python hough lines tutorials

### DIFF
--- a/samples/python/tutorial_code/imgProc/hough_line_transform/hough_line_transform.py
+++ b/samples/python/tutorial_code/imgProc/hough_line_transform/hough_line_transform.py
@@ -6,8 +6,8 @@ gray = cv.cvtColor(img,cv.COLOR_BGR2GRAY)
 edges = cv.Canny(gray,50,150,apertureSize = 3)
 
 lines = cv.HoughLines(edges,1,np.pi/180,200)
-for line in lines:
-    rho,theta = line[0]
+for line in lines[0]:
+    rho,theta = line
     a = np.cos(theta)
     b = np.sin(theta)
     x0 = a*rho

--- a/samples/python/tutorial_code/imgProc/hough_line_transform/probabilistic_hough_line_transform.py
+++ b/samples/python/tutorial_code/imgProc/hough_line_transform/probabilistic_hough_line_transform.py
@@ -5,8 +5,8 @@ img = cv.imread(cv.samples.findFile('sudoku.png'))
 gray = cv.cvtColor(img,cv.COLOR_BGR2GRAY)
 edges = cv.Canny(gray,50,150,apertureSize = 3)
 lines = cv.HoughLinesP(edges,1,np.pi/180,100,minLineLength=100,maxLineGap=10)
-for line in lines:
-    x1,y1,x2,y2 = line[0]
+for line in lines[0]:
+    x1,y1,x2,y2 = line
     cv.line(img,(x1,y1),(x2,y2),(0,255,0),2)
 
 cv.imwrite('houghlines5.jpg',img)


### PR DESCRIPTION
<!-- Please use this line to close one or multiple issues when this pullrequest gets merged
You can add another line right under the first one:
resolves #1234
resolves #1235
-->

### This pullrequest changes

<!-- Please describe what your pullrequest is changing -->
The hough lines tutorials for python have a bug where they only display the first detected line, due to an array indexing bug. This pull request changes the array indexing so that all lines are displayed.