### PR TITLE
calib3d: add find4QuadCornerSubpix java wrapper

### DIFF
--- a/modules/calib3d/include/opencv2/calib3d.hpp
+++ b/modules/calib3d/include/opencv2/calib3d.hpp
@@ -849,7 +849,7 @@ CV_EXPORTS_W bool findChessboardCorners( InputArray image, Size patternSize, Out
                                          int flags = CALIB_CB_ADAPTIVE_THRESH + CALIB_CB_NORMALIZE_IMAGE );
 
 //! finds subpixel-accurate positions of the chessboard corners
-CV_EXPORTS bool find4QuadCornerSubpix( InputArray img, InputOutputArray corners, Size region_size );
+CV_EXPORTS_W bool find4QuadCornerSubpix( InputArray img, InputOutputArray corners, Size region_size );
 
 /** @brief Renders the detected chessboard corners.
 

--- a/modules/calib3d/misc/java/test/Calib3dTest.java
+++ b/modules/calib3d/misc/java/test/Calib3dTest.java
@@ -188,6 +188,15 @@ public class Calib3dTest extends OpenCVTestCase {
         assertTrue(!corners.empty());
     }
 
+    public void testFind4QuadCornerSubpix() {
+        Size patternSize = new Size(9, 6);
+        MatOfPoint2f corners = new MatOfPoint2f();
+        Size region_size = new Size(5, 5);
+        Calib3d.findChessboardCorners(grayChess, patternSize, corners);
+        Calib3d.find4QuadCornerSubpix(grayChess, corners, region_size);
+        assertTrue(!corners.empty());
+    }
+
     public void testFindCirclesGridMatSizeMat() {
         int size = 300;
         Mat img = new Mat(size, size, CvType.CV_8U);


### PR DESCRIPTION
Fixes: https://github.com/opencv/opencv/issues/14169

<!-- Please use this line to close one or multiple issues when this pullrequest gets merged
You can add another line right under the first one:
resolves #1234
resolves #1235
-->
- [x] built locally succesfully
- [x] `make test` successfully
- [x] `java -cp ./lib/junit-4.11.jar:./build/jar/opencv-test.jar:./bin/opencv-346.jar -Djava.library.path="../lib" junit.textui.TestRunner org.opencv.test.calib3d.Calib3dTest` successfully
<!-- Please describe what your pullrequest is changing -->
