### PR TITLE
Added support for Py_LIMITED_API (stage 2)

### DIFF
--- a/modules/dnn/misc/python/pyopencv_dnn.hpp
+++ b/modules/dnn/misc/python/pyopencv_dnn.hpp
@@ -28,16 +28,19 @@ bool pyopencv_to(PyObject *o, dnn::DictValue &dv, const char *name)
     }
     else if (PyFloat_Check(o))
     {
-        dv = dnn::DictValue(PyFloat_AS_DOUBLE(o));
-        return true;
-    }
-    else if (PyString_Check(o))
-    {
-        dv = dnn::DictValue(String(PyString_AsString(o)));
+        dv = dnn::DictValue(PyFloat_AsDouble(o));
         return true;
     }
     else
-        return false;
+    {
+        std::string str;
+        if (getUnicodeString(o, str))
+        {
+            dv = dnn::DictValue(str);
+            return true;
+        }
+    }
+    return false;
 }
 
 template<>
@@ -181,7 +184,7 @@ public:
 
         PyObject* args = PyList_New(inputs.size());
         for(size_t i = 0; i < inputs.size(); ++i)
-            PyList_SET_ITEM(args, i, pyopencv_from_generic_vec(inputs[i]));
+            PyList_SetItem(args, i, pyopencv_from_generic_vec(inputs[i]));
 
         PyObject* res = PyObject_CallMethodObjArgs(o, PyString_FromString("getMemoryShapes"), args, NULL);
         Py_DECREF(args);

--- a/modules/flann/misc/python/pyopencv_flann.hpp
+++ b/modules/flann/misc/python/pyopencv_flann.hpp
@@ -27,20 +27,20 @@ bool pyopencv_to(PyObject *o, cv::flann::IndexParams& p, const char *name)
         return true;
 
     if(PyDict_Check(o)) {
-        while(PyDict_Next(o, &pos, &key, &item)) {
-            if( !PyString_Check(key) ) {
+        while(PyDict_Next(o, &pos, &key, &item))
+        {
+            // get key
+            std::string k;
+            if (!getUnicodeString(key, k))
+            {
                 ok = false;
                 break;
             }
-
-            String k = PyString_AsString(key);
-            if( PyString_Check(item) )
+            // get value
+            if( !!PyBool_Check(item) )
             {
-                const char* value = PyString_AsString(item);
-                p.setString(k, value);
-            }
-            else if( !!PyBool_Check(item) )
                 p.setBool(k, item == Py_True);
+            }
             else if( PyInt_Check(item) )
             {
                 int value = (int)PyInt_AsLong(item);
@@ -56,8 +56,13 @@ bool pyopencv_to(PyObject *o, cv::flann::IndexParams& p, const char *name)
             }
             else
             {
-                ok = false;
-                break;
+                std::string val_str;
+                if (!getUnicodeString(item, val_str))
+                {
+                    ok = false;
+                    break;
+                }
+                p.setString(k, val_str);
             }
         }
     }

--- a/modules/python/bindings/CMakeLists.txt
+++ b/modules/python/bindings/CMakeLists.txt
@@ -54,7 +54,6 @@ set(cv2_generated_files
     "${CMAKE_CURRENT_BINARY_DIR}/pyopencv_generated_include.h"
     "${CMAKE_CURRENT_BINARY_DIR}/pyopencv_generated_funcs.h"
     "${CMAKE_CURRENT_BINARY_DIR}/pyopencv_generated_types.h"
-    "${CMAKE_CURRENT_BINARY_DIR}/pyopencv_generated_type_reg.h"
     "${CMAKE_CURRENT_BINARY_DIR}/pyopencv_generated_ns_reg.h"
     "${OPENCV_PYTHON_SIGNATURES_FILE}"
 )

--- a/modules/python/bindings/CMakeLists.txt
+++ b/modules/python/bindings/CMakeLists.txt
@@ -51,10 +51,13 @@ if(NOT HAVE_CUDA)
 endif()
 
 set(cv2_generated_files
-    "${CMAKE_CURRENT_BINARY_DIR}/pyopencv_generated_include.h"
+    "${CMAKE_CURRENT_BINARY_DIR}/pyopencv_generated_enums.h"
     "${CMAKE_CURRENT_BINARY_DIR}/pyopencv_generated_funcs.h"
+    "${CMAKE_CURRENT_BINARY_DIR}/pyopencv_generated_include.h"
+    "${CMAKE_CURRENT_BINARY_DIR}/pyopencv_generated_modules.h"
+    "${CMAKE_CURRENT_BINARY_DIR}/pyopencv_generated_modules_content.h"
     "${CMAKE_CURRENT_BINARY_DIR}/pyopencv_generated_types.h"
-    "${CMAKE_CURRENT_BINARY_DIR}/pyopencv_generated_ns_reg.h"
+    "${CMAKE_CURRENT_BINARY_DIR}/pyopencv_generated_types_content.h"
     "${OPENCV_PYTHON_SIGNATURES_FILE}"
 )
 

--- a/modules/python/src2/cv2.cpp
+++ b/modules/python/src2/cv2.cpp
@@ -108,7 +108,7 @@ PyObject* pyopencv_from(const TYPE& src)                                        
 }
 
 #include "pyopencv_generated_include.h"
-// #include "opencv2/core/types_c.h"
+#include "opencv2/core/types_c.h"
 
 #include "opencv2/opencv_modules.hpp"
 

--- a/modules/python/src2/cv2.cpp
+++ b/modules/python/src2/cv2.cpp
@@ -5,6 +5,9 @@
 #pragma warning(push)
 #pragma warning(disable:5033)  // 'register' is no longer a supported storage class
 #endif
+
+// #define Py_LIMITED_API 0x03030000
+
 #include <math.h>
 #include <Python.h>
 #if defined(_MSC_VER) && (_MSC_VER > 1800)
@@ -105,7 +108,7 @@ PyObject* pyopencv_from(const TYPE& src)                                        
 }
 
 #include "pyopencv_generated_include.h"
-#include "opencv2/core/types_c.h"
+// #include "opencv2/core/types_c.h"
 
 #include "opencv2/opencv_modules.hpp"
 
@@ -337,7 +340,7 @@ static bool pyopencv_to(PyObject* o, Mat& m, const ArgInfo info)
         m = Mat(sz, 1, CV_64F);
         for( i = 0; i < sz; i++ )
         {
-            PyObject* oi = PyTuple_GET_ITEM(o, i);
+            PyObject* oi = PyTuple_GetItem(o, i);
             if( PyInt_Check(oi) )
                 m.at<double>(i) = (double)PyInt_AsLong(oi);
             else if( PyFloat_Check(oi) )
@@ -571,21 +574,26 @@ static PyObject* pyopencv_from(void*& ptr)
     return PyLong_FromVoidPtr(ptr);
 }
 
+struct SafeSeqItem
+{
+    PyObject * item;
+    SafeSeqItem(PyObject *obj, size_t idx) { item = PySequence_GetItem(obj, idx); }
+    ~SafeSeqItem() { Py_XDECREF(item); }
+};
+
 static bool pyopencv_to(PyObject *o, Scalar& s, const ArgInfo info)
 {
     if(!o || o == Py_None)
         return true;
     if (PySequence_Check(o)) {
-        PyObject *fi = PySequence_Fast(o, info.name);
-        if (fi == NULL)
-            return false;
-        if (4 < PySequence_Fast_GET_SIZE(fi))
+        if (4 < PySequence_Size(o))
         {
             failmsg("Scalar value for argument '%s' is longer than 4", info.name);
             return false;
         }
-        for (Py_ssize_t i = 0; i < PySequence_Fast_GET_SIZE(fi); i++) {
-            PyObject *item = PySequence_Fast_GET_ITEM(fi, i);
+        for (Py_ssize_t i = 0; i < PySequence_Size(o); i++) {
+            SafeSeqItem item_wrap(o, i);
+            PyObject *item = item_wrap.item;
             if (PyFloat_Check(item) || PyInt_Check(item)) {
                 s[(int)i] = PyFloat_AsDouble(item);
             } else {
@@ -593,7 +601,6 @@ static bool pyopencv_to(PyObject *o, Scalar& s, const ArgInfo info)
                 return false;
             }
         }
-        Py_DECREF(fi);
     } else {
         if (PyFloat_Check(o) || PyInt_Check(o)) {
             s[0] = PyFloat_AsDouble(o);
@@ -741,16 +748,18 @@ PyObject* pyopencv_from(const String& value)
 }
 
 template<>
-bool pyopencv_to(PyObject* obj, String& value, const char* name)
+bool pyopencv_to(PyObject* obj, String &value, const char* name)
 {
     CV_UNUSED(name);
     if(!obj || obj == Py_None)
         return true;
-    const char* str = PyString_AsString(obj);
-    if(!str)
-        return false;
-    value = String(str);
-    return true;
+    std::string str;
+    if (getUnicodeString(obj, str))
+    {
+        value = str;
+        return true;
+    }
+    return false;
 }
 
 template<>
@@ -821,36 +830,31 @@ bool pyopencv_to(PyObject* obj, Range& r, const char* name)
         return true;
     while (PySequence_Check(obj))
     {
-        PyObject *fi = PySequence_Fast(obj, name);
-        if (fi == NULL)
-            break;
-        if (2 != PySequence_Fast_GET_SIZE(fi))
+        if (2 != PySequence_Size(obj))
         {
             failmsg("Range value for argument '%s' is longer than 2", name);
-            Py_DECREF(fi);
             return false;
         }
         {
-            PyObject *item = PySequence_Fast_GET_ITEM(fi, 0);
+            SafeSeqItem item_wrap(obj, 0);
+            PyObject *item = item_wrap.item;
             if (PyInt_Check(item)) {
                 r.start = (int)PyInt_AsLong(item);
             } else {
                 failmsg("Range.start value for argument '%s' is not integer", name);
-                Py_DECREF(fi);
                 break;
             }
         }
         {
-            PyObject *item = PySequence_Fast_GET_ITEM(fi, 1);
+            SafeSeqItem item_wrap(obj, 1);
+            PyObject *item = item_wrap.item;
             if (PyInt_Check(item)) {
                 r.end = (int)PyInt_AsLong(item);
             } else {
                 failmsg("Range.end value for argument '%s' is not integer", name);
-                Py_DECREF(fi);
                 break;
             }
         }
-        Py_DECREF(fi);
         return true;
     }
     if(PyObject_Size(obj) == 0)
@@ -873,11 +877,10 @@ bool pyopencv_to(PyObject* obj, Point& p, const char* name)
     CV_UNUSED(name);
     if(!obj || obj == Py_None)
         return true;
-    if(!!PyComplex_CheckExact(obj))
+    if(PyComplex_Check(obj))
     {
-        Py_complex c = PyComplex_AsCComplex(obj);
-        p.x = saturate_cast<int>(c.real);
-        p.y = saturate_cast<int>(c.imag);
+        p.x = saturate_cast<int>(PyComplex_RealAsDouble(obj));
+        p.y = saturate_cast<int>(PyComplex_ImagAsDouble(obj));
         return true;
     }
     return PyArg_ParseTuple(obj, "ii", &p.x, &p.y) > 0;
@@ -889,11 +892,10 @@ bool pyopencv_to(PyObject* obj, Point2f& p, const char* name)
     CV_UNUSED(name);
     if(!obj || obj == Py_None)
         return true;
-    if(!!PyComplex_CheckExact(obj))
+    if (PyComplex_Check(obj))
     {
-        Py_complex c = PyComplex_AsCComplex(obj);
-        p.x = saturate_cast<float>(c.real);
-        p.y = saturate_cast<float>(c.imag);
+        p.x = saturate_cast<float>(PyComplex_RealAsDouble(obj));
+        p.y = saturate_cast<float>(PyComplex_ImagAsDouble(obj));
         return true;
     }
     return PyArg_ParseTuple(obj, "ff", &p.x, &p.y) > 0;
@@ -905,11 +907,10 @@ bool pyopencv_to(PyObject* obj, Point2d& p, const char* name)
     CV_UNUSED(name);
     if(!obj || obj == Py_None)
         return true;
-    if(!!PyComplex_CheckExact(obj))
+    if(PyComplex_Check(obj))
     {
-        Py_complex c = PyComplex_AsCComplex(obj);
-        p.x = saturate_cast<double>(c.real);
-        p.y = saturate_cast<double>(c.imag);
+        p.x = PyComplex_RealAsDouble(obj);
+        p.y = PyComplex_ImagAsDouble(obj);
         return true;
     }
     return PyArg_ParseTuple(obj, "dd", &p.x, &p.y) > 0;
@@ -1136,9 +1137,41 @@ PyObject* pyopencv_from(const Point3d& p)
 
 template<typename _Tp> struct pyopencvVecConverter
 {
+    typedef typename DataType<_Tp>::channel_type _Cp;
+    static inline bool copyOneItem(PyObject *obj, size_t start, int channels, _Cp * data)
+    {
+        for(size_t j = 0; (int)j < channels; j++ )
+        {
+            SafeSeqItem sub_item_wrap(obj, start + j);
+            PyObject* item_ij = sub_item_wrap.item;
+            if( PyInt_Check(item_ij))
+            {
+                int v = (int)PyInt_AsLong(item_ij);
+                if( v == -1 && PyErr_Occurred() )
+                    return false;
+                data[j] = saturate_cast<_Cp>(v);
+            }
+            else if( PyLong_Check(item_ij))
+            {
+                int v = (int)PyLong_AsLong(item_ij);
+                if( v == -1 && PyErr_Occurred() )
+                    return false;
+                data[j] = saturate_cast<_Cp>(v);
+            }
+            else if( PyFloat_Check(item_ij))
+            {
+                double v = PyFloat_AsDouble(item_ij);
+                if( PyErr_Occurred() )
+                    return false;
+                data[j] = saturate_cast<_Cp>(v);
+            }
+            else
+                return false;
+        }
+        return true;
+    }
     static bool to(PyObject* obj, std::vector<_Tp>& value, const ArgInfo info)
     {
-        typedef typename DataType<_Tp>::channel_type _Cp;
         if(!obj || obj == Py_None)
             return true;
         if (PyArray_Check(obj))
@@ -1146,92 +1179,63 @@ template<typename _Tp> struct pyopencvVecConverter
             Mat m;
             pyopencv_to(obj, m, info);
             m.copyTo(value);
+            return true;
         }
-        if (!PySequence_Check(obj))
-            return false;
-        PyObject *seq = PySequence_Fast(obj, info.name);
-        if (seq == NULL)
-            return false;
-        int i, j, n = (int)PySequence_Fast_GET_SIZE(seq);
-        value.resize(n);
-
-        int type = traits::Type<_Tp>::value;
-        int depth = CV_MAT_DEPTH(type), channels = CV_MAT_CN(type);
-        PyObject** items = PySequence_Fast_ITEMS(seq);
-
-        for( i = 0; i < n; i++ )
+        else if (PySequence_Check(obj))
         {
-            PyObject* item = items[i];
-            PyObject* seq_i = 0;
-            PyObject** items_i = &item;
-            _Cp* data = (_Cp*)&value[i];
-
-            if( channels == 2 && PyComplex_CheckExact(item) )
+            const int type = traits::Type<_Tp>::value;
+            const int depth = CV_MAT_DEPTH(type), channels = CV_MAT_CN(type);
+            size_t i, n = PySequence_Size(obj);
+            value.resize(n);
+            for (i = 0; i < n; i++ )
             {
-                Py_complex c = PyComplex_AsCComplex(obj);
-                data[0] = saturate_cast<_Cp>(c.real);
-                data[1] = saturate_cast<_Cp>(c.imag);
-                continue;
-            }
-            if( channels > 1 )
-            {
-                if( PyArray_Check(item))
-                {
-                    Mat src;
-                    pyopencv_to(item, src, info);
-                    if( src.dims != 2 || src.channels() != 1 ||
-                       ((src.cols != 1 || src.rows != channels) &&
-                        (src.cols != channels || src.rows != 1)))
-                        break;
-                    Mat dst(src.rows, src.cols, depth, data);
-                    src.convertTo(dst, type);
-                    if( dst.data != (uchar*)data )
-                        break;
-                    continue;
-                }
+                SafeSeqItem item_wrap(obj, i);
+                PyObject* item = item_wrap.item;
+                _Cp* data = (_Cp*)&value[i];
 
-                seq_i = PySequence_Fast(item, info.name);
-                if( !seq_i || (int)PySequence_Fast_GET_SIZE(seq_i) != channels )
+                if( channels == 2 && PyComplex_Check(item) )
                 {
-                    Py_XDECREF(seq_i);
-                    break;
+                    data[0] = saturate_cast<_Cp>(PyComplex_RealAsDouble(item));
+                    data[1] = saturate_cast<_Cp>(PyComplex_ImagAsDouble(item));
                 }
-                items_i = PySequence_Fast_ITEMS(seq_i);
-            }
-
-            for( j = 0; j < channels; j++ )
-            {
-                PyObject* item_ij = items_i[j];
-                if( PyInt_Check(item_ij))
+                else if( channels > 1 )
                 {
-                    int v = (int)PyInt_AsLong(item_ij);
-                    if( v == -1 && PyErr_Occurred() )
+                    if( PyArray_Check(item))
+                    {
+                        Mat src;
+                        pyopencv_to(item, src, info);
+                        if( src.dims != 2 || src.channels() != 1 ||
+                           ((src.cols != 1 || src.rows != channels) &&
+                            (src.cols != channels || src.rows != 1)))
+                            break;
+                        Mat dst(src.rows, src.cols, depth, data);
+                        src.convertTo(dst, type);
+                        if( dst.data != (uchar*)data )
+                            break;
+                    }
+                    else if (PySequence_Check(item))
+                    {
+                        if (!copyOneItem(item, 0, channels, data))
+                            break;
+                    }
+                    else
+                    {
                         break;
-                    data[j] = saturate_cast<_Cp>(v);
+                    }
                 }
-                else if( PyLong_Check(item_ij))
+                else if (channels == 1)
                 {
-                    int v = (int)PyLong_AsLong(item_ij);
-                    if( v == -1 && PyErr_Occurred() )
+                    if (!copyOneItem(obj, i, channels, data))
                         break;
-                    data[j] = saturate_cast<_Cp>(v);
-                }
-                else if( PyFloat_Check(item_ij))
-                {
-                    double v = PyFloat_AsDouble(item_ij);
-                    if( PyErr_Occurred() )
-                        break;
-                    data[j] = saturate_cast<_Cp>(v);
                 }
                 else
+                {
                     break;
+                }
             }
-            Py_XDECREF(seq_i);
-            if( j < channels )
-                break;
+            return i == n;
         }
-        Py_DECREF(seq);
-        return i == n;
+        return false;
     }
 
     static PyObject* from(const std::vector<_Tp>& value)
@@ -1263,22 +1267,15 @@ template<typename _Tp> static inline bool pyopencv_to_generic_vec(PyObject* obj,
        return true;
     if (!PySequence_Check(obj))
         return false;
-    PyObject *seq = PySequence_Fast(obj, info.name);
-    if (seq == NULL)
-        return false;
-    int i, n = (int)PySequence_Fast_GET_SIZE(seq);
+    size_t n = PySequence_Size(obj);
     value.resize(n);
-
-    PyObject** items = PySequence_Fast_ITEMS(seq);
-
-    for( i = 0; i < n; i++ )
+    for(size_t i = 0; i < n; i++ )
     {
-        PyObject* item = items[i];
-        if(!pyopencv_to(item, value[i], info))
-            break;
+        SafeSeqItem item_wrap(obj, i);
+        if(!pyopencv_to(item_wrap.item, value[i], info))
+            return false;
     }
-    Py_DECREF(seq);
-    return i == n;
+    return true;
 }
 
 template<typename _Tp> static inline PyObject* pyopencv_from_generic_vec(const std::vector<_Tp>& value)
@@ -1290,7 +1287,7 @@ template<typename _Tp> static inline PyObject* pyopencv_from_generic_vec(const s
         PyObject* item = pyopencv_from(value[i]);
         if(!item)
             break;
-        PyList_SET_ITEM(seq, i, item);
+        PyList_SetItem(seq, i, item);
     }
     if( i < n )
     {
@@ -1669,20 +1666,15 @@ static PyObject *pycvCreateButton(PyObject*, PyObject *args, PyObject *kw)
 
 static int convert_to_char(PyObject *o, char *dst, const char *name = "no_name")
 {
-  if (PyString_Check(o) && PyString_Size(o) == 1) {
-    *dst = PyString_AsString(o)[0];
-    return 1;
-  } else {
+    std::string str;
+    if (getUnicodeString(o, str))
+    {
+        *dst = str[0];
+        return 1;
+    }
     (*dst) = 0;
     return failmsg("Expected single character string for argument '%s'", name);
-  }
 }
-
-#if PY_MAJOR_VERSION >= 3
-#define MKTYPE2(NAME) pyopencv_##NAME##_specials(); if (!to_ok(&pyopencv_##NAME##_Type)) return NULL;
-#else
-#define MKTYPE2(NAME) pyopencv_##NAME##_specials(); if (!to_ok(&pyopencv_##NAME##_Type)) return
-#endif
 
 #ifdef __GNUC__
 #  pragma GCC diagnostic ignored "-Wunused-parameter"
@@ -1768,9 +1760,83 @@ static int to_ok(PyTypeObject *to)
   return (PyType_Ready(to) == 0);
 }
 
+static bool init_body(PyObject * m)
+{
+#define MKTYPE2(NAME) pyopencv_##NAME##_specials(); if (!to_ok(&pyopencv_##NAME##_Type)) return false
+    #include "pyopencv_generated_type_reg.h"
+#undef MKTYPE2
+
+    init_submodules(m); // from "pyopencv_generated_ns_reg.h"
+
+    PyObject* d = PyModule_GetDict(m);
+
+    PyDict_SetItemString(d, "__version__", PyString_FromString(CV_VERSION));
+
+    PyObject *opencv_error_dict = PyDict_New();
+    PyDict_SetItemString(opencv_error_dict, "file", Py_None);
+    PyDict_SetItemString(opencv_error_dict, "func", Py_None);
+    PyDict_SetItemString(opencv_error_dict, "line", Py_None);
+    PyDict_SetItemString(opencv_error_dict, "code", Py_None);
+    PyDict_SetItemString(opencv_error_dict, "msg", Py_None);
+    PyDict_SetItemString(opencv_error_dict, "err", Py_None);
+    opencv_error = PyErr_NewException((char*)MODULESTR".error", NULL, opencv_error_dict);
+    Py_DECREF(opencv_error_dict);
+    PyDict_SetItemString(d, "error", opencv_error);
 
 #if PY_MAJOR_VERSION >= 3
-extern "C" CV_EXPORTS PyObject* PyInit_cv2();
+#define PUBLISH_OBJECT(name, type) Py_INCREF(&type); PyModule_AddObject(m, name, (PyObject *)&type);
+#else
+// Unrolled Py_INCREF(&type) without (PyObject*) cast
+// due to "warning: dereferencing type-punned pointer will break strict-aliasing rules"
+#define PUBLISH_OBJECT(name, type) _Py_INC_REFTOTAL _Py_REF_DEBUG_COMMA (&type)->ob_refcnt++; PyModule_AddObject(m, name, (PyObject *)&type);
+#endif
+#include "pyopencv_generated_type_publish.h"
+#undef PUBLISH_OBJECT
+
+#define PUBLISH(I) PyDict_SetItemString(d, #I, PyInt_FromLong(I))
+    PUBLISH(CV_8U);
+    PUBLISH(CV_8UC1);
+    PUBLISH(CV_8UC2);
+    PUBLISH(CV_8UC3);
+    PUBLISH(CV_8UC4);
+    PUBLISH(CV_8S);
+    PUBLISH(CV_8SC1);
+    PUBLISH(CV_8SC2);
+    PUBLISH(CV_8SC3);
+    PUBLISH(CV_8SC4);
+    PUBLISH(CV_16U);
+    PUBLISH(CV_16UC1);
+    PUBLISH(CV_16UC2);
+    PUBLISH(CV_16UC3);
+    PUBLISH(CV_16UC4);
+    PUBLISH(CV_16S);
+    PUBLISH(CV_16SC1);
+    PUBLISH(CV_16SC2);
+    PUBLISH(CV_16SC3);
+    PUBLISH(CV_16SC4);
+    PUBLISH(CV_32S);
+    PUBLISH(CV_32SC1);
+    PUBLISH(CV_32SC2);
+    PUBLISH(CV_32SC3);
+    PUBLISH(CV_32SC4);
+    PUBLISH(CV_32F);
+    PUBLISH(CV_32FC1);
+    PUBLISH(CV_32FC2);
+    PUBLISH(CV_32FC3);
+    PUBLISH(CV_32FC4);
+    PUBLISH(CV_64F);
+    PUBLISH(CV_64FC1);
+    PUBLISH(CV_64FC2);
+    PUBLISH(CV_64FC3);
+    PUBLISH(CV_64FC4);
+#undef PUBLISH
+
+    return true;
+}
+
+#if PY_MAJOR_VERSION >= 3
+// === Python 3
+
 static struct PyModuleDef cv2_moduledef =
 {
     PyModuleDef_HEAD_INIT,
@@ -1781,92 +1847,24 @@ static struct PyModuleDef cv2_moduledef =
     special_methods
 };
 
+extern "C" CV_EXPORTS PyObject* PyInit_cv2();
 PyObject* PyInit_cv2()
-#else
-extern "C" CV_EXPORTS void initcv2();
-
-void initcv2()
-#endif
 {
-  import_array();
-
-#include "pyopencv_generated_type_reg.h"
-
-#if PY_MAJOR_VERSION >= 3
-  PyObject* m = PyModule_Create(&cv2_moduledef);
-#else
-  PyObject* m = Py_InitModule(MODULESTR, special_methods);
-#endif
-  init_submodules(m); // from "pyopencv_generated_ns_reg.h"
-
-  PyObject* d = PyModule_GetDict(m);
-
-  PyDict_SetItemString(d, "__version__", PyString_FromString(CV_VERSION));
-
-  PyObject *opencv_error_dict = PyDict_New();
-  PyDict_SetItemString(opencv_error_dict, "file", Py_None);
-  PyDict_SetItemString(opencv_error_dict, "func", Py_None);
-  PyDict_SetItemString(opencv_error_dict, "line", Py_None);
-  PyDict_SetItemString(opencv_error_dict, "code", Py_None);
-  PyDict_SetItemString(opencv_error_dict, "msg", Py_None);
-  PyDict_SetItemString(opencv_error_dict, "err", Py_None);
-  opencv_error = PyErr_NewException((char*)MODULESTR".error", NULL, opencv_error_dict);
-  Py_DECREF(opencv_error_dict);
-  PyDict_SetItemString(d, "error", opencv_error);
-
-#if PY_MAJOR_VERSION >= 3
-#define PUBLISH_OBJECT(name, type) Py_INCREF(&type);\
-  PyModule_AddObject(m, name, (PyObject *)&type);
-#else
-// Unrolled Py_INCREF(&type) without (PyObject*) cast
-// due to "warning: dereferencing type-punned pointer will break strict-aliasing rules"
-#define PUBLISH_OBJECT(name, type) _Py_INC_REFTOTAL _Py_REF_DEBUG_COMMA (&type)->ob_refcnt++;\
-  PyModule_AddObject(m, name, (PyObject *)&type);
-#endif
-
-#include "pyopencv_generated_type_publish.h"
-
-#define PUBLISH(I) PyDict_SetItemString(d, #I, PyInt_FromLong(I))
-//#define PUBLISHU(I) PyDict_SetItemString(d, #I, PyLong_FromUnsignedLong(I))
-#define PUBLISH2(I, value) PyDict_SetItemString(d, #I, PyLong_FromLong(value))
-
-  PUBLISH(CV_8U);
-  PUBLISH(CV_8UC1);
-  PUBLISH(CV_8UC2);
-  PUBLISH(CV_8UC3);
-  PUBLISH(CV_8UC4);
-  PUBLISH(CV_8S);
-  PUBLISH(CV_8SC1);
-  PUBLISH(CV_8SC2);
-  PUBLISH(CV_8SC3);
-  PUBLISH(CV_8SC4);
-  PUBLISH(CV_16U);
-  PUBLISH(CV_16UC1);
-  PUBLISH(CV_16UC2);
-  PUBLISH(CV_16UC3);
-  PUBLISH(CV_16UC4);
-  PUBLISH(CV_16S);
-  PUBLISH(CV_16SC1);
-  PUBLISH(CV_16SC2);
-  PUBLISH(CV_16SC3);
-  PUBLISH(CV_16SC4);
-  PUBLISH(CV_32S);
-  PUBLISH(CV_32SC1);
-  PUBLISH(CV_32SC2);
-  PUBLISH(CV_32SC3);
-  PUBLISH(CV_32SC4);
-  PUBLISH(CV_32F);
-  PUBLISH(CV_32FC1);
-  PUBLISH(CV_32FC2);
-  PUBLISH(CV_32FC3);
-  PUBLISH(CV_32FC4);
-  PUBLISH(CV_64F);
-  PUBLISH(CV_64FC1);
-  PUBLISH(CV_64FC2);
-  PUBLISH(CV_64FC3);
-  PUBLISH(CV_64FC4);
-
-#if PY_MAJOR_VERSION >= 3
+    import_array(); // from numpy
+    PyObject* m = PyModule_Create(&cv2_moduledef);
+    if (!init_body(m))
+        return NULL;
     return m;
-#endif
 }
+
+#else
+// === Python 2
+extern "C" CV_EXPORTS void initcv2();
+void initcv2()
+{
+    import_array(); // from numpy
+    PyObject* m = Py_InitModule(MODULESTR, special_methods);
+    init_body(m);
+}
+
+#endif

--- a/modules/python/src2/cv2.cpp
+++ b/modules/python/src2/cv2.cpp
@@ -1675,17 +1675,17 @@ static int convert_to_char(PyObject *o, char *dst, const char *name = "no_name")
 #  pragma GCC diagnostic ignored "-Wmissing-field-initializers"
 #endif
 
-#define CVPY_TYPE(name, name2) \
-    CVPY_TYPE_DECLARE(name, name2) \
-    CVPY_TYPE_REGISTER_STATIC(name)
 
 #include "pyopencv_generated_enums.h"
 #include "pyopencv_custom_headers.h"
-#include "pyopencv_generated_type_publish.h"
+
+#define CVPY_TYPE(NAME, STORAGE) CVPY_TYPE_DECLARE(NAME, STORAGE) CVPY_TYPE_REGISTER_STATIC(NAME)
 #include "pyopencv_generated_types.h"
+#undef CVPY_TYPE
+
+#include "pyopencv_generated_types_content.h"
 #include "pyopencv_generated_funcs.h"
 
-#undef CVPY_TYPE
 
 static PyMethodDef special_methods[] = {
   {"redirectError", CV_PY_FN_WITH_KW(pycvRedirectError), "redirectError(onError) -> None"},
@@ -1751,18 +1751,21 @@ static void init_submodule(PyObject * root, const char * name, PyMethodDef * met
 
 }
 
-#include "pyopencv_generated_ns_reg.h"
+#include "pyopencv_generated_modules_content.h"
 
 static bool init_body(PyObject * m)
 {
+#define CVPY_MODULE(NAMESTR, NAME) \
+    init_submodule(m, MODULESTR NAMESTR, methods_##NAME, consts_##NAME)
+#include "pyopencv_generated_modules.h"
+#undef CVPY_MODULE
 
-    init_submodules(m); // from "pyopencv_generated_ns_reg.h"
-
-#define CVPY_TYPE(name, name2) CVPY_TYPE_INIT_STATIC(name, return false)
-#include "pyopencv_generated_type_publish.h"
+#define CVPY_TYPE(NAME, _) CVPY_TYPE_INIT_STATIC(NAME, return false)
+#include "pyopencv_generated_types.h"
 #undef CVPY_TYPE
 
     PyObject* d = PyModule_GetDict(m);
+
 
     PyDict_SetItemString(d, "__version__", PyString_FromString(CV_VERSION));
 

--- a/modules/python/src2/cv2.cpp
+++ b/modules/python/src2/cv2.cpp
@@ -6,7 +6,7 @@
 #pragma warning(disable:5033)  // 'register' is no longer a supported storage class
 #endif
 
-#define CVPY_DYNAMIC_INIT
+// #define CVPY_DYNAMIC_INIT
 // #define Py_DEBUG
 
 #if defined(CVPY_DYNAMIC_INIT) && !defined(Py_DEBUG)

--- a/modules/python/src2/cv2.cpp
+++ b/modules/python/src2/cv2.cpp
@@ -1679,7 +1679,7 @@ static int convert_to_char(PyObject *o, char *dst, const char *name = "no_name")
 #include "pyopencv_generated_enums.h"
 #include "pyopencv_custom_headers.h"
 
-#define CVPY_TYPE(NAME, STORAGE) CVPY_TYPE_DECLARE(NAME, STORAGE) CVPY_TYPE_REGISTER_STATIC(NAME)
+#define CVPY_TYPE(NAME, STORAGE, SNAME) CVPY_TYPE_DECLARE(NAME, STORAGE, SNAME)
 #include "pyopencv_generated_types.h"
 #undef CVPY_TYPE
 
@@ -1760,7 +1760,7 @@ static bool init_body(PyObject * m)
 #include "pyopencv_generated_modules.h"
 #undef CVPY_MODULE
 
-#define CVPY_TYPE(NAME, _) CVPY_TYPE_INIT_STATIC(NAME, return false)
+#define CVPY_TYPE(NAME, _1, _2) CVPY_TYPE_INIT_STATIC(NAME, return false)
 #include "pyopencv_generated_types.h"
 #undef CVPY_TYPE
 

--- a/modules/python/src2/gen2.py
+++ b/modules/python/src2/gen2.py
@@ -859,7 +859,6 @@ class PythonWrapperGenerator(object):
         self.code_enums = StringIO()
         self.code_types = StringIO()
         self.code_funcs = StringIO()
-        self.code_type_reg = StringIO()
         self.code_ns_reg = StringIO()
         self.code_type_publish = StringIO()
         self.py_signatures = dict()
@@ -1123,8 +1122,7 @@ class PythonWrapperGenerator(object):
             code = classinfo.gen_code(self)
             self.code_types.write(code)
             if not classinfo.ismap:
-                self.code_type_reg.write("MKTYPE2(%s);\n" % (classinfo.name,) )
-                self.code_type_publish.write("PUBLISH_OBJECT(\"{name}\", pyopencv_{name}_Type);\n".format(name=classinfo.name))
+                self.code_type_publish.write("PUBLISH_OBJECT({});\n".format(classinfo.name))
 
         # step 3: generate the code for all the global functions
         for ns_name, ns in sorted(self.namespaces.items()):
@@ -1155,7 +1153,6 @@ class PythonWrapperGenerator(object):
         self.save(output_path, "pyopencv_generated_funcs.h", self.code_funcs)
         self.save(output_path, "pyopencv_generated_enums.h", self.code_enums)
         self.save(output_path, "pyopencv_generated_types.h", self.code_types)
-        self.save(output_path, "pyopencv_generated_type_reg.h", self.code_type_reg)
         self.save(output_path, "pyopencv_generated_ns_reg.h", self.code_ns_reg)
         self.save(output_path, "pyopencv_generated_type_publish.h", self.code_type_publish)
         self.save_json(output_path, "pyopencv_signatures.json", self.py_signatures)

--- a/modules/python/src2/gen2.py
+++ b/modules/python/src2/gen2.py
@@ -307,7 +307,7 @@ class ClassInfo(object):
         return "CVPY_TYPE({}, {}, {}, {}, {});\n".format(
             self.name,
             self.cname if self.issimple else "Ptr<{}>".format(self.cname),
-            self.sname if self.issimple else "Ptr<{}>".format(self.cname),
+            self.sname if self.issimple else "Ptr",
             baseptr,
             constructor_name
         )

--- a/modules/python/src2/gen2.py
+++ b/modules/python/src2/gen2.py
@@ -50,8 +50,6 @@ gen_template_func_body = Template("""$code_decl
     }
 """)
 
-head_init_str = "CV_PYTHON_TYPE_HEAD_INIT()"
-
 gen_template_simple_type_decl = Template("""
 struct pyopencv_${name}_t
 {
@@ -59,12 +57,7 @@ struct pyopencv_${name}_t
     ${cname} v;
 };
 
-static PyTypeObject pyopencv_${name}_Type =
-{
-    %s
-    MODULESTR".$wname",
-    sizeof(pyopencv_${name}_t),
-};
+REGISTER_TYPE(${name}, $wname)
 
 static void pyopencv_${name}_dealloc(PyObject* self)
 {
@@ -95,7 +88,7 @@ struct PyOpenCV_Converter< ${cname} >
         return false;
     }
 };
-""" % head_init_str)
+""")
 
 gen_template_mappable = Template("""
     {
@@ -114,12 +107,7 @@ struct pyopencv_${name}_t
     Ptr<${cname1}> v;
 };
 
-static PyTypeObject pyopencv_${name}_Type =
-{
-    %s
-    MODULESTR".$wname",
-    sizeof(pyopencv_${name}_t),
-};
+REGISTER_TYPE(${name}, $wname)
 
 static void pyopencv_${name}_dealloc(PyObject* self)
 {
@@ -153,7 +141,7 @@ struct PyOpenCV_Converter< Ptr<${cname}> >
     }
 };
 
-""" % head_init_str)
+""")
 
 gen_template_map_type_cvt = Template("""
 template<> bool pyopencv_to(PyObject* src, ${cname}& dst, const char* name);

--- a/modules/python/src2/pycompat.hpp
+++ b/modules/python/src2/pycompat.hpp
@@ -102,33 +102,33 @@ static inline bool getUnicodeString(PyObject * obj, std::string &str)
 #endif
 
 
-#define CVPY_TYPE_DECLARE(name, name2) \
-    struct pyopencv_##name##_t \
+#define CVPY_TYPE_DECLARE(NAME, STORAGE) \
+    struct pyopencv_##NAME##_t \
     { \
         PyObject_HEAD \
-        name2 v; \
+        STORAGE v; \
     }; \
 
-#define CVPY_TYPE_REGISTER_STATIC(name) \
-    static PyTypeObject pyopencv_##name##_Type = \
+#define CVPY_TYPE_REGISTER_STATIC(NAME) \
+    static PyTypeObject pyopencv_##NAME##_Type = \
     { \
         CVPY_TYPE_HEAD \
-        MODULESTR"."#name, \
-        sizeof(pyopencv_##name##_t), \
+        MODULESTR"."#NAME, \
+        sizeof(pyopencv_##NAME##_t), \
     };
 
-#define CVPY_TYPE_INIT_STATIC(name, err_code) \
+#define CVPY_TYPE_INIT_STATIC(NAME, ERROR_HANDLER) \
     { \
-        pyopencv_##name##_specials(); \
-        pyopencv_##name##_Type.tp_alloc = PyType_GenericAlloc; \
-        pyopencv_##name##_Type.tp_new = PyType_GenericNew; \
-        pyopencv_##name##_Type.tp_flags = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE; \
-        if (PyType_Ready(&pyopencv_##name##_Type) != 0) \
+        pyopencv_##NAME##_specials(); \
+        pyopencv_##NAME##_Type.tp_alloc = PyType_GenericAlloc; \
+        pyopencv_##NAME##_Type.tp_new = PyType_GenericNew; \
+        pyopencv_##NAME##_Type.tp_flags = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE; \
+        if (PyType_Ready(&pyopencv_##NAME##_Type) != 0) \
         { \
-            err_code; \
+            ERROR_HANDLER; \
         } \
-        CVPY_TYPE_INCREF(pyopencv_##name##_Type); \
-        PyModule_AddObject(m, #name, (PyObject *)&pyopencv_##name##_Type); \
+        CVPY_TYPE_INCREF(pyopencv_##NAME##_Type); \
+        PyModule_AddObject(m, #NAME, (PyObject *)&pyopencv_##NAME##_Type); \
     }
 
 

--- a/modules/python/src2/pycompat.hpp
+++ b/modules/python/src2/pycompat.hpp
@@ -115,6 +115,15 @@ static inline bool getUnicodeString(PyObject * obj, std::string &str)
         sizeof(pyopencv_##NAME##_t), \
     }; \
     static PyTypeObject * pyopencv_##NAME##_TypePtr = &pyopencv_##NAME##_TypeXXX; \
+    static bool pyopencv_##NAME##_getp(PyObject * self, STORAGE * & dst) \
+    { \
+        if (PyObject_TypeCheck(self, pyopencv_##NAME##_TypePtr)) \
+        { \
+            dst = &(((pyopencv_##NAME##_t*)self)->v); \
+            return true; \
+        } \
+        return false; \
+    } \
     static PyObject * pyopencv_##NAME##_Instance(const STORAGE &r) \
     { \
         pyopencv_##NAME##_t *m = PyObject_NEW(pyopencv_##NAME##_t, pyopencv_##NAME##_TypePtr); \


### PR DESCRIPTION
Supersedes #14120 

### This pullrequest changes

* moved some generated code details from gen2.py to C++ macros which can be switched to enable Py_LIMITED_API (see pycompat.hpp, define `CVPY_DYNAMIC_INIT`).

On next stage I'm going to add cmake support for single Python3 module building.

