### PR TITLE
core: add custom deallocator for Mat

### DIFF
--- a/modules/core/include/opencv2/core/mat.hpp
+++ b/modules/core/include/opencv2/core/mat.hpp
@@ -55,6 +55,7 @@
 
 #ifdef CV_CXX11
 #include <type_traits>
+#include <functional>
 #endif
 
 namespace cv
@@ -2089,6 +2090,17 @@ public:
     template<typename _Tp, typename Functor> void forEach(const Functor& operation);
     /** @overload */
     template<typename _Tp, typename Functor> void forEach(const Functor& operation) const;
+
+    /** @brief A user defined deallocator.
+
+    The customDeallocator will be called when this object goes out of scope (Mat's destructor is called).
+    This is useful when Mat() is constructed with a user's data that requires special care for deallocating.
+
+    customDeallocator has to be a function pointer, a function object or a lambda(C++11).
+     */
+#ifdef CV_CXX11
+    std::function<void()> customDeallocator;
+#endif
 
 #ifdef CV_CXX_MOVE_SEMANTICS
     Mat(Mat&& m);

--- a/modules/core/include/opencv2/core/mat.inl.hpp
+++ b/modules/core/include/opencv2/core/mat.inl.hpp
@@ -770,6 +770,10 @@ inline
 Mat::~Mat()
 {
     release();
+#ifdef CV_CXX11
+    if (customDeallocator)
+        customDeallocator();
+#endif
     if( step.p != step.buf )
         fastFree(step.p);
 }


### PR DESCRIPTION
added an std::function<>() as a member variable to class Mat() to let
the developer uses their own custom deallocator.
This is useful when Mat() is constructed with user-defined data which
needs special care for deallocating.

Fixes: https://github.com/opencv/opencv/issues/14178

<!-- Please use this line to close one or multiple issues when this pullrequest gets merged
You can add another line right under the first one:
resolves #1234
resolves #1235
-->

### This pullrequest changes

<!-- Please describe what your pullrequest is changing -->
- [x] build successfully
- [x] `make test` successfully
- [x] added tests