### PR TITLE
core:vsx fix sum of v_reduce_sad

### DIFF
--- a/modules/core/include/opencv2/core/hal/intrin_vsx.hpp
+++ b/modules/core/include/opencv2/core/hal/intrin_vsx.hpp
@@ -763,7 +763,7 @@ inline unsigned v_reduce_sad(const v_int8x16& a, const v_int8x16& b)
 inline unsigned v_reduce_sad(const v_uint16x8& a, const v_uint16x8& b)
 {
     vec_ushort8 ad = vec_absd(a.val, b.val);
-    VSX_UNUSED(vec_int4) sum = vec_sums(vec_int4_c(vec_unpackhu(ad)), vec_int4_c(vec_unpacklu(ad)));
+    VSX_UNUSED(vec_int4) sum = vec_sums(vec_int4_c(vec_unpackhu(ad)) + vec_int4_c(vec_unpacklu(ad)), vec_int4_z);
     return (unsigned)vec_extract(sum, 3);
 }
 inline unsigned v_reduce_sad(const v_int16x8& a, const v_int16x8& b)


### PR DESCRIPTION
### Test failure 

```BASH

List failed tests (first 10):

    hal_intrin128.uint16x8_BASELINE :

    SIMD128: void opencv_test::hal::intrin128::cpu_baseline::test_hal_intrin_uint16()
    /worker/buildbot/Power9_Linux_gcc-6__opencv/opencv/modules/core/test/test_intrin_utils.hpp:778: Failure
    Expected equality of these values:
      (unsigned)(R::nlanes*R::nlanes/4)
        Which is: 16
      v_reduce_sad(a, b)
        Which is: 10


````

````
force_builders_only=Custom
buildworker:Custom=linux-1,linux-2,linux-4
docker_image:Custom=powerpc64le
pw_compilers=gcc-4.9, gcc-5, power9_gcc-6, power9_gcc-7
````