### PR TITLE
Support very old V4L

### DIFF
--- a/modules/videoio/src/cap_v4l.cpp
+++ b/modules/videoio/src/cap_v4l.cpp
@@ -251,6 +251,13 @@ make & enjoy!
 #define V4L2_CID_MPEG_VIDEO_H264_VUI_EXT_SAR_WIDTH (V4L2_CID_MPEG_BASE+365)
 #endif
 
+#ifndef V4L2_CID_ROTATE
+#define V4L2_CID_ROTATE (V4L2_CID_BASE+34)
+#endif
+#ifndef V4L2_CID_IRIS_ABSOLUTE
+#define V4L2_CID_IRIS_ABSOLUTE (V4L2_CID_CAMERA_CLASS_BASE+17)
+#endif
+
 /* Defaults - If your board can do better, set it here.  Set for the most common type inputs. */
 #define DEFAULT_V4L_WIDTH  640
 #define DEFAULT_V4L_HEIGHT 480


### PR DESCRIPTION
Related #13969
Resolves #14439

### This pullrequest changes

Build with enabled V4L2 failed on CentOS 6.10 (docker image `condaforge/linux-anvil-comp7`):
```
../modules/videoio/src/cap_v4l.cpp: In function 'int cv::capPropertyToV4L2(int)':
../modules/videoio/src/cap_v4l.cpp:1614:16: error: 'V4L2_CID_ROTATE' was not declared in this scope
         return V4L2_CID_ROTATE;
                ^~~~~~~~~~~~~~~
../modules/videoio/src/cap_v4l.cpp:1614:16: note: suggested alternative: 'V4L2_CID_BASE'
         return V4L2_CID_ROTATE;
                ^~~~~~~~~~~~~~~
                V4L2_CID_BASE
../modules/videoio/src/cap_v4l.cpp:1616:16: error: 'V4L2_CID_IRIS_ABSOLUTE' was not declared in this scope
         return V4L2_CID_IRIS_ABSOLUTE;
                ^~~~~~~~~~~~~~~~~~~~~~
../modules/videoio/src/cap_v4l.cpp:1616:16: note: suggested alternative: 'V4L2_CID_FOCUS_ABSOLUTE'
         return V4L2_CID_IRIS_ABSOLUTE;
                ^~~~~~~~~~~~~~~~~~~~~~
                V4L2_CID_FOCUS_ABSOLUTE
```
