### PR TITLE
ts: silence zero memory usage messages

### DIFF
--- a/modules/ts/src/ts.cpp
+++ b/modules/ts/src/ts.cpp
@@ -790,7 +790,10 @@ void testTearDown()
     {
         size_t peak = malloc_peak();
         memory_usage = peak - memory_usage_base;
-        CV_LOG_INFO(NULL, "Memory_usage (malloc): " << memory_usage << " (base=" << memory_usage_base << ")");
+        if (peak > 0)
+        {
+            CV_LOG_INFO(NULL, "Memory_usage (malloc): " << memory_usage << " (base=" << memory_usage_base << ")");
+        }
     }
     {
         // core/src/alloc.cpp: #define OPENCV_ALLOC_ENABLE_STATISTICS
@@ -799,7 +802,10 @@ void testTearDown()
         cv::utils::AllocatorStatisticsInterface& ocv_stats = cv::getAllocatorStatistics();
         ocv_peak = ocv_stats.getPeakUsage();
         ocv_memory_usage = ocv_peak - memory_usage_base_opencv;
-        CV_LOG_INFO(NULL, "Memory_usage (OpenCV): " << ocv_memory_usage << " (base=" << memory_usage_base_opencv << "  current=" << ocv_stats.getCurrentUsage() << ")");
+        if (ocv_peak)
+        {
+            CV_LOG_INFO(NULL, "Memory_usage (OpenCV): " << ocv_memory_usage << " (base=" << memory_usage_base_opencv << "  current=" << ocv_stats.getCurrentUsage() << ")");
+        }
         if (memory_usage == 0)  // external profiler has higher priority (and accuracy)
             memory_usage = ocv_memory_usage;
     }
@@ -809,7 +815,10 @@ void testTearDown()
         cv::utils::AllocatorStatisticsInterface& ocl_stats = cv::ocl::getOpenCLAllocatorStatistics();
         ocl_peak = ocl_stats.getPeakUsage();
         ocl_memory_usage = ocl_peak - memory_usage_base_opencl;
-        CV_LOG_INFO(NULL, "Memory_usage (OpenCL): " << ocl_memory_usage << " (base=" << memory_usage_base_opencl << "  current=" << ocl_stats.getCurrentUsage() << ")");
+        if (ocl_memory_usage > 0)
+        {
+            CV_LOG_INFO(NULL, "Memory_usage (OpenCL): " << ocl_memory_usage << " (base=" << memory_usage_base_opencl << "  current=" << ocl_stats.getCurrentUsage() << ")");
+        }
         ::testing::Test::RecordProperty("ocl_memory_usage",
                 cv::format("%llu", (unsigned long long)ocl_memory_usage));
     }


### PR DESCRIPTION
relates #12783

Messages like these:
```
[ INFO:0] Memory_usage (OpenCV): 0 (base=0  current=0)
[ INFO:0] Memory_usage (OpenCL): 0 (base=0  current=0)
```