### PR TITLE
StridedSlice from TensorFlow

### DIFF
--- a/modules/dnn/include/opencv2/dnn/dnn.hpp
+++ b/modules/dnn/include/opencv2/dnn/dnn.hpp
@@ -820,6 +820,7 @@ CV__DNN_EXPERIMENTAL_NS_BEGIN
       *                  * `*.t7` | `*.net` (Torch, http://torch.ch/)
       *                  * `*.weights` (Darknet, https://pjreddie.com/darknet/)
       *                  * `*.bin` (DLDT, https://software.intel.com/openvino-toolkit)
+      *                  * `*.onnx` (ONNX, https://onnx.ai/)
       * @param[in] config Text file contains network configuration. It could be a
       *                   file with the following extensions:
       *                  * `*.prototxt` (Caffe, http://caffe.berkeleyvision.org/)

--- a/modules/dnn/test/test_onnx_importer.cpp
+++ b/modules/dnn/test/test_onnx_importer.cpp
@@ -248,7 +248,7 @@ TEST_P(Test_ONNX_layers, Reshape)
 TEST_P(Test_ONNX_layers, Softmax)
 {
     testONNXModels("softmax");
-    testONNXModels("log_softmax");
+    testONNXModels("log_softmax", npy, 0, 0, false, false);
 }
 
 INSTANTIATE_TEST_CASE_P(/*nothing*/, Test_ONNX_layers, dnnBackendsAndTargets());

--- a/modules/dnn/test/test_tf_importer.cpp
+++ b/modules/dnn/test/test_tf_importer.cpp
@@ -663,6 +663,7 @@ TEST_P(Test_TensorFlow_layers, slice)
         (target == DNN_TARGET_OPENCL || target == DNN_TARGET_OPENCL_FP16))
         throw SkipTestException("");
     runTensorFlowNet("slice_4d");
+    runTensorFlowNet("strided_slice");
 }
 
 TEST_P(Test_TensorFlow_layers, softmax)

--- a/samples/dnn/tf_text_graph_faster_rcnn.py
+++ b/samples/dnn/tf_text_graph_faster_rcnn.py
@@ -31,7 +31,13 @@ def createFasterRCNNGraph(modelPath, configPath, outputPath):
     aspect_ratios = [float(ar) for ar in grid_anchor_generator['aspect_ratios']]
     width_stride = float(grid_anchor_generator['width_stride'][0])
     height_stride = float(grid_anchor_generator['height_stride'][0])
-    features_stride = float(config['feature_extractor'][0]['first_stage_features_stride'][0])
+
+    feature_extractor = config['feature_extractor'][0]
+    if 'type' in feature_extractor and feature_extractor['type'][0] == 'faster_rcnn_nas':
+        features_stride = 16.0
+    else:
+        features_stride = float(feature_extractor['first_stage_features_stride'][0])
+
     first_stage_nms_iou_threshold = float(config['first_stage_nms_iou_threshold'][0])
     first_stage_max_proposals = int(config['first_stage_max_proposals'][0])
 


### PR DESCRIPTION
### This pullrequest changes

resolves https://github.com/opencv/opencv/issues/13720

Add support of [faster_rcnn_nas_coco_2018_01_28](http://download.tensorflow.org/models/object_detection/faster_rcnn_nas_coco_2018_01_28.tar.gz) from TensorFlow.

Known problems:
* Object detection classes are shifted for Faster R-CNN networks (need to fix a sample or list of classes?)
* Faster R-CNN from TensorFlow don't work on random input (need to test on images with no detections). Reason - the first DetectionOutput may have less detections than allocated memory. Possible solution - fill the rest of output blob by zeros. (fixed by https://github.com/opencv/opencv/pull/14552)

**Merge with extra**: https://github.com/opencv/opencv_extra/pull/604

![out](https://user-images.githubusercontent.com/25801568/56961923-d0c1c080-6b5d-11e9-9ece-bb2e8073b33f.jpg)

```
force_builders=Custom,Custom Win,Custom Mac
buildworker:Custom=linux-1,linux-2,linux-4
docker_image:Custom=ubuntu-openvino-2019r1:16.04
docker_image:Custom Win=openvino-2019r1
docker_image:Custom Mac=openvino-2019r1
```