### PR TITLE
Fix uint8 input data for Async mode of dnn

### DIFF
--- a/modules/dnn/src/op_inf_engine.cpp
+++ b/modules/dnn/src/op_inf_engine.cpp
@@ -958,7 +958,16 @@ Mat infEngineBlobToMat(const InferenceEngine::Blob::Ptr& blob)
     // NOTE: Inference Engine sizes are reversed.
     std::vector<size_t> dims = blob->dims();
     std::vector<int> size(dims.rbegin(), dims.rend());
-    return Mat(size, CV_32F, (void*)blob->buffer());
+
+    int type = -1;
+    switch (blob->precision())
+    {
+        case InferenceEngine::Precision::FP32: type = CV_32F; break;
+        case InferenceEngine::Precision::U8: type = CV_8U; break;
+        default:
+            CV_Error(Error::StsNotImplemented, "Unsupported blob precision");
+    }
+    return Mat(size, type, (void*)blob->buffer());
 }
 
 bool InfEngineBackendLayer::getMemoryShapes(const std::vector<MatShape> &inputs,

--- a/modules/dnn/test/test_misc.cpp
+++ b/modules/dnn/test/test_misc.cpp
@@ -343,11 +343,12 @@ TEST(Net, forwardAndRetrieve)
 #ifdef HAVE_INF_ENGINE
 // This test runs network in synchronous mode for different inputs and then
 // runs the same model asynchronously for the same inputs.
-typedef testing::TestWithParam<Target> Async;
+typedef testing::TestWithParam<tuple<int, Target> > Async;
 TEST_P(Async, set_and_forward_single)
 {
     static const int kTimeout = 5000;  // in milliseconds.
-    const int target = GetParam();
+    const int dtype = get<0>(GetParam());
+    const int target = get<1>(GetParam());
 
     const std::string suffix = (target == DNN_TARGET_OPENCL_FP16 || target == DNN_TARGET_MYRIAD) ? "_fp16" : "";
     const std::string& model = findDataFile("dnn/layers/layer_convolution" + suffix + ".bin");
@@ -365,8 +366,8 @@ TEST_P(Async, set_and_forward_single)
     int blobSize[] = {2, 6, 75, 113};
     for (int i = 0; i < numInputs; ++i)
     {
-        inputs[i].create(4, &blobSize[0], CV_32FC1);
-        randu(inputs[i], 0.0f, 1.0f);
+        inputs[i].create(4, &blobSize[0], dtype);
+        randu(inputs[i], 0, 255);
     }
 
     // Run synchronously.
@@ -392,7 +393,8 @@ TEST_P(Async, set_and_forward_single)
 TEST_P(Async, set_and_forward_all)
 {
     static const int kTimeout = 5000;  // in milliseconds.
-    const int target = GetParam();
+    const int dtype = get<0>(GetParam());
+    const int target = get<1>(GetParam());
 
     const std::string suffix = (target == DNN_TARGET_OPENCL_FP16 || target == DNN_TARGET_MYRIAD) ? "_fp16" : "";
     const std::string& model = findDataFile("dnn/layers/layer_convolution" + suffix + ".bin");
@@ -411,8 +413,8 @@ TEST_P(Async, set_and_forward_all)
     int blobSize[] = {2, 6, 75, 113};
     for (int i = 0; i < numInputs; ++i)
     {
-        inputs[i].create(4, &blobSize[0], CV_32FC1);
-        randu(inputs[i], 0.0f, 1.0f);
+        inputs[i].create(4, &blobSize[0], dtype);
+        randu(inputs[i], 0, 255);
     }
 
     // Run synchronously.
@@ -439,7 +441,10 @@ TEST_P(Async, set_and_forward_all)
     }
 }
 
-INSTANTIATE_TEST_CASE_P(/**/, Async, testing::ValuesIn(getAvailableTargets(DNN_BACKEND_INFERENCE_ENGINE)));
+INSTANTIATE_TEST_CASE_P(/**/, Async, Combine(
+  Values(CV_32F, CV_8U),
+  testing::ValuesIn(getAvailableTargets(DNN_BACKEND_INFERENCE_ENGINE))
+));
 #endif  // HAVE_INF_ENGINE
 
 }} // namespace


### PR DESCRIPTION
resolves https://github.com/opencv/opencv/issues/14483
relates #13694

<cut/>

```
force_builders=Custom,Linux AVX2
buildworker:Custom=linux-2
docker_image:Custom=ubuntu-openvino-2019r1:16.04
test_opencl:Custom=ON
test_bigdata:Custom=1
test_filter:Custom=*
test_modules:Custom=dnn

ci_branch:Linux AVX2=no-checks
docker_image:Linux AVX2=ubuntu-openvino-2018r5:16.04
test_opencl:Linux AVX2=OFF
buildworker:Linux AVX2=linux-1
build_parallel_tests:Linux AVX2=1
test_bigdata:Linux AVX2=1
test_module:Linux AVX2=dnn,python2,python3,java
tests_filter:Linux AVX2=*

buildworker:Mac OpenCL=macosx-1
build_image:Mac OpenCL=openvino-2019r1
test_module:Mac OpenCL=dnn,python2,python3,java
```