### PR TITLE
cmake: support CPU_DISPATCH=ALL

### DIFF
--- a/cmake/OpenCVCompilerOptimizations.cmake
+++ b/cmake/OpenCVCompilerOptimizations.cmake
@@ -380,6 +380,10 @@ if(CV_DISABLE_OPTIMIZATION)
   set(CPU_DISPATCH_REQUIRE "")
 endif()
 
+if("x${CPU_DISPATCH}" STREQUAL "xALL")
+  set(CPU_DISPATCH "${CPU_KNOWN_OPTIMIZATIONS}")
+endif()
+
 macro(ocv_check_compiler_optimization OPT)
   if(NOT DEFINED CPU_${OPT}_SUPPORTED)
     if((DEFINED CPU_${OPT}_FLAGS_ON AND NOT "x${CPU_${OPT}_FLAGS_ON}" STREQUAL "x") OR CPU_${OPT}_TEST_FILE)
@@ -854,19 +858,19 @@ macro(__ocv_add_dispatched_file filename target_src_var src_directory dst_direct
         file(WRITE "${__file}" "${__codestr}")
       endif()
 
-      if(";${CPU_DISPATCH};" MATCHES "${OPT}" OR __CPU_DISPATCH_INCLUDE_ALL)
+      if(";${CPU_DISPATCH_FINAL};" MATCHES "${OPT}" OR __CPU_DISPATCH_INCLUDE_ALL)
         if(EXISTS "${src_directory}/${filename}.${OPT_LOWER}.cpp")
           message(STATUS "Using overrided ${OPT} source: ${src_directory}/${filename}.${OPT_LOWER}.cpp")
         else()
           list(APPEND ${target_src_var} "${__file}")
         endif()
-      endif()
 
-      set(__declarations_str "${__declarations_str}
+        set(__declarations_str "${__declarations_str}
 #define CV_CPU_DISPATCH_MODE ${OPT}
 #include \"opencv2/core/private/cv_cpu_include_simd_declarations.hpp\"
 ")
-      set(__dispatch_modes "${OPT}, ${__dispatch_modes}")
+        set(__dispatch_modes "${OPT}, ${__dispatch_modes}")
+      endif()
     endforeach()
 
     set(__declarations_str "${__declarations_str}


### PR DESCRIPTION
- fix misused `CPU_DISPATCH`, `CPU_DISPATCH_FINAL` should be used for filtering

Usage:
```
cmake -DCPU_DISPATCH=ALL ...
```

Main purpose of ALL value is enable testing of all available CPU configurations (even if they are not in default list).

<cut/>

<details>

<summary>Result:</summary>

```
--   CPU/HW features:
--     Baseline:                    SSE SSE2 SSE3
--       requested:                 SSE3
--     Dispatched code generation:  SSSE3 SSE4_1 POPCNT SSE4_2 FP16 FMA3 AVX AVX2 AVX_512F AVX512_COMMON AVX512_KNL AVX512_KNM AVX512_SKX AVX512_CNL AVX512_CEL AVX512_ICL
--       requested:                 SSE SSE2 SSE3 SSSE3 SSE4_1 POPCNT SSE4_2 FP16 FMA3 AVX AVX2 AVX_512F AVX512_COMMON AVX512_KNL AVX512_KNM AVX512_SKX AVX512_CNL AVX512_CEL AVX512_ICL
--       SSSE3 (1 files):           + SSSE3
--       SSE4_1 (13 files):         + SSSE3 SSE4_1
--       POPCNT (0 files):          + SSSE3 SSE4_1 POPCNT
--       SSE4_2 (2 files):          + SSSE3 SSE4_1 POPCNT SSE4_2
--       FP16 (1 files):            + SSSE3 SSE4_1 POPCNT SSE4_2 FP16 AVX
--       FMA3 (0 files):            + SSSE3 SSE4_1 POPCNT SSE4_2 FP16 FMA3 AVX AVX2
--       AVX (6 files):             + SSSE3 SSE4_1 POPCNT SSE4_2 AVX
--       AVX2 (28 files):           + SSSE3 SSE4_1 POPCNT SSE4_2 FP16 FMA3 AVX AVX2
--       AVX_512F (0 files):        + SSSE3 SSE4_1 POPCNT SSE4_2 FP16 FMA3 AVX AVX2 AVX_512F
--       AVX512_COMMON (0 files):   + SSSE3 SSE4_1 POPCNT SSE4_2 FP16 FMA3 AVX AVX2 AVX_512F AVX512_COMMON
--       AVX512_KNL (0 files):      + SSSE3 SSE4_1 POPCNT SSE4_2 FP16 FMA3 AVX AVX2 AVX_512F AVX512_COMMON AVX512_KNL
--       AVX512_KNM (0 files):      + SSSE3 SSE4_1 POPCNT SSE4_2 FP16 FMA3 AVX AVX2 AVX_512F AVX512_COMMON AVX512_KNL AVX512_KNM
--       AVX512_SKX (2 files):      + SSSE3 SSE4_1 POPCNT SSE4_2 FP16 FMA3 AVX AVX2 AVX_512F AVX512_COMMON AVX512_SKX
--       AVX512_CNL (0 files):      + SSSE3 SSE4_1 POPCNT SSE4_2 FP16 FMA3 AVX AVX2 AVX_512F AVX512_COMMON AVX512_SKX AVX512_CNL
--       AVX512_CEL (0 files):      + SSSE3 SSE4_1 POPCNT SSE4_2 FP16 FMA3 AVX AVX2 AVX_512F AVX512_COMMON AVX512_SKX AVX512_CNL AVX512_CEL
--       AVX512_ICL (0 files):      + SSSE3 SSE4_1 POPCNT SSE4_2 FP16 FMA3 AVX AVX2 AVX_512F AVX512_COMMON AVX512_SKX AVX512_CNL AVX512_CEL AVX512_ICL
```

</details>

continues #14007

```
force_builders_only=Custom
CPU_DISPATCH:Custom=ALL
build_image:Custom=ubuntu:18.04
buildworker:Custom=linux-5
```