### PR TITLE
Add support for loading ONNX model from in-memory buffer.

### DIFF
--- a/modules/dnn/include/opencv2/dnn/dnn.hpp
+++ b/modules/dnn/include/opencv2/dnn/dnn.hpp
@@ -868,6 +868,23 @@ CV__DNN_EXPERIMENTAL_NS_BEGIN
      */
     CV_EXPORTS_W Net readNetFromONNX(const String &onnxFile);
 
+    /** @brief Reads a network model from <a href="https://onnx.ai/">ONNX</a>
+     *         in-memory buffer.
+     *  @param buffer memory address of the first byte of the buffer.
+     *  @param sizeBuffer size of the buffer.
+     *  @returns Network object that ready to do forward, throw an exception
+     *        in failure cases.
+     */
+    CV_EXPORTS Net readNetFromONNX(const char* buffer, size_t sizeBuffer);
+
+    /** @brief Reads a network model from <a href="https://onnx.ai/">ONNX</a>
+     *         in-memory buffer.
+     *  @param buffer in-memory buffer that stores the ONNX model bytes.
+     *  @returns Network object that ready to do forward, throw an exception
+     *        in failure cases.
+     */
+    CV_EXPORTS_W Net readNetFromONNX(const std::vector<uchar>& buffer);
+
     /** @brief Creates blob from .pb file.
      *  @param path to the .pb file with input tensor.
      *  @returns Mat.


### PR DESCRIPTION
This change allows ONNX model blob already loaded in-memory to be passed to the ONNX importer from which to initialize the cv::dnn::Net instance.  It accomplishes this by wrapping the in-memory buffer with std::streambuf interface which std::istream requires in order to read data from it.  Hopefully this functionality would be generally useful.

I'm open to renaming the top-level function to something more appropriate if the name I've given is not consistent with any sort of naming convention.

Thanks,

Kohei