### PR TITLE
calib3d: fix uninitialized fields in ctors

### DIFF
--- a/modules/calib3d/src/levmarq.cpp
+++ b/modules/calib3d/src/levmarq.cpp
@@ -80,11 +80,8 @@ namespace cv
 class LMSolverImpl CV_FINAL : public LMSolver
 {
 public:
-    LMSolverImpl() : maxIters(100) { init(); }
-    LMSolverImpl(const Ptr<LMSolver::Callback>& _cb, int _maxIters) : cb(_cb), epsx(FLT_EPSILON), epsf(FLT_EPSILON), maxIters(_maxIters) { init(); }
-    LMSolverImpl(const Ptr<LMSolver::Callback>& _cb, int _maxIters, double _eps) : cb(_cb), epsx(_eps), epsf(_eps), maxIters(_maxIters) { init(); }
-
-    void init()
+    LMSolverImpl(const Ptr<LMSolver::Callback>& _cb, int _maxIters, double _eps = FLT_EPSILON)
+        : cb(_cb), epsx(_eps), epsf(_eps), maxIters(_maxIters)
     {
         printInterval = 0;
     }


### PR DESCRIPTION

```
>>>     CID 1444972:  Uninitialized members  (UNINIT_CTOR)
>>>     Non-static class member "epsf" is not initialized in this constructor nor in any functions that it calls.
83         LMSolverImpl() : maxIters(100) { init(); }
```