### PR TITLE
core: drop 'operator << (ostream, String)' overload

### DIFF
--- a/modules/core/include/opencv2/core/cvstd.inl.hpp
+++ b/modules/core/include/opencv2/core/cvstd.inl.hpp
@@ -74,12 +74,6 @@ public:
 };
 
 static inline
-std::ostream& operator << (std::ostream& os, const String& str)
-{
-    return os << str.c_str();
-}
-
-static inline
 std::ostream& operator << (std::ostream& out, Ptr<Formatted> fmtd)
 {
     fmtd->reset();


### PR DESCRIPTION
`cv::String` is `std::string` in OpenCV 4.x
