### PR TITLE
fix the bug, when k[4] is negative, icdist may be negative at the edg…

### DIFF
--- a/modules/imgproc/src/undistort.cpp
+++ b/modules/imgproc/src/undistort.cpp
@@ -480,6 +480,12 @@ static void cvUndistortPointsInternal( const CvMat* _src, CvMat* _dst, const CvM
                     break;
                 double r2 = x*x + y*y;
                 double icdist = (1 + ((k[7]*r2 + k[6])*r2 + k[5])*r2)/(1 + ((k[4]*r2 + k[1])*r2 + k[0])*r2);
+                if (icdist < 0)  // test: undistortPoints.regression_14583
+                {
+                    x = (u - cx)*ifx;
+                    y = (v - cy)*ify;
+                    break;
+                }
                 double deltaX = 2*k[2]*x*y + k[3]*(r2 + 2*x*x)+ k[8]*r2+k[9]*r2*r2;
                 double deltaY = k[2]*(r2 + 2*y*y) + 2*k[3]*x*y+ k[10]*r2+k[11]*r2*r2;
                 x = (x0 - deltaX)*icdist;


### PR DESCRIPTION
### This pull request changes 
The `cvUndistortPointsInternal` function.
The k[4] is negative of my camera, the `icdist` will be negative at the edge of image. This cause the error like the point at right will be undistort to the left.
So the function will return when `icdist` < 0, and use the last compute result. 
