### PR TITLE
VideoCapture Direct Show. Added getter for CV_CAP_PROP_CONVERT_RGB, CAP_PROP_CHANNEL properties.

### DIFF
--- a/modules/videoio/src/cap_dshow.cpp
+++ b/modules/videoio/src/cap_dshow.cpp
@@ -527,6 +527,8 @@ class videoInput{
         int  getFourcc(int deviceID) const;
         double getFPS(int deviceID) const;
 
+        int getChannel(int deviceID) const;
+
         // RGB conversion setting
         bool getConvertRGB(int deviceID);
         bool setConvertRGB(int deviceID, bool enable);
@@ -962,6 +964,16 @@ videoDevice::~videoDevice(){
 
     HRESULT HR = NOERROR;
 
+    //Check to see if the graph is running, if so stop it.
+     if( (pControl) )
+    {
+        HR = pControl->Pause();
+        if (FAILED(HR)) DebugPrintOut("ERROR - Could not pause pControl\n");
+
+        HR = pControl->Stop();
+        if (FAILED(HR)) DebugPrintOut("ERROR - Could not stop pControl\n");
+    }
+
     //Stop the callback and free it
     if( (sgCallback) && (pGrabber) )
     {
@@ -976,16 +988,6 @@ videoDevice::~videoDevice(){
         }
 
         delete sgCallback;
-    }
-
-    //Check to see if the graph is running, if so stop it.
-     if( (pControl) )
-    {
-        HR = pControl->Pause();
-        if (FAILED(HR)) DebugPrintOut("ERROR - Could not pause pControl\n");
-
-        HR = pControl->Stop();
-        if (FAILED(HR)) DebugPrintOut("ERROR - Could not stop pControl\n");
     }
 
     //Disconnect filters from capture device
@@ -1479,6 +1481,12 @@ double videoInput::getFPS(int id) const
 
 }
 
+int videoInput::getChannel(int deviceID) const
+{
+    if (!isDeviceSetup(deviceID))
+        return 0;
+    return VDList[deviceID]->storeConn;
+}
 
 // ----------------------------------------------------------------------
 //
@@ -3332,11 +3340,15 @@ double VideoCapture_DShow::getProperty(int propIdx) const
         return g_VI.getFourcc(m_index);
     case CV_CAP_PROP_FPS:
         return g_VI.getFPS(m_index);
+    case CV_CAP_PROP_CONVERT_RGB:
+        return g_VI.getConvertRGB(m_index);
+    case CAP_PROP_CHANNEL:
+        return g_VI.getChannel(m_index);
     case CV_CAP_PROP_AUTOFOCUS:
       // Flags indicate whether or not autofocus is enabled
       if (g_VI.getVideoSettingCamera(m_index, CameraControl_Focus, min_value, max_value, stepping_delta, current_value, flags, defaultValue))
         return (double)flags;
-      return -1;
+      break;
 
     // video filter properties
     case CV_CAP_PROP_BRIGHTNESS:
@@ -3351,7 +3363,7 @@ double VideoCapture_DShow::getProperty(int propIdx) const
     case CV_CAP_PROP_GAIN:
         if (g_VI.getVideoSettingFilter(m_index, g_VI.getVideoPropertyFromCV(propIdx), min_value, max_value, stepping_delta, current_value, flags, defaultValue))
             return (double)current_value;
-        return -1;
+        break;
 
     // camera properties
     case CV_CAP_PROP_PAN:
@@ -3363,14 +3375,12 @@ double VideoCapture_DShow::getProperty(int propIdx) const
     case CV_CAP_PROP_FOCUS:
         if (g_VI.getVideoSettingCamera(m_index, g_VI.getCameraPropertyFromCV(propIdx), min_value, max_value, stepping_delta, current_value, flags, defaultValue))
             return (double)current_value;
-        return -1;
-    }
-
-    if (propIdx == CV_CAP_PROP_SETTINGS )
-    {
+        break;
+    case CV_CAP_PROP_SETTINGS:
         return g_VI.property_window_count(m_index);
+    default:
+        break;
     }
-
     // unknown parameter or value not available
     return -1;
 }
@@ -3470,12 +3480,6 @@ bool VideoCapture_DShow::setProperty(int propIdx, double propVal)
         return true;
     }
 
-    // show video/camera filter dialog
-    if (propIdx == CV_CAP_PROP_SETTINGS )
-    {
-        return g_VI.showSettingsWindow(m_index);
-    }
-
     //video Filter properties
     switch (propIdx)
     {
@@ -3503,6 +3507,9 @@ bool VideoCapture_DShow::setProperty(int propIdx, double propVal)
     case CV_CAP_PROP_IRIS:
     case CV_CAP_PROP_FOCUS:
         return g_VI.setVideoSettingCamera(m_index, g_VI.getCameraPropertyFromCV(propIdx), (long)propVal);
+    // show video/camera filter dialog
+    case CV_CAP_PROP_SETTINGS:
+        return g_VI.showSettingsWindow(m_index);
     }
 
     return false;

--- a/modules/videoio/src/cap_dshow.cpp
+++ b/modules/videoio/src/cap_dshow.cpp
@@ -965,7 +965,7 @@ videoDevice::~videoDevice(){
     HRESULT HR = NOERROR;
 
     //Check to see if the graph is running, if so stop it.
-     if( (pControl) )
+    if( (pControl) )
     {
         HR = pControl->Pause();
         if (FAILED(HR)) DebugPrintOut("ERROR - Could not pause pControl\n");


### PR DESCRIPTION
### This pullrequest changes

  * Missing getter for CV_CAP_PROP_CONVERT_RGB, CAP_PROP_CHANNEL

Refactoring:
  * moved `pControl->Stop()` before deleting any resources.
  * used switch case for `CV_CAP_PROP_SETTINGS` instead of `if`


```
build_image:Custom Win=msvs2019
```