### PR TITLE
java: fix java missing_consts

### DIFF
--- a/modules/calib3d/misc/java/gen_dict.json
+++ b/modules/calib3d/misc/java/gen_dict.json
@@ -3,21 +3,6 @@
         "CirclesGridFinderParameters",
         "CirclesGridFinderParameters2"
     ],
-    "missing_consts" : {
-        "Calib3d": {
-            "public" : [
-                ["CALIB_USE_INTRINSIC_GUESS", "1"],
-                ["CALIB_RECOMPUTE_EXTRINSIC", "2"],
-                ["CALIB_CHECK_COND", "4"],
-                ["CALIB_FIX_SKEW", "8"],
-                ["CALIB_FIX_K1", "16"],
-                ["CALIB_FIX_K2", "32"],
-                ["CALIB_FIX_K3", "64"],
-                ["CALIB_FIX_K4", "128"],
-                ["CALIB_FIX_INTRINSIC", "256"]
-            ]
-        }
-    },
     "namespaces_dict": {
         "cv.fisheye": "fisheye"
     },

--- a/modules/calib3d/misc/java/test/Calib3dTest.java
+++ b/modules/calib3d/misc/java/test/Calib3dTest.java
@@ -611,4 +611,32 @@ public class Calib3dTest extends OpenCVTestCase {
         Calib3d.computeCorrespondEpilines(left, 1, fundamental, lines);
         assertMatEqual(truth, lines, EPS);
     }
+
+    public void testConstants()
+    {
+        // calib3d.hpp: some constants have conflict with constants from 'fisheye' namespace
+        assertEquals(1, Calib3d.CALIB_USE_INTRINSIC_GUESS);
+        assertEquals(2, Calib3d.CALIB_FIX_ASPECT_RATIO);
+        assertEquals(4, Calib3d.CALIB_FIX_PRINCIPAL_POINT);
+        assertEquals(8, Calib3d.CALIB_ZERO_TANGENT_DIST);
+        assertEquals(16, Calib3d.CALIB_FIX_FOCAL_LENGTH);
+        assertEquals(32, Calib3d.CALIB_FIX_K1);
+        assertEquals(64, Calib3d.CALIB_FIX_K2);
+        assertEquals(128, Calib3d.CALIB_FIX_K3);
+        assertEquals(0x0800, Calib3d.CALIB_FIX_K4);
+        assertEquals(0x1000, Calib3d.CALIB_FIX_K5);
+        assertEquals(0x2000, Calib3d.CALIB_FIX_K6);
+        assertEquals(0x4000, Calib3d.CALIB_RATIONAL_MODEL);
+        assertEquals(0x8000, Calib3d.CALIB_THIN_PRISM_MODEL);
+        assertEquals(0x10000, Calib3d.CALIB_FIX_S1_S2_S3_S4);
+        assertEquals(0x40000, Calib3d.CALIB_TILTED_MODEL);
+        assertEquals(0x80000, Calib3d.CALIB_FIX_TAUX_TAUY);
+        assertEquals(0x100000, Calib3d.CALIB_USE_QR);
+        assertEquals(0x200000, Calib3d.CALIB_FIX_TANGENT_DIST);
+        assertEquals(0x100, Calib3d.CALIB_FIX_INTRINSIC);
+        assertEquals(0x200, Calib3d.CALIB_SAME_FOCAL_LENGTH);
+        assertEquals(0x400, Calib3d.CALIB_ZERO_DISPARITY);
+        assertEquals((1 << 17), Calib3d.CALIB_USE_LU);
+        assertEquals((1 << 22), Calib3d.CALIB_USE_EXTRINSIC_GUESS);
+    }
 }


### PR DESCRIPTION
<!-- Please use this line to close one or multiple issues when this pullrequest gets merged
You can add another line right under the first one:
resolves #1234
resolves #1235
-->

### This pullrequest changes

<!-- Please describe what your pullrequest is changing -->
The values of CALIB_FIX_K1, CALIB_FIX_K2, CALIB_FIX_K3, and CALIB_FIX_K4 reset by gen_dict.json are incorrect. Correct values are output by removing unnecessary missing_consts blocks.

https://github.com/opencv/opencv/blob/master/modules/calib3d/include/opencv2/calib3d.hpp#L262-L265
https://github.com/opencv/opencv/blob/master/modules/calib3d/misc/java/gen_dict.json#L5-L19