### PR TITLE
Kernel using events from OpenCL.

### DIFF
--- a/modules/core/include/opencv2/core/ocl.hpp
+++ b/modules/core/include/opencv2/core/ocl.hpp
@@ -562,18 +562,36 @@ public:
         i = set(i, a6); i = set(i, a7); i = set(i, a8); i = set(i, a9); i = set(i, a10); i = set(i, a11);
         i = set(i, a12); i = set(i, a13); i = set(i, a14); set(i, a15); return *this;
     }
+
     /** @brief Run the OpenCL kernel.
     @param dims the work problem dimensions. It is the length of globalsize and localsize. It can be either 1, 2 or 3.
     @param globalsize work items for each dimension. It is not the final globalsize passed to
-      OpenCL. Each dimension will be adjusted to the nearest integer divisible by the corresponding
-      value in localsize. If localsize is NULL, it will still be adjusted depending on dims. The
-      adjusted values are greater than or equal to the original values.
+    OpenCL. Each dimension will be adjusted to the nearest integer divisible by the corresponding
+    value in localsize. If localsize is NULL, it will still be adjusted depending on dims. The
+    adjusted values are greater than or equal to the original values.
     @param localsize work-group size for each dimension.
     @param sync specify whether to wait for OpenCL computation to finish before return.
-    @param q command queue
+    @param kernel_event event associated with this kernel launch. If used, it is the user's responsability to release it.
+    @param q command queue.
     */
-    bool run(int dims, size_t globalsize[],
-             size_t localsize[], bool sync, const Queue& q=Queue());
+    bool run(int dims, size_t globalsize[], size_t localsize[],
+        bool sync, const Queue& q = Queue(), cl_event* kernel_event = (cl_event*)0);
+
+    /** @brief Run the OpenCL kernel. Compared to the previous run method, the kernel is not launched immediately but it
+    waits for the events in wait_list to be completed. The method is necessarily launched asynchronously (sync=false in previous method).
+    @param dims the work problem dimensions. It is the length of globalsize and localsize. It can be either 1, 2 or 3.
+    @param globalsize work items for each dimension. It is not the final globalsize passed to
+    OpenCL. Each dimension will be adjusted to the nearest integer divisible by the corresponding
+    value in localsize. If localsize is NULL, it will still be adjusted depending on dims. The
+    adjusted values are greater than or equal to the original values.
+    @param localsize work-group size for each dimension.
+    @param wait_list list of OpenCL events that must be finished before the kernel is launched.
+    @param kernel_event event associated with this kernel launch. If used, it is the user's responsability to release it.
+    @param q command queue.
+    @sa Queue::finish()
+    */
+    bool run(int dims, size_t globalsize[], size_t localsize[],
+        const Queue& q = Queue(), std::vector<cl_event>& wait_list = std::vector<cl_event>(), cl_event* kernel_event = (cl_event*)0);
     bool runTask(bool sync, const Queue& q=Queue());
 
     /** @brief Similar to synchronized run() call with returning of kernel execution time

--- a/modules/core/include/opencv2/core/ocl.hpp
+++ b/modules/core/include/opencv2/core/ocl.hpp
@@ -369,7 +369,7 @@ public:
     /** @brief Return true if the kernel associated to that event is enqueued or submitted.
     **/
     bool isEnqueued();
-    /** @brief Return true if the event kernel associated to that is running.
+    /** @brief Return true if the event kernel associated to that event is running.
     **/
     bool isRunning();
     //bool setCallback(void* oclCallback(cl_event, cl_int, void* user_data), void* user_data);

--- a/modules/core/src/ocl.cpp
+++ b/modules/core/src/ocl.cpp
@@ -2913,7 +2913,8 @@ bool Event::isComplete(){
         return true;
 
     cl_event e = p->handle;
-    cl_int status = clGetEventInfo(e, CL_EVENT_COMMAND_EXECUTION_STATUS, 0, NULL, NULL);
+    cl_int status;
+    clGetEventInfo(e, CL_EVENT_COMMAND_EXECUTION_STATUS, sizeof(cl_int), &status, NULL);
     return (status == CL_COMPLETE);
 }
 
@@ -2922,7 +2923,8 @@ bool Event::isEnqueued(){
         return true;
 
     cl_event e = p->handle;
-    cl_int status = clGetEventInfo(e, CL_EVENT_COMMAND_EXECUTION_STATUS, 0, NULL, NULL);
+    cl_int status;
+    clGetEventInfo(e, CL_EVENT_COMMAND_EXECUTION_STATUS, sizeof(cl_int), &status, NULL);
     return ((status == CL_QUEUED)||(status == CL_SUBMITTED));
 }
 
@@ -2931,7 +2933,8 @@ bool Event::isRunning(){
         return true;
 
     cl_event e = p->handle;
-    cl_int status = clGetEventInfo(e, CL_EVENT_COMMAND_EXECUTION_STATUS, 0, NULL, NULL);
+    cl_int status;
+    clGetEventInfo(e, CL_EVENT_COMMAND_EXECUTION_STATUS, sizeof(cl_int), &status, NULL);
     return (status == CL_RUNNING);
 }
 
@@ -3470,6 +3473,7 @@ bool Kernel::Impl::run(int dims, size_t globalsize[], size_t localsize[],
         Event::Impl* eImpl = kernel_event->getImpl();
         if (!eImpl) {
             *kernel_event = Event();
+            eImpl = kernel_event->getImpl();
         }
         kernel_event->release();
         eImpl->setEvent(asyncEvent);

--- a/modules/core/test/ocl/test_opencl.cpp
+++ b/modules/core/test/ocl/test_opencl.cpp
@@ -18,8 +18,7 @@ static void testOpenCLEvents(cv::ocl::Kernel &k, std::vector<cv::ocl::Event>& wa
             cv::ocl::KernelArg::WriteOnly(dst),
             (int)5).runWithWaitList(2, globalSize, localSize, wait_list, &kEvent);
     ASSERT_TRUE(kSuccess);
-    std::cout << "kEvent.isEnqueued(): " << kEvent.isEnqueued() << std::endl;
-    //ASSERT_TRUE(kEvent.isEnqueued());
+    ASSERT_TRUE(kEvent.isEnqueued());
 }
 
 static void testOpenCLKernel(cv::ocl::Kernel& k)
@@ -96,17 +95,14 @@ TEST(OpenCL, support_binary_programs)
     testOpenCLKernel(k);
 
     cv::ocl::Event kEvent;
-    cv::ocl::Event wait_event;// = clCreateUserEvent((cl_context)ctx.ptr(), (cl_int*)0);
-    std::cout << "wait_event.isEnqueued(): " << wait_event.isEnqueued() << std::endl;
-    std::cout << "wait_event.isComplete(): " << wait_event.isComplete() << std::endl;
+    cv::ocl::Event wait_event;
     wait_event.create();
-    std::cout << "wait_event.isEnqueued(): " << wait_event.isEnqueued() << std::endl;
-    std::cout << "wait_event.isComplete(): " << wait_event.isComplete() << std::endl;
     std::vector<cv::ocl::Event> wait_list;
     wait_list.push_back(wait_event);
     testOpenCLEvents(k, wait_list, kEvent);
     wait_event.setFinished();
-    ASSERT_TRUE((kEvent.isRunning()) || (kEvent.isComplete()));
+    cv::ocl::Event::waitForEvents(std::vector<cv::ocl::Event>(1, kEvent));
+    ASSERT_TRUE(kEvent.isComplete());
 }
 
 


### PR DESCRIPTION
<!-- Please use this line to close one or multiple issues when this pullrequest gets merged
You can add another line right under the first one:
-->

### This pullrequest changes

Currently in OpenCV, the available OpenCL integration still does not include several tools defined by the standard. Among these features missing, I needed a way to use events.
For one of my current project, I need several Queues and synchronization between these using events. Since I am also using the OpenCL Kernels available in OpenCV, I thought it could be a nice idea to implement this Event class and add a way to run kernels using these events.
Also, from my point of view concerning the current goals for OpenCV, I think that these events could be a good tool for future developments. 

All comments (especially nice ones 😄 ) are welcome!