### PR TITLE
java: remove redundant declaration of java.lang package

### DIFF
--- a/modules/core/misc/java/src/java/core+CvType.java
+++ b/modules/core/misc/java/src/java/core+CvType.java
@@ -25,11 +25,11 @@ public final class CvType {
 
     public static final int makeType(int depth, int channels) {
         if (channels <= 0 || channels >= CV_CN_MAX) {
-            throw new java.lang.UnsupportedOperationException(
+            throw new UnsupportedOperationException(
                     "Channels count should be 1.." + (CV_CN_MAX - 1));
         }
         if (depth < 0 || depth >= CV_DEPTH_MAX) {
-            throw new java.lang.UnsupportedOperationException(
+            throw new UnsupportedOperationException(
                     "Data type depth should be 0.." + (CV_DEPTH_MAX - 1));
         }
         return (depth & (CV_DEPTH_MAX - 1)) + ((channels - 1) << CV_CN_SHIFT);
@@ -89,7 +89,7 @@ public final class CvType {
         case CV_64F:
             return 8 * channels(type);
         default:
-            throw new java.lang.UnsupportedOperationException(
+            throw new UnsupportedOperationException(
                     "Unsupported CvType value: " + type);
         }
     }
@@ -122,7 +122,7 @@ public final class CvType {
             s = "CV_USRTYPE1";
             break;
         default:
-            throw new java.lang.UnsupportedOperationException(
+            throw new UnsupportedOperationException(
                     "Unsupported CvType value: " + type);
         }
 

--- a/modules/core/misc/java/src/java/core+Mat.java
+++ b/modules/core/misc/java/src/java/core+Mat.java
@@ -11,7 +11,7 @@ public class Mat {
     public Mat(long addr)
     {
         if (addr == 0)
-            throw new java.lang.UnsupportedOperationException("Native object address is NULL");
+            throw new UnsupportedOperationException("Native object address is NULL");
         nativeObj = addr;
     }
 
@@ -1074,7 +1074,7 @@ public class Mat {
     public int put(int row, int col, double... data) {
         int t = type();
         if (data == null || data.length % CvType.channels(t) != 0)
-            throw new java.lang.UnsupportedOperationException(
+            throw new UnsupportedOperationException(
                     "Provided data element number (" +
                             (data == null ? 0 : data.length) +
                             ") should be multiple of the Mat channels count (" +
@@ -1086,7 +1086,7 @@ public class Mat {
     public int put(int[] idx, double... data) {
         int t = type();
         if (data == null || data.length % CvType.channels(t) != 0)
-            throw new java.lang.UnsupportedOperationException(
+            throw new UnsupportedOperationException(
                     "Provided data element number (" +
                             (data == null ? 0 : data.length) +
                             ") should be multiple of the Mat channels count (" +
@@ -1100,7 +1100,7 @@ public class Mat {
     public int put(int row, int col, float[] data) {
         int t = type();
         if (data == null || data.length % CvType.channels(t) != 0)
-            throw new java.lang.UnsupportedOperationException(
+            throw new UnsupportedOperationException(
                     "Provided data element number (" +
                             (data == null ? 0 : data.length) +
                             ") should be multiple of the Mat channels count (" +
@@ -1108,14 +1108,14 @@ public class Mat {
         if (CvType.depth(t) == CvType.CV_32F) {
             return nPutF(nativeObj, row, col, data.length, data);
         }
-        throw new java.lang.UnsupportedOperationException("Mat data type is not compatible: " + t);
+        throw new UnsupportedOperationException("Mat data type is not compatible: " + t);
     }
 
     // javadoc:Mat::put(idx,data)
     public int put(int[] idx, float[] data) {
         int t = type();
         if (data == null || data.length % CvType.channels(t) != 0)
-            throw new java.lang.UnsupportedOperationException(
+            throw new UnsupportedOperationException(
                     "Provided data element number (" +
                             (data == null ? 0 : data.length) +
                             ") should be multiple of the Mat channels count (" +
@@ -1125,14 +1125,14 @@ public class Mat {
         if (CvType.depth(t) == CvType.CV_32F) {
             return nPutFIdx(nativeObj, idx, data.length, data);
         }
-        throw new java.lang.UnsupportedOperationException("Mat data type is not compatible: " + t);
+        throw new UnsupportedOperationException("Mat data type is not compatible: " + t);
     }
 
     // javadoc:Mat::put(row,col,data)
     public int put(int row, int col, int[] data) {
         int t = type();
         if (data == null || data.length % CvType.channels(t) != 0)
-            throw new java.lang.UnsupportedOperationException(
+            throw new UnsupportedOperationException(
                     "Provided data element number (" +
                             (data == null ? 0 : data.length) +
                             ") should be multiple of the Mat channels count (" +
@@ -1140,14 +1140,14 @@ public class Mat {
         if (CvType.depth(t) == CvType.CV_32S) {
             return nPutI(nativeObj, row, col, data.length, data);
         }
-        throw new java.lang.UnsupportedOperationException("Mat data type is not compatible: " + t);
+        throw new UnsupportedOperationException("Mat data type is not compatible: " + t);
     }
 
     // javadoc:Mat::put(idx,data)
     public int put(int[] idx, int[] data) {
         int t = type();
         if (data == null || data.length % CvType.channels(t) != 0)
-            throw new java.lang.UnsupportedOperationException(
+            throw new UnsupportedOperationException(
                     "Provided data element number (" +
                             (data == null ? 0 : data.length) +
                             ") should be multiple of the Mat channels count (" +
@@ -1157,14 +1157,14 @@ public class Mat {
         if (CvType.depth(t) == CvType.CV_32S) {
             return nPutIIdx(nativeObj, idx, data.length, data);
         }
-        throw new java.lang.UnsupportedOperationException("Mat data type is not compatible: " + t);
+        throw new UnsupportedOperationException("Mat data type is not compatible: " + t);
     }
 
     // javadoc:Mat::put(row,col,data)
     public int put(int row, int col, short[] data) {
         int t = type();
         if (data == null || data.length % CvType.channels(t) != 0)
-            throw new java.lang.UnsupportedOperationException(
+            throw new UnsupportedOperationException(
                     "Provided data element number (" +
                             (data == null ? 0 : data.length) +
                             ") should be multiple of the Mat channels count (" +
@@ -1172,14 +1172,14 @@ public class Mat {
         if (CvType.depth(t) == CvType.CV_16U || CvType.depth(t) == CvType.CV_16S) {
             return nPutS(nativeObj, row, col, data.length, data);
         }
-        throw new java.lang.UnsupportedOperationException("Mat data type is not compatible: " + t);
+        throw new UnsupportedOperationException("Mat data type is not compatible: " + t);
     }
 
     // javadoc:Mat::put(idx,data)
     public int put(int[] idx, short[] data) {
         int t = type();
         if (data == null || data.length % CvType.channels(t) != 0)
-            throw new java.lang.UnsupportedOperationException(
+            throw new UnsupportedOperationException(
                     "Provided data element number (" +
                             (data == null ? 0 : data.length) +
                             ") should be multiple of the Mat channels count (" +
@@ -1189,14 +1189,14 @@ public class Mat {
         if (CvType.depth(t) == CvType.CV_16U || CvType.depth(t) == CvType.CV_16S) {
             return nPutSIdx(nativeObj, idx, data.length, data);
         }
-        throw new java.lang.UnsupportedOperationException("Mat data type is not compatible: " + t);
+        throw new UnsupportedOperationException("Mat data type is not compatible: " + t);
     }
 
     // javadoc:Mat::put(row,col,data)
     public int put(int row, int col, byte[] data) {
         int t = type();
         if (data == null || data.length % CvType.channels(t) != 0)
-            throw new java.lang.UnsupportedOperationException(
+            throw new UnsupportedOperationException(
                     "Provided data element number (" +
                             (data == null ? 0 : data.length) +
                             ") should be multiple of the Mat channels count (" +
@@ -1204,14 +1204,14 @@ public class Mat {
         if (CvType.depth(t) == CvType.CV_8U || CvType.depth(t) == CvType.CV_8S) {
             return nPutB(nativeObj, row, col, data.length, data);
         }
-        throw new java.lang.UnsupportedOperationException("Mat data type is not compatible: " + t);
+        throw new UnsupportedOperationException("Mat data type is not compatible: " + t);
     }
 
     // javadoc:Mat::put(idx,data)
     public int put(int[] idx, byte[] data) {
         int t = type();
         if (data == null || data.length % CvType.channels(t) != 0)
-            throw new java.lang.UnsupportedOperationException(
+            throw new UnsupportedOperationException(
                     "Provided data element number (" +
                             (data == null ? 0 : data.length) +
                             ") should be multiple of the Mat channels count (" +
@@ -1221,14 +1221,14 @@ public class Mat {
         if (CvType.depth(t) == CvType.CV_8U || CvType.depth(t) == CvType.CV_8S) {
             return nPutBIdx(nativeObj, idx, data.length, data);
         }
-        throw new java.lang.UnsupportedOperationException("Mat data type is not compatible: " + t);
+        throw new UnsupportedOperationException("Mat data type is not compatible: " + t);
     }
 
     // javadoc:Mat::put(row,col,data,offset,length)
     public int put(int row, int col, byte[] data, int offset, int length) {
         int t = type();
         if (data == null || length % CvType.channels(t) != 0)
-            throw new java.lang.UnsupportedOperationException(
+            throw new UnsupportedOperationException(
                     "Provided data element number (" +
                             (data == null ? 0 : data.length) +
                             ") should be multiple of the Mat channels count (" +
@@ -1236,14 +1236,14 @@ public class Mat {
         if (CvType.depth(t) == CvType.CV_8U || CvType.depth(t) == CvType.CV_8S) {
             return nPutBwOffset(nativeObj, row, col, length, offset, data);
         }
-        throw new java.lang.UnsupportedOperationException("Mat data type is not compatible: " + t);
+        throw new UnsupportedOperationException("Mat data type is not compatible: " + t);
     }
 
     // javadoc:Mat::put(idx,data,offset,length)
     public int put(int[] idx, byte[] data, int offset, int length) {
         int t = type();
         if (data == null || length % CvType.channels(t) != 0)
-            throw new java.lang.UnsupportedOperationException(
+            throw new UnsupportedOperationException(
                     "Provided data element number (" +
                             (data == null ? 0 : data.length) +
                             ") should be multiple of the Mat channels count (" +
@@ -1253,14 +1253,14 @@ public class Mat {
         if (CvType.depth(t) == CvType.CV_8U || CvType.depth(t) == CvType.CV_8S) {
             return nPutBwIdxOffset(nativeObj, idx, length, offset, data);
         }
-        throw new java.lang.UnsupportedOperationException("Mat data type is not compatible: " + t);
+        throw new UnsupportedOperationException("Mat data type is not compatible: " + t);
     }
 
     // javadoc:Mat::get(row,col,data)
     public int get(int row, int col, byte[] data) {
         int t = type();
         if (data == null || data.length % CvType.channels(t) != 0)
-            throw new java.lang.UnsupportedOperationException(
+            throw new UnsupportedOperationException(
                     "Provided data element number (" +
                             (data == null ? 0 : data.length) +
                             ") should be multiple of the Mat channels count (" +
@@ -1268,14 +1268,14 @@ public class Mat {
         if (CvType.depth(t) == CvType.CV_8U || CvType.depth(t) == CvType.CV_8S) {
             return nGetB(nativeObj, row, col, data.length, data);
         }
-        throw new java.lang.UnsupportedOperationException("Mat data type is not compatible: " + t);
+        throw new UnsupportedOperationException("Mat data type is not compatible: " + t);
     }
 
     // javadoc:Mat::get(idx,data)
     public int get(int[] idx, byte[] data) {
         int t = type();
         if (data == null || data.length % CvType.channels(t) != 0)
-            throw new java.lang.UnsupportedOperationException(
+            throw new UnsupportedOperationException(
                     "Provided data element number (" +
                             (data == null ? 0 : data.length) +
                             ") should be multiple of the Mat channels count (" +
@@ -1285,14 +1285,14 @@ public class Mat {
         if (CvType.depth(t) == CvType.CV_8U || CvType.depth(t) == CvType.CV_8S) {
             return nGetBIdx(nativeObj, idx, data.length, data);
         }
-        throw new java.lang.UnsupportedOperationException("Mat data type is not compatible: " + t);
+        throw new UnsupportedOperationException("Mat data type is not compatible: " + t);
     }
 
     // javadoc:Mat::get(row,col,data)
     public int get(int row, int col, short[] data) {
         int t = type();
         if (data == null || data.length % CvType.channels(t) != 0)
-            throw new java.lang.UnsupportedOperationException(
+            throw new UnsupportedOperationException(
                     "Provided data element number (" +
                             (data == null ? 0 : data.length) +
                             ") should be multiple of the Mat channels count (" +
@@ -1300,14 +1300,14 @@ public class Mat {
         if (CvType.depth(t) == CvType.CV_16U || CvType.depth(t) == CvType.CV_16S) {
             return nGetS(nativeObj, row, col, data.length, data);
         }
-        throw new java.lang.UnsupportedOperationException("Mat data type is not compatible: " + t);
+        throw new UnsupportedOperationException("Mat data type is not compatible: " + t);
     }
 
     // javadoc:Mat::get(idx,data)
     public int get(int[] idx, short[] data) {
         int t = type();
         if (data == null || data.length % CvType.channels(t) != 0)
-            throw new java.lang.UnsupportedOperationException(
+            throw new UnsupportedOperationException(
                     "Provided data element number (" +
                             (data == null ? 0 : data.length) +
                             ") should be multiple of the Mat channels count (" +
@@ -1317,14 +1317,14 @@ public class Mat {
         if (CvType.depth(t) == CvType.CV_16U || CvType.depth(t) == CvType.CV_16S) {
             return nGetSIdx(nativeObj, idx, data.length, data);
         }
-        throw new java.lang.UnsupportedOperationException("Mat data type is not compatible: " + t);
+        throw new UnsupportedOperationException("Mat data type is not compatible: " + t);
     }
 
     // javadoc:Mat::get(row,col,data)
     public int get(int row, int col, int[] data) {
         int t = type();
         if (data == null || data.length % CvType.channels(t) != 0)
-            throw new java.lang.UnsupportedOperationException(
+            throw new UnsupportedOperationException(
                     "Provided data element number (" +
                             (data == null ? 0 : data.length) +
                             ") should be multiple of the Mat channels count (" +
@@ -1332,14 +1332,14 @@ public class Mat {
         if (CvType.depth(t) == CvType.CV_32S) {
             return nGetI(nativeObj, row, col, data.length, data);
         }
-        throw new java.lang.UnsupportedOperationException("Mat data type is not compatible: " + t);
+        throw new UnsupportedOperationException("Mat data type is not compatible: " + t);
     }
 
     // javadoc:Mat::get(idx,data)
     public int get(int[] idx, int[] data) {
         int t = type();
         if (data == null || data.length % CvType.channels(t) != 0)
-            throw new java.lang.UnsupportedOperationException(
+            throw new UnsupportedOperationException(
                     "Provided data element number (" +
                             (data == null ? 0 : data.length) +
                             ") should be multiple of the Mat channels count (" +
@@ -1349,14 +1349,14 @@ public class Mat {
         if (CvType.depth(t) == CvType.CV_32S) {
             return nGetIIdx(nativeObj, idx, data.length, data);
         }
-        throw new java.lang.UnsupportedOperationException("Mat data type is not compatible: " + t);
+        throw new UnsupportedOperationException("Mat data type is not compatible: " + t);
     }
 
     // javadoc:Mat::get(row,col,data)
     public int get(int row, int col, float[] data) {
         int t = type();
         if (data == null || data.length % CvType.channels(t) != 0)
-            throw new java.lang.UnsupportedOperationException(
+            throw new UnsupportedOperationException(
                     "Provided data element number (" +
                             (data == null ? 0 : data.length) +
                             ") should be multiple of the Mat channels count (" +
@@ -1364,14 +1364,14 @@ public class Mat {
         if (CvType.depth(t) == CvType.CV_32F) {
             return nGetF(nativeObj, row, col, data.length, data);
         }
-        throw new java.lang.UnsupportedOperationException("Mat data type is not compatible: " + t);
+        throw new UnsupportedOperationException("Mat data type is not compatible: " + t);
     }
 
     // javadoc:Mat::get(idx,data)
     public int get(int[] idx, float[] data) {
         int t = type();
         if (data == null || data.length % CvType.channels(t) != 0)
-            throw new java.lang.UnsupportedOperationException(
+            throw new UnsupportedOperationException(
                     "Provided data element number (" +
                             (data == null ? 0 : data.length) +
                             ") should be multiple of the Mat channels count (" +
@@ -1381,14 +1381,14 @@ public class Mat {
         if (CvType.depth(t) == CvType.CV_32F) {
             return nGetFIdx(nativeObj, idx, data.length, data);
         }
-        throw new java.lang.UnsupportedOperationException("Mat data type is not compatible: " + t);
+        throw new UnsupportedOperationException("Mat data type is not compatible: " + t);
     }
 
     // javadoc:Mat::get(row,col,data)
     public int get(int row, int col, double[] data) {
         int t = type();
         if (data == null || data.length % CvType.channels(t) != 0)
-            throw new java.lang.UnsupportedOperationException(
+            throw new UnsupportedOperationException(
                     "Provided data element number (" +
                             (data == null ? 0 : data.length) +
                             ") should be multiple of the Mat channels count (" +
@@ -1396,14 +1396,14 @@ public class Mat {
         if (CvType.depth(t) == CvType.CV_64F) {
             return nGetD(nativeObj, row, col, data.length, data);
         }
-        throw new java.lang.UnsupportedOperationException("Mat data type is not compatible: " + t);
+        throw new UnsupportedOperationException("Mat data type is not compatible: " + t);
     }
 
     // javadoc:Mat::get(idx,data)
     public int get(int[] idx, double[] data) {
         int t = type();
         if (data == null || data.length % CvType.channels(t) != 0)
-            throw new java.lang.UnsupportedOperationException(
+            throw new UnsupportedOperationException(
                     "Provided data element number (" +
                             (data == null ? 0 : data.length) +
                             ") should be multiple of the Mat channels count (" +
@@ -1413,7 +1413,7 @@ public class Mat {
         if (CvType.depth(t) == CvType.CV_64F) {
             return nGetDIdx(nativeObj, idx, data.length, data);
         }
-        throw new java.lang.UnsupportedOperationException("Mat data type is not compatible: " + t);
+        throw new UnsupportedOperationException("Mat data type is not compatible: " + t);
     }
 
     // javadoc:Mat::get(row,col)

--- a/modules/imgproc/misc/java/src/java/imgproc+Moments.java
+++ b/modules/imgproc/misc/java/src/java/imgproc+Moments.java
@@ -1,7 +1,5 @@
 package org.opencv.imgproc;
 
-import java.lang.Math;
-
 //javadoc:Moments
 public class Moments {
 

--- a/modules/java/generator/android/java/org/opencv/android/Utils.java
+++ b/modules/java/generator/android/java/org/opencv/android/Utils.java
@@ -87,9 +87,9 @@ public class Utils {
      */
     public static void bitmapToMat(Bitmap bmp, Mat mat, boolean unPremultiplyAlpha) {
         if (bmp == null)
-            throw new java.lang.IllegalArgumentException("bmp == null");
+            throw new IllegalArgumentException("bmp == null");
         if (mat == null)
-            throw new java.lang.IllegalArgumentException("mat == null");
+            throw new IllegalArgumentException("mat == null");
         nBitmapToMat2(bmp, mat.nativeObj, unPremultiplyAlpha);
     }
 
@@ -117,9 +117,9 @@ public class Utils {
      */
     public static void matToBitmap(Mat mat, Bitmap bmp, boolean premultiplyAlpha) {
         if (mat == null)
-            throw new java.lang.IllegalArgumentException("mat == null");
+            throw new IllegalArgumentException("mat == null");
         if (bmp == null)
-            throw new java.lang.IllegalArgumentException("bmp == null");
+            throw new IllegalArgumentException("bmp == null");
         nMatToBitmap2(mat.nativeObj, bmp, premultiplyAlpha);
     }
 

--- a/modules/java/generator/src/java/org/opencv/utils/Converters.java
+++ b/modules/java/generator/src/java/org/opencv/utils/Converters.java
@@ -159,11 +159,11 @@ public class Converters {
 
     public static void Mat_to_vector_Point(Mat m, List<Point> pts) {
         if (pts == null)
-            throw new java.lang.IllegalArgumentException("Output List can't be null");
+            throw new IllegalArgumentException("Output List can't be null");
         int count = m.rows();
         int type = m.type();
         if (m.cols() != 1)
-            throw new java.lang.IllegalArgumentException("Input Mat should have one column\n" + m);
+            throw new IllegalArgumentException("Input Mat should have one column\n" + m);
 
         pts.clear();
         if (type == CvType.CV_32SC2) {
@@ -185,7 +185,7 @@ public class Converters {
                 pts.add(new Point(buff[i * 2], buff[i * 2 + 1]));
             }
         } else {
-            throw new java.lang.IllegalArgumentException(
+            throw new IllegalArgumentException(
                     "Input Mat should be of CV_32SC2, CV_32FC2 or CV_64FC2 type\n" + m);
         }
     }
@@ -204,11 +204,11 @@ public class Converters {
 
     public static void Mat_to_vector_Point3(Mat m, List<Point3> pts) {
         if (pts == null)
-            throw new java.lang.IllegalArgumentException("Output List can't be null");
+            throw new IllegalArgumentException("Output List can't be null");
         int count = m.rows();
         int type = m.type();
         if (m.cols() != 1)
-            throw new java.lang.IllegalArgumentException("Input Mat should have one column\n" + m);
+            throw new IllegalArgumentException("Input Mat should have one column\n" + m);
 
         pts.clear();
         if (type == CvType.CV_32SC3) {
@@ -230,7 +230,7 @@ public class Converters {
                 pts.add(new Point3(buff[i * 3], buff[i * 3 + 1], buff[i * 3 + 2]));
             }
         } else {
-            throw new java.lang.IllegalArgumentException(
+            throw new IllegalArgumentException(
                     "Input Mat should be of CV_32SC3, CV_32FC3 or CV_64FC3 type\n" + m);
         }
     }
@@ -255,10 +255,10 @@ public class Converters {
 
     public static void Mat_to_vector_Mat(Mat m, List<Mat> mats) {
         if (mats == null)
-            throw new java.lang.IllegalArgumentException("mats == null");
+            throw new IllegalArgumentException("mats == null");
         int count = m.rows();
         if (CvType.CV_32SC2 != m.type() || m.cols() != 1)
-            throw new java.lang.IllegalArgumentException(
+            throw new IllegalArgumentException(
                     "CvType.CV_32SC2 != m.type() ||  m.cols()!=1\n" + m);
 
         mats.clear();
@@ -289,10 +289,10 @@ public class Converters {
 
     public static void Mat_to_vector_float(Mat m, List<Float> fs) {
         if (fs == null)
-            throw new java.lang.IllegalArgumentException("fs == null");
+            throw new IllegalArgumentException("fs == null");
         int count = m.rows();
         if (CvType.CV_32FC1 != m.type() || m.cols() != 1)
-            throw new java.lang.IllegalArgumentException(
+            throw new IllegalArgumentException(
                     "CvType.CV_32FC1 != m.type() ||  m.cols()!=1\n" + m);
 
         fs.clear();
@@ -322,10 +322,10 @@ public class Converters {
 
     public static void Mat_to_vector_uchar(Mat m, List<Byte> us) {
         if (us == null)
-            throw new java.lang.IllegalArgumentException("Output List can't be null");
+            throw new IllegalArgumentException("Output List can't be null");
         int count = m.rows();
         if (CvType.CV_8UC1 != m.type() || m.cols() != 1)
-            throw new java.lang.IllegalArgumentException(
+            throw new IllegalArgumentException(
                     "CvType.CV_8UC1 != m.type() ||  m.cols()!=1\n" + m);
 
         us.clear();
@@ -372,10 +372,10 @@ public class Converters {
 
     public static void Mat_to_vector_int(Mat m, List<Integer> is) {
         if (is == null)
-            throw new java.lang.IllegalArgumentException("is == null");
+            throw new IllegalArgumentException("is == null");
         int count = m.rows();
         if (CvType.CV_32SC1 != m.type() || m.cols() != 1)
-            throw new java.lang.IllegalArgumentException(
+            throw new IllegalArgumentException(
                     "CvType.CV_32SC1 != m.type() ||  m.cols()!=1\n" + m);
 
         is.clear();
@@ -388,10 +388,10 @@ public class Converters {
 
     public static void Mat_to_vector_char(Mat m, List<Byte> bs) {
         if (bs == null)
-            throw new java.lang.IllegalArgumentException("Output List can't be null");
+            throw new IllegalArgumentException("Output List can't be null");
         int count = m.rows();
         if (CvType.CV_8SC1 != m.type() || m.cols() != 1)
-            throw new java.lang.IllegalArgumentException(
+            throw new IllegalArgumentException(
                     "CvType.CV_8SC1 != m.type() ||  m.cols()!=1\n" + m);
 
         bs.clear();
@@ -424,10 +424,10 @@ public class Converters {
 
     public static void Mat_to_vector_Rect(Mat m, List<Rect> rs) {
         if (rs == null)
-            throw new java.lang.IllegalArgumentException("rs == null");
+            throw new IllegalArgumentException("rs == null");
         int count = m.rows();
         if (CvType.CV_32SC4 != m.type() || m.cols() != 1)
-            throw new java.lang.IllegalArgumentException(
+            throw new IllegalArgumentException(
                     "CvType.CV_32SC4 != m.type() ||  m.rows()!=1\n" + m);
 
         rs.clear();
@@ -460,10 +460,10 @@ public class Converters {
 
     public static void Mat_to_vector_Rect2d(Mat m, List<Rect2d> rs) {
         if (rs == null)
-            throw new java.lang.IllegalArgumentException("rs == null");
+            throw new IllegalArgumentException("rs == null");
         int count = m.rows();
         if (CvType.CV_64FC4 != m.type() || m.cols() != 1)
-            throw new java.lang.IllegalArgumentException(
+            throw new IllegalArgumentException(
                                                          "CvType.CV_64FC4 != m.type() ||  m.rows()!=1\n" + m);
 
         rs.clear();
@@ -499,10 +499,10 @@ public class Converters {
 
     public static void Mat_to_vector_KeyPoint(Mat m, List<KeyPoint> kps) {
         if (kps == null)
-            throw new java.lang.IllegalArgumentException("Output List can't be null");
+            throw new IllegalArgumentException("Output List can't be null");
         int count = m.rows();
         if (CvType.CV_64FC(7) != m.type() || m.cols() != 1)
-            throw new java.lang.IllegalArgumentException(
+            throw new IllegalArgumentException(
                     "CvType.CV_64FC(7) != m.type() ||  m.cols()!=1\n" + m);
 
         kps.clear();
@@ -530,10 +530,10 @@ public class Converters {
 
     public static void Mat_to_vector_vector_Point(Mat m, List<MatOfPoint> pts) {
         if (pts == null)
-            throw new java.lang.IllegalArgumentException("Output List can't be null");
+            throw new IllegalArgumentException("Output List can't be null");
 
         if (m == null)
-            throw new java.lang.IllegalArgumentException("Input Mat can't be null");
+            throw new IllegalArgumentException("Input Mat can't be null");
 
         List<Mat> mats = new ArrayList<Mat>(m.rows());
         Mat_to_vector_Mat(m, mats);
@@ -548,10 +548,10 @@ public class Converters {
     // vector_vector_Point2f
     public static void Mat_to_vector_vector_Point2f(Mat m, List<MatOfPoint2f> pts) {
         if (pts == null)
-            throw new java.lang.IllegalArgumentException("Output List can't be null");
+            throw new IllegalArgumentException("Output List can't be null");
 
         if (m == null)
-            throw new java.lang.IllegalArgumentException("Input Mat can't be null");
+            throw new IllegalArgumentException("Input Mat can't be null");
 
         List<Mat> mats = new ArrayList<Mat>(m.rows());
         Mat_to_vector_Mat(m, mats);
@@ -580,10 +580,10 @@ public class Converters {
     // vector_vector_Point3f
     public static void Mat_to_vector_vector_Point3f(Mat m, List<MatOfPoint3f> pts) {
         if (pts == null)
-            throw new java.lang.IllegalArgumentException("Output List can't be null");
+            throw new IllegalArgumentException("Output List can't be null");
 
         if (m == null)
-            throw new java.lang.IllegalArgumentException("Input Mat can't be null");
+            throw new IllegalArgumentException("Input Mat can't be null");
 
         List<Mat> mats = new ArrayList<Mat>(m.rows());
         Mat_to_vector_Mat(m, mats);
@@ -625,10 +625,10 @@ public class Converters {
 
     public static void Mat_to_vector_vector_KeyPoint(Mat m, List<MatOfKeyPoint> kps) {
         if (kps == null)
-            throw new java.lang.IllegalArgumentException("Output List can't be null");
+            throw new IllegalArgumentException("Output List can't be null");
 
         if (m == null)
-            throw new java.lang.IllegalArgumentException("Input Mat can't be null");
+            throw new IllegalArgumentException("Input Mat can't be null");
 
         List<Mat> mats = new ArrayList<Mat>(m.rows());
         Mat_to_vector_Mat(m, mats);
@@ -659,10 +659,10 @@ public class Converters {
 
     public static void Mat_to_vector_double(Mat m, List<Double> ds) {
         if (ds == null)
-            throw new java.lang.IllegalArgumentException("ds == null");
+            throw new IllegalArgumentException("ds == null");
         int count = m.rows();
         if (CvType.CV_64FC1 != m.type() || m.cols() != 1)
-            throw new java.lang.IllegalArgumentException(
+            throw new IllegalArgumentException(
                     "CvType.CV_64FC1 != m.type() ||  m.cols()!=1\n" + m);
 
         ds.clear();
@@ -695,10 +695,10 @@ public class Converters {
 
     public static void Mat_to_vector_DMatch(Mat m, List<DMatch> matches) {
         if (matches == null)
-            throw new java.lang.IllegalArgumentException("Output List can't be null");
+            throw new IllegalArgumentException("Output List can't be null");
         int count = m.rows();
         if (CvType.CV_64FC4 != m.type() || m.cols() != 1)
-            throw new java.lang.IllegalArgumentException(
+            throw new IllegalArgumentException(
                     "CvType.CV_64FC4 != m.type() ||  m.cols()!=1\n" + m);
 
         matches.clear();
@@ -725,10 +725,10 @@ public class Converters {
 
     public static void Mat_to_vector_vector_DMatch(Mat m, List<MatOfDMatch> lvdm) {
         if (lvdm == null)
-            throw new java.lang.IllegalArgumentException("Output List can't be null");
+            throw new IllegalArgumentException("Output List can't be null");
 
         if (m == null)
-            throw new java.lang.IllegalArgumentException("Input Mat can't be null");
+            throw new IllegalArgumentException("Input Mat can't be null");
 
         List<Mat> mats = new ArrayList<Mat>(m.rows());
         Mat_to_vector_Mat(m, mats);
@@ -757,10 +757,10 @@ public class Converters {
 
     public static void Mat_to_vector_vector_char(Mat m, List<List<Byte>> llb) {
         if (llb == null)
-            throw new java.lang.IllegalArgumentException("Output List can't be null");
+            throw new IllegalArgumentException("Output List can't be null");
 
         if (m == null)
-            throw new java.lang.IllegalArgumentException("Input Mat can't be null");
+            throw new IllegalArgumentException("Input Mat can't be null");
 
         List<Mat> mats = new ArrayList<Mat>(m.rows());
         Mat_to_vector_Mat(m, mats);
@@ -796,10 +796,10 @@ public class Converters {
 
     public static void Mat_to_vector_RotatedRect(Mat m, List<RotatedRect> rs) {
         if (rs == null)
-            throw new java.lang.IllegalArgumentException("rs == null");
+            throw new IllegalArgumentException("rs == null");
         int count = m.rows();
         if (CvType.CV_32FC(5) != m.type() || m.cols() != 1)
-            throw new java.lang.IllegalArgumentException(
+            throw new IllegalArgumentException(
                     "CvType.CV_32FC5 != m.type() ||  m.rows()!=1\n" + m);
 
         rs.clear();


### PR DESCRIPTION
### This pullrequest changes

<!-- Please describe what your pullrequest is changing -->

In java, `java.lang` package is implicitly imported, so there is no need to fully qualify the classes, e.g. it would be redundant to say `java.lang.String`.