### PR TITLE
java: fix sample code to work on Windows.

### DIFF
--- a/doc/tutorials/introduction/desktop_java/java_dev_intro.markdown
+++ b/doc/tutorials/introduction/desktop_java/java_dev_intro.markdown
@@ -274,7 +274,8 @@ class DetectFaceDemo {
 
     // Create a face detector from the cascade file in the resources
     // directory.
-    CascadeClassifier faceDetector = new CascadeClassifier(getClass().getResource("/lbpcascade_frontalface.xml").getPath());
+    File file = new File(getClass().getResource("/lbpcascade_frontalface.xml").getFile());
+    CascadeClassifier faceDetector = new CascadeClassifier(file.toString());
     Mat image = Imgcodecs.imread(getClass().getResource("/lena.png").getPath());
 
     // Detect faces in the image.


### PR DESCRIPTION
resolves #5080 

This PR changes the sample code in the tutorial to use correct file format in Windows. Since `URL.getPath` returns a string starting with `\` which is incorrect from C++ perspective.