### PR TITLE
java: add CascadeClassifier(File) constructor

### DIFF
--- a/doc/tutorials/introduction/desktop_java/java_dev_intro.markdown
+++ b/doc/tutorials/introduction/desktop_java/java_dev_intro.markdown
@@ -274,7 +274,8 @@ class DetectFaceDemo {
 
     // Create a face detector from the cascade file in the resources
     // directory.
-    CascadeClassifier faceDetector = new CascadeClassifier(getClass().getResource("/lbpcascade_frontalface.xml").getPath());
+    File file = new File(getClass().getResource("/lbpcascade_frontalface.xml").getFile());
+    CascadeClassifier faceDetector = new CascadeClassifier(file);
     Mat image = Imgcodecs.imread(getClass().getResource("/lena.png").getPath());
 
     // Detect faces in the image.

--- a/modules/objdetect/misc/java/gen_dict.json
+++ b/modules/objdetect/misc/java/gen_dict.json
@@ -1,0 +1,17 @@
+{
+    "ManualFuncs" : {
+        "CascadeClassifier" : {
+            "pathConstructor" : {
+                "j_code" : [
+                    "\n",
+                    "public CascadeClassifier(java.io.File file) {",
+                    "    this(file.toString());",
+                    "}",
+                    "\n"
+                ],
+                "jn_code" : [],
+                "cpp_code" : []
+            }
+        }
+    }
+}

--- a/modules/objdetect/misc/java/test/CascadeClassifierTest.java
+++ b/modules/objdetect/misc/java/test/CascadeClassifierTest.java
@@ -8,6 +8,7 @@ import org.opencv.objdetect.CascadeClassifier;
 import org.opencv.objdetect.Objdetect;
 import org.opencv.test.OpenCVTestCase;
 import org.opencv.test.OpenCVTestRunner;
+import java.io.File;
 
 public class CascadeClassifierTest extends OpenCVTestCase {
 
@@ -98,6 +99,12 @@ public class CascadeClassifierTest extends OpenCVTestCase {
     public void testLoad() {
         cc = new CascadeClassifier();
         cc.load(OpenCVTestRunner.LBPCASCADE_FRONTALFACE_PATH);
+        assertTrue(!cc.empty());
+    }
+
+    public void testPath() {
+        File file = new File(OpenCVTestRunner.LBPCASCADE_FRONTALFACE_PATH);
+        cc = new CascadeClassifier(file);
         assertTrue(!cc.empty());
     }
 


### PR DESCRIPTION
As discussed in #5080 

This change adds a constructor to `CascadeClassifier` with `File` parameter.