### PR TITLE
java: test: use assertNotNull and assertFalse

### DIFF
--- a/modules/calib3d/misc/java/test/Calib3dTest.java
+++ b/modules/calib3d/misc/java/test/Calib3dTest.java
@@ -177,7 +177,7 @@ public class Calib3dTest extends OpenCVTestCase {
         Size patternSize = new Size(9, 6);
         MatOfPoint2f corners = new MatOfPoint2f();
         Calib3d.findChessboardCorners(grayChess, patternSize, corners);
-        assertTrue(!corners.empty());
+        assertFalse(corners.empty());
     }
 
     public void testFindChessboardCornersMatSizeMatInt() {
@@ -185,7 +185,7 @@ public class Calib3dTest extends OpenCVTestCase {
         MatOfPoint2f corners = new MatOfPoint2f();
         Calib3d.findChessboardCorners(grayChess, patternSize, corners, Calib3d.CALIB_CB_ADAPTIVE_THRESH + Calib3d.CALIB_CB_NORMALIZE_IMAGE
                 + Calib3d.CALIB_CB_FAST_CHECK);
-        assertTrue(!corners.empty());
+        assertFalse(corners.empty());
     }
 
     public void testFind4QuadCornerSubpix() {
@@ -194,7 +194,7 @@ public class Calib3dTest extends OpenCVTestCase {
         Size region_size = new Size(5, 5);
         Calib3d.findChessboardCorners(grayChess, patternSize, corners);
         Calib3d.find4QuadCornerSubpix(grayChess, corners, region_size);
-        assertTrue(!corners.empty());
+        assertFalse(corners.empty());
     }
 
     public void testFindCirclesGridMatSizeMat() {

--- a/modules/core/misc/java/test/MatTest.java
+++ b/modules/core/misc/java/test/MatTest.java
@@ -266,7 +266,7 @@ public class MatTest extends OpenCVTestCase {
 
     public void testEmpty() {
         assertTrue(dst.empty());
-        assertTrue(!gray0.empty());
+        assertFalse(gray0.empty());
     }
 
     public void testEyeIntIntInt() {
@@ -1194,7 +1194,7 @@ public class MatTest extends OpenCVTestCase {
     }
 
     public void testToString() {
-        assertTrue(null != gray0.toString());
+        assertNotNull(gray0.toString());
     }
 
     public void testTotal() {

--- a/modules/core/misc/java/test/RotatedRectTest.java
+++ b/modules/core/misc/java/test/RotatedRectTest.java
@@ -48,7 +48,7 @@ public class RotatedRectTest extends OpenCVTestCase {
         RotatedRect rrect = new RotatedRect(center, size, angle);
         RotatedRect clone = rrect.clone();
 
-        assertTrue(clone != null);
+        assertNotNull(clone);
         assertTrue(rrect.center.equals(clone.center));
         assertTrue(rrect.size.equals(clone.size));
         assertTrue(rrect.angle == clone.angle);
@@ -66,24 +66,24 @@ public class RotatedRectTest extends OpenCVTestCase {
         RotatedRect clone2 = rrect2.clone();
 
         assertTrue(rrect1.equals(rrect3));
-        assertTrue(!rrect1.equals(rrect2));
+        assertFalse(rrect1.equals(rrect2));
 
         assertTrue(rrect2.equals(clone2));
         clone2.angle = 10;
-        assertTrue(!rrect2.equals(clone2));
+        assertFalse(rrect2.equals(clone2));
 
         assertTrue(rrect1.equals(clone1));
 
         clone1.center.x += 1;
-        assertTrue(!rrect1.equals(clone1));
+        assertFalse(rrect1.equals(clone1));
 
         clone1.center.x -= 1;
         assertTrue(rrect1.equals(clone1));
 
         clone1.size.width += 1;
-        assertTrue(!rrect1.equals(clone1));
+        assertFalse(rrect1.equals(clone1));
 
-        assertTrue(!rrect1.equals(size));
+        assertFalse(rrect1.equals(size));
     }
 
     public void testHashCode() {
@@ -140,10 +140,10 @@ public class RotatedRectTest extends OpenCVTestCase {
     public void testRotatedRect() {
         RotatedRect rr = new RotatedRect();
 
-        assertTrue(rr != null);
-        assertTrue(rr.center != null);
-        assertTrue(rr.size != null);
-        assertTrue(rr.angle == 0.0);
+        assertNotNull(rr);
+        assertNotNull(rr.center);
+        assertNotNull(rr.size);
+        assertEquals(0.0, rr.angle);
     }
 
     public void testRotatedRectDoubleArray() {
@@ -161,10 +161,10 @@ public class RotatedRectTest extends OpenCVTestCase {
     public void testRotatedRectPointSizeDouble() {
         RotatedRect rr = new RotatedRect(center, size, 40);
 
-        assertTrue(rr != null);
-        assertTrue(rr.center != null);
-        assertTrue(rr.size != null);
-        assertTrue(rr.angle == 40.0);
+        assertNotNull(rr);
+        assertNotNull(rr.center);
+        assertNotNull(rr.size);
+        assertEquals(40.0, rr.angle);
     }
 
     public void testSet() {

--- a/modules/imgcodecs/misc/java/test/ImgcodecsTest.java
+++ b/modules/imgcodecs/misc/java/test/ImgcodecsTest.java
@@ -38,7 +38,7 @@ public class ImgcodecsTest extends OpenCVTestCase {
 
     public void testImreadString() {
         dst = Imgcodecs.imread(OpenCVTestRunner.LENA_PATH);
-        assertTrue(!dst.empty());
+        assertFalse(dst.empty());
         assertEquals(3, dst.channels());
         assertTrue(512 == dst.cols());
         assertTrue(512 == dst.rows());
@@ -46,7 +46,7 @@ public class ImgcodecsTest extends OpenCVTestCase {
 
     public void testImreadStringInt() {
         dst = Imgcodecs.imread(OpenCVTestRunner.LENA_PATH, 0);
-        assertTrue(!dst.empty());
+        assertFalse(dst.empty());
         assertEquals(1, dst.channels());
         assertTrue(512 == dst.cols());
         assertTrue(512 == dst.rows());

--- a/modules/java/test/android_test/src/org/opencv/test/OpenCVTestCase.java
+++ b/modules/java/test/android_test/src/org/opencv/test/OpenCVTestCase.java
@@ -581,7 +581,7 @@ public class OpenCVTestCase extends TestCase {
             message = TAG + " :: " + "could not instantiate " + cname + "! Exception: " + ex.getMessage();
         }
 
-        assertTrue(message, instance!=null);
+        assertNotNull(message, instance);
 
         return instance;
     }

--- a/modules/java/test/android_test/src/org/opencv/test/OpenCVTestRunner.java
+++ b/modules/java/test/android_test/src/org/opencv/test/OpenCVTestRunner.java
@@ -96,7 +96,7 @@ public class OpenCVTestRunner extends InstrumentationTestRunner {
         }
 
         context = getContext();
-        Assert.assertTrue("Context can't be 'null'", context != null);
+        Assert.assertNotNull("Context can't be 'null'", context);
         LENA_PATH = Utils.exportResource(context, R.drawable.lena);
         CHESS_PATH = Utils.exportResource(context, R.drawable.chessboard);
         LBPCASCADE_FRONTALFACE_PATH = Utils.exportResource(context, R.raw.lbpcascade_frontalface);

--- a/modules/java/test/android_test/src/org/opencv/test/android/UtilsTest.java
+++ b/modules/java/test/android_test/src/org/opencv/test/android/UtilsTest.java
@@ -74,7 +74,7 @@ public class UtilsTest extends OpenCVTestCase {
         // RGBA
         Mat imgRGBA = new Mat();
         Imgproc.cvtColor(imgBGR, imgRGBA, Imgproc.COLOR_BGR2RGBA);
-        assertTrue(!imgRGBA.empty() && imgRGBA.channels() == 4);
+        assertFalse(imgRGBA.empty() && imgRGBA.channels() == 4);
 
         bmp16.eraseColor(Color.BLACK); m16.setTo(s0);
         Utils.matToBitmap(imgRGBA, bmp16); Utils.bitmapToMat(bmp16, m16);
@@ -92,7 +92,7 @@ public class UtilsTest extends OpenCVTestCase {
         // RGB
         Mat imgRGB = new Mat();
         Imgproc.cvtColor(imgBGR, imgRGB, Imgproc.COLOR_BGR2RGB);
-        assertTrue(!imgRGB.empty() && imgRGB.channels() == 3);
+        assertFalse(imgRGB.empty() && imgRGB.channels() == 3);
 
         bmp16.eraseColor(Color.BLACK); m16.setTo(s0);
         Utils.matToBitmap(imgRGB, bmp16); Utils.bitmapToMat(bmp16, m16);
@@ -110,7 +110,7 @@ public class UtilsTest extends OpenCVTestCase {
         // Gray
         Mat imgGray = new Mat();
         Imgproc.cvtColor(imgBGR, imgGray, Imgproc.COLOR_BGR2GRAY);
-        assertTrue(!imgGray.empty() && imgGray.channels() == 1);
+        assertFalse(imgGray.empty() && imgGray.channels() == 1);
         Mat tmp = new Mat();
 
         bmp16.eraseColor(Color.BLACK); m16.setTo(s0);

--- a/modules/java/test/pure_test/src/org/opencv/test/OpenCVTestCase.java
+++ b/modules/java/test/pure_test/src/org/opencv/test/OpenCVTestCase.java
@@ -607,7 +607,7 @@ public class OpenCVTestCase extends TestCase {
             message = TAG + " :: " + "could not instantiate " + cname + "! Exception: " + ex.getMessage();
         }
 
-        assertTrue(message, instance!=null);
+        assertNotNull(message, instance);
 
         return instance;
     }

--- a/modules/objdetect/misc/java/test/CascadeClassifierTest.java
+++ b/modules/objdetect/misc/java/test/CascadeClassifierTest.java
@@ -22,12 +22,12 @@ public class CascadeClassifierTest extends OpenCVTestCase {
 
     public void testCascadeClassifier() {
         cc = new CascadeClassifier();
-        assertTrue(null != cc);
+        assertNotNull(cc);
     }
 
     public void testCascadeClassifierString() {
         cc = new CascadeClassifier(OpenCVTestRunner.LBPCASCADE_FRONTALFACE_PATH);
-        assertTrue(null != cc);
+        assertNotNull(cc);
     }
 
     public void testDetectMultiScaleMatListOfRect() {
@@ -98,7 +98,7 @@ public class CascadeClassifierTest extends OpenCVTestCase {
     public void testLoad() {
         cc = new CascadeClassifier();
         cc.load(OpenCVTestRunner.LBPCASCADE_FRONTALFACE_PATH);
-        assertTrue(!cc.empty());
+        assertFalse(cc.empty());
     }
 
 }


### PR DESCRIPTION
This is the first part of JUnit tests update, as they are with JUnit 3 syntax, while JUnit 4 syntax can be used. Another option is to migrate to JUnit 5, but that needs Java 8.

**Proposed change:**
To use specific assertions (e.g. `assertFalse`, `assertNotNull`, `assertEquals`) instead of `assertTrue` with condition. This leads to a little better readability.