### PR TITLE
java(test): test package filtering

### DIFF
--- a/modules/java/test/pure_test/build.xml
+++ b/modules/java/test/pure_test/build.xml
@@ -4,6 +4,9 @@
   <property name="test.dir" value="testResults"/>
   <property name="build.dir" value="build"/>
 
+  <property name="opencv.test.package" value="*"/>
+  <property name="opencv.test.class" value="*"/>
+
   <path id="master-classpath">
     <fileset dir="lib">
       <include name="*.jar"/>
@@ -38,7 +41,7 @@
 
   <target name="test" depends="jar">
     <mkdir dir="${test.dir}"/>
-    <junit printsummary="true" haltonfailure="false" haltonerror="false" showoutput="true" logfailedtests="true" maxmemory="256m">
+    <junit printsummary="withOutAndErr" haltonfailure="false" haltonerror="false" showoutput="true" logfailedtests="true" maxmemory="256m">
       <sysproperty key="java.library.path" path="${opencv.lib.path}"/>
       <env key="PATH" path="${opencv.lib.path}:${env.PATH}:${env.Path}"/>
       <env key="DYLD_LIBRARY_PATH" path="${env.OPENCV_SAVED_DYLD_LIBRARY_PATH}"/>  <!-- https://github.com/opencv/opencv/issues/14353 -->
@@ -50,7 +53,7 @@
       <formatter type="xml"/>
 
       <batchtest fork="yes" todir="${test.dir}">
-        <zipfileset src="build/jar/opencv-test.jar" includes="**/*.class" excludes="**/OpenCVTest*">
+        <zipfileset src="build/jar/opencv-test.jar" includes="**/${opencv.test.package}/${opencv.test.class}.class" excludes="**/OpenCVTest*">
           <exclude name="**/*$*.class"/>
         </zipfileset>
       </batchtest>

--- a/modules/ts/misc/run.py
+++ b/modules/ts/misc/run.py
@@ -50,7 +50,7 @@ if __name__ == "__main__":
     parser.add_argument("--android_env", action='append', help="Android: add environment variable (NAME=VALUE)")
     parser.add_argument("--android_propagate_opencv_env", action="store_true", default=False, help="Android: propagate OPENCV* environment variables")
     parser.add_argument("--serial", metavar="serial number", default="", help="Android: directs command to the USB device or emulator with the given serial number")
-    parser.add_argument("--package", metavar="package", default="", help="Android: run jUnit tests for specified package")
+    parser.add_argument("--package", metavar="package", default="", help="Java: run JUnit tests for specified module or Android package")
 
     parser.add_argument("--trace", action="store_true", default=False, help="Trace: enable OpenCV tracing")
     parser.add_argument("--trace_dump", metavar="trace_dump", default=-1, help="Trace: dump highlight calls (specify max entries count, 0 - dump all)")

--- a/modules/ts/misc/run_suite.py
+++ b/modules/ts/misc/run_suite.py
@@ -112,7 +112,10 @@ class TestSuite(object):
         args = args[:]
         exe = os.path.abspath(path)
         if module == "java":
-            cmd = [self.cache.ant_executable, "-Dopencv.build.type=%s" % self.cache.build_type, "buildAndTest"]
+            cmd = [self.cache.ant_executable, "-Dopencv.build.type=%s" % self.cache.build_type]
+            if self.options.package:
+                cmd += ["-Dopencv.test.package=%s" % self.options.package]
+            cmd += ["buildAndTest"]
             ret = execute(cmd, cwd=self.cache.java_test_dir)
             return None, ret
         elif module in ['python2', 'python3']:


### PR DESCRIPTION
Usage example:
- `run.py -a -t java --package=calib3d`
