### PR TITLE
Update matchers.cpp

### DIFF
--- a/modules/stitching/src/matchers.cpp
+++ b/modules/stitching/src/matchers.cpp
@@ -340,7 +340,7 @@ void FeaturesMatcher::operator ()(const std::vector<ImageFeatures> &features, st
 {
     const int num_images = static_cast<int>(features.size());
 
-    CV_Assert(mask.empty() || (mask.type() == CV_8U && mask.cols == num_images && mask.rows));
+    CV_Assert(mask.empty() || (mask.type() == CV_8U && mask.cols == num_images && mask.rows == num_images));
     Mat_<uchar> mask_(mask.getMat(ACCESS_READ));
     if (mask_.empty())
         mask_ = Mat::ones(num_images, num_images, CV_8U);
@@ -489,7 +489,7 @@ void BestOf2NearestRangeMatcher::operator ()(const std::vector<ImageFeatures> &f
 {
     const int num_images = static_cast<int>(features.size());
 
-    CV_Assert(mask.empty() || (mask.type() == CV_8U && mask.cols == num_images && mask.rows));
+    CV_Assert(mask.empty() || (mask.type() == CV_8U && mask.cols == num_images && mask.rows == num_images));
     Mat_<uchar> mask_(mask.getMat(ACCESS_READ));
     if (mask_.empty())
         mask_ = Mat::ones(num_images, num_images, CV_8U);


### PR DESCRIPTION
<!-- Please use this line to close one or multiple issues when this pullrequest gets merged
You can add another line right under the first one:
resolves #1234
resolves #1235
-->

### This pullrequest changes

The line "CV_Assert(mask.empty() || (mask.type() == CV_8U && mask.cols == num_images && mask.rows))" does not allow for giving a non-empty mask as parameter. By modifying as "CV_Assert(mask.empty() || (mask.type() == CV_8U && mask.cols == num_images && mask.rows == num_images))", this bug should be fixed. 
