### PR TITLE
G-API Introduce GAPI_TRANSFORM initial interface

### DIFF
--- a/modules/gapi/include/opencv2/gapi/cpu/gcpukernel.hpp
+++ b/modules/gapi/include/opencv2/gapi/cpu/gcpukernel.hpp
@@ -2,7 +2,7 @@
 // It is subject to the license terms in the LICENSE file found in the top-level directory
 // of this distribution and at http://opencv.org/license.html.
 //
-// Copyright (C) 2019 Intel Corporation
+// Copyright (C) 2018-2019 Intel Corporation
 
 
 #ifndef OPENCV_GAPI_GCPUKERNEL_HPP

--- a/modules/gapi/include/opencv2/gapi/cpu/gcpukernel.hpp
+++ b/modules/gapi/include/opencv2/gapi/cpu/gcpukernel.hpp
@@ -2,7 +2,7 @@
 // It is subject to the license terms in the LICENSE file found in the top-level directory
 // of this distribution and at http://opencv.org/license.html.
 //
-// Copyright (C) 2018 Intel Corporation
+// Copyright (C) 2019 Intel Corporation
 
 
 #ifndef OPENCV_GAPI_GCPUKERNEL_HPP

--- a/modules/gapi/include/opencv2/gapi/cpu/gcpukernel.hpp
+++ b/modules/gapi/include/opencv2/gapi/cpu/gcpukernel.hpp
@@ -19,6 +19,7 @@
 #include <opencv2/gapi/garg.hpp>
 #include <opencv2/gapi/own/convert.hpp> //to_ocv
 #include <opencv2/gapi/util/compiler_hints.hpp> //suppress_unused_warning
+#include <opencv2/gapi/util/util.hpp>
 
 // FIXME: namespace scheme for backends?
 namespace cv {
@@ -258,7 +259,8 @@ struct OCVCallHelper<Impl, std::tuple<Ins...>, std::tuple<Outs...> >
 } // namespace detail
 
 template<class Impl, class K>
-class GCPUKernelImpl: public detail::OCVCallHelper<Impl, typename K::InArgs, typename K::OutArgs>
+class GCPUKernelImpl: public detail::OCVCallHelper<Impl, typename K::InArgs, typename K::OutArgs>,
+                      public cv::detail::KernelTag
 {
     using P = detail::OCVCallHelper<Impl, typename K::InArgs, typename K::OutArgs>;
 

--- a/modules/gapi/include/opencv2/gapi/cpu/gcpukernel.hpp
+++ b/modules/gapi/include/opencv2/gapi/cpu/gcpukernel.hpp
@@ -259,7 +259,7 @@ struct OCVCallHelper<Impl, std::tuple<Ins...>, std::tuple<Outs...> >
 } // namespace detail
 
 template<class Impl, class K>
-class GCPUKernelImpl: public detail::OCVCallHelper<Impl, typename K::InArgs, typename K::OutArgs>,
+class GCPUKernelImpl: public cv::detail::OCVCallHelper<Impl, typename K::InArgs, typename K::OutArgs>,
                       public cv::detail::KernelTag
 {
     using P = detail::OCVCallHelper<Impl, typename K::InArgs, typename K::OutArgs>;

--- a/modules/gapi/include/opencv2/gapi/fluid/gfluidkernel.hpp
+++ b/modules/gapi/include/opencv2/gapi/fluid/gfluidkernel.hpp
@@ -275,7 +275,7 @@ struct FluidCallHelper<Impl, std::tuple<Ins...>, std::tuple<Outs...>, UseScratch
 
 
 template<class Impl, class K, bool UseScratch>
-class GFluidKernelImpl
+class GFluidKernelImpl : public cv::detail::KernelTag
 {
     static const int LPI = 1;
     static const auto Kind = GFluidKernel::Kind::Filter;

--- a/modules/gapi/include/opencv2/gapi/fluid/gfluidkernel.hpp
+++ b/modules/gapi/include/opencv2/gapi/fluid/gfluidkernel.hpp
@@ -2,7 +2,7 @@
 // It is subject to the license terms in the LICENSE file found in the top-level directory
 // of this distribution and at http://opencv.org/license.html.
 //
-// Copyright (C) 2019 Intel Corporation
+// Copyright (C) 2018-2019 Intel Corporation
 
 
 #ifndef OPENCV_GAPI_FLUID_KERNEL_HPP

--- a/modules/gapi/include/opencv2/gapi/fluid/gfluidkernel.hpp
+++ b/modules/gapi/include/opencv2/gapi/fluid/gfluidkernel.hpp
@@ -2,7 +2,7 @@
 // It is subject to the license terms in the LICENSE file found in the top-level directory
 // of this distribution and at http://opencv.org/license.html.
 //
-// Copyright (C) 2018 Intel Corporation
+// Copyright (C) 2019 Intel Corporation
 
 
 #ifndef OPENCV_GAPI_FLUID_KERNEL_HPP

--- a/modules/gapi/include/opencv2/gapi/gcommon.hpp
+++ b/modules/gapi/include/opencv2/gapi/gcommon.hpp
@@ -30,7 +30,7 @@ namespace detail
         static const char* tag() { return ""; };
     };
 
-    // These structures are tags which suppose to separate kernels and transformations
+    // These structures are tags which separate kernels and transformations
     struct KernelTag
     {};
     struct TransformTag

--- a/modules/gapi/include/opencv2/gapi/gcommon.hpp
+++ b/modules/gapi/include/opencv2/gapi/gcommon.hpp
@@ -29,6 +29,12 @@ namespace detail
     {
         static const char* tag() { return ""; };
     };
+
+    // These structures are tags which suppose to separate kernels and transformations
+    struct KernelTag
+    {};
+    struct TransformTag
+    {};
 }
 
 // This definition is here because it is reused by both public(?) and internal

--- a/modules/gapi/include/opencv2/gapi/gcompoundkernel.hpp
+++ b/modules/gapi/include/opencv2/gapi/gcompoundkernel.hpp
@@ -104,7 +104,8 @@ struct GCompoundCallHelper<Impl, std::tuple<Ins...>, std::tuple<Outs...> >
 };
 
 template<class Impl, class K>
-class GCompoundKernelImpl: public cv::detail::GCompoundCallHelper<Impl, typename K::InArgs, typename K::OutArgs>
+class GCompoundKernelImpl: public cv::detail::GCompoundCallHelper<Impl, typename K::InArgs, typename K::OutArgs>,
+                           public cv::detail::KernelTag
 {
     using P = cv::detail::GCompoundCallHelper<Impl, typename K::InArgs, typename K::OutArgs>;
 

--- a/modules/gapi/include/opencv2/gapi/gcompoundkernel.hpp
+++ b/modules/gapi/include/opencv2/gapi/gcompoundkernel.hpp
@@ -2,7 +2,7 @@
 // It is subject to the license terms in the LICENSE file found in the top-level directory
 // of this distribution and at http://opencv.org/license.html.
 //
-// Copyright (C) 2018 Intel Corporation
+// Copyright (C) 2019 Intel Corporation
 
 
 #ifndef OPENCV_GAPI_GCOMPOUNDKERNEL_HPP

--- a/modules/gapi/include/opencv2/gapi/gcompoundkernel.hpp
+++ b/modules/gapi/include/opencv2/gapi/gcompoundkernel.hpp
@@ -2,7 +2,7 @@
 // It is subject to the license terms in the LICENSE file found in the top-level directory
 // of this distribution and at http://opencv.org/license.html.
 //
-// Copyright (C) 2019 Intel Corporation
+// Copyright (C) 2018-2019 Intel Corporation
 
 
 #ifndef OPENCV_GAPI_GCOMPOUNDKERNEL_HPP
@@ -63,22 +63,6 @@ template<typename U> struct get_compound_in<cv::GArray<U>>
         ctx.m_args[idx] = GArg(array);
         return array;
     }
-};
-
-// Kernel may return one object(GMat, GScalar) or a tuple of objects.
-// This helper is needed to cast return value to the same form(tuple)
-template<typename>
-struct tuple_wrap_helper;
-
-template<typename T> struct tuple_wrap_helper
-{
-    static std::tuple<T> get(T&& obj) { return std::make_tuple(std::move(obj)); }
-};
-
-template<typename... Objs>
-struct tuple_wrap_helper<std::tuple<Objs...>>
-{
-    static std::tuple<Objs...> get(std::tuple<Objs...>&& objs) { return std::forward<std::tuple<Objs...>>(objs); }
 };
 
 template<typename, typename, typename>

--- a/modules/gapi/include/opencv2/gapi/gkernel.hpp
+++ b/modules/gapi/include/opencv2/gapi/gkernel.hpp
@@ -388,12 +388,11 @@ namespace gapi {
         std::size_t size() const;
 
         /**
-         * @brief Returns total number of transformations
-         * in the package (across all backends included)
+         * @brief Returns vector of transformations included in the package
          *
-         * @return a number of transformations in the package
+         * @return vector of transformations included in the package
          */
-        std::size_t transform_size() const;
+        const std::vector<GTransform> &get_transformations() const;
 
         /**
          * @brief Test if a particular kernel _implementation_ KImpl is

--- a/modules/gapi/include/opencv2/gapi/gkernel.hpp
+++ b/modules/gapi/include/opencv2/gapi/gkernel.hpp
@@ -380,12 +380,20 @@ namespace gapi {
 
     public:
         /**
-         * @brief Returns total number of kernels and transformations
+         * @brief Returns total number of kernels
          * in the package (across all backends included)
          *
-         * @return a number of kernels and transformations in the package
+         * @return a number of kernels in the package
          */
         std::size_t size() const;
+
+        /**
+         * @brief Returns total number of transformations
+         * in the package (across all backends included)
+         *
+         * @return a number of transformations in the package
+         */
+        std::size_t transform_size() const;
 
         /**
          * @brief Test if a particular kernel _implementation_ KImpl is

--- a/modules/gapi/include/opencv2/gapi/gkernel.hpp
+++ b/modules/gapi/include/opencv2/gapi/gkernel.hpp
@@ -400,11 +400,15 @@ namespace gapi {
          *
          * @sa includesAPI()
          *
+         * @note cannot be applied to transformations
+         *
          * @return true if there is such kernel, false otherwise.
          */
         template<typename KImpl>
         bool includes() const
         {
+            static_assert(!(std::is_base_of<detail::TransformTag, KImpl>::value),
+                          "includes() cannot be applied to transformations");
             return includesHelper<KImpl>();
         }
 

--- a/modules/gapi/include/opencv2/gapi/gtransform.hpp
+++ b/modules/gapi/include/opencv2/gapi/gtransform.hpp
@@ -31,109 +31,53 @@ struct GAPI_EXPORTS GTransform
     explicit GTransform(const char *d, const F &p, const F &s) : description(d), pattern(p), substitute(s){};
 };
 
-template <class Impl>
-GTransform transformation()
+namespace detail
 {
-    return GTransform(Impl::descr(), &Impl::get_pattern, &Impl::get_substitute);
-}
-
-////////////////////////////////////////////////////////////////////
 
 template <typename, typename, typename>
 struct TransHelper;
 
-// FIXME: code duplication:
-// consider better approach like in compound kernels with tuple wrappers and context class
-
 template <typename K, typename... Ins, typename Out>
 struct TransHelper<K, std::tuple<Ins...>, Out>
 {
-    // FIXME: code duplication
-    template <int... IIs>
-    static GArgs get_pattern_impl(const GArgs &in_args, detail::Seq<IIs...>)
+    template <typename Callable, int... IIs, int... OIs>
+    static GArgs get_impl(Callable f, const GArgs &in_args, detail::Seq<IIs...>, detail::Seq<OIs...>)
     {
-        const Out r = K::pattern(in_args.at(IIs).template get<Ins>()...);
-        return GArgs{GArg(r)};
-    }
-
-    template <int... IIs>
-    static GArgs get_substitute_impl(const GArgs &in_args, detail::Seq<IIs...>)
-    {
-        const Out r = K::pattern(in_args.at(IIs).template get<Ins>()...);
-        return GArgs{GArg(r)};
-    }
-
-    static GArgs get_pattern(const GArgs &in_args)
-    {
-        return get_pattern_impl(in_args, typename detail::MkSeq<sizeof...(Ins)>::type());
-    }
-    static GArgs get_substitute(const GArgs &in_args)
-    {
-        return get_substitute_impl(in_args, typename detail::MkSeq<sizeof...(Ins)>::type());
-    }
-};
-
-template <typename K, typename... Ins, typename... Outs>
-struct TransHelper<K, std::tuple<Ins...>, std::tuple<Outs...>>
-{
-    // FIXME: code duplication
-    template <int... IIs, int... OIs>
-    static GArgs get_pattern_impl(const GArgs &in_args, detail::Seq<IIs...>, detail::Seq<OIs...>)
-    {
-        using R = std::tuple<Outs...>;
-        const R r = K::pattern(in_args.at(IIs).template get<Ins>()...);
-        return GArgs{GArg(std::get<OIs>(r))...};
-    }
-
-    template <int... IIs, int... OIs>
-    static GArgs get_substitute_impl(const GArgs &in_args, detail::Seq<IIs...>, detail::Seq<OIs...>)
-    {
-        using R = std::tuple<Outs...>;
-        const R r = K::pattern(in_args.at(IIs).template get<Ins>()...);
+        const auto r = detail::tuple_wrap_helper<Out>::get(f(in_args.at(IIs).template get<Ins>()...));
         return GArgs{GArg(std::get<OIs>(r))...};
     }
 
     static GArgs get_pattern(const GArgs &in_args)
     {
-        return get_pattern_impl(in_args, typename detail::MkSeq<sizeof...(Ins)>::type(),
-                                typename detail::MkSeq<sizeof...(Outs)>::type());
+        return get_impl(K::pattern, in_args, typename detail::MkSeq<sizeof...(Ins)>::type(),
+                        typename detail::MkSeq<std::tuple_size<typename detail::tuple_wrap_helper<Out>::type>::value>::type());
     }
     static GArgs get_substitute(const GArgs &in_args)
     {
-        return get_substitute_impl(in_args, typename detail::MkSeq<sizeof...(Ins)>::type(),
-                                   typename detail::MkSeq<sizeof...(Outs)>::type());
+        return get_impl(K::substitute, in_args, typename detail::MkSeq<sizeof...(Ins)>::type(),
+                        typename detail::MkSeq<std::tuple_size<typename detail::tuple_wrap_helper<Out>::type>::value>::type());
     }
 };
-
-/////////////////////////////////////////////////////////////////////
+} // namespace detail
 
 template <typename, typename>
 class GTransformImpl;
 
 template <typename K, typename R, typename... Args>
-class GTransformImpl<K, std::function<R(Args...)>> : public TransHelper<K, std::tuple<Args...>, R>,
+class GTransformImpl<K, std::function<R(Args...)>> : public detail::TransHelper<K, std::tuple<Args...>, R>,
                                                      public cv::detail::TransformTag
 {
 public:
     // FIXME: currently there is no check that transformations' signatures are unique
     // and won't be any intersection in graph compilation stage
     using API = K;
+
+    static GTransform transformation()
+    {
+        return GTransform(K::descr(), &K::get_pattern, &K::get_substitute);
+    }
 };
-
-template <typename, typename>
-class GTransformImplM;
-
-template <typename K, typename... R, typename... Args>
-class GTransformImplM<K, std::function<std::tuple<R...>(Args...)>> : public TransHelper<K, std::tuple<Args...>, std::tuple<R...>>,
-                                                                     public cv::detail::TransformTag
-{
-public:
-    // FIXME: currently there is no check that transformations' signatures are unique
-    // and won't be any intersection in graph compilation stage
-    using API = K;
-};
-
-//////////////////////////////////////////////////////////////////////
+} // namespace cv
 
 #define G_DESCR_HELPER_CLASS(Class) Class##DescrHelper
 
@@ -150,12 +94,5 @@ public:
     G_DESCR_HELPER_BODY(Class, Descr)                                         \
     struct Class final : public cv::GTransformImpl<Class, std::function API>, \
                          public detail::G_DESCR_HELPER_CLASS(Class)
-
-#define GAPI_TRANSFORM_M(Class, API, Descr)                                    \
-    G_DESCR_HELPER_BODY(Class, Descr)                                          \
-    struct Class final : public cv::GTransformImplM<Class, std::function API>, \
-                         public detail::G_DESCR_HELPER_CLASS(Class)
-
-} // namespace cv
 
 #endif // OPENCV_GAPI_GTRANSFORM_HPP

--- a/modules/gapi/include/opencv2/gapi/gtransform.hpp
+++ b/modules/gapi/include/opencv2/gapi/gtransform.hpp
@@ -41,7 +41,7 @@ template <typename K, typename... Ins, typename Out>
 struct TransHelper<K, std::tuple<Ins...>, Out>
 {
     template <typename Callable, int... IIs, int... OIs>
-    static GArgs get_impl(Callable f, const GArgs &in_args, Seq<IIs...>, Seq<OIs...>)
+    static GArgs invoke(Callable f, const GArgs &in_args, Seq<IIs...>, Seq<OIs...>)
     {
         const auto r = tuple_wrap_helper<Out>::get(f(in_args.at(IIs).template get<Ins>()...));
         return GArgs{GArg(std::get<OIs>(r))...};
@@ -49,13 +49,13 @@ struct TransHelper<K, std::tuple<Ins...>, Out>
 
     static GArgs get_pattern(const GArgs &in_args)
     {
-        return get_impl(K::pattern, in_args, typename MkSeq<sizeof...(Ins)>::type(),
-                        typename MkSeq<std::tuple_size<typename tuple_wrap_helper<Out>::type>::value>::type());
+        return invoke(K::pattern, in_args, typename MkSeq<sizeof...(Ins)>::type(),
+                      typename MkSeq<std::tuple_size<typename tuple_wrap_helper<Out>::type>::value>::type());
     }
     static GArgs get_substitute(const GArgs &in_args)
     {
-        return get_impl(K::substitute, in_args, typename MkSeq<sizeof...(Ins)>::type(),
-                        typename MkSeq<std::tuple_size<typename tuple_wrap_helper<Out>::type>::value>::type());
+        return invoke(K::substitute, in_args, typename MkSeq<sizeof...(Ins)>::type(),
+                      typename MkSeq<std::tuple_size<typename tuple_wrap_helper<Out>::type>::value>::type());
     }
 };
 } // namespace detail

--- a/modules/gapi/include/opencv2/gapi/gtransform.hpp
+++ b/modules/gapi/include/opencv2/gapi/gtransform.hpp
@@ -163,6 +163,10 @@ template <typename K, typename R, typename... Args>
 class GTransformImpl<K, std::function<R(Args...)>> : public TransHelper<K, std::tuple<Args...>, R>,
                                                      public cv::detail::TransformTag
 {
+public:
+    // FIXME: currently there is no check that transformations' signatures are unique
+    // and won't be any intersection in graph compilation stage
+    using API = K;
 };
 
 template <typename, typename>
@@ -172,6 +176,10 @@ template <typename K, typename... R, typename... Args>
 class GTransformImplM<K, std::function<std::tuple<R...>(Args...)>> : public TransHelper<K, std::tuple<Args...>, std::tuple<R...>>,
                                                                      public cv::detail::TransformTag
 {
+public:
+    // FIXME: currently there is no check that transformations' signatures are unique
+    // and won't be any intersection in graph compilation stage
+    using API = K;
 };
 
 //////////////////////////////////////////////////////////////////////

--- a/modules/gapi/include/opencv2/gapi/gtransform.hpp
+++ b/modules/gapi/include/opencv2/gapi/gtransform.hpp
@@ -24,11 +24,11 @@ struct GAPI_EXPORTS GTransform
 {
     using F = std::function<GArgs(const GArgs &)>;
 
-    const char *description;
+    std::string description;
     F pattern;
     F substitute;
 
-    GTransform(const char *d, const F &p, const F &s) : description(d), pattern(p), substitute(s){};
+    GTransform(const std::string& d, const F &p, const F &s) : description(d), pattern(p), substitute(s){};
 };
 
 namespace detail

--- a/modules/gapi/include/opencv2/gapi/gtransform.hpp
+++ b/modules/gapi/include/opencv2/gapi/gtransform.hpp
@@ -1,0 +1,202 @@
+// This file is part of OpenCV project.
+// It is subject to the license terms in the LICENSE file found in the top-level directory
+// of this distribution and at http://opencv.org/license.html.
+//
+// Copyright (C) 2019 Intel Corporation
+
+#ifndef OPENCV_GAPI_GTRANSFORM_HPP
+#define OPENCV_GAPI_GTRANSFORM_HPP
+
+#include <functional>
+#include <type_traits>
+#include <utility>
+
+#include <opencv2/gapi/gcommon.hpp>
+#include <opencv2/gapi/util/util.hpp>
+#include <opencv2/gapi/garg.hpp>
+#include <opencv2/gapi/gtype_traits.hpp>
+#include <opencv2/gapi/util/compiler_hints.hpp>
+
+namespace cv
+{
+
+template <typename T>
+struct TransType;
+template <>
+struct TransType<cv::GMat>
+{
+    using type = cv::GMat;
+};
+template <>
+struct TransType<cv::GMatP>
+{
+    using type = cv::GMat;
+};
+template <>
+struct TransType<cv::GScalar>
+{
+    using type = cv::GScalar;
+};
+template <typename U>
+struct TransType<cv::GArray<U>>
+{
+    using type = cv::GArray<U>;
+};
+template <typename T>
+struct TransType
+{
+    using type = T;
+};
+
+template <typename T>
+using is_nongapi_type2 = std::is_same<T, typename TransType<T>::type>;
+
+template <typename T>
+typename std::enable_if<!is_nongapi_type2<T>::value,
+                        typename TransType<T>::type>::type
+get_in_args(const GArgs &in_args, int idx)
+{
+    return util::get<typename TransType<T>::type>(in_args.at(idx));
+}
+
+template <typename T>
+typename std::enable_if<is_nongapi_type2<T>::value, T>::type get_in_args(const GArgs &in_args, int idx)
+{
+    return in_args.at(idx).template get<T>();
+}
+
+//////////////////////////////////////////////////////////////////////
+
+struct GAPI_EXPORTS GTransform
+{
+    using F = std::function<GArgs(const GArgs &)>;
+
+    const char *description;
+    F pattern;
+    F substitute;
+
+    explicit GTransform(const char *d, const F &p, const F &s) : description(d), pattern(p), substitute(s){};
+};
+
+template <class Impl>
+GTransform transformation()
+{
+    return GTransform(Impl::descr(), &Impl::get_pattern, &Impl::get_substitute);
+}
+
+////////////////////////////////////////////////////////////////////
+
+template <typename, typename, typename>
+struct TransHelper;
+
+// FIXME: code duplication:
+// consider better approach like in compound kernels with tuple wrappers and context class
+
+template <typename K, typename... Ins, typename Out>
+struct TransHelper<K, std::tuple<Ins...>, Out>
+{
+    // FIXME: code duplication
+    template <int... IIs>
+    static GArgs get_pattern_impl(const GArgs &in_args, detail::Seq<IIs...>)
+    {
+        using R = typename TransType<Out>::type;
+        const R r = K::pattern(get_in_args<Ins>(in_args, IIs)...);
+        return GArgs{GArg(r)};
+    }
+
+    template <int... IIs>
+    static GArgs get_substitute_impl(const GArgs &in_args, detail::Seq<IIs...>)
+    {
+        using R = typename TransType<Out>::type;
+        const R r = K::substitute(get_in_args<Ins>(in_args, IIs)...);
+        return GArgs{GArg(r)};
+    }
+
+    static GArgs get_pattern(const GArgs &in_args)
+    {
+        return get_pattern_impl(in_args, typename detail::MkSeq<sizeof...(Ins)>::type());
+    }
+    static GArgs get_substitute(const GArgs &in_args)
+    {
+        return get_substitute_impl(in_args, typename detail::MkSeq<sizeof...(Ins)>::type());
+    }
+};
+
+template <typename K, typename... Ins, typename... Outs>
+struct TransHelper<K, std::tuple<Ins...>, std::tuple<Outs...>>
+{
+    // FIXME: code duplication
+    template <int... IIs, int... OIs>
+    static GArgs get_pattern_impl(const GArgs &in_args, detail::Seq<IIs...>, detail::Seq<OIs...>)
+    {
+        using R = std::tuple<typename TransType<Outs>::type...>;
+        const R r = K::pattern(get_in_args<Ins>(in_args, IIs)...);
+        return GArgs{GArg(std::get<OIs>(r))...};
+    }
+
+    template <int... IIs, int... OIs>
+    static GArgs get_substitute_impl(const GArgs &in_args, detail::Seq<IIs...>, detail::Seq<OIs...>)
+    {
+        using R = std::tuple<typename TransType<Outs>::type...>;
+        const R r = K::substitute(get_in_args<Ins>(in_args, IIs)...);
+        return GArgs{GArg(std::get<OIs>(r))...};
+    }
+
+    static GArgs get_pattern(const GArgs &in_args)
+    {
+        return get_pattern_impl(in_args, typename detail::MkSeq<sizeof...(Ins)>::type(),
+                                typename detail::MkSeq<sizeof...(Outs)>::type());
+    }
+    static GArgs get_substitute(const GArgs &in_args)
+    {
+        return get_substitute_impl(in_args, typename detail::MkSeq<sizeof...(Ins)>::type(),
+                                   typename detail::MkSeq<sizeof...(Outs)>::type());
+    }
+};
+
+/////////////////////////////////////////////////////////////////////
+
+template <typename, typename>
+class GTransformImpl;
+
+template <typename K, typename R, typename... Args>
+class GTransformImpl<K, std::function<R(Args...)>> : public TransHelper<K, std::tuple<Args...>, R>,
+                                                     public cv::detail::TransformTag
+{
+};
+
+template <typename, typename>
+class GTransformImplM;
+
+template <typename K, typename... R, typename... Args>
+class GTransformImplM<K, std::function<std::tuple<R...>(Args...)>> : public TransHelper<K, std::tuple<Args...>, std::tuple<R...>>,
+                                                                     public cv::detail::TransformTag
+{
+};
+
+//////////////////////////////////////////////////////////////////////
+
+#define G_DESCR_HELPER_CLASS(Class) Class##DescrHelper
+
+#define G_DESCR_HELPER_BODY(Class, Descr)                           \
+    namespace detail                                                \
+    {                                                               \
+    struct G_DESCR_HELPER_CLASS(Class)                              \
+    {                                                               \
+        static constexpr const char *descr() { return Descr; };     \
+    };                                                              \
+    }
+
+#define GAPI_TRANSFORM(Class, API, Descr)                                      \
+    G_DESCR_HELPER_BODY(Class, Descr)                                          \
+    struct Class final : public cv::GTransformImpl<Class, std::function API>,  \
+                         public detail::G_DESCR_HELPER_CLASS(Class)
+
+#define GAPI_TRANSFORM_M(Class, API, Descr)                                    \
+    G_DESCR_HELPER_BODY(Class, Descr)                                          \
+    struct Class final : public cv::GTransformImplM<Class, std::function API>, \
+                         public detail::G_DESCR_HELPER_CLASS(Class)
+
+} // namespace cv
+
+#endif // OPENCV_GAPI_GTRANSFORM_HPP

--- a/modules/gapi/include/opencv2/gapi/gtransform.hpp
+++ b/modules/gapi/include/opencv2/gapi/gtransform.hpp
@@ -28,7 +28,7 @@ struct GAPI_EXPORTS GTransform
     F pattern;
     F substitute;
 
-    explicit GTransform(const char *d, const F &p, const F &s) : description(d), pattern(p), substitute(s){};
+    GTransform(const char *d, const F &p, const F &s) : description(d), pattern(p), substitute(s){};
 };
 
 namespace detail
@@ -41,21 +41,21 @@ template <typename K, typename... Ins, typename Out>
 struct TransHelper<K, std::tuple<Ins...>, Out>
 {
     template <typename Callable, int... IIs, int... OIs>
-    static GArgs get_impl(Callable f, const GArgs &in_args, detail::Seq<IIs...>, detail::Seq<OIs...>)
+    static GArgs get_impl(Callable f, const GArgs &in_args, Seq<IIs...>, Seq<OIs...>)
     {
-        const auto r = detail::tuple_wrap_helper<Out>::get(f(in_args.at(IIs).template get<Ins>()...));
+        const auto r = tuple_wrap_helper<Out>::get(f(in_args.at(IIs).template get<Ins>()...));
         return GArgs{GArg(std::get<OIs>(r))...};
     }
 
     static GArgs get_pattern(const GArgs &in_args)
     {
-        return get_impl(K::pattern, in_args, typename detail::MkSeq<sizeof...(Ins)>::type(),
-                        typename detail::MkSeq<std::tuple_size<typename detail::tuple_wrap_helper<Out>::type>::value>::type());
+        return get_impl(K::pattern, in_args, typename MkSeq<sizeof...(Ins)>::type(),
+                        typename MkSeq<std::tuple_size<typename tuple_wrap_helper<Out>::type>::value>::type());
     }
     static GArgs get_substitute(const GArgs &in_args)
     {
-        return get_impl(K::substitute, in_args, typename detail::MkSeq<sizeof...(Ins)>::type(),
-                        typename detail::MkSeq<std::tuple_size<typename detail::tuple_wrap_helper<Out>::type>::value>::type());
+        return get_impl(K::substitute, in_args, typename MkSeq<sizeof...(Ins)>::type(),
+                        typename MkSeq<std::tuple_size<typename tuple_wrap_helper<Out>::type>::value>::type());
     }
 };
 } // namespace detail
@@ -64,7 +64,7 @@ template <typename, typename>
 class GTransformImpl;
 
 template <typename K, typename R, typename... Args>
-class GTransformImpl<K, std::function<R(Args...)>> : public detail::TransHelper<K, std::tuple<Args...>, R>,
+class GTransformImpl<K, std::function<R(Args...)>> : public cv::detail::TransHelper<K, std::tuple<Args...>, R>,
                                                      public cv::detail::TransformTag
 {
 public:

--- a/modules/gapi/include/opencv2/gapi/ocl/goclkernel.hpp
+++ b/modules/gapi/include/opencv2/gapi/ocl/goclkernel.hpp
@@ -2,7 +2,7 @@
 // It is subject to the license terms in the LICENSE file found in the top-level directory
 // of this distribution and at http://opencv.org/license.html.
 //
-// Copyright (C) 2018 Intel Corporation
+// Copyright (C) 2019 Intel Corporation
 
 
 #ifndef OPENCV_GAPI_GOCLKERNEL_HPP

--- a/modules/gapi/include/opencv2/gapi/ocl/goclkernel.hpp
+++ b/modules/gapi/include/opencv2/gapi/ocl/goclkernel.hpp
@@ -2,7 +2,7 @@
 // It is subject to the license terms in the LICENSE file found in the top-level directory
 // of this distribution and at http://opencv.org/license.html.
 //
-// Copyright (C) 2019 Intel Corporation
+// Copyright (C) 2018-2019 Intel Corporation
 
 
 #ifndef OPENCV_GAPI_GOCLKERNEL_HPP

--- a/modules/gapi/include/opencv2/gapi/ocl/goclkernel.hpp
+++ b/modules/gapi/include/opencv2/gapi/ocl/goclkernel.hpp
@@ -226,7 +226,8 @@ struct OCLCallHelper<Impl, std::tuple<Ins...>, std::tuple<Outs...> >
 } // namespace detail
 
 template<class Impl, class K>
-class GOCLKernelImpl: public detail::OCLCallHelper<Impl, typename K::InArgs, typename K::OutArgs>
+class GOCLKernelImpl: public detail::OCLCallHelper<Impl, typename K::InArgs, typename K::OutArgs>,
+                      public cv::detail::KernelTag
 {
     using P = detail::OCLCallHelper<Impl, typename K::InArgs, typename K::OutArgs>;
 

--- a/modules/gapi/include/opencv2/gapi/ocl/goclkernel.hpp
+++ b/modules/gapi/include/opencv2/gapi/ocl/goclkernel.hpp
@@ -226,7 +226,7 @@ struct OCLCallHelper<Impl, std::tuple<Ins...>, std::tuple<Outs...> >
 } // namespace detail
 
 template<class Impl, class K>
-class GOCLKernelImpl: public detail::OCLCallHelper<Impl, typename K::InArgs, typename K::OutArgs>,
+class GOCLKernelImpl: public cv::detail::OCLCallHelper<Impl, typename K::InArgs, typename K::OutArgs>,
                       public cv::detail::KernelTag
 {
     using P = detail::OCLCallHelper<Impl, typename K::InArgs, typename K::OutArgs>;

--- a/modules/gapi/include/opencv2/gapi/util/util.hpp
+++ b/modules/gapi/include/opencv2/gapi/util/util.hpp
@@ -2,7 +2,7 @@
 // It is subject to the license terms in the LICENSE file found in the top-level directory
 // of this distribution and at http://opencv.org/license.html.
 //
-// Copyright (C) 2018 Intel Corporation
+// Copyright (C) 2019 Intel Corporation
 
 
 #ifndef OPENCV_GAPI_UTIL_HPP

--- a/modules/gapi/include/opencv2/gapi/util/util.hpp
+++ b/modules/gapi/include/opencv2/gapi/util/util.hpp
@@ -97,6 +97,7 @@ namespace detail
     template <typename T1, typename... Ts>
     struct all_unique<T1, Ts...> : std::integral_constant<bool, !contains<T1, Ts...>::value &&
                                                                  all_unique<Ts...>::value> {};
+
     enum class PackageObjectTag {
         KERNEL,
         TRANSFORMATION

--- a/modules/gapi/include/opencv2/gapi/util/util.hpp
+++ b/modules/gapi/include/opencv2/gapi/util/util.hpp
@@ -8,7 +8,7 @@
 #ifndef OPENCV_GAPI_UTIL_HPP
 #define OPENCV_GAPI_UTIL_HPP
 
-#include <utility> // std::tuple
+#include <tuple>
 
 // \cond HIDDEN_SYMBOLS
 // This header file contains some generic utility functions which are

--- a/modules/gapi/include/opencv2/gapi/util/util.hpp
+++ b/modules/gapi/include/opencv2/gapi/util/util.hpp
@@ -97,6 +97,27 @@ namespace detail
     template <typename T1, typename... Ts>
     struct all_unique<T1, Ts...> : std::integral_constant<bool, !contains<T1, Ts...>::value &&
                                                                  all_unique<Ts...>::value> {};
+    enum class PackageObjectTag {
+        KERNEL,
+        TRANSFORMATION
+    };
+
+    struct KernelTag
+    {
+        static constexpr PackageObjectTag object_entity()
+        {
+            return PackageObjectTag::KERNEL;
+        };
+    };
+
+    struct TransformTag
+    {
+        static constexpr PackageObjectTag object_entity()
+        {
+            return PackageObjectTag::TRANSFORMATION;
+        };
+    };
+
 } // namespace detail
 } // namespace cv
 

--- a/modules/gapi/include/opencv2/gapi/util/util.hpp
+++ b/modules/gapi/include/opencv2/gapi/util/util.hpp
@@ -2,7 +2,7 @@
 // It is subject to the license terms in the LICENSE file found in the top-level directory
 // of this distribution and at http://opencv.org/license.html.
 //
-// Copyright (C) 2019 Intel Corporation
+// Copyright (C) 2018-2019 Intel Corporation
 
 
 #ifndef OPENCV_GAPI_UTIL_HPP
@@ -98,6 +98,22 @@ namespace detail
     struct all_unique<T1, Ts...> : std::integral_constant<bool, !contains<T1, Ts...>::value &&
                                                                  all_unique<Ts...>::value> {};
 
+    template<typename>
+    struct tuple_wrap_helper;
+
+    template<typename T> struct tuple_wrap_helper
+    {
+        using type = std::tuple<T>;
+        static type get(T&& obj) { return std::make_tuple(std::move(obj)); }
+    };
+
+    template<typename... Objs>
+    struct tuple_wrap_helper<std::tuple<Objs...>>
+    {
+        using type = std::tuple<Objs...>;
+        static type get(std::tuple<Objs...>&& objs) { return std::forward<std::tuple<Objs...>>(objs); }
+    };
+
     enum class PackageObjectTag {
         KERNEL,
         TRANSFORMATION
@@ -105,18 +121,10 @@ namespace detail
 
     struct KernelTag
     {
-        static constexpr PackageObjectTag object_entity()
-        {
-            return PackageObjectTag::KERNEL;
-        };
     };
 
     struct TransformTag
     {
-        static constexpr PackageObjectTag object_entity()
-        {
-            return PackageObjectTag::TRANSFORMATION;
-        };
     };
 
 } // namespace detail

--- a/modules/gapi/include/opencv2/gapi/util/util.hpp
+++ b/modules/gapi/include/opencv2/gapi/util/util.hpp
@@ -113,20 +113,6 @@ namespace detail
         using type = std::tuple<Objs...>;
         static type get(std::tuple<Objs...>&& objs) { return std::forward<std::tuple<Objs...>>(objs); }
     };
-
-    enum class PackageObjectTag {
-        KERNEL,
-        TRANSFORMATION
-    };
-
-    struct KernelTag
-    {
-    };
-
-    struct TransformTag
-    {
-    };
-
 } // namespace detail
 } // namespace cv
 

--- a/modules/gapi/src/api/gkernel.cpp
+++ b/modules/gapi/src/api/gkernel.cpp
@@ -50,9 +50,9 @@ std::size_t cv::gapi::GKernelPackage::size() const
     return m_id_kernels.size();
 }
 
-std::size_t cv::gapi::GKernelPackage::transform_size() const
+const std::vector<cv::GTransform> &cv::gapi::GKernelPackage::get_transformations() const
 {
-    return m_transformations.size();
+    return m_transformations;
 }
 
 cv::gapi::GKernelPackage cv::gapi::combine(const GKernelPackage  &lhs,

--- a/modules/gapi/src/api/gkernel.cpp
+++ b/modules/gapi/src/api/gkernel.cpp
@@ -2,7 +2,7 @@
 // It is subject to the license terms in the LICENSE file found in the top-level directory
 // of this distribution and at http://opencv.org/license.html.
 //
-// Copyright (C) 2018 Intel Corporation
+// Copyright (C) 2019 Intel Corporation
 
 
 #include "precomp.hpp"
@@ -65,6 +65,9 @@ cv::gapi::GKernelPackage cv::gapi::combine(const GKernelPackage  &lhs,
             {
                 result.m_id_kernels.emplace(kernel.first, kernel.second);
             }
+        }
+        for (const auto &transforms : lhs.m_transformations){
+            result.m_transformations.push_back(transforms);
         }
         return result;
 }

--- a/modules/gapi/src/api/gkernel.cpp
+++ b/modules/gapi/src/api/gkernel.cpp
@@ -47,7 +47,7 @@ void cv::gapi::GKernelPackage::removeAPI(const std::string &id)
 
 std::size_t cv::gapi::GKernelPackage::size() const
 {
-    return m_id_kernels.size();
+    return m_id_kernels.size() + m_transformations.size();
 }
 
 cv::gapi::GKernelPackage cv::gapi::combine(const GKernelPackage  &lhs,

--- a/modules/gapi/src/api/gkernel.cpp
+++ b/modules/gapi/src/api/gkernel.cpp
@@ -47,7 +47,12 @@ void cv::gapi::GKernelPackage::removeAPI(const std::string &id)
 
 std::size_t cv::gapi::GKernelPackage::size() const
 {
-    return m_id_kernels.size() + m_transformations.size();
+    return m_id_kernels.size();
+}
+
+std::size_t cv::gapi::GKernelPackage::transform_size() const
+{
+    return m_transformations.size();
 }
 
 cv::gapi::GKernelPackage cv::gapi::combine(const GKernelPackage  &lhs,

--- a/modules/gapi/src/api/gkernel.cpp
+++ b/modules/gapi/src/api/gkernel.cpp
@@ -2,7 +2,7 @@
 // It is subject to the license terms in the LICENSE file found in the top-level directory
 // of this distribution and at http://opencv.org/license.html.
 //
-// Copyright (C) 2019 Intel Corporation
+// Copyright (C) 2018-2019 Intel Corporation
 
 
 #include "precomp.hpp"

--- a/modules/gapi/src/compiler/passes/kernels.cpp
+++ b/modules/gapi/src/compiler/passes/kernels.cpp
@@ -35,7 +35,7 @@ namespace
     // 1. Get GCompoundKernel implementation
     // 2. Create GCompoundContext
     // 3. Run GCompoundKernel with GCompoundContext
-    // 4. Build subgraph from imputs/outputs GCompoundKernel
+    // 4. Build subgraph from inputs/outputs GCompoundKernel
     // 5. Replace compound node to subgraph
 
     void expand(ade::Graph& g, ade::NodeHandle nh, const ImplInfo& impl_info)

--- a/modules/gapi/test/gapi_transform_tests.cpp
+++ b/modules/gapi/test/gapi_transform_tests.cpp
@@ -62,7 +62,8 @@ TEST(KernelPackageTransform, SingleOutInclude)
 {
     cv::gapi::GKernelPackage pkg;
     pkg.include<my_transform>();
-    EXPECT_EQ(1u, pkg.transform_size());
+    auto tr= pkg.get_transformations();
+    EXPECT_EQ(1u, tr.size());
 }
 
 TEST(KernelPackageTransform, MultiOutInclude)
@@ -70,21 +71,24 @@ TEST(KernelPackageTransform, MultiOutInclude)
     cv::gapi::GKernelPackage pkg;
     pkg.include<my_transform>();
     pkg.include<another_transform>();
-    EXPECT_EQ(2u, pkg.transform_size());
+    auto tr= pkg.get_transformations();
+    EXPECT_EQ(2u, tr.size());
 }
 
 TEST(KernelPackageTransform, MultiOutConstructor)
 {
     cv::gapi::GKernelPackage pkg = cv::gapi::kernels<my_transform,
                                                      another_transform>();
-    EXPECT_EQ(2u, pkg.transform_size());
+    auto tr= pkg.get_transformations();
+    EXPECT_EQ(2u, tr.size());
 }
 
 TEST(KernelPackageTransform, CopyClass)
 {
     cv::gapi::GKernelPackage pkg = cv::gapi::kernels<copy_transform,
                                                      another_transform>();
-    EXPECT_EQ(2u, pkg.transform_size());
+    auto tr= pkg.get_transformations();
+    EXPECT_EQ(2u, tr.size());
 }
 
 TEST(KernelPackageTransform, Combine)
@@ -93,8 +97,8 @@ TEST(KernelPackageTransform, Combine)
     cv::gapi::GKernelPackage pkg2 = cv::gapi::kernels<another_transform>();
     cv::gapi::GKernelPackage pkg_comb =
         cv::gapi::combine(pkg1, pkg2);
-
-    EXPECT_EQ(2u, pkg_comb.transform_size());
+    auto tr= pkg_comb.get_transformations();
+    EXPECT_EQ(2u, tr.size());
 }
 
 TEST(KernelPackageTransform, GArgsSize)

--- a/modules/gapi/test/gapi_transform_tests.cpp
+++ b/modules/gapi/test/gapi_transform_tests.cpp
@@ -61,11 +61,19 @@ TEST(KernelPackageTransform, MultiOutInclude)
 
 TEST(KernelPackageTransform, MultiOutConstructor)
 {
-    cv::gapi::GKernelPackage pkg = cv::gapi::kernels
-    < my_transform,
-      another_transform
-    >();
+    cv::gapi::GKernelPackage pkg = cv::gapi::kernels<my_transform,
+                                                     another_transform>();
     EXPECT_EQ(2u, pkg.size());
+}
+
+TEST(KernelPackageTransform, Combine)
+{
+    cv::gapi::GKernelPackage pkg1 = cv::gapi::kernels<my_transform>();
+    cv::gapi::GKernelPackage pkg2 = cv::gapi::kernels<another_transform>();
+    cv::gapi::GKernelPackage pkg_comb =
+        cv::gapi::combine(pkg1, pkg2, cv::unite_policy::KEEP);
+
+    EXPECT_EQ(2u, pkg_comb.size());
 }
 
 } // namespace opencv_test

--- a/modules/gapi/test/gapi_transform_tests.cpp
+++ b/modules/gapi/test/gapi_transform_tests.cpp
@@ -62,7 +62,7 @@ TEST(KernelPackageTransform, SingleOutInclude)
 {
     cv::gapi::GKernelPackage pkg;
     pkg.include<my_transform>();
-    EXPECT_EQ(1u, pkg.size());
+    EXPECT_EQ(1u, pkg.transform_size());
 }
 
 TEST(KernelPackageTransform, MultiOutInclude)
@@ -70,21 +70,21 @@ TEST(KernelPackageTransform, MultiOutInclude)
     cv::gapi::GKernelPackage pkg;
     pkg.include<my_transform>();
     pkg.include<another_transform>();
-    EXPECT_EQ(2u, pkg.size());
+    EXPECT_EQ(2u, pkg.transform_size());
 }
 
 TEST(KernelPackageTransform, MultiOutConstructor)
 {
     cv::gapi::GKernelPackage pkg = cv::gapi::kernels<my_transform,
                                                      another_transform>();
-    EXPECT_EQ(2u, pkg.size());
+    EXPECT_EQ(2u, pkg.transform_size());
 }
 
 TEST(KernelPackageTransform, CopyClass)
 {
     cv::gapi::GKernelPackage pkg = cv::gapi::kernels<copy_transform,
                                                      another_transform>();
-    EXPECT_EQ(2u, pkg.size());
+    EXPECT_EQ(2u, pkg.transform_size());
 }
 
 TEST(KernelPackageTransform, Combine)
@@ -94,7 +94,7 @@ TEST(KernelPackageTransform, Combine)
     cv::gapi::GKernelPackage pkg_comb =
         cv::gapi::combine(pkg1, pkg2);
 
-    EXPECT_EQ(2u, pkg_comb.size());
+    EXPECT_EQ(2u, pkg_comb.transform_size());
 }
 
 TEST(KernelPackageTransform, GArgsSize)

--- a/modules/gapi/test/gapi_transform_tests.cpp
+++ b/modules/gapi/test/gapi_transform_tests.cpp
@@ -1,0 +1,71 @@
+// This file is part of OpenCV project.
+// It is subject to the license terms in the LICENSE file found in the top-level directory
+// of this distribution and at http://opencv.org/license.html.
+//
+// Copyright (C) 2019 Intel Corporation
+
+#include <tuple>
+
+#include "test_precomp.hpp"
+#include "opencv2/gapi/gtransform.hpp"
+
+namespace opencv_test
+{
+
+namespace
+{
+using GMat2 = std::tuple<GMat, GMat>;
+using GMat3 = std::tuple<GMat, GMat, GMat>;
+
+GAPI_TRANSFORM(my_transform, <cv::GMat(GMat2)>, "does nothing")
+{
+    static cv::GMat pattern(GMat2)
+    {
+        return {};
+    };
+
+    static cv::GMat substitute(GMat2)
+    {
+        return {};
+    }
+};
+
+GAPI_TRANSFORM_M(another_transform, <GMat3(GMat2)>, "does nothing")
+{
+    static GMat3 pattern(GMat2)
+    {
+        return {};
+    };
+
+    static GMat3 substitute(GMat2)
+    {
+        return {};
+    }
+};
+} // namespace
+
+TEST(KernelPackageTransform, SingleOutInclude)
+{
+    cv::gapi::GKernelPackage pkg;
+    pkg.include<my_transform>();
+    EXPECT_EQ(1u, pkg.size());
+}
+
+TEST(KernelPackageTransform, MultiOutInclude)
+{
+    cv::gapi::GKernelPackage pkg;
+    pkg.include<my_transform>();
+    pkg.include<another_transform>();
+    EXPECT_EQ(2u, pkg.size());
+}
+
+TEST(KernelPackageTransform, MultiOutConstructor)
+{
+    cv::gapi::GKernelPackage pkg = cv::gapi::kernels
+    < my_transform,
+      another_transform
+    >();
+    EXPECT_EQ(2u, pkg.size());
+}
+
+} // namespace opencv_test

--- a/modules/gapi/test/gapi_transform_tests.cpp
+++ b/modules/gapi/test/gapi_transform_tests.cpp
@@ -56,13 +56,47 @@ GAPI_TRANSFORM(copy_transform, <GMat3(GMat, GMat)>, "does nothing")
         return {};
     }
 };
+
+GAPI_TRANSFORM(simple_transform, <GMat(GMat)>, "does nothing")
+{
+    static GMat pattern(GMat)
+    {
+        return {};
+    };
+
+    static GMat substitute(GMat)
+    {
+        return {};
+    }
+};
+
+GAPI_TRANSFORM(another_simple_transform, <GMat2(GMat)>, "does nothing too")
+{
+    static GMat2 pattern(GMat)
+    {
+        return {};
+    };
+
+    static GMat2 substitute(GMat)
+    {
+        return {};
+    }
+};
 } // namespace
+
+TEST(KernelPackageTransform, SimpleInclude)
+{
+    cv::gapi::GKernelPackage pkg = cv::gapi::kernels<simple_transform,
+                                                     another_simple_transform>();
+    auto tr = pkg.get_transformations();
+    EXPECT_EQ(2u, tr.size());
+}
 
 TEST(KernelPackageTransform, SingleOutInclude)
 {
     cv::gapi::GKernelPackage pkg;
     pkg.include<my_transform>();
-    auto tr= pkg.get_transformations();
+    auto tr = pkg.get_transformations();
     EXPECT_EQ(1u, tr.size());
 }
 
@@ -71,7 +105,7 @@ TEST(KernelPackageTransform, MultiOutInclude)
     cv::gapi::GKernelPackage pkg;
     pkg.include<my_transform>();
     pkg.include<another_transform>();
-    auto tr= pkg.get_transformations();
+    auto tr = pkg.get_transformations();
     EXPECT_EQ(2u, tr.size());
 }
 
@@ -79,7 +113,7 @@ TEST(KernelPackageTransform, MultiOutConstructor)
 {
     cv::gapi::GKernelPackage pkg = cv::gapi::kernels<my_transform,
                                                      another_transform>();
-    auto tr= pkg.get_transformations();
+    auto tr = pkg.get_transformations();
     EXPECT_EQ(2u, tr.size());
 }
 
@@ -87,7 +121,7 @@ TEST(KernelPackageTransform, CopyClass)
 {
     cv::gapi::GKernelPackage pkg = cv::gapi::kernels<copy_transform,
                                                      another_transform>();
-    auto tr= pkg.get_transformations();
+    auto tr = pkg.get_transformations();
     EXPECT_EQ(2u, tr.size());
 }
 
@@ -97,7 +131,7 @@ TEST(KernelPackageTransform, Combine)
     cv::gapi::GKernelPackage pkg2 = cv::gapi::kernels<another_transform>();
     cv::gapi::GKernelPackage pkg_comb =
         cv::gapi::combine(pkg1, pkg2);
-    auto tr= pkg_comb.get_transformations();
+    auto tr = pkg_comb.get_transformations();
     EXPECT_EQ(2u, tr.size());
 }
 

--- a/modules/gapi/test/gapi_transform_tests.cpp
+++ b/modules/gapi/test/gapi_transform_tests.cpp
@@ -16,41 +16,42 @@ namespace
 {
 using GMat2 = std::tuple<GMat, GMat>;
 using GMat3 = std::tuple<GMat, GMat, GMat>;
+using GMat = cv::GMat;
 
-GAPI_TRANSFORM(my_transform, <cv::GMat(GMat2)>, "does nothing")
+GAPI_TRANSFORM(my_transform, <GMat(GMat, GMat)>, "does nothing")
 {
-    static cv::GMat pattern(GMat2)
+    static GMat pattern(GMat, GMat)
     {
         return {};
     };
 
-    static cv::GMat substitute(GMat2)
+    static GMat substitute(GMat, GMat)
     {
         return {};
     }
 };
 
-GAPI_TRANSFORM_M(another_transform, <GMat3(GMat2)>, "does nothing")
+GAPI_TRANSFORM(another_transform, <GMat3(GMat, GMat)>, "does nothing")
 {
-    static GMat3 pattern(GMat2)
+    static GMat3 pattern(GMat, GMat)
     {
         return {};
     };
 
-    static GMat3 substitute(GMat2)
+    static GMat3 substitute(GMat, GMat)
     {
         return {};
     }
 };
 
-GAPI_TRANSFORM_M(copy_transform, <GMat3(GMat2)>, "does nothing")
+GAPI_TRANSFORM(copy_transform, <GMat3(GMat, GMat)>, "does nothing")
 {
-    static GMat3 pattern(GMat2)
+    static GMat3 pattern(GMat, GMat)
     {
         return {};
     };
 
-    static GMat3 substitute(GMat2)
+    static GMat3 substitute(GMat, GMat)
     {
         return {};
     }
@@ -94,6 +95,16 @@ TEST(KernelPackageTransform, Combine)
         cv::gapi::combine(pkg1, pkg2);
 
     EXPECT_EQ(2u, pkg_comb.size());
+}
+
+TEST(KernelPackageTransform, GArgsSize)
+{
+    auto tr = copy_transform::transformation();
+    GMat a, b;
+    auto subst = tr.substitute({cv::GArg(a), cv::GArg(b)});
+
+    // return type of 'copy_transform' is GMat3
+    EXPECT_EQ(3u, subst.size());
 }
 
 } // namespace opencv_test

--- a/modules/gapi/test/gapi_transform_tests.cpp
+++ b/modules/gapi/test/gapi_transform_tests.cpp
@@ -42,6 +42,19 @@ GAPI_TRANSFORM_M(another_transform, <GMat3(GMat2)>, "does nothing")
         return {};
     }
 };
+
+GAPI_TRANSFORM_M(copy_transform, <GMat3(GMat2)>, "does nothing")
+{
+    static GMat3 pattern(GMat2)
+    {
+        return {};
+    };
+
+    static GMat3 substitute(GMat2)
+    {
+        return {};
+    }
+};
 } // namespace
 
 TEST(KernelPackageTransform, SingleOutInclude)
@@ -66,12 +79,19 @@ TEST(KernelPackageTransform, MultiOutConstructor)
     EXPECT_EQ(2u, pkg.size());
 }
 
+TEST(KernelPackageTransform, CopyClass)
+{
+    cv::gapi::GKernelPackage pkg = cv::gapi::kernels<copy_transform,
+                                                     another_transform>();
+    EXPECT_EQ(2u, pkg.size());
+}
+
 TEST(KernelPackageTransform, Combine)
 {
     cv::gapi::GKernelPackage pkg1 = cv::gapi::kernels<my_transform>();
     cv::gapi::GKernelPackage pkg2 = cv::gapi::kernels<another_transform>();
     cv::gapi::GKernelPackage pkg_comb =
-        cv::gapi::combine(pkg1, pkg2, cv::unite_policy::KEEP);
+        cv::gapi::combine(pkg1, pkg2);
 
     EXPECT_EQ(2u, pkg_comb.size());
 }


### PR DESCRIPTION
Description:

In utils.h were created 2 classes to separate kernels from transformations via "tag" in kernel package;
GAPI_TRANSFORM is implemented in a way similar to G_TYPED_KERNEL

```
build_gapi_standalone:Linux x64=ade-0.1.1d
build_gapi_standalone:Win64=ade-0.1.1d
build_gapi_standalone:Mac=ade-0.1.1d
build_gapi_standalone:Linux x64 Debug=ade-0.1.1d
```