### PR TITLE
Fixed out of bounds read for RGB2HLS_b and RGB2Luv_b

### DIFF
--- a/modules/imgproc/src/color_hsv.simd.hpp
+++ b/modules/imgproc/src/color_hsv.simd.hpp
@@ -724,7 +724,7 @@ struct RGB2HLS_b
     {
         CV_INSTRUMENT_REGION();
 
-        int i, j, scn = srccn;
+        int scn = srccn;
 
 #if CV_SIMD
         float CV_DECL_ALIGNED(CV_SIMD_WIDTH) buf[bufChannels*BLOCK_SIZE];
@@ -744,15 +744,15 @@ struct RGB2HLS_b
         }
 #endif
 
-        for( i = 0; i < n; i += BLOCK_SIZE, dst += BLOCK_SIZE*3 )
+        for(int i = 0; i < n; i += BLOCK_SIZE, dst += BLOCK_SIZE*3 )
         {
             int dn = std::min(n - i, (int)BLOCK_SIZE);
-            j = 0;
 
 #if CV_SIMD
             v_float32 v255inv = vx_setall_f32(1.f/255.f);
             if (scn == 3)
             {
+                int j = 0;
                 static const int nBlock = fsize*2;
                 for ( ; j <= (dn * bufChannels - nBlock);
                       j += nBlock, src += nBlock)
@@ -763,9 +763,14 @@ struct RGB2HLS_b
                     v_store_aligned(buf + j + 0*fsize, v_cvt_f32(qrgb0)*v255inv);
                     v_store_aligned(buf + j + 1*fsize, v_cvt_f32(qrgb1)*v255inv);
                 }
+                for( ; j < dn*3; j++, src++ )
+                {
+                    buf[j] = src[0]*(1.f/255.f);
+                }
             }
             else // if (scn == 4)
             {
+                int j = 0;
                 static const int nBlock = fsize*4;
                 for ( ; j <= dn*bufChannels - nBlock*bufChannels;
                       j += nBlock*bufChannels, src += nBlock*4)
@@ -795,17 +800,24 @@ struct RGB2HLS_b
                         v_store_interleave(buf + j + k*bufChannels*fsize, f[0*4+k], f[1*4+k], f[2*4+k]);
                     }
                 }
+                for( ; j < dn*3; j += 3, src += 4 )
+                {
+                    buf[j+0] = src[0]*(1.f/255.f);
+                    buf[j+1] = src[1]*(1.f/255.f);
+                    buf[j+2] = src[2]*(1.f/255.f);
+                }
             }
-#endif
-            for( ; j < dn*3; j += 3, src += scn )
+#else
+            for(int j = 0; j < dn*3; j += 3, src += scn )
             {
                 buf[j+0] = src[0]*(1.f/255.f);
                 buf[j+1] = src[1]*(1.f/255.f);
                 buf[j+2] = src[2]*(1.f/255.f);
             }
+#endif
             cvt(buf, buf, dn);
 
-            j = 0;
+            int j = 0;
 #if CV_SIMD
             for( ; j <= dn*3 - fsize*3*4; j += fsize*3*4)
             {

--- a/modules/imgproc/src/color_lab.cpp
+++ b/modules/imgproc/src/color_lab.cpp
@@ -3266,7 +3266,7 @@ struct RGB2Luv_b
             return;
         }
 
-        int i, j, scn = srccn;
+        int scn = srccn;
 #if CV_SIMD
         float CV_DECL_ALIGNED(CV_SIMD_WIDTH) buf[bufChannels*BLOCK_SIZE];
 #else
@@ -3295,16 +3295,16 @@ struct RGB2Luv_b
         }
 #endif
 
-        for( i = 0; i < n; i += BLOCK_SIZE, dst += BLOCK_SIZE*bufChannels )
+        for(int i = 0; i < n; i += BLOCK_SIZE, dst += BLOCK_SIZE*bufChannels )
         {
             int dn = std::min(n - i, (int)BLOCK_SIZE);
-            j = 0;
 
             static const softfloat f255inv = softfloat::one()/f255;
 #if CV_SIMD
             v_float32 v255inv = vx_setall_f32((float)f255inv);
             if(scn == 4)
             {
+                int j = 0;
                 static const int nBlock = fsize*4;
                 for( ; j <= dn*bufChannels - nBlock*3;
                      j += nBlock*3, src += nBlock*4)
@@ -3334,9 +3334,16 @@ struct RGB2Luv_b
                         v_store_interleave(buf + j + k*3*fsize, f[0*4+k], f[1*4+k], f[2*4+k]);
                     }
                 }
+                for( ; j < dn*bufChannels; j += bufChannels, src += 4 )
+                {
+                    buf[j  ] = (float)(src[0]*((float)f255inv));
+                    buf[j+1] = (float)(src[1]*((float)f255inv));
+                    buf[j+2] = (float)(src[2]*((float)f255inv));
+                }
             }
             else // scn == 3
             {
+                int j = 0;
                 static const int nBlock = fsize*2;
                 for( ; j <= dn*bufChannels - nBlock;
                      j += nBlock, src += nBlock)
@@ -3348,17 +3355,23 @@ struct RGB2Luv_b
                     v_store_aligned(buf + j + 0*fsize, v_cvt_f32(q0)*v255inv);
                     v_store_aligned(buf + j + 1*fsize, v_cvt_f32(q1)*v255inv);
                 }
+                for( ; j < dn*bufChannels; j++, src++ )
+                {
+                    buf[j] = (float)(src[0]*((float)f255inv));
+                }
             }
-#endif
-            for( ; j < dn*bufChannels; j += bufChannels, src += scn )
+#else
+            for(int j = 0; j < dn*bufChannels; j += bufChannels, src += scn )
             {
                 buf[j  ] = (float)(src[0]*((float)f255inv));
                 buf[j+1] = (float)(src[1]*((float)f255inv));
                 buf[j+2] = (float)(src[2]*((float)f255inv));
             }
+#endif
+
             fcvt(buf, buf, dn);
 
-            j = 0;
+            int j = 0;
 
 #if CV_SIMD
             for( ; j <= dn*3 - fsize*3*4; j += fsize*3*4)
@@ -3389,7 +3402,7 @@ struct RGB2Luv_b
 #endif
             for( ; j < dn*3; j += 3 )
             {
-                dst[j] = saturate_cast<uchar>(buf[j]*(float)fL);
+                dst[j+0] = saturate_cast<uchar>(buf[j+0]*(float)fL);
                 dst[j+1] = saturate_cast<uchar>(buf[j+1]*(float)fu + (float)su);
                 dst[j+2] = saturate_cast<uchar>(buf[j+2]*(float)fv + (float)sv);
             }


### PR DESCRIPTION
resolves #14629 

### This pullrequest changes

Fixed out of bounds read for cases when number of channels is the same between conversions.
In these cases a block size can be arbitrary i.e. not a multiplier of a number of channels.

```
allow_multiple_commits=1
```