### PR TITLE
dnn(test): replace file content reading

### DIFF
--- a/modules/dnn/test/test_caffe_importer.cpp
+++ b/modules/dnn/test/test_caffe_importer.cpp
@@ -83,17 +83,17 @@ TEST(Test_Caffe, memory_read)
     const string proto = findDataFile("dnn/bvlc_googlenet.prototxt", false);
     const string model = findDataFile("dnn/bvlc_googlenet.caffemodel", false);
 
-    string dataProto;
-    ASSERT_TRUE(readFileInMemory(proto, dataProto));
-    string dataModel;
-    ASSERT_TRUE(readFileInMemory(model, dataModel));
+    std::vector<char> dataProto;
+    readFileContent(proto, dataProto);
+    std::vector<char> dataModel;
+    readFileContent(model, dataModel);
 
-    Net net = readNetFromCaffe(dataProto.c_str(), dataProto.size());
+    Net net = readNetFromCaffe(dataProto.data(), dataProto.size());
     net.setPreferableBackend(DNN_BACKEND_OPENCV);
     ASSERT_FALSE(net.empty());
 
-    Net net2 = readNetFromCaffe(dataProto.c_str(), dataProto.size(),
-                                dataModel.c_str(), dataModel.size());
+    Net net2 = readNetFromCaffe(dataProto.data(), dataProto.size(),
+                                dataModel.data(), dataModel.size());
     ASSERT_FALSE(net2.empty());
 }
 
@@ -124,13 +124,13 @@ TEST_P(Reproducibility_AlexNet, Accuracy)
         const string model = findDataFile("dnn/bvlc_alexnet.caffemodel", false);
         if (readFromMemory)
         {
-            string dataProto;
-            ASSERT_TRUE(readFileInMemory(proto, dataProto));
-            string dataModel;
-            ASSERT_TRUE(readFileInMemory(model, dataModel));
+            std::vector<char> dataProto;
+            readFileContent(proto, dataProto);
+            std::vector<char> dataModel;
+            readFileContent(model, dataModel);
 
-            net = readNetFromCaffe(dataProto.c_str(), dataProto.size(),
-                                   dataModel.c_str(), dataModel.size());
+            net = readNetFromCaffe(dataProto.data(), dataProto.size(),
+                                   dataModel.data(), dataModel.size());
         }
         else
             net = readNetFromCaffe(proto, model);

--- a/modules/dnn/test/test_common.hpp
+++ b/modules/dnn/test/test_common.hpp
@@ -59,7 +59,7 @@ void normAssertDetections(
         double confThreshold = 0.0, double scores_diff = 1e-5,
         double boxes_iou_diff = 1e-4);
 
-bool readFileInMemory(const std::string& filename, std::string& content);
+void readFileContent(const std::string& filename, CV_OUT std::vector<char>& content);
 
 #ifdef HAVE_INF_ENGINE
 bool validateVPUType();

--- a/modules/dnn/test/test_common.impl.hpp
+++ b/modules/dnn/test/test_common.impl.hpp
@@ -158,23 +158,21 @@ void normAssertDetections(
                          testBoxes, comment, confThreshold, scores_diff, boxes_iou_diff);
 }
 
-bool readFileInMemory(const std::string& filename, std::string& content)
+void readFileContent(const std::string& filename, CV_OUT std::vector<char>& content)
 {
-    std::ios::openmode mode = std::ios::in | std::ios::binary;
+    const std::ios::openmode mode = std::ios::in | std::ios::binary;
     std::ifstream ifs(filename.c_str(), mode);
-    if (!ifs.is_open())
-        return false;
+    ASSERT_TRUE(ifs.is_open());
 
     content.clear();
 
     ifs.seekg(0, std::ios::end);
-    content.reserve(ifs.tellg());
+    const size_t sz = ifs.tellg();
+    content.resize(sz);
     ifs.seekg(0, std::ios::beg);
 
-    content.assign((std::istreambuf_iterator<char>(ifs)),
-                   std::istreambuf_iterator<char>());
-
-    return true;
+    ifs.read((char*)content.data(), sz);
+    ASSERT_FALSE(ifs.fail());
 }
 
 

--- a/modules/dnn/test/test_darknet_importer.cpp
+++ b/modules/dnn/test/test_darknet_importer.cpp
@@ -93,11 +93,11 @@ TEST(Test_Darknet, read_yolo_voc_stream)
     }
     // Import from bytes array.
     {
-        std::string cfg, weights;
-        readFileInMemory(cfgFile, cfg);
-        readFileInMemory(weightsFile, weights);
+        std::vector<char> cfg, weights;
+        readFileContent(cfgFile, cfg);
+        readFileContent(weightsFile, weights);
 
-        Net net = readNetFromDarknet(&cfg[0], cfg.size(), &weights[0], weights.size());
+        Net net = readNetFromDarknet(cfg.data(), cfg.size(), weights.data(), weights.size());
         net.setInput(inp);
         net.setPreferableBackend(DNN_BACKEND_OPENCV);
         Mat out = net.forward();

--- a/modules/dnn/test/test_tf_importer.cpp
+++ b/modules/dnn/test/test_tf_importer.cpp
@@ -96,17 +96,17 @@ public:
         if (memoryLoad)
         {
             // Load files into a memory buffers
-            string dataModel;
-            ASSERT_TRUE(readFileInMemory(netPath, dataModel));
+            std::vector<char> dataModel;
+            readFileContent(netPath, dataModel);
 
-            string dataConfig;
+            std::vector<char> dataConfig;
             if (hasText)
             {
-                ASSERT_TRUE(readFileInMemory(netConfig, dataConfig));
+                readFileContent(netConfig, dataConfig);
             }
 
-            net = readNetFromTensorflow(dataModel.c_str(), dataModel.size(),
-                                        dataConfig.c_str(), dataConfig.size());
+            net = readNetFromTensorflow(dataModel.data(), dataModel.size(),
+                                        dataConfig.data(), dataConfig.size());
         }
         else
             net = readNetFromTensorflow(netPath, netConfig);


### PR DESCRIPTION
- reading via `std::istreambuf_iterator<char>` is slow (especially in debug mode)
- raise errors from helper function