### PR TITLE
(3.4) 3rdparty(libpng): fix leak in png_handle_eXIf

### DIFF
--- a/3rdparty/libpng/patches/20190528-fix-leak-png_handle_exif.diff
+++ b/3rdparty/libpng/patches/20190528-fix-leak-png_handle_exif.diff
@@ -1,0 +1,17 @@
+diff --git a/3rdparty/libpng/pngrutil.c b/3rdparty/libpng/pngrutil.c
+index d5fa08c397..4db3de990b 100644
+--- a/3rdparty/libpng/pngrutil.c
++++ b/3rdparty/libpng/pngrutil.c
+@@ -2087,10 +2087,8 @@ png_handle_eXIf(png_structrp png_ptr, png_inforp info_ptr, png_uint_32 length)
+       }
+    }
+ 
+-   if (png_crc_finish(png_ptr, 0) != 0)
+-      return;
+-
+-   png_set_eXIf_1(png_ptr, info_ptr, length, info_ptr->eXIf_buf);
++   if (png_crc_finish(png_ptr, 0) == 0)
++      png_set_eXIf_1(png_ptr, info_ptr, length, info_ptr->eXIf_buf);
+ 
+    png_free(png_ptr, info_ptr->eXIf_buf);
+    info_ptr->eXIf_buf = NULL;

--- a/3rdparty/libpng/pngrutil.c
+++ b/3rdparty/libpng/pngrutil.c
@@ -2087,10 +2087,8 @@ png_handle_eXIf(png_structrp png_ptr, png_inforp info_ptr, png_uint_32 length)
       }
    }
 
-   if (png_crc_finish(png_ptr, 0) != 0)
-      return;
-
-   png_set_eXIf_1(png_ptr, info_ptr, length, info_ptr->eXIf_buf);
+   if (png_crc_finish(png_ptr, 0) == 0)
+      png_set_eXIf_1(png_ptr, info_ptr, length, info_ptr->eXIf_buf);
 
    png_free(png_ptr, info_ptr->eXIf_buf);
    info_ptr->eXIf_buf = NULL;


### PR DESCRIPTION
backport #14664