### PR TITLE
Fix build issue on QNX platform

### DIFF
--- a/modules/core/src/system.cpp
+++ b/modules/core/src/system.cpp
@@ -757,8 +757,12 @@ int64 getTickCount(void)
 #elif defined __MACH__ && defined __APPLE__
     return (int64)mach_absolute_time();
 #else
-    struct timeval tv;
+#if defined __QNX__
+    int tz;
+#else
     struct timezone tz;
+#endif
+    struct timeval tv;
     gettimeofday( &tv, &tz );
     return (int64)tv.tv_sec*1000000 + tv.tv_usec;
 #endif

--- a/modules/core/src/system.cpp
+++ b/modules/core/src/system.cpp
@@ -757,13 +757,8 @@ int64 getTickCount(void)
 #elif defined __MACH__ && defined __APPLE__
     return (int64)mach_absolute_time();
 #else
-#if defined __QNX__
-    int tz;
-#else
-    struct timezone tz;
-#endif
     struct timeval tv;
-    gettimeofday( &tv, &tz );
+    gettimeofday(&tv, NULL);
     return (int64)tv.tv_sec*1000000 + tv.tv_usec;
 #endif
 }


### PR DESCRIPTION
[QNX](http://blackberry.qnx.com/en/products/neutrino-rtos/index) is a POSIX-compliant real-time embedded operating system. In general OpenCV's core builds correctly with the QNX cross-compiler. However, there is a small conflict with the `gettimeofday` function.

The QNX implementation of the C standard library does not define the `timezone` struct, and the `tv` field of `gettimeofday` is not used. Documentation is available here: http://www.qnx.com/developers/docs/6.5.0/index.jsp?topic=%2Fcom.qnx.doc.neutrino_lib_ref%2Fg%2Fgettimeofday.html

Therefore, to maintain build compatibility with QNX we can define variable `tz` as an int rather than a `timezone`, which does not affect anything downstream because `tz` is unused but does fix the compile error.
