### PR TITLE
G-API: Add parameters alpha and beta in tests on ConvertTo kernel

### DIFF
--- a/modules/gapi/test/common/gapi_core_tests.hpp
+++ b/modules/gapi/test/common/gapi_core_tests.hpp
@@ -145,7 +145,7 @@ struct ConcatVertTest    : public TestWithParam<std::tuple<int, cv::Size, cv::GC
 struct ConcatVertVecTest : public TestWithParam<std::tuple<int, cv::Size, cv::GCompileArgs>> {};
 struct ConcatHorVecTest  : public TestWithParam<std::tuple<int, cv::Size, cv::GCompileArgs>> {};
 struct LUTTest           : public TestParams<std::tuple<int, int, cv::Size,bool, cv::GCompileArgs>> {};
-struct ConvertToTest     : public TestParams<std::tuple<int, int, cv::Size, cv::GCompileArgs>> {};
+struct ConvertToTest     : public TestParams<std::tuple<int, int, cv::Size, double, double, compare_f, cv::GCompileArgs>> {};
 struct PhaseTest         : public TestParams<std::tuple<int, cv::Size, bool, cv::GCompileArgs>> {};
 struct SqrtTest          : public TestParams<std::tuple<int, cv::Size, cv::GCompileArgs>> {};
 struct NormalizeTest : public TestParams<std::tuple<compare_f,MatType,cv::Size,double,double,int,MatType,bool,cv::GCompileArgs>> {};

--- a/modules/gapi/test/common/gapi_core_tests_inl.hpp
+++ b/modules/gapi/test/common/gapi_core_tests_inl.hpp
@@ -1361,27 +1361,30 @@ TEST_P(LUTTest, AccuracyTest)
 
 TEST_P(ConvertToTest, AccuracyTest)
 {
-    auto param = GetParam();
-    int type_mat = std::get<0>(param);
-    int depth_to = std::get<1>(param);
-    cv::Size sz_in = std::get<2>(param);
+    int type_mat = -1, depth_to = -1;
+    double alpha = 1.0, beta = 0.0;
+    cv::Size sz_in;
+    cv::GCompileArgs compile_args;
+    compare_f cmpF;
+
+    std::tie(type_mat, depth_to, sz_in, alpha, beta, cmpF, compile_args) = GetParam();
+
     int type_out = CV_MAKETYPE(depth_to, CV_MAT_CN(type_mat));
     initMatrixRandU(type_mat, sz_in, type_out);
-    auto compile_args = std::get<3>(GetParam());
 
     // G-API code //////////////////////////////////////////////////////////////
     cv::GMat in;
-    auto out = cv::gapi::convertTo(in, depth_to);
+    auto out = cv::gapi::convertTo(in, depth_to, alpha, beta);
 
     cv::GComputation c(in, out);
     c.apply(in_mat1, out_mat_gapi, std::move(compile_args));
     // OpenCV code /////////////////////////////////////////////////////////////
     {
-        in_mat1.convertTo(out_mat_ocv, depth_to);
+        in_mat1.convertTo(out_mat_ocv, depth_to, alpha, beta);
     }
     // Comparison //////////////////////////////////////////////////////////////
     {
-        EXPECT_EQ(0, cv::countNonZero(out_mat_ocv != out_mat_gapi));
+        EXPECT_TRUE(cmpF(out_mat_gapi, out_mat_ocv));
         EXPECT_EQ(out_mat_gapi.size(), sz_in);
     }
 }

--- a/modules/gapi/test/cpu/gapi_core_tests_cpu.cpp
+++ b/modules/gapi/test/cpu/gapi_core_tests_cpu.cpp
@@ -376,7 +376,7 @@ INSTANTIATE_TEST_CASE_P(ConvertToCPU, ConvertToTest,
                                        cv::Size(128, 128)),
                                 Values(3.0, 1.0, 0.5, 0.0, -1.0),
                                 Values(256.0, 32.0, 0.0, -128.0),
-                                Values(Tolerance_FloatRel_IntAbs(1e-5, 2).to_compare_f()),
+                                Values(AbsExact().to_compare_f()),
                                 Values(cv::compile_args(CORE_CPU))));
 
 INSTANTIATE_TEST_CASE_P(ConcatHorTestCPU, ConcatHorTest,

--- a/modules/gapi/test/cpu/gapi_core_tests_cpu.cpp
+++ b/modules/gapi/test/cpu/gapi_core_tests_cpu.cpp
@@ -369,11 +369,14 @@ INSTANTIATE_TEST_CASE_P(LUTTestCustomCPU, LUTTest,
                                 Values(cv::compile_args(CORE_CPU))));
 
 INSTANTIATE_TEST_CASE_P(ConvertToCPU, ConvertToTest,
-                        Combine(Values( CV_8UC1, CV_8UC3, CV_16UC1, CV_16SC1, CV_32FC1 ),
+                        Combine(Values(CV_8UC1, CV_8UC3, CV_16UC1, CV_16SC1, CV_32FC1),
                                 Values(CV_8U, CV_16U, CV_16S, CV_32F),
                                 Values(cv::Size(1280, 720),
                                        cv::Size(640, 480),
                                        cv::Size(128, 128)),
+                                Values(3.0, 1.0, 0.5, 0.0, -1.0),
+                                Values(256.0, 32.0, 0.0, -128.0),
+                                Values(Tolerance_FloatRel_IntAbs(1e-5, 2).to_compare_f()),
                                 Values(cv::compile_args(CORE_CPU))));
 
 INSTANTIATE_TEST_CASE_P(ConcatHorTestCPU, ConcatHorTest,

--- a/modules/gapi/test/cpu/gapi_core_tests_cpu.cpp
+++ b/modules/gapi/test/cpu/gapi_core_tests_cpu.cpp
@@ -374,8 +374,8 @@ INSTANTIATE_TEST_CASE_P(ConvertToCPU, ConvertToTest,
                                 Values(cv::Size(1280, 720),
                                        cv::Size(640, 480),
                                        cv::Size(128, 128)),
-                                Values(3.0, 1.0, 0.5, 0.0, -1.0),
-                                Values(256.0, 32.0, 0.0, -128.0),
+                                Values(2.5, 1.0, -1.0),
+                                Values(250.0, 0.0, -128.0),
                                 Values(AbsExact().to_compare_f()),
                                 Values(cv::compile_args(CORE_CPU))));
 

--- a/modules/gapi/test/cpu/gapi_core_tests_fluid.cpp
+++ b/modules/gapi/test/cpu/gapi_core_tests_fluid.cpp
@@ -142,6 +142,9 @@ INSTANTIATE_TEST_CASE_P(ConvertToFluid, ConvertToTest,
                                        cv::Size(1280, 720),
                                        cv::Size(640, 480),
                                        cv::Size(128, 128)),
+                                Values(3.0, 1.0, 0.5, 0.0, -1.0),
+                                Values(256.0, 32.0, 0.0, -128.0),
+                                Values(Tolerance_FloatRel_IntAbs(1e-5, 2).to_compare_f()),
                                 Values(cv::compile_args(CORE_FLUID))));
 
 INSTANTIATE_TEST_CASE_P(Split3TestFluid, Split3Test,

--- a/modules/gapi/test/cpu/gapi_core_tests_fluid.cpp
+++ b/modules/gapi/test/cpu/gapi_core_tests_fluid.cpp
@@ -142,8 +142,8 @@ INSTANTIATE_TEST_CASE_P(ConvertToFluid, ConvertToTest,
                                        cv::Size(1280, 720),
                                        cv::Size(640, 480),
                                        cv::Size(128, 128)),
-                                Values(3.0, 1.0, 0.5, 0.0, -1.0),
-                                Values(256.0, 32.0, 0.0, -128.0),
+                                Values(2.5, 1.0, -1.0),
+                                Values(250.0, 0.0, -128.0),
                                 Values(Tolerance_FloatRel_IntAbs(1e-5, 2).to_compare_f()),
                                 Values(cv::compile_args(CORE_FLUID))));
 

--- a/modules/gapi/test/gpu/gapi_core_tests_gpu.cpp
+++ b/modules/gapi/test/gpu/gapi_core_tests_gpu.cpp
@@ -360,7 +360,7 @@ INSTANTIATE_TEST_CASE_P(ConvertToGPU, ConvertToTest,
                                        cv::Size(128, 128)),
                                 Values(3.0, 1.0, 0.5, 0.0, -1.0),
                                 Values(256.0, 32.0, 0.0, -128.0),
-                                Values(Tolerance_FloatRel_IntAbs(1e-5, 2).to_compare_f()),
+                                Values(AbsExact().to_compare_f()),
                                 Values(cv::compile_args(CORE_GPU))));
 
 INSTANTIATE_TEST_CASE_P(ConcatHorTestGPU, ConcatHorTest,

--- a/modules/gapi/test/gpu/gapi_core_tests_gpu.cpp
+++ b/modules/gapi/test/gpu/gapi_core_tests_gpu.cpp
@@ -353,11 +353,14 @@ INSTANTIATE_TEST_CASE_P(LUTTestCustomGPU, LUTTest,
                                 Values(cv::compile_args(CORE_GPU))));
 
 INSTANTIATE_TEST_CASE_P(ConvertToGPU, ConvertToTest,
-                        Combine(Values( CV_8UC1, CV_8UC3, CV_16UC1, CV_16SC1, CV_32FC1 ),
+                        Combine(Values(CV_8UC1, CV_8UC3, CV_16UC1, CV_16SC1, CV_32FC1),
                                 Values(CV_8U, CV_16U, CV_16S, CV_32F),
                                 Values(cv::Size(1280, 720),
                                        cv::Size(640, 480),
                                        cv::Size(128, 128)),
+                                Values(3.0, 1.0, 0.5, 0.0, -1.0),
+                                Values(256.0, 32.0, 0.0, -128.0),
+                                Values(Tolerance_FloatRel_IntAbs(1e-5, 2).to_compare_f()),
                                 Values(cv::compile_args(CORE_GPU))));
 
 INSTANTIATE_TEST_CASE_P(ConcatHorTestGPU, ConcatHorTest,

--- a/modules/gapi/test/gpu/gapi_core_tests_gpu.cpp
+++ b/modules/gapi/test/gpu/gapi_core_tests_gpu.cpp
@@ -358,8 +358,8 @@ INSTANTIATE_TEST_CASE_P(ConvertToGPU, ConvertToTest,
                                 Values(cv::Size(1280, 720),
                                        cv::Size(640, 480),
                                        cv::Size(128, 128)),
-                                Values(3.0, 1.0, 0.5, 0.0, -1.0),
-                                Values(256.0, 32.0, 0.0, -128.0),
+                                Values(2.5, 1.0, -1.0),
+                                Values(250.0, 0.0, -128.0),
                                 Values(AbsExact().to_compare_f()),
                                 Values(cv::compile_args(CORE_GPU))));
 


### PR DESCRIPTION
This pullrequest adds new parameters alpha and beta in tests on ConvertTo kernel 
