### PR TITLE
stub cuda4dnn overall design

### DIFF
--- a/modules/dnn/include/opencv2/dnn/dnn.hpp
+++ b/modules/dnn/include/opencv2/dnn/dnn.hpp
@@ -85,7 +85,8 @@ CV__DNN_INLINE_NS_BEGIN
         DNN_BACKEND_HALIDE,
         DNN_BACKEND_INFERENCE_ENGINE,  //!< Intel's Inference Engine computational backend.
         DNN_BACKEND_OPENCV,
-        DNN_BACKEND_VKCOM
+        DNN_BACKEND_VKCOM,
+        DNN_BACKEND_CUDA
     };
 
     /**
@@ -99,7 +100,8 @@ CV__DNN_INLINE_NS_BEGIN
         DNN_TARGET_OPENCL_FP16,
         DNN_TARGET_MYRIAD,
         DNN_TARGET_VULKAN,
-        DNN_TARGET_FPGA  //!< FPGA device with CPU fallbacks using Inference Engine's Heterogeneous plugin.
+        DNN_TARGET_FPGA,  //!< FPGA device with CPU fallbacks using Inference Engine's Heterogeneous plugin.
+        DNN_TARGET_CUDA_FP32
     };
 
     CV_EXPORTS std::vector< std::pair<Backend, Target> > getAvailableBackends();
@@ -184,6 +186,8 @@ CV__DNN_INLINE_NS_BEGIN
      *
      * Each class, derived from Layer, must implement allocate() methods to declare own outputs and forward() to compute outputs.
      * Also before using the new layer into networks you must register your layer by using one of @ref dnnLayerFactory "LayerFactory" macros.
+     *
+     * If a layer intends to provide a CUDA implementation, it must implement initCUDA() and forwardCUDA() methods.
      */
     class CV_EXPORTS_W Layer : public Algorithm
     {
@@ -234,6 +238,20 @@ CV__DNN_INLINE_NS_BEGIN
          *  @param[out] internals allocated internal blobs
          */
         void forward_fallback(InputArrayOfArrays inputs, OutputArrayOfArrays outputs, OutputArrayOfArrays internals);
+
+        /** @brief forward the @p inputs through the layer
+         *
+         *  @param[in]  inputs  input tensors
+         *  @param[out] outputs output tensors
+         *  @param[out] workspace scratchpad memory that can be used for anything
+         *
+         *  This method needs to be implemented iff the layer supports computation on a CUDA device. If not implemented,
+         *  the forward pass is computed using the CPU.
+         */
+        virtual void forwardCUDA(
+            std::vector<cv::Ptr<BackendWrapper>>& inputs,
+            std::vector<cv::Ptr<BackendWrapper>>& outputs
+            /* cuda4dnn::csl::workspace& workspace */);
 
         /** @brief
          * @overload
@@ -288,6 +306,24 @@ CV__DNN_INLINE_NS_BEGIN
         virtual Ptr<BackendNode> initInfEngine(const std::vector<Ptr<BackendWrapper> > &inputs);
 
         virtual Ptr<BackendNode> initVkCom(const std::vector<Ptr<BackendWrapper> > &inputs);
+
+        /**
+         * @brief Initializes the layer to perform forward pass on CUDA capable devices.
+         *
+         * @params[in]  stream                  stream to use for operations
+         * @params[in]  cublas_handle           cuBLAS handle to use for cuBLAS operations
+         * @params[in]  cudnn_handle            cuDNN handle to use for cuDNN operations
+         * @params[out] scratch_mem_in_bytes    request extra device memory in bytes for internals
+         *
+         * This method needs to be implemented iff the layer supports computation on a CUDA device.
+         */
+        virtual void initCUDA(/*
+            cuda4dnn::csl::Stream stream,
+            cuda4dnn::csl::cublas::Handle cublas_handle,
+            cuda4dnn::csl::cudnn::Handle cudnn_handle,
+            std::size_t& scratch_mem_in_bytes
+        */);
+
        /**
         * @brief Automatic Halide scheduling based on layer hyper-parameters.
         * @param[in] node Backend node with Halide functions.
@@ -529,13 +565,14 @@ CV__DNN_INLINE_NS_BEGIN
          * @see Target
          *
          * List of supported combinations backend / target:
-         * |                        | DNN_BACKEND_OPENCV | DNN_BACKEND_INFERENCE_ENGINE | DNN_BACKEND_HALIDE |
-         * |------------------------|--------------------|------------------------------|--------------------|
-         * | DNN_TARGET_CPU         |                  + |                            + |                  + |
-         * | DNN_TARGET_OPENCL      |                  + |                            + |                  + |
-         * | DNN_TARGET_OPENCL_FP16 |                  + |                            + |                    |
-         * | DNN_TARGET_MYRIAD      |                    |                            + |                    |
-         * | DNN_TARGET_FPGA        |                    |                            + |                    |
+         * |                        | DNN_BACKEND_OPENCV | DNN_BACKEND_INFERENCE_ENGINE | DNN_BACKEND_HALIDE |  DNN_BACKEND_CUDA |
+         * |------------------------|--------------------|------------------------------|--------------------|-------------------|
+         * | DNN_TARGET_CPU         |                  + |                            + |                  + |                   |
+         * | DNN_TARGET_OPENCL      |                  + |                            + |                  + |                   |
+         * | DNN_TARGET_OPENCL_FP16 |                  + |                            + |                    |                   |
+         * | DNN_TARGET_MYRIAD      |                    |                            + |                    |                   |
+         * | DNN_TARGET_FPGA        |                    |                            + |                    |                   |
+         * | DNN_TARGET_CUDA_FP32   |                    |                              |                    |                 + |
          */
         CV_WRAP void setPreferableTarget(int targetId);
 

--- a/modules/dnn/include/opencv2/dnn/dnn.hpp
+++ b/modules/dnn/include/opencv2/dnn/dnn.hpp
@@ -243,7 +243,7 @@ CV__DNN_INLINE_NS_BEGIN
          *
          *  @param[in]  inputs  input tensors
          *  @param[out] outputs output tensors
-         *  @param[out] workspace scratchpad memory that can be used for anything
+         *  param[out] workspace scratchpad memory that can be used for anything
          *
          *  This method needs to be implemented iff the layer supports computation on a CUDA device. If not implemented,
          *  the forward pass is computed using the CPU.
@@ -310,10 +310,10 @@ CV__DNN_INLINE_NS_BEGIN
         /**
          * @brief Initializes the layer to perform forward pass on CUDA capable devices.
          *
-         * @params[in]  stream                  stream to use for operations
-         * @params[in]  cublas_handle           cuBLAS handle to use for cuBLAS operations
-         * @params[in]  cudnn_handle            cuDNN handle to use for cuDNN operations
-         * @params[out] scratch_mem_in_bytes    request extra device memory in bytes for internals
+         * param[in]  stream                  stream to use for operations
+         * param[in]  cublas_handle           cuBLAS handle to use for cuBLAS operations
+         * param[in]  cudnn_handle            cuDNN handle to use for cuDNN operations
+         * param[out] scratch_mem_in_bytes    request extra device memory in bytes for internals
          *
          * This method needs to be implemented iff the layer supports computation on a CUDA device.
          */

--- a/modules/dnn/src/op_cuda.cpp
+++ b/modules/dnn/src/op_cuda.cpp
@@ -1,0 +1,12 @@
+// This file is part of OpenCV project.
+// It is subject to the license terms in the LICENSE file found in the top-level directory
+// of this distribution and at http://opencv.org/license.html.
+
+#include "precomp.hpp"
+#include "op_cuda.hpp"
+
+namespace cv {
+    namespace dnn {
+
+    } /* namespace dnn */
+} /* namespace cv */

--- a/modules/dnn/src/op_cuda.hpp
+++ b/modules/dnn/src/op_cuda.hpp
@@ -1,0 +1,65 @@
+// This file is part of OpenCV project.
+// It is subject to the license terms in the LICENSE file found in the top-level directory
+// of this distribution and at http://opencv.org/license.html.
+
+#ifndef OPENCV_DNN_SRC_OP_CUDA_HPP
+#define OPENCV_DNN_SRC_OP_CUDA_HPP
+
+namespace cv {
+    namespace dnn {
+        inline bool haveCUDA() {
+#ifdef HAVE_CUDA
+            return true;
+#else
+            return false;
+#endif
+        }
+
+#ifdef HAVE_CUDA
+        /* CUDA Tensors are represented by csl::Tensor
+        ** CUDABackendWrapperFP32 wraps a csl::TensorSpan<float>
+        ** It also maintains a reference to the csl::Tensor.
+        */
+        class CUDABackendWrapperFP32 : public BackendWrapper {
+        public:
+            CUDABackendWrapperFP32(Mat& m) : BackendWrapper(DNN_BACKEND_OPENCV, DNN_TARGET_CUDA_FP32) {
+                /* TODO:
+                ** 1. store a reference to cv::Mat
+                ** 2. create a csl::Tensor<float>
+                ** 3. create a csl::TensorSpan<float> (or store shape)
+                */
+            }
+
+            CUDABackendWrapperFP32(const Ptr<BackendWrapper>& base, const MatShape& shape)
+                : BackendWrapper(DNN_BACKEND_OPENCV, DNN_TARGET_CUDA_FP32) {
+                /* TODO:
+                ** 1. copy reference to csl::Tensor<float> of base
+                ** 2. set TensorSpan<float> to mimic `shape` (or store shape)
+                */
+            }
+
+            static Ptr<BackendWrapper> create(Mat& m)
+            {
+                return Ptr<BackendWrapper>(new CUDABackendWrapperFP32(m));
+            }
+
+            static Ptr<BackendWrapper> create(const Ptr<BackendWrapper>& base, const MatShape& shape)
+            {
+                return Ptr<BackendWrapper>(new CUDABackendWrapperFP32(base, shape));
+            }
+
+            virtual void copyToHost() CV_OVERRIDE { }
+            virtual void setHostDirty() CV_OVERRIDE { }
+
+            //TensorSpan<float> getSpan();
+            //TensorView<float> getView();
+
+            /* TensorSpan member vs create in getSpan()
+            ** member tensor span can save shape changes
+            */
+        };
+#endif
+    } /* namespace dnn */
+}  /* namespace cv */
+
+#endif  /* OPENCV_DNN_SRC_OP_CUDA_HPP */

--- a/modules/dnn/src/precomp.hpp
+++ b/modules/dnn/src/precomp.hpp
@@ -77,6 +77,7 @@
 namespace cv { namespace dnn {
 CV__DNN_INLINE_NS_BEGIN
 #define IS_DNN_OPENCL_TARGET(id) (id == DNN_TARGET_OPENCL || id == DNN_TARGET_OPENCL_FP16)
+#define IS_DNN_CUDA_TARGET(id) (id == DNN_TARGET_CUDA_FP32)
 Mutex& getInitializationMutex();
 void initializeLayerFactory();
 CV__DNN_INLINE_NS_END

--- a/modules/dnn/test/test_common.impl.hpp
+++ b/modules/dnn/test/test_common.impl.hpp
@@ -26,6 +26,7 @@ void PrintTo(const cv::dnn::Backend& v, std::ostream* os)
     case DNN_BACKEND_INFERENCE_ENGINE: *os << "DLIE"; return;
     case DNN_BACKEND_VKCOM: *os << "VKCOM"; return;
     case DNN_BACKEND_OPENCV: *os << "OCV"; return;
+    case DNN_BACKEND_CUDA: *os << "CUDA"; return;
     } // don't use "default:" to emit compiler warnings
     *os << "DNN_BACKEND_UNKNOWN(" << (int)v << ")";
 }
@@ -39,6 +40,7 @@ void PrintTo(const cv::dnn::Target& v, std::ostream* os)
     case DNN_TARGET_MYRIAD: *os << "MYRIAD"; return;
     case DNN_TARGET_VULKAN: *os << "VULKAN"; return;
     case DNN_TARGET_FPGA: *os << "FPGA"; return;
+    case DNN_TARGET_CUDA_FP32: *os << "CUDA_FP32"; return;
     } // don't use "default:" to emit compiler warnings
     *os << "DNN_TARGET_UNKNOWN(" << (int)v << ")";
 }


### PR DESCRIPTION
### This pullrequest changes

**New constants:**
- `DNN_BACKEND_CUDA`
- `DNN_TARGET_CUDA_FP32`

**Additions to the `Layer` class:**
- `initCUDA` virtual method:
  - does nothing by default
  - mainly responsible copying blobs to device memory and other initialization tasks
- `forwardCUDA(inputs, outputs)` virtual method:
  - throws by default
  - responsible for computing the forward pass on the device

If `forwardCUDA` throws an exception, the network switches to CPU (`DNN_BACKEND_OPENCV`, `DNN_TARGET_CPU`). Hence, if a layer does not have a CUDA implementation, the `forwardCUDA` throws and causes a switch to CPU.

**Tests:**
https://gist.github.com/YashasSamaga/cba2ec8a73fca202b241d9d7d447c7f7

The full MNIST test dataset was run through a simple CNN. The accuracies on (`DNN_BACKEND_OPENCV`, `DNN_TARGET_CPU`) and (`DNN_BACKEND_CUDA`, `DNN_BACKEND_CUDA_FP32`) were found to be exactly identical. 

**Issues:**
1. a warning is sent every time a switch occurs which leads to huge spam of messages in the console

---

References: #14585
~~Merge after PR: #14660~~

```
force_builders=Custom
buildworker:Custom=linux-4
docker_image:Custom=ubuntu-cuda:18.04
```