### PR TITLE
doc: add parameter description

### DIFF
--- a/modules/ml/include/opencv2/ml.hpp
+++ b/modules/ml/include/opencv2/ml.hpp
@@ -1004,7 +1004,7 @@ public:
     @param samples Samples from which the Gaussian mixture model will be estimated. It should be a
         one-channel matrix, each row of which is a sample. If the matrix does not have CV_64F type
         it will be converted to the inner matrix of such type for the further computing.
-    @param probs0
+    @param probs0 the probabilities
     @param logLikelihoods The optional output matrix that contains a likelihood logarithm value for
         each sample. It has \f$nsamples \times 1\f$ size and CV_64FC1 type.
     @param labels The optional output "class label" for each sample:


### PR DESCRIPTION
Add javadoc parameter declaration.

This seems to prevent https://github.com/opencv/opencv_contrib/pull/2131. There log is [here](https://pullrequest.opencv.org/buildbot/builders/precommit-contrib_docs/builds/12485/steps/make%20doxygen/logs/warnings%20%281%29)

Although the error says "Parameter is documented more than once", the parameter is not duplicate, however there is another one named "probs", not sure if javadoc consider both "probs0" and "probs" the same, in which case we should rename one of them.

```
**WIP**
force_builders=Docs
```