### PR TITLE
Fix for MSVS2019 build warnings

### DIFF
--- a/cmake/OpenCVCompilerOptimizations.cmake
+++ b/cmake/OpenCVCompilerOptimizations.cmake
@@ -294,7 +294,7 @@ if(X86 OR X86_64)
     else()
       ocv_update(CPU_SSE_SUPPORTED ON)
       ocv_update(CPU_SSE2_SUPPORTED ON)
-	  ocv_update(CPU_AVX_512F_FLAGS_ON "/arch:AVX512")
+      ocv_update(CPU_AVX_512F_FLAGS_ON "/arch:AVX512")
     endif()
     # Other instruction sets are supported by default since MSVC 2008 at least
   else()

--- a/cmake/OpenCVCompilerOptimizations.cmake
+++ b/cmake/OpenCVCompilerOptimizations.cmake
@@ -294,6 +294,7 @@ if(X86 OR X86_64)
     else()
       ocv_update(CPU_SSE_SUPPORTED ON)
       ocv_update(CPU_SSE2_SUPPORTED ON)
+	  ocv_update(CPU_AVX_512F_FLAGS_ON "/arch:AVX512")
     endif()
     # Other instruction sets are supported by default since MSVC 2008 at least
   else()

--- a/modules/imgproc/src/sumpixels.avx512_skx.cpp
+++ b/modules/imgproc/src/sumpixels.avx512_skx.cpp
@@ -79,9 +79,9 @@ public:
     {
         // Note the negative index is because the sums/sqsums pointers point to the first real pixel
         // after the border pixel so we have to look backwards
-        _mm512_mask_storeu_epi64(&sums[-num_channels], (1<<num_channels)-1, _mm512_setzero_si512());
+        _mm512_mask_storeu_epi64(&sums[-(ptrdiff_t)num_channels], (1<<num_channels)-1, _mm512_setzero_si512());
         if (sqsums)
-            _mm512_mask_storeu_epi64(&sqsums[-num_channels], (1<<num_channels)-1, _mm512_setzero_si512());
+            _mm512_mask_storeu_epi64(&sqsums[-(ptrdiff_t)num_channels], (1<<num_channels)-1, _mm512_setzero_si512());
     }
 
 
@@ -180,11 +180,11 @@ public:
         //
         _mm512_mask_storeu_pd(
                 results_ptr,   // Store the result here
-                data_mask,     // Using the data mask to avoid overrunning the line
+                (__mmask8)data_mask,     // Using the data mask to avoid overrunning the line
                 calculate_integral( // Writing the value of the integral derived from:
-                        src_longs,                                           // input data
-                        _mm512_maskz_loadu_pd(data_mask, above_values_ptr),  // and the results from line above
-                        accumulator                                          // keeping track of the accumulator
+                        src_longs,                                                    // input data
+                        _mm512_maskz_loadu_pd((__mmask8)data_mask, above_values_ptr), // and the results from line above
+                        accumulator                                                   // keeping track of the accumulator
                 )
         );
     }


### PR DESCRIPTION
Fix for MSVS2019 build warnings

<cut/>

```
force_builders=Custom Win,Custom
buildworker:Custom Win=windows-1
build_image:Custom Win=msvs2019
CPU_BASELINE:Custom Win=AVX512_SKX

buildworker:Custom=linux-3
build_image:Custom=ubuntu-clang:18.04
```