### PR TITLE
videoio: Supply properties to VideoWriter on initialization

### DIFF
--- a/modules/videoio/include/opencv2/videoio.hpp
+++ b/modules/videoio/include/opencv2/videoio.hpp
@@ -188,6 +188,17 @@ enum VideoWriterProperties {
   VIDEOWRITER_PROP_NSTRIPES = 3    //!< Number of stripes for parallel encoding. -1 for auto detection.
 };
 
+/** @brief Key/value structure for %VideoWriterProperties
+*/
+struct VideoWriterPropertyValue {
+    VideoWriterProperties property;
+    double value;
+};
+
+/** @brief List of key/value pairs for %VideoWriterProperties
+*/
+typedef ::std::vector<VideoWriterPropertyValue> VideoWriterPropertyList;
+
 //! @} videoio_flags_base
 
 //! @addtogroup videoio_flags_others
@@ -853,6 +864,13 @@ public:
     CV_WRAP VideoWriter(const String& filename, int apiPreference, int fourcc, double fps,
                 Size frameSize, bool isColor = true);
 
+    /** @overload
+    The `properties` parameter allows to specify properties on initialization.  Some API backends
+    do not allow properties to be set after initialization.
+     */
+    CV_WRAP VideoWriter(const String& filename, int apiPreference, int fourcc, double fps,
+        Size frameSize, bool isColor, const VideoWriterPropertyList& properties);
+
     /** @brief Default destructor
 
     The method first calls VideoWriter::release to close the already opened file.
@@ -874,6 +892,18 @@ public:
      */
     CV_WRAP bool open(const String& filename, int apiPreference, int fourcc, double fps,
                       Size frameSize, bool isColor = true);
+
+    /** @overload
+    The `properties` allows setting properties on initialization.  Some API backends do not allow
+    setting properties after initialization.
+     */
+    CV_WRAP bool open(const String& filename, int fourcc, double fps,
+                      Size frameSize, bool isColor, const VideoWriterPropertyList& properties);
+
+    /** @overload
+     */
+    CV_WRAP bool open(const String& filename, int apiPreference, int fourcc, double fps,
+                      Size frameSize, bool isColor, const VideoWriterPropertyList& properties);
 
     /** @brief Returns true if video writer has been successfully initialized.
     */

--- a/modules/videoio/src/backend.hpp
+++ b/modules/videoio/src/backend.hpp
@@ -19,6 +19,7 @@ public:
     virtual Ptr<IVideoCapture> createCapture(int camera) const = 0;
     virtual Ptr<IVideoCapture> createCapture(const std::string &filename) const = 0;
     virtual Ptr<IVideoWriter>  createWriter(const std::string &filename, int fourcc, double fps, const cv::Size &sz, bool isColor) const = 0;
+    virtual Ptr<IVideoWriter>  createWriter(const std::string &filename, int fourcc, double fps, const cv::Size &sz, bool isColor, const VideoWriterPropertyList& properties) const = 0;
 };
 
 class IBackendFactory
@@ -33,9 +34,11 @@ public:
 typedef Ptr<IVideoCapture> (*FN_createCaptureFile)(const std::string & filename);
 typedef Ptr<IVideoCapture> (*FN_createCaptureCamera)(int camera);
 typedef Ptr<IVideoWriter>  (*FN_createWriter)(const std::string& filename, int fourcc, double fps, const Size& sz, bool isColor);
+typedef Ptr<IVideoWriter>  (*FN_createWriterWithProperties)(const std::string& filename, int fourcc, double fps, const Size& sz, bool isColor, const VideoWriterPropertyList& properties);
 Ptr<IBackendFactory> createBackendFactory(FN_createCaptureFile createCaptureFile,
                                           FN_createCaptureCamera createCaptureCamera,
-                                          FN_createWriter createWriter);
+                                          FN_createWriter createWriter,
+                                          FN_createWriterWithProperties createWriterWithProperties);
 
 Ptr<IBackendFactory> createPluginBackendFactory(VideoCaptureAPIs id, const char* baseName);
 

--- a/modules/videoio/src/backend_plugin.cpp
+++ b/modules/videoio/src/backend_plugin.cpp
@@ -187,6 +187,7 @@ public:
     Ptr<IVideoCapture> createCapture(int camera) const CV_OVERRIDE;
     Ptr<IVideoCapture> createCapture(const std::string &filename) const CV_OVERRIDE;
     Ptr<IVideoWriter>  createWriter(const std::string &filename, int fourcc, double fps, const cv::Size &sz, bool isColor) const CV_OVERRIDE;
+    Ptr<IVideoWriter>  createWriter(const std::string &filename, int fourcc, double fps, const cv::Size &sz, bool isColor, const VideoWriterPropertyList& properties) const CV_OVERRIDE;
 };
 
 class PluginBackendFactory : public IBackendFactory
@@ -498,6 +499,12 @@ Ptr<IVideoWriter> PluginBackend::createWriter(const std::string &filename, int f
         CV_LOG_DEBUG(NULL, "Video I/O: can't open writer: " << filename);
     }
     return Ptr<IVideoWriter>();
+}
+
+Ptr<IVideoWriter> PluginBackend::createWriter(const std::string &filename, int fourcc, double fps, const cv::Size &sz, bool isColor, const VideoWriterPropertyList& /*properties*/) const
+{
+    // TODO: Allow plugins to retrieve initial property list
+    return createWriter(filename, fourcc, fps, sz, isColor);
 }
 
 }  // namespace

--- a/modules/videoio/src/cap.cpp
+++ b/modules/videoio/src/cap.cpp
@@ -337,6 +337,11 @@ VideoWriter::VideoWriter(const String& filename, int apiPreference, int _fourcc,
     open(filename, apiPreference, _fourcc, fps, frameSize, isColor);
 }
 
+VideoWriter::VideoWriter(const String& filename, int apiPreference, int _fourcc, double fps, Size frameSize, bool isColor, const VideoWriterPropertyList& properties)
+{
+    open(filename, apiPreference, _fourcc, fps, frameSize, isColor, properties);
+}
+
 void VideoWriter::release()
 {
     iwriter.release();
@@ -353,6 +358,17 @@ bool VideoWriter::open(const String& filename, int _fourcc, double fps, Size fra
 }
 
 bool VideoWriter::open(const String& filename, int apiPreference, int _fourcc, double fps, Size frameSize, bool isColor)
+{
+    VideoWriterPropertyList emptyProperties;
+    return open(filename, apiPreference, _fourcc, fps, frameSize, isColor, emptyProperties);
+}
+
+bool VideoWriter::open(const String& filename, int _fourcc, double fps, Size frameSize, bool isColor, const VideoWriterPropertyList& properties)
+{
+    return open(filename, CAP_ANY, _fourcc, fps, frameSize, isColor, properties);
+}
+
+bool VideoWriter::open(const String& filename, int apiPreference, int _fourcc, double fps, Size frameSize, bool isColor, const VideoWriterPropertyList& properties)
 {
     CV_INSTRUMENT_REGION();
 
@@ -373,7 +389,7 @@ bool VideoWriter::open(const String& filename, int apiPreference, int _fourcc, d
             {
                 try
                 {
-                    iwriter = backend->createWriter(filename, _fourcc, fps, frameSize, isColor);
+                    iwriter = backend->createWriter(filename, _fourcc, fps, frameSize, isColor, properties);
                     if (!iwriter.empty())
                     {
                         if (param_VIDEOIO_DEBUG || param_VIDEOWRITER_DEBUG)

--- a/modules/videoio/src/videoio_registry.cpp
+++ b/modules/videoio/src/videoio_registry.cpp
@@ -41,9 +41,9 @@ namespace {
     cap, (BackendMode)(mode), 1000, name, createPluginBackendFactory(cap, name) \
 }
 
-#define DECLARE_STATIC_BACKEND(cap, name, mode, createCaptureFile, createCaptureCamera, createWriter) \
+#define DECLARE_STATIC_BACKEND(cap, name, mode, createCaptureFile, createCaptureCamera, createWriter, createWriterWithProperties) \
 { \
-    cap, (BackendMode)(mode), 1000, name, createBackendFactory(createCaptureFile, createCaptureCamera, createWriter) \
+    cap, (BackendMode)(mode), 1000, name, createBackendFactory(createCaptureFile, createCaptureCamera, createWriter, createWriterWithProperties) \
 }
 
 /** Ordering guidelines:
@@ -57,77 +57,77 @@ namespace {
 static const struct VideoBackendInfo builtin_backends[] =
 {
 #ifdef HAVE_FFMPEG
-    DECLARE_STATIC_BACKEND(CAP_FFMPEG, "FFMPEG", MODE_CAPTURE_BY_FILENAME | MODE_WRITER, cvCreateFileCapture_FFMPEG_proxy, 0, cvCreateVideoWriter_FFMPEG_proxy),
+    DECLARE_STATIC_BACKEND(CAP_FFMPEG, "FFMPEG", MODE_CAPTURE_BY_FILENAME | MODE_WRITER, cvCreateFileCapture_FFMPEG_proxy, 0, cvCreateVideoWriter_FFMPEG_proxy, 0),
 #elif defined(ENABLE_PLUGINS)
     DECLARE_DYNAMIC_BACKEND(CAP_FFMPEG, "FFMPEG", MODE_CAPTURE_BY_FILENAME | MODE_WRITER),
 #endif
 
 #ifdef HAVE_GSTREAMER
-    DECLARE_STATIC_BACKEND(CAP_GSTREAMER, "GSTREAMER", MODE_CAPTURE_ALL | MODE_WRITER, createGStreamerCapture_file, createGStreamerCapture_cam, create_GStreamer_writer),
+    DECLARE_STATIC_BACKEND(CAP_GSTREAMER, "GSTREAMER", MODE_CAPTURE_ALL | MODE_WRITER, createGStreamerCapture_file, createGStreamerCapture_cam, create_GStreamer_writer, 0),
 #elif defined(ENABLE_PLUGINS)
     DECLARE_DYNAMIC_BACKEND(CAP_GSTREAMER, "GSTREAMER", MODE_CAPTURE_ALL | MODE_WRITER),
 #endif
 
 #ifdef HAVE_MFX // Media SDK
-    DECLARE_STATIC_BACKEND(CAP_INTEL_MFX, "INTEL_MFX", MODE_CAPTURE_BY_FILENAME | MODE_WRITER, create_MFX_capture, 0, create_MFX_writer),
+    DECLARE_STATIC_BACKEND(CAP_INTEL_MFX, "INTEL_MFX", MODE_CAPTURE_BY_FILENAME | MODE_WRITER, create_MFX_capture, 0, create_MFX_writer, 0),
 #elif defined(ENABLE_PLUGINS)
     DECLARE_DYNAMIC_BACKEND(CAP_INTEL_MFX, "INTEL_MFX", MODE_CAPTURE_BY_FILENAME | MODE_WRITER),
 #endif
 
     // Apple platform
 #ifdef HAVE_AVFOUNDATION
-    DECLARE_STATIC_BACKEND(CAP_AVFOUNDATION, "AVFOUNDATION", MODE_CAPTURE_ALL | MODE_WRITER, create_AVFoundation_capture_file, create_AVFoundation_capture_cam, create_AVFoundation_writer),
+    DECLARE_STATIC_BACKEND(CAP_AVFOUNDATION, "AVFOUNDATION", MODE_CAPTURE_ALL | MODE_WRITER, create_AVFoundation_capture_file, create_AVFoundation_capture_cam, create_AVFoundation_writer, 0),
 #endif
 
     // Windows
 #ifdef WINRT_VIDEO
-    DECLARE_STATIC_BACKEND(CAP_WINRT, "WINRT", MODE_CAPTURE_BY_INDEX, 0, create_WRT_capture, 0),
+    DECLARE_STATIC_BACKEND(CAP_WINRT, "WINRT", MODE_CAPTURE_BY_INDEX, 0, create_WRT_capture, 0, 0),
 #endif
 #ifdef HAVE_MSMF
-    DECLARE_STATIC_BACKEND(CAP_MSMF, "MSMF", MODE_CAPTURE_ALL | MODE_WRITER, cvCreateCapture_MSMF, cvCreateCapture_MSMF, cvCreateVideoWriter_MSMF),
+    DECLARE_STATIC_BACKEND(CAP_MSMF, "MSMF", MODE_CAPTURE_ALL | MODE_WRITER, cvCreateCapture_MSMF, cvCreateCapture_MSMF, cvCreateVideoWriter_MSMF, 0),
 #endif
 #ifdef HAVE_DSHOW
-    DECLARE_STATIC_BACKEND(CAP_DSHOW, "DSHOW", MODE_CAPTURE_BY_INDEX, 0, create_DShow_capture, 0),
+    DECLARE_STATIC_BACKEND(CAP_DSHOW, "DSHOW", MODE_CAPTURE_BY_INDEX, 0, create_DShow_capture, 0, 0),
 #endif
 
     // Linux, some Unix
 #if defined HAVE_CAMV4L2
-    DECLARE_STATIC_BACKEND(CAP_V4L2, "V4L2", MODE_CAPTURE_ALL, create_V4L_capture_file, create_V4L_capture_cam, 0),
+    DECLARE_STATIC_BACKEND(CAP_V4L2, "V4L2", MODE_CAPTURE_ALL, create_V4L_capture_file, create_V4L_capture_cam, 0, 0),
 #elif defined HAVE_VIDEOIO
-    DECLARE_STATIC_BACKEND(CAP_V4L, "V4L_BSD", MODE_CAPTURE_ALL, create_V4L_capture_file, create_V4L_capture_cam, 0),
+    DECLARE_STATIC_BACKEND(CAP_V4L, "V4L_BSD", MODE_CAPTURE_ALL, create_V4L_capture_file, create_V4L_capture_cam, 0, 0),
 #endif
 
 
     // RGB-D universal
 #ifdef HAVE_OPENNI2
-    DECLARE_STATIC_BACKEND(CAP_OPENNI2, "OPENNI2", MODE_CAPTURE_ALL, create_OpenNI2_capture_file, create_OpenNI2_capture_cam, 0),
+    DECLARE_STATIC_BACKEND(CAP_OPENNI2, "OPENNI2", MODE_CAPTURE_ALL, create_OpenNI2_capture_file, create_OpenNI2_capture_cam, 0, 0),
 #endif
 
 #ifdef HAVE_LIBREALSENSE
-    DECLARE_STATIC_BACKEND(CAP_REALSENSE, "INTEL_REALSENSE", MODE_CAPTURE_BY_INDEX, 0, create_RealSense_capture, 0),
+    DECLARE_STATIC_BACKEND(CAP_REALSENSE, "INTEL_REALSENSE", MODE_CAPTURE_BY_INDEX, 0, create_RealSense_capture, 0, 0),
 #endif
 
     // OpenCV file-based only
-    DECLARE_STATIC_BACKEND(CAP_IMAGES, "CV_IMAGES", MODE_CAPTURE_BY_FILENAME | MODE_WRITER, create_Images_capture, 0, create_Images_writer),
-    DECLARE_STATIC_BACKEND(CAP_OPENCV_MJPEG, "CV_MJPEG", MODE_CAPTURE_BY_FILENAME | MODE_WRITER, createMotionJpegCapture, 0, createMotionJpegWriter),
+    DECLARE_STATIC_BACKEND(CAP_IMAGES, "CV_IMAGES", MODE_CAPTURE_BY_FILENAME | MODE_WRITER, create_Images_capture, 0, create_Images_writer, 0),
+    DECLARE_STATIC_BACKEND(CAP_OPENCV_MJPEG, "CV_MJPEG", MODE_CAPTURE_BY_FILENAME | MODE_WRITER, createMotionJpegCapture, 0, createMotionJpegWriter, 0),
 
     // special interfaces / stereo cameras / other SDKs
 #if defined(HAVE_DC1394_2)
-    DECLARE_STATIC_BACKEND(CAP_FIREWIRE, "FIREWIRE", MODE_CAPTURE_BY_INDEX, 0, create_DC1394_capture, 0),
+    DECLARE_STATIC_BACKEND(CAP_FIREWIRE, "FIREWIRE", MODE_CAPTURE_BY_INDEX, 0, create_DC1394_capture, 0, 0),
 #endif
     // GigE
 #ifdef HAVE_PVAPI
-    DECLARE_STATIC_BACKEND(CAP_PVAPI, "PVAPI", MODE_CAPTURE_BY_INDEX, 0, create_PvAPI_capture, 0),
+    DECLARE_STATIC_BACKEND(CAP_PVAPI, "PVAPI", MODE_CAPTURE_BY_INDEX, 0, create_PvAPI_capture, 0, 0),
 #endif
 #ifdef HAVE_XIMEA
-    DECLARE_STATIC_BACKEND(CAP_XIAPI, "XIMEA", MODE_CAPTURE_ALL, create_XIMEA_capture_file, create_XIMEA_capture_cam, 0),
+    DECLARE_STATIC_BACKEND(CAP_XIAPI, "XIMEA", MODE_CAPTURE_ALL, create_XIMEA_capture_file, create_XIMEA_capture_cam, 0, 0),
 #endif
 #ifdef HAVE_ARAVIS_API
-    DECLARE_STATIC_BACKEND(CAP_ARAVIS, "ARAVIS", MODE_CAPTURE_BY_INDEX, 0, create_Aravis_capture, 0),
+    DECLARE_STATIC_BACKEND(CAP_ARAVIS, "ARAVIS", MODE_CAPTURE_BY_INDEX, 0, create_Aravis_capture, 0, 0),
 #endif
 
 #ifdef HAVE_GPHOTO2
-    DECLARE_STATIC_BACKEND(CAP_GPHOTO2, "GPHOTO2", MODE_CAPTURE_ALL, createGPhoto2Capture, createGPhoto2Capture, 0),
+    DECLARE_STATIC_BACKEND(CAP_GPHOTO2, "GPHOTO2", MODE_CAPTURE_ALL, createGPhoto2Capture, createGPhoto2Capture, 0, 0),
 #endif
 #ifdef HAVE_XINE
     DECLARE_STATIC_BACKEND(CAP_XINE, "XINE", MODE_CAPTURE_BY_FILENAME, createXINECapture, 0, 0),


### PR DESCRIPTION
Most video compressors (including FFmpeg, MSMF and probably others) need to know their parameters on initialization, but the set()/setProperty() functions can only be used after initialization.  This PR adds overloads of the VideoWriter constructor and open() function which allow setting these parameters via properties when the compressor is initialized.

To avoid modifying each individual backend, static backends can register two functions to create a writer: one which accepts the new parameter and one which does not.  The new function is used if available; otherwise StaticBackendFactory falls back to the old function for backwards compatibility.

I've only implemented this for static backends, not for plugins.

This touches several existing bits including the well-established videoio API (though only in a backwards-compatible way) so I thought I'd get feedback before implementing anything which uses this new mechanism.  In particular, I'd like to implement bitrate control for MSMF and FFmpeg.

### This pullrequest changes

Adds new overloads to the VideoWriter constructor and open function which allow properties to be passed in at compressor initialization time.