### PR TITLE
Update obsolete flag in Intel video decoder.

### DIFF
--- a/modules/videoio/src/cap_mfx_common.cpp
+++ b/modules/videoio/src/cap_mfx_common.cpp
@@ -17,7 +17,7 @@ using namespace cv;
 bool DeviceHandler::init(MFXVideoSession &session)
 {
     mfxStatus res = MFX_ERR_NONE;
-    mfxIMPL impl = MFX_IMPL_AUTO;
+    mfxIMPL impl = MFX_IMPL_AUTO_ANY;
     mfxVersion ver = { {19, 1} };
 
     res = session.Init(impl, &ver);


### PR DESCRIPTION
On systems where the Intel GPU is not the primary device the obsolete flag MFX_IMPL_AUTO may cause a capture device created with the CAP_INTEL_MFX flag to use the software and not the hardware video decoder.

I can reproduce on a laptop with both an Nvidia and Intel GPU. Before the change the result of [this](https://github.com/opencv/opencv/blob/987061d800609ba8e4cff893fb6502bc6a4750c4/modules/videoio/src/cap_mfx_common.cpp#L26) was
`impl == MFX_IMPL_SOFTWARE`
after the change 
`impl == MFX_IMPL_VIA_D3D11 & MFX_IMPL_HARDWARE2`

Even if this does not effect every multiple device/monitor setup the obsolete flag should probably still be updated