### PR TITLE
core: avoid function type cast, make happy UBSAN

### DIFF
--- a/modules/core/src/convert.dispatch.cpp
+++ b/modules/core/src/convert.dispatch.cpp
@@ -244,12 +244,12 @@ void convertFp16(InputArray _src, OutputArray _dst)
         }
         else
             ddepth =  CV_16S;
-        func = (BinaryFunc)getConvertFunc(CV_32F, CV_16F);
+        func = getConvertFunc(CV_32F, CV_16F);
         break;
     case CV_16S:
     case CV_16F:
         ddepth = CV_32F;
-        func = (BinaryFunc)getConvertFunc(CV_16F, CV_32F);
+        func = getConvertFunc(CV_16F, CV_32F);
         break;
     default:
         CV_Error(Error::StsUnsupportedFormat, "Unsupported input depth");

--- a/modules/core/src/convert_scale.simd.hpp
+++ b/modules/core/src/convert_scale.simd.hpp
@@ -197,17 +197,23 @@ cvt_64f( const _Ts* src, size_t sstep, _Td* dst, size_t dstep,
 //==================================================================================================
 
 #define DEF_CVT_SCALE_ABS_FUNC(suffix, cvt, stype, dtype, wtype) \
-static void cvtScaleAbs##suffix( const stype* src, size_t sstep, const uchar*, size_t, \
-                                 dtype* dst, size_t dstep, Size size, double* scale) \
+static void cvtScaleAbs##suffix( const uchar* src_, size_t sstep, const uchar*, size_t, \
+                                 uchar* dst_, size_t dstep, Size size, void* scale_) \
 { \
+    const stype* src = (const stype*)src_; \
+    dtype* dst = (dtype*)dst_; \
+    double* scale = (double*)scale_; \
     cvt(src, sstep, dst, dstep, size, (wtype)scale[0], (wtype)scale[1]); \
 }
 
 
 #define DEF_CVT_SCALE_FUNC(suffix, cvt, stype, dtype, wtype) \
-static void cvtScale##suffix( const stype* src, size_t sstep, const uchar*, size_t, \
-                              dtype* dst, size_t dstep, Size size, double* scale) \
+static void cvtScale##suffix( const uchar* src_, size_t sstep, const uchar*, size_t, \
+                              uchar* dst_, size_t dstep, Size size, void* scale_) \
 { \
+    const stype* src = (const stype*)src_; \
+    dtype* dst = (dtype*)dst_; \
+    double* scale = (double*)scale_; \
     cvt(src, sstep, dst, dstep, size, (wtype)scale[0], (wtype)scale[1]); \
 }
 


### PR DESCRIPTION
Message from UBSAN:

<cut/>

> modules/core/src/convert.dispatch.cpp:213:9: runtime error: call to function cv::opt_AVX2::cvtScale32f(float const*, unsigned long, unsigned char const*, unsigned long, float*, unsigned long, cv::Size_<int>, double*) through pointer to incorrect function type 'void (*)(const unsigned char *, unsigned long, const unsigned char *, unsigned long, unsigned char *, unsigned long, cv::Size_<int>, void *)'
modules/core/src/convert_scale.simd.hpp:272: note: cv::opt_AVX2::cvtScale32f(float const*, unsigned long, unsigned char const*, unsigned long, float*, unsigned long, cv::Size_<int>, double*) defined here


```
buildworker:Custom=linux-1,linux-2,linux-4
docker_image:Custom=javascript
```