### PR TITLE
Increase CV_IO_MAX_IMAGE_PIXELS

### DIFF
--- a/modules/imgcodecs/src/loadsave.cpp
+++ b/modules/imgcodecs/src/loadsave.cpp
@@ -63,7 +63,7 @@ namespace cv {
 static const size_t CV_IO_MAX_IMAGE_PARAMS = cv::utils::getConfigurationParameterSizeT("OPENCV_IO_MAX_IMAGE_PARAMS", 50);
 static const size_t CV_IO_MAX_IMAGE_WIDTH = utils::getConfigurationParameterSizeT("OPENCV_IO_MAX_IMAGE_WIDTH", 1 << 20);
 static const size_t CV_IO_MAX_IMAGE_HEIGHT = utils::getConfigurationParameterSizeT("OPENCV_IO_MAX_IMAGE_HEIGHT", 1 << 20);
-static const size_t CV_IO_MAX_IMAGE_PIXELS = utils::getConfigurationParameterSizeT("OPENCV_IO_MAX_IMAGE_PIXELS", 1 << 30);
+static const size_t CV_IO_MAX_IMAGE_PIXELS = utils::getConfigurationParameterSizeT("OPENCV_IO_MAX_IMAGE_PIXELS", 1ULL << 40);
 
 static Size validateInputImageSize(const Size& size)
 {


### PR DESCRIPTION
resolves #10211 again

### This pullrequest changes

Increase CV_IO_MAX_IMAGE_PIXELS to 2^40 since apparently #11505 fixes #10211. I have no idea what this change breaks, but I assume all tests passed because no one is testing huge images. So if this max is increased then big images need to be tested. 
While we're at it maybe CV_IO_MAX_IMAGE_WIDTH and CV_IO_MAX_IMAGE_HEIGHT should be increased too. 

I tried reading in a 50000x50000 PNG file and running simple operations: saving, GaussianBlur, boxFilter, Laplacian. I could not load a 100000x100000 PNG without running out of memory.

Perhaps a warning can be issued to users if they try loading images bigger than 2^30 (previous limit). I know Pillow errors but this error can be turned into a warning or suppressed without recompiling. 

<details>

![50000_box](https://user-images.githubusercontent.com/7989982/59534474-6cb04d00-8ebc-11e9-8b4c-e089bbff35a2.png)
![50000_blur](https://user-images.githubusercontent.com/7989982/59534475-6cb04d00-8ebc-11e9-90c2-5fd9d42b39b4.png)
![50000](https://user-images.githubusercontent.com/7989982/59534476-6cb04d00-8ebc-11e9-8fd5-5a4539de6eba.png)
![10000](https://user-images.githubusercontent.com/7989982/59534477-6d48e380-8ebc-11e9-9e7b-d6dad3852387.png)

</details>