### PR TITLE
Fix Python code to get the same result between the Cpp, Java and Python.

### DIFF
--- a/samples/python/tutorial_code/ImgTrans/LaPlace/laplace_demo.py
+++ b/samples/python/tutorial_code/ImgTrans/LaPlace/laplace_demo.py
@@ -40,7 +40,7 @@ def main(argv):
 
     # [laplacian]
     # Apply Laplace function
-    dst = cv.Laplacian(src_gray, ddepth, kernel_size)
+    dst = cv.Laplacian(src_gray, ddepth, ksize=kernel_size)
     # [laplacian]
 
     # [convert]


### PR DESCRIPTION
### This pullrequest changes

According to this [stackoverflow question/answer](https://stackoverflow.com/questions/43903243/opencv-laplacian-different-results-in-python-and-c/56664626#56664626), we need to add the flag `ksize=` to get the same result between C++, Java and Python.

This will fix the snippet code associted with the following tutorial file:
 `/opencv/doc/tutorials/imgproc/imgtrans/laplace_operator/laplace_operator.markdown`