### PR TITLE
core: eliminate AVX512 build warnings

### DIFF
--- a/modules/core/include/opencv2/core/hal/intrin_avx512.hpp
+++ b/modules/core/include/opencv2/core/hal/intrin_avx512.hpp
@@ -5,6 +5,12 @@
 #ifndef OPENCV_HAL_INTRIN_AVX512_HPP
 #define OPENCV_HAL_INTRIN_AVX512_HPP
 
+#if defined(_MSC_VER) && (_MSC_VER < 1920/*MSVS2019*/)
+# pragma warning(disable:4146)  // unary minus operator applied to unsigned type, result still unsigned
+# pragma warning(disable:4309)  // 'argument': truncation of constant value
+# pragma warning(disable:4310)  // cast truncates constant value
+#endif
+
 #define CVT_ROUND_MODES_IMPLEMENTED 0
 
 #define CV_SIMD512 1
@@ -1599,13 +1605,13 @@ inline v_float64x8 v_lut(const double* tab, const v_int32x16& idxvec)
 inline void v_lut_deinterleave(const float* tab, const v_int32x16& idxvec, v_float32x16& x, v_float32x16& y)
 {
     x.val = _mm512_i32gather_ps(idxvec.val, tab, 4);
-    y.val = _mm512_i32gather_ps(idxvec.val, tab + 1, 4);
+    y.val = _mm512_i32gather_ps(idxvec.val, &tab[1], 4);
 }
 
 inline void v_lut_deinterleave(const double* tab, const v_int32x16& idxvec, v_float64x8& x, v_float64x8& y)
 {
     x.val = _mm512_i32gather_pd(_v512_extract_low(idxvec.val), tab, 8);
-    y.val = _mm512_i32gather_pd(_v512_extract_low(idxvec.val), tab + 1, 8);
+    y.val = _mm512_i32gather_pd(_v512_extract_low(idxvec.val), &tab[1], 8);
 }
 
 inline v_int8x64 v_interleave_pairs(const v_int8x64& vec)

--- a/modules/imgproc/src/sumpixels.avx512_skx.cpp
+++ b/modules/imgproc/src/sumpixels.avx512_skx.cpp
@@ -6,6 +6,9 @@
 #include "precomp.hpp"
 #include "sumpixels.hpp"
 
+#include "opencv2/core/hal/intrin.hpp"
+
+
 namespace cv {
 namespace { // Anonymous namespace to avoid exposing the implementation classes
 


### PR DESCRIPTION
from [MSVS2017](http://pullrequest.opencv.org/buildbot/builders/3_4-win64-vc15/builds/29) and GCC8 -O1 mode

<cut/>

```
                 from modules/dnn/layers/layers_common.avx512_skx.cpp:2:
modules/core/include/opencv2/core/hal/intrin_avx512.hpp: In function ‘void cv::hal_AVX512_SKX::v_lut_deinterleave(const float*, const cv::hal_AVX512_SKX::v_int32x16&, cv::hal_AVX512_SKX::v_float32x16&, cv::hal_AVX512_SKX::v_float32x16&)’:
modules/core/include/opencv2/core/hal/intrin_avx512.hpp:1602:49: warning: pointer of type ‘void *’ used in arithmetic [-Wpointer-arith]
     y.val = _mm512_i32gather_ps(idxvec.val, tab + 1, 4);
                                                 ^
modules/core/include/opencv2/core/hal/intrin_avx512.hpp: In function ‘void cv::hal_AVX512_SKX::v_lut_deinterleave(const double*, const cv::hal_AVX512_SKX::v_int32x16&, cv::hal_AVX512_SKX::v_float64x8&, cv::hal_AVX512_SKX::v_float64x8&)’:
modules/core/include/opencv2/core/hal/intrin_avx512.hpp:1608:68: warning: pointer of type ‘void *’ used in arithmetic [-Wpointer-arith]
     y.val = _mm512_i32gather_pd(_v512_extract_low(idxvec.val), tab + 1, 8);
                                                                    ^
```

---

```
force_builders=Linux AVX2,Custom
buildworker:Custom=linux-3
build_image:Custom=ubuntu:18.04
disable_ipp:Custom=ON
CPU_BASELINE:Custom=AVX512_SKX
```