### PR TITLE
Added mechanism to set/toggle NORMAL window to TOPMOST window.

### DIFF
--- a/modules/highgui/include/opencv2/highgui.hpp
+++ b/modules/highgui/include/opencv2/highgui.hpp
@@ -197,7 +197,8 @@ enum WindowPropertyFlags {
        WND_PROP_AUTOSIZE     = 1, //!< autosize property      (can be WINDOW_NORMAL or WINDOW_AUTOSIZE).
        WND_PROP_ASPECT_RATIO = 2, //!< window's aspect ration (can be set to WINDOW_FREERATIO or WINDOW_KEEPRATIO).
        WND_PROP_OPENGL       = 3, //!< opengl support.
-       WND_PROP_VISIBLE      = 4  //!< checks whether the window exists and is visible
+       WND_PROP_VISIBLE      = 4, //!< checks whether the window exists and is visible
+       WND_PROP_TOPMOST      = 5  //!< property to toggle normal window being topmost or not
      };
 
 //! Mouse Events see cv::MouseCallback

--- a/modules/highgui/src/precomp.hpp
+++ b/modules/highgui/src/precomp.hpp
@@ -116,6 +116,12 @@ double cvGetOpenGlProp_GTK(const char* name);
 
 double cvGetPropVisible_W32(const char* name);
 
+double cvGetPropTopmost_W32(const char* name);
+double cvGetPropTopmost_COCOA(const char* name);
+
+void cvSetPropTopmost_W32(const char* name, const bool topmost);
+void cvSetPropTopmost_COCOA(const char* name, const bool topmost);
+
 //for QT
 #if defined (HAVE_QT)
 CvRect cvGetWindowRect_QT(const char* name);

--- a/modules/highgui/src/window.cpp
+++ b/modules/highgui/src/window.cpp
@@ -180,6 +180,7 @@ CV_IMPL double cvGetWindowProperty(const char* name, int prop_id)
         #elif defined(HAVE_COCOA)
             return cvGetPropTopmost_COCOA(name);
         #else
+            CV_LOG_WARNING(NULL, "Property WND_PROP_TOPMOST is not supported on current GUI backend");
             return -1;
         #endif
     break;

--- a/modules/highgui/src/window.cpp
+++ b/modules/highgui/src/window.cpp
@@ -42,6 +42,7 @@
 #include "precomp.hpp"
 #include <map>
 #include "opencv2/core/opengl.hpp"
+#include "opencv2/core/utils/logger.hpp"
 
 // in later times, use this file as a dispatcher to implementations like cvcap.cpp
 
@@ -80,6 +81,16 @@ CV_IMPL void cvSetWindowProperty(const char* name, int prop_id, double prop_valu
     case CV_WND_PROP_ASPECTRATIO:
         #if defined (HAVE_QT)
             cvSetRatioWindow_QT(name,prop_value);
+        #endif
+    break;
+
+    case cv::WND_PROP_TOPMOST:
+        #if defined(HAVE_WIN32UI)
+            cvSetPropTopmost_W32(name, (prop_value != 0 ? true : false));
+        #elif defined(HAVE_COCOA)
+            cvSetPropTopmost_COCOA(name, (prop_value != 0 ? true : false));
+        #else
+            CV_LOG_WARNING(NULL, "Property WND_PROP_TOPMOST is not supported on current GUI backend");
         #endif
     break;
 
@@ -162,6 +173,17 @@ CV_IMPL double cvGetWindowProperty(const char* name, int prop_id)
             return -1;
         #endif
     break;
+
+    case cv::WND_PROP_TOPMOST:
+        #if defined(HAVE_WIN32UI)
+            return cvGetPropTopmost_W32(name);
+        #elif defined(HAVE_COCOA)
+            return cvGetPropTopmost_COCOA(name);
+        #else
+            return -1;
+        #endif
+    break;
+
     default:
         return -1;
     }

--- a/modules/highgui/src/window_cocoa.mm
+++ b/modules/highgui/src/window_cocoa.mm
@@ -712,6 +712,68 @@ void cvSetModeWindow_COCOA( const char* name, double prop_value )
     __END__;
 }
 
+double cvGetPropTopmost_COCOA(const char* name)
+{
+    double    result = -1;
+    CVWindow* window = nil;
+
+    CV_FUNCNAME("cvGetPropTopmost_COCOA");
+
+    __BEGIN__;
+    if (name == NULL)
+    {
+        CV_ERROR(CV_StsNullPtr, "NULL name string");
+    }
+
+    window = cvGetWindow(name);
+    if (window == NULL)
+    {
+        CV_ERROR(CV_StsNullPtr, "NULL window");
+    }
+
+    result = (window.level == NSStatusWindowLevel) ? 1 : 0;
+
+    __END__;
+    return result;
+}
+
+void cvSetPropTopmost_COCOA( const char* name, const bool topmost )
+{
+    CVWindow *window = nil;
+    NSAutoreleasePool* localpool = nil;
+    CV_FUNCNAME( "cvSetPropTopmost_COCOA" );
+
+    __BEGIN__;
+    if( name == NULL )
+    {
+        CV_ERROR( CV_StsNullPtr, "NULL name string" );
+    }
+
+    window = cvGetWindow(name);
+    if ( window == NULL )
+    {
+        CV_ERROR( CV_StsNullPtr, "NULL window" );
+    }
+
+    if ([[window contentView] isInFullScreenMode])
+    {
+        EXIT;
+    }
+
+    localpool = [[NSAutoreleasePool alloc] init];
+    if (topmost)
+    {
+        [window makeKeyAndOrderFront:window.self];
+        [window setLevel:CGWindowLevelForKey(kCGMaximumWindowLevelKey)];
+    }
+    else
+    {
+        [window makeKeyAndOrderFront:nil];
+    }
+    [localpool drain];
+    __END__;
+}
+
 void cv::setWindowTitle(const String& winname, const String& title)
 {
     CVWindow *window = cvGetWindow(winname.c_str());

--- a/modules/highgui/src/window_w32.cpp
+++ b/modules/highgui/src/window_w32.cpp
@@ -40,6 +40,9 @@
 //M*/
 
 #include "precomp.hpp"
+
+using namespace cv;
+
 #include <windowsx.h> // required for GET_X_LPARAM() and GET_Y_LPARAM() macros
 
 #if defined _WIN32
@@ -542,45 +545,32 @@ double cvGetPropTopmost_W32(const char* name)
 {
     double result = -1;
 
-    CV_FUNCNAME("cvGetPropTopmost_W32");
-
-    __BEGIN__;
-
-    if (!name)
-        CV_ERROR(CV_StsNullPtr, "NULL name string");
+    CV_Assert(name);
 
     CvWindow* window = icvFindWindowByName(name);
     if (!window)
-        CV_ERROR(CV_StsNullPtr, "NULL window");
+        CV_Error(Error::StsNullPtr, "NULL window");
 
     LONG style = GetWindowLongA(window->frame, GWL_EXSTYLE); // -20
     if (!style)
     {
         std::ostringstream errorMsg;
-        errorMsg << "Failed to retrieve extended window style using GetWindowLongA; error code: " << GetLastError() << "\n";
-
-        CV_ERROR(CV_StsError, errorMsg.str().c_str());
+        errorMsg << "window(" << name << "): failed to retrieve extended window style using GetWindowLongA(); error code: " << GetLastError();
+        CV_Error(Error::StsError, errorMsg.str().c_str());
     }
 
     result = (style & WS_EX_TOPMOST) == WS_EX_TOPMOST;
-
-    __END__;
 
     return result;
 }
 
 void cvSetPropTopmost_W32(const char* name, const bool topmost)
 {
-    CV_FUNCNAME("cvSetPropTopmost_W32");
-
-    __BEGIN__;
-
-    if (!name)
-        CV_ERROR(CV_StsNullPtr, "NULL name string");
+    CV_Assert(name);
 
     CvWindow* window = icvFindWindowByName(name);
     if (!window)
-        CV_ERROR(CV_StsNullPtr, "NULL window");
+        CV_Error(Error::StsNullPtr, "NULL window");
 
     HWND flag    = topmost ? HWND_TOPMOST : HWND_TOP;
     BOOL success = SetWindowPos(window->frame, flag, 0, 0, 0, 0, SWP_NOMOVE | SWP_NOSIZE);
@@ -588,11 +578,9 @@ void cvSetPropTopmost_W32(const char* name, const bool topmost)
     if (!success)
     {
         std::ostringstream errorMsg;
-        errorMsg << "Error reported by SetWindowPos, error code:  " << GetLastError() << "\n";
-        CV_ERROR(CV_StsError, errorMsg.str().c_str());
+        errorMsg << "window(" << name << "): error reported by SetWindowPos(" << (topmost ? "HWND_TOPMOST" : "HWND_TOP") << "), error code:  " << GetLastError();
+        CV_Error(Error::StsError, errorMsg.str().c_str());
     }
-
-    __END__;
 }
 
 void cv::setWindowTitle(const String& winname, const String& title)

--- a/modules/highgui/src/window_w32.cpp
+++ b/modules/highgui/src/window_w32.cpp
@@ -538,6 +538,63 @@ void cvSetModeWindow_W32( const char* name, double prop_value)//Yannick Verdie
     __END__;
 }
 
+double cvGetPropTopmost_W32(const char* name)
+{
+    double result = -1;
+
+    CV_FUNCNAME("cvGetPropTopmost_W32");
+
+    __BEGIN__;
+
+    if (!name)
+        CV_ERROR(CV_StsNullPtr, "NULL name string");
+
+    CvWindow* window = icvFindWindowByName(name);
+    if (!window)
+        CV_ERROR(CV_StsNullPtr, "NULL window");
+
+    LONG style = GetWindowLongA(window->frame, GWL_EXSTYLE); // -20
+    if (!style)
+    {
+        std::ostringstream errorMsg;
+        errorMsg << "Failed to retrieve extended window style using GetWindowLongA; error code: " << GetLastError() << "\n";
+
+        CV_ERROR(CV_StsError, errorMsg.str().c_str());
+    }
+
+    result = (style & WS_EX_TOPMOST) == WS_EX_TOPMOST;
+
+    __END__;
+
+    return result;
+}
+
+void cvSetPropTopmost_W32(const char* name, const bool topmost)
+{
+    CV_FUNCNAME("cvSetPropTopmost_W32");
+
+    __BEGIN__;
+
+    if (!name)
+        CV_ERROR(CV_StsNullPtr, "NULL name string");
+
+    CvWindow* window = icvFindWindowByName(name);
+    if (!window)
+        CV_ERROR(CV_StsNullPtr, "NULL window");
+
+    HWND flag    = topmost ? HWND_TOPMOST : HWND_TOP;
+    BOOL success = SetWindowPos(window->frame, flag, 0, 0, 0, 0, SWP_NOMOVE | SWP_NOSIZE);
+
+    if (!success)
+    {
+        std::ostringstream errorMsg;
+        errorMsg << "Error reported by SetWindowPos, error code:  " << GetLastError() << "\n";
+        CV_ERROR(CV_StsError, errorMsg.str().c_str());
+    }
+
+    __END__;
+}
+
 void cv::setWindowTitle(const String& winname, const String& title)
 {
     CvWindow* window = icvFindWindowByName(winname.c_str());


### PR DESCRIPTION
This change adds the ability for the cv created normal window to be TOPMOST, in situations where it is needed for the Window to be above all of the others.

To make a normal window TOPMOST, call cvSetWindowProperty with property WND_PROP_TOPMOST and a non-zero property value. Passing in 0 for the prop_value will make the window TOP.