### PR TITLE
core: revise syntax to support Visual C++ 2013

### DIFF
--- a/modules/core/include/opencv2/core/cvstd_wrapper.hpp
+++ b/modules/core/include/opencv2/core/cvstd_wrapper.hpp
@@ -49,7 +49,12 @@ private:
     typedef decltype(check<C>(0)) type;
 
 public:
+#if __cplusplus >= 201103L || (defined(_MSC_VER) && _MSC_VER >= 1900/*MSVS 2015*/)
     static CV_CONSTEXPR bool value = type::value;
+#else
+    // support MSVS 2013
+    static const int value = type::value;
+#endif
 };
 } // namespace sfinae
 


### PR DESCRIPTION
This pull request restores MSVC 2013 support to the core module.