### PR TITLE
Async API for GAPI : output arguments lifetime tests

### DIFF
--- a/modules/gapi/include/opencv2/gapi/gcompiled_async.hpp
+++ b/modules/gapi/include/opencv2/gapi/gcompiled_async.hpp
@@ -24,6 +24,11 @@ namespace wip {
     //These functions asynchronously (i.e. probably on a separate thread of execution) call operator() member function of their first argument with copies of rest of arguments (except callback) passed in.
     //The difference between the function is the way to get the completion notification (via callback or a waiting on std::future object)
     //If exception is occurred during execution of apply it is transfered to the callback (via function parameter) or passed to future (and will be thrown on call to std::future::get)
+
+    //N.B. :
+    //Input arguments are copied on call to async function (actually on call to cv::gin) and thus do not have to outlive the actual completion of asynchronous activity.
+    //While Output arguments are "captured" by reference(pointer) and therefore _must_ outlive the asynchronous activity
+    //(i.e. live at least until callback is called or future is unblocked)
     GAPI_EXPORTS void                async(GCompiled& gcmpld, std::function<void(std::exception_ptr)>&& callback, GRunArgs &&ins, GRunArgsP &&outs);
     GAPI_EXPORTS void                async(GCompiled& gcmpld, std::function<void(std::exception_ptr)>&& callback, GRunArgs &&ins, GRunArgsP &&outs, GAsyncContext& ctx);
 

--- a/modules/gapi/include/opencv2/gapi/gcomputation_async.hpp
+++ b/modules/gapi/include/opencv2/gapi/gcomputation_async.hpp
@@ -25,6 +25,11 @@ namespace wip  {
     //These functions asynchronously (i.e. probably on a separate thread of execution) call apply member function of their first argument with copies of rest of arguments (except callback) passed in.
     //The difference between the function is the way to get the completion notification (via callback or a waiting on std::future object)
     //If exception is occurred during execution of apply it is transfered to the callback (via function parameter) or passed to future (and will be thrown on call to std::future::get)
+
+    //N.B. :
+    //Input arguments are copied on call to async function (actually on call to cv::gin) and thus do not have to outlive the actual completion of asynchronous activity.
+    //While Output arguments are "captured" by reference(pointer) and therefore _must_ outlive the asynchronous activity
+    //(i.e. live at least until callback is called or future is unblocked)
     GAPI_EXPORTS void                async_apply(GComputation& gcomp, std::function<void(std::exception_ptr)>&& callback, GRunArgs &&ins, GRunArgsP &&outs, GCompileArgs &&args = {});
     GAPI_EXPORTS void                async_apply(GComputation& gcomp, std::function<void(std::exception_ptr)>&& callback, GRunArgs &&ins, GRunArgsP &&outs, GCompileArgs &&args, GAsyncContext& ctx);
 


### PR DESCRIPTION
### This pullrequest add explanatory  test cases for common usage models

<!-- Please describe what your pullrequest is changing -->
- added two template test cases (for calback and future usage model),  emphasising life time of output arguments compared to call to `async`  functions

```
build_gapi_standalone:Linux x64=ade-0.1.1d
build_gapi_standalone:Win64=ade-0.1.1d
build_gapi_standalone:Mac=ade-0.1.1d
build_gapi_standalone:Linux x64 Debug=ade-0.1.1d
```