### PR TITLE
Keep a local copy of `features` from `flann::GenericIndex ` constructor

### DIFF
--- a/modules/flann/include/opencv2/flann.hpp
+++ b/modules/flann/include/opencv2/flann.hpp
@@ -289,7 +289,7 @@ public:
 
         int veclen() const { return nnIndex->veclen(); }
 
-        int size() const { return nnIndex->size(); }
+        int size() const { return (int)nnIndex->size(); }
 
         ::cvflann::IndexParams getParameters() { return nnIndex->getParameters(); }
 

--- a/modules/flann/include/opencv2/flann.hpp
+++ b/modules/flann/include/opencv2/flann.hpp
@@ -297,6 +297,7 @@ public:
 
 private:
         ::cvflann::Index<Distance>* nnIndex;
+        Mat _dataset;
 };
 
 //! @cond IGNORED
@@ -312,10 +313,11 @@ private:
 
 template <typename Distance>
 GenericIndex<Distance>::GenericIndex(const Mat& dataset, const ::cvflann::IndexParams& params, Distance distance)
+: _dataset(dataset)
 {
     CV_Assert(dataset.type() == CvType<ElementType>::type());
     CV_Assert(dataset.isContinuous());
-    ::cvflann::Matrix<ElementType> m_dataset((ElementType*)dataset.ptr<ElementType>(0), dataset.rows, dataset.cols);
+    ::cvflann::Matrix<ElementType> m_dataset((ElementType*)_dataset.ptr<ElementType>(0), _dataset.rows, _dataset.cols);
 
     nnIndex = new ::cvflann::Index<Distance>(m_dataset, params, distance);
 

--- a/modules/flann/include/opencv2/flann/dist.h
+++ b/modules/flann/include/opencv2/flann/dist.h
@@ -114,7 +114,7 @@ struct L2_Simple
         ResultType result = ResultType();
         ResultType diff;
         for(size_t i = 0; i < size; ++i ) {
-            diff = *a++ - *b++;
+            diff = (ResultType)(*a++ - *b++);
             result += diff*diff;
         }
         return result;


### PR DESCRIPTION
<!-- Please use this line to close one or multiple issues when this pullrequest gets merged
You can add another line right under the first one:
resolves #4376
resolves #12606
-->

### This pullrequest changes
1. Keep a local copy of `features` matrix in `flann::GenericIndex` constructor. This fixes #4376 and #12606
2. Suppress some warnings in MSVC regarding implicit type conversions