### PR TITLE
Fixed names conflict with dldt

### DIFF
--- a/modules/dnn/src/op_inf_engine.cpp
+++ b/modules/dnn/src/op_inf_engine.cpp
@@ -476,7 +476,7 @@ bool InfEngineBackendNet::isInitialized()
     return (bool)enginePtr;
 }
 
-void InfEngineBackendNet::addBlobs(const std::vector<Ptr<BackendWrapper> >& ptrs)
+void InfEngineBackendNet::addBlobs(const std::vector<cv::Ptr<BackendWrapper> >& ptrs)
 {
     auto wrappers = infEngineWrappers(ptrs);
     for (const auto& wrapper : wrappers)

--- a/modules/dnn/src/op_inf_engine.hpp
+++ b/modules/dnn/src/op_inf_engine.hpp
@@ -84,7 +84,7 @@ public:
 
     void initPlugin(InferenceEngine::ICNNNetwork& net);
 
-    void addBlobs(const std::vector<Ptr<BackendWrapper> >& ptrs);
+    void addBlobs(const std::vector<cv::Ptr<BackendWrapper> >& ptrs);
 
 private:
     InferenceEngine::Builder::Network netBuilder;


### PR DESCRIPTION
resolves #14912

Fixed compilation names conflict cv::Ptr in opencv/dnn and ICNNNetwork::Ptr in dldt.
Was added cv:: namespace to the Ptr

<cut/>

```
force_builders=Custom,Custom Win,Custom Mac
build_image:Custom=ubuntu-openvino-2019r1:16.04
build_image:Custom Win=openvino-2019r1
build_image:Custom Mac=openvino-2019r1

test_modules:Custom=dnn,python2,python3,java
test_modules:Custom Win=dnn,python2,python3,java
test_modules:Custom Mac=dnn,python2,python3,java

buildworker:Custom=linux-1
test_opencl:Custom=ON
test_bigdata:Custom=1
test_filter:Custom=*
```