### PR TITLE
Fix detection of 32bit ARM builds on Aarch64

### DIFF
--- a/cmake/OpenCVDetectCXXCompiler.cmake
+++ b/cmake/OpenCVDetectCXXCompiler.cmake
@@ -83,6 +83,7 @@ if(WIN32 AND CV_GCC)
   endif()
 endif()
 
+message(STATUS "Detected processor: ${CMAKE_SYSTEM_PROCESSOR}")
 if(MSVC64 OR MINGW64)
   set(X86_64 1)
 elseif(MINGW OR (MSVC AND NOT CMAKE_CROSSCOMPILING))
@@ -101,11 +102,17 @@ elseif(CMAKE_SYSTEM_PROCESSOR MATCHES "^(powerpc|ppc)64")
   set(PPC64 1)
 endif()
 
-# Workaround for 32-bit operating systems on 64-bit x86_64 processor
-if(X86_64 AND CMAKE_SIZEOF_VOID_P EQUAL 4 AND NOT FORCE_X86_64)
-  message(STATUS "sizeof(void) = 4 on x86 / x86_64 processor. Assume 32-bit compilation mode (X86=1)")
-  unset(X86_64)
-  set(X86 1)
+# Workaround for 32-bit operating systems on x86_64/aarch64 processor
+if(CMAKE_SIZEOF_VOID_P EQUAL 4 AND NOT FORCE_X86_64)
+  message(STATUS "sizeof(void) = 4 on 64 bit processor. Assume 32-bit compilation mode")
+  if (X86_64)
+    unset(X86_64)
+    set(X86 1)
+  endif()
+  if (AARCH64)
+    unset(AARCH64)
+    set(ARM 1)
+  endif()
 endif()
 
 # Similar code exists in OpenCVConfig.cmake


### PR DESCRIPTION
It is perfectly possible to compile ARM binaries on Aarch64. Generalize
the code to no only swap X86 with X86_64, but also ARM and AARCH64.

Signed-off-by: Stefan Brüns <stefan.bruens@rwth-aachen.de>