### PR TITLE
Crosscorr cleanup

### DIFF
--- a/modules/imgproc/src/filter.dispatch.cpp
+++ b/modules/imgproc/src/filter.dispatch.cpp
@@ -1160,8 +1160,7 @@ static bool dftFilter2D(int stype, int dtype, int kernel_type,
             corrDepth = ddepth == CV_64F ? CV_64F : CV_32F;
             temp.create(Size(width, height), CV_MAKETYPE(corrDepth, dst_channels));
         }
-        crossCorr(src, kernel, temp, src.size(),
-                  CV_MAKETYPE(corrDepth, src_channels),
+        crossCorr(src, kernel, temp, temp.size(), temp.type(),
                   anchor, 0, borderType);
         add(temp, delta, temp);
         if (temp.data != dst_data) {
@@ -1172,8 +1171,7 @@ static bool dftFilter2D(int stype, int dtype, int kernel_type,
             temp = Mat(Size(width, height), dtype, dst_data, dst_step);
         else
             temp.create(Size(width, height), dtype);
-        crossCorr(src, kernel, temp, src.size(),
-                  CV_MAKETYPE(ddepth, src_channels),
+        crossCorr(src, kernel, temp, temp.size(), temp.type(),
                   anchor, delta, borderType);
         if (temp.data != dst_data)
             temp.copyTo(dst);

--- a/modules/imgproc/src/filter.dispatch.cpp
+++ b/modules/imgproc/src/filter.dispatch.cpp
@@ -1160,8 +1160,7 @@ static bool dftFilter2D(int stype, int dtype, int kernel_type,
             corrDepth = ddepth == CV_64F ? CV_64F : CV_32F;
             temp.create(Size(width, height), CV_MAKETYPE(corrDepth, dst_channels));
         }
-        crossCorr(src, kernel, temp, temp.size(), temp.type(),
-                  anchor, 0, borderType);
+        crossCorr(src, kernel, temp, anchor, 0, borderType);
         add(temp, delta, temp);
         if (temp.data != dst_data) {
             temp.convertTo(dst, dst.type());
@@ -1171,8 +1170,7 @@ static bool dftFilter2D(int stype, int dtype, int kernel_type,
             temp = Mat(Size(width, height), dtype, dst_data, dst_step);
         else
             temp.create(Size(width, height), dtype);
-        crossCorr(src, kernel, temp, temp.size(), temp.type(),
-                  anchor, delta, borderType);
+        crossCorr(src, kernel, temp, anchor, delta, borderType);
         if (temp.data != dst_data)
             temp.copyTo(dst);
     }

--- a/modules/imgproc/src/filterengine.hpp
+++ b/modules/imgproc/src/filterengine.hpp
@@ -366,7 +366,6 @@ static inline Point normalizeAnchor( Point anchor, Size ksize )
 
 void preprocess2DKernel( const Mat& kernel, std::vector<Point>& coords, std::vector<uchar>& coeffs );
 void crossCorr( const Mat& src, const Mat& templ, Mat& dst,
-               Size corrsize, int ctype,
                Point anchor=Point(0,0), double delta=0,
                int borderType=BORDER_REFLECT_101 );
 

--- a/modules/imgproc/src/templmatch.cpp
+++ b/modules/imgproc/src/templmatch.cpp
@@ -564,7 +564,6 @@ static bool ocl_matchTemplate( InputArray _img, InputArray _templ, OutputArray _
 #include "opencv2/core/hal/hal.hpp"
 
 void crossCorr( const Mat& img, const Mat& _templ, Mat& corr,
-                Size corrsize, int ctype,
                 Point anchor, double delta, int borderType )
 {
     const double blockScale = 4.5;
@@ -574,7 +573,7 @@ void crossCorr( const Mat& img, const Mat& _templ, Mat& corr,
     Mat templ = _templ;
     int depth = img.depth(), cn = img.channels();
     int tdepth = templ.depth(), tcn = templ.channels();
-    int cdepth = CV_MAT_DEPTH(ctype), ccn = CV_MAT_CN(ctype);
+    int cdepth = corr.depth(), ccn = corr.channels();
 
     CV_Assert( img.dims <= 2 && templ.dims <= 2 && corr.dims <= 2 );
 
@@ -585,12 +584,10 @@ void crossCorr( const Mat& img, const Mat& _templ, Mat& corr,
     }
 
     CV_Assert( depth == tdepth || tdepth == CV_32F);
-    CV_Assert( corrsize.height <= img.rows + templ.rows - 1 &&
-               corrsize.width <= img.cols + templ.cols - 1 );
+    CV_Assert( corr.rows <= img.rows + templ.rows - 1 &&
+               corr.cols <= img.cols + templ.cols - 1 );
 
     CV_Assert( ccn == 1 || delta == 0 );
-
-    corr.create(corrsize, ctype);
 
     int maxDepth = depth > CV_8S ? CV_64F : std::max(std::max(CV_32F, tdepth), cdepth);
     Size blocksize, dftsize;
@@ -815,8 +812,8 @@ static void matchTemplateMask( InputArray _img, InputArray _templ, OutputArray _
         Mat mask2_templ = templ.mul(mask2);
 
         Mat corr(corrSize, CV_32F);
-        crossCorr( img, mask2_templ, corr, corr.size(), corr.type(), Point(0,0), 0, 0 );
-        crossCorr( img2, mask, result, result.size(), result.type(), Point(0,0), 0, 0 );
+        crossCorr( img, mask2_templ, corr, Point(0,0), 0, 0 );
+        crossCorr( img2, mask, result, Point(0,0), 0, 0 );
 
         result -= corr * 2;
         result += templSum2;
@@ -830,8 +827,8 @@ static void matchTemplateMask( InputArray _img, InputArray _templ, OutputArray _
         }
 
         Mat corr(corrSize, CV_32F);
-        crossCorr( img2, mask2, corr, corr.size(), corr.type(), Point(0,0), 0, 0 );
-        crossCorr( img, mask_templ, result, result.size(), result.type(), Point(0,0), 0, 0 );
+        crossCorr( img2, mask2, corr, Point(0,0), 0, 0 );
+        crossCorr( img, mask_templ, result, Point(0,0), 0, 0 );
 
         sqrt(corr, corr);
         result = result.mul(1/corr);
@@ -1130,7 +1127,7 @@ void cv::matchTemplate( InputArray _img, InputArray _templ, OutputArray _result,
 
     CV_IPP_RUN_FAST(ipp_matchTemplate(img, templ, result, method))
 
-    crossCorr( img, templ, result, result.size(), result.type(), Point(0,0), 0, 0);
+    crossCorr( img, templ, result, Point(0,0), 0, 0);
 
     common_matchTemplate(img, templ, result, method, cn);
 }


### PR DESCRIPTION
### Remove redundant parameters from non-exported cv::crossCorr method

The first commit cleans up the crossCorr call from dftFilter2D.
The second commit does the actual removal.