### PR TITLE
G-API: Use object instead of reference in extended lifetime case

### DIFF
--- a/modules/gapi/src/compiler/passes/meta.cpp
+++ b/modules/gapi/src/compiler/passes/meta.cpp
@@ -75,7 +75,7 @@ void cv::gimpl::passes::inferMeta(ade::passes::PassContext &ctx, bool meta_is_in
             // Now ask kernel for it's output meta.
             // Resulting out_args may have a larger size than op.outs, since some
             // outputs could stay unused (unconnected)
-            const auto& out_metas = op.k.outMeta(input_meta_args, op.args);
+            auto out_metas = op.k.outMeta(input_meta_args, op.args);
 
             // Walk through operation's outputs, update meta of output objects
             // appropriately

--- a/modules/gapi/src/compiler/passes/meta.cpp
+++ b/modules/gapi/src/compiler/passes/meta.cpp
@@ -75,7 +75,7 @@ void cv::gimpl::passes::inferMeta(ade::passes::PassContext &ctx, bool meta_is_in
             // Now ask kernel for it's output meta.
             // Resulting out_args may have a larger size than op.outs, since some
             // outputs could stay unused (unconnected)
-            auto out_metas = op.k.outMeta(input_meta_args, op.args);
+            const auto out_metas = op.k.outMeta(input_meta_args, op.args);
 
             // Walk through operation's outputs, update meta of output objects
             // appropriately


### PR DESCRIPTION
### This pullrequest changes

const lvalue reference to object since in the given expression a new object is returned from a function. 

Original code is a valid behavior since this is the case for extended lifetime of the temporary object  (const lvalue reference of the same type is bound to that temporary).

Anyway, the code is doubtful and requires the developer to check for the return type and provide some rationale to ensure the code is correct. Taking this into account, it's easier to replace reference with an object.

---
References: [Temporary Object Lifetime](https://en.cppreference.com/w/cpp/language/lifetime) - look at the exceptions from the rules