### PR TITLE
Fix blob detector insertion sort (issue #12244)

### DIFF
--- a/modules/features2d/src/blobdetector.cpp
+++ b/modules/features2d/src/blobdetector.cpp
@@ -338,7 +338,7 @@ void SimpleBlobDetectorImpl::detect(InputArray image, std::vector<cv::KeyPoint>&
                     centers[j].push_back(curCenters[i]);
 
                     size_t k = centers[j].size() - 1;
-                    while( k > 0 && centers[j][k].radius < centers[j][k-1].radius )
+                    while( k > 0 && curCenters[i].radius < centers[j][k-1].radius )
                     {
                         centers[j][k] = centers[j][k-1];
                         k--;


### PR DESCRIPTION
<!-- Please use this line to close one or multiple issues when this pullrequest gets merged
You can add another line right under the first one:
resolves #1234
resolves #1235
-->
resolves #12244
### This pullrequest changes

<!-- Please describe what your pullrequest is changing -->
This PR addresses a small bug in the implementation of insertion sort inside the blob detector, as found in issue #12244.

### Reproducible example
Here is a dumbed down version of the bug and its solution that you can run on e.g. [cpp.sh](cpp.sh) (using doubles instead of circles but the idea is the same). The fix is simple really, the implementation of insertion sort is comparing the wrong variable in the while loop.

```
#include <iostream>
#include <string>
#include <vector>
#include <algorithm>


std::vector<double> broken_insert_sort(std::vector<double> centers, double new_num) {
    centers.push_back(new_num);
    
    size_t k = centers.size() - 1;
    while( k > 0 && centers[k] < centers[k-1]) // Wrong comparison here
    {
        centers[k] = centers[k-1];
        k--;
    }
    centers[k] = new_num;
    return centers;
}

std::vector<double> proper_insert_sort(std::vector<double> centers, double new_num) {
    centers.push_back(new_num);
    
    size_t k = centers.size() - 1;
    while( k > 0 && new_num < centers[k-1]) // Proper comparison here
    {
        centers[k] = centers[k-1];
        k--;
    }
    centers[k] = new_num;
    return centers;
}

void print_vec(const std::vector<double>& vec) {
    std::cout << "[";
    std::for_each(vec.begin(), vec.end(), [](double v) {
        std::cout << v << ", ";
    });
    std::cout << "]" << std::endl;
}

int main()
{
    std::vector<double> centers{3.0, 4.0, 5.0, 6.0};
    
    auto bugged = broken_insert_sort(centers, 2.0); // This is the version of insertion sort found in blobdetector.cpp
    auto fixed = proper_insert_sort(centers, 2.0); // This includes the fix (regular insertion sort)
    
    print_vec(bugged);
    print_vec(fixed);
}

```

