### PR TITLE
ts: runtime check for misused 'optional' test data files

### DIFF
--- a/modules/dnn/test/test_caffe_importer.cpp
+++ b/modules/dnn/test/test_caffe_importer.cpp
@@ -205,7 +205,7 @@ TEST(Reproducibility_FCN, Accuracy)
     Net net;
     {
         const string proto = findDataFile("dnn/fcn8s-heavy-pascal.prototxt");
-        const string model = findDataFile("dnn/fcn8s-heavy-pascal.caffemodel");
+        const string model = findDataFile("dnn/fcn8s-heavy-pascal.caffemodel", false);
         net = readNetFromCaffe(proto, model);
         ASSERT_FALSE(net.empty());
     }

--- a/modules/ts/src/ts.cpp
+++ b/modules/ts/src/ts.cpp
@@ -968,13 +968,15 @@ static std::string findData(const std::string& relative_path, bool required, boo
                 std::string prefix = path_join(datapath, subdir);
                 std::string result_;
                 CHECK_FILE_WITH_PREFIX(prefix, result_);
-#if 1  // check for misused 'optional' mode
                 if (!required && !result_.empty())
                 {
                     std::cout << "TEST ERROR: Don't use 'optional' findData() for " << relative_path << std::endl;
-                    CV_Assert(required || result_.empty());
+                    static bool checkOptionalFlag = cv::utils::getConfigurationParameterBool("OPENCV_TEST_CHECK_OPTIONAL_DATA", false);
+                    if (checkOptionalFlag)
+                    {
+                        CV_Assert(required || result_.empty());
+                    }
                 }
-#endif
                 if (!result_.empty())
                     return result_;
             }


### PR DESCRIPTION
Flag is enabled on CI

relates #14847