### PR TITLE
videoio: eliminate build warnings (clang)

### DIFF
--- a/modules/videoio/src/cap_gstreamer.cpp
+++ b/modules/videoio/src/cap_gstreamer.cpp
@@ -97,6 +97,11 @@ static void handleMessage(GstElement * pipeline);
 
 namespace {
 
+#if defined __clang__
+# pragma clang diagnostic push
+# pragma clang diagnostic ignored "-Wunused-function"
+#endif
+
 template<typename T> static inline void GSafePtr_addref(T* ptr)
 {
     if (ptr)
@@ -124,6 +129,10 @@ template<> inline void GSafePtr_release<GstEncodingContainerProfile>(GstEncoding
 
 template<> inline void GSafePtr_addref<char>(char* pPtr);  // declaration only. not defined. should not be used
 template<> inline void GSafePtr_release<char>(char** pPtr) { if (pPtr) { g_free(*pPtr); *pPtr = NULL; } }
+
+#if defined __clang__
+# pragma clang diagnostic pop
+#endif
 
 template <typename T>
 class GSafePtr


### PR DESCRIPTION
[Nightly build](http://pullrequest.opencv.org/buildbot/builders/3_4_opt-avx2_noICV-skl-lin64-clang/builds/264)


```
buildworker:Custom=linux-1,linux-2,linux-4
docker_image:Custom=ubuntu-clang:18.04
```