### PR TITLE
android: JavaCamera2View use calculateCameraFrameSize() method

### DIFF
--- a/modules/java/generator/android-21/java/org/opencv/android/JavaCamera2View.java
+++ b/modules/java/generator/android-21/java/org/opencv/android/JavaCamera2View.java
@@ -2,6 +2,7 @@ package org.opencv.android;
 
 import java.nio.ByteBuffer;
 import java.util.Arrays;
+import java.util.List;
 
 import android.annotation.TargetApi;
 import android.content.Context;
@@ -24,6 +25,7 @@ import android.view.ViewGroup.LayoutParams;
 
 import org.opencv.core.CvType;
 import org.opencv.core.Mat;
+import org.opencv.core.Size;
 import org.opencv.imgproc.Imgproc;
 
 /**
@@ -248,6 +250,20 @@ public class JavaCamera2View extends CameraBridgeViewBase {
         }
     }
 
+    public static class JavaCameraSizeAccessor implements ListItemAccessor {
+        @Override
+        public int getWidth(Object obj) {
+            android.util.Size size = (android.util.Size)obj;
+            return size.getWidth();
+        }
+
+        @Override
+        public int getHeight(Object obj) {
+            android.util.Size size = (android.util.Size)obj;
+            return size.getHeight();
+        }
+    }
+
     boolean calcPreviewSize(final int width, final int height) {
         Log.i(LOGTAG, "calcPreviewSize: " + width + "x" + height);
         if (mCameraID == null) {
@@ -258,26 +274,15 @@ public class JavaCamera2View extends CameraBridgeViewBase {
         try {
             CameraCharacteristics characteristics = manager.getCameraCharacteristics(mCameraID);
             StreamConfigurationMap map = characteristics.get(CameraCharacteristics.SCALER_STREAM_CONFIGURATION_MAP);
-            int bestWidth = 0, bestHeight = 0;
-            float aspect = (float) width / height;
             android.util.Size[] sizes = map.getOutputSizes(ImageReader.class);
-            bestWidth = sizes[0].getWidth();
-            bestHeight = sizes[0].getHeight();
-            for (android.util.Size sz : sizes) {
-                int w = sz.getWidth(), h = sz.getHeight();
-                Log.d(LOGTAG, "trying size: " + w + "x" + h);
-                if (width >= w && height >= h && bestWidth <= w && bestHeight <= h
-                        && Math.abs(aspect - (float) w / h) < 0.2) {
-                    bestWidth = w;
-                    bestHeight = h;
-                }
-            }
-            Log.i(LOGTAG, "best size: " + bestWidth + "x" + bestHeight);
-            assert(!(bestWidth == 0 || bestHeight == 0));
-            if (mPreviewSize.getWidth() == bestWidth && mPreviewSize.getHeight() == bestHeight)
+            List<android.util.Size> sizes_list = Arrays.asList(sizes);
+            Size frameSize = calculateCameraFrameSize(sizes_list, new JavaCameraSizeAccessor(), width, height);
+            Log.i(LOGTAG, "Selected preview size to " + Integer.valueOf((int)frameSize.width) + "x" + Integer.valueOf((int)frameSize.height));
+            assert(!(frameSize.width == 0 || frameSize.height == 0));
+            if (mPreviewSize.getWidth() == frameSize.width && mPreviewSize.getHeight() == frameSize.height)
                 return false;
             else {
-                mPreviewSize = new android.util.Size(bestWidth, bestHeight);
+                mPreviewSize = new android.util.Size((int)frameSize.width, (int)frameSize.height);
                 return true;
             }
         } catch (CameraAccessException e) {

--- a/modules/java/generator/android/java/org/opencv/android/CameraBridgeViewBase.java
+++ b/modules/java/generator/android/java/org/opencv/android/CameraBridgeViewBase.java
@@ -30,7 +30,7 @@ import android.view.SurfaceView;
 public abstract class CameraBridgeViewBase extends SurfaceView implements SurfaceHolder.Callback {
 
     private static final String TAG = "CameraBridge";
-    private static final int MAX_UNSPECIFIED = -1;
+    protected static final int MAX_UNSPECIFIED = -1;
     private static final int STOPPED = 0;
     private static final int STARTED = 1;
 
@@ -481,6 +481,7 @@ public abstract class CameraBridgeViewBase extends SurfaceView implements Surfac
         for (Object size : supportedSizes) {
             int width = accessor.getWidth(size);
             int height = accessor.getHeight(size);
+            Log.d(TAG, "trying size: " + width + "x" + height);
 
             if (width <= maxAllowedWidth && height <= maxAllowedHeight) {
                 if (width >= calcWidth && height >= calcHeight) {
@@ -488,6 +489,13 @@ public abstract class CameraBridgeViewBase extends SurfaceView implements Surfac
                     calcHeight = (int) height;
                 }
             }
+        }
+        if ((calcWidth == 0 || calcHeight == 0) && supportedSizes.size() > 0)
+        {
+            Log.i(TAG, "fallback to the first frame size");
+            Object size = supportedSizes.get(0);
+            calcWidth = accessor.getWidth(size);
+            calcHeight = accessor.getHeight(size);
         }
 
         return new Size(calcWidth, calcHeight);


### PR DESCRIPTION
from CameraBridgeViewBase (common base with JavaCameraView)

Both interfaces (JavaCameraView/JavaCamera2View) using the same method and the same approach.
If user want to tune calculation then it should override "View" class and override this method (`calculateCameraFrameSize()`)

resolves #14915