### PR TITLE
G-API: Add output allocation tests for backends

### DIFF
--- a/modules/gapi/test/common/gapi_core_tests.hpp
+++ b/modules/gapi/test/common/gapi_core_tests.hpp
@@ -165,6 +165,16 @@ GAPI_TEST_FIXTURE(PhaseTest, initMatsRandU, FIXTURE_API(bool), 1, angle_in_degre
 GAPI_TEST_FIXTURE(SqrtTest, initMatrixRandU, <>, 0)
 GAPI_TEST_FIXTURE(NormalizeTest, initNothing, FIXTURE_API(compare_f,double,double,int,MatType), 5,
     cmpF, a, b, norm_type, ddepth)
+struct BackendOutputTest : TestWithParamBase<>
+{
+    BackendOutputTest()
+    {
+        in_mat1 = cv::Mat(sz, type);
+        in_mat2 = cv::Mat(sz, type);
+        cv::randu(in_mat1, cv::Scalar::all(1), cv::Scalar::all(15));
+        cv::randu(in_mat2, cv::Scalar::all(1), cv::Scalar::all(15));
+    }
+};
 } // opencv_test
 
 #endif //OPENCV_GAPI_CORE_TESTS_HPP

--- a/modules/gapi/test/common/gapi_core_tests.hpp
+++ b/modules/gapi/test/common/gapi_core_tests.hpp
@@ -165,9 +165,9 @@ GAPI_TEST_FIXTURE(PhaseTest, initMatsRandU, FIXTURE_API(bool), 1, angle_in_degre
 GAPI_TEST_FIXTURE(SqrtTest, initMatrixRandU, <>, 0)
 GAPI_TEST_FIXTURE(NormalizeTest, initNothing, FIXTURE_API(compare_f,double,double,int,MatType), 5,
     cmpF, a, b, norm_type, ddepth)
-struct BackendOutputTest : TestWithParamBase<>
+struct BackendOutputAllocationTest : TestWithParamBase<>
 {
-    BackendOutputTest()
+    BackendOutputAllocationTest()
     {
         in_mat1 = cv::Mat(sz, type);
         in_mat2 = cv::Mat(sz, type);
@@ -176,7 +176,7 @@ struct BackendOutputTest : TestWithParamBase<>
     }
 };
 // FIXME: move all tests from this fixture to the base class once all issues are resolved
-struct BackendOutputLargeSizeWithCorrectSubmatrixTest : BackendOutputTest {};
+struct BackendOutputAllocationLargeSizeWithCorrectSubmatrixTest : BackendOutputAllocationTest {};
 } // opencv_test
 
 #endif //OPENCV_GAPI_CORE_TESTS_HPP

--- a/modules/gapi/test/common/gapi_core_tests.hpp
+++ b/modules/gapi/test/common/gapi_core_tests.hpp
@@ -175,6 +175,8 @@ struct BackendOutputTest : TestWithParamBase<>
         cv::randu(in_mat2, cv::Scalar::all(1), cv::Scalar::all(15));
     }
 };
+// FIXME: move all tests from this fixture to the base class once all issues are resolved
+struct BackendOutputLargeSizeWithCorrectSubmatrixTest : BackendOutputTest {};
 } // opencv_test
 
 #endif //OPENCV_GAPI_CORE_TESTS_HPP

--- a/modules/gapi/test/common/gapi_core_tests_inl.hpp
+++ b/modules/gapi/test/common/gapi_core_tests_inl.hpp
@@ -1398,7 +1398,7 @@ TEST_P(BackendOutputTest, LargeSize)
     EXPECT_EQ(sz, out_mat_gapi.size());
 }
 
-TEST_P(BackendOutputTest, LargeSizeWithCorrectSubmatrix)
+TEST_P(BackendOutputLargeSizeWithCorrectSubmatrixTest, LargeSizeWithCorrectSubmatrix)
 {
     out_mat_gapi = cv::Mat(sz * 2, type);
     auto out_mat_gapi_copy = out_mat_gapi; // shallow copy to ensure previous data is not deleted

--- a/modules/gapi/test/common/gapi_core_tests_inl.hpp
+++ b/modules/gapi/test/common/gapi_core_tests_inl.hpp
@@ -1372,6 +1372,8 @@ TEST_P(BackendOutputAllocationTest, SmallerPreallocatedSizeWithSubmatrix)
     out_mat_gapi = cv::Mat(sz / 2, type);
 
     cv::Mat out_mat_gapi_submat = out_mat_gapi(cv::Rect({10, 0}, sz / 5));
+    EXPECT_EQ(out_mat_gapi.data, out_mat_gapi_submat.datastart);
+
     auto out_mat_gapi_submat_ref = out_mat_gapi_submat; // shallow copy to ensure previous data is not deleted
 
     // G-API code //////////////////////////////////////////////////////////////
@@ -1390,7 +1392,7 @@ TEST_P(BackendOutputAllocationTest, SmallerPreallocatedSizeWithSubmatrix)
     EXPECT_EQ(sz / 2, out_mat_gapi.size());
 
     EXPECT_NE(out_mat_gapi_submat_ref.data, out_mat_gapi_submat.data);
-    EXPECT_NE(out_mat_gapi.datastart, out_mat_gapi_submat.datastart);
+    EXPECT_NE(out_mat_gapi.data, out_mat_gapi_submat.datastart);
 }
 
 TEST_P(BackendOutputAllocationTest, LargerPreallocatedSize)
@@ -1422,6 +1424,8 @@ TEST_P(BackendOutputAllocationLargeSizeWithCorrectSubmatrixTest,
     auto out_mat_gapi_ref = out_mat_gapi; // shallow copy to ensure previous data is not deleted
 
     cv::Mat out_mat_gapi_submat = out_mat_gapi(cv::Rect({5, 8}, sz));
+    EXPECT_EQ(out_mat_gapi.data, out_mat_gapi_submat.datastart);
+
     auto out_mat_gapi_submat_ref = out_mat_gapi_submat;
 
     // G-API code //////////////////////////////////////////////////////////////
@@ -1450,6 +1454,8 @@ TEST_P(BackendOutputAllocationTest, LargerPreallocatedSizeWithSmallSubmatrix)
     auto out_mat_gapi_ref = out_mat_gapi; // shallow copy to ensure previous data is not deleted
 
     cv::Mat out_mat_gapi_submat = out_mat_gapi(cv::Rect({5, 8}, sz / 2));
+    EXPECT_EQ(out_mat_gapi.data, out_mat_gapi_submat.datastart);
+
     auto out_mat_gapi_submat_ref = out_mat_gapi_submat;
 
     // G-API code //////////////////////////////////////////////////////////////
@@ -1469,7 +1475,7 @@ TEST_P(BackendOutputAllocationTest, LargerPreallocatedSizeWithSmallSubmatrix)
 
     EXPECT_EQ(out_mat_gapi_ref.data, out_mat_gapi.data);
     EXPECT_NE(out_mat_gapi_submat_ref.data, out_mat_gapi_submat.data);
-    EXPECT_NE(out_mat_gapi_ref.data, out_mat_gapi_submat.datastart);
+    EXPECT_NE(out_mat_gapi.data, out_mat_gapi_submat.datastart);
 }
 
 } // opencv_test

--- a/modules/gapi/test/common/gapi_core_tests_inl.hpp
+++ b/modules/gapi/test/common/gapi_core_tests_inl.hpp
@@ -1267,7 +1267,7 @@ TEST_P(NormalizeTest, Test)
     }
 }
 
-TEST_P(BackendOutputTest, EmptyOutput)
+TEST_P(BackendOutputAllocationTest, EmptyOutput)
 {
     // G-API code //////////////////////////////////////////////////////////////
     cv::GMat in1, in2, out;
@@ -1284,7 +1284,7 @@ TEST_P(BackendOutputTest, EmptyOutput)
     EXPECT_EQ(sz, out_mat_gapi.size());
 }
 
-TEST_P(BackendOutputTest, CorrectOutput)
+TEST_P(BackendOutputAllocationTest, CorrectOutput)
 {
     out_mat_gapi = cv::Mat(sz, type);
     auto out_mat_gapi_copy = out_mat_gapi;  // shallow copy to ensure previous data is not deleted
@@ -1306,7 +1306,7 @@ TEST_P(BackendOutputTest, CorrectOutput)
 }
 
 // FIXME: known issue with OCL backend - PR #14985
-TEST_P(BackendOutputTest, DISABLED_IncorrectOutputMetaAndLargeBuffer)
+TEST_P(BackendOutputAllocationTest, DISABLED_IncorrectOutputMetaAndLargeBuffer)
 {
     // G-API code //////////////////////////////////////////////////////////////
     cv::GMat in1, in2, out;
@@ -1337,7 +1337,7 @@ TEST_P(BackendOutputTest, DISABLED_IncorrectOutputMetaAndLargeBuffer)
     run_and_compare();
 }
 
-TEST_P(BackendOutputTest, SmallSize)
+TEST_P(BackendOutputAllocationTest, SmallSize)
 {
     out_mat_gapi = cv::Mat(sz / 2, type);
 
@@ -1356,7 +1356,7 @@ TEST_P(BackendOutputTest, SmallSize)
     EXPECT_EQ(sz, out_mat_gapi.size());
 }
 
-TEST_P(BackendOutputTest, SmallSizeWithSubmatrix)
+TEST_P(BackendOutputAllocationTest, SmallSizeWithSubmatrix)
 {
     out_mat_gapi = cv::Mat(sz / 2, type);
 
@@ -1379,7 +1379,7 @@ TEST_P(BackendOutputTest, SmallSizeWithSubmatrix)
     EXPECT_NE(out_mat_gapi.datastart, out_mat_gapi_submat.datastart);
 }
 
-TEST_P(BackendOutputTest, LargeSize)
+TEST_P(BackendOutputAllocationTest, LargeSize)
 {
     out_mat_gapi = cv::Mat(sz * 2, type);
 
@@ -1398,7 +1398,7 @@ TEST_P(BackendOutputTest, LargeSize)
     EXPECT_EQ(sz, out_mat_gapi.size());
 }
 
-TEST_P(BackendOutputLargeSizeWithCorrectSubmatrixTest, LargeSizeWithCorrectSubmatrix)
+TEST_P(BackendOutputAllocationLargeSizeWithCorrectSubmatrixTest, LargeSizeWithCorrectSubmatrix)
 {
     out_mat_gapi = cv::Mat(sz * 2, type);
     auto out_mat_gapi_copy = out_mat_gapi; // shallow copy to ensure previous data is not deleted
@@ -1426,7 +1426,7 @@ TEST_P(BackendOutputLargeSizeWithCorrectSubmatrixTest, LargeSizeWithCorrectSubma
     EXPECT_EQ(out_mat_gapi.data, out_mat_gapi_submat.datastart);
 }
 
-TEST_P(BackendOutputTest, LargeSizeWithSmallSubmatrix)
+TEST_P(BackendOutputAllocationTest, LargeSizeWithSmallSubmatrix)
 {
     out_mat_gapi = cv::Mat(sz * 2, type);
     auto out_mat_gapi_copy = out_mat_gapi; // shallow copy to ensure previous data is not deleted

--- a/modules/gapi/test/common/gapi_core_tests_inl.hpp
+++ b/modules/gapi/test/common/gapi_core_tests_inl.hpp
@@ -1387,7 +1387,6 @@ TEST_P(BackendOutputTest, SmallSizeWithSubmatrix)
 TEST_P(BackendOutputTest, LargeSize)
 {
     out_mat_gapi = cv::Mat(sz * 2, type);
-    const auto orig_addr = out_mat_gapi.data;
 
     // G-API code //////////////////////////////////////////////////////////////
     cv::GMat in1, in2, out;
@@ -1399,10 +1398,9 @@ TEST_P(BackendOutputTest, LargeSize)
     cv::multiply(in_mat1, in_mat2, out_mat_ocv);
 
     // Comparison //////////////////////////////////////////////////////////////
-    // Expected: size is changed, output is not reallocated
+    // Expected: size is changed, output is reallocated
     EXPECT_EQ(0, cv::countNonZero(out_mat_gapi != out_mat_ocv));
     EXPECT_EQ(sz, out_mat_gapi.size());
-    EXPECT_EQ(orig_addr, out_mat_gapi.data);
 }
 
 TEST_P(BackendOutputTest, LargeSizeWithCorrectSubmatrix)

--- a/modules/gapi/test/cpu/gapi_core_tests_cpu.cpp
+++ b/modules/gapi/test/cpu/gapi_core_tests_cpu.cpp
@@ -496,4 +496,12 @@ INSTANTIATE_TEST_CASE_P(BackendOutputTestCPU, BackendOutputTest,
                                 Values(-1),
                                 Values(false),
                                 Values(CORE_CPU)));
+
+INSTANTIATE_TEST_CASE_P(BackendOutputLargeSizeWithCorrectSubmatrixTestCPU,
+                        BackendOutputLargeSizeWithCorrectSubmatrixTest,
+                        Combine(Values(CV_8UC3, CV_16SC2, CV_32FC1),
+                                Values(cv::Size(50, 50)),
+                                Values(-1),
+                                Values(false),
+                                Values(CORE_CPU)));
 }

--- a/modules/gapi/test/cpu/gapi_core_tests_cpu.cpp
+++ b/modules/gapi/test/cpu/gapi_core_tests_cpu.cpp
@@ -489,4 +489,11 @@ INSTANTIATE_TEST_CASE_P(NormalizeTestCPU, NormalizeTest,
                                 Values(1.0, 120.0, 255.0),
                                 Values(NORM_MINMAX, NORM_INF, NORM_L1, NORM_L2),
                                 Values(-1, CV_8U, CV_16U, CV_16S, CV_32F)));
+
+INSTANTIATE_TEST_CASE_P(BackendOutputTestCPU, BackendOutputTest,
+                        Combine(Values(CV_8UC3, CV_16SC2, CV_32FC1),
+                                Values(cv::Size(50, 50)),
+                                Values(-1),
+                                Values(false),
+                                Values(CORE_CPU)));
 }

--- a/modules/gapi/test/cpu/gapi_core_tests_cpu.cpp
+++ b/modules/gapi/test/cpu/gapi_core_tests_cpu.cpp
@@ -490,15 +490,15 @@ INSTANTIATE_TEST_CASE_P(NormalizeTestCPU, NormalizeTest,
                                 Values(NORM_MINMAX, NORM_INF, NORM_L1, NORM_L2),
                                 Values(-1, CV_8U, CV_16U, CV_16S, CV_32F)));
 
-INSTANTIATE_TEST_CASE_P(BackendOutputTestCPU, BackendOutputTest,
+INSTANTIATE_TEST_CASE_P(BackendOutputAllocationTestCPU, BackendOutputAllocationTest,
                         Combine(Values(CV_8UC3, CV_16SC2, CV_32FC1),
                                 Values(cv::Size(50, 50)),
                                 Values(-1),
                                 Values(false),
                                 Values(CORE_CPU)));
 
-INSTANTIATE_TEST_CASE_P(BackendOutputLargeSizeWithCorrectSubmatrixTestCPU,
-                        BackendOutputLargeSizeWithCorrectSubmatrixTest,
+INSTANTIATE_TEST_CASE_P(BackendOutputAllocationLargeSizeWithCorrectSubmatrixTestCPU,
+                        BackendOutputAllocationLargeSizeWithCorrectSubmatrixTest,
                         Combine(Values(CV_8UC3, CV_16SC2, CV_32FC1),
                                 Values(cv::Size(50, 50)),
                                 Values(-1),

--- a/modules/gapi/test/cpu/gapi_core_tests_fluid.cpp
+++ b/modules/gapi/test/cpu/gapi_core_tests_fluid.cpp
@@ -283,15 +283,15 @@ INSTANTIATE_TEST_CASE_P(ResizeTestFluid, ResizeTest,
                                        cv::Size(64, 64),
                                        cv::Size(30, 30))));
 
-INSTANTIATE_TEST_CASE_P(BackendOutputTestFluid, BackendOutputTest,
+INSTANTIATE_TEST_CASE_P(BackendOutputAllocationTestFluid, BackendOutputAllocationTest,
                         Combine(Values(CV_8UC3, CV_16SC2, CV_32FC1),
                                 Values(cv::Size(50, 50)),
                                 Values(-1),
                                 Values(false),
                                 Values(CORE_FLUID)));
 
-INSTANTIATE_TEST_CASE_P(BackendOutputLargeSizeWithCorrectSubmatrixTestFluid,
-                        BackendOutputLargeSizeWithCorrectSubmatrixTest,
+INSTANTIATE_TEST_CASE_P(BackendOutputAllocationLargeSizeWithCorrectSubmatrixTestFluid,
+                        BackendOutputAllocationLargeSizeWithCorrectSubmatrixTest,
                         Combine(Values(CV_8UC3, CV_16SC2, CV_32FC1),
                                 Values(cv::Size(50, 50)),
                                 Values(-1),

--- a/modules/gapi/test/cpu/gapi_core_tests_fluid.cpp
+++ b/modules/gapi/test/cpu/gapi_core_tests_fluid.cpp
@@ -290,6 +290,14 @@ INSTANTIATE_TEST_CASE_P(BackendOutputTestFluid, BackendOutputTest,
                                 Values(false),
                                 Values(CORE_FLUID)));
 
+INSTANTIATE_TEST_CASE_P(BackendOutputLargeSizeWithCorrectSubmatrixTestFluid,
+                        BackendOutputLargeSizeWithCorrectSubmatrixTest,
+                        Combine(Values(CV_8UC3, CV_16SC2, CV_32FC1),
+                                Values(cv::Size(50, 50)),
+                                Values(-1),
+                                Values(false),
+                                Values(CORE_FLUID)));
+
 //----------------------------------------------------------------------
 // FIXME: Clean-up test configurations which are enabled already
 #if 0

--- a/modules/gapi/test/cpu/gapi_core_tests_fluid.cpp
+++ b/modules/gapi/test/cpu/gapi_core_tests_fluid.cpp
@@ -283,6 +283,13 @@ INSTANTIATE_TEST_CASE_P(ResizeTestFluid, ResizeTest,
                                        cv::Size(64, 64),
                                        cv::Size(30, 30))));
 
+INSTANTIATE_TEST_CASE_P(BackendOutputTestFluid, BackendOutputTest,
+                        Combine(Values(CV_8UC3, CV_16SC2, CV_32FC1),
+                                Values(cv::Size(50, 50)),
+                                Values(-1),
+                                Values(false),
+                                Values(CORE_FLUID)));
+
 //----------------------------------------------------------------------
 // FIXME: Clean-up test configurations which are enabled already
 #if 0

--- a/modules/gapi/test/gpu/gapi_core_tests_gpu.cpp
+++ b/modules/gapi/test/gpu/gapi_core_tests_gpu.cpp
@@ -433,6 +433,15 @@ INSTANTIATE_TEST_CASE_P(BackendOutputTestGPU, BackendOutputTest,
                                 Values(false),
                                 Values(CORE_GPU)));
 
+// FIXME: there's an issue in OCL backend with matrix reallocation that shouldn't happen
+INSTANTIATE_TEST_CASE_P(DISABLED_BackendOutputLargeSizeWithCorrectSubmatrixTestGPU,
+                        BackendOutputLargeSizeWithCorrectSubmatrixTest,
+                        Combine(Values(CV_8UC3, CV_16SC2, CV_32FC1),
+                                Values(cv::Size(50, 50)),
+                                Values(-1),
+                                Values(false),
+                                Values(CORE_GPU)));
+
 //TODO: fix this backend to allow ConcatVertVec ConcatHorVec
 #if 0
 INSTANTIATE_TEST_CASE_P(ConcatVertVecTestGPU, ConcatVertVecTest,

--- a/modules/gapi/test/gpu/gapi_core_tests_gpu.cpp
+++ b/modules/gapi/test/gpu/gapi_core_tests_gpu.cpp
@@ -426,6 +426,13 @@ INSTANTIATE_TEST_CASE_P(ConcatVertTestGPU, ConcatVertTest,
                                 Values(false),
                                 Values(CORE_GPU)));
 
+INSTANTIATE_TEST_CASE_P(BackendOutputTestGPU, BackendOutputTest,
+                        Combine(Values(CV_8UC3, CV_16SC2, CV_32FC1),
+                                Values(cv::Size(50, 50)),
+                                Values(-1),
+                                Values(false),
+                                Values(CORE_GPU)));
+
 //TODO: fix this backend to allow ConcatVertVec ConcatHorVec
 #if 0
 INSTANTIATE_TEST_CASE_P(ConcatVertVecTestGPU, ConcatVertVecTest,

--- a/modules/gapi/test/gpu/gapi_core_tests_gpu.cpp
+++ b/modules/gapi/test/gpu/gapi_core_tests_gpu.cpp
@@ -426,7 +426,7 @@ INSTANTIATE_TEST_CASE_P(ConcatVertTestGPU, ConcatVertTest,
                                 Values(false),
                                 Values(CORE_GPU)));
 
-INSTANTIATE_TEST_CASE_P(BackendOutputTestGPU, BackendOutputTest,
+INSTANTIATE_TEST_CASE_P(BackendOutputAllocationTestGPU, BackendOutputAllocationTest,
                         Combine(Values(CV_8UC3, CV_16SC2, CV_32FC1),
                                 Values(cv::Size(50, 50)),
                                 Values(-1),
@@ -434,8 +434,8 @@ INSTANTIATE_TEST_CASE_P(BackendOutputTestGPU, BackendOutputTest,
                                 Values(CORE_GPU)));
 
 // FIXME: there's an issue in OCL backend with matrix reallocation that shouldn't happen
-INSTANTIATE_TEST_CASE_P(DISABLED_BackendOutputLargeSizeWithCorrectSubmatrixTestGPU,
-                        BackendOutputLargeSizeWithCorrectSubmatrixTest,
+INSTANTIATE_TEST_CASE_P(DISABLED_BackendOutputAllocationLargeSizeWithCorrectSubmatrixTestGPU,
+                        BackendOutputAllocationLargeSizeWithCorrectSubmatrixTest,
                         Combine(Values(CV_8UC3, CV_16SC2, CV_32FC1),
                                 Values(cv::Size(50, 50)),
                                 Values(-1),


### PR DESCRIPTION
### This pullrequest

adds tests for output allocation for all backends
