### PR TITLE
G-API: fix export specifier in standalone build

### DIFF
--- a/modules/gapi/include/opencv2/gapi/own/exports.hpp
+++ b/modules/gapi/include/opencv2/gapi/own/exports.hpp
@@ -13,6 +13,19 @@
 #       define GAPI_EXPORTS CV_EXPORTS
 #   else
 #       define GAPI_EXPORTS
+
+#if 0  // Note: the following version currently is not needed for non-OpenCV build
+#       if defined _WIN32
+#           define GAPI_EXPORTS __declspec(dllexport)
+#       elif defined __GNUC__ && __GNUC__ >= 4
+#           define GAPI_EXPORTS __attribute__ ((visibility ("default")))
+#       endif
+
+#       ifndef GAPI_EXPORTS
+#           define GAPI_EXPORTS
+#       endif
+#endif
+
 #   endif
 
 #endif // OPENCV_GAPI_OWN_TYPES_HPP

--- a/modules/gapi/include/opencv2/gapi/own/exports.hpp
+++ b/modules/gapi/include/opencv2/gapi/own/exports.hpp
@@ -11,20 +11,8 @@
 #   if defined(__OPENCV_BUILD)
 #       include <opencv2/core/base.hpp>
 #       define GAPI_EXPORTS CV_EXPORTS
-
-#   elif !defined(GAPI_STANDALONE)
-#       if defined _WIN32
-#           define GAPI_EXPORTS __declspec(dllexport)
-#       elif defined __GNUC__ && __GNUC__ >= 4
-#           define GAPI_EXPORTS __attribute__ ((visibility ("default")))
-#       endif
-
-#       ifndef GAPI_EXPORTS
-#           define GAPI_EXPORTS
-#       endif
-#   else  // GAPI_EXPORTS is intentionally not set in standalone build
+#   else
 #       define GAPI_EXPORTS
-
 #   endif
 
 #endif // OPENCV_GAPI_OWN_TYPES_HPP

--- a/modules/gapi/include/opencv2/gapi/own/exports.hpp
+++ b/modules/gapi/include/opencv2/gapi/own/exports.hpp
@@ -12,7 +12,7 @@
 #       include <opencv2/core/base.hpp>
 #       define GAPI_EXPORTS CV_EXPORTS
 
-#   else
+#   elif !defined(GAPI_STANDALONE)
 #       if defined _WIN32
 #           define GAPI_EXPORTS __declspec(dllexport)
 #       elif defined __GNUC__ && __GNUC__ >= 4
@@ -22,6 +22,8 @@
 #       ifndef GAPI_EXPORTS
 #           define GAPI_EXPORTS
 #       endif
+#   else  // GAPI_EXPORTS is intentionally not set in standalone build
+#       define GAPI_EXPORTS
 
 #   endif
 


### PR DESCRIPTION
### This pullrequest

fixes G-API symbol export specifier in case of G-API standalone mode

Originally, if someone decides to use G-API standalone and link G-API static library to a user's dynamic one: the symbols from our static lib are exported and placed into the symbol table of the user's dynamic library.

```
build_gapi_standalone:Linux x64=ade-0.1.1d
build_gapi_standalone:Win64=ade-0.1.1d
build_gapi_standalone:Mac=ade-0.1.1d
build_gapi_standalone:Linux x64 Debug=ade-0.1.1d
```