### PR TITLE
Support compiliation for <=VS13

### DIFF
--- a/modules/core/include/opencv2/core/cvdef.h
+++ b/modules/core/include/opencv2/core/cvdef.h
@@ -627,7 +627,7 @@ Cv64suf;
 \****************************************************************************************/
 
 #ifndef CV_NOEXCEPT
-#  ifdef CV_CXX11
+#  if defined(CV_CXX11) && (!defined(_MSC_VER) || _MSC_VER > 1800) /* MSVC 2015 and above */
 #    define CV_NOEXCEPT noexcept
 #  endif
 #endif


### PR DESCRIPTION
### This pullrequest changes
Checking CV_CXX11 is not enough for MSVC <=1800 as the compiler is not fully c++11 compliant. This will fix compilation error using VS13, where `noexcept` is not supported.

After change:  
if CV_CXX11 is defined and the compiler is NOT MSVC1800 and below, `CV_NOEXCEPT` is defined as `noexcept`, else `no-op`