### PR TITLE
Support headless WindowsCE: No getenv, UNICODE, wchar filesystem API

### DIFF
--- a/modules/core/include/opencv2/core/cvdef.h
+++ b/modules/core/include/opencv2/core/cvdef.h
@@ -641,9 +641,7 @@ Cv64suf;
 #ifdef OPENCV_STDINT_HEADER
 #include OPENCV_STDINT_HEADER
 #elif defined(__cplusplus)
-#if defined(_WIN32_WCE)
-#include <stdint.h>
-#elif defined(_MSC_VER) && _MSC_VER < 1600 /* MSVS 2010 */
+if defined(_MSC_VER) && _MSC_VER < 1600 /* MSVS 2010 */
 namespace cv {
 typedef signed char int8_t;
 typedef unsigned char uint8_t;

--- a/modules/core/include/opencv2/core/cvdef.h
+++ b/modules/core/include/opencv2/core/cvdef.h
@@ -641,7 +641,9 @@ Cv64suf;
 #ifdef OPENCV_STDINT_HEADER
 #include OPENCV_STDINT_HEADER
 #elif defined(__cplusplus)
-#if defined(_MSC_VER) && _MSC_VER < 1600 /* MSVS 2010 */
+#if defined(_WIN32_WCE)
+#include <stdint.h>
+#elif defined(_MSC_VER) && _MSC_VER < 1600 /* MSVS 2010 */
 namespace cv {
 typedef signed char int8_t;
 typedef unsigned char uint8_t;

--- a/modules/core/include/opencv2/core/utils/filesystem.private.hpp
+++ b/modules/core/include/opencv2/core/utils/filesystem.private.hpp
@@ -9,7 +9,7 @@
 #ifndef OPENCV_HAVE_FILESYSTEM_SUPPORT
 #  if defined(__EMSCRIPTEN__) || defined(__native_client__)
      /* no support */
-#  elif defined WINRT
+#  elif defined WINRT || defined _WIN32_WCE
      /* not supported */
 #  elif defined __ANDROID__ || defined __linux__ || defined _WIN32 || \
         defined __FreeBSD__ || defined __bsdi__ || defined __HAIKU__

--- a/modules/core/src/glob.cpp
+++ b/modules/core/src/glob.cpp
@@ -57,7 +57,7 @@ namespace
 
     struct DIR
     {
-#ifdef WINRT
+#if defined(WINRT) || defined(_WIN32_WCE)
         WIN32_FIND_DATAW data;
 #else
         WIN32_FIND_DATAA data;
@@ -78,7 +78,7 @@ namespace
     {
         DIR* dir = new DIR;
         dir->ent.d_name = 0;
-#ifdef WINRT
+#if defined(WINRT) || defined(_WIN32_WCE)
         cv::String full_path = cv::String(path) + "\\*";
         wchar_t wfull_path[MAX_PATH];
         size_t copied = mbstowcs(wfull_path, full_path.c_str(), MAX_PATH);
@@ -100,7 +100,7 @@ namespace
 
     dirent* readdir(DIR* dir)
     {
-#ifdef WINRT
+#if defined(WINRT) || defined(_WIN32_WCE)
         if (dir->ent.d_name != 0)
         {
             if (::FindNextFileW(dir->handle, &dir->data) != TRUE)

--- a/modules/core/src/ocl.cpp
+++ b/modules/core/src/ocl.cpp
@@ -876,7 +876,12 @@ bool haveOpenCL()
     if (!g_isOpenCLInitialized)
     {
         CV_TRACE_REGION("Init_OpenCL_Runtime");
-        const char* envPath = getenv("OPENCV_OPENCL_RUNTIME");
+        const char* envPath =
+#ifdef NO_GETENV
+            NULL;
+#else
+            getenv("OPENCV_OPENCL_RUNTIME");
+#endif
         if (envPath)
         {
             if (cv::String(envPath) == "disabled")
@@ -1737,8 +1742,12 @@ static cl_device_id selectOpenCLDevice()
 {
     std::string platform, deviceName;
     std::vector<std::string> deviceTypes;
-
-    const char* configuration = getenv("OPENCV_OPENCL_DEVICE");
+    const char* configuration =
+#ifdef NO_GETENV
+        NULL;
+#else
+        getenv("OPENCV_OPENCL_DEVICE");
+#endif
     if (configuration &&
             (strcmp(configuration, "disabled") == 0 ||
              !parseOpenCLDeviceConfiguration(std::string(configuration), platform, deviceTypes, deviceName)

--- a/modules/core/src/system.cpp
+++ b/modules/core/src/system.cpp
@@ -914,15 +914,16 @@ String tempfile( const char* suffix )
     fname = String(aname);
     RoUninitialize();
 #elif _WIN32_WCE
-    LPWSTR temp_dir2[MAX_PATH+1] = {0};
-    LPWSTR temp_file[MAX_PATH+1] = {0};
+    const auto kMaxPathSize = MAX_PATH+1;
+    wchar_t temp_dir[kMaxPathSize] = {0};
+    wchar_t temp_file[kMaxPathSize] = {0};
 
-    ::GetTempPath(sizeof(temp_dir2), *temp_dir2);
+    ::GetTempPathW(kMaxPathSize, temp_dir);
 
-    if(0 != ::GetTempFileName(*temp_dir2, L"ocv", 0, *temp_file)) {
-        DeleteFile(*temp_file);
+    if(0 != ::GetTempFileNameW(temp_dir, L"ocv", 0, temp_file)) {
+        DeleteFileW(temp_file);
         char aname[MAX_PATH];
-        size_t copied = wcstombs(aname, *temp_file, MAX_PATH);
+        size_t copied = wcstombs(aname, temp_file, MAX_PATH);
         CV_Assert((copied != MAX_PATH) && (copied != (size_t)-1));
         fname = String(aname);
     }

--- a/modules/core/src/system.cpp
+++ b/modules/core/src/system.cpp
@@ -1705,14 +1705,7 @@ public:
         id(CV_XADD(&g_threadNum, 1))
     {
 #ifdef OPENCV_WITH_ITT
-        std::string thread_name = cv::format("OpenCVThread-%03d", id);
-#if defined _WIN32 && defined _UNICODE
-        std::wstring ws_thread_name;
-        ws_thread_name.assign(thread_name.begin(), thread_name.end());
-        __itt_thread_set_name(ws_thread_name.c_str());
-#else
-        __itt_thread_set_name(thread_name.c_str());
-#endif
+        __itt_thread_set_name(cv::format("OpenCVThread-%03d", id).c_str());
 #endif
     }
 };

--- a/modules/core/src/utils/filesystem.cpp
+++ b/modules/core/src/utils/filesystem.cpp
@@ -88,13 +88,10 @@ cv::String join(const cv::String& base, const cv::String& path)
 cv::String canonical(const cv::String& path)
 {
     cv::String result;
-    const char* result_str =
-#ifdef NO_GETENV
-        NULL;
-#elif defined(_WIN32)
-        _fullpath(NULL, path.c_str(), 0);
+#ifdef _WIN32
+    const char* result_str = _fullpath(NULL, path.c_str(), 0);
 #else
-        realpath(path.c_str(), NULL);
+    const char* result_str = realpath(path.c_str(), NULL);
 #endif
     if (result_str)
     {
@@ -425,25 +422,12 @@ cv::String getCacheDirectory(const char* sub_directory_name, const char* configu
     {
         cv::String default_cache_path;
 #ifdef _WIN32
-#ifdef _WIN32_WCE
-        LPWSTR tmp_path_buf[MAX_PATH+1] = {0};
-        LPWSTR temp_file[MAX_PATH+1] = {0};
-        ::GetTempPath(sizeof(tmp_path_buf), *tmp_path_buf);
-        if (0 != ::GetTempFileName(*tmp_path_buf, L"ocv_cache", 0, *temp_file)) {
-            DeleteFile(*temp_file);
-            char aname[MAX_PATH];
-            size_t copied = wcstombs(aname, *temp_file, MAX_PATH);
-            CV_Assert((copied != MAX_PATH) && (copied != (size_t)-1));
-            default_cache_path = aname;
-        }
-#else
         char tmp_path_buf[MAX_PATH+1] = {0};
         DWORD res = GetTempPath(MAX_PATH, tmp_path_buf);
         if (res > 0 && res <= MAX_PATH)
         {
             default_cache_path = tmp_path_buf;
         }
-#endif // _WIN32_WCE
 #elif defined __ANDROID__
         // no defaults
 #elif defined __APPLE__

--- a/modules/core/src/utils/filesystem.cpp
+++ b/modules/core/src/utils/filesystem.cpp
@@ -88,10 +88,13 @@ cv::String join(const cv::String& base, const cv::String& path)
 cv::String canonical(const cv::String& path)
 {
     cv::String result;
-#ifdef _WIN32
-    const char* result_str = _fullpath(NULL, path.c_str(), 0);
+    const char* result_str =
+#ifdef NO_GETENV
+        NULL;
+#elif defined(_WIN32)
+        _fullpath(NULL, path.c_str(), 0);
 #else
-    const char* result_str = realpath(path.c_str(), NULL);
+        realpath(path.c_str(), NULL);
 #endif
     if (result_str)
     {
@@ -169,8 +172,8 @@ cv::String getcwd()
 {
     CV_INSTRUMENT_REGION();
     cv::AutoBuffer<char, 4096> buf;
-#if defined WIN32 || defined _WIN32 || defined WINCE
-#ifdef WINRT
+#if defined WIN32 || defined _WIN32
+#if defined WINRT || defined _WIN32_WCE
     return cv::String();
 #else
     DWORD sz = GetCurrentDirectoryA(0, NULL);
@@ -422,12 +425,25 @@ cv::String getCacheDirectory(const char* sub_directory_name, const char* configu
     {
         cv::String default_cache_path;
 #ifdef _WIN32
+#ifdef _WIN32_WCE
+        LPWSTR tmp_path_buf[MAX_PATH+1] = {0};
+        LPWSTR temp_file[MAX_PATH+1] = {0};
+        ::GetTempPath(sizeof(tmp_path_buf), *tmp_path_buf);
+        if (0 != ::GetTempFileName(*tmp_path_buf, L"ocv_cache", 0, *temp_file)) {
+            DeleteFile(*temp_file);
+            char aname[MAX_PATH];
+            size_t copied = wcstombs(aname, *temp_file, MAX_PATH);
+            CV_Assert((copied != MAX_PATH) && (copied != (size_t)-1));
+            default_cache_path = aname;
+        }
+#else
         char tmp_path_buf[MAX_PATH+1] = {0};
         DWORD res = GetTempPath(MAX_PATH, tmp_path_buf);
         if (res > 0 && res <= MAX_PATH)
         {
             default_cache_path = tmp_path_buf;
         }
+#endif // _WIN32_WCE
 #elif defined __ANDROID__
         // no defaults
 #elif defined __APPLE__


### PR DESCRIPTION
### This pullrequest changes
This PR enables compilation for headless WINCE toolchains. WindowsCE only supports filesystem calls with wide characters, does not have getenv and operates on absolute filepaths only.
Compiling for WINCE should be done with the  `/p:CharacterSet=Unicode` flag.

Configuration that this PR supports:
```
-DBUILD_EXAMPLES=OFF -DBUILD_opencv_apps=OFF -DBUILD_opencv_calib3d=OFF -DBUILD_opencv_highgui=OFF -DBUILD_opencv_features2d=OFF -DBUILD_opencv_flann=OFF -DBUILD_opencv_ml=OFF -DBUILD_opencv_objdetect=OFF -DBUILD_opencv_photo=OFF -DBUILD_opencv_shape=OFF -DBUILD_opencv_stitching=OFF -DBUILD_opencv_superres=OFF -DBUILD_opencv_ts=OFF -DBUILD_opencv_video=OFF -DBUILD_opencv_videoio=OFF -DBUILD_opencv_videostab=OFF -DBUILD_opencv_dnn=OFF -DBUILD_opencv_java=OFF -DBUILD_opencv_python2=OFF -DBUILD_opencv_python3=OFF -DBUILD_opencv_java_bindings_generator=OFF -DBUILD_opencv_python_bindings_generator=OFF -DWITH_QT=OFF -DWITH_GTK=OFF -DWITH_QUIRC=OFF -DWITH_JASPER=OFF -DWITH_WEBP=OFF -DWITH_PROTOBUF=OFF -DBUILD_SHARED_LIBS=OFF -DWITH_OPENEXR=OFF -DCV_TRACE=OFF
```


