### PR TITLE
zlib: errno and fdopen is defined in WINCE 8.0

### DIFF
--- a/3rdparty/zlib/zutil.c
+++ b/3rdparty/zlib/zutil.c
@@ -136,7 +136,7 @@ const char * ZEXPORT zError(err)
     return ERR_MSG(err);
 }
 
-#if defined(_WIN32_WCE)
+#if defined(_WIN32_WCE) && _WIN32_WCE < 0x800
     /* The Microsoft C Run-Time Library for Windows CE doesn't have
      * errno.  We define it as a global variable to simplify porting.
      * Its value is always 0 and should not be used.

--- a/3rdparty/zlib/zutil.h
+++ b/3rdparty/zlib/zutil.h
@@ -169,11 +169,13 @@ extern z_const char * const z_errmsg[10]; /* indexed by 2-zlib_error */
 
 #if (defined(_MSC_VER) && (_MSC_VER > 600)) && !defined __INTERIX
 #  if defined(_WIN32_WCE)
-#    define fdopen(fd,mode) NULL /* No fdopen() */
-#    ifndef _PTRDIFF_T_DEFINED
-       typedef int ptrdiff_t;
-#      define _PTRDIFF_T_DEFINED
-#    endif
+#    if _WIN32_WCE < 0x800
+#      define fdopen(fd,mode) NULL /* No fdopen() */
+#      ifndef _PTRDIFF_T_DEFINED
+         typedef int ptrdiff_t;
+#        define _PTRDIFF_T_DEFINED
+#      endif
+#  endif
 #  else
 #    define fdopen(fd,type)  _fdopen(fd,type)
 #  endif


### PR DESCRIPTION
### This pullrequest changes
This PR enables compilation for WINCE 8.0. errno and fdopen is included in the compiler and cannot be redefined.