### PR TITLE
Fix error message on invalid seam finder parameter #14646

### DIFF
--- a/modules/stitching/src/seam_finders.cpp
+++ b/modules/stitching/src/seam_finders.cpp
@@ -55,7 +55,7 @@ Ptr<SeamFinder> SeamFinder::createDefault(int type)
         return makePtr<VoronoiSeamFinder>();
     if (type == DP_SEAM)
         return makePtr<DpSeamFinder>();
-    CV_Error(Error::StsBadArg, "unsupported exposure compensation method");
+    CV_Error(Error::StsBadArg, "unsupported seam finder method");
 }
 
 


### PR DESCRIPTION
resolves #14646

### This pullrequest

- corrects the error message in the SeamFinder::createDefault()
