### PR TITLE
gapi: fix build with unique_ptr

### DIFF
--- a/modules/gapi/src/backends/fluid/gfluidbackend.cpp
+++ b/modules/gapi/src/backends/fluid/gfluidbackend.cpp
@@ -1328,7 +1328,7 @@ cv::gimpl::GParallelFluidExecutable::GParallelFluidExecutable(const ade::Graph  
                                                               const std::vector<GFluidOutputRois>   &parallelOutputRois)
 {
     for (auto&& rois : parallelOutputRois){
-        tiles.emplace_back(g, graph_data, rois.rois);
+        tiles.emplace_back(new GFluidExecutable(g, graph_data, rois.rois));
     }
 }
 
@@ -1343,7 +1343,8 @@ void cv::gimpl::GParallelFluidExecutable::run(std::vector<InObj>  &&input_objs,
                                               std::vector<OutObj> &&output_objs)
 {
     for (auto& tile : tiles ){
-        tile.run(input_objs, output_objs);
+        GAPI_Assert((bool)tile);
+        tile->run(input_objs, output_objs);
     }
 }
 

--- a/modules/gapi/src/backends/fluid/gfluidbackend.hpp
+++ b/modules/gapi/src/backends/fluid/gfluidbackend.hpp
@@ -118,6 +118,8 @@ FluidGraphInputData fluidExtractInputDataFromGraph(const ade::Graph &m_g, const 
 
 class GFluidExecutable final: public GIslandExecutable
 {
+    GFluidExecutable(const GFluidExecutable&) = delete;  // due std::unique_ptr in members list
+
     const ade::Graph &m_g;
     GModel::ConstGraph m_gm;
 
@@ -161,7 +163,9 @@ public:
 
 
 class GParallelFluidExecutable final: public GIslandExecutable {
-    std::vector<GFluidExecutable> tiles;
+    GParallelFluidExecutable(const GParallelFluidExecutable&) = delete;  // due std::unique_ptr in members list
+
+    std::vector<std::unique_ptr<GFluidExecutable>> tiles;
 public:
     GParallelFluidExecutable(const ade::Graph                       &g,
                              const FluidGraphInputData              &graph_data,


### PR DESCRIPTION
avoid generation of copy ctors with unique_ptr members

resolves #15065

```
force_builders=ARMv7,Custom Win
```