### PR TITLE
[WIP] Support ROI + UMat in own::Mat

### DIFF
--- a/modules/gapi/include/opencv2/gapi/own/convert.hpp
+++ b/modules/gapi/include/opencv2/gapi/own/convert.hpp
@@ -17,14 +17,21 @@
 
 namespace cv
 {
-    inline cv::gapi::own::Mat to_own(Mat const& m) { return {m.rows, m.cols, m.type(), m.data, m.step};};
            cv::gapi::own::Mat to_own(Mat&&) = delete;
+    inline cv::gapi::own::Mat to_own(Mat const& mat)
+    {
+        cv::gapi::own::Mat own(mat.rows, mat.cols, mat.type(), mat.data, mat.step);
+        own.datastart = mat.datastart;
+        own.dataend = mat.dataend;
+        own.datalimit = mat.datalimit;
+        return own;
+    }
 
-    inline cv::gapi::own::Scalar to_own(const cv::Scalar& s) { return {s[0], s[1], s[2], s[3]}; };
+    inline cv::gapi::own::Scalar to_own(const cv::Scalar& s) { return {s[0], s[1], s[2], s[3]}; }
 
-    inline cv::gapi::own::Size to_own (const Size& s) { return {s.width, s.height}; };
+    inline cv::gapi::own::Size to_own (const Size& s) { return {s.width, s.height}; }
 
-    inline cv::gapi::own::Rect to_own (const Rect& r) { return {r.x, r.y, r.width, r.height}; };
+    inline cv::gapi::own::Rect to_own (const Rect& r) { return {r.x, r.y, r.width, r.height}; }
 
 
 
@@ -32,14 +39,21 @@ namespace gapi
 {
 namespace own
 {
-    inline cv::Mat to_ocv(Mat const& m) { return {m.rows, m.cols, m.type(), m.data, m.step};};
            cv::Mat to_ocv(Mat&&)    = delete;
+    inline cv::Mat to_ocv(Mat const& own)
+    {
+        cv::Mat mat(own.rows, own.cols, own.type(), own.data, own.step);
+        mat.datastart = own.datastart;
+        mat.dataend = own.dataend;
+        mat.datalimit = own.datalimit;
+        return mat;
+    }
 
-    inline cv::Scalar to_ocv(const Scalar& s) { return {s[0], s[1], s[2], s[3]}; };
+    inline cv::Scalar to_ocv(const Scalar& s) { return {s[0], s[1], s[2], s[3]}; }
 
-    inline cv::Size to_ocv (const Size& s) { return cv::Size(s.width, s.height); };
+    inline cv::Size to_ocv (const Size& s) { return cv::Size(s.width, s.height); }
 
-    inline cv::Rect to_ocv (const Rect& r) { return cv::Rect(r.x, r.y, r.width, r.height); };
+    inline cv::Rect to_ocv (const Rect& r) { return cv::Rect(r.x, r.y, r.width, r.height); }
 
 } // namespace own
 } // namespace gapi

--- a/modules/gapi/include/opencv2/gapi/own/mat.hpp
+++ b/modules/gapi/include/opencv2/gapi/own/mat.hpp
@@ -74,6 +74,11 @@ namespace cv { namespace gapi { namespace own {
             //! pointer to the data
             uchar* data = nullptr;
             size_t step = 0;
+
+            //! helper fields propagated to cv::Mat (used for locateROI, adjustROI)
+            const uchar* datastart = nullptr;
+            const uchar* dataend = nullptr;
+            const uchar* datalimit = nullptr;
         };
     }
     //concise version of cv::Mat suitable for GAPI needs (used when no dependence on OpenCV is required)

--- a/modules/gapi/test/common/gapi_core_tests.hpp
+++ b/modules/gapi/test/common/gapi_core_tests.hpp
@@ -121,8 +121,6 @@ struct BackendOutputAllocationTest : TestWithParamBase<>
         cv::randu(in_mat2, cv::Scalar::all(1), cv::Scalar::all(15));
     }
 };
-// FIXME: move all tests from this fixture to the base class once all issues are resolved
-struct BackendOutputAllocationLargeSizeWithCorrectSubmatrixTest : BackendOutputAllocationTest {};
 } // opencv_test
 
 #endif //OPENCV_GAPI_CORE_TESTS_HPP

--- a/modules/gapi/test/common/gapi_core_tests_inl.hpp
+++ b/modules/gapi/test/common/gapi_core_tests_inl.hpp
@@ -1418,8 +1418,7 @@ TEST_P(BackendOutputAllocationTest, LargerPreallocatedSize)
     EXPECT_NE(out_mat_gapi_ref.data, out_mat_gapi.data);
 }
 
-TEST_P(BackendOutputAllocationLargeSizeWithCorrectSubmatrixTest,
-    LargerPreallocatedSizeWithCorrectSubmatrix)
+TEST_P(BackendOutputAllocationTest, LargerPreallocatedSizeWithCorrectSubmatrix)
 {
     out_mat_gapi = cv::Mat(sz * 2, type);
     auto out_mat_gapi_ref = out_mat_gapi; // shallow copy to ensure previous data is not deleted

--- a/modules/gapi/test/cpu/gapi_core_tests_cpu.cpp
+++ b/modules/gapi/test/cpu/gapi_core_tests_cpu.cpp
@@ -442,10 +442,4 @@ INSTANTIATE_TEST_CASE_P(BackendOutputAllocationTestCPU, BackendOutputAllocationT
                                 Values(-1),
                                 Values(CORE_CPU)));
 
-INSTANTIATE_TEST_CASE_P(BackendOutputAllocationLargeSizeWithCorrectSubmatrixTestCPU,
-                        BackendOutputAllocationLargeSizeWithCorrectSubmatrixTest,
-                        Combine(Values(CV_8UC3, CV_16SC2, CV_32FC1),
-                                Values(cv::Size(50, 50)),
-                                Values(-1),
-                                Values(CORE_CPU)));
 }

--- a/modules/gapi/test/cpu/gapi_core_tests_fluid.cpp
+++ b/modules/gapi/test/cpu/gapi_core_tests_fluid.cpp
@@ -260,13 +260,6 @@ INSTANTIATE_TEST_CASE_P(BackendOutputAllocationTestFluid, BackendOutputAllocatio
                                 Values(-1),
                                 Values(CORE_FLUID)));
 
-INSTANTIATE_TEST_CASE_P(BackendOutputAllocationLargeSizeWithCorrectSubmatrixTestFluid,
-                        BackendOutputAllocationLargeSizeWithCorrectSubmatrixTest,
-                        Combine(Values(CV_8UC3, CV_16SC2, CV_32FC1),
-                                Values(cv::Size(50, 50)),
-                                Values(-1),
-                                Values(CORE_FLUID)));
-
 //----------------------------------------------------------------------
 // FIXME: Clean-up test configurations which are enabled already
 #if 0

--- a/modules/gapi/test/gpu/gapi_core_tests_gpu.cpp
+++ b/modules/gapi/test/gpu/gapi_core_tests_gpu.cpp
@@ -385,14 +385,6 @@ INSTANTIATE_TEST_CASE_P(BackendOutputAllocationTestGPU, BackendOutputAllocationT
                                 Values(-1),
                                 Values(CORE_GPU)));
 
-// FIXME: there's an issue in OCL backend with matrix reallocation that shouldn't happen
-INSTANTIATE_TEST_CASE_P(DISABLED_BackendOutputAllocationLargeSizeWithCorrectSubmatrixTestGPU,
-                        BackendOutputAllocationLargeSizeWithCorrectSubmatrixTest,
-                        Combine(Values(CV_8UC3, CV_16SC2, CV_32FC1),
-                                Values(cv::Size(50, 50)),
-                                Values(-1),
-                                Values(CORE_GPU)));
-
 //TODO: fix this backend to allow ConcatVertVec ConcatHorVec
 #if 0
 INSTANTIATE_TEST_CASE_P(ConcatVertVecTestGPU, ConcatVertVecTest,

--- a/modules/gapi/test/own/mat_tests.cpp
+++ b/modules/gapi/test/own/mat_tests.cpp
@@ -384,4 +384,26 @@ TEST(OwnMat, ROIView)
     << to_ocv(roi_view) << std::endl
     << expected_cv_mat  << std::endl;
 }
+
+TEST(OwnMat, ROIViewWithUMat)
+{
+    auto sz = cv::Size(50, 50);
+    cv::Mat mat = cv::Mat(sz * 2, CV_8UC3);
+
+    cv::Mat roi_view = mat(cv::Rect({5, 8}, sz));
+    const auto roi_view_ref = roi_view;
+
+    // access Mat through UMat
+    {
+    EXPECT_EQ(roi_view_ref.data, roi_view.getUMat(ACCESS_RW).getMat(ACCESS_RW).data);
+    EXPECT_EQ(roi_view_ref.datastart, roi_view.getUMat(ACCESS_RW).getMat(ACCESS_RW).datastart);
+    }
+
+    // access Mat through UMat but wrap Mat with gapi::own::Mat
+    {
+    auto own_roi_view = to_own(roi_view);
+    EXPECT_EQ(roi_view_ref.data, to_ocv(own_roi_view).getUMat(ACCESS_RW).getMat(ACCESS_RW).data);
+    EXPECT_EQ(roi_view_ref.datastart, to_ocv(own_roi_view).getUMat(ACCESS_RW).getMat(ACCESS_RW).datastart);
+    }
+}
 } // namespace opencv_test


### PR DESCRIPTION
### This pullrequest

- Adds ROI-related fields to `cv::gapi::own::Mat` and enables support of ROIs outputs (also inputs) for OCL backend (UMat use case)
- Adds tests for new behavior (unit test + backend-level)

---
**Problem**: if user passes ROI `cv::Mat` to G-API, in case of OCL backend we lose track of original data source when doing `own::Mat -> cv::Mat -> cv::UMat` conversion and this results in a failure at checking that populated UMat data equals original cv::Mat data (according to assert message this means that output was reallocated internally and graph execution result was written into that new memory)

**Solution**: the most obvious would be to propagate ROI-related fields through `cv::gapi::own::Mat` directly to internally (re-)constructed `cv::Mat`. Better ideas are appreciated

```
build_gapi_standalone:Linux x64=ade-0.1.1d
build_gapi_standalone:Win64=ade-0.1.1d
build_gapi_standalone:Mac=ade-0.1.1d
build_gapi_standalone:Linux x64 Debug=ade-0.1.1d
```