### PR TITLE
cudalegacy: fix test failure of SolvePnPRansac

### DIFF
--- a/modules/cudalegacy/src/calib3d.cpp
+++ b/modules/cudalegacy/src/calib3d.cpp
@@ -181,7 +181,7 @@ namespace
                    image_subset(0, i) = image->at<Point2f>(subset_indices[i]);
                 }
 
-                solvePnP(object_subset, image_subset, *camera_mat, *dist_coef, rot_vec, transl_vec);
+                solvePnP(object_subset, image_subset, *camera_mat, *dist_coef, rot_vec, transl_vec, false, SOLVEPNP_EPNP);
 
                 // Remember translation vector
                 Mat transl_vec_ = transl_vectors.colRange(iter * 3, (iter + 1) * 3);


### PR DESCRIPTION
fix #15079

### This pullrequest changes
  * use SOLVE_EPNP for the initial guess

```
force_builders=Custom
buildworker:Custom=linux-1,linux-2,linux-4
docker_image:Custom=ubuntu-cuda:16.04
```
