### PR TITLE
allow forcing the input format for ffmpeg backend with env var

### DIFF
--- a/modules/videoio/src/cap_ffmpeg_impl.hpp
+++ b/modules/videoio/src/cap_ffmpeg_impl.hpp
@@ -891,7 +891,14 @@ bool CvCapture_FFMPEG::open( const char* _filename )
 #else
     av_dict_set(&dict, "rtsp_transport", "tcp", 0);
 #endif
-    int err = avformat_open_input(&ic, _filename, NULL, &dict);
+    AVInputFormat* input_format = NULL;
+    AVDictionaryEntry* entry = av_dict_get(dict, "input_format", NULL, 0);
+    if (entry != 0)
+    {
+      input_format = av_find_input_format(entry->value);
+    }
+
+    int err = avformat_open_input(&ic, _filename, input_format, &dict);
 #else
     int err = av_open_input_file(&ic, _filename, NULL, 0, NULL);
 #endif


### PR DESCRIPTION
### Allows forcing the input format for ffmpeg backend to VideoCapture

I ran into a problem where ffmpeg would not recognise the video format of a .dav file produced by a security camera. Forcing ffmpeg to just assume h264 worked for me, but I had no way of specifying this using OpenCV.

This small patch allows you to specify input format using the OPENCV_FFMPEG_CAPTURE_OPTIONS environment variable, adding the key input_format. I figured it might be useful for others too, hence the PR. 
