### PR TITLE
Fix drawKeypoints and drawMatches for JS

### DIFF
--- a/modules/js/src/embindgen.py
+++ b/modules/js/src/embindgen.py
@@ -141,7 +141,7 @@ features2d = {'Feature2D': ['detect', 'compute', 'detectAndCompute', 'descriptor
               'AKAZE': ['create', 'setDescriptorType', 'getDescriptorType', 'setDescriptorSize', 'getDescriptorSize', 'setDescriptorChannels', 'getDescriptorChannels', 'setThreshold', 'getThreshold', 'setNOctaves', 'getNOctaves', 'setNOctaveLayers', 'getNOctaveLayers', 'setDiffusivity', 'getDiffusivity', 'getDefaultName'],
               'DescriptorMatcher': ['add', 'clear', 'empty', 'isMaskSupported', 'train', 'match', 'knnMatch', 'radiusMatch', 'clone', 'create'],
               'BFMatcher': ['isMaskSupported', 'create'],
-              '': ['drawKeypoints', 'drawMatches']}
+              '': ['drawKeypoints', 'drawMatches', 'drawMatchesKnn']}
 
 calib3d = {'': ['findHomography']}
 
@@ -562,7 +562,7 @@ class JSWrapperGenerator(object):
                     match = re.search(r'const std::vector<(.*)>&', arg_type)
                     if match:
                         type_in_vect = match.group(1)
-                        if type_in_vect != 'cv::Mat':
+                        if type_in_vect in ['int', 'float', 'double', 'char', 'uchar', 'String', 'std::string']:
                             casted_arg_name = 'emscripten::vecFromJSArray<' + type_in_vect + '>(' + arg_name + ')'
                             arg_type = re.sub(r'std::vector<(.*)>', 'emscripten::val', arg_type)
                 w_signature.append(arg_type + ' ' + arg_name)

--- a/modules/js/test/test_features2d.js
+++ b/modules/js/test/test_features2d.js
@@ -80,3 +80,36 @@ QUnit.test('BFMatcher', function(assert) {
 
   assert.equal(dm.size(), 67);
 });
+
+QUnit.test('Drawing', function(assert) {
+  // Generate key points.
+  let image = generateTestFrame();
+
+  let kp = new cv.KeyPointVector();
+  let descriptors = new cv.Mat();
+  let orb = new cv.ORB();
+  orb.detectAndCompute(image, new cv.Mat(), kp, descriptors);
+  assert.equal(kp.size(), 67);
+
+  let dst = new cv.Mat();
+  cv.drawKeypoints(image, kp, dst);
+  assert.equal(dst.rows, image.rows);
+  assert.equal(dst.cols, image.cols);
+
+  // Run a matcher.
+  let dm = new cv.DMatchVector();
+  let matcher = new cv.BFMatcher();
+  matcher.match(descriptors, descriptors, dm);
+  assert.equal(dm.size(), 67);
+
+  cv.drawMatches(image, kp, image, kp, dm, dst);
+  assert.equal(dst.rows, image.rows);
+  assert.equal(dst.cols, 2 * image.cols);
+
+  dm = new cv.DMatchVectorVector();
+  matcher.knnMatch(descriptors, descriptors, dm, 2);
+  assert.equal(dm.size(), 67);
+  cv.drawMatchesKnn(image, kp, image, kp, dm, dst);
+  assert.equal(dst.rows, image.rows);
+  assert.equal(dst.cols, 2 * image.cols);
+});


### PR DESCRIPTION
<!-- Please use this line to close one or multiple issues when this pullrequest gets merged
You can add another line right under the first one:
resolves #1234
resolves #1235
-->

### This pullrequest changes

resolves https://github.com/opencv/opencv/issues/13641

This is mostly a workaround for the issue.

```
docker_image:Docs=docs-js
docker_image:Custom=javascript
buildworker:Docs=linux-1
buildworker:Custom=linux-1
```