### PR TITLE
Remove unavoidable print of CV error

### DIFF
--- a/modules/videoio/src/cap_v4l.cpp
+++ b/modules/videoio/src/cap_v4l.cpp
@@ -788,13 +788,7 @@ bool CvCaptureCAM_V4L::open(int _index)
         name = cv::format("/dev/video%d", _index);
     }
 
-    /* Print the CameraNumber at the end of the string with a width of one character */
-    bool res = open(name.c_str());
-    if (!res)
-    {
-        fprintf(stderr, "VIDEOIO ERROR: V4L: can't open camera by index %d\n", _index);
-    }
-    return res;
+    return open(name.c_str());
 }
 
 bool CvCaptureCAM_V4L::open(const char* _deviceName)

--- a/modules/videoio/src/cap_v4l.cpp
+++ b/modules/videoio/src/cap_v4l.cpp
@@ -788,7 +788,12 @@ bool CvCaptureCAM_V4L::open(int _index)
         name = cv::format("/dev/video%d", _index);
     }
 
-    return open(name.c_str());
+    bool res = open(name.c_str());
+    if (!res)
+    {
+        CV_LOG_WARNING(NULL, cv::format("VIDEOIO ERROR: V4L: can't open camera by index %d", _index));
+    }
+    return res;
 }
 
 bool CvCaptureCAM_V4L::open(const char* _deviceName)


### PR DESCRIPTION
## This pullrequest changes

<!-- Please describe what your pullrequest is changing -->

This PR removes a print which was impossible to hide. My use case is it's also printed in the Python bindings, and as brute-forcing the camera ids is the only reliable way to enumerate all cameras, it's annoying and noisy to print each time.

The return value covers whether the device exists. This might be better hidden behind a debug flag, but I couldn't work out how to do that nicely.