### PR TITLE
Merge 3.4

### DIFF
--- a/modules/dnn/src/dnn.cpp
+++ b/modules/dnn/src/dnn.cpp
@@ -2233,7 +2233,10 @@ struct Net::Impl
                 if (isAsync)
                     CV_Error(Error::StsNotImplemented, "Default implementation fallbacks in asynchronous mode");
 
-                CV_Assert(layer->supportBackend(DNN_BACKEND_OPENCV));
+                if (!layer->supportBackend(DNN_BACKEND_OPENCV))
+                    CV_Error(Error::StsNotImplemented, format("Layer \"%s\" of type \"%s\" unsupported on OpenCV backend",
+                                                       ld.name.c_str(), ld.type.c_str()));
+
                 if (preferableBackend == DNN_BACKEND_OPENCV && IS_DNN_OPENCL_TARGET(preferableTarget))
                 {
                     std::vector<UMat> umat_inputBlobs = OpenCLBackendWrapper::getUMatVector(ld.inputBlobsWrappers);

--- a/modules/dnn/src/layers/layers_common.cpp
+++ b/modules/dnn/src/layers/layers_common.cpp
@@ -148,13 +148,12 @@ void getPoolingKernelParams(const LayerParams &params, std::vector<size_t>& kern
                             std::vector<size_t>& pads_begin, std::vector<size_t>& pads_end,
                             std::vector<size_t>& strides, cv::String &padMode)
 {
-    util::getStrideAndPadding(params, pads_begin, pads_end, strides, padMode);
-
     globalPooling = params.has("global_pooling") &&
                     params.get<bool>("global_pooling");
 
     if (globalPooling)
     {
+        util::getStrideAndPadding(params, pads_begin, pads_end, strides, padMode);
         if(params.has("kernel_h") || params.has("kernel_w") || params.has("kernel_size"))
         {
             CV_Error(cv::Error::StsBadArg, "In global_pooling mode, kernel_size (or kernel_h and kernel_w) cannot be specified");
@@ -171,6 +170,7 @@ void getPoolingKernelParams(const LayerParams &params, std::vector<size_t>& kern
     else
     {
         util::getKernelSize(params, kernel);
+        util::getStrideAndPadding(params, pads_begin, pads_end, strides, padMode, kernel.size());
     }
 }
 

--- a/modules/dnn/test/test_onnx_importer.cpp
+++ b/modules/dnn/test/test_onnx_importer.cpp
@@ -162,6 +162,18 @@ TEST_P(Test_ONNX_layers, Clip)
     testONNXModels("clip", npy);
 }
 
+TEST_P(Test_ONNX_layers, ReduceMean)
+{
+    testONNXModels("reduce_mean");
+}
+
+TEST_P(Test_ONNX_layers, ReduceMean3D)
+{
+    if (target != DNN_TARGET_CPU)
+        throw SkipTestException("Only CPU is supported");
+    testONNXModels("reduce_mean3d");
+}
+
 TEST_P(Test_ONNX_layers, MaxPooling_Sigmoid)
 {
     testONNXModels("maxpooling_sigmoid");

--- a/modules/dnn/test/test_tf_importer.cpp
+++ b/modules/dnn/test/test_tf_importer.cpp
@@ -350,11 +350,6 @@ TEST_P(Test_TensorFlow_layers, l2_normalize_3d)
     runTensorFlowNet("l2_normalize_3d");
 }
 
-TEST_P(Test_TensorFlow_layers, Split)
-{
-    runTensorFlowNet("split");
-}
-
 class Test_TensorFlow_nets : public DNNTestLayer {};
 
 TEST_P(Test_TensorFlow_nets, MobileNet_SSD)
@@ -682,6 +677,9 @@ TEST_P(Test_TensorFlow_layers, lstm)
 
 TEST_P(Test_TensorFlow_layers, split)
 {
+    if (backend == DNN_BACKEND_INFERENCE_ENGINE)
+        applyTestTag(CV_TEST_TAG_DNN_SKIP_IE_MYRIAD_2);
+    runTensorFlowNet("split");
     if (backend == DNN_BACKEND_INFERENCE_ENGINE)
         applyTestTag(CV_TEST_TAG_DNN_SKIP_IE);
     runTensorFlowNet("split_equals");

--- a/modules/js/src/embindgen.py
+++ b/modules/js/src/embindgen.py
@@ -141,7 +141,7 @@ features2d = {'Feature2D': ['detect', 'compute', 'detectAndCompute', 'descriptor
               'AKAZE': ['create', 'setDescriptorType', 'getDescriptorType', 'setDescriptorSize', 'getDescriptorSize', 'setDescriptorChannels', 'getDescriptorChannels', 'setThreshold', 'getThreshold', 'setNOctaves', 'getNOctaves', 'setNOctaveLayers', 'getNOctaveLayers', 'setDiffusivity', 'getDiffusivity', 'getDefaultName'],
               'DescriptorMatcher': ['add', 'clear', 'empty', 'isMaskSupported', 'train', 'match', 'knnMatch', 'radiusMatch', 'clone', 'create'],
               'BFMatcher': ['isMaskSupported', 'create'],
-              '': ['drawKeypoints', 'drawMatches']}
+              '': ['drawKeypoints', 'drawMatches', 'drawMatchesKnn']}
 
 photo = {'': ['createAlignMTB', 'createCalibrateDebevec', 'createCalibrateRobertson', \
               'createMergeDebevec', 'createMergeMertens', 'createMergeRobertson', \
@@ -590,7 +590,7 @@ class JSWrapperGenerator(object):
                     match = re.search(r'const std::vector<(.*)>&', arg_type)
                     if match:
                         type_in_vect = match.group(1)
-                        if type_in_vect != 'cv::Mat':
+                        if type_in_vect in ['int', 'float', 'double', 'char', 'uchar', 'String', 'std::string']:
                             casted_arg_name = 'emscripten::vecFromJSArray<' + type_in_vect + '>(' + arg_name + ')'
                             arg_type = re.sub(r'std::vector<(.*)>', 'emscripten::val', arg_type)
                 w_signature.append(arg_type + ' ' + arg_name)

--- a/modules/js/test/test_features2d.js
+++ b/modules/js/test/test_features2d.js
@@ -80,3 +80,36 @@ QUnit.test('BFMatcher', function(assert) {
 
   assert.equal(dm.size(), 67);
 });
+
+QUnit.test('Drawing', function(assert) {
+  // Generate key points.
+  let image = generateTestFrame();
+
+  let kp = new cv.KeyPointVector();
+  let descriptors = new cv.Mat();
+  let orb = new cv.ORB();
+  orb.detectAndCompute(image, new cv.Mat(), kp, descriptors);
+  assert.equal(kp.size(), 67);
+
+  let dst = new cv.Mat();
+  cv.drawKeypoints(image, kp, dst);
+  assert.equal(dst.rows, image.rows);
+  assert.equal(dst.cols, image.cols);
+
+  // Run a matcher.
+  let dm = new cv.DMatchVector();
+  let matcher = new cv.BFMatcher();
+  matcher.match(descriptors, descriptors, dm);
+  assert.equal(dm.size(), 67);
+
+  cv.drawMatches(image, kp, image, kp, dm, dst);
+  assert.equal(dst.rows, image.rows);
+  assert.equal(dst.cols, 2 * image.cols);
+
+  dm = new cv.DMatchVectorVector();
+  matcher.knnMatch(descriptors, descriptors, dm, 2);
+  assert.equal(dm.size(), 67);
+  cv.drawMatchesKnn(image, kp, image, kp, dm, dst);
+  assert.equal(dst.rows, image.rows);
+  assert.equal(dst.cols, 2 * image.cols);
+});


### PR DESCRIPTION
#15032 from l-bat:reduce_mean
#15092 from alalek:videoio_gstreamer_more_get_checks
~~#15093 from tomoaki0705:fixCudaLegacyRansac~~ (moved to opencv_contrib)
~~#15104 from alalek:videoio_fix_debug_message~~ (not applicable)
#15107 from dkurt:js_features2d_drawings

Previous "Merge 3.4": #15089


<cut/>

```
buildworker:Win64 OpenCL=windows-2
buildworker:Custom=linux-1,linux-2,linux-4
docker_image:Docs=docs-js
docker_image:Custom=javascript
#docker_image:Custom=powerpc64le
#docker_image:Custom=ubuntu-openvino:16.04
#buildworker:Custom=linux-2
#docker_image:Custom=ubuntu-vulkan:16.04
#buildworker:Custom=linux-4
#docker_image:Custom=fedora:28
#docker_image:Custom=ubuntu-cuda:16.04
build_image:Custom Mac=openvino-2019r1
build_image:Custom Win=openvino-2019r1
#build_image:Custom Win=msvs2017
#build_image:Custom Win=msvs2019
test_modules:Custom Mac=dnn,java,python3
```
