### PR TITLE
fast_math.hpp performance improvements

### DIFF
--- a/modules/core/include/opencv2/core/fast_math.hpp
+++ b/modules/core/include/opencv2/core/fast_math.hpp
@@ -92,6 +92,19 @@
     #define ARM_ROUND_FLT(value) ARM_ROUND(value, "vcvtr.s32.f32 %[temp], %[value]\n vmov %[res], %[temp]")
 #endif
 
+#if defined __PPC64__ && !defined OPENCV_USE_FASTMATH_GCC_BUILTINS
+    /* Let GCC inline C math functions when available. Dedicated hardware is available to
+       round and covert FP values. */
+    #define OPENCV_USE_FASTMATH_GCC_BUILTINS
+#endif
+
+/* Enable GCC builtin math functions if possible, desired, and available.
+   Note, not all math functions inline equally. E.g lrint will not inline
+   without the -fno-math-errno option. */
+#if defined OPENCV_USE_FASTMATH_GCC_BUILTINS && defined __GNUC__ && !defined __clang__ && !defined (__CUDACC__)
+    #define _OPENCV_FASTMATH_ENABLE_GCC_MATH_BUILTINS
+#endif
+
 /** @brief Rounds floating-point number to the nearest integer
 
  @param value floating-point number. If the value is outside of INT_MIN ... INT_MAX range, the
@@ -138,8 +151,12 @@ cvRound( double value )
  */
 CV_INLINE int cvFloor( double value )
 {
+#if defined _OPENCV_FASTMATH_ENABLE_GCC_MATH_BUILTINS
+    return __builtin_floor(value);
+#else
     int i = (int)value;
     return i - (i > value);
+#endif
 }
 
 /** @brief Rounds floating-point number to the nearest integer not smaller than the original.
@@ -151,8 +168,12 @@ CV_INLINE int cvFloor( double value )
  */
 CV_INLINE int cvCeil( double value )
 {
+#if defined _OPENCV_FASTMATH_ENABLE_GCC_MATH_BUILTINS
+    return __builtin_ceil(value);
+#else
     int i = (int)value;
     return i + (i < value);
+#endif
 }
 
 /** @brief Determines if the argument is Not A Number.
@@ -225,8 +246,12 @@ CV_INLINE int cvRound( int value )
 /** @overload */
 CV_INLINE int cvFloor( float value )
 {
+#if defined _OPENCV_FASTMATH_ENABLE_GCC_MATH_BUILTINS
+    return __builtin_floorf(value);
+#else
     int i = (int)value;
     return i - (i > value);
+#endif
 }
 
 /** @overload */
@@ -238,8 +263,12 @@ CV_INLINE int cvFloor( int value )
 /** @overload */
 CV_INLINE int cvCeil( float value )
 {
+#if defined _OPENCV_FASTMATH_ENABLE_GCC_MATH_BUILTINS
+    return __builtin_ceilf(value);
+#else
     int i = (int)value;
     return i + (i < value);
+#endif
 }
 
 /** @overload */

--- a/modules/core/perf/perf_cvround.cpp
+++ b/modules/core/perf/perf_cvround.cpp
@@ -4,42 +4,52 @@ namespace opencv_test
 {
 using namespace perf;
 
-template <typename T>
-static void CvRoundMat(const cv::Mat & src, cv::Mat & dst)
-{
-    for (int y = 0; y < dst.rows; ++y)
-    {
-        const T * sptr = src.ptr<T>(y);
-        int * dptr = dst.ptr<int>(y);
-
-        for (int x = 0; x < dst.cols; ++x)
-            dptr[x] = cvRound(sptr[x]);
+#define DECL_ROUND_TEST(NAME, OP, EXTRA) \
+    template <typename T>                                          \
+    static void OP ## Mat(const cv::Mat & src, cv::Mat & dst)      \
+    {                                                              \
+        for (int y = 0; y < dst.rows; ++y)                         \
+        {                                                          \
+            const T * sptr = src.ptr<T>(y);                        \
+            int * dptr = dst.ptr<int>(y);                          \
+                                                                   \
+            for (int x = 0; x < dst.cols; ++x)                     \
+                dptr[x] = OP(sptr[x]) EXTRA;                       \
+        }                                                          \
+    }                                                              \
+                                                                   \
+    PERF_TEST_P(Size_MatType, CvRound_Float ## NAME,               \
+            testing::Combine(testing::Values(TYPICAL_MAT_SIZES),   \
+                             testing::Values(CV_32FC1, CV_64FC1))) \
+    {                                                              \
+        Size size = get<0>(GetParam());                            \
+        int type = get<1>(GetParam()), depth = CV_MAT_DEPTH(type); \
+                                                                   \
+        cv::Mat src(size, type), dst(size, CV_32SC1);              \
+                                                                   \
+        declare.in(src, WARMUP_RNG).out(dst);                      \
+                                                                   \
+        if (depth == CV_32F)                                       \
+        {                                                          \
+            TEST_CYCLE()                                           \
+                OP ## Mat<float>(src, dst);                        \
+        }                                                          \
+        else if (depth == CV_64F)                                  \
+        {                                                          \
+            TEST_CYCLE()                                           \
+                OP ## Mat<double>(src, dst);                       \
+        }                                                          \
+                                                                   \
+        SANITY_CHECK_NOTHING();                                    \
     }
-}
 
-PERF_TEST_P(Size_MatType, CvRound_Float,
-            testing::Combine(testing::Values(TYPICAL_MAT_SIZES),
-                             testing::Values(CV_32FC1, CV_64FC1)))
-{
-    Size size = get<0>(GetParam());
-    int type = get<1>(GetParam()), depth = CV_MAT_DEPTH(type);
+DECL_ROUND_TEST(,cvRound,)
+DECL_ROUND_TEST(_Ceil,cvCeil,)
+DECL_ROUND_TEST(_Floor,cvFloor,)
 
-    cv::Mat src(size, type), dst(size, CV_32SC1);
-
-    declare.in(src, WARMUP_RNG).out(dst);
-
-    if (depth == CV_32F)
-    {
-        TEST_CYCLE()
-            CvRoundMat<float>(src, dst);
-    }
-    else if (depth == CV_64F)
-    {
-        TEST_CYCLE()
-            CvRoundMat<double>(src, dst);
-    }
-
-    SANITY_CHECK_NOTHING();
-}
+/* For FP classification tests, try to test them in way which uses
+   branching logic and avoids extra FP logic. */
+DECL_ROUND_TEST(_NaN,cvIsNaN, ? 1 : 2)
+DECL_ROUND_TEST(_Inf,cvIsInf, ? 1 : 2)
 
 } // namespace

--- a/modules/core/test/test_math.cpp
+++ b/modules/core/test/test_math.cpp
@@ -3923,5 +3923,59 @@ TEST(Core_SoftFloat, CvRound)
     }
 }
 
+template<typename T>
+static void checkRounding(T in, int outCeil, int outFloor)
+{
+    EXPECT_EQ(outCeil,cvCeil(in));
+    EXPECT_EQ(outFloor,cvFloor(in));
+
+    /* cvRound is not expected to be IEEE compliant. The implementation
+       should round to one of the above. */
+    EXPECT_TRUE((cvRound(in) == outCeil) || (cvRound(in) == outFloor));
+}
+
+TEST(Core_FastMath, InlineRoundingOps)
+{
+    struct
+    {
+        double in;
+        int outCeil;
+        int outFloor;
+    } values[] =
+    {
+        // Values are chosen to convert to binary float 32/64 exactly
+        { 1.0, 1, 1 },
+        { 1.5, 2, 1 },
+        { -1.5, -1, -2}
+    };
+
+    for (int i = 0, maxi = sizeof(values) / sizeof(values[0]); i < maxi; i++)
+    {
+        checkRounding<double>(values[i].in, values[i].outCeil, values[i].outFloor);
+        checkRounding<float>((float)values[i].in, values[i].outCeil, values[i].outFloor);
+    }
+}
+
+TEST(Core_FastMath, InlineNaN)
+{
+    EXPECT_EQ( cvIsNaN((float) NAN), 1);
+    EXPECT_EQ( cvIsNaN((float) -NAN), 1);
+    EXPECT_EQ( cvIsNaN(0.0f), 0);
+    EXPECT_EQ( cvIsNaN((double) NAN), 1);
+    EXPECT_EQ( cvIsNaN((double) -NAN), 1);
+    EXPECT_EQ( cvIsNaN(0.0), 0);
+}
+
+TEST(Core_FastMath, InlineIsInf)
+{
+    // Assume HUGE_VAL is infinity. Strictly speaking, may not always be true.
+    EXPECT_EQ( cvIsInf((float) HUGE_VAL), 1);
+    EXPECT_EQ( cvIsInf((float) -HUGE_VAL), 1);
+    EXPECT_EQ( cvIsInf(0.0f), 0);
+    EXPECT_EQ( cvIsInf((double) HUGE_VAL), 1);
+    EXPECT_EQ( cvIsInf((double) -HUGE_VAL), 1);
+    EXPECT_EQ( cvIsInf(0.0), 0);
+}
+
 }} // namespace
 /* End of file. */


### PR DESCRIPTION
Optimize fast_math.hpp primitives for P8+ and GCC based systems.

Leverage compiler builtins to implement most rounding primitives. This should allow the compiler to choose more efficient instructions for the target architecture. PPC has dedicated rounding instructions. Hopefully this also carries over to other architectures too.

Notably, __builtin_lrint{,f} functions just call out to libm. Instead, include an inline solution similar to ARM.

This reduces the testing time by 200-300 seconds on POWER9.

```
allow_multiple_commits=1
```