### PR TITLE
fix compile issue for libstdc++

### DIFF
--- a/modules/core/src/system.cpp
+++ b/modules/core/src/system.cpp
@@ -44,6 +44,7 @@
 #include "precomp.hpp"
 #include <iostream>
 #include <ostream>
+#include <unistd.h>
 
 #include <opencv2/core/utils/configuration.private.hpp>
 #include <opencv2/core/utils/trace.private.hpp>


### PR DESCRIPTION
 when build with cxx flag "-stdlib=libstdc++" :

    opencv/modules/core/src/system.cpp:907:13: error: 'close' was not declared in this scope
         close(fd);

<!-- Please use this line to close one or multiple issues when this pullrequest gets merged
You can add another line right under the first one:
resolves #1234
resolves #1235
-->

### This pullrequest changes

<!-- Please describe what your pullrequest is changing -->
