### PR TITLE
release: OpenCV 4.1.1

### DIFF
--- a/modules/core/include/opencv2/core/version.hpp
+++ b/modules/core/include/opencv2/core/version.hpp
@@ -8,7 +8,7 @@
 #define CV_VERSION_MAJOR    4
 #define CV_VERSION_MINOR    1
 #define CV_VERSION_REVISION 1
-#define CV_VERSION_STATUS   "-pre"
+#define CV_VERSION_STATUS   ""
 
 #define CVAUX_STR_EXP(__A)  #__A
 #define CVAUX_STR(__A)      CVAUX_STR_EXP(__A)


### PR DESCRIPTION
relates #14861

<cut/>

<details>

<summary>VirusTotal scan results:</summary>

[opencv_world411.dll (vc14)](https://www.virustotal.com/gui/file/9407bea21800a271e0e2d8029dcd4c9ede754f9ddea6d22bdfbae5c53d9b299c/detection) (1 detection, [considered false positive](https://stackoverflow.com/questions/54052224/virustotal-trapmine-suspicious-low-ml-score) - 2019-07-26)
[opencv_world411d.dll (vc14)](https://www.virustotal.com/gui/file/9a5bf11687a6d704f7cfa6ac4fac3b80bc18d9b5a178afb3bc4a3a6f865796ce/detection) (1 detection, [considered false positive](https://stackoverflow.com/questions/54052224/virustotal-trapmine-suspicious-low-ml-score) - 2019-07-26)
[opencv_world411.dll (vc15)](https://www.virustotal.com/gui/file/27b406d9d2c1985375f698c564382bd64f23ffa42e58d0974320acdbf8ddfd45/detection)
[opencv_world411d.dll (vc15)](https://www.virustotal.com/gui/file/92230148ebddcc1a6643a5b531105bd85c7489c3f53ecc2cf97d1e7ba4b09ead/detection) (1 detection, [considered false positive](https://stackoverflow.com/questions/54052224/virustotal-trapmine-suspicious-low-ml-score) - 2019-07-26)

[opencv_videoio_ffmpeg411_64.dll](https://www.virustotal.com/gui/file/e684107ba1ff8a6984a3bd0ad90db25407281b001d0d497fbfa5d48bd4979a8b/detection)
[opencv_videoio_ffmpeg411.dll](https://www.virustotal.com/gui/file/f4ba2a8e6ad86855e9539e45925b3cb49456d3af74b4368ec1814e748301ddb9/detection)

</details>