### PR TITLE
Add support for slice from ONNX with multiple outputs

### DIFF
--- a/modules/dnn/test/test_onnx_importer.cpp
+++ b/modules/dnn/test/test_onnx_importer.cpp
@@ -348,6 +348,13 @@ TEST_P(Test_ONNX_layers, Softmax)
     testONNXModels("log_softmax", npy, 0, 0, false, false);
 }
 
+TEST_P(Test_ONNX_layers, Split_EltwiseMax)
+{
+    if (backend == DNN_BACKEND_INFERENCE_ENGINE)
+        applyTestTag(CV_TEST_TAG_DNN_SKIP_IE);
+    testONNXModels("split_max");
+}
+
 INSTANTIATE_TEST_CASE_P(/*nothing*/, Test_ONNX_layers, dnnBackendsAndTargets());
 
 class Test_ONNX_nets : public Test_ONNX_layers


### PR DESCRIPTION
<!-- Please use this line to close one or multiple issues when this pullrequest gets merged
You can add another line right under the first one:
resolves #1234
resolves #1235
-->

### This pullrequest changes

resolves https://github.com/opencv/opencv/issues/15120

**Merge with extra**: https://github.com/opencv/opencv_extra/pull/651

```
force_builders=Custom,Custom Win,Custom Mac
build_image:Custom=ubuntu-openvino-2019r1:16.04
build_image:Custom Win=openvino-2019r2.0
build_image:Custom Mac=openvino-2019r2.0

test_modules:Custom=dnn,python2,python3,java
test_modules:Custom Win=dnn,python2,python3,java
test_modules:Custom Mac=dnn,python2,python3,java

buildworker:Custom=linux-1
test_opencl:Custom=ON
test_bigdata:Custom=1
test_filter:Custom=*
```