### PR TITLE
Remove VGG16 from ONNX test because there is VGG16_bn

### DIFF
--- a/modules/dnn/test/test_onnx_importer.cpp
+++ b/modules/dnn/test/test_onnx_importer.cpp
@@ -426,14 +426,6 @@ TEST_P(Test_ONNX_nets, RCNN_ILSVRC13)
     testONNXModels("rcnn_ilsvrc13", pb, 0.0045);
 }
 
-TEST_P(Test_ONNX_nets, VGG16)
-{
-    applyTestTag(CV_TEST_TAG_MEMORY_6GB);  // > 2.3Gb
-
-    // output range: [-69; 72], after Softmax [0; 0.96]
-    testONNXModels("vgg16", pb, default_l1, default_lInf, true);
-}
-
 TEST_P(Test_ONNX_nets, VGG16_bn)
 {
     applyTestTag(CV_TEST_TAG_MEMORY_6GB);  // > 2.3Gb


### PR DESCRIPTION
<!-- Please use this line to close one or multiple issues when this pullrequest gets merged
You can add another line right under the first one:
resolves #1234
resolves #1235
-->

### This pullrequest changes

-528MB of tests data

**Merge with extra**: https://github.com/opencv/opencv_extra/pull/652

VGG16_bn from ONNX is the same as VGG16 but with extra batch normalizations:

<details><summary>VGG16_bn</summary>

```
Conv
dilation : 1, 1
group : 1
kernel_size : 3, 3
pad : 1, 1, 1, 1
stride : 1, 1

BatchNormalization
epsilon : 1e-05
momentum : 0.9
spatial : 0

Relu

Conv
dilation : 1, 1
group : 1
kernel_size : 3, 3
pad : 1, 1, 1, 1
stride : 1, 1

BatchNormalization
epsilon : 1e-05
momentum : 0.9
spatial : 0

Relu

MaxPool
kernel_size : 2, 2
pad : 0, 0, 0, 0
stride : 2, 2

Conv
dilation : 1, 1
group : 1
kernel_size : 3, 3
pad : 1, 1, 1, 1
stride : 1, 1

BatchNormalization
epsilon : 1e-05
momentum : 0.9
spatial : 0

Relu

Conv
dilation : 1, 1
group : 1
kernel_size : 3, 3
pad : 1, 1, 1, 1
stride : 1, 1

BatchNormalization
epsilon : 1e-05
momentum : 0.9
spatial : 0

Relu

MaxPool
kernel_size : 2, 2
pad : 0, 0, 0, 0
stride : 2, 2

Conv
dilation : 1, 1
group : 1
kernel_size : 3, 3
pad : 1, 1, 1, 1
stride : 1, 1

BatchNormalization
epsilon : 1e-05
momentum : 0.9
spatial : 0

Relu

Conv
dilation : 1, 1
group : 1
kernel_size : 3, 3
pad : 1, 1, 1, 1
stride : 1, 1

BatchNormalization
epsilon : 1e-05
momentum : 0.9
spatial : 0

Relu

Conv
dilation : 1, 1
group : 1
kernel_size : 3, 3
pad : 1, 1, 1, 1
stride : 1, 1

BatchNormalization
epsilon : 1e-05
momentum : 0.9
spatial : 0

Relu

MaxPool
kernel_size : 2, 2
pad : 0, 0, 0, 0
stride : 2, 2

Conv
dilation : 1, 1
group : 1
kernel_size : 3, 3
pad : 1, 1, 1, 1
stride : 1, 1

BatchNormalization
epsilon : 1e-05
momentum : 0.9
spatial : 0

Relu

Conv
dilation : 1, 1
group : 1
kernel_size : 3, 3
pad : 1, 1, 1, 1
stride : 1, 1

BatchNormalization
epsilon : 1e-05
momentum : 0.9
spatial : 0

Relu

Conv
dilation : 1, 1
group : 1
kernel_size : 3, 3
pad : 1, 1, 1, 1
stride : 1, 1

BatchNormalization
epsilon : 1e-05
momentum : 0.9
spatial : 0

Relu

MaxPool
kernel_size : 2, 2
pad : 0, 0, 0, 0
stride : 2, 2

Conv
dilation : 1, 1
group : 1
kernel_size : 3, 3
pad : 1, 1, 1, 1
stride : 1, 1

BatchNormalization
epsilon : 1e-05
momentum : 0.9
spatial : 0

Relu

Conv
dilation : 1, 1
group : 1
kernel_size : 3, 3
pad : 1, 1, 1, 1
stride : 1, 1

BatchNormalization
epsilon : 1e-05
momentum : 0.9
spatial : 0

Relu

Conv
dilation : 1, 1
group : 1
kernel_size : 3, 3
pad : 1, 1, 1, 1
stride : 1, 1

BatchNormalization
epsilon : 1e-05
momentum : 0.9
spatial : 0

Relu

MaxPool
kernel_size : 2, 2
pad : 0, 0, 0, 0
stride : 2, 2

Flatten

Gemm
alpha : 1
beta : 1
transA : 0
transB : 1

Relu

Dropout
ratio : 0.5

Flatten

Gemm
alpha : 1
beta : 1
transA : 0
transB : 1

Relu

Dropout
ratio : 0.5

Flatten

Gemm
alpha : 1
beta : 1
transA : 0
transB : 1
```

</details>

<details><summary>VGG16</summary>

```
Conv
dilation : 1, 1
group : 1
kernel_size : 3, 3
pad : 1, 1, 1, 1
stride : 1, 1

Relu

Conv
dilation : 1, 1
group : 1
kernel_size : 3, 3
pad : 1, 1, 1, 1
stride : 1, 1

Relu

MaxPool
kernel_size : 2, 2
pad : 0, 0, 0, 0
stride : 2, 2

Conv
dilation : 1, 1
group : 1
kernel_size : 3, 3
pad : 1, 1, 1, 1
stride : 1, 1

Relu

Conv
dilation : 1, 1
group : 1
kernel_size : 3, 3
pad : 1, 1, 1, 1
stride : 1, 1

Relu

MaxPool
kernel_size : 2, 2
pad : 0, 0, 0, 0
stride : 2, 2

Conv
dilation : 1, 1
group : 1
kernel_size : 3, 3
pad : 1, 1, 1, 1
stride : 1, 1

Relu

Conv
dilation : 1, 1
group : 1
kernel_size : 3, 3
pad : 1, 1, 1, 1
stride : 1, 1

Relu

Conv
dilation : 1, 1
group : 1
kernel_size : 3, 3
pad : 1, 1, 1, 1
stride : 1, 1

Relu

MaxPool
kernel_size : 2, 2
pad : 0, 0, 0, 0
stride : 2, 2

Conv
dilation : 1, 1
group : 1
kernel_size : 3, 3
pad : 1, 1, 1, 1
stride : 1, 1

Relu

Conv
dilation : 1, 1
group : 1
kernel_size : 3, 3
pad : 1, 1, 1, 1
stride : 1, 1

Relu

Conv
dilation : 1, 1
group : 1
kernel_size : 3, 3
pad : 1, 1, 1, 1
stride : 1, 1

Relu

MaxPool
kernel_size : 2, 2
pad : 0, 0, 0, 0
stride : 2, 2

Conv
dilation : 1, 1
group : 1
kernel_size : 3, 3
pad : 1, 1, 1, 1
stride : 1, 1

Relu

Conv
dilation : 1, 1
group : 1
kernel_size : 3, 3
pad : 1, 1, 1, 1
stride : 1, 1

Relu

Conv
dilation : 1, 1
group : 1
kernel_size : 3, 3
pad : 1, 1, 1, 1
stride : 1, 1

Relu

MaxPool
kernel_size : 2, 2
pad : 0, 0, 0, 0
stride : 2, 2

Flatten

Gemm
alpha : 1
beta : 1
transA : 0
transB : 1

Relu

Dropout
ratio : 0.5

Flatten

Gemm
alpha : 1
beta : 1
transA : 0
transB : 1

Relu

Dropout
ratio : 0.5

Flatten

Gemm
alpha : 1
beta : 1
transA : 0
transB : 1
```

</details>