### PR TITLE
Spell correction

### DIFF
--- a/modules/objdetect/src/cascadedetect.cpp
+++ b/modules/objdetect/src/cascadedetect.cpp
@@ -558,7 +558,7 @@ bool HaarEvaluator::Feature::read(const FileNode& node, const Size& origWinSize)
     for(ri = 0; it != it_end; ++it, ri++)
     {
         FileNodeIterator it2 = (*it).begin();
-        Feature::RectWeigth& rw = rect[ri];
+        Feature::RectWeight& rw = rect[ri];
         it2 >> rw.r.x >> rw.r.y >> rw.r.width >> rw.r.height >> rw.weight;
         // input validation
         {

--- a/modules/objdetect/src/cascadedetect.hpp
+++ b/modules/objdetect/src/cascadedetect.hpp
@@ -322,7 +322,7 @@ public:
         bool tilted;
 
         enum { RECT_NUM = 3 };
-        struct RectWeigth
+        struct RectWeight
         {
             Rect r;
             float weight;


### PR DESCRIPTION
Spelling correction to commit [ac425f6](https://github.com/opencv/opencv/commit/ac425f67e4c1d0da9afb9203f0918d8d57c067ed)