### PR TITLE
Make sure to use defined(__GNUC__) instead of bare __GNUC__ in flann2…

### DIFF
--- a/modules/flann/include/opencv2/flann/dist.h
+++ b/modules/flann/include/opencv2/flann/dist.h
@@ -441,7 +441,7 @@ struct Hamming
             result = vgetq_lane_s32 (vreinterpretq_s32_u64(bitSet2),0);
             result += vgetq_lane_s32 (vreinterpretq_s32_u64(bitSet2),2);
         }
-#elif __GNUC__
+#elif defined(__GNUC__)
         {
             //for portability just use unsigned long -- and use the __builtin_popcountll (see docs for __builtin_popcountll)
             typedef unsigned long long pop_t;


### PR DESCRIPTION
… dist.h header.





### This pullrequest changes

This fixes a build error on MSVC with Unreal Engine (at least).
```
error C4668: '__GNUC__' is not defined as a preprocessor macro, replacing with '0' for '#if/#elif'
```
