### PR TITLE
java: fix Mat.toString() for higher dimensions

### DIFF
--- a/modules/core/misc/java/src/java/core+Mat.java
+++ b/modules/core/misc/java/src/java/core+Mat.java
@@ -954,8 +954,11 @@ public class Mat {
     // javadoc:Mat::toString()
     @Override
     public String toString() {
-        return "Mat [ " +
-                rows() + "*" + cols() + "*" + CvType.typeToString(type()) +
+        String _dims = (dims() > 0) ? "" : "-1*-1*";
+        for (int i=0; i<dims(); i++) {
+            _dims += size(i) + "*";
+        }
+        return "Mat [ " + _dims + CvType.typeToString(type()) +
                 ", isCont=" + isContinuous() + ", isSubmat=" + isSubmatrix() +
                 ", nativeObj=0x" + Long.toHexString(nativeObj) +
                 ", dataAddr=0x" + Long.toHexString(dataAddr()) +


### PR DESCRIPTION
 see #12520 or #10802
resolve some confusion from toString(), where Mat's with more than 2 dims (e.g.: dnn blobs) would show up like `[-1*-1*CV_32F` in the output.

expected outcome:
```
Mat m = new Mat(20,22,CvType.CV_32F);
[java] Mat [ 20*22*CV_32FC1, ....]
```

```
int siz[] = {1,2,3,4,5};
Mat m = new Mat(siz,CvType.CV_32F);
[java] Mat [ 1*2*3*4*5*CV_32FC1, ....]
```
