### PR TITLE
G-API: verify y offset and height of Fluid output ROIs

### DIFF
--- a/modules/gapi/src/backends/fluid/gfluidbackend.cpp
+++ b/modules/gapi/src/backends/fluid/gfluidbackend.cpp
@@ -565,16 +565,20 @@ void cv::gimpl::GFluidExecutable::initBufferRois(std::vector<int>& readStarts,
             auto id = m_id_map.at(d.rc);
             readStarts[id] = 0;
 
-            if (out_rois[idx] == gapi::own::Rect{})
+            const auto& out_roi = out_rois[idx];
+            if (out_roi == gapi::own::Rect{})
             {
                 rois[id] = gapi::own::Rect{ 0, 0, desc.size.width, desc.size.height };
             }
             else
             {
+                GAPI_Assert(out_roi.height > 0);
+                GAPI_Assert(out_roi.y + out_roi.height <= desc.size.height);
+
                 // Only slices are supported at the moment
-                GAPI_Assert(out_rois[idx].x == 0);
-                GAPI_Assert(out_rois[idx].width == desc.size.width);
-                rois[id] = out_rois[idx];
+                GAPI_Assert(out_roi.x == 0);
+                GAPI_Assert(out_roi.width == desc.size.width);
+                rois[id] = out_roi;
             }
 
             nodesToVisit.push(nh);

--- a/modules/gapi/test/gapi_fluid_test.cpp
+++ b/modules/gapi/test/gapi_fluid_test.cpp
@@ -752,7 +752,8 @@ INSTANTIATE_TEST_CASE_P(Fluid, NV12RoiTest,
                               ,std::make_pair(cv::Size{1920, 1080}, cv::Rect{0, 710, 1920, 270})
                               ));
 
-TEST(Fluid, UnusedNodeTest) {
+TEST(Fluid, UnusedNodeTest)
+{
     cv::GMat in;
     cv::GMat a, b, c, d;
     std::tie(a, b, c, d) = cv::gapi::split4(in);
@@ -765,6 +766,38 @@ TEST(Fluid, UnusedNodeTest) {
 
     ASSERT_NO_THROW(comp.apply(cv::gin(in_mat), cv::gout(out_mat),
         cv::compile_args(cv::gapi::core::fluid::kernels())));
+}
+
+TEST(Fluid, InvalidROIs)
+{
+    cv::GMat in;
+    cv::GMat out = cv::gapi::add(in, in);
+
+    cv::Mat in_mat(cv::Size(8, 8), CV_8UC3);
+    cv::Mat out_mat = in_mat.clone();
+    cv::randu(in_mat, cv::Scalar::all(0), cv::Scalar::all(100));
+
+    std::vector<cv::Rect> invalid_rois =
+    {
+        cv::Rect(0, 0, 1, 0),
+        cv::Rect(0, 0, 0, 1),
+        cv::Rect(1, 0, 0, 0),
+        cv::Rect(0, 1, 0, 0),
+        cv::Rect(0, out_mat.rows, out_mat.cols, out_mat.rows),
+        cv::Rect(out_mat.cols, 0, out_mat.cols, out_mat.rows),
+        cv::Rect(0, 0, out_mat.cols, 0),
+    };
+
+    const auto compile_args = [] (cv::Rect roi) {
+        return cv::compile_args(cv::gapi::core::fluid::kernels(), GFluidOutputRois{{to_own(roi)}});
+    };
+
+    for (const auto& roi : invalid_rois)
+    {
+        cv::GComputation comp(cv::GIn(in), cv::GOut(out));
+        EXPECT_THROW(comp.apply(cv::gin(in_mat), cv::gout(out_mat), compile_args(roi)),
+            std::exception);
+    }
 }
 
 } // namespace opencv_test

--- a/modules/gapi/test/gapi_fluid_test.cpp
+++ b/modules/gapi/test/gapi_fluid_test.cpp
@@ -804,13 +804,14 @@ TEST(Fluid, InvalidROIs)
 
     std::vector<cv::Rect> invalid_rois =
     {
-        cv::Rect(0, 0, 1, 0),
-        cv::Rect(0, 0, 0, 1),
         cv::Rect(1, 0, 0, 0),
         cv::Rect(0, 1, 0, 0),
+        cv::Rect(0, 0, 1, 0),
+        cv::Rect(0, 0, 0, 1),
+        cv::Rect(0, 0, out_mat.cols, 0),
+        cv::Rect(0, 0, 0, out_mat.rows),
         cv::Rect(0, out_mat.rows, out_mat.cols, out_mat.rows),
         cv::Rect(out_mat.cols, 0, out_mat.cols, out_mat.rows),
-        cv::Rect(0, 0, out_mat.cols, 0),
     };
 
     const auto compile_args = [] (cv::Rect roi) {


### PR DESCRIPTION
### This pullrequest

- Adds sanity checks for GFluidOutputRois
- Tests that invalid ROIs provided result in an exception throw
