### PR TITLE
Support building shared libraries on WINCE

### DIFF
--- a/cmake/templates/dllmain.cpp.in
+++ b/cmake/templates/dllmain.cpp.in
@@ -18,11 +18,17 @@ namespace cv {
 extern __declspec(dllimport) bool __termination;  // Details: #12750
 }
 
-extern "C"
-BOOL WINAPI DllMain(HINSTANCE, DWORD fdwReason, LPVOID lpReserved);
+#ifdef _WIN32_WCE
+#define DLL_MAIN_ARG0 HANDLE
+#else
+#define DLL_MAIN_ARG0 HINSTANCE
+#endif
 
 extern "C"
-BOOL WINAPI DllMain(HINSTANCE, DWORD fdwReason, LPVOID lpReserved)
+BOOL WINAPI DllMain(DLL_MAIN_ARG0, DWORD fdwReason, LPVOID lpReserved);
+
+extern "C"
+BOOL WINAPI DllMain(DLL_MAIN_ARG0, DWORD fdwReason, LPVOID lpReserved)
 {
     if (fdwReason == DLL_THREAD_DETACH || fdwReason == DLL_PROCESS_DETACH)
     {

--- a/modules/core/src/glob.cpp
+++ b/modules/core/src/glob.cpp
@@ -139,7 +139,7 @@ const char dir_separators[] = "/";
 
 static bool isDir(const cv::String& path, DIR* dir)
 {
-#if defined _WIN32 || defined WINCE
+#if defined _WIN32 || defined _WIN32_WCE
     DWORD attributes;
     BOOL status = TRUE;
     if (dir)
@@ -147,7 +147,7 @@ static bool isDir(const cv::String& path, DIR* dir)
     else
     {
         WIN32_FILE_ATTRIBUTE_DATA all_attrs;
-#ifdef WINRT
+#if defined WINRT || defined _WIN32_WCE
         wchar_t wpath[MAX_PATH];
         size_t copied = mbstowcs(wpath, path.c_str(), MAX_PATH);
         CV_Assert((copied != MAX_PATH) && (copied != (size_t)-1));

--- a/modules/core/src/utils/datafile.cpp
+++ b/modules/core/src/utils/datafile.cpp
@@ -115,13 +115,20 @@ static cv::String getModuleLocation(const void* addr)
 #endif
     if (m)
     {
-        char path[MAX_PATH];
-        const size_t path_size = sizeof(path)/sizeof(*path);
-        size_t sz = GetModuleFileNameA(m, path, path_size); // no unicode support
+        TCHAR path[MAX_PATH];
+        const size_t path_size = sizeof(path) / sizeof(*path);
+        size_t sz = GetModuleFileName(m, path, path_size);
         if (sz > 0 && sz < path_size)
         {
-            path[sz] = '\0';
+            path[sz] = TCHAR('\0');
+#ifdef _UNICODE
+            char char_path[MAX_PATH];
+            size_t copied = wcstombs(char_path, path, MAX_PATH);
+            CV_Assert((copied != MAX_PATH) && (copied != (size_t)-1));
+            return cv::String(char_path);
+#else
             return cv::String(path);
+#endif
         }
     }
 #elif defined(__linux__)

--- a/platforms/wince/arm-wince-headless-overrides.cmake
+++ b/platforms/wince/arm-wince-headless-overrides.cmake
@@ -3,10 +3,10 @@ if(WINCE)
   # Try_Compile succeed and therefore also C/C++ ABI Detetection work
   # https://gitlab.kitware.com/cmake/cmake/blob/master/Modules/Platform/Windows-
   # MSVC.cmake
-  set(CMAKE_C_STANDARD_LIBRARIES_INIT "coredll.lib")
+  set(CMAKE_C_STANDARD_LIBRARIES_INIT "coredll.lib oldnames.lib")
   set(CMAKE_CXX_STANDARD_LIBRARIES_INIT ${CMAKE_C_STANDARD_LIBRARIES_INIT})
   foreach(ID EXE SHARED MODULE)
     string(APPEND CMAKE_${ID}_LINKER_FLAGS_INIT
-           " /NODEFAULTLIB:libc.lib /NODEFAULTLIB:oldnames.lib")
+           " /NODEFAULTLIB:libc.lib")
   endforeach()
 endif()

--- a/platforms/wince/readme.md
+++ b/platforms/wince/readme.md
@@ -57,6 +57,14 @@ For headless WEC2013, this configuration may not be limited to but is known to w
 -DWITH_TIFF=OFF `
 ```
 
+## Configuring to build as shared
+Building OpenCV as shared libraries is as easy as appending
+```
+-DBUILD_SHARED_LIBS=ON `
+-DBUILD_ZLIB=ON
+```
+to the build configuration.
+
 ## Building
 You are required to build using Unicode:
 `cmake --build . -- /p:CharacterSet=Unicode`


### PR DESCRIPTION
# This pullrequest changes

This PR adds support to build OpenCV as a shared libraries by

* Adding UNICODE support for getModuleFileName and GetFileAttributesEx methods
* Adding OLDNAMES.lib to properly map zlib open/close/write calls to Windows _ prefixed names
* Add proper DllMain entry as this differs on WINCE and cannot be overridden
* Update README for building shared libraries on WINCE

 