### PR TITLE
Fix build for UWP

### DIFF
--- a/cmake/OpenCVModule.cmake
+++ b/cmake/OpenCVModule.cmake
@@ -1175,7 +1175,7 @@ function(ocv_add_perf_tests)
         set_target_properties(${the_target} PROPERTIES FOLDER "tests performance")
       endif()
 
-      if(WINRT AND BUILD_TESTS)
+      if(WINRT)
         # removing APPCONTAINER from tests to run from console
         # look for detailed description inside of ocv_create_module macro above
         add_custom_command(TARGET "opencv_perf_${name}"

--- a/cmake/OpenCVModule.cmake
+++ b/cmake/OpenCVModule.cmake
@@ -852,7 +852,7 @@ macro(ocv_create_module)
     set(the_module_target ${the_module})
   endif()
 
-  if(WINRT)
+  if(WINRT AND BUILD_TESTS)
     # removing APPCONTAINER from modules to run from console
     # in case of usual starting of WinRT test apps output is missing
     # so starting of console version w/o APPCONTAINER is required to get test results
@@ -1175,7 +1175,7 @@ function(ocv_add_perf_tests)
         set_target_properties(${the_target} PROPERTIES FOLDER "tests performance")
       endif()
 
-      if(WINRT)
+      if(WINRT AND BUILD_TESTS)
         # removing APPCONTAINER from tests to run from console
         # look for detailed description inside of ocv_create_module macro above
         add_custom_command(TARGET "opencv_perf_${name}"

--- a/modules/core/src/utils/datafile.cpp
+++ b/modules/core/src/utils/datafile.cpp
@@ -108,7 +108,7 @@ static cv::String getModuleLocation(const void* addr)
     CV_UNUSED(addr);
 #ifdef _WIN32
     HMODULE m = 0;
-#if _WIN32_WINNT >= 0x0501
+#if _WIN32_WINNT >= 0x0501 && (!defined(WINAPI_FAMILY) || (WINAPI_FAMILY == WINAPI_FAMILY_DESKTOP_APP))
     ::GetModuleHandleEx(GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS | GET_MODULE_HANDLE_EX_FLAG_UNCHANGED_REFCOUNT,
         reinterpret_cast<LPCTSTR>(addr),
         &m);
@@ -155,7 +155,7 @@ bool getBinLocation(std::wstring& dst)
 {
     void* addr = (void*)getModuleLocation; // using code address, doesn't work with static linkage!
     HMODULE m = 0;
-#if _WIN32_WINNT >= 0x0501
+#if _WIN32_WINNT >= 0x0501 && (!defined(WINAPI_FAMILY) || (WINAPI_FAMILY == WINAPI_FAMILY_DESKTOP_APP))
     ::GetModuleHandleEx(GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS | GET_MODULE_HANDLE_EX_FLAG_UNCHANGED_REFCOUNT,
         reinterpret_cast<LPCTSTR>(addr),
         &m);

--- a/modules/videoio/src/cap_winrt/CaptureFrameGrabber.cpp
+++ b/modules/videoio/src/cap_winrt/CaptureFrameGrabber.cpp
@@ -94,7 +94,7 @@ Media::CaptureFrameGrabber::~CaptureFrameGrabber()
 
 void Media::CaptureFrameGrabber::ShowCameraSettings()
 {
-#if WINAPI_FAMILY!=WINAPI_FAMILY_PHONE_APP
+#if (WINAPI_FAMILY != WINAPI_FAMILY_PHONE_APP) && (WINAPI_FAMILY != WINAPI_FAMILY_PC_APP)
     if (_state == State::Started)
     {
         CameraOptionsUI::Show(_capture.Get());


### PR DESCRIPTION
resolves #14388 

### This pullrequest changes

This PR contains some fixes to enable building OpenCV for UWP, these are issues that we came across while trying to package OpenCV for **vcpkg** (https://github.com/microsoft/vcpkg/pull/5169).

* Fixes build for UWP by guarding calls to invalid code.
* Fixes build for `videoio` module in UWP.
* Only remove the `/APPCONTAINER` linker flag when building tests in order to produce correct DLLs in UWP.