### PR TITLE
G-API: Introduce Streaming API

### DIFF
--- a/modules/gapi/CMakeLists.txt
+++ b/modules/gapi/CMakeLists.txt
@@ -133,5 +133,11 @@ if(TARGET opencv_test_gapi)
   target_link_libraries(opencv_test_gapi PRIVATE ade)
 endif()
 
+if(MSVC)
+  # Disable obsollete warning C4503 popping up on MSVC <<2017
+  # https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4503?view=vs-2019
+  set_target_properties(${the_module} PROPERTIES COMPILE_FLAGS "/wd4503")
+endif()
+
 ocv_add_perf_tests()
 ocv_add_samples()

--- a/modules/gapi/CMakeLists.txt
+++ b/modules/gapi/CMakeLists.txt
@@ -17,7 +17,9 @@ endif()
 
 set(the_description "OpenCV G-API Core Module")
 
-ocv_add_module(gapi opencv_imgproc)
+## FIXME: This is a huge dependency!
+ocv_add_module(gapi opencv_imgproc opencv_videoio)
+
 
 file(GLOB gapi_ext_hdrs
     "${CMAKE_CURRENT_LIST_DIR}/include/opencv2/*.hpp"
@@ -57,6 +59,7 @@ set(gapi_srcs
     src/compiler/gislandmodel.cpp
     src/compiler/gcompiler.cpp
     src/compiler/gcompiled.cpp
+    src/compiler/gstreaming.cpp
     src/compiler/passes/helpers.cpp
     src/compiler/passes/dump_dot.cpp
     src/compiler/passes/islands.cpp
@@ -66,9 +69,11 @@ set(gapi_srcs
     src/compiler/passes/transformations.cpp
     src/compiler/passes/pattern_matching.cpp
     src/compiler/passes/perform_substitution.cpp
+    src/compiler/passes/streaming.cpp
 
     # Executor
     src/executor/gexecutor.cpp
+    src/executor/gstreamingexecutor.cpp
     src/executor/gasync.cpp
 
     # CPU Backend (currently built-in)

--- a/modules/gapi/CMakeLists.txt
+++ b/modules/gapi/CMakeLists.txt
@@ -17,8 +17,7 @@ endif()
 
 set(the_description "OpenCV G-API Core Module")
 
-## FIXME: This is a huge dependency!
-ocv_add_module(gapi opencv_imgproc opencv_videoio)
+ocv_add_module(gapi opencv_imgproc)
 
 
 file(GLOB gapi_ext_hdrs

--- a/modules/gapi/CMakeLists.txt
+++ b/modules/gapi/CMakeLists.txt
@@ -32,6 +32,7 @@ file(GLOB gapi_ext_hdrs
     "${CMAKE_CURRENT_LIST_DIR}/include/opencv2/${name}/fluid/*.hpp"
     "${CMAKE_CURRENT_LIST_DIR}/include/opencv2/${name}/own/*.hpp"
     "${CMAKE_CURRENT_LIST_DIR}/include/opencv2/${name}/infer/*.hpp"
+    "${CMAKE_CURRENT_LIST_DIR}/include/opencv2/${name}/streaming/*.hpp"
     )
 
 set(gapi_srcs

--- a/modules/gapi/cmake/standalone.cmake
+++ b/modules/gapi/cmake/standalone.cmake
@@ -39,6 +39,9 @@ if(MSVC)
   target_compile_options(${FLUID_TARGET} PUBLIC "/wd4251")
   target_compile_options(${FLUID_TARGET} PUBLIC "/wd4275")
   target_compile_definitions(${FLUID_TARGET} PRIVATE _CRT_SECURE_NO_DEPRECATE)
+  # Disable obsollete warning C4503 popping up on MSVC <<2017
+  # https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4503?view=vs-2019
+  set_target_properties(${FLUID_TARGET} PROPERTIES COMPILE_FLAGS "/wd4503")
 endif()
 
 target_link_libraries(${FLUID_TARGET} PRIVATE ade)

--- a/modules/gapi/include/opencv2/gapi/core.hpp
+++ b/modules/gapi/include/opencv2/gapi/core.hpp
@@ -484,6 +484,12 @@ namespace core {
             return (ddepth < 0 ? in : in.withDepth(ddepth));
         }
     };
+
+    G_TYPED_KERNEL(GCopy, <GMat(GMat)>, "org.opencv.core.copy") {
+        static GMatDesc outMeta(GMatDesc in) {
+            return in;
+        }
+    };
 }
 
 //! @addtogroup gapi_math
@@ -1653,6 +1659,8 @@ number of channels as src and the depth =ddepth.
 GAPI_EXPORTS GMat normalize(const GMat& src, double alpha, double beta,
                             int norm_type, int ddepth = -1);
 //! @} gapi_transform
+
+GAPI_EXPORTS GMat copy(const GMat& src);
 
 } //namespace gapi
 } //namespace cv

--- a/modules/gapi/include/opencv2/gapi/core.hpp
+++ b/modules/gapi/include/opencv2/gapi/core.hpp
@@ -436,6 +436,7 @@ namespace core {
         }
     };
 
+    // TODO: eliminate the need in this kernel (streaming)
     G_TYPED_KERNEL(GCrop, <GMat(GMat, Rect)>, "org.opencv.core.transform.crop") {
         static GMatDesc outMeta(GMatDesc in, Rect rc) {
             return in.withSize(Size(rc.width, rc.height));
@@ -482,13 +483,6 @@ namespace core {
         static GMatDesc outMeta(GMatDesc in, double, double, int, int ddepth) {
             // unlike opencv doesn't have a mask as a parameter
             return (ddepth < 0 ? in : in.withDepth(ddepth));
-        }
-    };
-
-    // TODO: eliminate the need in this kernel (streaming)
-    G_TYPED_KERNEL(GCopy, <GMat(GMat)>, "org.opencv.core.copy") {
-        static GMatDesc outMeta(GMatDesc in) {
-            return in;
         }
     };
 }
@@ -1512,11 +1506,11 @@ Output matrix must be of the same depth as input one, size is specified by given
 */
 GAPI_EXPORTS GMat crop(const GMat& src, const Rect& rect);
 
-/** @brief Copies a 2D matrix.
+/** @brief Copies a matrix.
 
-The function copies the matrix.
-
-Output matrix must be of the same size and depth as input one.
+Copies an input array. Works as a regular Mat::clone but happens in-graph.
+Mainly is used to workaround some existing limitations (e.g. to forward an input frame to outputs
+in the streaming mode). Will be deprecated and removed in the future.
 
 @note Function textual ID is "org.opencv.core.transform.copy"
 
@@ -1660,19 +1654,6 @@ number of channels as src and the depth =ddepth.
 GAPI_EXPORTS GMat normalize(const GMat& src, double alpha, double beta,
                             int norm_type, int ddepth = -1);
 //! @} gapi_transform
-
-/** @brief Makes a copy of an input array.
-
-Copies an input array. Works as a regular Mat::clone but happens in-graph.
-Mainly is used to workaround some existing limitations (e.g. to forward an input frame to outputs
-in the streaming mode). Will be deprecated and removed in the future.
-
-@note Function textual ID is "org.opencv.core.copy"
-
-@param src input array (of any valid type).
-@sa Mat::clone
-*/
-GAPI_EXPORTS GMat copy(const GMat& src);
 
 } //namespace gapi
 } //namespace cv

--- a/modules/gapi/include/opencv2/gapi/core.hpp
+++ b/modules/gapi/include/opencv2/gapi/core.hpp
@@ -485,6 +485,7 @@ namespace core {
         }
     };
 
+    // TODO: eliminate the need in this kernel (streaming)
     G_TYPED_KERNEL(GCopy, <GMat(GMat)>, "org.opencv.core.copy") {
         static GMatDesc outMeta(GMatDesc in) {
             return in;
@@ -1660,6 +1661,17 @@ GAPI_EXPORTS GMat normalize(const GMat& src, double alpha, double beta,
                             int norm_type, int ddepth = -1);
 //! @} gapi_transform
 
+/** @brief Makes a copy of an input array.
+
+Copies an input array. Works as a regular Mat::clone but happens in-graph.
+Mainly is used to workaround some existing limitations (e.g. to forward an input frame to outputs
+in the streaming mode). Will be deprecated and removed in the future.
+
+@note Function textual ID is "org.opencv.core.copy"
+
+@param src input array (of any valid type).
+@sa Mat::clone
+*/
 GAPI_EXPORTS GMat copy(const GMat& src);
 
 } //namespace gapi

--- a/modules/gapi/include/opencv2/gapi/garg.hpp
+++ b/modules/gapi/include/opencv2/gapi/garg.hpp
@@ -24,6 +24,8 @@
 #include <opencv2/gapi/gmetaarg.hpp>
 #include <opencv2/gapi/own/scalar.hpp>
 
+#include <opencv2/gapi/streaming/cap.hpp>
+
 namespace cv {
 
 class GArg;
@@ -92,6 +94,7 @@ using GRunArg  = util::variant<
     cv::Scalar,
     cv::UMat,
 #endif // !defined(GAPI_STANDALONE)
+    cv::gapi::GVideoCapture, // FIXME: How bad it is?
     cv::gapi::own::Mat,
     cv::gapi::own::Scalar,
     cv::detail::VectorRef

--- a/modules/gapi/include/opencv2/gapi/garg.hpp
+++ b/modules/gapi/include/opencv2/gapi/garg.hpp
@@ -23,8 +23,7 @@
 #include <opencv2/gapi/gtype_traits.hpp>
 #include <opencv2/gapi/gmetaarg.hpp>
 #include <opencv2/gapi/own/scalar.hpp>
-
-#include <opencv2/gapi/streaming/cap.hpp>
+#include <opencv2/gapi/streaming/source.hpp>
 
 namespace cv {
 
@@ -94,12 +93,32 @@ using GRunArg  = util::variant<
     cv::Scalar,
     cv::UMat,
 #endif // !defined(GAPI_STANDALONE)
-    cv::gapi::GVideoCapture, // FIXME: How bad it is?
+    cv::gapi::wip::IStreamSource::Ptr,
     cv::gapi::own::Mat,
     cv::gapi::own::Scalar,
     cv::detail::VectorRef
     >;
 using GRunArgs = std::vector<GRunArg>;
+
+namespace gapi
+{
+namespace wip
+{
+/**
+ * @brief This aggregate type represents all types which G-API can handle (via variant).
+ *
+ * It only exists to overcome C++ language limitations (where a `using`-defined class can't be forward-declared).
+ */
+struct Data: public GRunArg
+{
+    using GRunArg::GRunArg;
+    template <typename T>
+    Data& operator= (const T& t) { GRunArg::operator=(t); return *this; }
+    template <typename T>
+    Data& operator= (T&& t) { GRunArg::operator=(std::move(t)); return *this; }
+};
+} // namespace wip
+} // namespace gapi
 
 using GRunArgP = util::variant<
 #if !defined(GAPI_STANDALONE)
@@ -112,7 +131,6 @@ using GRunArgP = util::variant<
     cv::detail::VectorRef
     >;
 using GRunArgsP = std::vector<GRunArgP>;
-
 
 template<typename... Ts> inline GRunArgs gin(const Ts&... args)
 {

--- a/modules/gapi/include/opencv2/gapi/garray.hpp
+++ b/modules/gapi/include/opencv2/gapi/garray.hpp
@@ -228,14 +228,6 @@ namespace detail
         }
 
     public:
-        const BasicVectorRef* inspect() const {
-            return  m_ref.get();
-        }
-
-        void mov(VectorRef &v) {
-            m_ref->mov(*v.m_ref);
-        }
-
         VectorRef() = default;
         template<typename T> explicit VectorRef(const std::vector<T>& vec) : m_ref(new VectorRefT<T>(vec)) {}
         template<typename T> explicit VectorRef(std::vector<T>& vec)       : m_ref(new VectorRefT<T>(vec)) {}
@@ -259,6 +251,11 @@ namespace detail
         {
             check<T>();
             return static_cast<VectorRefT<T>&>(*m_ref).rref();
+        }
+
+        void mov(VectorRef &v)
+        {
+            m_ref->mov(*v.m_ref);
         }
 
         cv::GArrayDesc descr_of() const
@@ -297,9 +294,7 @@ public:
     explicit GArray(detail::GArrayU &&ref) // GArrayU-based constructor
         : m_ref(ref) { putDetails(); }     //   (used by GCall, not for users)
 
-    detail::GArrayU strip() const {
-        return m_ref;
-    }
+    detail::GArrayU strip() const { return m_ref; }
 
 private:
     // Host type (or Flat type) - the type this GArray is actually

--- a/modules/gapi/include/opencv2/gapi/garray.hpp
+++ b/modules/gapi/include/opencv2/gapi/garray.hpp
@@ -118,7 +118,7 @@ namespace detail
         virtual void mov(BasicVectorRef &ref) = 0;
     };
 
-    template<typename T> class VectorRefT: public BasicVectorRef
+    template<typename T> class VectorRefT final: public BasicVectorRef
     {
         using empty_t  = util::monostate;
         using ro_ext_t = const std::vector<T> *;
@@ -203,7 +203,7 @@ namespace detail
             util::throw_error(std::logic_error("Impossible happened"));
         }
 
-        virtual void mov(BasicVectorRef &v) {
+        virtual void mov(BasicVectorRef &v) override {
             VectorRefT<T> *tv = dynamic_cast<VectorRefT<T>*>(&v);
             GAPI_Assert(tv != nullptr);
             wref() = std::move(tv->wref());

--- a/modules/gapi/include/opencv2/gapi/gcompiled.hpp
+++ b/modules/gapi/include/opencv2/gapi/gcompiled.hpp
@@ -60,6 +60,8 @@ namespace cv {
  * At the same time, two different GCompiled objects produced from the
  * single cv::GComputation are completely independent and can be used
  * concurrently.
+ *
+ * @sa GStreamingCompiled
  */
 class GAPI_EXPORTS GCompiled
 {

--- a/modules/gapi/include/opencv2/gapi/gcomputation.hpp
+++ b/modules/gapi/include/opencv2/gapi/gcomputation.hpp
@@ -399,9 +399,42 @@ public:
     // FIXME: Document properly in the Doxygen format
     // Video-oriented pipeline compilation:
     // 1. A generic version
+    /**
+     * @brief Compile the computation for streaming mode.
+     *
+     * This method triggers compilation process and produces a new
+     * GStreamingCompiled object which then can process video stream
+     * data of the given format. Passing a stream in a different
+     * format to the compiled computation will generate a run-time
+     * exception.
+     *
+     * @param in_metas vector of input metadata configuration. Grab
+     * metadata from real data objects (like cv::Mat or cv::Scalar)
+     * using cv::descr_of(), or create it on your own.  @param args
+     * compilation arguments for this compilation process. Compilation
+     * arguments directly affect what kind of executable object would
+     * be produced, e.g. which kernels (and thus, devices) would be
+     * used to execute computation.
+     *
+     * @return GStreamingCompiled, a streaming-oriented executable
+     * computation compiled specifically for the given input
+     * parameters.
+     *
+     * @sa @ref gapi_compile_args
+     */
     GStreamingCompiled compileStreaming(GMetaArgs &&in_metas, GCompileArgs &&args = {});
 
     // 2. Direct metadata version
+    /**
+     * @overload
+     *
+     * Takes a variadic parameter pack with metadata
+     * descriptors for which a compiled object needs to be produced.
+     *
+     * @return GStreamingCompiled, a streaming-oriented executable
+     * computation compiled specifically for the given input
+     * parameters.
+     */
     template<typename... Ts>
     auto compileStreaming(const Ts&... metas) ->
         typename std::enable_if<detail::are_meta_descrs<Ts...>::value, GStreamingCompiled>::type
@@ -410,6 +443,18 @@ public:
     }
 
     // 2. Direct metadata + compile arguments version
+    /**
+     * @overload
+     *
+     * Takes a  variadic parameter pack with metadata
+     * descriptors for which a compiled object needs to be produced,
+     * followed by GCompileArgs object representing compilation
+     * arguments for this process.
+     *
+     * @return GStreamingCompiled, a streaming-oriented executable
+     * computation compiled specifically for the given input
+     * parameters.
+     */
     template<typename... Ts>
     auto compileStreaming(const Ts&... meta_and_compile_args) ->
         typename std::enable_if<detail::are_meta_descrs_but_last<Ts...>::value

--- a/modules/gapi/include/opencv2/gapi/gmat.hpp
+++ b/modules/gapi/include/opencv2/gapi/gmat.hpp
@@ -211,6 +211,7 @@ GAPI_EXPORTS GMatDesc descr_of(const cv::UMat &mat);
 
 /** @} */
 
+// FIXME: WHY??? WHY it is under different namespace?
 namespace gapi { namespace own {
     GAPI_EXPORTS GMatDesc descr_of(const Mat &mat);
 }}//gapi::own

--- a/modules/gapi/include/opencv2/gapi/gstreaming.hpp
+++ b/modules/gapi/include/opencv2/gapi/gstreaming.hpp
@@ -34,7 +34,20 @@ public:
      *    false marks end of the stream.
      */
     bool pull(cv::GRunArgsP &&outs);
+
+    /**
+     * @return true if data has been obtained, and
+     *    false if it was not. Note: false here doesn't
+     *    mark the end of the stream.
+     */
+    bool try_pull(cv::GRunArgsP &&outs);
+
     void stop();
+
+    /**
+     * @return true if the current stream is not over yet.
+     */
+    bool running() const;
 
     /// @private
     Priv& priv();

--- a/modules/gapi/include/opencv2/gapi/gstreaming.hpp
+++ b/modules/gapi/include/opencv2/gapi/gstreaming.hpp
@@ -1,0 +1,81 @@
+// This file is part of OpenCV project.
+// It is subject to the license terms in the LICENSE file found in the top-level directory
+// of this distribution and at http://opencv.org/license.html.
+//
+// Copyright (C) 2018 Intel Corporation
+
+
+#ifndef OPENCV_GAPI_GSTREAMING_COMPILED_HPP
+#define OPENCV_GAPI_GSTREAMING_COMPILED_HPP
+
+#include <vector>
+
+#include <opencv2/gapi/opencv_includes.hpp>
+#include <opencv2/gapi/own/assert.hpp>
+#include <opencv2/gapi/garg.hpp>
+#include <opencv2/gapi/streaming/cap.hpp>
+
+namespace cv {
+
+class GAPI_EXPORTS GStreamingCompiled
+{
+public:
+    class GAPI_EXPORTS Priv;
+    GStreamingCompiled();
+
+    // FIXME: More overloads?
+    void setSource(GRunArgs &&ins);
+    void setSource(const gapi::GVideoCapture &c);
+
+    void start();
+
+    /**
+     * @return true if next result has been obtained,
+     *    false marks end of the stream.
+     */
+    bool pull(cv::GRunArgsP &&outs);
+    void stop();
+
+    /// @private
+    Priv& priv();
+
+    /**
+     * @brief Check if compiled object is valid (non-empty)
+     *
+     * @return true if the object is runnable (valid), false otherwise
+     */
+    explicit operator bool () const;
+
+    /**
+     * @brief Vector of metadata this graph was compiled for.
+     *
+     * @return Unless _reshape_ is not supported, return value is the
+     * same vector which was passed to cv::GComputation::compile() to
+     * produce this compiled object. Otherwise, it is the latest
+     * metadata vector passed to reshape() (if that call was
+     * successful).
+     */
+    const GMetaArgs& metas() const; // Meta passed to compile()
+
+    /**
+     * @brief Vector of metadata descriptions of graph outputs
+     *
+     * @return vector with formats/resolutions of graph's output
+     * objects, auto-inferred from input metadata vector by
+     * operations which form this computation.
+     *
+     * @note GCompiled objects produced from the same
+     * cv::GComputiation graph with different input metas may return
+     * different values in this vector.
+     */
+    const GMetaArgs& outMetas() const;
+
+protected:
+    /// @private
+    std::shared_ptr<Priv> m_priv;
+};
+/** @} */
+
+}
+
+#endif // OPENCV_GAPI_GSTREAMING_COMPILED_HPP

--- a/modules/gapi/include/opencv2/gapi/gstreaming.hpp
+++ b/modules/gapi/include/opencv2/gapi/gstreaming.hpp
@@ -13,7 +13,7 @@
 #include <opencv2/gapi/opencv_includes.hpp>
 #include <opencv2/gapi/own/assert.hpp>
 #include <opencv2/gapi/garg.hpp>
-#include <opencv2/gapi/streaming/cap.hpp>
+#include <opencv2/gapi/streaming/source.hpp>
 
 namespace cv {
 
@@ -106,15 +106,20 @@ public:
      * setSource() to run the graph on a new video stream.
      *
      * @overload
-     * @param c GVideoCapture representing the input video stream.
+     * @param s a shared pointer to IStreamSource representing the
+     * input video stream.
      */
-    void setSource(const gapi::GVideoCapture &c);
+    void setSource(const gapi::wip::IStreamSource::Ptr& s);
 
     /**
      * @brief Start the pipeline execution.
      *
      * Use pull()/try_pull() to obtain data. Throws an exception if
      * a video source was not specified.
+     *
+     * setSource() must be called first, even if the pipeline has been
+     * working already and then stopped (explicitly via stop() or due
+     * stream completion)
      *
      * @note This method is not thread-safe (with respect to the user
      * side) at the moment. Protect the access if

--- a/modules/gapi/include/opencv2/gapi/gstreaming.hpp
+++ b/modules/gapi/include/opencv2/gapi/gstreaming.hpp
@@ -88,6 +88,11 @@ public:
      * Throws if pipeline is already running. Use stop() and then
      * setSource() to run the graph on a new video stream.
      *
+     * @note This method is not thread-safe (with respect to the user
+     * side) at the moment. Protect the access if
+     * start()/stop()/setSource() may be called on the same object in
+     * multiple threads in your application.
+     *
      * @param ins vector of inputs to process.
      * @sa gin
      */
@@ -110,6 +115,11 @@ public:
      *
      * Use pull()/try_pull() to obtain data. Throws an exception if
      * a video source was not specified.
+     *
+     * @note This method is not thread-safe (with respect to the user
+     * side) at the moment. Protect the access if
+     * start()/stop()/setSource() may be called on the same object in
+     * multiple threads in your application.
      */
     void start();
 
@@ -161,6 +171,11 @@ public:
 
     /**
      * @brief Test if the pipeline is running.
+     *
+     * @note This method is not thread-safe (with respect to the user
+     * side) at the moment. Protect the access if
+     * start()/stop()/setSource() may be called on the same object in
+     * multiple threads in your application.
      *
      * @return true if the current stream is not over yet.
      */

--- a/modules/gapi/include/opencv2/gapi/gtype_traits.hpp
+++ b/modules/gapi/include/opencv2/gapi/gtype_traits.hpp
@@ -15,6 +15,7 @@
 #include <opencv2/gapi/gscalar.hpp>
 #include <opencv2/gapi/garray.hpp>
 #include <opencv2/gapi/gcommon.hpp>
+#include <opencv2/gapi/streaming/cap.hpp>
 #include <opencv2/gapi/own/convert.hpp>
 
 namespace cv
@@ -95,6 +96,7 @@ namespace detail
     template<>           struct GTypeOf<cv::Mat>               { using type = cv::GMat;      };
     template<>           struct GTypeOf<cv::UMat>              { using type = cv::GMat;      };
     template<>           struct GTypeOf<cv::Scalar>            { using type = cv::GScalar;   };
+    template<>           struct GTypeOf<cv::gapi::GVideoCapture> { using type = cv::GMat;    };
 #endif // !defined(GAPI_STANDALONE)
     template<>           struct GTypeOf<cv::gapi::own::Mat>    { using type = cv::GMat;      };
     template<>           struct GTypeOf<cv::gapi::own::Scalar> { using type = cv::GScalar;   };

--- a/modules/gapi/include/opencv2/gapi/gtype_traits.hpp
+++ b/modules/gapi/include/opencv2/gapi/gtype_traits.hpp
@@ -14,8 +14,8 @@
 #include <opencv2/gapi/gmat.hpp>
 #include <opencv2/gapi/gscalar.hpp>
 #include <opencv2/gapi/garray.hpp>
+#include <opencv2/gapi/streaming/source.hpp>
 #include <opencv2/gapi/gcommon.hpp>
-#include <opencv2/gapi/streaming/cap.hpp>
 #include <opencv2/gapi/own/convert.hpp>
 
 namespace cv
@@ -96,11 +96,13 @@ namespace detail
     template<>           struct GTypeOf<cv::Mat>               { using type = cv::GMat;      };
     template<>           struct GTypeOf<cv::UMat>              { using type = cv::GMat;      };
     template<>           struct GTypeOf<cv::Scalar>            { using type = cv::GScalar;   };
-    template<>           struct GTypeOf<cv::gapi::GVideoCapture> { using type = cv::GMat;    };
 #endif // !defined(GAPI_STANDALONE)
     template<>           struct GTypeOf<cv::gapi::own::Mat>    { using type = cv::GMat;      };
     template<>           struct GTypeOf<cv::gapi::own::Scalar> { using type = cv::GScalar;   };
     template<typename U> struct GTypeOf<std::vector<U> >       { using type = cv::GArray<U>; };
+    // FIXME: This is not quite correct since IStreamSource may produce not only Mat but also Scalar
+    // and vector data. TODO: Extend the type dispatchig on these types too.
+    template<>           struct GTypeOf<cv::gapi::wip::IStreamSource::Ptr> { using type = cv::GMat;};
     template<class T> using g_type_of_t = typename GTypeOf<T>::type;
 
     // Marshalling helper for G-types and its Host types. Helps G-API

--- a/modules/gapi/include/opencv2/gapi/ocl/goclkernel.hpp
+++ b/modules/gapi/include/opencv2/gapi/ocl/goclkernel.hpp
@@ -120,7 +120,8 @@ struct tracked_cv_umat{
     //TODO Think if T - API could reallocate UMat to a proper size - how do we handle this ?
     //tracked_cv_umat(cv::UMat& m) : r{(m)}, original_data{m.getMat(ACCESS_RW).data} {}
     tracked_cv_umat(cv::UMat& m) : r{ (m) }, original_data{ nullptr } {}
-    cv::UMat r;
+    cv::UMat &r; // FIXME: It was a value (not a reference) before.
+                 // Actually OCL backend should allocate its internal data!
     uchar* original_data;
 
     operator cv::UMat& (){ return r;}

--- a/modules/gapi/include/opencv2/gapi/own/convert.hpp
+++ b/modules/gapi/include/opencv2/gapi/own/convert.hpp
@@ -28,6 +28,7 @@ namespace cv
     }
 
            cv::gapi::own::Mat to_own(Mat&&) = delete;
+
     inline cv::gapi::own::Mat to_own(Mat const& m) {
         return (m.dims == 2)
             ?  cv::gapi::own::Mat{m.rows, m.cols, m.type(), m.data, m.step}
@@ -40,7 +41,6 @@ namespace cv
     inline cv::gapi::own::Size to_own (const Size& s) { return {s.width, s.height}; };
 
     inline cv::gapi::own::Rect to_own (const Rect& r) { return {r.x, r.y, r.width, r.height}; };
-
 
 
 namespace gapi

--- a/modules/gapi/include/opencv2/gapi/streaming/cap.hpp
+++ b/modules/gapi/include/opencv2/gapi/streaming/cap.hpp
@@ -1,0 +1,30 @@
+// This file is part of OpenCV project.
+// It is subject to the license terms in the LICENSE file found in the top-level directory
+// of this distribution and at http://opencv.org/license.html.
+//
+// Copyright (C) 2019 Intel Corporation
+
+#ifndef OPENCV_GAPI_STREAMING_CAP_HPP
+#define OPENCV_GAPI_STREAMING_CAP_HPP
+
+#include <string>
+
+// FIXME: Think how it could be composed from the streaming API
+// FIXME: Make it work only if videoio module is present
+// FIXME: Think how to make it extensible from the outside
+//  (support custom video sources?)
+
+namespace cv {
+namespace gapi {
+
+// FIXME: namespace wip?
+struct GVideoCapture
+{
+    // FIXME: extend to support camera
+    std::string path;
+};
+
+} // namespace gapi
+} // namespace cv
+
+#endif // OPENCV_GAPI_STREAMING_CAP_HPP

--- a/modules/gapi/include/opencv2/gapi/streaming/cap.hpp
+++ b/modules/gapi/include/opencv2/gapi/streaming/cap.hpp
@@ -7,23 +7,72 @@
 #ifndef OPENCV_GAPI_STREAMING_CAP_HPP
 #define OPENCV_GAPI_STREAMING_CAP_HPP
 
-#include <string>
+/**
+ * YOUR ATTENTION PLEASE!
+ *
+ * This is a header-only implementation of cv::VideoCapture-based
+ * Stream source.  It is not built by default with G-API as G-API
+ * doesn't depend on videoio module.
+ *
+ * If you want to use it in your application, please make sure
+ * videioio is available in your OpenCV package and is linked to your
+ * application.
+ *
+ * Note for developers: please don't put videoio dependency in G-API
+ * because of this file.
+ */
 
-// FIXME: Think how it could be composed from the streaming API
-// FIXME: Make it work only if videoio module is present
-// FIXME: Think how to make it extensible from the outside
-//  (support custom video sources?)
+#include <opencv2/videoio.hpp>
+#include <opencv2/gapi/garg.hpp>
 
 namespace cv {
 namespace gapi {
+namespace wip {
 
-// FIXME: namespace wip?
-struct GVideoCapture
+/**
+ * @brief OpenCV's VideoCapture-based streaming source.
+ *
+ * This class implements IStreamSource interface.
+ * Its constructor takes the same parameters as cv::VideoCapture does.
+ *
+ * Please make sure that videoio OpenCV module is avaiable before using
+ * this in your application (G-API doesn't depend on it directly).
+ *
+ * @note stream sources are passed to G-API via shared pointers, so
+ *  please gapi::make_src<> to create objects and ptr() to pass a
+ *  GCaptureSource to cv::gin().
+ */
+class GCaptureSource: public IStreamSource
 {
-    // FIXME: extend to support camera
-    std::string path;
+public:
+    explicit GCaptureSource(int id) : cap(id) {}
+    explicit GCaptureSource(const std::string &path) : cap(path) {}
+
+    // TODO: Add more constructor overloads to make it
+    // fully compatible with VideoCapture's interface.
+
+protected:
+    cv::VideoCapture cap;
+    virtual bool pull(cv::gapi::wip::Data &data) override
+    {
+        if (!cap.isOpened()) return false;
+        cv::Mat frame;
+        if (!cap.read(frame))
+        {
+            // end-of-stream happened
+            return false;
+        }
+
+        // NOTE: Some decode/media VideoCapture backends continue
+        // owning the video buffer under cv::Mat so in order to
+        // process it safely in a highly concurrent pipeline, clone()
+        // is the only right way.
+        data = frame.clone();
+        return true;
+    }
 };
 
+} // namespace wip
 } // namespace gapi
 } // namespace cv
 

--- a/modules/gapi/include/opencv2/gapi/streaming/source.hpp
+++ b/modules/gapi/include/opencv2/gapi/streaming/source.hpp
@@ -1,0 +1,57 @@
+// This file is part of OpenCV project.
+// It is subject to the license terms in the LICENSE file found in the top-level directory
+// of this distribution and at http://opencv.org/license.html.
+//
+// Copyright (C) 2019 Intel Corporation
+
+#ifndef OPENCV_GAPI_STREAMING_SOURCE_HPP
+#define OPENCV_GAPI_STREAMING_SOURCE_HPP
+
+#include <memory> // shared_ptr
+#include <type_traits> // is_base_of
+
+namespace cv {
+namespace gapi {
+namespace wip {
+    struct Data; // "forward-declaration" of GRunArg
+
+/**
+ * @brief Abstract streaming pipeline source.
+ *
+ * Implement this interface if you want customize the way how data is
+ * streaming into GStreamingCompiled.
+ *
+ * Objects implementing this interface can be passes to
+ * GStreamingCompiled via setSource()/cv::gin(). Regular compiled
+ * graphs (GCompiled) don't support input objects of this type.
+ *
+ * Default cv::VideoCapture-based implementation is available, see
+ * cv::gapi::GCaptureSource.
+ *
+ * @note stream sources are passed to G-API via shared pointers, so
+ *  please use ptr() when passing a IStreamSource implementation to
+ *  cv::gin().
+ */
+class IStreamSource: public std::enable_shared_from_this<IStreamSource>
+{
+public:
+    using Ptr = std::shared_ptr<IStreamSource>;
+    Ptr ptr() { return shared_from_this(); }
+    virtual bool pull(Data &data) = 0;
+    virtual ~IStreamSource() = default;
+};
+
+template<class T, class... Args>
+IStreamSource::Ptr inline make_src(Args&&... args)
+{
+    static_assert(std::is_base_of<IStreamSource, T>::value,
+                  "T must implement the cv::gapi::IStreamSource interface!");
+    auto src_ptr = std::make_shared<T>(std::forward<Args>(args)...);
+    return src_ptr->ptr();
+}
+
+} // namespace wip
+} // namespace gapi
+} // namespace cv
+
+#endif // OPENCV_GAPI_STREAMING_SOURCE_HPP

--- a/modules/gapi/src/api/gbackend.cpp
+++ b/modules/gapi/src/api/gbackend.cpp
@@ -118,7 +118,7 @@ void bindInArg(Mag& mag, const RcDesc &rc, const GRunArg &arg, bool is_umat)
             if (is_umat)
             {
                 auto& mag_umat = mag.template slot<cv::UMat>()[rc.id];
-                mag_umat = (util::get<cv::UMat>(arg));
+                mag_umat = util::get<cv::Mat>(arg).getUMat(ACCESS_READ);
             }
             else
             {
@@ -185,7 +185,7 @@ void bindOutArg(Mag& mag, const RcDesc &rc, const GRunArgP &arg, bool is_umat)
             if (is_umat)
             {
                 auto& mag_umat = mag.template slot<cv::UMat>()[rc.id];
-                mag_umat = (*util::get<cv::UMat*>(arg));
+                mag_umat = util::get<cv::Mat*>(arg)->getUMat(ACCESS_RW);
             }
             else
             {

--- a/modules/gapi/src/api/gcomputation.cpp
+++ b/modules/gapi/src/api/gcomputation.cpp
@@ -76,6 +76,12 @@ cv::GCompiled cv::GComputation::compile(GMetaArgs &&metas, GCompileArgs &&args)
     return comp.compile();
 }
 
+cv::GStreamingCompiled cv::GComputation::compileStreaming(GMetaArgs &&metas, GCompileArgs &&args)
+{
+    cv::gimpl::GCompiler comp(*this, std::move(metas), std::move(args));
+    return comp.compileStreaming();
+}
+
 // FIXME: Introduce similar query/test method for GMetaArgs as a building block
 // for functions like this?
 static bool formats_are_same(const cv::GMetaArgs& metas1, const cv::GMetaArgs& metas2)

--- a/modules/gapi/src/api/gproto.cpp
+++ b/modules/gapi/src/api/gproto.cpp
@@ -169,6 +169,7 @@ bool cv::can_describe(const GMetaArg& meta, const GRunArg& arg)
                                                             util::get<GMatDesc>(meta).canDescribe(util::get<cv::gapi::own::Mat>(arg));
     case GRunArg::index_of<cv::gapi::own::Scalar>(): return meta == cv::GMetaArg(descr_of(util::get<cv::gapi::own::Scalar>(arg)));
     case GRunArg::index_of<cv::detail::VectorRef>(): return meta == cv::GMetaArg(util::get<cv::detail::VectorRef>(arg).descr_of());
+    case GRunArg::index_of<cv::gapi::GVideoCapture>(): return util::holds_alternative<GMatDesc>(meta); // FIXME(?) may be not the best option
     default: util::throw_error(std::logic_error("Unsupported GRunArg type"));
     }
 }

--- a/modules/gapi/src/api/gproto.cpp
+++ b/modules/gapi/src/api/gproto.cpp
@@ -169,7 +169,7 @@ bool cv::can_describe(const GMetaArg& meta, const GRunArg& arg)
                                                             util::get<GMatDesc>(meta).canDescribe(util::get<cv::gapi::own::Mat>(arg));
     case GRunArg::index_of<cv::gapi::own::Scalar>(): return meta == cv::GMetaArg(descr_of(util::get<cv::gapi::own::Scalar>(arg)));
     case GRunArg::index_of<cv::detail::VectorRef>(): return meta == cv::GMetaArg(util::get<cv::detail::VectorRef>(arg).descr_of());
-    case GRunArg::index_of<cv::gapi::GVideoCapture>(): return util::holds_alternative<GMatDesc>(meta); // FIXME(?) may be not the best option
+    case GRunArg::index_of<cv::gapi::wip::IStreamSource::Ptr>(): return util::holds_alternative<GMatDesc>(meta); // FIXME(?) may be not the best option
     default: util::throw_error(std::logic_error("Unsupported GRunArg type"));
     }
 }

--- a/modules/gapi/src/api/kernels_core.cpp
+++ b/modules/gapi/src/api/kernels_core.cpp
@@ -371,5 +371,9 @@ GMat normalize(const GMat& _src, double a, double b,
     return core::GNormalize::on(_src, a, b, norm_type, ddepth);
 }
 
+GMat copy(const cv::GMat &src) {
+    return core::GCopy::on(src);
+}
+
 } //namespace gapi
 } //namespace cv

--- a/modules/gapi/src/api/kernels_core.cpp
+++ b/modules/gapi/src/api/kernels_core.cpp
@@ -371,9 +371,5 @@ GMat normalize(const GMat& _src, double a, double b,
     return core::GNormalize::on(_src, a, b, norm_type, ddepth);
 }
 
-GMat copy(const cv::GMat &src) {
-    return core::GCopy::on(src);
-}
-
 } //namespace gapi
 } //namespace cv

--- a/modules/gapi/src/backends/cpu/gcpucore.cpp
+++ b/modules/gapi/src/backends/cpu/gcpucore.cpp
@@ -558,6 +558,14 @@ GAPI_OCV_KERNEL(GCPUNormalize, cv::gapi::core::GNormalize)
     }
 };
 
+GAPI_OCV_KERNEL(GCPUCopy, cv::gapi::core::GCopy)
+{
+    static void run(const cv::Mat& src, cv::Mat& out)
+    {
+        src.copyTo(out);
+    }
+};
+
 cv::gapi::GKernelPackage cv::gapi::core::cpu::kernels()
 {
     static auto pkg = cv::gapi::kernels
@@ -626,6 +634,7 @@ cv::gapi::GKernelPackage cv::gapi::core::cpu::kernels()
          , GCPUConvertTo
          , GCPUSqrt
          , GCPUNormalize
+         , GCPUCopy
          >();
     return pkg;
 }

--- a/modules/gapi/src/backends/cpu/gcpucore.cpp
+++ b/modules/gapi/src/backends/cpu/gcpucore.cpp
@@ -505,7 +505,7 @@ GAPI_OCV_KERNEL(GCPUCopy, cv::gapi::core::GCopy)
 {
     static void run(const cv::Mat& in, cv::Mat& out)
     {
-        cv::Mat(in).copyTo(out);
+        in.copyTo(out);
     }
 };
 
@@ -555,14 +555,6 @@ GAPI_OCV_KERNEL(GCPUNormalize, cv::gapi::core::GNormalize)
                     int norm_type, int ddepth, cv::Mat& out)
     {
         cv::normalize(src, out, a, b, norm_type, ddepth);
-    }
-};
-
-GAPI_OCV_KERNEL(GCPUCopy, cv::gapi::core::GCopy)
-{
-    static void run(const cv::Mat& src, cv::Mat& out)
-    {
-        src.copyTo(out);
     }
 };
 
@@ -634,7 +626,6 @@ cv::gapi::GKernelPackage cv::gapi::core::cpu::kernels()
          , GCPUConvertTo
          , GCPUSqrt
          , GCPUNormalize
-         , GCPUCopy
          >();
     return pkg;
 }

--- a/modules/gapi/src/backends/fluid/gfluidbackend.cpp
+++ b/modules/gapi/src/backends/fluid/gfluidbackend.cpp
@@ -1238,6 +1238,7 @@ void cv::gimpl::GFluidExecutable::reshape(ade::Graph &g, const GCompileArgs &arg
 // FIXME: Document what it does
 void cv::gimpl::GFluidExecutable::bindInArg(const cv::gimpl::RcDesc &rc, const GRunArg &arg)
 {
+    using T = GRunArg;
     switch (rc.shape)
     {
     case GShape::GMAT:
@@ -1249,11 +1250,11 @@ void cv::gimpl::GFluidExecutable::bindInArg(const cv::gimpl::RcDesc &rc, const G
         // by default instead.
         auto &bref = m_buffers[m_id_map.at(rc.id)].priv();
         switch (arg.index()) {
-        case arg.index_of<cv::gapi::own::Mat>():
+        case T::index_of<cv::gapi::own::Mat>():
             bref.bindTo(util::get<cv::gapi::own::Mat>(arg), true);
             break;
 #if !defined(GAPI_STANDALONE)
-        case arg.index_of<cv::Mat>():
+        case T::index_of<cv::Mat>():
             bref.bindTo(cv::to_own(util::get<cv::Mat>(arg)), true);
             break;
 #endif // GAPI_STANDALONE
@@ -1266,11 +1267,11 @@ void cv::gimpl::GFluidExecutable::bindInArg(const cv::gimpl::RcDesc &rc, const G
         // FIXME: See above.
         auto &sref = m_res.slot<cv::gapi::own::Scalar>()[rc.id];
         switch (arg.index()) {
-        case arg.index_of<cv::gapi::own::Scalar>():
+        case T::index_of<cv::gapi::own::Scalar>():
             sref = util::get<cv::gapi::own::Scalar>(arg);
             break;
 #if !defined(GAPI_STANDALONE)
-        case arg.index_of<cv::Scalar>():
+        case T::index_of<cv::Scalar>():
             sref = cv::to_own(util::get<cv::Scalar>(arg));
             break;
 #endif // GAPI_STANDALONE
@@ -1289,6 +1290,7 @@ void cv::gimpl::GFluidExecutable::bindInArg(const cv::gimpl::RcDesc &rc, const G
 void cv::gimpl::GFluidExecutable::bindOutArg(const cv::gimpl::RcDesc &rc, const GRunArgP &arg)
 {
     // Only GMat is supported as return type
+    using T = GRunArgP;
     switch (rc.shape)
     {
     case GShape::GMAT:
@@ -1298,14 +1300,14 @@ void cv::gimpl::GFluidExecutable::bindOutArg(const cv::gimpl::RcDesc &rc, const 
 
             switch (arg.index()) {
             // FIXME: See the bindInArg comment on Streaming-related changes
-            case arg.index_of<cv::gapi::own::Mat*>(): {
+            case T::index_of<cv::gapi::own::Mat*>(): {
                 auto &outMat = *util::get<cv::gapi::own::Mat*>(arg);
                 GAPI_Assert(outMat.data != nullptr);
                 GAPI_Assert(descr_of(outMat) == desc && "Output argument was not preallocated as it should be ?");
                 bref.bindTo(outMat, false);
             } break;
 #if !defined(GAPI_STANDALONE)
-            case arg.index_of<cv::Mat*>(): {
+            case T::index_of<cv::Mat*>(): {
                 auto &outMat = *util::get<cv::Mat*>(arg);
                 GAPI_Assert(outMat.data != nullptr);
                 GAPI_Assert(descr_of(outMat) == desc && "Output argument was not preallocated as it should be ?");

--- a/modules/gapi/src/backends/fluid/gfluidbackend.cpp
+++ b/modules/gapi/src/backends/fluid/gfluidbackend.cpp
@@ -1240,9 +1240,48 @@ void cv::gimpl::GFluidExecutable::bindInArg(const cv::gimpl::RcDesc &rc, const G
 {
     switch (rc.shape)
     {
-    case GShape::GMAT:    m_buffers[m_id_map.at(rc.id)].priv().bindTo(util::get<cv::gapi::own::Mat>(arg), true); break;
-    case GShape::GSCALAR: m_res.slot<cv::gapi::own::Scalar>()[rc.id] = util::get<cv::gapi::own::Scalar>(arg); break;
-    case GShape::GARRAY:  m_res.slot<cv::detail::VectorRef>()[rc.id] = util::get<cv::detail::VectorRef>(arg); break;
+    case GShape::GMAT:
+    {
+        // FIXME: This ad-hoc cv/own conversion is absolutely terrible and should
+        // be avoided. This backend is purely OpenCV-independent and it should remain.
+        // These changes have been introduced to quickly pair Fluid with Streaming mode.
+        // Maybe Streaming mode needs to be refactored to work with own:: data structures
+        // by default instead.
+        auto &bref = m_buffers[m_id_map.at(rc.id)].priv();
+        switch (arg.index()) {
+        case arg.index_of<cv::gapi::own::Mat>():
+            bref.bindTo(util::get<cv::gapi::own::Mat>(arg), true);
+            break;
+#if !defined(GAPI_STANDALONE)
+        case arg.index_of<cv::Mat>():
+            bref.bindTo(cv::to_own(util::get<cv::Mat>(arg)), true);
+            break;
+#endif // GAPI_STANDALONE
+        default: GAPI_Assert(false);
+        }
+    } break;
+
+    case GShape::GSCALAR:
+    {
+        // FIXME: See above.
+        auto &sref = m_res.slot<cv::gapi::own::Scalar>()[rc.id];
+        switch (arg.index()) {
+        case arg.index_of<cv::gapi::own::Scalar>():
+            sref = util::get<cv::gapi::own::Scalar>(arg);
+            break;
+#if !defined(GAPI_STANDALONE)
+        case arg.index_of<cv::Scalar>():
+            sref = cv::to_own(util::get<cv::Scalar>(arg));
+            break;
+#endif // GAPI_STANDALONE
+        default: GAPI_Assert(false);
+        }
+    } break;
+
+    case GShape::GARRAY:
+        m_res.slot<cv::detail::VectorRef>()[rc.id] = util::get<cv::detail::VectorRef>(arg);
+        break;
+
     default: util::throw_error(std::logic_error("Unsupported GShape type"));
     }
 }
@@ -1255,10 +1294,26 @@ void cv::gimpl::GFluidExecutable::bindOutArg(const cv::gimpl::RcDesc &rc, const 
     case GShape::GMAT:
         {
             cv::GMatDesc desc = m_buffers[m_id_map.at(rc.id)].meta();
-            auto      &outMat = *util::get<cv::gapi::own::Mat*>(arg);
-            GAPI_Assert(outMat.data != nullptr);
-            GAPI_Assert(descr_of(outMat) == desc && "Output argument was not preallocated as it should be ?");
-            m_buffers[m_id_map.at(rc.id)].priv().bindTo(outMat, false);
+            auto &bref = m_buffers[m_id_map.at(rc.id)].priv();
+
+            switch (arg.index()) {
+            // FIXME: See the bindInArg comment on Streaming-related changes
+            case arg.index_of<cv::gapi::own::Mat*>(): {
+                auto &outMat = *util::get<cv::gapi::own::Mat*>(arg);
+                GAPI_Assert(outMat.data != nullptr);
+                GAPI_Assert(descr_of(outMat) == desc && "Output argument was not preallocated as it should be ?");
+                bref.bindTo(outMat, false);
+            } break;
+#if !defined(GAPI_STANDALONE)
+            case arg.index_of<cv::Mat*>(): {
+                auto &outMat = *util::get<cv::Mat*>(arg);
+                GAPI_Assert(outMat.data != nullptr);
+                GAPI_Assert(descr_of(outMat) == desc && "Output argument was not preallocated as it should be ?");
+                bref.bindTo(cv::to_own(outMat), false);
+            } break;
+#endif // GAPI_STANDALONE
+            default: GAPI_Assert(false);
+            } // switch(arg.index())
             break;
         }
     default: util::throw_error(std::logic_error("Unsupported return GShape type"));
@@ -1446,6 +1501,13 @@ void GFluidBackendImpl::addBackendPasses(ade::ExecutionEngineSetupContext &ectx)
                 // regardless if it is one fluid island (both writing to and reading from this object)
                 // or two distinct islands (both fluid)
                 auto isFluidIsland = [&](const ade::NodeHandle& node) {
+                    // With Streaming, Emitter islands may have no FusedIsland thing in meta.
+                    // FIXME: Probably this is a concept misalignment
+                    if (!gim.metadata(node).contains<FusedIsland>()) {
+                        const auto kind = gim.metadata(node).get<NodeKind>().k;
+                        GAPI_Assert(kind == NodeKind::EMIT || kind == NodeKind::SINK);
+                        return false;
+                    }
                     const auto isl = gim.metadata(node).get<FusedIsland>().object;
                     return isl->backend() == cv::gapi::fluid::backend();
                 };
@@ -1456,6 +1518,9 @@ void GFluidBackendImpl::addBackendPasses(ade::ExecutionEngineSetupContext &ectx)
                     setFluidData(data_node, false);
                 }
             } break; // case::SLOT
+            case NodeKind::EMIT:
+            case NodeKind::SINK:
+                break; // do nothing for Streaming nodes
             default: GAPI_Assert(false);
             } // switch
         } // for (gim.nodes())

--- a/modules/gapi/src/backends/fluid/gfluidbackend.cpp
+++ b/modules/gapi/src/backends/fluid/gfluidbackend.cpp
@@ -1238,52 +1238,11 @@ void cv::gimpl::GFluidExecutable::reshape(ade::Graph &g, const GCompileArgs &arg
 // FIXME: Document what it does
 void cv::gimpl::GFluidExecutable::bindInArg(const cv::gimpl::RcDesc &rc, const GRunArg &arg)
 {
-    using T = GRunArg;
     switch (rc.shape)
     {
-    case GShape::GMAT:
-    {
-        // FIXME: This ad-hoc cv/own conversion is absolutely terrible and should
-        // be avoided. This backend is purely OpenCV-independent and it should remain.
-        // These changes have been introduced to quickly pair Fluid with Streaming mode.
-        // Maybe Streaming mode needs to be refactored to work with own:: data structures
-        // by default instead.
-        auto &bref = m_buffers[m_id_map.at(rc.id)].priv();
-        switch (arg.index()) {
-        case T::index_of<cv::gapi::own::Mat>():
-            bref.bindTo(util::get<cv::gapi::own::Mat>(arg), true);
-            break;
-#if !defined(GAPI_STANDALONE)
-        case T::index_of<cv::Mat>():
-            bref.bindTo(cv::to_own(util::get<cv::Mat>(arg)), true);
-            break;
-#endif // GAPI_STANDALONE
-        default: GAPI_Assert(false);
-        }
-    } break;
-
-    case GShape::GSCALAR:
-    {
-        // FIXME: See above.
-        auto &sref = m_res.slot<cv::gapi::own::Scalar>()[rc.id];
-        switch (arg.index()) {
-        case T::index_of<cv::gapi::own::Scalar>():
-            sref = util::get<cv::gapi::own::Scalar>(arg);
-            break;
-#if !defined(GAPI_STANDALONE)
-        case T::index_of<cv::Scalar>():
-            sref = cv::to_own(util::get<cv::Scalar>(arg));
-            break;
-#endif // GAPI_STANDALONE
-        default: GAPI_Assert(false);
-        }
-    } break;
-
-    case GShape::GARRAY:
-        m_res.slot<cv::detail::VectorRef>()[rc.id] = util::get<cv::detail::VectorRef>(arg);
-        break;
-
-    default: util::throw_error(std::logic_error("Unsupported GShape type"));
+    case GShape::GMAT:    m_buffers[m_id_map.at(rc.id)].priv().bindTo(util::get<cv::gapi::own::Mat>(arg), true); break;
+    case GShape::GSCALAR: m_res.slot<cv::gapi::own::Scalar>()[rc.id] = util::get<cv::gapi::own::Scalar>(arg); break;
+    case GShape::GARRAY:  m_res.slot<cv::detail::VectorRef>()[rc.id] = util::get<cv::detail::VectorRef>(arg); break;
     }
 }
 

--- a/modules/gapi/src/backends/ocl/goclcore.cpp
+++ b/modules/gapi/src/backends/ocl/goclcore.cpp
@@ -486,7 +486,7 @@ GAPI_OCL_KERNEL(GOCLCopy, cv::gapi::core::GCopy)
 {
     static void run(const cv::UMat& in, cv::UMat& out)
     {
-        cv::UMat(in).copyTo(out);
+        in.copyTo(out);
     }
 };
 
@@ -519,14 +519,6 @@ GAPI_OCL_KERNEL(GOCLConvertTo, cv::gapi::core::GConvertTo)
     static void run(const cv::UMat& in, int rtype, double alpha, double beta, cv::UMat& out)
     {
         in.convertTo(out, rtype, alpha, beta);
-    }
-};
-
-GAPI_OCL_KERNEL(GOCLCopy, cv::gapi::core::GCopy)
-{
-    static void run(const cv::UMat& in, cv::UMat& out)
-    {
-        in.copyTo(out);
     }
 };
 
@@ -594,7 +586,6 @@ cv::gapi::GKernelPackage cv::gapi::core::ocl::kernels()
          , GOCLConcatVert
          , GOCLLUT
          , GOCLConvertTo
-         , GOCLCopy
          >();
     return pkg;
 }

--- a/modules/gapi/src/backends/ocl/goclcore.cpp
+++ b/modules/gapi/src/backends/ocl/goclcore.cpp
@@ -522,6 +522,14 @@ GAPI_OCL_KERNEL(GOCLConvertTo, cv::gapi::core::GConvertTo)
     }
 };
 
+GAPI_OCL_KERNEL(GOCLCopy, cv::gapi::core::GCopy)
+{
+    static void run(const cv::UMat& in, cv::UMat& out)
+    {
+        in.copyTo(out);
+    }
+};
+
 cv::gapi::GKernelPackage cv::gapi::core::ocl::kernels()
 {
     static auto pkg = cv::gapi::kernels
@@ -586,6 +594,7 @@ cv::gapi::GKernelPackage cv::gapi::core::ocl::kernels()
          , GOCLConcatVert
          , GOCLLUT
          , GOCLConvertTo
+         , GOCLCopy
          >();
     return pkg;
 }

--- a/modules/gapi/src/compiler/gcompiler.cpp
+++ b/modules/gapi/src/compiler/gcompiler.cpp
@@ -28,10 +28,12 @@
 #include "compiler/gmodelbuilder.hpp"
 #include "compiler/gcompiler.hpp"
 #include "compiler/gcompiled_priv.hpp"
+#include "compiler/gstreaming_priv.hpp"
 #include "compiler/passes/passes.hpp"
 #include "compiler/passes/pattern_matching.hpp"
 
 #include "executor/gexecutor.hpp"
+#include "executor/gstreamingexecutor.hpp"
 #include "backends/common/gbackend.hpp"
 
 // <FIXME:>
@@ -272,6 +274,12 @@ cv::gimpl::GCompiler::GCompiler(const cv::GComputation &c,
     m_e.addPass("exec", "fuse_islands",     passes::fuseIslands);
     m_e.addPass("exec", "sync_islands",     passes::syncIslandTags);
 
+    // FIXME: Since a set of passes is shared between
+    // GCompiled/GStreamingCompiled, this pass is added here unconditionally
+    // (even if it is not actually required to produce a GCompiled).
+    // FIXME: add a better way to do that!
+    m_e.addPass("exec", "add_streaming",    passes::addStreaming);
+
     if (dump_path.has_value())
     {
         m_e.addPass("exec", "dump_dot", std::bind(passes::dumpGraph, _1,
@@ -407,10 +415,31 @@ cv::GCompiled cv::gimpl::GCompiler::produceCompiled(GPtr &&pg)
     return compiled;
 }
 
+cv::GStreamingCompiled cv::gimpl::GCompiler::produceStreamingCompiled(GPtr &&pg)
+{
+    const auto &outMetas = GModel::ConstGraph(*pg).metadata()
+        .get<OutputMeta>().outMeta;
+    std::unique_ptr<GStreamingExecutor> pE(new GStreamingExecutor(std::move(pg)));
+
+    GStreamingCompiled compiled;
+    compiled.priv().setup(m_metas, outMetas, std::move(pE));
+    return compiled;
+}
+
 cv::GCompiled cv::gimpl::GCompiler::compile()
 {
     std::unique_ptr<ade::Graph> pG = generateGraph();
     runPasses(*pG);
     compileIslands(*pG);
     return produceCompiled(std::move(pG));
+}
+
+cv::GStreamingCompiled cv::gimpl::GCompiler::compileStreaming()
+{
+    // FIXME: self-note to DM: now keep these compile()/compileStreaming() in sync!
+    std::unique_ptr<ade::Graph> pG = generateGraph();
+    GModel::Graph(*pG).metadata().set(Streaming{});
+    runPasses(*pG);
+    compileIslands(*pG);
+    return produceStreamingCompiled(std::move(pG));
 }

--- a/modules/gapi/src/compiler/gcompiler.cpp
+++ b/modules/gapi/src/compiler/gcompiler.cpp
@@ -40,11 +40,11 @@
 #if !defined(GAPI_STANDALONE)
 #include <opencv2/gapi/cpu/core.hpp>    // Also directly refer to Core
 #include <opencv2/gapi/cpu/imgproc.hpp> // ...and Imgproc kernel implementations
+#include <opencv2/gapi/render/render.hpp>   // render::ocv::backend()
 #endif // !defined(GAPI_STANDALONE)
 // </FIXME:>
 
 #include <opencv2/gapi/gcompoundkernel.hpp> // compound::backend()
-#include <opencv2/gapi/render/render.hpp>   // render::ocv::backend()
 
 #include "logger.hpp"
 

--- a/modules/gapi/src/compiler/gcompiler.hpp
+++ b/modules/gapi/src/compiler/gcompiler.hpp
@@ -42,12 +42,16 @@ public:
     // The method which does everything...
     GCompiled compile();
 
-    // But is actually composed of this:
+    // This too.
+    GStreamingCompiled compileStreaming();
+
+    // But those are actually composed of this:
     using GPtr = std::unique_ptr<ade::Graph>;
     GPtr       generateGraph();               // Unroll GComputation into a GModel
     void       runPasses(ade::Graph &g);      // Apply all G-API passes on a GModel
     void       compileIslands(ade::Graph &g); // Instantiate GIslandExecutables in GIslandModel
     GCompiled  produceCompiled(GPtr &&pg);    // Produce GCompiled from processed GModel
+    GStreamingCompiled  produceStreamingCompiled(GPtr &&pg); // Produce GStreamingCompiled from processed GMbodel
 };
 
 }}

--- a/modules/gapi/src/compiler/gislandmodel.cpp
+++ b/modules/gapi/src/compiler/gislandmodel.cpp
@@ -223,6 +223,14 @@ ade::NodeHandle GIslandModel::mkEmitNode(Graph &g, std::size_t in_idx)
     return nh;
 }
 
+ade::NodeHandle GIslandModel::mkSinkNode(Graph &g, std::size_t out_idx)
+{
+    ade::NodeHandle nh = g.createNode();
+    g.metadata(nh).set(cv::gimpl::NodeKind{cv::gimpl::NodeKind::SINK});
+    g.metadata(nh).set(cv::gimpl::Sink{out_idx});
+    return nh;
+}
+
 void GIslandModel::syncIslandTags(Graph &g, ade::Graph &orig_g)
 {
     GModel::Graph gm(orig_g);

--- a/modules/gapi/src/compiler/gislandmodel.cpp
+++ b/modules/gapi/src/compiler/gislandmodel.cpp
@@ -215,6 +215,14 @@ ade::NodeHandle GIslandModel::mkIslandNode(Graph &g, std::shared_ptr<GIsland>&& 
     return nh;
 }
 
+ade::NodeHandle GIslandModel::mkEmitNode(Graph &g, std::size_t in_idx)
+{
+    ade::NodeHandle nh = g.createNode();
+    g.metadata(nh).set(cv::gimpl::NodeKind{cv::gimpl::NodeKind::EMIT});
+    g.metadata(nh).set(cv::gimpl::Emitter{in_idx, {}});
+    return nh;
+}
+
 void GIslandModel::syncIslandTags(Graph &g, ade::Graph &orig_g)
 {
     GModel::Graph gm(orig_g);

--- a/modules/gapi/src/compiler/gislandmodel.hpp
+++ b/modules/gapi/src/compiler/gislandmodel.hpp
@@ -129,7 +129,7 @@ public:
 struct NodeKind
 {
     static const char *name() { return "NodeKind"; }
-    enum { ISLAND, SLOT, EMIT} k;
+    enum { ISLAND, SLOT, EMIT, SINK} k;
 };
 
 // FIXME: Rename to Island (as soon as current GModel::Island is renamed
@@ -159,6 +159,12 @@ struct Emitter
     std::shared_ptr<GIslandEmitter> object;
 };
 
+struct Sink
+{
+    static const char *name() { return "Sink"; }
+    std::size_t proto_index;
+};
+
 namespace GIslandModel
 {
     using Graph = ade::TypedGraph
@@ -167,6 +173,7 @@ namespace GIslandModel
         , DataSlot
         , IslandExec
         , Emitter
+        , Sink
         , ade::passes::TopologicalSortData
         >;
 
@@ -177,6 +184,7 @@ namespace GIslandModel
         , DataSlot
         , IslandExec
         , Emitter
+        , Sink
         , ade::passes::TopologicalSortData
         >;
 
@@ -187,6 +195,7 @@ namespace GIslandModel
     ade::NodeHandle mkIslandNode(Graph &g, const gapi::GBackend &bknd, const ade::NodeHandle &op_nh, const ade::Graph &orig_g);
     ade::NodeHandle mkIslandNode(Graph &g, std::shared_ptr<GIsland>&& isl);
     ade::NodeHandle mkEmitNode(Graph &g, std::size_t in_idx); // streaming-related
+    ade::NodeHandle mkSinkNode(Graph &g, std::size_t out_idx); // streaming-related
 
     // GIslandModel API
     void syncIslandTags(Graph &g, ade::Graph &orig_g);

--- a/modules/gapi/src/compiler/gislandmodel.hpp
+++ b/modules/gapi/src/compiler/gislandmodel.hpp
@@ -1,8 +1,8 @@
 // This file is part of OpenCV project.
 // It is subject to the license terms in the LICENSE file found in the top-level directory
 // of this distribution and at http://opencv.org/license.html.
-
-
+//
+// Copyright (C) 2018-2019 Intel Corporation
 
 
 #ifndef OPENCV_GAPI_GISLANDMODEL_HPP
@@ -115,7 +115,7 @@ public:
     virtual ~GIslandExecutable() = default;
 };
 
-// GIslandExecutable - a backend-specific thing which feeds data into
+// GIslandEmitter - a backend-specific thing which feeds data into
 // the pipeline. This one is just an interface, implementations are executor-defined.
 class GIslandEmitter
 {

--- a/modules/gapi/src/compiler/gislandmodel.hpp
+++ b/modules/gapi/src/compiler/gislandmodel.hpp
@@ -1,8 +1,8 @@
 // This file is part of OpenCV project.
 // It is subject to the license terms in the LICENSE file found in the top-level directory
 // of this distribution and at http://opencv.org/license.html.
-//
-// Copyright (C) 2018 Intel Corporation
+
+
 
 
 #ifndef OPENCV_GAPI_GISLANDMODEL_HPP
@@ -115,13 +115,21 @@ public:
     virtual ~GIslandExecutable() = default;
 };
 
-
+// GIslandExecutable - a backend-specific thing which feeds data into
+// the pipeline. This one is just an interface, implementations are executor-defined.
+class GIslandEmitter
+{
+public:
+    // Obtain next value from the emitter
+    virtual bool pull(GRunArg &) = 0;
+    virtual ~GIslandEmitter() = default;
+};
 
 // Couldn't reuse NodeType here - FIXME unify (move meta to a shared place)
 struct NodeKind
 {
     static const char *name() { return "NodeKind"; }
-    enum { ISLAND, SLOT} k;
+    enum { ISLAND, SLOT, EMIT} k;
 };
 
 // FIXME: Rename to Island (as soon as current GModel::Island is renamed
@@ -144,6 +152,13 @@ struct IslandExec
     std::shared_ptr<GIslandExecutable> object;
 };
 
+struct Emitter
+{
+    static const char *name() { return "Emitter"; }
+    std::size_t proto_index;
+    std::shared_ptr<GIslandEmitter> object;
+};
+
 namespace GIslandModel
 {
     using Graph = ade::TypedGraph
@@ -151,6 +166,7 @@ namespace GIslandModel
         , FusedIsland
         , DataSlot
         , IslandExec
+        , Emitter
         , ade::passes::TopologicalSortData
         >;
 
@@ -160,6 +176,7 @@ namespace GIslandModel
         , FusedIsland
         , DataSlot
         , IslandExec
+        , Emitter
         , ade::passes::TopologicalSortData
         >;
 
@@ -169,6 +186,7 @@ namespace GIslandModel
     ade::NodeHandle mkSlotNode(Graph &g, const ade::NodeHandle &data_nh);
     ade::NodeHandle mkIslandNode(Graph &g, const gapi::GBackend &bknd, const ade::NodeHandle &op_nh, const ade::Graph &orig_g);
     ade::NodeHandle mkIslandNode(Graph &g, std::shared_ptr<GIsland>&& isl);
+    ade::NodeHandle mkEmitNode(Graph &g, std::size_t in_idx); // streaming-related
 
     // GIslandModel API
     void syncIslandTags(Graph &g, ade::Graph &orig_g);

--- a/modules/gapi/src/compiler/gmodel.cpp
+++ b/modules/gapi/src/compiler/gmodel.cpp
@@ -50,21 +50,17 @@ ade::NodeHandle GModel::mkDataNode(GModel::Graph &g, const GOrigin& origin)
         storage    = Data::Storage::CONST_VAL;
         g.metadata(data_h).set(ConstValue{value});
     }
-    g.metadata(data_h).set(Data{origin.shape, id, meta, origin.ctor, storage});
-    return data_h;
-}
-
-ade::NodeHandle GModel::mkDataNode(GModel::Graph &g, const GShape shape)
-{
-    ade::NodeHandle data_h = g.createNode();
-    g.metadata(data_h).set(NodeType{NodeType::DATA});
-
-    const auto id = g.metadata().get<DataObjectCounter>().GetNewId(shape);
-    GMetaArg meta;
-    HostCtor ctor;
-    Data::Storage storage = Data::Storage::INTERNAL; // By default, all objects are marked INTERNAL
-
-    g.metadata(data_h).set(Data{shape, id, meta, ctor, storage});
+    if (origin.shape == GShape::GARRAY) {
+        std::cout << "Creating a GArray from "
+                  << &origin.node.priv()
+                  << "/"
+                  << origin.port
+                  << " -- ctor "
+                  << origin.ctor.index()
+                  << std::endl;
+    }
+    auto ctor_copy = origin.ctor;
+    g.metadata(data_h).set(Data{origin.shape, id, meta, ctor_copy, storage});
     return data_h;
 }
 

--- a/modules/gapi/src/compiler/gmodel.cpp
+++ b/modules/gapi/src/compiler/gmodel.cpp
@@ -50,15 +50,9 @@ ade::NodeHandle GModel::mkDataNode(GModel::Graph &g, const GOrigin& origin)
         storage    = Data::Storage::CONST_VAL;
         g.metadata(data_h).set(ConstValue{value});
     }
-    if (origin.shape == GShape::GARRAY) {
-        std::cout << "Creating a GArray from "
-                  << &origin.node.priv()
-                  << "/"
-                  << origin.port
-                  << " -- ctor "
-                  << origin.ctor.index()
-                  << std::endl;
-    }
+    // FIXME: Sometimes a GArray-related node may be created w/o the
+    // associated host-type constructor (e.g. when the array is
+    // somewhere in the middle of the graph).
     auto ctor_copy = origin.ctor;
     g.metadata(data_h).set(Data{origin.shape, id, meta, ctor_copy, storage});
     return data_h;

--- a/modules/gapi/src/compiler/gmodel.hpp
+++ b/modules/gapi/src/compiler/gmodel.hpp
@@ -232,8 +232,6 @@ namespace GModel
 
     GAPI_EXPORTS ade::NodeHandle mkOpNode(Graph &g, const GKernel &k, const std::vector<GArg>& args, const std::string &island);
 
-    GAPI_EXPORTS ade::NodeHandle mkDataNode(Graph &g, const GShape shape);
-
     // Adds a string message to a node. Any node can be subject of log, messages then
     // appear in the dumped .dot file.x
     GAPI_EXPORTS void log(Graph &g, ade::NodeHandle op, std::string &&message, ade::NodeHandle updater = ade::NodeHandle());

--- a/modules/gapi/src/compiler/gmodel.hpp
+++ b/modules/gapi/src/compiler/gmodel.hpp
@@ -145,6 +145,16 @@ struct ActiveBackends
     std::unordered_set<cv::gapi::GBackend> backends;
 };
 
+// This is a graph-global flag indicating this graph is compiled for
+// the streaming case.  Streaming-neutral passes (i.e. nearly all of
+// them) can ignore this flag safely.
+//
+// FIXME: Probably a better design can be suggested.
+struct Streaming
+{
+    static const char *name() { return "StreamingFlag"; }
+};
+
 // Backend-specific inference parameters for a neural network.
 // Since these parameters are set on compilation stage (not
 // on a construction stage), these parameters are bound lately
@@ -190,6 +200,7 @@ namespace GModel
         , IslandModel
         , ActiveBackends
         , CustomMetaFunction
+        , Streaming
         >;
 
     // FIXME: How to define it based on GModel???
@@ -209,6 +220,7 @@ namespace GModel
         , IslandModel
         , ActiveBackends
         , CustomMetaFunction
+        , Streaming
         >;
 
     // FIXME:

--- a/modules/gapi/src/compiler/gmodelbuilder.cpp
+++ b/modules/gapi/src/compiler/gmodelbuilder.cpp
@@ -139,15 +139,6 @@ cv::gimpl::Unrolled cv::gimpl::unrollExpr(const GProtoArgs &ins,
                     std::size_t port  = ade::util::index(it);
                     GShape shape      = ade::util::value(it);
 
-                    if (shape == GShape::GARRAY)
-                    {
-                    std::cout << "Just created a new GArray origin "
-                              << &node.priv()
-                              << "/"
-                              << port
-                              << std::endl;
-                    }
-
                     GOrigin org { shape, node, port};
                     origins.insert(org);
                 }
@@ -318,7 +309,6 @@ ade::NodeHandle cv::gimpl::GModelBuilder::put_DataNode(const GOrigin &origin)
         if (it->first.ctor.index() == it->first.ctor.index_of<cv::util::monostate>()
             && origin.ctor.index() !=    origin.ctor.index_of<cv::util::monostate>()) {
             // meanwhile update existing object
-            std::cout << "Patching... " << std::endl;
             m_gm.metadata(it->second).get<Data>().ctor = origin.ctor;
         }
         return it->second;

--- a/modules/gapi/src/compiler/gmodelbuilder.cpp
+++ b/modules/gapi/src/compiler/gmodelbuilder.cpp
@@ -139,6 +139,15 @@ cv::gimpl::Unrolled cv::gimpl::unrollExpr(const GProtoArgs &ins,
                     std::size_t port  = ade::util::index(it);
                     GShape shape      = ade::util::value(it);
 
+                    if (shape == GShape::GARRAY)
+                    {
+                    std::cout << "Just created a new GArray origin "
+                              << &node.priv()
+                              << "/"
+                              << port
+                              << std::endl;
+                    }
+
                     GOrigin org { shape, node, port};
                     origins.insert(org);
                 }
@@ -303,5 +312,15 @@ ade::NodeHandle cv::gimpl::GModelBuilder::put_DataNode(const GOrigin &origin)
         m_graph_data[origin] = nh;
         return nh;
     }
-    else return it->second;
+    else
+    {
+        // FIXME: One of the ugliest workarounds ever
+        if (it->first.ctor.index() == it->first.ctor.index_of<cv::util::monostate>()
+            && origin.ctor.index() !=    origin.ctor.index_of<cv::util::monostate>()) {
+            // meanwhile update existing object
+            std::cout << "Patching... " << std::endl;
+            m_gm.metadata(it->second).get<Data>().ctor = origin.ctor;
+        }
+        return it->second;
+    }
 }

--- a/modules/gapi/src/compiler/gstreaming.cpp
+++ b/modules/gapi/src/compiler/gstreaming.cpp
@@ -80,11 +80,20 @@ bool cv::GStreamingCompiled::Priv::pull(cv::GRunArgsP &&outs)
     return m_exec->pull(std::move(outs));
 }
 
+bool cv::GStreamingCompiled::Priv::try_pull(cv::GRunArgsP &&outs)
+{
+    return m_exec->try_pull(std::move(outs));
+}
+
 void cv::GStreamingCompiled::Priv::stop()
 {
     m_exec->stop();
 }
 
+bool cv::GStreamingCompiled::Priv::running() const
+{
+    return m_exec->running();
+}
 
 // GStreamingCompiled public implementation ////////////////////////////////////
 cv::GStreamingCompiled::GStreamingCompiled()
@@ -113,9 +122,19 @@ bool cv::GStreamingCompiled::pull(cv::GRunArgsP &&outs)
     return m_priv->pull(std::move(outs));
 }
 
+bool cv::GStreamingCompiled::try_pull(cv::GRunArgsP &&outs)
+{
+    return m_priv->try_pull(std::move(outs));
+}
+
 void cv::GStreamingCompiled::stop()
 {
     m_priv->stop();
+}
+
+bool cv::GStreamingCompiled::running() const
+{
+    return m_priv->running();
 }
 
 cv::GStreamingCompiled::operator bool() const

--- a/modules/gapi/src/compiler/gstreaming.cpp
+++ b/modules/gapi/src/compiler/gstreaming.cpp
@@ -47,13 +47,13 @@ const cv::GMetaArgs& cv::GStreamingCompiled::Priv::outMetas() const
 // the G*Compiled's priv?
 void cv::GStreamingCompiled::Priv::setSource(cv::GRunArgs &&args)
 {
+    // FIXME: This metadata checking should be removed at all
+    // for the streaming case.
     if (!can_describe(m_metas, args))
     {
         util::throw_error(std::logic_error("This object was compiled "
                                            "for different metadata!"));
-        // FIXME: Add details on what is actually wrong
     }
-
     GAPI_Assert(m_exec != nullptr);
     m_exec->setSource(std::move(args));
 }

--- a/modules/gapi/src/compiler/gstreaming.cpp
+++ b/modules/gapi/src/compiler/gstreaming.cpp
@@ -32,14 +32,6 @@ bool cv::GStreamingCompiled::Priv::isEmpty() const
     return !m_exec;
 }
 
-// void cv::GStreamingCompiled::Priv::run(cv::gimpl::GRuntimeArgs &&args)
-// {
-//     // Strip away types since ADE knows nothing about that
-//     // args will be taken by specific GBackendExecutables
-//     checkArgs(args);
-//     m_exec->run(std::move(args));
-// }
-
 const cv::GMetaArgs& cv::GStreamingCompiled::Priv::metas() const
 {
     return m_metas;
@@ -50,22 +42,18 @@ const cv::GMetaArgs& cv::GStreamingCompiled::Priv::outMetas() const
     return m_outMetas;
 }
 
-void cv::GStreamingCompiled::Priv::checkArgs(const cv::gimpl::GRuntimeArgs &args) const
-{
-    // FIXME: This method mostly duplicates GCompiled!
-    if (!can_describe(m_metas, args.inObjs))
-    {
-        util::throw_error(std::logic_error("This object was compiled "
-                                           "for different metadata!"));
-        // FIXME: Add details on what is actually wrong
-    }
-}
-
 // FIXME: What is the reason in having Priv here if Priv actually dispatches
 // everything to the underlying executable?? May be this executable may become
 // the G*Compiled's priv?
 void cv::GStreamingCompiled::Priv::setSource(cv::GRunArgs &&args)
 {
+    if (!can_describe(m_metas, args))
+    {
+        util::throw_error(std::logic_error("This object was compiled "
+                                           "for different metadata!"));
+        // FIXME: Add details on what is actually wrong
+    }
+
     GAPI_Assert(m_exec != nullptr);
     m_exec->setSource(std::move(args));
 }

--- a/modules/gapi/src/compiler/gstreaming.cpp
+++ b/modules/gapi/src/compiler/gstreaming.cpp
@@ -1,0 +1,141 @@
+// This file is part of OpenCV project.
+// It is subject to the license terms in the LICENSE file found in the top-level directory
+// of this distribution and at http://opencv.org/license.html.
+//
+// Copyright (C) 2019 Intel Corporation
+
+
+#include "precomp.hpp"
+
+#if !defined(GAPI_STANDALONE)
+
+#include <ade/graph.hpp>
+
+#include <opencv2/gapi/gproto.hpp> // can_describe
+#include <opencv2/gapi/gcompiled.hpp>
+
+#include "compiler/gstreaming_priv.hpp"
+#include "backends/common/gbackend.hpp"
+
+// GStreamingCompiled private implementation ///////////////////////////////////
+void cv::GStreamingCompiled::Priv::setup(const GMetaArgs &_metaArgs,
+                                         const GMetaArgs &_outMetas,
+                                         std::unique_ptr<cv::gimpl::GStreamingExecutor> &&_pE)
+{
+    m_metas    = _metaArgs;
+    m_outMetas = _outMetas;
+    m_exec     = std::move(_pE);
+}
+
+bool cv::GStreamingCompiled::Priv::isEmpty() const
+{
+    return !m_exec;
+}
+
+// void cv::GStreamingCompiled::Priv::run(cv::gimpl::GRuntimeArgs &&args)
+// {
+//     // Strip away types since ADE knows nothing about that
+//     // args will be taken by specific GBackendExecutables
+//     checkArgs(args);
+//     m_exec->run(std::move(args));
+// }
+
+const cv::GMetaArgs& cv::GStreamingCompiled::Priv::metas() const
+{
+    return m_metas;
+}
+
+const cv::GMetaArgs& cv::GStreamingCompiled::Priv::outMetas() const
+{
+    return m_outMetas;
+}
+
+void cv::GStreamingCompiled::Priv::checkArgs(const cv::gimpl::GRuntimeArgs &args) const
+{
+    // FIXME: This method mostly duplicates GCompiled!
+    if (!can_describe(m_metas, args.inObjs))
+    {
+        util::throw_error(std::logic_error("This object was compiled "
+                                           "for different metadata!"));
+        // FIXME: Add details on what is actually wrong
+    }
+}
+
+// FIXME: What is the reason in having Priv here if Priv actually dispatches
+// everything to the underlying executable?? May be this executable may become
+// the G*Compiled's priv?
+void cv::GStreamingCompiled::Priv::setSource(cv::GRunArgs &&args)
+{
+    GAPI_Assert(m_exec != nullptr);
+    m_exec->setSource(std::move(args));
+}
+
+void cv::GStreamingCompiled::Priv::start()
+{
+    m_exec->start();
+}
+
+bool cv::GStreamingCompiled::Priv::pull(cv::GRunArgsP &&outs)
+{
+    return m_exec->pull(std::move(outs));
+}
+
+void cv::GStreamingCompiled::Priv::stop()
+{
+    m_exec->stop();
+}
+
+
+// GStreamingCompiled public implementation ////////////////////////////////////
+cv::GStreamingCompiled::GStreamingCompiled()
+    : m_priv(new Priv())
+{
+}
+
+void cv::GStreamingCompiled::setSource(GRunArgs &&ins)
+{
+    // FIXME: verify these input parameters according to the graph input meta
+    m_priv->setSource(std::move(ins));
+}
+
+void cv::GStreamingCompiled::setSource(const cv::gapi::GVideoCapture &cap)
+{
+    setSource(cv::gin(cap));
+}
+
+void cv::GStreamingCompiled::start()
+{
+    m_priv->start();
+}
+
+bool cv::GStreamingCompiled::pull(cv::GRunArgsP &&outs)
+{
+    return m_priv->pull(std::move(outs));
+}
+
+void cv::GStreamingCompiled::stop()
+{
+    m_priv->stop();
+}
+
+cv::GStreamingCompiled::operator bool() const
+{
+    return !m_priv->isEmpty();
+}
+
+const cv::GMetaArgs& cv::GStreamingCompiled::metas() const
+{
+    return m_priv->metas();
+}
+
+const cv::GMetaArgs& cv::GStreamingCompiled::outMetas() const
+{
+    return m_priv->outMetas();
+}
+
+cv::GStreamingCompiled::Priv& cv::GStreamingCompiled::priv()
+{
+    return *m_priv;
+}
+
+#endif // GAPI_STANDALONE

--- a/modules/gapi/src/compiler/gstreaming.cpp
+++ b/modules/gapi/src/compiler/gstreaming.cpp
@@ -95,9 +95,9 @@ void cv::GStreamingCompiled::setSource(GRunArgs &&ins)
     m_priv->setSource(std::move(ins));
 }
 
-void cv::GStreamingCompiled::setSource(const cv::gapi::GVideoCapture &cap)
+void cv::GStreamingCompiled::setSource(const cv::gapi::wip::IStreamSource::Ptr &s)
 {
-    setSource(cv::gin(cap));
+    setSource(cv::gin(s));
 }
 
 void cv::GStreamingCompiled::start()

--- a/modules/gapi/src/compiler/gstreaming_priv.hpp
+++ b/modules/gapi/src/compiler/gstreaming_priv.hpp
@@ -1,0 +1,47 @@
+// This file is part of OpenCV project.
+// It is subject to the license terms in the LICENSE file found in the top-level directory
+// of this distribution and at http://opencv.org/license.html.
+//
+// Copyright (C) 2019 Intel Corporation
+
+
+#ifndef OPENCV_GAPI_GSTREAMING_COMPILED_PRIV_HPP
+#define OPENCV_GAPI_GSTREAMING_COMPILED_PRIV_HPP
+
+#include <memory> // unique_ptr
+#include "executor/gstreamingexecutor.hpp"
+
+namespace cv {
+
+namespace gimpl
+{
+    struct GRuntimeArgs;
+};
+
+// FIXME: GAPI_EXPORTS is here only due to tests and Windows linker issues
+class GAPI_EXPORTS GStreamingCompiled::Priv
+{
+    GMetaArgs  m_metas;    // passed by user
+    GMetaArgs  m_outMetas; // inferred by compiler
+    std::unique_ptr<cv::gimpl::GStreamingExecutor> m_exec;
+
+    void checkArgs(const cv::gimpl::GRuntimeArgs &args) const;
+
+public:
+    void setup(const GMetaArgs &metaArgs,
+               const GMetaArgs &outMetas,
+               std::unique_ptr<cv::gimpl::GStreamingExecutor> &&pE);
+    bool isEmpty() const;
+
+    const GMetaArgs& metas() const;
+    const GMetaArgs& outMetas() const;
+
+    void setSource(GRunArgs &&args);
+    void start();
+    bool pull(cv::GRunArgsP &&outs);
+    void stop();
+};
+
+} // namespace cv
+
+#endif // OPENCV_GAPI_GSTREAMING_COMPILED_PRIV_HPP

--- a/modules/gapi/src/compiler/gstreaming_priv.hpp
+++ b/modules/gapi/src/compiler/gstreaming_priv.hpp
@@ -19,6 +19,9 @@ namespace gimpl
 };
 
 // FIXME: GAPI_EXPORTS is here only due to tests and Windows linker issues
+// FIXME: It seems it clearly duplicates the GStreamingCompiled and
+// GStreamingExecutable APIs so is highly redundant now.
+// Same applies to GCompiled/GCompiled::Priv/GExecutor.
 class GAPI_EXPORTS GStreamingCompiled::Priv
 {
     GMetaArgs  m_metas;    // passed by user
@@ -39,7 +42,10 @@ public:
     void setSource(GRunArgs &&args);
     void start();
     bool pull(cv::GRunArgsP &&outs);
+    bool try_pull(cv::GRunArgsP &&outs);
     void stop();
+
+    bool running() const;
 };
 
 } // namespace cv

--- a/modules/gapi/src/compiler/gstreaming_priv.hpp
+++ b/modules/gapi/src/compiler/gstreaming_priv.hpp
@@ -28,8 +28,6 @@ class GAPI_EXPORTS GStreamingCompiled::Priv
     GMetaArgs  m_outMetas; // inferred by compiler
     std::unique_ptr<cv::gimpl::GStreamingExecutor> m_exec;
 
-    void checkArgs(const cv::gimpl::GRuntimeArgs &args) const;
-
 public:
     void setup(const GMetaArgs &metaArgs,
                const GMetaArgs &outMetas,

--- a/modules/gapi/src/compiler/passes/dump_dot.cpp
+++ b/modules/gapi/src/compiler/passes/dump_dot.cpp
@@ -172,7 +172,6 @@ void dumpDot(const ade::Graph &g, std::ostream& os)
                 }
             }
             break;
-
         case NodeKind::SLOT:
             {
                 const auto obj_name = format_obj(gim.metadata(nh).get<DataSlot>()
@@ -185,7 +184,16 @@ void dumpDot(const ade::Graph &g, std::ostream& os)
                 }
             }
             break;
-
+        case NodeKind::EMIT:
+            {
+                for (auto out_nh : nh->outNodes())
+                {
+                    const auto obj_name = format_obj(gim.metadata(out_nh).get<DataSlot>()
+                                                     .original_data_node);
+                    os << "\"emit:" << nh << "\" -> \"slot:" << obj_name << "\"\n";
+                }
+            }
+            break;
         default:
             GAPI_Assert(false);
             break;

--- a/modules/gapi/src/compiler/passes/dump_dot.cpp
+++ b/modules/gapi/src/compiler/passes/dump_dot.cpp
@@ -178,9 +178,11 @@ void dumpDot(const ade::Graph &g, std::ostream& os)
                                                  .original_data_node);
                 for (auto cons_nh : nh->outNodes())
                 {
-                    os << "\"slot:" << obj_name << "\" -> \""
-                       << gim.metadata(cons_nh).get<FusedIsland>().object->name()
-                       << "\"\n";
+                    if (gim.metadata(cons_nh).get<NodeKind>().k == NodeKind::ISLAND) {
+                        os << "\"slot:" << obj_name << "\" -> \""
+                           << gim.metadata(cons_nh).get<FusedIsland>().object->name()
+                           << "\"\n";
+                    } // other data consumers -- sinks -- are processed separately
                 }
             }
             break;
@@ -191,6 +193,16 @@ void dumpDot(const ade::Graph &g, std::ostream& os)
                     const auto obj_name = format_obj(gim.metadata(out_nh).get<DataSlot>()
                                                      .original_data_node);
                     os << "\"emit:" << nh << "\" -> \"slot:" << obj_name << "\"\n";
+                }
+            }
+            break;
+        case NodeKind::SINK:
+            {
+                for (auto in_nh : nh->inNodes())
+                {
+                    const auto obj_name = format_obj(gim.metadata(in_nh).get<DataSlot>()
+                                                     .original_data_node);
+                    os << "\"slot:" << obj_name << "\" -> \"sink:" << nh << "\"\n";
                 }
             }
             break;

--- a/modules/gapi/src/compiler/passes/passes.hpp
+++ b/modules/gapi/src/compiler/passes/passes.hpp
@@ -63,6 +63,8 @@ void applyTransformations(ade::passes::PassContext &ctx,
                           const gapi::GKernelPackage &pkg,
                           const std::vector<std::unique_ptr<ade::Graph>> &preGeneratedPatterns);
 
+void addStreaming(ade::passes::PassContext &ctx);
+
 }} // namespace gimpl::passes
 
 } // namespace cv

--- a/modules/gapi/src/compiler/passes/streaming.cpp
+++ b/modules/gapi/src/compiler/passes/streaming.cpp
@@ -4,13 +4,6 @@
 //
 // Copyright (C) 2019 Intel Corporation
 
-// This file is part of OpenCV project.
-// It is subject to the license terms in the LICENSE file found in the top-level directory
-// of this distribution and at http://opencv.org/license.html.
-//
-// Copyright (C) 2018 Intel Corporation
-
-
 #include "precomp.hpp"
 
 #include <iostream>                              // cout

--- a/modules/gapi/src/compiler/passes/streaming.cpp
+++ b/modules/gapi/src/compiler/passes/streaming.cpp
@@ -1,0 +1,70 @@
+// This file is part of OpenCV project.
+// It is subject to the license terms in the LICENSE file found in the top-level directory
+// of this distribution and at http://opencv.org/license.html.
+//
+// Copyright (C) 2019 Intel Corporation
+
+// This file is part of OpenCV project.
+// It is subject to the license terms in the LICENSE file found in the top-level directory
+// of this distribution and at http://opencv.org/license.html.
+//
+// Copyright (C) 2018 Intel Corporation
+
+
+#include "precomp.hpp"
+
+#include <iostream>                              // cout
+#include <sstream>                               // stringstream
+#include <fstream>                               // ofstream
+#include <map>
+
+#include <ade/passes/check_cycles.hpp>
+#include <ade/util/zip_range.hpp>                // indexed()
+
+#include <opencv2/gapi/gproto.hpp>
+#include "compiler/gmodel.hpp"
+#include "compiler/gislandmodel.hpp"
+#include "compiler/passes/passes.hpp"
+
+namespace cv { namespace gimpl { namespace passes {
+
+void addStreaming(ade::passes::PassContext &ctx)
+{
+    GModel::Graph gr(ctx.graph);
+    if (!gr.metadata().contains<Streaming>()) {
+        return;
+    }
+
+    // Note: This pass is working on a GIslandModel.
+    // FIXME: May be introduce a new variant of GIslandModel to
+    // deal with streams?
+    auto igr = gr.metadata().get<IslandModel>().model;
+    GIslandModel::Graph igm(*igr);
+
+    // First collect all data slots & their respective original
+    // data objects
+    using M = std::unordered_map
+        < ade::NodeHandle  // key: a GModel's data object node
+        , ade::NodeHandle // value: an appropriate GIslandModel's slot node
+        , ade::HandleHasher<ade::Node>
+        >;
+    M orig_to_isl;
+    for (auto &&nh : igm.nodes()) {
+        if (igm.metadata(nh).get<NodeKind>().k == NodeKind::SLOT) {
+            const auto &orig_nh = igm.metadata(nh).get<DataSlot>().original_data_node;
+            orig_to_isl[orig_nh] = nh;
+        }
+    }
+
+    // Now walk through the list of input slots and connect those
+    // to a Streaming source.
+    const auto proto = gr.metadata().get<Protocol>();
+    for (auto &&it : ade::util::indexed(proto.in_nhs)) {
+        const auto in_idx = ade::util::index(it);
+        const auto in_nh  = ade::util::value(it);
+        auto emit_nh = GIslandModel::mkEmitNode(igm, in_idx);
+        igm.link(emit_nh, orig_to_isl.at(in_nh));
+    }
+}
+
+}}} // cv::gimpl::passes

--- a/modules/gapi/src/compiler/passes/streaming.cpp
+++ b/modules/gapi/src/compiler/passes/streaming.cpp
@@ -65,6 +65,14 @@ void addStreaming(ade::passes::PassContext &ctx)
         auto emit_nh = GIslandModel::mkEmitNode(igm, in_idx);
         igm.link(emit_nh, orig_to_isl.at(in_nh));
     }
+
+    // Same for output slots
+    for (auto &&it : ade::util::indexed(proto.out_nhs)) {
+        const auto out_idx = ade::util::index(it);
+        const auto out_nh  = ade::util::value(it);
+        auto sink_nh = GIslandModel::mkSinkNode(igm, out_idx);
+        igm.link(orig_to_isl.at(out_nh), sink_nh);
+    }
 }
 
 }}} // cv::gimpl::passes

--- a/modules/gapi/src/executor/conc_queue.hpp
+++ b/modules/gapi/src/executor/conc_queue.hpp
@@ -1,0 +1,118 @@
+// This file is part of OpenCV project.
+// It is subject to the license terms in the LICENSE file found in the top-level directory
+// of this distribution and at http://opencv.org/license.html.
+//
+// Copyright (C) 2019 Intel Corporation
+
+#ifndef OPENCV_GAPI_EXECUTOR_CONC_QUEUE_HPP
+#define OPENCV_GAPI_EXECUTOR_CONC_QUEUE_HPP
+
+#include <queue>
+#include <mutex>
+#include <condition_variable>
+
+#include <opencv2/gapi/own/assert.hpp>
+
+namespace cv {
+namespace gapi {
+namespace own {
+
+// This class implements a bare minimum interface of TBB's
+// concurrent_bounded_queue with only std:: stuff to make streaming
+// API work without TBB.
+//
+// Highly inefficient, please use it as a last resort if TBB is not
+// available in the build.
+template<class T>
+class concurrent_bounded_queue {
+    std::queue<T> m_data;
+    std::size_t m_capacity;
+
+    std::mutex m_mutex;
+    std::condition_variable m_cond_empty;
+    std::condition_variable m_cond_full;
+
+    void unsafe_pop(T &t);
+
+public:
+    concurrent_bounded_queue() : m_capacity(0) {}
+    concurrent_bounded_queue(const concurrent_bounded_queue<T> &cc)
+        : m_data(cc.m_data), m_capacity(cc.m_capacity) {
+        // FIXME: what to do with all that locks, etc?
+    }
+    concurrent_bounded_queue(concurrent_bounded_queue<T> &&cc)
+        : m_data(std::move(cc.m_data)), m_capacity(cc.m_capacity) {
+        // FIXME: what to do with all that locks, etc?
+    }
+
+    // FIXME: && versions
+    void push(const T &t);
+    void pop(T &t);
+    bool try_pop(T &t);
+
+    void set_capacity(std::size_t capacity);
+};
+
+// Internal: do shared pop things assuming the lock is already there
+template<typename T>
+void concurrent_bounded_queue<T>::unsafe_pop(T &t) {
+    GAPI_Assert(!m_data.empty());
+    t = m_data.front();
+    m_data.pop();
+}
+
+// Push an element to the queue. Blocking if there's no space left
+template<typename T>
+void concurrent_bounded_queue<T>::push(const T& t) {
+    std::unique_lock<std::mutex> lock(m_mutex);
+
+    if (m_capacity && m_capacity == m_data.size()) {
+        // if there is a limit and it is reached, wait
+        m_cond_full.wait(lock, [&](){return m_capacity > m_data.size();});
+        GAPI_Assert(m_capacity > m_data.size());
+    }
+    m_data.push(t);
+    lock.unlock();
+    m_cond_empty.notify_one();
+}
+
+// Pop an element from the queue. Blocking if there's no items
+template<typename T>
+void concurrent_bounded_queue<T>::pop(T &t) {
+    std::unique_lock<std::mutex> lock(m_mutex);
+    if (m_data.empty()) {
+        // if there is no data, wait
+        m_cond_empty.wait(lock, [&](){return !m_data.empty();});
+    }
+    unsafe_pop(t);
+    lock.unlock();
+    m_cond_full.notify_one();
+}
+
+// Try pop an element from the queue. Returns false if queue is empty
+template<typename T>
+bool concurrent_bounded_queue<T>::try_pop(T &t) {
+    std::unique_lock<std::mutex> lock(m_mutex);
+    if (m_data.empty()) {
+        // if there is no data, return
+        return false;
+    }
+    unsafe_pop(t);
+    lock.unlock();
+    m_cond_full.notify_one();
+    return true;
+}
+
+// Specify the upper limit to the queue. Assumed to be called after
+// queue construction but before any real use, any other case is UB
+template<typename T>
+void concurrent_bounded_queue<T>::set_capacity(std::size_t capacity) {
+    GAPI_Assert(m_data.empty());
+    GAPI_Assert(m_capacity == 0u);
+    GAPI_Assert(capacity != 0u);
+    m_capacity = capacity;
+}
+
+}}} // namespace cv::gapi::own
+
+#endif //  OPENCV_GAPI_EXECUTOR_CONC_QUEUE_HPP

--- a/modules/gapi/src/executor/conc_queue.hpp
+++ b/modules/gapi/src/executor/conc_queue.hpp
@@ -51,6 +51,9 @@ public:
     bool try_pop(T &t);
 
     void set_capacity(std::size_t capacity);
+
+    // Not thread-safe - as in TBB
+    void clear();
 };
 
 // Internal: do shared pop things assuming the lock is already there
@@ -111,6 +114,14 @@ void concurrent_bounded_queue<T>::set_capacity(std::size_t capacity) {
     GAPI_Assert(m_capacity == 0u);
     GAPI_Assert(capacity != 0u);
     m_capacity = capacity;
+}
+
+// Clear the queue. Similar to the TBB version, this method is not
+// thread-safe.
+template<typename T>
+void concurrent_bounded_queue<T>::clear()
+{
+    m_data = std::queue<T>{};
 }
 
 }}} // namespace cv::gapi::own

--- a/modules/gapi/src/executor/gstreamingexecutor.cpp
+++ b/modules/gapi/src/executor/gstreamingexecutor.cpp
@@ -16,51 +16,330 @@
 #if !defined(GAPI_STANDALONE)
 #include <opencv2/videoio.hpp>   // FIXME: MOVE THIS DEPENDENCY OUT!!1
 #endif // GAPI_STANDALONE
+
 #include <opencv2/gapi/opencv_includes.hpp>
+
 #include "executor/gstreamingexecutor.hpp"
 #include "compiler/passes/passes.hpp"
+#include "backends/common/gbackend.hpp" // createMat
 
 namespace
 {
+using namespace cv::gimpl::stream;
+
 #if !defined(GAPI_STANDALONE)
-    class VideoEmitter final: public cv::gimpl::GIslandEmitter {
-        // FIXME: This is a huge dependency for core G-API library!
-        // It needs to be moved out to some separate module.
-        cv::VideoCapture vcap;
+class VideoEmitter final: public cv::gimpl::GIslandEmitter {
+    // FIXME: This is a huge dependency for core G-API library!
+    // It needs to be moved out to some separate module.
+    cv::VideoCapture vcap;
 
-        virtual bool pull(cv::GRunArg &arg) override {
-            // FIXME: probably we can maintain a pool of (then) pre-allocated
-            // buffers to avoid runtime allocations.
-            // Pool size can be determined given the internal queue size.
-            cv::Mat nextFrame;
-            vcap >> nextFrame;
-            if (nextFrame.empty()) {
-                return false;
-            }
-            arg = std::move(nextFrame);
-            return true;
+    virtual bool pull(cv::GRunArg &arg) override {
+        // FIXME: probably we can maintain a pool of (then) pre-allocated
+        // buffers to avoid runtime allocations.
+        // Pool size can be determined given the internal queue size.
+        cv::Mat nextFrame;
+        vcap >> nextFrame;
+        if (nextFrame.empty()) {
+            return false;
         }
-    public:
-
-        explicit VideoEmitter(const cv::GRunArg &arg) {
-            const auto &param = cv::util::get<cv::gapi::GVideoCapture>(arg);
-            GAPI_Assert(vcap.open(param.path));
-        }
-    };
+        arg = std::move(nextFrame);
+        return true;
+    }
+public:
+    explicit VideoEmitter(const cv::GRunArg &arg) {
+        const auto &param = cv::util::get<cv::gapi::GVideoCapture>(arg);
+        GAPI_Assert(vcap.open(param.path));
+    }
+};
 #endif // GAPI_STANDALONE
 
-    class ConstEmitter final: public cv::gimpl::GIslandEmitter {
-        cv::GRunArg m_arg;
+class ConstEmitter final: public cv::gimpl::GIslandEmitter {
+    cv::GRunArg m_arg;
 
-        virtual bool pull(cv::GRunArg &arg) override {
-            arg = m_arg;
-            return true;
-        }
-    public:
+    virtual bool pull(cv::GRunArg &arg) override {
+        arg = const_cast<const cv::GRunArg&>(m_arg); // FIXME: variant workaround
+        return true;
+    }
+public:
 
-        explicit ConstEmitter(const cv::GRunArg &arg) : m_arg(arg) {
+    explicit ConstEmitter(const cv::GRunArg &arg) : m_arg(arg) {
+    }
+};
+
+struct DataQueue {
+    static const char *name() { return "StreamingDataQueue"; }
+
+    explicit DataQueue(std::size_t capacity) {
+        if (capacity) {
+            q.set_capacity(capacity);
         }
-    };
+    }
+
+    cv::gimpl::stream::Q q;
+};
+
+std::vector<cv::gimpl::stream::Q*> reader_queues(      ade::Graph &g,
+                                                 const ade::NodeHandle &obj)
+{
+    ade::TypedGraph<DataQueue> qgr(g);
+    std::vector<cv::gimpl::stream::Q*> result;
+    for (auto &&out_eh : obj->outEdges())
+    {
+        result.push_back(&qgr.metadata(out_eh).get<DataQueue>().q);
+    }
+    return result;
+}
+
+std::vector<cv::gimpl::stream::Q*> input_queues(      ade::Graph &g,
+                                                const ade::NodeHandle &obj)
+{
+    ade::TypedGraph<DataQueue> qgr(g);
+    std::vector<cv::gimpl::stream::Q*> result;
+    for (auto &&in_eh : obj->inEdges())
+    {
+        result.push_back(&qgr.metadata(in_eh).get<DataQueue>().q);
+    }
+    return result;
+}
+
+void sync_data(cv::GRunArgs &results, cv::GRunArgsP &outputs)
+{
+    namespace own = cv::gapi::own;
+
+    for (auto && it : ade::util::zip(ade::util::toRange(outputs),
+                                     ade::util::toRange(results)))
+    {
+        auto &out_obj = std::get<0>(it);
+        auto &res_obj = std::get<1>(it);
+
+        // FIXME: this conversion should be unified
+        switch (out_obj.index())
+        {
+#if !defined(GAPI_STANDALONE)
+        case out_obj.index_of<cv::Mat*>():
+            *cv::util::get<cv::Mat*>(out_obj) = std::move(cv::util::get<cv::Mat>(res_obj));
+            break;
+        case out_obj.index_of<cv::Scalar*>():
+            *cv::util::get<cv::Scalar*>(out_obj) = std::move(cv::util::get<cv::Scalar>(res_obj));
+            break;
+#endif // GAPI_STANDALONE
+        case out_obj.index_of<own::Mat*>():
+            *cv::util::get<own::Mat*>(out_obj) = std::move(cv::util::get<own::Mat>(res_obj));
+            break;
+        case out_obj.index_of<own::Scalar*>():
+            *cv::util::get<own::Scalar*>(out_obj) = std::move(cv::util::get<own::Scalar>(res_obj));
+            break;
+        case out_obj.index_of<cv::detail::VectorRef>():
+            cv::util::get<cv::detail::VectorRef>(out_obj).mov(cv::util::get<cv::detail::VectorRef>(res_obj));
+            break;
+        default:
+            GAPI_Assert(false && "This value type is not supported!"
+#if defined(GAPI_STANDALONE)
+                                 " (probably because of STANDALONE mode"
+#endif // GAPI_STANDALONE
+                        );
+            break;
+        }
+    }
+}
+
+// This thread is a plain dump source actor. What it do is just:
+// - Check input queue (the only one) for a control command
+// - Depending on the state, obtains next data object and pushes it to the
+//   pipeline.
+void emitterActorThread(std::shared_ptr<cv::gimpl::GIslandEmitter> emitter,
+                        Q& in_queue,
+                        std::vector<Q*> out_queues)
+{
+    // Wait for the explicit Start command.
+    // ...or Stop command, this also happens.
+    Cmd cmd;
+    in_queue.pop(cmd);
+    GAPI_Assert(   cmd.index() == cmd.index_of<Start>()
+              || cmd.index() == cmd.index_of<Stop>());
+    if (cmd.index() == cmd.index_of<Stop>()) {
+        for (auto &&oq : out_queues) oq->push(cmd);
+        return;
+    }
+
+    // Now start emitting the data from the source to the pipeline.
+    while (true) {
+        Cmd cancel;
+        if (in_queue.try_pop(cancel)) {
+            // if we just popped a cancellation command...
+            GAPI_Assert(cancel.index() == cancel.index_of<Stop>());
+            // Broadcast it to the readers and quit.
+            for (auto &&oq : out_queues) oq->push(cancel);
+            return;
+        }
+
+        // Try to obrain next data chunk from the source
+        cv::GRunArg data;
+        if (emitter->pull(data)) {
+            // // On success, broadcast it to our readers
+            for (auto &&oq : out_queues)
+            {
+                // FIXME: FOR SOME REASON, oq->push(Cmd{data}) doesn't work!!
+                // empty mats are arrived to the receivers!
+                // There may be a fatal bug in our variant!
+                const auto tmp = data;
+                oq->push(Cmd{tmp});
+            }
+        } else {
+            // On failure, broadcast STOP message to our readers and quit.
+            for (auto &&oq : out_queues) oq->push(Cmd{Stop{}});
+            return;
+        }
+    }
+}
+
+// This thread is a plain dumb processing actor. What it do is just:
+// - Reads input from the input queue(s), sleeps if there's nothing to read
+// - Once a full input vector is obtained, passes it to the underlying island
+//   executable for processing.
+// - Pushes processing results down to consumers - to the subsequent queues.
+//   Note: Every data object consumer has its own queue.
+void islandActorThread(std::vector<cv::gimpl::RcDesc> in_rcs,                // FIXME: this is...
+                       std::vector<cv::gimpl::RcDesc> out_rcs,               // FIXME: ...basically just...
+                       cv::GMetaArgs out_metas,                              // ...
+                       std::shared_ptr<cv::gimpl::GIslandExecutable> island, // FIXME: ...a copy of OpDesc{}.
+                       std::vector<Q*> in_queues,
+                       std::vector< std::vector<Q*> > out_queues)
+{
+    GAPI_Assert(in_queues.size() == in_rcs.size());
+    GAPI_Assert(out_queues.size() == out_rcs.size());
+    GAPI_Assert(out_queues.size() == out_metas.size());
+    while (true)
+    {
+        std::vector<cv::gimpl::GIslandExecutable::InObj> isl_inputs;
+        isl_inputs.resize(in_rcs.size());
+
+        // Try to obtain the full input vector.
+        // Note this may block us. We also may get Stop signal here
+        // and then exit the thread.
+        Cmd cmd;
+        for (auto &&it : ade::util::indexed(in_queues))
+        {
+            auto id = ade::util::index(it);
+            auto &q = ade::util::value(it);
+            q->pop(cmd);
+            if (cmd.index() == cmd.index_of<Stop>()) {
+                // Broadcast STOP down to the pipeline.
+                for (auto &&out_qq : out_queues)
+                {
+                    for (auto &&out_q : out_qq) out_q->push(cmd);
+                }
+                return;
+            }
+            // FIXME: MOVE PROBLEM
+            const cv::GRunArg &in_arg = cv::util::get<cv::GRunArg>(cmd);
+            isl_inputs[id].first  = in_rcs[id];
+            isl_inputs[id].second = in_arg;
+        }
+
+        // Once the vector is obtained, prepare data for island execution
+        // Note - we first allocate output vector via GRunArg!
+        // Then it is converted to a GRunArgP.
+        std::vector<cv::gimpl::GIslandExecutable::OutObj> isl_outputs;
+        std::vector<cv::GRunArg> out_data;
+        isl_outputs.resize(out_rcs.size());
+        out_data.resize(out_rcs.size());
+        for (auto &&it : ade::util::indexed(out_rcs))
+        {
+            auto id = ade::util::index(it);
+            auto &r = ade::util::value(it);
+
+#if !defined(GAPI_STANDALONE)
+            using MatType = cv::Mat;
+            using SclType = cv::Scalar;
+#else
+            using MatType = cv::gapi::own::Mat;
+            using SclType = cv::gapi::own::Scalar;
+#endif // GAPI_STANDALONE
+
+            switch (r.shape) {
+                // Allocate a data object based on its shape & meta, and put it into our vectors.
+                // Yes, first we put a cv::Mat GRunArg, and then specify _THAT_
+                // pointer as an output parameter - to make sure that after island completes,
+                // our GRunArg still has the right (up-to-date) value.
+                // Same applies to other types.
+                // FIXME: This is absolutely ugly but seem to work perfectly for its purpose.
+            case cv::GShape::GMAT:
+                {
+                    MatType newMat;
+                    cv::gimpl::createMat(cv::util::get<cv::GMatDesc>(out_metas[id]), newMat);
+                    out_data[id] = cv::GRunArg(std::move(newMat));
+                    isl_outputs[id] = { r, cv::GRunArgP(&cv::util::get<MatType>(out_data[id])) };
+                }
+                break;
+            case cv::GShape::GSCALAR:
+                {
+                    SclType newScl;
+                    out_data[id] = cv::GRunArg(std::move(newScl));
+                    isl_outputs[id] = { r, cv::GRunArgP(&cv::util::get<SclType>(out_data[id])) };
+                }
+                break;
+            case cv::GShape::GARRAY:
+                {
+                    cv::detail::VectorRef newVec;
+                    cv::util::get<cv::detail::ConstructVec>(r.ctor)(newVec);
+                    out_data[id]= cv::GRunArg(std::move(newVec));
+                    // VectorRef is implicitly shared so no pointer is taken here
+                    const auto &rr = cv::util::get<cv::detail::VectorRef>(out_data[id]); // FIXME: that variant MOVE problem again
+                    isl_outputs[id] = { r, cv::GRunArgP(rr) };
+                }
+                break;
+            default:
+                cv::util::throw_error(std::logic_error("Unsupported GShape"));
+                break;
+            }
+        }
+        // Now ask Island to execute on this data
+        island->run(std::move(isl_inputs), std::move(isl_outputs));
+
+        // Once executed, dispatch our results down to the pipeline.
+        for (auto &&it : ade::util::zip(ade::util::toRange(out_queues),
+                                        ade::util::toRange(out_data)))
+        {
+            for (auto &&q : std::get<0>(it))
+            {
+                // FIXME: FATAL VARIANT ISSUE!!
+                const auto tmp = std::get<1>(it);
+                q->push(Cmd{tmp});
+            }
+        }
+    }
+}
+
+void collectorThread(std::vector<Q*> in_queues,
+                     Q&              out_queue)
+{
+    while (true)
+    {
+        cv::GRunArgs this_result(in_queues.size());
+        std::size_t stops = 0u;
+        for (auto &&it : ade::util::indexed(in_queues))
+        {
+            Cmd cmd;
+            ade::util::value(it)->pop(cmd);
+            if (cmd.index() == cmd.index_of<Stop>()) {
+                stops++;
+            } else {
+                // FIXME: MOVE_PROBLEM
+                const cv::GRunArg &in_arg = cv::util::get<cv::GRunArg>(cmd);
+                this_result[ade::util::index(it)] = in_arg;
+                // FIXME: Check for other message types.
+            }
+        }
+        if (stops > 0)
+        {
+            GAPI_Assert(stops == in_queues.size());
+            out_queue.push(Cmd{Stop{}});
+            return;
+        }
+        out_queue.push(Cmd{this_result});
+    }
+}
 } // anonymous namespace
 
 cv::gimpl::GStreamingExecutor::GStreamingExecutor(std::unique_ptr<ade::Graph> &&g_model)
@@ -74,7 +353,19 @@ cv::gimpl::GStreamingExecutor::GStreamingExecutor(std::unique_ptr<ade::Graph> &&
     // NB: This naive execution code is taken from GExecutor nearly "as-is"
 
     const auto proto = m_gm.metadata().get<Protocol>();
-    m_emitters.resize(proto.in_nhs.size());
+    m_emitters      .resize(proto.in_nhs.size());
+    m_emitter_queues.resize(proto.in_nhs.size());
+    m_sinks         .resize(proto.out_nhs.size());
+    m_sink_queues   .resize(proto.out_nhs.size());
+
+    // Very rough estimation to limit internal queue sizes.
+    // Pipeline depth is equal to number of its (pipeline) steps.
+    const auto queue_capacity = std::count_if
+        (m_gim.nodes().begin(),
+         m_gim.nodes().end(),
+         [&](ade::NodeHandle nh) {
+            return m_gim.metadata(nh).get<NodeKind>().k == NodeKind::ISLAND;
+         });
 
     auto sorted = m_gim.metadata().get<ade::passes::TopologicalSortData>();
     for (auto nh : sorted.nodes())
@@ -85,37 +376,63 @@ cv::gimpl::GStreamingExecutor::GStreamingExecutor(std::unique_ptr<ade::Graph> &&
             {
                 std::vector<RcDesc> input_rcs;
                 std::vector<RcDesc> output_rcs;
+                cv::GMetaArgs output_metas;
                 input_rcs.reserve(nh->inNodes().size());
                 output_rcs.reserve(nh->outNodes().size());
+                output_metas.reserve(nh->outNodes().size());
 
-                auto xtract = [&](ade::NodeHandle slot_nh, std::vector<RcDesc> &vec) {
+                // FIXME: THIS ORDER IS IRRELEVANT TO PROTOCOL OR ANY OTHER ORDER!
+                // FIXME: SAME APPLIES TO THE REGULAR GEEXECUTOR!!
+                auto xtract_in = [&](ade::NodeHandle slot_nh, std::vector<RcDesc> &vec) {
                     const auto orig_data_nh
                         = m_gim.metadata(slot_nh).get<DataSlot>().original_data_node;
                     const auto &orig_data_info
                         = m_gm.metadata(orig_data_nh).get<Data>();
+                    if (orig_data_info.shape == GShape::GARRAY) {
+                        GAPI_Assert(orig_data_info.ctor.index() != orig_data_info.ctor.index_of<cv::util::monostate>());
+                    }
                     vec.emplace_back(RcDesc{ orig_data_info.rc
                                            , orig_data_info.shape
                                            , orig_data_info.ctor});
                 };
-                // (3)
-                for (auto in_slot_nh  : nh->inNodes())  xtract(in_slot_nh,  input_rcs);
-                for (auto out_slot_nh : nh->outNodes()) xtract(out_slot_nh, output_rcs);
+                auto xtract_out = [&](ade::NodeHandle slot_nh, std::vector<RcDesc> &vec, cv::GMetaArgs &metas) {
+                    const auto orig_data_nh
+                        = m_gim.metadata(slot_nh).get<DataSlot>().original_data_node;
+                    const auto &orig_data_info
+                        = m_gm.metadata(orig_data_nh).get<Data>();
+                    if (orig_data_info.shape == GShape::GARRAY) {
+                        GAPI_Assert(orig_data_info.ctor.index() != orig_data_info.ctor.index_of<cv::util::monostate>());
+                    }
+                    vec.emplace_back(RcDesc{ orig_data_info.rc
+                                           , orig_data_info.shape
+                                           , orig_data_info.ctor});
+                    metas.emplace_back(orig_data_info.meta);
+                };
+                // FIXME: JEZ IT WAS SO AWFUL!!!!
+                for (auto in_slot_nh  : nh->inNodes())  xtract_in(in_slot_nh,  input_rcs);
+                for (auto out_slot_nh : nh->outNodes()) xtract_out(out_slot_nh, output_rcs, output_metas);
 
                 m_ops.emplace_back(OpDesc{ std::move(input_rcs)
                                          , std::move(output_rcs)
+                                         , std::move(output_metas)
+                                         , nh
                                          , m_gim.metadata(nh).get<IslandExec>().object});
+
+                // Initialize queues for every operation's input
+                ade::TypedGraph<DataQueue> qgr(*m_island_graph);
+                for (auto eh : nh->inEdges())
+                {
+                    qgr.metadata(eh).set(DataQueue(queue_capacity));
+                }
             }
             break;
-
         case NodeKind::SLOT:
             {
                 const auto orig_data_nh
                     = m_gim.metadata(nh).get<DataSlot>().original_data_node;
-                initResource(orig_data_nh);
                 m_slots.emplace_back(DataDesc{nh, orig_data_nh});
             }
             break;
-
         case NodeKind::EMIT:
             {
                 const auto emitter_idx
@@ -124,50 +441,26 @@ cv::gimpl::GStreamingExecutor::GStreamingExecutor(std::unique_ptr<ade::Graph> &&
                 m_emitters[emitter_idx] = nh;
             }
             break;
+        case NodeKind::SINK:
+            {
+                const auto sink_idx
+                    = m_gim.metadata(nh).get<Sink>().proto_index;
+                GAPI_Assert(sink_idx < m_sinks.size());
+                m_sinks[sink_idx] = nh;
 
+                // Also initialize Sink's input queue
+                ade::TypedGraph<DataQueue> qgr(*m_island_graph);
+                GAPI_Assert(nh->inEdges().size() == 1u);
+                qgr.metadata(nh->inEdges().front()).set(DataQueue(queue_capacity));
+                m_sink_queues[sink_idx] = &qgr.metadata(nh->inEdges().front()).get<DataQueue>().q;
+            }
+            break;
         default:
             GAPI_Assert(false);
             break;
         } // switch(kind)
     } // for(gim nodes)
-}
-
-void cv::gimpl::GStreamingExecutor::initResource(const ade::NodeHandle &orig_nh)
-{
-    const Data &d = m_gm.metadata(orig_nh).get<Data>();
-
-    if (   d.storage != Data::Storage::INTERNAL
-        && d.storage != Data::Storage::CONST_VAL)
-        return;
-
-    // INTERNALS+CONST only! no need to allocate/reset output objects
-    // to as it is bound externally (e.g. already in the m_res)
-
-    switch (d.shape)
-    {
-    case GShape::GMAT:
-        {
-            const auto desc = util::get<cv::GMatDesc>(d.meta);
-            auto& mat = m_res.slot<cv::gapi::own::Mat>()[d.rc];
-            createMat(desc, mat);
-        }
-        break;
-
-    case GShape::GSCALAR:
-        if (d.storage == Data::Storage::CONST_VAL)
-        {
-            auto rc = RcDesc{d.rc, d.shape, d.ctor};
-            magazine::bindInArg(m_res, rc, m_gm.metadata(orig_nh).get<ConstValue>().arg);
-        }
-        break;
-
-    case GShape::GARRAY:
-        // Constructed on Reset, do nothing here
-        break;
-
-    default:
-        GAPI_Assert(false);
-    }
+    m_out_queue.set_capacity(queue_capacity);
 }
 
 void cv::gimpl::GStreamingExecutor::setSource(GRunArgs &&ins)
@@ -207,125 +500,151 @@ void cv::gimpl::GStreamingExecutor::setSource(GRunArgs &&ins)
             break;
         }
     }
+
+    // FIXME: ONLY now, after all executable objects are created,
+    // we can set up our execution threads. Let's do it.
+    // First create threads for all the emitters.
+    // FIXME: One way to avoid this may be including an Emitter object as a part of
+    // START message. Why not?
+    GAPI_Assert(m_threads.empty()); // FIXME: NOW WE CAN RUN ONLY ONCE!!!
+    for (auto it : ade::util::indexed(m_emitters))
+    {
+        const auto id = ade::util::index(it); // = index in GComputation's protocol
+        const auto eh = ade::util::value(it);
+
+        // Prepare emitter thread parameters
+        auto emitter = m_gim.metadata(eh).get<Emitter>().object;
+
+        // Collect all reader queues from the emitter's the only output object
+        auto out_queues = reader_queues(*m_island_graph, eh->outNodes().front());
+
+        m_threads.emplace_back(emitterActorThread,
+                               emitter,
+                               std::ref(m_emitter_queues[id]),
+                               out_queues);
+    }
+
+    // Now do this for every island (in a topological order)
+    for (auto &&op : m_ops)
+    {
+        // Prepare island thread parameters
+        auto island = m_gim.metadata(op.nh).get<IslandExec>().object;
+
+        // Collect actor's input queues
+        auto in_queues = input_queues(*m_island_graph, op.nh);
+
+        // Collect actor's output queues.
+        // This may be tricky...
+        std::vector< std::vector<stream::Q*> > out_queues;
+        for (auto &&out_eh : op.nh->outNodes()) {
+            out_queues.push_back(reader_queues(*m_island_graph, out_eh));
+        }
+
+        m_threads.emplace_back(islandActorThread,
+                               op.in_objects,
+                               op.out_objects,
+                               op.out_metas,
+                               island,
+                               in_queues,
+                               out_queues);
+    }
+
+    // Finally, start a collector thread.
+    m_threads.emplace_back(collectorThread,
+                           m_sink_queues,
+                           std::ref(m_out_queue));
 }
 
 void cv::gimpl::GStreamingExecutor::start()
 {
-    // FIXME: there's nothig to do here now,
-    // but in fact this method should activate emitters to work
+    // FIXME: start/stop/pause/etc logic
+    GAPI_Assert(state == State::STOPPED);
+
+    // Currently just trigger our emitters to work
+    state = State::RUNNING;
+    for (auto &q : m_emitter_queues)
+    {
+        q.push(stream::Cmd{stream::Start{}});
+    }
 }
 
 bool cv::gimpl::GStreamingExecutor::pull(cv::GRunArgsP &&outs)
 {
-    // FIXME: This method should only obtain data which is already processed,
-    // or block until it arrives.
-    // Currently it is more like GExecutor::run() with some changes
+    if (state == State::STOPPED)
+        return false;
 
-    const auto& proto = m_gm.metadata().get<Protocol>();
+    GAPI_Assert(m_sink_queues.size() == outs.size());
 
-    // First, poll data emitters to obtain "next data frame"
-    std::vector<GRunArg> this_shot;
-    this_shot.resize(proto.inputs.size());
-    for (auto it : ade::util::indexed(m_emitters))
+    Cmd cmd;
+    m_out_queue.pop(cmd);
+    if (cmd.index() == cmd.index_of<Stop>())
     {
-        auto idx = ade::util::index(it);
-        auto eh  = ade::util::value(it);
-
-        if (!m_gim.metadata(eh).get<Emitter>().object->pull(this_shot[idx])) {
-            // Emitter pull failure means end-of-stream
-            return false;
-        }
-    }
-    // FIXME: probably these two cycles can be merged into one
-    for (auto it : ade::util::zip(ade::util::toRange(proto.inputs),
-                                  ade::util::toRange(this_shot)))
-    {
-        magazine::bindInArg(m_res, std::get<0>(it), std::get<1>(it));
+        for (auto &t : m_threads) t.join();
+        state = State::STOPPED;
+        return false;
     }
 
-    //ensure that output Mat parameters are correctly allocated
-    for (auto index : ade::util::iota(proto.out_nhs.size()) )     //FIXME: avoid copy of NodeHandle and GRunRsltComp ?
-    {
-        auto& nh = proto.out_nhs.at(index);
-        const Data &d = m_gm.metadata(nh).get<Data>();
-        if (d.shape == GShape::GMAT)
-        {
-            using cv::util::get;
-            const auto desc = get<cv::GMatDesc>(d.meta);
+    GAPI_Assert(cmd.index() == cmd.index_of<cv::GRunArgs>());
+    cv::GRunArgs &this_result = cv::util::get<cv::GRunArgs>(cmd);
+    sync_data(this_result, outs);
+    return true;
+}
 
-            auto check_own_mat = [&desc, &outs, &index]()
-            {
-                auto& out_mat = *get<cv::gapi::own::Mat*>(outs.at(index));
-                GAPI_Assert(out_mat.data != nullptr &&
-                        desc.canDescribe(out_mat));
-            };
+bool cv::gimpl::GStreamingExecutor::try_pull(cv::GRunArgsP &&outs)
+{
+    if (state == State::STOPPED)
+        return false;
 
-#if !defined(GAPI_STANDALONE)
-            if (cv::util::holds_alternative<cv::Mat*>(outs.at(index)))
-            {
-                auto& out_mat = *get<cv::Mat*>(outs.at(index));
-                createMat(desc, out_mat);
-            }
-            // In the case of own::Mat never reallocated, checked to perfectly fit required meta
-            else
-#endif
-            {
-                check_own_mat();
-            }
-        }
+    GAPI_Assert(m_sink_queues.size() == outs.size());
+
+    Cmd cmd;
+    if (!m_out_queue.try_pop(cmd)) {
+        return false;
     }
-    // Bind results to storage
-    for (auto it : ade::util::zip(ade::util::toRange(proto.outputs),
-                                  ade::util::toRange(outs)))
+    if (cmd.index() == cmd.index_of<Stop>())
     {
-        magazine::bindOutArg(m_res, std::get<0>(it), std::get<1>(it));
+        // FIXME: Unify with pull()
+        for (auto &t : m_threads) t.join();
+        state = State::STOPPED;
+        return false;
     }
 
-    // Reset internal data
-    for (auto &sd : m_slots)
-    {
-        const auto& data = m_gm.metadata(sd.data_nh).get<Data>();
-        magazine::resetInternalData(m_res, data);
-    }
-
-    // Run the script
-    for (auto &op : m_ops)
-    {
-        // (5)
-        using InObj  = GIslandExecutable::InObj;
-        using OutObj = GIslandExecutable::OutObj;
-        std::vector<InObj>  in_objs;
-        std::vector<OutObj> out_objs;
-        in_objs.reserve (op.in_objects.size());
-        out_objs.reserve(op.out_objects.size());
-
-        for (const auto &rc : op.in_objects)
-        {
-            in_objs.emplace_back(InObj{rc, magazine::getArg(m_res, rc)});
-        }
-        for (const auto &rc : op.out_objects)
-        {
-            out_objs.emplace_back(OutObj{rc, magazine::getObjPtr(m_res, rc)});
-        }
-
-        // (6)
-        op.isl_exec->run(std::move(in_objs), std::move(out_objs));
-    }
-
-    // (7)
-    for (auto it : ade::util::zip(ade::util::toRange(proto.outputs),
-                                  ade::util::toRange(outs)))
-    {
-        magazine::writeBack(m_res, std::get<0>(it), std::get<1>(it));
-    }
-
-    return true; // Obtained data succesfully
+    GAPI_Assert(cmd.index() == cmd.index_of<cv::GRunArgs>());
+    cv::GRunArgs &this_result = cv::util::get<cv::GRunArgs>(cmd);
+    sync_data(this_result, outs);
+    return true;
 }
 
 void cv::gimpl::GStreamingExecutor::stop()
 {
-    // FIXME: there's nothing to do here now,
-    // but in fact once pipeline is stopped explicitly,
-    // pull() should start doing nothing and return false.
+    if (state == State::STOPPED)
+        return;
+
     // FIXME: ...and how to deal with still-unread data then?
+    // Push a Stop message to the every emitter,
+    // wait until it broadcasts within the pipeline,
+    // FIXME: worker threads could stuck on push()!
+    // need to read the output queues until Stop!
+    for (auto &q : m_emitter_queues) {
+        q.push(stream::Cmd{stream::Stop{}});
+    }
+
+    // Pull messages from the final queue to ensure completion
+    Cmd cmd;
+    while (cmd.index() != cmd.index_of<Stop>()) {
+        m_out_queue.pop(cmd);
+    }
+    GAPI_Assert(cmd.index() == cmd.index_of<Stop>());
+
+    for (auto &t : m_threads) {
+        t.join();
+    }
+    m_threads.clear();
+    // FIXME: Auto-stop on object destruction?
+    // There still must be a graceful shutdown!!!
+}
+
+bool cv::gimpl::GStreamingExecutor::running() const
+{
+    return (state == State::RUNNING);
 }

--- a/modules/gapi/src/executor/gstreamingexecutor.cpp
+++ b/modules/gapi/src/executor/gstreamingexecutor.cpp
@@ -4,7 +4,6 @@
 //
 // Copyright (C) 2019 Intel Corporation
 
-
 #include "precomp.hpp"
 
 #include <iostream>
@@ -263,22 +262,25 @@ void islandActorThread(std::vector<cv::gimpl::RcDesc> in_rcs,                // 
                 }
                 // FIXME: MOVE PROBLEM
                 const cv::GRunArg &in_arg = cv::util::get<cv::GRunArg>(cmd[id]);
+#if defined(GAPI_STANDALONE)
+                // Standalone mode - simply store input argument in the vector as-is
+                isl_inputs[id].second = in_arg;
+#else
                 // Make Islands operate on own:: data types (i.e. in the same
                 // environment as GExecutor provides)
                 // This way several backends (e.g. Fluid) remain OpenCV-independent.
                 switch (in_arg.index()) {
-#if !defined(GAPI_STANDALONE)
                 case cv::GRunArg::index_of<cv::Mat>():
-                    isl_inputs[id].second = cv::GRunArg{const_cast<const cv::gapi::own::Mat&>(cv::to_own(cv::util::get<cv::Mat>(in_arg)))};
+                    isl_inputs[id].second = cv::GRunArg{cv::to_own(cv::util::get<cv::Mat>(in_arg))};
                     break;
                 case cv::GRunArg::index_of<cv::Scalar>():
-                    isl_inputs[id].second = cv::GRunArg{const_cast<const cv::gapi::own::Scalar&>(cv::to_own(cv::util::get<cv::Scalar>(in_arg)))};
+                    isl_inputs[id].second = cv::GRunArg{cv::to_own(cv::util::get<cv::Scalar>(in_arg))};
                     break;
-#endif // !GAPI_STANDALONE
                 default:
                     isl_inputs[id].second = in_arg;
                     break;
                 }
+#endif // GAPI_STANDALONE
             }
         }
         // Once the vector is obtained, prepare data for island execution

--- a/modules/gapi/src/executor/gstreamingexecutor.cpp
+++ b/modules/gapi/src/executor/gstreamingexecutor.cpp
@@ -1,5 +1,4 @@
 // This file is part of OpenCV project.
-
 // It is subject to the license terms in the LICENSE file found in the top-level directory
 // of this distribution and at http://opencv.org/license.html.
 //
@@ -124,7 +123,7 @@ void sync_data(cv::GRunArgs &results, cv::GRunArgsP &outputs)
         case T::index_of<cv::Scalar*>():
             *cv::util::get<cv::Scalar*>(out_obj) = std::move(cv::util::get<cv::Scalar>(res_obj));
             break;
-#endif // GAPI_STANDALONE
+#endif // !GAPI_STANDALONE
         case T::index_of<own::Mat*>():
             *cv::util::get<own::Mat*>(out_obj) = std::move(cv::util::get<own::Mat>(res_obj));
             break;
@@ -320,6 +319,11 @@ void islandActorThread(std::vector<cv::gimpl::RcDesc> in_rcs,                // 
     }
 }
 
+// The idea of collecotThread is easy.  If there're multiple outptus
+// in the graph, we need to pull an object from every associated query
+// and then put the resulting vector into one single query.  While it
+// looks redundant, it simplifies dramatically the way how try_pull()
+// is implemented - we need to check one queue instead of may.
 void collectorThread(std::vector<Q*> in_queues,
                      Q&              out_queue)
 {

--- a/modules/gapi/src/executor/gstreamingexecutor.cpp
+++ b/modules/gapi/src/executor/gstreamingexecutor.cpp
@@ -642,6 +642,8 @@ void cv::gimpl::GStreamingExecutor::stop()
     m_threads.clear();
     // FIXME: Auto-stop on object destruction?
     // There still must be a graceful shutdown!!!
+
+    state = State::STOPPED;
 }
 
 bool cv::gimpl::GStreamingExecutor::running() const

--- a/modules/gapi/src/executor/gstreamingexecutor.cpp
+++ b/modules/gapi/src/executor/gstreamingexecutor.cpp
@@ -1,0 +1,331 @@
+// This file is part of OpenCV project.
+
+// It is subject to the license terms in the LICENSE file found in the top-level directory
+// of this distribution and at http://opencv.org/license.html.
+//
+// Copyright (C) 2019 Intel Corporation
+
+
+#include "precomp.hpp"
+
+
+#include <iostream>
+
+#include <ade/util/zip_range.hpp>
+
+#if !defined(GAPI_STANDALONE)
+#include <opencv2/videoio.hpp>   // FIXME: MOVE THIS DEPENDENCY OUT!!1
+#endif // GAPI_STANDALONE
+#include <opencv2/gapi/opencv_includes.hpp>
+#include "executor/gstreamingexecutor.hpp"
+#include "compiler/passes/passes.hpp"
+
+namespace
+{
+#if !defined(GAPI_STANDALONE)
+    class VideoEmitter final: public cv::gimpl::GIslandEmitter {
+        // FIXME: This is a huge dependency for core G-API library!
+        // It needs to be moved out to some separate module.
+        cv::VideoCapture vcap;
+
+        virtual bool pull(cv::GRunArg &arg) override {
+            // FIXME: probably we can maintain a pool of (then) pre-allocated
+            // buffers to avoid runtime allocations.
+            // Pool size can be determined given the internal queue size.
+            cv::Mat nextFrame;
+            vcap >> nextFrame;
+            if (nextFrame.empty()) {
+                return false;
+            }
+            arg = std::move(nextFrame);
+            return true;
+        }
+    public:
+
+        explicit VideoEmitter(const cv::GRunArg &arg) {
+            const auto &param = cv::util::get<cv::gapi::GVideoCapture>(arg);
+            GAPI_Assert(vcap.open(param.path));
+        }
+    };
+#endif // GAPI_STANDALONE
+
+    class ConstEmitter final: public cv::gimpl::GIslandEmitter {
+        cv::GRunArg m_arg;
+
+        virtual bool pull(cv::GRunArg &arg) override {
+            arg = m_arg;
+            return true;
+        }
+    public:
+
+        explicit ConstEmitter(const cv::GRunArg &arg) : m_arg(arg) {
+        }
+    };
+} // anonymous namespace
+
+cv::gimpl::GStreamingExecutor::GStreamingExecutor(std::unique_ptr<ade::Graph> &&g_model)
+    : m_orig_graph(std::move(g_model))
+    , m_island_graph(GModel::Graph(*m_orig_graph).metadata()
+                     .get<IslandModel>().model)
+    , m_gm(*m_orig_graph)
+    , m_gim(*m_island_graph)
+{
+    // NB: Right now GIslandModel is acyclic, and all the below code assumes that.
+    // NB: This naive execution code is taken from GExecutor nearly "as-is"
+
+    const auto proto = m_gm.metadata().get<Protocol>();
+    m_emitters.resize(proto.in_nhs.size());
+
+    auto sorted = m_gim.metadata().get<ade::passes::TopologicalSortData>();
+    for (auto nh : sorted.nodes())
+    {
+        switch (m_gim.metadata(nh).get<NodeKind>().k)
+        {
+        case NodeKind::ISLAND:
+            {
+                std::vector<RcDesc> input_rcs;
+                std::vector<RcDesc> output_rcs;
+                input_rcs.reserve(nh->inNodes().size());
+                output_rcs.reserve(nh->outNodes().size());
+
+                auto xtract = [&](ade::NodeHandle slot_nh, std::vector<RcDesc> &vec) {
+                    const auto orig_data_nh
+                        = m_gim.metadata(slot_nh).get<DataSlot>().original_data_node;
+                    const auto &orig_data_info
+                        = m_gm.metadata(orig_data_nh).get<Data>();
+                    vec.emplace_back(RcDesc{ orig_data_info.rc
+                                           , orig_data_info.shape
+                                           , orig_data_info.ctor});
+                };
+                // (3)
+                for (auto in_slot_nh  : nh->inNodes())  xtract(in_slot_nh,  input_rcs);
+                for (auto out_slot_nh : nh->outNodes()) xtract(out_slot_nh, output_rcs);
+
+                m_ops.emplace_back(OpDesc{ std::move(input_rcs)
+                                         , std::move(output_rcs)
+                                         , m_gim.metadata(nh).get<IslandExec>().object});
+            }
+            break;
+
+        case NodeKind::SLOT:
+            {
+                const auto orig_data_nh
+                    = m_gim.metadata(nh).get<DataSlot>().original_data_node;
+                initResource(orig_data_nh);
+                m_slots.emplace_back(DataDesc{nh, orig_data_nh});
+            }
+            break;
+
+        case NodeKind::EMIT:
+            {
+                const auto emitter_idx
+                    = m_gim.metadata(nh).get<Emitter>().proto_index;
+                GAPI_Assert(emitter_idx < m_emitters.size());
+                m_emitters[emitter_idx] = nh;
+            }
+            break;
+
+        default:
+            GAPI_Assert(false);
+            break;
+        } // switch(kind)
+    } // for(gim nodes)
+}
+
+void cv::gimpl::GStreamingExecutor::initResource(const ade::NodeHandle &orig_nh)
+{
+    const Data &d = m_gm.metadata(orig_nh).get<Data>();
+
+    if (   d.storage != Data::Storage::INTERNAL
+        && d.storage != Data::Storage::CONST_VAL)
+        return;
+
+    // INTERNALS+CONST only! no need to allocate/reset output objects
+    // to as it is bound externally (e.g. already in the m_res)
+
+    switch (d.shape)
+    {
+    case GShape::GMAT:
+        {
+            const auto desc = util::get<cv::GMatDesc>(d.meta);
+            auto& mat = m_res.slot<cv::gapi::own::Mat>()[d.rc];
+            createMat(desc, mat);
+        }
+        break;
+
+    case GShape::GSCALAR:
+        if (d.storage == Data::Storage::CONST_VAL)
+        {
+            auto rc = RcDesc{d.rc, d.shape, d.ctor};
+            magazine::bindInArg(m_res, rc, m_gm.metadata(orig_nh).get<ConstValue>().arg);
+        }
+        break;
+
+    case GShape::GARRAY:
+        // Constructed on Reset, do nothing here
+        break;
+
+    default:
+        GAPI_Assert(false);
+    }
+}
+
+void cv::gimpl::GStreamingExecutor::setSource(GRunArgs &&ins)
+{
+    bool has_video = false;
+
+    // Walk through the protocol, set-up emitters appropriately
+    // There's a 1:1 mapping between emitters and corresponding data inputs.
+    for (auto it : ade::util::zip(ade::util::toRange(m_emitters),
+                                  ade::util::toRange(ins)))
+    {
+        auto  emit_nh  = std::get<0>(it);
+        auto& emit_arg = std::get<1>(it);
+        auto& emitter  = m_gim.metadata(emit_nh).get<Emitter>().object;
+
+        switch (emit_arg.index())
+        {
+        // Create a streaming emitter.
+        // Produces the next video frame when pulled.
+        case emit_arg.index_of<cv::gapi::GVideoCapture>():
+            if (has_video)
+                util::throw_error(std::logic_error("Only one video source is"
+                                                   " currently supported!"));
+            has_video = true;
+#if !defined(GAPI_STANDALONE)
+            emitter.reset(new VideoEmitter{emit_arg});
+#else
+            util::throw_error(std::logic_error("Video is not supported in the "
+                                               "standalone mode"));
+#endif
+            break;
+
+        default:
+            // Create a constant emitter.
+            // Produces always the same ("constant") value when pulled.
+            emitter.reset(new ConstEmitter{emit_arg});
+            break;
+        }
+    }
+}
+
+void cv::gimpl::GStreamingExecutor::start()
+{
+    // FIXME: there's nothig to do here now,
+    // but in fact this method should activate emitters to work
+}
+
+bool cv::gimpl::GStreamingExecutor::pull(cv::GRunArgsP &&outs)
+{
+    // FIXME: This method should only obtain data which is already processed,
+    // or block until it arrives.
+    // Currently it is more like GExecutor::run() with some changes
+
+    const auto& proto = m_gm.metadata().get<Protocol>();
+
+    // First, poll data emitters to obtain "next data frame"
+    std::vector<GRunArg> this_shot;
+    this_shot.resize(proto.inputs.size());
+    for (auto it : ade::util::indexed(m_emitters))
+    {
+        auto idx = ade::util::index(it);
+        auto eh  = ade::util::value(it);
+
+        if (!m_gim.metadata(eh).get<Emitter>().object->pull(this_shot[idx])) {
+            // Emitter pull failure means end-of-stream
+            return false;
+        }
+    }
+    // FIXME: probably these two cycles can be merged into one
+    for (auto it : ade::util::zip(ade::util::toRange(proto.inputs),
+                                  ade::util::toRange(this_shot)))
+    {
+        magazine::bindInArg(m_res, std::get<0>(it), std::get<1>(it));
+    }
+
+    //ensure that output Mat parameters are correctly allocated
+    for (auto index : ade::util::iota(proto.out_nhs.size()) )     //FIXME: avoid copy of NodeHandle and GRunRsltComp ?
+    {
+        auto& nh = proto.out_nhs.at(index);
+        const Data &d = m_gm.metadata(nh).get<Data>();
+        if (d.shape == GShape::GMAT)
+        {
+            using cv::util::get;
+            const auto desc = get<cv::GMatDesc>(d.meta);
+
+            auto check_own_mat = [&desc, &outs, &index]()
+            {
+                auto& out_mat = *get<cv::gapi::own::Mat*>(outs.at(index));
+                GAPI_Assert(out_mat.data != nullptr &&
+                        desc.canDescribe(out_mat));
+            };
+
+#if !defined(GAPI_STANDALONE)
+            if (cv::util::holds_alternative<cv::Mat*>(outs.at(index)))
+            {
+                auto& out_mat = *get<cv::Mat*>(outs.at(index));
+                createMat(desc, out_mat);
+            }
+            // In the case of own::Mat never reallocated, checked to perfectly fit required meta
+            else
+#endif
+            {
+                check_own_mat();
+            }
+        }
+    }
+    // Bind results to storage
+    for (auto it : ade::util::zip(ade::util::toRange(proto.outputs),
+                                  ade::util::toRange(outs)))
+    {
+        magazine::bindOutArg(m_res, std::get<0>(it), std::get<1>(it));
+    }
+
+    // Reset internal data
+    for (auto &sd : m_slots)
+    {
+        const auto& data = m_gm.metadata(sd.data_nh).get<Data>();
+        magazine::resetInternalData(m_res, data);
+    }
+
+    // Run the script
+    for (auto &op : m_ops)
+    {
+        // (5)
+        using InObj  = GIslandExecutable::InObj;
+        using OutObj = GIslandExecutable::OutObj;
+        std::vector<InObj>  in_objs;
+        std::vector<OutObj> out_objs;
+        in_objs.reserve (op.in_objects.size());
+        out_objs.reserve(op.out_objects.size());
+
+        for (const auto &rc : op.in_objects)
+        {
+            in_objs.emplace_back(InObj{rc, magazine::getArg(m_res, rc)});
+        }
+        for (const auto &rc : op.out_objects)
+        {
+            out_objs.emplace_back(OutObj{rc, magazine::getObjPtr(m_res, rc)});
+        }
+
+        // (6)
+        op.isl_exec->run(std::move(in_objs), std::move(out_objs));
+    }
+
+    // (7)
+    for (auto it : ade::util::zip(ade::util::toRange(proto.outputs),
+                                  ade::util::toRange(outs)))
+    {
+        magazine::writeBack(m_res, std::get<0>(it), std::get<1>(it));
+    }
+
+    return true; // Obtained data succesfully
+}
+
+void cv::gimpl::GStreamingExecutor::stop()
+{
+    // FIXME: there's nothing to do here now,
+    // but in fact once pipeline is stopped explicitly,
+    // pull() should start doing nothing and return false.
+    // FIXME: ...and how to deal with still-unread data then?
+}

--- a/modules/gapi/src/executor/gstreamingexecutor.cpp
+++ b/modules/gapi/src/executor/gstreamingexecutor.cpp
@@ -8,7 +8,6 @@
 
 #include "precomp.hpp"
 
-
 #include <iostream>
 
 #include <ade/util/zip_range.hpp>
@@ -113,31 +112,28 @@ void sync_data(cv::GRunArgs &results, cv::GRunArgsP &outputs)
         auto &res_obj = std::get<1>(it);
 
         // FIXME: this conversion should be unified
+        using T = cv::GRunArgP;
         switch (out_obj.index())
         {
 #if !defined(GAPI_STANDALONE)
-        case out_obj.index_of<cv::Mat*>():
+        case T::index_of<cv::Mat*>():
             *cv::util::get<cv::Mat*>(out_obj) = std::move(cv::util::get<cv::Mat>(res_obj));
             break;
-        case out_obj.index_of<cv::Scalar*>():
+        case T::index_of<cv::Scalar*>():
             *cv::util::get<cv::Scalar*>(out_obj) = std::move(cv::util::get<cv::Scalar>(res_obj));
             break;
 #endif // GAPI_STANDALONE
-        case out_obj.index_of<own::Mat*>():
+        case T::index_of<own::Mat*>():
             *cv::util::get<own::Mat*>(out_obj) = std::move(cv::util::get<own::Mat>(res_obj));
             break;
-        case out_obj.index_of<own::Scalar*>():
+        case T::index_of<own::Scalar*>():
             *cv::util::get<own::Scalar*>(out_obj) = std::move(cv::util::get<own::Scalar>(res_obj));
             break;
-        case out_obj.index_of<cv::detail::VectorRef>():
+        case T::index_of<cv::detail::VectorRef>():
             cv::util::get<cv::detail::VectorRef>(out_obj).mov(cv::util::get<cv::detail::VectorRef>(res_obj));
             break;
         default:
-            GAPI_Assert(false && "This value type is not supported!"
-#if defined(GAPI_STANDALONE)
-                                 " (probably because of STANDALONE mode"
-#endif // GAPI_STANDALONE
-                        );
+            GAPI_Assert(false && "This value type is not supported!"); // ...maybe because of STANDALONE mode.
             break;
         }
     }
@@ -476,11 +472,12 @@ void cv::gimpl::GStreamingExecutor::setSource(GRunArgs &&ins)
         auto& emit_arg = std::get<1>(it);
         auto& emitter  = m_gim.metadata(emit_nh).get<Emitter>().object;
 
+        using T = GRunArg;
         switch (emit_arg.index())
         {
         // Create a streaming emitter.
         // Produces the next video frame when pulled.
-        case emit_arg.index_of<cv::gapi::GVideoCapture>():
+        case T::index_of<cv::gapi::GVideoCapture>():
             if (has_video)
                 util::throw_error(std::logic_error("Only one video source is"
                                                    " currently supported!"));

--- a/modules/gapi/src/executor/gstreamingexecutor.cpp
+++ b/modules/gapi/src/executor/gstreamingexecutor.cpp
@@ -357,11 +357,11 @@ void islandActorThread(std::vector<cv::gimpl::RcDesc> in_rcs,                // 
     }
 }
 
-// The idea of collecotThread is easy.  If there're multiple outptus
-// in the graph, we need to pull an object from every associated query
-// and then put the resulting vector into one single query.  While it
+// The idea of collectorThread is easy.  If there're multiple outputs
+// in the graph, we need to pull an object from every associated queue
+// and then put the resulting vector into one single queue.  While it
 // looks redundant, it simplifies dramatically the way how try_pull()
-// is implemented - we need to check one queue instead of may.
+// is implemented - we need to check one queue instead of many.
 void collectorThread(std::vector<Q*> in_queues,
                      Q&              out_queue)
 {

--- a/modules/gapi/src/executor/gstreamingexecutor.cpp
+++ b/modules/gapi/src/executor/gstreamingexecutor.cpp
@@ -359,13 +359,13 @@ cv::gimpl::GStreamingExecutor::GStreamingExecutor(std::unique_ptr<ade::Graph> &&
     : m_orig_graph(std::move(g_model))
     , m_island_graph(GModel::Graph(*m_orig_graph).metadata()
                      .get<IslandModel>().model)
-    , m_gm(*m_orig_graph)
     , m_gim(*m_island_graph)
 {
+    GModel::Graph gm(*m_orig_graph);
     // NB: Right now GIslandModel is acyclic, and all the below code assumes that.
     // NB: This naive execution code is taken from GExecutor nearly "as-is"
 
-    const auto proto = m_gm.metadata().get<Protocol>();
+    const auto proto = gm.metadata().get<Protocol>();
     m_emitters      .resize(proto.in_nhs.size());
     m_emitter_queues.resize(proto.in_nhs.size());
     m_sinks         .resize(proto.out_nhs.size());
@@ -404,11 +404,11 @@ cv::gimpl::GStreamingExecutor::GStreamingExecutor(std::unique_ptr<ade::Graph> &&
                     const auto orig_data_nh
                         = m_gim.metadata(slot_nh).get<DataSlot>().original_data_node;
                     const auto &orig_data_info
-                        = m_gm.metadata(orig_data_nh).get<Data>();
+                        = gm.metadata(orig_data_nh).get<Data>();
                     if (orig_data_info.storage == Data::Storage::CONST_VAL) {
                         const_ins.insert(slot_nh);
                         // FIXME: Variant move issue
-                        in_constants.push_back(const_cast<const cv::GRunArg&>(m_gm.metadata(orig_data_nh).get<ConstValue>().arg));
+                        in_constants.push_back(const_cast<const cv::GRunArg&>(gm.metadata(orig_data_nh).get<ConstValue>().arg));
                     } else in_constants.push_back(cv::GRunArg{});
                     if (orig_data_info.shape == GShape::GARRAY) {
                         GAPI_Assert(orig_data_info.ctor.index() != orig_data_info.ctor.index_of<cv::util::monostate>());
@@ -421,7 +421,7 @@ cv::gimpl::GStreamingExecutor::GStreamingExecutor(std::unique_ptr<ade::Graph> &&
                     const auto orig_data_nh
                         = m_gim.metadata(slot_nh).get<DataSlot>().original_data_node;
                     const auto &orig_data_info
-                        = m_gm.metadata(orig_data_nh).get<Data>();
+                        = gm.metadata(orig_data_nh).get<Data>();
                     if (orig_data_info.shape == GShape::GARRAY) {
                         GAPI_Assert(orig_data_info.ctor.index() != orig_data_info.ctor.index_of<cv::util::monostate>());
                     }

--- a/modules/gapi/src/executor/gstreamingexecutor.hpp
+++ b/modules/gapi/src/executor/gstreamingexecutor.hpp
@@ -69,6 +69,8 @@ protected:
         cv::GMetaArgs       out_metas;
         ade::NodeHandle     nh;
 
+        std::vector<GRunArg> in_constants;
+
         // FIXME: remove it as unused
         std::shared_ptr<GIslandExecutable> isl_exec;
     };

--- a/modules/gapi/src/executor/gstreamingexecutor.hpp
+++ b/modules/gapi/src/executor/gstreamingexecutor.hpp
@@ -57,7 +57,6 @@ protected:
     std::unique_ptr<ade::Graph> m_orig_graph;
     std::shared_ptr<ade::Graph> m_island_graph;
 
-    cv::gimpl::GModel::Graph       m_gm;  // FIXME: make const?
     cv::gimpl::GIslandModel::Graph m_gim; // FIXME: make const?
 
     // FIXME: Naive executor details are here for now

--- a/modules/gapi/src/executor/gstreamingexecutor.hpp
+++ b/modules/gapi/src/executor/gstreamingexecutor.hpp
@@ -1,0 +1,69 @@
+// This file is part of OpenCV project.
+// It is subject to the license terms in the LICENSE file found in the top-level directory
+// of this distribution and at http://opencv.org/license.html.
+//
+// Copyright (C) 2019 Intel Corporation
+
+#ifndef OPENCV_GAPI_GSTREAMING_EXECUTOR_HPP
+#define OPENCV_GAPI_GSTREAMING_EXECUTOR_HPP
+
+#include <memory> // unique_ptr, shared_ptr
+
+#include <utility> // tuple, required by magazine
+#include <unordered_map> // required by magazine
+
+#include <ade/graph.hpp>
+
+#include "backends/common/gbackend.hpp"
+
+namespace cv {
+namespace gimpl {
+
+// FIXME: Currently all GExecutor comments apply also
+// to this one. Please document it separately in the future.
+
+class GStreamingExecutor
+{
+protected:
+    std::unique_ptr<ade::Graph> m_orig_graph;
+    std::shared_ptr<ade::Graph> m_island_graph;
+
+    cv::gimpl::GModel::Graph       m_gm;  // FIXME: make const?
+    cv::gimpl::GIslandModel::Graph m_gim; // FIXME: make const?
+
+    // FIXME: Naive executor details are here for now
+    // but then it should be moved to another place
+    struct OpDesc
+    {
+        std::vector<RcDesc> in_objects;
+        std::vector<RcDesc> out_objects;
+        std::shared_ptr<GIslandExecutable> isl_exec;
+    };
+    std::vector<OpDesc> m_ops;
+
+    struct DataDesc
+    {
+        ade::NodeHandle slot_nh;
+        ade::NodeHandle data_nh;
+    };
+    std::vector<DataDesc> m_slots;
+
+    // Order in this vector follows the GComputaion's protocol
+    std::vector<ade::NodeHandle> m_emitters;
+
+    Mag m_res;
+
+    void initResource(const ade::NodeHandle &orig_nh); // FIXME: shouldn't it be RcDesc?
+
+public:
+    explicit GStreamingExecutor(std::unique_ptr<ade::Graph> &&g_model);
+    void setSource(GRunArgs &&args);
+    void start();
+    bool pull(cv::GRunArgsP &&outs);
+    void stop();
+};
+
+} // namespace gimpl
+} // namespace cv
+
+#endif // OPENCV_GAPI_GSTREAMING_EXECUTOR_HPP

--- a/modules/gapi/src/executor/gstreamingexecutor.hpp
+++ b/modules/gapi/src/executor/gstreamingexecutor.hpp
@@ -10,7 +10,13 @@
 #include <memory> // unique_ptr, shared_ptr
 #include <thread> // thread
 
-#include <tbb/concurrent_queue.h> // FIXME: drop it from here!
+#if defined(HAVE_TBB)
+#  include <tbb/concurrent_queue.h> // FIXME: drop it from here!
+template<typename T> using QueueClass = tbb::concurrent_bounded_queue<T>;
+#else
+#  include "executor/conc_queue.hpp"
+template<typename T> using QueueClass = cv::gapi::own::concurrent_bounded_queue<T>;
+#endif // TBB
 
 #include <ade/graph.hpp>
 
@@ -29,7 +35,7 @@ using Cmd = cv::util::variant
     , cv::GRunArg  // Workers data payload to process.
     , cv::GRunArgs // Full results vector
     >;
-using Q = tbb::concurrent_bounded_queue<Cmd>;
+using Q = QueueClass<Cmd>;
 } // namespace stream
 
 // FIXME: Currently all GExecutor comments apply also

--- a/modules/gapi/src/executor/gstreamingexecutor.hpp
+++ b/modules/gapi/src/executor/gstreamingexecutor.hpp
@@ -7,6 +7,11 @@
 #ifndef OPENCV_GAPI_GSTREAMING_EXECUTOR_HPP
 #define OPENCV_GAPI_GSTREAMING_EXECUTOR_HPP
 
+#ifdef _MSC_VER
+#pragma warning(disable: 4503)  // "decorated name length exceeded"
+                                // on concurrent_bounded_queue
+#endif
+
 #include <memory> // unique_ptr, shared_ptr
 #include <thread> // thread
 

--- a/modules/gapi/src/executor/gstreamingexecutor.hpp
+++ b/modules/gapi/src/executor/gstreamingexecutor.hpp
@@ -106,7 +106,6 @@ protected:
     std::vector<ade::NodeHandle> m_emitters;
     std::vector<ade::NodeHandle> m_sinks;
 
-    cv::util::optional<cv::GRunArgs> m_last_source;
     std::vector<std::thread> m_threads;
     std::vector<stream::Q>   m_emitter_queues;
     std::vector<stream::Q*>  m_const_emitter_queues; // a view over m_emitter_queues

--- a/modules/gapi/src/executor/gstreamingexecutor.hpp
+++ b/modules/gapi/src/executor/gstreamingexecutor.hpp
@@ -8,9 +8,9 @@
 #define OPENCV_GAPI_GSTREAMING_EXECUTOR_HPP
 
 #include <memory> // unique_ptr, shared_ptr
+#include <thread> // thread
 
-#include <utility> // tuple, required by magazine
-#include <unordered_map> // required by magazine
+#include <tbb/concurrent_queue.h> // FIXME: drop it from here!
 
 #include <ade/graph.hpp>
 
@@ -19,12 +19,30 @@
 namespace cv {
 namespace gimpl {
 
+namespace stream {
+struct Start {};
+struct Stop {};
+
+using Cmd = cv::util::variant
+    < Start        // Tells emitters to start working. Not broadcasted to workers.
+    , Stop         // Tells emitters to stop working. Broadcasted to workers.
+    , cv::GRunArg  // Workers data payload to process.
+    , cv::GRunArgs // Full results vector
+    >;
+using Q = tbb::concurrent_bounded_queue<Cmd>;
+} // namespace stream
+
 // FIXME: Currently all GExecutor comments apply also
 // to this one. Please document it separately in the future.
 
 class GStreamingExecutor
 {
 protected:
+    enum class State {
+        STOPPED,
+        RUNNING,
+    } state = State::STOPPED;
+
     std::unique_ptr<ade::Graph> m_orig_graph;
     std::shared_ptr<ade::Graph> m_island_graph;
 
@@ -37,6 +55,10 @@ protected:
     {
         std::vector<RcDesc> in_objects;
         std::vector<RcDesc> out_objects;
+        cv::GMetaArgs       out_metas;
+        ade::NodeHandle     nh;
+
+        // FIXME: remove it as unused
         std::shared_ptr<GIslandExecutable> isl_exec;
     };
     std::vector<OpDesc> m_ops;
@@ -48,19 +70,23 @@ protected:
     };
     std::vector<DataDesc> m_slots;
 
-    // Order in this vector follows the GComputaion's protocol
+    // Order in these vectors follows the GComputaion's protocol
     std::vector<ade::NodeHandle> m_emitters;
+    std::vector<ade::NodeHandle> m_sinks;
 
-    Mag m_res;
-
-    void initResource(const ade::NodeHandle &orig_nh); // FIXME: shouldn't it be RcDesc?
+    std::vector<std::thread> m_threads;
+    std::vector<stream::Q>   m_emitter_queues;
+    std::vector<stream::Q*>  m_sink_queues;
+    stream::Q m_out_queue;
 
 public:
     explicit GStreamingExecutor(std::unique_ptr<ade::Graph> &&g_model);
     void setSource(GRunArgs &&args);
     void start();
     bool pull(cv::GRunArgsP &&outs);
+    bool try_pull(cv::GRunArgsP &&outs);
     void stop();
+    bool running() const;
 };
 
 } // namespace gimpl

--- a/modules/gapi/src/executor/gstreamingexecutor.hpp
+++ b/modules/gapi/src/executor/gstreamingexecutor.hpp
@@ -109,6 +109,7 @@ protected:
     cv::util::optional<cv::GRunArgs> m_last_source;
     std::vector<std::thread> m_threads;
     std::vector<stream::Q>   m_emitter_queues;
+    std::vector<stream::Q*>  m_const_emitter_queues; // a view over m_emitter_queues
     std::vector<stream::Q*>  m_sink_queues;
     std::unordered_set<stream::Q*> m_internal_queues;
     stream::Q m_out_queue;

--- a/modules/gapi/src/precomp.hpp
+++ b/modules/gapi/src/precomp.hpp
@@ -18,4 +18,7 @@
 #include <opencv2/gapi.hpp>
 #include <opencv2/gapi/gkernel.hpp>
 
+// FIXME: Should this file be extended with our new headers?
+// (which sometimes may be implicitly included here already?)
+
 #endif // __OPENCV_GAPI_PRECOMP_HPP__

--- a/modules/gapi/test/common/gapi_core_tests.hpp
+++ b/modules/gapi/test/common/gapi_core_tests.hpp
@@ -128,6 +128,8 @@ GAPI_TEST_FIXTURE(PhaseTest, initMatsRandU, FIXTURE_API(bool), 1, angle_in_degre
 GAPI_TEST_FIXTURE(SqrtTest, initMatrixRandU, <>, 0)
 GAPI_TEST_FIXTURE(NormalizeTest, initNothing, FIXTURE_API(CompareMats,double,double,int,MatType2), 5,
     cmpF, a, b, norm_type, ddepth)
+GAPI_TEST_FIXTURE(CopyTest, initMatrixRandU, <>, 0)
+//GAPI_TEST_FIXTURE(CopyTest, initMatrixRandU, <>, 0)
 struct BackendOutputAllocationTest : TestWithParamBase<>
 {
     BackendOutputAllocationTest()

--- a/modules/gapi/test/common/gapi_core_tests.hpp
+++ b/modules/gapi/test/common/gapi_core_tests.hpp
@@ -128,8 +128,6 @@ GAPI_TEST_FIXTURE(PhaseTest, initMatsRandU, FIXTURE_API(bool), 1, angle_in_degre
 GAPI_TEST_FIXTURE(SqrtTest, initMatrixRandU, <>, 0)
 GAPI_TEST_FIXTURE(NormalizeTest, initNothing, FIXTURE_API(CompareMats,double,double,int,MatType2), 5,
     cmpF, a, b, norm_type, ddepth)
-GAPI_TEST_FIXTURE(CopyTest, initMatrixRandU, <>, 0)
-//GAPI_TEST_FIXTURE(CopyTest, initMatrixRandU, <>, 0)
 struct BackendOutputAllocationTest : TestWithParamBase<>
 {
     BackendOutputAllocationTest()

--- a/modules/gapi/test/common/gapi_core_tests_inl.hpp
+++ b/modules/gapi/test/common/gapi_core_tests_inl.hpp
@@ -1293,21 +1293,6 @@ TEST_P(NormalizeTest, Test)
     }
 }
 
-TEST_P(CopyTest, Test)
-{
-    // G-API code //////////////////////////////////////////////////////////////
-    cv::GMat in;
-    cv::GComputation c(in, cv::gapi::copy(in));
-    c.apply(in_mat1, out_mat_gapi, getCompileArgs());
-
-    // OpenCV code /////////////////////////////////////////////////////////////
-    // (no copy, check identity with the source mat ref)
-    out_mat_ocv = in_mat1;
-
-    // Comarison ///////////////////////////////////////////////////////////////
-    EXPECT_EQ(0, cv::countNonZero(out_mat_ocv != out_mat_gapi));
-}
-
 // PLEASE DO NOT PUT NEW ACCURACY TESTS BELOW THIS POINT! //////////////////////
 
 TEST_P(BackendOutputAllocationTest, EmptyOutput)

--- a/modules/gapi/test/common/gapi_core_tests_inl.hpp
+++ b/modules/gapi/test/common/gapi_core_tests_inl.hpp
@@ -1293,6 +1293,23 @@ TEST_P(NormalizeTest, Test)
     }
 }
 
+TEST_P(CopyTest, Test)
+{
+    // G-API code //////////////////////////////////////////////////////////////
+    cv::GMat in;
+    cv::GComputation c(in, cv::gapi::copy(in));
+    c.apply(in_mat1, out_mat_gapi, getCompileArgs());
+
+    // OpenCV code /////////////////////////////////////////////////////////////
+    // (no copy, check identity with the source mat ref)
+    out_mat_ocv = in_mat1;
+
+    // Comarison ///////////////////////////////////////////////////////////////
+    EXPECT_EQ(0, cv::countNonZero(out_mat_ocv != out_mat_gapi));
+}
+
+// PLEASE DO NOT PUT NEW ACCURACY TESTS BELOW THIS POINT! //////////////////////
+
 TEST_P(BackendOutputAllocationTest, EmptyOutput)
 {
     // G-API code //////////////////////////////////////////////////////////////

--- a/modules/gapi/test/cpu/gapi_core_tests_cpu.cpp
+++ b/modules/gapi/test/cpu/gapi_core_tests_cpu.cpp
@@ -447,6 +447,15 @@ INSTANTIATE_TEST_CASE_P(NormalizeTestCPU, NormalizeTest,
                                 Values(NORM_MINMAX, NORM_INF, NORM_L1, NORM_L2),
                                 Values(-1, CV_8U, CV_16U, CV_16S, CV_32F)));
 
+INSTANTIATE_TEST_CASE_P(CopyTestCPU, CopyTest,
+                        Combine(Values(CV_8UC1, CV_8UC3, CV_16UC1, CV_16SC1, CV_32FC1),
+                                Values(cv::Size(32, 32),
+                                       cv::Size(640, 480)),
+                                Values(-1),
+                                Values(CORE_CPU)));
+
+// PLEASE DO NOT PUT NEW ACCURACY TESTS BELOW THIS POINT! //////////////////////
+
 INSTANTIATE_TEST_CASE_P(BackendOutputAllocationTestCPU, BackendOutputAllocationTest,
                         Combine(Values(CV_8UC3, CV_16SC2, CV_32FC1),
                                 Values(cv::Size(50, 50)),
@@ -467,4 +476,5 @@ INSTANTIATE_TEST_CASE_P(ReInitOutTestCPU, ReInitOutTest,
                                 Values(CORE_CPU),
                                 Values(cv::Size(640, 400),
                                        cv::Size(10, 480))));
+
 }

--- a/modules/gapi/test/cpu/gapi_core_tests_cpu.cpp
+++ b/modules/gapi/test/cpu/gapi_core_tests_cpu.cpp
@@ -447,13 +447,6 @@ INSTANTIATE_TEST_CASE_P(NormalizeTestCPU, NormalizeTest,
                                 Values(NORM_MINMAX, NORM_INF, NORM_L1, NORM_L2),
                                 Values(-1, CV_8U, CV_16U, CV_16S, CV_32F)));
 
-INSTANTIATE_TEST_CASE_P(CopyTestCPU, CopyTest,
-                        Combine(Values(CV_8UC1, CV_8UC3, CV_16UC1, CV_16SC1, CV_32FC1),
-                                Values(cv::Size(32, 32),
-                                       cv::Size(640, 480)),
-                                Values(-1),
-                                Values(CORE_CPU)));
-
 // PLEASE DO NOT PUT NEW ACCURACY TESTS BELOW THIS POINT! //////////////////////
 
 INSTANTIATE_TEST_CASE_P(BackendOutputAllocationTestCPU, BackendOutputAllocationTest,

--- a/modules/gapi/test/cpu/gapi_core_tests_fluid.cpp
+++ b/modules/gapi/test/cpu/gapi_core_tests_fluid.cpp
@@ -518,6 +518,8 @@ INSTANTIATE_TEST_CASE_P(LUTTestCustomCPU, LUTTest,
                                        cv::Size(128, 128)),
 /*init output matrices or not*/ Values(true)));
 
+// PLEASE DO NOT PUT NEW ACCURACY TESTS BELOW THIS POINT! //////////////////////
+
 INSTANTIATE_TEST_CASE_P(ConvertToCPU, ConvertToTest,
                         Combine(Values(CV_8UC3, CV_8UC1, CV_16UC1, CV_32FC1),
                                 Values(CV_8U, CV_16U, CV_32F),

--- a/modules/gapi/test/gapi_array_tests.cpp
+++ b/modules/gapi/test/gapi_array_tests.cpp
@@ -163,4 +163,28 @@ TEST(GArray, TestIntermediateOutput)
     EXPECT_EQ(10u, out_points.size());
     EXPECT_EQ(10,  out_count[0]);
 }
+
+TEST(GArray_VectorRef, TestMov)
+{
+    // Warning: this test is testing some not-very-public APIs
+    // Test how VectorRef's mov() (aka poor man's move()) is working.
+
+    using I = int;
+    using V = std::vector<I>;
+    const V vgold = { 1, 2, 3};
+    V vtest = vgold;
+    const I* vptr = vtest.data();
+
+    cv::detail::VectorRef vref(vtest);
+    cv::detail::VectorRef vmov;
+    vmov.reset<I>();
+
+    EXPECT_EQ(vgold, vref.rref<I>());
+
+    vmov.mov(vref);
+    EXPECT_EQ(vgold, vmov.rref<I>());
+    EXPECT_EQ(vptr,  vmov.rref<I>().data());
+    EXPECT_EQ(V{}, vref.rref<I>());
+    EXPECT_EQ(V{}, vtest);
+}
 } // namespace opencv_test

--- a/modules/gapi/test/gpu/gapi_core_tests_gpu.cpp
+++ b/modules/gapi/test/gpu/gapi_core_tests_gpu.cpp
@@ -390,13 +390,6 @@ INSTANTIATE_TEST_CASE_P(ConcatVertTestGPU, ConcatVertTest,
                                 Values(-1),
                                 Values(CORE_GPU)));
 
-INSTANTIATE_TEST_CASE_P(CopyTestGPU, CopyTest,
-                        Combine(Values(CV_8UC1, CV_8UC3, CV_16UC1, CV_16SC1, CV_32FC1),
-                                Values(cv::Size(32, 32),
-                                       cv::Size(640, 480)),
-                                Values(-1),
-                                Values(CORE_GPU)));
-
 // PLEASE DO NOT PUT NEW ACCURACY TESTS BELOW THIS POINT! //////////////////////
 
 INSTANTIATE_TEST_CASE_P(BackendOutputAllocationTestGPU, BackendOutputAllocationTest,

--- a/modules/gapi/test/gpu/gapi_core_tests_gpu.cpp
+++ b/modules/gapi/test/gpu/gapi_core_tests_gpu.cpp
@@ -390,6 +390,15 @@ INSTANTIATE_TEST_CASE_P(ConcatVertTestGPU, ConcatVertTest,
                                 Values(-1),
                                 Values(CORE_GPU)));
 
+INSTANTIATE_TEST_CASE_P(CopyTestGPU, CopyTest,
+                        Combine(Values(CV_8UC1, CV_8UC3, CV_16UC1, CV_16SC1, CV_32FC1),
+                                Values(cv::Size(32, 32),
+                                       cv::Size(640, 480)),
+                                Values(-1),
+                                Values(CORE_GPU)));
+
+// PLEASE DO NOT PUT NEW ACCURACY TESTS BELOW THIS POINT! //////////////////////
+
 INSTANTIATE_TEST_CASE_P(BackendOutputAllocationTestGPU, BackendOutputAllocationTest,
                         Combine(Values(CV_8UC3, CV_16SC2, CV_32FC1),
                                 Values(cv::Size(50, 50)),

--- a/modules/gapi/test/infer/gapi_infer_ie_test.cpp
+++ b/modules/gapi/test/infer/gapi_infer_ie_test.cpp
@@ -101,7 +101,6 @@ TEST(TestAgeGenderIE, InferBasicTensor)
 
         const auto &iedims = net.getInputsInfo().begin()->second->getTensorDesc().getDims();
               auto  cvdims = cv::gapi::ie::util::to_ocv(iedims);
-        std::reverse(cvdims.begin(), cvdims.end());
         in_mat.create(cvdims, CV_32F);
         cv::randu(in_mat, -1, 1);
 

--- a/modules/gapi/test/own/conc_queue_tests.cpp
+++ b/modules/gapi/test/own/conc_queue_tests.cpp
@@ -1,0 +1,197 @@
+// This file is part of OpenCV project.
+// It is subject to the license terms in the LICENSE file found in the top-level directory
+// of this distribution and at http://opencv.org/license.html.
+//
+// Copyright (C) 2019 Intel Corporation
+
+#include "../test_precomp.hpp"
+
+#include <unordered_set>
+#include <thread>
+
+#include "executor/conc_queue.hpp"
+
+namespace opencv_test
+{
+using namespace cv::gapi;
+
+TEST(ConcQueue, PushPop)
+{
+    own::concurrent_bounded_queue<int> q;
+    for (int i = 0; i < 100; i++)
+    {
+        q.push(i);
+    }
+
+    for (int i = 0; i < 100; i++)
+    {
+        int x;
+        q.pop(x);
+        EXPECT_EQ(x, i);
+    }
+}
+
+TEST(ConcQueue, TryPop)
+{
+    own::concurrent_bounded_queue<int> q;
+    int x = 0;
+    EXPECT_FALSE(q.try_pop(x));
+
+    q.push(1);
+    EXPECT_TRUE(q.try_pop(x));
+    EXPECT_EQ(1, x);
+}
+
+TEST(ConcQueue, Clear)
+{
+    own::concurrent_bounded_queue<int> q;
+    for (int i = 0; i < 10; i++)
+    {
+        q.push(i);
+    }
+
+    q.clear();
+    int x = 0;
+    EXPECT_FALSE(q.try_pop(x));
+}
+
+// In this test, every writer thread produce its own range of integer
+// numbers, writing those to a shared queue.
+//
+// Every reader thread pops elements from the queue (until -1 is
+// reached) and stores those in its own associated set.
+//
+// Finally, the master thread waits for completion of all other
+// threads and verifies that all the necessary data is
+// produced/obtained.
+using StressParam = std::tuple<int           // Num writer threads
+                              ,int           // Num elements per writer
+                              ,int           // Num reader threads
+                              ,std::size_t>; // Queue capacity
+namespace
+{
+constexpr int STOP_SIGN = -1;
+constexpr int BASE      = 1000;
+}
+struct ConcQueue_: public ::testing::TestWithParam<StressParam>
+{
+    using Q = own::concurrent_bounded_queue<int>;
+    using S = std::unordered_set<int>;
+
+    static void writer(int base, int writes, Q& q)
+    {
+        for (int i = 0; i < writes; i++)
+        {
+            q.push(base + i);
+        }
+        q.push(STOP_SIGN);
+    }
+
+    static void reader(Q& q, S& s)
+    {
+        int x = 0;
+        while (true)
+        {
+            q.pop(x);
+            if (x == STOP_SIGN) return;
+            s.insert(x);
+        }
+    }
+};
+
+TEST_P(ConcQueue_, Test)
+{
+    int num_writers = 0;
+    int num_writes  = 0;
+    int num_readers = 0;
+    std::size_t capacity = 0u;
+    std::tie(num_writers, num_writes, num_readers, capacity) = GetParam();
+
+    CV_Assert(num_writers <   20);
+    CV_Assert(num_writes  < BASE);
+
+    Q q;
+    if (capacity)
+    {
+        // see below (2)
+        CV_Assert(static_cast<int>(capacity) > (num_writers - num_readers));
+        q.set_capacity(capacity);
+    }
+
+    // Start reader threads
+    std::vector<S> storage(num_readers);
+    std::vector<std::thread> readers;
+    for (S& s : storage)
+    {
+        readers.emplace_back(reader, std::ref(q), std::ref(s));
+    }
+
+    // Start writer threads, also pre-generate reference numbers
+    S reference;
+    std::vector<std::thread> writers;
+    for (int w = 0; w < num_writers; w++)
+    {
+        writers.emplace_back(writer, w*BASE, num_writes, std::ref(q));
+        for (int r = 0; r < num_writes; r++)
+        {
+            reference.insert(w*BASE + r);
+        }
+    }
+
+    // Every writer puts a STOP_SIGN at the end,
+    // There are three cases:
+    // 1) num_writers == num_readers
+    //    every reader should get its own STOP_SIGN from any
+    //    of the writers
+    //
+    // 2) num_writers > num_readers
+    //    every reader will get a STOP_SIGN but there're more
+    //    STOP_SIGNs may be pushed to the queue - and if this
+    //    number exceeds capacity, writers block (to a deadlock).
+    //    The latter situation must be avoided at parameters level.
+    //    [a] Also not every data produced by writers will be consumed
+    //    by a reader in this case. Master thread will read the rest
+    //
+    // 3) num_readers > num_writers
+    //    in this case, some readers will stuck and will never get
+    //    a STOP_SIGN. Master thread will push extra STOP_SIGNs to the
+    //    queue.
+
+    // Solution to (2a)
+    S remnants;
+    if (num_writers > num_readers)
+    {
+        int extra = num_writers - num_readers;
+        while (extra)
+        {
+            int x = 0;
+            q.pop(x);
+            if (x == STOP_SIGN) extra--;
+            else remnants.insert(x);
+        }
+    }
+
+    // Solution to (3)
+    if (num_readers > num_writers)
+    {
+        int extra = num_readers - num_writers;
+        while (extra--) q.push(STOP_SIGN);
+    }
+
+    // Wait for completions
+    for (auto &t : readers) t.join();
+    for (auto &t : writers) t.join();
+
+    // Accumulate and validate the result
+    S result(remnants.begin(), remnants.end());
+    for (const auto &s : storage) result.insert(s.begin(), s.end());
+
+    EXPECT_EQ(reference, result);
+}
+
+INSTANTIATE_TEST_CASE_P(ConcQueueStress, ConcQueue_,
+                        Combine(  Values(1, 2, 4, 8, 16)     // writers
+                                , Values(1, 32, 96, 256)     // writes
+                                , Values(1, 2, 10)           // readers
+                                , Values(0u, 16u, 32u)));    // capacity
+} // namespace opencv_test

--- a/modules/gapi/test/streaming/gapi_streaming_tests.cpp
+++ b/modules/gapi/test/streaming/gapi_streaming_tests.cpp
@@ -44,19 +44,20 @@ cv::gapi::GKernelPackage OCV_KERNELS()
     return pkg;
 }
 
-cv::gapi::GKernelPackage OCL_KERNELS()
-{
-    static cv::gapi::GKernelPackage pkg =
-        cv::gapi::combine(cv::gapi::core::ocl::kernels(),
-                          cv::gapi::imgproc::ocl::kernels());
-    return pkg;
-}
-
 cv::gapi::GKernelPackage OCV_FLUID_KERNELS()
 {
     static cv::gapi::GKernelPackage pkg =
         cv::gapi::combine(OCV_KERNELS(),
                           cv::gapi::core::fluid::kernels());
+    return pkg;
+}
+
+#if 0
+cv::gapi::GKernelPackage OCL_KERNELS()
+{
+    static cv::gapi::GKernelPackage pkg =
+        cv::gapi::combine(cv::gapi::core::ocl::kernels(),
+                          cv::gapi::imgproc::ocl::kernels());
     return pkg;
 }
 
@@ -67,6 +68,7 @@ cv::gapi::GKernelPackage OCL_FLUID_KERNELS()
                           cv::gapi::core::fluid::kernels());
     return pkg;
 }
+#endif // 0
 
 struct GAPI_Streaming: public ::testing::TestWithParam<cv::gapi::GKernelPackage> {
     GAPI_Streaming() { initTestDataPath(); }

--- a/modules/gapi/test/streaming/gapi_streaming_tests.cpp
+++ b/modules/gapi/test/streaming/gapi_streaming_tests.cpp
@@ -12,6 +12,7 @@
 
 #include <opencv2/gapi/fluid/core.hpp>
 #include <opencv2/gapi/fluid/imgproc.hpp>
+#include <opencv2/gapi/fluid/gfluidkernel.hpp>
 
 #include <opencv2/gapi/ocl/core.hpp>
 #include <opencv2/gapi/ocl/imgproc.hpp>
@@ -265,6 +266,258 @@ INSTANTIATE_TEST_CASE_P(TestStreaming, GAPI_Streaming,
                                  //, OCL_FLUID_KERNELS() // FIXME: Fails bit-exactness check, maybe relax it?
                                ));
 
+namespace TypesTest
+{
+    G_API_OP(SumV, <cv::GArray<int>(cv::GMat)>, "test.gapi.sumv") {
+        static cv::GArrayDesc outMeta(const cv::GMatDesc &) {
+            return cv::empty_array_desc();
+        }
+    };
+    G_API_OP(AddV, <cv::GMat(cv::GMat,cv::GArray<int>)>, "test.gapi.addv") {
+        static cv::GMatDesc outMeta(const cv::GMatDesc &in, const cv::GArrayDesc &) {
+            return in;
+        }
+    };
+
+    GAPI_OCV_KERNEL(OCVSumV, SumV) {
+        static void run(const cv::Mat &in, std::vector<int> &out) {
+            CV_Assert(in.depth() == CV_8U);
+            const auto length = in.cols * in.channels();
+            out.resize(length);
+
+            const uchar *ptr = in.ptr(0);
+            for (int c = 0; c < length; c++) {
+                out[c] = ptr[c];
+            }
+            for (int r = 1; r < in.rows; r++) {
+                ptr = in.ptr(r);
+                for (int c = 0; c < length; c++) {
+                    out[c] += ptr[c];
+                }
+            }
+        }
+    };
+
+    GAPI_OCV_KERNEL(OCVAddV, AddV) {
+        static void run(const cv::Mat &in, const std::vector<int> &inv, cv::Mat &out) {
+            CV_Assert(in.depth() == CV_8U);
+            const auto length = in.cols * in.channels();
+            CV_Assert(length == static_cast<int>(inv.size()));
+
+            for (int r = 0; r < in.rows; r++) {
+                const uchar *in_ptr = in.ptr(r);
+                uchar *out_ptr = out.ptr(r);
+
+                for (int c = 0; c < length; c++) {
+                    out_ptr[c] = in_ptr[c] + inv[c];
+                }
+            }
+        }
+    };
+
+    GAPI_FLUID_KERNEL(FluidAddV, AddV, false) {
+        static const int Window = 1;
+
+        static void run(const cv::gapi::fluid::View &in,
+                        const std::vector<int> &inv,
+                        cv::gapi::fluid::Buffer &out) {
+            const uchar *in_ptr = in.InLineB(0);
+            uchar *out_ptr = out.OutLineB(0);
+
+            const auto length = in.meta().size.width * in.meta().chan;
+            CV_Assert(length == static_cast<int>(inv.size()));
+
+            for (int c = 0; c < length; c++) {
+                out_ptr[c] = in_ptr[c] + inv[c];
+            }
+        }
+    };
+} // namespace TypesTest
+
+TEST(GAPI_Streaming_Types, InputScalar)
+{
+    // This test verifies if Streaming works with Scalar data @ input.
+
+    cv::GMat in_m;
+    cv::GScalar in_s;
+    cv::GMat out_m = in_m * in_s;
+    cv::GComputation c(cv::GIn(in_m, in_s), cv::GOut(out_m));
+
+    // Input data
+    cv::Mat in_mat = cv::Mat::eye(256, 256, CV_8UC1);
+    cv::Scalar in_scl = 32;
+
+    // Run pipeline
+    auto sc = c.compileStreaming(cv::descr_of(in_mat), cv::descr_of(in_scl));
+    sc.setSource(cv::gin(in_mat, in_scl));
+    sc.start();
+
+    for (int i = 0; i < 10; i++)
+    {
+        cv::Mat out;
+        sc.pull(cv::gout(out));
+        EXPECT_EQ(0., cv::norm(out, in_mat.mul(in_scl), cv::NORM_INF));
+    }
+}
+
+TEST(GAPI_Streaming_Types, InputVector)
+{
+    // This test verifies if Streaming works with Vector data @ input.
+
+    cv::GMat in_m;
+    cv::GArray<int> in_v;
+    cv::GMat out_m = TypesTest::AddV::on(in_m, in_v) - in_m;
+    cv::GComputation c(cv::GIn(in_m, in_v), cv::GOut(out_m));
+
+    // Input data
+    cv::Mat in_mat = cv::Mat::eye(256, 256, CV_8UC1);
+    std::vector<int> in_vec;
+    TypesTest::OCVSumV::run(in_mat, in_vec);
+    EXPECT_EQ(std::vector<int>(256,1), in_vec); // self-sanity-check
+
+    auto opencv_ref = [&](const cv::Mat &in, const std::vector<int> &inv, cv::Mat &out) {
+        cv::Mat tmp = in_mat.clone(); // allocate the same amount of memory as graph does
+        TypesTest::OCVAddV::run(in, inv, tmp);
+        out = tmp - in;
+    };
+
+    // Run pipeline
+    auto sc = c.compileStreaming(cv::descr_of(in_mat),
+                                 cv::descr_of(in_vec),
+                                 cv::compile_args(cv::gapi::kernels<TypesTest::OCVAddV>()));
+    sc.setSource(cv::gin(in_mat, in_vec));
+    sc.start();
+
+    for (int i = 0; i < 10; i++)
+    {
+        cv::Mat out_mat;
+        sc.pull(cv::gout(out_mat));
+
+        cv::Mat ref_mat;
+        opencv_ref(in_mat, in_vec, ref_mat);
+        EXPECT_EQ(0., cv::norm(ref_mat, out_mat, cv::NORM_INF));
+    }
+}
+
+TEST(GAPI_Streaming_Types, XChangeScalar)
+{
+    // This test verifies if Streaming works when pipeline steps
+    // (islands) exchange Scalar data.
+
+    initTestDataPath();
+
+    cv::GMat in;
+    cv::GScalar m = cv::gapi::mean(in);
+    cv::GMat tmp = cv::gapi::convertTo(in, CV_32F) - m;
+    cv::GMat out = cv::gapi::blur(tmp, cv::Size(3,3));
+    cv::GComputation c(cv::GIn(in), cv::GOut(cv::gapi::copy(in),
+                                             cv::gapi::convertTo(out, CV_8U)));
+
+    auto ocv_ref = [](const cv::Mat &in_mat, cv::Mat &out_mat) {
+        cv::Scalar ocv_m = cv::mean(in_mat);
+        cv::Mat ocv_tmp;
+        in_mat.convertTo(ocv_tmp, CV_32F);
+        ocv_tmp -= ocv_m;
+        cv::blur(ocv_tmp, ocv_tmp, cv::Size(3,3));
+        ocv_tmp.convertTo(out_mat, CV_8U);
+    };
+
+    // Here we want mean & convertTo run on OCV
+    // and subC & blur3x3 on Fluid.
+    // FIXME: With the current API it looks quite awful:
+    auto ocv_kernels = cv::gapi::core::cpu::kernels(); // convertTo
+    ocv_kernels.remove<cv::gapi::core::GSubC>();
+
+    auto fluid_kernels = cv::gapi::combine(cv::gapi::core::fluid::kernels(),     // subC
+                                           cv::gapi::imgproc::fluid::kernels()); // box3x3
+    fluid_kernels.remove<cv::gapi::core::GConvertTo>();
+    fluid_kernels.remove<cv::gapi::core::GMean>();
+
+    // FIXME: Now
+    // - fluid kernels take over ocv kernels (including Copy, SubC, & Box3x3)
+    // - selected kernels (which were removed from the fluid package) remain in OCV
+    //   (ConvertTo + some others)
+    // FIXME: This is completely awful. User should easily pick up specific kernels
+    // to an empty kernel package to craft his own but not do it via exclusion.
+    // Need to expose kernel declarations to public headers to enable kernels<..>()
+    // on user side.
+    auto kernels = cv::gapi::combine(ocv_kernels, fluid_kernels);
+
+    // Compile streaming pipeline
+    auto sc = c.compileStreaming(cv::GMatDesc{CV_8U,3,cv::Size{768,576}},
+                                 cv::compile_args(cv::gapi::use_only{kernels}));
+    sc.setSource(cv::gapi::GVideoCapture{findDataFile("cv/video/768x576.avi")});
+    sc.start();
+
+    cv::Mat in_frame;
+    cv::Mat out_mat_gapi;
+    cv::Mat out_mat_ref;
+
+    while (sc.pull(cv::gout(in_frame, out_mat_gapi))) {
+        ocv_ref(in_frame, out_mat_ref);
+        EXPECT_EQ(0., cv::norm(out_mat_gapi, out_mat_ref, cv::NORM_INF));
+    }
+}
+
+TEST(GAPI_Streaming_Types, XChangeVector)
+{
+    // This test verifies if Streaming works when pipeline steps
+    // (islands) exchange Vector data.
+
+    initTestDataPath();
+
+    cv::GMat in1, in2;
+    cv::GMat in = cv::gapi::crop(in1, cv::Rect{0,0,576,576});
+    cv::GScalar m = cv::gapi::mean(in);
+    cv::GArray<int> s = TypesTest::SumV::on(in2); // (in2 = eye, so s = [1,0,0,1,..])
+    cv::GMat out = TypesTest::AddV::on(in - m, s);
+
+    cv::GComputation c(cv::GIn(in1, in2), cv::GOut(cv::gapi::copy(in), out));
+
+    auto ocv_ref = [](const cv::Mat &in_mat1, const cv::Mat &in_mat2, cv::Mat &out_mat) {
+        cv::Mat in_roi = in_mat1(cv::Rect{0,0,576,576});
+        cv::Scalar ocv_m = cv::mean(in_roi);
+        std::vector<int> ocv_v;
+        TypesTest::OCVSumV::run(in_mat2, ocv_v);
+
+        out_mat.create(cv::Size(576,576), CV_8UC3);
+        cv::Mat in_tmp = in_roi - ocv_m;
+        TypesTest::OCVAddV::run(in_tmp, ocv_v, out_mat);
+    };
+
+    // Let crop/mean/sumV be calculated via OCV,
+    // and AddV/subC be calculated via Fluid
+    auto ocv_kernels = cv::gapi::core::cpu::kernels();
+    ocv_kernels.remove<cv::gapi::core::GSubC>();
+    ocv_kernels.include<TypesTest::OCVSumV>();
+
+    auto fluid_kernels = cv::gapi::core::fluid::kernels();
+    fluid_kernels.include<TypesTest::FluidAddV>();
+
+    // Here OCV takes precedense over Fluid, whith SubC & SumV remaining
+    // in Fluid.
+    auto kernels = cv::gapi::combine(fluid_kernels, ocv_kernels);
+
+    // Compile streaming pipeline
+    cv::Mat in_eye = cv::Mat::eye(cv::Size(576, 576), CV_8UC3);
+    auto sc = c.compileStreaming(cv::GMatDesc{CV_8U,3,cv::Size{768,576}},
+                                 cv::GMatDesc{CV_8U,3,cv::Size{576,576}},
+                                 cv::compile_args(cv::gapi::use_only{kernels}));
+    sc.setSource(cv::gin(cv::gapi::GVideoCapture{findDataFile("cv/video/768x576.avi")},
+                         in_eye));
+    sc.start();
+
+    cv::Mat in_frame;
+    cv::Mat out_mat_gapi;
+    cv::Mat out_mat_ref;
+
+    while (sc.pull(cv::gout(in_frame, out_mat_gapi))) {
+        ocv_ref(in_frame, in_eye, out_mat_ref);
+        EXPECT_EQ(0., cv::norm(out_mat_gapi, out_mat_ref, cv::NORM_INF));
+    }
+}
+
+
 struct GAPI_Streaming_Unit: public ::testing::Test {
     cv::GStreamingCompiled sc;
     cv::Mat m;
@@ -345,6 +598,15 @@ TEST_F(GAPI_Streaming_Unit, StartStopStress)
         for (int j = 0; j < 5; j++) EXPECT_TRUE(sc.pull(cv::gout(out)));
     }
 }
+
+TEST_F(GAPI_Streaming_Unit, PullNoStart)
+{
+    sc.setSource(cv::gin(m, m));
+
+    cv::Mat out;
+    EXPECT_ANY_THROW(sc.pull(cv::gout(out)));
+}
+
 
 TEST_F(GAPI_Streaming_Unit, SetSource_Multi_BeforeStart)
 {

--- a/modules/gapi/test/streaming/gapi_streaming_tests.cpp
+++ b/modules/gapi/test/streaming/gapi_streaming_tests.cpp
@@ -344,7 +344,7 @@ namespace TypesTest
                 uchar *out_ptr = out.ptr(r);
 
                 for (int c = 0; c < length; c++) {
-                    out_ptr[c] = in_ptr[c] + inv[c];
+                    out_ptr[c] = cv::saturate_cast<uchar>(in_ptr[c] + inv[c]);
                 }
             }
         }
@@ -363,7 +363,7 @@ namespace TypesTest
             CV_Assert(length == static_cast<int>(inv.size()));
 
             for (int c = 0; c < length; c++) {
-                out_ptr[c] = in_ptr[c] + inv[c];
+                out_ptr[c] = cv::saturate_cast<uchar>(in_ptr[c] + inv[c]);
             }
         }
     };

--- a/modules/gapi/test/streaming/gapi_streaming_tests.cpp
+++ b/modules/gapi/test/streaming/gapi_streaming_tests.cpp
@@ -1,0 +1,197 @@
+// This file is part of OpenCV project.
+// It is subject to the license terms in the LICENSE file found in the top-level directory
+// of this distribution and at http://opencv.org/license.html.
+//
+// Copyright (C) 2019 Intel Corporation
+
+
+#include "../test_precomp.hpp"
+
+#include <opencv2/gapi/cpu/core.hpp>
+#include <opencv2/gapi/cpu/imgproc.hpp>
+
+#include <opencv2/gapi/fluid/core.hpp>
+#include <opencv2/gapi/fluid/imgproc.hpp>
+
+#include <opencv2/gapi/ocl/core.hpp>
+#include <opencv2/gapi/ocl/imgproc.hpp>
+
+namespace opencv_test
+{
+namespace
+{
+void initTestDataPath()
+{
+#ifndef WINRT
+    static bool initialized = false;
+    if (!initialized)
+    {
+        // Since G-API has no own test data (yet), it is taken from the common space
+        const char* testDataPath = getenv("OPENCV_TEST_DATA_PATH");
+        GAPI_Assert(testDataPath != nullptr);
+
+        cvtest::addDataSearchPath(testDataPath);
+        initialized = true;
+    }
+#endif // WINRT
+}
+
+cv::gapi::GKernelPackage OCV_KERNELS()
+{
+    static cv::gapi::GKernelPackage pkg =
+        cv::gapi::combine(cv::gapi::core::cpu::kernels(),
+                          cv::gapi::imgproc::cpu::kernels());
+    return pkg;
+}
+
+cv::gapi::GKernelPackage OCL_KERNELS()
+{
+    static cv::gapi::GKernelPackage pkg =
+        cv::gapi::combine(cv::gapi::core::ocl::kernels(),
+                          cv::gapi::imgproc::ocl::kernels());
+    return pkg;
+}
+
+cv::gapi::GKernelPackage OCV_FLUID_KERNELS()
+{
+    static cv::gapi::GKernelPackage pkg =
+        cv::gapi::combine(OCV_KERNELS(),
+                          cv::gapi::core::fluid::kernels());
+    return pkg;
+}
+
+cv::gapi::GKernelPackage OCL_FLUID_KERNELS()
+{
+    static cv::gapi::GKernelPackage pkg =
+        cv::gapi::combine(OCL_KERNELS(),
+                          cv::gapi::core::fluid::kernels());
+    return pkg;
+}
+
+struct GAPI_Streaming: public ::testing::TestWithParam<cv::gapi::GKernelPackage> {
+    GAPI_Streaming() { initTestDataPath(); }
+};
+
+} // anonymous namespace
+
+TEST_P(GAPI_Streaming, SmokeTest_ConstInput_GMat)
+{
+    // This graph models the following use-case:
+    // Canny here is used as some "feature detector"
+    //
+    // Island/device layout may be different given the contents
+    // of the passed kernel package.
+    //
+    // The expectation is that we get as much islands in the
+    // graph as backends the GKernelPackage contains.
+    //
+    // [Capture] --> Crop --> Resize --> Canny --> [out]
+
+    const auto crop_rc = cv::Rect(13, 75, 377, 269);
+    const auto resample_sz = cv::Size(224, 224);
+    const auto thr_lo = 64.;
+    const auto thr_hi = 192.;
+
+    cv::GMat in;
+    auto roi = cv::gapi::crop(in, crop_rc);
+    auto res = cv::gapi::resize(roi, resample_sz);
+    auto out = cv::gapi::Canny(res, thr_lo, thr_hi);
+    cv::GComputation c(in, out);
+
+    // Input data
+    cv::Mat in_mat = cv::imread(findDataFile("cv/edgefilter/kodim23.png"));
+    cv::Mat out_mat_gapi;
+
+    // OpenCV reference image
+    cv::Mat out_mat_ocv;
+    {
+        cv::Mat tmp;
+        cv::resize(in_mat(crop_rc), tmp, resample_sz);
+        cv::Canny(tmp, out_mat_ocv, thr_lo, thr_hi);
+    }
+
+    // Compilation & testing
+    auto ccomp = c.compileStreaming(cv::descr_of(in_mat),
+                                    cv::compile_args(cv::gapi::use_only{GetParam()}));
+    EXPECT_TRUE(ccomp);
+    EXPECT_FALSE(ccomp.running());
+
+    ccomp.setSource(cv::gin(in_mat));
+
+    ccomp.start();
+    EXPECT_TRUE(ccomp.running());
+
+    // Fetch the result 15 times
+    for (int i = 0; i < 15; i++) {
+        // With constant inputs, the stream is endless so
+        // the blocking pull() should never return `false`.
+        EXPECT_TRUE(ccomp.pull(cv::gout(out_mat_gapi)));
+        EXPECT_EQ(0, cv::countNonZero(out_mat_gapi != out_mat_ocv));
+        if (cv::countNonZero(out_mat_gapi != out_mat_ocv) > 0) {
+            cv::imshow("G-API", out_mat_gapi);
+            cv::imshow("OpenCV", out_mat_ocv);
+            cv::imshow("Delta", out_mat_gapi - out_mat_ocv);
+            cv::waitKey(0);
+        }
+    }
+
+    EXPECT_TRUE(ccomp.running());
+    ccomp.stop();
+
+    EXPECT_FALSE(ccomp.running());
+}
+
+TEST_P(GAPI_Streaming, SmokeTest_VideoInput_GMat)
+{
+    const auto crop_rc = cv::Rect(13, 75, 377, 269);
+    const auto resample_sz = cv::Size(224, 224);
+    const auto thr_lo = 64.;
+    const auto thr_hi = 192.;
+
+    cv::GMat in;
+    auto roi = cv::gapi::crop(in, crop_rc);
+    auto res = cv::gapi::resize(roi, resample_sz);
+    auto out = cv::gapi::Canny(res, thr_lo, thr_hi);
+    cv::GComputation c(cv::GIn(in), cv::GOut(cv::gapi::copy(in), out));
+
+    // OpenCV reference image code
+    auto opencv_ref = [&](const cv::Mat &in_mat, cv::Mat &out_mat) {
+        cv::Mat tmp;
+        cv::resize(in_mat(crop_rc), tmp, resample_sz);
+        cv::Canny(tmp, out_mat, thr_lo, thr_hi);
+    };
+
+    // Compilation & testing
+    auto ccomp = c.compileStreaming(cv::GMatDesc{CV_8U,3,cv::Size{768,576}},
+                                    cv::compile_args(cv::gapi::use_only{GetParam()}));
+    EXPECT_TRUE(ccomp);
+    EXPECT_FALSE(ccomp.running());
+
+    ccomp.setSource(cv::gapi::GVideoCapture{findDataFile("cv/video/768x576.avi")});
+
+    ccomp.start();
+    EXPECT_TRUE(ccomp.running());
+
+    // Process the full video
+    cv::Mat in_mat_gapi, out_mat_gapi;
+
+    while (ccomp.pull(cv::gout(in_mat_gapi, out_mat_gapi))) {
+        cv::Mat out_mat_ocv;
+        opencv_ref(in_mat_gapi, out_mat_ocv);
+        EXPECT_EQ(0, cv::countNonZero(out_mat_gapi != out_mat_ocv));
+    }
+    EXPECT_FALSE(ccomp.running());
+
+    // Stop can be called at any time (even if the pipeline is not running)
+    ccomp.stop();
+
+    EXPECT_FALSE(ccomp.running());
+}
+
+INSTANTIATE_TEST_CASE_P(TestStreaming, GAPI_Streaming,
+                        Values(  OCV_KERNELS()
+                             //, OCL_KERNELS()       -- known issues with OpenCL backend, commented out
+                               , OCV_FLUID_KERNELS()
+                             //, OCL_FLUID_KERNELS() -- known issues with OpenCL backend, commented out
+                                 ));
+} // namespace opencv_test

--- a/modules/gapi/test/streaming/gapi_streaming_tests.cpp
+++ b/modules/gapi/test/streaming/gapi_streaming_tests.cpp
@@ -53,6 +53,11 @@ cv::gapi::GKernelPackage OCV_FLUID_KERNELS()
 }
 
 #if 0
+// FIXME: OpenCL backend seem to work fine with Streaming
+// however the results are not very bit exact with CPU
+// It may be a problem but may be just implementation innacuracy.
+// Need to customize the comparison function in tests where OpenCL
+// is involved.
 cv::gapi::GKernelPackage OCL_KERNELS()
 {
     static cv::gapi::GKernelPackage pkg =
@@ -129,12 +134,6 @@ TEST_P(GAPI_Streaming, SmokeTest_ConstInput_GMat)
         // the blocking pull() should never return `false`.
         EXPECT_TRUE(ccomp.pull(cv::gout(out_mat_gapi)));
         EXPECT_EQ(0, cv::countNonZero(out_mat_gapi != out_mat_ocv));
-        if (cv::countNonZero(out_mat_gapi != out_mat_ocv) > 0) {
-            cv::imshow("G-API", out_mat_gapi);
-            cv::imshow("OpenCV", out_mat_ocv);
-            cv::imshow("Delta", out_mat_gapi - out_mat_ocv);
-            cv::waitKey(0);
-        }
     }
 
     EXPECT_TRUE(ccomp.running());
@@ -261,10 +260,10 @@ TEST_P(GAPI_Streaming, TestStartRestart)
 
 INSTANTIATE_TEST_CASE_P(TestStreaming, GAPI_Streaming,
                         Values(  OCV_KERNELS()
-                             //, OCL_KERNELS()       -- known issues with OpenCL backend, commented out
+                                 //, OCL_KERNELS() // FIXME: Fails bit-exactness check, maybe relax it?
                                , OCV_FLUID_KERNELS()
-                             //, OCL_FLUID_KERNELS() -- known issues with OpenCL backend, commented out
-                                 ));
+                                 //, OCL_FLUID_KERNELS() // FIXME: Fails bit-exactness check, maybe relax it?
+                               ));
 
 struct GAPI_Streaming_Unit: public ::testing::Test {
     cv::GStreamingCompiled sc;

--- a/modules/gapi/test/streaming/gapi_streaming_tests.cpp
+++ b/modules/gapi/test/streaming/gapi_streaming_tests.cpp
@@ -190,9 +190,15 @@ TEST_P(GAPI_Streaming, SmokeTest_VideoInput_GMat)
     EXPECT_FALSE(ccomp.running());
 }
 
-TEST_P(GAPI_Streaming, Cucumber_Regression)
+TEST_P(GAPI_Streaming, Regression_CompileTimeScalar)
 {
-    // FIXME: Document what this test tests
+    // There was a bug with compile-time GScalars.  Compile-time
+    // GScalars generate their own DATA nodes at GModel/GIslandModel
+    // level, resulting in an extra link at the GIslandModel level, so
+    // GStreamingExecutor automatically assigned an input queue to
+    // such edges. Since there were no in-graph producer for that
+    // data, no data were pushed to such queue what lead to a
+    // deadlock.
 
     cv::GMat in;
     cv::GMat tmp = cv::gapi::copy(in);


### PR DESCRIPTION
Streaming in G-API
==========

This PR introduces basic streaming support in G-API. Now G-API can
handle video streams and pipeline the execution (especially
heterogeneous & inference) efficiently, thus maximizing the overall
throughput.

<cut/>

## API Overview

Now in addition to a regular `GComputation::compile()` a user can
compile the same (exactly the same!) graph for streaming -- via
`GComputation::compileStreaming()`. The returned object is
`GStreamingCompiled` -- a stream-oriented version of a compiled graph.
Use `setSource()`, `start()`, and `stop()` methods to specify the
input data (stream or constant), start the processing, and stop it,
respectively. Use methods `pull()` or `try_pull()` to obtain a /next
processed frame/ data from the pipeline in synchronous/asynchronous
mode, respectively.

Creating and running a pipeline is now as easy as:
```c++
cv::GMat in;
auto roi = cv::gapi::crop(in, crop_rc);
auto res = cv::gapi::resize(roi, resample_sz);
auto out = cv::gapi::Canny(res, thr_lo, thr_hi);
auto ccomp = cv::GComputation(cv::GIn(in), cv::GOut(out))
    .compileStreaming(cv::GMatDesc{CV_8U,3,cv::Size{768,576}});

ccomp.setSource(cv::gin(gapi::wip::make_src<cv::gapi::wip::GCaptureSource>
    (findDataFile("cv/video/768x576.avi"))));
ccomp.start();

cv::Mat out_mat_gapi;
while (ccomp.pull(cv::gout(in_mat_gapi))) {
    // Handle your pipeline-processed data here.
}
// Reaching this point means that stream is over (or pipeline was stopped)
```

Note that a generic version of `setSource()` takes a vector of input
data sources via `cv::gin()`, and the output data vector is written by
`pull()`/`try_pull()` into objects passed via `cv::gout()`; it is very
similar how regular `GComputation::apply()` or `GCompiled::operator()`
work.

`compileStreaming` also takes G-API compilation arguments similar to a
regular `compile()` -- so custom kernels, backend selection, and
debugging options are welcome!

## Implementation overview

The streaming implementation relies heavily on the existing G-API's
heterogeneous infrastructure. If G-API runs a mixture of kernels from
different backends (e.g., OpenCV, Fluid, Inference), the appropriate
graph nodes for these backends are organized into clusters called
"Islands". Kernels in every "Island" belong to the same
device/backend. Islands are regions in the Directed Acyclic Graph (the
G-API's underlying representation model).

Current streaming implementation makes these Islands run in parallel.
Currently it is done naively by assigning every Island to its own
dedicated thread. Since Islands are connected earch other at the graph
level, the execution threads are connected appropriately too (there is a
direct 1:1 mapping).

Island graph model is a bipartite graph with Islands ("super-nodes" or
"super-operations") connected each other via Data objects.

A Data object can be written by only one Island (exclusively) and can
be read from multiple other Islands.

In Streaming mode, every READ edge for Data node is associated with
its own queue (`tbb::concurrent_bounded_queue` or our own equivalent
if TBB is not available). Reader Islands poll their input queues and
fetch elements to a vector to form a call frame.

Writer Islands produce data and write it to ALL queues associated with
every output Data object at the graph level.

When a graph is compiled for Streaming, the Island Graph model is
extended with some extra nodes to maintain the above invariant &
reduce complexity: Emitters and Sinks.

Emitters push the input data (whether it is a video stream's next
frame or a constant ("frozen" in GStreamer terms) Mat or scalar) its
queues, which are then consumed by first Islands in the graph.

Sinks collect data from the last (output) Islands in the graph and
synchronize the data (if a pipeline has multiple outputs) to one
single vector to make the implementation of `try_pull()`/`pull()`
easier.

When there's no data anymore or `stop()` was called explicitly, a
special `STOP` sign is pushed by emitters/to internal queues and then
broadcasted to the rest of the pipeline. Some complex logic is
involved to avoid deadlocks in this situation.

## Current limitations

- A couple of bugs has been found on `GArray<>` and `util::variant` --
  all were reported internally, workarounded gracefully, and to be
  addressed within a release or two.
- Design on input video source is not yet closed so the appropriate
  objects are declared under `cv::gapi::wip` namespace.

```
force_builders=Custom,Custom Win,Custom Mac
build_image:Custom=ubuntu-openvino-2019r2.0:16.04
build_image:Custom Win=openvino-2019r2.0
build_image:Custom Mac=openvino-2019r2.0

test_modules:Custom=gapi
test_modules:Custom Win=gapi
test_modules:Custom Mac=gapi

buildworker:Custom=linux-1
test_opencl:Custom=ON
test_bigdata:Custom=1
test_filter:Custom=*

build_gapi_standalone:Linux x64=ade-0.1.1f
build_gapi_standalone:Win64=ade-0.1.1f
build_gapi_standalone:Mac=ade-0.1.1f
build_gapi_standalone:Linux x64 Debug=ade-0.1.1f
build_gapi_standalone:Custom Win=ade-0.1.1f
```