### PR TITLE
GAPI: use plain-C interface to math functions, sin/cos, etc.

### DIFF
--- a/modules/gapi/include/opencv2/gapi/core.hpp
+++ b/modules/gapi/include/opencv2/gapi/core.hpp
@@ -8,6 +8,8 @@
 #ifndef OPENCV_GAPI_CORE_HPP
 #define OPENCV_GAPI_CORE_HPP
 
+#include <math.h>
+
 #include <utility> // std::tuple
 
 #include <opencv2/imgproc.hpp>
@@ -392,8 +394,8 @@ namespace core {
             {
                 GAPI_Assert(fx != 0. && fy != 0.);
                 return in.withSize
-                    (Size(static_cast<int>(std::round(in.size.width  * fx)),
-                          static_cast<int>(std::round(in.size.height * fy))));
+                    (Size(static_cast<int>(round(in.size.width  * fx)),
+                          static_cast<int>(round(in.size.height * fy))));
             }
         }
     };

--- a/modules/gapi/include/opencv2/gapi/own/saturate.hpp
+++ b/modules/gapi/include/opencv2/gapi/own/saturate.hpp
@@ -8,7 +8,7 @@
 #ifndef OPENCV_GAPI_OWN_SATURATE_HPP
 #define OPENCV_GAPI_OWN_SATURATE_HPP
 
-#include <cmath>
+#include <math.h>
 
 #include <limits>
 #include <type_traits>
@@ -79,10 +79,10 @@ static inline DST saturate(SRC x, R round)
 }
 
 // explicit suffix 'd' for double type
-inline double  ceild(double x) { return std::ceil(x); }
-inline double floord(double x) { return std::floor(x); }
-inline double roundd(double x) { return std::round(x); }
-inline double  rintd(double x) { return std::rint(x); }
+inline double  ceild(double x) { return ceil(x); }
+inline double floord(double x) { return floor(x); }
+inline double roundd(double x) { return round(x); }
+inline double  rintd(double x) { return rint(x); }
 
 } //namespace own
 } //namespace gapi

--- a/modules/gapi/src/backends/fluid/gfluidcore.cpp
+++ b/modules/gapi/src/backends/fluid/gfluidcore.cpp
@@ -23,8 +23,9 @@
 #include "gfluidbackend.hpp"
 #include "gfluidutils.hpp"
 
+#include <math.h>
+
 #include <cassert>
-#include <cmath>
 #include <cstdlib>
 
 namespace cv {
@@ -389,7 +390,7 @@ static void run_arithm_s1(uchar out[], const float in[], int width, const float 
     cv::util::suppress_unused_warning(v_op);
     for (; w < width; w++)
     {
-        out[w] = saturate<uchar>(s_op(in[w], scalar[0]), std::roundf);
+        out[w] = saturate<uchar>(s_op(in[w], scalar[0]), roundf);
     }
 }
 
@@ -1920,8 +1921,8 @@ GAPI_FLUID_KERNEL(GFluidPolarToCart, cv::gapi::core::GPolarToCart, false)
                           in2[l] * static_cast<float>(CV_PI / 180):
                           in2[l];
             float magnitude = in1[l];
-            float x = magnitude * std::cos(angle);
-            float y = magnitude * std::sin(angle);
+            float x = magnitude * cosf(angle);
+            float y = magnitude * sinf(angle);
             out1[l] = x;
             out2[l] = y;
         }
@@ -1954,8 +1955,8 @@ GAPI_FLUID_KERNEL(GFluidCartToPolar, cv::gapi::core::GCartToPolar, false)
         {
             float x = in1[l];
             float y = in2[l];
-            float magnitude = std::hypot(y, x);
-            float angle_rad = std::atan2(y, x);
+            float magnitude = hypotf(y, x);
+            float angle_rad = atan2f(y, x);
             float angle = angleInDegrees?
                           angle_rad * static_cast<float>(180 / CV_PI):
                           angle_rad;


### PR DESCRIPTION
resolves #15163: C++11 definition issue by @neheb

Replace C++ style calls like `std::sin(x)` with plain C style like `sinf(x)` or `sin(x)` depending on type of `x`, is it `float` or `double`.