### PR TITLE
fix exif bug

### DIFF
--- a/modules/imgcodecs/src/exif.cpp
+++ b/modules/imgcodecs/src/exif.cpp
@@ -229,7 +229,7 @@ void ExifReader::parseExif()
 
     uint32_t offset = getStartOffset();
 
-    size_t numEntry = getNumDirEntry();
+    size_t numEntry = getNumDirEntry( offset );
 
     offset += 2; //go to start of tag fields
 
@@ -303,7 +303,7 @@ uint32_t ExifReader::getStartOffset() const
  *
  * @return The number of directory entries
  */
-size_t ExifReader::getNumDirEntry() const
+size_t ExifReader::getNumDirEntry(const size_t offsetNumDir) const
 {
     return getU16( offsetNumDir );
 }

--- a/modules/imgcodecs/src/exif.hpp
+++ b/modules/imgcodecs/src/exif.hpp
@@ -199,7 +199,7 @@ private:
     bool checkTagMark() const;
 
     size_t getFieldSize ();
-    size_t getNumDirEntry() const;
+    size_t getNumDirEntry( const size_t offsetNumDir ) const;
     uint32_t getStartOffset() const;
     uint16_t getExifTag( const size_t offset ) const;
     uint16_t getU16( const size_t offset ) const;
@@ -224,9 +224,6 @@ private:
 
 private:
     static const uint16_t tagMarkRequired = 0x2A;
-
-    //offset to the _number-of-directory-entry_ field
-    static const size_t offsetNumDir = 8;
 
     //max size of data in tag.
     //'DDDDDDDD' contains the value of that Tag. If its size is over 4bytes,


### PR DESCRIPTION
<!-- Please use this line to close one or multiple issues when this pullrequest gets merged
You can add another line right under the first one:
resolves #1234
resolves #1235
-->

### This pullrequest changes

<!-- Please describe what your pullrequest is changing -->
ExifReader::getNumDirEntry use the fixed offset value, which may parse error number of DirEntry in some cases.
Following is structure of TIFF header. We should get the offset through "Offset to first IFD" item.

![image](https://user-images.githubusercontent.com/17079711/62453966-0baf4200-b7a6-11e9-90b1-ce3db72de6a6.png)

![get_thumbnail](https://user-images.githubusercontent.com/17079711/62454331-b45da180-b7a6-11e9-85b1-c4ebef29fef5.jpg)
