### PR TITLE
G-API: Fix Journal usage in Fluid backend

### DIFF
--- a/modules/gapi/src/backends/fluid/gfluidbackend.cpp
+++ b/modules/gapi/src/backends/fluid/gfluidbackend.cpp
@@ -943,6 +943,8 @@ namespace
                 fd.skew            = 0;
                 fd.max_consumption = 0;
             }
+
+            GModel::log_clear(g, node);
         }
     }
 

--- a/modules/gapi/src/compiler/gmodel.cpp
+++ b/modules/gapi/src/compiler/gmodel.cpp
@@ -187,7 +187,6 @@ void GModel::log(Graph &g, ade::EdgeHandle eh, std::string &&msg, ade::NodeHandl
 
 void GModel::log_clear(Graph &g, ade::NodeHandle node)
 {
-    return;  // FIXME: remove this prior to merge. This is here to see whether memory consumption test works
     if (g.metadata(node).contains<Journal>())
     {
         // according to documentation, clear() doesn't deallocate (__capacity__ of vector preserved)

--- a/modules/gapi/src/compiler/gmodel.cpp
+++ b/modules/gapi/src/compiler/gmodel.cpp
@@ -23,15 +23,6 @@
 
 namespace cv { namespace gimpl {
 
-namespace {
-bool dumpDotRequired()
-{
-    // FIXME: should we also check cv::graph_dump_path in compile args?
-    static const bool dump_required = (std::getenv("GRAPH_DUMP_PATH") != nullptr);
-    return dump_required;
-}
-}  // anonymous namespace
-
 ade::NodeHandle GModel::mkOpNode(GModel::Graph &g, const GKernel &k, const std::vector<GArg> &args, const std::string &island)
 {
     ade::NodeHandle op_h = g.createNode();
@@ -154,8 +145,6 @@ void GModel::init(Graph& g)
 
 void GModel::log(Graph &g, ade::NodeHandle nh, std::string &&msg, ade::NodeHandle updater)
 {
-    if (!dumpDotRequired()) return;  // no need to log in this case: no one will access the Journal
-
     std::string s = std::move(msg);
     if (updater != nullptr)
     {
@@ -178,8 +167,6 @@ void GModel::log(Graph &g, ade::NodeHandle nh, std::string &&msg, ade::NodeHandl
 // Unify with GModel::log(.. ade::NodeHandle ..)
 void GModel::log(Graph &g, ade::EdgeHandle eh, std::string &&msg, ade::NodeHandle updater)
 {
-    if (!dumpDotRequired()) return;  // no need to log in this case: no one will access the Journal
-
     std::string s = std::move(msg);
     if (updater != nullptr)
     {
@@ -200,8 +187,6 @@ void GModel::log(Graph &g, ade::EdgeHandle eh, std::string &&msg, ade::NodeHandl
 
 void GModel::log_clear(Graph &g, ade::NodeHandle node)
 {
-    if (!dumpDotRequired()) return;  // nothing to do in this case
-
     if (g.metadata(node).contains<Journal>())
     {
         // according to documentation, clear() doesn't deallocate (__capacity__ of vector preserved)

--- a/modules/gapi/src/compiler/gmodel.cpp
+++ b/modules/gapi/src/compiler/gmodel.cpp
@@ -187,6 +187,7 @@ void GModel::log(Graph &g, ade::EdgeHandle eh, std::string &&msg, ade::NodeHandl
 
 void GModel::log_clear(Graph &g, ade::NodeHandle node)
 {
+    return;  // FIXME: remove this prior to merge. This is here to see whether memory consumption test works
     if (g.metadata(node).contains<Journal>())
     {
         // according to documentation, clear() doesn't deallocate (__capacity__ of vector preserved)

--- a/modules/gapi/src/compiler/gmodel.hpp
+++ b/modules/gapi/src/compiler/gmodel.hpp
@@ -194,6 +194,8 @@ namespace GModel
     // appear in the dumped .dot file.x
     GAPI_EXPORTS void log(Graph &g, ade::NodeHandle op, std::string &&message, ade::NodeHandle updater = ade::NodeHandle());
     GAPI_EXPORTS void log(Graph &g, ade::EdgeHandle op, std::string &&message, ade::NodeHandle updater = ade::NodeHandle());
+    // Clears logged messages of a node.
+    GAPI_EXPORTS void log_clear(Graph &g, ade::NodeHandle node);
 
     GAPI_EXPORTS void linkIn   (Graph &g, ade::NodeHandle op,     ade::NodeHandle obj, std::size_t in_port);
     GAPI_EXPORTS void linkOut  (Graph &g, ade::NodeHandle op,     ade::NodeHandle obj, std::size_t out_port);

--- a/modules/gapi/test/gapi_fluid_test.cpp
+++ b/modules/gapi/test/gapi_fluid_test.cpp
@@ -846,7 +846,7 @@ uint64_t currMemoryConsumption()
     // using resident set size
     std::istringstream(stat_line) >> unused >> rss;
     CV_Assert(rss != 0);
-    return static_cast<uint64_t>(rss);
+    return rss;
 }
 #else
 // FIXME: implement this part (at least for Windows?), right now it's enough to check Linux only
@@ -876,11 +876,11 @@ TEST(Fluid, MemoryConsumptionDoesNotGrowOnReshape)
         cv::descr_of(in_mat), compile_args());
     ASSERT_TRUE(compiled.canReshape());
 
-    constexpr const int iters = 1000;  // should be large enough to see the increasing mem usage
-    auto mem_before = currMemoryConsumption();
-    for (int _ = 0; _ < iters; ++_) compiled.reshape(cv::descr_of(cv::gin(in_mat)), compile_args());
+    const auto mem_before = currMemoryConsumption();
+    for (int _ = 0; _ < 1000; ++_) compiled.reshape(cv::descr_of(cv::gin(in_mat)), compile_args());
+    const auto mem_after = currMemoryConsumption();
 
-    ASSERT_GE(mem_before, currMemoryConsumption());
+    ASSERT_GE(mem_before, mem_after);
 }
 
 } // namespace opencv_test

--- a/modules/gapi/test/gapi_fluid_test.cpp
+++ b/modules/gapi/test/gapi_fluid_test.cpp
@@ -835,6 +835,7 @@ namespace
 // FIXME: need a better way to check memory consumption - is this trust-worthy enough?
 uint64_t currMemoryConsumption()
 {
+    std::cout << "Used" << std::endl;
     rusage info{};
     CV_Assert(getrusage(RUSAGE_SELF, &info) == 0);  // 0 - success
     CV_Assert(info.ru_maxrss != 0);  // 0 - unmaintained?

--- a/modules/gapi/test/gapi_fluid_test.cpp
+++ b/modules/gapi/test/gapi_fluid_test.cpp
@@ -868,7 +868,7 @@ TEST(Fluid, MemoryConsumptionDoesNotGrowOnReshape)
         cv::descr_of(in_mat), compile_args());
     ASSERT_TRUE(compiled.canReshape());
 
-    constexpr const int iters = 1000;  // should be large enough to see the increasing mem usage
+    constexpr const int iters = 3000;  // should be large enough to see the increasing mem usage
     auto mem_before = currMemoryConsumption();  // NB: memory in Kb for POSIX
     for (int _ = 0; _ < iters; ++_) compiled.reshape(cv::descr_of(cv::gin(in_mat)), compile_args());
 


### PR DESCRIPTION
### This pullrequest changes

- Fixes usage model of `Journal` in Fluid backend: clear existing `Journal` entries on graph reshape
- Adds (experimental) test to verify that memory usage stays the same
