### PR TITLE
Fix exif data failing to read on some images

### DIFF
--- a/modules/imgcodecs/src/exif.cpp
+++ b/modules/imgcodecs/src/exif.cpp
@@ -229,7 +229,7 @@ void ExifReader::parseExif()
 
     uint32_t offset = getStartOffset();
 
-    size_t numEntry = getNumDirEntry();
+    size_t numEntry = getU16( offset );
 
     offset += 2; //go to start of tag fields
 
@@ -296,16 +296,6 @@ bool ExifReader::checkTagMark() const
 uint32_t ExifReader::getStartOffset() const
 {
     return getU32( 4 );
-}
-
-/**
- * @brief Get the number of Directory Entries in Jpeg file
- *
- * @return The number of directory entries
- */
-size_t ExifReader::getNumDirEntry() const
-{
-    return getU16( offsetNumDir );
 }
 
 /**

--- a/modules/imgcodecs/src/exif.hpp
+++ b/modules/imgcodecs/src/exif.hpp
@@ -225,9 +225,6 @@ private:
 private:
     static const uint16_t tagMarkRequired = 0x2A;
 
-    //offset to the _number-of-directory-entry_ field
-    static const size_t offsetNumDir = 8;
-
     //max size of data in tag.
     //'DDDDDDDD' contains the value of that Tag. If its size is over 4bytes,
     //'DDDDDDDD' contains the offset to data stored address.


### PR DESCRIPTION

<!-- Please use this line to close one or multiple issues when this pullrequest gets merged
You can add another line right under the first one:
resolves #1234
resolves #1235
-->

### This pullrequest changes

<!-- Please describe what your pullrequest is changing -->
Fixes a bug in ExifReader causing it to fail on some specific jpegs (sample attached).

I do not have a deep knowledge of Exif structure, but exiv2 reads the number of entries in this manner and the patch fixes the problem for the attached image. I have also tested it with several other pictures taken with different cameras and didn't notice any regression.

![Example](https://user-images.githubusercontent.com/6755141/62480769-6736fb00-b7b9-11e9-8cde-b6dfc9e96a9f.jpg)

