### PR TITLE
Rect intersection Improve to support only border overlap

### DIFF
--- a/modules/core/include/opencv2/core/types.hpp
+++ b/modules/core/include/opencv2/core/types.hpp
@@ -1865,7 +1865,7 @@ Rect_<_Tp>& operator &= ( Rect_<_Tp>& a, const Rect_<_Tp>& b )
     a.height = std::min(a.y + a.height, b.y + b.height) - y1;
     a.x = x1;
     a.y = y1;
-    if( a.width <= 0 || a.height <= 0 )
+    if( a.width < 0 || a.height < 0 )
         a = Rect();
     return a;
 }

--- a/modules/core/test/test_rect.cpp
+++ b/modules/core/test/test_rect.cpp
@@ -5,7 +5,7 @@
 
 namespace opencv_test { namespace {
 
-    TEST(Rect, rectUnionOperator) {        
+    TEST(Rect, rectUnionOperator) {
 
         Rect2f test = Rect();
 
@@ -14,7 +14,6 @@ namespace opencv_test { namespace {
         ASSERT_EQ(Rect(0, 0, 1, 1), Rect(0, 0, 1, 1) & Rect(0, 0, 1, 1));
         ASSERT_EQ(Rect(1, 1, 1, 1), Rect(0, 0, 2, 2) & Rect(1, 1, 1, 1));
         ASSERT_EQ(Rect(1, 1, 1, 1), Rect(0, 0, 2, 2) & Rect(1, 1, 2, 2));
-
 
         ASSERT_EQ(Rect(1, 0, 0, 1), Rect(0, 0, 1, 1) & Rect(1, 0, 1, 1));
         ASSERT_EQ(Rect(1, 1, 0, 0), Rect(0, 0, 1, 1) & Rect(1, 1, 1, 1));

--- a/modules/core/test/test_rect.cpp
+++ b/modules/core/test/test_rect.cpp
@@ -7,8 +7,6 @@ namespace opencv_test { namespace {
 
     TEST(Rect, rectUnionOperator) {
 
-        Rect2f test = Rect();
-
         ASSERT_EQ(Rect(0, 0, 0, 0), Rect(0, 0, 1, 1) & Rect(2, 2, 1, 1));
         ASSERT_EQ(Rect(0, 0, 0, 0), Rect(2, 2, 1, 1) & Rect(0, 0, 1, 1));
         ASSERT_EQ(Rect(0, 0, 1, 1), Rect(0, 0, 1, 1) & Rect(0, 0, 1, 1));

--- a/modules/core/test/test_rect.cpp
+++ b/modules/core/test/test_rect.cpp
@@ -1,0 +1,23 @@
+// This file is part of OpenCV project.
+// It is subject to the license terms in the LICENSE file found in the top-level directory
+// of this distribution and at http://opencv.org/license.html.
+#include "test_precomp.hpp"
+
+namespace opencv_test { namespace {
+
+    TEST(Rect, rectUnionOperator) {        
+
+        Rect2f test = Rect();
+
+        ASSERT_EQ(Rect(0, 0, 0, 0), Rect(0, 0, 1, 1) & Rect(2, 2, 1, 1));
+        ASSERT_EQ(Rect(0, 0, 0, 0), Rect(2, 2, 1, 1) & Rect(0, 0, 1, 1));
+        ASSERT_EQ(Rect(0, 0, 1, 1), Rect(0, 0, 1, 1) & Rect(0, 0, 1, 1));
+        ASSERT_EQ(Rect(1, 1, 1, 1), Rect(0, 0, 2, 2) & Rect(1, 1, 1, 1));
+        ASSERT_EQ(Rect(1, 1, 1, 1), Rect(0, 0, 2, 2) & Rect(1, 1, 2, 2));
+
+
+        ASSERT_EQ(Rect(1, 0, 0, 1), Rect(0, 0, 1, 1) & Rect(1, 0, 1, 1));
+        ASSERT_EQ(Rect(1, 1, 0, 0), Rect(0, 0, 1, 1) & Rect(1, 1, 1, 1));
+    }
+
+}} // namespace

--- a/modules/core/test/test_rect.cpp
+++ b/modules/core/test/test_rect.cpp
@@ -5,7 +5,7 @@
 
 namespace opencv_test { namespace {
 
-    TEST(Rect, rectUnionOperator) {
+    TEST(Rect, rectInterSectionOperator) {
 
         ASSERT_EQ(Rect(0, 0, 0, 0), Rect(0, 0, 1, 1) & Rect(2, 2, 1, 1));
         ASSERT_EQ(Rect(0, 0, 0, 0), Rect(2, 2, 1, 1) & Rect(0, 0, 1, 1));


### PR DESCRIPTION
<!-- Please use this line to close one or multiple issues when this pullrequest gets merged
You can add another line right under the first one:
-->
resolves #15254 
### This pullrequest changes

<!-- Please describe what your pullrequest is changing -->
detect the situation when two Rect has only border or point overlap, and return the overlap info by a Rect who's width or/and height may be zero
