### PR TITLE
WINCE 8.0 requires ARMv7 Thumb2 and thus have NEON instructions

### DIFF
--- a/modules/core/src/system.cpp
+++ b/modules/core/src/system.cpp
@@ -554,7 +554,9 @@ struct HWFeatures
         have[CV_CPU_FP16] = true;
     #endif
     #endif
-
+    #if (defined(_WIN32_WCE) && _WIN32_WCE >= 0x800)
+        have[CV_CPU_NEON] = true;
+    #endif
     // there's no need to check VSX availability in runtime since it's always available on ppc64le CPUs
     have[CV_CPU_VSX] = (CV_VSX);
     // TODO: Check VSX3 availability in runtime for other platforms

--- a/modules/core/src/system.cpp
+++ b/modules/core/src/system.cpp
@@ -554,7 +554,7 @@ struct HWFeatures
         have[CV_CPU_FP16] = true;
     #endif
     #endif
-    #if (defined(_WIN32_WCE) && _WIN32_WCE >= 0x800)
+    #if defined _ARM_ && (defined(_WIN32_WCE) && _WIN32_WCE >= 0x800)
         have[CV_CPU_NEON] = true;
     #endif
     // there's no need to check VSX availability in runtime since it's always available on ppc64le CPUs


### PR DESCRIPTION
### This pullrequest changes

This fixes a cv::exception being thrown when trying to use OpenCV and WINCE on ARMv7 Thumb2. 