### PR TITLE
jas_stream: Add definition for L_tmpnam if missing

### DIFF
--- a/3rdparty/libjasper/jas_stream.c
+++ b/3rdparty/libjasper/jas_stream.c
@@ -86,6 +86,10 @@
 #include <io.h>
 #endif
 
+#ifndef L_tmpnam
+#define L_tmpnam 20
+#endif
+
 #include "jasper/jas_types.h"
 #include "jasper/jas_stream.h"
 #include "jasper/jas_malloc.h"

--- a/3rdparty/libjasper/jas_stream.c
+++ b/3rdparty/libjasper/jas_stream.c
@@ -86,10 +86,6 @@
 #include <io.h>
 #endif
 
-#ifndef L_tmpnam
-#define L_tmpnam 20
-#endif
-
 #include "jasper/jas_types.h"
 #include "jasper/jas_stream.h"
 #include "jasper/jas_malloc.h"

--- a/3rdparty/libjasper/jasper/jas_config.h
+++ b/3rdparty/libjasper/jasper/jas_config.h
@@ -17,6 +17,12 @@
 #if !defined(JAS_WIN_MSVC_BUILD)
 /* A configure-based build is being used. */
 
+#include <stdio.h>
+
+// uClibc-ng workaround: https://github.com/opencv/opencv/pull/15279
+#ifndef L_tmpnam
+#define L_tmpnam 20
+#endif
 
 
 /* Extra debugging support */


### PR DESCRIPTION
uClibc-ng for some reason does not provide a definition when some
deprecated APIs are disabled. Value taken from the musl libc.