### PR TITLE
G-API: fix compatibility with wingdi.h header on Windows systems

### DIFF
--- a/modules/gapi/include/opencv2/gapi/garg.hpp
+++ b/modules/gapi/include/opencv2/gapi/garg.hpp
@@ -76,7 +76,7 @@ public:
         return util::unsafe_any_cast<typename std::remove_reference<T>::type>(value);
     }
 
-    detail::ArgKind kind = detail::ArgKind::GOPAQUE;
+    detail::ArgKind kind = detail::ArgKind::OPAQUE_VAL;
 
 protected:
     util::any value;

--- a/modules/gapi/include/opencv2/gapi/garg.hpp
+++ b/modules/gapi/include/opencv2/gapi/garg.hpp
@@ -76,7 +76,7 @@ public:
         return util::unsafe_any_cast<typename std::remove_reference<T>::type>(value);
     }
 
-    detail::ArgKind kind = detail::ArgKind::OPAQUE;
+    detail::ArgKind kind = detail::ArgKind::GOPAQUE;
 
 protected:
     util::any value;

--- a/modules/gapi/include/opencv2/gapi/gtype_traits.hpp
+++ b/modules/gapi/include/opencv2/gapi/gtype_traits.hpp
@@ -26,9 +26,10 @@ namespace detail
     // a double dispatch
     enum class ArgKind: int
     {
-        GOPAQUE,      // Unknown, generic, opaque-to-GAPI data type - STATIC
+        OPAQUE_VAL,   // Unknown, generic, opaque-to-GAPI data type - STATIC
+                      // Note: OPAQUE is sometimes defined in Win sys headers
 #if !defined(OPAQUE) && !defined(CV_DOXYGEN)
-        OPAQUE = GOPAQUE,  // deprecated value used for compatibility only, use GOPAQUE instead
+        OPAQUE = OPAQUE_VAL,  // deprecated value used for compatibility, use OPAQUE_VAL instead
 #endif
         GOBJREF,      // <internal> reference to object
         GMAT,         // a cv::GMat
@@ -44,7 +45,7 @@ namespace detail
     template<typename T> struct GTypeTraits;
     template<typename T> struct GTypeTraits
     {
-        static constexpr const ArgKind kind = ArgKind::GOPAQUE;
+        static constexpr const ArgKind kind = ArgKind::OPAQUE_VAL;
     };
     template<>           struct GTypeTraits<cv::GMat>
     {

--- a/modules/gapi/include/opencv2/gapi/gtype_traits.hpp
+++ b/modules/gapi/include/opencv2/gapi/gtype_traits.hpp
@@ -27,6 +27,9 @@ namespace detail
     enum class ArgKind: int
     {
         GOPAQUE,      // Unknown, generic, opaque-to-GAPI data type - STATIC
+#if !defined(OPAQUE) && !defined(CV_DOXYGEN)
+        OPAQUE = GOPAQUE,  // deprecated value used for compatibility only, use GOPAQUE instead
+#endif
         GOBJREF,      // <internal> reference to object
         GMAT,         // a cv::GMat
         GMATP,        // a cv::GMatP

--- a/modules/gapi/include/opencv2/gapi/gtype_traits.hpp
+++ b/modules/gapi/include/opencv2/gapi/gtype_traits.hpp
@@ -26,7 +26,7 @@ namespace detail
     // a double dispatch
     enum class ArgKind: int
     {
-        OPAQUE,       // Unknown, generic, opaque-to-GAPI data type - STATIC
+        GOPAQUE,      // Unknown, generic, opaque-to-GAPI data type - STATIC
         GOBJREF,      // <internal> reference to object
         GMAT,         // a cv::GMat
         GMATP,        // a cv::GMatP
@@ -41,7 +41,7 @@ namespace detail
     template<typename T> struct GTypeTraits;
     template<typename T> struct GTypeTraits
     {
-        static constexpr const ArgKind kind = ArgKind::OPAQUE;
+        static constexpr const ArgKind kind = ArgKind::GOPAQUE;
     };
     template<>           struct GTypeTraits<cv::GMat>
     {

--- a/modules/gapi/test/internal/gapi_int_garg_test.cpp
+++ b/modules/gapi/test/internal/gapi_int_garg_test.cpp
@@ -39,14 +39,14 @@ using GArg_Test_Types = ::testing::Types
    , Expected<cv::GArray<cv::Rect>,     cv::detail::ArgKind::GARRAY>
 
  // Built-in types
-   , Expected<int,                      cv::detail::ArgKind::GOPAQUE>
-   , Expected<float,                    cv::detail::ArgKind::GOPAQUE>
-   , Expected<int*,                     cv::detail::ArgKind::GOPAQUE>
-   , Expected<cv::Point,                cv::detail::ArgKind::GOPAQUE>
-   , Expected<std::string,              cv::detail::ArgKind::GOPAQUE>
-   , Expected<cv::Mat,                  cv::detail::ArgKind::GOPAQUE>
-   , Expected<std::vector<int>,         cv::detail::ArgKind::GOPAQUE>
-   , Expected<std::vector<cv::Point>,   cv::detail::ArgKind::GOPAQUE>
+   , Expected<int,                      cv::detail::ArgKind::OPAQUE_VAL>
+   , Expected<float,                    cv::detail::ArgKind::OPAQUE_VAL>
+   , Expected<int*,                     cv::detail::ArgKind::OPAQUE_VAL>
+   , Expected<cv::Point,                cv::detail::ArgKind::OPAQUE_VAL>
+   , Expected<std::string,              cv::detail::ArgKind::OPAQUE_VAL>
+   , Expected<cv::Mat,                  cv::detail::ArgKind::OPAQUE_VAL>
+   , Expected<std::vector<int>,         cv::detail::ArgKind::OPAQUE_VAL>
+   , Expected<std::vector<cv::Point>,   cv::detail::ArgKind::OPAQUE_VAL>
    >;
 
 TYPED_TEST_CASE(GArgKind, GArg_Test_Types);

--- a/modules/gapi/test/internal/gapi_int_garg_test.cpp
+++ b/modules/gapi/test/internal/gapi_int_garg_test.cpp
@@ -39,14 +39,14 @@ using GArg_Test_Types = ::testing::Types
    , Expected<cv::GArray<cv::Rect>,     cv::detail::ArgKind::GARRAY>
 
  // Built-in types
-   , Expected<int,                      cv::detail::ArgKind::OPAQUE>
-   , Expected<float,                    cv::detail::ArgKind::OPAQUE>
-   , Expected<int*,                     cv::detail::ArgKind::OPAQUE>
-   , Expected<cv::Point,                cv::detail::ArgKind::OPAQUE>
-   , Expected<std::string,              cv::detail::ArgKind::OPAQUE>
-   , Expected<cv::Mat,                  cv::detail::ArgKind::OPAQUE>
-   , Expected<std::vector<int>,         cv::detail::ArgKind::OPAQUE>
-   , Expected<std::vector<cv::Point>,   cv::detail::ArgKind::OPAQUE>
+   , Expected<int,                      cv::detail::ArgKind::GOPAQUE>
+   , Expected<float,                    cv::detail::ArgKind::GOPAQUE>
+   , Expected<int*,                     cv::detail::ArgKind::GOPAQUE>
+   , Expected<cv::Point,                cv::detail::ArgKind::GOPAQUE>
+   , Expected<std::string,              cv::detail::ArgKind::GOPAQUE>
+   , Expected<cv::Mat,                  cv::detail::ArgKind::GOPAQUE>
+   , Expected<std::vector<int>,         cv::detail::ArgKind::GOPAQUE>
+   , Expected<std::vector<cv::Point>,   cv::detail::ArgKind::GOPAQUE>
    >;
 
 TYPED_TEST_CASE(GArgKind, GArg_Test_Types);


### PR DESCRIPTION
### This pullrequest

- fixes compatibility issue between G-API and wingdi.h header on Windows systems
  - renames `cv::detail::ArgKind::OPAQUE` value to `GOPAQUE` to fix the conflict

---
__Issue__:
Compilation error occurs in G-API code if user includes both wingdi.h and gtype_traits.hpp. The latter is included in garg.hpp, gkernel.hpp, gtransform.hpp ("API" headers).

I imagine that the issue occurs when the order of includes is the following:
```cpp
#include "wingdi.h"  // defines OPAQUE value
#include "gtype_traits.hpp"  // uses ArgKind::OPAQUE
```
In that case opaque error description (hence the joke) is shown:
```bash
include/opencv2/gapi/gtype_traits.hpp(29): error: expected an identifier
         OPAQUE,       // Unknown, generic, opaque-to-GAPI data type - STATIC
         ^
include/opencv2/gapi/gtype_traits.hpp(44): error: expected an identifier
static constexpr const ArgKind kind = ArgKind::OPAQUE;
                                               ^
```
Instead of interpreting `ArgKind::OPAQUE` as a enum value, pre-processor likely substitutes a macro resulting in `ArgKind::<value defined by OPAQUE macro>` in the code and thus G-API code becomes invalid

---
According to the documentation:
https://docs.microsoft.com/en-us/windows/win32/api/wingdi/nf-wingdi-setbkmode
there's a defined value "OPAQUE". And in the source file of wingdi.h I see the following:
```cpp
/* Background Modes */
#define TRANSPARENT 1
#define OPAQUE 2
#define BKMODE_LAST 2
```
---
```bash
build_gapi_standalone:Linux x64=ade-0.1.1f
build_gapi_standalone:Win64=ade-0.1.1f
#build_gapi_standalone:Mac=ade-0.1.1f
build_gapi_standalone:Linux x64 Debug=ade-0.1.1f
build_gapi_standalone:Custom Win=ade-0.1.1f
```
