### PR TITLE
build: eliminate warnings with Xcode 10.3

### DIFF
--- a/modules/core/test/test_ptr.cpp
+++ b/modules/core/test/test_ptr.cpp
@@ -43,6 +43,10 @@
 
 namespace opencv_test { namespace {
 
+#if defined __clang__ && defined __APPLE__
+#pragma clang diagnostic ignored "-Wself-assign-overloaded"  // explicitly assigning value of variable of type '...' to itself (p1 = p1)
+#endif
+
 #ifdef GTEST_CAN_COMPARE_NULL
 #  define EXPECT_NULL(ptr) EXPECT_EQ(NULL, ptr)
 #else


### PR DESCRIPTION
<cut/>

```
opencv_contrib=cmake_tesseract_cxx11_check
```