### PR TITLE
Update seamless_cloning.cpp

### DIFF
--- a/modules/photo/src/seamless_cloning.cpp
+++ b/modules/photo/src/seamless_cloning.cpp
@@ -78,6 +78,7 @@ void cv::seamlessClone(InputArray _src, InputArray _dst, InputArray _mask, Point
     copyMakeBorder(mask_inner, mask, 1, 1, 1, 1, BORDER_ISOLATED | BORDER_CONSTANT, Scalar(0));
 
     Rect roi_s = boundingRect(mask);
+    if (roi_s.empty()) return;
     Rect roi_d(p.x - roi_s.width / 2, p.y - roi_s.height / 2, roi_s.width, roi_s.height);
 
     Mat destinationROI = dest(roi_d).clone();

--- a/modules/photo/test/test_cloning.cpp
+++ b/modules/photo/test/test_cloning.cpp
@@ -86,6 +86,15 @@ TEST(Photo_SeamlessClone_normal, regression)
     EXPECT_LE(errorINF, 1);
     double errorL1 = cvtest::norm(reference, result, NORM_L1);
     EXPECT_LE(errorL1, reference.total() * numerical_precision) << "size=" << reference.size();
+
+    mask = Scalar(0, 0, 0);
+    seamlessClone(source, destination, mask, p, result, 1);
+
+    reference = destination;
+    errorINF = cvtest::norm(reference, result, NORM_INF);
+    EXPECT_LE(errorINF, 1);
+    errorL1 = cvtest::norm(reference, result, NORM_L1);
+    EXPECT_LE(errorL1, reference.total() * numerical_precision) << "size=" << reference.size();
 }
 
 TEST(Photo_SeamlessClone_mixed, regression)


### PR DESCRIPTION
resolves #15294

### This pullrequest changes

if mask is all zero matrix then actual code is broken. Proposed solution is just copy input to output ( already done in actual code ) and return.
