### PR TITLE
opencv.js : expose FS

### DIFF
--- a/modules/js/src/helpers.js
+++ b/modules/js/src/helpers.js
@@ -38,6 +38,10 @@
 // the use of this software, even if advised of the possibility of such damage.
 //
 
+if (typeof Module.FS === 'undefined' && typeof FS !== 'undefined') {
+    Module.FS = FS;
+}
+
 Module['imread'] = function(imageSource) {
     var img = null;
     if (typeof imageSource === 'string') {


### PR DESCRIPTION
expose FS in Module.FS so users can use the filesystem. This gives more flexibility and enable C/C++ APIs  that reference files. Also needed for supporting node.js and load images directly from local filesystem. (i'm working on supporting node.js too)

relates #15425