### PR TITLE
Fix Doc Feature Matching + Homography to find Objects's Code error

### DIFF
--- a/doc/py_tutorials/py_feature2d/py_feature_homography/py_feature_homography.markdown
+++ b/doc/py_tutorials/py_feature2d/py_feature_homography/py_feature_homography.markdown
@@ -78,7 +78,7 @@ if len(good)>MIN_MATCH_COUNT:
     M, mask = cv.findHomography(src_pts, dst_pts, cv.RANSAC,5.0)
     matchesMask = mask.ravel().tolist()
 
-    h,w,d = img1.shape
+    h,w = img1.shape
     pts = np.float32([ [0,0],[0,h-1],[w-1,h-1],[w-1,0] ]).reshape(-1,1,2)
     dst = cv.perspectiveTransform(pts,M)
 


### PR DESCRIPTION
### Doc Feature Matching + Homography to find Objects's  Code has error

```python
img1 = cv.imread('box.png',0)          # queryImage
....
h,w,d = img1.shape
```

Img1 is a grayscale image with only two color channels， but return three values.
And an error will accur after running.
```
ValueError: not enough values to unpack (expected 3, got 2)
```

Now changed `h, w = img1.shape`

```
force_builders=Docs
```