### PR TITLE
Add debug build option to macOS and iOS build scripts

### DIFF
--- a/platforms/ios/build_framework.py
+++ b/platforms/ios/build_framework.py
@@ -49,7 +49,7 @@ def getXCodeMajor():
         raise Exception("Failed to parse Xcode version")
 
 class Builder:
-    def __init__(self, opencv, contrib, dynamic, bitcodedisabled, exclude, enablenonfree, targets, debug):
+    def __init__(self, opencv, contrib, dynamic, bitcodedisabled, exclude, enablenonfree, targets, debug, debug_info):
         self.opencv = os.path.abspath(opencv)
         self.contrib = None
         if contrib:
@@ -64,6 +64,7 @@ class Builder:
         self.enablenonfree = enablenonfree
         self.targets = targets
         self.debug = debug
+        self.debug_info = debug_info
 
     def getBD(self, parent, t):
 
@@ -143,7 +144,9 @@ class Builder:
             "-DCMAKE_XCODE_ATTRIBUTE_CODE_SIGNING_REQUIRED=NO",
         ] if self.dynamic else []) + ([
             "-DOPENCV_ENABLE_NONFREE=ON"
-        ] if self.enablenonfree else [])
+        ] if self.enablenonfree else []) + ([
+            "-DBUILD_WITH_DEBUG_INFO=ON"
+        ] if self.debug_info else [])
 
         if len(self.exclude) > 0:
             args += ["-DBUILD_opencv_world=OFF"] if not self.dynamic else []
@@ -293,6 +296,7 @@ if __name__ == "__main__":
     parser.add_argument('--iphonesimulator_archs', default='i386,x86_64', help='select iPhoneSimulator target ARCHS')
     parser.add_argument('--enable_nonfree', default=False, dest='enablenonfree', action='store_true', help='enable non-free modules (disabled by default)')
     parser.add_argument('--debug', default=False, dest='debug', action='store_true', help='Build "Debug" binaries (disabled by default)')
+    parser.add_argument('--debug_info', default=False, dest='debug_info', action='store_true', help='Build with debug information (useful for Release mode: BUILD_WITH_DEBUG_INFO=ON)')
     args = parser.parse_args()
 
     os.environ['IPHONEOS_DEPLOYMENT_TARGET'] = args.iphoneos_deployment_target
@@ -309,5 +313,5 @@ if __name__ == "__main__":
         [
             (iphoneos_archs, "iPhoneOS"),
             (iphonesimulator_archs, "iPhoneSimulator"),
-        ], args.debug)
+        ], args.debug, args.debug_info)
     b.build(args.out)

--- a/platforms/osx/build_framework.py
+++ b/platforms/osx/build_framework.py
@@ -18,10 +18,10 @@ class OSXBuilder(Builder):
     def getBuildCommand(self, archs, target):
         buildcmd = [
             "xcodebuild",
-            "MACOSX_DEPLOYMENT_TARGET=10.9",
+            "MACOSX_DEPLOYMENT_TARGET=10.12",
             "ARCHS=%s" % archs[0],
             "-sdk", target.lower(),
-            "-configuration", "Release",
+            "-configuration", "Debug" if self.debug else "Release",
             "-parallelizeTargets",
             "-jobs", str(multiprocessing.cpu_count())
         ]
@@ -39,10 +39,12 @@ if __name__ == "__main__":
     parser.add_argument('--contrib', metavar='DIR', default=None, help='folder with opencv_contrib repository (default is "None" - build only main framework)')
     parser.add_argument('--without', metavar='MODULE', default=[], action='append', help='OpenCV modules to exclude from the framework')
     parser.add_argument('--enable_nonfree', default=False, dest='enablenonfree', action='store_true', help='enable non-free modules (disabled by default)')
+    parser.add_argument('--debug', action="store_true", help="Build 'Debug' binaries (CMAKE_BUILD_TYPE=Debug)")
+
     args = parser.parse_args()
 
     b = OSXBuilder(args.opencv, args.contrib, False, False, args.without, args.enablenonfree,
         [
             (["x86_64"], "MacOSX")
-        ])
+        ], args.debug)
     b.build(args.out)

--- a/platforms/osx/build_framework.py
+++ b/platforms/osx/build_framework.py
@@ -42,7 +42,8 @@ if __name__ == "__main__":
     parser.add_argument('--without', metavar='MODULE', default=[], action='append', help='OpenCV modules to exclude from the framework')
     parser.add_argument('--enable_nonfree', default=False, dest='enablenonfree', action='store_true', help='enable non-free modules (disabled by default)')
     parser.add_argument('--macosx_deployment_target', default=os.environ.get('MACOSX_DEPLOYMENT_TARGET', MACOSX_DEPLOYMENT_TARGET), help='specify MACOSX_DEPLOYMENT_TARGET')
-    parser.add_argument('--debug', action="store_true", help="Build 'Debug' binaries (CMAKE_BUILD_TYPE=Debug)")
+    parser.add_argument('--debug', action='store_true', help='Build "Debug" binaries (CMAKE_BUILD_TYPE=Debug)')
+    parser.add_argument('--debug_info', action='store_true', help='Build with debug information (useful for Release mode: BUILD_WITH_DEBUG_INFO=ON)')
 
     args = parser.parse_args()
 
@@ -52,5 +53,5 @@ if __name__ == "__main__":
     b = OSXBuilder(args.opencv, args.contrib, False, False, args.without, args.enablenonfree,
         [
             (["x86_64"], "MacOSX")
-        ], args.debug)
+        ], args.debug, args.debug_info)
     b.build(args.out)

--- a/platforms/osx/build_framework.py
+++ b/platforms/osx/build_framework.py
@@ -10,6 +10,8 @@ import os, os.path, sys, argparse, traceback, multiprocessing
 sys.path.insert(0, os.path.abspath(os.path.abspath(os.path.dirname(__file__))+'/../ios'))
 from build_framework import Builder
 
+MACOSX_DEPLOYMENT_TARGET='10.12'  # default, can be changed via command line options or environment variable
+
 class OSXBuilder(Builder):
 
     def getToolchain(self, arch, target):
@@ -18,7 +20,7 @@ class OSXBuilder(Builder):
     def getBuildCommand(self, archs, target):
         buildcmd = [
             "xcodebuild",
-            "MACOSX_DEPLOYMENT_TARGET=10.12",
+            "MACOSX_DEPLOYMENT_TARGET=" + os.environ['MACOSX_DEPLOYMENT_TARGET'],
             "ARCHS=%s" % archs[0],
             "-sdk", target.lower(),
             "-configuration", "Debug" if self.debug else "Release",
@@ -39,9 +41,13 @@ if __name__ == "__main__":
     parser.add_argument('--contrib', metavar='DIR', default=None, help='folder with opencv_contrib repository (default is "None" - build only main framework)')
     parser.add_argument('--without', metavar='MODULE', default=[], action='append', help='OpenCV modules to exclude from the framework')
     parser.add_argument('--enable_nonfree', default=False, dest='enablenonfree', action='store_true', help='enable non-free modules (disabled by default)')
+    parser.add_argument('--macosx_deployment_target', default=os.environ.get('MACOSX_DEPLOYMENT_TARGET', MACOSX_DEPLOYMENT_TARGET), help='specify MACOSX_DEPLOYMENT_TARGET')
     parser.add_argument('--debug', action="store_true", help="Build 'Debug' binaries (CMAKE_BUILD_TYPE=Debug)")
 
     args = parser.parse_args()
+
+    os.environ['MACOSX_DEPLOYMENT_TARGET'] = args.macosx_deployment_target
+    print('Using MACOSX_DEPLOYMENT_TARGET=' + os.environ['MACOSX_DEPLOYMENT_TARGET'])
 
     b = OSXBuilder(args.opencv, args.contrib, False, False, args.without, args.enablenonfree,
         [


### PR DESCRIPTION
Add command line option `--debug` to both the macOS and iOS build scripts to enable building OpenCV on these platforms with debug info.
Additionally add executable privilege to the macOS build script

```
force_builders=Custom Mac
build_image:Custom Mac=osx_framework
```