### PR TITLE
Convert ImgWarp from SSE SIMD to HAL - 2.8x faster on Power (VSX) and…

### DIFF
--- a/modules/imgproc/src/imgwarp.cpp
+++ b/modules/imgproc/src/imgwarp.cpp
@@ -2686,7 +2686,7 @@ void cv::warpAffine( InputArray _src, OutputArray _dst,
 
 namespace cv
 {
-#if CV_SIMD128
+#if CV_SIMD128_64F
 namespace opt_CV_SIMD
 {
 
@@ -2984,7 +2984,7 @@ public:
         int bw0 = std::min(BLOCK_SZ*BLOCK_SZ/bh0, width);
         bh0 = std::min(BLOCK_SZ*BLOCK_SZ/bw0, height);
 
-        #if CV_SIMD128
+        #if CV_SIMD128_64F
         Ptr<opt_CV_SIMD::WarpPerspectiveLine_CV_SIMD> pwarp_impl_CV_SIMD;
         pwarp_impl_CV_SIMD = opt_CV_SIMD::WarpPerspectiveLine_CV_SIMD::getImpl(M);
         #endif
@@ -3010,7 +3010,7 @@ public:
                     {
                         x1 = 0;
 
-                        #if CV_SIMD128
+                        #if CV_SIMD128_64F
                         if (pwarp_impl_CV_SIMD)
                             pwarp_impl_CV_SIMD->processNN(M, xy, X0, Y0, W0, bw);
                         else
@@ -3033,7 +3033,7 @@ public:
                         short* alpha = A + y1*bw;
                         x1 = 0;
 
-                        #if CV_SIMD128
+                        #if CV_SIMD128_64F
                         if (pwarp_impl_CV_SIMD)
                             pwarp_impl_CV_SIMD->process(M, xy, alpha, X0, Y0, W0, bw);
                         else

--- a/modules/imgproc/src/imgwarp.cpp
+++ b/modules/imgproc/src/imgwarp.cpp
@@ -2686,275 +2686,256 @@ void cv::warpAffine( InputArray _src, OutputArray _dst,
 
 namespace cv
 {
-#if CV_SIMD128_64F
-namespace opt_CV_SIMD
+#if !CV_TRY_SSE4_1 && CV_SIMD128_64F
+void WarpPerspectiveLine_ProcessNN_CV_SIMD(const double *M, short* xy, double X0, double Y0, double W0, int bw)
 {
+    const v_float64x2 v_M0 = v_setall_f64(M[0]);
+    const v_float64x2 v_M3 = v_setall_f64(M[3]);
+    const v_float64x2 v_M6 = v_setall_f64(M[6]);
+    const v_float64x2 v_intmax = v_setall_f64((double)INT_MAX);
+    const v_float64x2 v_intmin = v_setall_f64((double)INT_MIN);
+    const v_float64x2 v_2 = v_setall_f64(2.0);
+    const v_float64x2 v_zero = v_setzero_f64();
+    const v_float64x2 v_1 = v_setall_f64(1.0);
 
-class WarpPerspectiveLine_CV_SIMD_Impl CV_FINAL : public WarpPerspectiveLine_CV_SIMD
-{
-public:
-    WarpPerspectiveLine_CV_SIMD_Impl(const double *M)
+    int x1 = 0;
+    v_float64x2 v_X0d = v_setall_f64(X0);
+    v_float64x2 v_Y0d = v_setall_f64(Y0);
+    v_float64x2 v_W0 = v_setall_f64(W0);
+    v_float64x2 v_x1(0.0, 1.0);
+
+    for (; x1 <= bw - 16; x1 += 16)
     {
-        CV_UNUSED(M);
+        // 0-3
+        v_int32x4 v_X0, v_Y0;
+        {
+            v_float64x2 v_W = v_muladd(v_M6, v_x1, v_W0);
+            v_W = v_select(v_W != v_zero, v_1 / v_W, v_zero);
+            v_float64x2 v_fX0 = v_max(v_intmin, v_min(v_intmax, v_muladd(v_M0, v_x1, v_X0d) * v_W));
+            v_float64x2 v_fY0 = v_max(v_intmin, v_min(v_intmax, v_muladd(v_M3, v_x1, v_Y0d) * v_W));
+            v_x1 += v_2;
+
+            v_W = v_muladd(v_M6, v_x1, v_W0);
+            v_W = v_select(v_W != v_zero, v_1 / v_W, v_zero);
+            v_float64x2 v_fX1 = v_max(v_intmin, v_min(v_intmax, v_muladd(v_M0, v_x1, v_X0d) * v_W));
+            v_float64x2 v_fY1 = v_max(v_intmin, v_min(v_intmax, v_muladd(v_M3, v_x1, v_Y0d) * v_W));
+            v_x1 += v_2;
+
+            v_X0 = v_round(v_fX0, v_fX1);
+            v_Y0 = v_round(v_fY0, v_fY1);
+        }
+
+        // 4-7
+        v_int32x4 v_X1, v_Y1;
+        {
+            v_float64x2 v_W = v_muladd(v_M6, v_x1, v_W0);
+            v_W = v_select(v_W != v_zero, v_1 / v_W, v_zero);
+            v_float64x2 v_fX0 = v_max(v_intmin, v_min(v_intmax, v_muladd(v_M0, v_x1, v_X0d) * v_W));
+            v_float64x2 v_fY0 = v_max(v_intmin, v_min(v_intmax, v_muladd(v_M3, v_x1, v_Y0d) * v_W));
+            v_x1 += v_2;
+
+            v_W = v_muladd(v_M6, v_x1, v_W0);
+            v_W = v_select(v_W != v_zero, v_1 / v_W, v_zero);
+            v_float64x2 v_fX1 = v_max(v_intmin, v_min(v_intmax, v_muladd(v_M0, v_x1, v_X0d) * v_W));
+            v_float64x2 v_fY1 = v_max(v_intmin, v_min(v_intmax, v_muladd(v_M3, v_x1, v_Y0d) * v_W));
+            v_x1 += v_2;
+
+            v_X1 = v_round(v_fX0, v_fX1);
+            v_Y1 = v_round(v_fY0, v_fY1);
+        }
+
+        // 8-11
+        v_int32x4 v_X2, v_Y2;
+        {
+            v_float64x2 v_W = v_muladd(v_M6, v_x1, v_W0);
+            v_W = v_select(v_W != v_zero, v_1 / v_W, v_zero);
+            v_float64x2 v_fX0 = v_max(v_intmin, v_min(v_intmax, v_muladd(v_M0, v_x1, v_X0d) * v_W));
+            v_float64x2 v_fY0 = v_max(v_intmin, v_min(v_intmax, v_muladd(v_M3, v_x1, v_Y0d) * v_W));
+            v_x1 += v_2;
+
+            v_W = v_muladd(v_M6, v_x1, v_W0);
+            v_W = v_select(v_W != v_zero, v_1 / v_W, v_zero);
+            v_float64x2 v_fX1 = v_max(v_intmin, v_min(v_intmax, v_muladd(v_M0, v_x1, v_X0d) * v_W));
+            v_float64x2 v_fY1 = v_max(v_intmin, v_min(v_intmax, v_muladd(v_M3, v_x1, v_Y0d) * v_W));
+            v_x1 += v_2;
+
+            v_X2 = v_round(v_fX0, v_fX1);
+            v_Y2 = v_round(v_fY0, v_fY1);
+        }
+
+        // 12-15
+        v_int32x4 v_X3, v_Y3;
+        {
+            v_float64x2 v_W = v_muladd(v_M6, v_x1, v_W0);
+            v_W = v_select(v_W != v_zero, v_1 / v_W, v_zero);
+            v_float64x2 v_fX0 = v_max(v_intmin, v_min(v_intmax, v_muladd(v_M0, v_x1, v_X0d) * v_W));
+            v_float64x2 v_fY0 = v_max(v_intmin, v_min(v_intmax, v_muladd(v_M3, v_x1, v_Y0d) * v_W));
+            v_x1 += v_2;
+
+            v_W = v_muladd(v_M6, v_x1, v_W0);
+            v_W = v_select(v_W != v_zero, v_1 / v_W, v_zero);
+            v_float64x2 v_fX1 = v_max(v_intmin, v_min(v_intmax, v_muladd(v_M0, v_x1, v_X0d) * v_W));
+            v_float64x2 v_fY1 = v_max(v_intmin, v_min(v_intmax, v_muladd(v_M3, v_x1, v_Y0d) * v_W));
+            v_x1 += v_2;
+
+            v_X3 = v_round(v_fX0, v_fX1);
+            v_Y3 = v_round(v_fY0, v_fY1);
+        }
+
+        // convert to 16s
+        v_X0 = v_reinterpret_as_s32(v_pack(v_X0, v_X1));
+        v_X1 = v_reinterpret_as_s32(v_pack(v_X2, v_X3));
+        v_Y0 = v_reinterpret_as_s32(v_pack(v_Y0, v_Y1));
+        v_Y1 = v_reinterpret_as_s32(v_pack(v_Y2, v_Y3));
+
+        v_store_interleave(xy + x1 * 2, (v_reinterpret_as_s16)(v_X0), (v_reinterpret_as_s16)(v_Y0));
+        v_store_interleave(xy + x1 * 2 + 16, (v_reinterpret_as_s16)(v_X1), (v_reinterpret_as_s16)(v_Y1));
     }
-    virtual void processNN(const double *M, short* xy, double X0, double Y0, double W0, int bw) CV_OVERRIDE
+
+    for( ; x1 < bw; x1++ )
     {
-        const v_float64x2 v_M0 = v_setall_f64(M[0]);
-        const v_float64x2 v_M3 = v_setall_f64(M[3]);
-        const v_float64x2 v_M6 = v_setall_f64(M[6]);
-        const v_float64x2 v_intmax = v_setall_f64((double)INT_MAX);
-        const v_float64x2 v_intmin = v_setall_f64((double)INT_MIN);
-        const v_float64x2 v_2 = v_setall_f64(2.0);
-        const v_float64x2 v_zero = v_setzero_f64();
-        const v_float64x2 v_1 = v_setall_f64(1.0);
+        double W = W0 + M[6]*x1;
+        W = W ? 1./W : 0;
+        double fX = std::max((double)INT_MIN, std::min((double)INT_MAX, (X0 + M[0]*x1)*W));
+        double fY = std::max((double)INT_MIN, std::min((double)INT_MAX, (Y0 + M[3]*x1)*W));
+        int X = saturate_cast<int>(fX);
+        int Y = saturate_cast<int>(fY);
 
-        int x1 = 0;
-        v_float64x2 v_X0d = v_setall_f64(X0);
-        v_float64x2 v_Y0d = v_setall_f64(Y0);
-        v_float64x2 v_W0 = v_setall_f64(W0);
-        v_float64x2 v_x1(0.0, 1.0);
-
-        for (; x1 <= bw - 16; x1 += 16)
-        {
-            // 0-3
-            v_int32x4 v_X0, v_Y0;
-            {
-                v_float64x2 v_W = v_muladd(v_M6, v_x1, v_W0);
-                v_W = v_select(v_W != v_zero, v_1 / v_W, v_zero);
-                v_float64x2 v_fX0 = v_max(v_intmin, v_min(v_intmax, v_muladd(v_M0, v_x1, v_X0d) * v_W));
-                v_float64x2 v_fY0 = v_max(v_intmin, v_min(v_intmax, v_muladd(v_M3, v_x1, v_Y0d) * v_W));
-                v_x1 += v_2;
-
-                v_W = v_muladd(v_M6, v_x1, v_W0);
-                v_W = v_select(v_W != v_zero, v_1 / v_W, v_zero);
-                v_float64x2 v_fX1 = v_max(v_intmin, v_min(v_intmax, v_muladd(v_M0, v_x1, v_X0d) * v_W));
-                v_float64x2 v_fY1 = v_max(v_intmin, v_min(v_intmax, v_muladd(v_M3, v_x1, v_Y0d) * v_W));
-                v_x1 += v_2;
-
-                v_X0 = v_round(v_fX0, v_fX1);
-                v_Y0 = v_round(v_fY0, v_fY1);
-            }
-
-            // 4-7
-            v_int32x4 v_X1, v_Y1;
-            {
-                v_float64x2 v_W = v_muladd(v_M6, v_x1, v_W0);
-                v_W = v_select(v_W != v_zero, v_1 / v_W, v_zero);
-                v_float64x2 v_fX0 = v_max(v_intmin, v_min(v_intmax, v_muladd(v_M0, v_x1, v_X0d) * v_W));
-                v_float64x2 v_fY0 = v_max(v_intmin, v_min(v_intmax, v_muladd(v_M3, v_x1, v_Y0d) * v_W));
-                v_x1 += v_2;
-
-                v_W = v_muladd(v_M6, v_x1, v_W0);
-                v_W = v_select(v_W != v_zero, v_1 / v_W, v_zero);
-                v_float64x2 v_fX1 = v_max(v_intmin, v_min(v_intmax, v_muladd(v_M0, v_x1, v_X0d) * v_W));
-                v_float64x2 v_fY1 = v_max(v_intmin, v_min(v_intmax, v_muladd(v_M3, v_x1, v_Y0d) * v_W));
-                v_x1 += v_2;
-
-                v_X1 = v_round(v_fX0, v_fX1);
-                v_Y1 = v_round(v_fY0, v_fY1);
-            }
-
-            // 8-11
-            v_int32x4 v_X2, v_Y2;
-            {
-                v_float64x2 v_W = v_muladd(v_M6, v_x1, v_W0);
-                v_W = v_select(v_W != v_zero, v_1 / v_W, v_zero);
-                v_float64x2 v_fX0 = v_max(v_intmin, v_min(v_intmax, v_muladd(v_M0, v_x1, v_X0d) * v_W));
-                v_float64x2 v_fY0 = v_max(v_intmin, v_min(v_intmax, v_muladd(v_M3, v_x1, v_Y0d) * v_W));
-                v_x1 += v_2;
-
-                v_W = v_muladd(v_M6, v_x1, v_W0);
-                v_W = v_select(v_W != v_zero, v_1 / v_W, v_zero);
-                v_float64x2 v_fX1 = v_max(v_intmin, v_min(v_intmax, v_muladd(v_M0, v_x1, v_X0d) * v_W));
-                v_float64x2 v_fY1 = v_max(v_intmin, v_min(v_intmax, v_muladd(v_M3, v_x1, v_Y0d) * v_W));
-                v_x1 += v_2;
-
-                v_X2 = v_round(v_fX0, v_fX1);
-                v_Y2 = v_round(v_fY0, v_fY1);
-            }
-
-            // 12-15
-            v_int32x4 v_X3, v_Y3;
-            {
-                v_float64x2 v_W = v_muladd(v_M6, v_x1, v_W0);
-                v_W = v_select(v_W != v_zero, v_1 / v_W, v_zero);
-                v_float64x2 v_fX0 = v_max(v_intmin, v_min(v_intmax, v_muladd(v_M0, v_x1, v_X0d) * v_W));
-                v_float64x2 v_fY0 = v_max(v_intmin, v_min(v_intmax, v_muladd(v_M3, v_x1, v_Y0d) * v_W));
-                v_x1 += v_2;
-
-                v_W = v_muladd(v_M6, v_x1, v_W0);
-                v_W = v_select(v_W != v_zero, v_1 / v_W, v_zero);
-                v_float64x2 v_fX1 = v_max(v_intmin, v_min(v_intmax, v_muladd(v_M0, v_x1, v_X0d) * v_W));
-                v_float64x2 v_fY1 = v_max(v_intmin, v_min(v_intmax, v_muladd(v_M3, v_x1, v_Y0d) * v_W));
-                v_x1 += v_2;
-
-                v_X3 = v_round(v_fX0, v_fX1);
-                v_Y3 = v_round(v_fY0, v_fY1);
-            }
-
-
-            // convert to 16s
-            v_X0 = v_reinterpret_as_s32(v_pack(v_X0, v_X1));
-            v_X1 = v_reinterpret_as_s32(v_pack(v_X2, v_X3));
-            v_Y0 = v_reinterpret_as_s32(v_pack(v_Y0, v_Y1));
-            v_Y1 = v_reinterpret_as_s32(v_pack(v_Y2, v_Y3));
-
-            v_store_interleave(xy + x1 * 2, (v_reinterpret_as_s16)(v_X0), (v_reinterpret_as_s16)(v_Y0));
-            v_store_interleave(xy + x1 * 2 + 16, (v_reinterpret_as_s16)(v_X1), (v_reinterpret_as_s16)(v_Y1));
-        }
-
-        for( ; x1 < bw; x1++ )
-        {
-            double W = W0 + M[6]*x1;
-            W = W ? 1./W : 0;
-            double fX = std::max((double)INT_MIN, std::min((double)INT_MAX, (X0 + M[0]*x1)*W));
-            double fY = std::max((double)INT_MIN, std::min((double)INT_MAX, (Y0 + M[3]*x1)*W));
-            int X = saturate_cast<int>(fX);
-            int Y = saturate_cast<int>(fY);
-
-            xy[x1*2] = saturate_cast<short>(X);
-            xy[x1*2+1] = saturate_cast<short>(Y);
-        }
+        xy[x1*2] = saturate_cast<short>(X);
+        xy[x1*2+1] = saturate_cast<short>(Y);
     }
-    virtual void process(const double *M, short* xy, short* alpha, double X0, double Y0, double W0, int bw) CV_OVERRIDE
-    {
-        const v_float64x2 v_M0 = v_setall_f64(M[0]);
-        const v_float64x2 v_M3 = v_setall_f64(M[3]);
-        const v_float64x2 v_M6 = v_setall_f64(M[6]);
-        const v_float64x2 v_intmax = v_setall_f64((double)INT_MAX);
-        const v_float64x2 v_intmin = v_setall_f64((double)INT_MIN);
-        const v_float64x2 v_2 = v_setall_f64(2.0);
-        const v_float64x2 v_zero = v_setzero_f64();
-        const v_float64x2 v_its = v_setall_f64((double)INTER_TAB_SIZE);
-        const v_int32x4 v_itsi1 = v_setall_s32(INTER_TAB_SIZE - 1);
-
-        int x1 = 0;
-
-        v_float64x2 v_X0d = v_setall_f64(X0);
-        v_float64x2 v_Y0d = v_setall_f64(Y0);
-        v_float64x2 v_W0 = v_setall_f64(W0);
-        v_float64x2 v_x1(0.0, 1.0);
-
-        for (; x1 <= bw - 16; x1 += 16)
-        {
-            // 0-3
-            v_int32x4 v_X0, v_Y0;
-            {
-                v_float64x2 v_W = v_muladd(v_M6, v_x1, v_W0);
-                v_W = v_select(v_W != v_zero, v_its / v_W, v_zero);
-                v_float64x2 v_fX0 = v_max(v_intmin, v_min(v_intmax, v_muladd(v_M0, v_x1, v_X0d) * v_W));
-                v_float64x2 v_fY0 = v_max(v_intmin, v_min(v_intmax, v_muladd(v_M3, v_x1, v_Y0d) * v_W));
-                v_x1 += v_2;
-
-                v_W = v_muladd(v_M6, v_x1, v_W0);
-                v_W = v_select(v_W != v_zero, v_its / v_W, v_zero);
-                v_float64x2 v_fX1 = v_max(v_intmin, v_min(v_intmax, v_muladd(v_M0, v_x1, v_X0d) * v_W));
-                v_float64x2 v_fY1 = v_max(v_intmin, v_min(v_intmax, v_muladd(v_M3, v_x1, v_Y0d) * v_W));
-                v_x1 += v_2;
-
-                v_X0 = v_round(v_fX0, v_fX1);
-                v_Y0 = v_round(v_fY0, v_fY1);
-            }
-
-            // 4-7
-            v_int32x4 v_X1, v_Y1;
-            {
-                v_float64x2 v_W = v_muladd(v_M6, v_x1, v_W0);
-                v_W = v_select(v_W != v_zero, v_its / v_W, v_zero);
-                v_float64x2 v_fX0 = v_max(v_intmin, v_min(v_intmax, v_muladd(v_M0, v_x1, v_X0d) * v_W));
-                v_float64x2 v_fY0 = v_max(v_intmin, v_min(v_intmax, v_muladd(v_M3, v_x1, v_Y0d) * v_W));
-                v_x1 += v_2;
-
-                v_W = v_muladd(v_M6, v_x1, v_W0);
-                v_W = v_select(v_W != v_zero, v_its / v_W, v_zero);
-                v_float64x2 v_fX1 = v_max(v_intmin, v_min(v_intmax, v_muladd(v_M0, v_x1, v_X0d) * v_W));
-                v_float64x2 v_fY1 = v_max(v_intmin, v_min(v_intmax, v_muladd(v_M3, v_x1, v_Y0d) * v_W));
-                v_x1 += v_2;
-
-                v_X1 = v_round(v_fX0, v_fX1);
-                v_Y1 = v_round(v_fY0, v_fY1);
-            }
-
-            // 8-11
-            v_int32x4 v_X2, v_Y2;
-            {
-                v_float64x2 v_W = v_muladd(v_M6, v_x1, v_W0);
-                v_W = v_select(v_W != v_zero, v_its / v_W, v_zero);
-                v_float64x2 v_fX0 = v_max(v_intmin, v_min(v_intmax, v_muladd(v_M0, v_x1, v_X0d) * v_W));
-                v_float64x2 v_fY0 = v_max(v_intmin, v_min(v_intmax, v_muladd(v_M3, v_x1, v_Y0d) * v_W));
-                v_x1 += v_2;
-
-                v_W = v_muladd(v_M6, v_x1, v_W0);
-                v_W = v_select(v_W != v_zero, v_its / v_W, v_zero);
-                v_float64x2 v_fX1 = v_max(v_intmin, v_min(v_intmax, v_muladd(v_M0, v_x1, v_X0d) * v_W));
-                v_float64x2 v_fY1 = v_max(v_intmin, v_min(v_intmax, v_muladd(v_M3, v_x1, v_Y0d) * v_W));
-                v_x1 += v_2;
-
-                v_X2 = v_round(v_fX0, v_fX1);
-                v_Y2 = v_round(v_fY0, v_fY1);
-            }
-
-            // 12-15
-            v_int32x4 v_X3, v_Y3;
-            {
-                v_float64x2 v_W = v_muladd(v_M6, v_x1, v_W0);
-                v_W = v_select(v_W != v_zero, v_its / v_W, v_zero);
-                v_float64x2 v_fX0 = v_max(v_intmin, v_min(v_intmax, v_muladd(v_M0, v_x1, v_X0d) * v_W));
-                v_float64x2 v_fY0 = v_max(v_intmin, v_min(v_intmax, v_muladd(v_M3, v_x1, v_Y0d) * v_W));
-                v_x1 += v_2;
-
-                v_W = v_muladd(v_M6, v_x1, v_W0);
-                v_W = v_select(v_W != v_zero, v_its / v_W, v_zero);
-                v_float64x2 v_fX1 = v_max(v_intmin, v_min(v_intmax, v_muladd(v_M0, v_x1, v_X0d) * v_W));
-                v_float64x2 v_fY1 = v_max(v_intmin, v_min(v_intmax, v_muladd(v_M3, v_x1, v_Y0d) * v_W));
-                v_x1 += v_2;
-
-                v_X3 = v_round(v_fX0, v_fX1);
-                v_Y3 = v_round(v_fY0, v_fY1);
-            }
-
-            // store alpha
-            v_int32x4 v_alpha0 = ((v_Y0 & v_itsi1) << INTER_BITS) + (v_X0 & v_itsi1);
-            v_int32x4 v_alpha1 = ((v_Y1 & v_itsi1) << INTER_BITS) + (v_X1 & v_itsi1);
-            v_store((alpha + x1), v_pack(v_alpha0, v_alpha1));
-
-            v_alpha0 = ((v_Y2 & v_itsi1) << INTER_BITS) + (v_X2 & v_itsi1);
-            v_alpha1 = ((v_Y3 & v_itsi1) << INTER_BITS) + (v_X3 & v_itsi1);
-            v_store((alpha + x1 + 8), v_pack(v_alpha0, v_alpha1));
-
-            // convert to 16s
-            v_X0 = v_reinterpret_as_s32(v_pack(v_X0 >> INTER_BITS, v_X1 >> INTER_BITS));
-            v_X1 = v_reinterpret_as_s32(v_pack(v_X2 >> INTER_BITS, v_X3 >> INTER_BITS));
-            v_Y0 = v_reinterpret_as_s32(v_pack(v_Y0 >> INTER_BITS, v_Y1 >> INTER_BITS));
-            v_Y1 = v_reinterpret_as_s32(v_pack(v_Y2 >> INTER_BITS, v_Y3 >> INTER_BITS));
-
-            v_store_interleave(xy + x1 * 2, (v_reinterpret_as_s16)(v_X0), (v_reinterpret_as_s16)(v_Y0));
-            v_store_interleave(xy + x1 * 2 + 16, (v_reinterpret_as_s16)(v_X1), (v_reinterpret_as_s16)(v_Y1));
-        }
-
-        for( ; x1 < bw; x1++ )
-        {
-            double W = W0 + M[6]*x1;
-            W = W ? INTER_TAB_SIZE/W : 0;
-            double fX = std::max((double)INT_MIN, std::min((double)INT_MAX, (X0 + M[0]*x1)*W));
-            double fY = std::max((double)INT_MIN, std::min((double)INT_MAX, (Y0 + M[3]*x1)*W));
-            int X = saturate_cast<int>(fX);
-            int Y = saturate_cast<int>(fY);
-
-            xy[x1*2] = saturate_cast<short>(X >> INTER_BITS);
-            xy[x1*2+1] = saturate_cast<short>(Y >> INTER_BITS);
-            alpha[x1] = (short)((Y & (INTER_TAB_SIZE-1))*INTER_TAB_SIZE +
-                                (X & (INTER_TAB_SIZE-1)));
-        }
-    }
-    virtual ~WarpPerspectiveLine_CV_SIMD_Impl() CV_OVERRIDE {};
-};
-
-Ptr<WarpPerspectiveLine_CV_SIMD> WarpPerspectiveLine_CV_SIMD::getImpl(const double *M)
-{
-    return Ptr<WarpPerspectiveLine_CV_SIMD>(new WarpPerspectiveLine_CV_SIMD_Impl(M));
 }
 
+void WarpPerspectiveLine_Process_CV_SIMD(const double *M, short* xy, short* alpha, double X0, double Y0, double W0, int bw)
+{
+    const v_float64x2 v_M0 = v_setall_f64(M[0]);
+    const v_float64x2 v_M3 = v_setall_f64(M[3]);
+    const v_float64x2 v_M6 = v_setall_f64(M[6]);
+    const v_float64x2 v_intmax = v_setall_f64((double)INT_MAX);
+    const v_float64x2 v_intmin = v_setall_f64((double)INT_MIN);
+    const v_float64x2 v_2 = v_setall_f64(2.0);
+    const v_float64x2 v_zero = v_setzero_f64();
+    const v_float64x2 v_its = v_setall_f64((double)INTER_TAB_SIZE);
+    const v_int32x4 v_itsi1 = v_setall_s32(INTER_TAB_SIZE - 1);
+
+    int x1 = 0;
+
+    v_float64x2 v_X0d = v_setall_f64(X0);
+    v_float64x2 v_Y0d = v_setall_f64(Y0);
+    v_float64x2 v_W0 = v_setall_f64(W0);
+    v_float64x2 v_x1(0.0, 1.0);
+
+    for (; x1 <= bw - 16; x1 += 16)
+    {
+        // 0-3
+        v_int32x4 v_X0, v_Y0;
+        {
+            v_float64x2 v_W = v_muladd(v_M6, v_x1, v_W0);
+            v_W = v_select(v_W != v_zero, v_its / v_W, v_zero);
+            v_float64x2 v_fX0 = v_max(v_intmin, v_min(v_intmax, v_muladd(v_M0, v_x1, v_X0d) * v_W));
+            v_float64x2 v_fY0 = v_max(v_intmin, v_min(v_intmax, v_muladd(v_M3, v_x1, v_Y0d) * v_W));
+            v_x1 += v_2;
+
+            v_W = v_muladd(v_M6, v_x1, v_W0);
+            v_W = v_select(v_W != v_zero, v_its / v_W, v_zero);
+            v_float64x2 v_fX1 = v_max(v_intmin, v_min(v_intmax, v_muladd(v_M0, v_x1, v_X0d) * v_W));
+            v_float64x2 v_fY1 = v_max(v_intmin, v_min(v_intmax, v_muladd(v_M3, v_x1, v_Y0d) * v_W));
+            v_x1 += v_2;
+
+            v_X0 = v_round(v_fX0, v_fX1);
+            v_Y0 = v_round(v_fY0, v_fY1);
+        }
+
+        // 4-7
+        v_int32x4 v_X1, v_Y1;
+        {
+            v_float64x2 v_W = v_muladd(v_M6, v_x1, v_W0);
+            v_W = v_select(v_W != v_zero, v_its / v_W, v_zero);
+            v_float64x2 v_fX0 = v_max(v_intmin, v_min(v_intmax, v_muladd(v_M0, v_x1, v_X0d) * v_W));
+            v_float64x2 v_fY0 = v_max(v_intmin, v_min(v_intmax, v_muladd(v_M3, v_x1, v_Y0d) * v_W));
+            v_x1 += v_2;
+
+            v_W = v_muladd(v_M6, v_x1, v_W0);
+            v_W = v_select(v_W != v_zero, v_its / v_W, v_zero);
+            v_float64x2 v_fX1 = v_max(v_intmin, v_min(v_intmax, v_muladd(v_M0, v_x1, v_X0d) * v_W));
+            v_float64x2 v_fY1 = v_max(v_intmin, v_min(v_intmax, v_muladd(v_M3, v_x1, v_Y0d) * v_W));
+            v_x1 += v_2;
+
+            v_X1 = v_round(v_fX0, v_fX1);
+            v_Y1 = v_round(v_fY0, v_fY1);
+        }
+
+        // 8-11
+        v_int32x4 v_X2, v_Y2;
+        {
+            v_float64x2 v_W = v_muladd(v_M6, v_x1, v_W0);
+            v_W = v_select(v_W != v_zero, v_its / v_W, v_zero);
+            v_float64x2 v_fX0 = v_max(v_intmin, v_min(v_intmax, v_muladd(v_M0, v_x1, v_X0d) * v_W));
+            v_float64x2 v_fY0 = v_max(v_intmin, v_min(v_intmax, v_muladd(v_M3, v_x1, v_Y0d) * v_W));
+            v_x1 += v_2;
+
+            v_W = v_muladd(v_M6, v_x1, v_W0);
+            v_W = v_select(v_W != v_zero, v_its / v_W, v_zero);
+            v_float64x2 v_fX1 = v_max(v_intmin, v_min(v_intmax, v_muladd(v_M0, v_x1, v_X0d) * v_W));
+            v_float64x2 v_fY1 = v_max(v_intmin, v_min(v_intmax, v_muladd(v_M3, v_x1, v_Y0d) * v_W));
+            v_x1 += v_2;
+
+            v_X2 = v_round(v_fX0, v_fX1);
+            v_Y2 = v_round(v_fY0, v_fY1);
+        }
+
+        // 12-15
+        v_int32x4 v_X3, v_Y3;
+        {
+            v_float64x2 v_W = v_muladd(v_M6, v_x1, v_W0);
+            v_W = v_select(v_W != v_zero, v_its / v_W, v_zero);
+            v_float64x2 v_fX0 = v_max(v_intmin, v_min(v_intmax, v_muladd(v_M0, v_x1, v_X0d) * v_W));
+            v_float64x2 v_fY0 = v_max(v_intmin, v_min(v_intmax, v_muladd(v_M3, v_x1, v_Y0d) * v_W));
+            v_x1 += v_2;
+
+            v_W = v_muladd(v_M6, v_x1, v_W0);
+            v_W = v_select(v_W != v_zero, v_its / v_W, v_zero);
+            v_float64x2 v_fX1 = v_max(v_intmin, v_min(v_intmax, v_muladd(v_M0, v_x1, v_X0d) * v_W));
+            v_float64x2 v_fY1 = v_max(v_intmin, v_min(v_intmax, v_muladd(v_M3, v_x1, v_Y0d) * v_W));
+            v_x1 += v_2;
+
+            v_X3 = v_round(v_fX0, v_fX1);
+            v_Y3 = v_round(v_fY0, v_fY1);
+        }
+
+        // store alpha
+        v_int32x4 v_alpha0 = ((v_Y0 & v_itsi1) << INTER_BITS) + (v_X0 & v_itsi1);
+        v_int32x4 v_alpha1 = ((v_Y1 & v_itsi1) << INTER_BITS) + (v_X1 & v_itsi1);
+        v_store((alpha + x1), v_pack(v_alpha0, v_alpha1));
+
+        v_alpha0 = ((v_Y2 & v_itsi1) << INTER_BITS) + (v_X2 & v_itsi1);
+        v_alpha1 = ((v_Y3 & v_itsi1) << INTER_BITS) + (v_X3 & v_itsi1);
+        v_store((alpha + x1 + 8), v_pack(v_alpha0, v_alpha1));
+
+        // convert to 16s
+        v_X0 = v_reinterpret_as_s32(v_pack(v_X0 >> INTER_BITS, v_X1 >> INTER_BITS));
+        v_X1 = v_reinterpret_as_s32(v_pack(v_X2 >> INTER_BITS, v_X3 >> INTER_BITS));
+        v_Y0 = v_reinterpret_as_s32(v_pack(v_Y0 >> INTER_BITS, v_Y1 >> INTER_BITS));
+        v_Y1 = v_reinterpret_as_s32(v_pack(v_Y2 >> INTER_BITS, v_Y3 >> INTER_BITS));
+
+        v_store_interleave(xy + x1 * 2, (v_reinterpret_as_s16)(v_X0), (v_reinterpret_as_s16)(v_Y0));
+        v_store_interleave(xy + x1 * 2 + 16, (v_reinterpret_as_s16)(v_X1), (v_reinterpret_as_s16)(v_Y1));
+    }
+
+    for( ; x1 < bw; x1++ )
+    {
+        double W = W0 + M[6]*x1;
+        W = W ? INTER_TAB_SIZE/W : 0;
+        double fX = std::max((double)INT_MIN, std::min((double)INT_MAX, (X0 + M[0]*x1)*W));
+        double fY = std::max((double)INT_MIN, std::min((double)INT_MAX, (Y0 + M[3]*x1)*W));
+        int X = saturate_cast<int>(fX);
+        int Y = saturate_cast<int>(fY);
+
+        xy[x1*2] = saturate_cast<short>(X >> INTER_BITS);
+        xy[x1*2+1] = saturate_cast<short>(Y >> INTER_BITS);
+        alpha[x1] = (short)((Y & (INTER_TAB_SIZE-1))*INTER_TAB_SIZE +
+                            (X & (INTER_TAB_SIZE-1)));
+    }
 }
 #endif
 
@@ -2978,16 +2959,11 @@ public:
     {
         const int BLOCK_SZ = 32;
         short XY[BLOCK_SZ*BLOCK_SZ*2], A[BLOCK_SZ*BLOCK_SZ];
-        int x, y, x1, y1, width = dst.cols, height = dst.rows;
+        int x, y, y1, width = dst.cols, height = dst.rows;
 
         int bh0 = std::min(BLOCK_SZ/2, height);
         int bw0 = std::min(BLOCK_SZ*BLOCK_SZ/bh0, width);
         bh0 = std::min(BLOCK_SZ*BLOCK_SZ/bw0, height);
-
-        #if CV_SIMD128_64F
-        Ptr<opt_CV_SIMD::WarpPerspectiveLine_CV_SIMD> pwarp_impl_CV_SIMD;
-        pwarp_impl_CV_SIMD = opt_CV_SIMD::WarpPerspectiveLine_CV_SIMD::getImpl(M);
-        #endif
 
         for( y = range.start; y < range.end; y += bh0 )
         {
@@ -3008,14 +2984,12 @@ public:
 
                     if( interpolation == INTER_NEAREST )
                     {
-                        x1 = 0;
-
-                        #if CV_SIMD128_64F
-                        if (pwarp_impl_CV_SIMD)
-                            pwarp_impl_CV_SIMD->processNN(M, xy, X0, Y0, W0, bw);
-                        else
-                        #endif
-                        for( ; x1 < bw; x1++ )
+                        #if CV_TRY_SSE4_1
+                        WarpPerspectiveLine_ProcessNN_SSE41(M, xy, X0, Y0, W0, bw);
+                        #elif CV_SIMD128_64F
+                        WarpPerspectiveLine_ProcessNN_CV_SIMD(M, xy, X0, Y0, W0, bw);
+                        #else
+                        for( int x1 = 0; x1 < bw; x1++ )
                         {
                             double W = W0 + M[6]*x1;
                             W = W ? 1./W : 0;
@@ -3027,18 +3001,18 @@ public:
                             xy[x1*2] = saturate_cast<short>(X);
                             xy[x1*2+1] = saturate_cast<short>(Y);
                         }
+                        #endif
                     }
                     else
                     {
                         short* alpha = A + y1*bw;
-                        x1 = 0;
 
-                        #if CV_SIMD128_64F
-                        if (pwarp_impl_CV_SIMD)
-                            pwarp_impl_CV_SIMD->process(M, xy, alpha, X0, Y0, W0, bw);
-                        else
-                        #endif
-                        for( ; x1 < bw; x1++ )
+                        #if CV_TRY_SSE4_1
+                        WarpPerspectiveLine_Process_SSE41(M, xy, alpha, X0, Y0, W0, bw);
+                        #elif CV_SIMD128_64F
+                        WarpPerspectiveLine_Process_CV_SIMD(M, xy, alpha, X0, Y0, W0, bw);
+                        #else
+                        for( int x1 = 0; x1 < bw; x1++ )
                         {
                             double W = W0 + M[6]*x1;
                             W = W ? INTER_TAB_SIZE/W : 0;
@@ -3052,6 +3026,7 @@ public:
                             alpha[x1] = (short)((Y & (INTER_TAB_SIZE-1))*INTER_TAB_SIZE +
                                                 (X & (INTER_TAB_SIZE-1)));
                         }
+                        #endif
                     }
                 }
 

--- a/modules/imgproc/src/imgwarp.cpp
+++ b/modules/imgproc/src/imgwarp.cpp
@@ -2965,6 +2965,12 @@ public:
         int bw0 = std::min(BLOCK_SZ*BLOCK_SZ/bh0, width);
         bh0 = std::min(BLOCK_SZ*BLOCK_SZ/bw0, height);
 
+        #if CV_TRY_SSE4_1
+        Ptr<opt_SSE4_1::WarpPerspectiveLine_SSE4> pwarp_impl_sse4;
+        if(CV_CPU_HAS_SUPPORT_SSE4_1)
+            pwarp_impl_sse4 = opt_SSE4_1::WarpPerspectiveLine_SSE4::getImpl(M);
+        #endif
+
         for( y = range.start; y < range.end; y += bh0 )
         {
             for( x = 0; x < width; x += bw0 )
@@ -2985,8 +2991,8 @@ public:
                     if( interpolation == INTER_NEAREST )
                     {
                         #if CV_TRY_SSE4_1
-                        if(CV_CPU_HAS_SUPPORT_SSE4_1)
-                            WarpPerspectiveLine_ProcessNN_SSE41(M, xy, X0, Y0, W0, bw);
+                        if (pwarp_impl_sse4)
+                            pwarp_impl_sse4->processNN(M, xy, X0, Y0, W0, bw);
                         else
                         #endif
                         #if CV_SIMD128_64F
@@ -3011,8 +3017,8 @@ public:
                         short* alpha = A + y1*bw;
 
                         #if CV_TRY_SSE4_1
-                        if(CV_CPU_HAS_SUPPORT_SSE4_1)
-                            WarpPerspectiveLine_Process_SSE41(M, xy, alpha, X0, Y0, W0, bw);
+                        if (pwarp_impl_sse4)
+                            pwarp_impl_sse4->process(M, xy, alpha, X0, Y0, W0, bw);
                         else
                         #endif
                         #if CV_SIMD128_64F

--- a/modules/imgproc/src/imgwarp.cpp
+++ b/modules/imgproc/src/imgwarp.cpp
@@ -2686,7 +2686,7 @@ void cv::warpAffine( InputArray _src, OutputArray _dst,
 
 namespace cv
 {
-#if !CV_TRY_SSE4_1 && CV_SIMD128_64F
+#if CV_SIMD128_64F
 void WarpPerspectiveLine_ProcessNN_CV_SIMD(const double *M, short* xy, double X0, double Y0, double W0, int bw)
 {
     const v_float64x2 v_M0 = v_setall_f64(M[0]);
@@ -2985,8 +2985,11 @@ public:
                     if( interpolation == INTER_NEAREST )
                     {
                         #if CV_TRY_SSE4_1
-                        WarpPerspectiveLine_ProcessNN_SSE41(M, xy, X0, Y0, W0, bw);
-                        #elif CV_SIMD128_64F
+                        if(CV_CPU_HAS_SUPPORT_SSE4_1)
+                            WarpPerspectiveLine_ProcessNN_SSE41(M, xy, X0, Y0, W0, bw);
+                        else
+                        #endif
+                        #if CV_SIMD128_64F
                         WarpPerspectiveLine_ProcessNN_CV_SIMD(M, xy, X0, Y0, W0, bw);
                         #else
                         for( int x1 = 0; x1 < bw; x1++ )
@@ -3008,8 +3011,11 @@ public:
                         short* alpha = A + y1*bw;
 
                         #if CV_TRY_SSE4_1
-                        WarpPerspectiveLine_Process_SSE41(M, xy, alpha, X0, Y0, W0, bw);
-                        #elif CV_SIMD128_64F
+                        if(CV_CPU_HAS_SUPPORT_SSE4_1)
+                            WarpPerspectiveLine_Process_SSE41(M, xy, alpha, X0, Y0, W0, bw);
+                        else
+                        #endif
+                        #if CV_SIMD128_64F
                         WarpPerspectiveLine_Process_CV_SIMD(M, xy, alpha, X0, Y0, W0, bw);
                         #else
                         for( int x1 = 0; x1 < bw; x1++ )

--- a/modules/imgproc/src/imgwarp.hpp
+++ b/modules/imgproc/src/imgwarp.hpp
@@ -74,7 +74,8 @@ void WarpAffineInvoker_Blockline_SSE41(int *adelta, int *bdelta, short* xy, int 
 #if CV_TRY_SSE4_1
 void WarpPerspectiveLine_ProcessNN_SSE41(const double *M, short* xy, double X0, double Y0, double W0, int bw);
 void WarpPerspectiveLine_Process_SSE41(const double *M, short* xy, short* alpha, double X0, double Y0, double W0, int bw);
-#elif CV_SIMD128_64F
+#endif
+#if CV_SIMD128_64F
 void WarpPerspectiveLine_ProcessNN_CV_SIMD(const double *M, short* xy, double X0, double Y0, double W0, int bw);
 void WarpPerspectiveLine_Process_CV_SIMD(const double *M, short* xy, short* alpha, double X0, double Y0, double W0, int bw);
 #endif

--- a/modules/imgproc/src/imgwarp.hpp
+++ b/modules/imgproc/src/imgwarp.hpp
@@ -68,31 +68,17 @@ void convertMaps_nninterpolate32f1c16s_SSE41(const float* src1f, const float* sr
 void convertMaps_32f1c16s_SSE41(const float* src1f, const float* src2f, short* dst1, ushort* dst2, int width);
 void convertMaps_32f2c16s_SSE41(const float* src1f, short* dst1, ushort* dst2, int width);
 void WarpAffineInvoker_Blockline_SSE41(int *adelta, int *bdelta, short* xy, int X0, int Y0, int bw);
-
-class WarpPerspectiveLine_SSE4
-{
-public:
-    static Ptr<WarpPerspectiveLine_SSE4> getImpl(const double *M);
-    virtual void processNN(const double *M, short* xy, double X0, double Y0, double W0, int bw) = 0;
-    virtual void process(const double *M, short* xy, short* alpha, double X0, double Y0, double W0, int bw) = 0;
-    virtual ~WarpPerspectiveLine_SSE4() {};
-};
 #endif
 }
 
-namespace opt_CV_SIMD
-{
-#if CV_SIMD128_64F
-class WarpPerspectiveLine_CV_SIMD
-{
-public:
-    static Ptr<WarpPerspectiveLine_CV_SIMD> getImpl(const double *M);
-    virtual void processNN(const double *M, short* xy, double X0, double Y0, double W0, int bw) = 0;
-    virtual void process(const double *M, short* xy, short* alpha, double X0, double Y0, double W0, int bw) = 0;
-    virtual ~WarpPerspectiveLine_CV_SIMD() {};
-};
+#if CV_TRY_SSE4_1
+void WarpPerspectiveLine_ProcessNN_SSE41(const double *M, short* xy, double X0, double Y0, double W0, int bw);
+void WarpPerspectiveLine_Process_SSE41(const double *M, short* xy, short* alpha, double X0, double Y0, double W0, int bw);
+#elif CV_SIMD128_64F
+void WarpPerspectiveLine_ProcessNN_CV_SIMD(const double *M, short* xy, double X0, double Y0, double W0, int bw);
+void WarpPerspectiveLine_Process_CV_SIMD(const double *M, short* xy, short* alpha, double X0, double Y0, double W0, int bw);
 #endif
-}
+
 }
 #endif
 /* End of file. */

--- a/modules/imgproc/src/imgwarp.hpp
+++ b/modules/imgproc/src/imgwarp.hpp
@@ -68,13 +68,18 @@ void convertMaps_nninterpolate32f1c16s_SSE41(const float* src1f, const float* sr
 void convertMaps_32f1c16s_SSE41(const float* src1f, const float* src2f, short* dst1, ushort* dst2, int width);
 void convertMaps_32f2c16s_SSE41(const float* src1f, short* dst1, ushort* dst2, int width);
 void WarpAffineInvoker_Blockline_SSE41(int *adelta, int *bdelta, short* xy, int X0, int Y0, int bw);
+
+class WarpPerspectiveLine_SSE4
+{
+public:
+    static Ptr<WarpPerspectiveLine_SSE4> getImpl(const double *M);
+    virtual void processNN(const double *M, short* xy, double X0, double Y0, double W0, int bw) = 0;
+    virtual void process(const double *M, short* xy, short* alpha, double X0, double Y0, double W0, int bw) = 0;
+    virtual ~WarpPerspectiveLine_SSE4() {};
+};
 #endif
 }
 
-#if CV_TRY_SSE4_1
-void WarpPerspectiveLine_ProcessNN_SSE41(const double *M, short* xy, double X0, double Y0, double W0, int bw);
-void WarpPerspectiveLine_Process_SSE41(const double *M, short* xy, short* alpha, double X0, double Y0, double W0, int bw);
-#endif
 #if CV_SIMD128_64F
 void WarpPerspectiveLine_ProcessNN_CV_SIMD(const double *M, short* xy, double X0, double Y0, double W0, int bw);
 void WarpPerspectiveLine_Process_CV_SIMD(const double *M, short* xy, short* alpha, double X0, double Y0, double W0, int bw);

--- a/modules/imgproc/src/imgwarp.hpp
+++ b/modules/imgproc/src/imgwarp.hpp
@@ -50,6 +50,7 @@
 #ifndef OPENCV_IMGPROC_IMGWARP_HPP
 #define OPENCV_IMGPROC_IMGWARP_HPP
 #include "precomp.hpp"
+#include "opencv2/core/hal/intrin.hpp"
 
 namespace cv
 {
@@ -75,6 +76,20 @@ public:
     virtual void processNN(const double *M, short* xy, double X0, double Y0, double W0, int bw) = 0;
     virtual void process(const double *M, short* xy, short* alpha, double X0, double Y0, double W0, int bw) = 0;
     virtual ~WarpPerspectiveLine_SSE4() {};
+};
+#endif
+}
+
+namespace opt_CV_SIMD
+{
+#if CV_SIMD128
+class WarpPerspectiveLine_CV_SIMD
+{
+public:
+    static Ptr<WarpPerspectiveLine_CV_SIMD> getImpl(const double *M);
+    virtual void processNN(const double *M, short* xy, double X0, double Y0, double W0, int bw) = 0;
+    virtual void process(const double *M, short* xy, short* alpha, double X0, double Y0, double W0, int bw) = 0;
+    virtual ~WarpPerspectiveLine_CV_SIMD() {};
 };
 #endif
 }

--- a/modules/imgproc/src/imgwarp.hpp
+++ b/modules/imgproc/src/imgwarp.hpp
@@ -82,7 +82,7 @@ public:
 
 namespace opt_CV_SIMD
 {
-#if CV_SIMD128
+#if CV_SIMD128_64F
 class WarpPerspectiveLine_CV_SIMD
 {
 public:

--- a/modules/imgproc/src/imgwarp.sse4_1.cpp
+++ b/modules/imgproc/src/imgwarp.sse4_1.cpp
@@ -207,299 +207,285 @@ void WarpAffineInvoker_Blockline_SSE41(int *adelta, int *bdelta, short* xy, int 
         xy[x1 * 2 + 1] = saturate_cast<short>(Y);
     }
 }
+}
 
-
-class WarpPerspectiveLine_SSE4_Impl CV_FINAL : public WarpPerspectiveLine_SSE4
+void WarpPerspectiveLine_ProcessNN_SSE41(const double *M, short* xy, double X0, double Y0, double W0, int bw)
 {
-public:
-    WarpPerspectiveLine_SSE4_Impl(const double *M)
-    {
-        CV_UNUSED(M);
-    }
-    virtual void processNN(const double *M, short* xy, double X0, double Y0, double W0, int bw) CV_OVERRIDE
-    {
-        const __m128d v_M0 = _mm_set1_pd(M[0]);
-        const __m128d v_M3 = _mm_set1_pd(M[3]);
-        const __m128d v_M6 = _mm_set1_pd(M[6]);
-        const __m128d v_intmax = _mm_set1_pd((double)INT_MAX);
-        const __m128d v_intmin = _mm_set1_pd((double)INT_MIN);
-        const __m128d v_2 = _mm_set1_pd(2);
-        const __m128d v_zero = _mm_setzero_pd();
-        const __m128d v_1 = _mm_set1_pd(1);
+    const __m128d v_M0 = _mm_set1_pd(M[0]);
+    const __m128d v_M3 = _mm_set1_pd(M[3]);
+    const __m128d v_M6 = _mm_set1_pd(M[6]);
+    const __m128d v_intmax = _mm_set1_pd((double)INT_MAX);
+    const __m128d v_intmin = _mm_set1_pd((double)INT_MIN);
+    const __m128d v_2 = _mm_set1_pd(2);
+    const __m128d v_zero = _mm_setzero_pd();
+    const __m128d v_1 = _mm_set1_pd(1);
 
-        int x1 = 0;
-        __m128d v_X0d = _mm_set1_pd(X0);
-        __m128d v_Y0d = _mm_set1_pd(Y0);
-        __m128d v_W0 = _mm_set1_pd(W0);
-        __m128d v_x1 = _mm_set_pd(1, 0);
+    int x1 = 0;
+    __m128d v_X0d = _mm_set1_pd(X0);
+    __m128d v_Y0d = _mm_set1_pd(Y0);
+    __m128d v_W0 = _mm_set1_pd(W0);
+    __m128d v_x1 = _mm_set_pd(1, 0);
 
-        for (; x1 <= bw - 16; x1 += 16)
+    for (; x1 <= bw - 16; x1 += 16)
+    {
+        // 0-3
+        __m128i v_X0, v_Y0;
         {
-            // 0-3
-            __m128i v_X0, v_Y0;
-            {
-                __m128d v_W = _mm_add_pd(_mm_mul_pd(v_M6, v_x1), v_W0);
-                v_W = _mm_andnot_pd(_mm_cmpeq_pd(v_W, v_zero), _mm_div_pd(v_1, v_W));
-                __m128d v_fX0 = _mm_max_pd(v_intmin, _mm_min_pd(v_intmax, _mm_mul_pd(_mm_add_pd(v_X0d, _mm_mul_pd(v_M0, v_x1)), v_W)));
-                __m128d v_fY0 = _mm_max_pd(v_intmin, _mm_min_pd(v_intmax, _mm_mul_pd(_mm_add_pd(v_Y0d, _mm_mul_pd(v_M3, v_x1)), v_W)));
-                v_x1 = _mm_add_pd(v_x1, v_2);
+            __m128d v_W = _mm_add_pd(_mm_mul_pd(v_M6, v_x1), v_W0);
+            v_W = _mm_andnot_pd(_mm_cmpeq_pd(v_W, v_zero), _mm_div_pd(v_1, v_W));
+            __m128d v_fX0 = _mm_max_pd(v_intmin, _mm_min_pd(v_intmax, _mm_mul_pd(_mm_add_pd(v_X0d, _mm_mul_pd(v_M0, v_x1)), v_W)));
+            __m128d v_fY0 = _mm_max_pd(v_intmin, _mm_min_pd(v_intmax, _mm_mul_pd(_mm_add_pd(v_Y0d, _mm_mul_pd(v_M3, v_x1)), v_W)));
+            v_x1 = _mm_add_pd(v_x1, v_2);
 
-                v_W = _mm_add_pd(_mm_mul_pd(v_M6, v_x1), v_W0);
-                v_W = _mm_andnot_pd(_mm_cmpeq_pd(v_W, v_zero), _mm_div_pd(v_1, v_W));
-                __m128d v_fX1 = _mm_max_pd(v_intmin, _mm_min_pd(v_intmax, _mm_mul_pd(_mm_add_pd(v_X0d, _mm_mul_pd(v_M0, v_x1)), v_W)));
-                __m128d v_fY1 = _mm_max_pd(v_intmin, _mm_min_pd(v_intmax, _mm_mul_pd(_mm_add_pd(v_Y0d, _mm_mul_pd(v_M3, v_x1)), v_W)));
-                v_x1 = _mm_add_pd(v_x1, v_2);
+            v_W = _mm_add_pd(_mm_mul_pd(v_M6, v_x1), v_W0);
+            v_W = _mm_andnot_pd(_mm_cmpeq_pd(v_W, v_zero), _mm_div_pd(v_1, v_W));
+            __m128d v_fX1 = _mm_max_pd(v_intmin, _mm_min_pd(v_intmax, _mm_mul_pd(_mm_add_pd(v_X0d, _mm_mul_pd(v_M0, v_x1)), v_W)));
+            __m128d v_fY1 = _mm_max_pd(v_intmin, _mm_min_pd(v_intmax, _mm_mul_pd(_mm_add_pd(v_Y0d, _mm_mul_pd(v_M3, v_x1)), v_W)));
+            v_x1 = _mm_add_pd(v_x1, v_2);
 
-                v_X0 = _mm_castps_si128(_mm_movelh_ps(_mm_castsi128_ps(_mm_cvtpd_epi32(v_fX0)),
-                    _mm_castsi128_ps(_mm_cvtpd_epi32(v_fX1))));
-                v_Y0 = _mm_castps_si128(_mm_movelh_ps(_mm_castsi128_ps(_mm_cvtpd_epi32(v_fY0)),
-                    _mm_castsi128_ps(_mm_cvtpd_epi32(v_fY1))));
-            }
-
-            // 4-8
-            __m128i v_X1, v_Y1;
-            {
-                __m128d v_W = _mm_add_pd(_mm_mul_pd(v_M6, v_x1), v_W0);
-                v_W = _mm_andnot_pd(_mm_cmpeq_pd(v_W, v_zero), _mm_div_pd(v_1, v_W));
-                __m128d v_fX0 = _mm_max_pd(v_intmin, _mm_min_pd(v_intmax, _mm_mul_pd(_mm_add_pd(v_X0d, _mm_mul_pd(v_M0, v_x1)), v_W)));
-                __m128d v_fY0 = _mm_max_pd(v_intmin, _mm_min_pd(v_intmax, _mm_mul_pd(_mm_add_pd(v_Y0d, _mm_mul_pd(v_M3, v_x1)), v_W)));
-                v_x1 = _mm_add_pd(v_x1, v_2);
-
-                v_W = _mm_add_pd(_mm_mul_pd(v_M6, v_x1), v_W0);
-                v_W = _mm_andnot_pd(_mm_cmpeq_pd(v_W, v_zero), _mm_div_pd(v_1, v_W));
-                __m128d v_fX1 = _mm_max_pd(v_intmin, _mm_min_pd(v_intmax, _mm_mul_pd(_mm_add_pd(v_X0d, _mm_mul_pd(v_M0, v_x1)), v_W)));
-                __m128d v_fY1 = _mm_max_pd(v_intmin, _mm_min_pd(v_intmax, _mm_mul_pd(_mm_add_pd(v_Y0d, _mm_mul_pd(v_M3, v_x1)), v_W)));
-                v_x1 = _mm_add_pd(v_x1, v_2);
-
-                v_X1 = _mm_castps_si128(_mm_movelh_ps(_mm_castsi128_ps(_mm_cvtpd_epi32(v_fX0)),
-                    _mm_castsi128_ps(_mm_cvtpd_epi32(v_fX1))));
-                v_Y1 = _mm_castps_si128(_mm_movelh_ps(_mm_castsi128_ps(_mm_cvtpd_epi32(v_fY0)),
-                    _mm_castsi128_ps(_mm_cvtpd_epi32(v_fY1))));
-            }
-
-            // 8-11
-            __m128i v_X2, v_Y2;
-            {
-                __m128d v_W = _mm_add_pd(_mm_mul_pd(v_M6, v_x1), v_W0);
-                v_W = _mm_andnot_pd(_mm_cmpeq_pd(v_W, v_zero), _mm_div_pd(v_1, v_W));
-                __m128d v_fX0 = _mm_max_pd(v_intmin, _mm_min_pd(v_intmax, _mm_mul_pd(_mm_add_pd(v_X0d, _mm_mul_pd(v_M0, v_x1)), v_W)));
-                __m128d v_fY0 = _mm_max_pd(v_intmin, _mm_min_pd(v_intmax, _mm_mul_pd(_mm_add_pd(v_Y0d, _mm_mul_pd(v_M3, v_x1)), v_W)));
-                v_x1 = _mm_add_pd(v_x1, v_2);
-
-                v_W = _mm_add_pd(_mm_mul_pd(v_M6, v_x1), v_W0);
-                v_W = _mm_andnot_pd(_mm_cmpeq_pd(v_W, v_zero), _mm_div_pd(v_1, v_W));
-                __m128d v_fX1 = _mm_max_pd(v_intmin, _mm_min_pd(v_intmax, _mm_mul_pd(_mm_add_pd(v_X0d, _mm_mul_pd(v_M0, v_x1)), v_W)));
-                __m128d v_fY1 = _mm_max_pd(v_intmin, _mm_min_pd(v_intmax, _mm_mul_pd(_mm_add_pd(v_Y0d, _mm_mul_pd(v_M3, v_x1)), v_W)));
-                v_x1 = _mm_add_pd(v_x1, v_2);
-
-                v_X2 = _mm_castps_si128(_mm_movelh_ps(_mm_castsi128_ps(_mm_cvtpd_epi32(v_fX0)),
-                    _mm_castsi128_ps(_mm_cvtpd_epi32(v_fX1))));
-                v_Y2 = _mm_castps_si128(_mm_movelh_ps(_mm_castsi128_ps(_mm_cvtpd_epi32(v_fY0)),
-                    _mm_castsi128_ps(_mm_cvtpd_epi32(v_fY1))));
-            }
-
-            // 12-15
-            __m128i v_X3, v_Y3;
-            {
-                __m128d v_W = _mm_add_pd(_mm_mul_pd(v_M6, v_x1), v_W0);
-                v_W = _mm_andnot_pd(_mm_cmpeq_pd(v_W, v_zero), _mm_div_pd(v_1, v_W));
-                __m128d v_fX0 = _mm_max_pd(v_intmin, _mm_min_pd(v_intmax, _mm_mul_pd(_mm_add_pd(v_X0d, _mm_mul_pd(v_M0, v_x1)), v_W)));
-                __m128d v_fY0 = _mm_max_pd(v_intmin, _mm_min_pd(v_intmax, _mm_mul_pd(_mm_add_pd(v_Y0d, _mm_mul_pd(v_M3, v_x1)), v_W)));
-                v_x1 = _mm_add_pd(v_x1, v_2);
-
-                v_W = _mm_add_pd(_mm_mul_pd(v_M6, v_x1), v_W0);
-                v_W = _mm_andnot_pd(_mm_cmpeq_pd(v_W, v_zero), _mm_div_pd(v_1, v_W));
-                __m128d v_fX1 = _mm_max_pd(v_intmin, _mm_min_pd(v_intmax, _mm_mul_pd(_mm_add_pd(v_X0d, _mm_mul_pd(v_M0, v_x1)), v_W)));
-                __m128d v_fY1 = _mm_max_pd(v_intmin, _mm_min_pd(v_intmax, _mm_mul_pd(_mm_add_pd(v_Y0d, _mm_mul_pd(v_M3, v_x1)), v_W)));
-                v_x1 = _mm_add_pd(v_x1, v_2);
-
-                v_X3 = _mm_castps_si128(_mm_movelh_ps(_mm_castsi128_ps(_mm_cvtpd_epi32(v_fX0)),
-                    _mm_castsi128_ps(_mm_cvtpd_epi32(v_fX1))));
-                v_Y3 = _mm_castps_si128(_mm_movelh_ps(_mm_castsi128_ps(_mm_cvtpd_epi32(v_fY0)),
-                    _mm_castsi128_ps(_mm_cvtpd_epi32(v_fY1))));
-            }
-
-            // convert to 16s
-            v_X0 = _mm_packs_epi32(v_X0, v_X1);
-            v_X1 = _mm_packs_epi32(v_X2, v_X3);
-            v_Y0 = _mm_packs_epi32(v_Y0, v_Y1);
-            v_Y1 = _mm_packs_epi32(v_Y2, v_Y3);
-
-            _mm_interleave_epi16(v_X0, v_X1, v_Y0, v_Y1);
-
-            _mm_storeu_si128((__m128i *)(xy + x1 * 2), v_X0);
-            _mm_storeu_si128((__m128i *)(xy + x1 * 2 + 8), v_X1);
-            _mm_storeu_si128((__m128i *)(xy + x1 * 2 + 16), v_Y0);
-            _mm_storeu_si128((__m128i *)(xy + x1 * 2 + 24), v_Y1);
+            v_X0 = _mm_castps_si128(_mm_movelh_ps(_mm_castsi128_ps(_mm_cvtpd_epi32(v_fX0)),
+                _mm_castsi128_ps(_mm_cvtpd_epi32(v_fX1))));
+            v_Y0 = _mm_castps_si128(_mm_movelh_ps(_mm_castsi128_ps(_mm_cvtpd_epi32(v_fY0)),
+                _mm_castsi128_ps(_mm_cvtpd_epi32(v_fY1))));
         }
 
-        for (; x1 < bw; x1++)
+        // 4-8
+        __m128i v_X1, v_Y1;
         {
-            double W = W0 + M[6] * x1;
-            W = W ? 1. / W : 0;
-            double fX = std::max((double)INT_MIN, std::min((double)INT_MAX, (X0 + M[0] * x1)*W));
-            double fY = std::max((double)INT_MIN, std::min((double)INT_MAX, (Y0 + M[3] * x1)*W));
-            int X = saturate_cast<int>(fX);
-            int Y = saturate_cast<int>(fY);
+            __m128d v_W = _mm_add_pd(_mm_mul_pd(v_M6, v_x1), v_W0);
+            v_W = _mm_andnot_pd(_mm_cmpeq_pd(v_W, v_zero), _mm_div_pd(v_1, v_W));
+            __m128d v_fX0 = _mm_max_pd(v_intmin, _mm_min_pd(v_intmax, _mm_mul_pd(_mm_add_pd(v_X0d, _mm_mul_pd(v_M0, v_x1)), v_W)));
+            __m128d v_fY0 = _mm_max_pd(v_intmin, _mm_min_pd(v_intmax, _mm_mul_pd(_mm_add_pd(v_Y0d, _mm_mul_pd(v_M3, v_x1)), v_W)));
+            v_x1 = _mm_add_pd(v_x1, v_2);
 
-            xy[x1 * 2] = saturate_cast<short>(X);
-            xy[x1 * 2 + 1] = saturate_cast<short>(Y);
+            v_W = _mm_add_pd(_mm_mul_pd(v_M6, v_x1), v_W0);
+            v_W = _mm_andnot_pd(_mm_cmpeq_pd(v_W, v_zero), _mm_div_pd(v_1, v_W));
+            __m128d v_fX1 = _mm_max_pd(v_intmin, _mm_min_pd(v_intmax, _mm_mul_pd(_mm_add_pd(v_X0d, _mm_mul_pd(v_M0, v_x1)), v_W)));
+            __m128d v_fY1 = _mm_max_pd(v_intmin, _mm_min_pd(v_intmax, _mm_mul_pd(_mm_add_pd(v_Y0d, _mm_mul_pd(v_M3, v_x1)), v_W)));
+            v_x1 = _mm_add_pd(v_x1, v_2);
+
+            v_X1 = _mm_castps_si128(_mm_movelh_ps(_mm_castsi128_ps(_mm_cvtpd_epi32(v_fX0)),
+                _mm_castsi128_ps(_mm_cvtpd_epi32(v_fX1))));
+            v_Y1 = _mm_castps_si128(_mm_movelh_ps(_mm_castsi128_ps(_mm_cvtpd_epi32(v_fY0)),
+                _mm_castsi128_ps(_mm_cvtpd_epi32(v_fY1))));
         }
-    }
-    virtual void process(const double *M, short* xy, short* alpha, double X0, double Y0, double W0, int bw) CV_OVERRIDE
-    {
-        const __m128d v_M0 = _mm_set1_pd(M[0]);
-        const __m128d v_M3 = _mm_set1_pd(M[3]);
-        const __m128d v_M6 = _mm_set1_pd(M[6]);
-        const __m128d v_intmax = _mm_set1_pd((double)INT_MAX);
-        const __m128d v_intmin = _mm_set1_pd((double)INT_MIN);
-        const __m128d v_2 = _mm_set1_pd(2);
-        const __m128d v_zero = _mm_setzero_pd();
-        const __m128d v_its = _mm_set1_pd(INTER_TAB_SIZE);
-        const __m128i v_itsi1 = _mm_set1_epi32(INTER_TAB_SIZE - 1);
 
-        int x1 = 0;
-
-        __m128d v_X0d = _mm_set1_pd(X0);
-        __m128d v_Y0d = _mm_set1_pd(Y0);
-        __m128d v_W0 = _mm_set1_pd(W0);
-        __m128d v_x1 = _mm_set_pd(1, 0);
-
-        for (; x1 <= bw - 16; x1 += 16)
+        // 8-11
+        __m128i v_X2, v_Y2;
         {
-            // 0-3
-            __m128i v_X0, v_Y0;
-            {
-                __m128d v_W = _mm_add_pd(_mm_mul_pd(v_M6, v_x1), v_W0);
-                v_W = _mm_andnot_pd(_mm_cmpeq_pd(v_W, v_zero), _mm_div_pd(v_its, v_W));
-                __m128d v_fX0 = _mm_max_pd(v_intmin, _mm_min_pd(v_intmax, _mm_mul_pd(_mm_add_pd(v_X0d, _mm_mul_pd(v_M0, v_x1)), v_W)));
-                __m128d v_fY0 = _mm_max_pd(v_intmin, _mm_min_pd(v_intmax, _mm_mul_pd(_mm_add_pd(v_Y0d, _mm_mul_pd(v_M3, v_x1)), v_W)));
-                v_x1 = _mm_add_pd(v_x1, v_2);
+            __m128d v_W = _mm_add_pd(_mm_mul_pd(v_M6, v_x1), v_W0);
+            v_W = _mm_andnot_pd(_mm_cmpeq_pd(v_W, v_zero), _mm_div_pd(v_1, v_W));
+            __m128d v_fX0 = _mm_max_pd(v_intmin, _mm_min_pd(v_intmax, _mm_mul_pd(_mm_add_pd(v_X0d, _mm_mul_pd(v_M0, v_x1)), v_W)));
+            __m128d v_fY0 = _mm_max_pd(v_intmin, _mm_min_pd(v_intmax, _mm_mul_pd(_mm_add_pd(v_Y0d, _mm_mul_pd(v_M3, v_x1)), v_W)));
+            v_x1 = _mm_add_pd(v_x1, v_2);
 
-                v_W = _mm_add_pd(_mm_mul_pd(v_M6, v_x1), v_W0);
-                v_W = _mm_andnot_pd(_mm_cmpeq_pd(v_W, v_zero), _mm_div_pd(v_its, v_W));
-                __m128d v_fX1 = _mm_max_pd(v_intmin, _mm_min_pd(v_intmax, _mm_mul_pd(_mm_add_pd(v_X0d, _mm_mul_pd(v_M0, v_x1)), v_W)));
-                __m128d v_fY1 = _mm_max_pd(v_intmin, _mm_min_pd(v_intmax, _mm_mul_pd(_mm_add_pd(v_Y0d, _mm_mul_pd(v_M3, v_x1)), v_W)));
-                v_x1 = _mm_add_pd(v_x1, v_2);
+            v_W = _mm_add_pd(_mm_mul_pd(v_M6, v_x1), v_W0);
+            v_W = _mm_andnot_pd(_mm_cmpeq_pd(v_W, v_zero), _mm_div_pd(v_1, v_W));
+            __m128d v_fX1 = _mm_max_pd(v_intmin, _mm_min_pd(v_intmax, _mm_mul_pd(_mm_add_pd(v_X0d, _mm_mul_pd(v_M0, v_x1)), v_W)));
+            __m128d v_fY1 = _mm_max_pd(v_intmin, _mm_min_pd(v_intmax, _mm_mul_pd(_mm_add_pd(v_Y0d, _mm_mul_pd(v_M3, v_x1)), v_W)));
+            v_x1 = _mm_add_pd(v_x1, v_2);
 
-                v_X0 = _mm_castps_si128(_mm_movelh_ps(_mm_castsi128_ps(_mm_cvtpd_epi32(v_fX0)),
-                    _mm_castsi128_ps(_mm_cvtpd_epi32(v_fX1))));
-                v_Y0 = _mm_castps_si128(_mm_movelh_ps(_mm_castsi128_ps(_mm_cvtpd_epi32(v_fY0)),
-                    _mm_castsi128_ps(_mm_cvtpd_epi32(v_fY1))));
-            }
+            v_X2 = _mm_castps_si128(_mm_movelh_ps(_mm_castsi128_ps(_mm_cvtpd_epi32(v_fX0)),
+                _mm_castsi128_ps(_mm_cvtpd_epi32(v_fX1))));
+            v_Y2 = _mm_castps_si128(_mm_movelh_ps(_mm_castsi128_ps(_mm_cvtpd_epi32(v_fY0)),
+                _mm_castsi128_ps(_mm_cvtpd_epi32(v_fY1))));
+        }
 
-            // 4-8
-            __m128i v_X1, v_Y1;
-            {
-                __m128d v_W = _mm_add_pd(_mm_mul_pd(v_M6, v_x1), v_W0);
-                v_W = _mm_andnot_pd(_mm_cmpeq_pd(v_W, v_zero), _mm_div_pd(v_its, v_W));
-                __m128d v_fX0 = _mm_max_pd(v_intmin, _mm_min_pd(v_intmax, _mm_mul_pd(_mm_add_pd(v_X0d, _mm_mul_pd(v_M0, v_x1)), v_W)));
-                __m128d v_fY0 = _mm_max_pd(v_intmin, _mm_min_pd(v_intmax, _mm_mul_pd(_mm_add_pd(v_Y0d, _mm_mul_pd(v_M3, v_x1)), v_W)));
-                v_x1 = _mm_add_pd(v_x1, v_2);
+        // 12-15
+        __m128i v_X3, v_Y3;
+        {
+            __m128d v_W = _mm_add_pd(_mm_mul_pd(v_M6, v_x1), v_W0);
+            v_W = _mm_andnot_pd(_mm_cmpeq_pd(v_W, v_zero), _mm_div_pd(v_1, v_W));
+            __m128d v_fX0 = _mm_max_pd(v_intmin, _mm_min_pd(v_intmax, _mm_mul_pd(_mm_add_pd(v_X0d, _mm_mul_pd(v_M0, v_x1)), v_W)));
+            __m128d v_fY0 = _mm_max_pd(v_intmin, _mm_min_pd(v_intmax, _mm_mul_pd(_mm_add_pd(v_Y0d, _mm_mul_pd(v_M3, v_x1)), v_W)));
+            v_x1 = _mm_add_pd(v_x1, v_2);
 
-                v_W = _mm_add_pd(_mm_mul_pd(v_M6, v_x1), v_W0);
-                v_W = _mm_andnot_pd(_mm_cmpeq_pd(v_W, v_zero), _mm_div_pd(v_its, v_W));
-                __m128d v_fX1 = _mm_max_pd(v_intmin, _mm_min_pd(v_intmax, _mm_mul_pd(_mm_add_pd(v_X0d, _mm_mul_pd(v_M0, v_x1)), v_W)));
-                __m128d v_fY1 = _mm_max_pd(v_intmin, _mm_min_pd(v_intmax, _mm_mul_pd(_mm_add_pd(v_Y0d, _mm_mul_pd(v_M3, v_x1)), v_W)));
-                v_x1 = _mm_add_pd(v_x1, v_2);
+            v_W = _mm_add_pd(_mm_mul_pd(v_M6, v_x1), v_W0);
+            v_W = _mm_andnot_pd(_mm_cmpeq_pd(v_W, v_zero), _mm_div_pd(v_1, v_W));
+            __m128d v_fX1 = _mm_max_pd(v_intmin, _mm_min_pd(v_intmax, _mm_mul_pd(_mm_add_pd(v_X0d, _mm_mul_pd(v_M0, v_x1)), v_W)));
+            __m128d v_fY1 = _mm_max_pd(v_intmin, _mm_min_pd(v_intmax, _mm_mul_pd(_mm_add_pd(v_Y0d, _mm_mul_pd(v_M3, v_x1)), v_W)));
+            v_x1 = _mm_add_pd(v_x1, v_2);
 
-                v_X1 = _mm_castps_si128(_mm_movelh_ps(_mm_castsi128_ps(_mm_cvtpd_epi32(v_fX0)),
-                    _mm_castsi128_ps(_mm_cvtpd_epi32(v_fX1))));
-                v_Y1 = _mm_castps_si128(_mm_movelh_ps(_mm_castsi128_ps(_mm_cvtpd_epi32(v_fY0)),
-                    _mm_castsi128_ps(_mm_cvtpd_epi32(v_fY1))));
-            }
+            v_X3 = _mm_castps_si128(_mm_movelh_ps(_mm_castsi128_ps(_mm_cvtpd_epi32(v_fX0)),
+                _mm_castsi128_ps(_mm_cvtpd_epi32(v_fX1))));
+            v_Y3 = _mm_castps_si128(_mm_movelh_ps(_mm_castsi128_ps(_mm_cvtpd_epi32(v_fY0)),
+                _mm_castsi128_ps(_mm_cvtpd_epi32(v_fY1))));
+        }
 
-            // 8-11
-            __m128i v_X2, v_Y2;
-            {
-                __m128d v_W = _mm_add_pd(_mm_mul_pd(v_M6, v_x1), v_W0);
-                v_W = _mm_andnot_pd(_mm_cmpeq_pd(v_W, v_zero), _mm_div_pd(v_its, v_W));
-                __m128d v_fX0 = _mm_max_pd(v_intmin, _mm_min_pd(v_intmax, _mm_mul_pd(_mm_add_pd(v_X0d, _mm_mul_pd(v_M0, v_x1)), v_W)));
-                __m128d v_fY0 = _mm_max_pd(v_intmin, _mm_min_pd(v_intmax, _mm_mul_pd(_mm_add_pd(v_Y0d, _mm_mul_pd(v_M3, v_x1)), v_W)));
-                v_x1 = _mm_add_pd(v_x1, v_2);
+        // convert to 16s
+        v_X0 = _mm_packs_epi32(v_X0, v_X1);
+        v_X1 = _mm_packs_epi32(v_X2, v_X3);
+        v_Y0 = _mm_packs_epi32(v_Y0, v_Y1);
+        v_Y1 = _mm_packs_epi32(v_Y2, v_Y3);
 
-                v_W = _mm_add_pd(_mm_mul_pd(v_M6, v_x1), v_W0);
-                v_W = _mm_andnot_pd(_mm_cmpeq_pd(v_W, v_zero), _mm_div_pd(v_its, v_W));
-                __m128d v_fX1 = _mm_max_pd(v_intmin, _mm_min_pd(v_intmax, _mm_mul_pd(_mm_add_pd(v_X0d, _mm_mul_pd(v_M0, v_x1)), v_W)));
-                __m128d v_fY1 = _mm_max_pd(v_intmin, _mm_min_pd(v_intmax, _mm_mul_pd(_mm_add_pd(v_Y0d, _mm_mul_pd(v_M3, v_x1)), v_W)));
-                v_x1 = _mm_add_pd(v_x1, v_2);
+        _mm_interleave_epi16(v_X0, v_X1, v_Y0, v_Y1);
 
-                v_X2 = _mm_castps_si128(_mm_movelh_ps(_mm_castsi128_ps(_mm_cvtpd_epi32(v_fX0)),
-                    _mm_castsi128_ps(_mm_cvtpd_epi32(v_fX1))));
-                v_Y2 = _mm_castps_si128(_mm_movelh_ps(_mm_castsi128_ps(_mm_cvtpd_epi32(v_fY0)),
-                    _mm_castsi128_ps(_mm_cvtpd_epi32(v_fY1))));
-            }
+        _mm_storeu_si128((__m128i *)(xy + x1 * 2), v_X0);
+        _mm_storeu_si128((__m128i *)(xy + x1 * 2 + 8), v_X1);
+        _mm_storeu_si128((__m128i *)(xy + x1 * 2 + 16), v_Y0);
+        _mm_storeu_si128((__m128i *)(xy + x1 * 2 + 24), v_Y1);
+    }
 
-            // 12-15
-            __m128i v_X3, v_Y3;
-            {
-                __m128d v_W = _mm_add_pd(_mm_mul_pd(v_M6, v_x1), v_W0);
-                v_W = _mm_andnot_pd(_mm_cmpeq_pd(v_W, v_zero), _mm_div_pd(v_its, v_W));
-                __m128d v_fX0 = _mm_max_pd(v_intmin, _mm_min_pd(v_intmax, _mm_mul_pd(_mm_add_pd(v_X0d, _mm_mul_pd(v_M0, v_x1)), v_W)));
-                __m128d v_fY0 = _mm_max_pd(v_intmin, _mm_min_pd(v_intmax, _mm_mul_pd(_mm_add_pd(v_Y0d, _mm_mul_pd(v_M3, v_x1)), v_W)));
-                v_x1 = _mm_add_pd(v_x1, v_2);
+    for (; x1 < bw; x1++)
+    {
+        double W = W0 + M[6] * x1;
+        W = W ? 1. / W : 0;
+        double fX = std::max((double)INT_MIN, std::min((double)INT_MAX, (X0 + M[0] * x1)*W));
+        double fY = std::max((double)INT_MIN, std::min((double)INT_MAX, (Y0 + M[3] * x1)*W));
+        int X = saturate_cast<int>(fX);
+        int Y = saturate_cast<int>(fY);
 
-                v_W = _mm_add_pd(_mm_mul_pd(v_M6, v_x1), v_W0);
-                v_W = _mm_andnot_pd(_mm_cmpeq_pd(v_W, v_zero), _mm_div_pd(v_its, v_W));
-                __m128d v_fX1 = _mm_max_pd(v_intmin, _mm_min_pd(v_intmax, _mm_mul_pd(_mm_add_pd(v_X0d, _mm_mul_pd(v_M0, v_x1)), v_W)));
-                __m128d v_fY1 = _mm_max_pd(v_intmin, _mm_min_pd(v_intmax, _mm_mul_pd(_mm_add_pd(v_Y0d, _mm_mul_pd(v_M3, v_x1)), v_W)));
-                v_x1 = _mm_add_pd(v_x1, v_2);
+        xy[x1 * 2] = saturate_cast<short>(X);
+        xy[x1 * 2 + 1] = saturate_cast<short>(Y);
+    }
+}
 
-                v_X3 = _mm_castps_si128(_mm_movelh_ps(_mm_castsi128_ps(_mm_cvtpd_epi32(v_fX0)),
-                    _mm_castsi128_ps(_mm_cvtpd_epi32(v_fX1))));
-                v_Y3 = _mm_castps_si128(_mm_movelh_ps(_mm_castsi128_ps(_mm_cvtpd_epi32(v_fY0)),
-                    _mm_castsi128_ps(_mm_cvtpd_epi32(v_fY1))));
-            }
+void WarpPerspectiveLine_Process_SSE41(const double *M, short* xy, short* alpha, double X0, double Y0, double W0, int bw)
+{
+    const __m128d v_M0 = _mm_set1_pd(M[0]);
+    const __m128d v_M3 = _mm_set1_pd(M[3]);
+    const __m128d v_M6 = _mm_set1_pd(M[6]);
+    const __m128d v_intmax = _mm_set1_pd((double)INT_MAX);
+    const __m128d v_intmin = _mm_set1_pd((double)INT_MIN);
+    const __m128d v_2 = _mm_set1_pd(2);
+    const __m128d v_zero = _mm_setzero_pd();
+    const __m128d v_its = _mm_set1_pd(INTER_TAB_SIZE);
+    const __m128i v_itsi1 = _mm_set1_epi32(INTER_TAB_SIZE - 1);
 
-            // store alpha
-            __m128i v_alpha0 = _mm_add_epi32(_mm_slli_epi32(_mm_and_si128(v_Y0, v_itsi1), INTER_BITS),
-                _mm_and_si128(v_X0, v_itsi1));
-            __m128i v_alpha1 = _mm_add_epi32(_mm_slli_epi32(_mm_and_si128(v_Y1, v_itsi1), INTER_BITS),
-                _mm_and_si128(v_X1, v_itsi1));
-            _mm_storeu_si128((__m128i *)(alpha + x1), _mm_packs_epi32(v_alpha0, v_alpha1));
+    int x1 = 0;
 
-            v_alpha0 = _mm_add_epi32(_mm_slli_epi32(_mm_and_si128(v_Y2, v_itsi1), INTER_BITS),
-                _mm_and_si128(v_X2, v_itsi1));
-            v_alpha1 = _mm_add_epi32(_mm_slli_epi32(_mm_and_si128(v_Y3, v_itsi1), INTER_BITS),
-                _mm_and_si128(v_X3, v_itsi1));
+    __m128d v_X0d = _mm_set1_pd(X0);
+    __m128d v_Y0d = _mm_set1_pd(Y0);
+    __m128d v_W0 = _mm_set1_pd(W0);
+    __m128d v_x1 = _mm_set_pd(1, 0);
+
+    for (; x1 <= bw - 16; x1 += 16)
+    {
+        // 0-3
+        __m128i v_X0, v_Y0;
+        {
+            __m128d v_W = _mm_add_pd(_mm_mul_pd(v_M6, v_x1), v_W0);
+            v_W = _mm_andnot_pd(_mm_cmpeq_pd(v_W, v_zero), _mm_div_pd(v_its, v_W));
+            __m128d v_fX0 = _mm_max_pd(v_intmin, _mm_min_pd(v_intmax, _mm_mul_pd(_mm_add_pd(v_X0d, _mm_mul_pd(v_M0, v_x1)), v_W)));
+            __m128d v_fY0 = _mm_max_pd(v_intmin, _mm_min_pd(v_intmax, _mm_mul_pd(_mm_add_pd(v_Y0d, _mm_mul_pd(v_M3, v_x1)), v_W)));
+            v_x1 = _mm_add_pd(v_x1, v_2);
+
+            v_W = _mm_add_pd(_mm_mul_pd(v_M6, v_x1), v_W0);
+            v_W = _mm_andnot_pd(_mm_cmpeq_pd(v_W, v_zero), _mm_div_pd(v_its, v_W));
+            __m128d v_fX1 = _mm_max_pd(v_intmin, _mm_min_pd(v_intmax, _mm_mul_pd(_mm_add_pd(v_X0d, _mm_mul_pd(v_M0, v_x1)), v_W)));
+            __m128d v_fY1 = _mm_max_pd(v_intmin, _mm_min_pd(v_intmax, _mm_mul_pd(_mm_add_pd(v_Y0d, _mm_mul_pd(v_M3, v_x1)), v_W)));
+            v_x1 = _mm_add_pd(v_x1, v_2);
+
+            v_X0 = _mm_castps_si128(_mm_movelh_ps(_mm_castsi128_ps(_mm_cvtpd_epi32(v_fX0)),
+                _mm_castsi128_ps(_mm_cvtpd_epi32(v_fX1))));
+            v_Y0 = _mm_castps_si128(_mm_movelh_ps(_mm_castsi128_ps(_mm_cvtpd_epi32(v_fY0)),
+                _mm_castsi128_ps(_mm_cvtpd_epi32(v_fY1))));
+        }
+
+        // 4-8
+        __m128i v_X1, v_Y1;
+        {
+            __m128d v_W = _mm_add_pd(_mm_mul_pd(v_M6, v_x1), v_W0);
+            v_W = _mm_andnot_pd(_mm_cmpeq_pd(v_W, v_zero), _mm_div_pd(v_its, v_W));
+            __m128d v_fX0 = _mm_max_pd(v_intmin, _mm_min_pd(v_intmax, _mm_mul_pd(_mm_add_pd(v_X0d, _mm_mul_pd(v_M0, v_x1)), v_W)));
+            __m128d v_fY0 = _mm_max_pd(v_intmin, _mm_min_pd(v_intmax, _mm_mul_pd(_mm_add_pd(v_Y0d, _mm_mul_pd(v_M3, v_x1)), v_W)));
+            v_x1 = _mm_add_pd(v_x1, v_2);
+
+            v_W = _mm_add_pd(_mm_mul_pd(v_M6, v_x1), v_W0);
+            v_W = _mm_andnot_pd(_mm_cmpeq_pd(v_W, v_zero), _mm_div_pd(v_its, v_W));
+            __m128d v_fX1 = _mm_max_pd(v_intmin, _mm_min_pd(v_intmax, _mm_mul_pd(_mm_add_pd(v_X0d, _mm_mul_pd(v_M0, v_x1)), v_W)));
+            __m128d v_fY1 = _mm_max_pd(v_intmin, _mm_min_pd(v_intmax, _mm_mul_pd(_mm_add_pd(v_Y0d, _mm_mul_pd(v_M3, v_x1)), v_W)));
+            v_x1 = _mm_add_pd(v_x1, v_2);
+
+            v_X1 = _mm_castps_si128(_mm_movelh_ps(_mm_castsi128_ps(_mm_cvtpd_epi32(v_fX0)),
+                _mm_castsi128_ps(_mm_cvtpd_epi32(v_fX1))));
+            v_Y1 = _mm_castps_si128(_mm_movelh_ps(_mm_castsi128_ps(_mm_cvtpd_epi32(v_fY0)),
+                _mm_castsi128_ps(_mm_cvtpd_epi32(v_fY1))));
+        }
+
+        // 8-11
+        __m128i v_X2, v_Y2;
+        {
+            __m128d v_W = _mm_add_pd(_mm_mul_pd(v_M6, v_x1), v_W0);
+            v_W = _mm_andnot_pd(_mm_cmpeq_pd(v_W, v_zero), _mm_div_pd(v_its, v_W));
+            __m128d v_fX0 = _mm_max_pd(v_intmin, _mm_min_pd(v_intmax, _mm_mul_pd(_mm_add_pd(v_X0d, _mm_mul_pd(v_M0, v_x1)), v_W)));
+            __m128d v_fY0 = _mm_max_pd(v_intmin, _mm_min_pd(v_intmax, _mm_mul_pd(_mm_add_pd(v_Y0d, _mm_mul_pd(v_M3, v_x1)), v_W)));
+            v_x1 = _mm_add_pd(v_x1, v_2);
+
+            v_W = _mm_add_pd(_mm_mul_pd(v_M6, v_x1), v_W0);
+            v_W = _mm_andnot_pd(_mm_cmpeq_pd(v_W, v_zero), _mm_div_pd(v_its, v_W));
+            __m128d v_fX1 = _mm_max_pd(v_intmin, _mm_min_pd(v_intmax, _mm_mul_pd(_mm_add_pd(v_X0d, _mm_mul_pd(v_M0, v_x1)), v_W)));
+            __m128d v_fY1 = _mm_max_pd(v_intmin, _mm_min_pd(v_intmax, _mm_mul_pd(_mm_add_pd(v_Y0d, _mm_mul_pd(v_M3, v_x1)), v_W)));
+            v_x1 = _mm_add_pd(v_x1, v_2);
+
+            v_X2 = _mm_castps_si128(_mm_movelh_ps(_mm_castsi128_ps(_mm_cvtpd_epi32(v_fX0)),
+                _mm_castsi128_ps(_mm_cvtpd_epi32(v_fX1))));
+            v_Y2 = _mm_castps_si128(_mm_movelh_ps(_mm_castsi128_ps(_mm_cvtpd_epi32(v_fY0)),
+                _mm_castsi128_ps(_mm_cvtpd_epi32(v_fY1))));
+        }
+
+        // 12-15
+        __m128i v_X3, v_Y3;
+        {
+            __m128d v_W = _mm_add_pd(_mm_mul_pd(v_M6, v_x1), v_W0);
+            v_W = _mm_andnot_pd(_mm_cmpeq_pd(v_W, v_zero), _mm_div_pd(v_its, v_W));
+            __m128d v_fX0 = _mm_max_pd(v_intmin, _mm_min_pd(v_intmax, _mm_mul_pd(_mm_add_pd(v_X0d, _mm_mul_pd(v_M0, v_x1)), v_W)));
+            __m128d v_fY0 = _mm_max_pd(v_intmin, _mm_min_pd(v_intmax, _mm_mul_pd(_mm_add_pd(v_Y0d, _mm_mul_pd(v_M3, v_x1)), v_W)));
+            v_x1 = _mm_add_pd(v_x1, v_2);
+
+            v_W = _mm_add_pd(_mm_mul_pd(v_M6, v_x1), v_W0);
+            v_W = _mm_andnot_pd(_mm_cmpeq_pd(v_W, v_zero), _mm_div_pd(v_its, v_W));
+            __m128d v_fX1 = _mm_max_pd(v_intmin, _mm_min_pd(v_intmax, _mm_mul_pd(_mm_add_pd(v_X0d, _mm_mul_pd(v_M0, v_x1)), v_W)));
+            __m128d v_fY1 = _mm_max_pd(v_intmin, _mm_min_pd(v_intmax, _mm_mul_pd(_mm_add_pd(v_Y0d, _mm_mul_pd(v_M3, v_x1)), v_W)));
+            v_x1 = _mm_add_pd(v_x1, v_2);
+
+            v_X3 = _mm_castps_si128(_mm_movelh_ps(_mm_castsi128_ps(_mm_cvtpd_epi32(v_fX0)),
+                _mm_castsi128_ps(_mm_cvtpd_epi32(v_fX1))));
+            v_Y3 = _mm_castps_si128(_mm_movelh_ps(_mm_castsi128_ps(_mm_cvtpd_epi32(v_fY0)),
+                _mm_castsi128_ps(_mm_cvtpd_epi32(v_fY1))));
+        }
+
+        // store alpha
+        __m128i v_alpha0 = _mm_add_epi32(_mm_slli_epi32(_mm_and_si128(v_Y0, v_itsi1), INTER_BITS),
+            _mm_and_si128(v_X0, v_itsi1));
+        __m128i v_alpha1 = _mm_add_epi32(_mm_slli_epi32(_mm_and_si128(v_Y1, v_itsi1), INTER_BITS),
+            _mm_and_si128(v_X1, v_itsi1));
+        _mm_storeu_si128((__m128i *)(alpha + x1), _mm_packs_epi32(v_alpha0, v_alpha1));
+
+        v_alpha0 = _mm_add_epi32(_mm_slli_epi32(_mm_and_si128(v_Y2, v_itsi1), INTER_BITS),
+            _mm_and_si128(v_X2, v_itsi1));
+        v_alpha1 = _mm_add_epi32(_mm_slli_epi32(_mm_and_si128(v_Y3, v_itsi1), INTER_BITS),
+            _mm_and_si128(v_X3, v_itsi1));
             _mm_storeu_si128((__m128i *)(alpha + x1 + 8), _mm_packs_epi32(v_alpha0, v_alpha1));
 
-            // convert to 16s
-            v_X0 = _mm_packs_epi32(_mm_srai_epi32(v_X0, INTER_BITS), _mm_srai_epi32(v_X1, INTER_BITS));
-            v_X1 = _mm_packs_epi32(_mm_srai_epi32(v_X2, INTER_BITS), _mm_srai_epi32(v_X3, INTER_BITS));
-            v_Y0 = _mm_packs_epi32(_mm_srai_epi32(v_Y0, INTER_BITS), _mm_srai_epi32(v_Y1, INTER_BITS));
-            v_Y1 = _mm_packs_epi32(_mm_srai_epi32(v_Y2, INTER_BITS), _mm_srai_epi32(v_Y3, INTER_BITS));
+        // convert to 16s
+        v_X0 = _mm_packs_epi32(_mm_srai_epi32(v_X0, INTER_BITS), _mm_srai_epi32(v_X1, INTER_BITS));
+        v_X1 = _mm_packs_epi32(_mm_srai_epi32(v_X2, INTER_BITS), _mm_srai_epi32(v_X3, INTER_BITS));
+        v_Y0 = _mm_packs_epi32(_mm_srai_epi32(v_Y0, INTER_BITS), _mm_srai_epi32(v_Y1, INTER_BITS));
+        v_Y1 = _mm_packs_epi32(_mm_srai_epi32(v_Y2, INTER_BITS), _mm_srai_epi32(v_Y3, INTER_BITS));
 
-            _mm_interleave_epi16(v_X0, v_X1, v_Y0, v_Y1);
+        _mm_interleave_epi16(v_X0, v_X1, v_Y0, v_Y1);
 
-            _mm_storeu_si128((__m128i *)(xy + x1 * 2), v_X0);
-            _mm_storeu_si128((__m128i *)(xy + x1 * 2 + 8), v_X1);
-            _mm_storeu_si128((__m128i *)(xy + x1 * 2 + 16), v_Y0);
-            _mm_storeu_si128((__m128i *)(xy + x1 * 2 + 24), v_Y1);
-        }
-        for (; x1 < bw; x1++)
-        {
-            double W = W0 + M[6] * x1;
-            W = W ? INTER_TAB_SIZE / W : 0;
-            double fX = std::max((double)INT_MIN, std::min((double)INT_MAX, (X0 + M[0] * x1)*W));
-            double fY = std::max((double)INT_MIN, std::min((double)INT_MAX, (Y0 + M[3] * x1)*W));
-            int X = saturate_cast<int>(fX);
-            int Y = saturate_cast<int>(fY);
-
-            xy[x1 * 2] = saturate_cast<short>(X >> INTER_BITS);
-            xy[x1 * 2 + 1] = saturate_cast<short>(Y >> INTER_BITS);
-            alpha[x1] = (short)((Y & (INTER_TAB_SIZE - 1))*INTER_TAB_SIZE +
-                (X & (INTER_TAB_SIZE - 1)));
-        }
+        _mm_storeu_si128((__m128i *)(xy + x1 * 2), v_X0);
+        _mm_storeu_si128((__m128i *)(xy + x1 * 2 + 8), v_X1);
+        _mm_storeu_si128((__m128i *)(xy + x1 * 2 + 16), v_Y0);
+        _mm_storeu_si128((__m128i *)(xy + x1 * 2 + 24), v_Y1);
     }
-    virtual ~WarpPerspectiveLine_SSE4_Impl() CV_OVERRIDE {};
-};
+    for (; x1 < bw; x1++)
+    {
+        double W = W0 + M[6] * x1;
+        W = W ? INTER_TAB_SIZE / W : 0;
+        double fX = std::max((double)INT_MIN, std::min((double)INT_MAX, (X0 + M[0] * x1)*W));
+        double fY = std::max((double)INT_MIN, std::min((double)INT_MAX, (Y0 + M[3] * x1)*W));
+        int X = saturate_cast<int>(fX);
+        int Y = saturate_cast<int>(fY);
 
-Ptr<WarpPerspectiveLine_SSE4> WarpPerspectiveLine_SSE4::getImpl(const double *M)
-{
-    return Ptr<WarpPerspectiveLine_SSE4>(new WarpPerspectiveLine_SSE4_Impl(M));
+        xy[x1 * 2] = saturate_cast<short>(X >> INTER_BITS);
+        xy[x1 * 2 + 1] = saturate_cast<short>(Y >> INTER_BITS);
+        alpha[x1] = (short)((Y & (INTER_TAB_SIZE - 1))*INTER_TAB_SIZE +
+            (X & (INTER_TAB_SIZE - 1)));
+    }
 }
 
-}
 }
 /* End of file. */

--- a/modules/imgproc/src/imgwarp.sse4_1.cpp
+++ b/modules/imgproc/src/imgwarp.sse4_1.cpp
@@ -207,285 +207,299 @@ void WarpAffineInvoker_Blockline_SSE41(int *adelta, int *bdelta, short* xy, int 
         xy[x1 * 2 + 1] = saturate_cast<short>(Y);
     }
 }
-}
 
-void WarpPerspectiveLine_ProcessNN_SSE41(const double *M, short* xy, double X0, double Y0, double W0, int bw)
+
+class WarpPerspectiveLine_SSE4_Impl CV_FINAL : public WarpPerspectiveLine_SSE4
 {
-    const __m128d v_M0 = _mm_set1_pd(M[0]);
-    const __m128d v_M3 = _mm_set1_pd(M[3]);
-    const __m128d v_M6 = _mm_set1_pd(M[6]);
-    const __m128d v_intmax = _mm_set1_pd((double)INT_MAX);
-    const __m128d v_intmin = _mm_set1_pd((double)INT_MIN);
-    const __m128d v_2 = _mm_set1_pd(2);
-    const __m128d v_zero = _mm_setzero_pd();
-    const __m128d v_1 = _mm_set1_pd(1);
-
-    int x1 = 0;
-    __m128d v_X0d = _mm_set1_pd(X0);
-    __m128d v_Y0d = _mm_set1_pd(Y0);
-    __m128d v_W0 = _mm_set1_pd(W0);
-    __m128d v_x1 = _mm_set_pd(1, 0);
-
-    for (; x1 <= bw - 16; x1 += 16)
+public:
+    WarpPerspectiveLine_SSE4_Impl(const double *M)
     {
-        // 0-3
-        __m128i v_X0, v_Y0;
-        {
-            __m128d v_W = _mm_add_pd(_mm_mul_pd(v_M6, v_x1), v_W0);
-            v_W = _mm_andnot_pd(_mm_cmpeq_pd(v_W, v_zero), _mm_div_pd(v_1, v_W));
-            __m128d v_fX0 = _mm_max_pd(v_intmin, _mm_min_pd(v_intmax, _mm_mul_pd(_mm_add_pd(v_X0d, _mm_mul_pd(v_M0, v_x1)), v_W)));
-            __m128d v_fY0 = _mm_max_pd(v_intmin, _mm_min_pd(v_intmax, _mm_mul_pd(_mm_add_pd(v_Y0d, _mm_mul_pd(v_M3, v_x1)), v_W)));
-            v_x1 = _mm_add_pd(v_x1, v_2);
-
-            v_W = _mm_add_pd(_mm_mul_pd(v_M6, v_x1), v_W0);
-            v_W = _mm_andnot_pd(_mm_cmpeq_pd(v_W, v_zero), _mm_div_pd(v_1, v_W));
-            __m128d v_fX1 = _mm_max_pd(v_intmin, _mm_min_pd(v_intmax, _mm_mul_pd(_mm_add_pd(v_X0d, _mm_mul_pd(v_M0, v_x1)), v_W)));
-            __m128d v_fY1 = _mm_max_pd(v_intmin, _mm_min_pd(v_intmax, _mm_mul_pd(_mm_add_pd(v_Y0d, _mm_mul_pd(v_M3, v_x1)), v_W)));
-            v_x1 = _mm_add_pd(v_x1, v_2);
-
-            v_X0 = _mm_castps_si128(_mm_movelh_ps(_mm_castsi128_ps(_mm_cvtpd_epi32(v_fX0)),
-                _mm_castsi128_ps(_mm_cvtpd_epi32(v_fX1))));
-            v_Y0 = _mm_castps_si128(_mm_movelh_ps(_mm_castsi128_ps(_mm_cvtpd_epi32(v_fY0)),
-                _mm_castsi128_ps(_mm_cvtpd_epi32(v_fY1))));
-        }
-
-        // 4-8
-        __m128i v_X1, v_Y1;
-        {
-            __m128d v_W = _mm_add_pd(_mm_mul_pd(v_M6, v_x1), v_W0);
-            v_W = _mm_andnot_pd(_mm_cmpeq_pd(v_W, v_zero), _mm_div_pd(v_1, v_W));
-            __m128d v_fX0 = _mm_max_pd(v_intmin, _mm_min_pd(v_intmax, _mm_mul_pd(_mm_add_pd(v_X0d, _mm_mul_pd(v_M0, v_x1)), v_W)));
-            __m128d v_fY0 = _mm_max_pd(v_intmin, _mm_min_pd(v_intmax, _mm_mul_pd(_mm_add_pd(v_Y0d, _mm_mul_pd(v_M3, v_x1)), v_W)));
-            v_x1 = _mm_add_pd(v_x1, v_2);
-
-            v_W = _mm_add_pd(_mm_mul_pd(v_M6, v_x1), v_W0);
-            v_W = _mm_andnot_pd(_mm_cmpeq_pd(v_W, v_zero), _mm_div_pd(v_1, v_W));
-            __m128d v_fX1 = _mm_max_pd(v_intmin, _mm_min_pd(v_intmax, _mm_mul_pd(_mm_add_pd(v_X0d, _mm_mul_pd(v_M0, v_x1)), v_W)));
-            __m128d v_fY1 = _mm_max_pd(v_intmin, _mm_min_pd(v_intmax, _mm_mul_pd(_mm_add_pd(v_Y0d, _mm_mul_pd(v_M3, v_x1)), v_W)));
-            v_x1 = _mm_add_pd(v_x1, v_2);
-
-            v_X1 = _mm_castps_si128(_mm_movelh_ps(_mm_castsi128_ps(_mm_cvtpd_epi32(v_fX0)),
-                _mm_castsi128_ps(_mm_cvtpd_epi32(v_fX1))));
-            v_Y1 = _mm_castps_si128(_mm_movelh_ps(_mm_castsi128_ps(_mm_cvtpd_epi32(v_fY0)),
-                _mm_castsi128_ps(_mm_cvtpd_epi32(v_fY1))));
-        }
-
-        // 8-11
-        __m128i v_X2, v_Y2;
-        {
-            __m128d v_W = _mm_add_pd(_mm_mul_pd(v_M6, v_x1), v_W0);
-            v_W = _mm_andnot_pd(_mm_cmpeq_pd(v_W, v_zero), _mm_div_pd(v_1, v_W));
-            __m128d v_fX0 = _mm_max_pd(v_intmin, _mm_min_pd(v_intmax, _mm_mul_pd(_mm_add_pd(v_X0d, _mm_mul_pd(v_M0, v_x1)), v_W)));
-            __m128d v_fY0 = _mm_max_pd(v_intmin, _mm_min_pd(v_intmax, _mm_mul_pd(_mm_add_pd(v_Y0d, _mm_mul_pd(v_M3, v_x1)), v_W)));
-            v_x1 = _mm_add_pd(v_x1, v_2);
-
-            v_W = _mm_add_pd(_mm_mul_pd(v_M6, v_x1), v_W0);
-            v_W = _mm_andnot_pd(_mm_cmpeq_pd(v_W, v_zero), _mm_div_pd(v_1, v_W));
-            __m128d v_fX1 = _mm_max_pd(v_intmin, _mm_min_pd(v_intmax, _mm_mul_pd(_mm_add_pd(v_X0d, _mm_mul_pd(v_M0, v_x1)), v_W)));
-            __m128d v_fY1 = _mm_max_pd(v_intmin, _mm_min_pd(v_intmax, _mm_mul_pd(_mm_add_pd(v_Y0d, _mm_mul_pd(v_M3, v_x1)), v_W)));
-            v_x1 = _mm_add_pd(v_x1, v_2);
-
-            v_X2 = _mm_castps_si128(_mm_movelh_ps(_mm_castsi128_ps(_mm_cvtpd_epi32(v_fX0)),
-                _mm_castsi128_ps(_mm_cvtpd_epi32(v_fX1))));
-            v_Y2 = _mm_castps_si128(_mm_movelh_ps(_mm_castsi128_ps(_mm_cvtpd_epi32(v_fY0)),
-                _mm_castsi128_ps(_mm_cvtpd_epi32(v_fY1))));
-        }
-
-        // 12-15
-        __m128i v_X3, v_Y3;
-        {
-            __m128d v_W = _mm_add_pd(_mm_mul_pd(v_M6, v_x1), v_W0);
-            v_W = _mm_andnot_pd(_mm_cmpeq_pd(v_W, v_zero), _mm_div_pd(v_1, v_W));
-            __m128d v_fX0 = _mm_max_pd(v_intmin, _mm_min_pd(v_intmax, _mm_mul_pd(_mm_add_pd(v_X0d, _mm_mul_pd(v_M0, v_x1)), v_W)));
-            __m128d v_fY0 = _mm_max_pd(v_intmin, _mm_min_pd(v_intmax, _mm_mul_pd(_mm_add_pd(v_Y0d, _mm_mul_pd(v_M3, v_x1)), v_W)));
-            v_x1 = _mm_add_pd(v_x1, v_2);
-
-            v_W = _mm_add_pd(_mm_mul_pd(v_M6, v_x1), v_W0);
-            v_W = _mm_andnot_pd(_mm_cmpeq_pd(v_W, v_zero), _mm_div_pd(v_1, v_W));
-            __m128d v_fX1 = _mm_max_pd(v_intmin, _mm_min_pd(v_intmax, _mm_mul_pd(_mm_add_pd(v_X0d, _mm_mul_pd(v_M0, v_x1)), v_W)));
-            __m128d v_fY1 = _mm_max_pd(v_intmin, _mm_min_pd(v_intmax, _mm_mul_pd(_mm_add_pd(v_Y0d, _mm_mul_pd(v_M3, v_x1)), v_W)));
-            v_x1 = _mm_add_pd(v_x1, v_2);
-
-            v_X3 = _mm_castps_si128(_mm_movelh_ps(_mm_castsi128_ps(_mm_cvtpd_epi32(v_fX0)),
-                _mm_castsi128_ps(_mm_cvtpd_epi32(v_fX1))));
-            v_Y3 = _mm_castps_si128(_mm_movelh_ps(_mm_castsi128_ps(_mm_cvtpd_epi32(v_fY0)),
-                _mm_castsi128_ps(_mm_cvtpd_epi32(v_fY1))));
-        }
-
-        // convert to 16s
-        v_X0 = _mm_packs_epi32(v_X0, v_X1);
-        v_X1 = _mm_packs_epi32(v_X2, v_X3);
-        v_Y0 = _mm_packs_epi32(v_Y0, v_Y1);
-        v_Y1 = _mm_packs_epi32(v_Y2, v_Y3);
-
-        _mm_interleave_epi16(v_X0, v_X1, v_Y0, v_Y1);
-
-        _mm_storeu_si128((__m128i *)(xy + x1 * 2), v_X0);
-        _mm_storeu_si128((__m128i *)(xy + x1 * 2 + 8), v_X1);
-        _mm_storeu_si128((__m128i *)(xy + x1 * 2 + 16), v_Y0);
-        _mm_storeu_si128((__m128i *)(xy + x1 * 2 + 24), v_Y1);
+        CV_UNUSED(M);
     }
-
-    for (; x1 < bw; x1++)
+    virtual void processNN(const double *M, short* xy, double X0, double Y0, double W0, int bw) CV_OVERRIDE
     {
-        double W = W0 + M[6] * x1;
-        W = W ? 1. / W : 0;
-        double fX = std::max((double)INT_MIN, std::min((double)INT_MAX, (X0 + M[0] * x1)*W));
-        double fY = std::max((double)INT_MIN, std::min((double)INT_MAX, (Y0 + M[3] * x1)*W));
-        int X = saturate_cast<int>(fX);
-        int Y = saturate_cast<int>(fY);
+        const __m128d v_M0 = _mm_set1_pd(M[0]);
+        const __m128d v_M3 = _mm_set1_pd(M[3]);
+        const __m128d v_M6 = _mm_set1_pd(M[6]);
+        const __m128d v_intmax = _mm_set1_pd((double)INT_MAX);
+        const __m128d v_intmin = _mm_set1_pd((double)INT_MIN);
+        const __m128d v_2 = _mm_set1_pd(2);
+        const __m128d v_zero = _mm_setzero_pd();
+        const __m128d v_1 = _mm_set1_pd(1);
 
-        xy[x1 * 2] = saturate_cast<short>(X);
-        xy[x1 * 2 + 1] = saturate_cast<short>(Y);
+        int x1 = 0;
+        __m128d v_X0d = _mm_set1_pd(X0);
+        __m128d v_Y0d = _mm_set1_pd(Y0);
+        __m128d v_W0 = _mm_set1_pd(W0);
+        __m128d v_x1 = _mm_set_pd(1, 0);
+
+        for (; x1 <= bw - 16; x1 += 16)
+        {
+            // 0-3
+            __m128i v_X0, v_Y0;
+            {
+                __m128d v_W = _mm_add_pd(_mm_mul_pd(v_M6, v_x1), v_W0);
+                v_W = _mm_andnot_pd(_mm_cmpeq_pd(v_W, v_zero), _mm_div_pd(v_1, v_W));
+                __m128d v_fX0 = _mm_max_pd(v_intmin, _mm_min_pd(v_intmax, _mm_mul_pd(_mm_add_pd(v_X0d, _mm_mul_pd(v_M0, v_x1)), v_W)));
+                __m128d v_fY0 = _mm_max_pd(v_intmin, _mm_min_pd(v_intmax, _mm_mul_pd(_mm_add_pd(v_Y0d, _mm_mul_pd(v_M3, v_x1)), v_W)));
+                v_x1 = _mm_add_pd(v_x1, v_2);
+
+                v_W = _mm_add_pd(_mm_mul_pd(v_M6, v_x1), v_W0);
+                v_W = _mm_andnot_pd(_mm_cmpeq_pd(v_W, v_zero), _mm_div_pd(v_1, v_W));
+                __m128d v_fX1 = _mm_max_pd(v_intmin, _mm_min_pd(v_intmax, _mm_mul_pd(_mm_add_pd(v_X0d, _mm_mul_pd(v_M0, v_x1)), v_W)));
+                __m128d v_fY1 = _mm_max_pd(v_intmin, _mm_min_pd(v_intmax, _mm_mul_pd(_mm_add_pd(v_Y0d, _mm_mul_pd(v_M3, v_x1)), v_W)));
+                v_x1 = _mm_add_pd(v_x1, v_2);
+
+                v_X0 = _mm_castps_si128(_mm_movelh_ps(_mm_castsi128_ps(_mm_cvtpd_epi32(v_fX0)),
+                    _mm_castsi128_ps(_mm_cvtpd_epi32(v_fX1))));
+                v_Y0 = _mm_castps_si128(_mm_movelh_ps(_mm_castsi128_ps(_mm_cvtpd_epi32(v_fY0)),
+                    _mm_castsi128_ps(_mm_cvtpd_epi32(v_fY1))));
+            }
+
+            // 4-8
+            __m128i v_X1, v_Y1;
+            {
+                __m128d v_W = _mm_add_pd(_mm_mul_pd(v_M6, v_x1), v_W0);
+                v_W = _mm_andnot_pd(_mm_cmpeq_pd(v_W, v_zero), _mm_div_pd(v_1, v_W));
+                __m128d v_fX0 = _mm_max_pd(v_intmin, _mm_min_pd(v_intmax, _mm_mul_pd(_mm_add_pd(v_X0d, _mm_mul_pd(v_M0, v_x1)), v_W)));
+                __m128d v_fY0 = _mm_max_pd(v_intmin, _mm_min_pd(v_intmax, _mm_mul_pd(_mm_add_pd(v_Y0d, _mm_mul_pd(v_M3, v_x1)), v_W)));
+                v_x1 = _mm_add_pd(v_x1, v_2);
+
+                v_W = _mm_add_pd(_mm_mul_pd(v_M6, v_x1), v_W0);
+                v_W = _mm_andnot_pd(_mm_cmpeq_pd(v_W, v_zero), _mm_div_pd(v_1, v_W));
+                __m128d v_fX1 = _mm_max_pd(v_intmin, _mm_min_pd(v_intmax, _mm_mul_pd(_mm_add_pd(v_X0d, _mm_mul_pd(v_M0, v_x1)), v_W)));
+                __m128d v_fY1 = _mm_max_pd(v_intmin, _mm_min_pd(v_intmax, _mm_mul_pd(_mm_add_pd(v_Y0d, _mm_mul_pd(v_M3, v_x1)), v_W)));
+                v_x1 = _mm_add_pd(v_x1, v_2);
+
+                v_X1 = _mm_castps_si128(_mm_movelh_ps(_mm_castsi128_ps(_mm_cvtpd_epi32(v_fX0)),
+                    _mm_castsi128_ps(_mm_cvtpd_epi32(v_fX1))));
+                v_Y1 = _mm_castps_si128(_mm_movelh_ps(_mm_castsi128_ps(_mm_cvtpd_epi32(v_fY0)),
+                    _mm_castsi128_ps(_mm_cvtpd_epi32(v_fY1))));
+            }
+
+            // 8-11
+            __m128i v_X2, v_Y2;
+            {
+                __m128d v_W = _mm_add_pd(_mm_mul_pd(v_M6, v_x1), v_W0);
+                v_W = _mm_andnot_pd(_mm_cmpeq_pd(v_W, v_zero), _mm_div_pd(v_1, v_W));
+                __m128d v_fX0 = _mm_max_pd(v_intmin, _mm_min_pd(v_intmax, _mm_mul_pd(_mm_add_pd(v_X0d, _mm_mul_pd(v_M0, v_x1)), v_W)));
+                __m128d v_fY0 = _mm_max_pd(v_intmin, _mm_min_pd(v_intmax, _mm_mul_pd(_mm_add_pd(v_Y0d, _mm_mul_pd(v_M3, v_x1)), v_W)));
+                v_x1 = _mm_add_pd(v_x1, v_2);
+
+                v_W = _mm_add_pd(_mm_mul_pd(v_M6, v_x1), v_W0);
+                v_W = _mm_andnot_pd(_mm_cmpeq_pd(v_W, v_zero), _mm_div_pd(v_1, v_W));
+                __m128d v_fX1 = _mm_max_pd(v_intmin, _mm_min_pd(v_intmax, _mm_mul_pd(_mm_add_pd(v_X0d, _mm_mul_pd(v_M0, v_x1)), v_W)));
+                __m128d v_fY1 = _mm_max_pd(v_intmin, _mm_min_pd(v_intmax, _mm_mul_pd(_mm_add_pd(v_Y0d, _mm_mul_pd(v_M3, v_x1)), v_W)));
+                v_x1 = _mm_add_pd(v_x1, v_2);
+
+                v_X2 = _mm_castps_si128(_mm_movelh_ps(_mm_castsi128_ps(_mm_cvtpd_epi32(v_fX0)),
+                    _mm_castsi128_ps(_mm_cvtpd_epi32(v_fX1))));
+                v_Y2 = _mm_castps_si128(_mm_movelh_ps(_mm_castsi128_ps(_mm_cvtpd_epi32(v_fY0)),
+                    _mm_castsi128_ps(_mm_cvtpd_epi32(v_fY1))));
+            }
+
+            // 12-15
+            __m128i v_X3, v_Y3;
+            {
+                __m128d v_W = _mm_add_pd(_mm_mul_pd(v_M6, v_x1), v_W0);
+                v_W = _mm_andnot_pd(_mm_cmpeq_pd(v_W, v_zero), _mm_div_pd(v_1, v_W));
+                __m128d v_fX0 = _mm_max_pd(v_intmin, _mm_min_pd(v_intmax, _mm_mul_pd(_mm_add_pd(v_X0d, _mm_mul_pd(v_M0, v_x1)), v_W)));
+                __m128d v_fY0 = _mm_max_pd(v_intmin, _mm_min_pd(v_intmax, _mm_mul_pd(_mm_add_pd(v_Y0d, _mm_mul_pd(v_M3, v_x1)), v_W)));
+                v_x1 = _mm_add_pd(v_x1, v_2);
+
+                v_W = _mm_add_pd(_mm_mul_pd(v_M6, v_x1), v_W0);
+                v_W = _mm_andnot_pd(_mm_cmpeq_pd(v_W, v_zero), _mm_div_pd(v_1, v_W));
+                __m128d v_fX1 = _mm_max_pd(v_intmin, _mm_min_pd(v_intmax, _mm_mul_pd(_mm_add_pd(v_X0d, _mm_mul_pd(v_M0, v_x1)), v_W)));
+                __m128d v_fY1 = _mm_max_pd(v_intmin, _mm_min_pd(v_intmax, _mm_mul_pd(_mm_add_pd(v_Y0d, _mm_mul_pd(v_M3, v_x1)), v_W)));
+                v_x1 = _mm_add_pd(v_x1, v_2);
+
+                v_X3 = _mm_castps_si128(_mm_movelh_ps(_mm_castsi128_ps(_mm_cvtpd_epi32(v_fX0)),
+                    _mm_castsi128_ps(_mm_cvtpd_epi32(v_fX1))));
+                v_Y3 = _mm_castps_si128(_mm_movelh_ps(_mm_castsi128_ps(_mm_cvtpd_epi32(v_fY0)),
+                    _mm_castsi128_ps(_mm_cvtpd_epi32(v_fY1))));
+            }
+
+            // convert to 16s
+            v_X0 = _mm_packs_epi32(v_X0, v_X1);
+            v_X1 = _mm_packs_epi32(v_X2, v_X3);
+            v_Y0 = _mm_packs_epi32(v_Y0, v_Y1);
+            v_Y1 = _mm_packs_epi32(v_Y2, v_Y3);
+
+            _mm_interleave_epi16(v_X0, v_X1, v_Y0, v_Y1);
+
+            _mm_storeu_si128((__m128i *)(xy + x1 * 2), v_X0);
+            _mm_storeu_si128((__m128i *)(xy + x1 * 2 + 8), v_X1);
+            _mm_storeu_si128((__m128i *)(xy + x1 * 2 + 16), v_Y0);
+            _mm_storeu_si128((__m128i *)(xy + x1 * 2 + 24), v_Y1);
+        }
+
+        for (; x1 < bw; x1++)
+        {
+            double W = W0 + M[6] * x1;
+            W = W ? 1. / W : 0;
+            double fX = std::max((double)INT_MIN, std::min((double)INT_MAX, (X0 + M[0] * x1)*W));
+            double fY = std::max((double)INT_MIN, std::min((double)INT_MAX, (Y0 + M[3] * x1)*W));
+            int X = saturate_cast<int>(fX);
+            int Y = saturate_cast<int>(fY);
+
+            xy[x1 * 2] = saturate_cast<short>(X);
+            xy[x1 * 2 + 1] = saturate_cast<short>(Y);
+        }
     }
-}
-
-void WarpPerspectiveLine_Process_SSE41(const double *M, short* xy, short* alpha, double X0, double Y0, double W0, int bw)
-{
-    const __m128d v_M0 = _mm_set1_pd(M[0]);
-    const __m128d v_M3 = _mm_set1_pd(M[3]);
-    const __m128d v_M6 = _mm_set1_pd(M[6]);
-    const __m128d v_intmax = _mm_set1_pd((double)INT_MAX);
-    const __m128d v_intmin = _mm_set1_pd((double)INT_MIN);
-    const __m128d v_2 = _mm_set1_pd(2);
-    const __m128d v_zero = _mm_setzero_pd();
-    const __m128d v_its = _mm_set1_pd(INTER_TAB_SIZE);
-    const __m128i v_itsi1 = _mm_set1_epi32(INTER_TAB_SIZE - 1);
-
-    int x1 = 0;
-
-    __m128d v_X0d = _mm_set1_pd(X0);
-    __m128d v_Y0d = _mm_set1_pd(Y0);
-    __m128d v_W0 = _mm_set1_pd(W0);
-    __m128d v_x1 = _mm_set_pd(1, 0);
-
-    for (; x1 <= bw - 16; x1 += 16)
+    virtual void process(const double *M, short* xy, short* alpha, double X0, double Y0, double W0, int bw) CV_OVERRIDE
     {
-        // 0-3
-        __m128i v_X0, v_Y0;
+        const __m128d v_M0 = _mm_set1_pd(M[0]);
+        const __m128d v_M3 = _mm_set1_pd(M[3]);
+        const __m128d v_M6 = _mm_set1_pd(M[6]);
+        const __m128d v_intmax = _mm_set1_pd((double)INT_MAX);
+        const __m128d v_intmin = _mm_set1_pd((double)INT_MIN);
+        const __m128d v_2 = _mm_set1_pd(2);
+        const __m128d v_zero = _mm_setzero_pd();
+        const __m128d v_its = _mm_set1_pd(INTER_TAB_SIZE);
+        const __m128i v_itsi1 = _mm_set1_epi32(INTER_TAB_SIZE - 1);
+
+        int x1 = 0;
+
+        __m128d v_X0d = _mm_set1_pd(X0);
+        __m128d v_Y0d = _mm_set1_pd(Y0);
+        __m128d v_W0 = _mm_set1_pd(W0);
+        __m128d v_x1 = _mm_set_pd(1, 0);
+
+        for (; x1 <= bw - 16; x1 += 16)
         {
-            __m128d v_W = _mm_add_pd(_mm_mul_pd(v_M6, v_x1), v_W0);
-            v_W = _mm_andnot_pd(_mm_cmpeq_pd(v_W, v_zero), _mm_div_pd(v_its, v_W));
-            __m128d v_fX0 = _mm_max_pd(v_intmin, _mm_min_pd(v_intmax, _mm_mul_pd(_mm_add_pd(v_X0d, _mm_mul_pd(v_M0, v_x1)), v_W)));
-            __m128d v_fY0 = _mm_max_pd(v_intmin, _mm_min_pd(v_intmax, _mm_mul_pd(_mm_add_pd(v_Y0d, _mm_mul_pd(v_M3, v_x1)), v_W)));
-            v_x1 = _mm_add_pd(v_x1, v_2);
+            // 0-3
+            __m128i v_X0, v_Y0;
+            {
+                __m128d v_W = _mm_add_pd(_mm_mul_pd(v_M6, v_x1), v_W0);
+                v_W = _mm_andnot_pd(_mm_cmpeq_pd(v_W, v_zero), _mm_div_pd(v_its, v_W));
+                __m128d v_fX0 = _mm_max_pd(v_intmin, _mm_min_pd(v_intmax, _mm_mul_pd(_mm_add_pd(v_X0d, _mm_mul_pd(v_M0, v_x1)), v_W)));
+                __m128d v_fY0 = _mm_max_pd(v_intmin, _mm_min_pd(v_intmax, _mm_mul_pd(_mm_add_pd(v_Y0d, _mm_mul_pd(v_M3, v_x1)), v_W)));
+                v_x1 = _mm_add_pd(v_x1, v_2);
 
-            v_W = _mm_add_pd(_mm_mul_pd(v_M6, v_x1), v_W0);
-            v_W = _mm_andnot_pd(_mm_cmpeq_pd(v_W, v_zero), _mm_div_pd(v_its, v_W));
-            __m128d v_fX1 = _mm_max_pd(v_intmin, _mm_min_pd(v_intmax, _mm_mul_pd(_mm_add_pd(v_X0d, _mm_mul_pd(v_M0, v_x1)), v_W)));
-            __m128d v_fY1 = _mm_max_pd(v_intmin, _mm_min_pd(v_intmax, _mm_mul_pd(_mm_add_pd(v_Y0d, _mm_mul_pd(v_M3, v_x1)), v_W)));
-            v_x1 = _mm_add_pd(v_x1, v_2);
+                v_W = _mm_add_pd(_mm_mul_pd(v_M6, v_x1), v_W0);
+                v_W = _mm_andnot_pd(_mm_cmpeq_pd(v_W, v_zero), _mm_div_pd(v_its, v_W));
+                __m128d v_fX1 = _mm_max_pd(v_intmin, _mm_min_pd(v_intmax, _mm_mul_pd(_mm_add_pd(v_X0d, _mm_mul_pd(v_M0, v_x1)), v_W)));
+                __m128d v_fY1 = _mm_max_pd(v_intmin, _mm_min_pd(v_intmax, _mm_mul_pd(_mm_add_pd(v_Y0d, _mm_mul_pd(v_M3, v_x1)), v_W)));
+                v_x1 = _mm_add_pd(v_x1, v_2);
 
-            v_X0 = _mm_castps_si128(_mm_movelh_ps(_mm_castsi128_ps(_mm_cvtpd_epi32(v_fX0)),
-                _mm_castsi128_ps(_mm_cvtpd_epi32(v_fX1))));
-            v_Y0 = _mm_castps_si128(_mm_movelh_ps(_mm_castsi128_ps(_mm_cvtpd_epi32(v_fY0)),
-                _mm_castsi128_ps(_mm_cvtpd_epi32(v_fY1))));
-        }
+                v_X0 = _mm_castps_si128(_mm_movelh_ps(_mm_castsi128_ps(_mm_cvtpd_epi32(v_fX0)),
+                    _mm_castsi128_ps(_mm_cvtpd_epi32(v_fX1))));
+                v_Y0 = _mm_castps_si128(_mm_movelh_ps(_mm_castsi128_ps(_mm_cvtpd_epi32(v_fY0)),
+                    _mm_castsi128_ps(_mm_cvtpd_epi32(v_fY1))));
+            }
 
-        // 4-8
-        __m128i v_X1, v_Y1;
-        {
-            __m128d v_W = _mm_add_pd(_mm_mul_pd(v_M6, v_x1), v_W0);
-            v_W = _mm_andnot_pd(_mm_cmpeq_pd(v_W, v_zero), _mm_div_pd(v_its, v_W));
-            __m128d v_fX0 = _mm_max_pd(v_intmin, _mm_min_pd(v_intmax, _mm_mul_pd(_mm_add_pd(v_X0d, _mm_mul_pd(v_M0, v_x1)), v_W)));
-            __m128d v_fY0 = _mm_max_pd(v_intmin, _mm_min_pd(v_intmax, _mm_mul_pd(_mm_add_pd(v_Y0d, _mm_mul_pd(v_M3, v_x1)), v_W)));
-            v_x1 = _mm_add_pd(v_x1, v_2);
+            // 4-8
+            __m128i v_X1, v_Y1;
+            {
+                __m128d v_W = _mm_add_pd(_mm_mul_pd(v_M6, v_x1), v_W0);
+                v_W = _mm_andnot_pd(_mm_cmpeq_pd(v_W, v_zero), _mm_div_pd(v_its, v_W));
+                __m128d v_fX0 = _mm_max_pd(v_intmin, _mm_min_pd(v_intmax, _mm_mul_pd(_mm_add_pd(v_X0d, _mm_mul_pd(v_M0, v_x1)), v_W)));
+                __m128d v_fY0 = _mm_max_pd(v_intmin, _mm_min_pd(v_intmax, _mm_mul_pd(_mm_add_pd(v_Y0d, _mm_mul_pd(v_M3, v_x1)), v_W)));
+                v_x1 = _mm_add_pd(v_x1, v_2);
 
-            v_W = _mm_add_pd(_mm_mul_pd(v_M6, v_x1), v_W0);
-            v_W = _mm_andnot_pd(_mm_cmpeq_pd(v_W, v_zero), _mm_div_pd(v_its, v_W));
-            __m128d v_fX1 = _mm_max_pd(v_intmin, _mm_min_pd(v_intmax, _mm_mul_pd(_mm_add_pd(v_X0d, _mm_mul_pd(v_M0, v_x1)), v_W)));
-            __m128d v_fY1 = _mm_max_pd(v_intmin, _mm_min_pd(v_intmax, _mm_mul_pd(_mm_add_pd(v_Y0d, _mm_mul_pd(v_M3, v_x1)), v_W)));
-            v_x1 = _mm_add_pd(v_x1, v_2);
+                v_W = _mm_add_pd(_mm_mul_pd(v_M6, v_x1), v_W0);
+                v_W = _mm_andnot_pd(_mm_cmpeq_pd(v_W, v_zero), _mm_div_pd(v_its, v_W));
+                __m128d v_fX1 = _mm_max_pd(v_intmin, _mm_min_pd(v_intmax, _mm_mul_pd(_mm_add_pd(v_X0d, _mm_mul_pd(v_M0, v_x1)), v_W)));
+                __m128d v_fY1 = _mm_max_pd(v_intmin, _mm_min_pd(v_intmax, _mm_mul_pd(_mm_add_pd(v_Y0d, _mm_mul_pd(v_M3, v_x1)), v_W)));
+                v_x1 = _mm_add_pd(v_x1, v_2);
 
-            v_X1 = _mm_castps_si128(_mm_movelh_ps(_mm_castsi128_ps(_mm_cvtpd_epi32(v_fX0)),
-                _mm_castsi128_ps(_mm_cvtpd_epi32(v_fX1))));
-            v_Y1 = _mm_castps_si128(_mm_movelh_ps(_mm_castsi128_ps(_mm_cvtpd_epi32(v_fY0)),
-                _mm_castsi128_ps(_mm_cvtpd_epi32(v_fY1))));
-        }
+                v_X1 = _mm_castps_si128(_mm_movelh_ps(_mm_castsi128_ps(_mm_cvtpd_epi32(v_fX0)),
+                    _mm_castsi128_ps(_mm_cvtpd_epi32(v_fX1))));
+                v_Y1 = _mm_castps_si128(_mm_movelh_ps(_mm_castsi128_ps(_mm_cvtpd_epi32(v_fY0)),
+                    _mm_castsi128_ps(_mm_cvtpd_epi32(v_fY1))));
+            }
 
-        // 8-11
-        __m128i v_X2, v_Y2;
-        {
-            __m128d v_W = _mm_add_pd(_mm_mul_pd(v_M6, v_x1), v_W0);
-            v_W = _mm_andnot_pd(_mm_cmpeq_pd(v_W, v_zero), _mm_div_pd(v_its, v_W));
-            __m128d v_fX0 = _mm_max_pd(v_intmin, _mm_min_pd(v_intmax, _mm_mul_pd(_mm_add_pd(v_X0d, _mm_mul_pd(v_M0, v_x1)), v_W)));
-            __m128d v_fY0 = _mm_max_pd(v_intmin, _mm_min_pd(v_intmax, _mm_mul_pd(_mm_add_pd(v_Y0d, _mm_mul_pd(v_M3, v_x1)), v_W)));
-            v_x1 = _mm_add_pd(v_x1, v_2);
+            // 8-11
+            __m128i v_X2, v_Y2;
+            {
+                __m128d v_W = _mm_add_pd(_mm_mul_pd(v_M6, v_x1), v_W0);
+                v_W = _mm_andnot_pd(_mm_cmpeq_pd(v_W, v_zero), _mm_div_pd(v_its, v_W));
+                __m128d v_fX0 = _mm_max_pd(v_intmin, _mm_min_pd(v_intmax, _mm_mul_pd(_mm_add_pd(v_X0d, _mm_mul_pd(v_M0, v_x1)), v_W)));
+                __m128d v_fY0 = _mm_max_pd(v_intmin, _mm_min_pd(v_intmax, _mm_mul_pd(_mm_add_pd(v_Y0d, _mm_mul_pd(v_M3, v_x1)), v_W)));
+                v_x1 = _mm_add_pd(v_x1, v_2);
 
-            v_W = _mm_add_pd(_mm_mul_pd(v_M6, v_x1), v_W0);
-            v_W = _mm_andnot_pd(_mm_cmpeq_pd(v_W, v_zero), _mm_div_pd(v_its, v_W));
-            __m128d v_fX1 = _mm_max_pd(v_intmin, _mm_min_pd(v_intmax, _mm_mul_pd(_mm_add_pd(v_X0d, _mm_mul_pd(v_M0, v_x1)), v_W)));
-            __m128d v_fY1 = _mm_max_pd(v_intmin, _mm_min_pd(v_intmax, _mm_mul_pd(_mm_add_pd(v_Y0d, _mm_mul_pd(v_M3, v_x1)), v_W)));
-            v_x1 = _mm_add_pd(v_x1, v_2);
+                v_W = _mm_add_pd(_mm_mul_pd(v_M6, v_x1), v_W0);
+                v_W = _mm_andnot_pd(_mm_cmpeq_pd(v_W, v_zero), _mm_div_pd(v_its, v_W));
+                __m128d v_fX1 = _mm_max_pd(v_intmin, _mm_min_pd(v_intmax, _mm_mul_pd(_mm_add_pd(v_X0d, _mm_mul_pd(v_M0, v_x1)), v_W)));
+                __m128d v_fY1 = _mm_max_pd(v_intmin, _mm_min_pd(v_intmax, _mm_mul_pd(_mm_add_pd(v_Y0d, _mm_mul_pd(v_M3, v_x1)), v_W)));
+                v_x1 = _mm_add_pd(v_x1, v_2);
 
-            v_X2 = _mm_castps_si128(_mm_movelh_ps(_mm_castsi128_ps(_mm_cvtpd_epi32(v_fX0)),
-                _mm_castsi128_ps(_mm_cvtpd_epi32(v_fX1))));
-            v_Y2 = _mm_castps_si128(_mm_movelh_ps(_mm_castsi128_ps(_mm_cvtpd_epi32(v_fY0)),
-                _mm_castsi128_ps(_mm_cvtpd_epi32(v_fY1))));
-        }
+                v_X2 = _mm_castps_si128(_mm_movelh_ps(_mm_castsi128_ps(_mm_cvtpd_epi32(v_fX0)),
+                    _mm_castsi128_ps(_mm_cvtpd_epi32(v_fX1))));
+                v_Y2 = _mm_castps_si128(_mm_movelh_ps(_mm_castsi128_ps(_mm_cvtpd_epi32(v_fY0)),
+                    _mm_castsi128_ps(_mm_cvtpd_epi32(v_fY1))));
+            }
 
-        // 12-15
-        __m128i v_X3, v_Y3;
-        {
-            __m128d v_W = _mm_add_pd(_mm_mul_pd(v_M6, v_x1), v_W0);
-            v_W = _mm_andnot_pd(_mm_cmpeq_pd(v_W, v_zero), _mm_div_pd(v_its, v_W));
-            __m128d v_fX0 = _mm_max_pd(v_intmin, _mm_min_pd(v_intmax, _mm_mul_pd(_mm_add_pd(v_X0d, _mm_mul_pd(v_M0, v_x1)), v_W)));
-            __m128d v_fY0 = _mm_max_pd(v_intmin, _mm_min_pd(v_intmax, _mm_mul_pd(_mm_add_pd(v_Y0d, _mm_mul_pd(v_M3, v_x1)), v_W)));
-            v_x1 = _mm_add_pd(v_x1, v_2);
+            // 12-15
+            __m128i v_X3, v_Y3;
+            {
+                __m128d v_W = _mm_add_pd(_mm_mul_pd(v_M6, v_x1), v_W0);
+                v_W = _mm_andnot_pd(_mm_cmpeq_pd(v_W, v_zero), _mm_div_pd(v_its, v_W));
+                __m128d v_fX0 = _mm_max_pd(v_intmin, _mm_min_pd(v_intmax, _mm_mul_pd(_mm_add_pd(v_X0d, _mm_mul_pd(v_M0, v_x1)), v_W)));
+                __m128d v_fY0 = _mm_max_pd(v_intmin, _mm_min_pd(v_intmax, _mm_mul_pd(_mm_add_pd(v_Y0d, _mm_mul_pd(v_M3, v_x1)), v_W)));
+                v_x1 = _mm_add_pd(v_x1, v_2);
 
-            v_W = _mm_add_pd(_mm_mul_pd(v_M6, v_x1), v_W0);
-            v_W = _mm_andnot_pd(_mm_cmpeq_pd(v_W, v_zero), _mm_div_pd(v_its, v_W));
-            __m128d v_fX1 = _mm_max_pd(v_intmin, _mm_min_pd(v_intmax, _mm_mul_pd(_mm_add_pd(v_X0d, _mm_mul_pd(v_M0, v_x1)), v_W)));
-            __m128d v_fY1 = _mm_max_pd(v_intmin, _mm_min_pd(v_intmax, _mm_mul_pd(_mm_add_pd(v_Y0d, _mm_mul_pd(v_M3, v_x1)), v_W)));
-            v_x1 = _mm_add_pd(v_x1, v_2);
+                v_W = _mm_add_pd(_mm_mul_pd(v_M6, v_x1), v_W0);
+                v_W = _mm_andnot_pd(_mm_cmpeq_pd(v_W, v_zero), _mm_div_pd(v_its, v_W));
+                __m128d v_fX1 = _mm_max_pd(v_intmin, _mm_min_pd(v_intmax, _mm_mul_pd(_mm_add_pd(v_X0d, _mm_mul_pd(v_M0, v_x1)), v_W)));
+                __m128d v_fY1 = _mm_max_pd(v_intmin, _mm_min_pd(v_intmax, _mm_mul_pd(_mm_add_pd(v_Y0d, _mm_mul_pd(v_M3, v_x1)), v_W)));
+                v_x1 = _mm_add_pd(v_x1, v_2);
 
-            v_X3 = _mm_castps_si128(_mm_movelh_ps(_mm_castsi128_ps(_mm_cvtpd_epi32(v_fX0)),
-                _mm_castsi128_ps(_mm_cvtpd_epi32(v_fX1))));
-            v_Y3 = _mm_castps_si128(_mm_movelh_ps(_mm_castsi128_ps(_mm_cvtpd_epi32(v_fY0)),
-                _mm_castsi128_ps(_mm_cvtpd_epi32(v_fY1))));
-        }
+                v_X3 = _mm_castps_si128(_mm_movelh_ps(_mm_castsi128_ps(_mm_cvtpd_epi32(v_fX0)),
+                    _mm_castsi128_ps(_mm_cvtpd_epi32(v_fX1))));
+                v_Y3 = _mm_castps_si128(_mm_movelh_ps(_mm_castsi128_ps(_mm_cvtpd_epi32(v_fY0)),
+                    _mm_castsi128_ps(_mm_cvtpd_epi32(v_fY1))));
+            }
 
-        // store alpha
-        __m128i v_alpha0 = _mm_add_epi32(_mm_slli_epi32(_mm_and_si128(v_Y0, v_itsi1), INTER_BITS),
-            _mm_and_si128(v_X0, v_itsi1));
-        __m128i v_alpha1 = _mm_add_epi32(_mm_slli_epi32(_mm_and_si128(v_Y1, v_itsi1), INTER_BITS),
-            _mm_and_si128(v_X1, v_itsi1));
-        _mm_storeu_si128((__m128i *)(alpha + x1), _mm_packs_epi32(v_alpha0, v_alpha1));
+            // store alpha
+            __m128i v_alpha0 = _mm_add_epi32(_mm_slli_epi32(_mm_and_si128(v_Y0, v_itsi1), INTER_BITS),
+                _mm_and_si128(v_X0, v_itsi1));
+            __m128i v_alpha1 = _mm_add_epi32(_mm_slli_epi32(_mm_and_si128(v_Y1, v_itsi1), INTER_BITS),
+                _mm_and_si128(v_X1, v_itsi1));
+            _mm_storeu_si128((__m128i *)(alpha + x1), _mm_packs_epi32(v_alpha0, v_alpha1));
 
-        v_alpha0 = _mm_add_epi32(_mm_slli_epi32(_mm_and_si128(v_Y2, v_itsi1), INTER_BITS),
-            _mm_and_si128(v_X2, v_itsi1));
-        v_alpha1 = _mm_add_epi32(_mm_slli_epi32(_mm_and_si128(v_Y3, v_itsi1), INTER_BITS),
-            _mm_and_si128(v_X3, v_itsi1));
+            v_alpha0 = _mm_add_epi32(_mm_slli_epi32(_mm_and_si128(v_Y2, v_itsi1), INTER_BITS),
+                _mm_and_si128(v_X2, v_itsi1));
+            v_alpha1 = _mm_add_epi32(_mm_slli_epi32(_mm_and_si128(v_Y3, v_itsi1), INTER_BITS),
+                _mm_and_si128(v_X3, v_itsi1));
             _mm_storeu_si128((__m128i *)(alpha + x1 + 8), _mm_packs_epi32(v_alpha0, v_alpha1));
 
-        // convert to 16s
-        v_X0 = _mm_packs_epi32(_mm_srai_epi32(v_X0, INTER_BITS), _mm_srai_epi32(v_X1, INTER_BITS));
-        v_X1 = _mm_packs_epi32(_mm_srai_epi32(v_X2, INTER_BITS), _mm_srai_epi32(v_X3, INTER_BITS));
-        v_Y0 = _mm_packs_epi32(_mm_srai_epi32(v_Y0, INTER_BITS), _mm_srai_epi32(v_Y1, INTER_BITS));
-        v_Y1 = _mm_packs_epi32(_mm_srai_epi32(v_Y2, INTER_BITS), _mm_srai_epi32(v_Y3, INTER_BITS));
+            // convert to 16s
+            v_X0 = _mm_packs_epi32(_mm_srai_epi32(v_X0, INTER_BITS), _mm_srai_epi32(v_X1, INTER_BITS));
+            v_X1 = _mm_packs_epi32(_mm_srai_epi32(v_X2, INTER_BITS), _mm_srai_epi32(v_X3, INTER_BITS));
+            v_Y0 = _mm_packs_epi32(_mm_srai_epi32(v_Y0, INTER_BITS), _mm_srai_epi32(v_Y1, INTER_BITS));
+            v_Y1 = _mm_packs_epi32(_mm_srai_epi32(v_Y2, INTER_BITS), _mm_srai_epi32(v_Y3, INTER_BITS));
 
-        _mm_interleave_epi16(v_X0, v_X1, v_Y0, v_Y1);
+            _mm_interleave_epi16(v_X0, v_X1, v_Y0, v_Y1);
 
-        _mm_storeu_si128((__m128i *)(xy + x1 * 2), v_X0);
-        _mm_storeu_si128((__m128i *)(xy + x1 * 2 + 8), v_X1);
-        _mm_storeu_si128((__m128i *)(xy + x1 * 2 + 16), v_Y0);
-        _mm_storeu_si128((__m128i *)(xy + x1 * 2 + 24), v_Y1);
+            _mm_storeu_si128((__m128i *)(xy + x1 * 2), v_X0);
+            _mm_storeu_si128((__m128i *)(xy + x1 * 2 + 8), v_X1);
+            _mm_storeu_si128((__m128i *)(xy + x1 * 2 + 16), v_Y0);
+            _mm_storeu_si128((__m128i *)(xy + x1 * 2 + 24), v_Y1);
+        }
+        for (; x1 < bw; x1++)
+        {
+            double W = W0 + M[6] * x1;
+            W = W ? INTER_TAB_SIZE / W : 0;
+            double fX = std::max((double)INT_MIN, std::min((double)INT_MAX, (X0 + M[0] * x1)*W));
+            double fY = std::max((double)INT_MIN, std::min((double)INT_MAX, (Y0 + M[3] * x1)*W));
+            int X = saturate_cast<int>(fX);
+            int Y = saturate_cast<int>(fY);
+
+            xy[x1 * 2] = saturate_cast<short>(X >> INTER_BITS);
+            xy[x1 * 2 + 1] = saturate_cast<short>(Y >> INTER_BITS);
+            alpha[x1] = (short)((Y & (INTER_TAB_SIZE - 1))*INTER_TAB_SIZE +
+                (X & (INTER_TAB_SIZE - 1)));
+        }
     }
-    for (; x1 < bw; x1++)
-    {
-        double W = W0 + M[6] * x1;
-        W = W ? INTER_TAB_SIZE / W : 0;
-        double fX = std::max((double)INT_MIN, std::min((double)INT_MAX, (X0 + M[0] * x1)*W));
-        double fY = std::max((double)INT_MIN, std::min((double)INT_MAX, (Y0 + M[3] * x1)*W));
-        int X = saturate_cast<int>(fX);
-        int Y = saturate_cast<int>(fY);
+    virtual ~WarpPerspectiveLine_SSE4_Impl() CV_OVERRIDE {};
+};
 
-        xy[x1 * 2] = saturate_cast<short>(X >> INTER_BITS);
-        xy[x1 * 2 + 1] = saturate_cast<short>(Y >> INTER_BITS);
-        alpha[x1] = (short)((Y & (INTER_TAB_SIZE - 1))*INTER_TAB_SIZE +
-            (X & (INTER_TAB_SIZE - 1)));
-    }
+Ptr<WarpPerspectiveLine_SSE4> WarpPerspectiveLine_SSE4::getImpl(const double *M)
+{
+    return Ptr<WarpPerspectiveLine_SSE4>(new WarpPerspectiveLine_SSE4_Impl(M));
 }
 
+}
 }
 /* End of file. */


### PR DESCRIPTION
Convert ImgWarp from SSE SIMD to HAL - 2.8x faster on Power (VSX) and 15% speedup on x86.
