### PR TITLE
Fix #15343: stack overflow when converting two Mat_<> of different types.

### DIFF
--- a/modules/core/include/opencv2/core/mat.inl.hpp
+++ b/modules/core/include/opencv2/core/mat.inl.hpp
@@ -1809,7 +1809,7 @@ Mat_<_Tp> Mat_<_Tp>::cross(const Mat_& m) const
 template<typename _Tp> template<typename T2> inline
 Mat_<_Tp>::operator Mat_<T2>() const
 {
-    return Mat_<T2>(*this);
+    return Mat_<T2>(static_cast<const Mat&>(*this));
 }
 
 template<typename _Tp> inline

--- a/modules/core/include/opencv2/core/mat.inl.hpp
+++ b/modules/core/include/opencv2/core/mat.inl.hpp
@@ -2103,7 +2103,7 @@ void Mat_<_Tp>::forEach(const Functor& operation) const {
 
 template<typename _Tp> inline
 Mat_<_Tp>::Mat_(Mat_&& m)
-    : Mat(m)
+    : Mat(std::move(m))
 {
 }
 
@@ -2119,7 +2119,7 @@ Mat_<_Tp>::Mat_(Mat&& m)
     : Mat()
 {
     flags = (flags & ~CV_MAT_TYPE_MASK) | traits::Type<_Tp>::value;
-    *this = m;
+    *this = std::move(m);
 }
 
 template<typename _Tp> inline


### PR DESCRIPTION
resolves #15343

Additionally two move constructors of Mat_<T> are changed to properly move.

<cut/>

```
buildworker:Custom=linux-1
docker_image:Custom=ubuntu-clang:18.04
allow_multiple_commits=1
```