### PR TITLE
libpng: update check for VSX enablement

### DIFF
--- a/3rdparty/libpng/CMakeLists.txt
+++ b/3rdparty/libpng/CMakeLists.txt
@@ -47,7 +47,9 @@ if(";${CPU_BASELINE_FINAL};" MATCHES "SSE2"
 endif()
 
 if(PPC64LE OR PPC64)
-  if(ENABLE_VSX AND NOT PPC64)
+  # VSX3 features are backwards compatible
+  if(";${CPU_BASELINE_FINAL};" MATCHES "VSX.*"
+      AND NOT PPC64)
     list(APPEND lib_srcs powerpc/powerpc_init.c powerpc/filter_vsx_intrinsics.c)
     add_definitions(-DPNG_POWERPC_VSX_OPT=2)
   else()


### PR DESCRIPTION
The deprecated flag ENABLE_VSX should not be used to enable this
feature. Instead, use the baseline cpu feature set to determine.
