### PR TITLE
Adopted detection of Inference Engine

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1580,19 +1580,22 @@ endif()
 
 if(WITH_INF_ENGINE OR INF_ENGINE_TARGET)
   if(INF_ENGINE_TARGET)
+    list(GET INF_ENGINE_TARGET 0 ie_target)
     set(__msg "YES (${INF_ENGINE_RELEASE} / ${INF_ENGINE_VERSION})")
-    get_target_property(_lib ${INF_ENGINE_TARGET} IMPORTED_LOCATION)
-    get_target_property(_lib_imp_rel ${INF_ENGINE_TARGET} IMPORTED_IMPLIB_RELEASE)
-    get_target_property(_lib_imp_dbg ${INF_ENGINE_TARGET} IMPORTED_IMPLIB_DEBUG)
-    get_target_property(_lib_rel ${INF_ENGINE_TARGET} IMPORTED_LOCATION_RELEASE)
-    get_target_property(_lib_dbg ${INF_ENGINE_TARGET} IMPORTED_LOCATION_DEBUG)
+    get_target_property(_lib ${ie_target} IMPORTED_LOCATION)
+    get_target_property(_lib_imp_rel ${ie_target} IMPORTED_IMPLIB_RELEASE)
+    get_target_property(_lib_imp_dbg ${ie_target} IMPORTED_IMPLIB_DEBUG)
+    get_target_property(_lib_rel ${ie_target} IMPORTED_LOCATION_RELEASE)
+    get_target_property(_lib_dbg ${ie_target} IMPORTED_LOCATION_DEBUG)
     ocv_build_features_string(_lib
       IF _lib THEN "${_lib}"
       IF _lib_imp_rel AND _lib_imp_dbg THEN "${_lib_imp_rel} / ${_lib_imp_dbg}"
       IF _lib_rel AND _lib_dbg THEN "${_lib_rel} / ${_lib_dbg}"
+      IF _lib_rel  THEN "${_lib_rel}"
+      IF _lib_dbg  THEN "${_lib_dbg}"
       ELSE "unknown"
     )
-    get_target_property(_inc ${INF_ENGINE_TARGET} INTERFACE_INCLUDE_DIRECTORIES)
+    get_target_property(_inc ${ie_target} INTERFACE_INCLUDE_DIRECTORIES)
     status("    Inference Engine:" "${__msg}")
     status("                libs:" "${_lib}")
     status("            includes:" "${_inc}")

--- a/cmake/OpenCVDetectInferenceEngine.cmake
+++ b/cmake/OpenCVDetectInferenceEngine.cmake
@@ -52,7 +52,7 @@ endfunction()
 
 find_package(InferenceEngine QUIET)
 if(InferenceEngine_FOUND)
-  set(INF_ENGINE_TARGET IE::inference_engine)
+  set(INF_ENGINE_TARGET ${InferenceEngine_LIBRARIES})
   set(INF_ENGINE_VERSION "${InferenceEngine_VERSION}" CACHE STRING "")
   message(STATUS "Detected InferenceEngine: cmake package")
 endif()


### PR DESCRIPTION
Adopted detection of Inference Engine targets for case when Inference Engine has more than 1 public library

<cut/>

```
force_builders=Custom,Custom Win,Custom Mac
build_image:Custom=ubuntu-openvino-2019r2.0:16.04
build_image:Custom Win=openvino-2019r2.0
build_image:Custom Mac=openvino-2019r2.0

test_modules:Custom=dnn,python2,python3,java
test_modules:Custom Win=dnn,python2,python3,java
test_modules:Custom Mac=dnn,python2,python3,java

buildworker:Custom=linux-1
test_opencl:Custom=ON
test_bigdata:Custom=1
test_filter:Custom=*
```
