### PR TITLE
Document usage of accuracy tests model

### DIFF
--- a/modules/gapi/test/common/gapi_core_tests.hpp
+++ b/modules/gapi/test/common/gapi_core_tests.hpp
@@ -62,8 +62,24 @@ inline std::ostream& operator<<(std::ostream& os, bitwiseOp op)
     return os;
 }
 
+// Create new value-parameterized test fixture:
+// MathOpTest - fixture name
+// initMatsRandU - function that is used to initialize input/output data
+// FIXTURE_API(mathOp,bool,double,bool) - test-specific parameters (types)
+// 4 - number of test-specific parameters
+// opType, testWithScalar, scale, doReverseOp - test-spcific parameters (names)
+//
+// We get:
+// 1. Default parameters: int type, cv::Size sz, int dtype, getCompileArgs() function
+//      - available in test body
+// 2. Input/output matrices will be initialized by initMatsRandU (in this fixture)
+// 3. Specific parameters: opType, testWithScalar, scale, doReverseOp of correponding types
+//      - created (and initialized) automatically
+//      - available in test body
+// Note: all parameter _values_ (e.g. type CV_8UC3) are set via INSTANTIATE_TEST_CASE_P macro
 GAPI_TEST_FIXTURE(MathOpTest, initMatsRandU, FIXTURE_API(mathOp,bool,double,bool), 4,
     opType, testWithScalar, scale, doReverseOp)
+// No specific parameters for MulDoubleTest, so "fixture API" is empty - <>
 GAPI_TEST_FIXTURE(MulDoubleTest, initMatrixRandU, <>, 0)
 GAPI_TEST_FIXTURE(DivTest, initMatrixRandU, <>, 0)
 GAPI_TEST_FIXTURE(DivCTest, initMatrixRandU, <>, 0)

--- a/modules/gapi/test/common/gapi_imgproc_tests.hpp
+++ b/modules/gapi/test/common/gapi_imgproc_tests.hpp
@@ -14,6 +14,21 @@
 
 namespace opencv_test
 {
+// Create new value-parameterized test fixture:
+// Filter2DTest - fixture name
+// initMatrixRandN - function that is used to initialize input/output data
+// FIXTURE_API(CompareMats,int,int) - test-specific parameters (types)
+// 3 - number of test-specific parameters
+// cmpF, kernSize, borderType - test-spcific parameters (names)
+//
+// We get:
+// 1. Default parameters: int type, cv::Size sz, int dtype, getCompileArgs() function
+//      - available in test body
+// 2. Input/output matrices will be initialized by initMatrixRandN (in this fixture)
+// 3. Specific parameters: cmpF, kernSize, borderType of correponding types
+//      - created (and initialized) automatically
+//      - available in test body
+// Note: all parameter _values_ (e.g. type CV_8UC3) are set via INSTANTIATE_TEST_CASE_P macro
 GAPI_TEST_FIXTURE(Filter2DTest, initMatrixRandN, FIXTURE_API(CompareMats,int,int), 3,
     cmpF, kernSize, borderType)
 GAPI_TEST_FIXTURE(BoxFilterTest, initMatrixRandN, FIXTURE_API(CompareMats,int,int), 3,

--- a/modules/gapi/test/common/gapi_operators_tests.hpp
+++ b/modules/gapi/test/common/gapi_operators_tests.hpp
@@ -184,6 +184,21 @@ g_api_ocv_pair_mat_mat opXor = {std::string{"operator^"},
 
 } // anonymous namespace
 
+// Create new value-parameterized test fixture:
+// MathOperatorMatScalarTest - fixture name
+// initMatsRandU - function that is used to initialize input/output data
+// FIXTURE_API(CompareMats, g_api_ocv_pair_mat_scalar) - test-specific parameters (types)
+// 2 - number of test-specific parameters
+// cmpF, op - test-spcific parameters (names)
+//
+// We get:
+// 1. Default parameters: int type, cv::Size sz, int dtype, getCompileArgs() function
+//      - available in test body
+// 2. Input/output matrices will be initialized by initMatsRandU (in this fixture)
+// 3. Specific parameters: cmpF, op of correponding types
+//      - created (and initialized) automatically
+//      - available in test body
+// Note: all parameter _values_ (e.g. type CV_8UC3) are set via INSTANTIATE_TEST_CASE_P macro
 GAPI_TEST_FIXTURE(MathOperatorMatScalarTest, initMatsRandU,
     FIXTURE_API(CompareMats, g_api_ocv_pair_mat_scalar), 2, cmpF, op)
 GAPI_TEST_FIXTURE(MathOperatorMatMatTest, initMatsRandU,


### PR DESCRIPTION
### This pullrequest 

extends documentation on how to use new accuracy tests model (in *.hpp files with test fixtures declaration)
