### PR TITLE
try fix memory leakage when creating threads(under linux)

### DIFF
--- a/modules/core/include/opencv2/core/utils/trace.private.hpp
+++ b/modules/core/include/opencv2/core/utils/trace.private.hpp
@@ -321,6 +321,20 @@ struct TraceManagerThreadLocal
     inline int getCurrentDepth() const { return (int)stack.size(); }
 };
 
+} // namespace utils
+} // namespace trace
+} // namespace details
+
+// TODO: this cause memory leakage when tracing
+template <>
+struct TLSDeleter<cv::utils::trace::details::TraceManagerThreadLocal> {
+    static void delete_it(void*) {}
+};
+
+namespace utils {
+namespace trace {
+namespace details {
+
 class CV_EXPORTS TraceManager
 {
 public:


### PR DESCRIPTION
This pr tries to solve memory leakage when using threads. This may relate to issue #9745 and #12194 . Ideally, it should work for both linux and windows, however, my observation is that is solves the problem under linux (but I still have a case in my mind which leaks memory but not solved by this issue), and under windows it now leaks slower than #9745 described.

### This pullrequest changes

This pr basically does two things:
1. Remember to delete each thread's ThreadData when thread exits. Ths windows version has already done this in DllMain, I add that for the linux version in pthread_key_create.
2. Remember to delete ThreadData's slots when thread exits. The windows version used not to do this, and I add this for both the windows and linux version. To properly delete a void*, I have to add a deleter pointer for it.

If I'm right, the following code won't leak under linux, and leaks slower than before under windows.
https://gist.github.com/lijinpei/f2f7ace623a76454f1381646a9ebac51