### PR TITLE
Disambiguate vecpopcnt for (u)dword2.

### DIFF
--- a/modules/core/include/opencv2/core/vsx_utils.hpp
+++ b/modules/core/include/opencv2/core/vsx_utils.hpp
@@ -363,10 +363,12 @@ VSX_FINLINE(Tvec) vec_popcntu(const Tvec2& a)  \
 VSX_IMPL_POPCNTU(vec_uchar16, vec_char16, vec_uchar16_c);
 VSX_IMPL_POPCNTU(vec_ushort8, vec_short8, vec_ushort8_c);
 VSX_IMPL_POPCNTU(vec_uint4,   vec_int4,   vec_uint4_c);
+VSX_IMPL_POPCNTU(vec_udword2, vec_dword2, vec_udword2_c);
 // redirect unsigned types
 VSX_REDIRECT_1RG(vec_uchar16, vec_uchar16, vec_popcntu, vec_popcnt)
 VSX_REDIRECT_1RG(vec_ushort8, vec_ushort8, vec_popcntu, vec_popcnt)
 VSX_REDIRECT_1RG(vec_uint4,   vec_uint4,   vec_popcntu, vec_popcnt)
+VSX_REDIRECT_1RG(vec_udword2, vec_udword2, vec_popcntu, vec_popcnt)
 
 // converts between single and double precision
 VSX_REDIRECT_1RG(vec_float4,  vec_double2, vec_cvfo, __builtin_vsx_xvcvdpsp)


### PR DESCRIPTION
resolves #15411

### This pullrequest changes

This disambiguates vec_popcnt for the [v_uint64x2](https://github.com/opencv/opencv/blob/master/modules/core/include/opencv2/core/hal/intrin_vsx.hpp#L155) and [v_int64x2](https://github.com/opencv/opencv/blob/master/modules/core/include/opencv2/core/hal/intrin_vsx.hpp#L173) structs in their respective v_popcount overloads ([v_uint64x2](https://github.com/opencv/opencv/blob/master/modules/core/include/opencv2/core/hal/intrin_vsx.hpp#L840), [v_int64x2](https://github.com/opencv/opencv/blob/master/modules/core/include/opencv2/core/hal/intrin_vsx.hpp#L842)) by reusing existing macros to provide an overload for `vec_udword2`.

```
force_builders=Custom
buildworker:Custom=linux-1,linux-2,linux-4
build_image:Custom=powerpc64le
```
Extra PowerPC CI: https://ocv-power.imavr.com/#/opencv_pullrequests