### PR TITLE
Use commonly supported instruction mnemonic.

### DIFF
--- a/modules/core/include/opencv2/core/fast_math.hpp
+++ b/modules/core/include/opencv2/core/fast_math.hpp
@@ -102,7 +102,7 @@
     #define CV_INLINE_ROUND_DBL(value) \
         int out; \
         double temp; \
-        __asm__( "fctiw %[temp],%[in]\n\tmffprwz %[out],%[temp]\n\t" : [out] "=r" (out), [temp] "=d" (temp) : [in] "d" ((double)(value)) : ); \
+        __asm__( "fctiw %[temp],%[in]\n\tmfvsrwz %[out],%[temp]\n\t" : [out] "=r" (out), [temp] "=d" (temp) : [in] "d" ((double)(value)) : ); \
         return out;
 
     // FP32 also works with FP64 routine above


### PR DESCRIPTION
resolves #15413 

### This pullrequest changes
This alters inline assembly to use an instruction mnemonic commonly supported by both gcc and clang. This does not alter functionality, only enables the file to be compiled. See explanation in #15413 for references to the ISA manual.

```
force_builders=Custom
buildworker:Custom=linux-1,linux-2,linux-4
build_image:Custom=powerpc64le
```
Extra PowerPC CI: https://ocv-power.imavr.com/#/opencv_pullrequests