### PR TITLE
WIP: G-API: Internal IE flag check in public headers issue

### DIFF
--- a/modules/gapi/CMakeLists.txt
+++ b/modules/gapi/CMakeLists.txt
@@ -28,6 +28,8 @@ file(GLOB gapi_ext_hdrs
     "${CMAKE_CURRENT_LIST_DIR}/include/opencv2/${name}/ocl/*.hpp"
     "${CMAKE_CURRENT_LIST_DIR}/include/opencv2/${name}/fluid/*.hpp"
     "${CMAKE_CURRENT_LIST_DIR}/include/opencv2/${name}/own/*.hpp"
+    "${CMAKE_CURRENT_LIST_DIR}/include/opencv2/${name}/infer/*.hpp"
+    "${CMAKE_CURRENT_LIST_DIR}/include/opencv2/${name}/infer/ie/*.hpp"
     )
 
 set(gapi_srcs

--- a/modules/gapi/CMakeLists.txt
+++ b/modules/gapi/CMakeLists.txt
@@ -29,7 +29,6 @@ file(GLOB gapi_ext_hdrs
     "${CMAKE_CURRENT_LIST_DIR}/include/opencv2/${name}/fluid/*.hpp"
     "${CMAKE_CURRENT_LIST_DIR}/include/opencv2/${name}/own/*.hpp"
     "${CMAKE_CURRENT_LIST_DIR}/include/opencv2/${name}/infer/*.hpp"
-    "${CMAKE_CURRENT_LIST_DIR}/include/opencv2/${name}/infer/ie/*.hpp"
     )
 
 set(gapi_srcs

--- a/modules/gapi/include/opencv2/gapi/infer/ie.hpp
+++ b/modules/gapi/include/opencv2/gapi/infer/ie.hpp
@@ -7,8 +7,6 @@
 #ifndef OPENCV_GAPI_INFER_IE_HPP
 #define OPENCV_GAPI_INFER_IE_HPP
 
-#ifdef HAVE_INF_ENGINE
-
 #include <unordered_map>
 #include <string>
 #include <array>
@@ -16,6 +14,9 @@
 
 #include <opencv2/gapi/opencv_includes.hpp>
 #include <opencv2/gapi/util/any.hpp>
+
+#include <opencv2/core/cvdef.h>     // GAPI_EXPORTS
+#include <opencv2/gapi/gkernel.hpp> // GKernelPackage
 
 namespace cv {
 namespace gapi {
@@ -100,7 +101,5 @@ protected:
 } // namespace ie
 } // namespace gapi
 } // namespace cv
-
-#endif // HAVE_INF_ENGINE
 
 #endif // OPENCV_GAPI_INFER_HPP

--- a/modules/gapi/include/opencv2/gapi/infer/ie/util.hpp
+++ b/modules/gapi/include/opencv2/gapi/infer/ie/util.hpp
@@ -7,13 +7,14 @@
 #ifndef OPENCV_GAPI_INFER_IE_UTIL_HPP
 #define OPENCV_GAPI_INFER_IE_UTIL_HPP
 
-#ifdef HAVE_INF_ENGINE
-
 // NOTE: This file is not included by default in infer/ie.hpp
 // and won't be. infer/ie.hpp doesn't depend on IE headers itself.
 // This file does -- so needs to be included separately by those who care.
 
 #include "inference_engine.hpp"
+
+#include <opencv2/core/cvdef.h>     // GAPI_EXPORTS
+#include <opencv2/gapi/gkernel.hpp> // GKernelPackage
 
 namespace cv {
 namespace gapi {
@@ -27,5 +28,4 @@ GAPI_EXPORTS InferenceEngine::Blob::Ptr to_ie(cv::Mat &blob);
 
 }}}}
 
-#endif // HAVE_INF_ENGINE
 #endif // OPENCV_GAPI_INFER_IE_UTIL_HPP

--- a/modules/gapi/src/backends/ie/giebackend.cpp
+++ b/modules/gapi/src/backends/ie/giebackend.cpp
@@ -28,12 +28,12 @@
 #include <opencv2/gapi/gtype_traits.hpp>
 
 #include <opencv2/gapi/infer.hpp>
-#include <opencv2/gapi/infer/ie/util.hpp>
 
 #include "compiler/gobjref.hpp"
 #include "compiler/gmodel.hpp"
 
 #include "backends/ie/giebackend.hpp"
+#include "backends/ie/util.hpp"
 
 #include "api/gbackend_priv.hpp" // FIXME: Make it part of Backend SDK!
 

--- a/modules/gapi/src/backends/ie/util.hpp
+++ b/modules/gapi/src/backends/ie/util.hpp
@@ -7,6 +7,8 @@
 #ifndef OPENCV_GAPI_INFER_IE_UTIL_HPP
 #define OPENCV_GAPI_INFER_IE_UTIL_HPP
 
+#ifdef HAVE_INF_ENGINE
+
 // NOTE: This file is not included by default in infer/ie.hpp
 // and won't be. infer/ie.hpp doesn't depend on IE headers itself.
 // This file does -- so needs to be included separately by those who care.
@@ -27,5 +29,7 @@ GAPI_EXPORTS cv::Mat to_ocv(InferenceEngine::Blob::Ptr blob);
 GAPI_EXPORTS InferenceEngine::Blob::Ptr to_ie(cv::Mat &blob);
 
 }}}}
+
+#endif //HAVE_INF_ENGINE
 
 #endif // OPENCV_GAPI_INFER_IE_UTIL_HPP

--- a/modules/gapi/test/infer/gapi_infer_ie_test.cpp
+++ b/modules/gapi/test/infer/gapi_infer_ie_test.cpp
@@ -35,7 +35,8 @@
 #include <ade/util/iota_range.hpp>
 
 #include <opencv2/gapi/infer/ie.hpp>
-#include <opencv2/gapi/infer/ie/util.hpp>
+
+#include "backends/ie/util.hpp"
 
 namespace opencv_test
 {


### PR DESCRIPTION
<!-- Please use this line to close one or multiple issues when this pullrequest gets merged
You can add another line right under the first one:
resolves #1234
resolves #1235
-->

### This pullrequest changes

<!-- Please describe what your pullrequest is changing -->
- HAVE_INF_ENGINE flag check in headers "infer/ie.hpp" and "infer/ie/util.hpp" is deleted
- headers in "infer/" and "infer/ie/" folders are included into gapi_ext_hdrs;
+ because of that a few #includes are required in the headers

OpenCV public API should not have features-based conditional compilation in general (because these internal flags are not available in user apps). Instead of using such condoitions, user should add checks into their app.

Also the headers for G-API inference should be put into gapi_ext_hdrs CMake varaible