### PR TITLE
removed tegra optimization

### DIFF
--- a/modules/imgproc/src/median_blur.dispatch.cpp
+++ b/modules/imgproc/src/median_blur.dispatch.cpp
@@ -303,11 +303,6 @@ void medianBlur( InputArray _src0, OutputArray _dst, int ksize )
 
     //CV_IPP_RUN_FAST(ipp_medianFilter(src0, dst, ksize));
 
-#ifdef HAVE_TEGRA_OPTIMIZATION
-    if (tegra::useTegra() && tegra::medianBlur(src0, dst, ksize))
-        return;
-#endif
-
     CV_CPU_DISPATCH(medianBlur, (src0, dst, ksize),
         CV_CPU_DISPATCH_MODES_ALL);
 }


### PR DESCRIPTION
### This pullrequest changes
The https://github.com/opencv/opencv/commit/5b17a60dde5cb7706bc3b7f6caeb2dcb46850259 removed tegra optimization for OpenCV 4.x. But, I found that tegra optimization remains in master branch. So, I removed this code.
