### PR TITLE
Adding all possible data type interactions to the perf tests since some use SIMD acceleration and others do not.

### DIFF
--- a/modules/imgproc/perf/perf_integral.cpp
+++ b/modules/imgproc/perf/perf_integral.cpp
@@ -6,19 +6,19 @@
 namespace opencv_test {
 
 enum PerfSqMatDepth{
-    CV_32S32S = 0,
-    CV_32S32F,
-    CV_32S64F,
-    CV_32F32F,
-    CV_32F64F,
-    CV_64F64F};
+    SZ_32S32S = 0,
+    SZ_32S32F,
+    SZ_32S64F,
+    SZ_32F32F,
+    SZ_32F64F,
+    SZ_64F64F};
 
-CV_ENUM(SqSizes, CV_32S32S, CV_32S32F, CV_32S64F, CV_32F32F, CV_32F64F, CV_64F64F);
+CV_ENUM(IntegralOutputDepths, SZ_32S32S, SZ_32S32F, SZ_32S64F, SZ_32F32F, SZ_32F64F, SZ_64F64F);
 
 typedef tuple<Size, MatType, MatDepth> Size_MatType_OutMatDepth_t;
 typedef perf::TestBaseWithParam<Size_MatType_OutMatDepth_t> Size_MatType_OutMatDepth;
 
-typedef tuple<Size, MatType, SqSizes> Size_MatType_OutMatDepthArray_t;
+typedef tuple<Size, MatType, IntegralOutputDepths> Size_MatType_OutMatDepthArray_t;
 typedef perf::TestBaseWithParam<Size_MatType_OutMatDepthArray_t> Size_MatType_OutMatDepthArray;
 
 PERF_TEST_P(Size_MatType_OutMatDepth, integral,
@@ -73,7 +73,7 @@ PERF_TEST_P(Size_MatType_OutMatDepthArray, DISABLED_integral_sqsum_full,
             testing::Combine(
                 testing::Values(TYPICAL_MAT_SIZES),
                 testing::Values(CV_8UC1, CV_8UC2, CV_8UC3, CV_8UC4),
-                testing::Values(0,1,2,3,4,5)
+                testing::Values(SZ_32S32S,SZ_32S32F,SZ_32S64F,SZ_32F32F,SZ_32F64F,SZ_64F64F)
                 )
             )
 {
@@ -92,8 +92,8 @@ PERF_TEST_P(Size_MatType_OutMatDepthArray, DISABLED_integral_sqsum_full,
 
     TEST_CYCLE() integral(src, sum, sqsum, sdepth, sqdepth);
 
-    SANITY_CHECK(sum, 1e-6);
-    SANITY_CHECK(sqsum, 1e-6);
+    SANITY_CHECK_NOTHING();
+    SANITY_CHECK_NOTHING();
 
 }
 

--- a/modules/imgproc/perf/perf_integral.cpp
+++ b/modules/imgproc/perf/perf_integral.cpp
@@ -43,9 +43,33 @@ PERF_TEST_P(Size_MatType_OutMatDepth, integral,
     SANITY_CHECK(sum, 1e-6);
 }
 
+PERF_TEST_P(Size_MatType_OutMatDepth, integral_sqsum,
+                testing::Combine(
+                    testing::Values(TYPICAL_MAT_SIZES),
+                    testing::Values(CV_8UC1, CV_8UC2, CV_8UC3, CV_8UC4),
+                    testing::Values(CV_32S, CV_32F, CV_64F)
+                    )
+        )
+{
+    Size sz = get<0>(GetParam());
+    int matType = get<1>(GetParam());
+    int sdepth = get<2>(GetParam());
+
+    Mat src(sz, matType);
+    Mat sum(sz, sdepth);
+    Mat sqsum(sz, sdepth);
+
+    declare.in(src, WARMUP_RNG).out(sum, sqsum);
+    declare.time(100);
+
+    TEST_CYCLE() integral(src, sum, sqsum, sdepth);
+
+    SANITY_CHECK(sum, 1e-6);
+    SANITY_CHECK(sqsum, 1e-6);
+}
 
 int vals[6][2] = {{CV_32S, CV_32S}, {CV_32S, CV_32F}, {CV_32S, CV_64F}, {CV_32F, CV_32F}, {CV_32F, CV_64F}, {CV_64F, CV_64F}};
-PERF_TEST_P(Size_MatType_OutMatDepthArray, integral_sqsum,
+PERF_TEST_P(Size_MatType_OutMatDepthArray, DISABLED_integral_sqsum_full,
             testing::Combine(
                 testing::Values(TYPICAL_MAT_SIZES),
                 testing::Values(CV_8UC1, CV_8UC2, CV_8UC3, CV_8UC4),

--- a/modules/imgproc/perf/perf_integral.cpp
+++ b/modules/imgproc/perf/perf_integral.cpp
@@ -5,8 +5,21 @@
 
 namespace opencv_test {
 
+enum PerfSqMatDepth{
+    CV_32S32S = 0,
+    CV_32S32F,
+    CV_32S64F,
+    CV_32F32F,
+    CV_32F64F,
+    CV_64F64F};
+
+CV_ENUM(SqSizes, CV_32S32S, CV_32S32F, CV_32S64F, CV_32F32F, CV_32F64F, CV_64F64F);
+
 typedef tuple<Size, MatType, MatDepth> Size_MatType_OutMatDepth_t;
 typedef perf::TestBaseWithParam<Size_MatType_OutMatDepth_t> Size_MatType_OutMatDepth;
+
+typedef tuple<Size, MatType, SqSizes> Size_MatType_OutMatDepthArray_t;
+typedef perf::TestBaseWithParam<Size_MatType_OutMatDepthArray_t> Size_MatType_OutMatDepthArray;
 
 PERF_TEST_P(Size_MatType_OutMatDepth, integral,
             testing::Combine(
@@ -30,29 +43,34 @@ PERF_TEST_P(Size_MatType_OutMatDepth, integral,
     SANITY_CHECK(sum, 1e-6);
 }
 
-PERF_TEST_P(Size_MatType_OutMatDepth, integral_sqsum,
+
+int vals[6][2] = {{CV_32S, CV_32S}, {CV_32S, CV_32F}, {CV_32S, CV_64F}, {CV_32F, CV_32F}, {CV_32F, CV_64F}, {CV_64F, CV_64F}};
+PERF_TEST_P(Size_MatType_OutMatDepthArray, integral_sqsum,
             testing::Combine(
                 testing::Values(TYPICAL_MAT_SIZES),
                 testing::Values(CV_8UC1, CV_8UC2, CV_8UC3, CV_8UC4),
-                testing::Values(CV_32S, CV_32F, CV_64F)
+                testing::Values(0,1,2,3,4,5)
                 )
             )
 {
     Size sz = get<0>(GetParam());
     int matType = get<1>(GetParam());
-    int sdepth = get<2>(GetParam());
+    int *sizes = (int *)vals[get<2>(GetParam())];
+    int sdepth = sizes[0];
+    int sqdepth = sizes[1];
 
     Mat src(sz, matType);
     Mat sum(sz, sdepth);
-    Mat sqsum(sz, sdepth);
+    Mat sqsum(sz, sqdepth);
 
     declare.in(src, WARMUP_RNG).out(sum, sqsum);
     declare.time(100);
 
-    TEST_CYCLE() integral(src, sum, sqsum, sdepth);
+    TEST_CYCLE() integral(src, sum, sqsum, sdepth, sqdepth);
 
     SANITY_CHECK(sum, 1e-6);
     SANITY_CHECK(sqsum, 1e-6);
+
 }
 
 PERF_TEST_P( Size_MatType_OutMatDepth, integral_sqsum_tilted,

--- a/modules/imgproc/perf/perf_integral.cpp
+++ b/modules/imgproc/perf/perf_integral.cpp
@@ -6,14 +6,16 @@
 namespace opencv_test {
 
 enum PerfSqMatDepth{
-    SZ_32S32S = 0,
-    SZ_32S32F,
-    SZ_32S64F,
-    SZ_32F32F,
-    SZ_32F64F,
-    SZ_64F64F};
+    DEPTH_32S_32S = 0,
+    DEPTH_32S_32F,
+    DEPTH_32S_64F,
+    DEPTH_32F_32F,
+    DEPTH_32F_64F,
+    DEPTH_64F_64F};
 
-CV_ENUM(IntegralOutputDepths, SZ_32S32S, SZ_32S32F, SZ_32S64F, SZ_32F32F, SZ_32F64F, SZ_64F64F);
+CV_ENUM(IntegralOutputDepths, DEPTH_32S_32S, DEPTH_32S_32F, DEPTH_32S_64F, DEPTH_32F_32F, DEPTH_32F_64F, DEPTH_64F_64F);
+
+static int extraOutputDepths[6][2] = {{CV_32S, CV_32S}, {CV_32S, CV_32F}, {CV_32S, CV_64F}, {CV_32F, CV_32F}, {CV_32F, CV_64F}, {CV_64F, CV_64F}};
 
 typedef tuple<Size, MatType, MatDepth> Size_MatType_OutMatDepth_t;
 typedef perf::TestBaseWithParam<Size_MatType_OutMatDepth_t> Size_MatType_OutMatDepth;
@@ -44,12 +46,12 @@ PERF_TEST_P(Size_MatType_OutMatDepth, integral,
 }
 
 PERF_TEST_P(Size_MatType_OutMatDepth, integral_sqsum,
-                testing::Combine(
-                    testing::Values(TYPICAL_MAT_SIZES),
-                    testing::Values(CV_8UC1, CV_8UC2, CV_8UC3, CV_8UC4),
-                    testing::Values(CV_32S, CV_32F, CV_64F)
-                    )
-        )
+            testing::Combine(
+                testing::Values(TYPICAL_MAT_SIZES),
+                testing::Values(CV_8UC1, CV_8UC2, CV_8UC3, CV_8UC4),
+                testing::Values(CV_32S, CV_32F, CV_64F)
+                )
+            )
 {
     Size sz = get<0>(GetParam());
     int matType = get<1>(GetParam());
@@ -68,20 +70,19 @@ PERF_TEST_P(Size_MatType_OutMatDepth, integral_sqsum,
     SANITY_CHECK(sqsum, 1e-6);
 }
 
-int vals[6][2] = {{CV_32S, CV_32S}, {CV_32S, CV_32F}, {CV_32S, CV_64F}, {CV_32F, CV_32F}, {CV_32F, CV_64F}, {CV_64F, CV_64F}};
 PERF_TEST_P(Size_MatType_OutMatDepthArray, DISABLED_integral_sqsum_full,
             testing::Combine(
                 testing::Values(TYPICAL_MAT_SIZES),
                 testing::Values(CV_8UC1, CV_8UC2, CV_8UC3, CV_8UC4),
-                testing::Values(SZ_32S32S,SZ_32S32F,SZ_32S64F,SZ_32F32F,SZ_32F64F,SZ_64F64F)
+                testing::Values(DEPTH_32S_32S, DEPTH_32S_32F, DEPTH_32S_64F, DEPTH_32F_32F, DEPTH_32F_64F, DEPTH_64F_64F)
                 )
             )
 {
     Size sz = get<0>(GetParam());
     int matType = get<1>(GetParam());
-    int *sizes = (int *)vals[get<2>(GetParam())];
-    int sdepth = sizes[0];
-    int sqdepth = sizes[1];
+    int *outputDepths = (int *)extraOutputDepths[get<2>(GetParam())];
+    int sdepth = outputDepths[0];
+    int sqdepth = outputDepths[1];
 
     Mat src(sz, matType);
     Mat sum(sz, sdepth);
@@ -93,8 +94,6 @@ PERF_TEST_P(Size_MatType_OutMatDepthArray, DISABLED_integral_sqsum_full,
     TEST_CYCLE() integral(src, sum, sqsum, sdepth, sqdepth);
 
     SANITY_CHECK_NOTHING();
-    SANITY_CHECK_NOTHING();
-
 }
 
 PERF_TEST_P( Size_MatType_OutMatDepth, integral_sqsum_tilted,


### PR DESCRIPTION
resolves #15439

### This pullrequest changes

This PR is changing modules/imgproc/perf/perf_integral.cpp if you look at sumpixels.cpp there are several possible combinations of matrix sizes for the integral function. The performance tests do not cover all possibilities even with some of them being optimised with HAL instructions so it's impossible to analyse improvements made for those combinations.