### PR TITLE
cmake: download tries, customizable download parameters

### DIFF
--- a/cmake/OpenCVDownload.cmake
+++ b/cmake/OpenCVDownload.cmake
@@ -204,8 +204,8 @@ For details please refer to the download log file:
 ${OPENCV_DOWNLOAD_LOG}
 ")
       # write helper scripts for failed downloads
-      file(APPEND "${OPENCV_DOWNLOAD_WITH_CURL}" "curl --output \"${CACHE_CANDIDATE}\" \"${DL_URL}\"\n")
-      file(APPEND "${OPENCV_DOWNLOAD_WITH_WGET}" "wget -O \"${CACHE_CANDIDATE}\" \"${DL_URL}\"\n")
+      file(APPEND "${OPENCV_DOWNLOAD_WITH_CURL}" "curl --create-dirs --output \"${CACHE_CANDIDATE}\" \"${DL_URL}\"\n")
+      file(APPEND "${OPENCV_DOWNLOAD_WITH_WGET}" "mkdir -p $(dirname ${CACHE_CANDIDATE}) && wget -O \"${CACHE_CANDIDATE}\" \"${DL_URL}\"\n")
       return()
     endif()
 

--- a/cmake/OpenCVDownload.cmake
+++ b/cmake/OpenCVDownload.cmake
@@ -22,6 +22,9 @@ set(OPENCV_DOWNLOAD_PATH "${OpenCV_SOURCE_DIR}/.cache" CACHE PATH "${HELP_OPENCV
 set(OPENCV_DOWNLOAD_LOG "${OpenCV_BINARY_DIR}/CMakeDownloadLog.txt")
 set(OPENCV_DOWNLOAD_WITH_CURL "${OpenCV_BINARY_DIR}/download_with_curl.sh")
 set(OPENCV_DOWNLOAD_WITH_WGET "${OpenCV_BINARY_DIR}/download_with_wget.sh")
+set(OPENCV_DOWNLOAD_TRIES_LIST 1 CACHE STRING "List of download tries") # a list
+set(OPENCV_DOWNLOAD_PARAMS INACTIVITY_TIMEOUT 60 TIMEOUT 600 CACHE STRING "Download parameters to be passed to file(DOWNLAOD ...)")
+mark_as_advanced(OPENCV_DOWNLOAD_TRIES_LIST OPENCV_DOWNLOAD_PARAMS)
 
 # Init download cache directory and log file and helper scripts
 if(NOT EXISTS "${OPENCV_DOWNLOAD_PATH}")
@@ -154,11 +157,17 @@ function(ocv_download)
   # Download
   if(NOT EXISTS "${CACHE_CANDIDATE}")
     ocv_download_log("#cmake_download \"${CACHE_CANDIDATE}\" \"${DL_URL}\"")
-    file(DOWNLOAD "${DL_URL}" "${CACHE_CANDIDATE}"
-         INACTIVITY_TIMEOUT 60
-         TIMEOUT 600
-         STATUS status
-         LOG __log)
+    foreach(try ${OPENCV_DOWNLOAD_TRIES_LIST})
+      ocv_download_log("#try ${try}")
+      file(DOWNLOAD "${DL_URL}" "${CACHE_CANDIDATE}"
+           STATUS status
+           LOG __log
+           ${OPENCV_DOWNLOAD_PARAMS})
+      if(status EQUAL 0)
+        break()
+      endif()
+      message(STATUS "Try ${try} failed")
+    endforeach()
     if(NOT OPENCV_SKIP_FILE_DOWNLOAD_DUMP)  # workaround problem with old CMake versions: "Invalid escape sequence"
       string(LENGTH "${__log}" __log_length)
       if(__log_length LESS 65536)


### PR DESCRIPTION
resolves #13573

### This pullrequest changes

Adds two paramters to customize cmake download process for unstable and slow networks:
* `OPENCV_DOWNLOAD_TRIES_LIST` - list of items representing download tries:
* `OPENCV_DOWNLOAD_PARAMS` - raw parameter string to be used in cmake's `file(DOWNLOAD ...)` call
* added directory creation to fallback `download_with_*.sh` scripts

<cut/>

Examples:

bash:
```.sh
cmake \
    -DOPENCV_DOWNLOAD_TRIES_LIST=1\;2\;3\;4\;5 \
    -DOPENCV_DOWNLOAD_PARAMS=INACTIVITY_TIMEOUT\;30\;TIMEOUT\;180\;SHOW_PROGRESS \
../opencv
```
cmd:
```.bat
cmake ^
    -DOPENCV_DOWNLOAD_TRIES_LIST=a;b;c ^
    -DOPENCV_DOWNLOAD_PARAMS=INACTIVITY_TIMEOUT;30;TIMEOUT;180;SHOW_PROGRESS ^
../opencv
```


Edit: renamed to `OPENCV_DOWNLOAD_TRIES` => `OPENCV_DOWNLOAD_TRIES_LIST`, marked both variables as advanced.


```
allow_multiple_commits=1
```