### PR TITLE
Fix exception using calibrateCameraRO with iFixedPoint > 0

### DIFF
--- a/modules/calib3d/src/calibration.cpp
+++ b/modules/calib3d/src/calibration.cpp
@@ -1588,7 +1588,7 @@ static double cvCalibrateCamera2Internal( const CvMat* objectPoints,
     Mat _Je( maxPoints*2, 6, CV_64FC1 );
     Mat _err( maxPoints*2, 1, CV_64FC1 );
 
-    const bool allocJo = (solver.state == CvLevMarq::CALC_J) || stdDevs;
+    const bool allocJo = (solver.state == CvLevMarq::CALC_J) || stdDevs || releaseObject;
     Mat _Jo = allocJo ? Mat( maxPoints*2, maxPoints*3, CV_64FC1, Scalar(0) ) : Mat();
 
     if(flags & CALIB_USE_LU) {


### PR DESCRIPTION
resolves #14469 

relates #13910

### This pullrequest changes

Always allocate _Jo matrix in cvCalibrateCamera2Internal() when releaseObject flag is true. This prevents an attempt to multiply an empty _Jo (causing an exception) when the calcJ flag is true during solver iterations.