### PR TITLE
VideoCapture get property with range and default value support

### DIFF
--- a/modules/videoio/include/opencv2/videoio.hpp
+++ b/modules/videoio/include/opencv2/videoio.hpp
@@ -776,6 +776,17 @@ public:
     */
     CV_WRAP virtual double get(int propId) const;
 
+	/** @brief like get(int propId) but returns property range and default as well as value
+
+	@return true if success, false if querying a property that is not supported by the backend
+	used by the VideoCapture instance.
+
+	@note not all Property has a range and/or default value, if not , will set to min/max/defaultVal to -1,
+	see get(int propId) for more information
+	*/
+
+	CV_WRAP virtual bool get(int propId, double &val, double &min, double &max, double &defaultVal) const;
+
     /** @brief Returns used backend API name
 
      @note Stream should be opened.

--- a/modules/videoio/include/opencv2/videoio.hpp
+++ b/modules/videoio/include/opencv2/videoio.hpp
@@ -776,17 +776,17 @@ public:
     */
     CV_WRAP virtual double get(int propId) const;
 
-	/** @brief like get(int propId) but returns property range and default as well as value
-	
-	@param vals will contains 4 double element in order of value, min, max, default
-	@return true if success, false if querying a property that is not supported by the backend
-	used by the VideoCapture instance.
+    /** @brief like get(int propId) but returns property range and default as well as value
 
-	@note not all Property has a range and/or default value, if not , will set min/max/defaultVal to -1,
-	see get(int propId) for more information
-	*/
+    @param vals will contains 4 double element in order of value, min, max, default
+    @return true if success, false if querying a property that is not supported by the backend
+    used by the VideoCapture instance.
 
-	CV_WRAP virtual bool get(int propId, OutputArray vals) const;
+    @note not all Property has a range and/or default value, if not , will set min/max/defaultVal to -1,
+    see get(int propId) for more information
+    */
+
+    CV_WRAP virtual bool get(int propId, OutputArray vals) const;
 
     /** @brief Returns used backend API name
 

--- a/modules/videoio/include/opencv2/videoio.hpp
+++ b/modules/videoio/include/opencv2/videoio.hpp
@@ -777,7 +777,8 @@ public:
     CV_WRAP virtual double get(int propId) const;
 
 	/** @brief like get(int propId) but returns property range and default as well as value
-
+	
+	@param vals will contains 4 double element in order of value, min, max, default
 	@return true if success, false if querying a property that is not supported by the backend
 	used by the VideoCapture instance.
 
@@ -785,7 +786,7 @@ public:
 	see get(int propId) for more information
 	*/
 
-	CV_WRAP virtual bool get(int propId, double &val, double &min, double &max, double &defaultVal) const;
+	CV_WRAP virtual bool get(int propId, OutputArray vals) const;
 
     /** @brief Returns used backend API name
 

--- a/modules/videoio/include/opencv2/videoio.hpp
+++ b/modules/videoio/include/opencv2/videoio.hpp
@@ -778,6 +778,7 @@ public:
 
     /** @brief like get(int propId) but returns property range and default as well as value
 
+    @param propId is cv::VideoCaptureProperties same as get(int propId)
     @param vals will contains 4 double element in order of value, min, max, default
     @return true if success, false if querying a property that is not supported by the backend
     used by the VideoCapture instance.

--- a/modules/videoio/include/opencv2/videoio.hpp
+++ b/modules/videoio/include/opencv2/videoio.hpp
@@ -781,7 +781,7 @@ public:
 	@return true if success, false if querying a property that is not supported by the backend
 	used by the VideoCapture instance.
 
-	@note not all Property has a range and/or default value, if not , will set to min/max/defaultVal to -1,
+	@note not all Property has a range and/or default value, if not , will set min/max/defaultVal to -1,
 	see get(int propId) for more information
 	*/
 

--- a/modules/videoio/src/cap.cpp
+++ b/modules/videoio/src/cap.cpp
@@ -320,18 +320,18 @@ double VideoCapture::get(int propId) const
 
 bool VideoCapture::get(int propId, OutputArray vals) const
 {
-	int sizes = 4;
-	vals.create(1, &sizes, CV_64FC1);
-	double * p = (double *)vals.getMat().data;
-	if (propId == CAP_PROP_BACKEND) {		
-		p[0] = get(propId);
-		p[1] = p[2] = p[3] = -1;
-		return true;
-	}
-	if (!icap.empty()) {		
-		return icap->getProperty(propId, p[0], p[1], p[2], p[3]);
-	}
-	return false;
+    int sizes = 4;
+    vals.create(1, &sizes, CV_64FC1);
+    double * p = (double *)vals.getMat().data;
+    if (propId == CAP_PROP_BACKEND) {
+        p[0] = get(propId);
+        p[1] = p[2] = p[3] = -1;
+        return true;
+    }
+    if (!icap.empty()) {
+        return icap->getProperty(propId, p[0], p[1], p[2], p[3]);
+    }
+    return false;
 }
 
 

--- a/modules/videoio/src/cap.cpp
+++ b/modules/videoio/src/cap.cpp
@@ -318,6 +318,19 @@ double VideoCapture::get(int propId) const
     return !icap.empty() ? icap->getProperty(propId) : 0;
 }
 
+bool VideoCapture::get(int propId, double & val, double &min, double &max, double &defaultVal) const
+{
+	if (propId == CAP_PROP_BACKEND) {
+		val = get(propId);
+		min = max = defaultVal = -1;
+		return true;
+	}
+	if (!icap.empty()) {
+		return icap->getProperty(propId, val, min, max, defaultVal);
+	}
+	return false;
+}
+
 
 //=================================================================================================
 

--- a/modules/videoio/src/cap.cpp
+++ b/modules/videoio/src/cap.cpp
@@ -318,15 +318,18 @@ double VideoCapture::get(int propId) const
     return !icap.empty() ? icap->getProperty(propId) : 0;
 }
 
-bool VideoCapture::get(int propId, double &val, double &min, double &max, double &defaultVal) const
+bool VideoCapture::get(int propId, OutputArray vals) const
 {
-	if (propId == CAP_PROP_BACKEND) {
-		val = get(propId);
-		min = max = defaultVal = -1;
+	int sizes = 4;
+	vals.create(1, &sizes, CV_64FC1);
+	double * p = (double *)vals.getMat().data;
+	if (propId == CAP_PROP_BACKEND) {		
+		p[0] = get(propId);
+		p[1] = p[2] = p[3] = -1;
 		return true;
 	}
-	if (!icap.empty()) {
-		return icap->getProperty(propId, val, min, max, defaultVal);
+	if (!icap.empty()) {		
+		return icap->getProperty(propId, p[0], p[1], p[2], p[3]);
 	}
 	return false;
 }

--- a/modules/videoio/src/cap.cpp
+++ b/modules/videoio/src/cap.cpp
@@ -318,7 +318,7 @@ double VideoCapture::get(int propId) const
     return !icap.empty() ? icap->getProperty(propId) : 0;
 }
 
-bool VideoCapture::get(int propId, double & val, double &min, double &max, double &defaultVal) const
+bool VideoCapture::get(int propId, double &val, double &min, double &max, double &defaultVal) const
 {
 	if (propId == CAP_PROP_BACKEND) {
 		val = get(propId);

--- a/modules/videoio/src/cap_dshow.cpp
+++ b/modules/videoio/src/cap_dshow.cpp
@@ -3336,48 +3336,48 @@ VideoCapture_DShow::~VideoCapture_DShow()
 
 double VideoCapture_DShow::getProperty(int propIdx) const
 {
-	double val, min, max, defaultVal;
-	if (getProperty(propIdx, val, min, max, defaultVal)) {
-		return val;
-	}
-	return 0;
+    double val, min, max, defaultVal;
+    if (getProperty(propIdx, val, min, max, defaultVal)) {
+        return val;
+    }
+    return 0;
 }
 
 bool VideoCapture_DShow::getProperty(int propIdx, double &val, double &min, double &max, double &defaultVal) const
 {
 
     long min_value, max_value, stepping_delta, current_value, flags, defaultValue;
-	min = max = defaultVal = -1;
+    min = max = defaultVal = -1;
     switch (propIdx)
     {
     // image format properties
     case CV_CAP_PROP_FRAME_WIDTH:
         val = g_VI.getWidth(m_index);
-		return true;
+        return true;
     case CV_CAP_PROP_FRAME_HEIGHT:
         val = g_VI.getHeight(m_index);
-		return true;
+        return true;
     case CV_CAP_PROP_FOURCC:
         val = g_VI.getFourcc(m_index);
-		return true;
+        return true;
     case CV_CAP_PROP_FPS:
         val = g_VI.getFPS(m_index);
-		return true;
+        return true;
     case CV_CAP_PROP_CONVERT_RGB:
         val = g_VI.getConvertRGB(m_index);
-		return true;
+        return true;
     case CAP_PROP_CHANNEL:
         val = g_VI.getChannel(m_index);
-		return true;
+        return true;
     case CV_CAP_PROP_AUTOFOCUS:
       // Flags indicate whether or not autofocus is enabled
-		if (g_VI.getVideoSettingCamera(m_index, CameraControl_Focus, min_value, max_value, stepping_delta, current_value, flags, defaultValue)) {
-			val = (double)flags;
-			min = min_value;
-			max = max_value;
-			defaultVal = defaultValue;
-			return true;
-		}
+        if (g_VI.getVideoSettingCamera(m_index, CameraControl_Focus, min_value, max_value, stepping_delta, current_value, flags, defaultValue)) {
+            val = (double)flags;
+            min = min_value;
+            max = max_value;
+            defaultVal = defaultValue;
+            return true;
+        }
       break;
 
     // video filter properties
@@ -3391,13 +3391,13 @@ bool VideoCapture_DShow::getProperty(int propIdx, double &val, double &min, doub
     case CV_CAP_PROP_WHITE_BALANCE_BLUE_U:
     case CV_CAP_PROP_BACKLIGHT:
     case CV_CAP_PROP_GAIN:
-		if (g_VI.getVideoSettingFilter(m_index, g_VI.getVideoPropertyFromCV(propIdx), min_value, max_value, stepping_delta, current_value, flags, defaultValue)) {
+        if (g_VI.getVideoSettingFilter(m_index, g_VI.getVideoPropertyFromCV(propIdx), min_value, max_value, stepping_delta, current_value, flags, defaultValue)) {
             val = (double)current_value;
-			min = min_value;
-			max = max_value;
-			defaultVal = defaultValue;
-			return true;
-		}
+            min = min_value;
+            max = max_value;
+            defaultVal = defaultValue;
+            return true;
+        }
         break;
 
     // camera properties
@@ -3408,17 +3408,17 @@ bool VideoCapture_DShow::getProperty(int propIdx, double &val, double &min, doub
     case CV_CAP_PROP_EXPOSURE:
     case CV_CAP_PROP_IRIS:
     case CV_CAP_PROP_FOCUS:
-		if (g_VI.getVideoSettingCamera(m_index, g_VI.getCameraPropertyFromCV(propIdx), min_value, max_value, stepping_delta, current_value, flags, defaultValue)) {
-			val = (double)current_value;
-			min = min_value;
-			max = max_value;
-			defaultVal = defaultValue;
-			return true;
-		}            
+        if (g_VI.getVideoSettingCamera(m_index, g_VI.getCameraPropertyFromCV(propIdx), min_value, max_value, stepping_delta, current_value, flags, defaultValue)) {
+            val = (double)current_value;
+            min = min_value;
+            max = max_value;
+            defaultVal = defaultValue;
+            return true;
+        }
         break;
     case CV_CAP_PROP_SETTINGS:
         val = g_VI.property_window_count(m_index);
-		return true;
+        return true;
     default:
         break;
     }

--- a/modules/videoio/src/cap_dshow.cpp
+++ b/modules/videoio/src/cap_dshow.cpp
@@ -3343,7 +3343,7 @@ double VideoCapture_DShow::getProperty(int propIdx) const
 	return 0;
 }
 
-bool VideoCapture_DShow::getProperty(int propIdx, double & val, double &min, double &max, double &defaultVal) const
+bool VideoCapture_DShow::getProperty(int propIdx, double &val, double &min, double &max, double &defaultVal) const
 {
 
     long min_value, max_value, stepping_delta, current_value, flags, defaultValue;

--- a/modules/videoio/src/cap_dshow.cpp
+++ b/modules/videoio/src/cap_dshow.cpp
@@ -3336,28 +3336,48 @@ VideoCapture_DShow::~VideoCapture_DShow()
 
 double VideoCapture_DShow::getProperty(int propIdx) const
 {
+	double val, min, max, defaultVal;
+	if (getProperty(propIdx, val, min, max, defaultVal)) {
+		return val;
+	}
+	return 0;
+}
+
+bool VideoCapture_DShow::getProperty(int propIdx, double & val, double &min, double &max, double &defaultVal) const
+{
 
     long min_value, max_value, stepping_delta, current_value, flags, defaultValue;
-
+	min = max = defaultVal = -1;
     switch (propIdx)
     {
     // image format properties
     case CV_CAP_PROP_FRAME_WIDTH:
-        return g_VI.getWidth(m_index);
+        val = g_VI.getWidth(m_index);
+		return true;
     case CV_CAP_PROP_FRAME_HEIGHT:
-        return g_VI.getHeight(m_index);
+        val = g_VI.getHeight(m_index);
+		return true;
     case CV_CAP_PROP_FOURCC:
-        return g_VI.getFourcc(m_index);
+        val = g_VI.getFourcc(m_index);
+		return true;
     case CV_CAP_PROP_FPS:
-        return g_VI.getFPS(m_index);
+        val = g_VI.getFPS(m_index);
+		return true;
     case CV_CAP_PROP_CONVERT_RGB:
-        return g_VI.getConvertRGB(m_index);
+        val = g_VI.getConvertRGB(m_index);
+		return true;
     case CAP_PROP_CHANNEL:
-        return g_VI.getChannel(m_index);
+        val = g_VI.getChannel(m_index);
+		return true;
     case CV_CAP_PROP_AUTOFOCUS:
       // Flags indicate whether or not autofocus is enabled
-      if (g_VI.getVideoSettingCamera(m_index, CameraControl_Focus, min_value, max_value, stepping_delta, current_value, flags, defaultValue))
-        return (double)flags;
+		if (g_VI.getVideoSettingCamera(m_index, CameraControl_Focus, min_value, max_value, stepping_delta, current_value, flags, defaultValue)) {
+			val = (double)flags;
+			min = min_value;
+			max = max_value;
+			defaultVal = defaultValue;
+			return true;
+		}
       break;
 
     // video filter properties
@@ -3371,8 +3391,13 @@ double VideoCapture_DShow::getProperty(int propIdx) const
     case CV_CAP_PROP_WHITE_BALANCE_BLUE_U:
     case CV_CAP_PROP_BACKLIGHT:
     case CV_CAP_PROP_GAIN:
-        if (g_VI.getVideoSettingFilter(m_index, g_VI.getVideoPropertyFromCV(propIdx), min_value, max_value, stepping_delta, current_value, flags, defaultValue))
-            return (double)current_value;
+		if (g_VI.getVideoSettingFilter(m_index, g_VI.getVideoPropertyFromCV(propIdx), min_value, max_value, stepping_delta, current_value, flags, defaultValue)) {
+            val = (double)current_value;
+			min = min_value;
+			max = max_value;
+			defaultVal = defaultValue;
+			return true;
+		}
         break;
 
     // camera properties
@@ -3383,16 +3408,22 @@ double VideoCapture_DShow::getProperty(int propIdx) const
     case CV_CAP_PROP_EXPOSURE:
     case CV_CAP_PROP_IRIS:
     case CV_CAP_PROP_FOCUS:
-        if (g_VI.getVideoSettingCamera(m_index, g_VI.getCameraPropertyFromCV(propIdx), min_value, max_value, stepping_delta, current_value, flags, defaultValue))
-            return (double)current_value;
+		if (g_VI.getVideoSettingCamera(m_index, g_VI.getCameraPropertyFromCV(propIdx), min_value, max_value, stepping_delta, current_value, flags, defaultValue)) {
+			val = (double)current_value;
+			min = min_value;
+			max = max_value;
+			defaultVal = defaultValue;
+			return true;
+		}            
         break;
     case CV_CAP_PROP_SETTINGS:
-        return g_VI.property_window_count(m_index);
+        val = g_VI.property_window_count(m_index);
+		return true;
     default:
         break;
     }
     // unknown parameter or value not available
-    return -1;
+    return false;
 }
 bool VideoCapture_DShow::setProperty(int propIdx, double propVal)
 {

--- a/modules/videoio/src/cap_dshow.hpp
+++ b/modules/videoio/src/cap_dshow.hpp
@@ -25,7 +25,7 @@ public:
     virtual ~VideoCapture_DShow();
 
     virtual double getProperty(int propIdx) const CV_OVERRIDE;
-	virtual bool getProperty(int propIdx, double &val, double &min, double &max, double &defaultVal) const CV_OVERRIDE;
+    virtual bool getProperty(int propIdx, double &val, double &min, double &max, double &defaultVal) const CV_OVERRIDE;
     virtual bool setProperty(int propIdx, double propVal) CV_OVERRIDE;
 
     virtual bool grabFrame() CV_OVERRIDE;

--- a/modules/videoio/src/cap_dshow.hpp
+++ b/modules/videoio/src/cap_dshow.hpp
@@ -25,6 +25,7 @@ public:
     virtual ~VideoCapture_DShow();
 
     virtual double getProperty(int propIdx) const CV_OVERRIDE;
+	virtual bool getProperty(int propIdx, double &val, double &min, double &max, double &defaultVal) const CV_OVERRIDE;
     virtual bool setProperty(int propIdx, double propVal) CV_OVERRIDE;
 
     virtual bool grabFrame() CV_OVERRIDE;

--- a/modules/videoio/src/cap_interface.hpp
+++ b/modules/videoio/src/cap_interface.hpp
@@ -44,7 +44,7 @@ public:
     virtual ~IVideoCapture() {}
     virtual double getProperty(int) const { return 0; }
     virtual bool setProperty(int, double) { return false; }
-	virtual bool getProperty(int propId, double &val, double &min, double &max, double & defaultVal)const { return false; }
+	virtual bool getProperty(int, double &, double &, double &, double &)const { return false; }
     virtual bool grabFrame() = 0;
     virtual bool retrieveFrame(int, OutputArray) = 0;
     virtual bool isOpened() const = 0;

--- a/modules/videoio/src/cap_interface.hpp
+++ b/modules/videoio/src/cap_interface.hpp
@@ -44,7 +44,7 @@ public:
     virtual ~IVideoCapture() {}
     virtual double getProperty(int) const { return 0; }
     virtual bool setProperty(int, double) { return false; }
-	virtual bool getProperty(int, double &, double &, double &, double &)const { return false; }
+    virtual bool getProperty(int, double &, double &, double &, double &)const { return false; }
     virtual bool grabFrame() = 0;
     virtual bool retrieveFrame(int, OutputArray) = 0;
     virtual bool isOpened() const = 0;

--- a/modules/videoio/src/cap_interface.hpp
+++ b/modules/videoio/src/cap_interface.hpp
@@ -44,6 +44,7 @@ public:
     virtual ~IVideoCapture() {}
     virtual double getProperty(int) const { return 0; }
     virtual bool setProperty(int, double) { return false; }
+	virtual bool getProperty(int propId, double &val, double &min, double &max, double & defaultVal)const { return false; }
     virtual bool grabFrame() = 0;
     virtual bool retrieveFrame(int, OutputArray) = 0;
     virtual bool isOpened() const = 0;

--- a/modules/videoio/src/cap_msmf.cpp
+++ b/modules/videoio/src/cap_msmf.cpp
@@ -701,7 +701,7 @@ public:
     virtual bool open(const cv::String&);
     virtual void close();
     virtual double getProperty(int) const CV_OVERRIDE;
-	virtual bool getProperty(int property_id, double & val, double &min, double &max, double &default_val) const CV_OVERRIDE;
+    virtual bool getProperty(int property_id, double & val, double &min, double &max, double &default_val) const CV_OVERRIDE;
     virtual bool setProperty(int, double) CV_OVERRIDE;
     virtual bool grabFrame() CV_OVERRIDE;
     virtual bool retrieveFrame(int, cv::OutputArray) CV_OVERRIDE;
@@ -1375,65 +1375,65 @@ bool CvCapture_MSMF::setTime(double time, bool rough)
 
 
 static VideoProcAmpProperty getAmpPropFromCvCapProp(int property_id) {
-	switch (property_id)
-	{
-	case CV_CAP_PROP_BRIGHTNESS:
-		return VideoProcAmpProperty::VideoProcAmp_Brightness;
-	case CV_CAP_PROP_CONTRAST:
-		return VideoProcAmpProperty::VideoProcAmp_Contrast;
-	case CV_CAP_PROP_SATURATION:
-		return VideoProcAmpProperty::VideoProcAmp_Saturation;
-	case CV_CAP_PROP_HUE:
-		return VideoProcAmpProperty::VideoProcAmp_Hue;
-	case CV_CAP_PROP_GAIN:
-		return VideoProcAmpProperty::VideoProcAmp_Gain;
-	case CV_CAP_PROP_SHARPNESS:
-		return VideoProcAmpProperty::VideoProcAmp_Sharpness;
-	case CV_CAP_PROP_GAMMA:
-		return VideoProcAmpProperty::VideoProcAmp_Gamma;
-	case CV_CAP_PROP_BACKLIGHT:
-		return VideoProcAmpProperty::VideoProcAmp_BacklightCompensation;
-	case CV_CAP_PROP_MONOCHROME:
-		return VideoProcAmpProperty::VideoProcAmp_ColorEnable;
-	case CV_CAP_PROP_TEMPERATURE:
-		return VideoProcAmpProperty::VideoProcAmp_WhiteBalance;
-	default:
-		return (VideoProcAmpProperty)-1;//should never got here
-	}
+    switch (property_id)
+    {
+    case CV_CAP_PROP_BRIGHTNESS:
+        return VideoProcAmpProperty::VideoProcAmp_Brightness;
+    case CV_CAP_PROP_CONTRAST:
+        return VideoProcAmpProperty::VideoProcAmp_Contrast;
+    case CV_CAP_PROP_SATURATION:
+        return VideoProcAmpProperty::VideoProcAmp_Saturation;
+    case CV_CAP_PROP_HUE:
+        return VideoProcAmpProperty::VideoProcAmp_Hue;
+    case CV_CAP_PROP_GAIN:
+        return VideoProcAmpProperty::VideoProcAmp_Gain;
+    case CV_CAP_PROP_SHARPNESS:
+        return VideoProcAmpProperty::VideoProcAmp_Sharpness;
+    case CV_CAP_PROP_GAMMA:
+        return VideoProcAmpProperty::VideoProcAmp_Gamma;
+    case CV_CAP_PROP_BACKLIGHT:
+        return VideoProcAmpProperty::VideoProcAmp_BacklightCompensation;
+    case CV_CAP_PROP_MONOCHROME:
+        return VideoProcAmpProperty::VideoProcAmp_ColorEnable;
+    case CV_CAP_PROP_TEMPERATURE:
+        return VideoProcAmpProperty::VideoProcAmp_WhiteBalance;
+    default:
+        return (VideoProcAmpProperty)-1;//should never got here
+    }
 }
 
 
 static CameraControlProperty getControlPropFromCvCapProp(int property_id) {
-	switch (property_id)
-	{
-	case CV_CAP_PROP_PAN:
-		return CameraControlProperty::CameraControl_Pan;
-	case CV_CAP_PROP_TILT:
-		return CameraControlProperty::CameraControl_Tilt;
-	case CV_CAP_PROP_ROLL:
-		return CameraControlProperty::CameraControl_Roll;
-	case CV_CAP_PROP_IRIS:
-		return CameraControlProperty::CameraControl_Iris;
-	case CV_CAP_PROP_EXPOSURE:
-	case CV_CAP_PROP_AUTO_EXPOSURE:
-		return CameraControlProperty::CameraControl_Exposure;
-	case CV_CAP_PROP_ZOOM:
-		return CameraControlProperty::CameraControl_Zoom;
-	case CV_CAP_PROP_FOCUS:
-	case CV_CAP_PROP_AUTOFOCUS:
-		return CameraControlProperty::CameraControl_Focus;
-	default:
-		return (CameraControlProperty)-1;//should never got here
+    switch (property_id)
+    {
+    case CV_CAP_PROP_PAN:
+        return CameraControlProperty::CameraControl_Pan;
+    case CV_CAP_PROP_TILT:
+        return CameraControlProperty::CameraControl_Tilt;
+    case CV_CAP_PROP_ROLL:
+        return CameraControlProperty::CameraControl_Roll;
+    case CV_CAP_PROP_IRIS:
+        return CameraControlProperty::CameraControl_Iris;
+    case CV_CAP_PROP_EXPOSURE:
+    case CV_CAP_PROP_AUTO_EXPOSURE:
+        return CameraControlProperty::CameraControl_Exposure;
+    case CV_CAP_PROP_ZOOM:
+        return CameraControlProperty::CameraControl_Zoom;
+    case CV_CAP_PROP_FOCUS:
+    case CV_CAP_PROP_AUTOFOCUS:
+        return CameraControlProperty::CameraControl_Focus;
+    default:
+        return (CameraControlProperty)-1;//should never got here
 }
 }
 
 double CvCapture_MSMF::getProperty(int property_id) const
 {
-	double val, min, max, defaultVal;
-	if (getProperty(property_id, val, min, max, defaultVal)) {
-		return val;
-	}
-	return 0;
+    double val, min, max, defaultVal;
+    if (getProperty(property_id, val, min, max, defaultVal)) {
+        return val;
+    }
+    return 0;
 
 }
 
@@ -1441,135 +1441,133 @@ bool CvCapture_MSMF::getProperty(int property_id, double & val, double &min, dou
 {
     IAMVideoProcAmp *pProcAmp = NULL;
     IAMCameraControl *pProcControl = NULL;
-	min = max = default_val = -1;
+    min = max = default_val = -1;
     // image format properties
     if (isOpen)
         switch (property_id)
         {
         case CV_CAP_PROP_MODE:
                 val = captureMode;
-				return true;
+                return true;
         case CV_CAP_PROP_CONVERT_RGB:
                 val= convertFormat ? 1 : 0;
-				return true;
+                return true;
         case CV_CAP_PROP_SAR_NUM:
                 val= aspectN;
-				return true;
+                return true;
         case CV_CAP_PROP_SAR_DEN:
                 val= aspectD;
-				return true;
+                return true;
         case CV_CAP_PROP_FRAME_WIDTH:
             val= captureFormat.width;
-			return true;
+            return true;
         case CV_CAP_PROP_FRAME_HEIGHT:
             val= captureFormat.height;
-			return true;
+            return true;
         case CV_CAP_PROP_FOURCC:
             val= nativeFormat.MF_MT_SUBTYPE.Data1;
-			return true;
+            return true;
         case CV_CAP_PROP_FPS:
             val= getFramerate(nativeFormat);
-			return true;
+            return true;
         case CV_CAP_PROP_FRAME_COUNT:
             if (duration != 0){
                 val= floor(((double)duration / 1e7)*getFramerate(nativeFormat) + 0.5);
-				return true;
-			}
+                return true;
+            }
             else
                 break;
         case CV_CAP_PROP_POS_FRAMES:
             val = floor(((double)sampleTime / 1e7)*getFramerate(nativeFormat) + 0.5);
-			return true;
+            return true;
         case CV_CAP_PROP_POS_MSEC:
             val= (double)sampleTime / 1e4;
-			return true;
+            return true;
         case CV_CAP_PROP_POS_AVI_RATIO:
             if (duration != 0){
                 val= (double)sampleTime / duration;
-				return true;			
-			}
+                return true;            
+            }
             else
                 break;
         case CV_CAP_PROP_BRIGHTNESS:
-		case CV_CAP_PROP_CONTRAST:
-		case CV_CAP_PROP_SATURATION:
-		case CV_CAP_PROP_HUE:
-		case CV_CAP_PROP_GAIN:
-		case CV_CAP_PROP_SHARPNESS:
-		case CV_CAP_PROP_GAMMA:
-		case CV_CAP_PROP_BACKLIGHT:
-		case CV_CAP_PROP_MONOCHROME:
-		case CV_CAP_PROP_TEMPERATURE:
-		{
-			VideoProcAmpProperty propertyAmp = getAmpPropFromCvCapProp(property_id);
-			if (SUCCEEDED(videoFileSource->GetServiceForStream((DWORD)MF_SOURCE_READER_MEDIASOURCE, GUID_NULL, IID_PPV_ARGS(&pProcAmp))))
-			{
-				long paramVal, paramFlag;
-				HRESULT hr = pProcAmp->Get(propertyAmp, &paramVal, &paramFlag);
-				if (SUCCEEDED(hr)) val = paramVal;
-				long minVal, maxVal, stepVal, defaultVal;
-				HRESULT hrRange = pProcAmp->GetRange(propertyAmp, &minVal, &maxVal, &stepVal, &defaultVal, &paramFlag);//Unable to get the property, trying to return default value
-				if (FAILED(hr) && SUCCEEDED(hrRange)) {
-					val = defaultVal;
-				}
-				pProcAmp->Release();
-				if (SUCCEEDED(hrRange)) {
-					min = minVal;
-					max = maxVal;
-					default_val = defaultVal;
-				}
-				if (SUCCEEDED(hr) || SUCCEEDED(hrRange)) {
-					return true;
-				}
-			}
-			break;
-		}	         
-       
- 
+        case CV_CAP_PROP_CONTRAST:
+        case CV_CAP_PROP_SATURATION:
+        case CV_CAP_PROP_HUE:
+        case CV_CAP_PROP_GAIN:
+        case CV_CAP_PROP_SHARPNESS:
+        case CV_CAP_PROP_GAMMA:
+        case CV_CAP_PROP_BACKLIGHT:
+        case CV_CAP_PROP_MONOCHROME:
+        case CV_CAP_PROP_TEMPERATURE:
+        {
+            VideoProcAmpProperty propertyAmp = getAmpPropFromCvCapProp(property_id);
+            if (SUCCEEDED(videoFileSource->GetServiceForStream((DWORD)MF_SOURCE_READER_MEDIASOURCE, GUID_NULL, IID_PPV_ARGS(&pProcAmp))))
+            {
+                long paramVal, paramFlag;
+                HRESULT hr = pProcAmp->Get(propertyAmp, &paramVal, &paramFlag);
+                if (SUCCEEDED(hr)) val = paramVal;
+                long minVal, maxVal, stepVal, defaultVal;
+                HRESULT hrRange = pProcAmp->GetRange(propertyAmp, &minVal, &maxVal, &stepVal, &defaultVal, &paramFlag);//Unable to get the property, trying to return default value
+                if (FAILED(hr) && SUCCEEDED(hrRange)) {
+                    val = defaultVal;
+                }
+                pProcAmp->Release();
+                if (SUCCEEDED(hrRange)) {
+                    min = minVal;
+                    max = maxVal;
+                    default_val = defaultVal;
+                }
+                if (SUCCEEDED(hr) || SUCCEEDED(hrRange)) {
+                    return true;
+                }
+            }
+            break;
+        }
+
         case CV_CAP_PROP_WHITE_BALANCE_BLUE_U:
         case CV_CAP_PROP_WHITE_BALANCE_RED_V:
             break;
 
 
         case CV_CAP_PROP_PAN:
-		case CV_CAP_PROP_TILT:
-		case CV_CAP_PROP_ROLL:
-		case CV_CAP_PROP_IRIS:
-		case CV_CAP_PROP_EXPOSURE:
-		case CV_CAP_PROP_AUTO_EXPOSURE:
-		case CV_CAP_PROP_ZOOM:
-		case CV_CAP_PROP_FOCUS:
-		case CV_CAP_PROP_AUTOFOCUS:
-		{
-			CameraControlProperty propertyControl = getControlPropFromCvCapProp(property_id);
-			if (SUCCEEDED(videoFileSource->GetServiceForStream((DWORD)MF_SOURCE_READER_MEDIASOURCE, GUID_NULL, IID_PPV_ARGS(&pProcControl))))
-			{
-				long paramVal, paramFlag;
-				HRESULT hr = pProcControl->Get(propertyControl, &paramVal, &paramFlag);
-				if (SUCCEEDED(hr)) val = paramVal;
-				long minVal, maxVal, stepVal, defaultVal;
-				HRESULT hrRange = pProcControl->GetRange(propertyControl, &minVal, &maxVal, &stepVal, &defaultVal, &paramFlag);//Unable to get the property, trying to return default value
-				if (FAILED(hr) && SUCCEEDED(hrRange)) {
-					val = defaultVal;
-				}
-				pProcControl->Release();
-				if (SUCCEEDED(hrRange)) {
-					min = minVal;
-					max = maxVal;
-					default_val = defaultVal;
-				}
-				if (SUCCEEDED(hr) || SUCCEEDED(hrRange)) {
-					if (property_id == CV_CAP_PROP_AUTO_EXPOSURE || property_id == CV_CAP_PROP_AUTOFOCUS) {
-						val = paramFlag == VideoProcAmp_Flags_Auto;
-					}
-					return true;
+        case CV_CAP_PROP_TILT:
+        case CV_CAP_PROP_ROLL:
+        case CV_CAP_PROP_IRIS:
+        case CV_CAP_PROP_EXPOSURE:
+        case CV_CAP_PROP_AUTO_EXPOSURE:
+        case CV_CAP_PROP_ZOOM:
+        case CV_CAP_PROP_FOCUS:
+        case CV_CAP_PROP_AUTOFOCUS:
+        {
+            CameraControlProperty propertyControl = getControlPropFromCvCapProp(property_id);
+            if (SUCCEEDED(videoFileSource->GetServiceForStream((DWORD)MF_SOURCE_READER_MEDIASOURCE, GUID_NULL, IID_PPV_ARGS(&pProcControl))))
+            {
+                long paramVal, paramFlag;
+                HRESULT hr = pProcControl->Get(propertyControl, &paramVal, &paramFlag);
+                if (SUCCEEDED(hr)) val = paramVal;
+                long minVal, maxVal, stepVal, defaultVal;
+                HRESULT hrRange = pProcControl->GetRange(propertyControl, &minVal, &maxVal, &stepVal, &defaultVal, &paramFlag);//Unable to get the property, trying to return default value
+                if (FAILED(hr) && SUCCEEDED(hrRange)) {
+                    val = defaultVal;
+                }
+                pProcControl->Release();
+                if (SUCCEEDED(hrRange)) {
+                    min = minVal;
+                    max = maxVal;
+                    default_val = defaultVal;
+                }
+                if (SUCCEEDED(hr) || SUCCEEDED(hrRange)) {
+                    if (property_id == CV_CAP_PROP_AUTO_EXPOSURE || property_id == CV_CAP_PROP_AUTOFOCUS) {
+                        val = paramFlag == VideoProcAmp_Flags_Auto;
+                    }
+                    return true;
 
-				}
-			}
-			break;
-		}
-			
-   
+                }
+            }
+            break;
+        }
+
         case CV_CAP_PROP_RECTIFICATION:
         case CV_CAP_PROP_TRIGGER:
         case CV_CAP_PROP_TRIGGER_DELAY:

--- a/modules/videoio/src/cap_msmf.cpp
+++ b/modules/videoio/src/cap_msmf.cpp
@@ -1486,7 +1486,7 @@ bool CvCapture_MSMF::getProperty(int property_id, double & val, double &min, dou
         case CV_CAP_PROP_POS_AVI_RATIO:
             if (duration != 0){
                 val= (double)sampleTime / duration;
-                return true;            
+                return true;
             }
             else
                 break;

--- a/modules/videoio/src/cap_msmf.cpp
+++ b/modules/videoio/src/cap_msmf.cpp
@@ -701,6 +701,7 @@ public:
     virtual bool open(const cv::String&);
     virtual void close();
     virtual double getProperty(int) const CV_OVERRIDE;
+	virtual bool getProperty(int property_id, double & val, double &min, double &max, double &default_val) const CV_OVERRIDE;
     virtual bool setProperty(int, double) CV_OVERRIDE;
     virtual bool grabFrame() CV_OVERRIDE;
     virtual bool retrieveFrame(int, cv::OutputArray) CV_OVERRIDE;
@@ -1371,292 +1372,204 @@ bool CvCapture_MSMF::setTime(double time, bool rough)
     return false;
 }
 
-double CvCapture_MSMF::getProperty( int property_id ) const
+
+
+static VideoProcAmpProperty getAmpPropFromCvCapProp(int property_id) {
+	switch (property_id)
+	{
+	case CV_CAP_PROP_BRIGHTNESS:
+		return VideoProcAmpProperty::VideoProcAmp_Brightness;
+	case CV_CAP_PROP_CONTRAST:
+		return VideoProcAmpProperty::VideoProcAmp_Contrast;
+	case CV_CAP_PROP_SATURATION:
+		return VideoProcAmpProperty::VideoProcAmp_Saturation;
+	case CV_CAP_PROP_HUE:
+		return VideoProcAmpProperty::VideoProcAmp_Hue;
+	case CV_CAP_PROP_GAIN:
+		return VideoProcAmpProperty::VideoProcAmp_Gain;
+	case CV_CAP_PROP_SHARPNESS:
+		return VideoProcAmpProperty::VideoProcAmp_Sharpness;
+	case CV_CAP_PROP_GAMMA:
+		return VideoProcAmpProperty::VideoProcAmp_Gamma;
+	case CV_CAP_PROP_BACKLIGHT:
+		return VideoProcAmpProperty::VideoProcAmp_BacklightCompensation;
+	case CV_CAP_PROP_MONOCHROME:
+		return VideoProcAmpProperty::VideoProcAmp_ColorEnable;
+	case CV_CAP_PROP_TEMPERATURE:
+		return VideoProcAmpProperty::VideoProcAmp_WhiteBalance;
+	default:
+		return (VideoProcAmpProperty)-1;//should never got here
+	}
+}
+
+
+static CameraControlProperty getControlPropFromCvCapProp(int property_id) {
+	switch (property_id)
+	{
+	case CV_CAP_PROP_PAN:
+		return CameraControlProperty::CameraControl_Pan;
+	case CV_CAP_PROP_TILT:
+		return CameraControlProperty::CameraControl_Tilt;
+	case CV_CAP_PROP_ROLL:
+		return CameraControlProperty::CameraControl_Roll;
+	case CV_CAP_PROP_IRIS:
+		return CameraControlProperty::CameraControl_Iris;
+	case CV_CAP_PROP_EXPOSURE:
+	case CV_CAP_PROP_AUTO_EXPOSURE:
+		return CameraControlProperty::CameraControl_Exposure;
+	case CV_CAP_PROP_ZOOM:
+		return CameraControlProperty::CameraControl_Zoom;
+	case CV_CAP_PROP_FOCUS:
+	case CV_CAP_PROP_AUTOFOCUS:
+		return CameraControlProperty::CameraControl_Focus;
+	default:
+		return (CameraControlProperty)-1;//should never got here
+}
+}
+
+double CvCapture_MSMF::getProperty(int property_id) const
+{
+	double val, min, max, defaultVal;
+	if (getProperty(property_id, val, min, max, defaultVal)) {
+		return val;
+	}
+	return 0;
+
+}
+
+bool CvCapture_MSMF::getProperty(int property_id, double & val, double &min, double &max, double &default_val) const
 {
     IAMVideoProcAmp *pProcAmp = NULL;
     IAMCameraControl *pProcControl = NULL;
+	min = max = default_val = -1;
     // image format properties
     if (isOpen)
         switch (property_id)
         {
         case CV_CAP_PROP_MODE:
-                return captureMode;
+                val = captureMode;
+				return true;
         case CV_CAP_PROP_CONVERT_RGB:
-                return convertFormat ? 1 : 0;
+                val= convertFormat ? 1 : 0;
+				return true;
         case CV_CAP_PROP_SAR_NUM:
-                return aspectN;
+                val= aspectN;
+				return true;
         case CV_CAP_PROP_SAR_DEN:
-                return aspectD;
+                val= aspectD;
+				return true;
         case CV_CAP_PROP_FRAME_WIDTH:
-            return captureFormat.width;
+            val= captureFormat.width;
+			return true;
         case CV_CAP_PROP_FRAME_HEIGHT:
-            return captureFormat.height;
+            val= captureFormat.height;
+			return true;
         case CV_CAP_PROP_FOURCC:
-            return nativeFormat.MF_MT_SUBTYPE.Data1;
+            val= nativeFormat.MF_MT_SUBTYPE.Data1;
+			return true;
         case CV_CAP_PROP_FPS:
-            return getFramerate(nativeFormat);
+            val= getFramerate(nativeFormat);
+			return true;
         case CV_CAP_PROP_FRAME_COUNT:
-            if (duration != 0)
-                return floor(((double)duration / 1e7)*getFramerate(nativeFormat) + 0.5);
+            if (duration != 0){
+                val= floor(((double)duration / 1e7)*getFramerate(nativeFormat) + 0.5);
+				return true;
+			}
             else
                 break;
         case CV_CAP_PROP_POS_FRAMES:
-            return floor(((double)sampleTime / 1e7)*getFramerate(nativeFormat) + 0.5);
+            val = floor(((double)sampleTime / 1e7)*getFramerate(nativeFormat) + 0.5);
+			return true;
         case CV_CAP_PROP_POS_MSEC:
-            return (double)sampleTime / 1e4;
+            val= (double)sampleTime / 1e4;
+			return true;
         case CV_CAP_PROP_POS_AVI_RATIO:
-            if (duration != 0)
-                return (double)sampleTime / duration;
+            if (duration != 0){
+                val= (double)sampleTime / duration;
+				return true;			
+			}
             else
                 break;
         case CV_CAP_PROP_BRIGHTNESS:
-            if (SUCCEEDED(videoFileSource->GetServiceForStream((DWORD)MF_SOURCE_READER_MEDIASOURCE, GUID_NULL, IID_PPV_ARGS(&pProcAmp))))
-            {
-                long paramVal, paramFlag;
-                HRESULT hr = pProcAmp->Get(VideoProcAmp_Brightness, &paramVal, &paramFlag);
-                long minVal, maxVal, stepVal;
-                if(FAILED(hr))
-                    hr = pProcAmp->GetRange(VideoProcAmp_Brightness, &minVal, &maxVal, &stepVal, &paramVal, &paramFlag);//Unable to get the property, trying to return default value
-                pProcAmp->Release();
-                if (SUCCEEDED(hr))
-                    return paramVal;
-            }
-            break;
-        case CV_CAP_PROP_CONTRAST:
-            if (SUCCEEDED(videoFileSource->GetServiceForStream((DWORD)MF_SOURCE_READER_MEDIASOURCE, GUID_NULL, IID_PPV_ARGS(&pProcAmp))))
-            {
-                long paramVal, paramFlag;
-                HRESULT hr = pProcAmp->Get(VideoProcAmp_Contrast, &paramVal, &paramFlag);
-                long minVal, maxVal, stepVal;
-                if (FAILED(hr))
-                    hr = pProcAmp->GetRange(VideoProcAmp_Contrast, &minVal, &maxVal, &stepVal, &paramVal, &paramFlag);//Unable to get the property, trying to return default value
-                pProcAmp->Release();
-                if (SUCCEEDED(hr))
-                    return paramVal;
-            }
-            break;
-        case CV_CAP_PROP_SATURATION:
-            if (SUCCEEDED(videoFileSource->GetServiceForStream((DWORD)MF_SOURCE_READER_MEDIASOURCE, GUID_NULL, IID_PPV_ARGS(&pProcAmp))))
-            {
-                long paramVal, paramFlag;
-                HRESULT hr = pProcAmp->Get(VideoProcAmp_Saturation, &paramVal, &paramFlag);
-                long minVal, maxVal, stepVal;
-                if (FAILED(hr))
-                    hr = pProcAmp->GetRange(VideoProcAmp_Saturation, &minVal, &maxVal, &stepVal, &paramVal, &paramFlag);//Unable to get the property, trying to return default value
-                pProcAmp->Release();
-                if (SUCCEEDED(hr))
-                    return paramVal;
-            }
-            break;
-        case CV_CAP_PROP_HUE:
-            if (SUCCEEDED(videoFileSource->GetServiceForStream((DWORD)MF_SOURCE_READER_MEDIASOURCE, GUID_NULL, IID_PPV_ARGS(&pProcAmp))))
-            {
-                long paramVal, paramFlag;
-                HRESULT hr = pProcAmp->Get(VideoProcAmp_Hue, &paramVal, &paramFlag);
-                long minVal, maxVal, stepVal;
-                if (FAILED(hr))
-                    hr = pProcAmp->GetRange(VideoProcAmp_Hue, &minVal, &maxVal, &stepVal, &paramVal, &paramFlag);//Unable to get the property, trying to return default value
-                pProcAmp->Release();
-                if (SUCCEEDED(hr))
-                    return paramVal;
-            }
-            break;
-        case CV_CAP_PROP_GAIN:
-            if (SUCCEEDED(videoFileSource->GetServiceForStream((DWORD)MF_SOURCE_READER_MEDIASOURCE, GUID_NULL, IID_PPV_ARGS(&pProcAmp))))
-            {
-                long paramVal, paramFlag;
-                HRESULT hr = pProcAmp->Get(VideoProcAmp_Gain, &paramVal, &paramFlag);
-                long minVal, maxVal, stepVal;
-                if (FAILED(hr))
-                    hr = pProcAmp->GetRange(VideoProcAmp_Gain, &minVal, &maxVal, &stepVal, &paramVal, &paramFlag);//Unable to get the property, trying to return default value
-                pProcAmp->Release();
-                if (SUCCEEDED(hr))
-                    return paramVal;
-            }
-            break;
-        case CV_CAP_PROP_SHARPNESS:
-            if (SUCCEEDED(videoFileSource->GetServiceForStream((DWORD)MF_SOURCE_READER_MEDIASOURCE, GUID_NULL, IID_PPV_ARGS(&pProcAmp))))
-            {
-                long paramVal, paramFlag;
-                HRESULT hr = pProcAmp->Get(VideoProcAmp_Sharpness, &paramVal, &paramFlag);
-                long minVal, maxVal, stepVal;
-                if (FAILED(hr))
-                    hr = pProcAmp->GetRange(VideoProcAmp_Sharpness, &minVal, &maxVal, &stepVal, &paramVal, &paramFlag);//Unable to get the property, trying to return default value
-                pProcAmp->Release();
-                if (SUCCEEDED(hr))
-                    return paramVal;
-            }
-            break;
-        case CV_CAP_PROP_GAMMA:
-            if (SUCCEEDED(videoFileSource->GetServiceForStream((DWORD)MF_SOURCE_READER_MEDIASOURCE, GUID_NULL, IID_PPV_ARGS(&pProcAmp))))
-            {
-                long paramVal, paramFlag;
-                HRESULT hr = pProcAmp->Get(VideoProcAmp_Gamma, &paramVal, &paramFlag);
-                long minVal, maxVal, stepVal;
-                if (FAILED(hr))
-                    hr = pProcAmp->GetRange(VideoProcAmp_Gamma, &minVal, &maxVal, &stepVal, &paramVal, &paramFlag);//Unable to get the property, trying to return default value
-                pProcAmp->Release();
-                if (SUCCEEDED(hr))
-                    return paramVal;
-            }
-            break;
-        case CV_CAP_PROP_BACKLIGHT:
-            if (SUCCEEDED(videoFileSource->GetServiceForStream((DWORD)MF_SOURCE_READER_MEDIASOURCE, GUID_NULL, IID_PPV_ARGS(&pProcAmp))))
-            {
-                long paramVal, paramFlag;
-                HRESULT hr = pProcAmp->Get(VideoProcAmp_BacklightCompensation, &paramVal, &paramFlag);
-                long minVal, maxVal, stepVal;
-                if (FAILED(hr))
-                    hr = pProcAmp->GetRange(VideoProcAmp_BacklightCompensation, &minVal, &maxVal, &stepVal, &paramVal, &paramFlag);//Unable to get the property, trying to return default value
-                pProcAmp->Release();
-                if (SUCCEEDED(hr))
-                    return paramVal;
-            }
-            break;
-        case CV_CAP_PROP_MONOCHROME:
-            if (SUCCEEDED(videoFileSource->GetServiceForStream((DWORD)MF_SOURCE_READER_MEDIASOURCE, GUID_NULL, IID_PPV_ARGS(&pProcAmp))))
-            {
-                long paramVal, paramFlag;
-                HRESULT hr = pProcAmp->Get(VideoProcAmp_ColorEnable, &paramVal, &paramFlag);
-                long minVal, maxVal, stepVal;
-                if (FAILED(hr))
-                    hr = pProcAmp->GetRange(VideoProcAmp_ColorEnable, &minVal, &maxVal, &stepVal, &paramVal, &paramFlag);//Unable to get the property, trying to return default value
-                pProcAmp->Release();
-                if (SUCCEEDED(hr))
-                    return paramVal == 0 ? 1 : 0;
-            }
-            break;
-        case CV_CAP_PROP_TEMPERATURE:
-            if (SUCCEEDED(videoFileSource->GetServiceForStream((DWORD)MF_SOURCE_READER_MEDIASOURCE, GUID_NULL, IID_PPV_ARGS(&pProcAmp))))
-            {
-                long paramVal, paramFlag;
-                HRESULT hr = pProcAmp->Get(VideoProcAmp_WhiteBalance, &paramVal, &paramFlag);
-                long minVal, maxVal, stepVal;
-                if (FAILED(hr))
-                    hr = pProcAmp->GetRange(VideoProcAmp_WhiteBalance, &minVal, &maxVal, &stepVal, &paramVal, &paramFlag);//Unable to get the property, trying to return default value
-                pProcAmp->Release();
-                if (SUCCEEDED(hr))
-                    return paramVal;
-            }
+		case CV_CAP_PROP_CONTRAST:
+		case CV_CAP_PROP_SATURATION:
+		case CV_CAP_PROP_HUE:
+		case CV_CAP_PROP_GAIN:
+		case CV_CAP_PROP_SHARPNESS:
+		case CV_CAP_PROP_GAMMA:
+		case CV_CAP_PROP_BACKLIGHT:
+		case CV_CAP_PROP_MONOCHROME:
+		case CV_CAP_PROP_TEMPERATURE:
+		{
+			VideoProcAmpProperty propertyAmp = getAmpPropFromCvCapProp(property_id);
+			if (SUCCEEDED(videoFileSource->GetServiceForStream((DWORD)MF_SOURCE_READER_MEDIASOURCE, GUID_NULL, IID_PPV_ARGS(&pProcAmp))))
+			{
+				long paramVal, paramFlag;
+				HRESULT hr = pProcAmp->Get(propertyAmp, &paramVal, &paramFlag);
+				if (SUCCEEDED(hr)) val = paramVal;
+				long minVal, maxVal, stepVal, defaultVal;
+				HRESULT hrRange = pProcAmp->GetRange(propertyAmp, &minVal, &maxVal, &stepVal, &defaultVal, &paramFlag);//Unable to get the property, trying to return default value
+				if (FAILED(hr) && SUCCEEDED(hrRange)) {
+					val = defaultVal;
+				}
+				pProcAmp->Release();
+				if (SUCCEEDED(hrRange)) {
+					min = minVal;
+					max = maxVal;
+					default_val = defaultVal;
+				}
+				if (SUCCEEDED(hr) || SUCCEEDED(hrRange)) {
+					return true;
+				}
+			}
+			break;
+		}	         
+       
+ 
         case CV_CAP_PROP_WHITE_BALANCE_BLUE_U:
         case CV_CAP_PROP_WHITE_BALANCE_RED_V:
             break;
-        case CV_CAP_PROP_PAN:
-            if (SUCCEEDED(videoFileSource->GetServiceForStream((DWORD)MF_SOURCE_READER_MEDIASOURCE, GUID_NULL, IID_PPV_ARGS(&pProcControl))))
-            {
-                long paramVal, paramFlag;
-                HRESULT hr = pProcControl->Get(CameraControl_Pan, &paramVal, &paramFlag);
-                long minVal, maxVal, stepVal;
-                if (FAILED(hr))
-                    hr = pProcControl->GetRange(CameraControl_Pan, &minVal, &maxVal, &stepVal, &paramVal, &paramFlag);//Unable to get the property, trying to return default value
-                pProcControl->Release();
-                if (SUCCEEDED(hr))
-                    return paramVal;
-            }
-            break;
-        case CV_CAP_PROP_TILT:
-            if (SUCCEEDED(videoFileSource->GetServiceForStream((DWORD)MF_SOURCE_READER_MEDIASOURCE, GUID_NULL, IID_PPV_ARGS(&pProcControl))))
-            {
-                long paramVal, paramFlag;
-                HRESULT hr = pProcControl->Get(CameraControl_Tilt, &paramVal, &paramFlag);
-                long minVal, maxVal, stepVal;
-                if (FAILED(hr))
-                    hr = pProcControl->GetRange(CameraControl_Tilt, &minVal, &maxVal, &stepVal, &paramVal, &paramFlag);//Unable to get the property, trying to return default value
-                pProcControl->Release();
-                if (SUCCEEDED(hr))
-                    return paramVal;
-            }
-            break;
-        case CV_CAP_PROP_ROLL:
-            if (SUCCEEDED(videoFileSource->GetServiceForStream((DWORD)MF_SOURCE_READER_MEDIASOURCE, GUID_NULL, IID_PPV_ARGS(&pProcControl))))
-            {
-                long paramVal, paramFlag;
-                HRESULT hr = pProcControl->Get(CameraControl_Roll, &paramVal, &paramFlag);
-                long minVal, maxVal, stepVal;
-                if (FAILED(hr))
-                    hr = pProcControl->GetRange(CameraControl_Roll, &minVal, &maxVal, &stepVal, &paramVal, &paramFlag);//Unable to get the property, trying to return default value
-                pProcControl->Release();
-                if (SUCCEEDED(hr))
-                    return paramVal;
-            }
-            break;
-        case CV_CAP_PROP_IRIS:
-            if (SUCCEEDED(videoFileSource->GetServiceForStream((DWORD)MF_SOURCE_READER_MEDIASOURCE, GUID_NULL, IID_PPV_ARGS(&pProcControl))))
-            {
-                long paramVal, paramFlag;
-                HRESULT hr = pProcControl->Get(CameraControl_Iris, &paramVal, &paramFlag);
-                long minVal, maxVal, stepVal;
-                if (FAILED(hr))
-                    hr = pProcControl->GetRange(CameraControl_Iris, &minVal, &maxVal, &stepVal, &paramVal, &paramFlag);//Unable to get the property, trying to return default value
-                pProcControl->Release();
-                if (SUCCEEDED(hr))
-                    return paramVal;
-            }
-            break;
-        case CV_CAP_PROP_EXPOSURE:
-            if (SUCCEEDED(videoFileSource->GetServiceForStream((DWORD)MF_SOURCE_READER_MEDIASOURCE, GUID_NULL, IID_PPV_ARGS(&pProcControl))))
-            {
-                long paramVal, paramFlag;
-                HRESULT hr = pProcControl->Get(CameraControl_Exposure, &paramVal, &paramFlag);
-                long minVal, maxVal, stepVal;
-                if (FAILED(hr))
-                    hr = pProcControl->GetRange(CameraControl_Exposure, &minVal, &maxVal, &stepVal, &paramVal, &paramFlag);//Unable to get the property, trying to return default value
-                pProcControl->Release();
-                if (SUCCEEDED(hr))
-                    return paramVal;
-            }
-        case CV_CAP_PROP_AUTO_EXPOSURE:
-            if (SUCCEEDED(videoFileSource->GetServiceForStream((DWORD)MF_SOURCE_READER_MEDIASOURCE, GUID_NULL, IID_PPV_ARGS(&pProcControl))))
-            {
-                long paramVal, paramFlag;
-                HRESULT hr = pProcControl->Get(CameraControl_Exposure, &paramVal, &paramFlag);
-                long minVal, maxVal, stepVal;
-                if (FAILED(hr))
-                    hr = pProcControl->GetRange(CameraControl_Exposure, &minVal, &maxVal, &stepVal, &paramVal, &paramFlag);//Unable to get the property, trying to return default value
-                pProcControl->Release();
-                if (SUCCEEDED(hr))
-                    return paramFlag == VideoProcAmp_Flags_Auto;
-            }
-            break;
-        case CV_CAP_PROP_ZOOM:
-            if (SUCCEEDED(videoFileSource->GetServiceForStream((DWORD)MF_SOURCE_READER_MEDIASOURCE, GUID_NULL, IID_PPV_ARGS(&pProcControl))))
-            {
-                long paramVal, paramFlag;
-                HRESULT hr = pProcControl->Get(CameraControl_Zoom, &paramVal, &paramFlag);
-                long minVal, maxVal, stepVal;
-                if (FAILED(hr))
-                    hr = pProcControl->GetRange(CameraControl_Zoom, &minVal, &maxVal, &stepVal, &paramVal, &paramFlag);//Unable to get the property, trying to return default value
-                pProcControl->Release();
-                if (SUCCEEDED(hr))
-                    return paramVal;
-            }
-            break;
-        case CV_CAP_PROP_FOCUS:
-            if (SUCCEEDED(videoFileSource->GetServiceForStream((DWORD)MF_SOURCE_READER_MEDIASOURCE, GUID_NULL, IID_PPV_ARGS(&pProcControl))))
-            {
-                long paramVal, paramFlag;
-                HRESULT hr = pProcControl->Get(CameraControl_Focus, &paramVal, &paramFlag);
-                long minVal, maxVal, stepVal;
-                if (FAILED(hr))
-                    hr = pProcControl->GetRange(CameraControl_Focus, &minVal, &maxVal, &stepVal, &paramVal, &paramFlag);//Unable to get the property, trying to return default value
-                pProcControl->Release();
-                if (SUCCEEDED(hr))
-                    return paramVal;
-            }
-        case CV_CAP_PROP_AUTOFOCUS:
-            if (SUCCEEDED(videoFileSource->GetServiceForStream((DWORD)MF_SOURCE_READER_MEDIASOURCE, GUID_NULL, IID_PPV_ARGS(&pProcControl))))
-            {
-                long paramVal, paramFlag;
-                HRESULT hr = pProcControl->Get(CameraControl_Focus, &paramVal, &paramFlag);
-                long minVal, maxVal, stepVal;
-                if (FAILED(hr))
-                    hr = pProcControl->GetRange(CameraControl_Focus, &minVal, &maxVal, &stepVal, &paramVal, &paramFlag);//Unable to get the property, trying to return default value
-                pProcControl->Release();
-                if (SUCCEEDED(hr))
-                    return paramFlag == VideoProcAmp_Flags_Auto;
-            }
-            break;
 
+
+        case CV_CAP_PROP_PAN:
+		case CV_CAP_PROP_TILT:
+		case CV_CAP_PROP_ROLL:
+		case CV_CAP_PROP_IRIS:
+		case CV_CAP_PROP_EXPOSURE:
+		case CV_CAP_PROP_AUTO_EXPOSURE:
+		case CV_CAP_PROP_ZOOM:
+		case CV_CAP_PROP_FOCUS:
+		case CV_CAP_PROP_AUTOFOCUS:
+		{
+			CameraControlProperty propertyControl = getControlPropFromCvCapProp(property_id);
+			if (SUCCEEDED(videoFileSource->GetServiceForStream((DWORD)MF_SOURCE_READER_MEDIASOURCE, GUID_NULL, IID_PPV_ARGS(&pProcControl))))
+			{
+				long paramVal, paramFlag;
+				HRESULT hr = pProcControl->Get(propertyControl, &paramVal, &paramFlag);
+				if (SUCCEEDED(hr)) val = paramVal;
+				long minVal, maxVal, stepVal, defaultVal;
+				HRESULT hrRange = pProcControl->GetRange(propertyControl, &minVal, &maxVal, &stepVal, &defaultVal, &paramFlag);//Unable to get the property, trying to return default value
+				if (FAILED(hr) && SUCCEEDED(hrRange)) {
+					val = defaultVal;
+				}
+				pProcControl->Release();
+				if (SUCCEEDED(hrRange)) {
+					min = minVal;
+					max = maxVal;
+					default_val = defaultVal;
+				}
+				if (SUCCEEDED(hr) || SUCCEEDED(hrRange)) {
+					if (property_id == CV_CAP_PROP_AUTO_EXPOSURE || property_id == CV_CAP_PROP_AUTOFOCUS) {
+						val = paramFlag == VideoProcAmp_Flags_Auto;
+					}
+					return true;
+
+				}
+			}
+			break;
+		}
+			
+   
         case CV_CAP_PROP_RECTIFICATION:
         case CV_CAP_PROP_TRIGGER:
         case CV_CAP_PROP_TRIGGER_DELAY:
@@ -1668,7 +1581,7 @@ double CvCapture_MSMF::getProperty( int property_id ) const
             break;
         }
 
-    return -1;
+    return false;
 }
 
 bool CvCapture_MSMF::setProperty( int property_id, double value )

--- a/modules/videoio/test/test_camera.cpp
+++ b/modules/videoio/test/test_camera.cpp
@@ -46,15 +46,23 @@ TEST(DISABLED_videoio_camera, msmfGetPropertyRange) {
 	ASSERT_TRUE(capture.isOpened());
 	double val, min, max, defaultVal;
 
-
-	bool getSuccess= capture.get(CAP_PROP_EXPOSURE,val,min,max,defaultVal);
+	vector<double> vals;
+	bool getSuccess= capture.get(CAP_PROP_EXPOSURE,vals);
+	val = vals[0];
+	min = vals[1];
+	max = vals[2];
+	defaultVal = vals[3];
 	ASSERT_TRUE(getSuccess);
 	ASSERT_TRUE(min < max);
 	ASSERT_TRUE(val >= min && val <= max);
 	ASSERT_TRUE(defaultVal >= min && defaultVal <= max);
 
 
-	getSuccess = capture.get(CAP_PROP_BRIGHTNESS, val, min, max, defaultVal);
+	getSuccess = capture.get(CAP_PROP_BRIGHTNESS, vals);
+	val = vals[0];
+	min = vals[1];
+	max = vals[2];
+	defaultVal = vals[3];
 	ASSERT_TRUE(getSuccess);
 	ASSERT_TRUE(min < max);
 	ASSERT_TRUE(val >= min && val <= max);
@@ -70,15 +78,23 @@ TEST(DISABLED_videoio_camera, dshowGetPropertyRange) {
 	ASSERT_TRUE(capture.isOpened());
 	double val, min, max, defaultVal;
 
-
-	bool getSuccess = capture.get(CAP_PROP_EXPOSURE, val, min, max, defaultVal);
+	vector<double> vals;
+	bool getSuccess = capture.get(CAP_PROP_EXPOSURE, vals);
+	val = vals[0];
+	min = vals[1];
+	max = vals[2];
+	defaultVal = vals[3];
 	ASSERT_TRUE(getSuccess);
 	ASSERT_TRUE(min < max);
 	ASSERT_TRUE(val >= min && val <= max);
 	ASSERT_TRUE(defaultVal >= min && defaultVal <= max);
 
 
-	getSuccess = capture.get(CAP_PROP_BRIGHTNESS, val, min, max, defaultVal);
+	getSuccess = capture.get(CAP_PROP_BRIGHTNESS, vals);
+	val = vals[0];
+	min = vals[1];
+	max = vals[2];
+	defaultVal = vals[3];
 	ASSERT_TRUE(getSuccess);
 	ASSERT_TRUE(min < max);
 	ASSERT_TRUE(val >= min && val <= max);

--- a/modules/videoio/test/test_camera.cpp
+++ b/modules/videoio/test/test_camera.cpp
@@ -69,7 +69,6 @@ TEST(DISABLED_videoio_camera, msmfGetPropertyRange) {
     ASSERT_TRUE(defaultVal >= min && defaultVal <= max);
 
     capture.release();
-    
 }
 
 
@@ -101,7 +100,6 @@ TEST(DISABLED_videoio_camera, dshowGetPropertyRange) {
     ASSERT_TRUE(defaultVal >= min && defaultVal <= max);
 
     capture.release();
-
 }
 
 TEST(DISABLED_videoio_camera, v4l_read_mjpg)

--- a/modules/videoio/test/test_camera.cpp
+++ b/modules/videoio/test/test_camera.cpp
@@ -41,6 +41,53 @@ TEST(DISABLED_videoio_camera, basic)
     capture.release();
 }
 
+TEST(DISABLED_videoio_camera, msmfGetPropertyRange) {
+	VideoCapture capture(0,CAP_MSMF);
+	ASSERT_TRUE(capture.isOpened());
+	double val, min, max, defaultVal;
+
+
+	bool getSuccess= capture.get(CAP_PROP_EXPOSURE,val,min,max,defaultVal);
+	ASSERT_TRUE(getSuccess);
+	ASSERT_TRUE(min < max);
+	ASSERT_TRUE(val >= min && val <= max);
+	ASSERT_TRUE(defaultVal >= min && defaultVal <= max);
+
+
+	getSuccess = capture.get(CAP_PROP_BRIGHTNESS, val, min, max, defaultVal);
+	ASSERT_TRUE(getSuccess);
+	ASSERT_TRUE(min < max);
+	ASSERT_TRUE(val >= min && val <= max);
+	ASSERT_TRUE(defaultVal >= min && defaultVal <= max);
+
+	capture.release();
+	
+}
+
+
+TEST(DISABLED_videoio_camera, dshowGetPropertyRange) {
+	VideoCapture capture(0, CAP_DSHOW);
+	ASSERT_TRUE(capture.isOpened());
+	double val, min, max, defaultVal;
+
+
+	bool getSuccess = capture.get(CAP_PROP_EXPOSURE, val, min, max, defaultVal);
+	ASSERT_TRUE(getSuccess);
+	ASSERT_TRUE(min < max);
+	ASSERT_TRUE(val >= min && val <= max);
+	ASSERT_TRUE(defaultVal >= min && defaultVal <= max);
+
+
+	getSuccess = capture.get(CAP_PROP_BRIGHTNESS, val, min, max, defaultVal);
+	ASSERT_TRUE(getSuccess);
+	ASSERT_TRUE(min < max);
+	ASSERT_TRUE(val >= min && val <= max);
+	ASSERT_TRUE(defaultVal >= min && defaultVal <= max);
+
+	capture.release();
+
+}
+
 TEST(DISABLED_videoio_camera, v4l_read_mjpg)
 {
     VideoCapture capture(CAP_V4L2);

--- a/modules/videoio/test/test_camera.cpp
+++ b/modules/videoio/test/test_camera.cpp
@@ -42,65 +42,65 @@ TEST(DISABLED_videoio_camera, basic)
 }
 
 TEST(DISABLED_videoio_camera, msmfGetPropertyRange) {
-	VideoCapture capture(0,CAP_MSMF);
-	ASSERT_TRUE(capture.isOpened());
-	double val, min, max, defaultVal;
+    VideoCapture capture(0,CAP_MSMF);
+    ASSERT_TRUE(capture.isOpened());
+    double val, min, max, defaultVal;
 
-	vector<double> vals;
-	bool getSuccess= capture.get(CAP_PROP_EXPOSURE,vals);
-	val = vals[0];
-	min = vals[1];
-	max = vals[2];
-	defaultVal = vals[3];
-	ASSERT_TRUE(getSuccess);
-	ASSERT_TRUE(min < max);
-	ASSERT_TRUE(val >= min && val <= max);
-	ASSERT_TRUE(defaultVal >= min && defaultVal <= max);
+    vector<double> vals;
+    bool getSuccess= capture.get(CAP_PROP_EXPOSURE,vals);
+    val = vals[0];
+    min = vals[1];
+    max = vals[2];
+    defaultVal = vals[3];
+    ASSERT_TRUE(getSuccess);
+    ASSERT_TRUE(min < max);
+    ASSERT_TRUE(val >= min && val <= max);
+    ASSERT_TRUE(defaultVal >= min && defaultVal <= max);
 
 
-	getSuccess = capture.get(CAP_PROP_BRIGHTNESS, vals);
-	val = vals[0];
-	min = vals[1];
-	max = vals[2];
-	defaultVal = vals[3];
-	ASSERT_TRUE(getSuccess);
-	ASSERT_TRUE(min < max);
-	ASSERT_TRUE(val >= min && val <= max);
-	ASSERT_TRUE(defaultVal >= min && defaultVal <= max);
+    getSuccess = capture.get(CAP_PROP_BRIGHTNESS, vals);
+    val = vals[0];
+    min = vals[1];
+    max = vals[2];
+    defaultVal = vals[3];
+    ASSERT_TRUE(getSuccess);
+    ASSERT_TRUE(min < max);
+    ASSERT_TRUE(val >= min && val <= max);
+    ASSERT_TRUE(defaultVal >= min && defaultVal <= max);
 
-	capture.release();
-	
+    capture.release();
+    
 }
 
 
 TEST(DISABLED_videoio_camera, dshowGetPropertyRange) {
-	VideoCapture capture(0, CAP_DSHOW);
-	ASSERT_TRUE(capture.isOpened());
-	double val, min, max, defaultVal;
+    VideoCapture capture(0, CAP_DSHOW);
+    ASSERT_TRUE(capture.isOpened());
+    double val, min, max, defaultVal;
 
-	vector<double> vals;
-	bool getSuccess = capture.get(CAP_PROP_EXPOSURE, vals);
-	val = vals[0];
-	min = vals[1];
-	max = vals[2];
-	defaultVal = vals[3];
-	ASSERT_TRUE(getSuccess);
-	ASSERT_TRUE(min < max);
-	ASSERT_TRUE(val >= min && val <= max);
-	ASSERT_TRUE(defaultVal >= min && defaultVal <= max);
+    vector<double> vals;
+    bool getSuccess = capture.get(CAP_PROP_EXPOSURE, vals);
+    val = vals[0];
+    min = vals[1];
+    max = vals[2];
+    defaultVal = vals[3];
+    ASSERT_TRUE(getSuccess);
+    ASSERT_TRUE(min < max);
+    ASSERT_TRUE(val >= min && val <= max);
+    ASSERT_TRUE(defaultVal >= min && defaultVal <= max);
 
 
-	getSuccess = capture.get(CAP_PROP_BRIGHTNESS, vals);
-	val = vals[0];
-	min = vals[1];
-	max = vals[2];
-	defaultVal = vals[3];
-	ASSERT_TRUE(getSuccess);
-	ASSERT_TRUE(min < max);
-	ASSERT_TRUE(val >= min && val <= max);
-	ASSERT_TRUE(defaultVal >= min && defaultVal <= max);
+    getSuccess = capture.get(CAP_PROP_BRIGHTNESS, vals);
+    val = vals[0];
+    min = vals[1];
+    max = vals[2];
+    defaultVal = vals[3];
+    ASSERT_TRUE(getSuccess);
+    ASSERT_TRUE(min < max);
+    ASSERT_TRUE(val >= min && val <= max);
+    ASSERT_TRUE(defaultVal >= min && defaultVal <= max);
 
-	capture.release();
+    capture.release();
 
 }
 


### PR DESCRIPTION
**RFC**
resolves #15219
### This pullrequest changes

VideoCapture get properties support range and default value, add msmf and dshow backend implemention