### PR TITLE
DNN: multiple outputs for asynchronous inference

### DIFF
--- a/modules/core/include/opencv2/core/mat.hpp
+++ b/modules/core/include/opencv2/core/mat.hpp
@@ -380,6 +380,7 @@ public:
 
     void move(UMat& u) const;
     void move(Mat& m) const;
+    void move(std::vector<Mat>& m) const;
 };
 
 

--- a/modules/core/src/matrix_wrap.cpp
+++ b/modules/core/src/matrix_wrap.cpp
@@ -1949,6 +1949,29 @@ void _OutputArray::move(Mat& m) const
     }
 }
 
+void _OutputArray::move(std::vector<Mat>& m) const
+{
+    if (fixedSize())
+    {
+        // TODO Performance warning
+        assign(m);
+        return;
+    }
+    int k = kind();
+    if (k == STD_VECTOR_MAT)
+    {
+#ifdef CV_CXX11
+        *(std::vector<Mat>*)obj = std::move(m);
+#else
+        *(std::vector<Mat>*)obj = m;
+        m.release();
+#endif
+    }
+    else
+    {
+        CV_Error(Error::StsNotImplemented, "");
+    }
+}
 
 void _OutputArray::assign(const std::vector<UMat>& v) const
 {

--- a/modules/dnn/include/opencv2/dnn/dnn.hpp
+++ b/modules/dnn/include/opencv2/dnn/dnn.hpp
@@ -504,6 +504,8 @@ CV__DNN_EXPERIMENTAL_NS_BEGIN
          */
         CV_WRAP AsyncArray forwardAsync(const String& outputName = String());
 
+        CV_WRAP AsyncArray forwardAsync(const std::vector<String>& outputsNames);
+
         /** @brief Runs forward pass to compute output of layer with name @p outputName.
          *  @param outputBlobs contains all output blobs for specified layer.
          *  @param outputName name for layer which output is needed to get

--- a/modules/dnn/src/op_inf_engine.hpp
+++ b/modules/dnn/src/op_inf_engine.hpp
@@ -126,10 +126,11 @@ private:
     {
         InfEngineReqWrapper() : isReady(true) {}
 
-        void makePromises(const std::vector<Ptr<BackendWrapper> >& outs);
+        void makePromises(const std::vector<Ptr<BackendWrapper> >& outs,
+                          const std::vector<std::string>& outsNames);
 
         InferenceEngine::InferRequest req;
-        std::vector<cv::AsyncPromise> outProms;
+        cv::AsyncPromise outProm;
         std::vector<std::string> outsNames;
         bool isReady;
     };
@@ -143,6 +144,7 @@ private:
     std::vector<std::string> requestedOutputs;
 
     std::set<std::pair<int, int> > unconnectedPorts;
+    std::vector<std::string> outsNames;  // We have to store output names order similar to expected output promises order.
 };
 
 class InfEngineBackendNode : public BackendNode

--- a/modules/dnn/test/test_darknet_importer.cpp
+++ b/modules/dnn/test/test_darknet_importer.cpp
@@ -418,6 +418,7 @@ TEST_P(Test_Darknet_nets_async, Accuracy)
     {
         netSync.setInput(inputs[i]);
         refs[i] = netSync.forward().clone();
+
     }
 
     Net netAsync = readNet(findDataFile("dnn/" + prefix + ".cfg"),


### PR DESCRIPTION
<!-- Please use this line to close one or multiple issues when this pullrequest gets merged
You can add another line right under the first one:
resolves #1234
resolves #1235
-->

### This pullrequest changes

- [x] NNBuilder API
- [ ] nGraph API

resolves https://github.com/opencv/opencv/issues/15023

Let's merge it after https://github.com/opencv/opencv/pull/15537

```
force_builders=Custom,Custom Win,Custom Mac
build_image:Custom=ubuntu-openvino-2020.1.0:16.04
build_image:Custom Win=openvino-2020.1.0
build_image:Custom Mac=openvino-2020.1.0

test_modules:Custom=dnn,python2,python3,java
test_modules:Custom Win=dnn,python2,python3,java
test_modules:Custom Mac=dnn,python2,python3,java

buildworker:Custom=linux-1
# disabled due high memory usage: test_opencl:Custom=ON
test_opencl:Custom=OFF
test_bigdata:Custom=1
test_filter:Custom=*
```