### PR TITLE
ts: eliminate -Warray-bounds warning

### DIFF
--- a/modules/ts/src/ts_func.cpp
+++ b/modules/ts/src/ts_func.cpp
@@ -2703,7 +2703,7 @@ static void calcSobelKernel1D( int order, int _aperture_size, int size, vector<i
 
     if( _aperture_size < 0 )
     {
-        static const int scharr[] = { 3, 10, 3, -1, 0, 1 };
+        static const int scharr[8] = { 3, 10, 3, -1, 0, 1, 0, 0 };  // extra elements to eliminate "-Warray-bounds" bogus warning
         assert( size == 3 );
         for( i = 0; i < size; i++ )
             kernel[i] = scharr[order*3 + i];


### PR DESCRIPTION
GCC8

Message:
```
In function 'cv::Mat cvtest::calcLaplaceKernel2D(int)':
cc1plus: warning: 'void* __builtin_memcpy(void*, const void*, long unsigned int)' forming offset [25, 32] is out of the bounds [0, 24] of object 'scharr' with type 'const int [6]' [-Warray-bounds]
/build/precommit_custom_linux/3.4/opencv/modules/ts/src/ts_func.cpp:2706:26: note: 'scharr' declared here
         static const int scharr[] = { 3, 10, 3, -1, 0, 1 };
```

<cut/>

```
buildworker:Custom=linux-1
build_image:Custom=powerpc64le
```