### PR TITLE
G-API: fixing CMake warning for standalone build

### DIFF
--- a/modules/gapi/CMakeLists.txt
+++ b/modules/gapi/CMakeLists.txt
@@ -2,6 +2,7 @@
 # (Restructure directories, add common pass, etc)
 if (NOT DEFINED OPENCV_INITIAL_PASS)
     cmake_minimum_required(VERSION 3.3)
+    project(gapi_standalone)
     include("cmake/standalone.cmake")
     return()
 endif()


### PR DESCRIPTION
added `project` command for stand-alone build
```
build_gapi_standalone:Linux x64=ade-0.1.1f
build_gapi_standalone:Win64=ade-0.1.1f
build_gapi_standalone:Mac=ade-0.1.1f
build_gapi_standalone:Linux x64 Debug=ade-0.1.1f
```

@dmatveev please take a look 
