### PR TITLE
Split assertion to make error message more specific

### DIFF
--- a/modules/calib3d/src/undistort.dispatch.cpp
+++ b/modules/calib3d/src/undistort.dispatch.cpp
@@ -122,7 +122,8 @@ void initUndistortRectifyMap( InputArray _cameraMatrix, InputArray _distCoeffs,
         distCoeffs = 0.;
     }
 
-    CV_Assert( A.size() == Size(3,3) && A.size() == R.size() );
+    CV_Assert( A.size() == Size(3,3) );
+    CV_Assert( R.size() == Size(3,3) );
     CV_Assert( Ar.size() == Size(3,3) || Ar.size() == Size(4, 3));
     Mat_<double> iR = (Ar.colRange(0,3)*R).inv(DECOMP_LU);
     const double* ir = &iR(0,0);


### PR DESCRIPTION
I think having the assertion split into two separate assertions gives the programmer a better hint which of the matrices has the wrong size and speeds up debugging.