### PR TITLE
CV_PAUSE: Include definition of _mm_pause.

### DIFF
--- a/modules/core/src/parallel_impl.cpp
+++ b/modules/core/src/parallel_impl.cpp
@@ -42,6 +42,7 @@ DECLARE_CV_PAUSE
       static inline void cv_non_sse_mm_pause() { __asm__ __volatile__ ("rep; nop"); }
 #     define _mm_pause cv_non_sse_mm_pause
 #   endif
+#   include <emmintrin.h>
 #   define CV_PAUSE(v) do { for (int __delay = (v); __delay > 0; --__delay) { _mm_pause(); } } while (0)
 # elif defined __GNUC__ && defined __aarch64__
 #   define CV_PAUSE(v) do { for (int __delay = (v); __delay > 0; --__delay) { asm volatile("yield" ::: "memory"); } } while (0)


### PR DESCRIPTION
I tried to build OpenCV version 4.1.1 with minimal optimizations (CV_DISABLE_OPTIMIZATION=1) and I get the following error:

    [ 95%] Building CXX object modules/core/CMakeFiles/opencv_core.dir/src/parallel_impl.cpp.o
    /Users/.../opencv-4.1.1/modules/core/src/parallel_impl.cpp:368:21: error: use of
          undeclared identifier '_mm_pause'
                        CV_PAUSE(16);
                        ^
    /Users/.../opencv-4.1.1/modules/core/src/parallel_impl.cpp:45:79: note: 
          expanded from macro 'CV_PAUSE'
      ...do { for (int __delay = (v); __delay > 0; --__delay) { _mm_pause(); } } ...
                                                                ^

The `_mm_pause` intrinsic function is defined in the header file `emmintrin.h` (which comes with Clang). https://software.intel.com/sites/landingpage/IntrinsicsGuide/#text=pause&expand=4141
