### PR TITLE
Convert all the vectors to lists for Python bindings

### DIFF
--- a/modules/dnn/misc/python/test/test_dnn.py
+++ b/modules/dnn/misc/python/test/test_dnn.py
@@ -154,11 +154,16 @@ class dnn_test(NewOpenCVTests):
         normAssertDetections(self, refClassIds, refConfidences, refBoxes,
                              classIds, confidences, boxes,confThreshold, scoreDiff, iouDiff)
 
-        for box in boxes:
+        self.assertTrue(isinstance(classIds, list))
+        self.assertTrue(isinstance(confidences, list))
+        self.assertTrue(isinstance(boxes, list))
+        for classId, score, box in zip(classIds, confidences, boxes):
             cv.rectangle(frame, box, (0, 255, 0))
             cv.rectangle(frame, np.array(box), (0, 255, 0))
             cv.rectangle(frame, tuple(box), (0, 255, 0))
             cv.rectangle(frame, list(box), (0, 255, 0))
+            self.assertTrue(isinstance(classId, int))
+            self.assertTrue(isinstance(score, float))
 
 
     def test_classification_model(self):


### PR DESCRIPTION
<!-- Please use this line to close one or multiple issues when this pullrequest gets merged
You can add another line right under the first one:
resolves #1234
resolves #1235
-->

### This pullrequest changes

For now all the C++ vectors with simple data types are converted to numpy arrays with number of rows == number of values and number of columns == 1. That means we need to iterate in the following way:
```python
for elem in result:
  value = elem[0]
```
```
>>> print(result)
[[1],
 [2],
 [3]]
```
This PR proposes to convert `std::vector<T>` to lists so
```
>>> print(result)
[1, 2, 3]
```

Example with dnn:

```python
classIds, confidences, boxes = model.detect(frame)
for classId, score, box in zip(classIds, confidences, boxes):
  actualClassID = classId[0]
  actualScore = score[0]
```

**WIP**: let's check tests.