### PR TITLE
Fix DetectionModel in case of out of [0, 1] range detection prediction

### DIFF
--- a/modules/dnn/src/model.cpp
+++ b/modules/dnn/src/model.cpp
@@ -230,7 +230,7 @@ void DetectionModel::detect(InputArray frame, CV_OUT std::vector<int>& classIds,
                 int width  = right  - left + 1;
                 int height = bottom - top + 1;
 
-                if (width * height <= 1)
+                if (width <= 2 || height <= 2)
                 {
                     left   = data[j + 3] * frameWidth;
                     top    = data[j + 4] * frameHeight;

--- a/modules/dnn/test/test_model.cpp
+++ b/modules/dnn/test/test_model.cpp
@@ -221,6 +221,28 @@ TEST_P(Test_Model, DetectionMobilenetSSD)
                     scoreDiff, iouDiff, confThreshold, nmsThreshold, size, mean, scale);
 }
 
+TEST_P(Test_Model, Detection_normalized)
+{
+    std::string img_path = _tf("grace_hopper_227.png");
+    std::vector<int> refClassIds = {15};
+    std::vector<float> refConfidences = {0.999222f};
+    std::vector<Rect2d> refBoxes = {Rect2d(0, 4, 227, 222)};
+
+    std::string weights_file = _tf("MobileNetSSD_deploy.caffemodel");
+    std::string config_file = _tf("MobileNetSSD_deploy.prototxt");
+
+    Scalar mean = Scalar(127.5, 127.5, 127.5);
+    double scale = 1.0 / 127.5;
+    Size size{300, 300};
+
+    double scoreDiff = (target == DNN_TARGET_OPENCL_FP16 || target == DNN_TARGET_MYRIAD) ? 5e-3 : 1e-5;
+    double iouDiff = (target == DNN_TARGET_OPENCL_FP16 || target == DNN_TARGET_MYRIAD) ? 0.09 : 1e-5;
+    float confThreshold = FLT_MIN;
+    double nmsThreshold = 0.0;
+    testDetectModel(weights_file, config_file, img_path, refClassIds, refConfidences, refBoxes,
+                    scoreDiff, iouDiff, confThreshold, nmsThreshold, size, mean, scale);
+}
+
 TEST_P(Test_Model, Segmentation)
 {
     std::string inp = _tf("dog416.png");


### PR DESCRIPTION
<!-- Please use this line to close one or multiple issues when this pullrequest gets merged
You can add another line right under the first one:
resolves #1234
resolves #1235
-->

### This pullrequest changes

Fix missed detections in case of predicted values in relative coordinates but out of [0, 1] range (will fix samples in a separate PR).

```
force_builders=Custom,Custom Win,Custom Mac
build_image:Custom=ubuntu-openvino-2019r2.0:16.04
build_image:Custom Win=openvino-2019r2.0
build_image:Custom Mac=openvino-2019r2.0

test_modules:Custom=dnn,python2,python3,java
test_modules:Custom Win=dnn,python2,python3,java
test_modules:Custom Mac=dnn,python2,python3,java

buildworker:Custom=linux-1
test_opencl:Custom=ON
test_bigdata:Custom=1
test_filter:Custom=*
```