### PR TITLE
AVFoundation: fix camera authorization request

### DIFF
--- a/modules/videoio/src/cap_avfoundation_mac.mm
+++ b/modules/videoio/src/cap_avfoundation_mac.mm
@@ -328,10 +328,28 @@ int CvCaptureCAM::startCaptureDevice(int cameraNum) {
     }
     else if (status != AVAuthorizationStatusAuthorized)
     {
-        fprintf(stderr, "OpenCV: not authorized to capture video (status %ld), requesting...\n", status);
-        // TODO: doesn't work via ssh
-        [AVCaptureDevice requestAccessForMediaType:AVMediaTypeVideo completionHandler:^(BOOL) { /* we don't care */}];
-        // we do not wait for completion
+        if (!cv::utils::getConfigurationParameterBool("OPENCV_AVFOUNDATION_SKIP_AUTH", false))
+        {
+            fprintf(stderr, "OpenCV: not authorized to capture video (status %ld), requesting...\n", status);
+            [AVCaptureDevice requestAccessForMediaType:AVMediaTypeVideo completionHandler:^(BOOL) { /* we don't care */}];
+            if ([NSThread isMainThread])
+            {
+                // we run the main loop for 0.1 sec to show the message
+                [[NSRunLoop mainRunLoop] runUntilDate:[NSDate dateWithTimeIntervalSinceNow:0.1]];
+            }
+            else
+            {
+                fprintf(stderr, "OpenCV: can not spin main run loop from other thread, set "
+                                "OPENCV_AVFOUNDATION_SKIP_AUTH=1 to disable authorization request "
+                                "and perform it in your application.\n");
+            }
+        }
+        else
+        {
+            fprintf(stderr, "OpenCV: not authorized to capture video (status %ld), set "
+                            "OPENCV_AVFOUNDATION_SKIP_AUTH=0 to enable authorization request or "
+                            "perform it in your application.\n", status);
+        }
         [localpool drain];
         return 0;
     }

--- a/modules/videoio/src/cap_avfoundation_mac.mm
+++ b/modules/videoio/src/cap_avfoundation_mac.mm
@@ -316,42 +316,45 @@ int CvCaptureCAM::startCaptureDevice(int cameraNum) {
     NSAutoreleasePool *localpool = [[NSAutoreleasePool alloc] init];
 
 #if defined(__MAC_OS_X_VERSION_MAX_ALLOWED) && __MAC_OS_X_VERSION_MAX_ALLOWED >= 101400
-    AVAuthorizationStatus status = [AVCaptureDevice authorizationStatusForMediaType:AVMediaTypeVideo];
-    if (status == AVAuthorizationStatusDenied)
+    if (@available(macOS 10.14, *))
     {
-        fprintf(stderr, "OpenCV: camera access has been denied. Either run 'tccutil reset Camera' "
-                        "command in same terminal to reset application authorization status, "
-                        "either modify 'System Preferences -> Security & Privacy -> Camera' "
-                        "settings for your application.\n");
-        [localpool drain];
-        return 0;
-    }
-    else if (status != AVAuthorizationStatusAuthorized)
-    {
-        if (!cv::utils::getConfigurationParameterBool("OPENCV_AVFOUNDATION_SKIP_AUTH", false))
+        AVAuthorizationStatus status = [AVCaptureDevice authorizationStatusForMediaType:AVMediaTypeVideo];
+        if (status == AVAuthorizationStatusDenied)
         {
-            fprintf(stderr, "OpenCV: not authorized to capture video (status %ld), requesting...\n", status);
-            [AVCaptureDevice requestAccessForMediaType:AVMediaTypeVideo completionHandler:^(BOOL) { /* we don't care */}];
-            if ([NSThread isMainThread])
+            fprintf(stderr, "OpenCV: camera access has been denied. Either run 'tccutil reset Camera' "
+                            "command in same terminal to reset application authorization status, "
+                            "either modify 'System Preferences -> Security & Privacy -> Camera' "
+                            "settings for your application.\n");
+            [localpool drain];
+            return 0;
+        }
+        else if (status != AVAuthorizationStatusAuthorized)
+        {
+            if (!cv::utils::getConfigurationParameterBool("OPENCV_AVFOUNDATION_SKIP_AUTH", false))
             {
-                // we run the main loop for 0.1 sec to show the message
-                [[NSRunLoop mainRunLoop] runUntilDate:[NSDate dateWithTimeIntervalSinceNow:0.1]];
+                fprintf(stderr, "OpenCV: not authorized to capture video (status %ld), requesting...\n", status);
+                [AVCaptureDevice requestAccessForMediaType:AVMediaTypeVideo completionHandler:^(BOOL) { /* we don't care */}];
+                if ([NSThread isMainThread])
+                {
+                    // we run the main loop for 0.1 sec to show the message
+                    [[NSRunLoop mainRunLoop] runUntilDate:[NSDate dateWithTimeIntervalSinceNow:0.1]];
+                }
+                else
+                {
+                    fprintf(stderr, "OpenCV: can not spin main run loop from other thread, set "
+                                    "OPENCV_AVFOUNDATION_SKIP_AUTH=1 to disable authorization request "
+                                    "and perform it in your application.\n");
+                }
             }
             else
             {
-                fprintf(stderr, "OpenCV: can not spin main run loop from other thread, set "
-                                "OPENCV_AVFOUNDATION_SKIP_AUTH=1 to disable authorization request "
-                                "and perform it in your application.\n");
+                fprintf(stderr, "OpenCV: not authorized to capture video (status %ld), set "
+                                "OPENCV_AVFOUNDATION_SKIP_AUTH=0 to enable authorization request or "
+                                "perform it in your application.\n", status);
             }
+            [localpool drain];
+            return 0;
         }
-        else
-        {
-            fprintf(stderr, "OpenCV: not authorized to capture video (status %ld), set "
-                            "OPENCV_AVFOUNDATION_SKIP_AUTH=0 to enable authorization request or "
-                            "perform it in your application.\n", status);
-        }
-        [localpool drain];
-        return 0;
     }
 #endif
 


### PR DESCRIPTION
related #14267
related #14278

### This pullrequest changes

Authorization request being sent does can not result in message because of application exit (e.g. _example_cpp_videocapture_camera_). Thus added main run loop spin with small delay to make sure UI performs request.

Added an environment configuration parameter (`OPENCV_AVFOUNDATION_SKIP_AUTH`) to skip authorization request in OpenCV. Authorization check is still performed.

Backported runtime OSX check from _master_ branch. It should've been done in #14500, but slipped away for some reason.

cc @jeroen

```
allow_multiple_commits=1
```