### PR TITLE
cmake: use 'long long' for atomic check

### DIFF
--- a/cmake/checks/atomic_check.cpp
+++ b/cmake/checks/atomic_check.cpp
@@ -2,7 +2,7 @@
 
 static int test()
 {
-    std::atomic<int> x;
+    std::atomic<long long> x;
     return x;
 }
 


### PR DESCRIPTION
resolves #15278

<cut/>

```
buildworker:Custom=linux-1,linux-2,linux-4
docker_image:Custom=powerpc64le
```