### PR TITLE
Improve copymask and implement SIMD extensions

### DIFF
--- a/modules/core/include/opencv2/core/hal/intrin.hpp
+++ b/modules/core/include/opencv2/core/hal/intrin.hpp
@@ -274,6 +274,18 @@ CV_CPU_OPTIMIZATION_HAL_NAMESPACE_BEGIN
 #define CV_SIMD512_FP16 0
 #endif
 
+#ifndef CV_SIMD128_PERMUTE
+#define CV_SIMD128_PERMUTE 0
+#endif
+
+#ifndef CV_SIMD256_PERMUTE
+#define CV_SIMD256_PERMUTE 0
+#endif
+
+#ifndef CV_SIMD512_PERMUTE
+#define CV_SIMD512_PERMUTE 0
+#endif
+
 //==================================================================================================
 
 #define CV_INTRIN_DEFINE_WIDE_INTRIN(typ, vtyp, short_typ, prefix, loadsfx) \
@@ -390,6 +402,7 @@ namespace CV__SIMD_NAMESPACE {
     #define CV_SIMD 1
     #define CV_SIMD_64F CV_SIMD512_64F
     #define CV_SIMD_FP16 CV_SIMD512_FP16
+    #define CV_SIMD_PERMUTE CV_SIMD512_PERMUTE
     #define CV_SIMD_WIDTH 64
     typedef v_uint8x64    v_uint8;
     typedef v_int8x64     v_int8;
@@ -414,6 +427,7 @@ namespace CV__SIMD_NAMESPACE {
     #define CV_SIMD 1
     #define CV_SIMD_64F CV_SIMD256_64F
     #define CV_SIMD_FP16 CV_SIMD256_FP16
+    #define CV_SIMD_PERMUTE CV_SIMD256_PERMUTE
     #define CV_SIMD_WIDTH 32
     typedef v_uint8x32   v_uint8;
     typedef v_int8x32    v_int8;
@@ -437,6 +451,7 @@ using namespace CV__SIMD_NAMESPACE;
 namespace CV__SIMD_NAMESPACE {
     #define CV_SIMD CV_SIMD128
     #define CV_SIMD_64F CV_SIMD128_64F
+    #define CV_SIMD_PERMUTE CV_SIMD128_PERMUTE
     #define CV_SIMD_WIDTH 16
     typedef v_uint8x16  v_uint8;
     typedef v_int8x16   v_int8;
@@ -469,6 +484,9 @@ CV_CPU_OPTIMIZATION_HAL_NAMESPACE_END
 #define CV_SIMD_FP16 0  //!< Defined to 1 on native support of operations with float16x8_t / float16x16_t (SIMD256) types
 #endif
 
+#ifndef CV_SIMD_PERMUTE
+#define CV_SIMD_PERMUTE 0 //!< Defined to the number of vectors which can be byte permuted into a single vector
+#endif
 
 #ifndef CV_SIMD
 #define CV_SIMD 0

--- a/modules/core/include/opencv2/core/hal/intrin_neon.hpp
+++ b/modules/core/include/opencv2/core/hal/intrin_neon.hpp
@@ -58,8 +58,10 @@ CV_CPU_OPTIMIZATION_HAL_NAMESPACE_BEGIN
 #define CV_SIMD128 1
 #if defined(__aarch64__)
 #define CV_SIMD128_64F 1
+#define CV_SIMD128_PERMUTE 1
 #else
 #define CV_SIMD128_64F 0
+#define CV_SIMD128_PERMUTE 0
 #endif
 
 // TODO
@@ -2320,6 +2322,13 @@ inline void v_pack_store(float16_t* ptr, const v_float32x4& v)
 #endif
 
 inline void v_cleanup() {}
+
+#if CV_SIMD128_PERMUTE
+inline v_uint8x16 v_permute(const v_uint8x16 &ctrl, const v_uint8x16 &in)
+{
+    return v_uint8x16(vqtbl1q_u8(in.val, ctrl.val));
+}
+#endif
 
 CV_CPU_OPTIMIZATION_HAL_NAMESPACE_END
 

--- a/modules/core/include/opencv2/core/hal/intrin_sse.hpp
+++ b/modules/core/include/opencv2/core/hal/intrin_sse.hpp
@@ -52,6 +52,12 @@
 #define CV_SIMD128_64F 1
 #define CV_SIMD128_FP16 0  // no native operations with FP16 type.
 
+#if CV_SSSE3
+#define CV_SIMD128_PERMUTE 1
+#else
+#define CV_SIMD128_PERMUTE 0
+#endif
+
 namespace cv
 {
 
@@ -3425,6 +3431,13 @@ inline void v_pack_store(float16_t* ptr, const v_float32x4& v)
 }
 
 inline void v_cleanup() {}
+
+#if CV_SIMD128_PERMUTE
+inline v_uint8x16 v_permute(const v_uint8x16 &ctrl, const v_uint8x16 &in)
+{
+    return v_uint8x16(_mm_shuffle_epi8(in.val, ctrl.val));
+}
+#endif
 
 CV_CPU_OPTIMIZATION_HAL_NAMESPACE_END
 

--- a/modules/core/include/opencv2/core/hal/intrin_vsx.hpp
+++ b/modules/core/include/opencv2/core/hal/intrin_vsx.hpp
@@ -10,6 +10,7 @@
 
 #define CV_SIMD128 1
 #define CV_SIMD128_64F 1
+#define CV_SIMD128_PERMUTE 2
 
 namespace cv
 {
@@ -1614,8 +1615,19 @@ inline v_float64x2 v_broadcast_element(v_float64x2 v)
     return v_float64x2(vec_perm(v.val, v.val, p));
 }
 
-CV_CPU_OPTIMIZATION_HAL_NAMESPACE_END
+/* Permute 32B into a 16B vector using a control vector. Any control byte value greater than the number of
+   bytes in the aggregrate vector results in undefined behavior (e.x PPC will ignore those bits)  */
+inline v_uint8x16 v_permute(const v_uint8x16 &ctrl, const v_uint8x16 &in_lo, const v_uint8x16 &in_hi)
+{
+    return v_uint8x16(vec_perm(in_lo.val, in_hi.val, ctrl.val));
+}
 
+inline v_uint8x16 v_permute(const v_uint8x16 &ctrl, const v_uint8x16 &in)
+{
+    return v_permute(ctrl, in, in);
+}
+
+CV_CPU_OPTIMIZATION_HAL_NAMESPACE_END
 //! @endcond
 
 }

--- a/modules/core/include/opencv2/core/hal/intrin_vsx.hpp
+++ b/modules/core/include/opencv2/core/hal/intrin_vsx.hpp
@@ -347,11 +347,37 @@ OPENCV_HAL_IMPL_VSX_EXPAND(v_int16x8, v_int32x4, short, vec_unpackl, vec_unpackh
 OPENCV_HAL_IMPL_VSX_EXPAND(v_uint32x4, v_uint64x2, uint, vec_unpacklu, vec_unpackhu)
 OPENCV_HAL_IMPL_VSX_EXPAND(v_int32x4, v_int64x2, int, vec_unpackl, vec_unpackh)
 
+/* Load and zero expand a 4 byte value into the second dword, first is don't care. */
+#if !defined(CV_COMPILER_VSX_BROKEN_ASM)
+    #define _LXSIWZX(out, ptr, T) __asm__ ("lxsiwzx %x0, 0, %1\r\n" : "=wa"(out) : "r" (ptr) : "memory");
+#else
+    /* This is compiler-agnostic, but will introduce an unneeded splat on the critical path. */
+    #define _LXSIWZX(out, ptr, T) out = (T)vec_udword2_sp(*(uint32_t*)(ptr));
+#endif
+
 inline v_uint32x4 v_load_expand_q(const uchar* ptr)
-{ return v_uint32x4(vec_uint4_set(ptr[0], ptr[1], ptr[2], ptr[3])); }
+{
+    // Zero-extend the extra 24B instead of unpacking. Usually faster in small kernel
+    // Likewise note, value is zero extended and upper 4 bytes are zero'ed.
+    vec_uchar16 pmu = {8, 12, 12, 12, 9, 12, 12, 12, 10, 12, 12, 12, 11, 12, 12, 12};
+    vec_uchar16 out;
+
+    _LXSIWZX(out, ptr, vec_uchar16);
+    out = vec_perm(out, out, pmu);
+    return v_uint32x4((vec_uint4)out);
+}
 
 inline v_int32x4 v_load_expand_q(const schar* ptr)
-{ return v_int32x4(vec_int4_set(ptr[0], ptr[1], ptr[2], ptr[3])); }
+{
+    vec_char16 out;
+    vec_short8 outs;
+    vec_int4 outw;
+
+    _LXSIWZX(out, ptr, vec_char16);
+    outs = vec_unpackl(out);
+    outw = vec_unpackh(outs);
+    return v_int32x4(outw);
+}
 
 /* pack */
 #define OPENCV_HAL_IMPL_VSX_PACK(_Tpvec, _Tp, _Tpwvec, _Tpvn, _Tpdel, sfnc, pkfnc, addfnc, pack)    \


### PR DESCRIPTION
### This pullrequest vectorizes more copyMask variants

Improve masked copy performance by introducing the v_permute HAL to efficiently expand byte masks to non-native integer sizes (e.g 24b for 8uC3 masking) to implement the 8uC3 variant.

Likewise, add template specialization for 32b types which may not always implicitly vectorize.

```
force_builders=Linux AVX2,Custom
buildworker:Custom=linux-3
build_image:Custom=ubuntu:18.04
CPU_BASELINE:Custom=AVX512_SKX
disable_ipp=ON
```