### PR TITLE
dnn: skip "sum" tests on IE/OpenCL target

### DIFF
--- a/modules/dnn/test/test_halide_layers.cpp
+++ b/modules/dnn/test/test_halide_layers.cpp
@@ -758,6 +758,12 @@ TEST_P(Eltwise, Accuracy)
         applyTestTag(CV_TEST_TAG_DNN_SKIP_IE, CV_TEST_TAG_DNN_SKIP_IE_2019R1, CV_TEST_TAG_DNN_SKIP_IE_2019R1_1);
 #endif
 
+#if defined(INF_ENGINE_RELEASE)
+    if (backendId == DNN_BACKEND_INFERENCE_ENGINE && targetId == DNN_TARGET_OPENCL &&
+        op == "sum" && numConv == 1 && !weighted)
+        applyTestTag(CV_TEST_TAG_DNN_SKIP_IE_OPENCL, CV_TEST_TAG_DNN_SKIP_IE);
+#endif
+
     Net net;
 
     std::vector<int> convLayerIds(numConv);


### PR DESCRIPTION
Related tests:

<cut/>

```
[ RUN      ] Layer_Test_Halide/Eltwise.Accuracy/30, where GetParam() = ([1, 4, 5], "sum", 1, false, DLIE/CPU)
[       OK ] Layer_Test_Halide/Eltwise.Accuracy/30 (17 ms)
[ RUN      ] Layer_Test_Halide/Eltwise.Accuracy/31, where GetParam() = ([1, 4, 5], "sum", 1, false, DLIE/OCL)
/build/3_4_openvino-opencl-skl-lin64/opencv/modules/dnn/test/test_common.impl.hpp:63: Failure
Expected: (normL1) <= (l1), actual: 0.546033 vs 1e-05
/build/3_4_openvino-opencl-skl-lin64/opencv/modules/dnn/test/test_common.impl.hpp:66: Failure
Expected: (normInf) <= (lInf), actual: 0.986967 vs 0.0001
[  FAILED  ] Layer_Test_Halide/Eltwise.Accuracy/31, where GetParam() = ([1, 4, 5], "sum", 1, false, DLIE/OCL) (140 ms)
[ RUN      ] Layer_Test_Halide/Eltwise.Accuracy/32, where GetParam() = ([1, 4, 5], "sum", 1, false, DLIE/OCL_FP16)
[       OK ] Layer_Test_Halide/Eltwise.Accuracy/32 (129 ms)

...

[ RUN      ] Layer_Test_Halide/Eltwise.Accuracy/120, where GetParam() = ([2, 8, 6], "sum", 1, false, DLIE/CPU)
[       OK ] Layer_Test_Halide/Eltwise.Accuracy/120 (17 ms)
[ RUN      ] Layer_Test_Halide/Eltwise.Accuracy/121, where GetParam() = ([2, 8, 6], "sum", 1, false, DLIE/OCL)
/build/3_4_openvino-opencl-skl-lin64/opencv/modules/dnn/test/test_common.impl.hpp:63: Failure
Expected: (normL1) <= (l1), actual: 0.534888 vs 1e-05
/build/3_4_openvino-opencl-skl-lin64/opencv/modules/dnn/test/test_common.impl.hpp:66: Failure
Expected: (normInf) <= (lInf), actual: 0.986967 vs 0.0001
[  FAILED  ] Layer_Test_Halide/Eltwise.Accuracy/121, where GetParam() = ([2, 8, 6], "sum", 1, false, DLIE/OCL) (117 ms)
[ RUN      ] Layer_Test_Halide/Eltwise.Accuracy/122, where GetParam() = ([2, 8, 6], "sum", 1, false, DLIE/OCL_FP16)
[       OK ] Layer_Test_Halide/Eltwise.Accuracy/122 (148 ms)
[ RUN      ] Layer_Test_Halide/Eltwise.Accuracy/123, where GetParam() = ([2, 8, 6], "sum", 1, false, OCV/OCL)
[       OK ] Layer_Test_Halide/Eltwise.Accuracy/123 (1 ms)
[ RUN      ] Layer_Test_Halide/Eltwise.Accuracy/124, where GetParam() = ([2, 8, 6], "sum", 1, false, OCV/OCL_FP16)
[       OK ] Layer_Test_Halide/Eltwise.Accuracy/124 (1 ms)
```


```
force_builders=Custom,Custom Win,Custom Mac
build_image:Custom=ubuntu-openvino-2019r2.0:16.04
build_image:Custom Win=openvino-2019r2.0
build_image:Custom Mac=openvino-2019r2.0

test_modules:Custom=dnn,python2,python3,java
test_modules:Custom Win=dnn,python2,python3,java
test_modules:Custom Mac=dnn,python2,python3,java

buildworker:Custom=linux-1
test_opencl:Custom=ON
test_bigdata:Custom=1
test_filter:Custom=*
test_opencl:Custom Win=ON
```