### PR TITLE
Add note about pkg-config usage in tutorial

### DIFF
--- a/doc/tutorials/introduction/linux_install/linux_install.markdown
+++ b/doc/tutorials/introduction/linux_install/linux_install.markdown
@@ -101,6 +101,7 @@ Building OpenCV from Source Using CMake
     -   Add this flag when running CMake: `-DOPENCV_GENERATE_PKGCONFIG=ON`
     -   Will generate the .pc file for pkg-config and install it.
     -   Useful if not using CMake in projects that use OpenCV
+    -   Installed as `opencv4`, usage: `pkg-config --cflags --libs opencv4`
 
 -#  Build. From build directory execute *make*, it is recommended to do this in several threads
 


### PR DESCRIPTION
Add one bulletpoint into the Linux tutorial so it's clearer how to utilize the generated pkg-config info.

As the user might be confused about why `pkg-config --cflags --libs opencv` (<- not opencv4) fails, and issues like https://github.com/opencv/opencv/issues/13154 can suggest that support for pkg-config has been dropped.