### PR TITLE
OpenCV G-API Filter2D test improvement

### DIFF
--- a/modules/gapi/test/common/gapi_imgproc_tests.hpp
+++ b/modules/gapi/test/common/gapi_imgproc_tests.hpp
@@ -29,8 +29,8 @@ namespace opencv_test
 //      - created (and initialized) automatically
 //      - available in test body
 // Note: all parameter _values_ (e.g. type CV_8UC3) are set via INSTANTIATE_TEST_CASE_P macro
-GAPI_TEST_FIXTURE(Filter2DTest, initMatrixRandN, FIXTURE_API(CompareMats,int,int), 3,
-    cmpF, kernSize, borderType)
+GAPI_TEST_FIXTURE(Filter2DTest, initMatrixRandN, FIXTURE_API(CompareMats,cv::Size,int), 3,
+    cmpF, filterSize, borderType)
 GAPI_TEST_FIXTURE(BoxFilterTest, initMatrixRandN, FIXTURE_API(CompareMats,int,int), 3,
     cmpF, filterSize, borderType)
 GAPI_TEST_FIXTURE(SepFilterTest, initMatrixRandN, FIXTURE_API(CompareMats,int), 2, cmpF, kernSize)

--- a/modules/gapi/test/common/gapi_imgproc_tests_inl.hpp
+++ b/modules/gapi/test/common/gapi_imgproc_tests_inl.hpp
@@ -57,9 +57,23 @@ TEST_P(Filter2DTest, AccuracyTest)
     cv::Point anchor = {-1, -1};
     double delta = 0;
 
-    cv::Mat kernel = cv::Mat(kernSize, kernSize, CV_32FC1);
-    cv::Scalar kernMean = cv::Scalar(1.0);
-    cv::Scalar kernStddev = cv::Scalar(2.0/3);
+    cv::Mat kernel = cv::Mat(filterSize, CV_32FC1);
+    cv::Scalar kernMean, kernStddev;
+
+    const auto kernSize = filterSize.width * filterSize.height;
+    const auto bigKernSize = 49;
+
+    if (kernSize < bigKernSize)
+    {
+        kernMean = cv::Scalar(0.3);
+        kernStddev = cv::Scalar(0.5);
+    }
+    else
+    {
+        kernMean = cv::Scalar(0.008);
+        kernStddev = cv::Scalar(0.008);
+    }
+
     randn(kernel, kernMean, kernStddev);
 
     // G-API code //////////////////////////////////////////////////////////////
@@ -67,6 +81,7 @@ TEST_P(Filter2DTest, AccuracyTest)
     auto out = cv::gapi::filter2D(in, dtype, kernel, anchor, delta, borderType);
 
     cv::GComputation c(in, out);
+
     c.apply(in_mat1, out_mat_gapi, getCompileArgs());
     // OpenCV code /////////////////////////////////////////////////////////////
     {

--- a/modules/gapi/test/cpu/gapi_imgproc_tests_cpu.cpp
+++ b/modules/gapi/test/cpu/gapi_imgproc_tests_cpu.cpp
@@ -26,7 +26,10 @@ INSTANTIATE_TEST_CASE_P(Filter2DTestCPU, Filter2DTest,
                                 Values(-1, CV_32F),
                                 Values(IMGPROC_CPU),
                                 Values(AbsExact().to_compare_obj()),
-                                Values(3, 4, 5, 7),
+                                Values(cv::Size(3, 3),
+                                       cv::Size(4, 4),
+                                       cv::Size(5, 5),
+                                       cv::Size(7, 7)),
                                 Values(cv::BORDER_DEFAULT)));
 
 INSTANTIATE_TEST_CASE_P(BoxFilterTestCPU, BoxFilterTest,

--- a/modules/gapi/test/cpu/gapi_imgproc_tests_fluid.cpp
+++ b/modules/gapi/test/cpu/gapi_imgproc_tests_fluid.cpp
@@ -214,7 +214,7 @@ INSTANTIATE_TEST_CASE_P(filter2DTestFluid, Filter2DTest,
                                 Values(-1, CV_32F),
                                 Values(IMGPROC_FLUID),
                                 Values(ToleranceFilter(1e-4f, 0.01).to_compare_obj()),
-                                Values(3), // add kernel size=4,5,7 when implementation ready
+                                Values(cv::Size(3, 3)), // add kernel size=4x4,5x5,7x7 when implementation ready
                                 Values(cv::BORDER_DEFAULT)));
 
 } // opencv_test

--- a/modules/gapi/test/gpu/gapi_imgproc_tests_gpu.cpp
+++ b/modules/gapi/test/gpu/gapi_imgproc_tests_gpu.cpp
@@ -25,7 +25,10 @@ INSTANTIATE_TEST_CASE_P(Filter2DTestGPU, Filter2DTest,
                                 Values(-1, CV_32F),
                                 Values(IMGPROC_GPU),
                                 Values(Tolerance_FloatRel_IntAbs(1e-5, 2).to_compare_obj()),
-                                Values(3, 4, 5, 7),
+                                Values(cv::Size(3, 3),
+                                       cv::Size(4, 4),
+                                       cv::Size(5, 5),
+                                       cv::Size(7, 7)),
                                 Values(cv::BORDER_DEFAULT)));
 
 INSTANTIATE_TEST_CASE_P(BoxFilterTestCPU, BoxFilterTest,


### PR DESCRIPTION
- Size parameter is changed from int to cv::Size type to allow rectangle kernels
- Kernel creation code is adopted for different kernel sizes to not create only white images on the output

<!-- Please use this line to close one or multiple issues when this pullrequest gets merged
You can add another line right under the first one:
resolves #1234
resolves #1235
-->

### This pullrequest changes

<!-- Please describe what your pullrequest is changing -->
