### PR TITLE
Redesign PnP solvers with Algorithm-based design

### DIFF
--- a/modules/calib3d/include/opencv2/calib3d.hpp
+++ b/modules/calib3d/include/opencv2/calib3d.hpp
@@ -785,291 +785,6 @@ CV_EXPORTS_W bool solvePnPRansac( InputArray objectPoints, InputArray imagePoint
                                   float reprojectionError = 8.0, double confidence = 0.99,
                                   OutputArray inliers = noArray(), int flags = SOLVEPNP_ITERATIVE );
 
-/** @brief Finds an object pose from 3 3D-2D point correspondences.
-
-@param objectPoints Array of object points in the object coordinate space, 3x3 1-channel or
-1x3/3x1 3-channel. vector\<Point3f\> can be also passed here.
-@param imagePoints Array of corresponding image points, 3x2 1-channel or 1x3/3x1 2-channel.
- vector\<Point2f\> can be also passed here.
-@param cameraMatrix Input camera matrix \f$A = \vecthreethree{fx}{0}{cx}{0}{fy}{cy}{0}{0}{1}\f$ .
-@param distCoeffs Input vector of distortion coefficients
-\f$(k_1, k_2, p_1, p_2[, k_3[, k_4, k_5, k_6 [, s_1, s_2, s_3, s_4[, \tau_x, \tau_y]]]])\f$ of
-4, 5, 8, 12 or 14 elements. If the vector is NULL/empty, the zero distortion coefficients are
-assumed.
-@param rvecs Output rotation vectors (see @ref Rodrigues ) that, together with tvecs, brings points from
-the model coordinate system to the camera coordinate system. A P3P problem has up to 4 solutions.
-@param tvecs Output translation vectors.
-@param flags Method for solving a P3P problem:
--   **SOLVEPNP_P3P** Method is based on the paper of X.S. Gao, X.-R. Hou, J. Tang, H.-F. Chang
-"Complete Solution Classification for the Perspective-Three-Point Problem" (@cite gao2003complete).
--   **SOLVEPNP_AP3P** Method is based on the paper of T. Ke and S. Roumeliotis.
-"An Efficient Algebraic Solution to the Perspective-Three-Point Problem" (@cite Ke17).
-
-The function estimates the object pose given 3 object points, their corresponding image
-projections, as well as the camera matrix and the distortion coefficients.
-
-@note
-The solutions are sorted by reprojection errors (lowest to highest).
- */
-CV_EXPORTS_W int solveP3P( InputArray objectPoints, InputArray imagePoints,
-                           InputArray cameraMatrix, InputArray distCoeffs,
-                           OutputArrayOfArrays rvecs, OutputArrayOfArrays tvecs,
-                           int flags );
-
-/** @brief Refine a pose (the translation and the rotation that transform a 3D point expressed in the object coordinate frame
-to the camera coordinate frame) from a 3D-2D point correspondences and starting from an initial solution.
-
-@param objectPoints Array of object points in the object coordinate space, Nx3 1-channel or 1xN/Nx1 3-channel,
-where N is the number of points. vector\<Point3f\> can also be passed here.
-@param imagePoints Array of corresponding image points, Nx2 1-channel or 1xN/Nx1 2-channel,
-where N is the number of points. vector\<Point2f\> can also be passed here.
-@param cameraMatrix Input camera matrix \f$A = \vecthreethree{fx}{0}{cx}{0}{fy}{cy}{0}{0}{1}\f$ .
-@param distCoeffs Input vector of distortion coefficients
-\f$(k_1, k_2, p_1, p_2[, k_3[, k_4, k_5, k_6 [, s_1, s_2, s_3, s_4[, \tau_x, \tau_y]]]])\f$ of
-4, 5, 8, 12 or 14 elements. If the vector is NULL/empty, the zero distortion coefficients are
-assumed.
-@param rvec Input/Output rotation vector (see @ref Rodrigues ) that, together with tvec, brings points from
-the model coordinate system to the camera coordinate system. Input values are used as an initial solution.
-@param tvec Input/Output translation vector. Input values are used as an initial solution.
-@param criteria Criteria when to stop the Levenberg-Marquard iterative algorithm.
-
-The function refines the object pose given at least 3 object points, their corresponding image
-projections, an initial solution for the rotation and translation vector,
-as well as the camera matrix and the distortion coefficients.
-The function minimizes the projection error with respect to the rotation and the translation vectors, according
-to a Levenberg-Marquardt iterative minimization @cite Madsen04 @cite Eade13 process.
- */
-CV_EXPORTS_W void solvePnPRefineLM( InputArray objectPoints, InputArray imagePoints,
-                                    InputArray cameraMatrix, InputArray distCoeffs,
-                                    InputOutputArray rvec, InputOutputArray tvec,
-                                    TermCriteria criteria = TermCriteria(TermCriteria::EPS + TermCriteria::COUNT, 20, FLT_EPSILON));
-
-/** @brief Refine a pose (the translation and the rotation that transform a 3D point expressed in the object coordinate frame
-to the camera coordinate frame) from a 3D-2D point correspondences and starting from an initial solution.
-
-@param objectPoints Array of object points in the object coordinate space, Nx3 1-channel or 1xN/Nx1 3-channel,
-where N is the number of points. vector\<Point3f\> can also be passed here.
-@param imagePoints Array of corresponding image points, Nx2 1-channel or 1xN/Nx1 2-channel,
-where N is the number of points. vector\<Point2f\> can also be passed here.
-@param cameraMatrix Input camera matrix \f$A = \vecthreethree{fx}{0}{cx}{0}{fy}{cy}{0}{0}{1}\f$ .
-@param distCoeffs Input vector of distortion coefficients
-\f$(k_1, k_2, p_1, p_2[, k_3[, k_4, k_5, k_6 [, s_1, s_2, s_3, s_4[, \tau_x, \tau_y]]]])\f$ of
-4, 5, 8, 12 or 14 elements. If the vector is NULL/empty, the zero distortion coefficients are
-assumed.
-@param rvec Input/Output rotation vector (see @ref Rodrigues ) that, together with tvec, brings points from
-the model coordinate system to the camera coordinate system. Input values are used as an initial solution.
-@param tvec Input/Output translation vector. Input values are used as an initial solution.
-@param criteria Criteria when to stop the Levenberg-Marquard iterative algorithm.
-@param VVSlambda Gain for the virtual visual servoing control law, equivalent to the \f$\alpha\f$
-gain in the Damped Gauss-Newton formulation.
-
-The function refines the object pose given at least 3 object points, their corresponding image
-projections, an initial solution for the rotation and translation vector,
-as well as the camera matrix and the distortion coefficients.
-The function minimizes the projection error with respect to the rotation and the translation vectors, using a
-virtual visual servoing (VVS) @cite Chaumette06 @cite Marchand16 scheme.
- */
-CV_EXPORTS_W void solvePnPRefineVVS( InputArray objectPoints, InputArray imagePoints,
-                                     InputArray cameraMatrix, InputArray distCoeffs,
-                                     InputOutputArray rvec, InputOutputArray tvec,
-                                     TermCriteria criteria = TermCriteria(TermCriteria::EPS + TermCriteria::COUNT, 20, FLT_EPSILON),
-                                     double VVSlambda = 1);
-
-/** @brief Finds an object pose from 3D-2D point correspondences.
-This function returns a list of all the possible solutions (a solution is a <rotation vector, translation vector>
-couple), depending on the number of input points and the chosen method:
-- P3P methods (@ref SOLVEPNP_P3P, @ref SOLVEPNP_AP3P): 3 or 4 input points. Number of returned solutions can be between 0 and 4 with 3 input points.
-- @ref SOLVEPNP_IPPE Input points must be >= 4 and object points must be coplanar. Returns 2 solutions.
-- @ref SOLVEPNP_IPPE_SQUARE Special case suitable for marker pose estimation.
-Number of input points must be 4 and 2 solutions are returned. Object points must be defined in the following order:
-  - point 0: [-squareLength / 2,  squareLength / 2, 0]
-  - point 1: [ squareLength / 2,  squareLength / 2, 0]
-  - point 2: [ squareLength / 2, -squareLength / 2, 0]
-  - point 3: [-squareLength / 2, -squareLength / 2, 0]
-- for all the other flags, number of input points must be >= 4 and object points can be in any configuration.
-Only 1 solution is returned.
-
-@param objectPoints Array of object points in the object coordinate space, Nx3 1-channel or
-1xN/Nx1 3-channel, where N is the number of points. vector\<Point3f\> can be also passed here.
-@param imagePoints Array of corresponding image points, Nx2 1-channel or 1xN/Nx1 2-channel,
-where N is the number of points. vector\<Point2f\> can be also passed here.
-@param cameraMatrix Input camera matrix \f$A = \vecthreethree{fx}{0}{cx}{0}{fy}{cy}{0}{0}{1}\f$ .
-@param distCoeffs Input vector of distortion coefficients
-\f$(k_1, k_2, p_1, p_2[, k_3[, k_4, k_5, k_6 [, s_1, s_2, s_3, s_4[, \tau_x, \tau_y]]]])\f$ of
-4, 5, 8, 12 or 14 elements. If the vector is NULL/empty, the zero distortion coefficients are
-assumed.
-@param rvecs Vector of output rotation vectors (see @ref Rodrigues ) that, together with tvecs, brings points from
-the model coordinate system to the camera coordinate system.
-@param tvecs Vector of output translation vectors.
-@param useExtrinsicGuess Parameter used for #SOLVEPNP_ITERATIVE. If true (1), the function uses
-the provided rvec and tvec values as initial approximations of the rotation and translation
-vectors, respectively, and further optimizes them.
-@param flags Method for solving a PnP problem:
--   **SOLVEPNP_ITERATIVE** Iterative method is based on a Levenberg-Marquardt optimization. In
-this case the function finds such a pose that minimizes reprojection error, that is the sum
-of squared distances between the observed projections imagePoints and the projected (using
-projectPoints ) objectPoints .
--   **SOLVEPNP_P3P** Method is based on the paper of X.S. Gao, X.-R. Hou, J. Tang, H.-F. Chang
-"Complete Solution Classification for the Perspective-Three-Point Problem" (@cite gao2003complete).
-In this case the function requires exactly four object and image points.
--   **SOLVEPNP_AP3P** Method is based on the paper of T. Ke, S. Roumeliotis
-"An Efficient Algebraic Solution to the Perspective-Three-Point Problem" (@cite Ke17).
-In this case the function requires exactly four object and image points.
--   **SOLVEPNP_EPNP** Method has been introduced by F.Moreno-Noguer, V.Lepetit and P.Fua in the
-paper "EPnP: Efficient Perspective-n-Point Camera Pose Estimation" (@cite lepetit2009epnp).
--   **SOLVEPNP_DLS** Method is based on the paper of Joel A. Hesch and Stergios I. Roumeliotis.
-"A Direct Least-Squares (DLS) Method for PnP" (@cite hesch2011direct).
--   **SOLVEPNP_UPNP** Method is based on the paper of A.Penate-Sanchez, J.Andrade-Cetto,
-F.Moreno-Noguer. "Exhaustive Linearization for Robust Camera Pose and Focal Length
-Estimation" (@cite penate2013exhaustive). In this case the function also estimates the parameters \f$f_x\f$ and \f$f_y\f$
-assuming that both have the same value. Then the cameraMatrix is updated with the estimated
-focal length.
--   **SOLVEPNP_IPPE** Method is based on the paper of T. Collins and A. Bartoli.
-"Infinitesimal Plane-Based Pose Estimation" (@cite Collins14). This method requires coplanar object points.
--   **SOLVEPNP_IPPE_SQUARE** Method is based on the paper of Toby Collins and Adrien Bartoli.
-"Infinitesimal Plane-Based Pose Estimation" (@cite Collins14). This method is suitable for marker pose estimation.
-It requires 4 coplanar object points defined in the following order:
-  - point 0: [-squareLength / 2,  squareLength / 2, 0]
-  - point 1: [ squareLength / 2,  squareLength / 2, 0]
-  - point 2: [ squareLength / 2, -squareLength / 2, 0]
-  - point 3: [-squareLength / 2, -squareLength / 2, 0]
-@param rvec Rotation vector used to initialize an iterative PnP refinement algorithm, when flag is SOLVEPNP_ITERATIVE
-and useExtrinsicGuess is set to true.
-@param tvec Translation vector used to initialize an iterative PnP refinement algorithm, when flag is SOLVEPNP_ITERATIVE
-and useExtrinsicGuess is set to true.
-@param reprojectionError Optional vector of reprojection error, that is the RMS error
-(\f$ \text{RMSE} = \sqrt{\frac{\sum_{i}^{N} \left ( \hat{y_i} - y_i \right )^2}{N}} \f$) between the input image points
-and the 3D object points projected with the estimated pose.
-
-The function estimates the object pose given a set of object points, their corresponding image
-projections, as well as the camera matrix and the distortion coefficients, see the figure below
-(more precisely, the X-axis of the camera frame is pointing to the right, the Y-axis downward
-and the Z-axis forward).
-
-![](pnp.jpg)
-
-Points expressed in the world frame \f$ \bf{X}_w \f$ are projected into the image plane \f$ \left[ u, v \right] \f$
-using the perspective projection model \f$ \Pi \f$ and the camera intrinsic parameters matrix \f$ \bf{A} \f$:
-
-\f[
-  \begin{align*}
-  \begin{bmatrix}
-  u \\
-  v \\
-  1
-  \end{bmatrix} &=
-  \bf{A} \hspace{0.1em} \Pi \hspace{0.2em} ^{c}\bf{M}_w
-  \begin{bmatrix}
-  X_{w} \\
-  Y_{w} \\
-  Z_{w} \\
-  1
-  \end{bmatrix} \\
-  \begin{bmatrix}
-  u \\
-  v \\
-  1
-  \end{bmatrix} &=
-  \begin{bmatrix}
-  f_x & 0 & c_x \\
-  0 & f_y & c_y \\
-  0 & 0 & 1
-  \end{bmatrix}
-  \begin{bmatrix}
-  1 & 0 & 0 & 0 \\
-  0 & 1 & 0 & 0 \\
-  0 & 0 & 1 & 0
-  \end{bmatrix}
-  \begin{bmatrix}
-  r_{11} & r_{12} & r_{13} & t_x \\
-  r_{21} & r_{22} & r_{23} & t_y \\
-  r_{31} & r_{32} & r_{33} & t_z \\
-  0 & 0 & 0 & 1
-  \end{bmatrix}
-  \begin{bmatrix}
-  X_{w} \\
-  Y_{w} \\
-  Z_{w} \\
-  1
-  \end{bmatrix}
-  \end{align*}
-\f]
-
-The estimated pose is thus the rotation (`rvec`) and the translation (`tvec`) vectors that allow transforming
-a 3D point expressed in the world frame into the camera frame:
-
-\f[
-  \begin{align*}
-  \begin{bmatrix}
-  X_c \\
-  Y_c \\
-  Z_c \\
-  1
-  \end{bmatrix} &=
-  \hspace{0.2em} ^{c}\bf{M}_w
-  \begin{bmatrix}
-  X_{w} \\
-  Y_{w} \\
-  Z_{w} \\
-  1
-  \end{bmatrix} \\
-  \begin{bmatrix}
-  X_c \\
-  Y_c \\
-  Z_c \\
-  1
-  \end{bmatrix} &=
-  \begin{bmatrix}
-  r_{11} & r_{12} & r_{13} & t_x \\
-  r_{21} & r_{22} & r_{23} & t_y \\
-  r_{31} & r_{32} & r_{33} & t_z \\
-  0 & 0 & 0 & 1
-  \end{bmatrix}
-  \begin{bmatrix}
-  X_{w} \\
-  Y_{w} \\
-  Z_{w} \\
-  1
-  \end{bmatrix}
-  \end{align*}
-\f]
-
-@note
-   -   An example of how to use solvePnP for planar augmented reality can be found at
-        opencv_source_code/samples/python/plane_ar.py
-   -   If you are using Python:
-        - Numpy array slices won't work as input because solvePnP requires contiguous
-        arrays (enforced by the assertion using cv::Mat::checkVector() around line 55 of
-        modules/calib3d/src/solvepnp.cpp version 2.4.9)
-        - The P3P algorithm requires image points to be in an array of shape (N,1,2) due
-        to its calling of cv::undistortPoints (around line 75 of modules/calib3d/src/solvepnp.cpp version 2.4.9)
-        which requires 2-channel information.
-        - Thus, given some data D = np.array(...) where D.shape = (N,M), in order to use a subset of
-        it as, e.g., imagePoints, one must effectively copy it into a new array: imagePoints =
-        np.ascontiguousarray(D[:,:2]).reshape((N,1,2))
-   -   The methods **SOLVEPNP_DLS** and **SOLVEPNP_UPNP** cannot be used as the current implementations are
-       unstable and sometimes give completely wrong results. If you pass one of these two
-       flags, **SOLVEPNP_EPNP** method will be used instead.
-   -   The minimum number of points is 4 in the general case. In the case of **SOLVEPNP_P3P** and **SOLVEPNP_AP3P**
-       methods, it is required to use exactly 4 points (the first 3 points are used to estimate all the solutions
-       of the P3P problem, the last one is used to retain the best solution that minimizes the reprojection error).
-   -   With **SOLVEPNP_ITERATIVE** method and `useExtrinsicGuess=true`, the minimum number of points is 3 (3 points
-       are sufficient to compute a pose but there are up to 4 solutions). The initial solution should be close to the
-       global solution to converge.
-   -   With **SOLVEPNP_IPPE** input points must be >= 4 and object points must be coplanar.
-   -   With **SOLVEPNP_IPPE_SQUARE** this is a special case suitable for marker pose estimation.
-       Number of input points must be 4. Object points must be defined in the following order:
-         - point 0: [-squareLength / 2,  squareLength / 2, 0]
-         - point 1: [ squareLength / 2,  squareLength / 2, 0]
-         - point 2: [ squareLength / 2, -squareLength / 2, 0]
-         - point 3: [-squareLength / 2, -squareLength / 2, 0]
- */
-CV_EXPORTS_W int solvePnPGeneric( InputArray objectPoints, InputArray imagePoints,
-                                  InputArray cameraMatrix, InputArray distCoeffs,
-                                  OutputArrayOfArrays rvecs, OutputArrayOfArrays tvecs,
-                                  bool useExtrinsicGuess = false, SolvePnPMethod flags = SOLVEPNP_ITERATIVE,
-                                  InputArray rvec = noArray(), InputArray tvec = noArray(),
-                                  OutputArray reprojectionError = noArray() );
 
 /** @brief Finds an initial camera matrix from 3D-2D point correspondences.
 
@@ -2902,6 +2617,1268 @@ optimization. It stays at the center or at a different location specified when C
 
 //! @} calib3d_fisheye
 } // end namespace fisheye
+
+
+/**
+  @brief get3DPointsetShape computes the singluar values of a set of 3D points. The main use is for determining if the points have co-linear, co-planar or general 3D structure
+  @param objectPoints set of points. Can be an Nx3 matrix single channel, Nx1 3-channel or 1xN 3-channel, float or double, where N is the number of points
+  @param singValues matrix of singluar values. Nx1 matrix, double, sorted largest (first) to smallest (last).
+ */
+CV_EXPORTS_W void get3DPointsetShape(InputArray objectPoints, InputOutputArray singValues);
+
+
+/**
+  @defgroup PnPSolver PnPSolvers
+  @{
+  PnP Solvers
+
+  @}
+ */
+
+//! @addtogroup PnPSolver
+//! @{
+
+/** @brief Abstract base class for a PnP solver algorithm
+*/
+#ifdef __EMSCRIPTEN__
+class CV_EXPORTS_W PnPSolver : public Algorithm
+        #else
+class CV_EXPORTS_W PnPSolver : public virtual Algorithm
+        #endif
+{
+
+public:
+
+    /**
+      @brief PnPSolver constructor
+      @param stopIfGeometricWarning set this true if you want to execute geometric checking of inputs before pnp is solved.
+      This is a sanity check to prevent trying to solve pnp problem that cannot be solved by the derived class.
+      For example, pnp can only be solved if the object points are not colinear. If they are colinear then there exists infinite many solutions,
+      and there exists no algorithm that can solve the problem. The geometric checking is implemented in the member function geometryWarn.
+      If the check fails, then no pose solutions are returned.
+      If you know the sanity checks will be passed, you can set
+     */
+    PnPSolver(bool stopIfGeometricWarning = false);
+
+    CV_WRAP virtual ~PnPSolver();
+
+    /** @brief Solves the PnP problem to compute the 3D pose of an object, using a set of 3D-to-2D point correspondences and a perspective camera.
+
+    @param opoints Set of Object points. This must be a 1xN 3-channel or Nx1 3-channel matrix (double) where n is the number of points.
+    opoints are defined in object coordinates.
+    @param ipoints Set of Image points. This must be a 1xN 2-channel or Nx1 2-channel matrix (double) where n is the number of points.
+    ipoints are defined in normalized pixel coordinates. That is, they are defined by using a canonical intrinsic calibration matrix of K = eye(3).
+    You can convert a set of points defined in pixels to normalized pixel coordinates using @ref undistortPoints. This is convenient because it
+    eliminates the need for supplying the camera's intrinsics (calibration matrix and distortion parameters)
+    @param rvecs Vector of output rotation vectors (double) (see @ref Rodrigues ) that, together with tvecs, brings points from
+    the model coordinate system to the camera coordinate system.
+    @param tvecs Vector of output translation vectors (double).
+    @param sortOnReprojectionError Sorts the pose solutions with lowest reprojection error first
+    @param withReprojectionErrors true if reprojection errors should be returned
+    @returns if sortOnReprojectionError then returns the sorted reprojection errors corresponding to each pose solution (descending order)
+    otherwise returns an empty vector
+     */
+    std::vector<double> solveProblem(InputArray opoints, InputArray ipoints, CV_OUT std::vector<Mat> & rVecs, CV_OUT std::vector<Mat> & tVecs, bool sortOnReprojectionError = true) const;
+
+
+    /** @brief Checks if the number of object points n can be handled by the algorithm.
+     * This returns n >= minPointNumber() && n <= maxPointNumber()
+     * In the case that the derived solver cannot solve n for values between  minPointNumber() and maxPointNumber()
+     * this should be overriden to specify it
+
+    @param opoints Set of Object points. This must be a 1xN 3-channel or Nx1 3-channel matrix (double) where n is the number of points.
+    opoints are defined in object coordinates.
+    @returns true if number can be handled otherwise false
+     */
+    CV_WRAP virtual bool checkNumberOfPoints(InputArray opoints) const;
+
+    /** @brief Gives the minimal number of object points handled by the algorithm
+
+    @returns Minimal number of points
+     */
+    CV_WRAP virtual int minPointNumber() const = 0;
+
+    /** @brief Gives the Maximal number of object points handled by the algorithm. If there is no maximum this returns -1.
+
+    @returns Maximal number of points. If no maximum, returns -1
+     */
+    CV_WRAP virtual int maxPointNumber() const = 0;
+
+    /** @brief Indicates if the algorithm requires the object points to be 3D (i.e. not co-planar)
+
+    @returns true if required, false otherwise
+     */
+    CV_WRAP virtual bool requires3DObject() const = 0;
+
+    /** @brief Indicates if the algorithm requires the object points to be co-planar
+
+    @returns true if required, false otherwise
+     */
+    CV_WRAP virtual bool requiresPlanarObject() const = 0;
+
+    /** @brief Indicates if the algorithm requires the object points to be in a planar tag configuration of the following form:
+  - point 0: [-squareLength / 2,  squareLength / 2, 0]
+  - point 1: [ squareLength / 2,  squareLength / 2, 0]
+  - point 2: [ squareLength / 2, -squareLength / 2, 0]
+  - point 3: [-squareLength / 2, -squareLength / 2, 0]
+
+    @returns true if required, false otherwise
+     */
+    CV_WRAP virtual bool requiresPlanarTagObject() const = 0;
+
+    /** @brief Warns if the problem geometry is known to either cause the solver to fail or to cause unstable results.
+     * 1) that the number of points is incompatible with the solver
+     * 2) that the object points are co-linear (which causes all pnp methods to fail)
+     * 3) that the solver requires co-planar object points, and the points are not co-planar
+     * 4) that the solver requires non-coplanar object points, and the points are co-planar
+     * 5) that the solver requires object points in a square tag configuration, but they are not
+     * 6) that the object points and/or image points are in a special configuration called an artificial degeneracy.
+     * An artificial degeneracy is one where the problem is theoretically solvable,
+     * but the algorithm design prevents it from solving the problem. To know more about
+     * artifical degeneracies, see e.g. @cite Collins14. Artifical degeneracies are specific to the method and they
+     * are defined by overriding artificalDegeneracyWarn
+    @returns true if problem geometry is good, false otherwise
+     */
+    CV_WRAP bool geometryWarn(InputArray _opoints,InputArray _ipoints) const;
+
+
+    /** @brief Checks if the object points are in the correct format of a planar tag
+
+    @returns true if correct, false otherwise
+     */
+    CV_WRAP bool isPlanarTag(InputArray _opionts) const;
+
+
+protected:
+    /** @brief Makes a 3x3 identity intrinsic matrix
+
+    @returns Identity intrinsic matrix (3x3 single channel double)
+     */
+    CV_WRAP cv::Mat makeIdentityIntrinsic() const;
+
+
+    /** @brief Gets number of points in object matrix. Must be 1xN 3-channel or Nx1 3-channel matrix (double) where n is the number of points.
+
+    @returns number of points
+     */
+    CV_WRAP size_t getNumberOfPoints(InputArray opoints) const;
+
+
+    /** @brief Checks that argument types are correct. Specifically opoints must be a 1xN 3-channel or Nx1 3-channel matrix (double) where n is the number of points.
+    opoints are defined in object coordinates. ipoints must be a 1xN 2-channel or Nx1 2-channel matrix (double) where n is the number of points.
+
+    @returns true if correct, otherwise false
+     */
+    CV_WRAP void checkArgTypes(InputArray opoints, InputArray ipoints) const;
+
+
+    /** @brief Warns if the problem geometry is known to cause an artificial degeneracy.
+     * An artificial degeneracy is one where the problem is theoretically solvable,
+     * but the algorithm design prevents it from solving the problem. To know more about
+     * artifical degeneracies, see e.g. @cite Collins14
+    @returns true if there no artificial degeneracy, false otherwise
+     */
+    CV_WRAP virtual bool artificalDegeneracyWarn(InputArray opoints,InputArray ipoints) const;
+
+    /** @brief Solves PnP for a given set of inputs
+    @param opoints Set of Object points. This must be a 1xN 3-channel or Nx1 3-channel matrix (double) where n is the number of points.
+    opoints are defined in object coordinates.
+    @param ipoints Set of Image points. This must be a 1xN 2-channel or Nx1 2-channel matrix (double) where n is the number of points.
+    ipoints are defined in normalized pixel coordinates. That is, they are defined by using a canonical intrinsic calibration matrix of K = eye(3).
+    You can convert a set of points defined in pixels to normalized pixel coordinates using @ref undistortPoints. This is convenient because it
+    eliminates the need for supplying the camera's intrinsics (calibration matrix and distortion parameters)
+    @param rvecs Vector of output rotation vectors (double) (see @ref Rodrigues ) that, together with tvecs, brings points from
+    the model coordinate system to the camera coordinate system.
+    @param tvecs Vector of output translation vectors (double).
+    @returns true if it could find a solution, otherwise false
+     */
+    CV_WRAP virtual void solve(InputArray opoints, InputArray ipoints, CV_OUT std::vector<Mat> & rVecs, CV_OUT std::vector<Mat> & tVecs) const = 0;
+
+    /**
+     * @brief COPLANAR_THRESHOLD specifies tolerance for judging if object points are co-planar. If coplarity test using @get3DPointsetShape fails with
+     this threshold then a PnP method with requiresPlanarObject = true cannot be used to solve this problem
+     */
+    //static double COPLANAR_THRESHOLD;
+
+    /**
+     * @brief COLINEAR_THRESHOLD specifies tolerance for judging if object points are co-linear. If colinearity test using @get3DPointsetShape fails with
+     this threshold then no PnP method can be used to solve this problem.
+     */
+    //static double COLINEAR_THRESHOLD;
+
+    /**
+     * @brief NONCOPLANAR_THRESHOLD specifies tolerance for judging if object points are non coplanar (i.e. they are 3D). If coplarity test using @get3DPointsetShape passes with
+     this threshold then a PnP method with requires3DObject = true cannot be used to solve this problem
+     */
+    //static double NONCOPLANAR_THRESHOLD;
+
+
+    /**
+      @brief geometricTests flag
+     */
+    bool withGeometricTests;
+};
+
+
+
+
+
+/** @brief Solution to P3P from @cite gao2003complete
+*/
+class CV_EXPORTS_W PnPSolverP3PComplete : public PnPSolver{
+public:
+
+    /**
+     @brief create creates a pointer to a new instance of this class
+     @param withGeometricTests set this true if you want to execute geometric checking of inputs before solving pnp.
+     There is a small speed penalty for running geometric tests. If you are sure that your inputs have the correct geometry then
+     you can set this to false for a small speed improvement.
+     @return pointer
+     */
+    CV_WRAP static Ptr<PnPSolverP3PComplete> create(bool withGeometricTests = false);
+
+    /**
+      @brief PnPSolverP3P constructor
+      @param withGeometricTests flag
+     */
+    CV_WRAP PnPSolverP3PComplete(bool withGeometricTests);
+
+    /**
+    @returns Minimal number of points
+     */
+    CV_WRAP int minPointNumber() const override;
+
+    /** @brief Gives the Maximal number of object points handled by the algorithm. If there is no maximum this returns -1.
+
+    @returns Maximal number of points. If no maximum, returns -1
+     */
+    CV_WRAP int maxPointNumber() const override;
+
+    /** @brief Indicates if the algorithm requires the object points to be 3D (i.e. not co-planar)
+
+    @returns true if required, false otherwise
+     */
+    CV_WRAP bool requires3DObject() const override;
+
+    /** @brief Indicates if the algorithm requires the object points to be co-planar
+
+    @returns true if required, false otherwise
+     */
+    CV_WRAP bool requiresPlanarObject() const override;
+
+    /** @brief Indicates if the algorithm requires the object points to be in a planar tag configuration of the following form:
+  - point 0: [-squareLength / 2,  squareLength / 2, 0]
+  - point 1: [ squareLength / 2,  squareLength / 2, 0]
+  - point 2: [ squareLength / 2, -squareLength / 2, 0]
+  - point 3: [-squareLength / 2, -squareLength / 2, 0]
+
+    @returns true if required, false otherwise
+     */
+    CV_WRAP bool requiresPlanarTagObject() const override;
+
+protected:
+
+
+    /** @brief Solves PnP for a given set of inputs
+    @param opoints Set of Object points. This must be a 1xN 3-channel or Nx1 3-channel matrix (double) where n is the number of points.
+    opoints are defined in object coordinates.
+    @param ipoints Set of Image points. This must be a 1xN 2-channel or Nx1 2-channel matrix (double) where n is the number of points.
+    ipoints are defined in normalized pixel coordinates. That is, they are defined by using a canonical intrinsic calibration matrix of K = eye(3).
+    You can convert a set of points defined in pixels to normalized pixel coordinates using @ref undistortPoints. This is convenient because it
+    eliminates the need for supplying the camera's intrinsics (calibration matrix and distortion parameters)
+    @param rvecs Vector of output rotation vectors (double) (see @ref Rodrigues ) that, together with tvecs, brings points from
+    the model coordinate system to the camera coordinate system.
+    @param tvecs Vector of output translation vectors (double).
+    @returns true if it could find a solution, otherwise false
+     */
+    CV_WRAP void solve(InputArray opoints, InputArray ipoints, CV_OUT std::vector<Mat> & rVecs, CV_OUT std::vector<Mat> & tVecs) const override;
+
+
+};
+
+
+
+/** @brief Solution to P3P from @cite Ke17 (APNP)
+*/
+class CV_EXPORTS_W PnPSolverAP3P : public PnPSolver{
+public:
+
+    /**
+     @brief create creates a pointer to a new instance of this class
+     @param withGeometricTests set this true if you want to execute geometric checking of inputs before solving pnp.
+     There is a small speed penalty for running geometric tests. If you are sure that your inputs have the correct geometry then
+     you can set this to false for a small speed improvement.
+     @return pointer
+     */
+    CV_WRAP static Ptr<PnPSolverAP3P> create(bool withGeometricTests = false);
+
+    /**
+      @brief PnPSolverAP3P constructor
+      @param withGeometricTests flag
+     */
+    CV_WRAP PnPSolverAP3P(bool withGeometricTests);
+
+    /**
+    @returns Minimal number of points
+     */
+    CV_WRAP int minPointNumber() const override;
+
+    /** @brief Gives the Maximal number of object points handled by the algorithm. If there is no maximum this returns -1.
+
+    @returns Maximal number of points. If no maximum, returns -1
+     */
+    CV_WRAP int maxPointNumber() const override;
+
+    /** @brief Indicates if the algorithm requires the object points to be 3D (i.e. not co-planar)
+
+    @returns true if required, false otherwise
+     */
+    CV_WRAP bool requires3DObject() const override;
+
+    /** @brief Indicates if the algorithm requires the object points to be co-planar
+
+    @returns true if required, false otherwise
+     */
+    CV_WRAP bool requiresPlanarObject() const override;
+
+    /** @brief Indicates if the algorithm requires the object points to be in a planar tag configuration of the following form:
+  - point 0: [-squareLength / 2,  squareLength / 2, 0]
+  - point 1: [ squareLength / 2,  squareLength / 2, 0]
+  - point 2: [ squareLength / 2, -squareLength / 2, 0]
+  - point 3: [-squareLength / 2, -squareLength / 2, 0]
+
+    @returns true if required, false otherwise
+     */
+    CV_WRAP bool requiresPlanarTagObject() const override;
+
+protected:
+
+    /** @brief Solves PnP for a given set of inputs
+    @param opoints Set of Object points. This must be a 1xN 3-channel or Nx1 3-channel matrix (double) where n is the number of points.
+    opoints are defined in object coordinates.
+    @param ipoints Set of Image points. This must be a 1xN 2-channel or Nx1 2-channel matrix (double) where n is the number of points.
+    ipoints are defined in normalized pixel coordinates. That is, they are defined by using a canonical intrinsic calibration matrix of K = eye(3).
+    You can convert a set of points defined in pixels to normalized pixel coordinates using @ref undistortPoints. This is convenient because it
+    eliminates the need for supplying the camera's intrinsics (calibration matrix and distortion parameters)
+    @param rvecs Vector of output rotation vectors (double) (see @ref Rodrigues ) that, together with tvecs, brings points from
+    the model coordinate system to the camera coordinate system.
+    @param tvecs Vector of output translation vectors (double).
+    @returns true if it could find a solution, otherwise false
+     */
+    CV_WRAP void solve(InputArray opoints, InputArray ipoints, CV_OUT std::vector<Mat> & rVecs, CV_OUT std::vector<Mat> & tVecs) const override;
+
+};
+
+
+
+/** @brief Solution to PnP with 4 or more co-planar object points from @cite Collins14 (IPPE)
+*/
+class CV_EXPORTS_W PnPSolverIPPE : public PnPSolver{
+public:
+
+    /**
+     @brief create creates a pointer to a new instance of this class
+     @param withGeometricTests set this true if you want to execute geometric checking of inputs before solving pnp.
+     There is a small speed penalty for running geometric tests. If you are sure that your inputs have the correct geometry then
+     you can set this to false for a small speed improvement.
+     @return pointer
+     */
+    CV_WRAP static Ptr<PnPSolverIPPE> create(bool withGeometricTests = false);
+
+    /**
+      @brief PnPSolverIPPE constructor
+      @param withGeometricTests flag
+     */
+    CV_WRAP PnPSolverIPPE(bool withGeometricTests);
+
+    /**
+    @returns Minimal number of points
+     */
+    CV_WRAP int minPointNumber() const override;
+
+    /** @brief Gives the Maximal number of object points handled by the algorithm. If there is no maximum this returns -1.
+
+    @returns Maximal number of points. If no maximum, returns -1
+     */
+    CV_WRAP int maxPointNumber() const override;
+
+    /** @brief Indicates if the algorithm requires the object points to be 3D (i.e. not co-planar)
+
+    @returns true if required, false otherwise
+     */
+    CV_WRAP bool requires3DObject() const override;
+
+    /** @brief Indicates if the algorithm requires the object points to be co-planar
+
+    @returns true if required, false otherwise
+     */
+    CV_WRAP bool requiresPlanarObject() const override;
+
+    /** @brief Indicates if the algorithm requires the object points to be in a planar tag configuration of the following form:
+  - point 0: [-squareLength / 2,  squareLength / 2, 0]
+  - point 1: [ squareLength / 2,  squareLength / 2, 0]
+  - point 2: [ squareLength / 2, -squareLength / 2, 0]
+  - point 3: [-squareLength / 2, -squareLength / 2, 0]
+
+    @returns true if required, false otherwise
+     */
+    CV_WRAP bool requiresPlanarTagObject() const override;
+
+protected:
+
+    /** @brief Solves PnP for a given set of inputs
+    @param opoints Set of Object points. This must be a 1xN 3-channel or Nx1 3-channel matrix (double) where n is the number of points.
+    opoints are defined in object coordinates.
+    @param ipoints Set of Image points. This must be a 1xN 2-channel or Nx1 2-channel matrix (double) where n is the number of points.
+    ipoints are defined in normalized pixel coordinates. That is, they are defined by using a canonical intrinsic calibration matrix of K = eye(3).
+    You can convert a set of points defined in pixels to normalized pixel coordinates using @ref undistortPoints. This is convenient because it
+    eliminates the need for supplying the camera's intrinsics (calibration matrix and distortion parameters)
+    @param rvecs Vector of output rotation vectors (double) (see @ref Rodrigues ) that, together with tvecs, brings points from
+    the model coordinate system to the camera coordinate system.
+    @param tvecs Vector of output translation vectors (double).
+    @returns true if it could find a solution, otherwise false
+     */
+    CV_WRAP void solve(InputArray opoints, InputArray ipoints, CV_OUT std::vector<Mat> & rVecs, CV_OUT std::vector<Mat> & tVecs) const override;
+
+
+
+};
+
+
+
+/** @brief Solution to PnP with 4 co-planar square object ponts (tag configuration) from @cite Collins14 (IPPE_SQUARE)
+*/
+class CV_EXPORTS_W PnPSolverIPPESquare : public PnPSolver{
+public:
+
+    /**
+     @brief create creates a pointer to a new instance of this class
+     @param withGeometricTests set this true if you want to execute geometric checking of inputs before solving pnp.
+     There is a small speed penalty for running geometric tests. If you are sure that your inputs have the correct geometry then
+     you can set this to false for a small speed improvement.
+     @return pointer
+     */
+    CV_WRAP static Ptr<PnPSolverIPPESquare> create(bool withGeometricTests = false);
+
+    /**
+      @brief PnPSolverIPPESquare constructor
+      @param withGeometricTests flag
+     */
+    CV_WRAP PnPSolverIPPESquare(bool withGeometricTests);
+
+    /**
+    @returns Minimal number of points
+     */
+    CV_WRAP int minPointNumber() const override;
+
+    /** @brief Gives the Maximal number of object points handled by the algorithm. If there is no maximum this returns -1.
+
+    @returns Maximal number of points. If no maximum, returns -1
+     */
+    CV_WRAP int maxPointNumber() const override;
+
+    /** @brief Indicates if the algorithm requires the object points to be 3D (i.e. not co-planar)
+
+    @returns true if required, false otherwise
+     */
+    CV_WRAP bool requires3DObject() const override;
+
+    /** @brief Indicates if the algorithm requires the object points to be co-planar
+
+    @returns true if required, false otherwise
+     */
+    CV_WRAP bool requiresPlanarObject() const override;
+
+    /** @brief Indicates if the algorithm requires the object points to be in a planar tag configuration of the following form:
+  - point 0: [-squareLength / 2,  squareLength / 2, 0]
+  - point 1: [ squareLength / 2,  squareLength / 2, 0]
+  - point 2: [ squareLength / 2, -squareLength / 2, 0]
+  - point 3: [-squareLength / 2, -squareLength / 2, 0]
+
+    @returns true if required, false otherwise
+     */
+    CV_WRAP bool requiresPlanarTagObject() const override;
+
+
+protected:
+
+
+    /** @brief Solves PnP for a given set of inputs
+    @param opoints Set of Object points. This must be a 1xN 3-channel or Nx1 3-channel matrix (double) where n is the number of points.
+    opoints are defined in object coordinates.
+    @param ipoints Set of Image points. This must be a 1xN 2-channel or Nx1 2-channel matrix (double) where n is the number of points.
+    ipoints are defined in normalized pixel coordinates. That is, they are defined by using a canonical intrinsic calibration matrix of K = eye(3).
+    You can convert a set of points defined in pixels to normalized pixel coordinates using @ref undistortPoints. This is convenient because it
+    eliminates the need for supplying the camera's intrinsics (calibration matrix and distortion parameters)
+    @param rvecs Vector of output rotation vectors (double) (see @ref Rodrigues ) that, together with tvecs, brings points from
+    the model coordinate system to the camera coordinate system.
+    @param tvecs Vector of output translation vectors (double).
+    @returns true if it could find a solution, otherwise false
+     */
+    CV_WRAP void solve(InputArray opoints, InputArray ipoints, CV_OUT std::vector<Mat> & rVecs, CV_OUT std::vector<Mat> & tVecs) const override;
+
+
+
+
+};
+
+
+
+/** @brief Solution to PnP with 4 or more co-planar object points using Zhang's method. This is identical to the implementation in OpenCV's C API (cvFindExtrinsicCameraParams2)
+*/
+class CV_EXPORTS_W PnPSolverZhang : public PnPSolver{
+public:
+
+    /**
+     @brief create creates a pointer to a new instance of this class
+     @param withGeometricTests set this true if you want to execute geometric checking of inputs before solving pnp.
+     There is a small speed penalty for running geometric tests. If you are sure that your inputs have the correct geometry then
+     you can set this to false for a small speed improvement.
+     @return pointer
+     */
+    CV_WRAP static Ptr<PnPSolverZhang> create(bool withGeometricTests = false);
+
+    /**
+      @brief PnPSolverZhang constructor
+      @param withGeometricTests flag
+     */
+    CV_WRAP PnPSolverZhang(bool withGeometricTests);
+
+    /**
+    @returns Minimal number of points
+     */
+    CV_WRAP int minPointNumber() const override;
+
+    /** @brief Gives the Maximal number of object points handled by the algorithm. If there is no maximum this returns -1.
+
+    @returns Maximal number of points. If no maximum, returns -1
+     */
+    CV_WRAP int maxPointNumber() const override;
+
+    /** @brief Indicates if the algorithm requires the object points to be 3D (i.e. not co-planar)
+
+    @returns true if required, false otherwise
+     */
+    CV_WRAP bool requires3DObject() const override;
+
+    /** @brief Indicates if the algorithm requires the object points to be co-planar
+
+    @returns true if required, false otherwise
+     */
+    CV_WRAP bool requiresPlanarObject() const override;
+
+    /** @brief Indicates if the algorithm requires the object points to be in a planar tag configuration of the following form:
+  - point 0: [-squareLength / 2,  squareLength / 2, 0]
+  - point 1: [ squareLength / 2,  squareLength / 2, 0]
+  - point 2: [ squareLength / 2, -squareLength / 2, 0]
+  - point 3: [-squareLength / 2, -squareLength / 2, 0]
+
+    @returns true if required, false otherwise
+     */
+    CV_WRAP bool requiresPlanarTagObject() const override;
+
+
+protected:
+
+    /** @brief Solves PnP for a given set of inputs
+    @param opoints Set of Object points. This must be a 1xN 3-channel or Nx1 3-channel matrix (double) where n is the number of points.
+    opoints are defined in object coordinates.
+    @param ipoints Set of Image points. This must be a 1xN 2-channel or Nx1 2-channel matrix (double) where n is the number of points.
+    ipoints are defined in normalized pixel coordinates. That is, they are defined by using a canonical intrinsic calibration matrix of K = eye(3).
+    You can convert a set of points defined in pixels to normalized pixel coordinates using @ref undistortPoints. This is convenient because it
+    eliminates the need for supplying the camera's intrinsics (calibration matrix and distortion parameters)
+    @param rvecs Vector of output rotation vectors (double) (see @ref Rodrigues ) that, together with tvecs, brings points from
+    the model coordinate system to the camera coordinate system.
+    @param tvecs Vector of output translation vectors (double).
+    @returns true if it could find a solution, otherwise false
+     */
+    CV_WRAP void solve(InputArray opoints, InputArray ipoints, CV_OUT std::vector<Mat> & rVecs, CV_OUT std::vector<Mat> & tVecs) const override;
+
+    /** @brief Warns if the problem geometry is known to cause an artificial degeneracy.
+     * An artificial degeneracy is one where the problem is theoretically solvable,
+     * but the algorithm design prevents it from solving the problem. To know more about
+     * artifical degeneracies, see e.g. @cite Collins14
+    @returns true if there no artificial degeneracy, false otherwise
+     */
+    CV_WRAP bool artificalDegeneracyWarn(InputArray opoints,InputArray ipoints) const override;
+
+
+
+private:
+
+    /** @brief solveCImpl Solution is identical to the one in OpenCV's C API (cvFindExtrinsicCameraParams2)
+    @param opoints Set of Object points. This must be a CvMat pointer to a 1xN 3-channel or Nx1 3-channel matrix (double) where n is the number of points.
+    opoints are defined in object coordinates.
+    @param ipoints Set of Image points. This must be a CvMat pointer to 1xN 2-channel or Nx1 2-channel matrix (double) where n is the number of points.
+    ipoints are defined in normalized pixel coordinates. That is, they are defined by using a canonical intrinsic calibration matrix of K = eye(3).
+    You can convert a set of points defined in pixels to normalized pixel coordinates using @ref undistortPoints. This is convenient because it
+    eliminates the need for supplying the camera's intrinsics (calibration matrix and distortion parameters)
+    @param rvec output rotation vectors (double) (see @ref Rodrigues ) that, together with tvecs, brings points from
+    the model coordinate system to the camera coordinate system.
+    @param tvec output translation vector (double).
+    @returns true if it could find a solution, otherwise false
+     */
+    bool solveCImpl(const CvMat* objectPoints,
+                    const CvMat* imagePoints, CvMat* rvec, CvMat* tvec) const;
+
+
+};
+
+
+
+
+/** @brief Solution to PnP with >=6 non-co-planar object points using the basic DLT, implemented in OpenCV's C API (cvFindExtrinsicCameraParams2)
+*/
+class CV_EXPORTS_W PnPSolverDLT : public PnPSolver{
+public:
+
+    /**
+     @brief create creates a pointer to a new instance of this class
+     @param withGeometricTests set this true if you want to execute geometric checking of inputs before solving pnp.
+     There is a small speed penalty for running geometric tests. If you are sure that your inputs have the correct geometry then
+     you can set this to false for a small speed improvement.
+     @return pointer
+     */
+    CV_WRAP static Ptr<PnPSolverDLT> create(bool withGeometricTests = false);
+
+    /**
+      @brief PnPSolverDLT constructor
+      @param withGeometricTests flag
+     */
+    CV_WRAP PnPSolverDLT(bool withGeometricTests);
+
+
+    /**
+    @returns Minimal number of points
+     */
+    CV_WRAP int minPointNumber() const override;
+
+    /** @brief Gives the Maximal number of object points handled by the algorithm. If there is no maximum this returns -1.
+
+    @returns Maximal number of points. If no maximum, returns -1
+     */
+    CV_WRAP int maxPointNumber() const override;
+
+    /** @brief Indicates if the algorithm requires the object points to be 3D (i.e. not co-planar)
+
+    @returns true if required, false otherwise
+     */
+    CV_WRAP bool requires3DObject() const override;
+
+    /** @brief Indicates if the algorithm requires the object points to be co-planar
+
+    @returns true if required, false otherwise
+     */
+    CV_WRAP bool requiresPlanarObject() const override;
+
+    /** @brief Indicates if the algorithm requires the object points to be in a planar tag configuration of the following form:
+  - point 0: [-squareLength / 2,  squareLength / 2, 0]
+  - point 1: [ squareLength / 2,  squareLength / 2, 0]
+  - point 2: [ squareLength / 2, -squareLength / 2, 0]
+  - point 3: [-squareLength / 2, -squareLength / 2, 0]
+
+    @returns true if required, false otherwise
+     */
+    CV_WRAP bool requiresPlanarTagObject() const override;
+
+
+protected:
+
+    /** @brief Solves PnP for a given set of inputs
+    @param opoints Set of Object points. This must be a 1xN 3-channel or Nx1 3-channel matrix (double) where n is the number of points.
+    opoints are defined in object coordinates.
+    @param ipoints Set of Image points. This must be a 1xN 2-channel or Nx1 2-channel matrix (double) where n is the number of points.
+    ipoints are defined in normalized pixel coordinates. That is, they are defined by using a canonical intrinsic calibration matrix of K = eye(3).
+    You can convert a set of points defined in pixels to normalized pixel coordinates using @ref undistortPoints. This is convenient because it
+    eliminates the need for supplying the camera's intrinsics (calibration matrix and distortion parameters)
+    @param rvecs Vector of output rotation vectors (double) (see @ref Rodrigues ) that, together with tvecs, brings points from
+    the model coordinate system to the camera coordinate system.
+    @param tvecs Vector of output translation vectors (double).
+    @returns true if correct, otherwise false
+     */
+    CV_WRAP void solve(InputArray opoints, InputArray ipoints, CV_OUT std::vector<Mat> & rVecs, CV_OUT std::vector<Mat> & tVecs) const override;
+
+private:
+
+    /** @brief solveCImpl Solution is identitcal to the implementation in OpenCV's C API (cvFindExtrinsicCameraParams2)
+        @param opoints Set of Object points. This must be a CvMat pointer to a 1xN 3-channel or Nx1 3-channel matrix (double) where n is the number of points.
+        opoints are defined in object coordinates.
+        @param ipoints Set of Image points. This must be a CvMat pointer to 1xN 2-channel or Nx1 2-channel matrix (double) where n is the number of points.
+        ipoints are defined in normalized pixel coordinates. That is, they are defined by using a canonical intrinsic calibration matrix of K = eye(3).
+        You can convert a set of points defined in pixels to normalized pixel coordinates using @ref undistortPoints. This is convenient because it
+        eliminates the need for supplying the camera's intrinsics (calibration matrix and distortion parameters)
+        @param rvec output rotation vectors (double) (see @ref Rodrigues ) that, together with tvecs, brings points from
+        the model coordinate system to the camera coordinate system.
+        @param tvec output translation vector (double).
+        @returns true if it could find a solution, otherwise false
+         */
+    bool solveCImpl(const CvMat* objectPoints,
+                    const CvMat* imagePoints, CvMat* rvec, CvMat* tvec) const;
+
+};
+
+
+
+
+/** @brief Solution to PnP with >=5 non-co-planar object points @cite lepetit2009epnp (EPnP)
+*/
+class CV_EXPORTS_W PnPSolverEPnP3D : public PnPSolver{
+public:
+
+
+    /**
+     @brief create creates a pointer to a new instance of this class
+     @param withGeometricTests set this true if you want to execute geometric checking of inputs before solving pnp.
+     There is a small speed penalty for running geometric tests. If you are sure that your inputs have the correct geometry then
+     you can set this to false for a small speed improvement.
+     @return pointer
+     */
+    CV_WRAP static Ptr<PnPSolverEPnP3D> create(bool withGeometricTests = false);
+
+    /**
+      @brief PnPSolverEPnP3D constructor
+      @param withGeometricTests flag
+     */
+    CV_WRAP PnPSolverEPnP3D(bool withGeometricTests);
+
+    /**
+    @returns Minimal number of points
+     */
+    CV_WRAP int minPointNumber() const override;
+
+    /** @brief Gives the Maximal number of object points handled by the algorithm. If there is no maximum this returns -1.
+
+    @returns Maximal number of points. If no maximum, returns -1
+     */
+    CV_WRAP int maxPointNumber() const override;
+
+    /** @brief Indicates if the algorithm requires the object points to be 3D (i.e. not co-planar)
+
+    @returns true if required, false otherwise
+     */
+    CV_WRAP bool requires3DObject() const override;
+
+    /** @brief Indicates if the algorithm requires the object points to be co-planar
+
+    @returns true if required, false otherwise
+     */
+    CV_WRAP bool requiresPlanarObject() const override;
+
+    /** @brief Indicates if the algorithm requires the object points to be in a planar tag configuration of the following form:
+  - point 0: [-squareLength / 2,  squareLength / 2, 0]
+  - point 1: [ squareLength / 2,  squareLength / 2, 0]
+  - point 2: [ squareLength / 2, -squareLength / 2, 0]
+  - point 3: [-squareLength / 2, -squareLength / 2, 0]
+
+    @returns true if required, false otherwise
+     */
+    CV_WRAP bool requiresPlanarTagObject() const override;
+
+
+protected:
+
+    /** @brief Solves PnP for a given set of inputs
+    @param opoints Set of Object points. This must be a 1xN 3-channel or Nx1 3-channel matrix (double) where n is the number of points.
+    opoints are defined in object coordinates.
+    @param ipoints Set of Image points. This must be a 1xN 2-channel or Nx1 2-channel matrix (double) where n is the number of points.
+    ipoints are defined in normalized pixel coordinates. That is, they are defined by using a canonical intrinsic calibration matrix of K = eye(3).
+    You can convert a set of points defined in pixels to normalized pixel coordinates using @ref undistortPoints. This is convenient because it
+    eliminates the need for supplying the camera's intrinsics (calibration matrix and distortion parameters)
+    @param rvecs Vector of output rotation vectors (double) (see @ref Rodrigues ) that, together with tvecs, brings points from
+    the model coordinate system to the camera coordinate system.
+    @param tvecs Vector of output translation vectors (double).
+    @returns true if correct, otherwise false
+     */
+    CV_WRAP void solve(InputArray opoints, InputArray ipoints, CV_OUT std::vector<Mat> & rVecs, CV_OUT std::vector<Mat> & tVecs) const override;
+};
+
+
+/** @brief Solution to PnP using DLS algoritm.
+ *  This is based on the implementation in OpenCV's C API (cvFindExtrinsicCameraParams2)
+*/
+class CV_EXPORTS_W PnPSolverDLS : public PnPSolver{
+public:
+
+    /**
+     @brief create creates a pointer to a new instance of this class
+     @param withGeometricTests set this true if you want to execute geometric checking of inputs before solving pnp.
+     There is a small speed penalty for running geometric tests. If you are sure that your inputs have the correct geometry then
+     you can set this to false for a small speed improvement.
+     @return pointer
+     */
+    CV_WRAP static Ptr<PnPSolverDLS> create(bool withGeometricTests = false);
+
+    /**
+      @brief PnPSolverDLS constructor
+      @param withGeometricTests flag
+     */
+    CV_WRAP PnPSolverDLS(bool withGeometricTests);
+
+    /**
+    @returns Minimal number of points
+     */
+    CV_WRAP int minPointNumber() const override;
+
+    /** @brief Gives the Maximal number of object points handled by the algorithm. If there is no maximum this returns -1.
+
+    @returns Maximal number of points. If no maximum, returns -1
+     */
+    CV_WRAP int maxPointNumber() const override;
+
+    /** @brief Indicates if the algorithm requires the object points to be 3D (i.e. not co-planar)
+
+    @returns true if required, false otherwise
+     */
+    CV_WRAP bool requires3DObject() const override;
+
+    /** @brief Indicates if the algorithm requires the object points to be co-planar
+
+    @returns true if required, false otherwise
+     */
+    CV_WRAP bool requiresPlanarObject() const override;
+
+    /** @brief Indicates if the algorithm requires the object points to be in a planar tag configuration of the following form:
+  - point 0: [-squareLength / 2,  squareLength / 2, 0]
+  - point 1: [ squareLength / 2,  squareLength / 2, 0]
+  - point 2: [ squareLength / 2, -squareLength / 2, 0]
+  - point 3: [-squareLength / 2, -squareLength / 2, 0]
+
+    @returns true if required, false otherwise
+     */
+    CV_WRAP bool requiresPlanarTagObject() const override;
+
+
+protected:
+
+    /** @brief Solves PnP for a given set of inputs
+    @param opoints Set of Object points. This must be a 1xN 3-channel or Nx1 3-channel matrix (double) where n is the number of points.
+    opoints are defined in object coordinates.
+    @param ipoints Set of Image points. This must be a 1xN 2-channel or Nx1 2-channel matrix (double) where n is the number of points.
+    ipoints are defined in normalized pixel coordinates. That is, they are defined by using a canonical intrinsic calibration matrix of K = eye(3).
+    You can convert a set of points defined in pixels to normalized pixel coordinates using @ref undistortPoints. This is convenient because it
+    eliminates the need for supplying the camera's intrinsics (calibration matrix and distortion parameters)
+    @param rvecs Vector of output rotation vectors (double) (see @ref Rodrigues ) that, together with tvecs, brings points from
+    the model coordinate system to the camera coordinate system.
+    @param tvecs Vector of output translation vectors (double).
+    @returns true if correct, otherwise false
+     */
+    CV_WRAP void solve(InputArray opoints, InputArray ipoints, CV_OUT std::vector<Mat> & rVecs, CV_OUT std::vector<Mat> & tVecs) const override;
+
+};
+
+
+/** @brief Solution to PnP by automatically selecting a PnP solver according to the scene geometry.
+ *  This replicates the solver selection used in OpenCV's C API (cvFindExtrinsicCameraParams2):
+ *  Case 1: when the object points are co-planar and greater than 3, IPPE is used
+ *  Case 2: when the object points are not co-planar and greater than 6, DLT is used
+ *  Otherwise no solution is computed
+ *  Note: This differs only to the C API by replacing case 1 with IPPE instead of using Zhang. The benifit is
+ *  documented in @cite Collins14 (IPPE can handle ambiguous problems with 2 solutions, and Zhang's implementation fails in some object configurations
+ *  e.g. a planar tag. See test_solvePnPGeneric ProblemGeneratorFailures for showing the failure case)
+ *  If the object points are not co-planar, DLT is used.
+*/
+class CV_EXPORTS_W PnPSolverAutoSelect1 : public PnPSolver{
+public:
+
+    /**
+     @brief create creates a pointer to a new instance of this class
+     @param withGeometricTests set this true if you want to execute geometric checking of inputs before solving pnp.
+     There is a small speed penalty for running geometric tests. If you are sure that your inputs have the correct geometry then
+     you can set this to false for a small speed improvement.
+     @return pointer
+     */
+    CV_WRAP static Ptr<PnPSolverAutoSelect1> create(bool withGeometricTests = false);
+
+    /**
+      @brief PnPSolverDLS constructor
+      @param withGeometricTests flag
+     */
+    CV_WRAP PnPSolverAutoSelect1(bool withGeometricTests);
+
+    /**
+    @returns Minimal number of points
+     */
+    CV_WRAP int minPointNumber() const override;
+
+    /** @brief Gives the Maximal number of object points handled by the algorithm. If there is no maximum this returns -1.
+
+    @returns Maximal number of points. If no maximum, returns -1
+     */
+    CV_WRAP int maxPointNumber() const override;
+
+    /** @brief Indicates if the algorithm requires the object points to be 3D (i.e. not co-planar)
+
+    @returns true if required, false otherwise
+     */
+    CV_WRAP bool requires3DObject() const override;
+
+    /** @brief Indicates if the algorithm requires the object points to be co-planar
+
+    @returns true if required, false otherwise
+     */
+    CV_WRAP bool requiresPlanarObject() const override;
+
+    /** @brief Indicates if the algorithm requires the object points to be in a planar tag configuration of the following form:
+  - point 0: [-squareLength / 2,  squareLength / 2, 0]
+  - point 1: [ squareLength / 2,  squareLength / 2, 0]
+  - point 2: [ squareLength / 2, -squareLength / 2, 0]
+  - point 3: [-squareLength / 2, -squareLength / 2, 0]
+
+    @returns true if required, false otherwise
+     */
+    CV_WRAP bool requiresPlanarTagObject() const override;
+
+
+protected:
+
+    /** @brief Solves PnP for a given set of inputs
+    @param opoints Set of Object points. This must be a 1xN 3-channel or Nx1 3-channel matrix (double) where n is the number of points.
+    opoints are defined in object coordinates.
+    @param ipoints Set of Image points. This must be a 1xN 2-channel or Nx1 2-channel matrix (double) where n is the number of points.
+    ipoints are defined in normalized pixel coordinates. That is, they are defined by using a canonical intrinsic calibration matrix of K = eye(3).
+    You can convert a set of points defined in pixels to normalized pixel coordinates using @ref undistortPoints. This is convenient because it
+    eliminates the need for supplying the camera's intrinsics (calibration matrix and distortion parameters)
+    @param rvecs Vector of output rotation vectors (double) (see @ref Rodrigues ) that, together with tvecs, brings points from
+    the model coordinate system to the camera coordinate system.
+    @param tvecs Vector of output translation vectors (double).
+    @returns true if correct, otherwise false
+     */
+    CV_WRAP void solve(InputArray opoints, InputArray ipoints, CV_OUT std::vector<Mat> & rVecs, CV_OUT std::vector<Mat> & tVecs) const override;
+
+};
+//! @} PnPSolver
+
+
+/**
+  @defgroup PnPRefiner PnPRefiners
+  @{
+  PnP Refines
+
+  @}
+ */
+
+//! @addtogroup PnPRefiner
+//! @{
+
+
+/** @brief Abstract base class for a PnP refinement algorithm
+*/
+#ifdef __EMSCRIPTEN__
+class CV_EXPORTS_W PnPRefiner : public Algorithm
+        #else
+class CV_EXPORTS_W PnPRefiner : public virtual Algorithm
+        #endif
+{
+
+public:
+
+    /** @brief Refines a PnP solution using a refinement algorithm. The purpose is to take an initial pose soltuion and improve on it through a minimization of a non-convex loss function
+     * (least squares reprojection error such as the RMS reprojection error.
+     * Generally the loss function cannot be solved in closed-form, so refinement algorithms are iterative by nature.
+
+    @param opoints Set of Object points. This must be a 1xN 3-channel or Nx1 3-channel matrix (double) where n is the number of points.
+    opoints are defined in object coordinates.
+    @param ipoints Set of Image points. This must be a 1xN 2-channel or Nx1 2-channel matrix (double) where n is the number of points.
+    ipoints are defined in pixel coordinates.
+    @param cameraMatrix. The camera's intrinsic matrix. This must be a 3x3 1-channel matrix (double)
+    @param distortion. The camera's distortion matrix. See @solvePnPGeneric for details. If this is non-empty it must a double matrix
+    @param rvec output rotation vector (double) (see @ref Rodrigues ) that, together with tvec, brings points from
+    the model coordinate system to the camera coordinate system.
+    @param tvec output translation vector (double).
+     */
+    CV_WRAP virtual bool refine(InputArray opoints, InputArray ipoints, InputArray cameraMatrix, InputArray distortion, InputArray rVec, InputArray tVec, CV_OUT std::vector<Mat> & rVecs, CV_OUT std::vector<Mat> & tVecs) const = 0;
+protected:
+
+
+
+};
+
+/**
+ @brief PnP refinement algorithm using Levenberg Marquardt. The purpose is to take an initial pose soltuion and improve on it through a minimization of a non-convex loss function (least squares reprojection error).
+ The global minimum is solution is statistically optimal if there is no noise in the object points and noise in the image points described by zero-mean independent and identitically distributed Gaussian (white noise).
+  This is identical to the implementation in OpenCV's C API (cvFindExtrinsicCameraParams2). Requires 3 or more non co-linear object poitns and an initial solution with which to refine.
+ */
+class CV_EXPORTS_W PnPRefinerLM : public PnPRefiner{
+public:
+
+    /**
+      @brief creates pointer to a new instance of class
+      @return pointer
+     */
+    CV_WRAP static Ptr<PnPRefinerLM> create();
+
+
+    /** @brief Refines a PnP solution using a LM algorithm.
+
+    @param opoints Set of Object points. This must be a 1xN 3-channel or Nx1 3-channel matrix (double) where n is the number of points.
+    opoints are defined in object coordinates.
+    @param ipoints Set of Image points. This must be a 1xN 2-channel or Nx1 2-channel matrix (double) where n is the number of points.
+    ipoints are defined in pixel coordinates.
+    @param cameraMatrix. The camera's intrinsic matrix. This must be a 3x3 1-channel matrix (double)
+    @param distortion. The camera's distortion matrix. See @solvePnPGeneric for details. If this is non-empty it must a double matrix
+    @param rvec output rotation vector (double) (see @ref Rodrigues ) that, together with tvec, brings points from
+    the model coordinate system to the camera coordinate system.
+    @param tvec output translation vector (double).
+     */
+    CV_WRAP bool refine(InputArray opoints, InputArray ipoints, InputArray cameraMatrix, InputArray distortion, InputArray rVec, InputArray tVec, CV_OUT std::vector<Mat> & rVecs, CV_OUT std::vector<Mat> & tVecs) const override;
+
+};
+
+
+/**
+ @brief PnP refinement algorithm using Levenberg Marquardt implemented in C++. The purpose is to take an initial pose soltuion and improve on it through a minimization of a non-convex loss function (least squares reprojection error).
+ The global minimum is solution is statistically optimal if there is no noise in the object points and noise in the image points described by zero-mean independent and identitically distributed Gaussian (white noise).
+  This is identical to the implementation in OpenCV's C API (cvFindExtrinsicCameraParams2). Requires 3 or more non co-linear object poitns and an initial solution with which to refine.
+ */
+class CV_EXPORTS_W PnPRefinerLMcpp : public PnPRefiner{
+public:
+
+    /**
+      @brief creates pointer to a new instance of class
+      @param criteria Criteria when to stop the Levenberg-Marquard iterative algorithm.
+      @return pointer
+     */
+    CV_WRAP static Ptr<PnPRefinerLMcpp> create(TermCriteria criteria = TermCriteria(TermCriteria::EPS + TermCriteria::COUNT, 20, FLT_EPSILON));
+
+    /**
+     @brief PnPRefinerLMImpl2 constuctor
+     @param criteria termination criteria
+     */
+    CV_WRAP PnPRefinerLMcpp(TermCriteria criteria);
+
+    /** @brief Refines a PnP solution using a LM algorithm.
+
+    @param opoints Set of Object points. This must be a 1xN 3-channel or Nx1 3-channel matrix (double) where n is the number of points.
+    opoints are defined in object coordinates.
+    @param ipoints Set of Image points. This must be a 1xN 2-channel or Nx1 2-channel matrix (double) where n is the number of points.
+    ipoints are defined in pixel coordinates.
+    @param cameraMatrix. The camera's intrinsic matrix. This must be a 3x3 1-channel matrix (double)
+    @param distortion. The camera's distortion matrix. See @solvePnPGeneric for details. If this is non-empty it must a double matrix
+    @param rvec output rotation vector (double) (see @ref Rodrigues ) that, together with tvec, brings points from
+    the model coordinate system to the camera coordinate system.
+    @param tvec output translation vector (double).
+     */
+    CV_WRAP bool refine(InputArray opoints, InputArray ipoints, InputArray cameraMatrix, InputArray distortion, InputArray rVec, InputArray tVec, CV_OUT std::vector<Mat> & rVecs, CV_OUT std::vector<Mat> & tVecs) const override;
+private:
+
+    /**
+      @brief termination criteria
+     */
+    TermCriteria criteria;
+
+};
+
+
+/**
+ @brief PnP refinement algorithm using Virtual Visual Survoing. This minimizes the projection error with respect to the rotation and the translation vectors, using a
+virtual visual servoing (VVS) @cite Chaumette06 @cite Marchand16 scheme. Requires 3 or more non co-linear object poitns and an initial solution with which to refine.
+ */
+class CV_EXPORTS_W PnPRefinerVVS : public PnPRefiner{
+public:
+
+    /**
+     * @brief PnPRefinerVVS constructor
+     * @param criteria Criteria when to stop the Levenberg-Marquard iterative algorithm.
+     * @param VVSlambda Gain for the virtual visual servoing control law, equivalent to the \f$\alpha\f$
+gain in the Damped Gauss-Newton formulation.
+     */
+    CV_WRAP PnPRefinerVVS(TermCriteria  criteria, double VVSlambda);
+
+    CV_WRAP static Ptr<PnPRefinerVVS> create(TermCriteria criteria = TermCriteria(TermCriteria::EPS + TermCriteria::COUNT, 20, FLT_EPSILON),double vvslambda = 1);
+
+    /** @brief Refines a PnP solution using VVS.
+
+    @param opoints Set of Object points. This must be a 1xN 3-channel or Nx1 3-channel matrix (double) where n is the number of points.
+    opoints are defined in object coordinates.
+    @param ipoints Set of Image points. This must be a 1xN 2-channel or Nx1 2-channel matrix (double) where n is the number of points.
+    ipoints are defined in pixel coordinates.
+    @param cameraMatrix. The camera's intrinsic matrix. This must be a 3x3 1-channel matrix (double)
+    @param distortion. The camera's distortion matrix. See @solvePnPGeneric for details. If this is non-empty it must a double matrix
+    @param rvec output rotation vector (double) (see @ref Rodrigues ) that, together with tvec, brings points from
+    the model coordinate system to the camera coordinate system.
+    @param tvec output translation vector (double).
+     */
+    CV_WRAP bool refine(InputArray opoints, InputArray ipoints, InputArray cameraMatrix, InputArray distortion, InputArray rVec, InputArray tVec, CV_OUT std::vector<Mat> & rVecs, CV_OUT std::vector<Mat> & tVecs) const override;
+private:
+
+    TermCriteria criteria;
+    double vvslambda;
+
+};
+
+//! @} PnPRefiner
+
+
+
+/** @brief Finds an object pose from 3D-2D point correspondences.
+-This solves the problem in two stages. In the first stage, a @ref PnPSolver is called, which provides an initial set of
+candidate pose solutions. In the second stage, a @ref PnPRefiner is called, which takes each of the pose solutions
+and iteratively improves the solution to minimize a non-convex loss function (usually the reprojection error). This is an improved interface for
+solving PnP compared with the older one (@ref SolvePnP) for two important reasons. Firstly, it allows problems with
+multiple solutions to be handled, which typically occurs in the case when the object points are co-planar. See notes
+below for further details, taken from @cite Collins14. Secondly, it is a much cleaner interface by clearly dividing
+the problem into its two parts (initial solution followed by refinement). Thirdly it allows any combination of
+PnPSolver and PnPRefiner to be used.
+@param objectPoints Array of object points in the object coordinate space, Nx3 1-channel or
+1xN/Nx1 3-channel, where N is the number of points. vector\<Point3f\> can be also passed here.
+@param imagePoints Array of corresponding image points, Nx2 1-channel or 1xN/Nx1 2-channel,
+where N is the number of points. vector\<Point2f\> can be also passed here.
+@param cameraMatrix Input camera matrix \f$A = \vecthreethree{fx}{0}{cx}{0}{fy}{cy}{0}{0}{1}\f$ .
+@param distCoeffs Input vector of distortion coefficients
+\f$(k_1, k_2, p_1, p_2[, k_3[, k_4, k_5, k_6 [, s_1, s_2, s_3, s_4[, \tau_x, \tau_y]]]])\f$ of
+4, 5, 8, 12 or 14 elements. If the vector is NULL/empty, the zero distortion coefficients are
+assumed.
+@param rvecs Vector of output rotation vectors (see @ref Rodrigues ) that, together with tvecs, brings points from
+the model coordinate system to the camera coordinate system.
+@param tvecs Vector of output translation vectors.
+@param solver is the PnPSolver to be used. If you already have an initial set of pose solutions, and you just want to refine them
+you should set solver as an empty pointer (Ptr<PnPSolver>()). In this case the initial solutions are read from rvecs and tvecs.
+@param refiner is the PnPRefiner to be used. If do not want to run a refiner, you should set this as an empty pointer (Ptr<PnPRefiner>()).
+It is highly recommended that you use a PnPRefiner. We recommend @ref PnPRefinerLM, which performs Levenberg Marquardt refinement using
+OpenCVs C API (@ref cvFindExtrinsicCameraParams2)
+@param sortOnReprojectionError Bool that indicates pose solutions should be sorted by increasing RMS reprojection error (lowest reprojection error first).
+@param reprojectionError Optional vector of reprojection error, that is the RMS error
+(\f$ \text{RMSE} = \sqrt{\frac{\sum_{i}^{N} \left ( \hat{y_i} - y_i \right )^2}{N}} \f$) between the input image points
+and the 3D object points projected with the estimated pose.
+
+
+The function estimates the object pose given a set of object points, their corresponding image
+projections, as well as the camera matrix and the distortion coefficients, see the figure below
+(more precisely, the X-axis of the camera frame is pointing to the right, the Y-axis downward
+and the Z-axis forward).
+
+![](pnp.jpg)
+
+Points expressed in the world frame \f$ \bf{X}_w \f$ are projected into the image plane \f$ \left[ u, v \right] \f$
+using the perspective projection model \f$ \Pi \f$ and the camera intrinsic parameters matrix \f$ \bf{A} \f$:
+
+\f[
+  \begin{align*}
+  \begin{bmatrix}
+  u \\
+  v \\
+  1
+  \end{bmatrix} &=
+  \bf{A} \hspace{0.1em} \Pi \hspace{0.2em} ^{c}\bf{M}_w
+  \begin{bmatrix}
+  X_{w} \\
+  Y_{w} \\
+  Z_{w} \\
+  1
+  \end{bmatrix} \\
+  \begin{bmatrix}
+  u \\
+  v \\
+  1
+  \end{bmatrix} &=
+  \begin{bmatrix}
+  f_x & 0 & c_x \\
+  0 & f_y & c_y \\
+  0 & 0 & 1
+  \end{bmatrix}
+  \begin{bmatrix}
+  1 & 0 & 0 & 0 \\
+  0 & 1 & 0 & 0 \\
+  0 & 0 & 1 & 0
+  \end{bmatrix}
+  \begin{bmatrix}
+  r_{11} & r_{12} & r_{13} & t_x \\
+  r_{21} & r_{22} & r_{23} & t_y \\
+  r_{31} & r_{32} & r_{33} & t_z \\
+  0 & 0 & 0 & 1
+  \end{bmatrix}
+  \begin{bmatrix}
+  X_{w} \\
+  Y_{w} \\
+  Z_{w} \\
+  1
+  \end{bmatrix}
+  \end{align*}
+\f]
+
+The estimated pose is thus the rotation (`rvec`) and the translation (`tvec`) vectors that allow transforming
+a 3D point expressed in the world frame into the camera frame:
+
+\f[
+  \begin{align*}
+  \begin{bmatrix}
+  X_c \\
+  Y_c \\
+  Z_c \\
+  1
+  \end{bmatrix} &=
+  \hspace{0.2em} ^{c}\bf{M}_w
+  \begin{bmatrix}
+  X_{w} \\
+  Y_{w} \\
+  Z_{w} \\
+  1
+  \end{bmatrix} \\
+  \begin{bmatrix}
+  X_c \\
+  Y_c \\
+  Z_c \\
+  1
+  \end{bmatrix} &=
+  \begin{bmatrix}
+  r_{11} & r_{12} & r_{13} & t_x \\
+  r_{21} & r_{22} & r_{23} & t_y \\
+  r_{31} & r_{32} & r_{33} & t_z \\
+  0 & 0 & 0 & 1
+  \end{bmatrix}
+  \begin{bmatrix}
+  X_{w} \\
+  Y_{w} \\
+  Z_{w} \\
+  1
+  \end{bmatrix}
+  \end{align*}
+\f]
+
+@note
+- This is the preferred interface for solving PnP compared with the older @ref solvePnP. There are three main reasons.
+Firstly, unlike @ref solvePnP it allows problems with multiple solutions to be handled, which typically occurs in the case when the object
+points are co-planar. See notes below for further details, taken from @cite Collins14. Secondly, it is a much cleaner interface by clearly dividing
+the problem into its two parts (initial solution followed by refinement using objects derived from base classes). Thirdly it allows any combination of
+PnPSolver and PnPRefiner to be used for testing different PnPSolvers and PnPRefiners.
+-If you are unsure which PnPSolver to use, then use @ref PnPSolverAutoSelect. This will automatically select the right one based on
+The number of points and geometric configuration of the points. It is highly recommended to use this. Otherwise, you can use any PnPSolver
+as long as it supports the number of points and geometric configuration. Debugging tests are performed to check this.
+-   An example of how to use solvePnP for planar augmented reality can be found at
+    opencv_source_code/samples/python/plane_ar.py
+-   If you are using Python:
+        - Numpy array slices won't work as input because solvePnP requires contiguous
+        arrays (enforced by the assertion using cv::Mat::checkVector() around line 55 of
+        modules/calib3d/src/solvepnp.cpp version 2.4.9)
+- Problems with more than one solution are called ambiguous problems. When the object has 3 points, the problem is generally ambiguous and up to 4 solutions
+exist. See e.g. @cite gao2003complete for more details. When the object points are co-planar there can be 2 solutions, but this depends on the physical geometry.
+The ambiguity happens generally when the object points occupy a small region of the image, by either being close toegher or by being viewed from a large distance.
+In these cases there are generally two pose solutions that have similar reprojection error (up to noise), so it is impossible to know which is the right one without
+additional information. If you were to pick one of them, you can expect to be wrong 50% of the time. This problem is suffered by @ref solvePnP because it only returns one solution.
+Geometrically, the two poses roughly correspond to a flip of the object about a plane whose normal passes through the line-of-sight from the camera centre to the object's centre.
+For more details about the ambiguity, please refer to @cite Collins14.
+ */
+CV_EXPORTS_W int solvePnPGeneric( InputArray objectPoints, InputArray imagePoints,
+                                  InputArray cameraMatrix, InputArray distCoeffs,
+                                  OutputArrayOfArrays rvecs, OutputArrayOfArrays tvecs,
+                                  const Ptr<PnPSolver> solver, const Ptr<PnPRefiner> refiner,
+                                  bool sortOnReprojectionError = true,
+                                  OutputArray reprojectionError = noArray() );
+
+
+CV_EXPORTS_W void sortPosesOnReprojectionError(InputArray opoints, InputArray ipoints, InputArray cameraMatrix, InputArray distCoeffs, std::vector<Mat> & rVecs,
+                                          std::vector<Mat> & tVecs, std::vector<double> & rmses);
+
+
+/**
+ * @brief cvtSolvePnPFlag
+ * @param flag
+ * @param useExtrinsicGuess
+ * @return
+ */
+CV_EXPORTS_W void cvtSolvePnPFlag(const SolvePnPMethod & flag, bool useExtrinsicGuess, Ptr<PnPSolver> & solver, Ptr<PnPRefiner> & refiner);
+
+
 
 } //end namespace cv
 

--- a/modules/calib3d/include/opencv2/calib3d.hpp
+++ b/modules/calib3d/include/opencv2/calib3d.hpp
@@ -2795,25 +2795,6 @@ protected:
     CV_WRAP virtual void solve(InputArray opoints, InputArray ipoints, CV_OUT std::vector<Mat> & rVecs, CV_OUT std::vector<Mat> & tVecs) const = 0;
 
     /**
-     * @brief COPLANAR_THRESHOLD specifies tolerance for judging if object points are co-planar. If coplarity test using @get3DPointsetShape fails with
-     this threshold then a PnP method with requiresPlanarObject = true cannot be used to solve this problem
-     */
-    //static double COPLANAR_THRESHOLD;
-
-    /**
-     * @brief COLINEAR_THRESHOLD specifies tolerance for judging if object points are co-linear. If colinearity test using @get3DPointsetShape fails with
-     this threshold then no PnP method can be used to solve this problem.
-     */
-    //static double COLINEAR_THRESHOLD;
-
-    /**
-     * @brief NONCOPLANAR_THRESHOLD specifies tolerance for judging if object points are non coplanar (i.e. they are 3D). If coplarity test using @get3DPointsetShape passes with
-     this threshold then a PnP method with requires3DObject = true cannot be used to solve this problem
-     */
-    //static double NONCOPLANAR_THRESHOLD;
-
-
-    /**
       @brief geometricTests flag
      */
     bool withGeometricTests;

--- a/modules/calib3d/src/dls.h
+++ b/modules/calib3d/src/dls.h
@@ -16,6 +16,8 @@ public:
 
     bool compute_pose(cv::Mat& R, cv::Mat& t);
 
+    void compute_poses(std::vector<cv::Mat> Rs, std::vector<cv::Mat> ts);
+
 private:
 
     // initialisation

--- a/modules/calib3d/src/pnpRefiners.cpp
+++ b/modules/calib3d/src/pnpRefiners.cpp
@@ -1,0 +1,320 @@
+// This file is part of OpenCV project.
+// It is subject to the license terms in the LICENSE file found in the top-level directory
+// of this distribution and at http://opencv.org/license.html
+
+#include "precomp.hpp"
+#include "opencv2/calib3d/calib3d_c.h"
+
+using namespace cv;
+
+Ptr<PnPRefinerLM> PnPRefinerLM::create()
+{
+    return makePtr<PnPRefinerLM>();
+}
+
+bool PnPRefinerLM::refine(InputArray opoints, InputArray ipoints, InputArray cameraMatrix, InputArray distortion, InputArray rVec, InputArray tVec, CV_OUT std::vector<Mat> & rVecs, CV_OUT std::vector<Mat> & tVecs) const
+{
+    CV_INSTRUMENT_REGION();
+    Mat rIn,tIn;
+    rVec.copyTo(rIn);
+    tVec.copyTo(tIn);
+
+    CvMat c_objectPoints = cvMat(opoints.getMat()), c_imagePoints = cvMat(ipoints.getMat());
+    CvMat c_cameraMatrix = cvMat(cameraMatrix.getMat()), c_distCoeffs = cvMat(distortion.getMat());
+    CvMat c_rvec = cvMat(rIn), c_tvec = cvMat(tIn);
+    cvFindExtrinsicCameraParams2(&c_objectPoints, &c_imagePoints, &c_cameraMatrix,
+                                 (c_distCoeffs.rows && c_distCoeffs.cols) ? &c_distCoeffs : 0,
+                                 &c_rvec, &c_tvec, true );
+
+    rVecs.clear();
+    tVecs.clear();
+    rVecs.push_back(rIn);
+    tVecs.push_back(tIn);
+    return true;
+}
+
+class SolvePnPRefineLMCallback CV_FINAL : public LMSolver::Callback
+{
+public:
+    SolvePnPRefineLMCallback(InputArray _opoints, InputArray _ipoints, InputArray _cameraMatrix, InputArray _distCoeffs)
+    {
+        objectPoints = _opoints.getMat();
+        imagePoints = _ipoints.getMat();
+        npoints = std::max(objectPoints.checkVector(3, CV_32F), objectPoints.checkVector(3, CV_64F));
+        imagePoints0 = imagePoints.reshape(1, npoints*2);
+        cameraMatrix = _cameraMatrix.getMat();
+        distCoeffs = _distCoeffs.getMat();
+    }
+
+    bool compute(InputArray _param, OutputArray _err, OutputArray _Jac) const CV_OVERRIDE
+    {
+        Mat param = _param.getMat();
+        _err.create(npoints*2, 1, CV_64FC1);
+
+        if(_Jac.needed())
+        {
+            _Jac.create(npoints*2, param.rows, CV_64FC1);
+        }
+
+        Mat rvec = param(Rect(0, 0, 1, 3)), tvec = param(Rect(0, 3, 1, 3));
+
+        Mat J, projectedPts;
+        projectPoints(objectPoints, rvec, tvec, cameraMatrix, distCoeffs, projectedPts, _Jac.needed() ? J : noArray());
+
+        if (_Jac.needed())
+        {
+            Mat Jac = _Jac.getMat();
+            for (int i = 0; i < Jac.rows; i++)
+            {
+                for (int j = 0; j < Jac.cols; j++)
+                {
+                    Jac.at<double>(i,j) = J.at<double>(i,j);
+                }
+            }
+        }
+
+        Mat err = _err.getMat();
+        projectedPts = projectedPts.reshape(1, npoints*2);
+        err = projectedPts - imagePoints0;
+
+        return true;
+    }
+
+    Mat objectPoints, imagePoints, imagePoints0;
+    Mat cameraMatrix, distCoeffs;
+    int npoints;
+};
+
+/**
+ * @brief Compute the Interaction matrix and the residuals for the current pose.
+ * @param objectPoints 3D object points.
+ * @param R Current estimated rotation matrix.
+ * @param tvec Current estimated translation vector.
+ * @param L Interaction matrix for a vector of point features.
+ * @param s Residuals.
+ */
+static void computeInteractionMatrixAndResiduals(const Mat& objectPoints, const Mat& R, const Mat& tvec,
+                                                 Mat& L, Mat& s)
+{
+    Mat objectPointsInCam;
+
+    int npoints = objectPoints.rows;
+    for (int i = 0; i < npoints; i++)
+    {
+        Mat curPt = objectPoints.row(i);
+        objectPointsInCam = R * curPt.t() + tvec;
+
+        double Zi = objectPointsInCam.at<double>(2,0);
+        double xi = objectPointsInCam.at<double>(0,0) / Zi;
+        double yi = objectPointsInCam.at<double>(1,0) / Zi;
+
+        s.at<double>(2*i,0) = xi;
+        s.at<double>(2*i+1,0) = yi;
+
+        L.at<double>(2*i,0) = -1 / Zi;
+        L.at<double>(2*i,1) = 0;
+        L.at<double>(2*i,2) = xi / Zi;
+        L.at<double>(2*i,3) = xi*yi;
+        L.at<double>(2*i,4) = -(1 + xi*xi);
+        L.at<double>(2*i,5) = yi;
+
+        L.at<double>(2*i+1,0) = 0;
+        L.at<double>(2*i+1,1) = -1 / Zi;
+        L.at<double>(2*i+1,2) = yi / Zi;
+        L.at<double>(2*i+1,3) = 1 + yi*yi;
+        L.at<double>(2*i+1,4) = -xi*yi;
+        L.at<double>(2*i+1,5) = -xi;
+    }
+}
+
+/**
+ * @brief The exponential map from se(3) to SE(3).
+ * @param twist A twist (v, w) represents the velocity of a rigid body as an angular velocity
+ * around an axis and a linear velocity along this axis.
+ * @param R1 Resultant rotation matrix from the twist.
+ * @param t1 Resultant translation vector from the twist.
+ */
+static void exponentialMapToSE3Inv(const Mat& twist, Mat& R1, Mat& t1)
+{
+    //see Exponential Map in http://ethaneade.com/lie.pdf
+    /*
+    \begin{align*}
+    \boldsymbol{\delta} &= \left( \mathbf{u}, \boldsymbol{\omega} \right ) \in se(3) \\
+    \mathbf{u}, \boldsymbol{\omega} &\in \mathbb{R}^3 \\
+    \theta &= \sqrt{ \boldsymbol{\omega}^T \boldsymbol{\omega} } \\
+    A &= \frac{\sin \theta}{\theta} \\
+    B &= \frac{1 - \cos \theta}{\theta^2} \\
+    C &= \frac{1-A}{\theta^2} \\
+    \mathbf{R} &= \mathbf{I} + A \boldsymbol{\omega}_{\times} + B \boldsymbol{\omega}_{\times}^2 \\
+    \mathbf{V} &= \mathbf{I} + B \boldsymbol{\omega}_{\times} + C \boldsymbol{\omega}_{\times}^2 \\
+    \exp \begin{pmatrix}
+    \mathbf{u} \\
+    \boldsymbol{\omega}
+    \end{pmatrix} &=
+    \left(
+    \begin{array}{c|c}
+    \mathbf{R} & \mathbf{V} \mathbf{u} \\ \hline
+    \mathbf{0} & 1
+    \end{array}
+    \right )
+    \end{align*}
+    */
+    double vx = twist.at<double>(0,0);
+    double vy = twist.at<double>(1,0);
+    double vz = twist.at<double>(2,0);
+    double wx = twist.at<double>(3,0);
+    double wy = twist.at<double>(4,0);
+    double wz = twist.at<double>(5,0);
+
+    Matx31d rvec(wx, wy, wz);
+    Mat R;
+    Rodrigues(rvec, R);
+
+    double theta = sqrt(wx*wx + wy*wy + wz*wz);
+    double sinc = std::fabs(theta) < 1e-8 ? 1 : sin(theta) / theta;
+    double mcosc = (std::fabs(theta) < 1e-8) ? 0.5 : (1-cos(theta)) / (theta*theta);
+    double msinc = (std::abs(theta) < 1e-8) ? (1/6.0) : (1-sinc) / (theta*theta);
+
+    Matx31d dt;
+    dt(0) = vx*(sinc + wx*wx*msinc) + vy*(wx*wy*msinc - wz*mcosc) + vz*(wx*wz*msinc + wy*mcosc);
+    dt(1) = vx*(wx*wy*msinc + wz*mcosc) + vy*(sinc + wy*wy*msinc) + vz*(wy*wz*msinc - wx*mcosc);
+    dt(2) = vx*(wx*wz*msinc - wy*mcosc) + vy*(wy*wz*msinc + wx*mcosc) + vz*(sinc + wz*wz*msinc);
+
+    R1 = R.t();
+    t1 = -R1 * dt;
+}
+
+PnPRefinerLMcpp::PnPRefinerLMcpp(TermCriteria _criteria): criteria(_criteria)
+{
+
+}
+
+Ptr<PnPRefinerLMcpp> PnPRefinerLMcpp::create(TermCriteria _criteria)
+{
+    return makePtr<PnPRefinerLMcpp>(_criteria);
+}
+
+
+bool PnPRefinerLMcpp::refine(InputArray _objectPoints, InputArray _imagePoints, InputArray _cameraMatrix, InputArray _distCoeffs, InputArray _rvec, InputArray _tvec, CV_OUT std::vector<Mat> & rVecs, CV_OUT std::vector<Mat> & tVecs) const
+{
+    CV_INSTRUMENT_REGION();
+
+    Mat opoints_ = _objectPoints.getMat(), ipoints_ = _imagePoints.getMat();
+    Mat opoints, ipoints;
+    opoints_.convertTo(opoints, CV_64F);
+    ipoints_.convertTo(ipoints, CV_64F);
+    int npoints = opoints.checkVector(3, CV_64F);
+    CV_Assert( npoints >= 3 && npoints == ipoints.checkVector(2, CV_64F) );
+    CV_Assert( !_rvec.empty() && !_tvec.empty() );
+    int rtype = _rvec.type(), ttype = _tvec.type();
+    Size rsize = _rvec.size(), tsize = _tvec.size();
+    CV_Assert( (rtype == CV_32FC1 || rtype == CV_64FC1) &&
+               (ttype == CV_32FC1 || ttype == CV_64FC1) );
+    CV_Assert( (rsize == Size(1, 3) || rsize == Size(3, 1)) &&
+               (tsize == Size(1, 3) || tsize == Size(3, 1)) );
+
+    Mat cameraMatrix0 = _cameraMatrix.getMat();
+    Mat distCoeffs0 = _distCoeffs.getMat();
+    Mat cameraMatrix = Mat_<double>(cameraMatrix0);
+    Mat distCoeffs = Mat_<double>(distCoeffs0);
+    Mat rvec0 = _rvec.getMat(), tvec0 = _tvec.getMat();
+    Mat rvec, tvec;
+    rvec0.convertTo(rvec, CV_64F);
+    tvec0.convertTo(tvec, CV_64F);
+    Mat params(6, 1, CV_64FC1);
+    for (int i = 0; i < 3; i++)
+    {
+        params.at<double>(i,0) = rvec.at<double>(i,0);
+        params.at<double>(i+3,0) = tvec.at<double>(i,0);
+    }
+    createLMSolver(makePtr<SolvePnPRefineLMCallback>(opoints, ipoints, cameraMatrix, distCoeffs), criteria.maxCount, criteria.epsilon)->run(params);
+    params.rowRange(0, 3).convertTo(rvec0, rvec0.depth());
+    params.rowRange(3, 6).convertTo(tvec0, tvec0.depth());
+    rVecs.clear();
+    rVecs.push_back(rvec0);
+    tVecs.clear();
+    tVecs.push_back(tvec0);
+    return true;
+}
+
+
+PnPRefinerVVS::PnPRefinerVVS(TermCriteria _criteria, double _vvslambda): criteria(_criteria), vvslambda(_vvslambda)
+{
+
+}
+
+Ptr<PnPRefinerVVS> PnPRefinerVVS::create(TermCriteria _criteria, double _vvslambda)
+{
+    return makePtr<PnPRefinerVVS>(_criteria,_vvslambda);
+}
+
+
+bool PnPRefinerVVS::refine(InputArray _objectPoints, InputArray _imagePoints, InputArray _cameraMatrix, InputArray _distCoeffs, InputArray _rvec, InputArray _tvec, CV_OUT std::vector<Mat> & rVecs, CV_OUT std::vector<Mat> & tVecs) const
+{
+    CV_INSTRUMENT_REGION();
+    Mat opoints_ = _objectPoints.getMat(), ipoints_ = _imagePoints.getMat();
+    Mat opoints, ipoints;
+    opoints_.convertTo(opoints, CV_64F);
+    ipoints_.convertTo(ipoints, CV_64F);
+    int npoints = opoints.checkVector(3, CV_64F);
+    CV_Assert( npoints >= 3 && npoints == ipoints.checkVector(2, CV_64F) );
+    CV_Assert( !_rvec.empty() && !_tvec.empty() );
+    int rtype = _rvec.type(), ttype = _tvec.type();
+    Size rsize = _rvec.size(), tsize = _tvec.size();
+    CV_Assert( (rtype == CV_32FC1 || rtype == CV_64FC1) &&
+               (ttype == CV_32FC1 || ttype == CV_64FC1) );
+    CV_Assert( (rsize == Size(1, 3) || rsize == Size(3, 1)) &&
+               (tsize == Size(1, 3) || tsize == Size(3, 1)) );
+
+    Mat cameraMatrix0 = _cameraMatrix.getMat();
+    Mat distCoeffs0 = _distCoeffs.getMat();
+    Mat cameraMatrix = Mat_<double>(cameraMatrix0);
+    Mat distCoeffs = Mat_<double>(distCoeffs0);
+
+    Mat rvec0 = _rvec.getMat(), tvec0 = _tvec.getMat();
+    Mat rvec, tvec;
+    rvec0.convertTo(rvec, CV_64F);
+    tvec0.convertTo(tvec, CV_64F);
+
+    std::vector<Point2d> ipoints_normalized;
+    undistortPoints(ipoints, ipoints_normalized, cameraMatrix, distCoeffs);
+    Mat sd = Mat(ipoints_normalized).reshape(1, npoints*2);
+    Mat objectPoints0 = opoints.reshape(1, npoints);
+    Mat imagePoints0 = ipoints.reshape(1, npoints*2);
+    Mat L(npoints*2, 6, CV_64FC1), s(npoints*2, 1, CV_64FC1);
+
+    double residuals_1 = std::numeric_limits<double>::max(), residuals = 0;
+    Mat err;
+    Mat R;
+    Rodrigues(rvec, R);
+    for (int iter = 0; iter < criteria.maxCount; iter++)
+    {
+        computeInteractionMatrixAndResiduals(objectPoints0, R, tvec, L, s);
+        err = s - sd;
+
+        Mat Lp = L.inv(cv::DECOMP_SVD);
+        Mat dq = -vvslambda * Lp * err;
+
+        Mat R1, t1;
+        exponentialMapToSE3Inv(dq, R1, t1);
+        R = R1 * R;
+        tvec = R1 * tvec + t1;
+
+        residuals_1 = residuals;
+        Mat res = err.t()*err;
+        residuals = res.at<double>(0,0);
+
+        if (std::fabs(residuals - residuals_1) < criteria.epsilon)
+            break;
+    }
+
+    Rodrigues(R, rvec);
+    rvec.convertTo(rvec0, rvec0.depth());
+    tvec.convertTo(tvec0, tvec0.depth());
+    rVecs.clear();
+    rVecs.push_back(rvec0);
+    tVecs.clear();
+    tVecs.push_back(tvec0);
+    return true;
+}
+

--- a/modules/calib3d/src/pnpSolvers.cpp
+++ b/modules/calib3d/src/pnpSolvers.cpp
@@ -1,0 +1,922 @@
+// This file is part of OpenCV project.
+// It is subject to the license terms in the LICENSE file found in the top-level directory
+// of this distribution and at http://opencv.org/license.html
+
+#include "precomp.hpp"
+
+#include "upnp.h"
+#include "dls.h"
+#include "epnp.h"
+#include "p3p.h"
+#include "ap3p.h"
+#include "ippe.hpp"
+#include "opencv2/calib3d/calib3d_c.h"
+
+using namespace cv;
+
+static bool approxEqual(double a, double b, double eps)
+{
+    return std::fabs(a-b) < eps;
+}
+
+PnPSolver::PnPSolver(bool _withGeometricTests): withGeometricTests(_withGeometricTests)
+{
+
+}
+
+PnPSolver::~PnPSolver()
+{
+
+}
+
+std::vector<double> PnPSolver::solveProblem(InputArray _opoints, InputArray _ipoints, CV_OUT std::vector<Mat> & rVecs, CV_OUT std::vector<Mat> & tVecs, bool sortOnReprojectionError) const
+{
+    std::vector<double> reprojErrs;
+
+#if defined _DEBUG || defined CV_STATIC_ANALYSIS
+    checkArgTypes(_opoints,_ipoints);
+    checkNumberOfPoints(_opoints);
+#endif
+    rVecs.clear();
+    tVecs.clear();
+    if (!checkNumberOfPoints(_opoints))
+    {
+        return reprojErrs;
+    }
+    if (withGeometricTests)
+    {
+        if (geometryWarn(_opoints,_ipoints))
+        {
+            solve(_opoints,_ipoints,rVecs,tVecs);
+        }
+    }
+    else
+    {
+        solve(_opoints,_ipoints,rVecs,tVecs);
+    }
+    if (sortOnReprojectionError)
+    {
+        sortPosesOnReprojectionError(_opoints, _ipoints, makeIdentityIntrinsic(), cv::noArray(),  rVecs, tVecs, reprojErrs);
+    }
+    return reprojErrs;
+}
+
+
+cv::Mat PnPSolver::makeIdentityIntrinsic() const
+{
+
+    cv::Mat K(3,3,CV_64FC1);
+    K.setTo(0.0);
+    K.at<double>(0,0) = 1.0;
+    K.at<double>(1,1) = 1.0;
+    K.at<double>(2,2) = 1.0;
+    return K;
+}
+
+size_t PnPSolver::getNumberOfPoints(cv::InputArray _opoints) const
+{
+    Mat opoints = _opoints.getMat();
+    return opoints.checkVector(3, CV_64F);
+}
+
+void PnPSolver::checkArgTypes(InputArray _opoints, InputArray _ipoints) const
+{
+    const Mat opoints = _opoints.getMat();
+    const Mat ipoints = _ipoints.getMat();
+    CV_DbgAssert(opoints.depth() == CV_64F);
+    CV_DbgAssert(ipoints.depth() == CV_64F);
+}
+
+bool PnPSolver::checkNumberOfPoints(InputArray _opoints) const
+{
+    bool pmin,pmax;
+    const size_t n = getNumberOfPoints(_opoints);
+    pmin = n>=static_cast<size_t>(minPointNumber());
+    if (maxPointNumber()!=-1)
+    {
+        pmax = n<=static_cast<size_t>(maxPointNumber());
+    }
+    else
+    {
+        pmax = true;
+    }
+    return pmin & pmax;
+}
+
+bool PnPSolver::geometryWarn(InputArray _opoints,InputArray _ipoints) const
+{
+    Mat opoints_ = _opoints.getMat(), ipoints_ = _ipoints.getMat();
+    Mat opoints, ipoints;
+
+    opoints_.convertTo(opoints, CV_64F);
+    if (!_ipoints.empty())
+    {
+        ipoints_.convertTo(ipoints, CV_64F);
+        if (ipoints.channels()==1)
+        {
+            ipoints = ipoints.reshape(2);
+        }
+    }
+    if (opoints.channels()==1)
+    {
+        opoints = opoints.reshape(3);
+    }
+
+
+    if (!checkNumberOfPoints(opoints))
+    {
+        return false;
+    }
+    else
+    {
+        double coplaneThresh = 1e-5;
+        double colinThresh = 1e-5;
+
+        cv::Mat singValues;
+        get3DPointsetShape(_opoints, singValues);
+        bool isCoplanar = singValues.at<double>(2) < singValues.at<double>(1) * coplaneThresh;
+        bool isColinear = singValues.at<double>(1) < singValues.at<double>(0) * colinThresh;
+
+        if (isColinear)
+        {
+            return false;
+        }
+        else {
+            bool t = true;
+            if (this->requires3DObject())
+            {
+                t = t && !isCoplanar;
+            }
+            if (this->requiresPlanarObject())
+            {
+                t = t && isCoplanar;
+            }
+            if (this->requiresPlanarTagObject())
+            {
+                t = t && isPlanarTag(opoints);
+            }
+            return t & artificalDegeneracyWarn(opoints,ipoints);
+        }
+
+    }
+}
+
+bool PnPSolver::artificalDegeneracyWarn(InputArray opoints,InputArray ipoints) const
+{
+    (void)opoints;
+    (void)ipoints;
+    return true;
+}
+
+
+
+bool PnPSolver::isPlanarTag(InputArray _opoints) const
+{
+    const Mat opoints = _opoints.getMat();
+    double Xs[4][3];
+    if (opoints.depth() == CV_32F)
+    {
+        for (int i = 0; i < 4; i++)
+        {
+            for (int j = 0; j < 3; j++)
+            {
+                Xs[i][j] = static_cast<double>(opoints.ptr<Vec3f>(0)[i](j));
+            }
+        }
+    }
+    else
+    {
+        for (int i = 0; i < 4; i++)
+        {
+            for (int j = 0; j < 3; j++)
+            {
+                Xs[i][j] = opoints.ptr<Vec3d>(0)[i](j);
+            }
+        }
+    }
+
+    const double equalThreshold = 1e-9;
+    bool pass = true;
+    //Z must be zero
+    bool t;
+    for (int i = 0; i < 4; i++)
+    {
+        t = approxEqual(Xs[i][2], 0, equalThreshold);
+        pass = pass & t;
+
+    }
+    t = approxEqual(Xs[0][1], Xs[1][1], equalThreshold);
+    pass = pass &  t;
+
+    t =  approxEqual(Xs[2][1], Xs[3][1], equalThreshold);
+    pass = pass &  t;
+
+    t =  approxEqual(Xs[0][0], Xs[3][0], equalThreshold);
+    pass = pass & t;
+
+    t = approxEqual(Xs[1][0], Xs[2][0], equalThreshold);
+    pass = pass &  t;
+
+    t = approxEqual(Xs[1][0], Xs[1][1], equalThreshold);
+    pass = pass & t;
+
+    t = approxEqual(Xs[3][0], Xs[3][1], equalThreshold);
+    pass = pass & t;
+    return pass;
+}
+
+
+
+PnPSolverP3PComplete::PnPSolverP3PComplete(bool _withGeometricTests): PnPSolver(_withGeometricTests)
+{
+
+}
+
+Ptr<PnPSolverP3PComplete> PnPSolverP3PComplete::create(bool _withGeometricTests)
+{
+    return makePtr<PnPSolverP3PComplete>(_withGeometricTests);
+}
+
+void PnPSolverP3PComplete::solve(cv::InputArray _opoints, cv::InputArray _ipoints, CV_OUT std::vector<Mat> & rVecs, CV_OUT std::vector<Mat> & tVecs) const
+{
+    CV_INSTRUMENT_REGION();
+    std::vector<Mat> rMats, tvecs;
+    const auto K = makeIdentityIntrinsic();
+    auto solver = p3p(K);
+    solver.solve(rMats,tvecs,_opoints.getMat(),_ipoints.getMat());
+    for (size_t i = 0; i < rMats.size(); i++)
+    {
+        Mat rvec;
+        Rodrigues(rMats[i],rvec);
+        rVecs.push_back(rvec);
+        tVecs.push_back(tvecs[i]);
+    }
+}
+
+
+int PnPSolverP3PComplete::minPointNumber() const
+{
+    return 3;
+}
+
+int PnPSolverP3PComplete::maxPointNumber() const
+{
+    return 4;
+}
+
+bool PnPSolverP3PComplete::requires3DObject() const
+{
+    return false;
+}
+
+bool PnPSolverP3PComplete::requiresPlanarObject() const
+{
+    return false; //this is true only when the number of points is 4
+}
+
+bool PnPSolverP3PComplete::requiresPlanarTagObject() const
+{
+    return false; //this is true only when the number of points is 4
+}
+
+
+
+
+PnPSolverAP3P::PnPSolverAP3P(bool _withGeometricTests): PnPSolver(_withGeometricTests)
+{
+
+}
+
+Ptr<PnPSolverAP3P> PnPSolverAP3P::create(bool _withGeometricTests)
+{
+    return makePtr<PnPSolverAP3P>(_withGeometricTests);
+}
+
+void PnPSolverAP3P::solve(cv::InputArray _opoints, cv::InputArray _ipoints, CV_OUT std::vector<Mat> & rVecs, CV_OUT std::vector<Mat> & tVecs) const
+{
+    CV_INSTRUMENT_REGION();
+    std::vector<Mat> rMats, tvecs;
+    const auto K = makeIdentityIntrinsic();
+    auto solver = ap3p(K);
+    solver.solve(rMats,tvecs,_opoints.getMat(),_ipoints.getMat());
+    for (size_t i = 0; i < rMats.size(); i++)
+    {
+        Mat rvec;
+        Rodrigues(rMats[i],rvec);
+        rVecs.push_back(rvec);
+        tVecs.push_back(tvecs[i]);
+    }
+}
+
+int PnPSolverAP3P::minPointNumber() const
+{
+    return 3;
+}
+int PnPSolverAP3P::maxPointNumber() const
+{
+    return 4;
+}
+
+bool PnPSolverAP3P::requires3DObject() const
+{
+    return false;
+
+}
+
+bool PnPSolverAP3P::requiresPlanarObject() const
+{
+    return false; //this is true only when the number of points is 4
+}
+
+bool PnPSolverAP3P::requiresPlanarTagObject() const
+{
+    return false; //this is true only when the number of points is 4
+}
+
+PnPSolverIPPE::PnPSolverIPPE(bool _withGeometricTests): PnPSolver(_withGeometricTests)
+{
+
+}
+
+Ptr<PnPSolverIPPE> PnPSolverIPPE::create(bool _withGeometricTests)
+{
+    return makePtr<PnPSolverIPPE>(_withGeometricTests);
+}
+
+void PnPSolverIPPE::solve(cv::InputArray _opoints, cv::InputArray _ipoints, CV_OUT std::vector<Mat> & rVecs, CV_OUT std::vector<Mat> & tVecs) const
+{
+    CV_INSTRUMENT_REGION();
+    IPPE::PoseSolver poseSolver;
+    Mat rvec1, tvec1, rvec2, tvec2;
+    float reprojErr1, reprojErr2;
+    poseSolver.solveGeneric(_opoints, _ipoints, rvec1, tvec1, reprojErr1, rvec2, tvec2, reprojErr2);
+    rVecs.push_back(rvec1);
+    rVecs.push_back(rvec2);
+    tVecs.push_back(tvec1);
+    tVecs.push_back(tvec2);
+}
+
+int PnPSolverIPPE::minPointNumber() const
+{
+    return 4;
+}
+
+int PnPSolverIPPE::maxPointNumber() const
+{
+    return -1;
+}
+
+bool PnPSolverIPPE::requires3DObject() const
+{
+    return false;
+
+}
+
+bool PnPSolverIPPE::requiresPlanarObject() const
+{
+    return true;
+}
+
+bool PnPSolverIPPE::requiresPlanarTagObject() const
+{
+    return false;
+}
+
+PnPSolverIPPESquare::PnPSolverIPPESquare(bool _withGeometricTests): PnPSolver(_withGeometricTests)
+{
+
+}
+
+Ptr<PnPSolverIPPESquare> PnPSolverIPPESquare::create(bool _withGeometricTests)
+{
+    return makePtr<PnPSolverIPPESquare>(_withGeometricTests);
+}
+
+void PnPSolverIPPESquare::solve(cv::InputArray _opoints, cv::InputArray _ipoints, CV_OUT std::vector<Mat> & rVecs, CV_OUT std::vector<Mat> & tVecs) const
+{
+    CV_INSTRUMENT_REGION();
+    IPPE::PoseSolver poseSolver;
+    Mat rvec1, tvec1, rvec2, tvec2;
+    float reprojErr1, reprojErr2;
+    poseSolver.solveSquare(_opoints, _ipoints, rvec1, tvec1, reprojErr1, rvec2, tvec2, reprojErr2);
+    rVecs.push_back(rvec1);
+    rVecs.push_back(rvec2);
+    tVecs.push_back(tvec1);
+    tVecs.push_back(tvec2);
+}
+
+
+int PnPSolverIPPESquare::minPointNumber() const
+{
+    return 4;
+}
+
+int PnPSolverIPPESquare::maxPointNumber() const
+{
+    return 4;
+}
+
+bool PnPSolverIPPESquare::requires3DObject() const
+{
+    return false;
+
+}
+
+bool PnPSolverIPPESquare::requiresPlanarObject() const
+{
+    return true;
+}
+
+bool PnPSolverIPPESquare::requiresPlanarTagObject() const
+{
+    return true;
+}
+
+PnPSolverZhang::PnPSolverZhang(bool _withGeometricTests): PnPSolver(_withGeometricTests)
+{
+
+}
+
+Ptr<PnPSolverZhang> PnPSolverZhang::create(bool _withGeometricTests)
+{
+    return makePtr<PnPSolverZhang>(_withGeometricTests);
+}
+
+bool PnPSolverZhang::solveCImpl(const CvMat* objectPoints,
+                                const CvMat* imagePoints, CvMat* rvec, CvMat* tvec) const
+{
+    //taken from cvFindExtrinsicCameraParams2
+    bool succ = false;
+    Ptr<CvMat> matM, _Mxy, _m;
+
+    int i, count;
+    double R[9];
+    double MM[9], V[9], W[3];
+    cv::Scalar Mc;
+    double param[6];
+    CvMat matR = cvMat( 3, 3, CV_64F, R );
+    CvMat _r = cvMat( 3, 1, CV_64F, param );
+    CvMat _t = cvMat( 3, 1, CV_64F, param + 3 );
+    CvMat _Mc = cvMat( 1, 3, CV_64F, Mc.val );
+    CvMat _MM = cvMat( 3, 3, CV_64F, MM );
+    CvMat matV = cvMat( 3, 3, CV_64F, V );
+    CvMat matW = cvMat( 3, 1, CV_64F, W );
+
+    CV_Assert( CV_IS_MAT(objectPoints) && CV_IS_MAT(imagePoints) && CV_IS_MAT(rvec) && CV_IS_MAT(tvec) );
+
+    count = MAX(objectPoints->cols, objectPoints->rows);
+    matM.reset(cvCreateMat( 1, count, CV_64FC3 ));
+    _m.reset(cvCreateMat( 1, count, CV_64FC2 ));
+
+    cvConvertPointsHomogeneous( objectPoints, matM );
+    cvConvertPointsHomogeneous( imagePoints, _m );
+
+    CV_Assert( (CV_MAT_DEPTH(rvec->type) == CV_64F || CV_MAT_DEPTH(rvec->type) == CV_32F) &&
+               (rvec->rows == 1 || rvec->cols == 1) && rvec->rows*rvec->cols*CV_MAT_CN(rvec->type) == 3 );
+
+    CV_Assert( (CV_MAT_DEPTH(tvec->type) == CV_64F || CV_MAT_DEPTH(tvec->type) == CV_32F) &&
+               (tvec->rows == 1 || tvec->cols == 1) && tvec->rows*tvec->cols*CV_MAT_CN(tvec->type) == 3 );
+
+    CV_Assert((count >= 4)); // it is unsafe to call LM optimisation without an extrinsic guess in the case of 3 points. This is because there is no guarantee that it will converge on the correct solution.
+
+    //_mn.reset(cvCreateMat( 1, count, CV_64FC2 ));
+    _Mxy.reset(cvCreateMat( 1, count, CV_64FC2 ));
+
+    Mc = cvAvg(matM);
+    cvReshape( matM, matM, 1, count );
+    cvMulTransposed( matM, &_MM, 1, &_Mc );
+    cvSVD( &_MM, &matW, 0, &matV, CV_SVD_MODIFY_A + CV_SVD_V_T );
+
+    double tt[3], h[9], h1_norm, h2_norm;
+    CvMat* R_transform = &matV;
+    CvMat T_transform = cvMat( 3, 1, CV_64F, tt );
+    CvMat matH = cvMat( 3, 3, CV_64F, h );
+    CvMat _h1, _h2, _h3;
+
+    if( V[2]*V[2] + V[5]*V[5] < 1e-10 )
+    {
+        return false;
+    }
+
+    if( cvDet(R_transform) < 0 )
+        cvScale( R_transform, R_transform, -1 );
+
+    cvGEMM( R_transform, &_Mc, -1, 0, 0, &T_transform, CV_GEMM_B_T );
+
+    for( i = 0; i < count; i++ )
+    {
+        const double* Rp = R_transform->data.db;
+        const double* Tp = T_transform.data.db;
+        const double* src = matM->data.db + i*3;
+        double* dst = _Mxy->data.db + i*2;
+
+        dst[0] = Rp[0]*src[0] + Rp[1]*src[1] + Rp[2]*src[2] + Tp[0];
+        dst[1] = Rp[3]*src[0] + Rp[4]*src[1] + Rp[5]*src[2] + Tp[1];
+    }
+
+    cvFindHomography( _Mxy, _m, &matH );
+
+    if( cvCheckArr(&matH, CV_CHECK_QUIET) )
+    {
+        cvGetCol( &matH, &_h1, 0 );
+        _h2 = _h1; _h2.data.db++;
+        _h3 = _h2; _h3.data.db++;
+        h1_norm = std::sqrt(h[0]*h[0] + h[3]*h[3] + h[6]*h[6]);
+        h2_norm = std::sqrt(h[1]*h[1] + h[4]*h[4] + h[7]*h[7]);
+
+        cvScale( &_h1, &_h1, 1./MAX(h1_norm, DBL_EPSILON) );
+        cvScale( &_h2, &_h2, 1./MAX(h2_norm, DBL_EPSILON) );
+        cvScale( &_h3, &_t, 2./MAX(h1_norm + h2_norm, DBL_EPSILON));
+        cvCrossProduct( &_h1, &_h2, &_h3 );
+
+        cvRodrigues2( &matH, &_r );
+        cvRodrigues2( &_r, &matH );
+        cvMatMulAdd( &matH, &T_transform, &_t, &_t );
+        cvMatMul( &matH, R_transform, &matR );
+
+        cvRodrigues2( &matR, &_r );
+        // }
+
+        cvReshape( matM, matM, 3, 1 );
+        //cvReshape( _mn, _mn, 2, 1 );
+
+        _r = cvMat( rvec->rows, rvec->cols,
+                    CV_MAKETYPE(CV_64F,CV_MAT_CN(rvec->type)), param );
+        _t = cvMat( tvec->rows, tvec->cols,
+                    CV_MAKETYPE(CV_64F,CV_MAT_CN(tvec->type)), param + 3 );
+
+        cvConvert( &_r, rvec );
+        cvConvert( &_t, tvec );
+
+        succ = true;
+
+    }
+    else
+    {
+        succ = false;
+    }
+
+    return succ;
+}
+
+
+void PnPSolverZhang::solve(cv::InputArray _opoints, cv::InputArray _ipoints, CV_OUT std::vector<Mat> & rVecs, CV_OUT std::vector<Mat> & tVecs) const
+{
+    CV_INSTRUMENT_REGION();
+    cv::Mat rVec(3,1,CV_64FC1);
+    cv::Mat tVec(3,1,CV_64FC1);
+
+    const CvMat c_objectPoints = cvMat(_opoints.getMat()), c_imagePoints = cvMat(_ipoints.getMat());
+    CvMat c_rvec = cvMat(rVec), c_tvec = cvMat(tVec);
+    if (solveCImpl(&c_objectPoints, &c_imagePoints,
+                   &c_rvec, &c_tvec))
+    {
+        rVecs.push_back(rVec);
+        tVecs.push_back(tVec);
+    }
+}
+
+int PnPSolverZhang::minPointNumber() const
+{
+    return 4;
+}
+
+int PnPSolverZhang::maxPointNumber() const
+{
+    return -1;
+}
+
+bool PnPSolverZhang::requires3DObject() const
+{
+    return false;
+}
+
+bool PnPSolverZhang::requiresPlanarObject() const
+{
+    return true; //this is true only when the number of points is 4
+}
+
+bool PnPSolverZhang::requiresPlanarTagObject() const
+{
+    return false; //this is true only when the number of points is 4
+}
+
+bool PnPSolverZhang::artificalDegeneracyWarn(InputArray opoints,InputArray ipoints) const
+{
+    (void)ipoints;
+    return(!isPlanarTag(opoints)); //this is an artificially degenerate configuration
+}
+
+PnPSolverDLT::PnPSolverDLT(bool _withGeometricTests): PnPSolver(_withGeometricTests)
+{
+
+}
+
+bool PnPSolverDLT::solveCImpl(const CvMat* objectPoints,
+                              const CvMat* imagePoints, CvMat* rvec, CvMat* tvec) const
+{
+    //adapted from cvFindExtrinsicCameraParams2
+    bool succ = false;
+    Ptr<CvMat> matM, _Mxy, _m,matL;
+
+    int i, count;
+    double R[9];
+    double U[9], V[9], W[3];
+    cv::Scalar Mc;
+    double param[6];
+    CvMat matR = cvMat( 3, 3, CV_64F, R );
+    CvMat _r = cvMat( 3, 1, CV_64F, param );
+    CvMat _t = cvMat( 3, 1, CV_64F, param + 3 );
+    CvMat matU = cvMat( 3, 3, CV_64F, U );
+    CvMat matV = cvMat( 3, 3, CV_64F, V );
+    CvMat matW = cvMat( 3, 1, CV_64F, W );
+
+    CV_Assert( CV_IS_MAT(objectPoints) && CV_IS_MAT(imagePoints) && CV_IS_MAT(rvec) && CV_IS_MAT(tvec) );
+
+    count = MAX(objectPoints->cols, objectPoints->rows);
+    matM.reset(cvCreateMat( 1, count, CV_64FC3 ));
+    _m.reset(cvCreateMat( 1, count, CV_64FC2 ));
+
+    cvConvertPointsHomogeneous( objectPoints, matM );
+    cvConvertPointsHomogeneous( imagePoints, _m );
+
+    CV_Assert( (CV_MAT_DEPTH(rvec->type) == CV_64F || CV_MAT_DEPTH(rvec->type) == CV_32F) &&
+               (rvec->rows == 1 || rvec->cols == 1) && rvec->rows*rvec->cols*CV_MAT_CN(rvec->type) == 3 );
+
+    CV_Assert( (CV_MAT_DEPTH(tvec->type) == CV_64F || CV_MAT_DEPTH(tvec->type) == CV_32F) &&
+               (tvec->rows == 1 || tvec->cols == 1) && tvec->rows*tvec->cols*CV_MAT_CN(tvec->type) == 3 );
+
+    CV_Assert((count >= 4)); // it is unsafe to call LM optimisation without an extrinsic guess in the case of 3 points. This is because there is no guarantee that it will converge on the correct solution.
+
+    //_mn.reset(cvCreateMat( 1, count, CV_64FC2 ));
+    _Mxy.reset(cvCreateMat( 1, count, CV_64FC2 ));
+
+    // non-planar structure. Use DLT method
+    CV_CheckGE(count, 6, "DLT algorithm needs at least 6 points for pose estimation from 3D-2D point correspondences.");
+    double* L;
+    double LL[12*12], LW[12], LV[12*12], sc;
+    CvMat _LL = cvMat( 12, 12, CV_64F, LL );
+    CvMat _LW = cvMat( 12, 1, CV_64F, LW );
+    CvMat _LV = cvMat( 12, 12, CV_64F, LV );
+    CvMat _RRt, _RR, _tt;
+    CvPoint3D64f* M = (CvPoint3D64f*)matM->data.db;
+    CvPoint2D64f* mn = (CvPoint2D64f*)_m->data.db;
+
+    matL.reset(cvCreateMat( 2*count, 12, CV_64F ));
+    L = matL->data.db;
+
+    for( i = 0; i < count; i++, L += 24 )
+    {
+        double x = -mn[i].x, y = -mn[i].y;
+        L[0] = L[16] = M[i].x;
+        L[1] = L[17] = M[i].y;
+        L[2] = L[18] = M[i].z;
+        L[3] = L[19] = 1.;
+        L[4] = L[5] = L[6] = L[7] = 0.;
+        L[12] = L[13] = L[14] = L[15] = 0.;
+        L[8] = x*M[i].x;
+        L[9] = x*M[i].y;
+        L[10] = x*M[i].z;
+        L[11] = x;
+        L[20] = y*M[i].x;
+        L[21] = y*M[i].y;
+        L[22] = y*M[i].z;
+        L[23] = y;
+    }
+
+    cvMulTransposed( matL, &_LL, 1 );
+    cvSVD( &_LL, &_LW, 0, &_LV, CV_SVD_MODIFY_A + CV_SVD_V_T );
+    _RRt = cvMat( 3, 4, CV_64F, LV + 11*12 );
+    cvGetCols( &_RRt, &_RR, 0, 3 );
+    cvGetCol( &_RRt, &_tt, 3 );
+    if( cvDet(&_RR) < 0 )
+        cvScale( &_RRt, &_RRt, -1 );
+    sc = cvNorm(&_RR);
+    cvSVD( &_RR, &matW, &matU, &matV, CV_SVD_MODIFY_A + CV_SVD_U_T + CV_SVD_V_T );
+    cvGEMM( &matU, &matV, 1, 0, 0, &matR, CV_GEMM_A_T );
+    cvScale( &_tt, &_t, cvNorm(&matR)/sc );
+    cvRodrigues2( &matR, &_r );
+
+    cvReshape( matM, matM, 3, 1 );
+    //cvReshape( _mn, _mn, 2, 1 );
+
+    _r = cvMat( rvec->rows, rvec->cols,
+                CV_MAKETYPE(CV_64F,CV_MAT_CN(rvec->type)), param );
+    _t = cvMat( tvec->rows, tvec->cols,
+                CV_MAKETYPE(CV_64F,CV_MAT_CN(tvec->type)), param + 3 );
+
+    cvConvert( &_r, rvec );
+    cvConvert( &_t, tvec );
+
+    succ = true;
+
+    return succ;
+}
+
+
+Ptr<PnPSolverDLT> PnPSolverDLT::create(bool _withGeometricTests)
+{
+    return makePtr<PnPSolverDLT>(_withGeometricTests);
+}
+
+void PnPSolverDLT::solve(cv::InputArray _opoints, cv::InputArray _ipoints, CV_OUT std::vector<Mat> & rVecs, CV_OUT std::vector<Mat> & tVecs) const
+{
+    CV_INSTRUMENT_REGION();
+    cv::Mat rVec(3,1,CV_64FC1);
+    cv::Mat tVec(3,1,CV_64FC1);
+
+    const CvMat c_objectPoints = cvMat(_opoints.getMat()), c_imagePoints = cvMat(_ipoints.getMat());
+    CvMat c_rvec = cvMat(rVec), c_tvec = cvMat(tVec);
+    if (solveCImpl(&c_objectPoints, &c_imagePoints,
+                   &c_rvec, &c_tvec))
+    {
+        rVecs.push_back(rVec);
+        tVecs.push_back(tVec);
+    }
+}
+
+int PnPSolverDLT::minPointNumber() const
+{
+    return 6;
+}
+int PnPSolverDLT::maxPointNumber() const
+{
+    return -1;
+}
+
+
+bool PnPSolverDLT::requires3DObject() const
+{
+    return true;
+
+}
+bool PnPSolverDLT::requiresPlanarObject() const
+{
+    return false; //this is true only when the number of points is 4
+}
+
+bool PnPSolverDLT::requiresPlanarTagObject() const
+{
+    return false; //this is true only when the number of points is 4
+}
+
+PnPSolverEPnP3D::PnPSolverEPnP3D(bool _withGeometricTests): PnPSolver(_withGeometricTests)
+{
+
+}
+
+Ptr<PnPSolverEPnP3D> PnPSolverEPnP3D::create(bool _withGeometricTests)
+{
+    return makePtr<PnPSolverEPnP3D>(_withGeometricTests);
+}
+
+void PnPSolverEPnP3D::solve(cv::InputArray _opoints, cv::InputArray _ipoints,
+                            CV_OUT std::vector<Mat> & rVecs, CV_OUT std::vector<Mat> & tVecs) const
+{
+    CV_INSTRUMENT_REGION();
+    const auto K = makeIdentityIntrinsic();
+    std::vector<std::tuple<cv::Mat, cv::Mat> >  ret;
+    epnp solver(K, _opoints.getMat(), _ipoints.getMat());
+    Mat rvec, tvec, R;
+    solver.compute_pose(R, tvec);
+    Rodrigues(R, rvec);
+    rVecs.push_back(rvec);
+    tVecs.push_back(tvec);
+}
+
+int PnPSolverEPnP3D::minPointNumber() const
+{
+    return 4; // unstable with 3 and 4 points
+}
+
+int PnPSolverEPnP3D::maxPointNumber() const
+{
+    return -1;
+}
+
+bool PnPSolverEPnP3D::requires3DObject() const
+{
+    return true;
+}
+
+bool PnPSolverEPnP3D::requiresPlanarObject() const
+{
+    return false;
+}
+
+bool PnPSolverEPnP3D::requiresPlanarTagObject() const
+{
+    return false; //this is true only when the number of points is 4
+}
+
+PnPSolverDLS::PnPSolverDLS(bool _withGeometricTests): PnPSolver(_withGeometricTests)
+{
+
+}
+
+Ptr<PnPSolverDLS> PnPSolverDLS::create(bool _withGeometricTests)
+{
+    return makePtr<PnPSolverDLS>(_withGeometricTests);
+}
+
+void PnPSolverDLS::solve(cv::InputArray _opoints, cv::InputArray _ipoints,
+                         CV_OUT std::vector<Mat> & rVecs, CV_OUT std::vector<Mat> & tVecs) const
+{
+    CV_INSTRUMENT_REGION();
+    dls d(_opoints.getMat(),_ipoints.getMat());
+    std::vector<cv::Mat> Rs;
+    d.compute_poses(Rs, tVecs);
+    for (size_t i = 0; i < Rs.size(); i++)
+    {
+        cv::Mat r;
+        Rodrigues(Rs[i], r);
+        rVecs.push_back(r);
+    }
+}
+
+int PnPSolverDLS::minPointNumber() const
+{
+    return 4; // unstable with 3 and 4 points
+}
+
+int PnPSolverDLS::maxPointNumber() const
+{
+    return -1;
+}
+
+bool PnPSolverDLS::requires3DObject() const
+{
+    return false;
+}
+
+bool PnPSolverDLS::requiresPlanarObject() const
+{
+    return false;
+}
+
+bool PnPSolverDLS::requiresPlanarTagObject() const
+{
+    return false; //this is true only when the number of points is 4
+}
+
+
+
+
+PnPSolverAutoSelect1::PnPSolverAutoSelect1(bool withGeomTests): PnPSolver(withGeomTests)
+{
+
+}
+
+Ptr<PnPSolverAutoSelect1> PnPSolverAutoSelect1::create(bool withGeomTests)
+{
+    return makePtr<PnPSolverAutoSelect1>(withGeomTests);
+}
+
+void PnPSolverAutoSelect1::solve(InputArray _opoints, InputArray _ipoints, CV_OUT std::vector<Mat> & rVecs, CV_OUT std::vector<Mat> & tVecs) const
+{
+    CV_INSTRUMENT_REGION();
+    const double coplaneThresh = 1.0e-3;
+    cv::Mat singValues;
+    get3DPointsetShape(_opoints, singValues);
+    bool isCoplanar = singValues.at<double>(2) < singValues.at<double>(1) * coplaneThresh;
+    Ptr<PnPSolver> solver;
+    if (isCoplanar)
+    {
+        solver = PnPSolverIPPE::create();
+    }
+    else {
+        solver = PnPSolverDLT::create();
+    }
+    solver->solveProblem(_opoints,_ipoints,rVecs,tVecs);
+}
+
+int PnPSolverAutoSelect1::minPointNumber() const
+{
+    return 4;
+}
+
+int PnPSolverAutoSelect1::maxPointNumber() const
+{
+    return -1;
+}
+
+bool PnPSolverAutoSelect1::requires3DObject() const
+{
+    return false;
+}
+
+bool PnPSolverAutoSelect1::requiresPlanarObject() const
+{
+    return false;
+}
+
+bool PnPSolverAutoSelect1::requiresPlanarTagObject() const
+{
+    return false; //this is true only when the number of points is 4
+}
+
+
+
+
+
+

--- a/modules/calib3d/src/solvepnp.cpp
+++ b/modules/calib3d/src/solvepnp.cpp
@@ -112,6 +112,7 @@ void drawFrameAxes(InputOutputArray image, InputArray cameraMatrix, InputArray d
     line(image, imagePoints[0], imagePoints[3], Scalar(255, 0, 0), thickness);
 }
 
+
 bool solvePnP( InputArray opoints, InputArray ipoints,
                InputArray cameraMatrix, InputArray distCoeffs,
                OutputArray rvec, OutputArray tvec, bool useExtrinsicGuess, int flags )
@@ -119,10 +120,37 @@ bool solvePnP( InputArray opoints, InputArray ipoints,
     CV_INSTRUMENT_REGION();
 
     vector<Mat> rvecs, tvecs;
-    int solutions = solvePnPGeneric(opoints, ipoints, cameraMatrix, distCoeffs, rvecs, tvecs, useExtrinsicGuess, (SolvePnPMethod)flags, rvec, tvec);
+    Ptr<PnPSolver> solver;
+    Ptr<PnPRefiner> refiner;
+
+    SolvePnPMethod flg = static_cast<SolvePnPMethod>(flags);
+    cvtSolvePnPFlag(flg,useExtrinsicGuess,solver,refiner);
+
+    if (solver.empty())
+    {
+        CV_Assert(!rvec.empty());
+        CV_Assert(!tvec.empty());
+        rvecs.push_back(rvec.getMat());
+        tvecs.push_back(tvec.getMat());
+    }
+
+    int solutions = solvePnPGeneric(opoints, ipoints, cameraMatrix, distCoeffs, rvecs, tvecs, solver, refiner, true);
+    if ((solutions == 0) && (flg == SOLVEPNP_ITERATIVE))
+    {
+        ////this copies the behaviour of SOLVEPNP_ITERATIVE, where if it is not possible to find an initial solution, all-zeros are used for r and t, then this is refined.
+        cv::Mat rInit(3,1,CV_64FC1);
+        rInit.setTo(0.0);
+        cv::Mat tInit(3,1,CV_64FC1);
+        tInit.setTo(0,0);
+        refiner->refine(opoints,ipoints,cameraMatrix,distCoeffs,rInit,tInit,rvecs,tvecs);
+    }
+
 
     if (solutions > 0)
     {
+        rvecs.resize(1);
+        tvecs.resize(1);
+
         int rdepth = rvec.empty() ? CV_64F : rvec.depth();
         int tdepth = tvec.empty() ? CV_64F : tvec.depth();
         rvecs[0].convertTo(rvec, rdepth);
@@ -137,25 +165,26 @@ class PnPRansacCallback CV_FINAL : public PointSetRegistrator::Callback
 
 public:
 
-    PnPRansacCallback(Mat _cameraMatrix=Mat(3,3,CV_64F), Mat _distCoeffs=Mat(4,1,CV_64F), int _flags=SOLVEPNP_ITERATIVE,
-            bool _useExtrinsicGuess=false, Mat _rvec=Mat(), Mat _tvec=Mat() )
-        : cameraMatrix(_cameraMatrix), distCoeffs(_distCoeffs), flags(_flags), useExtrinsicGuess(_useExtrinsicGuess),
+    PnPRansacCallback(Ptr<PnPSolver> _minSolver, Mat _cameraMatrix=Mat(3,3,CV_64F), Mat _distCoeffs=Mat(4,1,CV_64F), Mat _rvec=Mat(), Mat _tvec=Mat() )
+        : cameraMatrix(_cameraMatrix), distCoeffs(_distCoeffs), minSolver(_minSolver),
           rvec(_rvec), tvec(_tvec) {}
 
     /* Pre: True */
     /* Post: compute _model with given points and return number of found models */
     int runKernel( InputArray _m1, InputArray _m2, OutputArray _model ) const CV_OVERRIDE
     {
-        Mat opoints = _m1.getMat(), ipoints = _m2.getMat();
+        std::vector<Mat> rs,ts;
+        int numSolutions = solvePnPGeneric(_m1, _m2, cameraMatrix, distCoeffs,
+                                           rs, ts, minSolver,Ptr<PnPRefiner>(), true);
 
-        bool correspondence = solvePnP( _m1, _m2, cameraMatrix, distCoeffs,
-                                            rvec, tvec, useExtrinsicGuess, flags );
+        if (numSolutions>0)
+        {
+            Mat _local_model;
+            hconcat(rs[0], ts[0], _local_model);
+            _local_model.copyTo(_model);
+        }
 
-        Mat _local_model;
-        hconcat(rvec, tvec, _local_model);
-        _local_model.copyTo(_model);
-
-        return correspondence;
+        return numSolutions>0;
     }
 
     /* Pre: True */
@@ -184,14 +213,15 @@ public:
 
     }
 
-
     Mat cameraMatrix;
     Mat distCoeffs;
-    int flags;
-    bool useExtrinsicGuess;
+    const Ptr<PnPSolver> minSolver;
     Mat rvec;
     Mat tvec;
+
 };
+
+
 
 bool solvePnPRansac(InputArray _opoints, InputArray _ipoints,
                     InputArray _cameraMatrix, InputArray _distCoeffs,
@@ -229,26 +259,51 @@ bool solvePnPRansac(InputArray _opoints, InputArray _ipoints,
     Mat tvec = useExtrinsicGuess ? _tvec.getMat() : Mat(3, 1, CV_64FC1);
     Mat cameraMatrix = _cameraMatrix.getMat(), distCoeffs = _distCoeffs.getMat();
 
-    int model_points = 5;
-    int ransac_kernel_method = SOLVEPNP_EPNP;
+    Ptr<PnPSolver> minimalSolver; //used to solve the minimal problem
+    Ptr<PnPSolver> inlierSolver;  //after a model has been found, used to solve using model's inliers
+    Ptr<PnPRefiner> inlierRefiner; //used to refine solution from initialSolver (optional)
 
-    if( flags == SOLVEPNP_P3P || flags == SOLVEPNP_AP3P)
+    //handling of flags input
+    SolvePnPMethod m = static_cast<SolvePnPMethod>(flags);
+    int model_points;
+    if (m == SOLVEPNP_P3P)
     {
+        minimalSolver = PnPSolverP3PComplete::create();
         model_points = 4;
-        ransac_kernel_method = flags;
     }
-    else if( npoints == 4 )
+    else if (m == SOLVEPNP_AP3P)
     {
+        minimalSolver = PnPSolverAP3P::create();
         model_points = 4;
-        ransac_kernel_method = SOLVEPNP_P3P;
     }
+    else if (npoints ==4)
+    {
+        minimalSolver =PnPSolverP3PComplete::create();
+        model_points = 4;
+    }
+    else
+    {
+        minimalSolver =PnPSolverEPnP3D::create();
+        model_points = 5;
+    }
+
+    if (m == SOLVEPNP_P3P || m == SOLVEPNP_AP3P)
+    {
+        inlierSolver = PnPSolverEPnP3D::create();
+    }
+    else {
+        cvtSolvePnPFlag(m,useExtrinsicGuess,inlierSolver,inlierRefiner);
+    }
+
+    CV_Assert(!minimalSolver.empty());
 
     if( model_points == npoints )
     {
         opoints = opoints.reshape(3);
         ipoints = ipoints.reshape(2);
+        std::vector<cv::Mat> rVecs, tVecs;
 
-        bool result = solvePnP(opoints, ipoints, cameraMatrix, distCoeffs, _rvec, _tvec, useExtrinsicGuess, ransac_kernel_method);
+        bool result = (solvePnPGeneric(opoints, ipoints, cameraMatrix, distCoeffs, rVecs, tVecs, minimalSolver, Ptr<PnPRefiner>(), true)>0);
 
         if(!result)
         {
@@ -256,6 +311,10 @@ bool solvePnPRansac(InputArray _opoints, InputArray _ipoints,
                 _inliers.release();
 
             return false;
+        }
+        else {
+            _rvec.assign(rVecs[0]);    // output rotation vector
+            _tvec.assign(tVecs[0]);    // output translation vector
         }
 
         if(_inliers.needed())
@@ -272,9 +331,9 @@ bool solvePnPRansac(InputArray _opoints, InputArray _ipoints,
     }
 
     Ptr<PointSetRegistrator::Callback> cb; // pointer to callback
-    cb = makePtr<PnPRansacCallback>( cameraMatrix, distCoeffs, ransac_kernel_method, useExtrinsicGuess, rvec, tvec);
+    cb = makePtr<PnPRansacCallback>(minimalSolver, cameraMatrix, distCoeffs, rvec, tvec);
 
-    double param1 = reprojectionError;                // reprojection error
+    double param1 = static_cast<double>(reprojectionError);                // reprojection error
     double param2 = confidence;                       // confidence
     int param3 = iterationsCount;                     // number maximum iterations
 
@@ -283,7 +342,8 @@ bool solvePnPRansac(InputArray _opoints, InputArray _ipoints,
 
     // call Ransac
     int result = createRANSACPointSetRegistrator(cb, model_points,
-        param1, param2, param3)->run(opoints, ipoints, _local_model, _mask_local_inliers);
+                                                 param1, param2, param3)->run(opoints, ipoints, _local_model, _mask_local_inliers);
+
 
     if( result <= 0 || _local_model.rows <= 0)
     {
@@ -307,11 +367,13 @@ bool solvePnPRansac(InputArray _opoints, InputArray _ipoints,
     int npoints1 = compressElems(&opoints_inliers[0], mask, 1, npoints);
     compressElems(&ipoints_inliers[0], mask, 1, npoints);
 
-    opoints_inliers.resize(npoints1);
-    ipoints_inliers.resize(npoints1);
-    result = solvePnP(opoints_inliers, ipoints_inliers, cameraMatrix,
-                      distCoeffs, rvec, tvec, useExtrinsicGuess,
-                      (flags == SOLVEPNP_P3P || flags == SOLVEPNP_AP3P) ? SOLVEPNP_EPNP : flags) ? 1 : -1;
+    opoints_inliers.resize(static_cast<size_t>(npoints1));
+    ipoints_inliers.resize(static_cast<size_t>(npoints1));
+
+    std::vector<cv::Mat> rVecs, tVecs;
+    result = solvePnPGeneric(opoints_inliers, ipoints_inliers, cameraMatrix,
+                             distCoeffs, rVecs, tVecs, inlierSolver,inlierRefiner);
+
 
     if( result <= 0 )
     {
@@ -325,8 +387,8 @@ bool solvePnPRansac(InputArray _opoints, InputArray _ipoints,
     }
     else
     {
-        _rvec.assign(rvec);    // output rotation vector
-        _tvec.assign(tvec);    // output translation vector
+        _rvec.assign(rVecs[0]);    // output rotation vector
+        _tvec.assign(tVecs[0]);    // output translation vector
     }
 
     if(_inliers.needed())
@@ -342,655 +404,241 @@ bool solvePnPRansac(InputArray _opoints, InputArray _ipoints,
     return true;
 }
 
-int solveP3P( InputArray _opoints, InputArray _ipoints,
-              InputArray _cameraMatrix, InputArray _distCoeffs,
-              OutputArrayOfArrays _rvecs, OutputArrayOfArrays _tvecs, int flags) {
-    CV_INSTRUMENT_REGION();
+void sortPosesOnReprojectionError(InputArray _opoints, InputArray _ipoints, InputArray cameraMatrix, InputArray distCoeffs, std::vector<Mat> & rVecs,
+                                  std::vector<Mat> & tVecs,  std::vector<double> & rmses)
+{
 
-    Mat opoints = _opoints.getMat(), ipoints = _ipoints.getMat();
-    int npoints = std::max(opoints.checkVector(3, CV_32F), opoints.checkVector(3, CV_64F));
-    CV_Assert( npoints == std::max(ipoints.checkVector(2, CV_32F), ipoints.checkVector(2, CV_64F)) );
-    CV_Assert( npoints == 3 || npoints == 4 );
-    CV_Assert( flags == SOLVEPNP_P3P || flags == SOLVEPNP_AP3P );
+    CV_Assert(tVecs.size()==rVecs.size());
+    CV_Assert(tVecs.size()>0);
+    CV_Assert(_opoints.depth()==CV_64F);
+    CV_Assert(_ipoints.depth()==CV_64F);
 
-    if (opoints.cols == 3)
-        opoints = opoints.reshape(3);
-    if (ipoints.cols == 2)
-        ipoints = ipoints.reshape(2);
+    rmses.clear();
+    size_t solutions = rVecs.size();
 
-    Mat cameraMatrix0 = _cameraMatrix.getMat();
-    Mat distCoeffs0 = _distCoeffs.getMat();
-    Mat cameraMatrix = Mat_<double>(cameraMatrix0);
-    Mat distCoeffs = Mat_<double>(distCoeffs0);
-
-    Mat undistortedPoints;
-    undistortPoints(ipoints, undistortedPoints, cameraMatrix, distCoeffs);
-    std::vector<Mat> Rs, ts, rvecs;
-
-    int solutions = 0;
-    if (flags == SOLVEPNP_P3P)
+    //sort poses on reprojection error:
+    std::vector<Mat> rVecsSorted(solutions),tVecsSorted(solutions);
+    std::vector<double> sortedRmses;
+    rmses.reserve(solutions);
+    int npoints = _opoints.getMat().checkVector(3, CV_64F);
+    for (size_t i = 0; i < solutions; i++)
     {
-        p3p P3Psolver(cameraMatrix);
-        solutions = P3Psolver.solve(Rs, ts, opoints, undistortedPoints);
-    }
-    else if (flags == SOLVEPNP_AP3P)
-    {
-        ap3p P3Psolver(cameraMatrix);
-        solutions = P3Psolver.solve(Rs, ts, opoints, undistortedPoints);
-    }
+        auto rv = rVecs[i];
+        auto tv = tVecs[i];
 
-    if (solutions == 0) {
-        return 0;
-    }
-
-    Mat objPts, imgPts;
-    opoints.convertTo(objPts, CV_64F);
-    ipoints.convertTo(imgPts, CV_64F);
-    if (imgPts.cols > 1)
-    {
-        imgPts = imgPts.reshape(1);
-        imgPts = imgPts.t();
-    }
-    else
-        imgPts = imgPts.reshape(1, 2*imgPts.rows);
-
-    vector<double> reproj_errors(solutions);
-    for (size_t i = 0; i < reproj_errors.size(); i++)
-    {
-        Mat rvec;
-        Rodrigues(Rs[i], rvec);
-        rvecs.push_back(rvec);
-
-        Mat projPts;
-        projectPoints(objPts, rvec, ts[i], _cameraMatrix, _distCoeffs, projPts);
-
-        projPts = projPts.reshape(1, 2*projPts.rows);
-        Mat err = imgPts - projPts;
-
-        err = err.t() * err;
-        reproj_errors[i] = err.at<double>(0,0);
-    }
-
-    //sort the solutions
-    for (int i = 1; i < solutions; i++)
-    {
-        for (int j = i; j > 0 && reproj_errors[j-1] > reproj_errors[j]; j--)
+        cv::Mat projectedPoints;
+        projectPoints(_opoints,rv,tv, cameraMatrix, distCoeffs, projectedPoints);
+        if (projectedPoints.rows != _ipoints.getMat().rows)
         {
-            std::swap(reproj_errors[j], reproj_errors[j-1]);
-            std::swap(rvecs[j], rvecs[j-1]);
-            std::swap(ts[j], ts[j-1]);
+            transpose(projectedPoints,projectedPoints);
+
         }
+        double rmse;
+        cv::Mat ipoints = _ipoints.getMat();
+        if (_ipoints.channels()!=2)
+        {
+            ipoints = ipoints.reshape(2);
+        }
+        rmse = norm(projectedPoints, ipoints, NORM_L2) / sqrt(2*npoints);
+        rmses.push_back(rmse);
     }
 
-    int depthRot = _rvecs.fixedType() ? _rvecs.depth() : CV_64F;
-    int depthTrans = _tvecs.fixedType() ? _tvecs.depth() : CV_64F;
-    _rvecs.create(solutions, 1, CV_MAKETYPE(depthRot, _rvecs.fixedType() && _rvecs.kind() == _InputArray::STD_VECTOR ? 3 : 1));
-    _tvecs.create(solutions, 1, CV_MAKETYPE(depthTrans, _tvecs.fixedType() && _tvecs.kind() == _InputArray::STD_VECTOR ? 3 : 1));
+    std::vector<size_t> y(solutions);
+    std::size_t n(0);
+    std::generate(std::begin(y), std::end(y), [&]{ return n++; });
 
-    for (int i = 0; i < solutions; i++)
+    std::sort(  std::begin(y),
+                std::end(y),
+                [&](size_t i1, size_t i2) { return rmses[i1] < rmses[i2]; } );
+
+    sortedRmses.resize(solutions);
+    for (size_t i= 0; i < solutions; i++)
     {
-        Mat rvec0, tvec0;
-        if (depthRot == CV_64F)
-            rvec0 = rvecs[i];
-        else
-            rvecs[i].convertTo(rvec0, depthRot);
+        rVecsSorted[i] = rVecs[y[i]];
+        tVecsSorted[i] = tVecs[y[i]];
 
-        if (depthTrans == CV_64F)
-            tvec0 = ts[i];
-        else
-            ts[i].convertTo(tvec0, depthTrans);
-
-        if (_rvecs.fixedType() && _rvecs.kind() == _InputArray::STD_VECTOR)
-        {
-            Mat rref = _rvecs.getMat_();
-
-            if (_rvecs.depth() == CV_32F)
-                rref.at<Vec3f>(0,i) = Vec3f(rvec0.at<float>(0,0), rvec0.at<float>(1,0), rvec0.at<float>(2,0));
-            else
-                rref.at<Vec3d>(0,i) = Vec3d(rvec0.at<double>(0,0), rvec0.at<double>(1,0), rvec0.at<double>(2,0));
-        }
-        else
-        {
-            _rvecs.getMatRef(i) = rvec0;
-        }
-
-        if (_tvecs.fixedType() && _tvecs.kind() == _InputArray::STD_VECTOR)
-        {
-
-            Mat tref = _tvecs.getMat_();
-
-            if (_tvecs.depth() == CV_32F)
-                tref.at<Vec3f>(0,i) = Vec3f(tvec0.at<float>(0,0), tvec0.at<float>(1,0), tvec0.at<float>(2,0));
-            else
-                tref.at<Vec3d>(0,i) = Vec3d(tvec0.at<double>(0,0), tvec0.at<double>(1,0), tvec0.at<double>(2,0));
-        }
-        else
-        {
-            _tvecs.getMatRef(i) = tvec0;
-        }
+        sortedRmses[i] = rmses[y[i]];
     }
+    rVecs = rVecsSorted;
+    tVecs = tVecsSorted;
+    rmses = sortedRmses;
 
-    return solutions;
 }
 
-class SolvePnPRefineLMCallback CV_FINAL : public LMSolver::Callback
-{
-public:
-    SolvePnPRefineLMCallback(InputArray _opoints, InputArray _ipoints, InputArray _cameraMatrix, InputArray _distCoeffs)
-    {
-        objectPoints = _opoints.getMat();
-        imagePoints = _ipoints.getMat();
-        npoints = std::max(objectPoints.checkVector(3, CV_32F), objectPoints.checkVector(3, CV_64F));
-        imagePoints0 = imagePoints.reshape(1, npoints*2);
-        cameraMatrix = _cameraMatrix.getMat();
-        distCoeffs = _distCoeffs.getMat();
-    }
-
-    bool compute(InputArray _param, OutputArray _err, OutputArray _Jac) const CV_OVERRIDE
-    {
-         Mat param = _param.getMat();
-         _err.create(npoints*2, 1, CV_64FC1);
-
-         if(_Jac.needed())
-         {
-             _Jac.create(npoints*2, param.rows, CV_64FC1);
-         }
-
-         Mat rvec = param(Rect(0, 0, 1, 3)), tvec = param(Rect(0, 3, 1, 3));
-
-         Mat J, projectedPts;
-         projectPoints(objectPoints, rvec, tvec, cameraMatrix, distCoeffs, projectedPts, _Jac.needed() ? J : noArray());
-
-         if (_Jac.needed())
-         {
-             Mat Jac = _Jac.getMat();
-             for (int i = 0; i < Jac.rows; i++)
-             {
-                 for (int j = 0; j < Jac.cols; j++)
-                 {
-                     Jac.at<double>(i,j) = J.at<double>(i,j);
-                 }
-             }
-         }
-
-         Mat err = _err.getMat();
-         projectedPts = projectedPts.reshape(1, npoints*2);
-         err = projectedPts - imagePoints0;
-
-        return true;
-    }
-
-    Mat objectPoints, imagePoints, imagePoints0;
-    Mat cameraMatrix, distCoeffs;
-    int npoints;
-};
-
-/**
- * @brief Compute the Interaction matrix and the residuals for the current pose.
- * @param objectPoints 3D object points.
- * @param R Current estimated rotation matrix.
- * @param tvec Current estimated translation vector.
- * @param L Interaction matrix for a vector of point features.
- * @param s Residuals.
- */
-static void computeInteractionMatrixAndResiduals(const Mat& objectPoints, const Mat& R, const Mat& tvec,
-                                                 Mat& L, Mat& s)
-{
-    Mat objectPointsInCam;
-
-    int npoints = objectPoints.rows;
-    for (int i = 0; i < npoints; i++)
-    {
-        Mat curPt = objectPoints.row(i);
-        objectPointsInCam = R * curPt.t() + tvec;
-
-        double Zi = objectPointsInCam.at<double>(2,0);
-        double xi = objectPointsInCam.at<double>(0,0) / Zi;
-        double yi = objectPointsInCam.at<double>(1,0) / Zi;
-
-        s.at<double>(2*i,0) = xi;
-        s.at<double>(2*i+1,0) = yi;
-
-        L.at<double>(2*i,0) = -1 / Zi;
-        L.at<double>(2*i,1) = 0;
-        L.at<double>(2*i,2) = xi / Zi;
-        L.at<double>(2*i,3) = xi*yi;
-        L.at<double>(2*i,4) = -(1 + xi*xi);
-        L.at<double>(2*i,5) = yi;
-
-        L.at<double>(2*i+1,0) = 0;
-        L.at<double>(2*i+1,1) = -1 / Zi;
-        L.at<double>(2*i+1,2) = yi / Zi;
-        L.at<double>(2*i+1,3) = 1 + yi*yi;
-        L.at<double>(2*i+1,4) = -xi*yi;
-        L.at<double>(2*i+1,5) = -xi;
-    }
-}
-
-/**
- * @brief The exponential map from se(3) to SE(3).
- * @param twist A twist (v, w) represents the velocity of a rigid body as an angular velocity
- * around an axis and a linear velocity along this axis.
- * @param R1 Resultant rotation matrix from the twist.
- * @param t1 Resultant translation vector from the twist.
- */
-static void exponentialMapToSE3Inv(const Mat& twist, Mat& R1, Mat& t1)
-{
-    //see Exponential Map in http://ethaneade.com/lie.pdf
-    /*
-    \begin{align*}
-    \boldsymbol{\delta} &= \left( \mathbf{u}, \boldsymbol{\omega} \right ) \in se(3) \\
-    \mathbf{u}, \boldsymbol{\omega} &\in \mathbb{R}^3 \\
-    \theta &= \sqrt{ \boldsymbol{\omega}^T \boldsymbol{\omega} } \\
-    A &= \frac{\sin \theta}{\theta} \\
-    B &= \frac{1 - \cos \theta}{\theta^2} \\
-    C &= \frac{1-A}{\theta^2} \\
-    \mathbf{R} &= \mathbf{I} + A \boldsymbol{\omega}_{\times} + B \boldsymbol{\omega}_{\times}^2 \\
-    \mathbf{V} &= \mathbf{I} + B \boldsymbol{\omega}_{\times} + C \boldsymbol{\omega}_{\times}^2 \\
-    \exp \begin{pmatrix}
-    \mathbf{u} \\
-    \boldsymbol{\omega}
-    \end{pmatrix} &=
-    \left(
-    \begin{array}{c|c}
-    \mathbf{R} & \mathbf{V} \mathbf{u} \\ \hline
-    \mathbf{0} & 1
-    \end{array}
-    \right )
-    \end{align*}
-    */
-    double vx = twist.at<double>(0,0);
-    double vy = twist.at<double>(1,0);
-    double vz = twist.at<double>(2,0);
-    double wx = twist.at<double>(3,0);
-    double wy = twist.at<double>(4,0);
-    double wz = twist.at<double>(5,0);
-
-    Matx31d rvec(wx, wy, wz);
-    Mat R;
-    Rodrigues(rvec, R);
-
-    double theta = sqrt(wx*wx + wy*wy + wz*wz);
-    double sinc = std::fabs(theta) < 1e-8 ? 1 : sin(theta) / theta;
-    double mcosc = (std::fabs(theta) < 1e-8) ? 0.5 : (1-cos(theta)) / (theta*theta);
-    double msinc = (std::abs(theta) < 1e-8) ? (1/6.0) : (1-sinc) / (theta*theta);
-
-    Matx31d dt;
-    dt(0) = vx*(sinc + wx*wx*msinc) + vy*(wx*wy*msinc - wz*mcosc) + vz*(wx*wz*msinc + wy*mcosc);
-    dt(1) = vx*(wx*wy*msinc + wz*mcosc) + vy*(sinc + wy*wy*msinc) + vz*(wy*wz*msinc - wx*mcosc);
-    dt(2) = vx*(wx*wz*msinc - wy*mcosc) + vy*(wy*wz*msinc + wx*mcosc) + vz*(sinc + wz*wz*msinc);
-
-    R1 = R.t();
-    t1 = -R1 * dt;
-}
-
-enum SolvePnPRefineMethod {
-    SOLVEPNP_REFINE_LM   = 0,
-    SOLVEPNP_REFINE_VVS  = 1
-};
-
-static void solvePnPRefine(InputArray _objectPoints, InputArray _imagePoints,
-                           InputArray _cameraMatrix, InputArray _distCoeffs,
-                           InputOutputArray _rvec, InputOutputArray _tvec,
-                           SolvePnPRefineMethod _flags,
-                           TermCriteria _criteria=TermCriteria(TermCriteria::EPS+TermCriteria::COUNT, 20, FLT_EPSILON),
-                           double _vvslambda=1)
-{
-    CV_INSTRUMENT_REGION();
-
-    Mat opoints_ = _objectPoints.getMat(), ipoints_ = _imagePoints.getMat();
-    Mat opoints, ipoints;
-    opoints_.convertTo(opoints, CV_64F);
-    ipoints_.convertTo(ipoints, CV_64F);
-    int npoints = opoints.checkVector(3, CV_64F);
-    CV_Assert( npoints >= 3 && npoints == ipoints.checkVector(2, CV_64F) );
-    CV_Assert( !_rvec.empty() && !_tvec.empty() );
-
-    int rtype = _rvec.type(), ttype = _tvec.type();
-    Size rsize = _rvec.size(), tsize = _tvec.size();
-    CV_Assert( (rtype == CV_32FC1 || rtype == CV_64FC1) &&
-               (ttype == CV_32FC1 || ttype == CV_64FC1) );
-    CV_Assert( (rsize == Size(1, 3) || rsize == Size(3, 1)) &&
-               (tsize == Size(1, 3) || tsize == Size(3, 1)) );
-
-    Mat cameraMatrix0 = _cameraMatrix.getMat();
-    Mat distCoeffs0 = _distCoeffs.getMat();
-    Mat cameraMatrix = Mat_<double>(cameraMatrix0);
-    Mat distCoeffs = Mat_<double>(distCoeffs0);
-
-    if (_flags == SOLVEPNP_REFINE_LM)
-    {
-        Mat rvec0 = _rvec.getMat(), tvec0 = _tvec.getMat();
-        Mat rvec, tvec;
-        rvec0.convertTo(rvec, CV_64F);
-        tvec0.convertTo(tvec, CV_64F);
-
-        Mat params(6, 1, CV_64FC1);
-        for (int i = 0; i < 3; i++)
-        {
-            params.at<double>(i,0) = rvec.at<double>(i,0);
-            params.at<double>(i+3,0) = tvec.at<double>(i,0);
-        }
-
-        createLMSolver(makePtr<SolvePnPRefineLMCallback>(opoints, ipoints, cameraMatrix, distCoeffs), _criteria.maxCount, _criteria.epsilon)->run(params);
-
-        params.rowRange(0, 3).convertTo(rvec0, rvec0.depth());
-        params.rowRange(3, 6).convertTo(tvec0, tvec0.depth());
-    }
-    else if (_flags == SOLVEPNP_REFINE_VVS)
-    {
-        Mat rvec0 = _rvec.getMat(), tvec0 = _tvec.getMat();
-        Mat rvec, tvec;
-        rvec0.convertTo(rvec, CV_64F);
-        tvec0.convertTo(tvec, CV_64F);
-
-        vector<Point2d> ipoints_normalized;
-        undistortPoints(ipoints, ipoints_normalized, cameraMatrix, distCoeffs);
-        Mat sd = Mat(ipoints_normalized).reshape(1, npoints*2);
-        Mat objectPoints0 = opoints.reshape(1, npoints);
-        Mat imagePoints0 = ipoints.reshape(1, npoints*2);
-        Mat L(npoints*2, 6, CV_64FC1), s(npoints*2, 1, CV_64FC1);
-
-        double residuals_1 = std::numeric_limits<double>::max(), residuals = 0;
-        Mat err;
-        Mat R;
-        Rodrigues(rvec, R);
-        for (int iter = 0; iter < _criteria.maxCount; iter++)
-        {
-            computeInteractionMatrixAndResiduals(objectPoints0, R, tvec, L, s);
-            err = s - sd;
-
-            Mat Lp = L.inv(cv::DECOMP_SVD);
-            Mat dq = -_vvslambda * Lp * err;
-
-            Mat R1, t1;
-            exponentialMapToSE3Inv(dq, R1, t1);
-            R = R1 * R;
-            tvec = R1 * tvec + t1;
-
-            residuals_1 = residuals;
-            Mat res = err.t()*err;
-            residuals = res.at<double>(0,0);
-
-            if (std::fabs(residuals - residuals_1) < _criteria.epsilon)
-                break;
-        }
-
-        Rodrigues(R, rvec);
-        rvec.convertTo(rvec0, rvec0.depth());
-        tvec.convertTo(tvec0, tvec0.depth());
-    }
-}
-
-void solvePnPRefineLM(InputArray _objectPoints, InputArray _imagePoints,
-                      InputArray _cameraMatrix, InputArray _distCoeffs,
-                      InputOutputArray _rvec, InputOutputArray _tvec,
-                      TermCriteria _criteria)
-{
-    CV_INSTRUMENT_REGION();
-    solvePnPRefine(_objectPoints, _imagePoints, _cameraMatrix, _distCoeffs, _rvec, _tvec, SOLVEPNP_REFINE_LM, _criteria);
-}
-
-void solvePnPRefineVVS(InputArray _objectPoints, InputArray _imagePoints,
-                       InputArray _cameraMatrix, InputArray _distCoeffs,
-                       InputOutputArray _rvec, InputOutputArray _tvec,
-                       TermCriteria _criteria, double _VVSlambda)
-{
-    CV_INSTRUMENT_REGION();
-    solvePnPRefine(_objectPoints, _imagePoints, _cameraMatrix, _distCoeffs, _rvec, _tvec, SOLVEPNP_REFINE_VVS, _criteria, _VVSlambda);
-}
 
 int solvePnPGeneric( InputArray _opoints, InputArray _ipoints,
                      InputArray _cameraMatrix, InputArray _distCoeffs,
                      OutputArrayOfArrays _rvecs, OutputArrayOfArrays _tvecs,
-                     bool useExtrinsicGuess, SolvePnPMethod flags,
-                     InputArray _rvec, InputArray _tvec,
+                     const Ptr<PnPSolver> solver, const Ptr<PnPRefiner> refiner,
+                     bool sortOnReprojectionError,
                      OutputArray reprojectionError) {
+
     CV_INSTRUMENT_REGION();
 
-    Mat opoints = _opoints.getMat(), ipoints = _ipoints.getMat();
-    int npoints = std::max(opoints.checkVector(3, CV_32F), opoints.checkVector(3, CV_64F));
-    CV_Assert( ( (npoints >= 4) || (npoints == 3 && flags == SOLVEPNP_ITERATIVE && useExtrinsicGuess) )
-               && npoints == std::max(ipoints.checkVector(2, CV_32F), ipoints.checkVector(2, CV_64F)) );
+    //parsing of _opoints, _ipoints, _cameraMatrix and _distCoeffs with format checking
+    Mat opoints_ = _opoints.getMat(), ipoints_ = _ipoints.getMat();
+    Mat opoints, ipoints, cameraMatrix, distCoeffs, ipointsNormalized;
+    opoints_.convertTo(opoints, CV_64F);
+    ipoints_.convertTo(ipoints, CV_64F);
+    _cameraMatrix.getMat().convertTo(cameraMatrix, CV_64F);
 
-    if (opoints.cols == 3)
+    ipoints.copyTo(ipointsNormalized);
+    if (opoints.channels()==1)
+    {
         opoints = opoints.reshape(3);
-    if (ipoints.cols == 2)
-        ipoints = ipoints.reshape(2);
-
-    if( flags != SOLVEPNP_ITERATIVE )
-        useExtrinsicGuess = false;
-
-    if (useExtrinsicGuess)
-        CV_Assert( !_rvec.empty() && !_tvec.empty() );
-
-    if( useExtrinsicGuess )
-    {
-        int rtype = _rvec.type(), ttype = _tvec.type();
-        Size rsize = _rvec.size(), tsize = _tvec.size();
-        CV_Assert( (rtype == CV_32FC1 || rtype == CV_64FC1) &&
-                   (ttype == CV_32FC1 || ttype == CV_64FC1) );
-        CV_Assert( (rsize == Size(1, 3) || rsize == Size(3, 1)) &&
-                   (tsize == Size(1, 3) || tsize == Size(3, 1)) );
     }
 
-    Mat cameraMatrix0 = _cameraMatrix.getMat();
-    Mat distCoeffs0 = _distCoeffs.getMat();
-    Mat cameraMatrix = Mat_<double>(cameraMatrix0);
-    Mat distCoeffs = Mat_<double>(distCoeffs0);
-
-    vector<Mat> vec_rvecs, vec_tvecs;
-    if (flags == SOLVEPNP_EPNP || flags == SOLVEPNP_DLS || flags == SOLVEPNP_UPNP)
+    if (!_distCoeffs.empty())
     {
-        Mat undistortedPoints;
-        undistortPoints(ipoints, undistortedPoints, cameraMatrix, distCoeffs);
-        epnp PnP(cameraMatrix, opoints, undistortedPoints);
-
-        Mat rvec, tvec, R;
-        PnP.compute_pose(R, tvec);
-        Rodrigues(R, rvec);
-
-        vec_rvecs.push_back(rvec);
-        vec_tvecs.push_back(tvec);
+        _distCoeffs.getMat().convertTo(distCoeffs, CV_64F);
+        undistortPoints(ipoints, ipointsNormalized, cameraMatrix, distCoeffs);
     }
-    else if (flags == SOLVEPNP_P3P || flags == SOLVEPNP_AP3P)
-    {
-        vector<Mat> rvecs, tvecs;
-        solveP3P(_opoints, _ipoints, _cameraMatrix, _distCoeffs, rvecs, tvecs, flags);
-        vec_rvecs.insert(vec_rvecs.end(), rvecs.begin(), rvecs.end());
-        vec_tvecs.insert(vec_tvecs.end(), tvecs.begin(), tvecs.end());
-    }
-    else if (flags == SOLVEPNP_ITERATIVE)
-    {
-        Mat rvec, tvec;
-        if (useExtrinsicGuess)
-        {
-            rvec = _rvec.getMat();
-            tvec = _tvec.getMat();
-        }
-        else
-        {
-            rvec.create(3, 1, CV_64FC1);
-            tvec.create(3, 1, CV_64FC1);
-        }
-
-        CvMat c_objectPoints = cvMat(opoints), c_imagePoints = cvMat(ipoints);
-        CvMat c_cameraMatrix = cvMat(cameraMatrix), c_distCoeffs = cvMat(distCoeffs);
-        CvMat c_rvec = cvMat(rvec), c_tvec = cvMat(tvec);
-        cvFindExtrinsicCameraParams2(&c_objectPoints, &c_imagePoints, &c_cameraMatrix,
-                                     (c_distCoeffs.rows && c_distCoeffs.cols) ? &c_distCoeffs : 0,
-                                     &c_rvec, &c_tvec, useExtrinsicGuess );
-
-        vec_rvecs.push_back(rvec);
-        vec_tvecs.push_back(tvec);
-    }
-    else if (flags == SOLVEPNP_IPPE)
-    {
-        CV_DbgAssert(isPlanarObjectPoints(opoints, 1e-3));
-        Mat undistortedPoints;
-        undistortPoints(ipoints, undistortedPoints, cameraMatrix, distCoeffs);
-
-        IPPE::PoseSolver poseSolver;
-        Mat rvec1, tvec1, rvec2, tvec2;
-        float reprojErr1, reprojErr2;
-        try
-        {
-            poseSolver.solveGeneric(opoints, undistortedPoints, rvec1, tvec1, reprojErr1, rvec2, tvec2, reprojErr2);
-
-            if (reprojErr1 < reprojErr2)
-            {
-                vec_rvecs.push_back(rvec1);
-                vec_tvecs.push_back(tvec1);
-
-                vec_rvecs.push_back(rvec2);
-                vec_tvecs.push_back(tvec2);
-            }
-            else
-            {
-                vec_rvecs.push_back(rvec2);
-                vec_tvecs.push_back(tvec2);
-
-                vec_rvecs.push_back(rvec1);
-                vec_tvecs.push_back(tvec1);
-            }
-        }
-        catch (...) { }
-    }
-    else if (flags == SOLVEPNP_IPPE_SQUARE)
-    {
-        CV_Assert(npoints == 4);
-
-#if defined _DEBUG || defined CV_STATIC_ANALYSIS
-        double Xs[4][3];
-        if (opoints.depth() == CV_32F)
-        {
-            for (int i = 0; i < 4; i++)
-            {
-                for (int j = 0; j < 3; j++)
-                {
-                    Xs[i][j] = opoints.ptr<Vec3f>(0)[i](j);
-                }
-            }
-        }
-        else
-        {
-            for (int i = 0; i < 4; i++)
-            {
-                for (int j = 0; j < 3; j++)
-                {
-                    Xs[i][j] = opoints.ptr<Vec3d>(0)[i](j);
-                }
-            }
-        }
-
-        const double equalThreshold = 1e-9;
-        //Z must be zero
-        for (int i = 0; i < 4; i++)
-        {
-            CV_DbgCheck(Xs[i][2], approxEqual(Xs[i][2], 0, equalThreshold), "Z object point coordinate must be zero!");
-        }
-        //Y0 == Y1 && Y2 == Y3
-        CV_DbgCheck(Xs[0][1], approxEqual(Xs[0][1], Xs[1][1], equalThreshold), "Object points must be: Y0 == Y1!");
-        CV_DbgCheck(Xs[2][1], approxEqual(Xs[2][1], Xs[3][1], equalThreshold), "Object points must be: Y2 == Y3!");
-        //X0 == X3 && X1 == X2
-        CV_DbgCheck(Xs[0][0], approxEqual(Xs[0][0], Xs[3][0], equalThreshold), "Object points must be: X0 == X3!");
-        CV_DbgCheck(Xs[1][0], approxEqual(Xs[1][0], Xs[2][0], equalThreshold), "Object points must be: X1 == X2!");
-        //X1 == Y1 && X3 == Y3
-        CV_DbgCheck(Xs[1][0], approxEqual(Xs[1][0], Xs[1][1], equalThreshold), "Object points must be: X1 == Y1!");
-        CV_DbgCheck(Xs[3][0], approxEqual(Xs[3][0], Xs[3][1], equalThreshold), "Object points must be: X3 == Y3!");
-#endif
-
-        Mat undistortedPoints;
-        undistortPoints(ipoints, undistortedPoints, cameraMatrix, distCoeffs);
-
-        IPPE::PoseSolver poseSolver;
-        Mat rvec1, tvec1, rvec2, tvec2;
-        float reprojErr1, reprojErr2;
-        try
-        {
-            poseSolver.solveSquare(opoints, undistortedPoints, rvec1, tvec1, reprojErr1, rvec2, tvec2, reprojErr2);
-
-            if (reprojErr1 < reprojErr2)
-            {
-                vec_rvecs.push_back(rvec1);
-                vec_tvecs.push_back(tvec1);
-
-                vec_rvecs.push_back(rvec2);
-                vec_tvecs.push_back(tvec2);
-            }
-            else
-            {
-                vec_rvecs.push_back(rvec2);
-                vec_tvecs.push_back(tvec2);
-
-                vec_rvecs.push_back(rvec1);
-                vec_tvecs.push_back(tvec1);
-            }
-        } catch (...) { }
-    }
-    /*else if (flags == SOLVEPNP_DLS)
-    {
-        Mat undistortedPoints;
-        undistortPoints(ipoints, undistortedPoints, cameraMatrix, distCoeffs);
-
-        dls PnP(opoints, undistortedPoints);
-
-        Mat rvec, tvec, R;
-        bool result = PnP.compute_pose(R, tvec);
-        if (result)
-        {
-            Rodrigues(R, rvec);
-            vec_rvecs.push_back(rvec);
-            vec_tvecs.push_back(tvec);
-        }
-    }
-    else if (flags == SOLVEPNP_UPNP)
-    {
-        upnp PnP(cameraMatrix, opoints, ipoints);
-
-        Mat rvec, tvec, R;
-        PnP.compute_pose(R, tvec);
-        Rodrigues(R, rvec);
-        vec_rvecs.push_back(rvec);
-        vec_tvecs.push_back(tvec);
-    }*/
     else
-        CV_Error(CV_StsBadArg, "The flags argument must be one of SOLVEPNP_ITERATIVE, SOLVEPNP_P3P, SOLVEPNP_EPNP or SOLVEPNP_DLS");
+    {
+        undistortPoints(ipoints, ipointsNormalized, cameraMatrix, noArray());
+    }
 
-    CV_Assert(vec_rvecs.size() == vec_tvecs.size());
+    //output pose solutions:
+    std::vector<Mat> rVecs;
+    std::vector<Mat> tVecs;
 
-    int solutions = static_cast<int>(vec_rvecs.size());
+    //output depths:
+    int depthRot = CV_64F;
+    int depthTrans = CV_64F;
 
-    int depthRot = _rvecs.fixedType() ? _rvecs.depth() : CV_64F;
-    int depthTrans = _tvecs.fixedType() ? _tvecs.depth() : CV_64F;
-    _rvecs.create(solutions, 1, CV_MAKETYPE(depthRot, _rvecs.fixedType() && _rvecs.kind() == _InputArray::STD_VECTOR ? 3 : 1));
-    _tvecs.create(solutions, 1, CV_MAKETYPE(depthTrans, _tvecs.fixedType() && _tvecs.kind() == _InputArray::STD_VECTOR ? 3 : 1));
+    if (_rvecs.fixedType() | !_rvecs.empty())
+    {
+        depthRot = _rvecs.depth();
+    }
+    if (_tvecs.fixedType() | !_tvecs.empty())
+    {
+        depthTrans = _tvecs.depth();
+    }
 
-    for (int i = 0; i < solutions; i++)
+    if (!solver.empty())
+    {
+        rVecs.clear();
+        tVecs.clear();
+        solver->solveProblem(opoints,ipointsNormalized,rVecs,tVecs,false);
+    }
+    else
+    {
+        //empty pnp solver is used, so copy poses from inputs and proceed
+        const int n = _rvecs.rows()*_rvecs.cols();
+        for (int i = 0; i < n; i++)
+        {
+            Mat r(3,1,CV_64F);
+            Mat t(3,1,CV_64F);
+
+            Mat r_,t_;
+
+            if (_rvecs.fixedType() && _rvecs.kind() == _InputArray::STD_VECTOR)
+            {
+                Mat rref = _rvecs.getMat_();
+
+                if (depthRot == CV_32F)
+                    r_ = rref.at<Vec3f>(0,i);
+
+                else
+                    r_ = rref.at<Vec3d>(0,i);
+            }
+            else
+            {
+                r_ = _rvecs.getMatRef(i);
+            }
+            r_.convertTo(r,CV_64F);
+
+
+            if (_tvecs.fixedType() && _tvecs.kind() == _InputArray::STD_VECTOR)
+            {
+                Mat tref = _tvecs.getMat_();
+
+                if (depthTrans == CV_32F)
+                    t_ = tref.at<Vec3f>(0,i);
+
+                else
+                    t_ = tref.at<Vec3d>(0,i);
+            }
+            else
+            {
+                t_ = _tvecs.getMatRef(i);
+            }
+            t_.convertTo(t,CV_64F);
+
+            rVecs.push_back(r);
+            tVecs.push_back(t);
+        }
+
+    }
+    _rvecs.clear();
+    _tvecs.clear();
+
+
+    size_t solutions = rVecs.size();
+    if (!refiner.empty())
+    {
+        //perform pose refinement
+        std::vector<Mat> rVecs2;
+        std::vector<Mat> tVecs2;
+
+        for (size_t i = 0; i < solutions; i++)
+        {
+
+            Mat r = rVecs[i];
+            Mat t = tVecs[i];
+            std::vector<Mat> rvs;
+            std::vector<Mat> tvs;
+            refiner->refine(opoints,ipoints,cameraMatrix,distCoeffs,r,t,rvs,tvs);
+            for (size_t j = 0; j < rvs.size(); j++)
+            {
+                rVecs2.push_back(rvs[j]);
+                tVecs2.push_back(tvs[j]);
+            }
+
+        }
+        rVecs = rVecs2;
+        tVecs = tVecs2;
+    }
+
+
+    //handle sorting of solutions based on reprojection error:
+    std::vector<double> rmses;
+    if ((solutions>0) & (sortOnReprojectionError | reprojectionError.needed()))
+    {
+        sortPosesOnReprojectionError(opoints, ipoints, cameraMatrix, distCoeffs,  rVecs, tVecs, rmses);
+    }
+
+    //copying results to outputs
+    _rvecs.create(static_cast<int>(solutions), 1, CV_MAKETYPE(depthRot, _rvecs.fixedType() && _rvecs.kind() == _InputArray::STD_VECTOR ? 3 : 1));
+    _tvecs.create(static_cast<int>(solutions), 1, CV_MAKETYPE(depthTrans, _tvecs.fixedType() && _tvecs.kind() == _InputArray::STD_VECTOR ? 3 : 1));
+
+    for (size_t i = 0; i < solutions; i++)
     {
         Mat rvec0, tvec0;
         if (depthRot == CV_64F)
-            rvec0 = vec_rvecs[i];
+        {rvec0 = rVecs[i];}
         else
-            vec_rvecs[i].convertTo(rvec0, depthRot);
+        {rVecs[i].convertTo(rvec0, depthRot);}
+
+        //std::cout <<"rvec0 " << rvec0 << std::endl;
 
         if (depthTrans == CV_64F)
-            tvec0 = vec_tvecs[i];
+        {tvec0 = tVecs[i];}
         else
-            vec_tvecs[i].convertTo(tvec0, depthTrans);
+        {tVecs[i].convertTo(tvec0, depthTrans);}
 
         if (_rvecs.fixedType() && _rvecs.kind() == _InputArray::STD_VECTOR)
         {
             Mat rref = _rvecs.getMat_();
 
             if (_rvecs.depth() == CV_32F)
-                rref.at<Vec3f>(0,i) = Vec3f(rvec0.at<float>(0,0), rvec0.at<float>(1,0), rvec0.at<float>(2,0));
+                rref.at<Vec3f>(0,static_cast<int>(i)) = Vec3f(rvec0.at<float>(0,0), rvec0.at<float>(1,0), rvec0.at<float>(2,0));
             else
-                rref.at<Vec3d>(0,i) = Vec3d(rvec0.at<double>(0,0), rvec0.at<double>(1,0), rvec0.at<double>(2,0));
+                rref.at<Vec3d>(0,static_cast<int>(i)) = Vec3d(rvec0.at<double>(0,0), rvec0.at<double>(1,0), rvec0.at<double>(2,0));
         }
         else
         {
-            _rvecs.getMatRef(i) = rvec0;
+            _rvecs.getMatRef(static_cast<int>(i)) = rvec0;
         }
 
         if (_tvecs.fixedType() && _tvecs.kind() == _InputArray::STD_VECTOR)
@@ -999,60 +647,164 @@ int solvePnPGeneric( InputArray _opoints, InputArray _ipoints,
             Mat tref = _tvecs.getMat_();
 
             if (_tvecs.depth() == CV_32F)
-                tref.at<Vec3f>(0,i) = Vec3f(tvec0.at<float>(0,0), tvec0.at<float>(1,0), tvec0.at<float>(2,0));
+                tref.at<Vec3f>(0,static_cast<int>(i)) = Vec3f(tvec0.at<float>(0,0), tvec0.at<float>(1,0), tvec0.at<float>(2,0));
             else
-                tref.at<Vec3d>(0,i) = Vec3d(tvec0.at<double>(0,0), tvec0.at<double>(1,0), tvec0.at<double>(2,0));
+                tref.at<Vec3d>(0,static_cast<int>(i)) = Vec3d(tvec0.at<double>(0,0), tvec0.at<double>(1,0), tvec0.at<double>(2,0));
         }
         else
         {
-            _tvecs.getMatRef(i) = tvec0;
+            _tvecs.getMatRef(static_cast<int>(i)) = tvec0;
         }
     }
 
     if (reprojectionError.needed())
     {
-        int type = reprojectionError.type();
-        reprojectionError.create(solutions, 1, type);
+        int type;
+        if (!reprojectionError.empty())
+        {
+            type = reprojectionError.type();
+        }
+        else {
+            type = CV_64FC1;
+        }
+        reprojectionError.create(static_cast<int>(solutions), 1, type);
         CV_CheckType(reprojectionError.type(), type == CV_32FC1 || type == CV_64FC1,
                      "Type of reprojectionError must be CV_32FC1 or CV_64FC1!");
 
-        Mat objectPoints, imagePoints;
-        if (_opoints.depth() == CV_32F)
+        for (size_t i = 0; i <solutions; i++)
         {
-            _opoints.getMat().convertTo(objectPoints, CV_64F);
-        }
-        else
-        {
-            objectPoints = _opoints.getMat();
-        }
-        if (_ipoints.depth() == CV_32F)
-        {
-            _ipoints.getMat().convertTo(imagePoints, CV_64F);
-        }
-        else
-        {
-            imagePoints = _ipoints.getMat();
-        }
-
-        for (size_t i = 0; i < vec_rvecs.size(); i++)
-        {
-            vector<Point2d> projectedPoints;
-            projectPoints(objectPoints, vec_rvecs[i], vec_tvecs[i], cameraMatrix, distCoeffs, projectedPoints);
-            double rmse = norm(projectedPoints, imagePoints, NORM_L2) / sqrt(2*projectedPoints.size());
-
             Mat err = reprojectionError.getMat();
             if (type == CV_32F)
             {
-                err.at<float>(0,static_cast<int>(i)) = static_cast<float>(rmse);
+                err.at<float>(static_cast<int>(i)) = static_cast<float>(rmses[i]);
             }
             else
             {
-                err.at<double>(0,static_cast<int>(i)) = rmse;
+                err.at<double>(static_cast<int>(i)) = rmses[i];
             }
         }
     }
 
-    return solutions;
+    return static_cast<int>(solutions);
 }
 
+
+void cvtSolvePnPFlag(const SolvePnPMethod & flag, bool useExtrinsicGuess, Ptr<PnPSolver> & solver, Ptr<PnPRefiner> & refiner)
+{
+    solver = Ptr<PnPSolver>();
+    refiner = Ptr<PnPRefiner>();
+
+    if (useExtrinsicGuess)
+    {
+        refiner = PnPRefinerLM::create();
+    }
+    else
+    {
+        switch (flag)
+        {
+
+        case SOLVEPNP_ITERATIVE:
+        {
+            solver = PnPSolverAutoSelect1::create();
+            refiner = PnPRefinerLM::create();
+            break;
+        }
+        case SOLVEPNP_P3P:
+        {
+            solver = PnPSolverP3PComplete::create();
+            break;
+        }
+        case SOLVEPNP_AP3P:
+        {
+            solver = PnPSolverAP3P::create();
+            break;
+        }
+        case SOLVEPNP_DLS:
+        {
+            solver = PnPSolverEPnP3D::create();
+            break;
+        }
+        case SOLVEPNP_UPNP:
+        {
+            solver = PnPSolverEPnP3D::create();
+            break;
+        }
+        case SOLVEPNP_EPNP:
+        {
+            solver = PnPSolverEPnP3D::create();
+            break;
+        }
+
+        case SOLVEPNP_IPPE:
+        {
+            solver = PnPSolverIPPE::create();
+            break;
+        }
+        case SOLVEPNP_IPPE_SQUARE:
+        {
+            solver = PnPSolverIPPESquare::create();
+            break;
+        }
+
+        case SOLVEPNP_MAX_COUNT:
+        {
+
+            break;
+        }
+
+        }
+    }
 }
+
+
+
+
+
+
+
+
+void get3DPointsetShape(InputArray _objectPoints, InputOutputArray _singValues)
+{
+    CV_INSTRUMENT_REGION();
+    Mat objectPoints;
+
+    _singValues.create(3,1,CV_64FC1);
+    Mat singValues = _singValues.getMat();
+
+    if (_objectPoints.getMat().channels()!=3)
+    {
+        objectPoints = _objectPoints.getMat().reshape(3);
+    }
+    else
+    {
+        objectPoints = _objectPoints.getMat();
+    }
+    CV_CheckType(objectPoints.type(), objectPoints.type() == CV_32FC3 || objectPoints.type() == CV_64FC3,
+                 "Type of _objectPoints must be CV_32FC3 or CV_64FC3");
+
+    bool floatDepth = objectPoints.type() == CV_32FC3;
+    if (floatDepth)
+    {
+        objectPoints.convertTo(objectPoints, CV_64F);
+    }
+
+
+    Scalar meanValues = mean(objectPoints);
+    int nbPts = objectPoints.checkVector(3, CV_64F);
+    Mat objectPointsCentred = objectPoints - meanValues;
+    objectPointsCentred = objectPointsCentred.reshape(1, nbPts);
+
+    Mat w, u, vt;
+    Mat MM = objectPointsCentred.t() * objectPointsCentred;
+    SVDecomp(MM, w, u, vt);
+    singValues.at<double>(0) = w.at<double>(0);
+    singValues.at<double>(1) = w.at<double>(1);
+    singValues.at<double>(2) = w.at<double>(2);
+}
+}
+
+
+
+
+
+

--- a/modules/calib3d/test/test_solvepnp_generic.cpp
+++ b/modules/calib3d/test/test_solvepnp_generic.cpp
@@ -1,0 +1,1812 @@
+/*M///////////////////////////////////////////////////////////////////////////////////////
+//
+//  IMPORTANT: READ BEFORE DOWNLOADING, COPYING, INSTALLING OR USING.
+//
+//  By downloading, copying, installing or using the software you agree to this license.
+//  If you do not agree to this license, do not download, install,
+//  copy or use the software.
+//
+//
+//                           License Agreement
+//                For Open Source Computer Vision Library
+//
+// Copyright (C) 2000-2008, Intel Corporation, all rights reserved.
+// Copyright (C) 2009, Willow Garage Inc., all rights reserved.
+// Third party copyrights are property of their respective owners.
+//
+// Redistribution and use in source and binary forms, with or without modification,
+// are permitted provided that the following conditions are met:
+//
+//   * Redistribution's of source code must retain the above copyright notice,
+//     this list of conditions and the following disclaimer.
+//
+//   * Redistribution's in binary form must reproduce the above copyright notice,
+//     this list of conditions and the following disclaimer in the documentation
+//     and/or other materials provided with the distribution.
+//
+//   * The name of the copyright holders may not be used to endorse or promote products
+//     derived from this software without specific prior written permission.
+//
+// This software is provided by the copyright holders and contributors "as is" and
+// any express or implied warranties, including, but not limited to, the implied
+// warranties of merchantability and fitness for a particular purpose are disclaimed.
+// In no event shall the Intel Corporation or contributors be liable for any direct,
+// indirect, incidental, special, exemplary, or consequential damages
+// (including, but not limited to, procurement of substitute goods or services;
+// loss of use, data, or profits; or business interruption) however caused
+// and on any theory of liability, whether in contract, strict liability,
+// or tort (including negligence or otherwise) arising in any way out of
+// the use of this software, even if advised of the possibility of such damage.
+//
+//M*/
+
+#include "test_precomp.hpp"
+#include <math.h>
+#include <string>
+#include <map>
+#include <set>
+
+namespace opencv_test { namespace {
+
+//Generates vector of all available PnPSolvers
+std::vector<Ptr<PnPSolver>> generateSolvers()
+{
+    std::vector<Ptr<PnPSolver>> solvers;
+    solvers.push_back(PnPSolverP3PComplete::create());
+    solvers.push_back(PnPSolverAP3P::create());
+    solvers.push_back(PnPSolverIPPE::create());
+    solvers.push_back(PnPSolverIPPESquare::create());
+    solvers.push_back(PnPSolverZhang::create());
+    solvers.push_back(PnPSolverDLT::create());
+    solvers.push_back(PnPSolverEPnP3D::create());
+    return solvers;
+}
+
+//Generates vector of all available PnPRefiners
+std::vector<Ptr<PnPRefiner>> generateRefiners()
+{
+    std::vector<Ptr<PnPRefiner>> refiners;
+    refiners.push_back(PnPRefinerLM::create());
+    refiners.push_back(PnPRefinerLMcpp::create());
+    refiners.push_back(PnPRefinerVVS::create());
+    refiners.push_back(Ptr<PnPRefiner>()); //last refiner is empty pointer. This is used when we run solvePnPGeneric without refining the solution from the PnPSolver
+    return refiners;
+}
+
+/**
+ * @brief solverName returns string associated with a PnPSolver. Used for printing to terminal if a test fails.
+ * @param s the PnPSolver
+ * @return name of s
+ */
+string solverName(const Ptr<PnPSolver> s)
+{
+    string ret;
+    if (s.dynamicCast<PnPSolverP3PComplete>())
+    {
+        ret = "PnPSolverP3P";
+    }
+    else if (s.dynamicCast<PnPSolverAP3P>())
+    {
+        ret = "PnPSolverAP3P";
+    }
+    else if (s.dynamicCast<PnPSolverIPPE>())
+    {
+        ret = "PnPSolverIPPE";
+    }
+    else if (s.dynamicCast<PnPSolverZhang>())
+    {
+        ret = "PnPSolverZhang";
+    }
+    else if (s.dynamicCast<PnPSolverIPPESquare>())
+    {
+        ret = "PnPSolverIPPESquare";
+    }
+    else if (s.dynamicCast<PnPSolverDLT>())
+    {
+        ret = "PnPSolverLinearDLS";
+    }
+    else if (s.dynamicCast<PnPSolverEPnP3D>())
+    {
+        ret = "PnPSolverEPnP3D";
+    }
+    else if (s.dynamicCast<PnPSolverAutoSelect1>())
+    {
+        ret = "PnPSolverAuto";
+    }
+    CV_Assert(!ret.empty());
+    return ret;
+
+}
+
+/**
+ * @brief refinerName returns string associated with a PnPRefiner. Used for printing to terminal if a test fails.
+ * @param r the PnPRefiner
+ * @return name of r
+ */
+string refinerName(const Ptr<PnPRefiner> r)
+{
+    string ret;
+    if (r.empty())
+    {
+        ret = "None";
+    }
+    else if (r.dynamicCast<PnPRefinerLM>())
+    {
+        ret = "PnPRefinerLM";
+    }
+    else if (r.dynamicCast<PnPRefinerLMcpp>())
+    {
+        ret = "PnPRefinerLMImpl2";
+    }
+    else if (r.dynamicCast<PnPRefinerVVS>())
+    {
+        ret = "PnPRefinerVVS";
+    }
+    CV_Assert(!ret.empty());
+    return ret;
+
+}
+
+/**
+ * @brief The ObjectPointShape enum holds all supported shapes for
+ * the object points argument in solvePnPGeneric
+ */
+enum ObjectPointShape
+{
+    O_MAT_1CH_Nx3, O_MAT_3CH_1xN, MAT_3CH_Nx1, VEC_POINT3, OPS_LEN
+};
+
+/**
+ * @brief The ImagePointShape enum holds all supported shapes for
+ * the image points argument in solvePnPGeneric
+ */
+enum ImagePointShape
+{
+    I_MAT_1CH_Nx2, I_MAT2CH_1xN, I_MAT2CH_Nx1, VEC_POINT2, IPS_LEN
+};
+
+/**
+ * @brief The ObjectGeometry enum holds all supported geometries for
+ * the object points. This is either co-planar, co-planar square (a tag), 3D (non-coplanar)
+ */
+enum ObjectGeometry
+{
+    OBJECT_COPLANAR, OBJECT_SQUARE, OBJECT_3D, OBJ_GEOM_LEN //last entry holds enumeration count
+};
+
+
+/**
+ * @brief The PnPProblem struct. Holds all data needed to solve a pnp problem. Includes ground truth pose.
+ */
+struct PnPProblem
+{
+    Mat oPts, imgPts, K, d, rvecGT, tvecGT; //object points, image points, intrinsic, distortion, rotation vector ground truth, translation
+    //vector ground truth
+    ObjectGeometry objectShape; //object shape geometry
+    size_t getNumPts() const; //gets number of points
+};
+
+/**
+ * @brief The ProblemFormat struct. Defines input types for Mats in a PnPProblem object
+ */
+struct ProblemFormat
+{
+    bool doubleObjectPoints; //true if object points are double otherwise false and object points are float
+    bool doubleIntrinsics; //true if intrinsics are double otherwise false and intrinsics are float
+    bool doubleDistCoeffs; //true if distortion coefficients are double otherwise false and they are float
+    bool doubleImagePoints; //true if image points are double otherwise false and image points are float
+    ObjectPointShape objShape;
+    ImagePointShape imgShape;
+
+    ProblemFormat();
+
+    static vector<ProblemFormat> createAllFormats(); //creates all combinations of problem formats.
+};
+
+
+/**
+ * @brief printProblemFormat prints problem format to terminal. Used if a test fails.
+ * @param f problem format
+ * @return string coding of problem format
+ */
+string printProblemFormat(const ProblemFormat & f);
+
+
+/**
+ * @brief The ProblemGenerator class. Base class for genetating a sequence of PnP problems
+ */
+class ProblemGenerator
+{
+public:
+    ProblemGenerator(const cv::RNG & rng, double mNoiseSigma);
+    virtual ~ProblemGenerator();
+
+    /**
+     * @brief generate generates the next problem in the sequence
+     * @param prob generated problem
+     */
+    void generate(PnPProblem & prob) const;
+
+    /**
+     * @brief toCameraCoords computes the camera coordinate positions of the object points
+     * @param prob pnp problem
+     * @return camera coordinates of object points
+     */
+    cv::Mat toCameraCoords(const PnPProblem & prob) const;
+
+    /**
+     * @brief getCentroid gets centroid of a set of points. Must be 1-channel Nx3 double
+     * @param pts points
+     * @return centroid. 1-channel 3x1 double
+     */
+    cv::Mat getCentroid(const Mat & pts) const;
+
+    /**
+     * @brief frontOfCameraCheck checks if problem is valid by testing if all object points
+     * in camera coordinates are in front of the camera (have positive z coefficients)
+     * @param prob PnP problem
+     * @return true if test passes, false otherwise
+     */
+    bool frontOfCameraCheck(const PnPProblem & prob) const;
+
+    /**
+     * @brief addWhiteNoiseImgPts adds zero mean I.I.D gaussian noise (white noise) to the
+     * image points. Used to simulate real noise of measured point positions in an image
+     * @param prob PnP problem
+     */
+    void addWhiteNoiseImgPts(PnPProblem & prob) const;
+
+
+protected:
+    mutable cv::RNG mRng;
+    double mNoiseSigma; //image point noise to apply (standard deviation). If zero, no
+    //noise is added
+
+    /**
+     * @brief create creates the next PnP problem in the sequenxe
+     * @param prob created PnP problem
+     */
+    virtual void create(PnPProblem & prob) const = 0;  //override this
+
+};
+
+
+/**
+ * @brief The ProblemGeneratorEpnP class generates random simulated pnp problems according to the EPnP paper @cite lepetit2009epnp
+ */
+class ProblemGeneratorEpnP : public ProblemGenerator
+{
+public:
+    ProblemGeneratorEpnP(bool centred, size_t n, double noiseSigma, const cv::RNG & rng);
+
+    /**
+     * @brief generateK generates intrinsic matrix
+     * @return intrinsic matrix
+     */
+    Mat generateK() const;
+
+    /**
+     * @brief generateD generates distortion coefficients
+     * @return distortion coefficients
+     */
+    Mat generateD() const;
+
+
+    /**
+     * @brief generateCamPts generates object points defined in camera coordinates
+     * @return object points in camera coordinates
+     */
+    Mat generateCamPts() const;
+
+    /**
+     * @brief generateRandomRvec generates random rotation vector (camera-to-object)
+     * @return rotation vector
+     */
+    Mat generateRandomRvec() const;
+
+private:
+    size_t mNumPts; //numbe of points to generate
+    bool mCentred; //set true if object points are centred (see EPnP paper)
+
+    /**
+     * @brief makeRandomObjectPts makes random set of object points
+     * @param rvecGT rotation vector ground truth
+     * @param tvecGT translation vector ground truth
+     * @param camPts object points in camera coordinates
+     * @param objPts object points in object coordinates
+     */
+    void makeRandomObjectPts(const Mat &rvecGT, const Mat &tvecGT, const Mat &camPts, Mat &objPts) const;
+
+
+protected:
+
+    /**
+     * @brief create creates the next PnP problem in the sequenxe
+     * @param prob created PnP problem
+     */
+    void create(PnPProblem & prob) const;
+
+};
+
+/**
+ * @brief The ProblemGeneratorIPPE class generates random simulated pnp problems based on method in the IPPE paper @ref PnPSolverIPPE
+ */
+class ProblemGeneratorIPPE : public ProblemGenerator
+{
+public:
+    ProblemGeneratorIPPE(int n, double w, double noiseSigma, const cv::RNG & rng);
+
+    /**
+     * @brief slantAngle computes the angle between the object's normal vector and the
+     * line-of-sight passing through the centroid of the object. If this angle is close to
+     * 90 degrees, the problem becomes ill-posed and cannot be solved. slantAngle is used to eliminate poses that
+     * are ill-posed.
+     * @param prob PnP problem
+     * @return the slant angle
+     */
+    double slantAngle(const PnPProblem & prob) const;
+
+    /**
+     * @brief checkProblem checks if PnP problem is valid (object points in front of camera
+     * and slant angle is not beyond 80 degrees
+     * @param prob PnP problem
+     * @return true if check passes, false otherwise
+     */
+    bool checkProblem(const PnPProblem & prob) const;
+
+    /**
+     * @brief generateRandomObjectPts generates a random set of object points.
+     * Created randomly with uniform probability of x and y coordinate in the range +-mW
+     * @param shape sets to OBJECT_COPLANAR
+     * @return
+     */
+    virtual Mat generateObjectPts(ObjectGeometry & shape) const;
+
+    /**
+     * @brief generateRandomRVec generates random rotation vector (object-to-camera)
+     * @return rotation vector
+     */
+    Mat generateRandomRVec() const;
+
+    /**
+     * @brief generateRandomTVec generates random translation vector (object-to-camera)
+     * @return translation vector
+     */
+    Mat generateRandomTVec() const;
+
+    /**
+     * @brief generateK generates intrinsic matrix
+     * @return intrinsic matrix
+     */
+    Mat generateK() const;
+
+    /**
+     * @brief generateD generates distortion coefficients
+     * @return distortion coefficients
+     */
+    Mat generateD() const;
+
+protected:
+    /**
+     * @brief create creates the next PnP problem in the sequenxe
+     * @param prob created PnP problem
+     */
+    void create(PnPProblem & prob) const;
+    int mNumPts; //number of points to generate
+    double mW; //w parameter in page 14 first paragraph of IPPE paper
+
+};
+
+/**
+ * @brief The ProblemGeneratorIPPETag class generates ranom problems with a square object (a tag)
+ */
+class ProblemGeneratorIPPETag : public ProblemGeneratorIPPE
+{
+public:
+
+    /**
+     * @brief ProblemGeneratorIPPETag constructor
+     * @param tagHeight tag height, same as tag width.
+     * @param noiseSigma amount of noise in image points (standard deviation)
+     * @param rng random generator
+     */
+    ProblemGeneratorIPPETag(double tagHeight, double noiseSigma, const cv::RNG & rng);
+
+    /**
+     * @brief generateObjectPts generates object points (4 tag corners)
+     * @param shape sets to OBJECT_SQUARE
+     * @return generated object points
+     */
+    virtual Mat generateObjectPts(ObjectGeometry & shape) const override;
+private:
+
+};
+
+/**
+ * @brief The ProblemGeneratorFormatTest class generates problems used for testing correct problem format
+ */
+class ProblemGeneratorFormatTest : public ProblemGenerator
+{
+public:
+    ProblemGeneratorFormatTest(const cv::RNG & rng, double noise);
+
+    /**
+     * @brief numberOfCases returns the number of problem cases
+     * @return number of problem cases
+     */
+    size_t numberOfCases() const;
+protected:
+
+    /**
+     * @brief create creates the next PnP problem in the sequenxe
+     * @param prob created PnP problem
+     */
+    void create(PnPProblem & prob) const;
+private:
+
+    std::vector<PnPProblem> problems; //set of problems
+    mutable size_t genCounter; //counter used to get the next problem in problems
+};
+
+
+/**
+ * @brief The ProblemGeneratorFailures class generates problems used for testing problems that
+ * cause PnP solvers to fail. This is useful to collect a list of failure modes for each PnPSolver.
+ */
+class ProblemGeneratorFailures : public ProblemGenerator
+{
+public:
+    ProblemGeneratorFailures(const cv::RNG & rng);
+
+    size_t numberOfCases() const;
+
+    /**
+    * @brief generate generates next problem in the problem sequence
+    * @param prob generated problem
+    * @param solverFails vector holding names of all PnPSolvers that fail with prob
+    */
+    void generate(PnPProblem & prob, std::set<string> & solverFails) const;
+
+protected:
+
+    /**
+     * @brief create this does nothing. You should use generate.
+     * @param prob
+     */
+    void create(PnPProblem & prob) const;
+
+private:
+    vector<PnPProblem> problems; //set of problem
+    vector<std::set<string>> solverFails; //solverFails[i] holds names of all PnPSolvers
+    //that fail for the corresponding problem problems[i]
+    mutable int genCounter; //used for keeping track of next problem to generate
+};
+
+
+/**
+ * @brief computeTErr computes translation error according to standard definition (e.g. EPnP and IPPE papers)
+ * @param tvecGT ground truth translation vector
+ * @param tvecEst estimated translation vector
+ * @return relative translation error in range 0 to 1
+ */
+static double computeTErr(const Mat & tvecGT, const Mat & tvecEst)
+{
+    double n1 = cv::norm(tvecGT-tvecEst);
+    double n2 = cv::norm(tvecEst);
+    return n1/n2;
+}
+
+/**
+ * @brief computeTErr computes translation error according to standard definition (e.g. IPPE papers)
+ * @param rvecGT ground truth translation vector
+ * @param rvecEst estimated translation vector
+ * @return rotation error defined as the minimal rotation angle needed to rotate matrix defined by rvecGT
+ * to matrix defined by rvecEst. In the range 0 to 180 (degrees). 0 means no rotation error.
+ */
+static double computeRErr(const Mat & rvecGT, const Mat & rvecEst)
+{
+    Mat RGT, REst;
+    cv::Rodrigues(rvecGT,RGT);
+    cv::Rodrigues(rvecEst,REst);
+
+    Mat RDiff = RGT.t()*REst;
+    Mat rDiffVec;
+    cv::Rodrigues(RDiff,rDiffVec);
+
+    double n1 = cv::norm(rDiffVec) * 2.0*M_PI;
+    return n1;
+}
+
+
+/**
+ * @brief The ErrorTols struct defines error tolerances for testing precision of PnPSolvers and PnPRefiners
+ */
+struct ErrorTols
+{
+    double preRefineTrans,preRefineRot; //pre-refinement translation and rotation tolerences
+    double postRefineTrans,postRefineRot; //post-refinement translation and rotation tolerences
+    ErrorTols();
+};
+
+
+/**
+ * @brief callSolvePnPGeneric wrapper to calling solvePnPGeneric. The PnP problem is defined
+ * by a PnPProblem p and a ProblemFormat f
+ * @param p PnP problem
+ * @param f problem format
+ * @param rvecs rotation vectors
+ * @param tvecs translation vectors
+ * @param solver PnP solver. Use Ptr<PnPSolver>() to indicate no solver is used. If so, then values in rvecs and tvecs are
+ * passed to the PnP refiner.
+ * @param refiner PnP refiner. Use Ptr<PnPRefiner>() to indicate no refiner is used.
+ * @param sortOnReprojErr sort results on reprojection error?
+ * @param reprojectionError reprojection error of solutions
+ * @return number of solutions
+ */
+int callSolvePnPGeneric(const PnPProblem  & p,
+                        const ProblemFormat & f,
+                        vector<Mat> & rvecs, vector<Mat> & tvecs,
+                        const Ptr<PnPSolver> solver, const Ptr<PnPRefiner> refiner,
+                        bool sortOnReprojErr = true,
+                        OutputArray reprojectionError = noArray());
+
+
+//tests precision of all PnP refiners
+TEST(Calib3d_SolvePnPGeneric, refinerPrecision)
+{
+    cv::RNG rng = theRNG();
+    const std::vector<Ptr<PnPRefiner>> refiners = generateRefiners();
+    const vector<ProblemFormat> fs  = ProblemFormat::createAllFormats();
+    const ErrorTols errTols;
+    const ProblemGeneratorFormatTest pg(rng,0.0); //the problem generator. No noise is used.
+    const size_t numGenerations = pg.numberOfCases();
+
+
+    //loop over all problem formats:
+    for (auto & f : fs)
+    {
+        //loop over all PnP problems
+        for (size_t t = 0; t < numGenerations; t++)
+        {
+            Mat rvecInit, tvecInit; // stores the initial rotation and translation estimate
+            PnPProblem prob;
+            pg.generate(prob); //generates the PnP problem
+
+            rvecInit = prob.rvecGT.clone();
+            tvecInit = prob.tvecGT.clone();
+
+            //perturb the initial estimates with small noise:
+            rvecInit.at<double>(0) = rvecInit.at<double>(0) + rng.uniform(-0.1,0.1);
+            rvecInit.at<double>(1) = rvecInit.at<double>(1) + rng.uniform(-0.1,0.1);
+            rvecInit.at<double>(2) = rvecInit.at<double>(2) + rng.uniform(-0.1,0.1);
+
+            tvecInit.at<double>(0) = tvecInit.at<double>(0) + rng.uniform(-1.0,1.0);
+            tvecInit.at<double>(1) = tvecInit.at<double>(1) + rng.uniform(-1.0,1.0);
+            tvecInit.at<double>(2) = tvecInit.at<double>(2) + rng.uniform(-1.0,1.0);
+
+            //loop over all PnP refiners
+            for (auto r : refiners)
+            {
+                if (r.empty())
+                {
+                    continue;
+                }
+                //compute reprojection errors of the initial pose estimate.
+                //this can be done using  callSolvePnPGeneric with an empty PnP solver and
+                //an empty PnP refiner
+                vector<Mat> rvecs, tvecs;
+                Mat reprojErrPreRefine, reprojErrPostRefine;
+                rvecs.push_back(rvecInit.clone());
+                tvecs.push_back(tvecInit.clone());
+
+                auto numSolutions = callSolvePnPGeneric(prob,f,rvecs,tvecs,Ptr<PnPSolver>(), Ptr<PnPRefiner>(), true,reprojErrPreRefine);
+                EXPECT_TRUE(numSolutions==1);
+
+                //refine the initial pose and get its new reprojection error:
+                numSolutions = callSolvePnPGeneric(prob,fs[0],rvecs,tvecs,Ptr<PnPSolver>(), r, true,reprojErrPostRefine);
+
+                //compare reprojection error before and after refinement
+                auto rErrorBefore = reprojErrPreRefine.at<double>(0);
+                auto rErrorAfter = reprojErrPostRefine.at<double>(0);
+                EXPECT_LE(rErrorAfter,rErrorBefore);
+
+                //ensure that the refined poses are accurate within precision limits
+                auto bestRerr = computeRErr(prob.rvecGT,rvecs[0]);
+                auto bestTerr = computeTErr(prob.tvecGT,tvecs[0]);
+
+                EXPECT_LE(bestRerr,1e-6);
+                EXPECT_LE(bestTerr,1e-6);
+            }
+        }
+    }
+}
+
+//tests precision of PnP refiners with noisy inputs.
+//This tests if the final reprojection error is improved
+//using a PnP refiner. This test is only valid for
+//pnp refiners that minimize the reprojection error.
+TEST(Calib3d_SolvePnPGeneric, refinerWithNoise)
+{
+    std::vector<Ptr<PnPRefiner>> refiners;
+    refiners.push_back(PnPRefinerLM::create());
+    refiners.push_back(PnPRefinerLMcpp::create());
+    //vvs dpes not minimizing reproj error
+
+    const vector<ProblemFormat> fs  = ProblemFormat::createAllFormats();
+    const ErrorTols errTols;
+    map<string,float> successRateThresholds;
+    successRateThresholds[solverName(PnPSolverP3PComplete::create())] = 1.0;
+    cv::RNG rng = theRNG();
+    const ProblemGeneratorFormatTest pg(rng,0.05);
+    const auto n = pg.numberOfCases();
+    //loop over problem formats
+    for (auto & f : fs)
+    {
+        //loop over PnP problems
+        for (size_t t = 0; t < n; t++)
+        {
+            Mat rvecInit, tvecInit; //initial pose estimate
+            PnPProblem prob;
+            pg.generate(prob);
+            rvecInit = prob.rvecGT.clone();
+            tvecInit = prob.tvecGT.clone();
+
+            //perturb initial pose estimates by small noise
+            rvecInit.at<double>(0) = rvecInit.at<double>(0) + rng.uniform(-0.1,0.1);
+            rvecInit.at<double>(1) = rvecInit.at<double>(1) + rng.uniform(-0.1,0.1);
+            rvecInit.at<double>(2) = rvecInit.at<double>(2) + rng.uniform(-0.1,0.1);
+
+            tvecInit.at<double>(0) = tvecInit.at<double>(0) + rng.uniform(-1.0,1.0);
+            tvecInit.at<double>(1) = tvecInit.at<double>(1) + rng.uniform(-1.0,1.0);
+            tvecInit.at<double>(2) = tvecInit.at<double>(2) + rng.uniform(-1.0,1.0);
+
+            //loop over PnP refiners
+            for (auto r : refiners)
+            {
+                if (r.empty())
+                {
+                    //don't consider an empty refiner
+                    continue;
+                }
+
+                //compute reprojection error before refinement:
+                vector<Mat> rvecs, tvecs;
+                Mat reprojErrPreRefine, reprojErrPostRefine;
+                rvecs.push_back(rvecInit.clone());
+                tvecs.push_back(tvecInit.clone());
+
+                auto numSolutions = callSolvePnPGeneric(prob,f,rvecs,tvecs,Ptr<PnPSolver>(), Ptr<PnPRefiner>(), true,reprojErrPreRefine);
+                EXPECT_TRUE(numSolutions==1);
+
+                //refine and re-compute reprojection error:
+                numSolutions = callSolvePnPGeneric(prob,fs[0],rvecs,tvecs,Ptr<PnPSolver>(), r, true,reprojErrPostRefine);
+                auto rErrorBefore = reprojErrPreRefine.at<double>(0);
+                auto rErrorAfter = reprojErrPostRefine.at<double>(0);
+                //ensure reprojection error after refinement is lower than before refinement
+                EXPECT_LE(rErrorAfter,rErrorBefore);
+            }
+        }
+    }
+}
+
+/**
+ * @brief runMethods runs all combinations of PnPSolvers and PnPRefiners on PnP problems generated by a PnP problem generator.
+ * If a PnPSolver cannot solve a given PnP problem then the test is skipped. This occurs if
+ * e.g. the number of points in the PnP problem is not compatible with the PnPSolver (such as 5 points and PnPSolverP3P)
+ * It is also skipped if the PnP solver cannot solve the problem because of its geometry. For example, if the PnP solver
+ * only works with co-planar points, and the PnP problem has non-coplanar points.
+ * @param probGenerator PnP problem generator
+ * @param probFormat PnP problem format
+ * @param numGenerations number of problems to generate
+ * @param errTols error tolerances used for indicating if a solution is correct
+ * @param successRateThresholds. For each PnPSolver, we define a success rate criteria.
+ * This gives the proportion of successfully solved problems needed to pass the test.
+ * For example,if successRateThresholds["solver"] = 1 then for the test to pass, all problems must be solved with
+ * the PnPSolver named "solver" to the error tolerance defined in errTols.
+ * If a PnP solver's name is not in successRateThresholds then it's success rate threshold is defined as 1.0
+ * @return if the test passes or fails. The method returns on the first failed test.
+ */
+bool runMethods(const std::vector<Ptr<ProblemGenerator>> & probGenerator,
+                const ProblemFormat & probFormat,
+                int numGenerations,
+                const ErrorTols & errTols,
+                const map<string,float> & successRateThresholds);
+
+
+//tests precision of all PnPSolver and PnPRefiner combinations, for all PnP problem formats.
+TEST(Calib3d_SolvePnPGeneric, formats)
+{
+    const vector<ProblemFormat> fs  = ProblemFormat::createAllFormats();
+    const ErrorTols errTols;
+    map<string,float> successRateThresholds;
+    auto rng = theRNG();
+    std::vector<Ptr<ProblemGenerator>> probGenerator;
+    auto pPtr = makePtr<ProblemGeneratorFormatTest>(rng,0.0);
+    probGenerator.push_back(pPtr);
+    const size_t numTrials = pPtr->numberOfCases();
+    for (auto & f : fs)
+    {
+        auto succ = runMethods(probGenerator,f,numTrials,errTols,successRateThresholds);
+        if (!succ)
+        {
+            cout << "failed for format " << printProblemFormat(f) << endl;
+        }
+        EXPECT_TRUE(succ);
+    }
+}
+
+//tests precision of all PnPSolver and PnPRefiner combinations for 3D (non-coplanar) objects
+TEST(Calib3d_SolvePnPGeneric, precision3DObjects1)
+{
+    const int numGenerations = 100; //number of generated problems
+    const ErrorTols errTols;
+
+    map<string,float> successRateThresholds;
+    successRateThresholds[solverName(PnPSolverP3PComplete::create())] = 0.6; //PnPSolverP3P fails with default errTols
+    successRateThresholds[solverName(PnPSolverEPnP3D::create())] = 0.3; //PnPSolverEPnP3D fails often with 4 points
+
+    ProblemFormat f;
+    auto rng = theRNG();
+
+    //define problem generators with number of points varying from 3 to 4
+    std::vector<Ptr<ProblemGenerator>> probGenerator;
+    probGenerator.push_back(makePtr<ProblemGeneratorEpnP>(true,3,0.0,rng));
+    probGenerator.push_back(makePtr<ProblemGeneratorEpnP>(true,4,0.0,rng));
+    probGenerator.push_back(makePtr<ProblemGeneratorEpnP>(false,3,0.0,rng));
+    probGenerator.push_back(makePtr<ProblemGeneratorEpnP>(false,4,0.0,rng));
+
+    EXPECT_TRUE(runMethods(probGenerator,f,numGenerations,errTols,successRateThresholds));
+}
+
+
+//tests precision of all PnPSolver and PnPRefiner combinations for 3D (non-coplanar) objects
+TEST(Calib3d_SolvePnPGeneric, precision3DObjects2)
+{
+    const int numGenerations = 100; //number of generated problems
+    const ErrorTols errTols;
+
+    map<string,float> successRateThresholds;
+    ProblemFormat f;
+    auto rng = theRNG();
+
+    //define problem generators with number of points varying from 5 to 100
+    std::vector<Ptr<ProblemGenerator>> probGenerator;
+    probGenerator.push_back(makePtr<ProblemGeneratorEpnP>(true,5,0.0,rng));
+    probGenerator.push_back(makePtr<ProblemGeneratorEpnP>(true,6,0.0,rng));
+    probGenerator.push_back(makePtr<ProblemGeneratorEpnP>(true,10,0.0,rng));
+    probGenerator.push_back(makePtr<ProblemGeneratorEpnP>(true,100,0.0,rng));
+    probGenerator.push_back(makePtr<ProblemGeneratorEpnP>(false,5,0.0,rng));
+    probGenerator.push_back(makePtr<ProblemGeneratorEpnP>(false,6,0.0,rng));
+    probGenerator.push_back(makePtr<ProblemGeneratorEpnP>(false,10,0.0,rng));
+    probGenerator.push_back(makePtr<ProblemGeneratorEpnP>(false,100,0.0,rng));
+
+    EXPECT_TRUE(runMethods(probGenerator,f,numGenerations,errTols,successRateThresholds));
+}
+
+//tests precision of all PnPSolver and PnPRefiner combinations for non-coplanar objects
+TEST(Calib3d_SolvePnPGeneric, precisionCoPlanarObjects1)
+{
+    const int numGenerations = 100;
+    const ErrorTols errTols;
+
+    map<string,float> successRateThresholds;
+    successRateThresholds[solverName(PnPSolverP3PComplete::create())] = 0.6;
+    successRateThresholds[solverName(PnPSolverZhang::create())] = 0.7;
+
+    const ProblemFormat f;
+    auto rng = theRNG();
+
+    //define problem generators with number of points varying from 3 to 100
+    std::vector<Ptr<ProblemGenerator>> probGenerator;
+    probGenerator.push_back(makePtr<ProblemGeneratorIPPE>(3,300,0.0,rng));
+    probGenerator.push_back(makePtr<ProblemGeneratorIPPE>(4,300,0.0,rng));
+    probGenerator.push_back(makePtr<ProblemGeneratorIPPE>(5,300,0.0,rng));
+    probGenerator.push_back(makePtr<ProblemGeneratorIPPE>(6,300,0.0,rng));
+    probGenerator.push_back(makePtr<ProblemGeneratorIPPE>(10,300,0.0,rng));
+    probGenerator.push_back(makePtr<ProblemGeneratorIPPE>(100,300,0.0,rng));
+
+    EXPECT_TRUE(runMethods(probGenerator,f,numGenerations,errTols,successRateThresholds));
+}
+
+//tests precision of all PnPSolver and PnPRefiner combinations for 3D (non-coplanar) objects.
+//These objects are smaller than those defined in the previous test.
+TEST(Calib3d_SolvePnPGeneric, precisionCoPlanarObjects2)
+{
+    //same as zeroNoiseCoPlanarObjects1 but with smaller objects
+    const int numTrials = 100;
+    const ErrorTols errTols;
+
+    map<string,float> successRateThresholds;
+    successRateThresholds[solverName(PnPSolverP3PComplete::create())] = 0.1; //PnPSolverP3P fails often to meet desired precision
+    successRateThresholds[solverName(PnPSolverZhang::create())] = 0.1;  //PnPSolverZhang fails often to meet desired precision
+
+    const ProblemFormat f;
+    auto rng = theRNG();
+
+    std::vector<Ptr<ProblemGenerator>> probGenerator;
+    probGenerator.push_back(makePtr<ProblemGeneratorIPPE>(3,100,0.0,rng));
+    probGenerator.push_back(makePtr<ProblemGeneratorIPPE>(4,100,0.0,rng));
+    probGenerator.push_back(makePtr<ProblemGeneratorIPPE>(5,100,0.0,rng));
+    probGenerator.push_back(makePtr<ProblemGeneratorIPPE>(6,100,0.0,rng));
+    probGenerator.push_back(makePtr<ProblemGeneratorIPPE>(10,100,0.0,rng));
+    probGenerator.push_back(makePtr<ProblemGeneratorIPPE>(100,100,0.0,rng));
+
+    EXPECT_TRUE(runMethods(probGenerator,f,numTrials,errTols,successRateThresholds));
+}
+
+//tests precision of all PnPSolver and PnPRefiner combinations for tage objects.
+TEST(Calib3d_SolvePnPGeneric, precisionTagObjects)
+{
+    const int numTrials = 100;
+    const ErrorTols errTols;
+
+    map<string,float> successRateThresholds;
+    successRateThresholds[solverName(PnPSolverP3PComplete::create())] = 0.9;
+    successRateThresholds[solverName(PnPSolverZhang::create())] = 0.9;
+
+    const ProblemFormat f;
+    auto rng = theRNG();
+
+    std::vector<Ptr<ProblemGenerator>> probGenerator;
+    probGenerator.push_back(makePtr<ProblemGeneratorIPPETag>(300,0.0,rng));
+    probGenerator.push_back(makePtr<ProblemGeneratorIPPETag>(1000,0.0,rng));
+
+    EXPECT_TRUE(runMethods(probGenerator,f,numTrials,errTols,successRateThresholds));
+}
+
+
+//tests PnP solver failure cases. There exist some inputs for which a PnP solver
+//cannot solve the problem. If the problem is actually solvable, then this indicates
+//a limitation of the solver algorithm. It is useful to maintain a list of these cases.
+TEST(Calib3d_SolvePnPGeneric, solverFailures)
+{
+    const std::vector<Ptr<PnPSolver>> solvers = generateSolvers();
+    ProblemFormat f;
+    auto rng = theRNG();
+
+    //the problem generator:
+    ProblemGeneratorFailures pg(rng);
+
+    double accTol = 1e-2; //pass precision tolerance
+    const auto numCases = pg.numberOfCases();
+
+    //loop over all cases:
+    for (size_t t = 0; t < numCases; t++)
+    {
+        Mat rvecInit, tvecInit; //initial pose estimate
+        //generate problem:
+        PnPProblem prob;
+        std::set<string> solverFails;
+        pg.generate(prob,solverFails);
+        for (auto s : solvers)
+        {
+            if (!s->geometryWarn(prob.oPts,prob.imgPts))
+            {
+                //ignore the solver if it cannot handle the geometry of the problem
+                continue;
+            }
+
+            //try to solve the problem:
+            vector<Mat> rvecs, tvecs;
+            Mat reprojErrs;
+            auto numSolutions = callSolvePnPGeneric(prob,f,rvecs,tvecs,s, Ptr<PnPRefiner>(), true,reprojErrs);
+            if (solverFails.find(solverName(s)) == solverFails.end())
+            {
+                //solver is not known to fail on this problem, so verify
+                EXPECT_TRUE(numSolutions>0);
+                if (numSolutions>0)
+                {
+                    double bestReprojErr = reprojErrs.at<double>(0);
+                    if (bestReprojErr>=accTol)
+                    {
+                        cout <<"solver " << solverName(s) << " failed but it was not in failure list for case " << t << std::endl;
+                    }
+                    EXPECT_TRUE(bestReprojErr<accTol);
+                }
+            }
+            else {
+                //solver is known to fail on this problem, so verify
+                if (numSolutions>0)
+                {
+                    double bestReprojErr = reprojErrs.at<double>(0);
+                    if (bestReprojErr<accTol)
+                    {
+                        cout <<"solver " << solverName(s) << " passed but it was in failure list for case " << t << std::endl;
+                    }
+                    EXPECT_TRUE(bestReprojErr>=accTol);
+                }
+            }
+        }
+    }
+}
+
+
+size_t PnPProblem::getNumPts() const
+{
+    return static_cast<size_t>(oPts.rows);
+}
+
+ProblemFormat::ProblemFormat(): doubleObjectPoints(true), doubleIntrinsics(true), doubleDistCoeffs(true),
+    doubleImagePoints(true), objShape(O_MAT_1CH_Nx3), imgShape(I_MAT_1CH_Nx2)
+{
+
+}
+
+string printProblemFormat(const ProblemFormat & f)
+{
+    string out;
+
+    out = "doubleObjectPoints: " + std::to_string(static_cast<int>(f.doubleObjectPoints)) + " " +
+            "doubleImagePoints: " + std::to_string(static_cast<int>(f.doubleImagePoints)) + " " +
+            "doubleIntrinsics: " + std::to_string(static_cast<int>(f.doubleIntrinsics)) + " " +
+            "objShape: " + std::to_string(static_cast<int>(f.objShape)) + " " +
+            "imgShape: " + std::to_string(static_cast<int>(f.imgShape));
+    return out;
+}
+
+vector<ProblemFormat> ProblemFormat::createAllFormats()
+{
+    vector<ProblemFormat> formats;
+    for (bool objDouble : { false, true })
+    {
+        for (bool imgDouble : { false, true })
+        {
+            for (bool distDouble : { false, true })
+            {
+                for (bool intrinsDouble : { false, true })
+                {
+                    for ( int opsInt = 0; opsInt != OPS_LEN; opsInt++ )
+                    {
+                        for ( int ipsInt = 0; ipsInt != IPS_LEN; ipsInt++ )
+                        {
+                            ProblemFormat f;
+                            f.doubleObjectPoints = objDouble;
+                            f.doubleImagePoints = imgDouble;
+                            f.doubleIntrinsics = intrinsDouble;
+                            f.doubleDistCoeffs = distDouble;
+                            f.objShape = static_cast<ObjectPointShape>(opsInt);
+                            f.imgShape = static_cast<ImagePointShape>(ipsInt);
+                            formats.push_back(f);
+                        }
+                    }
+                }
+            }
+        }
+    }
+    return formats;
+}
+
+
+ProblemGenerator::ProblemGenerator(const RNG &rng, double noiseSigma): mRng(rng), mNoiseSigma(noiseSigma)
+{
+
+}
+
+ProblemGenerator::~ProblemGenerator() {}
+
+void ProblemGenerator::generate(PnPProblem &prob) const
+{
+    create(prob);
+    CV_Assert(frontOfCameraCheck(prob));
+    addWhiteNoiseImgPts(prob);
+}
+
+Mat ProblemGenerator::toCameraCoords(const PnPProblem &prob) const
+{
+    Mat R;
+    cv::Rodrigues(prob.rvecGT,R);
+    const auto n = prob.getNumPts();
+    Mat camPts(static_cast<int>(n),3,CV_64FC1);
+    for (size_t i = 0; i < n; i++)
+    {
+        cv::Mat p(3,1,CV_64FC1);
+        int iint = static_cast<int>(i);
+        p.at<double>(0) = prob.oPts.at<double>(iint,0);
+        p.at<double>(1) = prob.oPts.at<double>(iint,1);
+        p.at<double>(2) = prob.oPts.at<double>(iint,2);
+
+        p = R*p + prob.tvecGT;
+
+        camPts.at<double>(iint,0) = p.at<double>(0);
+        camPts.at<double>(iint,1) = p.at<double>(1);
+        camPts.at<double>(iint,2) = p.at<double>(2);
+    }
+    return camPts;
+}
+
+Mat ProblemGenerator::getCentroid(const Mat &pts) const
+{
+    const int n = pts.rows;
+    cv::Mat c(3,1,CV_64FC1);
+    c.setTo(0.0);
+    for (int i = 0; i < n; i++)
+    {
+        c.at<double>(0) = c.at<double>(0) + pts.at<double>(i,0);
+        c.at<double>(1) = c.at<double>(1) + pts.at<double>(i,1);
+        c.at<double>(2) = c.at<double>(2) + pts.at<double>(i,2);
+    }
+    c = c /static_cast<double>(n);
+    return c;
+}
+
+bool ProblemGenerator::frontOfCameraCheck(const PnPProblem &prob) const
+{
+    const Mat camPts = toCameraCoords(prob);
+    const auto n = prob.getNumPts();
+    bool front = true;
+    for (size_t i = 0; i < n; i++)
+    {
+        front = front & (camPts.at<double>(static_cast<int>(i),2)>0.0);
+    }
+    return front;
+}
+
+void ProblemGenerator::addWhiteNoiseImgPts(PnPProblem &prob) const
+{
+    for (size_t i = 0; i < prob.getNumPts(); i++)
+    {
+        int iint = static_cast<int>(i);
+        prob.imgPts.at<double>(iint,0) = prob.imgPts.at<double>(iint,0) + mRng.gaussian(mNoiseSigma);
+        prob.imgPts.at<double>(iint,1) = prob.imgPts.at<double>(iint,1) + mRng.gaussian(mNoiseSigma);
+    }
+}
+
+ProblemGeneratorEpnP::ProblemGeneratorEpnP(bool centred, size_t n, double noiseSigma, const RNG &rng): ProblemGenerator(rng,noiseSigma), mNumPts(n), mCentred(centred)
+{
+
+}
+
+void ProblemGeneratorEpnP::create(PnPProblem &prob) const
+{
+    prob.objectShape = OBJECT_3D;
+    prob.K = generateK();
+    prob.d = generateD();
+    Mat camPts = generateCamPts();
+    Mat r(3,1,CV_64FC1); r.setTo(0.0);
+    Mat t(3,1,CV_64FC1); t.setTo(0.0);
+    cv::projectPoints(camPts,r,t,prob.K,prob.d,prob.imgPts);
+    Mat cent = getCentroid(camPts);
+
+    prob.tvecGT = Mat(3,1,CV_64FC1);
+    prob.tvecGT.at<double>(0) = cent.at<double>(0);
+    prob.tvecGT.at<double>(1) = cent.at<double>(1);
+    prob.tvecGT.at<double>(2) = cent.at<double>(2);
+
+    Mat rv = generateRandomRvec();
+    prob.rvecGT = Mat(3,1,CV_64FC1);
+    rv.copyTo(prob.rvecGT);
+
+    makeRandomObjectPts(prob.rvecGT,prob.tvecGT,camPts,prob.oPts);
+
+}
+
+Mat ProblemGeneratorEpnP::generateK() const
+{
+    Mat K(3,3,CV_64FC1);
+    K.setTo(0.0);
+    K.at<double>(0,0) = 800.0;
+    K.at<double>(1,1) = 800.0;
+    K.at<double>(2,2) = 1.0;
+    K.at<double>(0,2) = 320.0;
+    K.at<double>(1,2) = 240.0;
+    return K;
+}
+
+Mat ProblemGeneratorEpnP::generateD() const
+{
+    return Mat();
+}
+
+
+Mat ProblemGeneratorEpnP::generateCamPts() const
+{
+    Mat camPts = Mat(static_cast<int>(mNumPts),3,CV_64FC1);
+    for (size_t i = 0; i < mNumPts; i++)
+    {
+        const auto iint = static_cast<int>(i);
+        if (mCentred)
+        {
+            camPts.at<double>(iint,0) = mRng.uniform(-2.0, 2.0);
+            camPts.at<double>(iint,1) = mRng.uniform(-2.0, 2.0);
+            camPts.at<double>(iint,2) = mRng.uniform(4.0, 8.0);
+        }
+        else {
+            camPts.at<double>(iint,0) = mRng.uniform(1.0, 2.0);
+            camPts.at<double>(iint,1) = mRng.uniform(1.0, 2.0);
+            camPts.at<double>(iint,2) = mRng.uniform(4.0, 8.0);
+        }
+    }
+    return camPts;
+}
+
+Mat ProblemGeneratorEpnP::generateRandomRvec() const
+{
+    double alpha=mRng.uniform(0.0, 2.0*M_PI);
+    double beta=mRng.uniform(0.0, 2.0*M_PI);
+    double gamma=mRng.uniform(0.0, 2.0*M_PI);
+
+    Mat R(3,3,CV_64FC1);
+    R.setTo(0.0);
+
+    R.at<double>(0,0)=cos(alpha)*cos(gamma)-cos(beta)*sin(alpha)*sin(gamma);
+    R.at<double>(1,0)=cos(gamma)*sin(alpha)+cos(alpha)*cos(beta)*sin(gamma);
+    R.at<double>(2,0)=sin(beta)*sin(gamma);
+
+    R.at<double>(0,1)=-cos(beta)*cos(gamma)*sin(alpha)-cos(alpha)*sin(gamma);
+    R.at<double>(1,1)=cos(alpha)*cos(beta)*cos(gamma)-sin(alpha)*sin(gamma);
+    R.at<double>(2,1)=cos(gamma)*sin(beta);
+
+    R.at<double>(0,2)=sin(alpha)*sin(beta);
+    R.at<double>(1,2)=-cos(alpha)*sin(beta);
+    R.at<double>(2,2)=cos(beta);
+
+    Mat rvec;
+    cv::Rodrigues(R,rvec);
+    return rvec;
+}
+
+void ProblemGeneratorEpnP::makeRandomObjectPts(const Mat &rvecGT, const Mat &tvecGT, const Mat &camPts, Mat &objPts) const
+{
+    Mat R,rt;
+    cv::Rodrigues(rvecGT,R);
+    objPts = Mat(static_cast<int>(mNumPts),3,CV_64FC1);
+    rt = -R.t()*tvecGT;
+    for (size_t i = 0; i < mNumPts; i++)
+    {
+        const auto iint = static_cast<int>(i);
+        cv::Mat p(3,1,CV_64FC1);
+        p.at<double>(0) = camPts.at<double>(iint,0);
+        p.at<double>(1) = camPts.at<double>(iint,1);
+        p.at<double>(2) = camPts.at<double>(iint,2);
+
+        p = R.t()*p + rt;
+        objPts.at<double>(iint,0) = p.at<double>(0);
+        objPts.at<double>(iint,1) = p.at<double>(1);
+        objPts.at<double>(iint,2) = p.at<double>(2);
+    }
+
+}
+
+
+ProblemGeneratorIPPE::ProblemGeneratorIPPE(int n, double w, double noiseSigma, const RNG &rng):  ProblemGenerator(rng,noiseSigma), mNumPts(n), mW(w)
+{
+
+}
+
+void ProblemGeneratorIPPE::create(PnPProblem &prob) const
+{
+    bool foundGoodProblem = false;
+    while (!foundGoodProblem)
+    {
+        prob.K = generateK();
+        prob.d = generateD();
+        prob.tvecGT = generateRandomTVec();
+        prob.rvecGT = generateRandomRVec();
+        prob.oPts = generateObjectPts(prob.objectShape);
+
+        cv::projectPoints(prob.oPts,prob.rvecGT,prob.tvecGT,prob.K,prob.d,prob.imgPts);
+        foundGoodProblem = checkProblem(prob);
+    }
+}
+
+double ProblemGeneratorIPPE::slantAngle(const PnPProblem &prob) const
+{
+    Mat ptsCam = this->toCameraCoords(prob);
+    Mat cCam = this->getCentroid(ptsCam);
+    Mat centroidVec = cCam / cv::norm(cCam);
+
+    Point3d p0, p1, p2, v01, v02;
+    p0.x = ptsCam.at<double>(0,0);
+    p0.y = ptsCam.at<double>(0,1);
+    p0.z = ptsCam.at<double>(0,2);
+
+    p1.x = ptsCam.at<double>(1,0);
+    p1.y = ptsCam.at<double>(1,1);
+    p1.z = ptsCam.at<double>(1,2);
+
+    p2.x = ptsCam.at<double>(2,0);
+    p2.y = ptsCam.at<double>(2,1);
+    p2.z = ptsCam.at<double>(2,2);
+
+    v01 = p1-p0;
+    v02 = p2-p0;
+
+    Point3d crs = v01.cross(v02);
+    double crsnrm = cv::norm(crs);
+    crs.x = crs.x / crsnrm;
+    crs.y = crs.y / crsnrm;
+    crs.z = crs.z / crsnrm;
+
+    Point3d centroidVecp(centroidVec);
+    double dp = centroidVecp.dot(crs);
+    double ang = acos(dp);
+    ang = min(ang,M_PI - ang);
+    double angDeg = 180.0 * (ang / M_PI);
+    return angDeg;
+}
+
+bool ProblemGeneratorIPPE::checkProblem(const PnPProblem &prob) const
+{
+    bool frontCheck = frontOfCameraCheck(prob);
+    bool angCheck = slantAngle(prob)< 80.0;
+    return frontCheck && angCheck;
+}
+
+Mat ProblemGeneratorIPPE::generateObjectPts(ObjectGeometry &shape) const
+{
+    shape = OBJECT_COPLANAR;
+    Mat opts(mNumPts,3,CV_64FC1);
+    for (int i = 0; i < mNumPts; i++)
+    {
+        opts.at<double>(i,0) =  mRng.uniform(-mW / 2.0, mW / 2.0);
+        opts.at<double>(i,1) =  mRng.uniform(-mW / 2.0, mW / 2.0);
+        opts.at<double>(i,2) =  0.0;
+    }
+
+    Mat rv = generateRandomRVec();
+    Mat rMat;
+    cv::Rodrigues(rv, rMat);
+    opts = opts*rMat.t();
+    return opts;
+}
+
+Mat ProblemGeneratorIPPE::generateRandomRVec() const
+{
+    Mat rv(3,1,CV_64FC1);
+    rv.at<double>(0) = mRng.uniform(0.0, 2.0*M_PI);
+    rv.at<double>(1) = mRng.uniform(0.0, 2.0*M_PI);
+    rv.at<double>(2) = mRng.uniform(0.0, 2.0*M_PI);
+    return rv;
+}
+
+Mat ProblemGeneratorIPPE::generateRandomTVec() const
+{
+    Mat K = generateK();
+    cv::Mat p(3,1,CV_64FC1);
+    p.at<double>(0) = mRng.uniform(0.0,640.0);
+    p.at<double>(1) = mRng.uniform(0.0,480.0);
+    p.at<double>(2) = 1.0;
+
+    Mat Kinv;
+    cv::invert(K,Kinv);
+    Mat pu = Kinv*p;
+
+    double dpth = mRng.uniform(K.at<double>(0,0)/2.0,K.at<double>(0,0)*2.0);
+    return pu*dpth;
+}
+
+Mat ProblemGeneratorIPPE::generateK() const
+{
+    Mat K(3,3,CV_64FC1);
+    K.setTo(0.0);
+    K.at<double>(0,0) = 800.0;
+    K.at<double>(1,1) = 800.0;
+    K.at<double>(2,2) = 1.0;
+    K.at<double>(0,2) = 320.0;
+    K.at<double>(1,2) = 240.0;
+    return K;
+}
+
+Mat ProblemGeneratorIPPE::generateD() const
+{
+    return Mat();
+}
+
+ProblemGeneratorIPPETag::ProblemGeneratorIPPETag(double tagHeight, double noiseSigma, const RNG &rng): ProblemGeneratorIPPE(4,tagHeight,noiseSigma,rng)
+{
+
+}
+
+Mat ProblemGeneratorIPPETag::generateObjectPts(ObjectGeometry &shape) const
+{
+    shape = OBJECT_SQUARE;
+    Mat opts(mNumPts,3,CV_64FC1);
+    opts.setTo(0.0);
+    opts.at<double>(0,0) = -mW / 2.0;
+    opts.at<double>(0,1) =  mW / 2.0;
+    opts.at<double>(1,0) =  mW / 2.0;
+    opts.at<double>(1,1) =  mW / 2.0;
+    opts.at<double>(2,0) =  mW / 2.0;
+    opts.at<double>(2,1) =  -mW / 2.0;
+    opts.at<double>(3,0) = -mW / 2.0;
+    opts.at<double>(3,1) =  -mW / 2.0;
+
+    return opts;
+}
+
+
+
+ProblemGeneratorFormatTest::ProblemGeneratorFormatTest(const RNG &rng, double noise): genCounter(0), ProblemGenerator(rng,noise)
+{
+    {
+        PnPProblem prob;
+        prob.K = Mat::eye(3,3,CV_64FC1);
+        prob.d = Mat::zeros(1,5,CV_64FC1);
+        prob.rvecGT = Mat(Matx31d(0.9072420896651262, 0.09226497171882152, 0.8880772883671504));
+        prob.tvecGT = Mat(Matx31d(7.376333362427632, 8.434449036856979, 13.79801619778456));
+        prob.oPts = (Mat_<double>(3, 3) << 12.00604, -2.8654366, 18.472504,
+                     7.6863389, 4.9355154, 11.146358,
+                     14.260933, 2.8320458, 12.582781);
+        projectPoints(prob.oPts, prob.rvecGT, prob.tvecGT, prob.K, prob.d, prob.imgPts);
+        problems.push_back(prob);
+    }
+    {
+        PnPProblem prob;
+        prob.K = Mat::eye(3,3,CV_64FC1);
+        prob.d = Mat::zeros(1,5,CV_64FC1);
+        prob.rvecGT = Mat(Matx31d(0.9072420896651262, 0.09226497171882152, 0.8880772883671504));
+        prob.tvecGT = Mat(Matx31d(7.376333362427632, 8.434449036856979, 13.79801619778456));
+        prob.oPts = (Mat_<double>(4, 3) << 12.00604, -2.8654366, 18.472504,
+                     7.6863389, 4.9355154, 11.146358,
+                     14.260933, 2.8320458, 12.582781,
+                     3.4562225, 8.2668982, 11.300434);
+        projectPoints(prob.oPts, prob.rvecGT, prob.tvecGT, prob.K, prob.d, prob.imgPts);
+        problems.push_back(prob);
+    }
+    {
+        PnPProblem prob;
+        prob.K = Mat::eye(3,3,CV_64FC1);
+        prob.d = Mat::zeros(1,5,CV_64FC1);
+        prob.rvecGT = Mat(Matx31d(0.9072420896651262, 0.09226497171882152, 0.8880772883671504));
+        prob.tvecGT = Mat(Matx31d(7.376333362427632, 8.434449036856979, 13.79801619778456));
+        prob.oPts = (Mat_<double>(5, 3) << 12.00604, -2.8654366, 18.472504,
+                     7.6863389, 4.9355154, 11.146358,
+                     14.260933, 2.8320458, 12.582781,
+                     3.4562225, 8.2668982, 11.300434,
+                     10.00604,  2.8654366, 15.472504);
+        projectPoints(prob.oPts, prob.rvecGT, prob.tvecGT, prob.K, prob.d, prob.imgPts);
+        problems.push_back(prob);
+    }
+    {
+        PnPProblem prob;
+        prob.K = Mat::eye(3,3,CV_64FC1);
+        prob.d = Mat::zeros(1,5,CV_64FC1);
+        prob.rvecGT = Mat(Matx31d(0.9072420896651262, 0.09226497171882152, 0.8880772883671504));
+        prob.tvecGT = Mat(Matx31d(7.376333362427632, 8.434449036856979, 13.79801619778456));
+        prob.oPts = (Mat_<double>(6, 3) << 12.00604, -2.8654366, 18.472504,
+                     7.6863389, 4.9355154, 11.146358,
+                     14.260933, 2.8320458, 12.582781,
+                     3.4562225, 8.2668982, 11.300434,
+                     10.00604,  2.8654366, 15.472504,
+                     -4.6863389, 5.9355154, 13.146358);
+        projectPoints(prob.oPts, prob.rvecGT, prob.tvecGT, prob.K, prob.d, prob.imgPts);
+        problems.push_back(prob);
+    }
+    {
+        PnPProblem prob;
+        prob.K = Mat::eye(3,3,CV_64FC1);
+        prob.d = Mat::zeros(1,5,CV_64FC1);
+        prob.rvecGT = Mat(Matx31d(0.9072420896651262, 0.09226497171882152, 0.8880772883671504));
+        prob.tvecGT = Mat(Matx31d(7.376333362427632, 8.434449036856979, 13.79801619778456));
+        prob.oPts = (Mat_<double>(6, 3) <<  0, -2.8654366, 18.472504,
+                     0, 4.9355154, 11.146358,
+                     0, 2.8320458, 12.582781,
+                     0, 8.2668982, 11.300434,
+                     0,  2.8654366, 15.472504,
+                     0, 5.9355154, 13.146358);
+        projectPoints(prob.oPts, prob.rvecGT, prob.tvecGT, prob.K, prob.d, prob.imgPts);
+        problems.push_back(prob);
+    }
+
+}
+
+size_t ProblemGeneratorFormatTest::numberOfCases() const
+{
+    return problems.size();
+}
+
+void ProblemGeneratorFormatTest::create(PnPProblem &prob) const
+{
+    if (genCounter< problems.size())
+    {
+        prob = problems.at(genCounter);
+        genCounter++;
+    }
+    else {
+        prob = problems.at( problems.size()-1);
+    }
+}
+
+
+
+
+
+ErrorTols::ErrorTols(): preRefineTrans(1e-2), preRefineRot(1e-2),
+    postRefineTrans(1e-5), postRefineRot(1e-5)
+{
+
+}
+
+
+int callSolvePnPGeneric(const PnPProblem  & p,
+                        const ProblemFormat & f,
+                        vector<Mat> & rvecs, vector<Mat> & tvecs,
+                        const Ptr<PnPSolver> solver, const Ptr<PnPRefiner> refiner,
+                        bool sortOnReprojErr,
+                        OutputArray reprojectionError)
+{
+
+    //some ugly logic needed to handle all possible problem formats. Would be nice
+    //to template this but it doesn't work well with OpenCV's dynamic Mat typing.
+    Mat intrinsics, dist;
+    if (!f.doubleIntrinsics){p.K.convertTo(intrinsics,CV_32FC1);}
+    else {p.K.convertTo(intrinsics,CV_64FC1);}
+
+    if (!f.doubleDistCoeffs){p.d.convertTo(dist,CV_32FC1);}
+    else {p.d.convertTo(dist,CV_64FC1);}
+
+    Mat oPts, iPts;
+    if (!f.doubleObjectPoints){p.oPts.convertTo(oPts,CV_32FC1);}
+    else {p.oPts.convertTo(oPts,CV_64FC1);}
+
+    if (!f.doubleImagePoints){p.imgPts.convertTo(iPts,CV_32FC1);}
+    else {p.imgPts.convertTo(iPts,CV_64FC1);}
+
+    CV_Assert(p.oPts.isContinuous());
+    CV_Assert(p.imgPts.isContinuous());
+
+    bool isVecObjPts = false;
+    bool isVecImgPts = false;
+
+    switch (f.objShape)
+    {
+    case O_MAT_1CH_Nx3:{
+        oPts = oPts.reshape(1);
+        break;}
+    case O_MAT_3CH_1xN:{
+        oPts = oPts.reshape(3);
+        break;}
+    case MAT_3CH_Nx1:{
+        oPts = oPts.reshape(3).t();
+        break;}
+    case VEC_POINT3:{
+        isVecObjPts = true;
+        break;}
+    }
+
+    switch (f.imgShape)
+    {
+    case I_MAT_1CH_Nx2:{
+        iPts = iPts.reshape(1);
+        break;
+    }
+    case I_MAT2CH_1xN:{
+        iPts = iPts.reshape(2);
+        break;}
+    case I_MAT2CH_Nx1:{
+        iPts = iPts.reshape(2).t();
+        break;}
+    case VEC_POINT2:{
+        isVecImgPts = true;
+        break;}
+    }
+    int numSolutions;
+    if ((!isVecObjPts) && (!isVecImgPts))
+    {
+        numSolutions = solvePnPGeneric(oPts,iPts,intrinsics,dist,rvecs,tvecs,solver,refiner,sortOnReprojErr,reprojectionError);
+    }
+    else {
+        if (isVecObjPts)
+        {
+            if (f.doubleObjectPoints)
+            {
+                Point3d* ptr = (Point3d*)oPts.data;
+                vector<Point3d> optsVec(ptr, ptr + p.getNumPts());
+                if (isVecImgPts)
+                {
+                    if (f.doubleImagePoints)
+                    {
+                        Point2d* ptr = (Point2d*)iPts.data;
+                        vector<Point2d> iptsVec(ptr, ptr + p.getNumPts());
+                        numSolutions = solvePnPGeneric(optsVec,iptsVec,intrinsics,dist,rvecs,tvecs,solver,refiner,sortOnReprojErr,reprojectionError);
+                    }
+                    else {
+                        Point2f* ptr = (Point2f*)iPts.data;
+                        vector<Point2f> iptsVec(ptr, ptr + p.getNumPts());
+                        numSolutions = solvePnPGeneric(optsVec,iptsVec,intrinsics,dist,rvecs,tvecs,solver,refiner,sortOnReprojErr,reprojectionError);
+                    }
+
+                }
+                else {
+                    numSolutions = solvePnPGeneric(optsVec,iPts,intrinsics,dist,rvecs,tvecs,solver,refiner,sortOnReprojErr,reprojectionError);
+                }
+            }
+            else {
+
+                Point3f* ptr = (Point3f*)oPts.data;
+                vector<Point3f> optsVec(ptr, ptr + p.getNumPts());
+                if (isVecImgPts)
+                {
+                    if (f.doubleImagePoints)
+                    {
+                        Point2d* ptr = (Point2d*)iPts.data;
+                        vector<Point2d> iptsVec(ptr, ptr + p.getNumPts());
+                        numSolutions = solvePnPGeneric(optsVec,iptsVec,intrinsics,dist,rvecs,tvecs,solver,refiner,sortOnReprojErr,reprojectionError);
+                    }
+                    else {
+                        Point2f* ptr = (Point2f*)iPts.data;
+                        vector<Point2f> iptsVec(ptr, ptr + p.getNumPts());
+                        numSolutions = solvePnPGeneric(optsVec,iptsVec,intrinsics,dist,rvecs,tvecs,solver,refiner,sortOnReprojErr,reprojectionError);
+                    }
+
+                }
+                else {
+                    numSolutions = solvePnPGeneric(optsVec,iPts,intrinsics,dist,rvecs,tvecs,solver,refiner,sortOnReprojErr,reprojectionError);
+                }
+            }
+        }
+        else
+        {
+            if (f.doubleImagePoints)
+            {
+                Point2d* ptr = (Point2d*)iPts.data;
+                vector<Point2d> iptsVec(ptr, ptr + p.getNumPts());
+                numSolutions = solvePnPGeneric(oPts,iptsVec,intrinsics,dist,rvecs,tvecs,solver,refiner,sortOnReprojErr,reprojectionError);
+            }
+            else {
+                Point2f* ptr = (Point2f*)iPts.data;
+                vector<Point2f> iptsVec(ptr, ptr + p.getNumPts());
+                numSolutions = solvePnPGeneric(oPts,iptsVec,intrinsics,dist,rvecs,tvecs,solver,refiner,sortOnReprojErr,reprojectionError);
+            }
+        }
+    }
+    return numSolutions;
+}
+bool runMethods(const std::vector<Ptr<ProblemGenerator>> & probGenerator,
+                const ProblemFormat & probFormat,
+                int numTrials,
+                const ErrorTols & errTols,
+                const map<string,float> & successRateThresholds)
+{
+
+    std::vector<Ptr<PnPRefiner>> refiners = generateRefiners();
+    std::vector<Ptr<PnPSolver>> solvers = generateSolvers();
+
+    for (int pgIndx = 0; pgIndx < probGenerator.size(); pgIndx++)
+    {
+        auto pg  = probGenerator[pgIndx];
+        std::vector<PnPProblem> probs;
+        for (int t = 0; t < numTrials; t++)
+        {
+            PnPProblem p;
+            pg->generate(p);
+            probs.push_back(p);
+        }
+        for (auto s : solvers)
+        {
+            for (auto r : refiners)
+            {
+                double rErrorTol,tErrorTol;
+                if (r.empty())
+                {
+                    rErrorTol = errTols.preRefineRot;
+                    tErrorTol = errTols.preRefineTrans;
+                }
+                else {
+                    rErrorTol = errTols.postRefineRot;
+                    tErrorTol = errTols.postRefineTrans;
+                }
+                int numSuccesses = 0;
+                int numAttempts = 0;
+                for (int numTrial  = 0; numTrial < numTrials; numTrial++)
+                {
+                    PnPProblem p = probs[numTrial];
+
+                    if (p.objectShape == OBJECT_3D && (s->requiresPlanarObject() | s->requiresPlanarTagObject()))
+                    {
+                        continue;
+                    }
+                    if (p.objectShape == OBJECT_COPLANAR && (s->requiresPlanarTagObject() | s->requires3DObject()))
+                    {
+                        continue;
+                    }
+
+                    if (s->geometryWarn(p.oPts,p.imgPts))
+                    {
+                        numAttempts++;
+                        vector<Mat> rvecs,tvecs;
+                        Mat reprojErrs;
+                        const int numSolutions = callSolvePnPGeneric(p,probFormat,rvecs,tvecs,s,r,true,reprojErrs);
+                        if (numSolutions==0)
+                        {
+                            continue;
+                        }
+                        for (int i = 0; i < numSolutions -1 ; i++)
+                        {
+                            if (reprojErrs.at<double>(i+1) + 1e-6 <reprojErrs.at<double>(i))
+                            {
+                                cout << "Failure. Reprojection error order for problemGenerator: " << pgIndx << ", solver: " << solverName(s) << ", refiner: " << refinerName(r) << " is not descending" <<  endl;
+                                return false;
+                            }
+
+                        }
+                        double bestRerr = computeRErr(p.rvecGT,rvecs[0]);
+                        double bestTerr = computeTErr(p.tvecGT,tvecs[0]);
+
+                        for (int s = 1; s < numSolutions; s++)
+                        {
+                            double tErr = computeTErr(p.tvecGT,tvecs[s]);
+                            double rErr = computeRErr(p.rvecGT,rvecs[s]);
+
+                            if (tErr<bestTerr)
+                            {
+                                bestTerr = tErr;
+                            }
+                            if (rErr<bestRerr)
+                            {
+                                bestRerr = rErr;
+                            }
+                        }
+                        if ((bestRerr>rErrorTol) | (bestTerr>tErrorTol))
+                        {
+                            continue;
+                        }
+                        numSuccesses++;
+                    }
+                }
+                if (numAttempts!=0)
+                {
+                    float rateThresh;
+                    if ( successRateThresholds.find(solverName(s)) == successRateThresholds.end() ) {
+                        rateThresh = 1.0;
+                    } else {
+                        rateThresh = successRateThresholds.at(solverName(s));
+                    }
+
+                    float rate = (float)numSuccesses/(float)numAttempts;
+                    if (rate<rateThresh)
+                    {
+                        cout << "Failure. Success rate for problemGenerator: " << pgIndx << ", solver: " << solverName(s) << ", refiner: " << refinerName(r) << " is " << rate <<  endl;
+                        return false;
+                    }
+
+                }
+            }
+        }
+    }
+    return true;
+}
+
+
+size_t ProblemGeneratorFailures::numberOfCases() const
+{
+    return problems.size();
+}
+
+void ProblemGeneratorFailures::create(PnPProblem &prob) const
+{
+
+}
+
+void ProblemGeneratorFailures::generate(PnPProblem &prob, std::set<string> &sf) const
+{
+    size_t c = genCounter;
+    if (c >= problems.size())
+    {
+        c = problems.size()-1;
+    }
+    else {
+        genCounter++;
+    }
+    prob = problems.at(c);
+    sf = solverFails.at(c);
+
+}
+
+ProblemGeneratorFailures::ProblemGeneratorFailures(const RNG &rng) : genCounter(0), ProblemGenerator(rng, 0.0)
+{
+    {
+        PnPProblem prob;
+        double wdth = 20.0;
+        prob.K = Mat::eye(3,3,CV_64FC1);
+        prob.d = Mat::zeros(1,5,CV_64FC1);
+        prob.rvecGT = Mat(Matx31d(0.9072420896651262, 0.09226497171882152, 0.8880772883671504));
+        prob.tvecGT = Mat(Matx31d(7.376333362427632, 8.434449036856979, 13.79801619778456));
+        prob.oPts = (Mat_<double>(4, 3) << -wdth / 2.0,  wdth / 2.0, 0,
+                      wdth / 2.0,  wdth / 2.0, 0,
+                      wdth / 2.0, -wdth / 2.0, 0,
+                      -wdth / 2.0,  -wdth / 2.0, 0);
+        projectPoints(prob.oPts, prob.rvecGT, prob.tvecGT, prob.K, prob.d, prob.imgPts);
+        problems.push_back(prob);
+        std::set<string> fails = {solverName(PnPSolverZhang::create()), //degenerate configuration for Zhang implementation
+                                  solverName(PnPSolverDLT::create())};  //degenerate configuration (co-planar object)
+ // object not square
+        solverFails.push_back(fails);
+    }
+
+    {
+        PnPProblem prob;
+        prob.K = Mat::eye(3,3,CV_64FC1);
+        prob.d = Mat::zeros(1,5,CV_64FC1);
+        prob.rvecGT = Mat(Matx31d(0.9072420896651262, 0.09226497171882152, 0.8880772883671504));
+        prob.tvecGT = Mat(Matx31d(7.376333362427632, 8.434449036856979, 13.79801619778456));
+        prob.oPts = (Mat_<double>(6, 3) << 12.00604, -2.8654366, 0,
+                     7.6863389, 4.9355154, 0,
+                     14.260933, 2.8320458, 0,
+                     3.4562225, 8.2668982, 0,
+                     10.00604,  2.8654366, 0,
+                     -4.6863389, 5.9355154, 0);
+        projectPoints(prob.oPts, prob.rvecGT, prob.tvecGT, prob.K, prob.d, prob.imgPts);
+        problems.push_back(prob);
+        std::set<string> fails = {solverName(PnPSolverZhang::create()), //degenerate configuration (unknown reason)
+                                  solverName(PnPSolverDLT::create()),  //degenerate configuration (co-planar object)
+                                  solverName(PnPSolverIPPESquare::create())}; // object not square
+        solverFails.push_back(fails);
+    }
+
+    {
+        PnPProblem prob; // co-planar example
+        prob.K = (Mat_<double>(3, 3) << 800, 0, 320,
+                  0, 800, 240,
+                  0,0,1);
+        prob.d = Mat::zeros(1,5,CV_64FC1);
+        prob.rvecGT = Mat();
+        prob.tvecGT = Mat();
+        prob.oPts = (Mat_<double>(5, 3) <<125.4911844070545, -141.6464856132886, 2.1035540918816,
+                15.56081673101709, 146.8582460146606, -0.6425994678159378,
+                77.35197691728332, 126.1239553416953, 0.1238782914796581,
+                126.3792277274632, -141.7947735558015, 2.113747132966365,
+                -102.4491895513266, 48.7904801704582, -1.350008425218844);
+        prob.imgPts = (Mat_<double>(5, 2) << 211.3172241863653, 258.7392188558077,
+                146.542077788426, 323.4183455020655,
+                154.4149593976568, 343.2930499685378,
+                211.4546846117436, 259.0963999763775,
+                154.1419661384817, 239.8017744206864);
+        problems.push_back(prob);
+        std::set<string> fails = {solverName(PnPSolverDLT::create()),
+                                  solverName(PnPSolverIPPESquare::create()),  //object not square
+                                  solverName(PnPSolverEPnP3D::create())}; //degenerate configuration (unknown reason)
+        solverFails.push_back(fails);
+    }
+
+    {
+        PnPProblem prob;
+        prob.K = (Mat_<double>(3, 3) << 800, 0, 320,
+                  0, 800, 240,
+                  0,0,1);
+        prob.d = Mat::zeros(1,5,CV_64FC1);
+        prob.rvecGT = Mat();
+        prob.tvecGT = Mat();
+        prob.oPts = (Mat_<double>(5, 3) << 54.50760732727414, 90.39974569723172, -16.5218902770834,
+                -95.25016027022656, -8.847660462565507, -35.9773337903876,
+                -85.12253904642863, 67.30713703924297, -64.86019671380593,
+                124.1790118960073, 68.85302191697907, 21.97830276201228,
+                53.77392574181322, 53.10773695353704, -0.6115363162486993);
+        prob.imgPts = (Mat_<double>(5, 2) << 440.469369662699, 164.2063931256786,
+                303.5507874119983, 116.5595777076413,
+                351.0364046372179, 99.7866968358413,
+                460.30720787272, 199.614585342235,
+                417.6648503519709, 172.2234198887387);
+        problems.push_back(prob);
+        std::set<string> fails = {solverName(PnPSolverDLT::create()),
+                                  solverName(PnPSolverIPPESquare::create()),  //object not square
+                                  solverName(PnPSolverEPnP3D::create())}; //degenerate configuration (unknown reason)
+        solverFails.push_back(fails);
+    }
+
+    {
+        PnPProblem prob;
+        prob.K = (Mat_<double>(3, 3) << 547.9413023815613, 0, 298.3554570004314,
+                0, 548.17724002728, 230.6219405198623,
+                0, 0, 1);
+        prob.d = Mat::zeros(1,5,CV_64FC1);
+        prob.rvecGT = Mat();
+        prob.tvecGT = Mat();
+        prob.oPts = (Mat_<double>(4, 3) << 13, 11, 10,
+                13, 3, 2,
+                7, 5, 4,
+                11, 3, 2);
+        prob.imgPts = (Mat_<double>(4, 2) << -8, 8,
+                0, 8,
+                -2, 2,
+                0, 6);
+        problems.push_back(prob);
+        std::set<string> fails = {solverName(PnPSolverP3PComplete::create()), //degenerate configuration (unknown reason)
+                                  solverName(PnPSolverZhang::create())}; //degenerate configuration (unknown reason)
+        solverFails.push_back(fails);
+    }
+
+}
+
+}
+} // namespace

--- a/modules/calib3d/test/test_solvepnp_ransac.cpp
+++ b/modules/calib3d/test/test_solvepnp_ransac.cpp
@@ -611,7 +611,12 @@ protected:
         projectedPoints.resize(opoints.size());
         projectPoints(opoints, trueRvec, trueTvec, intrinsics, distCoeffs, projectedPoints);
 
-        int num_of_solutions = solveP3P(opoints, projectedPoints, intrinsics, distCoeffs, rvecs, tvecs, method);
+        SolvePnPMethod m = (SolvePnPMethod)method;
+        Ptr<PnPSolver> solver;
+        Ptr<PnPRefiner> refiner;
+        cvtSolvePnPFlag(m,false,solver,refiner);
+        int num_of_solutions = solvePnPGeneric(opoints, projectedPoints, intrinsics, distCoeffs, rvecs, tvecs, solver,refiner);
+
         if (num_of_solutions != (int) rvecs.size() || num_of_solutions != (int) tvecs.size() || num_of_solutions == 0)
         {
             return false;
@@ -826,8 +831,8 @@ TEST(Calib3d_SolvePnPRansac, double_support)
     Mat R, t, RF, tF;
     vector<int> inliers;
 
-    solvePnPRansac(points3dF, points2dF, intrinsics, cv::Mat(), RF, tF, true, 100, 8.f, 0.999, inliers, cv::SOLVEPNP_P3P);
-    solvePnPRansac(points3d, points2d, intrinsics, cv::Mat(), R, t, true, 100, 8.f, 0.999, inliers, cv::SOLVEPNP_P3P);
+    solvePnPRansac(points3dF, points2dF, intrinsics, cv::Mat(), RF, tF, true, 100, 8.f, 0.999, inliers, cv::SOLVEPNP_AP3P); //SOLVEPNP_P3P cannot solve this problem
+    solvePnPRansac(points3d, points2d, intrinsics, cv::Mat(), R, t, true, 100, 8.f, 0.999, inliers, cv::SOLVEPNP_AP3P); //SOLVEPNP_P3P cannot solve this problem
 
     EXPECT_LE(cvtest::norm(R, Mat_<double>(RF), NORM_INF), 1e-3);
     EXPECT_LE(cvtest::norm(t, Mat_<double>(tF), NORM_INF), 1e-3);
@@ -984,9 +989,13 @@ TEST(Calib3d_SolvePnP, input_type)
         //solvePnPGeneric
         {
             vector<Mat> Rs, ts, RFs, tFs;
+            SolvePnPMethod m = (SolvePnPMethod)method;
+            Ptr<PnPSolver> s;
+            Ptr<PnPRefiner> r;
+            cvtSolvePnPFlag(m,false,s,r);
 
-            int res1 = solvePnPGeneric(points3dF, points2dF, Matx33f(intrinsics), Mat(), RFs, tFs, false, (SolvePnPMethod)method);
-            int res2 = solvePnPGeneric(points3d, points2d, intrinsics, Mat(), Rs, ts, false, (SolvePnPMethod)method);
+            int res1 = solvePnPGeneric(points3dF, points2dF, Matx33f(intrinsics), Mat(), RFs, tFs, s, r);
+            int res2 = solvePnPGeneric(points3d, points2d, intrinsics, Mat(), Rs, ts, s, r);
 
             EXPECT_GT(res1, 0);
             EXPECT_GT(res2, 0);
@@ -1010,9 +1019,13 @@ TEST(Calib3d_SolvePnP, input_type)
         }
         {
             vector<Mat> R1s, t1s, R2s, t2s;
+            SolvePnPMethod m = (SolvePnPMethod)method;
+            Ptr<PnPSolver> s;
+            Ptr<PnPRefiner> r;
+            cvtSolvePnPFlag(m,false,s,r);
 
-            int res1 = solvePnPGeneric(points3dF, points2d, intrinsics, Mat(), R1s, t1s, false, (SolvePnPMethod)method);
-            int res2 = solvePnPGeneric(points3d, points2dF, intrinsics, Mat(), R2s, t2s, false, (SolvePnPMethod)method);
+            int res1 = solvePnPGeneric(points3dF, points2d, intrinsics, Mat(), R1s, t1s, s, r);
+            int res2 = solvePnPGeneric(points3d, points2dF, intrinsics, Mat(), R2s, t2s, s, r);
 
             EXPECT_GT(res1, 0);
             EXPECT_GT(res2, 0);
@@ -1037,9 +1050,13 @@ TEST(Calib3d_SolvePnP, input_type)
         {
             vector<Mat_<float> > R1s, t2s;
             vector<Mat_<double> > R2s, t1s;
+            SolvePnPMethod m = (SolvePnPMethod)method;
+                            Ptr<PnPSolver> s;
+                            Ptr<PnPRefiner> r;
+                            cvtSolvePnPFlag(m,false,s,r);
 
-            int res1 = solvePnPGeneric(points3dF, points2d, intrinsics, Mat(), R1s, t1s, false, (SolvePnPMethod)method);
-            int res2 = solvePnPGeneric(points3d, points2dF, intrinsics, Mat(), R2s, t2s, false, (SolvePnPMethod)method);
+            int res1 = solvePnPGeneric(points3dF, points2d, intrinsics, Mat(), R1s, t1s, s, r);
+            int res2 = solvePnPGeneric(points3d, points2dF, intrinsics, Mat(), R2s, t2s, s, r);
 
             EXPECT_GT(res1, 0);
             EXPECT_GT(res2, 0);
@@ -1065,9 +1082,13 @@ TEST(Calib3d_SolvePnP, input_type)
         {
             vector<Matx31f> R1s, t2s;
             vector<Matx31d> R2s, t1s;
+            SolvePnPMethod m = (SolvePnPMethod)method;
+                            Ptr<PnPSolver> s;
+                            Ptr<PnPRefiner> r;
+                            cvtSolvePnPFlag(m,false,s,r);
 
-            int res1 = solvePnPGeneric(points3dF, points2d, intrinsics, Mat(), R1s, t1s, false, (SolvePnPMethod)method);
-            int res2 = solvePnPGeneric(points3d, points2dF, intrinsics, Mat(), R2s, t2s, false, (SolvePnPMethod)method);
+            int res1 = solvePnPGeneric(points3dF, points2d, intrinsics, Mat(), R1s, t1s, s, r);
+            int res2 = solvePnPGeneric(points3d, points2dF, intrinsics, Mat(), R2s, t2s, s, r);
 
             EXPECT_GT(res1, 0);
             EXPECT_GT(res2, 0);
@@ -1090,9 +1111,13 @@ TEST(Calib3d_SolvePnP, input_type)
             //solveP3P
             {
                 vector<Mat> Rs, ts, RFs, tFs;
+                SolvePnPMethod m = (SolvePnPMethod)method;
+                                Ptr<PnPSolver> s;
+                                Ptr<PnPRefiner> r;
+                                cvtSolvePnPFlag(m,false,s,r);
 
-                int res1 = solveP3P(points3dF, points2dF, Matx33f(intrinsics), Mat(), RFs, tFs, (SolvePnPMethod)method);
-                int res2 = solveP3P(points3d, points2d, intrinsics, Mat(), Rs, ts, (SolvePnPMethod)method);
+                int res1 = solvePnPGeneric(points3dF, points2dF, Matx33f(intrinsics), Mat(), RFs, tFs, s, r);
+                int res2 = solvePnPGeneric(points3d, points2d, intrinsics, Mat(), Rs, ts, s, r);
 
                 EXPECT_GT(res1, 0);
                 EXPECT_GT(res2, 0);
@@ -1116,9 +1141,13 @@ TEST(Calib3d_SolvePnP, input_type)
             }
             {
                 vector<Mat> R1s, t1s, R2s, t2s;
+                SolvePnPMethod m = (SolvePnPMethod)method;
+                                Ptr<PnPSolver> s;
+                                Ptr<PnPRefiner> r;
+                                cvtSolvePnPFlag(m,false,s,r);
 
-                int res1 = solveP3P(points3dF, points2d, intrinsics, Mat(), R1s, t1s, (SolvePnPMethod)method);
-                int res2 = solveP3P(points3d, points2dF, intrinsics, Mat(), R2s, t2s, (SolvePnPMethod)method);
+                int res1 = solvePnPGeneric(points3dF, points2d, intrinsics, Mat(), R1s, t1s, s, r);
+                int res2 = solvePnPGeneric(points3d, points2dF, intrinsics, Mat(), R2s, t2s, s, r);
 
                 EXPECT_GT(res1, 0);
                 EXPECT_GT(res2, 0);
@@ -1143,9 +1172,13 @@ TEST(Calib3d_SolvePnP, input_type)
             {
                 vector<Mat_<float> > R1s, t2s;
                 vector<Mat_<double> > R2s, t1s;
+                SolvePnPMethod m = (SolvePnPMethod)method;
+                Ptr<PnPSolver> s;
+                Ptr<PnPRefiner> r;
+                cvtSolvePnPFlag(m,false,s,r);
 
-                int res1 = solveP3P(points3dF, points2d, intrinsics, Mat(), R1s, t1s, (SolvePnPMethod)method);
-                int res2 = solveP3P(points3d, points2dF, intrinsics, Mat(), R2s, t2s, (SolvePnPMethod)method);
+                int res1 = solvePnPGeneric(points3dF, points2d, intrinsics, Mat(), R1s, t1s, s, r);
+                int res2 = solvePnPGeneric(points3d, points2dF, intrinsics, Mat(), R2s, t2s, s, r);
 
                 EXPECT_GT(res1, 0);
                 EXPECT_GT(res2, 0);
@@ -1172,8 +1205,12 @@ TEST(Calib3d_SolvePnP, input_type)
                 vector<Matx31f> R1s, t2s;
                 vector<Matx31d> R2s, t1s;
 
-                int res1 = solveP3P(points3dF, points2d, intrinsics, Mat(), R1s, t1s, (SolvePnPMethod)method);
-                int res2 = solveP3P(points3d, points2dF, intrinsics, Mat(), R2s, t2s, (SolvePnPMethod)method);
+                SolvePnPMethod m = (SolvePnPMethod)method;
+                Ptr<PnPSolver> solver;
+                Ptr<PnPRefiner> refiner;
+                cvtSolvePnPFlag(m,false,solver,refiner);
+                int res1 = solvePnPGeneric(points3dF, points2d, intrinsics, Mat(), R1s, t1s, solver,refiner);
+                int res2 = solvePnPGeneric(points3d, points2dF, intrinsics, Mat(), R2s, t2s, solver,refiner);
 
                 EXPECT_GT(res1, 0);
                 EXPECT_GT(res2, 0);
@@ -1427,8 +1464,13 @@ TEST(Calib3d_SolvePnP, generic)
                 }
 
                 vector<double> reprojectionErrors;
-                solvePnPGeneric(p3d, p2d, intrinsics, noArray(), rvecs_est, tvecs_est, false, (SolvePnPMethod)method,
-                                noArray(), noArray(), reprojectionErrors);
+                SolvePnPMethod m = (SolvePnPMethod)method;
+                                Ptr<PnPSolver> s;
+                                Ptr<PnPRefiner> r;
+                                cvtSolvePnPFlag(m,false,s,r);
+
+                solvePnPGeneric(p3d, p2d, intrinsics, noArray(), rvecs_est, tvecs_est, s, r,
+                                true, reprojectionErrors);
 
                 EXPECT_TRUE(!rvecs_est.empty());
                 EXPECT_TRUE(rvecs_est.size() == tvecs_est.size() && tvecs_est.size() == reprojectionErrors.size());
@@ -1495,8 +1537,10 @@ TEST(Calib3d_SolvePnP, generic)
                 }
 
                 vector<double> reprojectionErrors;
-                solvePnPGeneric(p3f, p2f, intrinsics, noArray(), rvecs_est, tvecs_est, false, (SolvePnPMethod)method,
-                                noArray(), noArray(), reprojectionErrors);
+                Ptr<PnPSolver> s;
+                     Ptr<PnPRefiner> r;
+                     cvtSolvePnPFlag((SolvePnPMethod)method,false,s,r);
+                solvePnPGeneric(p3f, p2f, intrinsics, noArray(), rvecs_est, tvecs_est, s, r, true, reprojectionErrors);
 
                 EXPECT_TRUE(!rvecs_est.empty());
                 EXPECT_TRUE(rvecs_est.size() == tvecs_est.size() && tvecs_est.size() == reprojectionErrors.size());
@@ -1540,34 +1584,38 @@ TEST(Calib3d_SolvePnP, refine3pts)
         projectPoints(p3d, rvec_ground_truth, tvec_ground_truth, intrinsics, noArray(), p2d);
 
         {
-            Mat rvec_est = (Mat_<double>(3,1) << 0.2, -0.1, 0.6);
-            Mat tvec_est = (Mat_<double>(3,1) << 0.05, -0.05, 1.0);
-
-            solvePnPRefineLM(p3d, p2d, intrinsics, noArray(), rvec_est, tvec_est);
+            Mat rvec_init = (Mat_<double>(3,1) << 0.2, -0.1, 0.6);
+            Mat tvec_init = (Mat_<double>(3,1) << 0.05, -0.05, 1.0);
+            vector<Mat> rs, ts;
+            rs.push_back(rvec_init.clone());
+            ts.push_back(tvec_init.clone());
+            solvePnPGeneric(p3d, p2d, intrinsics, noArray(), rs, ts, Ptr<PnPSolver>(),PnPRefinerLMcpp::create());
 
             cout << "\nmethod: Levenberg-Marquardt" << endl;
             cout << "rvec_ground_truth: " << rvec_ground_truth.t() << std::endl;
-            cout << "rvec_est: " << rvec_est.t() << std::endl;
+            cout << "rvec_est: " << rs[0].t() << std::endl;
             cout << "tvec_ground_truth: " << tvec_ground_truth.t() << std::endl;
-            cout << "tvec_est: " << tvec_est.t() << std::endl;
+            cout << "tvec_est: " << ts[0].t() << std::endl;
 
-            EXPECT_LE(cvtest::norm(rvec_ground_truth, rvec_est, NORM_INF), 1e-6);
-            EXPECT_LE(cvtest::norm(tvec_ground_truth, tvec_est, NORM_INF), 1e-6);
+            EXPECT_LE(cvtest::norm(rvec_ground_truth, rs[0], NORM_INF), 1e-6);
+            EXPECT_LE(cvtest::norm(tvec_ground_truth, ts[0], NORM_INF), 1e-6);
         }
         {
-            Mat rvec_est = (Mat_<double>(3,1) << 0.2, -0.1, 0.6);
-            Mat tvec_est = (Mat_<double>(3,1) << 0.05, -0.05, 1.0);
-
-            solvePnPRefineVVS(p3d, p2d, intrinsics, noArray(), rvec_est, tvec_est);
+            Mat rvec_init = (Mat_<double>(3,1) << 0.2, -0.1, 0.6);
+            Mat tvec_init = (Mat_<double>(3,1) << 0.05, -0.05, 1.0);
+            vector<Mat> rs, ts;
+            rs.push_back(rvec_init.clone());
+            ts.push_back(tvec_init.clone());
+            solvePnPGeneric(p3d, p2d, intrinsics, noArray(), rs, ts, Ptr<PnPSolver>(),PnPRefinerVVS::create());
 
             cout << "\nmethod: Virtual Visual Servoing" << endl;
             cout << "rvec_ground_truth: " << rvec_ground_truth.t() << std::endl;
-            cout << "rvec_est: " << rvec_est.t() << std::endl;
+            cout << "rvec_est: " << rs[0].t() << std::endl;
             cout << "tvec_ground_truth: " << tvec_ground_truth.t() << std::endl;
-            cout << "tvec_est: " << tvec_est.t() << std::endl;
+            cout << "tvec_est: " << ts[0].t() << std::endl;
 
-            EXPECT_LE(cvtest::norm(rvec_ground_truth, rvec_est, NORM_INF), 1e-6);
-            EXPECT_LE(cvtest::norm(tvec_ground_truth, tvec_est, NORM_INF), 1e-6);
+            EXPECT_LE(cvtest::norm(rvec_ground_truth, rs[0], NORM_INF), 1e-6);
+            EXPECT_LE(cvtest::norm(tvec_ground_truth, ts[0], NORM_INF), 1e-6);
         }
     }
 
@@ -1589,34 +1637,38 @@ TEST(Calib3d_SolvePnP, refine3pts)
         projectPoints(p3d, rvec_ground_truth, tvec_ground_truth, intrinsics, noArray(), p2d);
 
         {
-            Mat rvec_est = (Mat_<float>(3,1) << -0.5f, 0.2f, 0.2f);
-            Mat tvec_est = (Mat_<float>(3,1) << 0.0f, 0.2f, 1.0f);
-
-            solvePnPRefineLM(p3d, p2d, intrinsics, noArray(), rvec_est, tvec_est);
+            Mat rvec_init = (Mat_<float>(3,1) << -0.5f, 0.2f, 0.2f);
+            Mat tvec_init = (Mat_<float>(3,1) << 0.0f, 0.2f, 1.0f);
+            vector<Mat> rs, ts;
+            rs.push_back(rvec_init.clone());
+            ts.push_back(tvec_init.clone());
+            solvePnPGeneric(p3d, p2d, intrinsics, noArray(), rs, ts, Ptr<PnPSolver>(),PnPRefinerLMcpp::create());
 
             cout << "\nmethod: Levenberg-Marquardt" << endl;
             cout << "rvec_ground_truth: " << rvec_ground_truth.t() << std::endl;
-            cout << "rvec_est: " << rvec_est.t() << std::endl;
+            cout << "rvec_est: " << rs[0].t() << std::endl;
             cout << "tvec_ground_truth: " << tvec_ground_truth.t() << std::endl;
-            cout << "tvec_est: " << tvec_est.t() << std::endl;
+            cout << "tvec_est: " << ts[0].t() << std::endl;
 
-            EXPECT_LE(cvtest::norm(rvec_ground_truth, rvec_est, NORM_INF), 1e-6);
-            EXPECT_LE(cvtest::norm(tvec_ground_truth, tvec_est, NORM_INF), 1e-6);
+            EXPECT_LE(cvtest::norm(rvec_ground_truth, rs[0], NORM_INF), 1e-6);
+            EXPECT_LE(cvtest::norm(tvec_ground_truth, ts[0], NORM_INF), 1e-6);
         }
         {
-            Mat rvec_est = (Mat_<float>(3,1) << -0.5f, 0.2f, 0.2f);
-            Mat tvec_est = (Mat_<float>(3,1) << 0.0f, 0.2f, 1.0f);
-
-            solvePnPRefineVVS(p3d, p2d, intrinsics, noArray(), rvec_est, tvec_est);
+            Mat rvec_init = (Mat_<float>(3,1) << -0.5f, 0.2f, 0.2f);
+            Mat tvec_init = (Mat_<float>(3,1) << 0.0f, 0.2f, 1.0f);
+            vector<Mat> rs, ts;
+            rs.push_back(rvec_init.clone());
+            ts.push_back(tvec_init.clone());
+            solvePnPGeneric(p3d, p2d, intrinsics, noArray(), rs, ts, Ptr<PnPSolver>(),PnPRefinerVVS::create());
 
             cout << "\nmethod: Virtual Visual Servoing" << endl;
             cout << "rvec_ground_truth: " << rvec_ground_truth.t() << std::endl;
-            cout << "rvec_est: " << rvec_est.t() << std::endl;
+            cout << "rvec_est: " << rs[0].t() << std::endl;
             cout << "tvec_ground_truth: " << tvec_ground_truth.t() << std::endl;
-            cout << "tvec_est: " << tvec_est.t() << std::endl;
+            cout << "tvec_est: " << ts[0].t() << std::endl;
 
-            EXPECT_LE(cvtest::norm(rvec_ground_truth, rvec_est, NORM_INF), 1e-6);
-            EXPECT_LE(cvtest::norm(tvec_ground_truth, tvec_est, NORM_INF), 1e-6);
+            EXPECT_LE(cvtest::norm(rvec_ground_truth, rs[0], NORM_INF), 1e-6);
+            EXPECT_LE(cvtest::norm(tvec_ground_truth, ts[0], NORM_INF), 1e-6);
         }
     }
 }
@@ -1659,34 +1711,38 @@ TEST(Calib3d_SolvePnP, refine)
             EXPECT_LE(cvtest::norm(tvec_ground_truth, tvec_est, NORM_INF), 1e-6);
         }
         {
-            Mat rvec_est = (Mat_<double>(3,1) << 0.1, -0.1, 0.1);
-            Mat tvec_est = (Mat_<double>(3,1) << 0.0, -0.5, 1.0);
-
-            solvePnPRefineLM(p3d, p2d, intrinsics, noArray(), rvec_est, tvec_est);
+            Mat rvec_init = (Mat_<double>(3,1) << 0.1, -0.1, 0.1);
+            Mat tvec_init = (Mat_<double>(3,1) << 0.0, -0.5, 1.0);
+            vector<Mat> rs, ts;
+            rs.push_back(rvec_init.clone());
+            ts.push_back(tvec_init.clone());
+            solvePnPGeneric(p3d, p2d, intrinsics, noArray(), rs, ts, Ptr<PnPSolver>(),PnPRefinerLMcpp::create());
 
             cout << "\nmethod: Levenberg-Marquardt (C++ API)" << endl;
             cout << "rvec_ground_truth: " << rvec_ground_truth.t() << std::endl;
-            cout << "rvec_est: " << rvec_est.t() << std::endl;
+            cout << "rvec_est: " << rs[0].t() << std::endl;
             cout << "tvec_ground_truth: " << tvec_ground_truth.t() << std::endl;
-            cout << "tvec_est: " << tvec_est.t() << std::endl;
+            cout << "tvec_est: " << ts[0].t() << std::endl;
 
-            EXPECT_LE(cvtest::norm(rvec_ground_truth, rvec_est, NORM_INF), 1e-6);
-            EXPECT_LE(cvtest::norm(tvec_ground_truth, tvec_est, NORM_INF), 1e-6);
+            EXPECT_LE(cvtest::norm(rvec_ground_truth, rs[0], NORM_INF), 1e-6);
+            EXPECT_LE(cvtest::norm(tvec_ground_truth, ts[0], NORM_INF), 1e-6);
         }
         {
-            Mat rvec_est = (Mat_<double>(3,1) << 0.1, -0.1, 0.1);
-            Mat tvec_est = (Mat_<double>(3,1) << 0.0, -0.5, 1.0);
-
-            solvePnPRefineVVS(p3d, p2d, intrinsics, noArray(), rvec_est, tvec_est);
+            Mat rvec_init = (Mat_<double>(3,1) << 0.1, -0.1, 0.1);
+            Mat tvec_init = (Mat_<double>(3,1) << 0.0, -0.5, 1.0);
+            vector<Mat> rs, ts;
+            rs.push_back(rvec_init.clone());
+            ts.push_back(tvec_init.clone());
+            solvePnPGeneric(p3d, p2d, intrinsics, noArray(), rs, ts, Ptr<PnPSolver>(),PnPRefinerVVS::create());
 
             cout << "\nmethod: Virtual Visual Servoing" << endl;
             cout << "rvec_ground_truth: " << rvec_ground_truth.t() << std::endl;
-            cout << "rvec_est: " << rvec_est.t() << std::endl;
+            cout << "rvec_est: " << rs[0].t() << std::endl;
             cout << "tvec_ground_truth: " << tvec_ground_truth.t() << std::endl;
-            cout << "tvec_est: " << tvec_est.t() << std::endl;
+            cout << "tvec_est: " << ts[0].t() << std::endl;
 
-            EXPECT_LE(cvtest::norm(rvec_ground_truth, rvec_est, NORM_INF), 1e-6);
-            EXPECT_LE(cvtest::norm(tvec_ground_truth, tvec_est, NORM_INF), 1e-6);
+            EXPECT_LE(cvtest::norm(rvec_ground_truth, rs[0], NORM_INF), 1e-6);
+            EXPECT_LE(cvtest::norm(tvec_ground_truth, ts[0], NORM_INF), 1e-6);
         }
     }
 
@@ -1726,34 +1782,38 @@ TEST(Calib3d_SolvePnP, refine)
             EXPECT_LE(cvtest::norm(tvec_ground_truth, tvec_est, NORM_INF), 1e-6);
         }
         {
-            Mat rvec_est = (Mat_<float>(3,1) << -0.1f, 0.1f, 0.1f);
-            Mat tvec_est = (Mat_<float>(3,1) << 0.0f, 0.0f, 1.0f);
-
-            solvePnPRefineLM(p3d, p2d, intrinsics, noArray(), rvec_est, tvec_est);
+            Mat rvec_init = (Mat_<float>(3,1) << -0.1f, 0.1f, 0.1f);
+            Mat tvec_init = (Mat_<float>(3,1) << 0.0f, 0.0f, 1.0f);
+            vector<Mat> rs, ts;
+            rs.push_back(rvec_init.clone());
+            ts.push_back(tvec_init.clone());
+            solvePnPGeneric(p3d, p2d, intrinsics, noArray(), rs, ts, Ptr<PnPSolver>(),PnPRefinerLMcpp::create());
 
             cout << "\nmethod: Levenberg-Marquardt (C++ API)" << endl;
             cout << "rvec_ground_truth: " << rvec_ground_truth.t() << std::endl;
-            cout << "rvec_est: " << rvec_est.t() << std::endl;
+            cout << "rvec_est: " << rs[0].t() << std::endl;
             cout << "tvec_ground_truth: " << tvec_ground_truth.t() << std::endl;
-            cout << "tvec_est: " << tvec_est.t() << std::endl;
+            cout << "tvec_est: " << ts[0].t() << std::endl;
 
-            EXPECT_LE(cvtest::norm(rvec_ground_truth, rvec_est, NORM_INF), 1e-6);
-            EXPECT_LE(cvtest::norm(tvec_ground_truth, tvec_est, NORM_INF), 1e-6);
+            EXPECT_LE(cvtest::norm(rvec_ground_truth, rs[0], NORM_INF), 1e-6);
+            EXPECT_LE(cvtest::norm(tvec_ground_truth, ts[0], NORM_INF), 1e-6);
         }
         {
-            Mat rvec_est = (Mat_<float>(3,1) << -0.1f, 0.1f, 0.1f);
-            Mat tvec_est = (Mat_<float>(3,1) << 0.0f, 0.0f, 1.0f);
-
-            solvePnPRefineVVS(p3d, p2d, intrinsics, noArray(), rvec_est, tvec_est);
+            Mat rvec_init = (Mat_<float>(3,1) << -0.1f, 0.1f, 0.1f);
+            Mat tvec_init = (Mat_<float>(3,1) << 0.0f, 0.0f, 1.0f);
+            vector<Mat> rs, ts;
+            rs.push_back(rvec_init.clone());
+            ts.push_back(tvec_init.clone());
+            solvePnPGeneric(p3d, p2d, intrinsics, noArray(), rs, ts, Ptr<PnPSolver>(),PnPRefinerVVS::create());
 
             cout << "\nmethod: Virtual Visual Servoing" << endl;
             cout << "rvec_ground_truth: " << rvec_ground_truth.t() << std::endl;
-            cout << "rvec_est: " << rvec_est.t() << std::endl;
+            cout << "rvec_est: " << rs[0].t() << std::endl;
             cout << "tvec_ground_truth: " << tvec_ground_truth.t() << std::endl;
-            cout << "tvec_est: " << tvec_est.t() << std::endl;
+            cout << "tvec_est: " << ts[0].t() << std::endl;
 
-            EXPECT_LE(cvtest::norm(rvec_ground_truth, rvec_est, NORM_INF), 1e-6);
-            EXPECT_LE(cvtest::norm(tvec_ground_truth, tvec_est, NORM_INF), 1e-6);
+            EXPECT_LE(cvtest::norm(rvec_ground_truth, rs[0], NORM_INF), 1e-6);
+            EXPECT_LE(cvtest::norm(tvec_ground_truth, ts[0], NORM_INF), 1e-6);
         }
     }
 
@@ -1808,40 +1868,44 @@ TEST(Calib3d_SolvePnP, refine)
             EXPECT_LT(cvtest::norm(tvec_ground_truth, tvec_est_refine, NORM_INF), cvtest::norm(tvec_ground_truth, tvec_est, NORM_INF));
         }
         {
-            Mat rvec_est_refine = rvec_est.clone(), tvec_est_refine = tvec_est.clone();
-            solvePnPRefineLM(p3d, p2d, intrinsics, noArray(), rvec_est_refine, tvec_est_refine);
+            vector<Mat> rs, ts;
+            rs.push_back(rvec_est.clone());
+            ts.push_back(tvec_est.clone());
+            solvePnPGeneric(p3d, p2d, intrinsics, noArray(), rs, ts, Ptr<PnPSolver>(),PnPRefinerLMcpp::create());
 
             cout << "\nmethod: Levenberg-Marquardt (C++ API)" << endl;
             cout << "rvec_ground_truth: " << rvec_ground_truth.t() << std::endl;
             cout << "rvec_est: " << rvec_est.t() << std::endl;
-            cout << "rvec_est_refine: " << rvec_est_refine.t() << std::endl;
+            cout << "rvec_est_refine: " << rs[0].t() << std::endl;
             cout << "tvec_ground_truth: " << tvec_ground_truth.t() << std::endl;
             cout << "tvec_est: " << tvec_est.t() << std::endl;
-            cout << "tvec_est_refine: " << tvec_est_refine.t() << std::endl;
+            cout << "tvec_est_refine: " << ts[0].t() << std::endl;
 
             EXPECT_LE(cvtest::norm(rvec_ground_truth, rvec_est, NORM_INF), 1e-2);
             EXPECT_LE(cvtest::norm(tvec_ground_truth, tvec_est, NORM_INF), 1e-3);
 
-            EXPECT_LT(cvtest::norm(rvec_ground_truth, rvec_est_refine, NORM_INF), cvtest::norm(rvec_ground_truth, rvec_est, NORM_INF));
-            EXPECT_LT(cvtest::norm(tvec_ground_truth, tvec_est_refine, NORM_INF), cvtest::norm(tvec_ground_truth, tvec_est, NORM_INF));
+            EXPECT_LT(cvtest::norm(rvec_ground_truth, rs[0], NORM_INF), cvtest::norm(rvec_ground_truth, rvec_est, NORM_INF));
+            EXPECT_LT(cvtest::norm(tvec_ground_truth, ts[0], NORM_INF), cvtest::norm(tvec_ground_truth, tvec_est, NORM_INF));
         }
         {
-            Mat rvec_est_refine = rvec_est.clone(), tvec_est_refine = tvec_est.clone();
-            solvePnPRefineVVS(p3d, p2d, intrinsics, noArray(), rvec_est_refine, tvec_est_refine);
+            vector<Mat> rs, ts;
+            rs.push_back(rvec_est.clone());
+            ts.push_back(tvec_est.clone());
+            solvePnPGeneric(p3d, p2d, intrinsics, noArray(), rs, ts, Ptr<PnPSolver>(),PnPRefinerVVS::create());
 
             cout << "\nmethod: Virtual Visual Servoing" << endl;
             cout << "rvec_ground_truth: " << rvec_ground_truth.t() << std::endl;
             cout << "rvec_est: " << rvec_est.t() << std::endl;
-            cout << "rvec_est_refine: " << rvec_est_refine.t() << std::endl;
+            cout << "rvec_est_refine: " << rs[0].t() << std::endl;
             cout << "tvec_ground_truth: " << tvec_ground_truth.t() << std::endl;
             cout << "tvec_est: " << tvec_est.t() << std::endl;
-            cout << "tvec_est_refine: " << tvec_est_refine.t() << std::endl;
+            cout << "tvec_est_refine: " << ts[0].t() << std::endl;
 
             EXPECT_LE(cvtest::norm(rvec_ground_truth, rvec_est, NORM_INF), 1e-2);
             EXPECT_LE(cvtest::norm(tvec_ground_truth, tvec_est, NORM_INF), 1e-3);
 
-            EXPECT_LT(cvtest::norm(rvec_ground_truth, rvec_est_refine, NORM_INF), cvtest::norm(rvec_ground_truth, rvec_est, NORM_INF));
-            EXPECT_LT(cvtest::norm(tvec_ground_truth, tvec_est_refine, NORM_INF), cvtest::norm(tvec_ground_truth, tvec_est, NORM_INF));
+            EXPECT_LT(cvtest::norm(rvec_ground_truth, rs[0], NORM_INF), cvtest::norm(rvec_ground_truth, rvec_est, NORM_INF));
+            EXPECT_LT(cvtest::norm(tvec_ground_truth, ts[0], NORM_INF), cvtest::norm(tvec_ground_truth, tvec_est, NORM_INF));
         }
     }
 }


### PR DESCRIPTION
<!-- Please use this line to close one or multiple issues when this pullrequest gets merged
resolves #15647
-->

### This pullrequest changes
This pull request is designed to fix the problems discussed in #15647

1. A `PnPSolver` base class has been created according to the OpenCV algorithm-based design guidelines. This is derived by classes that implements a PnP solver algorithm, and also for specifying important properties of the PnP solver, implemented as virtual member functions. These include:

- `minPointNumber`: specifies the minimal number of points that can be handled by the solver (e.g. EPnP requires 4 and DLT requires 6)

- `maxPointNumber`: specifies the maximal number of points that can be handled by the solver (e.g. AP3P handles at most 4 points, while others can handle an arbitrary number of points)

- `requires3DObject`: specifies if the PnP solver requires non co-planar model points

- `requiresPlanarObject`: specifies if the PnP solver requires co-planar model points

- `requiresPlanarTagObject`: specifies if the PnP solver requires co-planar model points arranged in a square tag formation

- `artificalDegeneracyWarn`: warns if the object points & image points will cause an artificial degeneracy

2.  The `PnPSolver` class provides the function `geometryWarn` that tests the input object points and image points for whether they will will cause the solver to fail. This involves running basic tests (checking number of points, checking for co-linear points etc.) and also running specific checks for each algorithn, as implemented in `artificalDegeneracyWarn`.

3. All the currently used PnP solvers in OpenCV have been implemented as derived classes of `PnPSolver`: EPnP, DLT, DLS,  P3P, AP3P, Zhang, IPPE and IPPESquare. 

4. A `PnPRefiner` base class has bee created according to the OpenCV algorithm-based design guidelines. This is derived by classes that implements refinement algorithms. All the currently used refinement algorithms in OpenCV have been implemented as derived classes: C API levenberg Marquardt, C++ API Levenberg Marquardt and VVS.

5. The public interfaces: `SolvePnP` and `SolvePnPRansac` are unchanged. When these are called, `PnPSolver` and `PnPRefiner` objects are created according to the flags passed to `SolvePnP` and `SolvePnPRansac` respectively.

6. The public interface: `solvePnPGeneric` has been modified to accept algorithm pointers as arguments, providing a cleaner and generic use with any PnPSolver and PnPRefiner objects.

7. A new test set has been created (test_solve_generic.cpp) that does the following:

- Tests all combinations of `PnPSolver` and `PnPRefiner` objects for solver precision, using all combinations of precision and formats for object points, image points, intrinsics and distortion coefficients. This exhaustive test makes testing a new PnPSolver or PnPRefiner classes easy. 

- Tests all refiners using an imprecise initial pose estimate. 

- Documents corner cases that cause one or more `PnPSolvers` to fail (also called artificial degeneracies). This set can grow if more corner cases get included by the community.