### PR TITLE
Build with cuda 10.1 and NPP 10.2.0.243

### DIFF
--- a/modules/core/include/opencv2/core/private.cuda.hpp
+++ b/modules/core/include/opencv2/core/private.cuda.hpp
@@ -72,7 +72,9 @@
 #  include "opencv2/core/cuda_stream_accessor.hpp"
 #  include "opencv2/core/cuda/common.hpp"
 
+# ifndef NPP_VERSION
 #  define NPP_VERSION (NPP_VERSION_MAJOR * 1000 + NPP_VERSION_MINOR * 100 + NPP_VERSION_BUILD)
+# endif
 
 #  define CUDART_MINIMUM_REQUIRED_VERSION 6050
 


### PR DESCRIPTION
Fix compiler warnings for latest cuda npp which defines this itself as:

```
#define NPP_VER_MAJOR 10
#define NPP_VER_MINOR 2
#define NPP_VER_PATCH 0
#define NPP_VER_BUILD 243

#define NPP_VERSION (NPP_VER_MAJOR * 1000 +     \
                     NPP_VER_MINOR *  100 +     \
                     NPP_VER_PATCH)
```

<!-- Please use this line to close one or multiple issues when this pullrequest gets merged
You can add another line right under the first one:
resolves #1234
resolves #1235
-->

### This pullrequest changes

<!-- Please describe what your pullrequest is changing -->


```
opencv_contrib=
buildworker:Custom=linux-1,linux-2,linux-4
build_image:Custom=ubuntu-cuda:16.04
```