### PR TITLE
gapi(test): refactor Prims test parameter

### DIFF
--- a/modules/gapi/test/common/gapi_render_tests_inl.hpp
+++ b/modules/gapi/test/common/gapi_render_tests_inl.hpp
@@ -16,9 +16,6 @@ namespace opencv_test
 
 TEST_P(RenderNV12, AccuracyTest)
 {
-    std::tie(sz, prims, pkg) = GetParam();
-    Init();
-
     cv::gapi::wip::draw::BGR2NV12(mat_gapi, y_mat_gapi, uv_mat_gapi);
     cv::gapi::wip::draw::render(y_mat_gapi, uv_mat_gapi, prims, pkg);
 
@@ -30,9 +27,6 @@ TEST_P(RenderNV12, AccuracyTest)
 
 TEST_P(RenderBGR, AccuracyTest)
 {
-    std::tie(sz, prims, pkg) = GetParam();
-    Init();
-
     cv::gapi::wip::draw::render(mat_gapi, prims, pkg);
     ComputeRef();
 

--- a/modules/gapi/test/cpu/gapi_render_tests_cpu.cpp
+++ b/modules/gapi/test/cpu/gapi_render_tests_cpu.cpp
@@ -17,86 +17,87 @@ namespace opencv_test
 INSTANTIATE_TEST_CASE_P(RenderNV12OCVRects, RenderNV12,
                         Combine(Values(cv::Size(1280, 720),
                                        cv::Size(640, 480)),
-                                Values(rects),
+                                Values(PrimsTestParam::RECTS),
                                 Values(OCV)));
 
 INSTANTIATE_TEST_CASE_P(RenderNV12OCVCircles, RenderNV12,
                         Combine(Values(cv::Size(1280, 720),
                                        cv::Size(640, 480)),
-                                Values(circles),
+                                Values(PrimsTestParam::CIRCLES),
                                 Values(OCV)));
 
 INSTANTIATE_TEST_CASE_P(RenderNV12OCVLines, RenderNV12,
                         Combine(Values(cv::Size(1280, 720),
                                        cv::Size(640, 480)),
-                                Values(lines),
+                                Values(PrimsTestParam::LINES),
                                 Values(OCV)));
 
 INSTANTIATE_TEST_CASE_P(RenderNV12OCVMosaics, RenderNV12,
                         Combine(Values(cv::Size(1280, 720),
                                        cv::Size(640, 480)),
-                                Values(mosaics),
+                                Values(PrimsTestParam::MOSAICS),
                                 Values(OCV)));
 
 // FIXME difference in color
 INSTANTIATE_TEST_CASE_P(RenderNV12OCVImages, RenderNV12,
                         Combine(Values(cv::Size(1280, 720),
                                        cv::Size(640, 480)),
-                                Values(images),
+                                Values(PrimsTestParam::IMAGES),
                                 Values(OCV)));
 
 INSTANTIATE_TEST_CASE_P(RenderNV12OCVPolygons, RenderNV12,
                         Combine(Values(cv::Size(1280, 720),
                                        cv::Size(640, 480)),
-                                Values(polygons),
+                                Values(PrimsTestParam::POLYGONS),
                                 Values(OCV)));
 
 INSTANTIATE_TEST_CASE_P(RenderNV12OCVTexts, RenderNV12,
                         Combine(Values(cv::Size(1280, 720),
                                        cv::Size(640, 480)),
-                                Values(texts),
+                                Values(PrimsTestParam::TEXTS),
                                 Values(OCV)));
 
 /* BGR test cases */
 INSTANTIATE_TEST_CASE_P(RenderBGROCVRects, RenderBGR,
                         Combine(Values(cv::Size(1280, 720),
                                        cv::Size(640, 480)),
-                                Values(rects),
+                                Values(PrimsTestParam::RECTS),
                                 Values(OCV)));
 
 INSTANTIATE_TEST_CASE_P(RenderBGROCVCircles, RenderBGR,
                         Combine(Values(cv::Size(1280, 720),
                                        cv::Size(640, 480)),
-                                Values(circles),
+                                Values(PrimsTestParam::CIRCLES),
                                 Values(OCV)));
 
 INSTANTIATE_TEST_CASE_P(RenderBGROCVLines, RenderBGR,
                         Combine(Values(cv::Size(1280, 720),
                                        cv::Size(640, 480)),
-                                Values(lines),
+                                Values(PrimsTestParam::LINES),
                                 Values(OCV)));
 
 INSTANTIATE_TEST_CASE_P(RenderBGROCVMosaics, RenderBGR,
                         Combine(Values(cv::Size(1280, 720),
                                        cv::Size(640, 480)),
-                                Values(mosaics),
+                                Values(PrimsTestParam::MOSAICS),
                                 Values(OCV)));
 
 INSTANTIATE_TEST_CASE_P(RenderBGROCVImages, RenderBGR,
                         Combine(Values(cv::Size(1280, 720),
                                        cv::Size(640, 480)),
-                                Values(images),
+                                Values(PrimsTestParam::IMAGES),
                                 Values(OCV)));
 
 INSTANTIATE_TEST_CASE_P(RenderBGROCVPolygons, RenderBGR,
                         Combine(Values(cv::Size(1280, 720),
                                        cv::Size(640, 480)),
-                                Values(polygons),
+                                Values(PrimsTestParam::POLYGONS),
                                 Values(OCV)));
 
 INSTANTIATE_TEST_CASE_P(RenderBGROCVTexts, RenderBGR,
                         Combine(Values(cv::Size(1280, 720),
                                        cv::Size(640, 480)),
-                                Values(texts),
+                                Values(PrimsTestParam::TEXTS),
                                 Values(OCV)));
-}
+
+}  // namespace


### PR DESCRIPTION
- avoid passing of complex raw values into gtest framework
- use simple enum wrapper instead

resolves #15636
[Validation build](http://pullrequest.opencv.org/buildbot/builders/master_valgrind-lin64-debug/builds/10197) :+1: