### PR TITLE
Cuda + OpenGL on ARM

### DIFF
--- a/modules/core/src/opengl.cpp
+++ b/modules/core/src/opengl.cpp
@@ -45,6 +45,13 @@
 #ifdef HAVE_OPENGL
 #  include "gl_core_3_1.hpp"
 #  ifdef HAVE_CUDA
+#    if defined(__arm__) || defined(__aarch64__)
+#      warning Workaround for CUDA on ARM
+#      include <GL/gl.h>
+#      ifndef GL_VERSION
+#        define GL_VERSION
+#      endif
+#    endif
 #    include <cuda_gl_interop.h>
 #  endif
 #else // HAVE_OPENGL

--- a/modules/core/src/opengl.cpp
+++ b/modules/core/src/opengl.cpp
@@ -45,11 +45,11 @@
 #ifdef HAVE_OPENGL
 #  include "gl_core_3_1.hpp"
 #  ifdef HAVE_CUDA
-#    if defined(__arm__) || defined(__aarch64__)
-#      warning Workaround for CUDA on ARM
+#    if (defined(__arm__) || defined(__aarch64__)) \
+         && !defined(OPENCV_SKIP_CUDA_OPENGL_ARM_WORKAROUND)
 #      include <GL/gl.h>
 #      ifndef GL_VERSION
-#        define GL_VERSION
+#        define GL_VERSION 0x1F02
 #      endif
 #    endif
 #    include <cuda_gl_interop.h>


### PR DESCRIPTION
### This pull request changes

There might be multiple ways of getting OpenCV compile on Tegra (NVIDIA Jetson) platform, but mainly they modify CUDA(8,9,10...) source code, this one fixes it for all installations. 
( https://devtalk.nvidia.com/default/topic/1007290/jetson-tx2/building-opencv-with-opengl-support-/post/5141945/#5141945 et al.).
This way is exactly the same as the one proposed but the code change happens in OpenCV.

```
opencv_contrib=
```