### PR TITLE
build: update AVX2 check

### DIFF
--- a/cmake/checks/cpu_avx2.cpp
+++ b/cmake/checks/cpu_avx2.cpp
@@ -6,5 +6,6 @@ void test()
 {
     int data[8] = {0,0,0,0, 0,0,0,0};
     __m256i a = _mm256_loadu_si256((const __m256i *)data);
+    __m256i b = _mm256_bslli_epi128(a, 1);  // available in GCC 4.9.3+
 }
 int main() { return 0; }


### PR DESCRIPTION
- _mm256_bslli_epi128() works in [GCC 4.9.3+](https://gcc.godbolt.org/z/LIZG-L) only
- Android NDK r10 doesn't support this instruction

relates #15510
fixes [nightly build](http://pullrequest.opencv.org/buildbot/builders/3_4_pack-android/builds/530).

```
force_builders=Android pack,Linux AVX2
```