### PR TITLE
fix: fix C API (load and show image) on Windows

### DIFF
--- a/modules/core/include/opencv2/core/cvdef.h
+++ b/modules/core/include/opencv2/core/cvdef.h
@@ -560,7 +560,7 @@ Cv64suf;
 *                                    C++ 11                                              *
 \****************************************************************************************/
 #ifndef CV_CXX11
-#  if __cplusplus >= 201103L || (defined(_MSC_VER) && _MSC_VER >= 1800)
+#  if __cplusplus >= 201103L || (defined(__cplusplus) && defined(_MSC_VER) && _MSC_VER >= 1800)
 #    define CV_CXX11 1
 #  endif
 #else


### PR DESCRIPTION
This PR tries to fix opencv 3.4 branch's load and show image functions in C API on windows visual studio platform. The following code run OK on Linux (ubuntu16.04), however compile failed on windows:

test code:
```C
// main.c
#include <opencv2/imgcodecs/imgcodecs_c.h>
#include "opencv2/highgui/highgui_c.h"

int main(){
    const char* im_pth = "cat.jpg";
    IplImage* im = cvLoadImage(im_pth, -1);
    cvShowImage("cat", im);
    cvWaitKey(0);

    return 0;
}
```

test CMakeLists.txt:
```C
cmake_minimum_required(VERSION 3.14)
project(123)
add_executable(123 src/main.c)

set(OpenCV_DIR "D:/lib/opencv-3.4.5/build")
find_package(OpenCV REQUIRED)
target_link_libraries(123 ${OpenCV_LIBS})
```

After this PR's fix, the above code can compile and run OK on windows visual studio 2015 and 2017.