### PR TITLE
build: eliminate CUDA warnings

### DIFF
--- a/modules/cudalegacy/src/cuda/NCVBroxOpticalFlow.cu
+++ b/modules/cudalegacy/src/cuda/NCVBroxOpticalFlow.cu
@@ -955,7 +955,7 @@ NCVStatus NCVBroxOpticalFlow(const NCVBroxOpticalFlowDescriptor desc,
 
             //compute derivatives
             dim3 dBlocks(iDivUp(kLevelWidth, 32), iDivUp(kLevelHeight, 6));
-            dim3 dThreads(32, 6);
+            //dim3 dThreads(32, 6);
 
             const int kPitchTex = kLevelStride * sizeof(float);
 
@@ -1121,7 +1121,7 @@ NCVStatus NCVBroxOpticalFlow(const NCVBroxOpticalFlowDescriptor desc,
                 Ncv32u ns = alignUp(nw, kStrideAlignmentFloat);
 
                 dim3 p_blocks(iDivUp(nw, 32), iDivUp(nh, 8));
-                dim3 p_threads(32, 8);
+                //dim3 p_threads(32, 8);
 
                 NcvSize32u inner_srcSize (kLevelWidth, kLevelHeight);
                 NcvSize32u dstSize (nw, nh);


### PR DESCRIPTION
Messages:

```
opencv/modules/cudalegacy/src/cuda/NCVBroxOpticalFlow.cu(1124): warning: variable "p_threads" was declared but never referenced

opencv/modules/cudalegacy/src/cuda/NCVBroxOpticalFlow.cu(958): warning: variable "dThreads" was declared but never referenced
```


```
force_builders=Custom
buildworker:Custom=linux-4
build_image:Custom=ubuntu-cuda:18.04
```
