### PR TITLE
OpenCV release (3.4.8)

### DIFF
--- a/modules/core/include/opencv2/core/version.hpp
+++ b/modules/core/include/opencv2/core/version.hpp
@@ -8,7 +8,7 @@
 #define CV_VERSION_MAJOR    3
 #define CV_VERSION_MINOR    4
 #define CV_VERSION_REVISION 8
-#define CV_VERSION_STATUS   "-pre"
+#define CV_VERSION_STATUS   ""
 
 #define CVAUX_STR_EXP(__A)  #__A
 #define CVAUX_STR(__A)      CVAUX_STR_EXP(__A)


### PR DESCRIPTION
OpenCV 3.4.8

relates #15435

<cut/>

<details>

<summary>VirusTotal scan results:</summary>

[opencv_world348.dll (vc14)](https://www.virustotal.com/gui/file/2872146a745b1f24050030d940511448998ee8a90702f03fa56e55dcff93d7bf/detection)
[opencv_world348d.dll (vc14)](https://www.virustotal.com/gui/file/2872146a745b1f24050030d940511448998ee8a90702f03fa56e55dcff93d7bf/detection)
[opencv_world348.dll (vc15)](https://www.virustotal.com/gui/file/2872146a745b1f24050030d940511448998ee8a90702f03fa56e55dcff93d7bf/detection)
[opencv_world348d.dll (vc15)](https://www.virustotal.com/gui/file/2872146a745b1f24050030d940511448998ee8a90702f03fa56e55dcff93d7bf/detection)

[opencv_ffmpeg348_64.dll](https://www.virustotal.com/gui/file/2872146a745b1f24050030d940511448998ee8a90702f03fa56e55dcff93d7bf/detection)
[opencv_ffmpeg348.dll](https://www.virustotal.com/gui/file/2872146a745b1f24050030d940511448998ee8a90702f03fa56e55dcff93d7bf/detection)

</details>
