### PR TITLE
Deprecated IE API in G-API test

### DIFF
--- a/modules/gapi/test/infer/gapi_infer_ie_test.cpp
+++ b/modules/gapi/test/infer/gapi_infer_ie_test.cpp
@@ -99,7 +99,7 @@ TEST(TestAgeGenderIE, InferBasicTensor)
         reader.ReadWeights(weights_path);
         auto net = reader.getNetwork();
 
-        const auto &iedims = net.getInputsInfo().begin()->second->getDims();
+        const auto &iedims = net.getInputsInfo().begin()->second->getTensorDesc().getDims();
               auto  cvdims = cv::gapi::ie::util::to_ocv(iedims);
         std::reverse(cvdims.begin(), cvdims.end());
         in_mat.create(cvdims, CV_32F);


### PR DESCRIPTION
### This pullrequest changes

`InputInfo::getDims()` is deprecated, used `getTensorDesc().getDims()` instead.

<cut/>

```
force_builders=Custom,Custom Win,Custom Mac
build_image:Custom=ubuntu-openvino-2019r3.0:16.04
build_image:Custom Win=openvino-2019r2.0
build_image:Custom Mac=openvino-2019r1

test_modules:Custom=dnn,python2,python3,java
test_modules:Custom Win=dnn,python2,python3,java
test_modules:Custom Mac=dnn,python2,python3,java

buildworker:Custom=linux-1
# disabled due high memory usage: test_opencl:Custom=ON
test_opencl:Custom=OFF
test_bigdata:Custom=1
test_filter:Custom=*
```