### PR TITLE
added cv::magnitude(InputArray xy...)

### DIFF
--- a/modules/core/include/opencv2/core.hpp
+++ b/modules/core/include/opencv2/core.hpp
@@ -1593,6 +1593,7 @@ have the same size as x.
 @sa cartToPolar, polarToCart, phase, sqrt
 */
 CV_EXPORTS_W void magnitude(InputArray x, InputArray y, OutputArray magnitude);
+CV_EXPORTS_W void magnitude(InputArray xy, OutputArray magnitude);
 
 /** @brief Checks every element of an input array for invalid values.
 

--- a/modules/core/include/opencv2/core/hal/hal.hpp
+++ b/modules/core/include/opencv2/core/hal/hal.hpp
@@ -95,6 +95,8 @@ CV_EXPORTS void fastAtan32f(const float* y, const float* x, float* dst, int n, b
 CV_EXPORTS void fastAtan64f(const double* y, const double* x, double* dst, int n, bool angleInDegrees);
 CV_EXPORTS void magnitude32f(const float* x, const float* y, float* dst, int n);
 CV_EXPORTS void magnitude64f(const double* x, const double* y, double* dst, int n);
+CV_EXPORTS void magnitude32fc(const float* xy,  float* dst, int n);
+CV_EXPORTS void magnitude64fc(const double* xy, double* dst, int n);
 CV_EXPORTS void sqrt32f(const float* src, float* dst, int len);
 CV_EXPORTS void sqrt64f(const double* src, double* dst, int len);
 CV_EXPORTS void invSqrt32f(const float* src, float* dst, int len);

--- a/modules/core/src/hal_replacement.hpp
+++ b/modules/core/src/hal_replacement.hpp
@@ -404,11 +404,15 @@ inline int hal_ni_fastAtan64f(const double* y, const double* x, double* dst, int
 //! @{
 inline int hal_ni_magnitude32f(const float *x, const float *y, float *dst, int len) { return CV_HAL_ERROR_NOT_IMPLEMENTED; }
 inline int hal_ni_magnitude64f(const double *x, const double  *y, double *dst, int len) { return CV_HAL_ERROR_NOT_IMPLEMENTED; }
+inline int hal_ni_magnitude32fc(const float *xy, float *dst, int len) { return CV_HAL_ERROR_NOT_IMPLEMENTED; }
+inline int hal_ni_magnitude64fc(const double *xy, double *dst, int len) { return CV_HAL_ERROR_NOT_IMPLEMENTED; }
 //! @}
 
 //! @cond IGNORED
 #define cv_hal_magnitude32f hal_ni_magnitude32f
 #define cv_hal_magnitude64f hal_ni_magnitude64f
+#define cv_hal_magnitude32fc hal_ni_magnitude32fc
+#define cv_hal_magnitude64fc hal_ni_magnitude64fc
 //! @endcond
 
 

--- a/modules/core/src/mathfuncs_core.dispatch.cpp
+++ b/modules/core/src/mathfuncs_core.dispatch.cpp
@@ -51,6 +51,19 @@ void magnitude32f(const float* x, const float* y, float* mag, int len)
         CV_CPU_DISPATCH_MODES_ALL);
 }
 
+void magnitude32fc(const float* xy, float* mag, int len)
+{
+    CV_INSTRUMENT_REGION();
+
+    CALL_HAL(magnitude32fc, cv_hal_magnitude32fc, xy, mag, len);
+    //TODO : use a new version of ippicv with ippsMagnitude_32fc implemented !
+    // SSE42 performance issues
+    //CV_IPP_RUN(IPP_VERSION_X100 > 201800 || cv::ipp::getIppTopFeatures() != ippCPUID_SSE42, CV_INSTRUMENT_FUN_IPP(ippsMagnitude_32fc, reinterpret_cast<const Ipp32fc*>(xy), mag, len) >= 0);
+
+    CV_CPU_DISPATCH(magnitude32fc, (xy, mag, len),
+        CV_CPU_DISPATCH_MODES_ALL);
+}
+
 void magnitude64f(const double* x, const double* y, double* mag, int len)
 {
     CV_INSTRUMENT_REGION();
@@ -63,6 +76,18 @@ void magnitude64f(const double* x, const double* y, double* mag, int len)
         CV_CPU_DISPATCH_MODES_ALL);
 }
 
+void magnitude64fc(const double* xy, double* mag, int len)
+{
+    CV_INSTRUMENT_REGION();
+
+    CALL_HAL(magnitude64fc, cv_hal_magnitude64fc, xy, mag, len);
+    //TODO : use a new version of ippicv with ippsMagnitude_64fc implemented !
+    // SSE42 performance issues
+    //CV_IPP_RUN(IPP_VERSION_X100 > 201800 || cv::ipp::getIppTopFeatures() != ippCPUID_SSE42, CV_INSTRUMENT_FUN_IPP(ippsMagnitude_64fc, reinterpret_cast<const Ipp64fc*>(xy), mag, len) >= 0);
+
+    CV_CPU_DISPATCH(magnitude64fc, (xy, mag, len),
+        CV_CPU_DISPATCH_MODES_ALL);
+}
 
 void invSqrt32f(const float* src, float* dst, int len)
 {
@@ -181,9 +206,19 @@ void magnitude(const float* x, const float* y, float* dst, int n)
     magnitude32f(x, y, dst, n);
 }
 
+void magnitude(const float* xy, float* dst, int n)
+{
+    magnitude32fc(xy, dst, n);
+}
+
 void magnitude(const double* x, const double* y, double* dst, int n)
 {
     magnitude64f(x, y, dst, n);
+}
+
+void magnitude(const double* xy, double* dst, int n)
+{
+    magnitude64fc(xy, dst, n);
 }
 
 void sqrt(const float* src, float* dst, int len)


### PR DESCRIPTION
Issue #15677

cv::magnitude now support interlaved input data as 32FC2 or 64FC2
TODO:
ippicvlib needs an implementation of ippsMagnitude_32fc/ippsMagnitude_64fc
the OpenCL abstraction is beyond my understanding to support interleaved data in ocl_math_op

