### PR TITLE
G-API: G_ID_HELPER_BODY macro semicolon issue 

### DIFF
--- a/modules/gapi/include/opencv2/gapi/gkernel.hpp
+++ b/modules/gapi/include/opencv2/gapi/gkernel.hpp
@@ -237,7 +237,7 @@ public:
     {                                                                       \
         struct G_ID_HELPER_CLASS(Class)                                     \
         {                                                                   \
-            static constexpr const char * id() {return Id;};                \
+            static constexpr const char * id() {return Id;}                 \
         };                                                                  \
     }
 


### PR DESCRIPTION
### This pullrequest changes
- Unnecessary extra semicolon after member function definition has been removed from the G_ID_HELPER_BODY macro definition because that has been raising warnings.

```
 struct G_ID_HELPER_CLASS(Class)                                            \
        {                                                                   \
-           static constexpr const char * id() {return Id;};                \
+           static constexpr const char * id() {return Id;}                 \
        };     
```