### PR TITLE
Fix incorrect use of std::move() in g-api perf tests

### DIFF
--- a/modules/gapi/perf/common/gapi_core_perf_tests_inl.hpp
+++ b/modules/gapi/perf/common/gapi_core_perf_tests_inl.hpp
@@ -36,16 +36,18 @@ PERF_TEST_P_(AddPerfTest, TestPerformance)
     cv::GComputation c(GIn(in1, in2), GOut(out));
 
     // Warm-up graph engine:
-    c.apply(gin(in_mat1, in_mat2), gout(out_mat_gapi), std::move(compile_args));
+    c.apply(gin(in_mat1, in_mat2), gout(out_mat_gapi));
+    auto cc = c.compile(cv::descr_of(in_mat1), cv::descr_of(in_mat2), compile_args);
 
     TEST_CYCLE()
     {
-        c.apply(gin(in_mat1, in_mat2), gout(out_mat_gapi), std::move(compile_args));
+        cc(in_mat1, in_mat2, out_mat_gapi);
     }
 
     // Comparison ////////////////////////////////////////////////////////////
     // FIXIT unrealiable check: EXPECT_EQ(0, cv::countNonZero(out_mat_gapi != out_mat_ocv));
-    EXPECT_EQ(out_mat_gapi.size(), sz);
+    //EXPECT_EQ(out_mat_gapi.size(), sz);
+    EXPECT_EQ(1, 0);
 
     SANITY_CHECK_NOTHING();
 }

--- a/modules/gapi/perf/common/gapi_core_perf_tests_inl.hpp
+++ b/modules/gapi/perf/common/gapi_core_perf_tests_inl.hpp
@@ -45,7 +45,7 @@ PERF_TEST_P_(AddPerfTest, TestPerformance)
 
     TEST_CYCLE()
     {
-        cc(in_mat1, in_mat2, out_mat_gapi);
+        cc(gin(in_mat1, in_mat2), gout(out_mat_gapi));
     }
 
     // Comparison ////////////////////////////////////////////////////////////
@@ -114,11 +114,11 @@ PERF_TEST_P_(SubPerfTest, TestPerformance)
     // Warm-up graph engine:
     auto cc = c.compile(descr_of(gin(in_mat1, in_mat2)),
                         std::move(compile_args));
-    cc(in_mat1, in_mat2, out_mat_gapi);
+    cc(gin(in_mat1, in_mat2), gout(out_mat_gapi));
 
     TEST_CYCLE()
     {
-        cc(in_mat1, in_mat2, out_mat_gapi);
+        cc(gin(in_mat1, in_mat2), gout(out_mat_gapi));
     }
 
     // Comparison ////////////////////////////////////////////////////////////
@@ -224,11 +224,11 @@ PERF_TEST_P_(MulPerfTest, TestPerformance)
     // Warm-up graph engine:
     auto cc = c.compile(descr_of(gin(in_mat1, in_mat2)),
                         std::move(compile_args));
-    cc(in_mat1, in_mat2, out_mat_gapi);
+    cc(gin(in_mat1, in_mat2), gout(out_mat_gapi));
 
     TEST_CYCLE()
     {
-        cc(in_mat1, in_mat2, out_mat_gapi);
+        cc(gin(in_mat1, in_mat2), gout(out_mat_gapi));
     }
 
     // Comparison ////////////////////////////////////////////////////////////
@@ -262,11 +262,11 @@ PERF_TEST_P_(MulDoublePerfTest, TestPerformance)
     // Warm-up graph engine:
     auto cc = c.compile(descr_of(gin(in_mat1)),
                         std::move(compile_args));
-    cc(in_mat1, out_mat_gapi);
+    cc(gin(in_mat1), gout(out_mat_gapi));
 
     TEST_CYCLE()
     {
-        cc(in_mat1, out_mat_gapi);
+        cc(gin(in_mat1), gout(out_mat_gapi));
     }
 
     // Comparison ////////////////////////////////////////////////////////////
@@ -332,16 +332,16 @@ PERF_TEST_P_(DivPerfTest, TestPerformance)
     // G-API code ////////////////////////////////////////////////////////////
     cv::GMat in1, in2, out;
     out = cv::gapi::div(in1, in2, dtype);
-    cv::GComputation c(in1, in2, out);
+    cv::GComputation c(GIn(in1, in2), GOut(out));
 
     // Warm-up graph engine:
     auto cc = c.compile(descr_of(gin(in_mat1, in_mat2)),
                         std::move(compile_args));
-    cc(in_mat1, in_mat2, out_mat_gapi);
+    cc(gin(in_mat1, in_mat2), gout(out_mat_gapi));
 
     TEST_CYCLE()
     {
-        cc(in_mat1, in_mat2, out_mat_gapi);
+        cc(gin(in_mat1, in_mat2), gout(out_mat_gapi));
     }
 
     // Comparison ////////////////////////////////////////////////////////////
@@ -457,11 +457,11 @@ PERF_TEST_P_(MaskPerfTest, TestPerformance)
     // Warm-up graph engine:
     auto cc = c.compile(descr_of(gin(in_mat1, in_mat2)),
                         std::move(compile_args));
-    cc(cv::gin(in_mat1, in_mat2), cv::gout(out_mat_gapi));
+    cc(gin(in_mat1, in_mat2), gout(out_mat_gapi));
 
     TEST_CYCLE()
     {
-        cc(cv::gin(in_mat1, in_mat2), cv::gout(out_mat_gapi));
+        cc(gin(in_mat1, in_mat2), gout(out_mat_gapi));
     }
 
     // Comparison ////////////////////////////////////////////////////////////
@@ -493,11 +493,11 @@ PERF_TEST_P_(MeanPerfTest, TestPerformance)
     // Warm-up graph engine:
     auto cc = c.compile(descr_of(gin(in_mat1)),
                         std::move(compile_args));
-    cc(cv::gin(in_mat1), cv::gout(out_norm));
+    cc(gin(in_mat1), gout(out_norm));
 
     TEST_CYCLE()
     {
-        cc(cv::gin(in_mat1), cv::gout(out_norm));
+        cc(gin(in_mat1), gout(out_norm));
     }
 
     // Comparison ////////////////////////////////////////////////////////////
@@ -750,11 +750,11 @@ PERF_TEST_P_(BitwiseNotPerfTest, TestPerformance)
     // Warm-up graph engine:
     auto cc = c.compile(descr_of(gin(in_mat1)),
                         std::move(compile_args));
-    cc(in_mat1, out_mat_gapi);
+    cc(gin(in_mat1), gout(out_mat_gapi));
 
     TEST_CYCLE()
     {
-        cc(in_mat1, out_mat_gapi);
+        cc(gin(in_mat1), gout(out_mat_gapi));
     }
 
     // Comparison ////////////////////////////////////////////////////////////
@@ -972,11 +972,11 @@ PERF_TEST_P_(SumPerfTest, TestPerformance)
     // Warm-up graph engine:
     auto cc = c.compile(descr_of(gin(in_mat1)),
                         std::move(compile_args));
-    cc(cv::gin(in_mat1), cv::gout(out_sum));
+    cc(gin(in_mat1), gout(out_sum));
 
     TEST_CYCLE()
     {
-        cc(cv::gin(in_mat1), cv::gout(out_sum));
+        cc(gin(in_mat1), gout(out_sum));
     }
 
     // Comparison ////////////////////////////////////////////////////////////
@@ -1110,11 +1110,11 @@ PERF_TEST_P_(IntegralPerfTest, TestPerformance)
     // Warm-up graph engine:
     auto cc = c.compile(descr_of(gin(in_mat1)),
                         std::move(compile_args));
-    cc(cv::gin(in_mat1), cv::gout(out_mat1, out_mat2));
+    cc(gin(in_mat1), gout(out_mat1, out_mat2));
 
     TEST_CYCLE()
     {
-        cc(cv::gin(in_mat1), cv::gout(out_mat1, out_mat2));
+        cc(gin(in_mat1), gout(out_mat1, out_mat2));
     }
 
     // Comparison ////////////////////////////////////////////////////////////
@@ -1269,11 +1269,11 @@ PERF_TEST_P_(Split3PerfTest, TestPerformance)
     // Warm-up graph engine:
     auto cc = c.compile(descr_of(gin(in_mat1)),
                         std::move(compile_args));
-    cc(cv::gin(in_mat1), cv::gout(out_mat_gapi, out_mat2, out_mat3));
+    cc(gin(in_mat1), gout(out_mat_gapi, out_mat2, out_mat3));
 
     TEST_CYCLE()
     {
-        cc(cv::gin(in_mat1), cv::gout(out_mat_gapi, out_mat2, out_mat3));
+        cc(gin(in_mat1), gout(out_mat_gapi, out_mat2, out_mat3));
     }
 
     // Comparison ////////////////////////////////////////////////////////////
@@ -1311,11 +1311,11 @@ PERF_TEST_P_(Split4PerfTest, TestPerformance)
     // Warm-up graph engine:
     auto cc = c.compile(descr_of(gin(in_mat1)),
                         std::move(compile_args));
-    cc(cv::gin(in_mat1), cv::gout(out_mat_gapi, out_mat2, out_mat3, out_mat4));
+    cc(gin(in_mat1), gout(out_mat_gapi, out_mat2, out_mat3, out_mat4));
 
     TEST_CYCLE()
     {
-        cc(cv::gin(in_mat1), cv::gout(out_mat_gapi, out_mat2, out_mat3, out_mat4));
+        cc(gin(in_mat1), gout(out_mat_gapi, out_mat2, out_mat3, out_mat4));
     }
 
     // Comparison ////////////////////////////////////////////////////////////
@@ -1352,11 +1352,11 @@ PERF_TEST_P_(Merge3PerfTest, TestPerformance)
     // Warm-up graph engine:
     auto cc = c.compile(descr_of(gin(in_mat1, in_mat2, in_mat3)),
                         std::move(compile_args));
-    cc(cv::gin(in_mat1, in_mat2, in_mat3), cv::gout(out_mat_gapi));
+    cc(gin(in_mat1, in_mat2, in_mat3), gout(out_mat_gapi));
 
     TEST_CYCLE()
     {
-        cc(cv::gin(in_mat1, in_mat2, in_mat3), cv::gout(out_mat_gapi));
+        cc(gin(in_mat1, in_mat2, in_mat3), gout(out_mat_gapi));
     }
 
     // Comparison ////////////////////////////////////////////////////////////
@@ -1392,11 +1392,11 @@ PERF_TEST_P_(Merge4PerfTest, TestPerformance)
     // Warm-up graph engine:
     auto cc = c.compile(descr_of(gin(in_mat1, in_mat2, in_mat3, in_mat4)),
                         std::move(compile_args));
-    cc(cv::gin(in_mat1, in_mat2, in_mat3, in_mat4), cv::gout(out_mat_gapi));
+    cc(gin(in_mat1, in_mat2, in_mat3, in_mat4), gout(out_mat_gapi));
 
     TEST_CYCLE()
     {
-        cc(cv::gin(in_mat1, in_mat2, in_mat3, in_mat4), cv::gout(out_mat_gapi));
+        cc(gin(in_mat1, in_mat2, in_mat3, in_mat4), gout(out_mat_gapi));
     }
 
     // Comparison ////////////////////////////////////////////////////////////
@@ -1430,11 +1430,11 @@ PERF_TEST_P_(RemapPerfTest, TestPerformance)
     // Warm-up graph engine:
     auto cc = c.compile(descr_of(gin(in_mat1)),
                         std::move(compile_args));
-    cc(in_mat1, out_mat_gapi);
+    cc(gin(in_mat1), gout(out_mat_gapi));
 
     TEST_CYCLE()
     {
-        cc(in_mat1, out_mat_gapi);
+        cc(gin(in_mat1), gout(out_mat_gapi));
     }
 
     // Comparison ////////////////////////////////////////////////////////////
@@ -1466,11 +1466,11 @@ PERF_TEST_P_(FlipPerfTest, TestPerformance)
     // Warm-up graph engine:
     auto cc = c.compile(descr_of(gin(in_mat1)),
                         std::move(compile_args));
-    cc(in_mat1, out_mat_gapi);
+    cc(gin(in_mat1), gout(out_mat_gapi));
 
     TEST_CYCLE()
     {
-        cc(in_mat1, out_mat_gapi);
+        cc(gin(in_mat1), gout(out_mat_gapi));
     }
 
     // Comparison ////////////////////////////////////////////////////////////
@@ -1503,11 +1503,11 @@ PERF_TEST_P_(CropPerfTest, TestPerformance)
     // Warm-up graph engine:
     auto cc = c.compile(descr_of(gin(in_mat1)),
                         std::move(compile_args));
-    cc(in_mat1, out_mat_gapi);
+    cc(gin(in_mat1), gout(out_mat_gapi));
 
     TEST_CYCLE()
     {
-        cc(in_mat1, out_mat_gapi);
+        cc(gin(in_mat1), gout(out_mat_gapi));
     }
 
     // Comparison ////////////////////////////////////////////////////////////
@@ -1539,11 +1539,11 @@ PERF_TEST_P_(CopyPerfTest, TestPerformance)
     // Warm-up graph engine:
     auto cc = c.compile(descr_of(gin(in_mat1)),
                         std::move(compile_args));
-    cc(in_mat1, out_mat_gapi);
+    cc(gin(in_mat1), gout(out_mat_gapi));
 
     TEST_CYCLE()
     {
-        cc(in_mat1, out_mat_gapi);
+        cc(gin(in_mat1), gout(out_mat_gapi));
     }
 
     // Comparison ////////////////////////////////////////////////////////////
@@ -1787,11 +1787,11 @@ PERF_TEST_P_(LUTPerfTest, TestPerformance)
     // Warm-up graph engine:
     auto cc = c.compile(descr_of(gin(in_mat1)),
                         std::move(compile_args));
-    cc(in_mat1, out_mat_gapi);
+    cc(gin(in_mat1), gout(out_mat_gapi));
 
     TEST_CYCLE()
     {
-        cc(in_mat1, out_mat_gapi);
+        cc(gin(in_mat1), gout(out_mat_gapi));
     }
 
     // Comparison ////////////////////////////////////////////////////////////
@@ -1824,11 +1824,11 @@ PERF_TEST_P_(ConvertToPerfTest, TestPerformance)
     // Warm-up graph engine:
     auto cc = c.compile(descr_of(gin(in_mat1)),
                         std::move(compile_args));
-    cc(in_mat1, out_mat_gapi);
+    cc(gin(in_mat1), gout(out_mat_gapi));
 
     TEST_CYCLE()
     {
-        cc(in_mat1, out_mat_gapi);
+        cc(gin(in_mat1), gout(out_mat_gapi));
     }
 
     // Comparison ////////////////////////////////////////////////////////////
@@ -1867,11 +1867,11 @@ PERF_TEST_P_(ResizePerfTest, TestPerformance)
     // Warm-up graph engine:
     auto cc = c.compile(descr_of(gin(in_mat1)),
                         std::move(compile_args));
-    cc(in_mat1, out_mat_gapi);
+    cc(gin(in_mat1), gout(out_mat_gapi));
 
     TEST_CYCLE()
     {
-        cc(in_mat1, out_mat_gapi);
+        cc(gin(in_mat1), gout(out_mat_gapi));
     }
 
     // Comparison ////////////////////////////////////////////////////////////
@@ -1913,11 +1913,11 @@ PERF_TEST_P_(ResizeFxFyPerfTest, TestPerformance)
     // Warm-up graph engine:
     auto cc = c.compile(descr_of(gin(in_mat1)),
                         std::move(compile_args));
-    cc(in_mat1, out_mat_gapi);
+    cc(gin(in_mat1), gout(out_mat_gapi));
 
     TEST_CYCLE()
     {
-        cc(in_mat1, out_mat_gapi);
+        cc(gin(in_mat1), gout(out_mat_gapi));
     }
 
     // Comparison ////////////////////////////////////////////////////////////

--- a/modules/gapi/perf/common/gapi_core_perf_tests_inl.hpp
+++ b/modules/gapi/perf/common/gapi_core_perf_tests_inl.hpp
@@ -112,7 +112,7 @@ PERF_TEST_P_(SubPerfTest, TestPerformance)
     auto cc = c.compile(cv::descr_of(in_mat1), cv::descr_of(in_mat2),
                         std::move(compile_args));
     cc(in_mat1, in_mat2, out_mat_gapi);
-    
+
     TEST_CYCLE()
     {
         cc(in_mat1, in_mat2, out_mat_gapi);
@@ -1007,7 +1007,7 @@ PERF_TEST_P_(AddWeightedPerfTest, TestPerformance)
     cv::GComputation c(GIn(in1, in2), GOut(out));
 
     // Warm-up graph engine:
-    auto cc = c.compile(cv::descr_of(in_mat1), cv::descr_of(in_mat2), 
+    auto cc = c.compile(cv::descr_of(in_mat1), cv::descr_of(in_mat2),
                         std::move(compile_args));
     cc(gin(in_mat1, in_mat2), gout(out_mat_gapi));
 

--- a/modules/gapi/perf/common/gapi_core_perf_tests_inl.hpp
+++ b/modules/gapi/perf/common/gapi_core_perf_tests_inl.hpp
@@ -183,7 +183,6 @@ PERF_TEST_P_(SubRCPerfTest, TestPerformance)
     cv::GComputation c(GIn(in1, sc1), GOut(out));
 
     // Warm-up graph engine:
-    //auto cc = c.compile(gin(in_mat1, sc), gout(out_mat_gapi), std::move(compile_args));
     auto cc = c.compile(descr_of(in_mat1), descr_of(sc),
                         std::move(compile_args));
     cc(gin(in_mat1, sc), gout(out_mat_gapi));

--- a/modules/gapi/perf/common/gapi_core_perf_tests_inl.hpp
+++ b/modules/gapi/perf/common/gapi_core_perf_tests_inl.hpp
@@ -35,9 +35,13 @@ PERF_TEST_P_(AddPerfTest, TestPerformance)
     out = cv::gapi::add(in1, in2, dtype);
     cv::GComputation c(GIn(in1, in2), GOut(out));
 
+    // There is no need to qualify gin, gout, descr_of with namespace (cv::)
+    // as they are in the same namespace as their actual argument (i.e. cv::Mat)
+    // and thus are found via ADL, as in the examples below.
     // Warm-up graph engine:
-    auto cc = c.compile(cv::descr_of(in_mat1), cv::descr_of(in_mat2), std::move(compile_args));
-    cc(in_mat1, in_mat2, out_mat_gapi);
+    auto cc = c.compile(descr_of(gin(in_mat1, in_mat2)),
+                        std::move(compile_args));
+    cc(gin(in_mat1, in_mat2), gout(out_mat_gapi));
 
     TEST_CYCLE()
     {
@@ -47,7 +51,6 @@ PERF_TEST_P_(AddPerfTest, TestPerformance)
     // Comparison ////////////////////////////////////////////////////////////
     // FIXIT unrealiable check: EXPECT_EQ(0, cv::countNonZero(out_mat_gapi != out_mat_ocv));
     EXPECT_EQ(out_mat_gapi.size(), sz);
-    //EXPECT_EQ(1, 0);
 
     SANITY_CHECK_NOTHING();
 }
@@ -73,7 +76,7 @@ PERF_TEST_P_(AddCPerfTest, TestPerformance)
     cv::GComputation c(GIn(in1, sc1), GOut(out));
 
     // Warm-up graph engine:
-    auto cc = c.compile(cv::descr_of(in_mat1), cv::descr_of(sc),
+    auto cc = c.compile(descr_of(gin(in_mat1, sc)),
                         std::move(compile_args));
     cc(gin(in_mat1, sc), gout(out_mat_gapi));
 
@@ -109,7 +112,7 @@ PERF_TEST_P_(SubPerfTest, TestPerformance)
     cv::GComputation c(GIn(in1, in2), GOut(out));
 
     // Warm-up graph engine:
-    auto cc = c.compile(cv::descr_of(in_mat1), cv::descr_of(in_mat2),
+    auto cc = c.compile(descr_of(gin(in_mat1, in_mat2)),
                         std::move(compile_args));
     cc(in_mat1, in_mat2, out_mat_gapi);
 
@@ -146,7 +149,7 @@ PERF_TEST_P_(SubCPerfTest, TestPerformance)
     cv::GComputation c(GIn(in1, sc1), GOut(out));
 
     // Warm-up graph engine:
-    auto cc = c.compile(cv::descr_of(in_mat1), cv::descr_of(sc),
+    auto cc = c.compile(descr_of(gin(in_mat1, sc)),
                         std::move(compile_args));
     cc(gin(in_mat1, sc), gout(out_mat_gapi));
 
@@ -183,7 +186,7 @@ PERF_TEST_P_(SubRCPerfTest, TestPerformance)
     cv::GComputation c(GIn(in1, sc1), GOut(out));
 
     // Warm-up graph engine:
-    auto cc = c.compile(descr_of(in_mat1), descr_of(sc),
+    auto cc = c.compile(descr_of(gin(in_mat1, sc)),
                         std::move(compile_args));
     cc(gin(in_mat1, sc), gout(out_mat_gapi));
 
@@ -219,7 +222,7 @@ PERF_TEST_P_(MulPerfTest, TestPerformance)
     cv::GComputation c(GIn(in1, in2), GOut(out));
 
     // Warm-up graph engine:
-    auto cc = c.compile(cv::descr_of(in_mat1), cv::descr_of(in_mat2),
+    auto cc = c.compile(descr_of(gin(in_mat1, in_mat2)),
                         std::move(compile_args));
     cc(in_mat1, in_mat2, out_mat_gapi);
 
@@ -257,7 +260,8 @@ PERF_TEST_P_(MulDoublePerfTest, TestPerformance)
     cv::GComputation c(in1, out);
 
     // Warm-up graph engine:
-    auto cc = c.compile(cv::descr_of(in_mat1), std::move(compile_args));
+    auto cc = c.compile(descr_of(gin(in_mat1)),
+                        std::move(compile_args));
     cc(in_mat1, out_mat_gapi);
 
     TEST_CYCLE()
@@ -293,7 +297,7 @@ PERF_TEST_P_(MulCPerfTest, TestPerformance)
     cv::GComputation c(GIn(in1, sc1), GOut(out));
 
     // Warm-up graph engine:
-    auto cc = c.compile(cv::descr_of(in_mat1), cv::descr_of(sc),
+    auto cc = c.compile(descr_of(gin(in_mat1, sc)),
                         std::move(compile_args));
     cc(gin(in_mat1, sc), gout(out_mat_gapi));
 
@@ -331,7 +335,7 @@ PERF_TEST_P_(DivPerfTest, TestPerformance)
     cv::GComputation c(in1, in2, out);
 
     // Warm-up graph engine:
-    auto cc = c.compile(cv::descr_of(in_mat1), cv::descr_of(in_mat2),
+    auto cc = c.compile(descr_of(gin(in_mat1, in_mat2)),
                         std::move(compile_args));
     cc(in_mat1, in_mat2, out_mat_gapi);
 
@@ -369,7 +373,7 @@ PERF_TEST_P_(DivCPerfTest, TestPerformance)
     cv::GComputation c(GIn(in1, sc1), GOut(out));
 
     // Warm-up graph engine:
-    auto cc = c.compile(cv::descr_of(in_mat1), cv::descr_of(sc),
+    auto cc = c.compile(descr_of(gin(in_mat1, sc)),
                         std::move(compile_args));
     cc(gin(in_mat1, sc), gout(out_mat_gapi));
 
@@ -412,7 +416,7 @@ PERF_TEST_P_(DivRCPerfTest, TestPerformance)
     cv::GComputation c(GIn(in1, sc1), GOut(out));
 
     // Warm-up graph engine:
-    auto cc = c.compile(cv::descr_of(in_mat1), cv::descr_of(sc),
+    auto cc = c.compile(descr_of(gin(in_mat1, sc)),
                         std::move(compile_args));
     cc(gin(in_mat1, sc), gout(out_mat_gapi));
 
@@ -451,7 +455,7 @@ PERF_TEST_P_(MaskPerfTest, TestPerformance)
     cv::GComputation c(cv::GIn(in, m), cv::GOut(out));
 
     // Warm-up graph engine:
-    auto cc = c.compile(cv::descr_of(in_mat1), cv::descr_of(in_mat2),
+    auto cc = c.compile(descr_of(gin(in_mat1, in_mat2)),
                         std::move(compile_args));
     cc(cv::gin(in_mat1, in_mat2), cv::gout(out_mat_gapi));
 
@@ -487,7 +491,8 @@ PERF_TEST_P_(MeanPerfTest, TestPerformance)
     cv::GComputation c(cv::GIn(in), cv::GOut(out));
 
     // Warm-up graph engine:
-    auto cc = c.compile(cv::descr_of(in_mat1), std::move(compile_args));
+    auto cc = c.compile(descr_of(gin(in_mat1)),
+                        std::move(compile_args));
     cc(cv::gin(in_mat1), cv::gout(out_norm));
 
     TEST_CYCLE()
@@ -522,7 +527,7 @@ PERF_TEST_P_(Polar2CartPerfTest, TestPerformance)
     cv::GComputation c(GIn(in1, in2), GOut(out1, out2));
 
     // Warm-up graph engine:
-    auto cc = c.compile(cv::descr_of(in_mat1), cv::descr_of(in_mat2),
+    auto cc = c.compile(descr_of(gin(in_mat1, in_mat2)),
                         std::move(compile_args));
     cc(gin(in_mat1, in_mat2), gout(out_mat_gapi, out_mat2));
 
@@ -559,7 +564,7 @@ PERF_TEST_P_(Cart2PolarPerfTest, TestPerformance)
     cv::GComputation c(GIn(in1, in2), GOut(out1, out2));
 
     // Warm-up graph engine:
-    auto cc = c.compile(cv::descr_of(in_mat1), cv::descr_of(in_mat2),
+    auto cc = c.compile(descr_of(gin(in_mat1, in_mat2)),
                         std::move(compile_args));
     cc(gin(in_mat1, in_mat2), gout(out_mat_gapi, out_mat2));
 
@@ -605,7 +610,7 @@ PERF_TEST_P_(CmpPerfTest, TestPerformance)
     cv::GComputation c(GIn(in1, in2), GOut(out));
 
     // Warm-up graph engine:
-    auto cc = c.compile(cv::descr_of(in_mat1), cv::descr_of(in_mat2),
+    auto cc = c.compile(descr_of(gin(in_mat1, in_mat2)),
                         std::move(compile_args));
     cc(gin(in_mat1, in_mat2), gout(out_mat_gapi));
 
@@ -651,7 +656,7 @@ PERF_TEST_P_(CmpWithScalarPerfTest, TestPerformance)
     cv::GComputation c(GIn(in1, in2), GOut(out));
 
     // Warm-up graph engine:
-    auto cc = c.compile(cv::descr_of(in_mat1), cv::descr_of(sc),
+    auto cc = c.compile(descr_of(gin(in_mat1, sc)),
                         std::move(compile_args));
     cc(gin(in_mat1, sc), gout(out_mat_gapi));
 
@@ -708,7 +713,7 @@ PERF_TEST_P_(BitwisePerfTest, TestPerformance)
     cv::GComputation c(GIn(in1, in2), GOut(out));
 
     // Warm-up graph engine:
-    auto cc = c.compile(cv::descr_of(in_mat1), cv::descr_of(in_mat2),
+    auto cc = c.compile(descr_of(gin(in_mat1, in_mat2)),
                         std::move(compile_args));
     cc(gin(in_mat1, in_mat2), gout(out_mat_gapi));
 
@@ -743,7 +748,8 @@ PERF_TEST_P_(BitwiseNotPerfTest, TestPerformance)
     cv::GComputation c(in, out);
 
     // Warm-up graph engine:
-    auto cc = c.compile(cv::descr_of(in_mat1), std::move(compile_args));
+    auto cc = c.compile(descr_of(gin(in_mat1)),
+                        std::move(compile_args));
     cc(in_mat1, out_mat_gapi);
 
     TEST_CYCLE()
@@ -780,8 +786,7 @@ PERF_TEST_P_(SelectPerfTest, TestPerformance)
     cv::GComputation c(GIn(in1, in2, in3), GOut(out));
 
     // Warm-up graph engine:
-    auto cc = c.compile(cv::descr_of(in_mat1), cv::descr_of(in_mat2),
-                        cv::descr_of(in_mask),
+    auto cc = c.compile(descr_of(gin(in_mat1, in_mat2, in_mask)),
                         std::move(compile_args));
     cc(gin(in_mat1, in_mat2, in_mask), gout(out_mat_gapi));
 
@@ -817,7 +822,7 @@ PERF_TEST_P_(MinPerfTest, TestPerformance)
     cv::GComputation c(GIn(in1, in2), GOut(out));
 
     // Warm-up graph engine:
-    auto cc = c.compile(cv::descr_of(in_mat1), cv::descr_of(in_mat2),
+    auto cc = c.compile(descr_of(gin(in_mat1, in_mat2)),
                         std::move(compile_args));
     cc(gin(in_mat1, in_mat2), gout(out_mat_gapi));
 
@@ -853,7 +858,7 @@ PERF_TEST_P_(MaxPerfTest, TestPerformance)
     cv::GComputation c(GIn(in1, in2), GOut(out));
 
     // Warm-up graph engine:
-    auto cc = c.compile(cv::descr_of(in_mat1), cv::descr_of(in_mat2),
+    auto cc = c.compile(descr_of(gin(in_mat1, in_mat2)),
                         std::move(compile_args));
     cc(gin(in_mat1, in_mat2), gout(out_mat_gapi));
 
@@ -889,7 +894,7 @@ PERF_TEST_P_(AbsDiffPerfTest, TestPerformance)
     cv::GComputation c(GIn(in1, in2), GOut(out));
 
     // Warm-up graph engine:
-    auto cc = c.compile(cv::descr_of(in_mat1), cv::descr_of(in_mat2),
+    auto cc = c.compile(descr_of(gin(in_mat1, in_mat2)),
                         std::move(compile_args));
     cc(gin(in_mat1, in_mat2), gout(out_mat_gapi));
 
@@ -926,7 +931,7 @@ PERF_TEST_P_(AbsDiffCPerfTest, TestPerformance)
     cv::GComputation c(cv::GIn(in1, sc1), cv::GOut(out));
 
     // Warm-up graph engine:
-    auto cc = c.compile(cv::descr_of(in_mat1), descr_of(sc),
+    auto cc = c.compile(descr_of(gin(in_mat1, sc)),
                         std::move(compile_args));
     cc(gin(in_mat1, sc), gout(out_mat_gapi));
 
@@ -965,7 +970,8 @@ PERF_TEST_P_(SumPerfTest, TestPerformance)
     cv::GComputation c(cv::GIn(in), cv::GOut(out));
 
     // Warm-up graph engine:
-    auto cc = c.compile(cv::descr_of(in_mat1), std::move(compile_args));
+    auto cc = c.compile(descr_of(gin(in_mat1)),
+                        std::move(compile_args));
     cc(cv::gin(in_mat1), cv::gout(out_sum));
 
     TEST_CYCLE()
@@ -1006,7 +1012,7 @@ PERF_TEST_P_(AddWeightedPerfTest, TestPerformance)
     cv::GComputation c(GIn(in1, in2), GOut(out));
 
     // Warm-up graph engine:
-    auto cc = c.compile(cv::descr_of(in_mat1), cv::descr_of(in_mat2),
+    auto cc = c.compile(descr_of(gin(in_mat1, in_mat2)),
                         std::move(compile_args));
     cc(gin(in_mat1, in_mat2), gout(out_mat_gapi));
 
@@ -1054,7 +1060,8 @@ PERF_TEST_P_(NormPerfTest, TestPerformance)
     cv::GComputation c(GIn(in1), GOut(out));
 
     // Warm-up graph engine:
-    auto cc = c.compile(cv::descr_of(in_mat1), std::move(compile_args));
+    auto cc = c.compile(descr_of(gin(in_mat1)),
+                        std::move(compile_args));
     cc(gin(in_mat1), gout(out_norm));
 
     TEST_CYCLE()
@@ -1101,7 +1108,8 @@ PERF_TEST_P_(IntegralPerfTest, TestPerformance)
     cv::GComputation c(cv::GIn(in1), cv::GOut(out1, out2));
 
     // Warm-up graph engine:
-    auto cc = c.compile(cv::descr_of(in_mat1), std::move(compile_args));
+    auto cc = c.compile(descr_of(gin(in_mat1)),
+                        std::move(compile_args));
     cc(cv::gin(in_mat1), cv::gout(out_mat1, out_mat2));
 
     TEST_CYCLE()
@@ -1140,8 +1148,7 @@ PERF_TEST_P_(ThresholdPerfTest, TestPerformance)
     cv::GComputation c(GIn(in1, th1, mv1), GOut(out));
 
     // Warm-up graph engine:
-    auto cc = c.compile(cv::descr_of(in_mat1), cv::descr_of(thr),
-                        cv::descr_of(maxval),
+    auto cc = c.compile(descr_of(gin(in_mat1, thr, maxval)),
                         std::move(compile_args));
     cc(gin(in_mat1, thr, maxval), gout(out_mat_gapi));
 
@@ -1181,7 +1188,7 @@ PERF_TEST_P_(ThresholdOTPerfTest, TestPerformance)
     cv::GComputation c(cv::GIn(in1, mv1), cv::GOut(out, scout));
 
     // Warm-up graph engine:
-    auto cc = c.compile(cv::descr_of(in_mat1), cv::descr_of(maxval),
+    auto cc = c.compile(descr_of(gin(in_mat1, maxval)),
                         std::move(compile_args));
     cc(gin(in_mat1, maxval), gout(out_mat_gapi, out_gapi_scalar));
 
@@ -1220,8 +1227,7 @@ PERF_TEST_P_(InRangePerfTest, TestPerformance)
     cv::GComputation c(GIn(in1, th1, mv1), GOut(out));
 
     // Warm-up graph engine:
-    auto cc = c.compile(cv::descr_of(in_mat1), cv::descr_of(thrLow),
-                        cv::descr_of(thrUp),
+    auto cc = c.compile(descr_of(gin(in_mat1, thrLow, thrUp)),
                         std::move(compile_args));
     cc(gin(in_mat1, thrLow, thrUp), gout(out_mat_gapi));
 
@@ -1261,7 +1267,8 @@ PERF_TEST_P_(Split3PerfTest, TestPerformance)
     cv::GComputation c(cv::GIn(in1), cv::GOut(out1, out2, out3));
 
     // Warm-up graph engine:
-    auto cc = c.compile(cv::descr_of(in_mat1), std::move(compile_args));
+    auto cc = c.compile(descr_of(gin(in_mat1)),
+                        std::move(compile_args));
     cc(cv::gin(in_mat1), cv::gout(out_mat_gapi, out_mat2, out_mat3));
 
     TEST_CYCLE()
@@ -1302,7 +1309,8 @@ PERF_TEST_P_(Split4PerfTest, TestPerformance)
     cv::GComputation c(cv::GIn(in1), cv::GOut(out1, out2, out3, out4));
 
     // Warm-up graph engine:
-    auto cc = c.compile(cv::descr_of(in_mat1), std::move(compile_args));
+    auto cc = c.compile(descr_of(gin(in_mat1)),
+                        std::move(compile_args));
     cc(cv::gin(in_mat1), cv::gout(out_mat_gapi, out_mat2, out_mat3, out_mat4));
 
     TEST_CYCLE()
@@ -1342,8 +1350,8 @@ PERF_TEST_P_(Merge3PerfTest, TestPerformance)
     cv::GComputation c(cv::GIn(in1, in2, in3), cv::GOut(out));
 
     // Warm-up graph engine:
-    auto cc = c.compile(cv::descr_of(in_mat1), cv::descr_of(in_mat2),
-                        cv::descr_of(in_mat3), std::move(compile_args));
+    auto cc = c.compile(descr_of(gin(in_mat1, in_mat2, in_mat3)),
+                        std::move(compile_args));
     cc(cv::gin(in_mat1, in_mat2, in_mat3), cv::gout(out_mat_gapi));
 
     TEST_CYCLE()
@@ -1382,8 +1390,7 @@ PERF_TEST_P_(Merge4PerfTest, TestPerformance)
     cv::GComputation c(cv::GIn(in1, in2, in3, in4), cv::GOut(out));
 
     // Warm-up graph engine:
-    auto cc = c.compile(cv::descr_of(in_mat1), cv::descr_of(in_mat2),
-                        cv::descr_of(in_mat3), cv::descr_of(in_mat4),
+    auto cc = c.compile(descr_of(gin(in_mat1, in_mat2, in_mat3, in_mat4)),
                         std::move(compile_args));
     cc(cv::gin(in_mat1, in_mat2, in_mat3, in_mat4), cv::gout(out_mat_gapi));
 
@@ -1421,7 +1428,8 @@ PERF_TEST_P_(RemapPerfTest, TestPerformance)
     cv::GComputation c(in1, out);
 
     // Warm-up graph engine:
-    auto cc = c.compile(cv::descr_of(in_mat1), std::move(compile_args));
+    auto cc = c.compile(descr_of(gin(in_mat1)),
+                        std::move(compile_args));
     cc(in_mat1, out_mat_gapi);
 
     TEST_CYCLE()
@@ -1456,7 +1464,8 @@ PERF_TEST_P_(FlipPerfTest, TestPerformance)
     cv::GComputation c(in, out);
 
     // Warm-up graph engine:
-    auto cc = c.compile(cv::descr_of(in_mat1), std::move(compile_args));
+    auto cc = c.compile(descr_of(gin(in_mat1)),
+                        std::move(compile_args));
     cc(in_mat1, out_mat_gapi);
 
     TEST_CYCLE()
@@ -1492,7 +1501,8 @@ PERF_TEST_P_(CropPerfTest, TestPerformance)
     cv::GComputation c(in, out);
 
     // Warm-up graph engine:
-    auto cc = c.compile(cv::descr_of(in_mat1), std::move(compile_args));
+    auto cc = c.compile(descr_of(gin(in_mat1)),
+                        std::move(compile_args));
     cc(in_mat1, out_mat_gapi);
 
     TEST_CYCLE()
@@ -1527,7 +1537,8 @@ PERF_TEST_P_(CopyPerfTest, TestPerformance)
     cv::GComputation c(in, out);
 
     // Warm-up graph engine:
-    auto cc = c.compile(cv::descr_of(in_mat1), std::move(compile_args));
+    auto cc = c.compile(descr_of(gin(in_mat1)),
+                        std::move(compile_args));
     cc(in_mat1, out_mat_gapi);
 
     TEST_CYCLE()
@@ -1576,7 +1587,7 @@ PERF_TEST_P_(ConcatHorPerfTest, TestPerformance)
     cv::GComputation c(GIn(in1, in2), GOut(out));
 
     // Warm-up graph engine:
-    auto cc = c.compile(cv::descr_of(in_mat1), cv::descr_of(in_mat2),
+    auto cc = c.compile(descr_of(gin(in_mat1, in_mat2)),
                         std::move(compile_args));
     cc(gin(in_mat1, in_mat2), gout(out_mat_gapi));
 
@@ -1631,8 +1642,7 @@ PERF_TEST_P_(ConcatHorVecPerfTest, TestPerformance)
     cv::GComputation c({ mats[0], mats[1], mats[2] }, { out });
 
     // Warm-up graph engine:
-    auto cc = c.compile(cv::descr_of(in_mat1), cv::descr_of(in_mat2),
-                        cv::descr_of(in_mat3),
+    auto cc = c.compile(descr_of(gin(in_mat1, in_mat2, in_mat3)),
                         std::move(compile_args));
     cc(gin(in_mat1, in_mat2, in_mat3), gout(out_mat_gapi));
 
@@ -1681,7 +1691,7 @@ PERF_TEST_P_(ConcatVertPerfTest, TestPerformance)
     cv::GComputation c(GIn(in1, in2), GOut(out));
 
     // Warm-up graph engine:
-    auto cc = c.compile(cv::descr_of(in_mat1), cv::descr_of(in_mat2),
+    auto cc = c.compile(descr_of(gin(in_mat1, in_mat2)),
                         std::move(compile_args));
     cc(gin(in_mat1, in_mat2), gout(out_mat_gapi));
 
@@ -1736,8 +1746,7 @@ PERF_TEST_P_(ConcatVertVecPerfTest, TestPerformance)
     cv::GComputation c({ mats[0], mats[1], mats[2] }, { out });
 
     // Warm-up graph engine:
-    auto cc = c.compile(cv::descr_of(in_mat1), cv::descr_of(in_mat2),
-                        cv::descr_of(in_mat3),
+    auto cc = c.compile(descr_of(gin(in_mat1, in_mat2, in_mat3)),
                         std::move(compile_args));
     cc(gin(in_mat1, in_mat2, in_mat3), gout(out_mat_gapi));
 
@@ -1776,7 +1785,8 @@ PERF_TEST_P_(LUTPerfTest, TestPerformance)
     cv::GComputation c(in, out);
 
     // Warm-up graph engine:
-    auto cc = c.compile(cv::descr_of(in_mat1), std::move(compile_args));
+    auto cc = c.compile(descr_of(gin(in_mat1)),
+                        std::move(compile_args));
     cc(in_mat1, out_mat_gapi);
 
     TEST_CYCLE()
@@ -1812,7 +1822,8 @@ PERF_TEST_P_(ConvertToPerfTest, TestPerformance)
     cv::GComputation c(in, out);
 
     // Warm-up graph engine:
-    auto cc = c.compile(cv::descr_of(in_mat1), std::move(compile_args));
+    auto cc = c.compile(descr_of(gin(in_mat1)),
+                        std::move(compile_args));
     cc(in_mat1, out_mat_gapi);
 
     TEST_CYCLE()
@@ -1854,7 +1865,8 @@ PERF_TEST_P_(ResizePerfTest, TestPerformance)
     cv::GComputation c(in, out);
 
     // Warm-up graph engine:
-    auto cc = c.compile(cv::descr_of(in_mat1), std::move(compile_args));
+    auto cc = c.compile(descr_of(gin(in_mat1)),
+                        std::move(compile_args));
     cc(in_mat1, out_mat_gapi);
 
     TEST_CYCLE()
@@ -1899,7 +1911,8 @@ PERF_TEST_P_(ResizeFxFyPerfTest, TestPerformance)
     cv::GComputation c(in, out);
 
     // Warm-up graph engine:
-    auto cc = c.compile(cv::descr_of(in_mat1), std::move(compile_args));
+    auto cc = c.compile(descr_of(gin(in_mat1)),
+                        std::move(compile_args));
     cc(in_mat1, out_mat_gapi);
 
     TEST_CYCLE()

--- a/modules/gapi/perf/common/gapi_core_perf_tests_inl.hpp
+++ b/modules/gapi/perf/common/gapi_core_perf_tests_inl.hpp
@@ -74,7 +74,7 @@ PERF_TEST_P_(AddCPerfTest, TestPerformance)
 
     // Warm-up graph engine:
     auto cc = c.compile(cv::descr_of(in_mat1), cv::descr_of(sc),
-                        cv::descr_of(out_mat_gapi), std::move(compile_args));
+                        std::move(compile_args));
     cc(gin(in_mat1, sc), gout(out_mat_gapi));
 
     TEST_CYCLE()
@@ -110,7 +110,7 @@ PERF_TEST_P_(SubPerfTest, TestPerformance)
 
     // Warm-up graph engine:
     auto cc = c.compile(cv::descr_of(in_mat1), cv::descr_of(in_mat2),
-                        cv::descr_of(out_mat_gapi), std::move(compile_args));
+                        std::move(compile_args));
     cc(in_mat1, in_mat2, out_mat_gapi);
     
     TEST_CYCLE()
@@ -147,7 +147,7 @@ PERF_TEST_P_(SubCPerfTest, TestPerformance)
 
     // Warm-up graph engine:
     auto cc = c.compile(cv::descr_of(in_mat1), cv::descr_of(sc),
-                        cv::descr_of(out_mat_gapi), std::move(compile_args));
+                        std::move(compile_args));
     cc(gin(in_mat1, sc), gout(out_mat_gapi));
 
     TEST_CYCLE()
@@ -185,7 +185,7 @@ PERF_TEST_P_(SubRCPerfTest, TestPerformance)
     // Warm-up graph engine:
     //auto cc = c.compile(gin(in_mat1, sc), gout(out_mat_gapi), std::move(compile_args));
     auto cc = c.compile(descr_of(in_mat1), descr_of(sc),
-                        descr_of(out_mat_gapi), std::move(compile_args));
+                        std::move(compile_args));
     cc(gin(in_mat1, sc), gout(out_mat_gapi));
 
     TEST_CYCLE()
@@ -221,7 +221,7 @@ PERF_TEST_P_(MulPerfTest, TestPerformance)
 
     // Warm-up graph engine:
     auto cc = c.compile(cv::descr_of(in_mat1), cv::descr_of(in_mat2),
-                    cv::descr_of(out_mat_gapi), std::move(compile_args));
+                        std::move(compile_args));
     cc(in_mat1, in_mat2, out_mat_gapi);
 
     TEST_CYCLE()
@@ -258,8 +258,7 @@ PERF_TEST_P_(MulDoublePerfTest, TestPerformance)
     cv::GComputation c(in1, out);
 
     // Warm-up graph engine:
-    auto cc = c.compile(cv::descr_of(in_mat1), cv::descr_of(out_mat_gapi),
-                        std::move(compile_args));
+    auto cc = c.compile(cv::descr_of(in_mat1), std::move(compile_args));
     cc(in_mat1, out_mat_gapi);
 
     TEST_CYCLE()
@@ -296,7 +295,7 @@ PERF_TEST_P_(MulCPerfTest, TestPerformance)
 
     // Warm-up graph engine:
     auto cc = c.compile(cv::descr_of(in_mat1), cv::descr_of(sc),
-                    cv::descr_of(out_mat_gapi), std::move(compile_args));
+                        std::move(compile_args));
     cc(gin(in_mat1, sc), gout(out_mat_gapi));
 
     TEST_CYCLE()
@@ -334,7 +333,7 @@ PERF_TEST_P_(DivPerfTest, TestPerformance)
 
     // Warm-up graph engine:
     auto cc = c.compile(cv::descr_of(in_mat1), cv::descr_of(in_mat2),
-                    cv::descr_of(out_mat_gapi), std::move(compile_args));
+                        std::move(compile_args));
     cc(in_mat1, in_mat2, out_mat_gapi);
 
     TEST_CYCLE()
@@ -372,7 +371,7 @@ PERF_TEST_P_(DivCPerfTest, TestPerformance)
 
     // Warm-up graph engine:
     auto cc = c.compile(cv::descr_of(in_mat1), cv::descr_of(sc),
-                    cv::descr_of(out_mat_gapi), std::move(compile_args));
+                        std::move(compile_args));
     cc(gin(in_mat1, sc), gout(out_mat_gapi));
 
     TEST_CYCLE()
@@ -415,7 +414,7 @@ PERF_TEST_P_(DivRCPerfTest, TestPerformance)
 
     // Warm-up graph engine:
     auto cc = c.compile(cv::descr_of(in_mat1), cv::descr_of(sc),
-                    cv::descr_of(out_mat_gapi), std::move(compile_args));
+                        std::move(compile_args));
     cc(gin(in_mat1, sc), gout(out_mat_gapi));
 
     TEST_CYCLE()
@@ -454,7 +453,7 @@ PERF_TEST_P_(MaskPerfTest, TestPerformance)
 
     // Warm-up graph engine:
     auto cc = c.compile(cv::descr_of(in_mat1), cv::descr_of(in_mat2),
-                       cv::descr_of(out_mat_gapi), std::move(compile_args));
+                        std::move(compile_args));
     cc(cv::gin(in_mat1, in_mat2), cv::gout(out_mat_gapi));
 
     TEST_CYCLE()
@@ -489,8 +488,7 @@ PERF_TEST_P_(MeanPerfTest, TestPerformance)
     cv::GComputation c(cv::GIn(in), cv::GOut(out));
 
     // Warm-up graph engine:
-    auto cc = c.compile(cv::descr_of(in_mat1), cv::descr_of(out_norm),
-                        std::move(compile_args));
+    auto cc = c.compile(cv::descr_of(in_mat1), std::move(compile_args));
     cc(cv::gin(in_mat1), cv::gout(out_norm));
 
     TEST_CYCLE()
@@ -526,7 +524,6 @@ PERF_TEST_P_(Polar2CartPerfTest, TestPerformance)
 
     // Warm-up graph engine:
     auto cc = c.compile(cv::descr_of(in_mat1), cv::descr_of(in_mat2),
-                        cv::descr_of(out_mat_gapi), cv::descr_of(out_mat2),
                         std::move(compile_args));
     cc(gin(in_mat1, in_mat2), gout(out_mat_gapi, out_mat2));
 
@@ -564,7 +561,6 @@ PERF_TEST_P_(Cart2PolarPerfTest, TestPerformance)
 
     // Warm-up graph engine:
     auto cc = c.compile(cv::descr_of(in_mat1), cv::descr_of(in_mat2),
-                        cv::descr_of(out_mat_gapi), cv::descr_of(out_mat2),
                         std::move(compile_args));
     cc(gin(in_mat1, in_mat2), gout(out_mat_gapi, out_mat2));
 
@@ -611,7 +607,7 @@ PERF_TEST_P_(CmpPerfTest, TestPerformance)
 
     // Warm-up graph engine:
     auto cc = c.compile(cv::descr_of(in_mat1), cv::descr_of(in_mat2),
-                        cv::descr_of(out_mat_gapi), std::move(compile_args));
+                        std::move(compile_args));
     cc(gin(in_mat1, in_mat2), gout(out_mat_gapi));
 
     TEST_CYCLE()
@@ -657,7 +653,7 @@ PERF_TEST_P_(CmpWithScalarPerfTest, TestPerformance)
 
     // Warm-up graph engine:
     auto cc = c.compile(cv::descr_of(in_mat1), cv::descr_of(sc),
-                        cv::descr_of(out_mat_gapi), std::move(compile_args));
+                        std::move(compile_args));
     cc(gin(in_mat1, sc), gout(out_mat_gapi));
 
     TEST_CYCLE()
@@ -714,7 +710,7 @@ PERF_TEST_P_(BitwisePerfTest, TestPerformance)
 
     // Warm-up graph engine:
     auto cc = c.compile(cv::descr_of(in_mat1), cv::descr_of(in_mat2),
-                        cv::descr_of(out_mat_gapi), std::move(compile_args));
+                        std::move(compile_args));
     cc(gin(in_mat1, in_mat2), gout(out_mat_gapi));
 
     TEST_CYCLE()
@@ -748,8 +744,7 @@ PERF_TEST_P_(BitwiseNotPerfTest, TestPerformance)
     cv::GComputation c(in, out);
 
     // Warm-up graph engine:
-    auto cc = c.compile(cv::descr_of(in_mat1), cv::descr_of(out_mat_gapi),
-                        std::move(compile_args));
+    auto cc = c.compile(cv::descr_of(in_mat1), std::move(compile_args));
     cc(in_mat1, out_mat_gapi);
 
     TEST_CYCLE()
@@ -787,7 +782,7 @@ PERF_TEST_P_(SelectPerfTest, TestPerformance)
 
     // Warm-up graph engine:
     auto cc = c.compile(cv::descr_of(in_mat1), cv::descr_of(in_mat2),
-                        cv::descr_of(in_mask), cv::descr_of(out_mat_gapi),
+                        cv::descr_of(in_mask),
                         std::move(compile_args));
     cc(gin(in_mat1, in_mat2, in_mask), gout(out_mat_gapi));
 
@@ -824,7 +819,7 @@ PERF_TEST_P_(MinPerfTest, TestPerformance)
 
     // Warm-up graph engine:
     auto cc = c.compile(cv::descr_of(in_mat1), cv::descr_of(in_mat2),
-                        cv::descr_of(out_mat_gapi), std::move(compile_args));
+                        std::move(compile_args));
     cc(gin(in_mat1, in_mat2), gout(out_mat_gapi));
 
     TEST_CYCLE()
@@ -860,7 +855,7 @@ PERF_TEST_P_(MaxPerfTest, TestPerformance)
 
     // Warm-up graph engine:
     auto cc = c.compile(cv::descr_of(in_mat1), cv::descr_of(in_mat2),
-                        cv::descr_of(out_mat_gapi), std::move(compile_args));
+                        std::move(compile_args));
     cc(gin(in_mat1, in_mat2), gout(out_mat_gapi));
 
     TEST_CYCLE()
@@ -896,7 +891,7 @@ PERF_TEST_P_(AbsDiffPerfTest, TestPerformance)
 
     // Warm-up graph engine:
     auto cc = c.compile(cv::descr_of(in_mat1), cv::descr_of(in_mat2),
-                        cv::descr_of(out_mat_gapi), std::move(compile_args));
+                        std::move(compile_args));
     cc(gin(in_mat1, in_mat2), gout(out_mat_gapi));
 
     TEST_CYCLE()
@@ -933,7 +928,7 @@ PERF_TEST_P_(AbsDiffCPerfTest, TestPerformance)
 
     // Warm-up graph engine:
     auto cc = c.compile(cv::descr_of(in_mat1), descr_of(sc),
-                        descr_of(out_mat_gapi), std::move(compile_args));
+                        std::move(compile_args));
     cc(gin(in_mat1, sc), gout(out_mat_gapi));
 
     TEST_CYCLE()
@@ -971,8 +966,7 @@ PERF_TEST_P_(SumPerfTest, TestPerformance)
     cv::GComputation c(cv::GIn(in), cv::GOut(out));
 
     // Warm-up graph engine:
-    auto cc = c.compile(cv::descr_of(in_mat1), cv::descr_of(out_sum),
-                        std::move(compile_args));
+    auto cc = c.compile(cv::descr_of(in_mat1), std::move(compile_args));
     cc(cv::gin(in_mat1), cv::gout(out_sum));
 
     TEST_CYCLE()
@@ -1014,7 +1008,7 @@ PERF_TEST_P_(AddWeightedPerfTest, TestPerformance)
 
     // Warm-up graph engine:
     auto cc = c.compile(cv::descr_of(in_mat1), cv::descr_of(in_mat2), 
-                        cv::descr_of(out_mat_gapi), std::move(compile_args));
+                        std::move(compile_args));
     cc(gin(in_mat1, in_mat2), gout(out_mat_gapi));
 
     TEST_CYCLE()
@@ -1061,8 +1055,7 @@ PERF_TEST_P_(NormPerfTest, TestPerformance)
     cv::GComputation c(GIn(in1), GOut(out));
 
     // Warm-up graph engine:
-    auto cc = c.compile(cv::descr_of(in_mat1), cv::descr_of(out_norm),
-                        std::move(compile_args));
+    auto cc = c.compile(cv::descr_of(in_mat1), std::move(compile_args));
     cc(gin(in_mat1), gout(out_norm));
 
     TEST_CYCLE()
@@ -1109,8 +1102,7 @@ PERF_TEST_P_(IntegralPerfTest, TestPerformance)
     cv::GComputation c(cv::GIn(in1), cv::GOut(out1, out2));
 
     // Warm-up graph engine:
-    auto cc = c.compile(cv::descr_of(in_mat1), cv::descr_of(out_mat1),
-                        cv::descr_of(out_mat2), std::move(compile_args));
+    auto cc = c.compile(cv::descr_of(in_mat1), std::move(compile_args));
     cc(cv::gin(in_mat1), cv::gout(out_mat1, out_mat2));
 
     TEST_CYCLE()
@@ -1150,7 +1142,7 @@ PERF_TEST_P_(ThresholdPerfTest, TestPerformance)
 
     // Warm-up graph engine:
     auto cc = c.compile(cv::descr_of(in_mat1), cv::descr_of(thr),
-                        cv::descr_of(maxval), cv::descr_of(out_mat_gapi),
+                        cv::descr_of(maxval),
                         std::move(compile_args));
     cc(gin(in_mat1, thr, maxval), gout(out_mat_gapi));
 
@@ -1191,7 +1183,6 @@ PERF_TEST_P_(ThresholdOTPerfTest, TestPerformance)
 
     // Warm-up graph engine:
     auto cc = c.compile(cv::descr_of(in_mat1), cv::descr_of(maxval),
-                        cv::descr_of(out_mat_gapi), cv::descr_of(out_gapi_scalar),
                         std::move(compile_args));
     cc(gin(in_mat1, maxval), gout(out_mat_gapi, out_gapi_scalar));
 
@@ -1231,7 +1222,7 @@ PERF_TEST_P_(InRangePerfTest, TestPerformance)
 
     // Warm-up graph engine:
     auto cc = c.compile(cv::descr_of(in_mat1), cv::descr_of(thrLow),
-                        cv::descr_of(thrUp), cv::descr_of(out_mat_gapi),
+                        cv::descr_of(thrUp),
                         std::move(compile_args));
     cc(gin(in_mat1, thrLow, thrUp), gout(out_mat_gapi));
 
@@ -1271,9 +1262,7 @@ PERF_TEST_P_(Split3PerfTest, TestPerformance)
     cv::GComputation c(cv::GIn(in1), cv::GOut(out1, out2, out3));
 
     // Warm-up graph engine:
-    auto cc = c.compile(cv::descr_of(in_mat1), cv::descr_of(out_mat_gapi),
-                        cv::descr_of(out_mat2), cv::descr_of(out_mat3),
-                        std::move(compile_args));
+    auto cc = c.compile(cv::descr_of(in_mat1), std::move(compile_args));
     cc(cv::gin(in_mat1), cv::gout(out_mat_gapi, out_mat2, out_mat3));
 
     TEST_CYCLE()
@@ -1314,9 +1303,7 @@ PERF_TEST_P_(Split4PerfTest, TestPerformance)
     cv::GComputation c(cv::GIn(in1), cv::GOut(out1, out2, out3, out4));
 
     // Warm-up graph engine:
-    auto cc = c.compile(cv::descr_of(in_mat1), cv::descr_of(out_mat_gapi),
-                        cv::descr_of(out_mat2), cv::descr_of(out_mat3),
-                        cv::descr_of(out_mat4), std::move(compile_args));
+    auto cc = c.compile(cv::descr_of(in_mat1), std::move(compile_args));
     cc(cv::gin(in_mat1), cv::gout(out_mat_gapi, out_mat2, out_mat3, out_mat4));
 
     TEST_CYCLE()
@@ -1357,8 +1344,7 @@ PERF_TEST_P_(Merge3PerfTest, TestPerformance)
 
     // Warm-up graph engine:
     auto cc = c.compile(cv::descr_of(in_mat1), cv::descr_of(in_mat2),
-                        cv::descr_of(in_mat3), cv::descr_of(out_mat_gapi),
-                        std::move(compile_args));
+                        cv::descr_of(in_mat3), std::move(compile_args));
     cc(cv::gin(in_mat1, in_mat2, in_mat3), cv::gout(out_mat_gapi));
 
     TEST_CYCLE()
@@ -1399,7 +1385,6 @@ PERF_TEST_P_(Merge4PerfTest, TestPerformance)
     // Warm-up graph engine:
     auto cc = c.compile(cv::descr_of(in_mat1), cv::descr_of(in_mat2),
                         cv::descr_of(in_mat3), cv::descr_of(in_mat4),
-                        cv::descr_of(out_mat_gapi),
                         std::move(compile_args));
     cc(cv::gin(in_mat1, in_mat2, in_mat3, in_mat4), cv::gout(out_mat_gapi));
 
@@ -1437,8 +1422,7 @@ PERF_TEST_P_(RemapPerfTest, TestPerformance)
     cv::GComputation c(in1, out);
 
     // Warm-up graph engine:
-    auto cc = c.compile(cv::descr_of(in_mat1), cv::descr_of(out_mat_gapi),
-                        std::move(compile_args));
+    auto cc = c.compile(cv::descr_of(in_mat1), std::move(compile_args));
     cc(in_mat1, out_mat_gapi);
 
     TEST_CYCLE()
@@ -1473,8 +1457,7 @@ PERF_TEST_P_(FlipPerfTest, TestPerformance)
     cv::GComputation c(in, out);
 
     // Warm-up graph engine:
-    auto cc = c.compile(cv::descr_of(in_mat1), cv::descr_of(out_mat_gapi),
-                        std::move(compile_args));
+    auto cc = c.compile(cv::descr_of(in_mat1), std::move(compile_args));
     cc(in_mat1, out_mat_gapi);
 
     TEST_CYCLE()
@@ -1510,8 +1493,7 @@ PERF_TEST_P_(CropPerfTest, TestPerformance)
     cv::GComputation c(in, out);
 
     // Warm-up graph engine:
-    auto cc = c.compile(cv::descr_of(in_mat1), cv::descr_of(out_mat_gapi),
-                        std::move(compile_args));
+    auto cc = c.compile(cv::descr_of(in_mat1), std::move(compile_args));
     cc(in_mat1, out_mat_gapi);
 
     TEST_CYCLE()
@@ -1546,8 +1528,7 @@ PERF_TEST_P_(CopyPerfTest, TestPerformance)
     cv::GComputation c(in, out);
 
     // Warm-up graph engine:
-    auto cc = c.compile(cv::descr_of(in_mat1), cv::descr_of(out_mat_gapi),
-                        std::move(compile_args));
+    auto cc = c.compile(cv::descr_of(in_mat1), std::move(compile_args));
     cc(in_mat1, out_mat_gapi);
 
     TEST_CYCLE()
@@ -1597,7 +1578,6 @@ PERF_TEST_P_(ConcatHorPerfTest, TestPerformance)
 
     // Warm-up graph engine:
     auto cc = c.compile(cv::descr_of(in_mat1), cv::descr_of(in_mat2),
-                        cv::descr_of(out_mat_gapi),
                         std::move(compile_args));
     cc(gin(in_mat1, in_mat2), gout(out_mat_gapi));
 
@@ -1653,7 +1633,7 @@ PERF_TEST_P_(ConcatHorVecPerfTest, TestPerformance)
 
     // Warm-up graph engine:
     auto cc = c.compile(cv::descr_of(in_mat1), cv::descr_of(in_mat2),
-                        cv::descr_of(in_mat3), cv::descr_of(out_mat_gapi),
+                        cv::descr_of(in_mat3),
                         std::move(compile_args));
     cc(gin(in_mat1, in_mat2, in_mat3), gout(out_mat_gapi));
 
@@ -1703,7 +1683,6 @@ PERF_TEST_P_(ConcatVertPerfTest, TestPerformance)
 
     // Warm-up graph engine:
     auto cc = c.compile(cv::descr_of(in_mat1), cv::descr_of(in_mat2),
-                        cv::descr_of(out_mat_gapi),
                         std::move(compile_args));
     cc(gin(in_mat1, in_mat2), gout(out_mat_gapi));
 
@@ -1759,7 +1738,7 @@ PERF_TEST_P_(ConcatVertVecPerfTest, TestPerformance)
 
     // Warm-up graph engine:
     auto cc = c.compile(cv::descr_of(in_mat1), cv::descr_of(in_mat2),
-                        cv::descr_of(in_mat3), cv::descr_of(out_mat_gapi),
+                        cv::descr_of(in_mat3),
                         std::move(compile_args));
     cc(gin(in_mat1, in_mat2, in_mat3), gout(out_mat_gapi));
 
@@ -1798,8 +1777,7 @@ PERF_TEST_P_(LUTPerfTest, TestPerformance)
     cv::GComputation c(in, out);
 
     // Warm-up graph engine:
-    auto cc = c.compile(cv::descr_of(in_mat1), cv::descr_of(out_mat_gapi),
-                        std::move(compile_args));
+    auto cc = c.compile(cv::descr_of(in_mat1), std::move(compile_args));
     cc(in_mat1, out_mat_gapi);
 
     TEST_CYCLE()
@@ -1835,8 +1813,7 @@ PERF_TEST_P_(ConvertToPerfTest, TestPerformance)
     cv::GComputation c(in, out);
 
     // Warm-up graph engine:
-    auto cc = c.compile(cv::descr_of(in_mat1), cv::descr_of(out_mat_gapi),
-                        std::move(compile_args));
+    auto cc = c.compile(cv::descr_of(in_mat1), std::move(compile_args));
     cc(in_mat1, out_mat_gapi);
 
     TEST_CYCLE()
@@ -1878,8 +1855,7 @@ PERF_TEST_P_(ResizePerfTest, TestPerformance)
     cv::GComputation c(in, out);
 
     // Warm-up graph engine:
-    auto cc = c.compile(cv::descr_of(in_mat1), cv::descr_of(out_mat_gapi),
-                        std::move(compile_args));
+    auto cc = c.compile(cv::descr_of(in_mat1), std::move(compile_args));
     cc(in_mat1, out_mat_gapi);
 
     TEST_CYCLE()
@@ -1924,8 +1900,7 @@ PERF_TEST_P_(ResizeFxFyPerfTest, TestPerformance)
     cv::GComputation c(in, out);
 
     // Warm-up graph engine:
-    auto cc = c.compile(cv::descr_of(in_mat1), cv::descr_of(out_mat_gapi),
-                        std::move(compile_args));
+    auto cc = c.compile(cv::descr_of(in_mat1), std::move(compile_args));
     cc(in_mat1, out_mat_gapi);
 
     TEST_CYCLE()

--- a/modules/gapi/perf/common/gapi_core_perf_tests_inl.hpp
+++ b/modules/gapi/perf/common/gapi_core_perf_tests_inl.hpp
@@ -36,8 +36,8 @@ PERF_TEST_P_(AddPerfTest, TestPerformance)
     cv::GComputation c(GIn(in1, in2), GOut(out));
 
     // Warm-up graph engine:
-    c.apply(gin(in_mat1, in_mat2), gout(out_mat_gapi));
-    auto cc = c.compile(cv::descr_of(in_mat1), cv::descr_of(in_mat2), compile_args);
+    auto cc = c.compile(cv::descr_of(in_mat1), cv::descr_of(in_mat2), std::move(compile_args));
+    cc(in_mat1, in_mat2, out_mat_gapi);
 
     TEST_CYCLE()
     {
@@ -46,8 +46,8 @@ PERF_TEST_P_(AddPerfTest, TestPerformance)
 
     // Comparison ////////////////////////////////////////////////////////////
     // FIXIT unrealiable check: EXPECT_EQ(0, cv::countNonZero(out_mat_gapi != out_mat_ocv));
-    //EXPECT_EQ(out_mat_gapi.size(), sz);
-    EXPECT_EQ(1, 0);
+    EXPECT_EQ(out_mat_gapi.size(), sz);
+    //EXPECT_EQ(1, 0);
 
     SANITY_CHECK_NOTHING();
 }
@@ -73,11 +73,13 @@ PERF_TEST_P_(AddCPerfTest, TestPerformance)
     cv::GComputation c(GIn(in1, sc1), GOut(out));
 
     // Warm-up graph engine:
-    c.apply(gin(in_mat1, sc), gout(out_mat_gapi), std::move(compile_args));
+    auto cc = c.compile(cv::descr_of(in_mat1), cv::descr_of(sc),
+                        cv::descr_of(out_mat_gapi), std::move(compile_args));
+    cc(gin(in_mat1, sc), gout(out_mat_gapi));
 
     TEST_CYCLE()
     {
-        c.apply(gin(in_mat1, sc), gout(out_mat_gapi), std::move(compile_args));
+        cc(gin(in_mat1, sc), gout(out_mat_gapi));
     }
 
     // Comparison ////////////////////////////////////////////////////////////
@@ -107,11 +109,13 @@ PERF_TEST_P_(SubPerfTest, TestPerformance)
     cv::GComputation c(GIn(in1, in2), GOut(out));
 
     // Warm-up graph engine:
-    c.apply(gin(in_mat1, in_mat2), gout(out_mat_gapi), std::move(compile_args));
-
+    auto cc = c.compile(cv::descr_of(in_mat1), cv::descr_of(in_mat2),
+                        cv::descr_of(out_mat_gapi), std::move(compile_args));
+    cc(in_mat1, in_mat2, out_mat_gapi);
+    
     TEST_CYCLE()
     {
-        c.apply(gin(in_mat1, in_mat2), gout(out_mat_gapi), std::move(compile_args));
+        cc(in_mat1, in_mat2, out_mat_gapi);
     }
 
     // Comparison ////////////////////////////////////////////////////////////
@@ -142,11 +146,13 @@ PERF_TEST_P_(SubCPerfTest, TestPerformance)
     cv::GComputation c(GIn(in1, sc1), GOut(out));
 
     // Warm-up graph engine:
-    c.apply(gin(in_mat1, sc), gout(out_mat_gapi), std::move(compile_args));
+    auto cc = c.compile(cv::descr_of(in_mat1), cv::descr_of(sc),
+                        cv::descr_of(out_mat_gapi), std::move(compile_args));
+    cc(gin(in_mat1, sc), gout(out_mat_gapi));
 
     TEST_CYCLE()
     {
-        c.apply(gin(in_mat1, sc), gout(out_mat_gapi), std::move(compile_args));
+        cc(gin(in_mat1, sc), gout(out_mat_gapi));
     }
 
     // Comparison ////////////////////////////////////////////////////////////
@@ -177,11 +183,14 @@ PERF_TEST_P_(SubRCPerfTest, TestPerformance)
     cv::GComputation c(GIn(in1, sc1), GOut(out));
 
     // Warm-up graph engine:
-    c.apply(gin(in_mat1, sc), gout(out_mat_gapi), std::move(compile_args));
+    //auto cc = c.compile(gin(in_mat1, sc), gout(out_mat_gapi), std::move(compile_args));
+    auto cc = c.compile(descr_of(in_mat1), descr_of(sc),
+                        descr_of(out_mat_gapi), std::move(compile_args));
+    cc(gin(in_mat1, sc), gout(out_mat_gapi));
 
     TEST_CYCLE()
     {
-        c.apply(gin(in_mat1, sc), gout(out_mat_gapi), std::move(compile_args));
+        cc(gin(in_mat1, sc), gout(out_mat_gapi));
     }
 
     // Comparison ////////////////////////////////////////////////////////////
@@ -211,11 +220,13 @@ PERF_TEST_P_(MulPerfTest, TestPerformance)
     cv::GComputation c(GIn(in1, in2), GOut(out));
 
     // Warm-up graph engine:
-    c.apply(gin(in_mat1, in_mat2), gout(out_mat_gapi), std::move(compile_args));
+    auto cc = c.compile(cv::descr_of(in_mat1), cv::descr_of(in_mat2),
+                    cv::descr_of(out_mat_gapi), std::move(compile_args));
+    cc(in_mat1, in_mat2, out_mat_gapi);
 
     TEST_CYCLE()
     {
-        c.apply(gin(in_mat1, in_mat2), gout(out_mat_gapi), std::move(compile_args));
+        cc(in_mat1, in_mat2, out_mat_gapi);
     }
 
     // Comparison ////////////////////////////////////////////////////////////
@@ -247,11 +258,13 @@ PERF_TEST_P_(MulDoublePerfTest, TestPerformance)
     cv::GComputation c(in1, out);
 
     // Warm-up graph engine:
-    c.apply(in_mat1, out_mat_gapi, std::move(compile_args));
+    auto cc = c.compile(cv::descr_of(in_mat1), cv::descr_of(out_mat_gapi),
+                        std::move(compile_args));
+    cc(in_mat1, out_mat_gapi);
 
     TEST_CYCLE()
     {
-        c.apply(in_mat1, out_mat_gapi, std::move(compile_args));
+        cc(in_mat1, out_mat_gapi);
     }
 
     // Comparison ////////////////////////////////////////////////////////////
@@ -282,11 +295,13 @@ PERF_TEST_P_(MulCPerfTest, TestPerformance)
     cv::GComputation c(GIn(in1, sc1), GOut(out));
 
     // Warm-up graph engine:
-    c.apply(gin(in_mat1, sc), gout(out_mat_gapi), std::move(compile_args));
+    auto cc = c.compile(cv::descr_of(in_mat1), cv::descr_of(sc),
+                    cv::descr_of(out_mat_gapi), std::move(compile_args));
+    cc(gin(in_mat1, sc), gout(out_mat_gapi));
 
     TEST_CYCLE()
     {
-        c.apply(gin(in_mat1, sc), gout(out_mat_gapi), std::move(compile_args));
+        cc(gin(in_mat1, sc), gout(out_mat_gapi));
     }
 
     // Comparison ////////////////////////////////////////////////////////////
@@ -315,14 +330,16 @@ PERF_TEST_P_(DivPerfTest, TestPerformance)
     // G-API code ////////////////////////////////////////////////////////////
     cv::GMat in1, in2, out;
     out = cv::gapi::div(in1, in2, dtype);
-    cv::GComputation c(GIn(in1, in2), GOut(out));
+    cv::GComputation c(in1, in2, out);
 
     // Warm-up graph engine:
-    c.apply(gin(in_mat1, in_mat2), gout(out_mat_gapi), std::move(compile_args));
+    auto cc = c.compile(cv::descr_of(in_mat1), cv::descr_of(in_mat2),
+                    cv::descr_of(out_mat_gapi), std::move(compile_args));
+    cc(in_mat1, in_mat2, out_mat_gapi);
 
     TEST_CYCLE()
     {
-        c.apply(gin(in_mat1, in_mat2), gout(out_mat_gapi), std::move(compile_args));
+        cc(in_mat1, in_mat2, out_mat_gapi);
     }
 
     // Comparison ////////////////////////////////////////////////////////////
@@ -354,11 +371,13 @@ PERF_TEST_P_(DivCPerfTest, TestPerformance)
     cv::GComputation c(GIn(in1, sc1), GOut(out));
 
     // Warm-up graph engine:
-    c.apply(gin(in_mat1, sc), gout(out_mat_gapi), std::move(compile_args));
+    auto cc = c.compile(cv::descr_of(in_mat1), cv::descr_of(sc),
+                    cv::descr_of(out_mat_gapi), std::move(compile_args));
+    cc(gin(in_mat1, sc), gout(out_mat_gapi));
 
     TEST_CYCLE()
     {
-        c.apply(gin(in_mat1, sc), gout(out_mat_gapi), std::move(compile_args));
+        cc(gin(in_mat1, sc), gout(out_mat_gapi));
     }
 
     // Comparison ////////////////////////////////////////////////////////////
@@ -395,11 +414,13 @@ PERF_TEST_P_(DivRCPerfTest, TestPerformance)
     cv::GComputation c(GIn(in1, sc1), GOut(out));
 
     // Warm-up graph engine:
-    c.apply(gin(in_mat1, sc), gout(out_mat_gapi), std::move(compile_args));
+    auto cc = c.compile(cv::descr_of(in_mat1), cv::descr_of(sc),
+                    cv::descr_of(out_mat_gapi), std::move(compile_args));
+    cc(gin(in_mat1, sc), gout(out_mat_gapi));
 
     TEST_CYCLE()
     {
-        c.apply(gin(in_mat1, sc), gout(out_mat_gapi), std::move(compile_args));
+        cc(gin(in_mat1, sc), gout(out_mat_gapi));
     }
 
     // Comparison ////////////////////////////////////////////////////////////
@@ -432,11 +453,13 @@ PERF_TEST_P_(MaskPerfTest, TestPerformance)
     cv::GComputation c(cv::GIn(in, m), cv::GOut(out));
 
     // Warm-up graph engine:
-    c.apply(cv::gin(in_mat1, in_mat2), cv::gout(out_mat_gapi), std::move(compile_args));
+    auto cc = c.compile(cv::descr_of(in_mat1), cv::descr_of(in_mat2),
+                       cv::descr_of(out_mat_gapi), std::move(compile_args));
+    cc(cv::gin(in_mat1, in_mat2), cv::gout(out_mat_gapi));
 
     TEST_CYCLE()
     {
-        c.apply(cv::gin(in_mat1, in_mat2), cv::gout(out_mat_gapi), std::move(compile_args));
+        cc(cv::gin(in_mat1, in_mat2), cv::gout(out_mat_gapi));
     }
 
     // Comparison ////////////////////////////////////////////////////////////
@@ -466,11 +489,13 @@ PERF_TEST_P_(MeanPerfTest, TestPerformance)
     cv::GComputation c(cv::GIn(in), cv::GOut(out));
 
     // Warm-up graph engine:
-    c.apply(cv::gin(in_mat1), cv::gout(out_norm), std::move(compile_args));
+    auto cc = c.compile(cv::descr_of(in_mat1), cv::descr_of(out_norm),
+                        std::move(compile_args));
+    cc(cv::gin(in_mat1), cv::gout(out_norm));
 
     TEST_CYCLE()
     {
-        c.apply(cv::gin(in_mat1), cv::gout(out_norm), std::move(compile_args));
+        cc(cv::gin(in_mat1), cv::gout(out_norm));
     }
 
     // Comparison ////////////////////////////////////////////////////////////
@@ -500,11 +525,14 @@ PERF_TEST_P_(Polar2CartPerfTest, TestPerformance)
     cv::GComputation c(GIn(in1, in2), GOut(out1, out2));
 
     // Warm-up graph engine:
-    c.apply(gin(in_mat1, in_mat2), gout(out_mat_gapi, out_mat2), std::move(compile_args));
+    auto cc = c.compile(cv::descr_of(in_mat1), cv::descr_of(in_mat2),
+                        cv::descr_of(out_mat_gapi), cv::descr_of(out_mat2),
+                        std::move(compile_args));
+    cc(gin(in_mat1, in_mat2), gout(out_mat_gapi, out_mat2));
 
     TEST_CYCLE()
     {
-        c.apply(gin(in_mat1, in_mat2), gout(out_mat_gapi, out_mat2), std::move(compile_args));
+        cc(gin(in_mat1, in_mat2), gout(out_mat_gapi, out_mat2));
     }
     // Comparison ////////////////////////////////////////////////////////////
     EXPECT_TRUE(cmpF(out_mat_gapi, out_mat_ocv));
@@ -535,11 +563,14 @@ PERF_TEST_P_(Cart2PolarPerfTest, TestPerformance)
     cv::GComputation c(GIn(in1, in2), GOut(out1, out2));
 
     // Warm-up graph engine:
-    c.apply(gin(in_mat1, in_mat2), gout(out_mat_gapi, out_mat2), std::move(compile_args));
+    auto cc = c.compile(cv::descr_of(in_mat1), cv::descr_of(in_mat2),
+                        cv::descr_of(out_mat_gapi), cv::descr_of(out_mat2),
+                        std::move(compile_args));
+    cc(gin(in_mat1, in_mat2), gout(out_mat_gapi, out_mat2));
 
     TEST_CYCLE()
     {
-        c.apply(gin(in_mat1, in_mat2), gout(out_mat_gapi, out_mat2), std::move(compile_args));
+        cc(gin(in_mat1, in_mat2), gout(out_mat_gapi, out_mat2));
     }
 
     // Comparison ////////////////////////////////////////////////////////////
@@ -579,11 +610,13 @@ PERF_TEST_P_(CmpPerfTest, TestPerformance)
     cv::GComputation c(GIn(in1, in2), GOut(out));
 
     // Warm-up graph engine:
-    c.apply(gin(in_mat1, in_mat2), gout(out_mat_gapi), std::move(compile_args));
+    auto cc = c.compile(cv::descr_of(in_mat1), cv::descr_of(in_mat2),
+                        cv::descr_of(out_mat_gapi), std::move(compile_args));
+    cc(gin(in_mat1, in_mat2), gout(out_mat_gapi));
 
     TEST_CYCLE()
     {
-        c.apply(gin(in_mat1, in_mat2), gout(out_mat_gapi), std::move(compile_args));
+        cc(gin(in_mat1, in_mat2), gout(out_mat_gapi));
     }
 
     // Comparison ////////////////////////////////////////////////////////////
@@ -623,11 +656,13 @@ PERF_TEST_P_(CmpWithScalarPerfTest, TestPerformance)
     cv::GComputation c(GIn(in1, in2), GOut(out));
 
     // Warm-up graph engine:
-    c.apply(gin(in_mat1, sc), gout(out_mat_gapi), std::move(compile_args));
+    auto cc = c.compile(cv::descr_of(in_mat1), cv::descr_of(sc),
+                        cv::descr_of(out_mat_gapi), std::move(compile_args));
+    cc(gin(in_mat1, sc), gout(out_mat_gapi));
 
     TEST_CYCLE()
     {
-        c.apply(gin(in_mat1, sc), gout(out_mat_gapi), std::move(compile_args));
+        cc(gin(in_mat1, sc), gout(out_mat_gapi));
     }
 
     // Comparison ////////////////////////////////////////////////////////////
@@ -678,11 +713,13 @@ PERF_TEST_P_(BitwisePerfTest, TestPerformance)
     cv::GComputation c(GIn(in1, in2), GOut(out));
 
     // Warm-up graph engine:
-    c.apply(gin(in_mat1, in_mat2), gout(out_mat_gapi), std::move(compile_args));
+    auto cc = c.compile(cv::descr_of(in_mat1), cv::descr_of(in_mat2),
+                        cv::descr_of(out_mat_gapi), std::move(compile_args));
+    cc(gin(in_mat1, in_mat2), gout(out_mat_gapi));
 
     TEST_CYCLE()
     {
-        c.apply(gin(in_mat1, in_mat2), gout(out_mat_gapi), std::move(compile_args));
+        cc(gin(in_mat1, in_mat2), gout(out_mat_gapi));
     }
 
     // Comparison ////////////////////////////////////////////////////////////
@@ -711,11 +748,13 @@ PERF_TEST_P_(BitwiseNotPerfTest, TestPerformance)
     cv::GComputation c(in, out);
 
     // Warm-up graph engine:
-    c.apply(in_mat1, out_mat_gapi, std::move(compile_args));
+    auto cc = c.compile(cv::descr_of(in_mat1), cv::descr_of(out_mat_gapi),
+                        std::move(compile_args));
+    cc(in_mat1, out_mat_gapi);
 
     TEST_CYCLE()
     {
-        c.apply(in_mat1, out_mat_gapi, std::move(compile_args));
+        cc(in_mat1, out_mat_gapi);
     }
 
     // Comparison ////////////////////////////////////////////////////////////
@@ -747,11 +786,14 @@ PERF_TEST_P_(SelectPerfTest, TestPerformance)
     cv::GComputation c(GIn(in1, in2, in3), GOut(out));
 
     // Warm-up graph engine:
-    c.apply(gin(in_mat1, in_mat2, in_mask), gout(out_mat_gapi), std::move(compile_args));
+    auto cc = c.compile(cv::descr_of(in_mat1), cv::descr_of(in_mat2),
+                        cv::descr_of(in_mask), cv::descr_of(out_mat_gapi),
+                        std::move(compile_args));
+    cc(gin(in_mat1, in_mat2, in_mask), gout(out_mat_gapi));
 
     TEST_CYCLE()
     {
-        c.apply(gin(in_mat1, in_mat2, in_mask), gout(out_mat_gapi), std::move(compile_args));
+        cc(gin(in_mat1, in_mat2, in_mask), gout(out_mat_gapi));
     }
 
     // Comparison ////////////////////////////////////////////////////////////
@@ -781,11 +823,13 @@ PERF_TEST_P_(MinPerfTest, TestPerformance)
     cv::GComputation c(GIn(in1, in2), GOut(out));
 
     // Warm-up graph engine:
-    c.apply(gin(in_mat1, in_mat2), gout(out_mat_gapi), std::move(compile_args));
+    auto cc = c.compile(cv::descr_of(in_mat1), cv::descr_of(in_mat2),
+                        cv::descr_of(out_mat_gapi), std::move(compile_args));
+    cc(gin(in_mat1, in_mat2), gout(out_mat_gapi));
 
     TEST_CYCLE()
     {
-        c.apply(gin(in_mat1, in_mat2), gout(out_mat_gapi), std::move(compile_args));
+        cc(gin(in_mat1, in_mat2), gout(out_mat_gapi));
     }
 
     // Comparison ////////////////////////////////////////////////////////////
@@ -815,11 +859,13 @@ PERF_TEST_P_(MaxPerfTest, TestPerformance)
     cv::GComputation c(GIn(in1, in2), GOut(out));
 
     // Warm-up graph engine:
-    c.apply(gin(in_mat1, in_mat2), gout(out_mat_gapi), std::move(compile_args));
+    auto cc = c.compile(cv::descr_of(in_mat1), cv::descr_of(in_mat2),
+                        cv::descr_of(out_mat_gapi), std::move(compile_args));
+    cc(gin(in_mat1, in_mat2), gout(out_mat_gapi));
 
     TEST_CYCLE()
     {
-        c.apply(gin(in_mat1, in_mat2), gout(out_mat_gapi), std::move(compile_args));
+        cc(gin(in_mat1, in_mat2), gout(out_mat_gapi));
     }
 
     // Comparison ////////////////////////////////////////////////////////////
@@ -849,11 +895,13 @@ PERF_TEST_P_(AbsDiffPerfTest, TestPerformance)
     cv::GComputation c(GIn(in1, in2), GOut(out));
 
     // Warm-up graph engine:
-    c.apply(gin(in_mat1, in_mat2), gout(out_mat_gapi), std::move(compile_args));
+    auto cc = c.compile(cv::descr_of(in_mat1), cv::descr_of(in_mat2),
+                        cv::descr_of(out_mat_gapi), std::move(compile_args));
+    cc(gin(in_mat1, in_mat2), gout(out_mat_gapi));
 
     TEST_CYCLE()
     {
-        c.apply(gin(in_mat1, in_mat2), gout(out_mat_gapi), std::move(compile_args));
+        cc(gin(in_mat1, in_mat2), gout(out_mat_gapi));
     }
 
     // Comparison ////////////////////////////////////////////////////////////
@@ -884,11 +932,13 @@ PERF_TEST_P_(AbsDiffCPerfTest, TestPerformance)
     cv::GComputation c(cv::GIn(in1, sc1), cv::GOut(out));
 
     // Warm-up graph engine:
-    c.apply(gin(in_mat1, sc), gout(out_mat_gapi), std::move(compile_args));
+    auto cc = c.compile(cv::descr_of(in_mat1), descr_of(sc),
+                        descr_of(out_mat_gapi), std::move(compile_args));
+    cc(gin(in_mat1, sc), gout(out_mat_gapi));
 
     TEST_CYCLE()
     {
-        c.apply(gin(in_mat1, sc), gout(out_mat_gapi), std::move(compile_args));
+        cc(gin(in_mat1, sc), gout(out_mat_gapi));
     }
 
     // Comparison ////////////////////////////////////////////////////////////
@@ -921,11 +971,13 @@ PERF_TEST_P_(SumPerfTest, TestPerformance)
     cv::GComputation c(cv::GIn(in), cv::GOut(out));
 
     // Warm-up graph engine:
-    c.apply(cv::gin(in_mat1), cv::gout(out_sum), std::move(compile_args));
+    auto cc = c.compile(cv::descr_of(in_mat1), cv::descr_of(out_sum),
+                        std::move(compile_args));
+    cc(cv::gin(in_mat1), cv::gout(out_sum));
 
     TEST_CYCLE()
     {
-        c.apply(cv::gin(in_mat1), cv::gout(out_sum), std::move(compile_args));
+        cc(cv::gin(in_mat1), cv::gout(out_sum));
     }
 
     // Comparison ////////////////////////////////////////////////////////////
@@ -961,11 +1013,13 @@ PERF_TEST_P_(AddWeightedPerfTest, TestPerformance)
     cv::GComputation c(GIn(in1, in2), GOut(out));
 
     // Warm-up graph engine:
-    c.apply(gin(in_mat1, in_mat2), gout(out_mat_gapi), std::move(compile_args));
+    auto cc = c.compile(cv::descr_of(in_mat1), cv::descr_of(in_mat2), 
+                        cv::descr_of(out_mat_gapi), std::move(compile_args));
+    cc(gin(in_mat1, in_mat2), gout(out_mat_gapi));
 
     TEST_CYCLE()
     {
-        c.apply(gin(in_mat1, in_mat2), gout(out_mat_gapi), std::move(compile_args));
+        cc(gin(in_mat1, in_mat2), gout(out_mat_gapi));
     }
 
     // Comparison ////////////////////////////////////////////////////////////
@@ -1007,11 +1061,13 @@ PERF_TEST_P_(NormPerfTest, TestPerformance)
     cv::GComputation c(GIn(in1), GOut(out));
 
     // Warm-up graph engine:
-    c.apply(gin(in_mat1), gout(out_norm), std::move(compile_args));
+    auto cc = c.compile(cv::descr_of(in_mat1), cv::descr_of(out_norm),
+                        std::move(compile_args));
+    cc(gin(in_mat1), gout(out_norm));
 
     TEST_CYCLE()
     {
-        c.apply(gin(in_mat1), gout(out_norm), std::move(compile_args));
+        cc(gin(in_mat1), gout(out_norm));
     }
 
     // Comparison ////////////////////////////////////////////////////////////
@@ -1053,11 +1109,13 @@ PERF_TEST_P_(IntegralPerfTest, TestPerformance)
     cv::GComputation c(cv::GIn(in1), cv::GOut(out1, out2));
 
     // Warm-up graph engine:
-    c.apply(cv::gin(in_mat1), cv::gout(out_mat1, out_mat2), std::move(compile_args));
+    auto cc = c.compile(cv::descr_of(in_mat1), cv::descr_of(out_mat1),
+                        cv::descr_of(out_mat2), std::move(compile_args));
+    cc(cv::gin(in_mat1), cv::gout(out_mat1, out_mat2));
 
     TEST_CYCLE()
     {
-        c.apply(cv::gin(in_mat1), cv::gout(out_mat1, out_mat2), std::move(compile_args));
+        cc(cv::gin(in_mat1), cv::gout(out_mat1, out_mat2));
     }
 
     // Comparison ////////////////////////////////////////////////////////////
@@ -1091,11 +1149,14 @@ PERF_TEST_P_(ThresholdPerfTest, TestPerformance)
     cv::GComputation c(GIn(in1, th1, mv1), GOut(out));
 
     // Warm-up graph engine:
-    c.apply(gin(in_mat1, thr, maxval), gout(out_mat_gapi), std::move(compile_args));
+    auto cc = c.compile(cv::descr_of(in_mat1), cv::descr_of(thr),
+                        cv::descr_of(maxval), cv::descr_of(out_mat_gapi),
+                        std::move(compile_args));
+    cc(gin(in_mat1, thr, maxval), gout(out_mat_gapi));
 
     TEST_CYCLE()
     {
-        c.apply(gin(in_mat1, thr, maxval), gout(out_mat_gapi), std::move(compile_args));
+        cc(gin(in_mat1, thr, maxval), gout(out_mat_gapi));
     }
 
     // Comparison ////////////////////////////////////////////////////////////
@@ -1129,11 +1190,14 @@ PERF_TEST_P_(ThresholdOTPerfTest, TestPerformance)
     cv::GComputation c(cv::GIn(in1, mv1), cv::GOut(out, scout));
 
     // Warm-up graph engine:
-    c.apply(gin(in_mat1, maxval), gout(out_mat_gapi, out_gapi_scalar), std::move(compile_args));
+    auto cc = c.compile(cv::descr_of(in_mat1), cv::descr_of(maxval),
+                        cv::descr_of(out_mat_gapi), cv::descr_of(out_gapi_scalar),
+                        std::move(compile_args));
+    cc(gin(in_mat1, maxval), gout(out_mat_gapi, out_gapi_scalar));
 
     TEST_CYCLE()
     {
-        c.apply(gin(in_mat1, maxval), gout(out_mat_gapi, out_gapi_scalar), std::move(compile_args));
+        cc(gin(in_mat1, maxval), gout(out_mat_gapi, out_gapi_scalar));
     }
 
     // Comparison ////////////////////////////////////////////////////////////
@@ -1166,11 +1230,14 @@ PERF_TEST_P_(InRangePerfTest, TestPerformance)
     cv::GComputation c(GIn(in1, th1, mv1), GOut(out));
 
     // Warm-up graph engine:
-    c.apply(gin(in_mat1, thrLow, thrUp), gout(out_mat_gapi), std::move(compile_args));
+    auto cc = c.compile(cv::descr_of(in_mat1), cv::descr_of(thrLow),
+                        cv::descr_of(thrUp), cv::descr_of(out_mat_gapi),
+                        std::move(compile_args));
+    cc(gin(in_mat1, thrLow, thrUp), gout(out_mat_gapi));
 
     TEST_CYCLE()
     {
-        c.apply(gin(in_mat1, thrLow, thrUp), gout(out_mat_gapi), std::move(compile_args));
+        cc(gin(in_mat1, thrLow, thrUp), gout(out_mat_gapi));
     }
 
     // Comparison ////////////////////////////////////////////////////////////
@@ -1204,11 +1271,14 @@ PERF_TEST_P_(Split3PerfTest, TestPerformance)
     cv::GComputation c(cv::GIn(in1), cv::GOut(out1, out2, out3));
 
     // Warm-up graph engine:
-    c.apply(cv::gin(in_mat1), cv::gout(out_mat_gapi, out_mat2, out_mat3), std::move(compile_args));
+    auto cc = c.compile(cv::descr_of(in_mat1), cv::descr_of(out_mat_gapi),
+                        cv::descr_of(out_mat2), cv::descr_of(out_mat3),
+                        std::move(compile_args));
+    cc(cv::gin(in_mat1), cv::gout(out_mat_gapi, out_mat2, out_mat3));
 
     TEST_CYCLE()
     {
-        c.apply(cv::gin(in_mat1), cv::gout(out_mat_gapi, out_mat2, out_mat3), std::move(compile_args));
+        cc(cv::gin(in_mat1), cv::gout(out_mat_gapi, out_mat2, out_mat3));
     }
 
     // Comparison ////////////////////////////////////////////////////////////
@@ -1244,11 +1314,14 @@ PERF_TEST_P_(Split4PerfTest, TestPerformance)
     cv::GComputation c(cv::GIn(in1), cv::GOut(out1, out2, out3, out4));
 
     // Warm-up graph engine:
-    c.apply(cv::gin(in_mat1), cv::gout(out_mat_gapi, out_mat2, out_mat3, out_mat4), std::move(compile_args));
+    auto cc = c.compile(cv::descr_of(in_mat1), cv::descr_of(out_mat_gapi),
+                        cv::descr_of(out_mat2), cv::descr_of(out_mat3),
+                        cv::descr_of(out_mat4), std::move(compile_args));
+    cc(cv::gin(in_mat1), cv::gout(out_mat_gapi, out_mat2, out_mat3, out_mat4));
 
     TEST_CYCLE()
     {
-        c.apply(cv::gin(in_mat1), cv::gout(out_mat_gapi, out_mat2, out_mat3, out_mat4), std::move(compile_args));
+        cc(cv::gin(in_mat1), cv::gout(out_mat_gapi, out_mat2, out_mat3, out_mat4));
     }
 
     // Comparison ////////////////////////////////////////////////////////////
@@ -1283,11 +1356,14 @@ PERF_TEST_P_(Merge3PerfTest, TestPerformance)
     cv::GComputation c(cv::GIn(in1, in2, in3), cv::GOut(out));
 
     // Warm-up graph engine:
-    c.apply(cv::gin(in_mat1, in_mat2, in_mat3), cv::gout(out_mat_gapi), std::move(compile_args));
+    auto cc = c.compile(cv::descr_of(in_mat1), cv::descr_of(in_mat2),
+                        cv::descr_of(in_mat3), cv::descr_of(out_mat_gapi),
+                        std::move(compile_args));
+    cc(cv::gin(in_mat1, in_mat2, in_mat3), cv::gout(out_mat_gapi));
 
     TEST_CYCLE()
     {
-        c.apply(cv::gin(in_mat1, in_mat2, in_mat3), cv::gout(out_mat_gapi), std::move(compile_args));
+        cc(cv::gin(in_mat1, in_mat2, in_mat3), cv::gout(out_mat_gapi));
     }
 
     // Comparison ////////////////////////////////////////////////////////////
@@ -1321,11 +1397,15 @@ PERF_TEST_P_(Merge4PerfTest, TestPerformance)
     cv::GComputation c(cv::GIn(in1, in2, in3, in4), cv::GOut(out));
 
     // Warm-up graph engine:
-    c.apply(cv::gin(in_mat1, in_mat2, in_mat3, in_mat4), cv::gout(out_mat_gapi), std::move(compile_args));
+    auto cc = c.compile(cv::descr_of(in_mat1), cv::descr_of(in_mat2),
+                        cv::descr_of(in_mat3), cv::descr_of(in_mat4),
+                        cv::descr_of(out_mat_gapi),
+                        std::move(compile_args));
+    cc(cv::gin(in_mat1, in_mat2, in_mat3, in_mat4), cv::gout(out_mat_gapi));
 
     TEST_CYCLE()
     {
-        c.apply(cv::gin(in_mat1, in_mat2, in_mat3, in_mat4), cv::gout(out_mat_gapi), std::move(compile_args));
+        cc(cv::gin(in_mat1, in_mat2, in_mat3, in_mat4), cv::gout(out_mat_gapi));
     }
 
     // Comparison ////////////////////////////////////////////////////////////
@@ -1357,11 +1437,13 @@ PERF_TEST_P_(RemapPerfTest, TestPerformance)
     cv::GComputation c(in1, out);
 
     // Warm-up graph engine:
-    c.apply(in_mat1, out_mat_gapi, std::move(compile_args));
+    auto cc = c.compile(cv::descr_of(in_mat1), cv::descr_of(out_mat_gapi),
+                        std::move(compile_args));
+    cc(in_mat1, out_mat_gapi);
 
     TEST_CYCLE()
     {
-        c.apply(in_mat1, out_mat_gapi, std::move(compile_args));
+        cc(in_mat1, out_mat_gapi);
     }
 
     // Comparison ////////////////////////////////////////////////////////////
@@ -1391,11 +1473,13 @@ PERF_TEST_P_(FlipPerfTest, TestPerformance)
     cv::GComputation c(in, out);
 
     // Warm-up graph engine:
-    c.apply(in_mat1, out_mat_gapi, std::move(compile_args));
+    auto cc = c.compile(cv::descr_of(in_mat1), cv::descr_of(out_mat_gapi),
+                        std::move(compile_args));
+    cc(in_mat1, out_mat_gapi);
 
     TEST_CYCLE()
     {
-        c.apply(in_mat1, out_mat_gapi, std::move(compile_args));
+        cc(in_mat1, out_mat_gapi);
     }
 
     // Comparison ////////////////////////////////////////////////////////////
@@ -1426,11 +1510,13 @@ PERF_TEST_P_(CropPerfTest, TestPerformance)
     cv::GComputation c(in, out);
 
     // Warm-up graph engine:
-    c.apply(in_mat1, out_mat_gapi, std::move(compile_args));
+    auto cc = c.compile(cv::descr_of(in_mat1), cv::descr_of(out_mat_gapi),
+                        std::move(compile_args));
+    cc(in_mat1, out_mat_gapi);
 
     TEST_CYCLE()
     {
-        c.apply(in_mat1, out_mat_gapi, std::move(compile_args));
+        cc(in_mat1, out_mat_gapi);
     }
 
     // Comparison ////////////////////////////////////////////////////////////
@@ -1460,11 +1546,13 @@ PERF_TEST_P_(CopyPerfTest, TestPerformance)
     cv::GComputation c(in, out);
 
     // Warm-up graph engine:
-    c.apply(in_mat1, out_mat_gapi, std::move(compile_args));
+    auto cc = c.compile(cv::descr_of(in_mat1), cv::descr_of(out_mat_gapi),
+                        std::move(compile_args));
+    cc(in_mat1, out_mat_gapi);
 
     TEST_CYCLE()
     {
-        c.apply(in_mat1, out_mat_gapi, std::move(compile_args));
+        cc(in_mat1, out_mat_gapi);
     }
 
     // Comparison ////////////////////////////////////////////////////////////
@@ -1508,11 +1596,14 @@ PERF_TEST_P_(ConcatHorPerfTest, TestPerformance)
     cv::GComputation c(GIn(in1, in2), GOut(out));
 
     // Warm-up graph engine:
-    c.apply(gin(in_mat1, in_mat2), gout(out_mat_gapi), std::move(compile_args));
+    auto cc = c.compile(cv::descr_of(in_mat1), cv::descr_of(in_mat2),
+                        cv::descr_of(out_mat_gapi),
+                        std::move(compile_args));
+    cc(gin(in_mat1, in_mat2), gout(out_mat_gapi));
 
     TEST_CYCLE()
     {
-        c.apply(gin(in_mat1, in_mat2), gout(out_mat_gapi), std::move(compile_args));
+        cc(gin(in_mat1, in_mat2), gout(out_mat_gapi));
     }
 
     // Comparison ////////////////////////////////////////////////////////////
@@ -1561,11 +1652,14 @@ PERF_TEST_P_(ConcatHorVecPerfTest, TestPerformance)
     cv::GComputation c({ mats[0], mats[1], mats[2] }, { out });
 
     // Warm-up graph engine:
-    c.apply(gin(in_mat1, in_mat2, in_mat3), gout(out_mat_gapi), std::move(compile_args));
+    auto cc = c.compile(cv::descr_of(in_mat1), cv::descr_of(in_mat2),
+                        cv::descr_of(in_mat3), cv::descr_of(out_mat_gapi),
+                        std::move(compile_args));
+    cc(gin(in_mat1, in_mat2, in_mat3), gout(out_mat_gapi));
 
     TEST_CYCLE()
     {
-        c.apply(gin(in_mat1, in_mat2, in_mat3), gout(out_mat_gapi), std::move(compile_args));
+        cc(gin(in_mat1, in_mat2, in_mat3), gout(out_mat_gapi));
     }
 
     // Comparison ////////////////////////////////////////////////////////////
@@ -1608,11 +1702,14 @@ PERF_TEST_P_(ConcatVertPerfTest, TestPerformance)
     cv::GComputation c(GIn(in1, in2), GOut(out));
 
     // Warm-up graph engine:
-    c.apply(gin(in_mat1, in_mat2), gout(out_mat_gapi), std::move(compile_args));
+    auto cc = c.compile(cv::descr_of(in_mat1), cv::descr_of(in_mat2),
+                        cv::descr_of(out_mat_gapi),
+                        std::move(compile_args));
+    cc(gin(in_mat1, in_mat2), gout(out_mat_gapi));
 
     TEST_CYCLE()
     {
-        c.apply(gin(in_mat1, in_mat2), gout(out_mat_gapi), std::move(compile_args));
+        cc(gin(in_mat1, in_mat2), gout(out_mat_gapi));
     }
 
     // Comparison ////////////////////////////////////////////////////////////
@@ -1661,11 +1758,14 @@ PERF_TEST_P_(ConcatVertVecPerfTest, TestPerformance)
     cv::GComputation c({ mats[0], mats[1], mats[2] }, { out });
 
     // Warm-up graph engine:
-    c.apply(gin(in_mat1, in_mat2, in_mat3), gout(out_mat_gapi), std::move(compile_args));
+    auto cc = c.compile(cv::descr_of(in_mat1), cv::descr_of(in_mat2),
+                        cv::descr_of(in_mat3), cv::descr_of(out_mat_gapi),
+                        std::move(compile_args));
+    cc(gin(in_mat1, in_mat2, in_mat3), gout(out_mat_gapi));
 
     TEST_CYCLE()
     {
-        c.apply(gin(in_mat1, in_mat2, in_mat3), gout(out_mat_gapi), std::move(compile_args));
+        cc(gin(in_mat1, in_mat2, in_mat3), gout(out_mat_gapi));
     }
 
     // Comparison ////////////////////////////////////////////////////////////
@@ -1698,11 +1798,13 @@ PERF_TEST_P_(LUTPerfTest, TestPerformance)
     cv::GComputation c(in, out);
 
     // Warm-up graph engine:
-    c.apply(in_mat1, out_mat_gapi, std::move(compile_args));
+    auto cc = c.compile(cv::descr_of(in_mat1), cv::descr_of(out_mat_gapi),
+                        std::move(compile_args));
+    cc(in_mat1, out_mat_gapi);
 
     TEST_CYCLE()
     {
-        c.apply(in_mat1, out_mat_gapi, std::move(compile_args));
+        cc(in_mat1, out_mat_gapi);
     }
 
     // Comparison ////////////////////////////////////////////////////////////
@@ -1733,11 +1835,13 @@ PERF_TEST_P_(ConvertToPerfTest, TestPerformance)
     cv::GComputation c(in, out);
 
     // Warm-up graph engine:
-    c.apply(in_mat1, out_mat_gapi, std::move(compile_args));
+    auto cc = c.compile(cv::descr_of(in_mat1), cv::descr_of(out_mat_gapi),
+                        std::move(compile_args));
+    cc(in_mat1, out_mat_gapi);
 
     TEST_CYCLE()
     {
-        c.apply(in_mat1, out_mat_gapi, std::move(compile_args));
+        cc(in_mat1, out_mat_gapi);
     }
 
     // Comparison ////////////////////////////////////////////////////////////
@@ -1774,11 +1878,13 @@ PERF_TEST_P_(ResizePerfTest, TestPerformance)
     cv::GComputation c(in, out);
 
     // Warm-up graph engine:
-    c.apply(in_mat1, out_mat_gapi, std::move(compile_args));
+    auto cc = c.compile(cv::descr_of(in_mat1), cv::descr_of(out_mat_gapi),
+                        std::move(compile_args));
+    cc(in_mat1, out_mat_gapi);
 
     TEST_CYCLE()
     {
-        c.apply(in_mat1, out_mat_gapi, std::move(compile_args));
+        cc(in_mat1, out_mat_gapi);
     }
 
     // Comparison ////////////////////////////////////////////////////////////
@@ -1818,11 +1924,13 @@ PERF_TEST_P_(ResizeFxFyPerfTest, TestPerformance)
     cv::GComputation c(in, out);
 
     // Warm-up graph engine:
-    c.apply(in_mat1, out_mat_gapi, std::move(compile_args));
+    auto cc = c.compile(cv::descr_of(in_mat1), cv::descr_of(out_mat_gapi),
+                        std::move(compile_args));
+    cc(in_mat1, out_mat_gapi);
 
     TEST_CYCLE()
     {
-        c.apply(in_mat1, out_mat_gapi, std::move(compile_args));
+        cc(in_mat1, out_mat_gapi);
     }
 
     // Comparison ////////////////////////////////////////////////////////////


### PR DESCRIPTION
Replace 
    c.apply();
With
    cc = c.compile();
    cc();
In g-api performance tests.

Change gapi_core_perf_tests.cpp