### PR TITLE
core(IPP): skip huge input in flip()

### DIFF
--- a/modules/core/src/copy.cpp
+++ b/modules/core/src/copy.cpp
@@ -711,6 +711,13 @@ static bool ipp_flip(Mat &src, Mat &dst, int flip_mode)
 #ifdef HAVE_IPP_IW
     CV_INSTRUMENT_REGION_IPP();
 
+    // Details: https://github.com/opencv/opencv/issues/12943
+    if (flip_mode <= 0 /* swap rows */
+        && cv::ipp::getIppTopFeatures() != ippCPUID_SSE42
+        && (int64_t)(src.total()) * src.elemSize() >= CV_BIG_INT(0x80000000)/*2Gb*/
+    )
+        return false;
+
     IppiAxis ippMode;
     if(flip_mode < 0)
         ippMode = ippAxsBoth;

--- a/modules/core/test/test_mat.cpp
+++ b/modules/core/test/test_mat.cpp
@@ -2035,4 +2035,17 @@ TEST(Core_Eigen, eigen2cv_check_Mat_type)
 }
 #endif // HAVE_EIGEN
 
+TEST(Mat, regression_12943)  // memory usage: ~4.5 Gb
+{
+    applyTestTag(CV_TEST_TAG_MEMORY_6GB);
+
+    const int width = 0x8000;
+    const int height = 0x10001;
+
+    cv::Mat src(height, width, CV_8UC1, Scalar::all(128));
+
+    cv::Mat dst;
+    cv::flip(src, dst, 0);
+}
+
 }} // namespace

--- a/modules/ts/src/ts_tags.cpp
+++ b/modules/ts/src/ts_tags.cpp
@@ -46,7 +46,8 @@ static std::vector<std::string>& getTestTagsSkipList()
 #if OPENCV_32BIT_CONFIGURATION
         testSkipWithTags.push_back(CV_TEST_TAG_MEMORY_2GB);
 #else
-        testSkipWithTags.push_back(CV_TEST_TAG_MEMORY_6GB);
+        if (!cvtest::runBigDataTests)
+            testSkipWithTags.push_back(CV_TEST_TAG_MEMORY_6GB);
 #endif
         testSkipWithTags.push_back(CV_TEST_TAG_VERYLONG);
 #if defined(_DEBUG)


### PR DESCRIPTION
workaround #12943

- IPP/SSE4.2 works well