### PR TITLE
Support software triggering aravis cameras

### DIFF
--- a/modules/videoio/include/opencv2/videoio.hpp
+++ b/modules/videoio/include/opencv2/videoio.hpp
@@ -483,6 +483,16 @@ enum { CAP_PROP_XI_DOWNSAMPLING                                 = 400, //!< Chan
 
 //! @} XIMEA
 
+/** @name XIMEA Camera API
+*  @{
+*/
+
+//! Properties of cameras available through ARAVIS backend
+enum { CAP_PROP_ARAVIS_AUTOTRIGGER                              = 600 //!< Automatically trigger frame capture if camera is configured with software trigger
+};
+
+//! @} ARAVIS
+
 /** @name AVFoundation framework for iOS
     OS X Lion will have the same API
     @{

--- a/modules/videoio/src/cap_aravis.cpp
+++ b/modules/videoio/src/cap_aravis.cpp
@@ -148,6 +148,7 @@ protected:
     double          exposureCompensation;
     bool            autoGain;
     double          targetGrey;             // Target grey value (mid grey))
+    bool            softwareTriggered;      // Flag if the camera is software triggered
 
     gint64          *pixelFormats;
     guint           pixelFormatsCnt;
@@ -275,6 +276,7 @@ bool CvCaptureCAM_Aravis::open( int index )
         exposure = exposureAvailable ? arv_camera_get_exposure_time(camera) : 0;
         gain = gainAvailable ? arv_camera_get_gain(camera) : 0;
         fps = arv_camera_get_frame_rate(camera);
+        softwareTriggered = (strcmp(arv_camera_get_trigger_source(camera), "Software") == 0);
 
         return startCapture();
     }
@@ -290,6 +292,9 @@ bool CvCaptureCAM_Aravis::grabFrame()
         ArvBuffer *arv_buffer = NULL;
         int max_tries = 10;
         int tries = 0;
+        if (softwareTriggered) {
+            arv_camera_software_trigger (camera);
+        }
         for(; tries < max_tries; tries ++) {
             arv_buffer = arv_stream_timeout_pop_buffer (stream, 200000);
             if (arv_buffer != NULL && arv_buffer_get_status (arv_buffer) != ARV_BUFFER_STATUS_SUCCESS) {

--- a/modules/videoio/src/cap_aravis.cpp
+++ b/modules/videoio/src/cap_aravis.cpp
@@ -149,6 +149,7 @@ protected:
     bool            autoGain;
     double          targetGrey;             // Target grey value (mid grey))
     bool            softwareTriggered;      // Flag if the camera is software triggered
+    bool            allowAutoTrigger;       // Flag that user allowed to trigger software triggered cameras automatically
 
     gint64          *pixelFormats;
     guint           pixelFormatsCnt;
@@ -190,6 +191,7 @@ CvCaptureCAM_Aravis::CvCaptureCAM_Aravis()
     exposureCompensation = 0;
     targetGrey = 0;
     frameID = prevFrameID = 0;
+    allowAutoTrigger = false;
 
     num_buffers = 10;
     frame = NULL;
@@ -292,7 +294,7 @@ bool CvCaptureCAM_Aravis::grabFrame()
         ArvBuffer *arv_buffer = NULL;
         int max_tries = 10;
         int tries = 0;
-        if (softwareTriggered) {
+        if (softwareTriggered && allowAutoTrigger) {
             arv_camera_software_trigger (camera);
         }
         for(; tries < max_tries; tries ++) {
@@ -499,6 +501,12 @@ double CvCaptureCAM_Aravis::getProperty( int property_id ) const
                 return out;
             }
             break;
+
+        case CAP_PROP_ARAVIS_AUTOTRIGGER:
+        {
+            return allowAutoTrigger ? 1. : 0.;
+        }
+        break;
     }
     return -1.0;
 }
@@ -583,6 +591,11 @@ bool CvCaptureCAM_Aravis::setProperty( int property_id, double value )
             }
             break;
 
+        case CAP_PROP_ARAVIS_AUTOTRIGGER:
+            {
+                allowAutoTrigger = (bool) value;
+            }
+            break;
 
         default:
             return false;


### PR DESCRIPTION
If an aravis camera is set up to be software triggered, a trigger needs to be explicitly sent using `arv_camera_software_trigger`, otherwise the camera will not grab any frames.

### This pullrequest changes
`modules/videoio/src/cap_aravis.cpp` to support aravis cameras that are set up to be software triggered. Without this change, only hardware-triggered cameras (i.e. cameras receiving a clock/TTL signal to one of their input lines) can grab frames.

```
allow_multiple_commits=1
```