### PR TITLE
COMP: Enabling build with recent VTK version

### DIFF
--- a/modules/viz/src/precomp.hpp
+++ b/modules/viz/src/precomp.hpp
@@ -53,6 +53,7 @@
 #include <iomanip>
 #include <limits>
 
+#include <vtkVersionMacros.h>
 #include <vtkAppendPolyData.h>
 #include <vtkAssemblyPath.h>
 #include <vtkCellData.h>


### PR DESCRIPTION
VTK_MAJOR_VERSION not found unless header is included

### This pullrequest changes

Adds include of vtkVersionMacros.h in precomp.hpp
