### PR TITLE
javadoc: fix generation with OpenJDK 11

### DIFF
--- a/modules/java/jar/CMakeLists.txt
+++ b/modules/java/jar/CMakeLists.txt
@@ -27,6 +27,13 @@ endif()
 
 set(OPENCV_JAVADOC_DESTINATION "${OpenCV_BINARY_DIR}/doc/doxygen/html/javadoc" CACHE STRING "")
 
+# Old Javadoc URL looks like this: https://docs.oracle.com/javase/6/docs/api/
+# New Javadoc URL looks like this: https://docs.oracle.com/en/java/javase/11/docs/api/
+set(OPENCV_JAVADOC_LINK_URL "" CACHE STRING "See details in modules/java/jar/CMakeLists.txt")
+if(OPENCV_JAVADOC_LINK_URL)
+  set(CMAKE_CONFIG_OPENCV_JAVADOC_LINK "link=\"${OPENCV_JAVADOC_LINK_URL}\"")
+endif()
+
 configure_file("${CMAKE_CURRENT_SOURCE_DIR}/build.xml.in" "${OPENCV_JAVA_DIR}/build.xml" @ONLY)
 list(APPEND depends "${OPENCV_JAVA_DIR}/build.xml")
 

--- a/modules/java/jar/build.xml.in
+++ b/modules/java/jar/build.xml.in
@@ -42,7 +42,7 @@
       bottom="Generated on ${timestamp} / OpenCV @OPENCV_VCSVERSION@"
       failonerror="true"
       encoding="UTF-8" charset="UTF-8" docencoding="UTF-8"
-      link="https://docs.oracle.com/javase/6/docs/api/"
+      @CMAKE_CONFIG_OPENCV_JAVADOC_LINK@
       additionalparam="--allow-script-in-comments"
       >
       <Header>


### PR DESCRIPTION
Error message:
> The code being documented uses modules but the packages defined in $URL are in the unnamed module.

```
force_builders_only=Docs
build_image:Docs=docs:18.04
buildworker:Docs=linux-1
```