### PR TITLE
refactor: remove extraneous uses-sdk from Android Lib manifest

### DIFF
--- a/modules/java/android_sdk/android_lib/AndroidManifest.xml
+++ b/modules/java/android_sdk/android_lib/AndroidManifest.xml
@@ -3,6 +3,4 @@
       package="org.opencv"
       android:versionCode="@OPENCV_VERSION_MAJOR@@OPENCV_VERSION_MINOR@@OPENCV_VERSION_PATCH@0"
       android:versionName="@OPENCV_VERSION@">
-
-    <uses-sdk android:minSdkVersion="8" android:targetSdkVersion="21" />
 </manifest>


### PR DESCRIPTION
# This pullrequest changes

The uses-sdk in the Android manifest for the android lib is deprecated and replaced by the declaration in the grade file for this same library. Unless it has a practical purpose, it should be removed. Otherwise it should at least be updated to match the gradle file. The linter throws error syncing gradle when uses-sdk is in an Android manifest. 