### PR TITLE
Vectorizing normDiffInf for 8u,8s multichannel

### DIFF
--- a/modules/core/include/opencv2/core/hal/hal.hpp
+++ b/modules/core/include/opencv2/core/hal/hal.hpp
@@ -86,6 +86,7 @@ CV_EXPORTS int normL1_(const uchar* a, const uchar* b, int n);
 CV_EXPORTS float normL1_(const float* a, const float* b, int n);
 CV_EXPORTS float normL2Sqr_(const float* a, const float* b, int n);
 CV_EXPORTS int normDiffInf_(const uchar* a, const uchar* b, const uchar* mask, int* _result, int len, int cn);
+CV_EXPORTS int normDiffInf_(const schar* a, const schar* b, const uchar* mask, int* _result, int len, int cn);
 
 CV_EXPORTS void exp32f(const float* src, float* dst, int n);
 CV_EXPORTS void exp64f(const double* src, double* dst, int n);

--- a/modules/core/include/opencv2/core/hal/hal.hpp
+++ b/modules/core/include/opencv2/core/hal/hal.hpp
@@ -85,6 +85,7 @@ CV_EXPORTS void gemm64fc(const double* src1, size_t src1_step, const double* src
 CV_EXPORTS int normL1_(const uchar* a, const uchar* b, int n);
 CV_EXPORTS float normL1_(const float* a, const float* b, int n);
 CV_EXPORTS float normL2Sqr_(const float* a, const float* b, int n);
+CV_EXPORTS int normDiffInf_(const uchar* a, const uchar* b, const uchar* mask, int* _result, int len, int cn);
 
 CV_EXPORTS void exp32f(const float* src, float* dst, int n);
 CV_EXPORTS void exp64f(const double* src, double* dst, int n);

--- a/modules/core/perf/perf_norm.cpp
+++ b/modules/core/perf/perf_norm.cpp
@@ -93,11 +93,10 @@ PERF_TEST_P(Size_MatType_NormType, DISABLED_norm2_extra,
 
     Mat src1(sz, matType);
     Mat src2(sz, matType);
-    double n;
 
     declare.in(src1, src2, WARMUP_RNG);
 
-    TEST_CYCLE() n = cv::norm(src1, src2, normType);
+    TEST_CYCLE() cv::norm(src1, src2, normType);
 
     SANITY_CHECK_NOTHING();
 }
@@ -142,11 +141,10 @@ PERF_TEST_P(Size_MatType_NormType, DISABLED_norm2_mask_extra,
     Mat src1(sz, matType);
     Mat src2(sz, matType);
     Mat mask = Mat::ones(sz, CV_8U);
-    double n;
 
     declare.in(src1, src2, WARMUP_RNG).in(mask);
 
-    TEST_CYCLE() n = cv::norm(src1, src2, normType, mask);
+    TEST_CYCLE() cv::norm(src1, src2, normType, mask);
 
     SANITY_CHECK_NOTHING();
 }

--- a/modules/core/perf/perf_norm.cpp
+++ b/modules/core/perf/perf_norm.cpp
@@ -79,6 +79,30 @@ PERF_TEST_P(Size_MatType_NormType, norm2,
     SANITY_CHECK(n, 1e-5, ERROR_RELATIVE);
 }
 
+PERF_TEST_P(Size_MatType_NormType, DISABLED_norm2_extra,
+            testing::Combine(
+                testing::Values(TYPICAL_MAT_SIZES),
+                testing::Values(CV_8UC1, CV_8SC1, CV_16UC1, CV_16SC1, CV_8UC4, CV_32FC1),
+                testing::Values((int)NORM_INF, (int)NORM_L1, (int)NORM_L2, (int)(NORM_RELATIVE+NORM_INF), (int)(NORM_RELATIVE+NORM_L1), (int)(NORM_RELATIVE+NORM_L2))
+                )
+            )
+{
+    Size sz = get<0>(GetParam());
+    int matType = get<1>(GetParam());
+    int normType = get<2>(GetParam());
+
+    Mat src1(sz, matType);
+    Mat src2(sz, matType);
+    double n;
+
+    declare.in(src1, src2, WARMUP_RNG);
+
+    TEST_CYCLE() n = cv::norm(src1, src2, normType);
+
+    SANITY_CHECK_NOTHING();
+}
+
+
 PERF_TEST_P(Size_MatType_NormType, norm2_mask,
             testing::Combine(
                 testing::Values(TYPICAL_MAT_SIZES),
@@ -101,6 +125,30 @@ PERF_TEST_P(Size_MatType_NormType, norm2_mask,
     TEST_CYCLE() n = cv::norm(src1, src2, normType, mask);
 
     SANITY_CHECK(n, 1e-5, ERROR_RELATIVE);
+}
+
+PERF_TEST_P(Size_MatType_NormType, DISABLED_norm2_mask_extra,
+            testing::Combine(
+                testing::Values(TYPICAL_MAT_SIZES),
+                testing::Values(CV_8UC1, CV_8SC1, CV_16UC1, CV_16SC1, CV_8UC4, CV_32FC1),
+                testing::Values((int)NORM_INF, (int)NORM_L1, (int)NORM_L2, (int)(NORM_RELATIVE|NORM_INF), (int)(NORM_RELATIVE|NORM_L1), (int)(NORM_RELATIVE|NORM_L2))
+                )
+            )
+{
+    Size sz = get<0>(GetParam());
+    int matType = get<1>(GetParam());
+    int normType = get<2>(GetParam());
+
+    Mat src1(sz, matType);
+    Mat src2(sz, matType);
+    Mat mask = Mat::ones(sz, CV_8U);
+    double n;
+
+    declare.in(src1, src2, WARMUP_RNG).in(mask);
+
+    TEST_CYCLE() n = cv::norm(src1, src2, normType, mask);
+
+    SANITY_CHECK_NOTHING();
 }
 
 namespace {

--- a/modules/core/src/norm.cpp
+++ b/modules/core/src/norm.cpp
@@ -431,7 +431,7 @@ int normDiffInf_(const uchar* a, const uchar* b, const uchar* mask, int* _result
                 int max10 = v_reduce_max(v_select(v_reinterpret_as_s32(m10), v_reinterpret_as_s32(v_abs(v_reinterpret_as_s32(v_srca210) - v_reinterpret_as_s32(v_srcb210))), v_res));
                 int max11 = v_reduce_max(v_select(v_reinterpret_as_s32(m11), v_reinterpret_as_s32(v_abs(v_reinterpret_as_s32(v_srca211) - v_reinterpret_as_s32(v_srcb211))), v_res));
 #if CV_SIMD256
-                res = std::max(v_reduce_max(v_int32(max00, max01, max02, max03, max04, max05, max06, max07)), v_reduce_max(v_int32(max08, max09, max10, max11, max11, max11, max11, max11));
+                res = std::max(v_reduce_max(v_int32(max00, max01, max02, max03, max04, max05, max06, max07)), v_reduce_max(v_int32(max08, max09, max10, max11, max11, max11, max11, max11)));
 #elif CV_SIMD512
                 res = v_reduce_max(v_int32(max00, max01, max02, max03, max04, max05, max06, max07, max08, max09, max10, max11, max11, max11, max11, max11));
 #else
@@ -543,7 +543,7 @@ int normDiffInf_(const uchar* a, const uchar* b, const uchar* mask, int* _result
                 int max14 = v_reduce_max(v_select(v_reinterpret_as_s32(m10), v_reinterpret_as_s32(v_abs(v_reinterpret_as_s32(v_srca310) - v_reinterpret_as_s32(v_srcb310))), v_res));
                 int max15 = v_reduce_max(v_select(v_reinterpret_as_s32(m11), v_reinterpret_as_s32(v_abs(v_reinterpret_as_s32(v_srca311) - v_reinterpret_as_s32(v_srcb311))), v_res));
 #if CV_SIMD256
-                res = std::max(v_reduce_max(v_int32(max00, max01, max02, max03, max04, max05, max06, max07)), v_reduce_max(v_int32(max08, max09, max10, max11, max12, max13, max14, max15));
+                res = std::max(v_reduce_max(v_int32(max00, max01, max02, max03, max04, max05, max06, max07)), v_reduce_max(v_int32(max08, max09, max10, max11, max12, max13, max14, max15)));
 #elif CV_SIMD512
                 res = v_reduce_max(v_int32(max00, max01, max02, max03, max04, max05, max06, max07, max08, max09, max10, max11, max12, max13, max14, max15));
 #else
@@ -804,7 +804,7 @@ int normDiffInf_(const schar* a, const schar* b, const uchar* mask, int* _result
                 int max10 = v_reduce_max(v_select(v_reinterpret_as_s32(m10), v_reinterpret_as_s32(v_abs(v_srca210 - v_srcb210)), v_res));
                 int max11 = v_reduce_max(v_select(v_reinterpret_as_s32(m11), v_reinterpret_as_s32(v_abs(v_srca211 - v_srcb211)), v_res));
 #if CV_SIMD256
-                res = std::max(v_reduce_max(v_int32(max00, max01, max02, max03, max04, max05, max06, max07)), v_reduce_max(v_int32(max08, max09, max10, max11, max11, max11, max11, max11));
+                res = std::max(v_reduce_max(v_int32(max00, max01, max02, max03, max04, max05, max06, max07)), v_reduce_max(v_int32(max08, max09, max10, max11, max11, max11, max11, max11)));
 #elif CV_SIMD512
                 res = v_reduce_max(v_int32(max00, max01, max02, max03, max04, max05, max06, max07, max08, max09, max10, max11, max11, max11, max11, max11));
 #else
@@ -916,7 +916,7 @@ int normDiffInf_(const schar* a, const schar* b, const uchar* mask, int* _result
                 int max14 = v_reduce_max(v_select(v_reinterpret_as_s32(m10), v_reinterpret_as_s32(v_abs(v_srca310 - v_srcb310)), v_res));
                 int max15 = v_reduce_max(v_select(v_reinterpret_as_s32(m11), v_reinterpret_as_s32(v_abs(v_srca311 - v_srcb311)), v_res));
 #if CV_SIMD256
-                res = std::max(v_reduce_max(v_int32(max00, max01, max02, max03, max04, max05, max06, max07)), v_reduce_max(v_int32(max08, max09, max10, max11, max12, max13, max14, max15));
+                res = std::max(v_reduce_max(v_int32(max00, max01, max02, max03, max04, max05, max06, max07)), v_reduce_max(v_int32(max08, max09, max10, max11, max12, max13, max14, max15)));
 #elif CV_SIMD512
                 res = v_reduce_max(v_int32(max00, max01, max02, max03, max04, max05, max06, max07, max08, max09, max10, max11, max12, max13, max14, max15));
 #else

--- a/modules/core/src/norm.cpp
+++ b/modules/core/src/norm.cpp
@@ -233,7 +233,7 @@ int normDiffInf_(const uchar* a, const uchar* b, const uchar* mask, int* _result
         if( cn == 1 )
         {
 #if CV_SIMD
-            const v_int32 zero = vx_setall_s32((int)0);
+            const v_int32 zero = vx_setzero_s32();
             for(; i <= len - v_uint16::nlanes; i+= v_uint16::nlanes)
             {
                 v_int16 m = v_reinterpret_as_s16(vx_load_expand(mask + i));
@@ -274,8 +274,8 @@ int normDiffInf_(const uchar* a, const uchar* b, const uchar* mask, int* _result
         } else if ( cn == 2 )
         {
 #if CV_SIMD
-            const v_uint32 zero = vx_setall_u32((int)0);
-            for(; i*cn <= len - v_uint8::nlanes*cn; i += v_uint8::nlanes )
+            const v_uint32 zero = vx_setzero_u32();
+            for(; i <= len - v_uint8::nlanes; i += v_uint8::nlanes )
             {
                 v_uint8 m = vx_load(mask + i);
 
@@ -361,8 +361,8 @@ int normDiffInf_(const uchar* a, const uchar* b, const uchar* mask, int* _result
         } else if ( cn == 3 )
         {
 #if CV_SIMD
-            const v_uint32 zero = vx_setall_u32((int)0);
-            for(; i*cn <= len - v_uint8::nlanes*cn; i += v_uint8::nlanes )
+            const v_uint32 zero = vx_setzero_u32();
+            for(; i <= len - v_uint8::nlanes; i += v_uint8::nlanes )
             {
                 v_uint8 m = vx_load(mask + i);
 
@@ -461,8 +461,8 @@ int normDiffInf_(const uchar* a, const uchar* b, const uchar* mask, int* _result
         } else if ( cn == 4 )
         {
 #if CV_SIMD
-            const v_uint32 zero = vx_setall_u32((int)0);
-            for(; i*cn <= len - v_uint8::nlanes*cn; i += v_uint8::nlanes )
+            const v_uint32 zero = vx_setzero_u32();
+            for(; i <= len - v_uint8::nlanes; i += v_uint8::nlanes )
             {
                 v_uint8 m = vx_load(mask + i);
 
@@ -617,7 +617,7 @@ int normDiffInf_(const schar* a, const schar* b, const uchar* mask, int* _result
         if( cn == 1 )
         {
 #if CV_SIMD
-            const v_int32 zero = vx_setall_s32((int)0);
+            const v_int32 zero = vx_setzero_s32();
             for(; i <= len - v_uint16::nlanes; i+= v_uint16::nlanes)
             {
                 v_int16 m = v_reinterpret_as_s16(vx_load_expand(mask + i));
@@ -659,8 +659,8 @@ int normDiffInf_(const schar* a, const schar* b, const uchar* mask, int* _result
         } else if ( cn == 2 )
         {
 #if CV_SIMD
-            const v_uint32 zero = vx_setall_u32((int)0);
-            for(; i*cn <= len - v_uint8::nlanes*cn; i += v_uint8::nlanes )
+            const v_uint32 zero = vx_setzero_u32();
+            for(; i <= len - v_uint8::nlanes; i += v_uint8::nlanes )
             {
                 v_uint8 m = vx_load(mask + i);
 
@@ -744,8 +744,8 @@ int normDiffInf_(const schar* a, const schar* b, const uchar* mask, int* _result
         } else if ( cn == 3 )
         {
 #if CV_SIMD
-            const v_uint32 zero = vx_setall_u32((int)0);
-            for(; i*cn <= len - v_uint8::nlanes*cn; i += v_uint8::nlanes )
+            const v_uint32 zero = vx_setzero_u32();
+            for(; i <= len - v_uint8::nlanes; i += v_uint8::nlanes )
             {
                 v_uint8 m = vx_load(mask + i);
 
@@ -844,8 +844,8 @@ int normDiffInf_(const schar* a, const schar* b, const uchar* mask, int* _result
         } else if ( cn == 4 )
         {
 #if CV_SIMD
-            const v_uint32 zero = vx_setall_u32((int)0);
-            for(; i*cn <= len - v_uint8::nlanes*cn; i += v_uint8::nlanes )
+            const v_uint32 zero = vx_setzero_u32();
+            for(; i <= len - v_uint8::nlanes; i += v_uint8::nlanes )
             {
                 v_uint8 m = vx_load(mask + i);
 

--- a/modules/core/src/norm.cpp
+++ b/modules/core/src/norm.cpp
@@ -227,7 +227,9 @@ int normDiffInf_(const uchar* a, const uchar* b, const uchar* mask, int* _result
             res = std::max(res, (int)std::abs(a[i] - b[i]));
         }
     } else {
+#if CV_SIMD
         int tres;
+#endif
         if( cn == 1 )
         {
 #if CV_SIMD
@@ -333,11 +335,11 @@ int normDiffInf_(const uchar* a, const uchar* b, const uchar* mask, int* _result
                 int max6 = v_reduce_max(v_select(v_reinterpret_as_s32(m10), v_reinterpret_as_s32(v_abs(v_reinterpret_as_s32(v_srca110) - v_reinterpret_as_s32(v_srcb110))), v_res));
                 int max7 = v_reduce_max(v_select(v_reinterpret_as_s32(m11), v_reinterpret_as_s32(v_abs(v_reinterpret_as_s32(v_srca111) - v_reinterpret_as_s32(v_srcb111))), v_res));
 
-#if CV_SIMD256
+#if CV_SIMD512
+                res = v_reduce_max(v_int32(max0, max1, max2, max3, max4, max5, max6, max7, max0, max0, max0, max0, max0, max0, max0, res));
+#elif CV_SIMD256
                 tres = v_reduce_max(v_int32(max0, max1, max2, max3, max4, max5, max6, max7));
                 res = std::max(tres, res);
-#elif CV_SIMD512
-                res = v_reduce_max(v_int32(max0, max1, max2, max3, max4, max5, max6, max7, max0, max0, max0, max0, max0, max0, max0, res));
 #else
                 tres = std::max(v_reduce_max(v_int32(max0, max1, max2, max3)), v_reduce_max(v_int32(max4, max5, max6, max7)));
                 res = std::max(tres, res);
@@ -434,10 +436,10 @@ int normDiffInf_(const uchar* a, const uchar* b, const uchar* mask, int* _result
                 int max09 = v_reduce_max(v_select(v_reinterpret_as_s32(m01), v_reinterpret_as_s32(v_abs(v_reinterpret_as_s32(v_srca201) - v_reinterpret_as_s32(v_srcb201))), v_res));
                 int max10 = v_reduce_max(v_select(v_reinterpret_as_s32(m10), v_reinterpret_as_s32(v_abs(v_reinterpret_as_s32(v_srca210) - v_reinterpret_as_s32(v_srcb210))), v_res));
                 int max11 = v_reduce_max(v_select(v_reinterpret_as_s32(m11), v_reinterpret_as_s32(v_abs(v_reinterpret_as_s32(v_srca211) - v_reinterpret_as_s32(v_srcb211))), v_res));
-#if CV_SIMD256
-                res = std::max(v_reduce_max(v_int32(max00, max01, max02, max03, max04, max05, max06, max07)), v_reduce_max(v_int32(max08, max09, max10, max11, max11, max11, max11, res)));
-#elif CV_SIMD512
+#if CV_SIMD512
                 res = v_reduce_max(v_int32(max00, max01, max02, max03, max04, max05, max06, max07, max08, max09, max10, max11, max11, max11, max11, res));
+#elif CV_SIMD256
+                res = std::max(v_reduce_max(v_int32(max00, max01, max02, max03, max04, max05, max06, max07)), v_reduce_max(v_int32(max08, max09, max10, max11, max11, max11, max11, res)));
 #else
                 tres = std::max(v_reduce_max(v_int32(max00, max01, max02, max03)), v_reduce_max(v_int32(max04, max05, max06, max07)));
                 tres = std::max(tres, v_reduce_max(v_int32(max08, max09, max10, max11)));
@@ -547,11 +549,11 @@ int normDiffInf_(const uchar* a, const uchar* b, const uchar* mask, int* _result
                 int max13 = v_reduce_max(v_select(v_reinterpret_as_s32(m01), v_reinterpret_as_s32(v_abs(v_reinterpret_as_s32(v_srca301) - v_reinterpret_as_s32(v_srcb301))), v_res));
                 int max14 = v_reduce_max(v_select(v_reinterpret_as_s32(m10), v_reinterpret_as_s32(v_abs(v_reinterpret_as_s32(v_srca310) - v_reinterpret_as_s32(v_srcb310))), v_res));
                 int max15 = v_reduce_max(v_select(v_reinterpret_as_s32(m11), v_reinterpret_as_s32(v_abs(v_reinterpret_as_s32(v_srca311) - v_reinterpret_as_s32(v_srcb311))), v_res));
-#if CV_SIMD256
-                tres = std::max(v_reduce_max(v_int32(max00, max01, max02, max03, max04, max05, max06, max07)), v_reduce_max(v_int32(max08, max09, max10, max11, max12, max13, max14, max15)));
-                res = std::max(tres, res);
-#elif CV_SIMD512
+#if CV_SIMD512
                 tres = v_reduce_max(v_int32(max00, max01, max02, max03, max04, max05, max06, max07, max08, max09, max10, max11, max12, max13, max14, max15));
+                res = std::max(tres, res);
+#elif CV_SIMD256
+                tres = std::max(v_reduce_max(v_int32(max00, max01, max02, max03, max04, max05, max06, max07)), v_reduce_max(v_int32(max08, max09, max10, max11, max12, max13, max14, max15)));
                 res = std::max(tres, res);
 #else
                 tres = std::max(v_reduce_max(v_int32(max00, max01, max02, max03)), v_reduce_max(v_int32(max04, max05, max06, max07)));
@@ -609,7 +611,9 @@ int normDiffInf_(const schar* a, const schar* b, const uchar* mask, int* _result
             res = std::max(res, (int)std::abs(a[i] - b[i]));
         }
     } else {
+#if CV_SIMD
         int tres;
+#endif
         if( cn == 1 )
         {
 #if CV_SIMD
@@ -715,12 +719,11 @@ int normDiffInf_(const schar* a, const schar* b, const uchar* mask, int* _result
                 int max5 = v_reduce_max(v_select(v_reinterpret_as_s32(m01), v_reinterpret_as_s32(v_abs(v_srca101 - v_srcb101)), v_res));
                 int max6 = v_reduce_max(v_select(v_reinterpret_as_s32(m10), v_reinterpret_as_s32(v_abs(v_srca110 - v_srcb110)), v_res));
                 int max7 = v_reduce_max(v_select(v_reinterpret_as_s32(m11), v_reinterpret_as_s32(v_abs(v_srca111 - v_srcb111)), v_res));
-
-#if CV_SIMD256
+#if CV_SIMD512
+                res = v_reduce_max(v_int32(max0, max1, max2, max3, max4, max5, max6, max7, max0, max0, max0, max0, max0, max0, max0, res));
+#elif CV_SIMD256
                 tres = v_reduce_max(v_int32(max0, max1, max2, max3, max4, max5, max6, max7));
                 res = std::max(tres, res);
-#elif CV_SIMD512
-                res = v_reduce_max(v_int32(max0, max1, max2, max3, max4, max5, max6, max7, max0, max0, max0, max0, max0, max0, max0, res));
 #else
                 tres = std::max(v_reduce_max(v_int32(max0, max1, max2, max3)), v_reduce_max(v_int32(max4, max5, max6, max7)));
                 res = std::max(tres, res);
@@ -816,10 +819,10 @@ int normDiffInf_(const schar* a, const schar* b, const uchar* mask, int* _result
                 int max09 = v_reduce_max(v_select(v_reinterpret_as_s32(m01), v_reinterpret_as_s32(v_abs(v_srca201 - v_srcb201)), v_res));
                 int max10 = v_reduce_max(v_select(v_reinterpret_as_s32(m10), v_reinterpret_as_s32(v_abs(v_srca210 - v_srcb210)), v_res));
                 int max11 = v_reduce_max(v_select(v_reinterpret_as_s32(m11), v_reinterpret_as_s32(v_abs(v_srca211 - v_srcb211)), v_res));
-#if CV_SIMD256
-                res = std::max(v_reduce_max(v_int32(max00, max01, max02, max03, max04, max05, max06, max07)), v_reduce_max(v_int32(max08, max09, max10, max11, max11, max11, max11, res)));
-#elif CV_SIMD512
+#if CV_SIMD512
                 res = v_reduce_max(v_int32(max00, max01, max02, max03, max04, max05, max06, max07, max08, max09, max10, max11, max11, max11, max11, res));
+#elif CV_SIMD256
+                res = std::max(v_reduce_max(v_int32(max00, max01, max02, max03, max04, max05, max06, max07)), v_reduce_max(v_int32(max08, max09, max10, max11, max11, max11, max11, res)));
 #else
                 tres = std::max(v_reduce_max(v_int32(max00, max01, max02, max03)), v_reduce_max(v_int32(max04, max05, max06, max07)));
                 tres = std::max(tres, v_reduce_max(v_int32(max08, max09, max10, max11)));
@@ -929,11 +932,11 @@ int normDiffInf_(const schar* a, const schar* b, const uchar* mask, int* _result
                 int max13 = v_reduce_max(v_select(v_reinterpret_as_s32(m01), v_reinterpret_as_s32(v_abs(v_srca301 - v_srcb301)), v_res));
                 int max14 = v_reduce_max(v_select(v_reinterpret_as_s32(m10), v_reinterpret_as_s32(v_abs(v_srca310 - v_srcb310)), v_res));
                 int max15 = v_reduce_max(v_select(v_reinterpret_as_s32(m11), v_reinterpret_as_s32(v_abs(v_srca311 - v_srcb311)), v_res));
-#if CV_SIMD256
-                tres = std::max(v_reduce_max(v_int32(max00, max01, max02, max03, max04, max05, max06, max07)), v_reduce_max(v_int32(max08, max09, max10, max11, max12, max13, max14, max15)));
-                res = std::max(tres, res);
-#elif CV_SIMD512
+#if CV_SIMD512
                 tres = v_reduce_max(v_int32(max00, max01, max02, max03, max04, max05, max06, max07, max08, max09, max10, max11, max12, max13, max14, max15));
+                res = std::max(tres, res);
+#elif CV_SIMD256
+                tres = std::max(v_reduce_max(v_int32(max00, max01, max02, max03, max04, max05, max06, max07)), v_reduce_max(v_int32(max08, max09, max10, max11, max12, max13, max14, max15)));
                 res = std::max(tres, res);
 #else
                 tres = std::max(v_reduce_max(v_int32(max00, max01, max02, max03)), v_reduce_max(v_int32(max04, max05, max06, max07)));

--- a/modules/core/src/norm.cpp
+++ b/modules/core/src/norm.cpp
@@ -230,15 +230,16 @@ int normDiffInf_(const uchar* a, const uchar* b, const uchar* mask, int* _result
         if( cn == 1 )
         {
 #if CV_SIMD
-            const v_int16 zero = vx_setall_s16((short)0);
+            const v_int32 zero = vx_setall_s32((int)0);
             for(; i <= len - v_uint16::nlanes; i+= v_uint16::nlanes)
             {
                 v_int16 m = v_reinterpret_as_s16(vx_load_expand(mask + i));
                 v_int32 m0, m1;
 
-                m = m != zero;
-
                 v_expand(m, m0, m1);
+
+                m0 = m0 != zero;
+                m1 = m1 != zero;
 
                 v_int32 v_res = vx_setall_s32(res);
 
@@ -270,7 +271,7 @@ int normDiffInf_(const uchar* a, const uchar* b, const uchar* mask, int* _result
         } else if ( cn == 2 )
         {
 #if CV_SIMD
-            const v_uint32 zero = vx_setall_u32((short)0);
+            const v_uint32 zero = vx_setall_u32((int)0);
             for(; i*cn <= len - v_uint8::nlanes*cn; i += v_uint8::nlanes )
             {
                 v_uint8 m = vx_load(mask + i);
@@ -355,7 +356,7 @@ int normDiffInf_(const uchar* a, const uchar* b, const uchar* mask, int* _result
         } else if ( cn == 3 )
         {
 #if CV_SIMD
-            const v_uint32 zero = vx_setall_u32((short)0);
+            const v_uint32 zero = vx_setall_u32((int)0);
             for(; i*cn <= len - v_uint8::nlanes*cn; i += v_uint8::nlanes )
             {
                 v_uint8 m = vx_load(mask + i);
@@ -454,7 +455,7 @@ int normDiffInf_(const uchar* a, const uchar* b, const uchar* mask, int* _result
         } else if ( cn == 4 )
         {
 #if CV_SIMD
-            const v_uint32 zero = vx_setall_u32((short)0);
+            const v_uint32 zero = vx_setall_u32((int)0);
             for(; i*cn <= len - v_uint8::nlanes*cn; i += v_uint8::nlanes )
             {
                 v_uint8 m = vx_load(mask + i);
@@ -604,15 +605,16 @@ int normDiffInf_(const schar* a, const schar* b, const uchar* mask, int* _result
         if( cn == 1 )
         {
 #if CV_SIMD
-            const v_int16 zero = vx_setall_s16((short)0);
+            const v_int32 zero = vx_setall_s32((int)0);
             for(; i <= len - v_uint16::nlanes; i+= v_uint16::nlanes)
             {
                 v_int16 m = v_reinterpret_as_s16(vx_load_expand(mask + i));
                 v_int32 m0, m1;
 
-                m = m != zero;
-
                 v_expand(m, m0, m1);
+
+                m0 = m0 != zero;
+                m1 = m1 != zero;
 
                 v_int32 v_res = vx_setall_s32(res);
 
@@ -644,7 +646,7 @@ int normDiffInf_(const schar* a, const schar* b, const uchar* mask, int* _result
         } else if ( cn == 2 )
         {
 #if CV_SIMD
-            const v_uint32 zero = vx_setall_u32((short)0);
+            const v_uint32 zero = vx_setall_u32((int)0);
             for(; i*cn <= len - v_uint8::nlanes*cn; i += v_uint8::nlanes )
             {
                 v_uint8 m = vx_load(mask + i);
@@ -728,7 +730,7 @@ int normDiffInf_(const schar* a, const schar* b, const uchar* mask, int* _result
         } else if ( cn == 3 )
         {
 #if CV_SIMD
-            const v_uint32 zero = vx_setall_u32((short)0);
+            const v_uint32 zero = vx_setall_u32((int)0);
             for(; i*cn <= len - v_uint8::nlanes*cn; i += v_uint8::nlanes )
             {
                 v_uint8 m = vx_load(mask + i);
@@ -827,7 +829,7 @@ int normDiffInf_(const schar* a, const schar* b, const uchar* mask, int* _result
         } else if ( cn == 4 )
         {
 #if CV_SIMD
-            const v_uint32 zero = vx_setall_u32((short)0);
+            const v_uint32 zero = vx_setall_u32((int)0);
             for(; i*cn <= len - v_uint8::nlanes*cn; i += v_uint8::nlanes )
             {
                 v_uint8 m = vx_load(mask + i);

--- a/modules/core/src/norm.cpp
+++ b/modules/core/src/norm.cpp
@@ -205,6 +205,41 @@ int normL1_(const uchar* a, const uchar* b, int n)
     return d;
 }
 
+int normDiffInf_(const uchar* a, const uchar* b, const uchar* mask, int* _result, int len, int cn)
+{
+    int i = 0;
+    int res = *_result;
+    int l = len*cn;
+
+    if(!mask)
+    {
+#if CV_SIMD
+        for(; i <= l - v_uint16::nlanes; i += v_uint16::nlanes )
+        {
+            v_int16 srca = v_reinterpret_as_s16(vx_load_expand(a + i));
+            v_int16 srcb = v_reinterpret_as_s16(vx_load_expand(b + i));
+
+            res = std::max(res, (int)v_reduce_max(v_abs(srca - srcb)));
+        }
+#endif
+        for(; i < l; i++)
+        {
+            res = std::max(res, (int)std::abs(a[i] - b[i]));
+        }
+    } else {
+        for(; i < len; i++, a += cn, b += cn)
+        {
+            if( mask[i] )
+            {
+                for(int j = 0; j < cn; j++ )
+                    res = std::max(res, (int)std::abs(a[j] - b[j]));
+            }
+        }
+    }
+    *_result = res;
+    return 0;
+}
+
 }} //cv::hal
 
 //==================================================================================================
@@ -356,7 +391,18 @@ normDiffL2_(const T* src1, const T* src2, const uchar* mask, ST* _result, int le
     CV_DEF_NORM_FUNC(L1, suffix, type, l1type) \
     CV_DEF_NORM_FUNC(L2, suffix, type, l2type)
 
-CV_DEF_NORM_ALL(8u, uchar, int, int, int)
+static int normDiffInf_8u(const uchar* src1, const uchar* src2, const uchar* mask, int* r, int len, int cn)
+{
+    return hal::normDiffInf_(src1, src2, mask, r, len, cn);
+}
+static int normInf_8u(const uchar* src, const uchar* mask, int* r, int len, int cn)
+{
+    return normInf_(src, mask, r, len, cn);
+}
+CV_DEF_NORM_FUNC(L1, 8u, uchar, int)
+CV_DEF_NORM_FUNC(L2, 8u, uchar, int)
+
+//CV_DEF_NORM_ALL(8u, uchar, int, int, int)
 CV_DEF_NORM_ALL(8s, schar, int, int, int)
 CV_DEF_NORM_ALL(16u, ushort, int, int, double)
 CV_DEF_NORM_ALL(16s, short, int, int, double)

--- a/modules/core/src/norm.cpp
+++ b/modules/core/src/norm.cpp
@@ -229,8 +229,8 @@ int normDiffInf_(const uchar* a, const uchar* b, const uchar* mask, int* _result
     } else {
         if( cn == 1 )
         {
-            const v_int16 zero = vx_setall_s16((short)0);
 #if CV_SIMD
+            const v_int16 zero = vx_setall_s16((short)0);
             for(; i <= len - v_uint16::nlanes; i+= v_uint16::nlanes)
             {
                 v_int16 m = v_reinterpret_as_s16(vx_load_expand(mask + i));
@@ -269,6 +269,7 @@ int normDiffInf_(const uchar* a, const uchar* b, const uchar* mask, int* _result
             }
         } else if ( cn == 2 )
         {
+#if CV_SIMD
             const v_uint32 zero = vx_setall_u32((short)0);
             for(; i*cn <= len - v_uint8::nlanes*cn; i += v_uint8::nlanes )
             {
@@ -341,6 +342,7 @@ int normDiffInf_(const uchar* a, const uchar* b, const uchar* mask, int* _result
 
             a += ( i * cn );
             b += ( i * cn );
+#endif
 
             for(; i < len; i++, a += cn, b += cn )
             {
@@ -352,6 +354,7 @@ int normDiffInf_(const uchar* a, const uchar* b, const uchar* mask, int* _result
             }
         } else if ( cn == 3 )
         {
+#if CV_SIMD
             const v_uint32 zero = vx_setall_u32((short)0);
             for(; i*cn <= len - v_uint8::nlanes*cn; i += v_uint8::nlanes )
             {
@@ -439,7 +442,7 @@ int normDiffInf_(const uchar* a, const uchar* b, const uchar* mask, int* _result
 
             a += ( i * cn );
             b += ( i * cn );
-
+#endif
             for(; i < len; i++, a += cn, b += cn )
             {
                 if( mask[i] )
@@ -450,6 +453,7 @@ int normDiffInf_(const uchar* a, const uchar* b, const uchar* mask, int* _result
             }
         } else if ( cn == 4 )
         {
+#if CV_SIMD
             const v_uint32 zero = vx_setall_u32((short)0);
             for(; i*cn <= len - v_uint8::nlanes*cn; i += v_uint8::nlanes )
             {
@@ -551,7 +555,7 @@ int normDiffInf_(const uchar* a, const uchar* b, const uchar* mask, int* _result
 
             a += ( i * cn );
             b += ( i * cn );
-
+#endif
             for(; i < len; i++, a += cn, b += cn )
             {
                 if( mask[i] )
@@ -599,8 +603,8 @@ int normDiffInf_(const schar* a, const schar* b, const uchar* mask, int* _result
     } else {
         if( cn == 1 )
         {
-            const v_int16 zero = vx_setall_s16((short)0);
 #if CV_SIMD
+            const v_int16 zero = vx_setall_s16((short)0);
             for(; i <= len - v_uint16::nlanes; i+= v_uint16::nlanes)
             {
                 v_int16 m = v_reinterpret_as_s16(vx_load_expand(mask + i));
@@ -639,6 +643,7 @@ int normDiffInf_(const schar* a, const schar* b, const uchar* mask, int* _result
             }
         } else if ( cn == 2 )
         {
+#if CV_SIMD
             const v_uint32 zero = vx_setall_u32((short)0);
             for(; i*cn <= len - v_uint8::nlanes*cn; i += v_uint8::nlanes )
             {
@@ -711,7 +716,7 @@ int normDiffInf_(const schar* a, const schar* b, const uchar* mask, int* _result
 
             a += ( i * cn );
             b += ( i * cn );
-
+#endif
             for(; i < len; i++, a += cn, b += cn )
             {
                 if( mask[i] )
@@ -722,6 +727,7 @@ int normDiffInf_(const schar* a, const schar* b, const uchar* mask, int* _result
             }
         } else if ( cn == 3 )
         {
+#if CV_SIMD
             const v_uint32 zero = vx_setall_u32((short)0);
             for(; i*cn <= len - v_uint8::nlanes*cn; i += v_uint8::nlanes )
             {
@@ -809,7 +815,7 @@ int normDiffInf_(const schar* a, const schar* b, const uchar* mask, int* _result
 
             a += ( i * cn );
             b += ( i * cn );
-
+#endif
             for(; i < len; i++, a += cn, b += cn )
             {
                 if( mask[i] )
@@ -820,6 +826,7 @@ int normDiffInf_(const schar* a, const schar* b, const uchar* mask, int* _result
             }
         } else if ( cn == 4 )
         {
+#if CV_SIMD
             const v_uint32 zero = vx_setall_u32((short)0);
             for(; i*cn <= len - v_uint8::nlanes*cn; i += v_uint8::nlanes )
             {
@@ -921,7 +928,7 @@ int normDiffInf_(const schar* a, const schar* b, const uchar* mask, int* _result
 
             a += ( i * cn );
             b += ( i * cn );
-
+#endif
             for(; i < len; i++, a += cn, b += cn )
             {
                 if( mask[i] )

--- a/modules/core/src/norm.cpp
+++ b/modules/core/src/norm.cpp
@@ -431,7 +431,7 @@ int normDiffInf_(const uchar* a, const uchar* b, const uchar* mask, int* _result
                 int max10 = v_reduce_max(v_select(v_reinterpret_as_s32(m10), v_reinterpret_as_s32(v_abs(v_reinterpret_as_s32(v_srca210) - v_reinterpret_as_s32(v_srcb210))), v_res));
                 int max11 = v_reduce_max(v_select(v_reinterpret_as_s32(m11), v_reinterpret_as_s32(v_abs(v_reinterpret_as_s32(v_srca211) - v_reinterpret_as_s32(v_srcb211))), v_res));
 #if CV_SIMD256
-                res = std::max(v_reduce_max(v_int32(max00, max01, max02, max03, max04, max05, max06, max07)), v_reduce_max(v_int32(max08, max09, max10, max11, max11, max11, max11, max11)););
+                res = std::max(v_reduce_max(v_int32(max00, max01, max02, max03, max04, max05, max06, max07)), v_reduce_max(v_int32(max08, max09, max10, max11, max11, max11, max11, max11));
 #elif CV_SIMD512
                 res = v_reduce_max(v_int32(max00, max01, max02, max03, max04, max05, max06, max07, max08, max09, max10, max11, max11, max11, max11, max11));
 #else
@@ -543,7 +543,7 @@ int normDiffInf_(const uchar* a, const uchar* b, const uchar* mask, int* _result
                 int max14 = v_reduce_max(v_select(v_reinterpret_as_s32(m10), v_reinterpret_as_s32(v_abs(v_reinterpret_as_s32(v_srca310) - v_reinterpret_as_s32(v_srcb310))), v_res));
                 int max15 = v_reduce_max(v_select(v_reinterpret_as_s32(m11), v_reinterpret_as_s32(v_abs(v_reinterpret_as_s32(v_srca311) - v_reinterpret_as_s32(v_srcb311))), v_res));
 #if CV_SIMD256
-                res = std::max(v_reduce_max(v_int32(max00, max01, max02, max03, max04, max05, max06, max07)), v_reduce_max(v_int32(max08, max09, max10, max11, max12, max13, max14, max15)););
+                res = std::max(v_reduce_max(v_int32(max00, max01, max02, max03, max04, max05, max06, max07)), v_reduce_max(v_int32(max08, max09, max10, max11, max12, max13, max14, max15));
 #elif CV_SIMD512
                 res = v_reduce_max(v_int32(max00, max01, max02, max03, max04, max05, max06, max07, max08, max09, max10, max11, max12, max13, max14, max15));
 #else
@@ -804,7 +804,7 @@ int normDiffInf_(const schar* a, const schar* b, const uchar* mask, int* _result
                 int max10 = v_reduce_max(v_select(v_reinterpret_as_s32(m10), v_reinterpret_as_s32(v_abs(v_srca210 - v_srcb210)), v_res));
                 int max11 = v_reduce_max(v_select(v_reinterpret_as_s32(m11), v_reinterpret_as_s32(v_abs(v_srca211 - v_srcb211)), v_res));
 #if CV_SIMD256
-                res = std::max(v_reduce_max(v_int32(max00, max01, max02, max03, max04, max05, max06, max07)), v_reduce_max(v_int32(max08, max09, max10, max11, max11, max11, max11, max11)););
+                res = std::max(v_reduce_max(v_int32(max00, max01, max02, max03, max04, max05, max06, max07)), v_reduce_max(v_int32(max08, max09, max10, max11, max11, max11, max11, max11));
 #elif CV_SIMD512
                 res = v_reduce_max(v_int32(max00, max01, max02, max03, max04, max05, max06, max07, max08, max09, max10, max11, max11, max11, max11, max11));
 #else
@@ -916,7 +916,7 @@ int normDiffInf_(const schar* a, const schar* b, const uchar* mask, int* _result
                 int max14 = v_reduce_max(v_select(v_reinterpret_as_s32(m10), v_reinterpret_as_s32(v_abs(v_srca310 - v_srcb310)), v_res));
                 int max15 = v_reduce_max(v_select(v_reinterpret_as_s32(m11), v_reinterpret_as_s32(v_abs(v_srca311 - v_srcb311)), v_res));
 #if CV_SIMD256
-                res = std::max(v_reduce_max(v_int32(max00, max01, max02, max03, max04, max05, max06, max07)), v_reduce_max(v_int32(max08, max09, max10, max11, max12, max13, max14, max15)););
+                res = std::max(v_reduce_max(v_int32(max00, max01, max02, max03, max04, max05, max06, max07)), v_reduce_max(v_int32(max08, max09, max10, max11, max12, max13, max14, max15));
 #elif CV_SIMD512
                 res = v_reduce_max(v_int32(max00, max01, max02, max03, max04, max05, max06, max07, max08, max09, max10, max11, max12, max13, max14, max15));
 #else

--- a/modules/core/src/norm.cpp
+++ b/modules/core/src/norm.cpp
@@ -227,6 +227,7 @@ int normDiffInf_(const uchar* a, const uchar* b, const uchar* mask, int* _result
             res = std::max(res, (int)std::abs(a[i] - b[i]));
         }
     } else {
+        int tres;
         if( cn == 1 )
         {
 #if CV_SIMD
@@ -243,7 +244,6 @@ int normDiffInf_(const uchar* a, const uchar* b, const uchar* mask, int* _result
 
                 v_int32 v_res = vx_setall_s32(res);
 
-
                 v_int16 srca = v_reinterpret_as_s16(vx_load_expand(a + i));
                 v_int32 srca0, srca1;
 
@@ -257,7 +257,8 @@ int normDiffInf_(const uchar* a, const uchar* b, const uchar* mask, int* _result
                 int max0 = v_reduce_max(v_select(m0, v_reinterpret_as_s32(v_abs(srca0 - srcb0)), v_res));
                 int max1 = v_reduce_max(v_select(m1, v_reinterpret_as_s32(v_abs(srca1 - srcb1)), v_res));
 
-                res = std::max(max0 ,max1);
+                tres = std::max(max0 ,max1);
+                res = std::max(tres, res);
 
             }
 #endif
@@ -333,11 +334,13 @@ int normDiffInf_(const uchar* a, const uchar* b, const uchar* mask, int* _result
                 int max7 = v_reduce_max(v_select(v_reinterpret_as_s32(m11), v_reinterpret_as_s32(v_abs(v_reinterpret_as_s32(v_srca111) - v_reinterpret_as_s32(v_srcb111))), v_res));
 
 #if CV_SIMD256
-                res = v_reduce_max(v_int32(max0, max1, max2, max3, max4, max5, max6, max7));
+                tres = v_reduce_max(v_int32(max0, max1, max2, max3, max4, max5, max6, max7));
+                res = std::max(tres, res);
 #elif CV_SIMD512
-                res = v_reduce_max(v_int32(max0, max1, max2, max3, max4, max5, max6, max7, max0, max0, max0, max0, max0, max0, max0, max0));
+                res = v_reduce_max(v_int32(max0, max1, max2, max3, max4, max5, max6, max7, max0, max0, max0, max0, max0, max0, max0, res));
 #else
-                res = std::max(v_reduce_max(v_int32(max0, max1, max2, max3)), v_reduce_max(v_int32(max4, max5, max6, max7)));
+                tres = std::max(v_reduce_max(v_int32(max0, max1, max2, max3)), v_reduce_max(v_int32(max4, max5, max6, max7)));
+                res = std::max(tres, res);
 #endif
             }
 
@@ -432,12 +435,13 @@ int normDiffInf_(const uchar* a, const uchar* b, const uchar* mask, int* _result
                 int max10 = v_reduce_max(v_select(v_reinterpret_as_s32(m10), v_reinterpret_as_s32(v_abs(v_reinterpret_as_s32(v_srca210) - v_reinterpret_as_s32(v_srcb210))), v_res));
                 int max11 = v_reduce_max(v_select(v_reinterpret_as_s32(m11), v_reinterpret_as_s32(v_abs(v_reinterpret_as_s32(v_srca211) - v_reinterpret_as_s32(v_srcb211))), v_res));
 #if CV_SIMD256
-                res = std::max(v_reduce_max(v_int32(max00, max01, max02, max03, max04, max05, max06, max07)), v_reduce_max(v_int32(max08, max09, max10, max11, max11, max11, max11, max11)));
+                res = std::max(v_reduce_max(v_int32(max00, max01, max02, max03, max04, max05, max06, max07)), v_reduce_max(v_int32(max08, max09, max10, max11, max11, max11, max11, res)));
 #elif CV_SIMD512
-                res = v_reduce_max(v_int32(max00, max01, max02, max03, max04, max05, max06, max07, max08, max09, max10, max11, max11, max11, max11, max11));
+                res = v_reduce_max(v_int32(max00, max01, max02, max03, max04, max05, max06, max07, max08, max09, max10, max11, max11, max11, max11, res));
 #else
-                res = std::max(v_reduce_max(v_int32(max00, max01, max02, max03)), v_reduce_max(v_int32(max04, max05, max06, max07)));
-                res = std::max(res, v_reduce_max(v_int32(max08, max09, max10, max11)));
+                tres = std::max(v_reduce_max(v_int32(max00, max01, max02, max03)), v_reduce_max(v_int32(max04, max05, max06, max07)));
+                tres = std::max(tres, v_reduce_max(v_int32(max08, max09, max10, max11)));
+                res = std::max(tres, res);
 #endif
             }
 
@@ -544,13 +548,16 @@ int normDiffInf_(const uchar* a, const uchar* b, const uchar* mask, int* _result
                 int max14 = v_reduce_max(v_select(v_reinterpret_as_s32(m10), v_reinterpret_as_s32(v_abs(v_reinterpret_as_s32(v_srca310) - v_reinterpret_as_s32(v_srcb310))), v_res));
                 int max15 = v_reduce_max(v_select(v_reinterpret_as_s32(m11), v_reinterpret_as_s32(v_abs(v_reinterpret_as_s32(v_srca311) - v_reinterpret_as_s32(v_srcb311))), v_res));
 #if CV_SIMD256
-                res = std::max(v_reduce_max(v_int32(max00, max01, max02, max03, max04, max05, max06, max07)), v_reduce_max(v_int32(max08, max09, max10, max11, max12, max13, max14, max15)));
+                tres = std::max(v_reduce_max(v_int32(max00, max01, max02, max03, max04, max05, max06, max07)), v_reduce_max(v_int32(max08, max09, max10, max11, max12, max13, max14, max15)));
+                res = std::max(tres, res);
 #elif CV_SIMD512
-                res = v_reduce_max(v_int32(max00, max01, max02, max03, max04, max05, max06, max07, max08, max09, max10, max11, max12, max13, max14, max15));
+                tres = v_reduce_max(v_int32(max00, max01, max02, max03, max04, max05, max06, max07, max08, max09, max10, max11, max12, max13, max14, max15));
+                res = std::max(tres, res);
 #else
-                res = std::max(v_reduce_max(v_int32(max00, max01, max02, max03)), v_reduce_max(v_int32(max04, max05, max06, max07)));
-                res = std::max(res, v_reduce_max(v_int32(max08, max09, max10, max11)));
-                res = std::max(res, v_reduce_max(v_int32(max12, max13, max14, max15)));
+                tres = std::max(v_reduce_max(v_int32(max00, max01, max02, max03)), v_reduce_max(v_int32(max04, max05, max06, max07)));
+                tres = std::max(tres, v_reduce_max(v_int32(max08, max09, max10, max11)));
+                tres = std::max(tres, v_reduce_max(v_int32(max12, max13, max14, max15)));
+                res = std::max(tres, res);
 #endif
             }
 
@@ -602,6 +609,7 @@ int normDiffInf_(const schar* a, const schar* b, const uchar* mask, int* _result
             res = std::max(res, (int)std::abs(a[i] - b[i]));
         }
     } else {
+        int tres;
         if( cn == 1 )
         {
 #if CV_SIMD
@@ -632,7 +640,8 @@ int normDiffInf_(const schar* a, const schar* b, const uchar* mask, int* _result
                 int max0 = v_reduce_max(v_select(m0, v_reinterpret_as_s32(v_abs(srca0 - srcb0)), v_res));
                 int max1 = v_reduce_max(v_select(m1, v_reinterpret_as_s32(v_abs(srca1 - srcb1)), v_res));
 
-                res = std::max(max0 ,max1);
+                tres = std::max(max0 ,max1);
+                res = std::max(tres, res);
 
             }
 #endif
@@ -708,11 +717,13 @@ int normDiffInf_(const schar* a, const schar* b, const uchar* mask, int* _result
                 int max7 = v_reduce_max(v_select(v_reinterpret_as_s32(m11), v_reinterpret_as_s32(v_abs(v_srca111 - v_srcb111)), v_res));
 
 #if CV_SIMD256
-                res = v_reduce_max(v_int32(max0, max1, max2, max3, max4, max5, max6, max7));
+                tres = v_reduce_max(v_int32(max0, max1, max2, max3, max4, max5, max6, max7));
+                res = std::max(tres, res);
 #elif CV_SIMD512
-                res = v_reduce_max(v_int32(max0, max1, max2, max3, max4, max5, max6, max7, max0, max0, max0, max0, max0, max0, max0, max0));
+                res = v_reduce_max(v_int32(max0, max1, max2, max3, max4, max5, max6, max7, max0, max0, max0, max0, max0, max0, max0, res));
 #else
-                res = std::max(v_reduce_max(v_int32(max0, max1, max2, max3)), v_reduce_max(v_int32(max4, max5, max6, max7)));
+                tres = std::max(v_reduce_max(v_int32(max0, max1, max2, max3)), v_reduce_max(v_int32(max4, max5, max6, max7)));
+                res = std::max(tres, res);
 #endif
             }
 
@@ -806,12 +817,13 @@ int normDiffInf_(const schar* a, const schar* b, const uchar* mask, int* _result
                 int max10 = v_reduce_max(v_select(v_reinterpret_as_s32(m10), v_reinterpret_as_s32(v_abs(v_srca210 - v_srcb210)), v_res));
                 int max11 = v_reduce_max(v_select(v_reinterpret_as_s32(m11), v_reinterpret_as_s32(v_abs(v_srca211 - v_srcb211)), v_res));
 #if CV_SIMD256
-                res = std::max(v_reduce_max(v_int32(max00, max01, max02, max03, max04, max05, max06, max07)), v_reduce_max(v_int32(max08, max09, max10, max11, max11, max11, max11, max11)));
+                res = std::max(v_reduce_max(v_int32(max00, max01, max02, max03, max04, max05, max06, max07)), v_reduce_max(v_int32(max08, max09, max10, max11, max11, max11, max11, res)));
 #elif CV_SIMD512
-                res = v_reduce_max(v_int32(max00, max01, max02, max03, max04, max05, max06, max07, max08, max09, max10, max11, max11, max11, max11, max11));
+                res = v_reduce_max(v_int32(max00, max01, max02, max03, max04, max05, max06, max07, max08, max09, max10, max11, max11, max11, max11, res));
 #else
-                res = std::max(v_reduce_max(v_int32(max00, max01, max02, max03)), v_reduce_max(v_int32(max04, max05, max06, max07)));
-                res = std::max(res, v_reduce_max(v_int32(max08, max09, max10, max11)));
+                tres = std::max(v_reduce_max(v_int32(max00, max01, max02, max03)), v_reduce_max(v_int32(max04, max05, max06, max07)));
+                tres = std::max(tres, v_reduce_max(v_int32(max08, max09, max10, max11)));
+                res = std::max(tres, res);
 #endif
             }
 
@@ -918,13 +930,16 @@ int normDiffInf_(const schar* a, const schar* b, const uchar* mask, int* _result
                 int max14 = v_reduce_max(v_select(v_reinterpret_as_s32(m10), v_reinterpret_as_s32(v_abs(v_srca310 - v_srcb310)), v_res));
                 int max15 = v_reduce_max(v_select(v_reinterpret_as_s32(m11), v_reinterpret_as_s32(v_abs(v_srca311 - v_srcb311)), v_res));
 #if CV_SIMD256
-                res = std::max(v_reduce_max(v_int32(max00, max01, max02, max03, max04, max05, max06, max07)), v_reduce_max(v_int32(max08, max09, max10, max11, max12, max13, max14, max15)));
+                tres = std::max(v_reduce_max(v_int32(max00, max01, max02, max03, max04, max05, max06, max07)), v_reduce_max(v_int32(max08, max09, max10, max11, max12, max13, max14, max15)));
+                res = std::max(tres, res);
 #elif CV_SIMD512
-                res = v_reduce_max(v_int32(max00, max01, max02, max03, max04, max05, max06, max07, max08, max09, max10, max11, max12, max13, max14, max15));
+                tres = v_reduce_max(v_int32(max00, max01, max02, max03, max04, max05, max06, max07, max08, max09, max10, max11, max12, max13, max14, max15));
+                res = std::max(tres, res);
 #else
-                res = std::max(v_reduce_max(v_int32(max00, max01, max02, max03)), v_reduce_max(v_int32(max04, max05, max06, max07)));
-                res = std::max(res, v_reduce_max(v_int32(max08, max09, max10, max11)));
-                res = std::max(res, v_reduce_max(v_int32(max12, max13, max14, max15)));
+                tres = std::max(v_reduce_max(v_int32(max00, max01, max02, max03)), v_reduce_max(v_int32(max04, max05, max06, max07)));
+                tres = std::max(tres, v_reduce_max(v_int32(max08, max09, max10, max11)));
+                tres = std::max(tres, v_reduce_max(v_int32(max12, max13, max14, max15)));
+                res = std::max(tres, res);
 #endif
             }
 


### PR DESCRIPTION
### This pullrequest changes

* Vectorize normDiffInf for uchar and schar with masking and multichannel.
* Adding additional performance tests for norm2 and norm2_mask disabled by default.

Performance gain of up to 2x on Intel for images around 1920x1024.

<cut/>

```
force_builders=Linux AVX2,Custom
buildworker:Custom=linux-3
build_image:Custom=ubuntu:18.04
CPU_BASELINE:Custom=AVX512_SKX
disable_ipp=ON
```