### PR TITLE
G-API: Fix for "using cv makes G_TYPED_KERNEL fail"

### DIFF
--- a/modules/gapi/include/opencv2/gapi/gkernel.hpp
+++ b/modules/gapi/include/opencv2/gapi/gkernel.hpp
@@ -230,27 +230,25 @@ public:
 // The problem is that every typed kernel should have ::id() but body
 // of the class is defined by user (with outMeta, other stuff)
 
+//! @cond IGNORED
 #define G_ID_HELPER_CLASS(Class)  Class##IdHelper
 
 #define G_ID_HELPER_BODY(Class, Id)                                         \
-    namespace detail                                                        \
+    struct G_ID_HELPER_CLASS(Class)                                         \
     {                                                                       \
-        struct G_ID_HELPER_CLASS(Class)                                     \
-        {                                                                   \
-            static constexpr const char * id() {return Id;}                 \
-        };                                                                  \
-    }
-
+        static constexpr const char * id() {return Id;}                     \
+    };                                                                      \
+//! @endcond
 #define G_TYPED_KERNEL(Class, API, Id)                                      \
     G_ID_HELPER_BODY(Class, Id)                                             \
     struct Class final: public cv::GKernelType<Class, std::function API >,  \
-                        public detail::G_ID_HELPER_CLASS(Class)
+                        public G_ID_HELPER_CLASS(Class)
 // {body} is to be defined by user
 
 #define G_TYPED_KERNEL_M(Class, API, Id)                                    \
     G_ID_HELPER_BODY(Class, Id)                                             \
     struct Class final: public cv::GKernelTypeM<Class, std::function API >, \
-                        public detail::G_ID_HELPER_CLASS(Class)
+                        public G_ID_HELPER_CLASS(Class)
 // {body} is to be defined by user
 
 #define G_API_OP   G_TYPED_KERNEL


### PR DESCRIPTION
…ilation

```
force_builders_only=Docs,linux

build_gapi_standalone:Linux x64=ade-0.1.1f
build_gapi_standalone:Win64=ade-0.1.1f
build_gapi_standalone:Mac=ade-0.1.1f
build_gapi_standalone:Linux x64 Debug=ade-0.1.1f
build_gapi_standalone:Custom Win=ade-0.1.1f
```