### PR TITLE
Tutorial - Make required input args positional.

### DIFF
--- a/samples/cpp/tutorial_code/Histograms_Matching/compareHist_Demo.cpp
+++ b/samples/cpp/tutorial_code/Histograms_Matching/compareHist_Demo.cpp
@@ -14,9 +14,9 @@ using namespace cv;
 
 const char* keys =
     "{ help  h| | Print help message. }"
-    "{ input1 | | Path to input image 1. }"
-    "{ input2 | | Path to input image 2. }"
-    "{ input3 | | Path to input image 3. }";
+    "{ @input1 | | Path to input image 1. }"
+    "{ @input2 | | Path to input image 2. }"
+    "{ @input3 | | Path to input image 3. }";
 
 /**
  * @function main


### PR DESCRIPTION
I think it would help to change all 3 of the the input file arguments to be "positional" for consistency with the other tutorials. This also simplifies the command line input to run this tutorial by reducing typing, and helpfully prints the "usage" info if any of the 3 required inputs are missing.

I'm new to OpenCV and working through the tutorials. I kept getting runtime errors with this one until I realized that the arguments weren't positional, and I was missing the "--input1", "--input2, "--input3" flags preceding the filenames. All of the previous tutorials had required filenames as positional arguments and didn't require this.

The original code would require each input to be specified like this:
```./compareHist_Demo --input1 filename1 --input2 filename2 --input3 filename3```

But with this change, the above command is simplified to:
```./compareHist_Demo  filename1 filename2 filename3```

This avoids a confusing runtime error to make things simpler for newcomers like me :)

<!-- Please use this line to close one or multiple issues when this pullrequest gets merged
You can add another line right under the first one:
(none)
-->

### This pullrequest changes

<!-- Please describe what your pullrequest is changing -->
samples/cpp/tutorial_code/Histograms_Matching/compareHist_Demo.cpp