### PR TITLE
stitching_detailed: use correct match_conf default

### DIFF
--- a/samples/cpp/stitching_detailed.cpp
+++ b/samples/cpp/stitching_detailed.cpp
@@ -100,6 +100,7 @@ double seam_megapix = 0.1;
 double compose_megapix = -1;
 float conf_thresh = 1.f;
 string features_type = "surf";
+float match_conf = 0.65f;
 string matcher_type = "homography";
 string estimator_type = "homography";
 string ba_cost_func = "ray";
@@ -110,7 +111,6 @@ bool save_graph = false;
 std::string save_graph_to;
 string warp_type = "spherical";
 int expos_comp_type = ExposureCompensator::GAIN_BLOCKS;
-float match_conf = 0.3f;
 string seam_find_type = "gc_color";
 int blend_type = Blender::MULTI_BAND;
 int timelapse_type = Timelapser::AS_IS;
@@ -174,7 +174,7 @@ static int parseCmdArgs(int argc, char** argv)
         else if (string(argv[i]) == "--features")
         {
             features_type = argv[i + 1];
-            if (features_type == "orb")
+            if (string(features_type) == "orb")
                 match_conf = 0.3f;
             i++;
         }


### PR DESCRIPTION
### This pullrequest changes

The usage function states that the default for match_conf is
0.65 if the default SURF feature finder is used, and 0.3 for
orbs. Indeed, if --feature orbs is used, match_conf is set
to 0.3f. This is a NOP, because the real default is also set
to 0.3f. Change it to 0.65f when SURF is in play.