### PR TITLE
G-API: fix ARMv7 build

### DIFF
--- a/modules/gapi/include/opencv2/gapi/ocl/goclkernel.hpp
+++ b/modules/gapi/include/opencv2/gapi/ocl/goclkernel.hpp
@@ -119,7 +119,7 @@ template<class T> struct ocl_get_in
 struct tracked_cv_umat{
     //TODO Think if T - API could reallocate UMat to a proper size - how do we handle this ?
     //tracked_cv_umat(cv::UMat& m) : r{(m)}, original_data{m.getMat(ACCESS_RW).data} {}
-    tracked_cv_umat(cv::UMat& m) : r{ (m) }, original_data{ nullptr } {}
+    tracked_cv_umat(cv::UMat& m) : r(m), original_data{ nullptr } {}
     cv::UMat &r; // FIXME: It was a value (not a reference) before.
                  // Actually OCL backend should allocate its internal data!
     uchar* original_data;

--- a/modules/gapi/src/executor/gstreamingexecutor.cpp
+++ b/modules/gapi/src/executor/gstreamingexecutor.cpp
@@ -546,7 +546,7 @@ void cv::gimpl::GStreamingExecutor::setSource(GRunArgs &&ins)
         return util::holds_alternative<cv::gapi::wip::IStreamSource::Ptr>(arg);
     };
     const auto num_videos = std::count_if(ins.begin(), ins.end(), is_video);
-    if (num_videos > 1u)
+    if (num_videos > 1)
     {
         // See below why (another reason - no documented behavior
         // on handling videos streams of different length)


### PR DESCRIPTION
- gcc 4.8.4 (ARMv7)

resolves #15758

```
force_builders=ARMv7,Custom
buildworker:Custom=linux-1,linux-2,linux-4
build_image:Custom=ubuntu-clang:18.04
```