### PR TITLE
G-API: Returned GModel::mkDataNode() overload for external backends

### DIFF
--- a/modules/gapi/src/compiler/gmodel.cpp
+++ b/modules/gapi/src/compiler/gmodel.cpp
@@ -58,6 +58,20 @@ ade::NodeHandle GModel::mkDataNode(GModel::Graph &g, const GOrigin& origin)
     return data_h;
 }
 
+ade::NodeHandle GModel::mkDataNode(GModel::Graph &g, const GShape shape)
+{
+    ade::NodeHandle data_h = g.createNode();
+    g.metadata(data_h).set(NodeType{NodeType::DATA});
+
+    const auto id = g.metadata().get<DataObjectCounter>().GetNewId(shape);
+    GMetaArg meta;
+    HostCtor ctor;
+    Data::Storage storage = Data::Storage::INTERNAL; // By default, all objects are marked INTERNAL
+
+    g.metadata(data_h).set(Data{shape, id, meta, ctor, storage});
+    return data_h;
+}
+
 void GModel::linkIn(Graph &g, ade::NodeHandle opH, ade::NodeHandle objH, std::size_t in_port)
 {
     // Check if input is already connected

--- a/modules/gapi/src/compiler/gmodel.hpp
+++ b/modules/gapi/src/compiler/gmodel.hpp
@@ -231,6 +231,8 @@ namespace GModel
     GAPI_EXPORTS void init (Graph& g);
 
     GAPI_EXPORTS ade::NodeHandle mkOpNode(Graph &g, const GKernel &k, const std::vector<GArg>& args, const std::string &island);
+    // Isn't used by the framework or default backends, required for external backend development
+    GAPI_EXPORTS ade::NodeHandle mkDataNode(Graph &g, const GShape shape);
 
     // Adds a string message to a node. Any node can be subject of log, messages then
     // appear in the dumped .dot file.x


### PR DESCRIPTION
* Returned `mkDataNode()` overload as a part of exported API for external backend development (was removed in https://github.com/opencv/opencv/pull/15216)

```
build_gapi_standalone:Linux x64=ade-0.1.1f
build_gapi_standalone:Win64=ade-0.1.1f
build_gapi_standalone:Mac=ade-0.1.1f
build_gapi_standalone:Linux x64 Debug=ade-0.1.1f
build_gapi_standalone:Custom Win=ade-0.1.1f
```