### PR TITLE
Use argument value for 'mat' in call to format for vector_mat and vector_mat_template

### DIFF
--- a/modules/python/src2/hdr_parser.py
+++ b/modules/python/src2/hdr_parser.py
@@ -571,8 +571,8 @@ class CppHeaderParser(object):
                     arg_type, arg_name, modlist, argno = self.parse_arg(a, argno)
                     if self.wrap_mode:
                         # TODO: Vectors should contain UMat, but this is not very easy to support and not very needed
-                        vector_mat = "vector_{}".format("Mat")
-                        vector_mat_template = "vector<{}>".format("Mat")
+                        vector_mat = "vector_{}".format(mat)
+                        vector_mat_template = "vector<{}>".format(mat)
 
                         if arg_type == "InputArray":
                             arg_type = mat

--- a/modules/python/test/test_umat.py
+++ b/modules/python/test/test_umat.py
@@ -4,7 +4,21 @@ from __future__ import print_function
 import numpy as np
 import cv2 as cv
 
+import os
+
 from tests_common import NewOpenCVTests
+
+
+def load_exposure_seq(path):
+    images = []
+    times = []
+    with open(os.path.join(path, 'list.txt'), 'r') as list_file:
+        for line in list_file.readlines():
+            name, time = line.split()
+            images.append(cv.imread(os.path.join(path, name)))
+            times.append(1. / float(time))
+    return images, times
+
 
 class UMat(NewOpenCVTests):
 
@@ -81,6 +95,23 @@ class UMat(NewOpenCVTests):
         # for p1_mask_err_umat in [p1_mask_err_umat0, p1_mask_err_umat1, p1_mask_err_umat2]:
         #     for data, data_umat in zip(p1_mask_err, p1_mask_err_umat):
         #         self.assertTrue(np.allclose(data, data_umat))
+
+    def test_umat_merge_mertens(self):
+        if self.extraTestDataPath is None:
+            self.fail('Test data is not available')
+
+        test_data_path = os.path.join(self.extraTestDataPath, 'cv', 'hdr')
+
+        images, _ = load_exposure_seq(os.path.join(test_data_path, 'exposures'))
+
+        merge = cv.createMergeMertens()
+        mat_result = merge.process(images)
+
+        umat_images = [cv.UMat(img) for img in images]
+        umat_result = merge.process(umat_images)
+
+        self.assertTrue(np.allclose(umat_result.get(), mat_result))
+
 
 if __name__ == '__main__':
     NewOpenCVTests.bootstrap()


### PR DESCRIPTION
The hard-coded string value "Mat" was used in the two format strings for vector_mat and vector_mat_template, preventing UMat arguments to functions that have these types from working correctly. as noted in #12231.

resolves #12231

