### PR TITLE
Parallelize pyrDown & calcSharrDeriv

### DIFF
--- a/modules/imgproc/src/pyramids.cpp
+++ b/modules/imgproc/src/pyramids.cpp
@@ -737,123 +737,7 @@ struct PyrDownInvoker : ParallelLoopBody
         return y*2 + 2;
     }
 
-    void operator()(const Range& range) const CV_OVERRIDE
-    {
-        const int PD_SZ = 5;
-        typedef typename CastOp::type1 WT;
-        typedef typename CastOp::rtype T;
-        Size ssize = _src->size(), dsize = _dst->size();
-        int cn = _src->channels();
-        int bufstep = (int)alignSize(dsize.width*cn, 16);
-        AutoBuffer<WT> _buf(bufstep*PD_SZ + 16);
-        WT* buf = alignPtr((WT*)_buf.data(), 16);
-        WT* rows[PD_SZ];
-        CastOp castOp;
-
-        int sy0 = -PD_SZ/2, sy = syloopboundary(range.start-1) + sy0, width0 = std::min((ssize.width-PD_SZ/2-1)/2 + 1, dsize.width);
-
-        ssize.width *= cn;
-        dsize.width *= cn;
-        width0 *= cn;
-
-        for (int y = range.start; y < range.end; y++)
-        {
-            T* dst = (T*)_dst->ptr<T>(y);
-            WT *row0, *row1, *row2, *row3, *row4;
-
-            // fill the ring buffer (horizontal convolution and decimation)
-            for( ; sy <= syloopboundary(y); sy++ )
-            {
-                WT* row = buf + ((sy - sy0) % PD_SZ)*bufstep;
-                int _sy = borderInterpolate(sy, ssize.height, _borderType);
-                const T* src = _src->ptr<T>(_sy);
-
-                do {
-                    int x = 0;
-                    const int* tabL = *_tabL;
-                    for( ; x < cn; x++ )
-                    {
-                        row[x] = src[tabL[x+cn*2]]*6 + (src[tabL[x+cn]] + src[tabL[x+cn*3]])*4 +
-                            src[tabL[x]] + src[tabL[x+cn*4]];
-                    }
-
-                    if( x == dsize.width )
-                        break;
-
-                    if( cn == 1 )
-                    {
-                        x += PyrDownVecH<T, WT, 1>(src + x * 2 - 2, row + x, width0 - x);
-                        for( ; x < width0; x++ )
-                            row[x] = src[x*2]*6 + (src[x*2 - 1] + src[x*2 + 1])*4 +
-                                src[x*2 - 2] + src[x*2 + 2];
-                    }
-                    else if( cn == 2 )
-                    {
-                        x += PyrDownVecH<T, WT, 2>(src + x * 2 - 4, row + x, width0 - x);
-                        for( ; x < width0; x += 2 )
-                        {
-                            const T* s = src + x*2;
-                            WT t0 = s[0] * 6 + (s[-2] + s[2]) * 4 + s[-4] + s[4];
-                            WT t1 = s[1] * 6 + (s[-1] + s[3]) * 4 + s[-3] + s[5];
-                            row[x] = t0; row[x + 1] = t1;
-                        }
-                    }
-                    else if( cn == 3 )
-                    {
-                        x += PyrDownVecH<T, WT, 3>(src + x * 2 - 6, row + x, width0 - x);
-                        for( ; x < width0; x += 3 )
-                        {
-                            const T* s = src + x*2;
-                            WT t0 = s[0]*6 + (s[-3] + s[3])*4 + s[-6] + s[6];
-                            WT t1 = s[1]*6 + (s[-2] + s[4])*4 + s[-5] + s[7];
-                            WT t2 = s[2]*6 + (s[-1] + s[5])*4 + s[-4] + s[8];
-                            row[x] = t0; row[x+1] = t1; row[x+2] = t2;
-                        }
-                    }
-                    else if( cn == 4 )
-                    {
-                        x += PyrDownVecH<T, WT, 4>(src + x * 2 - 8, row + x, width0 - x);
-                        for( ; x < width0; x += 4 )
-                        {
-                            const T* s = src + x*2;
-                            WT t0 = s[0]*6 + (s[-4] + s[4])*4 + s[-8] + s[8];
-                            WT t1 = s[1]*6 + (s[-3] + s[5])*4 + s[-7] + s[9];
-                            row[x] = t0; row[x+1] = t1;
-                            t0 = s[2]*6 + (s[-2] + s[6])*4 + s[-6] + s[10];
-                            t1 = s[3]*6 + (s[-1] + s[7])*4 + s[-5] + s[11];
-                            row[x+2] = t0; row[x+3] = t1;
-                        }
-                    }
-                    else
-                    {
-                        for( ; x < width0; x++ )
-                        {
-                            int sx = (*_tabM)[x];
-                            row[x] = src[sx]*6 + (src[sx - cn] + src[sx + cn])*4 +
-                                src[sx - cn*2] + src[sx + cn*2];
-                        }
-                    }
-
-                    // tabR
-                    const int* tabR = *_tabR;
-                    for (int x_ = 0; x < dsize.width; x++, x_++)
-                    {
-                        row[x] = src[tabR[x_+cn*2]]*6 + (src[tabR[x_+cn]] + src[tabR[x_+cn*3]])*4 +
-                            src[tabR[x_]] + src[tabR[x_+cn*4]];
-                    }
-                } while (0);
-            }
-
-            // do vertical convolution and decimation and write the result to the destination image
-            for (int k = 0; k < PD_SZ; k++)
-                rows[k] = buf + ((y*2 - PD_SZ/2 + k - sy0) % PD_SZ)*bufstep;
-            row0 = rows[0]; row1 = rows[1]; row2 = rows[2]; row3 = rows[3]; row4 = rows[4];
-
-            int x = PyrDownVecV<WT, T>(rows, dst, dsize.width);
-            for (; x < dsize.width; x++ )
-                dst[x] = castOp(row2[x]*6 + (row1[x] + row3[x])*4 + row0[x] + row4[x]);
-        }
-    }
+    void operator()(const Range& range) const CV_OVERRIDE;
 
     int **_tabR;
     int **_tabM;
@@ -898,6 +782,125 @@ pyrDown_( const Mat& _src, Mat& _dst, int borderType )
     int *tabRPtr = tabR;
 
     cv::parallel_for_(Range(0,dsize.height), cv::PyrDownInvoker<CastOp>(_src, _dst, borderType, &tabRPtr, &tabM, &tabLPtr), cv::getNumThreads());
+}
+
+template<class CastOp>
+void PyrDownInvoker<CastOp>::operator()(const Range& range) const
+{
+    const int PD_SZ = 5;
+    typedef typename CastOp::type1 WT;
+    typedef typename CastOp::rtype T;
+    Size ssize = _src->size(), dsize = _dst->size();
+    int cn = _src->channels();
+    int bufstep = (int)alignSize(dsize.width*cn, 16);
+    AutoBuffer<WT> _buf(bufstep*PD_SZ + 16);
+    WT* buf = alignPtr((WT*)_buf.data(), 16);
+    WT* rows[PD_SZ];
+    CastOp castOp;
+
+    int sy0 = -PD_SZ/2, sy = syloopboundary(range.start-1) + sy0, width0 = std::min((ssize.width-PD_SZ/2-1)/2 + 1, dsize.width);
+
+    ssize.width *= cn;
+    dsize.width *= cn;
+    width0 *= cn;
+
+    for (int y = range.start; y < range.end; y++)
+    {
+        T* dst = (T*)_dst->ptr<T>(y);
+        WT *row0, *row1, *row2, *row3, *row4;
+
+        // fill the ring buffer (horizontal convolution and decimation)
+        for( ; sy <= syloopboundary(y); sy++ )
+        {
+            WT* row = buf + ((sy - sy0) % PD_SZ)*bufstep;
+            int _sy = borderInterpolate(sy, ssize.height, _borderType);
+            const T* src = _src->ptr<T>(_sy);
+
+            do {
+                int x = 0;
+                const int* tabL = *_tabL;
+                for( ; x < cn; x++ )
+                {
+                    row[x] = src[tabL[x+cn*2]]*6 + (src[tabL[x+cn]] + src[tabL[x+cn*3]])*4 +
+                        src[tabL[x]] + src[tabL[x+cn*4]];
+                }
+
+                if( x == dsize.width )
+                    break;
+
+                if( cn == 1 )
+                {
+                    x += PyrDownVecH<T, WT, 1>(src + x * 2 - 2, row + x, width0 - x);
+                    for( ; x < width0; x++ )
+                        row[x] = src[x*2]*6 + (src[x*2 - 1] + src[x*2 + 1])*4 +
+                            src[x*2 - 2] + src[x*2 + 2];
+                }
+                else if( cn == 2 )
+                {
+                    x += PyrDownVecH<T, WT, 2>(src + x * 2 - 4, row + x, width0 - x);
+                    for( ; x < width0; x += 2 )
+                    {
+                        const T* s = src + x*2;
+                        WT t0 = s[0] * 6 + (s[-2] + s[2]) * 4 + s[-4] + s[4];
+                        WT t1 = s[1] * 6 + (s[-1] + s[3]) * 4 + s[-3] + s[5];
+                        row[x] = t0; row[x + 1] = t1;
+                    }
+                }
+                else if( cn == 3 )
+                {
+                    x += PyrDownVecH<T, WT, 3>(src + x * 2 - 6, row + x, width0 - x);
+                    for( ; x < width0; x += 3 )
+                    {
+                        const T* s = src + x*2;
+                        WT t0 = s[0]*6 + (s[-3] + s[3])*4 + s[-6] + s[6];
+                        WT t1 = s[1]*6 + (s[-2] + s[4])*4 + s[-5] + s[7];
+                        WT t2 = s[2]*6 + (s[-1] + s[5])*4 + s[-4] + s[8];
+                        row[x] = t0; row[x+1] = t1; row[x+2] = t2;
+                    }
+                }
+                else if( cn == 4 )
+                {
+                    x += PyrDownVecH<T, WT, 4>(src + x * 2 - 8, row + x, width0 - x);
+                    for( ; x < width0; x += 4 )
+                    {
+                        const T* s = src + x*2;
+                        WT t0 = s[0]*6 + (s[-4] + s[4])*4 + s[-8] + s[8];
+                        WT t1 = s[1]*6 + (s[-3] + s[5])*4 + s[-7] + s[9];
+                        row[x] = t0; row[x+1] = t1;
+                        t0 = s[2]*6 + (s[-2] + s[6])*4 + s[-6] + s[10];
+                        t1 = s[3]*6 + (s[-1] + s[7])*4 + s[-5] + s[11];
+                        row[x+2] = t0; row[x+3] = t1;
+                    }
+                }
+                else
+                {
+                    for( ; x < width0; x++ )
+                    {
+                        int sx = (*_tabM)[x];
+                        row[x] = src[sx]*6 + (src[sx - cn] + src[sx + cn])*4 +
+                            src[sx - cn*2] + src[sx + cn*2];
+                    }
+                }
+
+                // tabR
+                const int* tabR = *_tabR;
+                for (int x_ = 0; x < dsize.width; x++, x_++)
+                {
+                    row[x] = src[tabR[x_+cn*2]]*6 + (src[tabR[x_+cn]] + src[tabR[x_+cn*3]])*4 +
+                        src[tabR[x_]] + src[tabR[x_+cn*4]];
+                }
+            } while (0);
+        }
+
+        // do vertical convolution and decimation and write the result to the destination image
+        for (int k = 0; k < PD_SZ; k++)
+            rows[k] = buf + ((y*2 - PD_SZ/2 + k - sy0) % PD_SZ)*bufstep;
+        row0 = rows[0]; row1 = rows[1]; row2 = rows[2]; row3 = rows[3]; row4 = rows[4];
+
+        int x = PyrDownVecV<WT, T>(rows, dst, dsize.width);
+        for (; x < dsize.width; x++ )
+            dst[x] = castOp(row2[x]*6 + (row1[x] + row3[x])*4 + row0[x] + row4[x]);
+    }
 }
 
 

--- a/modules/imgproc/src/pyramids.cpp
+++ b/modules/imgproc/src/pyramids.cpp
@@ -732,11 +732,6 @@ struct PyrDownInvoker : ParallelLoopBody
         _tabL = tabL;
     }
 
-    inline int syloopboundary(int y) const
-    {
-        return y*2 + 2;
-    }
-
     void operator()(const Range& range) const CV_OVERRIDE;
 
     int **_tabR;
@@ -798,7 +793,7 @@ void PyrDownInvoker<CastOp>::operator()(const Range& range) const
     WT* rows[PD_SZ];
     CastOp castOp;
 
-    int sy0 = -PD_SZ/2, sy = syloopboundary(range.start-1) + sy0, width0 = std::min((ssize.width-PD_SZ/2-1)/2 + 1, dsize.width);
+    int sy0 = -PD_SZ/2, sy = range.start * 2 + sy0, width0 = std::min((ssize.width-PD_SZ/2-1)/2 + 1, dsize.width);
 
     ssize.width *= cn;
     dsize.width *= cn;
@@ -810,7 +805,8 @@ void PyrDownInvoker<CastOp>::operator()(const Range& range) const
         WT *row0, *row1, *row2, *row3, *row4;
 
         // fill the ring buffer (horizontal convolution and decimation)
-        for( ; sy <= syloopboundary(y); sy++ )
+        int sy_limit = y*2 + 2;
+        for( ; sy <= sy_limit; sy++ )
         {
             WT* row = buf + ((sy - sy0) % PD_SZ)*bufstep;
             int _sy = borderInterpolate(sy, ssize.height, _borderType);

--- a/modules/imgproc/src/pyramids.cpp
+++ b/modules/imgproc/src/pyramids.cpp
@@ -897,7 +897,8 @@ pyrDown_( const Mat& _src, Mat& _dst, int borderType )
     int *tabLPtr = tabL;
     int *tabRPtr = tabR;
 
-    cv::parallel_for_(Range(0,dsize.height), cv::PyrDownInvoker<CastOp>(_src, _dst, borderType, &tabRPtr, &tabM, &tabLPtr));
+    double granularity = (double)std::max(1., (double)(dsize.height / cv::getNumThreads()));
+    cv::parallel_for_(Range(0,dsize.height), cv::PyrDownInvoker<CastOp>(_src, _dst, borderType, &tabRPtr, &tabM, &tabLPtr), granularity);
 }
 
 

--- a/modules/imgproc/src/pyramids.cpp
+++ b/modules/imgproc/src/pyramids.cpp
@@ -49,7 +49,7 @@
 
 namespace cv
 {
-    
+
 template<typename T, int shift> struct FixPtCast
 {
     typedef int type1;
@@ -730,23 +730,23 @@ struct PyrDownInvoker : ParallelLoopBody
         _tabR = tabR;
         _tabM = tabM;
         _tabL = tabL;
-    }            
+    }
 
     inline int syloopboundary(int y) const
     {
         return y*2 + 2;
-    }            
+    }
 
     void operator()(const Range& range) const CV_OVERRIDE
-    {       
+    {
         const int PD_SZ = 5;
         typedef typename CastOp::type1 WT;
-        typedef typename CastOp::rtype T;            
+        typedef typename CastOp::rtype T;
         Size ssize = _src->size(), dsize = _dst->size();
-        int cn = _src->channels();        
+        int cn = _src->channels();
         int bufstep = (int)alignSize(dsize.width*cn, 16);
         AutoBuffer<WT> _buf(bufstep*PD_SZ + 16);
-        WT* buf = alignPtr((WT*)_buf.data(), 16);    
+        WT* buf = alignPtr((WT*)_buf.data(), 16);
         WT* rows[PD_SZ];
         CastOp castOp;
 
@@ -852,8 +852,7 @@ struct PyrDownInvoker : ParallelLoopBody
             int x = PyrDownVecV<WT, T>(rows, dst, dsize.width);
             for (; x < dsize.width; x++ )
                 dst[x] = castOp(row2[x]*6 + (row1[x] + row3[x])*4 + row0[x] + row4[x]);
-        }        
-        
+        }
     }
 
     int **_tabR;
@@ -862,8 +861,7 @@ struct PyrDownInvoker : ParallelLoopBody
     const Mat *_src;
     const Mat *_dst;
     int _borderType;
-};    
-
+};
 
 template<class CastOp> void
 pyrDown_( const Mat& _src, Mat& _dst, int borderType )
@@ -892,7 +890,7 @@ pyrDown_( const Mat& _src, Mat& _dst, int borderType )
             tabR[x*cn + k] = sx1 + k;
         }
     }
-    
+
     for (int x = 0; x < dsize.width*cn; x++)
         tabM[x] = (x/cn)*2*cn + x % cn;
 

--- a/modules/imgproc/src/pyramids.cpp
+++ b/modules/imgproc/src/pyramids.cpp
@@ -737,7 +737,7 @@ struct PyrDownInvoker : ParallelLoopBody
         return y*2 + 2;
     }            
 
-    void operator()(const Range& range) const override
+    void operator()(const Range& range) const CV_OVERRIDE
     {       
         const int PD_SZ = 5;
         typedef typename CastOp::type1 WT;

--- a/modules/imgproc/src/pyramids.cpp
+++ b/modules/imgproc/src/pyramids.cpp
@@ -897,8 +897,7 @@ pyrDown_( const Mat& _src, Mat& _dst, int borderType )
     int *tabLPtr = tabL;
     int *tabRPtr = tabR;
 
-    double granularity = (double)std::max(1., (double)(dsize.height / cv::getNumThreads()));
-    cv::parallel_for_(Range(0,dsize.height), cv::PyrDownInvoker<CastOp>(_src, _dst, borderType, &tabRPtr, &tabM, &tabLPtr), granularity);
+    cv::parallel_for_(Range(0,dsize.height), cv::PyrDownInvoker<CastOp>(_src, _dst, borderType, &tabRPtr, &tabM, &tabLPtr), cv::getNumThreads());
 }
 
 

--- a/modules/video/src/lkpyramid.cpp
+++ b/modules/video/src/lkpyramid.cpp
@@ -59,7 +59,8 @@ static void calcSharrDeriv(const cv::Mat& src, cv::Mat& dst)
     int rows = src.rows, cols = src.cols, cn = src.channels(), depth = src.depth();
     CV_Assert(depth == CV_8U);
     dst.create(rows, cols, CV_MAKETYPE(DataType<deriv_type>::depth, cn*2));
-    parallel_for_(Range(0, rows), cv::detail::SharrDerivInvoker(src, dst));
+    double granularity = (double)std::max(1., (double)(rows / cv::getNumThreads()));
+    parallel_for_(Range(0, rows), cv::detail::SharrDerivInvoker(src, dst), granularity);
 }
 
 }//namespace

--- a/modules/video/src/lkpyramid.cpp
+++ b/modules/video/src/lkpyramid.cpp
@@ -59,8 +59,7 @@ static void calcSharrDeriv(const cv::Mat& src, cv::Mat& dst)
     int rows = src.rows, cols = src.cols, cn = src.channels(), depth = src.depth();
     CV_Assert(depth == CV_8U);
     dst.create(rows, cols, CV_MAKETYPE(DataType<deriv_type>::depth, cn*2));
-    double granularity = (double)std::max(1., (double)(rows / cv::getNumThreads()));
-    parallel_for_(Range(0, rows), cv::detail::SharrDerivInvoker(src, dst), granularity);
+    parallel_for_(Range(0, rows), cv::detail::SharrDerivInvoker(src, dst), cv::getNumThreads());
 }
 
 }//namespace

--- a/modules/video/src/lkpyramid.cpp
+++ b/modules/video/src/lkpyramid.cpp
@@ -56,9 +56,25 @@ static void calcSharrDeriv(const cv::Mat& src, cv::Mat& dst)
 {
     using namespace cv;
     using cv::detail::deriv_type;
-    int rows = src.rows, cols = src.cols, cn = src.channels(), colsn = cols*cn, depth = src.depth();
+    int rows = src.rows, cols = src.cols, cn = src.channels(), depth = src.depth();
     CV_Assert(depth == CV_8U);
     dst.create(rows, cols, CV_MAKETYPE(DataType<deriv_type>::depth, cn*2));
+    parallel_for_(Range(0, rows), cv::detail::SharrDerivInvoker(src, dst));
+    
+}    
+
+}//namespace
+
+cv::detail::SharrDerivInvoker::SharrDerivInvoker(const Mat& _src, const Mat& _dst)
+{
+    src = &_src;
+    dst = &_dst;
+}
+
+void cv::detail::SharrDerivInvoker::operator()(const Range& range) const
+{
+    using cv::detail::deriv_type;
+    int rows = src->rows, cols = src->cols, cn = src->channels(), colsn = cols*cn;
 
 #ifdef HAVE_TEGRA_OPTIMIZATION
     if (tegra::useTegra() && tegra::calcSharrDeriv(src, dst))
@@ -73,12 +89,12 @@ static void calcSharrDeriv(const cv::Mat& src, cv::Mat& dst)
     v_int16x8 c3 = v_setall_s16(3), c10 = v_setall_s16(10);
 #endif
 
-    for( y = 0; y < rows; y++ )
+    for( y = range.start; y < range.end; y++ )
     {
-        const uchar* srow0 = src.ptr<uchar>(y > 0 ? y-1 : rows > 1 ? 1 : 0);
-        const uchar* srow1 = src.ptr<uchar>(y);
-        const uchar* srow2 = src.ptr<uchar>(y < rows-1 ? y+1 : rows > 1 ? rows-2 : 0);
-        deriv_type* drow = dst.ptr<deriv_type>(y);
+        const uchar* srow0 = src->ptr<uchar>(y > 0 ? y-1 : rows > 1 ? 1 : 0);
+        const uchar* srow1 = src->ptr<uchar>(y);
+        const uchar* srow2 = src->ptr<uchar>(y < rows-1 ? y+1 : rows > 1 ? rows-2 : 0);
+        deriv_type* drow = (deriv_type *)dst->ptr<deriv_type>(y);
 
         // do vertical convolution
         x = 0;
@@ -142,8 +158,6 @@ static void calcSharrDeriv(const cv::Mat& src, cv::Mat& dst)
         }
     }
 }
-
-}//namespace
 
 cv::detail::LKTrackerInvoker::LKTrackerInvoker(
                       const Mat& _prevImg, const Mat& _prevDeriv, const Mat& _nextImg,

--- a/modules/video/src/lkpyramid.cpp
+++ b/modules/video/src/lkpyramid.cpp
@@ -64,16 +64,10 @@ static void calcSharrDeriv(const cv::Mat& src, cv::Mat& dst)
 
 }//namespace
 
-cv::detail::SharrDerivInvoker::SharrDerivInvoker(const Mat& _src, const Mat& _dst)
-{
-    src = &_src;
-    dst = &_dst;
-}
-
 void cv::detail::SharrDerivInvoker::operator()(const Range& range) const
 {
     using cv::detail::deriv_type;
-    int rows = src->rows, cols = src->cols, cn = src->channels(), colsn = cols*cn;
+    int rows = src.rows, cols = src.cols, cn = src.channels(), colsn = cols*cn;
 
 #ifdef HAVE_TEGRA_OPTIMIZATION
     if (tegra::useTegra() && tegra::calcSharrDeriv(src, dst))
@@ -90,10 +84,10 @@ void cv::detail::SharrDerivInvoker::operator()(const Range& range) const
 
     for( y = range.start; y < range.end; y++ )
     {
-        const uchar* srow0 = src->ptr<uchar>(y > 0 ? y-1 : rows > 1 ? 1 : 0);
-        const uchar* srow1 = src->ptr<uchar>(y);
-        const uchar* srow2 = src->ptr<uchar>(y < rows-1 ? y+1 : rows > 1 ? rows-2 : 0);
-        deriv_type* drow = (deriv_type *)dst->ptr<deriv_type>(y);
+        const uchar* srow0 = src.ptr<uchar>(y > 0 ? y-1 : rows > 1 ? 1 : 0);
+        const uchar* srow1 = src.ptr<uchar>(y);
+        const uchar* srow2 = src.ptr<uchar>(y < rows-1 ? y+1 : rows > 1 ? rows-2 : 0);
+        deriv_type* drow = (deriv_type *)dst.ptr<deriv_type>(y);
 
         // do vertical convolution
         x = 0;

--- a/modules/video/src/lkpyramid.cpp
+++ b/modules/video/src/lkpyramid.cpp
@@ -60,8 +60,7 @@ static void calcSharrDeriv(const cv::Mat& src, cv::Mat& dst)
     CV_Assert(depth == CV_8U);
     dst.create(rows, cols, CV_MAKETYPE(DataType<deriv_type>::depth, cn*2));
     parallel_for_(Range(0, rows), cv::detail::SharrDerivInvoker(src, dst));
-    
-}    
+}
 
 }//namespace
 

--- a/modules/video/src/lkpyramid.hpp
+++ b/modules/video/src/lkpyramid.hpp
@@ -7,6 +7,15 @@ namespace detail
 
     typedef short deriv_type;
 
+    struct SharrDerivInvoker : ParallelLoopBody
+    {
+        SharrDerivInvoker(const Mat& _src, const Mat& _dst);
+
+        void operator()(const Range& range) const CV_OVERRIDE;
+        const Mat* src;
+        const Mat* dst;        
+    };    
+    
     struct LKTrackerInvoker : ParallelLoopBody
     {
         LKTrackerInvoker( const Mat& _prevImg, const Mat& _prevDeriv, const Mat& _nextImg,

--- a/modules/video/src/lkpyramid.hpp
+++ b/modules/video/src/lkpyramid.hpp
@@ -13,9 +13,9 @@ namespace detail
 
         void operator()(const Range& range) const CV_OVERRIDE;
         const Mat* src;
-        const Mat* dst;        
-    };    
-    
+        const Mat* dst;
+    };
+
     struct LKTrackerInvoker : ParallelLoopBody
     {
         LKTrackerInvoker( const Mat& _prevImg, const Mat& _prevDeriv, const Mat& _nextImg,

--- a/modules/video/src/lkpyramid.hpp
+++ b/modules/video/src/lkpyramid.hpp
@@ -9,11 +9,14 @@ namespace detail
 
     struct SharrDerivInvoker : ParallelLoopBody
     {
-        SharrDerivInvoker(const Mat& _src, const Mat& _dst);
+        SharrDerivInvoker(const Mat& _src, const Mat& _dst)
+            : src(_src), dst(_dst)
+        { }
 
         void operator()(const Range& range) const CV_OVERRIDE;
-        const Mat* src;
-        const Mat* dst;
+
+        const Mat& src;
+        const Mat& dst;
     };
 
     struct LKTrackerInvoker : ParallelLoopBody


### PR DESCRIPTION
### This pullrequest changes

Parallellizes execution of cv::pyrDown and calcSharrDeriv. Both are used extensively in buildOpticalFlowPyramid and changes are aimed to speedup this function.

 
