### PR TITLE
Supported ONNX Squeeze, ReduceL2 and Eltwise::DIV

### DIFF
--- a/modules/dnn/src/layers/eltwise_layer.cpp
+++ b/modules/dnn/src/layers/eltwise_layer.cpp
@@ -100,7 +100,7 @@ public:
 
     virtual bool supportBackend(int backendId) CV_OVERRIDE
     {
-        return (backendId == DNN_BACKEND_OPENCV && (op != DIV || preferableTarget == DNN_TARGET_CPU)) ||
+        return backendId == DNN_BACKEND_OPENCV ||
                backendId == DNN_BACKEND_HALIDE ||
                (backendId == DNN_BACKEND_INFERENCE_ENGINE && !variableChannels &&
                 (preferableTarget != DNN_TARGET_OPENCL || coeffs.empty()));
@@ -407,6 +407,11 @@ public:
                 multiply(inputs[0], inputs[1], outputs[0]);
                 for (int i = 2; i < inputs.size(); ++i)
                     multiply(inputs[i], outputs[0], outputs[0]);
+                break;
+            case DIV:
+                divide(inputs[0], inputs[1], outputs[0]);
+                for (int i = 2; i < inputs.size(); ++i)
+                    divide(outputs[0], inputs[i], outputs[0]);
                 break;
             case MAX:
                 max(inputs[0], inputs[1], outputs[0]);

--- a/modules/dnn/src/layers/eltwise_layer.cpp
+++ b/modules/dnn/src/layers/eltwise_layer.cpp
@@ -62,6 +62,7 @@ public:
         PROD = 0,
         SUM = 1,
         MAX = 2,
+        DIV = 3
     } op;
     std::vector<float> coeffs;
     bool variableChannels;
@@ -79,6 +80,8 @@ public:
                 op = SUM;
             else if (operation == "max")
                 op = MAX;
+            else if (operation == "div")
+                op = DIV;
             else
                 CV_Error(cv::Error::StsBadArg, "Unknown operation type \"" + operation + "\"");
         }
@@ -97,7 +100,7 @@ public:
 
     virtual bool supportBackend(int backendId) CV_OVERRIDE
     {
-        return backendId == DNN_BACKEND_OPENCV ||
+        return (backendId == DNN_BACKEND_OPENCV && (op != DIV || preferableTarget == DNN_TARGET_CPU)) ||
                backendId == DNN_BACKEND_HALIDE ||
                (backendId == DNN_BACKEND_INFERENCE_ENGINE && !variableChannels &&
                 (preferableTarget != DNN_TARGET_OPENCL || coeffs.empty()));
@@ -267,6 +270,18 @@ public:
                             for( j = 0; j < blockSize; j++ )
                             {
                                 dstptr[j] = srcptr0[j]*srcptr1[j];
+                            }
+                            srcptr0 = (const float*)dstptr;
+                        }
+                    }
+                    else if( op == DIV )
+                    {
+                        for( k = 1; k < n; k++ )
+                        {
+                            const float* srcptr1 = srcs[k]->ptr<float>() + globalDelta;
+                            for( j = 0; j < blockSize; j++ )
+                            {
+                                dstptr[j] = srcptr0[j]/srcptr1[j];
                             }
                             srcptr0 = (const float*)dstptr;
                         }
@@ -486,6 +501,8 @@ public:
             ieLayer.setEltwiseType(InferenceEngine::Builder::EltwiseLayer::EltwiseType::SUM);
         else if (op == PROD)
             ieLayer.setEltwiseType(InferenceEngine::Builder::EltwiseLayer::EltwiseType::MUL);
+        else if (op == DIV)
+            ieLayer.setEltwiseType(InferenceEngine::Builder::EltwiseLayer::EltwiseType::DIV);
         else if (op == MAX)
             ieLayer.setEltwiseType(InferenceEngine::Builder::EltwiseLayer::EltwiseType::MAX);
         else

--- a/modules/dnn/src/onnx/onnx_importer.cpp
+++ b/modules/dnn/src/onnx/onnx_importer.cpp
@@ -520,7 +520,7 @@ void ONNXImporter::populateNet(Net dstNet)
         }
         else if (layer_type == "Div")
         {
-            if (node_proto.input_size() == 2) {
+            if (constBlobs.find(node_proto.input(1)) == constBlobs.end()) {
                 layerParams.type = "Eltwise";
                 layerParams.set("operation", "div");
             } else {

--- a/modules/dnn/src/onnx/onnx_importer.cpp
+++ b/modules/dnn/src/onnx/onnx_importer.cpp
@@ -520,10 +520,13 @@ void ONNXImporter::populateNet(Net dstNet)
         }
         else if (layer_type == "Div")
         {
-            if (constBlobs.find(node_proto.input(1)) == constBlobs.end()) {
+            if (constBlobs.find(node_proto.input(1)) == constBlobs.end())
+            {
                 layerParams.type = "Eltwise";
                 layerParams.set("operation", "div");
-            } else {
+            }
+            else
+            {
                 Mat blob = getBlob(node_proto, constBlobs, 1);
                 CV_Assert_N(blob.type() == CV_32F, blob.total());
                 if (blob.total() == 1)

--- a/modules/dnn/src/onnx/onnx_importer.cpp
+++ b/modules/dnn/src/onnx/onnx_importer.cpp
@@ -779,31 +779,29 @@ void ONNXImporter::populateNet(Net dstNet)
         else if (layer_type == "ReduceL2")
         {
             CV_Assert(node_proto.input_size() == 1);
-            CV_Assert(graph_proto.node(li + 1).op_type() == "Div");
+            CV_Assert(graph_proto.node_size() > li + 1 && graph_proto.node(li + 1).op_type() == "Div");
             ++li;
 
             layerParams.type = "Normalize";
-            layerParams.set("p", 2);
             std::vector<int> axes;
-            if (layerParams.has("axes")) {
+            if (layerParams.has("axes"))
+            {
                 DictValue axes_dict = layerParams.get("axes");
                 if (axes_dict.size() != 1)
                     CV_Error(Error::StsNotImplemented, "Multidimensional reduceL2");
-
                 axes.push_back(axes_dict.getIntValue(0));
-            } else {
+            }
+            else
+            {
                 shapeIt = outShapes.find(node_proto.input(0));
                 CV_Assert(shapeIt != outShapes.end());
                 MatShape inpShape = shapeIt->second;
-                for (int j = 0; j < inpShape.size(); ++j) {
-                    if (inpShape[j] == 1) {
+                for (int j = 0; j < inpShape.size(); ++j)
+                {
+                    if (inpShape[j] == 1)
                         axes.push_back(j);
-                    }
                 }
                 CV_Assert(!axes.empty());
-                for (int j = 1; j < axes.size(); ++j) {
-                    CV_Assert(axes[j - 1] + 1 == axes[j]);
-                }
             }
             layerParams.set("axis", axes.front());
             layerParams.set("end_axis", axes.back());
@@ -812,23 +810,26 @@ void ONNXImporter::populateNet(Net dstNet)
         {
             CV_Assert(node_proto.input_size() == 1);
             std::vector<int> axes;
-            if (layerParams.has("axes")) {
+            if (layerParams.has("axes"))
+            {
                 DictValue axes_dict = layerParams.get("axes");
                 if (axes_dict.size() != 1)
                     CV_Error(Error::StsNotImplemented, "Multidimensional squeeze");
-
                 axes.push_back(axes_dict.getIntValue(0));
-            } else {
+            }
+            else
+            {
                 shapeIt = outShapes.find(node_proto.input(0));
                 CV_Assert(shapeIt != outShapes.end());
                 MatShape inpShape = shapeIt->second;
-                for (int j = 0; j < inpShape.size(); ++j) {
-                    if (inpShape[j] == 1) {
+                for (int j = 0; j < inpShape.size(); ++j)
+                {
+                    if (inpShape[j] == 1)
                         axes.push_back(j);
-                    }
                 }
                 CV_Assert(!axes.empty());
-                for (int j = 1; j < axes.size(); ++j) {
+                for (int j = 1; j < axes.size(); ++j)
+                {
                     CV_Assert(axes[j - 1] + 1 == axes[j]);
                 }
             }

--- a/modules/dnn/test/test_onnx_importer.cpp
+++ b/modules/dnn/test/test_onnx_importer.cpp
@@ -320,9 +320,6 @@ TEST_P(Test_ONNX_layers, MultyInputs)
 
 TEST_P(Test_ONNX_layers, Div)
 {
-    if (backend == DNN_BACKEND_OPENCV && target != DNN_TARGET_CPU)
-        throw SkipTestException("Only OpenCV CPU is supported");
-
     const String model =  _tf("models/div.onnx");
     Net net = readNetFromONNX(model);
     ASSERT_FALSE(net.empty());

--- a/modules/dnn/test/test_onnx_importer.cpp
+++ b/modules/dnn/test/test_onnx_importer.cpp
@@ -318,6 +318,31 @@ TEST_P(Test_ONNX_layers, MultyInputs)
     expectNoFallbacksFromIE(net);
 }
 
+TEST_P(Test_ONNX_layers, Div)
+{
+    if (backend == DNN_BACKEND_OPENCV && target != DNN_TARGET_CPU)
+        throw SkipTestException("Only OpenCV CPU is supported");
+
+    const String model =  _tf("models/div.onnx");
+    Net net = readNetFromONNX(model);
+    ASSERT_FALSE(net.empty());
+
+    net.setPreferableBackend(backend);
+    net.setPreferableTarget(target);
+
+    Mat inp1 = blobFromNPY(_tf("data/input_div_0.npy"));
+    Mat inp2 = blobFromNPY(_tf("data/input_div_1.npy"));
+    Mat ref  = blobFromNPY(_tf("data/output_div.npy"));
+    checkBackend(&inp1, &ref);
+
+    net.setInput(inp1, "0");
+    net.setInput(inp2, "1");
+    Mat out = net.forward();
+
+    normAssert(ref, out, "", default_l1,  default_lInf);
+    expectNoFallbacksFromIE(net);
+}
+
 TEST_P(Test_ONNX_layers, DynamicReshape)
 {
     if (backend == DNN_BACKEND_INFERENCE_ENGINE)
@@ -331,6 +356,16 @@ TEST_P(Test_ONNX_layers, DynamicReshape)
 TEST_P(Test_ONNX_layers, Reshape)
 {
     testONNXModels("unsqueeze");
+}
+
+TEST_P(Test_ONNX_layers, Squeeze)
+{
+    testONNXModels("squeeze");
+}
+
+TEST_P(Test_ONNX_layers, ReduceL2)
+{
+    testONNXModels("reduceL2");
 }
 
 TEST_P(Test_ONNX_layers, Slice)


### PR DESCRIPTION
Related: #15251 
**Merge with extra:** opencv/opencv_extra#683
```
force_builders=Custom,Custom Win,Custom Mac
build_image:Custom=ubuntu-openvino-2019r3.0:16.04
build_image:Custom Win=openvino-2019r3.0
build_image:Custom Mac=openvino-2019r3.0

test_modules:Custom=dnn,python2,python3,java
test_modules:Custom Win=dnn,python2,python3,java
test_modules:Custom Mac=dnn,python2,python3,java

buildworker:Custom=linux-1
test_opencl:Custom=OFF
test_bigdata:Custom=1
test_filter:Custom=*
```