### PR TITLE
Use FlsAlloc/FlsFree/FlsGetValue/FlsSetValue instead of TlsAlloc/TlsFree/TlsGetValue/TlsSetValue to implment TLS value cleanup when thread has been terminated on Windows Vista and above

### DIFF
--- a/modules/core/src/system.cpp
+++ b/modules/core/src/system.cpp
@@ -1431,7 +1431,7 @@ TlsAbstraction::TlsAbstraction()
 #if (_WIN32_WINNT < 0x0600)
     tlsKey = TlsAlloc();
 #else // _WIN32_WINNT < 0x0600
-    tlsKey = FlsAlloc(opencv_fls_destructor);
+    tlsKey = FlsAlloc((PFLS_CALLBACK_FUNCTION)opencv_fls_destructor);
 #endif // _WIN32_WINNT < 0x0600
     CV_Assert(tlsKey != TLS_OUT_OF_INDEXES);
 }

--- a/modules/core/src/system.cpp
+++ b/modules/core/src/system.cpp
@@ -1425,7 +1425,7 @@ void  TlsAbstraction::SetData(void *pData)
     tlsData = pData;
 }
 #else //WINRT
-static void WINAPI opencv_fls_destructor(void* pData);
+static void NTAPI opencv_fls_destructor(void* pData);
 TlsAbstraction::TlsAbstraction()
 {
 #if (_WIN32_WINNT < 0x0600)

--- a/modules/core/src/system.cpp
+++ b/modules/core/src/system.cpp
@@ -1425,13 +1425,13 @@ void  TlsAbstraction::SetData(void *pData)
     tlsData = pData;
 }
 #else //WINRT
-static void opencv_fls_destructor(void* pData);
+static void WINAPI opencv_fls_destructor(void* pData);
 TlsAbstraction::TlsAbstraction()
 {
 #if (_WIN32_WINNT < 0x0600)
     tlsKey = TlsAlloc();
 #else // _WIN32_WINNT < 0x0600
-    tlsKey = FlsAlloc((PFLS_CALLBACK_FUNCTION)opencv_fls_destructor);
+    tlsKey = FlsAlloc(opencv_fls_destructor);
 #endif // _WIN32_WINNT < 0x0600
     CV_Assert(tlsKey != TLS_OUT_OF_INDEXES);
 }
@@ -1695,7 +1695,7 @@ static void opencv_tls_destructor(void* pData)
     getTlsStorage().releaseThread(pData);
 }
 #else	// _WIN32
-static void opencv_fls_destructor(void* pData)
+static void WINAPI opencv_fls_destructor(void* pData)
 {
     getTlsStorage().releaseThread(pData);
 }


### PR DESCRIPTION
##### System information (version)
- OpenCV => 4.1.2-dev
- Operating System / Platform => Windows 7 64-bit
- Compiler => Visual Studio 2015

##### Detailed description

Use FlsAlloc/FlsFree/FlsGetValue/FlsSetValue instead of TlsAlloc/TlsFree/TlsGetValue/TlsSetValue to implment TLS operations and **cleanup of value** when thread has been terminated on Windows Vista and above.
Fls-functions operates on fiber local storage (FLS) and FlsAlloc allows to specify application-defined callback function. If the FLS slot is in use, then callback is called on fiber deletion, **thread exit**, and when an FLS index is freed. For more information see https://docs.microsoft.com/en-us/windows/win32/api/fibersapi/nf-fibersapi-flsalloc

In orer to use Fls-functions need to define _WIN32_WINNT to 0x0600 or above.
