### PR TITLE
TS: do not block reporting of launched "DISABLED_" tests

### DIFF
--- a/modules/ts/misc/testlog_parser.py
+++ b/modules/ts/misc/testlog_parser.py
@@ -30,7 +30,8 @@ class TestInfo(object):
             self.status = xmlnode.getAttribute("status")
 
         if self.name.startswith("DISABLED_"):
-            self.status = "disabled"
+            if self.status == 'notrun':
+                self.status = "disabled"
             self.fixture = self.fixture.replace("DISABLED_", "")
             self.name = self.name.replace("DISABLED_", "")
         self.properties = {


### PR DESCRIPTION
If tests are run through GTest option `--gtest_also_run_disabled_tests`

Launched tests have `status="run"` in GTest
Skipped disabled tests have `status="notrun"` in GTest