### PR TITLE
Clarify stereoRectify() doc

### DIFF
--- a/modules/calib3d/include/opencv2/calib3d.hpp
+++ b/modules/calib3d/include/opencv2/calib3d.hpp
@@ -1543,8 +1543,8 @@ CV_EXPORTS_W double stereoCalibrate( InputArrayOfArrays objectPoints,
 @param cameraMatrix2 Second camera matrix.
 @param distCoeffs2 Second camera distortion parameters.
 @param imageSize Size of the image used for stereo calibration.
-@param R Rotation matrix between the coordinate systems of the first and the second cameras.
-@param T Translation vector between coordinate systems of the cameras.
+@param R Rotation matrix from the coordinate system of the second camera to the first.
+@param T Translation vector from the coordinate system of the second camera to the first.
 @param R1 Output 3x3 rectification transform (rotation matrix) for the first camera.
 @param R2 Output 3x3 rectification transform (rotation matrix) for the second camera.
 @param P1 Output 3x4 projection matrix in the new (rectified) coordinate systems for the first


### PR DESCRIPTION
The function stereoRectify() takes as input a coordinate transform between two cameras. It is ambiguous how it goes. I clarified that it goes from the second camera to the first.

<!-- Please use this line to close one or multiple issues when this pullrequest gets merged
You can add another line right under the first one:
resolves #1234
resolves #1235
-->

### This pullrequest changes

<!-- Please describe what your pullrequest is changing -->
