### PR TITLE
Fix wrong definition of viz::Color::navy()

### DIFF
--- a/modules/viz/include/opencv2/viz/types.hpp
+++ b/modules/viz/include/opencv2/viz/types.hpp
@@ -75,42 +75,42 @@ namespace cv
             static Color black();
             static Color blue();
             static Color green();
-            static Color cyan();
-
             static Color red();
-            static Color magenta();
+            static Color cyan();
             static Color yellow();
+            static Color magenta();
             static Color white();
 
             static Color gray();
+            static Color silver();
 
             static Color mlab();
 
             static Color navy();
-            static Color olive();
             static Color maroon();
             static Color teal();
-            static Color rose();
+            static Color olive();
+            static Color purple();
             static Color azure();
+            static Color chartreuse();
+            static Color rose();
+
             static Color lime();
             static Color gold();
-            static Color brown();
             static Color orange();
-            static Color chartreuse();
             static Color orange_red();
-            static Color purple();
             static Color indigo();
 
-            static Color pink();
-            static Color cherry();
-            static Color bluberry();
-            static Color raspberry();
-            static Color silver();
-            static Color violet();
+            static Color brown();
             static Color apricot();
-            static Color turquoise();
-            static Color celestial_blue();
+            static Color pink();
+            static Color raspberry();
+            static Color cherry();
+            static Color violet();
             static Color amethyst();
+            static Color bluberry();
+            static Color celestial_blue();
+            static Color turquoise();
 
             static Color not_set();
         };
@@ -343,42 +343,44 @@ inline cv::viz::Color::Color(const Scalar& color) : Scalar(color) {}
 inline cv::viz::Color::operator cv::Vec3b() const { return cv::Vec3d(val); }
 
 inline cv::viz::Color cv::viz::Color::black()   { return Color(  0,   0,   0); }
-inline cv::viz::Color cv::viz::Color::green()   { return Color(  0, 255,   0); }
 inline cv::viz::Color cv::viz::Color::blue()    { return Color(255,   0,   0); }
-inline cv::viz::Color cv::viz::Color::cyan()    { return Color(255, 255,   0); }
+inline cv::viz::Color cv::viz::Color::green()   { return Color(  0, 255,   0); }
 inline cv::viz::Color cv::viz::Color::red()     { return Color(  0,   0, 255); }
+inline cv::viz::Color cv::viz::Color::cyan()    { return Color(255, 255,   0); }
 inline cv::viz::Color cv::viz::Color::yellow()  { return Color(  0, 255, 255); }
 inline cv::viz::Color cv::viz::Color::magenta() { return Color(255,   0, 255); }
 inline cv::viz::Color cv::viz::Color::white()   { return Color(255, 255, 255); }
+
 inline cv::viz::Color cv::viz::Color::gray()    { return Color(128, 128, 128); }
+inline cv::viz::Color cv::viz::Color::silver()  { return Color(192, 192, 192); }
 
 inline cv::viz::Color cv::viz::Color::mlab()    { return Color(255, 128, 128); }
 
-inline cv::viz::Color cv::viz::Color::navy()       { return Color(0,     0, 128); }
-inline cv::viz::Color cv::viz::Color::olive()      { return Color(0,   128, 128); }
-inline cv::viz::Color cv::viz::Color::maroon()     { return Color(0,     0, 128); }
+inline cv::viz::Color cv::viz::Color::navy()       { return Color(128,   0,   0); }
+inline cv::viz::Color cv::viz::Color::maroon()     { return Color(  0,   0, 128); }
 inline cv::viz::Color cv::viz::Color::teal()       { return Color(128, 128,   0); }
-inline cv::viz::Color cv::viz::Color::rose()       { return Color(128,   0, 255); }
-inline cv::viz::Color cv::viz::Color::azure()      { return Color(255, 128,   0); }
-inline cv::viz::Color cv::viz::Color::lime()       { return Color(0,   255, 191); }
-inline cv::viz::Color cv::viz::Color::gold()       { return Color(0,   215, 255); }
-inline cv::viz::Color cv::viz::Color::brown()      { return Color(42,    42, 165); }
-inline cv::viz::Color cv::viz::Color::orange()     { return Color(0,   165, 255); }
-inline cv::viz::Color cv::viz::Color::chartreuse() { return Color(0,   255, 128); }
-inline cv::viz::Color cv::viz::Color::orange_red() { return Color(0,    69, 255); }
+inline cv::viz::Color cv::viz::Color::olive()      { return Color(  0, 128, 128); }
 inline cv::viz::Color cv::viz::Color::purple()     { return Color(128,   0, 128); }
+inline cv::viz::Color cv::viz::Color::azure()      { return Color(255, 128,   0); }
+inline cv::viz::Color cv::viz::Color::chartreuse() { return Color(  0, 255, 128); }
+inline cv::viz::Color cv::viz::Color::rose()       { return Color(128,   0, 255); }
+
+inline cv::viz::Color cv::viz::Color::lime()       { return Color(  0, 255, 191); }
+inline cv::viz::Color cv::viz::Color::gold()       { return Color(  0, 215, 255); }
+inline cv::viz::Color cv::viz::Color::orange()     { return Color(  0, 165, 255); }
+inline cv::viz::Color cv::viz::Color::orange_red() { return Color(  0,  69, 255); }
 inline cv::viz::Color cv::viz::Color::indigo()     { return Color(130,   0,  75); }
 
-inline cv::viz::Color cv::viz::Color::pink()           { return Color(203, 192, 255); }
-inline cv::viz::Color cv::viz::Color::cherry()         { return Color( 99,  29, 222); }
-inline cv::viz::Color cv::viz::Color::bluberry()       { return Color(247, 134,  79); }
-inline cv::viz::Color cv::viz::Color::raspberry()      { return Color( 92,  11, 227); }
-inline cv::viz::Color cv::viz::Color::silver()         { return Color(192, 192, 192); }
-inline cv::viz::Color cv::viz::Color::violet()         { return Color(226,  43, 138); }
+inline cv::viz::Color cv::viz::Color::brown()          { return Color( 42,  42, 165); }
 inline cv::viz::Color cv::viz::Color::apricot()        { return Color(177, 206, 251); }
-inline cv::viz::Color cv::viz::Color::turquoise()      { return Color(208, 224,  64); }
-inline cv::viz::Color cv::viz::Color::celestial_blue() { return Color(208, 151,  73); }
+inline cv::viz::Color cv::viz::Color::pink()           { return Color(203, 192, 255); }
+inline cv::viz::Color cv::viz::Color::raspberry()      { return Color( 92,  11, 227); }
+inline cv::viz::Color cv::viz::Color::cherry()         { return Color( 99,  29, 222); }
+inline cv::viz::Color cv::viz::Color::violet()         { return Color(226,  43, 138); }
 inline cv::viz::Color cv::viz::Color::amethyst()       { return Color(204, 102, 153); }
+inline cv::viz::Color cv::viz::Color::bluberry()       { return Color(247, 134,  79); }
+inline cv::viz::Color cv::viz::Color::celestial_blue() { return Color(208, 151,  73); }
+inline cv::viz::Color cv::viz::Color::turquoise()      { return Color(208, 224,  64); }
 
 inline cv::viz::Color cv::viz::Color::not_set()        { return Color(-1, -1, -1); }
 


### PR DESCRIPTION
<!-- Please use this line to close one or multiple issues when this pullrequest gets merged
You can add another line right under the first one:
resolves #1234
resolves #1235
-->
resolves https://github.com/opencv/opencv_contrib/issues/2321

### This pullrequest changes
Fix wrong definition of viz::Color::navy().
All the other colors look good.
Reorder the colors definition in chromatic order (because it triggers my OCD)
