### PR TITLE
cmake: fix ITT define condition

### DIFF
--- a/modules/core/CMakeLists.txt
+++ b/modules/core/CMakeLists.txt
@@ -39,7 +39,7 @@ if(HAVE_CUDA)
   ocv_warnings_disable(CMAKE_CXX_FLAGS -Wundef -Wenum-compare -Wunused-function -Wshadow)
 endif()
 
-if(CV_TRACE AND HAVE_ITT AND BUILD_ITT)
+if(CV_TRACE AND HAVE_ITT)
   add_definitions(-DOPENCV_WITH_ITT=1)
 endif()
 


### PR DESCRIPTION
`BUILD_ITT=OFF` in case of using ITT from [VTune](https://software.intel.com/en-us/vtune/choose-download).

Example of CMake options (Linux x86-64):

<cut/>

```
cmake -DBUILD_ITT=OFF -DHAVE_ITT=ON \
    -DITT_INCLUDE_DIRS=${VTUNE_AMPLIFIER_2019_DIR}/include \
    -DITT_LIBRARIES=${VTUNE_AMPLIFIER_2019_DIR}/lib64/libittnotify.a ...
```