### PR TITLE
Correct stereoRectify documentation

### DIFF
--- a/modules/calib3d/include/opencv2/calib3d.hpp
+++ b/modules/calib3d/include/opencv2/calib3d.hpp
@@ -1543,8 +1543,8 @@ CV_EXPORTS_W double stereoCalibrate( InputArrayOfArrays objectPoints,
 @param cameraMatrix2 Second camera matrix.
 @param distCoeffs2 Second camera distortion parameters.
 @param imageSize Size of the image used for stereo calibration.
-@param R Rotation matrix from the coordinate system of the second camera to the first.
-@param T Translation vector from the coordinate system of the second camera to the first.
+@param R Rotation matrix from the coordinate system of the first camera to the second.
+@param T Translation vector from the coordinate system of the first camera to the second.
 @param R1 Output 3x3 rectification transform (rotation matrix) for the first camera.
 @param R2 Output 3x3 rectification transform (rotation matrix) for the second camera.
 @param P1 Output 3x4 projection matrix in the new (rectified) coordinate systems for the first


### PR DESCRIPTION
I made a mistake in my previous pull request. For the function stereoRectify(), R and T are transforms from the first camera to the second, rather than the other way around. To ensure that there is no mistake, I propose developers do a simple check using the stereo_match included executable. It goes as follows:

 - Create a left image and a right image, say 100 x 100 pixels each, with the right image shifted 10 pixels to the right. 
 - Create an intrinsics file, say with intrinsics matrix 80 0 50; 0 80 50;  0 0 1 and zero distortion (f=80, cx = cy = 50)
 - Create an extrinsics file, which is the transform from first to second camera, with identity rotation, translation of -10 0 0, 
 - Invoke the shipped stereo_match executable. This will call the stereoRectify() function whose documentation we want to test.  

This will result in a correct disparity of 10 pixels.

This is also consistent with the documentation of stereoCalibrate() in the same file, which creates such an R and T. It has the formula:

\f[R_2=R*R_1\f]
\f[T_2=R*T_1 + T,\f]

This only makes sense if  (R1, T1) go from the world to camera1, (R, T) goes from camera 1 to camera 2, and their composition goes from world to camera 2:

 [R | T] *[ R1 | T1]  = [R2 | T2]

which can be expanded to 
 R*( R1*x + T1 ) + T = R2*x + T2

which yields as above: R*R1 = R2, R*T1 + T = T2

<!-- Please use this line to close one or multiple issues when this pullrequest gets merged
You can add another line right under the first one:
resolves #1234
resolves #1235
-->

### This pullrequest changes

<!-- Please describe what your pullrequest is changing -->
