### PR TITLE
G-API: Unify GKernelType and GKernelTypeM logic (+ GNetworkType)

### DIFF
--- a/modules/gapi/include/opencv2/gapi/gkernel.hpp
+++ b/modules/gapi/include/opencv2/gapi/gkernel.hpp
@@ -176,17 +176,23 @@ namespace detail
 //
 // G_TYPED_KERNEL macros inherits user classes from GKernelType.
 template<typename, typename>
-class GKernelType;
+struct GKernelType;
 
 // Specialization for multiple-return-value
 template<class K, typename... R, typename... Args>
-class GKernelType<K, std::function<std::tuple<R...>(Args...)> >:
-    public detail::GKernelTypeImpl<K, std::function<std::tuple<R...>(Args...)> > {};
+struct GKernelType<K, std::function<std::tuple<R...>(Args...)> >:
+    public detail::GKernelTypeImpl<K, std::function<std::tuple<R...>(Args...)> >
+{
+    using detail::GKernelTypeImpl<K, std::function<std::tuple<R...>(Args...)>>::on;
+};
 
 // Specialization for single-return-value
 template<class K, typename R, typename... Args>
-class GKernelType<K, std::function<R(Args...)> >:
-    public detail::GKernelTypeImpl<K, std::function<std::tuple<R>(Args...)> > {};
+struct GKernelType<K, std::function<R(Args...)> >:
+    public detail::GKernelTypeImpl<K, std::function<std::tuple<R>(Args...)> >
+{
+    using detail::GKernelTypeImpl<K, std::function<std::tuple<R>(Args...)>>::on;
+};
 
 } // namespace cv
 

--- a/modules/gapi/include/opencv2/gapi/infer.hpp
+++ b/modules/gapi/include/opencv2/gapi/infer.hpp
@@ -23,23 +23,6 @@
 
 namespace cv {
 
-namespace detail {
-    // This tiny class eliminates the semantic difference between
-    // GKernelType and GKernelTypeM.
-    // FIXME: Something similar can be reused for regular kernels
-    template<typename, typename>
-    struct KernelTypeMedium;
-
-    template<class K, typename... R, typename... Args>
-    struct KernelTypeMedium<K, std::function<std::tuple<R...>(Args...)> >:
-        public GKernelTypeM<K, std::function<std::tuple<R...>(Args...)> > {};
-
-    template<class K, typename R, typename... Args>
-    struct KernelTypeMedium<K, std::function<R(Args...)> >:
-        public GKernelType<K, std::function<R(Args...)> > {};
-
-} // namespace detail
-
 template<typename, typename> class GNetworkType;
 
 // TODO: maybe tuple_wrap_helper from util.hpp may help with this.
@@ -103,12 +86,11 @@ struct GInferListBase {
 
 // A generic inference kernel. API (::on()) is fully defined by the Net
 // template parameter.
-// Acts as a regular kernel in graph (via KernelTypeMedium).
+// Acts as a regular kernel in graph (via GKernelType).
 template<typename Net>
 struct GInfer final
     : public GInferBase
-    , public detail::KernelTypeMedium< GInfer<Net>
-                                     , typename Net::API > {
+    , public GKernelType< GInfer<Net>, typename Net::API > {
     using GInferBase::getOutMeta; // FIXME: name lookup conflict workaround?
 
     static constexpr const char* tag() { return Net::tag(); }
@@ -119,8 +101,7 @@ struct GInfer final
 template<typename Net>
 struct GInferList final
     : public GInferListBase
-    , public detail::KernelTypeMedium< GInferList<Net>
-                                     , typename Net::APIList > {
+    , public GKernelType< GInferList<Net>, typename Net::APIList > {
     using GInferListBase::getOutMeta; // FIXME: name lookup conflict workaround?
 
     static constexpr const char* tag() { return Net::tag(); }

--- a/modules/gapi/include/opencv2/gapi/infer.hpp
+++ b/modules/gapi/include/opencv2/gapi/infer.hpp
@@ -23,13 +23,13 @@
 
 namespace cv {
 
-template<typename, typename> class GNetworkType;
+template<typename, typename> struct GNetworkType;
 
 namespace detail {
-template<typename, typename> class GNetworkTypeImpl;
+template<typename, typename> struct GNetworkTypeImpl;
 
 template<typename K, typename... R, typename... Args>
-class GNetworkTypeImpl<K, std::function<std::tuple<R...>(Args...)> >
+struct GNetworkTypeImpl<K, std::function<std::tuple<R...>(Args...)> >
 {
 public:
     using InArgs  = std::tuple<Args...>;

--- a/modules/gapi/include/opencv2/gapi/infer.hpp
+++ b/modules/gapi/include/opencv2/gapi/infer.hpp
@@ -31,7 +31,6 @@ template<typename, typename> struct GNetworkTypeImpl;
 template<typename K, typename... R, typename... Args>
 struct GNetworkTypeImpl<K, std::function<std::tuple<R...>(Args...)> >
 {
-public:
     using InArgs  = std::tuple<Args...>;
     using OutArgs = std::tuple<R...>;
 
@@ -46,12 +45,12 @@ public:
 // Specialization for multiple-return-value
 template<class K, typename... R, typename... Args>
 struct GNetworkType<K, std::function<std::tuple<R...>(Args...)> >:
-    public detail::GNetworkTypeImpl<K, std::function<std::tuple<R...>(Args...)> > {};
+    detail::GNetworkTypeImpl<K, std::function<std::tuple<R...>(Args...)> > {};
 
 // Specialization for single-return-value
 template<class K, typename R, typename... Args>
 struct GNetworkType<K, std::function<R(Args...)> >:
-    public detail::GNetworkTypeImpl<K, std::function<std::tuple<R>(Args...)> > {};
+    detail::GNetworkTypeImpl<K, std::function<std::tuple<R>(Args...)> > {};
 
 // Base "Infer" kernel. Note - for whatever network, kernel ID
 // is always the same. Different inference calls are distinguished by

--- a/modules/gapi/include/opencv2/gapi/util/util.hpp
+++ b/modules/gapi/include/opencv2/gapi/util/util.hpp
@@ -116,6 +116,39 @@ namespace detail
         using type = std::tuple<Objs...>;
         static type get(std::tuple<Objs...>&& objs) { return std::forward<std::tuple<Objs...>>(objs); }
     };
+
+    // Helper for return type definition. Provides the actual logic of how return type is defined.
+    template<bool, typename...>
+    struct return_type_helper_impl;
+
+    // Helper for return type definition. Generalizes type definition for single and multiple return
+    // values in the context of G-API kernels
+    template<typename... Ts>
+    struct return_type_helper
+    {
+        using impl = return_type_helper_impl<std::tuple_size<std::tuple<Ts...>>::value == 1, Ts...>;
+        using type = typename impl::type;
+        static type get(Ts&&... args) { return impl::get(std::forward<Ts>(args)...); }
+    };
+
+    // Alias to simplify code bloat
+    template<typename... Ts>
+    using return_type_helper_t = typename return_type_helper<Ts...>::type;
+
+    template<typename T>
+    struct return_type_helper_impl<true, T>
+    {
+        using type = T;
+        static type get(T&& obj) { return std::forward<T>(obj); }
+    };
+
+    template<typename... Ts>
+    struct return_type_helper_impl<false, Ts...>
+    {
+        using type = std::tuple<Ts...>;
+        static type get(Ts&&... args) { return std::make_tuple(std::forward<Ts>(args)...); };
+    };
+
 } // namespace detail
 } // namespace cv
 


### PR DESCRIPTION
### This pullrequest

- Unifies:
  * `GKernelType` and `GKernelTypeM`
  * `detail::MetaHelper` logic
  * `GNetworkType` logic
- `#define G_KERNEL_TYPE_M G_KERNEL_TYPE`
- Introduces `return_type_helper` to support single/multiple return-value differences

---
**Bottom line**: no difference between `G_KERNEL_TYPE_M` and `G_KERNEL_TYPE` now
