### PR TITLE
Fix YAML parse

### DIFF
--- a/modules/core/src/persistence_yml.cpp
+++ b/modules/core/src/persistence_yml.cpp
@@ -770,7 +770,7 @@ public:
         bool first = true;
         bool ok = true;
         FileNode root_collection(fs->getFS(), 0, 0);
-
+        FileNode root_node = fs->addNode(root_collection, std::string(), FileNode::NONE);
         for(;;)
         {
             // 0. skip leading comments and directives  and ...
@@ -821,7 +821,6 @@ public:
             if( memcmp( ptr, "...", 3 ) != 0 )
             {
                 // 2. parse the collection
-                FileNode root_node = fs->addNode(root_collection, std::string(), FileNode::NONE);
 
                 ptr = parseValue( ptr, root_node, 0, false );
                 if( !root_node.isMap() && !root_node.isSeq() )

--- a/modules/core/test/test_io.cpp
+++ b/modules/core/test/test_io.cpp
@@ -1644,7 +1644,7 @@ TEST(Core_InputOutput, FileStorage_YAML_parse_multiple_documents)
 {
     const std::string filename = "FileStorage_YAML_parse_multiple_documents.yml";
     FileStorage fs;
-    
+
     fs.open(filename, FileStorage::WRITE);
     fs << "a" << 42;
     fs.release();

--- a/modules/core/test/test_io.cpp
+++ b/modules/core/test/test_io.cpp
@@ -1640,4 +1640,23 @@ TEST(Core_InputOutput, FileStorage_free_file_after_exception)
     ASSERT_EQ(0, std::remove(fileName.c_str()));
 }
 
+TEST(Core_InputOutput, FileStorage_YAML_parse_multiple_documents)
+{
+    const std::string filename = "FileStorage_YAML_parse_multiple_documents.yml";
+    FileStorage fs;
+    
+    fs.open(filename, FileStorage::WRITE);
+    fs << "a" << 42;
+    fs.release();
+
+    fs.open(filename, FileStorage::APPEND);
+    fs << "b" << 1988;
+    fs.release();
+
+    fs.open(filename, FileStorage::READ);
+    ASSERT_EQ(42, (int)fs["a"]);
+    ASSERT_EQ(1988, (int)fs["b"]);
+    fs.release();
+}
+
 }} // namespace


### PR DESCRIPTION
<!-- Please use this line to close one or multiple issues when this pullrequest gets merged
You can add another line right under the first one:
resolves #1234
resolves #1235
-->
resolves #14130

### This pullrequest changes
This pullrequest changes `core/persistence_yml.cpp` to fix incorrect YAML parse behavior. Current 4.x fails to read multiple documents from single file. 
<!-- Please describe what your pullrequest is changing -->
