### PR TITLE
core(persistence): fix processing of multiple YAML documents

### DIFF
--- a/modules/core/src/persistence.cpp
+++ b/modules/core/src/persistence.cpp
@@ -1900,18 +1900,19 @@ int FileStorage::getFormat() const
 
 FileNode FileStorage::operator [](const char* key) const
 {
-    if( p->roots.empty() )
-        return FileNode();
-
-    return p->roots[0][key];
+    return this->operator[](std::string(key));
 }
 
 FileNode FileStorage::operator [](const std::string& key) const
 {
-    if( p->roots.empty() )
-        return FileNode();
-
-    return p->roots[0][key];
+    FileNode res;
+    for (size_t i = 0; i < p->roots.size(); i++)
+    {
+        res = p->roots[i][key];
+        if (!res.empty())
+            break;
+    }
+    return res;
 }
 
 String FileStorage::releaseAndGetString()

--- a/modules/core/test/test_io.cpp
+++ b/modules/core/test/test_io.cpp
@@ -1654,9 +1654,19 @@ TEST(Core_InputOutput, FileStorage_YAML_parse_multiple_documents)
     fs.release();
 
     fs.open(filename, FileStorage::READ);
-    ASSERT_EQ(42, (int)fs["a"]);
-    ASSERT_EQ(1988, (int)fs["b"]);
+
+    EXPECT_EQ(42, (int)fs["a"]);
+    EXPECT_EQ(1988, (int)fs["b"]);
+
+    EXPECT_EQ(42, (int)fs.root(0)["a"]);
+    EXPECT_TRUE(fs.root(0)["b"].empty());
+
+    EXPECT_TRUE(fs.root(1)["a"].empty());
+    EXPECT_EQ(1988, (int)fs.root(1)["b"]);
+
     fs.release();
+
+    ASSERT_EQ(0, std::remove(filename.c_str()));
 }
 
 }} // namespace


### PR DESCRIPTION
resolves #14130
resolves https://github.com/opencv/opencv_contrib/issues/2331
relates #15842

Corresponding code on "3.4" branch is [here](https://github.com/opencv/opencv/blame/3.4.8/modules/core/src/persistence_c.cpp#L662).

```
allow_multiple_commits=1
```