### PR TITLE
GAPI Fluid: The run_sepfilter() has logic error into snippet for 5x5 …

### DIFF
--- a/modules/gapi/perf/cpu/gapi_imgproc_perf_tests_fluid.cpp
+++ b/modules/gapi/perf/cpu/gapi_imgproc_perf_tests_fluid.cpp
@@ -58,7 +58,7 @@ INSTANTIATE_TEST_CASE_P(BlurPerfTestFluid, BlurPerfTest,
 INSTANTIATE_TEST_CASE_P(GaussianBlurPerfTestFluid, GaussianBlurPerfTest,
     Combine(Values(ToleranceFilter(1e-3f, 0.01).to_compare_f()),
             Values(CV_8UC1, CV_8UC3, CV_16UC1, CV_16SC1, CV_32FC1),
-            Values(3),                                     // TODO: add size=5, when kernel is ready
+            Values(3, 5),
             Values(szVGA, sz720p, sz1080p),
             Values(cv::compile_args(IMGPROC_FLUID))));
 

--- a/modules/gapi/src/backends/fluid/gfluidimgproc.cpp
+++ b/modules/gapi/src/backends/fluid/gfluidimgproc.cpp
@@ -628,7 +628,7 @@ static void run_sepfilter(Buffer& dst, const View& src,
     else
     {
         int length = chan * width;
-        int xshift = chan * xborder;
+        int xshift = chan;
 
         // horizontal pass
 
@@ -788,8 +788,6 @@ GAPI_FLUID_KERNEL(GFluidGaussBlur, cv::gapi::imgproc::GGaussBlur, true)
                               Buffer&    dst,
                               Buffer&    scratch)
     {
-        GAPI_Assert(ksize.height == 3);
-
         int kxsize = ksize.width;
         int kysize = ksize.height;
 
@@ -800,10 +798,16 @@ GAPI_FLUID_KERNEL(GFluidGaussBlur, cv::gapi::imgproc::GGaussBlur, true)
         int chan  = src.meta().chan;
         int length = width * chan;
 
-        float *buf[3];
+        constexpr int buffSize = 5;
+        GAPI_Assert(ksize.height <= buffSize);
+
+        float *buf[buffSize]{};
+
         buf[0] = ky + kysize;
-        buf[1] = buf[0] + length;
-        buf[2] = buf[1] + length;
+        for (int i = 1; i < ksize.height; ++i)
+        {
+            buf[i] = buf[i - 1] + length;
+        }
 
         auto  anchor = cv::Point(-1, -1);
 

--- a/modules/gapi/test/cpu/gapi_imgproc_tests_fluid.cpp
+++ b/modules/gapi/test/cpu/gapi_imgproc_tests_fluid.cpp
@@ -106,7 +106,7 @@ INSTANTIATE_TEST_CASE_P(gaussBlurTestFluid, GaussianBlurTest,
                                 Values(-1),
                                 Values(IMGPROC_FLUID),
                                 Values(ToleranceFilter(1e-3f, 0.01).to_compare_obj()),
-                                Values(3))); // add kernel size=5 when implementation is ready
+                                Values(3, 5)));
 
 INSTANTIATE_TEST_CASE_P(medianBlurTestFluid, MedianBlurTest,
                         Combine(Values(CV_8UC1, CV_16UC1, CV_16SC1),


### PR DESCRIPTION
…and larger kernels

<!-- Please use this line to close one or multiple issues when this pullrequest gets merged
You can add another line right under the first one:
resolves #1234
resolves #1235
-->

### This pullrequest changes

<!-- Please describe what your pullrequest is changing -->
build_gapi_standalone:Linux x64=ade-0.1.1f
build_gapi_standalone:Win64=ade-0.1.1f
build_gapi_standalone:Mac=ade-0.1.1f
build_gapi_standalone:Linux x64 Debug=ade-0.1.1f