### PR TITLE
Refactor opencl_info

### DIFF
--- a/modules/core/include/opencv2/core/opencl/opencl_info.hpp
+++ b/modules/core/include/opencv2/core/opencl/opencl_info.hpp
@@ -47,6 +47,23 @@ static std::string bytesToStringRepr(size_t value)
         s = s.substr(0, s.size() - 1);
     return s;
 }
+
+static String getDeviceTypeString(const cv::ocl::Device& device)
+{
+    if (device.type() == cv::ocl::Device::TYPE_CPU) {
+        return "CPU";
+    }
+
+    if (device.type() == cv::ocl::Device::TYPE_GPU) {
+        if (device.hostUnifiedMemory()) {
+            return "iGPU";
+        } else {
+            return "dGPU";
+        }
+    }
+
+    return "unkown";
+}
 } // namespace
 
 static void dumpOpenCLInformation()
@@ -80,12 +97,11 @@ static void dumpOpenCLInformation()
             for (int j = 0; j < platform->deviceNumber(); j++)
             {
                 platform->getDevice(current_device, j);
-                const char* deviceTypeStr = (current_device.type() == Device::TYPE_CPU) ? "CPU" :
-                    (current_device.type() == Device::TYPE_GPU ? current_device.hostUnifiedMemory() ? "iGPU" : "dGPU" : "unknown");
+                String deviceTypeStr = getDeviceTypeString(current_device);
                 DUMP_MESSAGE_STDOUT( "        " << deviceTypeStr << ": " << current_device.name() << " (" << current_device.version() << ")");
                 DUMP_CONFIG_PROPERTY( cv::format("cv_ocl_platform_%d_device_%d", (int)i, j ),
                     cv::format("(Platform=%s)(Type=%s)(Name=%s)(Version=%s)",
-                    platform->name().c_str(), deviceTypeStr, current_device.name().c_str(), current_device.version().c_str()) );
+                    platform->name().c_str(), deviceTypeStr.c_str(), current_device.name().c_str(), current_device.version().c_str()) );
             }
         }
         const Device& device = Device::getDefault();
@@ -94,13 +110,7 @@ static void dumpOpenCLInformation()
 
         DUMP_MESSAGE_STDOUT("Current OpenCL device: ");
 
-#if 0
-        DUMP_MESSAGE_STDOUT("    Platform = " << device.getPlatform().name());
-        DUMP_CONFIG_PROPERTY("cv_ocl_current_platformName", device.getPlatform().name());
-#endif
-
-        const char* deviceTypeStr = (device.type() == Device::TYPE_CPU) ? "CPU" :
-            (device.type() == Device::TYPE_GPU ? device.hostUnifiedMemory() ? "iGPU" : "dGPU" : "unknown");
+        String deviceTypeStr = getDeviceTypeString(device);
         DUMP_MESSAGE_STDOUT("    Type = " << deviceTypeStr);
         DUMP_CONFIG_PROPERTY("cv_ocl_current_deviceType", deviceTypeStr);
 


### PR DESCRIPTION
This pullrequest refactors parts of opencl information dumping: 

- Remove code duplication
- Clarify functionality of ternary operator
- Use cv's String instead of char * for strings
- Remove unused code

```
force_builders=Custom,Linux AVX2,Linux OpenCL
build_image:Custom=ubuntu:18.04
buildworker:Custom=linux-5
test_opencl:Custom=ON

build_image:Linux AVX2=ubuntu:18.04
buildworker:Linux AVX2=linux-3
test_opencl:Linux AVX2=ON
```