### PR TITLE
G-API: unique_ptr for Priv in fluid

### DIFF
--- a/modules/gapi/include/opencv2/gapi/fluid/gfluidbuffer.hpp
+++ b/modules/gapi/include/opencv2/gapi/fluid/gfluidbuffer.hpp
@@ -115,6 +115,8 @@ public:
            BorderOpt border);
     // Constructor for in/out buffers (for tests)
     Buffer(const cv::gapi::own::Mat &data, bool is_input);
+    ~Buffer();
+    Buffer& operator=(Buffer&&);
 
     inline uint8_t* OutLineB(int index = 0)
     {
@@ -143,7 +145,7 @@ public:
     const Priv& priv() const;   // internal use only
 
 private:
-    std::shared_ptr<Priv> m_priv;
+    std::unique_ptr<Priv> m_priv;
     const Cache* m_cache;
 };
 

--- a/modules/gapi/include/opencv2/gapi/fluid/gfluidbuffer.hpp
+++ b/modules/gapi/include/opencv2/gapi/fluid/gfluidbuffer.hpp
@@ -85,10 +85,13 @@ public:
     Priv& priv();               // internal use only
     const Priv& priv() const;   // internal use only
 
-    View(Priv* p);
+    View(std::unique_ptr<Priv>&& p);
+    View(View&& v);
+    View& operator=(View&& v);
+    ~View();
 
 private:
-    std::shared_ptr<Priv> m_priv;
+    std::unique_ptr<Priv> m_priv;
     const Cache* m_cache;
 };
 
@@ -139,6 +142,7 @@ public:
     inline const GMatDesc& meta() const { return m_cache->m_desc; }
 
     View mkView(int borderSize, bool ownStorage);
+    void addView(const View* v);
 
     class GAPI_EXPORTS Priv;      // internal use only
     Priv& priv();               // internal use only

--- a/modules/gapi/include/opencv2/gapi/fluid/gfluidkernel.hpp
+++ b/modules/gapi/include/opencv2/gapi/fluid/gfluidkernel.hpp
@@ -172,7 +172,7 @@ template<> struct fluid_get_in<cv::GMat>
 {
     static const cv::gapi::fluid::View& get(const cv::GArgs &in_args, int idx)
     {
-        return in_args[idx].unsafe_get<cv::gapi::fluid::View>();
+        return *in_args[idx].unsafe_get<cv::gapi::fluid::View*>();
     }
 };
 

--- a/modules/gapi/src/backends/fluid/gfluidbackend.cpp
+++ b/modules/gapi/src/backends/fluid/gfluidbackend.cpp
@@ -833,7 +833,8 @@ cv::gimpl::GFluidExecutable::GFluidExecutable(const ade::Graph                  
       m_num_int_buffers (traverse_res.m_mat_count),
       m_scratch_users   (traverse_res.m_scratch_users),
       m_id_map          (traverse_res.m_id_map),
-      m_all_gmat_ids    (traverse_res.m_all_gmat_ids)
+      m_all_gmat_ids    (traverse_res.m_all_gmat_ids),
+      m_buffers(m_num_int_buffers + m_scratch_users.size())
 {
     GConstFluidModel fg(m_g);
 
@@ -856,9 +857,6 @@ cv::gimpl::GFluidExecutable::GFluidExecutable(const ade::Graph                  
 
     // Actually initialize Fluid buffers
     GAPI_LOG_INFO(NULL, "Initializing " << m_num_int_buffers << " fluid buffer(s)" << std::endl);
-
-    const std::size_t num_scratch = m_scratch_users.size();
-    m_buffers.resize(m_num_int_buffers + num_scratch);
 
     // After buffers are allocated, repack: ...
     for (auto &agent : m_agents)
@@ -905,6 +903,7 @@ cv::gimpl::GFluidExecutable::GFluidExecutable(const ade::Graph                  
     }
 
     // After parameters are there, initialize scratch buffers
+    const std::size_t num_scratch = m_scratch_users.size();
     if (num_scratch)
     {
         GAPI_LOG_INFO(NULL, "Initializing " << num_scratch << " scratch buffer(s)" << std::endl);
@@ -932,8 +931,8 @@ std::size_t cv::gimpl::GFluidExecutable::total_buffers_size() const
     for (const auto &i : ade::util::indexed(m_buffers))
     {
         // Check that all internal and scratch buffers are allocated
-        const auto idx = ade::util::index(i);
-        const auto b   = ade::util::value(i);
+        const auto  idx = ade::util::index(i);
+        const auto& b   = ade::util::value(i);
         if (idx >= m_num_int_buffers ||
             fg.metadata(m_all_gmat_ids.at(idx)).get<FluidData>().internal == true)
         {

--- a/modules/gapi/src/backends/fluid/gfluidbackend.cpp
+++ b/modules/gapi/src/backends/fluid/gfluidbackend.cpp
@@ -880,10 +880,10 @@ cv::gimpl::GFluidExecutable::GFluidExecutable(const ade::Graph                  
                 auto inEdge = GModel::getInEdgeByPort(m_g, agent->op_handle, in_idx);
                 auto ownStorage = fg.metadata(inEdge).get<FluidUseOwnBorderBuffer>().use;
 
-                gapi::fluid::View view = buffer.mkView(fu.border_size, ownStorage);
                 // NB: It is safe to keep ptr as view lifetime is buffer lifetime
-                agent->in_views[in_idx] = view;
-                agent->in_args[in_idx]  = GArg(view);
+                agent->in_views[in_idx] = buffer.mkView(fu.border_size, ownStorage);
+                agent->in_args[in_idx]  = GArg(&agent->in_views[in_idx]);
+                buffer.addView(&agent->in_views[in_idx]);
             }
             else
             {

--- a/modules/gapi/src/backends/fluid/gfluidbackend.hpp
+++ b/modules/gapi/src/backends/fluid/gfluidbackend.hpp
@@ -125,7 +125,6 @@ class GFluidExecutable final: public GIslandExecutable
     GModel::ConstGraph m_gm;
 
     std::vector<std::unique_ptr<FluidAgent>> m_agents;
-    std::vector<cv::gapi::fluid::Buffer> m_buffers;
 
     std::vector<FluidAgent*> m_script;
 
@@ -137,6 +136,8 @@ class GFluidExecutable final: public GIslandExecutable
 
     std::unordered_map<int, std::size_t> m_id_map; // GMat id -> buffer idx map
     std::map<std::size_t, ade::NodeHandle> m_all_gmat_ids;
+
+    std::vector<cv::gapi::fluid::Buffer> m_buffers;
 
     void bindInArg (const RcDesc &rc, const GRunArg &arg);
     void bindOutArg(const RcDesc &rc, const GRunArgP &arg);

--- a/modules/gapi/src/backends/fluid/gfluidbuffer.cpp
+++ b/modules/gapi/src/backends/fluid/gfluidbuffer.cpp
@@ -680,6 +680,9 @@ fluid::Buffer::Buffer(const cv::gapi::own::Mat &data, bool is_input)
     m_priv->bindTo(data, is_input);
 }
 
+fluid::Buffer::~Buffer() = default;
+fluid::Buffer& fluid::Buffer::operator=(fluid::Buffer&&) = default;
+
 int fluid::Buffer::linesReady() const
 {
     return m_priv->linesReady();

--- a/modules/gapi/src/backends/fluid/gfluidbuffer.cpp
+++ b/modules/gapi/src/backends/fluid/gfluidbuffer.cpp
@@ -577,7 +577,7 @@ bool fluid::Buffer::Priv::full() const
     {
         // reset with maximum possible value and then find minimum
         slowest_y = m_desc.size.height;
-        for (const auto &v : m_views) slowest_y = std::min(slowest_y, v.y());
+        for (const auto &v : m_views) slowest_y = std::min(slowest_y, v->y());
     }
 
     return m_write_caret + lpi() - slowest_y > m_storage->rows();
@@ -609,7 +609,7 @@ void fluid::Buffer::Priv::reset()
 int fluid::Buffer::Priv::size() const
 {
     std::size_t view_sz = 0;
-    for (const auto &v : m_views) view_sz += v.priv().size();
+    for (const auto &v : m_views) view_sz += v->priv().size();
 
     auto total = view_sz;
     if (m_storage) total += m_storage->size();
@@ -693,17 +693,24 @@ int fluid::Buffer::lpi() const
     return m_priv->lpi();
 }
 
-fluid::View::View(Priv* p)
-    : m_priv(p), m_cache(&p->cache())
+fluid::View::View(std::unique_ptr<Priv>&& p)
+    : m_priv(std::move(p)), m_cache(&m_priv->cache())
 { /* nothing */ }
+
+fluid::View::View(View&&) = default;
+fluid::View& fluid::View::operator=(View&&) = default;
+fluid::View::~View() = default;
 
 fluid::View fluid::Buffer::mkView(int borderSize, bool ownStorage)
 {
     // FIXME: logic outside of Priv (because View takes pointer to Buffer)
-    auto view = ownStorage ? View(new ViewPrivWithOwnBorder(this, borderSize))
-                           : View(new ViewPrivWithoutOwnBorder(this, borderSize));
-    m_priv->addView(view);
-    return view;
+    return ownStorage ? View(std::unique_ptr<ViewPrivWithOwnBorder>(new ViewPrivWithOwnBorder(this, borderSize)))
+                      : View(std::unique_ptr<ViewPrivWithoutOwnBorder>(new ViewPrivWithoutOwnBorder(this, borderSize)));
+}
+
+void fluid::Buffer::addView(const View* v)
+{
+    m_priv->addView(v);
 }
 
 void fluid::debugBufferPriv(const fluid::Buffer& buffer, std::ostream &os)
@@ -717,7 +724,7 @@ void fluid::debugBufferPriv(const fluid::Buffer& buffer, std::ostream &os)
        <<" (phys " << "[" << p.storage().cols() << " x " <<  p.storage().rows() << "]" << ") :"
        << "  w: " << p.m_write_caret
        << ", r: [";
-    for (const auto &v : p.m_views) { os << &v.priv() << ":" << v.y() << " "; }
+    for (const auto &v : p.m_views) { os << &v->priv() << ":" << v->y() << " "; }
     os << "], avail: " << buffer.linesReady()
        << std::endl;
 }

--- a/modules/gapi/src/backends/fluid/gfluidbuffer_priv.hpp
+++ b/modules/gapi/src/backends/fluid/gfluidbuffer_priv.hpp
@@ -239,7 +239,7 @@ class GAPI_EXPORTS Buffer::Priv
 
     int m_write_caret      = -1;
 
-    std::vector<View> m_views;
+    std::vector<const View*> m_views;
 
     std::unique_ptr<BufferStorage> m_storage;
 
@@ -265,7 +265,7 @@ public:
     void allocate(BorderOpt border, int border_size, int line_consumption, int skew);
     void bindTo(const cv::gapi::own::Mat &data, bool is_input);
 
-    inline void addView(const View& view) { m_views.push_back(view); }
+    inline void addView(const View* view) { m_views.emplace_back(view); }
 
     inline const GMatDesc& meta() const { return m_desc; }
 

--- a/modules/gapi/test/gapi_kernel_tests.cpp
+++ b/modules/gapi/test/gapi_kernel_tests.cpp
@@ -101,7 +101,7 @@ namespace
         GAPI_FLUID_KERNEL(GClone, I::GClone, false)
         {
             static const int Window = 1;
-            static void run(const cv::gapi::fluid::View&, cv::gapi::fluid::Buffer)
+            static void run(const cv::gapi::fluid::View&, cv::gapi::fluid::Buffer&)
             {
                 HeteroGraph::registerCallKernel(KernelTags::FLUID_CUSTOM_CLONE);
             }


### PR DESCRIPTION
* Changed shared_ptr to unique_ptr for pimpl implementation in fluid::Buffer and fluid::View

```
build_gapi_standalone:Linux x64=ade-0.1.1f
build_gapi_standalone:Win64=ade-0.1.1f
Xbuild_gapi_standalone:Mac=ade-0.1.1f
build_gapi_standalone:Linux x64 Debug=ade-0.1.1f

build_image:Custom=centos:7
buildworker:Custom=linux-1

allow_multiple_commits=1
```