### PR TITLE
Fix bug in ONNX ReduceL2

### DIFF
--- a/modules/dnn/src/onnx/onnx_importer.cpp
+++ b/modules/dnn/src/onnx/onnx_importer.cpp
@@ -784,6 +784,8 @@ void ONNXImporter::populateNet(Net dstNet)
             CV_Assert_N(node_proto.input_size() == 1, layerParams.has("axes"));
             CV_Assert(graph_proto.node_size() > li + 1 && graph_proto.node(li + 1).op_type() == "Div");
             ++li;
+            node_proto = graph_proto.node(li);
+            layerParams.name = node_proto.output(0);
             layerParams.type = "Normalize";
 
             DictValue axes_dict = layerParams.get("axes");


### PR DESCRIPTION
**Merge with extra:** opencv/opencv_extra#687

relates #15811

<cut/>

```
force_builders=Custom,Custom Win,Custom Mac
build_image:Custom=ubuntu-openvino-2019r3.0:16.04
build_image:Custom Win=openvino-2019r3.0
build_image:Custom Mac=openvino-2019r3.0

test_modules:Custom=dnn,python2,python3,java
test_modules:Custom Win=dnn,python2,python3,java
test_modules:Custom Mac=dnn,python2,python3,java

buildworker:Custom=linux-1
test_opencl:Custom=OFF
test_bigdata:Custom=1
test_filter:Custom=*
```