### PR TITLE
python: force using of ArgInfo

### DIFF
--- a/modules/dnn/misc/python/pyopencv_dnn.hpp
+++ b/modules/dnn/misc/python/pyopencv_dnn.hpp
@@ -4,9 +4,9 @@ typedef std::vector<dnn::MatShape> vector_MatShape;
 typedef std::vector<std::vector<dnn::MatShape> > vector_vector_MatShape;
 
 template<>
-bool pyopencv_to(PyObject *o, dnn::DictValue &dv, const char *name)
+bool pyopencv_to(PyObject *o, dnn::DictValue &dv, const ArgInfo& info)
 {
-    CV_UNUSED(name);
+    CV_UNUSED(info);
     if (!o || o == Py_None)
         return true; //Current state will be used
     else if (PyLong_Check(o))
@@ -34,12 +34,6 @@ bool pyopencv_to(PyObject *o, dnn::DictValue &dv, const char *name)
         }
     }
     return false;
-}
-
-template<>
-bool pyopencv_to(PyObject *o, std::vector<Mat> &blobs, const char *name) //required for Layer::blobs RW
-{
-  return pyopencvVecConverter<Mat>::to(o, blobs, ArgInfo(name, false));
 }
 
 template<typename T>

--- a/modules/flann/misc/python/pyopencv_flann.hpp
+++ b/modules/flann/misc/python/pyopencv_flann.hpp
@@ -15,9 +15,9 @@ PyObject* pyopencv_from(const cvflann_flann_distance_t& value)
 }
 
 template<>
-bool pyopencv_to(PyObject *o, cv::flann::IndexParams& p, const char *name)
+bool pyopencv_to(PyObject *o, cv::flann::IndexParams& p, const ArgInfo& info)
 {
-    CV_UNUSED(name);
+    CV_UNUSED(info);
     bool ok = true;
     PyObject* key = NULL;
     PyObject* item = NULL;
@@ -71,16 +71,16 @@ bool pyopencv_to(PyObject *o, cv::flann::IndexParams& p, const char *name)
 }
 
 template<>
-bool pyopencv_to(PyObject* obj, cv::flann::SearchParams & value, const char * name)
+bool pyopencv_to(PyObject* obj, cv::flann::SearchParams & value, const ArgInfo& info)
 {
-    return pyopencv_to<cv::flann::IndexParams>(obj, value, name);
+    return pyopencv_to<cv::flann::IndexParams>(obj, value, info);
 }
 
 template<>
-bool pyopencv_to(PyObject *o, cvflann::flann_distance_t& dist, const char *name)
+bool pyopencv_to(PyObject *o, cvflann::flann_distance_t& dist, const ArgInfo& info)
 {
     int d = (int)dist;
-    bool ok = pyopencv_to(o, d, name);
+    bool ok = pyopencv_to(o, d, info);
     dist = (cvflann::flann_distance_t)d;
     return ok;
 }

--- a/modules/ml/misc/python/pyopencv_ml.hpp
+++ b/modules/ml/misc/python/pyopencv_ml.hpp
@@ -1,16 +1,16 @@
 template<>
-bool pyopencv_to(PyObject *obj, CvTermCriteria& dst, const char *name)
+bool pyopencv_to(PyObject *obj, CvTermCriteria& dst, const ArgInfo& info)
 {
-    CV_UNUSED(name);
+    CV_UNUSED(info);
     if(!obj)
         return true;
     return PyArg_ParseTuple(obj, "iid", &dst.type, &dst.max_iter, &dst.epsilon) > 0;
 }
 
 template<>
-bool pyopencv_to(PyObject* obj, CvSlice& r, const char* name)
+bool pyopencv_to(PyObject* obj, CvSlice& r, const ArgInfo& info)
 {
-    CV_UNUSED(name);
+    CV_UNUSED(info);
     if(!obj || obj == Py_None)
         return true;
     if(PyObject_Size(obj) == 0)

--- a/modules/python/src2/cv2.cpp
+++ b/modules/python/src2/cv2.cpp
@@ -34,15 +34,31 @@
 #include "pycompat.hpp"
 #include <map>
 
+class ArgInfo
+{
+public:
+    const char * name;
+    bool outputarg;
+    // more fields may be added if necessary
+
+    ArgInfo(const char * name_, bool outputarg_)
+        : name(name_)
+        , outputarg(outputarg_) {}
+
+private:
+    ArgInfo(const ArgInfo&); // = delete
+    ArgInfo& operator=(const ArgInfo&); // = delete
+};
+
 template<typename T, class TEnable = void>  // TEnable is used for SFINAE checks
 struct PyOpenCV_Converter
 {
-    //static inline bool to(PyObject* obj, T& p, const char* name);
+    //static inline bool to(PyObject* obj, T& p, const ArgInfo& info);
     //static inline PyObject* from(const T& src);
 };
 
 template<typename T> static
-bool pyopencv_to(PyObject* obj, T& p, const char* name = "<unknown>") { return PyOpenCV_Converter<T>::to(obj, p, name); }
+bool pyopencv_to(PyObject* obj, T& p, const ArgInfo& info) { return PyOpenCV_Converter<T>::to(obj, p, info); }
 
 template<typename T> static
 PyObject* pyopencv_from(const T& src) { return PyOpenCV_Converter<T>::from(src); }
@@ -61,20 +77,6 @@ static int failmsg(const char *fmt, ...)
     PyErr_SetString(PyExc_TypeError, str);
     return 0;
 }
-
-struct ArgInfo
-{
-    const char * name;
-    bool outputarg;
-    // more fields may be added if necessary
-
-    ArgInfo(const char * name_, bool outputarg_)
-        : name(name_)
-        , outputarg(outputarg_) {}
-
-    // to match with older pyopencv_to function signature
-    operator const char *() const { return name; }
-};
 
 class PyAllowThreads
 {
@@ -243,7 +245,7 @@ NumpyAllocator g_numpyAllocator;
 enum { ARG_NONE = 0, ARG_MAT = 1, ARG_SCALAR = 2 };
 
 // special case, when the converter needs full ArgInfo structure
-static bool pyopencv_to(PyObject* o, Mat& m, const ArgInfo info)
+static bool pyopencv_to(PyObject* o, Mat& m, const ArgInfo& info)
 {
     bool allowND = true;
     if(!o || o == Py_None)
@@ -422,14 +424,8 @@ static bool pyopencv_to(PyObject* o, Mat& m, const ArgInfo info)
     return true;
 }
 
-template<>
-bool pyopencv_to(PyObject* o, Mat& m, const char* name)
-{
-    return pyopencv_to(o, m, ArgInfo(name, 0));
-}
-
 template<typename _Tp, int m, int n>
-bool pyopencv_to(PyObject* o, Matx<_Tp, m, n>& mx, const ArgInfo info)
+bool pyopencv_to(PyObject* o, Matx<_Tp, m, n>& mx, const ArgInfo& info)
 {
     Mat tmp;
     if (!pyopencv_to(o, tmp, info)) {
@@ -440,10 +436,10 @@ bool pyopencv_to(PyObject* o, Matx<_Tp, m, n>& mx, const ArgInfo info)
     return true;
 }
 
-template<typename _Tp, int m, int n>
-bool pyopencv_to(PyObject* o, Matx<_Tp, m, n>& mx, const char* name)
+template<typename _Tp, int cn>
+bool pyopencv_to(PyObject* o, Vec<_Tp, cn>& vec, const ArgInfo& info)
 {
-    return pyopencv_to(o, mx, ArgInfo(name, 0));
+    return pyopencv_to(o, (Matx<_Tp, cn, 1>&)vec, info);
 }
 
 template<>
@@ -478,19 +474,19 @@ struct PyOpenCV_Converter< cv::Ptr<T> >
             Py_RETURN_NONE;
         return pyopencv_from(*p);
     }
-    static bool to(PyObject *o, Ptr<T>& p, const char *name)
+    static bool to(PyObject *o, Ptr<T>& p, const ArgInfo& info)
     {
         if (!o || o == Py_None)
             return true;
         p = makePtr<T>();
-        return pyopencv_to(o, *p, name);
+        return pyopencv_to(o, *p, info);
     }
 };
 
 template<>
-bool pyopencv_to(PyObject* obj, void*& ptr, const char* name)
+bool pyopencv_to(PyObject* obj, void*& ptr, const ArgInfo& info)
 {
-    CV_UNUSED(name);
+    CV_UNUSED(info);
     if (!obj || obj == Py_None)
         return true;
 
@@ -512,7 +508,7 @@ struct SafeSeqItem
     ~SafeSeqItem() { Py_XDECREF(item); }
 };
 
-static bool pyopencv_to(PyObject *o, Scalar& s, const ArgInfo info)
+static bool pyopencv_to(PyObject *o, Scalar& s, const ArgInfo& info)
 {
     if(!o || o == Py_None)
         return true;
@@ -544,12 +540,6 @@ static bool pyopencv_to(PyObject *o, Scalar& s, const ArgInfo info)
 }
 
 template<>
-bool pyopencv_to(PyObject *o, Scalar& s, const char *name)
-{
-    return pyopencv_to(o, s, ArgInfo(name, 0));
-}
-
-template<>
 PyObject* pyopencv_from(const Scalar& src)
 {
     return Py_BuildValue("(dddd)", src[0], src[1], src[2], src[3]);
@@ -562,9 +552,9 @@ PyObject* pyopencv_from(const bool& value)
 }
 
 template<>
-bool pyopencv_to(PyObject* obj, bool& value, const char* name)
+bool pyopencv_to(PyObject* obj, bool& value, const ArgInfo& info)
 {
-    CV_UNUSED(name);
+    CV_UNUSED(info);
     if(!obj || obj == Py_None)
         return true;
     int _val = PyObject_IsTrue(obj);
@@ -581,9 +571,9 @@ PyObject* pyopencv_from(const size_t& value)
 }
 
 template<>
-bool pyopencv_to(PyObject* obj, size_t& value, const char* name)
+bool pyopencv_to(PyObject* obj, size_t& value, const ArgInfo& info)
 {
-    CV_UNUSED(name);
+    CV_UNUSED(info);
     if(!obj || obj == Py_None)
         return true;
     value = (int)PyLong_AsUnsignedLong(obj);
@@ -597,9 +587,9 @@ PyObject* pyopencv_from(const int& value)
 }
 
 template<>
-bool pyopencv_to(PyObject* obj, int& value, const char* name)
+bool pyopencv_to(PyObject* obj, int& value, const ArgInfo& info)
 {
-    CV_UNUSED(name);
+    CV_UNUSED(info);
     if(!obj || obj == Py_None)
         return true;
     if(PyInt_Check(obj))
@@ -618,9 +608,9 @@ PyObject* pyopencv_from(const uchar& value)
 }
 
 template<>
-bool pyopencv_to(PyObject* obj, uchar& value, const char* name)
+bool pyopencv_to(PyObject* obj, uchar& value, const ArgInfo& info)
 {
-    CV_UNUSED(name);
+    CV_UNUSED(info);
     if(!obj || obj == Py_None)
         return true;
     int ivalue = (int)PyInt_AsLong(obj);
@@ -635,9 +625,9 @@ PyObject* pyopencv_from(const double& value)
 }
 
 template<>
-bool pyopencv_to(PyObject* obj, double& value, const char* name)
+bool pyopencv_to(PyObject* obj, double& value, const ArgInfo& info)
 {
-    CV_UNUSED(name);
+    CV_UNUSED(info);
     if(!obj || obj == Py_None)
         return true;
     if(!!PyInt_CheckExact(obj))
@@ -654,9 +644,9 @@ PyObject* pyopencv_from(const float& value)
 }
 
 template<>
-bool pyopencv_to(PyObject* obj, float& value, const char* name)
+bool pyopencv_to(PyObject* obj, float& value, const ArgInfo& info)
 {
-    CV_UNUSED(name);
+    CV_UNUSED(info);
     if(!obj || obj == Py_None)
         return true;
     if(!!PyInt_CheckExact(obj))
@@ -679,9 +669,9 @@ PyObject* pyopencv_from(const String& value)
 }
 
 template<>
-bool pyopencv_to(PyObject* obj, String &value, const char* name)
+bool pyopencv_to(PyObject* obj, String &value, const ArgInfo& info)
 {
-    CV_UNUSED(name);
+    CV_UNUSED(info);
     if(!obj || obj == Py_None)
         return true;
     std::string str;
@@ -694,9 +684,9 @@ bool pyopencv_to(PyObject* obj, String &value, const char* name)
 }
 
 template<>
-bool pyopencv_to(PyObject* obj, Size& sz, const char* name)
+bool pyopencv_to(PyObject* obj, Size& sz, const ArgInfo& info)
 {
-    CV_UNUSED(name);
+    CV_UNUSED(info);
     if(!obj || obj == Py_None)
         return true;
     return PyArg_ParseTuple(obj, "ii", &sz.width, &sz.height) > 0;
@@ -709,9 +699,9 @@ PyObject* pyopencv_from(const Size& sz)
 }
 
 template<>
-bool pyopencv_to(PyObject* obj, Size_<float>& sz, const char* name)
+bool pyopencv_to(PyObject* obj, Size_<float>& sz, const ArgInfo& info)
 {
-    CV_UNUSED(name);
+    CV_UNUSED(info);
     if(!obj || obj == Py_None)
         return true;
     return PyArg_ParseTuple(obj, "ff", &sz.width, &sz.height) > 0;
@@ -724,9 +714,9 @@ PyObject* pyopencv_from(const Size_<float>& sz)
 }
 
 template<>
-bool pyopencv_to(PyObject* obj, Rect& r, const char* name)
+bool pyopencv_to(PyObject* obj, Rect& r, const ArgInfo& info)
 {
-    CV_UNUSED(name);
+    CV_UNUSED(info);
     if(!obj || obj == Py_None)
         return true;
     return PyArg_ParseTuple(obj, "iiii", &r.x, &r.y, &r.width, &r.height) > 0;
@@ -739,9 +729,9 @@ PyObject* pyopencv_from(const Rect& r)
 }
 
 template<>
-bool pyopencv_to(PyObject* obj, Rect2d& r, const char* name)
+bool pyopencv_to(PyObject* obj, Rect2d& r, const ArgInfo& info)
 {
-    CV_UNUSED(name);
+    CV_UNUSED(info);
     if(!obj || obj == Py_None)
         return true;
     return PyArg_ParseTuple(obj, "dddd", &r.x, &r.y, &r.width, &r.height) > 0;
@@ -754,16 +744,16 @@ PyObject* pyopencv_from(const Rect2d& r)
 }
 
 template<>
-bool pyopencv_to(PyObject* obj, Range& r, const char* name)
+bool pyopencv_to(PyObject* obj, Range& r, const ArgInfo& info)
 {
-    CV_UNUSED(name);
+    CV_UNUSED(info);
     if(!obj || obj == Py_None)
         return true;
     while (PySequence_Check(obj))
     {
         if (2 != PySequence_Size(obj))
         {
-            failmsg("Range value for argument '%s' is longer than 2", name);
+            failmsg("Range value for argument '%s' is longer than 2", info.name);
             return false;
         }
         {
@@ -772,7 +762,7 @@ bool pyopencv_to(PyObject* obj, Range& r, const char* name)
             if (PyInt_Check(item)) {
                 r.start = (int)PyInt_AsLong(item);
             } else {
-                failmsg("Range.start value for argument '%s' is not integer", name);
+                failmsg("Range.start value for argument '%s' is not integer", info.name);
                 break;
             }
         }
@@ -782,7 +772,7 @@ bool pyopencv_to(PyObject* obj, Range& r, const char* name)
             if (PyInt_Check(item)) {
                 r.end = (int)PyInt_AsLong(item);
             } else {
-                failmsg("Range.end value for argument '%s' is not integer", name);
+                failmsg("Range.end value for argument '%s' is not integer", info.name);
                 break;
             }
         }
@@ -803,9 +793,9 @@ PyObject* pyopencv_from(const Range& r)
 }
 
 template<>
-bool pyopencv_to(PyObject* obj, Point& p, const char* name)
+bool pyopencv_to(PyObject* obj, Point& p, const ArgInfo& info)
 {
-    CV_UNUSED(name);
+    CV_UNUSED(info);
     if(!obj || obj == Py_None)
         return true;
     if(PyComplex_Check(obj))
@@ -818,9 +808,9 @@ bool pyopencv_to(PyObject* obj, Point& p, const char* name)
 }
 
 template<>
-bool pyopencv_to(PyObject* obj, Point2f& p, const char* name)
+bool pyopencv_to(PyObject* obj, Point2f& p, const ArgInfo& info)
 {
-    CV_UNUSED(name);
+    CV_UNUSED(info);
     if(!obj || obj == Py_None)
         return true;
     if (PyComplex_Check(obj))
@@ -833,9 +823,9 @@ bool pyopencv_to(PyObject* obj, Point2f& p, const char* name)
 }
 
 template<>
-bool pyopencv_to(PyObject* obj, Point2d& p, const char* name)
+bool pyopencv_to(PyObject* obj, Point2d& p, const ArgInfo& info)
 {
-    CV_UNUSED(name);
+    CV_UNUSED(info);
     if(!obj || obj == Py_None)
         return true;
     if(PyComplex_Check(obj))
@@ -848,18 +838,18 @@ bool pyopencv_to(PyObject* obj, Point2d& p, const char* name)
 }
 
 template<>
-bool pyopencv_to(PyObject* obj, Point3f& p, const char* name)
+bool pyopencv_to(PyObject* obj, Point3f& p, const ArgInfo& info)
 {
-    CV_UNUSED(name);
+    CV_UNUSED(info);
     if(!obj || obj == Py_None)
         return true;
     return PyArg_ParseTuple(obj, "fff", &p.x, &p.y, &p.z) > 0;
 }
 
 template<>
-bool pyopencv_to(PyObject* obj, Point3d& p, const char* name)
+bool pyopencv_to(PyObject* obj, Point3d& p, const ArgInfo& info)
 {
-    CV_UNUSED(name);
+    CV_UNUSED(info);
     if(!obj || obj == Py_None)
         return true;
     return PyArg_ParseTuple(obj, "ddd", &p.x, &p.y, &p.z) > 0;
@@ -883,121 +873,76 @@ PyObject* pyopencv_from(const Point3f& p)
     return Py_BuildValue("(ddd)", p.x, p.y, p.z);
 }
 
-static bool pyopencv_to(PyObject* obj, Vec4d& v, ArgInfo info)
+static bool pyopencv_to(PyObject* obj, Vec4d& v, ArgInfo& info)
 {
     CV_UNUSED(info);
     if (!obj)
         return true;
     return PyArg_ParseTuple(obj, "dddd", &v[0], &v[1], &v[2], &v[3]) > 0;
 }
-template<>
-bool pyopencv_to(PyObject* obj, Vec4d& v, const char* name)
-{
-    return pyopencv_to(obj, v, ArgInfo(name, 0));
-}
 
-static bool pyopencv_to(PyObject* obj, Vec4f& v, ArgInfo info)
+static bool pyopencv_to(PyObject* obj, Vec4f& v, ArgInfo& info)
 {
     CV_UNUSED(info);
     if (!obj)
         return true;
     return PyArg_ParseTuple(obj, "ffff", &v[0], &v[1], &v[2], &v[3]) > 0;
 }
-template<>
-bool pyopencv_to(PyObject* obj, Vec4f& v, const char* name)
-{
-    return pyopencv_to(obj, v, ArgInfo(name, 0));
-}
 
-static bool pyopencv_to(PyObject* obj, Vec4i& v, ArgInfo info)
+static bool pyopencv_to(PyObject* obj, Vec4i& v, ArgInfo& info)
 {
     CV_UNUSED(info);
     if (!obj)
         return true;
     return PyArg_ParseTuple(obj, "iiii", &v[0], &v[1], &v[2], &v[3]) > 0;
 }
-template<>
-bool pyopencv_to(PyObject* obj, Vec4i& v, const char* name)
-{
-    return pyopencv_to(obj, v, ArgInfo(name, 0));
-}
 
-static bool pyopencv_to(PyObject* obj, Vec3d& v, ArgInfo info)
+static bool pyopencv_to(PyObject* obj, Vec3d& v, ArgInfo& info)
 {
     CV_UNUSED(info);
     if (!obj)
         return true;
     return PyArg_ParseTuple(obj, "ddd", &v[0], &v[1], &v[2]) > 0;
 }
-template<>
-bool pyopencv_to(PyObject* obj, Vec3d& v, const char* name)
-{
-    return pyopencv_to(obj, v, ArgInfo(name, 0));
-}
 
-static bool pyopencv_to(PyObject* obj, Vec3f& v, ArgInfo info)
+static bool pyopencv_to(PyObject* obj, Vec3f& v, ArgInfo& info)
 {
     CV_UNUSED(info);
     if (!obj)
         return true;
     return PyArg_ParseTuple(obj, "fff", &v[0], &v[1], &v[2]) > 0;
 }
-template<>
-bool pyopencv_to(PyObject* obj, Vec3f& v, const char* name)
-{
-    return pyopencv_to(obj, v, ArgInfo(name, 0));
-}
 
-static bool pyopencv_to(PyObject* obj, Vec3i& v, ArgInfo info)
+static bool pyopencv_to(PyObject* obj, Vec3i& v, ArgInfo& info)
 {
     CV_UNUSED(info);
     if (!obj)
         return true;
     return PyArg_ParseTuple(obj, "iii", &v[0], &v[1], &v[2]) > 0;
 }
-template<>
-bool pyopencv_to(PyObject* obj, Vec3i& v, const char* name)
-{
-    return pyopencv_to(obj, v, ArgInfo(name, 0));
-}
 
-static bool pyopencv_to(PyObject* obj, Vec2d& v, ArgInfo info)
+static bool pyopencv_to(PyObject* obj, Vec2d& v, ArgInfo& info)
 {
     CV_UNUSED(info);
     if (!obj)
         return true;
     return PyArg_ParseTuple(obj, "dd", &v[0], &v[1]) > 0;
 }
-template<>
-bool pyopencv_to(PyObject* obj, Vec2d& v, const char* name)
-{
-    return pyopencv_to(obj, v, ArgInfo(name, 0));
-}
 
-static bool pyopencv_to(PyObject* obj, Vec2f& v, ArgInfo info)
+static bool pyopencv_to(PyObject* obj, Vec2f& v, ArgInfo& info)
 {
     CV_UNUSED(info);
     if (!obj)
         return true;
     return PyArg_ParseTuple(obj, "ff", &v[0], &v[1]) > 0;
 }
-template<>
-bool pyopencv_to(PyObject* obj, Vec2f& v, const char* name)
-{
-    return pyopencv_to(obj, v, ArgInfo(name, 0));
-}
 
-static bool pyopencv_to(PyObject* obj, Vec2i& v, ArgInfo info)
+static bool pyopencv_to(PyObject* obj, Vec2i& v, ArgInfo& info)
 {
     CV_UNUSED(info);
     if (!obj)
         return true;
     return PyArg_ParseTuple(obj, "ii", &v[0], &v[1]) > 0;
-}
-template<>
-bool pyopencv_to(PyObject* obj, Vec2i& v, const char* name)
-{
-    return pyopencv_to(obj, v, ArgInfo(name, 0));
 }
 
 template<>
@@ -1101,7 +1046,7 @@ template<typename _Tp> struct pyopencvVecConverter
         }
         return true;
     }
-    static bool to(PyObject* obj, std::vector<_Tp>& value, const ArgInfo info)
+    static bool to(PyObject* obj, std::vector<_Tp>& value, const ArgInfo& info)
     {
         if(!obj || obj == Py_None)
             return true;
@@ -1181,7 +1126,7 @@ template<typename _Tp> struct pyopencvVecConverter
 };
 
 template<typename _Tp>
-bool pyopencv_to(PyObject* obj, std::vector<_Tp>& value, const ArgInfo info)
+bool pyopencv_to(PyObject* obj, std::vector<_Tp>& value, const ArgInfo& info)
 {
     return pyopencvVecConverter<_Tp>::to(obj, value, info);
 }
@@ -1192,7 +1137,7 @@ PyObject* pyopencv_from(const std::vector<_Tp>& value)
     return pyopencvVecConverter<_Tp>::from(value);
 }
 
-template<typename _Tp> static inline bool pyopencv_to_generic_vec(PyObject* obj, std::vector<_Tp>& value, const ArgInfo info)
+template<typename _Tp> static inline bool pyopencv_to_generic_vec(PyObject* obj, std::vector<_Tp>& value, const ArgInfo& info)
 {
     if(!obj || obj == Py_None)
        return true;
@@ -1236,7 +1181,7 @@ PyObject* pyopencv_from(const std::pair<int, double>& src)
 
 template<typename _Tp, typename _Tr> struct pyopencvVecConverter<std::pair<_Tp, _Tr> >
 {
-    static bool to(PyObject* obj, std::vector<std::pair<_Tp, _Tr> >& value, const ArgInfo info)
+    static bool to(PyObject* obj, std::vector<std::pair<_Tp, _Tr> >& value, const ArgInfo& info)
     {
         return pyopencv_to_generic_vec(obj, value, info);
     }
@@ -1249,7 +1194,7 @@ template<typename _Tp, typename _Tr> struct pyopencvVecConverter<std::pair<_Tp, 
 
 template<typename _Tp> struct pyopencvVecConverter<std::vector<_Tp> >
 {
-    static bool to(PyObject* obj, std::vector<std::vector<_Tp> >& value, const ArgInfo info)
+    static bool to(PyObject* obj, std::vector<std::vector<_Tp> >& value, const ArgInfo& info)
     {
         return pyopencv_to_generic_vec(obj, value, info);
     }
@@ -1262,7 +1207,7 @@ template<typename _Tp> struct pyopencvVecConverter<std::vector<_Tp> >
 
 template<> struct pyopencvVecConverter<Mat>
 {
-    static bool to(PyObject* obj, std::vector<Mat>& value, const ArgInfo info)
+    static bool to(PyObject* obj, std::vector<Mat>& value, const ArgInfo& info)
     {
         return pyopencv_to_generic_vec(obj, value, info);
     }
@@ -1275,7 +1220,7 @@ template<> struct pyopencvVecConverter<Mat>
 
 template<> struct pyopencvVecConverter<UMat>
 {
-    static bool to(PyObject* obj, std::vector<UMat>& value, const ArgInfo info)
+    static bool to(PyObject* obj, std::vector<UMat>& value, const ArgInfo& info)
     {
         return pyopencv_to_generic_vec(obj, value, info);
     }
@@ -1288,7 +1233,7 @@ template<> struct pyopencvVecConverter<UMat>
 
 template<> struct pyopencvVecConverter<KeyPoint>
 {
-    static bool to(PyObject* obj, std::vector<KeyPoint>& value, const ArgInfo info)
+    static bool to(PyObject* obj, std::vector<KeyPoint>& value, const ArgInfo& info)
     {
         return pyopencv_to_generic_vec(obj, value, info);
     }
@@ -1301,7 +1246,7 @@ template<> struct pyopencvVecConverter<KeyPoint>
 
 template<> struct pyopencvVecConverter<DMatch>
 {
-    static bool to(PyObject* obj, std::vector<DMatch>& value, const ArgInfo info)
+    static bool to(PyObject* obj, std::vector<DMatch>& value, const ArgInfo& info)
     {
         return pyopencv_to_generic_vec(obj, value, info);
     }
@@ -1314,7 +1259,7 @@ template<> struct pyopencvVecConverter<DMatch>
 
 template<> struct pyopencvVecConverter<String>
 {
-    static bool to(PyObject* obj, std::vector<String>& value, const ArgInfo info)
+    static bool to(PyObject* obj, std::vector<String>& value, const ArgInfo& info)
     {
         return pyopencv_to_generic_vec(obj, value, info);
     }
@@ -1327,7 +1272,7 @@ template<> struct pyopencvVecConverter<String>
 
 template<> struct pyopencvVecConverter<RotatedRect>
 {
-    static bool to(PyObject* obj, std::vector<RotatedRect>& value, const ArgInfo info)
+    static bool to(PyObject* obj, std::vector<RotatedRect>& value, const ArgInfo& info)
     {
         return pyopencv_to_generic_vec(obj, value, info);
     }
@@ -1338,9 +1283,9 @@ template<> struct pyopencvVecConverter<RotatedRect>
 };
 
 template<>
-bool pyopencv_to(PyObject *obj, TermCriteria& dst, const char *name)
+bool pyopencv_to(PyObject *obj, TermCriteria& dst, const ArgInfo& info)
 {
-    CV_UNUSED(name);
+    CV_UNUSED(info);
     if(!obj)
         return true;
     return PyArg_ParseTuple(obj, "iid", &dst.type, &dst.maxCount, &dst.epsilon) > 0;
@@ -1353,9 +1298,9 @@ PyObject* pyopencv_from(const TermCriteria& src)
 }
 
 template<>
-bool pyopencv_to(PyObject *obj, RotatedRect& dst, const char *name)
+bool pyopencv_to(PyObject *obj, RotatedRect& dst, const ArgInfo& info)
 {
-    CV_UNUSED(name);
+    CV_UNUSED(info);
     if(!obj)
         return true;
     return PyArg_ParseTuple(obj, "(ff)(ff)f", &dst.center.x, &dst.center.y, &dst.size.width, &dst.size.height, &dst.angle) > 0;
@@ -1595,7 +1540,7 @@ static PyObject *pycvCreateButton(PyObject*, PyObject *args, PyObject *kw)
 
 ///////////////////////////////////////////////////////////////////////////////////////
 
-static int convert_to_char(PyObject *o, char *dst, const char *name = "no_name")
+static int convert_to_char(PyObject *o, char *dst, const ArgInfo& info)
 {
     std::string str;
     if (getUnicodeString(o, str))
@@ -1604,7 +1549,7 @@ static int convert_to_char(PyObject *o, char *dst, const char *name = "no_name")
         return 1;
     }
     (*dst) = 0;
-    return failmsg("Expected single character string for argument '%s'", name);
+    return failmsg("Expected single character string for argument '%s'", info.name);
 }
 
 #ifdef __GNUC__

--- a/modules/python/src2/gen2.py
+++ b/modules/python/src2/gen2.py
@@ -45,7 +45,7 @@ gen_template_func_body = Template("""$code_decl
 gen_template_mappable = Template("""
     {
         ${mappable} _src;
-        if (pyopencv_to(src, _src, name))
+        if (pyopencv_to(src, _src, info))
         {
             return cv_mappable_to(_src, dst);
         }
@@ -62,7 +62,7 @@ struct PyOpenCV_Converter< ${cname} >
     {
         return pyopencv_${name}_Instance(r);
     }
-    static bool to(PyObject* src, ${cname}& dst, const char* name)
+    static bool to(PyObject* src, ${cname}& dst, const ArgInfo& info)
     {
         if(!src || src == Py_None)
             return true;
@@ -73,7 +73,7 @@ struct PyOpenCV_Converter< ${cname} >
             return true;
         }
         ${mappable_code}
-        failmsg("Expected ${cname} for argument '%s'", name);
+        failmsg("Expected ${cname} for argument '%s'", info.name);
         return false;
     }
 };
@@ -81,7 +81,7 @@ struct PyOpenCV_Converter< ${cname} >
 """)
 
 gen_template_map_type_cvt = Template("""
-template<> bool pyopencv_to(PyObject* src, ${cname}& dst, const char* name);
+template<> bool pyopencv_to(PyObject* src, ${cname}& dst, const ArgInfo& info);
 
 """)
 
@@ -89,7 +89,7 @@ gen_template_set_prop_from_map = Template("""
     if( PyMapping_HasKeyString(src, (char*)"$propname") )
     {
         tmp = PyMapping_GetItemString(src, (char*)"$propname");
-        ok = tmp && pyopencv_to(tmp, dst.$propname);
+        ok = tmp && pyopencv_to(tmp, dst.$propname, ArgInfo("$propname", false));
         Py_DECREF(tmp);
         if(!ok) return false;
     }""")
@@ -143,7 +143,7 @@ static int pyopencv_${name}_set_${member}(pyopencv_${name}_t* p, PyObject *value
         PyErr_SetString(PyExc_TypeError, "Cannot delete the ${member} attribute");
         return -1;
     }
-    return pyopencv_to(value, p->v${access}${member}) ? 0 : -1;
+    return pyopencv_to(value, p->v${access}${member}, ArgInfo("value", false)) ? 0 : -1;
 }
 """)
 
@@ -161,7 +161,7 @@ static int pyopencv_${name}_set_${member}(pyopencv_${name}_t* p, PyObject *value
         failmsgp("Incorrect type of object (must be '${name}' or its derivative)");
         return -1;
     }
-    return pyopencv_to(value, _self_${access}${member}) ? 0 : -1;
+    return pyopencv_to(value, _self_${access}${member}, ArgInfo("value", false)) ? 0 : -1;
 }
 """)
 
@@ -238,10 +238,10 @@ class ClassInfo(object):
 
     def gen_map_code(self, codegen):
         all_classes = codegen.classes
-        code = "static bool pyopencv_to(PyObject* src, %s& dst, const char* name)\n{\n    PyObject* tmp;\n    bool ok;\n" % (self.cname)
+        code = "static bool pyopencv_to(PyObject* src, %s& dst, const ArgInfo& info)\n{\n    PyObject* tmp;\n    bool ok;\n" % (self.cname)
         code += "".join([gen_template_set_prop_from_map.substitute(propname=p.name,proptype=p.tp) for p in self.props])
         if self.base:
-            code += "\n    return pyopencv_to(src, (%s&)dst, name);\n}\n" % all_classes[self.base].cname
+            code += "\n    return pyopencv_to(src, (%s&)dst, info);\n}\n" % all_classes[self.base].cname
         else:
             code += "\n    return true;\n}\n"
         return code

--- a/modules/python/src2/pycompat.hpp
+++ b/modules/python/src2/pycompat.hpp
@@ -101,13 +101,13 @@ static inline bool getUnicodeString(PyObject * obj, std::string &str)
 
 #define CV_PY_TO_CLASS(TYPE)                                                                          \
 template<>                                                                                            \
-bool pyopencv_to(PyObject* dst, TYPE& src, const char* name)                                          \
+bool pyopencv_to(PyObject* dst, TYPE& src, const ArgInfo& info)                                       \
 {                                                                                                     \
     if (!dst || dst == Py_None)                                                                       \
         return true;                                                                                  \
     Ptr<TYPE> ptr;                                                                                    \
                                                                                                       \
-    if (!pyopencv_to(dst, ptr, name)) return false;                                                   \
+    if (!pyopencv_to(dst, ptr, info)) return false;                                                   \
     src = *ptr;                                                                                       \
     return true;                                                                                      \
 }
@@ -124,13 +124,13 @@ PyObject* pyopencv_from(const TYPE& src)                                        
 
 #define CV_PY_TO_CLASS_PTR(TYPE)                                                                      \
 template<>                                                                                            \
-bool pyopencv_to(PyObject* dst, TYPE*& src, const char* name)                                         \
+bool pyopencv_to(PyObject* dst, TYPE*& src, const ArgInfo& info)                                      \
 {                                                                                                     \
     if (!dst || dst == Py_None)                                                                       \
         return true;                                                                                  \
     Ptr<TYPE> ptr;                                                                                    \
                                                                                                       \
-    if (!pyopencv_to(dst, ptr, name)) return false;                                                   \
+    if (!pyopencv_to(dst, ptr, info)) return false;                                                   \
     src = ptr;                                                                                        \
     return true;                                                                                      \
 }
@@ -143,13 +143,13 @@ static PyObject* pyopencv_from(TYPE*& src)                                      
 
 #define CV_PY_TO_ENUM(TYPE)                                                                           \
 template<>                                                                                            \
-bool pyopencv_to(PyObject* dst, TYPE& src, const char* name)                                          \
+bool pyopencv_to(PyObject* dst, TYPE& src, const ArgInfo& info)                                       \
 {                                                                                                     \
     if (!dst || dst == Py_None)                                                                       \
         return true;                                                                                  \
     int underlying = 0;                                                  \
                                                                                                       \
-    if (!pyopencv_to(dst, underlying, name)) return false;                                            \
+    if (!pyopencv_to(dst, underlying, info)) return false;                                            \
     src = static_cast<TYPE>(underlying);                                                              \
     return true;                                                                                      \
 }

--- a/modules/videoio/misc/python/pyopencv_videoio.hpp
+++ b/modules/videoio/misc/python/pyopencv_videoio.hpp
@@ -3,7 +3,7 @@ typedef std::vector<VideoCaptureAPIs> vector_VideoCaptureAPIs;
 
 template<> struct pyopencvVecConverter<cv::VideoCaptureAPIs>
 {
-    static bool to(PyObject* obj, std::vector<cv::VideoCaptureAPIs>& value, const ArgInfo info)
+    static bool to(PyObject* obj, std::vector<cv::VideoCaptureAPIs>& value, const ArgInfo& info)
     {
         return pyopencv_to_generic_vec(obj, value, info);
     }
@@ -15,9 +15,9 @@ template<> struct pyopencvVecConverter<cv::VideoCaptureAPIs>
 };
 
 template<>
-bool pyopencv_to(PyObject *o, std::vector<cv::VideoCaptureAPIs>& apis, const char *name)
+bool pyopencv_to(PyObject *o, std::vector<cv::VideoCaptureAPIs>& apis, const ArgInfo& info)
 {
-  return pyopencvVecConverter<cv::VideoCaptureAPIs>::to(o, apis, ArgInfo(name, false));
+  return pyopencvVecConverter<cv::VideoCaptureAPIs>::to(o, apis, info);
 }
 
 #endif // HAVE_OPENCV_VIDEOIO


### PR DESCRIPTION
**Merge with contrib**: https://github.com/opencv/opencv_contrib/pull/2353

Using just "name" is not enough, especially in case of `UMat` and "output" parameter.

relates #15895