### PR TITLE
Remove hard coded meta data from compileStreaming()

### DIFF
--- a/modules/gapi/include/opencv2/gapi/gcompiled.hpp
+++ b/modules/gapi/include/opencv2/gapi/gcompiled.hpp
@@ -14,6 +14,8 @@
 #include <opencv2/gapi/own/assert.hpp>
 #include <opencv2/gapi/garg.hpp>
 
+#include <ade/execution_engine/execution_engine.hpp>
+
 namespace cv {
 
 // This class represents a compiled computation.
@@ -207,6 +209,9 @@ public:
      */
     // FIXME: Why it requires compile args?
     void reshape(const GMetaArgs& inMetas, const GCompileArgs& args);
+
+    static void setMetaData(ade::Graph &g, cv::GCompileArgs &args
+                        , const cv::GMetaArgs &metas);
 
 protected:
     /// @private

--- a/modules/gapi/src/compiler/gcompiled.cpp
+++ b/modules/gapi/src/compiler/gcompiled.cpp
@@ -14,6 +14,8 @@
 
 #include "compiler/gcompiled_priv.hpp"
 #include "backends/common/gbackend.hpp"
+#include "compiler/passes/passes.hpp"
+#include "compiler/gcompiler.hpp"
 
 // GCompiled private implementation ////////////////////////////////////////////
 void cv::GCompiled::Priv::setup(const GMetaArgs &_metaArgs,
@@ -153,4 +155,17 @@ bool cv::GCompiled::canReshape() const
 void cv::GCompiled::reshape(const GMetaArgs& inMetas, const GCompileArgs& args)
 {
     m_priv->reshape(inMetas, args);
+}
+
+void cv::GCompiled::setMetaData(ade::Graph &g, cv::GCompileArgs &args
+                                        , const cv::GMetaArgs &metas)
+{
+    auto pass_ctx = ade::passes::PassContext{g};
+    cv::gimpl::passes::initMeta(pass_ctx, metas);
+
+    cv::gimpl::passes::inferMeta(pass_ctx, true);
+    //compile islands for m_orig_graph
+    cv::gimpl::passes::storeResultingMeta(pass_ctx);
+    // Get compileArgs from m_ops??
+    cv::gimpl::GCompiler::compileIslands(g, args);
 }

--- a/modules/gapi/src/compiler/gcompiler.cpp
+++ b/modules/gapi/src/compiler/gcompiler.cpp
@@ -259,7 +259,7 @@ cv::gimpl::GCompiler::GCompiler(const cv::GComputation &c,
                                                       // (no compound backend present here)
     m_e.addPass("kernels", "check_islands_content", passes::checkIslandsContent);
 
-    if (!m_metas.empty()) 
+    if (!m_metas.empty())
     {
         m_e.addPassStage("meta");
         m_e.addPass("meta", "initialize",   std::bind(passes::initMeta, _1, std::ref(m_metas)));

--- a/modules/gapi/src/compiler/gcompiler.cpp
+++ b/modules/gapi/src/compiler/gcompiler.cpp
@@ -392,19 +392,6 @@ void cv::gimpl::GCompiler::compileIslands(ade::Graph &g, cv::GCompileArgs &args)
     GIslandModel::compileIslands(gim, g, args);
 }
 
-void cv::gimpl::GCompiler::setMetaData(ade::Graph &g, cv::GCompileArgs &args
-                                        , const cv::GMetaArgs &metas)
-{
-    auto pass_ctx = ade::passes::PassContext{g};
-    cv::gimpl::passes::initMeta(pass_ctx, metas);
-
-    cv::gimpl::passes::inferMeta(pass_ctx, true);
-    //compile islands for m_orig_graph
-    cv::gimpl::passes::storeResultingMeta(pass_ctx);
-    // Get compileArgs from m_ops??
-    cv::gimpl::GCompiler::compileIslands(g, args);
-}
-
 cv::GCompiled cv::gimpl::GCompiler::produceCompiled(GPtr &&pg)
 {
     // This is the final compilation step. Here:

--- a/modules/gapi/src/compiler/gcompiler.cpp
+++ b/modules/gapi/src/compiler/gcompiler.cpp
@@ -259,6 +259,7 @@ cv::gimpl::GCompiler::GCompiler(const cv::GComputation &c,
                                                       // (no compound backend present here)
     m_e.addPass("kernels", "check_islands_content", passes::checkIslandsContent);
 
+    //Input metas may be empty when a graph is compiled for streaming
     if (!m_metas.empty())
     {
         m_e.addPassStage("meta");
@@ -268,8 +269,8 @@ cv::gimpl::GCompiler::GCompiler(const cv::GComputation &c,
         // moved to another stage, FIXME: two dumps?
         //    m_e.addPass("meta", "dump_dot",     passes::dumpDotStdout);
     }
-        // Special stage for backend-specific transformations
-        // FIXME: document passes hierarchy and order for backend developers
+    // Special stage for backend-specific transformations
+    // FIXME: document passes hierarchy and order for backend developers
     m_e.addPassStage("transform");
 
     m_e.addPassStage("exec");
@@ -281,6 +282,9 @@ cv::gimpl::GCompiler::GCompiler(const cv::GComputation &c,
     // (even if it is not actually required to produce a GCompiled).
     // FIXME: add a better way to do that!
     m_e.addPass("exec", "add_streaming",    passes::addStreaming);
+    // Note: Must be called after addStreaming as addStreaming pass
+    // can possibly add new nodes to the IslandModel
+    m_e.addPass("exec", "sort_islands",     passes::topoSortIslands);
 
     if (dump_path.has_value())
     {
@@ -368,13 +372,14 @@ cv::gimpl::GCompiler::GPtr cv::gimpl::GCompiler::generateGraph()
     return makeGraph(m_c.priv().m_ins, m_c.priv().m_outs);
 }
 
-void cv::gimpl::GCompiler:: runPasses(ade::Graph &g)
+void cv::gimpl::GCompiler::runPasses(ade::Graph &g)
 {
     m_e.runPasses(g);
     GAPI_LOG_INFO(NULL, "All compiler passes are successful");
 }
 
-void cv::gimpl::GCompiler::compileIslands(ade::Graph &g) {
+void cv::gimpl::GCompiler::compileIslands(ade::Graph &g)
+{
     compileIslands(g, m_args);
 }
 
@@ -384,12 +389,20 @@ void cv::gimpl::GCompiler::compileIslands(ade::Graph &g, cv::GCompileArgs &args)
     std::shared_ptr<ade::Graph> gptr(gm.metadata().get<IslandModel>().model);
     GIslandModel::Graph gim(*gptr);
 
-    // Run topological sort on GIslandModel first
-    auto pass_ctx = ade::passes::PassContext{*gptr};
-    ade::passes::TopologicalSort{}(pass_ctx);
-
-    // Now compile islands
     GIslandModel::compileIslands(gim, g, args);
+}
+
+void cv::gimpl::GCompiler::setMetaData(ade::Graph &g, cv::GCompileArgs &args
+                                        , const cv::GMetaArgs &metas)
+{
+    auto pass_ctx = ade::passes::PassContext{g};
+    cv::gimpl::passes::initMeta(pass_ctx, metas);
+
+    cv::gimpl::passes::inferMeta(pass_ctx, true);
+    //compile islands for m_orig_graph
+    cv::gimpl::passes::storeResultingMeta(pass_ctx);
+    // Get compileArgs from m_ops??
+    cv::gimpl::GCompiler::compileIslands(g, args);
 }
 
 cv::GCompiled cv::gimpl::GCompiler::produceCompiled(GPtr &&pg)
@@ -425,7 +438,8 @@ cv::GStreamingCompiled cv::gimpl::GCompiler::produceStreamingCompiled(GPtr &&pg)
 {
     std::unique_ptr<GStreamingExecutor> pE(new GStreamingExecutor(std::move(pg), m_args, m_metas));
 
-    GMetaArgs outMetas{};
+    const auto &outMetas = GModel::ConstGraph(*pg).metadata()
+        .get<OutputMeta>().outMeta;
 
     GStreamingCompiled compiled;
     compiled.priv().setup(m_metas, outMetas, std::move(pE));
@@ -445,14 +459,7 @@ cv::GStreamingCompiled cv::gimpl::GCompiler::compileStreaming()
     // FIXME: self-note to DM: now keep these compile()/compileStreaming() in sync!
     std::unique_ptr<ade::Graph> pG = generateGraph();
     GModel::Graph gm(*pG);
-
     gm.metadata().set(Streaming{});
     runPasses(*pG);
-
-    std::shared_ptr<ade::Graph> gptr(gm.metadata().get<IslandModel>().model);
-    // Run topological sort on GIslandModel first
-    auto pass_ctx = ade::passes::PassContext{*gptr};
-    ade::passes::TopologicalSort{}(pass_ctx);
-
     return produceStreamingCompiled(std::move(pG));
 }

--- a/modules/gapi/src/compiler/gcompiler.cpp
+++ b/modules/gapi/src/compiler/gcompiler.cpp
@@ -259,7 +259,7 @@ cv::gimpl::GCompiler::GCompiler(const cv::GComputation &c,
                                                       // (no compound backend present here)
     m_e.addPass("kernels", "check_islands_content", passes::checkIslandsContent);
 
-    if (false)//(!m_metas.empty()) 
+    if (!m_metas.empty()) 
     {
         m_e.addPassStage("meta");
         m_e.addPass("meta", "initialize",   std::bind(passes::initMeta, _1, std::ref(m_metas)));
@@ -425,9 +425,6 @@ cv::GStreamingCompiled cv::gimpl::GCompiler::produceStreamingCompiled(GPtr &&pg)
 {
     std::unique_ptr<GStreamingExecutor> pE(new GStreamingExecutor(std::move(pg), m_args, m_metas));
 
-    // const auto &outMetas = GModel::ConstGraph(*pg).metadata()
-    //     .get<OutputMeta>().outMeta;
-
     GMetaArgs outMetas{};
 
     GStreamingCompiled compiled;
@@ -445,7 +442,6 @@ cv::GCompiled cv::gimpl::GCompiler::compile()
 
 cv::GStreamingCompiled cv::gimpl::GCompiler::compileStreaming()
 {
-  //  m_args
     // FIXME: self-note to DM: now keep these compile()/compileStreaming() in sync!
     std::unique_ptr<ade::Graph> pG = generateGraph();
     GModel::Graph gm(*pG);
@@ -458,6 +454,5 @@ cv::GStreamingCompiled cv::gimpl::GCompiler::compileStreaming()
     auto pass_ctx = ade::passes::PassContext{*gptr};
     ade::passes::TopologicalSort{}(pass_ctx);
 
-//    compileIslands(*pG);
     return produceStreamingCompiled(std::move(pG));
 }

--- a/modules/gapi/src/compiler/gcompiler.cpp
+++ b/modules/gapi/src/compiler/gcompiler.cpp
@@ -259,7 +259,7 @@ cv::gimpl::GCompiler::GCompiler(const cv::GComputation &c,
                                                       // (no compound backend present here)
     m_e.addPass("kernels", "check_islands_content", passes::checkIslandsContent);
 
-    if (/*!m_metas.empty()*/ false) {
+    if (!m_metas.empty()) {
         m_e.addPassStage("meta");
         m_e.addPass("meta", "initialize",   std::bind(passes::initMeta, _1, std::ref(m_metas)));
         m_e.addPass("meta", "propagate",    std::bind(passes::inferMeta, _1, false));

--- a/modules/gapi/src/compiler/gcompiler.hpp
+++ b/modules/gapi/src/compiler/gcompiler.hpp
@@ -35,6 +35,8 @@ class GAPI_EXPORTS GCompiler
     void validateOutProtoArgs();
 
 public:
+    // metas may be empty in case when graph compiling for streaming
+    // In this case graph get metas from first frame
     explicit GCompiler(const GComputation &c,
                              GMetaArgs    &&metas,
                              GCompileArgs &&args);
@@ -51,6 +53,8 @@ public:
     void        runPasses(ade::Graph &g);      // Apply all G-API passes on a GModel
     void        compileIslands(ade::Graph &g); // Instantiate GIslandExecutables in GIslandModel
     static void compileIslands(ade::Graph &g, cv::GCompileArgs &args);
+    static void setMetaData(ade::Graph &g, cv::GCompileArgs &args
+                            , const cv::GMetaArgs &metas);
     GCompiled   produceCompiled(GPtr &&pg);    // Produce GCompiled from processed GModel
     GStreamingCompiled  produceStreamingCompiled(GPtr &&pg); // Produce GStreamingCompiled from processed GMbodel
 };

--- a/modules/gapi/src/compiler/gcompiler.hpp
+++ b/modules/gapi/src/compiler/gcompiler.hpp
@@ -53,8 +53,6 @@ public:
     void        runPasses(ade::Graph &g);      // Apply all G-API passes on a GModel
     void        compileIslands(ade::Graph &g); // Instantiate GIslandExecutables in GIslandModel
     static void compileIslands(ade::Graph &g, cv::GCompileArgs &args);
-    static void setMetaData(ade::Graph &g, cv::GCompileArgs &args
-                            , const cv::GMetaArgs &metas);
     GCompiled   produceCompiled(GPtr &&pg);    // Produce GCompiled from processed GModel
     GStreamingCompiled  produceStreamingCompiled(GPtr &&pg); // Produce GStreamingCompiled from processed GMbodel
 };

--- a/modules/gapi/src/compiler/gcompiler.hpp
+++ b/modules/gapi/src/compiler/gcompiler.hpp
@@ -47,10 +47,11 @@ public:
 
     // But those are actually composed of this:
     using GPtr = std::unique_ptr<ade::Graph>;
-    GPtr       generateGraph();               // Unroll GComputation into a GModel
-    void       runPasses(ade::Graph &g);      // Apply all G-API passes on a GModel
-    void       compileIslands(ade::Graph &g); // Instantiate GIslandExecutables in GIslandModel
-    GCompiled  produceCompiled(GPtr &&pg);    // Produce GCompiled from processed GModel
+    GPtr        generateGraph();               // Unroll GComputation into a GModel
+    void        runPasses(ade::Graph &g);      // Apply all G-API passes on a GModel
+    void        compileIslands(ade::Graph &g); // Instantiate GIslandExecutables in GIslandModel
+    static void compileIslands(ade::Graph &g, cv::GCompileArgs &args);
+    GCompiled   produceCompiled(GPtr &&pg);    // Produce GCompiled from processed GModel
     GStreamingCompiled  produceStreamingCompiled(GPtr &&pg); // Produce GStreamingCompiled from processed GMbodel
 };
 

--- a/modules/gapi/src/compiler/passes/exec.cpp
+++ b/modules/gapi/src/compiler/passes/exec.cpp
@@ -638,4 +638,12 @@ void passes::syncIslandTags(ade::passes::PassContext &ctx)
     GIslandModel::Graph gim(*gptr);
     GIslandModel::syncIslandTags(gim, ctx.graph);
 }
+
+void passes::topoSortIslands(ade::passes::PassContext &ctx)
+{
+    GModel::Graph gm(ctx.graph);
+    std::shared_ptr<ade::Graph> gptr(gm.metadata().get<IslandModel>().model);
+    auto pass_ctx = ade::passes::PassContext{*gptr};
+    ade::passes::TopologicalSort{}(pass_ctx);
+}
 }} // namespace cv::gimpl

--- a/modules/gapi/src/compiler/passes/passes.hpp
+++ b/modules/gapi/src/compiler/passes/passes.hpp
@@ -58,6 +58,7 @@ void resolveKernels(ade::passes::PassContext   &ctx,
 
 void fuseIslands(ade::passes::PassContext &ctx);
 void syncIslandTags(ade::passes::PassContext &ctx);
+void topoSortIslands(ade::passes::PassContext &ctx);
 
 void applyTransformations(ade::passes::PassContext &ctx,
                           const gapi::GKernelPackage &pkg,

--- a/modules/gapi/src/executor/gstreamingexecutor.cpp
+++ b/modules/gapi/src/executor/gstreamingexecutor.cpp
@@ -484,7 +484,6 @@ cv::gimpl::GStreamingExecutor::GStreamingExecutor(std::unique_ptr<ade::Graph> &&
                                          , std::move(output_metas)
                                          , nh
                                          , in_constants});
-// вынести islandExec в сетсорс m_gim.metadata(nh).get<IslandExec>().object
 
                 // Initialize queues for every operation's input
                 ade::TypedGraph<DataQueue> qgr(*m_island_graph);
@@ -556,22 +555,17 @@ void cv::gimpl::GStreamingExecutor::setSource(GRunArgs &&ins)
         util::throw_error(std::logic_error("Only one video source is"
                                            " currently supported!"));
     }
-
-        //get metadata 
+ 
     // testing meta data is cv::GMatDesc{CV_8U,3,cv::Size{768,576}}
-    // cv::GMatDesc mat_desc(CV_8U,3,cv::Size(768,576));
-    // cv::GMetaArgs metas{cv::GMetaArg(mat_desc)};
-
+    if (m_metas.empty()) {
+        // extract meta from first frame
+    } else {
+        //const auto& metas = m_metas;
+    }
+    
     const auto& metas = m_metas;
     
     if (/*wasFinished*/true) {
-        //finishing graph
-        //set passes (ok?)
-        // is: GModel::Graph gm(m_orig_graph); eq  auto& g = *m_orig_graph.get(); ??
-        // GModel::Graph gm(*m_orig_graph);
-        // std::shared_ptr<ade::Graph> gptr(gm.metadata().get<IslandModel>().model);
-        // GIslandModel::Graph gim(*gptr);
-
         auto pass_ctx = ade::passes::PassContext{*m_orig_graph.get()};
         cv::gimpl::passes::initMeta(pass_ctx, metas);
         //does inferMeta needed?? 
@@ -581,42 +575,41 @@ void cv::gimpl::GStreamingExecutor::setSource(GRunArgs &&ins)
         // Get compileArgs from m_ops?? 
         cv::gimpl::GCompiler::compileIslands(*m_orig_graph.get(), comp_args);
         
-    GModel::Graph gm(*m_orig_graph);
-
-                auto xtract_in = [&](ade::NodeHandle slot_nh, std::vector<RcDesc> &vec) {
-                    const auto orig_data_nh
-                        = m_gim.metadata(slot_nh).get<DataSlot>().original_data_node;
-                    const auto &orig_data_info
-                        = gm.metadata(orig_data_nh).get<Data>();
-                    if (orig_data_info.shape == GShape::GARRAY) {
-                        // FIXME: GArray lost host constructor problem
-                        GAPI_Assert(!cv::util::holds_alternative<cv::util::monostate>(orig_data_info.ctor));
-                    }
-                    vec.emplace_back(RcDesc{ orig_data_info.rc
-                                           , orig_data_info.shape
-                                           , orig_data_info.ctor});
-                };
-                auto xtract_out = [&](ade::NodeHandle slot_nh, std::vector<RcDesc> &vec, cv::GMetaArgs &metas) {
-                    const auto orig_data_nh
-                        = m_gim.metadata(slot_nh).get<DataSlot>().original_data_node;
-                    const auto &orig_data_info
-                        = gm.metadata(orig_data_nh).get<Data>();
-                    if (orig_data_info.shape == GShape::GARRAY) {
-                        // FIXME: GArray lost host constructor problem
-                        GAPI_Assert(!cv::util::holds_alternative<cv::util::monostate>(orig_data_info.ctor));
-                    }
-                    vec.emplace_back(RcDesc{ orig_data_info.rc
-                                           , orig_data_info.shape
-                                           , orig_data_info.ctor});
-                    metas.emplace_back(orig_data_info.meta);
-                };
+        GModel::Graph gm(*m_orig_graph);
+        
+        auto xtract_in = [&](ade::NodeHandle slot_nh, std::vector<RcDesc> &vec) {
+            const auto orig_data_nh
+                = m_gim.metadata(slot_nh).get<DataSlot>().original_data_node;
+            const auto &orig_data_info
+                = gm.metadata(orig_data_nh).get<Data>();
+            if (orig_data_info.shape == GShape::GARRAY) {
+                // FIXME: GArray lost host constructor problem
+                GAPI_Assert(!cv::util::holds_alternative<cv::util::monostate>(orig_data_info.ctor));
+            }
+            vec.emplace_back(RcDesc{ orig_data_info.rc
+                                   , orig_data_info.shape
+                                   , orig_data_info.ctor});
+        };
+        auto xtract_out = [&](ade::NodeHandle slot_nh, std::vector<RcDesc> &vec, cv::GMetaArgs &metas) {
+            const auto orig_data_nh
+                = m_gim.metadata(slot_nh).get<DataSlot>().original_data_node;
+            const auto &orig_data_info
+                = gm.metadata(orig_data_nh).get<Data>();
+            if (orig_data_info.shape == GShape::GARRAY) {
+                // FIXME: GArray lost host constructor problem
+                GAPI_Assert(!cv::util::holds_alternative<cv::util::monostate>(orig_data_info.ctor));
+            }
+            vec.emplace_back(RcDesc{ orig_data_info.rc
+                                   , orig_data_info.shape
+                                   , orig_data_info.ctor});
+            metas.emplace_back(orig_data_info.meta);
+        };
 
         for (auto& op : m_ops) {
             op.isl_exec = m_gim.metadata(op.nh).get<IslandExec>().object;
 
              std::vector<RcDesc> input_rcs;
              std::vector<RcDesc> output_rcs;
-            //  std::vector<GRunArg> in_constants;
              cv::GMetaArgs output_metas;
 
             input_rcs.reserve(op.nh->inNodes().size());
@@ -634,18 +627,12 @@ void cv::gimpl::GStreamingExecutor::setSource(GRunArgs &&ins)
 
         wasFinished = true;
     } else {
-        //reshape
-        //does it required unempty comp_args??
         bool canReshape = true;
         for (auto &op : m_ops) {
             canReshape = op.isl_exec->canReshape();
             if (!canReshape)
                 break;
         }
-
-//        canReshape = std::all_of(m_ops.begin(), m_ops.end()
-//                                , [](){/*???*/})
-
 
         if (canReshape) {
             auto& g = *m_orig_graph.get();

--- a/modules/gapi/src/executor/gstreamingexecutor.cpp
+++ b/modules/gapi/src/executor/gstreamingexecutor.cpp
@@ -558,7 +558,7 @@ void cv::gimpl::GStreamingExecutor::setSource(GRunArgs &&ins)
 
     // Setting metas
     const auto& metas = m_metas;
-    cv::gimpl::GCompiler::setMetaData(*m_orig_graph.get(), m_comp_args, metas);
+    cv::GCompiled::setMetaData(*m_orig_graph.get(), m_comp_args, metas);
 
     GModel::Graph gm(*m_orig_graph);
 

--- a/modules/gapi/src/executor/gstreamingexecutor.cpp
+++ b/modules/gapi/src/executor/gstreamingexecutor.cpp
@@ -555,14 +555,14 @@ void cv::gimpl::GStreamingExecutor::setSource(GRunArgs &&ins)
         util::throw_error(std::logic_error("Only one video source is"
                                            " currently supported!"));
     }
- 
+
     // testing meta data is cv::GMatDesc{CV_8U,3,cv::Size{768,576}}
     if (m_metas.empty()) {
         // extract meta from first frame
     } else {
         //const auto& metas = m_metas;
     }
-    
+
     const auto& metas = m_metas;
     
     if (/*wasFinished*/true) {
@@ -576,7 +576,7 @@ void cv::gimpl::GStreamingExecutor::setSource(GRunArgs &&ins)
         cv::gimpl::GCompiler::compileIslands(*m_orig_graph.get(), comp_args);
         
         GModel::Graph gm(*m_orig_graph);
-        
+
         auto xtract_in = [&](ade::NodeHandle slot_nh, std::vector<RcDesc> &vec) {
             const auto orig_data_nh
                 = m_gim.metadata(slot_nh).get<DataSlot>().original_data_node;
@@ -627,13 +627,8 @@ void cv::gimpl::GStreamingExecutor::setSource(GRunArgs &&ins)
 
         wasFinished = true;
     } else {
-        bool canReshape = true;
-        for (auto &op : m_ops) {
-            canReshape = op.isl_exec->canReshape();
-            if (!canReshape)
-                break;
-        }
-
+        bool canReshape = std::all_of(m_ops.begin(), m_ops.begin(),
+                        [](OpDesc op){return op.isl_exec->canReshape();})
         if (canReshape) {
             auto& g = *m_orig_graph.get();
             ade::passes::PassContext ctx{g};
@@ -642,7 +637,6 @@ void cv::gimpl::GStreamingExecutor::setSource(GRunArgs &&ins)
             // outMetas()?
             for (auto &op : m_ops)
                 op.isl_exec->reshape(g, comp_args);
-
         } else {
             //???
         }

--- a/modules/gapi/src/executor/gstreamingexecutor.hpp
+++ b/modules/gapi/src/executor/gstreamingexecutor.hpp
@@ -74,13 +74,15 @@ protected:
         RUNNING,
     } state = State::STOPPED;
 
-    bool wasFinished;
-    cv::GCompileArgs comp_args;
-
     std::unique_ptr<ade::Graph> m_orig_graph;
     std::shared_ptr<ade::Graph> m_island_graph;
 
     cv::gimpl::GIslandModel::Graph m_gim; // FIXME: make const?
+
+    cv::GCompileArgs comp_args;
+    bool wasFinished = false;
+                
+    const GMetaArgs m_metas;
 
     // FIXME: Naive executor details are here for now
     // but then it should be moved to another place
@@ -119,7 +121,7 @@ protected:
     void wait_shutdown();
 
 public:
-    explicit GStreamingExecutor(std::unique_ptr<ade::Graph> &&g_model, cv::GCompileArgs m_args);
+    explicit GStreamingExecutor(std::unique_ptr<ade::Graph> &&g_model, cv::GCompileArgs m_args, const GMetaArgs& in_metas);
     ~GStreamingExecutor();
     void setSource(GRunArgs &&args);
     void start();

--- a/modules/gapi/src/executor/gstreamingexecutor.hpp
+++ b/modules/gapi/src/executor/gstreamingexecutor.hpp
@@ -81,7 +81,7 @@ protected:
 
     cv::GCompileArgs comp_args;
     bool wasFinished = false;
-                
+
     const GMetaArgs m_metas;
 
     // FIXME: Naive executor details are here for now

--- a/modules/gapi/src/executor/gstreamingexecutor.hpp
+++ b/modules/gapi/src/executor/gstreamingexecutor.hpp
@@ -79,8 +79,7 @@ protected:
 
     cv::gimpl::GIslandModel::Graph m_gim; // FIXME: make const?
 
-    cv::GCompileArgs comp_args;
-    bool wasFinished = false;
+    cv::GCompileArgs m_comp_args;
 
     const GMetaArgs m_metas;
 

--- a/modules/gapi/src/executor/gstreamingexecutor.hpp
+++ b/modules/gapi/src/executor/gstreamingexecutor.hpp
@@ -74,6 +74,9 @@ protected:
         RUNNING,
     } state = State::STOPPED;
 
+    bool wasFinished;
+    cv::GCompileArgs comp_args;
+
     std::unique_ptr<ade::Graph> m_orig_graph;
     std::shared_ptr<ade::Graph> m_island_graph;
 
@@ -116,7 +119,7 @@ protected:
     void wait_shutdown();
 
 public:
-    explicit GStreamingExecutor(std::unique_ptr<ade::Graph> &&g_model);
+    explicit GStreamingExecutor(std::unique_ptr<ade::Graph> &&g_model, cv::GCompileArgs m_args);
     ~GStreamingExecutor();
     void setSource(GRunArgs &&args);
     void start();


### PR DESCRIPTION
Its a first stap to remove hard coded meta data from compileStreaming().
Now all nedded graph passes replaced to setSource().
But it's still can't extract metadata from first frame and reshape on running.
