### PR TITLE
dnn: fix registration of custom OpenCVLayer

### DIFF
--- a/modules/dnn/src/op_inf_engine.cpp
+++ b/modules/dnn/src/op_inf_engine.cpp
@@ -646,8 +646,6 @@ void InfEngineBackendNet::initPlugin(InferenceEngine::CNNNetwork& net)
                     enginePtr->AddExtension(extension, 0);
 #else
                     ie.AddExtension(extension, "CPU");
-                    // OpenCV fallbacks as extensions.
-                    ie.AddExtension(std::make_shared<InfEngineExtension>(), "CPU");
 #endif
                     CV_LOG_INFO(NULL, "DNN-IE: Loaded extension plugin: " << libName);
                     found = true;
@@ -660,6 +658,10 @@ void InfEngineBackendNet::initPlugin(InferenceEngine::CNNNetwork& net)
                 CV_LOG_WARNING(NULL, "DNN-IE: Can't load extension plugin (extra layers for some networks). Specify path via OPENCV_DNN_IE_EXTRA_PLUGIN_PATH parameter");
             }
             // Some of networks can work without a library of extra layers.
+#if INF_ENGINE_VER_MAJOR_GT(INF_ENGINE_RELEASE_2019R1)
+            // OpenCV fallbacks as extensions.
+            ie.AddExtension(std::make_shared<InfEngineExtension>(), "CPU");
+#endif
 #ifndef _WIN32
             // Limit the number of CPU threads.
 #if INF_ENGINE_VER_MAJOR_LE(INF_ENGINE_RELEASE_2019R1)


### PR DESCRIPTION
- do not require extensions library

<cut/>

```
force_builders=Custom,Custom Win,Custom Mac
build_image:Custom=ubuntu-openvino-2019r3.0:16.04
build_image:Custom Win=openvino-2019r3.0
build_image:Custom Mac=openvino-2019r3.0

test_modules:Custom=dnn,python2,python3,java
test_modules:Custom Win=dnn,python2,python3,java
test_modules:Custom Mac=dnn,python2,python3,java

buildworker:Custom=linux-1
test_opencl:Custom=OFF
test_bigdata:Custom=1
test_filter:Custom=*
```
