### PR TITLE
Add checks for empty operands in Matrix expressions that

### DIFF
--- a/modules/calib3d/test/test_undistort_badarg.cpp
+++ b/modules/calib3d/test/test_undistort_badarg.cpp
@@ -270,7 +270,7 @@ void CV_UndistortPointsBadArgTest::run(int)
     cvReleaseMat(&temp);
 
     src_points = cv::Mat();
-    errcount += run_test_case( CV_StsAssert, "Input data matrix is not continuous" );
+    errcount += run_test_case( CV_StsBadArg, "Input data matrix is not continuous" );
     src_points = cv::cvarrToMat(&_src_points_orig);
     cvReleaseMat(&temp);
 

--- a/modules/core/include/opencv2/core/mat.hpp
+++ b/modules/core/include/opencv2/core/mat.hpp
@@ -3588,9 +3588,6 @@ public:
     Scalar s;
 };
 
-void checkOperandsExist(const Mat& a);
-void checkOperandsExist(const Mat& a, const Mat& b);
-
 //! @} core_basic
 
 //! @relates cv::MatExpr

--- a/modules/core/include/opencv2/core/mat.hpp
+++ b/modules/core/include/opencv2/core/mat.hpp
@@ -3588,6 +3588,9 @@ public:
     Scalar s;
 };
 
+void checkOperandsExist(const Mat& a);
+void checkOperandsExist(const Mat& a, Mat& b);
+
 //! @} core_basic
 
 //! @relates cv::MatExpr

--- a/modules/core/include/opencv2/core/mat.hpp
+++ b/modules/core/include/opencv2/core/mat.hpp
@@ -3589,7 +3589,7 @@ public:
 };
 
 void checkOperandsExist(const Mat& a);
-void checkOperandsExist(const Mat& a, Mat& b);
+void checkOperandsExist(const Mat& a, const Mat& b);
 
 //! @} core_basic
 

--- a/modules/core/src/matrix_expressions.cpp
+++ b/modules/core/src/matrix_expressions.cpp
@@ -1702,6 +1702,7 @@ MatExpr Mat::t() const
 {
     CV_INSTRUMENT_REGION();
 
+    checkOperandsExist(*this);
     MatExpr e;
     MatOp_T::makeExpr(e, *this);
     return e;

--- a/modules/core/src/matrix_expressions.cpp
+++ b/modules/core/src/matrix_expressions.cpp
@@ -16,7 +16,7 @@ namespace cv
 
 //This and its overload below are used in various MatExpr operator overloads
 //implemented to check that Matrix operands exist.
-void checkOperandsExist(const Mat& a)
+static void checkOperandsExist(const Mat& a)
 {
     if (a.empty())
     {
@@ -24,7 +24,7 @@ void checkOperandsExist(const Mat& a)
     }
 }
 
-void checkOperandsExist(const Mat& a, const Mat& b)
+static void checkOperandsExist(const Mat& a, const Mat& b)
 {
     if (a.empty() || b.empty())
     {

--- a/modules/core/src/matrix_expressions.cpp
+++ b/modules/core/src/matrix_expressions.cpp
@@ -678,6 +678,7 @@ MatExpr MatExpr::mul(const Mat& m, double scale) const
 
 MatExpr operator + (const Mat& a, const Mat& b)
 {
+    checkOperandsExist(a, b);
     MatExpr e;
     MatOp_AddEx::makeExpr(e, a, b, 1, 1);
     return e;
@@ -685,6 +686,7 @@ MatExpr operator + (const Mat& a, const Mat& b)
 
 MatExpr operator + (const Mat& a, const Scalar& s)
 {
+    checkOperandsExist(a);
     MatExpr e;
     MatOp_AddEx::makeExpr(e, a, Mat(), 1, 0, s);
     return e;
@@ -692,6 +694,7 @@ MatExpr operator + (const Mat& a, const Scalar& s)
 
 MatExpr operator + (const Scalar& s, const Mat& a)
 {
+    checkOperandsExist(a);
     MatExpr e;
     MatOp_AddEx::makeExpr(e, a, Mat(), 1, 0, s);
     return e;
@@ -706,6 +709,7 @@ MatExpr operator + (const MatExpr& e, const Mat& m)
 
 MatExpr operator + (const Mat& m, const MatExpr& e)
 {
+    checkOperandsExist(m);
     MatExpr en;
     e.op->add(e, MatExpr(m), en);
     return en;
@@ -734,6 +738,7 @@ MatExpr operator + (const MatExpr& e1, const MatExpr& e2)
 
 MatExpr operator - (const Mat& a, const Mat& b)
 {
+    checkOperandsExist(a, b);
     MatExpr e;
     MatOp_AddEx::makeExpr(e, a, b, 1, -1);
     return e;
@@ -741,6 +746,7 @@ MatExpr operator - (const Mat& a, const Mat& b)
 
 MatExpr operator - (const Mat& a, const Scalar& s)
 {
+    checkOperandsExist(a);
     MatExpr e;
     MatOp_AddEx::makeExpr(e, a, Mat(), 1, 0, -s);
     return e;
@@ -748,6 +754,7 @@ MatExpr operator - (const Mat& a, const Scalar& s)
 
 MatExpr operator - (const Scalar& s, const Mat& a)
 {
+    checkOperandsExist(a);
     MatExpr e;
     MatOp_AddEx::makeExpr(e, a, Mat(), -1, 0, s);
     return e;
@@ -755,6 +762,7 @@ MatExpr operator - (const Scalar& s, const Mat& a)
 
 MatExpr operator - (const MatExpr& e, const Mat& m)
 {
+    checkOperandsExist(m);
     MatExpr en;
     e.op->subtract(e, MatExpr(m), en);
     return en;
@@ -762,6 +770,7 @@ MatExpr operator - (const MatExpr& e, const Mat& m)
 
 MatExpr operator - (const Mat& m, const MatExpr& e)
 {
+    checkOperandsExist(m);
     MatExpr en;
     e.op->subtract(MatExpr(m), e, en);
     return en;
@@ -790,6 +799,7 @@ MatExpr operator - (const MatExpr& e1, const MatExpr& e2)
 
 MatExpr operator - (const Mat& m)
 {
+    checkOperandsExist(m);
     MatExpr e;
     MatOp_AddEx::makeExpr(e, m, Mat(), -1, 0);
     return e;
@@ -804,6 +814,7 @@ MatExpr operator - (const MatExpr& e)
 
 MatExpr operator * (const Mat& a, const Mat& b)
 {
+    checkOperandsExist(a, b);
     MatExpr e;
     MatOp_GEMM::makeExpr(e, 0, a, b);
     return e;
@@ -811,6 +822,7 @@ MatExpr operator * (const Mat& a, const Mat& b)
 
 MatExpr operator * (const Mat& a, double s)
 {
+    checkOperandsExist(a);
     MatExpr e;
     MatOp_AddEx::makeExpr(e, a, Mat(), s, 0);
     return e;
@@ -818,6 +830,7 @@ MatExpr operator * (const Mat& a, double s)
 
 MatExpr operator * (double s, const Mat& a)
 {
+    checkOperandsExist(a);
     MatExpr e;
     MatOp_AddEx::makeExpr(e, a, Mat(), s, 0);
     return e;
@@ -832,6 +845,7 @@ MatExpr operator * (const MatExpr& e, const Mat& m)
 
 MatExpr operator * (const Mat& m, const MatExpr& e)
 {
+    checkOperandsExist(m);
     MatExpr en;
     e.op->matmul(MatExpr(m), e, en);
     return en;
@@ -860,6 +874,7 @@ MatExpr operator * (const MatExpr& e1, const MatExpr& e2)
 
 MatExpr operator / (const Mat& a, const Mat& b)
 {
+    checkOperandsExist(a, b);
     MatExpr e;
     MatOp_Bin::makeExpr(e, '/', a, b);
     return e;
@@ -867,6 +882,7 @@ MatExpr operator / (const Mat& a, const Mat& b)
 
 MatExpr operator / (const Mat& a, double s)
 {
+    checkOperandsExist(a);
     MatExpr e;
     MatOp_AddEx::makeExpr(e, a, Mat(), 1./s, 0);
     return e;
@@ -874,6 +890,7 @@ MatExpr operator / (const Mat& a, double s)
 
 MatExpr operator / (double s, const Mat& a)
 {
+    checkOperandsExist(a);
     MatExpr e;
     MatOp_Bin::makeExpr(e, '/', a, Mat(), s);
     return e;
@@ -888,6 +905,7 @@ MatExpr operator / (const MatExpr& e, const Mat& m)
 
 MatExpr operator / (const Mat& m, const MatExpr& e)
 {
+    checkOperandsExist(m);
     MatExpr en;
     e.op->divide(MatExpr(m), e, en);
     return en;
@@ -916,6 +934,7 @@ MatExpr operator / (const MatExpr& e1, const MatExpr& e2)
 
 MatExpr operator < (const Mat& a, const Mat& b)
 {
+    checkOperandsExist(a, b);
     MatExpr e;
     MatOp_Cmp::makeExpr(e, CV_CMP_LT, a, b);
     return e;
@@ -923,6 +942,7 @@ MatExpr operator < (const Mat& a, const Mat& b)
 
 MatExpr operator < (const Mat& a, double s)
 {
+    checkOperandsExist(a);
     MatExpr e;
     MatOp_Cmp::makeExpr(e, CV_CMP_LT, a, s);
     return e;
@@ -930,6 +950,7 @@ MatExpr operator < (const Mat& a, double s)
 
 MatExpr operator < (double s, const Mat& a)
 {
+    checkOperandsExist(a);
     MatExpr e;
     MatOp_Cmp::makeExpr(e, CV_CMP_GT, a, s);
     return e;
@@ -937,6 +958,7 @@ MatExpr operator < (double s, const Mat& a)
 
 MatExpr operator <= (const Mat& a, const Mat& b)
 {
+    checkOperandsExist(a, b);
     MatExpr e;
     MatOp_Cmp::makeExpr(e, CV_CMP_LE, a, b);
     return e;
@@ -944,6 +966,7 @@ MatExpr operator <= (const Mat& a, const Mat& b)
 
 MatExpr operator <= (const Mat& a, double s)
 {
+    checkOperandsExist(a);
     MatExpr e;
     MatOp_Cmp::makeExpr(e, CV_CMP_LE, a, s);
     return e;
@@ -951,6 +974,7 @@ MatExpr operator <= (const Mat& a, double s)
 
 MatExpr operator <= (double s, const Mat& a)
 {
+    checkOperandsExist(a);
     MatExpr e;
     MatOp_Cmp::makeExpr(e, CV_CMP_GE, a, s);
     return e;
@@ -958,6 +982,7 @@ MatExpr operator <= (double s, const Mat& a)
 
 MatExpr operator == (const Mat& a, const Mat& b)
 {
+    checkOperandsExist(a, b);
     MatExpr e;
     MatOp_Cmp::makeExpr(e, CV_CMP_EQ, a, b);
     return e;
@@ -965,6 +990,7 @@ MatExpr operator == (const Mat& a, const Mat& b)
 
 MatExpr operator == (const Mat& a, double s)
 {
+    checkOperandsExist(a);
     MatExpr e;
     MatOp_Cmp::makeExpr(e, CV_CMP_EQ, a, s);
     return e;
@@ -972,6 +998,7 @@ MatExpr operator == (const Mat& a, double s)
 
 MatExpr operator == (double s, const Mat& a)
 {
+    checkOperandsExist(a);
     MatExpr e;
     MatOp_Cmp::makeExpr(e, CV_CMP_EQ, a, s);
     return e;
@@ -979,6 +1006,7 @@ MatExpr operator == (double s, const Mat& a)
 
 MatExpr operator != (const Mat& a, const Mat& b)
 {
+    checkOperandsExist(a, b);
     MatExpr e;
     MatOp_Cmp::makeExpr(e, CV_CMP_NE, a, b);
     return e;
@@ -986,6 +1014,7 @@ MatExpr operator != (const Mat& a, const Mat& b)
 
 MatExpr operator != (const Mat& a, double s)
 {
+    checkOperandsExist(a);
     MatExpr e;
     MatOp_Cmp::makeExpr(e, CV_CMP_NE, a, s);
     return e;
@@ -993,6 +1022,7 @@ MatExpr operator != (const Mat& a, double s)
 
 MatExpr operator != (double s, const Mat& a)
 {
+    checkOperandsExist(a);
     MatExpr e;
     MatOp_Cmp::makeExpr(e, CV_CMP_NE, a, s);
     return e;
@@ -1000,6 +1030,7 @@ MatExpr operator != (double s, const Mat& a)
 
 MatExpr operator >= (const Mat& a, const Mat& b)
 {
+    checkOperandsExist(a, b);
     MatExpr e;
     MatOp_Cmp::makeExpr(e, CV_CMP_GE, a, b);
     return e;
@@ -1007,6 +1038,7 @@ MatExpr operator >= (const Mat& a, const Mat& b)
 
 MatExpr operator >= (const Mat& a, double s)
 {
+    checkOperandsExist(a);
     MatExpr e;
     MatOp_Cmp::makeExpr(e, CV_CMP_GE, a, s);
     return e;
@@ -1014,6 +1046,7 @@ MatExpr operator >= (const Mat& a, double s)
 
 MatExpr operator >= (double s, const Mat& a)
 {
+    checkOperandsExist(a);
     MatExpr e;
     MatOp_Cmp::makeExpr(e, CV_CMP_LE, a, s);
     return e;
@@ -1021,6 +1054,7 @@ MatExpr operator >= (double s, const Mat& a)
 
 MatExpr operator > (const Mat& a, const Mat& b)
 {
+    checkOperandsExist(a, b);
     MatExpr e;
     MatOp_Cmp::makeExpr(e, CV_CMP_GT, a, b);
     return e;
@@ -1028,6 +1062,7 @@ MatExpr operator > (const Mat& a, const Mat& b)
 
 MatExpr operator > (const Mat& a, double s)
 {
+    checkOperandsExist(a);
     MatExpr e;
     MatOp_Cmp::makeExpr(e, CV_CMP_GT, a, s);
     return e;
@@ -1035,6 +1070,7 @@ MatExpr operator > (const Mat& a, double s)
 
 MatExpr operator > (double s, const Mat& a)
 {
+    checkOperandsExist(a);
     MatExpr e;
     MatOp_Cmp::makeExpr(e, CV_CMP_LT, a, s);
     return e;
@@ -1054,6 +1090,7 @@ MatExpr min(const Mat& a, double s)
 {
     CV_INSTRUMENT_REGION();
 
+    checkOperandsExist(a);
     MatExpr e;
     MatOp_Bin::makeExpr(e, 'n', a, s);
     return e;
@@ -1063,6 +1100,7 @@ MatExpr min(double s, const Mat& a)
 {
     CV_INSTRUMENT_REGION();
 
+    checkOperandsExist(a);
     MatExpr e;
     MatOp_Bin::makeExpr(e, 'n', a, s);
     return e;
@@ -1072,6 +1110,7 @@ MatExpr max(const Mat& a, const Mat& b)
 {
     CV_INSTRUMENT_REGION();
 
+    checkOperandsExist(a, b);
     MatExpr e;
     MatOp_Bin::makeExpr(e, 'M', a, b);
     return e;
@@ -1081,6 +1120,7 @@ MatExpr max(const Mat& a, double s)
 {
     CV_INSTRUMENT_REGION();
 
+    checkOperandsExist(a);
     MatExpr e;
     MatOp_Bin::makeExpr(e, 'N', a, s);
     return e;
@@ -1090,6 +1130,7 @@ MatExpr max(double s, const Mat& a)
 {
     CV_INSTRUMENT_REGION();
 
+    checkOperandsExist(a);
     MatExpr e;
     MatOp_Bin::makeExpr(e, 'N', a, s);
     return e;
@@ -1097,6 +1138,7 @@ MatExpr max(double s, const Mat& a)
 
 MatExpr operator & (const Mat& a, const Mat& b)
 {
+    checkOperandsExist(a, b);
     MatExpr e;
     MatOp_Bin::makeExpr(e, '&', a, b);
     return e;
@@ -1104,6 +1146,7 @@ MatExpr operator & (const Mat& a, const Mat& b)
 
 MatExpr operator & (const Mat& a, const Scalar& s)
 {
+    checkOperandsExist(a);
     MatExpr e;
     MatOp_Bin::makeExpr(e, '&', a, s);
     return e;
@@ -1111,6 +1154,7 @@ MatExpr operator & (const Mat& a, const Scalar& s)
 
 MatExpr operator & (const Scalar& s, const Mat& a)
 {
+    checkOperandsExist(a);
     MatExpr e;
     MatOp_Bin::makeExpr(e, '&', a, s);
     return e;
@@ -1118,6 +1162,7 @@ MatExpr operator & (const Scalar& s, const Mat& a)
 
 MatExpr operator | (const Mat& a, const Mat& b)
 {
+    checkOperandsExist(a, b);
     MatExpr e;
     MatOp_Bin::makeExpr(e, '|', a, b);
     return e;
@@ -1125,6 +1170,7 @@ MatExpr operator | (const Mat& a, const Mat& b)
 
 MatExpr operator | (const Mat& a, const Scalar& s)
 {
+    checkOperandsExist(a);
     MatExpr e;
     MatOp_Bin::makeExpr(e, '|', a, s);
     return e;
@@ -1132,6 +1178,7 @@ MatExpr operator | (const Mat& a, const Scalar& s)
 
 MatExpr operator | (const Scalar& s, const Mat& a)
 {
+    checkOperandsExist(a);
     MatExpr e;
     MatOp_Bin::makeExpr(e, '|', a, s);
     return e;
@@ -1139,6 +1186,7 @@ MatExpr operator | (const Scalar& s, const Mat& a)
 
 MatExpr operator ^ (const Mat& a, const Mat& b)
 {
+    checkOperandsExist(a, b);
     MatExpr e;
     MatOp_Bin::makeExpr(e, '^', a, b);
     return e;
@@ -1146,6 +1194,7 @@ MatExpr operator ^ (const Mat& a, const Mat& b)
 
 MatExpr operator ^ (const Mat& a, const Scalar& s)
 {
+    checkOperandsExist(a);
     MatExpr e;
     MatOp_Bin::makeExpr(e, '^', a, s);
     return e;
@@ -1153,6 +1202,7 @@ MatExpr operator ^ (const Mat& a, const Scalar& s)
 
 MatExpr operator ^ (const Scalar& s, const Mat& a)
 {
+    checkOperandsExist(a);
     MatExpr e;
     MatOp_Bin::makeExpr(e, '^', a, s);
     return e;
@@ -1160,6 +1210,7 @@ MatExpr operator ^ (const Scalar& s, const Mat& a)
 
 MatExpr operator ~(const Mat& a)
 {
+    checkOperandsExist(a);
     MatExpr e;
     MatOp_Bin::makeExpr(e, '~', a, Scalar());
     return e;
@@ -1169,6 +1220,7 @@ MatExpr abs(const Mat& a)
 {
     CV_INSTRUMENT_REGION();
 
+    checkOperandsExist(a);
     MatExpr e;
     MatOp_Bin::makeExpr(e, 'a', a, Scalar());
     return e;

--- a/modules/core/src/matrix_expressions.cpp
+++ b/modules/core/src/matrix_expressions.cpp
@@ -14,6 +14,25 @@
 namespace cv
 {
 
+//This and its overload below are used in various MatExpr operator overloads
+//implemented to check that Matrix operands exist.
+void checkOperandsExist(const Mat& a)
+{
+    if (a.empty())
+    {
+        CV_Error(CV_StsBadArg, "Matrix operand is an empty matrix.");
+    }
+}
+
+void checkOperandsExist(const Mat& a, const Mat& b)
+{
+    if (a.empty() || b.empty())
+    {
+        CV_Error(CV_StsBadArg, "One or more matrix operands are empty.");
+    }
+}
+
+
 class MatOp_Identity CV_FINAL : public MatOp
 {
 public:
@@ -1025,6 +1044,7 @@ MatExpr min(const Mat& a, const Mat& b)
 {
     CV_INSTRUMENT_REGION();
 
+    checkOperandsExist(a, b);
     MatExpr e;
     MatOp_Bin::makeExpr(e, 'm', a, b);
     return e;

--- a/modules/core/test/test_operations.cpp
+++ b/modules/core/test/test_operations.cpp
@@ -1467,4 +1467,19 @@ TEST(Core_sortIdx, regression_8941)
         "expected=" << std::endl << expected;
 }
 
+
+//These tests guard regressions against running MatExpr
+//operations on empty operands and giving bogus
+//results.
+TEST(Core_MatExpr, empty_check_15760)
+{
+    EXPECT_THROW(Mat c = min(Mat(), Mat()), cv::Exception);
+    EXPECT_THROW(Mat c = abs(Mat()), cv::Exception);
+    EXPECT_THROW(Mat c = min(Mat(), Mat()), cv::Exception);
+    EXPECT_THROW(Mat c = Mat() | Mat(), cv::Exception);
+    EXPECT_THROW(Mat c = Mat() + Mat(), cv::Exception);
+    EXPECT_THROW(Mat c = Mat().t(), cv::Exception);
+    EXPECT_THROW(Mat c = Mat().cross(Mat()), cv::Exception);
+}
+
 }} // namespace


### PR DESCRIPTION
don't check properly.

More checks and tests coming soon.

resolves #15760
