### PR TITLE
Fix android armv7 c++_static init crash

### DIFF
--- a/modules/core/src/logger.cpp
+++ b/modules/core/src/logger.cpp
@@ -71,6 +71,8 @@ namespace internal {
 
 void writeLogMessage(LogLevel logLevel, const char* message)
 {
+    static std::ios_base::Init s_iostream_initializer;
+
     const int threadID = cv::utils::getThreadID();
     std::ostringstream ss;
     switch (logLevel)

--- a/modules/core/src/logger.cpp
+++ b/modules/core/src/logger.cpp
@@ -21,6 +21,8 @@ namespace logging {
 
 static LogLevel parseLogLevelConfiguration()
 {
+    (void)getInitializationMutex();  // ensure initialization of global objects
+
     static cv::String param_log_level = utils::getConfigurationParameterString("OPENCV_LOG_LEVEL",
 #if defined NDEBUG
             "WARNING"
@@ -71,8 +73,6 @@ namespace internal {
 
 void writeLogMessage(LogLevel logLevel, const char* message)
 {
-    static std::ios_base::Init s_iostream_initializer;
-
     const int threadID = cv::utils::getThreadID();
     std::ostringstream ss;
     switch (logLevel)

--- a/modules/core/src/system.cpp
+++ b/modules/core/src/system.cpp
@@ -55,11 +55,26 @@
 
 namespace cv {
 
+static void _initSystem()
+{
+#ifdef __ANDROID__
+    // https://github.com/opencv/opencv/issues/14906
+    // "ios_base::Init" object is not a part of Android's "iostream" header (in case of clang toolchain, NDK 20).
+    // Ref1: https://en.cppreference.com/w/cpp/io/ios_base/Init
+    //       The header <iostream> behaves as if it defines (directly or indirectly) an instance of std::ios_base::Init with static storage duration
+    // Ref2: https://github.com/gcc-mirror/gcc/blob/gcc-8-branch/libstdc%2B%2B-v3/include/std/iostream#L73-L74
+    static std::ios_base::Init s_iostream_initializer;
+#endif
+}
+
 static Mutex* __initialization_mutex = NULL;
 Mutex& getInitializationMutex()
 {
     if (__initialization_mutex == NULL)
+    {
+        (void)_initSystem();
         __initialization_mutex = new Mutex();
+    }
     return *__initialization_mutex;
 }
 // force initialization (single-threaded environment)


### PR DESCRIPTION
<!-- Please use this line to close one or multiple issues when this pullrequest gets merged
You can add another line right under the first one:
resolves #14906
-->

### This pullrequest changes

Add iostream initializer in function writeLogMessage, fixed issue #14906 completely.