### PR TITLE
Add information to iOS build instructions:

### DIFF
--- a/doc/tutorials/introduction/ios_install/ios_install.markdown
+++ b/doc/tutorials/introduction/ios_install/ios_install.markdown
@@ -9,7 +9,7 @@ Required Packages
 
 ### Getting the Cutting-edge OpenCV from Git Repository
 
-Launch GIT client and clone OpenCV repository from [here](http://github.com/opencv/opencv)
+Launch Git client and clone OpenCV repository from [GitHub](http://github.com/opencv/opencv).
 
 In MacOS it can be done using the following command in Terminal:
 
@@ -18,24 +18,48 @@ cd ~/<my_working _directory>
 git clone https://github.com/opencv/opencv.git
 @endcode
 
+If you want to install OpenCV’s extra modules, clone the opencv_contrib repository as well:
+
+@code{.bash}
+cd ~/<my_working _directory>
+git clone https://github.com/opencv/opencv_contrib.git
+@endcode
+
+
 Building OpenCV from Source, using CMake and Command Line
 ---------------------------------------------------------
 
--#  Make symbolic link for Xcode to let OpenCV build scripts find the compiler, header files etc.
+1.  Make sure the xcode command line tools are installed:
     @code{.bash}
-    cd /
-    sudo ln -s /Applications/Xcode.app/Contents/Developer Developer
+    xcode-select --install
     @endcode
 
--#  Build OpenCV framework:
+2.  Build OpenCV framework:
     @code{.bash}
     cd ~/<my_working_directory>
     python opencv/platforms/ios/build_framework.py ios
     @endcode
 
-If everything's fine, a few minutes later you will get
-\~/\<my_working_directory\>/ios/opencv2.framework. You can add this framework to your Xcode
-projects.
+3.  To install OpenCV’s extra modules, append `--contrib opencv_contrib` to the python command above. **Note:** the extra modules are not included in the iOS Pack download at [OpenCV Releases](https://opencv.org/releases/). If you want to use the extra modules (e.g. aruco), you must build OpenCV yourself and include this option:
+    @code{.bash}
+    cd ~/<my_working_directory>
+    python opencv/platforms/ios/build_framework.py ios --contrib opencv_contrib
+    @endcode
+
+4.  To exclude a specific module, append `--without <module_name>`. For example, to exclude the "optflow" module from opencv_contrib:
+    @code{.bash}
+    cd ~/<my_working_directory>
+    python opencv/platforms/ios/build_framework.py ios --contrib opencv_contrib --without optflow
+    @endcode
+
+5.  The build process can take a significant amount of time. Currently (OpenCV 3.4 and 4.1), five separate architectures are built: armv7, armv7s, and arm64 for iOS plus i386 and x86_64 for the iPhone simulator. If you want to specify the architectures to include in the framework, use the `--iphoneos_archs` and/or `--iphonesimulator_archs` options. For example, to only build arm64 for iOS and x86_64 for the simulator:
+    @code{.bash}
+    cd ~/<my_working_directory>
+    python opencv/platforms/ios/build_framework.py ios --contrib opencv_contrib --iphoneos_archs arm64 --iphonesimulator_archs x86_64
+    @endcode
+
+If everything’s fine, the build process will create
+`~/<my_working_directory>/ios/opencv2.framework`. You can add this framework to your Xcode projects.
 
 Further Reading
 ---------------

--- a/doc/tutorials/introduction/table_of_content_introduction.markdown
+++ b/doc/tutorials/introduction/table_of_content_introduction.markdown
@@ -114,7 +114,7 @@ Additionally you can find very basic sample source code to introduce you to the 
 
     _Compatibility:_ \> OpenCV 2.4.2
 
-    _Author:_ Artem Myagkov, Eduard Feicho
+    _Author:_ Artem Myagkov, Eduard Feicho, Steve Nicholson
 
     We will learn how to setup OpenCV for using it in iOS!
 


### PR DESCRIPTION
resolves #15175

### This pullrequest changes

Adds additional information to iOS build instructions:

- Removes instructions to create a link to `/Applications/Xcode.app/Contents/Developer` in the root directory.
- Adds instructions to install Xcode command line tools.
- Notes that opencv_contrib modules are not currently included in the iOS Pack downloadable from the [OpenCV Releases](https://opencv.org/releases/) page so manual compilation is required to use those modules under iOS.
- Shows how to include opencv_contrib modules.
- Shows how to exclude specific modules.
- Shows how to specify which architectures to include in the framework.
