### PR TITLE
Fixes typo in calib3d.hpp

### DIFF
--- a/modules/calib3d/include/opencv2/calib3d.hpp
+++ b/modules/calib3d/include/opencv2/calib3d.hpp
@@ -124,7 +124,7 @@ The next figures show two common types of radial distortion: barrel distortion (
 ![](pics/distortion_examples2.png)
 
 In some cases the image sensor may be tilted in order to focus an oblique plane in front of the
-camera (Scheimpfug condition). This can be useful for particle image velocimetry (PIV) or
+camera (Scheimpflug principle). This can be useful for particle image velocimetry (PIV) or
 triangulation with a laser fan. The tilt causes a perspective distortion of \f$x''\f$ and
 \f$y''\f$. This distortion can be modelled in the following way, see e.g. @cite Louhichi07.
 


### PR DESCRIPTION
resolves #13523

Fixes a typo in the calib3d.hpp file. ( (Scheimpfug condition) to ([Scheimpflug principle](https://en.wikipedia.org/wiki/Scheimpflug_principle))

<!-- Please describe what your pullrequest is changing -->
