### PR TITLE
dnn(test): fix Vulkan skip test tag

### DIFF
--- a/modules/dnn/test/test_misc.cpp
+++ b/modules/dnn/test/test_misc.cpp
@@ -184,7 +184,7 @@ TEST_P(setInput, normalization)
     if (backend == DNN_BACKEND_OPENCV && target == DNN_TARGET_OPENCL_FP16 && dtype != CV_32F)
         applyTestTag(CV_TEST_TAG_DNN_SKIP_OPENCL_FP16);
     if (backend == DNN_BACKEND_VKCOM && dtype != CV_32F)
-        throw SkipTestException(CV_TEST_TAG_DNN_SKIP_VULKAN);
+        applyTestTag(CV_TEST_TAG_DNN_SKIP_VULKAN);
 
     Mat inp(5, 5, CV_8UC3);
     randu(inp, 0, 255);


### PR DESCRIPTION
Fix test skip statistics:

<cut/>

```
[ RUN      ] setInput.normalization/18, where GetParam() = (0.00784314, [50, 50, 50], 0, VKCOM/VULKAN)
[     SKIP ] dnn_skip_vulkan
...
[ SKIPSTAT ] TAG='skip_other' skip 20 tests
```

```
force_builders=Custom
build_image:Custom=ubuntu-vulkan:16.04
buildworker:Custom=linux-4
test_modules:Custom=dnn,java,python3
```