### PR TITLE
core: disable invalid constructors in C API by default

### DIFF
--- a/modules/core/include/opencv2/core/types_c.h
+++ b/modules/core/include/opencv2/core/types_c.h
@@ -44,8 +44,10 @@
 #ifndef OPENCV_CORE_TYPES_H
 #define OPENCV_CORE_TYPES_H
 
-#if !defined(__OPENCV_BUILD) && !defined(CV__DISABLE_C_API_CTORS)
-#define CV__ENABLE_C_API_CTORS // enable C API ctors (must be removed)
+#ifdef CV__ENABLE_C_API_CTORS  // invalid C API ctors (must be removed)
+#if defined(_WIN32) && !defined(CV__SKIP_MESSAGE_MALFORMED_C_API_CTORS)
+#error "C API ctors don't work on Win32: https://github.com/opencv/opencv/issues/15990"
+#endif
 #endif
 
 //#define CV__VALIDATE_UNUNITIALIZED_VARS 1  // C++11 & GCC only

--- a/samples/cpp/image.cpp
+++ b/samples/cpp/image.cpp
@@ -17,10 +17,9 @@ static void help()
     "./image [image-name Default: lena.jpg]\n" << endl;
 }
 
-// enable/disable use of mixed API in the code below.
-#define DEMO_MIXED_API_USE 1
+//#define USE_LEGACY_C_API 1  // not working with modern OpenCV
 
-#ifdef DEMO_MIXED_API_USE
+#ifdef USE_LEGACY_C_API
 #  include <opencv2/highgui/highgui_c.h>
 #  include <opencv2/imgcodecs/imgcodecs_c.h>
 #endif
@@ -34,7 +33,7 @@ int main( int argc, char** argv )
         return 0;
     }
     string imagename = parser.get<string>("@image");
-#if DEMO_MIXED_API_USE
+#ifdef USE_LEGACY_C_API
     //! [iplimage]
     Ptr<IplImage> iplimg(cvLoadImage(imagename.c_str())); // Ptr<T> is safe ref-counting pointer class
     if(!iplimg)
@@ -94,7 +93,7 @@ int main( int argc, char** argv )
 
     const double brightness_gain = 0;
     const double contrast_gain = 1.7;
-#if DEMO_MIXED_API_USE
+#ifdef USE_LEGACY_C_API
     // it's easy to pass the new matrices to the functions that only work with IplImage or CvMat:
     // step 1) - convert the headers, data will not be copied
     IplImage cv_planes_0 = planes[0], cv_noise = noise;
@@ -121,7 +120,7 @@ int main( int argc, char** argv )
 
     // this is counterpart for cvNamedWindow
     namedWindow("image with grain", WINDOW_AUTOSIZE);
-#if DEMO_MIXED_API_USE
+#ifdef USE_LEGACY_C_API
     // this is to demonstrate that img and iplimg really share the data - the result of the above
     // processing is stored in img and thus in iplimg too.
     cvShowImage("image with grain", iplimg);

--- a/samples/cpp/tutorial_code/core/interoperability_with_OpenCV_1/interoperability_with_OpenCV_1.cpp
+++ b/samples/cpp/tutorial_code/core/interoperability_with_OpenCV_1/interoperability_with_OpenCV_1.cpp
@@ -19,21 +19,21 @@ static void help( char* progName)
         << progName << " [image-name Default: ../data/lena.jpg]"                   << endl << endl;
 }
 
-//! [start]
-// comment out the define to use only the latest C++ API
-#define DEMO_MIXED_API_USE
+//#define USE_LEGACY_C_API 1  // not working with modern OpenCV
 
 #ifdef DEMO_MIXED_API_USE
 #  include <opencv2/highgui/highgui_c.h>
 #  include <opencv2/imgcodecs/imgcodecs_c.h>
 #endif
 
+//! [start]
+
 int main( int argc, char** argv )
 {
     help(argv[0]);
     const char* imagename = argc > 1 ? argv[1] : "../data/lena.jpg";
 
-#ifdef DEMO_MIXED_API_USE
+#ifdef USE_LEGACY_C_API
     Ptr<IplImage> IplI(cvLoadImage(imagename));      // Ptr<T> is a safe ref-counting pointer class
     if(!IplI)
     {
@@ -101,7 +101,7 @@ int main( int argc, char** argv )
     const double brightness_gain = 0;
     const double contrast_gain = 1.7;
 
-#ifdef DEMO_MIXED_API_USE
+#ifdef USE_LEGACY_C_API
     // To pass the new matrices to the functions that only work with IplImage or CvMat do:
     // step 1) Convert the headers (tip: data will not be copied).
     // step 2) call the function   (tip: to pass a pointer do not forget unary "&" to form pointers)
@@ -133,7 +133,7 @@ int main( int argc, char** argv )
 
     namedWindow("image with grain", WINDOW_AUTOSIZE);   // use this to create images
 
-#ifdef DEMO_MIXED_API_USE
+#ifdef USE_LEGACY_C_API
     // this is to demonstrate that I and IplI really share the data - the result of the above
     // processing is stored in I and thus in IplI too.
     cvShowImage("image with grain", IplI);

--- a/samples/cpp/tutorial_code/core/mat_operations/mat_operations.cpp
+++ b/samples/cpp/tutorial_code/core/mat_operations/mat_operations.cpp
@@ -131,8 +131,8 @@ int main(int,char**)
     {
         //! [C-API conversion]
         Mat img = imread("image.jpg");
-        IplImage img1 = img;
-        CvMat m = img;
+        IplImage img1 = cvIplImage(img);
+        CvMat m = cvMat(img);
         //! [C-API conversion]
         CV_UNUSED(img1);
         CV_UNUSED(m);


### PR DESCRIPTION
**Merge with contrib**: https://github.com/opencv/opencv_contrib/pull/2373

resolves #15990
relates #11630

- C API objects will lose their default initializers through constructors