### PR TITLE
bindings: basic support for #if preprocessor directives

### DIFF
--- a/modules/core/misc/java/src/cpp/core_manual.hpp
+++ b/modules/core/misc/java/src/cpp/core_manual.hpp
@@ -9,7 +9,7 @@ CV_EXPORTS_W void setErrorVerbosity(bool verbose);
 
 }
 
-#if 0
+#ifdef OPENCV_BINDINGS_PARSER
 
 namespace cv
 {
@@ -30,4 +30,4 @@ CV_EXPORTS_W void min(InputArray src1, Scalar src2, OutputArray dst);
 CV_EXPORTS_W void max(InputArray src1, Scalar src2, OutputArray dst);
 
 }
-#endif //0
+#endif

--- a/modules/features2d/misc/java/src/cpp/features2d_manual.hpp
+++ b/modules/features2d/misc/java/src/cpp/features2d_manual.hpp
@@ -294,7 +294,7 @@ private:
     Ptr<DescriptorExtractor> wrapped;
 };
 
-#if 0
+#ifdef OPENCV_BINDINGS_PARSER
 //DO NOT REMOVE! The block is required for sources parser
 enum
 {

--- a/modules/python/src2/hdr_parser.py
+++ b/modules/python/src2/hdr_parser.py
@@ -793,6 +793,7 @@ class CppHeaderParser(object):
         COMMENT = 1 # inside a multi-line comment
         DIRECTIVE = 2 # inside a multi-line preprocessor directive
         DOCSTRING = 3 # inside a multi-line docstring
+        DIRECTIVE_IF_0 = 4 # inside a '#if 0' directive
 
         state = SCAN
 
@@ -801,6 +802,8 @@ class CppHeaderParser(object):
         docstring = ""
         self.lineno = 0
         self.wrap_mode = wmode
+
+        depth_if_0 = 0
 
         for l0 in linelist:
             self.lineno += 1
@@ -813,8 +816,28 @@ class CppHeaderParser(object):
                 # fall through to the if state == DIRECTIVE check
 
             if state == DIRECTIVE:
-                if not l.endswith("\\"):
-                    state = SCAN
+                if l.endswith("\\"):
+                    continue
+                state = SCAN
+                l = re.sub(r'//(.+)?', '', l).strip()  # drop // comment
+                if l == '#if 0' or l == '#if defined(__OPENCV_BUILD)' or l == '#ifdef __OPENCV_BUILD':
+                    state = DIRECTIVE_IF_0
+                    depth_if_0 = 1
+                continue
+
+            if state == DIRECTIVE_IF_0:
+                if l.startswith('#'):
+                    l = l[1:].strip()
+                    if l.startswith("if"):
+                        depth_if_0 += 1
+                        continue
+                    if l.startswith("endif"):
+                        depth_if_0 -= 1
+                        if depth_if_0 == 0:
+                            state = SCAN
+                else:
+                    # print('---- {:30s}:{:5d}: {}'.format(hname[-30:], self.lineno, l))
+                    pass
                 continue
 
             if state == COMMENT:


### PR DESCRIPTION
resolves #16056
relates #12972

Bindings parser skip code blocks guarded by:
- `#if 0`
- `#ifdef __OPENCV_BUILD` with the same behavior as `#if 0`
- no `#else`/`#elif` support
- basic support for nested `#if` directives