### PR TITLE
Backport fix for autodetection of input shapes

### DIFF
--- a/modules/dnn/src/dnn.cpp
+++ b/modules/dnn/src/dnn.cpp
@@ -2772,17 +2772,25 @@ struct Net::Impl
     {
         std::vector<LayerPin>& inputLayerIds = layers[id].inputBlobsId;
 
-        if (inOutShapes[0].in[0].empty() && !layers[0].outputBlobs.empty())
+        if (id == 0 && inOutShapes[id].in[0].empty())
         {
-            ShapesVec shapes;
-            for (int i = 0; i < layers[0].outputBlobs.size(); i++)
+            if (!layers[0].outputBlobs.empty())
             {
-                Mat& inp = layers[0].outputBlobs[i];
-                CV_Assert(inp.total());
-                shapes.push_back(shape(inp));
+                ShapesVec shapes;
+                for (int i = 0; i < layers[0].outputBlobs.size(); i++)
+                {
+                    Mat& inp = layers[0].outputBlobs[i];
+                    CV_Assert(inp.total());
+                    shapes.push_back(shape(inp));
+                }
+                inOutShapes[0].in = shapes;
             }
-            inOutShapes[0].in = shapes;
-         }
+            else
+            {
+                inOutShapes[0].out.clear();
+                return;
+            }
+        }
 
         if (inOutShapes[id].in.empty())
         {


### PR DESCRIPTION
<!-- Please use this line to close one or multiple issues when this pullrequest gets merged
You can add another line right under the first one:
resolves #1234
resolves #1235
-->

### This pullrequest changes

backports https://github.com/opencv/opencv/pull/15611 (for https://github.com/opencv/opencv/pull/16068)

```
force_builders=Custom,Custom Win,Custom Mac
build_image:Custom=ubuntu-openvino-2019r3.0:16.04
build_image:Custom Win=openvino-2019r3.0
build_image:Custom Mac=openvino-2019r3.0

test_modules:Custom=dnn,python2,python3,java
test_modules:Custom Win=dnn,python2,python3,java
test_modules:Custom Mac=dnn,python2,python3,java

buildworker:Custom=linux-1
# disabled due high memory usage: test_opencl:Custom=ON
test_opencl:Custom=OFF
test_bigdata:Custom=1
test_filter:Custom=*
```