### PR TITLE
G-API: Added an arbitrary-argument version of cv::gapi::combine

### DIFF
--- a/modules/gapi/include/opencv2/gapi/gkernel.hpp
+++ b/modules/gapi/include/opencv2/gapi/gkernel.hpp
@@ -537,8 +537,29 @@ namespace gapi {
 
     /** @} */
 
+    // FYI - this function is already commented above
     GAPI_EXPORTS GKernelPackage combine(const GKernelPackage  &lhs,
                                         const GKernelPackage  &rhs);
+
+    /**
+     * @brief Combines multiple G-API kernel packages into one
+     *
+     * @overload
+     *
+     * This function successively combines the passed kernel packages using a right fold.
+     * Calling `combine(a, b, c)` is equal to `combine(a, combine(b, c))`.
+     *
+     * @return The resulting kernel package
+     */
+    template<typename... Ps>
+    GKernelPackage combine(const GKernelPackage &a, const GKernelPackage &b, Ps&&... rest)
+    {
+        return combine(a, combine(b, rest...));
+    }
+
+    /** \addtogroup gapi_compile_args
+     * @{
+     */
     /**
      * @brief cv::use_only() is a special combinator which hints G-API to use only
      * kernels specified in cv::GComputation::compile() (and not to extend kernels available by
@@ -548,6 +569,7 @@ namespace gapi {
     {
         GKernelPackage pkg;
     };
+    /** @} */
 
 } // namespace gapi
 

--- a/modules/gapi/test/gapi_kernel_tests.cpp
+++ b/modules/gapi/test/gapi_kernel_tests.cpp
@@ -325,6 +325,21 @@ TEST(KernelPackage, Can_Use_Custom_Kernel)
                         compile({in_meta, in_meta}, cv::compile_args(pkg)));
 }
 
+TEST(KernelPackage, CombineMultiple)
+{
+    namespace J = Jupiter;
+    namespace S = Saturn;
+    auto a = cv::gapi::kernels<J::Foo>();
+    auto b = cv::gapi::kernels<J::Bar>();
+    auto c = cv::gapi::kernels<S::Qux>();
+    auto pkg = cv::gapi::combine(a, b, c);
+
+    EXPECT_EQ(3u, pkg.size());
+    EXPECT_TRUE(pkg.includes<J::Foo>());
+    EXPECT_TRUE(pkg.includes<J::Bar>());
+    EXPECT_TRUE(pkg.includes<S::Qux>());
+}
+
 TEST_F(HeteroGraph, Call_Custom_Kernel_Default_Backend)
 {
     // in0 -> GCPUAdd -> tmp -> cpu::GClone -> GCPUBGR2Gray -> out


### PR DESCRIPTION
- Now user doesn't need to do `combine(x, combine(y, combine(z, zz)))` but
  just `combine(x, y, z, zz)`

<!-- Please use this line to close one or multiple issues when this pullrequest gets merged
You can add another line right under the first one:
resolves #1234
resolves #1235
-->

<!-- Please describe what your pullrequest is changing -->
