### PR TITLE
cuda4dnn: fuse activations with convolutions

### DIFF
--- a/modules/dnn/src/cuda/bias_activation.cu
+++ b/modules/dnn/src/cuda/bias_activation.cu
@@ -19,319 +19,318 @@ using namespace cv::dnn::cuda4dnn::csl::device;
 
 namespace cv { namespace dnn { namespace cuda4dnn { namespace kernels {
 
-    namespace raw {
+namespace raw {
 
-        template <class T, std::size_t N>
-        __global__ void biasN_relu_inplace_vec(Span<T> inplace_output, size_type inner_size, View<T> bias, T slope) {
-            using vector_type = get_vector_type_t<T, N>;
+    template <class T, std::size_t N>
+    __global__ void biasN_relu_inplace_vec(Span<T> inplace_output, size_type inner_size, View<T> bias, T slope) {
+        using vector_type = get_vector_type_t<T, N>;
 
-            auto inplace_output_vPtr = vector_type::get_pointer(inplace_output.data());
+        auto inplace_output_vPtr = vector_type::get_pointer(inplace_output.data());
 
-            inner_size /= vector_type::size();
-            for (auto i : grid_stride_range(inplace_output.size() / vector_type::size())) {
-                const index_type bias_idx = (i / inner_size) % static_cast<size_type>(bias.size());
+        inner_size /= vector_type::size();
+        for (auto i : grid_stride_range(inplace_output.size() / vector_type::size())) {
+            const index_type bias_idx = (i / inner_size) % static_cast<size_type>(bias.size());
 
-                vector_type vec;
-                v_load(vec, inplace_output_vPtr[i]);
-                for(int j = 0; j < vec.size(); j++) {
-                    vec.data[j] += bias[bias_idx];
-                    vec.data[j] = vec.data[j] >= T(0) ? vec.data[j] : slope * vec.data[j];
-                }
-                v_store(inplace_output_vPtr[i], vec);
+            vector_type vec;
+            v_load(vec, inplace_output_vPtr[i]);
+            for(int j = 0; j < vec.size(); j++) {
+                vec.data[j] += bias[bias_idx];
+                vec.data[j] = vec.data[j] >= T(0) ? vec.data[j] : slope * vec.data[j];
             }
+            v_store(inplace_output_vPtr[i], vec);
         }
+    }
 
-        template <class T, std::size_t N>
-        __global__ void biasN_clipped_relu_inplace_vec(Span<T> inplace_output, size_type inner_size, View<T> bias, T floor, T ceil) {
-            using vector_type = get_vector_type_t<T, N>;
+    template <class T, std::size_t N>
+    __global__ void biasN_clipped_relu_inplace_vec(Span<T> inplace_output, size_type inner_size, View<T> bias, T floor, T ceil) {
+        using vector_type = get_vector_type_t<T, N>;
 
-            auto inplace_output_vPtr = vector_type::get_pointer(inplace_output.data());
+        auto inplace_output_vPtr = vector_type::get_pointer(inplace_output.data());
 
-            inner_size /= vector_type::size();
-            for (auto i : grid_stride_range(inplace_output.size() / vector_type::size())) {
-                const index_type bias_idx = (i / inner_size) % static_cast<size_type>(bias.size());
+        inner_size /= vector_type::size();
+        for (auto i : grid_stride_range(inplace_output.size() / vector_type::size())) {
+            const index_type bias_idx = (i / inner_size) % static_cast<size_type>(bias.size());
 
-                vector_type vec;
-                v_load(vec, inplace_output_vPtr[i]);
-                for(int j = 0; j < vec.size(); j++) {
-                    using device::clamp;
-                    vec.data[j] = clamp(vec.data[j] + bias[bias_idx], floor, ceil);
-                }
-                v_store(inplace_output_vPtr[i], vec);
+            vector_type vec;
+            v_load(vec, inplace_output_vPtr[i]);
+            for(int j = 0; j < vec.size(); j++) {
+                using device::clamp;
+                vec.data[j] = clamp(vec.data[j] + bias[bias_idx], floor, ceil);
             }
+            v_store(inplace_output_vPtr[i], vec);
         }
+    }
 
-        template <class T, std::size_t N>
-        __global__ void biasN_power_inplace_vec(Span<T> inplace_output, size_type inner_size, View<T> bias, T power) {
-            using vector_type = get_vector_type_t<T, N>;
+    template <class T, std::size_t N>
+    __global__ void biasN_power_inplace_vec(Span<T> inplace_output, size_type inner_size, View<T> bias, T power) {
+        using vector_type = get_vector_type_t<T, N>;
 
-            auto inplace_output_vPtr = vector_type::get_pointer(inplace_output.data());
+        auto inplace_output_vPtr = vector_type::get_pointer(inplace_output.data());
 
-            inner_size /= vector_type::size();
-            for (auto i : grid_stride_range(inplace_output.size() / vector_type::size())) {
-                const index_type bias_idx = (i / inner_size) % static_cast<size_type>(bias.size());
+        inner_size /= vector_type::size();
+        for (auto i : grid_stride_range(inplace_output.size() / vector_type::size())) {
+            const index_type bias_idx = (i / inner_size) % static_cast<size_type>(bias.size());
 
-                vector_type vec;
-                v_load(vec, inplace_output_vPtr[i]);
-                for(int j = 0; j < vec.size(); j++) {
-                    using device::pow;
-                    vec.data[j] = pow(vec.data[j] + bias[bias_idx], power);
-                }
-                v_store(inplace_output_vPtr[i], vec);
+            vector_type vec;
+            v_load(vec, inplace_output_vPtr[i]);
+            for(int j = 0; j < vec.size(); j++) {
+                using device::pow;
+                vec.data[j] = pow(vec.data[j] + bias[bias_idx], power);
             }
+            v_store(inplace_output_vPtr[i], vec);
         }
+    }
 
-        template <class T, std::size_t N>
-        __global__ void biasN_tanh_inplace_vec(Span<T> inplace_output, size_type inner_size, View<T> bias) {
-            using vector_type = get_vector_type_t<T, N>;
+    template <class T, std::size_t N>
+    __global__ void biasN_tanh_inplace_vec(Span<T> inplace_output, size_type inner_size, View<T> bias) {
+        using vector_type = get_vector_type_t<T, N>;
 
-            auto inplace_output_vPtr = vector_type::get_pointer(inplace_output.data());
+        auto inplace_output_vPtr = vector_type::get_pointer(inplace_output.data());
 
-            inner_size /= vector_type::size();
-            for (auto i : grid_stride_range(inplace_output.size() / vector_type::size())) {
-                const index_type bias_idx = (i / inner_size) % static_cast<size_type>(bias.size());
+        inner_size /= vector_type::size();
+        for (auto i : grid_stride_range(inplace_output.size() / vector_type::size())) {
+            const index_type bias_idx = (i / inner_size) % static_cast<size_type>(bias.size());
 
-                vector_type vec;
-                v_load(vec, inplace_output_vPtr[i]);
-                for(int j = 0; j < vec.size(); j++) {
-                    using device::tanh;
-                    vec.data[j] = tanh(vec.data[j] + bias[bias_idx]);
-                }
-                v_store(inplace_output_vPtr[i], vec);
+            vector_type vec;
+            v_load(vec, inplace_output_vPtr[i]);
+            for(int j = 0; j < vec.size(); j++) {
+                using device::tanh;
+                vec.data[j] = tanh(vec.data[j] + bias[bias_idx]);
             }
+            v_store(inplace_output_vPtr[i], vec);
         }
+    }
 
-        template <class T, std::size_t N>
-        __global__ void biasN_sigmoid_inplace_vec(Span<T> inplace_output, size_type inner_size, View<T> bias) {
-            using vector_type = get_vector_type_t<T, N>;
+    template <class T, std::size_t N>
+    __global__ void biasN_sigmoid_inplace_vec(Span<T> inplace_output, size_type inner_size, View<T> bias) {
+        using vector_type = get_vector_type_t<T, N>;
 
-            auto inplace_output_vPtr = vector_type::get_pointer(inplace_output.data());
+        auto inplace_output_vPtr = vector_type::get_pointer(inplace_output.data());
 
-            inner_size /= vector_type::size();
-            for (auto i : grid_stride_range(inplace_output.size() / vector_type::size())) {
-                const index_type bias_idx = (i / inner_size) % static_cast<size_type>(bias.size());
+        inner_size /= vector_type::size();
+        for (auto i : grid_stride_range(inplace_output.size() / vector_type::size())) {
+            const index_type bias_idx = (i / inner_size) % static_cast<size_type>(bias.size());
 
-                vector_type vec;
-                v_load(vec, inplace_output_vPtr[i]);
-                for(int j = 0; j < vec.size(); j++) {
-                    using device::sigmoid;
-                    vec.data[j] = sigmoid(vec.data[j] + bias[bias_idx]);
-                }
-                v_store(inplace_output_vPtr[i], vec);
+            vector_type vec;
+            v_load(vec, inplace_output_vPtr[i]);
+            for(int j = 0; j < vec.size(); j++) {
+                using device::sigmoid;
+                vec.data[j] = sigmoid(vec.data[j] + bias[bias_idx]);
             }
+            v_store(inplace_output_vPtr[i], vec);
         }
+    }
 
-        template <class T, std::size_t N>
-        __global__ void biasN_swish_inplace_vec(Span<T> inplace_output, size_type inner_size, View<T> bias) {
-            using vector_type = get_vector_type_t<T, N>;
+    template <class T, std::size_t N>
+    __global__ void biasN_swish_inplace_vec(Span<T> inplace_output, size_type inner_size, View<T> bias) {
+        using vector_type = get_vector_type_t<T, N>;
 
-            auto inplace_output_vPtr = vector_type::get_pointer(inplace_output.data());
+        auto inplace_output_vPtr = vector_type::get_pointer(inplace_output.data());
 
-            inner_size /= vector_type::size();
-            for (auto i : grid_stride_range(inplace_output.size() / vector_type::size())) {
-                const index_type bias_idx = (i / inner_size) % static_cast<size_type>(bias.size());
+        inner_size /= vector_type::size();
+        for (auto i : grid_stride_range(inplace_output.size() / vector_type::size())) {
+            const index_type bias_idx = (i / inner_size) % static_cast<size_type>(bias.size());
 
-                vector_type vec;
-                v_load(vec, inplace_output_vPtr[i]);
-                for(int j = 0; j < vec.size(); j++) {
-                    using device::sigmoid;
-                    vec.data[j] += bias[bias_idx];
-                    vec.data[j] = vec.data[j] * sigmoid(vec.data[j]);
-                }
-                v_store(inplace_output_vPtr[i], vec);
+            vector_type vec;
+            v_load(vec, inplace_output_vPtr[i]);
+            for(int j = 0; j < vec.size(); j++) {
+                using device::sigmoid;
+                vec.data[j] += bias[bias_idx];
+                vec.data[j] = vec.data[j] * sigmoid(vec.data[j]);
             }
+            v_store(inplace_output_vPtr[i], vec);
         }
+    }
 
-        template <class T, std::size_t N>
-        __global__ void biasN_mish_inplace_vec(Span<T> inplace_output, size_type inner_size, View<T> bias) {
-            using vector_type = get_vector_type_t<T, N>;
+    template <class T, std::size_t N>
+    __global__ void biasN_mish_inplace_vec(Span<T> inplace_output, size_type inner_size, View<T> bias) {
+        using vector_type = get_vector_type_t<T, N>;
 
-            auto inplace_output_vPtr = vector_type::get_pointer(inplace_output.data());
+        auto inplace_output_vPtr = vector_type::get_pointer(inplace_output.data());
 
-            inner_size /= vector_type::size();
-            for (auto i : grid_stride_range(inplace_output.size() / vector_type::size())) {
-                const index_type bias_idx = (i / inner_size) % static_cast<size_type>(bias.size());
+        inner_size /= vector_type::size();
+        for (auto i : grid_stride_range(inplace_output.size() / vector_type::size())) {
+            const index_type bias_idx = (i / inner_size) % static_cast<size_type>(bias.size());
 
-                vector_type vec;
-                v_load(vec, inplace_output_vPtr[i]);
-                for(int j = 0; j < vec.size(); j++) {
-                    vec.data[j] += bias[bias_idx];
-
-                    using device::tanh;
-                    using device::log1pexp;
-                    vec.data[j] = vec.data[j] * tanh(log1pexp(vec.data[j]));
-                }
-                v_store(inplace_output_vPtr[i], vec);
+            vector_type vec;
+            v_load(vec, inplace_output_vPtr[i]);
+            for(int j = 0; j < vec.size(); j++) {
+                using device::tanh;
+                using device::log1pexp;
+                vec.data[j] += bias[bias_idx];
+                vec.data[j] = vec.data[j] * tanh(log1pexp(vec.data[j]));
             }
+            v_store(inplace_output_vPtr[i], vec);
         }
     }
+}
 
-    template <class T, std::size_t N> static
-    void launch_biasN_relu_inplace_vec_kernel(const Stream& stream, Span<T> inplace_output, std::size_t inner_size, View<T> bias, T slope) {
-        CV_Assert(is_fully_aligned<T>(inplace_output, N));
-        CV_Assert(inner_size % N == 0);
+template <class T, std::size_t N> static
+void launch_biasN_relu_inplace_vec_kernel(const Stream& stream, Span<T> inplace_output, std::size_t inner_size, View<T> bias, T slope) {
+    CV_Assert(is_fully_aligned<T>(inplace_output, N));
+    CV_Assert(inner_size % N == 0);
 
-        auto kernel = raw::biasN_relu_inplace_vec<T, N>;
-        auto policy = make_policy(kernel, inplace_output.size() / N, 0, stream);
-        launch_kernel(kernel, policy, inplace_output, inner_size, bias, slope);
+    auto kernel = raw::biasN_relu_inplace_vec<T, N>;
+    auto policy = make_policy(kernel, inplace_output.size() / N, 0, stream);
+    launch_kernel(kernel, policy, inplace_output, inner_size, bias, slope);
+}
+
+template <class T>
+void biasN_relu_inplace(const Stream& stream, Span<T> inplace_output, std::size_t inner_size, View<T> bias, T slope) {
+    if (is_fully_aligned<T>(inplace_output, 4) && inner_size % 4 == 0) {
+        launch_biasN_relu_inplace_vec_kernel<T, 4>(stream, inplace_output, inner_size, bias, slope);
+    } else if (is_fully_aligned<T>(inplace_output, 2) && inner_size % 2 == 0) {
+        launch_biasN_relu_inplace_vec_kernel<T, 2>(stream, inplace_output, inner_size, bias, slope);
+    } else {
+        launch_biasN_relu_inplace_vec_kernel<T, 1>(stream, inplace_output, inner_size, bias, slope);
     }
+}
 
-    template <class T>
-    void biasN_relu_inplace(const Stream& stream, Span<T> inplace_output, std::size_t inner_size, View<T> bias, T slope) {
-        if (is_fully_aligned<T>(inplace_output, 4) && inner_size % 4 == 0) {
-            launch_biasN_relu_inplace_vec_kernel<T, 4>(stream, inplace_output, inner_size, bias, slope);
-        } else if (is_fully_aligned<T>(inplace_output, 2) && inner_size % 2 == 0) {
-            launch_biasN_relu_inplace_vec_kernel<T, 2>(stream, inplace_output, inner_size, bias, slope);
-        } else {
-            launch_biasN_relu_inplace_vec_kernel<T, 1>(stream, inplace_output, inner_size, bias, slope);
-        }
+template void biasN_relu_inplace<__half>(const Stream&, Span<__half>, std::size_t, View<__half>, __half);
+template void biasN_relu_inplace<float>(const Stream&, Span<float>, std::size_t, View<float>, float);
+
+template <class T, std::size_t N> static
+void launch_biasN_clipped_relu_inplace_vec_kernel(const Stream& stream, Span<T> inplace_output, std::size_t inner_size, View<T> bias, T floor, T ceil) {
+    CV_Assert(is_fully_aligned<T>(inplace_output, N));
+    CV_Assert(inner_size % N == 0);
+
+    auto kernel = raw::biasN_clipped_relu_inplace_vec<T, N>;
+    auto policy = make_policy(kernel, inplace_output.size() / N, 0, stream);
+    launch_kernel(kernel, policy, inplace_output, inner_size, bias, floor, ceil);
+}
+
+template <class T>
+void biasN_clipped_relu_inplace(const Stream& stream, Span<T> inplace_output, std::size_t inner_size, View<T> bias, T floor, T ceil) {
+    if (is_fully_aligned<T>(inplace_output, 4) && inner_size % 4 == 0) {
+        launch_biasN_clipped_relu_inplace_vec_kernel<T, 4>(stream, inplace_output, inner_size, bias, floor, ceil);
+    } else if (is_fully_aligned<T>(inplace_output, 2) && inner_size % 2 == 0) {
+        launch_biasN_clipped_relu_inplace_vec_kernel<T, 2>(stream, inplace_output, inner_size, bias, floor, ceil);
+    } else {
+        launch_biasN_clipped_relu_inplace_vec_kernel<T, 1>(stream, inplace_output, inner_size, bias, floor, ceil);
     }
+}
 
-    template void biasN_relu_inplace<__half>(const Stream&, Span<__half>, std::size_t, View<__half>, __half);
-    template void biasN_relu_inplace<float>(const Stream&, Span<float>, std::size_t, View<float>, float);
+template void biasN_clipped_relu_inplace<__half>(const Stream&, Span<__half>, std::size_t, View<__half>, __half, __half);
+template void biasN_clipped_relu_inplace<float>(const Stream&, Span<float>, std::size_t, View<float>, float, float);
 
-    template <class T, std::size_t N> static
-    void launch_biasN_clipped_relu_inplace_vec_kernel(const Stream& stream, Span<T> inplace_output, std::size_t inner_size, View<T> bias, T floor, T ceil){
-        CV_Assert(is_fully_aligned<T>(inplace_output, N));
-        CV_Assert(inner_size % N == 0);
+template <class T, std::size_t N> static
+void launch_biasN_power_inplace_vec_kernel(const Stream& stream, Span<T> inplace_output, std::size_t inner_size, View<T> bias, T power) {
+    CV_Assert(is_fully_aligned<T>(inplace_output, N));
+    CV_Assert(inner_size % N == 0);
 
-        auto kernel = raw::biasN_clipped_relu_inplace_vec<T, N>;
-        auto policy = make_policy(kernel, inplace_output.size() / N, 0, stream);
-        launch_kernel(kernel, policy, inplace_output, inner_size, bias, floor, ceil);
+    auto kernel = raw::biasN_power_inplace_vec<T, N>;
+    auto policy = make_policy(kernel, inplace_output.size() / N, 0, stream);
+    launch_kernel(kernel, policy, inplace_output, inner_size, bias, power);
+}
+
+template <class T>
+void biasN_power_inplace(const Stream& stream, Span<T> inplace_output, std::size_t inner_size, View<T> bias, T power) {
+    if (is_fully_aligned<T>(inplace_output, 4) && inner_size % 4 == 0) {
+        launch_biasN_power_inplace_vec_kernel<T, 4>(stream, inplace_output, inner_size, bias, power);
+    } else if (is_fully_aligned<T>(inplace_output, 2) && inner_size % 2 == 0) {
+        launch_biasN_power_inplace_vec_kernel<T, 2>(stream, inplace_output, inner_size, bias, power);
+    } else {
+        launch_biasN_power_inplace_vec_kernel<T, 1>(stream, inplace_output, inner_size, bias, power);
     }
+}
 
-    template <class T>
-    void biasN_clipped_relu_inplace(const Stream& stream, Span<T> inplace_output, std::size_t inner_size, View<T> bias, T floor, T ceil) {
-        if (is_fully_aligned<T>(inplace_output, 4) && inner_size % 4 == 0) {
-            launch_biasN_clipped_relu_inplace_vec_kernel<T, 4>(stream, inplace_output, inner_size, bias, floor, ceil);
-        } else if (is_fully_aligned<T>(inplace_output, 2) && inner_size % 2 == 0) {
-            launch_biasN_clipped_relu_inplace_vec_kernel<T, 2>(stream, inplace_output, inner_size, bias, floor, ceil);
-        } else {
-            launch_biasN_clipped_relu_inplace_vec_kernel<T, 1>(stream, inplace_output, inner_size, bias, floor, ceil);
-        }
+template void biasN_power_inplace<__half>(const Stream&, Span<__half>, std::size_t, View<__half>, __half);
+template void biasN_power_inplace<float>(const Stream&, Span<float>, std::size_t, View<float>, float);
+
+template <class T, std::size_t N> static
+void launch_biasN_tanh_inplace_vec_kernel(const Stream& stream, Span<T> inplace_output, std::size_t inner_size, View<T> bias) {
+    CV_Assert(is_fully_aligned<T>(inplace_output, N));
+    CV_Assert(inner_size % N == 0);
+
+    auto kernel = raw::biasN_tanh_inplace_vec<T, N>;
+    auto policy = make_policy(kernel, inplace_output.size() / N, 0, stream);
+    launch_kernel(kernel, policy, inplace_output, inner_size, bias);
+}
+
+template <class T>
+void biasN_tanh_inplace(const Stream& stream, Span<T> inplace_output, std::size_t inner_size, View<T> bias) {
+    if (is_fully_aligned<T>(inplace_output, 4) && inner_size % 4 == 0) {
+        launch_biasN_tanh_inplace_vec_kernel<T, 4>(stream, inplace_output, inner_size, bias);
+    } else if (is_fully_aligned<T>(inplace_output, 2) && inner_size % 2 == 0) {
+        launch_biasN_tanh_inplace_vec_kernel<T, 2>(stream, inplace_output, inner_size, bias);
+    } else {
+        launch_biasN_tanh_inplace_vec_kernel<T, 1>(stream, inplace_output, inner_size, bias);
     }
+}
 
-    template void biasN_clipped_relu_inplace<__half>(const Stream&, Span<__half>, std::size_t, View<__half>, __half, __half);
-    template void biasN_clipped_relu_inplace<float>(const Stream&, Span<float>, std::size_t, View<float>, float, float);
+template void biasN_tanh_inplace<__half>(const Stream&, Span<__half>, std::size_t, View<__half>);
+template void biasN_tanh_inplace<float>(const Stream&, Span<float>, std::size_t, View<float>);
 
-    template <class T, std::size_t N> static
-    void launch_biasN_power_inplace_vec_kernel(const Stream& stream, Span<T> inplace_output, std::size_t inner_size, View<T> bias, T power){
-        CV_Assert(is_fully_aligned<T>(inplace_output, N));
-        CV_Assert(inner_size % N == 0);
+template <class T, std::size_t N> static
+void launch_biasN_sigmoid_inplace_vec_kernel(const Stream& stream, Span<T> inplace_output, std::size_t inner_size, View<T> bias) {
+    CV_Assert(is_fully_aligned<T>(inplace_output, N));
+    CV_Assert(inner_size % N == 0);
 
-        auto kernel = raw::biasN_power_inplace_vec<T, N>;
-        auto policy = make_policy(kernel, inplace_output.size() / N, 0, stream);
-        launch_kernel(kernel, policy, inplace_output, inner_size, bias, power);
+    auto kernel = raw::biasN_sigmoid_inplace_vec<T, N>;
+    auto policy = make_policy(kernel, inplace_output.size() / N, 0, stream);
+    launch_kernel(kernel, policy, inplace_output, inner_size, bias);
+}
+
+template <class T>
+void biasN_sigmoid_inplace(const Stream& stream, Span<T> inplace_output, std::size_t inner_size, View<T> bias) {
+    if (is_fully_aligned<T>(inplace_output, 4) && inner_size % 4 == 0) {
+        launch_biasN_sigmoid_inplace_vec_kernel<T, 4>(stream, inplace_output, inner_size, bias);
+    } else if (is_fully_aligned<T>(inplace_output, 2) && inner_size % 2 == 0) {
+        launch_biasN_sigmoid_inplace_vec_kernel<T, 2>(stream, inplace_output, inner_size, bias);
+    } else {
+        launch_biasN_sigmoid_inplace_vec_kernel<T, 1>(stream, inplace_output, inner_size, bias);
     }
+}
 
-    template <class T>
-    void biasN_power_inplace(const Stream& stream, Span<T> inplace_output, std::size_t inner_size, View<T> bias, T power) {
-        if (is_fully_aligned<T>(inplace_output, 4) && inner_size % 4 == 0) {
-            launch_biasN_power_inplace_vec_kernel<T, 4>(stream, inplace_output, inner_size, bias, power);
-        } else if (is_fully_aligned<T>(inplace_output, 2) && inner_size % 2 == 0) {
-            launch_biasN_power_inplace_vec_kernel<T, 2>(stream, inplace_output, inner_size, bias, power);
-        } else {
-            launch_biasN_power_inplace_vec_kernel<T, 1>(stream, inplace_output, inner_size, bias, power);
-        }
+template void biasN_sigmoid_inplace<__half>(const Stream&, Span<__half>, std::size_t, View<__half>);
+template void biasN_sigmoid_inplace<float>(const Stream&, Span<float>, std::size_t, View<float>);
+
+template <class T, std::size_t N> static
+void launch_biasN_swish_inplace_vec_kernel(const Stream& stream, Span<T> inplace_output, std::size_t inner_size, View<T> bias) {
+    CV_Assert(is_fully_aligned<T>(inplace_output, N));
+    CV_Assert(inner_size % N == 0);
+
+    auto kernel = raw::biasN_swish_inplace_vec<T, N>;
+    auto policy = make_policy(kernel, inplace_output.size() / N, 0, stream);
+    launch_kernel(kernel, policy, inplace_output, inner_size, bias);
+}
+
+template <class T>
+void biasN_swish_inplace(const Stream& stream, Span<T> inplace_output, std::size_t inner_size, View<T> bias) {
+    if (is_fully_aligned<T>(inplace_output, 4) && inner_size % 4 == 0) {
+        launch_biasN_swish_inplace_vec_kernel<T, 4>(stream, inplace_output, inner_size, bias);
+    } else if (is_fully_aligned<T>(inplace_output, 2) && inner_size % 2 == 0) {
+        launch_biasN_swish_inplace_vec_kernel<T, 2>(stream, inplace_output, inner_size, bias);
+    } else {
+        launch_biasN_swish_inplace_vec_kernel<T, 1>(stream, inplace_output, inner_size, bias);
     }
+}
 
-    template void biasN_power_inplace<__half>(const Stream&, Span<__half>, std::size_t, View<__half>, __half);
-    template void biasN_power_inplace<float>(const Stream&, Span<float>, std::size_t, View<float>, float);
+template void biasN_swish_inplace<__half>(const Stream&, Span<__half>, std::size_t, View<__half>);
+template void biasN_swish_inplace<float>(const Stream&, Span<float>, std::size_t, View<float>);
 
-    template <class T, std::size_t N> static
-    void launch_biasN_tanh_inplace_vec_kernel(const Stream& stream, Span<T> inplace_output, std::size_t inner_size, View<T> bias) {
-        CV_Assert(is_fully_aligned<T>(inplace_output, N));
-        CV_Assert(inner_size % N == 0);
+template <class T, std::size_t N> static
+void launch_biasN_mish_inplace_vec_kernel(const Stream& stream, Span<T> inplace_output, std::size_t inner_size, View<T> bias) {
+    CV_Assert(is_fully_aligned<T>(inplace_output, N));
+    CV_Assert(inner_size % N == 0);
 
-        auto kernel = raw::biasN_tanh_inplace_vec<T, N>;
-        auto policy = make_policy(kernel, inplace_output.size() / N, 0, stream);
-        launch_kernel(kernel, policy, inplace_output, inner_size, bias);
+    auto kernel = raw::biasN_mish_inplace_vec<T, N>;
+    auto policy = make_policy(kernel, inplace_output.size() / N, 0, stream);
+    launch_kernel(kernel, policy, inplace_output, inner_size, bias);
+}
+
+template <class T>
+void biasN_mish_inplace(const Stream& stream, Span<T> inplace_output, std::size_t inner_size, View<T> bias) {
+    if (is_fully_aligned<T>(inplace_output, 4) && inner_size % 4 == 0) {
+        launch_biasN_mish_inplace_vec_kernel<T, 4>(stream, inplace_output, inner_size, bias);
+    } else if (is_fully_aligned<T>(inplace_output, 2) && inner_size % 2 == 0) {
+        launch_biasN_mish_inplace_vec_kernel<T, 2>(stream, inplace_output, inner_size, bias);
+    } else {
+        launch_biasN_mish_inplace_vec_kernel<T, 1>(stream, inplace_output, inner_size, bias);
     }
+}
 
-    template <class T>
-    void biasN_tanh_inplace(const Stream& stream, Span<T> inplace_output, std::size_t inner_size, View<T> bias) {
-        if (is_fully_aligned<T>(inplace_output, 4) && inner_size % 4 == 0) {
-            launch_biasN_tanh_inplace_vec_kernel<T, 4>(stream, inplace_output, inner_size, bias);
-        } else if (is_fully_aligned<T>(inplace_output, 2) && inner_size % 2 == 0) {
-            launch_biasN_tanh_inplace_vec_kernel<T, 2>(stream, inplace_output, inner_size, bias);
-        } else {
-            launch_biasN_tanh_inplace_vec_kernel<T, 1>(stream, inplace_output, inner_size, bias);
-        }
-    }
-
-    template void biasN_tanh_inplace<__half>(const Stream&, Span<__half>, std::size_t, View<__half>);
-    template void biasN_tanh_inplace<float>(const Stream&, Span<float>, std::size_t, View<float>);
-
-    template <class T, std::size_t N> static
-    void launch_biasN_sigmoid_inplace_vec_kernel(const Stream& stream, Span<T> inplace_output, std::size_t inner_size, View<T> bias) {
-        CV_Assert(is_fully_aligned<T>(inplace_output, N));
-        CV_Assert(inner_size % N == 0);
-
-        auto kernel = raw::biasN_sigmoid_inplace_vec<T, N>;
-        auto policy = make_policy(kernel, inplace_output.size() / N, 0, stream);
-        launch_kernel(kernel, policy, inplace_output, inner_size, bias);
-    }
-
-    template <class T>
-    void biasN_sigmoid_inplace(const Stream& stream, Span<T> inplace_output, std::size_t inner_size, View<T> bias) {
-        if (is_fully_aligned<T>(inplace_output, 4) && inner_size % 4 == 0) {
-            launch_biasN_sigmoid_inplace_vec_kernel<T, 4>(stream, inplace_output, inner_size, bias);
-        } else if (is_fully_aligned<T>(inplace_output, 2) && inner_size % 2 == 0) {
-            launch_biasN_sigmoid_inplace_vec_kernel<T, 2>(stream, inplace_output, inner_size, bias);
-        } else {
-            launch_biasN_sigmoid_inplace_vec_kernel<T, 1>(stream, inplace_output, inner_size, bias);
-        }
-    }
-
-    template void biasN_sigmoid_inplace<__half>(const Stream&, Span<__half>, std::size_t, View<__half>);
-    template void biasN_sigmoid_inplace<float>(const Stream&, Span<float>, std::size_t, View<float>);
-
-    template <class T, std::size_t N> static
-    void launch_biasN_swish_inplace_vec_kernel(const Stream& stream, Span<T> inplace_output, std::size_t inner_size, View<T> bias) {
-        CV_Assert(is_fully_aligned<T>(inplace_output, N));
-        CV_Assert(inner_size % N == 0);
-
-        auto kernel = raw::biasN_swish_inplace_vec<T, N>;
-        auto policy = make_policy(kernel, inplace_output.size() / N, 0, stream);
-        launch_kernel(kernel, policy, inplace_output, inner_size, bias);
-    }
-
-    template <class T>
-    void biasN_swish_inplace(const Stream& stream, Span<T> inplace_output, std::size_t inner_size, View<T> bias) {
-        if (is_fully_aligned<T>(inplace_output, 4) && inner_size % 4 == 0) {
-            launch_biasN_swish_inplace_vec_kernel<T, 4>(stream, inplace_output, inner_size, bias);
-        } else if (is_fully_aligned<T>(inplace_output, 2) && inner_size % 2 == 0) {
-            launch_biasN_swish_inplace_vec_kernel<T, 2>(stream, inplace_output, inner_size, bias);
-        } else {
-            launch_biasN_swish_inplace_vec_kernel<T, 1>(stream, inplace_output, inner_size, bias);
-        }
-    }
-
-    template void biasN_swish_inplace<__half>(const Stream&, Span<__half>, std::size_t, View<__half>);
-    template void biasN_swish_inplace<float>(const Stream&, Span<float>, std::size_t, View<float>);
-
-    template <class T, std::size_t N> static
-    void launch_biasN_mish_inplace_vec_kernel(const Stream& stream, Span<T> inplace_output, std::size_t inner_size, View<T> bias) {
-        CV_Assert(is_fully_aligned<T>(inplace_output, N));
-        CV_Assert(inner_size % N == 0);
-
-        auto kernel = raw::biasN_mish_inplace_vec<T, N>;
-        auto policy = make_policy(kernel, inplace_output.size() / N, 0, stream);
-        launch_kernel(kernel, policy, inplace_output, inner_size, bias);
-    }
-
-    template <class T>
-    void biasN_mish_inplace(const Stream& stream, Span<T> inplace_output, std::size_t inner_size, View<T> bias) {
-        if (is_fully_aligned<T>(inplace_output, 4) && inner_size % 4 == 0) {
-            launch_biasN_mish_inplace_vec_kernel<T, 4>(stream, inplace_output, inner_size, bias);
-        } else if (is_fully_aligned<T>(inplace_output, 2) && inner_size % 2 == 0) {
-            launch_biasN_mish_inplace_vec_kernel<T, 2>(stream, inplace_output, inner_size, bias);
-        } else {
-            launch_biasN_mish_inplace_vec_kernel<T, 1>(stream, inplace_output, inner_size, bias);
-        }
-    }
-
-    template void biasN_mish_inplace<__half>(const Stream&, Span<__half>, std::size_t, View<__half>);
-    template void biasN_mish_inplace<float>(const Stream&, Span<float>, std::size_t, View<float>);
+template void biasN_mish_inplace<__half>(const Stream&, Span<__half>, std::size_t, View<__half>);
+template void biasN_mish_inplace<float>(const Stream&, Span<float>, std::size_t, View<float>);
 
 }}}} /* namespace cv::dnn::cuda4dnn::kernels */

--- a/modules/dnn/src/cuda/bias_activation.cu
+++ b/modules/dnn/src/cuda/bias_activation.cu
@@ -22,7 +22,7 @@ namespace cv { namespace dnn { namespace cuda4dnn { namespace kernels {
     namespace raw {
 
         template <class T, std::size_t N>
-        __global__ void biasN_relu_inplace_vec(Span<T> inplace_output, size_type inner_size, View<T> bias) {
+        __global__ void biasN_relu_inplace_vec(Span<T> inplace_output, size_type inner_size, View<T> bias, T slope) {
             using vector_type = get_vector_type_t<T, N>;
 
             auto inplace_output_vPtr = vector_type::get_pointer(inplace_output.data());
@@ -34,8 +34,8 @@ namespace cv { namespace dnn { namespace cuda4dnn { namespace kernels {
                 vector_type vec;
                 v_load(vec, inplace_output_vPtr[i]);
                 for(int j = 0; j < vec.size(); j++) {
-                    using device::max;
-                    vec.data[j] = max(vec.data[j] + bias[bias_idx], T(0));
+                    vec.data[j] += bias[bias_idx];
+                    vec.data[j] = vec.data[j] >= T(0) ? vec.data[j] : slope * vec.data[j];
                 }
                 v_store(inplace_output_vPtr[i], vec);
             }
@@ -56,6 +56,26 @@ namespace cv { namespace dnn { namespace cuda4dnn { namespace kernels {
                 for(int j = 0; j < vec.size(); j++) {
                     using device::clamp;
                     vec.data[j] = clamp(vec.data[j] + bias[bias_idx], floor, ceil);
+                }
+                v_store(inplace_output_vPtr[i], vec);
+            }
+        }
+
+        template <class T, std::size_t N>
+        __global__ void biasN_power_inplace_vec(Span<T> inplace_output, size_type inner_size, View<T> bias, T power) {
+            using vector_type = get_vector_type_t<T, N>;
+
+            auto inplace_output_vPtr = vector_type::get_pointer(inplace_output.data());
+
+            inner_size /= vector_type::size();
+            for (auto i : grid_stride_range(inplace_output.size() / vector_type::size())) {
+                const index_type bias_idx = (i / inner_size) % static_cast<size_type>(bias.size());
+
+                vector_type vec;
+                v_load(vec, inplace_output_vPtr[i]);
+                for(int j = 0; j < vec.size(); j++) {
+                    using device::pow;
+                    vec.data[j] = pow(vec.data[j] + bias[bias_idx], power);
                 }
                 v_store(inplace_output_vPtr[i], vec);
             }
@@ -100,31 +120,75 @@ namespace cv { namespace dnn { namespace cuda4dnn { namespace kernels {
                 v_store(inplace_output_vPtr[i], vec);
             }
         }
+
+        template <class T, std::size_t N>
+        __global__ void biasN_swish_inplace_vec(Span<T> inplace_output, size_type inner_size, View<T> bias) {
+            using vector_type = get_vector_type_t<T, N>;
+
+            auto inplace_output_vPtr = vector_type::get_pointer(inplace_output.data());
+
+            inner_size /= vector_type::size();
+            for (auto i : grid_stride_range(inplace_output.size() / vector_type::size())) {
+                const index_type bias_idx = (i / inner_size) % static_cast<size_type>(bias.size());
+
+                vector_type vec;
+                v_load(vec, inplace_output_vPtr[i]);
+                for(int j = 0; j < vec.size(); j++) {
+                    using device::sigmoid;
+                    vec.data[j] += bias[bias_idx];
+                    vec.data[j] = vec.data[j] * sigmoid(vec.data[j]);
+                }
+                v_store(inplace_output_vPtr[i], vec);
+            }
+        }
+
+        template <class T, std::size_t N>
+        __global__ void biasN_mish_inplace_vec(Span<T> inplace_output, size_type inner_size, View<T> bias) {
+            using vector_type = get_vector_type_t<T, N>;
+
+            auto inplace_output_vPtr = vector_type::get_pointer(inplace_output.data());
+
+            inner_size /= vector_type::size();
+            for (auto i : grid_stride_range(inplace_output.size() / vector_type::size())) {
+                const index_type bias_idx = (i / inner_size) % static_cast<size_type>(bias.size());
+
+                vector_type vec;
+                v_load(vec, inplace_output_vPtr[i]);
+                for(int j = 0; j < vec.size(); j++) {
+                    vec.data[j] += bias[bias_idx];
+
+                    using device::tanh;
+                    using device::log1pexp;
+                    vec.data[j] = vec.data[j] * tanh(log1pexp(vec.data[j]));
+                }
+                v_store(inplace_output_vPtr[i], vec);
+            }
+        }
     }
 
     template <class T, std::size_t N> static
-    void launch_biasN_relu_inplace_vec_kernel(const Stream& stream, Span<T> inplace_output, std::size_t inner_size, View<T> bias) {
+    void launch_biasN_relu_inplace_vec_kernel(const Stream& stream, Span<T> inplace_output, std::size_t inner_size, View<T> bias, T slope) {
         CV_Assert(is_fully_aligned<T>(inplace_output, N));
         CV_Assert(inner_size % N == 0);
 
         auto kernel = raw::biasN_relu_inplace_vec<T, N>;
         auto policy = make_policy(kernel, inplace_output.size() / N, 0, stream);
-        launch_kernel(kernel, policy, inplace_output, inner_size, bias);
+        launch_kernel(kernel, policy, inplace_output, inner_size, bias, slope);
     }
 
     template <class T>
-    void biasN_relu_inplace(const Stream& stream, Span<T> inplace_output, std::size_t inner_size, View<T> bias) {
+    void biasN_relu_inplace(const Stream& stream, Span<T> inplace_output, std::size_t inner_size, View<T> bias, T slope) {
         if (is_fully_aligned<T>(inplace_output, 4) && inner_size % 4 == 0) {
-            launch_biasN_relu_inplace_vec_kernel<T, 4>(stream, inplace_output, inner_size, bias);
+            launch_biasN_relu_inplace_vec_kernel<T, 4>(stream, inplace_output, inner_size, bias, slope);
         } else if (is_fully_aligned<T>(inplace_output, 2) && inner_size % 2 == 0) {
-            launch_biasN_relu_inplace_vec_kernel<T, 2>(stream, inplace_output, inner_size, bias);
+            launch_biasN_relu_inplace_vec_kernel<T, 2>(stream, inplace_output, inner_size, bias, slope);
         } else {
-            launch_biasN_relu_inplace_vec_kernel<T, 1>(stream, inplace_output, inner_size, bias);
+            launch_biasN_relu_inplace_vec_kernel<T, 1>(stream, inplace_output, inner_size, bias, slope);
         }
     }
 
-    template void biasN_relu_inplace<__half>(const Stream&, Span<__half>, std::size_t, View<__half>);
-    template void biasN_relu_inplace<float>(const Stream&, Span<float>, std::size_t, View<float>);
+    template void biasN_relu_inplace<__half>(const Stream&, Span<__half>, std::size_t, View<__half>, __half);
+    template void biasN_relu_inplace<float>(const Stream&, Span<float>, std::size_t, View<float>, float);
 
     template <class T, std::size_t N> static
     void launch_biasN_clipped_relu_inplace_vec_kernel(const Stream& stream, Span<T> inplace_output, std::size_t inner_size, View<T> bias, T floor, T ceil){
@@ -149,6 +213,30 @@ namespace cv { namespace dnn { namespace cuda4dnn { namespace kernels {
 
     template void biasN_clipped_relu_inplace<__half>(const Stream&, Span<__half>, std::size_t, View<__half>, __half, __half);
     template void biasN_clipped_relu_inplace<float>(const Stream&, Span<float>, std::size_t, View<float>, float, float);
+
+    template <class T, std::size_t N> static
+    void launch_biasN_power_inplace_vec_kernel(const Stream& stream, Span<T> inplace_output, std::size_t inner_size, View<T> bias, T power){
+        CV_Assert(is_fully_aligned<T>(inplace_output, N));
+        CV_Assert(inner_size % N == 0);
+
+        auto kernel = raw::biasN_power_inplace_vec<T, N>;
+        auto policy = make_policy(kernel, inplace_output.size() / N, 0, stream);
+        launch_kernel(kernel, policy, inplace_output, inner_size, bias, power);
+    }
+
+    template <class T>
+    void biasN_power_inplace(const Stream& stream, Span<T> inplace_output, std::size_t inner_size, View<T> bias, T power) {
+        if (is_fully_aligned<T>(inplace_output, 4) && inner_size % 4 == 0) {
+            launch_biasN_power_inplace_vec_kernel<T, 4>(stream, inplace_output, inner_size, bias, power);
+        } else if (is_fully_aligned<T>(inplace_output, 2) && inner_size % 2 == 0) {
+            launch_biasN_power_inplace_vec_kernel<T, 2>(stream, inplace_output, inner_size, bias, power);
+        } else {
+            launch_biasN_power_inplace_vec_kernel<T, 1>(stream, inplace_output, inner_size, bias, power);
+        }
+    }
+
+    template void biasN_power_inplace<__half>(const Stream&, Span<__half>, std::size_t, View<__half>, __half);
+    template void biasN_power_inplace<float>(const Stream&, Span<float>, std::size_t, View<float>, float);
 
     template <class T, std::size_t N> static
     void launch_biasN_tanh_inplace_vec_kernel(const Stream& stream, Span<T> inplace_output, std::size_t inner_size, View<T> bias) {
@@ -197,5 +285,53 @@ namespace cv { namespace dnn { namespace cuda4dnn { namespace kernels {
 
     template void biasN_sigmoid_inplace<__half>(const Stream&, Span<__half>, std::size_t, View<__half>);
     template void biasN_sigmoid_inplace<float>(const Stream&, Span<float>, std::size_t, View<float>);
+
+    template <class T, std::size_t N> static
+    void launch_biasN_swish_inplace_vec_kernel(const Stream& stream, Span<T> inplace_output, std::size_t inner_size, View<T> bias) {
+        CV_Assert(is_fully_aligned<T>(inplace_output, N));
+        CV_Assert(inner_size % N == 0);
+
+        auto kernel = raw::biasN_swish_inplace_vec<T, N>;
+        auto policy = make_policy(kernel, inplace_output.size() / N, 0, stream);
+        launch_kernel(kernel, policy, inplace_output, inner_size, bias);
+    }
+
+    template <class T>
+    void biasN_swish_inplace(const Stream& stream, Span<T> inplace_output, std::size_t inner_size, View<T> bias) {
+        if (is_fully_aligned<T>(inplace_output, 4) && inner_size % 4 == 0) {
+            launch_biasN_swish_inplace_vec_kernel<T, 4>(stream, inplace_output, inner_size, bias);
+        } else if (is_fully_aligned<T>(inplace_output, 2) && inner_size % 2 == 0) {
+            launch_biasN_swish_inplace_vec_kernel<T, 2>(stream, inplace_output, inner_size, bias);
+        } else {
+            launch_biasN_swish_inplace_vec_kernel<T, 1>(stream, inplace_output, inner_size, bias);
+        }
+    }
+
+    template void biasN_swish_inplace<__half>(const Stream&, Span<__half>, std::size_t, View<__half>);
+    template void biasN_swish_inplace<float>(const Stream&, Span<float>, std::size_t, View<float>);
+
+    template <class T, std::size_t N> static
+    void launch_biasN_mish_inplace_vec_kernel(const Stream& stream, Span<T> inplace_output, std::size_t inner_size, View<T> bias) {
+        CV_Assert(is_fully_aligned<T>(inplace_output, N));
+        CV_Assert(inner_size % N == 0);
+
+        auto kernel = raw::biasN_mish_inplace_vec<T, N>;
+        auto policy = make_policy(kernel, inplace_output.size() / N, 0, stream);
+        launch_kernel(kernel, policy, inplace_output, inner_size, bias);
+    }
+
+    template <class T>
+    void biasN_mish_inplace(const Stream& stream, Span<T> inplace_output, std::size_t inner_size, View<T> bias) {
+        if (is_fully_aligned<T>(inplace_output, 4) && inner_size % 4 == 0) {
+            launch_biasN_mish_inplace_vec_kernel<T, 4>(stream, inplace_output, inner_size, bias);
+        } else if (is_fully_aligned<T>(inplace_output, 2) && inner_size % 2 == 0) {
+            launch_biasN_mish_inplace_vec_kernel<T, 2>(stream, inplace_output, inner_size, bias);
+        } else {
+            launch_biasN_mish_inplace_vec_kernel<T, 1>(stream, inplace_output, inner_size, bias);
+        }
+    }
+
+    template void biasN_mish_inplace<__half>(const Stream&, Span<__half>, std::size_t, View<__half>);
+    template void biasN_mish_inplace<float>(const Stream&, Span<float>, std::size_t, View<float>);
 
 }}}} /* namespace cv::dnn::cuda4dnn::kernels */

--- a/modules/dnn/src/cuda/bias_activation.cu
+++ b/modules/dnn/src/cuda/bias_activation.cu
@@ -1,0 +1,201 @@
+// This file is part of OpenCV project.
+// It is subject to the license terms in the LICENSE file found in the top-level directory
+// of this distribution and at http://opencv.org/license.html.
+
+#include <cuda_runtime.h>
+#include <cuda_fp16.h>
+
+#include "types.hpp"
+#include "math.hpp"
+#include "vector_traits.hpp"
+#include "grid_stride_range.hpp"
+#include "execution.hpp"
+
+#include "../cuda4dnn/csl/stream.hpp"
+#include "../cuda4dnn/csl/span.hpp"
+
+using namespace cv::dnn::cuda4dnn::csl;
+using namespace cv::dnn::cuda4dnn::csl::device;
+
+namespace cv { namespace dnn { namespace cuda4dnn { namespace kernels {
+
+    namespace raw {
+
+        template <class T, std::size_t N>
+        __global__ void biasN_relu_inplace_vec(Span<T> inplace_output, size_type inner_size, View<T> bias) {
+            using vector_type = get_vector_type_t<T, N>;
+
+            auto inplace_output_vPtr = vector_type::get_pointer(inplace_output.data());
+
+            inner_size /= vector_type::size();
+            for (auto i : grid_stride_range(inplace_output.size() / vector_type::size())) {
+                const index_type bias_idx = (i / inner_size) % static_cast<size_type>(bias.size());
+
+                vector_type vec;
+                v_load(vec, inplace_output_vPtr[i]);
+                for(int j = 0; j < vec.size(); j++) {
+                    using device::max;
+                    vec.data[j] = max(vec.data[j] + bias[bias_idx], T(0));
+                }
+                v_store(inplace_output_vPtr[i], vec);
+            }
+        }
+
+        template <class T, std::size_t N>
+        __global__ void biasN_clipped_relu_inplace_vec(Span<T> inplace_output, size_type inner_size, View<T> bias, T floor, T ceil) {
+            using vector_type = get_vector_type_t<T, N>;
+
+            auto inplace_output_vPtr = vector_type::get_pointer(inplace_output.data());
+
+            inner_size /= vector_type::size();
+            for (auto i : grid_stride_range(inplace_output.size() / vector_type::size())) {
+                const index_type bias_idx = (i / inner_size) % static_cast<size_type>(bias.size());
+
+                vector_type vec;
+                v_load(vec, inplace_output_vPtr[i]);
+                for(int j = 0; j < vec.size(); j++) {
+                    using device::clamp;
+                    vec.data[j] = clamp(vec.data[j] + bias[bias_idx], floor, ceil);
+                }
+                v_store(inplace_output_vPtr[i], vec);
+            }
+        }
+
+        template <class T, std::size_t N>
+        __global__ void biasN_tanh_inplace_vec(Span<T> inplace_output, size_type inner_size, View<T> bias) {
+            using vector_type = get_vector_type_t<T, N>;
+
+            auto inplace_output_vPtr = vector_type::get_pointer(inplace_output.data());
+
+            inner_size /= vector_type::size();
+            for (auto i : grid_stride_range(inplace_output.size() / vector_type::size())) {
+                const index_type bias_idx = (i / inner_size) % static_cast<size_type>(bias.size());
+
+                vector_type vec;
+                v_load(vec, inplace_output_vPtr[i]);
+                for(int j = 0; j < vec.size(); j++) {
+                    using device::tanh;
+                    vec.data[j] = tanh(vec.data[j] + bias[bias_idx]);
+                }
+                v_store(inplace_output_vPtr[i], vec);
+            }
+        }
+
+        template <class T, std::size_t N>
+        __global__ void biasN_sigmoid_inplace_vec(Span<T> inplace_output, size_type inner_size, View<T> bias) {
+            using vector_type = get_vector_type_t<T, N>;
+
+            auto inplace_output_vPtr = vector_type::get_pointer(inplace_output.data());
+
+            inner_size /= vector_type::size();
+            for (auto i : grid_stride_range(inplace_output.size() / vector_type::size())) {
+                const index_type bias_idx = (i / inner_size) % static_cast<size_type>(bias.size());
+
+                vector_type vec;
+                v_load(vec, inplace_output_vPtr[i]);
+                for(int j = 0; j < vec.size(); j++) {
+                    using device::sigmoid;
+                    vec.data[j] = sigmoid(vec.data[j] + bias[bias_idx]);
+                }
+                v_store(inplace_output_vPtr[i], vec);
+            }
+        }
+    }
+
+    template <class T, std::size_t N> static
+    void launch_biasN_relu_inplace_vec_kernel(const Stream& stream, Span<T> inplace_output, std::size_t inner_size, View<T> bias) {
+        CV_Assert(is_fully_aligned<T>(inplace_output, N));
+        CV_Assert(inner_size % N == 0);
+
+        auto kernel = raw::biasN_relu_inplace_vec<T, N>;
+        auto policy = make_policy(kernel, inplace_output.size() / N, 0, stream);
+        launch_kernel(kernel, policy, inplace_output, inner_size, bias);
+    }
+
+    template <class T>
+    void biasN_relu_inplace(const Stream& stream, Span<T> inplace_output, std::size_t inner_size, View<T> bias) {
+        if (is_fully_aligned<T>(inplace_output, 4) && inner_size % 4 == 0) {
+            launch_biasN_relu_inplace_vec_kernel<T, 4>(stream, inplace_output, inner_size, bias);
+        } else if (is_fully_aligned<T>(inplace_output, 2) && inner_size % 2 == 0) {
+            launch_biasN_relu_inplace_vec_kernel<T, 2>(stream, inplace_output, inner_size, bias);
+        } else {
+            launch_biasN_relu_inplace_vec_kernel<T, 1>(stream, inplace_output, inner_size, bias);
+        }
+    }
+
+    template void biasN_relu_inplace<__half>(const Stream&, Span<__half>, std::size_t, View<__half>);
+    template void biasN_relu_inplace<float>(const Stream&, Span<float>, std::size_t, View<float>);
+
+    template <class T, std::size_t N> static
+    void launch_biasN_clipped_relu_inplace_vec_kernel(const Stream& stream, Span<T> inplace_output, std::size_t inner_size, View<T> bias, T floor, T ceil){
+        CV_Assert(is_fully_aligned<T>(inplace_output, N));
+        CV_Assert(inner_size % N == 0);
+
+        auto kernel = raw::biasN_clipped_relu_inplace_vec<T, N>;
+        auto policy = make_policy(kernel, inplace_output.size() / N, 0, stream);
+        launch_kernel(kernel, policy, inplace_output, inner_size, bias, floor, ceil);
+    }
+
+    template <class T>
+    void biasN_clipped_relu_inplace(const Stream& stream, Span<T> inplace_output, std::size_t inner_size, View<T> bias, T floor, T ceil) {
+        if (is_fully_aligned<T>(inplace_output, 4) && inner_size % 4 == 0) {
+            launch_biasN_clipped_relu_inplace_vec_kernel<T, 4>(stream, inplace_output, inner_size, bias, floor, ceil);
+        } else if (is_fully_aligned<T>(inplace_output, 2) && inner_size % 2 == 0) {
+            launch_biasN_clipped_relu_inplace_vec_kernel<T, 2>(stream, inplace_output, inner_size, bias, floor, ceil);
+        } else {
+            launch_biasN_clipped_relu_inplace_vec_kernel<T, 1>(stream, inplace_output, inner_size, bias, floor, ceil);
+        }
+    }
+
+    template void biasN_clipped_relu_inplace<__half>(const Stream&, Span<__half>, std::size_t, View<__half>, __half, __half);
+    template void biasN_clipped_relu_inplace<float>(const Stream&, Span<float>, std::size_t, View<float>, float, float);
+
+    template <class T, std::size_t N> static
+    void launch_biasN_tanh_inplace_vec_kernel(const Stream& stream, Span<T> inplace_output, std::size_t inner_size, View<T> bias) {
+        CV_Assert(is_fully_aligned<T>(inplace_output, N));
+        CV_Assert(inner_size % N == 0);
+
+        auto kernel = raw::biasN_tanh_inplace_vec<T, N>;
+        auto policy = make_policy(kernel, inplace_output.size() / N, 0, stream);
+        launch_kernel(kernel, policy, inplace_output, inner_size, bias);
+    }
+
+    template <class T>
+    void biasN_tanh_inplace(const Stream& stream, Span<T> inplace_output, std::size_t inner_size, View<T> bias) {
+        if (is_fully_aligned<T>(inplace_output, 4) && inner_size % 4 == 0) {
+            launch_biasN_tanh_inplace_vec_kernel<T, 4>(stream, inplace_output, inner_size, bias);
+        } else if (is_fully_aligned<T>(inplace_output, 2) && inner_size % 2 == 0) {
+            launch_biasN_tanh_inplace_vec_kernel<T, 2>(stream, inplace_output, inner_size, bias);
+        } else {
+            launch_biasN_tanh_inplace_vec_kernel<T, 1>(stream, inplace_output, inner_size, bias);
+        }
+    }
+
+    template void biasN_tanh_inplace<__half>(const Stream&, Span<__half>, std::size_t, View<__half>);
+    template void biasN_tanh_inplace<float>(const Stream&, Span<float>, std::size_t, View<float>);
+
+    template <class T, std::size_t N> static
+    void launch_biasN_sigmoid_inplace_vec_kernel(const Stream& stream, Span<T> inplace_output, std::size_t inner_size, View<T> bias) {
+        CV_Assert(is_fully_aligned<T>(inplace_output, N));
+        CV_Assert(inner_size % N == 0);
+
+        auto kernel = raw::biasN_sigmoid_inplace_vec<T, N>;
+        auto policy = make_policy(kernel, inplace_output.size() / N, 0, stream);
+        launch_kernel(kernel, policy, inplace_output, inner_size, bias);
+    }
+
+    template <class T>
+    void biasN_sigmoid_inplace(const Stream& stream, Span<T> inplace_output, std::size_t inner_size, View<T> bias) {
+        if (is_fully_aligned<T>(inplace_output, 4) && inner_size % 4 == 0) {
+            launch_biasN_sigmoid_inplace_vec_kernel<T, 4>(stream, inplace_output, inner_size, bias);
+        } else if (is_fully_aligned<T>(inplace_output, 2) && inner_size % 2 == 0) {
+            launch_biasN_sigmoid_inplace_vec_kernel<T, 2>(stream, inplace_output, inner_size, bias);
+        } else {
+            launch_biasN_sigmoid_inplace_vec_kernel<T, 1>(stream, inplace_output, inner_size, bias);
+        }
+    }
+
+    template void biasN_sigmoid_inplace<__half>(const Stream&, Span<__half>, std::size_t, View<__half>);
+    template void biasN_sigmoid_inplace<float>(const Stream&, Span<float>, std::size_t, View<float>);
+
+}}}} /* namespace cv::dnn::cuda4dnn::kernels */

--- a/modules/dnn/src/cuda4dnn/kernels/bias_activation.hpp
+++ b/modules/dnn/src/cuda4dnn/kernels/bias_activation.hpp
@@ -2,8 +2,8 @@
 // It is subject to the license terms in the LICENSE file found in the top-level directory
 // of this distribution and at http://opencv.org/license.html.
 
-#ifndef OPENCV_DNN_SRC_CUDA4DNN_KERNELS_BIAS_ACTIVATIONS_HPP
-#define OPENCV_DNN_SRC_CUDA4DNN_KERNELS_BIAS_ACTIVATIONS_HPP
+#ifndef OPENCV_DNN_SRC_CUDA4DNN_KERNELS_BIAS_ACTIVATION_HPP
+#define OPENCV_DNN_SRC_CUDA4DNN_KERNELS_BIAS_ACTIVATION_HPP
 
 #include "../csl/stream.hpp"
 #include "../csl/span.hpp"
@@ -35,4 +35,4 @@ namespace cv { namespace dnn { namespace cuda4dnn { namespace kernels {
 
 }}}} /* namespace cv::dnn::cuda4dnn::kernels */
 
-#endif /* OPENCV_DNN_SRC_CUDA4DNN_KERNELS_BIAS_ACTIVATIONS_HPP */
+#endif /* OPENCV_DNN_SRC_CUDA4DNN_KERNELS_BIAS_ACTIVATION_HPP */

--- a/modules/dnn/src/cuda4dnn/kernels/bias_activations.hpp
+++ b/modules/dnn/src/cuda4dnn/kernels/bias_activations.hpp
@@ -1,0 +1,29 @@
+// This file is part of OpenCV project.
+// It is subject to the license terms in the LICENSE file found in the top-level directory
+// of this distribution and at http://opencv.org/license.html.
+
+#ifndef OPENCV_DNN_SRC_CUDA4DNN_KERNELS_BIAS_ACTIVATIONS_HPP
+#define OPENCV_DNN_SRC_CUDA4DNN_KERNELS_BIAS_ACTIVATIONS_HPP
+
+#include "../csl/stream.hpp"
+#include "../csl/span.hpp"
+
+#include <cstddef>
+
+namespace cv { namespace dnn { namespace cuda4dnn { namespace kernels {
+
+    template <class T>
+    void biasN_relu_inplace(const csl::Stream& stream, csl::Span<T> inplace_output, std::size_t inner_size, csl::View<T> bias);
+
+    template <class T>
+    void biasN_clipped_relu_inplace(const csl::Stream& stream, csl::Span<T> inplace_output, std::size_t inner_size, csl::View<T> bias, T floor, T ceiling);
+
+    template <class T>
+    void biasN_tanh_inplace(const csl::Stream& stream, csl::Span<T> inplace_output, std::size_t inner_size, csl::View<T> bias);
+
+    template <class T>
+    void biasN_sigmoid_inplace(const csl::Stream& stream, csl::Span<T> inplace_output, std::size_t inner_size, csl::View<T> bias);
+
+}}}} /* namespace cv::dnn::cuda4dnn::kernels */
+
+#endif /* OPENCV_DNN_SRC_CUDA4DNN_KERNELS_BIAS_ACTIVATIONS_HPP */

--- a/modules/dnn/src/cuda4dnn/kernels/bias_activations.hpp
+++ b/modules/dnn/src/cuda4dnn/kernels/bias_activations.hpp
@@ -13,16 +13,25 @@
 namespace cv { namespace dnn { namespace cuda4dnn { namespace kernels {
 
     template <class T>
-    void biasN_relu_inplace(const csl::Stream& stream, csl::Span<T> inplace_output, std::size_t inner_size, csl::View<T> bias);
+    void biasN_relu_inplace(const csl::Stream& stream, csl::Span<T> inplace_output, std::size_t inner_size, csl::View<T> bias, T slope);
 
     template <class T>
     void biasN_clipped_relu_inplace(const csl::Stream& stream, csl::Span<T> inplace_output, std::size_t inner_size, csl::View<T> bias, T floor, T ceiling);
+
+    template <class T>
+    void biasN_power_inplace(const csl::Stream& stream, csl::Span<T> inplace_output, std::size_t inner_size, csl::View<T> bias, T exp);
 
     template <class T>
     void biasN_tanh_inplace(const csl::Stream& stream, csl::Span<T> inplace_output, std::size_t inner_size, csl::View<T> bias);
 
     template <class T>
     void biasN_sigmoid_inplace(const csl::Stream& stream, csl::Span<T> inplace_output, std::size_t inner_size, csl::View<T> bias);
+
+    template <class T>
+    void biasN_swish_inplace(const csl::Stream& stream, csl::Span<T> inplace_output, std::size_t inner_size, csl::View<T> bias);
+
+    template <class T>
+    void biasN_mish_inplace(const csl::Stream& stream, csl::Span<T> inplace_output, std::size_t inner_size, csl::View<T> bias);
 
 }}}} /* namespace cv::dnn::cuda4dnn::kernels */
 

--- a/modules/dnn/src/dnn.cpp
+++ b/modules/dnn/src/dnn.cpp
@@ -2432,8 +2432,11 @@ struct Net::Impl
                     if (IS_DNN_CUDA_TARGET(preferableTarget) &&
                         nextData->type != "ReLU" &&
                         nextData->type != "ReLU6" &&
+                        nextData->type != "Power" &&
                         nextData->type != "TanH" &&
-                        nextData->type != "Sigmoid")
+                        nextData->type != "Sigmoid" &&
+                        nextData->type != "Swish" &&
+                        nextData->type != "Mish")
                         break;
 
                     Ptr<ActivationLayer> nextActivLayer = nextData->layerInstance.dynamicCast<ActivationLayer>();

--- a/modules/dnn/src/dnn.cpp
+++ b/modules/dnn/src/dnn.cpp
@@ -2405,7 +2405,7 @@ struct Net::Impl
                         break;
                 }
 
-                if (preferableBackend != DNN_BACKEND_OPENCV)
+                if (preferableBackend != DNN_BACKEND_OPENCV && preferableBackend != DNN_BACKEND_CUDA)
                     continue;  // Go to the next layer.
 
                 // TODO: OpenCL target support more fusion styles.
@@ -2413,6 +2413,9 @@ struct Net::Impl
                      (!cv::ocl::useOpenCL() || (ld.layerInstance->type != "Convolution" &&
                      ld.layerInstance->type != "MVN" && ld.layerInstance->type != "Pooling" &&
                      ld.layerInstance->type != "Concat")) )
+                    continue;
+
+                if (preferableBackend == DNN_BACKEND_CUDA && IS_DNN_CUDA_TARGET(preferableTarget) && ld.layerInstance->type != "Convolution")
                     continue;
 
                 while (nextData)
@@ -2424,6 +2427,13 @@ struct Net::Impl
                         nextData->type != "ReLU6" &&
                         nextData->type != "TanH" &&
                         nextData->type != "Power")
+                        break;
+
+                    if (IS_DNN_CUDA_TARGET(preferableTarget) &&
+                        nextData->type != "ReLU" &&
+                        nextData->type != "ReLU6" &&
+                        nextData->type != "TanH" &&
+                        nextData->type != "Sigmoid")
                         break;
 
                     Ptr<ActivationLayer> nextActivLayer = nextData->layerInstance.dynamicCast<ActivationLayer>();

--- a/modules/dnn/src/layers/convolution_layer.cpp
+++ b/modules/dnn/src/layers/convolution_layer.cpp
@@ -414,14 +414,11 @@ public:
             {
                 activType = OCL4DNN_CONV_FUSED_ACTIV_TANH;
             }
-
-            if (activType == OCL4DNN_CONV_FUSED_ACTIV_NONE)
-            {
-                newActiv = false;
-                activ.reset();
-            }
         }
-        else if(IS_DNN_CUDA_TARGET(preferableTarget))
+#endif
+
+#ifdef HAVE_CUDA
+        if(IS_DNN_CUDA_TARGET(preferableTarget))
         {
             Ptr<ReLULayer> activ_relu = activ.dynamicCast<ReLULayer>();
             if(!activ_relu.empty())

--- a/modules/dnn/src/layers/convolution_layer.cpp
+++ b/modules/dnn/src/layers/convolution_layer.cpp
@@ -254,7 +254,7 @@ public:
 #endif
 
 #ifdef HAVE_CUDA
-        cudaActType = cuda4dnn::ConvolutionConfiguration::ActivationType::NONE;
+        cudaActType = cuda4dnn::ConvolutionConfiguration::ActivationType::IDENTITY;
 #endif
     }
 
@@ -423,7 +423,7 @@ public:
             if (activ.empty())
             {
                 /* setActivation was called without a layer => reset all fusions */
-                cudaActType = cuda4dnn::ConvolutionConfiguration::ActivationType::NONE;
+                cudaActType = cuda4dnn::ConvolutionConfiguration::ActivationType::IDENTITY;
             }
             else
             {
@@ -472,7 +472,7 @@ public:
                 if(!activ_mish.empty())
                     cudaActType = cuda4dnn::ConvolutionConfiguration::ActivationType::MISH;
 
-                if (cudaActType == cuda4dnn::ConvolutionConfiguration::ActivationType::NONE)
+                if (cudaActType == cuda4dnn::ConvolutionConfiguration::ActivationType::IDENTITY)
                     activ.reset();
             }
         }
@@ -1485,7 +1485,7 @@ public:
         config.output_shape.assign(std::begin(output_shape), std::end(output_shape));
         config.groups = groups;
 
-        config.activation = cudaActType;
+        config.activation_type = cudaActType;
         config.relu_negative_slope = cuda_relu_slope;
         config.crelu_floor = cuda_crelu_floor;
         config.crelu_ceil = cuda_crelu_ceil;


### PR DESCRIPTION
### This pullrequest changes
- fuses ReLU, ReLU6, Power, TanH, Sigmoid, Swish, Mish with convolutions

<cut/>

**Profiling results:**
- `biasN_relu_inplace` takes as much time as `biasN` => ReLU that follows conv with bias is fully FREE
- `biasN_clipped_relu`  takes as much time as `biasN` => ReLU6 that follows conv with bias is fully FREE
- haven't profiled others

**Issues:**
- investigate this fusion failure:
```
[FORWARD] Convolution
[FORWARD] Identity
[FORWARD] Sigmoid
```

Identity is NOP (it's not even copying) but it's blocking the fusion.

In general, shouldn't `Flatten`, `Blank`, `Reshape`, etc. be marked as skipped if there is no copying involved? It's never skipped even though it does absolutely nothing most of the times.


```
force_builders=Custom,docs
buildworker:Custom=linux-4
docker_image:Custom=ubuntu-cuda:16.04

build_image:Custom Mac=openvino-2019r3.0
build_image:Custom Win=openvino-2019r3.0
test_opencl:Custom Win=OFF
test_modules:Custom Mac=dnn,java,python3
```