### PR TITLE
videoio(plugins): relax version check for FFmpeg wrapper on Windows

### DIFF
--- a/modules/videoio/src/backend_plugin.cpp
+++ b/modules/videoio/src/backend_plugin.cpp
@@ -208,10 +208,23 @@ public:
                 CV_LOG_INFO(NULL, "Video I/O: plugin is incompatible: " << lib->getName());
                 return;
             }
-            if (plugin_api_->api_header.opencv_version_major != CV_VERSION_MAJOR ||
-                plugin_api_->api_header.opencv_version_minor != CV_VERSION_MINOR)
+            if (plugin_api_->api_header.opencv_version_major != CV_VERSION_MAJOR)
             {
-                CV_LOG_ERROR(NULL, "Video I/O: wrong OpenCV version used by plugin '" << plugin_api_->api_header.api_description << "': " <<
+                CV_LOG_ERROR(NULL, "Video I/O: wrong OpenCV major version used by plugin '" << plugin_api_->api_header.api_description << "': " <<
+                    cv::format("%d.%d, OpenCV version is '" CV_VERSION "'", plugin_api_->api_header.opencv_version_major, plugin_api_->api_header.opencv_version_minor))
+                plugin_api_ = NULL;
+                return;
+            }
+#ifdef HAVE_FFMPEG_WRAPPER
+            if (plugin_api_->captureAPI == CAP_FFMPEG)
+            {
+                // no checks for OpenCV minor version
+            }
+            else
+#endif
+            if (plugin_api_->api_header.opencv_version_minor != CV_VERSION_MINOR)
+            {
+                CV_LOG_ERROR(NULL, "Video I/O: wrong OpenCV minor version used by plugin '" << plugin_api_->api_header.api_description << "': " <<
                     cv::format("%d.%d, OpenCV version is '" CV_VERSION "'", plugin_api_->api_header.opencv_version_major, plugin_api_->api_header.opencv_version_minor))
                 plugin_api_ = NULL;
                 return;


### PR DESCRIPTION
Should fix messages like these:
> [ERROR:0] global C:\build\precommit_windows64\opencv\modules\videoio\src\backend_plugin.cpp (215) cv::impl::PluginBackend::PluginBackend
> Video I/O: wrong OpenCV version used by plugin 'FFmpeg OpenCV Video I/O plugin': 4.1, OpenCV version is '4.2.0-pre'

relates #16078 #15950