### PR TITLE
G-API: fix build with GCC 4.8

### DIFF
--- a/modules/gapi/src/backends/fluid/gfluidbuffer.cpp
+++ b/modules/gapi/src/backends/fluid/gfluidbuffer.cpp
@@ -347,12 +347,20 @@ std::unique_ptr<fluid::BufferStorage> createStorage(int capacity, int desc_width
         std::unique_ptr<fluid::BufferStorageWithBorder> storage(new BufferStorageWithBorder);
         storage->init(type, border_size, border.value());
         storage->create(capacity, desc_width, type);
+#if defined __GNUC__ && __GNUC__ < 5
+        return std::move(storage);
+#else
         return storage;
+#endif
     }
 
     std::unique_ptr<BufferStorageWithoutBorder> storage(new BufferStorageWithoutBorder);
     storage->create(capacity, desc_width, type);
+#if defined __GNUC__ && __GNUC__ < 5
+    return std::move(storage);
+#else
     return storage;
+#endif
 }
 
 std::unique_ptr<BufferStorage> createStorage(const cv::gapi::own::Mat& data, cv::gapi::own::Rect roi);
@@ -360,7 +368,11 @@ std::unique_ptr<BufferStorage> createStorage(const cv::gapi::own::Mat& data, cv:
 {
     std::unique_ptr<BufferStorageWithoutBorder> storage(new BufferStorageWithoutBorder);
     storage->attach(data, roi);
+#if defined __GNUC__ && __GNUC__ < 5
+    return std::move(storage);
+#else
     return storage;
+#endif
 }
 } // namespace
 } // namespace fluid


### PR DESCRIPTION
relates #16081
resolves #16133

Error message:

<cut/>

```
../opencv/modules/gapi/src/backends/fluid/gfluidbuffer.cpp: In function 'std::unique_ptr<cv::gapi::fluid::BufferStorage> cv::gapi::fluid::{anonymous}::createStorage(int, int, int, int, cv::gapi::fluid::BorderOpt)':
../opencv/modules/gapi/src/backends/fluid/gfluidbuffer.cpp:350:16: error: cannot bind 'std::unique_ptr<cv::gapi::fluid::BufferStorageWithBorder>' lvalue to 'std::unique_ptr<cv::gapi::fluid::BufferStorageWithBorder>&&'
         return storage;
                ^
In file included from /usr/include/c++/4.8.2/memory:81:0,
                 from ../opencv/modules/core/include/opencv2/core/cvstd_wrapper.hpp:11,
                 from ../opencv/modules/core/include/opencv2/core/cvstd.hpp:81,
                 from ../opencv/modules/core/include/opencv2/core/base.hpp:58,
                 from ../opencv/modules/core/include/opencv2/core.hpp:54,
                 from ../opencv/modules/gapi/src/precomp.hpp:12,
                 from ../opencv/modules/gapi/src/backends/fluid/gfluidbuffer.cpp:8:
/usr/include/c++/4.8.2/bits/unique_ptr.h:169:2: error:   initializing argument 1 of 'std::unique_ptr<_Tp, _Dp>::unique_ptr(std::unique_ptr<_Up, _Ep>&&) [with _Up = cv::gapi::fluid::BufferStorageWithBorder; _Ep = std::default_delete<cv::gapi::fluid::BufferStorageWithBorder>; <template-parameter-2-3> = void; _Tp = cv::gapi::fluid::BufferStorage; _Dp = std::default_delete<cv::gapi::fluid::BufferStorage>]'
  unique_ptr(unique_ptr<_Up, _Ep>&& __u) noexcept
  ^
../opencv/modules/gapi/src/backends/fluid/gfluidbuffer.cpp:355:12: error: cannot bind 'std::unique_ptr<cv::gapi::fluid::BufferStorageWithoutBorder>' lvalue to 'std::unique_ptr<cv::gapi::fluid::BufferStorageWithoutBorder>&&'
     return storage;
            ^
```