### PR TITLE
Eltwise::DIV support in Halide backend

### DIFF
--- a/modules/dnn/src/layers/eltwise_layer.cpp
+++ b/modules/dnn/src/layers/eltwise_layer.cpp
@@ -638,6 +638,12 @@ public:
                 for (int i = 2; i < inputBuffers.size(); ++i)
                     topExpr *= inputBuffers[i](x, y, c, n);
                 break;
+            case DIV:
+                topExpr = inputBuffers[0](x, y, c, n) /
+                          inputBuffers[1](x, y, c, n);
+                for (int i = 2; i < inputBuffers.size(); ++i)
+                    topExpr /= inputBuffers[i](x, y, c, n);
+                break;
             case MAX:
                 topExpr = max(inputBuffers[0](x, y, c, n),
                               inputBuffers[1](x, y, c, n));

--- a/modules/dnn/test/test_halide_layers.cpp
+++ b/modules/dnn/test/test_halide_layers.cpp
@@ -823,12 +823,25 @@ TEST_P(Eltwise, Accuracy)
 
     int sz[] = {1, inSize[0], inSize[1], inSize[2]};
     Mat input(4, &sz[0], CV_32F);
+    // ensure no divisor value has absouluate value of less than 0.5
+    if (op == "div") {
+        for (int i = 0; i < sz[0]; ++i) {
+            for (int j = 0; j < sz[1]; ++j) {
+                for (int k = 0; k < sz[2]; ++k) {
+                    for (int l = 0; l < sz[3]; ++l) {
+                        input.at<float>(i, j, k, l) = std::fabs(input.at<float>(i, j, k, l)) > 0.5 ?
+                                                        input.at<float>(i, j, k, l) : 0.55;
+                    }
+                }
+            }
+        }
+    }
     test(input, net, backendId, targetId);
 }
 
 INSTANTIATE_TEST_CASE_P(Layer_Test_Halide, Eltwise, Combine(
 /*input size*/ Values(Vec3i(1, 4, 5), Vec3i(2, 8, 6)),
-/*operation*/  Values("prod", "sum", "max"),
+/*operation*/  Values("prod", "sum", "div", "max"),
 /*num convs*/  Values(1, 2, 3),
 /*weighted(for sum only)*/ Bool(),
                dnnBackendsAndTargetsWithHalide()

--- a/modules/dnn/test/test_halide_layers.cpp
+++ b/modules/dnn/test/test_halide_layers.cpp
@@ -828,7 +828,7 @@ TEST_P(Eltwise, Accuracy)
 
 INSTANTIATE_TEST_CASE_P(Layer_Test_Halide, Eltwise, Combine(
 /*input size*/ Values(Vec3i(1, 4, 5), Vec3i(2, 8, 6)),
-/*operation*/  Values("prod", "sum", "max"),
+/*operation*/  Values("prod", "sum", "prod", "max"),
 /*num convs*/  Values(1, 2, 3),
 /*weighted(for sum only)*/ Bool(),
                dnnBackendsAndTargetsWithHalide()

--- a/modules/dnn/test/test_halide_layers.cpp
+++ b/modules/dnn/test/test_halide_layers.cpp
@@ -825,16 +825,7 @@ TEST_P(Eltwise, Accuracy)
     Mat input(4, &sz[0], CV_32F);
     // ensure no divisor value has absouluate value of less than 0.5
     if (op == "div") {
-        for (int i = 0; i < sz[0]; ++i) {
-            for (int j = 0; j < sz[1]; ++j) {
-                for (int k = 0; k < sz[2]; ++k) {
-                    for (int l = 0; l < sz[3]; ++l) {
-                        input.at<float>(i, j, k, l) = std::fabs(input.at<float>(i, j, k, l)) > 0.5 ?
-                                                        input.at<float>(i, j, k, l) : 0.55;
-                    }
-                }
-            }
-        }
+        randu(input, 0.55f, 1.5f);
     }
     test(input, net, backendId, targetId);
 }

--- a/modules/dnn/test/test_halide_layers.cpp
+++ b/modules/dnn/test/test_halide_layers.cpp
@@ -16,10 +16,11 @@ using namespace cv;
 using namespace cv::dnn;
 using namespace testing;
 
-static void test(Mat& input, Net& net, Backend backendId, Target targetId, bool skipCheck = false)
+static void test(Mat& input, Net& net, Backend backendId, Target targetId, bool skipCheck = false, bool randInput = true)
 {
     DNNTestLayer::checkBackend(backendId, targetId);
-    randu(input, -1.0f, 1.0f);
+    if (randInput)
+        randu(input, -1.0f, 1.0f);
 
     net.setInput(input);
     net.setPreferableBackend(DNN_BACKEND_OPENCV);
@@ -776,6 +777,14 @@ TEST_P(Eltwise, Accuracy)
         applyTestTag(CV_TEST_TAG_DNN_SKIP_IE_NGRAPH, CV_TEST_TAG_DNN_SKIP_IE_VERSION);
 #endif
 
+    bool convInputShift = 1;
+    int numEltwiseInputs = numConv;
+    if (op == "div")
+    {
+        numConv = 1;
+        convInputShift = 0; // first input is convolution
+    }
+
     Net net;
 
     std::vector<int> convLayerIds(numConv);
@@ -815,19 +824,24 @@ TEST_P(Eltwise, Accuracy)
     eltwiseParam.type = "Eltwise";
     eltwiseParam.name = "testLayer";
     int eltwiseId = net.addLayer(eltwiseParam.name, eltwiseParam.type, eltwiseParam);
-    net.connect(0, 0, eltwiseId, 0);
+    if (convInputShift == 1)
+        net.connect(0, 0, eltwiseId, 0);
     for (int i = 0; i < numConv; ++i)
     {
-        net.connect(convLayerIds[i], 0, eltwiseId, i + 1);
+        net.connect(convLayerIds[i], 0, eltwiseId, i + convInputShift);
+    }
+    if (convInputShift == 0)
+        net.connect(0, 0, eltwiseId, numConv);
+    for (int i = numConv; i < numEltwiseInputs; ++i)
+    {
+        net.connect(0, 0, eltwiseId, i + 1);
     }
 
     int sz[] = {1, inSize[0], inSize[1], inSize[2]};
     Mat input(4, &sz[0], CV_32F);
-    // ensure no divisor value has absouluate value of less than 0.5
-    if (op == "div") {
-        randu(input, 0.55f, 1.5f);
-    }
-    test(input, net, backendId, targetId);
+    if (op == "div")
+        randu(input, 1.0f, 1.0f);  // ensure no divisor value has absouluate value of less than 0.5
+    test(input, net, backendId, targetId, /*skipCheck*/false, (op == "div") ? false : true);
 }
 
 INSTANTIATE_TEST_CASE_P(Layer_Test_Halide, Eltwise, Combine(

--- a/modules/dnn/test/test_halide_layers.cpp
+++ b/modules/dnn/test/test_halide_layers.cpp
@@ -828,7 +828,7 @@ TEST_P(Eltwise, Accuracy)
 
 INSTANTIATE_TEST_CASE_P(Layer_Test_Halide, Eltwise, Combine(
 /*input size*/ Values(Vec3i(1, 4, 5), Vec3i(2, 8, 6)),
-/*operation*/  Values("prod", "sum", "prod", "max"),
+/*operation*/  Values("prod", "sum", "div", "max"),
 /*num convs*/  Values(1, 2, 3),
 /*weighted(for sum only)*/ Bool(),
                dnnBackendsAndTargetsWithHalide()

--- a/modules/dnn/test/test_halide_layers.cpp
+++ b/modules/dnn/test/test_halide_layers.cpp
@@ -828,7 +828,7 @@ TEST_P(Eltwise, Accuracy)
 
 INSTANTIATE_TEST_CASE_P(Layer_Test_Halide, Eltwise, Combine(
 /*input size*/ Values(Vec3i(1, 4, 5), Vec3i(2, 8, 6)),
-/*operation*/  Values("prod", "sum", "div", "max"),
+/*operation*/  Values("prod", "sum", "max"),
 /*num convs*/  Values(1, 2, 3),
 /*weighted(for sum only)*/ Bool(),
                dnnBackendsAndTargetsWithHalide()


### PR DESCRIPTION
resolves #15893

### This pullrequest changes

This PR adds Halide support for DNN::Eltwise::DIV


<cut/>

```
force_builders=Custom,docs
buildworker:Custom=linux-4
docker_image:Custom=halide:16.04
test_filter:Custom=*Halide*

build_image:Custom Mac=openvino-2019r3.0
build_image:Custom Win=openvino-2019r3.0
test_opencl:Custom Win=OFF
#build_image:Custom Win=msvs2017
#build_image:Custom Win=msvs2019
test_modules:Custom Mac=dnn,java,python3
```