### PR TITLE
cuda4dnn(concat): write outputs from previous layers directly into concat's output

### DIFF
--- a/modules/dnn/src/dnn.cpp
+++ b/modules/dnn/src/dnn.cpp
@@ -2450,7 +2450,9 @@ struct Net::Impl
                      ld.layerInstance->type != "Concat")) )
                     continue;
 
-                if (preferableBackend == DNN_BACKEND_CUDA && IS_DNN_CUDA_TARGET(preferableTarget) && ld.layerInstance->type != "Convolution")
+                if (preferableBackend == DNN_BACKEND_CUDA && IS_DNN_CUDA_TARGET(preferableTarget)
+                    && ld.layerInstance->type != "Convolution"
+                    && ld.layerInstance->type != "Concat")
                     continue;
 
                 while (nextData)

--- a/modules/dnn/src/dnn.cpp
+++ b/modules/dnn/src/dnn.cpp
@@ -2678,17 +2678,10 @@ struct Net::Impl
                             break;
 #ifdef HAVE_CUDA
                         if (preferableBackend == DNN_BACKEND_CUDA &&
-                            (inp_i_data->layerInstance->supportBackend(DNN_BACKEND_CUDA) == false || inp_i_data->layerInstance->type == "Region"))
+                            (inp_i_data->layerInstance->supportBackend(DNN_BACKEND_CUDA) == false ||
+                             (inp_i_data->layerInstance->type != "Convolution" &&
+                              inp_i_data->layerInstance->type != "Pooling")))
                         {
-                            /* If any of the inputs are computed on host, we cannot continue with the fusion because we
-                             * cannot store the dirty state information for each part of the of memory separately.
-                             *
-                             * Consider input_0 uses a CPU fallback and input_1 runs on GPU. After the CPU completes executing,
-                             * the output on the GPU will be overwritten (and hence input_1) by the contents of the host data.
-                             *
-                             * Region layer performs NMS on CPU. For the same reasons, we cannot eliminate concat if one of the
-                             * inputs comes from a region layer.
-                             */
                             break;
                         }
 #endif


### PR DESCRIPTION
### This pullrequest changes
- optimizes out concat layer by forcing the layers providing input to the concat to directly write to the corresponding section of concat's output

<cut/>

```
force_builders=Custom,docs
buildworker:Custom=linux-4
docker_image:Custom=ubuntu-cuda:16.04

build_image:Custom Mac=openvino-2019r3.0
build_image:Custom Win=openvino-2019r3.0
test_opencl:Custom Win=OFF
test_modules:Custom Mac=dnn,java,python3
```