### PR TITLE
[WIP] cuda4dnn(conv): fuse eltwise with convolutions

### DIFF
--- a/modules/dnn/include/opencv2/dnn/all_layers.hpp
+++ b/modules/dnn/include/opencv2/dnn/all_layers.hpp
@@ -518,6 +518,8 @@ CV__DNN_INLINE_NS_BEGIN
     class CV_EXPORTS EltwiseLayer : public Layer
     {
     public:
+        std::vector<float> coeffs;
+
         enum EltwiseOp
         {
             PROD = 0,

--- a/modules/dnn/include/opencv2/dnn/all_layers.hpp
+++ b/modules/dnn/include/opencv2/dnn/all_layers.hpp
@@ -518,6 +518,14 @@ CV__DNN_INLINE_NS_BEGIN
     class CV_EXPORTS EltwiseLayer : public Layer
     {
     public:
+        enum EltwiseOp
+        {
+            PROD = 0,
+            SUM = 1,
+            MAX = 2,
+            DIV = 3
+        } op;
+
         static Ptr<EltwiseLayer> create(const LayerParams &params);
     };
 

--- a/modules/dnn/src/cuda/activation_eltwise.cu
+++ b/modules/dnn/src/cuda/activation_eltwise.cu
@@ -1,0 +1,336 @@
+// This file is part of OpenCV project.
+// It is subject to the license terms in the LICENSE file found in the top-level directory
+// of this distribution and at http://opencv.org/license.html.
+
+#include <cuda_runtime.h>
+#include <cuda_fp16.h>
+
+#include "types.hpp"
+#include "math.hpp"
+#include "vector_traits.hpp"
+#include "grid_stride_range.hpp"
+#include "execution.hpp"
+
+#include "../cuda4dnn/csl/stream.hpp"
+#include "../cuda4dnn/csl/span.hpp"
+
+using namespace cv::dnn::cuda4dnn::csl;
+using namespace cv::dnn::cuda4dnn::csl::device;
+
+namespace cv { namespace dnn { namespace cuda4dnn { namespace kernels {
+
+namespace raw {
+
+    template <class T, std::size_t N>
+    __global__ void relu_eltwise_inplace_vec(Span<T> inplace_output, View<T> eltwise, T slope) {
+        using vector_type = get_vector_type_t<T, N>;
+
+        auto inplace_output_vPtr = vector_type::get_pointer(inplace_output.data());
+        auto eltwise_vPtr = vector_type::get_pointer(eltwise.data());
+
+        for (auto i : grid_stride_range(inplace_output.size() / vector_type::size())) {
+            vector_type output_vec, eltwise_vec;
+            v_load(output_vec, inplace_output_vPtr[i]);
+            v_load(eltwise_vec, eltwise_vPtr[i]);
+            for(int j = 0; j < output_vec.size(); j++) {
+                auto value = output_vec.data[j];
+                output_vec.data[j] = value >= T(0) ? value : slope * value;
+                output_vec.data[j] += eltwise_vec.data[j];
+            }
+            v_store(inplace_output_vPtr[i], output_vec);
+        }
+    }
+
+    template <class T, std::size_t N>
+    __global__ void clipped_relu_eltwise_inplace_vec(Span<T> inplace_output, View<T> eltwise, T floor, T ceil) {
+        using vector_type = get_vector_type_t<T, N>;
+
+        auto inplace_output_vPtr = vector_type::get_pointer(inplace_output.data());
+        auto eltwise_vPtr = vector_type::get_pointer(eltwise.data());
+
+        for (auto i : grid_stride_range(inplace_output.size() / vector_type::size())) {
+            vector_type output_vec, eltwise_vec;
+            v_load(output_vec, inplace_output_vPtr[i]);
+            v_load(eltwise_vec, eltwise_vPtr[i]);
+            for(int j = 0; j < output_vec.size(); j++) {
+                using device::clamp;
+                output_vec.data[j] = clamp(output_vec.data[j], floor, ceil);
+                output_vec.data[j] += eltwise_vec.data[j];
+            }
+            v_store(inplace_output_vPtr[i], output_vec);
+        }
+    }
+
+    template <class T, std::size_t N>
+    __global__ void power_eltwise_inplace_vec(Span<T> inplace_output, View<T> eltwise, T power) {
+        using vector_type = get_vector_type_t<T, N>;
+
+        auto inplace_output_vPtr = vector_type::get_pointer(inplace_output.data());
+        auto eltwise_vPtr = vector_type::get_pointer(eltwise.data());
+
+        for (auto i : grid_stride_range(inplace_output.size() / vector_type::size())) {
+            vector_type output_vec, eltwise_vec;
+            v_load(output_vec, inplace_output_vPtr[i]);
+            v_load(eltwise_vec, eltwise_vPtr[i]);
+            for(int j = 0; j < output_vec.size(); j++) {
+                using device::pow;
+                output_vec.data[j] = pow(output_vec.data[j], power);
+                output_vec.data[j] += eltwise_vec.data[j];
+            }
+            v_store(inplace_output_vPtr[i], output_vec);
+        }
+    }
+
+    template <class T, std::size_t N>
+    __global__ void tanh_eltwise_inplace_vec(Span<T> inplace_output, View<T> eltwise) {
+        using vector_type = get_vector_type_t<T, N>;
+
+        auto inplace_output_vPtr = vector_type::get_pointer(inplace_output.data());
+        auto eltwise_vPtr = vector_type::get_pointer(eltwise.data());
+
+        for (auto i : grid_stride_range(inplace_output.size() / vector_type::size())) {
+            vector_type output_vec, eltwise_vec;
+            v_load(output_vec, inplace_output_vPtr[i]);
+            v_load(eltwise_vec, eltwise_vPtr[i]);
+            for(int j = 0; j < output_vec.size(); j++) {
+                using device::tanh;
+                output_vec.data[j] = tanh(output_vec.data[j]);
+                output_vec.data[j] += eltwise_vec.data[j];
+            }
+            v_store(inplace_output_vPtr[i], output_vec);
+        }
+    }
+
+    template <class T, std::size_t N>
+    __global__ void sigmoid_eltwise_inplace_vec(Span<T> inplace_output, View<T> eltwise) {
+        using vector_type = get_vector_type_t<T, N>;
+
+        auto inplace_output_vPtr = vector_type::get_pointer(inplace_output.data());
+        auto eltwise_vPtr = vector_type::get_pointer(eltwise.data());
+
+        for (auto i : grid_stride_range(inplace_output.size() / vector_type::size())) {
+            vector_type output_vec, eltwise_vec;
+            v_load(output_vec, inplace_output_vPtr[i]);
+            v_load(eltwise_vec, eltwise_vPtr[i]);
+            for(int j = 0; j < output_vec.size(); j++) {
+                using device::sigmoid;
+                output_vec.data[j] = sigmoid(output_vec.data[j]);
+                output_vec.data[j] += eltwise_vec.data[j];
+            }
+            v_store(inplace_output_vPtr[i], output_vec);
+        }
+    }
+
+    template <class T, std::size_t N>
+    __global__ void swish_eltwise_inplace_vec(Span<T> inplace_output, View<T> eltwise) {
+        using vector_type = get_vector_type_t<T, N>;
+
+        auto inplace_output_vPtr = vector_type::get_pointer(inplace_output.data());
+        auto eltwise_vPtr = vector_type::get_pointer(eltwise.data());
+
+        for (auto i : grid_stride_range(inplace_output.size() / vector_type::size())) {
+            vector_type output_vec, eltwise_vec;
+            v_load(output_vec, inplace_output_vPtr[i]);
+            v_load(eltwise_vec, eltwise_vPtr[i]);
+            for(int j = 0; j < output_vec.size(); j++) {
+                using device::sigmoid;
+                auto value = output_vec.data[j];
+                output_vec.data[j] = value * sigmoid(value);
+                output_vec.data[j] += eltwise_vec.data[j];
+            }
+            v_store(inplace_output_vPtr[i], output_vec);
+        }
+    }
+
+    template <class T, std::size_t N>
+    __global__ void mish_eltwise_inplace_vec(Span<T> inplace_output, View<T> eltwise) {
+        using vector_type = get_vector_type_t<T, N>;
+
+        auto inplace_output_vPtr = vector_type::get_pointer(inplace_output.data());
+        auto eltwise_vPtr = vector_type::get_pointer(eltwise.data());
+
+        for (auto i : grid_stride_range(inplace_output.size() / vector_type::size())) {
+            vector_type output_vec, eltwise_vec;
+            v_load(output_vec, inplace_output_vPtr[i]);
+            v_load(eltwise_vec, eltwise_vPtr[i]);
+            for(int j = 0; j < output_vec.size(); j++) {
+                using device::tanh;
+                using device::log1pexp;
+                auto value = output_vec.data[j];
+                output_vec.data[j] = value * tanh(log1pexp(value));
+                output_vec.data[j] += eltwise_vec.data[j];
+            }
+            v_store(inplace_output_vPtr[i], output_vec);
+        }
+    }
+}
+
+template <class T, std::size_t N> static
+void launch_relu_eltwise_inplace_vec_kernel(const Stream& stream, Span<T> inplace_output, View<T> eltwise, T slope) {
+    CV_Assert(is_fully_aligned<T>(inplace_output, N));
+    CV_Assert(is_fully_aligned<T>(eltwise, N));
+
+    auto kernel = raw::relu_eltwise_inplace_vec<T, N>;
+    auto policy = make_policy(kernel, inplace_output.size() / N, 0, stream);
+    launch_kernel(kernel, policy, inplace_output, eltwise, slope);
+}
+
+template <class T>
+void relu_eltwise_inplace(const Stream& stream, Span<T> inplace_output, View<T> eltwise, T slope) {
+    if (is_fully_aligned<T>(inplace_output, 4) && is_fully_aligned<T>(eltwise, 4)) {
+        launch_relu_eltwise_inplace_vec_kernel<T, 4>(stream, inplace_output, eltwise, slope);
+    } else if (is_fully_aligned<T>(inplace_output, 2) && is_fully_aligned<T>(eltwise, 2)) {
+        launch_relu_eltwise_inplace_vec_kernel<T, 2>(stream, inplace_output, eltwise, slope);
+    } else {
+        launch_relu_eltwise_inplace_vec_kernel<T, 1>(stream, inplace_output, eltwise, slope);
+    }
+}
+
+template void relu_eltwise_inplace<__half>(const Stream&, Span<__half>, View<__half>, __half);
+template void relu_eltwise_inplace<float>(const Stream&, Span<float>, View<float>, float);
+
+template <class T, std::size_t N> static
+void launch_clipped_relu_eltwise_inplace_vec_kernel(const Stream& stream, Span<T> inplace_output, View<T> eltwise, T floor, T ceil){
+    CV_Assert(is_fully_aligned<T>(inplace_output, N));
+    CV_Assert(is_fully_aligned<T>(eltwise, N));
+
+    auto kernel = raw::clipped_relu_eltwise_inplace_vec<T, N>;
+    auto policy = make_policy(kernel, inplace_output.size() / N, 0, stream);
+    launch_kernel(kernel, policy, inplace_output, eltwise, floor, ceil);
+}
+
+template <class T>
+void clipped_relu_eltwise_inplace(const Stream& stream, Span<T> inplace_output, View<T> eltwise, T floor, T ceil) {
+    if (is_fully_aligned<T>(inplace_output, 4) && is_fully_aligned<T>(eltwise, 4)) {
+        launch_clipped_relu_eltwise_inplace_vec_kernel<T, 4>(stream, inplace_output, eltwise, floor, ceil);
+    } else if (is_fully_aligned<T>(inplace_output, 2) && is_fully_aligned<T>(eltwise, 2)) {
+        launch_clipped_relu_eltwise_inplace_vec_kernel<T, 2>(stream, inplace_output, eltwise, floor, ceil);
+    } else {
+        launch_clipped_relu_eltwise_inplace_vec_kernel<T, 1>(stream, inplace_output, eltwise, floor, ceil);
+    }
+}
+
+template void clipped_relu_eltwise_inplace<__half>(const Stream&, Span<__half>, View<__half>, __half, __half);
+template void clipped_relu_eltwise_inplace<float>(const Stream&, Span<float>, View<float>,  float, float);
+
+template <class T, std::size_t N> static
+void launch_power_eltwise_inplace_vec_kernel(const Stream& stream, Span<T> inplace_output, View<T> eltwise, T power) {
+    CV_Assert(is_fully_aligned<T>(inplace_output, N));
+    CV_Assert(is_fully_aligned<T>(eltwise, N));
+
+    auto kernel = raw::power_eltwise_inplace_vec<T, N>;
+    auto policy = make_policy(kernel, inplace_output.size() / N, 0, stream);
+    launch_kernel(kernel, policy, inplace_output, eltwise, power);
+}
+
+template <class T>
+void power_eltwise_inplace(const Stream& stream, Span<T> inplace_output, View<T> eltwise, T power) {
+    if (is_fully_aligned<T>(inplace_output, 4) && is_fully_aligned<T>(eltwise, 4)) {
+        launch_power_eltwise_inplace_vec_kernel<T, 4>(stream, inplace_output, eltwise, power);
+    } else if (is_fully_aligned<T>(inplace_output, 2) && is_fully_aligned<T>(eltwise, 2)) {
+        launch_power_eltwise_inplace_vec_kernel<T, 2>(stream, inplace_output, eltwise, power);
+    } else {
+        launch_power_eltwise_inplace_vec_kernel<T, 1>(stream, inplace_output, eltwise, power);
+    }
+}
+
+template void power_eltwise_inplace<__half>(const Stream&, Span<__half>, View<__half>, __half);
+template void power_eltwise_inplace<float>(const Stream&, Span<float>, View<float>, float);
+
+template <class T, std::size_t N> static
+void launch_tanh_eltwise_inplace_vec_kernel(const Stream& stream, Span<T> inplace_output, View<T> eltwise) {
+    CV_Assert(is_fully_aligned<T>(inplace_output, N));
+    CV_Assert(is_fully_aligned<T>(eltwise, N));
+
+    auto kernel = raw::tanh_eltwise_inplace_vec<T, N>;
+    auto policy = make_policy(kernel, inplace_output.size() / N, 0, stream);
+    launch_kernel(kernel, policy, inplace_output, eltwise);
+}
+
+template <class T>
+void tanh_eltwise_inplace(const Stream& stream, Span<T> inplace_output, View<T> eltwise) {
+    if (is_fully_aligned<T>(inplace_output, 4) && is_fully_aligned<T>(eltwise, 4)) {
+        launch_tanh_eltwise_inplace_vec_kernel<T, 4>(stream, inplace_output, eltwise);
+    } else if (is_fully_aligned<T>(inplace_output, 2) && is_fully_aligned<T>(eltwise, 2)) {
+        launch_tanh_eltwise_inplace_vec_kernel<T, 2>(stream, inplace_output, eltwise);
+    } else {
+        launch_tanh_eltwise_inplace_vec_kernel<T, 1>(stream, inplace_output, eltwise);
+    }
+}
+
+template void tanh_eltwise_inplace<__half>(const Stream&, Span<__half>, View<__half>);
+template void tanh_eltwise_inplace<float>(const Stream&, Span<float>, View<float>);
+
+template <class T, std::size_t N> static
+void launch_sigmoid_eltwise_inplace_vec_kernel(const Stream& stream, Span<T> inplace_output, View<T> eltwise) {
+    CV_Assert(is_fully_aligned<T>(inplace_output, N));
+    CV_Assert(is_fully_aligned<T>(eltwise, N));
+
+    auto kernel = raw::sigmoid_eltwise_inplace_vec<T, N>;
+    auto policy = make_policy(kernel, inplace_output.size() / N, 0, stream);
+    launch_kernel(kernel, policy, inplace_output, eltwise);
+}
+
+template <class T>
+void sigmoid_eltwise_inplace(const Stream& stream, Span<T> inplace_output, View<T> eltwise) {
+    if (is_fully_aligned<T>(inplace_output, 4) && is_fully_aligned<T>(eltwise, 4)) {
+        launch_sigmoid_eltwise_inplace_vec_kernel<T, 4>(stream, inplace_output, eltwise);
+    } else if (is_fully_aligned<T>(inplace_output, 2) && is_fully_aligned<T>(eltwise, 2)) {
+        launch_sigmoid_eltwise_inplace_vec_kernel<T, 2>(stream, inplace_output, eltwise);
+    } else {
+        launch_sigmoid_eltwise_inplace_vec_kernel<T, 1>(stream, inplace_output, eltwise);
+    }
+}
+
+template void sigmoid_eltwise_inplace<__half>(const Stream&, Span<__half>, View<__half>);
+template void sigmoid_eltwise_inplace<float>(const Stream&, Span<float>, View<float>);
+
+template <class T, std::size_t N> static
+void launch_swish_eltwise_inplace_vec_kernel(const Stream& stream, Span<T> inplace_output, View<T> eltwise) {
+    CV_Assert(is_fully_aligned<T>(inplace_output, N));
+    CV_Assert(is_fully_aligned<T>(eltwise, N));
+
+    auto kernel = raw::swish_eltwise_inplace_vec<T, N>;
+    auto policy = make_policy(kernel, inplace_output.size() / N, 0, stream);
+    launch_kernel(kernel, policy, inplace_output, eltwise);
+}
+
+template <class T>
+void swish_eltwise_inplace(const Stream& stream, Span<T> inplace_output, View<T> eltwise) {
+    if (is_fully_aligned<T>(inplace_output, 4) && is_fully_aligned<T>(eltwise, 4)) {
+        launch_swish_eltwise_inplace_vec_kernel<T, 4>(stream, inplace_output, eltwise);
+    } else if (is_fully_aligned<T>(inplace_output, 2) && is_fully_aligned<T>(eltwise, 2)) {
+        launch_swish_eltwise_inplace_vec_kernel<T, 2>(stream, inplace_output, eltwise);
+    } else {
+        launch_swish_eltwise_inplace_vec_kernel<T, 1>(stream, inplace_output, eltwise);
+    }
+}
+
+template void swish_eltwise_inplace<__half>(const Stream&, Span<__half>, View<__half>);
+template void swish_eltwise_inplace<float>(const Stream&, Span<float>, View<float>);
+
+template <class T, std::size_t N> static
+void launch_mish_eltwise_inplace_vec_kernel(const Stream& stream, Span<T> inplace_output, View<T> eltwise) {
+    CV_Assert(is_fully_aligned<T>(inplace_output, N));
+    CV_Assert(is_fully_aligned<T>(eltwise, N));
+
+    auto kernel = raw::mish_eltwise_inplace_vec<T, N>;
+    auto policy = make_policy(kernel, inplace_output.size() / N, 0, stream);
+    launch_kernel(kernel, policy, inplace_output, eltwise);
+}
+
+template <class T>
+void mish_eltwise_inplace(const Stream& stream, Span<T> inplace_output, View<T> eltwise) {
+    if (is_fully_aligned<T>(inplace_output, 4) && is_fully_aligned<T>(eltwise, 4)) {
+        launch_mish_eltwise_inplace_vec_kernel<T, 4>(stream, inplace_output, eltwise);
+    } else if (is_fully_aligned<T>(inplace_output, 2) && is_fully_aligned<T>(eltwise, 2)) {
+        launch_mish_eltwise_inplace_vec_kernel<T, 2>(stream, inplace_output, eltwise);
+    } else {
+        launch_mish_eltwise_inplace_vec_kernel<T, 1>(stream, inplace_output, eltwise);
+    }
+}
+
+template void mish_eltwise_inplace<__half>(const Stream&, Span<__half>, View<__half>);
+template void mish_eltwise_inplace<float>(const Stream&, Span<float>, View<float>);
+
+}}}} /* namespace cv::dnn::cuda4dnn::kernels */

--- a/modules/dnn/src/cuda/bias_activation_eltwise.cu
+++ b/modules/dnn/src/cuda/bias_activation_eltwise.cu
@@ -1,0 +1,365 @@
+// This file is part of OpenCV project.
+// It is subject to the license terms in the LICENSE file found in the top-level directory
+// of this distribution and at http://opencv.org/license.html.
+
+#include <cuda_runtime.h>
+#include <cuda_fp16.h>
+
+#include "types.hpp"
+#include "math.hpp"
+#include "vector_traits.hpp"
+#include "grid_stride_range.hpp"
+#include "execution.hpp"
+
+#include "../cuda4dnn/csl/stream.hpp"
+#include "../cuda4dnn/csl/span.hpp"
+
+using namespace cv::dnn::cuda4dnn::csl;
+using namespace cv::dnn::cuda4dnn::csl::device;
+
+namespace cv { namespace dnn { namespace cuda4dnn { namespace kernels {
+
+namespace raw {
+
+    template <class T, std::size_t N>
+    __global__ void biasN_relu_eltwise_inplace_vec(Span<T> inplace_output, size_type inner_size, View<T> bias, View<T> eltwise, T slope) {
+        using vector_type = get_vector_type_t<T, N>;
+
+        auto inplace_output_vPtr = vector_type::get_pointer(inplace_output.data());
+        auto eltwise_vPtr = vector_type::get_pointer(eltwise.data());
+
+        inner_size /= vector_type::size();
+        for (auto i : grid_stride_range(inplace_output.size() / vector_type::size())) {
+            const index_type bias_idx = (i / inner_size) % static_cast<size_type>(bias.size());
+
+            vector_type output_vec, eltwise_vec;
+            v_load(output_vec, inplace_output_vPtr[i]);
+            v_load(eltwise_vec, eltwise_vPtr[i]);
+            for(int j = 0; j < output_vec.size(); j++) {
+                auto value = output_vec.data[j] + bias[bias_idx];
+                value = value >= T(0) ? value : slope * value;
+                value += eltwise_vec.data[j];
+                output_vec.data[j] = value;
+            }
+            v_store(inplace_output_vPtr[i], output_vec);
+        }
+    }
+
+    template <class T, std::size_t N>
+    __global__ void biasN_clipped_relu_eltwise_inplace_vec(Span<T> inplace_output, size_type inner_size, View<T> bias, View<T> eltwise, T floor, T ceil) {
+        using vector_type = get_vector_type_t<T, N>;
+
+        auto inplace_output_vPtr = vector_type::get_pointer(inplace_output.data());
+        auto eltwise_vPtr = vector_type::get_pointer(eltwise.data());
+
+        inner_size /= vector_type::size();
+        for (auto i : grid_stride_range(inplace_output.size() / vector_type::size())) {
+            const index_type bias_idx = (i / inner_size) % static_cast<size_type>(bias.size());
+
+            vector_type output_vec, eltwise_vec;
+            v_load(output_vec, inplace_output_vPtr[i]);
+            v_load(eltwise_vec, eltwise_vPtr[i]);
+            for(int j = 0; j < output_vec.size(); j++) {
+                using device::clamp;
+                output_vec.data[j] = clamp(output_vec.data[j] + bias[bias_idx], floor, ceil);
+                output_vec.data[j] += eltwise_vec.data[j];
+            }
+            v_store(inplace_output_vPtr[i], output_vec);
+        }
+    }
+
+    template <class T, std::size_t N>
+    __global__ void biasN_power_eltwise_inplace_vec(Span<T> inplace_output, size_type inner_size, View<T> bias, View<T> eltwise, T power) {
+        using vector_type = get_vector_type_t<T, N>;
+
+        auto inplace_output_vPtr = vector_type::get_pointer(inplace_output.data());
+        auto eltwise_vPtr = vector_type::get_pointer(eltwise.data());
+
+        inner_size /= vector_type::size();
+        for (auto i : grid_stride_range(inplace_output.size() / vector_type::size())) {
+            const index_type bias_idx = (i / inner_size) % static_cast<size_type>(bias.size());
+
+            vector_type output_vec, eltwise_vec;
+            v_load(output_vec, inplace_output_vPtr[i]);
+            v_load(eltwise_vec, eltwise_vPtr[i]);
+            for(int j = 0; j < output_vec.size(); j++) {
+                using device::pow;
+                output_vec.data[j] = pow(output_vec.data[j] + bias[bias_idx], power);
+                output_vec.data[j] += eltwise_vec.data[j];
+            }
+            v_store(inplace_output_vPtr[i], output_vec);
+        }
+    }
+
+    template <class T, std::size_t N>
+    __global__ void biasN_tanh_eltwise_inplace_vec(Span<T> inplace_output, size_type inner_size, View<T> bias, View<T> eltwise) {
+        using vector_type = get_vector_type_t<T, N>;
+
+        auto inplace_output_vPtr = vector_type::get_pointer(inplace_output.data());
+        auto eltwise_vPtr = vector_type::get_pointer(eltwise.data());
+
+        inner_size /= vector_type::size();
+        for (auto i : grid_stride_range(inplace_output.size() / vector_type::size())) {
+            const index_type bias_idx = (i / inner_size) % static_cast<size_type>(bias.size());
+
+            vector_type output_vec, eltwise_vec;
+            v_load(output_vec, inplace_output_vPtr[i]);
+            v_load(eltwise_vec, eltwise_vPtr[i]);
+            for(int j = 0; j < output_vec.size(); j++) {
+                using device::tanh;
+                output_vec.data[j] = tanh(output_vec.data[j] + bias[bias_idx]);
+                output_vec.data[j] += eltwise_vec.data[j];
+            }
+            v_store(inplace_output_vPtr[i], output_vec);
+        }
+    }
+
+    template <class T, std::size_t N>
+    __global__ void biasN_sigmoid_eltwise_inplace_vec(Span<T> inplace_output, size_type inner_size, View<T> bias, View<T> eltwise) {
+        using vector_type = get_vector_type_t<T, N>;
+
+        auto inplace_output_vPtr = vector_type::get_pointer(inplace_output.data());
+        auto eltwise_vPtr = vector_type::get_pointer(eltwise.data());
+
+        inner_size /= vector_type::size();
+        for (auto i : grid_stride_range(inplace_output.size() / vector_type::size())) {
+            const index_type bias_idx = (i / inner_size) % static_cast<size_type>(bias.size());
+
+            vector_type output_vec, eltwise_vec;
+            v_load(output_vec, inplace_output_vPtr[i]);
+            v_load(eltwise_vec, eltwise_vPtr[i]);
+            for(int j = 0; j < output_vec.size(); j++) {
+                using device::sigmoid;
+                output_vec.data[j] = sigmoid(output_vec.data[j] + bias[bias_idx]);
+                output_vec.data[j] += eltwise_vec.data[j];
+            }
+            v_store(inplace_output_vPtr[i], output_vec);
+        }
+    }
+
+    template <class T, std::size_t N>
+    __global__ void biasN_swish_eltwise_inplace_vec(Span<T> inplace_output, size_type inner_size, View<T> bias, View<T> eltwise) {
+        using vector_type = get_vector_type_t<T, N>;
+
+        auto inplace_output_vPtr = vector_type::get_pointer(inplace_output.data());
+        auto eltwise_vPtr = vector_type::get_pointer(eltwise.data());
+
+        inner_size /= vector_type::size();
+        for (auto i : grid_stride_range(inplace_output.size() / vector_type::size())) {
+            const index_type bias_idx = (i / inner_size) % static_cast<size_type>(bias.size());
+
+            vector_type output_vec, eltwise_vec;
+            v_load(output_vec, inplace_output_vPtr[i]);
+            v_load(eltwise_vec, eltwise_vPtr[i]);
+            for(int j = 0; j < output_vec.size(); j++) {
+                using device::sigmoid;
+                auto value = output_vec.data[j] + bias[bias_idx];
+                output_vec.data[j] = value * sigmoid(value);
+                output_vec.data[j] += eltwise_vec.data[j];
+            }
+            v_store(inplace_output_vPtr[i], output_vec);
+        }
+    }
+
+    template <class T, std::size_t N>
+    __global__ void biasN_mish_eltwise_inplace_vec(Span<T> inplace_output, size_type inner_size, View<T> bias, View<T> eltwise) {
+        using vector_type = get_vector_type_t<T, N>;
+
+        auto inplace_output_vPtr = vector_type::get_pointer(inplace_output.data());
+        auto eltwise_vPtr = vector_type::get_pointer(eltwise.data());
+
+        inner_size /= vector_type::size();
+        for (auto i : grid_stride_range(inplace_output.size() / vector_type::size())) {
+            const index_type bias_idx = (i / inner_size) % static_cast<size_type>(bias.size());
+
+            vector_type output_vec, eltwise_vec;
+            v_load(output_vec, inplace_output_vPtr[i]);
+            v_load(eltwise_vec, eltwise_vPtr[i]);
+            for(int j = 0; j < output_vec.size(); j++) {
+                using device::tanh;
+                using device::log1pexp;
+                auto value = output_vec.data[j] + bias[bias_idx];
+                output_vec.data[j] = value * tanh(log1pexp(value));
+                output_vec.data[j] += eltwise_vec.data[j];
+            }
+            v_store(inplace_output_vPtr[i], output_vec);
+        }
+    }
+}
+
+template <class T, std::size_t N> static
+void launch_biasN_relu_eltwise_inplace_vec_kernel(const Stream& stream, Span<T> inplace_output, std::size_t inner_size, View<T> bias, View<T> eltwise, T slope) {
+    CV_Assert(is_fully_aligned<T>(inplace_output, N));
+    CV_Assert(is_fully_aligned<T>(eltwise, N));
+    CV_Assert(inner_size % N == 0);
+
+    auto kernel = raw::biasN_relu_eltwise_inplace_vec<T, N>;
+    auto policy = make_policy(kernel, inplace_output.size() / N, 0, stream);
+    launch_kernel(kernel, policy, inplace_output, inner_size, bias, eltwise, slope);
+}
+
+template <class T>
+void biasN_relu_eltwise_inplace(const Stream& stream, Span<T> inplace_output, std::size_t inner_size, View<T> bias, View<T> eltwise, T slope) {
+    if (is_fully_aligned<T>(inplace_output, 4) && is_fully_aligned<T>(eltwise, 4) && inner_size % 4 == 0) {
+        launch_biasN_relu_eltwise_inplace_vec_kernel<T, 4>(stream, inplace_output, inner_size, bias, eltwise, slope);
+    } else if (is_fully_aligned<T>(inplace_output, 2) && is_fully_aligned<T>(eltwise, 2) && inner_size % 2 == 0) {
+        launch_biasN_relu_eltwise_inplace_vec_kernel<T, 2>(stream, inplace_output, inner_size, bias, eltwise, slope);
+    } else {
+        launch_biasN_relu_eltwise_inplace_vec_kernel<T, 1>(stream, inplace_output, inner_size, bias, eltwise, slope);
+    }
+}
+
+template void biasN_relu_eltwise_inplace<__half>(const Stream&, Span<__half>, std::size_t, View<__half>, View<__half>, __half);
+template void biasN_relu_eltwise_inplace<float>(const Stream&, Span<float>, std::size_t, View<float>, View<float>, float);
+
+template <class T, std::size_t N> static
+void launch_biasN_clipped_relu_eltwise_inplace_vec_kernel(const Stream& stream, Span<T> inplace_output, std::size_t inner_size, View<T> bias, View<T> eltwise, T floor, T ceil){
+    CV_Assert(is_fully_aligned<T>(inplace_output, N));
+    CV_Assert(is_fully_aligned<T>(eltwise, N));
+    CV_Assert(inner_size % N == 0);
+
+    auto kernel = raw::biasN_clipped_relu_eltwise_inplace_vec<T, N>;
+    auto policy = make_policy(kernel, inplace_output.size() / N, 0, stream);
+    launch_kernel(kernel, policy, inplace_output, inner_size, bias, eltwise, floor, ceil);
+}
+
+template <class T>
+void biasN_clipped_relu_eltwise_inplace(const Stream& stream, Span<T> inplace_output, std::size_t inner_size, View<T> bias, View<T> eltwise, T floor, T ceil) {
+    if (is_fully_aligned<T>(inplace_output, 4) && is_fully_aligned<T>(eltwise, 4) && inner_size % 4 == 0) {
+        launch_biasN_clipped_relu_eltwise_inplace_vec_kernel<T, 4>(stream, inplace_output, inner_size, bias, eltwise, floor, ceil);
+    } else if (is_fully_aligned<T>(inplace_output, 2) && is_fully_aligned<T>(eltwise, 2) && inner_size % 2 == 0) {
+        launch_biasN_clipped_relu_eltwise_inplace_vec_kernel<T, 2>(stream, inplace_output, inner_size, bias, eltwise, floor, ceil);
+    } else {
+        launch_biasN_clipped_relu_eltwise_inplace_vec_kernel<T, 1>(stream, inplace_output, inner_size, bias, eltwise, floor, ceil);
+    }
+}
+
+template void biasN_clipped_relu_eltwise_inplace<__half>(const Stream&, Span<__half>, std::size_t, View<__half>, View<__half>, __half, __half);
+template void biasN_clipped_relu_eltwise_inplace<float>(const Stream&, Span<float>, std::size_t, View<float>, View<float>,  float, float);
+
+template <class T, std::size_t N> static
+void launch_biasN_power_eltwise_inplace_vec_kernel(const Stream& stream, Span<T> inplace_output, std::size_t inner_size, View<T> bias, View<T> eltwise, T power){
+    CV_Assert(is_fully_aligned<T>(inplace_output, N));
+    CV_Assert(is_fully_aligned<T>(eltwise, N));
+    CV_Assert(inner_size % N == 0);
+
+    auto kernel = raw::biasN_power_eltwise_inplace_vec<T, N>;
+    auto policy = make_policy(kernel, inplace_output.size() / N, 0, stream);
+    launch_kernel(kernel, policy, inplace_output, inner_size, bias, eltwise, power);
+}
+
+template <class T>
+void biasN_power_eltwise_inplace(const Stream& stream, Span<T> inplace_output, std::size_t inner_size, View<T> bias, View<T> eltwise, T power) {
+    if (is_fully_aligned<T>(inplace_output, 4) && is_fully_aligned<T>(eltwise, 4) && inner_size % 4 == 0) {
+        launch_biasN_power_eltwise_inplace_vec_kernel<T, 4>(stream, inplace_output, inner_size, bias, eltwise, power);
+    } else if (is_fully_aligned<T>(inplace_output, 2) && is_fully_aligned<T>(eltwise, 2) && inner_size % 2 == 0) {
+        launch_biasN_power_eltwise_inplace_vec_kernel<T, 2>(stream, inplace_output, inner_size, bias, eltwise, power);
+    } else {
+        launch_biasN_power_eltwise_inplace_vec_kernel<T, 1>(stream, inplace_output, inner_size, bias, eltwise, power);
+    }
+}
+
+template void biasN_power_eltwise_inplace<__half>(const Stream&, Span<__half>, std::size_t, View<__half>, View<__half>, __half);
+template void biasN_power_eltwise_inplace<float>(const Stream&, Span<float>, std::size_t, View<float>, View<float>, float);
+
+template <class T, std::size_t N> static
+void launch_biasN_tanh_eltwise_inplace_vec_kernel(const Stream& stream, Span<T> inplace_output, std::size_t inner_size, View<T> bias, View<T> eltwise) {
+    CV_Assert(is_fully_aligned<T>(inplace_output, N));
+    CV_Assert(is_fully_aligned<T>(eltwise, N));
+    CV_Assert(inner_size % N == 0);
+
+    auto kernel = raw::biasN_tanh_eltwise_inplace_vec<T, N>;
+    auto policy = make_policy(kernel, inplace_output.size() / N, 0, stream);
+    launch_kernel(kernel, policy, inplace_output, inner_size, bias, eltwise);
+}
+
+template <class T>
+void biasN_tanh_eltwise_inplace(const Stream& stream, Span<T> inplace_output, std::size_t inner_size, View<T> bias, View<T> eltwise) {
+    if (is_fully_aligned<T>(inplace_output, 4) && is_fully_aligned<T>(eltwise, 4) && inner_size % 4 == 0) {
+        launch_biasN_tanh_eltwise_inplace_vec_kernel<T, 4>(stream, inplace_output, inner_size, bias, eltwise);
+    } else if (is_fully_aligned<T>(inplace_output, 2) && is_fully_aligned<T>(eltwise, 2) && inner_size % 2 == 0) {
+        launch_biasN_tanh_eltwise_inplace_vec_kernel<T, 2>(stream, inplace_output, inner_size, bias, eltwise);
+    } else {
+        launch_biasN_tanh_eltwise_inplace_vec_kernel<T, 1>(stream, inplace_output, inner_size, bias, eltwise);
+    }
+}
+
+template void biasN_tanh_eltwise_inplace<__half>(const Stream&, Span<__half>, std::size_t, View<__half>, View<__half>);
+template void biasN_tanh_eltwise_inplace<float>(const Stream&, Span<float>, std::size_t, View<float>, View<float>);
+
+template <class T, std::size_t N> static
+void launch_biasN_sigmoid_eltwise_inplace_vec_kernel(const Stream& stream, Span<T> inplace_output, std::size_t inner_size, View<T> bias, View<T> eltwise) {
+    CV_Assert(is_fully_aligned<T>(inplace_output, N));
+    CV_Assert(is_fully_aligned<T>(eltwise, N));
+    CV_Assert(inner_size % N == 0);
+
+    auto kernel = raw::biasN_sigmoid_eltwise_inplace_vec<T, N>;
+    auto policy = make_policy(kernel, inplace_output.size() / N, 0, stream);
+    launch_kernel(kernel, policy, inplace_output, inner_size, bias, eltwise);
+}
+
+template <class T>
+void biasN_sigmoid_eltwise_inplace(const Stream& stream, Span<T> inplace_output, std::size_t inner_size, View<T> bias, View<T> eltwise) {
+    if (is_fully_aligned<T>(inplace_output, 4) && is_fully_aligned<T>(eltwise, 4) && inner_size % 4 == 0) {
+        launch_biasN_sigmoid_eltwise_inplace_vec_kernel<T, 4>(stream, inplace_output, inner_size, bias, eltwise);
+    } else if (is_fully_aligned<T>(inplace_output, 2) && is_fully_aligned<T>(eltwise, 2) && inner_size % 2 == 0) {
+        launch_biasN_sigmoid_eltwise_inplace_vec_kernel<T, 2>(stream, inplace_output, inner_size, bias, eltwise);
+    } else {
+        launch_biasN_sigmoid_eltwise_inplace_vec_kernel<T, 1>(stream, inplace_output, inner_size, bias, eltwise);
+    }
+}
+
+template void biasN_sigmoid_eltwise_inplace<__half>(const Stream&, Span<__half>, std::size_t, View<__half>, View<__half>);
+template void biasN_sigmoid_eltwise_inplace<float>(const Stream&, Span<float>, std::size_t, View<float>, View<float>);
+
+template <class T, std::size_t N> static
+void launch_biasN_swish_eltwise_inplace_vec_kernel(const Stream& stream, Span<T> inplace_output, std::size_t inner_size, View<T> bias, View<T> eltwise) {
+    CV_Assert(is_fully_aligned<T>(inplace_output, N));
+    CV_Assert(is_fully_aligned<T>(eltwise, N));
+    CV_Assert(inner_size % N == 0);
+
+    auto kernel = raw::biasN_swish_eltwise_inplace_vec<T, N>;
+    auto policy = make_policy(kernel, inplace_output.size() / N, 0, stream);
+    launch_kernel(kernel, policy, inplace_output, inner_size, bias, eltwise);
+}
+
+template <class T>
+void biasN_swish_eltwise_inplace(const Stream& stream, Span<T> inplace_output, std::size_t inner_size, View<T> bias, View<T> eltwise) {
+    if (is_fully_aligned<T>(inplace_output, 4) && is_fully_aligned<T>(eltwise, 4) && inner_size % 4 == 0) {
+        launch_biasN_swish_eltwise_inplace_vec_kernel<T, 4>(stream, inplace_output, inner_size, bias, eltwise);
+    } else if (is_fully_aligned<T>(inplace_output, 2) && is_fully_aligned<T>(eltwise, 2) && inner_size % 2 == 0) {
+        launch_biasN_swish_eltwise_inplace_vec_kernel<T, 2>(stream, inplace_output, inner_size, bias, eltwise);
+    } else {
+        launch_biasN_swish_eltwise_inplace_vec_kernel<T, 1>(stream, inplace_output, inner_size, bias, eltwise);
+    }
+}
+
+template void biasN_swish_eltwise_inplace<__half>(const Stream&, Span<__half>, std::size_t, View<__half>, View<__half>);
+template void biasN_swish_eltwise_inplace<float>(const Stream&, Span<float>, std::size_t, View<float>, View<float>);
+
+template <class T, std::size_t N> static
+void launch_biasN_mish_eltwise_inplace_vec_kernel(const Stream& stream, Span<T> inplace_output, std::size_t inner_size, View<T> bias, View<T> eltwise) {
+    CV_Assert(is_fully_aligned<T>(inplace_output, N));
+    CV_Assert(is_fully_aligned<T>(eltwise, N));
+    CV_Assert(inner_size % N == 0);
+
+    auto kernel = raw::biasN_mish_eltwise_inplace_vec<T, N>;
+    auto policy = make_policy(kernel, inplace_output.size() / N, 0, stream);
+    launch_kernel(kernel, policy, inplace_output, inner_size, bias, eltwise);
+}
+
+template <class T>
+void biasN_mish_eltwise_inplace(const Stream& stream, Span<T> inplace_output, std::size_t inner_size, View<T> bias, View<T> eltwise) {
+    if (is_fully_aligned<T>(inplace_output, 4) && is_fully_aligned<T>(eltwise, 4) && inner_size % 4 == 0) {
+        launch_biasN_mish_eltwise_inplace_vec_kernel<T, 4>(stream, inplace_output, inner_size, bias, eltwise);
+    } else if (is_fully_aligned<T>(inplace_output, 2) && is_fully_aligned<T>(eltwise, 2) && inner_size % 2 == 0) {
+        launch_biasN_mish_eltwise_inplace_vec_kernel<T, 2>(stream, inplace_output, inner_size, bias, eltwise);
+    } else {
+        launch_biasN_mish_eltwise_inplace_vec_kernel<T, 1>(stream, inplace_output, inner_size, bias, eltwise);
+    }
+}
+
+template void biasN_mish_eltwise_inplace<__half>(const Stream&, Span<__half>, std::size_t, View<__half>, View<__half>);
+template void biasN_mish_eltwise_inplace<float>(const Stream&, Span<float>, std::size_t, View<float>, View<float>);
+
+}}}} /* namespace cv::dnn::cuda4dnn::kernels */

--- a/modules/dnn/src/cuda/bias_eltwise_activation.cu
+++ b/modules/dnn/src/cuda/bias_eltwise_activation.cu
@@ -1,0 +1,401 @@
+// This file is part of OpenCV project.
+// It is subject to the license terms in the LICENSE file found in the top-level directory
+// of this distribution and at http://opencv.org/license.html.
+
+#include <cuda_runtime.h>
+#include <cuda_fp16.h>
+
+#include "types.hpp"
+#include "math.hpp"
+#include "vector_traits.hpp"
+#include "grid_stride_range.hpp"
+#include "execution.hpp"
+
+#include "../cuda4dnn/csl/stream.hpp"
+#include "../cuda4dnn/csl/span.hpp"
+
+using namespace cv::dnn::cuda4dnn::csl;
+using namespace cv::dnn::cuda4dnn::csl::device;
+
+namespace cv { namespace dnn { namespace cuda4dnn { namespace kernels {
+
+    namespace raw {
+        template <class T, std::size_t N>
+        __global__ void biasN_eltwise_identity_inplace_vec(Span<T> inplace_output, size_type inner_size, View<T> bias, View<T> eltwise) {
+            using vector_type = get_vector_type_t<T, N>;
+
+            auto inplace_output_vPtr = vector_type::get_pointer(inplace_output.data());
+            auto eltwise_vPtr = vector_type::get_pointer(eltwise.data());
+
+            inner_size /= vector_type::size();
+            for (auto i : grid_stride_range(inplace_output.size() / vector_type::size())) {
+                const index_type bias_idx = (i / inner_size) % static_cast<size_type>(bias.size());
+
+                vector_type output_vec, eltwise_vec;
+                v_load(output_vec, inplace_output_vPtr[i]);
+                v_load(eltwise_vec, eltwise_vPtr[i]);
+                for (int j = 0; j < output_vec.size(); j++)
+                    output_vec.data[j] += bias[bias_idx] + eltwise_vec.data[j];
+                v_store(inplace_output_vPtr[i], output_vec);
+            }
+        }
+
+        template <class T, std::size_t N>
+        __global__ void biasN_eltwise_relu_inplace_vec(Span<T> inplace_output, size_type inner_size, View<T> bias, View<T> eltwise, T slope) {
+            using vector_type = get_vector_type_t<T, N>;
+
+            auto inplace_output_vPtr = vector_type::get_pointer(inplace_output.data());
+            auto eltwise_vPtr = vector_type::get_pointer(eltwise.data());
+
+            inner_size /= vector_type::size();
+            for (auto i : grid_stride_range(inplace_output.size() / vector_type::size())) {
+                const index_type bias_idx = (i / inner_size) % static_cast<size_type>(bias.size());
+
+                vector_type output_vec, eltwise_vec;
+                v_load(output_vec, inplace_output_vPtr[i]);
+                v_load(eltwise_vec, eltwise_vPtr[i]);
+                for(int j = 0; j < output_vec.size(); j++) {
+                    auto value = output_vec.data[j] + bias[bias_idx] + eltwise_vec.data[j];
+                    output_vec.data[j] = value >= T(0) ? value : slope * value;
+                }
+                v_store(inplace_output_vPtr[i], output_vec);
+            }
+        }
+
+        template <class T, std::size_t N>
+        __global__ void biasN_eltwise_clipped_relu_inplace_vec(Span<T> inplace_output, size_type inner_size, View<T> bias, View<T> eltwise, T floor, T ceil) {
+            using vector_type = get_vector_type_t<T, N>;
+
+            auto inplace_output_vPtr = vector_type::get_pointer(inplace_output.data());
+            auto eltwise_vPtr = vector_type::get_pointer(eltwise.data());
+
+            inner_size /= vector_type::size();
+            for (auto i : grid_stride_range(inplace_output.size() / vector_type::size())) {
+                const index_type bias_idx = (i / inner_size) % static_cast<size_type>(bias.size());
+
+                vector_type output_vec, eltwise_vec;
+                v_load(output_vec, inplace_output_vPtr[i]);
+                v_load(eltwise_vec, eltwise_vPtr[i]);
+                for(int j = 0; j < output_vec.size(); j++) {
+                    using device::clamp;
+                    output_vec.data[j] = clamp(output_vec.data[j] + bias[bias_idx] + eltwise_vec.data[j], floor, ceil);
+                }
+                v_store(inplace_output_vPtr[i], output_vec);
+            }
+        }
+
+        template <class T, std::size_t N>
+        __global__ void biasN_eltwise_power_inplace_vec(Span<T> inplace_output, size_type inner_size, View<T> bias, View<T> eltwise, T power) {
+            using vector_type = get_vector_type_t<T, N>;
+
+            auto inplace_output_vPtr = vector_type::get_pointer(inplace_output.data());
+            auto eltwise_vPtr = vector_type::get_pointer(eltwise.data());
+
+            inner_size /= vector_type::size();
+            for (auto i : grid_stride_range(inplace_output.size() / vector_type::size())) {
+                const index_type bias_idx = (i / inner_size) % static_cast<size_type>(bias.size());
+
+                vector_type output_vec, eltwise_vec;
+                v_load(output_vec, inplace_output_vPtr[i]);
+                v_load(eltwise_vec, eltwise_vPtr[i]);
+                for(int j = 0; j < output_vec.size(); j++) {
+                    using device::pow;
+                    output_vec.data[j] = pow(output_vec.data[j] + bias[bias_idx] + eltwise_vec.data[j], power);
+                }
+                v_store(inplace_output_vPtr[i], output_vec);
+            }
+        }
+
+        template <class T, std::size_t N>
+        __global__ void biasN_eltwise_tanh_inplace_vec(Span<T> inplace_output, size_type inner_size, View<T> bias, View<T> eltwise) {
+            using vector_type = get_vector_type_t<T, N>;
+
+            auto inplace_output_vPtr = vector_type::get_pointer(inplace_output.data());
+            auto eltwise_vPtr = vector_type::get_pointer(eltwise.data());
+
+            inner_size /= vector_type::size();
+            for (auto i : grid_stride_range(inplace_output.size() / vector_type::size())) {
+                const index_type bias_idx = (i / inner_size) % static_cast<size_type>(bias.size());
+
+                vector_type output_vec, eltwise_vec;
+                v_load(output_vec, inplace_output_vPtr[i]);
+                v_load(eltwise_vec, eltwise_vPtr[i]);
+                for(int j = 0; j < output_vec.size(); j++) {
+                    using device::tanh;
+                    output_vec.data[j] = tanh(output_vec.data[j] + bias[bias_idx] + eltwise_vec.data[j]);
+                }
+                v_store(inplace_output_vPtr[i], output_vec);
+            }
+        }
+
+        template <class T, std::size_t N>
+        __global__ void biasN_eltwise_sigmoid_inplace_vec(Span<T> inplace_output, size_type inner_size, View<T> bias, View<T> eltwise) {
+            using vector_type = get_vector_type_t<T, N>;
+
+            auto inplace_output_vPtr = vector_type::get_pointer(inplace_output.data());
+            auto eltwise_vPtr = vector_type::get_pointer(eltwise.data());
+
+            inner_size /= vector_type::size();
+            for (auto i : grid_stride_range(inplace_output.size() / vector_type::size())) {
+                const index_type bias_idx = (i / inner_size) % static_cast<size_type>(bias.size());
+
+                vector_type output_vec, eltwise_vec;
+                v_load(output_vec, inplace_output_vPtr[i]);
+                v_load(eltwise_vec, eltwise_vPtr[i]);
+                for(int j = 0; j < output_vec.size(); j++) {
+                    using device::sigmoid;
+                    output_vec.data[j] = sigmoid(output_vec.data[j] + bias[bias_idx] + eltwise_vec.data[j]);
+                }
+                v_store(inplace_output_vPtr[i], output_vec);
+            }
+        }
+
+        template <class T, std::size_t N>
+        __global__ void biasN_eltwise_swish_inplace_vec(Span<T> inplace_output, size_type inner_size, View<T> bias, View<T> eltwise) {
+            using vector_type = get_vector_type_t<T, N>;
+
+            auto inplace_output_vPtr = vector_type::get_pointer(inplace_output.data());
+            auto eltwise_vPtr = vector_type::get_pointer(eltwise.data());
+
+            inner_size /= vector_type::size();
+            for (auto i : grid_stride_range(inplace_output.size() / vector_type::size())) {
+                const index_type bias_idx = (i / inner_size) % static_cast<size_type>(bias.size());
+
+                vector_type output_vec, eltwise_vec;
+                v_load(output_vec, inplace_output_vPtr[i]);
+                v_load(eltwise_vec, eltwise_vPtr[i]);
+                for(int j = 0; j < output_vec.size(); j++) {
+                    using device::sigmoid;
+                    auto value = output_vec.data[j] + bias[bias_idx] + eltwise_vec.data[j];
+                    output_vec.data[j] = value * sigmoid(value);
+                }
+                v_store(inplace_output_vPtr[i], output_vec);
+            }
+        }
+
+        template <class T, std::size_t N>
+        __global__ void biasN_eltwise_mish_inplace_vec(Span<T> inplace_output, size_type inner_size, View<T> bias, View<T> eltwise) {
+            using vector_type = get_vector_type_t<T, N>;
+
+            auto inplace_output_vPtr = vector_type::get_pointer(inplace_output.data());
+            auto eltwise_vPtr = vector_type::get_pointer(eltwise.data());
+
+            inner_size /= vector_type::size();
+            for (auto i : grid_stride_range(inplace_output.size() / vector_type::size())) {
+                const index_type bias_idx = (i / inner_size) % static_cast<size_type>(bias.size());
+
+                vector_type output_vec, eltwise_vec;
+                v_load(output_vec, inplace_output_vPtr[i]);
+                v_load(eltwise_vec, eltwise_vPtr[i]);
+                for(int j = 0; j < output_vec.size(); j++) {
+                    using device::tanh;
+                    using device::log1pexp;
+                    auto value = output_vec.data[j] + bias[bias_idx] + eltwise_vec.data[j];
+                    output_vec.data[j] = value * tanh(log1pexp(value));
+                }
+                v_store(inplace_output_vPtr[i], output_vec);
+            }
+        }
+    }
+
+    template <class T, std::size_t N> static
+    void launch_biasN_eltwise_identity_inplace_vec_kernel(const Stream& stream, Span<T> inplace_output, std::size_t inner_size, View<T> bias, View<T> eltwise) {
+        CV_Assert(is_fully_aligned<T>(inplace_output, N));
+        CV_Assert(is_fully_aligned<T>(eltwise, N));
+        CV_Assert(inner_size % N == 0);
+
+        auto kernel = raw::biasN_eltwise_identity_inplace_vec<T, N>;
+        auto policy = make_policy(kernel, inplace_output.size() / N, 0, stream);
+        launch_kernel(kernel, policy, inplace_output, inner_size, bias, eltwise);
+    }
+
+    template <class T>
+    void biasN_eltwise_identity_inplace(const Stream& stream, Span<T> inplace_output, std::size_t inner_size, View<T> bias, View<T> eltwise) {
+        if (is_fully_aligned<T>(inplace_output, 4) && is_fully_aligned<T>(eltwise, 4) && inner_size % 4 == 0) {
+            launch_biasN_eltwise_identity_inplace_vec_kernel<T, 4>(stream, inplace_output, inner_size, bias, eltwise);
+        } else if (is_fully_aligned<T>(inplace_output, 2) && is_fully_aligned<T>(eltwise, 2) && inner_size % 2 == 0) {
+            launch_biasN_eltwise_identity_inplace_vec_kernel<T, 2>(stream, inplace_output, inner_size, bias, eltwise);
+        } else {
+            launch_biasN_eltwise_identity_inplace_vec_kernel<T, 1>(stream, inplace_output, inner_size, bias, eltwise);
+        }
+    }
+
+    template void biasN_eltwise_identity_inplace<__half>(const Stream&, Span<__half>, std::size_t, View<__half>, View<__half>);
+    template void biasN_eltwise_identity_inplace<float>(const Stream&, Span<float>, std::size_t, View<float>, View<float>);
+
+    template <class T, std::size_t N> static
+    void launch_biasN_eltwise_relu_inplace_vec_kernel(const Stream& stream, Span<T> inplace_output, std::size_t inner_size, View<T> bias, View<T> eltwise, T slope) {
+        CV_Assert(is_fully_aligned<T>(inplace_output, N));
+        CV_Assert(is_fully_aligned<T>(eltwise, N));
+        CV_Assert(inner_size % N == 0);
+
+        auto kernel = raw::biasN_eltwise_relu_inplace_vec<T, N>;
+        auto policy = make_policy(kernel, inplace_output.size() / N, 0, stream);
+        launch_kernel(kernel, policy, inplace_output, inner_size, bias, eltwise, slope);
+    }
+
+    template <class T>
+    void biasN_eltwise_relu_inplace(const Stream& stream, Span<T> inplace_output, std::size_t inner_size, View<T> bias, View<T> eltwise, T slope) {
+        if (is_fully_aligned<T>(inplace_output, 4) && is_fully_aligned<T>(eltwise, 4) && inner_size % 4 == 0) {
+            launch_biasN_eltwise_relu_inplace_vec_kernel<T, 4>(stream, inplace_output, inner_size, bias, eltwise, slope);
+        } else if (is_fully_aligned<T>(inplace_output, 2) && is_fully_aligned<T>(eltwise, 2) && inner_size % 2 == 0) {
+            launch_biasN_eltwise_relu_inplace_vec_kernel<T, 2>(stream, inplace_output, inner_size, bias, eltwise, slope);
+        } else {
+            launch_biasN_eltwise_relu_inplace_vec_kernel<T, 1>(stream, inplace_output, inner_size, bias, eltwise, slope);
+        }
+    }
+
+    template void biasN_eltwise_relu_inplace<__half>(const Stream&, Span<__half>, std::size_t, View<__half>, View<__half>, __half);
+    template void biasN_eltwise_relu_inplace<float>(const Stream&, Span<float>, std::size_t, View<float>, View<float>, float);
+
+    template <class T, std::size_t N> static
+    void launch_biasN_eltwise_clipped_relu_inplace_vec_kernel(const Stream& stream, Span<T> inplace_output, std::size_t inner_size, View<T> bias, View<T> eltwise, T floor, T ceil){
+        CV_Assert(is_fully_aligned<T>(inplace_output, N));
+        CV_Assert(is_fully_aligned<T>(eltwise, N));
+        CV_Assert(inner_size % N == 0);
+
+        auto kernel = raw::biasN_eltwise_clipped_relu_inplace_vec<T, N>;
+        auto policy = make_policy(kernel, inplace_output.size() / N, 0, stream);
+        launch_kernel(kernel, policy, inplace_output, inner_size, bias, eltwise, floor, ceil);
+    }
+
+    template <class T>
+    void biasN_eltwise_clipped_relu_inplace(const Stream& stream, Span<T> inplace_output, std::size_t inner_size, View<T> bias, View<T> eltwise, T floor, T ceil) {
+        if (is_fully_aligned<T>(inplace_output, 4) && is_fully_aligned<T>(eltwise, 4) && inner_size % 4 == 0) {
+            launch_biasN_eltwise_clipped_relu_inplace_vec_kernel<T, 4>(stream, inplace_output, inner_size, bias, eltwise, floor, ceil);
+        } else if (is_fully_aligned<T>(inplace_output, 2) && is_fully_aligned<T>(eltwise, 2) && inner_size % 2 == 0) {
+            launch_biasN_eltwise_clipped_relu_inplace_vec_kernel<T, 2>(stream, inplace_output, inner_size, bias, eltwise, floor, ceil);
+        } else {
+            launch_biasN_eltwise_clipped_relu_inplace_vec_kernel<T, 1>(stream, inplace_output, inner_size, bias, eltwise, floor, ceil);
+        }
+    }
+
+    template void biasN_eltwise_clipped_relu_inplace<__half>(const Stream&, Span<__half>, std::size_t, View<__half>, View<__half>, __half, __half);
+    template void biasN_eltwise_clipped_relu_inplace<float>(const Stream&, Span<float>, std::size_t, View<float>, View<float>,  float, float);
+
+    template <class T, std::size_t N> static
+    void launch_biasN_eltwise_power_inplace_vec_kernel(const Stream& stream, Span<T> inplace_output, std::size_t inner_size, View<T> bias, View<T> eltwise, T power){
+        CV_Assert(is_fully_aligned<T>(inplace_output, N));
+        CV_Assert(is_fully_aligned<T>(eltwise, N));
+        CV_Assert(inner_size % N == 0);
+
+        auto kernel = raw::biasN_eltwise_power_inplace_vec<T, N>;
+        auto policy = make_policy(kernel, inplace_output.size() / N, 0, stream);
+        launch_kernel(kernel, policy, inplace_output, inner_size, bias, eltwise, power);
+    }
+
+    template <class T>
+    void biasN_eltwise_power_inplace(const Stream& stream, Span<T> inplace_output, std::size_t inner_size, View<T> bias, View<T> eltwise, T power) {
+        if (is_fully_aligned<T>(inplace_output, 4) && is_fully_aligned<T>(eltwise, 4) && inner_size % 4 == 0) {
+            launch_biasN_eltwise_power_inplace_vec_kernel<T, 4>(stream, inplace_output, inner_size, bias, eltwise, power);
+        } else if (is_fully_aligned<T>(inplace_output, 2) && is_fully_aligned<T>(eltwise, 2) && inner_size % 2 == 0) {
+            launch_biasN_eltwise_power_inplace_vec_kernel<T, 2>(stream, inplace_output, inner_size, bias, eltwise, power);
+        } else {
+            launch_biasN_eltwise_power_inplace_vec_kernel<T, 1>(stream, inplace_output, inner_size, bias, eltwise, power);
+        }
+    }
+
+    template void biasN_eltwise_power_inplace<__half>(const Stream&, Span<__half>, std::size_t, View<__half>, View<__half>, __half);
+    template void biasN_eltwise_power_inplace<float>(const Stream&, Span<float>, std::size_t, View<float>, View<float>, float);
+
+    template <class T, std::size_t N> static
+    void launch_biasN_eltwise_tanh_inplace_vec_kernel(const Stream& stream, Span<T> inplace_output, std::size_t inner_size, View<T> bias, View<T> eltwise) {
+        CV_Assert(is_fully_aligned<T>(inplace_output, N));
+        CV_Assert(is_fully_aligned<T>(eltwise, N));
+        CV_Assert(inner_size % N == 0);
+
+        auto kernel = raw::biasN_eltwise_tanh_inplace_vec<T, N>;
+        auto policy = make_policy(kernel, inplace_output.size() / N, 0, stream);
+        launch_kernel(kernel, policy, inplace_output, inner_size, bias, eltwise);
+    }
+
+    template <class T>
+    void biasN_eltwise_tanh_inplace(const Stream& stream, Span<T> inplace_output, std::size_t inner_size, View<T> bias, View<T> eltwise) {
+        if (is_fully_aligned<T>(inplace_output, 4) && is_fully_aligned<T>(eltwise, 4) && inner_size % 4 == 0) {
+            launch_biasN_eltwise_tanh_inplace_vec_kernel<T, 4>(stream, inplace_output, inner_size, bias, eltwise);
+        } else if (is_fully_aligned<T>(inplace_output, 2) && is_fully_aligned<T>(eltwise, 2) && inner_size % 2 == 0) {
+            launch_biasN_eltwise_tanh_inplace_vec_kernel<T, 2>(stream, inplace_output, inner_size, bias, eltwise);
+        } else {
+            launch_biasN_eltwise_tanh_inplace_vec_kernel<T, 1>(stream, inplace_output, inner_size, bias, eltwise);
+        }
+    }
+
+    template void biasN_eltwise_tanh_inplace<__half>(const Stream&, Span<__half>, std::size_t, View<__half>, View<__half>);
+    template void biasN_eltwise_tanh_inplace<float>(const Stream&, Span<float>, std::size_t, View<float>, View<float>);
+
+    template <class T, std::size_t N> static
+    void launch_biasN_eltwise_sigmoid_inplace_vec_kernel(const Stream& stream, Span<T> inplace_output, std::size_t inner_size, View<T> bias, View<T> eltwise) {
+        CV_Assert(is_fully_aligned<T>(inplace_output, N));
+        CV_Assert(is_fully_aligned<T>(eltwise, N));
+        CV_Assert(inner_size % N == 0);
+
+        auto kernel = raw::biasN_eltwise_sigmoid_inplace_vec<T, N>;
+        auto policy = make_policy(kernel, inplace_output.size() / N, 0, stream);
+        launch_kernel(kernel, policy, inplace_output, inner_size, bias, eltwise);
+    }
+
+    template <class T>
+    void biasN_eltwise_sigmoid_inplace(const Stream& stream, Span<T> inplace_output, std::size_t inner_size, View<T> bias, View<T> eltwise) {
+        if (is_fully_aligned<T>(inplace_output, 4) && is_fully_aligned<T>(eltwise, 4) && inner_size % 4 == 0) {
+            launch_biasN_eltwise_sigmoid_inplace_vec_kernel<T, 4>(stream, inplace_output, inner_size, bias, eltwise);
+        } else if (is_fully_aligned<T>(inplace_output, 2) && is_fully_aligned<T>(eltwise, 2) && inner_size % 2 == 0) {
+            launch_biasN_eltwise_sigmoid_inplace_vec_kernel<T, 2>(stream, inplace_output, inner_size, bias, eltwise);
+        } else {
+            launch_biasN_eltwise_sigmoid_inplace_vec_kernel<T, 1>(stream, inplace_output, inner_size, bias, eltwise);
+        }
+    }
+
+    template void biasN_eltwise_sigmoid_inplace<__half>(const Stream&, Span<__half>, std::size_t, View<__half>, View<__half>);
+    template void biasN_eltwise_sigmoid_inplace<float>(const Stream&, Span<float>, std::size_t, View<float>, View<float>);
+
+    template <class T, std::size_t N> static
+    void launch_biasN_eltwise_swish_inplace_vec_kernel(const Stream& stream, Span<T> inplace_output, std::size_t inner_size, View<T> bias, View<T> eltwise) {
+        CV_Assert(is_fully_aligned<T>(inplace_output, N));
+        CV_Assert(is_fully_aligned<T>(eltwise, N));
+        CV_Assert(inner_size % N == 0);
+
+        auto kernel = raw::biasN_eltwise_swish_inplace_vec<T, N>;
+        auto policy = make_policy(kernel, inplace_output.size() / N, 0, stream);
+        launch_kernel(kernel, policy, inplace_output, inner_size, bias, eltwise);
+    }
+
+    template <class T>
+    void biasN_eltwise_swish_inplace(const Stream& stream, Span<T> inplace_output, std::size_t inner_size, View<T> bias, View<T> eltwise) {
+        if (is_fully_aligned<T>(inplace_output, 4) && is_fully_aligned<T>(eltwise, 4) && inner_size % 4 == 0) {
+            launch_biasN_eltwise_swish_inplace_vec_kernel<T, 4>(stream, inplace_output, inner_size, bias, eltwise);
+        } else if (is_fully_aligned<T>(inplace_output, 2) && is_fully_aligned<T>(eltwise, 2) && inner_size % 2 == 0) {
+            launch_biasN_eltwise_swish_inplace_vec_kernel<T, 2>(stream, inplace_output, inner_size, bias, eltwise);
+        } else {
+            launch_biasN_eltwise_swish_inplace_vec_kernel<T, 1>(stream, inplace_output, inner_size, bias, eltwise);
+        }
+    }
+
+    template void biasN_eltwise_swish_inplace<__half>(const Stream&, Span<__half>, std::size_t, View<__half>, View<__half>);
+    template void biasN_eltwise_swish_inplace<float>(const Stream&, Span<float>, std::size_t, View<float>, View<float>);
+
+    template <class T, std::size_t N> static
+    void launch_biasN_eltwise_mish_inplace_vec_kernel(const Stream& stream, Span<T> inplace_output, std::size_t inner_size, View<T> bias, View<T> eltwise) {
+        CV_Assert(is_fully_aligned<T>(inplace_output, N));
+        CV_Assert(is_fully_aligned<T>(eltwise, N));
+        CV_Assert(inner_size % N == 0);
+
+        auto kernel = raw::biasN_eltwise_mish_inplace_vec<T, N>;
+        auto policy = make_policy(kernel, inplace_output.size() / N, 0, stream);
+        launch_kernel(kernel, policy, inplace_output, inner_size, bias, eltwise);
+    }
+
+    template <class T>
+    void biasN_eltwise_mish_inplace(const Stream& stream, Span<T> inplace_output, std::size_t inner_size, View<T> bias, View<T> eltwise) {
+        if (is_fully_aligned<T>(inplace_output, 4) && is_fully_aligned<T>(eltwise, 4) && inner_size % 4 == 0) {
+            launch_biasN_eltwise_mish_inplace_vec_kernel<T, 4>(stream, inplace_output, inner_size, bias, eltwise);
+        } else if (is_fully_aligned<T>(inplace_output, 2) && is_fully_aligned<T>(eltwise, 2) && inner_size % 2 == 0) {
+            launch_biasN_eltwise_mish_inplace_vec_kernel<T, 2>(stream, inplace_output, inner_size, bias, eltwise);
+        } else {
+            launch_biasN_eltwise_mish_inplace_vec_kernel<T, 1>(stream, inplace_output, inner_size, bias, eltwise);
+        }
+    }
+
+    template void biasN_eltwise_mish_inplace<__half>(const Stream&, Span<__half>, std::size_t, View<__half>, View<__half>);
+    template void biasN_eltwise_mish_inplace<float>(const Stream&, Span<float>, std::size_t, View<float>, View<float>);
+
+}}}} /* namespace cv::dnn::cuda4dnn::kernels */

--- a/modules/dnn/src/cuda/eltwise_activation.cu
+++ b/modules/dnn/src/cuda/eltwise_activation.cu
@@ -1,0 +1,343 @@
+// This file is part of OpenCV project.
+// It is subject to the license terms in the LICENSE file found in the top-level directory
+// of this distribution and at http://opencv.org/license.html.
+
+#include <cuda_runtime.h>
+#include <cuda_fp16.h>
+
+#include "types.hpp"
+#include "math.hpp"
+#include "vector_traits.hpp"
+#include "grid_stride_range.hpp"
+#include "execution.hpp"
+
+#include "../cuda4dnn/csl/stream.hpp"
+#include "../cuda4dnn/csl/span.hpp"
+
+using namespace cv::dnn::cuda4dnn::csl;
+using namespace cv::dnn::cuda4dnn::csl::device;
+
+namespace cv { namespace dnn { namespace cuda4dnn { namespace kernels {
+
+namespace raw {
+
+    template <class T, std::size_t N>
+    __global__ void eltwise_sum_2_relu_vec(Span<T> output, View<T> x, View<T> y, T slope) {
+        using vector_type = get_vector_type_t<T, N>;
+
+        auto output_vPtr = vector_type::get_pointer(output.data());
+        auto x_vPtr = vector_type::get_pointer(x.data());
+        auto y_vPtr = vector_type::get_pointer(y.data());
+
+        for (auto i : grid_stride_range(output.size() / vector_type::size())) {
+            vector_type vec_x, vec_y;
+            v_load(vec_x, x_vPtr[i]);
+            v_load(vec_y, y_vPtr[i]);
+            for(int j = 0; j < vector_type::size(); j++) {
+                T value = vec_x.data[j] + vec_y.data[j];
+                vec_x.data[j] = value >= T(0) ? value : slope * value;
+            }
+            v_store(output_vPtr[i], vec_x);
+        }
+    }
+
+    template <class T, std::size_t N>
+    __global__ void eltwise_sum_2_clipped_relu_vec(Span<T> output, View<T> x, View<T> y, T floor, T ceil) {
+        using vector_type = get_vector_type_t<T, N>;
+
+        auto output_vPtr = vector_type::get_pointer(output.data());
+        auto x_vPtr = vector_type::get_pointer(x.data());
+        auto y_vPtr = vector_type::get_pointer(y.data());
+
+        for (auto i : grid_stride_range(output.size() / vector_type::size())) {
+            vector_type vec_x, vec_y;
+            v_load(vec_x, x_vPtr[i]);
+            v_load(vec_y, y_vPtr[i]);
+            for(int j = 0; j < vector_type::size(); j++) {
+                using device::clamp;
+                vec_x.data[j] = clamp(vec_x.data[j] + vec_y.data[j], floor, ceil);
+            }
+            v_store(output_vPtr[i], vec_x);
+        }
+    }
+
+    template <class T, std::size_t N>
+    __global__ void eltwise_sum_2_power_vec(Span<T> output, View<T> x, View<T> y, T power) {
+        using vector_type = get_vector_type_t<T, N>;
+
+        auto output_vPtr = vector_type::get_pointer(output.data());
+        auto x_vPtr = vector_type::get_pointer(x.data());
+        auto y_vPtr = vector_type::get_pointer(y.data());
+
+        for (auto i : grid_stride_range(output.size() / vector_type::size())) {
+            vector_type vec_x, vec_y;
+            v_load(vec_x, x_vPtr[i]);
+            v_load(vec_y, y_vPtr[i]);
+            for(int j = 0; j < vector_type::size(); j++) {
+                using device::pow;
+                vec_x.data[j] = pow(vec_x.data[j] + vec_y.data[j], power);
+            }
+            v_store(output_vPtr[i], vec_x);
+        }
+    }
+
+    template <class T, std::size_t N>
+    __global__ void eltwise_sum_2_tanh_vec(Span<T> output, View<T> x, View<T> y) {
+        using vector_type = get_vector_type_t<T, N>;
+
+        auto output_vPtr = vector_type::get_pointer(output.data());
+        auto x_vPtr = vector_type::get_pointer(x.data());
+        auto y_vPtr = vector_type::get_pointer(y.data());
+
+        for (auto i : grid_stride_range(output.size() / vector_type::size())) {
+            vector_type vec_x, vec_y;
+            v_load(vec_x, x_vPtr[i]);
+            v_load(vec_y, y_vPtr[i]);
+            for(int j = 0; j < vector_type::size(); j++) {
+                using device::tanh;
+                vec_x.data[j] = tanh(vec_x.data[j] + vec_y.data[j]);
+            }
+            v_store(output_vPtr[i], vec_x);
+        }
+    }
+
+    template <class T, std::size_t N>
+    __global__ void eltwise_sum_2_sigmoid_vec(Span<T> output, View<T> x, View<T> y) {
+        using vector_type = get_vector_type_t<T, N>;
+
+        auto output_vPtr = vector_type::get_pointer(output.data());
+        auto x_vPtr = vector_type::get_pointer(x.data());
+        auto y_vPtr = vector_type::get_pointer(y.data());
+
+        for (auto i : grid_stride_range(output.size() / vector_type::size())) {
+            vector_type vec_x, vec_y;
+            v_load(vec_x, x_vPtr[i]);
+            v_load(vec_y, y_vPtr[i]);
+            for(int j = 0; j < vector_type::size(); j++) {
+                using device::sigmoid;
+                vec_x.data[j] = sigmoid(vec_x.data[j] + vec_y.data[j]);
+            }
+            v_store(output_vPtr[i], vec_x);
+        }
+    }
+
+    template <class T, std::size_t N>
+    __global__ void eltwise_sum_2_swish_vec(Span<T> output, View<T> x, View<T> y) {
+        using vector_type = get_vector_type_t<T, N>;
+
+        auto output_vPtr = vector_type::get_pointer(output.data());
+        auto x_vPtr = vector_type::get_pointer(x.data());
+        auto y_vPtr = vector_type::get_pointer(y.data());
+
+        for (auto i : grid_stride_range(output.size() / vector_type::size())) {
+            vector_type vec_x, vec_y;
+            v_load(vec_x, x_vPtr[i]);
+            v_load(vec_y, y_vPtr[i]);
+            for(int j = 0; j < vector_type::size(); j++) {
+                using device::sigmoid;
+                T value = vec_x.data[j] + vec_y.data[j];
+                vec_x.data[j] = value * sigmoid(value);
+            }
+            v_store(output_vPtr[i], vec_x);
+        }
+    }
+
+    template <class T, std::size_t N>
+    __global__ void eltwise_sum_2_mish_vec(Span<T> output, View<T> x, View<T> y) {
+        using vector_type = get_vector_type_t<T, N>;
+
+        auto output_vPtr = vector_type::get_pointer(output.data());
+        auto x_vPtr = vector_type::get_pointer(x.data());
+        auto y_vPtr = vector_type::get_pointer(y.data());
+
+        for (auto i : grid_stride_range(output.size() / vector_type::size())) {
+            vector_type vec_x, vec_y;
+            v_load(vec_x, x_vPtr[i]);
+            v_load(vec_y, y_vPtr[i]);
+            for(int j = 0; j < vector_type::size(); j++) {
+                using device::tanh;
+                using device::log1pexp;
+                T value = vec_x.data[j] + vec_y.data[j];
+                vec_x.data[j] = value * tanh(log1pexp(value));
+            }
+            v_store(output_vPtr[i], vec_x);
+        }
+    }
+}
+
+template <class T, std::size_t N> static
+void launch_eltwise_sum_2_relu_vec_kernel(const Stream& stream, Span<T> output, View<T> x, View<T> y, T slope) {
+    CV_Assert(is_fully_aligned<T>(output, N));
+    CV_Assert(is_fully_aligned<T>(x, N));
+    CV_Assert(is_fully_aligned<T>(y, N));
+
+    auto kernel = raw::eltwise_sum_2_relu_vec<T, N>;
+    auto policy = make_policy(kernel, output.size() / N, 0, stream);
+    launch_kernel(kernel, policy, output, x, y, slope);
+}
+
+template <class T>
+void eltwise_sum_2_relu(const Stream& stream, Span<T> output, View<T> x, View<T> y, T slope) {
+    if (is_fully_aligned<T>(output, 4) && is_fully_aligned<T>(x, 4) && is_fully_aligned<T>(y, 4)) {
+        launch_eltwise_sum_2_relu_vec_kernel<T, 4>(stream, output, x, y, slope);
+    } else if (is_fully_aligned<T>(output, 2) && is_fully_aligned<T>(x, 2) && is_fully_aligned<T>(y, 2)) {
+        launch_eltwise_sum_2_relu_vec_kernel<T, 2>(stream, output, x, y, slope);
+    } else {
+        launch_eltwise_sum_2_relu_vec_kernel<T, 1>(stream, output, x, y, slope);
+    }
+}
+
+template void eltwise_sum_2_relu<__half>(const Stream&, Span<__half>, View<__half>, View<__half>, __half);
+template void eltwise_sum_2_relu<float>(const Stream&, Span<float>, View<float>, View<float>, float);
+
+template <class T, std::size_t N> static
+void launch_eltwise_sum_2_clipped_relu_vec_kernel(const Stream& stream, Span<T> output, View<T> x, View<T> y, T floor, T ceil){
+    CV_Assert(is_fully_aligned<T>(output, N));
+    CV_Assert(is_fully_aligned<T>(x, N));
+    CV_Assert(is_fully_aligned<T>(y, N));
+
+    auto kernel = raw::eltwise_sum_2_clipped_relu_vec<T, N>;
+    auto policy = make_policy(kernel, output.size() / N, 0, stream);
+    launch_kernel(kernel, policy, output, x, y, floor, ceil);
+}
+
+template <class T>
+void eltwise_sum_2_clipped_relu(const Stream& stream, Span<T> output, View<T> x, View<T> y, T floor, T ceil) {
+    if (is_fully_aligned<T>(output, 4) && is_fully_aligned<T>(x, 4) && is_fully_aligned<T>(y, 4)) {
+        launch_eltwise_sum_2_clipped_relu_vec_kernel<T, 4>(stream, output, x, y, floor, ceil);
+    } else if (is_fully_aligned<T>(output, 2) && is_fully_aligned<T>(x, 2) && is_fully_aligned<T>(y, 2)) {
+        launch_eltwise_sum_2_clipped_relu_vec_kernel<T, 2>(stream, output, x, y, floor, ceil);
+    } else {
+        launch_eltwise_sum_2_clipped_relu_vec_kernel<T, 1>(stream, output, x, y, floor, ceil);
+    }
+}
+
+template void eltwise_sum_2_clipped_relu<__half>(const Stream&, Span<__half>, View<__half>, View<__half>, __half, __half);
+template void eltwise_sum_2_clipped_relu<float>(const Stream&, Span<float>, View<float>, View<float>, float, float);
+
+template <class T, std::size_t N> static
+void launch_eltwise_sum_2_power_vec_kernel(const Stream& stream, Span<T> output, View<T> x, View<T> y, T power){
+    CV_Assert(is_fully_aligned<T>(output, N));
+    CV_Assert(is_fully_aligned<T>(x, N));
+    CV_Assert(is_fully_aligned<T>(y, N));
+
+    auto kernel = raw::eltwise_sum_2_power_vec<T, N>;
+    auto policy = make_policy(kernel, output.size() / N, 0, stream);
+    launch_kernel(kernel, policy, output, x, y, power);
+}
+
+template <class T>
+void eltwise_sum_2_power(const Stream& stream, Span<T> output, View<T> x, View<T> y, T power) {
+    if (is_fully_aligned<T>(output, 4) && is_fully_aligned<T>(x, 4) && is_fully_aligned<T>(y, 4)) {
+        launch_eltwise_sum_2_power_vec_kernel<T, 4>(stream, output, x, y, power);
+    } else if (is_fully_aligned<T>(output, 2) && is_fully_aligned<T>(x, 2) && is_fully_aligned<T>(y, 2)) {
+        launch_eltwise_sum_2_power_vec_kernel<T, 2>(stream, output, x, y, power);
+    } else {
+        launch_eltwise_sum_2_power_vec_kernel<T, 1>(stream, output, x, y, power);
+    }
+}
+
+template void eltwise_sum_2_power<__half>(const Stream&, Span<__half>, View<__half>, View<__half>, __half);
+template void eltwise_sum_2_power<float>(const Stream&, Span<float>, View<float>, View<float>, float);
+
+template <class T, std::size_t N> static
+void launch_eltwise_sum_2_tanh_vec_kernel(const Stream& stream, Span<T> output, View<T> x, View<T> y) {
+    CV_Assert(is_fully_aligned<T>(output, N));
+    CV_Assert(is_fully_aligned<T>(x, N));
+    CV_Assert(is_fully_aligned<T>(y, N));
+
+    auto kernel = raw::eltwise_sum_2_tanh_vec<T, N>;
+    auto policy = make_policy(kernel, output.size() / N, 0, stream);
+    launch_kernel(kernel, policy, output, x, y);
+}
+
+template <class T>
+void eltwise_sum_2_tanh(const Stream& stream, Span<T> output, View<T> x, View<T> y) {
+    if (is_fully_aligned<T>(output, 4) && is_fully_aligned<T>(x, 4) && is_fully_aligned<T>(y, 4)) {
+        launch_eltwise_sum_2_tanh_vec_kernel<T, 4>(stream, output, x, y);
+    } else if (is_fully_aligned<T>(output, 2) && is_fully_aligned<T>(x, 2) && is_fully_aligned<T>(y, 2)) {
+        launch_eltwise_sum_2_tanh_vec_kernel<T, 2>(stream, output, x, y);
+    } else {
+        launch_eltwise_sum_2_tanh_vec_kernel<T, 1>(stream, output, x, y);
+    }
+}
+
+template void eltwise_sum_2_tanh<__half>(const Stream&, Span<__half>, View<__half>, View<__half>);
+template void eltwise_sum_2_tanh<float>(const Stream&, Span<float>, View<float>, View<float>);
+
+template <class T, std::size_t N> static
+void launch_eltwise_sum_2_sigmoid_vec_kernel(const Stream& stream, Span<T> output, View<T> x, View<T> y) {
+    CV_Assert(is_fully_aligned<T>(output, N));
+    CV_Assert(is_fully_aligned<T>(x, N));
+    CV_Assert(is_fully_aligned<T>(y, N));
+
+    auto kernel = raw::eltwise_sum_2_sigmoid_vec<T, N>;
+    auto policy = make_policy(kernel, output.size() / N, 0, stream);
+    launch_kernel(kernel, policy, output, x, y);
+}
+
+template <class T>
+void eltwise_sum_2_sigmoid(const Stream& stream, Span<T> output, View<T> x, View<T> y) {
+    if (is_fully_aligned<T>(output, 4) && is_fully_aligned<T>(x, 4) && is_fully_aligned<T>(y, 4)) {
+        launch_eltwise_sum_2_sigmoid_vec_kernel<T, 4>(stream, output, x, y);
+    } else if (is_fully_aligned<T>(output, 2) && is_fully_aligned<T>(x, 2) && is_fully_aligned<T>(y, 2)) {
+        launch_eltwise_sum_2_sigmoid_vec_kernel<T, 2>(stream, output, x, y);
+    } else {
+        launch_eltwise_sum_2_sigmoid_vec_kernel<T, 1>(stream, output, x, y);
+    }
+}
+
+template void eltwise_sum_2_sigmoid<__half>(const Stream&, Span<__half>, View<__half>, View<__half>);
+template void eltwise_sum_2_sigmoid<float>(const Stream&, Span<float>, View<float>, View<float>);
+
+template <class T, std::size_t N> static
+void launch_eltwise_sum_2_swish_vec_kernel(const Stream& stream, Span<T> output, View<T> x, View<T> y) {
+    CV_Assert(is_fully_aligned<T>(output, N));
+    CV_Assert(is_fully_aligned<T>(x, N));
+    CV_Assert(is_fully_aligned<T>(y, N));
+
+    auto kernel = raw::eltwise_sum_2_swish_vec<T, N>;
+    auto policy = make_policy(kernel, output.size() / N, 0, stream);
+    launch_kernel(kernel, policy, output, x, y);
+}
+
+template <class T>
+void eltwise_sum_2_swish(const Stream& stream, Span<T> output, View<T> x, View<T> y) {
+    if (is_fully_aligned<T>(output, 4) && is_fully_aligned<T>(x, 4) && is_fully_aligned<T>(y, 4)) {
+        launch_eltwise_sum_2_swish_vec_kernel<T, 4>(stream, output, x, y);
+    } else if (is_fully_aligned<T>(output, 2) && is_fully_aligned<T>(x, 2) && is_fully_aligned<T>(y, 2)) {
+        launch_eltwise_sum_2_swish_vec_kernel<T, 2>(stream, output, x, y);
+    } else {
+        launch_eltwise_sum_2_swish_vec_kernel<T, 1>(stream, output, x, y);
+    }
+}
+
+template void eltwise_sum_2_swish<__half>(const Stream&, Span<__half>, View<__half>, View<__half>);
+template void eltwise_sum_2_swish<float>(const Stream&, Span<float>, View<float>, View<float>);
+
+template <class T, std::size_t N> static
+void launch_eltwise_sum_2_mish_vec_kernel(const Stream& stream, Span<T> output, View<T> x, View<T> y) {
+    CV_Assert(is_fully_aligned<T>(output, N));
+    CV_Assert(is_fully_aligned<T>(x, N));
+    CV_Assert(is_fully_aligned<T>(y, N));
+
+    auto kernel = raw::eltwise_sum_2_mish_vec<T, N>;
+    auto policy = make_policy(kernel, output.size() / N, 0, stream);
+    launch_kernel(kernel, policy, output, x, y);
+}
+
+template <class T>
+void eltwise_sum_2_mish(const Stream& stream, Span<T> output, View<T> x, View<T> y) {
+    if (is_fully_aligned<T>(output, 4) && is_fully_aligned<T>(x, 4) && is_fully_aligned<T>(y, 4)) {
+        launch_eltwise_sum_2_mish_vec_kernel<T, 4>(stream, output, x, y);
+    } else if (is_fully_aligned<T>(output, 2) && is_fully_aligned<T>(x, 2) && is_fully_aligned<T>(y, 2)) {
+        launch_eltwise_sum_2_mish_vec_kernel<T, 2>(stream, output, x, y);
+    } else {
+        launch_eltwise_sum_2_mish_vec_kernel<T, 1>(stream, output, x, y);
+    }
+}
+
+template void eltwise_sum_2_mish<__half>(const Stream&, Span<__half>, View<__half>, View<__half>);
+template void eltwise_sum_2_mish<float>(const Stream&, Span<float>, View<float>, View<float>);
+
+}}}} /* namespace cv::dnn::cuda4dnn::kernels */

--- a/modules/dnn/src/cuda4dnn/kernels/activation_eltwise.hpp
+++ b/modules/dnn/src/cuda4dnn/kernels/activation_eltwise.hpp
@@ -1,0 +1,40 @@
+// This file is part of OpenCV project.
+// It is subject to the license terms in the LICENSE file found in the top-level directory
+// of this distribution and at http://opencv.org/license.html.
+
+#ifndef OPENCV_DNN_SRC_CUDA4DNN_KERNELS_ACTIVATION_ELTWISE_HPP
+#define OPENCV_DNN_SRC_CUDA4DNN_KERNELS_ACTIVATION_ELTWISE_HPP
+
+#include "../csl/stream.hpp"
+#include "../csl/span.hpp"
+
+#include <cstddef>
+
+namespace cv { namespace dnn { namespace cuda4dnn { namespace kernels {
+
+    /* inplace_output = activation(inplace_output) + eltwise */
+
+    template <class T>
+    void relu_eltwise_inplace(const csl::Stream& stream, csl::Span<T> inplace_output, csl::View<T> eltwise, T slope);
+
+    template <class T>
+    void clipped_relu_eltwise_inplace(const csl::Stream& stream, csl::Span<T> inplace_output, csl::View<T> eltwise, T floor, T ceiling);
+
+    template <class T>
+    void power_eltwise_inplace(const csl::Stream& stream, csl::Span<T> inplace_output, csl::View<T> eltwise, T exp);
+
+    template <class T>
+    void tanh_eltwise_inplace(const csl::Stream& stream, csl::Span<T> inplace_output, csl::View<T> eltwise);
+
+    template <class T>
+    void sigmoid_eltwise_inplace(const csl::Stream& stream, csl::Span<T> inplace_output, csl::View<T> eltwise);
+
+    template <class T>
+    void swish_eltwise_inplace(const csl::Stream& stream, csl::Span<T> inplace_output, csl::View<T> eltwise);
+
+    template <class T>
+    void mish_eltwise_inplace(const csl::Stream& stream, csl::Span<T> inplace_output, csl::View<T> eltwise);
+
+}}}} /* namespace cv::dnn::cuda4dnn::kernels */
+
+#endif /* OPENCV_DNN_SRC_CUDA4DNN_KERNELS_ACTIVATION_ELTWISE_HPP */

--- a/modules/dnn/src/cuda4dnn/kernels/bias_activation_eltwise.hpp
+++ b/modules/dnn/src/cuda4dnn/kernels/bias_activation_eltwise.hpp
@@ -1,0 +1,42 @@
+// This file is part of OpenCV project.
+// It is subject to the license terms in the LICENSE file found in the top-level directory
+// of this distribution and at http://opencv.org/license.html.
+
+#ifndef OPENCV_DNN_SRC_CUDA4DNN_KERNELS_BIAS_ACTIVATION_ELTWISE_HPP
+#define OPENCV_DNN_SRC_CUDA4DNN_KERNELS_BIAS_ACTIVATION_ELTWISE_HPP
+
+#include "../csl/stream.hpp"
+#include "../csl/span.hpp"
+
+#include <cstddef>
+
+namespace cv { namespace dnn { namespace cuda4dnn { namespace kernels {
+
+    /* inplace_output = activation(inplace_output + bias) + eltwise
+     * broadcasting on `bias` is allowed but not on `eltwise`
+     */
+
+    template <class T>
+    void biasN_relu_eltwise_inplace(const csl::Stream& stream, csl::Span<T> inplace_output, std::size_t inner_size, csl::View<T> bias, csl::View<T> eltwise, T slope);
+
+    template <class T>
+    void biasN_clipped_relu_eltwise_inplace(const csl::Stream& stream, csl::Span<T> inplace_output, std::size_t inner_size, csl::View<T> bias, csl::View<T> eltwise, T floor, T ceiling);
+
+    template <class T>
+    void biasN_power_eltwise_inplace(const csl::Stream& stream, csl::Span<T> inplace_output, std::size_t inner_size, csl::View<T> bias, csl::View<T> eltwise, T exp);
+
+    template <class T>
+    void biasN_tanh_eltwise_inplace(const csl::Stream& stream, csl::Span<T> inplace_output, std::size_t inner_size, csl::View<T> bias, csl::View<T> eltwise);
+
+    template <class T>
+    void biasN_sigmoid_eltwise_inplace(const csl::Stream& stream, csl::Span<T> inplace_output, std::size_t inner_size, csl::View<T> bias, csl::View<T> eltwise);
+
+    template <class T>
+    void biasN_swish_eltwise_inplace(const csl::Stream& stream, csl::Span<T> inplace_output, std::size_t inner_size, csl::View<T> bias, csl::View<T> eltwise);
+
+    template <class T>
+    void biasN_mish_eltwise_inplace(const csl::Stream& stream, csl::Span<T> inplace_output, std::size_t inner_size, csl::View<T> bias, csl::View<T> eltwise);
+
+}}}} /* namespace cv::dnn::cuda4dnn::kernels */
+
+#endif /* OPENCV_DNN_SRC_CUDA4DNN_KERNELS_BIAS_ACTIVATION_ELTWISE_HPP */

--- a/modules/dnn/src/cuda4dnn/kernels/bias_eltwise_activation.hpp
+++ b/modules/dnn/src/cuda4dnn/kernels/bias_eltwise_activation.hpp
@@ -1,0 +1,45 @@
+// This file is part of OpenCV project.
+// It is subject to the license terms in the LICENSE file found in the top-level directory
+// of this distribution and at http://opencv.org/license.html.
+
+#ifndef OPENCV_DNN_SRC_CUDA4DNN_KERNELS_BIAS_ELTWISE_ACTIVATION_HPP
+#define OPENCV_DNN_SRC_CUDA4DNN_KERNELS_BIAS_ELTWISE_ACTIVATION_HPP
+
+#include "../csl/stream.hpp"
+#include "../csl/span.hpp"
+
+#include <cstddef>
+
+namespace cv { namespace dnn { namespace cuda4dnn { namespace kernels {
+
+    /* inplace_output = activation(inplace_output + bias + eltwise)
+     * broadcasting on `bias` is allowed but not on `eltwise`
+     */
+
+    template <class T>
+    void biasN_eltwise_identity_inplace(const csl::Stream& stream, csl::Span<T> inplace_output, std::size_t inner_size, csl::View<T> bias, csl::View<T> eltwise);
+
+    template <class T>
+    void biasN_eltwise_relu_inplace(const csl::Stream& stream, csl::Span<T> inplace_output, std::size_t inner_size, csl::View<T> bias, csl::View<T> eltwise, T slope);
+
+    template <class T>
+    void biasN_eltwise_clipped_relu_inplace(const csl::Stream& stream, csl::Span<T> inplace_output, std::size_t inner_size, csl::View<T> bias, csl::View<T> eltwise, T floor, T ceiling);
+
+    template <class T>
+    void biasN_eltwise_power_inplace(const csl::Stream& stream, csl::Span<T> inplace_output, std::size_t inner_size, csl::View<T> bias, csl::View<T> eltwise, T exp);
+
+    template <class T>
+    void biasN_eltwise_tanh_inplace(const csl::Stream& stream, csl::Span<T> inplace_output, std::size_t inner_size, csl::View<T> bias, csl::View<T> eltwise);
+
+    template <class T>
+    void biasN_eltwise_sigmoid_inplace(const csl::Stream& stream, csl::Span<T> inplace_output, std::size_t inner_size, csl::View<T> bias, csl::View<T> eltwise);
+
+    template <class T>
+    void biasN_eltwise_swish_inplace(const csl::Stream& stream, csl::Span<T> inplace_output, std::size_t inner_size, csl::View<T> bias, csl::View<T> eltwise);
+
+    template <class T>
+    void biasN_eltwise_mish_inplace(const csl::Stream& stream, csl::Span<T> inplace_output, std::size_t inner_size, csl::View<T> bias, csl::View<T> eltwise);
+
+}}}} /* namespace cv::dnn::cuda4dnn::kernels */
+
+#endif /* OPENCV_DNN_SRC_CUDA4DNN_KERNELS_BIAS_ELTWISE_ACTIVATION_HPP */

--- a/modules/dnn/src/cuda4dnn/kernels/eltwise_activation.hpp
+++ b/modules/dnn/src/cuda4dnn/kernels/eltwise_activation.hpp
@@ -1,0 +1,40 @@
+// This file is part of OpenCV project.
+// It is subject to the license terms in the LICENSE file found in the top-level directory
+// of this distribution and at http://opencv.org/license.html.
+
+#ifndef OPENCV_DNN_SRC_CUDA4DNN_KERNELS_ELTWISE_ACTIVATION_HPP
+#define OPENCV_DNN_SRC_CUDA4DNN_KERNELS_ELTWISE_ACTIVATION_HPP
+
+#include "../csl/stream.hpp"
+#include "../csl/span.hpp"
+
+#include <cstddef>
+
+namespace cv { namespace dnn { namespace cuda4dnn { namespace kernels {
+
+    /* output = activation(x + y) */
+
+    template <class T>
+    void eltwise_sum_2_relu(const csl::Stream& stream, csl::Span<T> output, csl::View<T> x, csl::View<T> y, T slope);
+
+    template <class T>
+    void eltwise_sum_2_clipped_relu(const csl::Stream& stream, csl::Span<T> output, csl::View<T> x, csl::View<T> y, T floor, T ceiling);
+
+    template <class T>
+    void eltwise_sum_2_power(const csl::Stream& stream, csl::Span<T> output, csl::View<T> x, csl::View<T> y, T exp);
+
+    template <class T>
+    void eltwise_sum_2_tanh(const csl::Stream& stream, csl::Span<T> output, csl::View<T> x, csl::View<T> y);
+
+    template <class T>
+    void eltwise_sum_2_sigmoid(const csl::Stream& stream, csl::Span<T> output, csl::View<T> x, csl::View<T> y);
+
+    template <class T>
+    void eltwise_sum_2_swish(const csl::Stream& stream, csl::Span<T> output, csl::View<T> x, csl::View<T> y);
+
+    template <class T>
+    void eltwise_sum_2_mish(const csl::Stream& stream, csl::Span<T> output, csl::View<T> x, csl::View<T> y);
+
+}}}} /* namespace cv::dnn::cuda4dnn::kernels */
+
+#endif /* OPENCV_DNN_SRC_CUDA4DNN_KERNELS_ELTWISE_ACTIVATION_HPP */

--- a/modules/dnn/src/dnn.cpp
+++ b/modules/dnn/src/dnn.cpp
@@ -2482,7 +2482,7 @@ struct Net::Impl
                     // CUDA backend supports fusion with eltwise sum (without variable channels)
                     if (IS_DNN_CUDA_TARGET(preferableTarget) && !nextEltwiseLayer.empty())
                     {
-                        if (nextEltwiseLayer->op != EltwiseLayer::SUM)
+                        if (nextEltwiseLayer->op != EltwiseLayer::SUM || !nextEltwiseLayer->coeffs.empty())
                             nextEltwiseLayer = Ptr<EltwiseLayer>();
 
                         auto& inputs = nextData->inputBlobs;

--- a/modules/dnn/src/dnn.cpp
+++ b/modules/dnn/src/dnn.cpp
@@ -2382,6 +2382,11 @@ struct Net::Impl
                 LayerPin lpNext(ld.consumers[0].lid, 0);
                 while (nextData)
                 {
+                    /* we use `tryFuse` member of convolution layer to fuse eltwise later
+                     * it's not intended to be fused here; hence, we stop when we encounter eltwise
+                     */
+                    if (preferableBackend == DNN_BACKEND_CUDA && ld.type == "Convolution" && nextData->type == "Eltwise")
+                        break;
                     Ptr<Layer> nextLayer = nextData->layerInstance;
                     if (currLayer->tryFuse(nextLayer))
                     {
@@ -2465,15 +2470,33 @@ struct Net::Impl
                         break;
                 }
 
-                // fuse convolution layer followed by eltwise + relu
-                if ( IS_DNN_OPENCL_TARGET(preferableTarget) && ld.layerInstance->type == "Convolution" )
+                // OpenCL: fuse convolution layer followed by eltwise + relu
+                // CUDA: fuse convolution layer followed by eltwise (and optional activation)
+                if ((IS_DNN_OPENCL_TARGET(preferableTarget) || IS_DNN_CUDA_TARGET(preferableTarget)) &&
+                    ld.layerInstance->type == "Convolution" )
                 {
                     Ptr<EltwiseLayer> nextEltwiseLayer;
                     if( nextData )
                         nextEltwiseLayer = nextData->layerInstance.dynamicCast<EltwiseLayer>();
 
-                    if( !nextEltwiseLayer.empty() && pinsToKeep.count(lpNext) == 0 &&
-                        nextData && nextData->inputBlobsId.size() == 2 )
+                    // CUDA backend supports fusion with eltwise sum (without variable channels)
+                    if (IS_DNN_CUDA_TARGET(preferableTarget) && !nextEltwiseLayer.empty())
+                    {
+                        if (nextEltwiseLayer->op != EltwiseLayer::SUM)
+                            nextEltwiseLayer = Ptr<EltwiseLayer>();
+
+                        auto& inputs = nextData->inputBlobs;
+                        for (int i = 1; i < inputs.size(); ++i)
+                        {
+                            if (inputs[i]->size[1] != inputs[0]->size[1])
+                            {
+                                nextEltwiseLayer = Ptr<EltwiseLayer>();
+                                break;
+                            }
+                        }
+                    }
+
+                    if (!nextEltwiseLayer.empty() && nextData && nextData->inputBlobsId.size() == 2)
                     {
                         LayerData *eltwiseData = nextData;
 
@@ -2502,65 +2525,158 @@ struct Net::Impl
                         }
                         CV_Assert(biasLayerData);
                         {
-                            if( eltwiseData->consumers.size() == 1 )
+                            // fuse eltwise + activation layer
+                            if (biasLayerData->id < ld.id)
                             {
-                                // fuse eltwise + activation layer
-                                if (biasLayerData->id < ld.id)
+                                /* we can fuse activation if:
+                                 * => activation layer that follows is the only consumer of eltwise output
+                                 * => we do not require to keep the output of eltwise
+                                 */
+                                Ptr<ActivationLayer> nextFusabeleActivLayer;
+                                if (eltwiseData->consumers.size() == 1 && pinsToKeep.count(lpNext) == 0)
                                 {
                                     nextData = &layers[eltwiseData->consumers[0].lid];
                                     lpNext = LayerPin(eltwiseData->consumers[0].lid, 0);
-                                    Ptr<ActivationLayer> nextActivLayer;
-                                    if( nextData )
-                                        nextActivLayer = nextData->layerInstance.dynamicCast<ActivationLayer>();
+                                    if (pinsToKeep.count(lpNext) == 0)
+                                        nextFusabeleActivLayer = nextData->layerInstance.dynamicCast<ActivationLayer>();
+                                }
+                                else
+                                {
+                                    // OCL backend cannot fuse in this case but the CUDA backend can continue with just eltwise
+                                    nextData = 0;
+                                }
 
-                                    if( !nextActivLayer.empty() && pinsToKeep.count(lpNext) == 0 &&
-                                            (!nextData->type.compare("ReLU") ||
-                                             !nextData->type.compare("ChannelsPReLU") ||
-                                             !nextData->type.compare("Power")) &&
-                                            currLayer->setActivation(nextActivLayer) )
+                                // the requirements of OCV OpenCL backend and CUDA backend are different
+                                // we need to check them separately; hence, the fuse variables
+                                bool fuse_eltwise = false, fuse_activation = false;
+
+                                if (IS_DNN_OPENCL_TARGET(preferableTarget) && !nextFusabeleActivLayer.empty() &&
+                                    (!nextData->type.compare("ReLU") ||
+                                     !nextData->type.compare("ChannelsPReLU") ||
+                                     !nextData->type.compare("Power")) &&
+                                    currLayer->setActivation(nextFusabeleActivLayer))
+                                {
+                                    fuse_eltwise = true;
+                                    fuse_activation = true;
+                                }
+
+                                if (IS_DNN_CUDA_TARGET(preferableTarget))
+                                {
+                                    /* supported fusion options:
+                                     * => convolution + eltwise
+                                     * => activation(convolution) + eltwise
+                                     *    > convolution + activation would have been fused already; we have to fuse eltwise
+                                     * => activation(convolution + eltwise)
+                                     *    > fuse eltwise and then activation
+                                     */
+                                    auto layer = nextEltwiseLayer.staticCast<Layer>();
+                                    if (currLayer->tryFuse(layer))
                                     {
-                                        CV_Assert_N(biasLayerData->outputBlobsWrappers.size() == 1, ld.inputBlobsWrappers.size() == 1);
-                                        ld.inputBlobsWrappers.push_back(biasLayerData->outputBlobsWrappers[0]);
-                                        printf_(("\tfused with %s\n", nextEltwiseLayer->name.c_str()));
-                                        printf_(("\tfused with %s\n", nextActivLayer->name.c_str()));
-                                        eltwiseData->skip = true;
-                                        nextData->skip = true;
-                                        // This optimization for cases like
-                                        // some_layer   conv
-                                        //   |             |
-                                        //   +-- eltwise --+
-                                        //          |
-                                        //        activ
-                                        // This way all the element-wise computations
-                                        // (i.e. some_layer+conv or some_layer*conv)
-                                        // would be done at [conv] layer. So we need to
-                                        // replace [conv]'s output blob to [eltwise]'s one
-                                        // considering that [activ] is an in-place layer.
-                                        // Also we need to move all the consumers' references.
-                                        // To prevent memory collisions (i.e. when input of
-                                        // [conv] and output of [eltwise] is the same blob)
-                                        // we allocate a new blob.
-                                        CV_Assert_N(ld.outputBlobs.size() == 1, ld.outputBlobsWrappers.size() == 1);
-                                        ld.outputBlobs[0] = ld.outputBlobs[0].clone();
-                                        ld.outputBlobsWrappers[0] = wrap(ld.outputBlobs[0]);
-
-                                        eltwiseData->outputBlobs = ld.outputBlobs;
-                                        nextData->outputBlobs = ld.outputBlobs;
-                                        eltwiseData->outputBlobsWrappers = ld.outputBlobsWrappers;
-                                        nextData->outputBlobsWrappers = ld.outputBlobsWrappers;
-
-                                        // Move references of [activ] layer consumers to the newly allocated blob.
-                                        for (int i = 0; i < nextData->consumers.size(); ++i)
+                                        fuse_eltwise = true; /* eltwise was successfully fused */
+                                        if (!nextFusabeleActivLayer.empty())
                                         {
-                                            LayerData& consumer = layers[nextData->consumers[i].lid];
-                                            for (int j = 0; j < consumer.inputBlobsId.size(); ++j)
+                                            if ((!nextData->type.compare("ReLU") ||
+                                                 !nextData->type.compare("ReLU6") ||
+                                                 !nextData->type.compare("Power") ||
+                                                 !nextData->type.compare("TanH") ||
+                                                 !nextData->type.compare("Sigmoid") ||
+                                                 !nextData->type.compare("Swish") ||
+                                                 !nextData->type.compare("Mish")) &&
+                                                currLayer->setActivation(nextFusabeleActivLayer))
                                             {
-                                                if (consumer.inputBlobsId[j].lid == lpNext.lid)
-                                                {
-                                                    consumer.inputBlobs[j] = &ld.outputBlobs[0];
-                                                    consumer.inputBlobsWrappers[j] = ld.outputBlobsWrappers[0];
-                                                    break;
-                                                }
+                                                // activation was fused
+                                                fuse_activation = true;
+                                            }
+                                        }
+                                    }
+                                }
+
+                                CV_Assert(!fuse_activation || fuse_eltwise); /* cannot fuse activation without eltwise */
+                                if(fuse_eltwise && fuse_activation)
+                                {
+                                    CV_Assert_N(biasLayerData->outputBlobsWrappers.size() == 1, ld.inputBlobsWrappers.size() == 1);
+                                    ld.inputBlobsWrappers.push_back(biasLayerData->outputBlobsWrappers[0]);
+                                    printf_(("\tfused with %s\n", nextEltwiseLayer->name.c_str()));
+                                    printf_(("\tfused with %s\n", nextFusabeleActivLayer->name.c_str()));
+                                    eltwiseData->skip = true;
+                                    nextData->skip = true;
+                                    // This optimization for cases like
+                                    // some_layer   conv
+                                    //   |             |
+                                    //   +-- eltwise --+
+                                    //          |
+                                    //        activ
+                                    // This way all the element-wise computations
+                                    // (i.e. some_layer+conv or some_layer*conv)
+                                    // would be done at [conv] layer. So we need to
+                                    // replace [conv]'s output blob to [eltwise]'s one
+                                    // considering that [activ] is an in-place layer.
+                                    // Also we need to move all the consumers' references.
+                                    // To prevent memory collisions (i.e. when input of
+                                    // [conv] and output of [eltwise] is the same blob)
+                                    // we allocate a new blob.
+                                    CV_Assert_N(ld.outputBlobs.size() == 1, ld.outputBlobsWrappers.size() == 1);
+                                    ld.outputBlobs[0] = ld.outputBlobs[0].clone();
+                                    ld.outputBlobsWrappers[0] = wrap(ld.outputBlobs[0]);
+
+                                    eltwiseData->outputBlobs = ld.outputBlobs;
+                                    nextData->outputBlobs = ld.outputBlobs;
+                                    eltwiseData->outputBlobsWrappers = ld.outputBlobsWrappers;
+                                    nextData->outputBlobsWrappers = ld.outputBlobsWrappers;
+
+                                    // Move references of [activ] layer consumers to the newly allocated blob.
+                                    for (int i = 0; i < nextData->consumers.size(); ++i)
+                                    {
+                                        LayerData& consumer = layers[nextData->consumers[i].lid];
+                                        for (int j = 0; j < consumer.inputBlobsId.size(); ++j)
+                                        {
+                                            if (consumer.inputBlobsId[j].lid == lpNext.lid)
+                                            {
+                                                consumer.inputBlobs[j] = &ld.outputBlobs[0];
+                                                consumer.inputBlobsWrappers[j] = ld.outputBlobsWrappers[0];
+                                                break;
+                                            }
+                                        }
+                                    }
+                                }
+                                else if (fuse_eltwise) // conv + eltwise (note: conv could have fused activations before eltwise)
+                                {
+                                    CV_Assert(IS_DNN_CUDA_TARGET(preferableTarget));
+                                    CV_Assert_N(biasLayerData->outputBlobsWrappers.size() == 1, ld.inputBlobsWrappers.size() == 1);
+                                    ld.inputBlobsWrappers.push_back(biasLayerData->outputBlobsWrappers[0]);
+                                    printf_(("\tfused with %s\n", nextEltwiseLayer->name.c_str()));
+                                    eltwiseData->skip = true;
+                                    // This optimization is for cases like
+                                    // some_layer   conv (maybe fused with activ)
+                                    //   |             |
+                                    //   +-- eltwise --+
+                                    //
+                                    // This way all the element-wise computations
+                                    // (i.e. some_layer+conv or some_layer*conv)
+                                    // would be done at [conv] layer. So we need to
+                                    // replace [conv]'s output blob to [eltwise]'s one.
+                                    // Also we need to move all the consumers' references.
+                                    // To prevent memory collisions (i.e. when input of
+                                    // [conv] and output of [eltwise] is the same blob)
+                                    // we allocate a new blob.
+                                    CV_Assert_N(ld.outputBlobs.size() == 1, ld.outputBlobsWrappers.size() == 1);
+                                    ld.outputBlobs[0] = ld.outputBlobs[0].clone();
+                                    ld.outputBlobsWrappers[0] = wrap(ld.outputBlobs[0]);
+
+                                    eltwiseData->outputBlobs = ld.outputBlobs;
+                                    eltwiseData->outputBlobsWrappers = ld.outputBlobsWrappers;
+
+                                    // Move references of [eltwise] layer consumers to the newly allocated blob.
+                                    for (int i = 0; i < eltwiseData->consumers.size(); ++i)
+                                    {
+                                        LayerData& consumer = layers[eltwiseData->consumers[i].lid];
+                                        for (int j = 0; j < consumer.inputBlobsId.size(); ++j)
+                                        {
+                                            if (consumer.inputBlobsId[j].lid == eltwiseData->id)
+                                            {
+                                                consumer.inputBlobs[j] = &ld.outputBlobs[0];
+                                                consumer.inputBlobsWrappers[j] = ld.outputBlobsWrappers[0];
+                                                break;
                                             }
                                         }
                                     }

--- a/modules/dnn/src/layers/convolution_layer.cpp
+++ b/modules/dnn/src/layers/convolution_layer.cpp
@@ -241,6 +241,7 @@ public:
 #endif
 
 #ifdef HAVE_CUDA
+    cuda4dnn::ConvolutionConfiguration::FusionMode cudaFusionMode;
     cuda4dnn::ConvolutionConfiguration::ActivationType cudaActType;
     float cuda_relu_slope, cuda_crelu_floor, cuda_crelu_ceil, cuda_power_exp;
 #endif
@@ -254,6 +255,7 @@ public:
 #endif
 
 #ifdef HAVE_CUDA
+        cudaFusionMode = cuda4dnn::ConvolutionConfiguration::FusionMode::NONE;
         cudaActType = cuda4dnn::ConvolutionConfiguration::ActivationType::IDENTITY;
 #endif
     }
@@ -418,10 +420,18 @@ public:
 #endif
 
 #ifdef HAVE_CUDA
-        cudaActType = cuda4dnn::ConvolutionConfiguration::ActivationType::IDENTITY;
+        if (activ.empty())
+        {
+            /* setActivation was called with empty argument => reset all fusions */
+            cudaFusionMode = cuda4dnn::ConvolutionConfiguration::FusionMode::NONE;
+            cudaActType = cuda4dnn::ConvolutionConfiguration::ActivationType::IDENTITY;
+        }
 
         if(IS_DNN_CUDA_TARGET(preferableTarget))
         {
+            CV_Assert(cudaFusionMode == ConvolutionConfiguration::FusionMode::NONE ||
+                      cudaFusionMode == ConvolutionConfiguration::FusionMode::ELTWISE_SUM);
+
             Ptr<ReLULayer> activ_relu = activ.dynamicCast<ReLULayer>();
             if(!activ_relu.empty())
             {
@@ -468,10 +478,51 @@ public:
                 cudaActType = cuda4dnn::ConvolutionConfiguration::ActivationType::MISH;
 
             if (cudaActType == cuda4dnn::ConvolutionConfiguration::ActivationType::IDENTITY)
+            {
+                /* no activation fused */
                 activ.reset();
+            }
+            else
+            {
+                /* activation was fused */
+                if (cudaFusionMode == ConvolutionConfiguration::FusionMode::NONE) /* no previous fusion */
+                    cudaFusionMode = ConvolutionConfiguration::FusionMode::ACTIVATION; /* now activation */
+                else if (cudaFusionMode == ConvolutionConfiguration::FusionMode::ELTWISE_SUM) /* previously eltwise was fused */
+                    cudaFusionMode = ConvolutionConfiguration::FusionMode::ELTWISE_SUM_THEN_ACTIVATION; /* now activation on eltwise output */
+            }
         }
 #endif
         return !activ.empty();
+    }
+
+    virtual bool tryFuse(Ptr<Layer>& top) CV_OVERRIDE
+    {
+#ifdef HAVE_CUDA
+        if(IS_DNN_CUDA_TARGET(preferableTarget))
+        {
+            Ptr<EltwiseLayer> eltwise = top.dynamicCast<EltwiseLayer>();
+            if (!eltwise.empty() && eltwise->op == EltwiseLayer::SUM)
+            {
+                /* we also need to check that the eltwise input does not require shortcut mechanism
+                * it's difficult to verify it here but we hope that `fuseLayers` has done the check already
+                */
+                if (cudaFusionMode == ConvolutionConfiguration::FusionMode::NONE)
+                {
+                    /* no previous fusion */
+                    cudaFusionMode = ConvolutionConfiguration::FusionMode::ELTWISE_SUM; /* now eltwise */
+                    return true;
+                }
+                else if(cudaFusionMode == ConvolutionConfiguration::FusionMode::ACTIVATION)
+                {
+                    /* previously an activation was fused */
+                    cudaFusionMode = ConvolutionConfiguration::FusionMode::ACTIVATION_THEN_ELTWISE_SUM;
+                    return true;
+                }
+                return false;
+            }
+        }
+#endif
+        return BaseConvolutionLayerImpl::tryFuse(top);
     }
 
     void fuseWeights(const Mat& w_, const Mat& b_) CV_OVERRIDE
@@ -1442,7 +1493,7 @@ public:
     {
         auto context = reinterpret_cast<csl::CSLContext*>(context_);
 
-        CV_Assert(inputs.size() == 1);
+        CV_Assert(inputs.size() == 1 || inputs.size() == 2);
         auto input_wrapper = inputs[0].dynamicCast<CUDABackendWrapper>();
         auto input_shape = input_wrapper->getShape();
 
@@ -1483,6 +1534,7 @@ public:
         config.output_shape.assign(std::begin(output_shape), std::end(output_shape));
         config.groups = groups;
 
+        config.fusion_mode = cudaFusionMode;
         config.activation_type = cudaActType;
         config.relu_negative_slope = cuda_relu_slope;
         config.crelu_floor = cuda_crelu_floor;

--- a/modules/dnn/src/layers/convolution_layer.cpp
+++ b/modules/dnn/src/layers/convolution_layer.cpp
@@ -501,7 +501,7 @@ public:
         if(IS_DNN_CUDA_TARGET(preferableTarget))
         {
             Ptr<EltwiseLayer> eltwise = top.dynamicCast<EltwiseLayer>();
-            if (!eltwise.empty() && eltwise->op == EltwiseLayer::SUM)
+            if (!eltwise.empty() && eltwise->op == EltwiseLayer::SUM && eltwise->coeffs.empty())
             {
                 /* we also need to check that the eltwise input does not require shortcut mechanism
                 * it's difficult to verify it here but we hope that `fuseLayers` has done the check already

--- a/modules/dnn/src/layers/eltwise_layer.cpp
+++ b/modules/dnn/src/layers/eltwise_layer.cpp
@@ -64,13 +64,6 @@ namespace dnn
 class EltwiseLayerImpl CV_FINAL : public EltwiseLayer
 {
 public:
-    enum EltwiseOp
-    {
-        PROD = 0,
-        SUM = 1,
-        MAX = 2,
-        DIV = 3
-    } op;
     std::vector<float> coeffs;
 
     enum OutputChannelsMode

--- a/modules/dnn/src/layers/eltwise_layer.cpp
+++ b/modules/dnn/src/layers/eltwise_layer.cpp
@@ -64,8 +64,6 @@ namespace dnn
 class EltwiseLayerImpl CV_FINAL : public EltwiseLayer
 {
 public:
-    std::vector<float> coeffs;
-
     enum OutputChannelsMode
     {
         ELTWISE_CHANNNELS_SAME = 0,              //!< number of channels from inputs must be the same and equal to output's number of channels


### PR DESCRIPTION
### This pullrequest changes
- fuses eltwise with convolution for three topologies

<cut/>

### activation(conv + eltwise)
Examples: ResNet

```
--------------               ---------------
| Bias Layer |               | Convolution |
--------------               ---------------
      |                             |
      |       ----------------      |
      --------| Eltwise Sum  |-------
              ----------------
                     |
              ----------------
              |  Activation  |                 
              ----------------
                     |
```

### eltwise + activation(conv)
Examples: YOLOv3

```
--------------               ---------------
| Bias Layer |               | Convolution |
--------------               ---------------
      |                             |
      |                      ----------------
      |                      |  Activation  |                 
      |                      ----------------
      |                             |
      |       ----------------      |
      --------| Eltwise Sum  |-------
              ----------------
                     |
             
```

### conv + eltwise
```
--------------               ---------------
| Bias Layer |               | Convolution |
--------------               ---------------
      |                             |
      |       ----------------      |
      --------| Eltwise Sum  |-------
              ----------------
                     |
           
```

**Pending:**
- make a test network comprising all activations and all topologies for testing the entire PR

---

```
force_builders=Custom,docs
buildworker:Custom=linux-4
docker_image:Custom=ubuntu-cuda:16.04

build_image:Custom Mac=openvino-2019r3.0
build_image:Custom Win=openvino-2019r3.0
test_opencl:Custom Win=OFF
test_modules:Custom Mac=dnn,java,python3
```