### PR TITLE
added tutorial for text skewness correction

### DIFF
--- a/samples/cpp/text_skewness_correction.cpp
+++ b/samples/cpp/text_skewness_correction.cpp
@@ -1,0 +1,74 @@
+/*
+This tutorial demonstrates how to correct the skewness in a text.
+The program takes as input a skewed source image and shows non skewed text.
+
+*/
+
+#include <opencv2/core.hpp>
+#include <opencv2/imgcodecs.hpp>
+#include <opencv2/highgui.hpp>
+#include <opencv2/imgproc.hpp>
+
+#include <iostream>
+#include <iomanip>
+#include <string>
+
+using namespace cv;
+using namespace std;
+
+
+int main( int argc, char** argv )
+{
+    CommandLineParser parser(argc, argv, "{@input | imageTextR.png | input image}");
+
+    // Load image from the disk
+    Mat image = imread( samples::findFile( parser.get<String>("@input") ), IMREAD_COLOR);
+    if (image.empty())
+    {
+        cout << "Cannot load the image " + parser.get<String>("@input") << endl;
+        return -1;
+    }
+
+    Mat gray;
+    cvtColor(image, gray, COLOR_BGR2GRAY);
+
+    //Threshold the image, setting all foreground pixels to 255 and all background pixels to 0
+    Mat thresh;
+    threshold(gray, thresh, 0, 255, THRESH_BINARY_INV | THRESH_OTSU);
+
+    // Applying erode filter to remove random noise
+    int erosion_size = 1;
+    Mat element = getStructuringElement( MORPH_RECT, Size(2*erosion_size+1, 2*erosion_size+1), Point(erosion_size, erosion_size) );
+    erode(thresh, thresh, element);
+
+    cv::Mat coords;
+    findNonZero(thresh, coords);
+
+    RotatedRect box = minAreaRect(coords);
+    float angle = box.angle;
+
+    // The cv::minAreaRect function returns values in the range [-90, 0)
+    // if the angle is less than -45 we need to add 90 to it
+    if (angle < -45.0f)
+    {
+        angle = (90.0f + angle);
+    }
+
+    //Obtaining the rotation matrix
+    Point2f center((image.cols) / 2.0f, (image.rows) / 2.0f);
+    Mat M = getRotationMatrix2D(center, angle, 1.0f);
+    Mat rotated;
+
+    // Rotating the image by required angle
+    stringstream angle_to_str;
+    angle_to_str << fixed << setprecision(2) << angle;
+    warpAffine(image, rotated, M, image.size(), INTER_CUBIC, BORDER_REPLICATE);
+    putText(rotated, "Angle " + angle_to_str.str() + " degrees", Point(10, 30), FONT_HERSHEY_SIMPLEX, 0.7, Scalar(0, 0, 255), 2);
+    cout << "[INFO] angle: " << angle_to_str.str() << endl;
+
+    //Show the image
+    imshow("Input", image);
+    imshow("Rotated", rotated);
+    waitKey(0);
+    return 0;
+}

--- a/samples/python/text_skewness_correction.py
+++ b/samples/python/text_skewness_correction.py
@@ -1,0 +1,58 @@
+'''
+Text skewness correction
+This tutorial demonstrates how to correct the skewness in a text.
+The program takes as input a skewed source image and shows non skewed text.
+
+Usage:
+        python text_skewness_correction.py --image "Image path"
+'''
+
+import numpy as np
+import cv2 as cv
+import sys
+import argparse
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("-i", "--image", required=True, help="path to input image file")
+    args = vars(parser.parse_args())
+
+    # load the image from disk
+    image = cv.imread(cv.samples.findFile(args["image"]))
+    if image is None:
+        print("can't read image " + args["image"])
+        sys.exit(-1)
+    gray = cv.cvtColor(image, cv.COLOR_BGR2GRAY)
+
+    # threshold the image, setting all foreground pixels to
+    # 255 and all background pixels to 0
+    thresh = cv.threshold(gray, 0, 255, cv.THRESH_BINARY_INV | cv.THRESH_OTSU)[1]
+
+    # Applying erode filter to remove random noise
+    erosion_size = 1
+    element = cv.getStructuringElement(cv.MORPH_RECT, (2 * erosion_size + 1, 2 * erosion_size + 1), (erosion_size, erosion_size) )
+    thresh = cv.erode(thresh, element)
+
+    coords = cv.findNonZero(thresh)
+    angle = cv.minAreaRect(coords)[-1]
+    # the `cv.minAreaRect` function returns values in the
+    # range [-90, 0) if the angle is less than -45 we need to add 90 to it
+    if angle < -45:
+        angle = (90 + angle)
+
+    (h, w) = image.shape[:2]
+    center = (w // 2, h // 2)
+    M = cv.getRotationMatrix2D(center, angle, 1.0)
+    rotated = cv.warpAffine(image, M, (w, h), flags=cv.INTER_CUBIC, borderMode=cv.BORDER_REPLICATE)
+    cv.putText(rotated, "Angle: {:.2f} degrees".format(angle), (10, 30), cv.FONT_HERSHEY_SIMPLEX, 0.7, (0, 0, 255), 2)
+
+    # show the output image
+    print("[INFO] angle: {:.2f}".format(angle))
+    cv.imshow("Input", image)
+    cv.imshow("Rotated", rotated)
+    cv.waitKey(0)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
<!-- Please use this line to close one or multiple issues when this pullrequest gets merged
You can add another line right under the first one:
resolves #1234
resolves #1235
-->

### This pull request changes

Given an image containing a rotated block of text at an unknown angle  in an image, it corrects the text skew by </br>

1. Detecting the block of text in the image .</br>
2. Computing the angle of the rotated text </br>
3. Rotating the image to correct for the skew. 
Before</br>
![image](https://user-images.githubusercontent.com/34737471/71050782-2c33d380-216c-11ea-8bd5-2e90aef70747.jpeg)
After</br>
![corrected](https://user-images.githubusercontent.com/34737471/71050798-3786ff00-216c-11ea-88ae-6e054d65e2a0.jpeg)
