### PR TITLE
Added a helper function that will list all available Intel devices

### DIFF
--- a/modules/dnn/include/opencv2/dnn/utils/inference_engine.hpp
+++ b/modules/dnn/include/opencv2/dnn/utils/inference_engine.hpp
@@ -42,6 +42,10 @@ CV_EXPORTS_W cv::String setInferenceEngineBackendType(const cv::String& newBacke
  */
 CV_EXPORTS_W void resetMyriadDevice();
 
+/** @brief List available devices
+ * The devices are returned as { "CPU", "GPU", "FPGA.0", "FPGA.1", "MYRIAD" }
+ */
+CV_EXPORTS_W std::vector<std::string> listInferenceEngineDevices();
 
 /* Values for 'OPENCV_DNN_IE_VPU_TYPE' parameter */
 #define CV_DNN_INFERENCE_ENGINE_VPU_TYPE_UNSPECIFIED ""

--- a/modules/dnn/src/op_inf_engine.cpp
+++ b/modules/dnn/src/op_inf_engine.cpp
@@ -1045,6 +1045,20 @@ void forwardInfEngine(const std::vector<Ptr<BackendWrapper> >& outBlobsWrappers,
 
 CV__DNN_INLINE_NS_BEGIN
 
+std::vector<std::string> listInferenceEngineDevices()
+{
+    std::vector<std::string> availableDevices;
+#if INF_ENGINE_VER_MAJOR_LE(INF_ENGINE_RELEASE_2019R1)
+    auto& sharedPlugins = getSharedPlugins();
+    availableDevices << "TODO";
+    return allDevices;
+#else
+    InferenceEngine::Core ie = getCore();
+    availableDevices = ie.GetAvailableDevices();
+#endif
+    return availableDevices;
+}
+
 void resetMyriadDevice()
 {
 #ifdef HAVE_INF_ENGINE

--- a/modules/dnn/src/op_inf_engine.cpp
+++ b/modules/dnn/src/op_inf_engine.cpp
@@ -1048,6 +1048,7 @@ CV__DNN_INLINE_NS_BEGIN
 std::vector<std::string> listInferenceEngineDevices()
 {
     std::vector<std::string> availableDevices;
+#ifdef HAVE_INF_ENGINE
 #if INF_ENGINE_VER_MAJOR_LE(INF_ENGINE_RELEASE_2019R1)
     auto& sharedPlugins = getSharedPlugins();
     availableDevices << "TODO";
@@ -1056,6 +1057,7 @@ std::vector<std::string> listInferenceEngineDevices()
     InferenceEngine::Core ie = getCore();
     availableDevices = ie.GetAvailableDevices();
 #endif
+#endif  // HAVE_INF_ENGINE
     return availableDevices;
 }
 


### PR DESCRIPTION
 compatible with OpenVino inference engine (cpu, gpus, movidius, etc.)

### This pullrequest changes

new cv::dnn::listInferenceEngineDevices() which is a wrapper on InferenceEngine::Core::GetAvailableDevices()
