### PR TITLE
Change program type in hdr format files to modern value: RADIANCE so

### DIFF
--- a/modules/imgcodecs/src/rgbe.cpp
+++ b/modules/imgcodecs/src/rgbe.cpp
@@ -145,7 +145,7 @@ rgbe2float(float *red, float *green, float *blue, unsigned char rgbe[4])
 /* default minimal header. modify if you want more information in header */
 int RGBE_WriteHeader(FILE *fp, int width, int height, rgbe_header_info *info)
 {
-  const char *programtype = "RGBE";
+  const char *programtype = "RADIANCE";
 
   if (info && (info->valid & RGBE_VALID_PROGRAMTYPE))
     programtype = info->programtype;


### PR DESCRIPTION
modern readers that expect RADIANCE will read it

<!-- Please use this line to close one or multiple issues when this pullrequest gets merged
You can add another line right under the first one:
resolves #1234
resolves #1235
-->

### This pullrequest changes
the rgbe.cpp HDR image format codec to output RADIANCE as the program type in header. This is the commonly expected value for this file format.

<!-- Please describe what your pullrequest is changing -->
