### PR TITLE
release: OpenCV 4.2.0

### DIFF
--- a/modules/core/include/opencv2/core/version.hpp
+++ b/modules/core/include/opencv2/core/version.hpp
@@ -8,7 +8,7 @@
 #define CV_VERSION_MAJOR    4
 #define CV_VERSION_MINOR    2
 #define CV_VERSION_REVISION 0
-#define CV_VERSION_STATUS   "-pre"
+#define CV_VERSION_STATUS   ""
 
 #define CVAUX_STR_EXP(__A)  #__A
 #define CVAUX_STR(__A)      CVAUX_STR_EXP(__A)


### PR DESCRIPTION
relates #16078

<cut/>

<details>

<summary>VirusTotal scan results:</summary>

[opencv_world420.dll (vc14)](https://www.virustotal.com/gui/file/1fe571c8faf3fc1c55bd91bcfa854eb25acec36e8dc6ff7f39ee35b8da3a8800/detection)
[opencv_world420d.dll (vc14)](https://www.virustotal.com/gui/file/3457fe06413f21b69ef3ee0c61e988e784f3cd25febbd5c56e255cece388394a/detection) 
[opencv_world420.dll (vc15)](https://www.virustotal.com/gui/file/ebf0e8976d76623addfd3f902ede9b9caf627b1f35018bc9a3002f2fe1c8e217/detection)
[opencv_world420d.dll (vc15)](https://www.virustotal.com/gui/file/76837bc159fa286f0f619165871ae9ebf8a397d036633763e6305b19004528c0/detection)

detections from `Trapmine: *.ml.score`, [considered false positive](https://stackoverflow.com/questions/54052224/virustotal-trapmine-suspicious-low-ml-score) - 2019-12-20

[opencv_ffmpeg420_64.dll](virustotal.com/gui/file/bc6cca11924263d28c5716afba6208101574d190301ce9281af942c6d5c6b4dd/detection)
[opencv_ffmpeg420.dll](https://www.virustotal.com/gui/file/7f4addc67fe8abb56d2c961ae16c275d3f0acdf17b20ca309e8a89ce847ac3b7/detection)

</details>