### PR TITLE
Android move version info to Gradle style

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ bin/
 *.tlog
 build
 node_modules
+*.iml

--- a/.gitignore
+++ b/.gitignore
@@ -23,4 +23,3 @@ bin/
 *.tlog
 build
 node_modules
-*.iml

--- a/modules/java/android_sdk/android_gradle_lib/AndroidManifest.xml
+++ b/modules/java/android_sdk/android_gradle_lib/AndroidManifest.xml
@@ -1,6 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-      package="org.opencv"
-      android:versionCode="@OPENCV_VERSION_MAJOR@@OPENCV_VERSION_MINOR@@OPENCV_VERSION_PATCH@0"
-      android:versionName="@OPENCV_VERSION@">
+      package="org.opencv" >
 </manifest>

--- a/modules/java/android_sdk/android_gradle_lib/build.gradle
+++ b/modules/java/android_sdk/android_gradle_lib/build.gradle
@@ -1,12 +1,17 @@
 apply plugin: 'com.android.library'
 
+def openCVersionName = "@OPENCV_VERSION@"
+def openCVersionCode = @OPENCV_VERSION_MAJOR@@OPENCV_VERSION_MINOR@@OPENCV_VERSION_PATCH@0
+
 android {
     compileSdkVersion @ANDROID_COMPILE_SDK_VERSION@
-    //buildToolsVersion "x.y.z" // not needed since com.android.tools.build:gradle:3.0.0
 
     defaultConfig {
         minSdkVersion @ANDROID_MIN_SDK_VERSION@
         targetSdkVersion @ANDROID_TARGET_SDK_VERSION@
+
+        versionCode openCVersionCode
+        versionName openCVersionName
 
         externalNativeBuild {
             cmake {

--- a/modules/java/android_sdk/android_gradle_lib/build.gradle
+++ b/modules/java/android_sdk/android_gradle_lib/build.gradle
@@ -1,7 +1,7 @@
 apply plugin: 'com.android.library'
 
 def openCVersionName = "@OPENCV_VERSION@"
-def openCVersionCode = @OPENCV_VERSION_MAJOR@@OPENCV_VERSION_MINOR@@OPENCV_VERSION_PATCH@0
+def openCVersionCode = ((@OPENCV_VERSION_MAJOR@ * 100 + @OPENCV_VERSION_MINOR@) * 100 + @OPENCV_VERSION_PATCH@) * 10 + 0
 
 android {
     compileSdkVersion @ANDROID_COMPILE_SDK_VERSION@

--- a/modules/java/android_sdk/android_lib/AndroidManifest.xml
+++ b/modules/java/android_sdk/android_lib/AndroidManifest.xml
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-      package="org.opencv"
-      android:versionCode="@OPENCV_VERSION_MAJOR@@OPENCV_VERSION_MINOR@@OPENCV_VERSION_PATCH@0"
-      android:versionName="@OPENCV_VERSION@">
+      package="org.opencv">
 
     <uses-sdk android:minSdkVersion="8" android:targetSdkVersion="21" />
 </manifest>

--- a/modules/java/android_sdk/build.gradle.in
+++ b/modules/java/android_sdk/build.gradle.in
@@ -90,15 +90,20 @@
 
 apply plugin: 'com.android.library'
 
-println "OpenCV: " + project.buildscript.sourceFile
+def openCVersionName = "@OPENCV_VERSION@"
+def openCVersionCode = @OPENCV_VERSION_MAJOR@@OPENCV_VERSION_MINOR@@OPENCV_VERSION_PATCH@0
+
+println "OpenCV: " +openCVersionName + " " + project.buildscript.sourceFile
 
 android {
     compileSdkVersion @ANDROID_COMPILE_SDK_VERSION@
-    //buildToolsVersion "x.y.z" // not needed since com.android.tools.build:gradle:3.0.0
 
     defaultConfig {
         minSdkVersion @ANDROID_MIN_SDK_VERSION@
         targetSdkVersion @ANDROID_TARGET_SDK_VERSION@
+
+        versionCode openCVersionCode
+        versionName openCVersionName
 
         externalNativeBuild {
             cmake {

--- a/modules/java/generator/android/java/org/opencv/android/OpenCVLoader.java
+++ b/modules/java/generator/android/java/org/opencv/android/OpenCVLoader.java
@@ -2,6 +2,8 @@ package org.opencv.android;
 
 import android.content.Context;
 
+import org.opencv.BuildConfig;
+
 /**
  * Helper class provides common initialization methods for OpenCV library.
  */
@@ -95,7 +97,7 @@ public class OpenCVLoader
     /**
      * Current OpenCV Library version
      */
-    public static final String OPENCV_VERSION = "@OPENCV_VERSION_MAJOR@.@OPENCV_VERSION_MINOR@.@OPENCV_VERSION_PATCH@";
+    public static final String OPENCV_VERSION = BuildConfig.VERSION_NAME;
 
 
     /**


### PR DESCRIPTION
### This pullrequest changes

Currently you set Android version info in `AndroidManifest.xml` , but this is an old relict from Eclipse time. The Gradle way is to have this info in `build.gradle`

Btw, how you provide the Android release is very confusing at least to me. I was not able to test my pull request properly. To be honest, I would like a out-of-the-box running Android project within this repo and no `build.gradle.in` files and so on. Then we could much easier contribute to the Android part. 
