### PR TITLE
dnn: small fix in pose estimation model

### DIFF
--- a/modules/dnn/src/model.cpp
+++ b/modules/dnn/src/model.cpp
@@ -177,8 +177,8 @@ std::vector<Point2f> KeypointsModel::estimate(InputArray frame, float thresh)
                 p = maxLoc;
                 p.x *= (float)frameWidth / width;
                 p.y *= (float)frameHeight / height;
-                points.push_back(p);
             }
+            points.push_back(p);
         }
     }
     // Otherwise the output is a vector of keypoints and we can just return it

--- a/modules/dnn/test/test_model.cpp
+++ b/modules/dnn/test/test_model.cpp
@@ -273,9 +273,15 @@ TEST_P(Test_Model, Keypoints_pose)
 #endif
 
     Mat inp = imread(_tf("pose.png"));
-    std::string weights = _tf("onnx/models/lightweight_pose_estimation.onnx", false);
-    Mat exp = blobFromNPY(_tf("keypoints_exp.npy"));
-
+    std::string weights = _tf("onnx/models/lightweight_pose_estimation_201912.onnx", false);
+    float kpdata[] = {
+        237.65625f, 78.25f, 237.65625f, 136.9375f,
+        190.125f, 136.9375f, 142.59375f, 195.625f, 79.21875f, 176.0625f, 285.1875f, 117.375f,
+        348.5625f, 195.625f, 396.09375f, 176.0625f, 205.96875f, 313.0f, 205.96875f, 430.375f,
+        205.96875f, 528.1875f, 269.34375f, 293.4375f, 253.5f, 430.375f, 237.65625f, 528.1875f,
+        221.8125f, 58.6875f, 253.5f, 58.6875f, 205.96875f, 78.25f, 253.5f, 58.6875f
+    };
+    Mat exp(18, 2, CV_32FC1, kpdata);
 
     Size size{256, 256};
     float norm = 1e-4;


### PR DESCRIPTION
resolves #16204 , if merged with https://github.com/opencv/opencv_extra/pull/692

insert (-1,-1) keypoints in case of low probability, instead of skipping them.