### PR TITLE
Allow controlling the random number generator for RTrees training

### DIFF
--- a/modules/ml/src/rtrees.cpp
+++ b/modules/ml/src/rtrees.cpp
@@ -90,12 +90,12 @@ public:
         CV_TRACE_FUNCTION();
         DTreesImpl::clear();
         oobError = 0.;
-        rng = RNG((uint64)-1);
     }
 
     const vector<int>& getActiveVars() CV_OVERRIDE
     {
         CV_TRACE_FUNCTION();
+        RNG &rng = theRNG();
         int i, nvars = (int)allVars.size(), m = (int)activeVars.size();
         for( i = 0; i < nvars; i++ )
         {
@@ -134,6 +134,7 @@ public:
     bool train( const Ptr<TrainData>& trainData, int flags ) CV_OVERRIDE
     {
         CV_TRACE_FUNCTION();
+        RNG &rng = theRNG();
         CV_Assert(!trainData.empty());
         startTraining(trainData, flags);
         int treeidx, ntrees = (rparams.termCrit.type & TermCriteria::COUNT) != 0 ?
@@ -424,7 +425,6 @@ public:
     double oobError;
     vector<float> varImportance;
     vector<int> allVars, activeVars;
-    RNG rng;
 };
 
 


### PR DESCRIPTION
Currently the random number generator for training `cv::ml::RTrees` is seeded with a hardcoded value, which ensures that every forest trained with the same data yields identical results.

This PR adds a method for modifying the training seed per instance in order to allow training new or
additional solutions if desired.

Ultimately, this enables parallelized training / evaluation via forest subdivision. I.e. use `N` threads with `M` trees each instead of training a single `N*M` wide forest.

There are other benefits to this as well, like determining the variance of a model for a given set of hyperparameters.

**Update:** PR modified to make use of global `theRNG()` for `RTrees` training, making random forests random by default. Previous deterministic behavior is achieved by calling `cv::setRNGSeed` before training.