### PR TITLE
cuda4dnn(conv): use cudnn for conv + bias + relu fusion

### DIFF
--- a/modules/dnn/src/cuda4dnn/csl/cudnn/activation.hpp
+++ b/modules/dnn/src/cuda4dnn/csl/cudnn/activation.hpp
@@ -1,0 +1,80 @@
+// This file is part of OpenCV project.
+// It is subject to the license terms in the LICENSE file found in the top-level directory
+// of this distribution and at http://opencv.org/license.html.
+
+#ifndef OPENCV_DNN_CUDA4DNN_CSL_CUDNN_ACTIVATION_HPP
+#define OPENCV_DNN_CUDA4DNN_CSL_CUDNN_ACTIVATION_HPP
+
+#include <cudnn.h>
+
+namespace cv { namespace dnn { namespace cuda4dnn { namespace csl { namespace cudnn {
+
+    class ActivationDescriptor {
+    public:
+        enum class ActivationType {
+            IDENTITY,
+            RELU,
+            CLIPPED_RELU,
+            TANH,
+            SIGMOID,
+            ELU
+        };
+
+        ActivationDescriptor() noexcept : descriptor{ nullptr } { }
+        ActivationDescriptor(const ActivationDescriptor&) = delete;
+        ActivationDescriptor(ActivationDescriptor&& other) noexcept
+            : descriptor{ other.descriptor } {
+            other.descriptor = nullptr;
+        }
+
+        /* `relu_ceiling_or_elu_alpha`:
+         * - `alpha` coefficient in ELU activation
+         * - `ceiling` for CLIPPED_RELU activation
+         */
+        ActivationDescriptor(ActivationType type, double relu_ceiling_or_elu_alpha = 0.0) {
+            CUDA4DNN_CHECK_CUDNN(cudnnCreateActivationDescriptor(&descriptor));
+            try {
+                const auto mode = [type] {
+                    switch(type) {
+                        case ActivationType::IDENTITY: return CUDNN_ACTIVATION_IDENTITY;
+                        case ActivationType::RELU: return CUDNN_ACTIVATION_RELU;
+                        case ActivationType::CLIPPED_RELU: return CUDNN_ACTIVATION_CLIPPED_RELU;
+                        case ActivationType::SIGMOID: return CUDNN_ACTIVATION_SIGMOID;
+                        case ActivationType::TANH: return CUDNN_ACTIVATION_TANH;
+                        case ActivationType::ELU: return CUDNN_ACTIVATION_ELU;
+                    }
+                    CV_Assert(0);
+                    return CUDNN_ACTIVATION_IDENTITY;
+                } ();
+
+                CUDA4DNN_CHECK_CUDNN(cudnnSetActivationDescriptor(descriptor, mode, CUDNN_NOT_PROPAGATE_NAN, relu_ceiling_or_elu_alpha));
+            } catch(...) {
+                /* cudnnDestroyActivationDescriptor will not fail for a valid descriptor object */
+                CUDA4DNN_CHECK_CUDNN(cudnnDestroyActivationDescriptor(descriptor));
+                throw;
+            }
+        }
+
+        ~ActivationDescriptor() noexcept {
+            if (descriptor != nullptr) {
+                /* cudnnDestroyActivationDescriptor will not fail */
+                CUDA4DNN_CHECK_CUDNN(cudnnDestroyActivationDescriptor(descriptor));
+            }
+        }
+
+        ActivationDescriptor& operator=(const ActivationDescriptor&) = delete;
+        ActivationDescriptor& operator=(ActivationDescriptor&& other) noexcept {
+            descriptor = other.descriptor;
+            other.descriptor = nullptr;
+            return *this;
+        };
+
+        cudnnActivationDescriptor_t get() const noexcept { return descriptor; }
+
+    private:
+        cudnnActivationDescriptor_t descriptor;
+    };
+
+}}}}} /* namespace cv::dnn::cuda4dnn::csl::cudnn */
+
+#endif /* OPENCV_DNN_CUDA4DNN_CSL_CUDNN_ACTIVATION_HPP */

--- a/modules/dnn/src/cuda4dnn/csl/cudnn/convolution.hpp
+++ b/modules/dnn/src/cuda4dnn/csl/cudnn/convolution.hpp
@@ -6,6 +6,7 @@
 #define OPENCV_DNN_CUDA4DNN_CSL_CUDNN_CONVOLUTION_HPP
 
 #include "cudnn.hpp"
+#include "activation.hpp"
 
 #include "../pointer.hpp"
 #include "../workspace.hpp"
@@ -403,6 +404,93 @@ namespace cv { namespace dnn { namespace cuda4dnn { namespace csl { namespace cu
                 &beta_, outputDesc.get(), outputPtr.get()
             )
         );
+    }
+
+    /** @brief performs convolution, bias addition and activation simultaneously
+     *
+     * dstValue = act(alpha * conv(input) + bias)
+     *
+     * @tparam          T           convolution element type (must be `half` or `float`)
+     *
+     * @param           handle      valid cuDNN Handle
+     * @param           convDesc    convolution description
+     * @param           convAlgo    algorithm to use for convolution
+     * @param           workspace   workspace memory which meets the requirements of \p convAlgo
+     * @param           filterDesc  filter descriptor
+     * @param[in]       filterPtr   pointer to device memory containing the filters
+     * @param           alpha       convolution scale factor
+     * @param           inputDesc   tensor descriptor describing the input
+     * @param[in]       inputPtr    pointer to input tensor in device memory
+     * @param           biasDesc    tensor descriptor describing the bias
+     * @param[in]       biasPtr     pointer to bias tensor in device memory
+     * @param           actDesc     activation descriptor
+     * @param           outputDesc  tensor descriptor describing the output
+     * @param[out]      outputPtr   pointer to output tensor in device memory
+     *
+     * Exception Guarantee: Basic
+     */
+    template <class T>
+    void convolve_with_bias_activation(
+        const Handle& handle,
+        T alpha,
+        const ConvolutionDescriptor<T>& convDesc,
+        const ConvolutionAlgorithm<T>& convAlgo,
+        WorkspaceInstance workspace,
+        const FilterDescriptor<T>& filterDesc,
+        DevicePtr<const T> filterPtr,
+        const TensorDescriptor<T>& inputDesc,
+        DevicePtr<const T> inputPtr,
+        const TensorDescriptor<T>& biasDesc,
+        DevicePtr<const T> biasPtr,
+        const ActivationDescriptor& actDesc,
+        const TensorDescriptor<T>& outputDesc,
+        DevicePtr<T> outputPtr)
+    {
+        CV_Assert(handle);
+
+        T alpha2 = 0.0;
+        CUDA4DNN_CHECK_CUDNN(cudnnConvolutionBiasActivationForward(
+            handle.get(),
+            &alpha, inputDesc.get(), inputPtr.get(),
+            filterDesc.get(), filterPtr.get(),
+            convDesc.get(), convAlgo.get(),
+            static_cast<void*>(workspace.get()), workspace.size_in_bytes(),
+            &alpha2, outputDesc.get(), outputPtr.get(),
+            biasDesc.get(), biasPtr.get(),
+            actDesc.get(),
+            outputDesc.get(), outputPtr.get()));
+    }
+
+    template <> inline
+    void convolve_with_bias_activation(
+        const Handle& handle,
+        half alpha,
+        const ConvolutionDescriptor<half>& convDesc,
+        const ConvolutionAlgorithm<half>& convAlgo,
+        WorkspaceInstance workspace,
+        const FilterDescriptor<half>& filterDesc,
+        DevicePtr<const half> filterPtr,
+        const TensorDescriptor<half>& inputDesc,
+        DevicePtr<const half> inputPtr,
+        const TensorDescriptor<half>& biasDesc,
+        DevicePtr<const half> biasPtr,
+        const ActivationDescriptor& actDesc,
+        const TensorDescriptor<half>& outputDesc,
+        DevicePtr<half> outputPtr)
+    {
+        CV_Assert(handle);
+
+        float alpha_ = alpha, alpha2 = 0.0;
+        CUDA4DNN_CHECK_CUDNN(cudnnConvolutionBiasActivationForward(
+            handle.get(),
+            &alpha_, inputDesc.get(), inputPtr.get(),
+            filterDesc.get(), filterPtr.get(),
+            convDesc.get(), convAlgo.get(),
+            static_cast<void*>(workspace.get()), workspace.size_in_bytes(),
+            &alpha2, outputDesc.get(), outputPtr.get(),
+            biasDesc.get(), biasPtr.get(),
+            actDesc.get(),
+            outputDesc.get(), outputPtr.get()));
     }
 
 }}}}} /* namespace cv::dnn::cuda4dnn::csl::cudnn */


### PR DESCRIPTION
### This pullrequest changes
cuDNN supports conv + bias + relu fusion in some configurations. This PR enables this cuDNN optimized path whenever possible.

**Device:** GTX 1050

Model                               | without this patch | with this patch
--------------------------------- | ----------------------- | -------------------
Inception v2 MaskRCNN (1024x1024) | 187.6ms               | **180.3ms**
