### PR TITLE
Patch/python38 clock

### DIFF
--- a/samples/python/lk_track.py
+++ b/samples/python/lk_track.py
@@ -26,7 +26,6 @@ import cv2 as cv
 
 import video
 from common import anorm2, draw_str
-from time import clock
 
 lk_params = dict( winSize  = (15, 15),
                   maxLevel = 2,

--- a/samples/python/video.py
+++ b/samples/python/video.py
@@ -39,9 +39,6 @@ import re
 
 from numpy import pi, sin, cos
 
-# built-in modules
-from time import clock
-
 # local modules
 from tst_scene_render import TestSceneRender
 import common


### PR DESCRIPTION
### This pullrequest changes

Removed ``clock`` import from time module. It was removed in Python3.8 and causes the samples not to run.

It appears to be unused in both of the changed files.

```digits_adjust.py```, ```facedetect.py```, and ```videa_threaded.py``` all use the ```clock()``` function from ```common.py```

Python 3.7:

```
Python 3.7.5 (default, Nov 20 2019, 09:21:52) 
[GCC 9.2.1 20191008] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> from time import clock
>>> clock()
__main__:1: DeprecationWarning: time.clock has been deprecated in Python 3.3 and will be removed from Python 3.8: use time.perf_counter or time.process_time instead
```

Python 3.8:

```
Python 3.8.0 (default, Oct 28 2019, 16:14:01) 
[GCC 9.2.1 20191008] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> from time import clock

...

Original exception was:
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
ImportError: cannot import name 'clock' from 'time' (unknown location)
```
