### PR TITLE
add a wrapper for getAvailableTargets

### DIFF
--- a/modules/dnn/include/opencv2/dnn/dnn.hpp
+++ b/modules/dnn/include/opencv2/dnn/dnn.hpp
@@ -102,7 +102,7 @@ CV__DNN_EXPERIMENTAL_NS_BEGIN
     };
 
     CV_EXPORTS std::vector< std::pair<Backend, Target> > getAvailableBackends();
-    CV_EXPORTS_W std::vector<Target> getAvailableTargets(Backend be);
+    CV_EXPORTS_W std::vector<Target> getAvailableTargets(dnn::Backend be);
 
     /** @brief This class provides all data needed to initialize layer.
      *

--- a/modules/dnn/include/opencv2/dnn/dnn.hpp
+++ b/modules/dnn/include/opencv2/dnn/dnn.hpp
@@ -94,7 +94,7 @@ CV__DNN_EXPERIMENTAL_NS_BEGIN
      */
     enum Target
     {
-        DNN_TARGET_CPU,
+        DNN_TARGET_CPU = 0,
         DNN_TARGET_OPENCL,
         DNN_TARGET_OPENCL_FP16,
         DNN_TARGET_MYRIAD,
@@ -102,7 +102,7 @@ CV__DNN_EXPERIMENTAL_NS_BEGIN
     };
 
     CV_EXPORTS std::vector< std::pair<Backend, Target> > getAvailableBackends();
-    CV_EXPORTS std::vector<Target> getAvailableTargets(Backend be);
+    CV_EXPORTS_W std::vector<Target> getAvailableTargets(Backend be);
 
     /** @brief This class provides all data needed to initialize layer.
      *

--- a/modules/dnn/misc/java/gen_dict.json
+++ b/modules/dnn/misc/java/gen_dict.json
@@ -36,6 +36,14 @@
             "v_type": "vector_Layer",
             "j_import": "org.opencv.dnn.Layer"
         },
+        "vector_Target": {
+            "j_type": "List<Integer>",
+            "jn_type": "List<Integer>",
+            "jni_type": "jobject",
+            "jni_var": "std::vector< cv::dnn::Target > %(n)s",
+            "suffix": "Ljava_util_List",
+            "v_type": "vector_Target"
+        },
         "LayerId": {
             "j_type": "DictValue",
             "jn_type": "long",

--- a/modules/dnn/misc/java/src/cpp/dnn_converters.cpp
+++ b/modules/dnn/misc/java/src/cpp/dnn_converters.cpp
@@ -59,6 +59,25 @@ jobject vector_Ptr_Layer_to_List(JNIEnv* env, std::vector<cv::Ptr<cv::dnn::Layer
     return result;
 }
 
+jobject vector_Target_to_List(JNIEnv* env, std::vector<cv::dnn::Target>& vs)
+{
+    static jclass juArrayList   = ARRAYLIST(env);
+    static jmethodID m_create   = CONSTRUCTOR(env, juArrayList);
+    jmethodID m_add       = LIST_ADD(env, juArrayList);
+
+    static jclass jInteger = env->FindClass("java/lang/Integer");
+    static jmethodID m_create_Integer = env->GetMethodID(jInteger, "<init>", "(I)V");
+
+    jobject result = env->NewObject(juArrayList, m_create, vs.size());
+    for (size_t i = 0; i < vs.size(); ++i)
+    {
+        jobject element = env->NewObject(jInteger, m_create_Integer, vs[i]);
+        env->CallBooleanMethod(result, m_add, element);
+        env->DeleteLocalRef(element);
+    }
+    return result;
+}
+
 std::vector<cv::Ptr<cv::dnn::Layer> > List_to_vector_Ptr_Layer(JNIEnv* env, jobject list)
 {
     static jclass juArrayList       = ARRAYLIST(env);

--- a/modules/dnn/misc/java/src/cpp/dnn_converters.hpp
+++ b/modules/dnn/misc/java/src/cpp/dnn_converters.hpp
@@ -28,5 +28,6 @@ jobject vector_Ptr_Layer_to_List(JNIEnv* env, std::vector<cv::Ptr<cv::dnn::Layer
 
 std::vector<cv::Ptr<cv::dnn::Layer> > List_to_vector_Ptr_Layer(JNIEnv* env, jobject list);
 
+jobject vector_Target_to_List(JNIEnv* env, std::vector<cv::dnn::Target>& vs);
 
 #endif	/* DNN_CONVERTERS_HPP */

--- a/modules/dnn/misc/java/test/DnnTensorFlowTest.java
+++ b/modules/dnn/misc/java/test/DnnTensorFlowTest.java
@@ -141,4 +141,9 @@ public class DnnTensorFlowTest extends OpenCVTestCase {
         net = Dnn.readNetFromTensorflow(new MatOfByte(modelBuffer));
         checkInceptionNet(net);
     }
+
+    public void testGetAvailableTargets() {
+        List<Integer> targets = Dnn.getAvailableTargets(Dnn.DNN_BACKEND_OPENCV);
+        assertTrue(targets.contains(Dnn.DNN_TARGET_CPU));
+    }
 }

--- a/modules/dnn/misc/python/pyopencv_dnn.hpp
+++ b/modules/dnn/misc/python/pyopencv_dnn.hpp
@@ -71,6 +71,12 @@ PyObject* pyopencv_from(const dnn::LayerParams& lp)
     return dict;
 }
 
+template<>
+PyObject* pyopencv_from(const std::vector<dnn::Target> &t)
+{
+    return pyopencv_from(std::vector<int>(t.begin(), t.end()));
+}
+
 class pycvLayer CV_FINAL : public dnn::Layer
 {
 public:

--- a/modules/dnn/misc/python/test/test_dnn.py
+++ b/modules/dnn/misc/python/test/test_dnn.py
@@ -117,6 +117,10 @@ class dnn_test(NewOpenCVTests):
             return False
         return True
 
+    def test_getAvailableTargets(self):
+        targets = cv.dnn.getAvailableTargets(cv.dnn.DNN_BACKEND_OPENCV)
+        self.assertTrue(cv.dnn.DNN_TARGET_CPU in targets)
+
     def test_blobFromImage(self):
         np.random.seed(324)
 


### PR DESCRIPTION
as requested by @dkurt here: https://github.com/opencv/opencv/pull/16184#issuecomment-569006520

<cut/>

```
force_builders=Custom,Custom Win,Custom Mac
build_image:Custom=ubuntu-openvino-2019r3.0:16.04
build_image:Custom Win=openvino-2019r3.0
build_image:Custom Mac=openvino-2019r3.0

test_modules:Custom=dnn,python2,python3,java
test_modules:Custom Win=dnn,python2,python3,java
test_modules:Custom Mac=dnn,python2,python3,java

buildworker:Custom=linux-1
# disabled due high memory usage: test_opencl:Custom=ON
test_opencl:Custom=OFF
test_bigdata:Custom=1
test_filter:Custom=*
```