### PR TITLE
Enable cmake CMP0077 policy

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -68,6 +68,9 @@ if(POLICY CMP0075)
   cmake_policy(SET CMP0075 NEW)  # CMake 3.12+: Include file check macros honor `CMAKE_REQUIRED_LIBRARIES`
 endif()
 
+if(POLICY CMP0077)
+  cmake_policy(SET CMP0077 NEW)  # CMake 3.13+: option() honors normal variables.
+endif()
 
 #
 # Configure OpenCV CMake hooks


### PR DESCRIPTION
When building OpenCV as a sub-project using cmake's add_subdirectory()
the OpenCV's build options would be overwritten to its default
state. With cmake 3.13+ the CMP0077 policy, option() honors previous
definitions via set().
