### PR TITLE
Convolution padding parsing modified

### DIFF
--- a/modules/dnn/src/darknet/darknet_io.cpp
+++ b/modules/dnn/src/darknet/darknet_io.cpp
@@ -556,6 +556,7 @@ namespace cv {
                     {
                         int kernel_size = getParam<int>(layer_params, "size", -1);
                         int pad = getParam<int>(layer_params, "pad", 0);
+                        int padding = getParam<int>(layer_params, "padding", 0);
                         int stride = getParam<int>(layer_params, "stride", 1);
                         int filters = getParam<int>(layer_params, "filters", -1);
                         bool batch_normalize = getParam<int>(layer_params, "batch_normalize", 0) == 1;
@@ -563,13 +564,13 @@ namespace cv {
                         if (flipped == 1)
                             CV_Error(cv::Error::StsNotImplemented, "Transpose the convolutional weights is not implemented");
 
-                        // correct the strange value of pad=1 for kernel_size=1 in the Darknet cfg-file
-                        if (kernel_size < 3) pad = 0;
+                        if (pad)
+                            padding = kernel_size/2;
 
                         CV_Assert(kernel_size > 0 && filters > 0);
                         CV_Assert(current_channels > 0);
 
-                        setParams.setConvolution(kernel_size, pad, stride, filters, current_channels,
+                        setParams.setConvolution(kernel_size, padding, stride, filters, current_channels,
                             batch_normalize);
 
                         current_channels = filters;

--- a/modules/dnn/src/darknet/darknet_io.cpp
+++ b/modules/dnn/src/darknet/darknet_io.cpp
@@ -565,7 +565,7 @@ namespace cv {
                             CV_Error(cv::Error::StsNotImplemented, "Transpose the convolutional weights is not implemented");
 
                         if (pad)
-                            padding = kernel_size/2;
+                            padding = kernel_size / 2;
 
                         CV_Assert(kernel_size > 0 && filters > 0);
                         CV_Assert(current_channels > 0);

--- a/modules/dnn/test/test_darknet_importer.cpp
+++ b/modules/dnn/test/test_darknet_importer.cpp
@@ -528,6 +528,11 @@ TEST_P(Test_Darknet_layers, reorg)
     testDarknetLayer("reorg");
 }
 
+TEST_P(Test_Darknet_layers, convolutional)
+{
+    testDarknetLayer("convolutional");
+}
+
 INSTANTIATE_TEST_CASE_P(/**/, Test_Darknet_layers, dnnBackendsAndTargets());
 
 }} // namespace


### PR DESCRIPTION
**Merge with extra**: https://github.com/opencv/opencv_extra/pull/697

### This pullrequest modifies the parsing of 'padding' for convolution layers in darknet importer.
resolves #16259

```
opencv_extra=opencv_extra_modified
```