### PR TITLE
Fix lint issues in Android samples

### DIFF
--- a/samples/android/15-puzzle/src/org/opencv/samples/puzzle15/Puzzle15Activity.java
+++ b/samples/android/15-puzzle/src/org/opencv/samples/puzzle15/Puzzle15Activity.java
@@ -22,7 +22,7 @@ import java.util.List;
 
 public class Puzzle15Activity extends CameraActivity implements CvCameraViewListener, View.OnTouchListener {
 
-    private static final String  TAG = "Sample::Puzzle15::Activity";
+    private static final String  TAG = "Puzzle15::Activity";
 
     private CameraBridgeViewBase mOpenCvCameraView;
     private Puzzle15Processor    mPuzzle15;

--- a/samples/android/camera-calibration/src/org/opencv/samples/cameracalibration/CalibrationResult.java
+++ b/samples/android/camera-calibration/src/org/opencv/samples/cameracalibration/CalibrationResult.java
@@ -8,7 +8,7 @@ import android.content.SharedPreferences;
 import android.util.Log;
 
 public abstract class CalibrationResult {
-    private static final String TAG = "OCVSample::CalibrationResult";
+    private static final String TAG = "OCV::CalibrationResult";
 
     private static final int CAMERA_MATRIX_ROWS = 3;
     private static final int CAMERA_MATRIX_COLS = 3;
@@ -22,19 +22,19 @@ public abstract class CalibrationResult {
         cameraMatrix.get(0,  0, cameraMatrixArray);
         for (int i = 0; i < CAMERA_MATRIX_ROWS; i++) {
             for (int j = 0; j < CAMERA_MATRIX_COLS; j++) {
-                Integer id = i * CAMERA_MATRIX_ROWS + j;
-                editor.putFloat(id.toString(), (float)cameraMatrixArray[id]);
+                int id = i * CAMERA_MATRIX_ROWS + j;
+                editor.putFloat(Integer.toString(id), (float)cameraMatrixArray[id]);
             }
         }
 
         double[] distortionCoefficientsArray = new double[DISTORTION_COEFFICIENTS_SIZE];
         distortionCoefficients.get(0, 0, distortionCoefficientsArray);
         int shift = CAMERA_MATRIX_ROWS * CAMERA_MATRIX_COLS;
-        for (Integer i = shift; i < DISTORTION_COEFFICIENTS_SIZE + shift; i++) {
-            editor.putFloat(i.toString(), (float)distortionCoefficientsArray[i-shift]);
+        for (int i = shift; i < DISTORTION_COEFFICIENTS_SIZE + shift; i++) {
+            editor.putFloat(Integer.toString(i), (float)distortionCoefficientsArray[i-shift]);
         }
 
-        editor.commit();
+        editor.apply();
         Log.i(TAG, "Saved camera matrix: " + cameraMatrix.dump());
         Log.i(TAG, "Saved distortion coefficients: " + distortionCoefficients.dump());
     }
@@ -49,8 +49,8 @@ public abstract class CalibrationResult {
         double[] cameraMatrixArray = new double[CAMERA_MATRIX_ROWS * CAMERA_MATRIX_COLS];
         for (int i = 0; i < CAMERA_MATRIX_ROWS; i++) {
             for (int j = 0; j < CAMERA_MATRIX_COLS; j++) {
-                Integer id = i * CAMERA_MATRIX_ROWS + j;
-                cameraMatrixArray[id] = sharedPref.getFloat(id.toString(), -1);
+                int id = i * CAMERA_MATRIX_ROWS + j;
+                cameraMatrixArray[id] = sharedPref.getFloat(Integer.toString(id), -1);
             }
         }
         cameraMatrix.put(0, 0, cameraMatrixArray);
@@ -58,8 +58,8 @@ public abstract class CalibrationResult {
 
         double[] distortionCoefficientsArray = new double[DISTORTION_COEFFICIENTS_SIZE];
         int shift = CAMERA_MATRIX_ROWS * CAMERA_MATRIX_COLS;
-        for (Integer i = shift; i < DISTORTION_COEFFICIENTS_SIZE + shift; i++) {
-            distortionCoefficientsArray[i - shift] = sharedPref.getFloat(i.toString(), -1);
+        for (int i = shift; i < DISTORTION_COEFFICIENTS_SIZE + shift; i++) {
+            distortionCoefficientsArray[i - shift] = sharedPref.getFloat(Integer.toString(i), -1);
         }
         distortionCoefficients.put(0, 0, distortionCoefficientsArray);
         Log.i(TAG, "Loaded distortion coefficients: " + distortionCoefficients.dump());

--- a/samples/android/camera-calibration/src/org/opencv/samples/cameracalibration/CameraCalibrator.java
+++ b/samples/android/camera-calibration/src/org/opencv/samples/cameracalibration/CameraCalibrator.java
@@ -18,13 +18,13 @@ import org.opencv.imgproc.Imgproc;
 import android.util.Log;
 
 public class CameraCalibrator {
-    private static final String TAG = "OCVSample::CameraCalibrator";
+    private static final String TAG = "OCV::CameraCalibrator";
 
     private final Size mPatternSize = new Size(4, 11);
     private final int mCornersSize = (int)(mPatternSize.width * mPatternSize.height);
     private boolean mPatternWasFound = false;
     private MatOfPoint2f mCorners = new MatOfPoint2f();
-    private List<Mat> mCornersBuffer = new ArrayList<Mat>();
+    private List<Mat> mCornersBuffer = new ArrayList<>();
     private boolean mIsCalibrated = false;
 
     private Mat mCameraMatrix = new Mat();
@@ -53,10 +53,10 @@ public class CameraCalibrator {
     }
 
     public void calibrate() {
-        ArrayList<Mat> rvecs = new ArrayList<Mat>();
-        ArrayList<Mat> tvecs = new ArrayList<Mat>();
+        ArrayList<Mat> rvecs = new ArrayList<>();
+        ArrayList<Mat> tvecs = new ArrayList<>();
         Mat reprojectionErrors = new Mat();
-        ArrayList<Mat> objectPoints = new ArrayList<Mat>();
+        ArrayList<Mat> objectPoints = new ArrayList<>();
         objectPoints.add(Mat.zeros(mCornersSize, 1, CvType.CV_32FC3));
         calcBoardCornerPositions(objectPoints.get(0));
         for (int i = 1; i < mCornersBuffer.size(); i++) {
@@ -81,7 +81,7 @@ public class CameraCalibrator {
 
     private void calcBoardCornerPositions(Mat corners) {
         final int cn = 3;
-        float positions[] = new float[mCornersSize * cn];
+        float[] positions = new float[mCornersSize * cn];
 
         for (int i = 0; i < mPatternSize.height; i++) {
             for (int j = 0; j < mPatternSize.width * cn; j += cn) {
@@ -101,7 +101,7 @@ public class CameraCalibrator {
         MatOfPoint2f cornersProjected = new MatOfPoint2f();
         double totalError = 0;
         double error;
-        float viewErrors[] = new float[objectPoints.size()];
+        float[] viewErrors = new float[objectPoints.size()];
 
         MatOfDouble distortionCoefficients = new MatOfDouble(mDistortionCoefficients);
         int totalPoints = 0;


### PR DESCRIPTION
It fixes lint errors and warnings in Android samples.
Because library uses functions which requires camera permission, it makes more sense to move permissions to library instead of apply it to each sample separat 