### PR TITLE
dnn: prevent unloading of InferenceEngine plugins

### DIFF
--- a/modules/dnn/src/op_inf_engine.cpp
+++ b/modules/dnn/src/op_inf_engine.cpp
@@ -563,9 +563,43 @@ static std::map<std::string, InferenceEngine::InferenceEnginePluginPtr>& getShar
     return sharedPlugins;
 }
 #else
-InferenceEngine::Core& getCore()
+static bool init_IE_plugins()
+{
+    // load and hold IE plugins
+    static InferenceEngine::Core* init_core = new InferenceEngine::Core();  // 'delete' is never called
+    (void)init_core->GetAvailableDevices();
+    return true;
+}
+static InferenceEngine::Core& create_IE_Core_instance()
 {
     static InferenceEngine::Core core;
+    return core;
+}
+static InferenceEngine::Core& create_IE_Core_pointer()
+{
+    // load and hold IE plugins
+    static InferenceEngine::Core* core = new InferenceEngine::Core();  // 'delete' is never called
+    return *core;
+}
+InferenceEngine::Core& getCore()
+{
+    // to make happy memory leak tools use:
+    // - OPENCV_DNN_INFERENCE_ENGINE_HOLD_PLUGINS=0
+    // - OPENCV_DNN_INFERENCE_ENGINE_CORE_LIFETIME_WORKAROUND=0
+    static bool param_DNN_INFERENCE_ENGINE_HOLD_PLUGINS = utils::getConfigurationParameterBool("OPENCV_DNN_INFERENCE_ENGINE_HOLD_PLUGINS", true);
+    static bool init_IE_plugins_ = param_DNN_INFERENCE_ENGINE_HOLD_PLUGINS && init_IE_plugins(); CV_UNUSED(init_IE_plugins_);
+
+    static bool param_DNN_INFERENCE_ENGINE_CORE_LIFETIME_WORKAROUND =
+            utils::getConfigurationParameterBool("OPENCV_DNN_INFERENCE_ENGINE_CORE_LIFETIME_WORKAROUND",
+#ifdef _WIN32
+                true
+#else
+                false
+#endif
+            );
+    static InferenceEngine::Core& core = param_DNN_INFERENCE_ENGINE_CORE_LIFETIME_WORKAROUND
+            ? create_IE_Core_pointer()
+            : create_IE_Core_instance();
     return core;
 }
 #endif


### PR DESCRIPTION
<cut/>

```
force_builders=Custom,Custom Win,Custom Mac
build_image:Custom=ubuntu-openvino-2019r3.0:16.04
build_image:Custom Win=openvino-2019r3.0
build_image:Custom Mac=openvino-2019r3.0

test_modules:Custom=dnn,python2,python3,java
test_modules:Custom Win=dnn,python2,python3,java
test_modules:Custom Mac=dnn,python2,python3,java

buildworker:Custom=linux-1
# disabled due high memory usage: test_opencl:Custom=ON
test_opencl:Custom=OFF
test_bigdata:Custom=1
test_filter:Custom=*
```
