### PR TITLE
android: fix javadoc

### DIFF
--- a/modules/java/generator/android/java/org/opencv/android/OpenCVLoader.java.in
+++ b/modules/java/generator/android/java/org/opencv/android/OpenCVLoader.java.in
@@ -2,8 +2,6 @@ package org.opencv.android;
 
 import android.content.Context;
 
-import org.opencv.BuildConfig;
-
 /**
  * Helper class provides common initialization methods for OpenCV library.
  */
@@ -97,7 +95,7 @@ public class OpenCVLoader
     /**
      * Current OpenCV Library version
      */
-    public static final String OPENCV_VERSION = BuildConfig.VERSION_NAME;
+    public static final String OPENCV_VERSION = "@OPENCV_VERSION_MAJOR@.@OPENCV_VERSION_MINOR@.@OPENCV_VERSION_PATCH@";
 
 
     /**


### PR DESCRIPTION
partially reverts #16222

Javadoc doesn't know about Gradle and its scripts.
Should fix nightly builds: http://pullrequest.opencv.org/buildbot/builders/master_pack-android