### PR TITLE
carotene: Replace ipcp-unit-growth with ipa-cp-unit-growth on gcc >= 10

### DIFF
--- a/3rdparty/carotene/CMakeLists.txt
+++ b/3rdparty/carotene/CMakeLists.txt
@@ -20,8 +20,11 @@ if(CMAKE_COMPILER_IS_GNUCC)
     # - matchTemplate about 5-10%
     # - goodFeaturesToTrack 10-20%
     # - cornerHarris 30% for some cases
-
-    set_source_files_properties(${carotene_sources} COMPILE_FLAGS "--param ipcp-unit-growth=100000 --param inline-unit-growth=100000 --param large-stack-frame-growth=5000")
+    if(CMAKE_CXX_COMPILER_VERSION VERSION_LESS "10.0.0")
+        set_source_files_properties(${carotene_sources} COMPILE_FLAGS "--param ipcp-unit-growth=100000 --param inline-unit-growth=100000 --param large-stack-frame-growth=5000")
+    else()
+        set_source_files_properties(${carotene_sources} COMPILE_FLAGS "--param ipa-cp-unit-growth=100000 --param inline-unit-growth=100000 --param large-stack-frame-growth=5000")
+    endif()
 endif()
 
 add_library(carotene_objs OBJECT

--- a/3rdparty/carotene/hal/CMakeLists.txt
+++ b/3rdparty/carotene/hal/CMakeLists.txt
@@ -88,7 +88,11 @@ set_property(DIRECTORY APPEND PROPERTY COMPILE_DEFINITIONS ${carotene_defs})
     #   matchTemplate about 5-10%
     #   goodFeaturesToTrack 10-20%
     #   cornerHarris 30% for some cases
-    set_source_files_properties(impl.cpp $<TARGET_OBJECTS:carotene_objs> COMPILE_FLAGS "--param ipcp-unit-growth=100000 --param inline-unit-growth=100000 --param large-stack-frame-growth=5000")
+    if(CMAKE_CXX_COMPILER_VERSION VERSION_LESS "10.0.0")
+      set_source_files_properties(impl.cpp $<TARGET_OBJECTS:carotene_objs> COMPILE_FLAGS "--param ipcp-unit-growth=100000 --param inline-unit-growth=100000 --param large-stack-frame-growth=5000")
+    else()
+      set_source_files_properties(impl.cpp $<TARGET_OBJECTS:carotene_objs> COMPILE_FLAGS "--param ipa-cp-unit-growth=100000 --param inline-unit-growth=100000 --param large-stack-frame-growth=5000")
+    endif()
 #    set_source_files_properties(impl.cpp $<TARGET_OBJECTS:carotene_objs> COMPILE_FLAGS "--param ipcp-unit-growth=100000 --param inline-unit-growth=100000 --param large-stack-frame-growth=5000")
   endif()
 


### PR DESCRIPTION
gcc 10+ has renamed this option, therefore check for gcc version before
deciding which name to use for opt parameter


