### PR TITLE
feat(android): add parameter for choose modules for android

### DIFF
--- a/platforms/android/build_sdk.py
+++ b/platforms/android/build_sdk.py
@@ -226,6 +226,9 @@ class Builder:
         if self.ninja_path != 'ninja':
             cmake_vars['CMAKE_MAKE_PROGRAM'] = self.ninja_path
 
+        if self.config.modules_list is not None:
+            cmd.append("-DBUILD_LIST='%s'" % self.config.modules_list)
+
         if self.config.extra_modules_path is not None:
             cmd.append("-DOPENCV_EXTRA_MODULES_PATH='%s'" % self.config.extra_modules_path)
 
@@ -374,6 +377,7 @@ if __name__ == "__main__":
     parser.add_argument('--ndk_path', help="Path to Android NDK to use for build")
     parser.add_argument('--sdk_path', help="Path to Android SDK to use for build")
     parser.add_argument('--use_android_buildtools', action="store_true", help='Use cmake/ninja build tools from Android SDK')
+    parser.add_argument("--modules_list", help="List of  modules to include for build")
     parser.add_argument("--extra_modules_path", help="Path to extra modules to use for build")
     parser.add_argument('--sign_with', help="Certificate to sign the Manager apk")
     parser.add_argument('--build_doc', action="store_true", help="Build javadoc")


### PR DESCRIPTION
<!-- Please use this line to close one or multiple issues when this pullrequest gets merged
You can add another line right under the first one:
resolves #12689
build only selected modules for android
-->

### This pullrequest changes
build_sdk.py, which compiles OpenCV-SDK for Android.

Added an option/parameter for build only selected modules (for Android), like a whitelist.
Care should be take to include modules which are required to others (this is not checked).

==============
call sample:
==============
python2 ../platforms/android/build_sdk.py \
--modules_list core,imgcodecs,improc \
~/projects/opencv/build \
~/projects/opencv