### PR TITLE
cmake: apply '-Wl,--as-needed' linker option

### DIFF
--- a/cmake/OpenCVCompilerOptions.cmake
+++ b/cmake/OpenCVCompilerOptions.cmake
@@ -316,6 +316,21 @@ if(PPC64LE)
   endif()
 endif()
 
+# Apply "-Wl,--as-needed" linker flags: https://github.com/opencv/opencv/issues/7001
+if(NOT OPENCV_SKIP_LINK_AS_NEEDED)
+  if(UNIX AND (NOT APPLE OR NOT CMAKE_VERSION VERSION_LESS "3.2"))
+    set(_option "-Wl,--as-needed")
+    set(_saved_CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS}")
+    set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} ${_option}")  # requires CMake 3.2+ and CMP0056
+    ocv_check_compiler_flag(CXX "" HAVE_LINK_AS_NEEDED)
+    set(CMAKE_EXE_LINKER_FLAGS "${_saved_CMAKE_EXE_LINKER_FLAGS}")
+    if(HAVE_LINK_AS_NEEDED)
+      set(OPENCV_EXTRA_EXE_LINKER_FLAGS "${OPENCV_EXTRA_EXE_LINKER_FLAGS} ${_option}")
+      set(OPENCV_EXTRA_SHARED_LINKER_FLAGS "${OPENCV_EXTRA_SHARED_LINKER_FLAGS} ${_option}")
+    endif()
+  endif()
+endif()
+
 # combine all "extra" options
 if(NOT OPENCV_SKIP_EXTRA_COMPILER_FLAGS)
   set(CMAKE_C_FLAGS           "${CMAKE_C_FLAGS} ${OPENCV_EXTRA_FLAGS} ${OPENCV_EXTRA_C_FLAGS}")

--- a/cmake/OpenCVUtils.cmake
+++ b/cmake/OpenCVUtils.cmake
@@ -540,7 +540,7 @@ macro(ocv_check_flag_support lang flag varname base_options)
 
   string(TOUPPER "${flag}" ${varname})
   string(REGEX REPLACE "^(/|-)" "HAVE_${_lang}_" ${varname} "${${varname}}")
-  string(REGEX REPLACE " -|-|=| |\\." "_" ${varname} "${${varname}}")
+  string(REGEX REPLACE " -|-|=| |\\.|," "_" ${varname} "${${varname}}")
 
   ocv_check_compiler_flag("${_lang}" "${base_options} ${flag}" ${${varname}} ${ARGN})
 endmacro()


### PR DESCRIPTION
resolves #7001

<cut/>

Before:

```
$ ldd -u -r ./lib/libopencv_core.so
Unused direct dependencies:
	/lib64/librt.so.1

$ ldd -u -r ./bin/opencv_test_core
Unused direct dependencies:
	/home/alalek/projects/opencv/build/opencv/lib/libopencv_highgui.so.3.4
	/lib64/libdl.so.2
	/lib64/librt.so.1
	/home/alalek/projects/opencv/build/opencv/lib/libopencv_videoio.so.3.4
	/home/alalek/projects/opencv/build/opencv/lib/libopencv_imgcodecs.so.3.4
```

After:

```
$ ldd -u -r ./lib/libopencv_core.so

$ ldd -u -r ./bin/opencv_test_core
Unused direct dependencies:
	/home/alalek/projects/opencv/build/opencv/lib/libopencv_highgui.so.3.4
	/home/alalek/projects/opencv/build/opencv/lib/libopencv_imgcodecs.so.3.4
```


---

```
buildworker:Custom=linux-1
build_image:Custom=ubuntu-clang:18.04
```