### PR TITLE
G-API: Fix linkage in standalone mode

### DIFF
--- a/modules/gapi/src/compiler/gstreaming.cpp
+++ b/modules/gapi/src/compiler/gstreaming.cpp
@@ -7,8 +7,6 @@
 
 #include "precomp.hpp"
 
-#if !defined(GAPI_STANDALONE)
-
 #include <ade/graph.hpp>
 
 #include <opencv2/gapi/gproto.hpp> // can_describe
@@ -147,5 +145,3 @@ cv::GStreamingCompiled::Priv& cv::GStreamingCompiled::priv()
 {
     return *m_priv;
 }
-
-#endif // GAPI_STANDALONE


### PR DESCRIPTION
This PR fixes linkage of G-API library to some target in standalone mode.

The solution is pretty simple, yet maybe not so trim. Alternatively, we can move definitions and usage of functions from `gstreaming.cpp` under `#if !defined` in other files.
```
build_gapi_standalone:Linux x64=ade-0.1.1f
build_gapi_standalone:Win64=ade-0.1.1f
build_gapi_standalone:Mac=ade-0.1.1f
build_gapi_standalone:Linux x64 Debug=ade-0.1.1f
```