### PR TITLE
Fix bug 16410 and add test

### DIFF
--- a/modules/imgproc/src/connectedcomponents.cpp
+++ b/modules/imgproc/src/connectedcomponents.cpp
@@ -271,6 +271,11 @@ namespace cv{
     template<typename LabelT, typename PixelT, typename StatsOp = NoOp >
     struct LabelingWuParallel{
 
+        template <typename LT>
+        static LT stripeFirstLabel8Connectivity(int y, int w) {
+            return LT((y+2)/2) * LT((w+1)/2) + 1;
+        }
+
         class FirstScan8Connectivity : public cv::ParallelLoopBody{
             const cv::Mat& img_;
             cv::Mat& imgLabels_;
@@ -288,7 +293,7 @@ namespace cv{
                 int r = range.start;
                 chunksSizeAndLabels_[r] = range.end;
 
-                LabelT label = LabelT((r + 1) / 2)  * LabelT((imgLabels_.cols + 1) / 2) + 1;
+                LabelT label = stripeFirstLabel8Connectivity<LabelT>(r, imgLabels_.cols);
 
                 const LabelT firstLabel = label;
                 const int w = img_.cols;
@@ -615,7 +620,7 @@ namespace cv{
                 mergeLabels8Connectivity(imgLabels, P, chunksSizeAndLabels);
 
                 for (int i = 0; i < h; i = chunksSizeAndLabels[i]){
-                    flattenL(P, int((i + 1) / 2) * int((w + 1) / 2) + 1, chunksSizeAndLabels[i + 1], nLabels);
+                    flattenL(P, stripeFirstLabel8Connectivity<int>(i, w), chunksSizeAndLabels[i + 1], nLabels);
                 }
             }
             else{

--- a/modules/imgproc/src/connectedcomponents.cpp
+++ b/modules/imgproc/src/connectedcomponents.cpp
@@ -615,7 +615,7 @@ namespace cv{
 
             //Array used to store info and labeled pixel by each thread.
             //Different threads affect different memory location of chunksSizeAndLabels
-            std::vector<int> chunksSizeAndLabels(h);
+            std::vector<int> chunksSizeAndLabels(roundUp(h, 2));
 
             //Tree of labels
             std::vector<LabelT> P_(Plength, 0);
@@ -2559,7 +2559,7 @@ namespace cv{
 
             //Array used to store info and labeled pixel by each thread.
             //Different threads affect different memory location of chunksSizeAndLabels
-            const int chunksSizeAndLabelsSize = h + 1;
+            const int chunksSizeAndLabelsSize = roundUp(h, 2);
             std::vector<int> chunksSizeAndLabels(chunksSizeAndLabelsSize);
 
             //Tree of labels

--- a/modules/imgproc/test/test_connectedcomponents.cpp
+++ b/modules/imgproc/test/test_connectedcomponents.cpp
@@ -150,4 +150,80 @@ TEST(Imgproc_ConnectedComponents, grana_buffer_overflow)
     EXPECT_EQ(1, nbComponents);
 }
 
+
+static cv::Mat createCrashMat(int numThreads) {
+    const int h = numThreads * 4 * 2 + 8;
+    const double nParallelStripes = std::max(1, std::min(h / 2, numThreads * 4));
+    const int w = 4;
+
+    const int nstripes = cvRound(nParallelStripes <= 0 ? h : MIN(MAX(nParallelStripes, 1.), h));
+    const cv::Range stripeRange(0, nstripes);
+    const cv::Range wholeRange(0, h);
+
+    cv::Mat m(h, w, CV_8U);
+    m = 0;
+
+    // Look for a range that starts with odd value and ends with even value
+    cv::Range bugRange;
+    for (int s = stripeRange.start; s < stripeRange.end; s++) {
+        cv::Range sr(s, s + 1);
+        cv::Range r;
+        r.start = (int) (wholeRange.start +
+                         ((uint64) sr.start * (wholeRange.end - wholeRange.start) + nstripes / 2) / nstripes);
+        r.end = sr.end >= nstripes ?
+                    wholeRange.end :
+                    (int) (wholeRange.start +
+                           ((uint64) sr.end * (wholeRange.end - wholeRange.start) + nstripes / 2) / nstripes);
+
+        if (r.start > 0 && r.start % 2 == 1 && r.end % 2 == 0 && r.end >= r.start + 2) {
+            bugRange = r;
+            break;
+        }
+    }
+
+    if (bugRange.empty()) { // Could not create a buggy range
+        return m;
+    }
+
+    // Fill in bug Range
+    for (int x = 1; x < w; x++) {
+        m.at<char>(bugRange.start - 1, x) = 1;
+    }
+
+    m.at<char>(bugRange.start + 0, 0) = 1;
+    m.at<char>(bugRange.start + 0, 1) = 1;
+    m.at<char>(bugRange.start + 0, 3) = 1;
+    m.at<char>(bugRange.start + 1, 1) = 1;
+    m.at<char>(bugRange.start + 2, 1) = 1;
+    m.at<char>(bugRange.start + 2, 3) = 1;
+    m.at<char>(bugRange.start + 3, 0) = 1;
+    m.at<char>(bugRange.start + 3, 1) = 1;
+
+    return m;
+}
+
+TEST(Imgproc_ConnectedComponents, parallel_wu_labels)
+{
+    cv::Mat mat = createCrashMat(cv::getNumThreads());
+    if(mat.empty()) {
+        return;
+    }
+
+    const int nbPixels = cv::countNonZero(mat);
+
+    cv::Mat labels;
+    cv::Mat stats;
+    cv::Mat centroids;
+    int nb = 0;
+    EXPECT_NO_THROW( nb = cv::connectedComponentsWithStats(mat, labels, stats, centroids, 8, CV_32S, cv::CCL_WU) );
+
+    int area = 0;
+    for(int i=1; i<nb; ++i) {
+        area += stats.at<int32_t>(i, cv::CC_STAT_AREA);
+    }
+
+    EXPECT_EQ(nbPixels, area);
+}
+
+
 }} // namespace


### PR DESCRIPTION
resolves #16410

Here is what is happening. In order to do the parallelization, the image is split in stripes and labelling is done on each stripe. In order for stripes to be independent, each stripe starting at height `y` and with width `w` gets a startLabel defined as:
`startLabel = (y+1)/2 * (w+1)/2 + 1`

The formula comes from the fact that for an image of height `h` and width `w`,  an upper bound of the number of labels is: `(h+1)/2 * (w+1)/2 + 1`

The startLabels are too close to each other in some cases and create labels overlapping. Here is why:
let's say a stripe starts in `y0` and finishes in `y1`, we can write
`y0 = 2*y + 1` and `y1 = 2*y + 1 + h`
The maximum number of labels is `(h+1)/2 * (w+1)/2 + 1`
The number of labels for the stripe is: 
`( (2*y+1+h+1)/2 * (w+1)/2 + 1  ) - ( (2*y+1+1)/2 * (w+1)/2 + 1 )` which is equal to
`((h+2)/2 - 1) * (w+1)/2 = (h/2) * (w+1)/2`

If `h` is odd, then the number of allowed labels in the stripe is not large enough.

In order to make sure there is enough labels for each stripe, I suggest we use the formula:
`startLabel = (y+2)/2 * (w+1)/2 + 1`