### PR TITLE
Fixed ONNXImporter

### DIFF
--- a/modules/dnn/src/onnx/onnx_importer.cpp
+++ b/modules/dnn/src/onnx/onnx_importer.cpp
@@ -398,6 +398,7 @@ void ONNXImporter::populateNet(Net dstNet)
         std::string layer_type = node_proto.op_type();
         layerParams.type = layer_type;
 
+
         if (layer_type == "MaxPool")
         {
             layerParams.type = "Pooling";
@@ -482,7 +483,7 @@ void ONNXImporter::populateNet(Net dstNet)
          }
         else if (layer_type == "Split")
         {
-            if(layerParams.has("split"))
+            if (layerParams.has("split"))
             {
                 DictValue splits = layerParams.get("split");
                 const int numSplits = splits.size();
@@ -494,13 +495,12 @@ void ONNXImporter::populateNet(Net dstNet)
                     slicePoints[i] = slicePoints[i - 1] + splits.get<int>(i - 1);
                 }
                 layerParams.set("slice_point", DictValue::arrayInt(&slicePoints[0], slicePoints.size()));
-                layerParams.type = "Slice";
             }
             else
             {
                 layerParams.set("num_split", node_proto.output_size());
-                layerParams.type = "Slice";
             }
+            layerParams.type = "Slice";
         }
         else if (layer_type == "Add" || layer_type == "Sum")
         {

--- a/modules/dnn/src/onnx/onnx_importer.cpp
+++ b/modules/dnn/src/onnx/onnx_importer.cpp
@@ -398,7 +398,6 @@ void ONNXImporter::populateNet(Net dstNet)
         std::string layer_type = node_proto.op_type();
         layerParams.type = layer_type;
 
-
         if (layer_type == "MaxPool")
         {
             layerParams.type = "Pooling";
@@ -483,17 +482,25 @@ void ONNXImporter::populateNet(Net dstNet)
          }
         else if (layer_type == "Split")
         {
-            DictValue splits = layerParams.get("split");
-            const int numSplits = splits.size();
-            CV_Assert(numSplits > 1);
-
-            std::vector<int> slicePoints(numSplits - 1, splits.get<int>(0));
-            for (int i = 1; i < splits.size() - 1; ++i)
+            if(layerParams.has("split"))
             {
-                slicePoints[i] = slicePoints[i - 1] + splits.get<int>(i - 1);
+                DictValue splits = layerParams.get("split");
+                const int numSplits = splits.size();
+                CV_Assert(numSplits > 1);
+
+                std::vector<int> slicePoints(numSplits - 1, splits.get<int>(0));
+                for (int i = 1; i < splits.size() - 1; ++i)
+                {
+                    slicePoints[i] = slicePoints[i - 1] + splits.get<int>(i - 1);
+                }
+                layerParams.set("slice_point", DictValue::arrayInt(&slicePoints[0], slicePoints.size()));
+                layerParams.type = "Slice";
             }
-            layerParams.set("slice_point", DictValue::arrayInt(&slicePoints[0], slicePoints.size()));
-            layerParams.type = "Slice";
+            else
+            {
+                layerParams.set("num_split", node_proto.output_size());
+                layerParams.type = "Slice";
+            }
         }
         else if (layer_type == "Add" || layer_type == "Sum")
         {

--- a/modules/dnn/test/test_onnx_importer.cpp
+++ b/modules/dnn/test/test_onnx_importer.cpp
@@ -14,7 +14,7 @@ namespace opencv_test { namespace {
 template<typename TString>
 static std::string _tf(TString filename, bool required = true)
 {
-    return findDataFile(std::string("dnn/onnx/") + filename, required);
+    return findDataFile(std::string("../../opencv_extra/testdata/dnn/onnx/") + filename, required);
 }
 
 class Test_ONNX_layers : public DNNTestLayer
@@ -388,6 +388,10 @@ TEST_P(Test_ONNX_layers, ReduceL2)
 
 TEST_P(Test_ONNX_layers, Split)
 {
+    if (backend == DNN_BACKEND_INFERENCE_ENGINE_NN_BUILDER_2019)
+        applyTestTag(CV_TEST_TAG_DNN_SKIP_IE_NN_BUILDER);
+    if (backend == DNN_BACKEND_INFERENCE_ENGINE_NGRAPH)
+        applyTestTag(CV_TEST_TAG_DNN_SKIP_IE_NGRAPH);
     testONNXModels("split_1");
     testONNXModels("split_2");
     testONNXModels("split_3");

--- a/modules/dnn/test/test_onnx_importer.cpp
+++ b/modules/dnn/test/test_onnx_importer.cpp
@@ -388,7 +388,10 @@ TEST_P(Test_ONNX_layers, ReduceL2)
 
 TEST_P(Test_ONNX_layers, Split)
 {
-    testONNXModels("split");
+    testONNXModels("split_1");
+    testONNXModels("split_2");
+    testONNXModels("split_3");
+    testONNXModels("split_4");
 }
 
 TEST_P(Test_ONNX_layers, Slice)

--- a/modules/dnn/test/test_onnx_importer.cpp
+++ b/modules/dnn/test/test_onnx_importer.cpp
@@ -14,7 +14,7 @@ namespace opencv_test { namespace {
 template<typename TString>
 static std::string _tf(TString filename, bool required = true)
 {
-    return findDataFile(std::string("../../opencv_extra/testdata/dnn/onnx/") + filename, required);
+    return findDataFile(std::string("dnn/onnx/") + filename, required);
 }
 
 class Test_ONNX_layers : public DNNTestLayer

--- a/modules/dnn/test/test_onnx_importer.cpp
+++ b/modules/dnn/test/test_onnx_importer.cpp
@@ -386,6 +386,11 @@ TEST_P(Test_ONNX_layers, ReduceL2)
     testONNXModels("reduceL2");
 }
 
+TEST_P(Test_ONNX_layers, Split)
+{
+    testONNXModels("split");
+}
+
 TEST_P(Test_ONNX_layers, Slice)
 {
 #if defined(INF_ENGINE_RELEASE) && INF_ENGINE_VER_MAJOR_LT(2019010000)


### PR DESCRIPTION
**Merge with extra**: https://github.com/opencv/opencv_extra/pull/701

resolves #16370 

### This pullrequest changes

<!-- Please describe what your pullrequest is changing -->
This Pull Request aims to fix ONNXImporter. Currently, there are few bugs in processing of various `layer_type` from `.onnx` files. The referenced issue reports a bug in `Split` layer. Though I have observed that there are more bugs. I have listed them below as tasks. I will update them every commit.

- [x] "Split" layer fixed.
- [x] Tests added

```
force_builders=Custom,Custom Win,Custom Mac
build_image:Custom=ubuntu-openvino-2020.1.0:16.04
build_image:Custom Win=openvino-2020.1.0
build_image:Custom Mac=openvino-2020.1.0

test_modules:Custom=dnn,python2,python3,java
test_modules:Custom Win=dnn,python2,python3,java
test_modules:Custom Mac=dnn,python2,python3,java

buildworker:Custom=linux-1
# disabled due high memory usage: test_opencl:Custom=ON
test_opencl:Custom=OFF
test_bigdata:Custom=1
test_filter:Custom=*
```