### PR TITLE
cvdef.h: Don't use C's limits.h under C++

### DIFF
--- a/modules/core/include/opencv2/core/cvdef.h
+++ b/modules/core/include/opencv2/core/cvdef.h
@@ -181,7 +181,12 @@ namespace cv {
 #undef abs
 #undef Complex
 
+#if defined __cplusplus
+#include <limits>
+#else
 #include <limits.h>
+#endif
+
 #include "opencv2/core/hal/interface.h"
 
 #if defined __ICL


### PR DESCRIPTION
### This pullrequest changes

`<limits.h>` -> `<limits>` in C++ mode, just like with the other headers in the rest of the file.

See e.g. [StackOverflow](https://stackoverflow.com/questions/36831465/what-difference-does-it-make-when-i-include-limits-or-limits-h-in-my-c-cod) for the reasons, the most important one being that limits.h does not respect namespaces, which can make problems for downstream consumers of `cvdef.h`.


<cut/>

```
buildworker:Custom=linux-1
build_image:Custom=centos:7
```