### PR TITLE
TF importer: Corrected end tensor_content parsing for StridedSlice layer.

### DIFF
--- a/modules/dnn/src/tensorflow/tf_importer.cpp
+++ b/modules/dnn/src/tensorflow/tf_importer.cpp
@@ -1468,6 +1468,8 @@ void TFImporter::populateNet(Net dstNet)
             int end_mask = getLayerAttr(layer, "end_mask").i();
             for (int i = 0; i < num; ++i)
             {
+                if (ends.at<int>(i) < 0)
+                    ends.at<int>(i) -= 1;
                 if (end_mask & (1 << i))
                     ends.at<int>(i) = -1;
                 if (strides.at<int>(i) != 1)

--- a/modules/dnn/test/test_tf_importer.cpp
+++ b/modules/dnn/test/test_tf_importer.cpp
@@ -756,6 +756,8 @@ TEST_P(Test_TensorFlow_layers, slice)
         (target == DNN_TARGET_OPENCL || target == DNN_TARGET_OPENCL_FP16))
         applyTestTag(target == DNN_TARGET_OPENCL ? CV_TEST_TAG_DNN_SKIP_IE_OPENCL : CV_TEST_TAG_DNN_SKIP_IE_OPENCL_FP16,
                      CV_TEST_TAG_DNN_SKIP_IE_NN_BUILDER);
+    double l1 = target == DNN_TARGET_MYRIAD ? 4.9e-3 : default_l1;
+    runTensorFlowNet("crop2d", false, l1);
     runTensorFlowNet("slice_4d");
     runTensorFlowNet("strided_slice");
 }


### PR DESCRIPTION
**Merge with extra**: [opencv/opencv_extra#704](https://github.com/opencv/opencv_extra/pull/704)
resolves #16337

### This pullrequest changes 
Setting of end Mat values using tensor_content of "cropping2d/strided_slice/stack_1" from pbtxt file. 

`opencv_extra=opencv_extratf`

```
force_builders=Custom,Custom Win,Custom Mac
build_image:Custom=ubuntu-openvino-2019r3.0:16.04
build_image:Custom Win=openvino-2019r3.0
build_image:Custom Mac=openvino-2019r3.0

test_modules:Custom=dnn,python2,python3,java
test_modules:Custom Win=dnn,python2,python3,java
test_modules:Custom Mac=dnn,python2,python3,java

buildworker:Custom=linux-1
# disabled due high memory usage: test_opencl:Custom=ON
test_opencl:Custom=OFF
test_bigdata:Custom=1
test_filter:Custom=*
```