### PR TITLE
Fixed Compilation warnings | Issue #16336

### DIFF
--- a/modules/core/include/opencv2/core/types.hpp
+++ b/modules/core/include/opencv2/core/types.hpp
@@ -1192,7 +1192,7 @@ _Tp Point_<_Tp>::dot(const Point_& pt) const
 template<typename _Tp> inline
 double Point_<_Tp>::ddot(const Point_& pt) const
 {
-    return (double)x*pt.x + (double)y*pt.y;
+    return (double)x*(double)(pt.x) + (double)y*(double)(pt.y);
 }
 
 template<typename _Tp> inline


### PR DESCRIPTION
### This pullrequest changes
resolves #16336

### Brief
The `main.cpp` will occur the compilation warnings. The reason is at the [modules/core/include/opencv2/core/types.hpp#L1218](https://github.com/opencv/opencv/blob/7fa7fa02264eb2faed638947a5673839da386743/modules/core/include/opencv2/core/types.hpp#L1218)

<cut/>

### Detailed description

Assume a file calls `main.cpp` as below
```
#include <opencv2/core/types.hpp>

int main(void) {
  return 0;
}
```

If the developer enables the `g++` flags `-Wall -Wdouble-promotion` in the compilation, `g++` will output the following warning messages and generate a ELF file.

```
warning: implicit conversion from ‘float’ to ‘double’ to match other operand of binary expression [-Wdouble-promotion]
 1218 |     return (double)x*pt.x + (double)y*pt.y;
      |            ~~~~~~~~~^~~~~

warning: implicit conversion from ‘float’ to ‘double’ to match other operand of binary expression [-Wdouble-promotion]
 1218 |     return (double)x*pt.x + (double)y*pt.y;
      |                             ~~~~~~~~~^~~~~
```

If the developer enables the `g++` flags `-Wall -Werror -Wdouble-promotion` in the compilation, `g++` will output the same warning messages but can't generate a ELF file.