### PR TITLE
remove supports-screens for Android

### DIFF
--- a/samples/android/camera-calibration/gradle/AndroidManifest.xml
+++ b/samples/android/camera-calibration/gradle/AndroidManifest.xml
@@ -18,12 +18,6 @@
         </activity>
     </application>
 
-    <supports-screens android:resizeable="true"
-                      android:smallScreens="true"
-                      android:normalScreens="true"
-                      android:largeScreens="true"
-                      android:anyDensity="true" />
-
     <uses-permission android:name="android.permission.CAMERA"/>
 
     <uses-feature android:name="android.hardware.camera" android:required="false"/>

--- a/samples/android/color-blob-detection/gradle/AndroidManifest.xml
+++ b/samples/android/color-blob-detection/gradle/AndroidManifest.xml
@@ -19,12 +19,6 @@
         </activity>
     </application>
 
-    <supports-screens android:resizeable="true"
-                      android:smallScreens="true"
-                      android:normalScreens="true"
-                      android:largeScreens="true"
-                      android:anyDensity="true" />
-
     <uses-permission android:name="android.permission.CAMERA"/>
 
     <uses-feature android:name="android.hardware.camera" android:required="false"/>

--- a/samples/android/face-detection/gradle/AndroidManifest.xml
+++ b/samples/android/face-detection/gradle/AndroidManifest.xml
@@ -18,12 +18,6 @@
         </activity>
     </application>
 
-    <supports-screens android:resizeable="true"
-                      android:smallScreens="true"
-                      android:normalScreens="true"
-                      android:largeScreens="true"
-                      android:anyDensity="true" />
-
     <uses-permission android:name="android.permission.CAMERA"/>
 
     <uses-feature android:name="android.hardware.camera" android:required="false"/>

--- a/samples/android/image-manipulations/gradle/AndroidManifest.xml
+++ b/samples/android/image-manipulations/gradle/AndroidManifest.xml
@@ -18,12 +18,6 @@
         </activity>
     </application>
 
-    <supports-screens android:resizeable="true"
-                      android:smallScreens="true"
-                      android:normalScreens="true"
-                      android:largeScreens="true"
-                      android:anyDensity="true" />
-
     <uses-permission android:name="android.permission.CAMERA"/>
 
     <uses-feature android:name="android.hardware.camera" android:required="false"/>

--- a/samples/android/tutorial-1-camerapreview/gradle/AndroidManifest.xml
+++ b/samples/android/tutorial-1-camerapreview/gradle/AndroidManifest.xml
@@ -19,12 +19,6 @@
         </activity>
     </application>
 
-    <supports-screens android:resizeable="true"
-                      android:smallScreens="true"
-                      android:normalScreens="true"
-                      android:largeScreens="true"
-                      android:anyDensity="true" />
-
     <uses-permission android:name="android.permission.CAMERA"/>
 
     <uses-feature android:name="android.hardware.camera" android:required="false"/>

--- a/samples/android/tutorial-2-mixedprocessing/gradle/AndroidManifest.xml
+++ b/samples/android/tutorial-2-mixedprocessing/gradle/AndroidManifest.xml
@@ -18,12 +18,6 @@
         </activity>
     </application>
 
-    <supports-screens android:resizeable="true"
-                      android:smallScreens="true"
-                      android:normalScreens="true"
-                      android:largeScreens="true"
-                      android:anyDensity="true" />
-
     <uses-permission android:name="android.permission.CAMERA"/>
 
     <uses-feature android:name="android.hardware.camera" android:required="false"/>

--- a/samples/android/tutorial-3-cameracontrol/gradle/AndroidManifest.xml
+++ b/samples/android/tutorial-3-cameracontrol/gradle/AndroidManifest.xml
@@ -18,12 +18,6 @@
         </activity>
     </application>
 
-    <supports-screens android:resizeable="true"
-                      android:smallScreens="true"
-                      android:normalScreens="true"
-                      android:largeScreens="true"
-                      android:anyDensity="true" />
-
     <uses-permission android:name="android.permission.CAMERA"/>
 
     <uses-feature android:name="android.hardware.camera" android:required="false"/>


### PR DESCRIPTION
I see no point to use this `supports-screens`
The samples should not have pointless stuff, which maybe confuse someone.

That's why I vote for simplification