### PR TITLE
Issue 16458

### DIFF
--- a/cmake/OpenCVUtils.cmake
+++ b/cmake/OpenCVUtils.cmake
@@ -402,8 +402,8 @@ endmacro()
 
 set(OCV_COMPILER_FAIL_REGEX
     "argument .* is not valid"                  # GCC 9+ (including support of unicode quotes)
-    "command line option .* is valid for .* but not for C\\+\\+" # GNU
-    "command line option .* is valid for .* but not for C" # GNU
+    "command[- ]line option .* is valid for .* but not for C\\+\\+" # GNU
+    "command[- ]line option .* is valid for .* but not for C" # GNU
     "unrecognized .*option"                     # GNU
     "unknown .*option"                          # Clang
     "ignoring unknown option"                   # MSVC


### PR DESCRIPTION
<!-- Please use this line to close one or multiple issues when this pullrequest gets merged
You can add another line right under the first one:
resolves #16458 
resolves #1235
-->
resolves #16458 

### This pullrequest changes

<!-- Please describe what your pullrequest is changing -->
In issue #16458 someone used gcc 10 to build OpenCV and found some warnings were not ignored. Adjusting OpenCVUtils.cmake as per @alalek  's suggestion.