### PR TITLE
G-API: unify G_TYPED_KERNEL and G_TYPED_KERNEL_M

### DIFF
--- a/modules/gapi/include/opencv2/gapi/infer.hpp
+++ b/modules/gapi/include/opencv2/gapi/infer.hpp
@@ -23,23 +23,6 @@
 
 namespace cv {
 
-namespace detail {
-    // This tiny class eliminates the semantic difference between
-    // GKernelType and GKernelTypeM.
-    // FIXME: Something similar can be reused for regular kernels
-    template<typename, typename>
-    struct KernelTypeMedium;
-
-    template<class K, typename... R, typename... Args>
-    struct KernelTypeMedium<K, std::function<std::tuple<R...>(Args...)> >:
-        public GKernelTypeM<K, std::function<std::tuple<R...>(Args...)> > {};
-
-    template<class K, typename R, typename... Args>
-    struct KernelTypeMedium<K, std::function<R(Args...)> >:
-        public GKernelType<K, std::function<R(Args...)> > {};
-
-} // namespace detail
-
 template<typename, typename> class GNetworkType;
 
 // TODO: maybe tuple_wrap_helper from util.hpp may help with this.


### PR DESCRIPTION
### This pullrequest

continues #15840

Unifies macro `G_TYPED_KERNEL` and `G_TYPED_KERNEL_M` (by re-using mechanism introduced in Inference API).
Now can always use `G_TYPED_KERNEL` for any of G-API Kernel at the API level.

TODOs:
- [ ] Delete redundant code
- [ ] Update comments/documentation
- [ ] Remove `*_M` versions from documentation

```
force_builders=Custom,Custom Win,Custom Mac
build_image:Custom=ubuntu-openvino-2019r3.0:16.04
build_image:Custom Win=openvino-2019r3.0
build_image:Custom Mac=openvino-2019r3.0

test_modules:Custom=gapi
test_modules:Custom Win=gapi
test_modules:Custom Mac=gapi

buildworker:Custom=linux-1
test_opencl:Custom=ON
test_bigdata:Custom=1
test_filter:Custom=*

build_gapi_standalone:Linux x64=ade-0.1.1f
build_gapi_standalone:Win64=ade-0.1.1f
build_gapi_standalone:Mac=ade-0.1.1f
build_gapi_standalone:Linux x64 Debug=ade-0.1.1f
build_gapi_standalone:Custom Win=ade-0.1.1f
```
