### PR TITLE
G-API: deprecate G_TYPED_KERNEL_M and clean up redundant code

### DIFF
--- a/modules/gapi/include/opencv2/gapi/gkernel.hpp
+++ b/modules/gapi/include/opencv2/gapi/gkernel.hpp
@@ -325,47 +325,10 @@ G_TYPED_KERNEL_HELPER(Class, COMBINE_SIGNATURE(_1, _2, _3, _4, _5, _6, _7, _8, _
                                                  G_TYPED_KERNEL_HELPER)(Class, __VA_ARGS__)) \
 
 /**
- * Helper for G_TYPED_KERNEL_M declares a new G-API Operation. See [Kernel API](@ref gapi_kernel_api)
- * for more details.
+ * Declares a new G-API Operation. See [Kernel API](@ref gapi_kernel_api) for more details.
  *
- * @param Class type name for this operation.
- * @param API an `std::function<>`-like signature for the operation;
- *    return type is a tuple of multiple values.
- * @param Id string identifier for the operation. Must be unique.
- */
-#define G_TYPED_KERNEL_M_HELPER G_TYPED_KERNEL_HELPER
-// {body} is to be defined by user
-
-#define G_TYPED_KERNEL_M_HELPER_2(Class, _1, _2, Id) \
-    G_TYPED_KERNEL_M_HELPER(Class, COMBINE_SIGNATURE(_1, _2), Id)
-
-#define G_TYPED_KERNEL_M_HELPER_3(Class, _1, _2, _3, Id) \
-    G_TYPED_KERNEL_M_HELPER(Class, COMBINE_SIGNATURE(_1, _2, _3), Id)
-
-#define G_TYPED_KERNEL_M_HELPER_4(Class, _1, _2, _3, _4, Id) \
-    G_TYPED_KERNEL_M_HELPER(Class, COMBINE_SIGNATURE(_1, _2, _3, _4), Id)
-
-#define G_TYPED_KERNEL_M_HELPER_5(Class, _1, _2, _3, _4, _5, Id) \
-    G_TYPED_KERNEL_M_HELPER(Class, COMBINE_SIGNATURE(_1, _2, _3, _4, _5), Id)
-
-#define G_TYPED_KERNEL_M_HELPER_6(Class, _1, _2, _3, _4, _5, _6, Id) \
-    G_TYPED_KERNEL_M_HELPER(Class, COMBINE_SIGNATURE(_1, _2, _3, _4, _5, _6), Id)
-
-#define G_TYPED_KERNEL_M_HELPER_7(Class, _1, _2, _3, _4, _5, _6, _7, Id) \
-    G_TYPED_KERNEL_M_HELPER(Class, COMBINE_SIGNATURE(_1, _2, _3, _4, _5, _6, _7), Id)
-
-#define G_TYPED_KERNEL_M_HELPER_8(Class, _1, _2, _3, _4, _5, _6, _7, _8, Id) \
-    G_TYPED_KERNEL_M_HELPER(Class, COMBINE_SIGNATURE(_1, _2, _3, _4, _5, _6, _7, _8), Id)
-
-#define G_TYPED_KERNEL_M_HELPER_9(Class, _1, _2, _3, _4, _5, _6, _7, _8, _9, Id) \
-    G_TYPED_KERNEL_M_HELPER(Class, COMBINE_SIGNATURE(_1, _2, _3, _4, _5, _6, _7, _8, _9), Id)
-
-#define G_TYPED_KERNEL_M_HELPER_10(Class, _1, _2, _3, _4, _5, _6, _7, _8, _9, _10, Id) \
-    G_TYPED_KERNEL_M_HELPER(Class, COMBINE_SIGNATURE(_1, _2, _3, _4, _5, _6, _7, _8, _9, _10), Id)
-
-/**
- * Declares a new G-API Operation. See [Kernel API](@ref gapi_kernel_api)
- * for more details.
+ * @deprecated This macro is deprecated in favor of `G_TYPED_KERNEL` that is used for declaring any
+ * G-API Operation.
  *
  * @param Class type name for this operation.
  */


### PR DESCRIPTION
## This pullrequest

is a follow-up on  #16496:
- Deprecates `G_TYPED_KERNEL_M` in the documentation
- Removes `G_TYPED_KERNEL_M_HELPER*` - these are not needed anymore since `_M` and non-`_M` versions are unified

<cut/>

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under OpenCV (BSD) License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [x] The PR is proposed to proper branch
- [x] There is reference to original related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake


```
force_builders=Custom,Custom Win,Custom Mac
build_image:Custom=ubuntu-openvino-2019r3.0:16.04
build_image:Custom Win=openvino-2019r3.0
build_image:Custom Mac=openvino-2019r3.0

test_modules:Custom=gapi
test_modules:Custom Win=gapi
test_modules:Custom Mac=gapi

buildworker:Custom=linux-1
test_opencl:Custom=ON
test_bigdata:Custom=1
test_filter:Custom=*

build_gapi_standalone:Linux x64=ade-0.1.1f
build_gapi_standalone:Win64=ade-0.1.1f
build_gapi_standalone:Mac=ade-0.1.1f
build_gapi_standalone:Linux x64 Debug=ade-0.1.1f
build_gapi_standalone:Custom Win=ade-0.1.1f
```