### PR TITLE
Allow access to CUDA pointers for interoperability with other libraries

### DIFF
--- a/modules/core/include/opencv2/core/cuda.hpp
+++ b/modules/core/include/opencv2/core/cuda.hpp
@@ -305,6 +305,9 @@ public:
     //! returns true if GpuMat data is NULL
     CV_WRAP bool empty() const;
 
+    // returns pointer to cuda memory
+    CV_WRAP void* cudaPtr() const;
+
     //! internal use method: updates the continuity flag
     CV_WRAP void updateContinuityFlag();
 
@@ -680,6 +683,9 @@ public:
 
     //! returns true if stream object is not default (!= 0)
     operator bool_type() const;
+
+    //! return Pointer to CUDA stream
+    CV_WRAP void* cudaPtr() const;
 
     class Impl;
 

--- a/modules/core/include/opencv2/core/cuda.inl.hpp
+++ b/modules/core/include/opencv2/core/cuda.inl.hpp
@@ -343,6 +343,12 @@ bool GpuMat::empty() const
     return data == 0;
 }
 
+inline
+void* GpuMat::cudaPtr() const
+{
+    return data;
+}
+
 static inline
 GpuMat createContinuous(int rows, int cols, int type)
 {

--- a/modules/core/src/cuda_stream.cpp
+++ b/modules/core/src/cuda_stream.cpp
@@ -535,6 +535,15 @@ Stream& cv::cuda::Stream::Null()
 #endif
 }
 
+void* cv::cuda::Stream::cudaPtr() const
+{
+#ifndef HAVE_CUDA
+    return nullptr;
+#else
+    return impl_->stream;
+#endif
+}
+
 cv::cuda::Stream::operator bool_type() const
 {
 #ifndef HAVE_CUDA

--- a/modules/python/test/test_cuda.py
+++ b/modules/python/test/test_cuda.py
@@ -26,5 +26,13 @@ class cuda_test(NewOpenCVTests):
 
         self.assertTrue(np.allclose(cuMat.download(), npMat))
 
+    def test_cuda_interop(self):
+        npMat = (np.random.random((128, 128, 3)) * 255).astype(np.uint8)
+        cuMat = cv.cuda_GpuMat()
+        cuMat.upload(npMat)
+        self.assertTrue(cuMat.cudaPtr() != 0)
+        stream = cv.cuda_Stream()
+        self.assertTrue(stream.cudaPtr() != 0)
+
 if __name__ == '__main__':
     NewOpenCVTests.bootstrap()


### PR DESCRIPTION
This is a proposal for adding `CV_WRAP` compatible `cudaPtr()` getter methods to `GpuMat` and `Stream`, required for enabling interoperability between **OpenCV** and other CUDA supporting python libraries like **Numba**, **CuPy**, **PyTorch**, etc.

<cut/>

Here is an example for sharing a `GpuMat` with **CuPy**:
```python
import cv2 as cv
import cupy as cp

# Create GPU array with OpenCV
data_gpu_cv = cv.cuda_GpuMat()
data_gpu_cv.upload(np.eye(64, dtype=np.float32))

# Modify the same GPU array with CuPy
data_gpu_cp = cp.asarray(CudaArrayInterface(data_gpu_cv))
data_gpu_cp *= 42.0

# Download and verify
assert np.allclose(data_gpu_cp.get(), np.eye(64) * 42.0)
```

In this example `CudaArrayInterface` is a (incomplete) adapter class that implements the [cuda array interface](https://numba.pydata.org/numba-doc/dev/cuda/cuda_array_interface.html) used by other frameworks:
```python
class CudaArrayInterface:
    def __init__(self, gpu_mat):
        w, h = gpu_mat.size()
        type_map = {
            cv.CV_8U: "u1", cv.CV_8S: "i1",
            cv.CV_16U: "u2", cv.CV_16S: "i2",
            cv.CV_32S: "i4",
            cv.CV_32F: "f4", cv.CV_64F: "f8",
        }
        self.__cuda_array_interface__ = {
            "version": 2,
            "shape": (h, w),
            "data": (gpu_mat.cudaPtr(), False),
            "typestr": type_map[gpu_mat.type()],
            "strides": (gpu_mat.step, gpu_mat.elemSize()),
        }
```
If possible, I'd like to implement `__cuda_array_interface__` within the `GpuMat` python binding in a future PR (not sure how to define a python property using the wrapper generator though).

---

```
force_builders=Custom
buildworker:Custom=linux-4
build_image:Custom=ubuntu-cuda:18.04
```
