### PR TITLE
G-API: Fix. own::Mat successfully creates a {-1, -1} mat.

### DIFF
--- a/modules/gapi/include/opencv2/gapi/own/mat.hpp
+++ b/modules/gapi/include/opencv2/gapi/own/mat.hpp
@@ -230,6 +230,7 @@ namespace cv { namespace gapi { namespace own {
         */
         void create(Size _size, int _type)
         {
+            GAPI_Assert(_size.height >= 0 && _size.width >= 0);
             if (_size != Size{cols, rows} )
             {
                 Mat tmp{_size.height, _size.width, _type, nullptr};

--- a/modules/gapi/test/own/mat_tests.cpp
+++ b/modules/gapi/test/own/mat_tests.cpp
@@ -588,4 +588,23 @@ TEST(OwnMat, ROIView)
         << to_ocv(roi_view) << std::endl
         << expected_cv_mat  << std::endl;
 }
+
+TEST(OwnMat, CreateWithNegativeDims)
+{
+    Mat own_mat;
+    ASSERT_ANY_THROW(own_mat.create(cv::Size{-1, -1}, CV_8U));
+}
+
+TEST(OwnMat, CreateWithNegativeWidth)
+{
+    Mat own_mat;
+    ASSERT_ANY_THROW(own_mat.create(cv::Size{-1, 1}, CV_8U));
+}
+
+TEST(OwnMat, CreateWithNegativeHeight)
+{
+    Mat own_mat;
+    ASSERT_ANY_THROW(own_mat.create(cv::Size{1, -1}, CV_8U));
+}
+
 } // namespace opencv_test


### PR DESCRIPTION
### own::Mat successfully created a mat with negative dimensions. 
Method `create(...)` throw exception in this case now.

cv::Mat checks the dimensions in `setSize(...)`. If the dimension is less then 0, it throws exception. own::Mat checks `size.height` and `size.width` in `create(...)` and throws exception if dimension is less then 0.

Added test for this case.
