### PR TITLE
imgproc: revert resize changes from PR 16497

### DIFF
--- a/modules/imgproc/src/resize.cpp
+++ b/modules/imgproc/src/resize.cpp
@@ -1045,7 +1045,7 @@ public:
                 {
                     const int* _tS = (const int*)(S + x_ofs[x]);
                     int* _tD = (int*)D;
-                    for( int k = 0; k <= pix_size4; k++ )
+                    for( int k = 0; k < pix_size4; k++ )
                         _tD[k] = _tS[k];
                 }
             }

--- a/modules/imgproc/test/test_imgwarp.cpp
+++ b/modules/imgproc/test/test_imgwarp.cpp
@@ -1721,7 +1721,7 @@ TEST(Resize, lanczos4_regression_16192)
     EXPECT_EQ(cvtest::norm(dst, expected, NORM_INF), 0) << dst(Rect(0,0,8,8));
 }
 
-TEST(Resize, nearest_regression_15075)
+TEST(Resize, DISABLED_nearest_regression_15075)  // reverted https://github.com/opencv/opencv/pull/16497
 {
     const int C = 5;
     const int i1 = 5, j1 = 5;


### PR DESCRIPTION
reverts #16497

Avoid OOB buffer access.

```
[ RUN      ] Resize.nearest_regression_15075
==13146== Invalid write of size 4
==13146==    at 0x4DC1994: cv::resizeNNInvoker::operator()(cv::Range const&) const (resize.cpp:1049)
==13146==    by 0x6AD674C: parallel_for_impl(cv::Range const&, cv::ParallelLoopBody const&, double) (parallel.cpp:498)
==13146==    by 0x6AD6600: cv::parallel_for_(cv::Range const&, cv::ParallelLoopBody const&, double) (parallel.cpp:471)
==13146==    by 0x4DC1D5C: cv::resizeNN(cv::Mat const&, cv::Mat&, double, double) (resize.cpp:1105)
```