### PR TITLE
G-API: Zero-height mat is cause of crash

### DIFF
--- a/modules/gapi/include/opencv2/gapi/gproto.hpp
+++ b/modules/gapi/include/opencv2/gapi/gproto.hpp
@@ -126,6 +126,9 @@ bool GAPI_EXPORTS can_describe(const GMetaArgs& metas, const GRunArgs& args);
 // coincides with output arguments passed to computation in cpu and ocl backends
 bool GAPI_EXPORTS can_describe(const GMetaArg&  meta,  const GRunArgP& argp);
 
+// Checks dimensions of input Mat for inequality to zero.
+bool GAPI_EXPORTS nonzero_dims_in_inmat(const GMetaArgs& metas);
+
 } // namespace cv
 
 #endif // OPENCV_GAPI_GPROTO_HPP

--- a/modules/gapi/include/opencv2/gapi/gproto.hpp
+++ b/modules/gapi/include/opencv2/gapi/gproto.hpp
@@ -127,8 +127,8 @@ bool GAPI_EXPORTS can_describe(const GMetaArgs& metas, const GRunArgs& args);
 bool GAPI_EXPORTS can_describe(const GMetaArg&  meta,  const GRunArgP& argp);
 
 // Validates input arguments
-bool GAPI_EXPORTS validate_input_arg(const GRunArg& arg);
-bool GAPI_EXPORTS validate_input_arg(const GRunArgs& args);
+void GAPI_EXPORTS validate_input_arg(const GRunArg& arg);
+void GAPI_EXPORTS validate_input_args(const GRunArgs& args);
 
 } // namespace cv
 

--- a/modules/gapi/include/opencv2/gapi/gproto.hpp
+++ b/modules/gapi/include/opencv2/gapi/gproto.hpp
@@ -126,8 +126,9 @@ bool GAPI_EXPORTS can_describe(const GMetaArgs& metas, const GRunArgs& args);
 // coincides with output arguments passed to computation in cpu and ocl backends
 bool GAPI_EXPORTS can_describe(const GMetaArg&  meta,  const GRunArgP& argp);
 
-// Checks dimensions of input Mat for inequality to zero.
-bool GAPI_EXPORTS nonzero_dims_in_inmat(const GMetaArgs& metas);
+// Validates input arguments
+bool GAPI_EXPORTS validate_input_arg(const GRunArg& arg);
+bool GAPI_EXPORTS validate_input_arg(const GRunArgs& args);
 
 } // namespace cv
 

--- a/modules/gapi/src/api/gproto.cpp
+++ b/modules/gapi/src/api/gproto.cpp
@@ -197,6 +197,20 @@ bool cv::can_describe(const GMetaArgs &metas, const GRunArgs &args)
                      });
 }
 
+bool cv::nonzero_dims_in_inmat(const GMetaArgs& metas)
+{
+    bool state = true;
+    for (const auto& current_meta : metas)
+    {
+        if (current_meta.index() == cv::GMetaArg::index_of<cv::GMatDesc>())
+        {
+            const auto& desc_mat = cv::util::get<cv::GMatDesc>(current_meta);
+            state &= (desc_mat.size.height != 0 && desc_mat.size.width != 0);
+        }
+    }
+    return state;
+}
+
 namespace cv {
 std::ostream& operator<<(std::ostream& os, const cv::GMetaArg &arg)
 {

--- a/modules/gapi/src/api/gproto.cpp
+++ b/modules/gapi/src/api/gproto.cpp
@@ -197,43 +197,40 @@ bool cv::can_describe(const GMetaArgs &metas, const GRunArgs &args)
                      });
 }
 
-bool cv::validate_input_arg(const GRunArg& arg)
+void cv::validate_input_arg(const GRunArg& arg)
 {
-    // FIXME: It checks only Mat's argument
+    // FIXME: It checks only Mat argument
     switch (arg.index())
     {
 #if !defined(GAPI_STANDALONE)
     case GRunArg::index_of<cv::Mat>():
     {
         const auto desc = descr_of(util::get<cv::Mat>(arg));
-        GAPI_Assert(desc.size.height != 0 && desc.size.width != 0 && "incorrect dimensions of cv::Mat!"); return true;
+        GAPI_Assert(desc.size.height != 0 && desc.size.width != 0 && "incorrect dimensions of cv::Mat!"); break;
     }
     case GRunArg::index_of<cv::UMat>():
     {
         const auto desc = descr_of(util::get<cv::UMat>(arg));
-        GAPI_Assert(desc.size.height != 0 && desc.size.width != 0 && "incorrect dimensions of cv::UMat!"); return true;
+        GAPI_Assert(desc.size.height != 0 && desc.size.width != 0 && "incorrect dimensions of cv::UMat!"); break;
     }
-    case GRunArg::index_of<cv::Scalar>(): return true;
 #endif //  !defined(GAPI_STANDALONE)
     case GRunArg::index_of<cv::gapi::own::Mat>():
     {
         const auto desc = descr_of(util::get<cv::gapi::own::Mat>(arg));
-        GAPI_Assert(desc.size.height != 0 && desc.size.width != 0 && "incorrect dimensions of own::Mat!"); return true;
+        GAPI_Assert(desc.size.height != 0 && desc.size.width != 0 && "incorrect dimensions of own::Mat!"); break;
     }
-    case GRunArg::index_of<cv::gapi::own::Scalar>(): return true;
-    case GRunArg::index_of<cv::detail::VectorRef>(): return true;
-    case GRunArg::index_of<cv::detail::OpaqueRef>(): return true;
-    case GRunArg::index_of<cv::gapi::wip::IStreamSource::Ptr>(): return true;
-    default: util::throw_error(std::logic_error("Unsupported GRunArg type"));
+    default:
+        // No extra handling
+        break;
     }
 }
 
-bool cv::validate_input_arg(const GRunArgs& args)
+void cv::validate_input_args(const GRunArgs& args)
 {
-    return std::any_of(args.begin(), args.end(),
-                      [](const GRunArg& arg) {
-                          return validate_input_arg(arg);
-                      });
+    for (const auto& arg : args)
+    {
+        validate_input_arg(arg);
+    }
 }
 
 namespace cv {

--- a/modules/gapi/src/compiler/gcompiled.cpp
+++ b/modules/gapi/src/compiler/gcompiled.cpp
@@ -56,6 +56,11 @@ void cv::GCompiled::Priv::checkArgs(const cv::gimpl::GRuntimeArgs &args) const
                                            "for different metadata!"));
         // FIXME: Add details on what is actually wrong
     }
+    if (!nonzero_dims_in_inmat(m_metas))
+    {
+        util::throw_error(std::logic_error("This object was compiled "
+                                           "for Mat with zero dimensions!"));
+    }
 }
 
 bool cv::GCompiled::Priv::canReshape() const

--- a/modules/gapi/src/compiler/gcompiled.cpp
+++ b/modules/gapi/src/compiler/gcompiled.cpp
@@ -56,11 +56,7 @@ void cv::GCompiled::Priv::checkArgs(const cv::gimpl::GRuntimeArgs &args) const
                                            "for different metadata!"));
         // FIXME: Add details on what is actually wrong
     }
-    if (!validate_input_arg(args.inObjs))
-    {
-        util::throw_error(std::logic_error("This object was compiled "
-                                           "for incorrect input arguments!"));
-    }
+    validate_input_args(args.inObjs);
 }
 
 bool cv::GCompiled::Priv::canReshape() const

--- a/modules/gapi/src/compiler/gcompiled.cpp
+++ b/modules/gapi/src/compiler/gcompiled.cpp
@@ -56,10 +56,10 @@ void cv::GCompiled::Priv::checkArgs(const cv::gimpl::GRuntimeArgs &args) const
                                            "for different metadata!"));
         // FIXME: Add details on what is actually wrong
     }
-    if (!nonzero_dims_in_inmat(m_metas))
+    if (!validate_input_arg(args.inObjs))
     {
         util::throw_error(std::logic_error("This object was compiled "
-                                           "for Mat with zero dimensions!"));
+                                           "for incorrect input arguments!"));
     }
 }
 

--- a/modules/gapi/test/own/mat_tests.cpp
+++ b/modules/gapi/test/own/mat_tests.cpp
@@ -607,4 +607,28 @@ TEST(OwnMat, CreateWithNegativeHeight)
     ASSERT_ANY_THROW(own_mat.create(cv::Size{1, -1}, CV_8U));
 }
 
+TEST(OwnMat, ZeroHeightMat)
+{
+    cv::GMat in, a, b, c, d;
+    std::tie(a, b, c, d) = cv::gapi::split4(in);
+    cv::GMat out = cv::gapi::merge3(a, b, c);
+    cv::Mat in_mat(cv::Size(8, 0), CV_8UC4);
+    cv::Mat out_mat(cv::Size(8, 8), CV_8UC3);
+    cv::GComputation comp(cv::GIn(in), cv::GOut(out));
+    ASSERT_ANY_THROW(comp.apply(cv::gin(in_mat), cv::gout(out_mat),
+        cv::compile_args(cv::gapi::core::fluid::kernels())));
+}
+
+TEST(OwnMat, ZeroWidthMat)
+{
+    cv::GMat in, a, b, c, d;
+    std::tie(a, b, c, d) = cv::gapi::split4(in);
+    cv::GMat out = cv::gapi::merge3(a, b, c);
+    cv::Mat in_mat(cv::Size(0, 8), CV_8UC4);
+    cv::Mat out_mat(cv::Size(8, 8), CV_8UC3);
+    cv::GComputation comp(cv::GIn(in), cv::GOut(out));
+    ASSERT_ANY_THROW(comp.apply(cv::gin(in_mat), cv::gout(out_mat),
+        cv::compile_args(cv::gapi::core::fluid::kernels())));
+}
+
 } // namespace opencv_test


### PR DESCRIPTION
### Zero-height mat is cause of crash
     cv::GMat in;
     cv::GMat a, b, c, d;
     std::tie(a, b, c, d) = cv::gapi::split4(in);
     cv::GMat out = cv::gapi::merge3(a, b, c);   

     // Zero-height in_mat
     cv::Mat in_mat(cv::Size(8, 0), CV_8UC4);
     cv::Mat out_mat(cv::Size(8, 8), CV_8UC3);

     cv::GComputation comp(cv::GIn(in), cv::GOut(out));
     comp.apply(cv::gin(in_mat), cv::gout(out_mat),
         cv::compile_args(cv::gapi::core::fluid::kernels()));

It crashed in `physIdx(int logIdx)` from gfluidbuffer_priv.h ( Fluid backend ), because we use `(logIdx - m_roi.y) % m_data.rows`, when m_data.rows == 0 ( Segmentation fault ).

Added GAPI_Assert for this case.




