### PR TITLE
added estimateTranslation3D to calib3d/ptsetreg

### DIFF
--- a/modules/calib3d/include/opencv2/calib3d.hpp
+++ b/modules/calib3d/include/opencv2/calib3d.hpp
@@ -2328,6 +2328,53 @@ CV_EXPORTS_W  int estimateAffine3D(InputArray src, InputArray dst,
                                    OutputArray out, OutputArray inliers,
                                    double ransacThreshold = 3, double confidence = 0.99);
 
+/** @brief Computes an optimal translation between two 3D point sets.
+ *
+ * It computes
+ * \f[
+ * \begin{bmatrix}
+ * x\\
+ * y\\
+ * z\\
+ * \end{bmatrix}
+ * =
+ * \begin{bmatrix}
+ * X\\
+ * Y\\
+ * Z\\
+ * \end{bmatrix}
+ * +
+ * \begin{bmatrix}
+ * b_1\\
+ * b_2\\
+ * b_3\\
+ * \end{bmatrix}
+ * \f]
+ *
+ * @param src First input 3D point set containing \f$(X,Y,Z)\f$.
+ * @param dst Second input 3D point set containing \f$(x,y,z)\f$.
+ * @param out Output 3D translation vector \f$3 \times 1\f$ of the form
+ * \f[
+ * \begin{bmatrix}
+ * b_1 \\
+ * b_2 \\
+ * b_3 \\
+ * \end{bmatrix}
+ * \f]
+ * @param inliers Output vector indicating which points are inliers (1-inlier, 0-outlier).
+ * @param ransacThreshold Maximum reprojection error in the RANSAC algorithm to consider a point as
+ * an inlier.
+ * @param confidence Confidence level, between 0 and 1, for the estimated transformation. Anything
+ * between 0.95 and 0.99 is usually good enough. Values too close to 1 can slow down the estimation
+ * significantly. Values lower than 0.8-0.9 can result in an incorrectly estimated transformation.
+ *
+ * The function estimates an optimal 3D translation between two 3D point sets using the
+ * RANSAC algorithm.
+ *  */
+CV_EXPORTS_W  int estimateTranslation3D(InputArray src, InputArray dst,
+                                        OutputArray out, OutputArray inliers,
+                                        double ransacThreshold = 3, double confidence = 0.99);
+
 /** @brief Computes an optimal affine transformation between two 2D point sets.
 
 It computes

--- a/modules/calib3d/src/ptsetreg.cpp
+++ b/modules/calib3d/src/ptsetreg.cpp
@@ -519,7 +519,7 @@ public:
  *      t2
  *      t3
  */
-class Translation3DEstimatorCallback : public PointSetRegistrator::Callback
+class Translation3DEstimatorCallback CV_FINAL : public PointSetRegistrator::Callback
 {
 public:
     int runKernel( InputArray _m1, InputArray _m2, OutputArray _model ) const CV_OVERRIDE
@@ -529,8 +529,7 @@ public:
         const Point3f* from = m1.ptr<Point3f>();
         const Point3f* to   = m2.ptr<Point3f>();
 
-        double buf[3] = {0, 0, 0};
-        Matx13d T(buf);
+        Matx13d T;
 
         // The optimal translation is the mean of the pointwise displacements
         for(int i = 0; i < 4; i++)

--- a/modules/calib3d/src/ptsetreg.cpp
+++ b/modules/calib3d/src/ptsetreg.cpp
@@ -47,6 +47,8 @@
 #include <iterator>
 #include <limits>
 
+#include <iostream>
+
 namespace cv
 {
 
@@ -529,10 +531,8 @@ public:
         const Point3f* from = m1.ptr<Point3f>();
         const Point3f* to   = m2.ptr<Point3f>();
 
-        double buf[3];
-        Mat T(3, 1, CV_64F, &buf[0]);
-        double* Tptr = T.ptr<double>();
-        T = Scalar::all(0);
+        double buf[3] = {0, 0, 0};
+        Matx13d T(buf);
 
         // The optimal translation is the mean of the pointwise displacements
         for(int i = 0; i < 4; i++)
@@ -540,16 +540,12 @@ public:
             const Point3f& f = from[i];
             const Point3f& t = to[i];
 
-            Tptr[0] = Tptr[0] + t.x - f.x;
-            Tptr[1] = Tptr[1] + t.y - f.y;
-            Tptr[2] = Tptr[2] + t.z - f.z;
+            T(0, 0) = T(0, 0) + t.x - f.x;
+            T(0, 1) = T(0, 1) + t.y - f.y;
+            T(0, 2) = T(0, 2) + t.z - f.z;
         }
-        Tptr[0] = Tptr[0] / 4;
-        Tptr[1] = Tptr[1] / 4;
-        Tptr[2] = Tptr[2] / 4;
-
-        T.copyTo(_model);
-
+        T *= (1.0f / 4);
+        Mat(T, false).copyTo(_model);
         return 1;
     }
 

--- a/modules/calib3d/src/ptsetreg.cpp
+++ b/modules/calib3d/src/ptsetreg.cpp
@@ -580,9 +580,13 @@ public:
         }
     }
 
-    // not doing SVD, no degeneracy concerns
+    // not doing SVD, no degeneracy concerns, can simply return true
     bool checkSubset( InputArray _ms1, InputArray _ms2, int count ) const CV_OVERRIDE
     {
+        // voids to suppress compiler warnings
+        (void)_ms1;
+        (void)_ms2;
+        (void)count;
         return true;
     }
 };

--- a/modules/calib3d/src/ptsetreg.cpp
+++ b/modules/calib3d/src/ptsetreg.cpp
@@ -47,8 +47,6 @@
 #include <iterator>
 #include <limits>
 
-#include <iostream>
-
 namespace cv
 {
 

--- a/modules/calib3d/test/test_translation3d_estimator.cpp
+++ b/modules/calib3d/test/test_translation3d_estimator.cpp
@@ -1,44 +1,7 @@
-/*M///////////////////////////////////////////////////////////////////////////////////////
-//
-//  IMPORTANT: READ BEFORE DOWNLOADING, COPYING, INSTALLING OR USING.
-//
-//  By downloading, copying, installing or using the software you agree to this license.
-//  If you do not agree to this license, do not download, install,
-//  copy or use the software.
-//
-//
-//                           License Agreement
-//                For Open Source Computer Vision Library
-//
-// Copyright (C) 2000-2008, Intel Corporation, all rights reserved.
-// Copyright (C) 2009, Willow Garage Inc., all rights reserved.
-// Third party copyrights are property of their respective owners.
-//
-// Redistribution and use in source and binary forms, with or without modification,
-// are permitted provided that the following conditions are met:
-//
-//   * Redistribution's of source code must retain the above copyright notice,
-//     this list of conditions and the following disclaimer.
-//
-//   * Redistribution's in binary form must reproduce the above copyright notice,
-//     this list of conditions and the following disclaimer in the documentation
-//     and/or other materials provided with the distribution.
-//
-//   * The name of the copyright holders may not be used to endorse or promote products
-//     derived from this software without specific prior written permission.
-//
-// This software is provided by the copyright holders and contributors "as is" and
-// any express or implied warranties, including, but not limited to, the implied
-// warranties of merchantability and fitness for a particular purpose are disclaimed.
-// In no event shall the Intel Corporation or contributors be liable for any direct,
-// indirect, incidental, special, exemplary, or consequential damages
-// (including, but not limited to, procurement of substitute goods or services;
-// loss of use, data, or profits; or business interruption) however caused
-// and on any theory of liability, whether in contract, strict liability,
-// or tort (including negligence or otherwise) arising in any way out of
-// the use of this software, even if advised of the possibility of such damage.
-//
-//M*/
+// This file is part of OpenCV project.
+// It is subject to the license terms in the LICENSE file found in the top-level directory
+// of this distribution and at http://opencv.org/license.html.
+
 
 #include "test_precomp.hpp"
 
@@ -67,20 +30,20 @@ float rngIn(float from, float to) { return from + (to-from) * (float)theRNG(); }
 
 struct WrapTrans
 {
-    const double *F;
-    WrapTrans(const Mat& trans) : F(trans.ptr<double>()) {}
+    const Matx13d * F;
+    WrapTrans(const Matx13d& trans) { F = &trans; }
     Point3f operator()(const Point3f& p)
     {
-        return Point3f( (float)(p.x + F[0]),
-                        (float)(p.y + F[1]),
-                        (float)(p.z + F[2])  );
+        return Point3f( (float)(p.x + (*F)(0, 0)),
+                        (float)(p.y + (*F)(0, 1)),
+                        (float)(p.z + (*F)(0, 2))  );
     }
 };
 
 bool CV_Translation3D_EstTest::test4Points()
 {
 
-    Mat trans(3, 1, CV_64F);
+    Matx13d trans;
     cv::randu(trans, Scalar(1), Scalar(3));
 
     // setting points that are no in the same line
@@ -95,7 +58,7 @@ bool CV_Translation3D_EstTest::test4Points()
 
     std::transform(fpts.ptr<Point3f>(), fpts.ptr<Point3f>() + 4, tpts.ptr<Point3f>(), WrapTrans(trans));
 
-    Mat trans_est;
+    Matx13d trans_est;
     vector<uchar> outliers;
     estimateTranslation3D(fpts, tpts, trans_est, outliers);
 
@@ -123,7 +86,7 @@ struct Noise
 
 bool CV_Translation3D_EstTest::testNPoints()
 {
-    Mat trans(3, 1, CV_64F);
+    Matx13d trans;
     cv::randu(trans, Scalar(-2), Scalar(2));
 
     // setting points that are no in the same line
@@ -148,7 +111,7 @@ bool CV_Translation3D_EstTest::testNPoints()
     std::transform(tpts.ptr<Point3f>() + m, tpts.ptr<Point3f>() + n, tpts.ptr<Point3f>() + m, Noise(noise_level));
 #endif
 
-    Mat trans_est;
+    Matx13d trans_est;
     vector<uchar> outl;
     int res = estimateTranslation3D(fpts, tpts, trans_est, outl);
 

--- a/modules/calib3d/test/test_translation3d_estimator.cpp
+++ b/modules/calib3d/test/test_translation3d_estimator.cpp
@@ -1,0 +1,211 @@
+/*M///////////////////////////////////////////////////////////////////////////////////////
+//
+//  IMPORTANT: READ BEFORE DOWNLOADING, COPYING, INSTALLING OR USING.
+//
+//  By downloading, copying, installing or using the software you agree to this license.
+//  If you do not agree to this license, do not download, install,
+//  copy or use the software.
+//
+//
+//                           License Agreement
+//                For Open Source Computer Vision Library
+//
+// Copyright (C) 2000-2008, Intel Corporation, all rights reserved.
+// Copyright (C) 2009, Willow Garage Inc., all rights reserved.
+// Third party copyrights are property of their respective owners.
+//
+// Redistribution and use in source and binary forms, with or without modification,
+// are permitted provided that the following conditions are met:
+//
+//   * Redistribution's of source code must retain the above copyright notice,
+//     this list of conditions and the following disclaimer.
+//
+//   * Redistribution's in binary form must reproduce the above copyright notice,
+//     this list of conditions and the following disclaimer in the documentation
+//     and/or other materials provided with the distribution.
+//
+//   * The name of the copyright holders may not be used to endorse or promote products
+//     derived from this software without specific prior written permission.
+//
+// This software is provided by the copyright holders and contributors "as is" and
+// any express or implied warranties, including, but not limited to, the implied
+// warranties of merchantability and fitness for a particular purpose are disclaimed.
+// In no event shall the Intel Corporation or contributors be liable for any direct,
+// indirect, incidental, special, exemplary, or consequential damages
+// (including, but not limited to, procurement of substitute goods or services;
+// loss of use, data, or profits; or business interruption) however caused
+// and on any theory of liability, whether in contract, strict liability,
+// or tort (including negligence or otherwise) arising in any way out of
+// the use of this software, even if advised of the possibility of such damage.
+//
+//M*/
+
+#include "test_precomp.hpp"
+
+namespace opencv_test { namespace {
+
+class CV_Translation3D_EstTest : public cvtest::BaseTest
+{
+public:
+    CV_Translation3D_EstTest();
+    ~CV_Translation3D_EstTest();
+protected:
+    void run(int);
+
+    bool test4Points();
+    bool testNPoints();
+};
+
+CV_Translation3D_EstTest::CV_Translation3D_EstTest()
+{
+}
+CV_Translation3D_EstTest::~CV_Translation3D_EstTest() {}
+
+
+float rngIn(float from, float to) { return from + (to-from) * (float)theRNG(); }
+
+
+struct WrapTrans
+{
+    const double *F;
+    WrapTrans(const Mat& trans) : F(trans.ptr<double>()) {}
+    Point3f operator()(const Point3f& p)
+    {
+        return Point3f( (float)(p.x + F[0]),
+                        (float)(p.y + F[1]),
+                        (float)(p.z + F[2])  );
+    }
+};
+
+bool CV_Translation3D_EstTest::test4Points()
+{
+
+    Mat trans(3, 1, CV_64F);
+    cv::randu(trans, Scalar(1), Scalar(3));
+
+    // setting points that are no in the same line
+
+    Mat fpts(1, 4, CV_32FC3);
+    Mat tpts(1, 4, CV_32FC3);
+
+    fpts.ptr<Point3f>()[0] = Point3f( rngIn(1,2), rngIn(1,2), rngIn(5, 6) );
+    fpts.ptr<Point3f>()[1] = Point3f( rngIn(3,4), rngIn(3,4), rngIn(5, 6) );
+    fpts.ptr<Point3f>()[2] = Point3f( rngIn(1,2), rngIn(3,4), rngIn(5, 6) );
+    fpts.ptr<Point3f>()[3] = Point3f( rngIn(3,4), rngIn(1,2), rngIn(5, 6) );
+
+    std::transform(fpts.ptr<Point3f>(), fpts.ptr<Point3f>() + 4, tpts.ptr<Point3f>(), WrapTrans(trans));
+
+    Mat trans_est;
+    vector<uchar> outliers;
+    estimateTranslation3D(fpts, tpts, trans_est, outliers);
+
+    const double thres = 1e-3;
+    if (cvtest::norm(trans_est, trans, NORM_INF) > thres)
+    {
+        //cout << cvtest::norm(aff_est, aff, NORM_INF) << endl;
+        ts->set_failed_test_info(cvtest::TS::FAIL_MISMATCH);
+        return false;
+    }
+
+    return true;
+}
+
+struct Noise
+{
+    float l;
+    Noise(float level) : l(level) {}
+    Point3f operator()(const Point3f& p)
+    {
+        RNG& rng = theRNG();
+        return Point3f( p.x + l * (float)rng,  p.y + l * (float)rng,  p.z + l * (float)rng);
+    }
+};
+
+bool CV_Translation3D_EstTest::testNPoints()
+{
+    Mat trans(3, 1, CV_64F);
+    cv::randu(trans, Scalar(-2), Scalar(2));
+
+    // setting points that are no in the same line
+
+    const int n = 100;
+    const int m = 3*n/5;
+    const Point3f shift_outl = Point3f(15, 15, 15);
+    const float noise_level = 20.f;
+
+    Mat fpts(1, n, CV_32FC3);
+    Mat tpts(1, n, CV_32FC3);
+
+    randu(fpts, Scalar::all(0), Scalar::all(100));
+    std::transform(fpts.ptr<Point3f>(), fpts.ptr<Point3f>() + n, tpts.ptr<Point3f>(), WrapTrans(trans));
+
+    /* adding noise*/
+#ifdef CV_CXX11
+    std::transform(tpts.ptr<Point3f>() + m, tpts.ptr<Point3f>() + n, tpts.ptr<Point3f>() + m,
+        [=] (const Point3f& pt) -> Point3f { return Noise(noise_level)(pt + shift_outl); });
+#else
+    std::transform(tpts.ptr<Point3f>() + m, tpts.ptr<Point3f>() + n, tpts.ptr<Point3f>() + m, std::bind2nd(std::plus<Point3f>(), shift_outl));
+    std::transform(tpts.ptr<Point3f>() + m, tpts.ptr<Point3f>() + n, tpts.ptr<Point3f>() + m, Noise(noise_level));
+#endif
+
+    Mat trans_est;
+    vector<uchar> outl;
+    int res = estimateTranslation3D(fpts, tpts, trans_est, outl);
+
+    if (!res)
+    {
+        ts->set_failed_test_info(cvtest::TS::FAIL_MISMATCH);
+        return false;
+    }
+
+    const double thres = 1e-4;
+    if (cvtest::norm(trans_est, trans, NORM_INF) > thres)
+    {
+        cout << "aff est: " << trans_est << endl;
+        cout << "aff ref: " << trans << endl;
+        ts->set_failed_test_info(cvtest::TS::FAIL_MISMATCH);
+        return false;
+    }
+
+    bool outl_good = count(outl.begin(), outl.end(), 1) == m &&
+        m == accumulate(outl.begin(), outl.begin() + m, 0);
+
+    if (!outl_good)
+    {
+        ts->set_failed_test_info(cvtest::TS::FAIL_MISMATCH);
+        return false;
+    }
+    return true;
+}
+
+
+void CV_Translation3D_EstTest::run( int /* start_from */)
+{
+    cvtest::DefaultRngAuto dra;
+
+    if (!test4Points())
+        return;
+
+    if (!testNPoints())
+        return;
+
+    ts->set_failed_test_info(cvtest::TS::OK);
+}
+
+TEST(Calib3d_EstimateTranslation3D, accuracy) { CV_Translation3D_EstTest test; test.safe_run(); }
+
+TEST(Calib3d_EstimateTranslation3D, regression_16007)
+{
+    std::vector<cv::Point3f> m1, m2;
+    m1.push_back(Point3f(1.0f, 0.0f, 0.0f)); m2.push_back(Point3f(1.0f, 1.0f, 0.0f));
+    m1.push_back(Point3f(1.0f, 0.0f, 1.0f)); m2.push_back(Point3f(1.0f, 1.0f, 1.0f));
+    m1.push_back(Point3f(0.5f, 0.0f, 0.5f)); m2.push_back(Point3f(0.5f, 1.0f, 0.5f));
+    m1.push_back(Point3f(2.5f, 0.0f, 2.5f)); m2.push_back(Point3f(2.5f, 1.0f, 2.5f));
+    m1.push_back(Point3f(2.0f, 0.0f, 1.0f)); m2.push_back(Point3f(2.0f, 1.0f, 1.0f));
+
+    cv::Mat m3D, inl;
+    int res = cv::estimateTranslation3D(m1, m2, m3D, inl);
+    EXPECT_EQ(1, res);
+}
+
+}} // namespace


### PR DESCRIPTION
I've done my best to follow the PR guidelines, but this is my first PR to OpenCV, so I anticipate some back and forth; I'm grateful for your time.

Currently the RANSAC filter in calib3D/ptsetreg.cpp only permits full affine transformations. I have an application (and others may as well) that requires limiting the transform to translation only.

The new function follows the API and implementation structure for estimateAffine3D exactly, only the implementations of runKernel, computeError, and checkSubset are modified (and are considerably simpler) for the new class - users can call estimateTranslation3D as a drop in replacement for estimateAffine3D whenever it is appropriate.

I've built successfully on my system and implemented tests. estimateTranslation3D will be strictly faster than estimateAffine3D as it does not require SVD.

I believe I have documented the new code properly, as I simply copied the documentation strings from estimateAffine3D and modified them to be consistent with translation only. Please advise if I'm missing anything.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [X] I agree to contribute to the project under OpenCV (BSD) License.
- [X] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [X] The PR is proposed to proper branch
- [NA] There is reference to original bug report and related work
- [X] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [X] The feature is well documented and sample code can be built with the project CMake
