### PR TITLE
intrin: fixed int64->double conversion for AVX-512

### DIFF
--- a/modules/core/include/opencv2/core/hal/intrin_avx512.hpp
+++ b/modules/core/include/opencv2/core/hal/intrin_avx512.hpp
@@ -1553,13 +1553,13 @@ inline v_float64x8 v_cvt_f64(const v_int64x8& v)
     return v_float64x8(_mm512_cvtepi64_pd(v.val));
 #else
     // constants encoded as floating-point
-    __m512i magic_i_lo   = _mm512_set1_epi64x(0x4330000000000000); // 2^52
-    __m512i magic_i_hi32 = _mm512_set1_epi64x(0x4530000080000000); // 2^84 + 2^63
-    __m512i magic_i_all  = _mm512_set1_epi64x(0x4530000080100000); // 2^84 + 2^63 + 2^52
+    __m512i magic_i_lo   = _mm512_set1_epi64(0x4330000000000000); // 2^52
+    __m512i magic_i_hi32 = _mm512_set1_epi64(0x4530000080000000); // 2^84 + 2^63
+    __m512i magic_i_all  = _mm512_set1_epi64(0x4530000080100000); // 2^84 + 2^63 + 2^52
     __m512d magic_d_all  = _mm512_castsi512_pd(magic_i_all);
 
     // Blend the 32 lowest significant bits of v with magic_int_lo
-    __m512i v_lo         = _mm512_blend_epi32(magic_i_lo, v.val, 0x55);
+    __m512i v_lo         = _mm512_mask_blend_epi32(0x5555, magic_i_lo, v.val);
     // Extract the 32 most significant bits of v
     __m512i v_hi         = _mm512_srli_epi64(v.val, 32);
     // Flip the msb of v_hi and blend with 0x45300000


### PR DESCRIPTION
related #15510

Wrong intrinsics were used in AVX-512 without DQ fallback implementation.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under OpenCV (BSD) License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [x] The PR is proposed to proper branch
- [x] There is reference to original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake

```
force_builders=Linux AVX2,Custom
buildworker:Custom=linux-3
build_image:Custom=ubuntu:18.04
CPU_BASELINE:Custom=AVX512_SKX
disable_ipp=ON
```