### PR TITLE
cuda4dnn(InnerProduct): fix blob rank check assertion

### DIFF
--- a/modules/dnn/src/cuda4dnn/primitives/inner_product.hpp
+++ b/modules/dnn/src/cuda4dnn/primitives/inner_product.hpp
@@ -31,7 +31,7 @@ namespace cv { namespace dnn { namespace cuda4dnn {
             : stream(std::move(stream_)), cublasHandle(std::move(handle)), axis{ axis }
         {
             weightsTensor = csl::makeTensorHeader<T>(weights);
-            CV_Assert(get_effective_rank(weightsTensor) == 2);
+            CV_Assert(get_effective_rank(weightsTensor) <= 2);
             csl::copyMatToTensor<T>(weights, weightsTensor, stream);
 
             if (!bias.empty())


### PR DESCRIPTION
### Pull Request Readiness Checklist

Resolves a problem mentioned in https://github.com/opencv/opencv/issues/16568#issuecomment-589473657

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under OpenCV (BSD) License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [x] The PR is proposed to proper branch
- [x] There is reference to original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake

```
force_builders=Custom
buildworker:Custom=linux-4
docker_image:Custom=ubuntu-cuda:18.04
```