### PR TITLE
Using argv[0] represent binary executable files' name in help() function in sample codes instead of cpp files' name.

### DIFF
--- a/samples/cpp/3calibration.cpp
+++ b/samples/cpp/3calibration.cpp
@@ -17,10 +17,10 @@ using namespace std;
 
 enum { DETECTION = 0, CAPTURING = 1, CALIBRATED = 2 };
 
-static void help()
+static void help(char** argv)
 {
         printf( "\nThis is a camera calibration sample that calibrates 3 horizontally placed cameras together.\n"
-               "Usage: 3calibration\n"
+               "Usage: %s\n"
                "     -w=<board_width>         # the number of inner corners per one of board dimension\n"
                "     -h=<board_height>        # the number of inner corners per another board dimension\n"
                "     [-s=<squareSize>]       # square size in some user-defined units (1 by default)\n"
@@ -29,7 +29,7 @@ static void help()
                "     [-a=<aspectRatio>]      # fix aspect ratio (fx/fy)\n"
                "     [-p]                     # fix the principal point at the center\n"
                "     [input_data]             # input data - text file with a list of the images of the board\n"
-               "\n" );
+               "\n", argv[0] );
 
 }
 
@@ -190,7 +190,7 @@ int main( int argc, char** argv )
         "{zt||}{a|1|}{p||}{@input||}");
     if (parser.has("help"))
     {
-        help();
+        help(argv);
         return 0;
     }
     boardSize.width = parser.get<int>("w");
@@ -207,7 +207,7 @@ int main( int argc, char** argv )
     inputFilename = parser.get<string>("@input");
     if (!parser.check())
     {
-        help();
+        help(argv);
         parser.printErrors();
         return -1;
     }

--- a/samples/cpp/calibration.cpp
+++ b/samples/cpp/calibration.cpp
@@ -46,10 +46,10 @@ const char* liveCaptureHelp =
         "  'g' - start capturing images\n"
         "  'u' - switch undistortion on/off\n";
 
-static void help()
+static void help(char** argv)
 {
     printf( "This is a camera calibration sample.\n"
-        "Usage: calibration\n"
+        "Usage: %s\n"
         "     -w=<board_width>         # the number of inner corners per one of board dimension\n"
         "     -h=<board_height>        # the number of inner corners per another board dimension\n"
         "     [-pt=<pattern>]          # the type of pattern: chessboard or circles' grid\n"
@@ -74,7 +74,7 @@ static void help()
         "                              #    the text file can be generated with imagelist_creator\n"
         "                              #  - name of video file with a video of the board\n"
         "                              # if input_data not specified, a live view from the camera is used\n"
-        "\n" );
+        "\n", argv[0] );
     printf("\n%s",usage);
     printf( "\n%s", liveCaptureHelp );
 }
@@ -343,7 +343,7 @@ int main( int argc, char** argv )
         "{@input_data|0|}");
     if (parser.has("help"))
     {
-        help();
+        help(argv);
         return 0;
     }
     boardSize.width = parser.get<int>( "w" );
@@ -383,7 +383,7 @@ int main( int argc, char** argv )
         inputFilename = parser.get<string>("@input_data");
     if (!parser.check())
     {
-        help();
+        help(argv);
         parser.printErrors();
         return -1;
     }

--- a/samples/cpp/camshiftdemo.cpp
+++ b/samples/cpp/camshiftdemo.cpp
@@ -1,4 +1,4 @@
-#include <opencv2/core/utility.hpp>
+#include "opencv2/core/utility.hpp"
 #include "opencv2/video/tracking.hpp"
 #include "opencv2/imgproc.hpp"
 #include "opencv2/videoio.hpp"
@@ -57,13 +57,13 @@ string hot_keys =
     "\tp - pause video\n"
     "To initialize tracking, select the object with mouse\n";
 
-static void help()
+static void help(const char** argv)
 {
     cout << "\nThis is a demo that shows mean-shift based tracking\n"
             "You select a color objects such as your face and it tracks it.\n"
             "This reads from video camera (0 by default, or the camera number the user enters\n"
-            "Usage: \n"
-            "   ./camshiftdemo [camera number]\n";
+            "Usage: \n\t";
+    cout << argv[0] << " [camera number]\n";
     cout << hot_keys;
 }
 
@@ -82,7 +82,7 @@ int main( int argc, const char** argv )
     CommandLineParser parser(argc, argv, keys);
     if (parser.has("help"))
     {
-        help();
+        help(argv);
         return 0;
     }
     int camNum = parser.get<int>(0);
@@ -90,7 +90,7 @@ int main( int argc, const char** argv )
 
     if( !cap.isOpened() )
     {
-        help();
+        help(argv);
         cout << "***Could not initialize capturing...***\n";
         cout << "Current parameter's value: \n";
         parser.printMessage();

--- a/samples/cpp/contours2.cpp
+++ b/samples/cpp/contours2.cpp
@@ -6,15 +6,16 @@
 using namespace cv;
 using namespace std;
 
-static void help()
+static void help(char** argv)
 {
     cout
-    << "\nThis program illustrates the use of findContours and drawContours\n"
-    << "The original image is put up along with the image of drawn contours\n"
-    << "Usage:\n"
-    << "./contours2\n"
-    << "\nA trackbar is put up which controls the contour level from -3 to 3\n"
-    << endl;
+        << "\nThis program illustrates the use of findContours and drawContours\n"
+        << "The original image is put up along with the image of drawn contours\n"
+        << "Usage:\n";
+    cout
+        << argv[0]
+        << "\nA trackbar is put up which controls the contour level from -3 to 3\n"
+        << endl;
 }
 
 const int w = 500;
@@ -38,7 +39,7 @@ int main( int argc, char** argv)
     cv::CommandLineParser parser(argc, argv, "{help h||}");
     if (parser.has("help"))
     {
-        help();
+        help(argv);
         return 0;
     }
     Mat img = Mat::zeros(w, w, CV_8UC1);

--- a/samples/cpp/convexhull.cpp
+++ b/samples/cpp/convexhull.cpp
@@ -5,11 +5,11 @@
 using namespace cv;
 using namespace std;
 
-static void help()
+static void help(char** argv)
 {
     cout << "\nThis sample program demonstrates the use of the convexHull() function\n"
          << "Call:\n"
-         << "./convexhull\n" << endl;
+         << argv[0] << endl;
 }
 
 int main( int argc, char** argv )
@@ -17,7 +17,7 @@ int main( int argc, char** argv )
     CommandLineParser parser(argc, argv, "{help h||}");
     if (parser.has("help"))
     {
-        help();
+        help(argv);
         return 0;
     }
     Mat img(500, 500, CV_8UC3);

--- a/samples/cpp/cout_mat.cpp
+++ b/samples/cpp/cout_mat.cpp
@@ -11,7 +11,7 @@
 using namespace std;
 using namespace cv;
 
-static void help()
+static void help(char** argv)
 {
     cout
     << "\n------------------------------------------------------------------\n"
@@ -19,8 +19,8 @@ static void help()
     << "That is, cv::Mat M(...); cout << M;  Now works.\n"
     << "Output can be formatted to OpenCV, matlab, python, numpy, csv and \n"
     << "C styles Usage:\n"
-    << "./cvout_sample\n"
-    << "------------------------------------------------------------------\n\n"
+    << argv[0]
+    << "\n------------------------------------------------------------------\n\n"
     << endl;
 }
 
@@ -30,7 +30,7 @@ int main(int argc, char** argv)
     cv::CommandLineParser parser(argc, argv, "{help h||}");
     if (parser.has("help"))
     {
-        help();
+        help(argv);
         return 0;
     }
     Mat I = Mat::eye(4, 4, CV_64F);

--- a/samples/cpp/delaunay2.cpp
+++ b/samples/cpp/delaunay2.cpp
@@ -5,15 +5,15 @@
 using namespace cv;
 using namespace std;
 
-static void help()
+static void help(char** argv)
 {
     cout << "\nThis program demonstrates iterative construction of\n"
-           "delaunay triangulation and voronoi tessellation.\n"
-           "It draws a random set of points in an image and then delaunay triangulates them.\n"
-           "Usage: \n"
-           "./delaunay \n"
-           "\nThis program builds the triangulation interactively, you may stop this process by\n"
-           "hitting any key.\n";
+            "delaunay triangulation and voronoi tessellation.\n"
+            "It draws a random set of points in an image and then delaunay triangulates them.\n"
+            "Usage: \n";
+    cout << argv[0];
+    cout << "\n\nThis program builds the triangulation interactively, you may stop this process by\n"
+            "hitting any key.\n";
 }
 
 static void draw_subdiv_point( Mat& img, Point2f fp, Scalar color )
@@ -108,7 +108,7 @@ int main( int argc, char** argv )
     cv::CommandLineParser parser(argc, argv, "{help h||}");
     if (parser.has("help"))
     {
-        help();
+        help(argv);
         return 0;
     }
 

--- a/samples/cpp/detect_blob.cpp
+++ b/samples/cpp/detect_blob.cpp
@@ -10,12 +10,13 @@ using namespace std;
 using namespace cv;
 
 
-static void help()
+static void help(char** argv)
 {
     cout << "\n This program demonstrates how to use BLOB to detect and filter region \n"
-        "Usage: \n"
-        "  ./detect_blob <image1(detect_blob.png as default)>\n"
-        "Press a key when image window is active to change descriptor";
+         << "Usage: \n"
+         << argv[0]
+         << " <image1(detect_blob.png as default)>\n"
+         << "Press a key when image window is active to change descriptor";
 }
 
 
@@ -74,7 +75,7 @@ int main(int argc, char *argv[])
     cv::CommandLineParser parser(argc, argv, "{@input |detect_blob.png| }{h help | | }");
     if (parser.has("h"))
     {
-        help();
+        help(argv);
         return 0;
     }
     fileName = parser.get<string>("@input");
@@ -120,7 +121,7 @@ int main(int argc, char *argv[])
         uchar c3 = (uchar)rand();
         palette.push_back(Vec3b(c1, c2, c3));
     }
-    help();
+    help(argv);
 
 
     // These descriptors are going to be detecting and computing BLOBS with 6 different params

--- a/samples/cpp/detect_mser.cpp
+++ b/samples/cpp/detect_mser.cpp
@@ -34,13 +34,13 @@ using namespace std;
 using namespace cv;
 
 
-static void help()
+static void help(char** argv)
 {
     cout << "\nThis program demonstrates how to use MSER to detect extremal regions\n"
-        "Usage:\n"
-        "  ./detect_mser <image1(without parameter a synthetic image is used as default)>\n"
-        "Press esc key when image window is active to change descriptor parameter\n"
-        "Press 2, 8, 4, 6, +, -, or 5 keys in openGL windows to change view or use mouse\n";
+            "Usage:\n"
+         << argv[0] << " <image1(without parameter a synthetic image is used as default)>\n"
+            "Press esc key when image window is active to change descriptor parameter\n"
+            "Press 2, 8, 4, 6, +, -, or 5 keys in openGL windows to change view or use mouse\n";
 }
 
 struct MSERParams
@@ -405,7 +405,7 @@ int main(int argc, char *argv[])
     cv::CommandLineParser parser(argc, argv, "{ help h | | }{ @input | | }");
     if (parser.has("help"))
     {
-        help();
+        help(argv);
         return 0;
     }
 
@@ -431,7 +431,7 @@ int main(int argc, char *argv[])
     for (int i = 0; i<=numeric_limits<uint16_t>::max(); i++)
         palette.push_back(Vec3b((uchar)rand(), (uchar)rand(), (uchar)rand()));
 
-    help();
+    help(argv);
 
     MSERParams params;
 

--- a/samples/cpp/digits.cpp
+++ b/samples/cpp/digits.cpp
@@ -15,7 +15,7 @@ const int SZ = 20;  // size of each digit is SZ x SZ
 const int CLASS_N = 10;
 const char* DIGITS_FN = "digits.png";
 
-static void help()
+static void help(char** argv)
 {
     cout <<
     "\n"
@@ -38,7 +38,7 @@ static void help()
     "    http://www.robots.ox.ac.uk/~vgg/publications/2012/Arandjelovic12/arandjelovic12.pdf\n"
     "\n"
     "Usage:\n"
-    "   ./digits\n" << endl;
+    << argv[0] << endl;
 }
 
 static void split2d(const Mat& image, const Size cell_size, vector<Mat>& cells)
@@ -299,9 +299,9 @@ static void shuffle(vector<Mat>& digits, vector<int>& labels)
     labels = shuffled_labels;
 }
 
-int main()
+int main(int /* argc */, char* argv[])
 {
-    help();
+    help(argv);
 
     vector<Mat> digits;
     vector<int> labels;

--- a/samples/cpp/distrans.cpp
+++ b/samples/cpp/distrans.cpp
@@ -87,11 +87,11 @@ static void onTrackbar( int, void* )
     imshow("Distance Map", dist8u );
 }
 
-static void help()
+static void help(const char** argv)
 {
     printf("\nProgram to demonstrate the use of the distance transform function between edge images.\n"
             "Usage:\n"
-            "./distrans [image_name -- default image is stuff.jpg]\n"
+            "%s [image_name -- default image is stuff.jpg]\n"
             "\nHot keys: \n"
             "\tESC - quit the program\n"
             "\tC - use C/Inf metric\n"
@@ -102,7 +102,7 @@ static void help()
             "\t0 - use precise distance transform\n"
             "\tv - switch to Voronoi diagram mode\n"
             "\tp - switch to pixel-based Voronoi diagram mode\n"
-            "\tSPACE - loop through all the modes\n\n");
+            "\tSPACE - loop through all the modes\n\n", argv[0]);
 }
 
 const char* keys =
@@ -113,7 +113,7 @@ const char* keys =
 int main( int argc, const char** argv )
 {
     CommandLineParser parser(argc, argv, keys);
-    help();
+    help(argv);
     if (parser.has("help"))
         return 0;
     string filename = parser.get<string>(0);
@@ -121,7 +121,7 @@ int main( int argc, const char** argv )
     if(gray.empty())
     {
         printf("Cannot read image file: %s\n", filename.c_str());
-        help();
+        help(argv);
         return -1;
     }
 

--- a/samples/cpp/drawing.cpp
+++ b/samples/cpp/drawing.cpp
@@ -5,11 +5,11 @@
 
 using namespace cv;
 
-static void help()
+static void help(char** argv)
 {
     printf("\nThis program demonstrates OpenCV drawing and text output functions.\n"
     "Usage:\n"
-    "   ./drawing\n");
+    "   %s\n", argv[0]);
 }
 static Scalar randomColor(RNG& rng)
 {
@@ -17,9 +17,9 @@ static Scalar randomColor(RNG& rng)
     return Scalar(icolor&255, (icolor>>8)&255, (icolor>>16)&255);
 }
 
-int main()
+int main(int /* argc */, char** argv)
 {
-    help();
+    help(argv);
     char wndname[] = "Drawing Demo";
     const int NUMBER = 100;
     const int DELAY = 5;

--- a/samples/cpp/edge.cpp
+++ b/samples/cpp/edge.cpp
@@ -39,11 +39,11 @@ static void onTrackbar(int, void*)
     imshow(window_name2, cedge);
 }
 
-static void help()
+static void help(const char** argv)
 {
     printf("\nThis sample demonstrates Canny edge detection\n"
            "Call:\n"
-           "    /.edge [image_name -- Default is fruits.jpg]\n\n");
+           "    %s [image_name -- Default is fruits.jpg]\n\n", argv[0]);
 }
 
 const char* keys =
@@ -53,7 +53,7 @@ const char* keys =
 
 int main( int argc, const char** argv )
 {
-    help();
+    help(argv);
     CommandLineParser parser(argc, argv, keys);
     string filename = parser.get<string>(0);
 
@@ -61,7 +61,7 @@ int main( int argc, const char** argv )
     if(image.empty())
     {
         printf("Cannot read image file: %s\n", filename.c_str());
-        help();
+        help(argv);
         return -1;
     }
     cedge.create(image.size(), image.type());

--- a/samples/cpp/facedetect.cpp
+++ b/samples/cpp/facedetect.cpp
@@ -7,19 +7,21 @@
 using namespace std;
 using namespace cv;
 
-static void help()
+static void help(const char** argv)
 {
     cout << "\nThis program demonstrates the use of cv::CascadeClassifier class to detect objects (Face + eyes). You can use Haar or LBP features.\n"
             "This classifier can recognize many kinds of rigid objects, once the appropriate classifier is trained.\n"
             "It's most known use is for faces.\n"
             "Usage:\n"
-            "./facedetect [--cascade=<cascade_path> this is the primary trained classifier such as frontal face]\n"
-               "   [--nested-cascade[=nested_cascade_path this an optional secondary classifier such as eyes]]\n"
-               "   [--scale=<image scale greater or equal to 1, try 1.3 for example>]\n"
-               "   [--try-flip]\n"
-               "   [filename|camera_index]\n\n"
-            "see facedetect.cmd for one call:\n"
-            "./facedetect --cascade=\"data/haarcascades/haarcascade_frontalface_alt.xml\" --nested-cascade=\"data/haarcascades/haarcascade_eye_tree_eyeglasses.xml\" --scale=1.3\n\n"
+        <<  argv[0]
+        <<  "   [--cascade=<cascade_path> this is the primary trained classifier such as frontal face]\n"
+            "   [--nested-cascade[=nested_cascade_path this an optional secondary classifier such as eyes]]\n"
+            "   [--scale=<image scale greater or equal to 1, try 1.3 for example>]\n"
+            "   [--try-flip]\n"
+            "   [filename|camera_index]\n\n"
+            "example:\n"
+        <<  argv[0]
+        <<  " --cascade=\"data/haarcascades/haarcascade_frontalface_alt.xml\" --nested-cascade=\"data/haarcascades/haarcascade_eye_tree_eyeglasses.xml\" --scale=1.3\n\n"
             "During execution:\n\tHit any key to quit.\n"
             "\tUsing OpenCV version " << CV_VERSION << "\n" << endl;
 }
@@ -48,7 +50,7 @@ int main( int argc, const char** argv )
     );
     if (parser.has("help"))
     {
-        help();
+        help(argv);
         return 0;
     }
     cascadeName = parser.get<string>("cascade");
@@ -68,7 +70,7 @@ int main( int argc, const char** argv )
     if (!cascade.load(samples::findFile(cascadeName)))
     {
         cerr << "ERROR: Could not load classifier cascade" << endl;
-        help();
+        help(argv);
         return -1;
     }
     if( inputName.empty() || (isdigit(inputName[0]) && inputName.size() == 1) )

--- a/samples/cpp/facial_features.cpp
+++ b/samples/cpp/facial_features.cpp
@@ -19,7 +19,7 @@ using namespace std;
 using namespace cv;
 
 // Functions for facial feature detection
-static void help();
+static void help(char** argv);
 static void detectFaces(Mat&, vector<Rect_<int> >&, string);
 static void detectEyes(Mat&, vector<Rect_<int> >&, string);
 static void detectNose(Mat&, vector<Rect_<int> >&, string);
@@ -35,7 +35,7 @@ int main(int argc, char** argv)
             "{eyes||}{nose||}{mouth||}{help h||}{@image||}{@facexml||}");
     if (parser.has("help"))
     {
-        help();
+        help(argv);
         return 0;
     }
     input_image_path = parser.get<string>("@image");
@@ -63,14 +63,14 @@ int main(int argc, char** argv)
     return 0;
 }
 
-static void help()
+static void help(char** argv)
 {
     cout << "\nThis file demonstrates facial feature points detection using Haarcascade classifiers.\n"
         "The program detects a face and eyes, nose and mouth inside the face."
         "The code has been tested on the Japanese Female Facial Expression (JAFFE) database and found"
         "to give reasonably accurate results. \n";
 
-    cout << "\nUSAGE: ./cpp-example-facial_features [IMAGE] [FACE_CASCADE] [OPTIONS]\n"
+    cout << "\nUSAGE: " << argv[0] << " [IMAGE] [FACE_CASCADE] [OPTIONS]\n"
         "IMAGE\n\tPath to the image of a face taken as input.\n"
         "FACE_CASCSDE\n\t Path to a haarcascade classifier for face detection.\n"
         "OPTIONS: \nThere are 3 options available which are described in detail. There must be a "
@@ -81,11 +81,11 @@ static void help()
 
 
     cout << "EXAMPLE:\n"
-        "(1) ./cpp-example-facial_features image.jpg face.xml -eyes=eyes.xml -mouth=mouth.xml\n"
+        "(1) " << argv[0] << " image.jpg face.xml -eyes=eyes.xml -mouth=mouth.xml\n"
         "\tThis will detect the face, eyes and mouth in image.jpg.\n"
-        "(2) ./cpp-example-facial_features image.jpg face.xml -nose=nose.xml\n"
+        "(2) " << argv[0] << " image.jpg face.xml -nose=nose.xml\n"
         "\tThis will detect the face and nose in image.jpg.\n"
-        "(3) ./cpp-example-facial_features image.jpg face.xml\n"
+        "(3) " << argv[0] << " image.jpg face.xml\n"
         "\tThis will detect only the face in image.jpg.\n";
 
     cout << " \n\nThe classifiers for face and eyes can be downloaded from : "

--- a/samples/cpp/fback.cpp
+++ b/samples/cpp/fback.cpp
@@ -8,14 +8,14 @@
 using namespace cv;
 using namespace std;
 
-static void help()
+static void help(char** argv)
 {
     cout <<
             "\nThis program demonstrates dense optical flow algorithm by Gunnar Farneback\n"
             "Mainly the function: calcOpticalFlowFarneback()\n"
             "Call:\n"
-            "./fback\n"
-            "This reads from video camera 0\n" << endl;
+        <<  argv[0]
+        <<  "This reads from video camera 0\n" << endl;
 }
 static void drawOptFlowMap(const Mat& flow, Mat& cflowmap, int step,
                     double, const Scalar& color)
@@ -35,11 +35,11 @@ int main(int argc, char** argv)
     cv::CommandLineParser parser(argc, argv, "{help h||}");
     if (parser.has("help"))
     {
-        help();
+        help(argv);
         return 0;
     }
     VideoCapture cap(0);
-    help();
+    help(argv);
     if( !cap.isOpened() )
         return -1;
 

--- a/samples/cpp/ffilldemo.cpp
+++ b/samples/cpp/ffilldemo.cpp
@@ -8,11 +8,12 @@
 using namespace cv;
 using namespace std;
 
-static void help()
+static void help(char** argv)
 {
     cout << "\nThis program demonstrated the floodFill() function\n"
             "Call:\n"
-            "./ffilldemo [image_name -- Default: fruits.jpg]\n" << endl;
+        <<  argv[0]
+        <<  " [image_name -- Default: fruits.jpg]\n" << endl;
 
     cout << "Hot keys: \n"
             "\tESC - quit the program\n"
@@ -90,7 +91,7 @@ int main( int argc, char** argv )
         parser.printMessage();
         return 0;
     }
-    help();
+    help(argv);
     image0.copyTo(image);
     cvtColor(image0, gray, COLOR_BGR2GRAY);
     mask.create(image0.rows+2, image0.cols+2, CV_8UC1);

--- a/samples/cpp/fitellipse.cpp
+++ b/samples/cpp/fitellipse.cpp
@@ -164,14 +164,13 @@ public:
 
 };
 
-static void help()
+static void help(char** argv)
 {
-    cout <<
-    "\nThis program is demonstration for ellipse fitting. The program finds\n"
-    "contours and approximate it by ellipses. Three methods are used to find the \n"
-    "elliptical fits: fitEllipse, fitEllipseAMS and fitEllipseDirect.\n"
-    "Call:\n"
-    "./fitellipse [image_name -- Default ellipses.jpg]\n" << endl;
+    cout << "\nThis program is demonstration for ellipse fitting. The program finds\n"
+            "contours and approximate it by ellipses. Three methods are used to find the \n"
+            "elliptical fits: fitEllipse, fitEllipseAMS and fitEllipseDirect.\n"
+            "Call:\n"
+        << argv[0] << " [image_name -- Default ellipses.jpg]\n" << endl;
 }
 
 int sliderPos = 70;
@@ -195,7 +194,7 @@ int main( int argc, char** argv )
     cv::CommandLineParser parser(argc, argv,"{help h||}{@image|ellipses.jpg|}");
     if (parser.has("help"))
     {
-        help();
+        help(argv);
         return 0;
     }
     string filename = parser.get<string>("@image");

--- a/samples/cpp/grabcut.cpp
+++ b/samples/cpp/grabcut.cpp
@@ -7,25 +7,25 @@
 using namespace std;
 using namespace cv;
 
-static void help()
+static void help(char** argv)
 {
     cout << "\nThis program demonstrates GrabCut segmentation -- select an object in a region\n"
             "and then grabcut will attempt to segment it out.\n"
             "Call:\n"
-            "./grabcut <image_name>\n"
-        "\nSelect a rectangular area around the object you want to segment\n" <<
-        "\nHot keys: \n"
-        "\tESC - quit the program\n"
-        "\tr - restore the original image\n"
-        "\tn - next iteration\n"
-        "\n"
-        "\tleft mouse button - set rectangle\n"
-        "\n"
-        "\tCTRL+left mouse button - set GC_BGD pixels\n"
-        "\tSHIFT+left mouse button - set GC_FGD pixels\n"
-        "\n"
-        "\tCTRL+right mouse button - set GC_PR_BGD pixels\n"
-        "\tSHIFT+right mouse button - set GC_PR_FGD pixels\n" << endl;
+        <<  argv[0] << " <image_name>\n"
+            "\nSelect a rectangular area around the object you want to segment\n" <<
+            "\nHot keys: \n"
+            "\tESC - quit the program\n"
+            "\tr - restore the original image\n"
+            "\tn - next iteration\n"
+            "\n"
+            "\tleft mouse button - set rectangle\n"
+            "\n"
+            "\tCTRL+left mouse button - set GC_BGD pixels\n"
+            "\tSHIFT+left mouse button - set GC_FGD pixels\n"
+            "\n"
+            "\tCTRL+right mouse button - set GC_PR_BGD pixels\n"
+            "\tSHIFT+right mouse button - set GC_PR_FGD pixels\n" << endl;
 }
 
 const Scalar RED = Scalar(0,0,255);
@@ -277,7 +277,7 @@ static void on_mouse( int event, int x, int y, int flags, void* param )
 int main( int argc, char** argv )
 {
     cv::CommandLineParser parser(argc, argv, "{@input| messi5.jpg |}");
-    help();
+    help(argv);
 
     string filename = parser.get<string>("@input");
     if( filename.empty() )

--- a/samples/cpp/image_alignment.cpp
+++ b/samples/cpp/image_alignment.cpp
@@ -28,7 +28,7 @@
 using namespace cv;
 using namespace std;
 
-static void help(void);
+static void help(const char** argv);
 static int readWarp(string iFilename, Mat& warp, int motionType);
 static int saveWarp(string fileName, const Mat& warp, int motionType);
 static void draw_warped_roi(Mat& image, const int width, const int height, Mat& W);
@@ -57,7 +57,7 @@ const std::string keys =
 ;
 
 
-static void help(void)
+static void help(const char** argv)
 {
 
     cout << "\nThis file demonstrates the use of the ECC image alignment algorithm. When one image"
@@ -65,10 +65,14 @@ static void help(void)
         " are given, the initialization of the warp by command line parsing is possible. "
         "If inputWarp is missing, the identity transformation initializes the algorithm. \n" << endl;
 
-    cout << "\nUsage example (one image): \n./image_alignment fruits.jpg -o=outWarp.ecc "
-        "-m=euclidean -e=1e-6 -N=70 -v=1 \n" << endl;
+    cout << "\nUsage example (one image): \n"
+         << argv[0]
+         << " fruits.jpg -o=outWarp.ecc "
+            "-m=euclidean -e=1e-6 -N=70 -v=1 \n" << endl;
 
-    cout << "\nUsage example (two images with initialization): \n./image_alignment yourInput.png yourTemplate.png "
+    cout << "\nUsage example (two images with initialization): \n"
+         << argv[0]
+         << " yourInput.png yourTemplate.png "
         "yourInitialWarp.ecc -o=outWarp.ecc -m=homography -e=1e-6 -N=70 -v=1 -w=yourFinalImage.png \n" << endl;
 
 }
@@ -178,7 +182,7 @@ int main (const int argc, const char * argv[])
     parser.about("ECC demo");
 
     parser.printMessage();
-    help();
+    help(argv);
 
     string imgFile = parser.get<string>(0);
     string tempImgFile = parser.get<string>(1);

--- a/samples/cpp/laplace.cpp
+++ b/samples/cpp/laplace.cpp
@@ -9,13 +9,13 @@
 using namespace cv;
 using namespace std;
 
-static void help()
+static void help(char** argv)
 {
     cout <<
             "\nThis program demonstrates Laplace point/edge detection using OpenCV function Laplacian()\n"
             "It captures from the camera of your choice: 0, 1, ... default 0\n"
             "Call:\n"
-            "./laplace -c=<camera #, default 0> -p=<index of the frame to be decoded/captured next>\n" << endl;
+         <<  argv[0] << " -c=<camera #, default 0> -p=<index of the frame to be decoded/captured next>\n" << endl;
 }
 
 enum {GAUSSIAN, BLUR, MEDIAN};
@@ -26,7 +26,7 @@ int smoothType = GAUSSIAN;
 int main( int argc, char** argv )
 {
     cv::CommandLineParser parser(argc, argv, "{ c | 0 | }{ p | | }");
-    help();
+    help(argv);
 
     VideoCapture cap;
     string camera = parser.get<string>("c");

--- a/samples/cpp/letter_recog.cpp
+++ b/samples/cpp/letter_recog.cpp
@@ -9,7 +9,7 @@ using namespace std;
 using namespace cv;
 using namespace cv::ml;
 
-static void help()
+static void help(char** argv)
 {
     printf("\nThe sample demonstrates how to train Random Trees classifier\n"
     "(or Boosting classifier, or MLP, or Knearest, or Nbayes, or Support Vector Machines - see main()) using the provided dataset.\n"
@@ -28,10 +28,10 @@ static void help()
     "and the remaining 4000 (10000 for boosting) - to test the classifier.\n"
     "======================================================\n");
     printf("\nThis is letter recognition sample.\n"
-            "The usage: letter_recog [-data=<path to letter-recognition.data>] \\\n"
+            "The usage: %s [-data=<path to letter-recognition.data>] \\\n"
             "  [-save=<output XML file for the classifier>] \\\n"
             "  [-load=<XML file with the pre-trained classifier>] \\\n"
-            "  [-boost|-mlp|-knearest|-nbayes|-svm] # to use boost/mlp/knearest/SVM classifier instead of default Random Trees\n" );
+            "  [-boost|-mlp|-knearest|-nbayes|-svm] # to use boost/mlp/knearest/SVM classifier instead of default Random Trees\n", argv[0] );
 }
 
 // This function reads data and responses from the file <filename>
@@ -538,7 +538,7 @@ int main( int argc, char *argv[] )
     else if (parser.has("svm"))
         method = 5;
 
-    help();
+    help(argv);
 
     if( (method == 0 ?
         build_rtrees_classifier( data_filename, filename_to_save, filename_to_load ) :

--- a/samples/cpp/matchmethod_orb_akaze_brisk.cpp
+++ b/samples/cpp/matchmethod_orb_akaze_brisk.cpp
@@ -8,11 +8,11 @@
 using namespace std;
 using namespace cv;
 
-static void help()
+static void help(char* argv[])
 {
     cout << "\n This program demonstrates how to detect compute and match ORB BRISK and AKAZE descriptors \n"
-        "Usage: \n"
-        "  ./matchmethod_orb_akaze_brisk --image1=<image1(basketball1.png as default)> --image2=<image2(basketball2.png as default)>\n"
+            "Usage: \n  "
+         << argv[0] << " --image1=<image1(basketball1.png as default)> --image2=<image2(basketball2.png as default)>\n"
         "Press a key when image window is active to change algorithm or descriptor";
 }
 
@@ -39,7 +39,7 @@ int main(int argc, char *argv[])
         "{help h ||}");
     if (parser.has("help"))
     {
-        help();
+        help(argv);
         return 0;
     }
     fileName.push_back(samples::findFile(parser.get<string>(0)));

--- a/samples/cpp/morphology2.cpp
+++ b/samples/cpp/morphology2.cpp
@@ -7,12 +7,12 @@
 
 using namespace cv;
 
-static void help()
+static void help(char** argv)
 {
 
 printf("\nShow off image morphology: erosion, dialation, open and close\n"
-    "Call:\n   morphology2 [image]\n"
-    "This program also shows use of rect, ellipse and cross kernels\n\n");
+    "Call:\n   %s [image]\n"
+    "This program also shows use of rect, ellipse and cross kernels\n\n", argv[0]);
 printf( "Hot keys: \n"
     "\tESC - quit the program\n"
     "\tr - use rectangle structuring element\n"
@@ -62,13 +62,13 @@ int main( int argc, char** argv )
     cv::CommandLineParser parser(argc, argv, "{help h||}{ @image | baboon.jpg | }");
     if (parser.has("help"))
     {
-        help();
+        help(argv);
         return 0;
     }
     std::string filename = samples::findFile(parser.get<std::string>("@image"));
     if( (src = imread(filename,IMREAD_COLOR)).empty() )
     {
-        help();
+        help(argv);
         return -1;
     }
 

--- a/samples/cpp/segment_objects.cpp
+++ b/samples/cpp/segment_objects.cpp
@@ -8,14 +8,14 @@
 using namespace std;
 using namespace cv;
 
-static void help()
+static void help(char** argv)
 {
     printf("\n"
             "This program demonstrated a simple method of connected components clean up of background subtraction\n"
             "When the program starts, it begins learning the background.\n"
             "You can toggle background learning on and off by hitting the space bar.\n"
             "Call\n"
-            "./segment_objects [video file, else it reads camera 0]\n\n");
+            "%s [video file, else it reads camera 0]\n\n", argv[0]);
 }
 
 static void refineSegments(const Mat& img, Mat& mask, Mat& dst)
@@ -66,7 +66,7 @@ int main(int argc, char** argv)
     CommandLineParser parser(argc, argv, "{help h||}{@input||}");
     if (parser.has("help"))
     {
-        help();
+        help(argv);
         return 0;
     }
     string input = parser.get<std::string>("@input");

--- a/samples/cpp/select3dobj.cpp
+++ b/samples/cpp/select3dobj.cpp
@@ -19,48 +19,51 @@
 #include <ctype.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <string>
 
 using namespace std;
 using namespace cv;
 
-const char* helphelp =
-"\nThis program's purpose is to collect data sets of an object and its segmentation mask.\n"
-"\n"
-"It shows how to use a calibrated camera together with a calibration pattern to\n"
-"compute the homography of the plane the calibration pattern is on. It also shows grabCut\n"
-"segmentation etc.\n"
-"\n"
-"select3dobj -w=<board_width> -h=<board_height> [-s=<square_size>]\n"
-"           -i=<camera_intrinsics_filename> -o=<output_prefix>\n"
-"\n"
-" -w=<board_width>          Number of chessboard corners wide\n"
-" -h=<board_height>         Number of chessboard corners width\n"
-" [-s=<square_size>]            Optional measure of chessboard squares in meters\n"
-" -i=<camera_intrinsics_filename> Camera matrix .yml file from calibration.cpp\n"
-" -o=<output_prefix>        Prefix the output segmentation images with this\n"
-" [video_filename/cameraId]  If present, read from that video file or that ID\n"
-"\n"
-"Using a camera's intrinsics (from calibrating a camera -- see calibration.cpp) and an\n"
-"image of the object sitting on a planar surface with a calibration pattern of\n"
-"(board_width x board_height) on the surface, we draw a 3D box around the object. From\n"
-"then on, we can move a camera and as long as it sees the chessboard calibration pattern,\n"
-"it will store a mask of where the object is. We get successive images using <output_prefix>\n"
-"of the segmentation mask containing the object. This makes creating training sets easy.\n"
-"It is best if the chessboard is odd x even in dimensions to avoid ambiguous poses.\n"
-"\n"
-"The actions one can use while the program is running are:\n"
-"\n"
-"  Select object as 3D box with the mouse.\n"
-"   First draw one line on the plane to outline the projection of that object on the plane\n"
-"    Then extend that line into a box to encompass the projection of that object onto the plane\n"
-"    The use the mouse again to extend the box upwards from the plane to encase the object.\n"
-"  Then use the following commands\n"
-"    ESC   - Reset the selection\n"
-"    SPACE - Skip the frame; move to the next frame (not in video mode)\n"
-"    ENTER - Confirm the selection. Grab next object in video mode.\n"
-"    q     - Exit the program\n"
-"\n\n";
-
+static string helphelp(char** argv)
+{
+    return  string("\nThis program's purpose is to collect data sets of an object and its segmentation mask.\n")
+        +   "\n"
+            "It shows how to use a calibrated camera together with a calibration pattern to\n"
+            "compute the homography of the plane the calibration pattern is on. It also shows grabCut\n"
+            "segmentation etc.\n"
+            "\n"
+        +   argv[0]
+        +   " -w=<board_width> -h=<board_height> [-s=<square_size>]\n"
+            "           -i=<camera_intrinsics_filename> -o=<output_prefix>\n"
+            "\n"
+            " -w=<board_width>          Number of chessboard corners wide\n"
+            " -h=<board_height>         Number of chessboard corners width\n"
+            " [-s=<square_size>]            Optional measure of chessboard squares in meters\n"
+            " -i=<camera_intrinsics_filename> Camera matrix .yml file from calibration.cpp\n"
+            " -o=<output_prefix>        Prefix the output segmentation images with this\n"
+            " [video_filename/cameraId]  If present, read from that video file or that ID\n"
+            "\n"
+            "Using a camera's intrinsics (from calibrating a camera -- see calibration.cpp) and an\n"
+            "image of the object sitting on a planar surface with a calibration pattern of\n"
+            "(board_width x board_height) on the surface, we draw a 3D box around the object. From\n"
+            "then on, we can move a camera and as long as it sees the chessboard calibration pattern,\n"
+            "it will store a mask of where the object is. We get successive images using <output_prefix>\n"
+            "of the segmentation mask containing the object. This makes creating training sets easy.\n"
+            "It is best if the chessboard is odd x even in dimensions to avoid ambiguous poses.\n"
+            "\n"
+            "The actions one can use while the program is running are:\n"
+            "\n"
+            "  Select object as 3D box with the mouse.\n"
+            "   First draw one line on the plane to outline the projection of that object on the plane\n"
+            "    Then extend that line into a box to encompass the projection of that object onto the plane\n"
+            "    The use the mouse again to extend the box upwards from the plane to encase the object.\n"
+            "  Then use the following commands\n"
+            "    ESC   - Reset the selection\n"
+            "    SPACE - Skip the frame; move to the next frame (not in video mode)\n"
+            "    ENTER - Confirm the selection. Grab next object in video mode.\n"
+            "    q     - Exit the program\n"
+            "\n\n";
+}
 // static void help()
 // {
 //     puts(helphelp);
@@ -384,7 +387,7 @@ static bool readStringList( const string& filename, vector<string>& l )
 
 int main(int argc, char** argv)
 {
-    const char* help = "Usage: select3dobj -w=<board_width> -h=<board_height> [-s=<square_size>]\n"
+    string help = string("Usage: ") + argv[0] + " -w=<board_width> -h=<board_height> [-s=<square_size>]\n" +
            "\t-i=<intrinsics_filename> -o=<output_prefix> [video_filename/cameraId]\n";
     const char* screen_help =
     "Actions: \n"
@@ -397,8 +400,8 @@ int main(int argc, char** argv)
     cv::CommandLineParser parser(argc, argv, "{help h||}{w||}{h||}{s|1|}{i||}{o||}{@input|0|}");
     if (parser.has("help"))
     {
-        puts(helphelp);
-        puts(help);
+        puts(helphelp(argv).c_str());
+        puts(help.c_str());
         return 0;
     }
     string intrinsicsFilename;
@@ -419,26 +422,26 @@ int main(int argc, char** argv)
         inputName = samples::findFileOrKeep(parser.get<string>("@input"));
     if (!parser.check())
     {
-        puts(help);
+        puts(help.c_str());
         parser.printErrors();
         return 0;
     }
     if ( boardSize.width <= 0 )
     {
         printf("Incorrect -w parameter (must be a positive integer)\n");
-        puts(help);
+        puts(help.c_str());
         return 0;
     }
     if ( boardSize.height <= 0 )
     {
         printf("Incorrect -h parameter (must be a positive integer)\n");
-        puts(help);
+        puts(help.c_str());
         return 0;
     }
     if ( squareSize <= 0 )
     {
         printf("Incorrect -s parameter (must be a positive real number)\n");
-        puts(help);
+        puts(help.c_str());
         return 0;
     }
     Mat cameraMatrix, distCoeffs;

--- a/samples/cpp/stereo_calib.cpp
+++ b/samples/cpp/stereo_calib.cpp
@@ -38,7 +38,7 @@
 using namespace cv;
 using namespace std;
 
-static int print_help()
+static int print_help(char** argv)
 {
     cout <<
             " Given a list of chessboard images, the number of corners (nx, ny)\n"
@@ -49,7 +49,7 @@ static int print_help()
             "         matrix separately) stereo. \n"
             " Calibrate the cameras and display the\n"
             " rectified results along with the computed disparity images.   \n" << endl;
-    cout << "Usage:\n ./stereo_calib -w=<board_width default=9> -h=<board_height default=6> -s=<square_size default=1.0> <image list XML/YML file default=stereo_calib.xml>\n" << endl;
+    cout << "Usage:\n " << argv[0] << " -w=<board_width default=9> -h=<board_height default=6> -s=<square_size default=1.0> <image list XML/YML file default=stereo_calib.xml>\n" << endl;
     return 0;
 }
 
@@ -348,7 +348,7 @@ int main(int argc, char** argv)
     bool showRectified;
     cv::CommandLineParser parser(argc, argv, "{w|9|}{h|6|}{s|1.0|}{nr||}{help||}{@input|stereo_calib.xml|}");
     if (parser.has("help"))
-        return print_help();
+        return print_help(argv);
     showRectified = !parser.has("nr");
     imagelistfn = samples::findFile(parser.get<string>("@input"));
     boardSize.width = parser.get<int>("w");
@@ -364,7 +364,7 @@ int main(int argc, char** argv)
     if(!ok || imagelist.empty())
     {
         cout << "can not open " << imagelistfn << " or the string list is empty" << endl;
-        return print_help();
+        return print_help(argv);
     }
 
     StereoCalib(imagelist, boardSize, squareSize, false, true, showRectified);

--- a/samples/cpp/stereo_match.cpp
+++ b/samples/cpp/stereo_match.cpp
@@ -17,12 +17,12 @@
 
 using namespace cv;
 
-static void print_help()
+static void print_help(char** argv)
 {
     printf("\nDemo stereo matching converting L and R images into disparity and point clouds\n");
-    printf("\nUsage: stereo_match <left_image> <right_image> [--algorithm=bm|sgbm|hh|sgbm3way] [--blocksize=<block_size>]\n"
+    printf("\nUsage: %s <left_image> <right_image> [--algorithm=bm|sgbm|hh|sgbm3way] [--blocksize=<block_size>]\n"
            "[--max-disparity=<max_disparity>] [--scale=scale_factor>] [-i=<intrinsic_filename>] [-e=<extrinsic_filename>]\n"
-           "[--no-display] [-o=<disparity_image>] [-p=<point_cloud_file>]\n");
+           "[--no-display] [-o=<disparity_image>] [-p=<point_cloud_file>]\n", argv[0]);
 }
 
 static void saveXYZ(const char* filename, const Mat& mat)
@@ -62,7 +62,7 @@ int main(int argc, char** argv)
         "{@arg1||}{@arg2||}{help h||}{algorithm||}{max-disparity|0|}{blocksize|0|}{no-display||}{scale|1|}{i||}{e||}{o||}{p||}");
     if(parser.has("help"))
     {
-        print_help();
+        print_help(argv);
         return 0;
     }
     img1_filename = samples::findFile(parser.get<std::string>(0));
@@ -96,13 +96,13 @@ int main(int argc, char** argv)
     if( alg < 0 )
     {
         printf("Command-line parameter error: Unknown stereo algorithm\n\n");
-        print_help();
+        print_help(argv);
         return -1;
     }
     if ( numberOfDisparities < 1 || numberOfDisparities % 16 != 0 )
     {
         printf("Command-line parameter error: The max disparity (--maxdisparity=<...>) must be a positive integer divisible by 16\n");
-        print_help();
+        print_help(argv);
         return -1;
     }
     if (scale < 0)

--- a/samples/cpp/stitching_detailed.cpp
+++ b/samples/cpp/stitching_detailed.cpp
@@ -25,11 +25,11 @@ using namespace std;
 using namespace cv;
 using namespace cv::detail;
 
-static void printUsage()
+static void printUsage(char** argv)
 {
     cout <<
         "Rotation model images stitcher.\n\n"
-        "stitching_detailed img1 img2 [...imgN] [flags]\n\n"
+         << argv[0] << " img1 img2 [...imgN] [flags]\n\n"
         "Flags:\n"
         "  --preview\n"
         "      Run stitching in the preview mode. Works faster than usual mode,\n"
@@ -124,14 +124,14 @@ static int parseCmdArgs(int argc, char** argv)
 {
     if (argc == 1)
     {
-        printUsage();
+        printUsage(argv);
         return -1;
     }
     for (int i = 1; i < argc; ++i)
     {
         if (string(argv[i]) == "--help" || string(argv[i]) == "/?")
         {
-            printUsage();
+            printUsage(argv);
             return -1;
         }
         else if (string(argv[i]) == "--preview")

--- a/samples/cpp/tree_engine.cpp
+++ b/samples/cpp/tree_engine.cpp
@@ -8,14 +8,14 @@
 using namespace cv;
 using namespace cv::ml;
 
-static void help()
+static void help(char** argv)
 {
     printf(
         "\nThis sample demonstrates how to use different decision trees and forests including boosting and random trees.\n"
-        "Usage:\n\t./tree_engine [-r=<response_column>] [-ts=type_spec] <csv filename>\n"
+        "Usage:\n\t%s [-r=<response_column>] [-ts=type_spec] <csv filename>\n"
         "where -r=<response_column> specified the 0-based index of the response (0 by default)\n"
         "-ts= specifies the var type spec in the form ord[n1,n2-n3,n4-n5,...]cat[m1-m2,m3,m4-m5,...]\n"
-        "<csv filename> is the name of training data file in comma-separated value format\n\n");
+        "<csv filename> is the name of training data file in comma-separated value format\n\n", argv[0]);
 }
 
 static void train_and_print_errs(Ptr<StatModel> model, const Ptr<TrainData>& data)
@@ -37,7 +37,7 @@ int main(int argc, char** argv)
     cv::CommandLineParser parser(argc, argv, "{ help h | | }{r | 0 | }{ts | | }{@input | | }");
     if (parser.has("help"))
     {
-        help();
+        help(argv);
         return 0;
     }
     std::string filename = parser.get<std::string>("@input");
@@ -48,7 +48,7 @@ int main(int argc, char** argv)
     if( filename.empty() || !parser.check() )
     {
         parser.printErrors();
-        help();
+        help(argv);
         return 0;
     }
     printf("\nReading in %s...\n\n",filename.c_str());


### PR DESCRIPTION
In some sample files, when display usage, it will use the cpp files' name as binary executable files' name.  However, it should be actual file name. So I use the `argv[0]`  instead of cpp files' name.

<cut/>

For example,  sample files code as follows.
```C++
static void help()
{
    printf("\nThis sample demonstrates Canny edge detection\n"
           "Call:\n"
           "    /.edge [image_name -- Default is fruits.jpg]\n\n");
}
```

Now, I update it to:
```C++
static void help(char** argv)
{
    printf("\nThis sample demonstrates Canny edge detection\n"
           "Call:\n"
           "    %s [image_name -- Default is fruits.jpg]\n\n", argv[0]);
}
```

### Pull Request Readiness Checklist
- [x] I agree to contribute to the project under OpenCV (BSD) License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [x] The PR is proposed to proper branch
- [x] There is reference to original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake


```
force_builders=docs,linux,windows,mac
```