### PR TITLE
G-API: fix test checks due MatExpr::type() bug

### DIFF
--- a/modules/gapi/perf/common/gapi_core_perf_tests_inl.hpp
+++ b/modules/gapi/perf/common/gapi_core_perf_tests_inl.hpp
@@ -620,7 +620,7 @@ PERF_TEST_P_(CmpPerfTest, TestPerformance)
     }
 
     // Comparison ////////////////////////////////////////////////////////////
-    EXPECT_EQ(0, cv::countNonZero(out_mat_gapi != out_mat_ocv));
+    EXPECT_EQ(0, cvtest::norm(out_mat_gapi, out_mat_ocv, NORM_INF));
     EXPECT_EQ(out_mat_gapi.size(), sz);
 
     SANITY_CHECK_NOTHING();
@@ -666,7 +666,7 @@ PERF_TEST_P_(CmpWithScalarPerfTest, TestPerformance)
     }
 
     // Comparison ////////////////////////////////////////////////////////////
-    EXPECT_EQ(0, cv::countNonZero(out_mat_gapi != out_mat_ocv));
+    EXPECT_EQ(0, cvtest::norm(out_mat_gapi, out_mat_ocv, NORM_INF));
     EXPECT_EQ(out_mat_gapi.size(), sz);
 
     SANITY_CHECK_NOTHING();

--- a/modules/gapi/test/common/gapi_compoundkernel_tests.cpp
+++ b/modules/gapi/test/common/gapi_compoundkernel_tests.cpp
@@ -245,7 +245,7 @@ TEST(GCompoundKernel, ReplaceDefaultKernel)
     comp.apply(cv::gin(in_mat1, in_mat2), cv::gout(out_mat), cv::compile_args(full_pkg));
     ref_mat = in_mat1 - in_mat2 - in_mat2;
 
-    EXPECT_EQ(0, cv::countNonZero(out_mat != ref_mat));
+    EXPECT_EQ(0, cvtest::norm(out_mat, ref_mat, NORM_INF));
 }
 
 TEST(GCompoundKernel, DoubleAddC)
@@ -270,7 +270,7 @@ TEST(GCompoundKernel, DoubleAddC)
     comp.apply(cv::gin(in_mat1, in_mat2, scalar), cv::gout(out_mat), cv::compile_args(full_pkg));
     ref_mat = in_mat1 + in_mat2 + scalar + scalar + scalar;
 
-    EXPECT_EQ(0, cv::countNonZero(out_mat != ref_mat));
+    EXPECT_EQ(0, cvtest::norm(out_mat, ref_mat, NORM_INF));
 }
 
 TEST(GCompoundKernel, AddC)
@@ -295,7 +295,7 @@ TEST(GCompoundKernel, AddC)
     comp.apply(cv::gin(in_mat1, in_mat2, scalar), cv::gout(out_mat), cv::compile_args(full_pkg));
     ref_mat = in_mat1 + in_mat2 + scalar + scalar;
 
-    EXPECT_EQ(0, cv::countNonZero(out_mat != ref_mat));
+    EXPECT_EQ(0, cvtest::norm(out_mat, ref_mat, NORM_INF));
 }
 
 TEST(GCompoundKernel, MergeWithSplit)
@@ -315,7 +315,7 @@ TEST(GCompoundKernel, MergeWithSplit)
     comp.apply(cv::gin(in_mat), cv::gout(out_mat), cv::compile_args(full_pkg));
     ref_mat = in_mat;
 
-    EXPECT_EQ(0, cv::countNonZero(out_mat != ref_mat));
+    EXPECT_EQ(0, cvtest::norm(out_mat, ref_mat, NORM_INF));
 }
 
 TEST(GCompoundKernel, AddWithAddC)
@@ -338,7 +338,7 @@ TEST(GCompoundKernel, AddWithAddC)
     comp.apply(cv::gin(in_mat1, in_mat2, scalar), cv::gout(out_mat), cv::compile_args(full_pkg));
     ref_mat = in_mat1 + in_mat2 + scalar;
 
-    EXPECT_EQ(0, cv::countNonZero(out_mat != ref_mat));
+    EXPECT_EQ(0, cvtest::norm(out_mat, ref_mat, NORM_INF));
 }
 
 TEST(GCompoundKernel, SplitWithAdd)
@@ -364,8 +364,8 @@ TEST(GCompoundKernel, SplitWithAdd)
     ref_mat1 = channels[0] + channels[1];
     ref_mat2 = channels[2];
 
-    EXPECT_EQ(0, cv::countNonZero(out_mat1 != ref_mat1));
-    EXPECT_EQ(0, cv::countNonZero(out_mat2 != ref_mat2));
+    EXPECT_EQ(0, cvtest::norm(out_mat1, ref_mat1, NORM_INF));
+    EXPECT_EQ(0, cvtest::norm(out_mat2, ref_mat2, NORM_INF));
 }
 
 TEST(GCompoundKernel, ParallelAddC)
@@ -391,8 +391,8 @@ TEST(GCompoundKernel, ParallelAddC)
     ref_mat1 = in_mat + scalar;
     ref_mat2 = in_mat + scalar;
 
-    EXPECT_EQ(0, cv::countNonZero(out_mat1 != ref_mat1));
-    EXPECT_EQ(0, cv::countNonZero(out_mat2 != ref_mat2));
+    EXPECT_EQ(0, cvtest::norm(out_mat1, ref_mat1, NORM_INF));
+    EXPECT_EQ(0, cvtest::norm(out_mat2, ref_mat2, NORM_INF));
 }
 
 TEST(GCompoundKernel, GCompundKernelAndDefaultUseOneData)
@@ -415,7 +415,7 @@ TEST(GCompoundKernel, GCompundKernelAndDefaultUseOneData)
     comp.apply(cv::gin(in_mat1, in_mat2, scalar), cv::gout(out_mat), cv::compile_args(full_pkg));
     ref_mat = in_mat1 + in_mat2 + scalar + in_mat2 + scalar;
 
-    EXPECT_EQ(0, cv::countNonZero(out_mat != ref_mat));
+    EXPECT_EQ(0, cvtest::norm(out_mat, ref_mat, NORM_INF));
 }
 
 TEST(GCompoundKernel, CompoundExpandedToCompound)
@@ -441,7 +441,7 @@ TEST(GCompoundKernel, CompoundExpandedToCompound)
     comp.apply(cv::gin(in_mat1, in_mat2, scalar), cv::gout(out_mat), cv::compile_args(full_pkg));
     ref_mat = in_mat1 + in_mat2 + scalar + scalar + scalar;
 
-    EXPECT_EQ(0, cv::countNonZero(out_mat != ref_mat));
+    EXPECT_EQ(0, cvtest::norm(out_mat, ref_mat, NORM_INF));
 }
 
 TEST(GCompoundKernel, MaxInArray)
@@ -494,7 +494,7 @@ TEST(GCompoundKernel, RightGArrayHandle)
 
     comp.apply(cv::gin(in_mat1, in_v, in_mat2), cv::gout(out_mat), cv::compile_args(full_pkg));
 
-    EXPECT_EQ(0, cv::countNonZero(out_mat != ref_mat));
+    EXPECT_EQ(0, cvtest::norm(out_mat, ref_mat, NORM_INF));
 
 }
 } // opencv_test

--- a/modules/gapi/test/common/gapi_core_tests_inl.hpp
+++ b/modules/gapi/test/common/gapi_core_tests_inl.hpp
@@ -131,11 +131,10 @@ TEST_P(MathOpTest, MatricesAccuracyTest)
         else
         {
             // floating-point: expect 6 decimal digits - best we expect of F32
-            EXPECT_EQ(0, cv::countNonZero(cv::abs(out_mat_gapi - out_mat_ocv) >
-                                                    1e-6*cv::abs(out_mat_ocv)));
+            EXPECT_LE(cvtest::norm(out_mat_ocv, out_mat_gapi, NORM_INF | NORM_RELATIVE), 1e-6);
         }
     #else
-        EXPECT_EQ(0, cv::countNonZero(out_mat_gapi != out_mat_ocv));
+        EXPECT_EQ(0, cvtest::norm(out_mat_gapi, out_mat_ocv, NORM_INF));
     #endif
         EXPECT_EQ(out_mat_gapi.size(), sz);
     }
@@ -161,18 +160,16 @@ TEST_P(MulDoubleTest, AccuracyTest)
         CV_MAT_DEPTH(out_mat_ocv.type()) != CV_64F)
     {
         // integral: allow 1% of differences, and no diffs by >1 unit
-        EXPECT_LE(countNonZeroPixels(cv::abs(out_mat_gapi - out_mat_ocv) > 0),
-                                                    0.01*out_mat_ocv.total());
-        EXPECT_LE(countNonZeroPixels(cv::abs(out_mat_gapi - out_mat_ocv) > 1), 0);
+        EXPECT_LE(cvtest::norm(out_mat_gapi, out_mat_ocv, NORM_L1 | NORM_RELATIVE), 0.01);
+        EXPECT_LE(cvtest::norm(out_mat_gapi, out_mat_ocv, NORM_L1), 1);
     }
     else
     {
         // floating-point: expect 6 decimal digits - best we expect of F32
-        EXPECT_EQ(0, cv::countNonZero(cv::abs(out_mat_gapi - out_mat_ocv) >
-            1e-6*cv::abs(out_mat_ocv)));
+        EXPECT_LE(cvtest::norm(out_mat_ocv, out_mat_gapi, NORM_INF | NORM_RELATIVE), 1e-6);
     }
 #else
-    EXPECT_EQ(0, cv::countNonZero(out_mat_gapi != out_mat_ocv));
+    EXPECT_EQ(0, cvtest::norm(out_mat_gapi, out_mat_ocv, NORM_INF));
 #endif
     EXPECT_EQ(out_mat_gapi.size(), sz);
 }
@@ -195,7 +192,7 @@ TEST_P(DivTest, DISABLED_DivByZeroTest)  // https://github.com/opencv/opencv/pul
 
     // Comparison //////////////////////////////////////////////////////////////
     {
-        EXPECT_EQ(0, cv::countNonZero(out_mat_gapi != out_mat_ocv));
+        EXPECT_EQ(0, cvtest::norm(out_mat_gapi, out_mat_ocv, NORM_INF));
         EXPECT_EQ(out_mat_gapi.size(), sz);
     }
 }
@@ -219,9 +216,9 @@ TEST_P(DivCTest, DISABLED_DivByZeroTest)  // https://github.com/opencv/opencv/pu
 
     // Comparison //////////////////////////////////////////////////////////////
     {
-        EXPECT_EQ(0, cv::countNonZero(out_mat_ocv != out_mat_gapi));
+        EXPECT_EQ(0, cvtest::norm(out_mat_ocv, out_mat_gapi, NORM_INF));
         cv::Mat zeros = cv::Mat::zeros(sz, type);
-        EXPECT_EQ(0, cv::countNonZero(out_mat_gapi != zeros));
+        EXPECT_EQ(0, cvtest::norm(out_mat_gapi, zeros, NORM_INF));
     }
 }
 
@@ -265,7 +262,7 @@ TEST_P(MaskTest, AccuracyTest)
     }
     // Comparison //////////////////////////////////////////////////////////////
     {
-        EXPECT_EQ(0, cv::countNonZero(out_mat_ocv != out_mat_gapi));
+        EXPECT_EQ(0, cvtest::norm(out_mat_ocv, out_mat_gapi, NORM_INF));
     }
 }
 
@@ -305,18 +302,15 @@ TEST_P(Polar2CartTest, AccuracyTest)
         //
         // TODO: Make threshold a configurable parameter of this test (ADE-221)
 
+        ASSERT_EQ(out_mat_gapi.size(), sz);
+
         cv::Mat &outx = out_mat_gapi,
                 &outy = out_mat2;
         cv::Mat &refx = out_mat_ocv,
                 &refy = out_mat_ocv2;
-        cv::Mat difx = cv::abs(refx - outx),
-                dify = cv::abs(refy - outy);
-        cv::Mat absx = cv::abs(refx),
-                absy = cv::abs(refy);
 
-        EXPECT_EQ(0, cv::countNonZero(difx > 1e-6*absx));
-        EXPECT_EQ(0, cv::countNonZero(dify > 1e-6*absy));
-        EXPECT_EQ(out_mat_gapi.size(), sz);
+        EXPECT_LE(cvtest::norm(refx, outx, NORM_L1 | NORM_RELATIVE), 1e-6);
+        EXPECT_LE(cvtest::norm(refy, outy, NORM_L1 | NORM_RELATIVE), 1e-6);
     }
 }
 
@@ -351,20 +345,17 @@ TEST_P(Cart2PolarTest, AccuracyTest)
         //
         // TODO: Make threshold a configurable parameter of this test (ADE-221)
 
+        ASSERT_EQ(out_mat_gapi.size(), sz);
+
         cv::Mat &outm = out_mat_gapi,
                 &outa = out_mat2;
         cv::Mat &refm = out_mat_ocv,
                 &refa = out_mat_ocv2;
-        cv::Mat difm = cv::abs(refm - outm),
-                difa = cv::abs(refa - outa);
-        cv::Mat absm = cv::abs(refm),
-                absa = cv::abs(refa);
 
         // FIXME: Angle result looks inaccurate at OpenCV
         //        (expected relative accuracy like 1e-6)
-        EXPECT_EQ(0, cv::countNonZero(difm > 1e-6*absm));
-        EXPECT_EQ(0, cv::countNonZero(difa > 1e-3*absa));
-        EXPECT_EQ(out_mat_gapi.size(), sz);
+        EXPECT_LE(cvtest::norm(refm, outm, NORM_INF), 1e-6);
+        EXPECT_LE(cvtest::norm(refa, outa, NORM_INF), 1e-3);
     }
 }
 
@@ -413,8 +404,8 @@ TEST_P(CmpTest, AccuracyTest)
 
     // Comparison //////////////////////////////////////////////////////////////
     {
-        EXPECT_EQ(0, cv::countNonZero(out_mat_gapi != out_mat_ocv));
-        EXPECT_EQ(out_mat_gapi.size(), sz);
+        ASSERT_EQ(out_mat_gapi.size(), sz);
+        EXPECT_EQ(0, cvtest::norm(out_mat_gapi, out_mat_ocv, NORM_INF));
     }
 }
 
@@ -452,8 +443,8 @@ TEST_P(BitwiseTest, AccuracyTest)
 
     // Comparison //////////////////////////////////////////////////////////////
     {
-        EXPECT_EQ(0, cv::countNonZero(out_mat_ocv != out_mat_gapi));
-        EXPECT_EQ(out_mat_gapi.size(), sz);
+        ASSERT_EQ(out_mat_gapi.size(), sz);
+        EXPECT_EQ(0, cvtest::norm(out_mat_ocv, out_mat_gapi, NORM_INF));
     }
 }
 
@@ -472,8 +463,8 @@ TEST_P(NotTest, AccuracyTest)
     }
     // Comparison //////////////////////////////////////////////////////////////
     {
-        EXPECT_EQ(0, cv::countNonZero(out_mat_ocv != out_mat_gapi));
-        EXPECT_EQ(out_mat_gapi.size(), sz);
+        ASSERT_EQ(out_mat_gapi.size(), sz);
+        EXPECT_EQ(0, cvtest::norm(out_mat_ocv, out_mat_gapi, NORM_INF));
     }
 }
 
@@ -496,8 +487,8 @@ TEST_P(SelectTest, AccuracyTest)
     }
     // Comparison //////////////////////////////////////////////////////////////
     {
-        EXPECT_EQ(0, cv::countNonZero(out_mat_gapi != out_mat_ocv));
-        EXPECT_EQ(out_mat_gapi.size(), sz);
+        ASSERT_EQ(out_mat_gapi.size(), sz);
+        EXPECT_EQ(0, cvtest::norm(out_mat_gapi, out_mat_ocv, NORM_INF));
     }
 }
 
@@ -516,8 +507,8 @@ TEST_P(MinTest, AccuracyTest)
     }
     // Comparison //////////////////////////////////////////////////////////////
     {
-        EXPECT_EQ(0, cv::countNonZero(out_mat_gapi != out_mat_ocv));
-        EXPECT_EQ(out_mat_gapi.size(), sz);
+        ASSERT_EQ(out_mat_gapi.size(), sz);
+        EXPECT_EQ(0, cvtest::norm(out_mat_gapi, out_mat_ocv, NORM_INF));
     }
 }
 
@@ -536,8 +527,8 @@ TEST_P(MaxTest, AccuracyTest)
     }
     // Comparison //////////////////////////////////////////////////////////////
     {
-        EXPECT_EQ(0, cv::countNonZero(out_mat_gapi != out_mat_ocv));
-        EXPECT_EQ(out_mat_gapi.size(), sz);
+        ASSERT_EQ(out_mat_gapi.size(), sz);
+        EXPECT_EQ(0, cvtest::norm(out_mat_gapi, out_mat_ocv, NORM_INF));
     }
 }
 
@@ -556,8 +547,8 @@ TEST_P(AbsDiffTest, AccuracyTest)
     }
     // Comparison //////////////////////////////////////////////////////////////
     {
-        EXPECT_EQ(0, cv::countNonZero(out_mat_gapi != out_mat_ocv));
-        EXPECT_EQ(out_mat_gapi.size(), sz);
+        ASSERT_EQ(out_mat_gapi.size(), sz);
+        EXPECT_EQ(0, cvtest::norm(out_mat_gapi, out_mat_ocv, NORM_INF));
     }
 }
 
@@ -577,8 +568,8 @@ TEST_P(AbsDiffCTest, AccuracyTest)
     }
     // Comparison //////////////////////////////////////////////////////////////
     {
-        EXPECT_EQ(0, cv::countNonZero(out_mat_gapi != out_mat_ocv));
-        EXPECT_EQ(out_mat_gapi.size(), sz);
+        ASSERT_EQ(out_mat_gapi.size(), sz);
+        EXPECT_EQ(0, cvtest::norm(out_mat_gapi, out_mat_ocv, NORM_INF));
     }
 }
 
@@ -678,8 +669,8 @@ TEST_P(IntegralTest, AccuracyTest)
     }
     // Comparison //////////////////////////////////////////////////////////////
     {
-        EXPECT_EQ(0, cv::countNonZero(out_mat_ocv1 != out_mat1));
-        EXPECT_EQ(0, cv::countNonZero(out_mat_ocv2 != out_mat2));
+        EXPECT_EQ(0, cvtest::norm(out_mat_ocv1, out_mat1, NORM_INF));
+        EXPECT_EQ(0, cvtest::norm(out_mat_ocv2, out_mat2, NORM_INF));
     }
 }
 
@@ -727,7 +718,7 @@ TEST_P(ThresholdOTTest, AccuracyTestOtsu)
     }
     // Comparison //////////////////////////////////////////////////////////////
     {
-        EXPECT_EQ(0, cv::countNonZero(out_mat_ocv != out_mat_gapi));
+        EXPECT_EQ(0, cvtest::norm(out_mat_ocv, out_mat_gapi, NORM_INF));
         EXPECT_EQ(out_mat_gapi.size(), sz);
         EXPECT_EQ(ocv_res, out_gapi_scalar.val[0]);
     }
@@ -752,8 +743,8 @@ TEST_P(InRangeTest, AccuracyTest)
     }
     // Comparison //////////////////////////////////////////////////////////////
     {
-        EXPECT_EQ(0, cv::countNonZero(out_mat_ocv != out_mat_gapi));
-        EXPECT_EQ(out_mat_gapi.size(), sz);
+        ASSERT_EQ(out_mat_gapi.size(), sz);
+        EXPECT_EQ(0, cvtest::norm(out_mat_ocv, out_mat_gapi, NORM_INF));
     }
 }
 
@@ -776,9 +767,9 @@ TEST_P(Split3Test, AccuracyTest)
     }
     // Comparison //////////////////////////////////////////////////////////////
     {
-        EXPECT_EQ(0, cv::countNonZero(out_mat_ocv  != out_mat_gapi));
-        EXPECT_EQ(0, cv::countNonZero(out_mat_ocv2 != out_mat2));
-        EXPECT_EQ(0, cv::countNonZero(out_mat_ocv3 != out_mat3));
+        EXPECT_EQ(0, cvtest::norm(out_mat_ocv,  out_mat_gapi, NORM_INF));
+        EXPECT_EQ(0, cvtest::norm(out_mat_ocv2, out_mat2, NORM_INF));
+        EXPECT_EQ(0, cvtest::norm(out_mat_ocv3, out_mat3, NORM_INF));
     }
 }
 
@@ -804,10 +795,10 @@ TEST_P(Split4Test, AccuracyTest)
     }
     // Comparison //////////////////////////////////////////////////////////////
     {
-        EXPECT_EQ(0, cv::countNonZero(out_mat_ocv  != out_mat_gapi));
-        EXPECT_EQ(0, cv::countNonZero(out_mat_ocv2 != out_mat2));
-        EXPECT_EQ(0, cv::countNonZero(out_mat_ocv3 != out_mat3));
-        EXPECT_EQ(0, cv::countNonZero(out_mat_ocv4 != out_mat4));
+        EXPECT_EQ(0, cvtest::norm(out_mat_ocv,  out_mat_gapi, NORM_INF));
+        EXPECT_EQ(0, cvtest::norm(out_mat_ocv2, out_mat2, NORM_INF));
+        EXPECT_EQ(0, cvtest::norm(out_mat_ocv3, out_mat3, NORM_INF));
+        EXPECT_EQ(0, cvtest::norm(out_mat_ocv4, out_mat4, NORM_INF));
     }
 }
 
@@ -904,7 +895,7 @@ TEST_P(Merge3Test, AccuracyTest)
     }
     // Comparison //////////////////////////////////////////////////////////////
     {
-        EXPECT_EQ(0, cv::countNonZero(out_mat_ocv != out_mat_gapi));
+        EXPECT_EQ(0, cvtest::norm(out_mat_ocv, out_mat_gapi, NORM_INF));
     }
 }
 
@@ -931,7 +922,7 @@ TEST_P(Merge4Test, AccuracyTest)
     }
     // Comparison //////////////////////////////////////////////////////////////
     {
-        EXPECT_EQ(0, cv::countNonZero(out_mat_ocv != out_mat_gapi));
+        EXPECT_EQ(0, cvtest::norm(out_mat_ocv, out_mat_gapi, NORM_INF));
     }
 }
 
@@ -955,7 +946,7 @@ TEST_P(RemapTest, AccuracyTest)
     }
     // Comparison //////////////////////////////////////////////////////////////
     {
-        EXPECT_EQ(0, cv::countNonZero(out_mat_ocv != out_mat_gapi));
+        EXPECT_EQ(0, cvtest::norm(out_mat_ocv, out_mat_gapi, NORM_INF));
         EXPECT_EQ(out_mat_gapi.size(), sz);
     }
 }
@@ -974,7 +965,7 @@ TEST_P(FlipTest, AccuracyTest)
     }
     // Comparison //////////////////////////////////////////////////////////////
     {
-        EXPECT_EQ(0, cv::countNonZero(out_mat_ocv != out_mat_gapi));
+        EXPECT_EQ(0, cvtest::norm(out_mat_ocv, out_mat_gapi, NORM_INF));
         EXPECT_EQ(out_mat_gapi.size(), sz);
     }
 }
@@ -1000,7 +991,7 @@ TEST_P(CropTest, AccuracyTest)
     }
     // Comparison //////////////////////////////////////////////////////////////
     {
-        EXPECT_EQ(0, cv::countNonZero(out_mat_ocv != out_mat_gapi));
+        EXPECT_EQ(0, cvtest::norm(out_mat_ocv, out_mat_gapi, NORM_INF));
         EXPECT_EQ(out_mat_gapi.size(), sz_out);
     }
 }
@@ -1026,7 +1017,7 @@ TEST_P(CopyTest, AccuracyTest)
     }
     // Comparison //////////////////////////////////////////////////////////////
     {
-        EXPECT_EQ(0, cv::countNonZero(out_mat_ocv != out_mat_gapi));
+        EXPECT_EQ(0, cvtest::norm(out_mat_ocv, out_mat_gapi, NORM_INF));
         EXPECT_EQ(out_mat_gapi.size(), sz_out);
     }
 }
@@ -1062,7 +1053,7 @@ TEST_P(ConcatHorTest, AccuracyTest)
     }
     // Comparison //////////////////////////////////////////////////////////////
     {
-        EXPECT_EQ(0, cv::countNonZero(out_mat_ocv != out_mat));
+        EXPECT_EQ(0, cvtest::norm(out_mat_ocv, out_mat, NORM_INF));
     }
 }
 
@@ -1097,7 +1088,7 @@ TEST_P(ConcatVertTest, AccuracyTest)
     }
     // Comparison //////////////////////////////////////////////////////////////
     {
-        EXPECT_EQ(0, cv::countNonZero(out_mat_ocv != out_mat));
+        EXPECT_EQ(0, cvtest::norm(out_mat_ocv, out_mat, NORM_INF));
     }
 }
 
@@ -1139,7 +1130,7 @@ TEST_P(ConcatVertVecTest, AccuracyTest)
     }
     // Comparison //////////////////////////////////////////////////////////////
     {
-        EXPECT_EQ(0, cv::countNonZero(out_mat_ocv != out_mat));
+        EXPECT_EQ(0, cvtest::norm(out_mat_ocv, out_mat, NORM_INF));
     }
 }
 
@@ -1181,7 +1172,7 @@ TEST_P(ConcatHorVecTest, AccuracyTest)
     }
     // Comparison //////////////////////////////////////////////////////////////
     {
-        EXPECT_EQ(0, cv::countNonZero(out_mat_ocv != out_mat));
+        EXPECT_EQ(0, cvtest::norm(out_mat_ocv, out_mat, NORM_INF));
     }
 }
 
@@ -1208,7 +1199,7 @@ TEST_P(LUTTest, AccuracyTest)
     }
     // Comparison //////////////////////////////////////////////////////////////
     {
-        EXPECT_EQ(0, cv::countNonZero(out_mat_ocv != out_mat_gapi));
+        EXPECT_EQ(0, cvtest::norm(out_mat_ocv, out_mat_gapi, NORM_INF));
         EXPECT_EQ(out_mat_gapi.size(), sz);
     }
 }
@@ -1252,7 +1243,7 @@ TEST_P(PhaseTest, AccuracyTest)
     // Comparison //////////////////////////////////////////////////////////////
     // FIXME: use a comparison functor instead (after enabling OpenCL)
     {
-        EXPECT_EQ(0, cv::countNonZero(out_mat_ocv != out_mat_gapi));
+        EXPECT_EQ(0, cvtest::norm(out_mat_ocv, out_mat_gapi, NORM_INF));
     }
 }
 
@@ -1271,7 +1262,7 @@ TEST_P(SqrtTest, AccuracyTest)
     // Comparison //////////////////////////////////////////////////////////////
     // FIXME: use a comparison functor instead (after enabling OpenCL)
     {
-        EXPECT_EQ(0, cv::countNonZero(out_mat_ocv != out_mat_gapi));
+        EXPECT_EQ(0, cvtest::norm(out_mat_ocv, out_mat_gapi, NORM_INF));
     }
 }
 
@@ -1315,7 +1306,7 @@ TEST_P(BackendOutputAllocationTest, EmptyOutput)
 
     // Comparison //////////////////////////////////////////////////////////////
     // Expected: output is allocated to the needed size
-    EXPECT_EQ(0, cv::countNonZero(out_mat_gapi != out_mat_ocv));
+    EXPECT_EQ(0, cvtest::norm(out_mat_gapi, out_mat_ocv, NORM_INF));
     EXPECT_EQ(sz, out_mat_gapi.size());
 }
 
@@ -1335,7 +1326,7 @@ TEST_P(BackendOutputAllocationTest, CorrectlyPreallocatedOutput)
 
     // Comparison //////////////////////////////////////////////////////////////
     // Expected: output is not reallocated
-    EXPECT_EQ(0, cv::countNonZero(out_mat_gapi != out_mat_ocv));
+    EXPECT_EQ(0, cvtest::norm(out_mat_gapi, out_mat_ocv, NORM_INF));
     EXPECT_EQ(sz, out_mat_gapi.size());
 
     EXPECT_EQ(out_mat_gapi_ref.data, out_mat_gapi.data);
@@ -1360,7 +1351,7 @@ TEST_P(BackendOutputAllocationTest, IncorrectOutputMeta)
 
         // Comparison //////////////////////////////////////////////////////////////
         // Expected: size is changed, type is changed, output is reallocated
-        EXPECT_EQ(0, cv::countNonZero(out_mat_gapi != out_mat_ocv));
+        EXPECT_EQ(0, cvtest::norm(out_mat_gapi, out_mat_ocv, NORM_INF));
         EXPECT_EQ(sz, out_mat_gapi.size());
         EXPECT_EQ(type, out_mat_gapi.type());
 
@@ -1392,7 +1383,7 @@ TEST_P(BackendOutputAllocationTest, SmallerPreallocatedSize)
 
     // Comparison //////////////////////////////////////////////////////////////
     // Expected: size is changed, output is reallocated due to original size < curr size
-    EXPECT_EQ(0, cv::countNonZero(out_mat_gapi != out_mat_ocv));
+    EXPECT_EQ(0, cvtest::norm(out_mat_gapi, out_mat_ocv, NORM_INF));
     EXPECT_EQ(sz, out_mat_gapi.size());
 
     EXPECT_NE(out_mat_gapi_ref.data, out_mat_gapi.data);
@@ -1418,7 +1409,7 @@ TEST_P(BackendOutputAllocationTest, SmallerPreallocatedSizeWithSubmatrix)
 
     // Comparison //////////////////////////////////////////////////////////////
     // Expected: submatrix is reallocated and is "detached", original matrix is unchanged
-    EXPECT_EQ(0, cv::countNonZero(out_mat_gapi_submat != out_mat_ocv));
+    EXPECT_EQ(0, cvtest::norm(out_mat_gapi_submat, out_mat_ocv, NORM_INF));
     EXPECT_EQ(sz, out_mat_gapi_submat.size());
     EXPECT_EQ(sz / 2, out_mat_gapi.size());
 
@@ -1442,7 +1433,7 @@ TEST_P(BackendOutputAllocationTest, LargerPreallocatedSize)
 
     // Comparison //////////////////////////////////////////////////////////////
     // Expected: size is changed, output is reallocated
-    EXPECT_EQ(0, cv::countNonZero(out_mat_gapi != out_mat_ocv));
+    EXPECT_EQ(0, cvtest::norm(out_mat_gapi, out_mat_ocv, NORM_INF));
     EXPECT_EQ(sz, out_mat_gapi.size());
 
     EXPECT_NE(out_mat_gapi_ref.data, out_mat_gapi.data);
@@ -1470,7 +1461,7 @@ TEST_P(BackendOutputAllocationLargeSizeWithCorrectSubmatrixTest,
 
     // Comparison //////////////////////////////////////////////////////////////
     // Expected: submatrix is not reallocated, original matrix is not reallocated
-    EXPECT_EQ(0, cv::countNonZero(out_mat_gapi_submat != out_mat_ocv));
+    EXPECT_EQ(0, cvtest::norm(out_mat_gapi_submat, out_mat_ocv, NORM_INF));
     EXPECT_EQ(sz, out_mat_gapi_submat.size());
     EXPECT_EQ(sz * 2, out_mat_gapi.size());
 
@@ -1500,7 +1491,7 @@ TEST_P(BackendOutputAllocationTest, LargerPreallocatedSizeWithSmallSubmatrix)
 
     // Comparison //////////////////////////////////////////////////////////////
     // Expected: submatrix is reallocated and is "detached", original matrix is unchanged
-    EXPECT_EQ(0, cv::countNonZero(out_mat_gapi_submat != out_mat_ocv));
+    EXPECT_EQ(0, cvtest::norm(out_mat_gapi_submat, out_mat_ocv, NORM_INF));
     EXPECT_EQ(sz, out_mat_gapi_submat.size());
     EXPECT_EQ(sz * 2, out_mat_gapi.size());
 
@@ -1530,7 +1521,7 @@ TEST_P(ReInitOutTest, TestWithAdd)
         cv::add(in_mat1, in_mat2, out_mat_ocv, cv::noArray());
 
         // Comparison //////////////////////////////////////////////////////////////
-        EXPECT_EQ(0, cv::countNonZero(out_mat_gapi != out_mat_ocv));
+        EXPECT_EQ(0, cvtest::norm(out_mat_gapi, out_mat_ocv, NORM_INF));
         EXPECT_EQ(out_mat_gapi.size(), sz);
     };
 

--- a/modules/gapi/test/common/gapi_operators_tests_inl.hpp
+++ b/modules/gapi/test/common/gapi_operators_tests_inl.hpp
@@ -30,8 +30,8 @@ TEST_P(MathOperatorMatScalarTest, OperatorAccuracyTest )
 
     // Comparison //////////////////////////////////////////////////////////////
     {
+        ASSERT_EQ(out_mat_gapi.size(), sz);
         EXPECT_TRUE(cmpF(out_mat_gapi, out_mat_ocv));
-        EXPECT_EQ(out_mat_gapi.size(), sz);
     }
 }
 
@@ -53,8 +53,8 @@ TEST_P(MathOperatorMatMatTest, OperatorAccuracyTest )
 
     // Comparison //////////////////////////////////////////////////////////////
     {
+        ASSERT_EQ(out_mat_gapi.size(), sz);
         EXPECT_TRUE(cmpF(out_mat_gapi, out_mat_ocv));
-        EXPECT_EQ(out_mat_gapi.size(), sz);
     }
 }
 
@@ -73,8 +73,8 @@ TEST_P(NotOperatorTest, OperatorAccuracyTest)
     }
     // Comparison //////////////////////////////////////////////////////////////
     {
-        EXPECT_EQ(0, cv::countNonZero(out_mat_ocv != out_mat_gapi));
-        EXPECT_EQ(out_mat_gapi.size(), sz);
+        ASSERT_EQ(out_mat_gapi.size(), sz);
+        EXPECT_EQ(0, cvtest::norm(out_mat_ocv, out_mat_gapi, NORM_INF));
     }
 }
 } // opencv_test

--- a/modules/gapi/test/common/gapi_tests_common.hpp
+++ b/modules/gapi/test/common/gapi_tests_common.hpp
@@ -157,28 +157,6 @@ public:
 
     // empty function intended to show that nothing is to be initialized via TestFunctional methods
     void initNothing(int, cv::Size, int, bool = true) {}
-
-    static cv::Mat nonZeroPixels(const cv::Mat& mat)
-    {
-        int channels = mat.channels();
-        std::vector<cv::Mat> split(channels);
-        cv::split(mat, split);
-        cv::Mat result;
-        for (int c=0; c < channels; c++)
-        {
-            if (c == 0)
-                result = split[c] != 0;
-            else
-                result = result | (split[c] != 0);
-        }
-        return result;
-    }
-
-    static int countNonZeroPixels(const cv::Mat& mat)
-    {
-        return cv::countNonZero( nonZeroPixels(mat) );
-    }
-
 };
 
 template<class T>
@@ -453,7 +431,7 @@ public:
         Mat diff;
         cv::absdiff(in1, in2, diff);
         Mat err_mask = diff > _tol;
-        int err_points = cv::countNonZero(err_mask.reshape(1));
+        int err_points = (cv::countNonZero)(err_mask.reshape(1));
         double max_err_points = _percent * std::max((size_t)1000, in1.total());
         if (err_points > max_err_points)
         {

--- a/modules/gapi/test/gapi_basic_hetero_tests.cpp
+++ b/modules/gapi/test/gapi_basic_hetero_tests.cpp
@@ -184,7 +184,7 @@ TEST_F(GAPIHeteroTest, TestOCV)
 
     cv::Mat ref = ocvBar(ocvFoo(m_in_mat), ocvFoo(m_in_mat));
     EXPECT_NO_THROW(m_comp.apply(m_in_mat, m_out_mat, cv::compile_args(m_ocv_kernels)));
-    EXPECT_EQ(0, cv::countNonZero(ref != m_out_mat));
+    EXPECT_EQ(0, cvtest::norm(ref, m_out_mat, NORM_INF));
 }
 
 TEST_F(GAPIHeteroTest, TestFluid)
@@ -194,7 +194,7 @@ TEST_F(GAPIHeteroTest, TestFluid)
 
     cv::Mat ref = fluidBar(fluidFoo(m_in_mat), fluidFoo(m_in_mat));
     EXPECT_NO_THROW(m_comp.apply(m_in_mat, m_out_mat, cv::compile_args(m_fluid_kernels)));
-    EXPECT_EQ(0, cv::countNonZero(ref != m_out_mat));
+    EXPECT_EQ(0, cvtest::norm(ref, m_out_mat, NORM_INF));
 }
 
 TEST_F(GAPIHeteroTest, TestBoth)
@@ -204,7 +204,7 @@ TEST_F(GAPIHeteroTest, TestBoth)
 
     cv::Mat ref = fluidBar(ocvFoo(m_in_mat), ocvFoo(m_in_mat));
     EXPECT_NO_THROW(m_comp.apply(m_in_mat, m_out_mat, cv::compile_args(m_hetero_kernels)));
-    EXPECT_EQ(0, cv::countNonZero(ref != m_out_mat));
+    EXPECT_EQ(0, cvtest::norm(ref, m_out_mat, NORM_INF));
 }
 
 struct GAPIBigHeteroTest : public ::testing::TestWithParam<std::array<int, 9>>
@@ -271,8 +271,8 @@ GAPIBigHeteroTest::GAPIBigHeteroTest()
 TEST_P(GAPIBigHeteroTest, Test)
 {
     EXPECT_NO_THROW(m_comp.apply(gin(m_in_mat), gout(m_out_mat1, m_out_mat2), cv::compile_args(m_kernels)));
-    EXPECT_EQ(0, cv::countNonZero(m_ref_mat1 != m_out_mat1));
-    EXPECT_EQ(0, cv::countNonZero(m_ref_mat2 != m_out_mat2));
+    EXPECT_EQ(0, cvtest::norm(m_ref_mat1, m_out_mat1, NORM_INF));
+    EXPECT_EQ(0, cvtest::norm(m_ref_mat2 != m_out_mat2, NORM_INF));
 }
 
 static auto configurations = []()
@@ -306,7 +306,7 @@ TEST(GAPIHeteroTestLPI, Test)
     cv::Mat out_mat;
     EXPECT_NO_THROW(c.apply(in_mat, out_mat, cv::compile_args(cv::gapi::kernels<FluidFoo2lpi>())));
     cv::Mat ref = fluidFoo(fluidFoo(in_mat));
-    EXPECT_EQ(0, cv::countNonZero(ref != out_mat));
+    EXPECT_EQ(0, cvtest::norm(ref, out_mat, NORM_INF));
 }
 
 }  // namespace opencv_test

--- a/modules/gapi/test/gapi_fluid_parallel_rois_test.cpp
+++ b/modules/gapi/test/gapi_fluid_parallel_rois_test.cpp
@@ -156,7 +156,7 @@ TEST_P(TiledComputation, Test)
     cp->run_with_gapi(in_mat, comp_args, out_mat_gapi);
     cp->run_with_ocv (in_mat, rois,      out_mat_ocv);
 
-    EXPECT_EQ(0, cv::countNonZero(out_mat_gapi != out_mat_ocv))
+    EXPECT_EQ(0, cvtest::norm(out_mat_gapi, out_mat_ocv, NORM_INF))
             << "in_mat : \n"      << in_mat << std::endl
             << "diff matrix :\n " << (out_mat_gapi != out_mat_ocv) << std::endl
             << "out_mat_gapi: \n" << out_mat_gapi << std::endl

--- a/modules/gapi/test/gapi_fluid_resize_test.cpp
+++ b/modules/gapi/test/gapi_fluid_resize_test.cpp
@@ -422,9 +422,7 @@ TEST_P(ResizeTestFluid, SanityTest)
     cv::blur(in_mat1, mid_mat, {3,3}, {-1,-1},  cv::BORDER_REPLICATE);
     cv::resize(mid_mat, out_mat_ocv, sz_out, fx, fy, interp);
 
-    cv::Mat absDiff;
-    cv::absdiff(out_mat(outRoi), out_mat_ocv(outRoi), absDiff);
-    EXPECT_EQ(0, cv::countNonZero(absDiff > tolerance));
+    EXPECT_LE(cvtest::norm(out_mat(outRoi), out_mat_ocv(outRoi), NORM_INF), tolerance);
 }
 
 INSTANTIATE_TEST_CASE_P(ResizeTestCPU, ResizeTestFluid,
@@ -618,8 +616,8 @@ TEST_P(ResizeAndAnotherReaderTest, SanityTest)
     cv::Mat ocv_blur_out = cv::Mat::zeros(sz, CV_8UC1);
     cvBlur(in_mat, ocv_blur_out, kernelSize);
 
-    EXPECT_EQ(0, cv::countNonZero(gapi_resize_out(resizedRoi) != ocv_resize_out(resizedRoi)));
-    EXPECT_EQ(0, cv::countNonZero(gapi_blur_out(roi) != ocv_blur_out(roi)));
+    EXPECT_EQ(0, cvtest::norm(gapi_resize_out(resizedRoi), ocv_resize_out(resizedRoi), NORM_INF));
+    EXPECT_EQ(0, cvtest::norm(gapi_blur_out(roi), ocv_blur_out(roi), NORM_INF));
 }
 
 INSTANTIATE_TEST_CASE_P(ResizeTestCPU, ResizeAndAnotherReaderTest,
@@ -691,8 +689,8 @@ TEST_P(BlursAfterResizeTest, SanityTest)
     cvBlur(resized, ocv_out1, kernelSize1);
     cvBlur(resized, ocv_out2, kernelSize2);
 
-    EXPECT_EQ(0, cv::countNonZero(gapi_out1(outRoi) != ocv_out1(outRoi)));
-    EXPECT_EQ(0, cv::countNonZero(gapi_out2(outRoi) != ocv_out2(outRoi)));
+    EXPECT_EQ(0, cvtest::norm(gapi_out1(outRoi), ocv_out1(outRoi), NORM_INF));
+    EXPECT_EQ(0, cvtest::norm(gapi_out2(outRoi), ocv_out2(outRoi), NORM_INF));
 }
 
 INSTANTIATE_TEST_CASE_P(ResizeTestCPU, BlursAfterResizeTest,
@@ -752,7 +750,7 @@ TEST_P(NV12PlusResizeTest, Test)
     cv::cvtColor(in_mat, rgb_mat, cv::COLOR_YUV2RGB_NV12);
     cv::resize(rgb_mat, out_mat_ocv, out_sz, 0, 0, interp);
 
-    EXPECT_EQ(0, cv::countNonZero(out_mat(roi) != out_mat_ocv(roi)));
+    EXPECT_EQ(0, cvtest::norm(out_mat(roi), out_mat_ocv(roi), NORM_INF));
 }
 
 INSTANTIATE_TEST_CASE_P(Fluid, NV12PlusResizeTest,
@@ -831,7 +829,7 @@ TEST_P(Preproc4lpiTest, Test)
     cv::cvtColor(in_mat, rgb_mat, cv::COLOR_YUV2RGB_NV12);
     cv::resize(rgb_mat, out_mat_ocv, out_sz, 0, 0, interp);
 
-    EXPECT_EQ(0, cv::countNonZero(out_mat(roi) != out_mat_ocv(roi)));
+    EXPECT_EQ(0, cvtest::norm(out_mat(roi), out_mat_ocv(roi), NORM_INF));
 }
 
 INSTANTIATE_TEST_CASE_P(Fluid, Preproc4lpiTest,

--- a/modules/gapi/test/gapi_fluid_roi_test.cpp
+++ b/modules/gapi/test/gapi_fluid_roi_test.cpp
@@ -45,7 +45,7 @@ TEST_P(PartialComputation, Test)
     if (roi == cv::Rect{}) roi = cv::Rect{0,0,sz.width,sz.height};
     cv::blur(in_mat(roi), out_mat_ocv(roi), {kernelSize, kernelSize}, anchor, borderType);
 
-    EXPECT_EQ(0, cv::countNonZero(out_mat_gapi != out_mat_ocv));
+    EXPECT_EQ(0, cvtest::norm(out_mat_gapi, out_mat_ocv, NORM_INF));
 }
 
 INSTANTIATE_TEST_CASE_P(Fluid, PartialComputation,
@@ -79,7 +79,7 @@ TEST_P(PartialComputationAddC, Test)
     if (roi == cv::Rect{}) roi = cv::Rect{0,0,sz.width,sz.height};
     out_mat_ocv(roi) = in_mat(roi) + 1;
 
-    EXPECT_EQ(0, cv::countNonZero(out_mat_gapi != out_mat_ocv));
+    EXPECT_EQ(0, cvtest::norm(out_mat_gapi, out_mat_ocv, NORM_INF));
 }
 
 INSTANTIATE_TEST_CASE_P(FluidRoi, PartialComputationAddC,
@@ -125,7 +125,7 @@ TEST_P(SequenceOfBlursRoiTest, Test)
 
     cv::blur(mid_mat_ocv(roi), out_mat_ocv(roi), {5,5}, anchor, borderType);
 
-    EXPECT_EQ(0, countNonZero(out_mat_ocv != out_mat_gapi));
+    EXPECT_EQ(0, cvtest::norm(out_mat_ocv, out_mat_gapi, NORM_INF));
 }
 
 INSTANTIATE_TEST_CASE_P(FluidRoi, SequenceOfBlursRoiTest,
@@ -180,8 +180,8 @@ TEST_P(TwoBlursRoiTest, Test)
     cv::blur(in_mat(outRoi), out_mat_ocv1(outRoi), {kernelSize1, kernelSize1}, anchor, borderType1);
     cv::blur(in_mat(outRoi), out_mat_ocv2(outRoi), {kernelSize2, kernelSize2}, anchor, borderType2);
 
-    EXPECT_EQ(0, countNonZero(out_mat_ocv1 != out_mat_gapi1));
-    EXPECT_EQ(0, countNonZero(out_mat_ocv2 != out_mat_gapi2));
+    EXPECT_EQ(0, cvtest::norm(out_mat_ocv1, out_mat_gapi1, NORM_INF));
+    EXPECT_EQ(0, cvtest::norm(out_mat_ocv2, out_mat_gapi2, NORM_INF));
 }
 
 INSTANTIATE_TEST_CASE_P(FluidRoi, TwoBlursRoiTest,

--- a/modules/gapi/test/gapi_fluid_test.cpp
+++ b/modules/gapi/test/gapi_fluid_test.cpp
@@ -64,7 +64,7 @@ TEST(FluidBuffer, InputTest)
         view.priv().readDone(1,1);
 
         cv::Mat from_buffer(1, buffer_size.width, CV_8U, const_cast<uint8_t*>(rrow));
-        EXPECT_EQ(0, cv::countNonZero(in_mat.row(this_y) != from_buffer));
+        EXPECT_EQ(0, cvtest::norm(in_mat.row(this_y), from_buffer, NORM_INF));
 
         this_y++;
     }
@@ -141,9 +141,9 @@ TEST(FluidBuffer, CircularTest)
                 cv::Mat read_thisLine(1, buffer_size.width, CV_8U, const_cast<uint8_t*>(rrow[1]));
                 cv::Mat read_nextLine(1, buffer_size.width, CV_8U, const_cast<uint8_t*>(rrow[2]));
 
-                EXPECT_EQ(0, cv::countNonZero(written_lastLine2 != read_prevLine));
-                EXPECT_EQ(0, cv::countNonZero(written_lastLine1 != read_thisLine));
-                EXPECT_EQ(0, cv::countNonZero(written_lastLine0 != read_nextLine));
+                EXPECT_EQ(0, cvtest::norm(written_lastLine2, read_prevLine, NORM_INF));
+                EXPECT_EQ(0, cvtest::norm(written_lastLine1, read_thisLine, NORM_INF));
+                EXPECT_EQ(0, cvtest::norm(written_lastLine0, read_nextLine, NORM_INF));
             }
             num_reads++;
         }
@@ -190,7 +190,7 @@ TEST(Fluid, AddC_WithScalar)
 
     cc(cv::gin(in_mat, in_s), cv::gout(out_mat));
     ref_mat = in_mat + in_s;
-    EXPECT_EQ(0, cv::countNonZero(out_mat != ref_mat));
+    EXPECT_EQ(0, cvtest::norm(out_mat, ref_mat, NORM_INF));
 }
 
 TEST(Fluid, Scalar_In_Middle_Graph)
@@ -206,7 +206,7 @@ TEST(Fluid, Scalar_In_Middle_Graph)
 
     cc(cv::gin(in_mat, in_s), cv::gout(out_mat));
     ref_mat = (in_mat + 5) + in_s;
-    EXPECT_EQ(0, cv::countNonZero(out_mat != ref_mat));
+    EXPECT_EQ(0, cvtest::norm(out_mat, ref_mat, NORM_INF));
 }
 
 TEST(Fluid, Add_Scalar_To_Mat)
@@ -222,7 +222,7 @@ TEST(Fluid, Add_Scalar_To_Mat)
 
     cc(cv::gin(in_s, in_mat), cv::gout(out_mat));
     ref_mat = in_mat + in_s;
-    EXPECT_EQ(0, cv::countNonZero(out_mat != ref_mat));
+    EXPECT_EQ(0, cvtest::norm(out_mat, ref_mat, NORM_INF));
 }
 
 TEST(Fluid, Sum_2_Mats_And_Scalar)
@@ -241,7 +241,7 @@ TEST(Fluid, Sum_2_Mats_And_Scalar)
 
     cc(cv::gin(in_mat1, in_s, in_mat2), cv::gout(out_mat));
     ref_mat = in_mat1 + in_mat2 + in_s;
-    EXPECT_EQ(0, cv::countNonZero(out_mat != ref_mat));
+    EXPECT_EQ(0, cvtest::norm(out_mat, ref_mat, NORM_INF));
 }
 
 TEST(Fluid, EqualizeHist)
@@ -261,7 +261,7 @@ TEST(Fluid, EqualizeHist)
 
     cv::equalizeHist(in_mat, ref_mat);
 
-    EXPECT_EQ(0, cv::countNonZero(out_mat != ref_mat));
+    EXPECT_EQ(0, cvtest::norm(out_mat, ref_mat, NORM_INF));
 }
 
 TEST(Fluid, Split3)
@@ -290,7 +290,7 @@ TEST(Fluid, Split3)
     cv::split(in_mat, chans);
 
     // Compare
-    EXPECT_EQ(0, cv::countNonZero(out_mat != (chans[2]*3)));
+    EXPECT_EQ(0, cvtest::norm(out_mat, Mat(chans[2]*3), NORM_INF));
 }
 
 TEST(Fluid, ScratchTest)
@@ -319,11 +319,11 @@ TEST(Fluid, ScratchTest)
                         cv::compile_args(fluidTestPackage));
     cc(in_mat, out_mat);
     GAPI_LOG_INFO(NULL, "\n" << out_mat);
-    EXPECT_EQ(0, cv::countNonZero(ref != out_mat));
+    EXPECT_EQ(0, cvtest::norm(ref, out_mat, NORM_INF));
 
     cc(in_mat, out_mat);
     GAPI_LOG_INFO(NULL, "\n" << out_mat);
-    EXPECT_EQ(0, cv::countNonZero(ref != out_mat));
+    EXPECT_EQ(0, cvtest::norm(ref, out_mat, NORM_INF));
 }
 
 TEST(Fluid, MultipleOutRowsTest)
@@ -343,7 +343,7 @@ TEST(Fluid, MultipleOutRowsTest)
     std::cout << out_mat << std::endl;
 
     cv::Mat ocv_ref = in_mat + 1 + 2;
-    EXPECT_EQ(0, cv::countNonZero(ocv_ref != out_mat));
+    EXPECT_EQ(0, cvtest::norm(ocv_ref, out_mat, NORM_INF));
 }
 
 
@@ -374,7 +374,7 @@ TEST(Fluid, LPIWindow)
     // OpenCV reference
     cv::Mat ocv_ref = eyes[0]+eyes[1]+eyes[2];
 
-    EXPECT_EQ(0, cv::countNonZero(ocv_ref != out_mat));
+    EXPECT_EQ(0, cvtest::norm(ocv_ref, out_mat, NORM_INF));
 }
 
 TEST(Fluid, MultipleReaders_SameLatency)
@@ -403,7 +403,7 @@ TEST(Fluid, MultipleReaders_SameLatency)
     // Check with OpenCV
     cv::Mat tmp = in_mat + 1;
     out_mat_ocv = (tmp+2) + (tmp+3);
-    EXPECT_EQ(0, cv::countNonZero(out_mat_gapi != out_mat_ocv));
+    EXPECT_EQ(0, cvtest::norm(out_mat_gapi, out_mat_ocv, NORM_INF));
 }
 
 TEST(Fluid, MultipleReaders_DifferentLatency)
@@ -437,7 +437,7 @@ TEST(Fluid, MultipleReaders_DifferentLatency)
     cv::Mat ocv_d = ocv_a;
     cv::Mat ocv_c = ocv_a + ocv_d;
     cv::Mat out_mat_ocv = ocv_b + ocv_c;
-    EXPECT_EQ(0, cv::countNonZero(out_mat_gapi != out_mat_ocv));
+    EXPECT_EQ(0, cvtest::norm(out_mat_gapi, out_mat_ocv, NORM_INF));
 }
 
 TEST(Fluid, MultipleOutputs)
@@ -464,8 +464,8 @@ TEST(Fluid, MultipleOutputs)
     // Check with OpenCV
     out_mat_ocv1 = in_mat + 1 + 2;
     out_mat_ocv2 = in_mat + 1 + 7;
-    EXPECT_EQ(0, cv::countNonZero(out_mat_gapi1 != out_mat_ocv1));
-    EXPECT_EQ(0, cv::countNonZero(out_mat_gapi2 != out_mat_ocv2));
+    EXPECT_EQ(0, cvtest::norm(out_mat_gapi1, out_mat_ocv1, NORM_INF));
+    EXPECT_EQ(0, cvtest::norm(out_mat_gapi2, out_mat_ocv2, NORM_INF));
 }
 
 TEST(Fluid, EmptyOutputMatTest)
@@ -509,7 +509,7 @@ TEST_P(LPISequenceTest, LPISequenceTest)
 
     // Check with OpenCV
     cv::blur(in_mat + 1, out_mat_ocv, {kernelSize,kernelSize}, {-1,-1}, cv::BORDER_CONSTANT);
-    EXPECT_EQ(0, cv::countNonZero(out_mat_gapi != out_mat_ocv));
+    EXPECT_EQ(0, cvtest::norm(out_mat_gapi, out_mat_ocv, NORM_INF));
 }
 
 INSTANTIATE_TEST_CASE_P(Fluid, LPISequenceTest,
@@ -547,7 +547,7 @@ TEST_P(InputImageBorderTest, InputImageBorderTest)
     cv::Mat out_mat_ocv = Mat::zeros(sz_in, CV_8UC1);
     cv::blur(in_mat1, out_mat_ocv, kernelSize, anchor, borderType);
 
-    EXPECT_EQ(0, countNonZero(out_mat_ocv != out_mat_gapi));
+    EXPECT_EQ(0, cvtest::norm(out_mat_ocv, out_mat_gapi, NORM_INF));
 }
 
 INSTANTIATE_TEST_CASE_P(Fluid, InputImageBorderTest,
@@ -585,7 +585,7 @@ TEST_P(SequenceOfBlursTest, Test)
     cv::blur(in_mat, mid_mat_ocv, {3,3}, anchor, borderType);
     cv::blur(mid_mat_ocv, out_mat_ocv, {5,5}, anchor, borderType);
 
-    EXPECT_EQ(0, countNonZero(out_mat_ocv != out_mat_gapi));
+    EXPECT_EQ(0, cvtest::norm(out_mat_ocv, out_mat_gapi, NORM_INF));
 }
 
 INSTANTIATE_TEST_CASE_P(Fluid, SequenceOfBlursTest,
@@ -637,8 +637,8 @@ TEST_P(TwoBlursTest, Test)
     cv::blur(in_mat, out_mat_ocv1, {kernelSize1, kernelSize1}, anchor, borderType1);
     cv::blur(in_mat, out_mat_ocv2, {kernelSize2, kernelSize2}, anchor, borderType2);
 
-    EXPECT_EQ(0, countNonZero(out_mat_ocv1 != out_mat_gapi1));
-    EXPECT_EQ(0, countNonZero(out_mat_ocv2 != out_mat_gapi2));
+    EXPECT_EQ(0, cvtest::norm(out_mat_ocv1, out_mat_gapi1, NORM_INF));
+    EXPECT_EQ(0, cvtest::norm(out_mat_ocv2, out_mat_gapi2, NORM_INF));
 }
 
 INSTANTIATE_TEST_CASE_P(Fluid, TwoBlursTest,
@@ -695,8 +695,8 @@ TEST_P(TwoReadersTest, Test)
     out_mat_ocv1 = in_mat;
     cv::blur(in_mat, out_mat_ocv2, {kernelSize, kernelSize}, anchor, borderType);
 
-    EXPECT_EQ(0, countNonZero(out_mat_ocv1 != out_mat_gapi1));
-    EXPECT_EQ(0, countNonZero(out_mat_ocv2 != out_mat_gapi2));
+    EXPECT_EQ(0, cvtest::norm(out_mat_ocv1, out_mat_gapi1, NORM_INF));
+    EXPECT_EQ(0, cvtest::norm(out_mat_ocv2, out_mat_gapi2, NORM_INF));
 }
 
 INSTANTIATE_TEST_CASE_P(Fluid, TwoReadersTest,
@@ -726,8 +726,8 @@ TEST(FluidTwoIslands, SanityTest)
 
     GComputation c(GIn(in1, in2), GOut(out1, out2));
     EXPECT_NO_THROW(c.apply(gin(in_mat1, in_mat2), gout(out_mat1, out_mat2), cv::compile_args(fluidTestPackage)));
-    EXPECT_EQ(0, countNonZero(in_mat1 != out_mat1));
-    EXPECT_EQ(0, countNonZero(in_mat2 != out_mat2));
+    EXPECT_EQ(0, cvtest::norm(in_mat1, out_mat1, NORM_INF));
+    EXPECT_EQ(0, cvtest::norm(in_mat2, out_mat2, NORM_INF));
 }
 
 struct NV12RoiTest : public TestWithParam <std::pair<cv::Size, cv::Rect>> {};
@@ -758,7 +758,7 @@ TEST_P(NV12RoiTest, Test)
 
     cv::cvtColor(in_mat, out_mat_ocv, cv::COLOR_YUV2RGB_NV12);
 
-    EXPECT_EQ(0, cv::countNonZero(out_mat(roi) != out_mat_ocv(roi)));
+    EXPECT_EQ(0, cvtest::norm(out_mat(roi), out_mat_ocv(roi), NORM_INF));
 }
 
 INSTANTIATE_TEST_CASE_P(Fluid, NV12RoiTest,

--- a/modules/gapi/test/gapi_gcomputation_tests.cpp
+++ b/modules/gapi/test/gapi_gcomputation_tests.cpp
@@ -83,7 +83,7 @@ namespace opencv_test
                   const auto& ref_mat = std::get<0>(it);
                   const auto& out_mat = std::get<1>(it);
 
-                  EXPECT_EQ(0, cv::countNonZero(ref_mat != out_mat));
+                  EXPECT_EQ(0, cvtest::norm(ref_mat, out_mat, NORM_INF));
               }
           }
       };

--- a/modules/gapi/test/gapi_opaque_tests.cpp
+++ b/modules/gapi/test/gapi_opaque_tests.cpp
@@ -124,7 +124,7 @@ TEST(GOpaque, TestOpaqueIn)
     c.apply(cv::gin(fill), cv::gout(mat), cv::compile_args(cv::gapi::kernels<OCVFillMat>()));
 
     auto diff = cv::Mat(sz, CV_MAKETYPE(depth, chan), cv::Scalar(fill)) - mat;
-    EXPECT_EQ(cv::countNonZero(diff), 0);
+    EXPECT_EQ(0, cvtest::norm(diff, NORM_INF));
 }
 
 TEST(GOpaque, TestOpaqueBetween)

--- a/modules/gapi/test/gapi_planar_test.cpp
+++ b/modules/gapi/test/gapi_planar_test.cpp
@@ -131,7 +131,7 @@ TEST_P(PlanarTest, Resize3c3p)
     cv::resize(in_mat, resized_mat, out_sz, 0, 0, interp);
     toPlanar(resized_mat, out_mat_ocv);
 
-    EXPECT_EQ(0, cv::countNonZero(out_mat != out_mat_ocv));
+    EXPECT_EQ(0, cvtest::norm(out_mat, out_mat_ocv, NORM_INF));
 }
 
 TEST_P(PlanarTest, Resize3p3p)
@@ -161,7 +161,7 @@ TEST_P(PlanarTest, Resize3p3p)
         cv::resize(in_mat_roi, out_mat_roi, out_sz, 0, 0, interp);
     }
 
-    EXPECT_EQ(0, cv::countNonZero(out_mat != out_mat_ocv));
+    EXPECT_EQ(0, cvtest::norm(out_mat, out_mat_ocv, NORM_INF));
 }
 
 TEST_P(PlanarTest, Pipeline)
@@ -193,7 +193,7 @@ TEST_P(PlanarTest, Pipeline)
     cv::resize(rgb, resized_mat, out_sz, 0, 0, interp);
     toPlanar(resized_mat, out_mat_ocv);
 
-    EXPECT_EQ(0, cv::countNonZero(out_mat != out_mat_ocv));
+    EXPECT_EQ(0, cvtest::norm(out_mat, out_mat_ocv, NORM_INF));
 }
 
 INSTANTIATE_TEST_CASE_P(Sanity, PlanarTest,

--- a/modules/gapi/test/gapi_sample_pipelines.cpp
+++ b/modules/gapi/test/gapi_sample_pipelines.cpp
@@ -81,12 +81,12 @@ TEST(GAPI_Pipeline, OverloadUnary_MatMat)
 
     cv::Mat out_mat;
     comp.apply(in_mat, out_mat);
-    EXPECT_EQ(0, cv::countNonZero(out_mat != ref_mat));
+    EXPECT_EQ(0, cvtest::norm(out_mat, ref_mat, NORM_INF));
 
     out_mat = cv::Mat();
     auto cc = comp.compile(cv::descr_of(in_mat));
     cc(in_mat, out_mat);
-    EXPECT_EQ(0, cv::countNonZero(out_mat != ref_mat));
+    EXPECT_EQ(0, cvtest::norm(out_mat, ref_mat, NORM_INF));
 }
 
 TEST(GAPI_Pipeline, OverloadUnary_MatScalar)
@@ -117,12 +117,12 @@ TEST(GAPI_Pipeline, OverloadBinary_Mat)
 
     cv::Mat out_mat;
     comp.apply(in_mat, in_mat, out_mat);
-    EXPECT_EQ(0, cv::countNonZero(out_mat != ref_mat));
+    EXPECT_EQ(0, cvtest::norm(out_mat, ref_mat, NORM_INF));
 
     out_mat = cv::Mat();
     auto cc = comp.compile(cv::descr_of(in_mat), cv::descr_of(in_mat));
     cc(in_mat, in_mat, out_mat);
-    EXPECT_EQ(0, cv::countNonZero(out_mat != ref_mat));
+    EXPECT_EQ(0, cvtest::norm(out_mat, ref_mat, NORM_INF));
 }
 
 TEST(GAPI_Pipeline, OverloadBinary_Scalar)
@@ -193,9 +193,9 @@ TEST(GAPI_Pipeline, Sharpen)
         cv::Mat diff = out_mat_ocv != out_mat;
         std::vector<cv::Mat> diffBGR(3);
         cv::split(diff, diffBGR);
-        EXPECT_EQ(0, cv::countNonZero(diffBGR[0]));
-        EXPECT_EQ(0, cv::countNonZero(diffBGR[1]));
-        EXPECT_EQ(0, cv::countNonZero(diffBGR[2]));
+        EXPECT_EQ(0, cvtest::norm(diffBGR[0], NORM_INF));
+        EXPECT_EQ(0, cvtest::norm(diffBGR[1], NORM_INF));
+        EXPECT_EQ(0, cvtest::norm(diffBGR[2], NORM_INF));
     }
 
     // Metadata check /////////////////////////////////////////////////////////
@@ -283,9 +283,9 @@ TEST(GAPI_Pipeline, CustomRGB2YUV)
             diff_u = diff(out_mats_cv[1], out_mats_gapi[1], 2),
             diff_v = diff(out_mats_cv[2], out_mats_gapi[2], 2);
 
-        EXPECT_EQ(0, cv::countNonZero(diff_y));
-        EXPECT_EQ(0, cv::countNonZero(diff_u));
-        EXPECT_EQ(0, cv::countNonZero(diff_v));
+        EXPECT_EQ(0, cvtest::norm(diff_y, NORM_INF));
+        EXPECT_EQ(0, cvtest::norm(diff_u, NORM_INF));
+        EXPECT_EQ(0, cvtest::norm(diff_v, NORM_INF));
     }
 }
 

--- a/modules/gapi/test/gapi_scalar_tests.cpp
+++ b/modules/gapi/test/gapi_scalar_tests.cpp
@@ -27,7 +27,7 @@ TEST(GAPI_Scalar, Argument)
     mulS.apply(in_mat, cv::Scalar(2), out_mat);
 
     cv::Mat reference = in_mat*2;
-    EXPECT_EQ(0, cv::countNonZero(cv::abs(out_mat - reference)));
+    EXPECT_EQ(0, cvtest::norm(out_mat, reference, NORM_INF));
 }
 
 TEST(GAPI_Scalar, ReturnValue)
@@ -60,7 +60,7 @@ TEST(GAPI_Scalar, TmpScalar)
     mul_by_sum.apply(in_mat, out_mat);
 
     cv::Mat reference = cv::Mat(sz, CV_8U, cv::Scalar(4));
-    EXPECT_EQ(0, cv::countNonZero(cv::abs(out_mat - reference)));
+    EXPECT_EQ(0, cvtest::norm(out_mat, reference, NORM_INF));
 }
 
 TEST(GAPI_ScalarWithValue, Simple_Arithmetic_Pipeline)
@@ -75,7 +75,7 @@ TEST(GAPI_ScalarWithValue, Simple_Arithmetic_Pipeline)
     ref_mat = (in_mat + 1) * 2;
     comp.apply(in_mat, out_mat);
 
-    EXPECT_EQ(0, cv::countNonZero(out_mat != ref_mat));
+    EXPECT_EQ(0, cvtest::norm(out_mat, ref_mat, NORM_INF));
 }
 
 TEST(GAPI_ScalarWithValue, GScalar_Initilization)
@@ -90,7 +90,7 @@ TEST(GAPI_ScalarWithValue, GScalar_Initilization)
     cv::multiply(in_mat, sc, ref_mat, 1, CV_8UC1);
     comp.apply(cv::gin(in_mat), cv::gout(out_mat));
 
-    EXPECT_EQ(0, cv::countNonZero(out_mat != ref_mat));
+    EXPECT_EQ(0, cvtest::norm(out_mat, ref_mat, NORM_INF));
 }
 
 TEST(GAPI_ScalarWithValue, Constant_GScalar_In_Middle_Graph)
@@ -111,7 +111,7 @@ TEST(GAPI_ScalarWithValue, Constant_GScalar_In_Middle_Graph)
     cv::multiply(add_mat, sc, ref_mat, 1, CV_8UC1);
     comp.apply(cv::gin(in_mat, in_scalar), cv::gout(out_mat));
 
-    EXPECT_EQ(0, cv::countNonZero(out_mat != ref_mat));
+    EXPECT_EQ(0, cvtest::norm(out_mat, ref_mat, NORM_INF));
 }
 
 } // namespace opencv_test

--- a/modules/gapi/test/gapi_smoke_test.cpp
+++ b/modules/gapi/test/gapi_smoke_test.cpp
@@ -91,7 +91,7 @@ TEST(GAPI, EmptyOutMat)
     EXPECT_EQ(640, out.cols);
     EXPECT_EQ(480, out.rows);
     EXPECT_EQ(CV_8U, out.type());
-    EXPECT_EQ(0, cv::countNonZero(out - (in_mat+in_mat)));
+    EXPECT_EQ(0, cvtest::norm(out, (in_mat+in_mat), NORM_INF));
 }
 
 }

--- a/modules/gapi/test/gapi_typed_tests.cpp
+++ b/modules/gapi/test/gapi_typed_tests.cpp
@@ -10,23 +10,6 @@
 namespace opencv_test
 {
 
-namespace
-{
-    cv::Mat diff(cv::Mat m1, cv::Mat m2, int t)
-    {
-        return cv::abs(m1-m2) > t;
-    }
-
-    int non_zero3(cv::Mat m3c)
-    {
-        std::vector<cv::Mat> mm(3);
-        cv::split(m3c, mm);
-        return (  cv::countNonZero(mm[0])
-                + cv::countNonZero(mm[1])
-                + cv::countNonZero(mm[2]));
-    }
-}
-
 TEST(GAPI_Typed, UnaryOp)
 {
     // Initialization //////////////////////////////////////////////////////////
@@ -60,14 +43,9 @@ TEST(GAPI_Typed, UnaryOp)
 
     // Comparison //////////////////////////////////////////////////////////////
     // FIXME: There must be OpenCV comparison test functions already available!
-    cv::Mat
-        diff_u  = diff(out_mat_cv, out_mat_untyped, 0),
-        diff_t  = diff(out_mat_cv, out_mat_typed1,  0),
-        diff_tc = diff(out_mat_cv, out_mat_typed2,  0);
-
-    EXPECT_EQ(0, non_zero3(diff_u));
-    EXPECT_EQ(0, non_zero3(diff_t));
-    EXPECT_EQ(0, non_zero3(diff_tc));
+    EXPECT_EQ(0, cvtest::norm(out_mat_cv, out_mat_untyped, NORM_INF));
+    EXPECT_EQ(0, cvtest::norm(out_mat_cv, out_mat_typed1, NORM_INF));
+    EXPECT_EQ(0, cvtest::norm(out_mat_cv, out_mat_typed2, NORM_INF));
 }
 
 TEST(GAPI_Typed, BinaryOp)
@@ -111,14 +89,9 @@ TEST(GAPI_Typed, BinaryOp)
 
     // Comparison //////////////////////////////////////////////////////////////
     // FIXME: There must be OpenCV comparison test functions already available!
-    cv::Mat
-        diff_u  = diff(out_mat_cv, out_mat_untyped, 0),
-        diff_t  = diff(out_mat_cv, out_mat_typed1,  0),
-        diff_tc = diff(out_mat_cv, out_mat_typed2,  0);
-
-    EXPECT_EQ(0, cv::countNonZero(diff_u));
-    EXPECT_EQ(0, cv::countNonZero(diff_t));
-    EXPECT_EQ(0, cv::countNonZero(diff_tc));
+    EXPECT_EQ(0, cvtest::norm(out_mat_cv, out_mat_untyped, NORM_INF));
+    EXPECT_EQ(0, cvtest::norm(out_mat_cv, out_mat_typed1, NORM_INF));
+    EXPECT_EQ(0, cvtest::norm(out_mat_cv, out_mat_typed2, NORM_INF));
 }
 
 
@@ -166,20 +139,12 @@ TEST(GAPI_Typed, MultipleOuts)
 
     // Comparison //////////////////////////////////////////////////////////////
     // FIXME: There must be OpenCV comparison test functions already available!
-    cv::Mat
-        diff_u1 = diff(out_mat_cv1, out_mat_unt1,   0),
-        diff_u2 = diff(out_mat_cv2, out_mat_unt2,   0),
-        diff_t1 = diff(out_mat_cv1, out_mat_typed1, 0),
-        diff_t2 = diff(out_mat_cv2, out_mat_typed2, 0),
-        diff_c1 = diff(out_mat_cv1, out_mat_comp1,  0),
-        diff_c2 = diff(out_mat_cv2, out_mat_comp2,  0);
-
-    EXPECT_EQ(0, cv::countNonZero(diff_u1));
-    EXPECT_EQ(0, cv::countNonZero(diff_u2));
-    EXPECT_EQ(0, cv::countNonZero(diff_t1));
-    EXPECT_EQ(0, cv::countNonZero(diff_t2));
-    EXPECT_EQ(0, cv::countNonZero(diff_c1));
-    EXPECT_EQ(0, cv::countNonZero(diff_c2));
+    EXPECT_EQ(0, cvtest::norm(out_mat_cv1, out_mat_unt1, NORM_INF));
+    EXPECT_EQ(0, cvtest::norm(out_mat_cv2, out_mat_unt2, NORM_INF));
+    EXPECT_EQ(0, cvtest::norm(out_mat_cv1, out_mat_typed1, NORM_INF));
+    EXPECT_EQ(0, cvtest::norm(out_mat_cv2, out_mat_typed2, NORM_INF));
+    EXPECT_EQ(0, cvtest::norm(out_mat_cv1, out_mat_comp1, NORM_INF));
+    EXPECT_EQ(0, cvtest::norm(out_mat_cv2, out_mat_comp2, NORM_INF));
 }
 
 } // opencv_test

--- a/modules/gapi/test/internal/gapi_int_executor_tests.cpp
+++ b/modules/gapi/test/internal/gapi_int_executor_tests.cpp
@@ -70,8 +70,8 @@ TEST(GExecutor, SmokeTest)
         cv::boxFilter(ocv_tmp3, out_ocv[1], -1, cv::Size(3,3));
     }
 
-    EXPECT_EQ(0, cv::countNonZero(out_gapi[0] != out_ocv[0]));
-    EXPECT_EQ(0, cv::countNonZero(out_gapi[1] != out_ocv[1]));
+    EXPECT_EQ(0, cvtest::norm(out_gapi[0], out_ocv[0], NORM_INF));
+    EXPECT_EQ(0, cvtest::norm(out_gapi[1], out_ocv[1], NORM_INF));
 
     // FIXME: check that GIslandModel has more than 1 island (e.g. fusion
     // with breakdown worked)

--- a/modules/gapi/test/internal/gapi_int_recompilation_test.cpp
+++ b/modules/gapi/test/internal/gapi_int_recompilation_test.cpp
@@ -116,8 +116,8 @@ TEST(GComputationCompile, FluidReshapeResizeDownScale)
     cv::resize(in_mat1, cv_out_mat1, szOut);
     cv::resize(in_mat2, cv_out_mat2, szOut);
 
-    EXPECT_EQ(0, cv::countNonZero(out_mat1 != cv_out_mat1));
-    EXPECT_EQ(0, cv::countNonZero(out_mat2 != cv_out_mat2));
+    EXPECT_EQ(0, cvtest::norm(out_mat1, cv_out_mat1, NORM_INF));
+    EXPECT_EQ(0, cvtest::norm(out_mat2, cv_out_mat2, NORM_INF));
 }
 
 TEST(GComputationCompile, FluidReshapeSwitchToUpscaleFromDownscale)
@@ -151,9 +151,9 @@ TEST(GComputationCompile, FluidReshapeSwitchToUpscaleFromDownscale)
     cv::resize(in_mat2, cv_out_mat2, szOut);
     cv::resize(in_mat3, cv_out_mat3, szOut);
 
-    EXPECT_EQ(0, cv::countNonZero(out_mat1 != cv_out_mat1));
-    EXPECT_EQ(0, cv::countNonZero(out_mat2 != cv_out_mat2));
-    EXPECT_EQ(0, cv::countNonZero(out_mat3 != cv_out_mat3));
+    EXPECT_EQ(0, cvtest::norm(out_mat1, cv_out_mat1, NORM_INF));
+    EXPECT_EQ(0, cvtest::norm(out_mat2, cv_out_mat2, NORM_INF));
+    EXPECT_EQ(0, cvtest::norm(out_mat3, cv_out_mat3, NORM_INF));
 }
 
 TEST(GComputationCompile, ReshapeBlur)
@@ -181,8 +181,8 @@ TEST(GComputationCompile, ReshapeBlur)
     cv::blur(in_mat1, cv_out_mat1, kernelSize);
     cv::blur(in_mat2, cv_out_mat2, kernelSize);
 
-    EXPECT_EQ(0, cv::countNonZero(out_mat1 != cv_out_mat1));
-    EXPECT_EQ(0, cv::countNonZero(out_mat2 != cv_out_mat2));
+    EXPECT_EQ(0, cvtest::norm(out_mat1, cv_out_mat1, NORM_INF));
+    EXPECT_EQ(0, cvtest::norm(out_mat2, cv_out_mat2, NORM_INF));
 }
 
 TEST(GComputationCompile, ReshapeRois)
@@ -225,7 +225,7 @@ TEST(GComputationCompile, ReshapeRois)
         cv::blur(in_mat, blur_mat, kernelSize);
         cv::resize(blur_mat, cv_out_mat, szOut);
 
-        EXPECT_EQ(0, cv::countNonZero(out_mat(roi) != cv_out_mat(roi)));
+        EXPECT_EQ(0, cvtest::norm(out_mat(roi), cv_out_mat(roi), NORM_INF));
     }
 }
 

--- a/modules/gapi/test/own/mat_tests.cpp
+++ b/modules/gapi/test/own/mat_tests.cpp
@@ -220,7 +220,7 @@ TEST(OwnMatConversion, WithStep)
     auto ownMat = to_own(cvMat);
     auto cvMatFromOwn = cv::gapi::own::to_ocv(ownMat);
 
-    EXPECT_EQ(0, cv::countNonZero(cvMat != cvMatFromOwn))
+    EXPECT_EQ(0, cvtest::norm(cvMat, cvMatFromOwn, NORM_INF))
     << cvMat << std::endl
     << (cvMat != cvMatFromOwn);
 }
@@ -285,7 +285,7 @@ TEST(OwnMat, CopyToWithStep)
     mat.copyTo(dst);
 
     EXPECT_NE(mat.data, dst.data);
-    EXPECT_EQ(0, cv::countNonZero(to_ocv(mat) != to_ocv(dst)))
+    EXPECT_EQ(0, cvtest::norm(to_ocv(mat), to_ocv(dst), NORM_INF))
     << to_ocv(mat) << std::endl
     << (to_ocv(mat) != to_ocv(dst));
 }
@@ -460,8 +460,8 @@ TEST(OwnMat, ScalarAssign32SC1)
     }
 
     auto cmp_result_mat = (cv::Mat{height, stepInPixels, CV_32S, data.data()} != cv::Mat{height, stepInPixels, CV_32S, expected.data()});
-    EXPECT_EQ(0, cv::countNonZero(cmp_result_mat))
-    << cmp_result_mat << std::endl;
+    EXPECT_EQ(0, cvtest::norm(cmp_result_mat, NORM_INF))
+        << cmp_result_mat;
 }
 
 TEST(OwnMat, ScalarAssign8UC1)
@@ -491,8 +491,8 @@ TEST(OwnMat, ScalarAssign8UC1)
     }
 
     auto cmp_result_mat = (cv::Mat{height, stepInPixels, CV_8U, data.data()} != cv::Mat{height, stepInPixels, CV_8U, expected.data()});
-    EXPECT_EQ(0, cv::countNonZero(cmp_result_mat))
-    << cmp_result_mat << std::endl;
+    EXPECT_EQ(0, cvtest::norm(cmp_result_mat, NORM_INF))
+        << cmp_result_mat;
 }
 
 TEST(OwnMat, ScalarAssignND)
@@ -542,12 +542,12 @@ TEST(OwnMat, ScalarAssign8UC3)
     }
 
     auto cmp_result_mat = (cv::Mat{height, stepInPixels, cv_type, data.data()} != cv::Mat{height, stepInPixels, cv_type, expected.data()});
-    EXPECT_EQ(0, cv::countNonZero(cmp_result_mat))
-    << cmp_result_mat << std::endl
-    << "data : " << std::endl
-    << cv::Mat{height, stepInPixels, cv_type, data.data()}     << std::endl
-    << "expected : " << std::endl
-    << cv::Mat{height, stepInPixels, cv_type, expected.data()} << std::endl;
+    EXPECT_EQ(0, cvtest::norm(cmp_result_mat, NORM_INF))
+        << cmp_result_mat << std::endl
+        << "data : " << std::endl
+        << cv::Mat{height, stepInPixels, cv_type, data.data()}     << std::endl
+        << "expected : " << std::endl
+        << cv::Mat{height, stepInPixels, cv_type, expected.data()} << std::endl;
 }
 
 TEST(OwnMat, ROIView)
@@ -583,9 +583,9 @@ TEST(OwnMat, ROIView)
     auto expected_cv_mat = cv::Mat{4, 4, CV_8U, expected.data()};
 
     auto cmp_result_mat = (to_ocv(roi_view) != expected_cv_mat);
-    EXPECT_EQ(0, cv::countNonZero(cmp_result_mat))
-    << cmp_result_mat   << std::endl
-    << to_ocv(roi_view) << std::endl
-    << expected_cv_mat  << std::endl;
+    EXPECT_EQ(0, cvtest::norm(cmp_result_mat, NORM_INF))
+        << cmp_result_mat   << std::endl
+        << to_ocv(roi_view) << std::endl
+        << expected_cv_mat  << std::endl;
 }
 } // namespace opencv_test

--- a/modules/gapi/test/streaming/gapi_streaming_tests.cpp
+++ b/modules/gapi/test/streaming/gapi_streaming_tests.cpp
@@ -154,7 +154,7 @@ TEST_P(GAPI_Streaming, SmokeTest_ConstInput_GMat)
         // With constant inputs, the stream is endless so
         // the blocking pull() should never return `false`.
         EXPECT_TRUE(ccomp.pull(cv::gout(out_mat_gapi)));
-        EXPECT_EQ(0, cv::countNonZero(out_mat_gapi != out_mat_ocv));
+        EXPECT_EQ(0, cvtest::norm(out_mat_gapi, out_mat_ocv, NORM_INF));
     }
 
     EXPECT_TRUE(ccomp.running());
@@ -202,7 +202,7 @@ TEST_P(GAPI_Streaming, SmokeTest_VideoInput_GMat)
         frames++;
         cv::Mat out_mat_ocv;
         opencv_ref(in_mat_gapi, out_mat_ocv);
-        EXPECT_EQ(0, cv::countNonZero(out_mat_gapi != out_mat_ocv));
+        EXPECT_EQ(0, cvtest::norm(out_mat_gapi, out_mat_ocv, NORM_INF));
     }
     EXPECT_LT(0u, frames);
     EXPECT_FALSE(ccomp.running());

--- a/modules/gapi/test/test_precomp.hpp
+++ b/modules/gapi/test/test_precomp.hpp
@@ -28,4 +28,9 @@
 #include <opencv2/gapi/fluid/core.hpp>
 #include <opencv2/gapi/infer.hpp>
 
+namespace cv {
+static inline void countNonZero_is_forbidden_in_tests_use_norm_instead() {}
+}
+#define countNonZero() countNonZero_is_forbidden_in_tests_use_norm_instead()
+
 #endif // __OPENCV_GAPI_TEST_PRECOMP_HPP__


### PR DESCRIPTION
Misused `countNonZero()` (banned for future use)

**Review the latest commit only.**

opencv_test_gapi: 646 FAILED TESTS
opencv_perf_gapi: 96 FAILED TESTS

Message example:
```
[ RUN      ] GCompoundKernel.MergeWithSplit
unknown file: Failure
C++ exception with description "OpenCV(4.2.0-dev) /build/precommit_opencl_linux/opencv/modules/core/src/count_non_zero.dispatch.cpp:124: error: (-215:Assertion failed) cn == 1 in function 'countNonZero'
" thrown in the test body.
[  FAILED  ] GCompoundKernel.MergeWithSplit (0 ms)
```

relates #16656