### PR TITLE
Fixing typo in "-DOPENCV_"

### DIFF
--- a/doc/tutorials/introduction/linux_install/linux_install.markdown
+++ b/doc/tutorials/introduction/linux_install/linux_install.markdown
@@ -98,7 +98,7 @@ Building OpenCV from Source Using CMake
         will be statically linked with OpenCV and can take a lot of memory.
 
 -#  [optional] Generate pkg-config info
-    -   Add this flag when running CMake: `-DOPENCV_GENERATE_PKGCONFIG=ON`
+    -   Add this flag when running CMake: `-D OPENCV_GENERATE_PKGCONFIG=ON`
     -   Will generate the .pc file for pkg-config and install it.
     -   Useful if not using CMake in projects that use OpenCV
     -   Installed as `opencv4`, usage: `pkg-config --cflags --libs opencv4`


### PR DESCRIPTION
I've fixed a lot of problems because people are using -DOPENCV_ in OpenCV CMake tasks and pkg file is not generated. These errors are very difficult to find.

Now I just realized that the root of those problems seems to be in the documentation.

see #13154
