### PR TITLE
build: exclude opencv_contrib modules

### DIFF
--- a/cmake/OpenCVPackaging.cmake
+++ b/cmake/OpenCVPackaging.cmake
@@ -123,10 +123,9 @@ endif()
 set(STD_OPENCV_LIBS opencv-data)
 set(STD_OPENCV_DEV libopencv-dev)
 
-foreach(module calib3d core cudaarithm cudabgsegm cudacodec cudafeatures2d cudafilters
-               cudaimgproc cudalegacy cudaobjdetect cudaoptflow cudastereo cudawarping
-               cudev features2d flann hal highgui imgcodecs imgproc ml objdetect ocl
-               photo shape stitching superres ts video videoio videostab viz)
+foreach(module calib3d core dnn features2d flann gapi highgui
+               imgcodecs imgproc ml objdetect
+               photo stitching ts video videoio)
   if(HAVE_opencv_${module})
     list(APPEND STD_OPENCV_LIBS "libopencv-${module}4.0")
     list(APPEND STD_OPENCV_DEV "libopencv-${module}-dev")

--- a/include/opencv2/opencv.hpp
+++ b/include/opencv2/opencv.hpp
@@ -82,58 +82,14 @@
 #ifdef HAVE_OPENCV_PHOTO
 #include "opencv2/photo.hpp"
 #endif
-#ifdef HAVE_OPENCV_SHAPE
-#include "opencv2/shape.hpp"
-#endif
 #ifdef HAVE_OPENCV_STITCHING
 #include "opencv2/stitching.hpp"
-#endif
-#ifdef HAVE_OPENCV_SUPERRES
-#include "opencv2/superres.hpp"
 #endif
 #ifdef HAVE_OPENCV_VIDEO
 #include "opencv2/video.hpp"
 #endif
 #ifdef HAVE_OPENCV_VIDEOIO
 #include "opencv2/videoio.hpp"
-#endif
-#ifdef HAVE_OPENCV_VIDEOSTAB
-#include "opencv2/videostab.hpp"
-#endif
-#ifdef HAVE_OPENCV_VIZ
-#include "opencv2/viz.hpp"
-#endif
-
-// Finally CUDA specific entries are checked and added
-#ifdef HAVE_OPENCV_CUDAARITHM
-#include "opencv2/cudaarithm.hpp"
-#endif
-#ifdef HAVE_OPENCV_CUDABGSEGM
-#include "opencv2/cudabgsegm.hpp"
-#endif
-#ifdef HAVE_OPENCV_CUDACODEC
-#include "opencv2/cudacodec.hpp"
-#endif
-#ifdef HAVE_OPENCV_CUDAFEATURES2D
-#include "opencv2/cudafeatures2d.hpp"
-#endif
-#ifdef HAVE_OPENCV_CUDAFILTERS
-#include "opencv2/cudafilters.hpp"
-#endif
-#ifdef HAVE_OPENCV_CUDAIMGPROC
-#include "opencv2/cudaimgproc.hpp"
-#endif
-#ifdef HAVE_OPENCV_CUDAOBJDETECT
-#include "opencv2/cudaobjdetect.hpp"
-#endif
-#ifdef HAVE_OPENCV_CUDAOPTFLOW
-#include "opencv2/cudaoptflow.hpp"
-#endif
-#ifdef HAVE_OPENCV_CUDASTEREO
-#include "opencv2/cudastereo.hpp"
-#endif
-#ifdef HAVE_OPENCV_CUDAWARPING
-#include "opencv2/cudawarping.hpp"
 #endif
 
 #endif

--- a/modules/core/include/opencv2/core/persistence.hpp
+++ b/modules/core/include/opencv2/core/persistence.hpp
@@ -124,7 +124,7 @@ streams.
 
 Here is an example:
 @code
-    #include "opencv2/opencv.hpp"
+    #include "opencv2/core.hpp"
     #include <time.h>
 
     using namespace cv;


### PR DESCRIPTION
ABI dump for 4.2.0 should be updated too.
