### PR TITLE
add Copy to clipboard functional to imshow wnd with Qt

### DIFF
--- a/modules/highgui/src/window_QT.cpp
+++ b/modules/highgui/src/window_QT.cpp
@@ -1856,7 +1856,7 @@ void CvWindow::displayStatusBar(QString text, int delayms)
 void CvWindow::enablePropertiesButton()
 {
     if (!vect_QActions.empty())
-        vect_QActions[9]->setDisabled(false);
+        vect_QActions[10]->setDisabled(false);
 }
 
 
@@ -1991,7 +1991,7 @@ void CvWindow::createView()
 
 void CvWindow::createActions()
 {
-    vect_QActions.resize(10);
+    vect_QActions.resize(11);
 
     QWidget* view = myView->getWidget();
 
@@ -2032,18 +2032,22 @@ void CvWindow::createActions()
     vect_QActions[8]->setIconVisibleInMenu(true);
     QObject::connect(vect_QActions[8], SIGNAL(triggered()), view, SLOT(saveView()));
 
-    vect_QActions[9] = new QAction(QIcon(":/properties-icon"), "Display properties window (CTRL+P)", this);
+    vect_QActions[9] = new QAction(QIcon(":/copy_clipbrd-icon"), "Copy image to clipboard (CTRL+C)", this);
     vect_QActions[9]->setIconVisibleInMenu(true);
-    QObject::connect(vect_QActions[9], SIGNAL(triggered()), this, SLOT(displayPropertiesWin()));
+    QObject::connect(vect_QActions[9], SIGNAL(triggered()), view, SLOT(copy2Clipbrd()));
+
+    vect_QActions[10] = new QAction(QIcon(":/properties-icon"), "Display properties window (CTRL+P)", this);
+    vect_QActions[10]->setIconVisibleInMenu(true);
+    QObject::connect(vect_QActions[10], SIGNAL(triggered()), this, SLOT(displayPropertiesWin()));
 
     if (global_control_panel->myLayout->count() == 0)
-        vect_QActions[9]->setDisabled(true);
+        vect_QActions[10]->setDisabled(true);
 }
 
 
 void CvWindow::createShortcuts()
 {
-    vect_QShortcuts.resize(10);
+    vect_QShortcuts.resize(11);
 
     QWidget* view = myView->getWidget();
 
@@ -2074,8 +2078,11 @@ void CvWindow::createShortcuts()
     vect_QShortcuts[8] = new QShortcut(shortcut_save_img, this);
     QObject::connect(vect_QShortcuts[8], SIGNAL(activated()), view, SLOT(saveView()));
 
-    vect_QShortcuts[9] = new QShortcut(shortcut_properties_win, this);
-    QObject::connect(vect_QShortcuts[9], SIGNAL(activated()), this, SLOT(displayPropertiesWin()));
+    vect_QShortcuts[9] = new QShortcut(shortcut_copy_clipbrd, this);
+    QObject::connect(vect_QShortcuts[9], SIGNAL(activated()), view, SLOT(copy2Clipbrd()));
+
+    vect_QShortcuts[10] = new QShortcut(shortcut_properties_win, this);
+    QObject::connect(vect_QShortcuts[10], SIGNAL(activated()), this, SLOT(displayPropertiesWin()));
 }
 
 
@@ -2695,6 +2702,18 @@ void DefaultViewPort::saveView()
 
         CV_Error(CV_StsNullPtr, "file extension not recognized, please choose between JPG, JPEG, BMP or PNG");
     }
+}
+
+
+//copy image to clipboard
+void DefaultViewPort::copy2Clipbrd()
+{
+    // Create a new pixmap to render the viewport into
+    QPixmap viewportPixmap(viewport()->size());
+    viewport()->render(&viewportPixmap);
+
+    QClipboard *pClipboard = QApplication::clipboard();
+    pClipboard->setPixmap(viewportPixmap);
 }
 
 

--- a/modules/highgui/src/window_QT.h
+++ b/modules/highgui/src/window_QT.h
@@ -76,6 +76,7 @@
 #include <QDate>
 #include <QFileDialog>
 #include <QToolBar>
+#include <QClipboard>
 
 #include <QAction>
 #include <QCheckBox>
@@ -91,6 +92,7 @@ enum { CV_MODE_NORMAL = 0, CV_MODE_OPENGL = 1 };
 enum {	shortcut_zoom_normal 	= Qt::CTRL + Qt::Key_Z,
         shortcut_zoom_imgRegion = Qt::CTRL + Qt::Key_X,
         shortcut_save_img		= Qt::CTRL + Qt::Key_S,
+        shortcut_copy_clipbrd   = Qt::CTRL + Qt::Key_C,
         shortcut_properties_win	= Qt::CTRL + Qt::Key_P,
         shortcut_zoom_in 		= Qt::CTRL + Qt::Key_Plus,//QKeySequence(QKeySequence::ZoomIn),
         shortcut_zoom_out		= Qt::CTRL + Qt::Key_Minus,//QKeySequence(QKeySequence::ZoomOut),
@@ -518,6 +520,7 @@ public slots:
     void ZoomOut();
 
     void saveView();
+    void copy2Clipbrd();
 
 protected:
     void contextMenuEvent(QContextMenuEvent* event) CV_OVERRIDE;

--- a/modules/highgui/src/window_QT.qrc
+++ b/modules/highgui/src/window_QT.qrc
@@ -9,6 +9,7 @@
         <file alias="zoom_in-icon">files_Qt/Milky/48/106.png</file>
         <file alias="zoom_out-icon">files_Qt/Milky/48/107.png</file>
         <file alias="save-icon">files_Qt/Milky/48/7.png</file>
+        <file alias="copy_clipbrd-icon">files_Qt/Milky/48/43.png</file>
         <file alias="properties-icon">files_Qt/Milky/48/38.png</file>
         <file alias="stylesheet-trackbar">files_Qt/stylesheet_trackbar.qss</file>
     </qresource>


### PR DESCRIPTION
Adds "copy to clipboard" button to `imshow` window if opencv was built with Qt.
Tested on Windows 10, MACOS 10.14.6, Xubuntu 18.04.2, Qt 5.11.xx.

```
force_builders=Custom
build_image:Custom=qt:16.04
buildworker:Custom=linux-1,linux-2,linux-4
```