### PR TITLE
dnn(test): adjust check tolerance in Keypoints_face

### DIFF
--- a/modules/dnn/test/test_model.cpp
+++ b/modules/dnn/test/test_model.cpp
@@ -308,12 +308,20 @@ TEST_P(Test_Model, Keypoints_face)
     Mat exp = blobFromNPY(_tf("facial_keypoints_exp.npy"));
 
     Size size{224, 224};
-    float norm = (target == DNN_TARGET_OPENCL_FP16) ? 5e-3 : 1e-4;
     double scale = 1.0/255;
     Scalar mean = Scalar();
     bool swapRB = false;
 
     // Ref. Range: [-1.1784188, 1.7758257]
+    float norm = 1e-4;
+    if (target == DNN_TARGET_OPENCL_FP16)
+        norm = 5e-3;
+    if (target == DNN_TARGET_MYRIAD)
+    {
+        // Myriad2: l1 = 0.0004, lInf = 0.002
+        // MyriadX: l1 = 0.003, lInf = 0.009
+        norm = 0.009;
+    }
     if (target == DNN_TARGET_CUDA_FP16)
         norm = 0.004; // l1 = 0.0006, lInf = 0.004
 


### PR DESCRIPTION
[Nightly build](http://pullrequest.opencv.org/buildbot/builders/master_openvino-skl-lin64/builds/583)

<cut/>

Message with NCS - Myriad2:
```
[ RUN      ] Test_Model.Keypoints_face/3, where GetParam() = NGRAPH/MYRIAD
/build/master_openvino-skl-lin64/opencv/modules/dnn/test/test_common.impl.hpp:70: Failure
Expected: (normL1) <= (l1), actual: 0.000332259 vs 0.0001
/build/master_openvino-skl-lin64/opencv/modules/dnn/test/test_common.impl.hpp:73: Failure
Expected: (normInf) <= (lInf), actual: 0.00166094 vs 0.0001
[  FAILED  ] Test_Model.Keypoints_face/3, where GetParam() = NGRAPH/MYRIAD (133 ms)
```

NCS 2 - MyriadX:
```
[ RUN      ] Test_Model.Keypoints_face/3, where GetParam() = NGRAPH/MYRIAD
/build/precommit_custom_linux/opencv/modules/dnn/test/test_common.impl.hpp:70: Failure
Expected: (normL1) <= (l1), actual: 0.00284849 vs 0.002
/build/precommit_custom_linux/opencv/modules/dnn/test/test_common.impl.hpp:73: Failure
Expected: (normInf) <= (lInf), actual: 0.00824761 vs 0.002
[  FAILED  ] Test_Model.Keypoints_face/3, where GetParam() = NGRAPH/MYRIAD (242 ms)
```

```
force_builders=Custom,Custom Win,Custom Mac
build_image:Custom=ubuntu-openvino-2020.1.0:16.04
build_image:Custom Win=openvino-2020.1.0
build_image:Custom Mac=openvino-2020.1.0

test_modules:Custom=dnn,python2,python3,java
test_modules:Custom Win=dnn,python2,python3,java
test_modules:Custom Mac=dnn,python2,python3,java

buildworker:Custom=linux-1
# disabled due high memory usage: test_opencl:Custom=ON
test_opencl:Custom=OFF
test_bigdata:Custom=1
test_filter:Custom=*
```