### PR TITLE
Fix annoying compiler warning issue-16680

### DIFF
--- a/modules/gapi/samples/privacy_masking_camera.cpp
+++ b/modules/gapi/samples/privacy_masking_camera.cpp
@@ -35,7 +35,7 @@ std::string weights_path(const std::string &model_path) {
 
     auto ext = model_path.substr(sz - EXT_LEN);
 
-    std::transform(ext.begin(), ext.end(), ext.begin(), [](unsigned char c){ return std::tolower(c); });
+    std::transform(ext.begin(), ext.end(), ext.begin(), [](unsigned char c){ return static_cast<unsigned char>(std::tolower(c)); });
     CV_Assert(ext == ".xml");
 
     return model_path.substr(0u, sz - EXT_LEN) + ".bin";


### PR DESCRIPTION
resolves #16680

### Pull Request Readiness Checklist

Compiling solution locally fixes warning. Solution is untested.

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under OpenCV (BSD) License.
- [ ] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [x] The PR is proposed to proper branch
- [x] There is reference to original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
