### PR TITLE
Ignore clang warnings for deprecated enum+enum operations in mat.inl.hpp

### DIFF
--- a/cmake/OpenCVCompilerOptions.cmake
+++ b/cmake/OpenCVCompilerOptions.cmake
@@ -151,6 +151,10 @@ if(CV_GCC OR CV_CLANG)
     if(CV_GCC AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS 5.0)
       add_extra_compiler_option(-Wno-missing-field-initializers)  # GCC 4.x emits warnings about {}, fixed in GCC 5+
     endif()
+    if(CV_CLANG AND NOT CMAKE_CXX_COMPILER_VERSION VERSION_LESS 10.0)
+      add_extra_compiler_option(-Wno-deprecated-enum-enum-conversion)
+      add_extra_compiler_option(-Wno-deprecated-anon-enum-enum-conversion)
+    endif()
   endif()
   add_extra_compiler_option(-fdiagnostics-show-option)
 

--- a/modules/core/include/opencv2/core/mat.inl.hpp
+++ b/modules/core/include/opencv2/core/mat.inl.hpp
@@ -54,13 +54,19 @@
 #pragma warning( disable: 4127 )
 #endif
 
-#if defined(__clang__) && defined(__has_warning)
-#if __has_warning("-Wdeprecated-enum-enum-conversion") && __has_warning("-Wdeprecated-anon-enum-enum-conversion")
-#define DISABLE_CLANG_ENUM_WARNINGS
+#if defined(CV_SKIP_DISABLE_CLANG_ENUM_WARNINGS)
+  // nothing
+#elif defined(CV_FORCE_DISABLE_CLANG_ENUM_WARNINGS)
+  #define CV_DISABLE_CLANG_ENUM_WARNINGS
+#elif defined(__clang__) && defined(__has_warning)
+  #if __has_warning("-Wdeprecated-enum-enum-conversion") && __has_warning("-Wdeprecated-anon-enum-enum-conversion")
+    #define CV_DISABLE_CLANG_ENUM_WARNINGS
+  #endif
+#endif
+#ifdef CV_DISABLE_CLANG_ENUM_WARNINGS
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdeprecated-enum-enum-conversion"
 #pragma clang diagnostic ignored "-Wdeprecated-anon-enum-enum-conversion"
-#endif
 #endif
 
 namespace cv
@@ -4043,8 +4049,8 @@ inline void UMatData::markDeviceCopyObsolete(bool flag)
 #pragma warning( pop )
 #endif
 
-#ifdef DISABLE_CLANG_ENUM_WARNINGS
-#undef DISABLE_CLANG_ENUM_WARNINGS
+#ifdef CV_DISABLE_CLANG_ENUM_WARNINGS
+#undef CV_DISABLE_CLANG_ENUM_WARNINGS
 #pragma clang diagnostic pop
 #endif
 

--- a/modules/core/include/opencv2/core/mat.inl.hpp
+++ b/modules/core/include/opencv2/core/mat.inl.hpp
@@ -54,6 +54,15 @@
 #pragma warning( disable: 4127 )
 #endif
 
+#if defined(__clang__) && defined(__has_warning)
+#if __has_warning("-Wdeprecated-enum-enum-conversion") && __has_warning("-Wdeprecated-anon-enum-enum-conversion")
+#define DISABLE_CLANG_ENUM_WARNINGS
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-enum-enum-conversion"
+#pragma clang diagnostic ignored "-Wdeprecated-anon-enum-enum-conversion"
+#endif
+#endif
+
 namespace cv
 {
 CV__DEBUG_NS_BEGIN
@@ -4032,6 +4041,11 @@ inline void UMatData::markDeviceCopyObsolete(bool flag)
 
 #ifdef _MSC_VER
 #pragma warning( pop )
+#endif
+
+#ifdef DISABLE_CLANG_ENUM_WARNINGS
+#undef DISABLE_CLANG_ENUM_WARNINGS
+#pragma clang diagnostic pop
 #endif
 
 #endif


### PR DESCRIPTION
Recent versions of `clang` emit warnings for deprecated `enum` + `other_enum` expressions ([Compiler Explorer Example](https://godbolt.org/z/KDQL6c)). 

`mat.inl.hpp` relies quite extensively on those expressions for joining flags, which shows when using OpenCV with the latest Emscripten release for example.

As a least-intrusive option, I added a local `clang diagnostic ignored` pragma for this warning type.

```
buildworker:Custom=linux-1
build_image:Custom=ubuntu-clang:18.04
```