### PR TITLE
G-API: Include <imgproc.hpp> to <render.hpp>

### DIFF
--- a/modules/gapi/src/api/render.cpp
+++ b/modules/gapi/src/api/render.cpp
@@ -2,7 +2,6 @@
 
 #include <stdexcept>
 
-#include <opencv2/imgproc.hpp>
 #include <opencv2/gapi/render/render.hpp>
 #include <opencv2/gapi/own/assert.hpp>
 


### PR DESCRIPTION
### Added #include<imgproc.hpp> to <render.hpp>
Integer parameters to Drawing primitives require definitions from `imgproc.hpp` which is not included by default.


`#include <opencv2/imgproc.hpp>` already exists in `render.hpp`

Removed `#include <opencv2/imgproc.hpp>`  from `render.cpp`

