### PR TITLE
ONNX: Add support for Style trasfer models, ONNX model zoo

### DIFF
--- a/modules/dnn/src/graph_simplifier.cpp
+++ b/modules/dnn/src/graph_simplifier.cpp
@@ -194,15 +194,14 @@ void simplifySubgraphs(const Ptr<ImportGraphWrapper>& net,
 {
     int numNodes = net->getNumNodes();
     std::vector<int> matchedNodesIds, targetNodesIds;
-    for (int i = 0; i < numNodes; ++i)
+    for (int j = 0; j < patterns.size(); ++j)
     {
-        for (int j = 0; j < patterns.size(); ++j)
+        for (int i = 0; i < numNodes; ++i)
         {
             if (patterns[j]->match(net, i, matchedNodesIds, targetNodesIds))
             {
                 patterns[j]->replace(net, matchedNodesIds, targetNodesIds);
                 numNodes -= matchedNodesIds.size() - 1;  // #matchedNodes removed and one added.
-                break;
             }
         }
     }

--- a/modules/dnn/test/test_onnx_importer.cpp
+++ b/modules/dnn/test/test_onnx_importer.cpp
@@ -320,6 +320,7 @@ TEST_P(Test_ONNX_layers, ResizeUnfused)
 {
     if (backend == DNN_BACKEND_INFERENCE_ENGINE_NN_BUILDER_2019)
         applyTestTag(CV_TEST_TAG_DNN_SKIP_IE_NN_BUILDER);
+    testONNXModels("upsample_unfused_torch1.2");
     testONNXModels("upsample_unfused_opset9_torch1.4");
     testONNXModels("resize_nearest_unfused_opset11_torch1.4");
     testONNXModels("resize_nearest_unfused_opset11_torch1.3");


### PR DESCRIPTION
resolves #16707 

**Merge with extra**: [opencv/opencv_extra#719](https://github.com/opencv/opencv_extra/pull/719)

`opencv_extra=cvonnx`

### Pull Request Readiness Checklist

- [x] I agree to contribute to the project under OpenCV (BSD) License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [x] The PR is proposed to proper branch
- [x] There is reference to original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake

### This PR adds :
1. Gather-Cast subgraph fusion
2. Mul-Cast subgraph fusion

### Detailed Description
Different Pytorch versions create different subgraphs, according to what I have observed till now, the difference is only because of presence or absence of cast layer after Gather and Mul layer. The idea is to fuse Gather-Cast and Mul-Cast . Hence presence or absence of Cast layer wouldn't make any affect on loading of model.

Below attached, three different subgraphs obtained using same code but different pytorch versions. Producer of Fast style transfer models is Pytorch 1.1, which is middle subgraph in attached image . PR [#16573](https://github.com/opencv/opencv/pull/16573) added support for only first subgraph. This PR adds support for all three subgraphs. 

![Screenshot from 2020-03-01 20-28-02](https://user-images.githubusercontent.com/26292819/75628022-4160c000-5bfb-11ea-91a8-fe139e2b6c5a.png)


### Merging these changes 
would allow loading of all [Style trasfer models](https://github.com/onnx/models/tree/master/vision/style_transfer/fast_neural_style) of ONNX model Zoo which includes:
- Mosaic 
- Candy 
- Rain Princess 
- Udnie 
- Pointilism

```
force_builders=Custom,Custom Win,Custom Mac
build_image:Custom=ubuntu-openvino-2020.1.0:16.04
build_image:Custom Win=openvino-2020.1.0
build_image:Custom Mac=openvino-2020.1.0

test_modules:Custom=dnn,python2,python3,java
test_modules:Custom Win=dnn,python2,python3,java
test_modules:Custom Mac=dnn,python2,python3,java

buildworker:Custom=linux-1
# disabled due high memory usage: test_opencl:Custom=ON
test_opencl:Custom=OFF
test_bigdata:Custom=1
test_filter:Custom=*
```