### PR TITLE
KW: G-API tests - fixes for uninitialized variables

### DIFF
--- a/modules/gapi/test/gapi_opaque_tests.cpp
+++ b/modules/gapi/test/gapi_opaque_tests.cpp
@@ -37,7 +37,7 @@ G_TYPED_KERNEL(PaintPoint, <GMat(GPointOpaque, int, int, cv::Size)>, "test.opaqu
 };
 
 struct MyCustomType{
-    int num;
+    int num = -1;
     std::string s;
 };
 


### PR DESCRIPTION
This fixes Static Analyses issues in G-API tests. 

` MyCustomType::num` member is not initialized by default, because: 
- it is  built-in type
- it has no (c++11 style) default member initializer 
- class `MyCustomType` has no user-defined default constructor 

So KW is right here , and some  kind of initialization should be added

@dmatveev  please review 
@smirnov-alexey , FYI