### PR TITLE
MSMF: fixed issue with camera format selection

### DIFF
--- a/modules/videoio/src/cap_msmf.cpp
+++ b/modules/videoio/src/cap_msmf.cpp
@@ -498,7 +498,7 @@ public:
                 best = *i;
                 break;
             }
-            if (i->second.isBetterThan(best.second, newType))
+            if (best.second.isEmpty() || i->second.isBetterThan(best.second, newType))
             {
                 best = *i;
             }


### PR DESCRIPTION
resolves #16711

Default resolution for camera is set to `640x480`, if camera supports only greater resolutions, the detection process fails to select them because starting value of `0x0` is considered closer to `640x480` than to e.g. `1920x960`.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under OpenCV (BSD) License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [x] The PR is proposed to proper branch
- [x] There is reference to original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
