### PR TITLE
Some debian package manager tweaks

### DIFF
--- a/modules/videoio/misc/plugin_ffmpeg/Dockerfile-ffmpeg
+++ b/modules/videoio/misc/plugin_ffmpeg/Dockerfile-ffmpeg
@@ -1,6 +1,6 @@
 FROM ubuntu:18.04
 
-RUN apt-get update && apt-get install -y \
+RUN apt-get update && apt-get --no-install-recommends install -y \
         pkg-config \
         cmake \
         g++ \

--- a/modules/videoio/misc/plugin_ffmpeg/Dockerfile-ubuntu
+++ b/modules/videoio/misc/plugin_ffmpeg/Dockerfile-ubuntu
@@ -1,7 +1,7 @@
 ARG VER
 FROM ubuntu:$VER
 
-RUN apt-get update && apt-get install -y \
+RUN apt-get update && apt-get --no-install-recommends install -y \
         libavcodec-dev \
         libavfilter-dev \
         libavformat-dev \

--- a/modules/videoio/misc/plugin_gstreamer/Dockerfile
+++ b/modules/videoio/misc/plugin_gstreamer/Dockerfile
@@ -1,6 +1,6 @@
 FROM ubuntu:18.04
 
-RUN apt-get update && apt-get install -y \
+RUN apt-get update && apt-get --no-install-recommends install -y \
         libgstreamer-plugins-base1.0-dev \
         libgstreamer-plugins-good1.0-dev \
         libgstreamer1.0-dev \


### PR DESCRIPTION
By default, Ubuntu or Debian based "apt" or "apt-get" system installs recommended but not suggested packages . 

By passing "--no-install-recommends" option, the user lets apt-get know not to consider recommended packages as a dependency to install.

This results in smaller downloads and installation of packages .

Refer to blog at [Ubuntu Blog](https://ubuntu.com/blog/we-reduced-our-docker-images-by-60-with-no-install-recommends) .

results in smaller image size.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [ ] I agree to contribute to the project under OpenCV (BSD) License.
- [ ] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [ ] The PR is proposed to proper branch
- [ ] There is reference to original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
