### PR TITLE
cmake: allow extra compile options for tests

### DIFF
--- a/cmake/OpenCVModule.cmake
+++ b/cmake/OpenCVModule.cmake
@@ -1111,6 +1111,8 @@ macro(__ocv_parse_test_sources tests_type)
   unset(__currentvar)
 endmacro()
 
+ocv_check_environment_variables(OPENCV_TEST_EXTRA_CXX_FLAGS_Release)
+
 # this is a command for adding OpenCV performance tests to the module
 # ocv_add_perf_tests(<extra_dependencies>)
 function(ocv_add_perf_tests)
@@ -1255,6 +1257,10 @@ function(ocv_add_accuracy_tests)
 
       if(NOT BUILD_opencv_world)
         _ocv_add_precompiled_headers(${the_target})
+      endif()
+
+      if(OPENCV_TEST_EXTRA_CXX_FLAGS_Release)
+        target_compile_options(${the_target} PRIVATE "$<$<CONFIG:Release>:${OPENCV_TEST_EXTRA_CXX_FLAGS_Release}>")
       endif()
 
       ocv_add_test_from_target("${the_target}" "Accuracy" "${the_target}")


### PR DESCRIPTION
Goal is tuning of build process for OpenCV accuracy tests:
- speedup through applying `-O1` instead of regular `-O3`/`-O2`
- add extra debug symbols
- or smaller size (`-Os`)
- emulate user's `-ffast-math`
- etc

<cut/>

Results (i5-6600, PCH and ccache are OFF, "-O1" override, GCC 9):
- opencv_test_core: 1:47.16 => 1:13.43
- opencv_test_gapi: 1:24.94 => 1.01:04