### PR TITLE
Support for MobileNetV3-SSD from TensorFlow

### DIFF
--- a/modules/dnn/test/test_tf_importer.cpp
+++ b/modules/dnn/test/test_tf_importer.cpp
@@ -181,6 +181,13 @@ TEST_P(Test_TensorFlow_layers, eltwise)
     runTensorFlowNet("eltwise_sub");
 }
 
+TEST_P(Test_TensorFlow_layers, channel_broadcast)
+{
+    if (backend == DNN_BACKEND_INFERENCE_ENGINE_NN_BUILDER_2019)
+        applyTestTag(CV_TEST_TAG_DNN_SKIP_IE_NN_BUILDER);
+    runTensorFlowNet("channel_broadcast");
+}
+
 TEST_P(Test_TensorFlow_layers, pad_and_concat)
 {
     runTensorFlowNet("pad_and_concat");

--- a/samples/dnn/tf_text_graph_ssd.py
+++ b/samples/dnn/tf_text_graph_ssd.py
@@ -64,7 +64,7 @@ def createSSDGraph(modelPath, configPath, outputPath):
     # Nodes that should be kept.
     keepOps = ['Conv2D', 'BiasAdd', 'Add', 'AddV2', 'Relu', 'Relu6', 'Placeholder', 'FusedBatchNorm',
                'DepthwiseConv2dNative', 'ConcatV2', 'Mul', 'MaxPool', 'AvgPool', 'Identity',
-               'Sub', 'ResizeNearestNeighbor', 'Pad', 'FusedBatchNormV3']
+               'Sub', 'ResizeNearestNeighbor', 'Pad', 'FusedBatchNormV3', 'Mean']
 
     # Node with which prefixes should be removed
     prefixesToRemove = ('MultipleGridAnchorGenerator/', 'Concatenate/', 'Postprocessor/', 'Preprocessor/map')
@@ -235,7 +235,7 @@ def createSSDGraph(modelPath, configPath, outputPath):
     # Connect input node to the first layer
     assert(graph_def.node[0].op == 'Placeholder')
     # assert(graph_def.node[1].op == 'Conv2D')
-    weights = graph_def.node[1].input[0]
+    weights = graph_def.node[1].input[-1]
     for i in range(len(graph_def.node[1].input)):
         graph_def.node[1].input.pop()
     graph_def.node[1].input.append(graph_def.node[0].name)


### PR DESCRIPTION
### Pull Request Readiness Checklist

**Merge with extra**: https://github.com/opencv/opencv_extra/pull/725

Add support for MobileNetV3  SSD from TensorFlow Object Detection API: https://github.com/tensorflow/models/blob/master/research/object_detection/g3doc/detection_model_zoo.md#mobile-models

Follow a guide to run the model: https://github.com/opencv/opencv/wiki/TensorFlow-Object-Detection-API

**NOTE**: considering discussion https://github.com/tensorflow/models/issues/7727, only updated models work correctly: https://github.com/tensorflow/models/pull/8057

**NOTE**: comparing to other SSD networks, these models expect normalized inputs (`[-1, 1]` input range):

```python
import cv2 as cv

net = cv.dnn_DetectionModel('frozen_inference_graph.pb', 'graph.pbtxt')
net.setInputSize(320, 320)
net.setInputScale(1.0 / 127.5)
net.setInputMean((127.5, 127.5, 127.5))
net.setInputSwapRB(True)

frame = cv.imread('example.jpg')

classes, confidences, boxes = net.detect(frame, confThreshold=0.5)

for classId, confidence, box in zip(classes.flatten(), confidences.flatten(), boxes):
    print(classId, confidence)
    cv.rectangle(frame, box, color=(0, 255, 0))

cv.imshow('out', frame)
cv.waitKey()
```

![res](https://user-images.githubusercontent.com/25801568/76167741-0ff76f80-617a-11ea-93a5-690eb9746ae4.jpg)

```
force_builders=Custom,Custom Win,Custom Mac
build_image:Custom=ubuntu-openvino-2020.1.0:16.04
build_image:Custom Win=openvino-2020.1.0
build_image:Custom Mac=openvino-2020.1.0

test_modules:Custom=dnn,python2,python3,java
test_modules:Custom Win=dnn,python2,python3,java
test_modules:Custom Mac=dnn,python2,python3,java

buildworker:Custom=linux-1
# disabled due high memory usage: test_opencl:Custom=ON
test_opencl:Custom=OFF
test_bigdata:Custom=1
test_filter:Custom=*
```

