### PR TITLE
feature: Extend VideoWriter to accept vector of parameters

### DIFF
--- a/modules/videoio/include/opencv2/videoio.hpp
+++ b/modules/videoio/include/opencv2/videoio.hpp
@@ -191,7 +191,7 @@ enum VideoWriterProperties {
   VIDEOWRITER_PROP_FRAMEBYTES = 2, //!< (Read-only): Size of just encoded video frame. Note that the encoding order may be different from representation order.
   VIDEOWRITER_PROP_NSTRIPES = 3,   //!< Number of stripes for parallel encoding. -1 for auto detection.
   VIDEOWRITER_PROP_IS_COLOR = 4    //!< If it is not zero, the encoder will expect and encode color frames, otherwise it
-                                   //!< will work with grayscale frames (the flag is ignored on MSMF and Intel MFX backends)
+                                   //!< will work with grayscale frames.
 };
 
 //! @} videoio_flags_base
@@ -878,7 +878,7 @@ public:
     @param fps Framerate of the created video stream.
     @param frameSize Size of the video frames.
     @param isColor If it is not zero, the encoder will expect and encode color frames, otherwise it
-    will work with grayscale frames (the flag is ignored on MSMF and Intel MFX backends).
+    will work with grayscale frames.
 
     @b Tips:
     - With some backends `fourcc=-1` pops up the codec selection dialog from the system.

--- a/modules/videoio/include/opencv2/videoio.hpp
+++ b/modules/videoio/include/opencv2/videoio.hpp
@@ -191,7 +191,7 @@ enum VideoWriterProperties {
   VIDEOWRITER_PROP_FRAMEBYTES = 2, //!< (Read-only): Size of just encoded video frame. Note that the encoding order may be different from representation order.
   VIDEOWRITER_PROP_NSTRIPES = 3,   //!< Number of stripes for parallel encoding. -1 for auto detection.
   VIDEOWRITER_PROP_IS_COLOR = 4    //!< If it is not zero, the encoder will expect and encode color frames, otherwise it
-                                   //!< will work with grayscale frames (the flag is currently supported on Windows only)
+                                   //!< will work with grayscale frames (the flag is ignored on MSMF and Intel MFX backends)
 };
 
 //! @} videoio_flags_base
@@ -878,7 +878,7 @@ public:
     @param fps Framerate of the created video stream.
     @param frameSize Size of the video frames.
     @param isColor If it is not zero, the encoder will expect and encode color frames, otherwise it
-    will work with grayscale frames (the flag is currently supported on Windows only).
+    will work with grayscale frames (the flag is ignored on MSMF and Intel MFX backends).
 
     @b Tips:
     - With some backends `fourcc=-1` pops up the codec selection dialog from the system.

--- a/modules/videoio/include/opencv2/videoio.hpp
+++ b/modules/videoio/include/opencv2/videoio.hpp
@@ -189,7 +189,9 @@ enum VideoCaptureProperties {
 enum VideoWriterProperties {
   VIDEOWRITER_PROP_QUALITY = 1,    //!< Current quality (0..100%) of the encoded videostream. Can be adjusted dynamically in some codecs.
   VIDEOWRITER_PROP_FRAMEBYTES = 2, //!< (Read-only): Size of just encoded video frame. Note that the encoding order may be different from representation order.
-  VIDEOWRITER_PROP_NSTRIPES = 3    //!< Number of stripes for parallel encoding. -1 for auto detection.
+  VIDEOWRITER_PROP_NSTRIPES = 3,   //!< Number of stripes for parallel encoding. -1 for auto detection.
+  VIDEOWRITER_PROP_IS_COLOR = 4    //!< If it is not zero, the encoder will expect and encode color frames, otherwise it
+                                   //!< will work with grayscale frames (the flag is currently supported on Windows only)
 };
 
 //! @} videoio_flags_base
@@ -896,6 +898,19 @@ public:
     CV_WRAP VideoWriter(const String& filename, int apiPreference, int fourcc, double fps,
                 Size frameSize, bool isColor = true);
 
+    /** @overload
+     *
+     * @param params Encoder parameters encoded as pairs (paramId_1, paramValue_1, paramId_2, paramValue_2, ... .)
+     * see cv::VideoWriterProperties
+     */
+    CV_WRAP VideoWriter(const String& filename, int fourcc, double fps, const Size& frameSize,
+                        const std::vector<int>& params);
+
+    /** @overload
+     */
+    CV_WRAP VideoWriter(const String& filename, int apiPreference, int fourcc, double fps,
+                        const Size& frameSize, const std::vector<int>& params);
+
     /** @brief Default destructor
 
     The method first calls VideoWriter::release to close the already opened file.
@@ -917,6 +932,16 @@ public:
      */
     CV_WRAP bool open(const String& filename, int apiPreference, int fourcc, double fps,
                       Size frameSize, bool isColor = true);
+
+    /** @overload
+     */
+    CV_WRAP bool open(const String& filename, int fourcc, double fps, const Size& frameSize,
+                      const std::vector<int>& params);
+
+    /** @overload
+     */
+    CV_WRAP bool open(const String& filename, int apiPreference, int fourcc, double fps,
+                      const Size& frameSize, const std::vector<int>& params);
 
     /** @brief Returns true if video writer has been successfully initialized.
     */

--- a/modules/videoio/include/opencv2/videoio.hpp
+++ b/modules/videoio/include/opencv2/videoio.hpp
@@ -899,8 +899,7 @@ public:
                 Size frameSize, bool isColor = true);
 
     /** @overload
-     *
-     * @param params Encoder parameters encoded as pairs (paramId_1, paramValue_1, paramId_2, paramValue_2, ... .)
+     * The `params` parameter allows to specify extra encoder parameters encoded as pairs (paramId_1, paramValue_1, paramId_2, paramValue_2, ... .)
      * see cv::VideoWriterProperties
      */
     CV_WRAP VideoWriter(const String& filename, int fourcc, double fps, const Size& frameSize,

--- a/modules/videoio/src/backend.hpp
+++ b/modules/videoio/src/backend.hpp
@@ -9,6 +9,7 @@
 #include "opencv2/videoio/registry.hpp"
 
 namespace cv {
+
 // TODO: move to public interface
 // TODO: allow runtime backend registration
 class IBackend

--- a/modules/videoio/src/backend.hpp
+++ b/modules/videoio/src/backend.hpp
@@ -9,7 +9,6 @@
 #include "opencv2/videoio/registry.hpp"
 
 namespace cv {
-
 // TODO: move to public interface
 // TODO: allow runtime backend registration
 class IBackend
@@ -18,7 +17,8 @@ public:
     virtual ~IBackend() {}
     virtual Ptr<IVideoCapture> createCapture(int camera) const = 0;
     virtual Ptr<IVideoCapture> createCapture(const std::string &filename) const = 0;
-    virtual Ptr<IVideoWriter>  createWriter(const std::string &filename, int fourcc, double fps, const cv::Size &sz, bool isColor) const = 0;
+    virtual Ptr<IVideoWriter> createWriter(const std::string& filename, int fourcc, double fps, const cv::Size& sz,
+                                           const VideoWriterParameters& params) const = 0;
 };
 
 class IBackendFactory
@@ -32,7 +32,8 @@ public:
 
 typedef Ptr<IVideoCapture> (*FN_createCaptureFile)(const std::string & filename);
 typedef Ptr<IVideoCapture> (*FN_createCaptureCamera)(int camera);
-typedef Ptr<IVideoWriter>  (*FN_createWriter)(const std::string& filename, int fourcc, double fps, const Size& sz, bool isColor);
+typedef Ptr<IVideoWriter>  (*FN_createWriter)(const std::string& filename, int fourcc, double fps, const Size& sz,
+                                              const VideoWriterParameters& params);
 Ptr<IBackendFactory> createBackendFactory(FN_createCaptureFile createCaptureFile,
                                           FN_createCaptureCamera createCaptureCamera,
                                           FN_createWriter createWriter);

--- a/modules/videoio/src/backend_plugin.cpp
+++ b/modules/videoio/src/backend_plugin.cpp
@@ -496,7 +496,7 @@ public:
         {
             CV_Assert(plugin_api->Writer_release);
             CV_Assert(!filename.empty());
-            const bool isColor = params.at(VIDEOWRITER_PROP_IS_COLOR) != 0;
+            const bool isColor = params.get(VIDEOWRITER_PROP_IS_COLOR, true);
             if (CV_ERROR_OK == plugin_api->Writer_open(filename.c_str(), fourcc, fps, sz.width, sz.height, isColor, &writer))
             {
                 CV_Assert(writer);

--- a/modules/videoio/src/backend_plugin.cpp
+++ b/modules/videoio/src/backend_plugin.cpp
@@ -240,7 +240,8 @@ public:
 
     Ptr<IVideoCapture> createCapture(int camera) const CV_OVERRIDE;
     Ptr<IVideoCapture> createCapture(const std::string &filename) const CV_OVERRIDE;
-    Ptr<IVideoWriter>  createWriter(const std::string &filename, int fourcc, double fps, const cv::Size &sz, bool isColor) const CV_OVERRIDE;
+    Ptr<IVideoWriter> createWriter(const std::string& filename, int fourcc, double fps,
+                                   const cv::Size& sz, const VideoWriterParameters& params) const CV_OVERRIDE;
 };
 
 class PluginBackendFactory : public IBackendFactory
@@ -486,7 +487,8 @@ class PluginWriter : public cv::IVideoWriter
 public:
     static
     Ptr<PluginWriter> create(const OpenCV_VideoIO_Plugin_API_preview* plugin_api,
-            const std::string &filename, int fourcc, double fps, const cv::Size &sz, bool isColor)
+            const std::string& filename, int fourcc, double fps, const cv::Size& sz,
+            const VideoWriterParameters& params)
     {
         CV_Assert(plugin_api);
         CvPluginWriter writer = NULL;
@@ -494,6 +496,7 @@ public:
         {
             CV_Assert(plugin_api->Writer_release);
             CV_Assert(!filename.empty());
+            const bool isColor = params.at(VIDEOWRITER_PROP_IS_COLOR) != 0;
             if (CV_ERROR_OK == plugin_api->Writer_open(filename.c_str(), fourcc, fps, sz.width, sz.height, isColor, &writer))
             {
                 CV_Assert(writer);
@@ -581,12 +584,13 @@ Ptr<IVideoCapture> PluginBackend::createCapture(const std::string &filename) con
     return Ptr<IVideoCapture>();
 }
 
-Ptr<IVideoWriter> PluginBackend::createWriter(const std::string &filename, int fourcc, double fps, const cv::Size &sz, bool isColor) const
+Ptr<IVideoWriter> PluginBackend::createWriter(const std::string& filename, int fourcc, double fps,
+                                              const cv::Size& sz, const VideoWriterParameters& params) const
 {
     try
     {
         if (plugin_api_)
-            return PluginWriter::create(plugin_api_, filename, fourcc, fps, sz, isColor); //.staticCast<IVideoWriter>();
+            return PluginWriter::create(plugin_api_, filename, fourcc, fps, sz, params); //.staticCast<IVideoWriter>();
     }
     catch (...)
     {

--- a/modules/videoio/src/backend_static.cpp
+++ b/modules/videoio/src/backend_static.cpp
@@ -34,10 +34,11 @@ public:
             return fn_createCaptureFile_(filename);
         return Ptr<IVideoCapture>();
     }
-    Ptr<IVideoWriter> createWriter(const std::string &filename, int fourcc, double fps, const cv::Size &sz, bool isColor) const CV_OVERRIDE
+    Ptr<IVideoWriter> createWriter(const std::string& filename, int fourcc, double fps,
+                                   const cv::Size& sz, const VideoWriterParameters& params) const CV_OVERRIDE
     {
         if (fn_createWriter_)
-            return fn_createWriter_(filename, fourcc, fps, sz, isColor);
+            return fn_createWriter_(filename, fourcc, fps, sz, params);
         return Ptr<IVideoWriter>();
     }
 }; // StaticBackend

--- a/modules/videoio/src/cap.cpp
+++ b/modules/videoio/src/cap.cpp
@@ -535,6 +535,15 @@ bool VideoWriter::open(const String& filename, int apiPreference, int fourcc, do
                         CV_WRITER_LOG_DEBUG(NULL,
                                             cv::format("VIDEOIO(%s): created, isOpened=%d",
                                                        info.name, iwriter->isOpened()));
+                        if (param_VIDEOIO_DEBUG || param_VIDEOWRITER_DEBUG)
+                        {
+                            for (int key: parameters.getUnused())
+                            {
+                                CV_LOG_WARNING(NULL,
+                                               cv::format("VIDEOIO(%s): parameter with key '%d' was unused",
+                                                          info.name, key));
+                            }
+                        }
                         if (iwriter->isOpened())
                         {
                             return true;

--- a/modules/videoio/src/cap_avfoundation.mm
+++ b/modules/videoio/src/cap_avfoundation.mm
@@ -221,9 +221,12 @@ cv::Ptr<cv::IVideoCapture> cv::create_AVFoundation_capture_cam(int index)
     return 0;
 }
 
-cv::Ptr<cv::IVideoWriter> cv::create_AVFoundation_writer(const std::string& filename, int fourcc, double fps, const cv::Size &frameSize, bool isColor)
+cv::Ptr<cv::IVideoWriter> cv::create_AVFoundation_writer(const std::string& filename, int fourcc,
+                                                         double fps, const cv::Size &frameSize,
+                                                         const cv::VideoWriterParameters& params)
 {
     CvSize sz = { frameSize.width, frameSize.height };
+    const bool isColor = params.at(VIDEOWRITER_PROP_IS_COLOR) != 0;
     CvVideoWriter_AVFoundation* wrt = new CvVideoWriter_AVFoundation(filename.c_str(), fourcc, fps, sz, isColor);
     return cv::makePtr<cv::LegacyWriter>(wrt);
 }

--- a/modules/videoio/src/cap_avfoundation.mm
+++ b/modules/videoio/src/cap_avfoundation.mm
@@ -226,7 +226,7 @@ cv::Ptr<cv::IVideoWriter> cv::create_AVFoundation_writer(const std::string& file
                                                          const cv::VideoWriterParameters& params)
 {
     CvSize sz = { frameSize.width, frameSize.height };
-    const bool isColor = params.at(VIDEOWRITER_PROP_IS_COLOR) != 0;
+    const bool isColor = params.get(VIDEOWRITER_PROP_IS_COLOR, true);
     CvVideoWriter_AVFoundation* wrt = new CvVideoWriter_AVFoundation(filename.c_str(), fourcc, fps, sz, isColor);
     return cv::makePtr<cv::LegacyWriter>(wrt);
 }

--- a/modules/videoio/src/cap_avfoundation_mac.mm
+++ b/modules/videoio/src/cap_avfoundation_mac.mm
@@ -231,9 +231,12 @@ cv::Ptr<cv::IVideoCapture> cv::create_AVFoundation_capture_cam(int index)
     return 0;
 }
 
-cv::Ptr<cv::IVideoWriter> cv::create_AVFoundation_writer(const std::string& filename, int fourcc, double fps, const cv::Size &frameSize, bool isColor)
+cv::Ptr<cv::IVideoWriter> cv::create_AVFoundation_writer(const std::string& filename, int fourcc,
+                                                         double fps, const cv::Size& frameSize,
+                                                         const cv::VideoWriterParameters& params)
 {
     CvSize sz = { frameSize.width, frameSize.height };
+    const bool isColor = params.at(VIDEOWRITER_PROP_IS_COLOR);
     CvVideoWriter_AVFoundation* wrt = new CvVideoWriter_AVFoundation(filename, fourcc, fps, sz, isColor);
     if (wrt->isOpened())
     {

--- a/modules/videoio/src/cap_avfoundation_mac.mm
+++ b/modules/videoio/src/cap_avfoundation_mac.mm
@@ -236,7 +236,7 @@ cv::Ptr<cv::IVideoWriter> cv::create_AVFoundation_writer(const std::string& file
                                                          const cv::VideoWriterParameters& params)
 {
     CvSize sz = { frameSize.width, frameSize.height };
-    const bool isColor = params.at(VIDEOWRITER_PROP_IS_COLOR);
+    const bool isColor = params.get(VIDEOWRITER_PROP_IS_COLOR, true);
     CvVideoWriter_AVFoundation* wrt = new CvVideoWriter_AVFoundation(filename, fourcc, fps, sz, isColor);
     if (wrt->isOpened())
     {

--- a/modules/videoio/src/cap_ffmpeg.cpp
+++ b/modules/videoio/src/cap_ffmpeg.cpp
@@ -174,7 +174,7 @@ cv::Ptr<cv::IVideoWriter> cvCreateVideoWriter_FFMPEG_proxy(const std::string& fi
                                                            double fps, const cv::Size& frameSize,
                                                            const VideoWriterParameters& params)
 {
-    const bool isColor = params.at(VIDEOWRITER_PROP_IS_COLOR) != 0;
+    const bool isColor = params.get(VIDEOWRITER_PROP_IS_COLOR, true);
     cv::Ptr<CvVideoWriter_FFMPEG_proxy> writer = cv::makePtr<CvVideoWriter_FFMPEG_proxy>(filename, fourcc, fps, frameSize, isColor);
     if (writer && writer->isOpened())
         return writer;

--- a/modules/videoio/src/cap_ffmpeg.cpp
+++ b/modules/videoio/src/cap_ffmpeg.cpp
@@ -170,9 +170,12 @@ protected:
 
 } // namespace
 
-cv::Ptr<cv::IVideoWriter> cvCreateVideoWriter_FFMPEG_proxy(const std::string& filename, int fourcc, double fps, const cv::Size &frameSize, bool isColor)
+cv::Ptr<cv::IVideoWriter> cvCreateVideoWriter_FFMPEG_proxy(const std::string& filename, int fourcc,
+                                                           double fps, const cv::Size& frameSize,
+                                                           const VideoWriterParameters& params)
 {
-    cv::Ptr<CvVideoWriter_FFMPEG_proxy> writer = cv::makePtr<CvVideoWriter_FFMPEG_proxy>(filename, fourcc, fps, frameSize, isColor != 0);
+    const bool isColor = params.at(VIDEOWRITER_PROP_IS_COLOR) != 0;
+    cv::Ptr<CvVideoWriter_FFMPEG_proxy> writer = cv::makePtr<CvVideoWriter_FFMPEG_proxy>(filename, fourcc, fps, frameSize, isColor);
     if (writer && writer->isOpened())
         return writer;
     return cv::Ptr<cv::IVideoWriter>();

--- a/modules/videoio/src/cap_gstreamer.cpp
+++ b/modules/videoio/src/cap_gstreamer.cpp
@@ -1673,9 +1673,11 @@ bool CvVideoWriter_GStreamer::writeFrame( const IplImage * image )
     return true;
 }
 
-Ptr<IVideoWriter> create_GStreamer_writer(const std::string &filename, int fourcc, double fps, const cv::Size &frameSize, bool isColor)
+Ptr<IVideoWriter> create_GStreamer_writer(const std::string& filename, int fourcc, double fps,
+                                          const cv::Size& frameSize, const VideoWriterParameters& params)
 {
     CvVideoWriter_GStreamer* wrt = new CvVideoWriter_GStreamer;
+    const bool isColor = params.at(VIDEOWRITER_PROP_IS_COLOR) != 0;
     try
     {
         if (wrt->open(filename, fourcc, fps, frameSize, isColor))

--- a/modules/videoio/src/cap_gstreamer.cpp
+++ b/modules/videoio/src/cap_gstreamer.cpp
@@ -1677,7 +1677,7 @@ Ptr<IVideoWriter> create_GStreamer_writer(const std::string& filename, int fourc
                                           const cv::Size& frameSize, const VideoWriterParameters& params)
 {
     CvVideoWriter_GStreamer* wrt = new CvVideoWriter_GStreamer;
-    const bool isColor = params.at(VIDEOWRITER_PROP_IS_COLOR) != 0;
+    const bool isColor = params.get(VIDEOWRITER_PROP_IS_COLOR, true);
     try
     {
         if (wrt->open(filename, fourcc, fps, frameSize, isColor))

--- a/modules/videoio/src/cap_images.cpp
+++ b/modules/videoio/src/cap_images.cpp
@@ -429,7 +429,8 @@ bool CvVideoWriter_Images::setProperty( int id, double value )
     return false; // not supported
 }
 
-Ptr<IVideoWriter> create_Images_writer(const std::string &filename, int, double, const Size &, bool)
+Ptr<IVideoWriter> create_Images_writer(const std::string &filename, int, double, const Size &,
+    const cv::VideoWriterParameters&)
 {
     CvVideoWriter_Images *writer = new CvVideoWriter_Images;
 

--- a/modules/videoio/src/cap_interface.hpp
+++ b/modules/videoio/src/cap_interface.hpp
@@ -43,7 +43,7 @@ public:
     struct VideoWriterParameter {
         VideoWriterParameter() = default;
 
-        VideoWriterParameter(int key, int value) : key(key), value(value) {}
+        VideoWriterParameter(int key_, int value_) : key(key_), value(value_) {}
 
         int key{-1};
         int value{-1};
@@ -88,6 +88,18 @@ public:
         {
             return defaultValue;
         }
+    }
+
+    std::vector<int> getUnused() const CV_NOEXCEPT {
+        std::vector<int> unusedParams;
+        for (const auto &param : params_)
+        {
+            if (!param.isConsumed)
+            {
+                unusedParams.push_back(param.key);
+            }
+        }
+        return unusedParams;
     }
 private:
     std::vector<VideoWriterParameter> params_;

--- a/modules/videoio/src/cap_interface.hpp
+++ b/modules/videoio/src/cap_interface.hpp
@@ -10,6 +10,8 @@
 #include "opencv2/videoio.hpp"
 #include "opencv2/videoio/videoio_c.h"
 
+#include <map>
+
 //===================================================
 
 // Legacy structs
@@ -37,6 +39,7 @@ struct CvVideoWriter
 
 namespace cv
 {
+using VideoWriterParameters = std::map<int, int>;
 
 class IVideoCapture
 {
@@ -168,24 +171,34 @@ public:
 //==================================================================================================
 
 Ptr<IVideoCapture> cvCreateFileCapture_FFMPEG_proxy(const std::string &filename);
-Ptr<IVideoWriter> cvCreateVideoWriter_FFMPEG_proxy(const std::string& filename, int fourcc, double fps, const Size &frameSize, bool isColor);
+Ptr<IVideoWriter> cvCreateVideoWriter_FFMPEG_proxy(const std::string& filename, int fourcc,
+                                                   double fps, const Size& frameSize,
+                                                   const VideoWriterParameters& params);
 
 Ptr<IVideoCapture> createGStreamerCapture_file(const std::string& filename);
 Ptr<IVideoCapture> createGStreamerCapture_cam(int index);
-Ptr<IVideoWriter> create_GStreamer_writer(const std::string& filename, int fourcc, double fps, const Size &frameSize, bool isColor);
+Ptr<IVideoWriter> create_GStreamer_writer(const std::string& filename, int fourcc,
+                                          double fps, const Size& frameSize,
+                                          const VideoWriterParameters& params);
 
 Ptr<IVideoCapture> create_MFX_capture(const std::string &filename);
-Ptr<IVideoWriter> create_MFX_writer(const std::string &filename, int _fourcc, double fps, const Size &frameSize, bool isColor);
+Ptr<IVideoWriter> create_MFX_writer(const std::string& filename, int _fourcc,
+                                    double fps, const Size& frameSize,
+                                    const VideoWriterParameters& params);
 
 Ptr<IVideoCapture> create_AVFoundation_capture_file(const std::string &filename);
 Ptr<IVideoCapture> create_AVFoundation_capture_cam(int index);
-Ptr<IVideoWriter> create_AVFoundation_writer(const std::string& filename, int fourcc, double fps, const Size &frameSize, bool isColor);
+Ptr<IVideoWriter> create_AVFoundation_writer(const std::string& filename, int fourcc,
+                                             double fps, const Size& frameSize,
+                                             const VideoWriterParameters& params);
 
 Ptr<IVideoCapture> create_WRT_capture(int device);
 
 Ptr<IVideoCapture> cvCreateCapture_MSMF(int index);
 Ptr<IVideoCapture> cvCreateCapture_MSMF(const std::string& filename);
-Ptr<IVideoWriter> cvCreateVideoWriter_MSMF(const std::string& filename, int fourcc, double fps, const Size &frameSize, bool is_color);
+Ptr<IVideoWriter> cvCreateVideoWriter_MSMF(const std::string& filename, int fourcc,
+                                           double fps, const Size& frameSize,
+                                           const VideoWriterParameters& params);
 
 Ptr<IVideoCapture> create_DShow_capture(int index);
 
@@ -196,7 +209,9 @@ Ptr<IVideoCapture> create_OpenNI2_capture_cam( int index );
 Ptr<IVideoCapture> create_OpenNI2_capture_file( const std::string &filename );
 
 Ptr<IVideoCapture> create_Images_capture(const std::string &filename);
-Ptr<IVideoWriter> create_Images_writer(const std::string &filename, int fourcc, double fps, const Size &frameSize, bool iscolor);
+Ptr<IVideoWriter> create_Images_writer(const std::string& filename, int fourcc,
+                                       double fps, const Size& frameSize,
+                                       const VideoWriterParameters& params);
 
 Ptr<IVideoCapture> create_DC1394_capture(int index);
 
@@ -210,7 +225,9 @@ Ptr<IVideoCapture> create_XIMEA_capture_file( const std::string &serialNumber );
 Ptr<IVideoCapture> create_Aravis_capture( int index );
 
 Ptr<IVideoCapture> createMotionJpegCapture(const std::string& filename);
-Ptr<IVideoWriter> createMotionJpegWriter(const std::string &filename, int fourcc, double fps, const Size &frameSize, bool iscolor);
+Ptr<IVideoWriter> createMotionJpegWriter(const std::string& filename, int fourcc,
+                                         double fps, const Size& frameSize,
+                                         const VideoWriterParameters& params);
 
 Ptr<IVideoCapture> createGPhoto2Capture(int index);
 Ptr<IVideoCapture> createGPhoto2Capture(const std::string& deviceName);

--- a/modules/videoio/src/cap_interface.hpp
+++ b/modules/videoio/src/cap_interface.hpp
@@ -37,6 +37,21 @@ struct CvVideoWriter
 
 namespace cv
 {
+namespace
+{
+template <class T>
+inline T castParameterTo(int paramValue)
+{
+    return static_cast<T>(paramValue);
+}
+
+template <>
+inline bool castParameterTo(int paramValue)
+{
+    return paramValue != 0;
+}
+}
+
 class VideoWriterParameters
 {
 public:
@@ -72,7 +87,7 @@ public:
         params_.emplace_back(key, value);
     }
 
-    template<class ValueType>
+    template <class ValueType>
     ValueType get(int key, ValueType defaultValue) const CV_NOEXCEPT
     {
         auto it = std::find_if(params_.begin(), params_.end(),
@@ -82,7 +97,7 @@ public:
         if (it != params_.end())
         {
             it->isConsumed = true;
-            return static_cast<ValueType>(it->value);
+            return castParameterTo<ValueType>(it->value);
         }
         else
         {

--- a/modules/videoio/src/cap_mfx_writer.cpp
+++ b/modules/videoio/src/cap_mfx_writer.cpp
@@ -251,10 +251,12 @@ bool VideoWriter_IntelMFX::write_one(cv::InputArray bgr)
     }
 }
 
-Ptr<IVideoWriter> cv::create_MFX_writer(const std::string &filename, int _fourcc, double fps, const Size &frameSize, bool isColor)
+Ptr<IVideoWriter> cv::create_MFX_writer(const std::string& filename, int _fourcc, double fps,
+                                        const Size& frameSize, const VideoWriterParameters& params)
 {
     if (codecIdByFourCC(_fourcc) > 0)
     {
+        const bool isColor = params.at(VIDEOWRITER_PROP_IS_COLOR) != 0;
         Ptr<VideoWriter_IntelMFX> a = makePtr<VideoWriter_IntelMFX>(filename, _fourcc, fps, frameSize, isColor);
         if (a->isOpened())
             return a;

--- a/modules/videoio/src/cap_mfx_writer.cpp
+++ b/modules/videoio/src/cap_mfx_writer.cpp
@@ -256,7 +256,7 @@ Ptr<IVideoWriter> cv::create_MFX_writer(const std::string& filename, int _fourcc
 {
     if (codecIdByFourCC(_fourcc) > 0)
     {
-        const bool isColor = params.at(VIDEOWRITER_PROP_IS_COLOR) != 0;
+        const bool isColor = params.get(VIDEOWRITER_PROP_IS_COLOR, true);
         Ptr<VideoWriter_IntelMFX> a = makePtr<VideoWriter_IntelMFX>(filename, _fourcc, fps, frameSize, isColor);
         if (a->isOpened())
             return a;

--- a/modules/videoio/src/cap_mjpeg_encoder.cpp
+++ b/modules/videoio/src/cap_mjpeg_encoder.cpp
@@ -1539,7 +1539,7 @@ Ptr<IVideoWriter> createMotionJpegWriter(const std::string& filename, int fourcc
     if (fourcc != CV_FOURCC('M', 'J', 'P', 'G'))
         return Ptr<IVideoWriter>();
 
-    const bool isColor = params.at(VIDEOWRITER_PROP_IS_COLOR) != 0;
+    const bool isColor = params.get(VIDEOWRITER_PROP_IS_COLOR, true);
     Ptr<IVideoWriter> iwriter = makePtr<mjpeg::MotionJpegWriter>(filename, fps, frameSize, isColor);
     if( !iwriter->isOpened() )
         iwriter.release();

--- a/modules/videoio/src/cap_mjpeg_encoder.cpp
+++ b/modules/videoio/src/cap_mjpeg_encoder.cpp
@@ -1532,12 +1532,15 @@ void MotionJpegWriter::writeFrameData( const uchar* data, int step, int colorspa
 
 }
 
-Ptr<IVideoWriter> createMotionJpegWriter(const std::string &filename, int fourcc, double fps, const Size &frameSize, bool iscolor)
+Ptr<IVideoWriter> createMotionJpegWriter(const std::string& filename, int fourcc,
+                                         double fps, const Size& frameSize,
+                                         const VideoWriterParameters& params)
 {
     if (fourcc != CV_FOURCC('M', 'J', 'P', 'G'))
         return Ptr<IVideoWriter>();
 
-    Ptr<IVideoWriter> iwriter = makePtr<mjpeg::MotionJpegWriter>(filename, fps, frameSize, iscolor);
+    const bool isColor = params.at(VIDEOWRITER_PROP_IS_COLOR) != 0;
+    Ptr<IVideoWriter> iwriter = makePtr<mjpeg::MotionJpegWriter>(filename, fps, frameSize, isColor);
     if( !iwriter->isOpened() )
         iwriter.release();
     return iwriter;

--- a/modules/videoio/src/cap_msmf.cpp
+++ b/modules/videoio/src/cap_msmf.cpp
@@ -1662,7 +1662,7 @@ cv::Ptr<cv::IVideoWriter> cv::cvCreateVideoWriter_MSMF( const std::string& filen
     cv::Ptr<CvVideoWriter_MSMF> writer = cv::makePtr<CvVideoWriter_MSMF>();
     if (writer)
     {
-        const bool isColor = params.at(VIDEOWRITER_PROP_IS_COLOR) != 0;
+        const bool isColor = params.get(VIDEOWRITER_PROP_IS_COLOR, true);
         writer->open(filename, fourcc, fps, frameSize, isColor);
         if (writer->isOpened())
             return writer;

--- a/modules/videoio/src/cap_msmf.cpp
+++ b/modules/videoio/src/cap_msmf.cpp
@@ -1656,11 +1656,13 @@ void CvVideoWriter_MSMF::write(cv::InputArray img)
 }
 
 cv::Ptr<cv::IVideoWriter> cv::cvCreateVideoWriter_MSMF( const std::string& filename, int fourcc,
-                                                        double fps, const cv::Size &frameSize, bool isColor )
+                                                        double fps, const cv::Size& frameSize,
+                                                        const VideoWriterParameters& params)
 {
     cv::Ptr<CvVideoWriter_MSMF> writer = cv::makePtr<CvVideoWriter_MSMF>();
     if (writer)
     {
+        const bool isColor = params.at(VIDEOWRITER_PROP_IS_COLOR) != 0;
         writer->open(filename, fourcc, fps, frameSize, isColor);
         if (writer->isOpened())
             return writer;


### PR DESCRIPTION
 - Added additional constructor and `open` method for `VideoWriter`
   those accept a vector of parameters
 - Moved the actual implementation of the `VideoWriter::open` to the general method
   which accepts a vector of parameters
 - Propagate parsed parameters map up to actual video backend construction

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under OpenCV (BSD) License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [x] The PR is proposed to proper branch
- [ ] There is reference to original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake

```
build_image:Custom=centos:7
buildworker:Custom=linux-1

force_builders=Custom Win
build_image:Custom Win=msvs2019
```