### PR TITLE
Do not copy standalone IPP libraries to install for static builds

### DIFF
--- a/cmake/OpenCVFindIPP.cmake
+++ b/cmake/OpenCVFindIPP.cmake
@@ -148,7 +148,7 @@ macro(ipp_detect_version)
           IMPORTED_LOCATION ${IPP_LIBRARY_DIR}/${IPP_LIB_PREFIX}${IPP_PREFIX}${name}${IPP_SUFFIX}${IPP_LIB_SUFFIX}
         )
         list(APPEND IPP_LIBRARIES ipp${name})
-        if (NOT BUILD_SHARED_LIBS)
+        if (NOT BUILD_SHARED_LIBS AND HAVE_IPP_ICV)
           # CMake doesn't support "install(TARGETS ${IPP_PREFIX}${name} " command with imported targets
           install(FILES ${IPP_LIBRARY_DIR}/${IPP_LIB_PREFIX}${IPP_PREFIX}${name}${IPP_SUFFIX}${IPP_LIB_SUFFIX}
                   DESTINATION ${OPENCV_3P_LIB_INSTALL_PATH} COMPONENT dev)

--- a/cmake/OpenCVFindIPP.cmake
+++ b/cmake/OpenCVFindIPP.cmake
@@ -148,7 +148,7 @@ macro(ipp_detect_version)
           IMPORTED_LOCATION ${IPP_LIBRARY_DIR}/${IPP_LIB_PREFIX}${IPP_PREFIX}${name}${IPP_SUFFIX}${IPP_LIB_SUFFIX}
         )
         list(APPEND IPP_LIBRARIES ipp${name})
-        if (NOT BUILD_SHARED_LIBS AND HAVE_IPP_ICV)
+        if (NOT BUILD_SHARED_LIBS AND (HAVE_IPP_ICV OR ";${OPENCV_INSTALL_EXTERNAL_DEPENDENCIES};" MATCHES ";ipp;"))
           # CMake doesn't support "install(TARGETS ${IPP_PREFIX}${name} " command with imported targets
           install(FILES ${IPP_LIBRARY_DIR}/${IPP_LIB_PREFIX}${IPP_PREFIX}${name}${IPP_SUFFIX}${IPP_LIB_SUFFIX}
                   DESTINATION ${OPENCV_3P_LIB_INSTALL_PATH} COMPONENT dev)

--- a/cmake/OpenCVFindIPPIW.cmake
+++ b/cmake/OpenCVFindIPPIW.cmake
@@ -114,6 +114,14 @@ macro(ippiw_setup PATH BUILD)
             IMPORTED_LOCATION "${FILE}"
           )
 
+          if (NOT BUILD_SHARED_LIBS AND ";${OPENCV_INSTALL_EXTERNAL_DEPENDENCIES};" MATCHES ";ipp;")
+            # CMake doesn't support "install(TARGETS ${name} ...)" command with imported targets
+            install(FILES "${FILE}"
+                    DESTINATION ${OPENCV_3P_LIB_INSTALL_PATH} COMPONENT dev)
+            set(IPPIW_INSTALL_PATH "${CMAKE_INSTALL_PREFIX}/${OPENCV_3P_LIB_INSTALL_PATH}/${CMAKE_STATIC_LIBRARY_PREFIX}ipp_iw${CMAKE_STATIC_LIBRARY_SUFFIX}" CACHE INTERNAL "" FORCE)
+            set(IPPIW_LOCATION_PATH "${FILE}" CACHE INTERNAL "" FORCE)
+          endif()
+
           set(IPP_IW_INCLUDES "${IPP_IW_PATH}/include")
           set(IPP_IW_LIBRARIES ipp_iw)
 

--- a/cmake/OpenCVFindIPPIW.cmake
+++ b/cmake/OpenCVFindIPPIW.cmake
@@ -108,21 +108,14 @@ macro(ippiw_setup PATH BUILD)
           message(STATUS "found Intel IPP Integration Wrappers binaries: ${IW_VERSION_MAJOR}.${IW_VERSION_MINOR}.${IW_VERSION_UPDATE}")
           message(STATUS "at: ${IPP_IW_PATH}")
 
-          add_library(ippiw STATIC IMPORTED)
-          set_target_properties(ippiw PROPERTIES
+          add_library(ipp_iw STATIC IMPORTED)
+          set_target_properties(ipp_iw PROPERTIES
             IMPORTED_LINK_INTERFACE_LIBRARIES ""
             IMPORTED_LOCATION "${FILE}"
           )
-          if (NOT BUILD_SHARED_LIBS)
-            # CMake doesn't support "install(TARGETS ${name} ...)" command with imported targets
-            install(FILES "${FILE}"
-                    DESTINATION ${OPENCV_3P_LIB_INSTALL_PATH} COMPONENT dev)
-            set(IPPIW_INSTALL_PATH "${CMAKE_INSTALL_PREFIX}/${OPENCV_3P_LIB_INSTALL_PATH}/${CMAKE_STATIC_LIBRARY_PREFIX}ipp_iw${CMAKE_STATIC_LIBRARY_SUFFIX}" CACHE INTERNAL "" FORCE)
-            set(IPPIW_LOCATION_PATH "${FILE}" CACHE INTERNAL "" FORCE)
-          endif()
 
           set(IPP_IW_INCLUDES "${IPP_IW_PATH}/include")
-          set(IPP_IW_LIBRARIES ippiw)
+          set(IPP_IW_LIBRARIES ipp_iw)
 
           set(HAVE_IPP_IW 1)
           set(BUILD_IPP_IW 0)


### PR DESCRIPTION
Resolves #16537

Only IPP/IPPIW binaries distributed with OpenCV should be copied to `<INSTALL>/lib/opencv4/3rdparty`.

Checked samples build with following configurations (Ubuntu 18):
```
cmake -GNinja -DBUILD_SHARED_LIBS=OFF -DCMAKE_INSTALL_PREFIX=install $OPT ../opencv
```
where OPT is:
1. `<empty>` - default, use IPPICV and IPPIW from OpenCV
2. `-DIPPROOT=/opt/intel/compilers_and_libraries_2020.0.166/linux/ipp` - use standalone IPP, use IPPIW from OpenCV
3. `-DIPPROOT=/opt/intel/compilers_and_libraries_2020.0.166/linux/ipp -DBUILD_IPP_IW=OFF` - use standalone IPP and IPPIW

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under OpenCV (BSD) License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [x] The PR is proposed to proper branch
- [x] There is reference to original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
