### PR TITLE
ffmpeg/3.4: update FFmpeg wrapper

### DIFF
--- a/3rdparty/ffmpeg/ffmpeg.cmake
+++ b/3rdparty/ffmpeg/ffmpeg.cmake
@@ -1,8 +1,8 @@
-# Binaries branch name: ffmpeg/3.4_20191118
-# Binaries were created for OpenCV: 3f431a16a38be35e52b4887a3591d23030d34fc5
-ocv_update(FFMPEG_BINARIES_COMMIT "548e3c997a80d65f710b9048f1d33371e3a203ac")
-ocv_update(FFMPEG_FILE_HASH_BIN32 "168635a192fc2d2ae7d7d40150f0b349")
-ocv_update(FFMPEG_FILE_HASH_BIN64 "cbc25f8f2954475b127c7558558c18e6")
+# Binaries branch name: ffmpeg/3.4_20200310
+# Binaries were created for OpenCV: 4966186e10e2a940514d8c20447ca4a828af5f46
+ocv_update(FFMPEG_BINARIES_COMMIT "e81ccda615672833b578c6cefdb859ad69c560ba")
+ocv_update(FFMPEG_FILE_HASH_BIN32 "301ae2000e25f800ab8e0065f277ad28")
+ocv_update(FFMPEG_FILE_HASH_BIN64 "d87ce032289c3f811d02f0c3d8dbe366")
 ocv_update(FFMPEG_FILE_HASH_CMAKE "3b90f67f4b429e77d3da36698cef700c")
 
 function(download_win_ffmpeg script_var)


### PR DESCRIPTION
relates #15939

<cut/>

```
buildworker:Win64 OpenCL=windows-2
force_builders=Win32
allow_multiple_commits=1
```