### PR TITLE
GAPI - KW fixes - - replace "unsafe" memcpy with "safe" :) std::copy_n to make KW happy

### DIFF
--- a/modules/gapi/src/backends/fluid/gfluidimgproc.cpp
+++ b/modules/gapi/src/backends/fluid/gfluidimgproc.cpp
@@ -31,7 +31,7 @@
 #include <opencv2/core/hal/intrin.hpp>
 
 #include <cmath>
-#include <cstdlib>
+#include <algorithm>
 
 namespace cv {
 namespace gapi {
@@ -1800,12 +1800,12 @@ GAPI_FLUID_KERNEL(GFluidBayerGR2RGB, cv::gapi::imgproc::GBayerGR2RGB, false)
         if (in.y() == -1)
         {
             run_bayergr2rgb_bg_impl(dst[1], src + border_size, width);
-            std::memcpy(dst[0], dst[1], width * 3);
+            std::copy_n(dst[1], width * 3, dst[0]);
         }
         else if (in.y() == height - LPI - 2 * border_size + 1)
         {
             run_bayergr2rgb_gr_impl(dst[0], src, width);
-            std::memcpy(dst[1], dst[0], width * 3);
+            std::copy_n(dst[0], width * 3, dst[1]);
         }
         else
         {


### PR DESCRIPTION

"Unsafe" `memcpy` were replaced with "safe" :) `std::copy_n` to make static analysis  happy

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under OpenCV (BSD) License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [x] The PR is proposed to proper branch
- [x] There is reference to original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
