### PR TITLE
GAPI - KW fixes - replaced bitwise &= on bools, with explicit &&

### DIFF
--- a/modules/gapi/src/executor/gstreamingexecutor.cpp
+++ b/modules/gapi/src/executor/gstreamingexecutor.cpp
@@ -737,7 +737,7 @@ void cv::gimpl::GStreamingExecutor::setSource(GRunArgs &&ins)
             for (auto& op : m_ops)
             {
                 op.isl_exec = m_gim.metadata(op.nh).get<IslandExec>().object;
-                is_reshapable &= op.isl_exec->canReshape();
+                is_reshapable = is_reshapable && op.isl_exec->canReshape();
             }
             update_int_metas(); // (7)
             m_reshapable = util::make_optional(is_reshapable);


### PR DESCRIPTION
Bitwise operations (&=) on booleans were replaced with correct logical one ( && ) to make KW happy

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under OpenCV (BSD) License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [x] The PR is proposed to proper branch
- [x] There is reference to original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
