### PR TITLE
GAPI - KW fixes - avoid overflow in own::Mat::total() and according tests

### DIFF
--- a/modules/gapi/include/opencv2/gapi/own/mat.hpp
+++ b/modules/gapi/include/opencv2/gapi/own/mat.hpp
@@ -297,10 +297,9 @@ namespace cv { namespace gapi { namespace own {
          */
         size_t total() const
         {
-            return static_cast<std::size_t>
-                (dims.empty()
-                 ? (rows * cols)
-                 : std::accumulate(dims.begin(), dims.end(), 1, std::multiplies<int>()));
+            return dims.empty()
+                 ? (static_cast<std::size_t>(rows) * cols)
+                 : std::accumulate(dims.begin(), dims.end(), static_cast<std::size_t>(1), std::multiplies<size_t>());
         }
 
         /** @overload

--- a/modules/gapi/test/own/mat_tests.cpp
+++ b/modules/gapi/test/own/mat_tests.cpp
@@ -14,6 +14,12 @@ namespace opencv_test
 using Mat = cv::gapi::own::Mat;
 using Dims = std::vector<int>;
 
+namespace {
+inline std::size_t multiply_dims(Dims const& dims){
+    return std::accumulate(dims.begin(), dims.end(), static_cast<size_t>(1), std::multiplies<std::size_t>());
+}
+}
+
 TEST(OwnMat, DefaultConstruction)
 {
     Mat m;
@@ -74,7 +80,7 @@ TEST(OwnMat, CreateOverload)
     ASSERT_NE(m.data, nullptr);
     ASSERT_EQ((cv::Size{m.cols, m.rows}), size);
 
-    ASSERT_EQ(m.total(), static_cast<size_t>(size.height*size.width));
+    ASSERT_EQ(m.total(), static_cast<size_t>(size.height) * size.width);
     ASSERT_EQ(m.type(), CV_8UC1);
     ASSERT_EQ(m.depth(), CV_8U);
     ASSERT_EQ(m.channels(), 1);
@@ -371,7 +377,7 @@ TEST(OwnMat, CopyNDtoRegular)
 
     ASSERT_NE(nullptr , a.data);
     ASSERT_EQ(sz      , (cv::gapi::own::Size{a.cols, a.rows}));
-    ASSERT_EQ(static_cast<size_t>(sz.width*sz.height), a.total());
+    ASSERT_EQ(static_cast<size_t>(sz.width) * sz.height, a.total());
     ASSERT_EQ(CV_8U   , a.type());
     ASSERT_EQ(CV_8U   , a.depth());
     ASSERT_EQ(1       , a.channels());
@@ -387,7 +393,7 @@ TEST(OwnMat, CopyNDtoRegular)
     ASSERT_NE(old_ptr , a.data);
     ASSERT_NE(b.data  , a.data);
     ASSERT_EQ((cv::gapi::own::Size{0,0}), (cv::gapi::own::Size{a.cols, a.rows}));
-    ASSERT_EQ(static_cast<size_t>(dims[0]*dims[1]*dims[2]*dims[3]), a.total());
+    ASSERT_EQ(multiply_dims(dims), a.total());
     ASSERT_EQ(CV_32F  , a.type());
     ASSERT_EQ(CV_32F  , a.depth());
     ASSERT_EQ(-1      , a.channels());
@@ -408,7 +414,7 @@ TEST(OwnMat, CopyRegularToND)
 
     ASSERT_NE(nullptr , a.data);
     ASSERT_EQ((cv::gapi::own::Size{0,0}), (cv::gapi::own::Size{a.cols, a.rows}));
-    ASSERT_EQ(static_cast<size_t>(dims[0]*dims[1]*dims[2]*dims[3]), a.total());
+    ASSERT_EQ(multiply_dims(dims), a.total());
     ASSERT_EQ(CV_32F  , a.type());
     ASSERT_EQ(CV_32F  , a.depth());
     ASSERT_EQ(-1      , a.channels());
@@ -424,7 +430,7 @@ TEST(OwnMat, CopyRegularToND)
     ASSERT_NE(old_ptr , a.data);
     ASSERT_NE(b.data  , a.data);
     ASSERT_EQ(sz      , (cv::gapi::own::Size{a.cols, a.rows}));
-    ASSERT_EQ(static_cast<size_t>(sz.width*sz.height), a.total());
+    ASSERT_EQ(static_cast<size_t>(sz.width) * sz.height, a.total());
     ASSERT_EQ(CV_8U   , a.type());
     ASSERT_EQ(CV_8U   , a.depth());
     ASSERT_EQ(1       , a.channels());


### PR DESCRIPTION
This patch adds promoting for one of the arguments to bigger type to avoid multiplication overflow in own::Mat::total() and according tests

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under OpenCV (BSD) License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [x] The PR is proposed to proper branch
- [x] There is reference to original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
