### PR TITLE
cmake: fix missing project() warning in Python standalone builds

### DIFF
--- a/modules/python/CMakeLists.txt
+++ b/modules/python/CMakeLists.txt
@@ -41,6 +41,7 @@ add_subdirectory(python3)
 else()  # standalone build
 
 cmake_minimum_required(VERSION 2.8.12)
+project(OpenCVPython CXX C)
 include("./standalone.cmake")
 
 endif()


### PR DESCRIPTION
Warning from [Winpack builder](http://pullrequest.opencv.org/buildbot/builders/3_4_winpack-build-win64-vc14/builds/701).