### PR TITLE
Scale_layer: enable scale layer to handle inputs in batch

### DIFF
--- a/modules/dnn/src/layers/scale_layer.cpp
+++ b/modules/dnn/src/layers/scale_layer.cpp
@@ -101,7 +101,6 @@ public:
         }
         endAxis = (numWeightsPerSample == 1) ? 1 : endAxis;
 
-        CV_Assert(total(inpShape, axis, endAxis) == numWeightsPerSample);
         CV_Assert(!hasBias || numWeights == bias.total());
         CV_CheckTypeEQ(inpBlob.type(), CV_32FC1, ""); CV_CheckTypeEQ(outBlob.type(), CV_32FC1, "");
 
@@ -115,7 +114,7 @@ public:
         {
             for (int inp_sample = 0; inp_sample < numSamples; inp_sample++)
             {
-                int spatialSize = total(inpShape, endAxis);  // spatialSize != 1
+                int spatialSize = total(inpShape, (endAxis > axis ? endAxis : axis));  // spatialSize != 1
                 for (int i = 0; i < numSlices; ++i)
                 {
                     for (int j = 0; j < numWeightsPerSample; ++j)
@@ -164,8 +163,8 @@ public:
                 }
                 if (numWeightsSamples > 1)
                 {
-                    weightsData += numWeightsPerSample;
-                    biasesData += numWeightsPerSample;
+                    weightsData += weightsData ? numWeightsPerSample : 0;
+                    biasesData += biasesData ? numWeightsPerSample : 0;
                 }
             }
         }

--- a/modules/dnn/test/test_darknet_importer.cpp
+++ b/modules/dnn/test/test_darknet_importer.cpp
@@ -558,8 +558,7 @@ TEST_P(Test_Darknet_layers, convolutional)
 
 TEST_P(Test_Darknet_layers, scale_channels)
 {
-    // TODO: test fails for batches due to a bug/missing feature in ScaleLayer
-    testDarknetLayer("scale_channels", false, false);
+    testDarknetLayer("scale_channels", false, true);
 }
 
 TEST_P(Test_Darknet_layers, connected)


### PR DESCRIPTION
**Merge with extra**: https://github.com/opencv/opencv_extra/pull/729

resolves #16630 
resolves #17063
resolves #13626

```
opencv_extra=scale_batchsize
```

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under OpenCV (BSD) License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [x] The PR is proposed to proper branch
- [x] There is reference to original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake

### This PR Modifies
Handling of inputs in batch for scale layer. 

Changes are done considering two cases:
1 - Weights and Biases are constants, in this case dimension could be either [1, C, H, W] or [C, H, W].
2 - Weights and Biases are non-constants ( say input_1 ), i.e. they are calculated at runtime. so their shapes will be [N, C, H, W] where N will be same as batch size of input_0.

So Basically changes are added for Point 2. i.e. untrainable parameters/ scales with batch size greater than 1. Before scale layer was only supporting Point 1. i.e. trainable weights, ignoring the fact that scales can have batchsize > 1.

```
force_builders=Custom,Custom Win,Custom Mac
build_image:Custom=ubuntu-openvino-2020.3.0:16.04
build_image:Custom Win=openvino-2020.1.0
build_image:Custom Mac=openvino-2020.1.0

test_modules:Custom=dnn,python2,python3,java
test_modules:Custom Win=dnn,python2,python3,java
test_modules:Custom Mac=dnn,python2,python3,java

buildworker:Custom=linux-1
test_opencl:Custom=ON
test_bigdata:Custom=1
test_filter:Custom=*Layer_Test*:*cale*
```