### PR TITLE
G-API: Unification of own:: Scalar with cv:: Scalar

### DIFF
--- a/modules/gapi/include/opencv2/gapi/cpu/gcpukernel.hpp
+++ b/modules/gapi/include/opencv2/gapi/cpu/gcpukernel.hpp
@@ -99,8 +99,8 @@ public:
     const cv::gapi::own::Mat&   inMat(int input);
     cv::gapi::own::Mat&         outMatR(int output); // FIXME: Avoid cv::gapi::own::Mat m = ctx.outMatR()
 
-    const cv::gapi::own::Scalar& inVal(int input);
-    cv::gapi::own::Scalar& outValR(int output); // FIXME: Avoid cv::gapi::own::Scalar s = ctx.outValR()
+    const cv::Scalar& inVal(int input);
+    cv::Scalar& outValR(int output); // FIXME: Avoid cv::gapi::own::Scalar s = ctx.outValR()
     template<typename T> std::vector<T>& outVecR(int output) // FIXME: the same issue
     {
         return outVecRef(output).wref<T>();
@@ -155,7 +155,7 @@ template<> struct get_in<cv::GMatP>
 };
 template<> struct get_in<cv::GScalar>
 {
-    static cv::Scalar get(GCPUContext &ctx, int idx) { return to_ocv(ctx.inVal(idx)); }
+    static cv::Scalar get(GCPUContext &ctx, int idx) { return cv::gapi::own::to_ocv(ctx.inVal(idx)); }
 };
 template<typename U> struct get_in<cv::GArray<U> >
 {
@@ -210,12 +210,12 @@ struct tracked_cv_mat{
 
 struct scalar_wrapper
 {
-    scalar_wrapper(cv::gapi::own::Scalar& s) : m_s{cv::gapi::own::to_ocv(s)}, m_org_s(s) {};
+    scalar_wrapper(cv::Scalar& s) : m_s{cv::gapi::own::to_ocv(s)}, m_org_s(s) {};
     operator cv::Scalar& () { return m_s; }
-    void writeBack() const  { m_org_s = to_own(m_s); }
+    void writeBack() const  { m_org_s = m_s; }
 
     cv::Scalar m_s;
-    cv::gapi::own::Scalar& m_org_s;
+    cv::Scalar& m_org_s;
 };
 
 template<typename... Outputs>

--- a/modules/gapi/include/opencv2/gapi/cpu/gcpukernel.hpp
+++ b/modules/gapi/include/opencv2/gapi/cpu/gcpukernel.hpp
@@ -155,7 +155,7 @@ template<> struct get_in<cv::GMatP>
 };
 template<> struct get_in<cv::GScalar>
 {
-    static cv::Scalar get(GCPUContext &ctx, int idx) { return cv::gapi::own::to_ocv(ctx.inVal(idx)); }
+    static cv::Scalar get(GCPUContext &ctx, int idx) { return ctx.inVal(idx); }
 };
 template<typename U> struct get_in<cv::GArray<U> >
 {
@@ -210,7 +210,7 @@ struct tracked_cv_mat{
 
 struct scalar_wrapper
 {
-    scalar_wrapper(cv::Scalar& s) : m_s{cv::gapi::own::to_ocv(s)}, m_org_s(s) {};
+    scalar_wrapper(cv::Scalar& s) : m_s{s}, m_org_s(s) {};
     operator cv::Scalar& () { return m_s; }
     void writeBack() const  { m_org_s = m_s; }
 

--- a/modules/gapi/include/opencv2/gapi/cpu/gcpukernel.hpp
+++ b/modules/gapi/include/opencv2/gapi/cpu/gcpukernel.hpp
@@ -210,12 +210,9 @@ struct tracked_cv_mat{
 
 struct scalar_wrapper
 {
-    scalar_wrapper(cv::Scalar& s) : m_s{s}, m_org_s(s) {};
-    operator cv::Scalar& () { return m_s; }
-    void writeBack() const  { m_org_s = m_s; }
-
-    cv::Scalar m_s;
-    cv::Scalar& m_org_s;
+    scalar_wrapper(cv::Scalar& s) : m_s{s} {};
+    operator cv::Scalar& () { return m_s; }    
+    cv::Scalar m_s;    
 };
 
 template<typename... Outputs>
@@ -223,8 +220,7 @@ void postprocess(Outputs&... outs)
 {
     struct
     {
-        void operator()(tracked_cv_mat* bm) { bm->validate();  }
-        void operator()(scalar_wrapper* sw) { sw->writeBack(); }
+        void operator()(tracked_cv_mat* bm) { bm->validate();  }        
         void operator()(...)                {                  }
 
     } validate;

--- a/modules/gapi/include/opencv2/gapi/cpu/gcpukernel.hpp
+++ b/modules/gapi/include/opencv2/gapi/cpu/gcpukernel.hpp
@@ -221,7 +221,7 @@ void postprocess(Outputs&... outs)
 {
     struct
     {
-        void operator()(tracked_cv_mat* bm) { bm->validate();  }        
+        void operator()(tracked_cv_mat* bm) { bm->validate();  }
         void operator()(...)                {                  }
 
     } validate;

--- a/modules/gapi/include/opencv2/gapi/cpu/gcpukernel.hpp
+++ b/modules/gapi/include/opencv2/gapi/cpu/gcpukernel.hpp
@@ -100,7 +100,7 @@ public:
     cv::gapi::own::Mat&         outMatR(int output); // FIXME: Avoid cv::gapi::own::Mat m = ctx.outMatR()
 
     const cv::Scalar& inVal(int input);
-    cv::Scalar& outValR(int output); // FIXME: Avoid cv::gapi::own::Scalar s = ctx.outValR()
+    cv::Scalar& outValR(int output); // FIXME: Avoid cv::Scalar s = ctx.outValR()
     template<typename T> std::vector<T>& outVecR(int output) // FIXME: the same issue
     {
         return outVecRef(output).wref<T>();
@@ -208,14 +208,6 @@ struct tracked_cv_mat{
     }
 };
 
-struct scalar_wrapper
-{
-    scalar_wrapper(cv::Scalar& s) : m_org_s(s) {};
-    operator cv::Scalar& () { return m_org_s; }
-
-    cv::Scalar& m_org_s;
-};
-
 template<typename... Outputs>
 void postprocess(Outputs&... outs)
 {
@@ -248,10 +240,9 @@ template<> struct get_out<cv::GMatP>
 };
 template<> struct get_out<cv::GScalar>
 {
-    static scalar_wrapper get(GCPUContext &ctx, int idx)
+    static cv::Scalar& get(GCPUContext &ctx, int idx)
     {
-        auto& s = ctx.outValR(idx);
-        return {s};
+        return ctx.outValR(idx);
     }
 };
 template<typename U> struct get_out<cv::GArray<U>>

--- a/modules/gapi/include/opencv2/gapi/cpu/gcpukernel.hpp
+++ b/modules/gapi/include/opencv2/gapi/cpu/gcpukernel.hpp
@@ -210,9 +210,10 @@ struct tracked_cv_mat{
 
 struct scalar_wrapper
 {
-    scalar_wrapper(cv::Scalar& s) : m_s{s} {};
-    operator cv::Scalar& () { return m_s; }    
-    cv::Scalar m_s;    
+    scalar_wrapper(cv::Scalar& s) : m_org_s(s) {};
+    operator cv::Scalar& () { return m_org_s; }
+
+    cv::Scalar& m_org_s;
 };
 
 template<typename... Outputs>

--- a/modules/gapi/include/opencv2/gapi/fluid/gfluidbuffer.hpp
+++ b/modules/gapi/include/opencv2/gapi/fluid/gfluidbuffer.hpp
@@ -18,7 +18,6 @@
 #include <opencv2/gapi/gmat.hpp>
 
 #include <opencv2/gapi/util/optional.hpp>
-#include <opencv2/gapi/own/scalar.hpp>
 #include <opencv2/gapi/own/mat.hpp>
 
 namespace cv {

--- a/modules/gapi/include/opencv2/gapi/fluid/gfluidbuffer.hpp
+++ b/modules/gapi/include/opencv2/gapi/fluid/gfluidbuffer.hpp
@@ -27,13 +27,11 @@ namespace fluid {
 
 struct Border
 {
-#if !defined(GAPI_STANDALONE)
     // This constructor is required to support existing kernels which are part of G-API
     Border(int _type, cv::Scalar _val) : type(_type), value(to_own(_val)) {};
-#endif // !defined(GAPI_STANDALONE)
-    Border(int _type, cv::gapi::own::Scalar _val) : type(_type), value(_val) {};
+
     int type;
-    cv::gapi::own::Scalar value;
+    cv::Scalar value;
 };
 
 using BorderOpt = util::optional<Border>;

--- a/modules/gapi/include/opencv2/gapi/fluid/gfluidbuffer.hpp
+++ b/modules/gapi/include/opencv2/gapi/fluid/gfluidbuffer.hpp
@@ -28,7 +28,7 @@ namespace fluid {
 struct Border
 {
     // This constructor is required to support existing kernels which are part of G-API
-    Border(int _type, cv::Scalar _val) : type(_type), value(to_own(_val)) {};
+    Border(int _type, cv::Scalar _val) : type(_type), value(_val) {};
 
     int type;
     cv::Scalar value;

--- a/modules/gapi/include/opencv2/gapi/fluid/gfluidkernel.hpp
+++ b/modules/gapi/include/opencv2/gapi/fluid/gfluidkernel.hpp
@@ -179,17 +179,10 @@ template<> struct fluid_get_in<cv::GMat>
 template<> struct fluid_get_in<cv::GScalar>
 {
     // FIXME: change to return by reference when moved to own::Scalar
-#if !defined(GAPI_STANDALONE)
     static const cv::Scalar get(const cv::GArgs &in_args, int idx)
     {
-        return cv::gapi::own::to_ocv(in_args[idx].unsafe_get<cv::gapi::own::Scalar>());
+        return cv::gapi::own::to_ocv(in_args[idx].unsafe_get<cv::Scalar>());
     }
-#else
-    static const cv::gapi::own::Scalar get(const cv::GArgs &in_args, int idx)
-    {
-        return in_args[idx].get<cv::gapi::own::Scalar>();
-    }
-#endif // !defined(GAPI_STANDALONE)
 };
 
 template<typename U> struct fluid_get_in<cv::GArray<U>>

--- a/modules/gapi/include/opencv2/gapi/fluid/gfluidkernel.hpp
+++ b/modules/gapi/include/opencv2/gapi/fluid/gfluidkernel.hpp
@@ -181,7 +181,7 @@ template<> struct fluid_get_in<cv::GScalar>
     // FIXME: change to return by reference when moved to own::Scalar
     static const cv::Scalar get(const cv::GArgs &in_args, int idx)
     {
-        return cv::gapi::own::to_ocv(in_args[idx].unsafe_get<cv::Scalar>());
+        return in_args[idx].unsafe_get<cv::Scalar>();
     }
 };
 

--- a/modules/gapi/include/opencv2/gapi/garg.hpp
+++ b/modules/gapi/include/opencv2/gapi/garg.hpp
@@ -23,7 +23,6 @@
 #include <opencv2/gapi/gopaque.hpp>
 #include <opencv2/gapi/gtype_traits.hpp>
 #include <opencv2/gapi/gmetaarg.hpp>
-#include <opencv2/gapi/own/scalar.hpp>
 #include <opencv2/gapi/streaming/source.hpp>
 
 namespace cv {

--- a/modules/gapi/include/opencv2/gapi/garg.hpp
+++ b/modules/gapi/include/opencv2/gapi/garg.hpp
@@ -90,7 +90,7 @@ using GArgs = std::vector<GArg>;
 // FIXME: Move to a separate file!
 using GRunArg  = util::variant<
 #if !defined(GAPI_STANDALONE)
-    cv::Mat,    
+    cv::Mat,
     cv::UMat,
 #endif // !defined(GAPI_STANDALONE)
     cv::gapi::wip::IStreamSource::Ptr,
@@ -123,7 +123,7 @@ struct Data: public GRunArg
 
 using GRunArgP = util::variant<
 #if !defined(GAPI_STANDALONE)
-    cv::Mat*,    
+    cv::Mat*,
     cv::UMat*,
 #endif // !defined(GAPI_STANDALONE)
     cv::gapi::own::Mat*,

--- a/modules/gapi/include/opencv2/gapi/garg.hpp
+++ b/modules/gapi/include/opencv2/gapi/garg.hpp
@@ -90,13 +90,12 @@ using GArgs = std::vector<GArg>;
 // FIXME: Move to a separate file!
 using GRunArg  = util::variant<
 #if !defined(GAPI_STANDALONE)
-    cv::Mat,
-    cv::Scalar,
+    cv::Mat,    
     cv::UMat,
 #endif // !defined(GAPI_STANDALONE)
     cv::gapi::wip::IStreamSource::Ptr,
     cv::gapi::own::Mat,
-    cv::gapi::own::Scalar,
+    cv::Scalar,
     cv::detail::VectorRef,
     cv::detail::OpaqueRef
     >;
@@ -124,12 +123,11 @@ struct Data: public GRunArg
 
 using GRunArgP = util::variant<
 #if !defined(GAPI_STANDALONE)
-    cv::Mat*,
-    cv::Scalar*,
+    cv::Mat*,    
     cv::UMat*,
 #endif // !defined(GAPI_STANDALONE)
     cv::gapi::own::Mat*,
-    cv::gapi::own::Scalar*,
+    cv::Scalar*,
     cv::detail::VectorRef,
     cv::detail::OpaqueRef
     >;

--- a/modules/gapi/include/opencv2/gapi/gscalar.hpp
+++ b/modules/gapi/include/opencv2/gapi/gscalar.hpp
@@ -31,11 +31,9 @@ class GAPI_EXPORTS GScalar
 {
 public:
     GScalar();                                         // Empty constructor
-    explicit GScalar(const cv::gapi::own::Scalar& s);  // Constant value constructor from cv::gapi::own::Scalar
-    explicit GScalar(cv::gapi::own::Scalar&& s);       // Constant value move-constructor from cv::gapi::own::Scalar
-#if !defined(GAPI_STANDALONE)
-    explicit GScalar(const cv::Scalar& s);             // Constant value constructor from cv::Scalar
-#endif  // !defined(GAPI_STANDALONE)
+    explicit GScalar(const cv::Scalar& s);  // Constant value constructor from cv::gapi::own::Scalar
+    explicit GScalar(cv::Scalar&& s);       // Constant value move-constructor from cv::gapi::own::Scalar
+
     GScalar(double v0);                                // Constant value constructor from double
     GScalar(const GNode &n, std::size_t out);          // Operation result constructor
 
@@ -69,12 +67,7 @@ struct GScalarDesc
 
 static inline GScalarDesc empty_scalar_desc() { return GScalarDesc(); }
 
-#if !defined(GAPI_STANDALONE)
 GAPI_EXPORTS GScalarDesc descr_of(const cv::Scalar            &scalar);
-#endif // !defined(GAPI_STANDALONE)
-/** @} */
-
-GAPI_EXPORTS GScalarDesc descr_of(const cv::gapi::own::Scalar &scalar);
 
 std::ostream& operator<<(std::ostream& os, const cv::GScalarDesc &desc);
 

--- a/modules/gapi/include/opencv2/gapi/gscalar.hpp
+++ b/modules/gapi/include/opencv2/gapi/gscalar.hpp
@@ -14,7 +14,6 @@
 #include <opencv2/gapi/opencv_includes.hpp>
 #include <opencv2/gapi/gcommon.hpp> // GShape
 #include <opencv2/gapi/util/optional.hpp>
-#include <opencv2/gapi/own/scalar.hpp>
 
 namespace cv
 {

--- a/modules/gapi/include/opencv2/gapi/gscalar.hpp
+++ b/modules/gapi/include/opencv2/gapi/gscalar.hpp
@@ -30,8 +30,8 @@ class GAPI_EXPORTS GScalar
 {
 public:
     GScalar();                                         // Empty constructor
-    explicit GScalar(const cv::Scalar& s);  // Constant value constructor from cv::gapi::own::Scalar
-    explicit GScalar(cv::Scalar&& s);       // Constant value move-constructor from cv::gapi::own::Scalar
+    explicit GScalar(const cv::Scalar& s);  // Constant value constructor from cv::Scalar
+    explicit GScalar(cv::Scalar&& s);       // Constant value move-constructor from cv::Scalar
 
     GScalar(double v0);                                // Constant value constructor from double
     GScalar(const GNode &n, std::size_t out);          // Operation result constructor

--- a/modules/gapi/include/opencv2/gapi/gtype_traits.hpp
+++ b/modules/gapi/include/opencv2/gapi/gtype_traits.hpp
@@ -107,10 +107,9 @@ namespace detail
 #if !defined(GAPI_STANDALONE)
     template<>           struct GTypeOf<cv::Mat>               { using type = cv::GMat;      };
     template<>           struct GTypeOf<cv::UMat>              { using type = cv::GMat;      };
-    template<>           struct GTypeOf<cv::Scalar>            { using type = cv::GScalar;   };
 #endif // !defined(GAPI_STANDALONE)
     template<>           struct GTypeOf<cv::gapi::own::Mat>    { using type = cv::GMat;      };
-    template<>           struct GTypeOf<cv::gapi::own::Scalar> { using type = cv::GScalar;   };
+    template<>           struct GTypeOf<cv::Scalar>            { using type = cv::GScalar;   };
     template<typename U> struct GTypeOf<std::vector<U> >       { using type = cv::GArray<U>; };
     template<typename U> struct GTypeOf                        { using type = cv::GOpaque<U>;};
     // FIXME: This is not quite correct since IStreamSource may produce not only Mat but also Scalar

--- a/modules/gapi/include/opencv2/gapi/ocl/goclkernel.hpp
+++ b/modules/gapi/include/opencv2/gapi/ocl/goclkernel.hpp
@@ -149,12 +149,9 @@ struct tracked_cv_umat{
 struct scalar_wrapper_ocl
 {
     //FIXME reuse CPU (OpenCV) plugin code
-    scalar_wrapper_ocl(cv::Scalar& s) : m_s{s}, m_org_s(s) {};
-    operator cv::Scalar& () { return m_s; }
-    void writeBack() const  { m_org_s = m_s; }
-
-    cv::Scalar m_s;
-    cv::Scalar& m_org_s;
+    scalar_wrapper_ocl(cv::Scalar& s) : m_s{s} {};
+    operator cv::Scalar& () { return m_s; }    
+    cv::Scalar m_s;    
 };
 
 template<typename... Outputs>
@@ -162,8 +159,7 @@ void postprocess_ocl(Outputs&... outs)
 {
     struct
     {
-        void operator()(tracked_cv_umat* bm) { bm->validate(); }
-        void operator()(scalar_wrapper_ocl* sw) { sw->writeBack(); }
+        void operator()(tracked_cv_umat* bm) { bm->validate(); }        
         void operator()(...) {                  }
 
     } validate;

--- a/modules/gapi/include/opencv2/gapi/ocl/goclkernel.hpp
+++ b/modules/gapi/include/opencv2/gapi/ocl/goclkernel.hpp
@@ -110,7 +110,7 @@ template<> struct ocl_get_in<cv::GMat>
 };
 template<> struct ocl_get_in<cv::GScalar>
 {
-    static cv::Scalar get(GOCLContext &ctx, int idx) { return cv::gapi::own::to_ocv(ctx.inVal(idx)); }
+    static cv::Scalar get(GOCLContext &ctx, int idx) { return ctx.inVal(idx); }
 };
 template<typename U> struct ocl_get_in<cv::GArray<U> >
 {
@@ -149,7 +149,7 @@ struct tracked_cv_umat{
 struct scalar_wrapper_ocl
 {
     //FIXME reuse CPU (OpenCV) plugin code
-    scalar_wrapper_ocl(cv::Scalar& s) : m_s{cv::gapi::own::to_ocv(s)}, m_org_s(s) {};
+    scalar_wrapper_ocl(cv::Scalar& s) : m_s{s}, m_org_s(s) {};
     operator cv::Scalar& () { return m_s; }
     void writeBack() const  { m_org_s = m_s; }
 

--- a/modules/gapi/include/opencv2/gapi/ocl/goclkernel.hpp
+++ b/modules/gapi/include/opencv2/gapi/ocl/goclkernel.hpp
@@ -149,9 +149,10 @@ struct tracked_cv_umat{
 struct scalar_wrapper_ocl
 {
     //FIXME reuse CPU (OpenCV) plugin code
-    scalar_wrapper_ocl(cv::Scalar& s) : m_s{s} {};
-    operator cv::Scalar& () { return m_s; }    
-    cv::Scalar m_s;    
+    scalar_wrapper_ocl(cv::Scalar& s) : m_org_s(s) {};
+    operator cv::Scalar& () { return m_org_s; }
+
+    cv::Scalar& m_org_s;
 };
 
 template<typename... Outputs>
@@ -159,7 +160,7 @@ void postprocess_ocl(Outputs&... outs)
 {
     struct
     {
-        void operator()(tracked_cv_umat* bm) { bm->validate(); }        
+        void operator()(tracked_cv_umat* bm) { bm->validate(); }
         void operator()(...) {                  }
 
     } validate;

--- a/modules/gapi/include/opencv2/gapi/ocl/goclkernel.hpp
+++ b/modules/gapi/include/opencv2/gapi/ocl/goclkernel.hpp
@@ -63,7 +63,7 @@ public:
     cv::UMat&  outMatR(int output); // FIXME: Avoid cv::Mat m = ctx.outMatR()
 
     const cv::Scalar& inVal(int input);
-    cv::Scalar& outValR(int output); // FIXME: Avoid cv::gapi::own::Scalar s = ctx.outValR()
+    cv::Scalar& outValR(int output); // FIXME: Avoid cv::Scalar s = ctx.outValR()
     template<typename T> std::vector<T>& outVecR(int output) // FIXME: the same issue
     {
         return outVecRef(output).wref<T>();
@@ -146,15 +146,6 @@ struct tracked_cv_umat{
     }
 };
 
-struct scalar_wrapper_ocl
-{
-    //FIXME reuse CPU (OpenCV) plugin code
-    scalar_wrapper_ocl(cv::Scalar& s) : m_org_s(s) {};
-    operator cv::Scalar& () { return m_org_s; }
-
-    cv::Scalar& m_org_s;
-};
-
 template<typename... Outputs>
 void postprocess_ocl(Outputs&... outs)
 {
@@ -180,10 +171,9 @@ template<> struct ocl_get_out<cv::GMat>
 };
 template<> struct ocl_get_out<cv::GScalar>
 {
-    static scalar_wrapper_ocl get(GOCLContext &ctx, int idx)
+    static cv::Scalar& get(GOCLContext &ctx, int idx)
     {
-        auto& s = ctx.outValR(idx);
-        return{ s };
+        return ctx.outValR(idx);
     }
 };
 template<typename U> struct ocl_get_out<cv::GArray<U> >

--- a/modules/gapi/include/opencv2/gapi/ocl/goclkernel.hpp
+++ b/modules/gapi/include/opencv2/gapi/ocl/goclkernel.hpp
@@ -62,8 +62,8 @@ public:
     const cv::UMat&  inMat(int input);
     cv::UMat&  outMatR(int output); // FIXME: Avoid cv::Mat m = ctx.outMatR()
 
-    const cv::gapi::own::Scalar& inVal(int input);
-    cv::gapi::own::Scalar& outValR(int output); // FIXME: Avoid cv::gapi::own::Scalar s = ctx.outValR()
+    const cv::Scalar& inVal(int input);
+    cv::Scalar& outValR(int output); // FIXME: Avoid cv::gapi::own::Scalar s = ctx.outValR()
     template<typename T> std::vector<T>& outVecR(int output) // FIXME: the same issue
     {
         return outVecRef(output).wref<T>();
@@ -110,7 +110,7 @@ template<> struct ocl_get_in<cv::GMat>
 };
 template<> struct ocl_get_in<cv::GScalar>
 {
-    static cv::Scalar get(GOCLContext &ctx, int idx) { return to_ocv(ctx.inVal(idx)); }
+    static cv::Scalar get(GOCLContext &ctx, int idx) { return cv::gapi::own::to_ocv(ctx.inVal(idx)); }
 };
 template<typename U> struct ocl_get_in<cv::GArray<U> >
 {
@@ -149,12 +149,12 @@ struct tracked_cv_umat{
 struct scalar_wrapper_ocl
 {
     //FIXME reuse CPU (OpenCV) plugin code
-    scalar_wrapper_ocl(cv::gapi::own::Scalar& s) : m_s{cv::gapi::own::to_ocv(s)}, m_org_s(s) {};
+    scalar_wrapper_ocl(cv::Scalar& s) : m_s{cv::gapi::own::to_ocv(s)}, m_org_s(s) {};
     operator cv::Scalar& () { return m_s; }
-    void writeBack() const  { m_org_s = to_own(m_s); }
+    void writeBack() const  { m_org_s = m_s; }
 
     cv::Scalar m_s;
-    cv::gapi::own::Scalar& m_org_s;
+    cv::Scalar& m_org_s;
 };
 
 template<typename... Outputs>

--- a/modules/gapi/include/opencv2/gapi/own/convert.hpp
+++ b/modules/gapi/include/opencv2/gapi/own/convert.hpp
@@ -50,10 +50,6 @@ namespace own
             : cv::Mat{m.dims, m.type(), m.data};
     }
            cv::Mat to_ocv(Mat&&)    = delete;
-
-    inline cv::Scalar to_ocv(const Scalar& s) { return {s[0], s[1], s[2], s[3]}; };
-    // inline cv::Scalar to_ocv(const cv::Scalar& s) { return {s[0], s[1], s[2], s[3]}; };
-
     inline cv::Size to_ocv (const Size& s) { return cv::Size(s.width, s.height); };
 
     inline cv::Rect to_ocv (const Rect& r) { return cv::Rect(r.x, r.y, r.width, r.height); };

--- a/modules/gapi/include/opencv2/gapi/own/convert.hpp
+++ b/modules/gapi/include/opencv2/gapi/own/convert.hpp
@@ -36,7 +36,7 @@ namespace cv
     };
 
 
-    inline cv::gapi::own::Scalar to_own(const cv::Scalar& s) { return {s[0], s[1], s[2], s[3]}; };
+    inline cv::Scalar to_own(const cv::Scalar& s) { return {s[0], s[1], s[2], s[3]}; };
 
     inline cv::gapi::own::Size to_own (const Size& s) { return {s.width, s.height}; };
 

--- a/modules/gapi/include/opencv2/gapi/own/convert.hpp
+++ b/modules/gapi/include/opencv2/gapi/own/convert.hpp
@@ -13,7 +13,6 @@
 #include <opencv2/gapi/opencv_includes.hpp>
 #include <opencv2/gapi/own/types.hpp>
 #include <opencv2/gapi/own/mat.hpp>
-#include <opencv2/gapi/own/scalar.hpp>
 
 namespace cv
 {

--- a/modules/gapi/include/opencv2/gapi/own/convert.hpp
+++ b/modules/gapi/include/opencv2/gapi/own/convert.hpp
@@ -35,9 +35,6 @@ namespace cv
             :  cv::gapi::own::Mat{to_own<int>(m.size), m.type(), m.data};
     };
 
-
-    inline cv::Scalar to_own(const cv::Scalar& s) { return {s[0], s[1], s[2], s[3]}; };
-
     inline cv::gapi::own::Size to_own (const Size& s) { return {s.width, s.height}; };
 
     inline cv::gapi::own::Rect to_own (const Rect& r) { return {r.x, r.y, r.width, r.height}; };
@@ -55,6 +52,7 @@ namespace own
            cv::Mat to_ocv(Mat&&)    = delete;
 
     inline cv::Scalar to_ocv(const Scalar& s) { return {s[0], s[1], s[2], s[3]}; };
+    // inline cv::Scalar to_ocv(const cv::Scalar& s) { return {s[0], s[1], s[2], s[3]}; };
 
     inline cv::Size to_ocv (const Size& s) { return cv::Size(s.width, s.height); };
 

--- a/modules/gapi/include/opencv2/gapi/own/cvdefs.hpp
+++ b/modules/gapi/include/opencv2/gapi/own/cvdefs.hpp
@@ -138,9 +138,9 @@ enum InterpolationFlags{
     INTER_MAX            = 7,
 };
 namespace gapi { namespace own {
-    class Scalar;
-}
-}
+class Scalar;
+} // namespace own
+} // namespace gapi
     using Scalar = gapi::own::Scalar;
 } // namespace cv
 

--- a/modules/gapi/include/opencv2/gapi/own/cvdefs.hpp
+++ b/modules/gapi/include/opencv2/gapi/own/cvdefs.hpp
@@ -138,6 +138,7 @@ enum InterpolationFlags{
     INTER_LINEAR_EXACT   = 5,
     INTER_MAX            = 7,
 };
+// replacement of cv's structures:
 using Scalar = gapi::own::Scalar;
 } // namespace cv
 

--- a/modules/gapi/include/opencv2/gapi/own/cvdefs.hpp
+++ b/modules/gapi/include/opencv2/gapi/own/cvdefs.hpp
@@ -9,6 +9,7 @@
 #define OPENCV_GAPI_CV_DEFS_HPP
 
 #if defined(GAPI_STANDALONE)
+#include <opencv2/gapi/own/scalar.hpp> // cv::gapi::own::Scalar
 
 // Simulate OpenCV definitions taken from various
 // OpenCV interface headers if G-API is built in a
@@ -137,10 +138,6 @@ enum InterpolationFlags{
     INTER_LINEAR_EXACT   = 5,
     INTER_MAX            = 7,
 };
-namespace gapi { namespace own {
-class Scalar;
-} // namespace own
-} // namespace gapi
 using Scalar = gapi::own::Scalar;
 } // namespace cv
 

--- a/modules/gapi/include/opencv2/gapi/own/cvdefs.hpp
+++ b/modules/gapi/include/opencv2/gapi/own/cvdefs.hpp
@@ -137,6 +137,11 @@ enum InterpolationFlags{
     INTER_LINEAR_EXACT   = 5,
     INTER_MAX            = 7,
 };
+namespace gapi { namespace own {
+    class Scalar;
+}
+}
+    using Scalar = gapi::own::Scalar;
 } // namespace cv
 
 static inline int cvFloor( double value )

--- a/modules/gapi/include/opencv2/gapi/own/cvdefs.hpp
+++ b/modules/gapi/include/opencv2/gapi/own/cvdefs.hpp
@@ -141,7 +141,7 @@ namespace gapi { namespace own {
 class Scalar;
 } // namespace own
 } // namespace gapi
-    using Scalar = gapi::own::Scalar;
+using Scalar = gapi::own::Scalar;
 } // namespace cv
 
 static inline int cvFloor( double value )

--- a/modules/gapi/include/opencv2/gapi/render/render.hpp
+++ b/modules/gapi/include/opencv2/gapi/render/render.hpp
@@ -17,7 +17,6 @@
 #include <opencv2/gapi/opencv_includes.hpp>
 #include <opencv2/gapi/util/variant.hpp>
 #include <opencv2/gapi/own/exports.hpp>
-#include <opencv2/gapi/own/scalar.hpp>
 
 
 /** \defgroup gapi_draw G-API Drawing and composition functionality

--- a/modules/gapi/src/api/gbackend.cpp
+++ b/modules/gapi/src/api/gbackend.cpp
@@ -375,7 +375,7 @@ void writeBack(const Mag& mag, const RcDesc &rc, GRunArgP &g_arg, bool is_umat)
     {
         switch (g_arg.index())
         {
-            case GRunArgP::index_of<cv::Scalar*>()            : *util::get<cv::Scalar*>(g_arg) = (mag.template slot<cv::Scalar>().at(rc.id)); break;
+            case GRunArgP::index_of<cv::Scalar*>()            : *util::get<cv::Scalar*>(g_arg) = mag.template slot<cv::Scalar>().at(rc.id); break;
             default: util::throw_error(std::logic_error("content type of the runtime argument does not match to resource description ?"));
         }
         break;

--- a/modules/gapi/src/api/gbackend.cpp
+++ b/modules/gapi/src/api/gbackend.cpp
@@ -152,13 +152,10 @@ void bindInArg(Mag& mag, const RcDesc &rc, const GRunArg &arg, bool is_umat)
 
     case GShape::GSCALAR:
     {
-        auto& mag_scalar = mag.template slot<cv::gapi::own::Scalar>()[rc.id];
+        auto& mag_scalar = mag.template slot<cv::Scalar>()[rc.id];
         switch (arg.index())
         {
-            case GRunArg::index_of<cv::gapi::own::Scalar>() : mag_scalar = util::get<cv::gapi::own::Scalar>(arg); break;
-#if !defined(GAPI_STANDALONE)
             case GRunArg::index_of<cv::Scalar>()            : mag_scalar = to_own(util::get<cv::Scalar>(arg));    break;
-#endif //  !defined(GAPI_STANDALONE)
             default: util::throw_error(std::logic_error("content type of the runtime argument does not match to resource description ?"));
         }
         break;
@@ -222,13 +219,10 @@ void bindOutArg(Mag& mag, const RcDesc &rc, const GRunArgP &arg, bool is_umat)
 
     case GShape::GSCALAR:
     {
-        auto& mag_scalar = mag.template slot<cv::gapi::own::Scalar>()[rc.id];
+        auto& mag_scalar = mag.template slot<cv::Scalar>()[rc.id];
         switch (arg.index())
         {
-            case GRunArgP::index_of<cv::gapi::own::Scalar*>() : mag_scalar = *util::get<cv::gapi::own::Scalar*>(arg); break;
-#if !defined(GAPI_STANDALONE)
             case GRunArgP::index_of<cv::Scalar*>()            : mag_scalar = to_own(*util::get<cv::Scalar*>(arg)); break;
-#endif //  !defined(GAPI_STANDALONE)
             default: util::throw_error(std::logic_error("content type of the runtime argument does not match to resource description ?"));
         }
         break;
@@ -265,7 +259,7 @@ void resetInternalData(Mag& mag, const Data &d)
         break;
 
     case GShape::GSCALAR:
-        mag.template slot<cv::gapi::own::Scalar>()[d.rc] = cv::gapi::own::Scalar();
+        mag.template slot<cv::Scalar>()[d.rc] = cv::Scalar();
         break;
 
     case GShape::GMAT:
@@ -284,7 +278,7 @@ cv::GRunArg getArg(const Mag& mag, const RcDesc &ref)
     switch (ref.shape)
     {
     case GShape::GMAT:    return GRunArg(mag.template slot<cv::gapi::own::Mat>().at(ref.id));
-    case GShape::GSCALAR: return GRunArg(mag.template slot<cv::gapi::own::Scalar>().at(ref.id));
+    case GShape::GSCALAR: return GRunArg(mag.template slot<cv::Scalar>().at(ref.id));
     // Note: .at() is intentional for GArray and GOpaque as objects MUST be already there
     //   (and constructed by either bindIn/Out or resetInternal)
     case GShape::GARRAY:  return GRunArg(mag.template slot<cv::detail::VectorRef>().at(ref.id));
@@ -310,7 +304,7 @@ cv::GRunArgP getObjPtr(Mag& mag, const RcDesc &rc, bool is_umat)
         }
         else
             return GRunArgP(&mag.template slot<cv::gapi::own::Mat>()[rc.id]);
-    case GShape::GSCALAR: return GRunArgP(&mag.template slot<cv::gapi::own::Scalar>()[rc.id]);
+    case GShape::GSCALAR: return GRunArgP(&mag.template slot<cv::Scalar>()[rc.id]);
     // Note: .at() is intentional for GArray and GOpaque as objects MUST be already there
     //   (and constructor by either bindIn/Out or resetInternal)
     case GShape::GARRAY:
@@ -381,10 +375,7 @@ void writeBack(const Mag& mag, const RcDesc &rc, GRunArgP &g_arg, bool is_umat)
     {
         switch (g_arg.index())
         {
-            case GRunArgP::index_of<cv::gapi::own::Scalar*>() : *util::get<cv::gapi::own::Scalar*>(g_arg) = mag.template slot<cv::gapi::own::Scalar>().at(rc.id); break;
-#if !defined(GAPI_STANDALONE)
-            case GRunArgP::index_of<cv::Scalar*>()            : *util::get<cv::Scalar*>(g_arg) = cv::gapi::own::to_ocv(mag.template slot<cv::gapi::own::Scalar>().at(rc.id)); break;
-#endif //  !defined(GAPI_STANDALONE)
+            case GRunArgP::index_of<cv::Scalar*>()            : *util::get<cv::Scalar*>(g_arg) = cv::gapi::own::to_ocv(mag.template slot<cv::Scalar>().at(rc.id)); break;
             default: util::throw_error(std::logic_error("content type of the runtime argument does not match to resource description ?"));
         }
         break;

--- a/modules/gapi/src/api/gbackend.cpp
+++ b/modules/gapi/src/api/gbackend.cpp
@@ -155,7 +155,7 @@ void bindInArg(Mag& mag, const RcDesc &rc, const GRunArg &arg, bool is_umat)
         auto& mag_scalar = mag.template slot<cv::Scalar>()[rc.id];
         switch (arg.index())
         {
-            case GRunArg::index_of<cv::Scalar>()            : mag_scalar = to_own(util::get<cv::Scalar>(arg));    break;
+            case GRunArg::index_of<cv::Scalar>()            : mag_scalar = util::get<cv::Scalar>(arg);    break;
             default: util::throw_error(std::logic_error("content type of the runtime argument does not match to resource description ?"));
         }
         break;
@@ -222,7 +222,7 @@ void bindOutArg(Mag& mag, const RcDesc &rc, const GRunArgP &arg, bool is_umat)
         auto& mag_scalar = mag.template slot<cv::Scalar>()[rc.id];
         switch (arg.index())
         {
-            case GRunArgP::index_of<cv::Scalar*>()            : mag_scalar = to_own(*util::get<cv::Scalar*>(arg)); break;
+            case GRunArgP::index_of<cv::Scalar*>()            : mag_scalar = *util::get<cv::Scalar*>(arg); break;
             default: util::throw_error(std::logic_error("content type of the runtime argument does not match to resource description ?"));
         }
         break;
@@ -375,7 +375,7 @@ void writeBack(const Mag& mag, const RcDesc &rc, GRunArgP &g_arg, bool is_umat)
     {
         switch (g_arg.index())
         {
-            case GRunArgP::index_of<cv::Scalar*>()            : *util::get<cv::Scalar*>(g_arg) = cv::gapi::own::to_ocv(mag.template slot<cv::Scalar>().at(rc.id)); break;
+            case GRunArgP::index_of<cv::Scalar*>()            : *util::get<cv::Scalar*>(g_arg) = to_ocv(mag.template slot<cv::Scalar>().at(rc.id)); break;
             default: util::throw_error(std::logic_error("content type of the runtime argument does not match to resource description ?"));
         }
         break;

--- a/modules/gapi/src/api/gbackend.cpp
+++ b/modules/gapi/src/api/gbackend.cpp
@@ -375,7 +375,7 @@ void writeBack(const Mag& mag, const RcDesc &rc, GRunArgP &g_arg, bool is_umat)
     {
         switch (g_arg.index())
         {
-            case GRunArgP::index_of<cv::Scalar*>()            : *util::get<cv::Scalar*>(g_arg) = to_ocv(mag.template slot<cv::Scalar>().at(rc.id)); break;
+            case GRunArgP::index_of<cv::Scalar*>()            : *util::get<cv::Scalar*>(g_arg) = (mag.template slot<cv::Scalar>().at(rc.id)); break;
             default: util::throw_error(std::logic_error("content type of the runtime argument does not match to resource description ?"));
         }
         break;

--- a/modules/gapi/src/api/gbackend.cpp
+++ b/modules/gapi/src/api/gbackend.cpp
@@ -155,7 +155,7 @@ void bindInArg(Mag& mag, const RcDesc &rc, const GRunArg &arg, bool is_umat)
         auto& mag_scalar = mag.template slot<cv::Scalar>()[rc.id];
         switch (arg.index())
         {
-        case GRunArg::index_of<cv::Scalar>()            : mag_scalar = util::get<cv::Scalar>(arg);    break;
+        case GRunArg::index_of<cv::Scalar>() : mag_scalar = util::get<cv::Scalar>(arg);    break;
         default: util::throw_error(std::logic_error("content type of the runtime argument does not match to resource description ?"));
         }
         break;
@@ -222,7 +222,7 @@ void bindOutArg(Mag& mag, const RcDesc &rc, const GRunArgP &arg, bool is_umat)
         auto& mag_scalar = mag.template slot<cv::Scalar>()[rc.id];
         switch (arg.index())
         {
-        case GRunArgP::index_of<cv::Scalar*>()            : mag_scalar = *util::get<cv::Scalar*>(arg); break;
+        case GRunArgP::index_of<cv::Scalar*>() : mag_scalar = *util::get<cv::Scalar*>(arg); break;
         default: util::throw_error(std::logic_error("content type of the runtime argument does not match to resource description ?"));
         }
         break;
@@ -375,7 +375,7 @@ void writeBack(const Mag& mag, const RcDesc &rc, GRunArgP &g_arg, bool is_umat)
     {
         switch (g_arg.index())
         {
-        case GRunArgP::index_of<cv::Scalar*>()            : *util::get<cv::Scalar*>(g_arg) = mag.template slot<cv::Scalar>().at(rc.id); break;
+        case GRunArgP::index_of<cv::Scalar*>() : *util::get<cv::Scalar*>(g_arg) = mag.template slot<cv::Scalar>().at(rc.id); break;
         default: util::throw_error(std::logic_error("content type of the runtime argument does not match to resource description ?"));
         }
         break;

--- a/modules/gapi/src/api/gbackend.cpp
+++ b/modules/gapi/src/api/gbackend.cpp
@@ -155,8 +155,8 @@ void bindInArg(Mag& mag, const RcDesc &rc, const GRunArg &arg, bool is_umat)
         auto& mag_scalar = mag.template slot<cv::Scalar>()[rc.id];
         switch (arg.index())
         {
-            case GRunArg::index_of<cv::Scalar>()            : mag_scalar = util::get<cv::Scalar>(arg);    break;
-            default: util::throw_error(std::logic_error("content type of the runtime argument does not match to resource description ?"));
+        case GRunArg::index_of<cv::Scalar>()            : mag_scalar = util::get<cv::Scalar>(arg);    break;
+        default: util::throw_error(std::logic_error("content type of the runtime argument does not match to resource description ?"));
         }
         break;
     }
@@ -222,8 +222,8 @@ void bindOutArg(Mag& mag, const RcDesc &rc, const GRunArgP &arg, bool is_umat)
         auto& mag_scalar = mag.template slot<cv::Scalar>()[rc.id];
         switch (arg.index())
         {
-            case GRunArgP::index_of<cv::Scalar*>()            : mag_scalar = *util::get<cv::Scalar*>(arg); break;
-            default: util::throw_error(std::logic_error("content type of the runtime argument does not match to resource description ?"));
+        case GRunArgP::index_of<cv::Scalar*>()            : mag_scalar = *util::get<cv::Scalar*>(arg); break;
+        default: util::throw_error(std::logic_error("content type of the runtime argument does not match to resource description ?"));
         }
         break;
     }
@@ -375,8 +375,8 @@ void writeBack(const Mag& mag, const RcDesc &rc, GRunArgP &g_arg, bool is_umat)
     {
         switch (g_arg.index())
         {
-            case GRunArgP::index_of<cv::Scalar*>()            : *util::get<cv::Scalar*>(g_arg) = mag.template slot<cv::Scalar>().at(rc.id); break;
-            default: util::throw_error(std::logic_error("content type of the runtime argument does not match to resource description ?"));
+        case GRunArgP::index_of<cv::Scalar*>()            : *util::get<cv::Scalar*>(g_arg) = mag.template slot<cv::Scalar>().at(rc.id); break;
+        default: util::throw_error(std::logic_error("content type of the runtime argument does not match to resource description ?"));
         }
         break;
     }

--- a/modules/gapi/src/api/gproto.cpp
+++ b/modules/gapi/src/api/gproto.cpp
@@ -74,7 +74,7 @@ cv::GRunArg cv::value_of(const cv::GOrigin &origin)
 {
     switch (origin.shape)
     {
-    case GShape::GSCALAR: return GRunArg(util::get<cv::gapi::own::Scalar>(origin.value));
+    case GShape::GSCALAR: return GRunArg(util::get<cv::Scalar>(origin.value));
     default: util::throw_error(std::logic_error("Unsupported shape for constant"));
     }
 }
@@ -102,15 +102,13 @@ cv::GMetaArg cv::descr_of(const cv::GRunArg &arg)
         case GRunArg::index_of<cv::Mat>():
             return cv::GMetaArg(descr_of(util::get<cv::Mat>(arg)));
 
-        case GRunArg::index_of<cv::Scalar>():
-            return cv::GMetaArg(descr_of(util::get<cv::Scalar>(arg)));
 #endif // !defined(GAPI_STANDALONE)
 
         case GRunArg::index_of<cv::gapi::own::Mat>():
             return cv::GMetaArg(descr_of(util::get<cv::gapi::own::Mat>(arg)));
 
-        case GRunArg::index_of<cv::gapi::own::Scalar>():
-            return cv::GMetaArg(descr_of(util::get<cv::gapi::own::Scalar>(arg)));
+        case GRunArg::index_of<cv::Scalar>():
+            return cv::GMetaArg(descr_of(util::get<cv::Scalar>(arg)));
 
         case GRunArg::index_of<cv::detail::VectorRef>():
             return cv::GMetaArg(util::get<cv::detail::VectorRef>(arg).descr_of());
@@ -138,11 +136,10 @@ cv::GMetaArg cv::descr_of(const cv::GRunArgP &argp)
     {
 #if !defined(GAPI_STANDALONE)
     case GRunArgP::index_of<cv::Mat*>():               return GMetaArg(descr_of(*util::get<cv::Mat*>(argp)));
-    case GRunArgP::index_of<cv::UMat*>():              return GMetaArg(descr_of(*util::get<cv::UMat*>(argp)));
-    case GRunArgP::index_of<cv::Scalar*>():            return GMetaArg(descr_of(*util::get<cv::Scalar*>(argp)));
+    case GRunArgP::index_of<cv::UMat*>():              return GMetaArg(descr_of(*util::get<cv::UMat*>(argp)));    
 #endif //  !defined(GAPI_STANDALONE)
     case GRunArgP::index_of<cv::gapi::own::Mat*>():    return GMetaArg(descr_of(*util::get<cv::gapi::own::Mat*>(argp)));
-    case GRunArgP::index_of<cv::gapi::own::Scalar*>(): return GMetaArg(descr_of(*util::get<cv::gapi::own::Scalar*>(argp)));
+    case GRunArgP::index_of<cv::Scalar*>(): return GMetaArg(descr_of(*util::get<cv::Scalar*>(argp)));
     case GRunArgP::index_of<cv::detail::VectorRef>(): return GMetaArg(util::get<cv::detail::VectorRef>(argp).descr_of());
     case GRunArgP::index_of<cv::detail::OpaqueRef>(): return GMetaArg(util::get<cv::detail::OpaqueRef>(argp).descr_of());
     default: util::throw_error(std::logic_error("Unsupported GRunArgP type"));
@@ -156,12 +153,11 @@ bool cv::can_describe(const GMetaArg& meta, const GRunArgP& argp)
 #if !defined(GAPI_STANDALONE)
     case GRunArgP::index_of<cv::Mat*>():               return util::holds_alternative<GMatDesc>(meta) &&
                                                               util::get<GMatDesc>(meta).canDescribe(*util::get<cv::Mat*>(argp));
-    case GRunArgP::index_of<cv::UMat*>():              return meta == GMetaArg(descr_of(*util::get<cv::UMat*>(argp)));
-    case GRunArgP::index_of<cv::Scalar*>():            return meta == GMetaArg(descr_of(*util::get<cv::Scalar*>(argp)));
+    case GRunArgP::index_of<cv::UMat*>():              return meta == GMetaArg(descr_of(*util::get<cv::UMat*>(argp)));    
 #endif //  !defined(GAPI_STANDALONE)
     case GRunArgP::index_of<cv::gapi::own::Mat*>():    return util::holds_alternative<GMatDesc>(meta) &&
                                                               util::get<GMatDesc>(meta).canDescribe(*util::get<cv::gapi::own::Mat*>(argp));
-    case GRunArgP::index_of<cv::gapi::own::Scalar*>(): return meta == GMetaArg(descr_of(*util::get<cv::gapi::own::Scalar*>(argp)));
+    case GRunArgP::index_of<cv::Scalar*>(): return meta == GMetaArg(descr_of(*util::get<cv::Scalar*>(argp)));
     case GRunArgP::index_of<cv::detail::VectorRef>():  return meta == GMetaArg(util::get<cv::detail::VectorRef>(argp).descr_of());
     case GRunArgP::index_of<cv::detail::OpaqueRef>():  return meta == GMetaArg(util::get<cv::detail::OpaqueRef>(argp).descr_of());
     default: util::throw_error(std::logic_error("Unsupported GRunArgP type"));
@@ -176,11 +172,10 @@ bool cv::can_describe(const GMetaArg& meta, const GRunArg& arg)
     case GRunArg::index_of<cv::Mat>():               return util::holds_alternative<GMatDesc>(meta) &&
                                                             util::get<GMatDesc>(meta).canDescribe(util::get<cv::Mat>(arg));
     case GRunArg::index_of<cv::UMat>():              return meta == cv::GMetaArg(descr_of(util::get<cv::UMat>(arg)));
-    case GRunArg::index_of<cv::Scalar>():            return meta == cv::GMetaArg(descr_of(util::get<cv::Scalar>(arg)));
 #endif //  !defined(GAPI_STANDALONE)
     case GRunArg::index_of<cv::gapi::own::Mat>():    return util::holds_alternative<GMatDesc>(meta) &&
                                                             util::get<GMatDesc>(meta).canDescribe(util::get<cv::gapi::own::Mat>(arg));
-    case GRunArg::index_of<cv::gapi::own::Scalar>(): return meta == cv::GMetaArg(descr_of(util::get<cv::gapi::own::Scalar>(arg)));
+    case GRunArg::index_of<cv::Scalar>(): return meta == cv::GMetaArg(descr_of(util::get<cv::Scalar>(arg)));
     case GRunArg::index_of<cv::detail::VectorRef>(): return meta == cv::GMetaArg(util::get<cv::detail::VectorRef>(arg).descr_of());
     case GRunArg::index_of<cv::detail::OpaqueRef>(): return meta == cv::GMetaArg(util::get<cv::detail::OpaqueRef>(arg).descr_of());
     case GRunArg::index_of<cv::gapi::wip::IStreamSource::Ptr>(): return util::holds_alternative<GMatDesc>(meta); // FIXME(?) may be not the best option

--- a/modules/gapi/src/api/gproto.cpp
+++ b/modules/gapi/src/api/gproto.cpp
@@ -175,7 +175,7 @@ bool cv::can_describe(const GMetaArg& meta, const GRunArg& arg)
 #endif //  !defined(GAPI_STANDALONE)
     case GRunArg::index_of<cv::gapi::own::Mat>():    return util::holds_alternative<GMatDesc>(meta) &&
                                                             util::get<GMatDesc>(meta).canDescribe(util::get<cv::gapi::own::Mat>(arg));
-    case GRunArg::index_of<cv::Scalar>(): return meta == cv::GMetaArg(descr_of(util::get<cv::Scalar>(arg)));
+    case GRunArg::index_of<cv::Scalar>():            return meta == cv::GMetaArg(descr_of(util::get<cv::Scalar>(arg)));
     case GRunArg::index_of<cv::detail::VectorRef>(): return meta == cv::GMetaArg(util::get<cv::detail::VectorRef>(arg).descr_of());
     case GRunArg::index_of<cv::detail::OpaqueRef>(): return meta == cv::GMetaArg(util::get<cv::detail::OpaqueRef>(arg).descr_of());
     case GRunArg::index_of<cv::gapi::wip::IStreamSource::Ptr>(): return util::holds_alternative<GMatDesc>(meta); // FIXME(?) may be not the best option

--- a/modules/gapi/src/api/gproto.cpp
+++ b/modules/gapi/src/api/gproto.cpp
@@ -136,12 +136,12 @@ cv::GMetaArg cv::descr_of(const cv::GRunArgP &argp)
     {
 #if !defined(GAPI_STANDALONE)
     case GRunArgP::index_of<cv::Mat*>():               return GMetaArg(descr_of(*util::get<cv::Mat*>(argp)));
-    case GRunArgP::index_of<cv::UMat*>():              return GMetaArg(descr_of(*util::get<cv::UMat*>(argp)));    
+    case GRunArgP::index_of<cv::UMat*>():              return GMetaArg(descr_of(*util::get<cv::UMat*>(argp)));
 #endif //  !defined(GAPI_STANDALONE)
     case GRunArgP::index_of<cv::gapi::own::Mat*>():    return GMetaArg(descr_of(*util::get<cv::gapi::own::Mat*>(argp)));
-    case GRunArgP::index_of<cv::Scalar*>(): return GMetaArg(descr_of(*util::get<cv::Scalar*>(argp)));
-    case GRunArgP::index_of<cv::detail::VectorRef>(): return GMetaArg(util::get<cv::detail::VectorRef>(argp).descr_of());
-    case GRunArgP::index_of<cv::detail::OpaqueRef>(): return GMetaArg(util::get<cv::detail::OpaqueRef>(argp).descr_of());
+    case GRunArgP::index_of<cv::Scalar*>():            return GMetaArg(descr_of(*util::get<cv::Scalar*>(argp)));
+    case GRunArgP::index_of<cv::detail::VectorRef>():  return GMetaArg(util::get<cv::detail::VectorRef>(argp).descr_of());
+    case GRunArgP::index_of<cv::detail::OpaqueRef>():  return GMetaArg(util::get<cv::detail::OpaqueRef>(argp).descr_of());
     default: util::throw_error(std::logic_error("Unsupported GRunArgP type"));
     }
 }
@@ -153,11 +153,11 @@ bool cv::can_describe(const GMetaArg& meta, const GRunArgP& argp)
 #if !defined(GAPI_STANDALONE)
     case GRunArgP::index_of<cv::Mat*>():               return util::holds_alternative<GMatDesc>(meta) &&
                                                               util::get<GMatDesc>(meta).canDescribe(*util::get<cv::Mat*>(argp));
-    case GRunArgP::index_of<cv::UMat*>():              return meta == GMetaArg(descr_of(*util::get<cv::UMat*>(argp)));    
+    case GRunArgP::index_of<cv::UMat*>():              return meta == GMetaArg(descr_of(*util::get<cv::UMat*>(argp)));
 #endif //  !defined(GAPI_STANDALONE)
     case GRunArgP::index_of<cv::gapi::own::Mat*>():    return util::holds_alternative<GMatDesc>(meta) &&
                                                               util::get<GMatDesc>(meta).canDescribe(*util::get<cv::gapi::own::Mat*>(argp));
-    case GRunArgP::index_of<cv::Scalar*>(): return meta == GMetaArg(descr_of(*util::get<cv::Scalar*>(argp)));
+    case GRunArgP::index_of<cv::Scalar*>():            return meta == GMetaArg(descr_of(*util::get<cv::Scalar*>(argp)));
     case GRunArgP::index_of<cv::detail::VectorRef>():  return meta == GMetaArg(util::get<cv::detail::VectorRef>(argp).descr_of());
     case GRunArgP::index_of<cv::detail::OpaqueRef>():  return meta == GMetaArg(util::get<cv::detail::OpaqueRef>(argp).descr_of());
     default: util::throw_error(std::logic_error("Unsupported GRunArgP type"));

--- a/modules/gapi/src/api/gscalar.cpp
+++ b/modules/gapi/src/api/gscalar.cpp
@@ -8,7 +8,7 @@
 #include "precomp.hpp"
 
 #include <opencv2/gapi/gscalar.hpp>
-#include <opencv2/gapi/own/convert.hpp>
+// #include <opencv2/gapi/own/convert.hpp>
 #include "api/gorigin.hpp"
 
 // cv::GScalar public implementation ///////////////////////////////////////////
@@ -22,18 +22,18 @@ cv::GScalar::GScalar(const GNode &n, std::size_t out)
 {
 }
 
-cv::GScalar::GScalar(const cv::gapi::own::Scalar& s)
+cv::GScalar::GScalar(const cv::Scalar& s)
     : m_priv(new GOrigin(GShape::GSCALAR, cv::gimpl::ConstVal(s)))
 {
 }
 
-cv::GScalar::GScalar(cv::gapi::own::Scalar&& s)
+cv::GScalar::GScalar(cv::Scalar&& s)
     : m_priv(new GOrigin(GShape::GSCALAR, cv::gimpl::ConstVal(std::move(s))))
 {
 }
 
 cv::GScalar::GScalar(double v0)
-    : m_priv(new GOrigin(GShape::GSCALAR, cv::gimpl::ConstVal(cv::gapi::own::Scalar(v0))))
+    : m_priv(new GOrigin(GShape::GSCALAR, cv::gimpl::ConstVal(cv::Scalar(v0))))
 {
 }
 
@@ -47,22 +47,10 @@ const cv::GOrigin& cv::GScalar::priv() const
     return *m_priv;
 }
 
-cv::GScalarDesc cv::descr_of(const cv::gapi::own::Scalar &)
+cv::GScalarDesc cv::descr_of(const cv::Scalar &)
 {
     return empty_scalar_desc();
 }
-
-#if !defined(GAPI_STANDALONE)
-cv::GScalar::GScalar(const cv::Scalar& s)
-    : m_priv(new GOrigin(GShape::GSCALAR, cv::gimpl::ConstVal(to_own(s))))
-{
-}
-
-cv::GScalarDesc cv::descr_of(const cv::Scalar& s)
-{
-    return cv::descr_of(to_own(s));
-}
-#endif // !defined(GAPI_STANDALONE)
 
 namespace cv {
 std::ostream& operator<<(std::ostream& os, const cv::GScalarDesc &)

--- a/modules/gapi/src/api/gscalar.cpp
+++ b/modules/gapi/src/api/gscalar.cpp
@@ -8,7 +8,7 @@
 #include "precomp.hpp"
 
 #include <opencv2/gapi/gscalar.hpp>
-// #include <opencv2/gapi/own/convert.hpp>
+#include <opencv2/gapi/own/convert.hpp>
 #include "api/gorigin.hpp"
 
 // cv::GScalar public implementation ///////////////////////////////////////////

--- a/modules/gapi/src/backends/common/gbackend.hpp
+++ b/modules/gapi/src/backends/common/gbackend.hpp
@@ -17,7 +17,6 @@
 #include "opencv2/gapi/own/mat.hpp"
 
 #include "opencv2/gapi/util/optional.hpp"
-#include "opencv2/gapi/own/scalar.hpp"
 
 #include "compiler/gmodel.hpp"
 

--- a/modules/gapi/src/backends/common/gbackend.hpp
+++ b/modules/gapi/src/backends/common/gbackend.hpp
@@ -46,9 +46,9 @@ namespace magazine {
 
 } // namespace magazine
 #if !defined(GAPI_STANDALONE)
-using Mag = magazine::Class<cv::gapi::own::Mat, cv::UMat, cv::gapi::own::Scalar, cv::detail::VectorRef, cv::detail::OpaqueRef>;
+using Mag = magazine::Class<cv::gapi::own::Mat, cv::UMat, cv::Scalar, cv::detail::VectorRef, cv::detail::OpaqueRef>;
 #else
-using Mag = magazine::Class<cv::gapi::own::Mat, cv::gapi::own::Scalar, cv::detail::VectorRef, cv::detail::OpaqueRef>;
+using Mag = magazine::Class<cv::gapi::own::Mat, cv::Scalar, cv::detail::VectorRef, cv::detail::OpaqueRef>;
 #endif
 
 namespace magazine

--- a/modules/gapi/src/backends/cpu/gcpubackend.cpp
+++ b/modules/gapi/src/backends/cpu/gcpubackend.cpp
@@ -129,7 +129,7 @@ cv::GArg cv::gimpl::GCPUExecutable::packArg(const GArg &arg)
     switch (ref.shape)
     {
     case GShape::GMAT:    return GArg(m_res.slot<cv::gapi::own::Mat>()   [ref.id]);
-    case GShape::GSCALAR: return GArg(m_res.slot<cv::gapi::own::Scalar>()[ref.id]);
+    case GShape::GSCALAR: return GArg(m_res.slot<cv::Scalar>()[ref.id]);
     // Note: .at() is intentional for GArray and GOpaque as objects MUST be already there
     //   (and constructed by either bindIn/Out or resetInternal)
     case GShape::GARRAY:  return GArg(m_res.slot<cv::detail::VectorRef>().at(ref.id));

--- a/modules/gapi/src/backends/cpu/gcpukernel.cpp
+++ b/modules/gapi/src/backends/cpu/gcpukernel.cpp
@@ -21,14 +21,14 @@ cv::gapi::own::Mat&  cv::GCPUContext::outMatR(int output)
     return *util::get<cv::gapi::own::Mat*>(m_results.at(output));
 }
 
-const cv::gapi::own::Scalar& cv::GCPUContext::inVal(int input)
+const cv::Scalar& cv::GCPUContext::inVal(int input)
 {
-    return inArg<cv::gapi::own::Scalar>(input);
+    return inArg<cv::Scalar>(input);
 }
 
-cv::gapi::own::Scalar& cv::GCPUContext::outValR(int output)
+cv::Scalar& cv::GCPUContext::outValR(int output)
 {
-    return *util::get<cv::gapi::own::Scalar*>(m_results.at(output));
+    return *util::get<cv::Scalar*>(m_results.at(output));
 }
 
 cv::detail::VectorRef& cv::GCPUContext::outVecRef(int output)

--- a/modules/gapi/src/backends/fluid/gfluidbackend.cpp
+++ b/modules/gapi/src/backends/fluid/gfluidbackend.cpp
@@ -1248,7 +1248,7 @@ void cv::gimpl::GFluidExecutable::bindInArg(const cv::gimpl::RcDesc &rc, const G
     switch (rc.shape)
     {
     case GShape::GMAT:    m_buffers[m_id_map.at(rc.id)].priv().bindTo(util::get<cv::gapi::own::Mat>(arg), true); break;
-    case GShape::GSCALAR: m_res.slot<cv::gapi::own::Scalar>()[rc.id] = util::get<cv::gapi::own::Scalar>(arg); break;
+    case GShape::GSCALAR: m_res.slot<cv::Scalar>()[rc.id] = util::get<cv::Scalar>(arg); break;
     case GShape::GARRAY:  m_res.slot<cv::detail::VectorRef>()[rc.id] = util::get<cv::detail::VectorRef>(arg); break;
     case GShape::GOPAQUE: m_res.slot<cv::detail::OpaqueRef>()[rc.id] = util::get<cv::detail::OpaqueRef>(arg); break;
     }
@@ -1301,7 +1301,7 @@ void cv::gimpl::GFluidExecutable::packArg(cv::GArg &in_arg, const cv::GArg &op_a
         const cv::gimpl::RcDesc &ref = op_arg.get<cv::gimpl::RcDesc>();
         if (ref.shape == GShape::GSCALAR)
         {
-            in_arg = GArg(m_res.slot<cv::gapi::own::Scalar>()[ref.id]);
+            in_arg = GArg(m_res.slot<cv::Scalar>()[ref.id]);
         }
         else if (ref.shape == GShape::GARRAY)
         {

--- a/modules/gapi/src/backends/fluid/gfluidbackend.hpp
+++ b/modules/gapi/src/backends/fluid/gfluidbackend.hpp
@@ -129,7 +129,7 @@ class GFluidExecutable final: public GIslandExecutable
 
     std::vector<FluidAgent*> m_script;
 
-    using Magazine = detail::magazine<cv::gapi::own::Scalar, cv::detail::VectorRef, cv::detail::OpaqueRef>;
+    using Magazine = detail::magazine<cv::Scalar, cv::detail::VectorRef, cv::detail::OpaqueRef>;
     Magazine m_res;
 
     std::size_t m_num_int_buffers; // internal buffers counter (m_buffers - num_scratch)

--- a/modules/gapi/src/backends/fluid/gfluidbuffer.cpp
+++ b/modules/gapi/src/backends/fluid/gfluidbuffer.cpp
@@ -181,7 +181,8 @@ const uint8_t* fluid::BorderHandlerT<cv::BORDER_CONSTANT>::inLineB(int /*log_idx
 void fluid::BorderHandlerT<cv::BORDER_CONSTANT>::fillCompileTimeBorder(BufferStorageWithBorder& data)
 {
     m_const_border.create(1, data.cols(), data.data().type());
-    m_const_border = {m_border_value[0], m_border_value[1], m_border_value[2], m_border_value[3]}; // crutch is waiting deowned mat
+    m_const_border = {m_border_value[0], m_border_value[1],
+                      m_border_value[2], m_border_value[3]};
 
     cv::gapi::fillBorderConstant(m_border_size, m_border_value, data.data());
 }

--- a/modules/gapi/src/backends/fluid/gfluidbuffer.cpp
+++ b/modules/gapi/src/backends/fluid/gfluidbuffer.cpp
@@ -181,6 +181,7 @@ const uint8_t* fluid::BorderHandlerT<cv::BORDER_CONSTANT>::inLineB(int /*log_idx
 void fluid::BorderHandlerT<cv::BORDER_CONSTANT>::fillCompileTimeBorder(BufferStorageWithBorder& data)
 {
     m_const_border.create(1, data.cols(), data.data().type());
+    // FIXME: remove this crutch in deowned Mat
     m_const_border = {m_border_value[0], m_border_value[1],
                       m_border_value[2], m_border_value[3]};
 

--- a/modules/gapi/src/backends/fluid/gfluidbuffer.cpp
+++ b/modules/gapi/src/backends/fluid/gfluidbuffer.cpp
@@ -181,7 +181,7 @@ const uint8_t* fluid::BorderHandlerT<cv::BORDER_CONSTANT>::inLineB(int /*log_idx
 void fluid::BorderHandlerT<cv::BORDER_CONSTANT>::fillCompileTimeBorder(BufferStorageWithBorder& data)
 {
     m_const_border.create(1, data.cols(), data.data().type());
-    m_const_border = m_border_value;
+    m_const_border = {m_border_value[0], m_border_value[1], m_border_value[2], m_border_value[3]}; // to_own crutch
 
     cv::gapi::fillBorderConstant(m_border_size, m_border_value, data.data());
 }

--- a/modules/gapi/src/backends/fluid/gfluidbuffer.cpp
+++ b/modules/gapi/src/backends/fluid/gfluidbuffer.cpp
@@ -181,7 +181,7 @@ const uint8_t* fluid::BorderHandlerT<cv::BORDER_CONSTANT>::inLineB(int /*log_idx
 void fluid::BorderHandlerT<cv::BORDER_CONSTANT>::fillCompileTimeBorder(BufferStorageWithBorder& data)
 {
     m_const_border.create(1, data.cols(), data.data().type());
-    m_const_border = {m_border_value[0], m_border_value[1], m_border_value[2], m_border_value[3]}; // to_own crutch
+    m_const_border = {m_border_value[0], m_border_value[1], m_border_value[2], m_border_value[3]}; // crutch is waiting deowned mat
 
     cv::gapi::fillBorderConstant(m_border_size, m_border_value, data.data());
 }

--- a/modules/gapi/src/backends/fluid/gfluidbuffer.cpp
+++ b/modules/gapi/src/backends/fluid/gfluidbuffer.cpp
@@ -64,7 +64,7 @@ void fillBorderReflectRow(uint8_t* row, int length, int chan, int borderSize)
 }
 
 template<typename T>
-void fillConstBorderRow(uint8_t* row, int length, int chan, int borderSize, cv::gapi::own::Scalar borderValue)
+void fillConstBorderRow(uint8_t* row, int length, int chan, int borderSize, cv::Scalar borderValue)
 {
     GAPI_DbgAssert(chan > 0 && chan <= 4);
 
@@ -81,7 +81,7 @@ void fillConstBorderRow(uint8_t* row, int length, int chan, int borderSize, cv::
 }
 
 // Fills const border pixels in the whole mat
-void fillBorderConstant(int borderSize, cv::gapi::own::Scalar borderValue, cv::gapi::own::Mat& mat)
+void fillBorderConstant(int borderSize, cv::Scalar borderValue, cv::gapi::own::Mat& mat)
 {
     // cv::Scalar can contain maximum 4 chan
     GAPI_Assert(mat.channels() > 0 && mat.channels() <= 4);
@@ -169,7 +169,7 @@ const uint8_t* fluid::BorderHandlerT<BorderType>::inLineB(int log_idx, const Buf
     return data.ptr(idx);
 }
 
-fluid::BorderHandlerT<cv::BORDER_CONSTANT>::BorderHandlerT(int border_size, cv::gapi::own::Scalar border_value)
+fluid::BorderHandlerT<cv::BORDER_CONSTANT>::BorderHandlerT(int border_size, cv::Scalar border_value)
     : BorderHandler(border_size), m_border_value(border_value)
 { /* nothing */ }
 

--- a/modules/gapi/src/backends/fluid/gfluidbuffer_priv.hpp
+++ b/modules/gapi/src/backends/fluid/gfluidbuffer_priv.hpp
@@ -52,11 +52,11 @@ public:
 template<>
 class BorderHandlerT<cv::BORDER_CONSTANT> : public BorderHandler
 {
-    cv::gapi::own::Scalar m_border_value;
+    cv::Scalar m_border_value;
     cv::gapi::own::Mat m_const_border;
 
 public:
-    BorderHandlerT(int border_size, cv::gapi::own::Scalar border_value);
+    BorderHandlerT(int border_size, cv::Scalar border_value);
     virtual const uint8_t* inLineB(int log_idx, const BufferStorageWithBorder &data, int desc_height) const override;
     virtual void fillCompileTimeBorder(BufferStorageWithBorder &) override;
     virtual std::size_t size() const override;

--- a/modules/gapi/src/backends/fluid/gfluidimgproc.cpp
+++ b/modules/gapi/src/backends/fluid/gfluidimgproc.cpp
@@ -1525,7 +1525,7 @@ GAPI_FLUID_KERNEL(GFluidErode, cv::gapi::imgproc::GErode, true)
     #if 1
         // TODO: saturate borderValue to image type in general case (not only maximal border)
         GAPI_Assert(borderType == cv::BORDER_CONSTANT && borderValue[0] == DBL_MAX);
-        return { borderType, cv::gapi::own::Scalar::all(INT_MAX) };
+        return { borderType, cv::Scalar::all(INT_MAX) };
     #else
         return { borderType, borderValue };
     #endif
@@ -1611,7 +1611,7 @@ GAPI_FLUID_KERNEL(GFluidDilate, cv::gapi::imgproc::GDilate, true)
     #if 1
         // TODO: fix borderValue for Dilate in general case (not only minimal border)
         GAPI_Assert(borderType == cv::BORDER_CONSTANT && borderValue[0] == DBL_MAX);
-        return { borderType, cv::gapi::own::Scalar::all(INT_MIN) };
+        return { borderType, cv::Scalar::all(INT_MIN) };
     #else
         return { borderType, borderValue };
     #endif

--- a/modules/gapi/src/backends/ocl/goclbackend.cpp
+++ b/modules/gapi/src/backends/ocl/goclbackend.cpp
@@ -129,7 +129,7 @@ cv::GArg cv::gimpl::GOCLExecutable::packArg(const GArg &arg)
     switch (ref.shape)
     {
     case GShape::GMAT:    return GArg(m_res.slot<cv::UMat>()[ref.id]);
-    case GShape::GSCALAR: return GArg(m_res.slot<cv::gapi::own::Scalar>()[ref.id]);
+    case GShape::GSCALAR: return GArg(m_res.slot<cv::Scalar>()[ref.id]);
     // Note: .at() is intentional for GArray as object MUST be already there
     //   (and constructed by either bindIn/Out or resetInternal)
     case GShape::GARRAY:  return GArg(m_res.slot<cv::detail::VectorRef>().at(ref.id));

--- a/modules/gapi/src/backends/ocl/goclkernel.cpp
+++ b/modules/gapi/src/backends/ocl/goclkernel.cpp
@@ -19,14 +19,14 @@ cv::UMat& cv::GOCLContext::outMatR(int output)
     return (*(util::get<cv::UMat*>(m_results.at(output))));
 }
 
-const cv::gapi::own::Scalar& cv::GOCLContext::inVal(int input)
+const cv::Scalar& cv::GOCLContext::inVal(int input)
 {
-    return inArg<cv::gapi::own::Scalar>(input);
+    return inArg<cv::Scalar>(input);
 }
 
-cv::gapi::own::Scalar& cv::GOCLContext::outValR(int output)
+cv::Scalar& cv::GOCLContext::outValR(int output)
 {
-    return *util::get<cv::gapi::own::Scalar*>(m_results.at(output));
+    return *util::get<cv::Scalar*>(m_results.at(output));
 }
 
 cv::detail::VectorRef& cv::GOCLContext::outVecRef(int output)

--- a/modules/gapi/src/compiler/gobjref.hpp
+++ b/modules/gapi/src/compiler/gobjref.hpp
@@ -28,7 +28,7 @@ namespace gimpl
 
     using ConstVal = util::variant
     < util::monostate
-    , cv::gapi::own::Scalar
+    , cv::Scalar
     >;
 
     struct RcDesc

--- a/modules/gapi/src/executor/gstreamingexecutor.cpp
+++ b/modules/gapi/src/executor/gstreamingexecutor.cpp
@@ -415,7 +415,7 @@ void islandActorThread(std::vector<cv::gimpl::RcDesc> in_rcs,                // 
                 isl_input.second = cv::GRunArg{cv::to_own(cv::util::get<cv::Mat>(in_arg))};
                 break;
             case cv::GRunArg::index_of<cv::Scalar>():
-                isl_input.second = cv::GRunArg{cv::to_own(cv::util::get<cv::Scalar>(in_arg))};
+                isl_input.second = cv::GRunArg{cv::util::get<cv::Scalar>(in_arg)};
                 break;
             default:
                 isl_input.second = in_arg;

--- a/modules/gapi/src/executor/gstreamingexecutor.cpp
+++ b/modules/gapi/src/executor/gstreamingexecutor.cpp
@@ -112,15 +112,12 @@ void sync_data(cv::GRunArgs &results, cv::GRunArgsP &outputs)
         case T::index_of<cv::Mat*>():
             *cv::util::get<cv::Mat*>(out_obj) = std::move(cv::util::get<cv::Mat>(res_obj));
             break;
-        case T::index_of<cv::Scalar*>():
-            *cv::util::get<cv::Scalar*>(out_obj) = std::move(cv::util::get<cv::Scalar>(res_obj));
-            break;
 #endif // !GAPI_STANDALONE
         case T::index_of<own::Mat*>():
             *cv::util::get<own::Mat*>(out_obj) = std::move(cv::util::get<own::Mat>(res_obj));
             break;
-        case T::index_of<own::Scalar*>():
-            *cv::util::get<own::Scalar*>(out_obj) = std::move(cv::util::get<own::Scalar>(res_obj));
+        case T::index_of<cv::Scalar*>():
+            *cv::util::get<cv::Scalar*>(out_obj) = std::move(cv::util::get<cv::Scalar>(res_obj));
             break;
         case T::index_of<cv::detail::VectorRef>():
             cv::util::get<cv::detail::VectorRef>(out_obj).mov(cv::util::get<cv::detail::VectorRef>(res_obj));
@@ -443,7 +440,7 @@ void islandActorThread(std::vector<cv::gimpl::RcDesc> in_rcs,                // 
             using SclType = cv::Scalar;
 #else
             using MatType = cv::gapi::own::Mat;
-            using SclType = cv::gapi::own::Scalar;
+            using SclType = cv::Scalar;
 #endif // GAPI_STANDALONE
 
             switch (r.shape) {

--- a/modules/gapi/test/gapi_async_test.cpp
+++ b/modules/gapi/test/gapi_async_test.cpp
@@ -387,11 +387,11 @@ namespace {
             //FIXME: replace this switch with use of visit() on variant, when it will be available
             switch (arg.index()){
     #if !defined(GAPI_STANDALONE)
-                case GRunArgP::index_of<cv::Mat*>()                 :   result.emplace_back(*util::get<cv::Mat*>(arg));     break;                
+                case GRunArgP::index_of<cv::Mat*>()                 :   result.emplace_back(*util::get<cv::Mat*>(arg));     break;
                 case GRunArgP::index_of<cv::UMat*>()                :   result.emplace_back(*util::get<cv::UMat*>(arg));    break;
     #endif // !defined(GAPI_STANDALONE)
                 case GRunArgP::index_of<cv::gapi::own::Mat*>()      :   result.emplace_back(*util::get<cv::gapi::own::Mat*>   (arg));   break;
-                case GRunArgP::index_of<cv::Scalar*>()   :   result.emplace_back(*util::get<cv::Scalar*>(arg));   break;
+                case GRunArgP::index_of<cv::Scalar*>()              :   result.emplace_back(*util::get<cv::Scalar*>           (arg));   break;
                 case GRunArgP::index_of<cv::detail::VectorRef>()    :   result.emplace_back(util::get<cv::detail::VectorRef>  (arg));   break;
                 default : ;
             }
@@ -404,12 +404,12 @@ namespace {
         for (auto&& arg : args){
             switch (arg.index()){
     #if !defined(GAPI_STANDALONE)
-                case GRunArg::index_of<cv::Mat>()                 :   result.emplace_back(&util::get<cv::Mat>(arg));     break;                
+                case GRunArg::index_of<cv::Mat>()                 :   result.emplace_back(&util::get<cv::Mat>(arg));     break;
                 case GRunArg::index_of<cv::UMat>()                :   result.emplace_back(&util::get<cv::UMat>(arg));    break;
     #endif // !defined(GAPI_STANDALONE)
                 case GRunArg::index_of<cv::gapi::own::Mat>()      :   result.emplace_back(&util::get<cv::gapi::own::Mat>   (arg));   break;
-                case GRunArg::index_of<cv::Scalar>()   :   result.emplace_back(&util::get<cv::Scalar>(arg));   break;
-                case GRunArg::index_of<cv::detail::VectorRef>()   :   result.emplace_back(util::get<cv::detail::VectorRef>  (arg));   break;
+                case GRunArg::index_of<cv::Scalar>()              :   result.emplace_back(&util::get<cv::Scalar>           (arg));   break;
+                case GRunArg::index_of<cv::detail::VectorRef>()   :   result.emplace_back(util::get<cv::detail::VectorRef> (arg));   break;
                 default : ;
             }
         }

--- a/modules/gapi/test/gapi_async_test.cpp
+++ b/modules/gapi/test/gapi_async_test.cpp
@@ -387,12 +387,11 @@ namespace {
             //FIXME: replace this switch with use of visit() on variant, when it will be available
             switch (arg.index()){
     #if !defined(GAPI_STANDALONE)
-                case GRunArgP::index_of<cv::Mat*>()                 :   result.emplace_back(*util::get<cv::Mat*>(arg));     break;
-                case GRunArgP::index_of<cv::Scalar*>()              :   result.emplace_back(*util::get<cv::Scalar*>(arg));  break;
+                case GRunArgP::index_of<cv::Mat*>()                 :   result.emplace_back(*util::get<cv::Mat*>(arg));     break;                
                 case GRunArgP::index_of<cv::UMat*>()                :   result.emplace_back(*util::get<cv::UMat*>(arg));    break;
     #endif // !defined(GAPI_STANDALONE)
                 case GRunArgP::index_of<cv::gapi::own::Mat*>()      :   result.emplace_back(*util::get<cv::gapi::own::Mat*>   (arg));   break;
-                case GRunArgP::index_of<cv::gapi::own::Scalar*>()   :   result.emplace_back(*util::get<cv::gapi::own::Scalar*>(arg));   break;
+                case GRunArgP::index_of<cv::Scalar*>()   :   result.emplace_back(*util::get<cv::Scalar*>(arg));   break;
                 case GRunArgP::index_of<cv::detail::VectorRef>()    :   result.emplace_back(util::get<cv::detail::VectorRef>  (arg));   break;
                 default : ;
             }
@@ -405,12 +404,11 @@ namespace {
         for (auto&& arg : args){
             switch (arg.index()){
     #if !defined(GAPI_STANDALONE)
-                case GRunArg::index_of<cv::Mat>()                 :   result.emplace_back(&util::get<cv::Mat>(arg));     break;
-                case GRunArg::index_of<cv::Scalar>()              :   result.emplace_back(&util::get<cv::Scalar>(arg));  break;
+                case GRunArg::index_of<cv::Mat>()                 :   result.emplace_back(&util::get<cv::Mat>(arg));     break;                
                 case GRunArg::index_of<cv::UMat>()                :   result.emplace_back(&util::get<cv::UMat>(arg));    break;
     #endif // !defined(GAPI_STANDALONE)
                 case GRunArg::index_of<cv::gapi::own::Mat>()      :   result.emplace_back(&util::get<cv::gapi::own::Mat>   (arg));   break;
-                case GRunArg::index_of<cv::gapi::own::Scalar>()   :   result.emplace_back(&util::get<cv::gapi::own::Scalar>(arg));   break;
+                case GRunArg::index_of<cv::Scalar>()   :   result.emplace_back(&util::get<cv::Scalar>(arg));   break;
                 case GRunArg::index_of<cv::detail::VectorRef>()   :   result.emplace_back(util::get<cv::detail::VectorRef>  (arg));   break;
                 default : ;
             }

--- a/modules/gapi/test/gapi_fluid_test.cpp
+++ b/modules/gapi/test/gapi_fluid_test.cpp
@@ -75,7 +75,7 @@ TEST(FluidBuffer, CircularTest)
     const cv::Size buffer_size = {8,16};
 
     cv::gapi::fluid::Buffer buffer(cv::GMatDesc{CV_8U,1,buffer_size}, 3, 1, 0, 1,
-        util::make_optional(cv::gapi::fluid::Border{cv::BORDER_CONSTANT, cv::gapi::own::Scalar(255)}));
+        util::make_optional(cv::gapi::fluid::Border{cv::BORDER_CONSTANT, cv::Scalar(255)}));
     cv::gapi::fluid::View view = buffer.mkView(1, {});
     view.priv().reset(3);
     view.priv().allocate(3, {});

--- a/modules/gapi/test/gapi_fluid_test_kernels.cpp
+++ b/modules/gapi/test/gapi_fluid_test_kernels.cpp
@@ -184,7 +184,7 @@ GAPI_FLUID_KERNEL(FBlur3x3, TBlur3x3, false)
 
     static cv::gapi::fluid::Border getBorder(const cv::GMatDesc &/*src*/, int borderType, cv::Scalar borderValue)
     {
-        return { borderType, to_own(borderValue)};
+        return { borderType, borderValue};
     }
 };
 
@@ -200,7 +200,7 @@ GAPI_FLUID_KERNEL(FBlur5x5, TBlur5x5, false)
 
     static cv::gapi::fluid::Border getBorder(const cv::GMatDesc &/*src*/, int borderType, cv::Scalar borderValue)
     {
-        return { borderType, to_own(borderValue)};
+        return { borderType, borderValue};
     }
 };
 
@@ -217,7 +217,7 @@ GAPI_FLUID_KERNEL(FBlur3x3_2lpi, TBlur3x3_2lpi, false)
 
     static cv::gapi::fluid::Border getBorder(const cv::GMatDesc &/*src*/, int borderType, cv::Scalar borderValue)
     {
-        return { borderType, to_own(borderValue)};
+        return { borderType, borderValue};
     }
 };
 
@@ -234,7 +234,7 @@ GAPI_FLUID_KERNEL(FBlur5x5_2lpi, TBlur5x5_2lpi, false)
 
     static cv::gapi::fluid::Border getBorder(const cv::GMatDesc &/*src*/, int borderType, cv::Scalar borderValue)
     {
-        return { borderType, to_own(borderValue )};
+        return { borderType, borderValue};
     }
 };
 

--- a/modules/gapi/test/gapi_fluid_test_kernels.cpp
+++ b/modules/gapi/test/gapi_fluid_test_kernels.cpp
@@ -261,7 +261,7 @@ GAPI_FLUID_KERNEL(FIdentity, TId, false)
 
     static gapi::fluid::Border getBorder(const cv::GMatDesc &)
     {
-        return { cv::BORDER_REPLICATE, cv::gapi::own::Scalar{} };
+        return { cv::BORDER_REPLICATE, cv::Scalar{} };
     }
 };
 
@@ -308,7 +308,7 @@ GAPI_FLUID_KERNEL(FId7x7, TId7x7, false)
 
     static cv::gapi::fluid::Border getBorder(const cv::GMatDesc&/* src*/)
     {
-        return { cv::BORDER_REPLICATE, cv::gapi::own::Scalar{} };
+        return { cv::BORDER_REPLICATE, cv::Scalar{} };
     }
 };
 

--- a/modules/gapi/test/gapi_kernel_tests.cpp
+++ b/modules/gapi/test/gapi_kernel_tests.cpp
@@ -6,7 +6,6 @@
 
 
 #include "test_precomp.hpp"
-#include <opencv2/gapi/cpu/gcpukernel.hpp>
 #include "gapi_mock_kernels.hpp"
 
 #include <opencv2/gapi/cpu/gcpukernel.hpp>     // cpu::backend

--- a/modules/gapi/test/internal/gapi_int_gmetaarg_test.cpp
+++ b/modules/gapi/test/internal/gapi_int_gmetaarg_test.cpp
@@ -141,7 +141,7 @@ TEST(GMetaArg, Can_Describe_RunArg)
     constexpr int w = 3, h = 3, c = 3;
     uchar data[w*h*c];
     cv::gapi::own::Mat om(h, w, CV_8UC3, data);
-    cv::gapi::own::Scalar os;
+    cv::Scalar os;
     std::vector<int> v;
 
     GMetaArgs metas = {GMetaArg(descr_of(m)),
@@ -181,7 +181,7 @@ TEST(GMetaArg, Can_Describe_RunArgP)
     constexpr int w = 3, h = 3, c = 3;
     uchar data[w*h*c];
     cv::gapi::own::Mat om(h, w, CV_8UC3, data);
-    cv::gapi::own::Scalar os;
+    cv::Scalar os;
     std::vector<int> v;
 
     GMetaArgs metas = {GMetaArg(descr_of(m)),

--- a/modules/gapi/test/internal/gapi_int_gmodel_builder_test.cpp
+++ b/modules/gapi/test/internal/gapi_int_gmodel_builder_test.cpp
@@ -166,8 +166,8 @@ TEST(GModelBuilder, Constant_GScalar)
     EXPECT_EQ(9u, static_cast<std::size_t>(g.nodes().size()));          // 6 data nodes (1 -input, 1 output, 2 constant, 2 temp) and 3 op nodes
     EXPECT_EQ(2u, static_cast<std::size_t>(addC_nh->inNodes().size())); // in and 3
     EXPECT_EQ(2u, static_cast<std::size_t>(mulC_nh->inNodes().size())); // addC output and c_s
-    EXPECT_EQ(3, (util::get<cv::gapi::own::Scalar>(gm.metadata(s_3).get<cv::gimpl::ConstValue>().arg))[0]);
-    EXPECT_EQ(5, (util::get<cv::gapi::own::Scalar>(gm.metadata(s_5).get<cv::gimpl::ConstValue>().arg))[0]);
+    EXPECT_EQ(3, (util::get<cv::Scalar>(gm.metadata(s_3).get<cv::gimpl::ConstValue>().arg))[0]);
+    EXPECT_EQ(5, (util::get<cv::Scalar>(gm.metadata(s_5).get<cv::gimpl::ConstValue>().arg))[0]);
 }
 
 TEST(GModelBuilder, Check_Multiple_Outputs)


### PR DESCRIPTION
### Deowned Scalar
Added:
- using Scalar = gapi::own::Scalar in `cvdefs.hpp`.

Removed from code:
- `gapi::own::` for Scalar.

Tests:
- non-GAPI_STANDALONE tests passed;
- GAPI_STANDALONE `fluid_preproc_tests` passed*.

#### Description:
We build gapi_module with GAPI_STANDALONE = ON, then we use `gapi::own::Scalar` instead `Scalar`. We make a substitution in `cvdefs.hpp`. `cvdefs.hpp` included in `opencv2/gapi/opencv_includes.hpp` when GAPI_STANDALONE=ON. 
Therefore `cv::gapi::own::Scalar` disappears in code. We change it to `cv::Scalar` in code (GRunArg without `own::Scalar` now, but `cv::Scalar` isn't under `#if !defined(GAPI_STANDALONE)` for example). 
Conversion methods for Scalar removed (no need anymore). `../own/scalar.hpp` header removed from files (except own/mat.hpp (for mat_tests) and tests). `../own/scalar.hpp` included in  `cvdefs.hpp` now.
And
- if we build OpenCV (GAPI_STANDALONE = OFF), then `cv::Scalar` is `cv::Scalar` (from ocv);
- if we build gapi_module (GAPI_STANDALONE = ON), then `cv::Scalar` is `cv::gapi::own::Scalar` (from own/scalar.hpp)

in code now.

### Pull Request Readiness Checklist
- [x]  I agree to contribute to the project under OpenCV (BSD) License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [x] The PR is proposed to proper branch
- [ ] There is reference to original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
- [ ] Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake

```
build_image:Custom=centos:7
buildworker:Custom=linux-1

build_gapi_standalone:Linux x64=ade-0.1.1f
build_gapi_standalone:Win64=ade-0.1.1f
build_gapi_standalone:Mac=ade-0.1.1f
build_gapi_standalone:Linux x64 Debug=ade-0.1.1f
```