### PR TITLE
core:vsx reimplement `v_broadcast_element()`

### DIFF
--- a/modules/core/include/opencv2/core/hal/intrin_vsx.hpp
+++ b/modules/core/include/opencv2/core/hal/intrin_vsx.hpp
@@ -1564,81 +1564,10 @@ OPENCV_HAL_IMPL_VSX_TRANSPOSE4x4(v_uint32x4, vec_uint4)
 OPENCV_HAL_IMPL_VSX_TRANSPOSE4x4(v_int32x4, vec_int4)
 OPENCV_HAL_IMPL_VSX_TRANSPOSE4x4(v_float32x4, vec_float4)
 
-template<int i>
-inline v_int8x16 v_broadcast_element(v_int8x16 v)
-{
-    return v_int8x16(vec_perm(v.val, v.val, vec_splats((unsigned char)i)));
-}
+template<int i, typename Tvec>
+inline Tvec v_broadcast_element(const Tvec& v)
+{ return Tvec(vec_splat(v.val, i)); }
 
-template<int i>
-inline v_uint8x16 v_broadcast_element(v_uint8x16 v)
-{
-    return v_uint8x16(vec_perm(v.val, v.val, vec_splats((unsigned char)i)));
-}
-
-template<int i>
-inline v_int16x8 v_broadcast_element(v_int16x8 v)
-{
-    unsigned char t0 = 2*i, t1 = 2*i + 1;
-    vec_uchar16 p = {t0, t1, t0, t1, t0, t1, t0, t1, t0, t1, t0, t1, t0, t1, t0, t1};
-    return v_int16x8(vec_perm(v.val, v.val, p));
-}
-
-template<int i>
-inline v_uint16x8 v_broadcast_element(v_uint16x8 v)
-{
-    unsigned char t0 = 2*i, t1 = 2*i + 1;
-    vec_uchar16 p = {t0, t1, t0, t1, t0, t1, t0, t1, t0, t1, t0, t1, t0, t1, t0, t1};
-    return v_uint16x8(vec_perm(v.val, v.val, p));
-}
-
-template<int i>
-inline v_int32x4 v_broadcast_element(v_int32x4 v)
-{
-    unsigned char t0 = 4*i, t1 = 4*i + 1, t2 = 4*i + 2, t3 = 4*i + 3;
-    vec_uchar16 p = {t0, t1, t2, t3, t0, t1, t2, t3, t0, t1, t2, t3, t0, t1, t2, t3};
-    return v_int32x4(vec_perm(v.val, v.val, p));
-}
-
-template<int i>
-inline v_uint32x4 v_broadcast_element(v_uint32x4 v)
-{
-    unsigned char t0 = 4*i, t1 = 4*i + 1, t2 = 4*i + 2, t3 = 4*i + 3;
-    vec_uchar16 p = {t0, t1, t2, t3, t0, t1, t2, t3, t0, t1, t2, t3, t0, t1, t2, t3};
-    return v_uint32x4(vec_perm(v.val, v.val, p));
-}
-
-template<int i>
-inline v_int64x2 v_broadcast_element(v_int64x2 v)
-{
-    unsigned char t0 = 8*i, t1 = 8*i + 1, t2 = 8*i + 2, t3 = 8*i + 3, t4 = 8*i + 4, t5 = 8*i + 5, t6 = 8*i + 6, t7 = 8*i + 7;
-    vec_uchar16 p = {t0, t1, t2, t3, t4, t5, t6, t7, t0, t1, t2, t3, t4, t5, t6, t7};
-    return v_int64x2(vec_perm(v.val, v.val, p));
-}
-
-template<int i>
-inline v_uint64x2 v_broadcast_element(v_uint64x2 v)
-{
-    unsigned char t0 = 8*i, t1 = 8*i + 1, t2 = 8*i + 2, t3 = 8*i + 3, t4 = 8*i + 4, t5 = 8*i + 5, t6 = 8*i + 6, t7 = 8*i + 7;
-    vec_uchar16 p = {t0, t1, t2, t3, t4, t5, t6, t7, t0, t1, t2, t3, t4, t5, t6, t7};
-    return v_uint64x2(vec_perm(v.val, v.val, p));
-}
-
-template<int i>
-inline v_float32x4 v_broadcast_element(v_float32x4 v)
-{
-    unsigned char t0 = 4*i, t1 = 4*i + 1, t2 = 4*i + 2, t3 = 4*i + 3;
-    vec_uchar16 p = {t0, t1, t2, t3, t0, t1, t2, t3, t0, t1, t2, t3, t0, t1, t2, t3};
-    return v_float32x4(vec_perm(v.val, v.val, p));
-}
-
-template<int i>
-inline v_float64x2 v_broadcast_element(v_float64x2 v)
-{
-    unsigned char t0 = 8*i, t1 = 8*i + 1, t2 = 8*i + 2, t3 = 8*i + 3, t4 = 8*i + 4, t5 = 8*i + 5, t6 = 8*i + 6, t7 = 8*i + 7;
-    vec_uchar16 p = {t0, t1, t2, t3, t4, t5, t6, t7, t0, t1, t2, t3, t4, t5, t6, t7};
-    return v_float64x2(vec_perm(v.val, v.val, p));
-}
 
 CV_CPU_OPTIMIZATION_HAL_NAMESPACE_END
 


### PR DESCRIPTION
releated to #15494
#### core:vsx reimplement `v_broadcast_element()`

 There's no need to use `vec_perm()` instead of `vec_splat()`,
  since instruction `vperm` is quite heavy compared to `vsplt[b,h,w]`.

````
force_builders=Custom
build_image:Custom=powerpc64le
buildworker:Custom=linux-1
````

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under OpenCV (BSD) License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [x] The PR is proposed to proper branch
- [x] There is reference to original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
