### PR TITLE
Update template_matching.markdown

### DIFF
--- a/doc/tutorials/imgproc/histograms/template_matching/template_matching.markdown
+++ b/doc/tutorials/imgproc/histograms/template_matching/template_matching.markdown
@@ -31,7 +31,7 @@ that should be used to find the match.
 -   We need two primary components:
 
     -#  **Source image (I):** The image in which we expect to find a match to the template image
-    -#  **Template image (T):** The patch image which will be compared to the template image
+    -#  **Template image (T):** The patch image which will be compared to the source image
 
     our goal is to detect the highest matching area:
 
@@ -61,7 +61,7 @@ that should be used to find the match.
 - If masking is needed for the match, three components are required:
 
     -#  **Source image (I):** The image in which we expect to find a match to the template image
-    -#  **Template image (T):** The patch image which will be compared to the template image
+    -#  **Template image (T):** The patch image which will be compared to the source image
     -#  **Mask image (M):** The mask, a grayscale image that masks the template
 
 


### PR DESCRIPTION
Fixed "template image" should be "source image" in two sentences explaining template matching.

<cut/>

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under OpenCV (BSD) License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [x] The PR is proposed to proper branch
- [ ] There is reference to original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake


```
force_builders=docs
```