### PR TITLE
more robust error handling

### DIFF
--- a/modules/core/src/persistence.cpp
+++ b/modules/core/src/persistence.cpp
@@ -704,10 +704,15 @@ public:
             const char* json_signature = "{";
             const char* xml_signature  = "<?xml";
             char* buf = this->gets(16);
-            char* bufPtr = !buf ? "" : cv_skip_BOM(buf);
-            size_t bufOffset = bufPtr - buf;
+            char* bufPtr = !buf ? 0 : cv_skip_BOM(buf);
+            size_t bufOffset = (bufPtr - buf);
 
-            if(strncmp( bufPtr, yaml_signature, strlen(yaml_signature) ) == 0)
+            if(!bufPtr)
+            {
+                closeFile();
+                CV_Error(CV_BADARG_ERR, "Input file is invalid");
+            }
+            else if(strncmp( bufPtr, yaml_signature, strlen(yaml_signature) ) == 0)
                 fmt = FileStorage::FORMAT_YAML;
             else if(strncmp( bufPtr, json_signature, strlen(json_signature) ) == 0)
                 fmt = FileStorage::FORMAT_JSON;

--- a/modules/core/src/persistence.cpp
+++ b/modules/core/src/persistence.cpp
@@ -408,13 +408,13 @@ public:
                     puts( "}\n" );
             }
 
-            closeFile();
             if( mem_mode && out )
             {
                 *out = cv::String(outbuf.begin(), outbuf.end());
             }
-            init();
         }
+        closeFile();
+        init();
     }
 
     void analyze_file_name( const std::string& file_name, std::vector<std::string>& params )

--- a/modules/core/src/persistence.cpp
+++ b/modules/core/src/persistence.cpp
@@ -704,7 +704,7 @@ public:
             const char* json_signature = "{";
             const char* xml_signature  = "<?xml";
             char* buf = this->gets(16);
-            char* bufPtr = cv_skip_BOM(buf);
+            char* bufPtr = !buf ? "" : cv_skip_BOM(buf);
             size_t bufOffset = bufPtr - buf;
 
             if(strncmp( bufPtr, yaml_signature, strlen(yaml_signature) ) == 0)
@@ -714,9 +714,15 @@ public:
             else if(strncmp( bufPtr, xml_signature, strlen(xml_signature) ) == 0)
                 fmt = FileStorage::FORMAT_XML;
             else if(strbufsize  == bufOffset)
+            {
+                closeFile();
                 CV_Error(CV_BADARG_ERR, "Input file is invalid");
+            }
             else
+            {
+                closeFile();
                 CV_Error(CV_BADARG_ERR, "Unsupported file storage format");
+            }
 
             rewind();
             strbufpos = bufOffset;


### PR DESCRIPTION
Fixed #16823 (OOB crash and resource leaking for invalid empty yml file)

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under OpenCV (BSD) License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [x] The PR is proposed to proper branch
- [x] There is reference to original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
