### PR TITLE
objdetect: fix QRCode tests with disabled QUIRC

### DIFF
--- a/modules/objdetect/test/test_qrcode.cpp
+++ b/modules/objdetect/test/test_qrcode.cpp
@@ -284,7 +284,7 @@ TEST_P(Objdetect_QRCode_Close, regression)
     ASSERT_FALSE(corners.empty());
     ASSERT_FALSE(decoded_info.empty());
 #else
-    ASSERT_TRUE(qrcode.detect(src, corners));
+    ASSERT_TRUE(qrcode.detect(barcode, corners));
 #endif
 
     const std::string dataset_config = findDataFile(root + "dataset_config.json");
@@ -349,7 +349,7 @@ TEST_P(Objdetect_QRCode_Monitor, regression)
     ASSERT_FALSE(corners.empty());
     ASSERT_FALSE(decoded_info.empty());
 #else
-    ASSERT_TRUE(qrcode.detect(src, corners));
+    ASSERT_TRUE(qrcode.detect(barcode, corners));
 #endif
 
     const std::string dataset_config = findDataFile(root + "dataset_config.json");


### PR DESCRIPTION
Two _objdetect_ tests were failing in build configurations without QUIRC (`WITH_QUIRC=OFF`) due to invalid input image being used.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under OpenCV (BSD) License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [x] The PR is proposed to proper branch
- [x] There is reference to original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
