### PR TITLE
[WIP] cuda4dnn: release and relock page-locked memory when tensor is resized

### DIFF
--- a/modules/dnn/src/cuda4dnn/csl/memory.hpp
+++ b/modules/dnn/src/cuda4dnn/csl/memory.hpp
@@ -276,14 +276,22 @@ namespace cv { namespace dnn { namespace cuda4dnn { namespace csl {
 
         MemoryLockGuard& operator=(const MemoryLockGuard&) = delete;
         MemoryLockGuard& operator=(MemoryLockGuard&& other) noexcept {
-            ptr = other.ptr;
-            other.ptr = nullptr;
+            if (&other != this) {
+                if(ptr != nullptr) {
+                    /* cudaHostUnregister does not throw for a valid ptr */
+                    CUDA4DNN_CHECK_CUDA(cudaHostUnregister(ptr));
+                }
+                ptr = other.ptr;
+                other.ptr = nullptr;
+            }
             return *this;
         }
 
         ~MemoryLockGuard() {
-            if(ptr != nullptr)
+            if(ptr != nullptr) {
+                /* cudaHostUnregister does not throw for a valid ptr */
                 CUDA4DNN_CHECK_CUDA(cudaHostUnregister(ptr));
+            }
         }
 
     private:


### PR DESCRIPTION
The host memory is page-locked to improve host-device memory transfer performance. #16648 
fixed a bug where the device memory is resized if the previously allocated memory isn't sufficient. However, it did not re-register the corresponding host memory.

Original report: https://github.com/opencv/opencv/issues/16568#issuecomment-590202635

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under OpenCV (BSD) License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [x] The PR is proposed to proper branch
- [x] There is reference to original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake


```
force_builders_only=docs,Custom
buildworker:Custom=linux-4
build_image:Custom=ubuntu-cuda:16.04
```
