### PR TITLE
Supported Fully Connected layer with two inputs

### DIFF
--- a/modules/dnn/src/layers/fully_connected_layer.cpp
+++ b/modules/dnn/src/layers/fully_connected_layer.cpp
@@ -118,9 +118,7 @@ public:
         {
             int dims = inputs[0].size();
             for (int i = 0; i < dims - 2; i++)
-            {
                 CV_CheckEQ(inputs[0][i], inputs[1][i], "");
-            }
             CV_CheckEQ(inputs[0].back(), inputs[1][dims - 2], "");
         }
         CV_Assert(!bias || ((blobs.empty() && numOutput == inputs[0][cAxis]) ||

--- a/modules/dnn/src/layers/fully_connected_layer.cpp
+++ b/modules/dnn/src/layers/fully_connected_layer.cpp
@@ -83,7 +83,7 @@ public:
             int numOutput = params.get<int>("num_output");
             int innerSize = (int)blobs[0].total() / numOutput;
 
-            CV_Assert(blobs[0].dims == 2 && (size_t)(innerSize * numOutput) == blobs[0].total());
+            CV_Assert(blobs[0].dims >= 2 && (size_t)(innerSize * numOutput) == blobs[0].total());
             CV_Assert(!bias || (blobs.size() == 2 && (size_t)numOutput == blobs[1].total()));
 
             weightsMat = blobs[0] = blobs[0].reshape(1, numOutput);
@@ -111,6 +111,7 @@ public:
                          std::vector<MatShape> &) const CV_OVERRIDE
     {
         CV_Assert((inputs.size() == 1 && !blobs.empty()) || inputs.size() == 2);
+        CV_Assert(blobs.empty() || blobs[0].dims == 2);
         int numOutput = !blobs.empty() ? blobs[0].size[0] : inputs[1].back();
         int cAxis = !blobs.empty() ? clamp(axis, inputs[0]) : inputs[0].size() - 1;
 

--- a/modules/dnn/src/onnx/onnx_graph_simplifier.cpp
+++ b/modules/dnn/src/onnx/onnx_graph_simplifier.cpp
@@ -154,10 +154,64 @@ private:
     int axis;
 };
 
-class NormalizeSubgraph : public Subgraph
+class NormalizeSubgraph1 : public Subgraph
 {
 public:
-    NormalizeSubgraph() : axis(1)
+    NormalizeSubgraph1() : axis(1)
+    {
+        int input = addNodeToMatch("");
+        int norm = addNodeToMatch("ReduceL2", input);
+        addNodeToMatch("Div", input, norm);
+        setFusedNode("Normalize", input);
+    }
+
+    virtual bool match(const Ptr<ImportGraphWrapper>& net, int nodeId,
+                       std::vector<int>& matchedNodesIds,
+                       std::vector<int>& targetNodesIds) CV_OVERRIDE
+    {
+        if (Subgraph::match(net, nodeId, matchedNodesIds, targetNodesIds))
+        {
+            Ptr<ImportNodeWrapper> norm = net->getNode(matchedNodesIds[0]);
+            opencv_onnx::NodeProto* node = norm.dynamicCast<ONNXNodeWrapper>()->node;
+
+            for (int i = 0; i < node->attribute_size(); i++)
+            {
+                opencv_onnx::AttributeProto attr = node->attribute(i);
+                if (attr.name() != "axes")
+                    continue;
+                if (attr.ints_size() != 1)
+                    CV_Error(Error::StsNotImplemented, format("Unexpected number of axes: %d", attr.ints_size()));
+                axis = attr.ints(0);
+                return true;
+            }
+            CV_Error(Error::StsNotImplemented, "Missed axes attribute");
+        }
+        return false;
+    }
+
+    virtual void finalize(const Ptr<ImportGraphWrapper>&,
+                          const Ptr<ImportNodeWrapper>& fusedNode,
+                          std::vector<Ptr<ImportNodeWrapper> >&) CV_OVERRIDE
+    {
+        opencv_onnx::NodeProto* node = fusedNode.dynamicCast<ONNXNodeWrapper>()->node;
+        opencv_onnx::AttributeProto* axis_attr = node->add_attribute();
+        axis_attr->set_name("axis");
+        axis_attr->set_i(axis);
+
+        opencv_onnx::AttributeProto* end_axis_attr = node->add_attribute();
+        end_axis_attr->set_name("end_axis");
+        end_axis_attr->set_i(axis);
+    }
+
+private:
+    int axis;
+};
+
+
+class NormalizeSubgraph2 : public Subgraph
+{
+public:
+    NormalizeSubgraph2() : axis(1)
     {
         int input = addNodeToMatch("");
         int norm = addNodeToMatch("ReduceL2", input);
@@ -355,7 +409,8 @@ void simplifySubgraphs(opencv_onnx::GraphProto& net)
     subgraphs.push_back(makePtr<ResizeSubgraph1>());
     subgraphs.push_back(makePtr<ResizeSubgraph2>());
     subgraphs.push_back(makePtr<SoftMaxSubgraph>());
-    subgraphs.push_back(makePtr<NormalizeSubgraph>());
+    subgraphs.push_back(makePtr<NormalizeSubgraph1>());
+    subgraphs.push_back(makePtr<NormalizeSubgraph2>());
 
     simplifySubgraphs(Ptr<ImportGraphWrapper>(new ONNXGraphWrapper(net)), subgraphs);
 }

--- a/modules/dnn/src/onnx/onnx_graph_simplifier.cpp
+++ b/modules/dnn/src/onnx/onnx_graph_simplifier.cpp
@@ -154,6 +154,62 @@ private:
     int axis;
 };
 
+class NormalizeSubgraph : public Subgraph
+{
+public:
+    NormalizeSubgraph() : axis(1)
+    {
+        int input = addNodeToMatch("");
+        int norm = addNodeToMatch("ReduceL2", input);
+        int clip = addNodeToMatch("Clip", norm);
+        int shape = addNodeToMatch("Shape", input);
+        int expand = addNodeToMatch("Expand", clip, shape);
+        addNodeToMatch("Div", input, expand);
+        setFusedNode("Normalize", input);
+    }
+
+    virtual bool match(const Ptr<ImportGraphWrapper>& net, int nodeId,
+                       std::vector<int>& matchedNodesIds,
+                       std::vector<int>& targetNodesIds) CV_OVERRIDE
+    {
+        if (Subgraph::match(net, nodeId, matchedNodesIds, targetNodesIds))
+        {
+            Ptr<ImportNodeWrapper> norm = net->getNode(matchedNodesIds[0]);
+            opencv_onnx::NodeProto* node = norm.dynamicCast<ONNXNodeWrapper>()->node;
+
+            for (int i = 0; i < node->attribute_size(); i++)
+            {
+                opencv_onnx::AttributeProto attr = node->attribute(i);
+                if (attr.name() != "axes")
+                    continue;
+                if (attr.ints_size() != 1)
+                    CV_Error(Error::StsNotImplemented, format("Unexpected number of axes: %d", attr.ints_size()));
+                axis = attr.ints(0);
+                return true;
+            }
+            CV_Error(Error::StsNotImplemented, "Missed axes attribute");
+        }
+        return false;
+    }
+
+    virtual void finalize(const Ptr<ImportGraphWrapper>&,
+                          const Ptr<ImportNodeWrapper>& fusedNode,
+                          std::vector<Ptr<ImportNodeWrapper> >&) CV_OVERRIDE
+    {
+        opencv_onnx::NodeProto* node = fusedNode.dynamicCast<ONNXNodeWrapper>()->node;
+        opencv_onnx::AttributeProto* axis_attr = node->add_attribute();
+        axis_attr->set_name("axis");
+        axis_attr->set_i(axis);
+
+        opencv_onnx::AttributeProto* end_axis_attr = node->add_attribute();
+        end_axis_attr->set_name("end_axis");
+        end_axis_attr->set_i(axis);
+    }
+
+private:
+    int axis;
+};
+
 class GatherCastSubgraph : public Subgraph
 {
 public:
@@ -299,6 +355,7 @@ void simplifySubgraphs(opencv_onnx::GraphProto& net)
     subgraphs.push_back(makePtr<ResizeSubgraph1>());
     subgraphs.push_back(makePtr<ResizeSubgraph2>());
     subgraphs.push_back(makePtr<SoftMaxSubgraph>());
+    subgraphs.push_back(makePtr<NormalizeSubgraph>());
 
     simplifySubgraphs(Ptr<ImportGraphWrapper>(new ONNXGraphWrapper(net)), subgraphs);
 }

--- a/modules/dnn/src/onnx/onnx_importer.cpp
+++ b/modules/dnn/src/onnx/onnx_importer.cpp
@@ -1024,22 +1024,6 @@ void ONNXImporter::populateNet(Net dstNet)
                 continue;
             }
         }
-        else if (layer_type == "ReduceL2")
-        {
-            CV_Assert_N(node_proto.input_size() == 1, layerParams.has("axes"));
-            CV_Assert(graph_proto.node_size() > li + 1 && graph_proto.node(li + 1).op_type() == "Div");
-            ++li;
-            node_proto = graph_proto.node(li);
-            layerParams.name = node_proto.output(0);
-            layerParams.type = "Normalize";
-
-            DictValue axes_dict = layerParams.get("axes");
-            if (axes_dict.size() != 1)
-                CV_Error(Error::StsNotImplemented, "Multidimensional reduceL2");
-            int axis = axes_dict.getIntValue(0);
-            layerParams.set("axis",axis);
-            layerParams.set("end_axis", axis);
-        }
         else if (layer_type == "Squeeze")
         {
             CV_Assert_N(node_proto.input_size() == 1, layerParams.has("axes"));

--- a/modules/dnn/src/onnx/onnx_importer.cpp
+++ b/modules/dnn/src/onnx/onnx_importer.cpp
@@ -1155,7 +1155,7 @@ void ONNXImporter::populateNet(Net dstNet)
                     if (inpShape[i] == 1)
                         broadcast_axes.push_back(i);
                     else
-                        CV_Error(Error::StsError, "Could not be broadcast by axis: " + i);
+                        CV_Error(Error::StsError, format("Could not be broadcast by axis: %d", i));
                 }
             }
 

--- a/modules/dnn/src/onnx/onnx_importer.cpp
+++ b/modules/dnn/src/onnx/onnx_importer.cpp
@@ -816,10 +816,21 @@ void ONNXImporter::populateNet(Net dstNet)
         {
             CV_Assert(node_proto.input_size() == 2);
             layerParams.type = "InnerProduct";
-            Mat blob = getBlob(node_proto, constBlobs, 1);
-            layerParams.blobs.push_back(blob.t());
             layerParams.set("bias_term", false);
-            layerParams.set("num_output", layerParams.blobs[0].size[0]);
+
+            int constId = -1;
+            for (int i = 0; i < 2; ++i)
+            {
+                if (constBlobs.find(node_proto.input(i)) != constBlobs.end())
+                    constId = i;
+            }
+
+            if (constId != -1)
+            {
+                Mat blob = getBlob(node_proto, constBlobs, constId);
+                layerParams.blobs.push_back(blob.t());
+                layerParams.set("num_output", layerParams.blobs[0].size[0]);
+            }
         }
         else if (layer_type == "Mul" || layer_type == "Div")
         {

--- a/modules/dnn/src/onnx/onnx_importer.cpp
+++ b/modules/dnn/src/onnx/onnx_importer.cpp
@@ -408,8 +408,10 @@ void ONNXImporter::populateNet(Net dstNet)
                     int newShape[] = {1, -1};
                     reshapeLp.set("dim", DictValue::arrayInt(&newShape[0], 2));
 
-                    node_proto.set_output(0, reshapeLp.name);
-                    addLayer(dstNet, reshapeLp, node_proto, layer_id, outShapes);
+                    opencv_onnx::NodeProto proto;
+                    proto.add_input(node_proto.input(0));
+                    proto.add_output(reshapeLp.name);
+                    addLayer(dstNet, reshapeLp, proto, layer_id, outShapes);
 
                     LayerParams avgLp;
                     avgLp.name = layerParams.name + "/avg";
@@ -1160,14 +1162,14 @@ void ONNXImporter::populateNet(Net dstNet)
                 Mat inp = Mat::ones(newShapeMat.total(), newShapeMat.ptr<int>(), CV_32F);
                 constParams.blobs.push_back(inp);
 
-                node_proto.clear_input();
-                node_proto.set_output(0, constParams.name);
-                addLayer(dstNet, constParams, node_proto, layer_id, outShapes);
+                opencv_onnx::NodeProto proto;
+                proto.add_output(constParams.name);
+                addLayer(dstNet, constParams, proto, layer_id, outShapes);
 
                 layerParams.type = "Scale";
                 layerParams.set("bias_term", false);
-                node_proto.add_input(constParams.name);
-                node_proto.add_input(shapeIt->first);
+                node_proto.set_input(0, constParams.name);
+                node_proto.set_input(1, shapeIt->first);
             }
             else if (broadcast_axes.size() == 1 && broadcast_axes[0] <= 1)
             {

--- a/modules/dnn/src/onnx/onnx_importer.cpp
+++ b/modules/dnn/src/onnx/onnx_importer.cpp
@@ -871,16 +871,9 @@ void ONNXImporter::populateNet(Net dstNet)
             layerParams.type = "InnerProduct";
             layerParams.set("bias_term", false);
 
-            int constId = -1;
-            for (int i = 0; i < 2; ++i)
+            if (constBlobs.find(node_proto.input(1)) != constBlobs.end())
             {
-                if (constBlobs.find(node_proto.input(i)) != constBlobs.end())
-                    constId = i;
-            }
-
-            if (constId != -1)
-            {
-                Mat blob = getBlob(node_proto, constBlobs, constId);
+                Mat blob = getBlob(node_proto, constBlobs, 1);
                 layerParams.blobs.push_back(blob.t());
                 layerParams.set("num_output", layerParams.blobs[0].size[0]);
             }

--- a/modules/dnn/test/test_onnx_importer.cpp
+++ b/modules/dnn/test/test_onnx_importer.cpp
@@ -310,8 +310,8 @@ TEST_P(Test_ONNX_layers, Multiplication)
 
 TEST_P(Test_ONNX_layers, MatMul)
 {
-    if (backend != DNN_BACKEND_OPENCV)
-        applyTestTag(CV_TEST_TAG_DNN_SKIP_IE_NGRAPH, CV_TEST_TAG_DNN_SKIP_IE_NN_BUILDER);
+    if (backend == DNN_BACKEND_INFERENCE_ENGINE_NN_BUILDER_2019)
+        applyTestTag(CV_TEST_TAG_DNN_SKIP_IE_NN_BUILDER);
 
     testONNXModels("matmul_2d");
     testONNXModels("matmul_3d");

--- a/modules/dnn/test/test_onnx_importer.cpp
+++ b/modules/dnn/test/test_onnx_importer.cpp
@@ -324,6 +324,10 @@ TEST_P(Test_ONNX_layers, Expand)
 {
     testONNXModels("expand_batch");
     testONNXModels("expand_channels");
+}
+
+TEST_P(Test_ONNX_layers, ExpandHW)
+{
     // ngraph::op::v1::Multiply bug
     if (backend == DNN_BACKEND_INFERENCE_ENGINE_NN_BUILDER_2019 || backend == DNN_BACKEND_INFERENCE_ENGINE_NGRAPH)
         applyTestTag(CV_TEST_TAG_DNN_SKIP_IE_NN_BUILDER, CV_TEST_TAG_DNN_SKIP_IE_NGRAPH);

--- a/modules/dnn/test/test_onnx_importer.cpp
+++ b/modules/dnn/test/test_onnx_importer.cpp
@@ -308,6 +308,13 @@ TEST_P(Test_ONNX_layers, Multiplication)
     testONNXModels("mul");
 }
 
+TEST_P(Test_ONNX_layers, MatMul)
+{
+    testONNXModels("matmul_2d");
+    testONNXModels("matmul_3d");
+    testONNXModels("matmul_4d");
+}
+
 TEST_P(Test_ONNX_layers, Constant)
 {
 #if defined(INF_ENGINE_RELEASE) && INF_ENGINE_VER_MAJOR_EQ(2018050000)

--- a/modules/dnn/test/test_onnx_importer.cpp
+++ b/modules/dnn/test/test_onnx_importer.cpp
@@ -320,6 +320,13 @@ TEST_P(Test_ONNX_layers, MatMul)
     testONNXModels("matmul_4d");
 }
 
+TEST_P(Test_ONNX_layers, Expand)
+{
+    testONNXModels("expand_batch");
+    testONNXModels("expand_channels");
+    testONNXModels("expand_hw");
+}
+
 TEST_P(Test_ONNX_layers, Constant)
 {
 #if defined(INF_ENGINE_RELEASE) && INF_ENGINE_VER_MAJOR_EQ(2018050000)

--- a/modules/dnn/test/test_onnx_importer.cpp
+++ b/modules/dnn/test/test_onnx_importer.cpp
@@ -310,6 +310,9 @@ TEST_P(Test_ONNX_layers, Multiplication)
 
 TEST_P(Test_ONNX_layers, MatMul)
 {
+    if (backend != DNN_BACKEND_OPENCV)
+        applyTestTag(CV_TEST_TAG_DNN_SKIP_IE_NGRAPH, CV_TEST_TAG_DNN_SKIP_IE_NN_BUILDER);
+
     testONNXModels("matmul_2d");
     testONNXModels("matmul_3d");
     testONNXModels("matmul_4d");

--- a/modules/dnn/test/test_onnx_importer.cpp
+++ b/modules/dnn/test/test_onnx_importer.cpp
@@ -432,6 +432,7 @@ TEST_P(Test_ONNX_layers, Squeeze)
 TEST_P(Test_ONNX_layers, ReduceL2)
 {
     testONNXModels("reduceL2");
+    testONNXModels("reduceL2_subgraph");
 }
 
 TEST_P(Test_ONNX_layers, Split)

--- a/modules/dnn/test/test_onnx_importer.cpp
+++ b/modules/dnn/test/test_onnx_importer.cpp
@@ -324,6 +324,9 @@ TEST_P(Test_ONNX_layers, Expand)
 {
     testONNXModels("expand_batch");
     testONNXModels("expand_channels");
+    // ngraph::op::v1::Multiply bug
+    if (backend == DNN_BACKEND_INFERENCE_ENGINE_NN_BUILDER_2019 || backend == DNN_BACKEND_INFERENCE_ENGINE_NGRAPH)
+        applyTestTag(CV_TEST_TAG_DNN_SKIP_IE_NN_BUILDER, CV_TEST_TAG_DNN_SKIP_IE_NGRAPH);
     testONNXModels("expand_hw");
 }
 

--- a/modules/dnn/test/test_onnx_importer.cpp
+++ b/modules/dnn/test/test_onnx_importer.cpp
@@ -179,6 +179,8 @@ TEST_P(Test_ONNX_layers, Shape)
 TEST_P(Test_ONNX_layers, ReduceMean)
 {
     testONNXModels("reduce_mean");
+    testONNXModels("reduce_mean_axis1");
+    testONNXModels("reduce_mean_axis2");
 }
 
 TEST_P(Test_ONNX_layers, ReduceMean3D)


### PR DESCRIPTION
**Merge with extra:** opencv/opencv_extra#732  
**relates:** #14853, #14813

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under OpenCV (BSD) License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [x] The PR is proposed to proper branch
- [x] There is reference to original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake

_TODO:_
- [x] Add nGraph

```
force_builders=Custom,Custom Win,Custom Mac
build_image:Custom=ubuntu-openvino-2020.1.0:16.04
build_image:Custom Win=openvino-2020.1.0
build_image:Custom Mac=openvino-2020.1.0

test_modules:Custom=dnn,python2,python3,java
test_modules:Custom Win=dnn,python2,python3,java
test_modules:Custom Mac=dnn,python2,python3,java

buildworker:Custom=linux-1
# disabled due high memory usage: test_opencl:Custom=ON
test_opencl:Custom=OFF
test_bigdata:Custom=1
test_filter:Custom=*
```