### PR TITLE
Update types_c.h

### DIFF
--- a/modules/core/include/opencv2/core/types_c.h
+++ b/modules/core/include/opencv2/core/types_c.h
@@ -44,6 +44,10 @@
 #ifndef OPENCV_CORE_TYPES_H
 #define OPENCV_CORE_TYPES_H
 
+#if !defined(__OPENCV_BUILD) && !defined(CV__DISABLE_C_API_CTORS)
+#define CV__ENABLE_C_API_CTORS // enable C API ctors (must be removed)
+#endif
+
 #ifdef CV__ENABLE_C_API_CTORS  // invalid C API ctors (must be removed)
 #if defined(_WIN32) && !defined(CV__SKIP_MESSAGE_MALFORMED_C_API_CTORS)
 #error "C API ctors don't work on Win32: https://github.com/opencv/opencv/issues/15990"


### PR DESCRIPTION
it seems that "CV__ENABLE_C_API_CTORS" was no where defined. Occasionally it led to failed conversion  of some old c style structures to the c++ ones in my projects.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under OpenCV (BSD) License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [x] The PR is proposed to proper branch
- [x] There is reference to original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
