### PR TITLE
G-API utils - fix compilation error in variant::operator=

### DIFF
--- a/modules/gapi/include/opencv2/gapi/util/variant.hpp
+++ b/modules/gapi/include/opencv2/gapi/util/variant.hpp
@@ -281,13 +281,14 @@ namespace util
     template<class T> typename detail::are_different<variant<Ts...>, T, variant<Ts...>&>
     ::type variant<Ts...>::operator=(T&& t) noexcept
     {
+        using decayed_t = typename std::decay<T>::type;
         // FIXME: No version with implicit type conversion available!
         static const constexpr std::size_t t_index =
-            util::type_list_index<T, Ts...>::value;
+            util::type_list_index<decayed_t, Ts...>::value;
 
         if (t_index == m_index)
         {
-            util::get<T>(*this) = std::move(t);
+            util::get<decayed_t>(*this) = std::move(t);
             return *this;
         }
         else return (*this = variant(std::move(t)));

--- a/modules/gapi/test/util/variant_tests.cpp
+++ b/modules/gapi/test/util/variant_tests.cpp
@@ -115,6 +115,18 @@ TEST(Variant, Assign_Basic)
     EXPECT_EQ(42, util::get<int>(vis));
 }
 
+TEST(Variant, Assign_LValueRef)
+{
+    TestVar vis;
+    EXPECT_EQ(0u, vis.index());
+    EXPECT_EQ(0,  util::get<int>(vis));
+
+    int val = 42;
+    vis = val;
+    EXPECT_EQ(0u, vis.index());
+    EXPECT_EQ(42, util::get<int>(vis));
+}
+
 TEST(Variant, Assign_ValueUpdate_SameType)
 {
     TestVar vis(42);
@@ -135,6 +147,19 @@ TEST(Variant, Assign_ValueUpdate_DiffType)
     EXPECT_EQ(42, util::get<int>(vis));
 
     vis = std::string("42");
+    EXPECT_EQ(1u, vis.index());
+    EXPECT_EQ("42", util::get<std::string>(vis));
+}
+
+TEST(Variant, Assign_LValueRef_DiffType)
+{
+    TestVar vis(42);
+
+    EXPECT_EQ(0u, vis.index());
+    EXPECT_EQ(42, util::get<int>(vis));
+
+    std::string s("42");
+    vis = s;
     EXPECT_EQ(1u, vis.index());
     EXPECT_EQ("42", util::get<std::string>(vis));
 }


### PR DESCRIPTION
### Description
This patch fixes compilation during (perfectly valid) assignment of [lvalue reference](https://en.cppreference.com/w/cpp/language/reference) to a `variant`. 
The error is something like this : 
> error: static assertion failed: Type not found
             static_assert(std::is_same<Target, First>::value, "Type not found");

Root cause of the problem is that during argument type deduction for `emplate<class T> varaiant::operator=(T&&)`  and lvalue ref argument  `T` is matched as a ref (e.g. `int&`). Then it is look up in the total types list of the variant (which fails) : 
>required from ‘constexpr const size_t cv::util::type_list_index<__int&__, int, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >::value’

```
build_gapi_standalone:Linux x64=ade-0.1.1f
build_gapi_standalone:Win64=ade-0.1.1f
build_gapi_standalone:Mac=ade-0.1.1f
build_gapi_standalone:Linux x64 Debug=ade-0.1.1f
```

### Pull Request Readiness Checklist
See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under OpenCV (BSD) License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [x] The PR is proposed to proper branch
- [x] There is reference to original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake

