### PR TITLE
fix: minor typo in CMakeCVDetectPython

### DIFF
--- a/cmake/OpenCVDetectPython.cmake
+++ b/cmake/OpenCVDetectPython.cmake
@@ -78,10 +78,10 @@ if(NOT ${found})
         AND NOT DEFINED ${executable}
     )
       if(NOT OPENCV_SKIP_PYTHON_WARNING)
-        message(WARNING "CMake's 'find_host_package(PythonInterp ${__python_package_version})' founds wrong Python version:\n"
+        message(WARNING "CMake's 'find_host_package(PythonInterp ${__python_package_version})' found wrong Python version:\n"
                         "PYTHON_EXECUTABLE=${PYTHON_EXECUTABLE}\n"
                         "PYTHON_VERSION_STRING=${PYTHON_VERSION_STRING}\n"
-                        "Consider specify '${executable}' variable via CMake command line or environment variables\n")
+                        "Consider providing the '${executable}' variable via CMake command line or environment variables\n")
       endif()
       ocv_clear_vars(PYTHONINTERP_FOUND PYTHON_EXECUTABLE PYTHON_VERSION_STRING PYTHON_VERSION_MAJOR PYTHON_VERSION_MINOR PYTHON_VERSION_PATCH)
       if(NOT CMAKE_VERSION VERSION_LESS "3.12")


### PR DESCRIPTION
Minor issue that's applicable on 3.4. Found it on Fedora 31 where Python is 3.7.6.
If you feel it's not spelt to your liking it can be changed to something else since we're here.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under OpenCV (BSD) License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [x] The PR is proposed to proper branch
- [x] There is reference to original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
