### PR TITLE
cmake(apps): support OPENCV_INSTALL_APPS_LIST

### DIFF
--- a/apps/CMakeLists.txt
+++ b/apps/CMakeLists.txt
@@ -1,6 +1,8 @@
 add_definitions(-D__OPENCV_BUILD=1)
 add_definitions(-D__OPENCV_APPS=1)
 
+string(REPLACE "," ";" OPENCV_INSTALL_APPS_LIST "${OPENCV_INSTALL_APPS_LIST}")  # support comma-separated list (,) too
+
 # Unified function for creating OpenCV applications:
 #   ocv_add_application(tgt [MODULES <m1> [<m2> ...]] SRCS <src1> [<src2> ...])
 function(ocv_add_application the_target)
@@ -25,12 +27,14 @@ function(ocv_add_application the_target)
     set_target_properties(${the_target} PROPERTIES FOLDER "applications")
   endif()
 
-  if(INSTALL_CREATE_DISTRIB)
+  if(NOT INSTALL_CREATE_DISTRIB
+      OR (OPENCV_INSTALL_APPS_LIST STREQUAL "all" OR ";${OPENCV_INSTALL_APPS_LIST};" MATCHES ";${the_target};")
+  )
+    install(TARGETS ${the_target} RUNTIME DESTINATION ${OPENCV_BIN_INSTALL_PATH} COMPONENT dev)
+  elseif(INSTALL_CREATE_DISTRIB)
     if(BUILD_SHARED_LIBS)
       install(TARGETS ${the_target} RUNTIME DESTINATION ${OPENCV_BIN_INSTALL_PATH} CONFIGURATIONS Release COMPONENT dev)
     endif()
-  else()
-    install(TARGETS ${the_target} RUNTIME DESTINATION ${OPENCV_BIN_INSTALL_PATH} COMPONENT dev)
   endif()
 endfunction()
 


### PR DESCRIPTION
Usage:
- `cmake -DOPENCV_INSTALL_APPS_LIST=opencv_version ...`

To replace `INSTALL_CREATE_DISTRIB` behavior restrictions (it doesn't install debug binaries).