### PR TITLE
calib3d: fixed VS2019 warning C4756

### DIFF
--- a/modules/calib3d/src/quadsubpix.cpp
+++ b/modules/calib3d/src/quadsubpix.cpp
@@ -61,13 +61,13 @@ static void orderContours(const std::vector<std::vector<Point> >& contours, Poin
     for(i = 0; i < n; i++)
     {
         size_t ni = contours[i].size();
-        double min_dist = std::numeric_limits<double>::max();
+        float min_dist = std::numeric_limits<float>::max();
         for(j = 0; j < ni; j++)
         {
             double dist = norm(Point2f((float)contours[i][j].x, (float)contours[i][j].y) - point);
-            min_dist = MIN(min_dist, dist);
+            min_dist = (float)MIN((double)min_dist, dist);
         }
-        order.push_back(std::pair<int, float>((int)i, (float)min_dist));
+        order.push_back(std::pair<int, float>((int)i, min_dist));
     }
 
     std::sort(order.begin(), order.end(), is_smaller);


### PR DESCRIPTION
Following warning has been reproduced with latest version of Visual Studio 2019 16.5.0:
```
opencv\modules\core\include\opencv2\core\types.hpp(1302): warning C4756: overflow in constant arithmetic
```
### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under OpenCV (BSD) License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [x] The PR is proposed to proper branch
- [x] There is reference to original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake


```
force_builders=Custom Win
build_image:Custom Win=msvs2019
```