### PR TITLE
cuda4dnn(conv): autotuning for convolution

### DIFF
--- a/modules/dnn/src/cuda4dnn/csl/workspace.hpp
+++ b/modules/dnn/src/cuda4dnn/csl/workspace.hpp
@@ -120,6 +120,13 @@ namespace cv { namespace dnn { namespace cuda4dnn { namespace csl {
             CV_Assert(bytes_remaining % 256 == 0);
         }
 
+        WorkspaceAllocator(WorkspaceInstance& instance) noexcept
+            : current{ instance.get() }, bytes_remaining { instance.size_in_bytes() }
+        {
+            CV_Assert(is_aligned<void>(current, 256));
+            CV_Assert(bytes_remaining % 256 == 0);
+        }
+
         /** allocates a Span<T> of \p count elements from the workspace memory */
         template <class T>
         Span<T> get_span(std::size_t count = 0) {

--- a/modules/dnn/src/cuda4dnn/primitives/convolution.hpp
+++ b/modules/dnn/src/cuda4dnn/primitives/convolution.hpp
@@ -7,10 +7,12 @@
 
 #include "../../op_cuda.hpp"
 
+#include "./convolution/cudnn.hpp"
+
 #include "../csl/cudnn.hpp"
 #include "../csl/stream.hpp"
+#include "../csl/event.hpp"
 #include "../csl/tensor.hpp"
-#include "../csl/tensor_ops.hpp"
 #include "../kernels/scale_shift.hpp"
 #include "../kernels/activations.hpp"
 #include "../kernels/bias_activation.hpp"
@@ -22,6 +24,8 @@
 #include <vector>
 #include <utility>
 #include <algorithm>
+#include <numeric>
+#include <cmath>
 
 namespace cv { namespace dnn { namespace cuda4dnn {
 
@@ -99,8 +103,16 @@ namespace cv { namespace dnn { namespace cuda4dnn {
             filtersTensor = csl::makeTensorHeader<T>(filters);
             csl::copyMatToTensor<T>(filters, filtersTensor, stream);
 
+            std::vector<std::size_t> filter_shape(rank);
+            filter_shape[0] = output_feature_maps;
+            filter_shape[1] = input_feature_maps_per_group;
+            std::copy(std::begin(kernel_size), std::end(kernel_size), std::begin(filter_shape) + 2);
+
+            std::vector<std::size_t> bias_shape;
             if (!bias.empty())
             {
+                bias_shape.resize(rank, 1);
+                bias_shape[1] = output_feature_maps;
                 biasTensor = csl::makeTensorHeader<T>(bias);
                 csl::copyMatToTensor<T>(bias, biasTensor, stream);
             }
@@ -167,59 +179,11 @@ namespace cv { namespace dnn { namespace cuda4dnn {
                     padding_right[i] = std::max<std::int64_t>(0, padding_right[i] - rem);
             }
 
-            auto is_not_zero = [](std::size_t i) { return i != 0; };
-            if(std::any_of(std::begin(padding_left), std::end(padding_left), is_not_zero) ||
-               std::any_of(std::begin(padding_right), std::end(padding_right), is_not_zero))
-            {
-                /* csl::Convolution supports symmetric padding only; hence, we deal with asymmetric padding by
-                 * copying the input to a bigger tensor and padding the ends manually
-                 */
-                transformed_shape = input_shape;
-                for (int i = 0; i < rank; i++)
-                    transformed_shape[i] += padding_left[i] + padding_right[i];
-
-                inputTransformer = csl::TensorTransform<T>(cudnnHandle, padding_left, padding_right);
-            }
-
-            typename csl::Convolution<T>::params_type params;
-            if (transformed_shape.empty())
-            {
-                params.input_shape.assign(std::begin(input_shape), std::end(input_shape));
-            }
-            else
-            {
-                /* the convolution operation will be seeing the transformed input */
-                params.input_shape.assign(std::begin(transformed_shape), std::end(transformed_shape));
-            }
-
-            auto& fshape = params.filter_shape;
-            fshape.resize(rank);
-            fshape[0] = output_feature_maps;
-            fshape[1] = input_feature_maps_per_group;
-            std::copy(std::begin(kernel_size), std::end(kernel_size), std::begin(fshape) + 2);
-            CV_Assert(fshape.size() == kernel_size.size() + 2);
-
-            params.padding.assign(std::begin(common_padding) + 2, std::end(common_padding));
-            params.stride = strides;
-            params.dilation = dilations;
-            params.groups = config.groups;
-
-            /* check if we can perform fused convolution using cudnn */
-            params.activation_type = csl::Convolution<T>::ActivationType::IDENTITY;
-            fusion_location = InternalFusionLocation::NATIVE;
-            if (!biasTensor.empty() &&
-                biasTensor.size() == output_feature_maps && /* cuDNN requirement */
-                config.activation_type == ConvolutionConfiguration::ActivationType::RELU &&
-                config.relu_negative_slope == 0.0)
-            {
-                fusion_location = InternalFusionLocation::CUDNN;
-                auto bias_shape = std::vector<std::size_t>(rank, 1);
-                bias_shape[1] = output_feature_maps;
-                params.bias_shape = bias_shape;
-                params.activation_type = csl::Convolution<T>::ActivationType::RELU;
-            }
-
-            convoluter = csl::Convolution<T>(cudnnHandle, params);
+            /* POWER's scale and shift are already fused with the weights
+             * Hence, if the `power_exp` is unity, it's effectively identity activation.
+             */
+            if (activation == ConvolutionConfiguration::ActivationType::POWER && power_exp == 1.0f)
+                activation = ConvolutionConfiguration::ActivationType::IDENTITY;
 
             activation = config.activation_type;
             relu_negative_slope = config.relu_negative_slope;
@@ -227,17 +191,178 @@ namespace cv { namespace dnn { namespace cuda4dnn {
             crelu_ceil = config.crelu_ceil;
             power_exp = config.power_exp;
 
-            if (activation == ConvolutionConfiguration::ActivationType::POWER && power_exp == 1.0f)
-                activation = ConvolutionConfiguration::ActivationType::IDENTITY;
+            typename cuDNNConvolution<T>::params_type params;
+            params.input_shape.assign(std::begin(input_shape), std::end(input_shape));
+            params.filter_shape.assign(std::begin(filter_shape), std::end(filter_shape));
+            for (int i = 2; i < input_shape.size(); i++)
+            {
+                params.padding_left.push_back(common_padding[i] + padding_left[i]);
+                params.padding_right.push_back(common_padding[i] + padding_right[i]);
+            }
+            params.stride = strides;
+            params.dilation = dilations;
+            params.groups = config.groups;
+
+            // Runtime Tuning
+            {
+                using csl::cudnn::ConvolutionAlgorithm;
+                using csl::cudnn::MathType;
+
+                struct algorithm_stats_t {
+                    float mean_time, stddev_time;
+                    std::size_t workspace_size; // in bytes
+
+                    MathType math_type;
+                    ConvolutionAlgorithm algorithm;
+                    bool bias_activation_fused;
+                };
+
+                std::vector<algorithm_stats_t> stats;
+
+                csl::Workspace workspace;
+                csl::Tensor<T> dummy_input(std::begin(input_shape), std::end(input_shape));
+                csl::Tensor<T> dummy_output(std::begin(output_shape), std::end(output_shape));
+
+                auto start_event = csl::Event(true, true);
+                auto end_event = csl::Event(true, true);
+
+                auto profile_conv_fn = [&] {
+                    if (cudnn_fused_bias_relu)
+                    {
+                        params.bias_shape = bias_shape;
+                        params.activation_type = cuDNNConvolution<T>::ActivationType::RELU;
+                    }
+                    else
+                    {
+                        params.bias_shape.clear();
+                        params.activation_type = cuDNNConvolution<T>::ActivationType::IDENTITY;
+                    }
+
+                    csl::WorkspaceBuilder builder;
+                    auto convoluter = cuDNNConvolution<T>(cudnnHandle, builder, params);
+
+                    /* This reallocates memory and hence can fail. It however provides a strong exception guarantee.
+                     * Hence, workspace is still safe for use after an exception.
+                     */
+                    workspace.require(builder.required_workspace_size());
+
+                    std::vector<float> runtimes;
+                    for (int i = 0; i < 3; i++)
+                    {
+                        start_event.record(stream);
+                        execute_cudnn_convolution(convoluter, dummy_output, dummy_input, workspace);
+                        end_event.record(stream);
+
+                        stream.synchronize();
+
+                        auto time_in_ms = csl::TimeElapsedBetweenEvents(start_event, end_event);
+                        runtimes.push_back(time_in_ms);
+                    }
+
+                    auto sum = std::accumulate(std::begin(runtimes), std::end(runtimes), 0.0f);
+                    auto squared_sum = std::inner_product(std::begin(runtimes), std::end(runtimes), std::begin(runtimes), 0.0f);
+                    auto mean = sum / runtimes.size();
+                    auto stddev = std::sqrt(squared_sum / runtimes.size() - mean * mean);
+
+                    algorithm_stats_t result;
+                    result.algorithm = params.algorithm;
+                    result.math_type = params.math_type;
+                    result.bias_activation_fused = cudnn_fused_bias_relu;
+                    result.mean_time = mean;
+                    result.stddev_time = stddev;
+                    result.workspace_size = builder.required_workspace_size();
+                    stats.push_back(result);
+                };
+
+                // DEFAULT_MATH
+                {
+                    auto algos_to_try =
+                    {
+                        ConvolutionAlgorithm::IMPLICIT_GEMM,
+                        ConvolutionAlgorithm::IMPLICIT_PRECOMP_GEMM,
+                        ConvolutionAlgorithm::GEMM,
+                        ConvolutionAlgorithm::DIRECT,
+                        ConvolutionAlgorithm::WINOGRAD,
+                        ConvolutionAlgorithm::WINOGRAD_NONFUSED,
+                        ConvolutionAlgorithm::FFT,
+                        ConvolutionAlgorithm::FFT_TILING
+                    };
+
+                    std::vector<bool> fusion_options_to_try;
+                    fusion_options_to_try.push_back(false);
+                    if (!bias_shape.empty() && activation == ConvolutionConfiguration::ActivationType::RELU && relu_negative_slope == 0.0)
+                        fusion_options_to_try.push_back(true);
+
+                    for (auto fusion : fusion_options_to_try)
+                    {
+                        for (auto algo : algos_to_try)
+                        {
+                            params.math_type = csl::cudnn::MathType::DEFAULT_MATH;
+                            params.algorithm = algo;
+                            cudnn_fused_bias_relu = fusion;
+
+                            try {
+                                profile_conv_fn();
+                            } catch(...) {
+                                // ignore
+                            }
+                        }
+                    }
+                }
+
+                // TENSOR_OP
+                if (std::is_same<T, half>::value)
+                {
+                    auto algos_to_try =
+                    {
+                        ConvolutionAlgorithm::IMPLICIT_PRECOMP_GEMM,
+                        ConvolutionAlgorithm::WINOGRAD_NONFUSED
+                    };
+
+                    std::vector<bool> fusion_options_to_try;
+                    fusion_options_to_try.push_back(false);
+                    if (!bias_shape.empty() && activation == ConvolutionConfiguration::ActivationType::RELU && relu_negative_slope == 0.0)
+                        fusion_options_to_try.push_back(true);
+
+                    for (auto fusion : fusion_options_to_try)
+                    {
+                        for (auto algo : algos_to_try)
+                        {
+                            params.math_type = csl::cudnn::MathType::TENSOR_OP_MATH;
+                            params.algorithm = algo;
+                            cudnn_fused_bias_relu = fusion;
+
+                            try {
+                                profile_conv_fn();
+                            } catch(...) {
+                                // ignore
+                            }
+                        }
+                    }
+                }
+
+                CV_Assert(!stats.empty());
+
+                auto& best = *std::min_element(std::begin(stats), std::end(stats),
+                    [] (const algorithm_stats_t& lhs, const algorithm_stats_t& rhs) { return lhs.mean_time < rhs.mean_time; });
+                params.algorithm = best.algorithm;
+                params.math_type = best.math_type;
+                cudnn_fused_bias_relu = best.bias_activation_fused;
+            }
+
+            if (cudnn_fused_bias_relu)
+            {
+                params.bias_shape.assign(std::begin(bias_shape), std::end(bias_shape));
+                params.activation_type = cuDNNConvolution<T>::ActivationType::RELU;
+            }
+            else
+            {
+                params.bias_shape.clear();
+                params.activation_type = cuDNNConvolution<T>::ActivationType::IDENTITY;
+            }
 
             csl::WorkspaceBuilder builder;
-            if (!transformed_shape.empty())
-            {
-                auto& shape = transformed_shape;
-                auto sz = std::accumulate(std::begin(shape), std::end(shape), 1, std::multiplies<std::size_t>());
-                builder.require<T>(sz);
-            }
-            builder.require(convoluter.get_workspace_size());
+            cudnn_convoluter = cuDNNConvolution<T>(cudnnHandle, builder, params);
             scratch_mem_in_bytes = builder.required_workspace_size();
         }
 
@@ -248,45 +373,29 @@ namespace cv { namespace dnn { namespace cuda4dnn {
         {
             CV_Assert(inputs.size() == 1 && outputs.size() == 1);
 
-            csl::WorkspaceAllocator allocator(workspace);
-
             auto input_wrapper = inputs[0].dynamicCast<wrapper_type>();
             auto input = input_wrapper->getView();
-
-            if (!transformed_shape.empty())
-            {
-                auto& shape = transformed_shape;
-                auto transformed_input = allocator.get_tensor_span<T>(std::begin(shape), std::end(shape));
-                inputTransformer.transform(input, transformed_input);
-                input = transformed_input;
-            }
-
-            auto conv_scratchpad = allocator.get_instance();
 
             auto output_wrapper = outputs[0].dynamicCast<wrapper_type>();
             auto output = output_wrapper->getSpan();
 
-            if (fusion_location == InternalFusionLocation::CUDNN)
-            {
-                try
-                {
-                    convoluter.convolve_with_bias_activation(output, input, filtersTensor, biasTensor, conv_scratchpad);
-                }
-                catch(const csl::cudnn::cuDNNException& ex)
-                {
-                    if (ex.getCUDNNStatus() == CUDNN_STATUS_NOT_SUPPORTED)
-                    {
-                        /* drop cuDNN fusion and use the native fusion path */
-                        fusion_location = InternalFusionLocation::NATIVE;
-                    }
-                    else
-                        throw;
-                }
-            }
+            execute_cudnn_convolution(cudnn_convoluter, output, input, workspace);
+        }
 
-            if (fusion_location == InternalFusionLocation::NATIVE)
+        std::size_t get_workspace_memory_in_bytes() const noexcept override { return scratch_mem_in_bytes; }
+
+    private:
+        void execute_cudnn_convolution(cuDNNConvolution<T>& convoluter, csl::TensorSpan<T> output, csl::TensorView<T> input, csl::Workspace workspace)
+        {
+            csl::WorkspaceAllocator allocator(workspace);
+
+            if (cudnn_fused_bias_relu)
             {
-                convoluter.convolve(output, input, filtersTensor, conv_scratchpad);
+                convoluter.convolve_with_bias_activation(output, input, filtersTensor, biasTensor, allocator.get_instance());
+            }
+            else
+            {
+                convoluter.convolve(output, input, filtersTensor, allocator.get_instance());
                 if (!biasTensor.empty())
                 {
                     std::size_t inner_size = output.size_range(2, output.rank());
@@ -350,26 +459,17 @@ namespace cv { namespace dnn { namespace cuda4dnn {
             }
         }
 
-        std::size_t get_workspace_memory_in_bytes() const noexcept override { return scratch_mem_in_bytes; }
-
-    private:
         csl::Stream stream;
         csl::cudnn::Handle cudnnHandle;
         csl::Tensor<T> filtersTensor, biasTensor;
-        csl::Convolution<T> convoluter;
-
-        std::vector<std::size_t> transformed_shape;
-        csl::TensorTransform<T> inputTransformer;
 
         std::size_t scratch_mem_in_bytes;
 
         ConvolutionConfiguration::ActivationType activation;
         float relu_negative_slope, crelu_floor, crelu_ceil, power_exp;
 
-        enum class InternalFusionLocation {
-            CUDNN,
-            NATIVE
-        } fusion_location;
+        bool cudnn_fused_bias_relu;
+        cuDNNConvolution<T> cudnn_convoluter;
     };
 
 }}} /* namespace cv::dnn::cuda4dnn */

--- a/modules/dnn/src/cuda4dnn/primitives/convolution/cudnn.hpp
+++ b/modules/dnn/src/cuda4dnn/primitives/convolution/cudnn.hpp
@@ -1,0 +1,181 @@
+// This file is part of OpenCV project.
+// It is subject to the license terms in the LICENSE file found in the top-level directory
+// of this distribution and at http://opencv.org/license.html.
+
+#ifndef OPENCV_DNN_SRC_CUDA4DNN_PRIMITIVES_CONVOLUTION_CUDNN_HPP
+#define OPENCV_DNN_SRC_CUDA4DNN_PRIMITIVES_CONVOLUTION_CUDNN_HPP
+
+#include "../../csl/workspace.hpp"
+
+#include "../../csl/cudnn/cudnn.hpp"
+#include "../../csl/cudnn/convolution.hpp"
+#include "../../csl/tensor.hpp"
+#include "../../csl/tensor_ops.hpp"
+
+#include <cstddef>
+#include <vector>
+#include <algorithm>
+#include <numeric>
+
+namespace cv { namespace dnn { namespace cuda4dnn {
+
+template <class T>
+class cuDNNConvolution {
+    using TensorDescriptor = csl::cudnn::TensorDescriptor<T>;
+    using FilterDescriptor = csl::cudnn::FilterDescriptor<T>;
+    using ConvolutionDescriptor = csl::cudnn::ConvolutionDescriptor<T>;
+    using ConvolutionAlgorithm = csl::cudnn::ConvolutionAlgorithm;
+    using ActivationDescriptor = csl::cudnn::ActivationDescriptor;
+    using MathType = csl::cudnn::MathType;
+
+public:
+    using ActivationType = ActivationDescriptor::ActivationType;
+
+    struct params_type {
+        std::vector<std::size_t> input_shape;
+        std::vector<std::size_t> filter_shape;
+        std::vector<std::size_t> padding_left;
+        std::vector<std::size_t> padding_right;
+        std::vector<std::size_t> stride;
+        std::vector<std::size_t> dilation;
+        std::size_t groups;
+
+        ConvolutionAlgorithm algorithm;
+        MathType math_type;
+
+        /* bias and activation (only RELU supported) */
+        std::vector<std::size_t> bias_shape;
+        ActivationType activation_type; /* MUST BE identity if there is no bias and ReLU if there is bias */
+    };
+
+    cuDNNConvolution() = default;
+    cuDNNConvolution(const cuDNNConvolution&) = delete;
+    cuDNNConvolution(cuDNNConvolution&&) = default;
+    cuDNNConvolution(csl::cudnn::Handle handle, csl::WorkspaceBuilder& builder, const params_type& params) {
+        cudnnHandle = std::move(handle);
+
+        const auto& input_shape = params.input_shape;
+        auto padding_left = params.padding_left;
+        auto padding_right = params.padding_right;
+
+        std::vector<std::size_t> common_padding;
+        for (int i = 0; i < padding_left.size(); i++)
+        {
+            const auto sym_padding = std::min(padding_left[i], padding_right[i]);
+            padding_left[i] -= sym_padding;
+            padding_right[i] -= sym_padding;
+            common_padding.push_back(sym_padding);
+        }
+
+        auto is_not_zero = [](std::size_t i) { return i != 0; };
+        if(std::any_of(std::begin(padding_left), std::end(padding_left), is_not_zero) ||
+            std::any_of(std::begin(padding_right), std::end(padding_right), is_not_zero))
+        {
+            /* cuDNN does not support asymmetric padding. We deal with this by copying the input
+                * to a bigger tensor and manually padding the ends.
+                */
+            transformed_input_shape = input_shape;
+            for (int i = 0; i < padding_left.size(); i++)
+                transformed_input_shape[i + 2] += padding_left[i] + padding_right[i];
+
+            std::vector<std::size_t> tpad_left(input_shape.size(), 0), tpad_right(input_shape.size(), 0);
+            for (int i = 0; i < padding_left.size(); i++)
+            {
+                tpad_left[i + 2] = padding_left[i];
+                tpad_right[i + 2] = padding_right[i];
+            }
+            inputTransformer = csl::TensorTransform<T>(cudnnHandle, tpad_left, tpad_right);
+        }
+
+        // cuDNN convolution API sees the transformed input if the input was manually padded
+        auto conv_input_shape = transformed_input_shape.empty() ? input_shape : transformed_input_shape;
+        inputTensorDesc = TensorDescriptor(conv_input_shape);
+        filterDesc = FilterDescriptor(params.filter_shape);
+        convDesc = ConvolutionDescriptor(common_padding, params.stride, params.dilation, params.groups, params.math_type);
+
+        if (!params.bias_shape.empty()) {
+            biasTensorDesc = TensorDescriptor(params.bias_shape);
+            activationDesc = ActivationDescriptor(params.activation_type, 0.0);
+        } else {
+            CV_Assert(params.activation_type == ActivationType::IDENTITY);
+        }
+
+        std::vector<int> output_dims;
+        getConvolutionForwardOutputDim(convDesc, filterDesc, inputTensorDesc, output_dims);
+        outputTensorDesc = TensorDescriptor(output_dims);
+
+        if (!transformed_input_shape.empty())
+        {
+            const auto& shape = transformed_input_shape;
+            const auto sz = std::accumulate(std::begin(shape), std::end(shape), 1, std::multiplies<std::size_t>());
+            builder.require<T>(sz);
+        }
+
+        algorithm = params.algorithm;
+        conv_workspace_size_in_bytes = get_convolution_workspace_size(cudnnHandle, convDesc, filterDesc, inputTensorDesc, outputTensorDesc, algorithm);
+        builder.require(conv_workspace_size_in_bytes);
+    }
+
+    cuDNNConvolution& operator=(const cuDNNConvolution&) = delete;
+    cuDNNConvolution& operator=(cuDNNConvolution&&) = default;
+
+    void convolve(csl::TensorSpan<T> output, csl::TensorView<T> input, csl::TensorView<T> filters, csl::WorkspaceInstance scratchpad) {
+        csl::WorkspaceAllocator allocator(scratchpad);
+
+        if (!transformed_input_shape.empty()) {
+            auto& shape = transformed_input_shape;
+            auto transformed_input = allocator.get_tensor_span<T>(std::begin(shape), std::end(shape));
+            inputTransformer.transform(input, transformed_input);
+            input = transformed_input;
+        }
+
+        auto conv_scratchpad = allocator.get_instance(conv_workspace_size_in_bytes);
+        csl::cudnn::convolve<T>(
+            cudnnHandle,
+            convDesc, algorithm, conv_scratchpad,
+            filterDesc, filters.get(),
+            inputTensorDesc, input.get(),
+            1.0, 0.0, outputTensorDesc, output.get()
+        );
+    }
+
+    void convolve_with_bias_activation(csl::TensorSpan<T> output, csl::TensorView<T> input, csl::TensorView<T> filters, csl::TensorView<T> bias, csl::WorkspaceInstance scratchpad) {
+        csl::WorkspaceAllocator allocator(scratchpad);
+
+        if (!transformed_input_shape.empty()) {
+            auto& shape = transformed_input_shape;
+            auto transformed_input = allocator.get_tensor_span<T>(std::begin(shape), std::end(shape));
+            inputTransformer.transform(input, transformed_input);
+            input = transformed_input;
+        }
+
+        auto conv_scratchpad = allocator.get_instance(conv_workspace_size_in_bytes);
+        csl::cudnn::convolve_with_bias_activation<T>(
+            cudnnHandle,
+            1.0, convDesc, algorithm, conv_scratchpad,
+            filterDesc, filters.get(),
+            inputTensorDesc, input.get(),
+            biasTensorDesc, bias.get(),
+            activationDesc,
+            outputTensorDesc, output.get()
+        );
+    }
+
+private:
+    csl::cudnn::Handle cudnnHandle;
+    TensorDescriptor inputTensorDesc, outputTensorDesc;
+    FilterDescriptor filterDesc;
+    ConvolutionDescriptor convDesc;
+    TensorDescriptor biasTensorDesc;
+    ActivationDescriptor activationDesc;
+
+    ConvolutionAlgorithm algorithm;
+    std::size_t conv_workspace_size_in_bytes;
+
+    std::vector<std::size_t> transformed_input_shape;
+    csl::TensorTransform<T> inputTransformer;
+};
+
+}}} /* namespace cv::dnn::cuda4dnn */
+
+#endif /* OPENCV_DNN_SRC_CUDA4DNN_PRIMITIVES_CONVOLUTION_CUDNN_HPP */

--- a/modules/dnn/test/test_backends.cpp
+++ b/modules/dnn/test/test_backends.cpp
@@ -170,10 +170,16 @@ TEST_P(DNNTestNetwork, ENet)
         applyTestTag(CV_TEST_TAG_DNN_SKIP_OPENCL_FP16);
     if (backend == DNN_BACKEND_CUDA && target == DNN_TARGET_CUDA_FP16)
         applyTestTag(CV_TEST_TAG_DNN_SKIP_CUDA_FP16);
+    double l1 = 2e-5, lInf = 0.15;
+    if (target == DNN_TARGET_CUDA)
+    {
+        l1 = 6e-5;
+        lInf = 0.36;
+    }
     processNet("dnn/Enet-model-best.net", "", Size(512, 512), "l367_Deconvolution",
                target == DNN_TARGET_OPENCL ? "dnn/halide_scheduler_opencl_enet.yml" :
                                              "dnn/halide_scheduler_enet.yml",
-               2e-5, 0.15);
+               l1, lInf);
     expectNoFallbacksFromCUDA(net);
 }
 
@@ -187,6 +193,11 @@ TEST_P(DNNTestNetwork, MobileNet_SSD_Caffe)
     float scoreDiff = (target == DNN_TARGET_OPENCL_FP16 || target == DNN_TARGET_MYRIAD) ? 1.5e-2 : 0.0;
     float iouDiff = (target == DNN_TARGET_MYRIAD) ? 0.063  : 0.0;
     float detectionConfThresh = (target == DNN_TARGET_MYRIAD) ? 0.252  : FLT_MIN;
+    if (target == DNN_TARGET_CUDA_FP16)
+    {
+        scoreDiff = 0.006;
+        detectionConfThresh = 0.26;
+    }
          processNet("dnn/MobileNetSSD_deploy.caffemodel", "dnn/MobileNetSSD_deploy.prototxt",
                     inp, "detection_out", "", scoreDiff, iouDiff, detectionConfThresh);
     expectNoFallbacksFromIE(net);
@@ -268,7 +279,7 @@ TEST_P(DNNTestNetwork, MobileNet_SSD_v1_TensorFlow_Different_Width_Height)
     }
     else if (target == DNN_TARGET_CUDA_FP16)
     {
-        scoreDiff = 0.007;
+        scoreDiff = 0.008;
         iouDiff = 0.06;
     }
     processNet("dnn/ssd_mobilenet_v1_coco_2017_11_17.pb", "dnn/ssd_mobilenet_v1_coco_2017_11_17.pbtxt",
@@ -470,8 +481,8 @@ TEST_P(DNNTestNetwork, DenseNet_121)
     }
     else if (target == DNN_TARGET_CUDA_FP16)
     {
-        l1 = 0.008;
-        lInf = 0.05;
+        l1 = 0.015;
+        lInf = 0.06;
     }
     processNet("dnn/DenseNet_121.caffemodel", "dnn/DenseNet_121.prototxt", Size(224, 224), "", "", l1, lInf);
     if (target != DNN_TARGET_MYRIAD || getInferenceEngineVPUType() != CV_DNN_INFERENCE_ENGINE_VPU_TYPE_MYRIAD_X)

--- a/modules/dnn/test/test_caffe_importer.cpp
+++ b/modules/dnn/test/test_caffe_importer.cpp
@@ -358,7 +358,13 @@ TEST_P(Reproducibility_MobileNet_SSD, Accuracy)
     {
         Mat pred = outBatch.rowRange(i * numRealDetections, (i + 1) * numRealDetections);
         EXPECT_EQ(countNonZero(pred.col(0) != i), 0);
-        normAssert(pred.colRange(1, 7), out.colRange(1, 7));
+        double l1 = 1e-5, lInf = 1e-4;
+        if (targetId == DNN_TARGET_CUDA_FP16)
+        {
+            l1 = 3e-4;
+            lInf = 0.002;
+        }
+        normAssert(pred.colRange(1, 7), out.colRange(1, 7), "", l1, lInf);
     }
 }
 INSTANTIATE_TEST_CASE_P(/**/, Reproducibility_MobileNet_SSD, dnnBackendsAndTargets());

--- a/modules/dnn/test/test_caffe_importer.cpp
+++ b/modules/dnn/test/test_caffe_importer.cpp
@@ -361,8 +361,8 @@ TEST_P(Reproducibility_MobileNet_SSD, Accuracy)
         double l1 = 1e-5, lInf = 1e-4;
         if (targetId == DNN_TARGET_CUDA_FP16)
         {
-            l1 = 3e-4;
-            lInf = 0.002;
+            l1 = 4e-4;
+            lInf = 0.004;
         }
         normAssert(pred.colRange(1, 7), out.colRange(1, 7), "", l1, lInf);
     }

--- a/modules/dnn/test/test_layers.cpp
+++ b/modules/dnn/test/test_layers.cpp
@@ -417,7 +417,7 @@ TEST_P(Test_Caffe_layers, Conv_Elu)
     if (target == DNN_TARGET_CUDA_FP16)
     {
         l1 = 0.0002;
-        lInf = 0.0005;
+        lInf = 0.005;
     }
     normAssert(ref, out, "", l1, lInf);
 }

--- a/modules/dnn/test/test_model.cpp
+++ b/modules/dnn/test/test_model.cpp
@@ -254,7 +254,8 @@ TEST_P(Test_Model, DetectionMobilenetSSD)
     }
     else if (target == DNN_TARGET_CUDA_FP16)
     {
-        scoreDiff = 4e-4;
+        scoreDiff = 0.006;
+        iouDiff = 0.01;
     }
     float confThreshold = FLT_MIN;
     double nmsThreshold = 0.0;

--- a/modules/dnn/test/test_onnx_importer.cpp
+++ b/modules/dnn/test/test_onnx_importer.cpp
@@ -537,11 +537,15 @@ TEST_P(Test_ONNX_layers, Split_EltwiseMax)
 
 TEST_P(Test_ONNX_layers, LSTM)
 {
+    if (backend == DNN_BACKEND_CUDA)
+        applyTestTag(CV_TEST_TAG_DNN_SKIP_CUDA);
     testONNXModels("lstm", npy, 0, 0, false, false);
 }
 
 TEST_P(Test_ONNX_layers, LSTM_bidirectional)
 {
+    if (backend == DNN_BACKEND_CUDA)
+        applyTestTag(CV_TEST_TAG_DNN_SKIP_CUDA);
     testONNXModels("lstm_bidirectional", npy, 0, 0, false, false);
 }
 
@@ -916,8 +920,8 @@ TEST_P(Test_ONNX_nets, Resnet34_kinetics)
     float l1 = 0.0013, lInf = 0.009;
     if (target == DNN_TARGET_CUDA_FP16)
     {
-        l1 = 0.008;
-        lInf = 0.04;
+        l1 = 0.01;
+        lInf = 0.06;
     }
 
     checkBackend(&input0, &ref0);

--- a/modules/dnn/test/test_tf_importer.cpp
+++ b/modules/dnn/test/test_tf_importer.cpp
@@ -347,7 +347,13 @@ TEST_P(Test_TensorFlow_layers, pooling_max_pool_odd_same)
     if (backend == DNN_BACKEND_INFERENCE_ENGINE_NGRAPH && target == DNN_TARGET_MYRIAD)
         applyTestTag(CV_TEST_TAG_DNN_SKIP_IE_MYRIAD, CV_TEST_TAG_DNN_SKIP_IE_NGRAPH, CV_TEST_TAG_DNN_SKIP_IE_VERSION);
 #endif
-    runTensorFlowNet("max_pool_odd_same");
+    double l1 = 0.0, lInf = 0.0;
+    if (target == DNN_TARGET_CUDA_FP16)
+    {
+        l1 = 0.006;
+        lInf = 0.1;
+    }
+    runTensorFlowNet("max_pool_odd_same", false, l1, lInf);
 }
 TEST_P(Test_TensorFlow_layers, pooling_reduce_mean)
 {
@@ -562,6 +568,7 @@ TEST_P(Test_TensorFlow_nets, MobileNet_SSD)
     }
     else if (target == DNN_TARGET_CUDA_FP16)
     {
+        scoreDiff = 0.005;
         iouDiff = 0.04;
     }
     normAssertDetections(ref, out, "", 0.2, scoreDiff, iouDiff);
@@ -740,7 +747,7 @@ TEST_P(Test_TensorFlow_nets, MobileNet_v1_SSD_PPN)
     }
     else if (target == DNN_TARGET_CUDA_FP16)
     {
-        scoreDiff = 0.006;
+        scoreDiff = 0.02;
         iouDiff = 0.05;
     }
     normAssertDetections(ref, out, "", 0.45, scoreDiff, iouDiff);
@@ -883,6 +890,11 @@ TEST_P(Test_TensorFlow_layers, fp16_weights_fp16_max_pool_odd_same)
         applyTestTag(CV_TEST_TAG_DNN_SKIP_IE_MYRIAD, CV_TEST_TAG_DNN_SKIP_IE_NGRAPH, CV_TEST_TAG_DNN_SKIP_IE_VERSION);
 #endif
     float l1 = 0.00078, lInf = 0.012;
+    if (target == DNN_TARGET_CUDA_FP16)
+    {
+        l1 = 0.004;
+        lInf = 0.08;
+    }
     runTensorFlowNet("fp16_max_pool_odd_same", false, l1, lInf);
 }
 TEST_P(Test_TensorFlow_layers, fp16_weights_fp16_eltwise_add_mul)
@@ -932,7 +944,7 @@ TEST_P(Test_TensorFlow_layers, fp16_weights_fp16_max_pool_odd_valid)
         lInf = 0.024;
     }
     // Reference output values are in range [0.418, 2.297]
-    runTensorFlowNet("fp16_max_pool_odd_valid", false, l1, lInf);
+    runTensorFlowNet("fp16_max_pool_odd_valid", false, target == DNN_TARGET_CUDA_FP16 ? 0.002 : l1, lInf);
 }
 
 TEST_P(Test_TensorFlow_layers, fp16_padding_same)

--- a/modules/dnn/test/test_torch_importer.cpp
+++ b/modules/dnn/test/test_torch_importer.cpp
@@ -191,7 +191,7 @@ TEST_P(Test_Torch_layers, run_depth_concat)
     }
     else if (target == DNN_TARGET_CUDA_FP16)
     {
-        lInf = 0.03;
+        lInf = 0.05;
     }
     runTorchNet("net_depth_concat", "", false, true, true, 0.0, lInf);
 }
@@ -254,8 +254,8 @@ TEST_P(Test_Torch_layers, net_conv_gemm_lrn)
     }
     else if (target == DNN_TARGET_CUDA_FP16)
     {
-        l1 = 0.0042;
-        lInf = 0.021;
+        l1 = 0.005;
+        lInf = 0.03;
     }
     runTorchNet("net_conv_gemm_lrn", "", false, true, true, l1, lInf);
 }


### PR DESCRIPTION
**Statistics as of May 14th 2020:**

Devices:

- GTX 1050 Mobile
- GTX 1080 Ti
- RTX 2080 Ti

[benchmarks without this PR](https://gist.github.com/YashasSamaga/4640594be2580d85b80f5c662339ff4b)

[benchmarks with this PR](https://gist.github.com/YashasSamaga/be44243671b4796977b475d02f41ef80)

[autotuning algorithm selections](https://gist.github.com/YashasSamaga/963d628a10711c8b5bfd6d8da2a5fee0)

[convolution configurations](https://gist.github.com/YashasSamaga/b048ee7084e52d9c9a3dd41f15663e09)

---

**NOTE:** Not up-to-date.

**Device:** GTX 1050

Model                                       | without this patch | with this patch
---------------------------------------- | ----------------------- | ---------------------
MobileNet SSD Coco v1          | 55ms                    |  **7ms**
MobileNet SSD Coco v2          | 84ms                    | **11ms**
OpenPose pose MPI                | 156ms                 | **111ms**
EfficientNet B0 YOLOv3          | 121ms                  | **15ms**
FastNeuralStyle Stary Night    | 26ms                    | **22ms**
Inception v2 Mask RCNN        | 180ms                  | **152ms**

Every model which uses depthwise convolutions has got an improvement.

Most of Mask RCNN improvement comes from a single convolution layer where the algorithm chosen by heuristics took 40ms whereas the best algorithm took just 20ms. 

---

**Pending:**
- insanely big initialization times

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under OpenCV (BSD) License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [x] The PR is proposed to proper branch
- [x] There is reference to original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake

```
force_builders=Custom
buildworker:Custom=linux-4
build_image:Custom=ubuntu-cuda:18.04
```