### PR TITLE
G-API utils - make variant converting constructor and assignment operator properly forward it's argument

### DIFF
--- a/modules/gapi/test/util/variant_tests.cpp
+++ b/modules/gapi/test/util/variant_tests.cpp
@@ -33,7 +33,7 @@ TEST(Variant, EmptyCTor)
     EXPECT_EQ("", util::get<std::string>(vsi));
 }
 
-TEST(Variant, ValueMoveCTor)
+TEST(Variant, ConvertingCTorMove)
 {
     util::variant<int> vi(42);
     EXPECT_EQ(0u,     vi.index());
@@ -55,16 +55,23 @@ TEST(Variant, ValueMoveCTor)
     EXPECT_EQ(0u,     vsi.index());
     EXPECT_EQ("2017", util::get<std::string>(vsi));
 
+    std::string rvs("2017");
+    util::variant<std::string, int> vsi3(std::move(rvs));
+    EXPECT_EQ(0u,     vsi3.index());
+    EXPECT_EQ("2017", util::get<std::string>(vsi3));
+    EXPECT_EQ("", rvs) <<"Rvalue source argument was not moved from while should?";
+
     util::variant<std::string, int> vsi2(42);
     EXPECT_EQ(1u,     vsi2.index());
     EXPECT_EQ(42,     util::get<int>(vsi2));
 }
 
-TEST(Variant, ValueCopyCTor)
+TEST(Variant, ConvertingCTorCopy)
 {
     const int i42         = 42;
     const int i17         = 2017;
     const std::string s17 = "2017";
+    std::string s17_lvref = s17;
 
     util::variant<int> vi(i42);
     EXPECT_EQ(0u,     vi.index());
@@ -81,6 +88,11 @@ TEST(Variant, ValueCopyCTor)
     util::variant<std::string> vs(s17);
     EXPECT_EQ(0u,     vs.index());
     EXPECT_EQ(s17,    util::get<std::string>(vs));
+
+    util::variant<std::string> vs_lv(s17_lvref);
+    EXPECT_EQ(0u,           vs_lv.index());
+    EXPECT_EQ(s17, s17_lvref);
+    EXPECT_EQ(s17_lvref,    util::get<std::string>(vs_lv));
 
     util::variant<std::string, int> vsi(s17);
     EXPECT_EQ(0u,     vsi.index());
@@ -151,6 +163,20 @@ TEST(Variant, Assign_ValueUpdate_DiffType)
     EXPECT_EQ("42", util::get<std::string>(vis));
 }
 
+TEST(Variant, Assign_RValueRef_DiffType)
+{
+    TestVar vis(42);
+
+    EXPECT_EQ(0u, vis.index());
+    EXPECT_EQ(42, util::get<int>(vis));
+
+    std::string s("42");
+    vis = std::move(s);
+    EXPECT_EQ(1u, vis.index());
+    EXPECT_EQ("42", util::get<std::string>(vis));
+    EXPECT_EQ("", s) << "right hand side argument of assignment operation was not moved from while should?";;
+}
+
 TEST(Variant, Assign_LValueRef_DiffType)
 {
     TestVar vis(42);
@@ -162,6 +188,7 @@ TEST(Variant, Assign_LValueRef_DiffType)
     vis = s;
     EXPECT_EQ(1u, vis.index());
     EXPECT_EQ("42", util::get<std::string>(vis));
+    EXPECT_EQ("42", s) << "right hand side argument of assignment operation was moved from while should not ?";
 }
 
 TEST(Variant, Assign_ValueUpdate_Const)
@@ -198,7 +225,7 @@ TEST(Variant, Assign_ValueUpdate_Const_DiffType)
     EXPECT_EQ("42", util::get<std::string>(va));
 }
 
-TEST(Variant, Assign_Move)
+TEST(Variant, Assign_Move_Variant)
 {
     TestVar va(42);
     TestVar vb(std::string("42"));


### PR DESCRIPTION
This patch fixes usage of [Universal (Forwarding ) reference](https://en.cppreference.com/w/cpp/language/reference) in the converting constructor and assignment operator of `variant`.
 
<cut/>

In c++,  function template argument such  as `T&&`  is not always a _rvalue  reference_. If `T` is function template parameter, then `T&&` is a universal reference , which can be bound to both _rvalue  reference_ and _lvalue  reference_  . I.e. in the following declaration  `t` is the universal reference: 
```c++
template <typename T> 
voif f(T&& t);
```
So, in order to have a template function with templated parameter accepting only _rvalue references_, some extra effort is needed . One possible way is to add an extra overload which is a better match for _lvalue references_ .  For `variant` converting constructor it is:
```c++
template<typename T> explicit variant::variant(T& t);
```

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under OpenCV (BSD) License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [x] The PR is proposed to proper branch
- [x] There is reference to original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake


```
force_builders=ARMv7,Custom
build_image:Custom=centos:7
buildworker:Custom=linux-1

build_gapi_standalone:Linux x64=ade-0.1.1f
build_gapi_standalone:Win64=ade-0.1.1f
build_gapi_standalone:Mac=ade-0.1.1f
build_gapi_
```
