### PR TITLE
Update train.prototxt

### DIFF
--- a/samples/dnn/face_detector/train.prototxt
+++ b/samples/dnn/face_detector/train.prototxt
@@ -1020,7 +1020,7 @@ layer {
   }
   convolution_param {
     num_output: 128
-    pad: 1
+    pad: 0
     kernel_size: 3
     stride: 1
     weight_filler {
@@ -1600,7 +1600,7 @@ layer {
   }
   convolution_param {
     num_output: 16
-    pad: 0
+    pad: 1
     kernel_size: 3
     stride: 1
     weight_filler {


### PR DESCRIPTION
Check failed: num_priors_ * loc_classes_ * 4 == bottom[0]->channels() (35312 vs. 35056) Number of priors must match number of location predictions.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under OpenCV (BSD) License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [x] The PR is proposed to proper branch
- [x] There is reference to original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
