### PR TITLE
fix freebsd build

### DIFF
--- a/modules/core/src/parallel.cpp
+++ b/modules/core/src/parallel.cpp
@@ -54,7 +54,7 @@
 #endif
 
 #if defined __linux__ || defined __APPLE__ || defined __GLIBC__ \
-    || defined __HAIKU__ || defined __EMSCRIPTEN__
+    || defined __HAIKU__ || defined __EMSCRIPTEN__ || defined __FreeBSD__
     #include <unistd.h>
     #include <stdio.h>
     #include <sys/types.h>


### PR DESCRIPTION
fix

> 
error: use of undeclared identifier '_SC_NPROCESSORS_ONLN'

> 