### PR TITLE
(3.4) eliminate build warnings

### DIFF
--- a/modules/core/src/parallel.cpp
+++ b/modules/core/src/parallel.cpp
@@ -95,6 +95,9 @@
 */
 
 #if defined HAVE_TBB
+    #ifndef TBB_SUPPRESS_DEPRECATED_MESSAGES  // supress warning
+    #define TBB_SUPPRESS_DEPRECATED_MESSAGES 1
+    #endif
     #include "tbb/tbb.h"
     #include "tbb/task.h"
     #include "tbb/tbb_stddef.h"

--- a/modules/dnn/CMakeLists.txt
+++ b/modules/dnn/CMakeLists.txt
@@ -100,6 +100,7 @@ endif()
 ocv_module_include_directories(${include_dirs})
 if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
   ocv_append_source_files_cxx_compiler_options(fw_srcs "-Wno-suggest-override")  # GCC
+  ocv_append_source_files_cxx_compiler_options(fw_srcs "-Wno-array-bounds")  # GCC 9.3.0 (Ubuntu 20.04)
 elseif(CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
   ocv_append_source_files_cxx_compiler_options(fw_srcs "-Wno-inconsistent-missing-override")  # Clang
 endif()


### PR DESCRIPTION
backport #16915

```
force_builders=Custom
build_image:Custom=ubuntu:20.04
buildworker:Custom=linux-1
Xbuild_image:Linux OpenCL=ubuntu:20.04
Xbuildworker:Linux OpenCL=linux-2
build_image:Linux AVX2=ubuntu:20.04
build_image:Custom Win=msvs2019
```