### PR TITLE
Enable ONNX SSD from https://github.com/amdegroot/ssd.pytorch

### DIFF
--- a/modules/dnn/test/test_onnx_importer.cpp
+++ b/modules/dnn/test/test_onnx_importer.cpp
@@ -440,6 +440,7 @@ TEST_P(Test_ONNX_layers, ReduceL2)
 {
     testONNXModels("reduceL2");
     testONNXModels("reduceL2_subgraph");
+    testONNXModels("reduceL2_subgraph_2");
 }
 
 TEST_P(Test_ONNX_layers, Split)


### PR DESCRIPTION
**Merge with extra**: https://github.com/opencv/opencv_extra/pull/744

Let's merge after https://github.com/opencv/opencv/pull/16985

### Convert to ONNX
To export model to ONNX, see https://github.com/amdegroot/ssd.pytorch/pull/462

```
python3 export_to_onnx.py --model ssd300_mAP_77.43_v2.pth
```

### Run with OpenCV
```python
import numpy as np
import cv2 as cv

net = cv.dnn.readNet('ssd.onnx')

img = cv.imread('example.jpg')
rows, cols = img.shape[0:2]
inp = cv.dnn.blobFromImage(img, 1.0, (300, 300), mean=(123, 117, 104), swapRB=True)

net.setInput(inp)
out = net.forward()

for detection in out[0,0,:,:]:
    score = float(detection[2])
    if score > 0.7:
        xmin, ymin, xmax, ymax = [int(v) for v in detection[3:] * [cols, rows, cols, rows]]
        cv.rectangle(img, (xmin, ymin), (xmax, ymax), (23, 230, 210), thickness=2)

cv.imshow('Object detection', img)
cv.waitKey()
```

### OpenVINO conversion flags

```
python3 /opt/intel/openvino/deployment_tools/model_optimizer/mo_onnx.py \
  --input_model ssd.onnx \
  --mean_values [123,117,104] \
  --reverse_input_channels \
  --input_shape [1,3,300,300]
```

![res](https://user-images.githubusercontent.com/25801568/77827963-d935c900-7129-11ea-8b4c-015931eb12ff.jpg)

```
force_builders=Custom,Custom Win,Custom Mac
build_image:Custom=ubuntu-openvino-2020.1.0:16.04
build_image:Custom Win=openvino-2020.1.0
build_image:Custom Mac=openvino-2020.1.0

test_modules:Custom=dnn,python2,python3,java
test_modules:Custom Win=dnn,python2,python3,java
test_modules:Custom Mac=dnn,python2,python3,java

buildworker:Custom=linux-1
# disabled due high memory usage: test_opencl:Custom=ON
test_opencl:Custom=OFF
test_bigdata:Custom=1
test_filter:Custom=*
```