### PR TITLE
Fisheye model extended with additional plane to support FOV > 90 in projectPoints

### DIFF
--- a/modules/calib3d/src/fisheye.cpp
+++ b/modules/calib3d/src/fisheye.cpp
@@ -416,6 +416,8 @@ void cv::fisheye::undistortPoints( InputArray distorted, OutputArray undistorted
                     break;
             }
 
+            theta = min(theta, CV_PI/2.);
+                
             scale = std::tan(theta) / theta_d;
         }
 

--- a/modules/calib3d/src/fisheye.cpp
+++ b/modules/calib3d/src/fisheye.cpp
@@ -381,11 +381,6 @@ void cv::fisheye::undistortPoints( InputArray distorted, OutputArray undistorted
 
         double theta_d = sqrt(pw[0]*pw[0] + pw[1]*pw[1]);
 
-        // the current camera model is only valid up to 180 FOV
-        // for larger FOV the loop below does not converge
-        // clip values so we still get plausible results for super fisheye images > 180 grad
-        theta_d = min(max(-CV_PI/2., theta_d), CV_PI/2.);
-
         if (theta_d > 1e-8)
         {
             // compensate distortion iteratively


### PR DESCRIPTION
### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [y] I agree to contribute to the project under OpenCV (BSD) License.
- [y] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [y] The PR is proposed to proper branch
- [y] There is reference to original bug report and related work 
**see: http://www.ee.oulu.fi/~jkannala/publications/tpami2006.pdf**
- [y] There is accuracy test, performance test and test data in opencv_extra repository, if applicable. Patch to opencv_extra has the same branch name.
**opencv_extra PR: https://github.com/opencv/opencv_extra/pull/747**
- [n] The feature is well documented and sample code can be built with the project CMake

Context: OpenCV 3.4.3-4.2.0, Ubuntu 18.04, Cmake ~3.10
Documentation in progress

---
-According paper theta_d is actually tan_theta_d and that restrictive condition had no sense in undistortPoints();
-model extended on additional plane to support FOV > 90 in projectPoints() 