### PR TITLE
imgproc(resize): fix resizeNNInvoker handling of generic pixel size

### DIFF
--- a/modules/imgproc/src/resize.cpp
+++ b/modules/imgproc/src/resize.cpp
@@ -1043,10 +1043,9 @@ public:
             default:
                 for( x = 0; x < dsize.width; x++, D += pix_size )
                 {
-                    const int* _tS = (const int*)(S + x_ofs[x]);
-                    int* _tD = (int*)D;
-                    for( int k = 0; k < pix_size4; k++ )
-                        _tD[k] = _tS[k];
+                    const uchar* _tS = S + x_ofs[x];
+                    for (int k = 0; k < pix_size; k++)
+                        D[k] = _tS[k];
                 }
             }
         }

--- a/modules/imgproc/test/test_imgwarp.cpp
+++ b/modules/imgproc/test/test_imgwarp.cpp
@@ -1721,7 +1721,7 @@ TEST(Resize, lanczos4_regression_16192)
     EXPECT_EQ(cvtest::norm(dst, expected, NORM_INF), 0) << dst(Rect(0,0,8,8));
 }
 
-TEST(Resize, DISABLED_nearest_regression_15075)  // reverted https://github.com/opencv/opencv/pull/16497
+TEST(Resize, nearest_regression_15075)
 {
     const int C = 5;
     const int i1 = 5, j1 = 5;


### PR DESCRIPTION
resolves #15075
relates #16497

- ~~drop unused `pix_size4`~~ (separate PR with cleanup)