### PR TITLE
GAPI - KW fixes - removes unreachable code GIsland::producer()

### DIFF
--- a/modules/gapi/src/compiler/gislandmodel.cpp
+++ b/modules/gapi/src/compiler/gislandmodel.cpp
@@ -117,8 +117,7 @@ ade::NodeHandle GIsland::producer(const ade::Graph &g,
     }
     // Consistency: A GIsland requested for producer() of slot_nh should
     // always had the appropriate GModel node handle in its m_out_ops vector.
-    GAPI_Assert(false);
-    return ade::NodeHandle();
+    GAPI_Assert(false && "Broken GIslandModel ?.");
 }
 
 std::string GIsland::name() const


### PR DESCRIPTION
 - remove unreachable code in `GIsland::producer()`

Static analysis complains that code after  `GAPI_Assert` is unreachable (is it's either `throw`s exception / issue division by zero / call `abort`)

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [X] I agree to contribute to the project under OpenCV (BSD) License.
- [X] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [X] The PR is proposed to proper branch
- [X] There is reference to original bug report and related work
- [X] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [X] The feature is well documented and sample code can be built with the project CMake

```
force_builders=ARMv7,Custom
build_image:Custom=centos:7
buildworker:Custom=linux-1

build_gapi_standalone:Linux x64=ade-0.1.1f
build_gapi_standalone:Win64=ade-0.1.1f
build_gapi_standalone:Mac=ade-0.1.1f
build_gapi_standalone:Linux x64 Debug=ade-0.1.1f
```