### PR TITLE
QRDetectMulti : different return value bug fix

### DIFF
--- a/modules/objdetect/perf/perf_qrcode_pipeline.cpp
+++ b/modules/objdetect/perf/perf_qrcode_pipeline.cpp
@@ -114,7 +114,7 @@ INSTANTIATE_TEST_CASE_P(/*nothing*/, Perf_Objdetect_QRCode,
 INSTANTIATE_TEST_CASE_P(/*nothing*/, Perf_Objdetect_QRCode_Multi,
     ::testing::Values(
       "2_qrcodes.png", "3_close_qrcodes.png", "3_qrcodes.png", "4_qrcodes.png",
-       "5_qrcodes.png", "6_qrcodes.png", "7_qrcodes.png", "8_close_qrcodes.png"
+      "5_qrcodes.png", "6_qrcodes.png", "7_qrcodes.png", "8_close_qrcodes.png"
     )
 );
 

--- a/modules/objdetect/src/qrcode.cpp
+++ b/modules/objdetect/src/qrcode.cpp
@@ -1952,8 +1952,9 @@ bool QRDetectMulti::checkSets(vector<vector<Point2f> >& true_points_group, vecto
     vector<int> set_size(true_points_group.size());
     for (size_t i = 0; i < true_points_group.size(); i++)
     {
-        set_size[i] = int(0.5 * (true_points_group[i].size() - 2 ) * (true_points_group[i].size() - 1));
+        set_size[i] = int( (true_points_group[i].size() - 2 ) * (true_points_group[i].size() - 1) * true_points_group[i].size()) / 6;
     }
+
     vector< vector< Vec3i > > all_points(true_points_group.size());
     for (size_t i = 0; i < true_points_group.size(); i++)
         all_points[i].resize(set_size[i]);
@@ -1961,14 +1962,15 @@ bool QRDetectMulti::checkSets(vector<vector<Point2f> >& true_points_group, vecto
     for (size_t i = 0; i < true_points_group.size(); i++)
     {
         cur_cluster = 0;
-        for (size_t j = 1; j < true_points_group[i].size() - 1; j++)
-            for (size_t k = j + 1; k < true_points_group[i].size(); k++)
-            {
-                all_points[i][cur_cluster][0] = 0;
-                all_points[i][cur_cluster][1] = int(j);
-                all_points[i][cur_cluster][2] = int(k);
-                cur_cluster++;
-            }
+        for (size_t l = 0; l < true_points_group[i].size() - 2; l++)
+            for (size_t j = l + 1; j < true_points_group[i].size() - 1; j++)
+                for (size_t k = j + 1; k < true_points_group[i].size(); k++)
+                {
+                    all_points[i][cur_cluster][0] = int(l);
+                    all_points[i][cur_cluster][1] = int(j);
+                    all_points[i][cur_cluster][2] = int(k);
+                    cur_cluster++;
+                }
     }
 
     for (size_t i = 0; i < true_points_group.size(); i++)

--- a/modules/objdetect/test/test_qrcode.cpp
+++ b/modules/objdetect/test/test_qrcode.cpp
@@ -23,7 +23,8 @@ std::string qrcode_images_monitor[] = {
 };
 std::string qrcode_images_multiple[] = {
   "2_qrcodes.png", "3_close_qrcodes.png", "3_qrcodes.png", "4_qrcodes.png",
-   "5_qrcodes.png", "6_qrcodes.png", "7_qrcodes.png", "8_close_qrcodes.png"
+  "5_qrcodes.png", "6_qrcodes.png", "7_qrcodes.png", "8_close_qrcodes.png",
+  "14_qrcodes.png"
 };
 //#define UPDATE_QRCODE_TEST_DATA
 #ifdef  UPDATE_QRCODE_TEST_DATA
@@ -138,7 +139,6 @@ TEST(Objdetect_QRCode_Monitor, generate_test_data)
     file_config.release();
 }
 
-
 TEST(Objdetect_QRCode_Multi, generate_test_data)
 {
     const std::string root = "qrcode/multiple/";
@@ -155,11 +155,12 @@ TEST(Objdetect_QRCode_Multi, generate_test_data)
 
         ASSERT_FALSE(src.empty()) << "Can't read image: " << image_path;
         std::vector<Point> corners;
-        EXPECT_TRUE(detectQRCodeMulti(src, corners));
+        QRCodeDetector qrcode;
+        EXPECT_TRUE(qrcode.detectMulti(src, corners));
 #ifdef HAVE_QUIRC
         std::vector<cv::String> decoded_info;
         std::vector<Mat> straight_barcode;
-        EXPECT_TRUE(decodeQRCodeMulti(src, corners, decoded_info, straight_barcode));
+        EXPECT_TRUE(qrcode.decodeMulti(src, corners, decoded_info, straight_barcode));
 #endif
         file_config << "x" << "[:";
         for(size_t j = 0; j < corners.size(); j += 4)
@@ -499,6 +500,24 @@ TEST(Objdetect_QRCode_decodeMulti, decode_regression_16491)
     QRCodeDetector mat_qrcode;
     EXPECT_NO_THROW(mat_qrcode.decodeMulti(zero_image, mat_corners, decoded_info, straight_barcode));
 #endif
+}
+
+TEST(Objdetect_QRCode_detectMulti, detect_regression_16961)
+{
+    const std::string name_current_image = "14_qrcodes.png";
+    const std::string root = "qrcode/multiple/";
+
+    std::string image_path = findDataFile(root + name_current_image);
+    Mat src = imread(image_path);
+    ASSERT_FALSE(src.empty()) << "Can't read image: " << image_path;
+    QRCodeDetector qrcode;
+    std::vector<Point> corners;
+    size_t expect_corners_size = 56;
+
+    ASSERT_TRUE(qrcode.detectMulti(src, corners));
+    ASSERT_FALSE(corners.empty());
+    std::cout << corners.size() << std::endl;
+    EXPECT_EQ(corners.size(), expect_corners_size);
 }
 
 TEST(Objdetect_QRCode_basic, not_found_qrcode)

--- a/modules/objdetect/test/test_qrcode.cpp
+++ b/modules/objdetect/test/test_qrcode.cpp
@@ -23,8 +23,7 @@ std::string qrcode_images_monitor[] = {
 };
 std::string qrcode_images_multiple[] = {
   "2_qrcodes.png", "3_close_qrcodes.png", "3_qrcodes.png", "4_qrcodes.png",
-  "5_qrcodes.png", "6_qrcodes.png", "7_qrcodes.png", "8_close_qrcodes.png",
-  "14_qrcodes.png"
+  "5_qrcodes.png", "6_qrcodes.png", "7_qrcodes.png", "8_close_qrcodes.png"
 };
 //#define UPDATE_QRCODE_TEST_DATA
 #ifdef  UPDATE_QRCODE_TEST_DATA
@@ -476,7 +475,6 @@ TEST_P(Objdetect_QRCode_Multi, regression)
     }
 }
 
-
 INSTANTIATE_TEST_CASE_P(/**/, Objdetect_QRCode, testing::ValuesIn(qrcode_images_name));
 INSTANTIATE_TEST_CASE_P(/**/, Objdetect_QRCode_Close, testing::ValuesIn(qrcode_images_close));
 INSTANTIATE_TEST_CASE_P(/**/, Objdetect_QRCode_Monitor, testing::ValuesIn(qrcode_images_monitor));
@@ -504,19 +502,18 @@ TEST(Objdetect_QRCode_decodeMulti, decode_regression_16491)
 
 TEST(Objdetect_QRCode_detectMulti, detect_regression_16961)
 {
-    const std::string name_current_image = "14_qrcodes.png";
+    const std::string name_current_image = "9_qrcodes.jpg";
     const std::string root = "qrcode/multiple/";
 
     std::string image_path = findDataFile(root + name_current_image);
     Mat src = imread(image_path);
     ASSERT_FALSE(src.empty()) << "Can't read image: " << image_path;
+
     QRCodeDetector qrcode;
     std::vector<Point> corners;
-    size_t expect_corners_size = 56;
-
-    ASSERT_TRUE(qrcode.detectMulti(src, corners));
+    EXPECT_TRUE(qrcode.detectMulti(src, corners));
     ASSERT_FALSE(corners.empty());
-    std::cout << corners.size() << std::endl;
+    size_t expect_corners_size = 36;
     EXPECT_EQ(corners.size(), expect_corners_size);
 }
 


### PR DESCRIPTION
**Merge with extra**: https://github.com/opencv/opencv_extra/pull/746

Fixed bug with skip some localization points. Due to this bug some QR-Codes couldn't be found and also the method detectMulti() could return a different number of found QR-codes 

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under OpenCV (BSD) License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [x] The PR is proposed to proper branch
- [ ] There is reference to original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
