### PR TITLE
release: OpenCV 3.4.10

### DIFF
--- a/modules/core/include/opencv2/core/version.hpp
+++ b/modules/core/include/opencv2/core/version.hpp
@@ -8,7 +8,7 @@
 #define CV_VERSION_MAJOR    3
 #define CV_VERSION_MINOR    4
 #define CV_VERSION_REVISION 10
-#define CV_VERSION_STATUS   "-pre"
+#define CV_VERSION_STATUS   ""
 
 #define CVAUX_STR_EXP(__A)  #__A
 #define CVAUX_STR(__A)      CVAUX_STR_EXP(__A)


### PR DESCRIPTION
OpenCV 3.4.10

relates #16770

<cut/>

<details>

<summary>VirusTotal scan results:</summary>

[opencv_world3410.dll (vc14)](https://www.virustotal.com/gui/file/d220bc5c12bc7b4058cb787bb213470707883169f905676aa167873904989d42/detection)
[opencv_world3410d.dll (vc14)](https://www.virustotal.com/gui/file/12853e01f95464aa91028f0546cd9329212a718330cca73c91d7724960553e7b/detection)
[opencv_world3410.dll (vc15)](https://www.virustotal.com/gui/file/b925e1955af1718ed1ae10d1f3f1db57e5ab8c4865729e4748d0ba721edca687/detection)
[opencv_world3410d.dll (vc15)](https://www.virustotal.com/gui/file/6a50675deabb1a687630bf5c515a53eaf6415d5eaa49cd400be03da8f54276f4/detection)

[opencv_ffmpeg3410_64.dll](https://www.virustotal.com/gui/file/02546b95e59bf99b2a6dd409b644498224e3b625f2028e278b00d98cfb73001a/detection)
[opencv_ffmpeg3410.dll](https://www.virustotal.com/gui/file/516e1774deff23343b58ece797a400b96dfba3cf7b90007818ba4a1b72ea5744/detection)

</details>
