### PR TITLE
Added GFrame class

### DIFF
--- a/modules/gapi/include/opencv2/gapi/cpu/gcpukernel.hpp
+++ b/modules/gapi/include/opencv2/gapi/cpu/gcpukernel.hpp
@@ -153,6 +153,10 @@ template<> struct get_in<cv::GMatP>
 {
     static cv::Mat    get(GCPUContext &ctx, int idx) { return get_in<cv::GMat>::get(ctx, idx); }
 };
+template<> struct get_in<cv::GFrame>
+{
+    static cv::Mat    get(GCPUContext &ctx, int idx) { return get_in<cv::GMat>::get(ctx, idx); }
+};
 template<> struct get_in<cv::GScalar>
 {
     static cv::Scalar get(GCPUContext &ctx, int idx) { return ctx.inVal(idx); }

--- a/modules/gapi/include/opencv2/gapi/gkernel.hpp
+++ b/modules/gapi/include/opencv2/gapi/gkernel.hpp
@@ -90,6 +90,7 @@ namespace detail
     template<typename T> struct MetaType;
     template<> struct MetaType<cv::GMat>    { using type = GMatDesc; };
     template<> struct MetaType<cv::GMatP>   { using type = GMatDesc; };
+    template<> struct MetaType<cv::GFrame>  { using type = GMatDesc; };
     template<> struct MetaType<cv::GScalar> { using type = GScalarDesc; };
     template<typename U> struct MetaType<cv::GArray<U> >  { using type = GArrayDesc; };
     template<typename U> struct MetaType<cv::GOpaque<U> > { using type = GOpaqueDesc; };
@@ -219,6 +220,8 @@ class GKernelType<K, std::function<R(Args...)> >
 public:
     using InArgs  = std::tuple<Args...>;
     using OutArgs = std::tuple<R>;
+
+    static_assert(!cv::detail::contains<GFrame, OutArgs>::value, "Values of GFrame type can't be used as operation outputs");
 
     static R on(Args... args)
     {

--- a/modules/gapi/include/opencv2/gapi/gmat.hpp
+++ b/modules/gapi/include/opencv2/gapi/gmat.hpp
@@ -65,6 +65,12 @@ public:
     using GMat::GMat;
 };
 
+class GAPI_EXPORTS GFrame : public GMat
+{
+public:
+    using GMat::GMat;
+};
+
 namespace gapi { namespace own {
     class Mat;
 }}//gapi::own

--- a/modules/gapi/include/opencv2/gapi/gproto.hpp
+++ b/modules/gapi/include/opencv2/gapi/gproto.hpp
@@ -36,6 +36,7 @@ namespace cv {
 using GProtoArg = util::variant
     < GMat
     , GMatP
+    , GFrame
     , GScalar
     , detail::GArrayU  // instead of GArray<T>
     , detail::GOpaqueU // instead of GOpaque<T>

--- a/modules/gapi/include/opencv2/gapi/gtype_traits.hpp
+++ b/modules/gapi/include/opencv2/gapi/gtype_traits.hpp
@@ -36,6 +36,7 @@ namespace detail
         GOBJREF,      // <internal> reference to object
         GMAT,         // a cv::GMat
         GMATP,        // a cv::GMatP
+        GFRAME,       // a cv::GFrame
         GSCALAR,      // a cv::GScalar
         GARRAY,       // a cv::GArrayU  (note - exactly GArrayU,  not GArray<T>!)
         GOPAQUE,      // a cv::GOpaqueU (note - exactly GOpaqueU, not GOpaque<T>!)
@@ -58,6 +59,11 @@ namespace detail
     template<>           struct GTypeTraits<cv::GMatP>
     {
         static constexpr const ArgKind kind = ArgKind::GMATP;
+        static constexpr const GShape shape = GShape::GMAT;
+    };
+    template<>           struct GTypeTraits<cv::GFrame>
+    {
+        static constexpr const ArgKind kind = ArgKind::GFRAME;
         static constexpr const GShape shape = GShape::GMAT;
     };
     template<>           struct GTypeTraits<cv::GScalar>

--- a/modules/gapi/src/api/gproto.cpp
+++ b/modules/gapi/src/api/gproto.cpp
@@ -28,6 +28,9 @@ const cv::GOrigin& cv::gimpl::proto::origin_of(const cv::GProtoArg &arg)
     case cv::GProtoArg::index_of<cv::GMatP>():
         return util::get<cv::GMatP>(arg).priv();
 
+    case cv::GProtoArg::index_of<cv::GFrame>():
+        return util::get<cv::GFrame>(arg).priv();
+
     case cv::GProtoArg::index_of<cv::GScalar>():
         return util::get<cv::GScalar>(arg).priv();
 
@@ -60,6 +63,7 @@ bool cv::gimpl::proto::is_dynamic(const cv::GArg& arg)
     {
     case detail::ArgKind::GMAT:
     case detail::ArgKind::GMATP:
+    case detail::ArgKind::GFRAME:
     case detail::ArgKind::GSCALAR:
     case detail::ArgKind::GARRAY:
     case detail::ArgKind::GOPAQUE:
@@ -87,9 +91,10 @@ cv::GProtoArg cv::gimpl::proto::rewrap(const cv::GArg &arg)
     {
     case detail::ArgKind::GMAT:    return GProtoArg(arg.get<cv::GMat>());
     case detail::ArgKind::GMATP:   return GProtoArg(arg.get<cv::GMatP>());
+    case detail::ArgKind::GFRAME:  return GProtoArg(arg.get<cv::GFrame>());
     case detail::ArgKind::GSCALAR: return GProtoArg(arg.get<cv::GScalar>());
     case detail::ArgKind::GARRAY:  return GProtoArg(arg.get<cv::detail::GArrayU>());
-    case detail::ArgKind::GOPAQUE:  return GProtoArg(arg.get<cv::detail::GOpaqueU>());
+    case detail::ArgKind::GOPAQUE: return GProtoArg(arg.get<cv::detail::GOpaqueU>());
     default: util::throw_error(std::logic_error("Unsupported GArg type"));
     }
 }

--- a/modules/gapi/src/compiler/gcompiler.cpp
+++ b/modules/gapi/src/compiler/gcompiler.cpp
@@ -324,6 +324,7 @@ void cv::gimpl::GCompiler::validateInputMeta()
         // FIXME: Auto-generate methods like this from traits:
         case GProtoArg::index_of<cv::GMat>():
         case GProtoArg::index_of<cv::GMatP>():
+        case GProtoArg::index_of<cv::GFrame>():
             return util::holds_alternative<cv::GMatDesc>(meta);
 
         case GProtoArg::index_of<cv::GScalar>():

--- a/modules/gapi/test/gapi_frame_tests.cpp
+++ b/modules/gapi/test/gapi_frame_tests.cpp
@@ -1,0 +1,61 @@
+// This file is part of OpenCV project.
+// It is subject to the license terms in the LICENSE file found in the top-level directory
+// of this distribution and at http://opencv.org/license.html.
+//
+// Copyright (C) 2020 Intel Corporation
+
+#include "test_precomp.hpp"
+
+#include <opencv2/gapi/cpu/gcpukernel.hpp>
+
+namespace opencv_test
+{
+
+G_API_OP(GBlurFrame, <GMat(GFrame)>, "test.blur_frame") {
+    static GMatDesc outMeta(GMatDesc in) {
+        return in;
+    }
+};
+
+GAPI_OCV_KERNEL(OCVBlurFrame, GBlurFrame)
+{
+    static void run(const cv::Mat& in, cv::Mat& out) {
+        cv::blur(in, out, cv::Size{3,3});
+    }
+};
+
+struct GFrameTest : public ::testing::Test
+{
+    cv::Size sz{32,32};
+    cv::Mat in_mat;
+    cv::Mat out_mat;
+    cv::Mat out_mat_ocv;
+
+    GFrameTest()
+        : in_mat(cv::Mat(sz, CV_8UC1))
+        , out_mat(cv::Mat::zeros(sz, CV_8UC1))
+        , out_mat_ocv(cv::Mat::zeros(sz, CV_8UC1))
+    {
+        cv::randn(in_mat, cv::Scalar::all(127.0f), cv::Scalar::all(40.f));
+        cv::blur(in_mat, out_mat_ocv, cv::Size{3,3});
+    }
+
+    void check()
+    {
+        EXPECT_EQ(0, cvtest::norm(out_mat, out_mat_ocv, NORM_INF));
+    }
+};
+
+TEST_F(GFrameTest, Input)
+{
+    cv::GFrame in;
+    auto out = GBlurFrame::on(in);
+    cv::GComputation c(cv::GIn(in), cv::GOut(out));
+
+    auto pkg = cv::gapi::kernels<OCVBlurFrame>();
+    c.apply(cv::gin(in_mat), cv::gout(out_mat), cv::compile_args(pkg));
+
+    check();
+}
+
+} // namespace opencv_test

--- a/modules/gapi/test/internal/gapi_int_garg_test.cpp
+++ b/modules/gapi/test/internal/gapi_int_garg_test.cpp
@@ -32,6 +32,7 @@ using GArg_Test_Types = ::testing::Types
   // G-API types
      Expected<cv::GMat,                 cv::detail::ArgKind::GMAT>
    , Expected<cv::GMatP,                cv::detail::ArgKind::GMATP>
+   , Expected<cv::GFrame,               cv::detail::ArgKind::GFRAME>
    , Expected<cv::GScalar,              cv::detail::ArgKind::GSCALAR>
    , Expected<cv::GArray<int>,          cv::detail::ArgKind::GARRAY>
    , Expected<cv::GArray<float>,        cv::detail::ArgKind::GARRAY>


### PR DESCRIPTION
## Summary

* Added a GFrame class to introduce an api entity for image buffer with some auxiliary information

```
build_gapi_standalone:Linux x64=ade-0.1.1f
build_gapi_standalone:Win64=ade-0.1.1f
build_gapi_standalone:Mac=ade-0.1.1f
build_gapi_standalone:Linux x64 Debug=ade-0.1.1f
```

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under OpenCV (BSD) License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [x] The PR is proposed to proper branch
- [x] There is reference to original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
