### PR TITLE
Added GOpaque support to GStreamingExecutor

### DIFF
--- a/modules/gapi/src/executor/gexecutor.cpp
+++ b/modules/gapi/src/executor/gexecutor.cpp
@@ -114,6 +114,7 @@ void cv::gimpl::GExecutor::initResource(const ade::NodeHandle &orig_nh)
         break;
 
     case GShape::GARRAY:
+    case GShape::GOPAQUE:
         // Constructed on Reset, do nothing here
         break;
 

--- a/modules/gapi/src/executor/gstreamingexecutor.cpp
+++ b/modules/gapi/src/executor/gstreamingexecutor.cpp
@@ -122,6 +122,9 @@ void sync_data(cv::GRunArgs &results, cv::GRunArgsP &outputs)
         case T::index_of<cv::detail::VectorRef>():
             cv::util::get<cv::detail::VectorRef>(out_obj).mov(cv::util::get<cv::detail::VectorRef>(res_obj));
             break;
+        case T::index_of<cv::detail::OpaqueRef>():
+            cv::util::get<cv::detail::OpaqueRef>(out_obj).mov(cv::util::get<cv::detail::OpaqueRef>(res_obj));
+            break;
         default:
             GAPI_Assert(false && "This value type is not supported!"); // ...maybe because of STANDALONE mode.
             break;
@@ -472,6 +475,16 @@ void islandActorThread(std::vector<cv::gimpl::RcDesc> in_rcs,                // 
                     out_data[id] = cv::GRunArg(std::move(newVec));
                     // VectorRef is implicitly shared so no pointer is taken here
                     const auto &rr = cv::util::get<cv::detail::VectorRef>(out_data[id]); // FIXME: that variant MOVE problem again
+                    isl_outputs[id] = { r, cv::GRunArgP(rr) };
+                }
+                break;
+            case cv::GShape::GOPAQUE:
+                {
+                    cv::detail::OpaqueRef newOpaque;
+                    cv::util::get<cv::detail::ConstructOpaque>(r.ctor)(newOpaque);
+                    out_data[id] = cv::GRunArg(std::move(newOpaque));
+                    // OpaqueRef is implicitly shared so no pointer is taken here
+                    const auto &rr = cv::util::get<cv::detail::OpaqueRef>(out_data[id]); // FIXME: that variant MOVE problem again
                     isl_outputs[id] = { r, cv::GRunArgP(rr) };
                 }
                 break;

--- a/modules/gapi/test/gapi_opaque_tests.cpp
+++ b/modules/gapi/test/gapi_opaque_tests.cpp
@@ -146,6 +146,26 @@ TEST(GOpaque, TestOpaqueBetween)
     EXPECT_EQ(painted, 77);
 }
 
+TEST(GOpaque, TestOpaqueBetweenIslands)
+{
+    cv::Size sz = {50, 50};
+    int depth = CV_8U;
+    int chan = 1;
+    cv::Mat mat_in = cv::Mat::zeros(sz, CV_MAKETYPE(depth, chan));
+    cv::Mat mat_out = cv::Mat::zeros(sz, CV_MAKETYPE(depth, chan));
+
+    cv::GMat in, out;
+    auto betw = ThisTest::GeneratePoint::on(in);
+    out = ThisTest::PaintPoint::on(betw, depth, chan, sz);
+
+    cv::gapi::island("test", cv::GIn(in), cv::GOut(betw));
+    cv::GComputation c(cv::GIn(in), cv::GOut(out));
+    c.apply(cv::gin(mat_in), cv::gout(mat_out), cv::compile_args(cv::gapi::kernels<OCVGeneratePoint, OCVPaintPoint>()));
+
+    int painted = mat_out.at<uint8_t>(42, 42);
+    EXPECT_EQ(painted, 77);
+}
+
 TEST(GOpaque, TestOpaqueCustomOut2)
 {
     cv::Mat input1 = cv::Mat(52, 52, CV_8U);


### PR DESCRIPTION
```
build_gapi_standalone:Linux x64=ade-0.1.1f
build_gapi_standalone:Win64=ade-0.1.1f
build_gapi_standalone:Mac=ade-0.1.1f
build_gapi_standalone:Linux x64 Debug=ade-0.1.1f
```

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under OpenCV (BSD) License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [x] The PR is proposed to proper branch
- [x] There is reference to original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
