### PR TITLE
release: OpenCV 4.3.0

### DIFF
--- a/modules/core/include/opencv2/core/version.hpp
+++ b/modules/core/include/opencv2/core/version.hpp
@@ -8,7 +8,7 @@
 #define CV_VERSION_MAJOR    4
 #define CV_VERSION_MINOR    3
 #define CV_VERSION_REVISION 0
-#define CV_VERSION_STATUS   "-pre"
+#define CV_VERSION_STATUS   ""
 
 #define CVAUX_STR_EXP(__A)  #__A
 #define CVAUX_STR(__A)      CVAUX_STR_EXP(__A)


### PR DESCRIPTION
relates #16771

<cut/>

<details>

<summary>VirusTotal scan results:</summary>

[opencv_world430.dll (vc14)](https://www.virustotal.com/gui/file/b88dfc5fae838927362b24037d85aaa07cd3d64d7dcde97a108c0bda1f0e1553/detection)
[opencv_world430d.dll (vc14)](https://www.virustotal.com/gui/file/649ccdbb5aaffeb210efba5b9bfef0b63bc41807bf5408d32a78f739d4239f78/detection) 
[opencv_world430.dll (vc15)](https://www.virustotal.com/gui/file/db70a0e572acea07b9a3385a2b177afb4e27b30520440217c63aa886bf38897e/detection)
[opencv_world430d.dll (vc15)](https://www.virustotal.com/gui/file/f8895f461b134117c0501b0da602ab0c620735279b180b27a217bd0e9e709258/detection)

detections from `Trapmine: *.ml.score`, [considered false positive](https://stackoverflow.com/questions/54052224/virustotal-trapmine-suspicious-low-ml-score) - 2020-04-03

[opencv_ffmpeg430_64.dll]()
[opencv_ffmpeg430.dll](https://www.virustotal.com/gui/file/d7bbeafb918452abb1f0ec7fef6ae95c3310195fc23850a846edc18f3888a0b2/detection)

</details>