### PR TITLE
highgui: Fix error at #include <window_winrt_bridge.hpp>

### DIFF
--- a/modules/highgui/src/window_winrt.cpp
+++ b/modules/highgui/src/window_winrt.cpp
@@ -33,7 +33,7 @@
 #include <assert.h>
 #include <opencv2\highgui.hpp>
 #include <opencv2\highgui\highgui_winrt.hpp>
-#include <window_winrt_bridge.hpp>
+#include "window_winrt_bridge.hpp"
 
 #define CV_WINRT_NO_GUI_ERROR( funcname )       \
 {                                               \


### PR DESCRIPTION
Fix #16974

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under OpenCV (BSD) License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [x] The PR is proposed to proper branch
- [x] There is reference to original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake


```
build_image:Custom Win=msvs2019-ws-x64
```