### PR TITLE
Incorrect PREDEFINED setting.

### DIFF
--- a/doc/Doxyfile.in
+++ b/doc/Doxyfile.in
@@ -241,7 +241,7 @@ PREDEFINED             = __cplusplus=1 \
                          CV_WRAP= \
                          CV_WRAP_AS(x)= \
                          CV_CDECL= \
-                         CV_Func = \
+                         CV_Func= \
                          CV_DO_PRAGMA(x)= \
                          CV_SUPPRESS_DEPRECATED_START= \
                          CV_SUPPRESS_DEPRECATED_END= \


### PR DESCRIPTION
The PREDEFINED setting for  had a space between the define name and the equal sign and this is not allowed, it results in the warning:
```
error: Illegal PREDEFINED format '=', no define name specified
```
according to the documentation explicitly states that no space is allowed:
> The PREDEFINED tag can be used to specify one or more macro names that are defined before the preprocessor is started (similar to the -D option of e.g. gcc). The argument of the tag is a list of macros of the form: name or name=definition (no spaces). If the definition and the "=" are omitted, "=1" is assumed. To prevent a macro definition from being undefined via #undef or recursively expanded use the := operator instead of the = operator.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under OpenCV (BSD) License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [x] The PR is proposed to proper branch
