### PR TITLE
Fixed divide by zero segfault in forEach

### DIFF
--- a/modules/core/include/opencv2/core/utility.hpp
+++ b/modules/core/include/opencv2/core/utility.hpp
@@ -622,7 +622,8 @@ void Mat::forEach_impl(const Functor& operation) {
         //  or (_Tp&, void*)        <- in case you don't need current idx.
     }
 
-    CV_Assert(this->size[this->dims - 1] > 0 && this->total() / this->size[this->dims - 1] <= INT_MAX);
+    CV_Assert(!empty());
+    CV_Assert(this->total() / this->size[this->dims - 1] <= INT_MAX);
     const int LINES = static_cast<int>(this->total() / this->size[this->dims - 1]);
 
     class PixelOperationWrapper :public ParallelLoopBody

--- a/modules/core/include/opencv2/core/utility.hpp
+++ b/modules/core/include/opencv2/core/utility.hpp
@@ -622,7 +622,7 @@ void Mat::forEach_impl(const Functor& operation) {
         //  or (_Tp&, void*)        <- in case you don't need current idx.
     }
 
-    CV_Assert(this->total() / this->size[this->dims - 1] <= INT_MAX);
+    CV_Assert(this->size[this->dims - 1] > 0 && this->total() / this->size[this->dims - 1] <= INT_MAX);
     const int LINES = static_cast<int>(this->total() / this->size[this->dims - 1]);
 
     class PixelOperationWrapper :public ParallelLoopBody


### PR DESCRIPTION
It's possible either by accident or design to init a Mat with no rows. In such a case instead of a CV assertion you end up with a divide by zero seg fault when trying to forEach.
```
#include <opencv2/core.hpp>

int main() {
  cv::Mat test(cv::Size(0,1), CV_8UC1);
  test.forEach<uint8_t>([](const auto& pixel, const int pos[]) {
  });
}

```

`Process finished with exit code 136 (interrupted by signal 8: SIGFPE)`
### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under OpenCV (BSD) License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [x] The PR is proposed to proper branch
- [ ] There is reference to original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
