### PR TITLE
G-API: Mat's "deownification"

### DIFF
--- a/modules/gapi/include/opencv2/gapi/cpu/gcpukernel.hpp
+++ b/modules/gapi/include/opencv2/gapi/cpu/gcpukernel.hpp
@@ -17,7 +17,6 @@
 #include <opencv2/gapi/gcommon.hpp>
 #include <opencv2/gapi/gkernel.hpp>
 #include <opencv2/gapi/garg.hpp>
-#include <opencv2/gapi/own/convert.hpp> //to_ocv
 #include <opencv2/gapi/util/compiler_hints.hpp> //suppress_unused_warning
 #include <opencv2/gapi/util/util.hpp>
 
@@ -96,8 +95,8 @@ public:
     const T& inArg(int input) { return m_args.at(input).get<T>(); }
 
     // Syntax sugar
-    const cv::gapi::own::Mat&   inMat(int input);
-    cv::gapi::own::Mat&         outMatR(int output); // FIXME: Avoid cv::gapi::own::Mat m = ctx.outMatR()
+    const cv::Mat&   inMat(int input);
+    cv::Mat&         outMatR(int output); // FIXME: Avoid cv::Mat m = ctx.outMatR()
 
     const cv::Scalar& inVal(int input);
     cv::Scalar& outValR(int output); // FIXME: Avoid cv::Scalar s = ctx.outValR()
@@ -147,7 +146,7 @@ namespace detail
 template<class T> struct get_in;
 template<> struct get_in<cv::GMat>
 {
-    static cv::Mat    get(GCPUContext &ctx, int idx) { return to_ocv(ctx.inMat(idx)); }
+    static cv::Mat    get(GCPUContext &ctx, int idx) { return ctx.inMat(idx); }
 };
 template<> struct get_in<cv::GMatP>
 {
@@ -196,7 +195,7 @@ template<class T> struct get_in
 };
 
 struct tracked_cv_mat{
-    tracked_cv_mat(cv::gapi::own::Mat& m) : r{to_ocv(m)}, original_data{m.data} {}
+    tracked_cv_mat(cv::Mat& m) : r{m}, original_data{m.data} {}
     cv::Mat r;
     uchar* original_data;
 

--- a/modules/gapi/include/opencv2/gapi/fluid/gfluidbuffer.hpp
+++ b/modules/gapi/include/opencv2/gapi/fluid/gfluidbuffer.hpp
@@ -14,7 +14,6 @@
 #include <cstdint> // uint8_t
 
 #include <opencv2/gapi/opencv_includes.hpp>
-#include <opencv2/gapi/own/mat.hpp>
 #include <opencv2/gapi/gmat.hpp>
 
 #include <opencv2/gapi/util/optional.hpp>

--- a/modules/gapi/include/opencv2/gapi/fluid/gfluidbuffer.hpp
+++ b/modules/gapi/include/opencv2/gapi/fluid/gfluidbuffer.hpp
@@ -113,7 +113,7 @@ public:
            int wlpi,
            BorderOpt border);
     // Constructor for in/out buffers (for tests)
-    Buffer(const cv::gapi::own::Mat &data, bool is_input);
+    Buffer(const cv::Mat &data, bool is_input);
     ~Buffer();
     Buffer& operator=(Buffer&&);
 

--- a/modules/gapi/include/opencv2/gapi/fluid/gfluidbuffer.hpp
+++ b/modules/gapi/include/opencv2/gapi/fluid/gfluidbuffer.hpp
@@ -18,7 +18,6 @@
 #include <opencv2/gapi/gmat.hpp>
 
 #include <opencv2/gapi/util/optional.hpp>
-#include <opencv2/gapi/own/mat.hpp>
 
 namespace cv {
 namespace gapi {

--- a/modules/gapi/include/opencv2/gapi/garg.hpp
+++ b/modules/gapi/include/opencv2/gapi/garg.hpp
@@ -89,11 +89,10 @@ using GArgs = std::vector<GArg>;
 // FIXME: Move to a separate file!
 using GRunArg  = util::variant<
 #if !defined(GAPI_STANDALONE)
-    cv::Mat,
     cv::UMat,
 #endif // !defined(GAPI_STANDALONE)
     cv::gapi::wip::IStreamSource::Ptr,
-    cv::gapi::own::Mat,
+    cv::Mat,
     cv::Scalar,
     cv::detail::VectorRef,
     cv::detail::OpaqueRef
@@ -122,10 +121,9 @@ struct Data: public GRunArg
 
 using GRunArgP = util::variant<
 #if !defined(GAPI_STANDALONE)
-    cv::Mat*,
     cv::UMat*,
 #endif // !defined(GAPI_STANDALONE)
-    cv::gapi::own::Mat*,
+    cv::Mat*,
     cv::Scalar*,
     cv::detail::VectorRef,
     cv::detail::OpaqueRef

--- a/modules/gapi/include/opencv2/gapi/gcompiled.hpp
+++ b/modules/gapi/include/opencv2/gapi/gcompiled.hpp
@@ -94,6 +94,7 @@ public:
      * cv::gin()/cv::gout() wrappers instead.
      */
     void operator() (GRunArgs &&ins, GRunArgsP &&outs);          // Generic arg-to-arg
+#if !defined(GAPI_STANDALONE)
 
     /**
      * @brief Execute an unary computation
@@ -152,6 +153,7 @@ public:
      */
     void operator() (const std::vector<cv::Mat> &ins,            // Compatibility overload
                      const std::vector<cv::Mat> &outs);
+#endif  // !defined(GAPI_STANDALONE)
     /// @private
     Priv& priv();
 

--- a/modules/gapi/include/opencv2/gapi/gcompiled.hpp
+++ b/modules/gapi/include/opencv2/gapi/gcompiled.hpp
@@ -94,7 +94,6 @@ public:
      * cv::gin()/cv::gout() wrappers instead.
      */
     void operator() (GRunArgs &&ins, GRunArgsP &&outs);          // Generic arg-to-arg
-#if !defined(GAPI_STANDALONE)
 
     /**
      * @brief Execute an unary computation
@@ -153,7 +152,6 @@ public:
      */
     void operator() (const std::vector<cv::Mat> &ins,            // Compatibility overload
                      const std::vector<cv::Mat> &outs);
-#endif  // !defined(GAPI_STANDALONE)
     /// @private
     Priv& priv();
 

--- a/modules/gapi/include/opencv2/gapi/gcomputation.hpp
+++ b/modules/gapi/include/opencv2/gapi/gcomputation.hpp
@@ -250,8 +250,8 @@ public:
     void apply(GRunArgs &&ins, GRunArgsP &&outs, GCompileArgs &&args = {});       // Arg-to-arg overload
 
     /// @private -- Exclude this function from OpenCV documentation
-    void apply(const std::vector<cv::gapi::own::Mat>& ins,                        // Compatibility overload
-               const std::vector<cv::gapi::own::Mat>& outs,
+    void apply(const std::vector<cv::Mat>& ins,                        // Compatibility overload
+               const std::vector<cv::Mat>& outs,
                GCompileArgs &&args = {});
 
     // 2. Syntax sugar and compatibility overloads

--- a/modules/gapi/include/opencv2/gapi/gcomputation.hpp
+++ b/modules/gapi/include/opencv2/gapi/gcomputation.hpp
@@ -255,6 +255,7 @@ public:
                GCompileArgs &&args = {});
 
     // 2. Syntax sugar and compatibility overloads
+#if !defined(GAPI_STANDALONE)
     /**
      * @brief Execute an unary computation (with compilation on the fly)
      *
@@ -319,6 +320,7 @@ public:
     void apply(const std::vector<cv::Mat>& ins,         // Compatibility overload
                      std::vector<cv::Mat>& outs,
                GCompileArgs &&args = {});
+#endif // !defined(GAPI_STANDALONE)
     // Various versions of compile(): //////////////////////////////////////////
     // 1. Generic compile() - requires metas to be passed as vector
     /**

--- a/modules/gapi/include/opencv2/gapi/gcomputation.hpp
+++ b/modules/gapi/include/opencv2/gapi/gcomputation.hpp
@@ -250,7 +250,7 @@ public:
     void apply(GRunArgs &&ins, GRunArgsP &&outs, GCompileArgs &&args = {});       // Arg-to-arg overload
 
     /// @private -- Exclude this function from OpenCV documentation
-    void apply(const std::vector<cv::Mat>& ins,                        // Compatibility overload
+    void apply(const std::vector<cv::Mat>& ins,                                   // Compatibility overload
                const std::vector<cv::Mat>& outs,
                GCompileArgs &&args = {});
 

--- a/modules/gapi/include/opencv2/gapi/gcomputation.hpp
+++ b/modules/gapi/include/opencv2/gapi/gcomputation.hpp
@@ -255,7 +255,6 @@ public:
                GCompileArgs &&args = {});
 
     // 2. Syntax sugar and compatibility overloads
-#if !defined(GAPI_STANDALONE)
     /**
      * @brief Execute an unary computation (with compilation on the fly)
      *
@@ -320,7 +319,6 @@ public:
     void apply(const std::vector<cv::Mat>& ins,         // Compatibility overload
                      std::vector<cv::Mat>& outs,
                GCompileArgs &&args = {});
-#endif // !defined(GAPI_STANDALONE)
     // Various versions of compile(): //////////////////////////////////////////
     // 1. Generic compile() - requires metas to be passed as vector
     /**

--- a/modules/gapi/include/opencv2/gapi/gmat.hpp
+++ b/modules/gapi/include/opencv2/gapi/gmat.hpp
@@ -71,10 +71,6 @@ public:
     using GMat::GMat;
 };
 
-namespace gapi { namespace own {
-    class Mat;
-}}//gapi::own
-
 /** @} */
 
 /**
@@ -121,7 +117,7 @@ struct GAPI_EXPORTS GMatDesc
     // (it handles the case when
     // 1-channel mat can be reinterpreted as is (1-channel mat)
     // and as a 3-channel planar mat with height divided by 3)
-    bool canDescribe(const cv::gapi::own::Mat& mat) const;
+    bool canDescribe(const cv::Mat& mat) const;
 
     // Meta combinator: return a new GMatDesc which differs in size by delta
     // (all other fields are taken unchanged from this GMatDesc)
@@ -132,9 +128,6 @@ struct GAPI_EXPORTS GMatDesc
         desc.size += delta;
         return desc;
     }
-#if !defined(GAPI_STANDALONE)
-    bool canDescribe(const cv::Mat& mat) const;
-#endif // !defined(GAPI_STANDALONE)
     // Meta combinator: return a new GMatDesc which differs in size by delta
     // (all other fields are taken unchanged from this GMatDesc)
     //
@@ -213,15 +206,15 @@ struct GAPI_EXPORTS GMatDesc
 static inline GMatDesc empty_gmat_desc() { return GMatDesc{-1,-1,{-1,-1}}; }
 
 #if !defined(GAPI_STANDALONE)
-class Mat;
-GAPI_EXPORTS GMatDesc descr_of(const cv::Mat &mat);
 GAPI_EXPORTS GMatDesc descr_of(const cv::UMat &mat);
 #endif // !defined(GAPI_STANDALONE)
 
+GAPI_EXPORTS GMatDesc descr_of(const cv::Mat &mat);
 /** @} */
 
 // FIXME: WHY??? WHY it is under different namespace?
 namespace gapi { namespace own {
+    class Mat;
     GAPI_EXPORTS GMatDesc descr_of(const Mat &mat);
 }}//gapi::own
 

--- a/modules/gapi/include/opencv2/gapi/gmat.hpp
+++ b/modules/gapi/include/opencv2/gapi/gmat.hpp
@@ -212,12 +212,6 @@ GAPI_EXPORTS GMatDesc descr_of(const cv::UMat &mat);
 GAPI_EXPORTS GMatDesc descr_of(const cv::Mat &mat);
 /** @} */
 
-// FIXME: WHY??? WHY it is under different namespace?
-namespace gapi { namespace own {
-    class Mat;
-    GAPI_EXPORTS GMatDesc descr_of(const Mat &mat);
-}}//gapi::own
-
 GAPI_EXPORTS std::ostream& operator<<(std::ostream& os, const cv::GMatDesc &desc);
 
 } // namespace cv

--- a/modules/gapi/include/opencv2/gapi/gmat.hpp
+++ b/modules/gapi/include/opencv2/gapi/gmat.hpp
@@ -212,6 +212,12 @@ GAPI_EXPORTS GMatDesc descr_of(const cv::UMat &mat);
 GAPI_EXPORTS GMatDesc descr_of(const cv::Mat &mat);
 /** @} */
 
+// FIXME: WHY??? WHY it is under different namespace?
+namespace gapi { namespace own {
+    class Mat;
+    GAPI_EXPORTS GMatDesc descr_of(const Mat &mat);
+}}//gapi::own
+
 GAPI_EXPORTS std::ostream& operator<<(std::ostream& os, const cv::GMatDesc &desc);
 
 } // namespace cv

--- a/modules/gapi/include/opencv2/gapi/gmetaarg.hpp
+++ b/modules/gapi/include/opencv2/gapi/gmetaarg.hpp
@@ -66,12 +66,10 @@ namespace detail
 
 // Note: descr_of(std::vector<..>) returns a GArrayDesc, while
 //       descrs_of(std::vector<..>) returns an array of Meta args!
-class Mat;
 class UMat;
 GAPI_EXPORTS cv::GMetaArgs descrs_of(const std::vector<cv::Mat> &vec);
 GAPI_EXPORTS cv::GMetaArgs descrs_of(const std::vector<cv::UMat> &vec);
 namespace gapi { namespace own {
-    class Mat;
     GAPI_EXPORTS cv::GMetaArgs descrs_of(const std::vector<Mat> &vec);
 }} // namespace gapi::own
 

--- a/modules/gapi/include/opencv2/gapi/gtype_traits.hpp
+++ b/modules/gapi/include/opencv2/gapi/gtype_traits.hpp
@@ -17,7 +17,6 @@
 #include <opencv2/gapi/gopaque.hpp>
 #include <opencv2/gapi/streaming/source.hpp>
 #include <opencv2/gapi/gcommon.hpp>
-#include <opencv2/gapi/own/convert.hpp>
 
 namespace cv
 {

--- a/modules/gapi/include/opencv2/gapi/gtype_traits.hpp
+++ b/modules/gapi/include/opencv2/gapi/gtype_traits.hpp
@@ -111,10 +111,9 @@ namespace detail
     // and GMat behavior is correct for GMatP)
     template<typename T> struct GTypeOf;
 #if !defined(GAPI_STANDALONE)
-    template<>           struct GTypeOf<cv::Mat>               { using type = cv::GMat;      };
     template<>           struct GTypeOf<cv::UMat>              { using type = cv::GMat;      };
 #endif // !defined(GAPI_STANDALONE)
-    template<>           struct GTypeOf<cv::gapi::own::Mat>    { using type = cv::GMat;      };
+    template<>           struct GTypeOf<cv::Mat>               { using type = cv::GMat;      };
     template<>           struct GTypeOf<cv::Scalar>            { using type = cv::GScalar;   };
     template<typename U> struct GTypeOf<std::vector<U> >       { using type = cv::GArray<U>; };
     template<typename U> struct GTypeOf                        { using type = cv::GOpaque<U>;};

--- a/modules/gapi/include/opencv2/gapi/own/cvdefs.hpp
+++ b/modules/gapi/include/opencv2/gapi/own/cvdefs.hpp
@@ -140,10 +140,14 @@ enum InterpolationFlags{
     INTER_MAX            = 7,
 };
 // replacement of cv's structures:
+namespace gapi { namespace own {
+class Mat;
+}} // namespace gapi::own
 using Rect   = gapi::own::Rect;
 using Size   = gapi::own::Size;
 using Point  = gapi::own::Point;
 using Scalar = gapi::own::Scalar;
+using Mat    = gapi::own::Mat;
 } // namespace cv
 
 static inline int cvFloor( double value )

--- a/modules/gapi/src/api/gbackend.cpp
+++ b/modules/gapi/src/api/gbackend.cpp
@@ -10,7 +10,6 @@
 #include <functional> // multiplies
 
 #include <opencv2/gapi/gkernel.hpp>
-#include <opencv2/gapi/own/convert.hpp>
 
 #include "api/gbackend_priv.hpp"
 #include "backends/common/gbackend.hpp"
@@ -114,36 +113,22 @@ void bindInArg(Mag& mag, const RcDesc &rc, const GRunArg &arg, bool is_umat)
     {
         switch (arg.index())
         {
-        case GRunArg::index_of<cv::gapi::own::Mat>() :
+        case GRunArg::index_of<cv::Mat>() :
             if (is_umat)
             {
 #if !defined(GAPI_STANDALONE)
                 auto& mag_umat = mag.template slot<cv::UMat>()[rc.id];
-                mag_umat = to_ocv(util::get<cv::gapi::own::Mat>(arg)).getUMat(ACCESS_READ);
+                mag_umat = util::get<cv::Mat>(arg).getUMat(ACCESS_READ);
 #else
                 util::throw_error(std::logic_error("UMat is not supported in standalone build"));
 #endif // !defined(GAPI_STANDALONE)
             }
             else
             {
-                auto& mag_mat = mag.template slot<cv::gapi::own::Mat>()[rc.id];
-                mag_mat = util::get<cv::gapi::own::Mat>(arg);
+                auto& mag_mat = mag.template slot<cv::Mat>()[rc.id];
+                mag_mat = util::get<cv::Mat>(arg);
             }
             break;
-#if !defined(GAPI_STANDALONE)
-        case GRunArg::index_of<cv::Mat>() :
-            if (is_umat)
-            {
-                auto& mag_umat = mag.template slot<cv::UMat>()[rc.id];
-                mag_umat = util::get<cv::Mat>(arg).getUMat(ACCESS_READ);
-            }
-            else
-            {
-                auto& mag_mat = mag.template slot<cv::gapi::own::Mat>()[rc.id];
-                mag_mat = to_own(util::get<cv::Mat>(arg));
-            }
-            break;
-#endif //  !defined(GAPI_STANDALONE)
         default: util::throw_error(std::logic_error("content type of the runtime argument does not match to resource description ?"));
         }
         break;
@@ -182,36 +167,22 @@ void bindOutArg(Mag& mag, const RcDesc &rc, const GRunArgP &arg, bool is_umat)
     {
         switch (arg.index())
         {
-        case GRunArgP::index_of<cv::gapi::own::Mat*>() :
+        case GRunArgP::index_of<cv::Mat*>() :
             if (is_umat)
             {
 #if !defined(GAPI_STANDALONE)
                 auto& mag_umat = mag.template slot<cv::UMat>()[rc.id];
-                mag_umat = to_ocv(*(util::get<cv::gapi::own::Mat*>(arg))).getUMat(ACCESS_RW);
+                mag_umat = util::get<cv::Mat*>(arg)->getUMat(ACCESS_RW);
 #else
                 util::throw_error(std::logic_error("UMat is not supported in standalone build"));
 #endif // !defined(GAPI_STANDALONE)
             }
             else
             {
-                auto& mag_mat = mag.template slot<cv::gapi::own::Mat>()[rc.id];
-                mag_mat = *util::get<cv::gapi::own::Mat*>(arg);
+                auto& mag_mat = mag.template slot<cv::Mat>()[rc.id];
+                mag_mat = *util::get<cv::Mat*>(arg);
             }
             break;
-#if !defined(GAPI_STANDALONE)
-        case GRunArgP::index_of<cv::Mat*>() :
-            if (is_umat)
-            {
-                auto& mag_umat = mag.template slot<cv::UMat>()[rc.id];
-                mag_umat = util::get<cv::Mat*>(arg)->getUMat(ACCESS_RW);
-            }
-            else
-            {
-                auto& mag_mat = mag.template slot<cv::gapi::own::Mat>()[rc.id];
-                mag_mat = to_own(*util::get<cv::Mat*>(arg));
-            }
-            break;
-#endif //  !defined(GAPI_STANDALONE)
         default: util::throw_error(std::logic_error("content type of the runtime argument does not match to resource description ?"));
         }
         break;
@@ -277,7 +248,7 @@ cv::GRunArg getArg(const Mag& mag, const RcDesc &ref)
     // Wrap associated CPU object (either host or an internal one)
     switch (ref.shape)
     {
-    case GShape::GMAT:    return GRunArg(mag.template slot<cv::gapi::own::Mat>().at(ref.id));
+    case GShape::GMAT:    return GRunArg(mag.template slot<cv::Mat>().at(ref.id));
     case GShape::GSCALAR: return GRunArg(mag.template slot<cv::Scalar>().at(ref.id));
     // Note: .at() is intentional for GArray and GOpaque as objects MUST be already there
     //   (and constructed by either bindIn/Out or resetInternal)
@@ -303,7 +274,7 @@ cv::GRunArgP getObjPtr(Mag& mag, const RcDesc &rc, bool is_umat)
 #endif //  !defined(GAPI_STANDALONE)
         }
         else
-            return GRunArgP(&mag.template slot<cv::gapi::own::Mat>()[rc.id]);
+            return GRunArgP(&mag.template slot<cv::Mat>()[rc.id]);
     case GShape::GSCALAR: return GRunArgP(&mag.template slot<cv::Scalar>()[rc.id]);
     // Note: .at() is intentional for GArray and GOpaque as objects MUST be already there
     //   (and constructor by either bindIn/Out or resetInternal)
@@ -347,9 +318,8 @@ void writeBack(const Mag& mag, const RcDesc &rc, GRunArgP &g_arg, bool is_umat)
         uchar* out_arg_data = nullptr;
         switch (g_arg.index())
         {
-            case GRunArgP::index_of<cv::gapi::own::Mat*>() : out_arg_data = util::get<cv::gapi::own::Mat*>(g_arg)->data; break;
+            case GRunArgP::index_of<cv::Mat*>()            : out_arg_data = util::get<cv::Mat*>(g_arg)->data; break; break;
 #if !defined(GAPI_STANDALONE)
-            case GRunArgP::index_of<cv::Mat*>()            : out_arg_data = util::get<cv::Mat*>(g_arg)->data; break;
             case GRunArgP::index_of<cv::UMat*>()           : out_arg_data = (util::get<cv::UMat*>(g_arg))->getMat(ACCESS_RW).data; break;
 #endif //  !defined(GAPI_STANDALONE)
             default: util::throw_error(std::logic_error("content type of the runtime argument does not match to resource description ?"));
@@ -365,7 +335,7 @@ void writeBack(const Mag& mag, const RcDesc &rc, GRunArgP &g_arg, bool is_umat)
         }
         else
         {
-            auto& in_mag = mag.template slot<cv::gapi::own::Mat>().at(rc.id);
+            auto& in_mag = mag.template slot<cv::Mat>().at(rc.id);
             GAPI_Assert((out_arg_data == in_mag.data) && " data for output parameters was reallocated ?");
         }
         break;
@@ -389,24 +359,6 @@ void writeBack(const Mag& mag, const RcDesc &rc, GRunArgP &g_arg, bool is_umat)
 
 } // namespace magazine
 
-void createMat(const cv::GMatDesc &desc, cv::gapi::own::Mat& mat)
-{
-    // FIXME: Refactor (probably start supporting N-Dimensional blobs natively
-    if (desc.dims.empty())
-    {
-        const auto type = desc.planar ? desc.depth : CV_MAKETYPE(desc.depth, desc.chan);
-        const auto size = desc.planar ? cv::Size{desc.size.width, desc.size.height*desc.chan}
-                                      : desc.size;
-        mat.create(size, type);
-    }
-    else
-    {
-        GAPI_Assert(!desc.planar);
-        mat.create(desc.dims, desc.depth);
-    }
-}
-
-#if !defined(GAPI_STANDALONE)
 void createMat(const cv::GMatDesc &desc, cv::Mat& mat)
 {
     // FIXME: Refactor (probably start supporting N-Dimensional blobs natively
@@ -423,7 +375,6 @@ void createMat(const cv::GMatDesc &desc, cv::Mat& mat)
         mat.create(desc.dims, desc.depth);
     }
 }
-#endif
 
 } // namespace gimpl
 } // namespace cv

--- a/modules/gapi/src/api/gbackend.cpp
+++ b/modules/gapi/src/api/gbackend.cpp
@@ -318,9 +318,9 @@ void writeBack(const Mag& mag, const RcDesc &rc, GRunArgP &g_arg, bool is_umat)
         uchar* out_arg_data = nullptr;
         switch (g_arg.index())
         {
-            case GRunArgP::index_of<cv::Mat*>()            : out_arg_data = util::get<cv::Mat*>(g_arg)->data; break; break;
+            case GRunArgP::index_of<cv::Mat*>() : out_arg_data = util::get<cv::Mat*>(g_arg)->data; break;
 #if !defined(GAPI_STANDALONE)
-            case GRunArgP::index_of<cv::UMat*>()           : out_arg_data = (util::get<cv::UMat*>(g_arg))->getMat(ACCESS_RW).data; break;
+            case GRunArgP::index_of<cv::UMat*>() : out_arg_data = (util::get<cv::UMat*>(g_arg))->getMat(ACCESS_RW).data; break;
 #endif //  !defined(GAPI_STANDALONE)
             default: util::throw_error(std::logic_error("content type of the runtime argument does not match to resource description ?"));
         }

--- a/modules/gapi/src/api/gcomputation.cpp
+++ b/modules/gapi/src/api/gcomputation.cpp
@@ -132,16 +132,16 @@ void cv::GComputation::apply(GRunArgs &&ins, GRunArgsP &&outs, GCompileArgs &&ar
     m_priv->m_lastCompiled(std::move(ins), std::move(outs));
 }
 
-void cv::GComputation::apply(const std::vector<cv::gapi::own::Mat> &ins,
-                             const std::vector<cv::gapi::own::Mat> &outs,
+void cv::GComputation::apply(const std::vector<cv::Mat> &ins,
+                             const std::vector<cv::Mat> &outs,
                              GCompileArgs &&args)
 {
     GRunArgs call_ins;
     GRunArgsP call_outs;
 
     auto tmp = outs;
-    for (const cv::gapi::own::Mat &m : ins) { call_ins.emplace_back(m);   }
-    for (      cv::gapi::own::Mat &m : tmp) { call_outs.emplace_back(&m); }
+    for (const cv::Mat &m : ins) { call_ins.emplace_back(m);   }
+    for (      cv::Mat &m : tmp) { call_outs.emplace_back(&m); }
 
     apply(std::move(call_ins), std::move(call_outs), std::move(args));
 }

--- a/modules/gapi/src/api/gcomputation.cpp
+++ b/modules/gapi/src/api/gcomputation.cpp
@@ -146,7 +146,6 @@ void cv::GComputation::apply(const std::vector<cv::Mat> &ins,
     apply(std::move(call_ins), std::move(call_outs), std::move(args));
 }
 
-#if !defined(GAPI_STANDALONE)
 void cv::GComputation::apply(cv::Mat in, cv::Mat &out, GCompileArgs &&args)
 {
     apply(cv::gin(in), cv::gout(out), std::move(args));
@@ -182,7 +181,6 @@ void cv::GComputation::apply(const std::vector<cv::Mat> &ins,
 
     apply(std::move(call_ins), std::move(call_outs), std::move(args));
 }
-#endif // !defined(GAPI_STANDALONE)
 
 cv::GComputation::Priv& cv::GComputation::priv()
 {

--- a/modules/gapi/src/api/gcomputation.cpp
+++ b/modules/gapi/src/api/gcomputation.cpp
@@ -146,6 +146,7 @@ void cv::GComputation::apply(const std::vector<cv::Mat> &ins,
     apply(std::move(call_ins), std::move(call_outs), std::move(args));
 }
 
+#if !defined(GAPI_STANDALONE)
 void cv::GComputation::apply(cv::Mat in, cv::Mat &out, GCompileArgs &&args)
 {
     apply(cv::gin(in), cv::gout(out), std::move(args));
@@ -181,6 +182,7 @@ void cv::GComputation::apply(const std::vector<cv::Mat> &ins,
 
     apply(std::move(call_ins), std::move(call_outs), std::move(args));
 }
+#endif // !defined(GAPI_STANDALONE)
 
 cv::GComputation::Priv& cv::GComputation::priv()
 {

--- a/modules/gapi/src/api/gmat.cpp
+++ b/modules/gapi/src/api/gmat.cpp
@@ -48,10 +48,16 @@ namespace{
     }
 }
 
+cv::GMatDesc cv::gapi::own::descr_of(const Mat &mat)
+{
+    return (mat.dims.empty())
+        ? GMatDesc{mat.depth(), mat.channels(), {mat.cols, mat.rows}}
+        : GMatDesc{mat.depth(), mat.dims};
+}
 
-#if !defined(GAPI_STANDALONE)
 cv::GMatDesc cv::descr_of(const cv::Mat &mat)
 {
+#if !defined(GAPI_STANDALONE)
     const auto mat_dims = mat.size.dims();
 
     if (mat_dims == 2)
@@ -63,17 +69,18 @@ cv::GMatDesc cv::descr_of(const cv::Mat &mat)
         dims[i] = mat.size[i];
     }
     return GMatDesc{mat.depth(), std::move(dims)};
+#else
+    return (mat.dims.empty())
+        ? GMatDesc{mat.depth(), mat.channels(), {mat.cols, mat.rows}}
+        : GMatDesc{mat.depth(), mat.dims};
+#endif
 }
 
+#if !defined(GAPI_STANDALONE)
 cv::GMatDesc cv::descr_of(const cv::UMat &mat)
 {
     GAPI_Assert(mat.size.dims() == 2);
     return GMatDesc{ mat.depth(), mat.channels(),{ mat.cols, mat.rows } };
-}
-
-cv::GMetaArgs cv::descrs_of(const std::vector<cv::Mat> &vec)
-{
-    return vec_descr_of(vec);
 }
 
 cv::GMetaArgs cv::descrs_of(const std::vector<cv::UMat> &vec)
@@ -82,14 +89,12 @@ cv::GMetaArgs cv::descrs_of(const std::vector<cv::UMat> &vec)
 }
 #endif
 
-cv::GMatDesc cv::gapi::own::descr_of(const cv::gapi::own::Mat &mat)
+cv::GMetaArgs cv::descrs_of(const std::vector<cv::Mat> &vec)
 {
-    return (mat.dims.empty())
-        ? GMatDesc{mat.depth(), mat.channels(), {mat.cols, mat.rows}}
-        : GMatDesc{mat.depth(), mat.dims};
+    return vec_descr_of(vec);
 }
 
-cv::GMetaArgs cv::gapi::own::descrs_of(const std::vector<cv::gapi::own::Mat> &vec)
+cv::GMetaArgs cv::gapi::own::descrs_of(const std::vector<Mat> &vec)
 {
     return vec_descr_of(vec);
 }
@@ -126,21 +131,14 @@ std::ostream& operator<<(std::ostream& os, const cv::GMatDesc &desc)
 namespace {
 template<typename M> inline bool canDescribeHelper(const GMatDesc& desc, const M& mat)
 {
-    const auto mat_desc = desc.planar ? descr_of(mat).asPlanar(desc.chan) : descr_of(mat);
+    const auto mat_desc = desc.planar ? cv::descr_of(mat).asPlanar(desc.chan) : cv::descr_of(mat);
     return desc == mat_desc;
 }
 } // anonymous namespace
 
-bool GMatDesc::canDescribe(const cv::gapi::own::Mat& mat) const
-{
-    return canDescribeHelper(*this, mat);
-}
-
-#if !defined(GAPI_STANDALONE)
 bool GMatDesc::canDescribe(const cv::Mat& mat) const
 {
     return canDescribeHelper(*this, mat);
 }
-#endif
 
 }// namespace cv

--- a/modules/gapi/src/api/gmat.cpp
+++ b/modules/gapi/src/api/gmat.cpp
@@ -42,7 +42,7 @@ namespace{
         cv::GMetaArgs vec_descr;
         vec_descr.reserve(vec.size());
         for(auto& mat : vec){
-            vec_descr.emplace_back(cv::descr_of(mat));
+            vec_descr.emplace_back(descr_of(mat));
         }
         return vec_descr;
     }
@@ -67,6 +67,13 @@ cv::GMatDesc cv::descr_of(const cv::Mat &mat)
         ? GMatDesc{mat.depth(), mat.channels(), {mat.cols, mat.rows}}
         : GMatDesc{mat.depth(), mat.dims};
 #endif
+}
+
+cv::GMatDesc cv::gapi::own::descr_of(const Mat &mat)
+{
+    return (mat.dims.empty())
+        ? GMatDesc{mat.depth(), mat.channels(), {mat.cols, mat.rows}}
+        : GMatDesc{mat.depth(), mat.dims};
 }
 
 #if !defined(GAPI_STANDALONE)

--- a/modules/gapi/src/api/gmat.cpp
+++ b/modules/gapi/src/api/gmat.cpp
@@ -42,17 +42,10 @@ namespace{
         cv::GMetaArgs vec_descr;
         vec_descr.reserve(vec.size());
         for(auto& mat : vec){
-            vec_descr.emplace_back(descr_of(mat));
+            vec_descr.emplace_back(cv::descr_of(mat));
         }
         return vec_descr;
     }
-}
-
-cv::GMatDesc cv::gapi::own::descr_of(const Mat &mat)
-{
-    return (mat.dims.empty())
-        ? GMatDesc{mat.depth(), mat.channels(), {mat.cols, mat.rows}}
-        : GMatDesc{mat.depth(), mat.dims};
 }
 
 cv::GMatDesc cv::descr_of(const cv::Mat &mat)

--- a/modules/gapi/src/api/gproto.cpp
+++ b/modules/gapi/src/api/gproto.cpp
@@ -255,15 +255,13 @@ const void* cv::gimpl::proto::ptr(const GRunArgP &arg)
     switch (arg.index())
     {
 #if !defined(GAPI_STANDALONE)
+    case GRunArgP::index_of<cv::UMat*>():
+        return static_cast<const void*>(cv::util::get<cv::UMat*>(arg));
+#endif
     case GRunArgP::index_of<cv::Mat*>():
         return static_cast<const void*>(cv::util::get<cv::Mat*>(arg));
     case GRunArgP::index_of<cv::Scalar*>():
         return static_cast<const void*>(cv::util::get<cv::Scalar*>(arg));
-    case GRunArgP::index_of<cv::UMat*>():
-        return static_cast<const void*>(cv::util::get<cv::UMat*>(arg));
-#endif
-    case GRunArgP::index_of<cv::gapi::own::Mat*>():
-        return static_cast<const void*>(cv::util::get<cv::gapi::own::Mat*>(arg));
     case GRunArgP::index_of<cv::detail::VectorRef>():
         return cv::util::get<cv::detail::VectorRef>(arg).ptr();
     case GRunArgP::index_of<cv::detail::OpaqueRef>():

--- a/modules/gapi/src/api/gproto.cpp
+++ b/modules/gapi/src/api/gproto.cpp
@@ -103,17 +103,11 @@ cv::GMetaArg cv::descr_of(const cv::GRunArg &arg)
 {
     switch (arg.index())
     {
-#if !defined(GAPI_STANDALONE)
         case GRunArg::index_of<cv::Mat>():
-            return cv::GMetaArg(descr_of(util::get<cv::Mat>(arg)));
-
-#endif // !defined(GAPI_STANDALONE)
-
-        case GRunArg::index_of<cv::gapi::own::Mat>():
-            return cv::GMetaArg(descr_of(util::get<cv::gapi::own::Mat>(arg)));
+            return cv::GMetaArg(cv::descr_of(util::get<cv::Mat>(arg)));
 
         case GRunArg::index_of<cv::Scalar>():
-            return cv::GMetaArg(descr_of(util::get<cv::Scalar>(arg)));
+            return cv::GMetaArg(cv::descr_of(util::get<cv::Scalar>(arg)));
 
         case GRunArg::index_of<cv::detail::VectorRef>():
             return cv::GMetaArg(util::get<cv::detail::VectorRef>(arg).descr_of());
@@ -140,11 +134,10 @@ cv::GMetaArg cv::descr_of(const cv::GRunArgP &argp)
     switch (argp.index())
     {
 #if !defined(GAPI_STANDALONE)
-    case GRunArgP::index_of<cv::Mat*>():               return GMetaArg(descr_of(*util::get<cv::Mat*>(argp)));
-    case GRunArgP::index_of<cv::UMat*>():              return GMetaArg(descr_of(*util::get<cv::UMat*>(argp)));
+    case GRunArgP::index_of<cv::UMat*>():              return GMetaArg(cv::descr_of(*util::get<cv::UMat*>(argp)));
 #endif //  !defined(GAPI_STANDALONE)
-    case GRunArgP::index_of<cv::gapi::own::Mat*>():    return GMetaArg(descr_of(*util::get<cv::gapi::own::Mat*>(argp)));
-    case GRunArgP::index_of<cv::Scalar*>():            return GMetaArg(descr_of(*util::get<cv::Scalar*>(argp)));
+    case GRunArgP::index_of<cv::Mat*>():               return GMetaArg(cv::descr_of(*util::get<cv::Mat*>(argp)));
+    case GRunArgP::index_of<cv::Scalar*>():            return GMetaArg(cv::descr_of(*util::get<cv::Scalar*>(argp)));
     case GRunArgP::index_of<cv::detail::VectorRef>():  return GMetaArg(util::get<cv::detail::VectorRef>(argp).descr_of());
     case GRunArgP::index_of<cv::detail::OpaqueRef>():  return GMetaArg(util::get<cv::detail::OpaqueRef>(argp).descr_of());
     default: util::throw_error(std::logic_error("Unsupported GRunArgP type"));
@@ -156,13 +149,11 @@ bool cv::can_describe(const GMetaArg& meta, const GRunArgP& argp)
     switch (argp.index())
     {
 #if !defined(GAPI_STANDALONE)
+    case GRunArgP::index_of<cv::UMat*>():              return meta == GMetaArg(cv::descr_of(*util::get<cv::UMat*>(argp)));
+#endif //  !defined(GAPI_STANDALONE)
     case GRunArgP::index_of<cv::Mat*>():               return util::holds_alternative<GMatDesc>(meta) &&
                                                               util::get<GMatDesc>(meta).canDescribe(*util::get<cv::Mat*>(argp));
-    case GRunArgP::index_of<cv::UMat*>():              return meta == GMetaArg(descr_of(*util::get<cv::UMat*>(argp)));
-#endif //  !defined(GAPI_STANDALONE)
-    case GRunArgP::index_of<cv::gapi::own::Mat*>():    return util::holds_alternative<GMatDesc>(meta) &&
-                                                              util::get<GMatDesc>(meta).canDescribe(*util::get<cv::gapi::own::Mat*>(argp));
-    case GRunArgP::index_of<cv::Scalar*>():            return meta == GMetaArg(descr_of(*util::get<cv::Scalar*>(argp)));
+    case GRunArgP::index_of<cv::Scalar*>():            return meta == GMetaArg(cv::descr_of(*util::get<cv::Scalar*>(argp)));
     case GRunArgP::index_of<cv::detail::VectorRef>():  return meta == GMetaArg(util::get<cv::detail::VectorRef>(argp).descr_of());
     case GRunArgP::index_of<cv::detail::OpaqueRef>():  return meta == GMetaArg(util::get<cv::detail::OpaqueRef>(argp).descr_of());
     default: util::throw_error(std::logic_error("Unsupported GRunArgP type"));
@@ -174,13 +165,11 @@ bool cv::can_describe(const GMetaArg& meta, const GRunArg& arg)
     switch (arg.index())
     {
 #if !defined(GAPI_STANDALONE)
+    case GRunArg::index_of<cv::UMat>():              return meta == cv::GMetaArg(cv::descr_of(util::get<cv::UMat>(arg)));
+#endif //  !defined(GAPI_STANDALONE)
     case GRunArg::index_of<cv::Mat>():               return util::holds_alternative<GMatDesc>(meta) &&
                                                             util::get<GMatDesc>(meta).canDescribe(util::get<cv::Mat>(arg));
-    case GRunArg::index_of<cv::UMat>():              return meta == cv::GMetaArg(descr_of(util::get<cv::UMat>(arg)));
-#endif //  !defined(GAPI_STANDALONE)
-    case GRunArg::index_of<cv::gapi::own::Mat>():    return util::holds_alternative<GMatDesc>(meta) &&
-                                                            util::get<GMatDesc>(meta).canDescribe(util::get<cv::gapi::own::Mat>(arg));
-    case GRunArg::index_of<cv::Scalar>():            return meta == cv::GMetaArg(descr_of(util::get<cv::Scalar>(arg)));
+    case GRunArg::index_of<cv::Scalar>():            return meta == cv::GMetaArg(cv::descr_of(util::get<cv::Scalar>(arg)));
     case GRunArg::index_of<cv::detail::VectorRef>(): return meta == cv::GMetaArg(util::get<cv::detail::VectorRef>(arg).descr_of());
     case GRunArg::index_of<cv::detail::OpaqueRef>(): return meta == cv::GMetaArg(util::get<cv::detail::OpaqueRef>(arg).descr_of());
     case GRunArg::index_of<cv::gapi::wip::IStreamSource::Ptr>(): return util::holds_alternative<GMatDesc>(meta); // FIXME(?) may be not the best option
@@ -203,21 +192,16 @@ void cv::validate_input_arg(const GRunArg& arg)
     switch (arg.index())
     {
 #if !defined(GAPI_STANDALONE)
-    case GRunArg::index_of<cv::Mat>():
-    {
-        const auto desc = descr_of(util::get<cv::Mat>(arg));
-        GAPI_Assert(desc.size.height != 0 && desc.size.width != 0 && "incorrect dimensions of cv::Mat!"); break;
-    }
     case GRunArg::index_of<cv::UMat>():
     {
-        const auto desc = descr_of(util::get<cv::UMat>(arg));
+        const auto desc = cv::descr_of(util::get<cv::UMat>(arg));
         GAPI_Assert(desc.size.height != 0 && desc.size.width != 0 && "incorrect dimensions of cv::UMat!"); break;
     }
 #endif //  !defined(GAPI_STANDALONE)
-    case GRunArg::index_of<cv::gapi::own::Mat>():
+    case GRunArg::index_of<cv::Mat>():
     {
-        const auto desc = descr_of(util::get<cv::gapi::own::Mat>(arg));
-        GAPI_Assert(desc.size.height != 0 && desc.size.width != 0 && "incorrect dimensions of own::Mat!"); break;
+        const auto desc = cv::descr_of(util::get<cv::Mat>(arg));
+        GAPI_Assert(desc.size.height != 0 && desc.size.width != 0 && "incorrect dimensions of cv::Mat!"); break;
     }
     default:
         // No extra handling

--- a/modules/gapi/src/api/gproto.cpp
+++ b/modules/gapi/src/api/gproto.cpp
@@ -107,7 +107,7 @@ cv::GMetaArg cv::descr_of(const cv::GRunArg &arg)
             return cv::GMetaArg(cv::descr_of(util::get<cv::Mat>(arg)));
 
         case GRunArg::index_of<cv::Scalar>():
-            return cv::GMetaArg(cv::descr_of(util::get<cv::Scalar>(arg)));
+            return cv::GMetaArg(descr_of(util::get<cv::Scalar>(arg)));
 
         case GRunArg::index_of<cv::detail::VectorRef>():
             return cv::GMetaArg(util::get<cv::detail::VectorRef>(arg).descr_of());
@@ -137,7 +137,7 @@ cv::GMetaArg cv::descr_of(const cv::GRunArgP &argp)
     case GRunArgP::index_of<cv::UMat*>():              return GMetaArg(cv::descr_of(*util::get<cv::UMat*>(argp)));
 #endif //  !defined(GAPI_STANDALONE)
     case GRunArgP::index_of<cv::Mat*>():               return GMetaArg(cv::descr_of(*util::get<cv::Mat*>(argp)));
-    case GRunArgP::index_of<cv::Scalar*>():            return GMetaArg(cv::descr_of(*util::get<cv::Scalar*>(argp)));
+    case GRunArgP::index_of<cv::Scalar*>():            return GMetaArg(descr_of(*util::get<cv::Scalar*>(argp)));
     case GRunArgP::index_of<cv::detail::VectorRef>():  return GMetaArg(util::get<cv::detail::VectorRef>(argp).descr_of());
     case GRunArgP::index_of<cv::detail::OpaqueRef>():  return GMetaArg(util::get<cv::detail::OpaqueRef>(argp).descr_of());
     default: util::throw_error(std::logic_error("Unsupported GRunArgP type"));
@@ -165,11 +165,11 @@ bool cv::can_describe(const GMetaArg& meta, const GRunArg& arg)
     switch (arg.index())
     {
 #if !defined(GAPI_STANDALONE)
-    case GRunArg::index_of<cv::UMat>():              return meta == cv::GMetaArg(cv::descr_of(util::get<cv::UMat>(arg)));
+    case GRunArg::index_of<cv::UMat>():              return meta == cv::GMetaArg(descr_of(util::get<cv::UMat>(arg)));
 #endif //  !defined(GAPI_STANDALONE)
     case GRunArg::index_of<cv::Mat>():               return util::holds_alternative<GMatDesc>(meta) &&
                                                             util::get<GMatDesc>(meta).canDescribe(util::get<cv::Mat>(arg));
-    case GRunArg::index_of<cv::Scalar>():            return meta == cv::GMetaArg(cv::descr_of(util::get<cv::Scalar>(arg)));
+    case GRunArg::index_of<cv::Scalar>():            return meta == cv::GMetaArg(descr_of(util::get<cv::Scalar>(arg)));
     case GRunArg::index_of<cv::detail::VectorRef>(): return meta == cv::GMetaArg(util::get<cv::detail::VectorRef>(arg).descr_of());
     case GRunArg::index_of<cv::detail::OpaqueRef>(): return meta == cv::GMetaArg(util::get<cv::detail::OpaqueRef>(arg).descr_of());
     case GRunArg::index_of<cv::gapi::wip::IStreamSource::Ptr>(): return util::holds_alternative<GMatDesc>(meta); // FIXME(?) may be not the best option

--- a/modules/gapi/src/api/gproto.cpp
+++ b/modules/gapi/src/api/gproto.cpp
@@ -195,7 +195,7 @@ void cv::validate_input_arg(const GRunArg& arg)
     case GRunArg::index_of<cv::UMat>():
     {
         const auto desc = cv::descr_of(util::get<cv::UMat>(arg));
-        GAPI_Assert(desc.size.height != 0 && desc.size.width != 0 && "incorrect dimensions of UMat!"); break;
+        GAPI_Assert(desc.size.height != 0 && desc.size.width != 0 && "incorrect dimensions of cv::UMat!"); break;
     }
 #endif //  !defined(GAPI_STANDALONE)
     case GRunArg::index_of<cv::Mat>():

--- a/modules/gapi/src/api/gproto.cpp
+++ b/modules/gapi/src/api/gproto.cpp
@@ -195,13 +195,13 @@ void cv::validate_input_arg(const GRunArg& arg)
     case GRunArg::index_of<cv::UMat>():
     {
         const auto desc = cv::descr_of(util::get<cv::UMat>(arg));
-        GAPI_Assert(desc.size.height != 0 && desc.size.width != 0 && "incorrect dimensions of cv::UMat!"); break;
+        GAPI_Assert(desc.size.height != 0 && desc.size.width != 0 && "incorrect dimensions of UMat!"); break;
     }
 #endif //  !defined(GAPI_STANDALONE)
     case GRunArg::index_of<cv::Mat>():
     {
         const auto desc = cv::descr_of(util::get<cv::Mat>(arg));
-        GAPI_Assert(desc.size.height != 0 && desc.size.width != 0 && "incorrect dimensions of cv::Mat!"); break;
+        GAPI_Assert(desc.size.height != 0 && desc.size.width != 0 && "incorrect dimensions of Mat!"); break;
     }
     default:
         // No extra handling

--- a/modules/gapi/src/api/gscalar.cpp
+++ b/modules/gapi/src/api/gscalar.cpp
@@ -8,7 +8,6 @@
 #include "precomp.hpp"
 
 #include <opencv2/gapi/gscalar.hpp>
-#include <opencv2/gapi/own/convert.hpp>
 #include "api/gorigin.hpp"
 
 // cv::GScalar public implementation ///////////////////////////////////////////

--- a/modules/gapi/src/backends/common/gbackend.hpp
+++ b/modules/gapi/src/backends/common/gbackend.hpp
@@ -14,7 +14,6 @@
 #include <ade/node.hpp>
 
 #include "opencv2/gapi/garg.hpp"
-// #include "opencv2/gapi/own/mat.hpp"
 
 #include "opencv2/gapi/util/optional.hpp"
 

--- a/modules/gapi/src/backends/common/gbackend.hpp
+++ b/modules/gapi/src/backends/common/gbackend.hpp
@@ -45,9 +45,9 @@ namespace magazine {
 
 } // namespace magazine
 #if !defined(GAPI_STANDALONE)
-using Mag = magazine::Class<cv::gapi::own::Mat, cv::UMat, cv::Scalar, cv::detail::VectorRef, cv::detail::OpaqueRef>;
+using Mag = magazine::Class<cv::Mat, cv::UMat, cv::Scalar, cv::detail::VectorRef, cv::detail::OpaqueRef>;
 #else
-using Mag = magazine::Class<cv::gapi::own::Mat, cv::Scalar, cv::detail::VectorRef, cv::detail::OpaqueRef>;
+using Mag = magazine::Class<cv::Mat, cv::Scalar, cv::detail::VectorRef, cv::detail::OpaqueRef>;
 #endif
 
 namespace magazine
@@ -98,10 +98,7 @@ inline cv::util::optional<T> getCompileArg(const cv::GCompileArgs &args)
     return cv::util::optional<T>();
 }
 
-void createMat(const cv::GMatDesc& desc, cv::gapi::own::Mat& mat);
-#if !defined(GAPI_STANDALONE)
 void createMat(const cv::GMatDesc& desc, cv::Mat& mat);
-#endif
 
 }} // cv::gimpl
 

--- a/modules/gapi/src/backends/common/gbackend.hpp
+++ b/modules/gapi/src/backends/common/gbackend.hpp
@@ -14,7 +14,7 @@
 #include <ade/node.hpp>
 
 #include "opencv2/gapi/garg.hpp"
-#include "opencv2/gapi/own/mat.hpp"
+// #include "opencv2/gapi/own/mat.hpp"
 
 #include "opencv2/gapi/util/optional.hpp"
 

--- a/modules/gapi/src/backends/cpu/gcpubackend.cpp
+++ b/modules/gapi/src/backends/cpu/gcpubackend.cpp
@@ -96,7 +96,7 @@ cv::gimpl::GCPUExecutable::GCPUExecutable(const ade::Graph &g,
             if (desc.storage == Data::Storage::INTERNAL && desc.shape == GShape::GMAT)
             {
                 const auto mat_desc = util::get<cv::GMatDesc>(desc.meta);
-                auto& mat = m_res.slot<cv::gapi::own::Mat>()[desc.rc];
+                auto& mat = m_res.slot<cv::Mat>()[desc.rc];
                 createMat(mat_desc, mat);
             }
             break;
@@ -128,7 +128,7 @@ cv::GArg cv::gimpl::GCPUExecutable::packArg(const GArg &arg)
     const cv::gimpl::RcDesc &ref = arg.get<cv::gimpl::RcDesc>();
     switch (ref.shape)
     {
-    case GShape::GMAT:    return GArg(m_res.slot<cv::gapi::own::Mat>()   [ref.id]);
+    case GShape::GMAT:    return GArg(m_res.slot<cv::Mat>()   [ref.id]);
     case GShape::GSCALAR: return GArg(m_res.slot<cv::Scalar>()[ref.id]);
     // Note: .at() is intentional for GArray and GOpaque as objects MUST be already there
     //   (and constructed by either bindIn/Out or resetInternal)

--- a/modules/gapi/src/backends/cpu/gcpukernel.cpp
+++ b/modules/gapi/src/backends/cpu/gcpukernel.cpp
@@ -11,14 +11,14 @@
 
 #include <opencv2/gapi/cpu/gcpukernel.hpp>
 
-const cv::gapi::own::Mat& cv::GCPUContext::inMat(int input)
+const cv::Mat& cv::GCPUContext::inMat(int input)
 {
-    return inArg<cv::gapi::own::Mat>(input);
+    return inArg<cv::Mat>(input);
 }
 
-cv::gapi::own::Mat&  cv::GCPUContext::outMatR(int output)
+cv::Mat&  cv::GCPUContext::outMatR(int output)
 {
-    return *util::get<cv::gapi::own::Mat*>(m_results.at(output));
+    return *util::get<cv::Mat*>(m_results.at(output));
 }
 
 const cv::Scalar& cv::GCPUContext::inVal(int input)

--- a/modules/gapi/src/backends/fluid/gfluidbackend.cpp
+++ b/modules/gapi/src/backends/fluid/gfluidbackend.cpp
@@ -26,7 +26,6 @@
 #include <opencv2/gapi/gcommon.hpp>
 #include "logger.hpp"
 
-#include <opencv2/gapi/own/convert.hpp>
 #include <opencv2/gapi/gmat.hpp>    //for version of descr_of
 // PRIVATE STUFF!
 #include "compiler/gobjref.hpp"
@@ -1246,7 +1245,7 @@ void cv::gimpl::GFluidExecutable::bindInArg(const cv::gimpl::RcDesc &rc, const G
 {
     switch (rc.shape)
     {
-    case GShape::GMAT:    m_buffers[m_id_map.at(rc.id)].priv().bindTo(util::get<cv::gapi::own::Mat>(arg), true); break;
+    case GShape::GMAT:    m_buffers[m_id_map.at(rc.id)].priv().bindTo(util::get<cv::Mat>(arg), true); break;
     case GShape::GSCALAR: m_res.slot<cv::Scalar>()[rc.id] = util::get<cv::Scalar>(arg); break;
     case GShape::GARRAY:  m_res.slot<cv::detail::VectorRef>()[rc.id] = util::get<cv::detail::VectorRef>(arg); break;
     case GShape::GOPAQUE: m_res.slot<cv::detail::OpaqueRef>()[rc.id] = util::get<cv::detail::OpaqueRef>(arg); break;
@@ -1266,20 +1265,12 @@ void cv::gimpl::GFluidExecutable::bindOutArg(const cv::gimpl::RcDesc &rc, const 
 
             switch (arg.index()) {
             // FIXME: See the bindInArg comment on Streaming-related changes
-            case T::index_of<cv::gapi::own::Mat*>(): {
-                auto &outMat = *util::get<cv::gapi::own::Mat*>(arg);
-                GAPI_Assert(outMat.data != nullptr);
-                GAPI_Assert(descr_of(outMat) == desc && "Output argument was not preallocated as it should be ?");
-                bref.bindTo(outMat, false);
-            } break;
-#if !defined(GAPI_STANDALONE)
             case T::index_of<cv::Mat*>(): {
                 auto &outMat = *util::get<cv::Mat*>(arg);
                 GAPI_Assert(outMat.data != nullptr);
-                GAPI_Assert(descr_of(outMat) == desc && "Output argument was not preallocated as it should be ?");
-                bref.bindTo(cv::to_own(outMat), false);
+                GAPI_Assert(cv::descr_of(outMat) == desc && "Output argument was not preallocated as it should be ?");
+                bref.bindTo(outMat, false);
             } break;
-#endif // GAPI_STANDALONE
             default: GAPI_Assert(false);
             } // switch(arg.index())
             break;

--- a/modules/gapi/src/backends/fluid/gfluidbuffer_priv.hpp
+++ b/modules/gapi/src/backends/fluid/gfluidbuffer_priv.hpp
@@ -53,7 +53,7 @@ template<>
 class BorderHandlerT<cv::BORDER_CONSTANT> : public BorderHandler
 {
     cv::Scalar m_border_value;
-    cv::gapi::own::Mat m_const_border;
+    cv::Mat m_const_border;
 
 public:
     BorderHandlerT(int border_size, cv::Scalar border_value);
@@ -65,7 +65,7 @@ public:
 class BufferStorage
 {
 protected:
-    cv::gapi::own::Mat m_data;
+    cv::Mat m_data;
 
 public:
     void updateInCache(View::Cache& cache, int start_log_idx, int nLines) const;
@@ -80,8 +80,8 @@ public:
 
     inline bool empty() const { return m_data.empty(); }
 
-    inline const cv::gapi::own::Mat& data() const { return m_data; }
-    inline       cv::gapi::own::Mat& data()       { return m_data; }
+    inline const cv::Mat& data() const { return m_data; }
+    inline       cv::Mat& data()       { return m_data; }
 
     inline int rows() const { return m_data.rows; }
     inline int cols() const { return m_data.cols; }
@@ -117,7 +117,7 @@ public:
         return m_data.ptr(physIdx(idx), 0);
     }
 
-    inline void attach(const cv::gapi::own::Mat& _data, cv::Rect _roi)
+    inline void attach(const cv::Mat& _data, cv::Rect _roi)
     {
         m_data = _data(_roi);
         m_roi = _roi;
@@ -263,7 +263,7 @@ public:
               cv::Rect roi);
 
     void allocate(BorderOpt border, int border_size, int line_consumption, int skew);
-    void bindTo(const cv::gapi::own::Mat &data, bool is_input);
+    void bindTo(const cv::Mat &data, bool is_input);
 
     inline void addView(const View* view) { m_views.emplace_back(view); }
 

--- a/modules/gapi/src/backends/ie/giebackend.cpp
+++ b/modules/gapi/src/backends/ie/giebackend.cpp
@@ -288,7 +288,7 @@ struct IECallContext
     const cv::Mat&   inMat(std::size_t input) {
         return inArg<cv::Mat>(input);
     }
-    cv::gMat&         outMatR(std::size_t output) {
+    cv::Mat&         outMatR(std::size_t output) {
         return *cv::util::get<cv::Mat*>(results.at(output));
     }
 

--- a/modules/gapi/src/backends/ie/giebackend.cpp
+++ b/modules/gapi/src/backends/ie/giebackend.cpp
@@ -285,11 +285,11 @@ struct IECallContext
     const T& inArg(std::size_t input) { return args.at(input).get<T>(); }
 
     // Syntax sugar
-    const cv::gapi::own::Mat&   inMat(std::size_t input) {
-        return inArg<cv::gapi::own::Mat>(input);
+    const cv::Mat&   inMat(std::size_t input) {
+        return inArg<cv::Mat>(input);
     }
-    cv::gapi::own::Mat&         outMatR(std::size_t output) {
-        return *cv::util::get<cv::gapi::own::Mat*>(results.at(output));
+    cv::gMat&         outMatR(std::size_t output) {
+        return *cv::util::get<cv::Mat*>(results.at(output));
     }
 
     template<typename T> std::vector<T>& outVecR(std::size_t output) { // FIXME: the same issue
@@ -391,7 +391,7 @@ cv::GArg cv::gimpl::ie::GIEExecutable::packArg(const cv::GArg &arg) {
     const cv::gimpl::RcDesc &ref = arg.get<cv::gimpl::RcDesc>();
     switch (ref.shape)
     {
-    case GShape::GMAT:    return GArg(m_res.slot<cv::gapi::own::Mat>()[ref.id]);
+    case GShape::GMAT:    return GArg(m_res.slot<cv::Mat>()[ref.id]);
 
     // Note: .at() is intentional for GArray as object MUST be already there
     //   (and constructed by either bindIn/Out or resetInternal)
@@ -528,7 +528,7 @@ struct Infer: public cv::detail::KernelTag {
             // Not a <very> big deal for classifiers and detectors,
             // but may be critical to segmentation.
 
-            cv::gapi::own::Mat& out_mat = ctx.outMatR(i);
+            cv::Mat& out_mat = ctx.outMatR(i);
             IE::Blob::Ptr this_blob = iec.this_request.GetBlob(uu.params.output_names[i]);
             copyFromIE(this_blob, out_mat);
         }

--- a/modules/gapi/src/backends/ocl/goclbackend.cpp
+++ b/modules/gapi/src/backends/ocl/goclbackend.cpp
@@ -96,7 +96,7 @@ cv::gimpl::GOCLExecutable::GOCLExecutable(const ade::Graph &g,
             if (desc.storage == Data::Storage::INTERNAL && desc.shape == GShape::GMAT)
             {
                 const auto mat_desc = util::get<cv::GMatDesc>(desc.meta);
-                auto& mat = m_res.slot<cv::gapi::own::Mat>()[desc.rc];
+                auto& mat = m_res.slot<cv::Mat>()[desc.rc];
                 createMat(mat_desc, mat);
             }
             break;

--- a/modules/gapi/src/backends/plaidml/gplaidmlbackend.cpp
+++ b/modules/gapi/src/backends/plaidml/gplaidmlbackend.cpp
@@ -212,20 +212,12 @@ void cv::gimpl::GPlaidMLExecutable::bindInArg(const RcDesc &rc, const GRunArg  &
 
         switch (arg.index())
         {
-        case GRunArg::index_of<cv::gapi::own::Mat>():
-        {
-            auto& arg_mat = util::get<cv::gapi::own::Mat>(arg);
-            binder_->input(it->second).copy_from(arg_mat.data);
-        }
-        break;
-#if !defined(GAPI_STANDALONE)
         case GRunArg::index_of<cv::Mat>() :
         {
             auto& arg_mat = util::get<cv::Mat>(arg);
             binder_->input(it->second).copy_from(arg_mat.data);
         }
         break;
-#endif //  !defined(GAPI_STANDALONE)
         default: util::throw_error(std::logic_error("content type of the runtime argument does not match to resource description ?"));
         }
     }
@@ -248,20 +240,12 @@ void cv::gimpl::GPlaidMLExecutable::bindOutArg(const RcDesc &rc, const GRunArgP 
 
         switch (arg.index())
         {
-        case GRunArgP::index_of<cv::gapi::own::Mat*>():
-        {
-            auto& arg_mat = *util::get<cv::gapi::own::Mat*>(arg);
-            binder_->output(it->second).copy_into(arg_mat.data);
-        }
-        break;
-#if !defined(GAPI_STANDALONE)
         case GRunArgP::index_of<cv::Mat*>() :
         {
             auto& arg_mat = *util::get<cv::Mat*>(arg);
             binder_->output(it->second).copy_into(arg_mat.data);
         }
         break;
-#endif //  !defined(GAPI_STANDALONE)
         default: util::throw_error(std::logic_error("content type of the runtime argument does not match to resource description ?"));
         }
     }

--- a/modules/gapi/src/backends/render/grenderocvbackend.cpp
+++ b/modules/gapi/src/backends/render/grenderocvbackend.cpp
@@ -113,7 +113,7 @@ cv::GArg cv::gimpl::render::ocv::GRenderExecutable::packArg(const cv::GArg &arg)
     const cv::gimpl::RcDesc &ref = arg.get<cv::gimpl::RcDesc>();
     switch (ref.shape)
     {
-    case GShape::GMAT:   return GArg(m_res.slot<cv::gapi::own::Mat>()[ref.id]);
+    case GShape::GMAT:   return GArg(m_res.slot<cv::Mat>()[ref.id]);
     case GShape::GARRAY: return GArg(m_res.slot<cv::detail::VectorRef>().at(ref.id));
     default:
         util::throw_error(std::logic_error("Unsupported GShape type"));

--- a/modules/gapi/src/compiler/gcompiled.cpp
+++ b/modules/gapi/src/compiler/gcompiled.cpp
@@ -95,7 +95,6 @@ void cv::GCompiled::operator() (GRunArgs &&ins, GRunArgsP &&outs)
     m_priv->run(cv::gimpl::GRuntimeArgs{std::move(ins),std::move(outs)});
 }
 
-#if !defined(GAPI_STANDALONE)
 void cv::GCompiled::operator ()(cv::Mat in, cv::Mat &out)
 {
     (*this)(cv::gin(in), cv::gout(out));
@@ -129,7 +128,6 @@ void cv::GCompiled::operator ()(const std::vector<cv::Mat> &ins,
 
     (*this)(std::move(call_ins), std::move(call_outs));
 }
-#endif // !defined(GAPI_STANDALONE)
 
 const cv::GMetaArgs& cv::GCompiled::metas() const
 {

--- a/modules/gapi/src/compiler/gcompiled.cpp
+++ b/modules/gapi/src/compiler/gcompiled.cpp
@@ -95,6 +95,7 @@ void cv::GCompiled::operator() (GRunArgs &&ins, GRunArgsP &&outs)
     m_priv->run(cv::gimpl::GRuntimeArgs{std::move(ins),std::move(outs)});
 }
 
+#if !defined(GAPI_STANDALONE)
 void cv::GCompiled::operator ()(cv::Mat in, cv::Mat &out)
 {
     (*this)(cv::gin(in), cv::gout(out));
@@ -128,6 +129,7 @@ void cv::GCompiled::operator ()(const std::vector<cv::Mat> &ins,
 
     (*this)(std::move(call_ins), std::move(call_outs));
 }
+#endif // !defined(GAPI_STANDALONE)
 
 const cv::GMetaArgs& cv::GCompiled::metas() const
 {

--- a/modules/gapi/src/compiler/gislandmodel.cpp
+++ b/modules/gapi/src/compiler/gislandmodel.cpp
@@ -348,7 +348,7 @@ void GIslandExecutable::run(GIslandExecutable::IInput &in, GIslandExecutable::IO
         switch (in_data_orig.index())
         {
         case cv::GRunArg::index_of<cv::Mat>():
-            in_data = cv::GRunArg{cv::to_own(cv::util::get<cv::Mat>(in_data_orig))};
+            in_data = cv::GRunArg{cv::util::get<cv::Mat>(in_data_orig)};
             break;
         case cv::GRunArg::index_of<cv::Scalar>():
             in_data = cv::GRunArg{(cv::util::get<cv::Scalar>(in_data_orig))};

--- a/modules/gapi/src/executor/gexecutor.cpp
+++ b/modules/gapi/src/executor/gexecutor.cpp
@@ -100,7 +100,7 @@ void cv::gimpl::GExecutor::initResource(const ade::NodeHandle &orig_nh)
     case GShape::GMAT:
         {
             const auto desc = util::get<cv::GMatDesc>(d.meta);
-            auto& mat = m_res.slot<cv::gapi::own::Mat>()[d.rc];
+            auto& mat = m_res.slot<cv::Mat>()[d.rc];
             createMat(desc, mat);
         }
         break;
@@ -182,7 +182,7 @@ void cv::gimpl::GExecutor::run(cv::gimpl::GRuntimeArgs &&args)
 
             auto check_own_mat = [&desc, &args, &index]()
             {
-                auto& out_mat = *get<cv::gapi::own::Mat*>(args.outObjs.at(index));
+                auto& out_mat = *get<cv::Mat*>(args.outObjs.at(index));
                 GAPI_Assert(out_mat.data != nullptr &&
                         desc.canDescribe(out_mat));
             };

--- a/modules/gapi/src/executor/gstreamingexecutor.cpp
+++ b/modules/gapi/src/executor/gstreamingexecutor.cpp
@@ -413,13 +413,8 @@ class StreamingOutput final: public cv::gimpl::GIslandExecutable::IOutput
     // Prepare this object for posting
     virtual cv::GRunArgP get(int idx) override
     {
-#if !defined(GAPI_STANDALONE)
         using MatType = cv::Mat;
         using SclType = cv::Scalar;
-#else
-        using MatType = cv::gapi::own::Mat;
-        using SclType = cv::gapi::own::Scalar;
-#endif // GAPI_STANDALONE
 
         // Allocate a new posting first, then bind this GRunArgP to this item
         auto iter    = m_postings[idx].insert(m_postings[idx].end(), Posting{});
@@ -581,130 +576,7 @@ void islandActorThread(std::vector<cv::gimpl::RcDesc> in_rcs,                // 
     StreamingOutput output(out_metas, out_queues, out_rcs);
     while (!output.done())
     {
-<<<<<<< HEAD
         island->run(input, output);
-=======
-        std::vector<cv::gimpl::GIslandExecutable::InObj> isl_inputs;
-        isl_inputs.resize(in_rcs.size());
-
-        cv::GRunArgs isl_input_args;
-        if (!qr.getInputVector(in_queues, in_constants, isl_input_args))
-        {
-            // Stop received -- broadcast Stop down to the pipeline and quit
-            for (auto &&out_qq : out_queues)
-            {
-                for (auto &&out_q : out_qq) out_q->push(Cmd{Stop{}});
-            }
-            return;
-        }
-        GAPI_Assert(isl_inputs.size() == isl_input_args.size());
-        for (auto &&it : ade::util::indexed(ade::util::zip(ade::util::toRange(in_rcs),
-                                            ade::util::toRange(isl_inputs),
-                                            ade::util::toRange(isl_input_args))))
-        {
-            const auto &value     = ade::util::value(it);
-            const auto &in_rc     = std::get<0>(value);
-            auto       &isl_input = std::get<1>(value);
-            const auto &in_arg    = std::get<2>(value); // FIXME: MOVE PROBLEM
-            isl_input.first = in_rc;
-#if defined(GAPI_STANDALONE)
-            // Standalone mode - simply store input argument in the vector as-is
-            auto id               = ade::util::index(it);
-            isl_inputs[id].second = in_arg;
-#else
-            // Make Islands operate on own:: data types (i.e. in the same
-            // environment as GExecutor provides)
-            // This way several backends (e.g. Fluid) remain OpenCV-independent.
-            switch (in_arg.index()) {
-            case cv::GRunArg::index_of<cv::Mat>():
-                isl_input.second = cv::GRunArg{cv::util::get<cv::Mat>(in_arg)};
-                break;
-            case cv::GRunArg::index_of<cv::Scalar>():
-                isl_input.second = cv::GRunArg{cv::util::get<cv::Scalar>(in_arg)};
-                break;
-            default:
-                isl_input.second = in_arg;
-                break;
-            }
-#endif // GAPI_STANDALONE
-        }
-        // Once the vector is obtained, prepare data for island execution
-        // Note - we first allocate output vector via GRunArg!
-        // Then it is converted to a GRunArgP.
-        std::vector<cv::gimpl::GIslandExecutable::OutObj> isl_outputs;
-        cv::GRunArgs out_data;
-        isl_outputs.resize(out_rcs.size());
-        out_data.resize(out_rcs.size());
-        for (auto &&it : ade::util::indexed(out_rcs))
-        {
-            auto id = ade::util::index(it);
-            auto &r = ade::util::value(it);
-
-            using MatType = cv::Mat;
-            using SclType = cv::Scalar;
-
-            switch (r.shape) {
-                // Allocate a data object based on its shape & meta, and put it into our vectors.
-                // Yes, first we put a cv::Mat GRunArg, and then specify _THAT_
-                // pointer as an output parameter - to make sure that after island completes,
-                // our GRunArg still has the right (up-to-date) value.
-                // Same applies to other types.
-                // FIXME: This is absolutely ugly but seem to work perfectly for its purpose.
-            case cv::GShape::GMAT:
-                {
-                    MatType newMat;
-                    cv::gimpl::createMat(cv::util::get<cv::GMatDesc>(out_metas[id]), newMat);
-                    out_data[id] = cv::GRunArg(std::move(newMat));
-                    isl_outputs[id] = { r, cv::GRunArgP(&cv::util::get<MatType>(out_data[id])) };
-                }
-                break;
-            case cv::GShape::GSCALAR:
-                {
-                    SclType newScl;
-                    out_data[id] = cv::GRunArg(std::move(newScl));
-                    isl_outputs[id] = { r, cv::GRunArgP(&cv::util::get<SclType>(out_data[id])) };
-                }
-                break;
-            case cv::GShape::GARRAY:
-                {
-                    cv::detail::VectorRef newVec;
-                    cv::util::get<cv::detail::ConstructVec>(r.ctor)(newVec);
-                    out_data[id] = cv::GRunArg(std::move(newVec));
-                    // VectorRef is implicitly shared so no pointer is taken here
-                    const auto &rr = cv::util::get<cv::detail::VectorRef>(out_data[id]); // FIXME: that variant MOVE problem again
-                    isl_outputs[id] = { r, cv::GRunArgP(rr) };
-                }
-                break;
-            case cv::GShape::GOPAQUE:
-                {
-                    cv::detail::OpaqueRef newOpaque;
-                    cv::util::get<cv::detail::ConstructOpaque>(r.ctor)(newOpaque);
-                    out_data[id] = cv::GRunArg(std::move(newOpaque));
-                    // OpaqueRef is implicitly shared so no pointer is taken here
-                    const auto &rr = cv::util::get<cv::detail::OpaqueRef>(out_data[id]); // FIXME: that variant MOVE problem again
-                    isl_outputs[id] = { r, cv::GRunArgP(rr) };
-                }
-                break;
-            default:
-                cv::util::throw_error(std::logic_error("Unsupported GShape"));
-                break;
-            }
-        }
-        // Now ask Island to execute on this data
-        island->run(std::move(isl_inputs), std::move(isl_outputs));
-
-        // Once executed, dispatch our results down to the pipeline.
-        for (auto &&it : ade::util::zip(ade::util::toRange(out_queues),
-                                        ade::util::toRange(out_data)))
-        {
-            for (auto &&q : std::get<0>(it))
-            {
-                // FIXME: FATAL VARIANT ISSUE!!
-                const auto tmp = std::get<1>(it);
-                q->push(Cmd{tmp});
-            }
-        }
->>>>>>> deowned Mat
     }
 }
 

--- a/modules/gapi/test/gapi_async_test.cpp
+++ b/modules/gapi/test/gapi_async_test.cpp
@@ -386,11 +386,8 @@ namespace {
         for (auto&& arg : args){
             //FIXME: replace this switch with use of visit() on variant, when it will be available
             switch (arg.index()){
-    #if !defined(GAPI_STANDALONE)
-                case GRunArgP::index_of<cv::Mat*>()                 :   result.emplace_back(*util::get<cv::Mat*>(arg));     break;
                 case GRunArgP::index_of<cv::UMat*>()                :   result.emplace_back(*util::get<cv::UMat*>(arg));    break;
-    #endif // !defined(GAPI_STANDALONE)
-                case GRunArgP::index_of<cv::gapi::own::Mat*>()      :   result.emplace_back(*util::get<cv::gapi::own::Mat*>   (arg));   break;
+                case GRunArgP::index_of<cv::Mat*>()                 :   result.emplace_back(*util::get<cv::Mat*>(arg));     break;
                 case GRunArgP::index_of<cv::Scalar*>()              :   result.emplace_back(*util::get<cv::Scalar*>           (arg));   break;
                 case GRunArgP::index_of<cv::detail::VectorRef>()    :   result.emplace_back(util::get<cv::detail::VectorRef>  (arg));   break;
                 default : ;
@@ -403,11 +400,8 @@ namespace {
         GRunArgsP result; result.reserve(args.size());
         for (auto&& arg : args){
             switch (arg.index()){
-    #if !defined(GAPI_STANDALONE)
                 case GRunArg::index_of<cv::Mat>()                 :   result.emplace_back(&util::get<cv::Mat>(arg));     break;
                 case GRunArg::index_of<cv::UMat>()                :   result.emplace_back(&util::get<cv::UMat>(arg));    break;
-    #endif // !defined(GAPI_STANDALONE)
-                case GRunArg::index_of<cv::gapi::own::Mat>()      :   result.emplace_back(&util::get<cv::gapi::own::Mat>   (arg));   break;
                 case GRunArg::index_of<cv::Scalar>()              :   result.emplace_back(&util::get<cv::Scalar>           (arg));   break;
                 case GRunArg::index_of<cv::detail::VectorRef>()   :   result.emplace_back(util::get<cv::detail::VectorRef> (arg));   break;
                 default : ;

--- a/modules/gapi/test/gapi_desc_tests.cpp
+++ b/modules/gapi/test/gapi_desc_tests.cpp
@@ -137,23 +137,6 @@ TEST(GAPI_MetaDesc, OwnMatDescND)
     EXPECT_TRUE(desc.isND());
 }
 
-TEST(GAPI_MetaDesc, CanDescribeOwnMat)
-{
-    constexpr int w = 15;
-    constexpr int h = 7;
-    cv::gapi::own::Mat m0(h, w, CV_8UC3, nullptr);
-    cv::GMatDesc md0{CV_8U,3,{w,h},false};
-
-    cv::gapi::own::Mat m1(h*3, w, CV_8UC1, nullptr);
-    cv::GMatDesc md10{CV_8U,3,{w,h},true};
-    cv::GMatDesc md11{CV_8U,1,{w,h*3},false};
-
-    EXPECT_TRUE (md0 .canDescribe(m0));
-    EXPECT_FALSE(md0 .canDescribe(m1));
-    EXPECT_TRUE (md10.canDescribe(m1));
-    EXPECT_TRUE (md11.canDescribe(m1));
-}
-
 TEST(GAPI_MetaDesc, VecOwnMatDesc)
 {
     std::vector<cv::gapi::own::Mat> vec = {

--- a/modules/gapi/test/gapi_desc_tests.cpp
+++ b/modules/gapi/test/gapi_desc_tests.cpp
@@ -95,65 +95,11 @@ TEST(GAPI_MetaDesc, CanDescribe)
     EXPECT_TRUE (md11.canDescribe(m1));
 }
 
-TEST(GAPI_MetaDesc, OwnMatDescOneCh)
+TEST(GAPI_MetaDesc, AdlVecMatDesc)
 {
-    cv::gapi::own::Mat mat(240, 320, CV_8U, nullptr);
-
-    const auto desc = cv::gapi::own::descr_of(mat);
-
-    EXPECT_EQ(CV_8U, desc.depth);
-    EXPECT_EQ(1,     desc.chan);
-    EXPECT_EQ(320,   desc.size.width);
-    EXPECT_EQ(240,   desc.size.height);
-    EXPECT_FALSE(desc.isND());
-}
-
-TEST(GAPI_MetaDesc, OwnMatDescThreeCh)
-{
-    cv::gapi::own::Mat mat(480, 640, CV_8UC3, nullptr);
-
-    const auto desc = cv::gapi::own::descr_of(mat);
-
-    EXPECT_EQ(CV_8U,   desc.depth);
-    EXPECT_EQ(3,       desc.chan);
-    EXPECT_EQ(640,     desc.size.width);
-    EXPECT_EQ(480,     desc.size.height);
-    EXPECT_FALSE(desc.isND());
-}
-
-TEST(GAPI_MetaDesc, OwnMatDescND)
-{
-    std::vector<int> dims = {1,3,224,224};
-    cv::gapi::own::Mat m(dims, CV_32F, nullptr);
-
-    const auto desc = cv::gapi::own::descr_of(m);
-
-    EXPECT_EQ(CV_32F, desc.depth);
-    EXPECT_EQ(-1,     desc.chan);
-    EXPECT_EQ(1,      desc.dims[0]);
-    EXPECT_EQ(3,      desc.dims[1]);
-    EXPECT_EQ(224,    desc.dims[2]);
-    EXPECT_EQ(224,    desc.dims[3]);
-    EXPECT_TRUE(desc.isND());
-}
-
-TEST(GAPI_MetaDesc, VecOwnMatDesc)
-{
-    std::vector<cv::gapi::own::Mat> vec = {
-    cv::gapi::own::Mat(240, 320, CV_8U, nullptr),
-    cv::gapi::own::Mat(480, 640, CV_8UC3, nullptr)};
-
-    const auto desc = cv::gapi::own::descrs_of(vec);
-
-    EXPECT_EQ((GMatDesc{CV_8U, 1, {320, 240}}), get<GMatDesc>(desc[0]));
-    EXPECT_EQ((GMatDesc{CV_8U, 3, {640, 480}}), get<GMatDesc>(desc[1]));
-}
-
-TEST(GAPI_MetaDesc, AdlVecOwnMatDesc)
-{
-    std::vector<cv::gapi::own::Mat> vec = {
-    cv::gapi::own::Mat(240, 320, CV_8U, nullptr),
-    cv::gapi::own::Mat(480, 640, CV_8UC3, nullptr)};
+    std::vector<cv::Mat> vec = {
+    cv::Mat(240, 320, CV_8U),
+    cv::Mat(480, 640, CV_8UC3)};
 
     const auto desc = descrs_of(vec);
 

--- a/modules/gapi/test/gapi_desc_tests.cpp
+++ b/modules/gapi/test/gapi_desc_tests.cpp
@@ -95,11 +95,65 @@ TEST(GAPI_MetaDesc, CanDescribe)
     EXPECT_TRUE (md11.canDescribe(m1));
 }
 
-TEST(GAPI_MetaDesc, AdlVecMatDesc)
+TEST(GAPI_MetaDesc, OwnMatDescOneCh)
 {
-    std::vector<cv::Mat> vec = {
-    cv::Mat(240, 320, CV_8U),
-    cv::Mat(480, 640, CV_8UC3)};
+    cv::gapi::own::Mat mat(240, 320, CV_8U, nullptr);
+
+    const auto desc = cv::gapi::own::descr_of(mat);
+
+    EXPECT_EQ(CV_8U, desc.depth);
+    EXPECT_EQ(1,     desc.chan);
+    EXPECT_EQ(320,   desc.size.width);
+    EXPECT_EQ(240,   desc.size.height);
+    EXPECT_FALSE(desc.isND());
+}
+
+TEST(GAPI_MetaDesc, OwnMatDescThreeCh)
+{
+    cv::gapi::own::Mat mat(480, 640, CV_8UC3, nullptr);
+
+    const auto desc = cv::gapi::own::descr_of(mat);
+
+    EXPECT_EQ(CV_8U,   desc.depth);
+    EXPECT_EQ(3,       desc.chan);
+    EXPECT_EQ(640,     desc.size.width);
+    EXPECT_EQ(480,     desc.size.height);
+    EXPECT_FALSE(desc.isND());
+}
+
+TEST(GAPI_MetaDesc, OwnMatDescND)
+{
+    std::vector<int> dims = {1,3,224,224};
+    cv::gapi::own::Mat m(dims, CV_32F, nullptr);
+
+    const auto desc = cv::gapi::own::descr_of(m);
+
+    EXPECT_EQ(CV_32F, desc.depth);
+    EXPECT_EQ(-1,     desc.chan);
+    EXPECT_EQ(1,      desc.dims[0]);
+    EXPECT_EQ(3,      desc.dims[1]);
+    EXPECT_EQ(224,    desc.dims[2]);
+    EXPECT_EQ(224,    desc.dims[3]);
+    EXPECT_TRUE(desc.isND());
+}
+
+TEST(GAPI_MetaDesc, VecOwnMatDesc)
+{
+    std::vector<cv::gapi::own::Mat> vec = {
+    cv::gapi::own::Mat(240, 320, CV_8U, nullptr),
+    cv::gapi::own::Mat(480, 640, CV_8UC3, nullptr)};
+
+    const auto desc = cv::gapi::own::descrs_of(vec);
+
+    EXPECT_EQ((GMatDesc{CV_8U, 1, {320, 240}}), get<GMatDesc>(desc[0]));
+    EXPECT_EQ((GMatDesc{CV_8U, 3, {640, 480}}), get<GMatDesc>(desc[1]));
+}
+
+TEST(GAPI_MetaDesc, AdlVecOwnMatDesc)
+{
+    std::vector<cv::gapi::own::Mat> vec = {
+    cv::gapi::own::Mat(240, 320, CV_8U, nullptr),
+    cv::gapi::own::Mat(480, 640, CV_8UC3, nullptr)};
 
     const auto desc = descrs_of(vec);
 

--- a/modules/gapi/test/gapi_fluid_test.cpp
+++ b/modules/gapi/test/gapi_fluid_test.cpp
@@ -50,7 +50,7 @@ TEST(FluidBuffer, InputTest)
     const cv::Size buffer_size = {8,8};
     cv::Mat in_mat = cv::Mat::eye(buffer_size, CV_8U);
 
-    cv::gapi::fluid::Buffer buffer(to_own(in_mat), true);
+    cv::gapi::fluid::Buffer buffer(in_mat, true);
     cv::gapi::fluid::View  view = buffer.mkView(0, false);
     view.priv().allocate(1, {});
     view.priv().reset(1);
@@ -155,7 +155,7 @@ TEST(FluidBuffer, OutputTest)
     const cv::Size buffer_size = {8,16};
     cv::Mat out_mat = cv::Mat(buffer_size, CV_8U);
 
-    cv::gapi::fluid::Buffer buffer(to_own(out_mat), false);
+    cv::gapi::fluid::Buffer buffer(out_mat, false);
     int num_writes = 0;
     while (num_writes < buffer_size.height)
     {

--- a/modules/gapi/test/gapi_sample_pipelines.cpp
+++ b/modules/gapi/test/gapi_sample_pipelines.cpp
@@ -327,21 +327,6 @@ TEST(GAPI_Pipeline, PipelineAllocatingKernel)
     EXPECT_THROW(comp.apply(in_mat, out_mat, cv::compile_args(pkg)), std::logic_error);
 }
 
-TEST(GAPI_Pipeline, CanUseOwnMatAsOutput)
-{
-    cv::GMat in;
-    cv::GComputation comp(in, cv::gapi::bitwise_not(in));
-
-    cv::Mat in_mat(3, 3, CV_8UC1);
-    cv::Mat out_mat(3, 3, CV_8UC1);
-
-    cv::gapi::own::Mat in_own_mat(in_mat.rows, in_mat.cols, CV_8UC1, in_mat.data);
-    cv::gapi::own::Mat out_own_mat(out_mat.rows, out_mat.cols, CV_8UC1, out_mat.data);
-
-    // FIXME add overload for apply(cv::gapi::own::Mat in, cv::gapi::own::Mat& out)
-    EXPECT_NO_THROW(comp.apply({in_own_mat}, {out_own_mat}));
-}
-
 TEST(GAPI_Pipeline, CreateKernelImplFromLambda)
 {
     cv::Size size(300, 300);

--- a/modules/gapi/test/own/mat_tests.cpp
+++ b/modules/gapi/test/own/mat_tests.cpp
@@ -7,6 +7,7 @@
 
 #include "../test_precomp.hpp"
 #include <opencv2/gapi/own/mat.hpp>
+#include <opencv2/gapi/own/convert.hpp>
 #include <opencv2/gapi/util/compiler_hints.hpp> //suppress_unused_warning
 
 namespace opencv_test


### PR DESCRIPTION
### "Deowned" Mat
Added:
- substitution
       `using Mat = gapi::own::Mat`.

Removed:
- Mat's `gapi::own::` (`cv::Mat` now);
- `TEST(GAPI_Pipeline, CanUseOwnMatAsOutput)`;
- `TEST(GAPI_MetaDesc, CanDescribeOwnMat)`;
- Duplicate code (overloaded functions for `cv::gapi::own::Mat`);
- `own::Mat`'s headers.

Untouched:
- `cv::gapi::own::descrs_of(...)` function (nemaspace's conflict in IE tests for standalone build without);
- `cv::gapi::own::descr_of(...)` function (it is used in gapi_desc_tests for own::Mat in non-STANDALONE build).

Tests:
- `opencv_test_gapi` passed;
- STANDALONE (IE) tests passed.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under OpenCV (BSD) License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [x] The PR is proposed to proper branch
- [x] There is reference to original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake

```
build_gapi_standalone:Linux x64=ade-0.1.1f
build_gapi_standalone:Win64=ade-0.1.1f
build_gapi_standalone:Mac=ade-0.1.1f
build_gapi_standalone:Linux x64 Debug=ade-0.1.1f
force_builders=Custom
buildworker:Custom=linux-1
build_image:Custom=plaidml2
test_modules:Custom=gapi
test_filter:Custom=*ML* 
```
