### PR TITLE
OpenJPEG: fixed compilation and warnings with VS

### DIFF
--- a/modules/imgcodecs/src/grfmt_jpeg2000_openjpeg.cpp
+++ b/modules/imgcodecs/src/grfmt_jpeg2000_openjpeg.cpp
@@ -34,7 +34,7 @@ String colorspaceName(COLOR_SPACE colorspace)
     case OPJ_CLRSPC_UNSPECIFIED:
         return "unspecified";
     default:
-        CV_Assert(!"Invalid colorspace");
+        CV_Error(Error::StsNotImplemented, "Invalid colorspace");
     }
 }
 
@@ -141,7 +141,7 @@ public:
         return ChannelsIterator<Traits>(*this) += n;
     }
 
-    difference_type operator-(const ChannelsIterator<Traits>& other)
+    difference_type operator-(const ChannelsIterator<Traits>& other) const
     {
         return (ptr_ - other.ptr_) / step_;
     }
@@ -214,7 +214,7 @@ void copyToMatImpl(std::vector<InT*>&& in, Mat& out, uint8_t shift)
                 const auto first = in[c];
                 const auto last = first + size.width;
                 auto dOut = ChannelsIt(rowPtr, c, channelsCount);
-                std::transform(first, last, dOut, [shift](InT val) -> OutT { return val >> shift; });
+                std::transform(first, last, dOut, [shift](InT val) -> OutT { return static_cast<OutT>(val >> shift); });
                 in[c] += size.width;
             }
         }
@@ -229,7 +229,7 @@ void copyToMatImpl(std::vector<InT*>&& in, Mat& out, uint8_t shift)
                 const auto first = in[c];
                 const auto last = first + size.width;
                 auto dOut = ChannelsIt(rowPtr, c, channelsCount);
-                std::copy(first, last, dOut);
+                std::transform(first, last, dOut, [](InT val) -> OutT { return static_cast<OutT>(val); });
                 in[c] += size.width;
             }
         }
@@ -558,8 +558,12 @@ bool Jpeg2KOpjDecoder::readHeader()
             CV_Error(Error::StsNotImplemented, cv::format("OpenJPEG2000: Component %d/%d is duplicate alpha channel", i, numcomps));
         }
 
-        hasAlpha |= comp.alpha;
+        hasAlpha |= (bool)comp.alpha;
 
+        if (comp.prec > 64)
+        {
+            CV_Error(Error::StsNotImplemented, "OpenJPEG2000: precision > 64 is not supported");
+        }
         m_maxPrec = std::max(m_maxPrec, comp.prec);
     }
 
@@ -623,7 +627,7 @@ bool Jpeg2KOpjDecoder::readData( Mat& img )
         CV_Error(Error::StsNotImplemented,
                  cv::format("OpenJPEG2000: output precision > 16 not supported: target depth %d", depth));
     }();
-    const uint8_t shift = outPrec > m_maxPrec ? 0 : m_maxPrec - outPrec;
+    const uint8_t shift = outPrec > m_maxPrec ? 0 : (uint8_t)(m_maxPrec - outPrec); // prec <= 64
     return decode(*image_, img, shift);
 }
 


### PR DESCRIPTION
resolves #16998

warnings:
```
opencv\modules\imgcodecs\src\grfmt_jpeg2000_openjpeg.cpp(39): 
  warning C4715: 'cv::`anonymous namespace'::colorspaceName': not all control paths return a value

opencv\modules\imgcodecs\src\grfmt_jpeg2000_openjpeg.cpp(217,89): 
  warning C4244: 'return': conversion from 'const InT' to 'OutT', possible loss of data 

opencv\modules\imgcodecs\src\grfmt_jpeg2000_openjpeg.cpp(561,31): 
  warning C4805: '|=': unsafe mix of type 'bool' and type 'const OPJ_UINT16' in operation

opencv\modules\imgcodecs\src\grfmt_jpeg2000_openjpeg.cpp(626,35): 
  warning C4244: 'initializing': conversion from 'OPJ_UINT32' to 'uint8_t', possible loss of data

C:\Program Files (x86)\Microsoft Visual Studio\2019\Professional\VC\Tools\MSVC\14.25.28610\include\xutility(3606,22): 
  warning C4244: '=': conversion from 'const OPJ_I NT32' to 'T', possible loss of data
...
opencv\modules\imgcodecs\src\grfmt_jpeg2000_openjpeg.cpp(232): 
  message : see reference to function template instantiation '_OutIt std::copy<_Ty,ChannelsIt>(_I nIt,_InIt,_OutIt)' being compiled with 
[
_OutIt=ChannelsIt,
_Ty=const OPJ_INT32 *,
_InIt=const OPJ_INT32 *
]
```

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under OpenCV (BSD) License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [x] The PR is proposed to proper branch
- [x] There is reference to original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
