### PR TITLE
Header parser `explicit` constructors support

### DIFF
--- a/modules/python/src2/hdr_parser.py
+++ b/modules/python/src2/hdr_parser.py
@@ -430,9 +430,10 @@ class CppHeaderParser(object):
         # filter off some common prefixes, which are meaningless for Python wrappers.
         # note that we do not strip "static" prefix, which does matter;
         # it means class methods, not instance methods
-        decl_str = self.batch_replace(decl_str, [("static inline", ""), ("inline", ""),\
-            ("CV_EXPORTS_W", ""), ("CV_EXPORTS", ""), ("CV_CDECL", ""), ("CV_WRAP ", " "), ("CV_INLINE", ""),
-            ("CV_DEPRECATED", ""), ("CV_DEPRECATED_EXTERNAL", "")]).strip()
+        decl_str = self.batch_replace(decl_str, [("static inline", ""), ("inline", ""), ("explicit ", ""),
+                                                 ("CV_EXPORTS_W", ""), ("CV_EXPORTS", ""), ("CV_CDECL", ""),
+                                                 ("CV_WRAP ", " "), ("CV_INLINE", ""),
+                                                 ("CV_DEPRECATED", ""), ("CV_DEPRECATED_EXTERNAL", "")]).strip()
 
 
         if decl_str.strip().startswith('virtual'):

--- a/modules/videoio/misc/java/test/VideoCaptureTest.java
+++ b/modules/videoio/misc/java/test/VideoCaptureTest.java
@@ -35,10 +35,30 @@ public class VideoCaptureTest extends OpenCVTestCase {
         assertFalse(capture.isOpened());
     }
 
-    public void testVideoCapture() {
+    public void testDefaultConstructor() {
         capture = new VideoCapture();
         assertNotNull(capture);
         assertFalse(capture.isOpened());
+    }
+
+    public void testConstructorWithFilename() {
+        capture = new VideoCapture("some_file.avi");
+        assertNotNull(capture);
+    }
+
+    public void testConstructorWithFilenameAndExplicitlySpecifiedAPI() {
+        capture = new VideoCapture("some_file.avi", Videoio.CAP_ANY);
+        assertNotNull(capture);
+    }
+
+    public void testConstructorWithIndex() {
+        capture = new VideoCapture(0);
+        assertNotNull(capture);
+    }
+
+    public void testConstructorWithIndexAndExplicitlySpecifiedAPI() {
+        capture = new VideoCapture(0, Videoio.CAP_ANY);
+        assertNotNull(capture);
     }
 
 }


### PR DESCRIPTION
`explicit` keyword is removed from the function declaration string.

Resolves:  #16988.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under OpenCV (BSD) License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [x] The PR is proposed to proper branch
- [x] There is reference to original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake

```
allow_multiple_commits=1
```