### PR TITLE
GAPI: Fix [-Wreturn-type] warning on standalone mac build

### DIFF
--- a/modules/gapi/include/opencv2/gapi/own/assert.hpp
+++ b/modules/gapi/include/opencv2/gapi/own/assert.hpp
@@ -20,7 +20,7 @@
 
 namespace detail
 {
-    inline void assert_abort(const char* str, int line, const char* file, const char* func)
+    [[noreturn]] inline void assert_abort(const char* str, int line, const char* file, const char* func)
     {
         std::stringstream ss;
         ss << file << ":" << line << ": Assertion " << str << " in function " << func << " failed\n";


### PR DESCRIPTION
- added `[[noreturn]]` to standalone version of  `GAPI_Assert` implementaion 

relates #16952

@dmatveev @rgarnov please take a look

<cut/>

```
force_builders=ARMv7,Custom
build_image:Custom=centos:7
buildworker:Custom=linux-1
build_gapi_standalone:Custom=ade-0.1.1f

build_gapi_standalone:Linux x64=ade-0.1.1f
build_gapi_standalone:Win64=ade-0.1.1f
build_gapi_standalone:Mac=ade-0.1.1f
build_gapi_standalone:Linux x64 Debug=ade-0.1.1f
```

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under OpenCV (BSD) License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [x] The PR is proposed to proper branch
- [x] There is reference to original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
