### PR TITLE
Remove std::binary_function as it's deprecated in C++11

### DIFF
--- a/3rdparty/openexr/IlmImf/ImfAttribute.cpp
+++ b/3rdparty/openexr/IlmImf/ImfAttribute.cpp
@@ -63,7 +63,7 @@ Attribute::~Attribute () {}
 
 namespace {
 
-struct NameCompare: std::binary_function <const char *, const char *, bool>
+struct NameCompare
 {
     bool
     operator () (const char *x, const char *y) const


### PR DESCRIPTION
std::binary_function was deprecated with C++11 and removed in C++17. It provided just two typedefs which in this case were unused.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under OpenCV (BSD) License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [ ] The PR is proposed to proper branch
- [ ] There is reference to original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
