### PR TITLE
photo: fix test failure on Jetson Nano/TX1/TX2

### DIFF
--- a/modules/photo/test/test_denoising.cuda.cpp
+++ b/modules/photo/test/test_denoising.cuda.cpp
@@ -82,7 +82,7 @@ TEST(CUDA_BruteForceNonLocalMeans, Regression)
     cv::resize(gray_gold, gray_gold, cv::Size(256, 256));
 
     EXPECT_MAT_NEAR(bgr_gold, dbgr, 1);
-    EXPECT_MAT_NEAR(gray_gold, dgray, 1e-4);
+    EXPECT_MAT_NEAR(gray_gold, dgray, 1);
 }
 
 ////////////////////////////////////////////////////////


### PR DESCRIPTION
resolves #17024 

This test failure only happens in master branch, but test fix now based on 3.4 branch (regular procedure)

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under OpenCV (BSD) License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [x] The PR is proposed to proper branch
- [x] There is reference to original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
