### PR TITLE
Fixed Mat function issues

### DIFF
--- a/samples/cpp/tutorial_code/ImgProc/HitMiss/HitMiss.cpp
+++ b/samples/cpp/tutorial_code/ImgProc/HitMiss/HitMiss.cpp
@@ -5,7 +5,7 @@
 using namespace cv;
 
 int main(){
-    Mat input_image = (Mat_<uchar>(8, 8) <<
+    Mat input_image = Mat_<uchar>(8, 8) <<(
         0, 0, 0, 0, 0, 0, 0, 0,
         0, 255, 255, 255, 0, 0, 0, 255,
         0, 255, 255, 255, 0, 0, 0, 0,
@@ -15,7 +15,7 @@ int main(){
         0, 255, 0, 255, 0, 0, 255, 0,
         0, 255, 255, 255, 0, 0, 0, 0);
 
-    Mat kernel = (Mat_<int>(3, 3) <<
+    Mat kernel = Mat_<int>(3, 3) <<(
         0, 1, 0,
         1, -1, 1,
         0, 1, 0);


### PR DESCRIPTION
Here Mat constructors do not work due to invalid initialization. Ref https://docs.opencv.org/master/df/dfc/classcv_1_1Mat__.html

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under OpenCV (BSD) License.
- [ ] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [ ] The PR is proposed to proper branch
- [ ] There is reference to original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
