### PR TITLE
Update OpenCVFindVA_INTEL.cmake

### DIFF
--- a/cmake/OpenCVFindVA_INTEL.cmake
+++ b/cmake/OpenCVFindVA_INTEL.cmake
@@ -5,10 +5,9 @@
 # VA_INTEL_IOCL_ROOT - root of Intel OCL installation
 
 if(UNIX AND NOT ANDROID)
-    if(DEFINED ENV{VA_INTEL_IOCL_ROOT})
-        set(VA_INTEL_IOCL_ROOT $ENV{VA_INTEL_IOCL_ROOT})
-    else()
-        set(VA_INTEL_IOCL_ROOT "/opt/intel/opencl")
+    ocv_check_environment_variables(VA_INTEL_IOCL_ROOT)
+    if(NOT DEFINED VA_INTEL_IOCL_ROOT)
+      set(VA_INTEL_IOCL_ROOT "/opt/intel/opencl")
     endif()
 
     find_path(

--- a/cmake/OpenCVFindVA_INTEL.cmake
+++ b/cmake/OpenCVFindVA_INTEL.cmake
@@ -5,7 +5,7 @@
 # VA_INTEL_IOCL_ROOT - root of Intel OCL installation
 
 if(UNIX AND NOT ANDROID)
-    if($ENV{VA_INTEL_IOCL_ROOT})
+    if(DEFINED ENV{VA_INTEL_IOCL_ROOT})
         set(VA_INTEL_IOCL_ROOT $ENV{VA_INTEL_IOCL_ROOT})
     else()
         set(VA_INTEL_IOCL_ROOT "/opt/intel/opencl")


### PR DESCRIPTION
When set env VA_INTEL_IOCL_ROOT, "if($ENV{VA_INTEL_IOCL_ROOT})" don't work.
    My modification as follow.
    
    -    if($ENV{VA_INTEL_IOCL_ROOT})
    +    if(DEFINED ENV{VA_INTEL_IOCL_ROOT})
    
    Refer: https://cmake.org/cmake/help/latest/variable/ENV.html

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under OpenCV (BSD) License.
- [ ] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [x] The PR is proposed to proper branch
- [ ] There is reference to original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
