### PR TITLE
Update exit status code

### DIFF
--- a/modules/python/src2/hdr_parser.py
+++ b/modules/python/src2/hdr_parser.py
@@ -690,7 +690,7 @@ class CppHeaderParser(object):
                     classname, bases, modlist = self.parse_class_decl(stmt[len("typedef "):])
                 except:
                     print("Error at %s:%d" % (self.hname, self.lineno))
-                    exit(1)
+                    exit(-1)
                 if classname.startswith("_Ipl"):
                     classname = classname[1:]
                 decl = [stmt_type + " " + self.get_dotted_name(classname), "", modlist, [], None, docstring]
@@ -705,7 +705,7 @@ class CppHeaderParser(object):
                         classname, bases, modlist = self.parse_class_decl(stmt)
                     except:
                         print("Error at %s:%d" % (self.hname, self.lineno))
-                        exit(1)
+                        exit(-1)
                     decl = []
                     if ("CV_EXPORTS_W" in stmt) or ("CV_EXPORTS_AS" in stmt) or (not self.wrap_mode):# and ("CV_EXPORTS" in stmt)):
                         decl = [stmt_type + " " + self.get_dotted_name(classname), "", modlist, [], None, docstring]


### PR DESCRIPTION
### Description

Not a big change, just changed exit status code for errors to `exit(-1)`, to maintain uniformity across the script.

### Pull Request Readiness Checklist

- [x] I agree to contribute to the project under OpenCV (BSD) License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [x] The PR is proposed to proper branch
- [x] There is reference to original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake

