### PR TITLE
GAPI: utils - variant::get_if

### DIFF
--- a/modules/gapi/test/util/variant_tests.cpp
+++ b/modules/gapi/test/util/variant_tests.cpp
@@ -289,6 +289,22 @@ TEST(Variant, Swap_DiffIndex)
     EXPECT_EQ(3.14f, util::get<float>(tv1));
 }
 
+TEST(Variant, GetIf)
+{
+    const TestVar cv(42);
+
+    // Test const& get_if()
+    EXPECT_EQ(nullptr, util::get_if<std::string>(&cv));
+    ASSERT_NE(nullptr, util::get_if<int>(&cv));
+    EXPECT_EQ(42, *util::get_if<int>(&cv));
+
+    // Test &get_if
+    TestVar cv2(std::string("42"));
+    EXPECT_EQ(nullptr, util::get_if<int>(&cv2));
+    ASSERT_NE(nullptr, util::get_if<std::string>(&cv2));
+    EXPECT_EQ("42", *util::get_if<std::string>(&cv2));
+}
+
 TEST(Variant, Get)
 {
     const TestVar cv(42);


### PR DESCRIPTION
adding one more [missing function](https://en.cppreference.com/w/cpp/utility/variant/get_if) to local version of `std::variant`
```
force_builders=ARMv7,Custom
build_image:Custom=centos:7
buildworker:Custom=linux-1
build_gapi_standalone:Custom=ade-0.1.1f

build_gapi_standalone:Linux x64=ade-0.1.1f
build_gapi_standalone:Win64=ade-0.1.1f
build_gapi_standalone:Mac=ade-0.1.1f
build_gapi_standalone:Linux x64 Debug=ade-0.1.1f
```

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under OpenCV (BSD) License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [x] The PR is proposed to proper branch
- [x] There is reference to original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
