### PR TITLE
Fixed compilation when NN builder is not built

### DIFF
--- a/modules/dnn/CMakeLists.txt
+++ b/modules/dnn/CMakeLists.txt
@@ -107,7 +107,13 @@ endif()
 
 set(dnn_runtime_libs "")
 if(INF_ENGINE_TARGET)
-  ocv_option(OPENCV_DNN_IE_NN_BUILDER_2019 "Build with Inference Engine NN Builder API support" ON)  # future: NOT HAVE_NGRAPH
+  set(use_nn_builder OFF)
+  if(TARGET inference_engine_nn_builder OR # custom imported target
+     TARGET IE::inference_engine_nn_builder OR # default imported target via InferenceEngineConfig.cmake
+     INF_ENGINE_RELEASE VERSION_LESS "2020000000") # compatibility with older versions on IE
+    set(use_nn_builder ON)
+  endif()
+  ocv_option(OPENCV_DNN_IE_NN_BUILDER_2019 "Build with Inference Engine NN Builder API support" ${use_nn_builder})  # future: NOT HAVE_NGRAPH
   if(OPENCV_DNN_IE_NN_BUILDER_2019)
     message(STATUS "DNN: Enabling Inference Engine NN Builder API support")
     add_definitions(-DHAVE_DNN_IE_NN_BUILDER_2019=1)

--- a/modules/dnn/src/op_inf_engine.hpp
+++ b/modules/dnn/src/op_inf_engine.hpp
@@ -58,7 +58,9 @@
 
 #include <inference_engine.hpp>
 
+#ifdef HAVE_DNN_IE_NN_BUILDER_2019
 #include <ie_builders.hpp>
+#endif
 
 #if defined(__GNUC__) && INF_ENGINE_VER_MAJOR_LT(INF_ENGINE_RELEASE_2020_1)
 #pragma GCC visibility pop


### PR DESCRIPTION
Allow to build without NN Builder API, but with IE + ngraph

<cut/>

```
force_builders=Custom,Custom Win,Custom Mac
build_image:Custom=ubuntu-openvino-2020.1.0:16.04
build_image:Custom Win=openvino-2020.1.0
build_image:Custom Mac=openvino-2020.1.0

test_modules:Custom=dnn,python2,python3,java
test_modules:Custom Win=dnn,python2,python3,java
test_modules:Custom Mac=dnn,python2,python3,java

buildworker:Custom=linux-1
# disabled due high memory usage: test_opencl:Custom=ON
test_opencl:Custom=OFF
test_bigdata:Custom=1
test_filter:Custom=*
```