### PR TITLE
Update calcBackProject_Demo1.py

### DIFF
--- a/samples/python/tutorial_code/Histograms_Matching/back_projection/calcBackProject_Demo1.py
+++ b/samples/python/tutorial_code/Histograms_Matching/back_projection/calcBackProject_Demo1.py
@@ -31,7 +31,7 @@ def Hist_and_Backproj(val):
     histImg = np.zeros((h, w, 3), dtype=np.uint8)
 
     for i in range(bins):
-        cv.rectangle(histImg, (i*bin_w, h), ( (i+1)*bin_w, h - int(round( hist[i]*h/255.0 )) ), (0, 0, 255), cv.FILLED)
+        cv.rectangle(histImg, (i*bin_w, h), ( (i+1)*bin_w, h - int(np.round( hist[i]*h/255.0 )) ), (0, 0, 255), cv.FILLED)
 
     cv.imshow('Histogram', histImg)
     ## [Draw the histogram]


### PR DESCRIPTION
To round a ndarray it's necessary to use np.round() instead to Built-in Python round()

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [ ] I agree to contribute to the project under OpenCV (BSD) License.
- [ ] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [ ] The PR is proposed to proper branch
- [ ] There is reference to original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake