### PR TITLE
Align DLIE and nGraph average pooling layers

### DIFF
--- a/modules/dnn/src/layers/pooling_layer.cpp
+++ b/modules/dnn/src/layers/pooling_layer.cpp
@@ -325,7 +325,7 @@ public:
             ieLayer.setRoundingType(ceilMode ?
                                     InferenceEngine::Builder::PoolingLayer::RoundingType::CEIL :
                                     InferenceEngine::Builder::PoolingLayer::RoundingType::FLOOR);
-            ieLayer.setExcludePad(type == AVE && padMode == "SAME");
+            ieLayer.setExcludePad(!avePoolPaddedArea);
 
             InferenceEngine::Builder::Layer l = ieLayer;
             if (!padMode.empty())


### PR DESCRIPTION
Fix potential bug in deprecated API for the internal changes in IE

<cut/>

```
force_builders=Custom,Custom Win,Custom Mac
build_image:Custom=ubuntu-openvino-2020.1.0:16.04
build_image:Custom Win=openvino-2020.1.0
build_image:Custom Mac=openvino-2020.1.0

test_modules:Custom=dnn,python2,python3,java
test_modules:Custom Win=dnn,python2,python3,java
test_modules:Custom Mac=dnn,python2,python3,java

buildworker:Custom=linux-1
# disabled due high memory usage: test_opencl:Custom=ON
test_opencl:Custom=OFF
test_bigdata:Custom=1
test_filter:Custom=*
```