### PR TITLE
CUDA: fix test failure on Jetson TX2

### DIFF
--- a/modules/cudabgsegm/test/test_bgsegm.cpp
+++ b/modules/cudabgsegm/test/test_bgsegm.cpp
@@ -110,7 +110,7 @@ CUDA_TEST_P(MOG2, Update)
 
         mog2_gold->apply(frame, foreground_gold);
 
-        ASSERT_MAT_SIMILAR(foreground_gold, foreground, detectShadow ? 13e-3 : 18e-8);
+        ASSERT_MAT_SIMILAR(foreground_gold, foreground, detectShadow ? 13e-3 : 2e-4);
     }
 }
 


### PR DESCRIPTION
resolves #17078

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under OpenCV (BSD) License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [x] The PR is proposed to proper branch
- [x] There is reference to original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
