### PR TITLE
G-API: gapi::buildOpticalFlowPyramid() Implementation

### DIFF
--- a/modules/gapi/include/opencv2/gapi/cpu/gcpukernel.hpp
+++ b/modules/gapi/include/opencv2/gapi/cpu/gcpukernel.hpp
@@ -256,6 +256,12 @@ template<typename U> struct get_out<cv::GArray<U>>
         return ctx.outVecR<U>(idx);
     }
 };
+
+//FIXME(dm): GArray<Mat>/GArray<GMat> conversion should be done more gracefully in the system
+template<> struct get_out<cv::GArray<cv::GMat> >: public get_out<cv::GArray<cv::Mat> >
+{
+};
+
 template<typename U> struct get_out<cv::GOpaque<U>>
 {
     static U& get(GCPUContext &ctx, int idx)

--- a/modules/gapi/perf/common/gapi_video_perf_tests.hpp
+++ b/modules/gapi/perf/common/gapi_video_perf_tests.hpp
@@ -16,11 +16,16 @@ using namespace perf;
 
 //------------------------------------------------------------------------------
 
+class BuildOptFlowPyramidPerfTest : public TestPerfParams<tuple<std::string,int,int,bool,int,int,
+                                                                bool,GCompileArgs>> {};
 class OptFlowLKPerfTest : public TestPerfParams<tuple<std::string,int,tuple<int,int>,int,
                                                       cv::TermCriteria,cv::GCompileArgs>> {};
 class OptFlowLKForPyrPerfTest : public TestPerfParams<tuple<std::string,int,tuple<int,int>,int,
                                                             cv::TermCriteria,bool,
                                                             cv::GCompileArgs>> {};
+class BuildPyr_CalcOptFlow_PipelinePerfTest : public TestPerfParams<tuple<std::string,int,int,bool,
+                                                                          cv::GCompileArgs>> {};
+
 } // opencv_test
 
 #endif // OPENCV_GAPI_VIDEO_PERF_TESTS_HPP

--- a/modules/gapi/perf/cpu/gapi_video_perf_tests_cpu.cpp
+++ b/modules/gapi/perf/cpu/gapi_video_perf_tests_cpu.cpp
@@ -27,6 +27,29 @@ namespace
 
 namespace opencv_test
 {
+INSTANTIATE_TEST_CASE_MACRO_P(WITH_VIDEO(BuildOptFlowPyramidPerfTestCPU),
+                              BuildOptFlowPyramidPerfTest,
+                              Combine(Values("cv/optflow/rock_1.bmp",
+                                             "cv/optflow/frames/1080p_01.png"),
+                                      Values(7, 11),
+                                      Values(1000),
+                                      testing::Bool(),
+                                      Values(BORDER_DEFAULT, BORDER_TRANSPARENT),
+                                      Values(BORDER_DEFAULT, BORDER_TRANSPARENT),
+                                      testing::Bool(),
+                                      Values(cv::compile_args(VIDEO_CPU))));
+
+INSTANTIATE_TEST_CASE_MACRO_P(WITH_VIDEO(BuildOptFlowPyramidInternalPerfTestCPU),
+                              BuildOptFlowPyramidPerfTest,
+                              Combine(Values("cv/optflow/rock_1.bmp"),
+                                      Values(15),
+                                      Values(3),
+                                      Values(true),
+                                      Values(BORDER_REFLECT_101),
+                                      Values(BORDER_CONSTANT),
+                                      Values(true),
+                                      Values(cv::compile_args(VIDEO_CPU))));
+
 INSTANTIATE_TEST_CASE_MACRO_P(WITH_VIDEO(OptFlowLKPerfTestCPU), OptFlowLKPerfTest,
                               Combine(Values("cv/optflow/rock_%01d.bmp",
                                              "cv/optflow/frames/1080p_%02d.png"),
@@ -59,6 +82,22 @@ INSTANTIATE_TEST_CASE_MACRO_P(WITH_VIDEO(OptFlowLKInternalPerfTestCPU),
                                       Values(cv::TermCriteria(cv::TermCriteria::COUNT |
                                                               cv::TermCriteria::EPS,
                                                               21, 0.05)),
+                                      Values(true),
+                                      Values(cv::compile_args(VIDEO_CPU))));
+
+INSTANTIATE_TEST_CASE_MACRO_P(WITH_VIDEO(BuildPyr_CalcOptFlow_PipelinePerfTestCPU),
+                              BuildPyr_CalcOptFlow_PipelinePerfTest,
+                              Combine(Values("cv/optflow/frames/1080p_%02d.png"),
+                                      Values(7, 11),
+                                      Values(1000),
+                                      Values(true, false),
+                                      Values(cv::compile_args(VIDEO_CPU))));
+
+INSTANTIATE_TEST_CASE_MACRO_P(WITH_VIDEO(BuildPyr_CalcOptFlow_PipelineInternalTestPerfCPU),
+                              BuildPyr_CalcOptFlow_PipelinePerfTest,
+                              Combine(Values("cv/optflow/rock_%01d.bmp"),
+                                      Values(15),
+                                      Values(3),
                                       Values(true),
                                       Values(cv::compile_args(VIDEO_CPU))));
 } // opencv_test

--- a/modules/gapi/src/api/kernels_video.cpp
+++ b/modules/gapi/src/api/kernels_video.cpp
@@ -12,13 +12,24 @@
 namespace cv { namespace gapi {
 using namespace video;
 
+GBuildPyrOutput buildOpticalFlowPyramid(const GMat    &img,
+                                        const Size    &winSize,
+                                        const GScalar &maxLevel,
+                                              bool     withDerivatives,
+                                              int      pyrBorder,
+                                              int      derivBorder,
+                                              bool     tryReuseInputImage)
+{
+    return GBuildOptFlowPyramid::on(img, winSize, maxLevel, withDerivatives, pyrBorder,
+                                    derivBorder, tryReuseInputImage);
+}
 
 GOptFlowLKOutput calcOpticalFlowPyrLK(const GMat                    &prevImg,
                                       const GMat                    &nextImg,
                                       const cv::GArray<cv::Point2f> &prevPts,
                                       const cv::GArray<cv::Point2f> &predPts,
                                       const Size                    &winSize,
-                                            int                      maxLevel,
+                                      const GScalar                 &maxLevel,
                                       const TermCriteria            &criteria,
                                             int                      flags,
                                             double                   minEigThresh)
@@ -32,7 +43,7 @@ GOptFlowLKOutput calcOpticalFlowPyrLK(const cv::GArray<cv::GMat>    &prevPyr,
                                       const cv::GArray<cv::Point2f> &prevPts,
                                       const cv::GArray<cv::Point2f> &predPts,
                                       const Size                    &winSize,
-                                            int                      maxLevel,
+                                      const GScalar                 &maxLevel,
                                       const TermCriteria            &criteria,
                                             int                      flags,
                                             double                   minEigThresh)

--- a/modules/gapi/test/common/gapi_video_tests.hpp
+++ b/modules/gapi/test/common/gapi_video_tests.hpp
@@ -11,6 +11,11 @@
 
 namespace opencv_test
 {
+GAPI_TEST_FIXTURE_SPEC_PARAMS(BuildOptFlowPyramidTest,
+                              FIXTURE_API(std::string,int,int,bool,int,int,bool), 7,
+                              fileName, winSize, maxLevel, withDerivatives, pyrBorder,
+                              derivBorder, tryReuseInputImage)
+
 GAPI_TEST_FIXTURE_SPEC_PARAMS(OptFlowLKTest, FIXTURE_API(std::string,int,tuple<int,int>,int,
                                                          cv::TermCriteria),
                               5, fileNamePattern, channels, pointsNum, winSize, criteria)
@@ -18,6 +23,11 @@ GAPI_TEST_FIXTURE_SPEC_PARAMS(OptFlowLKTest, FIXTURE_API(std::string,int,tuple<i
 GAPI_TEST_FIXTURE_SPEC_PARAMS(OptFlowLKTestForPyr, FIXTURE_API(std::string,int,tuple<int,int>,int,
                                                                cv::TermCriteria,bool),
                               6, fileNamePattern, channels, pointsNum, winSize, criteria,withDeriv)
+
+GAPI_TEST_FIXTURE_SPEC_PARAMS(BuildPyr_CalcOptFlow_PipelineTest,
+                              FIXTURE_API(std::string,int,int,bool), 4,
+                              fileNamePattern, winSize, maxLevel, withDerivatives)
+
 } // opencv_test
 
 

--- a/modules/gapi/test/common/gapi_video_tests_inl.hpp
+++ b/modules/gapi/test/common/gapi_video_tests_inl.hpp
@@ -12,6 +12,23 @@
 namespace opencv_test
 {
 
+TEST_P(BuildOptFlowPyramidTest, AccuracyTest)
+{
+    std::vector<Mat> outPyrOCV,          outPyrGAPI;
+    int              outMaxLevelOCV = 0, outMaxLevelGAPI = 0;
+
+    BuildOpticalFlowPyramidTestParams params { fileName, winSize, maxLevel,
+                                              withDerivatives, pyrBorder, derivBorder,
+                                              tryReuseInputImage, getCompileArgs() };
+
+    BuildOpticalFlowPyramidTestOutput outOCV  { outPyrOCV,  outMaxLevelOCV };
+    BuildOpticalFlowPyramidTestOutput outGAPI { outPyrGAPI, outMaxLevelGAPI };
+
+    runOCVnGAPIBuildOptFlowPyramid(*this, params, outOCV, outGAPI);
+
+    compareOutputPyramids(outOCV, outGAPI);
+}
+
 TEST_P(OptFlowLKTest, AccuracyTest)
 {
     std::vector<cv::Point2f> outPtsOCV,    outPtsGAPI,    inPts;
@@ -44,6 +61,29 @@ TEST_P(OptFlowLKTestForPyr, AccuracyTest)
     OptFlowLKTestOutput outGAPI { outPtsGAPI, outStatusGAPI, outErrGAPI };
 
     runOCVnGAPIOptFlowLKForPyr(*this, in, params, withDeriv, outOCV, outGAPI);
+
+    compareOutputsOptFlow(outOCV, outGAPI);
+}
+
+TEST_P(BuildPyr_CalcOptFlow_PipelineTest, AccuracyTest)
+{
+    std::vector<Point2f> outPtsOCV,    outPtsGAPI,    inPts;
+    std::vector<uchar>   outStatusOCV, outStatusGAPI;
+    std::vector<float>   outErrOCV,    outErrGAPI;
+
+    BuildOpticalFlowPyramidTestParams params { fileNamePattern, winSize, maxLevel,
+                                              withDerivatives, BORDER_DEFAULT, BORDER_DEFAULT,
+                                              true, getCompileArgs() };
+
+    auto customKernel  = gapi::kernels<GCPUMinScalar>();
+    auto kernels       = gapi::combine(customKernel,
+                                       params.compileArgs[0].get<gapi::GKernelPackage>());
+    params.compileArgs = compile_args(kernels);
+
+    OptFlowLKTestOutput outOCV  { outPtsOCV,  outStatusOCV,  outErrOCV };
+    OptFlowLKTestOutput outGAPI { outPtsGAPI, outStatusGAPI, outErrGAPI };
+
+    runOCVnGAPIOptFlowPipeline(*this, params, outOCV, outGAPI, inPts);
 
     compareOutputsOptFlow(outOCV, outGAPI);
 }

--- a/modules/gapi/test/cpu/gapi_video_tests_cpu.cpp
+++ b/modules/gapi/test/cpu/gapi_video_tests_cpu.cpp
@@ -26,6 +26,28 @@ namespace
 
 namespace opencv_test
 {
+INSTANTIATE_TEST_CASE_MACRO_P(WITH_VIDEO(BuildOptFlowPyramidTestCPU), BuildOptFlowPyramidTest,
+                              Combine(Values(VIDEO_CPU),
+                                      Values("cv/optflow/rock_1.bmp",
+                                             "cv/optflow/frames/1080p_01.png"),
+                                      Values(7, 11),
+                                      Values(1000),
+                                      testing::Bool(),
+                                      Values(BORDER_DEFAULT, BORDER_TRANSPARENT),
+                                      Values(BORDER_DEFAULT, BORDER_TRANSPARENT),
+                                      testing::Bool()));
+
+INSTANTIATE_TEST_CASE_MACRO_P(WITH_VIDEO(BuildOptFlowPyramidInternalTestCPU),
+                              BuildOptFlowPyramidTest,
+                              Combine(Values(VIDEO_CPU),
+                                      Values("cv/optflow/rock_1.bmp"),
+                                      Values(15),
+                                      Values(3),
+                                      Values(true),
+                                      Values(BORDER_REFLECT_101),
+                                      Values(BORDER_CONSTANT),
+                                      Values(true)));
+
 INSTANTIATE_TEST_CASE_MACRO_P(WITH_VIDEO(OptFlowLKTestCPU), OptFlowLKTest,
                               Combine(Values(VIDEO_CPU),
                                       Values("cv/optflow/rock_%01d.bmp",
@@ -58,5 +80,21 @@ INSTANTIATE_TEST_CASE_MACRO_P(WITH_VIDEO(OptFlowLKInternalTestCPU), OptFlowLKTes
                                       Values(cv::TermCriteria(cv::TermCriteria::COUNT |
                                                               cv::TermCriteria::EPS,
                                                               21, 0.05)),
+                                      Values(true)));
+
+INSTANTIATE_TEST_CASE_MACRO_P(WITH_VIDEO(BuildPyr_CalcOptFlow_PipelineTestCPU),
+                              BuildPyr_CalcOptFlow_PipelineTest,
+                              Combine(Values(VIDEO_CPU),
+                                      Values("cv/optflow/frames/1080p_%02d.png"),
+                                      Values(7, 11),
+                                      Values(1000),
+                                      testing::Bool()));
+
+INSTANTIATE_TEST_CASE_MACRO_P(WITH_VIDEO(BuildPyr_CalcOptFlow_PipelineInternalTestCPU),
+                              BuildPyr_CalcOptFlow_PipelineTest,
+                              Combine(Values(VIDEO_CPU),
+                                      Values("cv/optflow/rock_%01d.bmp"),
+                                      Values(15),
+                                      Values(3),
                                       Values(true)));
 } // opencv_test


### PR DESCRIPTION
### gapi::buildOpticalFlowPyramid() interface, CPUkernel and CPUtests implementation

     - kernel added to a cv::gapi::video namespace
     - tests to check a kernels (based on cv::video tests for cv::buildOpticalFlowPyramid())
     - tests for a combined G-API-pipeline (buildOpticalFlowPyramid() -> calcOpticalFlowPyrLK())
     - tests for internal purposes added
     - custom function for comparison in tests implemented

### Pull Request Readiness Checklist
- [x] I agree to contribute to the project under OpenCV (BSD) License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [x] The PR is proposed to proper branch
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake

```

Xforce_builders=Custom,Custom Win,Custom Mac
build_image:Custom=ubuntu-openvino-2019r2.0:16.04
build_image:Custom Win=openvino-2019r2.0
build_image:Custom Mac=openvino-2019r2.0

test_modules:Custom=gapi
test_modules:Custom Win=gapi
test_modules:Custom Mac=gapi

buildworker:Custom=linux-1
test_opencl:Custom=ON
test_bigdata:Custom=1
test_filter:Custom=*

build_gapi_standalone:Linux x64=ade-0.1.1f
build_gapi_standalone:Win64=ade-0.1.1f
build_gapi_standalone:Mac=ade-0.1.1f
build_gapi_standalone:Linux x64 Debug=ade-0.1.1f
build_gapi_standalone:Custom Win=ade-0.1.1f

```