### PR TITLE
objdetect: fix wrong condition check

### DIFF
--- a/modules/objdetect/src/qrcode.cpp
+++ b/modules/objdetect/src/qrcode.cpp
@@ -32,7 +32,7 @@ static bool checkQRInputImage(InputArray img, Mat& gray)
         return false;  // image data is not enough for providing reliable results
     }
     int incn = img.channels();
-    CV_Check(incn, incn == 1 || incn == 3 || incn == 3, "");
+    CV_Check(incn, incn == 1 || incn == 3 || incn == 4, "");
     if (incn == 3 || incn == 4)
     {
         cvtColor(img, gray, COLOR_BGR2GRAY);


### PR DESCRIPTION
I'm quite sure that this is a typo

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under OpenCV (BSD) License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [x] The PR is proposed to proper branch
- [ ] There is reference to original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
