### PR TITLE
Flexible inputs for OpenVINO IR models

### DIFF
--- a/modules/dnn/src/dnn.cpp
+++ b/modules/dnn/src/dnn.cpp
@@ -1629,6 +1629,7 @@ struct Net::Impl
 
             Ptr<InfEngineBackendNode> ieNode = node.dynamicCast<InfEngineBackendNode>();
             CV_Assert(!ieNode.empty());
+            ieNode->net->reset();
 
             for (it = layers.begin(); it != layers.end(); ++it)
             {
@@ -1930,6 +1931,7 @@ struct Net::Impl
 
             Ptr<InfEngineNgraphNode> ieNode = node.dynamicCast<InfEngineNgraphNode>();
             CV_Assert(!ieNode.empty());
+            ieNode->net->reset();
 
             for (it = layers.begin(); it != layers.end(); ++it)
             {

--- a/modules/dnn/src/ie_ngraph.cpp
+++ b/modules/dnn/src/ie_ngraph.cpp
@@ -780,6 +780,13 @@ void forwardNgraph(const std::vector<Ptr<BackendWrapper> >& outBlobsWrappers,
     ieNode->net->forward(outBlobsWrappers, isAsync);
 }
 
+void InfEngineNgraphNet::reset()
+{
+    allBlobs.clear();
+    infRequests.clear();
+    isInit = false;
+}
+
 void InfEngineNgraphNet::addBlobs(const std::vector<cv::Ptr<BackendWrapper> >& ptrs)
 {
     auto wrappers = ngraphWrappers(ptrs);

--- a/modules/dnn/src/ie_ngraph.hpp
+++ b/modules/dnn/src/ie_ngraph.hpp
@@ -52,6 +52,8 @@ public:
 
     void createNet(Target targetId);
     void setNodePtr(std::shared_ptr<ngraph::Node>* ptr);
+
+    void reset();
 private:
     void release();
     int getNumComponents();

--- a/modules/dnn/src/op_inf_engine.cpp
+++ b/modules/dnn/src/op_inf_engine.cpp
@@ -891,6 +891,13 @@ bool InfEngineBackendNet::isInitialized()
 #endif
 }
 
+void InfEngineBackendNet::reset()
+{
+    allBlobs.clear();
+    infRequests.clear();
+    isInit = false;
+}
+
 void InfEngineBackendNet::addBlobs(const std::vector<cv::Ptr<BackendWrapper> >& ptrs)
 {
     auto wrappers = infEngineWrappers(ptrs);

--- a/modules/dnn/src/op_inf_engine.hpp
+++ b/modules/dnn/src/op_inf_engine.hpp
@@ -112,6 +112,8 @@ public:
 
     void addBlobs(const std::vector<cv::Ptr<BackendWrapper> >& ptrs);
 
+    void reset();
+
 private:
     InferenceEngine::Builder::Network netBuilder;
 

--- a/modules/dnn/test/test_misc.cpp
+++ b/modules/dnn/test/test_misc.cpp
@@ -760,6 +760,48 @@ TEST_P(Test_Model_Optimizer, readFromBuffer)
     normAssert(ref, actual, "", 0, 0);
 }
 
+TEST_P(Test_Model_Optimizer, flexible_inputs)
+{
+    const Backend backendId = get<0>(GetParam());
+    const Target targetId = get<1>(GetParam());
+
+    const std::string& model = findDataFile("dnn/layers/layer_convolution_fp16.bin");
+    const std::string& proto = findDataFile("dnn/layers/layer_convolution_fp16.xml");
+
+    if (backendId == DNN_BACKEND_INFERENCE_ENGINE_NN_BUILDER_2019)
+        setInferenceEngineBackendType(CV_DNN_BACKEND_INFERENCE_ENGINE_NN_BUILDER_API);
+    else if (backendId == DNN_BACKEND_INFERENCE_ENGINE_NGRAPH)
+        setInferenceEngineBackendType(CV_DNN_BACKEND_INFERENCE_ENGINE_NGRAPH);
+    else
+        FAIL() << "Unknown backendId";
+
+    Net net0 = readNet(model, proto);
+    net0.setPreferableTarget(targetId);
+
+    Net net1 = readNet(model, proto);
+    net1.setPreferableTarget(targetId);
+
+    // Generate inputs.
+    int blobSize0[] = {2, 6, 75, 113};
+    Mat input0(4, &blobSize0[0], CV_32F);
+    randu(input0, 0, 255);
+
+    net0.setInput(input0);
+    Mat ref = net0.forward().clone();
+
+    int blobSize1[] = {1, 6, 10, 9};
+    Mat input1(4, &blobSize1[0], CV_32F);
+    randu(input1, 0, 255);
+
+    net1.setInput(input1);
+    Mat out = net1.forward();
+    EXPECT_NE(out.size, ref.size);
+
+    net1.setInput(input0);
+    out = net1.forward();
+    normAssert(ref, out, 0, 0);
+}
+
 INSTANTIATE_TEST_CASE_P(/**/, Test_Model_Optimizer,
     dnnBackendsAndTargetsIE()
 );


### PR DESCRIPTION
Support flexible inputs for OpenVINO IR models. We can work with non-default IR input resolutions but not with flexible inputs which may change between runs.

<cut/>

```
force_builders=Custom,Custom Win,Custom Mac
build_image:Custom=ubuntu-openvino-2020.1.0:16.04
build_image:Custom Win=openvino-2020.1.0
build_image:Custom Mac=openvino-2020.1.0

test_modules:Custom=dnn,python2,python3,java
test_modules:Custom Win=dnn,python2,python3,java
test_modules:Custom Mac=dnn,python2,python3,java

buildworker:Custom=linux-1
# disabled due high memory usage: test_opencl:Custom=ON
test_opencl:Custom=OFF
test_bigdata:Custom=1
test_filter:Custom=*
```