### PR TITLE
Point Polygon Test Demo : resolved tuple error

### DIFF
--- a/samples/python/tutorial_code/ShapeDescriptors/point_polygon_test/pointPolygonTest_demo.py
+++ b/samples/python/tutorial_code/ShapeDescriptors/point_polygon_test/pointPolygonTest_demo.py
@@ -46,7 +46,7 @@ for i in range(src.shape[0]):
             drawing[i,j,1] = 255
             drawing[i,j,2] = 255
 
-cv.circle(drawing,maxDistPt, int(maxVal),tuple(255,255,255), 1, cv.LINE_8, 0)
+cv.circle(drawing,maxDistPt, int(maxVal),(255,255,255), 1, cv.LINE_8, 0)
 cv.imshow('Source', src)
 cv.imshow('Distance and inscribed circle', drawing)
 cv.waitKey()


### PR DESCRIPTION
resolves #17070

fixed a `TypeError` caused by incorrect use of `tuple()`.  As mentioned by @qingshihuangdi, python expects `tuple([255,255,255])` rather than `tuple(255,255,255)`.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under OpenCV (BSD) License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [x] The PR is proposed to proper branch
- [x] There is reference to original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
