### PR TITLE
Fixed "strange" formulas in the documentation for master branch

### DIFF
--- a/modules/gapi/include/opencv2/gapi/imgproc.hpp
+++ b/modules/gapi/include/opencv2/gapi/imgproc.hpp
@@ -305,7 +305,7 @@ according to the specified border mode.
 
 The function does actually compute correlation, not the convolution:
 
-\f[\texttt{dst} (x,y) =  \sum _{ \stackrel{0\leq x' < \texttt{kernel.cols},}{0\leq y' < \texttt{kernel.rows}} }  \texttt{kernel} (x',y')* \texttt{src} (x+x'- \texttt{anchor.x} ,y+y'- \texttt{anchor.y} )\f]
+\f[\texttt{dst} (x,y) =  \sum _{ \substack{0\leq x' < \texttt{kernel.cols}\\{0\leq y' < \texttt{kernel.rows}}}}  \texttt{kernel} (x',y')* \texttt{src} (x+x'- \texttt{anchor.x} ,y+y'- \texttt{anchor.y} )\f]
 
 That is, the kernel is not mirrored around the anchor point. If you need a real convolution, flip
 the kernel using flip and set the new anchor to `(kernel.cols - anchor.x - 1, kernel.rows -
@@ -342,7 +342,7 @@ The function smooths an image using the kernel:
 
 where
 
-\f[\alpha = \fork{\frac{1}{\texttt{ksize.width*ksize.height}}}{when \texttt{normalize=true}}{1}{otherwise}\f]
+\f[\alpha = \begin{cases} \frac{1}{\texttt{ksize.width*ksize.height}} & \texttt{when } \texttt{normalize=true}  \\1 & \texttt{otherwise} \end{cases}\f]
 
 Unnormalized box filter is useful for computing various integral characteristics over each pixel
 neighborhood, such as covariance matrices of image derivatives (used in dense optical flow


### PR DESCRIPTION
Resolves #16987 

Here are new outputs:

6. https://docs.opencv.org/4.3.0/da/dc5/group__gapi__filters.html: remaining texttt command
<img width="313" alt="6" src="https://user-images.githubusercontent.com/20969920/79858998-ee7eda00-83ed-11ea-9a94-86988b35c3b2.PNG">

7.  https://docs.opencv.org/4.3.0/da/dc5/group__gapi__filters.html: different size underneath sum symbol
<img width="497" alt="7" src="https://user-images.githubusercontent.com/20969920/79859018-f63e7e80-83ed-11ea-885b-9364d9efb971.PNG">

1, 2, 3, 4, 5, 8 are fixed in #17123 #17123
