### PR TITLE
videoio: load debug versions of plug-ins in debug builds

### DIFF
--- a/modules/videoio/CMakeLists.txt
+++ b/modules/videoio/CMakeLists.txt
@@ -31,6 +31,10 @@ file(GLOB videoio_ext_hdrs
   "${CMAKE_CURRENT_LIST_DIR}/include/opencv2/${name}/*.h"
   "${CMAKE_CURRENT_LIST_DIR}/include/opencv2/${name}/legacy/*.h")
 
+if(OPENCV_DEBUG_POSTFIX)
+  ocv_append_source_file_compile_definitions("${CMAKE_CURRENT_LIST_DIR}/src/backend_plugin.cpp" "DEBUG_POSTFIX=${OPENCV_DEBUG_POSTFIX}")
+endif()
+
 # Removing WinRT API headers by default
 list(REMOVE_ITEM videoio_ext_hdrs "${CMAKE_CURRENT_LIST_DIR}/include/opencv2/${name}/cap_winrt.hpp")
 

--- a/modules/videoio/cmake/plugin.cmake
+++ b/modules/videoio/cmake/plugin.cmake
@@ -40,6 +40,7 @@ function(ocv_create_builtin_videoio_plugin name target)
   set_target_properties(${name} PROPERTIES
     CXX_STANDARD 11
     CXX_VISIBILITY_PRESET hidden
+    DEBUG_POSTFIX "${OPENCV_DEBUG_POSTFIX}"
     OUTPUT_NAME "${name}${OPENCV_PLUGIN_VERSION}${OPENCV_PLUGIN_ARCH}"
   )
 

--- a/modules/videoio/src/backend_plugin.cpp
+++ b/modules/videoio/src/backend_plugin.cpp
@@ -124,6 +124,9 @@ std::string librarySuffix()
     #if (defined _MSC_VER && defined _M_X64) || (defined __GNUC__ && defined __x86_64__)
         "_64"
     #endif
+    #if defined(_DEBUG) && defined(DEBUG_POSTFIX)
+        CVAUX_STR(DEBUG_POSTFIX)
+    #endif
         ".dll";
     return suffix;
 #else
@@ -338,6 +341,19 @@ std::vector<FileSystemPath_t> getPluginCandidates(const std::string& baseName)
         results.push_back(path + L"\\" + moduleName);
     }
     results.push_back(moduleName);
+#if defined(_DEBUG) && defined(DEBUG_POSTFIX)
+    if (baseName_u == "FFMPEG")  // backward compatibility
+    {
+        const FileSystemPath_t templ = toFileSystemPath(CVAUX_STR(DEBUG_POSTFIX) ".dll");
+        FileSystemPath_t nonDebugName(moduleName);
+        size_t suf = nonDebugName.rfind(templ);
+        if (suf != FileSystemPath_t::npos)
+        {
+            nonDebugName.replace(suf, suf + templ.size(), L".dll");
+            results.push_back(nonDebugName);
+        }
+    }
+#endif // _DEBUG && DEBUG_POSTFIX
 #else
     CV_LOG_INFO(NULL, "VideoIO pluigin (" << baseName << "): glob is '" << plugin_expr << "', " << paths.size() << " location(s)");
     for (const string & path : paths)


### PR DESCRIPTION
- added suffix to debug versions of videoio plug-ins
- trying to load plug-ins with `d` suffix in debug builds

Note: FFmpeg plug-in does not work because it does not have debug version, but the file can be renamed or forced via environment and then it will work (more or less)

Validated debug builds:
- [Win64](http://pullrequest.opencv.org/buildbot/builders/precommit_opencl/builds/24118)
- [Win32](http://pullrequest.opencv.org/buildbot/builders/precommit_windows32/builds/12399)

<cut/>

```
# no plugins in Custom builds (except forced FFmpeg)
build_debug:Custom Win=ON
test_modules:Custom Win=videoio

Xbuild_debug:Win64 OpenCL=ON
Xtest_modules:Win64 OpenCL=videoio

build_debug:Win32=ON
test_modules:Win32=videoio
**WIP**
```