### PR TITLE
Fixed "strange" formulas in the documentation for 3.4 branch

### DIFF
--- a/doc/tutorials/ml/non_linear_svms/non_linear_svms.markdown
+++ b/doc/tutorials/ml/non_linear_svms/non_linear_svms.markdown
@@ -43,7 +43,7 @@ There are multiple ways in which this model can be modified so it takes into acc
 misclassification errors. For example, one could think of minimizing the same quantity plus a
 constant times the number of misclassification errors in the training data, i.e.:
 
-\f[\min ||\beta||^{2} + C \text{(\# misclassication errors)}\f]
+\f[\min ||\beta||^{2} + C \text{(misclassification errors)}\f]
 
 However, this one is not a very good solution since, among some other reasons, we do not distinguish
 between samples that are misclassified with a small distance to their appropriate decision region or

--- a/modules/calib3d/include/opencv2/calib3d.hpp
+++ b/modules/calib3d/include/opencv2/calib3d.hpp
@@ -1760,7 +1760,7 @@ Optionally, it computes the essential matrix E:
 where \f$T_i\f$ are components of the translation vector \f$T\f$ : \f$T=[T_0, T_1, T_2]^T\f$ .
 And the function can also compute the fundamental matrix F:
 
-\f[F = cameraMatrix2^{-T} E cameraMatrix1^{-1}\f]
+\f[F = cameraMatrix2^{-T}\cdot E \cdot cameraMatrix1^{-1}\f]
 
 Besides the stereo-related information, the function can also perform a full calibration of each of
 the two cameras. However, due to the high dimensionality of the parameter space and noise in the

--- a/modules/imgproc/include/opencv2/imgproc.hpp
+++ b/modules/imgproc/include/opencv2/imgproc.hpp
@@ -226,7 +226,7 @@ enum MorphTypes{
 enum MorphShapes {
     MORPH_RECT    = 0, //!< a rectangular structuring element:  \f[E_{ij}=1\f]
     MORPH_CROSS   = 1, //!< a cross-shaped structuring element:
-                       //!< \f[E_{ij} =  \fork{1}{if i=\texttt{anchor.y} or j=\texttt{anchor.x}}{0}{otherwise}\f]
+                       //!< \f[E_{ij} = \begin{cases} 1 & \texttt{if } {i=\texttt{anchor.y } {or } {j=\texttt{anchor.x}}} \\0 & \texttt{otherwise} \end{cases}\f]
     MORPH_ELLIPSE = 2 //!< an elliptic structuring element, that is, a filled ellipse inscribed
                       //!< into the rectangle Rect(0, 0, esize.width, 0.esize.height)
 };
@@ -1457,7 +1457,7 @@ The function smooths an image using the kernel:
 
 where
 
-\f[\alpha = \fork{\frac{1}{\texttt{ksize.width*ksize.height}}}{when \texttt{normalize=true}}{1}{otherwise}\f]
+\f[\alpha = \begin{cases} \frac{1}{\texttt{ksize.width*ksize.height}} & \texttt{when } \texttt{normalize=true}  \\1 & \texttt{otherwise}\end{cases}\f]
 
 Unnormalized box filter is useful for computing various integral characteristics over each pixel
 neighborhood, such as covariance matrices of image derivatives (used in dense optical flow
@@ -1531,7 +1531,7 @@ according to the specified border mode.
 
 The function does actually compute correlation, not the convolution:
 
-\f[\texttt{dst} (x,y) =  \sum _{ \stackrel{0\leq x' < \texttt{kernel.cols},}{0\leq y' < \texttt{kernel.rows}} }  \texttt{kernel} (x',y')* \texttt{src} (x+x'- \texttt{anchor.x} ,y+y'- \texttt{anchor.y} )\f]
+\f[\texttt{dst} (x,y) =  \sum _{ \substack{0\leq x' < \texttt{kernel.cols}\\{0\leq y' < \texttt{kernel.rows}}}}  \texttt{kernel} (x',y')* \texttt{src} (x+x'- \texttt{anchor.x} ,y+y'- \texttt{anchor.y} )\f]
 
 That is, the kernel is not mirrored around the anchor point. If you need a real convolution, flip
 the kernel using #flip and set the new anchor to `(kernel.cols - anchor.x - 1, kernel.rows -

--- a/modules/video/include/opencv2/video/tracking.hpp
+++ b/modules/video/include/opencv2/video/tracking.hpp
@@ -308,7 +308,7 @@ Default values are shown in the declaration above.
 The function estimates the optimum transformation (warpMatrix) with respect to ECC criterion
 (@cite EP08), that is
 
-\f[\texttt{warpMatrix} = \texttt{warpMatrix} = \arg\max_{W} \texttt{ECC}(\texttt{templateImage}(x,y),\texttt{inputImage}(x',y'))\f]
+\f[\texttt{warpMatrix} = \arg\max_{W} \texttt{ECC}(\texttt{templateImage}(x,y),\texttt{inputImage}(x',y'))\f]
 
 where
 


### PR DESCRIPTION
Resolves #16987 

Here are new outputs:

1. https://docs.opencv.org/4.3.0/d0/dcc/tutorial_non_linear_svms.html: backslash
<img width="237" alt="1" src="https://user-images.githubusercontent.com/20969920/79858924-c98a6700-83ed-11ea-9a8a-59bae640c4f4.PNG">

2. https://docs.opencv.org/4.3.0/d4/d86/group__imgproc__filter.html: remaining texttt command
<img width="271" alt="2" src="https://user-images.githubusercontent.com/20969920/79858900-c000ff00-83ed-11ea-9092-fc4f7bf24a7f.PNG">

3. https://docs.opencv.org/4.3.0/d4/d86/group__imgproc__filter.html: remaining texttt command
<img width="323" alt="3" src="https://user-images.githubusercontent.com/20969920/79858949-d73fec80-83ed-11ea-9e25-9b91276277fb.PNG">

4.  https://docs.opencv.org/4.3.0/d4/d86/group__imgproc__filter.html: different size underneath sum symbol
<img width="495" alt="4" src="https://user-images.githubusercontent.com/20969920/79858963-df982780-83ed-11ea-964d-d6c230ef630e.PNG">

5.  https://docs.opencv.org/4.3.0/d9/d0c/group__calib3d.html: probably missing some \cdot around the E
<img width="269" alt="5" src="https://user-images.githubusercontent.com/20969920/79858979-e757cc00-83ed-11ea-87d3-3ef5f1afbe0e.PNG">

8.  https://docs.opencv.org/4.3.0/dc/d6b/group__video__track.html: twice warpMatrix
<img width="400" alt="8" src="https://user-images.githubusercontent.com/20969920/79859036-fcccf600-83ed-11ea-8a16-539386217671.PNG">

Formulas 6 and 7 are fixed in #17120 
