### PR TITLE
GAPI: fix build, update IE handling, add OPENCV_GAPI_INF_ENGINE

### DIFF
--- a/modules/gapi/CMakeLists.txt
+++ b/modules/gapi/CMakeLists.txt
@@ -13,6 +13,10 @@ if(NOT TARGET ade)
   return()
 endif()
 
+if(INF_ENGINE_TARGET)
+  ocv_option(OPENCV_GAPI_INF_ENGINE "Build GraphAPI module with Inference Engine support" ON)
+endif()
+
 set(the_description "OpenCV G-API Core Module")
 
 ocv_add_module(gapi
@@ -139,12 +143,19 @@ ocv_module_include_directories("${CMAKE_CURRENT_LIST_DIR}/src")
 
 ocv_create_module()
 
-ocv_target_link_libraries(${the_module} PRIVATE ade ${INF_ENGINE_TARGET})
+ocv_target_link_libraries(${the_module} PRIVATE ade)
+if(OPENCV_GAPI_INF_ENGINE)
+  ocv_target_link_libraries(${the_module} PRIVATE ${INF_ENGINE_TARGET})
+endif()
 if(HAVE_TBB)
   ocv_target_link_libraries(${the_module} PRIVATE tbb)
 endif()
 
-ocv_add_accuracy_tests(${INF_ENGINE_TARGET})
+set(__test_extra_deps "")
+if(OPENCV_GAPI_INF_ENGINE)
+  list(APPEND __test_extra_deps ${INF_ENGINE_TARGET})
+endif()
+ocv_add_accuracy_tests(${__test_extra_deps})
 # FIXME: test binary is linked with ADE directly since ADE symbols
 # are not exported from libopencv_gapi.so in any form - thus
 # there're two copies of ADE code in memory when tests run (!)

--- a/modules/gapi/include/opencv2/gapi/own/convert.hpp
+++ b/modules/gapi/include/opencv2/gapi/own/convert.hpp
@@ -25,23 +25,27 @@ namespace cv
         return result;
     }
 
-           cv::gapi::own::Mat to_own(Mat&&) = delete;
+    cv::gapi::own::Mat to_own(Mat&&) = delete;
 
     inline cv::gapi::own::Mat to_own(Mat const& m) {
         return (m.dims == 2)
             ?  cv::gapi::own::Mat{m.rows, m.cols, m.type(), m.data, m.step}
             :  cv::gapi::own::Mat{to_own<int>(m.size), m.type(), m.data};
     };
+
 namespace gapi
 {
 namespace own
 {
+
     inline cv::Mat to_ocv(Mat const& m) {
         return m.dims.empty()
             ? cv::Mat{m.rows, m.cols, m.type(), m.data, m.step}
             : cv::Mat{m.dims, m.type(), m.data};
     }
-           cv::Mat to_ocv(Mat&&)    = delete;
+
+    cv::Mat to_ocv(Mat&&) = delete;
+
 } // namespace own
 } // namespace gapi
 } // namespace cv

--- a/modules/gapi/src/backends/ie/giebackend.cpp
+++ b/modules/gapi/src/backends/ie/giebackend.cpp
@@ -35,6 +35,7 @@
 #include <opencv2/gapi/util/any.hpp>
 #include <opencv2/gapi/gtype_traits.hpp>
 #include <opencv2/gapi/infer.hpp>
+#include <opencv2/gapi/own/convert.hpp>
 
 #include "compiler/gobjref.hpp"
 #include "compiler/gmodel.hpp"
@@ -211,6 +212,7 @@ struct IEUnit {
     cv::gimpl::ie::IECompiled compile() const {
         auto this_plugin = IE::PluginDispatcher().getPluginByDevice(params.device_id);
 
+#if INF_ENGINE_RELEASE < 2020000000  // <= 2019.R3
         // Load extensions (taken from DNN module)
         if (params.device_id == "CPU" || params.device_id == "FPGA")
         {
@@ -247,10 +249,11 @@ struct IEUnit {
                 }
                 catch(...)
                 {
-                    CV_LOG_WARNING(NULL, "Failed to load IE extension " << extlib);
+                    CV_LOG_INFO(NULL, "Failed to load IE extension: " << extlib);
                 }
             }
         }
+#endif
 
         auto this_network = this_plugin.LoadNetwork(net, {}); // FIXME: 2nd parameter to be
                                                               // configurable via the API
@@ -514,7 +517,7 @@ struct Infer: public cv::detail::KernelTag {
             // and redirect our data producers to this memory
             // (A memory dialog comes to the picture again)
 
-            const cv::Mat this_mat = to_ocv(ctx.inMat(i));
+            const cv::Mat this_mat = ctx.inMat(i);
             // FIXME: By default here we trait our inputs as images.
             // May be we need to make some more intelligence here about it
             IE::Blob::Ptr this_blob = wrapIE(this_mat, cv::gapi::ie::TraitAs::IMAGE);
@@ -586,7 +589,7 @@ struct InferList: public cv::detail::KernelTag {
         GAPI_Assert(uu.params.num_in == 1); // roi list is not counted in net's inputs
 
         const auto& in_roi_vec = ctx.inArg<cv::detail::VectorRef>(0u).rref<cv::Rect>();
-        const cv::Mat this_mat = to_ocv(ctx.inMat(1u));
+        const cv::Mat this_mat = ctx.inMat(1u);
         // Since we do a ROI list inference, always assume our input buffer is image
         IE::Blob::Ptr this_blob = wrapIE(this_mat, cv::gapi::ie::TraitAs::IMAGE);
 


### PR DESCRIPTION
relates #16995

<cut/>

```
build_gapi_standalone:Linux x64=ade-0.1.1f
build_gapi_standalone:Win64=ade-0.1.1f
build_gapi_standalone:Mac=ade-0.1.1f
build_gapi_standalone:Linux x64 Debug=ade-0.1.1f
Xforce_builders=Custom
buildworker:Custom=linux-1
build_image:Custom=plaidml2
test_modules:Custom=gapi
test_filter:Custom=*ML* 

force_builders=Custom,Custom Win,Custom Mac
Xbuild_image:Custom=ubuntu-openvino-2020.1.0:16.04
build_image:Custom Win=openvino-2019r3.0
build_image:Custom Mac=openvino-2020.1.0

Xtest_modules:Custom=gapi
test_modules:Custom Win=gapi
test_modules:Custom Mac=gapi

Xbuildworker:Custom=linux-1
# disabled due high memory usage: test_opencl:Custom=ON
Xtest_opencl:Custom=OFF
Xtest_bigdata:Custom=1
Xtest_filter:Custom=*

test_bigdata:Custom Win=1
test_filter:Custom Win=*
```