### PR TITLE
cuda4dnn(Slice): handle case where no slicing is required

### DIFF
--- a/modules/dnn/src/cuda4dnn/primitives/slice.hpp
+++ b/modules/dnn/src/cuda4dnn/primitives/slice.hpp
@@ -10,11 +10,13 @@
 #include "../csl/stream.hpp"
 
 #include "../kernels/slice.hpp"
+#include "../kernels/fill_copy.hpp"
 
 #include <opencv2/core.hpp>
 
 #include <cstddef>
 #include <vector>
+#include <algorithm>
 #include <utility>
 
 namespace cv { namespace dnn { namespace cuda4dnn {
@@ -42,6 +44,22 @@ namespace cv { namespace dnn { namespace cuda4dnn {
 
             auto input_wrapper = inputs[0].dynamicCast<wrapper_type>();
             auto input = input_wrapper->getView();
+
+            CV_Assert(offsets.size() == outputs.size());
+
+            /* one output with the same shape as the input => direct copy */
+            if (outputs.size() == 1)
+            {
+                auto output_wrapper = outputs[0].dynamicCast<wrapper_type>();
+                auto output = output_wrapper->getSpan();
+
+                if (is_shape_same(output, input))
+                {
+                    CV_Assert(std::all_of(std::begin(offsets[0]), std::end(offsets[0]), [] (std::size_t x) { return x == 0; }));
+                    kernels::copy<T>(stream, output, input);
+                    return;
+                }
+            }
 
             for (int i = 0; i < outputs.size(); ++i)
             {


### PR DESCRIPTION
### Pull Request Readiness Checklist

resolves #17116 

details: https://github.com/opencv/opencv/issues/17116#issuecomment-618828526

<cut/>

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under OpenCV (BSD) License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [x] The PR is proposed to proper branch
- [x] There is reference to original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake

```
force_builders=Custom
buildworker:Custom=linux-4
build_image:Custom=ubuntu-cuda:18.04
```
