### PR TITLE
Support Yolov4

### DIFF
--- a/modules/dnn/src/layers/elementwise_layers.cpp
+++ b/modules/dnn/src/layers/elementwise_layers.cpp
@@ -654,19 +654,11 @@ struct SwishFunctor : public BaseFunctor
 struct MishFunctor : public BaseFunctor
 {
     typedef MishLayer Layer;
-    float MISH_THRESHOLD;
-
-    MishFunctor() : MISH_THRESHOLD(20.0f) {}
 
     bool supportBackend(int backendId, int)
     {
-        // op::v1::Greater
-#ifdef HAVE_DNN_NGRAPH
-        if (backendId == DNN_BACKEND_INFERENCE_ENGINE_NGRAPH)
-            return INF_ENGINE_VER_MAJOR_GT(INF_ENGINE_RELEASE_2020_2);
-#endif
-
-        return backendId == DNN_BACKEND_OPENCV || backendId == DNN_BACKEND_HALIDE;
+        return backendId == DNN_BACKEND_OPENCV ||
+               backendId == DNN_BACKEND_HALIDE || backendId == DNN_BACKEND_INFERENCE_ENGINE_NGRAPH;
     }
 
     void apply(const float* srcptr, float* dstptr, int len, size_t planeSize, int cn0, int cn1) const

--- a/modules/dnn/src/layers/elementwise_layers.cpp
+++ b/modules/dnn/src/layers/elementwise_layers.cpp
@@ -676,14 +676,7 @@ struct MishFunctor : public BaseFunctor
             for( int i = 0; i < len; i++ )
             {
                 float x = srcptr[i];
-                float softplus;
-                if (x > MISH_THRESHOLD)
-                    softplus = x;
-                else if (x < -MISH_THRESHOLD)
-                    softplus = exp(x);
-                else
-                    softplus = log(1.0f + exp(x));
-                dstptr[i] = x * tanh(softplus);
+                dstptr[i] = x * tanh(log(1.0f + exp(x)));
             }
         }
     }
@@ -734,19 +727,12 @@ struct MishFunctor : public BaseFunctor
 #ifdef HAVE_DNN_NGRAPH
     std::shared_ptr<ngraph::Node> initNgraphAPI(const std::shared_ptr<ngraph::Node>& node)
     {
-        auto neg_thresh_node = std::make_shared<ngraph::op::Constant>(ngraph::element::f32, ngraph::Shape{1}, std::vector<float>{-MISH_THRESHOLD});
-        auto mask_LT = std::make_shared<ngraph::op::v1::Less>(node, neg_thresh_node);
+        float one = 1.0f;
+        auto constant = std::make_shared<ngraph::op::Constant>(ngraph::element::f32, ngraph::Shape{1}, &one);
         auto exp_node = std::make_shared<ngraph::op::v0::Exp>(node);
-
-        auto constant = std::make_shared<ngraph::op::Constant>(ngraph::element::f32, ngraph::Shape{1}, std::vector<float>{1});
         auto sum = std::make_shared<ngraph::op::v1::Add>(constant, exp_node, ngraph::op::AutoBroadcastType::NUMPY);
         auto log_node = std::make_shared<ngraph::op::v0::Log>(sum);
-        auto select = std::make_shared<ngraph::op::v1::Select>(mask_LT, exp_node, log_node);
-
-        auto thresh_node = std::make_shared<ngraph::op::Constant>(ngraph::element::f32, ngraph::Shape{1}, &MISH_THRESHOLD);
-        auto mask_GT = std::make_shared<ngraph::op::v1::Greater>(node, thresh_node);
-        auto softplus = std::make_shared<ngraph::op::v1::Select>(mask_GT, node, select);
-        auto tanh_node = std::make_shared<ngraph::op::Tanh>(softplus);
+        auto tanh_node = std::make_shared<ngraph::op::Tanh>(log_node);
         return std::make_shared<ngraph::op::v1::Multiply>(node, tanh_node);
     }
 #endif  // HAVE_DNN_NGRAPH

--- a/modules/dnn/src/layers/elementwise_layers.cpp
+++ b/modules/dnn/src/layers/elementwise_layers.cpp
@@ -660,8 +660,13 @@ struct MishFunctor : public BaseFunctor
 
     bool supportBackend(int backendId, int)
     {
-        return backendId == DNN_BACKEND_OPENCV ||
-               backendId == DNN_BACKEND_HALIDE || backendId == DNN_BACKEND_INFERENCE_ENGINE_NGRAPH;
+        // op::v1::Greater
+#ifdef HAVE_DNN_NGRAPH
+        if (backendId == DNN_BACKEND_INFERENCE_ENGINE_NGRAPH)
+            return INF_ENGINE_VER_MAJOR_GT(INF_ENGINE_RELEASE_2020_2);
+#endif
+
+        return backendId == DNN_BACKEND_OPENCV || backendId == DNN_BACKEND_HALIDE;
     }
 
     void apply(const float* srcptr, float* dstptr, int len, size_t planeSize, int cn0, int cn1) const

--- a/modules/dnn/test/test_darknet_importer.cpp
+++ b/modules/dnn/test/test_darknet_importer.cpp
@@ -523,6 +523,11 @@ TEST_P(Test_Darknet_layers, upsample)
     testDarknetLayer("upsample");
 }
 
+TEST_P(Test_Darknet_layers, mish)
+{
+    testDarknetLayer("mish", true);
+}
+
 TEST_P(Test_Darknet_layers, avgpool_softmax)
 {
     testDarknetLayer("avgpool_softmax");


### PR DESCRIPTION
**Merge with extra:** opencv/opencv_extra#753
resolves: #17148 

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [ ] I agree to contribute to the project under OpenCV (BSD) License.
- [ ] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [ ] The PR is proposed to proper branch
- [ ] There is reference to original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake


```
force_builders=Custom,Custom Win,Custom Mac
build_image:Custom=ubuntu-openvino-2020.1.0:16.04
build_image:Custom Win=openvino-2020.2.0
build_image:Custom Mac=openvino-2020.2.0

test_modules:Custom=dnn,python2,python3,java
test_modules:Custom Win=dnn,python2,python3,java
test_modules:Custom Mac=dnn,python2,python3,java

buildworker:Custom=linux-1
# disabled due high memory usage: test_opencl:Custom=ON
test_opencl:Custom=OFF
test_bigdata:Custom=1
test_filter:Custom=*
```
**Performance tests**
**CPU:** Intel(R) Core(TM) i5-6500 CPU @ 3.20GHz
| Net               | Backend                      | branch 3.4 | branch yolov4 |
|-------------------|------------------------------|------------|---------------|
| TinyYoloVOC       | DNN_BACKEND_INFERENCE_ENGINE | 23.29      | 23.15         |
| TinyYoloVOC       | DNN_BACKEND_OPENCV           | 35.24      | 35.29         |
| YoloVOC @ 416x416 | DNN_BACKEND_INFERENCE_ENGINE | 88.42      | 88.54         |
| YoloVOC @ 416x416 | DNN_BACKEND_OPENCV           | 129.50     | 130.03        |
| YOLOv3 @ 416x416  | DNN_BACKEND_INFERENCE_ENGINE | 200.76     | 200.93        |
| YOLOv3 @ 416x416  | DNN_BACKEND_OPENCV           | 273.93     | 274.48        |
| YOLOv4 @ 416x416  | DNN_BACKEND_INFERENCE_ENGINE |      -     | 537.48        |
| YOLOv4 @ 416x416  | DNN_BACKEND_OPENCV           |      -     | 712.38        |


```python
import cv2 as cv

net = cv.dnn_DetectionModel(yolov4.cfg', 'yolov4.weights)
net.setInputSize(608, 608)
net.setInputScale(1.0 / 255)
net.setInputSwapRB(True)

frame = cv.imread('example.jpg')

with open('coco.names', 'rt') as f:
    names = f.read().rstrip('\n').split('\n')

classes, confidences, boxes = net.detect(frame, confThreshold=0.1, nmsThreshold=0.4)
for classId, confidence, box in zip(classes.flatten(), confidences.flatten(), boxes):
    label = '%.2f' % confidence
    label = '%s: %s' % (names[classId], label)
    labelSize, baseLine = cv.getTextSize(label, cv.FONT_HERSHEY_SIMPLEX, 0.5, 1)
    left, top, width, height = box
    top = max(top, labelSize[1])
    cv.rectangle(frame, box, color=(0, 255, 0), thickness=3)
    cv.rectangle(frame, (left, top - labelSize[1]), (left + labelSize[0], top + baseLine), (255, 255, 255), cv.FILLED)
    cv.putText(frame, label, (left, top), cv.FONT_HERSHEY_SIMPLEX, 0.5, (0, 0, 0))

cv.imshow('out', frame)
```

![yolo_out](https://user-images.githubusercontent.com/22346860/80714290-68eddf00-8afd-11ea-8e9e-3e7ae6d79850.jpg)
