### PR TITLE
dnn(test): update skip tests on Win32 configuration

### DIFF
--- a/modules/dnn/test/test_onnx_importer.cpp
+++ b/modules/dnn/test/test_onnx_importer.cpp
@@ -534,7 +534,7 @@ public:
 
 TEST_P(Test_ONNX_nets, Alexnet)
 {
-#if defined(OPENCV_32BIT_CONFIGURATION) && defined(HAVE_OPENCL)
+#if defined(OPENCV_32BIT_CONFIGURATION) && (defined(HAVE_OPENCL) || defined(_WIN32))
     applyTestTag(CV_TEST_TAG_MEMORY_2GB);
 #else
     applyTestTag(target == DNN_TARGET_CPU ? CV_TEST_TAG_MEMORY_512MB : CV_TEST_TAG_MEMORY_1GB);
@@ -598,7 +598,7 @@ TEST_P(Test_ONNX_nets, Googlenet)
 
 TEST_P(Test_ONNX_nets, CaffeNet)
 {
-#if defined(OPENCV_32BIT_CONFIGURATION) && defined(HAVE_OPENCL)
+#if defined(OPENCV_32BIT_CONFIGURATION) && (defined(HAVE_OPENCL) || defined(_WIN32))
     applyTestTag(CV_TEST_TAG_MEMORY_2GB);
 #else
     applyTestTag(target == DNN_TARGET_CPU ? CV_TEST_TAG_MEMORY_512MB : CV_TEST_TAG_MEMORY_1GB);
@@ -614,7 +614,7 @@ TEST_P(Test_ONNX_nets, CaffeNet)
 
 TEST_P(Test_ONNX_nets, RCNN_ILSVRC13)
 {
-#if defined(OPENCV_32BIT_CONFIGURATION) && defined(HAVE_OPENCL)
+#if defined(OPENCV_32BIT_CONFIGURATION) && (defined(HAVE_OPENCL) || defined(_WIN32))
     applyTestTag(CV_TEST_TAG_MEMORY_2GB);
 #else
     applyTestTag(target == DNN_TARGET_CPU ? CV_TEST_TAG_MEMORY_512MB : CV_TEST_TAG_MEMORY_1GB);


### PR DESCRIPTION
relates #16629

<cut/>

Message:
```
[ RUN      ] Test_ONNX_nets.Alexnet/0, where GetParam() = OCV/CPU
unknown file: error: C++ exception with description "OpenCV(3.4.10-dev) C:\build\precommit_windows32\3.4\opencv\modules\core\src\alloc.cpp:73: error: (-4:Insufficient memory) Failed to allocate 150994944 bytes in function 'cv::OutOfMemoryError'
" thrown in the test body.
[  FAILED  ] Test_ONNX_nets.Alexnet/0, where GetParam() = OCV/CPU (1538 ms)
...
[ RUN      ] Test_ONNX_nets.CaffeNet/0, where GetParam() = OCV/CPU
unknown file: error: C++ exception with description "OpenCV(3.4.10-dev) C:\build\precommit_windows32\3.4\opencv\modules\core\src\alloc.cpp:73: error: (-4:Insufficient memory) Failed to allocate 150994944 bytes in function 'cv::OutOfMemoryError'
" thrown in the test body.
[  FAILED  ] Test_ONNX_nets.CaffeNet/0, where GetParam() = OCV/CPU (1525 ms)
[ RUN      ] Test_ONNX_nets.RCNN_ILSVRC13/0, where GetParam() = OCV/CPU
unknown file: error: C++ exception with description "OpenCV(3.4.10-dev) C:\build\precommit_windows32\3.4\opencv\modules\core\src\alloc.cpp:73: error: (-4:Insufficient memory) Failed to allocate 150994944 bytes in function 'cv::OutOfMemoryError'
" thrown in the test body.
[  FAILED  ] Test_ONNX_nets.RCNN_ILSVRC13/0, where GetParam() = OCV/CPU (1461 ms)
```

```
force_builders=Win32,Custom Win
build_image:Custom Win=msvs2015-win32
test_opencl:Custom Win=ON
```