### PR TITLE
cuda4dnn: optimizations for swish, mish, sigmoid, region, resize based ops, transpose, identity-conv fusion

### DIFF
--- a/modules/dnn/src/cuda/crop_and_resize.cu
+++ b/modules/dnn/src/cuda/crop_and_resize.cu
@@ -9,6 +9,7 @@
 #include "types.hpp"
 #include "grid_stride_range.hpp"
 #include "execution.hpp"
+#include "memory.hpp"
 
 #include "../cuda4dnn/csl/stream.hpp"
 #include "../cuda4dnn/csl/tensor.hpp"
@@ -102,10 +103,10 @@ namespace cv { namespace dnn { namespace cuda4dnn { namespace kernels {
 
                 #pragma unroll 1 /* disable unrolling */
                 for (int i = 0; i < CHANNELS_PER_ITER; i++) {
-                    auto v_00 = input[in_offset_r0 + in_x0],
-                         v_01 = input[in_offset_r0 + in_x1],
-                         v_10 = input[in_offset_r1 + in_x0],
-                         v_11 = input[in_offset_r1 + in_x1];
+                    auto v_00 = load_ldg(input[in_offset_r0 + in_x0]),
+                         v_01 = load_ldg(input[in_offset_r0 + in_x1]),
+                         v_10 = load_ldg(input[in_offset_r1 + in_x0]),
+                         v_11 = load_ldg(input[in_offset_r1 + in_x1]);
 
                     output[out_idx] =
                         v_00 +

--- a/modules/dnn/src/cuda/math.hpp
+++ b/modules/dnn/src/cuda/math.hpp
@@ -160,6 +160,15 @@ namespace cv { namespace dnn { namespace cuda4dnn { namespace csl { namespace de
     template <> inline __device__ __half2 ceil(__half2 value) { return h2ceil(value); }
 #endif
 
+    template <class T> __device__ T fast_divide(T x, T y) { return x / y; }
+    template <> inline __device__ float fast_divide(float x, float y) { return __fdividef(x, y); }
+
+    template <class T> __device__ T fast_exp(T value) { return exp(value); }
+    template <> inline __device__ float fast_exp(float value) { return __expf(value); }
+
+    template <class T> __device__ T fast_sigmoid(T value) { return sigmoid(value); }
+    template <> inline __device__ float fast_sigmoid(float value) { return __fdividef(1, 1 + __expf(-value)); }
+
 }}}}} /* namespace cv::dnn::cuda4dnn::csl::device */
 
 #endif /* OPENCV_DNN_SRC_CUDA_MATH_HPP */

--- a/modules/dnn/src/cuda/memory.hpp
+++ b/modules/dnn/src/cuda/memory.hpp
@@ -1,0 +1,32 @@
+// This file is part of OpenCV project.
+// It is subject to the license terms in the LICENSE file found in the top-level directory
+// of this distribution and at http://opencv.org/license.html.
+
+#ifndef OPENCV_DNN_SRC_CUDA_MEMORY_HPP
+#define OPENCV_DNN_SRC_CUDA_MEMORY_HPP
+
+#include <cuda_runtime.h>
+
+namespace cv { namespace dnn { namespace cuda4dnn { namespace csl { namespace device {
+
+template <class T>
+__device__ T load_ldg(const T& src) {
+#if defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 350)
+    return __ldg(&src);
+#else
+    return src;
+#endif
+}
+
+template <class T>
+__device__ T load_ldg(const T* src) {
+#if defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 350)
+    return __ldg(src);
+#else
+    return *src;
+#endif
+}
+
+}}}}} /* namespace cv::dnn::cuda4dnn::csl::device */
+
+#endif /* OPENCV_DNN_SRC_CUDA_MEMORY_HPP */

--- a/modules/dnn/src/cuda/resize.cu
+++ b/modules/dnn/src/cuda/resize.cu
@@ -9,6 +9,7 @@
 #include "types.hpp"
 #include "grid_stride_range.hpp"
 #include "execution.hpp"
+#include "memory.hpp"
 
 #include "../cuda4dnn/csl/stream.hpp"
 #include "../cuda4dnn/csl/tensor.hpp"
@@ -70,7 +71,7 @@ namespace cv { namespace dnn { namespace cuda4dnn { namespace kernels {
                 index_type out_idx = c_start * out_image_size + y * out_width + x;
 
                 for (int i = 0; i < CHANNELS_PER_ITER; i++) {
-                    output[out_idx] = input[in_idx];
+                    output[out_idx] = load_ldg(input[in_idx]);
 
                     in_idx += in_image_size;
                     out_idx += out_image_size;
@@ -134,10 +135,10 @@ namespace cv { namespace dnn { namespace cuda4dnn { namespace kernels {
 
                 #pragma unroll 1 /* disable unrolling to reduce register pressure; not sure how but it works */
                 for (auto c = c_start; c < c_end; c++) {
-                    auto v_00 = input[in_offset_r0 + in_x0],
-                         v_01 = input[in_offset_r0 + in_x1],
-                         v_10 = input[in_offset_r1 + in_x0],
-                         v_11 = input[in_offset_r1 + in_x1];
+                    auto v_00 = load_ldg(input[in_offset_r0 + in_x0]),
+                         v_01 = load_ldg(input[in_offset_r0 + in_x1]),
+                         v_10 = load_ldg(input[in_offset_r1 + in_x0]),
+                         v_11 = load_ldg(input[in_offset_r1 + in_x1]);
 
                     output[out_idx] =
                         v_00 +

--- a/modules/dnn/src/cuda/roi_pooling.cu
+++ b/modules/dnn/src/cuda/roi_pooling.cu
@@ -10,6 +10,7 @@
 #include "types.hpp"
 #include "grid_stride_range.hpp"
 #include "execution.hpp"
+#include "memory.hpp"
 
 #include "../cuda4dnn/csl/stream.hpp"
 #include "../cuda4dnn/csl/tensor.hpp"
@@ -118,7 +119,7 @@ namespace cv { namespace dnn { namespace cuda4dnn { namespace kernels {
                         const auto in_idx = in_offset + iy * in_width;
                         for (auto ix = x_start; ix < x_end; ix++)
                         {
-                            max_val = max(max_val, input[in_idx + ix]);
+                            max_val = max(max_val, load_ldg(input[in_idx + ix]));
                         }
                     }
 

--- a/modules/dnn/src/cuda/vector_traits.hpp
+++ b/modules/dnn/src/cuda/vector_traits.hpp
@@ -8,6 +8,7 @@
 #include <cuda_runtime.h>
 
 #include "types.hpp"
+#include "memory.hpp"
 
 #include "../cuda4dnn/csl/pointer.hpp"
 
@@ -84,6 +85,16 @@ namespace cv { namespace dnn { namespace cuda4dnn { namespace csl { namespace de
     template <class V>
     __device__ void v_load(V& dest, const V* src) {
         dest.raw = src->raw;
+    }
+
+    template <class V>
+    __device__ void v_load_ldg(V& dest, const V& src) {
+        dest.raw = load_ldg(src.raw);
+    }
+
+    template <class V>
+    __device__ void v_load_ldg(V& dest, const V* src) {
+        dest.raw = load_ldg(src->raw);
     }
 
     template <class V>

--- a/modules/dnn/src/layers/convolution_layer.cpp
+++ b/modules/dnn/src/layers/convolution_layer.cpp
@@ -167,6 +167,10 @@ public:
 
     virtual bool tryFuse(Ptr<Layer>& top) CV_OVERRIDE
     {
+        Ptr<BlankLayer> blank_layer = top.dynamicCast<BlankLayer>();
+        if (blank_layer)
+            return true;
+
         Mat w, b;
         top->getScaleShift(w, b);
         if (!w.empty() || !b.empty())


### PR DESCRIPTION
### Pull Request Readiness Checklist

**Mish (+ swish and sigmoid):**

This activation is used in YOLOv4. Surprisingly, the mish kernels are compute-bound instead of being bandwidth-bound. The first convolution in YOLOv4 takes less time than the fused bias mish activation step. 

Mish is a composition of several functions: tanh(log(1 + exp(x))). Hence, it is very likely that there is a very good approximation or simplification to the mish function (clearly the log isn't necessary since tanh is a composition over e^x). This PR introduces a fast numerically stable implementation of the mish activation.

Details of the approximation can be found [here](https://cs.stackexchange.com/a/125052/66162).

Operation                                              | without this PR | with this PR
--------------------------------------------------- | -------------------- | -----------------
biasN_mish (YOLOv4 conv_1)              | 1.35ms             | 980us
biasN_mish (YOLOv4 conv_2)             | 742us                | 496us

Based on similar reasoning, good fast approximations to swish and sigmoid were also added.

**Identity is fused with convolution layer:**

Activations would not be fused with convolution if an identity layer is present between them. This happens in the case of Mask RCNN: the final sigmoid operation is not fused with the preceding convolution operation.

Operation                                              | without fusion   | with fusion
--------------------------------------------------- | -------------------- | ---------------------------------
biasN_sigmoid (Mask RCNN)               |               368us | 206us

This kernel is compute-bound if the sigmoid approximation mentioned above is not used. The timings reported here are with the approximation.

**Others:**

Operation                                              | without this PR | with this PR
--------------------------------------------------- | -------------------- | -----------------
transpose (YOLOv4 permute1)             | 195us              | 154us
region_box                                            | 62us                  | 56us
region_sigmoid_class_score                | 100.4us            | 72us 
crop_and_resize                                   | 2.98ms             | 2.72ms
resize_bilinear                                      | 1.77ms             | 1.65ms 

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under OpenCV (BSD) License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [x] The PR is proposed to proper branch
- [ ] There is reference to original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake

<cut/>

```
force_builders=Custom
buildworker:Custom=linux-4
build_image:Custom=ubuntu-cuda:18.04
```
