### PR TITLE
CAP_MFX: surface pool with timeout, more parameters

### DIFF
--- a/modules/videoio/src/cap_mfx_reader.cpp
+++ b/modules/videoio/src/cap_mfx_reader.cpp
@@ -214,7 +214,7 @@ bool VideoCapture_IntelMFX::grabFrame()
         else if (res == MFX_WRN_DEVICE_BUSY)
         {
             DBG(cout << "Waiting for device" << endl);
-            sleep(1);
+            sleep_ms(1000);
             continue;
         }
         else if (res == MFX_WRN_VIDEO_PARAM_CHANGED)

--- a/modules/videoio/src/cap_mfx_writer.cpp
+++ b/modules/videoio/src/cap_mfx_writer.cpp
@@ -10,6 +10,18 @@
 using namespace std;
 using namespace cv;
 
+static size_t getBitrateDivisor()
+{
+    static const size_t res = utils::getConfigurationParameterSizeT("OPENCV_VIDEOIO_MFX_BITRATE_DIVISOR", 300);
+    return res;
+}
+
+static mfxU32 getWriterTimeoutMS()
+{
+    static const size_t res = utils::getConfigurationParameterSizeT("OPENCV_VIDEOIO_MFX_WRITER_TIMEOUT", 1);
+    return saturate_cast<mfxU32>(res * 1000); // convert from seconds
+}
+
 inline mfxU32 codecIdByFourCC(int fourcc)
 {
     const int CC_MPG2 = FourCC('M', 'P', 'G', '2').vali32;
@@ -77,7 +89,7 @@ VideoWriter_IntelMFX::VideoWriter_IntelMFX(const String &filename, int _fourcc, 
     memset(&params, 0, sizeof(params));
     params.mfx.CodecId = codecId;
     params.mfx.TargetUsage = MFX_TARGETUSAGE_BALANCED;
-    params.mfx.TargetKbps = (mfxU16)cvRound(frameSize.area() * fps / 500); // TODO: set in options
+    params.mfx.TargetKbps = saturate_cast<mfxU16>((frameSize.area() * fps) / (42.6666 * getBitrateDivisor())); // TODO: set in options
     params.mfx.RateControlMethod = MFX_RATECONTROL_VBR;
     params.mfx.FrameInfo.FrameRateExtN = cvRound(fps * 1000);
     params.mfx.FrameInfo.FrameRateExtD = 1000;
@@ -210,7 +222,7 @@ bool VideoWriter_IntelMFX::write_one(cv::InputArray bgr)
         res = encoder->EncodeFrameAsync(NULL, workSurface, &bs->stream, &sync);
         if (res == MFX_ERR_NONE)
         {
-            res = session->SyncOperation(sync, 1000); // 1 sec, TODO: provide interface to modify timeout
+            res = session->SyncOperation(sync, getWriterTimeoutMS()); // TODO: provide interface to modify timeout
             if (res == MFX_ERR_NONE)
             {
                 // ready to write
@@ -239,7 +251,7 @@ bool VideoWriter_IntelMFX::write_one(cv::InputArray bgr)
         else if (res == MFX_WRN_DEVICE_BUSY)
         {
             DBG(cout << "Waiting for device" << endl);
-            sleep(1);
+            sleep_ms(1000);
             continue;
         }
         else


### PR DESCRIPTION
Added environment variables to control MFX videoio backend:
- `OPENCV_VIDEOIO_MFX_IMPL` - preferred implementation, number, see mfxIMPL documentation
- `OPENCV_VIDEOIO_MFX_POOL_TIMEOUT` - surface pool wait timeout, seconds, default value is 1
- `OPENCV_VIDEOIO_MFX_EXTRA_SURFACE_NUM` - extra surfaces in surface pool, number, default value is 0
- `OPENCV_VIDEOIO_MFX_BITRATE_DIVISOR` - bitrate calculation divisor, number, default value is 500, `bitrate = pixel_num * fps/ divisor`
- `OPENCV_VIDEOIO_MFX_WRITER_TIMEOUT` - encoder timeout, seconds, default value is 1

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under OpenCV (BSD) License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [x] The PR is proposed to proper branch
- [x] There is reference to original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
