### PR TITLE
Added C++ and Java regression test for estimateNewCameraMatrixForUndistortRectify

### DIFF
--- a/modules/calib3d/misc/java/test/Calib3dTest.java
+++ b/modules/calib3d/misc/java/test/Calib3dTest.java
@@ -682,4 +682,31 @@ public class Calib3dTest extends OpenCVTestCase {
         assertMatEqual(truth_rvec, rvecs.get(0), 10 * EPS);
         assertMatEqual(truth_tvec, tvecs.get(0), 1000 * EPS);
     }
+
+    public void testEstimateNewCameraMatrixForUndistortRectify() {
+        Mat K = new Mat().eye(3, 3, CvType.CV_64FC1);
+        Mat K_new = new Mat().eye(3, 3, CvType.CV_64FC1);
+        Mat K_new_truth = new Mat().eye(3, 3, CvType.CV_64FC1);
+        Mat D = new Mat().zeros(4, 1, CvType.CV_64FC1);
+
+        K.put(0,0,600.4447738238429);
+        K.put(1,1,578.9929805505851);
+        K.put(0,2,992.0642578801213);
+        K.put(1,2,549.2682624212172);
+
+        D.put(0,0,-0.05090103223466704);
+        D.put(1,0,0.030944413642173308);
+        D.put(2,0,-0.021509225493198905);
+        D.put(3,0,0.0043378096628297145);
+
+        K_new_truth.put(0,0, 387.4809086880343);
+        K_new_truth.put(0,2, 1036.669802754649);
+        K_new_truth.put(1,1, 373.6375700303157);
+        K_new_truth.put(1,2, 538.8373261247601);
+
+        Calib3d.fisheye_estimateNewCameraMatrixForUndistortRectify(K,D,new Size(1920,1080),
+                    new Mat().eye(3, 3, CvType.CV_64F), K_new, 0.0, new Size(1920,1080));
+
+        assertMatEqual(K_new, K_new_truth, EPS);
+    }
 }

--- a/modules/calib3d/test/test_fisheye.cpp
+++ b/modules/calib3d/test/test_fisheye.cpp
@@ -656,6 +656,51 @@ TEST_F(fisheyeTest, CalibrationWithDifferentPointsNumber)
         cv::noArray(), cv::noArray(), flag, cv::TermCriteria(3, 20, 1e-6));
 }
 
+TEST_F(fisheyeTest, estimateNewCameraMatrixForUndistortRectify)
+{
+    cv::Size size(1920, 1080);
+
+    cv::Mat K_fullhd(3, 3, cv::DataType<double>::type);
+    K_fullhd.at<double>(0, 0) = 600.44477382;
+    K_fullhd.at<double>(0, 1) = 0.0;
+    K_fullhd.at<double>(0, 2) = 992.06425788;
+
+    K_fullhd.at<double>(1, 0) = 0.0;
+    K_fullhd.at<double>(1, 1) = 578.99298055;
+    K_fullhd.at<double>(1, 2) = 549.26826242;
+
+    K_fullhd.at<double>(2, 0) = 0.0;
+    K_fullhd.at<double>(2, 1) = 0.0;
+    K_fullhd.at<double>(2, 2) = 1.0;
+
+    cv::Mat K_new_truth(3, 3, cv::DataType<double>::type);
+
+    K_new_truth.at<double>(0, 0) = 387.4809086880343;
+    K_new_truth.at<double>(0, 1) = 0.0;
+    K_new_truth.at<double>(0, 2) = 1036.669802754649;
+
+    K_new_truth.at<double>(1, 0) = 0.0;
+    K_new_truth.at<double>(1, 1) = 373.6375700303157;
+    K_new_truth.at<double>(1, 2) = 538.8373261247601;
+
+    K_new_truth.at<double>(2, 0) = 0.0;
+    K_new_truth.at<double>(2, 1) = 0.0;
+    K_new_truth.at<double>(2, 2) = 1.0;
+
+    cv::Mat D_fullhd(4, 1, cv::DataType<double>::type);
+    D_fullhd.at<double>(0, 0) = -0.05090103223466704;
+    D_fullhd.at<double>(1, 0) = 0.030944413642173308;
+    D_fullhd.at<double>(2, 0) = -0.021509225493198905;
+    D_fullhd.at<double>(3, 0) = 0.0043378096628297145;
+    cv::Mat E = cv::Mat::eye(3, 3, cv::DataType<double>::type);
+
+    cv::Mat K_new(3, 3, cv::DataType<double>::type);
+
+    cv::fisheye::estimateNewCameraMatrixForUndistortRectify(K_fullhd, D_fullhd, size, E, K_new, 0.0, size);
+
+    EXPECT_MAT_NEAR(K_new, K_new_truth, 1e-6);
+}
+
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 ///  fisheyeTest::
 


### PR DESCRIPTION
Reproducer for https://github.com/opencv/opencv/issues/17171

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under OpenCV (BSD) License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [x] The PR is proposed to proper branch
- [x] There is reference to original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
