### PR TITLE
Added ONNX BatchNorm subgraph

### DIFF
--- a/modules/dnn/src/onnx/onnx_graph_simplifier.cpp
+++ b/modules/dnn/src/onnx/onnx_graph_simplifier.cpp
@@ -61,27 +61,28 @@ public:
     ONNXGraphWrapper(opencv_onnx::GraphProto& _net) : net(_net)
     {
         numInputs = net.input_size();
+        numInitializers = net.initializer_size();
     }
 
     virtual Ptr<ImportNodeWrapper> getNode(int idx) const CV_OVERRIDE
     {
         opencv_onnx::NodeProto* node = 0;
-        if (idx >= numInputs)
-            node = net.mutable_node(idx - numInputs);
+        if (idx >= numInputs + numInitializers)
+            node = net.mutable_node(idx - numInputs - numInitializers);
         return makePtr<ONNXNodeWrapper>(node);
     }
 
     virtual int getNumNodes() const CV_OVERRIDE
     {
-        return numInputs + net.node_size();
+        return numInputs + numInitializers + net.node_size();
     }
 
     virtual int getNumOutputs(int nodeId) const CV_OVERRIDE
     {
-        if (nodeId < numInputs)
+        if (nodeId < numInputs + numInitializers)
             return 1;
         else
-            return net.node(nodeId - numInputs).output_size();
+            return net.node(nodeId - numInputs - numInitializers).output_size();
     }
 
     virtual std::string getOutputName(int nodeId, int outId) const CV_OVERRIDE
@@ -89,18 +90,20 @@ public:
         CV_Assert(outId < getNumOutputs(nodeId));
         if (nodeId < numInputs)
             return net.input(nodeId).name();
+        else if (nodeId < numInputs + numInitializers)
+            return net.initializer(nodeId - numInputs).name();
         else
-            return net.node(nodeId - numInputs).output(outId);
+            return net.node(nodeId - numInputs - numInitializers).output(outId);
     }
 
     virtual void removeNode(int idx) CV_OVERRIDE
     {
-        CV_Assert(idx >= numInputs);
-        net.mutable_node()->DeleteSubrange(idx - numInputs, 1);
+        CV_Assert(idx >= numInputs + numInitializers);
+        net.mutable_node()->DeleteSubrange(idx - numInputs - numInitializers, 1);
     }
 
 private:
-    int numInputs;
+    int numInputs, numInitializers;
     opencv_onnx::GraphProto& net;
 };
 
@@ -388,13 +391,13 @@ public:
     BatchNormalizationSubgraphBase()
     {
         input  = addNodeToMatch("");
-        var    = addNodeToMatch("Constant");
-        mean   = addNodeToMatch("Constant");
-        weight = addNodeToMatch("Constant");
-        bias   = addNodeToMatch("Constant");
-        A      = addNodeToMatch("Constant");
-        shape1 = addNodeToMatch("Constant");
-        shape2 = addNodeToMatch("Constant");
+        var    = addNodeToMatch("");
+        mean   = addNodeToMatch("");
+        weight = addNodeToMatch("");
+        bias   = addNodeToMatch("");
+        A      = addNodeToMatch("");
+        shape1 = addNodeToMatch("");
+        shape2 = addNodeToMatch("");
     }
 protected:
     int input, var, mean, weight, bias, A, shape1, shape2;

--- a/modules/dnn/src/onnx/onnx_graph_simplifier.cpp
+++ b/modules/dnn/src/onnx/onnx_graph_simplifier.cpp
@@ -382,33 +382,63 @@ public:
     }
 };
 
-class BatchNormalizationSubgraph : public Subgraph
+class BatchNormalizationSubgraphBase : public Subgraph
 {
 public:
-    BatchNormalizationSubgraph()
+    BatchNormalizationSubgraphBase()
     {
-        int input = addNodeToMatch("");
-        int data1 = addNodeToMatch("Constant");
-        int data2 = addNodeToMatch("Constant");
-        int data3 = addNodeToMatch("Constant");
-        int data4 = addNodeToMatch("Constant");
-        int shape1 = addNodeToMatch("Constant");
-        int reshape1 = addNodeToMatch("Reshape", data1, shape1);
-        int shape2 = addNodeToMatch("Constant");
-        int reshape2 = addNodeToMatch("Reshape", data2, shape2);
+        input  = addNodeToMatch("");
+        var    = addNodeToMatch("Constant");
+        mean   = addNodeToMatch("Constant");
+        weight = addNodeToMatch("Constant");
+        bias   = addNodeToMatch("Constant");
+        A = addNodeToMatch("Constant");
+        shape1 = addNodeToMatch("Constant");
+        shape2 = addNodeToMatch("Constant");
+    }
+protected:
+    int input, var, mean, weight, bias, A, shape1, shape2;
+};
+
+class BatchNormalizationSubgraph1 : public BatchNormalizationSubgraphBase
+{
+public:
+    BatchNormalizationSubgraph1()
+    {
+        int reshape1 = addNodeToMatch("Reshape", weight, shape1);
+        int reshape2 = addNodeToMatch("Reshape", bias, shape2);
         int shape3 = addNodeToMatch("Constant");
-        int reshape3 = addNodeToMatch("Reshape", data3, shape3);
+        int reshape3 = addNodeToMatch("Reshape", var, shape3);
         int shape4 = addNodeToMatch("Constant");
-        int reshape4 = addNodeToMatch("Reshape", data4, shape4);
+        int reshape4 = addNodeToMatch("Reshape", mean, shape4);
         int sqrtNode = addNodeToMatch("Sqrt", reshape3);
-        int A = addNodeToMatch("Constant");
         int divNode = addNodeToMatch("Div", A, sqrtNode);
         int mul1 = addNodeToMatch("Mul", reshape1, divNode);
         int mul2 = addNodeToMatch("Mul", reshape4, mul1);
         int sub = addNodeToMatch("Sub", reshape2, mul2);
         int mul3 = addNodeToMatch("Mul", input, mul1);
         addNodeToMatch("Add", mul3, sub);
-        setFusedNode("BatchNormalization", input, data1, data2, data4 ,data3);
+        setFusedNode("BatchNormalization", input, weight, bias, mean, var);
+    }
+};
+
+class BatchNormalizationSubgraph2 : public BatchNormalizationSubgraphBase
+{
+public:
+    BatchNormalizationSubgraph2()
+    {
+        int sqrtNode = addNodeToMatch("Sqrt", var);
+        int divNode = addNodeToMatch("Div", A, sqrtNode);
+        int mul1 = addNodeToMatch("Mul", weight, divNode);
+        int reshape2 = addNodeToMatch("Reshape", mul1, shape2);
+
+        int mulMean = addNodeToMatch("Mul", mean, mul1);
+        int sub = addNodeToMatch("Sub", bias, mulMean);
+        int reshape1 = addNodeToMatch("Reshape", sub, shape1);
+
+        int mulInput = addNodeToMatch("Mul", input, reshape2);
+        addNodeToMatch("Add", mulInput, reshape1);
+        setFusedNode("BatchNormalization", input, weight, bias, mean, var);
     }
 };
 
@@ -424,7 +454,8 @@ void simplifySubgraphs(opencv_onnx::GraphProto& net)
     subgraphs.push_back(makePtr<NormalizeSubgraph1>());
     subgraphs.push_back(makePtr<NormalizeSubgraph2>());
     subgraphs.push_back(makePtr<NormalizeSubgraph3>());
-    subgraphs.push_back(makePtr<BatchNormalizationSubgraph>());
+    subgraphs.push_back(makePtr<BatchNormalizationSubgraph1>());
+    subgraphs.push_back(makePtr<BatchNormalizationSubgraph2>());
 
     simplifySubgraphs(Ptr<ImportGraphWrapper>(new ONNXGraphWrapper(net)), subgraphs);
 }

--- a/modules/dnn/src/onnx/onnx_graph_simplifier.cpp
+++ b/modules/dnn/src/onnx/onnx_graph_simplifier.cpp
@@ -392,7 +392,7 @@ public:
         mean   = addNodeToMatch("Constant");
         weight = addNodeToMatch("Constant");
         bias   = addNodeToMatch("Constant");
-        A = addNodeToMatch("Constant");
+        A      = addNodeToMatch("Constant");
         shape1 = addNodeToMatch("Constant");
         shape2 = addNodeToMatch("Constant");
     }

--- a/modules/dnn/src/onnx/onnx_importer.cpp
+++ b/modules/dnn/src/onnx/onnx_importer.cpp
@@ -130,6 +130,22 @@ void runLayer(LayerParams& params, const std::vector<Mat>& inputs,
     layer->forward(inputs, outputs, internals);
 }
 
+std::map<std::string, Mat> ONNXImporter::getGraphTensors(
+                                        const opencv_onnx::GraphProto& graph_proto)
+{
+  opencv_onnx::TensorProto tensor_proto;
+  std::map<std::string, Mat> layers_weights;
+
+  for (int i = 0; i < graph_proto.initializer_size(); i++)
+  {
+    tensor_proto = graph_proto.initializer(i);
+    Mat mat = getMatFromTensor(tensor_proto);
+    releaseONNXTensor(tensor_proto);
+    layers_weights.insert(std::make_pair(tensor_proto.name(), mat));
+  }
+  return layers_weights;
+}
+
 static DictValue parse(const ::google::protobuf::RepeatedField< ::google::protobuf::int64>& src) {
     std::vector<int32_t> dst(src.size());
     convertInt64ToInt32(src, dst, src.size());
@@ -293,69 +309,20 @@ static void addConstant(const std::string& name,
     outShapes.insert(std::make_pair(name, shape(blob)));
 }
 
-std::map<std::string, Mat> addConstantNodesForInitializers(opencv_onnx::GraphProto& graph_proto)
-{
-    int num_initializers = graph_proto.initializer_size();
-    std::map<std::string, Mat> layers_weights;
-    for (int id = 0; id < num_initializers; id++)
-    {
-        opencv_onnx::TensorProto initializer = graph_proto.initializer(id);
-        const std::string& name = initializer.name();
-        opencv_onnx::NodeProto* constant_node = graph_proto.add_node();
-        constant_node->set_op_type("Constant");
-        constant_node->set_name(name);
-        constant_node->add_output(name);
-        opencv_onnx::AttributeProto* value = constant_node->add_attribute();
-        opencv_onnx::TensorProto* tensor = initializer.New();
-        tensor->CopyFrom(initializer);
-
-        Mat mat = getMatFromTensor(initializer);
-        layers_weights.insert(std::make_pair(name, mat));
-        releaseONNXTensor(initializer);
-        value->set_allocated_t(tensor);
-    }
-
-    // remove constant network inputs (initializers have already been added as constant nodes to graph)
-    int input_size = graph_proto.input_size();
-    for (int i = 0, j = 0; i < input_size; ++i)
-    {
-        const std::string& name = graph_proto.input(j).name();
-        if (layers_weights.find(name) != layers_weights.end())
-        {
-            graph_proto.mutable_input()->DeleteSubrange(j, 1);
-        }
-        else
-        {
-            ++j;
-        }
-    }
-    return layers_weights;
-}
-
 void ONNXImporter::populateNet(Net dstNet)
 {
     CV_Assert(model_proto.has_graph());
     opencv_onnx::GraphProto graph_proto = model_proto.graph();
 
-    std::map<std::string, Mat> constBlobs = addConstantNodesForInitializers(graph_proto);
     simplifySubgraphs(graph_proto);
 
+    std::map<std::string, Mat> constBlobs = getGraphTensors(graph_proto);
     // List of internal blobs shapes.
     std::map<std::string, MatShape> outShapes;
-    std::map<std::string, MatShape>::iterator shapeIt;
-    // create map with network inputs (without const blobs)
-    std::map<std::string, LayerInfo> layer_id;
-    std::map<std::string, LayerInfo>::iterator layerId;
-    // fill map: push layer name, layer id and output id
-    std::vector<String> netInputs;
     // Add all the inputs shapes. It includes as constant blobs as network's inputs shapes.
     for (int i = 0; i < graph_proto.input_size(); ++i)
     {
         opencv_onnx::ValueInfoProto valueInfoProto = graph_proto.input(i);
-        const std::string& name = valueInfoProto.name();
-        netInputs.push_back(name);
-        layer_id.insert(std::make_pair(name, LayerInfo(0, netInputs.size() - 1)));
-
         CV_Assert(valueInfoProto.has_type());
         opencv_onnx::TypeProto typeProto = valueInfoProto.type();
         CV_Assert(typeProto.has_tensor_type());
@@ -368,14 +335,29 @@ void ONNXImporter::populateNet(Net dstNet)
         {
             inpShape[j] = tensorShape.dim(j).dim_value();
         }
-        outShapes[name] = inpShape;
+        outShapes[valueInfoProto.name()] = inpShape;
     }
-    dstNet.setInputsNames(netInputs);
 
     std::string framework_name;
     if (model_proto.has_producer_name()) {
         framework_name = model_proto.producer_name();
     }
+
+    // create map with network inputs (without const blobs)
+    std::map<std::string, LayerInfo> layer_id;
+    std::map<std::string, LayerInfo>::iterator layerId;
+    std::map<std::string, MatShape>::iterator shapeIt;
+    // fill map: push layer name, layer id and output id
+    std::vector<String> netInputs;
+    for (int j = 0; j < graph_proto.input_size(); j++)
+    {
+        const std::string& name = graph_proto.input(j).name();
+        if (constBlobs.find(name) == constBlobs.end()) {
+            netInputs.push_back(name);
+            layer_id.insert(std::make_pair(name, LayerInfo(0, netInputs.size() - 1)));
+        }
+    }
+    dstNet.setInputsNames(netInputs);
 
     int layersSize = graph_proto.node_size();
     LayerParams layerParams;

--- a/modules/dnn/test/test_onnx_importer.cpp
+++ b/modules/dnn/test/test_onnx_importer.cpp
@@ -306,6 +306,13 @@ TEST_P(Test_ONNX_layers, BatchNormalizationUnfused)
     testONNXModels("frozenBatchNorm2d");
 }
 
+TEST_P(Test_ONNX_layers, BatchNormalizationSubgraph)
+{
+    if (backend == DNN_BACKEND_INFERENCE_ENGINE_NGRAPH)
+        applyTestTag(CV_TEST_TAG_DNN_SKIP_IE_NGRAPH);
+    testONNXModels("batch_norm_subgraph");
+}
+
 TEST_P(Test_ONNX_layers, Transpose)
 {
     if (backend == DNN_BACKEND_INFERENCE_ENGINE_NN_BUILDER_2019)


### PR DESCRIPTION
**Merge with extra:** opencv/opencv_extra#755

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under OpenCV (BSD) License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [x] The PR is proposed to proper branch
- [x] There is reference to original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake


```
force_builders=Custom,Custom Win,Custom Mac
build_image:Custom=ubuntu-openvino-2020.1.0:16.04
build_image:Custom Win=openvino-2020.2.0
build_image:Custom Mac=openvino-2020.2.0

test_modules:Custom=dnn,python2,python3,java
test_modules:Custom Win=dnn,python2,python3,java
test_modules:Custom Mac=dnn,python2,python3,java

buildworker:Custom=linux-1
# disabled due high memory usage: test_opencl:Custom=ON
test_opencl:Custom=OFF
test_bigdata:Custom=1
test_filter:Custom=*
```

![image](https://user-images.githubusercontent.com/22346860/81308595-a2d55d00-908a-11ea-91d6-b12eb6f0dcde.png)
