### PR TITLE
dnn: Implement graph (gapi) version of forward functions

### DIFF
--- a/modules/dnn/CMakeLists.txt
+++ b/modules/dnn/CMakeLists.txt
@@ -10,7 +10,7 @@ set(the_description "Deep neural network module. It allows to load models from d
 
 ocv_add_dispatched_file_force_all("layers/layers_common" AVX AVX2 AVX512_SKX)
 
-ocv_add_module(dnn opencv_core opencv_imgproc WRAP python java js)
+ocv_add_module(dnn opencv_core opencv_imgproc opencv_gapi WRAP python java js)
 
 ocv_option(OPENCV_DNN_OPENCL "Build with OpenCL support" HAVE_OPENCL AND NOT APPLE)
 if(HAVE_TENGINE)

--- a/modules/dnn/include/opencv2/dnn/dnn.hpp
+++ b/modules/dnn/include/opencv2/dnn/dnn.hpp
@@ -521,12 +521,26 @@ CV__DNN_INLINE_NS_BEGIN
          */
         CV_WRAP void forward(OutputArrayOfArrays outputBlobs, const String& outputName = String());
 
+        /** @brief Runs forward pass using GAPI to compute outputs of layers listed in @p outBlobNames.
+         *  @param outputBlobs contains blobs for first outputs of specified layers.
+         *  @param outBlobNames names for layers which outputs are needed to get
+         */
+        CV_WRAP void forwardGraph(OutputArrayOfArrays outputBlobs,
+                                  const std::vector<String>& outBlobNames);
+
         /** @brief Runs forward pass to compute outputs of layers listed in @p outBlobNames.
          *  @param outputBlobs contains blobs for first outputs of specified layers.
          *  @param outBlobNames names for layers which outputs are needed to get
          */
         CV_WRAP void forward(OutputArrayOfArrays outputBlobs,
                              const std::vector<String>& outBlobNames);
+
+        /** @brief Runs forward pass using GAPI to compute outputs of layers listed in @p outBlobNames.
+         *  @param outputBlobs contains all output blobs for each layer specified in @p outBlobNames.
+         *  @param outBlobNames names for layers which outputs are needed to get
+         */
+        CV_WRAP_AS(forwardAndRetrieve) void forwardGraph(CV_OUT std::vector<std::vector<Mat> >& outputBlobs,
+                                                         const std::vector<String>& outBlobNames);
 
         /** @brief Runs forward pass to compute outputs of layers listed in @p outBlobNames.
          *  @param outputBlobs contains all output blobs for each layer specified in @p outBlobNames.

--- a/modules/dnn/test/test_misc.cpp
+++ b/modules/dnn/test/test_misc.cpp
@@ -432,6 +432,40 @@ TEST(Net, forwardAndRetrieve)
     normAssert(outBlobs[0][1], inp.rowRange(2, 4), "second part");
 }
 
+TEST(Net, forwardAndGAPI)
+{
+    std::string prototxt =
+        "input: \"data\"\n"
+        "layer {\n"
+        "  name: \"testLayer\"\n"
+        "  type: \"Slice\"\n"
+        "  bottom: \"data\"\n"
+        "  top: \"firstCopy\"\n"
+        "  top: \"secondCopy\"\n"
+        "  slice_param {\n"
+        "    axis: 0\n"
+        "    slice_point: 2\n"
+        "  }\n"
+        "}";
+    Net net = readNetFromCaffe(&prototxt[0], prototxt.size());
+    net.setPreferableBackend(DNN_BACKEND_OPENCV);
+
+    Mat inp(4, 5, CV_32F);
+    randu(inp, -1, 1);
+    net.setInput(inp);
+
+    std::vector<String> outNames;
+    outNames.push_back("testLayer");
+    std::vector<std::vector<Mat> > outBlobs;
+
+    net.forwardGraph(outBlobs, outNames);
+
+    EXPECT_EQ(outBlobs.size(), 1);
+    EXPECT_EQ(outBlobs[0].size(), 2);
+    normAssert(outBlobs[0][0], inp.rowRange(0, 2), "first part");
+    normAssert(outBlobs[0][1], inp.rowRange(2, 4), "second part");
+}
+
 #ifdef HAVE_INF_ENGINE
 static const std::chrono::milliseconds async_timeout(10000);
 


### PR DESCRIPTION
Unroll the for loop of layers' forward function calls, using the gapi
support for lambda functions provided in the CPU backend.

Add a test that retrieves per-layer results.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under OpenCV (BSD) License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [x] The PR is proposed to proper branch
- [ ] There is reference to original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
