### PR TITLE
Update FindCUDNN.cmake

### DIFF
--- a/cmake/FindCUDNN.cmake
+++ b/cmake/FindCUDNN.cmake
@@ -70,7 +70,7 @@ if(CUDNN_INCLUDE_DIR)
   if(EXISTS "${CUDNN_INCLUDE_DIR}/cudnn_version.h")
     file(READ "${CUDNN_INCLUDE_DIR}/cudnn_version.h" CUDNN_VERSION_H_CONTENTS)
     string(APPEND CUDNN_H_CONTENTS "${CUDNN_VERSION_H_CONTENTS}")
-    unset(CUDNN_VERSION_H_CONTENTS)  
+    unset(CUDNN_VERSION_H_CONTENTS)
   endif()
 
   string(REGEX MATCH "define CUDNN_MAJOR ([0-9]+)" _ "${CUDNN_H_CONTENTS}")

--- a/cmake/FindCUDNN.cmake
+++ b/cmake/FindCUDNN.cmake
@@ -66,6 +66,12 @@ endif()
 # extract version from the include
 if(CUDNN_INCLUDE_DIR)
   file(READ "${CUDNN_INCLUDE_DIR}/cudnn.h" CUDNN_H_CONTENTS)
+  # recent versions use a seperate version header
+  if(EXISTS "${CUDNN_INCLUDE_DIR}/cudnn_version.h")
+    file(READ "${CUDNN_INCLUDE_DIR}/cudnn_version.h" CUDNN_VERSION_H_CONTENTS)
+    string(APPEND CUDNN_H_CONTENTS "${CUDNN_VERSION_H_CONTENTS}")
+    unset(CUDNN_VERSION_H_CONTENTS)  
+  endif()
 
   string(REGEX MATCH "define CUDNN_MAJOR ([0-9]+)" _ "${CUDNN_H_CONTENTS}")
   set(CUDNN_MAJOR_VERSION ${CMAKE_MATCH_1} CACHE INTERNAL "")


### PR DESCRIPTION
As of at least CUDA 10.2, the definitions of CUDNN_MAJOR, CUDNN_MINOR, and CUDNN_PATCHLEVEL are in cudnn_version.h rather than cudnn.h.  The proposed change adds the contents of cudnn_version.h to the regex search text if it exists.

<cut/>
### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under OpenCV (BSD) License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [x] The PR is proposed to proper branch
- [ ] There is reference to original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake

```
force_builders=Custom
buildworker:Custom=linux-4
build_image:Custom=ubuntu-cuda:18.04
```
