### PR TITLE
Update tutorials tables of content for several modules

### DIFF
--- a/doc/tutorials/calib3d/table_of_content_calib3d.markdown
+++ b/doc/tutorials/calib3d/table_of_content_calib3d.markdown
@@ -5,6 +5,8 @@ Although we get most of our images in a 2D format they do come from a 3D world. 
 
 -   @subpage tutorial_camera_calibration_pattern
 
+    *Languages:* Python
+
     *Compatibility:* \> OpenCV 2.0
 
     *Author:* Laurent Berger
@@ -13,6 +15,8 @@ Although we get most of our images in a 2D format they do come from a 3D world. 
 
 -   @subpage tutorial_camera_calibration_square_chess
 
+    *Languages:* C++
+
     *Compatibility:* \> OpenCV 2.0
 
     *Author:* Victor Eruhimov
@@ -20,6 +24,8 @@ Although we get most of our images in a 2D format they do come from a 3D world. 
     You will use some chessboard images to calibrate your camera.
 
 -   @subpage tutorial_camera_calibration
+
+    *Languages:* C++
 
     *Compatibility:* \> OpenCV 2.0
 
@@ -30,6 +36,8 @@ Although we get most of our images in a 2D format they do come from a 3D world. 
     collection.
 
 -   @subpage tutorial_real_time_pose
+
+    *Languages:* C++
 
     *Compatibility:* \> OpenCV 2.0
 

--- a/doc/tutorials/core/table_of_content_core.markdown
+++ b/doc/tutorials/core/table_of_content_core.markdown
@@ -6,6 +6,8 @@ understanding how to manipulate the images on a pixel level.
 
 -   @subpage tutorial_mat_the_basic_image_container
 
+    *Languages:* C++
+
     *Compatibility:* \> OpenCV 2.0
 
     *Author:* Bernát Gábor
@@ -14,6 +16,8 @@ understanding how to manipulate the images on a pixel level.
     console.
 
 -   @subpage tutorial_how_to_scan_images
+
+    *Languages:* C++
 
     *Compatibility:* \> OpenCV 2.0
 
@@ -75,6 +79,8 @@ understanding how to manipulate the images on a pixel level.
 
 -   @subpage tutorial_file_input_output_with_xml_yml
 
+    *Languages:* C++, Python
+
     *Compatibility:* \> OpenCV 2.0
 
     *Author:* Bernát Gábor
@@ -83,6 +89,8 @@ understanding how to manipulate the images on a pixel level.
     data to XML or YAML file format.
 
 -   @subpage tutorial_interoperability_with_OpenCV_1
+
+    *Languages:* C++
 
     *Compatibility:* \> OpenCV 2.0
 
@@ -94,6 +102,8 @@ understanding how to manipulate the images on a pixel level.
 
 
 -   @subpage tutorial_how_to_use_OpenCV_parallel_for_
+
+    *Languages:* C++
 
     *Compatibility:* \>= OpenCV 2.4.3
 

--- a/doc/tutorials/dnn/table_of_content_dnn.markdown
+++ b/doc/tutorials/dnn/table_of_content_dnn.markdown
@@ -3,6 +3,8 @@ Deep Neural Networks (dnn module) {#tutorial_table_of_content_dnn}
 
 -   @subpage tutorial_dnn_googlenet
 
+    *Languages:* C++
+
     *Compatibility:* \> OpenCV 3.3
 
     *Author:* Vitaliy Lyudvichenko
@@ -10,6 +12,8 @@ Deep Neural Networks (dnn module) {#tutorial_table_of_content_dnn}
     In this tutorial you will learn how to use opencv_dnn module for image classification by using GoogLeNet trained network from Caffe model zoo.
 
 -   @subpage tutorial_dnn_halide
+
+    *Languages:* Halide
 
     *Compatibility:* \> OpenCV 3.3
 
@@ -19,6 +23,8 @@ Deep Neural Networks (dnn module) {#tutorial_table_of_content_dnn}
 
 -   @subpage tutorial_dnn_halide_scheduling
 
+    *Languages:* Halide
+
     *Compatibility:* \> OpenCV 3.3
 
     *Author:* Dmitry Kurtaev
@@ -26,6 +32,8 @@ Deep Neural Networks (dnn module) {#tutorial_table_of_content_dnn}
     In this tutorial we describe the ways to schedule your networks using Halide backend in OpenCV deep learning module.
 
 -   @subpage tutorial_dnn_android
+
+    *Languages:* Java
 
     *Compatibility:* \> OpenCV 3.3
 
@@ -35,6 +43,8 @@ Deep Neural Networks (dnn module) {#tutorial_table_of_content_dnn}
 
 -   @subpage tutorial_dnn_yolo
 
+    *Languages:* C++, Python
+
     *Compatibility:* \> OpenCV 3.3.1
 
     *Author:* Alessandro de Oliveira Faria
@@ -43,6 +53,8 @@ Deep Neural Networks (dnn module) {#tutorial_table_of_content_dnn}
 
 -   @subpage tutorial_dnn_javascript
 
+    *Languages:* JavaScript
+
     *Compatibility:* \> OpenCV 3.3.1
 
     *Author:* Dmitry Kurtaev
@@ -50,6 +62,8 @@ Deep Neural Networks (dnn module) {#tutorial_table_of_content_dnn}
     In this tutorial we'll run deep learning models in browser using OpenCV.js.
 
 -   @subpage tutorial_dnn_custom_layers
+
+    *Languages:* C++, Python
 
     *Compatibility:* \> OpenCV 3.4.1
 

--- a/doc/tutorials/features2d/table_of_content_features2d.markdown
+++ b/doc/tutorials/features2d/table_of_content_features2d.markdown
@@ -89,6 +89,8 @@ OpenCV.
 
 -   @subpage tutorial_detection_of_planar_objects
 
+    *Languages:* C++
+
     *Compatibility:* \> OpenCV 2.0
 
     *Author:* Victor Eruhimov
@@ -108,6 +110,8 @@ OpenCV.
 
 -   @subpage tutorial_akaze_tracking
 
+    *Languages:* C++
+
     *Compatibility:* \> OpenCV 3.0
 
     *Author:* Fedor Morozov
@@ -115,6 +119,8 @@ OpenCV.
     Using *AKAZE* and *ORB* for planar object tracking.
 
 -   @subpage tutorial_homography
+
+    *Languages:* C++, Java, Python
 
     *Compatibility:* \> OpenCV 3.0
 

--- a/doc/tutorials/gpu/table_of_content_gpu.markdown
+++ b/doc/tutorials/gpu/table_of_content_gpu.markdown
@@ -6,6 +6,8 @@ run the OpenCV algorithms.
 
 -   @subpage tutorial_gpu_basics_similarity
 
+    *Languages:* C++
+
     *Compatibility:* \> OpenCV 2.0
 
     *Author:* Bernát Gábor
@@ -15,6 +17,8 @@ run the OpenCV algorithms.
     tutorial @ref tutorial_video_input_psnr_ssim to the GPU.
 
 -   @subpage tutorial_gpu_thrust_interop
+
+    *Languages:* C++
 
     *Compatibility:* \>= OpenCV 3.0
 

--- a/doc/tutorials/imgcodecs/table_of_content_highgui.markdown
+++ b/doc/tutorials/imgcodecs/table_of_content_highgui.markdown
@@ -5,6 +5,8 @@ This section contains tutorials about how to read/save your image files.
 
 -   @subpage tutorial_raster_io_gdal
 
+    *Languages:* C++
+
     *Compatibility:* \> OpenCV 2.0
 
     *Author:* Marvin Smith

--- a/doc/tutorials/ios/table_of_content_ios.markdown
+++ b/doc/tutorials/ios/table_of_content_ios.markdown
@@ -3,6 +3,8 @@ OpenCV iOS {#tutorial_table_of_content_ios}
 
 -   @subpage tutorial_hello
 
+    *Languages:* Objective-C++
+
     *Compatibility:* \> OpenCV 2.4.3
 
     *Author:* Charu Hans
@@ -11,6 +13,8 @@ OpenCV iOS {#tutorial_table_of_content_ios}
 
 -   @subpage tutorial_image_manipulation
 
+    *Languages:* Objective-C++
+
     *Compatibility:* \> OpenCV 2.4.3
 
     *Author:* Charu Hans
@@ -18,6 +22,8 @@ OpenCV iOS {#tutorial_table_of_content_ios}
     You will learn how to do simple image manipulation using OpenCV in iOS.
 
 -   @subpage tutorial_video_processing
+
+    *Languages:* Objective-C++
 
     *Compatibility:* \> OpenCV 2.4.3
 

--- a/doc/tutorials/stitching/table_of_content_stitching.markdown
+++ b/doc/tutorials/stitching/table_of_content_stitching.markdown
@@ -7,6 +7,8 @@ create a photo panorama or you want to stitch scans.
 
 -   @subpage tutorial_stitcher
 
+    *Languages:* C++
+
     *Compatibility:* \>= OpenCV 3.2
 
     *Author:* Jiri Horner

--- a/doc/tutorials/videoio/table_of_content_videoio.markdown
+++ b/doc/tutorials/videoio/table_of_content_videoio.markdown
@@ -5,6 +5,8 @@ This section contains tutorials about how to read/save your video files.
 
 -   @subpage tutorial_video_input_psnr_ssim
 
+    *Languages:* C++, Python
+
     *Compatibility:* \> OpenCV 2.0
 
     *Author:* Bernát Gábor
@@ -14,10 +16,16 @@ This section contains tutorials about how to read/save your video files.
 
 -   @subpage tutorial_video_write
 
+    *Languages:* C++
+
     *Compatibility:* \> OpenCV 2.0
 
     *Author:* Bernát Gábor
 
 -   @subpage tutorial_kinect_openni
 
+    *Languages:* C++
+
 -   @subpage tutorial_intelperc
+
+    *Languages:* C++

--- a/doc/tutorials/viz/table_of_content_viz.markdown
+++ b/doc/tutorials/viz/table_of_content_viz.markdown
@@ -3,6 +3,8 @@ OpenCV Viz {#tutorial_table_of_content_viz}
 
 -   @subpage tutorial_launching_viz
 
+    *Languages:* C++
+
     *Compatibility:* \> OpenCV 3.0.0
 
     *Author:* Ozan Tonkal
@@ -10,6 +12,8 @@ OpenCV Viz {#tutorial_table_of_content_viz}
     You will learn how to launch a viz window.
 
 -   @subpage tutorial_widget_pose
+
+    *Languages:* C++
 
     *Compatibility:* \> OpenCV 3.0.0
 
@@ -19,6 +23,8 @@ OpenCV Viz {#tutorial_table_of_content_viz}
 
 -   @subpage tutorial_transformations
 
+    *Languages:* C++
+
     *Compatibility:* \> OpenCV 3.0.0
 
     *Author:* Ozan Tonkal
@@ -27,6 +33,8 @@ OpenCV Viz {#tutorial_table_of_content_viz}
 
 -   @subpage tutorial_creating_widgets
 
+    *Languages:* C++
+
     *Compatibility:* \> OpenCV 3.0.0
 
     *Author:* Ozan Tonkal
@@ -34,6 +42,8 @@ OpenCV Viz {#tutorial_table_of_content_viz}
     You will learn how to create your own widgets.
 
 -   @subpage tutorial_histo3D
+
+    *Languages:* C++
 
     *Compatibility:* \> OpenCV 3.0.0
 


### PR DESCRIPTION
Per the discussion on #17223, this pull request covers similar additions of languages fields to the tutorials tables of content for several modules. Note that there are still many tutorials which do not specify compatibility or an author (ex: latter two of the [videoio module tutorials](https://docs.opencv.org/master/df/d2c/tutorial_table_of_content_videoio.html)) but it would be very difficult for me to reliably provide that information. 

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under OpenCV (BSD) License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [x] The PR is proposed to proper branch
- [x] There is reference to original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
