### PR TITLE
Prefer addAll instead of iteration for performance

### DIFF
--- a/modules/java/generator/src/java/org/opencv/utils/Converters.java
+++ b/modules/java/generator/src/java/org/opencv/utils/Converters.java
@@ -519,8 +519,7 @@ public class Converters {
         Mat res;
         int lCount = (pts != null) ? pts.size() : 0;
         if (lCount > 0) {
-            for (MatOfPoint vpt : pts)
-                mats.add(vpt);
+            mats.addAll(pts);
             res = vector_Mat_to_Mat(mats);
         } else {
             res = new Mat();
@@ -568,8 +567,7 @@ public class Converters {
         Mat res;
         int lCount = (pts != null) ? pts.size() : 0;
         if (lCount > 0) {
-            for (MatOfPoint2f vpt : pts)
-                mats.add(vpt);
+            mats.addAll(pts);
             res = vector_Mat_to_Mat(mats);
         } else {
             res = new Mat();
@@ -600,8 +598,7 @@ public class Converters {
         Mat res;
         int lCount = (pts != null) ? pts.size() : 0;
         if (lCount > 0) {
-            for (MatOfPoint3f vpt : pts)
-                mats.add(vpt);
+            mats.addAll(pts);
             res = vector_Mat_to_Mat(mats);
         } else {
             res = new Mat();
@@ -614,8 +611,7 @@ public class Converters {
         Mat res;
         int lCount = (kps != null) ? kps.size() : 0;
         if (lCount > 0) {
-            for (MatOfKeyPoint vkp : kps)
-                mats.add(vkp);
+            mats.addAll(kps);
             res = vector_Mat_to_Mat(mats);
         } else {
             res = new Mat();
@@ -714,8 +710,7 @@ public class Converters {
         Mat res;
         int lCount = (lvdm != null) ? lvdm.size() : 0;
         if (lCount > 0) {
-            for (MatOfDMatch vdm : lvdm)
-                mats.add(vdm);
+            mats.addAll(lvdm);
             res = vector_Mat_to_Mat(mats);
         } else {
             res = new Mat();
@@ -746,8 +741,7 @@ public class Converters {
         Mat res;
         int lCount = (lvb != null) ? lvb.size() : 0;
         if (lCount > 0) {
-            for (MatOfByte vb : lvb)
-                mats.add(vb);
+            mats.addAll(lvb);
             res = vector_Mat_to_Mat(mats);
         } else {
             res = new Mat();


### PR DESCRIPTION
### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under OpenCV (BSD) License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [x] The PR is proposed to proper branch
- [ ] There is reference to original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake

Using addAll is preferred for performance reason (implementation of addAll uses System. arraycopy())

See https://dev.to/sendilkumarn/9-tips-to-increase-your-java-performance-1l4d