### PR TITLE
cuda4dnn(region): add scale_x_y parameter for YOLOv4

### DIFF
--- a/modules/dnn/src/cuda4dnn/kernels/region.hpp
+++ b/modules/dnn/src/cuda4dnn/kernels/region.hpp
@@ -16,7 +16,7 @@ namespace cv { namespace dnn { namespace cuda4dnn { namespace kernels {
     void region(const csl::Stream& stream, csl::Span<T> output, csl::View<T> input, csl::View<T> bias,
         T object_prob_cutoff, T class_prob_cutoff,
         std::size_t boxes_per_cell, std::size_t box_size,
-        std::size_t rows, std::size_t cols,
+        std::size_t rows, std::size_t cols, T scale_x_y,
         std::size_t height_norm, std::size_t width_norm,
         bool if_true_sigmoid_else_softmax);
 

--- a/modules/dnn/src/cuda4dnn/primitives/region.hpp
+++ b/modules/dnn/src/cuda4dnn/primitives/region.hpp
@@ -48,13 +48,12 @@ namespace cv { namespace dnn { namespace cuda4dnn {
          *
          * actual class probability = conditional_class_prob * object_prob
          */
+        std::size_t classes, boxes_per_cell;
+        std::size_t width_norm, height_norm;
+        T scale_x_y;
 
         /* method for reducing class scores to probabilities */
         SquashMethod squash_method;
-
-        std::size_t classes, boxes_per_cell;
-
-        std::size_t width_norm, height_norm;
 
         /* prob cutoffs below which the prediction is nulled */
         T object_prob_cutoff;
@@ -81,8 +80,9 @@ namespace cv { namespace dnn { namespace cuda4dnn {
             width_norm = config.width_norm;
             height_norm = config.height_norm;
 
-            squash_type = config.squash_method;
+            scale_x_y = config.scale_x_y;
 
+            squash_type = config.squash_method;
             object_prob_cutoff = config.object_prob_cutoff;
             class_prob_cutoff = config.class_prob_cutoff;
 
@@ -113,7 +113,7 @@ namespace cv { namespace dnn { namespace cuda4dnn {
             kernels::region<T>(stream, output, input, biasTensor,
                 object_prob_cutoff, class_prob_cutoff,
                 boxes_per_cell, cell_box_size,
-                rows, cols,
+                rows, cols, scale_x_y,
                 height_norm, width_norm,
                 if_true_sigmoid_else_softmax
             );
@@ -170,9 +170,11 @@ namespace cv { namespace dnn { namespace cuda4dnn {
         csl::Tensor<T> biasTensor;
         std::size_t classes, boxes_per_cell;
         std::size_t width_norm, height_norm;
-        SquashMethod squash_type;
+        T scale_x_y;
 
+        SquashMethod squash_type;
         T object_prob_cutoff, class_prob_cutoff;
+
         T nms_iou_threshold;
     };
 

--- a/modules/dnn/src/layers/region_layer.cpp
+++ b/modules/dnn/src/layers/region_layer.cpp
@@ -405,6 +405,8 @@ public:
         config.height_norm = height_norm;
         config.width_norm = width_norm;
 
+        config.scale_x_y = scale_x_y;
+
         config.object_prob_cutoff = (classfix == -1) ? 0.5 : 0.0;
         config.class_prob_cutoff = thresh;
 


### PR DESCRIPTION
#17148 for CUDA backend

OCV CPU vs CUDA FP32
```
Relative Error >> Total: 0.00654598, Average: 7.11095e-08, Max: 2.4893e-05
```

GTX 1050 Mobile with 608 x 608 input

Model      | Inference FPS | Inference FPS (with #16900) | Inference + NMS FPS  | 
------------ | ------------------- | --------------------------------------- | ------------------------------ |
YOLOv3  | 10.42              | 10.91                                       |
YOLOv4  | 10.31              | 10.56                                       | 9.71

Code: https://gist.github.com/YashasSamaga/2b98b7ebd62b9719f81941bccabd2e52

```
NOTE: NMS not included.

YOLO v4
OCV CPU >> init: 1120.1ms, inference: 855.422ms
CUDA FP32 >> init: 624.283ms, inference: 96.9914ms


YOLO v3
OCV CPU >> init: 709.338ms, inference: 610.165ms
CUDA FP32 >> init: 384.22ms, inference: 95.1821ms
```

Code: https://gist.github.com/YashasSamaga/a292cbf0ff0cc388d8bab0ae60c9dabf

I tried to benchmark with darknet but I'm not sure if this is correct because there is a big difference (or maybe OCV is that fast) :

`./darknet detector demo cfg/coco.data cfg/yolov4.cfg yolov4.weights demo.mp4 -benchmark`

stabilizes at 8.3 average FPS after a several seconds.

`./darknet detector test cfg/coco.data cfg/yolov4.cfg yolov4.weights data/dog.jpg` gives ~8.6 FPS (116.4ms average of 5 runs)

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under OpenCV (BSD) License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [x] The PR is proposed to proper branch
- [ ] There is reference to original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake

<cut/>

```
force_builders=Custom
buildworker:Custom=linux-4
build_image:Custom=ubuntu-cuda:18.04
```
