### PR TITLE
cuda4dnn(Slice): fix regression from 3.4 port

### DIFF
--- a/modules/dnn/src/layers/slice_layer.cpp
+++ b/modules/dnn/src/layers/slice_layer.cpp
@@ -373,7 +373,7 @@ public:
         auto context = reinterpret_cast<csl::CSLContext*>(context_);
 
         std::vector<std::vector<std::size_t>> offsets;
-        for (const auto& ranges : sliceRanges)
+        for (const auto& ranges : finalSliceRanges)
         {
             std::vector<std::size_t> offsets_i;
             for (const auto& range : ranges)


### PR DESCRIPTION
### Pull Request Readiness Checklist

#17222 introduced `finalSliceRanges` as a replacement for `sliceRanges`. When #17231 was merged into master, the `sliceRanges` was not changed to `finalSliceRanges` in `initCUDA`. This tipped off assertions in the SliceOp primitive.

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under OpenCV (BSD) License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [x] The PR is proposed to proper branch
- [ ] There is reference to original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake

<cut/>

```
force_builders=Custom
buildworker:Custom=linux-4
build_image:Custom=ubuntu-cuda:18.04
```
