### PR TITLE
G-API: "deownification" corrections

### DIFF
--- a/modules/gapi/include/opencv2/gapi/gmat.hpp
+++ b/modules/gapi/include/opencv2/gapi/gmat.hpp
@@ -209,14 +209,19 @@ static inline GMatDesc empty_gmat_desc() { return GMatDesc{-1,-1,{-1,-1}}; }
 GAPI_EXPORTS GMatDesc descr_of(const cv::UMat &mat);
 #endif // !defined(GAPI_STANDALONE)
 
-GAPI_EXPORTS GMatDesc descr_of(const cv::Mat &mat);
-/** @} */
-
-// FIXME: WHY??? WHY it is under different namespace?
+//Fwd declarations
 namespace gapi { namespace own {
     class Mat;
     GAPI_EXPORTS GMatDesc descr_of(const Mat &mat);
 }}//gapi::own
+
+#if !defined(GAPI_STANDALONE)
+GAPI_EXPORTS GMatDesc descr_of(const cv::Mat &mat);
+#else
+using gapi::own::descr_of;
+#endif
+
+/** @} */
 
 GAPI_EXPORTS std::ostream& operator<<(std::ostream& os, const cv::GMatDesc &desc);
 

--- a/modules/gapi/include/opencv2/gapi/opencv_includes.hpp
+++ b/modules/gapi/include/opencv2/gapi/opencv_includes.hpp
@@ -16,6 +16,17 @@
 #  include <opencv2/core/base.hpp>
 #else   // Without OpenCV
 #  include <opencv2/gapi/own/cvdefs.hpp>
+#  include <opencv2/gapi/own/types.hpp>  // cv::gapi::own::Rect/Size/Point
+#  include <opencv2/gapi/own/scalar.hpp> // cv::gapi::own::Scalar
+#  include <opencv2/gapi/own/mat.hpp>
+// replacement of cv's structures:
+namespace cv {
+    using Rect   = gapi::own::Rect;
+    using Size   = gapi::own::Size;
+    using Point  = gapi::own::Point;
+    using Scalar = gapi::own::Scalar;
+    using Mat    = gapi::own::Mat;
+}  // namespace cv
 #endif // !defined(GAPI_STANDALONE)
 
 #endif // OPENCV_GAPI_OPENCV_INCLUDES_HPP

--- a/modules/gapi/include/opencv2/gapi/own/cvdefs.hpp
+++ b/modules/gapi/include/opencv2/gapi/own/cvdefs.hpp
@@ -9,9 +9,6 @@
 #define OPENCV_GAPI_CV_DEFS_HPP
 
 #if defined(GAPI_STANDALONE)
-#include <opencv2/gapi/own/types.hpp> // cv::gapi::own::Rect/Size/Point
-#include <opencv2/gapi/own/scalar.hpp> // cv::gapi::own::Scalar
-
 // Simulate OpenCV definitions taken from various
 // OpenCV interface headers if G-API is built in a
 // standalone mode.
@@ -139,15 +136,6 @@ enum InterpolationFlags{
     INTER_LINEAR_EXACT   = 5,
     INTER_MAX            = 7,
 };
-// replacement of cv's structures:
-namespace gapi { namespace own {
-class Mat;
-}} // namespace gapi::own
-using Rect   = gapi::own::Rect;
-using Size   = gapi::own::Size;
-using Point  = gapi::own::Point;
-using Scalar = gapi::own::Scalar;
-using Mat    = gapi::own::Mat;
 } // namespace cv
 
 static inline int cvFloor( double value )

--- a/modules/gapi/include/opencv2/gapi/own/mat.hpp
+++ b/modules/gapi/include/opencv2/gapi/own/mat.hpp
@@ -17,6 +17,7 @@
 #include <memory>                   //std::shared_ptr
 #include <cstring>                  //std::memcpy
 #include <numeric>                  //std::accumulate
+#include <vector>
 #include <opencv2/gapi/util/throw.hpp>
 
 namespace cv { namespace gapi { namespace own {

--- a/modules/gapi/src/api/gmat.cpp
+++ b/modules/gapi/src/api/gmat.cpp
@@ -48,9 +48,9 @@ namespace{
     }
 }
 
+#if !defined(GAPI_STANDALONE)
 cv::GMatDesc cv::descr_of(const cv::Mat &mat)
 {
-#if !defined(GAPI_STANDALONE)
     const auto mat_dims = mat.size.dims();
 
     if (mat_dims == 2)
@@ -62,12 +62,8 @@ cv::GMatDesc cv::descr_of(const cv::Mat &mat)
         dims[i] = mat.size[i];
     }
     return GMatDesc{mat.depth(), std::move(dims)};
-#else
-    return (mat.dims.empty())
-        ? GMatDesc{mat.depth(), mat.channels(), {mat.cols, mat.rows}}
-        : GMatDesc{mat.depth(), mat.dims};
-#endif
 }
+#endif
 
 cv::GMatDesc cv::gapi::own::descr_of(const Mat &mat)
 {

--- a/modules/gapi/src/api/gscalar.cpp
+++ b/modules/gapi/src/api/gscalar.cpp
@@ -46,6 +46,8 @@ const cv::GOrigin& cv::GScalar::priv() const
     return *m_priv;
 }
 
+//N.B. if we ever need more complicated logic for desc_of(cv::(gapi::own::)Scalar)
+//dispatching should be done in the same way as for cv::(gapi::own)::Mat
 cv::GScalarDesc cv::descr_of(const cv::Scalar &)
 {
     return empty_scalar_desc();


### PR DESCRIPTION
- moved "standalone" aliases of cv types to `opencv_includes.hpp` to
keep responsibility principle aplied
- introduced correct aliasing for `descr_of(Mat)` function for
standalone case

```
force_builders=ARMv7,Custom,Custom Win,Custom Mac
build_image:Custom=centos:7
buildworker:Custom=linux-1
build_gapi_standalone:Custom=ade-0.1.1f

build_gapi_standalone:Linux x64=ade-0.1.1f
build_gapi_standalone:Win64=ade-0.1.1f
build_gapi_standalone:Mac=ade-0.1.1f
build_gapi_standalone:Linux x64 Debug=ade-0.1.1f

build_image:Custom Win=openvino-2020.2.0
build_image:Custom Mac=openvino-2020.2.0

test_modules:Custom Win=dnn,python2,python3,java
test_modules:Custom Mac=dnn,python2,python3,java
```
### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under OpenCV (BSD) License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [x] The PR is proposed to proper branch
- [x] There is reference to original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake

@mpashchenkov, FYI