### PR TITLE
Create multiscale_sharpen

### DIFF
--- a/samples/cpp/multiscale_sharpen
+++ b/samples/cpp/multiscale_sharpen
@@ -1,0 +1,82 @@
+#include "opencv2/core/utility.hpp"
+#include "opencv2/imgproc.hpp"
+#include "opencv2/imgcodecs.hpp"
+#include "opencv2/highgui.hpp"
+#include <stdio.h>
+using namespace cv;
+using namespace std;
+int sharpenRadius = 1;
+Mat image, sharpen;
+const char* window_name1 = "multiScaleSharpen";
+Mat multiScaleSharpen(Mat Src, int Radius)
+{
+    int rows = Src.rows;
+    int cols = Src.cols;
+    int cha = Src.channels();
+    Mat B1, B2, B3;
+    GaussianBlur(Src, B1, Size(Radius, Radius), 1.0, 1.0);
+    GaussianBlur(Src, B2, Size(Radius * 2 - 1, Radius * 2 - 1), 2.0, 2.0);
+    GaussianBlur(Src, B3, Size(Radius * 4 - 1, Radius * 4 - 1), 4.0, 4.0);
+    double w1 = 0.5;
+    double w2 = 0.5;
+    double w3 = 0.25;
+    cv::Mat dest = cv::Mat::zeros(Src.size(), Src.type());
+    for (size_t i = 0; i < rows; i++)
+    {
+        uchar* src_ptr = Src.ptr<uchar>(i);
+        uchar* dest_ptr = dest.ptr<uchar>(i);
+        uchar* B1_ptr = B1.ptr<uchar>(i);
+        uchar* B2_ptr = B2.ptr<uchar>(i);
+        uchar* B3_ptr = B3.ptr<uchar>(i);
+        for (size_t j = 0; j < cols; j++)
+        {
+            for (size_t c = 0; c < cha; c++)
+            {
+                int  D1 = src_ptr[3 * j + c] - B1_ptr[3 * j + c];
+                int  D2 = B1_ptr[3 * j + c] - B2_ptr[3 * j + c];
+                int  D3 = B2_ptr[3 * j + c] - B3_ptr[3 * j + c];
+                int  sign = (D1 > 0) ? 1 : -1;
+                dest_ptr[3 * j + c] = saturate_cast<uchar>((1 - w1 * sign)*D1 - w2 * D2 + w3 * D3 + src_ptr[3 * j + c]);
+            }
+        }
+    }
+    return dest;
+}
+// define a trackbar callback
+static void onTrackbar(int, void*)
+{
+    sharpen = multiScaleSharpen(image, sharpenRadius *2+1);
+    imshow(window_name1, sharpen);
+}
+static void help(const char** argv)
+{
+    printf("\nThis sample demonstrates multiScaleSharpen detection\n"
+           "Call:\n"
+           "    %s [image_name -- Default is lena.jpg]\n\n", argv[0]);
+}
+const char* keys =
+{
+    "{help h||}{@image |lena.jpg|input image name}"
+};
+int main( int argc, const char** argv )
+{
+    help(argv);
+    CommandLineParser parser(argc, argv, keys);
+    string filename = parser.get<string>(0);
+    image = imread(samples::findFile(filename), IMREAD_COLOR);
+    if(image.empty())
+    {
+        printf("Cannot read image file: %s\n", filename.c_str());
+        help(argv);
+        return -1;
+    }
+    // Create a window
+    namedWindow(window_name1, 1);
+    // create a toolbar
+    createTrackbar("Canny threshold default", window_name1, &sharpenRadius, 7, onTrackbar);
+    // Show the image
+    onTrackbar(0, 0);
+    // Wait for a key stroke; the same function arranges events processing
+    waitKey(0);
+    return 0;
+}

--- a/samples/cpp/multiscale_sharpen
+++ b/samples/cpp/multiscale_sharpen
@@ -1,18 +1,25 @@
+// This file is part of OpenCV project.
+// It is subject to the license terms in the LICENSE file found in the top-level directory
+// of this distribution and at http://opencv.org/license.html.
+
 #include "opencv2/core/utility.hpp"
 #include "opencv2/imgproc.hpp"
 #include "opencv2/imgcodecs.hpp"
 #include "opencv2/highgui.hpp"
 #include <stdio.h>
+
 using namespace cv;
 using namespace std;
+
 int sharpenRadius = 1;
 Mat image, sharpen;
 const char* window_name1 = "multiScaleSharpen";
+
 Mat multiScaleSharpen(Mat Src, int Radius)
 {
     int rows = Src.rows;
     int cols = Src.cols;
-    int cha = Src.channels();
+    int channels = Src.channels();
     Mat B1, B2, B3;
     GaussianBlur(Src, B1, Size(Radius, Radius), 1.0, 1.0);
     GaussianBlur(Src, B2, Size(Radius * 2 - 1, Radius * 2 - 1), 2.0, 2.0);
@@ -30,7 +37,7 @@ Mat multiScaleSharpen(Mat Src, int Radius)
         uchar* B3_ptr = B3.ptr<uchar>(i);
         for (size_t j = 0; j < cols; j++)
         {
-            for (size_t c = 0; c < cha; c++)
+            for (size_t c = 0; c < channels; c++)
             {
                 int  D1 = src_ptr[3 * j + c] - B1_ptr[3 * j + c];
                 int  D2 = B1_ptr[3 * j + c] - B2_ptr[3 * j + c];

--- a/samples/cpp/multiscale_sharpen.cpp
+++ b/samples/cpp/multiscale_sharpen.cpp
@@ -21,7 +21,7 @@ static void onTrackbar(int, void*)
 }
 static void help(const char** argv)
 {
-    printf("\nThis sample demonstrates multiScaleSharpen detection\n"
+    printf("\nThis sample demonstrates multiScaleSharpen image processing\n"
            "Call:\n"
            "    %s [image_name -- Default is lena.jpg]\n\n", argv[0]);
 }
@@ -44,7 +44,7 @@ int main( int argc, const char** argv )
     // Create a window
     namedWindow(window_name1, 1);
     // create a toolbar
-    createTrackbar("Canny threshold default", window_name1, &sharpenRadius, 7, onTrackbar);
+    createTrackbar("multiScaleSharpen default", window_name1, &sharpenRadius, 7, onTrackbar);
     // Show the image
     onTrackbar(0, 0);
     // Wait for a key stroke; the same function arranges events processing

--- a/samples/cpp/multiscale_sharpen.cpp
+++ b/samples/cpp/multiscale_sharpen.cpp
@@ -11,40 +11,8 @@ int sharpenRadius = 1;
 Mat image, sharpen;
 const char* window_name1 = "multiScaleSharpen";
 
-Mat multiScaleSharpen(Mat Src, int Radius)
-{
-    int rows = Src.rows;
-    int cols = Src.cols;
-    int channels = Src.channels();
-    Mat B1, B2, B3;
-    GaussianBlur(Src, B1, Size(Radius, Radius), 1.0, 1.0);
-    GaussianBlur(Src, B2, Size(Radius * 2 - 1, Radius * 2 - 1), 2.0, 2.0);
-    GaussianBlur(Src, B3, Size(Radius * 4 - 1, Radius * 4 - 1), 4.0, 4.0);
-    double w1 = 0.5;
-    double w2 = 0.5;
-    double w3 = 0.25;
-    cv::Mat dest = cv::Mat::zeros(Src.size(), Src.type());
-    for (size_t i = 0; i < rows; i++)
-    {
-        uchar* src_ptr = Src.ptr<uchar>(i);
-        uchar* dest_ptr = dest.ptr<uchar>(i);
-        uchar* B1_ptr = B1.ptr<uchar>(i);
-        uchar* B2_ptr = B2.ptr<uchar>(i);
-        uchar* B3_ptr = B3.ptr<uchar>(i);
-        for (size_t j = 0; j < cols; j++)
-        {
-            for (size_t c = 0; c < channels; c++)
-            {
-                int  D1 = src_ptr[3 * j + c] - B1_ptr[3 * j + c];
-                int  D2 = B1_ptr[3 * j + c] - B2_ptr[3 * j + c];
-                int  D3 = B2_ptr[3 * j + c] - B3_ptr[3 * j + c];
-                int  sign = (D1 > 0) ? 1 : -1;
-                dest_ptr[3 * j + c] = saturate_cast<uchar>((1 - w1 * sign)*D1 - w2 * D2 + w3 * D3 + src_ptr[3 * j + c]);
-            }
-        }
-    }
-    return dest;
-}
+//multi-scale detail boosting
+Mat multiScaleSharpen(Mat, int);
 // define a trackbar callback
 static void onTrackbar(int, void*)
 {
@@ -82,4 +50,38 @@ int main( int argc, const char** argv )
     // Wait for a key stroke; the same function arranges events processing
     waitKey(0);
     return 0;
+}
+Mat multiScaleSharpen(Mat Src, int Radius)
+{
+    size_t rows = Src.rows;
+    size_t cols = Src.cols;
+    size_t channels = Src.channels();
+    Mat B1, B2, B3;
+    GaussianBlur(Src, B1, Size(Radius, Radius), 1.0, 1.0);
+    GaussianBlur(Src, B2, Size(Radius * 2 - 1, Radius * 2 - 1), 2.0, 2.0);
+    GaussianBlur(Src, B3, Size(Radius * 4 - 1, Radius * 4 - 1), 4.0, 4.0);
+    double w1 = 0.5;
+    double w2 = 0.5;
+    double w3 = 0.25;
+    cv::Mat dest = cv::Mat::zeros(Src.size(), Src.type());
+    for (size_t i = 0; i < rows; i++)
+    {
+        uchar* src_ptr = Src.ptr<uchar>(i);
+        uchar* dest_ptr = dest.ptr<uchar>(i);
+        uchar* B1_ptr = B1.ptr<uchar>(i);
+        uchar* B2_ptr = B2.ptr<uchar>(i);
+        uchar* B3_ptr = B3.ptr<uchar>(i);
+        for (size_t j = 0; j < cols; j++)
+        {
+            for (size_t c = 0; c < channels; c++)
+            {
+                int  D1 = src_ptr[3 * j + c] - B1_ptr[3 * j + c];
+                int  D2 = B1_ptr[3 * j + c] - B2_ptr[3 * j + c];
+                int  D3 = B2_ptr[3 * j + c] - B3_ptr[3 * j + c];
+                int  sign = (D1 > 0) ? 1 : -1;
+                dest_ptr[3 * j + c] = saturate_cast<uchar>((1 - w1 * sign)*D1 - w2 * D2 + w3 * D3 + src_ptr[3 * j + c]);
+            }
+        }
+    }
+    return dest;
 }

--- a/samples/cpp/multiscale_sharpen.cpp
+++ b/samples/cpp/multiscale_sharpen.cpp
@@ -1,7 +1,3 @@
-// This file is part of OpenCV project.
-// It is subject to the license terms in the LICENSE file found in the top-level directory
-// of this distribution and at http://opencv.org/license.html.
-
 #include "opencv2/core/utility.hpp"
 #include "opencv2/imgproc.hpp"
 #include "opencv2/imgcodecs.hpp"

--- a/samples/cpp/multiscale_sharpen.cpp
+++ b/samples/cpp/multiscale_sharpen.cpp
@@ -53,9 +53,9 @@ int main( int argc, const char** argv )
 }
 Mat multiScaleSharpen(Mat Src, int Radius)
 {
-    size_t rows = Src.rows;
-    size_t cols = Src.cols;
-    size_t channels = Src.channels();
+    int rows = Src.rows;
+    int cols = Src.cols;
+    int channels = Src.channels();
     Mat B1, B2, B3;
     GaussianBlur(Src, B1, Size(Radius, Radius), 1.0, 1.0);
     GaussianBlur(Src, B2, Size(Radius * 2 - 1, Radius * 2 - 1), 2.0, 2.0);
@@ -64,16 +64,16 @@ Mat multiScaleSharpen(Mat Src, int Radius)
     double w2 = 0.5;
     double w3 = 0.25;
     cv::Mat dest = cv::Mat::zeros(Src.size(), Src.type());
-    for (size_t i = 0; i < rows; i++)
+    for (int i = 0; i < rows; i++)
     {
         uchar* src_ptr = Src.ptr<uchar>(i);
         uchar* dest_ptr = dest.ptr<uchar>(i);
         uchar* B1_ptr = B1.ptr<uchar>(i);
         uchar* B2_ptr = B2.ptr<uchar>(i);
         uchar* B3_ptr = B3.ptr<uchar>(i);
-        for (size_t j = 0; j < cols; j++)
+        for (int j = 0; j < cols; j++)
         {
-            for (size_t c = 0; c < channels; c++)
+            for (int c = 0; c < channels; c++)
             {
                 int  D1 = src_ptr[3 * j + c] - B1_ptr[3 * j + c];
                 int  D2 = B1_ptr[3 * j + c] - B2_ptr[3 * j + c];


### PR DESCRIPTION
### This pullrequest changes 0516
This enhanced algorithm comes from paper
**Dark image enhancement based on binocular target contrast and multi-scale detail enhancement**
https://ieeexplore.ieee.org/abstract/document/7351031/
Section 2.3，there is Screenshot
![e57b8fb4-c4a8-45a1-bcce-a2d973b644ba](https://user-images.githubusercontent.com/16490259/81754088-dcbdbd80-94e7-11ea-9ff7-1e6106fb61bf.png)

The core idea of ​​the paper is similar to Retinex, which uses Gaussian blur at three scales, and then subtracts from the original image to obtain different levels of detail information, and then merges these details into the original image through a certain combination, which is strengthened The ability of original image information. 
It is worth mentioning that the coefficients of D1 have been specially processed. The algorithm has simple coding and obvious effects.

**Core function：**
```
Mat multiScaleSharpen(Mat Src, int Radius)
{
    int rows = Src.rows;
    int cols = Src.cols;
    int channels = Src.channels();
    Mat B1, B2, B3;
    GaussianBlur(Src, B1, Size(Radius, Radius), 1.0, 1.0);
    GaussianBlur(Src, B2, Size(Radius * 2 - 1, Radius * 2 - 1), 2.0, 2.0);
    GaussianBlur(Src, B3, Size(Radius * 4 - 1, Radius * 4 - 1), 4.0, 4.0);
    double w1 = 0.5;
    double w2 = 0.5;
    double w3 = 0.25;
    cv::Mat dest = cv::Mat::zeros(Src.size(), Src.type());
    for (size_t i = 0; i < rows; i++)
    {
        uchar* src_ptr = Src.ptr<uchar>(i);
        uchar* dest_ptr = dest.ptr<uchar>(i);
        uchar* B1_ptr = B1.ptr<uchar>(i);
        uchar* B2_ptr = B2.ptr<uchar>(i);
        uchar* B3_ptr = B3.ptr<uchar>(i);
        for (size_t j = 0; j < cols; j++)
        {
            for (size_t c = 0; c < channels; c++)
            {
                int  D1 = src_ptr[3 * j + c] - B1_ptr[3 * j + c];
                int  D2 = B1_ptr[3 * j + c] - B2_ptr[3 * j + c];
                int  D3 = B2_ptr[3 * j + c] - B3_ptr[3 * j + c];
                int  sign = (D1 > 0) ? 1 : -1;
                dest_ptr[3 * j + c] = saturate_cast<uchar>((1 - w1 * sign)*D1 - w2 * D2 + w3 * D3 + src_ptr[3 * j + c]);
            }
        }
    }
    return dest;
}
```

**Results show：**
![无标题](https://user-images.githubusercontent.com/16490259/81753991-a122f380-94e7-11ea-8e36-094cab472fbb.png)

CPP Shampe was PR to illustrate the algorithm。
### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under OpenCV (BSD) License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [x] The PR is proposed to proper branch
- [ ] There is reference to original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
