### PR TITLE
fix bug for CHECK bpp issue

### DIFF
--- a/modules/imgcodecs/src/grfmt_tiff.cpp
+++ b/modules/imgcodecs/src/grfmt_tiff.cpp
@@ -273,7 +273,11 @@ bool TiffDecoder::readHeader()
         {
             bool isGrayScale = photometric == PHOTOMETRIC_MINISWHITE || photometric == PHOTOMETRIC_MINISBLACK;
             uint16 bpp = 8, ncn = isGrayScale ? 1 : 3;
-            TIFFGetField(tif, TIFFTAG_BITSPERSAMPLE, &bpp);
+            if (0 == TIFFGetField(tif, TIFFTAG_BITSPERSAMPLE, &bpp))
+            {
+                // TIFF bi-level images don't require TIFFTAG_BITSPERSAMPLE tag
+                bpp = 1;
+            }
             CV_TIFF_CHECK_CALL_DEBUG(TIFFGetField(tif, TIFFTAG_SAMPLESPERPIXEL, &ncn));
 
             m_width = wdth;
@@ -430,7 +434,11 @@ bool  TiffDecoder::readData( Mat& img )
         int is_tiled = TIFFIsTiled(tif) != 0;
         bool isGrayScale = photometric == PHOTOMETRIC_MINISWHITE || photometric == PHOTOMETRIC_MINISBLACK;
         uint16 bpp = 8, ncn = isGrayScale ? 1 : 3;
-        TIFFGetField(tif, TIFFTAG_BITSPERSAMPLE, &bpp);
+        if (0 == TIFFGetField(tif, TIFFTAG_BITSPERSAMPLE, &bpp))
+        {
+            // TIFF bi-level images don't require TIFFTAG_BITSPERSAMPLE tag
+            bpp = 1;
+        }
         CV_TIFF_CHECK_CALL_DEBUG(TIFFGetField(tif, TIFFTAG_SAMPLESPERPIXEL, &ncn));
         uint16 img_orientation = ORIENTATION_TOPLEFT;
         CV_TIFF_CHECK_CALL_DEBUG(TIFFGetField(tif, TIFFTAG_ORIENTATION, &img_orientation));

--- a/modules/imgcodecs/src/grfmt_tiff.cpp
+++ b/modules/imgcodecs/src/grfmt_tiff.cpp
@@ -273,7 +273,7 @@ bool TiffDecoder::readHeader()
         {
             bool isGrayScale = photometric == PHOTOMETRIC_MINISWHITE || photometric == PHOTOMETRIC_MINISBLACK;
             uint16 bpp = 8, ncn = isGrayScale ? 1 : 3;
-            CV_TIFF_CHECK_CALL(TIFFGetField(tif, TIFFTAG_BITSPERSAMPLE, &bpp));
+            TIFFGetField(tif, TIFFTAG_BITSPERSAMPLE, &bpp);
             CV_TIFF_CHECK_CALL_DEBUG(TIFFGetField(tif, TIFFTAG_SAMPLESPERPIXEL, &ncn));
 
             m_width = wdth;

--- a/modules/imgcodecs/src/grfmt_tiff.cpp
+++ b/modules/imgcodecs/src/grfmt_tiff.cpp
@@ -430,7 +430,7 @@ bool  TiffDecoder::readData( Mat& img )
         int is_tiled = TIFFIsTiled(tif) != 0;
         bool isGrayScale = photometric == PHOTOMETRIC_MINISWHITE || photometric == PHOTOMETRIC_MINISBLACK;
         uint16 bpp = 8, ncn = isGrayScale ? 1 : 3;
-        CV_TIFF_CHECK_CALL(TIFFGetField(tif, TIFFTAG_BITSPERSAMPLE, &bpp));
+        TIFFGetField(tif, TIFFTAG_BITSPERSAMPLE, &bpp);
         CV_TIFF_CHECK_CALL_DEBUG(TIFFGetField(tif, TIFFTAG_SAMPLESPERPIXEL, &ncn));
         uint16 img_orientation = ORIENTATION_TOPLEFT;
         CV_TIFF_CHECK_CALL_DEBUG(TIFFGetField(tif, TIFFTAG_ORIENTATION, &img_orientation));

--- a/modules/imgcodecs/test/test_tiff.cpp
+++ b/modules/imgcodecs/test/test_tiff.cpp
@@ -333,6 +333,17 @@ TEST(Imgcodecs_Tiff, decode_black_and_write_image_pr12989_default)
     EXPECT_EQ(CV_8UC3, img.type()) << cv::typeToString(img.type());
 }
 
+TEST(Imgcodecs_Tiff, decode_black_and_write_image_pr12989_default)
+{
+    const string filename = cvtest::findDataFile("readwrite/bitsperpixel1_min.tiff");
+    cv::Mat img;
+    ASSERT_NO_THROW(img = cv::imread(filename));  // by default image type is CV_8UC3
+    ASSERT_FALSE(img.empty());
+    EXPECT_EQ(64, img.cols);
+    EXPECT_EQ(64, img.rows);
+    EXPECT_EQ(CV_8UC3, img.type()) << cv::typeToString(img.type());
+}
+
 #endif
 
 }} // namespace

--- a/modules/imgcodecs/test/test_tiff.cpp
+++ b/modules/imgcodecs/test/test_tiff.cpp
@@ -308,7 +308,7 @@ TEST(Imgcodecs_Tiff, imdecode_no_exception_temporary_file_removed)
 }
 
 
-TEST(Imgcodecs_Tiff, decode_black_and_write_image_pr12989)
+TEST(Imgcodecs_Tiff, decode_black_and_write_image_pr12989_grayscale)
 {
     const string filename = cvtest::findDataFile("readwrite/bitsperpixel1.tiff");
     cv::Mat img;
@@ -333,7 +333,7 @@ TEST(Imgcodecs_Tiff, decode_black_and_write_image_pr12989_default)
     EXPECT_EQ(CV_8UC3, img.type()) << cv::typeToString(img.type());
 }
 
-TEST(Imgcodecs_Tiff, decode_black_and_write_image_pr17275)
+TEST(Imgcodecs_Tiff, decode_black_and_write_image_pr17275_grayscale)
 {
     const string filename = cvtest::findDataFile("readwrite/bitsperpixel1_min.tiff");
     cv::Mat img;

--- a/modules/imgcodecs/test/test_tiff.cpp
+++ b/modules/imgcodecs/test/test_tiff.cpp
@@ -333,6 +333,20 @@ TEST(Imgcodecs_Tiff, decode_black_and_write_image_pr12989_default)
     EXPECT_EQ(CV_8UC3, img.type()) << cv::typeToString(img.type());
 }
 
+TEST(Imgcodecs_Tiff, decode_black_and_write_image_pr12989)
+{
+    const string filename = cvtest::findDataFile("readwrite/bitsperpixel1_min.tiff");
+    cv::Mat img;
+    ASSERT_NO_THROW(img = cv::imread(filename, IMREAD_GRAYSCALE));
+    ASSERT_FALSE(img.empty());
+    EXPECT_EQ(64, img.cols);
+    EXPECT_EQ(64, img.rows);
+    EXPECT_EQ(CV_8UC1, img.type()) << cv::typeToString(img.type());
+    // Check for 0/255 values only: 267 + 3829 = 64*64
+    EXPECT_EQ(267, countNonZero(img == 0));
+    EXPECT_EQ(3829, countNonZero(img == 255));
+}
+
 TEST(Imgcodecs_Tiff, decode_black_and_write_image_pr12989_default)
 {
     const string filename = cvtest::findDataFile("readwrite/bitsperpixel1_min.tiff");

--- a/modules/imgcodecs/test/test_tiff.cpp
+++ b/modules/imgcodecs/test/test_tiff.cpp
@@ -333,7 +333,7 @@ TEST(Imgcodecs_Tiff, decode_black_and_write_image_pr12989_default)
     EXPECT_EQ(CV_8UC3, img.type()) << cv::typeToString(img.type());
 }
 
-TEST(Imgcodecs_Tiff, decode_black_and_write_image_pr12989)
+TEST(Imgcodecs_Tiff, decode_black_and_write_image_pr17275)
 {
     const string filename = cvtest::findDataFile("readwrite/bitsperpixel1_min.tiff");
     cv::Mat img;
@@ -347,7 +347,7 @@ TEST(Imgcodecs_Tiff, decode_black_and_write_image_pr12989)
     EXPECT_EQ(3829, countNonZero(img == 255));
 }
 
-TEST(Imgcodecs_Tiff, decode_black_and_write_image_pr12989_default)
+TEST(Imgcodecs_Tiff, decode_black_and_write_image_pr17275_default)
 {
     const string filename = cvtest::findDataFile("readwrite/bitsperpixel1_min.tiff");
     cv::Mat img;


### PR DESCRIPTION
**Merge with extra**: https://github.com/opencv/opencv_extra/pull/758

For the tiff file which has 1 bpp, it will fail after calling CV_TIFF_CHECK_CALL. But TIFFGetField for bpp failed will not influence the final image decoding result. I have attached a tiff file for this case.(https://drive.google.com/file/d/1NurdgX8QF_7Nig-k6n_BFDY52_pY8Yob/view?usp=sharing)
Too many CHECK will result regression.

<cut/>

```
opencv_extra=master
```

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [ ] I agree to contribute to the project under OpenCV (BSD) License.
- [ ] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [ ] The PR is proposed to proper branch
- [ ] There is reference to original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
