### PR TITLE
Increase test threshold for YOLOv3 on OCL FP16

### DIFF
--- a/modules/dnn/test/test_common.impl.hpp
+++ b/modules/dnn/test/test_common.impl.hpp
@@ -106,6 +106,7 @@ void normAssertDetections(
         int testClassId = testClassIds[i];
         const cv::Rect2d& testBox = testBoxes[i];
         bool matched = false;
+        double topIoU = 0;
         for (int j = 0; j < refBoxes.size() && !matched; ++j)
         {
             if (!matchedRefBoxes[j] && testClassId == refClassIds[j] &&
@@ -113,7 +114,8 @@ void normAssertDetections(
             {
                 double interArea = (testBox & refBoxes[j]).area();
                 double iou = interArea / (testBox.area() + refBoxes[j].area() - interArea);
-                if (std::abs(iou - 1.0) < boxes_iou_diff)
+                topIoU = std::max(topIoU, iou);
+                if (1.0 - iou < boxes_iou_diff)
                 {
                     matched = true;
                     matchedRefBoxes[j] = true;
@@ -121,8 +123,11 @@ void normAssertDetections(
             }
         }
         if (!matched)
+        {
             std::cout << cv::format("Unmatched prediction: class %d score %f box ",
                                     testClassId, testScore) << testBox << std::endl;
+            std::cout << "Highest IoU: " << topIoU << std::endl;
+        }
         EXPECT_TRUE(matched) << comment;
     }
 

--- a/modules/dnn/test/test_darknet_importer.cpp
+++ b/modules/dnn/test/test_darknet_importer.cpp
@@ -464,7 +464,7 @@ TEST_P(Test_Darknet_nets, YOLOv3)
                                     1, 2,  0.997412f, 0.647584f, 0.459939f, 0.821038f, 0.663947f); // a car
 
     double scoreDiff = (target == DNN_TARGET_OPENCL_FP16 || target == DNN_TARGET_MYRIAD) ? 0.006 : 8e-5;
-    double iouDiff = (target == DNN_TARGET_OPENCL_FP16 || target == DNN_TARGET_MYRIAD) ? 0.018 : 3e-4;
+    double iouDiff = (target == DNN_TARGET_OPENCL_FP16 || target == DNN_TARGET_MYRIAD) ? 0.042 : 3e-4;
 
     std::string config_file = "yolov3.cfg";
     std::string weights_file = "yolov3.weights";
@@ -487,15 +487,10 @@ TEST_P(Test_Darknet_nets, YOLOv3)
 #if defined(INF_ENGINE_RELEASE)
     if (backend == DNN_BACKEND_INFERENCE_ENGINE_NN_BUILDER_2019)
     {
-        if (INF_ENGINE_VER_MAJOR_LE(2018050000) && target == DNN_TARGET_OPENCL)
+        if (target == DNN_TARGET_OPENCL)
             applyTestTag(CV_TEST_TAG_DNN_SKIP_IE_OPENCL, CV_TEST_TAG_DNN_SKIP_IE_VERSION);
-        else if (INF_ENGINE_VER_MAJOR_EQ(2019020000))
-        {
-            if (target == DNN_TARGET_OPENCL)
-                applyTestTag(CV_TEST_TAG_DNN_SKIP_IE_OPENCL, CV_TEST_TAG_DNN_SKIP_IE_VERSION);
-            if (target == DNN_TARGET_OPENCL_FP16)
-                applyTestTag(CV_TEST_TAG_DNN_SKIP_IE_OPENCL_FP16, CV_TEST_TAG_DNN_SKIP_IE_VERSION);
-        }
+        else if (target == DNN_TARGET_OPENCL_FP16 && INF_ENGINE_VER_MAJOR_LE(202010000))
+            applyTestTag(CV_TEST_TAG_DNN_SKIP_IE_OPENCL_FP16, CV_TEST_TAG_DNN_SKIP_IE_VERSION);
         else if (target == DNN_TARGET_MYRIAD &&
                  getInferenceEngineVPUType() == CV_DNN_INFERENCE_ENGINE_VPU_TYPE_MYRIAD_X)
             applyTestTag(CV_TEST_TAG_DNN_SKIP_IE_MYRIAD_X);


### PR DESCRIPTION
<cut/>

```
force_builders=Custom,Custom Win,Custom Mac
build_image:Custom=ubuntu-openvino-2020.1.0:16.04
#build_image:Custom=ubuntu-openvino-2019r3.0:16.04
build_image:Custom Win=openvino-2020.2.0
build_image:Custom Mac=openvino-2020.2.0

test_modules:Custom=dnn,python2,python3,java
test_modules:Custom Win=dnn,python2,python3,java
test_modules:Custom Mac=dnn,python2,python3,java

buildworker:Custom=linux-1
# disabled due high memory usage: test_opencl:Custom=ON
test_opencl:Custom=ON
test_bigdata:Custom=1
test_filter:Custom=*YOLO*
```