### PR TITLE
Compilation fixes for Mac Catalyst

### DIFF
--- a/modules/imgcodecs/CMakeLists.txt
+++ b/modules/imgcodecs/CMakeLists.txt
@@ -105,7 +105,7 @@ file(GLOB imgcodecs_ext_hdrs
 
 if(IOS)
   list(APPEND imgcodecs_srcs ${CMAKE_CURRENT_LIST_DIR}/src/ios_conversions.mm)
-  list(APPEND IMGCODECS_LIBRARIES "-framework Accelerate" "-framework CoreGraphics" "-framework QuartzCore" "-framework AssetsLibrary")
+  list(APPEND IMGCODECS_LIBRARIES "-framework Accelerate" "-framework CoreGraphics" "-framework QuartzCore")
 endif()
 if(APPLE_FRAMEWORK)
   list(APPEND IMGCODECS_LIBRARIES "-framework UIKit")

--- a/modules/videoio/src/cap_avfoundation.mm
+++ b/modules/videoio/src/cap_avfoundation.mm
@@ -383,7 +383,7 @@ int CvCaptureCAM::startCaptureDevice(int cameraNum) {
         [mCaptureDecompressedVideoOutput setVideoSettings:pixelBufferOptions];
         mCaptureDecompressedVideoOutput.alwaysDiscardsLateVideoFrames = YES;
 
-#if TARGET_OS_IPHONE || TARGET_IPHONE_SIMULATOR
+#if (TARGET_OS_IPHONE || TARGET_IPHONE_SIMULATOR) && !TARGET_OS_MACCATALYST
         mCaptureDecompressedVideoOutput.minFrameDuration = CMTimeMake(1, 30);
 #endif
 

--- a/modules/videoio/src/cap_ios_abstract_camera.mm
+++ b/modules/videoio/src/cap_ios_abstract_camera.mm
@@ -299,11 +299,13 @@
     }
     else
     {
+#if !TARGET_OS_MACCATALYST
         // Deprecated in 6.0; here for backward compatibility
         if ([self.captureVideoPreviewLayer isOrientationSupported])
         {
             [self.captureVideoPreviewLayer setOrientation:self.defaultAVCaptureVideoOrientation];
         }
+#endif
     }
 
     if (parentView != nil) {


### PR DESCRIPTION
This PR resolves a few compilation issues when targeting Mac Catalyst by using the `TARGET_OS_MACCATALYST` conditional around iOS APIs that are unavailable on the Mac platform.

Additionally, the removal of linkage to the AssetsLibrary framework was because that library is unavailable on Mac Catalyst. It appears that the iOS specific code in OpenCV doesn't include or link against that framework, and seems to work fine without it. Perhaps it was left over from older / removed code?

Although this PR doesn't fully resolve the related issue #17291, it's a step in the right direction.

### Pull Request Readiness Checklist

- [x] I agree to contribute to the project under OpenCV (BSD) License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [x] The PR is proposed to proper branch
- [x] There is reference to original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake

```
force_builders=Custom Mac
build_image:Custom Mac=osx_framework
allow_multiple_commits=1
```