### PR TITLE
ignore a features2d's test dependent on flann when flann module is absent

### DIFF
--- a/modules/features2d/test/test_matchers_algorithmic.cpp
+++ b/modules/features2d/test/test_matchers_algorithmic.cpp
@@ -558,6 +558,7 @@ TEST( Features2d_DMatch, read_write )
     ASSERT_NE( strstr(str.c_str(), "4.5"), (char*)0 );
 }
 
+#ifdef HAVE_OPENCV_FLANN
 TEST( Features2d_FlannBasedMatcher, read_write )
 {
     static const char* ymlfile = "%YAML:1.0\n---\n"
@@ -594,7 +595,7 @@ TEST( Features2d_FlannBasedMatcher, read_write )
 
     EXPECT_EQ(ymlfile, out);
 }
-
+#endif
 
 TEST(Features2d_DMatch, issue_11855)
 {


### PR DESCRIPTION
In the current master branch, building features2d and its test without flann causes build failure and the error log is below:
```
$ mkdir build && cd build && cmake -DBUILD_LIST="ts,features2d" .. && make -j8
...
--   OpenCV modules:
--     To be built:                 core features2d highgui imgcodecs imgproc ts videoio
--     Disabled:                    world
--     Disabled by dependency:      calib3d dnn flann gapi java_bindings_generator ml objdetect photo python_bindings_generator python_tests stitching video
--     Unavailable:                 java js python2 python3
--     Applications:                tests perf_tests apps
...
/home/yosshi999_for_entry/opencv/modules/features2d/test/test_matchers_algorithmic.cpp: In member function ‘virtual void opencv_test::{anonymous}::Features2d_FlannBasedMatcher_read_write_Test::Body()’:
/home/yosshi999_for_entry/opencv/modules/features2d/test/test_matchers_algorithmic.cpp:588:38: error: ‘FlannBasedMatcher’ has not been declared
     Ptr<DescriptorMatcher> matcher = FlannBasedMatcher::create();
                                      ^~~~~~~~~~~~~~~~~
```

This is because one test which depends on flann is not ignored even if flann is not to be built.
This test should be compiled only when HAVE_OPENCV_FLANN is enabled.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under OpenCV (BSD) License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [x] The PR is proposed to proper branch
- [ ] There is reference to original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
