### PR TITLE
Add eigen tensor conversions

### DIFF
--- a/modules/core/include/opencv2/core/eigen.hpp
+++ b/modules/core/include/opencv2/core/eigen.hpp
@@ -47,10 +47,10 @@
 
 #include "opencv2/core.hpp"
 
-#if EIGEN_WORLD_VERSION >= 3 && EIGEN_MINOR_VERSION >= 3
+#if EIGEN_WORLD_VERSION == 3 && EIGEN_MAJOR_VERSION >= 3
 #include <unsupported/Eigen/CXX11/Tensor>
 #define OPENCV_EIGEN_TENSOR_SUPPORT
-#endif // EIGEN_WORLD_VERSION >= 3 && EIGEN_MINOR_VERSION >= 3
+#endif // EIGEN_WORLD_VERSION >= 3 && EIGEN_MAJOR_VERSION >= 3
 
 #if defined _MSC_VER && _MSC_VER >= 1200
 #pragma warning( disable: 4714 ) //__forceinline is not inlined

--- a/modules/core/include/opencv2/core/eigen.hpp
+++ b/modules/core/include/opencv2/core/eigen.hpp
@@ -75,7 +75,7 @@ Usage:
 \code
 Eigen::Tensor<float, 3, Eigen::RowMajor> a_tensor(...);
 // populate tensor with values
-cv::Mat a_mat;
+Mat a_mat;
 eigen2cv(a_tensor, a_mat);
 \endcode
 */
@@ -105,7 +105,7 @@ The method converts a cv::Mat to an Eigen Tensor with shape (H x W x C) where:
 
 Usage:
 \code
-cv::Mat a_mat(...);
+Mat a_mat(...);
 // populate Mat with values
 Eigen::Tensor<float, 3, Eigen::RowMajor> a_tensor(...);
 cv2eigen(a_mat, a_tensor);
@@ -148,14 +148,14 @@ Explicit instantiation of the return type is required.
 The example below initializes a cv::Mat and produces an Eigen::TensorMap:
 \code
 float arr[] = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11};
-cv::Mat a_mat(2, 2, CV_32FC3, arr);
-Eigen::TensorMap<Eigen::Tensor<float, 3, Eigen::RowMajor>> color_tensor = cv2eigen_tensormap<float>(a_mat);
+Mat a_mat(2, 2, CV_32FC3, arr);
+Eigen::TensorMap<Eigen::Tensor<float, 3, Eigen::RowMajor>> a_tensormap = cv2eigen_tensormap<float>(a_mat);
 \endcode
 */
 template <typename _Tp> static inline
 Eigen::TensorMap<Eigen::Tensor<_Tp, 3, Eigen::RowMajor>> cv2eigen_tensormap(const cv::InputArray &src)
 {
-  cv::Mat mat = src.getMat();
+  Mat mat = src.getMat();
   return Eigen::TensorMap<Eigen::Tensor<_Tp, 3, Eigen::RowMajor>>((_Tp *)mat.data, mat.rows, mat.cols, mat.channels());
 }
 #endif // EIGEN_WORLD_VERSION >= 3 && EIGEN_MAJOR_VERSION >= 3

--- a/modules/core/include/opencv2/core/eigen.hpp
+++ b/modules/core/include/opencv2/core/eigen.hpp
@@ -50,7 +50,7 @@
 #if EIGEN_WORLD_VERSION == 3 && EIGEN_MAJOR_VERSION >= 3
 #include <unsupported/Eigen/CXX11/Tensor>
 #define OPENCV_EIGEN_TENSOR_SUPPORT
-#endif // EIGEN_WORLD_VERSION >= 3 && EIGEN_MAJOR_VERSION >= 3
+#endif // EIGEN_WORLD_VERSION == 3 && EIGEN_MAJOR_VERSION >= 3
 
 #if defined _MSC_VER && _MSC_VER >= 1200
 #pragma warning( disable: 4714 ) //__forceinline is not inlined

--- a/modules/core/include/opencv2/core/eigen.hpp
+++ b/modules/core/include/opencv2/core/eigen.hpp
@@ -47,9 +47,10 @@
 
 #include "opencv2/core.hpp"
 
-#if EIGEN_WORLD_VERSION >= 3 && EIGEN_MAJOR_VERSION >= 3
+#if EIGEN_WORLD_VERSION >= 3 && EIGEN_MINOR_VERSION >= 3
 #include <unsupported/Eigen/CXX11/Tensor>
-#endif // EIGEN_WORLD_VERSION >= 3 && EIGEN_MAJOR_VERSION >= 3
+#define OPENCV_EIGEN_TENSOR_SUPPORT
+#endif // EIGEN_WORLD_VERSION >= 3 && EIGEN_MINOR_VERSION >= 3
 
 #if defined _MSC_VER && _MSC_VER >= 1200
 #pragma warning( disable: 4714 ) //__forceinline is not inlined
@@ -63,7 +64,7 @@ namespace cv
 //! @addtogroup core_eigen
 //! @{
 
-#if EIGEN_WORLD_VERSION >= 3 && EIGEN_MAJOR_VERSION >= 3
+#ifdef OPENCV_EIGEN_TENSOR_SUPPORT
 /** @brief Converts an Eigen::Tensor to a cv::Mat.
 
 The method converts an Eigen::Tensor with shape (H x W x C) to a cv::Mat where:
@@ -158,7 +159,7 @@ Eigen::TensorMap<Eigen::Tensor<_Tp, 3, Eigen::RowMajor>> cv2eigen_tensormap(cons
   Mat mat = src.getMat();
   return Eigen::TensorMap<Eigen::Tensor<_Tp, 3, Eigen::RowMajor>>((_Tp *)mat.data, mat.rows, mat.cols, mat.channels());
 }
-#endif // EIGEN_WORLD_VERSION >= 3 && EIGEN_MAJOR_VERSION >= 3
+#endif // OPENCV_EIGEN_TENSOR_SUPPORT
 
 template<typename _Tp, int _rows, int _cols, int _options, int _maxRows, int _maxCols> static inline
 void eigen2cv( const Eigen::Matrix<_Tp, _rows, _cols, _options, _maxRows, _maxCols>& src, OutputArray dst )

--- a/modules/core/include/opencv2/core/eigen.hpp
+++ b/modules/core/include/opencv2/core/eigen.hpp
@@ -66,18 +66,18 @@ namespace cv
 #if EIGEN_WORLD_VERSION >= 3 && EIGEN_MAJOR_VERSION >= 3
 /** @brief Converts an Eigen::Tensor to a cv::Mat.
 
- The method converts an Eigen::Tensor with shape (H x W x C) to a cv::Mat where:
-  H = number of rows
-  W = number of columns
-  C = number of channels
+The method converts an Eigen::Tensor with shape (H x W x C) to a cv::Mat where:
+ H = number of rows
+ W = number of columns
+ C = number of channels
 
- Usage:
- \code
- Eigen::Tensor<float, 3, Eigen::RowMajor> a_tensor(...);
- // populate tensor with values
- cv::Mat a_mat;
- eigen2cv(a_tensor, a_mat);
- \endcode
+Usage:
+\code
+Eigen::Tensor<float, 3, Eigen::RowMajor> a_tensor(...);
+// populate tensor with values
+cv::Mat a_mat;
+eigen2cv(a_tensor, a_mat);
+\endcode
 */
 template <typename _Tp, int _layout> static inline
 void eigen2cv( const Eigen::Tensor<_Tp, 3, _layout> &src, OutputArray dst )
@@ -98,17 +98,18 @@ void eigen2cv( const Eigen::Tensor<_Tp, 3, _layout> &src, OutputArray dst )
 
 /** @brief Converts a cv::Mat to an Eigen::Tensor.
 
- The method converts a cv::Mat to an Eigen Tensor with shape (H x W x C) where:
-  H = number of rows
-  W = number of columns
-  C = number of channels
+The method converts a cv::Mat to an Eigen Tensor with shape (H x W x C) where:
+ H = number of rows
+ W = number of columns
+ C = number of channels
 
- Usage:
- \code
- cv::Mat a_mat(...);
- // populate Mat with values
- Eigen::Tensor<float, 3, Eigen::RowMajor> a_tensor(...);
- cv2eigen(a_mat, a_tensor);
+Usage:
+\code
+cv::Mat a_mat(...);
+// populate Mat with values
+Eigen::Tensor<float, 3, Eigen::RowMajor> a_tensor(...);
+cv2eigen(a_mat, a_tensor);
+\endcode
 */
 template <typename _Tp, int _layout> static inline
 void cv2eigen( const Mat &src, Eigen::Tensor<_Tp, 3, _layout> &dst )
@@ -133,6 +134,29 @@ void cv2eigen( const Mat &src, Eigen::Tensor<_Tp, 3, _layout> &dst )
         else
             src.convertTo(_dst, _dst.type());
     }
+}
+
+/** @brief Maps cv::Mat data to an Eigen::TensorMap.
+
+The method wraps an existing Mat data array with an Eigen TensorMap of shape (H x W x C) where:
+ H = number of rows
+ W = number of columns
+ C = number of channels
+
+Explicit instantiation of the return type is required.
+
+The example below initializes a cv::Mat and produces an Eigen::TensorMap:
+\code
+float arr[] = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11};
+cv::Mat a_mat(2, 2, CV_32FC3, arr);
+Eigen::TensorMap<Eigen::Tensor<float, 3, Eigen::RowMajor>> color_tensor = cv2eigen_tensormap<float>(a_mat);
+\endcode
+*/
+template <typename _Tp> static inline
+Eigen::TensorMap<Eigen::Tensor<_Tp, 3, Eigen::RowMajor>> cv2eigen_tensormap(const cv::InputArray &src)
+{
+  cv::Mat mat = src.getMat();
+  return Eigen::TensorMap<Eigen::Tensor<_Tp, 3, Eigen::RowMajor>>((_Tp *)mat.data, mat.rows, mat.cols, mat.channels());
 }
 #endif // EIGEN_WORLD_VERSION >= 3 && EIGEN_MAJOR_VERSION >= 3
 

--- a/modules/core/include/opencv2/core/eigen.hpp
+++ b/modules/core/include/opencv2/core/eigen.hpp
@@ -46,6 +46,7 @@
 #define OPENCV_CORE_EIGEN_HPP
 
 #include "opencv2/core.hpp"
+#include <unsupported/Eigen/CXX11/Tensor>
 
 #if defined _MSC_VER && _MSC_VER >= 1200
 #pragma warning( disable: 4714 ) //__forceinline is not inlined
@@ -58,6 +59,21 @@ namespace cv
 
 //! @addtogroup core_eigen
 //! @{
+
+/**
+ * Convert a 3-dimensional Eigen::Tensor of size H x W x C to a cv::Mat with C channels
+ * where:
+ *   H = number of rows
+ *   W = number of columns
+ *   C = number of channels
+ */
+template <typename _Tp> static inline
+void eigen2cv( const Eigen::Tensor<_Tp, 3, Eigen::RowMajor> &src, OutputArray dst )
+{
+    Mat _src(src.dimension(0), src.dimension(1),
+            CV_MAKE_TYPE(DataType<_Tp>::type, src.dimension(2)), (void *)src.data());
+    _src.copyTo(dst);
+}
 
 template<typename _Tp, int _rows, int _cols, int _options, int _maxRows, int _maxCols> static inline
 void eigen2cv( const Eigen::Matrix<_Tp, _rows, _cols, _options, _maxRows, _maxCols>& src, OutputArray dst )
@@ -89,6 +105,24 @@ void eigen2cv( const Eigen::Matrix<_Tp, _rows, _cols, _options, _maxRows, _maxCo
     {
         dst = Matx<_Tp, _rows, _cols>(static_cast<const _Tp*>(src.data()));
     }
+}
+
+/**
+ * Convert a cv::Mat containing C channels to a 3-dimensional Eigen::Tensor of size H x W x C
+ * where:
+ *   H = number of rows
+ *   W = number of columns
+ *   C = number of channels
+ */
+template <typename _Tp> static inline
+void cv2eigen( const Mat &src, Eigen::Tensor<_Tp, 3, Eigen::RowMajor> &dst )
+{
+    dst.resize(src.rows, src.cols, src.channels());
+    Mat _dst(src.rows, src.cols, CV_MAKE_TYPE(DataType<_Tp>::type, src.channels()), dst.data());
+    if (src.type() == _dst.type())
+        src.copyTo(_dst);
+    else
+        src.convertTo(_dst, _dst.type());
 }
 
 template<typename _Tp, int _rows, int _cols, int _options, int _maxRows, int _maxCols> static inline

--- a/modules/core/include/opencv2/core/eigen.hpp
+++ b/modules/core/include/opencv2/core/eigen.hpp
@@ -146,6 +146,9 @@ The method wraps an existing Mat data array with an Eigen TensorMap of shape (H 
 
 Explicit instantiation of the return type is required.
 
+@note Caller should be aware of the lifetime of the cv::Mat instance and take appropriate safety measures.
+The cv::Mat instance will retain ownership of the data and the Eigen::TensorMap will lose access when the cv::Mat data is deallocated.
+
 The example below initializes a cv::Mat and produces an Eigen::TensorMap:
 \code
 float arr[] = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11};
@@ -156,8 +159,9 @@ Eigen::TensorMap<Eigen::Tensor<float, 3, Eigen::RowMajor>> a_tensormap = cv2eige
 template <typename _Tp> static inline
 Eigen::TensorMap<Eigen::Tensor<_Tp, 3, Eigen::RowMajor>> cv2eigen_tensormap(const cv::InputArray &src)
 {
-  Mat mat = src.getMat();
-  return Eigen::TensorMap<Eigen::Tensor<_Tp, 3, Eigen::RowMajor>>((_Tp *)mat.data, mat.rows, mat.cols, mat.channels());
+    Mat mat = src.getMat();
+    CV_CheckTypeEQ(mat.type(), CV_MAKETYPE(traits::Type<_Tp>::value, mat.channels()), "");
+    return Eigen::TensorMap<Eigen::Tensor<_Tp, 3, Eigen::RowMajor>>((_Tp *)mat.data, mat.rows, mat.cols, mat.channels());
 }
 #endif // OPENCV_EIGEN_TENSOR_SUPPORT
 

--- a/modules/core/include/opencv2/core/eigen.hpp
+++ b/modules/core/include/opencv2/core/eigen.hpp
@@ -56,7 +56,7 @@
 #pragma warning( disable: 4127 ) //conditional expression is constant
 #pragma warning( disable: 4244 ) //conversion from '__int64' to 'int', possible loss of data
 #endif
- 
+
 namespace cv
 {
 
@@ -66,7 +66,7 @@ namespace cv
 
 #if EIGEN_WORLD_VERSION >= 3 && EIGEN_MAJOR_VERSION >= 3
 /** @brief Converts an Eigen::Tensor to a cv::Mat.
- 
+
  The method converts an Eigen::Tensor with shape (H x W x C) to a cv::Mat where:
   H = number of rows
   W = number of columns
@@ -137,7 +137,7 @@ void eigen2cv( const Eigen::Matrix<_Tp, _rows, _cols, _options, _maxRows, _maxCo
   H = number of rows
   W = number of columns
   C = number of channels
- 
+
  Usage:
  \code
  cv::Mat a_mat(...);

--- a/modules/core/include/opencv2/core/eigen.hpp
+++ b/modules/core/include/opencv2/core/eigen.hpp
@@ -47,9 +47,9 @@
 
 #include "opencv2/core.hpp"
 
-#if EIGEN_VERSION_AT_LEAST(3,3,0)
+#if EIGEN_WORLD_VERSION >= 3 && EIGEN_MAJOR_VERSION >= 3
 #include <unsupported/Eigen/CXX11/Tensor>
-#endif // EIGEN_VERSION_AT_LEAST(3,3,0)
+#endif // EIGEN_WORLD_VERSION >= 3 && EIGEN_MAJOR_VERSION >= 3
 
 #if defined _MSC_VER && _MSC_VER >= 1200
 #pragma warning( disable: 4714 ) //__forceinline is not inlined
@@ -64,7 +64,7 @@ namespace cv
 //! @{
 
 
-#if EIGEN_VERSION_AT_LEAST(3, 3, 0)
+#if EIGEN_WORLD_VERSION >= 3 && EIGEN_MAJOR_VERSION >= 3
 /** @brief Converts an Eigen::Tensor to a cv::Mat.
  
  The method converts an Eigen::Tensor with shape (H x W x C) to a cv::Mat where:
@@ -96,7 +96,7 @@ void eigen2cv( const Eigen::Tensor<_Tp, 3, _layout> &src, OutputArray dst )
         _src.copyTo(dst);
     }
 }
-#endif // EIGEN_VERSION_AT_LEAST(3,3,0)
+#endif // EIGEN_WORLD_VERSION >= 3 && EIGEN_MAJOR_VERSION >= 3
 
 template<typename _Tp, int _rows, int _cols, int _options, int _maxRows, int _maxCols> static inline
 void eigen2cv( const Eigen::Matrix<_Tp, _rows, _cols, _options, _maxRows, _maxCols>& src, OutputArray dst )
@@ -130,7 +130,7 @@ void eigen2cv( const Eigen::Matrix<_Tp, _rows, _cols, _options, _maxRows, _maxCo
     }
 }
 
-#if EIGEN_VERSION_AT_LEAST(3, 3, 0)
+#if EIGEN_WORLD_VERSION >= 3 && EIGEN_MAJOR_VERSION >= 3
 /** @brief Converts a cv::Mat to an Eigen::Tensor.
 
  The method converts a cv::Mat to an Eigen Tensor with shape (H x W x C) where:
@@ -169,7 +169,7 @@ void cv2eigen( const Mat &src, Eigen::Tensor<_Tp, 3, _layout> &dst )
         dst = row_major_tensor.swap_layout().shuffle(shuffle);
     }
 }
-#endif // EIGEN_VERSION_AT_LEAST(3,3,0)
+#endif // EIGEN_WORLD_VERSION >= 3 && EIGEN_MAJOR_VERSION >= 3
 
 template<typename _Tp, int _rows, int _cols, int _options, int _maxRows, int _maxCols> static inline
 void cv2eigen( const Mat& src,

--- a/modules/core/test/test_mat.cpp
+++ b/modules/core/test/test_mat.cpp
@@ -2083,8 +2083,8 @@ TEST(Core_Eigen, eigen2cv_check_Mat_type)
     //EXPECT_EQ(CV_64FC1, d_mat.type());
 }
 #endif // HAVE_EIGEN
-
-#ifdef HAVE_EIGEN
+ 
+#if EIGEN_VERSION_AT_LEAST(3, 3, 0)
 TEST(Core_Eigen, cv2eigen_check_tensor_conversion)
 {
     Mat A(2, 3, CV_32FC3);
@@ -2110,9 +2110,9 @@ TEST(Core_Eigen, cv2eigen_check_tensor_conversion)
             for(int ch=0; ch<A.channels(); ch++)
                 ASSERT_FLOAT_EQ(value++, col_tensor(row,col,ch));
 }
-#endif // HAVE_EIGEN
+#endif // EIGEN_VERSION_AT_LEAST(3, 3, 0)
 
-#ifdef HAVE_EIGEN
+#if EIGEN_VERSION_AT_LEAST(3, 3, 0)
 TEST(Core_Eigen, eigen2cv_check_tensor_conversion)
 {
     Eigen::Tensor<float, 3, Eigen::RowMajor> row_tensor(2,3,3);
@@ -2120,7 +2120,8 @@ TEST(Core_Eigen, eigen2cv_check_tensor_conversion)
     float value = 0;
     for(int row=0; row<row_tensor.dimension(0); row++)
         for(int col=0; col<row_tensor.dimension(1); col++)
-            for(int ch=0; ch<row_tensor.dimension(2); ch++) {
+            for(int ch=0; ch<row_tensor.dimension(2); ch++)
+            {
                 row_tensor(row,col,ch) = value;
                 col_tensor(row,col,ch) = value;
                 value++;
@@ -2143,7 +2144,7 @@ TEST(Core_Eigen, eigen2cv_check_tensor_conversion)
             for(int ch=0; ch<B.channels(); ch++)
                 ASSERT_FLOAT_EQ(value++, B.at<Vec3f>(row,col)[ch]);
 }
-#endif // HAVE_EIGEN
+#endif // EIGEN_VERSION_AT_LEAST(3, 3, 0)
 
 TEST(Mat, regression_12943)  // memory usage: ~4.5 Gb
 {

--- a/modules/core/test/test_mat.cpp
+++ b/modules/core/test/test_mat.cpp
@@ -2150,6 +2150,26 @@ TEST(Core_Eigen, eigen2cv_check_tensor_conversion)
 #endif // EIGEN_WORLD_VERSION >= 3 && EIGEN_MAJOR_VERSION >= 3
 #endif // HAVE_EIGEN
 
+#ifdef HAVE_EIGEN
+#if EIGEN_WORLD_VERSION >= 3 && EIGEN_MAJOR_VERSION >= 3
+TEST(Core_Eigen, cv2eigen_tensormap_check_tensormap_access)
+{
+    float arr[] = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11};
+    Mat a_mat(2, 2, CV_32FC3, arr);
+    Eigen::TensorMap<Eigen::Tensor<float, 3, Eigen::RowMajor>> a_tensor = cv2eigen_tensormap<float>(a_mat);
+
+    for(int i=0; i<a_mat.rows; i++) {
+        for (int j=0; j<a_mat.cols; j++) {
+            for (int ch=0; ch<a_mat.channels(); ch++) {
+                ASSERT_FLOAT_EQ(a_mat.at<Vec3f>(row,col)[ch], a_tensor(i,j,ch));
+                ASSERT_EQ(&a_mat.at<Vec3f>(row,col)[ch], &a_tensor(i,j,ch))
+            }
+        }
+    }
+}
+#endif // EIGEN_WORLD_VERSION >= 3 && EIGEN_MAJOR_VERSION >= 3
+#endif // HAVE_EIGEN
+
 TEST(Mat, regression_12943)  // memory usage: ~4.5 Gb
 {
     applyTestTag(CV_TEST_TAG_MEMORY_6GB);

--- a/modules/core/test/test_mat.cpp
+++ b/modules/core/test/test_mat.cpp
@@ -2083,7 +2083,7 @@ TEST(Core_Eigen, eigen2cv_check_Mat_type)
     //EXPECT_EQ(CV_64FC1, d_mat.type());
 }
 #endif // HAVE_EIGEN
- 
+
 #ifdef HAVE_EIGEN
 #if EIGEN_WORLD_VERSION >= 3 && EIGEN_MAJOR_VERSION >= 3
 TEST(Core_Eigen, cv2eigen_check_tensor_conversion)

--- a/modules/core/test/test_mat.cpp
+++ b/modules/core/test/test_mat.cpp
@@ -2084,7 +2084,8 @@ TEST(Core_Eigen, eigen2cv_check_Mat_type)
 }
 #endif // HAVE_EIGEN
  
-#if EIGEN_VERSION_AT_LEAST(3, 3, 0)
+#ifdef HAVE_EIGEN
+#if EIGEN_WORLD_VERSION >= 3 && EIGEN_MAJOR_VERSION >= 3
 TEST(Core_Eigen, cv2eigen_check_tensor_conversion)
 {
     Mat A(2, 3, CV_32FC3);
@@ -2110,9 +2111,11 @@ TEST(Core_Eigen, cv2eigen_check_tensor_conversion)
             for(int ch=0; ch<A.channels(); ch++)
                 ASSERT_FLOAT_EQ(value++, col_tensor(row,col,ch));
 }
-#endif // EIGEN_VERSION_AT_LEAST(3, 3, 0)
+#endif // EIGEN_WORLD_VERSION >= 3 && EIGEN_MAJOR_VERSION >= 3
+#endif // HAVE_EIGEN
 
-#if EIGEN_VERSION_AT_LEAST(3, 3, 0)
+#ifdef HAVE_EIGEN
+#if EIGEN_WORLD_VERSION >= 3 && EIGEN_MAJOR_VERSION >= 3
 TEST(Core_Eigen, eigen2cv_check_tensor_conversion)
 {
     Eigen::Tensor<float, 3, Eigen::RowMajor> row_tensor(2,3,3);
@@ -2144,7 +2147,8 @@ TEST(Core_Eigen, eigen2cv_check_tensor_conversion)
             for(int ch=0; ch<B.channels(); ch++)
                 ASSERT_FLOAT_EQ(value++, B.at<Vec3f>(row,col)[ch]);
 }
-#endif // EIGEN_VERSION_AT_LEAST(3, 3, 0)
+#endif // EIGEN_WORLD_VERSION >= 3 && EIGEN_MAJOR_VERSION >= 3
+#endif // HAVE_EIGEN
 
 TEST(Mat, regression_12943)  // memory usage: ~4.5 Gb
 {

--- a/modules/core/test/test_mat.cpp
+++ b/modules/core/test/test_mat.cpp
@@ -2084,6 +2084,48 @@ TEST(Core_Eigen, eigen2cv_check_Mat_type)
 }
 #endif // HAVE_EIGEN
 
+#ifdef HAVE_EIGEN
+TEST(Core_Eigen, cv2eigen_check_tensor_conversion)
+{
+    Mat A(2, 3, CV_32FC3);
+    float value = 0;
+    for(int row=0; row<A.rows; row++)
+        for(int col=0; col<A.cols; col++)
+            for(int ch=0; ch<A.channels(); ch++)
+                A.at<Vec3f>(row,col)[ch] = value++;
+
+    Eigen::Tensor<float, 3, Eigen::RowMajor> eigen_A;
+    cv2eigen(A, eigen_A);
+
+    value = 0;
+    for(int row=0; row<A.rows; row++)
+        for(int col=0; col<A.cols; col++)
+            for(int ch=0; ch<A.channels(); ch++)
+                ASSERT_FLOAT_EQ(value++, eigen_A(row,col,ch));
+}
+#endif // HAVE_EIGEN
+
+#ifdef HAVE_EIGEN
+TEST(Core_Eigen, eigen2cv_check_tensor_conversion)
+{
+    Eigen::Tensor<float, 3, Eigen::RowMajor> A_eigen(2,3,3);
+    float value = 0;
+    for(int row=0; row<A_eigen.dimension(0); row++)
+        for(int col=0; col<A_eigen.dimension(1); col++)
+            for(int ch=0; ch<A_eigen.dimension(2); ch++)
+                A_eigen(row,col,ch) = value++;
+
+    Mat A;
+    eigen2cv(A_eigen, A);
+
+    value = 0;
+    for(int row=0; row<A.rows; row++)
+        for(int col=0; col<A.cols; col++)
+            for(int ch=0; ch<A.channels(); ch++)
+                ASSERT_FLOAT_EQ(value++, A.at<Vec3f>(row,col)[ch]);
+}
+#endif // HAVE_EIGEN
+
 TEST(Mat, regression_12943)  // memory usage: ~4.5 Gb
 {
     applyTestTag(CV_TEST_TAG_MEMORY_6GB);

--- a/modules/core/test/test_mat.cpp
+++ b/modules/core/test/test_mat.cpp
@@ -2161,8 +2161,8 @@ TEST(Core_Eigen, cv2eigen_tensormap_check_tensormap_access)
     for(int i=0; i<a_mat.rows; i++) {
         for (int j=0; j<a_mat.cols; j++) {
             for (int ch=0; ch<a_mat.channels(); ch++) {
-                ASSERT_FLOAT_EQ(a_mat.at<Vec3f>(row,col)[ch], a_tensor(i,j,ch));
-                ASSERT_EQ(&a_mat.at<Vec3f>(row,col)[ch], &a_tensor(i,j,ch))
+                ASSERT_FLOAT_EQ(a_mat.at<Vec3f>(i,j)[ch], a_tensor(i,j,ch));
+                ASSERT_EQ(&a_mat.at<Vec3f>(i,j)[ch], &a_tensor(i,j,ch));
             }
         }
     }

--- a/modules/core/test/test_mat.cpp
+++ b/modules/core/test/test_mat.cpp
@@ -2084,8 +2084,7 @@ TEST(Core_Eigen, eigen2cv_check_Mat_type)
 }
 #endif // HAVE_EIGEN
 
-#ifdef HAVE_EIGEN
-#if EIGEN_WORLD_VERSION >= 3 && EIGEN_MAJOR_VERSION >= 3
+#ifdef OPENCV_EIGEN_TENSOR_SUPPORT
 TEST(Core_Eigen, cv2eigen_check_tensor_conversion)
 {
     Mat A(2, 3, CV_32FC3);
@@ -2111,11 +2110,9 @@ TEST(Core_Eigen, cv2eigen_check_tensor_conversion)
             for(int ch=0; ch<A.channels(); ch++)
                 ASSERT_FLOAT_EQ(value++, col_tensor(row,col,ch));
 }
-#endif // EIGEN_WORLD_VERSION >= 3 && EIGEN_MAJOR_VERSION >= 3
-#endif // HAVE_EIGEN
+#endif // OPENCV_EIGEN_TENSOR_SUPPORT
 
-#ifdef HAVE_EIGEN
-#if EIGEN_WORLD_VERSION >= 3 && EIGEN_MAJOR_VERSION >= 3
+#ifdef OPENCV_EIGEN_TENSOR_SUPPORT
 TEST(Core_Eigen, eigen2cv_check_tensor_conversion)
 {
     Eigen::Tensor<float, 3, Eigen::RowMajor> row_tensor(2,3,3);
@@ -2147,11 +2144,9 @@ TEST(Core_Eigen, eigen2cv_check_tensor_conversion)
             for(int ch=0; ch<B.channels(); ch++)
                 ASSERT_FLOAT_EQ(value++, B.at<Vec3f>(row,col)[ch]);
 }
-#endif // EIGEN_WORLD_VERSION >= 3 && EIGEN_MAJOR_VERSION >= 3
-#endif // HAVE_EIGEN
+#endif // OPENCV_EIGEN_TENSOR_SUPPORT
 
-#ifdef HAVE_EIGEN
-#if EIGEN_WORLD_VERSION >= 3 && EIGEN_MAJOR_VERSION >= 3
+#ifdef OPENCV_EIGEN_TENSOR_SUPPORT
 TEST(Core_Eigen, cv2eigen_tensormap_check_tensormap_access)
 {
     float arr[] = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11};
@@ -2167,8 +2162,7 @@ TEST(Core_Eigen, cv2eigen_tensormap_check_tensormap_access)
         }
     }
 }
-#endif // EIGEN_WORLD_VERSION >= 3 && EIGEN_MAJOR_VERSION >= 3
-#endif // HAVE_EIGEN
+#endif // OPENCV_EIGEN_TENSOR_SUPPORT
 
 TEST(Mat, regression_12943)  // memory usage: ~4.5 Gb
 {


### PR DESCRIPTION
This PR addresses issue https://github.com/opencv/opencv/issues/17237. The primary contributions are two conversion functions (cv2eigen and eigen2cv) for the Eigen::Tensor module along with unit tests.

### Pull Request Readiness Checklist
- [X] I agree to contribute to the project under OpenCV (BSD) License.
- [X] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [X] The PR is proposed to proper branch
- [X] There is reference to original bug report and related work
- [X] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [X] The feature is well documented and sample code can be built with the project CMake
