### PR TITLE
Expand random generator and text tutorial with existing Python sample

### DIFF
--- a/doc/tutorials/imgproc/random_generator_and_text/random_generator_and_text.markdown
+++ b/doc/tutorials/imgproc/random_generator_and_text/random_generator_and_text.markdown
@@ -9,19 +9,14 @@ Goals
 
 In this tutorial you will learn how to:
 
--   Use the *Random Number generator class* (@ref cv::RNG ) and how to get a random number from a
-    uniform distribution.
+-   Use the *Random Number generator class* (@ref cv::RNG ) and how to get a random number from a uniform distribution.
 -   Display text on an OpenCV window by using the function @ref cv::putText
 
 Code
 ----
 
--   In the previous tutorial (@ref tutorial_basic_geometric_drawing) we drew diverse geometric figures, giving as input
-    parameters such as coordinates (in the form of @ref cv::Point), color, thickness, etc. You
-    might have noticed that we gave specific values for these arguments.
--   In this tutorial, we intend to use *random* values for the drawing parameters. Also, we intend
-    to populate our image with a big number of geometric figures. Since we will be initializing them
-    in a random fashion, this process will be automatic and made by using *loops* .
+-   In the previous tutorial (@ref tutorial_basic_geometric_drawing) we drew diverse geometric figures, giving as input parameters such as coordinates (in the form of @ref cv::Point), color, thickness, etc. You might have noticed that we gave specific values for these arguments.
+-   In this tutorial, we intend to use *random* values for the drawing parameters. Also, we intend to populate our image with a big number of geometric figures. Since we will be initializing them in a random fashion, this process will be automatic and made by using *loops* .
 @add_toggle_cpp
 -   This code is in your OpenCV sample folder. Otherwise you can grab it from
     [here](https://raw.githubusercontent.com/opencv/opencv/3.4/samples/cpp/tutorial_code/ImgProc/basic_drawing/Drawing_2.cpp).
@@ -38,82 +33,59 @@ Explanation
 
 -#  Let's start by checking out the *main* function.
 @add_toggle_cpp
-We observe that first thing we do is creating a
-    *Random Number Generator* object (RNG):
+We observe that first thing we do is creating a *Random Number Generator* object (RNG):
     @snippet samples/cpp/tutorial_code/ImgProc/basic_drawing/Drawing_2.cpp create_RNG
-    RNG implements a random number generator. In this example, *rng* is a RNG element initialized
-    with the value *0xFFFFFFFF*
+    RNG implements a random number generator. In this example, *rng* is a RNG element initialized with the value *0xFFFFFFFF*
 @end_toggle
 @add_toggle_python
-    In Python we can perform random number generation with NumPy's `randint()` function. There
-    are no bindings for the OpenCV RNG class in Python.
+    In Python we can perform random number generation with NumPy's `randint()` function. There are no bindings for the OpenCV RNG class in Python.
 @end_toggle
--#  Then we create a matrix initialized to *zeros* (which means that it will appear as black),
-    specifying its height, width and its type:
+-#  Then we create a matrix initialized to *zeros* (which means that it will appear as black), specifying its height, width and its type:
 @add_toggle_cpp
     @snippet samples/cpp/tutorial_code/ImgProc/basic_drawing/Drawing_2.cpp create_zeros
 @end_toggle
 @add_toggle_python
     @snippet samples/python/tutorial_code/imgProc/BasicGeometricDrawing/drawing.py create_zeros
 @end_toggle
--#  Then we proceed to draw crazy stuff. After taking a look at the code, you can see that it is
-    mainly divided in 8 sections, defined as functions:
+-#  Then we proceed to draw crazy stuff. After taking a look at the code, you can see that it is mainly divided in 8 sections, defined as functions:
 @add_toggle_cpp
     @snippet samples/cpp/tutorial_code/ImgProc/basic_drawing/Drawing_2.cpp main_drawing
 @end_toggle
 @add_toggle_python
     @snippet samples/python/tutorial_code/imgProc/BasicGeometricDrawing/drawing.py main_drawing
 @end_toggle
-    All of these functions follow the same pattern, so we will analyze only a couple of them, since
-    the same explanation applies for all.
+    All of these functions follow the same pattern, so we will analyze only a couple of them, since the same explanation applies for all.
 
 -#  Checking out the function **Drawing_Random_Lines**:
 @add_toggle_cpp
     @snippet samples/cpp/tutorial_code/ImgProc/basic_drawing/Drawing_2.cpp random_lines
     We can observe the following:
     @snippet samples/cpp/tutorial_code/ImgProc/basic_drawing/Drawing_2.cpp line_points
-    -   The *for* loop will repeat **NUMBER** times. Since the function @ref cv::line is inside this
-        loop, that means that **NUMBER** lines will be generated.
+    -   The *for* loop will repeat **NUMBER** times. Since the function @ref cv::line is inside this loop, that means that **NUMBER** lines will be generated.
     -   The line extremes are given by *pt1* and *pt2*. For *pt1* we can see that:
-        -   We know that **rng** is a *Random number generator* object. In the code above we are
-            calling **rng.uniform(a,b)**. This generates a randomly uniformed distribution between
-            the values **a** and **b** (inclusive in **a**, exclusive in **b**).
-        -   From the explanation above, we deduce that the extremes *pt1* and *pt2* will be random
-            values, so the lines positions will be quite impredictable, giving a nice visual effect
-            (check out the Result section below).
-        -   As another observation, we notice that in the @ref cv::line arguments, for the *color*
-            input we enter:
+        -   We know that **rng** is a *Random number generator* object. In the code above we are calling **rng.uniform(a,b)**. This generates a randomly uniformed distribution between the values **a** and **b** (inclusive in **a**, exclusive in **b**).
+        -   From the explanation above, we deduce that the extremes *pt1* and *pt2* will be random values, so the lines positions will be quite impredictable, giving a nice visual effect (check out the Result section below).
+        -   As another observation, we notice that in the @ref cv::line arguments, for the *color* input we enter:
             @code{.cpp}
             randomColor(rng)
             @endcode
             Let's check the function implementation:
             @snippet samples/cpp/tutorial_code/ImgProc/basic_drawing/Drawing_2.cpp random_color
-            As we can see, the return value is an *Scalar* with 3 randomly initialized values, which
-            are used as the *R*, *G* and *B* parameters for the line color. Hence, the color of the
-            lines will be random too!
+            As we can see, the return value is an *Scalar* with 3 randomly initialized values, which are used as the *R*, *G* and *B* parameters for the line color. Hence, the color of the lines will be random too!
 @end_toggle
 @add_toggle_python
     @snippet samples/python/tutorial_code/imgProc/BasicGeometricDrawing/drawing.py random_lines
     We can observe the following:
     @snippet samples/python/tutorial_code/imgProc/BasicGeometricDrawing/drawing.py line_points
-    -   The *for* loop will repeat **NUMBER** times. Since the function @ref cv::line is inside this
-        loop, that means that **NUMBER** lines will be generated.
+    -   The *for* loop will repeat **NUMBER** times. Since the function @ref cv::line is inside this loop, that means that **NUMBER** lines will be generated.
     -   The line extremes are given by *pt1* and *pt2*. For *pt1* we can see that:
-        -   In the code above we are
-            calling **np.random.randint(a,b)**. This generates a randomly uniformed distribution between
-            the values **a** and **b** (inclusive in **a**, exclusive in **b**).
-        -   From the explanation above, we deduce that the extremes *pt1* and *pt2* will be random
-            values, so the lines positions will be quite impredictable, giving a nice visual effect
-            (check out the Result section below).
-        -   As another observation, we notice that in the @ref cv::line arguments, for the *color*
-            input we generate a random color by using a tuple of three random
-            values generated like so:
-            @snippet samples/python/tutorial_code/imgProc/BasicGeometricDrawing/drawing.py random_color
+        -   In the code above we are calling **np.random.randint(a,b)**. This generates a randomly uniformed distribution between the values **a** and **b** (inclusive in **a**, exclusive in **b**).
+        -   From the explanation above, we deduce that the extremes *pt1* and *pt2* will be random values, so the lines positions will be quite impredictable, giving a nice visual effect (check out the Result section below).
+        -   As another observation, we notice that in the @ref cv::line arguments, for the *color* input we generate a random color by using a tuple of three random values generated like so:
+        @snippet samples/python/tutorial_code/imgProc/BasicGeometricDrawing/drawing.py random_color
 @end_toggle
--#  The explanation above applies for the other functions generating circles, ellipses, polygons,
-    etc. The parameters such as *center* and *vertices* are also generated randomly.
--#  Before finishing, we also should take a look at the functions *Display_Random_Text* and
-    *Displaying_Big_End*, since they both have a few interesting features:
+-#  The explanation above applies for the other functions generating circles, ellipses, polygons, etc. The parameters such as *center* and *vertices* are also generated randomly.
+-#  Before finishing, we also should take a look at the functions *Display_Random_Text* and *Displaying_Big_End*, since they both have a few interesting features:
 -#  **Display_Random_Text:**
     @add_toggle_cpp
     @snippet samples/cpp/tutorial_code/ImgProc/basic_drawing/Drawing_2.cpp random_text
@@ -124,8 +96,7 @@ We observe that first thing we do is creating a
     -   Draws the text **"Testing text rendering"** in **image**
     -   The bottom-left corner of the text will be located in the Point **org**
     -   The font type is a random integer value in the range: \f$[0, 8>\f$.
-    -   The scale of the font is denoted by the expression **rng.uniform(0, 100)x0.05 + 0.1**
-        (meaning its range is: \f$[0.1, 5.1>\f$)
+    -   The scale of the font is denoted by the expression **rng.uniform(0, 100)x0.05 + 0.1** (meaning its range is: \f$[0.1, 5.1>\f$)
     -   The text color is random (denoted by **randomColor(rng)**)
     -   The text thickness ranges between 1 and 10, as specified by **rng.uniform(1,10)**
     @end_toggle
@@ -138,39 +109,27 @@ We observe that first thing we do is creating a
     -   Draws the text **"Testing text rendering"** in **image**
     -   The bottom-left corner of the text will be located at the point defined by the tuple **org**
     -   The font type is a random integer value in the range: \f$[0, 8>\f$.
-    -   The scale of the font is denoted by the expression **rng.uniform(0, 100)x0.05 + 0.1**
-        (meaning its range is: \f$[0.1, 5.1>\f$)
+    -   The scale of the font is denoted by the expression **rng.uniform(0, 100)x0.05 + 0.1** (meaning its range is: \f$[0.1, 5.1>\f$)
     -   The text color is random, generated in the same fashion as above
     -   The text thickness ranges between 1 and 10, as specified by **np.random.randint(1, 10)**
     @end_toggle
 
-    As a result, we will get (analagously to the other drawing functions) **NUMBER** texts over our
-    image, in random locations.
+    As a result, we will get (analagously to the other drawing functions) **NUMBER** texts over our image, in random locations.
 
 -#  **Displaying_Big_End**
     @add_toggle_cpp
     @snippet samples/cpp/tutorial_code/ImgProc/basic_drawing/Drawing_2.cpp big_end
-    Besides the function **getTextSize** (which gets the size of the argument text), the new
-    operation we can observe is inside the *for* loop:
+    Besides the function **getTextSize** (which gets the size of the argument text), the new operation we can observe is inside the *for* loop:
     @snippet samples/cpp/tutorial_code/ImgProc/basic_drawing/Drawing_2.cpp subtract
-    So, **image2** is the subtraction of **image** and **Scalar::all(i)**. In fact, what happens
-    here is that every pixel of **image2** will be the result of subtracting every pixel of
-    **image** minus the value of **i** (remember that for each pixel we are considering three values
-    such as R, G and B, so each of them will be affected)
+    So, **image2** is the subtraction of **image** and **Scalar::all(i)**. In fact, what happens here is that every pixel of **image2** will be the result of subtracting every pixel of **image** minus the value of **i** (remember that for each pixel we are considering three values such as R, G and B, so each of them will be affected)
 
-    Also remember that the subtraction operation *always* performs internally a **saturate**
-    operation, which means that the result obtained will always be inside the allowed range (no
-    negative and between 0 and 255 for our example).
+    Also remember that the subtraction operation *always* performs internally a **saturate** operation, which means that the result obtained will always be inside the allowed range (no negative and between 0 and 255 for our example).
     @end_toggle
     @add_toggle_python
     @snippet samples/python/tutorial_code/imgProc/BasicGeometricDrawing/drawing.py big_end
-    Besides the function **getTextSize** (which gets the size of the argument text), the new
-    operation we can observe is inside the *for* loop:
+    Besides the function **getTextSize** (which gets the size of the argument text), the new operation we can observe is inside the *for* loop:
     @snippet samples/python/tutorial_code/imgProc/BasicGeometricDrawing/drawing.py subtract
-    So, **image2** is the subtraction of **image** and the value of **i**. In fact, what happens
-    here is that every pixel of **image2** will be the result of subtracting every pixel of
-    **image** minus the value of **i** (remember that for each pixel we are considering three values
-    such as R, G and B, so each of them will be affected)
+    So, **image2** is the subtraction of **image** and the value of **i**. In fact, what happens here is that every pixel of **image2** will be the result of subtracting every pixel of **image** minus the value of **i** (remember that for each pixel we are considering three values such as R, G and B, so each of them will be affected)
 
     Note that NumPy subtraction is equivalent to regular subtraction and is not saturated: meaning that values can become negative. Thus rather than values simply being set to 0 if negative, the values will wrap around beginning from 255 and count down.
     @end_toggle
@@ -178,17 +137,14 @@ We observe that first thing we do is creating a
 Result
 ------
 
-As you just saw in the Code section, the program will sequentially execute diverse drawing
-functions, which will produce:
+As you just saw in the Code section, the program will sequentially execute diverse drawing functions, which will produce:
 
--#  First a random set of *NUMBER* lines will appear on screen such as it can be seen in this
-    screenshot:
+-#  First a random set of *NUMBER* lines will appear on screen such as it can be seen in this screenshot:
 
     ![](images/Drawing_2_Tutorial_Result_0.jpg)
 
 -#  Then, a new set of figures, these time *rectangles* will follow.
--#  Now some ellipses will appear, each of them with random position, size, thickness and arc
-    length:
+-#  Now some ellipses will appear, each of them with random position, size, thickness and arc length:
 
     ![](images/Drawing_2_Tutorial_Result_2.jpg)
 
@@ -201,8 +157,7 @@ functions, which will produce:
 
     ![](images/Drawing_2_Tutorial_Result_5.jpg)
 
--#  Near the end, the text *"Testing Text Rendering"* will appear in a variety of fonts, sizes,
-    colors and positions.
+-#  Near the end, the text *"Testing Text Rendering"* will appear in a variety of fonts, sizes, colors and positions.
 -#  And the big end (which by the way expresses a big truth too):
 
     ![](images/Drawing_2_Tutorial_Result_big.jpg)

--- a/doc/tutorials/imgproc/random_generator_and_text/random_generator_and_text.markdown
+++ b/doc/tutorials/imgproc/random_generator_and_text/random_generator_and_text.markdown
@@ -22,97 +22,59 @@ Code
 -   In this tutorial, we intend to use *random* values for the drawing parameters. Also, we intend
     to populate our image with a big number of geometric figures. Since we will be initializing them
     in a random fashion, this process will be automatic and made by using *loops* .
+@add_toggle_cpp
 -   This code is in your OpenCV sample folder. Otherwise you can grab it from
-    [here](http://code.opencv.org/projects/opencv/repository/revisions/master/raw/samples/cpp/tutorial_code/core/Matrix/Drawing_2.cpp)
+    [here](https://raw.githubusercontent.com/opencv/opencv/3.4/samples/cpp/tutorial_code/ImgProc/basic_drawing/Drawing_2.cpp).
+    @include samples/cpp/tutorial_code/ImgProc/basic_drawing/Drawing_2.cpp
+@end_toggle
+@add_toggle_python
+-   This code is in your OpenCV sample folder. Otherwise you can grab it from
+    [here](https://raw.githubusercontent.com/opencv/opencv/3.4/samples/python/tutorial_code/imgProc/BasicGeometricDrawing/drawing.py).
+    @include samples/python/tutorial_code/imgProc/BasicGeometricDrawing/drawing.py
+@end_toggle
 
 Explanation
 -----------
 
--#  Let's start by checking out the *main* function. We observe that first thing we do is creating a
+-#  Let's start by checking out the *main* function.
+@add_toggle_cpp
+We observe that first thing we do is creating a
     *Random Number Generator* object (RNG):
-    @code{.cpp}
-    RNG rng( 0xFFFFFFFF );
-    @endcode
+    @snippet samples/cpp/tutorial_code/ImgProc/basic_drawing/Drawing_2.cpp create_RNG
     RNG implements a random number generator. In this example, *rng* is a RNG element initialized
     with the value *0xFFFFFFFF*
-
+@end_toggle
+@add_toggle_python
+    In Python we can perform random number generation with NumPy's `randint()` function. There
+    are no bindings for the OpenCV RNG class in Python.
+@end_toggle
 -#  Then we create a matrix initialized to *zeros* (which means that it will appear as black),
     specifying its height, width and its type:
-    @code{.cpp}
-    /// Initialize a matrix filled with zeros
-    Mat image = Mat::zeros( window_height, window_width, CV_8UC3 );
-
-    /// Show it in a window during DELAY ms
-    imshow( window_name, image );
-    @endcode
+@add_toggle_cpp
+    @snippet samples/cpp/tutorial_code/ImgProc/basic_drawing/Drawing_2.cpp create_zeros
+@end_toggle
+@add_toggle_python
+    @snippet samples/python/tutorial_code/imgProc/BasicGeometricDrawing/drawing.py create_zeros
+@end_toggle
 -#  Then we proceed to draw crazy stuff. After taking a look at the code, you can see that it is
     mainly divided in 8 sections, defined as functions:
-    @code{.cpp}
-    /// Now, let's draw some lines
-    c = Drawing_Random_Lines(image, window_name, rng);
-    if( c != 0 ) return 0;
-
-    /// Go on drawing, this time nice rectangles
-    c = Drawing_Random_Rectangles(image, window_name, rng);
-    if( c != 0 ) return 0;
-
-    /// Draw some ellipses
-    c = Drawing_Random_Ellipses( image, window_name, rng );
-    if( c != 0 ) return 0;
-
-    /// Now some polylines
-    c = Drawing_Random_Polylines( image, window_name, rng );
-    if( c != 0 ) return 0;
-
-    /// Draw filled polygons
-    c = Drawing_Random_Filled_Polygons( image, window_name, rng );
-    if( c != 0 ) return 0;
-
-    /// Draw circles
-    c = Drawing_Random_Circles( image, window_name, rng );
-    if( c != 0 ) return 0;
-
-    /// Display text in random positions
-    c = Displaying_Random_Text( image, window_name, rng );
-    if( c != 0 ) return 0;
-
-    /// Displaying the big end!
-    c = Displaying_Big_End( image, window_name, rng );
-    @endcode
+@add_toggle_cpp
+    @snippet samples/cpp/tutorial_code/ImgProc/basic_drawing/Drawing_2.cpp main_drawing
+@end_toggle
+@add_toggle_python
+    @snippet samples/python/tutorial_code/imgProc/BasicGeometricDrawing/drawing.py main_drawing
+@end_toggle
     All of these functions follow the same pattern, so we will analyze only a couple of them, since
     the same explanation applies for all.
 
 -#  Checking out the function **Drawing_Random_Lines**:
-    @code{.cpp}
-    int Drawing_Random_Lines( Mat image, char* window_name, RNG rng )
-    {
-      int lineType = 8;
-      Point pt1, pt2;
-
-      for( int i = 0; i < NUMBER; i++ )
-      {
-       pt1.x = rng.uniform( x_1, x_2 );
-       pt1.y = rng.uniform( y_1, y_2 );
-       pt2.x = rng.uniform( x_1, x_2 );
-       pt2.y = rng.uniform( y_1, y_2 );
-
-       line( image, pt1, pt2, randomColor(rng), rng.uniform(1, 10), 8 );
-       imshow( window_name, image );
-       if( waitKey( DELAY ) >= 0 )
-       { return -1; }
-      }
-      return 0;
-    }
-    @endcode
+@add_toggle_cpp
+    @snippet samples/cpp/tutorial_code/ImgProc/basic_drawing/Drawing_2.cpp random_lines
     We can observe the following:
-
+    @snippet samples/cpp/tutorial_code/ImgProc/basic_drawing/Drawing_2.cpp line_points
     -   The *for* loop will repeat **NUMBER** times. Since the function @ref cv::line is inside this
         loop, that means that **NUMBER** lines will be generated.
     -   The line extremes are given by *pt1* and *pt2*. For *pt1* we can see that:
-        @code{.cpp}
-        pt1.x = rng.uniform( x_1, x_2 );
-        pt1.y = rng.uniform( y_1, y_2 );
-        @endcode
         -   We know that **rng** is a *Random number generator* object. In the code above we are
             calling **rng.uniform(a,b)**. This generates a randomly uniformed distribution between
             the values **a** and **b** (inclusive in **a**, exclusive in **b**).
@@ -125,49 +87,38 @@ Explanation
             randomColor(rng)
             @endcode
             Let's check the function implementation:
-            @code{.cpp}
-            static Scalar randomColor( RNG& rng )
-              {
-              int icolor = (unsigned) rng;
-              return Scalar( icolor&255, (icolor>>8)&255, (icolor>>16)&255 );
-              }
-            @endcode
+            @snippet samples/cpp/tutorial_code/ImgProc/basic_drawing/Drawing_2.cpp random_color
             As we can see, the return value is an *Scalar* with 3 randomly initialized values, which
             are used as the *R*, *G* and *B* parameters for the line color. Hence, the color of the
             lines will be random too!
-
+@end_toggle
+@add_toggle_python
+    @snippet samples/python/tutorial_code/imgProc/BasicGeometricDrawing/drawing.py random_lines
+    We can observe the following:
+    @snippet samples/python/tutorial_code/imgProc/BasicGeometricDrawing/drawing.py line_points
+    -   The *for* loop will repeat **NUMBER** times. Since the function @ref cv::line is inside this
+        loop, that means that **NUMBER** lines will be generated.
+    -   The line extremes are given by *pt1* and *pt2*. For *pt1* we can see that:
+        -   In the code above we are
+            calling **np.random.randint(a,b)**. This generates a randomly uniformed distribution between
+            the values **a** and **b** (inclusive in **a**, exclusive in **b**).
+        -   From the explanation above, we deduce that the extremes *pt1* and *pt2* will be random
+            values, so the lines positions will be quite impredictable, giving a nice visual effect
+            (check out the Result section below).
+        -   As another observation, we notice that in the @ref cv::line arguments, for the *color*
+            input we generate a random color by using a tuple of three random
+            values generated like so:
+            @snippet samples/python/tutorial_code/imgProc/BasicGeometricDrawing/drawing.py random_color
+@end_toggle
 -#  The explanation above applies for the other functions generating circles, ellipses, polygons,
     etc. The parameters such as *center* and *vertices* are also generated randomly.
 -#  Before finishing, we also should take a look at the functions *Display_Random_Text* and
     *Displaying_Big_End*, since they both have a few interesting features:
 -#  **Display_Random_Text:**
-    @code{.cpp}
-    int Displaying_Random_Text( Mat image, char* window_name, RNG rng )
-    {
-      int lineType = 8;
-
-      for ( int i = 1; i < NUMBER; i++ )
-      {
-        Point org;
-        org.x = rng.uniform(x_1, x_2);
-        org.y = rng.uniform(y_1, y_2);
-
-        putText( image, "Testing text rendering", org, rng.uniform(0,8),
-                 rng.uniform(0,100)*0.05+0.1, randomColor(rng), rng.uniform(1, 10), lineType);
-
-        imshow( window_name, image );
-        if( waitKey(DELAY) >= 0 )
-          { return -1; }
-      }
-
-      return 0;
-    }
-    @endcode
+    @add_toggle_cpp
+    @snippet samples/cpp/tutorial_code/ImgProc/basic_drawing/Drawing_2.cpp random_text
     Everything looks familiar but the expression:
-    @code{.cpp}
-    putText( image, "Testing text rendering", org, rng.uniform(0,8),
-             rng.uniform(0,100)*0.05+0.1, randomColor(rng), rng.uniform(1, 10), lineType);
-    @endcode
+    @snippet samples/cpp/tutorial_code/ImgProc/basic_drawing/Drawing_2.cpp put_text
     So, what does the function @ref cv::putText do? In our example:
 
     -   Draws the text **"Testing text rendering"** in **image**
@@ -177,39 +128,31 @@ Explanation
         (meaning its range is: \f$[0.1, 5.1>\f$)
     -   The text color is random (denoted by **randomColor(rng)**)
     -   The text thickness ranges between 1 and 10, as specified by **rng.uniform(1,10)**
+    @end_toggle
+    @add_toggle_python
+    @snippet samples/python/tutorial_code/imgProc/BasicGeometricDrawing/drawing.py random_text
+    Everything looks familiar but the expression:
+    @snippet samples/python/tutorial_code/imgProc/BasicGeometricDrawing/drawing.py put_text
+    So, what does the function @ref cv::putText do? In our example:
+
+    -   Draws the text **"Testing text rendering"** in **image**
+    -   The bottom-left corner of the text will be located at the point defined by the tuple **org**
+    -   The font type is a random integer value in the range: \f$[0, 8>\f$.
+    -   The scale of the font is denoted by the expression **rng.uniform(0, 100)x0.05 + 0.1**
+        (meaning its range is: \f$[0.1, 5.1>\f$)
+    -   The text color is random, generated in the same fashion as above
+    -   The text thickness ranges between 1 and 10, as specified by **np.random.randint(1, 10)**
+    @end_toggle
 
     As a result, we will get (analagously to the other drawing functions) **NUMBER** texts over our
     image, in random locations.
 
 -#  **Displaying_Big_End**
-    @code{.cpp}
-    int Displaying_Big_End( Mat image, char* window_name, RNG rng )
-    {
-      Size textsize = getTextSize("OpenCV forever!", FONT_HERSHEY_COMPLEX, 3, 5, 0);
-      Point org((window_width - textsize.width)/2, (window_height - textsize.height)/2);
-      int lineType = 8;
-
-      Mat image2;
-
-      for( int i = 0; i < 255; i += 2 )
-      {
-        image2 = image - Scalar::all(i);
-        putText( image2, "OpenCV forever!", org, FONT_HERSHEY_COMPLEX, 3,
-               Scalar(i, i, 255), 5, lineType );
-
-        imshow( window_name, image2 );
-        if( waitKey(DELAY) >= 0 )
-          { return -1; }
-      }
-
-      return 0;
-    }
-    @endcode
+    @add_toggle_cpp
+    @snippet samples/cpp/tutorial_code/ImgProc/basic_drawing/Drawing_2.cpp big_end
     Besides the function **getTextSize** (which gets the size of the argument text), the new
-    operation we can observe is inside the *foor* loop:
-    @code{.cpp}
-    image2 = image - Scalar::all(i)
-    @endcode
+    operation we can observe is inside the *for* loop:
+    @snippet samples/cpp/tutorial_code/ImgProc/basic_drawing/Drawing_2.cpp subtract
     So, **image2** is the subtraction of **image** and **Scalar::all(i)**. In fact, what happens
     here is that every pixel of **image2** will be the result of subtracting every pixel of
     **image** minus the value of **i** (remember that for each pixel we are considering three values
@@ -218,6 +161,19 @@ Explanation
     Also remember that the subtraction operation *always* performs internally a **saturate**
     operation, which means that the result obtained will always be inside the allowed range (no
     negative and between 0 and 255 for our example).
+    @end_toggle
+    @add_toggle_python
+    @snippet samples/python/tutorial_code/imgProc/BasicGeometricDrawing/drawing.py big_end
+    Besides the function **getTextSize** (which gets the size of the argument text), the new
+    operation we can observe is inside the *for* loop:
+    @snippet samples/python/tutorial_code/imgProc/BasicGeometricDrawing/drawing.py subtract
+    So, **image2** is the subtraction of **image** and the value of **i**. In fact, what happens
+    here is that every pixel of **image2** will be the result of subtracting every pixel of
+    **image** minus the value of **i** (remember that for each pixel we are considering three values
+    such as R, G and B, so each of them will be affected)
+
+    Note that NumPy subtraction is equivalent to regular subtraction and is not saturated: meaning that values can become negative. Thus rather than values simply being set to 0 if negative, the values will wrap around beginning from 255 and count down.
+    @end_toggle
 
 Result
 ------

--- a/doc/tutorials/imgproc/table_of_content_imgproc.markdown
+++ b/doc/tutorials/imgproc/table_of_content_imgproc.markdown
@@ -15,7 +15,7 @@ In this section you will learn about the image processing (manipulation) functio
 
 -   @subpage tutorial_random_generator_and_text
 
-    *Languages:* C++
+    *Languages:* C++, Python
 
     *Compatibility:* \> OpenCV 2.0
 

--- a/samples/cpp/tutorial_code/ImgProc/basic_drawing/Drawing_2.cpp
+++ b/samples/cpp/tutorial_code/ImgProc/basic_drawing/Drawing_2.cpp
@@ -44,15 +44,20 @@ int main( void )
   /// Start creating a window
   char window_name[] = "Drawing_2 Tutorial";
 
+  //![create_RNG]
   /// Also create a random object (RNG)
   RNG rng( 0xFFFFFFFF );
+  //![create_RNG]
 
+  //![create_zeros]
   /// Initialize a matrix filled with zeros
   Mat image = Mat::zeros( window_height, window_width, CV_8UC3 );
   /// Show it in a window during DELAY ms
   imshow( window_name, image );
+  //![create_zeros]
   waitKey( DELAY );
 
+  //![main_drawing]
   /// Now, let's draw some lines
   c = Drawing_Random_Lines(image, window_name, rng);
   if( c != 0 ) return 0;
@@ -83,6 +88,7 @@ int main( void )
 
   /// Displaying the big end!
   c = Displaying_Big_End( image, window_name, rng );
+  //![main_drawing]
   if( c != 0 ) return 0;
 
   waitKey(0);
@@ -91,6 +97,7 @@ int main( void )
 
 /// Function definitions
 
+//![random_color]
 /**
  * @function randomColor
  * @brief Produces a random color given a random object
@@ -100,8 +107,9 @@ static Scalar randomColor( RNG& rng )
   int icolor = (unsigned) rng;
   return Scalar( icolor&255, (icolor>>8)&255, (icolor>>16)&255 );
 }
+//![random_color]
 
-
+//![random_lines]
 /**
  * @function Drawing_Random_Lines
  */
@@ -111,8 +119,10 @@ int Drawing_Random_Lines( Mat image, char* window_name, RNG rng )
 
   for( int i = 0; i < NUMBER; i++ )
   {
+    //![line_points]
     pt1.x = rng.uniform( x_1, x_2 );
     pt1.y = rng.uniform( y_1, y_2 );
+    //![line_points]
     pt2.x = rng.uniform( x_1, x_2 );
     pt2.y = rng.uniform( y_1, y_2 );
 
@@ -124,6 +134,7 @@ int Drawing_Random_Lines( Mat image, char* window_name, RNG rng )
 
   return 0;
 }
+//![random_lines]
 
 /**
  * @function Drawing_Rectangles
@@ -276,6 +287,7 @@ int Drawing_Random_Circles( Mat image, char* window_name, RNG rng )
   return 0;
 }
 
+//![random_text]
 /**
  * @function Displaying_Random_Text
  */
@@ -288,10 +300,10 @@ int Displaying_Random_Text( Mat image, char* window_name, RNG rng )
     Point org;
     org.x = rng.uniform(x_1, x_2);
     org.y = rng.uniform(y_1, y_2);
-
+    //![put_text]
     putText( image, "Testing text rendering", org, rng.uniform(0,8),
              rng.uniform(0,100)*0.05+0.1, randomColor(rng), rng.uniform(1, 10), lineType);
-
+    //![put_text]
     imshow( window_name, image );
     if( waitKey(DELAY) >= 0 )
       { return -1; }
@@ -299,7 +311,9 @@ int Displaying_Random_Text( Mat image, char* window_name, RNG rng )
 
   return 0;
 }
+//![random_text]
 
+//![big_end]
 /**
  * @function Displaying_Big_End
  */
@@ -313,7 +327,9 @@ int Displaying_Big_End( Mat image, char* window_name, RNG )
 
   for( int i = 0; i < 255; i += 2 )
   {
+    //![subtract]
     image2 = image - Scalar::all(i);
+    //![subtract]
     putText( image2, "OpenCV forever!", org, FONT_HERSHEY_COMPLEX, 3,
              Scalar(i, i, 255), 5, lineType );
 
@@ -324,3 +340,4 @@ int Displaying_Big_End( Mat image, char* window_name, RNG )
 
   return 0;
 }
+//![big_end]

--- a/samples/python/tutorial_code/imgProc/BasicGeometricDrawing/drawing.py
+++ b/samples/python/tutorial_code/imgProc/BasicGeometricDrawing/drawing.py
@@ -12,16 +12,21 @@ from __future__ import print_function
 import numpy as np
 import cv2 as cv
 
+## [random_lines]
 # Drawing Lines
 def lines():
-    for i in range(NUMBER*2):
+    for i in range(NUMBER):
         pt1, pt2 = [], []
+        ## [line_points]
         pt1.append(np.random.randint(x1, x2))
         pt1.append(np.random.randint(y1, y2))
+        ## [line_points]
         pt2.append(np.random.randint(x1, x2))
         pt2.append(np.random.randint(y1, y2))
+        ## [random_color]
         color = "%06x" % np.random.randint(0, 0xFFFFFF)
         color = tuple(int(color[i:i+2], 16) for i in (0, 2 ,4))
+        ## [random_color]
         arrowed =  np.random.randint(0, 6)
         if (arrowed<3):
             cv.line(image, tuple(pt1), tuple(pt2), color, np.random.randint(1, 10), lineType)
@@ -30,10 +35,11 @@ def lines():
         cv.imshow(wndname, image)
         if cv.waitKey(DELAY)>=0:
             return
+## [random_lines]
 
 # Drawing Rectangle
 def rectangle():
-    for i in range(NUMBER*2):
+    for i in range(NUMBER):
         pt1, pt2 = [], []
         pt1.append(np.random.randint(x1, x2))
         pt1.append(np.random.randint(y1, y2))
@@ -55,7 +61,7 @@ def rectangle():
 
 # Drawing ellipse
 def ellipse():
-    for i in range(NUMBER*2):
+    for i in range(NUMBER):
         center = []
         center.append(np.random.randint(x1, x2))
         center.append(np.random.randint(x1, x2))
@@ -144,6 +150,7 @@ def circles():
         if cv.waitKey(DELAY) >= 0:
             return
 
+## [random_text]
 # Draws a text string
 def string():
     for i in range(NUMBER):
@@ -152,21 +159,27 @@ def string():
         org.append(np.random.randint(x1, x2))
         color = "%06x" % np.random.randint(0, 0xFFFFFF)
         color = tuple(int(color[i:i+2], 16) for i in (0, 2 ,4))
+        ## [put_text]
         cv.putText(image, "Testing text rendering", tuple(org), np.random.randint(0, 8), np.random.randint(0, 100)*0.05+0.1, color, np.random.randint(1, 10), lineType)
+        ## [put_text]
         cv.imshow(wndname, image)
         if cv.waitKey(DELAY) >= 0:
             return
+## [random_text]
 
-
+## [big_end]
 def string1():
     textsize = cv.getTextSize("OpenCV forever!", cv.FONT_HERSHEY_COMPLEX, 3, 5)
     org = (int((width - textsize[0][0])/2), int((height - textsize[0][1])/2))
     for i in range(0, 255, 2):
+        ## [subtract]
         image2 = np.array(image) - i
+        ## [subtract]
         cv.putText(image2, "OpenCV forever!", org, cv.FONT_HERSHEY_COMPLEX, 3, (i, i, 255), 5, lineType)
         cv.imshow(wndname, image2)
         if cv.waitKey(DELAY) >= 0:
             return
+## [big_end]
 
 if __name__ == '__main__':
     print(__doc__)
@@ -176,9 +189,12 @@ if __name__ == '__main__':
     width, height = 1000, 700
     lineType = cv.LINE_AA  # change it to LINE_8 to see non-antialiased graphics
     x1, x2, y1, y2 = -width/2, width*3/2, -height/2, height*3/2
+    ## [create_zeros]
     image = np.zeros((height, width, 3), dtype = np.uint8)
     cv.imshow(wndname, image)
+    ## [create_zeros]
     cv.waitKey(DELAY)
+    ## [main_drawing]
     lines()
     rectangle()
     ellipse()
@@ -187,5 +203,6 @@ if __name__ == '__main__':
     circles()
     string()
     string1()
+    ## [main_drawing]
     cv.waitKey(0)
     cv.destroyAllWindows()


### PR DESCRIPTION
This expands the [Random generator and text with OpenCV](https://docs.opencv.org/3.4/df/d61/tutorial_random_generator_and_text.html) tutorial to include Python coverage, using an existing Python sample file which contains translation of the original C++ source code. 

To accomplish this I followed the steps I identified in the below named issue and also updated the table of contents accordingly. This required adding Doxygen comments in the cpp and py files, and I modified the number of loop iterations in lines(), rectangle() and ellipse() to directly match the C++ source code.  

Closes #17312 
 

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under OpenCV (BSD) License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [x] The PR is proposed to proper branch
- [x] There is reference to original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
