### PR TITLE
Fixed NMSBoxes bug

### DIFF
--- a/samples/dnn/object_detection.cpp
+++ b/samples/dnn/object_detection.cpp
@@ -45,7 +45,7 @@ std::vector<std::string> classes;
 inline void preprocess(const Mat& frame, Net& net, Size inpSize, float scale,
                        const Scalar& mean, bool swapRB);
 
-void postprocess(Mat& frame, const std::vector<Mat>& out, Net& net);
+void postprocess(Mat& frame, const std::vector<Mat>& out, Net& net, int backend);
 
 void drawPred(int classId, float conf, int left, int top, int right, int bottom, Mat& frame);
 
@@ -148,7 +148,8 @@ int main(int argc, char** argv)
 
     // Load a model.
     Net net = readNet(modelPath, configPath, parser.get<String>("framework"));
-    net.setPreferableBackend(parser.get<int>("backend"));
+    int backend = parser.get<int>("backend");
+    net.setPreferableBackend(backend);
     net.setPreferableTarget(parser.get<int>("target"));
     std::vector<String> outNames = net.getUnconnectedOutLayersNames();
 
@@ -245,7 +246,7 @@ int main(int argc, char** argv)
         std::vector<Mat> outs = predictionsQueue.get();
         Mat frame = processedFramesQueue.get();
 
-        postprocess(frame, outs, net);
+        postprocess(frame, outs, net, backend);
 
         if (predictionsQueue.counter > 1)
         {
@@ -285,7 +286,7 @@ int main(int argc, char** argv)
         std::vector<Mat> outs;
         net.forward(outs, outNames);
 
-        postprocess(frame, outs, net);
+        postprocess(frame, outs, net, backend);
 
         // Put efficiency information.
         std::vector<double> layersTimes;
@@ -319,7 +320,7 @@ inline void preprocess(const Mat& frame, Net& net, Size inpSize, float scale,
     }
 }
 
-void postprocess(Mat& frame, const std::vector<Mat>& outs, Net& net)
+void postprocess(Mat& frame, const std::vector<Mat>& outs, Net& net, int backend)
 {
     static std::vector<int> outLayers = net.getUnconnectedOutLayers();
     static std::string outLayerType = net.getLayer(outLayers[0])->type;
@@ -396,7 +397,9 @@ void postprocess(Mat& frame, const std::vector<Mat>& outs, Net& net)
     else
         CV_Error(Error::StsNotImplemented, "Unknown output layer type: " + outLayerType);
 
-    if (outLayers.size() > 1)
+    // NMS is used inside Region layer only on DNN_BACKEND_OPENCV for another backends we need NMS in sample
+    // or NMS is required if number of outputs > 1
+    if (outLayers.size() > 1 || (outLayerType == "Region" && backend != DNN_BACKEND_OPENCV))
     {
         std::map<int, std::vector<size_t> > class2indices;
         for (size_t i = 0; i < classIds.size(); i++)

--- a/samples/dnn/object_detection.cpp
+++ b/samples/dnn/object_detection.cpp
@@ -411,21 +411,21 @@ void postprocess(Mat& frame, const std::vector<Mat>& outs, Net& net)
         std::vector<int> nmsClassIds;
         for (std::map<int, std::vector<size_t> >::iterator it = class2indices.begin(); it != class2indices.end(); ++it)
         {
-            std::vector<Rect> local_boxes;
-            std::vector<float> local_confidences;
-            std::vector<size_t> class_indices = it->second;
-            for (size_t i = 0; i < class_indices.size(); i++)
+            std::vector<Rect> localBoxes;
+            std::vector<float> localConfidences;
+            std::vector<size_t> classIndices = it->second;
+            for (size_t i = 0; i < classIndices.size(); i++)
             {
-                local_boxes.push_back(boxes[class_indices[i]]);
-                local_confidences.push_back(confidences[class_indices[i]]);
+                localBoxes.push_back(boxes[classIndices[i]]);
+                localConfidences.push_back(confidences[classIndices[i]]);
             }
-            std::vector<int> nms_indices;
-            NMSBoxes(local_boxes, local_confidences, confThreshold, nmsThreshold, nms_indices);
-            for (size_t i = 0; i < nms_indices.size(); i++)
+            std::vector<int> nmsIndices;
+            NMSBoxes(localBoxes, localConfidences, confThreshold, nmsThreshold, nmsIndices);
+            for (size_t i = 0; i < nmsIndices.size(); i++)
             {
-                size_t idx = nms_indices[i];
-                nmsBoxes.push_back(local_boxes[idx]);
-                nmsConfidences.push_back(local_confidences[idx]);
+                size_t idx = nmsIndices[i];
+                nmsBoxes.push_back(localBoxes[idx]);
+                nmsConfidences.push_back(localConfidences[idx]);
                 nmsClassIds.push_back(it->first);
             }
         }
@@ -434,10 +434,10 @@ void postprocess(Mat& frame, const std::vector<Mat>& outs, Net& net)
         confidences = nmsConfidences;
     }
 
-    for (size_t i = 0; i < boxes.size(); ++i)
+    for (size_t idx = 0; idx < boxes.size(); ++idx)
     {
-        Rect box = boxes[i];
-        drawPred(classIds[i], confidences[i], box.x, box.y,
+        Rect box = boxes[idx];
+        drawPred(classIds[idx], confidences[idx], box.x, box.y,
                  box.x + box.width, box.y + box.height, frame);
     }
 }

--- a/samples/dnn/object_detection.py
+++ b/samples/dnn/object_detection.py
@@ -161,7 +161,7 @@ def postprocess(frame, outs):
         exit()
 
     indices = []
-    if lastLayer.type == 'Region' and len(outNames) > 1:
+    if len(outNames) > 1:
         classIds = np.array(classIds)
         boxes = np.array(boxes)
         confidences = np.array(confidences)

--- a/samples/dnn/object_detection.py
+++ b/samples/dnn/object_detection.py
@@ -141,9 +141,6 @@ def postprocess(frame, outs):
         # Network produces output blob with a shape NxC where N is a number of
         # detected objects and C is a number of classes + 4 where the first 4
         # numbers are [center_x, center_y, width, height]
-        classIds = []
-        confidences = []
-        boxes = []
         for out in outs:
             for detection in out:
                 scores = detection[5:]
@@ -163,9 +160,23 @@ def postprocess(frame, outs):
         print('Unknown output layer type: ' + lastLayer.type)
         exit()
 
-    indices = cv.dnn.NMSBoxes(boxes, confidences, confThreshold, nmsThreshold)
+    indices = []
+    if lastLayer.type == 'Region' and len(outNames) > 1:
+        classIds = np.array(classIds)
+        boxes = np.array(boxes)
+        confidences = np.array(confidences)
+        unique_classes = set(classIds)
+        for cl in unique_classes:
+            class_indices = np.where(classIds == cl)[0]
+            conf = confidences[class_indices]
+            box  = boxes[class_indices].tolist()
+            nms_indices = cv.dnn.NMSBoxes(box, conf, confThreshold, nmsThreshold)
+            nms_indices = nms_indices[:, 0] if len(nms_indices) else []
+            indices.extend(class_indices[nms_indices])
+    else:
+        indices = np.arange(0, len(classIds))
+
     for i in indices:
-        i = i[0]
         box = boxes[i]
         left = box[0]
         top = box[1]

--- a/samples/dnn/object_detection.py
+++ b/samples/dnn/object_detection.py
@@ -160,8 +160,10 @@ def postprocess(frame, outs):
         print('Unknown output layer type: ' + lastLayer.type)
         exit()
 
-    indices = []
-    if len(outNames) > 1:
+    # NMS is used inside Region layer only on DNN_BACKEND_OPENCV for another backends we need NMS in sample
+    # or NMS is required if number of outputs > 1
+    if len(outNames) > 1 or lastLayer.type == 'Region' and args.backend != cv.dnn.DNN_BACKEND_OPENCV:
+        indices = []
         classIds = np.array(classIds)
         boxes = np.array(boxes)
         confidences = np.array(confidences)


### PR DESCRIPTION
### Pull Request Readiness Checklist
resolves: opencv/opencv#17246, opencv/opencv#17111

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under OpenCV (BSD) License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [x] The PR is proposed to proper branch
- [x] There is reference to original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake

<details>
<summary>Hypothesis: NMS over multiple output layers is not needed (i.e. YOLOv3, YOLOv4)</summary>

**Hypothesis**: NMS over multiple output layers is not needed (i.e. YOLOv3, YOLOv4)
**Resuls**: NMS is required

Output without NMS in sample - 10 detections. Some of detections have an IoU approximately equal 1.
![no_nms](https://user-images.githubusercontent.com/22346860/82549194-37e55500-9b65-11ea-99f5-c1f266a21c71.png)

Output with NMS in sample - 7 detections.
![nms](https://user-images.githubusercontent.com/22346860/82549221-429fea00-9b65-11ea-9a5d-a11313e80f00.png)

</details>