### PR TITLE
Add note on CMake installation with Homebrew

### DIFF
--- a/doc/tutorials/introduction/macos_install/macos_install.markdown
+++ b/doc/tutorials/introduction/macos_install/macos_install.markdown
@@ -39,6 +39,8 @@ Installing CMake
     cmake --version
     @endcode
 
+@note You can use [Homebrew](https://brew.sh/) to install CMake with @code{.bash} brew install cmake @endcode
+
 Getting OpenCV Source Code
 --------------------------
 


### PR DESCRIPTION
This adds a note mentioning CMake can be installed simply with brew on macOS.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under OpenCV (BSD) License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [x] The PR is proposed to proper branch
- [x] There is reference to original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
