### PR TITLE
build: fix warnings about TARGET_OS_MACCATALYST

### DIFF
--- a/modules/videoio/src/cap_avfoundation.mm
+++ b/modules/videoio/src/cap_avfoundation.mm
@@ -383,7 +383,7 @@ int CvCaptureCAM::startCaptureDevice(int cameraNum) {
         [mCaptureDecompressedVideoOutput setVideoSettings:pixelBufferOptions];
         mCaptureDecompressedVideoOutput.alwaysDiscardsLateVideoFrames = YES;
 
-#if (TARGET_OS_IPHONE || TARGET_IPHONE_SIMULATOR) && !TARGET_OS_MACCATALYST
+#if (TARGET_OS_IPHONE || TARGET_IPHONE_SIMULATOR) && (!defined(TARGET_OS_MACCATALYST) || !TARGET_OS_MACCATALYST)
         mCaptureDecompressedVideoOutput.minFrameDuration = CMTimeMake(1, 30);
 #endif
 

--- a/modules/videoio/src/cap_ios_abstract_camera.mm
+++ b/modules/videoio/src/cap_ios_abstract_camera.mm
@@ -299,7 +299,7 @@
     }
     else
     {
-#if !TARGET_OS_MACCATALYST
+#if (!defined(TARGET_OS_MACCATALYST) || !TARGET_OS_MACCATALYST)
         // Deprecated in 6.0; here for backward compatibility
         if ([self.captureVideoPreviewLayer isOrientationSupported])
         {


### PR DESCRIPTION
relates #17304

Messages:
> /Volumes/build-storage/build/precommit_ios/opencv/modules/videoio/src/cap_avfoundation.mm:395:55: warning: 'TARGET_OS_MACCATALYST' is not defined, evaluates to 0 [-Wundef]
/Volumes/build-storage/build/precommit_ios/opencv/modules/videoio/src/cap_ios_abstract_camera.mm:302:6: warning: 'TARGET_OS_MACCATALYST' is not defined, evaluates to 0 [-Wundef]


```
buildworker:iOS=macosx-2
```
