### PR TITLE
added bash command to create shared library in the system lib path /usr/local/lib

### DIFF
--- a/doc/tutorials/introduction/linux_install/linux_install.markdown
+++ b/doc/tutorials/introduction/linux_install/linux_install.markdown
@@ -120,6 +120,8 @@ Building OpenCV from Source Using CMake
 -#  To install libraries, execute the following command from build directory
     @code{.bash}
     sudo make install
+    sudo sh -c 'echo "/usr/local/lib" > /etc/ld.so.conf.d/opencv4.conf' 
+    sudo ldconfig
     @endcode
 -#  [optional] Running tests
 


### PR DESCRIPTION
In order to allow code to run after installation, we need to add opencv as a shared library to the system library path.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [ x] I agree to contribute to the project under OpenCV (BSD) License.
- [x ] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [ x] The PR is proposed to proper branch
- [ ] There is reference to original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
