### PR TITLE
Fix integer overflow in parseOption().

### DIFF
--- a/modules/core/src/system.cpp
+++ b/modules/core/src/system.cpp
@@ -1961,7 +1961,11 @@ inline size_t parseOption(const std::string &value)
     }
     cv::String valueStr = value.substr(0, pos);
     cv::String suffixStr = value.substr(pos, value.length() - pos);
-    size_t v = sizeof(size_t) == 8 ? (size_t)std::stoull(valueStr) : (size_t)std::stoul(valueStr);
+#ifdef CV_CXX11
+    size_t v = (size_t)std::stoull(valueStr);
+#else
+    size_t v = (size_t)atol(valueStr.c_str());
+#endif
     if (suffixStr.length() == 0)
         return v;
     else if (suffixStr == "MB" || suffixStr == "Mb" || suffixStr == "mb")

--- a/modules/core/src/system.cpp
+++ b/modules/core/src/system.cpp
@@ -1961,7 +1961,7 @@ inline size_t parseOption(const std::string &value)
     }
     cv::String valueStr = value.substr(0, pos);
     cv::String suffixStr = value.substr(pos, value.length() - pos);
-    size_t v = sizeof(size_t) == 8 ? std::stoull(valueStr) : std::stoul(valueStr);
+    size_t v = sizeof(size_t) == 8 ? (size_t)std::stoull(valueStr) : (size_t)std::stoul(valueStr);
     if (suffixStr.length() == 0)
         return v;
     else if (suffixStr == "MB" || suffixStr == "Mb" || suffixStr == "mb")

--- a/modules/core/src/system.cpp
+++ b/modules/core/src/system.cpp
@@ -1961,7 +1961,7 @@ inline size_t parseOption(const std::string &value)
     }
     cv::String valueStr = value.substr(0, pos);
     cv::String suffixStr = value.substr(pos, value.length() - pos);
-    int v = atoi(valueStr.c_str());
+    size_t v = sizeof(size_t) == 8 ? std::stoull(valueStr) : std::stoul(valueStr);
     if (suffixStr.length() == 0)
         return v;
     else if (suffixStr == "MB" || suffixStr == "Mb" || suffixStr == "mb")


### PR DESCRIPTION
Previous code does not work for values like 100000MB.
The overflow itself is in line `return v * 1024 * 1024;`.

### Pull Request Readiness Checklist

- [x] I agree to contribute to the project under OpenCV (BSD) License.