### PR TITLE
GAPI: fix uninitialized variables in Fluid

### DIFF
--- a/modules/gapi/include/opencv2/gapi/fluid/gfluidbuffer.hpp
+++ b/modules/gapi/include/opencv2/gapi/fluid/gfluidbuffer.hpp
@@ -87,7 +87,7 @@ public:
 
 private:
     std::unique_ptr<Priv> m_priv;
-    const Cache* m_cache;
+    const Cache* m_cache = nullptr;
 };
 
 class GAPI_EXPORTS Buffer

--- a/modules/gapi/src/backends/fluid/gfluidbuffer_priv.hpp
+++ b/modules/gapi/src/backends/fluid/gfluidbuffer_priv.hpp
@@ -245,7 +245,7 @@ class GAPI_EXPORTS Buffer::Priv
 
     // Coordinate starting from which this buffer is assumed
     // to be read (with border not being taken into account)
-    int m_readStart;
+    int m_readStart = 0;
     cv::Rect m_roi;
 
     friend void debugBufferPriv(const Buffer& p, std::ostream &os);


### PR DESCRIPTION

Fixed some uninitialized members in `Fluid` structures to make static analysis happy.
 
```
force_builders=ARMv7,Custom
build_image:Custom=centos:7
buildworker:Custom=linux-1
build_gapi_standalone:Custom=ade-0.1.1f

build_gapi_standalone:Linux x64=ade-0.1.1f
build_gapi_standalone:Win64=ade-0.1.1f
build_gapi_standalone:Mac=ade-0.1.1f
build_gapi_standalone:Linux x64 Debug=ade-0.1.1f

build_image:Custom Win=openvino-2020.2.0
test_modules:Custom Win=gapi,dnn,python2,python3,java
test_opencl:Custom Win=OFF
test_bigdata:Custom Win=1
test_filter:Custom Win=*
```
### Pull Request Readiness Checklist
See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under OpenCV (BSD) License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [x] The PR is proposed to proper branch
- [x] There is reference to original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
