### PR TITLE
pkg-config: Drop broken include path

### DIFF
--- a/cmake/templates/opencv-XXX.pc.in
+++ b/cmake/templates/opencv-XXX.pc.in
@@ -3,12 +3,11 @@
 prefix=@prefix@
 exec_prefix=@exec_prefix@
 libdir=@libdir@
-includedir_old=@includedir@/opencv
-includedir_new=@includedir@
+includedir=@includedir@
 
 Name: OpenCV
 Description: Open Source Computer Vision Library
 Version: @OPENCV_VERSION_PLAIN@
 Libs: @OPENCV_PC_LIBS@
 Libs.private: @OPENCV_PC_LIBS_PRIVATE@
-Cflags: -I${includedir_old} -I${includedir_new}
+Cflags: -I${includedir}


### PR DESCRIPTION
The legacy `includedir` was removed in 4.0 (https://github.com/opencv/opencv/pull/12477) but it was not removed from the `.pc` file.

The non-existing path causes issues when trying to link against OpenCV using pkg-config in CMake.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under OpenCV (BSD) License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [x] The PR is proposed to proper branch
- [ ] There is reference to original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
