### PR TITLE
Do not wrap matcher constructor to Java and Python

### DIFF
--- a/modules/features2d/include/opencv2/features2d.hpp
+++ b/modules/features2d/include/opencv2/features2d.hpp
@@ -1123,7 +1123,7 @@ public:
      *
      *
     */
-    CV_WRAP BFMatcher( int normType=NORM_L2, bool crossCheck=false );
+    BFMatcher( int normType=NORM_L2, bool crossCheck=false );
 
     virtual ~BFMatcher() {}
 
@@ -1166,7 +1166,7 @@ matches of descriptor sets because flann::Index does not support this. :
 class CV_EXPORTS_W FlannBasedMatcher : public DescriptorMatcher
 {
 public:
-    CV_WRAP FlannBasedMatcher( const Ptr<flann::IndexParams>& indexParams=makePtr<flann::KDTreeIndexParams>(),
+    FlannBasedMatcher( const Ptr<flann::IndexParams>& indexParams=makePtr<flann::KDTreeIndexParams>(),
                        const Ptr<flann::SearchParams>& searchParams=makePtr<flann::SearchParams>() );
 
     virtual void add( InputArrayOfArrays descriptors ) CV_OVERRIDE;


### PR DESCRIPTION
Fix for https://github.com/opencv/opencv/issues/11268.

Java wrappers expects that Java object holds pointer to `cv::Ptr` and tries to dereference it each time. `create()` method should (and actually is) used to create object.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [ ] I agree to contribute to the project under OpenCV (BSD) License.
- [ ] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [ ] The PR is proposed to proper branch
- [ ] There is reference to original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
