### PR TITLE
improved fitEllipse and fitEllipseDirect accuracy in singular cases

### DIFF
--- a/modules/imgproc/misc/java/test/ImgprocTest.java
+++ b/modules/imgproc/misc/java/test/ImgprocTest.java
@@ -797,10 +797,13 @@ public class ImgprocTest extends OpenCVTestCase {
 
         rrect = Imgproc.fitEllipse(points);
 
-        double FIT_ELLIPSE_EPS = 0.4;
-        assertPointEquals(new Point(0, 0), rrect.center, EPS);
-        assertEquals(2.828, rrect.size.width, FIT_ELLIPSE_EPS);
-        assertEquals(2.828, rrect.size.height, FIT_ELLIPSE_EPS);
+        double FIT_ELLIPSE_CENTER_EPS = 0.01;
+        double FIT_ELLIPSE_SIZE_EPS = 0.4;
+        
+        assertEquals(0.0, rrect.center.x, FIT_ELLIPSE_CENTER_EPS);
+        assertEquals(0.0, rrect.center.y, FIT_ELLIPSE_CENTER_EPS);
+        assertEquals(2.828, rrect.size.width, FIT_ELLIPSE_SIZE_EPS);
+        assertEquals(2.828, rrect.size.height, FIT_ELLIPSE_SIZE_EPS);
     }
 
     public void testFitLine() {

--- a/modules/imgproc/misc/java/test/ImgprocTest.java
+++ b/modules/imgproc/misc/java/test/ImgprocTest.java
@@ -797,9 +797,10 @@ public class ImgprocTest extends OpenCVTestCase {
 
         rrect = Imgproc.fitEllipse(points);
 
+        double FIT_ELLIPSE_EPS = 0.3;
         assertPointEquals(new Point(0, 0), rrect.center, EPS);
-        assertEquals(2.828, rrect.size.width, EPS);
-        assertEquals(2.828, rrect.size.height, EPS);
+        assertEquals(2.828, rrect.size.width, FIT_ELLIPSE_EPS);
+        assertEquals(2.828, rrect.size.height, FIT_ELLIPSE_EPS);
     }
 
     public void testFitLine() {

--- a/modules/imgproc/misc/java/test/ImgprocTest.java
+++ b/modules/imgproc/misc/java/test/ImgprocTest.java
@@ -799,7 +799,7 @@ public class ImgprocTest extends OpenCVTestCase {
 
         double FIT_ELLIPSE_CENTER_EPS = 0.01;
         double FIT_ELLIPSE_SIZE_EPS = 0.4;
-        
+
         assertEquals(0.0, rrect.center.x, FIT_ELLIPSE_CENTER_EPS);
         assertEquals(0.0, rrect.center.y, FIT_ELLIPSE_CENTER_EPS);
         assertEquals(2.828, rrect.size.width, FIT_ELLIPSE_SIZE_EPS);

--- a/modules/imgproc/misc/java/test/ImgprocTest.java
+++ b/modules/imgproc/misc/java/test/ImgprocTest.java
@@ -797,7 +797,7 @@ public class ImgprocTest extends OpenCVTestCase {
 
         rrect = Imgproc.fitEllipse(points);
 
-        double FIT_ELLIPSE_EPS = 0.3;
+        double FIT_ELLIPSE_EPS = 0.4;
         assertPointEquals(new Point(0, 0), rrect.center, EPS);
         assertEquals(2.828, rrect.size.width, FIT_ELLIPSE_EPS);
         assertEquals(2.828, rrect.size.height, FIT_ELLIPSE_EPS);

--- a/modules/imgproc/src/shapedescr.cpp
+++ b/modules/imgproc/src/shapedescr.cpp
@@ -723,13 +723,13 @@ cv::RotatedRect cv::fitEllipseDirect( InputArray _points )
         for( i = 0; i < n; i++, eps *= -1 )
         {
             Point2f p = is_float ? ptsf[i] : Point2f((float)ptsi[i].x, (float)ptsi[i].y);
-            p.x = (p.x + eps - c.x)*scale; p.y = (p.y + eps - c.y)*scale;
+            double px = (p.x + eps - c.x)*scale, py = (p.y + eps - c.y)*scale;
 
-            A.at<double>(i,0) = (double)(p.x)*(p.x);
-            A.at<double>(i,1) = (double)(p.x)*(p.y);
-            A.at<double>(i,2) = (double)(p.y)*(p.y);
-            A.at<double>(i,3) = (double)p.x;
-            A.at<double>(i,4) = (double)p.y;
+            A.at<double>(i,0) = px*px;
+            A.at<double>(i,1) = px*py;
+            A.at<double>(i,2) = py*py;
+            A.at<double>(i,3) = px;
+            A.at<double>(i,4) = py;
             A.at<double>(i,5) = 1.0;
         }
         cv::mulTransposed( A, DM, true, noArray(), 1.0, -1 );

--- a/modules/imgproc/test/test_fitellipse.cpp
+++ b/modules/imgproc/test/test_fitellipse.cpp
@@ -98,8 +98,8 @@ TEST(Imgproc_FitEllipse_JavaCase, accuracy) {
     RotatedRect e = fitEllipse(pts);
     EXPECT_NEAR(e.center.x, 0, 0.5);
     EXPECT_NEAR(e.center.y, 0, 0.5);
-    EXPECT_NEAR(e.size.width, sqrt(2.)*2, 0.3);
-    EXPECT_NEAR(e.size.height, sqrt(2.)*2, 0.3);
+    EXPECT_NEAR(e.size.width, sqrt(2.)*2, 0.4);
+    EXPECT_NEAR(e.size.height, sqrt(2.)*2, 0.4);
 }
 
 }} // namespace

--- a/modules/imgproc/test/test_fitellipse.cpp
+++ b/modules/imgproc/test/test_fitellipse.cpp
@@ -96,8 +96,8 @@ TEST(Imgproc_FitEllipse_JavaCase, accuracy) {
 
     // check that we get almost vertical ellipse centered around (1, 3)
     RotatedRect e = fitEllipse(pts);
-    EXPECT_NEAR(e.center.x, 0, 0.5);
-    EXPECT_NEAR(e.center.y, 0, 0.5);
+    EXPECT_NEAR(e.center.x, 0, 0.01);
+    EXPECT_NEAR(e.center.y, 0, 0.01);
     EXPECT_NEAR(e.size.width, sqrt(2.)*2, 0.4);
     EXPECT_NEAR(e.size.height, sqrt(2.)*2, 0.4);
 }

--- a/modules/imgproc/test/test_fitellipse.cpp
+++ b/modules/imgproc/test/test_fitellipse.cpp
@@ -66,7 +66,7 @@ TEST(Imgproc_FitEllipse_Issue_6544, accuracy) {
     EXPECT_TRUE(fit_and_check_ellipse(pts));
 }
 
-TEST(Imgproc_FitEllipse_Issue_9923, accuracy) {
+TEST(Imgproc_FitEllipse_Issue_10270, accuracy) {
     vector<Point2f> pts;
     float scale = 1;
     Point2f shift(0, 0);
@@ -82,6 +82,24 @@ TEST(Imgproc_FitEllipse_Issue_9923, accuracy) {
     EXPECT_NEAR(e.center.x, 1, 1);
     EXPECT_NEAR(e.center.y, 3, 1);
     EXPECT_LT(e.size.width*3, e.size.height);
+}
+
+TEST(Imgproc_FitEllipse_JavaCase, accuracy) {
+    vector<Point2f> pts;
+    float scale = 1;
+    Point2f shift(0, 0);
+    pts.push_back(Point2f(0, 0)*scale+shift);
+    pts.push_back(Point2f(1, 1)*scale+shift);
+    pts.push_back(Point2f(-1, 1)*scale+shift);
+    pts.push_back(Point2f(-1, -1)*scale+shift);
+    pts.push_back(Point2f(1, -1)*scale+shift);
+
+    // check that we get almost vertical ellipse centered around (1, 3)
+    RotatedRect e = fitEllipse(pts);
+    EXPECT_NEAR(e.center.x, 0, 0.5);
+    EXPECT_NEAR(e.center.y, 0, 0.5);
+    EXPECT_NEAR(e.size.width, sqrt(2.)*2, 0.3);
+    EXPECT_NEAR(e.size.height, sqrt(2.)*2, 0.3);
 }
 
 }} // namespace

--- a/modules/imgproc/test/test_fitellipse.cpp
+++ b/modules/imgproc/test/test_fitellipse.cpp
@@ -66,4 +66,22 @@ TEST(Imgproc_FitEllipse_Issue_6544, accuracy) {
     EXPECT_TRUE(fit_and_check_ellipse(pts));
 }
 
+TEST(Imgproc_FitEllipse_Issue_9923, accuracy) {
+    vector<Point2f> pts;
+    float scale = 1;
+    Point2f shift(0, 0);
+    pts.push_back(Point2f(0, 1)*scale+shift);
+    pts.push_back(Point2f(0, 2)*scale+shift);
+    pts.push_back(Point2f(0, 3)*scale+shift);
+    pts.push_back(Point2f(2, 3)*scale+shift);
+    pts.push_back(Point2f(0, 4)*scale+shift);
+
+    // check that we get almost vertical ellipse centered around (1, 3)
+    RotatedRect e = fitEllipse(pts);
+    EXPECT_LT(std::min(fabs(e.angle-180), fabs(e.angle)), 10.);
+    EXPECT_NEAR(e.center.x, 1, 1);
+    EXPECT_NEAR(e.center.y, 3, 1);
+    EXPECT_LT(e.size.width*3, e.size.height);
+}
+
 }} // namespace


### PR DESCRIPTION
... or close-to-singular cases.

Seems to resolve https://github.com/opencv/opencv/issues/10270

### Pull Request Readiness Checklist

- [x] I agree to contribute to the project under OpenCV (BSD) License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [x] The PR is proposed to proper branch
- [x] There is reference to original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
