### PR TITLE
Fixed cascadedetect convert from old cascade to new

### DIFF
--- a/modules/objdetect/src/cascadedetect_convert.cpp
+++ b/modules/objdetect/src/cascadedetect_convert.cpp
@@ -205,8 +205,8 @@ static bool convert(const String& oldcascade, const String& newcascade)
     newfs << "cascade" << "{:opencv-cascade-classifier"
     << "stageType" << "BOOST"
     << "featureType" << "HAAR"
-    << "height" << cascadesize.width
-    << "width" << cascadesize.height
+    << "width" << cascadesize.width
+    << "height" << cascadesize.height
     << "stageParams" << "{"
         << "maxWeakCount" << (int)maxWeakCount
     << "}"


### PR DESCRIPTION
### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [ y] I agree to contribute to the project under OpenCV (BSD) License.
- [y ] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [x] The PR is proposed to proper branch 
- [n ] There is reference to original bug report and related work - no bug report was opened. it's a straightforward fix.
- [n ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name. - simple fix for cascade conversions
- [n ] The feature is well documented and sample code can be built with the project CMake - simple fix
