### PR TITLE
Generate proper constructor for classes with smart pointer

### DIFF
--- a/modules/features2d/misc/java/test/BruteForceDescriptorMatcherTest.java
+++ b/modules/features2d/misc/java/test/BruteForceDescriptorMatcherTest.java
@@ -12,6 +12,7 @@ import org.opencv.core.Point;
 import org.opencv.core.Scalar;
 import org.opencv.core.DMatch;
 import org.opencv.features2d.DescriptorMatcher;
+import org.opencv.features2d.BFMatcher;
 import org.opencv.core.KeyPoint;
 import org.opencv.test.OpenCVTestCase;
 import org.opencv.test.OpenCVTestRunner;
@@ -91,6 +92,15 @@ public class BruteForceDescriptorMatcherTest extends OpenCVTestCase {
                 new DMatch(3, 1, 0, 0.2925074f),
                 new DMatch(4, 1, 0, 0.26520672f)
                 };
+    }
+
+    // https://github.com/opencv/opencv/issues/11268
+    public void testConstructor()
+    {
+        BFMatcher self_created_matcher = new BFMatcher();
+        Mat train = new Mat(1, 1, CvType.CV_8U, new Scalar(123));
+        self_created_matcher.add(Arrays.asList(train));
+        assertTrue(!self_created_matcher.empty());
     }
 
     public void testAdd() {

--- a/modules/features2d/misc/java/test/FlannBasedDescriptorMatcherTest.java
+++ b/modules/features2d/misc/java/test/FlannBasedDescriptorMatcherTest.java
@@ -12,6 +12,7 @@ import org.opencv.core.Point;
 import org.opencv.core.Scalar;
 import org.opencv.core.DMatch;
 import org.opencv.features2d.DescriptorMatcher;
+import org.opencv.features2d.FlannBasedMatcher;
 import org.opencv.core.KeyPoint;
 import org.opencv.test.OpenCVTestCase;
 import org.opencv.test.OpenCVTestRunner;
@@ -166,6 +167,15 @@ public class FlannBasedDescriptorMatcherTest extends OpenCVTestCase {
                 new DMatch(3, 1, 0, 0.2925075f),
                 new DMatch(4, 1, 0, 0.26520672f)
                 };
+    }
+
+    // https://github.com/opencv/opencv/issues/11268
+    public void testConstructor()
+    {
+        FlannBasedMatcher self_created_matcher = new FlannBasedMatcher();
+        Mat train = new Mat(1, 1, CvType.CV_8U, new Scalar(123));
+        self_created_matcher.add(Arrays.asList(train));
+        assertTrue(!self_created_matcher.empty());
     }
 
     public void testAdd() {

--- a/modules/java/generator/gen_java.py
+++ b/modules/java/generator/gen_java.py
@@ -877,7 +877,10 @@ class JavaWrapperGenerator(object):
                 ret = ""
                 default = ""
             elif not fi.ctype: # c-tor
-                ret = "return (jlong) _retval_;"
+                if self.isSmartClass(ci):
+                    ret = "return (jlong)(new Ptr<%(ctype)s>(_retval_));" % { 'ctype': fi.fullClass(isCPP=True) }
+                else:
+                    ret = "return (jlong) _retval_;"
             elif "v_type" in type_dict[fi.ctype]: # c-tor
                 if type_dict[fi.ctype]["v_type"] in ("Mat", "vector_Mat"):
                     ret = "return (jlong) _retval_;"
@@ -920,8 +923,12 @@ class JavaWrapperGenerator(object):
                         c_epilogue.append("return " + fi.ctype + "_to_List(env, _ret_val_vector_);")
             if fi.classname:
                 if not fi.ctype: # c-tor
-                    retval = fi.fullClass(isCPP=True) + "* _retval_ = "
-                    cvname = "new " + fi.fullClass(isCPP=True)
+                    if self.isSmartClass(ci):
+                        retval = self.smartWrap(ci, fi.fullClass(isCPP=True)) + " _retval_ = "
+                        cvname = "makePtr<" + fi.fullClass(isCPP=True) +">"
+                    else:
+                        retval = fi.fullClass(isCPP=True) + "* _retval_ = "
+                        cvname = "new " + fi.fullClass(isCPP=True)
                 elif fi.static:
                     cvname = fi.fullName(isCPP=True)
                 else:


### PR DESCRIPTION
Issue: https://github.com/opencv/opencv/issues/11268

Affected classes in 3.4:
- BOWKMeansTrainer
- FlannBasedMatcher
- BFMatcher

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under OpenCV (BSD) License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [x] The PR is proposed to proper branch
- [x] There is reference to original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
