### PR TITLE
core: fix builds with eigen helper header

### DIFF
--- a/modules/core/include/opencv2/core/eigen.hpp
+++ b/modules/core/include/opencv2/core/eigen.hpp
@@ -45,9 +45,14 @@
 #ifndef OPENCV_CORE_EIGEN_HPP
 #define OPENCV_CORE_EIGEN_HPP
 
+#ifndef EIGEN_WORLD_VERSION
+#error "Wrong usage of OpenCV's Eigen utility header. Include Eigen's headers first. See https://github.com/opencv/opencv/issues/17366"
+#endif
+
 #include "opencv2/core.hpp"
 
-#if EIGEN_WORLD_VERSION == 3 && EIGEN_MAJOR_VERSION >= 3
+#if EIGEN_WORLD_VERSION == 3 && EIGEN_MAJOR_VERSION >= 3 \
+    && defined(CV_CXX11) && defined(CV_CXX_STD_ARRAY)
 #include <unsupported/Eigen/CXX11/Tensor>
 #define OPENCV_EIGEN_TENSOR_SUPPORT
 #endif // EIGEN_WORLD_VERSION == 3 && EIGEN_MAJOR_VERSION >= 3
@@ -157,7 +162,7 @@ Eigen::TensorMap<Eigen::Tensor<float, 3, Eigen::RowMajor>> a_tensormap = cv2eige
 \endcode
 */
 template <typename _Tp> static inline
-Eigen::TensorMap<Eigen::Tensor<_Tp, 3, Eigen::RowMajor>> cv2eigen_tensormap(const cv::InputArray &src)
+Eigen::TensorMap<Eigen::Tensor<_Tp, 3, Eigen::RowMajor>> cv2eigen_tensormap(InputArray src)
 {
     Mat mat = src.getMat();
     CV_CheckTypeEQ(mat.type(), CV_MAKETYPE(traits::Type<_Tp>::value, mat.channels()), "");


### PR DESCRIPTION
- fixes #17366
- [fixes](http://pullrequest.opencv.org/buildbot/builders/3_4_noICV-lin64-clang/builds/595) `warning: 'const' qualifier on reference type 'cv::InputArray' (aka 'const cv::_InputArray &') has no effect`
- [fixes](https://ocv-power.imavr.com/#/builders/9/builds/8727) requirement of C++11: `error: 'array' in namespace 'std' does not name a template type`

relates #17320

```
force_builders=Custom
buildworker:Custom=linux-1
build_image:Custom=ubuntu-clang:18.04
```
