### PR TITLE
fix instable fisheye undistortPoints

### DIFF
--- a/modules/calib3d/src/fisheye.cpp
+++ b/modules/calib3d/src/fisheye.cpp
@@ -411,8 +411,8 @@ void cv::fisheye::undistortPoints( InputArray distorted, OutputArray undistorted
             }
 
             scale = std::tan(theta) / theta_d;
-        } 
-        else 
+        }
+        else
         {
             converged = true;
         }

--- a/modules/calib3d/src/fisheye.cpp
+++ b/modules/calib3d/src/fisheye.cpp
@@ -377,8 +377,6 @@ void cv::fisheye::undistortPoints( InputArray distorted, OutputArray undistorted
         Vec2d pi = sdepth == CV_32F ? (Vec2d)srcf[i] : srcd[i];  // image point
         Vec2d pw((pi[0] - c[0])/f[0], (pi[1] - c[1])/f[1]);      // world point
 
-        double scale = 1.0;
-
         double theta_d = sqrt(pw[0]*pw[0] + pw[1]*pw[1]);
 
         // the current camera model is only valid up to 180 FOV
@@ -386,12 +384,15 @@ void cv::fisheye::undistortPoints( InputArray distorted, OutputArray undistorted
         // clip values so we still get plausible results for super fisheye images > 180 grad
         theta_d = min(max(-CV_PI/2., theta_d), CV_PI/2.);
 
+        bool converged = false;
+        double theta = theta_d;
+
         if (theta_d > 1e-8)
         {
             // compensate distortion iteratively
-            double theta = theta_d;
 
             const double EPS = 1e-8; // or std::numeric_limits<double>::epsilon();
+
             for (int j = 0; j < 10; j++)
             {
                 double theta2 = theta*theta, theta4 = theta2*theta2, theta6 = theta4*theta2, theta8 = theta6*theta2;
@@ -401,22 +402,41 @@ void cv::fisheye::undistortPoints( InputArray distorted, OutputArray undistorted
                                    (1 + 3*k0_theta2 + 5*k1_theta4 + 7*k2_theta6 + 9*k3_theta8);
                 theta = theta - theta_fix;
                 if (fabs(theta_fix) < EPS)
+                {
+                    converged = true;
                     break;
+                }
             }
-
-            scale = std::tan(theta) / theta_d;
         }
 
-        Vec2d pu = pw * scale; //undistorted point
+        // theta is monotonously increasing or decreasing depending on the sign of theta
+        // if theta has flipped, it might converge due to symmetry but on the opposite of the camera center
+        // so we can check whether theta has changed the sign during the optimization
+        bool theta_flipped = ((theta_d < 0 && theta > 0) || (theta_d > 0 && theta < 0));
 
-        // reproject
-        Vec3d pr = RR * Vec3d(pu[0], pu[1], 1.0); // rotated point optionally multiplied by new camera matrix
-        Vec2d fi(pr[0]/pr[2], pr[1]/pr[2]);       // final
+        if (converged && !theta_flipped)
+        {
+            double scale = std::tan(theta) / theta_d;
+            Vec2d pu = pw * scale; //undistorted point
 
-        if( sdepth == CV_32F )
-            dstf[i] = fi;
+            // reproject
+            Vec3d pr = RR * Vec3d(pu[0], pu[1], 1.0); // rotated point optionally multiplied by new camera matrix
+            Vec2d fi(pr[0]/pr[2], pr[1]/pr[2]);       // final
+
+            if( sdepth == CV_32F )
+                dstf[i] = fi;
+            else
+                dstd[i] = fi;
+        }
         else
-            dstd[i] = fi;
+        {
+            Vec2d fi(std::numeric_limits<double>::quiet_NaN(), std::numeric_limits<double>::quiet_NaN());
+
+            if( sdepth == CV_32F )
+                dstf[i] = fi;
+            else
+                dstd[i] = fi;
+        }
     }
 }
 

--- a/modules/calib3d/src/fisheye.cpp
+++ b/modules/calib3d/src/fisheye.cpp
@@ -387,7 +387,9 @@ void cv::fisheye::undistortPoints( InputArray distorted, OutputArray undistorted
         bool converged = false;
         double theta = theta_d;
 
-        if (theta_d > 1e-8)
+        double scale = 0.0;
+
+        if (fabs(theta_d) > 1e-8)
         {
             // compensate distortion iteratively
 
@@ -407,6 +409,12 @@ void cv::fisheye::undistortPoints( InputArray distorted, OutputArray undistorted
                     break;
                 }
             }
+
+            scale = std::tan(theta) / theta_d;
+        } 
+        else 
+        {
+            converged = true;
         }
 
         // theta is monotonously increasing or decreasing depending on the sign of theta
@@ -416,7 +424,6 @@ void cv::fisheye::undistortPoints( InputArray distorted, OutputArray undistorted
 
         if (converged && !theta_flipped)
         {
-            double scale = std::tan(theta) / theta_d;
             Vec2d pu = pw * scale; //undistorted point
 
             // reproject
@@ -430,7 +437,8 @@ void cv::fisheye::undistortPoints( InputArray distorted, OutputArray undistorted
         }
         else
         {
-            Vec2d fi(std::numeric_limits<double>::quiet_NaN(), std::numeric_limits<double>::quiet_NaN());
+            // Vec2d fi(std::numeric_limits<double>::quiet_NaN(), std::numeric_limits<double>::quiet_NaN());
+            Vec2d fi(-1000000.0, -1000000.0);
 
             if( sdepth == CV_32F )
                 dstf[i] = fi;

--- a/modules/calib3d/test/test_fisheye.cpp
+++ b/modules/calib3d/test/test_fisheye.cpp
@@ -151,8 +151,8 @@ TEST_F(fisheyeTest, undistortAndDistortImage)
     cv::Vec4d D_dst_vec (-1.0, 0.0, 0.0, 0.0);
     cv::Mat D_dst = cv::Mat(D_dst_vec);
 
-    double imageWidth = this->imageSize.width;
-    double imageHeight = this->imageSize.height;
+    int imageWidth = (int)this->imageSize.width;
+    int imageHeight = (int)this->imageSize.height;
 
     cv::Mat imagePoints(imageHeight, imageWidth, CV_32FC2), undPoints, distPoints;
     cv::Vec2f* pts = imagePoints.ptr<cv::Vec2f>();
@@ -161,7 +161,7 @@ TEST_F(fisheyeTest, undistortAndDistortImage)
     {
         for(int x = 0; x < imageWidth; ++x)
         {
-            cv::Vec2f point(x, y);
+            cv::Vec2f point((float)x, (float)y);
             pts[k++] = point;
         }
     }
@@ -172,8 +172,8 @@ TEST_F(fisheyeTest, undistortAndDistortImage)
 
     float dx, dy, r_sq;
     float R_MAX = 250;
-    float imageCenterX = imageWidth / 2;
-    float imageCenterY = imageHeight / 2;
+    float imageCenterX = (float)imageWidth / 2;
+    float imageCenterY = (float)imageHeight / 2;
 
     cv::Mat undPointsGt(imageHeight, imageWidth, CV_32FC2);
     cv::Mat imageGt(imageHeight, imageWidth, CV_8UC3);
@@ -220,19 +220,19 @@ TEST_F(fisheyeTest, undistortAndDistortImage)
     EXPECT_MAT_NEAR(image_projected, imageGt, 1e-10);
 
     Vec2f dist_point_1 = distPoints.at<Vec2f>(400, 640);
-    Vec2f dist_point_1_gt(640.044, 400.041);
+    Vec2f dist_point_1_gt(640.044f, 400.041f);
 
     Vec2f dist_point_2 = distPoints.at<Vec2f>(400, 440);
-    Vec2f dist_point_2_gt(409.731, 403.029);
+    Vec2f dist_point_2_gt(409.731f, 403.029f);
 
     Vec2f dist_point_3 = distPoints.at<Vec2f>(200, 640);
-    Vec2f dist_point_3_gt(643.341, 168.896);
+    Vec2f dist_point_3_gt(643.341f, 168.896f);
 
     Vec2f dist_point_4 = distPoints.at<Vec2f>(300, 480);
-    Vec2f dist_point_4_gt(463.402, 290.317);
+    Vec2f dist_point_4_gt(463.402f, 290.317f);
 
     Vec2f dist_point_5 = distPoints.at<Vec2f>(550, 750);
-    Vec2f dist_point_5_gt(797.51, 611.637);
+    Vec2f dist_point_5_gt(797.51f, 611.637f);
 
     EXPECT_MAT_NEAR(dist_point_1, dist_point_1_gt, 1e-2);
     EXPECT_MAT_NEAR(dist_point_2, dist_point_2_gt, 1e-2);

--- a/modules/calib3d/test/test_fisheye.cpp
+++ b/modules/calib3d/test/test_fisheye.cpp
@@ -141,6 +141,108 @@ TEST_F(fisheyeTest, undistortImage)
     }
 }
 
+TEST_F(fisheyeTest, undistortAndDistortImage)
+{
+    cv::Matx33d K_src = this->K;
+    cv::Mat D_src = cv::Mat(this->D);
+    std::string file = combine(datasets_repository_path, "/calib-3_stereo_from_JY/left/stereo_pair_014.jpg");
+    cv::Matx33d K_dst = K_src;
+    cv::Mat image = cv::imread(file), image_projected;
+    cv::Vec4d D_dst_vec (-1.0, 0.0, 0.0, 0.0);
+    cv::Mat D_dst = cv::Mat(D_dst_vec);
+
+    double imageWidth = this->imageSize.width;
+    double imageHeight = this->imageSize.height;
+
+    cv::Mat imagePoints(imageHeight, imageWidth, CV_32FC2), undPoints, distPoints;
+    cv::Vec2f* pts = imagePoints.ptr<cv::Vec2f>();
+
+    for(int y = 0, k = 0; y < imageHeight; ++y)
+    {
+        for(int x = 0; x < imageWidth; ++x)
+        {
+            cv::Vec2f point(x, y);
+            pts[k++] = point;
+        }
+    }
+
+    cv::fisheye::undistortPoints(imagePoints, undPoints, K_dst, D_dst);
+    cv::fisheye::distortPoints(undPoints, distPoints, K_src, D_src);
+    cv::remap(image, image_projected, distPoints, cv::noArray(), cv::INTER_LINEAR);
+
+    float dx, dy, r_sq;
+    float R_MAX = 250;
+    float imageCenterX = imageWidth / 2;
+    float imageCenterY = imageHeight / 2;
+
+    cv::Mat undPointsGt(imageHeight, imageWidth, CV_32FC2);
+    cv::Mat imageGt(imageHeight, imageWidth, CV_8UC3);
+
+    for(int y = 0, k = 0; y < imageHeight; ++y)
+    {
+        for(int x = 0; x < imageWidth; ++x)
+        {
+            dx = x - imageCenterX;
+            dy = y - imageCenterY;
+            r_sq = dy * dy + dx * dx;
+
+            Vec2f & und_vec = undPoints.at<Vec2f>(y,x);
+            Vec3b & pixel = image_projected.at<Vec3b>(y,x);
+
+            Vec2f & undist_vec_gt = undPointsGt.at<Vec2f>(y,x);
+            Vec3b & pixel_gt = imageGt.at<Vec3b>(y,x);
+
+            if (r_sq > R_MAX * R_MAX)
+            {
+
+                undist_vec_gt[0] = -1e6;
+                undist_vec_gt[1] = -1e6;
+
+                pixel_gt[0] = 0;
+                pixel_gt[1] = 0;
+                pixel_gt[2] = 0;
+            }
+            else
+            {
+                undist_vec_gt[0] = und_vec[0];
+                undist_vec_gt[1] = und_vec[1];
+
+                pixel_gt[0] = pixel[0];
+                pixel_gt[1] = pixel[1];
+                pixel_gt[2] = pixel[2];
+            }
+
+            k++;
+        }
+    }
+
+    EXPECT_MAT_NEAR(undPoints, undPointsGt, 1e-10);
+    EXPECT_MAT_NEAR(image_projected, imageGt, 1e-10);
+
+    Vec2f dist_point_1 = distPoints.at<Vec2f>(400, 640);
+    Vec2f dist_point_1_gt(640.044, 400.041);
+
+    Vec2f dist_point_2 = distPoints.at<Vec2f>(400, 440);
+    Vec2f dist_point_2_gt(409.731, 403.029);
+
+    Vec2f dist_point_3 = distPoints.at<Vec2f>(200, 640);
+    Vec2f dist_point_3_gt(643.341, 168.896);
+
+    Vec2f dist_point_4 = distPoints.at<Vec2f>(300, 480);
+    Vec2f dist_point_4_gt(463.402, 290.317);
+
+    Vec2f dist_point_5 = distPoints.at<Vec2f>(550, 750);
+    Vec2f dist_point_5_gt(797.51, 611.637);
+
+    EXPECT_MAT_NEAR(dist_point_1, dist_point_1_gt, 1e-2);
+    EXPECT_MAT_NEAR(dist_point_2, dist_point_2_gt, 1e-2);
+    EXPECT_MAT_NEAR(dist_point_3, dist_point_3_gt, 1e-2);
+    EXPECT_MAT_NEAR(dist_point_4, dist_point_4_gt, 1e-2);
+    EXPECT_MAT_NEAR(dist_point_5, dist_point_5_gt, 1e-2);
+
+    CV_Assert(cv::imwrite(combine(datasets_repository_path, "new_distortion.png"), image_projected));
+}
+
 TEST_F(fisheyeTest, jacobians)
 {
     int n = 10;


### PR DESCRIPTION
Fisheye undistorting points is unstable in configurations with larger distortion coefficients. Lets assume a standard situation of undistorting  images and redistorting it with new fisheye distortion coefficients.

<cut/>

The following test image from Cityscapes datasets is used
![image](https://user-images.githubusercontent.com/8905380/83530888-a1ae1900-a4ec-11ea-814f-b573e755495a.png)


### Current Implementation

The following settings show that the current implementation is instable for larger distortion coefficients.

Distortion Parameters 1: [3.0, 0.0, 0.0, 0.0]
![distorted_original_A](https://user-images.githubusercontent.com/8905380/83528530-7ece3580-a4e9-11ea-9be8-90fad8527daf.jpg)

Distortion Parameters 2: [9.0, 0.0, 0.0, 0.0]
![distorted_original_B](https://user-images.githubusercontent.com/8905380/83529330-7e826a00-a4ea-11ea-9824-1b846e193df2.jpg)

### Improvement A: Filter noise

The current implementation shows a lot of noise outside the actual image. To fix this, the optimization can be improved by checking the convergence and returning an invalid point otherwise.

Results of improvement A:
Distortion Parameters 1: [3.0, 0.0, 0.0, 0.0]
![distorted_imp1_A](https://user-images.githubusercontent.com/8905380/83529631-e20c9780-a4ea-11ea-9ac0-4aeadabf5084.jpg)
Distortion Parameters 2: [9.0, 0.0, 0.0, 0.0]
![distorted_imp1_B](https://user-images.githubusercontent.com/8905380/83529644-e6d14b80-a4ea-11ea-9e26-668db6572553.jpg)


### Improvement B: Check flipped theta

As visible, the noise disappeared but another problem is visible: Inverted patches of the original image appear in the distorted images. During the optimization, theta_fix is very large. Generally, theta is monotonously increasing or decreasing depending on its sign. In the mentioned areas, theta converges due to the symmetry, however, on the opposite of the camera center. So we can check whether theta has changed the sign during the optimization

Results of improvement B (without improvement A)
Distortion Parameters 1: [3.0, 0.0, 0.0, 0.0]
![distorted_imp2_A](https://user-images.githubusercontent.com/8905380/83529662-ed5fc300-a4ea-11ea-8b49-d575b6f4b135.jpg)

Distortion Parameters 2: [9.0, 0.0, 0.0, 0.0]
![distorted_imp2_B](https://user-images.githubusercontent.com/8905380/83529670-f05ab380-a4ea-11ea-9caa-dac2eb2d1a27.jpg)



### Combination of A and B

Combining both improvements allows for removing all the mentioned artifacts:
Distortion Parameters 1: [3.0, 0.0, 0.0, 0.0]
![distorted_imp12_A](https://user-images.githubusercontent.com/8905380/83529677-f3ee3a80-a4ea-11ea-8513-1850c78c1ec5.jpg)

Distortion Parameters 2: [9.0, 0.0, 0.0, 0.0]
![distorted_imp12_B](https://user-images.githubusercontent.com/8905380/83529684-f6509480-a4ea-11ea-9d52-8414acfba625.jpg)


###  Sample Code in Python

``` python
import os
import numpy as np
import cv2


def undistort2distort(
        img_src,
        K_src,
        dist_coeffs_src,
        K_dst, dist_coeffs_dst,
):
    # Generate an array of ids
    width = img_src.shape[1]
    height = img_src.shape[0]

    iv, jv = np.meshgrid(range(0, width), range(0, height), sparse=False, indexing='xy')

    iv = iv.flatten()
    jv = jv.flatten()

    # for iP in range(1, iv.length):
    npts = iv.shape[0]

    # convert to Nx1x2 (fisheye)
    img_px_pts = np.zeros((npts, 1, 2), dtype=np.float32)
    img_px_pts[:, 0, 0] = iv
    img_px_pts[:, 0, 1] = jv

    # undistort destination points
    undPts = cv2.fisheye.undistortPoints(img_px_pts, K_dst, dist_coeffs_dst)

    # distort destination points to the source
    distPts = cv2.fisheye.distortPoints(undPts, K_src, dist_coeffs_src)

    # build a map
    x_pts = np.reshape(distPts[:, 0, 0], (height, width))
    y_pts = np.reshape(distPts[:, 0, 1], (height, width))

    img_dst = cv2.remap(img_src, x_pts, y_pts, interpolation=cv2.INTER_LINEAR, borderMode=cv2.BORDER_CONSTANT)

    return img_dst


# Calibration data

K_src = np.array([[2245, 0.00000000e+00, 2048 / 2],
                  [0.00000000e+00, 2245, 1024 / 2],
                  [0.00000000e+00, 0.00000000e+00, 1.00000000e+00]])
dist_coeffs_src = np.zeros((1, 4))

K_dst = K_src.copy()
dist_coeffs_dst = np.array([[-3.0, 0.0, 0.0, 0.0]])  # setting 1
# dist_coeffs_dst = np.array([[-9.0, 0.0, 0.0, 0.0]])  # setting 2
# dist_coeffs_dst = np.array([[-20.0, 0.0, 0.0, 0.0]])  # setting 3

# image to distort
img = cv2.imread('image.png')

# distort
img_distorted = undistort2distort(img, K_src, dist_coeffs_src, K_dst, dist_coeffs_dst)

# save
output_image_name = os.path.join("distorted.jpg")
cv2.imwrite(output_image_name, img_distorted)
```

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under OpenCV (BSD) License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [x] There is reference to original bug report and related work
- [x] The PR is proposed to proper branch
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake

```
force_builders=linux,docs,Win64,Mac
allow_multiple_commits=1
```