### PR TITLE
Fixed virtual Try-On sample

### DIFF
--- a/modules/dnn/src/onnx/onnx_importer.cpp
+++ b/modules/dnn/src/onnx/onnx_importer.cpp
@@ -806,6 +806,10 @@ void ONNXImporter::populateNet(Net dstNet)
         {
             layerParams.type = "ELU";
         }
+        else if (layer_type == "Tanh")
+        {
+            layerParams.type = "TanH";
+        }
         else if (layer_type == "PRelu")
         {
             layerParams.type = "PReLU";

--- a/samples/dnn/virtual_try_on.py
+++ b/samples/dnn/virtual_try_on.py
@@ -185,7 +185,7 @@ class CpVton(object):
 
         agnostic = np.concatenate((res_shape, img_head, pose_map), axis=0)
         agnostic = np.expand_dims(agnostic, axis=0)
-        return agnostic
+        return agnostic.astype(np.float32)
 
     def get_warped_cloth(self, cloth_img, agnostic, height=256, width=192):
         cloth = cv.dnn.blobFromImage(cloth_img, 1.0 / 127.5, (width, height), mean=(127.5, 127.5, 127.5), swapRB=True)


### PR DESCRIPTION
### Pull Request Readiness Checklist
resolves: opencv/opencv#17463

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under OpenCV (BSD) License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [x] The PR is proposed to proper branch
- [x] There is reference to original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake

```
force_builders=Custom,Custom Win,Custom Mac
build_image:Custom=ubuntu-openvino-2020.1.0:16.04
build_image:Custom Win=openvino-2020.2.0
build_image:Custom Mac=openvino-2020.2.0

test_modules:Custom=dnn,python2,python3,java
test_modules:Custom Win=dnn,python2,python3,java
test_modules:Custom Mac=dnn,python2,python3,java

buildworker:Custom=linux-1
# disabled due high memory usage: test_opencl:Custom=ON
test_opencl:Custom=OFF
test_bigdata:Custom=1
test_filter:Custom=*
```