### PR TITLE
- Fixing broken URL to mp4ra website

### DIFF
--- a/modules/videoio/include/opencv2/videoio.hpp
+++ b/modules/videoio/include/opencv2/videoio.hpp
@@ -873,7 +873,7 @@ public:
     VideoWriter::fourcc('P','I','M','1') is a MPEG-1 codec, VideoWriter::fourcc('M','J','P','G') is a
     motion-jpeg codec etc. List of codes can be obtained at [Video Codecs by
     FOURCC](http://www.fourcc.org/codecs.php) page. FFMPEG backend with MP4 container natively uses
-    other values as fourcc code: see [ObjectType](http://www.mp4ra.org/codecs.html),
+    other values as fourcc code: see [ObjectType](http://mp4ra.org/#/codecs),
     so you may receive a warning message from OpenCV about fourcc code conversion.
     @param fps Framerate of the created video stream.
     @param frameSize Size of the video frames.

--- a/modules/videoio/include/opencv2/videoio/videoio_c.h
+++ b/modules/videoio/include/opencv2/videoio/videoio_c.h
@@ -542,7 +542,7 @@ Simply call it with 4 chars fourcc code like `CV_FOURCC('I', 'Y', 'U', 'V')`
 
 List of codes can be obtained at [Video Codecs by FOURCC](http://www.fourcc.org/codecs.php) page.
 FFMPEG backend with MP4 container natively uses other values as fourcc code:
-see [ObjectType](http://www.mp4ra.org/codecs.html).
+see [ObjectType](http://mp4ra.org/#/codecs).
 */
 CV_INLINE int CV_FOURCC(char c1, char c2, char c3, char c4)
 {


### PR DESCRIPTION
This fixes a broken link in the documentation (no functionality change) to the mp4ra website within the fourcc section.