### PR TITLE
Fix '--help' of stitching_detailed.py sample

### DIFF
--- a/samples/python/stitching_detailed.py
+++ b/samples/python/stitching_detailed.py
@@ -103,19 +103,19 @@ parser.add_argument(
 )
 parser.add_argument(
     '--features', action='store', default=list(FEATURES_FIND_CHOICES.keys())[0],
-    help="Type of features used for images matching. The default is '%s'." % FEATURES_FIND_CHOICES.keys(),
+    help="Type of features used for images matching. The default is '%s'." % list(FEATURES_FIND_CHOICES.keys())[0],
     choices=FEATURES_FIND_CHOICES.keys(),
     type=str, dest='features'
 )
 parser.add_argument(
     '--matcher', action='store', default='homography',
-    help="Matcher used for pairwise image matching.",
+    help="Matcher used for pairwise image matching. The default is 'homography'.",
     choices=('homography', 'affine'),
     type=str, dest='matcher'
 )
 parser.add_argument(
     '--estimator', action='store', default=list(ESTIMATOR_CHOICES.keys())[0],
-    help="Type of estimator used for transformation estimation.",
+    help="Type of estimator used for transformation estimation. The default is '%s'." % list(ESTIMATOR_CHOICES.keys())[0],
     choices=ESTIMATOR_CHOICES.keys(),
     type=str, dest='estimator'
 )


### PR DESCRIPTION
Fixes the help for `--features`, previously listed all possible values as default value.

Also adds the default value to the help for two other arguments

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under OpenCV (BSD) License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [x] The PR is proposed to proper branch
- [ ] There is reference to original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
