### PR TITLE
CUDA: fix corner case of libnvcuvid

### DIFF
--- a/cmake/OpenCVDetectCUDA.cmake
+++ b/cmake/OpenCVDetectCUDA.cmake
@@ -38,11 +38,30 @@ if(CUDA_FOUND)
   endif()
 
   if(WITH_NVCUVID)
+    macro(SEARCH_NVCUVID_HEADER _filename _result)
+      # place header file under CUDA_TOOLKIT_TARGET_DIR or CUDA_TOOLKIT_ROOT_DIR
+      find_path(_header_result
+        ${_filename}
+        PATHS "${CUDA_TOOLKIT_TARGET_DIR}" "${CUDA_TOOLKIT_ROOT_DIR}"
+        ENV CUDA_PATH
+        ENV CUDA_INC_PATH
+        PATH_SUFFIXES include
+        NO_DEFAULT_PATH
+        )
+      if("x${_header_result}" STREQUAL "x_header_result-NOTFOUND")
+        set(${_result} 0)
+      else()
+        set(${_result} 1)
+      endif()
+    endmacro()
+    SEARCH_NVCUVID_HEADER("nvcuvid.h" HAVE_NVCUVID_HEADER)
+    SEARCH_NVCUVID_HEADER("dynlink_nvcuvid.h" HAVE_DYNLINK_NVCUVID_HEADER)
     find_cuda_helper_libs(nvcuvid)
     if(WIN32)
       find_cuda_helper_libs(nvcuvenc)
     endif()
-    if(CUDA_nvcuvid_LIBRARY)
+    if(CUDA_nvcuvid_LIBRARY AND (${HAVE_NVCUVID_HEADER} OR ${HAVE_DYNLINK_NVCUVID_HEADER}))
+      # make sure to have both header and library before enabling
       set(HAVE_NVCUVID 1)
     endif()
     if(CUDA_nvcuvenc_LIBRARY)

--- a/cmake/templates/cvconfig.h.in
+++ b/cmake/templates/cvconfig.h.in
@@ -127,6 +127,8 @@
 
 /* NVIDIA Video Decoding API*/
 #cmakedefine HAVE_NVCUVID
+#cmakedefine HAVE_NVCUVID_HEADER
+#cmakedefine HAVE_DYNLINK_NVCUVID_HEADER
 
 /* NVIDIA Video Encoding API*/
 #cmakedefine HAVE_NVCUVENC

--- a/modules/cudacodec/src/cuvid_video_source.hpp
+++ b/modules/cudacodec/src/cuvid_video_source.hpp
@@ -44,9 +44,9 @@
 #ifndef __CUVID_VIDEO_SOURCE_HPP__
 #define __CUVID_VIDEO_SOURCE_HPP__
 
-#if CUDA_VERSION >= 9000 && CUDA_VERSION < 10000
+#if defined(HAVE_DYNLINK_NVCUVID_HEADER)
     #include <dynlink_nvcuvid.h>
-#else
+#elif defined(HAVE_NVCUVID_HEADER)
     #include <nvcuvid.h>
 #endif
 #include "opencv2/core/private.cuda.hpp"

--- a/modules/cudacodec/src/frame_queue.hpp
+++ b/modules/cudacodec/src/frame_queue.hpp
@@ -47,9 +47,9 @@
 #include "opencv2/core/utility.hpp"
 #include "opencv2/core/private.cuda.hpp"
 
-#if CUDA_VERSION >= 9000 && CUDA_VERSION < 10000
+#if defined(HAVE_DYNLINK_NVCUVID_HEADER)
     #include <dynlink_nvcuvid.h>
-#else
+#elif defined(HAVE_NVCUVID_HEADER)
     #include <nvcuvid.h>
 #endif
 

--- a/modules/cudacodec/src/precomp.hpp
+++ b/modules/cudacodec/src/precomp.hpp
@@ -56,9 +56,9 @@
 #include "opencv2/core/private.cuda.hpp"
 
 #ifdef HAVE_NVCUVID
-    #if CUDA_VERSION >= 9000 && CUDA_VERSION < 10000
+    #if defined(HAVE_DYNLINK_NVCUVID_HEADER)
         #include <dynlink_nvcuvid.h>
-    #else
+    #elif defined(HAVE_NVCUVID_HEADER)
         #include <nvcuvid.h>
     #endif
 

--- a/modules/cudacodec/src/video_decoder.hpp
+++ b/modules/cudacodec/src/video_decoder.hpp
@@ -44,9 +44,9 @@
 #ifndef __VIDEO_DECODER_HPP__
 #define __VIDEO_DECODER_HPP__
 
-#if CUDA_VERSION >= 9000 && CUDA_VERSION < 10000
+#if defined(HAVE_DYNLINK_NVCUVID_HEADER)
     #include <dynlink_nvcuvid.h>
-#else
+#elif defined(HAVE_NVCUVID_HEADER)
     #include <nvcuvid.h>
 #endif
 

--- a/modules/cudacodec/src/video_parser.hpp
+++ b/modules/cudacodec/src/video_parser.hpp
@@ -44,9 +44,9 @@
 #ifndef __VIDEO_PARSER_HPP__
 #define __VIDEO_PARSER_HPP__
 
-#if CUDA_VERSION >= 9000 && CUDA_VERSION < 10000
+#if defined(HAVE_DYNLINK_NVCUVID_HEADER)
     #include <dynlink_nvcuvid.h>
-#else
+#elif defined(HAVE_NVCUVID_HEADER)
     #include <nvcuvid.h>
 #endif
 


### PR DESCRIPTION
  * detect header automatically and not based on version number

### summary
- CUDA 11 RC comes 
   - with nvcuvid library (libnvcuvid.so)
   - without the header file
- So building ends up with "header not found"
- Twisting more `ifdef`is chaos, so check before building.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under OpenCV (BSD) License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [x] The PR is proposed to proper branch
- [ ] There is reference to original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake

```
force_builders=Custom
buildworker:Custom=linux-4
build_image:Custom=ubuntu-cuda:18.04
```