### PR TITLE
Removed error lisneter usage

### DIFF
--- a/modules/dnn/src/ie_ngraph.cpp
+++ b/modules/dnn/src/ie_ngraph.cpp
@@ -239,7 +239,9 @@ private:
 class InfEngineNgraphExtension : public InferenceEngine::IExtension
 {
 public:
+#if INF_ENGINE_VER_MAJOR_LT(INF_ENGINE_RELEASE_2020_2)
     virtual void SetLogCallback(InferenceEngine::IErrorListener&) noexcept {}
+#endif
     virtual void Unload() noexcept {}
     virtual void Release() noexcept {}
     virtual void GetVersion(const InferenceEngine::Version*&) const noexcept {}

--- a/modules/dnn/src/op_inf_engine.hpp
+++ b/modules/dnn/src/op_inf_engine.hpp
@@ -225,7 +225,9 @@ private:
 class InfEngineExtension : public InferenceEngine::IExtension
 {
 public:
+#if INF_ENGINE_VER_MAJOR_LT(INF_ENGINE_RELEASE_2020_2)
     virtual void SetLogCallback(InferenceEngine::IErrorListener&) noexcept {}
+#endif
     virtual void Unload() noexcept {}
     virtual void Release() noexcept {}
     virtual void GetVersion(const InferenceEngine::Version*&) const noexcept {}


### PR DESCRIPTION
Starting from 2020.2 this method is deprecated. See https://github.com/openvinotoolkit/openvino/blob/2020/inference-engine/include/ie_iextension.h

<cut/>

```
force_builders=Custom,Custom Win,Custom Mac
build_image:Custom=ubuntu-openvino-2020.1.0:16.04
build_image:Custom Win=openvino-2020.2.0
build_image:Custom Mac=openvino-2020.3.0

test_modules:Custom=dnn,python2,python3,java
test_modules:Custom Win=dnn,python2,python3,java
test_modules:Custom Mac=dnn,python2,python3,java

buildworker:Custom=linux-1
# disabled due high memory usage: test_opencl:Custom=ON
test_opencl:Custom=OFF
test_bigdata:Custom=1
test_filter:Custom=*
```