### PR TITLE
cuda4dnn(mish): improve accuracy and performance

### DIFF
--- a/modules/dnn/src/cuda/functors.hpp
+++ b/modules/dnn/src/cuda/functors.hpp
@@ -54,11 +54,8 @@ struct mish_functor<float> {
         using csl::device::fast_exp;
 
         auto e = fast_exp(value);
-        if (value <= -18.0f)
-            return value * e;
-
         auto n = e * e + 2 * e;
-        if (value <= -5.0f)
+        if (value <= -0.6f)
             return value * fast_divide(n, n + 2);
 
         return value - 2 * fast_divide(value, n + 2);


### PR DESCRIPTION
- faster and more accurate mish implementation
- the thresholds were set incorrectly in the #17200 (not wrong but less accurate)

 \#                | Time (float)    | Time (float4)  | L2 norm*        | SM SOL (float) | SM SOL (float4)
---------------- | ----------------- | ------------------ | ----------------- | -------------------- | ---------------------
ReLU           | 1.47ms          | 1.39ms          | N/A                | 21.31%            | 14.04%
Mish (old)    | 1.51ms          | 1.39ms           | 0.00012458  | 40.27%             | 28.77%
Mish (new)  | 1.49ms          | 1.39ms           | 2.4583e-05   | 38.5%               | 23.5% 

\* L2 norm of the error vector for 16 million+ activations uniformly sampled from `[-50, 50]`

Code: https://gist.github.com/YashasSamaga/8ad0cd3b30dbd0eb588c1f4c035db28c

Input Range | L2 norm
---------------- | -----------
`[-100, -80]`  | `1.73186e-36`
`[-80, -20]`    | `7.14342e-12`
`[-20, 0]`       | `3.37544e-05`
`[0, 100]`      | `1.94085e-05`

<details>
<summary>Raw accuracy output (with other implementations)</summary>

For [-100, -80]

```
[vec1] mish_tb: 5.23885e-38
[vec1] mish_rw: 5.23885e-38
[vec1] mish_njuffa1: 9.41435e-31
[vec1] mish_njuffa2: 9.58304e-38
[vec1] mish_aj1: 1.69838e-34
[vec1] mish_aj2: 1.73186e-36
[vec1] mish_aj2_fastdiv: 1.73186e-36
[vec1] mish_dlib: 9.41435e-31
[vec1] mish_ocv: 1.73186e-36
[vec4] mish_tb: 5.23885e-38
[vec4] mish_rw: 5.23885e-38
[vec4] mish_njuffa1: 9.41435e-31
[vec4] mish_njuffa2: 9.58304e-38
[vec4] mish_aj1: 1.69838e-34
[vec4] mish_aj2: 1.73186e-36
[vec4] mish_aj2_fastdiv: 1.73186e-36
[vec4] mish_dlib: 9.41435e-31
[vec4] mish_ocv: 1.73186e-36
```

For [-80, -20]:

```
[vec1] mish_tb: 8.93439e-13
[vec1] mish_rw: 8.93439e-13
[vec1] mish_njuffa1: 1.58053e-05
[vec1] mish_njuffa2: 1.53516e-12
[vec1] mish_aj1: 7.15513e-12
[vec1] mish_aj2: 7.14342e-12
[vec1] mish_aj2_fastdiv: 7.14342e-12
[vec1] mish_dlib: 1.58053e-05
[vec1] mish_ocv: 7.14342e-12
[vec4] mish_tb: 8.93439e-13
[vec4] mish_rw: 8.93439e-13
[vec4] mish_njuffa1: 1.58053e-05
[vec4] mish_njuffa2: 1.53516e-12
[vec4] mish_aj1: 7.15513e-12
[vec4] mish_aj2: 7.14342e-12
[vec4] mish_aj2_fastdiv: 7.14342e-12
[vec4] mish_dlib: 1.58053e-05
[vec4] mish_ocv: 7.14342e-12
```

For [-20, 0]:

```
[vec1] mish_tb: 3.34032e-05
[vec1] mish_rw: 0.00141026
[vec1] mish_njuffa1: 0.00143353
[vec1] mish_njuffa2: 4.30863e-05
[vec1] mish_aj1: 3.23414e-05
[vec1] mish_aj2: 3.37344e-05
[vec1] mish_aj2_fastdiv: 3.50414e-05
[vec1] mish_dlib: 0.0015637
[vec1] mish_ocv: 3.37544e-05
[vec4] mish_tb: 3.34032e-05
[vec4] mish_rw: 0.00141026
[vec4] mish_njuffa1: 0.00143353
[vec4] mish_njuffa2: 4.30863e-05
[vec4] mish_aj1: 3.23414e-05
[vec4] mish_aj2: 3.37344e-05
[vec4] mish_aj2_fastdiv: 3.50414e-05
[vec4] mish_dlib: 0.0015637
[vec4] mish_ocv: 3.37544e-05
```

For [0, 100]:

```
[vec1] mish_tb: 0.000302692
[vec1] mish_rw: 0.000302707
[vec1] mish_njuffa1: 1.55673e-05
[vec1] mish_njuffa2: 1.55673e-05
[vec1] mish_aj1: 0.000268539
[vec1] mish_aj2: nan
[vec1] mish_aj2_fastdiv: nan
[vec1] mish_dlib: 1.64015e-05
[vec1] mish_ocv: 1.94085e-05
[vec4] mish_tb: 0.000302692
[vec4] mish_rw: 0.000302707
[vec4] mish_njuffa1: 1.55673e-05
[vec4] mish_njuffa2: 1.55673e-05
[vec4] mish_aj1: 0.000268539
[vec4] mish_aj2: nan
[vec4] mish_aj2_fastdiv: nan
[vec4] mish_dlib: 1.64015e-05
[vec4] mish_ocv: 1.94085e-05
```

</details>

The performance improvement is not significant as the activation is not compute-bound. But the reduction in compute usage makes more room for other compute-heavy operations to be fused with the activation (index calculation in bias addition).

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under OpenCV (BSD) License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [x] The PR is proposed to proper branch
- [x] There is reference to original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake

```
force_builders=Custom
buildworker:Custom=linux-4
build_image:Custom=ubuntu-cuda:18.04
```