### PR TITLE
[WIP] add findEssentialMat for two different cameras

### DIFF
--- a/modules/calib3d/include/opencv2/calib3d.hpp
+++ b/modules/calib3d/include/opencv2/calib3d.hpp
@@ -2521,6 +2521,57 @@ CV_EXPORTS_W Mat findEssentialMat( InputArray points1, InputArray points2,
                                  double focal = 1.0, Point2d pp = Point2d(0, 0),
                                  int method = RANSAC, double prob = 0.999,
                                  double threshold = 1.0, OutputArray mask = noArray() );
+    
+/** @brief Calculates an essential matrix from the corresponding points in two images from potentially two different cameras.
+
+@param points1 Array of N (N \>= 5) 2D points from the first image. The point coordinates should
+be floating-point (single or double precision).
+@param points2 Array of the second image points of the same size and format as points1 .
+@param cameraMatrix1 Camera matrix \f$K = \vecthreethree{f_x}{0}{c_x}{0}{f_y}{c_y}{0}{0}{1}\f$ .
+Note that this function assumes that points1 and points2 are feature points from cameras with the
+same camera matrix. If this assumption does not hold for your use case, use
+`undistortPoints()` with `P = cv::NoArray()` for both cameras to transform image points
+to normalized image coordinates, which are valid for the identity camera matrix. When
+passing these coordinates, pass the identity matrix for this parameter.
+@param cameraMatrix2 Camera matrix \f$K = \vecthreethree{f_x}{0}{c_x}{0}{f_y}{c_y}{0}{0}{1}\f$ .
+Note that this function assumes that points1 and points2 are feature points from cameras with the
+same camera matrix. If this assumption does not hold for your use case, use
+`undistortPoints()` with `P = cv::NoArray()` for both cameras to transform image points
+to normalized image coordinates, which are valid for the identity camera matrix. When
+passing these coordinates, pass the identity matrix for this parameter.
+@param distCoeffs1 Input vector of distortion coefficients
+\f$(k_1, k_2, p_1, p_2[, k_3[, k_4, k_5, k_6[, s_1, s_2, s_3, s_4[, \tau_x, \tau_y]]]])\f$
+of 4, 5, 8, 12 or 14 elements. If the vector is NULL/empty, the zero distortion coefficients are assumed.
+@param distCoeffs2 Input vector of distortion coefficients
+\f$(k_1, k_2, p_1, p_2[, k_3[, k_4, k_5, k_6[, s_1, s_2, s_3, s_4[, \tau_x, \tau_y]]]])\f$
+of 4, 5, 8, 12 or 14 elements. If the vector is NULL/empty, the zero distortion coefficients are assumed.
+@param method Method for computing an essential matrix.
+-   **RANSAC** for the RANSAC algorithm.
+-   **LMEDS** for the LMedS algorithm.
+@param prob Parameter used for the RANSAC or LMedS methods only. It specifies a desirable level of
+confidence (probability) that the estimated matrix is correct.
+@param threshold Parameter used for RANSAC. It is the maximum distance from a point to an epipolar
+line in pixels, beyond which the point is considered an outlier and is not used for computing the
+final fundamental matrix. It can be set to something like 1-3, depending on the accuracy of the
+point localization, image resolution, and the image noise.
+@param mask Output array of N elements, every element of which is set to 0 for outliers and to 1
+for the other points. The array is computed only in the RANSAC and LMedS methods.
+
+This function estimates essential matrix based on the five-point algorithm solver in @cite Nister03 .
+@cite SteweniusCFS is also a related. The epipolar geometry is described by the following equation:
+
+\f[[p_2; 1]^T K^{-T} E K^{-1} [p_1; 1] = 0\f]
+
+where \f$E\f$ is an essential matrix, \f$p_1\f$ and \f$p_2\f$ are corresponding points in the first and the
+second images, respectively. The result of this function may be passed further to
+decomposeEssentialMat or recoverPose to recover the relative pose between cameras.
+ */
+CV_EXPORTS_W Mat findEssentialMat( InputArray points1, InputArray points2,
+                                 InputArray cameraMatrix1, InputArray distCoeffs1,
+                                 InputArray cameraMatrix2, InputArray distCoeffs2,
+                                 int method = RANSAC,
+                                 double prob = 0.999, double threshold = 1.0,
+                                 OutputArray mask = noArray() );
 
 /** @brief Decompose an essential matrix to possible rotations and translation.
 

--- a/modules/calib3d/include/opencv2/calib3d.hpp
+++ b/modules/calib3d/include/opencv2/calib3d.hpp
@@ -2521,7 +2521,7 @@ CV_EXPORTS_W Mat findEssentialMat( InputArray points1, InputArray points2,
                                  double focal = 1.0, Point2d pp = Point2d(0, 0),
                                  int method = RANSAC, double prob = 0.999,
                                  double threshold = 1.0, OutputArray mask = noArray() );
-    
+
 /** @brief Calculates an essential matrix from the corresponding points in two images from potentially two different cameras.
 
 @param points1 Array of N (N \>= 5) 2D points from the first image. The point coordinates should

--- a/modules/calib3d/src/five-point.cpp
+++ b/modules/calib3d/src/five-point.cpp
@@ -466,11 +466,11 @@ cv::Mat cv::findEssentialMat( InputArray _points1, InputArray _points2,
     CV_INSTRUMENT_REGION();
     
     //undistort image points and use 3x3 eye matrix as camera matrix
-    cv::undistortPoints(_points1, _points1, cameraMatrix1, distCoeffs1);
-    cv::undistortPoints(_points2, _points2, cameraMatrix2, distCoeffs2);
-
-    Mat cameraMatrix = Mat::eye(3,3, CV_64F);
-    return cv::findEssentialMat(_points1, _points2, cameraMatrix, method, prob, threshold, _mask);
+    Mat _pointsUntistorted1, _pointsUntistorted2;
+    cv::undistortPoints(_points1, _pointsUntistorted1, cameraMatrix1, distCoeffs1);
+    cv::undistortPoints(_points2, _pointsUntistorted2, cameraMatrix2, distCoeffs2);
+    
+    return cv::findEssentialMat(_pointsUntistorted1, _pointsUntistorted2, Mat::eye(3,3, CV_64F), method, prob, threshold, _mask);
 }
 
 int cv::recoverPose( InputArray E, InputArray _points1, InputArray _points2,

--- a/modules/calib3d/src/five-point.cpp
+++ b/modules/calib3d/src/five-point.cpp
@@ -458,6 +458,21 @@ cv::Mat cv::findEssentialMat( InputArray _points1, InputArray _points2, double f
     return cv::findEssentialMat(_points1, _points2, cameraMatrix, method, prob, threshold, _mask);
 }
 
+cv::Mat cv::findEssentialMat( InputArray _points1, InputArray _points2,
+                              InputArray cameraMatrix1, InputArray distCoeffs1,
+                              InputArray cameraMatrix2, InputArray distCoeffs2,
+                              int method, double prob, double threshold, OutputArray _mask)
+{
+    CV_INSTRUMENT_REGION();
+    
+    //undistort image points and use 3x3 eye matrix as camera matrix
+    cv::undistortPoints(_points1, _points1, cameraMatrix1, distCoeffs1);
+    cv::undistortPoints(_points2, _points2, cameraMatrix2, distCoeffs2);
+
+    Mat cameraMatrix = cv::Mat::eye(3,3, CV_64F);
+    return cv::findEssentialMat(_points1, _points2, cameraMatrix, method, prob, threshold, _mask);
+}
+
 int cv::recoverPose( InputArray E, InputArray _points1, InputArray _points2,
                             InputArray _cameraMatrix, OutputArray _R, OutputArray _t, double distanceThresh,
                      InputOutputArray _mask, OutputArray triangulatedPoints)

--- a/modules/calib3d/src/five-point.cpp
+++ b/modules/calib3d/src/five-point.cpp
@@ -469,7 +469,7 @@ cv::Mat cv::findEssentialMat( InputArray _points1, InputArray _points2,
     cv::undistortPoints(_points1, _points1, cameraMatrix1, distCoeffs1);
     cv::undistortPoints(_points2, _points2, cameraMatrix2, distCoeffs2);
 
-    Mat cameraMatrix = cv::Mat::eye(3,3, CV_64F);
+    Mat cameraMatrix = Mat::eye(3,3, CV_64F);
     return cv::findEssentialMat(_points1, _points2, cameraMatrix, method, prob, threshold, _mask);
 }
 

--- a/modules/calib3d/src/five-point.cpp
+++ b/modules/calib3d/src/five-point.cpp
@@ -464,12 +464,12 @@ cv::Mat cv::findEssentialMat( InputArray _points1, InputArray _points2,
                               int method, double prob, double threshold, OutputArray _mask)
 {
     CV_INSTRUMENT_REGION();
-    
+
     //undistort image points and use 3x3 eye matrix as camera matrix
     Mat _pointsUntistorted1, _pointsUntistorted2;
     cv::undistortPoints(_points1, _pointsUntistorted1, cameraMatrix1, distCoeffs1);
     cv::undistortPoints(_points2, _pointsUntistorted2, cameraMatrix2, distCoeffs2);
-    
+
     return cv::findEssentialMat(_pointsUntistorted1, _pointsUntistorted2, Mat::eye(3,3, CV_64F), method, prob, threshold, _mask);
 }
 


### PR DESCRIPTION
Adds findEssentialMatrix for two cameras with different matrices. Uses the undistortion workaround discussed in  #17329

related to #17329

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under OpenCV (BSD) License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [x] The PR is proposed to proper branch
- [x] There is reference to original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake

```
force_builders=linux,docs
```