### PR TITLE
platforms/android: fix --no_samples_build flag not working

### DIFF
--- a/platforms/android/build_sdk.py
+++ b/platforms/android/build_sdk.py
@@ -223,7 +223,7 @@ class Builder:
             BUILD_PERF_TESTS="OFF",
             BUILD_DOCS="OFF",
             BUILD_ANDROID_EXAMPLES=("OFF" if self.no_samples_build else "ON"),
-            INSTALL_ANDROID_EXAMPLES="ON",
+            INSTALL_ANDROID_EXAMPLES=("OFF" if self.no_samples_build else "ON"),
         )
         if self.ninja_path != 'ninja':
             cmake_vars['CMAKE_MAKE_PROGRAM'] = self.ninja_path


### PR DESCRIPTION
The `build_sdk.py` script in `platforms/android` has a `--no_samples_build` flag, which is supposed to disable building the sample projects. However, this only sets the `BUILD_ANDROID_EXAMPLES` CMake variable, and leaves the `INSTALL_ANDROID_EXAMPLES` CMake variable to `ON`. If you take a look at the [samples CMakeLists](https://github.com/opencv/opencv/blob/977e5afbacb7b6ecb91efe071629b636bd6fa807/samples/CMakeLists.txt#L41-L43), you will see that it's actually checking for either of this variables being true. Therefore, even with this flag set, it will still build the samples!

This pull request fixes that by changing both CMake variables. This does not affect the 3.4 branch (since this flag does not exist in 3.4) so it's based on master.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [X] I agree to contribute to the project under OpenCV (BSD) License.
- [X] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [X] The PR is proposed to proper branch
- [ ] There is reference to original bug report and related work - _I didn't make a bug report because it seemed like too small of an issue, hopefully that's ok?_
- [NA] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [X] The feature is well documented and sample code can be built with the project CMake
