### PR TITLE
fixing #17572

### DIFF
--- a/platforms/android/build_sdk.py
+++ b/platforms/android/build_sdk.py
@@ -59,6 +59,7 @@ def check_executable(cmd):
     try:
         log.debug("Executing: %s" % cmd)
         result = subprocess.check_output(cmd, stderr=subprocess.STDOUT)
+        result = str(result)
         log.debug("Result: %s" % (result+'\n').split('\n')[0])
         return True
     except Exception as e:

--- a/platforms/android/build_sdk.py
+++ b/platforms/android/build_sdk.py
@@ -59,7 +59,8 @@ def check_executable(cmd):
     try:
         log.debug("Executing: %s" % cmd)
         result = subprocess.check_output(cmd, stderr=subprocess.STDOUT)
-        result = str(result)
+        if not isinstance(result, str):
+            result = result.decode("utf-8")
         log.debug("Result: %s" % (result+'\n').split('\n')[0])
         return True
     except Exception as e:


### PR DESCRIPTION
resolves #17572 Build for Android failed: "can't concat str to bytes"

on Windows 10 64bit with python 3.6.6

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under OpenCV (BSD) License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [x] The PR is proposed to proper branch
- [x] There is reference to original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
