### PR TITLE
videoio(ximea): fix the detection of the XIMEA library

### DIFF
--- a/modules/videoio/cmake/detect_ximea.cmake
+++ b/modules/videoio/cmake/detect_ximea.cmake
@@ -6,10 +6,10 @@ if(NOT HAVE_XIMEA)
     endif()
   endif()
   if(X86_64)
-    set(lib_dir "x64")
+    set(lib_dir "API/x64" "API/64bit")
     set(lib_suffix "64")
   else()
-    set(lib_dir "x86")
+    set(lib_dir "API/x86" "API/32bit")
     set(lib_suffix "32")
   endif()
   find_path(XIMEA_INCLUDE "xiApi.h"
@@ -19,7 +19,7 @@ if(NOT HAVE_XIMEA)
   find_library(XIMEA_LIBRARY m3api xiapi${lib_suffix}
     PATHS "${XIMEA_ROOT}" ENV XIMEA_ROOT "/opt/XIMEA"
     HINTS "${regpath}"
-    PATH_SUFFIXES "API/${lib_dir}")
+    PATH_SUFFIXES ${lib_dir})
   if(XIMEA_INCLUDE AND XIMEA_LIBRARY)
     set(HAVE_XIMEA TRUE)
   endif()


### PR DESCRIPTION
The location of the XIMEA library is not the same in all versions of this software.
The search path is updated to take into account the different locations identified.