### PR TITLE
docs: linkfix in bibliography

### DIFF
--- a/doc/opencv.bib
+++ b/doc/opencv.bib
@@ -346,7 +346,8 @@
   year = {2003},
   pages = {363--370},
   publisher = {Springer},
-  url = {https://arxiv.org/pdf/1808.01752}
+  url = {https://doi.org/10.1007/3-540-45103-X_50},
+  doi = {10.1007/3-540-45103-X_50}
 }
 @inproceedings{Farsiu03,
   author = {Farsiu, Sina and Robinson, Dirk and Elad, Michael and Milanfar, Peyman},


### PR DESCRIPTION
Linkfix, the [current link](https://arxiv.org/pdf/1808.01752) goes to a random unrelated paper.
