### PR TITLE
CUDA: fix build error on Jetson TX1 and TX2

### DIFF
--- a/modules/cudaimgproc/src/cuda/canny.cu
+++ b/modules/cudaimgproc/src/cuda/canny.cu
@@ -107,7 +107,7 @@ namespace canny
     {
         __host__ SrcTexRef(int _xoff, int _yoff) : SrcTex(_xoff, _yoff) {}
 
-        __device__ __forceinline__ int operator ()(int y, int x) const override
+        __device__ __forceinline__ int operator ()(int y, int x) const
         {
             return tex2D(tex_src, x + xoff, y + yoff);
         }
@@ -117,7 +117,7 @@ namespace canny
     {
         __host__ SrcTexObj(int _xoff, int _yoff, cudaTextureObject_t _tex_src_object) : SrcTex(_xoff, _yoff), tex_src_object(_tex_src_object) { }
 
-        __device__ __forceinline__ int operator ()(int y, int x) const override
+        __device__ __forceinline__ int operator ()(int y, int x) const
         {
             return tex2D<uchar>(tex_src_object, x + xoff, y + yoff);
         }
@@ -127,8 +127,7 @@ namespace canny
 
     template <
         class T,
-        class Norm,
-        typename = std::enable_if_t<std::is_base_of<SrcTex, T>::value>
+        class Norm
     >
     __global__ void calcMagnitudeKernel(const T src, PtrStepi dx, PtrStepi dy, PtrStepSzf mag, const Norm norm)
     {


### PR DESCRIPTION
relates #17556 

 * After #17556 , the build on Jetson TX1 and TX2 fails
 * enable_if_t and is_base_of is c++14 feature
 * override is c++11 feature

```
opencv/modules/cudaimgproc/src/cuda/canny.cu(110): warning: "override" and "final" are C++11 features
opencv/modules/cudaimgproc/src/cuda/canny.cu(131): error: namespace "std" has no member "enable_if_t"
```

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under OpenCV (BSD) License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [x] The PR is proposed to proper branch
- [x] There is reference to original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
