### PR TITLE
G-API: Add default implementation for plaidml::kernels

### DIFF
--- a/modules/gapi/src/backends/plaidml/gplaidmlcore.cpp
+++ b/modules/gapi/src/backends/plaidml/gplaidmlcore.cpp
@@ -5,12 +5,14 @@
 // Copyright (C) 2019 Intel Corporation
 
 
-#ifdef HAVE_PLAIDML
-
 #include "precomp.hpp"
 
 #include <opencv2/gapi/core.hpp>
+
 #include <opencv2/gapi/plaidml/core.hpp>
+
+#ifdef HAVE_PLAIDML
+
 #include <opencv2/gapi/plaidml/gplaidmlkernel.hpp>
 
 #include <plaidml2/edsl/edsl.h>
@@ -51,4 +53,12 @@ cv::gapi::GKernelPackage cv::gapi::core::plaidml::kernels()
     return pkg;
 }
 
-#endif // HACE_PLAIDML
+#else // HAVE_PLAIDML
+
+cv::gapi::GKernelPackage cv::gapi::core::plaidml::kernels()
+{
+    // Still provide this symbol to avoid linking issues
+    util::throw_error(std::runtime_error("G-API has been compiled without PlaidML2 support"));
+}
+
+#endif // HAVE_PLAIDML

--- a/modules/gapi/test/gapi_plaidml_pipelines.cpp
+++ b/modules/gapi/test/gapi_plaidml_pipelines.cpp
@@ -5,8 +5,6 @@
 // Copyright (C) 2019 Intel Corporation
 
 
-#ifdef HAVE_PLAIDML
-
 #include "test_precomp.hpp"
 
 #include <stdexcept>
@@ -18,6 +16,8 @@
 
 namespace opencv_test
 {
+
+#ifdef HAVE_PLAIDML
 
 inline cv::gapi::plaidml::config getConfig()
 {
@@ -173,6 +173,13 @@ TEST(GAPI_PlaidML_Pipelines, TwoOutputOperations)
     EXPECT_EQ(0, cv::norm(out_mat[1], ref_mat[1]));
 }
 
-} // namespace opencv_test
+#else // HAVE_PLAIDML
+
+TEST(GAPI_PlaidML_Pipelines, ThrowIfPlaidMLNotFound)
+{
+    ASSERT_ANY_THROW(cv::gapi::core::plaidml::kernels());
+}
 
 #endif // HAVE_PLAIDML
+
+} // namespace opencv_test


### PR DESCRIPTION
### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under OpenCV (BSD) License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [x] The PR is proposed to proper branch
- [ ] There is reference to original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake

### Changes overview
`cv::gapi::core::plaidml::kernels()` has got implementation only under `HAVE_PLAIDML` macro while API available without this macro, so in case using this function without `HAVE_PLAIDML` it will cause linking error

### Build configuration
```
force_builders=Custom
buildworker:Custom=linux-1
build_image:Custom=plaidml2
test_modules:Custom=gapi
test_filter:Custom=*ML*

build_gapi_standalone:Linux x64=ade-0.1.1f
build_gapi_standalone:Win64=ade-0.1.1f
build_gapi_standalone:Mac=ade-0.1.1f
build_gapi_standalone:Linux x64 Debug=ade-0.1.1f
```
