### PR TITLE
Fix: error in the dimension used for computeMinMax

### DIFF
--- a/modules/flann/include/opencv2/flann/kdtree_single_index.h
+++ b/modules/flann/include/opencv2/flann/kdtree_single_index.h
@@ -461,7 +461,7 @@ private:
             DistanceType span = bbox[i].high-bbox[i].low;
             if (span>(DistanceType)((1-EPS)*max_span)) {
                 ElementType min_elem, max_elem;
-                computeMinMax(ind, count, cutfeat, min_elem, max_elem);
+                computeMinMax(ind, count, (int)i, min_elem, max_elem);
                 DistanceType spread = (DistanceType)(max_elem-min_elem);
                 if (spread>max_spread) {
                     cutfeat = (int)i;


### PR DESCRIPTION
Instead of using the current dimension for which we just got a big span,
we were computing Min and Max for the previous dimension stored in cutfeat
(and using 0 instead of the dimension indice for the very first dimension
with "span > (1-eps)max_span")

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under OpenCV (BSD) License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [x] The PR is proposed to proper branch
- [ ] There is reference to original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
