### PR TITLE
cuda4dnn(mish): use fp32 mish for fp16 mish (faster and more accurate)

### DIFF
--- a/modules/dnn/src/cuda/functors.hpp
+++ b/modules/dnn/src/cuda/functors.hpp
@@ -57,10 +57,18 @@ struct mish_functor<float> {
         auto n = e * e + 2 * e;
         if (value <= -0.6f)
             return value * fast_divide(n, n + 2);
-
         return value - 2 * fast_divide(value, n + 2);
     }
 };
+
+#if !defined(__CUDA_ARCH__) || (__CUDA_ARCH__ >= 530)
+template <>
+struct mish_functor<__half> {
+    __device__ __half operator()(__half value) {
+        return mish_functor<float>()(value);
+    }
+};
+#endif
 
 template <class T>
 struct sigmoid_functor {


### PR DESCRIPTION
The FP32 mish is well optimized. It's sufficiently optimized that converting the FP16 input to FP32 and applying the FP32 mish activation is faster than the FP16 direct mish computation (what is currently on master).

<cut/>

\#                            | master                    | (this PR)             | tkDNN (with TensorRT)
------------------------- |  ------------------------ | --------------------- | --------------------------------
YOLOv4 608 x 608 | 9.75ms                      | 9.50ms            | 9.01ms

</cut>

<details>
<summary>raw performance stats (master)</summary>

```
YOLO v4
[CUDA FP32]
	init >> 438.666ms
	inference >> min = 17.583ms, max = 21.566ms, mean = 18.0522ms, stddev = 0.898828ms
[CUDA FP16]
	init >> 422.158ms
	inference >> min = 9.704ms, max = 9.862ms, mean = 9.74722ms, stddev = 0.028705ms

```

</details>

<details>
<summary>raw performance stats (this PR)</summary>

```
YOLO v4
[CUDA FP32]
	init >> 429.76ms
	inference >> min = 17.454ms, max = 21.558ms, mean = 18.0478ms, stddev = 0.966053ms
[CUDA FP16]
	init >> 301.384ms
	inference >> min = 9.472ms, max = 9.632ms, mean = 9.5029ms, stddev = 0.0245504ms
```

</details>

---

I also tried to write a fast fp16 mish implementation. The fp32 mish is still faster than this one.

```
__device__ half mish(half value)
{
    if (value > half(3.999))
        return value;

    auto e = hexp(value);
    auto n = e * e + half(2) * e;
    return value * n / (n + half(2));
}
```


\#                           | Time (non-vectorized)  | Norm of L2 error vector
------------------------ | ------------------------------ | --------------------------------
mish_fp16 (old)     | 160us                           | 2.93
mish_fp16 (new)   | 148us                           | 1.62
mish_fp16_fp32    | 125us                           | 1.50

`mish_fp16 (old)` is what is currently in OpenCV. `mish_fp16 (new)` is the function given above. `mish_fp16_fp32` is the version which this PR adds.

Accuracy comparision of `mish_fp16 (old)`, `mish_fp16 (new)` and `mish_fp32` (not the converted one but actual fp32 for reference). Reference values calculated using 128-bit floats.

![graphs_fp16](https://user-images.githubusercontent.com/6652578/85316989-4663bb00-b4db-11ea-835c-19239c55c87d.png)

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under OpenCV (BSD) License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [x] The PR is proposed to proper branch
- [ ] There is reference to original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake


```
force_builders=Custom
buildworker:Custom=linux-4
build_image:Custom=ubuntu-cuda:18.04
```
