### PR TITLE
(3.4) Conditional compilation for network reader

### DIFF
--- a/modules/dnn/test/test_ie_models.cpp
+++ b/modules/dnn/test/test_ie_models.cpp
@@ -136,12 +136,6 @@ void runIE(Target target, const std::string& xmlPath, const std::string& binPath
 {
     SCOPED_TRACE("runIE");
 
-    CNNNetReader reader;
-    reader.ReadNetwork(xmlPath);
-    reader.ReadWeights(binPath);
-
-    CNNNetwork net = reader.getNetwork();
-
     std::string device_name;
 
 #if defined(INF_ENGINE_RELEASE) && INF_ENGINE_VER_MAJOR_GT(2019010000)
@@ -150,6 +144,17 @@ void runIE(Target target, const std::string& xmlPath, const std::string& binPath
     InferenceEnginePluginPtr enginePtr;
     InferencePlugin plugin;
 #endif
+
+#if defined(INF_ENGINE_RELEASE) && INF_ENGINE_VER_MAJOR_GT(2019030000)
+    CNNNetwork net = ie.ReadNetwork(xmlPath, binPath);
+#else
+    CNNNetReader reader;
+    reader.ReadNetwork(xmlPath);
+    reader.ReadWeights(binPath);
+
+    CNNNetwork net = reader.getNetwork();
+#endif
+
     ExecutableNetwork netExec;
     InferRequest infRequest;
 


### PR DESCRIPTION
backport #17616

<cut/>

```
force_builders=Custom,Custom Win,Custom Mac
build_image:Custom=ubuntu-openvino-2020.3.0:16.04
build_image:Custom Win=openvino-2020.2.0
build_image:Custom Mac=openvino-2020.1.0

test_modules:Custom=dnn,python2,python3,java
test_modules:Custom Win=dnn,python2,python3,java
test_modules:Custom Mac=dnn,python2,python3,java

buildworker:Custom=linux-1
# disabled due high memory usage: test_opencl:Custom=ON
test_opencl:Custom=ON
test_bigdata:Custom=1
test_filter:Custom=*OpenVINO*
```