### PR TITLE
Use"moms"replace "contourArea"

### DIFF
--- a/modules/features2d/src/blobdetector.cpp
+++ b/modules/features2d/src/blobdetector.cpp
@@ -257,7 +257,7 @@ void SimpleBlobDetectorImpl::findBlobs(InputArray _image, InputArray _binaryImag
         {
             std::vector < Point > hull;
             convexHull(contours[contourIdx], hull);
-            double area = contourArea(contours[contourIdx]);
+            double area = moms.m00;
             double hullArea = contourArea(hull);
             if (fabs(hullArea) < DBL_EPSILON)
                 continue;


### PR DESCRIPTION
double area = moms.m00;
is same as
double area = contourArea(contours[contourIdx]);
Not to mention
"moms" already calculated here,"contourArea" should not apply

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under OpenCV (BSD) License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [ ] The PR is proposed to proper branch
- [ ] There is reference to original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
