### PR TITLE
support indexed color images on iOS

### DIFF
--- a/modules/imgcodecs/src/ios_conversions.mm
+++ b/modules/imgcodecs/src/ios_conversions.mm
@@ -112,6 +112,21 @@ void UIImageToMat(const UIImage* image,
                                            m.step[0], colorSpace,
                                            bitmapInfo);
     }
+    else if (CGColorSpaceGetModel(colorSpace) == kCGColorSpaceModelIndexed)
+    {
+        // CGBitmapContextCreate() does not support indexed color spaces.
+        colorSpace = CGColorSpaceCreateDeviceRGB();
+        m.create(rows, cols, CV_8UC4); // 8 bits per component, 4 channels
+        if (!alphaExist)
+            bitmapInfo = kCGImageAlphaNoneSkipLast |
+                                kCGBitmapByteOrderDefault;
+        else
+            m = cv::Scalar(0);
+        contextRef = CGBitmapContextCreate(m.data, m.cols, m.rows, 8,
+                                           m.step[0], colorSpace,
+                                           bitmapInfo);
+        CGColorSpaceRelease(colorSpace);
+    }
     else
     {
         m.create(rows, cols, CV_8UC4); // 8 bits per component, 4 channels


### PR DESCRIPTION
UIImageToMat() fail to convert indexed color image now.
This is because CGBitmapContextCreate() in UIImageToMat() don't support indexed color spaces.
I added if block for indexed color spaces.


CGBitmapContextCreate
https://developer.apple.com/documentation/coregraphics/1455939-cgbitmapcontextcreate?language=objc

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [○] I agree to contribute to the project under OpenCV (BSD) License.
- [○] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [○] The PR is proposed to proper branch
- [ ] There is reference to original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [○] The feature is well documented and sample code can be built with the project CMake
