### PR TITLE
Merge 3.4

### DIFF
--- a/cmake/OpenCVDetectCUDA.cmake
+++ b/cmake/OpenCVDetectCUDA.cmake
@@ -82,13 +82,14 @@ if(CUDA_FOUND)
 
   message(STATUS "CUDA detected: " ${CUDA_VERSION})
 
-  set(_generations "Fermi" "Kepler" "Maxwell" "Pascal" "Volta" "Turing")
+  set(_generations "Fermi" "Kepler" "Maxwell" "Pascal" "Volta" "Turing" "Ampere")
   set(_arch_fermi   "2.0")
   set(_arch_kepler  "3.0;3.5;3.7")
   set(_arch_maxwell "5.0;5.2")
   set(_arch_pascal  "6.0;6.1")
   set(_arch_volta   "7.0")
   set(_arch_turing  "7.5")
+  set(_arch_ampere  "8.0")
   if(NOT CMAKE_CROSSCOMPILING)
     list(APPEND _generations "Auto")
   endif()
@@ -163,6 +164,8 @@ if(CUDA_FOUND)
     set(__cuda_arch_bin ${_arch_volta})
   elseif(CUDA_GENERATION STREQUAL "Turing")
     set(__cuda_arch_bin ${_arch_turing})
+  elseif(CUDA_GENERATION STREQUAL "Ampere")
+    set(__cuda_arch_bin ${_arch_ampere})
   elseif(CUDA_GENERATION STREQUAL "Auto")
     ocv_detect_native_cuda_arch(_nvcc_res _nvcc_out)
     if(NOT _nvcc_res EQUAL 0)
@@ -180,7 +183,13 @@ if(CUDA_FOUND)
       ocv_detect_native_cuda_arch(_nvcc_res _nvcc_out)
       if(NOT _nvcc_res EQUAL 0)
         message(STATUS "Automatic detection of CUDA generation failed. Going to build for all known architectures.")
-        set(__cuda_arch_bin "5.3 6.2 7.2")
+        # TX1 (5.3) TX2 (6.2) Xavier (7.2) V100 (7.0)
+        ocv_filter_available_architecture(__cuda_arch_bin
+            5.3
+            6.2
+            7.2
+            7.0
+        )
       else()
         set(__cuda_arch_bin "${_nvcc_out}")
       endif()
@@ -193,6 +202,7 @@ if(CUDA_FOUND)
           ${_arch_pascal}
           ${_arch_volta}
           ${_arch_turing}
+          ${_arch_ampere}
       )
     endif()
   endif()

--- a/doc/opencv.bib
+++ b/doc/opencv.bib
@@ -346,7 +346,8 @@
   year = {2003},
   pages = {363--370},
   publisher = {Springer},
-  url = {https://arxiv.org/pdf/1808.01752}
+  url = {https://doi.org/10.1007/3-540-45103-X_50},
+  doi = {10.1007/3-540-45103-X_50}
 }
 @inproceedings{Farsiu03,
   author = {Farsiu, Sina and Robinson, Dirk and Elad, Michael and Milanfar, Peyman},

--- a/modules/dnn/src/darknet/darknet_io.cpp
+++ b/modules/dnn/src/darknet/darknet_io.cpp
@@ -797,7 +797,7 @@ namespace cv {
                         int classes = getParam<int>(layer_params, "classes", -1);
                         int num_of_anchors = getParam<int>(layer_params, "num", -1);
                         float thresh = getParam<float>(layer_params, "thresh", 0.2);
-                        float nms_threshold = getParam<float>(layer_params, "nms_threshold", 0.4);
+                        float nms_threshold = getParam<float>(layer_params, "nms_threshold", 0.0);
                         float scale_x_y = getParam<float>(layer_params, "scale_x_y", 1.0);
 
                         std::string anchors_values = getParam<std::string>(layer_params, "anchors", std::string());

--- a/modules/dnn/src/layers/elementwise_layers.cpp
+++ b/modules/dnn/src/layers/elementwise_layers.cpp
@@ -763,8 +763,11 @@ struct MishFunctor : public BaseFunctor
         {
             for( int i = 0; i < len; i++ )
             {
+                // Use fast approximation introduced in https://github.com/opencv/opencv/pull/17200
                 float x = srcptr[i];
-                dstptr[i] = x * tanh(log(1.0f + exp(x)));
+                float eX = exp(std::min(x, 20.f));
+                float n = (eX + 2) * eX;
+                dstptr[i] = (x * n) / (n + 2);
             }
         }
     }


### PR DESCRIPTION
#17580 from sitic:bibfix
#17592 from l-bat:disable_nms_in_yolo_layer
#17593 from tomoaki0705:addAmpereCUDA
#17599 from tomoaki0705:fixCUDAFailSafePath
#17622 from dkurt:dnn_ie_cpu_ext_update
#17624 from dkurt:dnn_optimize_mish
~~#17633 from alalek:backport_17616~~

Previous "Merge 3.4": #17586

<cut/>

```
buildworker:Win64 OpenCL=windows-2
buildworker:Custom=linux-1,linux-2,linux-4
build_image:Docs=docs-js
build_image:Custom=javascript
#build_image:Custom=powerpc64le
#build_image:Custom=ubuntu-openvino-2019r3.0:16.04
#build_image:Custom=ubuntu-openvino-2020.1.0:16.04
#build_image:Custom=ubuntu-openvino-2020.2.0:16.04
#buildworker:Custom=linux-2
#build_image:Custom=ubuntu-vulkan:16.04
#buildworker:Custom=linux-4
#build_image:Custom=fedora:28
#build_image:Custom=ubuntu-cuda:16.04
#build_image:Custom=ubuntu-clang:18.04
#build_image:Custom=ubuntu:20.04
#buildworker:Custom=linux-1
#build_image:Custom=javascript-simd
#build_image:Custom=mips64el
#build_image:Custom Mac=openvino-2019r3.0
#build_image:Custom Mac=openvino-2020.2.0
build_image:Custom Mac=openvino-2020.2.0
#build_image:Custom Win=openvino-2019r3.0
#build_image:Custom Win=openvino-2020.1.0
build_image:Custom Win=openvino-2020.2.0
test_bigdata:Custom Win=1
test_filter:Custom Win=*
test_modules=dnn,python2,python3,java
test_opencl:Custom Win=OFF
#build_image:Custom Win=msvs2017
#build_image:Custom Win=msvs2019
test_modules:Custom Mac=dnn,java,python3
```
