### PR TITLE
Dynamic build for Objective-C/Swift wrapper

### DIFF
--- a/cmake/OpenCVGenInfoPlist.cmake
+++ b/cmake/OpenCVGenInfoPlist.cmake
@@ -2,7 +2,7 @@ set(OPENCV_APPLE_BUNDLE_NAME "OpenCV")
 set(OPENCV_APPLE_BUNDLE_ID "org.opencv")
 
 if(IOS)
-  if (APPLE_FRAMEWORK AND BUILD_SHARED_LIBS)
+  if (APPLE_FRAMEWORK AND DYNAMIC_PLIST)
     configure_file("${OpenCV_SOURCE_DIR}/platforms/ios/Info.Dynamic.plist.in"
                    "${CMAKE_BINARY_DIR}/ios/Info.plist")
   else()

--- a/modules/core/misc/objc/common/ByteVector.h
+++ b/modules/core/misc/objc/common/ByteVector.h
@@ -10,13 +10,14 @@
 #ifdef __cplusplus
 #import <vector>
 #endif
+#import "CVObjcUtil.h"
 
 NS_ASSUME_NONNULL_BEGIN
 
 /**
 * Utility class to wrap a `std::vector<char>`
 */
-@interface ByteVector : NSObject
+CV_EXPORTS @interface ByteVector : NSObject
 
 #pragma mark - Constructors
 

--- a/modules/core/misc/objc/common/CVObjcUtil.h
+++ b/modules/core/misc/objc/common/CVObjcUtil.h
@@ -12,6 +12,14 @@ typedef union { float f; int32_t i; } V32;
 #define DOUBLE_TO_BITS(x)  ((V64){ .d = x }).l
 #define FLOAT_TO_BITS(x)  ((V32){ .f = x }).i
 
+#ifndef CV_EXPORTS
+#ifdef __cplusplus
+#define CV_EXPORTS __attribute__ ((visibility ("default")))
+#else
+#define CV_EXPORTS
+#endif
+#endif
+
 #ifdef __cplusplus
 #import <vector>
 

--- a/modules/core/misc/objc/common/Converters.h
+++ b/modules/core/misc/objc/common/Converters.h
@@ -8,6 +8,8 @@
 
 #ifdef __cplusplus
 #import <opencv2/opencv.hpp>
+#else
+#define CV_EXPORTS
 #endif
 
 #import <Foundation/Foundation.h>
@@ -27,7 +29,7 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-@interface Converters : NSObject
+CV_EXPORTS @interface Converters : NSObject
 
 + (Mat*)vector_Point_to_Mat:(NSArray<Point2i*>*)pts NS_SWIFT_NAME(vector_Point_to_Mat(_:));
 

--- a/modules/core/misc/objc/common/CvType.h
+++ b/modules/core/misc/objc/common/CvType.h
@@ -6,6 +6,8 @@
 
 #ifdef __cplusplus
 #import "opencv.hpp"
+#else
+#define CV_EXPORTS
 #endif
 
 #import <Foundation/Foundation.h>
@@ -15,7 +17,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
 * Utility functions for handling CvType values
 */
-@interface CvType : NSObject
+CV_EXPORTS @interface CvType : NSObject
 
 #pragma mark - Type Utility functions
 

--- a/modules/core/misc/objc/common/DMatch.h
+++ b/modules/core/misc/objc/common/DMatch.h
@@ -8,6 +8,8 @@
 
 #ifdef __cplusplus
 #import "opencv.hpp"
+#else
+#define CV_EXPORTS
 #endif
 
 #import <Foundation/Foundation.h>
@@ -18,7 +20,7 @@ NS_ASSUME_NONNULL_BEGIN
 * Structure for matching: query descriptor index, train descriptor index, train
 * image index and distance between descriptors.
 */
-@interface DMatch : NSObject
+CV_EXPORTS @interface DMatch : NSObject
 
 /**
  * Query descriptor index.

--- a/modules/core/misc/objc/common/Double2.h
+++ b/modules/core/misc/objc/common/Double2.h
@@ -8,6 +8,8 @@
 
 #ifdef __cplusplus
 #import "opencv.hpp"
+#else
+#define CV_EXPORTS
 #endif
 
 #import <Foundation/Foundation.h>
@@ -19,7 +21,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
 * Simple wrapper for a vector of two `double`
 */
-@interface Double2 : NSObject
+CV_EXPORTS @interface Double2 : NSObject
 
 #pragma mark - Properties
 
@@ -32,11 +34,6 @@ NS_ASSUME_NONNULL_BEGIN
 * Second vector element
 */
 @property double v1;
-
-/**
-* Third vector element
-*/
-@property double v2;
 
 
 #ifdef __cplusplus

--- a/modules/core/misc/objc/common/Double3.h
+++ b/modules/core/misc/objc/common/Double3.h
@@ -8,6 +8,8 @@
 
 #ifdef __cplusplus
 #import "opencv.hpp"
+#else
+#define CV_EXPORTS
 #endif
 
 #import <Foundation/Foundation.h>
@@ -19,7 +21,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
 * Simple wrapper for a vector of three `double`
 */
-@interface Double3 : NSObject
+CV_EXPORTS @interface Double3 : NSObject
 
 #pragma mark - Properties
 

--- a/modules/core/misc/objc/common/DoubleVector.h
+++ b/modules/core/misc/objc/common/DoubleVector.h
@@ -10,13 +10,14 @@
 #ifdef __cplusplus
 #import <vector>
 #endif
+#import "CVObjcUtil.h"
 
 NS_ASSUME_NONNULL_BEGIN
 
 /**
 * Utility class to wrap a `std::vector<double>`
 */
-@interface DoubleVector : NSObject
+CV_EXPORTS @interface DoubleVector : NSObject
 
 #pragma mark - Constructors
 

--- a/modules/core/misc/objc/common/Float4.h
+++ b/modules/core/misc/objc/common/Float4.h
@@ -8,6 +8,8 @@
 
 #ifdef __cplusplus
 #import "opencv.hpp"
+#else
+#define CV_EXPORTS
 #endif
 
 #import <Foundation/Foundation.h>
@@ -19,7 +21,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
 * Simple wrapper for a vector of four `float`
 */
-@interface Float4 : NSObject
+CV_EXPORTS @interface Float4 : NSObject
 
 #pragma mark - Properties
 

--- a/modules/core/misc/objc/common/Float6.h
+++ b/modules/core/misc/objc/common/Float6.h
@@ -8,6 +8,8 @@
 
 #ifdef __cplusplus
 #import "opencv.hpp"
+#else
+#define CV_EXPORTS
 #endif
 
 #import <Foundation/Foundation.h>
@@ -19,7 +21,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
 * Simple wrapper for a vector of six `float`
 */
-@interface Float6 : NSObject
+CV_EXPORTS @interface Float6 : NSObject
 
 #pragma mark - Properties
 

--- a/modules/core/misc/objc/common/FloatVector.h
+++ b/modules/core/misc/objc/common/FloatVector.h
@@ -10,13 +10,14 @@
 #ifdef __cplusplus
 #import <vector>
 #endif
+#import "CVObjcUtil.h"
 
 NS_ASSUME_NONNULL_BEGIN
 
 /**
 * Utility class to wrap a `std::vector<float>`
 */
-@interface FloatVector : NSObject
+CV_EXPORTS @interface FloatVector : NSObject
 
 #pragma mark - Constructors
 

--- a/modules/core/misc/objc/common/Int4.h
+++ b/modules/core/misc/objc/common/Int4.h
@@ -8,6 +8,8 @@
 
 #ifdef __cplusplus
 #import "opencv.hpp"
+#else
+#define CV_EXPORTS
 #endif
 
 #import <Foundation/Foundation.h>
@@ -19,7 +21,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
 * Simple wrapper for a vector of four `int`
 */
-@interface Int4 : NSObject
+CV_EXPORTS @interface Int4 : NSObject
 
 #pragma mark - Properties
 

--- a/modules/core/misc/objc/common/IntVector.h
+++ b/modules/core/misc/objc/common/IntVector.h
@@ -10,13 +10,14 @@
 #ifdef __cplusplus
 #import <vector>
 #endif
+#import "CVObjcUtil.h"
 
 NS_ASSUME_NONNULL_BEGIN
 
 /**
 * Utility class to wrap a `std::vector<int>`
 */
-@interface IntVector : NSObject
+CV_EXPORTS @interface IntVector : NSObject
 
 #pragma mark - Constructors
 

--- a/modules/core/misc/objc/common/KeyPoint.h
+++ b/modules/core/misc/objc/common/KeyPoint.h
@@ -8,6 +8,8 @@
 
 #ifdef __cplusplus
 #import "opencv.hpp"
+#else
+#define CV_EXPORTS
 #endif
 
 #import <Foundation/Foundation.h>
@@ -18,7 +20,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
 *  Object representing a point feature found by one of many available keypoint detectors, such as Harris corner detector, FAST, StarDetector, SURF, SIFT etc.
 */
-@interface KeyPoint : NSObject
+CV_EXPORTS @interface KeyPoint : NSObject
 
 #pragma mark - Properties
 

--- a/modules/core/misc/objc/common/Mat.h
+++ b/modules/core/misc/objc/common/Mat.h
@@ -8,6 +8,8 @@
 
 #ifdef __cplusplus
 #import "opencv.hpp"
+#else
+#define CV_EXPORTS
 #endif
 
 #import <Foundation/Foundation.h>
@@ -23,7 +25,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
 * The class Mat represents an n-dimensional dense numerical single-channel or multi-channel array.
 */
-@interface Mat : NSObject
+CV_EXPORTS @interface Mat : NSObject
 
 #ifdef __cplusplus
 @property(readonly) cv::Ptr<cv::Mat> nativePtr;

--- a/modules/core/misc/objc/common/MatOfByte.h
+++ b/modules/core/misc/objc/common/MatOfByte.h
@@ -13,7 +13,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
 * Mat representation of an array of bytes
 */
-@interface MatOfByte : Mat
+CV_EXPORTS @interface MatOfByte : Mat
 
 #pragma mark - Constructors
 

--- a/modules/core/misc/objc/common/MatOfDMatch.h
+++ b/modules/core/misc/objc/common/MatOfDMatch.h
@@ -15,7 +15,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
 * Mat representation of an array of DMatch objects
 */
-@interface MatOfDMatch : Mat
+CV_EXPORTS @interface MatOfDMatch : Mat
 
 #pragma mark - Constructors
 

--- a/modules/core/misc/objc/common/MatOfDouble.h
+++ b/modules/core/misc/objc/common/MatOfDouble.h
@@ -13,7 +13,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
 * Mat representation of an array of doubles
 */
-@interface MatOfDouble : Mat
+CV_EXPORTS @interface MatOfDouble : Mat
 
 #pragma mark - Constructors
 

--- a/modules/core/misc/objc/common/MatOfFloat.h
+++ b/modules/core/misc/objc/common/MatOfFloat.h
@@ -13,7 +13,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
 * Mat representation of an array of floats
 */
-@interface MatOfFloat : Mat
+CV_EXPORTS @interface MatOfFloat : Mat
 
 #ifdef __cplusplus
 - (instancetype)initWithNativeMat:(cv::Mat*)nativeMat;

--- a/modules/core/misc/objc/common/MatOfFloat4.h
+++ b/modules/core/misc/objc/common/MatOfFloat4.h
@@ -13,7 +13,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
 * Mat representation of an array of vectors of four floats
 */
-@interface MatOfFloat4 : Mat
+CV_EXPORTS @interface MatOfFloat4 : Mat
 
 #pragma mark - Constructors
 

--- a/modules/core/misc/objc/common/MatOfFloat6.h
+++ b/modules/core/misc/objc/common/MatOfFloat6.h
@@ -13,7 +13,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
 * Mat representation of an array of vectors of six floats
 */
-@interface MatOfFloat6 : Mat
+CV_EXPORTS @interface MatOfFloat6 : Mat
 
 #pragma mark - Constructors
 

--- a/modules/core/misc/objc/common/MatOfInt.h
+++ b/modules/core/misc/objc/common/MatOfInt.h
@@ -13,7 +13,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
 * Mat representation of an array of ints
 */
-@interface MatOfInt : Mat
+CV_EXPORTS @interface MatOfInt : Mat
 
 #pragma mark - Constructors
 

--- a/modules/core/misc/objc/common/MatOfInt4.h
+++ b/modules/core/misc/objc/common/MatOfInt4.h
@@ -13,7 +13,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
 * Mat representation of an array of vectors of four ints
 */
-@interface MatOfInt4 : Mat
+CV_EXPORTS @interface MatOfInt4 : Mat
 
 #pragma mark - Constructors
 

--- a/modules/core/misc/objc/common/MatOfKeyPoint.h
+++ b/modules/core/misc/objc/common/MatOfKeyPoint.h
@@ -15,7 +15,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
 * Mat representation of an array of KeyPoint objects
 */
-@interface MatOfKeyPoint : Mat
+CV_EXPORTS @interface MatOfKeyPoint : Mat
 
 #pragma mark - Constructors
 

--- a/modules/core/misc/objc/common/MatOfPoint2f.h
+++ b/modules/core/misc/objc/common/MatOfPoint2f.h
@@ -15,7 +15,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
 * Mat representation of an array of Point2f objects
 */
-@interface MatOfPoint2f : Mat
+CV_EXPORTS @interface MatOfPoint2f : Mat
 
 #pragma mark - Constructors
 

--- a/modules/core/misc/objc/common/MatOfPoint2i.h
+++ b/modules/core/misc/objc/common/MatOfPoint2i.h
@@ -16,7 +16,7 @@ NS_ASSUME_NONNULL_BEGIN
 * Mat representation of an array of Point objects
 */
 NS_SWIFT_NAME(MatOfPoint)
-@interface MatOfPoint2i : Mat
+CV_EXPORTS @interface MatOfPoint2i : Mat
 
 #pragma mark - Constructors
 

--- a/modules/core/misc/objc/common/MatOfPoint3.h
+++ b/modules/core/misc/objc/common/MatOfPoint3.h
@@ -15,7 +15,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
 * Mat representation of an array of Point3i objects
 */
-@interface MatOfPoint3 : Mat
+CV_EXPORTS @interface MatOfPoint3 : Mat
 
 #pragma mark - Constructors
 

--- a/modules/core/misc/objc/common/MatOfPoint3f.h
+++ b/modules/core/misc/objc/common/MatOfPoint3f.h
@@ -15,7 +15,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
 * Mat representation of an array of Point3f objects
 */
-@interface MatOfPoint3f : Mat
+CV_EXPORTS @interface MatOfPoint3f : Mat
 
 #pragma mark - Constructors
 

--- a/modules/core/misc/objc/common/MatOfRect2d.h
+++ b/modules/core/misc/objc/common/MatOfRect2d.h
@@ -15,7 +15,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
 * Mat representation of an array of Rect2d objects
 */
-@interface MatOfRect2d : Mat
+CV_EXPORTS @interface MatOfRect2d : Mat
 
 #pragma mark - Constructors
 

--- a/modules/core/misc/objc/common/MatOfRect2i.h
+++ b/modules/core/misc/objc/common/MatOfRect2i.h
@@ -16,7 +16,7 @@ NS_ASSUME_NONNULL_BEGIN
 * Mat representation of an array of Rect objects
 */
 NS_SWIFT_NAME(MatOfRect)
-@interface MatOfRect2i : Mat
+CV_EXPORTS @interface MatOfRect2i : Mat
 
 #pragma mark - Constructors
 

--- a/modules/core/misc/objc/common/MatOfRotatedRect.h
+++ b/modules/core/misc/objc/common/MatOfRotatedRect.h
@@ -15,7 +15,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
 * Mat representation of an array of RotatedRect objects
 */
-@interface MatOfRotatedRect : Mat
+CV_EXPORTS @interface MatOfRotatedRect : Mat
 
 #pragma mark - Constructors
 

--- a/modules/core/misc/objc/common/MinMaxLocResult.h
+++ b/modules/core/misc/objc/common/MinMaxLocResult.h
@@ -8,6 +8,8 @@
 
 #ifdef __cplusplus
 #import "opencv.hpp"
+#else
+#define CV_EXPORTS
 #endif
 
 #import <Foundation/Foundation.h>
@@ -19,7 +21,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
 * Result of operation to determine global minimum and maximum of an array
 */
-@interface MinMaxLocResult : NSObject
+CV_EXPORTS @interface MinMaxLocResult : NSObject
 
 #pragma mark - Properties
 

--- a/modules/core/misc/objc/common/Point2d.h
+++ b/modules/core/misc/objc/common/Point2d.h
@@ -8,6 +8,8 @@
 
 #ifdef __cplusplus
 #import "opencv.hpp"
+#else
+#define CV_EXPORTS
 #endif
 
 #import <Foundation/Foundation.h>
@@ -19,7 +21,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
 * Represents a two dimensional point the coordinate values of which are of type `double`
 */
-@interface Point2d : NSObject
+CV_EXPORTS @interface Point2d : NSObject
 
 # pragma mark - Properties
 

--- a/modules/core/misc/objc/common/Point2f.h
+++ b/modules/core/misc/objc/common/Point2f.h
@@ -8,6 +8,8 @@
 
 #ifdef __cplusplus
 #import "opencv.hpp"
+#else
+#define CV_EXPORTS
 #endif
 
 #import <Foundation/Foundation.h>
@@ -19,7 +21,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
 * Represents a two dimensional point the coordinate values of which are of type `float`
 */
-@interface Point2f : NSObject
+CV_EXPORTS @interface Point2f : NSObject
 
 # pragma mark - Properties
 

--- a/modules/core/misc/objc/common/Point2i.h
+++ b/modules/core/misc/objc/common/Point2i.h
@@ -8,6 +8,8 @@
 
 #ifdef __cplusplus
 #import "opencv.hpp"
+#else
+#define CV_EXPORTS
 #endif
 
 #import <Foundation/Foundation.h>
@@ -20,7 +22,7 @@ NS_ASSUME_NONNULL_BEGIN
 * Represents a two dimensional point the coordinate values of which are of type `int`
 */
 NS_SWIFT_NAME(Point)
-@interface Point2i : NSObject
+CV_EXPORTS @interface Point2i : NSObject
 
 # pragma mark - Properties
 

--- a/modules/core/misc/objc/common/Point3d.h
+++ b/modules/core/misc/objc/common/Point3d.h
@@ -8,6 +8,8 @@
 
 #ifdef __cplusplus
 #import "opencv.hpp"
+#else
+#define CV_EXPORTS
 #endif
 
 #import <Foundation/Foundation.h>
@@ -19,7 +21,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
 * Represents a three dimensional point the coordinate values of which are of type `double`
 */
-@interface Point3d : NSObject
+CV_EXPORTS @interface Point3d : NSObject
 
 # pragma mark - Properties
 

--- a/modules/core/misc/objc/common/Point3f.h
+++ b/modules/core/misc/objc/common/Point3f.h
@@ -8,6 +8,8 @@
 
 #ifdef __cplusplus
 #import "opencv.hpp"
+#else
+#define CV_EXPORTS
 #endif
 
 #import <Foundation/Foundation.h>
@@ -19,7 +21,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
 * Represents a three dimensional point the coordinate values of which are of type `float`
 */
-@interface Point3f : NSObject
+CV_EXPORTS @interface Point3f : NSObject
 
 # pragma mark - Properties
 

--- a/modules/core/misc/objc/common/Point3i.h
+++ b/modules/core/misc/objc/common/Point3i.h
@@ -8,6 +8,8 @@
 
 #ifdef __cplusplus
 #import "opencv.hpp"
+#else
+#define CV_EXPORTS
 #endif
 
 #import <Foundation/Foundation.h>
@@ -19,7 +21,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
 * Represents a three dimensional point the coordinate values of which are of type `int`
 */
-@interface Point3i : NSObject
+CV_EXPORTS @interface Point3i : NSObject
 
 # pragma mark - Properties
 

--- a/modules/core/misc/objc/common/Range.h
+++ b/modules/core/misc/objc/common/Range.h
@@ -8,6 +8,8 @@
 
 #ifdef __cplusplus
 #import "opencv.hpp"
+#else
+#define CV_EXPORTS
 #endif
 
 #import <Foundation/Foundation.h>
@@ -17,7 +19,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
 * Represents a range of dimension indices
 */
-@interface Range : NSObject
+CV_EXPORTS @interface Range : NSObject
 
 #pragma mark - Properties
 

--- a/modules/core/misc/objc/common/Rect2d.h
+++ b/modules/core/misc/objc/common/Rect2d.h
@@ -8,6 +8,8 @@
 
 #ifdef __cplusplus
 #import "opencv.hpp"
+#else
+#define CV_EXPORTS
 #endif
 
 @class Point2d;
@@ -20,7 +22,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
 * Represents a rectange the coordinate and dimension values of which are of type `double`
 */
-@interface Rect2d : NSObject
+CV_EXPORTS @interface Rect2d : NSObject
 
 #pragma mark - Properties
 

--- a/modules/core/misc/objc/common/Rect2f.h
+++ b/modules/core/misc/objc/common/Rect2f.h
@@ -8,6 +8,8 @@
 
 #ifdef __cplusplus
 #import "opencv.hpp"
+#else
+#define CV_EXPORTS
 #endif
 
 @class Point2f;
@@ -20,7 +22,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
 * Represents a rectange the coordinate and dimension values of which are of type `float`
 */
-@interface Rect2f : NSObject
+CV_EXPORTS @interface Rect2f : NSObject
 
 #pragma mark - Properties
 

--- a/modules/core/misc/objc/common/Rect2i.h
+++ b/modules/core/misc/objc/common/Rect2i.h
@@ -8,6 +8,8 @@
 
 #ifdef __cplusplus
 #import "opencv.hpp"
+#else
+#define CV_EXPORTS
 #endif
 
 @class Point2i;
@@ -21,7 +23,7 @@ NS_ASSUME_NONNULL_BEGIN
 * Represents a rectange the coordinate and dimension values of which are of type `int`
 */
 NS_SWIFT_NAME(Rect)
-@interface Rect2i : NSObject
+CV_EXPORTS @interface Rect2i : NSObject
 
 #pragma mark - Properties
 

--- a/modules/core/misc/objc/common/RotatedRect.h
+++ b/modules/core/misc/objc/common/RotatedRect.h
@@ -8,6 +8,8 @@
 
 #ifdef __cplusplus
 #import "opencv.hpp"
+#else
+#define CV_EXPORTS
 #endif
 
 @class Point2f;
@@ -21,7 +23,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
 * Represents a rotated rectangle on a plane
 */
-@interface RotatedRect : NSObject
+CV_EXPORTS @interface RotatedRect : NSObject
 
 #pragma mark - Properties
 

--- a/modules/core/misc/objc/common/Scalar.h
+++ b/modules/core/misc/objc/common/Scalar.h
@@ -8,6 +8,8 @@
 
 #ifdef __cplusplus
 #import "opencv.hpp"
+#else
+#define CV_EXPORTS
 #endif
 
 #import <Foundation/Foundation.h>
@@ -17,7 +19,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
 * Represents a four element vector
 */
-@interface Scalar : NSObject
+CV_EXPORTS @interface Scalar : NSObject
 
 #pragma mark - Properties
 

--- a/modules/core/misc/objc/common/Size2d.h
+++ b/modules/core/misc/objc/common/Size2d.h
@@ -8,6 +8,8 @@
 
 #ifdef __cplusplus
 #import "opencv.hpp"
+#else
+#define CV_EXPORTS
 #endif
 
 @class Point2d;
@@ -19,7 +21,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
 * Represents the dimensions of a rectangle the values of which are of type `double`
 */
-@interface Size2d : NSObject
+CV_EXPORTS @interface Size2d : NSObject
 
 #pragma mark - Properties
 

--- a/modules/core/misc/objc/common/Size2f.h
+++ b/modules/core/misc/objc/common/Size2f.h
@@ -8,6 +8,8 @@
 
 #ifdef __cplusplus
 #import "opencv.hpp"
+#else
+#define CV_EXPORTS
 #endif
 
 @class Point2f;
@@ -19,7 +21,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
 * Represents the dimensions of a rectangle the values of which are of type `float`
 */
-@interface Size2f : NSObject
+CV_EXPORTS @interface Size2f : NSObject
 
 #pragma mark - Properties
 

--- a/modules/core/misc/objc/common/Size2i.h
+++ b/modules/core/misc/objc/common/Size2i.h
@@ -8,6 +8,8 @@
 
 #ifdef __cplusplus
 #import "opencv.hpp"
+#else
+#define CV_EXPORTS
 #endif
 
 @class Point2i;
@@ -20,7 +22,7 @@ NS_ASSUME_NONNULL_BEGIN
 * Represents the dimensions of a rectangle the values of which are of type `int`
 */
 NS_SWIFT_NAME(Size)
-@interface Size2i : NSObject
+CV_EXPORTS @interface Size2i : NSObject
 
 #pragma mark - Properties
 

--- a/modules/core/misc/objc/common/TermCriteria.h
+++ b/modules/core/misc/objc/common/TermCriteria.h
@@ -8,6 +8,8 @@
 
 #ifdef __cplusplus
 #import "opencv.hpp"
+#else
+#define CV_EXPORTS
 #endif
 
 #import <Foundation/Foundation.h>
@@ -17,7 +19,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
 * Class representing termination criteria for iterative algorithms.
 */
-@interface TermCriteria : NSObject
+CV_EXPORTS @interface TermCriteria : NSObject
 
 #pragma mark - Properties
 

--- a/modules/imgcodecs/misc/objc/ios/Mat+Converters.h
+++ b/modules/imgcodecs/misc/objc/ios/Mat+Converters.h
@@ -8,6 +8,8 @@
 
 #ifdef __cplusplus
 #import "opencv.hpp"
+#else
+#define CV_EXPORTS
 #endif
 
 #import <Foundation/Foundation.h>
@@ -16,7 +18,7 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-@interface Mat (Converters)
+CV_EXPORTS @interface Mat (Converters)
 
 -(UIImage*)toUIImage;
 -(instancetype)initWithUIImage:(UIImage*)image;

--- a/modules/imgproc/misc/objc/common/Moments.h
+++ b/modules/imgproc/misc/objc/common/Moments.h
@@ -8,13 +8,15 @@
 
 #ifdef __cplusplus
 #import "opencv.hpp"
+#else
+#define CV_EXPORTS
 #endif
 
 #import <Foundation/Foundation.h>
 
 NS_ASSUME_NONNULL_BEGIN
 
-@interface Moments : NSObject
+CV_EXPORTS @interface Moments : NSObject
 
 @property double m00;
 @property double m10;

--- a/modules/objc/generator/templates/cmakelists.template
+++ b/modules/objc/generator/templates/cmakelists.template
@@ -8,7 +8,7 @@ set(MODULES "$modules")
 set (CMAKE_CXX_STANDARD 11)
 set (CMAKE_CXX_STANDARD_REQUIRED TRUE)
 
-set (OBJC_COMPILE_FLAGS "-fobjc-arc -fobjc-weak -fvisibility=hidden -D__OPENCV_BUILD=1")
+set (OBJC_COMPILE_FLAGS "-fobjc-arc -fobjc-weak -fvisibility=hidden -fPIC -D__OPENCV_BUILD=1")
 set (SUPPRESS_WARNINGS_FLAGS "-Wno-incomplete-umbrella")
 set (CMAKE_CXX_FLAGS  "$${CMAKE_CXX_FLAGS} $${OBJC_COMPILE_FLAGS} $${SUPPRESS_WARNINGS_FLAGS}")
 

--- a/modules/objc/generator/templates/objc_class_header.template
+++ b/modules/objc/generator/templates/objc_class_header.template
@@ -6,6 +6,8 @@
 #ifdef __cplusplus
 #import "opencv.hpp"
 $additionalImports
+#else
+#define CV_EXPORTS
 #endif
 
 #import <Foundation/Foundation.h>
@@ -18,7 +20,7 @@ $enumDeclarations
 NS_ASSUME_NONNULL_BEGIN
 
 $docs
-@interface $objcName : $base
+CV_EXPORTS @interface $objcName : $base
 
 $nativePointerHandling
 

--- a/modules/objc/generator/templates/objc_module_header.template
+++ b/modules/objc/generator/templates/objc_module_header.template
@@ -6,6 +6,8 @@
 #ifdef __cplusplus
 #import "opencv.hpp"
 $additionalImports
+#else
+#define CV_EXPORTS
 #endif
 
 #import <Foundation/Foundation.h>
@@ -17,7 +19,7 @@ $enumDeclarations
 NS_ASSUME_NONNULL_BEGIN
 
 $docs
-@interface $module : $base
+CV_EXPORTS @interface $module : $base
 
 $methodDeclarations
 

--- a/modules/videoio/misc/objc/ios/CvCamera2.h
+++ b/modules/videoio/misc/objc/ios/CvCamera2.h
@@ -8,12 +8,13 @@
 #import <Accelerate/Accelerate.h>
 #import <AVFoundation/AVFoundation.h>
 #import <ImageIO/ImageIO.h>
+#import "CVObjcUtil.h"
 
 @class Mat;
 
 @class CvAbstractCamera2;
 
-@interface CvAbstractCamera2 : NSObject
+CV_EXPORTS @interface CvAbstractCamera2 : NSObject
 
 @property UIDeviceOrientation currentDeviceOrientation;
 @property BOOL cameraAvailable;
@@ -55,7 +56,7 @@
 - (void)processImage:(Mat*)image;
 @end
 
-@interface CvVideoCamera2 : CvAbstractCamera2<AVCaptureVideoDataOutputSampleBufferDelegate>
+CV_EXPORTS @interface CvVideoCamera2 : CvAbstractCamera2<AVCaptureVideoDataOutputSampleBufferDelegate>
 @property (nonatomic, weak) id<CvVideoCameraDelegate2> delegate;
 @property (nonatomic, assign) BOOL grayscaleMode;
 @property (nonatomic, assign) BOOL recordVideo;
@@ -78,7 +79,7 @@
 - (void)photoCameraCancel:(CvPhotoCamera2*)photoCamera;
 @end
 
-@interface CvPhotoCamera2 : CvAbstractCamera2<AVCapturePhotoCaptureDelegate>
+CV_EXPORTS @interface CvPhotoCamera2 : CvAbstractCamera2<AVCapturePhotoCaptureDelegate>
 @property (nonatomic, weak) id<CvPhotoCameraDelegate2> delegate;
 - (void)takePicture;
 @end

--- a/platforms/ios/Info.Dynamic.plist.in
+++ b/platforms/ios/Info.Dynamic.plist.in
@@ -5,7 +5,7 @@
     <key>CFBundleDevelopmentRegion</key>
     <string>en</string>
     <key>CFBundleExecutable</key>
-    <string>opencv2</string>
+    <string>${FRAMEWORK_NAME}</string>
     <key>CFBundleName</key>
     <string>${OPENCV_APPLE_BUNDLE_NAME}</string>
     <key>CFBundleIdentifier</key>


### PR DESCRIPTION
### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under OpenCV (BSD) License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [x] The PR is proposed to proper branch
- [x] There is reference to original bug report and related work

Fix for ##17664

This Pull request fixes iOS build when `--dynamic` is specified
* for legacy iOS leaves implementation as is
* when building with the Objective-C/Swift wrapper builds static library first then runs additional link stage to create a dynamic library
* adds CV_EXPORT to relevant interface declarations
* correctly handles plist file generation, bitcode generation and `-install_path` location for `--dynamic` build
* removes extraneous property from `Double2`