### PR TITLE
cuda4dnn(build): add basic support for cuDNN 8

### DIFF
--- a/modules/dnn/CMakeLists.txt
+++ b/modules/dnn/CMakeLists.txt
@@ -21,14 +21,10 @@ if(OPENCV_DNN_OPENCL AND HAVE_OPENCL)
   add_definitions(-DCV_OCL4DNN=1)
 endif()
 
-if(NOT DEFINED OPENCV_DNN_CUDA AND HAVE_CUDNN AND CUDNN_VERSION VERSION_LESS 8.0)
-  message(STATUS "DNN: CUDNN 8.0 is not supported yes. Details: https://github.com/opencv/opencv/issues/17496")
-endif()
 ocv_option(OPENCV_DNN_CUDA "Build with CUDA support"
     HAVE_CUDA
     AND HAVE_CUBLAS
     AND HAVE_CUDNN
-    AND CUDNN_VERSION VERSION_LESS 8.0
 )
 
 if(OPENCV_DNN_CUDA AND HAVE_CUDA AND HAVE_CUBLAS AND HAVE_CUDNN)

--- a/modules/dnn/src/cuda4dnn/csl/cudnn/convolution.hpp
+++ b/modules/dnn/src/cuda4dnn/csl/cudnn/convolution.hpp
@@ -225,6 +225,15 @@ namespace cv { namespace dnn { namespace cuda4dnn { namespace csl { namespace cu
                     );
                 }
                 CUDA4DNN_CHECK_CUDNN(cudnnSetConvolutionGroupCount(descriptor, group_count));
+
+#if CUDNN_MAJOR >= 8
+                /* cuDNN 7 and below use FMA math by default. cuDNN 8 includes TF32 Tensor Ops
+                 * in the default setting. TF32 convolutions have lower precision than FP32.
+                 * Hence, we set the math type to CUDNN_FMA_MATH to reproduce old behavior.
+                 */
+                CUDA4DNN_CHECK_CUDNN(cudnnSetConvolutionMathType(descriptor, CUDNN_FMA_MATH));
+#endif
+
                 if (std::is_same<T, half>::value)
                     CUDA4DNN_CHECK_CUDNN(cudnnSetConvolutionMathType(descriptor, CUDNN_TENSOR_OP_MATH));
             } catch (...) {
@@ -254,15 +263,49 @@ namespace cv { namespace dnn { namespace cuda4dnn { namespace csl { namespace cu
          */
         ConvolutionAlgorithm(
             const Handle& handle,
-            const ConvolutionDescriptor<T>& conv,
-            const FilterDescriptor<T>& filter,
-            const TensorDescriptor<T>& input,
-            const TensorDescriptor<T>& output)
+            const ConvolutionDescriptor<T>& convDesc,
+            const FilterDescriptor<T>& filterDesc,
+            const TensorDescriptor<T>& inputDesc,
+            const TensorDescriptor<T>& outputDesc)
         {
+#if CUDNN_MAJOR >= 8
+            int requestedAlgoCount = 0, returnedAlgoCount = 0;
+            CUDA4DNN_CHECK_CUDNN(cudnnGetConvolutionForwardAlgorithmMaxCount(handle.get(), &requestedAlgoCount));
+            std::vector<cudnnConvolutionFwdAlgoPerf_t> results(requestedAlgoCount);
+            CUDA4DNN_CHECK_CUDNN(
+                cudnnGetConvolutionForwardAlgorithm_v7(
+                    handle.get(),
+                    inputDesc.get(), filterDesc.get(), convDesc.get(), outputDesc.get(),
+                    requestedAlgoCount,
+                    &returnedAlgoCount,
+                    &results[0]
+                )
+            );
+
+            size_t free_memory, total_memory;
+            CUDA4DNN_CHECK_CUDA(cudaMemGetInfo(&free_memory, &total_memory));
+
+            bool found_conv_algorithm = false;
+            for (int i = 0; i < returnedAlgoCount; i++)
+            {
+                if (results[i].status == CUDNN_STATUS_SUCCESS &&
+                    results[i].algo != CUDNN_CONVOLUTION_FWD_ALGO_WINOGRAD_NONFUSED &&
+                    results[i].memory < free_memory)
+                {
+                    found_conv_algorithm = true;
+                    algo = results[i].algo;
+                    workspace_size = results[i].memory;
+                    break;
+                }
+            }
+
+            if (!found_conv_algorithm)
+                CV_Error (cv::Error::GpuApiCallError, "cuDNN did not return a suitable algorithm for convolution.");
+#else
             CUDA4DNN_CHECK_CUDNN(
                 cudnnGetConvolutionForwardAlgorithm(
                     handle.get(),
-                    input.get(), filter.get(), conv.get(), output.get(),
+                    inputDesc.get(), filterDesc.get(), convDesc.get(), outputDesc.get(),
                     CUDNN_CONVOLUTION_FWD_PREFER_FASTEST,
                     0, /* no memory limit */
                     &algo
@@ -272,10 +315,11 @@ namespace cv { namespace dnn { namespace cuda4dnn { namespace csl { namespace cu
             CUDA4DNN_CHECK_CUDNN(
                 cudnnGetConvolutionForwardWorkspaceSize(
                     handle.get(),
-                    input.get(), filter.get(), conv.get(), output.get(),
+                    inputDesc.get(), filterDesc.get(), convDesc.get(), outputDesc.get(),
                     algo, &workspace_size
                 )
             );
+#endif
         }
 
         ConvolutionAlgorithm& operator=(const ConvolutionAlgorithm&) = default;


### PR DESCRIPTION
There are five tests failing on GTX 1050 which are not fixable (no convolution algorithm found). These might be limited to 6.1 devices or devices that don't support good FP16 performance.

```
[  FAILED  ] 5 tests, listed below:
[  FAILED  ] Test_ONNX_layers.Convolution3D/1, where GetParam() = CUDA/CUDA_FP16
[  FAILED  ] Test_ONNX_layers.PoolConv3D/1, where GetParam() = CUDA/CUDA_FP16
[  FAILED  ] Test_ONNX_nets.Resnet34_kinetics/1, where GetParam() = CUDA/CUDA_FP16
[  FAILED  ] Test_TensorFlow_layers.Convolution3D/1, where GetParam() = CUDA/CUDA_FP16
[  FAILED  ] Test_TensorFlow_layers.concat_3d/1, where GetParam() = CUDA/CUDA_FP16
```

Related #17496
fixes #17747 

**Pending:**
- test on CUDA11

<cut/>

# Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under OpenCV (BSD) License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [x] The PR is proposed to proper branch
- [x] There is reference to original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake

```
force_builders=Custom
buildworker:Custom=linux-4
Xbuild_image:Custom=ubuntu-cuda:18.04
build_image:Custom=ubuntu-cuda11:18.04
build_image:Custom Win=cuda11
```