### PR TITLE
ximgproc: add loose comparison based on pixel count

### DIFF
--- a/modules/ts/include/opencv2/ts.hpp
+++ b/modules/ts/include/opencv2/ts.hpp
@@ -360,6 +360,9 @@ void max(const Mat& src, double s, Mat& dst);
 
 void compare(const Mat& src1, const Mat& src2, Mat& dst, int cmpop);
 void compare(const Mat& src, double s, Mat& dst, int cmpop);
+
+int countExceed(const Mat& src, double value, int cmpop);
+int countExceed(const Mat& src1, const Mat& src2, double value, int cmpop);
 void gemm(const Mat& src1, const Mat& src2, double alpha,
                      const Mat& src3, double beta, Mat& dst, int flags);
 void transform( const Mat& src, Mat& dst, const Mat& transmat, const Mat& shift );

--- a/modules/ts/src/ts_func.cpp
+++ b/modules/ts/src/ts_func.cpp
@@ -1744,6 +1744,19 @@ void compare(const Mat& src, double value, Mat& dst, int cmpop)
     }
 }
 
+int countExceed(const Mat& src, double value, int cmpop)
+{
+    Mat count;
+    cvtest::compare(src, value, count, cmpop);
+    return countNonZero(count.reshape(1));
+}
+
+int countExceed(const Mat& src1, const Mat& src2, double value, int cmpop)
+{
+    Mat diff;
+    absdiff(src1.reshape(1), src2.reshape(1), diff);
+    return countExceed(diff, value, cmpop);
+}
 
 template<typename _Tp> double
 cmpUlpsInt_(const _Tp* src1, const _Tp* src2, size_t total, int imaxdiff,


### PR DESCRIPTION
realtes https://github.com/opencv/opencv_contrib/pull/2581

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under OpenCV (BSD) License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [x] The PR is proposed to proper branch
- [x] There is reference to original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
