### PR TITLE
cmake(gapi): fix opencv_world build for winpack

### DIFF
--- a/modules/gapi/CMakeLists.txt
+++ b/modules/gapi/CMakeLists.txt
@@ -190,7 +190,7 @@ endif()
 
 if(WIN32)
   # Required for htonl/ntohl on Windows
-  target_link_libraries(${the_module} PRIVATE wsock32 ws2_32)
+  ocv_target_link_libraries(${the_module} PRIVATE wsock32 ws2_32)
 endif()
 
 ocv_add_perf_tests()


### PR DESCRIPTION
resolves #17677
[Failed nightly builds](http://pullrequest.opencv.org/buildbot/builders/master_winpack-build-win64-vc15/builds/907).

```
build_world:Custom Win=ON
```