### PR TITLE
(3.4) CUDA: fix build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1652,6 +1652,10 @@ if(ENABLE_CONFIG_VERIFICATION)
   ocv_verify_config()
 endif()
 
+if(HAVE_CUDA AND COMMAND CUDA_BUILD_CLEAN_TARGET)
+  CUDA_BUILD_CLEAN_TARGET()
+endif()
+
 ocv_cmake_hook(POST_FINALIZE)
 
 # ----------------------------------------------------------------------------

--- a/cmake/OpenCVDetectCUDA.cmake
+++ b/cmake/OpenCVDetectCUDA.cmake
@@ -375,4 +375,11 @@ if(HAVE_CUDA)
     set(CUDA_cufft_LIBRARY_ABS ${CUDA_cufft_LIBRARY})
     ocv_convert_to_lib_name(CUDA_cufft_LIBRARY ${CUDA_cufft_LIBRARY})
   endif()
+
+  if(CMAKE_GENERATOR MATCHES "Visual Studio"
+      AND NOT OPENCV_SKIP_CUDA_CMAKE_SUPPRESS_REGENERATION
+  )
+    message(WARNING "CUDA with MSVS generator is detected. Disabling CMake re-run checks (CMAKE_SUPPRESS_REGENERATION=ON). You need to run CMake manually if updates are required.")
+    set(CMAKE_SUPPRESS_REGENERATION ON)
+  endif()
 endif()

--- a/cmake/OpenCVDetectCUDA.cmake
+++ b/cmake/OpenCVDetectCUDA.cmake
@@ -28,6 +28,11 @@ endif()
 
 if(CUDA_FOUND)
   set(HAVE_CUDA 1)
+  if(NOT CUDA_VERSION VERSION_LESS 11.0)
+    # CUDA 11.0 removes nppicom
+    ocv_list_filterout(CUDA_nppi_LIBRARY "nppicom")
+    ocv_list_filterout(CUDA_npp_LIBRARY "nppicom")
+  endif()
 
   if(WITH_CUFFT)
     set(HAVE_CUFFT 1)

--- a/modules/core/include/opencv2/core/cuda_types.hpp
+++ b/modules/core/include/opencv2/core/cuda_types.hpp
@@ -106,8 +106,8 @@ namespace cv
 
             size_t step;
 
-            __CV_CUDA_HOST_DEVICE__       T* ptr(int y = 0)       { return (      T*)( (      char*)DevPtr<T>::data + y * step); }
-            __CV_CUDA_HOST_DEVICE__ const T* ptr(int y = 0) const { return (const T*)( (const char*)DevPtr<T>::data + y * step); }
+            __CV_CUDA_HOST_DEVICE__       T* ptr(int y = 0)       { return (      T*)( (      char*)(((DevPtr<T>*)this)->data) + y * step); }
+            __CV_CUDA_HOST_DEVICE__ const T* ptr(int y = 0) const { return (const T*)( (const char*)(((DevPtr<T>*)this)->data) + y * step); }
 
             __CV_CUDA_HOST_DEVICE__       T& operator ()(int y, int x)       { return ptr(y)[x]; }
             __CV_CUDA_HOST_DEVICE__ const T& operator ()(int y, int x) const { return ptr(y)[x]; }


### PR DESCRIPTION
<cut/>

- Fixes error message:

> cuda_types.hpp(109): error C3861: 'data': identifier not found

```
Xforce_builders_only=Custom,Custom Win
buildworker:Custom=linux-4
Xbuild_image:Custom=ubuntu-cuda:18.04
build_image:Custom=ubuntu-cuda11:18.04
build_image:Custom Win=cuda11
Xbuild_image:Custom Win=cuda10
```