### PR TITLE
Restored compatibility with CMake older than 3.7.

### DIFF
--- a/cmake/OpenCVDetectCUDA.cmake
+++ b/cmake/OpenCVDetectCUDA.cmake
@@ -31,7 +31,7 @@ endif()
 
 if(CUDA_FOUND)
   set(HAVE_CUDA 1)
-  if(CUDA_VERSION VERSION_GREATER_EQUAL "11.0")
+  if(NOT CUDA_VERSION VERSION_LESS 11.0)
     # CUDA 11.0 removes nppicom
     ocv_list_filterout(CUDA_nppi_LIBRARY "nppicom")
     ocv_list_filterout(CUDA_npp_LIBRARY "nppicom")


### PR DESCRIPTION
Introduced in https://github.com/opencv/opencv/pull/17499

<cut/>

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under OpenCV (BSD) License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [x] The PR is proposed to proper branch
- [x] There is reference to original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake

```
buildworker:Custom=linux-2,linux-4
docker_image:Custom=ubuntu-cuda:16.04
```