### PR TITLE
Type consistency for all xxxIndexParams integer arguments as well as …

### DIFF
--- a/modules/flann/include/opencv2/flann.hpp
+++ b/modules/flann/include/opencv2/flann.hpp
@@ -224,9 +224,9 @@ public:
         struct LshIndexParams : public IndexParams
         {
             LshIndexParams(
-                unsigned int table_number,
-                unsigned int key_size,
-                unsigned int multi_probe_level );
+                int table_number,
+                int key_size,
+                int multi_probe_level );
         };
         @endcode
         - **AutotunedIndexParams** When passing an object of this type the index created is

--- a/modules/flann/include/opencv2/flann/lsh_index.h
+++ b/modules/flann/include/opencv2/flann/lsh_index.h
@@ -58,15 +58,15 @@ namespace cvflann
 
 struct LshIndexParams : public IndexParams
 {
-    LshIndexParams(unsigned int table_number = 12, unsigned int key_size = 20, unsigned int multi_probe_level = 2)
+    LshIndexParams(int table_number = 12, int key_size = 20, int multi_probe_level = 2)
     {
         (*this)["algorithm"] = FLANN_INDEX_LSH;
         // The number of hash tables to use
-        (*this)["table_number"] = static_cast<int>(table_number);
+        (*this)["table_number"] = table_number;
         // The length of the key in the hash tables
-        (*this)["key_size"] = static_cast<int>(key_size);
+        (*this)["key_size"] = key_size;
         // Number of levels to use in multi-probe (0 for standard LSH)
-        (*this)["multi_probe_level"] = static_cast<int>(multi_probe_level);
+        (*this)["multi_probe_level"] = multi_probe_level;
     }
 };
 


### PR DESCRIPTION
…with miniflann's LshIndexParams

<cut/>

test_module_force=flann

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under OpenCV (BSD) License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [x] The PR is proposed to proper branch
- [ ] There is reference to original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
