### PR TITLE
Fix genericity of computeNodeStatistics that couldn't compute stats p…

### DIFF
--- a/modules/flann/include/opencv2/flann/kmeans_index.h
+++ b/modules/flann/include/opencv2/flann/kmeans_index.h
@@ -663,7 +663,7 @@ private:
 
         memset(mean,0,veclen_*sizeof(DistanceType));
 
-        for (size_t i=0; i<(size_t)indices_length; ++i) {
+        for (int i=0; i<indices_length; ++i) {
             ElementType* vec = dataset_[indices[i]];
             for (size_t j=0; j<veclen_; ++j) {
                 mean[j] += vec[j];
@@ -671,9 +671,9 @@ private:
             variance += distance_(vec, ZeroIterator<ElementType>(), veclen_);
         }
         for (size_t j=0; j<veclen_; ++j) {
-            mean[j] /= size_;
+            mean[j] /= indices_length;
         }
-        variance /= size_;
+        variance /= indices_length;
         variance -= distance_(mean, ZeroIterator<ElementType>(), veclen_);
 
         DistanceType tmp = 0;


### PR DESCRIPTION
…roperly on sub-nodes

<cut/>

test_module_force=flann

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under OpenCV (BSD) License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [x] The PR is proposed to proper branch
- [ ] There is reference to original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
