### PR TITLE
Precompute the divisor to ensure that no kind of compiler would proce…

### DIFF
--- a/modules/flann/include/opencv2/flann/dist.h
+++ b/modules/flann/include/opencv2/flann/dist.h
@@ -506,7 +506,7 @@ struct Hamming2
         const uint64_t* pa = reinterpret_cast<const uint64_t*>(a);
         const uint64_t* pb = reinterpret_cast<const uint64_t*>(b);
         ResultType result = 0;
-        size /= (sizeof(uint64_t)/sizeof(unsigned char));
+        size /= long_word_size_;
         for(size_t i = 0; i < size; ++i ) {
             result += popcnt64(*pa ^ *pb);
             ++pa;
@@ -516,7 +516,7 @@ struct Hamming2
         const uint32_t* pa = reinterpret_cast<const uint32_t*>(a);
         const uint32_t* pb = reinterpret_cast<const uint32_t*>(b);
         ResultType result = 0;
-        size /= (sizeof(uint32_t)/sizeof(unsigned char));
+        size /= long_word_size_;
         for(size_t i = 0; i < size; ++i ) {
             result += popcnt32(*pa ^ *pb);
             ++pa;
@@ -525,6 +525,13 @@ struct Hamming2
 #endif
         return result;
     }
+
+private:
+#ifdef FLANN_PLATFORM_64_BIT
+    static const size_t long_word_size_ = sizeof(uint64_t)/sizeof(unsigned char);
+#else
+    static const size_t long_word_size_ = sizeof(uint32_t)/sizeof(unsigned char);
+#endif
 };
 
 


### PR DESCRIPTION
…ss it on the fly at each call.

<cut/>

test_module_force=flann

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under OpenCV (BSD) License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [x] The PR is proposed to proper branch
- [ ] There is reference to original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake

```
force_builders=Custom
build_image:Custom=centos:7
buildworker:Custom=linux-1
```