### PR TITLE
Supported yolov4-tiny

### DIFF
--- a/modules/dnn/test/test_darknet_importer.cpp
+++ b/modules/dnn/test/test_darknet_importer.cpp
@@ -627,6 +627,12 @@ TEST_P(Test_Darknet_layers, reorg)
     testDarknetLayer("reorg");
 }
 
+TEST_P(Test_Darknet_layers, route)
+{
+    testDarknetLayer("route");
+    testDarknetLayer("route_multi");
+}
+
 TEST_P(Test_Darknet_layers, maxpool)
 {
 #if defined(INF_ENGINE_RELEASE) && INF_ENGINE_VER_MAJOR_GE(2020020000)


### PR DESCRIPTION
Merge with extra: opencv/opencv_extra#770

relates #17666

<cut/>

```
force_builders=Linux32,Win32,Custom,Custom Win,Custom Mac
build_image:Custom=ubuntu-openvino-2020.2.0:16.04
build_image:Custom Win=openvino-2020.2.0
build_image:Custom Mac=openvino-2020.2.0

test_modules:Custom=dnn,python2,python3,java
test_modules:Custom Win=dnn,python2,python3,java
test_modules:Custom Mac=dnn,python2,python3,java

buildworker:Custom=linux-1
test_opencl:Custom=ON
test_bigdata:Custom=1
test_filter:Custom=*YOLO*:*VINO*:*ENet*:*route*

test_opencl:Custom Win=ON
test_bigdata:Custom Win=1
test_filter:Custom Win=*YOLO*:*VINO*:*ENet*:*route*

```

