### PR TITLE
Fix trees parsing behavior in hierarchical_clustering_index:

### DIFF
--- a/modules/flann/include/opencv2/flann/hierarchical_clustering_index.h
+++ b/modules/flann/include/opencv2/flann/hierarchical_clustering_index.h
@@ -548,7 +548,7 @@ public:
     void findNeighbors(ResultSet<DistanceType>& result, const ElementType* vec, const SearchParams& searchParams) CV_OVERRIDE
     {
 
-        int maxChecks = get_param(searchParams,"checks",32);
+        const int maxChecks = get_param(searchParams,"checks",32);
 
         // Priority queue storing intermediate branches in the best-bin-first search
         Heap<BranchSt>* heap = new Heap<BranchSt>((int)size_);
@@ -557,6 +557,8 @@ public:
         int checks = 0;
         for (int i=0; i<trees_; ++i) {
             findNN(root[i], result, vec, checks, maxChecks, heap, checked);
+            if ((checks >= maxChecks) && result.full())
+                break;
         }
 
         BranchSt branch;
@@ -748,8 +750,8 @@ private:
                 Heap<BranchSt>* heap, std::vector<bool>& checked)
     {
         if (node->childs==NULL) {
-            if (checks>=maxChecks) {
-                if (result.full()) return;
+            if ((checks>=maxChecks) && result.full()) {
+                return;
             }
             for (int i=0; i<node->size; ++i) {
                 int index = node->indices[i];


### PR DESCRIPTION
Before, when maxCheck was reached in the first descent of a tree, time was still wasted parsing
the next trees till their best leaves whose points were not used at all.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under OpenCV (BSD) License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [x] The PR is proposed to proper branch
- [ ] There is reference to original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
