### PR TITLE
Adding comment from source code to DetectionOutputLayer class documentation

### DIFF
--- a/modules/dnn/include/opencv2/dnn/all_layers.hpp
+++ b/modules/dnn/include/opencv2/dnn/all_layers.hpp
@@ -599,13 +599,11 @@ CV__DNN_EXPERIMENTAL_NS_BEGIN
     };
 
     /**
-     * @brief \f$ L_p \f$ - detection output layer.
+     * @brief detection output layer.
      *
-     * num() and channels() are 1.
-     * Since the number of bboxes to be kept is unknown before nms, we manually
-     * set it to maximal number of detections, [keep_top_k] parameter multiplied by batch size.
-     * Each row is a 7 dimension std::vector, which stores
-     * [image_id, label, confidence, xmin, ymin, xmax, ymax]
+     * The layer size is: @f$ (1 \times 1 \times N \times 7) @f$
+     *    where N is the number of detections after nms, and each row is:
+     *    [image_id, label, confidence, xmin, ymin, xmax, ymax]
      */
     class CV_EXPORTS DetectionOutputLayer : public Layer
     {

--- a/modules/dnn/include/opencv2/dnn/all_layers.hpp
+++ b/modules/dnn/include/opencv2/dnn/all_layers.hpp
@@ -598,6 +598,15 @@ CV__DNN_EXPERIMENTAL_NS_BEGIN
         static Ptr<RegionLayer> create(const LayerParams& params);
     };
 
+    /**
+     * @brief \f$ L_p \f$ - detection output layer.
+     *
+     * num() and channels() are 1.
+     * Since the number of bboxes to be kept is unknown before nms, we manually
+     * set it to maximal number of detections, [keep_top_k] parameter multiplied by batch size.
+     * Each row is a 7 dimension std::vector, which stores
+     * [image_id, label, confidence, xmin, ymin, xmax, ymax]
+     */
     class CV_EXPORTS DetectionOutputLayer : public Layer
     {
     public:

--- a/modules/dnn/include/opencv2/dnn/all_layers.hpp
+++ b/modules/dnn/include/opencv2/dnn/all_layers.hpp
@@ -599,11 +599,12 @@ CV__DNN_EXPERIMENTAL_NS_BEGIN
     };
 
     /**
-     * @brief detection output layer.
+     * @brief Detection output layer.
      *
      * The layer size is: @f$ (1 \times 1 \times N \times 7) @f$
-     *    where N is the number of detections after nms, and each row is:
+     *    where N is [keep_top_k] parameter multiplied by batch size. Each row is:
      *    [image_id, label, confidence, xmin, ymin, xmax, ymax]
+     *    where image_id is the index of image input in the batch.
      */
     class CV_EXPORTS DetectionOutputLayer : public Layer
     {


### PR DESCRIPTION
Adds a comment written in the source code for bool getMemoryShapes into the DetectionOutputLayer class documentation, as requested in this issue:

resolves #14645

```
force_builders_only=Docs
```