### PR TITLE
cuda4dnn: overlap D2H output blobs transfer with inference

### DIFF
--- a/modules/dnn/src/cuda4dnn/csl/event.hpp
+++ b/modules/dnn/src/cuda4dnn/csl/event.hpp
@@ -33,7 +33,7 @@ namespace cv { namespace dnn { namespace cuda4dnn { namespace csl {
         /** if \p create is `true`, a new event will be created; otherwise, an empty event object is created */
         Event(bool create, bool timing_event = false) : event{nullptr} {
             if (create) {
-                unsigned int flags = cudaEventBlockingSync | (timing_event ? 0 : cudaEventDisableTiming);
+                unsigned int flags = (timing_event ? 0 : cudaEventDisableTiming);
                 CUDA4DNN_CHECK_CUDA(cudaEventCreateWithFlags(&event, flags));
             }
         }
@@ -60,6 +60,7 @@ namespace cv { namespace dnn { namespace cuda4dnn { namespace csl {
 
         /** mark a point in \p stream */
         void record(const Stream& stream) {
+            CV_Assert(stream);
             CUDA4DNN_CHECK_CUDA(cudaEventRecord(event, stream.get()));
         }
 
@@ -85,12 +86,13 @@ namespace cv { namespace dnn { namespace cuda4dnn { namespace csl {
     };
 
     /** makes a stream wait on an event */
-    void StreamWaitOnEvent(const Stream& stream, const Event& event) {
+    inline void StreamWaitOnEvent(const Stream& stream, const Event& event) {
+        CV_Assert(stream);
         CUDA4DNN_CHECK_CUDA(cudaStreamWaitEvent(stream.get(), event.get(), 0));
     }
 
     /** returns the time elapsed between two events in milliseconds */
-    float TimeElapsedBetweenEvents(const Event& start, const Event& end) {
+    inline float TimeElapsedBetweenEvents(const Event& start, const Event& end) {
         float temp;
         CUDA4DNN_CHECK_CUDA(cudaEventElapsedTime(&temp, start.get(), end.get()));
         return temp;

--- a/modules/dnn/src/dnn.cpp
+++ b/modules/dnn/src/dnn.cpp
@@ -585,6 +585,13 @@ struct LayerData
     std::vector<Ptr<BackendWrapper> > inputBlobsWrappers;
     std::vector<Ptr<BackendWrapper> > internalBlobsWrappers;
 
+#ifdef HAVE_CUDA
+    /* output ids which must be transferred to the host in the background
+     * after the completion of the forward pass of the layer
+     */
+    std::vector<int> cudaD2HBackgroundTransfers;
+#endif
+
     Ptr<Layer> layerInstance;
     std::vector<Mat> outputBlobs;
     std::vector<Mat*> inputBlobs;
@@ -1187,7 +1194,8 @@ struct Net::Impl : public detail::NetImplBase
             context.cublas_handle = cuda4dnn::csl::cublas::Handle(context.stream);
             context.cudnn_handle = cuda4dnn::csl::cudnn::Handle(context.stream);
 
-            cudaInfo = std::unique_ptr<CudaInfo_t>(new CudaInfo_t(std::move(context)));
+            auto d2h_stream = cuda4dnn::csl::Stream(true); // stream for background D2H data transfers
+            cudaInfo = std::unique_ptr<CudaInfo_t>(new CudaInfo_t(std::move(context), std::move(d2h_stream)));
         }
 #endif
     }
@@ -1215,8 +1223,10 @@ struct Net::Impl : public detail::NetImplBase
 #ifdef HAVE_CUDA
     struct CudaInfo_t
     {
-        CudaInfo_t(cuda4dnn::csl::CSLContext ctxt) : context(std::move(ctxt)) { }
+        CudaInfo_t(cuda4dnn::csl::CSLContext ctxt, cuda4dnn::csl::Stream d2h_stream_)
+         : context(std::move(ctxt)), d2h_stream(std::move(d2h_stream_)) { }
         cuda4dnn::csl::CSLContext context;
+        cuda4dnn::csl::Stream d2h_stream;
         cuda4dnn::csl::Workspace workspace;
     };
 
@@ -1290,7 +1300,7 @@ struct Net::Impl : public detail::NetImplBase
         if (preferableBackend == DNN_BACKEND_CUDA)
         {
             auto cudaWrapper = wrapper.dynamicCast<CUDABackendWrapper>();
-            cudaWrapper->setStream(cudaInfo->context.stream);
+            cudaWrapper->setStream(cudaInfo->context.stream, cudaInfo->d2h_stream);
         }
 #endif
         backendWrappers[data] = wrapper;
@@ -1630,7 +1640,7 @@ struct Net::Impl : public detail::NetImplBase
         else if (preferableBackend == DNN_BACKEND_VKCOM)
             initVkComBackend();
         else if (preferableBackend == DNN_BACKEND_CUDA)
-            initCUDABackend();
+            initCUDABackend(blobsToKeep_);
         else
             CV_Error(Error::StsNotImplemented, "Unknown backend identifier");
     }
@@ -2360,7 +2370,7 @@ struct Net::Impl : public detail::NetImplBase
 #endif
     }
 
-    void initCUDABackend() {
+    void initCUDABackend(const std::vector<LayerPin>& blobsToKeep_) {
         CV_Assert(haveCUDA());
 
 #ifdef HAVE_CUDA
@@ -2385,6 +2395,15 @@ struct Net::Impl : public detail::NetImplBase
 
             auto cudaNode = node.dynamicCast<CUDABackendNode>();
             cudaInfo->workspace.require(cudaNode->get_workspace_memory_in_bytes());
+        }
+
+        if (blobsToKeep_.size() > 1)
+        {
+            for (const auto& pin : blobsToKeep_)
+            {
+                LayerData& ld = layers[pin.lid];
+                ld.cudaD2HBackgroundTransfers.push_back(pin.oid);
+            }
         }
 #endif
     }
@@ -3120,6 +3139,12 @@ struct Net::Impl : public detail::NetImplBase
                     CV_Assert(!cudaNode.empty());
 
                     cudaNode->forward(ld.inputBlobsWrappers, ld.outputBlobsWrappers, cudaInfo->workspace);
+
+                    for (auto id : ld.cudaD2HBackgroundTransfers)
+                    {
+                        auto wrapper = ld.outputBlobsWrappers[id].dynamicCast<CUDABackendWrapper>();
+                        wrapper->copyToHostInBackground();
+                    }
 #endif
                 }
                 else if (preferableBackend == DNN_BACKEND_HALIDE)

--- a/modules/dnn/src/op_cuda.hpp
+++ b/modules/dnn/src/op_cuda.hpp
@@ -7,6 +7,7 @@
 
 #ifdef HAVE_CUDA
 #include "cuda4dnn/csl/stream.hpp"
+#include "cuda4dnn/csl/event.hpp"
 #include "cuda4dnn/csl/cublas.hpp"
 #include "cuda4dnn/csl/cudnn.hpp"
 #include "cuda4dnn/csl/tensor.hpp"
@@ -206,6 +207,7 @@ namespace cv { namespace dnn {
         virtual ~CUDABackendWrapper() { }
 
         void copyToHost() override = 0;
+        virtual void copyToHostInBackground() = 0;
         void setHostDirty() override = 0;
 
         virtual void copyToDevice() = 0;
@@ -215,7 +217,7 @@ namespace cv { namespace dnn {
         virtual std::size_t getRank() const noexcept = 0;
 
         /** @note setting the stream updates the stream for all wrappers which use the same tensor */
-        virtual void setStream(cuda4dnn::csl::Stream stream) noexcept = 0;
+        virtual void setStream(cuda4dnn::csl::Stream stream, cuda4dnn::csl::Stream h2d_stream) noexcept = 0;
 
         virtual void update(const MatShape& shape, std::size_t offset) = 0;
     };
@@ -238,6 +240,36 @@ namespace cv { namespace dnn {
         template <> inline
         void convert_D2H<float>(const cv::Mat& mat, cuda4dnn::csl::View<float> view, cuda4dnn::csl::ManagedPtr<float>& device_temp, const cuda4dnn::csl::Stream& stream) {
             cuda4dnn::csl::memcpy<float>(reinterpret_cast<float*>(mat.data), view.data(), view.size(), stream);
+        }
+
+        template <class U>
+        void convert_D2H_background(const cv::Mat& mat, cuda4dnn::csl::View<U> view, cuda4dnn::csl::ManagedPtr<float>& device_temp, const cuda4dnn::csl::Stream& stream, const cuda4dnn::csl::Stream& d2h_stream, cuda4dnn::csl::Event& d2h_event);
+
+        template <> inline
+        void convert_D2H_background<half>(const cv::Mat& mat, cuda4dnn::csl::View<half> view, cuda4dnn::csl::ManagedPtr<float>& device_temp, const cuda4dnn::csl::Stream& stream, const cuda4dnn::csl::Stream& d2h_stream, cuda4dnn::csl::Event& d2h_event) {
+            if (device_temp.size() < view.size())
+                device_temp.reset(view.size());
+            auto temp_span = cuda4dnn::csl::Span<float>(device_temp.get(), view.size());
+
+            /* The conversion kernel should can be executed in the background stream for better
+             * performance. We do it in the inference stream to prevent an unexplained performance
+             * regression on RTX 2080 Ti. Executing conversion kernel in the background stream causes
+             * everything to slow down (even operations that appear before the background transfer).
+             *
+             * TODO: identify the cause and move conversion kernel to the background stream
+             */
+            cuda4dnn::kernels::fp16_to_fp32(stream, temp_span, view);
+
+            d2h_event.record(stream); // mark position in inference stream
+            cuda4dnn::csl::StreamWaitOnEvent(d2h_stream, d2h_event); // don't start transfer until data is available
+            cuda4dnn::csl::memcpy<float>(reinterpret_cast<float*>(mat.data), temp_span.data(), view.size(), d2h_stream);
+        }
+
+        template <> inline
+        void convert_D2H_background<float>(const cv::Mat& mat, cuda4dnn::csl::View<float> view, cuda4dnn::csl::ManagedPtr<float>& device_temp, const cuda4dnn::csl::Stream& stream, const cuda4dnn::csl::Stream& d2h_stream, cuda4dnn::csl::Event& d2h_event) {
+            d2h_event.record(stream);
+            cuda4dnn::csl::StreamWaitOnEvent(d2h_stream, d2h_event);
+            cuda4dnn::csl::memcpy<float>(reinterpret_cast<float*>(mat.data), view.data(), view.size(), d2h_stream);
         }
 
         template <class U>
@@ -349,6 +381,28 @@ namespace cv { namespace dnn {
 
                 cuda4dnn::detail::convert_D2H<T>(mat, view, shared_block->device_temp, shared_block->stream);
                 shared_block->stream.synchronize();
+            } else if(shared_block->d2h_event && shared_block->d2h_event.busy()) {
+                /* wait for the background copy to finish */
+                shared_block->d2h_event.synchronize();
+            }
+        }
+
+        void copyToHostInBackground() override {
+            CV_Assert(shared_block->d2h_stream);
+            if (shared_block->device_dirty) {
+                shared_block->host_dirty = false;
+                shared_block->device_dirty = false;
+
+                auto view = tensor_view_type(shared_block->device.get(), std::begin(shape), std::end(shape));
+
+                auto& mat = shared_block->host;
+                CV_Assert(mat.isContinuous());
+                CV_Assert(mat.type() == CV_32F);
+
+                if (!shared_block->d2h_event)
+                    shared_block->d2h_event = cuda4dnn::csl::Event(true);
+                cuda4dnn::detail::convert_D2H_background<T>(mat, view, shared_block->device_temp, shared_block->stream, shared_block->d2h_stream, shared_block->d2h_event);
+                shared_block->d2h_event.record(shared_block->d2h_stream); // record position so that we can check status later
             }
         }
 
@@ -383,8 +437,9 @@ namespace cv { namespace dnn {
 
         std::size_t getRank() const noexcept override { return shape.size(); }
 
-        void setStream(cuda4dnn::csl::Stream stream) noexcept override {
+        void setStream(cuda4dnn::csl::Stream stream, cuda4dnn::csl::Stream d2h_stream) noexcept override {
             shared_block->stream = std::move(stream);
+            shared_block->d2h_stream = std::move(d2h_stream);
         }
 
         void update(const MatShape& shape_, std::size_t offset_) override {
@@ -452,6 +507,9 @@ namespace cv { namespace dnn {
             cuda4dnn::csl::ManagedPtr<T> device;
             cuda4dnn::csl::ManagedPtr<float> device_temp; /* use for conversions */
             cuda4dnn::csl::Stream stream;
+
+            cuda4dnn::csl::Event d2h_event;
+            cuda4dnn::csl::Stream d2h_stream;
         };
 
         std::shared_ptr<shared_block_type> shared_block;


### PR DESCRIPTION
Some models like YOLOv3, YOLOv4, Mask RCNN, etc. have multiple output blobs. Currently, the output blobs are transferred one after another after the inference is completed. This PR allows output blobs that are computed early during inference to be copied to CPU buffers while rest of inference is still happening on the GPU.

YOLOv4 has three output blobs and they take approximately 0.5ms, 0.3ms and 0.03ms to be copied to the CPU. This PR begins transferring the 0.5ms blob as soon as possible simultaneously as GPU is doing rest of the inference.

<cut/>

![Screenshot from 2020-07-04 14-18-41](https://user-images.githubusercontent.com/6652578/86508882-37490b00-be01-11ea-9473-f55efdc6cf84.png)

Profiling shows that the transfer of 0.5ms and 0.3ms blob is now completely hidden. The PINK indicates D2H memory operation.

Gains are big for YOLOv4 as the importer somehow sets up the network to compute 0.5ms blob first, 0.3ms blob next and then tiny blob. It's the opposite for YOLOv3; biggest blob is computed last. Hence, the gains are from the 0.3ms blob. Reordering the layers might improve the performance of YOLOv3.

**batch = 1 benchmark:**
\#                          | master (fp32)    | this PR (fp32)    |  master (fp16)       | this PR (fp16)
--------------------------- | ---------------- | ----------------- | -------------------- | ----------------
YOLOv4                      | 17.32ms          | **16.87ms**       | 9.14ms               | **8.62ms** 
YOLOv3                      | 16.70ms          | **16.52ms**       | 7.49ms               | **7.37ms**
YOLOv3 Tiny                 | 1.20ms           | **1.17ms**        | 1.24ms               | **1.22ms**

**batch = 1 benchmark with #16900 :**

\#                          | this PR (fp32)    | this + autotuning (fp32)    | this PR (fp16)    |  this + autotuning (fp16)
--------------------------- | ----------------- | --------------------------- | ----------------- | -------------------------
YOLOv4                      | 16.87ms           | **15.64ms**                 | 8.62ms            | **7.98ms**
YOLOv3                      | 16.52ms           | **15.23ms**                  | 7.37ms            | **7.04ms**
YOLOv3 Tiny                 | 1.17ms            | 1.18ms                     | 1.22ms            | **1.11ms**


**NOTE:** There is an unexpected improvement in timings on master and I am not able to reproduce the timings reported in #17621. The inference is somehow faster now. It could be temperature or power setting but I need to find out.

<details>
<summary>stats for master</summary>

```
YOLO v3
[CUDA FP32]
	init >> 325.318ms
	inference >> min = 16.497ms, max = 20.389ms, mean = 16.6962ms, stddev = 0.465811ms
[CUDA FP16]
	init >> 321.78ms
	inference >> min = 7.441ms, max = 7.549ms, mean = 7.49495ms, stddev = 0.0222691ms


YOLO v3 Tiny
[CUDA FP32]
	init >> 47.694ms
	inference >> min = 1.192ms, max = 1.216ms, mean = 1.2001ms, stddev = 0.00370258ms
[CUDA FP16]
	init >> 49.712ms
	inference >> min = 1.237ms, max = 1.253ms, mean = 1.24323ms, stddev = 0.00239208ms


YOLO v4
[CUDA FP32]
	init >> 401.732ms
	inference >> min = 17.078ms, max = 18.06ms, mean = 17.3195ms, stddev = 0.174867ms
[CUDA FP16]
	init >> 284.639ms
	inference >> min = 9.069ms, max = 9.207ms, mean = 9.13881ms, stddev = 0.03125ms
```

</details>

<details>
<summary>stats for this PR</summary>

```
YOLO v3
[CUDA FP32]
	init >> 348.116ms
	inference >> min = 16.319ms, max = 17.048ms, mean = 16.5294ms, stddev = 0.107546ms
[CUDA FP16]
	init >> 322.748ms
	inference >> min = 7.317ms, max = 8.847ms, mean = 7.37378ms, stddev = 0.149768ms


YOLO v3 Tiny
[CUDA FP32]
	init >> 53.616ms
	inference >> min = 1.169ms, max = 1.203ms, mean = 1.17796ms, stddev = 0.00417188ms
[CUDA FP16]
	init >> 50.37ms
	inference >> min = 1.209ms, max = 1.234ms, mean = 1.21517ms, stddev = 0.00452813ms


YOLO v4
[CUDA FP32]
	init >> 404.897ms
	inference >> min = 16.529ms, max = 20.164ms, mean = 16.871ms, stddev = 0.345786ms
[CUDA FP16]
	init >> 277.327ms
	inference >> min = 8.539ms, max = 8.704ms, mean = 8.62049ms, stddev = 0.0331456ms
```

</details>

<details>
<summary>stats for this PR + autotuning</summary>

```
YOLO v3
[CUDA FP32]
	init >> 8611.32ms
	inference >> min = 15.074ms, max = 15.533ms, mean = 15.2363ms, stddev = 0.0826797ms
[CUDA FP16]
	init >> 695.106ms
	inference >> min = 7ms, max = 7.101ms, mean = 7.04987ms, stddev = 0.0219238ms


YOLO v3 Tiny
[CUDA FP32]
	init >> 288.575ms
	inference >> min = 1.169ms, max = 1.193ms, mean = 1.1804ms, stddev = 0.00529284ms
[CUDA FP16]
	init >> 88.197ms
	inference >> min = 1.102ms, max = 1.19ms, mean = 1.1089ms, stddev = 0.00881615ms


YOLO v4
[CUDA FP32]
	init >> 10871.9ms
	inference >> min = 15.404ms, max = 16.017ms, mean = 15.6477ms, stddev = 0.103202ms
[CUDA FP16]
	init >> 687.905ms
	inference >> min = 7.919ms, max = 8.042ms, mean = 7.98261ms, stddev = 0.0355876ms
```

</details>

<details>
<summary>stats for master (batch = 4)</summary>

```
YOLO v3
[CUDA FP32]
	init >> 501.427ms
	inference >> min = 56.07ms, max = 56.841ms, mean = 56.4295ms, stddev = 0.14574ms
[CUDA FP16]
	init >> 377.34ms
	inference >> min = 24.732ms, max = 25.346ms, mean = 24.9663ms, stddev = 0.159727ms


YOLO v3 Tiny
[CUDA FP32]
	init >> 33.274ms
	inference >> min = 3.707ms, max = 3.765ms, mean = 3.72931ms, stddev = 0.00878906ms
[CUDA FP16]
	init >> 34.327ms
	inference >> min = 3.159ms, max = 3.182ms, mean = 3.17117ms, stddev = 0.00497951ms


YOLO v4
[CUDA FP32]
	init >> 448.526ms
	inference >> min = 58.114ms, max = 59.255ms, mean = 58.5176ms, stddev = 0.185537ms
[CUDA FP16]
	init >> 351.688ms
	inference >> min = 29.329ms, max = 29.77ms, mean = 29.5112ms, stddev = 0.106834ms

```

</details>

<details>
<summary>stats for this PR (batch = 4)</summary>

```
YOLO v3
[CUDA FP32]
	init >> 495.881ms
	inference >> min = 55.948ms, max = 56.721ms, mean = 56.2994ms, stddev = 0.137109ms
[CUDA FP16]
	init >> 373.095ms
	inference >> min = 24.235ms, max = 26.156ms, mean = 24.5377ms, stddev = 0.221109ms


YOLO v3 Tiny
[CUDA FP32]
	init >> 32.883ms
	inference >> min = 3.673ms, max = 3.813ms, mean = 3.69337ms, stddev = 0.0146158ms
[CUDA FP16]
	init >> 33.944ms
	inference >> min = 3.104ms, max = 3.134ms, mean = 3.11433ms, stddev = 0.00560992ms


YOLO v4
[CUDA FP32]
	init >> 446.201ms
	inference >> min = 56.605ms, max = 57.763ms, mean = 56.8878ms, stddev = 0.14574ms
[CUDA FP16]
	init >> 347.83ms
	inference >> min = 27.277ms, max = 27.694ms, mean = 27.4973ms, stddev = 0.0880424ms
```

</details>

<details>
<summary>stats for this PR + autotuning (batch = 4)</summary>

```
YOLO v3
[CUDA FP32]
	init >> 10155.8ms
	inference >> min = 53.622ms, max = 55.963ms, mean = 54.4893ms, stddev = 0.238505ms
[CUDA FP16]
	init >> 1006.96ms
	inference >> min = 22.314ms, max = 23.856ms, mean = 22.5236ms, stddev = 0.193271ms


YOLO v3 Tiny
[CUDA FP32]
	init >> 363.004ms
	inference >> min = 3.541ms, max = 3.593ms, mean = 3.56357ms, stddev = 0.0112623ms
[CUDA FP16]
	init >> 106.495ms
	inference >> min = 2.602ms, max = 2.625ms, mean = 2.61131ms, stddev = 0.00358812ms


YOLO v4
[CUDA FP32]
	init >> 12691.9ms
	inference >> min = 55.17ms, max = 56.085ms, mean = 55.5041ms, stddev = 0.178836ms
[CUDA FP16]
	init >> 1033.87ms
	inference >> min = 24.009ms, max = 24.568ms, mean = 24.2024ms, stddev = 0.133271ms
```

</details>

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under OpenCV (BSD) License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [x] The PR is proposed to proper branch
- [ ] There is reference to original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake

```
force_builders_only=Custom
buildworker:Custom=linux-4
build_image:Custom=ubuntu-cuda:18.04
Xbuild_image:Custom=ubuntu-cuda11:18.04
Xbuild_image:Custom Win=cuda11
Xbuild_image:Custom Win=cuda10
```