### PR TITLE
cuda4dnn(slice, concat): reduce slice and concat to copy, more concat fusions

### DIFF
--- a/modules/dnn/src/cuda/concat.cu
+++ b/modules/dnn/src/cuda/concat.cu
@@ -16,6 +16,8 @@
 #include "../cuda4dnn/csl/tensor.hpp"
 #include "../cuda4dnn/csl/span.hpp"
 
+#include "../cuda4dnn/kernels/fill_copy.hpp"
+
 #include <cstddef>
 #include <vector>
 
@@ -95,6 +97,20 @@ namespace cv { namespace dnn { namespace cuda4dnn { namespace kernels {
         TensorSpan<T> output, std::size_t output_axis_offset,
         TensorView<T> input, std::size_t axis)
     {
+        CV_Assert(output.rank() == input.rank());
+        CV_Assert(output_axis_offset < output.get_axis_size(axis));
+
+        /* if axes preceeding the concat axis are all singleton, the concat blocks are contiguous
+         * in the output and we can copy each block directly
+         */
+        if (output.size_range(0, axis) == 1)
+        {
+            auto stride = output.size_range(axis + 1, output.rank());
+            auto sliced_output = Span<T>(output.get() + output_axis_offset * stride, input.size());
+            kernels::copy<T>(stream, sliced_output, input);
+            return;
+        }
+
         /* let's call the axis of interest as the channel axis for the purpose of the following discussion
          * even though it can be any axis
          *

--- a/modules/dnn/src/cuda4dnn/primitives/slice.hpp
+++ b/modules/dnn/src/cuda4dnn/primitives/slice.hpp
@@ -47,20 +47,6 @@ namespace cv { namespace dnn { namespace cuda4dnn {
 
             CV_Assert(offsets.size() == outputs.size());
 
-            /* one output with the same shape as the input => direct copy */
-            if (outputs.size() == 1)
-            {
-                auto output_wrapper = outputs[0].dynamicCast<wrapper_type>();
-                auto output = output_wrapper->getSpan();
-
-                if (is_shape_same(output, input))
-                {
-                    CV_Assert(std::all_of(std::begin(offsets[0]), std::end(offsets[0]), [] (std::size_t x) { return x == 0; }));
-                    kernels::copy<T>(stream, output, input);
-                    return;
-                }
-            }
-
             for (int i = 0; i < outputs.size(); ++i)
             {
                 auto output_wrapper = outputs[i].dynamicCast<wrapper_type>();

--- a/modules/dnn/src/dnn.cpp
+++ b/modules/dnn/src/dnn.cpp
@@ -2788,7 +2788,13 @@ struct Net::Impl : public detail::NetImplBase
                         if (preferableBackend == DNN_BACKEND_CUDA &&
                             (inp_i_data->layerInstance->supportBackend(DNN_BACKEND_CUDA) == false ||
                              (inp_i_data->layerInstance->type != "Convolution" &&
-                              inp_i_data->layerInstance->type != "Pooling")))
+                              inp_i_data->layerInstance->type != "Pooling" &&
+                              inp_i_data->layerInstance->type != "Resize"  &&
+                              inp_i_data->layerInstance->type != "Flatten" &&
+                              inp_i_data->layerInstance->type != "Permute" &&
+                              inp_i_data->layerInstance->type != "Reorg" &&
+                              inp_i_data->layerInstance->type != "Eltwise" &&
+                              inp_i_data->layerInstance.dynamicCast<ActivationLayer>().empty())))
                         {
                             break;
                         }


### PR DESCRIPTION
- reduces slice to copy if possible (like in YOLOv4 Tiny)
- reduces concat to copy if possible
- enables more concat fusions

slice from yolov4 tiny         | master            | this PR
--------- | ------------------ | ----------
slice1  | 46us                | 31us
slice2  | 25us                | 17us
slice3  | 19us                | 9us

I think it's possible to fuse slice just like concat but it seems to be a more complex than concat fusion.

<cut/>

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under OpenCV (BSD) License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [x] The PR is proposed to proper branch
- [ ] There is reference to original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake

```
force_builders_only=Custom
buildworker:Custom=linux-4
build_image:Custom=ubuntu-cuda:18.04
```