### PR TITLE
imgcodecs: fix test build with disabled JPEG and PNG libs

### DIFF
--- a/modules/imgcodecs/test/test_read_write.cpp
+++ b/modules/imgcodecs/test/test_read_write.cpp
@@ -31,6 +31,7 @@ const tuple<string, Size> images[] =
 #ifdef HAVE_PNG
     make_tuple<string, Size>("../cv/shared/pic1.png", Size(400, 300)),
 #endif
+    make_tuple<string, Size>("../highgui/readwrite/ordinary.bmp", Size(480, 272)),
 };
 
 TEST_P(Imgcodecs_Resize, imread_reduce_flags)


### PR DESCRIPTION
resolves #17751

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under OpenCV (BSD) License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [x] The PR is proposed to proper branch
- [x] There is reference to original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
