### PR TITLE
3.4 Allow first capture to return false

### DIFF
--- a/modules/videoio/src/cap_v4l.cpp
+++ b/modules/videoio/src/cap_v4l.cpp
@@ -1033,15 +1033,15 @@ bool CvCaptureCAM_V4L::grabFrame()
             return false;
         }
 
+        /* preparation is ok */
+        FirstCapture = false;
+
 #if defined(V4L_ABORT_BADJPEG)
         // skip first frame. it is often bad -- this is unnotied in traditional apps,
         //  but could be fatal if bad jpeg is enabled
         if (!read_frame_v4l2())
             return false;
 #endif
-
-        /* preparation is ok */
-        FirstCapture = false;
     }
     // In the case that the grab frame was without retrieveFrame
     if (bufferIndex >= 0)

--- a/modules/videoio/src/cap_v4l.cpp
+++ b/modules/videoio/src/cap_v4l.cpp
@@ -1033,6 +1033,7 @@ bool CvCaptureCAM_V4L::grabFrame()
             return false;
         }
 
+        // No need to skip this if the first read returns false
         /* preparation is ok */
         FirstCapture = false;
 


### PR DESCRIPTION
### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under OpenCV (BSD) License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [x] The PR is proposed to proper branch
- [ ] There is reference to original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake

I am working with a triggered camera that uses v4l2 in Linux.  Because it is a triggered camera, a "select timeout" is very likely.  In the function `CvCaptureCAM_V4L::grabFrame`, there is an initialization process that is conditionally dependent on the variable `FirstCapture` being `True`.   If the first call to `read_frame_v4l2` returns `False`, the `FirstCapture` variable is never set to `True`.  This will cause a re-initialization on the next iteration along with impassible failure.  The following output is generated using OPENCV_LOG_LEVEL=DEBUG:
```none
[DEBUG:1] VIDEOIO(V4L2:/dev/video2): tryIoctl(3, VIDIOC_QBUF(3227014671), failIfBusy=1)                              
[DEBUG:1] VIDEOIO(V4L2:/dev/video2): call ioctl(3, VIDIOC_QBUF(3227014671), ...) => -1    errno=22 (Invalid argument)
[DEBUG:1] VIDEOIO(V4L2:/dev/video2): failed VIDIOC_QBUF (buffer=0): errno=22 (Invalid argument)                      
```
