### PR TITLE
Fixed checkMasks in DescriptorMatcher with train descs in UMats

### DIFF
--- a/modules/features2d/src/matchers.cpp
+++ b/modules/features2d/src/matchers.cpp
@@ -622,15 +622,20 @@ void DescriptorMatcher::checkMasks( InputArrayOfArrays _masks, int queryDescript
     if( isMaskSupported() && !masks.empty() )
     {
         // Check masks
-        size_t imageCount = std::max(trainDescCollection.size(), utrainDescCollection.size() );
+        const size_t imageCount = std::max(trainDescCollection.size(), utrainDescCollection.size() );
         CV_Assert( masks.size() == imageCount );
         for( size_t i = 0; i < imageCount; i++ )
         {
-            if( !masks[i].empty() && (!trainDescCollection[i].empty() || !utrainDescCollection[i].empty() ) )
+            if (masks[i].empty())
+                continue;
+            const bool hasTrainDesc = !trainDescCollection.empty() && !trainDescCollection[i].empty();
+            const bool hasUTrainDesc = !utrainDescCollection.empty() && !utrainDescCollection[i].empty();
+            if (hasTrainDesc || hasUTrainDesc)
             {
-                int rows = trainDescCollection[i].empty() ? utrainDescCollection[i].rows : trainDescCollection[i].rows;
-                    CV_Assert( masks[i].rows == queryDescriptorsCount &&
-                        masks[i].cols == rows && masks[i].type() == CV_8UC1);
+                const int rows = hasTrainDesc ? trainDescCollection[i].rows : utrainDescCollection[i].rows;
+                CV_Assert(masks[i].type() == CV_8UC1
+                    && masks[i].rows == queryDescriptorsCount
+                    && masks[i].cols == rows);
             }
         }
     }

--- a/modules/features2d/test/test_matchers_algorithmic.cpp
+++ b/modules/features2d/test/test_matchers_algorithmic.cpp
@@ -565,7 +565,6 @@ TEST(Features2d_DMatch, issue_11855)
                                         1, 1, 1);
     Mat targets = (Mat_<uchar>(2, 3) << 1, 1, 1,
                                         0, 0, 0);
-
     Ptr<BFMatcher> bf = BFMatcher::create(NORM_HAMMING, true);
     vector<vector<DMatch> > match;
     bf->knnMatch(sources, targets, match, 1, noArray(), true);
@@ -575,6 +574,20 @@ TEST(Features2d_DMatch, issue_11855)
     EXPECT_EQ(1, match[0][0].queryIdx);
     EXPECT_EQ(0, match[0][0].trainIdx);
     EXPECT_EQ(0.0f, match[0][0].distance);
+}
+
+TEST(Features2d_DMatch, issue_17771)
+{
+    Mat sources = (Mat_<uchar>(2, 3) << 1, 1, 0,
+                                        1, 1, 1);
+    Mat targets = (Mat_<uchar>(2, 3) << 1, 1, 1,
+                                        0, 0, 0);
+    UMat usources = sources.getUMat(ACCESS_READ);
+    UMat utargets = targets.getUMat(ACCESS_READ);
+    vector<vector<DMatch> > match;
+    Ptr<BFMatcher> ubf = BFMatcher::create(NORM_HAMMING);
+    Mat mask = (Mat_<uchar>(2, 2) << 1, 0, 0, 1);
+    EXPECT_NO_THROW(ubf->knnMatch(usources, utargets, match, 1, mask, true));
 }
 
 }} // namespace


### PR DESCRIPTION
resolves #17771

Applied patch from the issue + minor refactoring and formatting

<cut/>

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under OpenCV (BSD) License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [x] The PR is proposed to proper branch
- [x] There is reference to original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake

```
allow_multiple_commits=1
```