### PR TITLE
cuda4dnn(concat): fix concat fusion to work with arbitary axis

### DIFF
--- a/modules/dnn/src/dnn.cpp
+++ b/modules/dnn/src/dnn.cpp
@@ -2972,7 +2972,6 @@ struct Net::Impl : public detail::NetImplBase
                             ld.outputBlobsWrappers[0] = wrap(output);
 #endif
                         std::vector<Range> chrange(output.dims, Range::all());
-
                         int ofs = 0;
                         for( i = 0; i < ninputs; i++ )
                         {
@@ -3000,9 +2999,9 @@ struct Net::Impl : public detail::NetImplBase
                             if (preferableBackend == DNN_BACKEND_CUDA)
                             {
                                 auto cuda_wrapper = wrap(output).dynamicCast<CUDABackendWrapper>();
-                                auto offset = chrange[1].start * (output.size[2] * output.size[3]);
-                                auto shape = MatShape{1, chrange[1].size(), output.size[2], output.size[3]};
-                                cuda_wrapper->update(shape, offset);
+                                auto offset = chrange[axis].start * output_slice.total(axis + 1, output.dims);
+                                auto new_shape = shape(output_slice);
+                                cuda_wrapper->update(new_shape, offset);
                                 inp_i_data->outputBlobsWrappers[pin.oid] = cuda_wrapper.staticCast<BackendWrapper>();
                             }
 #endif


### PR DESCRIPTION
fixes #17796 

There were some CUDA backend specific changes in `dnn.cpp` which weren't done in #17752. This caused tests to fail on master.

All tests pass with this PR.

Sorry for the delay.

<cut/>

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under OpenCV (BSD) License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [x] The PR is proposed to proper branch
- [ ] There is reference to original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake

```
force_builders=Custom
buildworker:Custom=linux-4
build_image:Custom=ubuntu-cuda:18.04
```