### PR TITLE
fixed issue #17412

### DIFF
--- a/modules/core/src/persistence.cpp
+++ b/modules/core/src/persistence.cpp
@@ -1819,7 +1819,6 @@ void FileStorage::endWriteStruct()
 
 FileStorage::~FileStorage()
 {
-    p.release();
 }
 
 bool FileStorage::open(const String& filename, int flags, const String& encoding)

--- a/modules/core/test/test_io.cpp
+++ b/modules/core/test/test_io.cpp
@@ -1772,4 +1772,20 @@ TEST(Core_InputOutput, FileStorage_open_empty_16823)
     EXPECT_EQ(0, remove(fname.c_str()));
 }
 
+TEST(Core_InputOutput, FileStorage_copy_constructor_17412)
+{
+    std::string fname = tempfile("test.yml");
+    FileStorage fs_orig(fname, cv::FileStorage::WRITE);
+    fs_orig << "string" << "wat";
+    fs_orig.release();
+
+    // crash:
+    cv::FileStorage fs;
+    fs = cv::FileStorage(fname,  cv::FileStorage::READ);
+    std::string s;
+    fs["string"] >> s;
+    EXPECT_EQ(s, "wat");
+    EXPECT_EQ(0, remove(fname.c_str()));
+}
+
 }} // namespace

--- a/modules/core/test/test_io.cpp
+++ b/modules/core/test/test_io.cpp
@@ -1779,7 +1779,7 @@ TEST(Core_InputOutput, FileStorage_copy_constructor_17412)
     fs_orig << "string" << "wat";
     fs_orig.release();
 
-    // crash:
+    // no crash anymore
     cv::FileStorage fs;
     fs = cv::FileStorage(fname,  cv::FileStorage::READ);
     std::string s;


### PR DESCRIPTION
Issue: https://github.com/opencv/opencv/issues/17412
It replaces https://github.com/opencv/opencv/pull/17458

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under OpenCV (BSD) License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [x] The PR is proposed to proper branch
- [x] There is reference to original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
