### PR TITLE
GAPI: GAPI_LOG_DEBUG facility

### DIFF
--- a/modules/gapi/src/logger.hpp
+++ b/modules/gapi/src/logger.hpp
@@ -13,9 +13,11 @@
 #  include "opencv2/core/utils/logger.hpp"
 #  define GAPI_LOG_INFO(tag, ...)    CV_LOG_INFO(tag, __VA_ARGS__)
 #  define GAPI_LOG_WARNING(tag, ...) CV_LOG_WARNING(tag, __VA_ARGS__)
+#  define GAPI_LOG_DEBUG(tag, ...)    CV_LOG_DEBUG(tag, __VA_ARGS__)
 #else
 #  define GAPI_LOG_INFO(tag, ...)
 #  define GAPI_LOG_WARNING(tag, ...)
+#  define GAPI_LOG_DEBUG(tag, ...)
 #endif //  !defined(GAPI_STANDALONE)
 
 


### PR DESCRIPTION
This patch add missing `GAPI_LOG_DEBUG`  facility.

<cut/>

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under OpenCV (BSD) License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [x] The PR is proposed to proper branch
- [x] There is reference to original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake

```
force_builders=ARMv7,Custom
build_image:Custom=centos:7
buildworker:Custom=linux-1
build_gapi_standalone:Custom=ade-0.1.1f

build_gapi_standalone:Linux x64=ade-0.1.1f
build_gapi_standalone:Win64=ade-0.1.1f
build_gapi_standalone:Mac=ade-0.1.1f
build_gapi_standalone:Linux x64 Debug=ade-0.1.1f
```