### PR TITLE
GAPI: fix warnings in own::Mat default generated constructors/assign op

### DIFF
--- a/modules/gapi/include/opencv2/gapi/own/mat.hpp
+++ b/modules/gapi/include/opencv2/gapi/own/mat.hpp
@@ -124,11 +124,11 @@ namespace cv { namespace gapi { namespace own {
            data = ptr(roi.y, roi.x);
         }
 
-        Mat(Mat const& src) = default;
-        Mat(Mat&& src) = default;
+        Mat(Mat const& ) = default;
+        Mat(Mat&& ) = default;
 
-        Mat& operator=(Mat const& src) = default;
-        Mat& operator=(Mat&& src) = default;
+        Mat& operator=(Mat const& ) = default;
+        Mat& operator=(Mat&& ) = default;
 
         /** @brief Sets all or some of the array elements to the specified value.
         @param s Assigned scalar converted to the actual array type.


### PR DESCRIPTION
Made arguments unnamed for explicitly-defaulted constructors and assign operators to avoid compiler warnings

  
### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under OpenCV (BSD) License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [x] The PR is proposed to proper branch
- [x] There is reference to original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake

```
force_builders=ARMv7,Custom
build_image:Custom=centos:7
buildworker:Custom=linux-1
build_gapi_standalone:Custom=ade-0.1.1f

build_gapi_standalone:Linux x64=ade-0.1.1f
build_gapi_standalone:Win64=ade-0.1.1f
build_gapi_standalone:Mac=ade-0.1.1f
build_gapi_standalone:Linux x64 Debug=ade-0.1.1f
```