### PR TITLE
added depth-wise convolution; gives ~20-40% performance improvement on MobileSSD networks

### DIFF
--- a/modules/dnn/src/layers/convolution_layer.cpp
+++ b/modules/dnn/src/layers/convolution_layer.cpp
@@ -1040,7 +1040,7 @@ public:
                     const float* wptr = wptr_orig + cn0*karea;
                     // we apply [Channels][P]ReLU (if any) during the final pass only.
                     const float* relu = cn1 == inpCn && reluptr_ ? reluptr_ + startOutCn : 0;
-                    const int blk_size = depthWiseConvolution ? outPlaneSize : BLK_SIZE;
+                    const int blk_size = depthWiseConvolution ? (int)outPlaneSize : (int)BLK_SIZE;
 
                     for( int ofs0 = stripeStart; ofs0 < stripeEnd; ofs0 += blk_size )
                     {

--- a/modules/dnn/src/layers/convolution_layer.cpp
+++ b/modules/dnn/src/layers/convolution_layer.cpp
@@ -833,6 +833,7 @@ public:
         bool useAVX;
         bool useAVX2;
         bool useAVX512;
+        int blk_size_cn;
 
         ParallelConv()
             : input_(0), weights_(0), output_(0), ngroups_(0), nstripes_(0),
@@ -889,11 +890,16 @@ public:
             p.useAVX2   = checkHardwareSupport(CPU_AVX2) && isConv2D;
             p.useAVX512 = CV_CPU_HAS_SUPPORT_AVX512_SKX  && isConv2D;
 
-            int ncn = std::min(inpCn, (int)BLK_SIZE_CN);
-
             int kernel_d = !isConv2D? kernel_size[0] : 1;
             int kernel_h = kernel_size[kernel_size.size() - 2];
             int kernel_w = kernel_size.back();
+
+            int blk_size_cn0 = cvCeil(800./(kernel_w*kernel_h));
+            int ncn = 16;
+            while (ncn*2 < blk_size_cn0 && ncn < inpCn)
+                ncn *= 2;
+            ncn = std::min(ncn, inpCn);
+            p.blk_size_cn = ncn;
 
             int dil_d = !isConv2D? dilations[0] : 1;
             int dil_h = dilations[dilations.size() - 2];
@@ -962,14 +968,14 @@ public:
             int dilation_w = dilations.back();
 
             int i, j, k, d;
-            size_t inpPlaneSize = input_->total(2);
-            size_t outPlaneSize = output_->total(2);
+            int inpPlaneSize = (int)input_->total(2);
+            int outPlaneSize = (int)output_->total(2);
             bool is1x1 = is1x1_;
 
             int stripesPerSample;
-            size_t stripeSize;
+            int stripeSize;
             Range r = r0;
-            bool depthWiseConvolution = !is1x1 && isConv2D && ngroups > 1 && batchSize == ngroups && inpCn == 1 &&
+            bool depthWiseConvolution = !is1x1 && isConv2D && ngroups > 1 && inpCn == 1 &&
                 outCn == 1 && kernel_d == 1 && dilation_d == 1 && stride_d == 0 && pad_d == 0 &&
                 width >= 16 + dilation_w*(kernel_w - 1);
             // for now only 3x3 depth-wise convolutions are supported
@@ -981,7 +987,7 @@ public:
             if( !depthWiseConvolution && nstripes >= batchSize*2 )
             {
                 stripesPerSample = nstripes/batchSize;
-                stripeSize = alignSize((outPlaneSize + stripesPerSample - 1)/stripesPerSample, valign);
+                stripeSize = (int)alignSize((outPlaneSize + stripesPerSample - 1)/stripesPerSample, valign);
                 stripeSize = std::min(stripeSize, outPlaneSize);
             }
             else
@@ -1000,13 +1006,18 @@ public:
             const float* biasptr_ = &biasvec_->at(0);
             const float* reluptr_ = reluslope_->empty() ? 0 : &reluslope_->at(0);
             float* data_out0_ = output_->ptr<float>();
-            size_t rowbufsz = (size_t)karea*BLK_SIZE_CN*BLK_SIZE;
-            AutoBuffer<float> rowbuf0_(rowbufsz + valign);
-            float* rowbuf0 = alignPtr(rowbuf0_.data(), (int)(valign*sizeof(float)));
+            AutoBuffer<float> rowbuf0_;
+            float* rowbuf0 = 0;
+            bool use_rowbuf = !depthWiseConvolution;
+            int blk_size = depthWiseConvolution ? outPlaneSize : min((int)BLK_SIZE, stripeSize);
 
             // im2row buffer is not used for depth-wise convolution
-            if(!depthWiseConvolution)
+            if(use_rowbuf)
             {
+                size_t rowbufsz = alignSize(karea*blk_size_cn, valign)*min((int)BLK_SIZE, blk_size);
+                //printf("karea=%d, blk_size_cn=%d, rowbufsz=%d, stripeSize=%d\n", karea, blk_size_cn, (int)rowbufsz, stripeSize);
+                rowbuf0_.allocate(rowbufsz + valign);
+                rowbuf0 = alignPtr(rowbuf0_.data(), (int)(valign*sizeof(float)));
                 // we clear the buffer once; ultimately, it lets us to avoid
                 // tail processing after running the unrolled/vectorized loop.
                 // the main idea is to make sure that the tail (a.k.a. padding) of each row
@@ -1032,19 +1043,19 @@ public:
                 const float* wptr_orig = wptr_orig_ + wstep*startOutCn;
                 const float* biasptr = biasptr_ + startOutCn;
 
-                for( int cn0 = 0; cn0 < inpCn; cn0 += BLK_SIZE_CN )
+                for( int cn0 = 0; cn0 < inpCn; cn0 += blk_size_cn )
                 {
-                    int cn1 = std::min(cn0 + BLK_SIZE_CN, inpCn);
+                    int cn1 = std::min(cn0 + blk_size_cn, inpCn);
                     int ncn = cn1 - cn0, vsz = karea*ncn;
                     int vsz_a = (int)alignSize(vsz, valign);
                     const float* wptr = wptr_orig + cn0*karea;
                     // we apply [Channels][P]ReLU (if any) during the final pass only.
                     const float* relu = cn1 == inpCn && reluptr_ ? reluptr_ + startOutCn : 0;
-                    const int blk_size = depthWiseConvolution ? (int)outPlaneSize : (int)BLK_SIZE;
 
                     for( int ofs0 = stripeStart; ofs0 < stripeEnd; ofs0 += blk_size )
                     {
                         int ofs, ofs1 = std::min(ofs0 + blk_size, stripeEnd);
+                        int bsz = ofs1 - ofs0;
 
                         int out_d = ofs0 / (outH * outW);
                         int out_i = (ofs0 - out_d * outH * outW) / outW;
@@ -1059,14 +1070,14 @@ public:
 
                         #if CV_TRY_AVX2
                             if(useAVX2)
-                                opt_AVX2::fastBitwiseConv(wptr, kernel_h, kernel_w,
+                                opt_AVX2::fastDepthwiseConv(wptr, kernel_h, kernel_w,
                                     stride_h, stride_w, dilation_h, dilation_w, pad_t, pad_l,
                                     biasptr, relu, inptr_, height, width, outptr_, out_d, outH, outW);
                             else
                         #endif
                         #if CV_TRY_AVX
                             if(useAVX)
-                                opt_AVX::fastBitwiseConv(wptr, kernel_h, kernel_w,
+                                opt_AVX::fastDepthwiseConv(wptr, kernel_h, kernel_w,
                                     stride_h, stride_w, dilation_h, dilation_w, pad_t, pad_l,
                                     biasptr, relu, inptr_, height, width, outptr_, out_d, outH, outW);
                             else
@@ -1112,7 +1123,7 @@ public:
                                     // maybe with AVX or AVX512 strided depthwise convolution
                                     // can be accelerated with vector code, but with 4xfloat vectors
                                     // it's hardly the case
-                                    if( stride_w == 1 && stride_h == 1 )
+                                    if( stride_w == 1 )
                                     {
                                         const int VECSZ = v_float32::nlanes;
                                         const int out_delta = VECSZ/stride_w;
@@ -1122,8 +1133,12 @@ public:
                                         v_float32 z = vx_setzero_f32(), vbias = vx_setall_f32(bias), vrc = vx_setall_f32(relu_coeff);
                                         for( ; out_j < outW1; out_j += out_delta )
                                         {
-                                            if (out_j + out_delta > outW1 && out_j > pad_l)
+                                            if (out_j + out_delta > outW1)
+                                            {
+                                                if (out_j <= pad_l)
+                                                    break;
                                                 out_j = outW1 - out_delta;
+                                            }
                                             int in_j = out_j * stride_w - pad_l;
                                             v_float32 v00 = vx_load(imgptr0 + in_j),
                                                       v01 = vx_load(imgptr0 + in_j + dilation_w),
@@ -1191,6 +1206,50 @@ public:
 
                         if (isConv2D)
                         {
+                            if( is1x1 && stride_w == 1 && stride_h == 1 )
+                            {
+                                const float* imgptr = data_inp0 + (cn0*height + out_i)*width + out_j;
+                                for( int j = 0; j < bsz; j++, rowbuf += vsz_a )
+                                {
+                                    if( j + 4 <= bsz )
+                                    {
+                                        k = 0;
+                                    #if CV_SIMD128
+                                        for( ; k <= vsz - 4; k += 4 )
+                                        {
+                                            const float* inp = imgptr + j + k*inpPlaneSize;
+                                            v_float32x4 p0 = v_load(inp), p1 = v_load(inp + inpPlaneSize);
+                                            v_float32x4 p2 = v_load(inp + inpPlaneSize*2), p3 = v_load(inp + inpPlaneSize*3);
+                                            v_float32x4 r0, r1, r2, r3;
+                                            v_transpose4x4(p0, p1, p2, p3, r0, r1, r2, r3);
+                                            v_store(rowbuf + k, r0);
+                                            v_store(rowbuf + k + vsz_a, r1);
+                                            v_store(rowbuf + k + vsz_a*2, r2);
+                                            v_store(rowbuf + k + vsz_a*3, r3);
+                                        }
+                                    #endif
+                                        for( ; k < vsz; k++ )
+                                        {
+                                            const float* inp = imgptr + j + k*inpPlaneSize;
+                                            float v0 = inp[0], v1 = inp[1], v2 = inp[2], v3 = inp[3];
+                                            rowbuf[k] = v0;
+                                            rowbuf[k + vsz_a] = v1;
+                                            rowbuf[k + vsz_a*2] = v2;
+                                            rowbuf[k + vsz_a*3] = v3;
+                                        }
+                                        j += 3;
+                                        rowbuf += vsz_a*3;
+                                    }
+                                    else
+                                    {
+                                        for( k = 0; k < vsz; k++ )
+                                        {
+                                            rowbuf[k] = imgptr[j + k*inpPlaneSize];
+                                        }
+                                    }
+                                }
+                            }
+                            else
                             for( ofs = ofs0; ofs < ofs1; out_j = 0, ++out_i )
                             {
                                 int delta = std::min(ofs1 - ofs, outW - out_j);
@@ -1310,7 +1369,6 @@ public:
 
                         // now compute dot product of the weights
                         // and im2row-transformed part of the tensor
-                        int bsz = ofs1 - ofs0;
                     #if CV_TRY_AVX512_SKX
                         /* AVX512 convolution requires an alignment of 16, and ROI is only there for larger vector sizes */
                         if(useAVX512)

--- a/modules/dnn/src/layers/layers_common.simd.hpp
+++ b/modules/dnn/src/layers/layers_common.simd.hpp
@@ -398,9 +398,9 @@ void fastBitwiseConv( const float* wptr,
                 }
                 if (stride_w == 2)
                 {
-                    __m256 hi = _mm256_zextps128_ps256 (_mm256_extractf128_ps (vout0, 1));
+                    __m256 hi = _mm256_castps128_ps256(_mm256_extractf128_ps (vout0, 1));
                     __m256 even = _mm256_shuffle_ps(vout0, hi, 0x88);
-                    _mm256_storeu_ps(outptr + out_j, even);
+                    _mm_storeu_ps(outptr + out_j, _mm256_castps256_ps128(even));
                 }
                 else
                     _mm256_storeu_ps(outptr + out_j, vout0);


### PR DESCRIPTION
Measured on 8-core Xeon E5-1680v2 (IvyBridge)

<cut/>

```
Geometric mean (ms)

                    Name of Test                           dnn             dnn             dnn      
                                                     20200716-002758 20200717-055311 20200717-055311
                                                                                           vs       
                                                                                           dnn      
                                                                                     20200716-002758
                                                                                       (x-factor)   
MobileNet_SSD_Caffe::DNNTestNetwork::OCV/CPU             25.192          18.289           1.38      
MobileNet_SSD_v1_TensorFlow::DNNTestNetwork::OCV/CPU     27.942          20.386           1.37      
MobileNet_SSD_v2_TensorFlow::DNNTestNetwork::OCV/CPU     39.447          31.799           1.24
```

- [x] I agree to contribute to the project under OpenCV (BSD) License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [x] The PR is proposed to proper branch
- [x] There is reference to original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake

```
force_builders=Linux AVX2,Custom
buildworker:Custom=linux-3
build_image:Custom=ubuntu:18.04
CPU_BASELINE:Custom=AVX512_SKX
disable_ipp=ON
```