### PR TITLE
cuda::flip - Use in-place npp function for inplace arguments

### DIFF
--- a/modules/cudaarithm/test/test_core.cpp
+++ b/modules/cudaarithm/test/test_core.cpp
@@ -279,6 +279,19 @@ CUDA_TEST_P(Flip, Accuracy)
     EXPECT_MAT_NEAR(dst_gold, dst, 0.0);
 }
 
+CUDA_TEST_P(Flip, AccuracyInplace)
+{
+    cv::Mat src = randomMat(size, type);
+
+    cv::cuda::GpuMat srcDst = loadMat(src, useRoi);
+    cv::cuda::flip(srcDst, srcDst, flip_code);
+
+    cv::Mat dst_gold;
+    cv::flip(src, dst_gold, flip_code);
+
+    EXPECT_MAT_NEAR(dst_gold, srcDst, 0.0);
+}
+
 INSTANTIATE_TEST_CASE_P(CUDA_Arithm, Flip, testing::Combine(
     ALL_DEVICES,
     DIFFERENT_SIZES,


### PR DESCRIPTION
Resolves #17840 

https://github.com/opencv/opencv/pull/17863#issuecomment-661536808

~~`cv::cuda::GpuMat::create` does not allocate a new GpuMat if required size and type equals existing size and type.~~
https://github.com/opencv/opencv/blob/bf8136eaa68d8f17edba929622ddba05f95c89d8/modules/core/src/cuda/gpu_mat.cu#L160-L161

~~This PR implements `cv::cuda::detachOutput` to allocate a new GpuMat in such cases. Unfortunately, `_dst` is const so assignment is not possible. Instead, this implementation clones `src`.~~

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under OpenCV (BSD) License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [x] The PR is proposed to proper branch
- [x] There is reference to original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
