### PR TITLE
release: OpenCV 3.4.11

### DIFF
--- a/modules/core/include/opencv2/core/version.hpp
+++ b/modules/core/include/opencv2/core/version.hpp
@@ -8,7 +8,7 @@
 #define CV_VERSION_MAJOR    3
 #define CV_VERSION_MINOR    4
 #define CV_VERSION_REVISION 11
-#define CV_VERSION_STATUS   "-pre"
+#define CV_VERSION_STATUS   ""
 
 #define CVAUX_STR_EXP(__A)  #__A
 #define CVAUX_STR(__A)      CVAUX_STR_EXP(__A)


### PR DESCRIPTION
OpenCV 3.4.11

relates #17501


<cut/>

<details>

<summary>VirusTotal scan results:</summary>

[opencv_world3411.dll (vc14)](https://www.virustotal.com/gui/file/b74a7cf8d3d4adbc749cb45b3e270ad10937ff4dc02f206aa7c31df180ea91cf/detection)
[opencv_world3411d.dll (vc14)](https://www.virustotal.com/gui/file/35df2c2a211528f9966e2feaf88f25862e746389413300c0d697e8516db27d5c/detection)
[opencv_world3411.dll (vc15)](https://www.virustotal.com/gui/file/781138599cae9e9abc1dd353518635a6df40c440d4048f233e2380fe7011fda8/detection)
[opencv_world3411d.dll (vc15)](https://www.virustotal.com/gui/file/e6aeb211c7a542a003197135aca789fa1a42681907b6e328d20eabe2732fe5e9/detection)

[opencv_ffmpeg3411_64.dll](https://www.virustotal.com/gui/file/431947a3feb6e67f0a9d1bcc9480a0fcde16c02fc355e8be0fee186c93cc23a2/detection)
[opencv_ffmpeg3411.dll](https://www.virustotal.com/gui/file/59b70d6744a03db962117d2787369dc6b90a3ff17a39c40165e5cdfc4bc0303d/detection)

</details>
