### PR TITLE
Merge 3.4

### DIFF
--- a/modules/imgproc/src/color_yuv.dispatch.cpp
+++ b/modules/imgproc/src/color_yuv.dispatch.cpp
@@ -406,6 +406,8 @@ void cvtColorTwoPlaneYUV2BGRpair( InputArray _ysrc, InputArray _uvsrc, OutputArr
 
     Mat ysrc = _ysrc.getMat(), uvsrc = _uvsrc.getMat();
 
+    CV_CheckEQ(ysrc.step, uvsrc.step, "");
+
     _dst.create( ysz, CV_MAKETYPE(depth, dcn));
     Mat dst = _dst.getMat();
 

--- a/modules/imgproc/test/test_color.cpp
+++ b/modules/imgproc/test/test_color.cpp
@@ -3072,4 +3072,21 @@ TEST(ImgProc_RGB2YUV, regression_13668)
     EXPECT_EQ(res, ref);
 }
 
+TEST(ImgProc_cvtColorTwoPlane, missing_check_17036)  // test can be removed if required feature is implemented
+{
+    std::vector<uchar> y_data(700 * 480);
+    std::vector<uchar> uv_data(640 * 240);
+
+    Mat y_plane_padding(480, 640, CV_8UC1, y_data.data(), 700);  // with stride
+    Mat uv_plane(240, 320, CV_8UC2, uv_data.data());
+
+    Mat result;
+
+    EXPECT_THROW(
+        cvtColorTwoPlane(y_plane_padding, uv_plane, result, COLOR_YUV2RGB_NV21);
+        , cv::Exception
+    );
+}
+
+
 }} // namespace


### PR DESCRIPTION
#17865 from alalek:add_missing_check_17036

Previous "Merge 3.4": #17866

<cut/>

```
Xbuild_image:Custom Win=winpack-dldt-2020.4
Xbuild_image:Custom Win=winpack-dldt-2020.3

buildworker:Win64 OpenCL=windows-2
Xbuildworker:Custom=linux-1,linux-2,linux-4
build_image:Docs=docs-js
Xbuild_image:Custom=javascript
#build_image:Custom=powerpc64le
#build_image:Custom=ubuntu-openvino-2019r3.0:16.04
#build_image:Custom=ubuntu-openvino-2020.3.0:16.04
build_image:Custom=ubuntu-openvino-2020.4.0:16.04
buildworker:Custom=linux-1
#build_image:Custom=ubuntu-vulkan:16.04
#buildworker:Custom=linux-4
#build_image:Custom=fedora:28
#build_image:Custom=ubuntu-cuda:16.04
#build_image:Custom=ubuntu-clang:18.04
#build_image:Custom=ubuntu:20.04
#buildworker:Custom=linux-1
#build_image:Custom=javascript-simd
#build_image:Custom=mips64el
#build_image:Custom Mac=openvino-2019r3.0
#build_image:Custom Mac=openvino-2020.3.0
build_image:Custom Mac=openvino-2020.4.0
#build_image:Custom Win=openvino-2019r3.0
#build_image:Custom Win=openvino-2020.3.0
build_image:Custom Win=openvino-2020.4.0
test_bigdata:Custom Win=1
test_filter:Custom Win=*
test_modules=dnn,python2,python3,java
test_opencl:Custom Win=OFF
#build_image:Custom Win=msvs2017
#build_image:Custom Win=msvs2019
test_modules:Custom Mac=dnn,java,python3
```
