### PR TITLE
GAPI: KW fix - video_tests

### DIFF
--- a/modules/gapi/test/common/gapi_video_tests_common.hpp
+++ b/modules/gapi/test/common/gapi_video_tests_common.hpp
@@ -43,7 +43,7 @@ inline void initTrackingPointsArray(std::vector<cv::Point2f>& points, int width,
 
     points.clear();
     GAPI_Assert((nPointsX >= 0) && (nPointsY) >= 0);
-    points.reserve(static_cast<size_t>(nPointsX * nPointsY));
+    points.reserve(static_cast<size_t>(nPointsX) * nPointsY);
 
     for (int x = stepX / 2; x < width; x += stepX)
     {
@@ -80,9 +80,7 @@ struct OptFlowLKTestOutput
 
 struct BuildOpticalFlowPyramidTestParams
 {
-    BuildOpticalFlowPyramidTestParams(): fileName(""), winSize(-1), maxLevel(-1),
-                                         withDerivatives(false), pyrBorder(-1),
-                                         derivBorder(-1), tryReuseInputImage(false) { }
+    BuildOpticalFlowPyramidTestParams() = default;
 
     BuildOpticalFlowPyramidTestParams(const std::string& name, int winSz, int maxLvl,
                                       bool withDeriv, int pBorder, int dBorder,

--- a/modules/gapi/test/common/gapi_video_tests_common.hpp
+++ b/modules/gapi/test/common/gapi_video_tests_common.hpp
@@ -43,7 +43,7 @@ inline void initTrackingPointsArray(std::vector<cv::Point2f>& points, int width,
 
     points.clear();
     GAPI_Assert((nPointsX >= 0) && (nPointsY) >= 0);
-    points.reserve(static_cast<size_t>(nPointsX) * nPointsY);
+    points.reserve(nPointsX * nPointsY);
 
     for (int x = stepX / 2; x < width; x += stepX)
     {


### PR DESCRIPTION
 - fix numeric overflow due to incorrect type casting:
    The result of expression `nPointsX*nPointsY` generated 4-byte type while casting to a bigger size of 8-byte
 - remove unnecessary default constructor

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under OpenCV (BSD) License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [x] The PR is proposed to proper branch
- [ ] There is reference to original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake

```
force_builders=Custom,Custom Win,Custom Mac
build_gapi_standalone:Linux x64=ade-0.1.1f
build_gapi_standalone:Win64=ade-0.1.1f
build_gapi_standalone:Mac=ade-0.1.1f
build_gapi_standalone:Linux x64 Debug=ade-0.1.1f

Xbuild_image:Custom=centos:7
Xbuildworker:Custom=linux-1
build_gapi_standalone:Custom=ade-0.1.1f

build_image:Custom=ubuntu-openvino-2020.3.0:16.04
build_image:Custom Win=openvino-2020.3.0
build_image:Custom Mac=openvino-2020.3.0

test_modules:Custom=gapi
test_modules:Custom Win=gapi
test_modules:Custom Mac=gapi

buildworker:Custom=linux-1
# disabled due high memory usage: test_opencl:Custom=ON
test_opencl:Custom=OFF
test_bigdata:Custom=1
test_filter:Custom=*
```
