### PR TITLE
calib3d: calibrateHandEye - allow using Rodrigues vectors for rotation

### DIFF
--- a/modules/calib3d/src/calibration_handeye.cpp
+++ b/modules/calib3d/src/calibration_handeye.cpp
@@ -712,7 +712,10 @@ void calibrateHandEye(InputArrayOfArrays R_gripper2base, InputArrayOfArrays t_gr
     {
         Mat m = Mat::eye(4, 4, CV_64FC1);
         Mat R = m(Rect(0, 0, 3, 3));
-        R_gripper2base_[i].convertTo(R, CV_64F);
+        if(R_gripper2base_[i].size() == Size(3, 3))
+            R_gripper2base_[i].convertTo(R, CV_64F);
+        else
+            Rodrigues(R_gripper2base_[i], R);
 
         Mat t = m(Rect(3, 0, 1, 3));
         t_gripper2base_[i].convertTo(t, CV_64F);
@@ -727,7 +730,10 @@ void calibrateHandEye(InputArrayOfArrays R_gripper2base, InputArrayOfArrays t_gr
     {
         Mat m = Mat::eye(4, 4, CV_64FC1);
         Mat R = m(Rect(0, 0, 3, 3));
-        R_target2cam_[i].convertTo(R, CV_64F);
+        if(R_target2cam_[i].size() == Size(3, 3))
+            R_target2cam_[i].convertTo(R, CV_64F);
+        else
+            Rodrigues(R_target2cam_[i], R);
 
         Mat t = m(Rect(3, 0, 1, 3));
         t_target2cam_[i].convertTo(t, CV_64F);

--- a/modules/calib3d/test/test_calibration_hand_eye.cpp
+++ b/modules/calib3d/test/test_calibration_hand_eye.cpp
@@ -317,7 +317,10 @@ void CV_CalibrateHandEyeTest::simulateData(RNG& rng, int nPoses,
             t_gripper2base_noise.at<double>(2,0) += rng.gaussian(0.001);
         }
 
-        R_target2cam.push_back(T_target2cam(Rect(0, 0, 3, 3)));
+        // test rvec represenation
+        Mat rvec_target2cam;
+        cv::Rodrigues(T_target2cam(Rect(0, 0, 3, 3)), rvec_target2cam);
+        R_target2cam.push_back(rvec_target2cam);
         t_target2cam.push_back(T_target2cam(Rect(3, 0, 1, 3)));
     }
 }


### PR DESCRIPTION
the documentation [suggests using PnP](https://docs.opencv.org/trunk/d9/d0c/group__calib3d.html#gaebfc1c9f7434196a374c382abf43439b) for the camera pose, but solvePnP returns a Rodrigues vector and there are no checks warning you about this..

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under OpenCV (BSD) License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [x] The PR is proposed to proper branch
- [ ] There is reference to original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
