### PR TITLE
Fix ONNX loading in issues opencv#17516, opencv#17531

### DIFF
--- a/modules/dnn/src/onnx/onnx_importer.cpp
+++ b/modules/dnn/src/onnx/onnx_importer.cpp
@@ -933,6 +933,19 @@ void ONNXImporter::populateNet(Net dstNet)
                 Mat bias = getBlob(node_proto, constBlobs, 2);
                 layerParams.blobs.push_back(bias);
             }
+            if (constBlobs.find(node_proto.input(0)) != constBlobs.end())
+            {
+                Mat inputBuf = getBlob(node_proto, constBlobs, 0);
+
+                LayerParams constParams;
+                constParams.name = node_proto.input(0);
+                constParams.type = "Const";
+                constParams.blobs.push_back(inputBuf);
+
+                opencv_onnx::NodeProto proto;
+                proto.add_output(constParams.name);
+                addLayer(dstNet, constParams, proto, layer_id, outShapes);
+            }
 
             layerParams.set("num_output", layerParams.blobs[0].size[ind_num_out]);
             layerParams.set("bias_term", node_proto.input_size() == 3);

--- a/modules/dnn/test/test_onnx_importer.cpp
+++ b/modules/dnn/test/test_onnx_importer.cpp
@@ -608,7 +608,8 @@ TEST_P(Test_ONNX_layers, Pad2d_Unfused)
 
 TEST_P(Test_ONNX_layers, LinearWithConstant)
 {
-    applyTestTag(CV_TEST_TAG_DNN_SKIP_OPENCL_FP16);
+    if (target == DNN_TARGET_OPENCL_FP16)
+        applyTestTag(CV_TEST_TAG_DNN_SKIP_OPENCL_FP16);
 #if defined(INF_ENGINE_RELEASE) && INF_ENGINE_VER_MAJOR_LT(2020040000)
     applyTestTag(CV_TEST_TAG_DNN_SKIP_IE);
 #endif
@@ -617,7 +618,8 @@ TEST_P(Test_ONNX_layers, LinearWithConstant)
 
 TEST_P(Test_ONNX_layers, MatmulWithTwoInputs)
 {
-    applyTestTag(CV_TEST_TAG_DNN_SKIP_OPENCL_FP16);
+    if (target == DNN_TARGET_OPENCL_FP16)
+        applyTestTag(CV_TEST_TAG_DNN_SKIP_OPENCL_FP16);
 #if defined(INF_ENGINE_RELEASE) && INF_ENGINE_VER_MAJOR_LT(2020040000)
     applyTestTag(CV_TEST_TAG_DNN_SKIP_IE);
 #endif

--- a/modules/dnn/test/test_onnx_importer.cpp
+++ b/modules/dnn/test/test_onnx_importer.cpp
@@ -608,7 +608,7 @@ TEST_P(Test_ONNX_layers, Pad2d_Unfused)
 
 TEST_P(Test_ONNX_layers, LinearWithConstant)
 {
-    if (target == DNN_TARGET_OPENCL_FP16)
+    if (backend == DNN_BACKEND_OPENCV && target == DNN_TARGET_OPENCL_FP16)
         applyTestTag(CV_TEST_TAG_DNN_SKIP_OPENCL_FP16);
 #if defined(INF_ENGINE_RELEASE) && INF_ENGINE_VER_MAJOR_LT(2020040000)
     applyTestTag(CV_TEST_TAG_DNN_SKIP_IE);
@@ -618,7 +618,7 @@ TEST_P(Test_ONNX_layers, LinearWithConstant)
 
 TEST_P(Test_ONNX_layers, MatmulWithTwoInputs)
 {
-    if (target == DNN_TARGET_OPENCL_FP16)
+    if (backend == DNN_BACKEND_OPENCV && target == DNN_TARGET_OPENCL_FP16)
         applyTestTag(CV_TEST_TAG_DNN_SKIP_OPENCL_FP16);
 #if defined(INF_ENGINE_RELEASE) && INF_ENGINE_VER_MAJOR_LT(2020040000)
     applyTestTag(CV_TEST_TAG_DNN_SKIP_IE);

--- a/modules/dnn/test/test_onnx_importer.cpp
+++ b/modules/dnn/test/test_onnx_importer.cpp
@@ -608,6 +608,7 @@ TEST_P(Test_ONNX_layers, Pad2d_Unfused)
 
 TEST_P(Test_ONNX_layers, LinearWithConstant)
 {
+    applyTestTag(CV_TEST_TAG_DNN_SKIP_OPENCL_FP16);
 #if defined(INF_ENGINE_RELEASE) && INF_ENGINE_VER_MAJOR_LT(2020040000)
     applyTestTag(CV_TEST_TAG_DNN_SKIP_IE);
 #endif
@@ -616,6 +617,7 @@ TEST_P(Test_ONNX_layers, LinearWithConstant)
 
 TEST_P(Test_ONNX_layers, MatmulWithTwoInputs)
 {
+    applyTestTag(CV_TEST_TAG_DNN_SKIP_OPENCL_FP16);
 #if defined(INF_ENGINE_RELEASE) && INF_ENGINE_VER_MAJOR_LT(2020040000)
     applyTestTag(CV_TEST_TAG_DNN_SKIP_IE);
 #endif

--- a/modules/dnn/test/test_onnx_importer.cpp
+++ b/modules/dnn/test/test_onnx_importer.cpp
@@ -608,11 +608,17 @@ TEST_P(Test_ONNX_layers, Pad2d_Unfused)
 
 TEST_P(Test_ONNX_layers, LinearWithConstant)
 {
+#if defined(INF_ENGINE_RELEASE) && INF_ENGINE_VER_MAJOR_LT(2020040000)
+    applyTestTag(CV_TEST_TAG_DNN_SKIP_IE);
+#endif
     testONNXModels("lin_with_constant");
 }
 
 TEST_P(Test_ONNX_layers, MatmulWithTwoInputs)
 {
+#if defined(INF_ENGINE_RELEASE) && INF_ENGINE_VER_MAJOR_LT(2020040000)
+    applyTestTag(CV_TEST_TAG_DNN_SKIP_IE);
+#endif
     testONNXModels("matmul_with_two_inputs");
 }
 

--- a/modules/dnn/test/test_onnx_importer.cpp
+++ b/modules/dnn/test/test_onnx_importer.cpp
@@ -606,6 +606,16 @@ TEST_P(Test_ONNX_layers, Pad2d_Unfused)
     testONNXModels("ZeroPad2d");
 }
 
+TEST_P(Test_ONNX_layers, LinearWithConstant)
+{
+    testONNXModels("lin_with_constant");
+}
+
+TEST_P(Test_ONNX_layers, MatmulWithTwoInputs)
+{
+    testONNXModels("matmul_with_two_inputs");
+}
+
 INSTANTIATE_TEST_CASE_P(/*nothing*/, Test_ONNX_layers, dnnBackendsAndTargets());
 
 class Test_ONNX_nets : public Test_ONNX_layers


### PR DESCRIPTION
**Merge with extra:** opencv/opencv_extra#793

resolves #17516
resolves #17531
 
Also resolves untracked problem with constant input for Gemm layers

```
opencv_extra=testdata_for_17516_17531

force_builders=Custom,Custom Win,Custom Mac
build_image:Custom=ubuntu-openvino-2020.4.0:16.04
build_image:Custom Win=openvino-2020.2.0
build_image:Custom Mac=openvino-2020.3.0

test_modules:Custom=dnn,python2,python3,java
test_modules:Custom Win=dnn,python2,python3,java
test_modules:Custom Mac=dnn,python2,python3,java

buildworker:Custom=linux-1
# disabled due high memory usage: test_opencl:Custom=ON
test_opencl:Custom=OFF
test_bigdata:Custom=1
test_filter:Custom=*
```