### PR TITLE
cuda::GpuMat::convertTo - fix for in-place arguments

### DIFF
--- a/modules/core/src/cuda/gpu_mat.cu
+++ b/modules/core/src/cuda/gpu_mat.cu
@@ -561,7 +561,7 @@ void cv::cuda::GpuMat::convertTo(OutputArray _dst, int rtype, Stream& stream) co
         {convertToNoScale<double, uchar>, convertToNoScale<double, schar>, convertToNoScale<double, ushort>, convertToNoScale<double, short>, convertToNoScale<double, int>, convertToNoScale<double, float>, 0}
     };
 
-    funcs[sdepth][ddepth](reshape(1), dst.reshape(1), stream);
+    funcs[sdepth][ddepth](src.reshape(1), dst.reshape(1), stream);
 }
 
 void cv::cuda::GpuMat::convertTo(OutputArray _dst, int rtype, double alpha, double beta, Stream& stream) const
@@ -591,7 +591,7 @@ void cv::cuda::GpuMat::convertTo(OutputArray _dst, int rtype, double alpha, doub
         {convertToScale<double, uchar>, convertToScale<double, schar>, convertToScale<double, ushort>, convertToScale<double, short>, convertToScale<double, int>, convertToScale<double, float>, convertToScale<double, double>}
     };
 
-    funcs[sdepth][ddepth](reshape(1), dst.reshape(1), alpha, beta, stream);
+    funcs[sdepth][ddepth](src.reshape(1), dst.reshape(1), alpha, beta, stream);
 }
 
 void cv::cuda::convertFp16(InputArray _src, OutputArray _dst, Stream& stream)

--- a/modules/cudaarithm/test/test_gpumat.cpp
+++ b/modules/cudaarithm/test/test_gpumat.cpp
@@ -320,6 +320,65 @@ CUDA_TEST_P(GpuMat_ConvertTo, WithScaling)
     }
 }
 
+CUDA_TEST_P(GpuMat_ConvertTo, InplaceWithOutScaling)
+{
+    cv::Mat src = randomMat(size, depth1);
+
+    if ((depth1 == CV_64F || depth2 == CV_64F) && !supportFeature(devInfo, cv::cuda::NATIVE_DOUBLE))
+    {
+        try
+        {
+            cv::cuda::GpuMat d_srcDst = loadMat(src);
+            d_srcDst.convertTo(d_srcDst, depth2);
+        }
+        catch (const cv::Exception& e)
+        {
+            ASSERT_EQ(cv::Error::StsUnsupportedFormat, e.code);
+        }
+    }
+    else
+    {
+        cv::cuda::GpuMat d_srcDst = loadMat(src, useRoi);
+        d_srcDst.convertTo(d_srcDst, depth2);
+
+        cv::Mat dst_gold;
+        src.convertTo(dst_gold, depth2);
+
+        EXPECT_MAT_NEAR(dst_gold, d_srcDst, depth2 < CV_32F ? 1.0 : 1e-4);
+    }
+}
+
+
+CUDA_TEST_P(GpuMat_ConvertTo, InplaceWithScaling)
+{
+    cv::Mat src = randomMat(size, depth1);
+    double a = randomDouble(0.0, 1.0);
+    double b = randomDouble(-10.0, 10.0);
+
+    if ((depth1 == CV_64F || depth2 == CV_64F) && !supportFeature(devInfo, cv::cuda::NATIVE_DOUBLE))
+    {
+        try
+        {
+            cv::cuda::GpuMat d_srcDst = loadMat(src);
+            d_srcDst.convertTo(d_srcDst, depth2, a, b);
+        }
+        catch (const cv::Exception& e)
+        {
+            ASSERT_EQ(cv::Error::StsUnsupportedFormat, e.code);
+        }
+    }
+    else
+    {
+        cv::cuda::GpuMat d_srcDst = loadMat(src, useRoi);
+        d_srcDst.convertTo(d_srcDst, depth2, a, b);
+
+        cv::Mat dst_gold;
+        src.convertTo(dst_gold, depth2, a, b);
+
+        EXPECT_MAT_NEAR(dst_gold, d_srcDst, depth2 < CV_32F ? 1.0 : 1e-4);
+    }
+}
+
 INSTANTIATE_TEST_CASE_P(CUDA, GpuMat_ConvertTo, testing::Combine(
     ALL_DEVICES,
     DIFFERENT_SIZES,


### PR DESCRIPTION
Resolves #13092

If given in-place arguments to `GpuMat::convertTo`, `*this` and `dst` refers to the same newly allocated GpuMat after these two lines:
```
_dst.create(size(), rtype);
GpuMat dst = _dst.getGpuMat();
```

<cut/>

In consequence, `*this` refers to a different GpuMat from which `src` refers to.

Before this PR, in the following line:
```
funcs[sdepth][ddepth](reshape(1), dst.reshape(1), stream);
```
the first argument derives from `*this` which refers to the same data as `dst`.

So it should be fixed as the following line to make the first argument derive from `src`:
```
funcs[sdepth][ddepth](src.reshape(1), dst.reshape(1), stream);
                      ^^^^
```

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under OpenCV (BSD) License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [x] The PR is proposed to proper branch
- [x] There is reference to original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake


```
force_builders=Custom
buildworker:Custom=linux-4
build_image:Custom=ubuntu-cuda:18.04

allow_multiple_commits=1
```