### PR TITLE
Fix Carotene compilation with XCode

### DIFF
--- a/3rdparty/carotene/CMakeLists.txt
+++ b/3rdparty/carotene/CMakeLists.txt
@@ -40,4 +40,5 @@ if(WITH_NEON)
     target_compile_definitions(carotene_objs PRIVATE "-DWITH_NEON")
 endif()
 
-add_library(carotene STATIC EXCLUDE_FROM_ALL "$<TARGET_OBJECTS:carotene_objs>")
+# we add dummy file to fix XCode build
+add_library(carotene STATIC EXCLUDE_FROM_ALL "$<TARGET_OBJECTS:carotene_objs>" "${CAROTENE_SOURCE_DIR}/dummy.cpp")

--- a/3rdparty/carotene/hal/CMakeLists.txt
+++ b/3rdparty/carotene/hal/CMakeLists.txt
@@ -80,7 +80,8 @@ set_property(DIRECTORY APPEND PROPERTY COMPILE_DEFINITIONS ${carotene_defs})
 #    set_source_files_properties(impl.cpp $<TARGET_OBJECTS:carotene_objs> COMPILE_FLAGS "--param ipcp-unit-growth=100000 --param inline-unit-growth=100000 --param large-stack-frame-growth=5000")
   endif()
 
-add_library(tegra_hal STATIC $<TARGET_OBJECTS:carotene_objs>)
+# we add dummy file to fix XCode build
+add_library(tegra_hal STATIC $<TARGET_OBJECTS:carotene_objs> "dummy.cpp")
 set_target_properties(tegra_hal PROPERTIES ARCHIVE_OUTPUT_DIRECTORY ${3P_LIBRARY_OUTPUT_PATH})
 set(OPENCV_SRC_DIR "${CMAKE_SOURCE_DIR}")
 if(NOT BUILD_SHARED_LIBS)

--- a/3rdparty/carotene/hal/dummy.cpp
+++ b/3rdparty/carotene/hal/dummy.cpp
@@ -1,0 +1,2 @@
+// This file is needed for compilation on some platforms e.g. with XCode generator
+// Related issue: https://gitlab.kitware.com/cmake/cmake/-/issues/17457

--- a/3rdparty/carotene/src/dummy.cpp
+++ b/3rdparty/carotene/src/dummy.cpp
@@ -1,0 +1,2 @@
+// This file is needed for compilation on some platforms e.g. with XCode generator
+// Related issue: https://gitlab.kitware.com/cmake/cmake/-/issues/17457


### PR DESCRIPTION
When building with XCode for ARM, carotene and tegra_hal static libraries will be deleted. Probably caused by issue: https://gitlab.kitware.com/cmake/cmake/-/issues/17457

From cmake docs:

>Some native build systems may not like targets that have only object files, so consider adding at least one real source file

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under OpenCV (BSD) License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [x] The PR is proposed to proper branch
- [x] There is reference to original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
