### PR TITLE
Fix build of grfmt_jpeg2000.cpp (backported to 2.4)

### DIFF
--- a/modules/highgui/src/grfmt_jpeg2000.cpp
+++ b/modules/highgui/src/grfmt_jpeg2000.cpp
@@ -338,7 +338,7 @@ bool  Jpeg2KDecoder::readComponent8u( uchar *data, void *_buffer,
 
     for( y = 0; y < yend - ystart; )
     {
-        jas_seqent_t* pix_row = &jas_matrix_get( buffer, y / ystep, 0 );
+        jas_seqent_t* pix_row = jas_matrix_getref( buffer, y / ystep, 0 );
         uchar* dst = data + (y - yoffset) * step - xoffset;
 
         if( xstep == 1 )
@@ -402,7 +402,7 @@ bool  Jpeg2KDecoder::readComponent16u( unsigned short *data, void *_buffer,
 
     for( y = 0; y < yend - ystart; )
     {
-        jas_seqent_t* pix_row = &jas_matrix_get( buffer, y / ystep, 0 );
+        jas_seqent_t* pix_row = jas_matrix_getref( buffer, y / ystep, 0 );
         ushort* dst = data + (y - yoffset) * step - xoffset;
 
         if( xstep == 1 )


### PR DESCRIPTION
This is #17983 backported to the 2.4 branch.

libjasper has recently changed `jas_matrix_get` from a macro to an inline function
(389951d071 in https://github.com/jasper-software/jasper), causing the build to fail.

Backported to 2.4 from f66fc199a20882c546fa31142e9c0f5a8b3cf983
