### PR TITLE
videoio: fix compilation with Aravis enabled

### DIFF
--- a/modules/videoio/src/cap_aravis.cpp
+++ b/modules/videoio/src/cap_aravis.cpp
@@ -502,7 +502,7 @@ double CvCaptureCAM_Aravis::getProperty( int property_id ) const
             }
             break;
 
-        case CAP_PROP_ARAVIS_AUTOTRIGGER:
+        case cv::CAP_PROP_ARAVIS_AUTOTRIGGER:
         {
             return allowAutoTrigger ? 1. : 0.;
         }
@@ -591,7 +591,7 @@ bool CvCaptureCAM_Aravis::setProperty( int property_id, double value )
             }
             break;
 
-        case CAP_PROP_ARAVIS_AUTOTRIGGER:
+        case cv::CAP_PROP_ARAVIS_AUTOTRIGGER:
             {
                 allowAutoTrigger = (bool) value;
             }


### PR DESCRIPTION
Hi,

Module videoio fails to compile on recent master if WITH_ARAVIS is set. GCC 9.3.0 reports the following errors:

`opencv/modules/videoio/src/cap_aravis.cpp:505:14: error: ‘CAP_PROP_ARAVIS_AUTOTRIGGER’ was not declared in this scope; did you mean ‘cv::CAP_PROP_ARAVIS_AUTOTRIGGER’?`

`opencv/modules/videoio/src/cap_aravis.cpp:594:14: error: ‘CAP_PROP_ARAVIS_AUTOTRIGGER’ was not declared in this scope; did you mean ‘cv::CAP_PROP_ARAVIS_AUTOTRIGGER’?`

The proposed patch fixes the code accordingly.