### PR TITLE
Add Python binding for composePanorama

### DIFF
--- a/modules/stitching/include/opencv2/stitching.hpp
+++ b/modules/stitching/include/opencv2/stitching.hpp
@@ -264,7 +264,7 @@ public:
     @param pano Final pano.
     @return Status code.
      */
-    Status composePanorama(InputArrayOfArrays images, OutputArray pano);
+    CV_WRAP Status composePanorama(InputArrayOfArrays images, OutputArray pano);
 
     /** @overload */
     CV_WRAP Status stitch(InputArrayOfArrays images, OutputArray pano);

--- a/modules/stitching/misc/python/test/test_stitching.py
+++ b/modules/stitching/misc/python/test/test_stitching.py
@@ -19,5 +19,36 @@ class stitching_test(NewOpenCVTests):
         self.assertAlmostEqual(pano.shape[0], 685, delta=100, msg="rows: %r" % list(pano.shape))
         self.assertAlmostEqual(pano.shape[1], 1025, delta=100, msg="cols: %r" % list(pano.shape))
 
+
+class stitching_compose_panorama_test_no_args(NewOpenCVTests):
+
+    def test_simple(self):
+
+        img1 = self.get_sample('stitching/a1.png')
+        img2 = self.get_sample('stitching/a2.png')
+
+        stitcher = cv.createStitcher(False)
+
+        stitcher.estimateTransform((img1, img2))
+
+        result, _ = stitcher.composePanorama()
+
+        assert result == 0
+
+
+class stitching_compose_panorama_args(NewOpenCVTests):
+
+    def test_simple(self):
+
+        img1 = self.get_sample('stitching/a1.png')
+        img2 = self.get_sample('stitching/a2.png')
+
+        stitcher = cv.createStitcher(False)
+
+        stitcher.estimateTransform((img1, img2))
+        result, _ = stitcher.composePanorama((img1, img2))
+
+        assert result == 0
+
 if __name__ == '__main__':
     NewOpenCVTests.bootstrap()


### PR DESCRIPTION
Related to https://github.com/opencv/opencv/issues/17956, enable calling composePanorama with both function signatures in Python, and add tests to verify both implementations can run with the test images.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- *[x] I agree to contribute to the project under OpenCV (BSD) License.
- *[x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- *[x] The PR is proposed to proper branch
- *[x] There is reference to original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
