### PR TITLE
Parallelize Best Split Determination

### DIFF
--- a/modules/ml/src/tree.cpp
+++ b/modules/ml/src/tree.cpp
@@ -84,7 +84,7 @@ struct ParallelBestSplit
         }
     }
     DTreesImpl * tree;
-    vector<int> _sidx;
+    const vector<int>& _sidx;
     DTreesImpl::WSplit best_split;
     int * best_subset;
 };


### PR DESCRIPTION
Parallelize the best split determination, similar to 2.4 (https://github.com/opencv/opencv/blob/2.4/modules/ml/src/rtrees.cpp#L159, https://github.com/opencv/opencv/blob/master/apps/traincascade/old_ml_tree.cpp#L1912). This feature was requested in https://github.com/opencv/opencv/issues/10191.

Specs:
OS: Linux (Ubuntu 18.04)
Build type: Debug
Compiler: /usr/bin/c++  (ver 7.5.0)
Parallel framework: pthreads (nthreads=8)
CPU features: SSE SSE2 SSE3 *SSE4.1 *SSE4.2 *FP16 *AVX *AVX2 *AVX512-SKX?

```
cat /proc/cpuinfo  | grep 'name'| uniq
model name	: Intel(R) Core(TM) i7-7700HQ CPU @ 2.80GHz
```

Test Case (sweep over range of rows):
```
            cv::theRNG().state = 0;
            const std::vector<unsigned int> n_rows = {100, 1000, 10000, 50000, 100000};
            for (int ii = 0; ii < n_rows.size(); ++ii) {

                Mat data(n_rows[ii], 100, CV_32F);

                Mat labels(n_rows[ii], 1, CV_32F);
                randu(labels, 0, 10);
                randu(data, 0, 10000);
                std::vector<double> times_elapsed;
                for (int i = 0; i < 10; ++i) {
                    Ptr<ml::RTrees> rt = cv::ml::RTrees::create();
                    rt->setTermCriteria(TermCriteria(TermCriteria::MAX_ITER, 100, 1e-6));
                    const auto t_start = std::chrono::high_resolution_clock::now();
                    rt->train(data, ml::ROW_SAMPLE, labels);
                    const auto t_end = std::chrono::high_resolution_clock::now();
                    times_elapsed.push_back(std::chrono::duration<double>(t_end - t_start).count());
                }
                double mean = std::accumulate(times_elapsed.begin(), times_elapsed.end(), 0.0) / times_elapsed.size();
                std::cout << n_rows[ii] << " : " << mean << std::endl;
            }
        }
```

Sequential:
```
100 : 0.00812943
1000 : 0.0883755
10000 : 1.23321
50000 : 6.84579
100000 : 14.4617
```

Parallel:
```
100 : 0.00845567
1000 : 0.0894653
10000 : 1.18367
50000 : 6.72176
100000 : 14.1852
```
Overall, it seems like parallelizing the best split algorithm, at least in the basic test cases, offers minimal to no benefit. I think the bigger benefit would be to parallelize on actual trees, but that would probably be more involved to implement, and I don't know if there's a high demand for a more performant Random Forest. I think I'll close this out, unless someone else has any thoughts or ideas on cases where this may actually be beneficial.


### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- *[x] I agree to contribute to the project under OpenCV (BSD) License.
- *[x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- *[x] The PR is proposed to proper branch
- *[x] There is reference to original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
