### PR TITLE
Fix Objective-C declaration of Mat_to_vector_Point2d

### DIFF
--- a/modules/core/misc/objc/common/Converters.h
+++ b/modules/core/misc/objc/common/Converters.h
@@ -41,7 +41,7 @@ CV_EXPORTS @interface Converters : NSObject
 
 + (Mat*)vector_Point2d_to_Mat:(NSArray<Point2d*>*)pts NS_SWIFT_NAME(vector_Point2d_to_Mat(_:));
 
-+ (NSArray<Point2f*>*)Mat_to_vector_Point2d:(Mat*)mat NS_SWIFT_NAME(Mat_to_vector_Point2d(_:));
++ (NSArray<Point2d*>*)Mat_to_vector_Point2d:(Mat*)mat NS_SWIFT_NAME(Mat_to_vector_Point2d(_:));
 
 + (Mat*)vector_Point3i_to_Mat:(NSArray<Point3i*>*)pts NS_SWIFT_NAME(vector_Point3i_to_Mat(_:));
 


### PR DESCRIPTION
### Pull Request Readiness Checklist
- [x] I agree to contribute to the project under OpenCV (BSD) License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [x] The PR is proposed to proper branch
- [x] There is reference to original bug report and related work

Partial fix for #18049
- fix incorrect return type in the declaration of `Mat_to_vector_Point2d` (Objective-C version)
