### PR TITLE
improve Mat::operator=(Scalar)

### DIFF
--- a/modules/core/src/copy.cpp
+++ b/modules/core/src/copy.cpp
@@ -415,7 +415,7 @@ void Mat::copyTo( OutputArray _dst, InputArray _mask ) const
 }
 
 // just 1 byte is valid
-#define CANT_APPLY_MEMSET 0xDEADBEEF
+#define CANT_APPLY_MEMSET int(0xDEADBEEF)
 
 static int check_apply_memset(const Mat *mat, const int64 *is)
 {
@@ -429,8 +429,8 @@ static int check_apply_memset(const Mat *mat, const int64 *is)
         return CANT_APPLY_MEMSET;
     }
     
-    bool apply_memset = false;  
-    switch (mat->channels()) // ch
+    bool apply_memset = false;
+    switch (mat->channels())
     {
     case 1:
         apply_memset = true;

--- a/modules/core/src/copy.cpp
+++ b/modules/core/src/copy.cpp
@@ -417,19 +417,20 @@ void Mat::copyTo( OutputArray _dst, InputArray _mask ) const
 // just 1 byte is valid
 #define CANT_APPLY_MEMSET int(0xDEADBEEF)
 
-static int check_apply_memset(const Mat *mat, const int64 *is)
+static int check_apply_memset(const Mat *mat, const Scalar &s)
 {
     int fill_value = CANT_APPLY_MEMSET;
     switch (mat->depth())
     {
-    case CV_8U: fill_value = saturate_cast<uchar>(is[0]); break;
-    case CV_8S: fill_value = saturate_cast<schar>(is[0]); break;
+    case CV_8U: fill_value = saturate_cast<uchar>( s.val[0] ); break;
+    case CV_8S: fill_value = saturate_cast<schar>( s.val[0] ); break;
     default:
         //CV_Error(CV_BadDepth, "Unsupported depth");
         return CANT_APPLY_MEMSET;
     }
-    
+
     bool apply_memset = false;
+    const int64* is = (const int64*)&s.val[0];
     switch (mat->channels())
     {
     case 1:
@@ -473,7 +474,7 @@ Mat& Mat::operator = (const Scalar& s)
     }
     else
     {
-        int fill_value = check_apply_memset(this, is);
+        int fill_value = check_apply_memset(this, s);
         if (fill_value != CANT_APPLY_MEMSET)
         {
             for (size_t i = 0; i < it.nplanes; i++, ++it)

--- a/modules/core/src/copy.cpp
+++ b/modules/core/src/copy.cpp
@@ -468,7 +468,7 @@ Mat& Mat::operator = (const Scalar& s)
                 apply_memset = false;
                 break;
             }
-            //apply_memset = false; // test for compare
+            apply_memset = false; // test for compare
 
             if (apply_memset)
             {

--- a/modules/core/src/copy.cpp
+++ b/modules/core/src/copy.cpp
@@ -447,8 +447,7 @@ Mat& Mat::operator = (const Scalar& s)
                     m = Scalar(1,1,1);  // m = [ 1,1,1 ]
 
                 2) Mat::ones ( little ambiguous )
-                    Mat m = Mat::ones(1,1, CV_8UC3);  // m = [ 1, 0, 0 ] 
-
+                    Mat m = Mat::ones(1,1, CV_8UC3);  // m = [ 1, 0, 0 ]
             */
             bool apply_memset = false;  // memset faster than memcpy
             switch (channels()) // ch

--- a/modules/core/src/copy.cpp
+++ b/modules/core/src/copy.cpp
@@ -486,7 +486,7 @@ Mat& Mat::operator = (const Scalar& s)
                 return *this;
             }
         }
-        
+
         if( it.nplanes > 0 )
         {
             double scalar[12];

--- a/modules/core/src/copy.cpp
+++ b/modules/core/src/copy.cpp
@@ -417,6 +417,7 @@ void Mat::copyTo( OutputArray _dst, InputArray _mask ) const
 
 static bool can_apply_memset(const Mat &mat, const Scalar &s, int &fill_value)
 {
+    // check if depth is 1 byte.
     switch (mat.depth())
     {
     case CV_8U: fill_value = saturate_cast<uchar>( s.val[0] ); break;
@@ -424,6 +425,7 @@ static bool can_apply_memset(const Mat &mat, const Scalar &s, int &fill_value)
     default: return false;
     }
 
+    // check if all element is same.
     const int64* is = (const int64*)&s.val[0];
     switch (mat.channels())
     {


### PR DESCRIPTION
improve Mat::operator=(Scalar)
- Mat::zeros() is faster than Mat::ones(). 
- The reason is that Mat::zeros() use memset(), but Mat::ones() use memcpy() for every row.
- As a result, Mat::ones() need more memory access than Mat::zeros().
-  I modified Mat::operator=(Scalar) that use memset() on possible case. ( 8U, 8S, and 8UC3 same scalar element etc...)
- 50% performance enhancement

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [X] I agree to contribute to the project under OpenCV (BSD) License.
- [X] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [X] The PR is proposed to proper branch
- [ ] There is reference to original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
