### PR TITLE
core(OpenCL): fix ocl::Image2d::isFormatSupported()

### DIFF
--- a/modules/core/src/ocl.cpp
+++ b/modules/core/src/ocl.cpp
@@ -6458,6 +6458,9 @@ struct Image2D::Impl
             CV_Error(Error::OpenCLApiCallError, "OpenCL runtime not found!");
 
         cl_context context = (cl_context)Context::getDefault().ptr();
+        if (!context)
+            return false;
+
         // Figure out how many formats are supported by this context.
         cl_uint numFormats = 0;
         cl_int err = clGetSupportedImageFormats(context, CL_MEM_READ_WRITE,


### PR DESCRIPTION
in case of `OPENCV_OPENCL_DEVICE=disabled`

<cut/>

Error message:
```
 RUN      ] Image2D.turnOffOpenCL
Exception message: OpenCV(3.4.11-dev) /home/alalek/projects/opencv/dev/modules/core/src/ocl.cpp:6466: error: (-220:Unknown error code -220) OpenCL error CL_INVALID_CONTEXT (-34) during call: clGetSupportedImageFormats(CL_MEM_OBJECT_IMAGE2D, NULL) in function 'isFormatSupported'

/home/alalek/projects/opencv/dev/modules/core/test/ocl/test_image2d.cpp:78: Failure
Expected: isFormatSupported = cv::ocl::Image2D::isFormatSupported(0, 1, true) doesn't throw an exception.
  Actual: it throws.
CV_8UC1 is not supported for OpenCL images. Test skipped.
[  FAILED  ] Image2D.turnOffOpenCL (0 ms)
```