### PR TITLE
highgui: don't terminate if we can't initialize GTK backend

### DIFF
--- a/modules/highgui/src/window_gtk.cpp
+++ b/modules/highgui/src/window_gtk.cpp
@@ -612,19 +612,33 @@ static std::vector< Ptr<CvWindow> > g_windows;
 CV_IMPL int cvInitSystem( int argc, char** argv )
 {
     static int wasInitialized = 0;
+    static bool hasError = false;
 
     // check initialization status
     if( !wasInitialized )
     {
-        gtk_init( &argc, &argv );
+        if (!gtk_init_check(&argc, &argv))
+        {
+            hasError = true;
+            wasInitialized = true;
+            CV_Error(Error::StsError, "Can't initialize GTK backend");
+        }
+
         setlocale(LC_NUMERIC,"C");
 
         #ifdef HAVE_OPENGL
-            gtk_gl_init(&argc, &argv);
+            if (!gtk_gl_init_check(&argc, &argv))
+            {
+                hasError = true;
+                wasInitialized = true;
+                CV_Error(Error::StsError, "Can't initialize GTK-OpenGL backend");
+            }
         #endif
 
         wasInitialized = 1;
     }
+    if (hasError)
+       CV_Error(Error::StsError, "GTK backend is not available");
 
     return 0;
 }


### PR DESCRIPTION
- allow Users to handle such case
- exception will be thrown instead

Useful for docker containers or other environments without configured DISPLAY.

GTK doc reference:
- https://developer.gnome.org/gtk3/stable/gtk3-General.html#gtk-init
- https://developer.gnome.org/gtkglext/stable/gtkglext-gtkglinit.html

<cut/>

-----

Before:
- `terminate()` called with message "Gtk-WARNING **: 09:37:26.975: cannot open display:"

After:
- throws C++ exception from imshow() and subsequent calls.