### PR TITLE
Invert sequence

### DIFF
--- a/samples/cpp/tutorial_code/ImgProc/Threshold_inRange.cpp
+++ b/samples/cpp/tutorial_code/ImgProc/Threshold_inRange.cpp
@@ -60,17 +60,17 @@ int main(int argc, char* argv[])
     //! [cap]
 
     //! [window]
-    namedWindow(window_capture_name);
-    namedWindow(window_detection_name);
+    namedWindow(window_capture_name,WINDOW_NORMAL);
+    namedWindow(window_detection_name,WINDOW_NORMAL);
     //! [window]
 
     //! [trackbar]
     // Trackbars to set thresholds for HSV values
     createTrackbar("Low H", window_detection_name, &low_H, max_value_H, on_low_H_thresh_trackbar);
-    createTrackbar("High H", window_detection_name, &high_H, max_value_H, on_high_H_thresh_trackbar);
     createTrackbar("Low S", window_detection_name, &low_S, max_value, on_low_S_thresh_trackbar);
-    createTrackbar("High S", window_detection_name, &high_S, max_value, on_high_S_thresh_trackbar);
     createTrackbar("Low V", window_detection_name, &low_V, max_value, on_low_V_thresh_trackbar);
+    createTrackbar("High H", window_detection_name, &high_H, max_value_H, on_high_H_thresh_trackbar);
+    createTrackbar("High S", window_detection_name, &high_S, max_value, on_high_S_thresh_trackbar);
     createTrackbar("High V", window_detection_name, &high_V, max_value, on_high_V_thresh_trackbar);
     //! [trackbar]
 

--- a/samples/dnn/models.yml
+++ b/samples/dnn/models.yml
@@ -15,6 +15,32 @@ opencv_fd:
   rgb: false
   sample: "object_detection"
 
+
+# YOLO object detection family from Darknet (https://github.com/AlexeyAB/darknet#pre-trained-models)
+# Might be used for YOLOv4 and TinyYolov4
+yolov4:
+  model: "yolov4.weights"
+  config: "yolov4.cfg"
+  mean: [0, 0, 0]
+  scale: 0.00392
+  width: 416
+  height: 416
+  rgb: true
+  classes: "object_detection_classes_yolov3.txt"
+  sample: "object_detection"
+
+
+yolov4-tiny-voc:
+  model: " yolov4-tiny.weights"
+  config: "yolov4-tiny.cfg"
+  mean: [0, 0, 0]
+  scale: 0.00392
+  width: 416
+  height: 416
+  rgb: true
+  classes: "object_detection_classes_pascal_voc.txt"
+  sample: "object_detection"
+
 # YOLO object detection family from Darknet (https://pjreddie.com/darknet/yolo/)
 # Might be used for all YOLOv2, TinyYolov2 and YOLOv3
 yolo:

--- a/samples/dnn/object_detection.cpp
+++ b/samples/dnn/object_detection.cpp
@@ -248,18 +248,12 @@ int main(int argc, char** argv)
 
         postprocess(frame, outs, net, backend);
 
+        imshow(kWinName, frame);
         if (predictionsQueue.counter > 1)
         {
-            std::string label = format("Camera: %.2f FPS", framesQueue.getFPS());
-            putText(frame, label, Point(0, 15), FONT_HERSHEY_SIMPLEX, 0.5, Scalar(0, 255, 0));
-
-            label = format("Network: %.2f FPS", predictionsQueue.getFPS());
-            putText(frame, label, Point(0, 30), FONT_HERSHEY_SIMPLEX, 0.5, Scalar(0, 255, 0));
-
-            label = format("Skipped frames: %d", framesQueue.counter - predictionsQueue.counter);
-            putText(frame, label, Point(0, 45), FONT_HERSHEY_SIMPLEX, 0.5, Scalar(0, 255, 0));
+            std::string label = format("Camera: %.2f FPS, Network: %.2f FPS, Skipped frames: %d", framesQueue.getFPS(),predictionsQueue.getFPS(),framesQueue.counter - predictionsQueue.counter);
+            displayOverlay(kWinName,label,2000);
         }
-        imshow(kWinName, frame);
     }
 
     process = false;


### PR DESCRIPTION
### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [x] The PR is proposed to proper branch
- [x] There is reference to original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake


Humble suggestion, reverse the slider bar sequence.

When I used this example, the capture of the device was greater than the resolution of the monitor.

I also suggest placing the slider bar sequence as used in the inRange function (lowH, lowS, lowV, highH, highS, highV).

It's just a suggestion.