### PR TITLE
[G-API]: Fluid Core kernels performance tests

### DIFF
--- a/modules/gapi/perf/cpu/gapi_core_perf_tests_fluid.cpp
+++ b/modules/gapi/perf/cpu/gapi_core_perf_tests_fluid.cpp
@@ -1,0 +1,294 @@
+// This file is part of OpenCV project.
+// It is subject to the license terms in the LICENSE file found in the top-level directory
+// of this distribution and at http://opencv.org/license.html.
+//
+// Copyright (C) 2018-2020 Intel Corporation
+
+
+#include "../perf_precomp.hpp"
+#include "../common/gapi_core_perf_tests.hpp"
+
+#define CORE_FLUID cv::gapi::core::fluid::kernels()
+
+namespace opencv_test
+{
+INSTANTIATE_TEST_CASE_P(AddPerfTestFluid, AddPerfTest,
+    Combine(Values(szSmall128, szVGA, sz720p, sz1080p),
+            Values(CV_8UC1, CV_8UC3, CV_16SC1, CV_32FC1),
+            Values(-1, CV_8U, CV_32F),
+            Values(cv::compile_args(CORE_FLUID))));
+
+// INSTANTIATE_TEST_CASE_P(AddCPerfTestFluid, AddCPerfTest,
+//     Combine(Values(szSmall128, szVGA, sz720p, sz1080p),
+//         Values(CV_8UC1, CV_8UC3, CV_16UC1, CV_16SC1, CV_32FC1),
+//         Values(-1, CV_8U, CV_16U, CV_32F),
+//         Values(cv::compile_args(CORE_FLUID))));
+
+INSTANTIATE_TEST_CASE_P(SubPerfTestFluid, SubPerfTest,
+    Combine(Values(szSmall128, szVGA, sz720p, sz1080p),
+            Values(CV_8UC1, CV_8UC3, CV_16SC1, CV_32FC1),
+            Values(-1, CV_8U, CV_32F),
+            Values(cv::compile_args(CORE_FLUID))));
+
+// INSTANTIATE_TEST_CASE_P(SubCPerfTestFluid, SubCPerfTest,
+//     Combine(Values(szSmall128, szVGA, sz720p, sz1080p),
+//         Values(CV_8UC1, CV_8UC3, CV_16UC1, CV_16SC1, CV_32FC1),
+//         Values(-1, CV_8U, CV_16U, CV_32F),
+//         Values(cv::compile_args(CORE_FLUID))));
+
+// INSTANTIATE_TEST_CASE_P(SubRCPerfTestFluid, SubRCPerfTest,
+//     Combine(Values(szSmall128, szVGA, sz720p, sz1080p),
+//         Values(CV_8UC1, CV_8UC3, CV_16UC1, CV_16SC1, CV_32FC1),
+//         Values(-1, CV_8U, CV_16U, CV_32F),
+//         Values(cv::compile_args(CORE_FLUID))));
+
+// INSTANTIATE_TEST_CASE_P(MulPerfTestFluid, MulPerfTest,
+//     Combine(Values(szSmall128, szVGA, sz720p, sz1080p),
+//         Values(CV_8UC1, CV_8UC3, CV_16UC1, CV_16SC1, CV_32FC1),
+//         Values(-1, CV_8U, CV_16U, CV_32F),
+//         Values(cv::compile_args(CORE_FLUID))));
+
+// INSTANTIATE_TEST_CASE_P(MulDoublePerfTestFluid, MulDoublePerfTest,
+//     Combine(Values(szSmall128, szVGA, sz720p, sz1080p),
+//         Values(CV_8UC1, CV_8UC3, CV_16UC1, CV_16SC1, CV_32FC1),
+//         Values(-1, CV_8U, CV_16U, CV_32F),
+//         Values(cv::compile_args(CORE_FLUID))));
+
+// INSTANTIATE_TEST_CASE_P(MulCPerfTestFluid, MulCPerfTest,
+//     Combine(Values(szSmall128, szVGA, sz720p, sz1080p),
+//         Values(CV_8UC1, CV_8UC3, CV_16UC1, CV_16SC1, CV_32FC1),
+//         Values(-1, CV_8U, CV_16U, CV_32F),
+//         Values(cv::compile_args(CORE_FLUID))));
+
+// INSTANTIATE_TEST_CASE_P(DivPerfTestFluid, DivPerfTest,
+//     Combine(Values(AbsExact().to_compare_f()),
+//         Values(szSmall128, szVGA, sz720p, sz1080p),
+//         Values(CV_8UC1, CV_8UC3, CV_16UC1, CV_16SC1, CV_32FC1),
+//         Values(-1, CV_8U, CV_16U, CV_32F),
+//         Values(cv::compile_args(CORE_FLUID))));
+
+// INSTANTIATE_TEST_CASE_P(DivCPerfTestFluid, DivCPerfTest,
+//     Combine(Values(szSmall128, szVGA, sz720p, sz1080p),
+//         Values(CV_8UC1, CV_8UC3, CV_16UC1, CV_16SC1, CV_32FC1),
+//         Values(-1, CV_8U, CV_16U, CV_32F),
+//         Values(cv::compile_args(CORE_FLUID))));
+
+// INSTANTIATE_TEST_CASE_P(DivRCPerfTestFluid, DivRCPerfTest,
+//     Combine(Values(AbsExact().to_compare_f()),
+//         Values(szSmall128, szVGA, sz720p, sz1080p),
+//         Values(CV_8UC1, CV_8UC3, CV_16UC1, CV_16SC1, CV_32FC1),
+//         Values(-1, CV_8U, CV_16U, CV_32F),
+//         Values(cv::compile_args(CORE_FLUID))));
+
+// INSTANTIATE_TEST_CASE_P(MaskPerfTestFluid, MaskPerfTest,
+//     Combine(Values(szSmall128, szVGA, sz720p, sz1080p),
+//         Values(CV_8UC1, CV_16UC1, CV_16SC1),
+//         Values(cv::compile_args(CORE_FLUID))));
+
+// INSTANTIATE_TEST_CASE_P(MeanPerfTestFluid, MeanPerfTest,
+//     Combine(Values(szSmall128, szVGA, sz720p, sz1080p),
+//         Values(CV_8UC1, CV_8UC3, CV_16UC1, CV_16SC1, CV_32FC1),
+//         Values(cv::compile_args(CORE_FLUID))));
+
+// INSTANTIATE_TEST_CASE_P(Polar2CartPerfTestFluid, Polar2CartPerfTest,
+//     Combine(Values(AbsExact().to_compare_f()),
+//         Values(szSmall128, szVGA, sz720p, sz1080p),
+//         Values(cv::compile_args(CORE_FLUID))));
+
+// INSTANTIATE_TEST_CASE_P(Cart2PolarPerfTestFluid, Cart2PolarPerfTest,
+//     Combine(Values(AbsExact().to_compare_f()),
+//         Values(szSmall128, szVGA, sz720p, sz1080p),
+//         Values(cv::compile_args(CORE_FLUID))));
+
+// INSTANTIATE_TEST_CASE_P(CmpPerfTestFluid, CmpPerfTest,
+//     Combine(Values(CMP_EQ, CMP_GE, CMP_NE, CMP_GT, CMP_LT, CMP_LE),
+//         Values(szSmall128, szVGA, sz720p, sz1080p),
+//         Values(CV_8UC1, CV_8UC3, CV_16UC1, CV_16SC1, CV_32FC1),
+//         Values(cv::compile_args(CORE_FLUID))));
+
+INSTANTIATE_TEST_CASE_P(CmpWithScalarPerfTestFluid, CmpWithScalarPerfTest,
+    Combine(Values(CMP_EQ, CMP_GE, CMP_NE, CMP_GT, CMP_LT, CMP_LE),
+                   Values(szSmall128, szVGA, sz720p, sz1080p),
+                   Values(CV_8UC1, CV_8UC3, CV_16SC1, CV_32FC1),
+                   Values(cv::compile_args(CORE_FLUID))));
+
+INSTANTIATE_TEST_CASE_P(BitwisePerfTestFluid, BitwisePerfTest,
+    Combine(Values(AND, OR, XOR),
+            Values(szSmall128, szVGA, sz720p, sz1080p),
+            Values(CV_8UC1, CV_8UC3, CV_16UC1, CV_16SC1),
+            Values(cv::compile_args(CORE_FLUID))));
+
+INSTANTIATE_TEST_CASE_P(BitwiseNotPerfTestFluid, BitwiseNotPerfTest,
+    Combine(Values(szSmall128, szVGA, sz720p, sz1080p),
+            Values(CV_8UC1, CV_8UC3, CV_16UC1, CV_16SC1),
+            Values(cv::compile_args(CORE_FLUID))));
+
+// INSTANTIATE_TEST_CASE_P(SelectPerfTestFluid, SelectPerfTest,
+//     Combine(Values(szSmall128, szVGA, sz720p, sz1080p),
+//         Values(CV_8UC1, CV_8UC3, CV_16UC1, CV_16SC1, CV_32FC1),
+//         Values(cv::compile_args(CORE_FLUID))));
+
+// INSTANTIATE_TEST_CASE_P(MinPerfTestFluid, MinPerfTest,
+//     Combine(Values(szSmall128, szVGA, sz720p, sz1080p),
+//         Values(CV_8UC1, CV_8UC3, CV_16UC1, CV_16SC1, CV_32FC1),
+//         Values(cv::compile_args(CORE_FLUID))));
+
+// INSTANTIATE_TEST_CASE_P(MaxPerfTestFluid, MaxPerfTest,
+//     Combine(Values(szSmall128, szVGA, sz720p, sz1080p),
+//         Values(CV_8UC1, CV_8UC3, CV_16UC1, CV_16SC1, CV_32FC1),
+//         Values(cv::compile_args(CORE_FLUID))));
+
+INSTANTIATE_TEST_CASE_P(AbsDiffPerfTestFluid, AbsDiffPerfTest,
+    Combine(Values(szSmall128, szVGA, sz720p, sz1080p),
+            Values(CV_8UC1, CV_8UC3, CV_16UC1, CV_16SC1, CV_32FC1),
+            Values(cv::compile_args(CORE_FLUID))));
+
+INSTANTIATE_TEST_CASE_P(AbsDiffCPerfTestFluid, AbsDiffCPerfTest,
+    Combine(Values(szSmall128, szVGA, sz720p, sz1080p),
+            Values(CV_8UC1, CV_8UC3, CV_16UC1, CV_16SC1),
+            Values(cv::compile_args(CORE_FLUID))));
+
+// INSTANTIATE_TEST_CASE_P(SumPerfTestFluid, SumPerfTest,
+//     Combine(Values(AbsToleranceScalar(0.0).to_compare_f()),
+//         Values(szSmall128, szVGA, sz720p, sz1080p),
+//         Values(CV_8UC1, CV_8UC3, CV_16UC1, CV_16SC1, CV_32FC1),
+//         //Values(0.0),
+//         Values(cv::compile_args(CORE_FLUID))));
+
+INSTANTIATE_TEST_CASE_P(AddWeightedPerfTestFluid, AddWeightedPerfTest,
+    Combine(Values(Tolerance_FloatRel_IntAbs(1e-6, 1).to_compare_f()),
+            Values(szSmall128, szVGA, sz720p, sz1080p),
+            Values(CV_8UC1, CV_8UC3, CV_16UC1, CV_16SC1),
+            Values(-1, CV_8U, CV_32F),
+            Values(cv::compile_args(CORE_FLUID))));
+
+INSTANTIATE_TEST_CASE_P(AddWeightedPerfTestFluid_short, AddWeightedPerfTest,
+    Combine(Values(Tolerance_FloatRel_IntAbs(1e-6, 1).to_compare_f()),
+            Values(szSmall128, szVGA, sz720p, sz1080p),
+            Values(CV_16UC1, CV_16SC1),
+            Values(-1),
+            Values(cv::compile_args(CORE_FLUID))));
+
+// INSTANTIATE_TEST_CASE_P(NormPerfTestFluid, NormPerfTest,
+//     Combine(Values(AbsToleranceScalar(0.0).to_compare_f()),
+//         Values(NORM_INF, NORM_L1, NORM_L2),
+//         Values(szSmall128, szVGA, sz720p, sz1080p),
+//         Values(CV_8UC1, CV_8UC3, CV_16UC1, CV_16SC1, CV_32FC1),
+//         Values(cv::compile_args(CORE_FLUID))));
+
+// INSTANTIATE_TEST_CASE_P(IntegralPerfTestFluid, IntegralPerfTest,
+//     Combine(Values(szSmall128, szVGA, sz720p, sz1080p),
+//         Values(CV_8UC1, CV_16UC1, CV_16SC1, CV_32FC1),
+//         Values(cv::compile_args(CORE_FLUID))));
+
+// INSTANTIATE_TEST_CASE_P(ThresholdPerfTestFluid, ThresholdPerfTest,
+//     Combine(Values(szSmall128, szVGA, sz720p, sz1080p),
+//         Values(CV_8UC1, CV_8UC3, CV_16UC1, CV_16SC1, CV_32FC1),
+//         Values(cv::THRESH_BINARY, cv::THRESH_BINARY_INV, cv::THRESH_TRUNC, cv::THRESH_TOZERO, cv::THRESH_TOZERO_INV),
+//         Values(cv::compile_args(CORE_FLUID))));
+
+// INSTANTIATE_TEST_CASE_P(ThresholdPerfTestFluid, ThresholdOTPerfTest,
+//     Combine(Values(szSmall128, szVGA, sz720p, sz1080p),
+//         Values(CV_8UC1),
+//         Values(cv::THRESH_OTSU, cv::THRESH_TRIANGLE),
+//         Values(cv::compile_args(CORE_FLUID))));
+
+// INSTANTIATE_TEST_CASE_P(InRangePerfTestFluid, InRangePerfTest,
+//     Combine(Values(szSmall128, szVGA, sz720p, sz1080p),
+//         Values(CV_8UC1),
+//         Values(cv::compile_args(CORE_FLUID))));
+
+INSTANTIATE_TEST_CASE_P(Split3PerfTestFluid, Split3PerfTest,
+    Combine(Values(szSmall128, szVGA, sz720p, sz1080p),
+            Values(cv::compile_args(CORE_FLUID))));
+
+// INSTANTIATE_TEST_CASE_P(Split4PerfTestFluid, Split4PerfTest,
+//     Combine(Values(szSmall128, szVGA, sz720p, sz1080p),
+//         Values(cv::compile_args(CORE_FLUID))));
+
+// INSTANTIATE_TEST_CASE_P(Merge3PerfTestFluid, Merge3PerfTest,
+//     Combine(Values(szSmall128, szVGA, sz720p, sz1080p),
+//         Values(cv::compile_args(CORE_FLUID))));
+
+// INSTANTIATE_TEST_CASE_P(Merge4PerfTestFluid, Merge4PerfTest,
+//     Combine(Values(szSmall128, szVGA, sz720p, sz1080p),
+//         Values(cv::compile_args(CORE_FLUID))));
+
+// INSTANTIATE_TEST_CASE_P(RemapPerfTestFluid, RemapPerfTest,
+//     Combine(Values(szSmall128, szVGA, sz720p, sz1080p),
+//         Values(CV_8UC1, CV_8UC3, CV_16UC1, CV_16SC1, CV_32FC1),
+//         Values(cv::compile_args(CORE_FLUID))));
+
+// INSTANTIATE_TEST_CASE_P(FlipPerfTestFluid, FlipPerfTest,
+//     Combine(Values(szSmall128, szVGA, sz720p, sz1080p),
+//         Values(CV_8UC1, CV_8UC3, CV_16UC1, CV_16SC1, CV_32FC1),
+//         Values(0, 1, -1),
+//         Values(cv::compile_args(CORE_FLUID))));
+
+// INSTANTIATE_TEST_CASE_P(CropPerfTestFluid, CropPerfTest,
+//     Combine(Values(szSmall128, szVGA, sz720p, sz1080p),
+//         Values(CV_8UC1, CV_8UC3, CV_16UC1, CV_16SC1, CV_32FC1),
+//         Values(cv::Rect(10, 8, 20, 35), cv::Rect(4, 10, 37, 50)),
+//         Values(cv::compile_args(CORE_FLUID))));
+
+// INSTANTIATE_TEST_CASE_P(CopyPerfTestFluid, CopyPerfTest,
+//     Combine(Values(szSmall128, szVGA, sz720p, sz1080p),
+//         Values(CV_8UC1, CV_8UC3, CV_16UC1, CV_16SC1, CV_32FC1),
+//         Values(cv::compile_args(CORE_FLUID))));
+
+// INSTANTIATE_TEST_CASE_P(ConcatHorPerfTestFluid, ConcatHorPerfTest,
+//     Combine(Values(szSmall128, szVGA, sz720p, sz1080p),
+//         Values(CV_8UC1, CV_8UC3, CV_16UC1, CV_16SC1, CV_32FC1),
+//         Values(cv::compile_args(CORE_FLUID))));
+
+// INSTANTIATE_TEST_CASE_P(ConcatHorVecPerfTestFluid, ConcatHorVecPerfTest,
+//     Combine(Values(szSmall128, szVGA, sz720p, sz1080p),
+//         Values(CV_8UC1, CV_8UC3, CV_16UC1, CV_16SC1, CV_32FC1),
+//         Values(cv::compile_args(CORE_FLUID))));
+
+// INSTANTIATE_TEST_CASE_P(ConcatVertPerfTestFluid, ConcatVertPerfTest,
+//     Combine(Values(szSmall128, szVGA, sz720p, sz1080p),
+//         Values(CV_8UC1, CV_8UC3, CV_16UC1, CV_16SC1, CV_32FC1),
+//         Values(cv::compile_args(CORE_FLUID))));
+
+// INSTANTIATE_TEST_CASE_P(ConcatVertVecPerfTestFluid, ConcatVertVecPerfTest,
+//     Combine(Values(szSmall128, szVGA, sz720p, sz1080p),
+//         Values(CV_8UC1, CV_8UC3, CV_16UC1, CV_16SC1, CV_32FC1),
+//         Values(cv::compile_args(CORE_FLUID))));
+
+// INSTANTIATE_TEST_CASE_P(LUTPerfTestFluid, LUTPerfTest,
+//     Combine(Values(CV_8UC1, CV_8UC3),
+//         Values(CV_8UC1),
+//         Values(szSmall128, szVGA, sz720p, sz1080p),
+//         Values(cv::compile_args(CORE_FLUID))));
+
+// INSTANTIATE_TEST_CASE_P(LUTPerfTestCustomFluid, LUTPerfTest,
+//     Combine(Values(CV_8UC3),
+//         Values(CV_8UC3),
+//         Values(szSmall128, szVGA, sz720p, sz1080p),
+//         Values(cv::compile_args(CORE_FLUID))));
+
+INSTANTIATE_TEST_CASE_P(ConvertToPerfTestFluid, ConvertToPerfTest,
+    Combine(Values(CV_8UC3, CV_8UC1, CV_16UC1, CV_32FC1),
+            Values(CV_8U, CV_16U, CV_32F),
+            Values(szSmall128, szVGA, sz720p, sz1080p),
+            Values(cv::compile_args(CORE_FLUID))));
+
+INSTANTIATE_TEST_CASE_P(ResizePerfTestFluid, ResizePerfTest,
+    Combine(Values(AbsExact().to_compare_f()),
+        Values(CV_8UC3/*CV_8UC1, CV_16UC1, CV_16SC1*/),
+        Values(/*cv::INTER_NEAREST,*/ cv::INTER_LINEAR/*, cv::INTER_AREA*/),
+        Values(szSmall128, szVGA, sz720p, sz1080p),
+        Values(cv::Size(64, 64),
+               cv::Size(30, 30)),
+        Values(cv::compile_args(CORE_FLUID))));
+
+INSTANTIATE_TEST_CASE_P(ResizeFxFyPerfTestFluid, ResizeFxFyPerfTest,
+    Combine(Values(AbsExact().to_compare_f()),
+        Values(CV_8UC3/*CV_8UC1, CV_16UC1, CV_16SC1*/),
+        Values(/*cv::INTER_NEAREST,*/ cv::INTER_LINEAR/*, cv::INTER_AREA*/),
+        Values(szSmall128, szVGA, sz720p, sz1080p),
+        Values(0.5, 0.1),
+        Values(0.5, 0.1),
+        Values(cv::compile_args(CORE_FLUID))));
+} // opencv_test

--- a/modules/gapi/perf/cpu/gapi_core_perf_tests_fluid.cpp
+++ b/modules/gapi/perf/cpu/gapi_core_perf_tests_fluid.cpp
@@ -2,7 +2,7 @@
 // It is subject to the license terms in the LICENSE file found in the top-level directory
 // of this distribution and at http://opencv.org/license.html.
 //
-// Copyright (C) 2018-2020 Intel Corporation
+// Copyright (C) 2020 Intel Corporation
 
 
 #include "../perf_precomp.hpp"


### PR DESCRIPTION
These changes

1. add performance tests for a list of Fluid Core kernels:
 - GAdd
 - GSub
 - GCmpScalar
 - bitwise operations with GMats
 - GAbsDiff
 - GAbsDiffC
 - GAddWeighted
 - GSplit3
 - GConvertTo
 - GResize

2. propose perfomance tests for other kernels (which are not checked/implemented for Fluid yet)

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [x] The PR is proposed to proper branch
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.

```
force_builders=Custom,Custom Win,Custom Mac
build_gapi_standalone:Linux x64=ade-0.1.1f
build_gapi_standalone:Win64=ade-0.1.1f
build_gapi_standalone:Mac=ade-0.1.1f
build_gapi_standalone:Linux x64 Debug=ade-0.1.1f

Xbuild_image:Custom=centos:7
Xbuildworker:Custom=linux-1
build_gapi_standalone:Custom=ade-0.1.1f

build_image:Custom=ubuntu-openvino-2020.3.0:16.04
Xbuild_image:Custom Win=openvino-2020.3.0
Xbuild_image:Custom Mac=openvino-2020.3.0

test_modules:Custom=gapi
test_modules:Custom Win=gapi
test_modules:Custom Mac=gapi

buildworker:Custom=linux-1
# disabled due high memory usage: test_opencl:Custom=ON
test_opencl:Custom=OFF
test_bigdata:Custom=1
test_filter:Custom=*
```