### PR TITLE
core(trace): lazy quering for OPENCV_TRACE_LOCATION

### DIFF
--- a/modules/core/src/trace.cpp
+++ b/modules/core/src/trace.cpp
@@ -82,7 +82,12 @@ static bool getParameterTraceEnable()
 static int param_maxRegionDepthOpenCV = (int)utils::getConfigurationParameterSizeT("OPENCV_TRACE_DEPTH_OPENCV", 1);
 static int param_maxRegionChildrenOpenCV = (int)utils::getConfigurationParameterSizeT("OPENCV_TRACE_MAX_CHILDREN_OPENCV", 1000);
 static int param_maxRegionChildren = (int)utils::getConfigurationParameterSizeT("OPENCV_TRACE_MAX_CHILDREN", 10000);
-static cv::String param_traceLocation = utils::getConfigurationParameterString("OPENCV_TRACE_LOCATION", "OpenCVTrace");
+
+static const cv::String& getParameterTraceLocation()
+{
+    static cv::String param_traceLocation = utils::getConfigurationParameterString("OPENCV_TRACE_LOCATION", "OpenCVTrace");
+    return param_traceLocation;
+}
 
 #ifdef HAVE_OPENCL
 static bool param_synchronizeOpenCL = utils::getConfigurationParameterBool("OPENCV_TRACE_SYNC_OPENCL", false);
@@ -813,7 +818,7 @@ TraceStorage* TraceManagerThreadLocal::getStorage() const
         TraceStorage* global = getTraceManager().trace_storage.get();
         if (global)
         {
-            const std::string filepath = cv::format("%s-%03d.txt", param_traceLocation.c_str(), threadID).c_str();
+            const std::string filepath = cv::format("%s-%03d.txt", getParameterTraceLocation().c_str(), threadID).c_str();
             TraceMessage msg;
             const char* pos = strrchr(filepath.c_str(), '/'); // extract filename
 #ifdef _WIN32
@@ -848,7 +853,7 @@ TraceManager::TraceManager()
     activated = getParameterTraceEnable();
 
     if (activated)
-        trace_storage.reset(new SyncTraceStorage(std::string(param_traceLocation) + ".txt"));
+        trace_storage.reset(new SyncTraceStorage(std::string(getParameterTraceLocation()) + ".txt"));
 
 #ifdef OPENCV_WITH_ITT
     if (isITTEnabled())


### PR DESCRIPTION
Avoid creation of `(null).txt` or `.txt` trace files due to uninitialized global static variable.

relates #17822