### PR TITLE
Display overlay for show FPS message

### DIFF
--- a/samples/dnn/object_detection.cpp
+++ b/samples/dnn/object_detection.cpp
@@ -248,12 +248,15 @@ int main(int argc, char** argv)
 
         postprocess(frame, outs, net, backend);
 
-        imshow(kWinName, frame);
         if (predictionsQueue.counter > 1)
         {
+            int baseLine = 0;
             std::string label = format("Camera: %.2f FPS, Network: %.2f FPS, Skipped frames: %d", framesQueue.getFPS(),predictionsQueue.getFPS(),framesQueue.counter - predictionsQueue.counter);
-            displayOverlay(kWinName,label,2000);
+            cv::Size labelSize = getTextSize(label, FONT_HERSHEY_SIMPLEX, 0.5, 1, &baseLine);
+            rectangle(frame, Point( 0, 0), Point(labelSize.width, labelSize.height+baseLine), Scalar::all(0), FILLED);
+            putText(frame, label, Point(0,labelSize.height), FONT_HERSHEY_SIMPLEX, 0.5, Scalar::all(255));
         }
+        imshow(kWinName, frame);
     }
 
     process = false;

--- a/samples/dnn/object_detection.cpp
+++ b/samples/dnn/object_detection.cpp
@@ -251,7 +251,7 @@ int main(int argc, char** argv)
         if (predictionsQueue.counter > 1)
         {
             int baseLine = 0;
-            std::string label = format("Camera: %.2f FPS, Network: %.2f FPS, Skipped frame(s): %d", framesQueue.getFPS(),predictionsQueue.getFPS(),framesQueue.counter - predictionsQueue.counter);
+            std::string label = format("Camera: %.2f FPS, Network: %.2f FPS, Skipped frame(s): %d", framesQueue.getFPS(), predictionsQueue.getFPS(),framesQueue.counter - predictionsQueue.counter);
             cv::Size labelSize = getTextSize(label, FONT_HERSHEY_SIMPLEX, 0.5, 1, &baseLine);
             rectangle(frame, Point( 0, 0), Point(labelSize.width, labelSize.height+baseLine), Scalar::all(0), FILLED);
             putText(frame, label, Point(0,labelSize.height), FONT_HERSHEY_SIMPLEX, 0.5, Scalar::all(255));

--- a/samples/dnn/object_detection.cpp
+++ b/samples/dnn/object_detection.cpp
@@ -248,18 +248,12 @@ int main(int argc, char** argv)
 
         postprocess(frame, outs, net, backend);
 
+        imshow(kWinName, frame);
         if (predictionsQueue.counter > 1)
         {
-            std::string label = format("Camera: %.2f FPS", framesQueue.getFPS());
-            putText(frame, label, Point(0, 15), FONT_HERSHEY_SIMPLEX, 0.5, Scalar(0, 255, 0));
-
-            label = format("Network: %.2f FPS", predictionsQueue.getFPS());
-            putText(frame, label, Point(0, 30), FONT_HERSHEY_SIMPLEX, 0.5, Scalar(0, 255, 0));
-
-            label = format("Skipped frames: %d", framesQueue.counter - predictionsQueue.counter);
-            putText(frame, label, Point(0, 45), FONT_HERSHEY_SIMPLEX, 0.5, Scalar(0, 255, 0));
+            std::string label = format("Camera: %.2f FPS, Network: %.2f FPS, Skipped frames: %d", framesQueue.getFPS(),predictionsQueue.getFPS(),framesQueue.counter - predictionsQueue.counter);
+            displayOverlay(kWinName,label,2000);
         }
-        imshow(kWinName, frame);
     }
 
     process = false;

--- a/samples/dnn/object_detection.cpp
+++ b/samples/dnn/object_detection.cpp
@@ -251,7 +251,7 @@ int main(int argc, char** argv)
         if (predictionsQueue.counter > 1)
         {
             int baseLine = 0;
-            std::string label = format("Camera: %.2f FPS, Network: %.2f FPS, Skipped frames: %d", framesQueue.getFPS(),predictionsQueue.getFPS(),framesQueue.counter - predictionsQueue.counter);
+            std::string label = format("Camera: %.2f FPS, Network: %.2f FPS, Skipped frame(s): %d", framesQueue.getFPS(),predictionsQueue.getFPS(),framesQueue.counter - predictionsQueue.counter);
             cv::Size labelSize = getTextSize(label, FONT_HERSHEY_SIMPLEX, 0.5, 1, &baseLine);
             rectangle(frame, Point( 0, 0), Point(labelSize.width, labelSize.height+baseLine), Scalar::all(0), FILLED);
             putText(frame, label, Point(0,labelSize.height), FONT_HERSHEY_SIMPLEX, 0.5, Scalar::all(255));


### PR DESCRIPTION
### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [x] The PR is proposed to proper branch
- [x] There is reference to original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake


 Display overlay for display FPS message.

# Before:
![yolovelho](https://user-images.githubusercontent.com/675645/90588759-cbeda980-e1b2-11ea-8ba1-bf0007083f55.jpg)

# After:
![yolonovo](https://user-images.githubusercontent.com/675645/90588771-d6a83e80-e1b2-11ea-887f-47985d6e9cf0.jpg)