### PR TITLE
Supported ONNX Pow op

### DIFF
--- a/modules/dnn/src/onnx/onnx_importer.cpp
+++ b/modules/dnn/src/onnx/onnx_importer.cpp
@@ -712,6 +712,19 @@ void ONNXImporter::populateNet(Net dstNet)
                 layerParams.set("bias_term", true);
             }
         }
+        else if (layer_type == "Pow")
+        {
+            if (layer_id.find(node_proto.input(1)) != layer_id.end())
+                CV_Error(Error::StsNotImplemented, "Unsupported Pow op with variable power");
+
+            Mat blob = getBlob(node_proto, constBlobs, 1);
+            if (blob.total() != 1)
+                CV_Error(Error::StsNotImplemented, "Pow op supports only scalar power");
+
+            blob.convertTo(blob, CV_32F);
+            layerParams.type = "Power";
+            layerParams.set("power", blob.at<float>(0));
+        }
         else if (layer_type == "Max")
         {
             layerParams.type = "Eltwise";

--- a/modules/dnn/test/test_onnx_importer.cpp
+++ b/modules/dnn/test/test_onnx_importer.cpp
@@ -283,6 +283,11 @@ TEST_P(Test_ONNX_layers, Cast)
     testONNXModels("cast");
 }
 
+TEST_P(Test_ONNX_layers, Power)
+{
+    testONNXModels("pow2", npy, 0, 0, false, false);
+}
+
 TEST_P(Test_ONNX_layers, Concatenation)
 {
     if (backend == DNN_BACKEND_INFERENCE_ENGINE_NN_BUILDER_2019)


### PR DESCRIPTION
resolves: #18179
merge with extra: opencv/opencv_extra#801

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under OpenCV (BSD) License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [x] The PR is proposed to proper branch
- [x] There is reference to original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake



<cut/>

```
force_builders=Custom,Custom Win,Custom Mac
build_image:Custom=ubuntu-openvino-2020.4.0:16.04
build_image:Custom Win=openvino-2020.3.0
build_image:Custom Mac=openvino-2020.3.0

test_modules:Custom=dnn,python2,python3,java
test_modules:Custom Win=dnn,python2,python3,java
test_modules:Custom Mac=dnn,python2,python3,java

buildworker:Custom=linux-1
# disabled due high memory usage: test_opencl:Custom=ON
test_opencl:Custom=OFF
test_bigdata:Custom=1
test_filter:Custom=*
```
