### PR TITLE
[G-API]: Relocation of operators' overloads

### DIFF
--- a/modules/gapi/include/opencv2/gapi/operators.hpp
+++ b/modules/gapi/include/opencv2/gapi/operators.hpp
@@ -11,6 +11,8 @@
 #include <opencv2/gapi/gmat.hpp>
 #include <opencv2/gapi/gscalar.hpp>
 
+namespace cv
+{
 GAPI_EXPORTS cv::GMat operator+(const cv::GMat&    lhs, const cv::GMat&    rhs);
 
 GAPI_EXPORTS cv::GMat operator+(const cv::GMat&    lhs, const cv::GScalar& rhs);
@@ -63,7 +65,6 @@ GAPI_EXPORTS cv::GMat operator<(const cv::GScalar&    lhs, const cv::GMat& rhs);
 GAPI_EXPORTS cv::GMat operator<=(const cv::GScalar&   lhs, const cv::GMat& rhs);
 GAPI_EXPORTS cv::GMat operator==(const cv::GScalar&   lhs, const cv::GMat& rhs);
 GAPI_EXPORTS cv::GMat operator!=(const cv::GScalar&   lhs, const cv::GMat& rhs);
-
-
+} // cv
 
 #endif // OPENCV_GAPI_OPERATORS_HPP

--- a/modules/gapi/src/api/operators.cpp
+++ b/modules/gapi/src/api/operators.cpp
@@ -12,6 +12,8 @@
 #include <opencv2/gapi/gscalar.hpp>
 #include <opencv2/gapi/operators.hpp>
 
+namespace cv
+{
 cv::GMat operator+(const cv::GMat& lhs, const cv::GMat& rhs)
 {
     return cv::gapi::add(lhs, rhs);
@@ -211,3 +213,4 @@ cv::GMat operator!=(const cv::GScalar& lhs, const cv::GMat& rhs)
 {
     return cv::gapi::cmpNE(rhs, lhs);
 }
+} // cv

--- a/modules/gapi/test/common/gapi_operators_tests_inl.hpp
+++ b/modules/gapi/test/common/gapi_operators_tests_inl.hpp
@@ -82,44 +82,22 @@ namespace for_test
 {
 class Foo {};
 
-int operator&(Foo, int);
-int operator&(Foo, int) { return 1; }
+inline int operator&(Foo, int) { return 1; }
+inline int operator|(Foo, int) { return 1; }
+inline int operator^(Foo, int) { return 1; }
+inline int operator~(Foo)      { return 1; }
 
-int operator|(Foo, int);
-int operator|(Foo, int) { return 1; }
+inline int operator+(Foo, int) { return 1; }
+inline int operator-(Foo, int) { return 1; }
+inline int operator*(Foo, int) { return 1; }
+inline int operator/(Foo, int) { return 1; }
 
-int operator^(Foo, int);
-int operator^(Foo, int) { return 1; }
-
-int operator+(Foo, int);
-int operator+(Foo, int) { return 1; }
-
-int operator-(Foo, int);
-int operator-(Foo, int) { return 1; }
-
-int operator*(Foo, int);
-int operator*(Foo, int) { return 1; }
-
-int operator/(Foo, int);
-int operator/(Foo, int) { return 1; }
-
-int operator>(Foo, int);
-int operator>(Foo, int) { return 1; }
-
-int operator>=(Foo, int);
-int operator>=(Foo, int) { return 1; }
-
-int operator<(Foo, int);
-int operator<(Foo, int) { return 1; }
-
-int operator<=(Foo, int);
-int operator<=(Foo, int) { return 1; }
-
-int operator==(Foo, int);
-int operator==(Foo, int) { return 1; }
-
-int operator!=(Foo, int);
-int operator!=(Foo, int) { return 1; }
+inline int operator> (Foo, int) { return 1; }
+inline int operator>=(Foo, int) { return 1; }
+inline int operator< (Foo, int) { return 1; }
+inline int operator<=(Foo, int) { return 1; }
+inline int operator==(Foo, int) { return 1; }
+inline int operator!=(Foo, int) { return 1; }
 
 TEST(CVNamespaceOperatorsTest, OperatorCompilationTest)
 {

--- a/modules/gapi/test/common/gapi_operators_tests_inl.hpp
+++ b/modules/gapi/test/common/gapi_operators_tests_inl.hpp
@@ -82,22 +82,95 @@ namespace for_test
 {
 class Foo {};
 
+int operator&(Foo, int);
+int operator&(Foo, int) { return 1; }
+
 int operator|(Foo, int);
 int operator|(Foo, int) { return 1; }
 
-int operator&(Foo, int);
-int operator&(Foo, int) { return 1; }
+int operator^(Foo, int);
+int operator^(Foo, int) { return 1; }
 
 int operator+(Foo, int);
 int operator+(Foo, int) { return 1; }
 
+int operator-(Foo, int);
+int operator-(Foo, int) { return 1; }
+
+int operator*(Foo, int);
+int operator*(Foo, int) { return 1; }
+
+int operator/(Foo, int);
+int operator/(Foo, int) { return 1; }
+
+int operator>(Foo, int);
+int operator>(Foo, int) { return 1; }
+
+int operator>=(Foo, int);
+int operator>=(Foo, int) { return 1; }
+
+int operator<(Foo, int);
+int operator<(Foo, int) { return 1; }
+
+int operator<=(Foo, int);
+int operator<=(Foo, int) { return 1; }
+
+int operator==(Foo, int);
+int operator==(Foo, int) { return 1; }
+
+int operator!=(Foo, int);
+int operator!=(Foo, int) { return 1; }
+
 TEST(CVNamespaceOperatorsTest, OperatorCompilationTest)
 {
-    cv::GScalar sc1;
-    cv::GMat mat1, mat2;
-    cv::GMat mat3 = mat1 | mat2;
-    cv::GMat mat4 = mat1 & sc1;
-    cv::GMat mat5 = sc1 + mat2;
+    cv::GScalar sc;
+    cv::GMat mat_in1, mat_in2;
+
+    cv::GMat op_not = ~ mat_in1;
+
+    cv::GMat op_mat_mat1  = mat_in1 &  mat_in2;
+    cv::GMat op_mat_mat2  = mat_in1 |  mat_in2;
+    cv::GMat op_mat_mat3  = mat_in1 ^  mat_in2;
+    cv::GMat op_mat_mat4  = mat_in1 +  mat_in2;
+    cv::GMat op_mat_mat5  = mat_in1 -  mat_in2;
+    cv::GMat op_mat_mat6  = mat_in1 /  mat_in2;
+    cv::GMat op_mat_mat7  = mat_in1 >  mat_in2;
+    cv::GMat op_mat_mat8  = mat_in1 >= mat_in2;
+    cv::GMat op_mat_mat9  = mat_in1 <  mat_in2;
+    cv::GMat op_mat_mat10 = mat_in1 <= mat_in2;
+    cv::GMat op_mat_mat11 = mat_in1 == mat_in2;
+    cv::GMat op_mat_mat12 = mat_in1 != mat_in2;
+
+    cv::GMat op_mat_sc1  = mat_in1 &  sc;
+    cv::GMat op_mat_sc2  = mat_in1 |  sc;
+    cv::GMat op_mat_sc3  = mat_in1 ^  sc;
+    cv::GMat op_mat_sc4  = mat_in1 +  sc;
+    cv::GMat op_mat_sc5  = mat_in1 -  sc;
+    cv::GMat op_mat_sc6  = mat_in1 *  sc;
+    cv::GMat op_mat_sc7  = mat_in1 /  sc;
+    cv::GMat op_mat_sc8  = mat_in1 >  sc;
+    cv::GMat op_mat_sc9  = mat_in1 >= sc;
+    cv::GMat op_mat_sc10 = mat_in1 <  sc;
+    cv::GMat op_mat_sc11 = mat_in1 <= sc;
+    cv::GMat op_mat_sc12 = mat_in1 == sc;
+    cv::GMat op_mat_sc13 = mat_in1 != sc;
+
+    cv::GMat op_sc_mat1  = sc &  mat_in2;
+    cv::GMat op_sc_mat2  = sc |  mat_in2;
+    cv::GMat op_sc_mat3  = sc ^  mat_in2;
+    cv::GMat op_sc_mat4  = sc +  mat_in2;
+    cv::GMat op_sc_mat5  = sc -  mat_in2;
+    cv::GMat op_sc_mat6  = sc *  mat_in2;
+    cv::GMat op_sc_mat7  = sc /  mat_in2;
+    cv::GMat op_sc_mat8  = sc >  mat_in2;
+    cv::GMat op_sc_mat9  = sc >= mat_in2;
+    cv::GMat op_sc_mat10 = sc <  mat_in2;
+    cv::GMat op_sc_mat11 = sc <= mat_in2;
+    cv::GMat op_sc_mat12 = sc == mat_in2;
+    cv::GMat op_sc_mat13 = sc != mat_in2;
+
+    cv::GMat mul_mat_float1 = mat_in1 * 1.0f;
+    cv::GMat mul_mat_float2 = 1.0f * mat_in2;
     // No compilation errors expected
 }
 } // for_test

--- a/modules/gapi/test/common/gapi_operators_tests_inl.hpp
+++ b/modules/gapi/test/common/gapi_operators_tests_inl.hpp
@@ -77,6 +77,30 @@ TEST_P(NotOperatorTest, OperatorAccuracyTest)
         EXPECT_EQ(0, cvtest::norm(out_mat_ocv, out_mat_gapi, NORM_INF));
     }
 }
+
+namespace for_test
+{
+class Foo {};
+
+int operator|(Foo, int);
+int operator|(Foo, int) { return 1; }
+
+int operator&(Foo, int);
+int operator&(Foo, int) { return 1; }
+
+int operator+(Foo, int);
+int operator+(Foo, int) { return 1; }
+
+TEST(CVNamespaceOperatorsTest, OperatorCompilationTest)
+{
+    cv::GScalar sc1;
+    cv::GMat mat1, mat2;
+    cv::GMat mat3 = mat1 | mat2;
+    cv::GMat mat4 = mat1 & sc1;
+    cv::GMat mat5 = sc1 + mat2;
+    // No compilation errors expected
+}
+} // for_test
 } // opencv_test
 
 #endif // OPENCV_GAPI_OPERATOR_TESTS_INL_COMMON_HPP


### PR DESCRIPTION
**These changes**:
 - relocate overloaded operators for `cv::GMat` and `cv::GScalar` to `cv::` 
   namespace
 - add a test to check the compilation of operators' usage.

**Explanation**:
Overloads of math (and other) operators for `cv::GMat` and `cv::GScalar` contained in `operators.hpp` are located in a global namespace, which causes conflicts in a particular case: when an operator is called in a non-global namespace and there is another overload of this operator in this namespace - it **hides** our overload situated in the global namespace.

**Example**:
```
#include <opencv2/gapi.hpp>

namespace for_test
{
class A {};
int operator|(A, int);
int operator|(A, int) { return 1; }
cv::GComputationT<cv::GMat(cv::GMat, cv::GMat)> cmp([&](cv::GMat in1, cv::GMat in2)
{
    return in1 | in2;
});
} // namespace for_test
```

**Sources**:
 - [Namespaces and operator resolution]( https://stackoverflow.com/questions/5195512/namespaces-and-operator-resolution);
 - [Where should non-member operator overloads be placed](https://stackoverflow.com/questions/3623631/where-should-non-member-operator-overloads-be-placed)
### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [x] The PR is proposed to proper branch
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake

```
force_builders=Custom,Custom Win,Custom Mac
build_gapi_standalone:Linux x64=ade-0.1.1f
build_gapi_standalone:Win64=ade-0.1.1f
build_gapi_standalone:Mac=ade-0.1.1f
build_gapi_standalone:Linux x64 Debug=ade-0.1.1f

Xbuild_image:Custom=centos:7
Xbuildworker:Custom=linux-1
build_gapi_standalone:Custom=ade-0.1.1f

build_image:Custom=ubuntu-openvino-2020.3.0:16.04
build_image:Custom Win=openvino-2020.3.0
build_image:Custom Mac=openvino-2020.3.0

test_modules:Custom=gapi
test_modules:Custom Win=gapi
test_modules:Custom Mac=gapi

buildworker:Custom=linux-1
# disabled due high memory usage: test_opencl:Custom=ON
test_opencl:Custom=OFF
test_bigdata:Custom=1
test_filter:Custom=*
```
