### PR TITLE
Installation tutorials rework

### DIFF
--- a/doc/stylesheet.css
+++ b/doc/stylesheet.css
@@ -6,18 +6,27 @@ body, table, div, p, dl {
 }
 
 code {
-    font: 12px Consolas, "Liberation Mono", Courier, monospace;
     font-size: 85%;
+    font-family: "SFMono-Regular",Consolas,"Liberation Mono",Menlo,Courier,monospace;
     white-space: pre-wrap;
     padding: 1px 5px;
-    padding: 0;
-    background-color: #ddd;
+    background-color: rgb(223, 229, 241);
     vertical-align: baseline;
 }
 
 body {
     background-image: url(bodybg.png);
     margin: 0 auto;
+}
+
+div.fragment {
+    padding: 3px;
+    padding-bottom: 0px;
+}
+
+div.line {
+    padding-bottom: 3px;
+    font-family: "SFMono-Regular",Consolas,"Liberation Mono",Menlo,Courier,monospace;
 }
 
 div.contents {
@@ -34,4 +43,12 @@ span.arrow {
 
 div.image img{
     max-width: 900px;
+}
+
+#projectlogo
+{
+    text-align: center;
+    vertical-align: middle;
+    border-collapse: separate;
+    padding-left: 0.5em;
 }

--- a/doc/tutorials/introduction/android_binary_package/O4A_SDK.markdown
+++ b/doc/tutorials/introduction/android_binary_package/O4A_SDK.markdown
@@ -4,6 +4,13 @@ OpenCV4Android SDK {#tutorial_O4A_SDK}
 @prev_tutorial{tutorial_android_dev_intro}
 @next_tutorial{tutorial_dev_with_OCV_on_Android}
 
+|    |    |
+| -: | :- |
+| Original author | Vsevolod Glumov |
+| Compatibility | OpenCV >= 3.0 |
+
+@warning
+This tutorial is deprecated.
 
 This tutorial was designed to help you with installation and configuration of OpenCV4Android SDK.
 

--- a/doc/tutorials/introduction/android_binary_package/android_dev_intro.markdown
+++ b/doc/tutorials/introduction/android_binary_package/android_dev_intro.markdown
@@ -4,6 +4,14 @@ Introduction into Android Development {#tutorial_android_dev_intro}
 @prev_tutorial{tutorial_clojure_dev_intro}
 @next_tutorial{tutorial_O4A_SDK}
 
+|    |    |
+| -: | :- |
+| Original author | Vsevolod Glumov |
+| Compatibility | OpenCV >= 3.0 |
+
+@warning
+This tutorial is deprecated.
+
 
 This guide was designed to help you in learning Android development basics and setting up your
 working environment quickly. It was written with Windows 7 in mind, though it would work with Linux

--- a/doc/tutorials/introduction/android_binary_package/android_ocl_intro.markdown
+++ b/doc/tutorials/introduction/android_binary_package/android_ocl_intro.markdown
@@ -4,6 +4,13 @@ Use OpenCL in Android camera preview based CV application {#tutorial_android_ocl
 @prev_tutorial{tutorial_dev_with_OCV_on_Android}
 @next_tutorial{tutorial_macos_install}
 
+|    |    |
+| -: | :- |
+| Original author | Andrey Pavlenko |
+| Compatibility | OpenCV >= 3.0 |
+
+@warning
+This tutorial is deprecated.
 
 This guide was designed to help you in use of [OpenCL &trade;](https://www.khronos.org/opencl/) in Android camera preview based CV application.
 It was written for [Eclipse-based ADT tools](http://developer.android.com/tools/help/adt.html)

--- a/doc/tutorials/introduction/android_binary_package/dev_with_OCV_on_Android.markdown
+++ b/doc/tutorials/introduction/android_binary_package/dev_with_OCV_on_Android.markdown
@@ -4,6 +4,13 @@ Android Development with OpenCV {#tutorial_dev_with_OCV_on_Android}
 @prev_tutorial{tutorial_O4A_SDK}
 @next_tutorial{tutorial_android_ocl_intro}
 
+|    |    |
+| -: | :- |
+| Original author | Vsevolod Glumov |
+| Compatibility | OpenCV >= 3.0 |
+
+@warning
+This tutorial is deprecated.
 
 This tutorial has been created to help you use OpenCV library within your Android project.
 

--- a/doc/tutorials/introduction/building_tegra_cuda/building_tegra_cuda.markdown
+++ b/doc/tutorials/introduction/building_tegra_cuda/building_tegra_cuda.markdown
@@ -4,6 +4,13 @@ Building OpenCV for Tegra with CUDA {#tutorial_building_tegra_cuda}
 @prev_tutorial{tutorial_arm_crosscompile_with_cmake}
 @next_tutorial{tutorial_display_image}
 
+|    |    |
+| -: | :- |
+| Original author |  Randy J. Ray |
+| Compatibility | OpenCV >= 3.1.0 |
+
+@warning
+This tutorial is deprecated.
 
 @tableofcontents
 

--- a/doc/tutorials/introduction/clojure_dev_intro/clojure_dev_intro.markdown
+++ b/doc/tutorials/introduction/clojure_dev_intro/clojure_dev_intro.markdown
@@ -4,6 +4,13 @@ Introduction to OpenCV Development with Clojure {#tutorial_clojure_dev_intro}
 @prev_tutorial{tutorial_java_eclipse}
 @next_tutorial{tutorial_android_dev_intro}
 
+|    |    |
+| -: | :- |
+| Original author | Mimmo Cosenza |
+| Compatibility | OpenCV >= 3.0 |
+
+@warning
+This tutorial can contain obsolete information.
 
 As of OpenCV 2.4.4, OpenCV supports desktop Java development using nearly the same interface as for
 Android development.

--- a/doc/tutorials/introduction/config_reference/config_reference.markdown
+++ b/doc/tutorials/introduction/config_reference/config_reference.markdown
@@ -201,6 +201,7 @@ cmake -DCV_DISABLE_OPTIMIZATION=ON ../opencv
 @note
 More details on CPU optimization options can be found in wiki: https://github.com/opencv/opencv/wiki/CPU-optimizations-build-options
 
+
 ## Profiling, coverage, sanitize, hardening, size optimization
 
 Following options can be used to produce special builds with instrumentation or improved security. All options are disabled by default.
@@ -227,7 +228,8 @@ There are many optional dependencies and features that can be turned on or off. 
 cmake -LH ../opencv
 ```
 
-## Options scheme
+
+## Options naming conventions
 
 There are three kinds of options used to control dependencies of the library, they have different prefixes:
 - Options starting with `WITH_` enable or disable a dependency
@@ -253,7 +255,7 @@ Some tutorials can be found in the corresponding section: @ref tutorial_table_of
 
 @see https://en.wikipedia.org/wiki/CUDA
 
-TODO: other options: `WITH_CUFFT`, `WITH_CUBLAS`, `WITH_CUDNN`, `WITH_NVCUVID`?
+TODO: other options: `WITH_CUFFT`, `WITH_CUBLAS`, WITH_NVCUVID`?
 
 ### OpenCL support
 
@@ -352,11 +354,13 @@ Enables MSMF backend which uses Windows' built-in [Media Foundation framework](h
 
 @note Older versions of Windows (prior to 10) can have incompatible versions of Media Foundation and are known to have problems when used from OpenCV.
 
+
 ### DirectShow
 
 `WITH_DSHOW` (Windows; default: _ON_)
 
 This backend uses older [DirectShow](https://en.wikipedia.org/wiki/DirectShow) framework. It can be used only to capture frames from camera. It is now deprecated in favor of MSMF backend, although both can be enabled in the same build.
+
 
 ### AVFoundation
 
@@ -364,12 +368,13 @@ This backend uses older [DirectShow](https://en.wikipedia.org/wiki/DirectShow) f
 
 [AVFoundation](https://en.wikipedia.org/wiki/AVFoundation) framework is part of Apple platforms and can be used to capture frames from camera, encode and decode video files.
 
+
 ### Other backends
 
 There are multiple less popular frameworks which can be used to read and write videos. Each requires corresponding library or SDK installed.
 
-| Option | Default | Info |
-| --------| ------ | ------- |
+| Option | Default | Description |
+| ------ | ------- | ----------- |
 | `WITH_1394` | _ON_ | [IIDC IEEE1394](https://en.wikipedia.org/wiki/IEEE_1394#IIDC) support using DC1394 library |
 | `WITH_OPENNI` | _OFF_ | [OpenNI](https://en.wikipedia.org/wiki/OpenNI) can be used to capture data from depth-sensing cameras. Deprecated. |
 | `WITH_OPENNI2` | _OFF_ | [OpenNI2](https://structure.io/openni) can be used to capture data from depth-sensing cameras. |
@@ -387,9 +392,11 @@ There are multiple less popular frameworks which can be used to read and write v
 
 Some _videoio_ backends can be built as plugins thus breaking strict dependency on third-party libraries and making them optional at runtime. Following options can be used to control this mechanism:
 
-- `VIDEOIO_ENABLE_PLUGINS`, default is _ON_ - enable or disable plugins completely
-- `VIDEOIO_PLUGIN_LIST`, default is _empty_ - comma- or semicolon-separated list of backend names to be compiled as plugins. Supported names are _ffmpeg_, _gstreamer_, _msmf_, _mfx_ and _all_.
-- `VIDEOIO_ENABLE_STRICT_PLUGIN_CHECK`, default is _ON_ - enable strict runtime version check to only allow plugins built with the same version of OpenCV
+| Option | Default | Description |
+| --------| ------ | ------- |
+| `VIDEOIO_ENABLE_PLUGINS` | _ON_ | Enable or disable plugins completely. |
+| `VIDEOIO_PLUGIN_LIST` | _empty_ | Comma- or semicolon-separated list of backend names to be compiled as plugins. Supported names are _ffmpeg_, _gstreamer_, _msmf_, _mfx_ and _all_. |
+| `VIDEOIO_ENABLE_STRICT_PLUGIN_CHECK` | _ON_ | Enable strict runtime version check to only allow plugins built with the same version of OpenCV. |
 
 
 ## Parallel processing {#tutorial_config_reference_func_core}
@@ -407,7 +414,8 @@ Some of OpenCV algorithms can use multithreading to accelerate processing. OpenC
 
 @note OpenCV can download and build TBB library from GitHub, this functionality can be enabled with the `BUILD_TBB` option.
 
-## GUI backend (highgui module) {#tutorial_config_reference_highgui}
+
+## GUI backends (highgui module) {#tutorial_config_reference_highgui}
 
 OpenCV relies on various GUI libraries for window drawing.
 
@@ -418,13 +426,33 @@ OpenCV relies on various GUI libraries for window drawing.
 | N/A | _ON_ | macOS | [Cocoa](https://en.wikipedia.org/wiki/Cocoa_(API)) is a framework used in macOS. |
 | `WITH_QT` | _OFF_ | Cross-platform | [Qt](https://en.wikipedia.org/wiki/Qt_(software)) is a cross-platform GUI framework. |
 
-@note OpenCV compiled with Qt support allows use of advanced _highgui_ interface, see @ref highgui_qt for details.
+@note OpenCV compiled with Qt support enables advanced _highgui_ interface, see @ref highgui_qt for details.
+
 
 ### OpenGL
 
 `WITH_OPENGL` (default: _OFF_)
 
 OpenGL integration can be used to draw HW-accelerated windows with following backends: GTK, WIN32 and Qt. And enables basic interoperability with OpenGL, see @ref core_opengl and @ref highgui_opengl for details.
+
+
+## Deep learning neural networks inference backends and options (dnn module) {#tutorial_config_reference_dnn}
+
+OpenCV have own DNN inference module which have own build-in engine, but can also use other libraries for optimized processing. Multiple backends can be enabled in single build. Selection happens at runtime automatically or manually.
+
+| Option | Default | Description |
+| ------ | ------- | ----------- |
+| `WITH_PROTOBUF` | _ON_ | Enables [protobuf](https://en.wikipedia.org/wiki/Protocol_Buffers) library search. OpenCV can either build own copy of the library or use external one. This dependency is required by the _dnn_ module, if it can't be found module will be disabled. |
+| `BUILD_PROTOBUF` | _ON_ | Build own copy of _protobuf_. Must be disabled if you want to use external library. |
+| `PROTOBUF_UPDATE_FILES` | _OFF_ | Re-generate all .proto files. _protoc_ compiler compatible with used version of _protobuf_ must be installed. |
+| `OPENCV_DNN_OPENCL` | _ON_ | Enable built-in OpenCL inference backend. |
+| `WITH_INF_ENGINE` | _OFF_ | Enables [Intel Inference Engine (IE)](https://github.com/openvinotoolkit/openvino) backend. Allows to execute networks in IE format (.xml + .bin). Inference Engine must be installed either as part of [OpenVINO toolkit](https://en.wikipedia.org/wiki/OpenVINO), either as a standalone library built from sources. |
+| `INF_ENGINE_RELEASE` | _2020040000_ | Defines version of Inference Engine library which is tied to OpenVINO toolkit version. Must be a 10-digit string, e.g. _2020040000_ for OpenVINO 2020.4. |
+| `WITH_NGRAPH` | _OFF_ | Enables Intel NGraph library support. This library is part of Inference Engine backend which allows executing arbitrary networks read from files in multiple formats supported by OpenCV: Caffe, TensorFlow, PyTorch, Darknet, etc.. NGraph library must be installed, it is included into Inference Engine. |
+| `OPENCV_DNN_CUDA` | _OFF_ | Enable CUDA backend. [CUDA](https://en.wikipedia.org/wiki/CUDA), CUBLAS and [CUDNN](https://developer.nvidia.com/cudnn) must be installed. |
+| `WITH_HALIDE` | _OFF_ | Use experimental [Halide](https://en.wikipedia.org/wiki/Halide_(programming_language)) backend which can generate optimized code for dnn-layers at runtime. Halide must be installed. |
+| `WITH_VULKAN` | _OFF_ | Enable experimental [Vulkan](https://en.wikipedia.org/wiki/Vulkan_(API)) backend. Does not require additional dependencies, but can use external Vulkan headers (`VULKAN_INCLUDE_DIRS`). |
+| `WITH_TENGINE` | _OFF_ | Enable experimental [Tengine](https://github.com/OAID/Tengine) backend for ARM CPUs. Tengine library must be installed. |
 
 
 # Installation layout {#tutorial_config_reference_install}
@@ -455,6 +483,7 @@ On some platforms (Linux) it is possible to remove symbol information during ins
 ```.sh
 cmake --build . --target install/strip
 ```
+
 
 ## Components and locations {#tutorial_config_reference_install_comp}
 
@@ -505,19 +534,33 @@ Following options can be used to change installation layout for common scenarios
 | ------ | ------- | ----------- |
 | `OPENCV_ENABLE_NONFREE` | _OFF_ | Some algorithms included in the library are known to be protected by patents and are disabled by default. |
 | `OPENCV_FORCE_3RDPARTY_BUILD`| _OFF_ | Enable all `BUILD_` options at once. |
-| `ENABLE_CCACHE` | _ON_ (on Unix-like platforms) | Enable [ccache](https://en.wikipedia.org/wiki/Ccache) auto-detection. This tool wraps compiler calls and caches results, can significantly improve re-compilation time.  |
+| `ENABLE_CCACHE` | _ON_ (on Unix-like platforms) | Enable [ccache](https://en.wikipedia.org/wiki/Ccache) auto-detection. This tool wraps compiler calls and caches results, can significantly improve re-compilation time. |
 | `ENABLE_PRECOMPILED_HEADERS` | _ON_ (for MSVC) | Enable precompiled headers support. Improves build time. |
 | `BUILD_DOCS` | _OFF_ | Enable documentation build (_doxygen_, _doxygen_cpp_, _doxygen_python_, _doxygen_javadoc_ targets). [Doxygen](http://www.doxygen.org/index.html) must be installed for C++ documentation build. Python and [BeautifulSoup4](https://en.wikipedia.org/wiki/Beautiful_Soup_(HTML_parser)) must be installed for Python documentation build. Javadoc and Ant must be installed for Java documentation build (part of Java SDK). |
 | `ENABLE_PYLINT` | _ON_ (when docs or examples are enabled) | Enable python scripts check with [Pylint](https://en.wikipedia.org/wiki/Pylint) (_check_pylint_ target). Pylint must be installed. |
 | `ENABLE_FLAKE8` | _ON_ (when docs or examples are enabled) | Enable python scripts check with [Flake8](https://flake8.pycqa.org/) (_check_flake8_ target). Flake8 must be installed. |
-| `BUILD_JAVA` | _ON_ | Enable Java wrappers build. |
+| `BUILD_JAVA` | _ON_ | Enable Java wrappers build. Java SDK and Ant must be installed. |
 | `BUILD_FAT_JAVA_LIB` | _ON_ (for static Android builds) | Build single _opencv_java_ dynamic library containing all library functionality bundled with Java bindings. |
-| `BUILD_opencv_python2` | _ON_ | Build python2 bindings (deprecated). |
-| `BUILD_opencv_python3` | _ON_ | Build python3 bindings. |
+| `BUILD_opencv_python2` | _ON_ | Build python2 bindings (deprecated). Python with development files and numpy must be installed. |
+| `BUILD_opencv_python3` | _ON_ | Build python3 bindings. Python with development files and numpy must be installed. |
 
 TODO: need separate tutorials covering bindings builds
 
-## Android
+
+## Automated builds
+
+Some features have been added specifically for automated build environments, like continuous integration and packaging systems.
+
+| Option | Default | Description |
+| ------ | ------- | ----------- |
+| `ENABLE_NOISY_WARNINGS` | _OFF_ | Enables several compiler warnings considered _noisy_, i.e. having less importance than others. These warnings are usually ignored but in some cases can be worth being checked for. |
+| `OPENCV_WARNINGS_ARE_ERRORS` | _OFF_ | Treat compiler warnings as errors. Build will be halted. |
+| `ENABLE_CONFIG_VERIFICATION` | _OFF_ | For each enabled dependency (`WITH_` option) verify that it has been found and enabled (`HAVE_` variable). By default feature will be silently turned off if dependency was not found, but with this option enabled cmake configuration will fail. Convenient for packaging systems which require stable library configuration not depending on environment fluctuations. |
+| `OPENCV_CMAKE_HOOKS_DIR` | _empty_ | OpenCV allows to customize configuration process by adding custom hook scripts at each stage and substage. cmake scripts with predefined names located in the directory set by this variable will be included before and after various configuration stages. Examples of file names: _CMAKE_INIT.cmake_, _PRE_CMAKE_BOOTSTRAP.cmake_, _POST_CMAKE_BOOTSTRAP.cmake_, etc.. Other names are not documented and can be found in the project cmake files by searching for the _ocv_cmake_hook_ macro calls. |
+| `OPENCV_DUMP_HOOKS_FLOW` | _OFF_ | Enables a debug message print on each cmake hook script call. |
+
+
+# Other non-documented options
 
 `BUILD_ANDROID_PROJECTS`
 `BUILD_ANDROID_EXAMPLES`
@@ -526,34 +569,16 @@ TODO: need separate tutorials covering bindings builds
 `ANDROID_NDK`
 `ANDROID_SDK_ROOT`
 
-
-## Cross-compilation
-
-CMAKE_TOOLCHAIN_FILE
-
-
-## Automated builds
-
-`ENABLE_NOISY_WARNINGS`
-`OPENCV_WARNINGS_ARE_ERRORS`
-`ENABLE_CONFIG_VERIFICATION`
-`OPENCV_CMAKE_HOOKS_DIR`
-`OPENCV_DUMP_HOOKS_FLOW`
-
-# TODO
+`CMAKE_TOOLCHAIN_FILE`
 
 `WITH_CAROTENE`
 `WITH_CPUFEATURES`
 `WITH_EIGEN`
-`WITH_HALIDE`
-`WITH_VULKAN`
-`WITH_INF_ENGINE`
 `WITH_OPENVX`
 `WITH_CLP`
 `WITH_DIRECTX`
 `WITH_VA`
 `WITH_LAPACK`
-`WITH_PROTOBUF`
 `WITH_QUIRC`
 `BUILD_ZLIB`
 `BUILD_ITT`

--- a/doc/tutorials/introduction/config_reference/config_reference.markdown
+++ b/doc/tutorials/introduction/config_reference/config_reference.markdown
@@ -1,0 +1,561 @@
+OpenCV configuration options reference {#tutorial_config_reference}
+======================================
+
+@tableofcontents
+
+# Introduction {#tutorial_config_reference_intro}
+
+@note
+We assume you have read @ref tutorial_general_install tutorial or have experience with CMake.
+
+Configuration options can be set in several different ways:
+* Command line: `cmake -Doption=value ...`
+* Initial cache files: `cmake -C my_options.txt ...`
+* Interactive via GUI
+
+In this reference we will use regular command line.
+
+Most of the options can be found in the root cmake script of OpenCV: `opencv/CMakeLists.txt`. Some options can be defined in specific modules.
+
+It is possible to use CMake tool to print all available options:
+```.sh
+# initial configuration
+cmake ../opencv
+
+# print all options
+cmake -L
+
+# print all options with help message
+cmake -LH
+
+# print all options including advanced
+cmake -LA
+```
+
+Most popular and useful are options starting with `WITH_`, `ENABLE_`, `BUILD_`, `OPENCV_`.
+
+Default values vary depending on platform and other options values.
+
+
+# General options {#tutorial_config_reference_general}
+
+## Build with extra modules {#tutorial_config_reference_general_contrib}
+
+`OPENCV_EXTRA_MODULES_PATH` option contains a semicolon-separated list of directories containing extra modules which will be added to the build. Module directory must have compatible layout and CMakeLists.txt, brief description can be found in the [Coding Style Guide](https://github.com/opencv/opencv/wiki/Coding_Style_Guide).
+
+Examples:
+```.sh
+# build with all modules in opencv_contrib
+cmake -DOPENCV_EXTRA_MODULES_PATH=../opencv_contrib/modules ../opencv
+
+# build with one of opencv_contrib modules
+cmake -DOPENCV_EXTRA_MODULES_PATH=../opencv_contrib/modules/bgsegm ../opencv
+
+# build with two custom modules (semicolon must be escaped in bash)
+cmake -DOPENCV_EXTRA_MODULES_PATH=../my_mod1\;../my_mod2 ../opencv
+```
+
+@note
+Only 0- and 1-level deep module locations are supported, following command will raise an error:
+```.sh
+cmake -DOPENCV_EXTRA_MODULES_PATH=../opencv_contrib ../opencv
+```
+
+
+## Debug build {#tutorial_config_reference_general_debug}
+
+`CMAKE_BUILD_TYPE` option can be used to enable debug build; resulting binaries will contain debug symbols and most of compiler optimizations will be turned off. To enable debug symbols in Release build turn the `BUILD_WITH_DEBUG_INFO` option on.
+
+On some platforms (e.g. Linux) build type must be set at configuration stage:
+```.sh
+cmake -DCMAKE_BUILD_TYPE=Debug ../opencv
+cmake --build .
+```
+On other platforms different types of build can be produced in the same build directory (e.g. Visual Studio, XCode):
+```.sh
+cmake <options> ../opencv
+cmake --build . --config Debug
+```
+
+If you use GNU libstdc++ (default for GCC) you can turn on the `ENABLE_GNU_STL_DEBUG` option, then C++ library will be used in Debug mode, e.g. indexes will be bound-checked during vector element access.
+
+Many kinds of optimizations can be disabled with `CV_DISABLE_OPTIMIZATION` option:
+* Some third-party libraries (e.g. IPP, Lapack, Eigen)
+* Explicit vectorized implementation (universal intrinsics, raw intrinsics, etc.)
+* Dispatched optimizations
+* Explicit loop unrolling
+
+@see https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html
+@see https://gcc.gnu.org/onlinedocs/libstdc++/manual/using_macros.html
+@see https://github.com/opencv/opencv/wiki/CPU-optimizations-build-options
+
+
+## Static build {#tutorial_config_reference_general_static}
+
+`BUILD_SHARED_LIBS` option control whether to produce dynamic (.dll, .so, .dylib) or static (.a, .lib) libraries. Default value depends on target platform, in most cases it is `ON`.
+
+Example:
+```.sh
+cmake -DBUILD_SHARED_LIBS=OFF ../opencv
+```
+
+@see https://en.wikipedia.org/wiki/Static_library
+
+`ENABLE_PIC` sets the [CMAKE_POSITION_INDEPENDENT_CODE](https://cmake.org/cmake/help/latest/variable/CMAKE_POSITION_INDEPENDENT_CODE.html) option. It enables or disable generation of "position-independent code". This option must be enabled when building dynamic libraries or static libraries intended to be linked into dynamic libraries. Default value is `ON`.
+
+@see https://en.wikipedia.org/wiki/Position-independent_code
+
+
+## Generate pkg-config info
+
+`OPENCV_GENERATE_PKGCONFIG` option enables `.pc` file generation along with standard CMake package. This file can be useful for projects which do not use CMake for build.
+
+Example:
+```.sh
+cmake -DOPENCV_GENERATE_PKGCONFIG=ON ../opencv
+```
+
+@note
+Due to complexity of configuration process resulting `.pc` file can contain incomplete list of third-party dependencies and may not work in some configurations, especially for static builds. This feature is not officially supported since 4.x version and is disabled by default.
+
+
+## Build tests, samples and applications {#tutorial_config_reference_general_tests}
+
+There are two kinds of tests: accuracy (`opencv_test_*`) and performance (`opencv_perf_*`). Tests and applications are enabled by default. Examples are not being built by default and should be enabled explicitly.
+
+Corresponding _cmake_ options:
+```.sh
+cmake \
+  -DBUILD_TESTS=ON \
+  -DBUILD_PERF_TESTS=ON \
+  -DBUILD_EXAMPLES=ON \
+  -DBUILD_opencv_apps=ON \
+  ../opencv
+```
+
+
+## Build limited set of modules {#tutorial_config_reference_general_modules}
+
+Each module is a subdirectory of the `modules` directory. It is possible to disable one module:
+```.sh
+cmake -DBUILD_opencv_calib3d=OFF ../opencv
+```
+
+The opposite option is to build only specified modules and all modules they depend on:
+```.sh
+cmake -DBUILD_LIST=calib3d,videoio,ts ../opencv
+```
+In this example we requested 3 modules and configuration script has determined all dependencies automatically:
+```
+--   OpenCV modules:
+--     To be built:                 calib3d core features2d flann highgui imgcodecs imgproc ts videoio
+```
+
+
+## Downloaded dependencies {#tutorial_config_reference_general_download}
+
+Configuration script can try to download additional libraries and files from the internet, if it fails to do it corresponding features will be turned off. In some cases configuration error can occur. By default all files are first downloaded to the `<source>/.cache` directory and then unpacked or copied to the build directory. It is possible to change download cache location by setting environment variable or configuration option:
+```.sh
+export OPENCV_DOWNLOAD_PATH=/tmp/opencv-cache
+cmake ../opencv
+# or
+cmake -DOPENCV_DOWNLOAD_PATH=/tmp/opencv-cache ../opencv
+```
+
+In case of access via proxy, corresponding environment variables should be set before running cmake:
+```.sh
+export http_proxy=<proxy-host>:<port>
+export https_proxy=<proxy-host>:<port>
+```
+
+Full log of download process can be found in build directory - `CMakeDownloadLog.txt`. In addition, for each failed download a command will be added to helper scripts in the build directory, e.g. `download_with_wget.sh`. Users can run these scripts as is or modify according to their needs.
+
+
+## CPU optimization level {#tutorial_config_reference_general_cpu}
+
+On x86_64 machines the library will be compiled for SSE3 instruction set level by default. This level can be changed by configuration option:
+```.sh
+cmake -DCPU_BASELINE=AVX2 ../opencv
+```
+
+@note
+Other platforms have their own instruction set levels: `VFPV3` and `NEON` on ARM, `VSX` on PowerPC.
+
+Some functions support dispatch mechanism allowing to compile them for several instruction sets and to choose one during runtime. List of enabled instruction sets can be changed during configuration:
+```.sh
+cmake -DCPU_DISPATCH=AVX,AVX2 ../opencv
+```
+To disable dispatch mechanism this option should be set to an empty value:
+```.sh
+cmake -DCPU_DISPATCH= ../opencv
+```
+
+It is possible to disable optimized parts of code for troubleshooting and debugging:
+```.sh
+# disable universal intrinsics
+cmake -DCV_ENABLE_INTRINSICS=OFF ../opencv
+# disable all possible built-in optimizations
+cmake -DCV_DISABLE_OPTIMIZATION=ON ../opencv
+```
+
+@note
+More details on CPU optimization options can be found in wiki: https://github.com/opencv/opencv/wiki/CPU-optimizations-build-options
+
+## Profiling, coverage, sanitize, hardening, size optimization
+
+Following options can be used to produce special builds with instrumentation or improved security. All options are disabled by default.
+
+| Option | Compiler | Description |
+| `ENABLE_PROFILING` | GCC or Clang | Enable profiling compiler and linker options. |
+| `ENABLE_COVERAGE` | GCC or Clang | Enable code coverage support. |
+| `OPENCV_ENABLE_MEMORY_SANITIZER` | N/A | Enable several quirks in code to assist memory sanitizer. |
+| `ENABLE_BUILD_HARDENING` | GCC, Clang, MSVC | Enable compiler options which reduce possibility of code exploitation.  |
+| `ENABLE_LTO` | GCC, Clang, MSVC | Enable Link Time Optimization (LTO). |
+| `ENABLE_THIN_LTO` | Clang | Enable thin LTO which incorporates intermediate bitcode to binaries allowing consumers optimize their applications later. |
+
+@see [GCC instrumentation](https://gcc.gnu.org/onlinedocs/gcc/Instrumentation-Options.html)
+@see [Build hardening](https://en.wikipedia.org/wiki/Hardening_(computing))
+@see [Interprocedural optimization](https://en.wikipedia.org/wiki/Interprocedural_optimization)
+@see [Link time optimization](https://gcc.gnu.org/wiki/LinkTimeOptimization)
+@see [ThinLTO](https://clang.llvm.org/docs/ThinLTO.html)
+
+
+# Functional features and dependencies {#tutorial_config_reference_func}
+
+There are many optional dependencies and features that can be turned on or off. _cmake_ has special option allowing to print all available configuration parameters:
+```.sh
+cmake -LH ../opencv
+```
+
+## Options scheme
+
+There are three kinds of options used to control dependencies of the library, they have different prefixes:
+- Options starting with `WITH_` enable or disable a dependency
+- Options starting with `BUILD_` enable or disable building and using 3rdparty library bundled with OpenCV
+- Options starting with `HAVE_` indicate that dependency have been enabled, can be used to manually enable a dependency if automatic detection can not be used.
+
+When `WITH_` option is enabled:
+- If `BUILD_` option is enabled, 3rdparty library will be built and enabled => `HAVE_` set to `ON`
+- If `BUILD_` option is disabled, 3rdparty library will be detected and enabled if found => `HAVE_` set to `ON` if dependency is found
+
+
+## Heterogeneous computation {#tutorial_config_reference_func_hetero}
+
+### CUDA support
+
+`WITH_CUDA` (default: _OFF_)
+
+Many algorithms have been implemented using CUDA acceleration, these functions are located in separate modules: @ref cuda. CUDA toolkit must be installed from the official NVIDIA site as a prerequisite. For cmake versions older than 3.9 OpenCV uses own `cmake/FindCUDA.cmake` script, for newer versions - the one packaged with CMake. Additional options can be used to control build process, e.g. `CUDA_GENERATION` or `CUDA_ARCH_BIN`. These parameters are not documented yet, please consult with the `cmake/OpenCVDetectCUDA.cmake` script for details.
+
+Some tutorials can be found in the corresponding section: @ref tutorial_table_of_content_gpu
+
+@note Since OpenCV version 4.0 all CUDA-accelerated algorithm implementations have been moved to the _opencv_contrib_ repository. To build _opencv_ and _opencv_contrib_ together check @ref tutorial_config_reference_general_contrib.
+
+@see https://en.wikipedia.org/wiki/CUDA
+
+TODO: other options: `WITH_CUFFT`, `WITH_CUBLAS`, `WITH_CUDNN`, `WITH_NVCUVID`?
+
+### OpenCL support
+
+`WITH_OPENCL` (default: _ON_)
+
+Multiple OpenCL-accelerated algorithms are available via so-called "Transparent API (T-API)". This integration uses same functions at the user level as regular CPU implementations. Switch to the OpenCL execution branch happens if input and output image arguments are passed as opaque cv::UMat objects. More information can be found in [the brief introduction](https://opencv.org/opencl/) and @ref core_opencl
+
+At the build time this feature does not have any prerequisites. During runtime a working OpenCL runtime is required, to check it run `clinfo` and/or `opencv_version --opencl` command. Some parameters of OpenCL integration can be modified using environment variables, e.g. `OPENCV_OPENCL_DEVICE`. However there is no thorough documentation for this feature yet, so please check the source code in `modules/core/src/ocl.cpp` file for details.
+
+@see https://en.wikipedia.org/wiki/OpenCL
+
+TODO: other options: `WITH_OPENCL_SVM`, `WITH_OPENCLAMDFFT`, `WITH_OPENCLAMDBLAS`, `WITH_OPENCL_D3D11_NV`, `WITH_VA_INTEL`
+
+## Image reading and writing (imgcodecs module)  {#tutorial_config_reference_func_imgcodecs}
+
+### Built-in formats
+
+Following formats can be read by OpenCV without help of any third-party library:
+
+- [BMP](https://en.wikipedia.org/wiki/BMP_file_format)
+- [HDR](https://en.wikipedia.org/wiki/RGBE_image_format) (`WITH_IMGCODEC_HDR`)
+- [Sun Raster](https://en.wikipedia.org/wiki/Sun_Raster) (`WITH_IMGCODEC_SUNRASTER`)
+- [PPM, PGM, PBM, PFM](https://en.wikipedia.org/wiki/Netpbm#File_formats) (`WITH_IMGCODEC_PXM`, `WITH_IMGCODEC_PFM`)
+
+
+### PNG, JPEG, TIFF, WEBP support
+
+| Formats | Option | Default | Force build own |
+| --------| ------ | ------- | --------------- |
+| [PNG](https://en.wikipedia.org/wiki/Portable_Network_Graphics) | `WITH_PNG` | _ON_ | `BUILD_PNG` |
+| [JPEG](https://en.wikipedia.org/wiki/JPEG) | `WITH_JPEG` | _ON_ | `BUILD_JPEG` |
+| [TIFF](https://en.wikipedia.org/wiki/TIFF) | `WITH_TIFF` | _ON_ | `BUILD_TIFF` |
+| [WEBP](https://en.wikipedia.org/wiki/WebP) | `WITH_WEBP` | _ON_ | `BUILD_WEBP` |
+| [JPEG2000 with OpenJPEG](https://en.wikipedia.org/wiki/OpenJPEG) | `WITH_OPENJPEG` | _ON_ | `BUILD_OPENJPEG` |
+| [JPEG2000 with JasPer](https://en.wikipedia.org/wiki/JasPer) | `WITH_JASPER` | _ON_ (see note) | `BUILD_JASPER` |
+| [EXR](https://en.wikipedia.org/wiki/OpenEXR) | `WITH_OPENEXR` | _ON_ | `BUILD_OPENEXR` |
+
+All libraries required to read images in these formats are included into OpenCV and will be built automatically if not found at the configuration stage. Corresponding `BUILD_*` options will force building and using own libraries, they are enabled by default on some platforms, e.g. Windows.
+
+@note OpenJPEG have higher priority than JasPer which is deprecated. In order to use JasPer, OpenJPEG must be disabled.
+
+
+### GDAL integration
+
+`WITH_GDAL` (default: _OFF_)
+
+[GDAL](https://en.wikipedia.org/wiki/GDAL) is a higher level library which supports reading multiple file formats including PNG, JPEG and TIFF. It will have higher priority when opening files and can override other backends. This library will be searched using cmake package mechanism, make sure it is installed correctly or manually set `GDAL_DIR` environment or cmake variable.
+
+
+### GDCM integration
+
+`WITH_GDCM` (default: _OFF_)
+
+Enables [DICOM](https://en.wikipedia.org/wiki/DICOM) medical image format support through [GDCM  library](https://en.wikipedia.org/wiki/GDCM). This library will be searched using cmake package mechanism, make sure it is installed correctly or manually set `GDCM_DIR` environment or cmake variable.
+
+
+## Video reading and writing (videoio module) {#tutorial_config_reference_func_videoio}
+
+TODO: how videoio works, registry, priorities
+
+### Video4Linux
+
+`WITH_V4L` (Linux; default: _ON_ )
+
+Capture images from camera using [Video4Linux](https://en.wikipedia.org/wiki/Video4Linux) API. Linux kernel headers must be installed.
+
+### FFmpeg
+
+`WITH_FFMPEG` (default: _ON_)
+
+Integration with [FFmpeg](https://en.wikipedia.org/wiki/FFmpeg) library for decoding and encoding video files and network streams. This library can read and write many popular video formats. It consists of several components which must be installed as prerequisites for the build:
+- _avcodec_
+- _avformat_
+- _avutil_
+- _swscale_
+- _avresample_ (optional)
+
+Exception is Windows platform where a prebuilt [plugin library containing FFmpeg](https://github.com/opencv/opencv_3rdparty/tree/ffmpeg/master) will be downloaded during a configuration stage and copied to the `bin` folder with all produced libraries.
+
+@note [Libav](https://en.wikipedia.org/wiki/Libav) library can be used instead of FFmpeg, but this combination is not actively supported.
+
+### GStreamer
+
+`WITH_GSTREAMER` (default: _ON_)
+
+Enable integration with [GStreamer](https://en.wikipedia.org/wiki/GStreamer) library for decoding and encoding video files, capturing frames from cameras and network streams. Numerous plugins can be installed to extend supported formats list. OpenCV allows running arbitrary GStreamer pipelines passed as strings to @ref cv::VideoCapture and @ref cv::VideoWriter objects.
+
+Various GStreamer plugins offer HW-accelerated video processing on different platforms.
+
+
+### Microsoft Media Foundation
+
+`WITH_MSMF` (Windows; default: _ON_)
+
+Enables MSMF backend which uses Windows' built-in [Media Foundation framework](https://en.wikipedia.org/wiki/Media_Foundation). Can be used to capture frames from camera, decode and encode video files. This backend have HW-accelerated processing support (`WITH_MSMF_DXVA` option, default is _ON_).
+
+@note Older versions of Windows (prior to 10) can have incompatible versions of Media Foundation and are known to have problems when used from OpenCV.
+
+### DirectShow
+
+`WITH_DSHOW` (Windows; default: _ON_)
+
+This backend uses older [DirectShow](https://en.wikipedia.org/wiki/DirectShow) framework. It can be used only to capture frames from camera. It is now deprecated in favor of MSMF backend, although both can be enabled in the same build.
+
+### AVFoundation
+
+`WITH_AVFOUNDATION` (Apple; default: _ON_)
+
+[AVFoundation](https://en.wikipedia.org/wiki/AVFoundation) framework is part of Apple platforms and can be used to capture frames from camera, encode and decode video files.
+
+### Other backends
+
+There are multiple less popular frameworks which can be used to read and write videos. Each requires corresponding library or SDK installed.
+
+| Option | Default | Info |
+| --------| ------ | ------- |
+| `WITH_1394` | _ON_ | [IIDC IEEE1394](https://en.wikipedia.org/wiki/IEEE_1394#IIDC) support using DC1394 library |
+| `WITH_OPENNI` | _OFF_ | [OpenNI](https://en.wikipedia.org/wiki/OpenNI) can be used to capture data from depth-sensing cameras. Deprecated. |
+| `WITH_OPENNI2` | _OFF_ | [OpenNI2](https://structure.io/openni) can be used to capture data from depth-sensing cameras. |
+| `WITH_PVAPI` | _OFF_ | [PVAPI](https://www.alliedvision.com/en/support/software-downloads.html) is legacy SDK for Prosilica GigE cameras. Deprecated. |
+| `WITH_ARAVIS` | _OFF_ | [Aravis](https://github.com/AravisProject/aravis) library is used for video acquisition using Genicam cameras. |
+| `WITH_XIMEA` | _OFF_ | [XIMEA](https://www.ximea.com/) cameras support. |
+| `WITH_XINE` | _OFF_ | [XINE](https://en.wikipedia.org/wiki/Xine) library support. |
+| `WITH_LIBREALSENSE` | _OFF_ | [RealSense](https://en.wikipedia.org/wiki/Intel_RealSense) cameras support. |
+| `WITH_MFX` | _OFF_ | [MediaSDK](http://mediasdk.intel.com/) library can be used for HW-accelerated decoding and encoding of raw video streams. |
+| `WITH_GPHOTO2` | _OFF_ | [GPhoto](https://en.wikipedia.org/wiki/GPhoto) library can be used to capure frames from cameras. |
+| `WITH_ANDROID_MEDIANDK` | _ON_ | [MediaNDK](https://developer.android.com/ndk/guides/stable_apis#libmediandk) library is available on Android since API level 21. |
+
+
+### videoio plugins
+
+Some _videoio_ backends can be built as plugins thus breaking strict dependency on third-party libraries and making them optional at runtime. Following options can be used to control this mechanism:
+
+- `VIDEOIO_ENABLE_PLUGINS`, default is _ON_ - enable or disable plugins completely
+- `VIDEOIO_PLUGIN_LIST`, default is _empty_ - comma- or semicolon-separated list of backend names to be compiled as plugins. Supported names are _ffmpeg_, _gstreamer_, _msmf_, _mfx_ and _all_.
+- `VIDEOIO_ENABLE_STRICT_PLUGIN_CHECK`, default is _ON_ - enable strict runtime version check to only allow plugins built with the same version of OpenCV
+
+
+## Parallel processing {#tutorial_config_reference_func_core}
+
+Some of OpenCV algorithms can use multithreading to accelerate processing. OpenCV can be built with one of threading backends.
+
+| Backend | Option | Default | Platform | Description |
+|-------- | ------ | ------- | -------- | ----------- |
+| pthreads | `WITH_PTHREADS_PF` | _ON_ | Unix-like | Default backend based on [pthreads](https://en.wikipedia.org/wiki/POSIX_Threads) library is available on Linux, Android and other Unix-like platforms. Thread pool is implemented in OpenCV and can be controlled with environment variables `OPENCV_THREAD_POOL_*`. Please check sources in _modules/core/src/parallel_impl.cpp_ file for details. |
+| Concurrency | N/A | _ON_ | Windows | [Concurrency runtime](https://docs.microsoft.com/en-us/cpp/parallel/concrt/concurrency-runtime) is available on Windows and will be turned _ON_ on supported platforms unless other backend is enabled. |
+| GCD | N/A | _ON_ | Apple | [Grand Central Dispatch](https://en.wikipedia.org/wiki/Grand_Central_Dispatch) is available on Apple platforms and will be turned _ON_ automatically unless other backend is enabled. Uses global system thread pool. |
+| TBB | `WITH_TBB` | Multiple | _OFF_ | [Threading Building Blocks](https://en.wikipedia.org/wiki/Threading_Building_Blocks) is a cross-platform library for parallel programming. |
+| OpenMP | `WITH_OPENMP` | Multiple | _OFF_ | [OpenMP](https://en.wikipedia.org/wiki/OpenMP) API relies on compiler support. |
+| HPX | `WITH_HPX` | Multiple | _OFF_ | [High Performance ParallelX](https://en.wikipedia.org/wiki/HPX) is an experimental backend which is more suitable for multiprocessor environments. |
+
+@note OpenCV can download and build TBB library from GitHub, this functionality can be enabled with the `BUILD_TBB` option.
+
+## GUI backend (highgui module) {#tutorial_config_reference_highgui}
+
+OpenCV relies on various GUI libraries for window drawing.
+
+| Option | Default | Platform | Description |
+| ------ | ------- | -------- | ----------- |
+| `WITH_GTK` | _ON_ | Linux | [GTK](https://en.wikipedia.org/wiki/GTK) is a common toolkit in Linux and Unix-like OS-es. By default version 3 will be used if found, version 2 can be forced with the `WITH_GTK_2_X` option. |
+| `WITH_WIN32UI` | _ON_ | Windows | [WinAPI](https://en.wikipedia.org/wiki/Windows_API) is a standard GUI API in Windows. |
+| N/A | _ON_ | macOS | [Cocoa](https://en.wikipedia.org/wiki/Cocoa_(API)) is a framework used in macOS. |
+| `WITH_QT` | _OFF_ | Cross-platform | [Qt](https://en.wikipedia.org/wiki/Qt_(software)) is a cross-platform GUI framework. |
+
+@note OpenCV compiled with Qt support allows use of advanced _highgui_ interface, see @ref highgui_qt for details.
+
+### OpenGL
+
+`WITH_OPENGL` (default: _OFF_)
+
+OpenGL integration can be used to draw HW-accelerated windows with following backends: GTK, WIN32 and Qt. And enables basic interoperability with OpenGL, see @ref core_opengl and @ref highgui_opengl for details.
+
+
+# Installation layout {#tutorial_config_reference_install}
+
+## Installation root {#tutorial_config_reference_install_root}
+
+To install produced binaries root location should be configured. Default value depends on distribution, in Ubuntu it is usually set to `/usr/local`. It can be changed during configuration:
+```.sh
+cmake -DCMAKE_INSTALL_PREFIX=/opt/opencv ../opencv
+```
+This path can be relative to current working directory, in the following example it will be set to `<absolute-path-to-build>/install`:
+```.sh
+cmake -DCMAKE_INSTALL_PREFIX=install ../opencv
+```
+
+After building the library, all files can be copied to the configured install location using the following command:
+```.sh
+cmake --build . --target install
+```
+
+To install binaries to the system location (e.g. `/usr/local`) as a regular user it is necessary to run the previous command with elevated privileges:
+```.sh
+sudo cmake --build . --target install
+```
+
+@note
+On some platforms (Linux) it is possible to remove symbol information during install. Binaries will become 10-15% smaller but debugging will be limited:
+```.sh
+cmake --build . --target install/strip
+```
+
+## Components and locations {#tutorial_config_reference_install_comp}
+
+Options cane be used to control whether or not a part of the library will be installed:
+
+| Option | Default | Description |
+| ------ | ------- | ----------- |
+| `INSTALL_C_EXAMPLES` | _OFF_ | Install C++ sample sources from the _samples/cpp_ directory. |
+| `INSTALL_PYTHON_EXAMPLES` | _OFF_ | Install Python sample sources from the _samples/python_ directory. |
+| `INSTALL_ANDROID_EXAMPLES` | _OFF_ | Install Android sample sources from the _samples/android_ directory. |
+| `INSTALL_BIN_EXAMPLES` | _OFF_ | Install prebuilt sample applications (`BUILD_EXAMPLES` must be enabled). |
+| `INSTALL_TESTS` | _OFF_ | Install tests (`BUILD_TESTS` must be enabled). |
+| `OPENCV_INSTALL_APPS_LIST` | _all_ | Comma- or semicolon-separated list of prebuilt applications to install (from _apps_ directory) |
+
+Following options allow to modify components' installation locations relatively to install prefix. Default values of these options depend on platform and other options, please check the _cmake/OpenCVInstallLayout.cmake_ file for details.
+
+| Option | Components |
+| ------ | ----------- |
+| `OPENCV_BIN_INSTALL_PATH` | applications, dynamic libraries (_win_) |
+| `OPENCV_TEST_INSTALL_PATH` | test applications |
+| `OPENCV_SAMPLES_BIN_INSTALL_PATH` | sample applications |
+| `OPENCV_LIB_INSTALL_PATH` | dynamic libraries, import libraries (_win_) |
+| `OPENCV_LIB_ARCHIVE_INSTALL_PATH` | static libraries |
+| `OPENCV_3P_LIB_INSTALL_PATH` | 3rdparty libraries |
+| `OPENCV_CONFIG_INSTALL_PATH` | cmake config package |
+| `OPENCV_INCLUDE_INSTALL_PATH` | header files |
+| `OPENCV_OTHER_INSTALL_PATH` | extra data files |
+| `OPENCV_SAMPLES_SRC_INSTALL_PATH` | sample sources |
+| `OPENCV_LICENSES_INSTALL_PATH` | licenses for included 3rdparty components |
+| `OPENCV_TEST_DATA_INSTALL_PATH` | test data |
+| `OPENCV_DOC_INSTALL_PATH` | documentation |
+| `OPENCV_JAR_INSTALL_PATH` | JAR file with Java bindings |
+| `OPENCV_JNI_INSTALL_PATH` | JNI part of Java bindings |
+| `OPENCV_JNI_BIN_INSTALL_PATH` | Dynamic libraries from the JNI part of Java bindings |
+
+Following options can be used to change installation layout for common scenarios:
+
+| Option | Default | Description |
+| ------ | ------- | ----------- |
+| `INSTALL_CREATE_DISTRIB` | _OFF_ | Tune multiple things to produce Windows and Android distributions. |
+| `INSTALL_TO_MANGLED_PATHS` | _OFF_ | Adds one level to several installation locations to allow side-by-side installations. For example, headers will be installed to _/usr/include/opencv-4.4.0_ instead of _/usr/include/opencv4_ with this option enabled. |
+
+
+# Miscellaneous features {#tutorial_config_reference_misc}
+
+
+| Option | Default | Description |
+| ------ | ------- | ----------- |
+| `OPENCV_ENABLE_NONFREE` | _OFF_ | Some algorithms included in the library are known to be protected by patents and are disabled by default. |
+| `OPENCV_FORCE_3RDPARTY_BUILD`| _OFF_ | Enable all `BUILD_` options at once. |
+| `ENABLE_CCACHE` | _ON_ (on Unix-like platforms) | Enable [ccache](https://en.wikipedia.org/wiki/Ccache) auto-detection. This tool wraps compiler calls and caches results, can significantly improve re-compilation time.  |
+| `ENABLE_PRECOMPILED_HEADERS` | _ON_ (for MSVC) | Enable precompiled headers support. Improves build time. |
+| `BUILD_DOCS` | _OFF_ | Enable documentation build (_doxygen_, _doxygen_cpp_, _doxygen_python_, _doxygen_javadoc_ targets). [Doxygen](http://www.doxygen.org/index.html) must be installed for C++ documentation build. Python and [BeautifulSoup4](https://en.wikipedia.org/wiki/Beautiful_Soup_(HTML_parser)) must be installed for Python documentation build. Javadoc and Ant must be installed for Java documentation build (part of Java SDK). |
+| `ENABLE_PYLINT` | _ON_ (when docs or examples are enabled) | Enable python scripts check with [Pylint](https://en.wikipedia.org/wiki/Pylint) (_check_pylint_ target). Pylint must be installed. |
+| `ENABLE_FLAKE8` | _ON_ (when docs or examples are enabled) | Enable python scripts check with [Flake8](https://flake8.pycqa.org/) (_check_flake8_ target). Flake8 must be installed. |
+| `BUILD_JAVA` | _ON_ | Enable Java wrappers build. |
+| `BUILD_FAT_JAVA_LIB` | _ON_ (for static Android builds) | Build single _opencv_java_ dynamic library containing all library functionality bundled with Java bindings. |
+| `BUILD_opencv_python2` | _ON_ | Build python2 bindings (deprecated). |
+| `BUILD_opencv_python3` | _ON_ | Build python3 bindings. |
+
+TODO: need separate tutorials covering bindings builds
+
+## Android
+
+`BUILD_ANDROID_PROJECTS`
+`BUILD_ANDROID_EXAMPLES`
+`ANDROID_HOME`
+`ANDROID_SDK`
+`ANDROID_NDK`
+`ANDROID_SDK_ROOT`
+
+
+## Cross-compilation
+
+CMAKE_TOOLCHAIN_FILE
+
+
+## Automated builds
+
+`ENABLE_NOISY_WARNINGS`
+`OPENCV_WARNINGS_ARE_ERRORS`
+`ENABLE_CONFIG_VERIFICATION`
+`OPENCV_CMAKE_HOOKS_DIR`
+`OPENCV_DUMP_HOOKS_FLOW`
+
+# TODO
+
+`WITH_CAROTENE`
+`WITH_CPUFEATURES`
+`WITH_EIGEN`
+`WITH_HALIDE`
+`WITH_VULKAN`
+`WITH_INF_ENGINE`
+`WITH_OPENVX`
+`WITH_CLP`
+`WITH_DIRECTX`
+`WITH_VA`
+`WITH_LAPACK`
+`WITH_PROTOBUF`
+`WITH_QUIRC`
+`BUILD_ZLIB`
+`BUILD_ITT`
+`WITH_IPP`
+`BUILD_IPP_IW`

--- a/doc/tutorials/introduction/cross_referencing/tutorial_cross_referencing.markdown
+++ b/doc/tutorials/introduction/cross_referencing/tutorial_cross_referencing.markdown
@@ -3,6 +3,13 @@ Cross referencing OpenCV from other Doxygen projects {#tutorial_cross_referencin
 
 @prev_tutorial{tutorial_transition_guide}
 
+|    |    |
+| -: | :- |
+| Original author | Sebastian Höffner |
+| Compatibility | OpenCV >= 3.3.0 |
+
+@warning
+This tutorial can contain obsolete information.
 
 Cross referencing OpenCV
 ------------------------

--- a/doc/tutorials/introduction/crosscompilation/arm_crosscompile_with_cmake.markdown
+++ b/doc/tutorials/introduction/crosscompilation/arm_crosscompile_with_cmake.markdown
@@ -4,6 +4,13 @@ Cross compilation for ARM based Linux systems {#tutorial_arm_crosscompile_with_c
 @prev_tutorial{tutorial_ios_install}
 @next_tutorial{tutorial_building_tegra_cuda}
 
+|    |    |
+| -: | :- |
+| Original author |  Alexander Smorkalov |
+| Compatibility | OpenCV >= 3.0 |
+
+@warning
+This tutorial can contain obsolete information.
 
 This steps are tested on Ubuntu Linux 12.04, but should work for other Linux distributions. I case
 of other distributions package names and names of cross compilation tools may differ. There are

--- a/doc/tutorials/introduction/desktop_java/java_dev_intro.markdown
+++ b/doc/tutorials/introduction/desktop_java/java_dev_intro.markdown
@@ -4,6 +4,13 @@ Introduction to Java Development {#tutorial_java_dev_intro}
 @prev_tutorial{tutorial_windows_visual_studio_image_watch}
 @next_tutorial{tutorial_java_eclipse}
 
+|    |    |
+| -: | :- |
+| Original author | Eric Christiansen and Andrey Pavlenko |
+| Compatibility | OpenCV >= 3.0 |
+
+@warning
+This tutorial can contain obsolete information.
 
 As of OpenCV 2.4.4, OpenCV supports desktop Java development using nearly the same interface as for
 Android development. This guide will help you to create your first Java (or Scala) application using

--- a/doc/tutorials/introduction/display_image/display_image.markdown
+++ b/doc/tutorials/introduction/display_image/display_image.markdown
@@ -4,6 +4,14 @@ Getting Started with Images {#tutorial_display_image}
 @prev_tutorial{tutorial_building_tegra_cuda}
 @next_tutorial{tutorial_documentation}
 
+|    |    |
+| -: | :- |
+| Original author | Ana Huamán |
+| Compatibility | OpenCV >= 3.4.4 |
+
+@warning
+This tutorial can contain obsolete information.
+
 Goal
 ----
 

--- a/doc/tutorials/introduction/documenting_opencv/documentation_tutorial.markdown
+++ b/doc/tutorials/introduction/documenting_opencv/documentation_tutorial.markdown
@@ -4,6 +4,10 @@ Writing documentation for OpenCV {#tutorial_documentation}
 @prev_tutorial{tutorial_display_image}
 @next_tutorial{tutorial_transition_guide}
 
+|    |    |
+| -: | :- |
+| Original author | Maksim Shabunin |
+| Compatibility | OpenCV >= 3.0 |
 
 @tableofcontents
 

--- a/doc/tutorials/introduction/general_install/general_install.markdown
+++ b/doc/tutorials/introduction/general_install/general_install.markdown
@@ -55,12 +55,12 @@ You can download a snapshot of repository in form of an archive or clone reposit
 
 To download snapshot archives:
 
-- Go to https://github.com/opencv/opencv/releases and download "Source code" archive from any release, e.g. 4.1.2.
+- Go to https://github.com/opencv/opencv/releases and download "Source code" archive from any release.
 - (optionally) Go to https://github.com/opencv/opencv_contrib/releases and download "Source code" archive for the same release as _opencv_
 - (optionally) Go to https://github.com/opencv/opencv_extra/releases and download "Source code" archive for the same release as _opencv_
 - Unpack all archives to some location
 
-To clone repositories run the following commands in console (_git_ must be installed):
+To clone repositories run the following commands in console (_git_ [must be installed](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git)):
 
 ```.sh
 git clone https://github.com/opencv/opencv
@@ -78,6 +78,8 @@ git -C opencv_extra checkout <same-tag-as-opencv>
 @note
 If you want to build software using more than one repository, make sure all components are compatible with each other. For OpenCV it means that _opencv_ and _opencv_contrib_ repositories must be checked out at the same tag or that all snapshot archives are downloaded from the same release.
 
+@note
+When choosing which version to download take in account your target platform and development tools versions, latest versions of OpenCV can have build problems with very old compilers and vice versa. We recommend using latest release and fresh OS/compiler combination.
 
 ## Step 2: Configure {#tutorial_general_install_sources_2}
 

--- a/doc/tutorials/introduction/general_install/general_install.markdown
+++ b/doc/tutorials/introduction/general_install/general_install.markdown
@@ -1,0 +1,115 @@
+OpenCV installation overview {#tutorial_general_install}
+============================
+
+@tableofcontents
+
+There are two ways of installing OpenCV on your machine: download prebuilt version for your platform or compile from sources.
+
+# Prebuilt version {#tutorial_general_install_prebuilt}
+
+In many cases you can find prebuilt version of OpenCV that will meet your needs.
+
+## Packages by OpenCV core team  {#tutorial_general_install_prebuilt_core}
+
+Packages for Android, iOS and Windows built with default parameters and recent compilers are published for each release, they do not contain _opencv_contrib_ modules.
+
+- GitHub releases: https://github.com/opencv/opencv/releases
+- SourceForge.net: https://sourceforge.net/projects/opencvlibrary/files/
+
+
+## Third-party packages  {#tutorial_general_install_prebuilt_thirdparty}
+
+Other organizations and people maintain their own binary distributions of OpenCV. For example:
+
+- System packages in popular Linux distributions (https://pkgs.org/search/?q=opencv)
+- PyPI (https://pypi.org/search/?q=opencv)
+- Conda (https://anaconda.org/search?q=opencv)
+- Conan (https://github.com/conan-community/conan-opencv)
+- vcpkg (https://github.com/microsoft/vcpkg/tree/master/ports/opencv)
+- NuGet (https://www.nuget.org/packages?q=opencv)
+- Brew (https://formulae.brew.sh/formula/opencv)
+- Maven (https://search.maven.org/search?q=opencv)
+
+
+# Build from sources {#tutorial_general_install_sources}
+
+It can happen that existing binary packages are not applicable for your use case, then you'll have to build custom version of OpenCV by yourself. This section gives a high-level overview of the build process, check tutorial for specific platform for actual build instructions.
+
+OpenCV uses [CMake](https://cmake.org/) build management system for configuration and build, so this section mostly describes generalized process of building software with CMake.
+
+
+## Step 0: Prerequisites {#tutorial_general_install_sources_0}
+
+Install C++ compiler and build tools. On \*NIX platforms it is usually GCC/G++ or Clang compiler and Make or Ninja build tool. On Windows it can be Visual Studio IDE or MinGW-w64 compiler. Native toolchains for Android are provided in the Android NDK. XCode IDE is used to build software for OSX and iOS platforms.
+
+Install CMake from the official site or some other source.
+
+Get other third-party dependencies: libraries with extra functionality like decoding videos or showing GUI elements; libraries providing optimized implementations of selected algorithms; tools used for documentation generation and other extras. Check @ref tutorial_config_reference for available options and corresponding dependencies.
+
+
+## Step 1: Get software sources {#tutorial_general_install_sources_1}
+
+Typical software project consists of one or several code repositories. OpenCV have two repositories with code: _opencv_ - main repository with stable and actively supported algorithms and _opencv_contrib_ which contains experimental and non-free (patented) algorithms; and one repository with test data: _opencv_extra_.
+
+You can download a snapshot of repository in form of an archive or clone repository with full history.
+
+To download snapshot archives:
+
+- Go to https://github.com/opencv/opencv/releases and download "Source code" archive from any release, e.g. 4.1.2.
+- (optionally) Go to https://github.com/opencv/opencv_contrib/releases and download "Source code" archive for the same release as _opencv_
+- (optionally) Go to https://github.com/opencv/opencv_extra/releases and download "Source code" archive for the same release as _opencv_
+- Unpack all archives to some location
+
+To clone repositories run the following commands in console (_git_ must be installed):
+
+```.sh
+git clone https://github.com/opencv/opencv
+git -C opencv checkout <some-tag>
+
+# optionally
+git clone https://github.com/opencv/opencv_contrib
+git -C opencv_contrib checkout <same-tag-as-opencv>
+
+# optionally
+git clone https://github.com/opencv/opencv_extra
+git -C opencv_extra checkout <same-tag-as-opencv>
+```
+
+@note
+If you want to build software using more than one repository, make sure all components are compatible with each other. For OpenCV it means that _opencv_ and _opencv_contrib_ repositories must be checked out at the same tag or that all snapshot archives are downloaded from the same release.
+
+
+## Step 2: Configure {#tutorial_general_install_sources_2}
+
+At this step CMake will verify that all necessary tools and dependencies are available and compatible with the library and will generate intermediate files for the chosen build system. It could be Makefiles, IDE projects and solutions, etc. Usually this step is performed in newly created build directory:
+```
+cmake -G<generator> <configuration-options> <source-directory>
+```
+
+@note
+`cmake-gui` application allows to see and modify available options using graphical user interface. See https://cmake.org/runningcmake/ for details.
+
+
+## Step 3: Build {#tutorial_general_install_sources_3}
+
+During build process source files are compiled into object files which are linked together or otherwise combined into libraries and applications. This step can be run using universal command:
+```
+cmake --build <build-directory> <build-options>
+```
+... or underlying build system can be called directly:
+```
+make
+```
+
+## Step 3: Install {#tutorial_general_install_sources_4}
+
+During installation procedure build results and other files from build directory will be copied to the install location. Default installation location is `/usr/local` on UNIX and `C:/Program Files` on Windows. This location can be changed at the configuration step by setting `CMAKE_INSTALL_PREFIX` option. To perform installation run the following command:
+```
+cmake --build <build-directory> --target install <other-options>
+```
+
+@note
+This step is optional, OpenCV can be used directly from the build directory.
+
+@note
+If the installation root location is a protected system directory, so the installation process must be run with superuser or administrator privileges (e.g. `sudo cmake ...`).

--- a/doc/tutorials/introduction/ios_install/ios_install.markdown
+++ b/doc/tutorials/introduction/ios_install/ios_install.markdown
@@ -4,6 +4,14 @@ Installation in iOS {#tutorial_ios_install}
 @prev_tutorial{tutorial_macos_install}
 @next_tutorial{tutorial_arm_crosscompile_with_cmake}
 
+|    |    |
+| -: | :- |
+| Original author | Artem Myagkov, Eduard Feicho, Steve Nicholson |
+| Compatibility | OpenCV >= 3.0 |
+
+@warning
+This tutorial can contain obsolete information.
+
 Required Packages
 -----------------
 

--- a/doc/tutorials/introduction/java_eclipse/java_eclipse.markdown
+++ b/doc/tutorials/introduction/java_eclipse/java_eclipse.markdown
@@ -4,6 +4,13 @@ Using OpenCV Java with Eclipse {#tutorial_java_eclipse}
 @prev_tutorial{tutorial_java_dev_intro}
 @next_tutorial{tutorial_clojure_dev_intro}
 
+|    |    |
+| -: | :- |
+| Original author | Barış Evrim Demiröz |
+| Compatibility | OpenCV >= 3.0 |
+
+@warning
+This tutorial can contain obsolete information.
 
 Since version 2.4.4 [OpenCV supports Java](http://opencv.org/opencv-java-api.html). In this tutorial
 I will explain how to setup development environment for using OpenCV Java with Eclipse in

--- a/doc/tutorials/introduction/linux_eclipse/linux_eclipse.markdown
+++ b/doc/tutorials/introduction/linux_eclipse/linux_eclipse.markdown
@@ -4,6 +4,14 @@ Using OpenCV with Eclipse (plugin CDT) {#tutorial_linux_eclipse}
 @prev_tutorial{tutorial_linux_gcc_cmake}
 @next_tutorial{tutorial_windows_install}
 
+|    |    |
+| -: | :- |
+| Original author | Ana Huamán |
+| Compatibility | OpenCV >= 3.0 |
+
+@warning
+This tutorial can contain obsolete information.
+
 Prerequisites
 -------------
 Two ways, one by forming a project directly, and another by CMake Prerequisites

--- a/doc/tutorials/introduction/linux_gcc_cmake/linux_gcc_cmake.markdown
+++ b/doc/tutorials/introduction/linux_gcc_cmake/linux_gcc_cmake.markdown
@@ -4,6 +4,13 @@ Using OpenCV with gcc and CMake {#tutorial_linux_gcc_cmake}
 @prev_tutorial{tutorial_linux_install}
 @next_tutorial{tutorial_linux_eclipse}
 
+|    |    |
+| -: | :- |
+| Original author | Ana Huamán |
+| Compatibility | OpenCV >= 3.0 |
+
+@warning
+This tutorial can contain obsolete information.
 
 @note We assume that you have successfully installed OpenCV in your workstation.
 

--- a/doc/tutorials/introduction/linux_install/linux_install.markdown
+++ b/doc/tutorials/introduction/linux_install/linux_install.markdown
@@ -3,146 +3,123 @@ Installation in Linux {#tutorial_linux_install}
 
 @next_tutorial{tutorial_linux_gcc_cmake}
 
+|    |    |
+| -: | :- |
+| Original author | Ana Huamán |
+| Compatibility | OpenCV >= 3.0 |
 
-The following steps have been tested for Ubuntu 10.04 but should work with other distros as well.
+@tableofcontents
 
-Required Packages
------------------
+# Quick start {#tutorial_linux_install_quick_start}
 
--   GCC 4.4.x or later
--   CMake 2.8.7 or higher
--   Git
--   GTK+2.x or higher, including headers (libgtk2.0-dev)
--   pkg-config
--   Python 2.6 or later and Numpy 1.5 or later with developer packages (python-dev, python-numpy)
--   ffmpeg or libav development packages: libavcodec-dev, libavformat-dev, libswscale-dev
--   [optional] libtbb2 libtbb-dev
--   [optional] libdc1394 2.x
--   [optional] libjpeg-dev, libpng-dev, libtiff-dev, libjasper-dev, libdc1394-22-dev
--   [optional] CUDA Toolkit 6.5 or higher
 
-The packages can be installed using a terminal and the following commands or by using Synaptic
-Manager:
-@code{.bash}
-[compiler] sudo apt-get install build-essential
-[required] sudo apt-get install cmake git libgtk2.0-dev pkg-config libavcodec-dev libavformat-dev libswscale-dev
-[optional] sudo apt-get install python-dev python-numpy libtbb2 libtbb-dev libjpeg-dev libpng-dev libtiff-dev libjasper-dev libdc1394-22-dev
-@endcode
-Getting OpenCV Source Code
---------------------------
+## Build core modules {#tutorial_linux_install_quick_build_core}
 
-You can use the latest stable OpenCV version or you can grab the latest snapshot from our [Git
-repository](https://github.com/opencv/opencv.git).
+@snippet linux_quick_install.sh body
 
-### Getting the Latest Stable OpenCV Version
 
--   Go to our [downloads page](http://opencv.org/releases.html).
--   Download the source archive and unpack it.
+## Build with opencv_contrib {#tutorial_linux_install_quick_build_contrib}
 
-### Getting the Cutting-edge OpenCV from the Git Repository
+@snippet linux_quick_install_contrib.sh body
 
-Launch Git client and clone [OpenCV repository](http://github.com/opencv/opencv). If you need
-modules from [OpenCV contrib repository](http://github.com/opencv/opencv_contrib) then clone it as well.
 
-For example
-@code{.bash}
-cd ~/<my_working_directory>
-git clone https://github.com/opencv/opencv.git
-git clone https://github.com/opencv/opencv_contrib.git
-@endcode
-Building OpenCV from Source Using CMake
----------------------------------------
+# Detailed process {#tutorial_linux_install_detailed}
 
--#  Create a temporary directory, which we denote as \<cmake_build_dir\>, where you want to put
-    the generated Makefiles, project files as well the object files and output binaries and enter
-    there.
+This section provides more details of the build process and describes alternative methods and tools. Please refer to the @ref tutorial_general_install tutorial for general installation details and to the @ref tutorial_config_reference for configuration options documentation.
 
-    For example
-    @code{.bash}
-    cd ~/opencv
-    mkdir build
-    cd build
-    @endcode
--#  Configuring. Run cmake [\<some optional parameters\>] \<path to the OpenCV source directory\>
 
-    For example
-    @code{.bash}
-    cmake -D CMAKE_BUILD_TYPE=Release -D CMAKE_INSTALL_PREFIX=/usr/local ..
-    @endcode
-    or cmake-gui
+## Install compiler and build tools {#tutorial_linux_install_detailed_basic_compiler}
 
-    -   set full path to OpenCV source code, e.g. /home/user/opencv
-    -   set full path to \<cmake_build_dir\>, e.g. /home/user/opencv/build
-    -   set optional parameters
-    -   run: “Configure”
-    -   run: “Generate”
+- To compile OpenCV you will need a C++ compiler. Usually it is G++/GCC or Clang/LLVM:
+    - Install GCC...
+    @snippet linux_install_a.sh gcc
+    - ... or Clang:
+    @snippet linux_install_b.sh clang
 
-    @note
-    Use `cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/usr/local ..` , without spaces after -D if the above example doesn't work.
+- OpenCV uses CMake build configuration tool:
+@snippet linux_install_a.sh cmake
 
--#  Description of some parameters
-    -   build type: `CMAKE_BUILD_TYPE=Release\Debug`
-    -   to build with modules from opencv_contrib set OPENCV_EXTRA_MODULES_PATH to \<path to
-        opencv_contrib/modules/\>
-    -   set BUILD_DOCS for building documents
-    -   set BUILD_EXAMPLES to build all examples
+- CMake can generate scripts for different build systems, e.g. _make_, _ninja_:
 
--#  [optional] Building python. Set the following python parameters:
-    -   PYTHON2(3)_EXECUTABLE = \<path to python\>
-    -   PYTHON_INCLUDE_DIR = /usr/include/python\<version\>
-    -   PYTHON_INCLUDE_DIR2 = /usr/include/x86_64-linux-gnu/python\<version\>
-    -   PYTHON_LIBRARY = /usr/lib/x86_64-linux-gnu/libpython\<version\>.so
-    -   PYTHON2(3)_NUMPY_INCLUDE_DIRS =
-        /usr/lib/python\<version\>/dist-packages/numpy/core/include/
+    - Install Make...
+    @snippet linux_install_a.sh make
+    - ... or Ninja:
+    @snippet linux_install_b.sh ninja
 
--#  [optional] Building java.
-    -   Unset parameter: BUILD_SHARED_LIBS
-    -   It is useful also to unset BUILD_EXAMPLES, BUILD_TESTS, BUILD_PERF_TESTS - as they all
-        will be statically linked with OpenCV and can take a lot of memory.
+- Install tool for getting and unpacking sources:
 
--#  [optional] Generate pkg-config info
-    -   Add this flag when running CMake: `-DOPENCV_GENERATE_PKGCONFIG=ON`
-    -   Will generate the .pc file for pkg-config and install it.
-    -   Useful if not using CMake in projects that use OpenCV
-    -   Installed as `opencv4`, usage: `pkg-config --cflags --libs opencv4`
+    - _wget_ and _unzip_...
+    @snippet linux_install_a.sh wget
+    - ... or _git_:
+    @snippet linux_install_b.sh git
 
--#  Build. From build directory execute *make*, it is recommended to do this in several threads
 
-    For example
-    @code{.bash}
-    make -j7 # runs 7 jobs in parallel
-    @endcode
--#  [optional] Building documents. Enter \<cmake_build_dir/doc/\> and run make with target
-    "doxygen"
+## Download sources {#tutorial_linux_install_detailed_basic_download}
 
-    For example
-    @code{.bash}
-    cd ~/opencv/build/doc/
-    make -j7 doxygen
-    @endcode
--#  To install libraries, execute the following command from build directory
-    @code{.bash}
-    sudo make install
-    @endcode
--#  [optional] Running tests
+There are two methods of getting OpenCV sources:
 
-    -   Get the required test data from [OpenCV extra
-        repository](https://github.com/opencv/opencv_extra).
+- Download snapshot of repository using web browser or any download tool (~80-90Mb) and unpack it...
+@snippet linux_install_a.sh download
+- ... or clone repository to local machine using _git_ to get full change history (>470Mb):
+@snippet linux_install_b.sh download
 
-    For example
-    @code{.bash}
-    git clone https://github.com/opencv/opencv_extra.git
-    @endcode
-    -   set OPENCV_TEST_DATA_PATH environment variable to \<path to opencv_extra/testdata\>.
-    -   execute tests from build directory.
-
-    For example
-    @code{.bash}
-    <cmake_build_dir>/bin/opencv_test_core
-    @endcode
 
 @note
-   If the size of the created library is a critical issue (like in case of an Android build) you
-    can use the install/strip command to get the smallest size possible. The *stripped* version
-    appears to be twice as small. However, we do not recommend using this unless those extra
-    megabytes do really matter.
+Snapshots of other branches, releases or commits can be found on the [GitHub](https://github.com/opencv/opencv) and the [official download page](https://opencv.org/releases.html).
+
+
+## Configure and build {#tutorial_linux_install_detailed_basic_build}
+
+- Create build directory:
+@snippet linux_install_a.sh prepare
+
+- Configure - generate build scripts for the preferred build system:
+    - For _make_...
+    @snippet linux_install_a.sh configure
+    - ... or for _ninja_:
+    @snippet linux_install_b.sh configure
+
+- Build - run actual compilation process:
+    - Using _make_...
+    @snippet linux_install_a.sh build
+    - ... or _ninja_:
+    @snippet linux_install_b.sh build
+
+
+@note
+_Configure_ process can download some files from the internet to satisfy library dependencies, connection failures can cause some of modules or functionalities to be turned off or behave differently. Refer to the @ref tutorial_general_install and @ref tutorial_config_reference tutorials for details and full configuration options reference.
+
+@note
+If you experience problems with the build process, try to clean or recreate the build directory. Changes in the configuration like disabling a dependency, modifying build scripts or switching sources to another branch are not handled very well and can result in broken workspace.
+
+@note
+_Make_ can run multiple compilation processes in parallel, `-j<NUM>` option means "run <NUM> jobs simultaneously". _Ninja_ will automatically detect number of available processor cores and does not need `-j` option.
+
+
+## Check build results {#tutorial_linux_install_detailed_basic_verify}
+
+After successful build you will find libraries in the `build/lib` directory and executables (test, samples, apps) in the `build/bin` directory:
+@snippet linux_install_a.sh check
+
+CMake package files will be located in the build root:
+@snippet linux_install_a.sh check cmake
+
+
+## Install
+
+@warning
+Installation process only copies files to predefined locations and do minor patching. Library installed using this method is not integrated into the system package registry and can not be uninstalled automatically. We do not recommend system-wide installation to regular users due to possible conflicts with system packages.
+
+By default OpenCV will be installed to the `/usr/local` directory, all files will be copied to following locations:
+* `/usr/local/bin` - executable files
+* `/usr/local/lib` - libraries (.so)
+* `/usr/local/cmake/opencv4` - cmake package
+* `/usr/local/include/opencv4` - headers
+* `/usr/local/share/opencv4` - other files (e.g. trained cascades in XML format)
+
+Since `/usr/local` is owned by the root user, the installation should be performed with elevated privileges (`sudo`):
+@snippet linux_install_a.sh install
+or
+@snippet linux_install_b.sh install
+
+Installation root directory can be changed with `CMAKE_INSTALL_PREFIX` configuration parameter, e.g. `-DCMAKE_INSTALL_PREFIX=$HOME/.local` to install to current user's local directory. Installation layout can be changed with `OPENCV_*_INSTALL_PATH` parameters. See @ref tutorial_config_reference for details.

--- a/doc/tutorials/introduction/macos_install/macos_install.markdown
+++ b/doc/tutorials/introduction/macos_install/macos_install.markdown
@@ -4,6 +4,10 @@ Installation in MacOS {#tutorial_macos_install}
 @prev_tutorial{tutorial_android_ocl_intro}
 @next_tutorial{tutorial_ios_install}
 
+|    |    |
+| -: | :- |
+| Original author | @sajarindider |
+| Compatibility | OpenCV >= 3.4 |
 
 The following steps have been tested for MacOSX (Mavericks) but should work with other versions as well.
 

--- a/doc/tutorials/introduction/macos_install/macos_install.markdown
+++ b/doc/tutorials/introduction/macos_install/macos_install.markdown
@@ -6,7 +6,7 @@ Installation in MacOS {#tutorial_macos_install}
 
 |    |    |
 | -: | :- |
-| Original author | @sajarindider |
+| Original author | `@sajarindider` |
 | Compatibility | OpenCV >= 3.4 |
 
 The following steps have been tested for MacOSX (Mavericks) but should work with other versions as well.

--- a/doc/tutorials/introduction/table_of_content_introduction.markdown
+++ b/doc/tutorials/introduction/table_of_content_introduction.markdown
@@ -1,175 +1,38 @@
 Introduction to OpenCV {#tutorial_table_of_content_introduction}
 ======================
 
-Here you can read tutorials about how to set up your computer to work with the OpenCV library.
-Additionally you can find very basic sample source code to introduce you to the world of the OpenCV.
+- @subpage tutorial_general_install
+- @subpage tutorial_config_reference
 
+##### Linux
 -   @subpage tutorial_linux_install
-
-    _Compatibility:_ \> OpenCV 2.0
-
-    _Author:_ Ana Huamán
-
-    We will learn how to setup OpenCV in your computer!
-
 -   @subpage tutorial_linux_gcc_cmake
-
-    _Compatibility:_ \> OpenCV 2.0
-
-    _Author:_ Ana Huamán
-
-    We will learn how to compile your first project using gcc and CMake
-
 -   @subpage tutorial_linux_eclipse
 
-    _Compatibility:_ \> OpenCV 2.0
-
-    _Author:_ Ana Huamán
-
-    We will learn how to compile your first project using the Eclipse environment
-
+##### Windows
 -   @subpage tutorial_windows_install
-
-    _Compatibility:_ \> OpenCV 2.0
-
-    _Author:_ Bernát Gábor
-
-    You will learn how to setup OpenCV in your Windows Operating System!
-
 -   @subpage tutorial_windows_visual_studio_opencv
-
-    _Compatibility:_ \> OpenCV 2.0
-
-    _Author:_ Bernát Gábor
-
-    You will learn what steps you need to perform in order to use the OpenCV library inside a new
-    Microsoft Visual Studio project.
-
 -   @subpage tutorial_windows_visual_studio_image_watch
 
-    _Compatibility:_ \>= OpenCV 2.4
-
-    _Author:_ Wolf Kienzle
-
-    You will learn how to visualize OpenCV matrices and images within Visual Studio 2012.
-
+##### Java & Android
 -   @subpage tutorial_java_dev_intro
-
-    _Compatibility:_ \> OpenCV 2.4.4
-
-    _Authors:_ Eric Christiansen and Andrey Pavlenko
-
-    Explains how to build and run a simple desktop Java application using Eclipse, Ant or the
-    Simple Build Tool (SBT).
-
 -   @subpage tutorial_java_eclipse
-
-    _Compatibility:_ \> OpenCV 2.4.4
-
-    _Author:_ Barış Evrim Demiröz
-
-    A tutorial on how to use OpenCV Java with Eclipse.
-
 -   @subpage tutorial_clojure_dev_intro
-
-    _Compatibility:_ \> OpenCV 2.4.4
-
-    _Author:_ Mimmo Cosenza
-
-    A tutorial on how to interactively use OpenCV from the Clojure REPL.
-
 -   @subpage tutorial_android_dev_intro
-
-    _Compatibility:_ \> OpenCV 2.4.2
-
-    _Author:_ Vsevolod Glumov
-
-    Not a tutorial, but a guide introducing Android development basics and environment setup
-
 -   @subpage tutorial_O4A_SDK
-
-    _Compatibility:_ \> OpenCV 2.4.2
-
-    _Author:_ Vsevolod Glumov
-
-    OpenCV4Android SDK: general info, installation, running samples
-
 -   @subpage tutorial_dev_with_OCV_on_Android
-
-    _Compatibility:_ \> OpenCV 2.4.3
-
-    _Author:_ Vsevolod Glumov
-
-    Development with OpenCV4Android SDK
-
 -   @subpage tutorial_android_ocl_intro
 
-    _Compatibility:_ \>= OpenCV 3.0
-
-    _Author:_ Andrey Pavlenko
-
-    Modify Android camera preview with OpenCL
-
+##### Other platforms
 -   @subpage tutorial_macos_install
-
-    _Compatibility:_ \> OpenCV 3.4.x
-
-    _Author:_ [\@sajarindider](https://github.com/sajarindider)
-
-    We will learn how to setup OpenCV in MacOS.
-
 -   @subpage tutorial_ios_install
-
-    _Compatibility:_ \> OpenCV 2.4.2
-
-    _Author:_ Artem Myagkov, Eduard Feicho, Steve Nicholson
-
-    We will learn how to setup OpenCV for using it in iOS!
-
 -   @subpage tutorial_arm_crosscompile_with_cmake
-
-    _Compatibility:_ \> OpenCV 2.4.4
-
-    _Author:_ Alexander Smorkalov
-
-    We will learn how to setup OpenCV cross compilation environment for ARM Linux.
-
 -   @subpage tutorial_building_tegra_cuda
 
-    _Compatibility:_ \>= OpenCV 3.1.0
+##### Usage basics
+-   @subpage tutorial_display_image - We will learn how to load an image from file and display it using OpenCV
 
-    _Author:_ Randy J. Ray
-
-    This tutorial will help you build OpenCV 3.1.0 for NVIDIA<sup>&reg;</sup> Tegra<sup>&reg;</sup> systems with CUDA 8.0.
-
--   @subpage tutorial_display_image
-
-    _Languages:_ C++, Python
-
-    _Compatibility:_ \> OpenCV 3.4.4
-
-    _Author:_ Ana Huamán
-
-    We will learn how to read an image, display it in a window and write it to a file using OpenCV
-
--   @subpage tutorial_documentation
-
-    _Compatibility:_ \> OpenCV 3.0
-
-    _Author:_ Maksim Shabunin
-
-    This tutorial describes new documenting process and some useful Doxygen features.
-
--   @subpage tutorial_transition_guide
-
-    _Author:_ Maksim Shabunin
-
-    This document describes some aspects of 2.4 -> 3.0 transition process.
-
--   @subpage tutorial_cross_referencing
-
-    _Compatibility:_ \> OpenCV 3.3.0
-
-    _Author:_ Sebastian Höffner
-
-    This document outlines how to create cross references to the OpenCV documentation from other Doxygen projects.
+##### Miscellaneous
+-   @subpage tutorial_documentation - This tutorial describes new documenting process and some useful Doxygen features.
+-   @subpage tutorial_transition_guide - This document describes some aspects of 2.4 -> 3.0 transition process.
+-   @subpage tutorial_cross_referencing - This document outlines how to create cross references to the OpenCV documentation from other Doxygen projects.

--- a/doc/tutorials/introduction/transition_guide/transition_guide.markdown
+++ b/doc/tutorials/introduction/transition_guide/transition_guide.markdown
@@ -4,6 +4,10 @@ Transition guide {#tutorial_transition_guide}
 @prev_tutorial{tutorial_documentation}
 @next_tutorial{tutorial_cross_referencing}
 
+|    |    |
+| -: | :- |
+| Original author | Maksim Shabunin |
+| Compatibility | OpenCV >= 3.0 |
 
 @tableofcontents
 

--- a/doc/tutorials/introduction/windows_install/windows_install.markdown
+++ b/doc/tutorials/introduction/windows_install/windows_install.markdown
@@ -4,6 +4,13 @@ Installation in Windows {#tutorial_windows_install}
 @prev_tutorial{tutorial_linux_eclipse}
 @next_tutorial{tutorial_windows_visual_studio_opencv}
 
+|    |    |
+| -: | :- |
+| Original author | Bernát Gábor |
+| Compatibility | OpenCV >= 3.0 |
+
+@warning
+This tutorial can contain obsolete information.
 
 The description here was tested on Windows 7 SP1. Nevertheless, it should also work on any other
 relatively modern version of Windows OS. If you encounter errors after following the steps described

--- a/doc/tutorials/introduction/windows_visual_studio_image_watch/windows_visual_studio_image_watch.markdown
+++ b/doc/tutorials/introduction/windows_visual_studio_image_watch/windows_visual_studio_image_watch.markdown
@@ -4,6 +4,13 @@ Image Watch: viewing in-memory images in the Visual Studio debugger {#tutorial_w
 @prev_tutorial{tutorial_windows_visual_studio_opencv}
 @next_tutorial{tutorial_java_dev_intro}
 
+|    |    |
+| -: | :- |
+| Original author | Wolf Kienzle |
+| Compatibility | OpenCV >= 3.0 |
+
+@warning
+This tutorial can contain obsolete information.
 
 Image Watch is a plug-in for Microsoft Visual Studio that lets you to visualize in-memory images
 (*cv::Mat* or *IplImage_* objects, for example) while debugging an application. This can be helpful

--- a/doc/tutorials/introduction/windows_visual_studio_opencv/windows_visual_studio_opencv.markdown
+++ b/doc/tutorials/introduction/windows_visual_studio_opencv/windows_visual_studio_opencv.markdown
@@ -1,9 +1,15 @@
 How to build applications with OpenCV inside the "Microsoft Visual Studio" {#tutorial_windows_visual_studio_opencv}
 ==========================================================================
-
 @prev_tutorial{tutorial_windows_install}
 @next_tutorial{tutorial_windows_visual_studio_image_watch}
 
+|    |    |
+| -: | :- |
+| Original author | Bernát Gábor |
+| Compatibility | OpenCV >= 3.0 |
+
+@warning
+This tutorial can contain obsolete information.
 
 Everything I describe here will apply to the `C\C++` interface of OpenCV. I start out from the
 assumption that you have read and completed with success the @ref tutorial_windows_install tutorial.

--- a/doc/tutorials/tutorials.markdown
+++ b/doc/tutorials/tutorials.markdown
@@ -1,93 +1,22 @@
 OpenCV Tutorials {#tutorial_root}
 ================
 
-The following links describe a set of basic OpenCV tutorials. All the source code mentioned here is
-provided as part of the OpenCV regular releases, so check before you start copying & pasting the code.
-The list of tutorials below is automatically generated from reST files located in our GIT
-repository.
-
-As always, we would be happy to hear your comments and receive your contributions on any tutorial.
-
--   @subpage tutorial_table_of_content_introduction
-
-    You will learn how to setup OpenCV on your computer
-
--   @subpage tutorial_table_of_content_core
-
-    Here you will learn
-    about the basic building blocks of this library. A must read for understanding how
-    to manipulate the images on a pixel level.
-
--   @subpage tutorial_table_of_content_imgproc
-
-    In this section
-    you will learn about the image processing (manipulation) functions inside OpenCV.
-
--   @subpage tutorial_table_of_content_highgui
-
-    This section contains valuable tutorials on how to use the
-    built-in graphical user interface of the library.
-
--   @subpage tutorial_table_of_content_imgcodecs
-
-    These tutorials show how to read and write images using imgcodecs module.
-
--   @subpage tutorial_table_of_content_videoio
-
-    These tutorials show how to read and write videos using videio module.
-
--   @subpage tutorial_table_of_content_calib3d
-
-    Although
-    most of our images are in a 2D format they do come from a 3D world. Here you will learn how to find
-    out 3D world information from 2D images.
-
--   @subpage tutorial_table_of_content_features2d
-
-    Learn about how
-    to use the feature points detectors, descriptors and matching framework found inside OpenCV.
-
--   @subpage tutorial_table_of_content_video
-
-    Here you will find
-    algorithms usable on your video streams like motion extraction, feature tracking and
-    foreground extractions.
-
--   @subpage tutorial_table_of_content_objdetect
-
-    Ever wondered
-    how your digital camera detects people's faces? Look here to find out!
-
--   @subpage tutorial_table_of_content_dnn
-
-    These tutorials show how to use dnn module effectively.
-
--   @subpage tutorial_table_of_content_ml
-
-    Use the powerful
-    machine learning classes for statistical classification, regression and clustering of data.
-
--   @subpage tutorial_table_of_content_gapi
-
-    Learn how to use Graph API (G-API) and port algorithms from "traditional" OpenCV to a graph model.
-
--   @subpage tutorial_table_of_content_photo
-
-    Use OpenCV for
-    advanced photo processing.
-
--   @subpage tutorial_table_of_content_stitching
-
-    Learn how to create beautiful photo panoramas and more with OpenCV stitching pipeline.
-
+- @subpage tutorial_table_of_content_introduction - build and install OpenCV on your computer
+- @subpage tutorial_table_of_content_core - basic building blocks of the library
+- @subpage tutorial_table_of_content_imgproc - image processing functions
+- @subpage tutorial_table_of_content_highgui - built-in graphical user interface
+- @subpage tutorial_table_of_content_imgcodecs - read and write images from/to files using _imgcodecs_ module
+- @subpage tutorial_table_of_content_videoio - read and write videos using _videio_ module
+- @subpage tutorial_table_of_content_calib3d - extract 3D world information from 2D images
+- @subpage tutorial_table_of_content_features2d - feature detectors, descriptors and matching framework
+- @subpage tutorial_table_of_content_video - algorithms for video streams: motion detection, object and feature tracking, etc.
+- @subpage tutorial_table_of_content_objdetect - detect objects using conventional CV methods
+- @subpage tutorial_table_of_content_dnn - infer neural networks using built-in _dnn_ module
+- @subpage tutorial_table_of_content_ml - machine learning algorithms for statistical classification, regression and data clustering
+- @subpage tutorial_table_of_content_gapi - graph-based approach to computer vision algorithms building
+- @subpage tutorial_table_of_content_photo - advanced photo processing
+- @subpage tutorial_table_of_content_stitching - create panoramas and more using _stitching_ module
+- @subpage tutorial_table_of_content_ios - running OpenCV on an iDevice
 @cond CUDA_MODULES
--   @subpage tutorial_table_of_content_gpu
-
-    Squeeze out every
-    little computational power from your system by utilizing the power of your video card to run the
-    OpenCV algorithms.
+- @subpage tutorial_table_of_content_gpu - utilizing power of video card to run CV algorithms
 @endcond
-
--   @subpage tutorial_table_of_content_ios
-
-    Run OpenCV and your vision apps on an iDevice

--- a/samples/install/linux_install_a.sh
+++ b/samples/install/linux_install_a.sh
@@ -1,0 +1,58 @@
+#!/bin/bash
+# This file contains documentation snippets for Linux installation tutorial
+if [ "$1" = "--check" ] ; then
+sudo()
+{
+    command $@
+}
+fi
+
+sudo apt update
+
+# [gcc]
+sudo apt install -y g++
+# [gcc]
+
+# [make]
+sudo apt install -y make
+# [make]
+
+# [cmake]
+sudo apt install -y cmake
+# [cmake]
+
+# [wget]
+sudo apt install -y wget unzip
+# [wget]
+
+# [download]
+wget -O opencv.zip https://github.com/opencv/opencv/archive/master.zip
+unzip opencv.zip
+mv opencv-master opencv
+# [download]
+
+# [prepare]
+mkdir -p build && cd build
+# [prepare]
+
+# [configure]
+cmake ../opencv
+# [configure]
+
+# [build]
+make -j4
+# [build]
+
+# [check]
+ls bin
+ls lib
+# [check]
+
+# [check cmake]
+ls OpenCVConfig*.cmake
+ls OpenCVModules.cmake
+# [check cmake]
+
+# [install]
+sudo make install
+# [install]

--- a/samples/install/linux_install_b.sh
+++ b/samples/install/linux_install_b.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+# This file contains documentation snippets for Linux installation tutorial
+if [ "$1" = "--check" ] ; then
+sudo()
+{
+    command $@
+}
+fi
+
+sudo apt update
+
+# [clang]
+sudo apt install -y clang
+# [clang]
+
+# [ninja]
+sudo apt install -y ninja-build
+# [ninja]
+
+# [cmake]
+sudo apt install -y cmake
+# [cmake]
+
+# [git]
+sudo apt install -y git
+# [git]
+
+# [download]
+git clone https://github.com/opencv/opencv.git
+git -C opencv checkout master
+# [download]
+
+# [prepare]
+mkdir -p build && cd build
+# [prepare]
+
+# [configure]
+cmake -GNinja ../opencv
+# [configure]
+
+# [build]
+ninja
+# [build]
+
+# [install]
+sudo ninja install
+# [install]

--- a/samples/install/linux_quick_install.sh
+++ b/samples/install/linux_quick_install.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+# This file contains documentation snippets for Linux installation tutorial
+if [ "$1" = "--check" ] ; then
+sudo()
+{
+    command $@
+}
+fi
+
+# [body]
+# Install minimal prerequisites (Ubuntu 18.04 as reference)
+sudo apt update && sudo apt install -y cmake g++ wget unzip
+
+# Download and unpack sources
+wget -O opencv.zip https://github.com/opencv/opencv/archive/master.zip
+unzip opencv.zip
+
+# Create build directory
+mkdir -p build && cd build
+
+# Configure
+cmake  ../opencv-master
+
+# Build
+cmake --build .
+# [body]

--- a/samples/install/linux_quick_install_contrib.sh
+++ b/samples/install/linux_quick_install_contrib.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+# This file contains documentation snippets for Linux installation tutorial
+if [ "$1" = "--check" ] ; then
+sudo()
+{
+    command $@
+}
+fi
+
+# [body]
+# Install minimal prerequisites (Ubuntu 18.04 as reference)
+sudo apt update && sudo apt install -y cmake g++ wget unzip
+
+# Download and unpack sources
+wget -O opencv.zip https://github.com/opencv/opencv/archive/master.zip
+wget -O opencv_contrib.zip https://github.com/opencv/opencv_contrib/archive/master.zip
+unzip opencv.zip
+unzip opencv_contrib.zip
+
+# Create build directory and switch into it
+mkdir -p build && cd build
+
+# Configure
+cmake -DOPENCV_EXTRA_MODULES_PATH=../opencv_contrib-master/modules ../opencv-master
+
+# Build
+cmake --build .
+# [body]

--- a/samples/install/linux_verify.sh
+++ b/samples/install/linux_verify.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+# This script verifies that all shell snippets in the
+# Linux installation tutorial work (in Ubuntu 18 container)
+set -e
+set -x
+
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
+
+docker pull ubuntu:18.04
+
+for f in $(cd "${SCRIPT_DIR}" && ls -1 linux_*install*.sh) ; do
+    echo "Checking $f..."
+    docker run -it \
+        --volume "${SCRIPT_DIR}":/install:ro \
+        ubuntu:18.04 \
+        /bin/bash -ex /install/$f --check
+
+done


### PR DESCRIPTION
Changes:
* Created "Installation overview" and "Configuration reference" tutorials.
* Updated "Linux installation" tutorial.
* Added scripts for automatic checks of installation for Ubuntu 18
* General tutorials: moved "Author" and "Version" information from listing into tutorials, marked some tutorials "Obsolete"
* Minor CSS doxygen changes

[Demo](http://pullrequest.opencv.org/buildbot/export/pr/18195/docs/df/d65/tutorial_table_of_content_introduction.html)

<cut/>

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [ ] The PR is proposed to proper branch ❔ 
- [ ] There is reference to original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
