### PR TITLE
[G-API]: Add GArray initialization support

### DIFF
--- a/modules/gapi/include/opencv2/gapi/garray.hpp
+++ b/modules/gapi/include/opencv2/gapi/garray.hpp
@@ -71,7 +71,7 @@ namespace detail
     {
     public:
         GArrayU(const GNode &n, std::size_t out); // Operation result constructor
-        
+
         template <typename T>
         bool holds() const;                       // Check if was created from GArray<T>
 

--- a/modules/gapi/include/opencv2/gapi/garray.hpp
+++ b/modules/gapi/include/opencv2/gapi/garray.hpp
@@ -71,6 +71,7 @@ namespace detail
     {
     public:
         GArrayU(const GNode &n, std::size_t out); // Operation result constructor
+        
         template <typename T>
         bool holds() const;                       // Check if was created from GArray<T>
 
@@ -327,7 +328,7 @@ namespace detail
  */
 
 template<typename T> class GArray
-{  
+{
 public:
     // Host type (or Flat type) - the type this GArray is actually
     // specified to.

--- a/modules/gapi/include/opencv2/gapi/garray.hpp
+++ b/modules/gapi/include/opencv2/gapi/garray.hpp
@@ -335,7 +335,7 @@ public:
 
     explicit GArray(const std::vector<HT>& v) // Constant value constructor
         : m_ref(detail::GArrayU(detail::VectorRef(v))) { putDetails(); }
-    explicit GArray(std::vector<HT>&& v)      // Constant value move-constructor
+    explicit GArray(std::vector<HT>&& v)      // Move-constructor
         : m_ref(detail::GArrayU(detail::VectorRef(std::move(v)))) { putDetails(); }
     GArray() { putDetails(); }             // Empty constructor
     explicit GArray(detail::GArrayU &&ref) // GArrayU-based constructor

--- a/modules/gapi/include/opencv2/gapi/garray.hpp
+++ b/modules/gapi/include/opencv2/gapi/garray.hpp
@@ -81,7 +81,6 @@ namespace detail
     protected:
         GArrayU();                                // Default constructor
         GArrayU(const detail::VectorRef& vref);   // Constant value constructor
-        GArrayU(detail::VectorRef&& vref);        // Constant value move-constructor
         template<class> friend class cv::GArray;  //  (available to GArray<T> only)
 
         void setConstructFcn(ConstructVec &&cv);  // Store T-aware constructor
@@ -337,7 +336,7 @@ public:
     explicit GArray(const std::vector<HT>& v) // Constant value constructor
         : m_ref(detail::GArrayU(detail::VectorRef(v))) { putDetails(); }
     explicit GArray(std::vector<HT>&& v)      // Constant value move-constructor
-        : m_ref(detail::GArrayU(std::move(detail::VectorRef(v)))) { putDetails(); }
+        : m_ref(detail::GArrayU(detail::VectorRef(std::move(v)))) { putDetails(); }
     GArray() { putDetails(); }             // Empty constructor
     explicit GArray(detail::GArrayU &&ref) // GArrayU-based constructor
         : m_ref(ref) { putDetails(); }     //   (used by GCall, not for users)

--- a/modules/gapi/include/opencv2/gapi/garray.hpp
+++ b/modules/gapi/include/opencv2/gapi/garray.hpp
@@ -335,9 +335,9 @@ public:
     using HT = typename detail::flatten_g<typename std::decay<T>::type>::type;
 
     explicit GArray(const std::vector<HT>& v) // Constant value constructor
-        : m_ref(detail::GArrayU(detail::VectorRef(v))) { putDetails(); }                      
+        : m_ref(detail::GArrayU(detail::VectorRef(v))) { putDetails(); }
     explicit GArray(std::vector<HT>&& v)      // Constant value move-constructor
-        : m_ref(detail::GArrayU(std::move(detail::VectorRef(v)))) { putDetails(); }                      
+        : m_ref(detail::GArrayU(std::move(detail::VectorRef(v)))) { putDetails(); }
     GArray() { putDetails(); }             // Empty constructor
     explicit GArray(detail::GArrayU &&ref) // GArrayU-based constructor
         : m_ref(ref) { putDetails(); }     //   (used by GCall, not for users)

--- a/modules/gapi/src/api/garray.cpp
+++ b/modules/gapi/src/api/garray.cpp
@@ -25,11 +25,6 @@ cv::detail::GArrayU::GArrayU(const detail::VectorRef& vref)
 {
 }
 
-cv::detail::GArrayU::GArrayU(detail::VectorRef&& vref)
-    : m_priv(new GOrigin(GShape::GARRAY, cv::gimpl::ConstVal(std::move(vref))))
-{
-}
-
 cv::GOrigin& cv::detail::GArrayU::priv()
 {
     return *m_priv;

--- a/modules/gapi/src/api/garray.cpp
+++ b/modules/gapi/src/api/garray.cpp
@@ -20,6 +20,16 @@ cv::detail::GArrayU::GArrayU(const GNode &n, std::size_t out)
 {
 }
 
+cv::detail::GArrayU::GArrayU(const detail::VectorRef& vref)
+    : m_priv(new GOrigin(GShape::GARRAY, cv::gimpl::ConstVal(vref)))
+{
+}
+
+cv::detail::GArrayU::GArrayU(detail::VectorRef&& vref)
+    : m_priv(new GOrigin(GShape::GARRAY, cv::gimpl::ConstVal(std::move(vref))))
+{
+}
+
 cv::GOrigin& cv::detail::GArrayU::priv()
 {
     return *m_priv;

--- a/modules/gapi/src/api/gorigin.cpp
+++ b/modules/gapi/src/api/gorigin.cpp
@@ -21,8 +21,15 @@ cv::GOrigin::GOrigin(GShape s,
 }
 
 cv::GOrigin::GOrigin(GShape s, cv::gimpl::ConstVal v)
-    : shape(s), node(cv::GNode::Const()), value(v), port(INVALID_PORT), kind(cv::detail::OpaqueKind::CV_UNKNOWN)
+    : shape(s), node(cv::GNode::Const()), value(v), port(INVALID_PORT)
 {
+    switch (v.index())
+    {
+    case cv::gimpl::ConstVal::index_of<detail::VectorRef>():
+        kind = util::get<detail::VectorRef>(v).getKind();
+    default:
+        kind = cv::detail::OpaqueKind::CV_UNKNOWN;
+    }
 }
 
 bool cv::detail::GOriginCmp::operator() (const cv::GOrigin &lhs,

--- a/modules/gapi/src/api/gorigin.cpp
+++ b/modules/gapi/src/api/gorigin.cpp
@@ -21,15 +21,11 @@ cv::GOrigin::GOrigin(GShape s,
 }
 
 cv::GOrigin::GOrigin(GShape s, cv::gimpl::ConstVal v)
-    : shape(s), node(cv::GNode::Const()), value(v), port(INVALID_PORT)
+    : shape(s), node(cv::GNode::Const()), value(v), port(INVALID_PORT),
+      kind(util::holds_alternative<detail::VectorRef>(v)
+               ? util::get<detail::VectorRef>(v).getKind()
+               : cv::detail::OpaqueKind::CV_UNKNOWN)
 {
-    switch (v.index())
-    {
-    case cv::gimpl::ConstVal::index_of<detail::VectorRef>():
-        kind = util::get<detail::VectorRef>(v).getKind();
-    default:
-        kind = cv::detail::OpaqueKind::CV_UNKNOWN;
-    }
 }
 
 bool cv::detail::GOriginCmp::operator() (const cv::GOrigin &lhs,

--- a/modules/gapi/src/api/gproto.cpp
+++ b/modules/gapi/src/api/gproto.cpp
@@ -79,6 +79,7 @@ cv::GRunArg cv::value_of(const cv::GOrigin &origin)
     switch (origin.shape)
     {
     case GShape::GSCALAR: return GRunArg(util::get<cv::Scalar>(origin.value));
+    case GShape::GARRAY:  return GRunArg(util::get<cv::detail::VectorRef>(origin.value));
     default: util::throw_error(std::logic_error("Unsupported shape for constant"));
     }
 }

--- a/modules/gapi/src/compiler/gobjref.hpp
+++ b/modules/gapi/src/compiler/gobjref.hpp
@@ -29,6 +29,7 @@ namespace gimpl
     using ConstVal = util::variant
     < util::monostate
     , cv::Scalar
+    , cv::detail::VectorRef
     >;
 
     struct RcDesc

--- a/modules/gapi/src/executor/gexecutor.cpp
+++ b/modules/gapi/src/executor/gexecutor.cpp
@@ -114,6 +114,12 @@ void cv::gimpl::GExecutor::initResource(const ade::NodeHandle &orig_nh)
         break;
 
     case GShape::GARRAY:
+        if (d.storage == Data::Storage::CONST_VAL)
+        {
+            auto rc = RcDesc{d.rc, d.shape, d.ctor};
+            magazine::bindInArg(m_res, rc, m_gm.metadata(orig_nh).get<ConstValue>().arg);
+        }
+        break;
     case GShape::GOPAQUE:
         // Constructed on Reset, do nothing here
         break;

--- a/modules/gapi/test/gapi_array_tests.cpp
+++ b/modules/gapi/test/gapi_array_tests.cpp
@@ -30,7 +30,7 @@ G_TYPED_KERNEL(CountCorners,   <GScalar(GPointArray)>,  "test.array.in")
 };
 G_TYPED_KERNEL(PointIncrement, <GPointArray(GMat, GPointArray)>, "test.point_increment")
 {
-    static GArrayDesc outMeta(const GMatDesc&, const GArrayDesc &) { return empty_array_desc(); }
+    static GArrayDesc outMeta(const GMatDesc&, const GArrayDesc&) { return empty_array_desc(); }
 };
 } // namespace ThisTest
 
@@ -63,7 +63,7 @@ GAPI_OCV_KERNEL(OCVCountCorners, ThisTest::CountCorners)
 
 GAPI_OCV_KERNEL(OCVPointIncrement, ThisTest::PointIncrement)
 {
-    static void run(cv::Mat, const std::vector<cv::Point> &in, std::vector<cv::Point> &out)
+    static void run(const cv::Mat&, const std::vector<cv::Point>& in, std::vector<cv::Point>& out)
     {
         for (const auto& el : in)
             out.emplace_back(el + Point(1,1));
@@ -186,7 +186,8 @@ TEST(GArray, GArrayConstValInitialization)
 
     cv::GComputationT<ThisTest::GPointArray(cv::GMat)> c([&](cv::GMat in)
     {
-        ThisTest::GPointArray test_garray(initial_vec); // Initialization
+        // Initialization
+        ThisTest::GPointArray test_garray(initial_vec);
         return ThisTest::PointIncrement::on(in, test_garray);
     });
     auto cc = c.compile(cv::descr_of(in_mat),
@@ -196,7 +197,7 @@ TEST(GArray, GArrayConstValInitialization)
     EXPECT_EQ(ref_vec, out_vec);
 }
 
-TEST(GArray, GArrayConstRValInitialization)
+TEST(GArray, GArrayRValInitialization)
 {
     std::vector<cv::Point> ref_vec {Point(1,1), Point(2,2), Point(3,3)};
     std::vector<cv::Point> out_vec;
@@ -204,8 +205,8 @@ TEST(GArray, GArrayConstRValInitialization)
 
     cv::GComputationT<ThisTest::GPointArray(cv::GMat)> c([&](cv::GMat in)
     {
-        ThisTest::GPointArray test_garray(
-            { Point(0,0), Point(1,1), Point(2,2) } ); // Rvalue initialization
+        // Rvalue initialization
+        ThisTest::GPointArray test_garray({Point(0,0), Point(1,1), Point(2,2)});
         return ThisTest::PointIncrement::on(in, test_garray);
     });
     auto cc = c.compile(cv::descr_of(in_mat),

--- a/modules/gapi/test/gapi_array_tests.cpp
+++ b/modules/gapi/test/gapi_array_tests.cpp
@@ -28,7 +28,7 @@ G_TYPED_KERNEL(CountCorners,   <GScalar(GPointArray)>,  "test.array.in")
 {
     static GScalarDesc outMeta(const GArrayDesc &) { return empty_scalar_desc(); }
 };
-G_TYPED_KERNEL(PointIncrement, <GPointArray(GMat, GPointArray)>, "test.array.initialization")
+G_TYPED_KERNEL(PointIncrement, <GPointArray(GMat, GPointArray)>, "test.point_increment")
 {
     static GArrayDesc outMeta(const GMatDesc&, const GArrayDesc &) { return empty_array_desc(); }
 };
@@ -187,6 +187,25 @@ TEST(GArray, GArrayConstValInitialization)
     cv::GComputationT<ThisTest::GPointArray(cv::GMat)> c([&](cv::GMat in)
     {
         ThisTest::GPointArray test_garray(initial_vec); // Initialization
+        return ThisTest::PointIncrement::on(in, test_garray);
+    });
+    auto cc = c.compile(cv::descr_of(in_mat),
+                        cv::compile_args(cv::gapi::kernels<OCVPointIncrement>()));
+    cc(in_mat, out_vec);
+
+    EXPECT_EQ(ref_vec, out_vec);
+}
+
+TEST(GArray, GArrayConstRValInitialization)
+{
+    std::vector<cv::Point> ref_vec {Point(1,1), Point(2,2), Point(3,3)};
+    std::vector<cv::Point> out_vec;
+    cv::Mat in_mat;
+
+    cv::GComputationT<ThisTest::GPointArray(cv::GMat)> c([&](cv::GMat in)
+    {
+        ThisTest::GPointArray test_garray(
+            { Point(0,0), Point(1,1), Point(2,2) } ); // Rvalue initialization
         return ThisTest::PointIncrement::on(in, test_garray);
     });
     auto cc = c.compile(cv::descr_of(in_mat),

--- a/modules/gapi/test/gapi_array_tests.cpp
+++ b/modules/gapi/test/gapi_array_tests.cpp
@@ -28,6 +28,10 @@ G_TYPED_KERNEL(CountCorners,   <GScalar(GPointArray)>,  "test.array.in")
 {
     static GScalarDesc outMeta(const GArrayDesc &) { return empty_scalar_desc(); }
 };
+G_TYPED_KERNEL(PointIncrement, <GPointArray(GMat, GPointArray)>, "test.array.initialization")
+{
+    static GArrayDesc outMeta(const GMatDesc&, const GArrayDesc &) { return empty_array_desc(); }
+};
 } // namespace ThisTest
 
 namespace
@@ -54,6 +58,15 @@ GAPI_OCV_KERNEL(OCVCountCorners, ThisTest::CountCorners)
     static void run(const std::vector<cv::Point> &in, cv::Scalar &out)
     {
         out[0] = static_cast<double>(in.size());
+    }
+};
+
+GAPI_OCV_KERNEL(OCVPointIncrement, ThisTest::PointIncrement)
+{
+    static void run(cv::Mat, const std::vector<cv::Point> &in, std::vector<cv::Point> &out)
+    {
+        for (const auto& el : in)
+            out.emplace_back(el + Point(1,1));
     }
 };
 
@@ -162,6 +175,25 @@ TEST(GArray, TestIntermediateOutput)
 
     EXPECT_EQ(10u, out_points.size());
     EXPECT_EQ(10,  out_count[0]);
+}
+
+TEST(GArray, GArrayInitialization)
+{
+    std::vector<cv::Point> initial_vec {Point(0,0), Point(1,1), Point(2,2)};
+    std::vector<cv::Point> ref_vec     {Point(1,1), Point(2,2), Point(3,3)};
+    std::vector<cv::Point> out_vec;
+    cv::Mat in_mat;
+
+    cv::GComputationT<ThisTest::GPointArray(cv::GMat)> c([&](cv::GMat in)
+    {
+        ThisTest::GPointArray test_garray(initial_vec); // Initialization
+        return ThisTest::PointIncrement::on(in, test_garray);
+    });
+    auto cc = c.compile(cv::descr_of(in_mat),
+                        cv::compile_args(cv::gapi::kernels<OCVPointIncrement>()));
+    cc(in_mat, out_vec);
+
+    EXPECT_EQ(ref_vec, out_vec);
 }
 
 TEST(GArray_VectorRef, TestMov)

--- a/modules/gapi/test/gapi_array_tests.cpp
+++ b/modules/gapi/test/gapi_array_tests.cpp
@@ -177,7 +177,7 @@ TEST(GArray, TestIntermediateOutput)
     EXPECT_EQ(10,  out_count[0]);
 }
 
-TEST(GArray, GArrayInitialization)
+TEST(GArray, GArrayConstValInitialization)
 {
     std::vector<cv::Point> initial_vec {Point(0,0), Point(1,1), Point(2,2)};
     std::vector<cv::Point> ref_vec     {Point(1,1), Point(2,2), Point(3,3)};


### PR DESCRIPTION
## Add GArray initialization support

Added support initialization for GArray. CONST_VALUE used for this.
You can create an empty or filled std::vector and put or move it into a GArray.

Example:

```
std::vector<cv::Mat> vec; // or vec = {some values}
cv::GComputation pp([&]() {
    cv::GMat in;
    cv::GArray<cv::GMat> garr(vec); // or garr(std::move(vec))
    return cv::GComputation(custom::SomeOp::on(in, garr));
});
```
Possible:
- `cv::GArray<cv::GMat> garr(vec)`;
- `cv::GArray<cv::GMat> garr(rval)`;
- `cv::GArray<cv::GMat> garr({some values})`.

Impossible:

- `cv::GArray<cv::GMat> garr = vec; // explicit`;
- `cv::GArray<cv::GMat> garr = std::vector<cv::Mat>(some size); // explicit`;
- `cv::GArray<cv::GMat> garr = std::vector<cv::Mat>()`.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [x] The PR is proposed to proper branch
- [x] There is reference to original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake

### Magic commands

```
force_builders=Custom,Custom Win,Custom Mac
build_gapi_standalone:Linux x64=ade-0.1.1f
build_gapi_standalone:Win64=ade-0.1.1f
build_gapi_standalone:Mac=ade-0.1.1f
build_gapi_standalone:Linux x64 Debug=ade-0.1.1f

Xbuild_image:Custom=centos:7
Xbuildworker:Custom=linux-1
build_gapi_standalone:Custom=ade-0.1.1f

build_image:Custom=ubuntu-openvino-2020.3.0:16.04
build_image:Custom Win=openvino-2020.3.0
build_image:Custom Mac=openvino-2020.3.0

test_modules:Custom=gapi
test_modules:Custom Win=gapi
test_modules:Custom Mac=gapi

buildworker:Custom=linux-1
# disabled due high memory usage: test_opencl:Custom=ON
test_opencl:Custom=OFF
test_bigdata:Custom=1
test_filter:Custom=*
```