### PR TITLE
videoio: reduce min libavcodec version

### DIFF
--- a/modules/videoio/cmake/detect_ffmpeg.cmake
+++ b/modules/videoio/cmake/detect_ffmpeg.cmake
@@ -51,7 +51,7 @@ endif()
 #=================================
 # Versions check.
 if(HAVE_FFMPEG AND NOT HAVE_FFMPEG_WRAPPER)
-  set(_min_libavcodec_version 54.35.1)
+  set(_min_libavcodec_version 54.35.0)
   set(_min_libavformat_version 54.20.4)
   set(_min_libavutil_version 52.3.0)
   set(_min_libswscale_version 2.1.1)


### PR DESCRIPTION
Checked build with specified FFmpeg version - it works.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [x] The PR is proposed to proper branch
- [x] There is reference to original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
