### PR TITLE
Change default parameters of OpenJPEG encoder to produce lossy result

### DIFF
--- a/modules/imgcodecs/src/grfmt_jpeg2000_openjpeg.cpp
+++ b/modules/imgcodecs/src/grfmt_jpeg2000_openjpeg.cpp
@@ -327,12 +327,14 @@ opj_cparameters setupEncoderParameters(const std::vector<int>& params)
 {
     opj_cparameters parameters;
     opj_set_default_encoder_parameters(&parameters);
+    bool rate_is_specified = false;
     for (size_t i = 0; i < params.size(); i += 2)
     {
         switch (params[i])
         {
         case cv::IMWRITE_JPEG2000_COMPRESSION_X1000:
             parameters.tcp_rates[0] = 1000.f / std::min(std::max(params[i + 1], 1), 1000);
+            rate_is_specified = true;
             break;
         default:
             CV_LOG_WARNING(NULL, "OpenJPEG2000(encoder): skip unsupported parameter: " << params[i]);
@@ -341,6 +343,10 @@ opj_cparameters setupEncoderParameters(const std::vector<int>& params)
     }
     parameters.tcp_numlayers = 1;
     parameters.cp_disto_alloc = 1;
+    if (!rate_is_specified)
+    {
+        parameters.tcp_rates[0] = 4;
+    }
     return parameters;
 }
 

--- a/modules/imgcodecs/test/test_read_write.cpp
+++ b/modules/imgcodecs/test/test_read_write.cpp
@@ -228,9 +228,12 @@ TEST_P(Imgcodecs_Image, read_write_BGR)
     double psnrThreshold = 100;
     if (ext == "jpg")
         psnrThreshold = 32;
-#ifdef HAVE_JASPER
+#if defined(HAVE_JASPER)
     if (ext == "jp2")
         psnrThreshold = 95;
+#elif defined(HAVE_OPENJPEG)
+    if (ext == "jp2")
+        psnrThreshold = 35;
 #endif
 
     Mat image = generateTestImageBGR();
@@ -254,9 +257,12 @@ TEST_P(Imgcodecs_Image, read_write_GRAYSCALE)
     double psnrThreshold = 100;
     if (ext == "jpg")
         psnrThreshold = 40;
-#ifdef HAVE_JASPER
+#if defined(HAVE_JASPER)
     if (ext == "jp2")
         psnrThreshold = 70;
+#elif defined(HAVE_OPENJPEG)
+    if (ext == "jp2")
+        psnrThreshold = 35;
 #endif
 
     Mat image = generateTestImageGrayscale();


### PR DESCRIPTION
Default parameters of OpenJPEG encoder produce lossless encoding (or visual lossless) which leads to heavy encoded files.

This patch helps to reduce output file size if user doesn't explicitly specify compression ratio.


| Test            |  Size Before   | Size After       | PSNR Before | PSNR After |
| --------------- | ------------------ | ------------------ | ------------------ | --------------- |
|  BGR          | 585751 bytes | 230283 bytes | 361.202          | 36.3795      |
|  Grayscale  | 193798 bytes | 76691 bytes   | 361.202          | 36.6272       |


### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [x] The PR is proposed to proper branch
- [ ] There is reference to original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
