### PR TITLE
fix missing 0.5 factor in anisotropic segmentation tutorial

### DIFF
--- a/doc/tutorials/imgproc/anisotropic_image_segmentation/anisotropic_image_segmentation.markdown
+++ b/doc/tutorials/imgproc/anisotropic_image_segmentation/anisotropic_image_segmentation.markdown
@@ -37,7 +37,7 @@ J_{12} & J_{22}
 where \f$J_{11} = M[Z_{x}^{2}]\f$, \f$J_{22} = M[Z_{y}^{2}]\f$, \f$J_{12} = M[Z_{x}Z_{y}]\f$ - components of the tensor, \f$M[]\f$ is a symbol of mathematical expectation (we can consider this operation as averaging in a window w), \f$Z_{x}\f$ and \f$Z_{y}\f$ are partial derivatives of an image \f$Z\f$ with respect to \f$x\f$ and \f$y\f$.
 
 The eigenvalues of the tensor can be found in the below formula:
-\f[\lambda_{1,2} = J_{11} + J_{22} \pm \sqrt{(J_{11} - J_{22})^{2} + 4J_{12}^{2}}\f]
+\f[\lambda_{1,2} = \frac{1}{2} \left [ J_{11} + J_{22} \pm \sqrt{(J_{11} - J_{22})^{2} + 4J_{12}^{2}} \right ] \f]
 where \f$\lambda_1\f$ - largest eigenvalue, \f$\lambda_2\f$ - smallest eigenvalue.
 
 ### How to estimate orientation and coherency of an anisotropic image by gradient structure tensor?

--- a/samples/cpp/tutorial_code/ImgProc/anisotropic_image_segmentation/anisotropic_image_segmentation.cpp
+++ b/samples/cpp/tutorial_code/ImgProc/anisotropic_image_segmentation/anisotropic_image_segmentation.cpp
@@ -74,8 +74,8 @@ void calcGST(const Mat& inputImg, Mat& imgCoherencyOut, Mat& imgOrientationOut, 
     // GST components calculation (stop)
 
     // eigenvalue calculation (start)
-    // lambda1 = J11 + J22 + sqrt((J11-J22)^2 + 4*J12^2)
-    // lambda2 = J11 + J22 - sqrt((J11-J22)^2 + 4*J12^2)
+    // lambda1 = 0.5*(J11 + J22 + sqrt((J11-J22)^2 + 4*J12^2))
+    // lambda2 = 0.5*(J11 + J22 - sqrt((J11-J22)^2 + 4*J12^2))
     Mat tmp1, tmp2, tmp3, tmp4;
     tmp1 = J11 + J22;
     tmp2 = J11 - J22;
@@ -84,8 +84,10 @@ void calcGST(const Mat& inputImg, Mat& imgCoherencyOut, Mat& imgOrientationOut, 
     sqrt(tmp2 + 4.0 * tmp3, tmp4);
 
     Mat lambda1, lambda2;
-    lambda1 = tmp1 + tmp4;      // biggest eigenvalue
-    lambda2 = tmp1 - tmp4;      // smallest eigenvalue
+    lambda1 = tmp1 + tmp4;
+    lambda1 = 0.5*lambda1;      // biggest eigenvalue
+    lambda2 = tmp1 - tmp4;
+    lambda2 = 0.5*lambda2;      // smallest eigenvalue
     // eigenvalue calculation (stop)
 
     // Coherency calculation (start)

--- a/samples/python/tutorial_code/imgProc/anisotropic_image_segmentation/anisotropic_image_segmentation.py
+++ b/samples/python/tutorial_code/imgProc/anisotropic_image_segmentation/anisotropic_image_segmentation.py
@@ -31,16 +31,16 @@ def calcGST(inputIMG, w):
     # GST components calculations (stop)
 
     # eigenvalue calculation (start)
-    # lambda1 = J11 + J22 + sqrt((J11-J22)^2 + 4*J12^2)
-    # lambda2 = J11 + J22 - sqrt((J11-J22)^2 + 4*J12^2)
+    # lambda1 = 0.5*(J11 + J22 + sqrt((J11-J22)^2 + 4*J12^2))
+    # lambda2 = 0.5*(J11 + J22 - sqrt((J11-J22)^2 + 4*J12^2))
     tmp1 = J11 + J22
     tmp2 = J11 - J22
     tmp2 = cv.multiply(tmp2, tmp2)
     tmp3 = cv.multiply(J12, J12)
     tmp4 = np.sqrt(tmp2 + 4.0 * tmp3)
 
-    lambda1 = tmp1 + tmp4    # biggest eigenvalue
-    lambda2 = tmp1 - tmp4    # smallest eigenvalue
+    lambda1 = 0.5*(tmp1 + tmp4)    # biggest eigenvalue
+    lambda2 = 0.5*(tmp1 - tmp4)    # smallest eigenvalue
     # eigenvalue calculation (stop)
 
     # Coherency calculation (start)


### PR DESCRIPTION
I found a typo in the tutorial "Anisotropic image segmentation by a gradient structure tensor" from the Image Processing module.

A factor 1/2 is missing in the computation of the eigenvalues of the structure tensor. The correct formula is the eq. 4 of this paper:
http://citeseerx.ist.psu.edu/viewdoc/download?doi=10.1.1.104.8552&rep=rep1&type=pdf

This pull request changes the text of the tutorial and the code of the python/cpp samples by inserting the 0.5 x factor.
