### PR TITLE
[G-API]: Adding reshape for CNN input.

### DIFF
--- a/modules/gapi/include/opencv2/gapi/infer/ie.hpp
+++ b/modules/gapi/include/opencv2/gapi/infer/ie.hpp
@@ -68,6 +68,9 @@ namespace detail {
         bool is_generic;
         IEConfig config;
 
+        std::map<std::string, std::vector<std::size_t>> reshape_table;
+        std::vector<std::string> layer_names_to_reshape;
+
         // NB: Number of asyncrhonious infer requests
         size_t nireq;
     };
@@ -95,6 +98,8 @@ public:
               , detail::ParamDesc::Kind::Load
               , false
               , {}
+              , {}
+              , {}
               , 1u} {
     };
 
@@ -105,6 +110,8 @@ public:
               , std::tuple_size<typename Net::OutArgs>::value // num_out
               , detail::ParamDesc::Kind::Import
               , false
+              , {}
+              , {}
               , {}
               , 1u} {
     };
@@ -148,6 +155,36 @@ public:
         return *this;
     }
 
+    Params<Net>& cfgInputReshape(std::map<std::string, std::vector<std::size_t>>&& reshape_table) {
+        desc.reshape_table = std::move(reshape_table);
+        return *this;
+    }
+
+    Params<Net>& cfgInputReshape(const std::map<std::string, std::vector<std::size_t>>& reshape_table) {
+        desc.reshape_table = reshape_table;
+        return *this;
+    }
+
+    Params<Net>& cfgInputReshape(std::string&& layer_name, std::vector<size_t>&& layer_dims) {
+        desc.reshape_table.emplace(layer_name, layer_dims);
+        return *this;
+    }
+
+    Params<Net>& cfgInputReshape(const std::string& layer_name, const std::vector<size_t>& layer_dims) {
+        desc.reshape_table.emplace(layer_name, layer_dims);
+        return *this;
+    }
+
+    Params<Net>& cfgInputReshape(std::vector<std::string>&& layer_names) {
+        desc.layer_names_to_reshape = std::move(layer_names);
+        return *this;
+    }
+
+    Params<Net>& cfgInputReshape(const std::vector<std::string>& layer_names) {
+        desc.layer_names_to_reshape = layer_names;
+        return *this;
+    }
+
     // BEGIN(G-API's network parametrization API)
     GBackend      backend()    const { return cv::gapi::ie::backend();  }
     std::string   tag()        const { return Net::tag(); }
@@ -165,13 +202,13 @@ public:
            const std::string &model,
            const std::string &weights,
            const std::string &device)
-        : desc{ model, weights, device, {}, {}, {}, 0u, 0u, detail::ParamDesc::Kind::Load, true, {}, 1u}, m_tag(tag) {
+        : desc{ model, weights, device, {}, {}, {}, 0u, 0u, detail::ParamDesc::Kind::Load, true, {}, {}, {}, 1u}, m_tag(tag) {
     };
 
     Params(const std::string &tag,
            const std::string &model,
            const std::string &device)
-        : desc{ model, {}, device, {}, {}, {}, 0u, 0u, detail::ParamDesc::Kind::Import, true, {}, 1u}, m_tag(tag) {
+        : desc{ model, {}, device, {}, {}, {}, 0u, 0u, detail::ParamDesc::Kind::Import, true, {}, {}, {}, 1u}, m_tag(tag) {
     };
 
     Params& pluginConfig(IEConfig&& cfg) {

--- a/modules/gapi/include/opencv2/gapi/infer/ie.hpp
+++ b/modules/gapi/include/opencv2/gapi/infer/ie.hpp
@@ -8,6 +8,7 @@
 #define OPENCV_GAPI_INFER_IE_HPP
 
 #include <unordered_map>
+#include <unordered_set>
 #include <string>
 #include <array>
 #include <tuple> // tuple, tuple_size
@@ -69,7 +70,7 @@ namespace detail {
         IEConfig config;
 
         std::map<std::string, std::vector<std::size_t>> reshape_table;
-        std::vector<std::string> layer_names_to_reshape;
+        std::unordered_set<std::string> layer_names_to_reshape;
 
         // NB: Number of asyncrhonious infer requests
         size_t nireq;
@@ -175,12 +176,12 @@ public:
         return *this;
     }
 
-    Params<Net>& cfgInputReshape(std::vector<std::string>&& layer_names) {
+    Params<Net>& cfgInputReshape(std::unordered_set<std::string>&& layer_names) {
         desc.layer_names_to_reshape = std::move(layer_names);
         return *this;
     }
 
-    Params<Net>& cfgInputReshape(const std::vector<std::string>& layer_names) {
+    Params<Net>& cfgInputReshape(const std::unordered_set<std::string>& layer_names) {
         desc.layer_names_to_reshape = layer_names;
         return *this;
     }

--- a/modules/gapi/src/backends/ie/giebackend.cpp
+++ b/modules/gapi/src/backends/ie/giebackend.cpp
@@ -789,7 +789,7 @@ struct Infer: public cv::detail::KernelTag {
                                         ade::util::toRange(in_metas))) {
             const auto &input_name = std::get<0>(it);
             auto       &&ii = uu.inputs.at(input_name);
-            const auto & mm =              std::get<1>(it);
+            const auto & mm = std::get<1>(it);
 
             configureInputInfo(ii, mm);
             if (uu.params.layer_names_to_reshape.find(input_name) !=

--- a/modules/gapi/test/infer/gapi_infer_ie_test.cpp
+++ b/modules/gapi/test/infer/gapi_infer_ie_test.cpp
@@ -1659,7 +1659,6 @@ TEST_F(InferWithReshapeNV12, TestInferListYUV)
     // Validate
     validate();
 }
-
 } // namespace opencv_test
 
 #endif //  HAVE_INF_ENGINE

--- a/modules/gapi/test/infer/gapi_infer_ie_test.cpp
+++ b/modules/gapi/test/infer/gapi_infer_ie_test.cpp
@@ -233,6 +233,115 @@ TEST(TestAgeGenderIE, InferBasicImage)
     normAssert(cv::gapi::ie::util::to_ocv(ie_gender), gapi_gender, "Test gender output");
 }
 
+struct InferWithReshape: public ::testing::Test {
+    cv::gapi::ie::detail::ParamDesc params;
+    cv::Mat m_in_mat;
+    std::vector<cv::Rect> m_roi_list;
+    std::vector<size_t> reshape_dims;
+    std::vector<cv::Mat> m_out_ie_ages;
+    std::vector<cv::Mat> m_out_ie_genders;
+    std::vector<cv::Mat> m_out_gapi_ages;
+    std::vector<cv::Mat> m_out_gapi_genders;
+    using AGInfo = std::tuple<cv::GMat, cv::GMat>;
+    G_API_NET(AgeGender, <AGInfo(cv::GMat)>, "test-age-gender");
+
+    InferenceEngine::CNNNetwork net;
+    InferenceEngine::Core plugin;
+
+    InferWithReshape() {
+        // FIXME: it must be cv::imread(findDataFile("../dnn/grace_hopper_227.png", false));
+        m_in_mat = cv::Mat(cv::Size(320, 240), CV_8UC3);
+        cv::randu(m_in_mat, 0, 255);
+
+        m_out_gapi_ages.resize(1);
+        m_out_gapi_genders.resize(1);
+
+        // both ROIs point to the same face, with a slightly changed geometry
+        m_roi_list = {
+            cv::Rect(cv::Point{64, 60}, cv::Size{ 96,  96}),
+            cv::Rect(cv::Point{50, 32}, cv::Size{128, 160}),
+        };
+
+        // New dimensions for "data" input
+        reshape_dims = {1, 3, 70, 70};
+
+        initDLDTDataPath();
+        params.model_path = findDataFile(SUBDIR + "age-gender-recognition-retail-0013.xml");
+        params.weights_path = findDataFile(SUBDIR + "age-gender-recognition-retail-0013.bin");
+
+        params.device_id = "CPU";
+
+        plugin = cv::gimpl::ie::wrap::getPlugin(params);
+        net    = cv::gimpl::ie::wrap::readNetwork(params);
+        setNetParameters(net);
+        net.reshape({{"data", reshape_dims}});
+    }
+
+    void inferROIs(IE::Blob::Ptr blob) {
+        auto this_network  = cv::gimpl::ie::wrap::loadNetwork(plugin, net, params);
+        auto infer_request = this_network.CreateInferRequest();
+        for (auto &&rc : m_roi_list) {
+            const auto ie_rc = IE::ROI {
+                0u
+                , static_cast<std::size_t>(rc.x)
+                , static_cast<std::size_t>(rc.y)
+                , static_cast<std::size_t>(rc.width)
+                , static_cast<std::size_t>(rc.height)
+            };
+            infer_request.SetBlob("data", IE::make_shared_blob(blob, ie_rc));
+            infer_request.Infer();
+            using namespace cv::gapi::ie::util;
+            m_out_ie_ages.push_back(to_ocv(infer_request.GetBlob("age_conv3")).clone());
+            m_out_ie_genders.push_back(to_ocv(infer_request.GetBlob("prob")).clone());
+        }
+    }
+
+    void infer(cv::Mat& in, const bool with_roi = false) {
+        if (!with_roi) {
+            auto this_network  = cv::gimpl::ie::wrap::loadNetwork(plugin, net, params);
+            auto infer_request = this_network.CreateInferRequest();
+            infer_request.SetBlob("data", cv::gapi::ie::util::to_ie(in));
+            infer_request.Infer();
+            using namespace cv::gapi::ie::util;
+            m_out_ie_ages.push_back(to_ocv(infer_request.GetBlob("age_conv3")).clone());
+            m_out_ie_genders.push_back(to_ocv(infer_request.GetBlob("prob")).clone());
+        } else {
+            auto frame_blob = cv::gapi::ie::util::to_ie(in);
+            inferROIs(frame_blob);
+        }
+    }
+
+    void validate() {
+        // Validate with IE itself (avoid DNN module dependency here)
+        GAPI_Assert(!m_out_gapi_ages.empty());
+        ASSERT_EQ(m_out_gapi_genders.size(), m_out_gapi_ages.size());
+        ASSERT_EQ(m_out_gapi_ages.size(), m_out_ie_ages.size());
+        ASSERT_EQ(m_out_gapi_genders.size(), m_out_ie_genders.size());
+
+        const size_t size = m_out_gapi_ages.size();
+        for (size_t i = 0; i < size; ++i) {
+            normAssert(m_out_ie_ages   [i], m_out_gapi_ages   [i], "Test age output");
+            normAssert(m_out_ie_genders[i], m_out_gapi_genders[i], "Test gender output");
+        }
+    }
+}; // InferWithReshape
+
+struct InferWithReshapeNV12: public InferWithReshape {
+    cv::Mat m_in_uv;
+    cv::Mat m_in_y;
+    void SetUp() {
+        cv::Size sz{320, 240};
+        m_in_y = cv::Mat{sz, CV_8UC1};
+        cv::randu(m_in_y, 0, 255);
+        m_in_uv = cv::Mat{sz / 2, CV_8UC2};
+        cv::randu(m_in_uv, 0, 255);
+        setNetParameters(net, true);
+        net.reshape({{"data", reshape_dims}});
+        auto frame_blob = cv::gapi::ie::util::to_ie(m_in_y, m_in_uv);
+        inferROIs(frame_blob);
+    }
+};
+
 struct ROIList: public ::testing::Test {
     cv::gapi::ie::detail::ParamDesc params;
 
@@ -1401,6 +1510,154 @@ TEST(Infer2EmptyList, TestStreamingInfer)
         EXPECT_TRUE(gapi_ages.empty());
         EXPECT_TRUE(gapi_genders.empty());
     }
+}
+
+TEST_F(InferWithReshape, TestInfer)
+{
+    // IE code
+    infer(m_in_mat);
+    // G-API code
+    cv::GMat in;
+    cv::GMat age, gender;
+    std::tie(age, gender) = cv::gapi::infer<AgeGender>(in);
+    cv::GComputation comp(cv::GIn(in), cv::GOut(age, gender));
+
+    auto pp = cv::gapi::ie::Params<AgeGender> {
+        params.model_path, params.weights_path, params.device_id
+    }.cfgOutputLayers({ "age_conv3", "prob" }).cfgInputReshape({{"data", reshape_dims}});
+    comp.apply(cv::gin(m_in_mat), cv::gout(m_out_gapi_ages.front(), m_out_gapi_genders.front()),
+               cv::compile_args(cv::gapi::networks(pp)));
+    // Validate
+    validate();
+}
+
+TEST_F(InferWithReshape, TestInferInImage)
+{
+    // Input image already has 70x70 size
+    cv::Mat rsz;
+    cv::resize(m_in_mat, rsz, cv::Size(70, 70));
+    // IE code
+    infer(rsz);
+    // G-API code
+    cv::GMat in;
+    cv::GMat age, gender;
+    std::tie(age, gender) = cv::gapi::infer<AgeGender>(in);
+    cv::GComputation comp(cv::GIn(in), cv::GOut(age, gender));
+
+    auto pp = cv::gapi::ie::Params<AgeGender> {
+        params.model_path, params.weights_path, params.device_id
+    }.cfgOutputLayers({ "age_conv3", "prob" }).cfgInputReshape({"data"});
+    // Reshape CNN input by input image size
+    comp.apply(cv::gin(rsz), cv::gout(m_out_gapi_ages.front(), m_out_gapi_genders.front()),
+               cv::compile_args(cv::gapi::networks(pp)));
+    // Validate
+    validate();
+}
+
+TEST_F(InferWithReshape, TestInferForSingleLayer)
+{
+    // IE code
+    infer(m_in_mat);
+    // G-API code
+    cv::GMat in;
+    cv::GMat age, gender;
+    std::tie(age, gender) = cv::gapi::infer<AgeGender>(in);
+    cv::GComputation comp(cv::GIn(in), cv::GOut(age, gender));
+
+    auto pp = cv::gapi::ie::Params<AgeGender> {
+        params.model_path, params.weights_path, params.device_id
+    }.cfgOutputLayers({ "age_conv3", "prob" })
+     .cfgInputReshape("data", reshape_dims);
+    comp.apply(cv::gin(m_in_mat), cv::gout(m_out_gapi_ages.front(), m_out_gapi_genders.front()),
+               cv::compile_args(cv::gapi::networks(pp)));
+    // Validate
+    validate();
+}
+
+TEST_F(InferWithReshape, TestInferList)
+{
+    // IE code
+    infer(m_in_mat, true);
+    // G-API code
+    cv::GArray<cv::Rect> rr;
+    cv::GMat in;
+    cv::GArray<cv::GMat> age, gender;
+    std::tie(age, gender) = cv::gapi::infer<AgeGender>(rr, in);
+    cv::GComputation comp(cv::GIn(in, rr), cv::GOut(age, gender));
+
+    auto pp = cv::gapi::ie::Params<AgeGender> {
+        params.model_path, params.weights_path, params.device_id
+    }.cfgOutputLayers({ "age_conv3", "prob" }).cfgInputReshape({{"data", reshape_dims}});
+    comp.apply(cv::gin(m_in_mat, m_roi_list),
+               cv::gout(m_out_gapi_ages, m_out_gapi_genders),
+               cv::compile_args(cv::gapi::networks(pp)));
+    // Validate
+    validate();
+}
+
+TEST_F(InferWithReshape, TestInferList2)
+{
+    // IE code
+    infer(m_in_mat, true);
+    // G-API code
+    cv::GArray<cv::Rect> rr;
+    cv::GMat in;
+    cv::GArray<cv::GMat> age, gender;
+    std::tie(age, gender) = cv::gapi::infer2<AgeGender>(in, rr);
+    cv::GComputation comp(cv::GIn(in, rr), cv::GOut(age, gender));
+
+    auto pp = cv::gapi::ie::Params<AgeGender> {
+        params.model_path, params.weights_path, params.device_id
+    }.cfgOutputLayers({ "age_conv3", "prob" }).cfgInputReshape({{"data", reshape_dims}});
+    comp.apply(cv::gin(m_in_mat, m_roi_list),
+               cv::gout(m_out_gapi_ages, m_out_gapi_genders),
+               cv::compile_args(cv::gapi::networks(pp)));
+    // Validate
+    validate();
+}
+
+TEST_F(InferWithReshape, TestInferListBGR)
+{
+    // IE code
+    infer(m_in_mat, true);
+    // G-API code
+    cv::GArray<cv::Rect> rr;
+    cv::GFrame in;
+    cv::GArray<cv::GMat> age, gender;
+    std::tie(age, gender) = cv::gapi::infer<AgeGender>(rr, in);
+    cv::GComputation comp(cv::GIn(in, rr), cv::GOut(age, gender));
+
+    auto frame = MediaFrame::Create<TestMediaBGR>(m_in_mat);
+
+    auto pp = cv::gapi::ie::Params<AgeGender> {
+        params.model_path, params.weights_path, params.device_id
+    }.cfgOutputLayers({ "age_conv3", "prob" }).cfgInputReshape({{"data", reshape_dims}});
+    comp.apply(cv::gin(frame, m_roi_list),
+               cv::gout(m_out_gapi_ages, m_out_gapi_genders),
+               cv::compile_args(cv::gapi::networks(pp)));
+    // Validate
+    validate();
+}
+
+TEST_F(InferWithReshapeNV12, TestInferListYUV)
+{
+    // G-API code
+    cv::GFrame in;
+    cv::GArray<cv::Rect> rr;
+    cv::GArray<cv::GMat> age, gender;
+    std::tie(age, gender) = cv::gapi::infer<AgeGender>(rr, in);
+    cv::GComputation comp(cv::GIn(in, rr), cv::GOut(age, gender));
+
+    auto frame = MediaFrame::Create<TestMediaNV12>(m_in_y, m_in_uv);
+
+    auto pp = cv::gapi::ie::Params<AgeGender> {
+        params.model_path, params.weights_path, params.device_id
+    }.cfgOutputLayers({ "age_conv3", "prob" }).cfgInputReshape({{"data", reshape_dims}});
+    comp.apply(cv::gin(frame, m_roi_list),
+               cv::gout(m_out_gapi_ages, m_out_gapi_genders),
+               cv::compile_args(cv::gapi::networks(pp)));
+    // Validate
+    validate();
 }
 
 } // namespace opencv_test


### PR DESCRIPTION
## Adding reshape for CNN input

Reshape changes shape for CNN input dims.

To use input reshape, you should call function `cfgInputReshape` for `Params`:
1. `.cfgInputReshape( { {layer1_name, shape1}, {layer3_name, shape3} } )` - for some layers;
2. `.cfgInputReshape(layer1_name, shape1)` - for single layer;
3. `.cfgInputReshape( { layer1_name, layer3_name } )` - for reshaping by input image.

`layer..._name` - name of input layer, which should to be reshaped.
`shape...` - vector of dimensions, which reshape will use (1,3,300,300 for example).

Behavior:
- `input_reshape_table` from IEUnit contains pairs layer's name --- dimensions for reshape;
- Unfortunately, now current CNN input layers dimensions are not checked, but if provided incorrect dimensions in 1st and 2nd cases of `cfgInputReshape` then IE throw error message;
- In 3rd case of `cfgInputReshape` are constructing element of `input_reshape_table` by current CNN dimensions and height and width input image;
- If user call 1st, 2nd and 3rd case of `.cfgInputReshape` at the same time then reshape by dimensions is preferred then by input image;
- Call of `InferenceEngine::CNNNetwork::reshape` function is located in `OutMeta()` of Infer, InferROI, InferList and InferList2.

Tests:
New fixture InferWithReshape:
- TestInfer - simple infer by shapes;
- TestInferInImage - infer by input image size;
- TestInferBehavior - launch with 1st and 3rd case of `.cfgInputReshape` at the same time;
- TestInferForSingleLayer - launch with 2nd case of `.cfgInputReshape`;
- TestInferList - infer by ROIs with CNN input reshape;
- TestInferList2;
- TestInferListBGR - infer GFrame (BGR).
New fixture InferWithReshapeNV12:
- TestInferListYUV - infer GFrame (YUV)..
### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [x] The PR is proposed to proper branch
- [x] There is reference to original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake

### Magic commands
```
force_builders=Custom,Custom Win,Custom Mac
build_gapi_standalone:Linux x64=ade-0.1.1f
build_gapi_standalone:Win64=ade-0.1.1f
build_gapi_standalone:Mac=ade-0.1.1f
build_gapi_standalone:Linux x64 Debug=ade-0.1.1f

build_image:Custom=centos:7
buildworker:Custom=linux-1
build_gapi_standalone:Custom=ade-0.1.1f

xbuild_image:Custom=ubuntu-openvino-2021.1.0:20.04
xbuild_image:Custom Win=openvino-2021.1.0
xbuild_image:Custom Mac=openvino-2021.1.0

test_modules:Custom=gapi
test_modules:Custom Win=gapi
test_modules:Custom Mac=gapi

# disabled due high memory usage: test_opencl:Custom=ON
test_opencl:Custom=OFF
test_bigdata:Custom=1
test_filter:Custom=*
```
