### PR TITLE
videoio: repair build of FFmpeg Windows wrapper

### DIFF
--- a/modules/videoio/src/cap_ffmpeg_impl.hpp
+++ b/modules/videoio/src/cap_ffmpeg_impl.hpp
@@ -484,7 +484,6 @@ struct CvCapture_FFMPEG
     bool setProperty(int, double);
     bool grabFrame();
     bool retrieveFrame(int, unsigned char** data, int* step, int* width, int* height, int* cn);
-    void rotateFrame(cv::Mat &mat) const;
 
     void init();
 


### PR DESCRIPTION
relates #17489

`cv::Mat` is not available in FFmpeg Windows wrapper for 3.4 branch.