### PR TITLE
[G-API] Wrap cv::gapi::mean kernel into python

### DIFF
--- a/modules/gapi/include/opencv2/gapi/core.hpp
+++ b/modules/gapi/include/opencv2/gapi/core.hpp
@@ -744,7 +744,7 @@ Supported matrix data types are @ref CV_8UC1, @ref CV_8UC3, @ref CV_16UC1, @ref 
 @note Function textual ID is "org.opencv.core.math.mean"
 @param src input matrix.
 */
-GAPI_EXPORTS GScalar mean(const GMat& src);
+GAPI_EXPORTS_W GScalar mean(const GMat& src);
 
 /** @brief Calculates x and y coordinates of 2D vectors from their magnitude and angle.
 

--- a/modules/gapi/include/opencv2/gapi/gcomputation.hpp
+++ b/modules/gapi/include/opencv2/gapi/gcomputation.hpp
@@ -181,7 +181,7 @@ public:
      * @param in input GMat of the defined unary computation
      * @param out output GScalar of the defined unary computation
      */
-    GComputation(GMat in, GScalar out);                // Unary overload (scalar)
+    GAPI_WRAP GComputation(GMat in, GScalar out);      // Unary overload (scalar)
 
     /**
      * @brief Defines a binary (two inputs -- one output) computation
@@ -286,7 +286,7 @@ public:
      * @param args compilation arguments for underlying compilation
      * process.
      */
-    void apply(cv::Mat in, cv::Scalar &out, GCompileArgs &&args = {}); // Unary overload (scalar)
+    GAPI_WRAP void apply(cv::Mat in, CV_OUT cv::Scalar &out, GCompileArgs &&args = {}); // Unary overload (scalar)
 
     /**
      * @brief Execute a binary computation (with compilation on the fly)

--- a/modules/gapi/include/opencv2/gapi/gscalar.hpp
+++ b/modules/gapi/include/opencv2/gapi/gscalar.hpp
@@ -26,10 +26,10 @@ struct GOrigin;
  * @{
  */
 
-class GAPI_EXPORTS GScalar
+class GAPI_EXPORTS_W_SIMPLE GScalar
 {
 public:
-    GScalar();                                         // Empty constructor
+    GAPI_WRAP GScalar();                    // Empty constructor
     explicit GScalar(const cv::Scalar& s);  // Constant value constructor from cv::Scalar
     explicit GScalar(cv::Scalar&& s);       // Constant value move-constructor from cv::Scalar
 

--- a/modules/gapi/misc/python/test/test_gapi_core.py
+++ b/modules/gapi/misc/python/test/test_gapi_core.py
@@ -37,6 +37,23 @@ class gapi_core_test(NewOpenCVTests):
             # Comparison
             self.assertEqual(0.0, cv.norm(expected, actual, cv.NORM_INF))
 
+    def test_mean(self):
+        sz = (1280, 720, 3)
+        in1 = np.random.randint(0, 100, sz).astype(np.uint8)
+
+        # OpenCV
+        expected = np.mean(in1,axis=(0,1))
+
+        # G-API
+        g_in1 = cv.GMat()
+        g_out = cv.gapi.mean(g_in1)
+        comp = cv.GComputation(g_in1, g_out)
+
+        for pkg in pkgs:
+            actual = np.array(comp.apply(in1, args=cv.compile_args(pkg))[:3])
+            # Comparison
+            self.assertEqual(0.0, cv.norm(expected, actual, cv.NORM_INF))
+
 
 if __name__ == '__main__':
     NewOpenCVTests.bootstrap()

--- a/modules/gapi/misc/python/test/test_gapi_core.py
+++ b/modules/gapi/misc/python/test/test_gapi_core.py
@@ -37,20 +37,21 @@ class gapi_core_test(NewOpenCVTests):
             # Comparison
             self.assertEqual(0.0, cv.norm(expected, actual, cv.NORM_INF))
 
+
     def test_mean(self):
         sz = (1280, 720, 3)
-        in1 = np.random.randint(0, 100, sz).astype(np.uint8)
+        in_mat = np.random.randint(0, 100, sz).astype(np.uint8)
 
         # OpenCV
-        expected = np.mean(in1,axis=(0,1))
+        expected = cv.mean(in_mat)
 
         # G-API
-        g_in1 = cv.GMat()
-        g_out = cv.gapi.mean(g_in1)
-        comp = cv.GComputation(g_in1, g_out)
+        g_in = cv.GMat()
+        g_out = cv.gapi.mean(g_in)
+        comp = cv.GComputation(g_in, g_out)
 
         for pkg in pkgs:
-            actual = np.array(comp.apply(in1, args=cv.compile_args(pkg))[:3])
+            actual = comp.apply(in_mat, args=cv.compile_args(pkg))
             # Comparison
             self.assertEqual(0.0, cv.norm(expected, actual, cv.NORM_INF))
 


### PR DESCRIPTION
### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [ ] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [x] The PR is proposed to proper branch
- [ ] There is reference to original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake


### Overview
Basically this PR proves that opencv `python gen` supports overloads

* Wrapped `cv::gapi::mean` operation
* Wrapped `GScalar`
* Wrapped corresponding overloads for `GComputation()` and `apply`

### Buildbot configuration

```
build_gapi_standalone:Linux x64=ade-0.1.1f
build_gapi_standalone:Win64=ade-0.1.1f
build_gapi_standalone:Mac=ade-0.1.1f
build_gapi_standalone:Linux x64 Debug=ade-0.1.1f

force_builders=ARMv7,Custom
build_image:Custom=centos:7
buildworker:Custom=linux-1
build_gapi_standalone:Custom=ade-0.1.1f
```