### PR TITLE
Typo fix: CV.rabCutClasses to CV.grabCutClasses

### DIFF
--- a/doc/js_tutorials/js_imgproc/js_grabcut/js_grabcut.markdown
+++ b/doc/js_tutorials/js_imgproc/js_grabcut/js_grabcut.markdown
@@ -59,7 +59,7 @@ Demo
 We use the function: **cv.grabCut (image, mask, rect, bgdModel, fgdModel, iterCount, mode = cv.GC_EVAL)**
 
 @param image      input 8-bit 3-channel image.
-@param mask       input/output 8-bit single-channel mask. The mask is initialized by the function when mode is set to GC_INIT_WITH_RECT. Its elements may have one of the cv.rabCutClasses.
+@param mask       input/output 8-bit single-channel mask. The mask is initialized by the function when mode is set to GC_INIT_WITH_RECT. Its elements may have one of the cv.grabCutClasses.
 @param rect       ROI containing a segmented object. The pixels outside of the ROI are marked as "obvious background". The parameter is only used when mode==GC_INIT_WITH_RECT.
 @param bgdModel   temporary array for the background model. Do not modify it while you are processing the same image.
 @param fgdModel   temporary arrays for the foreground model. Do not modify it while you are processing the same image.


### PR DESCRIPTION
### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [x] The PR is proposed to proper branch
- [ ] There is reference to original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
