### PR TITLE
Fix loading of ONNX models with Resize operation with Opset 11 for newer versions of Pytorch

### DIFF
--- a/modules/dnn/src/onnx/onnx_importer.cpp
+++ b/modules/dnn/src/onnx/onnx_importer.cpp
@@ -1557,7 +1557,9 @@ void ONNXImporter::populateNet(Net dstNet)
             Mat shapes = getBlob(node_proto, constBlobs, node_proto.input_size() - 1);
             CV_CheckEQ(shapes.size[0], 4, "");
             CV_CheckEQ(shapes.size[1], 1, "");
-            CV_CheckTypeEQ(shapes.depth(), CV_32S, "");
+            CV_Check(shapes.depth(), shapes.depth() == CV_32S || shapes.depth() == CV_32F, "");
+            if (shapes.depth() == CV_32F)
+                shapes.convertTo(shapes, CV_32S);
             int height = shapes.at<int>(2);
             int width  = shapes.at<int>(3);
             if (node_proto.input_size() == 3)

--- a/modules/dnn/src/onnx/onnx_importer.cpp
+++ b/modules/dnn/src/onnx/onnx_importer.cpp
@@ -1557,7 +1557,7 @@ void ONNXImporter::populateNet(Net dstNet)
             Mat shapes = getBlob(node_proto, constBlobs, node_proto.input_size() - 1);
             CV_CheckEQ(shapes.size[0], 4, "");
             CV_CheckEQ(shapes.size[1], 1, "");
-            CV_Check(shapes.depth(), shapes.depth() == CV_32S || shapes.depth() == CV_32F, "");
+            CV_CheckDepth(shapes.depth(), shapes.depth() == CV_32S || shapes.depth() == CV_32F, "");
             if (shapes.depth() == CV_32F)
                 shapes.convertTo(shapes, CV_32S);
             int height = shapes.at<int>(2);

--- a/modules/dnn/test/test_onnx_importer.cpp
+++ b/modules/dnn/test/test_onnx_importer.cpp
@@ -631,6 +631,11 @@ TEST_P(Test_ONNX_layers, MatmulWithTwoInputs)
     testONNXModels("matmul_with_two_inputs");
 }
 
+TEST_P(Test_ONNX_layers, ResizeOpset11_Torch1_6)
+{
+    testONNXModels("resize_opset11_torch1.6");
+}
+
 INSTANTIATE_TEST_CASE_P(/*nothing*/, Test_ONNX_layers, dnnBackendsAndTargets());
 
 class Test_ONNX_nets : public Test_ONNX_layers


### PR DESCRIPTION
With Pytorch ver. 1.6 (or newer) onnx importer with Opset 11 stores **scales** parameter as float32.

relates: https://github.com/opencv/opencv/issues/18253 and https://github.com/opencv/opencv/issues/18300

merge with extra: opencv/opencv_extra#806

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under OpenCV (BSD) License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [x] The PR is proposed to proper branch
- [x] There is reference to original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake



<cut/>

```
opencv_extra=testdata_for_resize_opset11
force_builders=Custom,Custom Win,Custom Mac
build_image:Custom=ubuntu-openvino-2020.4.0:16.04
build_image:Custom Win=openvino-2020.3.0
build_image:Custom Mac=openvino-2020.3.0

test_modules:Custom=dnn,python2,python3,java
test_modules:Custom Win=dnn,python2,python3,java
test_modules:Custom Mac=dnn,python2,python3,java

buildworker:Custom=linux-1
# disabled due high memory usage: test_opencl:Custom=ON
test_opencl:Custom=OFF
test_bigdata:Custom=1
test_filter:Custom=*
```
