### PR TITLE
Fix np row,column to cv  y,x

### DIFF
--- a/doc/py_tutorials/py_imgproc/py_contours/py_contour_properties/py_contour_properties.markdown
+++ b/doc/py_tutorials/py_imgproc/py_contours/py_contour_properties/py_contour_properties.markdown
@@ -78,7 +78,7 @@ pixelpoints = np.transpose(np.nonzero(mask))
 Here, two methods, one using Numpy functions, next one using OpenCV function (last commented line)
 are given to do the same. Results are also same, but with a slight difference. Numpy gives
 coordinates in **(row, column)** format, while OpenCV gives coordinates in **(x,y)** format. So
-basically the answers will be interchanged. Note that, **row = x** and **column = y**.
+basically the answers will be interchanged. Note that, **row = y** and **column = x**.
 
 7. Maximum Value, Minimum Value and their locations
 ---------------------------------------------------


### PR DESCRIPTION
py_contour_properties: there is an explanation that was created to avoid confusion between np coordinates and cv coordinates, but it seems like the author was confused :D. Pay attention that numpy's rows matches cv's y-values.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [x] The PR is proposed to proper branch
- [x] There is reference to original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
