### PR TITLE
[G-API] Support std::tuple for return type

### DIFF
--- a/modules/gapi/include/opencv2/gapi/core.hpp
+++ b/modules/gapi/include/opencv2/gapi/core.hpp
@@ -1434,7 +1434,7 @@ All output matrices must be in @ref CV_8UC1.
 @sa merge3, merge4
 */
 GAPI_EXPORTS std::tuple<GMat, GMat, GMat,GMat> split4(const GMat& src);
-GAPI_EXPORTS std::tuple<GMat, GMat, GMat> split3(const GMat& src);
+GAPI_EXPORTS_W std::tuple<GMat, GMat, GMat> split3(const GMat& src);
 
 /** @brief Applies a generic geometrical transformation to an image.
 

--- a/modules/gapi/include/opencv2/gapi/gcomputation.hpp
+++ b/modules/gapi/include/opencv2/gapi/gcomputation.hpp
@@ -172,7 +172,7 @@ public:
      * @param in input GMat of the defined unary computation
      * @param out output GMat of the defined unary computation
      */
-    GComputation(GMat in, GMat out);                   // Unary overload
+    GAPI_WRAP GComputation(GMat in, GMat out);  // Unary overload
 
     /**
      * @brief Defines an unary (one input -- one output) computation

--- a/modules/gapi/misc/python/test/test_gapi_sample_pipelines.py
+++ b/modules/gapi/misc/python/test/test_gapi_sample_pipelines.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python
+
+import numpy as np
+import cv2 as cv
+
+from tests_common import NewOpenCVTests
+
+
+# Plaidml is an optional backend
+pkgs = [
+         cv.gapi.core.ocl.kernels(),
+         cv.gapi.core.cpu.kernels(),
+         cv.gapi.core.fluid.kernels()
+         # cv.gapi.core.plaidml.kernels()
+       ]
+
+
+class gapi_sample_pipelines(NewOpenCVTests):
+
+    # NB: This test check multiple outputs for operation
+    def test_mean_over_r(self):
+        sz = (100, 100, 3)
+        in_mat = np.random.randint(0, 100, sz).astype(np.uint8)
+
+        # # OpenCV
+        _, _, r_ch = cv.split(in_mat)
+        expected = cv.mean(r_ch)
+
+        # G-API
+        g_in = cv.GMat()
+        b, g, r = cv.gapi.split3(g_in)
+        g_out = cv.gapi.mean(r)
+        comp = cv.GComputation(g_in, g_out)
+
+        actual = comp.apply(in_mat)
+
+        for pkg in pkgs:
+            actual = comp.apply(in_mat, args=cv.compile_args(pkg))
+            # Comparison
+            self.assertEqual(0.0, cv.norm(expected, actual, cv.NORM_INF))
+
+
+if __name__ == '__main__':
+    NewOpenCVTests.bootstrap()

--- a/modules/gapi/misc/python/test/test_gapi_sample_pipelines.py
+++ b/modules/gapi/misc/python/test/test_gapi_sample_pipelines.py
@@ -32,8 +32,6 @@ class gapi_sample_pipelines(NewOpenCVTests):
         g_out = cv.gapi.mean(r)
         comp = cv.GComputation(g_in, g_out)
 
-        actual = comp.apply(in_mat)
-
         for pkg in pkgs:
             actual = comp.apply(in_mat, args=cv.compile_args(pkg))
             # Comparison

--- a/modules/python/test/test_copytomask.py
+++ b/modules/python/test/test_copytomask.py
@@ -7,8 +7,8 @@ Test for copyto with mask
 # Python 2/3 compatibility
 from __future__ import print_function
 
-import cv2 as cv
 import numpy as np
+import cv2 as cv
 import sys
 
 from tests_common import NewOpenCVTests


### PR DESCRIPTION
### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [x] The PR is proposed to proper branch
- [ ] There is reference to original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake

### Problem overview
Impossible to wrap function which return `std::tuple<>`, so this patch introduce `pyopencv_from` for `std::tuple<Ts...>`

### Buildbot configuration

```
build_gapi_standalone:Linux x64=ade-0.1.1f
build_gapi_standalone:Win64=ade-0.1.1f
build_gapi_standalone:Mac=ade-0.1.1f
build_gapi_standalone:Linux x64 Debug=ade-0.1.1f

force_builders=ARMv7,Custom
build_image:Custom=centos:7
buildworker:Custom=linux-1
build_gapi_standalone:Custom=ade-0.1.1f
```