### PR TITLE
cudaarithm: use only even number for inplace flip

### DIFF
--- a/modules/cudaarithm/src/core.cpp
+++ b/modules/cudaarithm/src/core.cpp
@@ -163,8 +163,10 @@ void cv::cuda::flip(InputArray _src, OutputArray _dst, int flipCode, Stream& str
 
     _dst.create(src.size(), src.type());
     GpuMat dst = getOutputMat(_dst, src.size(), src.type(), stream);
+    if (src.data == dst.data && ((src.cols & 1) == 1 || (src.rows & 1) == 1))
+        CV_Error(Error::BadROISize, "In-place version of flip only accepts even width/height");
 
-    if (src.refcount != dst.refcount)
+    if (src.data != dst.data)
         funcs[src.depth()][src.channels() - 1](src, dst, flipCode, StreamAccessor::getStream(stream));
     else // in-place
         ifuncs[src.depth()][src.channels() - 1](src, flipCode, StreamAccessor::getStream(stream));

--- a/modules/cudaarithm/test/test_core.cpp
+++ b/modules/cudaarithm/test/test_core.cpp
@@ -281,6 +281,8 @@ CUDA_TEST_P(Flip, Accuracy)
 
 CUDA_TEST_P(Flip, AccuracyInplace)
 {
+    size.width  = (size.width  >> 1) << 1; // in-place version only accepts even number
+    size.height = (size.height >> 1) << 1; // in-place version only accepts even number
     cv::Mat src = randomMat(size, type);
 
     cv::cuda::GpuMat srcDst = loadMat(src, useRoi);


### PR DESCRIPTION
resolves #18347 

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [x] The PR is proposed to proper branch
- [x] There is reference to original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake

<cut/>

```
force_builders=Custom
buildworker:Custom=linux-4
build_image:Custom=ubuntu-cuda:18.04
```
