### PR TITLE
Fixed bug in ONNX Mul op

### DIFF
--- a/modules/dnn/src/onnx/onnx_importer.cpp
+++ b/modules/dnn/src/onnx/onnx_importer.cpp
@@ -1054,9 +1054,11 @@ void ONNXImporter::populateNet(Net dstNet)
                 // Scale layer allocate output with the first input shape
                 if (total(outShapes[node_proto.input(0)]) < total(outShapes[node_proto.input(1)]))
                 {
-                    std::string secondInp = node_proto.input(1);
-                    node_proto.set_input(1, node_proto.input(0));
-                    node_proto.set_input(0, secondInp);
+                    opencv_onnx::NodeProto proto;
+                    proto.add_input(node_proto.input(1));
+                    proto.add_input(node_proto.input(0));
+                    proto.add_output(layerParams.name);
+                    node_proto = proto;
                 }
 
                 if (isDiv)

--- a/modules/dnn/src/onnx/onnx_importer.cpp
+++ b/modules/dnn/src/onnx/onnx_importer.cpp
@@ -1051,6 +1051,14 @@ void ONNXImporter::populateNet(Net dstNet)
             }
             else
             {
+                // Scale layer allocate output with the first input shape
+                if (total(outShapes[node_proto.input(0)]) < total(outShapes[node_proto.input(1)]))
+                {
+                    std::string secondInp = node_proto.input(1);
+                    node_proto.set_input(1, node_proto.input(0));
+                    node_proto.set_input(0, secondInp);
+                }
+
                 if (isDiv)
                 {
                     LayerParams powerParams;

--- a/modules/dnn/test/test_onnx_importer.cpp
+++ b/modules/dnn/test/test_onnx_importer.cpp
@@ -269,7 +269,7 @@ TEST_P(Test_ONNX_layers, ReduceMaxGlobal)
 
 TEST_P(Test_ONNX_layers, Scale)
 {
-     if (backend == DNN_BACKEND_INFERENCE_ENGINE_NN_BUILDER_2019)
+    if (backend == DNN_BACKEND_INFERENCE_ENGINE_NN_BUILDER_2019)
         applyTestTag(CV_TEST_TAG_DNN_SKIP_IE_NN_BUILDER);
     testONNXModels("scale");
 }

--- a/modules/dnn/test/test_onnx_importer.cpp
+++ b/modules/dnn/test/test_onnx_importer.cpp
@@ -267,6 +267,13 @@ TEST_P(Test_ONNX_layers, ReduceMaxGlobal)
     testONNXModels("reduce_max");
 }
 
+TEST_P(Test_ONNX_layers, Scale)
+{
+     if (backend == DNN_BACKEND_INFERENCE_ENGINE_NN_BUILDER_2019)
+        applyTestTag(CV_TEST_TAG_DNN_SKIP_IE_NN_BUILDER);
+    testONNXModels("scale");
+}
+
 TEST_P(Test_ONNX_layers, ReduceMean3D)
 {
     if (backend == DNN_BACKEND_INFERENCE_ENGINE_NN_BUILDER_2019 && target != DNN_TARGET_CPU)


### PR DESCRIPTION
merge with extra: opencv/opencv_extra#808
resolves: #18350 

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under OpenCV (BSD) License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [x] The PR is proposed to proper branch
- [x] There is reference to original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake


<cut/>

```
force_builders=Custom,Custom Win,Custom Mac
build_image:Custom=ubuntu-openvino-2020.4.0:16.04
build_image:Custom Win=openvino-2020.3.0
build_image:Custom Mac=openvino-2020.3.0

test_modules:Custom=dnn,python2,python3,java
test_modules:Custom Win=dnn,python2,python3,java
test_modules:Custom Mac=dnn,python2,python3,java

buildworker:Custom=linux-1
# disabled due high memory usage: test_opencl:Custom=ON
test_opencl:Custom=OFF
test_bigdata:Custom=1
test_filter:Custom=*
```
