### PR TITLE
OpenCL: add explicit cast for half

### DIFF
--- a/modules/dnn/src/opencl/prior_box.cl
+++ b/modules/dnn/src/opencl/prior_box.cl
@@ -114,6 +114,6 @@ __kernel void clip(const int nthreads,
     for (int index = get_global_id(0); index < nthreads; index += get_global_size(0))
     {
         Dtype4 vec = vload4(index, dst);
-        vstore4(clamp(vec, 0.0f, 1.0f), index, dst);
+        vstore4(clamp(vec, (Dtype)0.0f, (Dtype)1.0f), index, dst);
     }
 }


### PR DESCRIPTION
relates #18283 

### Pull Request Readiness Checklist

OpenCL FP16 inference on Arm Mali is not supported, as claimed on #18283 
There are 2 points, one is `isIntel()` call and another is kernel build failure 

```
OpenCL program build log: dnn/prior_box
Status -11: CL_BUILD_PROGRAM_FAILURE
-DDtype=half -DDtype4=half4 -Dconvert_T=convert_half4
<source>:67:9: error: call to 'clamp' is ambiguous
vstore4(clamp(vec, 0.0f, 1.0f), index, dst);
        ^~~~~
```

This PR is to fix the 2nd point.
The error comes that clamp is accepting 
`half4, float, float` as a parameter, when it's supposed to accept either `half4, half, half` or `float4, float, float`

This PR will explicitly cast the latter 2 parameters, and let the kernel to be built.
I confirmed on RK3399, by also disabling [here](https://github.com/opencv/opencv/blob/e668cff5731b4f1005889f1c49913d083ced989b/modules/dnn/src/dnn.cpp#L1316-L1323)
https://github.com/opencv/opencv/blob/e668cff5731b4f1005889f1c49913d083ced989b/modules/dnn/src/dnn.cpp#L1316-L1323

The build passed successfully and the `opencv_test_dnn` only raised rounding error.
The kernel seems to be doing its work.

I don't think it's safe enough to comment out the `isIntel()` due to the support situation, but at least the kernel build failure comes from OpenCL spec violation, so I think it's worth to fix it.



See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [x] The PR is proposed to proper branch
- [x] There is reference to original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
