### PR TITLE
imgcodecs(openjpeg): add checks for input

### DIFF
--- a/modules/imgcodecs/src/grfmt_jpeg2000_openjpeg.cpp
+++ b/modules/imgcodecs/src/grfmt_jpeg2000_openjpeg.cpp
@@ -634,6 +634,23 @@ bool Jpeg2KOpjDecoder::readData( Mat& img )
                  cv::format("OpenJPEG2000: output precision > 16 not supported: target depth %d", depth));
     }();
     const uint8_t shift = outPrec > m_maxPrec ? 0 : (uint8_t)(m_maxPrec - outPrec); // prec <= 64
+
+    const int inChannels = image_->numcomps;
+
+    CV_Assert(inChannels > 0);
+    CV_Assert(image_->comps);
+    for (int c = 0; c < inChannels; c++)
+    {
+        const opj_image_comp_t& comp = image_->comps[c];
+        CV_CheckEQ((int)comp.dx, 1, "OpenJPEG2000: tiles are not supported");
+        CV_CheckEQ((int)comp.dy, 1, "OpenJPEG2000: tiles are not supported");
+        CV_CheckEQ((int)comp.x0, 0, "OpenJPEG2000: tiles are not supported");
+        CV_CheckEQ((int)comp.y0, 0, "OpenJPEG2000: tiles are not supported");
+        CV_CheckEQ((int)comp.w, img.cols, "OpenJPEG2000: tiles are not supported");
+        CV_CheckEQ((int)comp.h, img.rows, "OpenJPEG2000: tiles are not supported");
+        CV_Assert(comp.data && "OpenJPEG2000: missing component data (unsupported / broken input)");
+    }
+
     return decode(*image_, img, shift);
 }
 


### PR DESCRIPTION
Tiling and scaling modes are not supported by underlying code.

relates #16494

See also:
- https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=25779
- https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=25823