### PR TITLE
G-API: Make GFrame a new (distinct) G-type, not an alias to GMat

### DIFF
--- a/modules/gapi/CMakeLists.txt
+++ b/modules/gapi/CMakeLists.txt
@@ -61,6 +61,7 @@ set(gapi_srcs
     src/api/garray.cpp
     src/api/gopaque.cpp
     src/api/gscalar.cpp
+    src/api/gframe.cpp
     src/api/gkernel.cpp
     src/api/gbackend.cpp
     src/api/gproto.cpp

--- a/modules/gapi/include/opencv2/gapi/gcommon.hpp
+++ b/modules/gapi/include/opencv2/gapi/gcommon.hpp
@@ -80,6 +80,7 @@ enum class GShape: int
     GSCALAR,
     GARRAY,
     GOPAQUE,
+    GFRAME,
 };
 
 struct GCompileArg;

--- a/modules/gapi/include/opencv2/gapi/gframe.hpp
+++ b/modules/gapi/include/opencv2/gapi/gframe.hpp
@@ -1,0 +1,59 @@
+// This file is part of OpenCV project.
+// It is subject to the license terms in the LICENSE file found in the top-level directory
+// of this distribution and at http://opencv.org/license.html.
+//
+// Copyright (C) 2020 Intel Corporation
+
+
+#ifndef OPENCV_GAPI_GFRAME_HPP
+#define OPENCV_GAPI_GFRAME_HPP
+
+#include <ostream>
+#include <memory>                 // std::shared_ptr
+
+#include <opencv2/gapi/opencv_includes.hpp>
+#include <opencv2/gapi/gcommon.hpp> // GShape
+
+#include <opencv2/gapi/gmat.hpp>
+#include <opencv2/gapi/own/assert.hpp>
+
+// TODO GAPI_EXPORTS or so
+namespace cv
+{
+// Forward declaration; GNode and GOrigin are an internal
+// (user-inaccessible) classes.
+class GNode;
+struct GOrigin;
+
+/** \addtogroup gapi_data_objects
+ * @{
+ */
+class GAPI_EXPORTS_W_SIMPLE GFrame
+{
+public:
+    GAPI_WRAP GFrame();                       // Empty constructor
+    GFrame(const GNode &n, std::size_t out);  // Operation result constructor
+
+    GOrigin& priv();                        // Internal use only
+    const GOrigin& priv()  const;           // Internal use only
+
+private:
+    std::shared_ptr<GOrigin> m_priv;
+};
+/** @} */
+
+/**
+ * \addtogroup gapi_meta_args
+ * @{
+ */
+struct GAPI_EXPORTS GFrameDesc
+{
+};
+static inline GFrameDesc empty_gframe_desc() { return GFrameDesc{}; }
+/** @} */
+
+GAPI_EXPORTS std::ostream& operator<<(std::ostream& os, const cv::GFrameDesc &desc);
+
+} // namespace cv
+
+#endif // OPENCV_GAPI_GFRAME_HPP

--- a/modules/gapi/include/opencv2/gapi/gmat.hpp
+++ b/modules/gapi/include/opencv2/gapi/gmat.hpp
@@ -2,7 +2,7 @@
 // It is subject to the license terms in the LICENSE file found in the top-level directory
 // of this distribution and at http://opencv.org/license.html.
 //
-// Copyright (C) 2018 Intel Corporation
+// Copyright (C) 2018-2020 Intel Corporation
 
 
 #ifndef OPENCV_GAPI_GMAT_HPP
@@ -60,12 +60,6 @@ private:
 };
 
 class GAPI_EXPORTS GMatP : public GMat
-{
-public:
-    using GMat::GMat;
-};
-
-class GAPI_EXPORTS GFrame : public GMat
 {
 public:
     using GMat::GMat;

--- a/modules/gapi/include/opencv2/gapi/gtype_traits.hpp
+++ b/modules/gapi/include/opencv2/gapi/gtype_traits.hpp
@@ -15,6 +15,7 @@
 #include <opencv2/gapi/gscalar.hpp>
 #include <opencv2/gapi/garray.hpp>
 #include <opencv2/gapi/gopaque.hpp>
+#include <opencv2/gapi/gframe.hpp>
 #include <opencv2/gapi/streaming/source.hpp>
 #include <opencv2/gapi/gcommon.hpp>
 

--- a/modules/gapi/src/api/gframe.cpp
+++ b/modules/gapi/src/api/gframe.cpp
@@ -34,8 +34,7 @@ const cv::GOrigin& cv::GFrame::priv() const {
 }
 
 namespace cv {
-std::ostream& operator<<(std::ostream& os, const cv::GFrameDesc &desc) {
-    (void) desc;
+std::ostream& operator<<(std::ostream& os, const cv::GFrameDesc &) {
     return os;
 }
 

--- a/modules/gapi/src/api/gframe.cpp
+++ b/modules/gapi/src/api/gframe.cpp
@@ -1,0 +1,42 @@
+// This file is part of OpenCV project.
+// It is subject to the license terms in the LICENSE file found in the top-level directory
+// of this distribution and at http://opencv.org/license.html.
+//
+// Copyright (C) 2020 Intel Corporation
+
+
+#include "precomp.hpp"
+
+#include <opencv2/gapi/gframe.hpp>
+
+#include "api/gorigin.hpp"
+
+// cv::GFrame public implementation //////////////////////////////////////////////
+cv::GFrame::GFrame()
+    : m_priv(new GOrigin(GShape::GMAT, GNode::Param())) {
+    // N.B.: The shape here is still GMAT as currently cv::Mat is used
+    // as an underlying host type. Will be changed to GFRAME once
+    // GExecutor & GStreamingExecutor & selected backends will be extended
+    // to support cv::MediaFrame.
+}
+
+cv::GFrame::GFrame(const GNode &n, std::size_t out)
+    : m_priv(new GOrigin(GShape::GMAT, n, out)) {
+    // N.B.: GMAT is here for the same reason as above ^
+}
+
+cv::GOrigin& cv::GFrame::priv() {
+    return *m_priv;
+}
+
+const cv::GOrigin& cv::GFrame::priv() const {
+    return *m_priv;
+}
+
+namespace cv {
+std::ostream& operator<<(std::ostream& os, const cv::GFrameDesc &desc) {
+    (void) desc;
+    return os;
+}
+
+} // namespace cv

--- a/modules/gapi/src/backends/fluid/gfluidbackend.cpp
+++ b/modules/gapi/src/backends/fluid/gfluidbackend.cpp
@@ -1249,6 +1249,7 @@ void cv::gimpl::GFluidExecutable::bindInArg(const cv::gimpl::RcDesc &rc, const G
     case GShape::GSCALAR: m_res.slot<cv::Scalar>()[rc.id] = util::get<cv::Scalar>(arg); break;
     case GShape::GARRAY:  m_res.slot<cv::detail::VectorRef>()[rc.id] = util::get<cv::detail::VectorRef>(arg); break;
     case GShape::GOPAQUE: m_res.slot<cv::detail::OpaqueRef>()[rc.id] = util::get<cv::detail::OpaqueRef>(arg); break;
+    default: util::throw_error(std::logic_error("Unsupported input GShape type"));
     }
 }
 

--- a/modules/gapi/test/gapi_frame_tests.cpp
+++ b/modules/gapi/test/gapi_frame_tests.cpp
@@ -17,15 +17,13 @@ G_API_OP(GBlurFrame, <GMat(GFrame)>, "test.blur_frame") {
     }
 };
 
-GAPI_OCV_KERNEL(OCVBlurFrame, GBlurFrame)
-{
+GAPI_OCV_KERNEL(OCVBlurFrame, GBlurFrame) {
     static void run(const cv::Mat& in, cv::Mat& out) {
         cv::blur(in, out, cv::Size{3,3});
     }
 };
 
-struct GFrameTest : public ::testing::Test
-{
+struct GFrameTest : public ::testing::Test {
     cv::Size sz{32,32};
     cv::Mat in_mat;
     cv::Mat out_mat;
@@ -34,20 +32,17 @@ struct GFrameTest : public ::testing::Test
     GFrameTest()
         : in_mat(cv::Mat(sz, CV_8UC1))
         , out_mat(cv::Mat::zeros(sz, CV_8UC1))
-        , out_mat_ocv(cv::Mat::zeros(sz, CV_8UC1))
-    {
+        , out_mat_ocv(cv::Mat::zeros(sz, CV_8UC1)) {
         cv::randn(in_mat, cv::Scalar::all(127.0f), cv::Scalar::all(40.f));
         cv::blur(in_mat, out_mat_ocv, cv::Size{3,3});
     }
 
-    void check()
-    {
+    void check() {
         EXPECT_EQ(0, cvtest::norm(out_mat, out_mat_ocv, NORM_INF));
     }
 };
 
-TEST_F(GFrameTest, Input)
-{
+TEST_F(GFrameTest, Input) {
     cv::GFrame in;
     auto out = GBlurFrame::on(in);
     cv::GComputation c(cv::GIn(in), cv::GOut(out));


### PR DESCRIPTION
- The underlying host type is still cv::Mat, a new cv::MediaFrame
  type is to be added as a separate PR.

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [x] The PR is proposed to proper branch
- [ ] There is reference to original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake

```
force_builders=Custom,Custom Win,Custom Mac
build_gapi_standalone:Linux x64=ade-0.1.1f
build_gapi_standalone:Win64=ade-0.1.1f
build_gapi_standalone:Mac=ade-0.1.1f
build_gapi_standalone:Linux x64 Debug=ade-0.1.1f

Xbuild_image:Custom=centos:7
Xbuildworker:Custom=linux-1
build_gapi_standalone:Custom=ade-0.1.1f

build_image:Custom=ubuntu-openvino-2020.4.0:16.04
build_image:Custom Win=openvino-2020.4.0
build_image:Custom Mac=openvino-2020.4.0

test_modules:Custom=gapi
test_modules:Custom Win=gapi
test_modules:Custom Mac=gapi

buildworker:Custom=linux-1
# disabled due high memory usage: test_opencl:Custom=ON
test_opencl:Custom=OFF
test_bigdata:Custom=1
test_filter:Custom=*
```