### PR TITLE
OpenCL: fix cast for native_powr when half

### DIFF
--- a/modules/dnn/src/opencl/ocl4dnn_lrn.cl
+++ b/modules/dnn/src/opencl/ocl4dnn_lrn.cl
@@ -83,7 +83,7 @@ __kernel void TEMPLATE(lrn_full_no_scale,Dtype)(const int nthreads, __global con
             * in_off[(head - size) * step];
       }
       scale_val = k + accum_scale * alpha_over_size;
-      out_off[(head - post_pad) * step] = in_off[(head - post_pad) * step] * (Dtype)native_powr((Dtype)scale_val, (Dtype)negative_beta);
+      out_off[(head - post_pad) * step] = in_off[(head - post_pad) * step] * (Dtype)native_powr(scale_val, negative_beta);
       ++head;
     }
     // subtract only
@@ -93,7 +93,7 @@ __kernel void TEMPLATE(lrn_full_no_scale,Dtype)(const int nthreads, __global con
             * in_off[(head - size) * step];
       }
       scale_val = k + accum_scale * alpha_over_size;
-      out_off[(head - post_pad) * step] = in_off[(head - post_pad) * step] * (Dtype)native_powr((Dtype)scale_val, (Dtype)negative_beta);
+      out_off[(head - post_pad) * step] = in_off[(head - post_pad) * step] * (Dtype)native_powr(scale_val, negative_beta);
       ++head;
     }
   }


### PR DESCRIPTION
relates #18283 #18360 

Platform: Firefly RK3399 (Arm Mali-T860 OpenCL 1.2)
Compiler: GCC 5.4.0
OpenCV: Recent 3.4 ( 3e3787ecb6b1823944a9be8e65a71a3c02a4260f )

When running `opencv_test_dnn` with `OPENCV_DNN_OPENCL_ALLOW_ALL_DEVICES=1`, one kernel fails building.

```
[----------] 192 tests from Layer_Test_Halide/LRN
(snip)
[ RUN      ] Layer_Test_Halide/LRN.Accuracy/1, where GetParam() = ([6, 5, 8], 3, [0.9, 1, 1.1], false, "ACROSS_CHANNELS", OCV/OCL_FP16)
OpenCL program build log: dnn/ocl4dnn_lrn
Status -11: CL_BUILD_PROGRAM_FAILURE
-D Dtype=half
<source>:38:79: error: call to 'native_powr' is ambiguous
out_off[(head - post_pad) * step] = in_off[(head - post_pad) * step] * (Dtype)native_powr((Dtype)scale_val, (Dtype)negative_beta);
                                                                              ^~~~~~~~~~~

note: candidate function
note: candidate function
note: candidate function
note: candidate function
note: candidate function
note: candidate function
<source>:47:79: error: call to 'native_powr' is ambiguous
out_off[(head - post_pad) * step] = in_off[(head - post_pad) * step] * (Dtype)native_powr((Dtype)scale_val, (Dtype)negative_beta);
                                                                              ^~~~~~~~~~~

note: candidate function
note: candidate function
note: candidate function
note: candidate function
note: candidate function
note: candidate function
error: Compiler frontend failed (error code 59)

[       OK ] Layer_Test_Halide/LRN.Accuracy/1 (20 ms)
```

The cast should work properly, but somehow raises an error.
Both `scale_val` and `negative_beta` are fixed as `float`, so casting only after the function call should be sufficient.

https://github.com/opencv/opencv/blob/3e3787ecb6b1823944a9be8e65a71a3c02a4260f/modules/dnn/src/opencl/ocl4dnn_lrn.cl#L45
https://github.com/opencv/opencv/blob/3e3787ecb6b1823944a9be8e65a71a3c02a4260f/modules/dnn/src/opencl/ocl4dnn_lrn.cl#L56
https://github.com/opencv/opencv/blob/3e3787ecb6b1823944a9be8e65a71a3c02a4260f/modules/dnn/src/opencl/ocl4dnn_lrn.cl#L67

The `opencv_test_dnn` after this PR
```
[ RUN      ] Layer_Test_Halide/LRN.Accuracy/1, where GetParam() = ([6, 5, 8], 3, [0.9, 1, 1.1], false, "ACROSS_CHANNELS", OCV/OCL_FP16)
[       OK ] Layer_Test_Halide/LRN.Accuracy/1 (120 ms)
```

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [x] The PR is proposed to proper branch
- [x] There is reference to original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
