### PR TITLE
videoio: naming MFX tests

### DIFF
--- a/modules/videoio/test/test_mfx.cpp
+++ b/modules/videoio/test/test_mfx.cpp
@@ -144,10 +144,20 @@ TEST_P(videoio_mfx, read_write_raw)
     remove(filename.c_str());
 }
 
+inline static std::string videoio_mfx_name_printer(const testing::TestParamInfo<videoio_mfx::ParamType>& info)
+{
+    std::ostringstream out;
+    const Size sz = get<0>(info.param);
+    const std::string ext = get<2>(info.param);
+    out << sz.width << "x" << sz.height << "x" << get<1>(info.param) << "x" << ext.substr(1, ext.size() - 1);
+    return out.str();
+}
+
 INSTANTIATE_TEST_CASE_P(videoio, videoio_mfx,
                         testing::Combine(
                             testing::Values(Size(640, 480), Size(638, 478), Size(636, 476), Size(1920, 1080)),
                             testing::Values(1, 30, 100),
-                            testing::Values(".mpeg2", ".264", ".265")));
+                            testing::Values(".mpeg2", ".264", ".265")),
+                        videoio_mfx_name_printer);
 
 }} // namespace

--- a/modules/videoio/test/test_precomp.hpp
+++ b/modules/videoio/test/test_precomp.hpp
@@ -4,6 +4,8 @@
 #ifndef __OPENCV_TEST_PRECOMP_HPP__
 #define __OPENCV_TEST_PRECOMP_HPP__
 
+#include <sstream>
+
 #include "opencv2/ts.hpp"
 #include "opencv2/videoio.hpp"
 #include "opencv2/videoio/registry.hpp"


### PR DESCRIPTION
Names instead of numbers help with filtering.
```
videoio/videoio_mfx.
  read_write_raw/640x480x1xmpeg2  # GetParam() = (640x480, 1, 0x5609b5c36567 pointing to ".mpeg2")
  read_write_raw/640x480x1x264  # GetParam() = (640x480, 1, 0x5609b5c3656e pointing to ".264")
  read_write_raw/640x480x1x265  # GetParam() = (640x480, 1, 0x5609b5c36573 pointing to ".265")
  ...
  read_write_raw/1920x1080x100x265  # GetParam() = (1920x1080, 100, 0x5609b5c36573 pointing to ".265")
```

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [ ] I agree to contribute to the project under Apache 2 License.
- [ ] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [ ] The PR is proposed to proper branch
- [ ] There is reference to original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
