### PR TITLE
[G-API] Introduce generic version for cv::gapi::infer

### DIFF
--- a/modules/gapi/include/opencv2/gapi/gcall.hpp
+++ b/modules/gapi/include/opencv2/gapi/gcall.hpp
@@ -56,6 +56,8 @@ public:
     Priv& priv();
     const Priv& priv() const;
 
+    // GKernel and params can be modified, it's needed for infer<Generic>,
+    // because information about output shapes doesn't exist in compile time
     GKernel& kernel();
     cv::util::any& params();
 

--- a/modules/gapi/include/opencv2/gapi/gcall.hpp
+++ b/modules/gapi/include/opencv2/gapi/gcall.hpp
@@ -56,10 +56,13 @@ public:
     Priv& priv();
     const Priv& priv() const;
 
-protected:
-    std::shared_ptr<Priv> m_priv;
+    GKernel& kernel();
+    cv::util::any& params();
 
     void setArgs(std::vector<GArg> &&args);
+
+protected:
+    std::shared_ptr<Priv> m_priv;
 
     // Public versions return a typed array or opaque, those are implementation details
     detail::GArrayU yieldArray(int output = 0);

--- a/modules/gapi/include/opencv2/gapi/infer.hpp
+++ b/modules/gapi/include/opencv2/gapi/infer.hpp
@@ -136,7 +136,7 @@ struct InOutInfo
 class GAPI_EXPORTS GInferInputs
 {
 public:
-    cv::GMat operator[](const std::string& name);
+    cv::GMat& operator[](const std::string& name);
     const std::unordered_map<std::string, cv::GMat>& getBlobs() const;
 
 private:

--- a/modules/gapi/include/opencv2/gapi/infer.hpp
+++ b/modules/gapi/include/opencv2/gapi/infer.hpp
@@ -133,11 +133,11 @@ struct InOutInfo
  * @{
  * @brief G-API object used to collect network inputs
  */
-class GInferInputs
+class GAPI_EXPORTS GInferInputs
 {
 public:
-    cv::GMat operator[](const std::string& name) { return in_blobs[name]; }
-    const std::unordered_map<std::string, cv::GMat>& getBlobs() const { return in_blobs; }
+    cv::GMat operator[](const std::string& name);
+    const std::unordered_map<std::string, cv::GMat>& getBlobs() const;
 
 private:
     std::unordered_map<std::string, cv::GMat> in_blobs;
@@ -148,25 +148,11 @@ private:
  * @{
  * @brief G-API object used to collect network outputs
  */
-struct GInferOutputs
+struct GAPI_EXPORTS GInferOutputs
 {
 public:
-    GInferOutputs(std::shared_ptr<cv::GCall> call)
-        : m_call(std::move(call)), m_info(cv::util::any_cast<InOutInfo>(&m_call->params()))
-    {
-    };
-
-    cv::GMat at(const std::string& name)
-    {
-        auto it = out_blobs.find(name);
-        if (it == out_blobs.end()) {
-            m_call->kernel().outShapes.push_back(cv::GShape::GMAT);
-            int size = static_cast<int>(out_blobs.size());
-            it = out_blobs.emplace(name, m_call->yield(size)).first;
-            m_info->out_names.push_back(name);
-        }
-        return it->second;
-    };
+    GInferOutputs(std::shared_ptr<cv::GCall> call);
+    cv::GMat at(const std::string& name);
 
 private:
     std::shared_ptr<cv::GCall> m_call;
@@ -319,8 +305,7 @@ struct Generic { };
  * @param inputs networks's inputs
  * @return a GInferOutputs
  */
-template<typename Net, typename... Args>
-typename std::enable_if<std::is_same<Net, Generic>::value, GInferOutputs>::type
+template<typename T = Generic> GInferOutputs
 infer(const std::string& tag, const GInferInputs& inputs)
 {
     std::vector<GArg> input_args;

--- a/modules/gapi/include/opencv2/gapi/infer.hpp
+++ b/modules/gapi/include/opencv2/gapi/infer.hpp
@@ -21,7 +21,6 @@
 #include <opencv2/gapi/garg.hpp>      // GArg
 #include <opencv2/gapi/gcommon.hpp>   // CompileArgTag
 #include <opencv2/gapi/gmetaarg.hpp>  // GMetaArg
-#include <opencv2/gapi/infer/ie.hpp> // Generic
 
 namespace cv {
 
@@ -297,8 +296,10 @@ typename Net::Result infer(Args&&... args) {
     return GInfer<Net>::on(std::forward<Args>(args)...);
 }
 
+struct Generic { };
+
 template<typename Net, typename... Args>
-typename std::enable_if<std::is_same<Net, cv::gapi::ie::Generic>::value, GInferOutputs>::type
+typename std::enable_if<std::is_same<Net, Generic>::value, GInferOutputs>::type
 infer(const std::string& name, const GInferInputs& inputs)
 {
     std::vector<GArg> input_args;

--- a/modules/gapi/include/opencv2/gapi/infer.hpp
+++ b/modules/gapi/include/opencv2/gapi/infer.hpp
@@ -315,8 +315,7 @@ struct Generic { };
 /**
  * @brief Calculates response for generic network
  *
- * @tparam A network type - Generic
- * @param a network tag
+ * @param tag a network tag
  * @param inputs networks's inputs
  * @return a GInferOutputs
  */

--- a/modules/gapi/include/opencv2/gapi/infer.hpp
+++ b/modules/gapi/include/opencv2/gapi/infer.hpp
@@ -150,7 +150,7 @@ public:
         auto it = out_blobs.find(name);
         if (it == out_blobs.end()) {
             m_call->kernel().outShapes.push_back(cv::GShape::GMAT);
-            size_t size = out_blobs.size();
+            int size = static_cast<int>(out_blobs.size());
             it = out_blobs.emplace(name, m_call->yield(size)).first;
             m_info->out_names.push_back(name);
         }

--- a/modules/gapi/include/opencv2/gapi/infer.hpp
+++ b/modules/gapi/include/opencv2/gapi/infer.hpp
@@ -150,15 +150,14 @@ public:
         auto it = out_blobs.find(name);
         if (it == out_blobs.end()) {
             m_call->kernel().outShapes.push_back(cv::GShape::GMAT);
-            it = out_blobs.emplace(name, m_call->yield(num_outs)).first;
+            size_t size = out_blobs.size();
+            it = out_blobs.emplace(name, m_call->yield(size)).first;
             m_info->out_names.push_back(name);
-            ++num_outs;
         }
         return it->second;
     };
 
 private:
-    int num_outs = 0;
     std::shared_ptr<cv::GCall> m_call;
     InOutInfo* m_info = nullptr;
     std::unordered_map<std::string, cv::GMat> out_blobs;

--- a/modules/gapi/include/opencv2/gapi/infer/ie.hpp
+++ b/modules/gapi/include/opencv2/gapi/infer/ie.hpp
@@ -17,7 +17,7 @@
 
 #include <opencv2/core/cvdef.h>     // GAPI_EXPORTS
 #include <opencv2/gapi/gkernel.hpp> // GKernelPackage
-#include <opencv2/gapi/infer.hpp> // Generic
+#include <opencv2/gapi/infer.hpp>   // Generic
 
 namespace cv {
 namespace gapi {

--- a/modules/gapi/include/opencv2/gapi/infer/ie.hpp
+++ b/modules/gapi/include/opencv2/gapi/infer/ie.hpp
@@ -17,6 +17,7 @@
 
 #include <opencv2/core/cvdef.h>     // GAPI_EXPORTS
 #include <opencv2/gapi/gkernel.hpp> // GKernelPackage
+#include <opencv2/gapi/infer.hpp> // Generic
 
 namespace cv {
 namespace gapi {
@@ -116,10 +117,8 @@ protected:
     detail::ParamDesc desc;
 };
 
-struct Generic { };
-
 template<>
-class Params<Generic> {
+class Params<cv::gapi::Generic> {
 public:
     Params(const std::string& tag,
            const std::string &model,

--- a/modules/gapi/include/opencv2/gapi/infer/ie.hpp
+++ b/modules/gapi/include/opencv2/gapi/infer/ie.hpp
@@ -116,6 +116,29 @@ protected:
     detail::ParamDesc desc;
 };
 
+struct Generic { };
+
+template<>
+class Params<Generic> {
+public:
+    Params(const std::string& tag,
+           const std::string &model,
+           const std::string &weights,
+           const std::string &device)
+        : desc{ model, weights, device, {}, {}, {}, 0u, 0u}, m_tag(tag) {
+    };
+
+    // BEGIN(G-API's network parametrization API)
+    GBackend      backend() const { return cv::gapi::ie::backend();  }
+    std::string   tag()     const { return m_tag; }
+    cv::util::any params()  const { return { desc }; }
+    // END(G-API's network parametrization API)
+
+protected:
+    detail::ParamDesc desc;
+    std::string m_tag;
+};
+
 } // namespace ie
 } // namespace gapi
 } // namespace cv

--- a/modules/gapi/include/opencv2/gapi/infer/ie.hpp
+++ b/modules/gapi/include/opencv2/gapi/infer/ie.hpp
@@ -59,6 +59,8 @@ namespace detail {
         // (e.g. topology's partial execution)
         std::size_t num_in;  // How many inputs are defined in the operation
         std::size_t num_out; // How many outputs are defined in the operation
+
+        bool is_generic;
     };
 } // namespace detail
 
@@ -81,7 +83,7 @@ public:
         : desc{ model, weights, device, {}, {}, {}
               , std::tuple_size<typename Net::InArgs>::value  // num_in
               , std::tuple_size<typename Net::OutArgs>::value // num_out
-              } {
+              , false} {
     };
 
     Params<Net>& cfgInputLayers(const typename PortCfg<Net>::In &ll) {
@@ -108,9 +110,9 @@ public:
     }
 
     // BEGIN(G-API's network parametrization API)
-    GBackend      backend() const { return cv::gapi::ie::backend();  }
-    std::string   tag()     const { return Net::tag(); }
-    cv::util::any params()  const { return { desc }; }
+    GBackend      backend()    const { return cv::gapi::ie::backend();  }
+    std::string   tag()        const { return Net::tag(); }
+    cv::util::any params()     const { return { desc }; }
     // END(G-API's network parametrization API)
 
 protected:
@@ -124,13 +126,13 @@ public:
            const std::string &model,
            const std::string &weights,
            const std::string &device)
-        : desc{ model, weights, device, {}, {}, {}, 0u, 0u}, m_tag(tag) {
+        : desc{ model, weights, device, {}, {}, {}, 0u, 0u, true}, m_tag(tag) {
     };
 
     // BEGIN(G-API's network parametrization API)
-    GBackend      backend() const { return cv::gapi::ie::backend();  }
-    std::string   tag()     const { return m_tag; }
-    cv::util::any params()  const { return { desc }; }
+    GBackend      backend()    const { return cv::gapi::ie::backend();  }
+    std::string   tag()        const { return m_tag; }
+    cv::util::any params()     const { return { desc }; }
     // END(G-API's network parametrization API)
 
 protected:

--- a/modules/gapi/src/api/gcall.cpp
+++ b/modules/gapi/src/api/gcall.cpp
@@ -78,3 +78,13 @@ const cv::GCall::Priv& cv::GCall::priv() const
 {
     return *m_priv;
 }
+
+cv::GKernel& cv::GCall::kernel()
+{
+    return m_priv->m_k;
+}
+
+cv::util::any& cv::GCall::params()
+{
+    return m_priv->m_params;
+}

--- a/modules/gapi/src/api/gcall_priv.hpp
+++ b/modules/gapi/src/api/gcall_priv.hpp
@@ -42,10 +42,11 @@ class GCall::Priv
 {
 public:
     std::vector<GArg> m_args;
-    const GKernel     m_k;
+    GKernel     m_k;
 
     // TODO: Rename to "constructionNode" or smt to reflect its lifetime
     GNode             m_node;
+    cv::util::any     m_params;
 
     explicit Priv(const GKernel &k);
 };

--- a/modules/gapi/src/api/ginfer.cpp
+++ b/modules/gapi/src/api/ginfer.cpp
@@ -29,7 +29,7 @@ std::vector<cv::gapi::GBackend> cv::gapi::GNetPackage::backends() const {
 // FIXME: Inference API is currently only available in full mode
 #if !defined(GAPI_STANDALONE)
 
-cv::GMat cv::GInferInputs::operator[](const std::string& name) {
+cv::GMat& cv::GInferInputs::operator[](const std::string& name) {
     return in_blobs[name];
 }
 

--- a/modules/gapi/src/api/ginfer.cpp
+++ b/modules/gapi/src/api/ginfer.cpp
@@ -25,3 +25,29 @@ std::vector<cv::gapi::GBackend> cv::gapi::GNetPackage::backends() const {
     for (const auto &nn : networks) unique_set.insert(nn.backend);
     return std::vector<cv::gapi::GBackend>(unique_set.begin(), unique_set.end());
 }
+
+cv::GMat cv::GInferInputs::operator[](const std::string& name) {
+    return in_blobs[name];
+}
+
+const std::unordered_map<std::string, cv::GMat>& cv::GInferInputs::getBlobs() const {
+    return in_blobs;
+}
+
+cv::GInferOutputs::GInferOutputs(std::shared_ptr<cv::GCall> call)
+    : m_call(std::move(call)), m_info(cv::util::any_cast<InOutInfo>(&m_call->params()))
+{
+};
+
+cv::GMat cv::GInferOutputs::at(const std::string& name)
+{
+    auto it = out_blobs.find(name);
+    if (it == out_blobs.end()) {
+        // FIXME: Avoid modifying GKernel
+        m_call->kernel().outShapes.push_back(cv::GShape::GMAT);
+        int out_idx = static_cast<int>(out_blobs.size());
+        it = out_blobs.emplace(name, m_call->yield(out_idx)).first;
+        m_info->out_names.push_back(name);
+    }
+    return it->second;
+};

--- a/modules/gapi/src/api/ginfer.cpp
+++ b/modules/gapi/src/api/ginfer.cpp
@@ -26,6 +26,9 @@ std::vector<cv::gapi::GBackend> cv::gapi::GNetPackage::backends() const {
     return std::vector<cv::gapi::GBackend>(unique_set.begin(), unique_set.end());
 }
 
+// FIXME: Inference API is currently only available in full mode
+#if !defined(GAPI_STANDALONE)
+
 cv::GMat cv::GInferInputs::operator[](const std::string& name) {
     return in_blobs[name];
 }
@@ -51,3 +54,4 @@ cv::GMat cv::GInferOutputs::at(const std::string& name)
     }
     return it->second;
 };
+#endif // GAPI_STANDALONE

--- a/modules/gapi/src/backends/ie/giebackend.cpp
+++ b/modules/gapi/src/backends/ie/giebackend.cpp
@@ -725,13 +725,13 @@ namespace {
             auto& op = model.metadata(nh).get<Op>();
 
             // NB: In case generic infer, info about in/out names is stored in operation (op.params)
-            auto* in_out_info = cv::util::any_cast<cv::InOutInfo>(&op.params);
-            if (in_out_info)
+            if (pp.is_generic)
             {
-                pp.input_names  = in_out_info->in_names;
-                pp.output_names = in_out_info->out_names;
-                pp.num_in  = in_out_info->in_names.size();
-                pp.num_out = in_out_info->out_names.size();
+                auto& info      = cv::util::any_cast<cv::InOutInfo>(op.params);
+                pp.input_names  = info.in_names;
+                pp.output_names = info.out_names;
+                pp.num_in       = info.in_names.size();
+                pp.num_out      = info.out_names.size();
             }
 
             gm.metadata(nh).set(IEUnit{pp});

--- a/modules/gapi/src/backends/ie/giebackend.cpp
+++ b/modules/gapi/src/backends/ie/giebackend.cpp
@@ -717,9 +717,23 @@ namespace {
             // FIXME: Introduce a DNNBackend interface which'd specify
             // the framework for this???
             GIEModel gm(gr);
-            const auto &np = gm.metadata(nh).get<NetworkParams>();
-            const auto &pp = cv::util::any_cast<cv::gapi::ie::detail::ParamDesc>(np.opaque);
+            auto &np = gm.metadata(nh).get<NetworkParams>();
+            auto &pp = cv::util::any_cast<cv::gapi::ie::detail::ParamDesc>(np.opaque);
             const auto &ki = cv::util::any_cast<KImpl>(ii.opaque);
+
+            GModel::Graph model(gr);
+            auto& op = model.metadata(nh).get<Op>();
+
+            // NB: In case generic infer, info about in/out names is stored in operation (op.params)
+            auto* in_out_info = cv::util::any_cast<cv::InOutInfo>(&op.params);
+            if (in_out_info)
+            {
+                pp.input_names  = in_out_info->in_names;
+                pp.output_names = in_out_info->out_names;
+                pp.num_in  = in_out_info->in_names.size();
+                pp.num_out = in_out_info->out_names.size();
+            }
+
             gm.metadata(nh).set(IEUnit{pp});
             gm.metadata(nh).set(IECallable{ki.run});
             gm.metadata(nh).set(CustomMetaFunction{ki.customMetaFunc});

--- a/modules/gapi/src/compiler/gmodel.cpp
+++ b/modules/gapi/src/compiler/gmodel.cpp
@@ -23,12 +23,16 @@
 
 namespace cv { namespace gimpl {
 
-ade::NodeHandle GModel::mkOpNode(GModel::Graph &g, const GKernel &k, const std::vector<GArg> &args, const std::string &island)
+ade::NodeHandle GModel::mkOpNode(GModel::Graph &g,
+                                 const GKernel &k,
+                                 const std::vector<GArg> &args,
+                                 const cv::util::any& params,
+                                 const std::string &island)
 {
     ade::NodeHandle op_h = g.createNode();
     g.metadata(op_h).set(NodeType{NodeType::OP});
     //These extra empty {} are to please GCC (-Wmissing-field-initializers)
-    g.metadata(op_h).set(Op{k, args, {}, {}});
+    g.metadata(op_h).set(Op{k, args, {}, {}, params});
     if (!island.empty())
         g.metadata(op_h).set(Island{island});
     return op_h;

--- a/modules/gapi/src/compiler/gmodel.cpp
+++ b/modules/gapi/src/compiler/gmodel.cpp
@@ -26,7 +26,7 @@ namespace cv { namespace gimpl {
 ade::NodeHandle GModel::mkOpNode(GModel::Graph &g,
                                  const GKernel &k,
                                  const std::vector<GArg> &args,
-                                 const cv::util::any& params,
+                                 const cv::util::any &params,
                                  const std::string &island)
 {
     ade::NodeHandle op_h = g.createNode();

--- a/modules/gapi/src/compiler/gmodel.hpp
+++ b/modules/gapi/src/compiler/gmodel.hpp
@@ -61,7 +61,7 @@ struct Op
     std::vector<RcDesc> outs; // TODO: Introduce a new type for resource references
 
     cv::gapi::GBackend  backend;
-    cv::util::any params;
+    cv::util::any params; // Operation specific information
 };
 
 struct Data

--- a/modules/gapi/src/compiler/gmodel.hpp
+++ b/modules/gapi/src/compiler/gmodel.hpp
@@ -61,6 +61,7 @@ struct Op
     std::vector<RcDesc> outs; // TODO: Introduce a new type for resource references
 
     cv::gapi::GBackend  backend;
+    cv::util::any params;
 };
 
 struct Data
@@ -262,7 +263,11 @@ namespace GModel
     // GAPI_EXPORTS for tests
     GAPI_EXPORTS void init (Graph& g);
 
-    GAPI_EXPORTS ade::NodeHandle mkOpNode(Graph &g, const GKernel &k, const std::vector<GArg>& args, const std::string &island);
+    GAPI_EXPORTS ade::NodeHandle mkOpNode(Graph &g,
+                                          const GKernel &k,
+                                          const std::vector<GArg>& args,
+                                          const cv::util::any& params,
+                                          const std::string &island);
     // Isn't used by the framework or default backends, required for external backend development
     GAPI_EXPORTS ade::NodeHandle mkDataNode(Graph &g, const GShape shape);
 

--- a/modules/gapi/src/compiler/gmodelbuilder.cpp
+++ b/modules/gapi/src/compiler/gmodelbuilder.cpp
@@ -286,7 +286,7 @@ ade::NodeHandle cv::gimpl::GModelBuilder::put_OpNode(const cv::GNode &node)
     {
         GAPI_Assert(node.shape() == GNode::NodeShape::CALL);
         const auto &call_p = node.call().priv();
-        auto nh = cv::gimpl::GModel::mkOpNode(m_gm, call_p.m_k, call_p.m_args, node_p.m_island);
+        auto nh = cv::gimpl::GModel::mkOpNode(m_gm, call_p.m_k, call_p.m_args, call_p.m_params, node_p.m_island);
         m_graph_ops[&node_p] = nh;
         return nh;
     }

--- a/modules/gapi/test/infer/gapi_infer_ie_test.cpp
+++ b/modules/gapi/test/infer/gapi_infer_ie_test.cpp
@@ -350,6 +350,59 @@ TEST(DISABLED_TestTwoIENNPipeline, InferBasicImage)
     normAssert(cv::gapi::ie::util::to_ocv(ie_gender2), gapi_gender2, "Test gender output 2");
 }
 
+TEST(TestAgeGenderIE, GenericInfer)
+{
+    initDLDTDataPath();
+
+    cv::gapi::ie::detail::ParamDesc params;
+    params.model_path = findDataFile(SUBDIR + "age-gender-recognition-retail-0013.xml");
+    params.weights_path = findDataFile(SUBDIR + "age-gender-recognition-retail-0013.bin");
+    params.device_id = "CPU";
+
+    cv::Mat in_mat(cv::Size(320, 240), CV_8UC3);
+    cv::randu(in_mat, 0, 255);
+
+    cv::Mat gapi_age, gapi_gender;
+
+    // Load & run IE network
+    IE::Blob::Ptr ie_age, ie_gender;
+    {
+        auto plugin = cv::gimpl::ie::wrap::getPlugin(params);
+        auto net    = cv::gimpl::ie::wrap::readNetwork(params);
+        setNetParameters(net);
+        auto this_network  = cv::gimpl::ie::wrap::loadNetwork(plugin, net, params);
+        auto infer_request = this_network.CreateInferRequest();
+        infer_request.SetBlob("data", cv::gapi::ie::util::to_ie(in_mat));
+        infer_request.Infer();
+        ie_age    = infer_request.GetBlob("age_conv3");
+        ie_gender = infer_request.GetBlob("prob");
+    }
+
+    // Configure & run G-API
+    cv::GMat in;
+    GInferInputs inputs;
+    inputs["data"] = in;
+
+    auto outputs = cv::gapi::infer<cv::gapi::ie::Generic>("age-gender-generic", inputs);
+
+    auto age    = outputs.at("age_conv3");
+    auto gender = outputs.at("prob");
+
+    cv::GComputation comp(cv::GIn(in), cv::GOut(age, gender));
+
+    cv::gapi::ie::Params<cv::gapi::ie::Generic> pp("age-gender-generic",
+                                                   params.model_path,
+                                                   params.weights_path,
+                                                   params.device_id);
+
+    comp.apply(cv::gin(in_mat), cv::gout(gapi_age, gapi_gender),
+               cv::compile_args(cv::gapi::networks(pp)));
+
+    // Validate with IE itself (avoid DNN module dependency here)
+    normAssert(cv::gapi::ie::util::to_ocv(ie_age),    gapi_age,    "Test age output"   );
+    normAssert(cv::gapi::ie::util::to_ocv(ie_gender), gapi_gender, "Test gender output");
+}
+
 } // namespace opencv_test
 
 #endif //  HAVE_INF_ENGINE

--- a/modules/gapi/test/infer/gapi_infer_ie_test.cpp
+++ b/modules/gapi/test/infer/gapi_infer_ie_test.cpp
@@ -390,10 +390,10 @@ TEST(TestAgeGenderIE, GenericInfer)
 
     cv::GComputation comp(cv::GIn(in), cv::GOut(age, gender));
 
-    cv::gapi::ie::Params<cv::gapi::Generic> pp("age-gender-generic",
+    cv::gapi::ie::Params<cv::gapi::Generic> pp{"age-gender-generic",
                                                 params.model_path,
                                                 params.weights_path,
-                                                params.device_id);
+                                                params.device_id};
 
     comp.apply(cv::gin(in_mat), cv::gout(gapi_age, gapi_gender),
                cv::compile_args(cv::gapi::networks(pp)));

--- a/modules/gapi/test/infer/gapi_infer_ie_test.cpp
+++ b/modules/gapi/test/infer/gapi_infer_ie_test.cpp
@@ -383,17 +383,17 @@ TEST(TestAgeGenderIE, GenericInfer)
     GInferInputs inputs;
     inputs["data"] = in;
 
-    auto outputs = cv::gapi::infer<cv::gapi::ie::Generic>("age-gender-generic", inputs);
+    auto outputs = cv::gapi::infer<cv::gapi::Generic>("age-gender-generic", inputs);
 
     auto age    = outputs.at("age_conv3");
     auto gender = outputs.at("prob");
 
     cv::GComputation comp(cv::GIn(in), cv::GOut(age, gender));
 
-    cv::gapi::ie::Params<cv::gapi::ie::Generic> pp("age-gender-generic",
-                                                   params.model_path,
-                                                   params.weights_path,
-                                                   params.device_id);
+    cv::gapi::ie::Params<cv::gapi::Generic> pp("age-gender-generic",
+                                                params.model_path,
+                                                params.weights_path,
+                                                params.device_id);
 
     comp.apply(cv::gin(in_mat), cv::gout(gapi_age, gapi_gender),
                cv::compile_args(cv::gapi::networks(pp)));


### PR DESCRIPTION
### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [x] The PR is proposed to proper branch
- [ ] There is reference to original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake


### Buildbot configuration

```
build_gapi_standalone:Linux x64=ade-0.1.1f
build_gapi_standalone:Win64=ade-0.1.1f
build_gapi_standalone:Mac=ade-0.1.1f
build_gapi_standalone:Linux x64 Debug=ade-0.1.1f

force_builders=ARMv7,Custom
Xbuild_image:Custom=centos:7
Xbuildworker:Custom=linux-1
Xbuild_gapi_standalone:Custom=ade-0.1.1f

Xbuild_image:Custom=ubuntu-openvino-2020.4.0:16.04
build_image:Custom=ubuntu-openvino-2021.1.0:20.04
test_modules:Custom=gapi,python2,python3,java
buildworker:Custom=linux-1
# disabled due high memory usage: test_opencl:Custom=ON
test_opencl:Custom=OFF
test_bigdata:Custom=1
test_filter:Custom=*

Xbuild_image:Custom Mac=openvino-2020.4.0
build_image:Custom Mac=openvino-2021.1.0

build_image:Linux AVX2=ubuntu:20.04
```