### PR TITLE
videoio: fix plugins build with enabled Eigen

### DIFF
--- a/modules/videoio/cmake/plugin.cmake
+++ b/modules/videoio/cmake/plugin.cmake
@@ -22,7 +22,7 @@ function(ocv_create_builtin_videoio_plugin name target)
 
   foreach(mod opencv_videoio opencv_core opencv_imgproc opencv_imgcodecs)
     ocv_target_link_libraries(${name} LINK_PRIVATE ${mod})
-    ocv_target_include_directories(${name} PRIVATE "${OPENCV_MODULE_${mod}_LOCATION}/include")
+    ocv_target_include_directories(${name} "${OPENCV_MODULE_${mod}_LOCATION}/include")
   endforeach()
 
   if(WIN32)

--- a/modules/videoio/src/precomp.hpp
+++ b/modules/videoio/src/precomp.hpp
@@ -42,6 +42,12 @@
 #ifndef __VIDEOIO_H_
 #define __VIDEOIO_H_
 
+#if defined(__OPENCV_BUILD) && defined(BUILD_PLUGIN)
+#undef __OPENCV_BUILD  // allow public API only
+#include <opencv2/core.hpp>
+#include <opencv2/core/utils/trace.hpp>
+#endif
+
 #if defined __linux__ || defined __APPLE__ || defined __HAIKU__
 #include <unistd.h>  // -D_FORTIFY_SOURCE=2 workaround: https://github.com/opencv/opencv/issues/15020
 #endif


### PR DESCRIPTION
Build environment: Ubuntu 20.04 with installed Eigen and enable videoio plugins (`VIDEOIO_PLUGIN_LIST=all`).

Avoid including of `private.hpp` through removal of `__OPENCV_BUILD` definition.

<cut/>

```
In file included from /build/precommit_opencl_linux/next/opencv/modules/videoio/src/precomp.hpp:55,
                 from /build/precommit_opencl_linux/next/opencv/modules/videoio/src/cap_ffmpeg.cpp:42:
/build/precommit_opencl_linux/next/opencv/modules/core/include/opencv2/core/private.hpp:70:12: fatal error: Eigen/Core: No such file or directory
   70 | #  include <Eigen/Core>
      |            ^~~~~~~~~~~~
compilation terminated.
```