### PR TITLE
core: force check for string literals are used in the message

### DIFF
--- a/modules/core/include/opencv2/core/check.hpp
+++ b/modules/core/include/opencv2/core/check.hpp
@@ -63,7 +63,7 @@ struct CheckContext {
 #define CV__CHECK_LOCATION_VARNAME(id) CVAUX_CONCAT(CVAUX_CONCAT(__cv_check_, id), __LINE__)
 #define CV__DEFINE_CHECK_CONTEXT(id, message, testOp, p1_str, p2_str) \
     static const cv::detail::CheckContext CV__CHECK_LOCATION_VARNAME(id) = \
-            { CV__CHECK_FUNCTION, CV__CHECK_FILENAME, __LINE__, testOp, message, p1_str, p2_str }
+            { CV__CHECK_FUNCTION, CV__CHECK_FILENAME, __LINE__, testOp, "" message, "" p1_str, "" p2_str }
 
 CV_EXPORTS void CV_NORETURN check_failed_auto(const int v1, const int v2, const CheckContext& ctx);
 CV_EXPORTS void CV_NORETURN check_failed_auto(const size_t v1, const size_t v2, const CheckContext& ctx);

--- a/modules/dnn/src/onnx/onnx_importer.cpp
+++ b/modules/dnn/src/onnx/onnx_importer.cpp
@@ -446,8 +446,8 @@ void ONNXImporter::populateNet(Net dstNet)
                     avgLp.set("pool", pool);
                     if (axes.size() == 2)
                     {
-                        CV_CheckEQ(clamp(axes.get<int>(0), inpShape.size()), 1, ("Unsupported " + layer_type  + " mode").c_str());
-                        CV_CheckEQ(clamp(axes.get<int>(1), inpShape.size()), 2, ("Unsupported " + layer_type  + " mode").c_str());
+                        CV_CheckEQ(clamp(axes.get<int>(0), inpShape.size()), 1, "Unsupported mode");
+                        CV_CheckEQ(clamp(axes.get<int>(1), inpShape.size()), 2, "Unsupported mode");
                         avgLp.set("global_pooling", true);
                     }
                     else
@@ -489,7 +489,7 @@ void ONNXImporter::populateNet(Net dstNet)
             }
             else if (!layerParams.has("axes") && (layer_type == "ReduceMean" || layer_type == "ReduceSum" || layer_type == "ReduceMax"))
             {
-                CV_CheckEQ(layerParams.get<int>("keepdims"), 0, (layer_type + " layer only supports keepdims = false").c_str());
+                CV_CheckEQ(layerParams.get<int>("keepdims"), 0, "layer only supports keepdims = false");
                 LayerParams reshapeLp;
                 reshapeLp.name = layerParams.name + "/reshape";
                 reshapeLp.type = "Reshape";


### PR DESCRIPTION
Compile-time check to avoid crashes.

`CheckContext` content should not be initialized in runtime (stored in "Data" section).