### PR TITLE
core: fix corner-case in rotatedrect

### DIFF
--- a/modules/core/src/types.cpp
+++ b/modules/core/src/types.cpp
@@ -41,6 +41,7 @@
 //
 //M*/
 
+#include <cfloat>
 #include "precomp.hpp"
 
 namespace cv
@@ -196,7 +197,7 @@ Rect RotatedRect::boundingRect() const
            cvCeil(std::max(std::max(std::max(pt[0].y, pt[1].y), pt[2].y), pt[3].y)));
     
     // Modification of width and height is unnecessary if angle is 0
-    if ( angle != 0.0f )
+    if ( abs(angle) >= FLT_EPSILON )
     {
     r.width -= r.x - 1;
     r.height -= r.y - 1;

--- a/modules/core/src/types.cpp
+++ b/modules/core/src/types.cpp
@@ -194,8 +194,13 @@ Rect RotatedRect::boundingRect() const
            cvFloor(std::min(std::min(std::min(pt[0].y, pt[1].y), pt[2].y), pt[3].y)),
            cvCeil(std::max(std::max(std::max(pt[0].x, pt[1].x), pt[2].x), pt[3].x)),
            cvCeil(std::max(std::max(std::max(pt[0].y, pt[1].y), pt[2].y), pt[3].y)));
+    
+    // Modification of width and height is unnecessary if angle is 0
+    if ( angle != 0.0f )
+    {
     r.width -= r.x - 1;
     r.height -= r.y - 1;
+    }
     return r;
 }
 


### PR DESCRIPTION
Fixes #18417 
- Added a check for corner-case when angle is 0

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [x] The PR is proposed to proper branch
- [x] There is reference to original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake