### PR TITLE
calib3d: check for minimum corresponding points to calculate homography

### DIFF
--- a/modules/calib3d/src/fundam.cpp
+++ b/modules/calib3d/src/fundam.cpp
@@ -374,6 +374,9 @@ cv::Mat cv::findHomography( InputArray _points1, InputArray _points2,
                 return Mat();
             convertPointsFromHomogeneous(p, p);
         }
+        // Need at least 4 point correspondences to calculate Homography
+        if( npoints < 4 )
+            CV_Error(Error::StsVecLengthErr , "The input arrays should have at least 4 corresponding point sets to calculate Homography");
         p.reshape(2, npoints).convertTo(m, CV_32F);
     }
 

--- a/modules/calib3d/test/test_homography.cpp
+++ b/modules/calib3d/test/test_homography.cpp
@@ -63,6 +63,7 @@ namespace opencv_test { namespace {
 #define MESSAGE_RANSAC_DIFF "Reprojection error for current pair of points more than required."
 
 #define MAX_COUNT_OF_POINTS 303
+#define MIN_COUNT_OF_POINTS 4
 #define COUNT_NORM_TYPES 3
 #define METHODS_COUNT 4
 
@@ -249,7 +250,7 @@ void CV_HomographyTest::print_information_8(int _method, int j, int N, int k, in
 
 void CV_HomographyTest::run(int)
 {
-    for (int N = 4; N <= MAX_COUNT_OF_POINTS; ++N)
+    for (int N = MIN_COUNT_OF_POINTS; N <= MAX_COUNT_OF_POINTS; ++N)
     {
         RNG& rng = ts->get_rng();
 
@@ -709,6 +710,29 @@ TEST(Calib3d_Homography, fromImages)
     ASSERT_GE(ninliers0, 80);
     ASSERT_TRUE(!H1.empty());
     ASSERT_GE(ninliers1, 80);
+}
+
+TEST(Calib3d_Homography, minPoints)
+{
+    float pt1data[] =
+    {
+        2.80073029e+002f, 2.39591217e+002f, 2.21912201e+002f, 2.59783997e+002f
+    };
+
+    float pt2data[] =
+    {
+        1.84072723e+002f, 1.43591202e+002f, 1.25912483e+002f, 1.63783859e+002f
+    };
+
+    int npoints = (int)(sizeof(pt1data)/sizeof(pt1data[0])/2);
+    printf("npoints = %d\n", npoints);  // npoints = 2
+
+    Mat p1(1, npoints, CV_32FC2, pt1data);
+    Mat p2(1, npoints, CV_32FC2, pt2data);
+    Mat mask;
+
+    // findHomography should raise an error since npoints < MIN_COUNT_OF_POINTS
+    EXPECT_THROW(findHomography(p1, p2, RANSAC, 0.01, mask), cv::Exception);
 }
 
 }} // namespace


### PR DESCRIPTION
Fixes #18254 
- Added a check for minimum points to calculate Homography

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [x] The PR is proposed to proper branch
- [x] There is reference to original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake

```
allow_multiple_commits=1
```