### PR TITLE
ml: fix python test

### DIFF
--- a/modules/ml/misc/python/test/test_goodfeatures.py
+++ b/modules/ml/misc/python/test/test_goodfeatures.py
@@ -11,7 +11,7 @@ from tests_common import NewOpenCVTests
 class TestGoodFeaturesToTrack_test(NewOpenCVTests):
     def test_goodFeaturesToTrack(self):
         arr = self.get_sample('samples/data/lena.jpg', 0)
-        original = arr.copy(True)
+        original = arr.copy()
         threshes = [ x / 100. for x in range(1,10) ]
         numPoints = 20000
 


### PR DESCRIPTION
relates #6285

Error:
```
Traceback (most recent call last):
  File "modules/ml/misc/python/test/test_goodfeatures.py", line 14, in test_goodFeaturesToTrack
    original = arr.copy(True)
TypeError: order must be str, not bool
```

<cut/>

```
buildworker:Mac=macosx-1
```