### PR TITLE
ios: don't force BUILD_opencv_world=OFF in case of excluded modules

### DIFF
--- a/platforms/ios/build_framework.py
+++ b/platforms/ios/build_framework.py
@@ -150,7 +150,6 @@ class Builder:
         ] if self.debug_info else [])
 
         if len(self.exclude) > 0:
-            args += ["-DBUILD_opencv_world=OFF"] if not self.dynamic else []
             args += ["-DBUILD_opencv_%s=OFF" % m for m in self.exclude]
 
         if len(self.disable) > 0:


### PR DESCRIPTION
relates #7358 #18381

There is no reason to disable `opencv_world` in general. This special module includes subset of OpenCV modules. For example, it should be able to build with `opencv_core` only.
Looks like disabling `opencv_world` was wrong from the beginning (by #7358 and following fixes).

P.S. Use `--without world` to disable `opencv_world` again

/cc @komakai @sjang42 @nevir