### PR TITLE
OpenCL: use half when specified

### DIFF
--- a/modules/dnn/src/ocl4dnn/src/ocl4dnn_conv_spatial.cpp
+++ b/modules/dnn/src/ocl4dnn/src/ocl4dnn_conv_spatial.cpp
@@ -594,10 +594,10 @@ bool OCL4DNNConvSpatial<Dtype>::Forward(const UMat& bottom,
     if (use_half_ && weights_half.empty())
         convertFp16(weight, weights_half);
 
-    prepareKernel(bottom, top, weight, (use_half_) ? bias_half : bias, numImages);
+    prepareKernel(bottom, top, (use_half_) ? weights_half : weight, (use_half_) ? bias_half : bias, numImages);
     if (bestKernelConfig.empty())
         return false;
-    return convolve(bottom, top, weight, (use_half_) ? bias_half : bias, numImages, bestKernelConfig);
+    return convolve(bottom, top, (use_half_) ? weights_half : weight, (use_half_) ? bias_half : bias, numImages, bestKernelConfig);
 }
 
 template<typename Dtype>


### PR DESCRIPTION
relates #18457

### Pull Request Readiness Checklist

This PR doesn't fix #18457, but during the debug, I found that `weights_half` is never used even it has been converted from `weight`
I confirmed the this PR doesn't harm the tests.  `perf_dnn` fails as same as before, and some tests fails even before from this PR, so nothing gets worse.

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [x] The PR is proposed to proper branch
- [ ] There is reference to original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
