### PR TITLE
Fix out-of-bounds access in setSize() from cv::Mat() constructor

### DIFF
--- a/modules/core/src/matrix.cpp
+++ b/modules/core/src/matrix.cpp
@@ -237,12 +237,19 @@ void setSize( Mat& m, int _dims, const int* _sz, const size_t* _steps, bool auto
 
         if( _steps )
         {
-            if (_steps[i] % esz1 != 0)
+            if (i < _dims-1)
             {
-                CV_Error(Error::BadStep, "Step must be a multiple of esz1");
-            }
+                if (_steps[i] % esz1 != 0)
+                {
+                    CV_Error_(Error::BadStep, ("Step %zu for dimension %d must be a multiple of esz1 %zu", _steps[i], i, esz1));
+                }
 
-            m.step.p[i] = i < _dims-1 ? _steps[i] : esz;
+                m.step.p[i] = _steps[i];
+            }
+            else
+            {
+                m.step.p[i] = esz;
+            }
         }
         else if( autoSteps )
         {


### PR DESCRIPTION
### Pull Request Readiness Checklist

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [x] The PR is proposed to proper branch
- [ ] There is reference to original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake

This PR fixes an issue in the `setSize()` method of `cv::Mat`. According to the documentation (for example https://docs.opencv.org/4.4.0/d3/d63/classcv_1_1Mat.html#a5fafc033e089143062fd31015b5d0f40) the parameter `const size_t* steps` is an `Array of ndims-1 steps in case of a multi-dimensional array (the last step is always set to the element size)`. This is reflected in the implementation, where the `m.step.p[i]` is always set to `esz` for the last dimension:
https://github.com/opencv/opencv/blob/1913482cf5d257d7da292bb2c15f22d0588d34dc/modules/core/src/matrix.cpp#L245

However a few lines above, there is a check if `_steps[i]` is a multiple of `esz1`. This statement **does** access the `i`th element of `_steps` for the last dimension. This is an out of bounds access according to the documentation:
https://github.com/opencv/opencv/blob/1913482cf5d257d7da292bb2c15f22d0588d34dc/modules/core/src/matrix.cpp#L240

Proposed patch fixes the out-of-bounds access and restores the documented behavior.