### PR TITLE
calib3d: add GCGraph::maxFlow() missing empty checks

### DIFF
--- a/modules/imgproc/include/opencv2/imgproc/detail/gcgraph.hpp
+++ b/modules/imgproc/include/opencv2/imgproc/detail/gcgraph.hpp
@@ -155,6 +155,8 @@ void GCGraph<TWeight>::addTermWeights( int i, TWeight sourceW, TWeight sinkW )
 template <class TWeight>
 TWeight GCGraph<TWeight>::maxFlow()
 {
+    CV_Assert(!vtcs.empty());
+    CV_Assert(!edges.empty());
     const int TERMINAL = -1, ORPHAN = -2;
     Vtx stub, *nilNode = &stub, *first = nilNode, *last = nilNode;
     int curr_ts = 0;


### PR DESCRIPTION
relates #18454

force_builders_only=linux