### PR TITLE
calib3d/imgproc: add GCGraph::maxFlow() missing empty checks

### DIFF
--- a/modules/imgproc/src/gcgraph.hpp
+++ b/modules/imgproc/src/gcgraph.hpp
@@ -152,6 +152,8 @@ void GCGraph<TWeight>::addTermWeights( int i, TWeight sourceW, TWeight sinkW )
 template <class TWeight>
 TWeight GCGraph<TWeight>::maxFlow()
 {
+    CV_Assert(!vtcs.empty());
+    CV_Assert(!edges.empty());
     const int TERMINAL = -1, ORPHAN = -2;
     Vtx stub, *nilNode = &stub, *first = nilNode, *last = nilNode;
     int curr_ts = 0;


### PR DESCRIPTION
relates #18454

3.4 branch: imgproc module
master branch: calib3d module (moved code)