### PR TITLE
python: replace numpy.full() to support numpy<1.13

### DIFF
--- a/modules/python/test/test_copytomask.py
+++ b/modules/python/test/test_copytomask.py
@@ -24,10 +24,12 @@ class copytomask_test(NewOpenCVTests):
         valeurBGRSup = np.array([70, 70,255])
         maskRed = cv.inRange(img, valeurBGRinf, valeurBGRSup)
         #New binding
-        dstcv = np.full(np.array((2, 2, 1))*img.shape, 255, dtype=img.dtype)
+        dstcv = np.ndarray(np.array((2, 2, 1))*img.shape, dtype=img.dtype)
+        dstcv.fill(255)
         cv.copyTo(img, maskRed, dstcv[:img.shape[0],:img.shape[1],:])
         #using numpy
-        dstnp = np.full(np.array((2, 2, 1))*img.shape, 255, dtype=img.dtype)
+        dstnp = np.ndarray(np.array((2, 2, 1))*img.shape, dtype=img.dtype)
+        dstnp.fill(255)
         mask2=maskRed.astype(bool)
         _, mask_b = np.broadcast_arrays(img, mask2[..., None])
         np.copyto(dstnp[:img.shape[0],:img.shape[1],:], img, where=mask_b)


### PR DESCRIPTION
[Nightly build](http://pullrequest.opencv.org/buildbot/builders/master_etc-centos-lin64/builds/35/steps/test_python2/logs/stdio):

```
AttributeError: 'module' object has no attribute 'full'
```

<cut/>

```
force_builders=Custom
buildworker:Custom=linux-1
build_image:Custom=centos:7
```