### PR TITLE
[G-API] Numpy array with int64 failed in cv.gin

### DIFF
--- a/modules/gapi/misc/python/pyopencv_gapi.hpp
+++ b/modules/gapi/misc/python/pyopencv_gapi.hpp
@@ -128,7 +128,7 @@ static PyObject* pyopencv_cv_gin(PyObject* , PyObject* py_args, PyObject* kw)
         if (PyTuple_Check(item))
         {
             cv::Scalar s;
-            if (pyopencv_to(item, s, ArgInfo("scalar", true)))
+            if (pyopencv_to(item, s, ArgInfo("scalar", false)))
             {
                 args.emplace_back(s);
             }
@@ -141,7 +141,7 @@ static PyObject* pyopencv_cv_gin(PyObject* , PyObject* py_args, PyObject* kw)
         else if (PyArray_Check(item))
         {
             cv::Mat m;
-            if (pyopencv_to(item, m, ArgInfo("mat", true)))
+            if (pyopencv_to(item, m, ArgInfo("mat", false)))
             {
                 args.emplace_back(m);
             }

--- a/modules/gapi/misc/python/test/test_gapi_core.py
+++ b/modules/gapi/misc/python/test/test_gapi_core.py
@@ -24,7 +24,7 @@ class gapi_core_test(NewOpenCVTests):
         in2 = np.random.randint(0, 100, sz)
 
         # OpenCV
-        expected = in1 + in2
+        expected = cv.add(in1, in2)
 
         # G-API
         g_in1 = cv.GMat()
@@ -36,6 +36,28 @@ class gapi_core_test(NewOpenCVTests):
             actual = comp.apply(cv.gin(in1, in2), args=cv.compile_args(pkg))
             # Comparison
             self.assertEqual(0.0, cv.norm(expected, actual, cv.NORM_INF))
+            self.assertEqual(expected.dtype, actual.dtype)
+
+
+    def test_add_uint8(self):
+        sz = (1280, 720)
+        in1 = np.random.randint(0, 100, sz).astype(np.uint8)
+        in2 = np.random.randint(0, 100, sz).astype(np.uint8)
+
+        # OpenCV
+        expected = cv.add(in1, in2)
+
+        # G-API
+        g_in1 = cv.GMat()
+        g_in2 = cv.GMat()
+        g_out = cv.gapi.add(g_in1, g_in2)
+        comp = cv.GComputation(cv.GIn(g_in1, g_in2), cv.GOut(g_out))
+
+        for pkg in pkgs:
+            actual = comp.apply(cv.gin(in1, in2), args=cv.compile_args(pkg))
+            # Comparison
+            self.assertEqual(0.0, cv.norm(expected, actual, cv.NORM_INF))
+            self.assertEqual(expected.dtype, actual.dtype)
 
 
     def test_mean(self):
@@ -73,6 +95,7 @@ class gapi_core_test(NewOpenCVTests):
             # Comparison
             for e, a in zip(expected, actual):
                 self.assertEqual(0.0, cv.norm(e, a, cv.NORM_INF))
+                self.assertEqual(e.dtype, a.dtype)
 
 
     def test_threshold(self):
@@ -94,6 +117,7 @@ class gapi_core_test(NewOpenCVTests):
             actual_mat, actual_thresh = comp.apply(cv.gin(in_mat, maxv), args=cv.compile_args(pkg))
             # Comparison
             self.assertEqual(0.0, cv.norm(expected_mat, actual_mat, cv.NORM_INF))
+            self.assertEqual(expected_mat.dtype, actual_mat.dtype)
             self.assertEqual(expected_thresh, actual_thresh[0])
 
 

--- a/modules/gapi/misc/python/test/test_gapi_core.py
+++ b/modules/gapi/misc/python/test/test_gapi_core.py
@@ -20,8 +20,8 @@ class gapi_core_test(NewOpenCVTests):
     def test_add(self):
         # TODO: Extend to use any type and size here
         sz = (1280, 720)
-        in1 = np.random.randint(0, 100, sz).astype(np.uint8)
-        in2 = np.random.randint(0, 100, sz).astype(np.uint8)
+        in1 = np.random.randint(0, 100, sz)
+        in2 = np.random.randint(0, 100, sz)
 
         # OpenCV
         expected = in1 + in2
@@ -40,7 +40,7 @@ class gapi_core_test(NewOpenCVTests):
 
     def test_mean(self):
         sz = (1280, 720, 3)
-        in_mat = np.random.randint(0, 100, sz).astype(np.uint8)
+        in_mat = np.random.randint(0, 100, sz)
 
         # OpenCV
         expected = cv.mean(in_mat)
@@ -58,7 +58,7 @@ class gapi_core_test(NewOpenCVTests):
 
     def test_split3(self):
         sz = (1280, 720, 3)
-        in_mat = np.random.randint(0, 100, sz).astype(np.uint8)
+        in_mat = np.random.randint(0, 100, sz)
 
         # OpenCV
         expected = cv.split(in_mat)


### PR DESCRIPTION
### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [ ] The PR is proposed to proper branch
- [x] There is reference to original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake

### Problem overview

This code failed: `Failed convert array to cv::Mat` 
```
in_mat = np.array([1,2,3])
cv.gin(in_mat)
```
But this code works fine:
```
in_mat = np.array([1,2,3]).astype(np.uint8)
cv.gin(in_mat)
```

### Solution
While parsing was used incorrect `ArgInfo` it was marked as outputarg == `true` instead of `false` 
https://github.com/opencv/opencv/blob/master/modules/gapi/misc/python/pyopencv_gapi.hpp#L144
Replace `ArgInfo{"mat", true}` -> `ArgInfo{"mat", false}`


### Buildbot configuration

```
build_gapi_standalone:Linux x64=ade-0.1.1f
build_gapi_standalone:Win64=ade-0.1.1f
build_gapi_standalone:Mac=ade-0.1.1f
build_gapi_standalone:Linux x64 Debug=ade-0.1.1f

force_builders=ARMv7,Custom
build_image:Custom=centos:7
buildworker:Custom=linux-1
build_gapi_standalone:Custom=ade-0.1.1f
```
