### PR TITLE
(3.4) [IE][VPU]: Refactor vpu configs (backport 17993)

### DIFF
--- a/modules/dnn/src/ie_ngraph.cpp
+++ b/modules/dnn/src/ie_ngraph.cpp
@@ -684,7 +684,11 @@ void InfEngineNgraphNet::initPlugin(InferenceEngine::CNNNetwork& net)
         }
         std::map<std::string, std::string> config;
         if (device_name == "MYRIAD") {
+#if INF_ENGINE_VER_MAJOR_GT(INF_ENGINE_RELEASE_2020_4)
+            config.emplace("MYRIAD_DETECT_NETWORK_BATCH", CONFIG_VALUE(NO));
+#else
             config.emplace("VPU_DETECT_NETWORK_BATCH", CONFIG_VALUE(NO));
+#endif
         }
 
         bool isHetero = device_name == "FPGA";


### PR DESCRIPTION
backport #17993

<cut/>

```
force_builders=Custom,Custom Win,Custom Mac
Xbuild_image:Custom=ubuntu-openvino-2020.4.0:16.04
build_image:Custom=ubuntu-openvino-2021.1.0:20.04
Xbuild_image:Custom Win=openvino-2020.4.0
build_image:Custom Win=openvino-2021.1.0
build_image:Custom Mac=openvino-2020.4.0

test_modules:Custom=dnn,python2,python3,java
test_modules:Custom Win=dnn,python2,python3,java
test_modules:Custom Mac=dnn,python2,python3,java

buildworker:Custom=linux-1
# disabled due high memory usage: test_opencl:Custom=ON
test_opencl:Custom=OFF
test_bigdata:Custom=1
test_filter:Custom=*
```