### PR TITLE
core(logger): avoid destruction of GlobalLoggingInitStruct object

### DIFF
--- a/modules/core/src/logger.cpp
+++ b/modules/core/src/logger.cpp
@@ -94,8 +94,7 @@ LogLevel GlobalLoggingInitStruct::m_defaultUnconfiguredGlobalLevel = GlobalLoggi
 //
 static GlobalLoggingInitStruct& getGlobalLoggingInitStruct()
 {
-    static GlobalLoggingInitStruct globalLoggingInitInstance;
-    return globalLoggingInitInstance;
+    CV_SINGLETON_LAZY_INIT_REF(GlobalLoggingInitStruct, new GlobalLoggingInitStruct());
 }
 
 // To ensure that the combined struct defined above is initialized even

--- a/platforms/scripts/valgrind.supp
+++ b/platforms/scripts/valgrind.supp
@@ -219,6 +219,13 @@
 }
 
 {
+   OpenCV-SingletonLogger
+   Memcheck:Leak
+   ...
+   fun:_ZN2cv5utils7logging8internalL26getGlobalLoggingInitStructEv
+}
+
+{
    OpenCV-gtk_init
    Memcheck:Leak
    ...


### PR DESCRIPTION
- keep logger available until the program termination

fixes #18152