### PR TITLE
Add CV_16UC1/GRAY16_LE support to GStreamer backend for VideoWriter

### DIFF
--- a/modules/videoio/include/opencv2/videoio.hpp
+++ b/modules/videoio/include/opencv2/videoio.hpp
@@ -194,8 +194,9 @@ enum VideoWriterProperties {
   VIDEOWRITER_PROP_QUALITY = 1,    //!< Current quality (0..100%) of the encoded videostream. Can be adjusted dynamically in some codecs.
   VIDEOWRITER_PROP_FRAMEBYTES = 2, //!< (Read-only): Size of just encoded video frame. Note that the encoding order may be different from representation order.
   VIDEOWRITER_PROP_NSTRIPES = 3,   //!< Number of stripes for parallel encoding. -1 for auto detection.
-  VIDEOWRITER_PROP_IS_COLOR = 4    //!< If it is not zero, the encoder will expect and encode color frames, otherwise it
+  VIDEOWRITER_PROP_IS_COLOR = 4,   //!< If it is not zero, the encoder will expect and encode color frames, otherwise it
                                    //!< will work with grayscale frames.
+  VIDEOWRITER_PROP_DEPTH = 5       //!< Defaults to CV_8U.
 };
 
 //! @} videoio_flags_base

--- a/modules/videoio/src/backend_plugin.cpp
+++ b/modules/videoio/src/backend_plugin.cpp
@@ -508,7 +508,21 @@ public:
     {
         CV_Assert(plugin_api);
         CvPluginWriter writer = NULL;
-        if (plugin_api->Writer_open)
+        if (plugin_api->api_header.api_version == 1 && plugin_api->Writer_open_with_params)
+        {
+            CV_Assert(plugin_api->Writer_release);
+            CV_Assert(!filename.empty());
+            std::vector<int> vint_params = params.getIntVector();
+            int* c_params = &vint_params[0];
+            size_t n_params = vint_params.size() / 2;
+
+            if (CV_ERROR_OK == plugin_api->Writer_open_with_params(filename.c_str(), fourcc, fps, sz.width, sz.height, c_params, n_params, &writer))
+            {
+                CV_Assert(writer);
+                return makePtr<PluginWriter>(plugin_api, writer);
+            }
+        }
+        else if (plugin_api->Writer_open)
         {
             CV_Assert(plugin_api->Writer_release);
             CV_Assert(!filename.empty());

--- a/modules/videoio/src/backend_plugin.cpp
+++ b/modules/videoio/src/backend_plugin.cpp
@@ -540,7 +540,7 @@ public:
             CV_Assert(!filename.empty());
             std::vector<int> vint_params = params.getIntVector();
             int* c_params = &vint_params[0];
-            size_t n_params = vint_params.size() / 2;
+            unsigned n_params = (unsigned)(vint_params.size() / 2);
 
             if (CV_ERROR_OK == plugin_api->Writer_open_with_params(filename.c_str(), fourcc, fps, sz.width, sz.height, c_params, n_params, &writer))
             {

--- a/modules/videoio/src/backend_plugin.cpp
+++ b/modules/videoio/src/backend_plugin.cpp
@@ -205,10 +205,15 @@ public:
         FN_opencv_videoio_plugin_init_t fn_init = reinterpret_cast<FN_opencv_videoio_plugin_init_t>(lib_->getSymbol(init_name));
         if (fn_init)
         {
-            plugin_api_ = fn_init(ABI_VERSION, API_VERSION, NULL);
+            for (int supported_api_version = API_VERSION; supported_api_version >= 0; supported_api_version--)
+            {
+                plugin_api_ = fn_init(ABI_VERSION, supported_api_version, NULL);
+                if (plugin_api_)
+                    break;
+            }
             if (!plugin_api_)
             {
-                CV_LOG_INFO(NULL, "Video I/O: plugin is incompatible: " << lib->getName());
+                CV_LOG_INFO(NULL, "Video I/O: plugin is incompatible (can't be initialized): " << lib->getName());
                 return;
             }
             if (plugin_api_->api_header.opencv_version_major != CV_VERSION_MAJOR)
@@ -232,8 +237,29 @@ public:
                 plugin_api_ = NULL;
                 return;
             }
-            // TODO Preview: add compatibility API/ABI checks
-            CV_LOG_INFO(NULL, "Video I/O: loaded plugin '" << plugin_api_->api_header.api_description << "'");
+            CV_LOG_INFO(NULL, "Video I/O: initialized '" << plugin_api_->api_header.api_description << "': built with "
+                << cv::format("OpenCV %d.%d (ABI/API = %d/%d)",
+                     plugin_api_->api_header.opencv_version_major, plugin_api_->api_header.opencv_version_minor,
+                     plugin_api_->api_header.min_api_version, plugin_api_->api_header.api_version)
+                << ", current OpenCV version is '" CV_VERSION "' (ABI/API = " << ABI_VERSION << "/" << API_VERSION << ")"
+            );
+            if (plugin_api_->api_header.min_api_version != ABI_VERSION)  // future: range can be here
+            {
+                // actually this should never happen due to checks in plugin's init() function
+                CV_LOG_ERROR(NULL, "Video I/O: plugin is not supported due to incompatible ABI = " << plugin_api_->api_header.min_api_version);
+                plugin_api_ = NULL;
+                return;
+            }
+            if (plugin_api_->api_header.api_version != API_VERSION)
+            {
+                CV_LOG_INFO(NULL, "Video I/O: NOTE: plugin is supported, but there is API version mismath: "
+                    << cv::format("plugin API level (%d) != OpenCV API level (%d)", plugin_api_->api_header.api_version, API_VERSION));
+                if (plugin_api_->api_header.api_version < API_VERSION)
+                {
+                    CV_LOG_INFO(NULL, "Video I/O: NOTE: some functionality may be unavailable due to lack of support by plugin implementation");
+                }
+            }
+            CV_LOG_INFO(NULL, "Video I/O: plugin is ready to use '" << plugin_api_->api_header.api_description << "'");
         }
         else
         {
@@ -508,7 +534,7 @@ public:
     {
         CV_Assert(plugin_api);
         CvPluginWriter writer = NULL;
-        if (plugin_api->api_header.api_version == 1 && plugin_api->Writer_open_with_params)
+        if (plugin_api->api_header.api_version >= 1 && plugin_api->Writer_open_with_params)
         {
             CV_Assert(plugin_api->Writer_release);
             CV_Assert(!filename.empty());
@@ -527,6 +553,12 @@ public:
             CV_Assert(plugin_api->Writer_release);
             CV_Assert(!filename.empty());
             const bool isColor = params.get(VIDEOWRITER_PROP_IS_COLOR, true);
+            const int depth = params.get(VIDEOWRITER_PROP_DEPTH, CV_8U);
+            if (depth != CV_8U)
+            {
+                CV_LOG_WARNING(NULL, "Video I/O plugin doesn't support (due to lower API level) creation of VideoWriter with depth != CV_8U");
+                return Ptr<PluginWriter>();
+            }
             if (CV_ERROR_OK == plugin_api->Writer_open(filename.c_str(), fourcc, fps, sz.width, sz.height, isColor, &writer))
             {
                 CV_Assert(writer);

--- a/modules/videoio/src/cap_ffmpeg.cpp
+++ b/modules/videoio/src/cap_ffmpeg.cpp
@@ -396,7 +396,7 @@ CvResult CV_API_CALL cv_writer_write(CvPluginWriter handle, const unsigned char 
 static const OpenCV_VideoIO_Plugin_API_preview plugin_api_v0 =
 {
     {
-        sizeof(OpenCV_VideoIO_Plugin_API_preview), ABI_VERSION, API_VERSION,
+        sizeof(OpenCV_VideoIO_Plugin_API_preview), ABI_VERSION, 0/*API_VERSION*/,
         CV_VERSION_MAJOR, CV_VERSION_MINOR, CV_VERSION_REVISION, CV_VERSION_STATUS,
         "FFmpeg OpenCV Video I/O plugin"
     },
@@ -412,7 +412,7 @@ static const OpenCV_VideoIO_Plugin_API_preview plugin_api_v0 =
     /* 10*/cv_writer_get_prop,
     /* 11*/cv_writer_set_prop,
     /* 12*/cv_writer_write,
-    /* 13*/NULL
+    /* 13 Writer_open_with_params*/NULL
 };
 
 } // namespace
@@ -421,7 +421,7 @@ const OpenCV_VideoIO_Plugin_API_preview* opencv_videoio_plugin_init_v0(int reque
 {
     if (requested_abi_version != 0)
         return NULL;
-    if (requested_api_version != 0 && requested_api_version != 1)
+    if (requested_api_version != 0)
         return NULL;
     return &cv::plugin_api_v0;
 }

--- a/modules/videoio/src/cap_ffmpeg.cpp
+++ b/modules/videoio/src/cap_ffmpeg.cpp
@@ -411,7 +411,8 @@ static const OpenCV_VideoIO_Plugin_API_preview plugin_api_v0 =
     /*  9*/cv_writer_release,
     /* 10*/cv_writer_get_prop,
     /* 11*/cv_writer_set_prop,
-    /* 12*/cv_writer_write
+    /* 12*/cv_writer_write,
+    /* 13*/NULL
 };
 
 } // namespace
@@ -420,7 +421,7 @@ const OpenCV_VideoIO_Plugin_API_preview* opencv_videoio_plugin_init_v0(int reque
 {
     if (requested_abi_version != 0)
         return NULL;
-    if (requested_api_version != 0)
+    if (requested_api_version != 0 && requested_api_version != 1)
         return NULL;
     return &cv::plugin_api_v0;
 }

--- a/modules/videoio/src/cap_gstreamer.cpp
+++ b/modules/videoio/src/cap_gstreamer.cpp
@@ -2003,7 +2003,8 @@ static const OpenCV_VideoIO_Plugin_API_preview plugin_api_v0 =
     /*  9*/cv_writer_release,
     /* 10*/cv_writer_get_prop,
     /* 11*/cv_writer_set_prop,
-    /* 12*/cv_writer_write
+    /* 12*/cv_writer_write,
+    /* 13*/NULL
 };
 
 } // namespace
@@ -2012,7 +2013,7 @@ const OpenCV_VideoIO_Plugin_API_preview* opencv_videoio_plugin_init_v0(int reque
 {
     if (requested_abi_version != 0)
         return NULL;
-    if (requested_api_version != 0)
+    if (requested_api_version != 0 && requested_api_version != 1)
         return NULL;
     return &cv::plugin_api_v0;
 }

--- a/modules/videoio/src/cap_interface.hpp
+++ b/modules/videoio/src/cap_interface.hpp
@@ -117,7 +117,8 @@ public:
         return unusedParams;
     }
 
-    std::vector<int> getIntVector() const CV_NOEXCEPT {
+    std::vector<int> getIntVector() const
+    {
         std::vector<int> vint_params;
         for (const auto& param : params_)
         {

--- a/modules/videoio/src/cap_interface.hpp
+++ b/modules/videoio/src/cap_interface.hpp
@@ -116,6 +116,17 @@ public:
         }
         return unusedParams;
     }
+
+    std::vector<int> getIntVector() const CV_NOEXCEPT {
+        std::vector<int> vint_params;
+        for (const auto& param : params_)
+        {
+            vint_params.push_back(param.key);
+            vint_params.push_back(param.value);
+        }
+        return vint_params;
+    }
+
 private:
     std::vector<VideoWriterParameter> params_;
 };

--- a/modules/videoio/src/cap_mfx_plugin.cpp
+++ b/modules/videoio/src/cap_mfx_plugin.cpp
@@ -188,7 +188,7 @@ CvResult CV_API_CALL cv_writer_write(CvPluginWriter handle, const unsigned char 
 static const OpenCV_VideoIO_Plugin_API_preview plugin_api_v0 =
 {
     {
-        sizeof(OpenCV_VideoIO_Plugin_API_preview), ABI_VERSION, API_VERSION,
+        sizeof(OpenCV_VideoIO_Plugin_API_preview), ABI_VERSION, 0/*API_VERSION*/,
         CV_VERSION_MAJOR, CV_VERSION_MINOR, CV_VERSION_REVISION, CV_VERSION_STATUS,
         "MediaSDK OpenCV Video I/O plugin"
     },
@@ -203,7 +203,8 @@ static const OpenCV_VideoIO_Plugin_API_preview plugin_api_v0 =
     /*  9*/cv_writer_release,
     /* 10*/cv_writer_get_prop,
     /* 11*/cv_writer_set_prop,
-    /* 12*/cv_writer_write
+    /* 12*/cv_writer_write,
+    /* 13 Writer_open_with_params*/NULL
 };
 
 } // namespace

--- a/modules/videoio/src/cap_msmf.cpp
+++ b/modules/videoio/src/cap_msmf.cpp
@@ -1865,7 +1865,7 @@ CvResult CV_API_CALL cv_writer_write(CvPluginWriter handle, const unsigned char*
 static const OpenCV_VideoIO_Plugin_API_preview plugin_api_v0 =
 {
     {
-        sizeof(OpenCV_VideoIO_Plugin_API_preview), ABI_VERSION, API_VERSION,
+        sizeof(OpenCV_VideoIO_Plugin_API_preview), ABI_VERSION, 0/*API_VERSION*/,
         CV_VERSION_MAJOR, CV_VERSION_MINOR, CV_VERSION_REVISION, CV_VERSION_STATUS,
         "Microsoft Media Foundation OpenCV Video I/O plugin"
     },
@@ -1880,8 +1880,7 @@ static const OpenCV_VideoIO_Plugin_API_preview plugin_api_v0 =
     /*  9*/cv_writer_release,
     /* 10*/cv_writer_get_prop,
     /* 11*/cv_writer_set_prop,
-    /* 12*/cv_writer_write,
-    /* 13*/NULL
+    /* 12*/cv_writer_write
 };
 
 } // namespace
@@ -1890,7 +1889,7 @@ const OpenCV_VideoIO_Plugin_API_preview* opencv_videoio_plugin_init_v0(int reque
 {
     if (requested_abi_version != 0)
         return NULL;
-    if (requested_api_version != 0 && requested_api_version != 1)
+    if (requested_api_version != 0)
         return NULL;
     return &cv::plugin_api_v0;
 }

--- a/modules/videoio/src/cap_msmf.cpp
+++ b/modules/videoio/src/cap_msmf.cpp
@@ -1880,7 +1880,8 @@ static const OpenCV_VideoIO_Plugin_API_preview plugin_api_v0 =
     /*  9*/cv_writer_release,
     /* 10*/cv_writer_get_prop,
     /* 11*/cv_writer_set_prop,
-    /* 12*/cv_writer_write
+    /* 12*/cv_writer_write,
+    /* 13*/NULL
 };
 
 } // namespace
@@ -1889,7 +1890,7 @@ const OpenCV_VideoIO_Plugin_API_preview* opencv_videoio_plugin_init_v0(int reque
 {
     if (requested_abi_version != 0)
         return NULL;
-    if (requested_api_version != 0)
+    if (requested_api_version != 0 && requested_api_version != 1)
         return NULL;
     return &cv::plugin_api_v0;
 }

--- a/modules/videoio/src/cap_ueye.cpp
+++ b/modules/videoio/src/cap_ueye.cpp
@@ -467,7 +467,7 @@ CvResult CV_API_CALL cv_writer_write(CvPluginWriter /*handle*/, const unsigned c
 const OpenCV_VideoIO_Plugin_API_preview plugin_api_v0 =
 {
     {
-        sizeof(OpenCV_VideoIO_Plugin_API_preview), ABI_VERSION, API_VERSION,
+        sizeof(OpenCV_VideoIO_Plugin_API_preview), ABI_VERSION, 0/*API_VERSION*/,
         CV_VERSION_MAJOR, CV_VERSION_MINOR, CV_VERSION_REVISION, CV_VERSION_STATUS,
         "uEye OpenCV Video I/O plugin"
     },
@@ -482,7 +482,8 @@ const OpenCV_VideoIO_Plugin_API_preview plugin_api_v0 =
     /*  9*/cv_writer_release,
     /* 10*/cv_writer_get_prop,
     /* 11*/cv_writer_set_prop,
-    /* 12*/cv_writer_write
+    /* 12*/cv_writer_write,
+    /* 13 Writer_open_with_params*/NULL
 };
 } // namespace
 } // namespace cv

--- a/modules/videoio/src/plugin_api.hpp
+++ b/modules/videoio/src/plugin_api.hpp
@@ -10,7 +10,7 @@
 
 // increase for backward-compatible changes, e.g. add new function
 // Main API <= Plugin API -> plugin is compatible
-#define API_VERSION 0 // preview
+#define API_VERSION 1 // preview
 // increase for incompatible changes, e.g. remove function argument
 // Main ABI == Plugin ABI -> plugin is compatible
 #define ABI_VERSION 0 // preview
@@ -142,6 +142,18 @@ typedef struct OpenCV_VideoIO_Plugin_API_preview
     @note API-CALL 12, API-Version == 0
      */
     CvResult (CV_API_CALL *Writer_write)(CvPluginWriter handle, const unsigned char *data, int step, int width, int height, int cn);
+
+
+    /** @brief Try to open video writer
+
+    @param filename File name or NULL to use camera_index instead
+    @param camera_index Camera index (used if filename == NULL)
+    @param[out] handle pointer on Writer handle
+
+    @note API-CALL 13, API-Version == 1
+     */
+    CvResult(CV_API_CALL* Writer_open_with_params)(const char* filename, int fourcc, double fps, int width, int height, int * params, size_t n_params,
+        CV_OUT CvPluginWriter* handle);
 
 } OpenCV_VideoIO_Plugin_API_preview;
 

--- a/modules/videoio/src/plugin_api.hpp
+++ b/modules/videoio/src/plugin_api.hpp
@@ -9,10 +9,12 @@
 #include <opencv2/core/llapi/llapi.h>
 
 // increase for backward-compatible changes, e.g. add new function
-// Main API <= Plugin API -> plugin is compatible
+// Main API <= Plugin API -> plugin is fully compatible
+// Main API > Plugin API -> plugin is not compatible, caller should use shim code to use plugins with old API
 #define API_VERSION 1 // preview
 // increase for incompatible changes, e.g. remove function argument
 // Main ABI == Plugin ABI -> plugin is compatible
+// Main ABI > Plugin ABI -> plugin is not compatible, caller should use shim code to use old ABI plugins
 #define ABI_VERSION 0 // preview
 
 #ifdef __cplusplus
@@ -93,8 +95,12 @@ typedef struct OpenCV_VideoIO_Plugin_API_preview
 
     /** @brief Try to open video writer
 
-    @param filename File name or NULL to use camera_index instead
-    @param camera_index Camera index (used if filename == NULL)
+    @param filename Destination location
+    @param fourcc FOURCC code
+    @param fps FPS
+    @param width frame width
+    @param height frame height
+    @param isColor true if video stream should save color frames
     @param[out] handle pointer on Writer handle
 
     @note API-CALL 8, API-Version == 0
@@ -146,14 +152,22 @@ typedef struct OpenCV_VideoIO_Plugin_API_preview
 
     /** @brief Try to open video writer
 
-    @param filename File name or NULL to use camera_index instead
-    @param camera_index Camera index (used if filename == NULL)
+    @param filename Destination location
+    @param fourcc FOURCC code
+    @param fps FPS
+    @param width frame width
+    @param height frame height
+    @param params pointer on 2*n_params array of 'key,value' pairs
+    @param n_params number of passed parameters
     @param[out] handle pointer on Writer handle
 
     @note API-CALL 13, API-Version == 1
      */
-    CvResult(CV_API_CALL* Writer_open_with_params)(const char* filename, int fourcc, double fps, int width, int height, int * params, size_t n_params,
-        CV_OUT CvPluginWriter* handle);
+    CvResult (CV_API_CALL* Writer_open_with_params)(
+        const char* filename, int fourcc, double fps, int width, int height,
+        int* params, unsigned n_params,
+        CV_OUT CvPluginWriter* handle
+    );
 
 } OpenCV_VideoIO_Plugin_API_preview;
 

--- a/modules/videoio/test/test_gstreamer.cpp
+++ b/modules/videoio/test/test_gstreamer.cpp
@@ -108,12 +108,15 @@ TEST(videoio_gstreamer, gray16_writing)
     // write noise frame to file using GStreamer
     std::ostringstream writer_pipeline;
     writer_pipeline << "appsrc ! filesink location=" << temp_file;
+    std::vector<int> params {
+        VIDEOWRITER_PROP_IS_COLOR, 0/*false*/,
+        VIDEOWRITER_PROP_DEPTH, CV_16U
+    };
     VideoWriter writer;
-    std::vector<int> params{ VIDEOWRITER_PROP_IS_COLOR, 0, VIDEOWRITER_PROP_DEPTH, CV_16U };
     ASSERT_NO_THROW(writer.open(writer_pipeline.str(), CAP_GSTREAMER, 0/*fourcc*/, 30/*fps*/, frame_size, params));
     ASSERT_TRUE(writer.isOpened());
     ASSERT_NO_THROW(writer.write(frame));
-    EXPECT_NO_THROW(writer.release());
+    ASSERT_NO_THROW(writer.release());
 
     // read noise frame back in
     Mat written_frame(frame_size, CV_16U);

--- a/modules/videoio/test/test_gstreamer.cpp
+++ b/modules/videoio/test/test_gstreamer.cpp
@@ -73,22 +73,60 @@ Param test_data[] = {
 
 INSTANTIATE_TEST_CASE_P(videoio, videoio_gstreamer, testing::ValuesIn(test_data));
 
-TEST(Videoio_GStreamer, unsupported_pipeline)
+TEST(videoio_gstreamer, unsupported_pipeline)
 {
-    VideoCaptureAPIs apiPref = CAP_GSTREAMER;
-    if (!isBackendAvailable(apiPref, cv::videoio_registry::getStreamBackends()))
-        throw SkipTestException(cv::String("Backend is not available/disabled: ") + cv::videoio_registry::getBackendName(apiPref));
+    if (!videoio_registry::hasBackend(CAP_GSTREAMER))
+        throw SkipTestException("GStreamer backend was not found");
 
     // could not link videoconvert0 to matroskamux0, matroskamux0 can't handle caps video/x-raw, format=(string)RGBA
     std::string pipeline = "appsrc ! videoconvert ! video/x-raw, format=(string)RGBA ! matroskamux ! filesink location=test.mkv";
     Size frame_size(640, 480);
 
     VideoWriter writer;
-    EXPECT_NO_THROW(writer.open(pipeline, apiPref, 0/*fourcc*/, 30/*fps*/, frame_size, true));
+    EXPECT_NO_THROW(writer.open(pipeline, CAP_GSTREAMER, 0/*fourcc*/, 30/*fps*/, frame_size, true));
     EXPECT_FALSE(writer.isOpened());
     // no frames
     EXPECT_NO_THROW(writer.release());
 
+}
+
+TEST(videoio_gstreamer, gray16_writing)
+{
+    if (!videoio_registry::hasBackend(CAP_GSTREAMER))
+        throw SkipTestException("GStreamer backend was not found");
+
+    Size frame_size(320, 240);
+
+    // generate a noise frame
+    Mat frame = Mat(frame_size, CV_16U);
+    randu(frame, 0, 65535);
+
+    // generate a temp filename, and fix path separators to how GStreamer expects them
+    cv::String temp_file = cv::tempfile(".raw");
+    std::replace(temp_file.begin(), temp_file.end(), '\\', '/');
+
+    // write noise frame to file using GStreamer
+    std::ostringstream writer_pipeline;
+    writer_pipeline << "appsrc ! filesink location=" << temp_file;
+    VideoWriter writer;
+    std::vector<int> params{ VIDEOWRITER_PROP_IS_COLOR, 0, VIDEOWRITER_PROP_DEPTH, CV_16U };
+    ASSERT_NO_THROW(writer.open(writer_pipeline.str(), CAP_GSTREAMER, 0/*fourcc*/, 30/*fps*/, frame_size, params));
+    ASSERT_TRUE(writer.isOpened());
+    ASSERT_NO_THROW(writer.write(frame));
+    EXPECT_NO_THROW(writer.release());
+
+    // read noise frame back in
+    Mat written_frame(frame_size, CV_16U);
+    std::ifstream fs(temp_file, std::ios::in | std::ios::binary);
+    fs.read((char*)written_frame.ptr(0), frame_size.width * frame_size.height * 2);
+    ASSERT_TRUE(fs);
+    fs.close();
+
+    // compare to make sure it's identical
+    EXPECT_EQ(0, cv::norm(frame, written_frame, NORM_INF));
+
+    // remove temp file
+    EXPECT_EQ(0, remove(temp_file.c_str()));
 }
 
 } // namespace


### PR DESCRIPTION
See #14035 for a companion PR to add CV_16UC1/GRAY16_LE capture support. I'm new to test writing, but added one that seems to make sense. I'm not clear if all PRs are still supposed to be based off 3.4, but I ran into roadblocks trying to build 3.4 at all, master just worked so easily.

<cut/>

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [x] The PR is proposed to proper branch
- [x] There is reference to original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake

```
force_builders=Linux AVX2,Custom
build_image:Custom=gstreamer:16.04
buildworker:Custom=linux-1,linux-2,linux-4
test_modules:Custom=videoio,python2,python3,java
```