### PR TITLE
Mat conversions for macOS/AppKit

### DIFF
--- a/cmake/templates/opencv_abi.xml.in
+++ b/cmake/templates/opencv_abi.xml.in
@@ -32,6 +32,7 @@
     opencv2/flann/hdf5.h
     opencv2/imgcodecs/imgcodecs_c.h
     opencv2/imgcodecs/ios.h
+    opencv2/imgcodecs/macosx.h
     opencv2/videoio/videoio_c.h
     opencv2/videoio/cap_ios.h
     opencv2/xobjdetect/private.hpp

--- a/modules/imgcodecs/CMakeLists.txt
+++ b/modules/imgcodecs/CMakeLists.txt
@@ -113,9 +113,17 @@ file(GLOB imgcodecs_ext_hdrs
      "${CMAKE_CURRENT_LIST_DIR}/include/opencv2/${name}/legacy/*.h"
      )
 
+if(APPLE)
+  list(APPEND imgcodecs_srcs ${CMAKE_CURRENT_LIST_DIR}/src/apple_conversions.h)
+  list(APPEND imgcodecs_srcs ${CMAKE_CURRENT_LIST_DIR}/src/apple_conversions.mm)
+endif()
 if(IOS)
   list(APPEND imgcodecs_srcs ${CMAKE_CURRENT_LIST_DIR}/src/ios_conversions.mm)
   list(APPEND IMGCODECS_LIBRARIES "-framework UIKit" "-framework AssetsLibrary")
+endif()
+if(APPLE AND (NOT IOS))
+  list(APPEND imgcodecs_srcs ${CMAKE_CURRENT_LIST_DIR}/src/macosx_conversions.mm)
+  list(APPEND IMGCODECS_LIBRARIES "-framework AppKit")
 endif()
 if(APPLE_FRAMEWORK)
   list(APPEND IMGCODECS_LIBRARIES "-framework Accelerate" "-framework CoreGraphics" "-framework QuartzCore")

--- a/modules/imgcodecs/include/opencv2/imgcodecs.hpp
+++ b/modules/imgcodecs/include/opencv2/imgcodecs.hpp
@@ -50,6 +50,7 @@
   @{
     @defgroup imgcodecs_c C API
     @defgroup imgcodecs_ios iOS glue
+    @defgroup imgcodecs_macosx MacOS(OSX) glue
   @}
 */
 

--- a/modules/imgcodecs/include/opencv2/imgcodecs/macosx.h
+++ b/modules/imgcodecs/include/opencv2/imgcodecs/macosx.h
@@ -1,45 +1,7 @@
 
-/*M///////////////////////////////////////////////////////////////////////////////////////
-//
-//  IMPORTANT: READ BEFORE DOWNLOADING, COPYING, INSTALLING OR USING.
-//
-//  By downloading, copying, installing or using the software you agree to this license.
-//  If you do not agree to this license, do not download, install,
-//  copy or use the software.
-//
-//
-//                          License Agreement
-//                For Open Source Computer Vision Library
-//
-// Copyright (C) 2000-2008, Intel Corporation, all rights reserved.
-// Copyright (C) 2009, Willow Garage Inc., all rights reserved.
-// Third party copyrights are property of their respective owners.
-//
-// Redistribution and use in source and binary forms, with or without modification,
-// are permitted provided that the following conditions are met:
-//
-//   * Redistribution's of source code must retain the above copyright notice,
-//     this list of conditions and the following disclaimer.
-//
-//   * Redistribution's in binary form must reproduce the above copyright notice,
-//     this list of conditions and the following disclaimer in the documentation
-//     and/or other materials provided with the distribution.
-//
-//   * The name of the copyright holders may not be used to endorse or promote products
-//     derived from this software without specific prior written permission.
-//
-// This software is provided by the copyright holders and contributors "as is" and
-// any express or implied warranties, including, but not limited to, the implied
-// warranties of merchantability and fitness for a particular purpose are disclaimed.
-// In no event shall the Intel Corporation or contributors be liable for any direct,
-// indirect, incidental, special, exemplary, or consequential damages
-// (including, but not limited to, procurement of substitute goods or services;
-// loss of use, data, or profits; or business interruption) however caused
-// and on any theory of liability, whether in contract, strict liability,
-// or tort (including negligence or otherwise) arising in any way out of
-// the use of this software, even if advised of the possibility of such damage.
-//
-//M*/
+// This file is part of OpenCV project.
+// It is subject to the license terms in the LICENSE file found in the top-level directory
+// of this distribution and at http://opencv.org/license.html.
 
 #import <AppKit/AppKit.h>
 #import <Accelerate/Accelerate.h>

--- a/modules/imgcodecs/include/opencv2/imgcodecs/macosx.h
+++ b/modules/imgcodecs/include/opencv2/imgcodecs/macosx.h
@@ -3,6 +3,10 @@
 // It is subject to the license terms in the LICENSE file found in the top-level directory
 // of this distribution and at http://opencv.org/license.html.
 
+#if !defined(__APPLE__) && !defined(__MACH__)
+#error This header should be used in macOS ObjC/Swift projects.
+#endif
+
 #import <AppKit/AppKit.h>
 #import <Accelerate/Accelerate.h>
 #import <AVFoundation/AVFoundation.h>

--- a/modules/imgcodecs/include/opencv2/imgcodecs/macosx.h
+++ b/modules/imgcodecs/include/opencv2/imgcodecs/macosx.h
@@ -1,0 +1,58 @@
+
+/*M///////////////////////////////////////////////////////////////////////////////////////
+//
+//  IMPORTANT: READ BEFORE DOWNLOADING, COPYING, INSTALLING OR USING.
+//
+//  By downloading, copying, installing or using the software you agree to this license.
+//  If you do not agree to this license, do not download, install,
+//  copy or use the software.
+//
+//
+//                          License Agreement
+//                For Open Source Computer Vision Library
+//
+// Copyright (C) 2000-2008, Intel Corporation, all rights reserved.
+// Copyright (C) 2009, Willow Garage Inc., all rights reserved.
+// Third party copyrights are property of their respective owners.
+//
+// Redistribution and use in source and binary forms, with or without modification,
+// are permitted provided that the following conditions are met:
+//
+//   * Redistribution's of source code must retain the above copyright notice,
+//     this list of conditions and the following disclaimer.
+//
+//   * Redistribution's in binary form must reproduce the above copyright notice,
+//     this list of conditions and the following disclaimer in the documentation
+//     and/or other materials provided with the distribution.
+//
+//   * The name of the copyright holders may not be used to endorse or promote products
+//     derived from this software without specific prior written permission.
+//
+// This software is provided by the copyright holders and contributors "as is" and
+// any express or implied warranties, including, but not limited to, the implied
+// warranties of merchantability and fitness for a particular purpose are disclaimed.
+// In no event shall the Intel Corporation or contributors be liable for any direct,
+// indirect, incidental, special, exemplary, or consequential damages
+// (including, but not limited to, procurement of substitute goods or services;
+// loss of use, data, or profits; or business interruption) however caused
+// and on any theory of liability, whether in contract, strict liability,
+// or tort (including negligence or otherwise) arising in any way out of
+// the use of this software, even if advised of the possibility of such damage.
+//
+//M*/
+
+#import <AppKit/AppKit.h>
+#import <Accelerate/Accelerate.h>
+#import <AVFoundation/AVFoundation.h>
+#import <ImageIO/ImageIO.h>
+#include "opencv2/core.hpp"
+
+//! @addtogroup imgcodecs_macosx
+//! @{
+
+CV_EXPORTS CGImageRef MatToCGImage(const cv::Mat& image);
+CV_EXPORTS void CGImageToMat(const CGImageRef image, cv::Mat& m, bool alphaExist = false);
+CV_EXPORTS NSImage* MatToNSImage(const cv::Mat& image);
+CV_EXPORTS void NSImageToMat(const NSImage* image, cv::Mat& m, bool alphaExist = false);
+
+//! @}

--- a/modules/imgcodecs/include/opencv2/imgcodecs/macosx.h
+++ b/modules/imgcodecs/include/opencv2/imgcodecs/macosx.h
@@ -8,9 +8,6 @@
 #endif
 
 #import <AppKit/AppKit.h>
-#import <Accelerate/Accelerate.h>
-#import <AVFoundation/AVFoundation.h>
-#import <ImageIO/ImageIO.h>
 #include "opencv2/core.hpp"
 
 //! @addtogroup imgcodecs_macosx

--- a/modules/imgcodecs/include/opencv2/imgcodecs/macosx.h
+++ b/modules/imgcodecs/include/opencv2/imgcodecs/macosx.h
@@ -1,9 +1,8 @@
-
 // This file is part of OpenCV project.
 // It is subject to the license terms in the LICENSE file found in the top-level directory
 // of this distribution and at http://opencv.org/license.html.
 
-#if !defined(__APPLE__) && !defined(__MACH__)
+#if !defined(__APPLE__) || !defined(__MACH__)
 #error This header should be used in macOS ObjC/Swift projects.
 #endif
 

--- a/modules/imgcodecs/misc/objc/macosx/Mat+Converters.h
+++ b/modules/imgcodecs/misc/objc/macosx/Mat+Converters.h
@@ -1,0 +1,32 @@
+//
+//  Mat+Converters.h
+//
+//  Created by Masaya Tsuruta on 2020/10/08.
+//
+
+#pragma once
+
+#ifdef __cplusplus
+#import "opencv.hpp"
+#else
+#define CV_EXPORTS
+#endif
+
+#import <Foundation/Foundation.h>
+#import <AppKit/AppKit.h>
+#import "Mat.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+CV_EXPORTS @interface Mat (Converters)
+
+-(CGImageRef)toCGImage;
+-(instancetype)initWithCGImage:(CGImageRef)image;
+-(instancetype)initWithCGImage:(CGImageRef)image alphaExist:(BOOL)alphaExist;
+-(NSImage*)toNSImage;
+-(instancetype)initWithNSImage:(NSImage*)image;
+-(instancetype)initWithNSImage:(NSImage*)image alphaExist:(BOOL)alphaExist;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/modules/imgcodecs/misc/objc/macosx/Mat+Converters.mm
+++ b/modules/imgcodecs/misc/objc/macosx/Mat+Converters.mm
@@ -1,0 +1,44 @@
+//
+//  Mat+Converters.mm
+//
+//  Created by Masaya Tsuruta on 2020/10/08.
+//
+
+#import "Mat+Converters.h"
+#import <opencv2/imgcodecs/macosx.h>
+
+@implementation Mat (Converters)
+
+-(CGImageRef)toCGImage {
+    return MatToCGImage(self.nativeRef);
+}
+
+-(instancetype)initWithCGImage:(CGImageRef)image {
+    return [self initWithCGImage:image alphaExist:NO];
+}
+
+-(instancetype)initWithCGImage:(CGImageRef)image alphaExist:(BOOL)alphaExist {
+    self = [self init];
+    if (self) {
+        CGImageToMat(image, self.nativeRef, (bool)alphaExist);
+    }
+    return self;
+}
+
+-(NSImage*)toNSImage {
+    return MatToNSImage(self.nativeRef);
+}
+
+-(instancetype)initWithNSImage:(NSImage*)image {
+    return [self initWithNSImage:image alphaExist:NO];
+}
+
+-(instancetype)initWithNSImage:(NSImage*)image alphaExist:(BOOL)alphaExist {
+    self = [self init];
+    if (self) {
+        NSImageToMat(image, self.nativeRef, (bool)alphaExist);
+    }
+    return self;
+}
+
+@end

--- a/modules/imgcodecs/src/apple_conversions.h
+++ b/modules/imgcodecs/src/apple_conversions.h
@@ -40,24 +40,11 @@
 //
 //M*/
 
-#import <UIKit/UIKit.h>
-#include "apple_conversions.h"
+#import <Accelerate/Accelerate.h>
+#import <AVFoundation/AVFoundation.h>
+#import <ImageIO/ImageIO.h>
+#include "opencv2/core.hpp"
+#include "precomp.hpp"
 
-CV_EXPORTS UIImage* MatToUIImage(const cv::Mat& image);
-CV_EXPORTS void UIImageToMat(const UIImage* image, cv::Mat& m, bool alphaExist);
-
-UIImage* MatToUIImage(const cv::Mat& image) {
-    // Creating CGImage from cv::Mat
-    CGImageRef imageRef = MatToCGImage(image);
-
-    // Getting UIImage from CGImage
-    UIImage *uiImage = [UIImage imageWithCGImage:imageRef];
-    CGImageRelease(imageRef);
-
-    return uiImage;
-}
-
-void UIImageToMat(const UIImage* image, cv::Mat& m, bool alphaExist) {
-    CGImageRef imageRef = image.CGImage;
-    CGImageToMat(imageRef, m, alphaExist);
-}
+CV_EXPORTS CGImageRef MatToCGImage(const cv::Mat& image);
+CV_EXPORTS void CGImageToMat(const CGImageRef image, cv::Mat& m, bool alphaExist);

--- a/modules/imgcodecs/src/apple_conversions.h
+++ b/modules/imgcodecs/src/apple_conversions.h
@@ -1,44 +1,6 @@
-/*M///////////////////////////////////////////////////////////////////////////////////////
-//
-//  IMPORTANT: READ BEFORE DOWNLOADING, COPYING, INSTALLING OR USING.
-//
-//  By downloading, copying, installing or using the software you agree to this license.
-//  If you do not agree to this license, do not download, install,
-//  copy or use the software.
-//
-//
-//                          License Agreement
-//                For Open Source Computer Vision Library
-//
-// Copyright (C) 2000-2008, Intel Corporation, all rights reserved.
-// Copyright (C) 2009, Willow Garage Inc., all rights reserved.
-// Third party copyrights are property of their respective owners.
-//
-// Redistribution and use in source and binary forms, with or without modification,
-// are permitted provided that the following conditions are met:
-//
-//   * Redistribution's of source code must retain the above copyright notice,
-//     this list of conditions and the following disclaimer.
-//
-//   * Redistribution's in binary form must reproduce the above copyright notice,
-//     this list of conditions and the following disclaimer in the documentation
-//     and/or other materials provided with the distribution.
-//
-//   * The name of the copyright holders may not be used to endorse or promote products
-//     derived from this software without specific prior written permission.
-//
-// This software is provided by the copyright holders and contributors "as is" and
-// any express or implied warranties, including, but not limited to, the implied
-// warranties of merchantability and fitness for a particular purpose are disclaimed.
-// In no event shall the Intel Corporation or contributors be liable for any direct,
-// indirect, incidental, special, exemplary, or consequential damages
-// (including, but not limited to, procurement of substitute goods or services;
-// loss of use, data, or profits; or business interruption) however caused
-// and on any theory of liability, whether in contract, strict liability,
-// or tort (including negligence or otherwise) arising in any way out of
-// the use of this software, even if advised of the possibility of such damage.
-//
-//M*/
+// This file is part of OpenCV project.
+// It is subject to the license terms in the LICENSE file found in the top-level directory
+// of this distribution and at http://opencv.org/license.html.
 
 #import <Accelerate/Accelerate.h>
 #import <AVFoundation/AVFoundation.h>

--- a/modules/imgcodecs/src/apple_conversions.h
+++ b/modules/imgcodecs/src/apple_conversions.h
@@ -44,7 +44,6 @@
 #import <AVFoundation/AVFoundation.h>
 #import <ImageIO/ImageIO.h>
 #include "opencv2/core.hpp"
-#include "precomp.hpp"
 
 CV_EXPORTS CGImageRef MatToCGImage(const cv::Mat& image);
 CV_EXPORTS void CGImageToMat(const CGImageRef image, cv::Mat& m, bool alphaExist);

--- a/modules/imgcodecs/src/apple_conversions.mm
+++ b/modules/imgcodecs/src/apple_conversions.mm
@@ -1,0 +1,135 @@
+/*M///////////////////////////////////////////////////////////////////////////////////////
+//
+//  IMPORTANT: READ BEFORE DOWNLOADING, COPYING, INSTALLING OR USING.
+//
+//  By downloading, copying, installing or using the software you agree to this license.
+//  If you do not agree to this license, do not download, install,
+//  copy or use the software.
+//
+//
+//                          License Agreement
+//                For Open Source Computer Vision Library
+//
+// Copyright (C) 2000-2008, Intel Corporation, all rights reserved.
+// Copyright (C) 2009, Willow Garage Inc., all rights reserved.
+// Third party copyrights are property of their respective owners.
+//
+// Redistribution and use in source and binary forms, with or without modification,
+// are permitted provided that the following conditions are met:
+//
+//   * Redistribution's of source code must retain the above copyright notice,
+//     this list of conditions and the following disclaimer.
+//
+//   * Redistribution's in binary form must reproduce the above copyright notice,
+//     this list of conditions and the following disclaimer in the documentation
+//     and/or other materials provided with the distribution.
+//
+//   * The name of the copyright holders may not be used to endorse or promote products
+//     derived from this software without specific prior written permission.
+//
+// This software is provided by the copyright holders and contributors "as is" and
+// any express or implied warranties, including, but not limited to, the implied
+// warranties of merchantability and fitness for a particular purpose are disclaimed.
+// In no event shall the Intel Corporation or contributors be liable for any direct,
+// indirect, incidental, special, exemplary, or consequential damages
+// (including, but not limited to, procurement of substitute goods or services;
+// loss of use, data, or profits; or business interruption) however caused
+// and on any theory of liability, whether in contract, strict liability,
+// or tort (including negligence or otherwise) arising in any way out of
+// the use of this software, even if advised of the possibility of such damage.
+//
+//M*/
+
+#include "apple_conversions.h"
+
+CV_EXPORTS CGImageRef MatToCGImage(const cv::Mat& image);
+CV_EXPORTS void CGImageToMat(const CGImageRef image, cv::Mat& m, bool alphaExist);
+
+CGImageRef MatToCGImage(const cv::Mat& image) {
+    NSData *data = [NSData dataWithBytes:image.data
+                                  length:image.step.p[0] * image.rows];
+
+    CGColorSpaceRef colorSpace;
+
+    if (image.elemSize() == 1) {
+        colorSpace = CGColorSpaceCreateDeviceGray();
+    } else {
+        colorSpace = CGColorSpaceCreateDeviceRGB();
+    }
+
+    CGDataProviderRef provider =
+            CGDataProviderCreateWithCFData((__bridge CFDataRef)data);
+
+    // Preserve alpha transparency, if exists
+    bool alpha = image.channels() == 4;
+    CGBitmapInfo bitmapInfo = (alpha ? kCGImageAlphaLast : kCGImageAlphaNone) | kCGBitmapByteOrderDefault;
+
+    // Creating CGImage from cv::Mat
+    CGImageRef imageRef = CGImageCreate(image.cols,
+                                        image.rows,
+                                        8 * image.elemSize1(),
+                                        8 * image.elemSize(),
+                                        image.step.p[0],
+                                        colorSpace,
+                                        bitmapInfo,
+                                        provider,
+                                        NULL,
+                                        false,
+                                        kCGRenderingIntentDefault
+                                        );
+
+    //CGImageRelease(imageRef);
+    CGDataProviderRelease(provider);
+    CGColorSpaceRelease(colorSpace);
+
+    return imageRef;
+}
+
+void CGImageToMat(const CGImageRef image, cv::Mat& m, bool alphaExist) {
+    CGColorSpaceRef colorSpace = CGImageGetColorSpace(image);
+    CGFloat cols = CGImageGetWidth(image), rows = CGImageGetHeight(image);
+    CGContextRef contextRef;
+    CGBitmapInfo bitmapInfo = kCGImageAlphaPremultipliedLast;
+    if (CGColorSpaceGetModel(colorSpace) == kCGColorSpaceModelMonochrome)
+    {
+        m.create(rows, cols, CV_8UC1); // 8 bits per component, 1 channel
+        bitmapInfo = kCGImageAlphaNone;
+        if (!alphaExist)
+            bitmapInfo = kCGImageAlphaNone;
+        else
+            m = cv::Scalar(0);
+        contextRef = CGBitmapContextCreate(m.data, m.cols, m.rows, 8,
+                                           m.step[0], colorSpace,
+                                           bitmapInfo);
+    }
+    else if (CGColorSpaceGetModel(colorSpace) == kCGColorSpaceModelIndexed)
+    {
+        // CGBitmapContextCreate() does not support indexed color spaces.
+        colorSpace = CGColorSpaceCreateDeviceRGB();
+        m.create(rows, cols, CV_8UC4); // 8 bits per component, 4 channels
+        if (!alphaExist)
+            bitmapInfo = kCGImageAlphaNoneSkipLast |
+                                kCGBitmapByteOrderDefault;
+        else
+            m = cv::Scalar(0);
+        contextRef = CGBitmapContextCreate(m.data, m.cols, m.rows, 8,
+                                           m.step[0], colorSpace,
+                                           bitmapInfo);
+        CGColorSpaceRelease(colorSpace);
+    }
+    else
+    {
+        m.create(rows, cols, CV_8UC4); // 8 bits per component, 4 channels
+        if (!alphaExist)
+            bitmapInfo = kCGImageAlphaNoneSkipLast |
+                                kCGBitmapByteOrderDefault;
+        else
+            m = cv::Scalar(0);
+        contextRef = CGBitmapContextCreate(m.data, m.cols, m.rows, 8,
+                                           m.step[0], colorSpace,
+                                           bitmapInfo);
+    }
+    CGContextDrawImage(contextRef, CGRectMake(0, 0, cols, rows),
+                       image);
+    CGContextRelease(contextRef);
+}

--- a/modules/imgcodecs/src/apple_conversions.mm
+++ b/modules/imgcodecs/src/apple_conversions.mm
@@ -1,44 +1,6 @@
-/*M///////////////////////////////////////////////////////////////////////////////////////
-//
-//  IMPORTANT: READ BEFORE DOWNLOADING, COPYING, INSTALLING OR USING.
-//
-//  By downloading, copying, installing or using the software you agree to this license.
-//  If you do not agree to this license, do not download, install,
-//  copy or use the software.
-//
-//
-//                          License Agreement
-//                For Open Source Computer Vision Library
-//
-// Copyright (C) 2000-2008, Intel Corporation, all rights reserved.
-// Copyright (C) 2009, Willow Garage Inc., all rights reserved.
-// Third party copyrights are property of their respective owners.
-//
-// Redistribution and use in source and binary forms, with or without modification,
-// are permitted provided that the following conditions are met:
-//
-//   * Redistribution's of source code must retain the above copyright notice,
-//     this list of conditions and the following disclaimer.
-//
-//   * Redistribution's in binary form must reproduce the above copyright notice,
-//     this list of conditions and the following disclaimer in the documentation
-//     and/or other materials provided with the distribution.
-//
-//   * The name of the copyright holders may not be used to endorse or promote products
-//     derived from this software without specific prior written permission.
-//
-// This software is provided by the copyright holders and contributors "as is" and
-// any express or implied warranties, including, but not limited to, the implied
-// warranties of merchantability and fitness for a particular purpose are disclaimed.
-// In no event shall the Intel Corporation or contributors be liable for any direct,
-// indirect, incidental, special, exemplary, or consequential damages
-// (including, but not limited to, procurement of substitute goods or services;
-// loss of use, data, or profits; or business interruption) however caused
-// and on any theory of liability, whether in contract, strict liability,
-// or tort (including negligence or otherwise) arising in any way out of
-// the use of this software, even if advised of the possibility of such damage.
-//
-//M*/
+// This file is part of OpenCV project.
+// It is subject to the license terms in the LICENSE file found in the top-level directory
+// of this distribution and at http://opencv.org/license.html.
 
 #include "apple_conversions.h"
 #include "precomp.hpp"

--- a/modules/imgcodecs/src/apple_conversions.mm
+++ b/modules/imgcodecs/src/apple_conversions.mm
@@ -38,7 +38,6 @@ CGImageRef MatToCGImage(const cv::Mat& image) {
                                         kCGRenderingIntentDefault
                                         );
 
-    //CGImageRelease(imageRef);
     CGDataProviderRelease(provider);
     CGColorSpaceRelease(colorSpace);
 

--- a/modules/imgcodecs/src/apple_conversions.mm
+++ b/modules/imgcodecs/src/apple_conversions.mm
@@ -41,6 +41,7 @@
 //M*/
 
 #include "apple_conversions.h"
+#include "precomp.hpp"
 
 CGImageRef MatToCGImage(const cv::Mat& image) {
     NSData *data = [NSData dataWithBytes:image.data

--- a/modules/imgcodecs/src/apple_conversions.mm
+++ b/modules/imgcodecs/src/apple_conversions.mm
@@ -42,9 +42,6 @@
 
 #include "apple_conversions.h"
 
-CV_EXPORTS CGImageRef MatToCGImage(const cv::Mat& image);
-CV_EXPORTS void CGImageToMat(const CGImageRef image, cv::Mat& m, bool alphaExist);
-
 CGImageRef MatToCGImage(const cv::Mat& image) {
     NSData *data = [NSData dataWithBytes:image.data
                                   length:image.step.p[0] * image.rows];

--- a/modules/imgcodecs/src/macosx_conversions.mm
+++ b/modules/imgcodecs/src/macosx_conversions.mm
@@ -1,44 +1,6 @@
-/*M///////////////////////////////////////////////////////////////////////////////////////
-//
-//  IMPORTANT: READ BEFORE DOWNLOADING, COPYING, INSTALLING OR USING.
-//
-//  By downloading, copying, installing or using the software you agree to this license.
-//  If you do not agree to this license, do not download, install,
-//  copy or use the software.
-//
-//
-//                          License Agreement
-//                For Open Source Computer Vision Library
-//
-// Copyright (C) 2000-2008, Intel Corporation, all rights reserved.
-// Copyright (C) 2009, Willow Garage Inc., all rights reserved.
-// Third party copyrights are property of their respective owners.
-//
-// Redistribution and use in source and binary forms, with or without modification,
-// are permitted provided that the following conditions are met:
-//
-//   * Redistribution's of source code must retain the above copyright notice,
-//     this list of conditions and the following disclaimer.
-//
-//   * Redistribution's in binary form must reproduce the above copyright notice,
-//     this list of conditions and the following disclaimer in the documentation
-//     and/or other materials provided with the distribution.
-//
-//   * The name of the copyright holders may not be used to endorse or promote products
-//     derived from this software without specific prior written permission.
-//
-// This software is provided by the copyright holders and contributors "as is" and
-// any express or implied warranties, including, but not limited to, the implied
-// warranties of merchantability and fitness for a particular purpose are disclaimed.
-// In no event shall the Intel Corporation or contributors be liable for any direct,
-// indirect, incidental, special, exemplary, or consequential damages
-// (including, but not limited to, procurement of substitute goods or services;
-// loss of use, data, or profits; or business interruption) however caused
-// and on any theory of liability, whether in contract, strict liability,
-// or tort (including negligence or otherwise) arising in any way out of
-// the use of this software, even if advised of the possibility of such damage.
-//
-//M*/
+// This file is part of OpenCV project.
+// It is subject to the license terms in the LICENSE file found in the top-level directory
+// of this distribution and at http://opencv.org/license.html.
 
 #import <AppKit/AppKit.h>
 #include "apple_conversions.h"

--- a/modules/imgcodecs/src/macosx_conversions.mm
+++ b/modules/imgcodecs/src/macosx_conversions.mm
@@ -40,24 +40,24 @@
 //
 //M*/
 
-#import <UIKit/UIKit.h>
+#import <AppKit/AppKit.h>
 #include "apple_conversions.h"
 
-CV_EXPORTS UIImage* MatToUIImage(const cv::Mat& image);
-CV_EXPORTS void UIImageToMat(const UIImage* image, cv::Mat& m, bool alphaExist);
+CV_EXPORTS NSImage* MatToNSImage(const cv::Mat& image);
+CV_EXPORTS void NSImageToMat(const NSImage* image, cv::Mat& m, bool alphaExist);
 
-UIImage* MatToUIImage(const cv::Mat& image) {
+NSImage* MatToNSImage(const cv::Mat& image) {
     // Creating CGImage from cv::Mat
     CGImageRef imageRef = MatToCGImage(image);
 
-    // Getting UIImage from CGImage
-    UIImage *uiImage = [UIImage imageWithCGImage:imageRef];
+    // Getting NSImage from CGImage
+    NSImage *nsImage = [[NSImage alloc] initWithCGImage:imageRef size:CGSizeMake(CGImageGetWidth(imageRef), CGImageGetHeight(imageRef))];
     CGImageRelease(imageRef);
 
-    return uiImage;
+    return nsImage;
 }
 
-void UIImageToMat(const UIImage* image, cv::Mat& m, bool alphaExist) {
-    CGImageRef imageRef = image.CGImage;
+void NSImageToMat(const NSImage* image, cv::Mat& m, bool alphaExist) {
+    CGImageRef imageRef = [image CGImageForProposedRect:NULL context:NULL hints:NULL];
     CGImageToMat(imageRef, m, alphaExist);
 }

--- a/modules/objc/generator/gen_objc.py
+++ b/modules/objc/generator/gen_objc.py
@@ -1584,6 +1584,11 @@ if __name__ == "__main__":
             if os.path.exists(ios_files_dir):
                 copied_files += copy_objc_files(ios_files_dir, objc_base_path, module, True)
 
+        if args.target == 'osx':
+            osx_files_dir = os.path.join(misc_location, 'macosx')
+            if os.path.exists(osx_files_dir):
+                copied_files += copy_objc_files(osx_files_dir, objc_base_path, module, True)
+
         objc_test_files_dir = os.path.join(misc_location, 'test')
         if os.path.exists(objc_test_files_dir):
             copy_objc_files(objc_test_files_dir, objc_test_base_path, 'test', False)


### PR DESCRIPTION
This PR solves https://github.com/opencv/opencv/issues/18546.
It consists

- Extract CoreGraphics conversion logics from ios_conversions.mm to apple_conversions.h, apple_conversions.mm (MatToCGImage(), CGImageToMat())
- Simplify ios_conversions.mm
- Add macosx_conversions.mm for macOS/AppKit (MatToNSImage(), NSImageToMat())
- Add Mat+Conversions.h and Mat+Conversions.mm for macOS/AppKit

<cut/>

**Usage example in Swift:**
**※ Don't forget to set the `-all_load` flag to "Other Linker Flags" in "Build Settings" when using!** https://github.com/opencv/opencv/issues/17532
```
// CGImage to Mat
let sourceMat = Mat(cgImage: cgImage, alphaExist: true)

// NSImage to Mat
let sourceMat = Mat(nsImage: nsImage, alphaExist: true)

// Something to process
let grayMat = Mat()
Imgproc.cvtColor(src: sourceMat, dst: grayMat, code: .COLOR_RGBA2GRAY)

// Mat to CGImage
let cgImage = grayMat.toCGImage().takeRetainedValue() // or .takeUnetainedValue()

// Mat to NSImage
let nsImage = grayMat.toNSImage()
```

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [x] The PR is proposed to proper branch
- [x] There is reference to original bug report and related work


```
force_builders=Custom Mac
build_image:Custom Mac=osx_framework

buildworker:iOS=macosx-1
```