### PR TITLE
Fix warnings: "-Wrange-loop-construct" in gapi

### DIFF
--- a/modules/gapi/src/backends/fluid/gfluidbackend.cpp
+++ b/modules/gapi/src/backends/fluid/gfluidbackend.cpp
@@ -952,7 +952,7 @@ namespace
         using namespace cv::gimpl;
         GModel::Graph g(graph);
         GFluidModel fg(graph);
-        for (const auto node : g.nodes())
+        for (const auto& node : g.nodes())
         {
             if (g.metadata(node).get<NodeType>().t == NodeType::DATA)
             {
@@ -1440,7 +1440,7 @@ void GFluidBackendImpl::addMetaSensitiveBackendPasses(ade::ExecutionEngineSetupC
                 {
                     // Add FluidData to all data nodes inside island,
                     // set internal = true if node is not a slot in terms of higher-level GIslandModel
-                    for (const auto node : isl->contents())
+                    for (const auto& node : isl->contents())
                     {
                         if (g.metadata(node).get<NodeType>().t == NodeType::DATA &&
                             !fg.metadata(node).contains<FluidData>())

--- a/modules/gapi/src/compiler/passes/exec.cpp
+++ b/modules/gapi/src/compiler/passes/exec.cpp
@@ -71,12 +71,12 @@ namespace
 
         all.insert(src_g.nodes().begin(), src_g.nodes().end());
 
-        for (const auto nh : proto.in_nhs)
+        for (const auto& nh : proto.in_nhs)
         {
             all.erase(nh);
             in_ops.insert(nh->outNodes().begin(), nh->outNodes().end());
         }
-        for (const auto nh : proto.out_nhs)
+        for (const auto& nh : proto.out_nhs)
         {
             all.erase(nh);
             out_ops.insert(nh->inNodes().begin(), nh->inNodes().end());
@@ -90,12 +90,12 @@ namespace
 
         auto ih = GIslandModel::mkIslandNode(g, std::move(isl));
 
-        for (const auto nh : proto.in_nhs)
+        for (const auto& nh : proto.in_nhs)
         {
             auto slot = GIslandModel::mkSlotNode(g, nh);
             g.link(slot, ih);
         }
-        for (const auto nh : proto.out_nhs)
+        for (const auto& nh : proto.out_nhs)
         {
             auto slot = GIslandModel::mkSlotNode(g, nh);
             g.link(ih, slot);


### PR DESCRIPTION
Fix warning in clang version 10.0.0-4ubuntu1
```
warning: loop variable 'nh' of type 'const ade::Handle<ade::Node>' creates a copy from type 'const ade::Handle<ade::Node>' [-Wrange-loop-construct]
```

<cut/>

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [ ] I agree to contribute to the project under Apache 2 License.
- [ ] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [ ] The PR is proposed to proper branch
- [ ] There is reference to original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake

```
force_builders=ARMv7,Custom
build_image:Custom=centos:7
buildworker:Custom=linux-1
```
