### PR TITLE
release: OpenCV 3.4.12

### DIFF
--- a/modules/core/include/opencv2/core/version.hpp
+++ b/modules/core/include/opencv2/core/version.hpp
@@ -8,7 +8,7 @@
 #define CV_VERSION_MAJOR    3
 #define CV_VERSION_MINOR    4
 #define CV_VERSION_REVISION 12
-#define CV_VERSION_STATUS   "-pre"
+#define CV_VERSION_STATUS   ""
 
 #define CVAUX_STR_EXP(__A)  #__A
 #define CVAUX_STR(__A)      CVAUX_STR_EXP(__A)


### PR DESCRIPTION
OpenCV 3.4.12

relates #18282

<cut/>

<details>

<summary>VirusTotal scan results:</summary>

[opencv_world3412.dll (vc14)](https://www.virustotal.com/gui/file/b92d1901d363ca5eb2ec887b7363c3d444107deba4c2229d70d3c739abfc4923/detection)
[opencv_world3412d.dll (vc14)](https://www.virustotal.com/gui/file/cfda706e01e43151029b22802f08ea776a24744af25691b32e9b5140772da350/detection)
[opencv_world3412.dll (vc15)](https://www.virustotal.com/gui/file/994f6b832c2d9fdb53e28f9bdf0fb57428e787da237d7a844588d7323e0fb78d/detection)
[opencv_world3412d.dll (vc15)](https://www.virustotal.com/gui/file/01bb89bd9a71790afeac9f6996d23a77fa38d19cd4d2251c4e3de0fc2958be0c/detection)

[opencv_ffmpeg3412_64.dll](https://www.virustotal.com/gui/file/2abd4c09ef76e913bde03929d8a0c31b5515772f682551acb43a2914d4bd42d0/detection)

</details>
