### PR TITLE
Add Mat data pointer bridging method for Objective-C/Swift

### DIFF
--- a/modules/core/misc/objc/common/Mat.h
+++ b/modules/core/misc/objc/common/Mat.h
@@ -97,6 +97,7 @@ CV_EXPORTS @interface Mat : NSObject
 - (void)createEx:(NSArray<NSNumber*>*)sizes type:(int)type  NS_SWIFT_NAME(create(sizes:type:));
 - (void)copySize:(Mat*)mat;
 - (Mat*)cross:(Mat*)mat;
+- (unsigned char*)dataPtr NS_SWIFT_NAME(dataPointer());
 - (int)depth;
 - (Mat*)diag:(int)diagonal;
 - (Mat*)diag;

--- a/modules/core/misc/objc/common/Mat.mm
+++ b/modules/core/misc/objc/common/Mat.mm
@@ -286,6 +286,10 @@ static bool updateIdx(cv::Mat* mat, std::vector<int>& indices, int inc) {
     return [[Mat alloc] initWithNativeMat:new cv::Mat(_nativePtr->cross(*(cv::Mat*)mat.nativePtr))];
 }
 
+- (unsigned char*)dataPtr {
+    return _nativePtr->data;
+}
+
 - (int)depth {
     return _nativePtr->depth();
 }


### PR DESCRIPTION
Added because there was no method to get Mat data directly in Objective-C or Swift.

Usage example in Swift:
```
let mat = Mat.zeros(Size(width: 256, height: 256), type: CvType.CV_8UC4)
let dataPointer = mat.dataPointer() // <- UnsafeMutablePointer<UInt8>
let data = Data(bytes: dataPointer, count: bytesPerPixel * pixels)
```

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [x] The PR is proposed to proper branch
- [x] There is reference to original bug report and related work

```
force_builders=Custom Mac
build_image:Custom Mac=osx_framework

buildworker:iOS=macosx-1
```