### PR TITLE
Merge 3.4

### DIFF
--- a/cmake/OpenCVDetectCUDA.cmake
+++ b/cmake/OpenCVDetectCUDA.cmake
@@ -208,7 +208,7 @@ if(CUDA_FOUND)
 
       if(${status} EQUAL 0)
         # cache detected values
-        set(OPENCV_CACHE_CUDA_ACTIVE_CC ${${result_list}} CACHE INTERNAL "")
+        set(OPENCV_CACHE_CUDA_ACTIVE_CC ${${output}} CACHE INTERNAL "")
         set(OPENCV_CACHE_CUDA_ACTIVE_CC_check "${__cache_key_check}" CACHE INTERNAL "")
       endif()
     endif()


### PR DESCRIPTION
#18557 from alalek:cuda_cmake_fix_auto

Previous "Merge 3.4": #18556

<cut/>

```
Xci_branch=merge-3.4
buildworker:Win64 OpenCL=windows-2
#buildworker:Custom=linux-1,linux-2,linux-4
xbuild_image:Docs=docs-js
#build_image:Custom=javascript
xbuildworker:Custom=linux-4
Xbuild_image:Custom=javascript-simd:1.39.16
build_image:Custom=javascript-simd
#build_image:Custom=powerpc64le
#build_image:Custom=ubuntu-openvino-2019r3.0:16.04
#build_image:Custom=ubuntu-openvino-2020.3.0:16.04
#build_image:Custom=ubuntu-openvino-2020.4.0:16.04
build_image:Custom=ubuntu-openvino-2021.1.0:20.04
buildworker:Custom=linux-1
#build_image:Custom=ubuntu-vulkan:16.04
#buildworker:Custom=linux-4
#build_image:Custom=fedora:28
#build_image:Custom=ubuntu-cuda:16.04
#build_image:Custom=ubuntu-clang:18.04
#build_image:Custom=ubuntu:20.04
#buildworker:Custom=linux-1
#build_image:Custom=javascript-simd
#build_image:Custom=mips64el
#build_image:Custom Mac=openvino-2019r3.0
#build_image:Custom Mac=openvino-2020.3.0
Xbuild_image:Custom Mac=openvino-2020.4.0
build_image:Custom Mac=openvino-2021.1.0
#build_image:Custom Win=openvino-2019r3.0
#build_image:Custom Win=openvino-2020.3.0
Xbuild_image:Custom Win=openvino-2020.4.0
build_image:Custom Win=openvino-2021.1.0
test_bigdata:Custom Win=1
test_filter:Custom Win=*
test_modules=dnn,python2,python3,java
test_opencl:Custom Win=OFF
#build_image:Custom Win=msvs2017
#build_image:Custom Win=msvs2019
test_modules:Custom Mac=dnn,java,python3
```
