### PR TITLE
Update calibCommon.hpp

### DIFF
--- a/apps/interactive-calibration/calibCommon.hpp
+++ b/apps/interactive-calibration/calibCommon.hpp
@@ -53,7 +53,7 @@ namespace calib
 
         cv::Mat undistMap1, undistMap2;
 
-        calibrationData()
+        calibrationData() //Not all members of a class are initialized inside the constructor.
         {
             imageSize = cv::Size(IMAGE_MAX_WIDTH, IMAGE_MAX_HEIGHT);
         }


### PR DESCRIPTION
Found a security issue in the codebase. 
Line 56 Issue: Not all members of a class are initialized inside the constructor.

Here's a simple synthetic example:
```
struct MyPoint
{
  int m_x, m_y;
  MyPoint() { m_x = 0; }
  void Print() { cout << m_x << " " << m_y; }
};
MyPoint Point;
Point.Print();
```
When creating the Point object, a constructor will be called that won't initialize the 'm_y' member. Accordingly, when calling the Print function, an uninitialized variable will be used. The consequences of this are unpredictable.

The correct version of the constructor should look like this:
```
MyPoint() { m_x = 0; m_y = 0; }
```

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [X] I agree to contribute to the project under Apache 2 License.
- [X] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [X] The PR is proposed to proper branch
- [X] There is reference to original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [X] The feature is well documented and sample code can be built with the project CMake
