### PR TITLE
Fix TypeError when building for WebAssembly with Python 3

### DIFF
--- a/modules/js/src/make_umd.py
+++ b/modules/js/src/make_umd.py
@@ -103,7 +103,7 @@ def make_umd(opencvjs, cvjs):
     Module = {};
   return cv(Module);
 }));
-    """ % (content)).lstrip())
+    """ % (content)).lstrip().encode())
 
 if __name__ == "__main__":
     if len(sys.argv) > 2:


### PR DESCRIPTION
resolves #18632

Fixes TypeError mentioned in #18632.

<cut/>
### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [x] The PR is proposed to proper branch
- [x] There is reference to original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake (N/A)

```
force_builders=Custom,docs
build_image:Docs=docs-js
buildworker:Custom=linux-4
build_image:Custom=javascript-simd:1.39.16
Xbuild_image:Custom=javascript-simd
```