### PR TITLE
Add support for Swift version independence

### DIFF
--- a/modules/objc/generator/gen_objc.py
+++ b/modules/objc/generator/gen_objc.py
@@ -1348,7 +1348,17 @@ typedef NS_ENUM(int, {2}) {{
 
     def finalize(self, output_objc_path):
         opencv_header_file = os.path.join(output_objc_path, framework_name + ".h")
-        self.save(opencv_header_file, '\n'.join(['#import "%s"' % os.path.basename(f) for f in self.header_files]))
+        opencv_header = "#import <Foundation/Foundation.h>\n\n"
+        opencv_header += "// ! Project version number\nFOUNDATION_EXPORT double " + framework_name + "VersionNumber;\n\n"
+        opencv_header += "// ! Project version string\nFOUNDATION_EXPORT const unsigned char " + framework_name + "VersionString[];\n\n"
+        opencv_header += "\n".join(["#import <" + framework_name + "/%s>" % os.path.basename(f) for f in self.header_files])
+        self.save(opencv_header_file, opencv_header)
+        opencv_modulemap_file = os.path.join(output_objc_path, framework_name + ".modulemap")
+        opencv_modulemap = "framework module " + framework_name + " {\n"
+        opencv_modulemap += "  umbrella header \"" + framework_name + ".h\"\n"
+        opencv_modulemap += "\n".join(["  header \"%s\"" % os.path.basename(f) for f in self.header_files])
+        opencv_modulemap += "\n  export *\n  module * {export *}\n}\n"
+        self.save(opencv_modulemap_file, opencv_modulemap)
         cmakelist_template = read_contents(os.path.join(SCRIPT_DIR, 'templates/cmakelists.template'))
         cmakelist = Template(cmakelist_template).substitute(modules = ";".join(modules), framework = framework_name)
         self.save(os.path.join(dstdir, "CMakeLists.txt"), cmakelist)

--- a/modules/objc/generator/templates/cmakelists.template
+++ b/modules/objc/generator/templates/cmakelists.template
@@ -13,43 +13,49 @@ set (SUPPRESS_WARNINGS_FLAGS "-Wno-incomplete-umbrella")
 set (CMAKE_CXX_FLAGS  "$${CMAKE_CXX_FLAGS} $${OBJC_COMPILE_FLAGS} $${SUPPRESS_WARNINGS_FLAGS}")
 
 # grab the files
-file(GLOB_RECURSE objc_sources "objc/*\.h" "objc/*\.m" "objc/*\.mm" "objc/*\.swift")
+file(GLOB_RECURSE objc_sources "objc/*\.h" "objc/*\.m" "objc/*\.mm" "objc/*\.swift" "objc/*\.modulemap")
 file(GLOB_RECURSE objc_headers "*\.h")
 
-add_library(opencv_objc_framework STATIC $${objc_sources})
+add_library($framework STATIC $${objc_sources})
 
-set_target_properties(opencv_objc_framework PROPERTIES LINKER_LANGUAGE CXX)
+set_target_properties($framework PROPERTIES LINKER_LANGUAGE CXX)
 
-target_include_directories(opencv_objc_framework PRIVATE "$${BUILD_ROOT}")
-target_include_directories(opencv_objc_framework PRIVATE "$${BUILD_ROOT}/install/include")
-target_include_directories(opencv_objc_framework PRIVATE "$${BUILD_ROOT}/install/include/opencv2")
+target_include_directories($framework PRIVATE "$${BUILD_ROOT}")
+target_include_directories($framework PRIVATE "$${BUILD_ROOT}/install/include")
+target_include_directories($framework PRIVATE "$${BUILD_ROOT}/install/include/opencv2")
 foreach(m $${MODULES})
-  target_include_directories(opencv_objc_framework PRIVATE "$${BUILD_ROOT}/modules/objc/gen/objc/$${m}")
+  target_include_directories($framework PRIVATE "$${BUILD_ROOT}/modules/objc/gen/objc/$${m}")
 endforeach()
 
-install(TARGETS opencv_objc_framework LIBRARY DESTINATION lib)
+install(TARGETS $framework LIBRARY DESTINATION lib)
 
 enable_language(Swift)
 
 # Additional target properties
 if (CMAKE_XCODE_BUILD_SYSTEM GREATER_EQUAL 12)
-  set_target_properties(opencv_objc_framework PROPERTIES
+  set_target_properties($framework PROPERTIES
       OUTPUT_NAME "$framework"
       ARCHIVE_OUTPUT_DIRECTORY "$${BUILD_ROOT}/lib"
       XCODE_ATTRIBUTE_SWIFT_VERSION 5.0
+      XCODE_ATTRIBUTE_DEFINES_MODULE YES
       XCODE_ATTRIBUTE_BUILD_LIBRARY_FOR_DISTRIBUTION YES
       XCODE_ATTRIBUTE_OTHER_SWIFT_FLAGS "-Xcc $${SUPPRESS_WARNINGS_FLAGS}"
+      XCODE_ATTRIBUTE_MODULEMAP_FILE objc/$framework.modulemap
+      XCODE_ATTRIBUTE_PRODUCT_BUNDLE_IDENTIFIER org.opencv.$framework
       FRAMEWORK TRUE
       MACOSX_FRAMEWORK_IDENTIFIER org.opencv.$framework
       PUBLIC_HEADER "$${objc_headers}"
       DEFINE_SYMBOL CVAPI_EXPORTS
       )
 else()
-  set_target_properties(opencv_objc_framework PROPERTIES
+  set_target_properties($framework PROPERTIES
       OUTPUT_NAME "$framework"
       ARCHIVE_OUTPUT_DIRECTORY "$${BUILD_ROOT}/lib"
       XCODE_ATTRIBUTE_SWIFT_VERSION 5.0
+      XCODE_ATTRIBUTE_DEFINES_MODULE YES
       XCODE_ATTRIBUTE_OTHER_SWIFT_FLAGS "-Xcc $${SUPPRESS_WARNINGS_FLAGS}"
+      XCODE_ATTRIBUTE_MODULEMAP_FILE objc/$framework.modulemap
+      XCODE_ATTRIBUTE_PRODUCT_BUNDLE_IDENTIFIER org.opencv.$framework
       FRAMEWORK TRUE
       MACOSX_FRAMEWORK_IDENTIFIER org.opencv.$framework
       PUBLIC_HEADER "$${objc_headers}"

--- a/modules/objc/generator/templates/cmakelists.template
+++ b/modules/objc/generator/templates/cmakelists.template
@@ -32,13 +32,27 @@ install(TARGETS opencv_objc_framework LIBRARY DESTINATION lib)
 enable_language(Swift)
 
 # Additional target properties
-set_target_properties(opencv_objc_framework PROPERTIES
-    OUTPUT_NAME "$framework"
-    ARCHIVE_OUTPUT_DIRECTORY "$${BUILD_ROOT}/lib"
-    XCODE_ATTRIBUTE_SWIFT_VERSION 5.0
-    XCODE_ATTRIBUTE_OTHER_SWIFT_FLAGS "-Xcc $${SUPPRESS_WARNINGS_FLAGS}"
-    FRAMEWORK TRUE
-    MACOSX_FRAMEWORK_IDENTIFIER org.opencv.$framework
-    PUBLIC_HEADER "$${objc_headers}"
-    DEFINE_SYMBOL CVAPI_EXPORTS
-    )
+if (CMAKE_XCODE_BUILD_SYSTEM GREATER_EQUAL 12)
+  set_target_properties(opencv_objc_framework PROPERTIES
+      OUTPUT_NAME "$framework"
+      ARCHIVE_OUTPUT_DIRECTORY "$${BUILD_ROOT}/lib"
+      XCODE_ATTRIBUTE_SWIFT_VERSION 5.0
+      XCODE_ATTRIBUTE_BUILD_LIBRARY_FOR_DISTRIBUTION YES
+      XCODE_ATTRIBUTE_OTHER_SWIFT_FLAGS "-Xcc $${SUPPRESS_WARNINGS_FLAGS}"
+      FRAMEWORK TRUE
+      MACOSX_FRAMEWORK_IDENTIFIER org.opencv.$framework
+      PUBLIC_HEADER "$${objc_headers}"
+      DEFINE_SYMBOL CVAPI_EXPORTS
+      )
+else()
+  set_target_properties(opencv_objc_framework PROPERTIES
+      OUTPUT_NAME "$framework"
+      ARCHIVE_OUTPUT_DIRECTORY "$${BUILD_ROOT}/lib"
+      XCODE_ATTRIBUTE_SWIFT_VERSION 5.0
+      XCODE_ATTRIBUTE_OTHER_SWIFT_FLAGS "-Xcc $${SUPPRESS_WARNINGS_FLAGS}"
+      FRAMEWORK TRUE
+      MACOSX_FRAMEWORK_IDENTIFIER org.opencv.$framework
+      PUBLIC_HEADER "$${objc_headers}"
+      DEFINE_SYMBOL CVAPI_EXPORTS
+      )
+endif()


### PR DESCRIPTION
- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [x] The PR is proposed to proper branch

This PR addresses #18489

- when building with CMake 3.19 or greater and Xcode 12 or greater generate **swiftinterface** files
- improvements to the autogenerated Xcode project for Xcode New Build system
- add support for standard module properties **VersionNumber** and **VersionString**
- when build with older versions of CMake and/or Xcode continue to build as before (without generating **swiftinterface** files)

```
force_builders=Custom Mac
build_image:Custom Mac=osx_framework
```