### PR TITLE
Fix errors when building with cuda stubs

### DIFF
--- a/modules/cudaarithm/src/lut.cpp
+++ b/modules/cudaarithm/src/lut.cpp
@@ -4,8 +4,6 @@
 
 #include "precomp.hpp"
 
-#include "lut.hpp"
-
 using namespace cv;
 using namespace cv::cuda;
 
@@ -14,6 +12,9 @@ using namespace cv::cuda;
 Ptr<LookUpTable> cv::cuda::createLookUpTable(InputArray) { throw_no_cuda(); return Ptr<LookUpTable>(); }
 
 #else /* !defined (HAVE_CUDA) || defined (CUDA_DISABLER) */
+
+// lut.hpp includes cuda_runtime.h and can only be included when we have CUDA
+#include "lut.hpp"
 
 Ptr<LookUpTable> cv::cuda::createLookUpTable(InputArray lut)
 {

--- a/modules/stitching/src/blenders.cpp
+++ b/modules/stitching/src/blenders.cpp
@@ -219,7 +219,7 @@ MultiBandBlender::MultiBandBlender(int try_gpu, int num_bands, int weight_type)
     num_bands_ = 0;
     setNumBands(num_bands);
 
-#if defined(HAVE_OPENCV_CUDAARITHM) && defined(HAVE_OPENCV_CUDAWARPING)
+#if defined(HAVE_CUDA) && defined(HAVE_OPENCV_CUDAARITHM) && defined(HAVE_OPENCV_CUDAWARPING)
     can_use_gpu_ = try_gpu && cuda::getCudaEnabledDeviceCount();
     gpu_feed_idx_ = 0;
 #else
@@ -246,7 +246,7 @@ void MultiBandBlender::prepare(Rect dst_roi)
 
     Blender::prepare(dst_roi);
 
-#if defined(HAVE_OPENCV_CUDAARITHM) && defined(HAVE_OPENCV_CUDAWARPING)
+#if defined(HAVE_CUDA) && defined(HAVE_OPENCV_CUDAARITHM) && defined(HAVE_OPENCV_CUDAWARPING)
     if (can_use_gpu_)
     {
         gpu_initialized_ = false;
@@ -332,7 +332,7 @@ void MultiBandBlender::feed(InputArray _img, InputArray mask, Point tl)
 
     UMat img;
 
-#if defined(HAVE_OPENCV_CUDAARITHM) && defined(HAVE_OPENCV_CUDAWARPING)
+#if defined(HAVE_CUDA) && defined(HAVE_OPENCV_CUDAARITHM) && defined(HAVE_OPENCV_CUDAWARPING)
     // If using gpu save the top left coordinate when running first time after prepare
     if (can_use_gpu_)
     {
@@ -353,7 +353,7 @@ void MultiBandBlender::feed(InputArray _img, InputArray mask, Point tl)
     {
         img = _img.getUMat();
     }
-#if defined(HAVE_OPENCV_CUDAARITHM) && defined(HAVE_OPENCV_CUDAWARPING)
+#if defined(HAVE_CUDA) && defined(HAVE_OPENCV_CUDAARITHM) && defined(HAVE_OPENCV_CUDAWARPING)
     else
     {
         gpu_img_ = _img.getGpuMat();
@@ -394,7 +394,7 @@ void MultiBandBlender::feed(InputArray _img, InputArray mask, Point tl)
     int bottom = br_new.y - tl.y - img.rows;
     int right = br_new.x - tl.x - img.cols;
 
-#if defined(HAVE_OPENCV_CUDAARITHM) && defined(HAVE_OPENCV_CUDAWARPING)
+#if defined(HAVE_CUDA) && defined(HAVE_OPENCV_CUDAARITHM) && defined(HAVE_OPENCV_CUDAWARPING)
     if (can_use_gpu_)
     {
         if (!gpu_initialized_)
@@ -603,7 +603,7 @@ void MultiBandBlender::feed(InputArray _img, InputArray mask, Point tl)
 void MultiBandBlender::blend(InputOutputArray dst, InputOutputArray dst_mask)
 {
     Rect dst_rc(0, 0, dst_roi_final_.width, dst_roi_final_.height);
-#if defined(HAVE_OPENCV_CUDAARITHM) && defined(HAVE_OPENCV_CUDAWARPING)
+#if defined(HAVE_CUDA) && defined(HAVE_OPENCV_CUDAARITHM) && defined(HAVE_OPENCV_CUDAWARPING)
     if (can_use_gpu_)
     {
         if (!gpu_initialized_)
@@ -850,7 +850,7 @@ void createLaplacePyr(InputArray img, int num_levels, std::vector<UMat> &pyr)
 
 void createLaplacePyrGpu(InputArray img, int num_levels, std::vector<UMat> &pyr)
 {
-#if defined(HAVE_OPENCV_CUDAARITHM) && defined(HAVE_OPENCV_CUDAWARPING)
+#if defined(HAVE_CUDA) && defined(HAVE_OPENCV_CUDAARITHM) && defined(HAVE_OPENCV_CUDAWARPING)
     pyr.resize(num_levels + 1);
 
     std::vector<cuda::GpuMat> gpu_pyr(num_levels + 1);
@@ -891,7 +891,7 @@ void restoreImageFromLaplacePyr(std::vector<UMat> &pyr)
 
 void restoreImageFromLaplacePyrGpu(std::vector<UMat> &pyr)
 {
-#if defined(HAVE_OPENCV_CUDAARITHM) && defined(HAVE_OPENCV_CUDAWARPING)
+#if defined(HAVE_CUDA) && defined(HAVE_OPENCV_CUDAARITHM) && defined(HAVE_OPENCV_CUDAWARPING)
     if (pyr.empty())
         return;
 


### PR DESCRIPTION
Fixes two errors when building with the options WITH_CUDA=ON and BUILD_CUDA_STUBS=ON on a machine without CUDA.

In the cudaarithm module, make sure cuda_runtime.h only gets included when CUDA is installed.

In the stitching module, don't assume that cuda is present just because cudaarithm and cudawarping are present (as is the case when building with the above options).
 
Fixes opencv/opencv_contrib#2724

<cut/>

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [x] The PR is proposed to proper branch
- [x] There is reference to original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake

```
force_builders=Custom
buildworker:Custom=linux-4
build_image:Custom=ubuntu-cuda:16.04
```
